### PR TITLE
feat: Convert anaconda-project files to pixi format

### DIFF
--- a/anndata_diffex/pixi.lock
+++ b/anndata_diffex/pixi.lock
@@ -1,0 +1,8088 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/nodefaults/
+    indexes:
+    - https://pypi.org/simple
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-25.1.0-py311h49ec1c0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb03c661_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb03c661_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311h1ddb823_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py311h5b438cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py311hdf67eae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/crc32c-2.7.1-py311haee01d2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.17-py311hc665b79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.60.0-py311h3778330_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.1-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.14.0-nompi_py311h0b2f468_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h6e4c0c1_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.9-py311h724c32c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.17-h717163a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.44-ha97dd6f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.4-h3f801dc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-36_h4a7cf45_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb03c661_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb03c661_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb03c661_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-36_h0358290_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.14.1-h332b0f4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.24-h86f0d12_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.1-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.1-h73754d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.1.0-h69a702a_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.1.0-hcea5267_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.1-default_h7f8ec31_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.0-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-36_h47877c9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.67.0-had1ee68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.50-h421ea60_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.4-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h8261f1e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.0-ha9997c6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.0-h26afc86_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.45.0-py311h41a00d4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py311h2dc5d0c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.6-py311h0f3be63_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.1-py311hdf67eae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.62.0-py311h6220fa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.16.1-py311hed34c8f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.3.3-py311h2e04523_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.3-h26f9b46_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.3.2-py311hed34c8f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.3.0-py311h98278a2_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.1.0-py311h49ec1c0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.13-h9e4cc4f_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h2dc5d0c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py311h2315fbb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.27.1-py311h902ca64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.7.2-py311hc3e1efb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.16.2-py311h1e13796_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.5-py311hb0beb2c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.2.0-hb60516a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.2-py311h49ec1c0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/umap-learn-0.5.9.post2-py311h38be061_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-16.0.0-py311h49ec1c0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py311h49ec1c0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h387f397_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py311haee01d2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anndata-0.12.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.11.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/array-api-compat-1.12.0-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.5-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.13.5-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyh29332c3_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.2.0-h82add2a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.8.3-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.8.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.2.18-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/donfig-0.8.1.post1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.5.0-pyhfa0c392_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.25.1-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.25.1-he01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.8.1-pyh31011fe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.0-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.17.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.4.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/legacy-api-wrap-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.1.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.5.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/natsort-8.4.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.3.3-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.8.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.5-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/patsy-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.23.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pynndescent-0.5.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.5-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.36.2-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/scanpy-1.11.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/session-info2-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20250822-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-3.1.3-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
+      - pypi: https://files.pythonhosted.org/packages/02/3f/a6ec28c88e2d8e54d32598a1e0b5208a4baa72a8e7f6e241beab5731eb9d/interface_meta-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/9d/c2c8b51b32f829a16fe042db30ad1dcef7947bf1dcf77c2cfd7b6f37b83a/formulaic-1.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/28/0e/b11ad5fd77e3dd0baad9cac3184315be7654ae401e3b0b0c324503f23d96/datashader-0.18.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/40/7b/639411281256c84e8111bf6cb9676c44dbf5d8ad4cb042f4359b7e7b9e74/formulaic_contrasts-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/43/8c/f637418a679fb49bc3368940e0705df3b43c85b2ff5ae91455e78401750b/pydeseq2-0.5.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/51/c0/00c9809d8b9346eb238a6bbd5f83e846a4ce4503da94a4c08cb7284c325b/multipledispatch-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/58/a7/acc7690029de56ecc324f153f27286c82c08ebd3eefabc267877f6a9729e/panel_material_ui-0.5.1a0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/8f/99214dc3d59d6aef171821dc8cc3dea34db8fafb962c98c34b1527a76e51/holoviews-1.22.0a0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/c7/4102536de33c19d090ed2b04e90e7452e2e3dc653cf3323208034eaaca27/stdlib_list-0.11.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/b2/23f4032cd1c9744aa8e9ecda43cd4d755fcb209f7f40fae035248f31a679/pyct-0.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8d/f0/73c24457c941b8b08f7d090853e40f4b2cdde88b5da721f3f28e98df77c9/xarray-2025.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/b8/8d37825625c6558d8e2ad48be9429634ef84c69d6ea80e33a0f965c98cf7/hv_anndata-0.0.3a3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c5/c4/f6b7c0ec5241a2bde90c7ba1eca6ba44f8488bcedafe9072c79593015ec0/session_info-1.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d5/9b/700f7d7d4f39e909f8c098a283797d61afc694934c87eb041dd87ba8f63f/fastcluster-1.3.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anndata-0.12.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.11.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/array-api-compat-1.12.0-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.5-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.13.5-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyh29332c3_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.2.0-h82add2a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.8.3-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.8.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.2.18-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/donfig-0.8.1.post1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.5.0-pyhfa0c392_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.25.1-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.25.1-he01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.8.1-pyh31011fe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.0-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.17.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.4.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/legacy-api-wrap-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.1.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.5.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/natsort-8.4.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.3.3-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.8.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.5-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/patsy-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.23.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pynndescent-0.5.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.5-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.36.2-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/scanpy-1.11.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/session-info2-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20250822-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-3.1.3-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-25.1.0-py311h13e5629_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h1c43f85_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h1c43f85_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311h7b20566_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.5-hf13058a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-2.0.0-py311h8ebb5ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.3-py311hd4d69bb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/crc32c-2.7.1-py311h179db11_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.17-py311h1854d6b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.60.0-py311he13f9b5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.14.1-h694c41f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.14.0-nompi_py311h9f650d9_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.6-nompi_hc8237f9_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.9-py311ha94bed4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.17-h72f5680_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hcca01a6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.4-ha6bc127_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-36_he492b99_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h1c43f85_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h1c43f85_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h1c43f85_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-36_h9b27e0a_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.14.1-h5dec5d8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-21.1.2-h3d58e20_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.24-hcc1b750_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20250104-pl5321ha958ccf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.7.1-h21dd04a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.6-h281671d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libfreetype-2.14.1-h694c41f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libfreetype6-2.14.1-h6912278_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.1.0-h5f6db21_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.1.0-hfa3c126_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwloc-2.12.1-default_h094e1f9_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h57a12c2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.1.0-h6e16a3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-36_h859234e_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.1-hd471939_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.67.0-h3338091_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.30-openmp_h83c2472_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.50-h84aeda2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.50.4-h39a8b3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-hed3591d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.1-haa3b502_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.6.0-hb807250_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.0-h0ad03eb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.0-h23bb396_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-21.1.0-hf4e0ed4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.45.0-py311hb26b958_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.2-py311ha3cf9ac_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.10.6-py311h48d7e91_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.1.1-py311hd4d69bb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.62.0-py311hf901296_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numcodecs-0.16.1-py311hf4bc098_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.3.3-py311hf157cb9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.4-h87e8dc5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.5.3-h230baf5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.3.2-py311hf4bc098_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.3.0-py311ha88f94d_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.1.0-py311hf197a57_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.1-py311h2f44256_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.1-py311hbc8e8a3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.13-h9ccd52b_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311ha3cf9ac_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-27.1.0-py311h0ab6910_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h7cca4af_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.27.1-py311hd3d88a1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.7.2-py311had5a2ce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.16.2-py311h32c7e5c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/statsmodels-0.14.5-py311ha2d3830_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tbb-2022.2.0-hc025b3e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hf689a15_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.5.2-py311h13e5629_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/umap-learn-0.5.9.post2-py311h6eed73b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-16.0.0-py311h13e5629_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.17.3-py311h13e5629_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.12-h6e16a3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h6c33b1e_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.25.0-py311h62e9434_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h8210216_2.conda
+      - pypi: https://files.pythonhosted.org/packages/02/3f/a6ec28c88e2d8e54d32598a1e0b5208a4baa72a8e7f6e241beab5731eb9d/interface_meta-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/9d/c2c8b51b32f829a16fe042db30ad1dcef7947bf1dcf77c2cfd7b6f37b83a/formulaic-1.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/28/0e/b11ad5fd77e3dd0baad9cac3184315be7654ae401e3b0b0c324503f23d96/datashader-0.18.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/40/7b/639411281256c84e8111bf6cb9676c44dbf5d8ad4cb042f4359b7e7b9e74/formulaic_contrasts-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/43/8c/f637418a679fb49bc3368940e0705df3b43c85b2ff5ae91455e78401750b/pydeseq2-0.5.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/51/c0/00c9809d8b9346eb238a6bbd5f83e846a4ce4503da94a4c08cb7284c325b/multipledispatch-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/58/a7/acc7690029de56ecc324f153f27286c82c08ebd3eefabc267877f6a9729e/panel_material_ui-0.5.1a0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7b/fa/427569f391a9951fe483222d3df6bb18a690d963810473fb0e305150cf86/fastcluster-1.3.0-cp311-cp311-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/8f/99214dc3d59d6aef171821dc8cc3dea34db8fafb962c98c34b1527a76e51/holoviews-1.22.0a0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/c7/4102536de33c19d090ed2b04e90e7452e2e3dc653cf3323208034eaaca27/stdlib_list-0.11.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/b2/23f4032cd1c9744aa8e9ecda43cd4d755fcb209f7f40fae035248f31a679/pyct-0.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8d/f0/73c24457c941b8b08f7d090853e40f4b2cdde88b5da721f3f28e98df77c9/xarray-2025.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/b8/8d37825625c6558d8e2ad48be9429634ef84c69d6ea80e33a0f965c98cf7/hv_anndata-0.0.3a3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c5/c4/f6b7c0ec5241a2bde90c7ba1eca6ba44f8488bcedafe9072c79593015ec0/session_info-1.0.1-py3-none-any.whl
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anndata-0.12.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.11.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/array-api-compat-1.12.0-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.5-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.13.5-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyh29332c3_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.2.0-h82add2a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.8.3-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.8.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.2.18-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/donfig-0.8.1.post1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.5.0-pyhfa0c392_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.25.1-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.25.1-he01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.8.1-pyh31011fe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.0-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.17.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.4.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/legacy-api-wrap-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.1.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.5.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/natsort-8.4.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.3.3-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.8.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.5-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/patsy-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.23.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pynndescent-0.5.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.5-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.36.2-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/scanpy-1.11.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/session-info2-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20250822-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-3.1.3-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-25.1.0-py311h3696347_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-h6caf38d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-h6caf38d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311hf719da1_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.5-h5505292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.0.0-py311hcfc1310_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.3-py311h57a9ea7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/crc32c-2.7.1-py311hb76fab6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.17-py311hc58e375_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.60.0-py311ha9b3269_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.14.1-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.14.0-nompi_py311h1d03b57_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.6-nompi_he65715a_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py311h267d04e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.9-py311h63e5c0c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.17-h7eeda09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-hd64df32_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.4-h51d1e36_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-36_h51639a9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-h6caf38d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-h6caf38d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-h6caf38d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-36_hb0561ab_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.14.1-h73640d1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.2-hf598326_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.24-h5773f1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.1-hec049ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.1-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.14.1-h6da58f4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.1.0-hfdf1602_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.1.0-hb74de2c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.12.1-default_h48b22c3_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.1.0-h5505292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-36_hd9741b5_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.67.0-hc438710_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.30-openmp_h60d53f8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.50-h280e0eb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.50.4-h4237e3c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.1-h7dc4979_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.6.0-h07db88b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.0-h0ff4647_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.0-h9329255_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-21.1.0-hbb9b287_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.45.0-py311h27de090_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py311h4921393_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.10.6-py311h66dac5a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.1-py311h57a9ea7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.62.0-py311h922685c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numcodecs-0.16.1-py311hff7e5bb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.3.3-py311h8685306_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.4-hbfb3c88_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.5.3-h5503f6c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.3.2-py311hff7e5bb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.3.0-py311h1f9957d_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.1.0-py311h9408147_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-11.1-py311hf0763de_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-11.1-py311hc5b188e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.13-hc22306f_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h4921393_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py311h13abfa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.27.1-py311h1c3fc1a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.7.2-py311h0f965f6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.16.2-py311h2734c94_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.5-py311h9dc9093_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2022.2.0-h5b2e6d4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.2-py311h3696347_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/umap-learn-0.5.9.post2-py311h267d04e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-16.0.0-py311h3696347_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.3-py311h3696347_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-h5505292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h888dc83_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py311h5bb9006_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_2.conda
+      - pypi: https://files.pythonhosted.org/packages/02/3f/a6ec28c88e2d8e54d32598a1e0b5208a4baa72a8e7f6e241beab5731eb9d/interface_meta-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/9d/c2c8b51b32f829a16fe042db30ad1dcef7947bf1dcf77c2cfd7b6f37b83a/formulaic-1.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/28/0e/b11ad5fd77e3dd0baad9cac3184315be7654ae401e3b0b0c324503f23d96/datashader-0.18.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/40/7b/639411281256c84e8111bf6cb9676c44dbf5d8ad4cb042f4359b7e7b9e74/formulaic_contrasts-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/43/8c/f637418a679fb49bc3368940e0705df3b43c85b2ff5ae91455e78401750b/pydeseq2-0.5.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/51/c0/00c9809d8b9346eb238a6bbd5f83e846a4ce4503da94a4c08cb7284c325b/multipledispatch-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/58/a7/acc7690029de56ecc324f153f27286c82c08ebd3eefabc267877f6a9729e/panel_material_ui-0.5.1a0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7b/fa/427569f391a9951fe483222d3df6bb18a690d963810473fb0e305150cf86/fastcluster-1.3.0-cp311-cp311-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/8f/99214dc3d59d6aef171821dc8cc3dea34db8fafb962c98c34b1527a76e51/holoviews-1.22.0a0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/c7/4102536de33c19d090ed2b04e90e7452e2e3dc653cf3323208034eaaca27/stdlib_list-0.11.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/b2/23f4032cd1c9744aa8e9ecda43cd4d755fcb209f7f40fae035248f31a679/pyct-0.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8d/f0/73c24457c941b8b08f7d090853e40f4b2cdde88b5da721f3f28e98df77c9/xarray-2025.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/b8/8d37825625c6558d8e2ad48be9429634ef84c69d6ea80e33a0f965c98cf7/hv_anndata-0.0.3a3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c5/c4/f6b7c0ec5241a2bde90c7ba1eca6ba44f8488bcedafe9072c79593015ec0/session_info-1.0.1-py3-none-any.whl
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anndata-0.12.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.11.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/array-api-compat-1.12.0-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.5-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.13.5-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyh29332c3_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.2.0-h82add2a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.8.3-h4c7d964_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.8.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.13-py311hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.2.18-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/donfig-0.8.1.post1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.5.0-pyh6be1c34_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.25.1-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.25.1-he01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.8.1-pyh5737063_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.0-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.17.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.4.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/legacy-api-wrap-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.1.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.5.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/natsort-8.4.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.3.3-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.8.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.5-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/patsy-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.23.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pynndescent-0.5.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.5-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.36.2-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/scanpy-1.11.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/session-info2-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20250822-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-3.1.3-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-25.1.0-py311h3485c13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-hfd05255_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-hfd05255_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311h3e6a449_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.0.0-py311h3485c13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.3-py311h3fd045d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/crc32c-2.7.1-py311hf893f09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.17-py311h5dfdfe8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.60.0-py311h3f79411_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.14.1-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.14.0-nompi_py311hc40ba4b_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.6-nompi_he30205f_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/icu-75.1-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.9-py311h275cad7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.17-hbcf6048_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h6470a55_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.4-h20038f6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-35_h5709861_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hfd05255_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hfd05255_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hfd05255_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-35_h2a3cdd5_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.14.1-h88aaa65_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.24-h76ddb4d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.1-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.6-h537db12_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libfreetype-2.14.1-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libfreetype6-2.14.1-hdbac1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-15.1.0-h1383e82_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-15.1.0-h1383e82_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.12.1-default_h64bd3f2_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.1.0-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-35_hf9ab0e9_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.50-h7351971_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.50.4-hf5d6505_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-h9aa295b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.1-h550210a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.6.0-h4d5522a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-16-2.15.0-h06f855e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.15.0-ha29bfb0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/llvm-openmp-20.1.8-hfa2b4ca_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.44.0-py311h7c248df_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py311h5082efb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.10.6-py311h1675fdf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h57928b3_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.1-py311h3fd045d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.61.2-py311hffedbe7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numcodecs-0.16.1-py311h11fd7f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.2.6-py311h5e411d1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.4-h24db6dd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.5.3-h725018a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.3.2-py311h11fd7f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.3.0-py311h26a3c52_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.1.0-py311h3485c13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.13-h3f84c4b_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-311-py311hefeebc8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.15-py311hda3d55a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311h5082efb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-27.1.0-py311hb77b9c8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.27.1-py311hf51aa87_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.7.2-py311h8a15ebc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.16.2-py311h9a1c30b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/statsmodels-0.14.5-py311h17033d2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-h18a62a1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.5.2-py311h3485c13_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/umap-learn-0.5.9.post2-py311h1ea47a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-16.0.0-py311h3485c13_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_31.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_31.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_31.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.17.3-py311h3485c13_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.12-h0e40799_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.5-h0e40799_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-h5bddc39_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.25.0-py311hf893f09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-hbeecb71_2.conda
+      - pypi: https://files.pythonhosted.org/packages/02/3f/a6ec28c88e2d8e54d32598a1e0b5208a4baa72a8e7f6e241beab5731eb9d/interface_meta-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/9d/c2c8b51b32f829a16fe042db30ad1dcef7947bf1dcf77c2cfd7b6f37b83a/formulaic-1.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/28/0e/b11ad5fd77e3dd0baad9cac3184315be7654ae401e3b0b0c324503f23d96/datashader-0.18.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/40/7b/639411281256c84e8111bf6cb9676c44dbf5d8ad4cb042f4359b7e7b9e74/formulaic_contrasts-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/43/8c/f637418a679fb49bc3368940e0705df3b43c85b2ff5ae91455e78401750b/pydeseq2-0.5.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4c/60/ef55d3aa66914e0d1fe751df85b222fe9e78c8782c8f930ad3240d52d92f/fastcluster-1.3.0-cp311-cp311-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/51/c0/00c9809d8b9346eb238a6bbd5f83e846a4ce4503da94a4c08cb7284c325b/multipledispatch-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/58/a7/acc7690029de56ecc324f153f27286c82c08ebd3eefabc267877f6a9729e/panel_material_ui-0.5.1a0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/8f/99214dc3d59d6aef171821dc8cc3dea34db8fafb962c98c34b1527a76e51/holoviews-1.22.0a0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/c7/4102536de33c19d090ed2b04e90e7452e2e3dc653cf3323208034eaaca27/stdlib_list-0.11.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/b2/23f4032cd1c9744aa8e9ecda43cd4d755fcb209f7f40fae035248f31a679/pyct-0.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8d/f0/73c24457c941b8b08f7d090853e40f4b2cdde88b5da721f3f28e98df77c9/xarray-2025.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/b8/8d37825625c6558d8e2ad48be9429634ef84c69d6ea80e33a0f965c98cf7/hv_anndata-0.0.3a3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c5/c4/f6b7c0ec5241a2bde90c7ba1eca6ba44f8488bcedafe9072c79593015ec0/session_info-1.0.1-py3-none-any.whl
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  license: None
+  size: 2562
+  timestamp: 1578324546067
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23621
+  timestamp: 1650670423406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-25.1.0-py311h49ec1c0_0.conda
+  sha256: d6d2f38ece253492a3e00800b5d4a5c2cc4b2de73b2c0fcc580c218f1cf58de6
+  md5: 112c5e2b7fe99e3678bbd64316d38f0c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.0.1
+  - libgcc >=14
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 35657
+  timestamp: 1753994819264
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb03c661_4.conda
+  sha256: 294526a54fa13635341729f250d0b1cf8f82cad1e6b83130304cbf3b6d8b74cc
+  md5: eaf3fbd2aa97c212336de38a51fe404e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli-bin 1.1.0 hb03c661_4
+  - libbrotlidec 1.1.0 hb03c661_4
+  - libbrotlienc 1.1.0 hb03c661_4
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 19883
+  timestamp: 1756599394934
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb03c661_4.conda
+  sha256: 444903c6e5c553175721a16b7c7de590ef754a15c28c99afbc8a963b35269517
+  md5: ca4ed8015764937c81b830f7f5b68543
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlidec 1.1.0 hb03c661_4
+  - libbrotlienc 1.1.0 hb03c661_4
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 19615
+  timestamp: 1756599385418
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311h1ddb823_4.conda
+  sha256: 318d4985acbf46457d254fbd6f0df80cc069890b5fc0013b3546d88eee1b1a1f
+  md5: 7138a06a7b0d11a23cfae323e6010a08
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 hb03c661_4
+  license: MIT
+  license_family: MIT
+  size: 354304
+  timestamp: 1756599521587
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
+  sha256: c30daba32ddebbb7ded490f0e371eae90f51e72db620554089103b4a6934b0d5
+  md5: 51a19bba1b8ebfb60df25cde030b7ebc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 260341
+  timestamp: 1757437258798
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.5-hb9d3cd8_0.conda
+  sha256: f8003bef369f57396593ccd03d08a8e21966157269426f71e943f96e4b579aeb
+  md5: f7f0d6cc2dc986d42ac2689ec88192be
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 206884
+  timestamp: 1744127994291
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py311h5b438cf_0.conda
+  sha256: 4986d5b3ce60af4e320448a1a2231cb5dd5e3705537e28a7b58951a24bd69893
+  md5: 6cb6c4d57d12dfa0ecdd19dbe758ffc9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.4.6,<3.5.0a0
+  - libgcc >=14
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 304057
+  timestamp: 1758716282627
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py311hdf67eae_2.conda
+  sha256: cb35e53fc4fc2ae59c85303b0668d05fa3be9cd9f8b27a127882f47aa795895b
+  md5: bb6a0f88cf345f7e7a143d349dae6d9f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy >=1.25
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296784
+  timestamp: 1756544804579
+- conda: https://conda.anaconda.org/conda-forge/linux-64/crc32c-2.7.1-py311haee01d2_2.conda
+  sha256: 748dbb4c7a738e75ee5ac45dacc8ab670b63c5cc60a95f1dd6d3618d2cd7bb2a
+  md5: 9b04def27d786ab853536f133f909624
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  license: LGPL-2.1-or-later
+  size: 51845
+  timestamp: 1756602214713
+- conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.17-py311hc665b79_0.conda
+  sha256: d9a621da97c263fbea14f6cd3ff3f24f94ab55c7fbca50efe8dd8f1007c11c97
+  md5: af20efc4f52675e7ce9a3e3ed8447fbb
+  depends:
+  - python
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2730518
+  timestamp: 1758162063262
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.60.0-py311h3778330_0.conda
+  sha256: 031d9205093b4686eaf515adf4847ea798a3ec5ab51f9ee92dfee88485e1bca2
+  md5: 92d090806dcf5e5c5f2f3cfacf1d6aa3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli
+  - libgcc >=14
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2975122
+  timestamp: 1758132609865
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.1-ha770c72_0.conda
+  sha256: bf8e4dffe46f7d25dc06f31038cacb01672c47b9f45201f065b0f4d00ab0a83e
+  md5: 4afc585cd97ba8a23809406cd8a9eda8
+  depends:
+  - libfreetype 2.14.1 ha770c72_0
+  - libfreetype6 2.14.1 h73754d4_0
+  license: GPL-2.0-only OR FTL
+  size: 173114
+  timestamp: 1757945422243
+- conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.14.0-nompi_py311h0b2f468_101.conda
+  sha256: f5d1955b90eb7060ee6f81bc39de0f4f8e28247b8fe810d70382b4fde9e0e1f9
+  md5: b3dd5deacc3147498b31366315fdc6cc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cached-property
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - libgcc >=14
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1358447
+  timestamp: 1756767156419
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h6e4c0c1_103.conda
+  sha256: 4f173af9e2299de7eee1af3d79e851bca28ee71e7426b377e841648b51d48614
+  md5: c74d83614aec66227ae5199d98852aaf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libaec >=1.1.4,<2.0a0
+  - libcurl >=8.14.1,<9.0a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3710057
+  timestamp: 1753357500665
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+  sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
+  md5: 8b189310083baabfb622af68fd9d3ae3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 12129203
+  timestamp: 1720853576813
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_2.conda
+  sha256: 4e744b30e3002b519c48868b3f5671328274d1d78cc8cbc0cda43057b570c508
+  md5: 5dd29601defbcc14ac6953d9504a80a7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18368
+  timestamp: 1756754243123
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+  sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
+  md5: b38117a3c920364aff79f870c984b4a3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  size: 134088
+  timestamp: 1754905959823
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.9-py311h724c32c_1.conda
+  sha256: 029a00a337e307256beab9cbaefc2c23cd28f040fff6f087703a63bc7487fc14
+  md5: 92720706b174926bc7238cc24f3b5956
+  depends:
+  - python
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78167
+  timestamp: 1756467524636
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+  sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
+  md5: 3f43953b7d3fb3aaa1d0d0723d91e368
+  depends:
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1370023
+  timestamp: 1719463201255
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.17-h717163a_0.conda
+  sha256: d6a61830a354da022eae93fa896d0991385a875c6bba53c82263a289deda9db8
+  md5: 000e85703f0fd9594c81710dd5066471
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 248046
+  timestamp: 1739160907615
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.44-ha97dd6f_2.conda
+  sha256: 707dfb8d55d7a5c6f95c772d778ef07a7ca85417d9971796f7d3daad0b615de8
+  md5: 14bae321b8127b63cba276bd53fac237
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - binutils_impl_linux-64 2.44
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 747158
+  timestamp: 1758810907507
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
+  sha256: 412381a43d5ff9bbed82cd52a0bbca5b90623f62e41007c9c42d3870c60945ff
+  md5: 9344155d33912347b37f0ae6c410a835
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 264243
+  timestamp: 1745264221534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.4-h3f801dc_0.conda
+  sha256: 410ab78fe89bc869d435de04c9ffa189598ac15bb0fe1ea8ace8fb1b860a2aa3
+  md5: 01ba04e414e47f95c03d6ddd81fd37be
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 36825
+  timestamp: 1749993532943
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-36_h4a7cf45_openblas.conda
+  sha256: a1670eb8c9293f37a245e313bd9d72a301c79e8668a6a5d418c90335719fbaff
+  md5: 2a6122504dc8ea139337046d34a110cb
+  depends:
+  - libopenblas >=0.3.30,<0.3.31.0a0
+  - libopenblas >=0.3.30,<1.0a0
+  constrains:
+  - liblapacke 3.9.0   36*_openblas
+  - blas 2.136   openblas
+  - liblapack  3.9.0   36*_openblas
+  - mkl <2025
+  - libcblas   3.9.0   36*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17421
+  timestamp: 1758396490057
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb03c661_4.conda
+  sha256: 2338a92d1de71f10c8cf70f7bb9775b0144a306d75c4812276749f54925612b6
+  md5: 1d29d2e33fe59954af82ef54a8af3fe1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 69333
+  timestamp: 1756599354727
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb03c661_4.conda
+  sha256: fcec0d26f67741b122f0d5eff32f0393d7ebd3ee6bb866ae2f17f3425a850936
+  md5: 5cb5a1c9a94a78f5b23684bcb845338d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.1.0 hb03c661_4
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 33406
+  timestamp: 1756599364386
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb03c661_4.conda
+  sha256: d42c7f0afce21d5279a0d54ee9e64a2279d35a07a90e0c9545caae57d6d7dc57
+  md5: 2e55011fa483edb8bfe3fd92e860cd79
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.1.0 hb03c661_4
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 289680
+  timestamp: 1756599375485
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-36_h0358290_openblas.conda
+  sha256: 45110023d1661062288168c6ee01510bcb472ba2f5184492acdcdd3d1af9b58d
+  md5: 13a3fe5f9812ac8c5710ef8c03105121
+  depends:
+  - libblas 3.9.0 36_h4a7cf45_openblas
+  constrains:
+  - liblapacke 3.9.0   36*_openblas
+  - blas 2.136   openblas
+  - liblapack  3.9.0   36*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17401
+  timestamp: 1758396499759
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.14.1-h332b0f4_0.conda
+  sha256: b6c5cf340a4f80d70d64b3a29a7d9885a5918d16a5cb952022820e6d3e79dc8b
+  md5: 45f6713cb00f124af300342512219182
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libnghttp2 >=1.64.0,<2.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 449910
+  timestamp: 1749033146806
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.24-h86f0d12_0.conda
+  sha256: 8420748ea1cc5f18ecc5068b4f24c7a023cc9b20971c99c824ba10641fb95ddf
+  md5: 64f0c503da58ec25ebd359e4d990afa8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 72573
+  timestamp: 1747040452262
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+  sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
+  md5: c277e0a4d549b03ac1e9d6cbbe3d017b
+  depends:
+  - ncurses
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - ncurses >=6.5,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134676
+  timestamp: 1738479519902
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+  md5: 172bf1cd1ff8629f2b1179945ed45055
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 112766
+  timestamp: 1702146165126
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
+  sha256: da2080da8f0288b95dd86765c801c6e166c4619b910b11f9a8446fb852438dc2
+  md5: 4211416ecba1866fab0c6470986c22d6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - expat 2.7.1.*
+  license: MIT
+  license_family: MIT
+  size: 74811
+  timestamp: 1752719572741
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
+  sha256: 764432d32db45466e87f10621db5b74363a9f847d2b8b1f9743746cd160f06ab
+  md5: ede4673863426c0883c0063d853bbd85
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 57433
+  timestamp: 1743434498161
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.1-ha770c72_0.conda
+  sha256: 4641d37faeb97cf8a121efafd6afd040904d4bca8c46798122f417c31d5dfbec
+  md5: f4084e4e6577797150f9b04a4560ceb0
+  depends:
+  - libfreetype6 >=2.14.1
+  license: GPL-2.0-only OR FTL
+  size: 7664
+  timestamp: 1757945417134
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.1-h73754d4_0.conda
+  sha256: 4a7af818a3179fafb6c91111752954e29d3a2a950259c14a2fc7ba40a8b03652
+  md5: 8e7251989bca326a28f4a5ffbd74557a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libpng >=1.6.50,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - freetype >=2.14.1
+  license: GPL-2.0-only OR FTL
+  size: 386739
+  timestamp: 1757945416744
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_5.conda
+  sha256: 0caed73aac3966bfbf5710e06c728a24c6c138605121a3dacb2e03440e8baa6a
+  md5: 264fbfba7fb20acf3b29cde153e345ce
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 15.1.0 h767d61c_5
+  - libgcc-ng ==15.1.0=*_5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 824191
+  timestamp: 1757042543820
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_5.conda
+  sha256: f54bb9c3be12b24be327f4c1afccc2969712e0b091cdfbd1d763fb3e61cda03f
+  md5: 069afdf8ea72504e48d23ae1171d951c
+  depends:
+  - libgcc 15.1.0 h767d61c_5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 29187
+  timestamp: 1757042549554
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.1.0-h69a702a_5.conda
+  sha256: 4c1a526198d0d62441549fdfd668cc8e18e77609da1e545bdcc771dd8dc6a990
+  md5: 0c91408b3dec0b97e8a3c694845bd63b
+  depends:
+  - libgfortran5 15.1.0 hcea5267_5
+  constrains:
+  - libgfortran-ng ==15.1.0=*_5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 29169
+  timestamp: 1757042575979
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.1.0-hcea5267_5.conda
+  sha256: 9d06adc6d8e8187ddc1cad87525c690bc8202d8cb06c13b76ab2fc80a35ed565
+  md5: fbd4008644add05032b6764807ee2cba
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15.1.0
+  constrains:
+  - libgfortran 15.1.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1564589
+  timestamp: 1757042559498
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_5.conda
+  sha256: 125051d51a8c04694d0830f6343af78b556dd88cc249dfec5a97703ebfb1832d
+  md5: dcd5ff1940cd38f6df777cac86819d60
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 447215
+  timestamp: 1757042483384
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.1-default_h7f8ec31_1002.conda
+  sha256: f7fbc792dbcd04bf27219c765c10c239937b34c6c1a1f77a5827724753e02da1
+  md5: c01021ae525a76fe62720c7346212d74
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2450642
+  timestamp: 1757624375958
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+  sha256: c467851a7312765447155e071752d7bf9bf44d610a5687e32706f480aad2833f
+  md5: 915f5995e94f60e9a4826e0b0920ee88
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-only
+  size: 790176
+  timestamp: 1754908768807
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.0-hb9d3cd8_0.conda
+  sha256: 98b399287e27768bf79d48faba8a99a2289748c65cd342ca21033fab1860d4a4
+  md5: 9fa334557db9f63da6c9285fd2a48638
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 628947
+  timestamp: 1745268527144
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-36_h47877c9_openblas.conda
+  sha256: 1bbd142b34dfc8cb55e1e37c00e78ebba909542ac1054d22fc54843a94797337
+  md5: 55daaac7ecf8ebd169cdbe34dc79549e
+  depends:
+  - libblas 3.9.0 36_h4a7cf45_openblas
+  constrains:
+  - liblapacke 3.9.0   36*_openblas
+  - libcblas   3.9.0   36*_openblas
+  - blas 2.136   openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17409
+  timestamp: 1758396509549
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
+  sha256: f2591c0069447bbe28d4d696b7fcb0c5bd0b4ac582769b89addbcf26fb3430d8
+  md5: 1a580f7796c7bf6393fddb8bbbde58dc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD
+  size: 112894
+  timestamp: 1749230047870
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.67.0-had1ee68_0.conda
+  sha256: a4a7dab8db4dc81c736e9a9b42bdfd97b087816e029e221380511960ac46c690
+  md5: b499ce4b026493a13774bcf0f4c33849
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - c-ares >=1.34.5,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 666600
+  timestamp: 1756834976695
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+  sha256: 927fe72b054277cde6cb82597d0fcf6baf127dcbce2e0a9d8925a68f1265eef5
+  md5: d864d34357c3b65a4b731f78c0801dc4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-only
+  license_family: GPL
+  size: 33731
+  timestamp: 1750274110928
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_2.conda
+  sha256: 1b51d1f96e751dc945cc06f79caa91833b0c3326efe24e9b506bd64ef49fc9b0
+  md5: dfc5aae7b043d9f56ba99514d5e60625
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  constrains:
+  - openblas >=0.3.30,<0.3.31.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5938936
+  timestamp: 1755474342204
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.50-h421ea60_1.conda
+  sha256: e75a2723000ce3a4b9fd9b9b9ce77553556c93e475a4657db6ed01abc02ea347
+  md5: 7af8e91b0deb5f8e25d1a595dea79614
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 317390
+  timestamp: 1753879899951
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
+  sha256: 0105bd108f19ea8e6a78d2d994a6d4a8db16d19a41212070d2d1d48a63c34161
+  md5: a587892d3c13b6621a6091be690dbca2
+  depends:
+  - libgcc-ng >=12
+  license: ISC
+  size: 205978
+  timestamp: 1716828628198
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.4-h0c1763c_0.conda
+  sha256: 6d9c32fc369af5a84875725f7ddfbfc2ace795c28f246dc70055a79f9b2003da
+  md5: 0b367fad34931cb79e0d6b7e5c06bb1c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: blessing
+  size: 932581
+  timestamp: 1753948484112
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+  sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
+  md5: eecce068c7e4eddeb169591baac20ac4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 304790
+  timestamp: 1745608545575
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_5.conda
+  sha256: 0f5f61cab229b6043541c13538d75ce11bd96fb2db76f94ecf81997b1fde6408
+  md5: 4e02a49aaa9d5190cb630fa43528fbe6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 15.1.0 h767d61c_5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3896432
+  timestamp: 1757042571458
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_5.conda
+  sha256: 7b8cabbf0ab4fe3581ca28fe8ca319f964078578a51dd2ca3f703c1d21ba23ff
+  md5: 8bba50c7f4679f08c861b597ad2bda6b
+  depends:
+  - libstdcxx 15.1.0 h8f9b012_5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 29233
+  timestamp: 1757042603319
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h8261f1e_0.conda
+  sha256: ddda0d7ee67e71e904a452010c73e32da416806f5cb9145fb62c322f97e717fb
+  md5: 72b531694ebe4e8aa6f5745d1015c1b4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.24,<1.26.0a0
+  - libgcc >=14
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libstdcxx >=14
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: HPND
+  size: 437211
+  timestamp: 1758278398952
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
+  sha256: e5ec6d2ad7eef538ddcb9ea62ad4346fde70a4736342c4ad87bd713641eb9808
+  md5: 80c07c68d2f6870250959dcc95b209d1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37135
+  timestamp: 1758626800002
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+  sha256: 3aed21ab28eddffdaf7f804f49be7a7d701e8f0e46c856d801270b470820a37b
+  md5: aea31d2e5b1091feca96fcfe945c3cf9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - libwebp 1.6.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 429011
+  timestamp: 1752159441324
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+  sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
+  md5: 92ed62436b625154323d40d5f2f11dd7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 395888
+  timestamp: 1727278577118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
+  md5: 5aa797f8787fe7a17d1b0821485b5adc
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 100393
+  timestamp: 1702724383534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.0-ha9997c6_1.conda
+  sha256: 5420ea77505a8d5ca7b5351ddb2da7e8a178052fccf8fca00189af7877608e89
+  md5: b24dd2bd61cd8e4f8a13ee2a945a723c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - libxml2 2.15.0
+  license: MIT
+  license_family: MIT
+  size: 556276
+  timestamp: 1758640612398
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.0-h26afc86_1.conda
+  sha256: 4310577d7eea817d35a1c05e1e54575b06ce085d73e6dd59aa38523adf50168f
+  md5: 8337b675e0cad517fbcb3daf7588087a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libxml2-16 2.15.0 ha9997c6_1
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 45363
+  timestamp: 1758640621036
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
+  md5: edb0dca6bc32e4f4789199455a1dbeb8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 60963
+  timestamp: 1727963148474
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.45.0-py311h41a00d4_1.conda
+  sha256: b7be994990899364431fe307101f919e31b70160501ff33bfd449c1c1022053e
+  md5: f7a345c3530232ff7f770dc8ba12bfed
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 34164885
+  timestamp: 1758282308294
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py311h2dc5d0c_1.conda
+  sha256: 0291d90706ac6d3eea73e66cd290ef6d805da3fad388d1d476b8536ec92ca9a8
+  md5: 6565a715337ae279e351d0abd8ffe88a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25354
+  timestamp: 1733219879408
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.6-py311h0f3be63_1.conda
+  sha256: 504ff6c8b4d5fba670b9b518d6e4ed7149a9c3682cb495fe9f87c79d387b2992
+  md5: 65ddf155ea43aa3bb366cb03ddf3436a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype
+  - kiwisolver >=1.3.1
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy >=1.23
+  - numpy >=1.23,<3
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  - tk >=8.6.13,<8.7.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8484360
+  timestamp: 1756869716686
+  purls:
+  - pkg:pypi/matplotlib?source=hash-mapping
+- conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.1-py311hdf67eae_1.conda
+  sha256: 8cbad527b1e5d5ed6c009661b692d3870e5cbf61c3accad28125c88b3636ab17
+  md5: d2494f7b8cbb0c6e9adb866c3d7a883f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 103624
+  timestamp: 1756678682315
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+  sha256: 3fde293232fa3fca98635e1167de6b7c7fda83caf24b9d6c91ec9eefb4f4d586
+  md5: 47e340acb35de30501a76c7c799c41d7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: X11 AND BSD-3-Clause
+  size: 891641
+  timestamp: 1738195959188
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.62.0-py311h6220fa4_0.conda
+  sha256: 8908c098b2e11f583dc060922a182e64aadad6daee226390700e3ccffdf7f2da
+  md5: 4450ce0284f0d736e4d2c31987bf7be9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - libgcc >=14
+  - libstdcxx >=14
+  - llvmlite >=0.45.0,<0.46.0a0
+  - numpy >=1.23,<3
+  - numpy >=1.24,<2.4
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - cudatoolkit >=11.2
+  - cuda-python >=11.6
+  - tbb >=2021.6.0
+  - cuda-version >=11.2
+  - libopenblas !=0.3.6
+  - scipy >=1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5845298
+  timestamp: 1758871798669
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.16.1-py311hed34c8f_1.conda
+  sha256: 394ba61aa08c0403d834ea28380fe3b58e9bd74da75012f21208a3b65db0119a
+  md5: 57479325cf442221eab67985b58f5fc6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - deprecated
+  - libgcc >=14
+  - libstdcxx >=14
+  - msgpack-python
+  - numpy >=1.23,<3
+  - numpy >=1.24
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - typing_extensions
+  license: MIT
+  license_family: MIT
+  size: 823259
+  timestamp: 1756542922354
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.3.3-py311h2e04523_0.conda
+  sha256: 264528d6e73d5c902a0463d9d138607018d994b86e209df4a51945886233989d
+  md5: 3b0d0a2241770397d3146fdcab3b49f8
+  depends:
+  - python
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - liblapack >=3.9.0,<4.0a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9416009
+  timestamp: 1757505084571
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
+  sha256: 3900f9f2dbbf4129cf3ad6acf4e4b6f7101390b53843591c53b00f034343bc4d
+  md5: 11b3379b191f63139e29c0d19dee24cd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libpng >=1.6.50,<1.7.0a0
+  - libstdcxx >=14
+  - libtiff >=4.7.1,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 355400
+  timestamp: 1758489294972
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.3-h26f9b46_1.conda
+  sha256: 0572be1b7d3c4f4c288bb8ab1cb6007b5b8b9523985b34b862b5222dea3c45f5
+  md5: 4fc6c4c88da64c0219c0c6c0408cedd4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  size: 3128517
+  timestamp: 1758597915858
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.3.2-py311hed34c8f_0.conda
+  sha256: ac5372b55c12644ba4bab81270bb294fb70197f86c9b3ede57dfe367ecc6f198
+  md5: f98711aba4ad00ea3c286dcea5f57c1f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy >=1.22.4
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1
+  constrains:
+  - pyqt5 >=5.15.9
+  - pyarrow >=10.0.1
+  - s3fs >=2022.11.0
+  - xlrd >=2.0.1
+  - numexpr >=2.8.4
+  - openpyxl >=3.1.0
+  - pyreadstat >=1.2.0
+  - zstandard >=0.19.0
+  - bottleneck >=1.3.6
+  - python-calamine >=0.1.7
+  - fastparquet >=2022.12.0
+  - psycopg2 >=2.9.6
+  - html5lib >=1.1
+  - numba >=0.56.4
+  - lxml >=4.9.2
+  - odfpy >=1.4.1
+  - xlsxwriter >=3.0.5
+  - pytables >=3.8.0
+  - pandas-gbq >=0.19.0
+  - sqlalchemy >=2.0.0
+  - blosc >=1.21.3
+  - pyxlsb >=1.0.10
+  - tabulate >=0.9.0
+  - tzdata >=2022.7
+  - gcsfs >=2022.11.0
+  - fsspec >=2022.11.0
+  - scipy >=1.10.0
+  - beautifulsoup4 >=4.11.2
+  - qtpy >=2.3.0
+  - matplotlib >=3.6.3
+  - xarray >=2022.12.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15354460
+  timestamp: 1755779368955
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.3.0-py311h98278a2_3.conda
+  sha256: 7268d3f04cc28069eb34a7051d04a59cf2e3737ca2199b39dbc5b7149ad2839b
+  md5: 76839149314cc1d07f270174801576b0
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - libwebp-base >=1.6.0,<2.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - lcms2 >=2.17,<3.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - openjpeg >=2.5.3,<3.0a0
+  license: HPND
+  size: 1045029
+  timestamp: 1758208668856
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.1.0-py311h49ec1c0_0.conda
+  sha256: 06797609454011c59555e1dd2f9b5ac951227169d15f762a2219acf971fc8a5d
+  md5: eaf20d52642262d2987c3cdc7423649e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 491832
+  timestamp: 1758169257845
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+  sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
+  md5: b3c17d95b5a10c6e64a21fa17573e70e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 8252
+  timestamp: 1726802366959
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.13-h9e4cc4f_0_cpython.conda
+  sha256: 9979a7d4621049388892489267139f1aa629b10c26601ba5dce96afc2b1551d4
+  md5: 8c399445b6dc73eab839659e6c7b5ad1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.7.0,<3.0a0
+  - libffi >=3.4.6,<3.5.0a0
+  - libgcc >=13
+  - liblzma >=5.8.1,<6.0a0
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.50.0,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.5.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 30629559
+  timestamp: 1749050021812
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h2dc5d0c_2.conda
+  sha256: d107ad62ed5c62764fba9400f2c423d89adf917d687c7f2e56c3bfed605fb5b3
+  md5: 014417753f948da1f70d132b2de573be
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 213136
+  timestamp: 1737454846598
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py311h2315fbb_0.conda
+  sha256: 719104f31c414166a20281c973b6e29d1a2ab35e7930327368949895b8bc5629
+  md5: 6c87a0f4566469af3585b11d89163fd7
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - zeromq >=4.3.5,<4.4.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 386618
+  timestamp: 1757387012835
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+  sha256: 776363493bad83308ba30bcb88c2552632581b143e8ee25b1982c8c743e73abc
+  md5: 353823361b1d27eb3960efb076dfcaf6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-Qhull
+  size: 552937
+  timestamp: 1720813982144
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
+  sha256: 2d6d0c026902561ed77cd646b5021aef2d4db22e57a5b0178dfc669231e06d2c
+  md5: 283b96675859b20a825f8fa30f311446
+  depends:
+  - libgcc >=13
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 282480
+  timestamp: 1740379431762
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.27.1-py311h902ca64_1.conda
+  sha256: d9bc1564949ede4abd32aea34cf1997d704b6091e547f255dc0168996f5d5ec8
+  md5: 622c389c080689ba1575a0750eb0209d
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  size: 387057
+  timestamp: 1756737832651
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.7.2-py311hc3e1efb_0.conda
+  sha256: c10973e92f71d6a1277a29d3abffefc9ed4b27854b1e3144e505844d7e0a3fe7
+  md5: 3f5b4f552d1ef2a5fdc2a4e25db2ee9a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - joblib >=1.2.0
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy >=1.22.0
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scipy >=1.8.0
+  - threadpoolctl >=3.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9785405
+  timestamp: 1757406401803
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.16.2-py311h1e13796_0.conda
+  sha256: e87176da9a36babfb2f65ca1143050b07581efea67368999808378c1c96163fd
+  md5: 124834cd571d0174ad1c22701ab63199
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=14
+  - numpy <2.6
+  - numpy >=1.23,<3
+  - numpy >=1.25.2
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17289352
+  timestamp: 1757682174416
+- conda: https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.5-py311hb0beb2c_0.conda
+  sha256: 766186eb4ff37a69479ec0695df9d7b775a8fd79b8ded727a1963cc1bedcfc80
+  md5: 763f2b77d523c8662fa8a4fcabc4ef36
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy <3,>=1.22.3
+  - numpy >=1.23,<3
+  - packaging >=21.3
+  - pandas !=2.1.0,>=1.4
+  - patsy >=0.5.6
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scipy !=1.9.2,>=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12015823
+  timestamp: 1751917868394
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.2.0-hb60516a_1.conda
+  sha256: 105a12b00e407aaaf04d811d3e737d470fd9e9328bc9a6a57f0f3fea5a486e84
+  md5: 29ed2be4b47b5aa1b07689e12407fbfd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libhwloc >=2.12.1,<2.12.2.0a0
+  - libstdcxx >=14
+  license: Apache-2.0
+  license_family: APACHE
+  size: 183204
+  timestamp: 1755775909376
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
+  sha256: a84ff687119e6d8752346d1d408d5cf360dee0badd487a472aa8ddedfdc219e1
+  md5: a0116df4f4ed05c303811a837d5b39d8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: TCL
+  license_family: BSD
+  size: 3285204
+  timestamp: 1748387766691
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.2-py311h49ec1c0_1.conda
+  sha256: b1d686806d6b913e42aadb052b12d9cc91aae295640df3acfef645142fc33b3d
+  md5: 18a98f4444036100d78b230c94453ff4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 868049
+  timestamp: 1756855060036
+- conda: https://conda.anaconda.org/conda-forge/linux-64/umap-learn-0.5.9.post2-py311h38be061_0.conda
+  sha256: c00faf815359495beaeb2fdefc001c85076c8f5769c1301e09cf4632725589ae
+  md5: d024e9d8b8590f9366f5abab7038e697
+  depends:
+  - numba >=0.51.2
+  - numpy >=1.17
+  - pynndescent >=0.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scikit-learn >=0.22
+  - scipy >=1.3.1
+  - setuptools
+  - tbb >=2019.0
+  - tqdm
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 196112
+  timestamp: 1751544372477
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-16.0.0-py311h49ec1c0_1.conda
+  sha256: e2715a04632d75de539c1510238886ff1d6fc5b7e9e2ec240d8c11c175c1fffd
+  md5: 3457bd5c93b085bec51cdab58fbd1882
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 405256
+  timestamp: 1756494610217
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py311h49ec1c0_1.conda
+  sha256: efcb41a300b58624790d2ce1c6ac9c1da7d23dd91c3d329bd22853866f8f8533
+  md5: 47c1c27dee6c31bf8eefbdbdde817d83
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 65464
+  timestamp: 1756851731483
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb9d3cd8_0.conda
+  sha256: ed10c9283974d311855ae08a16dfd7e56241fac632aec3b92e3cfe73cff31038
+  md5: f6ebe2cb3f82ba6c057dde5d9debe4f7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 14780
+  timestamp: 1734229004433
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+  sha256: 6b250f3e59db07c2514057944a3ea2044d6a8cdde8a47b6497c254520fade1ee
+  md5: 8035c64cb77ed555e3f150b7b3972480
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 19901
+  timestamp: 1727794976192
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
+  sha256: 6d9ea2f731e284e9316d95fa61869fe7bbba33df7929f82693c121022810f4ad
+  md5: a77f85f77be52ff59391544bfe73390a
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  license_family: MIT
+  size: 85189
+  timestamp: 1753484064210
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h387f397_9.conda
+  sha256: 47cfe31255b91b4a6fa0e9dbaf26baa60ac97e033402dbc8b90ba5fee5ffe184
+  md5: 8035e5b54c08429354d5d64027041cad
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 310648
+  timestamp: 1757370847287
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py311haee01d2_0.conda
+  sha256: ed149760ea78e038e6424d8a327ea95da351727536c0e9abedccf5a61fc19932
+  md5: 0fd242142b0691eb9311dc32c1d4ab76
+  depends:
+  - python
+  - cffi >=1.11
+  - zstd >=1.5.7,<1.5.8.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 466651
+  timestamp: 1757930101225
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
+  sha256: a4166e3d8ff4e35932510aaff7aa90772f84b4d07e9f6f83c614cba7ceefe0eb
+  md5: 6432cb5d4ac0046c3ac0a8a0f95842f9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 567578
+  timestamp: 1742433379869
+- conda: https://conda.anaconda.org/conda-forge/noarch/anndata-0.12.2-pyhd8ed1ab_0.conda
+  sha256: 2cff0e6978b1216c0635c309b56f9d910684d0e072d0ef3b4728118f1b5c22c0
+  md5: fe01453b9202574809a0e6f68123751c
+  depends:
+  - array-api-compat >=1.7.1
+  - h5py >=3.8
+  - legacy-api-wrap
+  - natsort
+  - numpy >=1.26
+  - packaging >=24.2
+  - pandas >=2.1.0,!=2.1.2
+  - python >=3.11
+  - scipy >=1.12
+  - zarr >=2.18.7,!=3.0.*
+  constrains:
+  - awkward >=2.3.2
+  - xarray >=2025.06.1
+  - dask[array] >=2023.5.1,!=2024.8.*,!=2024.9.*,<2025.2.0
+  - pyarrow <21
+  - pandas<3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 131604
+  timestamp: 1754995412070
+- conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.11.0-pyhcf101f3_0.conda
+  sha256: 7378b5b9d81662d73a906fabfc2fb81daddffe8dc0680ed9cda7a9562af894b0
+  md5: 814472b61da9792fae28156cb9ee54f5
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.10
+  - sniffio >=1.1
+  - typing_extensions >=4.5
+  - python
+  constrains:
+  - trio >=0.31.0
+  - uvloop >=0.21
+  license: MIT
+  license_family: MIT
+  size: 138159
+  timestamp: 1758634638734
+- conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
+  sha256: 8f032b140ea4159806e4969a68b4a3c0a7cab1ad936eb958a2b5ffe5335e19bf
+  md5: 54898d0f524c9dee622d44bbb081a8ab
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 10076
+  timestamp: 1733332433806
+- conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
+  sha256: bea62005badcb98b1ae1796ec5d70ea0fc9539e7d59708ac4e7d41e2f4bb0bad
+  md5: 8ac12aff0860280ee0cff7fa2cf63f3b
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.9
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 18715
+  timestamp: 1749017288144
+- conda: https://conda.anaconda.org/conda-forge/noarch/array-api-compat-1.12.0-pyhe01879c_0.conda
+  sha256: 259b8e21ee0ce8f2cdcee9df7ba9b7e53d1b4aa2d252946acf5108e03d5d7b5e
+  md5: b656a1f58a53e7b6f5d4588d9b19e7b0
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 45821
+  timestamp: 1747403732947
+- conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_1.conda
+  sha256: c4b0bdb3d5dee50b60db92f99da3e4c524d5240aafc0a5fcc15e45ae2d1a3cd1
+  md5: 46b53236fdd990271b03c3978d4218a9
+  depends:
+  - python >=3.9
+  - python-dateutil >=2.7.0
+  - types-python-dateutil >=2.8.10
+  license: Apache-2.0
+  license_family: Apache
+  size: 99951
+  timestamp: 1733584345583
+- conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+  sha256: 93b14414b3b3ed91e286e1cbe4e7a60c4e1b1c730b0814d1e452a8ac4b9af593
+  md5: 8f587de4bcf981e26228f268df374a9b
+  depends:
+  - python >=3.9
+  constrains:
+  - astroid >=2,<4
+  license: Apache-2.0
+  license_family: Apache
+  size: 28206
+  timestamp: 1733250564754
+- conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.5-pyh29332c3_0.conda
+  sha256: 3b7233041e462d9eeb93ea1dfe7b18aca9c358832517072054bb8761df0c324b
+  md5: d9d0f99095a9bb7e3641bca8c6ad2ac7
+  depends:
+  - python >=3.9
+  - typing_extensions >=4.0.0
+  - python
+  license: MIT
+  license_family: MIT
+  size: 17335
+  timestamp: 1742153708859
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
+  sha256: 99c53ffbcb5dc58084faf18587b215f9ac8ced36bbfb55fa807c00967e419019
+  md5: a10d11958cadc13fdb43df75f8b1903f
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 57181
+  timestamp: 1741918625732
+- conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.17.0-pyhd8ed1ab_0.conda
+  sha256: 1c656a35800b7f57f7371605bc6507c8d3ad60fbaaec65876fce7f73df1fc8ac
+  md5: 0a01c169f0ab0f91b26e77a3301fbfe4
+  depends:
+  - python >=3.9
+  - pytz >=2015.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6938256
+  timestamp: 1738490268466
+- conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.13.5-pyha770c72_0.conda
+  sha256: d2124c0ea13527c7f54582269b3ae19541141a3740d6d779e7aa95aa82eaf561
+  md5: de0fd9702fd4c1186e930b8c35af6b6b
+  depends:
+  - python >=3.10
+  - soupsieve >=1.2
+  - typing-extensions
+  license: MIT
+  license_family: MIT
+  size: 88278
+  timestamp: 1756094375546
+- conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyh29332c3_4.conda
+  sha256: a05971bb80cca50ce9977aad3f7fc053e54ea7d5321523efc7b9a6e12901d3cd
+  md5: f0b4c8e370446ef89797608d60a564b3
+  depends:
+  - python >=3.9
+  - webencodings
+  - python
+  constrains:
+  - tinycss >=1.1.0,<1.5
+  license: Apache-2.0 AND MIT
+  size: 141405
+  timestamp: 1737382993425
+- conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.2.0-h82add2a_4.conda
+  sha256: 0aba699344275b3972bd751f9403316edea2ceb942db12f9f493b63c74774a46
+  md5: a30e9406c873940383555af4c873220d
+  depends:
+  - bleach ==6.2.0 pyh29332c3_4
+  - tinycss2
+  license: Apache-2.0 AND MIT
+  size: 4213
+  timestamp: 1737382993425
+- conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.8.0-pyhd8ed1ab_0.conda
+  sha256: 3a0af5b0c30d1e50cda6fea8c7783f3ea925e83f427b059fa81b2f36cde72e28
+  md5: 30698cfea774ec175babb8ff08dbc07a
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - narwhals >=1.13
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.10
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5020661
+  timestamp: 1756543232734
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.8.3-h4c7d964_0.conda
+  sha256: 3b82f62baad3fd33827b01b0426e8203a2786c8f452f633740868296bcbe8485
+  md5: c9e0c0f82f6e63323827db462b40ede8
+  depends:
+  - __win
+  license: ISC
+  size: 154489
+  timestamp: 1754210967212
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.8.3-hbd8a1cb_0.conda
+  sha256: 837b795a2bb39b75694ba910c13c15fa4998d4bb2a622c214a6a5174b2ae53d1
+  md5: 74784ee3d225fc3dca89edb635b4e5cc
+  depends:
+  - __unix
+  license: ISC
+  size: 154402
+  timestamp: 1754210968730
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+  sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
+  md5: 9b347a7ec10940d3f7941ff6c460b551
+  depends:
+  - cached_property >=1.5.2,<1.5.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4134
+  timestamp: 1615209571450
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+  sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+  md5: 576d629e47797577ab0f1b351297ef4a
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11065
+  timestamp: 1615209567874
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.8.3-pyhd8ed1ab_0.conda
+  sha256: a1ad5b0a2a242f439608f22a538d2175cac4444b7b3f4e2b8c090ac337aaea40
+  md5: 11f59985f49df4620890f3e746ed7102
+  depends:
+  - python >=3.9
+  license: ISC
+  size: 158692
+  timestamp: 1754231530168
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.3-pyhd8ed1ab_0.conda
+  sha256: 838d5a011f0e7422be6427becba3de743c78f3874ad2743c341accbba9bb2624
+  md5: 7e7d5ef1b9ed630e4a1c358d6bc62284
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 51033
+  timestamp: 1754767444665
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
+  md5: 962b9857ee8e7018c22f2776ffa0b2d7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27011
+  timestamp: 1733218222191
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_1.conda
+  sha256: 46055a0524ed3a48b23cd27a52246c89ac059ccce90a50b2eeb84d2f833ae827
+  md5: 91d7152c744dc0f18ef8beb3cbc9980a
+  depends:
+  - python >=3.9
+  license: CC-BY-4.0
+  size: 173950
+  timestamp: 1734007415513
+- conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
+  sha256: 576a44729314ad9e4e5ebe055fbf48beb8116b60e58f9070278985b2b634f212
+  md5: 2da13f2b299d8e1995bafbbe9689a2f7
+  depends:
+  - python >=3.9
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14690
+  timestamp: 1753453984907
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.13-py311hd8ed1ab_0.conda
+  sha256: ab70477f5cfb60961ba27d84a4c933a24705ac4b1736d8f3da14858e95bbfa7a
+  md5: 4666fd336f6d48d866a58490684704cd
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi * *_cp311
+  license: Python-2.0
+  size: 47495
+  timestamp: 1749048148121
+- conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+  sha256: 9827efa891e507a91a8a2acf64e210d2aff394e1cde432ad08e1f8c66b12293c
+  md5: 44600c4667a319d67dbe0681fc0bc833
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13399
+  timestamp: 1733332563512
+- conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
+  sha256: c17c6b9937c08ad63cb20a26f403a3234088e57d4455600974a0ce865cb14017
+  md5: 9ce473d1d1be1cc3810856a48b3fab32
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14129
+  timestamp: 1740385067843
+- conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
+  md5: 961b3a227b437d82ad7054484cfa71b2
+  depends:
+  - python >=3.6
+  license: PSF-2.0
+  license_family: PSF
+  size: 24062
+  timestamp: 1615232388757
+- conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.2.18-pyhd8ed1ab_0.conda
+  sha256: d614bcff10696f1efc714df07651b50bf3808401fcc03814309ecec242cc8870
+  md5: 0cef44b1754ae4d6924ac0eef6b9fdbe
+  depends:
+  - python >=3.9
+  - wrapt <2,>=1.10
+  license: MIT
+  license_family: MIT
+  size: 14382
+  timestamp: 1737987072859
+- conda: https://conda.anaconda.org/conda-forge/noarch/donfig-0.8.1.post1-pyhd8ed1ab_1.conda
+  sha256: d58e97d418f71703e822c422af5b9c431e3621a0ecdc8b0334c1ca33e076dfe7
+  md5: c56a7fa5597ad78b62e1f5d21f7f8b8f
+  depends:
+  - python >=3.9
+  - pyyaml
+  license: MIT
+  license_family: MIT
+  size: 22491
+  timestamp: 1734368817583
+- conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+  sha256: 80f579bfc71b3dab5bef74114b89e26c85cb0df8caf4c27ab5ffc16363d57ee7
+  md5: 3366592d3c219f2731721f11bc93755c
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 11259
+  timestamp: 1733327239578
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
+  sha256: ce61f4f99401a4bd455b89909153b40b9c823276aefcbb06f2044618696009ca
+  md5: 72e42d28960d875c7654614f8b50939a
+  depends:
+  - python >=3.9
+  - typing_extensions >=4.6.0
+  license: MIT and PSF-2.0
+  size: 21284
+  timestamp: 1746947398083
+- conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
+  sha256: 210c8165a58fdbf16e626aac93cc4c14dbd551a01d1516be5ecad795d2422cad
+  md5: ff9efb7f7469aed3c4a8106ffa29593c
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 30753
+  timestamp: 1756729456476
+- conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+  sha256: 2509992ec2fd38ab27c7cdb42cf6cadc566a1cc0d1021a2673475d9fa87c6276
+  md5: d3549fd50d450b6d9e7dddff25dd2110
+  depends:
+  - cached-property >=1.3.0
+  - python >=3.9,<4
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 16705
+  timestamp: 1733327494780
+- conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhd8ed1ab_0.conda
+  sha256: f64b68148c478c3bfc8f8d519541de7d2616bf59d44485a5271041d40c061887
+  md5: 4b69232755285701bc86a5afe4d9933a
+  depends:
+  - python >=3.9
+  - typing_extensions
+  license: MIT
+  license_family: MIT
+  size: 37697
+  timestamp: 1745526482242
+- conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+  sha256: 84c64443368f84b600bfecc529a1194a3b14c3656ee2e832d15a20e0329b6da3
+  md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
+  depends:
+  - python >=3.10
+  - hyperframe >=6.1,<7
+  - hpack >=4.1,<5
+  - python
+  license: MIT
+  license_family: MIT
+  size: 95967
+  timestamp: 1756364871835
+- conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+  sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+  md5: 0a802cb9888dd14eeefc611f05c40b6e
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 30731
+  timestamp: 1737618390337
+- conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+  sha256: 04d49cb3c42714ce533a8553986e1642d0549a05dc5cc48e0d43ff5be6679a5b
+  md5: 4f14640d58e2cc0aa0819d9d8ba125bb
+  depends:
+  - python >=3.9
+  - h11 >=0.16
+  - h2 >=3,<5
+  - sniffio 1.*
+  - anyio >=4.0,<5.0
+  - certifi
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49483
+  timestamp: 1745602916758
+- conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+  sha256: cd0f1de3697b252df95f98383e9edb1d00386bfdd03fdf607fa42fe5fcb09950
+  md5: d6989ead454181f4f9bc987d3dc4e285
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 63082
+  timestamp: 1733663449209
+- conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.12.1-pyhd8ed1ab_0.conda
+  sha256: 6183ff5c90cb952947faf3c21f209f6093bf0b2bcfec056e283e00e9f94ebbd4
+  md5: c803ef11db60aa995b60b661c565a733
+  depends:
+  - bokeh >=3.1
+  - colorcet >=2
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 267907
+  timestamp: 1756971031591
+- conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+  sha256: 77af6f5fe8b62ca07d09ac60127a30d9069fdc3c68d6b256754d0ffb1f7779f8
+  md5: 8e6923fc12f1fe8f8c4e5c9f343256ac
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 17397
+  timestamp: 1737618427549
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+  sha256: d7a472c9fd479e2e8dcb83fb8d433fce971ea369d704ece380e876f9c3494e87
+  md5: 39a4f67be3286c86d696df570b1201b7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49765
+  timestamp: 1733211921194
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+  sha256: c18ab120a0613ada4391b15981d86ff777b5690ca461ea7e9e49531e8f374745
+  md5: 63ccfdc3a3ce25b027b8767eb722fca8
+  depends:
+  - python >=3.9
+  - zipp >=3.20
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 34641
+  timestamp: 1747934053147
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+  sha256: 33cfd339bb4efac56edf93474b37ddc049e08b1b4930cf036c893cc1f5a1f32a
+  md5: b40131ab6a36ac2c09b7c57d4d3fbf99
+  depends:
+  - __linux
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119084
+  timestamp: 1719845605084
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+  sha256: dc569094125127c0078aa536f78733f383dd7e09507277ef8bcd1789786e7086
+  md5: 18df5fc4944a679e085e0e8f31775fc8
+  depends:
+  - __win
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119853
+  timestamp: 1719845858082
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+  sha256: 072534d4d379225b2c3a4e38bc7730b65ae171ac7f0c2d401141043336e97980
+  md5: 9eb15d654daa0ef5a98802f586bb4ffc
+  depends:
+  - __osx
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119568
+  timestamp: 1719845667420
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.5.0-pyh6be1c34_0.conda
+  sha256: 658c547dafb10cd0989f2cdf72f8ee9fe8f66240307b64555ee43f6908e9d0ad
+  md5: aec1868dd4cbe028b2c8cb11377895a6
+  depends:
+  - __win
+  - colorama
+  - decorator
+  - exceptiongroup
+  - ipython_pygments_lexers
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 630157
+  timestamp: 1756474536497
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.5.0-pyhfa0c392_0.conda
+  sha256: e9ca009d3aab9d8a85f0241d6ada2c7fbc84072008e95f803fa59da3294aa863
+  md5: c0916cc4b733577cd41df93884d857b0
+  depends:
+  - __unix
+  - pexpect >4.3
+  - decorator
+  - exceptiongroup
+  - ipython_pygments_lexers
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 630826
+  timestamp: 1756474504536
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_2.conda
+  sha256: 45821a8986b4cb2421f766b240dbe6998a3c3123f012dd566720c1322e9b6e18
+  md5: 2f0ba4bc12af346bc6c99bdc377e8944
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28153
+  timestamp: 1733399692864
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
+  sha256: 894682a42a7d659ae12878dbcb274516a7031bbea9104e92f8e88c1f2765a104
+  md5: bd80ba060603cc228d9d81c257093119
+  depends:
+  - pygments
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13993
+  timestamp: 1737123723464
+- conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+  sha256: 08e838d29c134a7684bca0468401d26840f41c92267c4126d7b43a6b533b0aed
+  md5: 0b0154421989637d424ccf0f104be51a
+  depends:
+  - arrow >=0.15.0
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 19832
+  timestamp: 1733493720346
+- conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+  sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+  md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.9
+  license: Apache-2.0 AND MIT
+  size: 843646
+  timestamp: 1733300981994
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+  sha256: f1ac18b11637ddadc05642e8185a851c7fab5998c6f5470d716812fae943b2af
+  md5: 446bd6c8cb26050d528881df495ce646
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 112714
+  timestamp: 1741263433881
+- conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.2-pyhd8ed1ab_0.conda
+  sha256: 6fc414c5ae7289739c2ba75ff569b79f72e38991d61eb67426a8a4b92f90462c
+  md5: 4e717929cfa0d49cef92d911e31d0e90
+  depends:
+  - python >=3.10
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 224671
+  timestamp: 1756321850584
+- conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.12.1-pyhd8ed1ab_0.conda
+  sha256: 4e08ccf9fa1103b617a4167a270768de736a36be795c6cd34c2761100d332f74
+  md5: 0fc93f473c31a2f85c0bde213e7c63ca
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 34191
+  timestamp: 1755034963991
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.25.1-pyhe01879c_0.conda
+  sha256: ac377ef7762e49cb9c4f985f1281eeff471e9adc3402526eea78e6ac6589cf1d
+  md5: 341fd940c242cf33e832c0402face56f
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.3.6
+  - python >=3.9
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  - python
+  license: MIT
+  license_family: MIT
+  size: 81688
+  timestamp: 1755595646123
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+  sha256: 0a4f3b132f0faca10c89fdf3b60e15abb62ded6fa80aebfc007d05965192aa04
+  md5: 439cd0f567d697b20a8f45cb70a1005a
+  depends:
+  - python >=3.10
+  - referencing >=0.31.0
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19236
+  timestamp: 1757335715225
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.25.1-he01879c_0.conda
+  sha256: aef6705fe1335e6472e1b6365fcdb586356b18dceff72d8d6a315fc90e900ccf
+  md5: 13e31c573c884962318a738405ca3487
+  depends:
+  - jsonschema >=4.25.1,<4.25.2.0a0
+  - fqdn
+  - idna
+  - isoduration
+  - jsonpointer >1.13
+  - rfc3339-validator
+  - rfc3986-validator >0.1.0
+  - rfc3987-syntax >=1.1.0
+  - uri-template
+  - webcolors >=24.6.0
+  license: MIT
+  license_family: MIT
+  size: 4744
+  timestamp: 1755595646123
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.3.0-pyhcf101f3_0.conda
+  sha256: 897ad2e2c2335ef3c2826d7805e16002a1fd0d509b4ae0bc66617f0e0ff07bc2
+  md5: 62b7c96c6cd77f8173cc5cada6a9acaa
+  depends:
+  - importlib-metadata >=4.8.3
+  - jupyter_server >=1.1.2
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 60377
+  timestamp: 1756388269267
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+  sha256: 38e67f3e0d631f4aeeab4bbd4062dcb6f4ae9dc35803053c995d02912a999b65
+  md5: 5cbf9a31a19d4ef9103adb7d71fd45fd
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.7
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99449
+  timestamp: 1673616104031
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.8.1-pyh31011fe_0.conda
+  sha256: 56a7a7e907f15cca8c4f9b0c99488276d4cb10821d2d15df9245662184872e81
+  md5: b7d89d860ebcda28a5303526cdee68ab
+  depends:
+  - __unix
+  - platformdirs >=2.5
+  - python >=3.8
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59562
+  timestamp: 1748333186063
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.8.1-pyh5737063_0.conda
+  sha256: 928c2514c2974fda78447903217f01ca89a77eefedd46bf6a2fe97072df57e8d
+  md5: 324e60a0d3f39f268e899709575ea3cd
+  depends:
+  - __win
+  - cpython
+  - platformdirs >=2.5
+  - python >=3.8
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59972
+  timestamp: 1748333368923
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.0-pyh29332c3_0.conda
+  sha256: 37e6ac3ccf7afcc730c3b93cb91a13b9ae827fd306f35dd28f958a74a14878b5
+  md5: f56000b36f09ab7533877e695e4e8cb0
+  depends:
+  - jsonschema-with-format-nongpl >=4.18.0
+  - packaging
+  - python >=3.9
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23647
+  timestamp: 1738765986736
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.17.0-pyhcf101f3_0.conda
+  sha256: 74c4e642be97c538dae1895f7052599dfd740d8bd251f727bce6453ce8d6cd9a
+  md5: d79a87dcfa726bcea8e61275feed6f83
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.11.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert-core >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.10
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 347094
+  timestamp: 1755870522134
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+  sha256: 0890fc79422191bc29edf17d7b42cff44ba254aa225d31eb30819f8772b775b8
+  md5: 2d983ff1b82a1ccb6f2e9d8784bdd6bd
+  depends:
+  - python >=3.9
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19711
+  timestamp: 1733428049134
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.4.8-pyhd8ed1ab_0.conda
+  sha256: 023addbb350950ba8ef551d768f13f916146a3ddb57840f9cf76463652994547
+  md5: 2b683da45f88eec826e1d14d7a0e8361
+  depends:
+  - async-lru >=1.0.0
+  - httpx >=0.25.0,<1
+  - importlib-metadata >=4.8.3
+  - ipykernel >=6.5.0,!=6.30.0
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.27.1,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.10
+  - setuptools >=41.1.0
+  - tomli >=1.2.2
+  - tornado >=6.2.0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8239652
+  timestamp: 1758824788276
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+  sha256: dc24b900742fdaf1e077d9a3458fd865711de80bca95fe3c6d46610c532c6ef0
+  md5: fd312693df06da3578383232528c468d
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.9
+  constrains:
+  - jupyterlab >=4.0.8,<5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18711
+  timestamp: 1733328194037
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_1.conda
+  sha256: d03d0b7e23fa56d322993bc9786b3a43b88ccc26e58b77c756619a921ab30e86
+  md5: 9dc4b2b0f41f0de41d27f3293e319357
+  depends:
+  - babel >=2.10
+  - importlib-metadata >=4.8.3
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.9
+  - requests >=2.31
+  constrains:
+  - openapi-core >=0.18.0,<0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49449
+  timestamp: 1733599666357
+- conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.0-pyhd8ed1ab_0.conda
+  sha256: 6370d6a458b4f11a9ab5db7eb05e895f55f276e6aa4c4bbac7dde412c87fae35
+  md5: c9ee16acbcea5cc91d9f3eb1d8f903bd
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 94267
+  timestamp: 1758590674960
+- conda: https://conda.anaconda.org/conda-forge/noarch/legacy-api-wrap-1.4.1-pyhd8ed1ab_0.conda
+  sha256: 109ae0f20710a36cdd7f332e00117c49905f5f1e836a63b2f9930901fdcbc7f1
+  md5: 67a115a2ad8b264b815680f67fd6b7ec
+  depends:
+  - python >=3.10
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 15126
+  timestamp: 1732285081924
+- conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_1.conda
+  sha256: d975a2015803d4fdaaae3f53e21f64996577d7a069eb61c6d2792504f16eb57b
+  md5: b02fe519b5dc0dc55e7299810fcdfb8e
+  depends:
+  - python >=3.9
+  - uc-micro-py
+  license: MIT
+  license_family: MIT
+  size: 24154
+  timestamp: 1733781296133
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.9-pyhd8ed1ab_0.conda
+  sha256: d05fa62dd1fedfa4c6bc86fe5a34d8a256d7a5b051edc14678371cfb3e8d5e87
+  md5: 17784de2c4da64a3595328b34982cdc5
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 80879
+  timestamp: 1757093529525
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+  sha256: 7b1da4b5c40385791dbc3cc85ceea9fad5da680a27d5d3cb8bfaa185e304a89e
+  md5: 5b5203189eb668f042ac2b0826244964
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 64736
+  timestamp: 1754951288511
+- conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+  sha256: 69b7dc7131703d3d60da9b0faa6dd8acbf6f6c396224cf6aef3e855b8c0c41c6
+  md5: af6ab708897df59bd6e7283ceab1b56b
+  depends:
+  - python >=3.9
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14467
+  timestamp: 1733417051523
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.5.0-pyhd8ed1ab_0.conda
+  sha256: 123cc004e2946879708cdb6a9eff24acbbb054990d6131bb94bca7a374ebebfc
+  md5: 1997a083ef0b4c9331f9191564be275e
+  depends:
+  - markdown-it-py >=2.0.0,<5.0.0
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 43805
+  timestamp: 1754946862113
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+  sha256: 78c1bbe1723449c52b7a9df1af2ee5f005209f67e40b6e1d3c7619127c43b1c7
+  md5: 592132998493b3ff25fd7479396e8351
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 14465
+  timestamp: 1733255681319
+- conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.1.4-pyhcf101f3_0.conda
+  sha256: 609ea628ace5c6cdbdce772704e6cb159ead26969bb2f386ca1757632b0f74c6
+  md5: f5a4d548d1d3bdd517260409fc21e205
+  depends:
+  - python >=3.10
+  - typing_extensions
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 72996
+  timestamp: 1756495311698
+- conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+  sha256: d09c47c2cf456de5c09fa66d2c3c5035aa1fa228a1983a433c47b876aa16ce90
+  md5: 37293a85a0f4f77bbd9cf7aaefc62609
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  size: 15851
+  timestamp: 1749895533014
+- conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.5.0-pyhcf101f3_0.conda
+  sha256: a82b09ed2f505617f3743a5703ce25c0abc845afc58588572ea5f83bf08467c7
+  md5: c64dc3b3e0c804e0f1213abd46c1705d
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 253309
+  timestamp: 1757782706200
+- conda: https://conda.anaconda.org/conda-forge/noarch/natsort-8.4.0-pyh29332c3_1.conda
+  sha256: 594ae12c32f163f6d312e38de41311a89e476544613df0c1d048f699721621d7
+  md5: 0aa03903d33997f3886be58abc890aef
+  depends:
+  - python >=3.9
+  - python
+  license: MIT
+  license_family: MIT
+  size: 39002
+  timestamp: 1733880463101
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.3.3-pyhcf101f3_0.conda
+  sha256: fe85d996d2622d7f5f9738f8f2ba7bd9298675d0689393c1e5f0cfd9de7c7a32
+  md5: beea105461da36f4f9a204484704c69a
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6798159
+  timestamp: 1758148016592
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
+  sha256: a20cff739d66c2f89f413e4ba4c6f6b59c50d5c30b5f0d840c13e8c9c2df9135
+  md5: 6bb0d77277061742744176ab555b723c
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.8
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28045
+  timestamp: 1734628936013
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
+  sha256: dcccb07c5a1acb7dc8be94330e62d54754c0e9c9cb2bb6865c8e3cfe44cf5a58
+  md5: d24beda1d30748afcc87c429454ece1b
+  depends:
+  - beautifulsoup4
+  - bleach-with-css !=5.0.0
+  - defusedxml
+  - importlib-metadata >=3.6
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9
+  - traitlets >=5.1
+  - python
+  constrains:
+  - pandoc >=2.9.2,<4.0.0
+  - nbconvert ==7.16.6 *_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 200601
+  timestamp: 1738067871724
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+  sha256: 7a5bd30a2e7ddd7b85031a5e2e14f290898098dc85bea5b3a5bf147c25122838
+  md5: bbe1963f1e47f594070ffe87cdf612ea
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.9
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100945
+  timestamp: 1733402844974
+- conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+  sha256: bb7b21d7fd0445ddc0631f64e66d91a179de4ba920b8381f29b9d006a42788c0
+  md5: 598fd7d4d0de2455fb74f56063969a97
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11543
+  timestamp: 1733325673691
+- conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
+  sha256: 02019191a2597865940394ff42418b37bc585a03a1c643d7cea9981774de2128
+  md5: 16bff3d37a4f99e3aa089c36c2b8d650
+  depends:
+  - python >=3.11
+  - python
+  constrains:
+  - numpy >=1.25
+  - scipy >=1.11.2
+  - matplotlib >=3.8
+  - pandas >=2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1564462
+  timestamp: 1749078300258
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+  sha256: e37db45223e432bcad809897177e05fff31828dfcfc3ef18f046ae44ec01286c
+  md5: f81a6fe643390df9347984644727d796
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert-core >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.7
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 308643
+  timestamp: 1715849037288
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+  sha256: 7b920e46b9f7a2d2aa6434222e5c8d739021dbc5cc75f32d124a8191d86f9056
+  md5: e7f89ea5f7ea9401642758ff50a2d9c1
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16817
+  timestamp: 1733408419340
+- conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+  sha256: 1840bd90d25d4930d60f57b4f38d4e0ae3f5b8db2819638709c36098c6ba770c
+  md5: e51f1e4089cad105b6cac64bd8166587
+  depends:
+  - python >=3.9
+  - typing_utils
+  license: Apache-2.0
+  license_family: APACHE
+  size: 30139
+  timestamp: 1734587755455
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+  sha256: 289861ed0c13a15d7bbb408796af4de72c2fe67e2bcb0de98f4c3fce259d7991
+  md5: 58335b26c38bf4a20f399384c33cbcf9
+  depends:
+  - python >=3.8
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 62477
+  timestamp: 1745345660407
+- conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
+  md5: 457c2c8c08e54905d6954e79cb5b5db9
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11627
+  timestamp: 1631603397334
+- conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.8.1-pyhd8ed1ab_0.conda
+  sha256: 322e531fbfe6a35824a0ff6adf8485e2b77c058049b17cfdce3effb52c54a3d7
+  md5: 40448737a3b10aaec78d8013827a5c5c
+  depends:
+  - bleach
+  - bokeh >=3.7.0,<3.9.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.1.0,<3.0
+  - python >=3.10
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22854483
+  timestamp: 1758082607539
+- conda: https://conda.anaconda.org/conda-forge/noarch/param-2.2.1-pyhd8ed1ab_0.conda
+  sha256: 2dc5b1f066e283d23678ef6484fa2fdaebe9db6a6d83905f7fc9233dc65ceba0
+  md5: b6f8a6ac73c7d5fdc5efc206ac8c98c4
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105120
+  timestamp: 1749664822292
+- conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.5-pyhcf101f3_0.conda
+  sha256: 30de7b4d15fbe53ffe052feccde31223a236dae0495bab54ab2479de30b2990f
+  md5: a110716cdb11cf51482ff4000dc253d7
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 81562
+  timestamp: 1755974222274
+- conda: https://conda.anaconda.org/conda-forge/noarch/patsy-1.0.1-pyhd8ed1ab_1.conda
+  sha256: ab52916f056b435757d46d4ce0a93fd73af47df9c11fd72b74cc4b7e1caca563
+  md5: ee23fabfd0a8c6b8d6f3729b47b2859d
+  depends:
+  - numpy >=1.4.0
+  - python >=3.9
+  license: BSD-2-Clause AND PSF-2.0
+  license_family: BSD
+  size: 186594
+  timestamp: 1733792482894
+- conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+  sha256: 202af1de83b585d36445dc1fda94266697341994d1a3328fabde4989e1b3d07a
+  md5: d0d408b1f18883a944376da5cf8101ea
+  depends:
+  - ptyprocess >=0.5
+  - python >=3.9
+  license: ISC
+  size: 53561
+  timestamp: 1733302019362
+- conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+  sha256: e2ac3d66c367dada209fc6da43e645672364b9fd5f9d28b9f016e24b81af475b
+  md5: 11a9d1d09a3615fc07c3faf79bc0b943
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 11748
+  timestamp: 1733327448200
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
+  sha256: ec9ed3cef137679f3e3a68e286c6efd52144684e1be0b05004d9699882dadcdd
+  md5: dfce4b2af4bfe90cdcaf56ca0b28ddf5
+  depends:
+  - python >=3.9,<3.13.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 1177168
+  timestamp: 1753924973872
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
+  sha256: dfe0fa6e351d2b0cef95ac1a1533d4f960d3992f9e0f82aeb5ec3623a699896b
+  md5: cc9d9a3929503785403dbfad9f707145
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 23653
+  timestamp: 1756227402815
+- conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
+  sha256: 032405adb899ba7c7cc24d3b4cd4e7f40cf24ac4f253a8e385a4f44ccb5e0fc6
+  md5: d2bbbd293097e664ffb01fc4cdaf5729
+  depends:
+  - packaging >=20.0
+  - platformdirs >=2.5.0
+  - python >=3.9
+  - requests >=2.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55588
+  timestamp: 1754941801129
+- conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.23.1-pyhd8ed1ab_0.conda
+  sha256: 13dc67de68db151ff909f2c1d2486fa7e2d51355b25cee08d26ede1b62d48d40
+  md5: a1e91db2d17fd258c64921cb38e6745a
+  depends:
+  - python >=3.10
+  license: Apache-2.0
+  license_family: Apache
+  size: 54592
+  timestamp: 1758278323953
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+  sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae
+  md5: edb16f14d920fb3faf17f5ce582942d6
+  depends:
+  - python >=3.10
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.52
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 273927
+  timestamp: 1756321848365
+- conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+  sha256: a7713dfe30faf17508ec359e0bc7e0983f5d94682492469bd462cdaae9c64d83
+  md5: 7d9daffbb8d8e0af0f769dbbcd173a54
+  depends:
+  - python >=3.9
+  license: ISC
+  size: 19457
+  timestamp: 1733302371990
+- conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+  sha256: 71bd24600d14bb171a6321d523486f6a06f855e75e547fa0cb2a0953b02047f0
+  md5: 3bfdfb8dbcdc4af1ae3f9a8eb3948f04
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 16668
+  timestamp: 1733569518868
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+  sha256: 79db7928d13fab2d892592223d7570f5061c192f27b9febd1a418427b719acc6
+  md5: 12c566707c80111f9799308d9e265aef
+  depends:
+  - python >=3.9
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110100
+  timestamp: 1733195786147
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+  sha256: 5577623b9f6685ece2697c6eb7511b4c9ac5fb607c9babc2646c811b428fd46a
+  md5: 6b6ece66ebcae2d5f326c77ef2c5a066
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 889287
+  timestamp: 1750615908735
+- conda: https://conda.anaconda.org/conda-forge/noarch/pynndescent-0.5.13-pyhd8ed1ab_1.conda
+  sha256: fd7f81cfed1a04883261e2ebd73677066f5040c4ed7984e870c9c931069f9398
+  md5: 87b563f2388f452cedb6a878b738c7dc
+  depends:
+  - llvmlite >=0.30
+  - numba >=0.46
+  - numpy >=1.13
+  - python >=3.9
+  - scikit-learn >=0.19
+  - scipy >=1.0
+  - setuptools
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 49630
+  timestamp: 1734193646381
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.5-pyhcf101f3_0.conda
+  sha256: 6814b61b94e95ffc45ec539a6424d8447895fef75b0fec7e1be31f5beee883fb
+  md5: 6c8979be6d7a17692793114fa26916e8
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 104044
+  timestamp: 1758436411254
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
+  sha256: d016e04b0e12063fbee4a2d5fbb9b39a8d191b5a0042f0b8459188aedeabb0ca
+  md5: e2fd202833c4a981ce8a65974fe4abd1
+  depends:
+  - __win
+  - python >=3.9
+  - win_inet_pton
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21784
+  timestamp: 1733217448189
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+  sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
+  md5: 461219d1a5bd61342293efa2c0c90eac
+  depends:
+  - __unix
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21085
+  timestamp: 1733217331982
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+  md5: 5b8d21249ff20967101ffa321cab24e8
+  depends:
+  - python >=3.9
+  - six >=1.5
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 233310
+  timestamp: 1751104122689
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
+  sha256: df9aa74e9e28e8d1309274648aac08ec447a92512c33f61a8de0afa9ce32ebe8
+  md5: 23029aae904a2ba587daba708208012f
+  depends:
+  - python >=3.9
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 244628
+  timestamp: 1755304154927
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+  sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
+  md5: a61bf9ec79426938ff785eb69dbb1960
+  depends:
+  - python >=3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13383
+  timestamp: 1677079727691
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.2-pyhd8ed1ab_0.conda
+  sha256: e8392a8044d56ad017c08fec2b0eb10ae3d1235ac967d0aab8bd7b41c4a5eaf0
+  md5: 88476ae6ebd24f39261e0854ac244f33
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 144160
+  timestamp: 1742745254292
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
+  sha256: fddf123692aa4b1fc48f0471e346400d9852d96eeed77dbfdd746fa50a8ff894
+  md5: 8fcb6b0e2161850556231336dae58358
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7003
+  timestamp: 1752805919375
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
+  sha256: 8d2a8bf110cc1fc3df6904091dead158ba3e614d8402a83e51ed3a8aa93cdeb0
+  md5: bc8e3267d44011051f2eb14d22fb0960
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 189015
+  timestamp: 1742920947249
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.6-pyhd8ed1ab_0.conda
+  sha256: 4095768d06ffbe31aa98f1d4a982c1f483de088749f30e990673fcae94f1d8d1
+  md5: e0f2c3ecb4dc40d031bbe88869a2a7a1
+  depends:
+  - param
+  - python >=3.9
+  constrains:
+  - jupyterlab >=4.0,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49425
+  timestamp: 1750669964512
+- conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.36.2-pyh29332c3_0.conda
+  sha256: e20909f474a6cece176dfc0dc1addac265deb5fa92ea90e975fbca48085b20c3
+  md5: 9140f1c09dd5489549c6a33931b943c7
+  depends:
+  - attrs >=22.2.0
+  - python >=3.9
+  - rpds-py >=0.7.0
+  - typing_extensions >=4.4.0
+  - python
+  license: MIT
+  license_family: MIT
+  size: 51668
+  timestamp: 1737836872415
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
+  sha256: 8dc54e94721e9ab545d7234aa5192b74102263d3e704e6d0c8aa7008f2da2a7b
+  md5: db0c6b99149880c8ba515cf4abe93ee4
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 59263
+  timestamp: 1755614348400
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+  sha256: 2e4372f600490a6e0b3bac60717278448e323cab1c0fecd5f43f7c56535a99c5
+  md5: 36de09a8d3e5d5e6f4ee63af49e59706
+  depends:
+  - python >=3.9
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10209
+  timestamp: 1733600040800
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+  sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
+  md5: 912a71cc01012ee38e6b90ddd561e36f
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 7818
+  timestamp: 1598024297745
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
+  sha256: 70001ac24ee62058557783d9c5a7bbcfd97bd4911ef5440e3f7a576f9e43bc92
+  md5: 7234f99325263a5af6d4cd195035e8f2
+  depends:
+  - python >=3.9
+  - lark >=1.2.2
+  - python
+  license: MIT
+  license_family: MIT
+  size: 22913
+  timestamp: 1752876729969
+- conda: https://conda.anaconda.org/conda-forge/noarch/scanpy-1.11.4-pyhd8ed1ab_0.conda
+  sha256: 8d7be36901b4385b0b3da5c882ab509b4723a4d333cf046a0c1bc2044cce56f7
+  md5: 23d6ee85f416341db93463665899af6e
+  depends:
+  - anndata >=0.8
+  - h5py >=3.7.0
+  - joblib
+  - legacy-api-wrap >=1.4.1
+  - matplotlib-base >=3.7.5
+  - natsort
+  - networkx >=2.7.1
+  - numba >=0.57.1
+  - numpy >=1.24.1
+  - packaging >=21.3
+  - pandas >=1.5.3
+  - patsy !=1.0.0
+  - pynndescent >=0.5.13
+  - python >=3.10
+  - scikit-learn >=1.1.3
+  - scipy >=1.8.1
+  - seaborn >=0.13.2
+  - session-info2
+  - statsmodels >=0.14.5
+  - tqdm
+  - typing-extensions
+  - umap-learn >=0.5.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1962506
+  timestamp: 1753948476573
+- conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_3.conda
+  sha256: ea29a69b14dd6be5cdeeaa551bf50d78cafeaf0351e271e358f9b820fcab4cb0
+  md5: 62afb877ca2c2b4b6f9ecb37320085b6
+  depends:
+  - seaborn-base 0.13.2 pyhd8ed1ab_3
+  - statsmodels >=0.12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6876
+  timestamp: 1733730113224
+- conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_3.conda
+  sha256: f209c9c18187570b85ec06283c72d64b8738f825b1b82178f194f4866877f8aa
+  md5: fd96da444e81f9e6fcaac38590f3dd42
+  depends:
+  - matplotlib-base >=3.4,!=3.6.1
+  - numpy >=1.20,!=1.24.0
+  - pandas >=1.2
+  - python >=3.9
+  - scipy >=1.7
+  constrains:
+  - seaborn =0.13.2=*_3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 227843
+  timestamp: 1733730112409
+  purls:
+  - pkg:pypi/seaborn?source=hash-mapping
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_1.conda
+  sha256: 00926652bbb8924e265caefdb1db100f86a479e8f1066efe395d5552dde54d02
+  md5: 938c8de6b9de091997145b3bf25cdbf9
+  depends:
+  - __linux
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22736
+  timestamp: 1733322148326
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_1.conda
+  sha256: 5282eb5b462502c38df8cb37cd1542c5bbe26af2453a18a0a0602d084ca39f53
+  md5: e67b1b1fa7a79ff9e8e326d0caf55854
+  depends:
+  - __osx
+  - pyobjc-framework-cocoa
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23100
+  timestamp: 1733322309409
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_1.conda
+  sha256: ba8b93df52e0d625177907852340d735026c81118ac197f61f1f5baea19071ad
+  md5: e6a4e906051565caf5fdae5b0415b654
+  depends:
+  - __win
+  - python >=3.9
+  - pywin32
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23359
+  timestamp: 1733322590167
+- conda: https://conda.anaconda.org/conda-forge/noarch/session-info2-0.2.2-pyhd8ed1ab_0.conda
+  sha256: 89753b10cc1ea763ab692931da152240af28f57fea878ea8dbd45f4f92c9343d
+  md5: b1592c08e769ea2e05b9a88f45bc275a
+  depends:
+  - python >=3.10
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 21065
+  timestamp: 1757704121818
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+  sha256: 972560fcf9657058e3e1f97186cc94389144b46dbdf58c807ce62e83f977e863
+  md5: 4de79c071274a53dcaf2a8c749d1499e
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 748788
+  timestamp: 1748804951958
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+  sha256: 458227f759d5e3fcec5d9b7acce54e10c9e1f4f4b7ec978f3bfd54ce4ee9853d
+  md5: 3339e3b65d58accf4ca4fb8748ab16b3
+  depends:
+  - python >=3.9
+  - python
+  license: MIT
+  license_family: MIT
+  size: 18455
+  timestamp: 1753199211006
+- conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+  sha256: c2248418c310bdd1719b186796ae50a8a77ce555228b6acd32768e2543a15012
+  md5: bf7a226e58dfb8346c70df36065d86c9
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  size: 15019
+  timestamp: 1733244175724
+- conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8-pyhd8ed1ab_0.conda
+  sha256: c978576cf9366ba576349b93be1cfd9311c00537622a2f9e14ba2b90c97cae9c
+  md5: 18c019ccf43769d211f2cf78e9ad46c2
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 37803
+  timestamp: 1756330614547
+- conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+  sha256: 570da295d421661af487f1595045760526964f41471021056e993e73089e9c41
+  md5: b1b505328da7a6b246787df4b5a49fbc
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 26988
+  timestamp: 1733569565672
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+  sha256: b300557c0382478cf661ddb520263508e4b3b5871b471410450ef2846e8c352c
+  md5: efba281bbdae5f6b0a1d53c6d4a97c93
+  depends:
+  - __linux
+  - ptyprocess
+  - python >=3.8
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22452
+  timestamp: 1710262728753
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+  sha256: 4daae56fc8da17784578fbdd064f17e3b3076b394730a14119e571707568dc8a
+  md5: 00b54981b923f5aefcd5e8547de056d5
+  depends:
+  - __osx
+  - ptyprocess
+  - python >=3.8
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22717
+  timestamp: 1710265922593
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
+  sha256: 8cb078291fd7882904e3de594d299c8de16dd3af7405787fce6919a385cfc238
+  md5: 4abd500577430a942a995fd0d09b76a2
+  depends:
+  - __win
+  - python >=3.8
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22883
+  timestamp: 1710262943966
+- conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
+  sha256: 6016672e0e72c4cf23c0cf7b1986283bd86a9c17e8d319212d78d8e9ae42fdfd
+  md5: 9d64911b31d57ca443e9f1e36b04385f
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23869
+  timestamp: 1741878358548
+- conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+  sha256: cad582d6f978276522f84bd209a5ddac824742fe2d452af6acf900f8650a73a2
+  md5: f1acf5fdefa8300de697982bcb1761c9
+  depends:
+  - python >=3.5
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28285
+  timestamp: 1729802975370
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhe01879c_2.conda
+  sha256: 040a5a05c487647c089ad5e05ad5aff5942830db2a4e656f1e300d73436436f1
+  md5: 30a0a26c8abccf4b7991d590fe17c699
+  depends:
+  - python >=3.9
+  - python
+  license: MIT
+  license_family: MIT
+  size: 21238
+  timestamp: 1753796677376
+- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+  sha256: 11e2c85468ae9902d24a27137b6b39b4a78099806e551d390e394a8c34b48e40
+  md5: 9efbfdc37242619130ea42b1cc4ed861
+  depends:
+  - colorama
+  - python >=3.9
+  license: MPL-2.0 or MIT
+  size: 89498
+  timestamp: 1735661472632
+- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+  sha256: f39a5620c6e8e9e98357507262a7869de2ae8cc07da8b7f84e517c9fd6c2b959
+  md5: 019a7385be9af33791c989871317e1ed
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110051
+  timestamp: 1733367480074
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20250822-pyhd8ed1ab_0.conda
+  sha256: dfdf6e3dea87c873a86cfa47f7cba6ffb500bad576d083b3de6ad1b17e1a59c3
+  md5: 5e9220c892fe069da8de2b9c63663319
+  depends:
+  - python >=3.10
+  license: Apache-2.0 AND MIT
+  size: 24939
+  timestamp: 1755865615651
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+  sha256: 7c2df5721c742c2a47b2c8f960e718c930031663ac1174da67c1ed5999f7938c
+  md5: edd329d7d3a4ab45dcf905899a7a6115
+  depends:
+  - typing_extensions ==4.15.0 pyhcf101f3_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 91383
+  timestamp: 1756220668932
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+  sha256: 032271135bca55aeb156cee361c81350c6f3fb203f57d024d7e5a1fc9ef18731
+  md5: 0caa1af407ecff61170c9437a808404d
+  depends:
+  - python >=3.10
+  - python
+  license: PSF-2.0
+  license_family: PSF
+  size: 51692
+  timestamp: 1756220668932
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+  sha256: 3088d5d873411a56bf988eee774559335749aed6f6c28e07bf933256afb9eb6c
+  md5: f6d7aa696c67756a650e91e15e88223c
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 15183
+  timestamp: 1733331395943
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+  sha256: 5aaa366385d716557e365f0a4e9c3fca43ba196872abbbe3d56bb610d131e192
+  md5: 4222072737ccff51314b5ece9c7d6f5a
+  license: LicenseRef-Public-Domain
+  size: 122968
+  timestamp: 1742727099393
+- conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_1.conda
+  sha256: a2f837780af450d633efc052219c31378bcad31356766663fb88a99e8e4c817b
+  md5: 9c96c9876ba45368a03056ddd0f20431
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 11199
+  timestamp: 1733784280160
+- conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+  sha256: e0eb6c8daf892b3056f08416a96d68b0a358b7c46b99c8a50481b22631a4dfc0
+  md5: e7cb0f5745e4c5035a460248334af7eb
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 23990
+  timestamp: 1733323714454
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+  sha256: 4fb9789154bd666ca74e428d973df81087a697dbb987775bc3198d2215f240f8
+  md5: 436c165519e140cb08d246a4472a9d6a
+  depends:
+  - brotli-python >=1.0.9
+  - h2 >=4,<5
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 101735
+  timestamp: 1750271478254
+- conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.14-pyhd8ed1ab_0.conda
+  sha256: e311b64e46c6739e2a35ab8582c20fa30eb608da130625ed379f4467219d4813
+  md5: 7e1e5ff31239f9cd5855714df8a3783d
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 33670
+  timestamp: 1758622418893
+- conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+  sha256: 08315dc2e61766a39219b2d82685fc25a56b2817acf84d5b390176080eaacf99
+  md5: b49f7b291e15494aafb0a7d74806f337
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18431
+  timestamp: 1733359823938
+- conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+  sha256: 19ff205e138bb056a46f9e3839935a2e60bd1cf01c8241a5e172a422fed4f9c6
+  md5: 2841eb5bfc75ce15e9a0054b98dcd64d
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15496
+  timestamp: 1733236131358
+- conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+  sha256: 1dd84764424ffc82030c19ad70607e6f9e3b9cb8e633970766d697185652053e
+  md5: 84f8f77f0a9c6ef401ee96611745da8f
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 46718
+  timestamp: 1733157432924
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+  sha256: 1b34021e815ff89a4d902d879c3bd2040bc1bd6169b32e9427497fa05c55f1ce
+  md5: 75cb7132eb58d97896e173ef12ac9986
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 62931
+  timestamp: 1733130309598
+- conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+  sha256: 93807369ab91f230cf9e6e2a237eaa812492fe00face5b38068735858fba954f
+  md5: 46e441ba871f524e2b067929da3051c2
+  depends:
+  - __win
+  - python >=3.9
+  license: LicenseRef-Public-Domain
+  size: 9555
+  timestamp: 1733130678956
+- conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.4.0-pyhd8ed1ab_0.conda
+  sha256: ac6d4d4133b1e0f69075158cdf00fccad20e29fc6cc45faa480cec37a84af6ae
+  md5: 5663fa346821cd06dc1ece2c2600be2c
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49477
+  timestamp: 1745598150265
+- conda: https://conda.anaconda.org/conda-forge/noarch/zarr-3.1.3-pyhcf101f3_0.conda
+  sha256: 3d494f058f1e8aef41c5fac202c45de26fdc7b169ed886522497a8b83615e8db
+  md5: 540ed093cbc10711485a385a58f34b00
+  depends:
+  - python >=3.11
+  - packaging >=22.0
+  - numpy >=1.26
+  - numcodecs >=0.14
+  - typing_extensions >=4.9
+  - donfig >=0.8
+  - crc32c
+  - python
+  constrains:
+  - fsspec >=2023.10.0
+  - obstore >=0.5.1
+  license: MIT
+  license_family: MIT
+  size: 290974
+  timestamp: 1758255670714
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
+  sha256: 7560d21e1b021fd40b65bfb72f67945a3fcb83d78ad7ccf37b8b3165ec3b68ad
+  md5: df5e78d904988eb55042c0c97446079f
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 22963
+  timestamp: 1749421737203
+- conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-25.1.0-py311h13e5629_0.conda
+  sha256: cab14d6bdcaf64f0911dcd994b51ddb753650d041a74c87a2107041763605e66
+  md5: 8051f5bb22c95da482362f7a8c35fd68
+  depends:
+  - __osx >=10.13
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 33400
+  timestamp: 1753995045262
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h1c43f85_4.conda
+  sha256: 13847b7477bd66d0f718f337e7980c9a32f82ec4e4527c7e0a0983db2d798b8e
+  md5: 1a0a37da4466d45c00fc818bb6b446b3
+  depends:
+  - __osx >=10.13
+  - brotli-bin 1.1.0 h1c43f85_4
+  - libbrotlidec 1.1.0 h1c43f85_4
+  - libbrotlienc 1.1.0 h1c43f85_4
+  license: MIT
+  license_family: MIT
+  size: 20022
+  timestamp: 1756599872109
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h1c43f85_4.conda
+  sha256: 549ea0221019cfb4b370354f2c3ffbd4be1492740e1c73b2cdf9687ed6ad7364
+  md5: 718fb8aa4c8cb953982416db9a82b349
+  depends:
+  - __osx >=10.13
+  - libbrotlidec 1.1.0 h1c43f85_4
+  - libbrotlienc 1.1.0 h1c43f85_4
+  license: MIT
+  license_family: MIT
+  size: 17311
+  timestamp: 1756599830763
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311h7b20566_4.conda
+  sha256: 10afc3a0df8e7447c56b0753848336eeeeea04be9bf1817569c45755392de14b
+  md5: 13de3b969fd0ba12c4f6f9513f486f16
+  depends:
+  - __osx >=10.13
+  - libcxx >=19
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 h1c43f85_4
+  license: MIT
+  license_family: MIT
+  size: 368751
+  timestamp: 1756600247737
+- conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_8.conda
+  sha256: 8f50b58efb29c710f3cecf2027a8d7325ba769ab10c746eff75cea3ac050b10c
+  md5: 97c4b3bd8a90722104798175a1bdddbf
+  depends:
+  - __osx >=10.13
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 132607
+  timestamp: 1757437730085
+- conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.5-hf13058a_0.conda
+  sha256: b37f5dacfe1c59e0a207c1d65489b760dff9ddb97b8df7126ceda01692ba6e97
+  md5: eafe5d9f1a8c514afe41e6e833f66dfd
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 184824
+  timestamp: 1744128064511
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-2.0.0-py311h8ebb5ae_0.conda
+  sha256: 2f83931e589c53ce9cdd85d96686c3ec431077f567c85e6710e6b05c9099b202
+  md5: c79d9a886f7089352482fbb9b7f079a9
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4.6,<3.5.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 295961
+  timestamp: 1758716718225
+- conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.3-py311hd4d69bb_2.conda
+  sha256: 69740b02124fd104b0c14494bc333cfc1bd64508d9dd0075a1493935866fbd64
+  md5: 7d3b5e08077a62b8f24737e54aa3fe81
+  depends:
+  - __osx >=10.13
+  - libcxx >=19
+  - numpy >=1.25
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269105
+  timestamp: 1756545009456
+- conda: https://conda.anaconda.org/conda-forge/osx-64/crc32c-2.7.1-py311h179db11_2.conda
+  sha256: 1fb331d5425ad730d2c9eb0b7055ea1ab7a5ba1049168a5a5231bb55c37a7e79
+  md5: 9a70e6717b9347cebfc8ce472fea2fe3
+  depends:
+  - python
+  - __osx >=10.13
+  - python_abi 3.11.* *_cp311
+  license: LGPL-2.1-or-later
+  size: 50983
+  timestamp: 1756602276112
+- conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.17-py311h1854d6b_0.conda
+  sha256: 0b07c46d15fc32e9eb35a74c56de4fa7bac5c36cf4a05f326e73baa3273a5520
+  md5: ebc7f723cde7539c66ec925ec761f792
+  depends:
+  - python
+  - libcxx >=19
+  - __osx >=10.13
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2666646
+  timestamp: 1758162088550
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.60.0-py311he13f9b5_0.conda
+  sha256: a0adeb0a808a838e0045466e55ec48613be6d453ccb513262bb06073185dcf1b
+  md5: d3c136bd22e73f51f446fa42cba15bc1
+  depends:
+  - __osx >=10.13
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2851913
+  timestamp: 1758133016210
+- conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.14.1-h694c41f_0.conda
+  sha256: 9f8282510db291496e89618fc66a58a1124fe7a6276fbd57ed18c602ce2576e9
+  md5: ca641fdf8b7803f4b7212b6d66375930
+  depends:
+  - libfreetype 2.14.1 h694c41f_0
+  - libfreetype6 2.14.1 h6912278_0
+  license: GPL-2.0-only OR FTL
+  size: 173969
+  timestamp: 1757945973505
+- conda: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.14.0-nompi_py311h9f650d9_101.conda
+  sha256: 35bbb215c41a52ef69ba748c9d7e663acde1f17c5d838e0e933acf0d14c07ec5
+  md5: cd1012a17d3e6078ee6549a4289f1f74
+  depends:
+  - __osx >=10.13
+  - cached-property
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1166065
+  timestamp: 1756767313574
+- conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.6-nompi_hc8237f9_103.conda
+  sha256: e41d22f672b1fbe713d22cf69630abffaee68bdb38a500a708fc70e6f639357f
+  md5: 3f1df98f96e0c369d94232712c9b87d0
+  depends:
+  - __osx >=10.13
+  - libaec >=1.1.4,<2.0a0
+  - libcurl >=8.14.1,<9.0a0
+  - libcxx >=19
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - libgfortran5 >=15.1.0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3522832
+  timestamp: 1753358062940
+- conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_2.conda
+  sha256: 8e0f5af4d5bd59f52d27926750416638e32a65d58a202593fa0e97f312ad78c3
+  md5: 9983b3959da3b695c8da48c93510cbdf
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18407
+  timestamp: 1756754411612
+- conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.9-py311ha94bed4_1.conda
+  sha256: 58391bf10f4450020c792b2dbd4f1b0aa0281dd008c121b36a9eae63a9d4322b
+  md5: a5e96ec3e24dd2fd9887ad284ee1a8c5
+  depends:
+  - python
+  - __osx >=10.13
+  - libcxx >=19
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 67533
+  timestamp: 1756467598070
+- conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+  sha256: 83b52685a4ce542772f0892a0f05764ac69d57187975579a0835ff255ae3ef9c
+  md5: d4765c524b1d91567886bde656fb514b
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1185323
+  timestamp: 1719463492984
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.17-h72f5680_0.conda
+  sha256: bcb81543e49ff23e18dea79ef322ab44b8189fb11141b1af99d058503233a5fc
+  md5: bf210d0c63f2afb9e414a858b79f0eaa
+  depends:
+  - __osx >=10.13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 226001
+  timestamp: 1739161050843
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hcca01a6_1.conda
+  sha256: cc1f1d7c30aa29da4474ec84026ec1032a8df1d7ec93f4af3b98bb793d01184e
+  md5: 21f765ced1a0ef4070df53cb425e1967
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 248882
+  timestamp: 1745264331196
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.4-ha6bc127_0.conda
+  sha256: f4fe00ef0df58b670696c62f2ec3f6484431acbf366ecfbcb71141c81439e331
+  md5: 1a768b826dfc68e07786788d98babfc3
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30034
+  timestamp: 1749993664561
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-36_he492b99_openblas.conda
+  sha256: 9777a98bc129d5036bbcc6924fd42c7f9012813ff591053ccdb3f8b94071da54
+  md5: 81067fbe6234231aa66b35de4c5230f5
+  depends:
+  - libopenblas >=0.3.30,<0.3.31.0a0
+  - libopenblas >=0.3.30,<1.0a0
+  constrains:
+  - mkl <2025
+  - liblapack  3.9.0   36*_openblas
+  - liblapacke 3.9.0   36*_openblas
+  - blas 2.136   openblas
+  - libcblas   3.9.0   36*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17726
+  timestamp: 1758397387194
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h1c43f85_4.conda
+  sha256: 28c1a5f7dbe68342b7341d9584961216bd16f81aa3c7f1af317680213c00b46a
+  md5: b8e1ee78815e0ba7835de4183304f96b
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 67948
+  timestamp: 1756599727911
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h1c43f85_4.conda
+  sha256: a287470602e8380c0bdb5e7a45ba3facac644432d7857f27b39d6ceb0dcbf8e9
+  md5: 9cc4be0cc163d793d5d4bcc405c81bf3
+  depends:
+  - __osx >=10.13
+  - libbrotlicommon 1.1.0 h1c43f85_4
+  license: MIT
+  license_family: MIT
+  size: 30743
+  timestamp: 1756599755474
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h1c43f85_4.conda
+  sha256: 820caf0a78770758830adbab97fe300104981a5327683830d162b37bc23399e9
+  md5: f2c000dc0185561b15de7f969f435e61
+  depends:
+  - __osx >=10.13
+  - libbrotlicommon 1.1.0 h1c43f85_4
+  license: MIT
+  license_family: MIT
+  size: 294904
+  timestamp: 1756599789206
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-36_h9b27e0a_openblas.conda
+  sha256: d3b3d21ac4fd3850e6d1c67392ebe0625831cf30d44ea812aa07e285f352f634
+  md5: b85f4bbdbc15902078cab28615e872d2
+  depends:
+  - libblas 3.9.0 36_he492b99_openblas
+  constrains:
+  - liblapacke 3.9.0   36*_openblas
+  - blas 2.136   openblas
+  - liblapack  3.9.0   36*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17693
+  timestamp: 1758397405253
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.14.1-h5dec5d8_0.conda
+  sha256: ca0d8d12056227d6b47122cfb6d68fc5a3a0c6ab75a0e908542954fc5f84506c
+  md5: 8738cd19972c3599400404882ddfbc24
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.64.0,<2.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 424040
+  timestamp: 1749033558114
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-21.1.2-h3d58e20_0.conda
+  sha256: c3feab716740baa6193a1bc5c948c47c913e28f6e52d418bb67123cb92b9761e
+  md5: 34cd9d03a8f27081a556cb397a19f6cd
+  depends:
+  - __osx >=10.13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 572006
+  timestamp: 1758698149906
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.24-hcc1b750_0.conda
+  sha256: 2733a4adf53daca1aa4f41fe901f0f8ee9e4c509abd23ffcd7660013772d6f45
+  md5: f0a46c359722a3e84deb05cd4072d153
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 69751
+  timestamp: 1747040526774
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20250104-pl5321ha958ccf_0.conda
+  sha256: 6cc49785940a99e6a6b8c6edbb15f44c2dd6c789d9c283e5ee7bdfedd50b4cd6
+  md5: 1f4ed31220402fcddc083b4bff406868
+  depends:
+  - ncurses
+  - __osx >=10.13
+  - ncurses >=6.5,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 115563
+  timestamp: 1738479554273
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+  sha256: 0d238488564a7992942aa165ff994eca540f687753b4f0998b29b4e4d030ff43
+  md5: 899db79329439820b7e8f8de41bca902
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 106663
+  timestamp: 1702146352558
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.7.1-h21dd04a_0.conda
+  sha256: 689862313571b62ee77ee01729dc093f2bf25a2f99415fcfe51d3a6cd31cce7b
+  md5: 9fdeae0b7edda62e989557d645769515
+  depends:
+  - __osx >=10.13
+  constrains:
+  - expat 2.7.1.*
+  license: MIT
+  license_family: MIT
+  size: 72450
+  timestamp: 1752719744781
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.6-h281671d_1.conda
+  sha256: 6394b1bc67c64a21a5cc73d1736d1d4193a64515152e861785c44d2cfc49edf3
+  md5: 4ca9ea59839a9ca8df84170fab4ceb41
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 51216
+  timestamp: 1743434595269
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libfreetype-2.14.1-h694c41f_0.conda
+  sha256: 035e23ef87759a245d51890aedba0b494a26636784910c3730d76f3dc4482b1d
+  md5: e0e2edaf5e0c71b843e25a7ecc451cc9
+  depends:
+  - libfreetype6 >=2.14.1
+  license: GPL-2.0-only OR FTL
+  size: 7780
+  timestamp: 1757945952392
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libfreetype6-2.14.1-h6912278_0.conda
+  sha256: f5f28092e368efc773bcd1c381d123f8b211528385a9353e36f8808d00d11655
+  md5: dfbdc8fd781dc3111541e4234c19fdbd
+  depends:
+  - __osx >=10.13
+  - libpng >=1.6.50,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - freetype >=2.14.1
+  license: GPL-2.0-only OR FTL
+  size: 374993
+  timestamp: 1757945949585
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.1.0-h5f6db21_1.conda
+  sha256: 844500c9372d455f6ae538ffd3cdd7fda5f53d25a2a6b3ba33060a302c37bc3e
+  md5: 07cfad6b37da6e79349c6e3a0316a83b
+  depends:
+  - libgfortran5 15.1.0 hfa3c126_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 133973
+  timestamp: 1756239628906
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.1.0-hfa3c126_1.conda
+  sha256: c4bb79d9e9be3e3a335282b50d18a7965e2a972b95508ea47e4086f1fd699342
+  md5: 696e408f36a5a25afdb23e862053ca82
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 15.1.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1225193
+  timestamp: 1756238834726
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libhwloc-2.12.1-default_h094e1f9_1002.conda
+  sha256: 11e49fcf5c38aad4a78f4b74843eccd610c0e86c424b701e3e87cac072049fb7
+  md5: 4d9e9610b6a16291168144842cd9cae2
+  depends:
+  - __osx >=10.13
+  - libcxx >=19
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2381331
+  timestamp: 1757624131667
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h57a12c2_2.conda
+  sha256: a1c8cecdf9966921e13f0ae921309a1f415dfbd2b791f2117cf7e8f5e61a48b6
+  md5: 210a85a1119f97ea7887188d176db135
+  depends:
+  - __osx >=10.13
+  license: LGPL-2.1-only
+  size: 737846
+  timestamp: 1754908900138
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.1.0-h6e16a3a_0.conda
+  sha256: 9c0009389c1439ec96a08e3bf7731ac6f0eab794e0a133096556a9ae10be9c27
+  md5: 87537967e6de2f885a9fcebd42b7cb10
+  depends:
+  - __osx >=10.13
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 586456
+  timestamp: 1745268522731
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-36_h859234e_openblas.conda
+  sha256: 55032855709253ab2dddb9f125091b944de20ab30a6d399c12d0188ed06f3057
+  md5: 5614cabd1b003b5287183b3e0f149c7e
+  depends:
+  - libblas 3.9.0 36_he492b99_openblas
+  constrains:
+  - liblapacke 3.9.0   36*_openblas
+  - blas 2.136   openblas
+  - libcblas   3.9.0   36*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17704
+  timestamp: 1758397422264
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.1-hd471939_2.conda
+  sha256: 7e22fd1bdb8bf4c2be93de2d4e718db5c548aa082af47a7430eb23192de6bb36
+  md5: 8468beea04b9065b9807fc8b9cdc5894
+  depends:
+  - __osx >=10.13
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD
+  size: 104826
+  timestamp: 1749230155443
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.67.0-h3338091_0.conda
+  sha256: c48d7e1cc927aef83ff9c48ae34dd1d7495c6ccc1edc4a3a6ba6aff1624be9ac
+  md5: e7630cef881b1174d40f3e69a883e55f
+  depends:
+  - __osx >=10.13
+  - c-ares >=1.34.5,<2.0a0
+  - libcxx >=19
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 605680
+  timestamp: 1756835898134
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.30-openmp_h83c2472_2.conda
+  sha256: 341dd45c2e88261f1f9ff76c3410355b4b0e894abe6ac89f7cbf64a3d10f0f01
+  md5: 89edf77977f520c4245567460d065821
+  depends:
+  - __osx >=10.13
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - llvm-openmp >=19.1.7
+  constrains:
+  - openblas >=0.3.30,<0.3.31.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6262457
+  timestamp: 1755473612572
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.50-h84aeda2_1.conda
+  sha256: 8d92c82bcb09908008d8cf5fab75e20733810d40081261d57ef8cd6495fc08b4
+  md5: 1fe32bb16991a24e112051cc0de89847
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 297609
+  timestamp: 1753879919854
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
+  sha256: d3975cfe60e81072666da8c76b993af018cf2e73fe55acba2b5ba0928efaccf5
+  md5: 6af4b059e26492da6013e79cbcb4d069
+  depends:
+  - __osx >=10.13
+  license: ISC
+  size: 210249
+  timestamp: 1716828641383
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.50.4-h39a8b3b_0.conda
+  sha256: 466366b094c3eb4b1d77320530cbf5400e7a10ab33e4824c200147488eebf7a6
+  md5: 156bfb239b6a67ab4a01110e6718cbc4
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: blessing
+  size: 980121
+  timestamp: 1753948554003
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-hed3591d_0.conda
+  sha256: 00654ba9e5f73aa1f75c1f69db34a19029e970a4aeb0fa8615934d8e9c369c3c
+  md5: a6cb15db1c2dc4d3a5f6cf3772e09e81
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 284216
+  timestamp: 1745608575796
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.1-haa3b502_0.conda
+  sha256: 667bdfa1d2956952bca26adfb01a0848f716fea72afe29a684bd107ba8ec0a3c
+  md5: 9aeb6f2819a41937d670e73f15a12da5
+  depends:
+  - __osx >=10.13
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=19
+  - libdeflate >=1.24,<1.26.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: HPND
+  size: 404501
+  timestamp: 1758278988445
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.6.0-hb807250_0.conda
+  sha256: 00dbfe574b5d9b9b2b519acb07545380a6bc98d1f76a02695be4995d4ec91391
+  md5: 7bb6608cf1f83578587297a158a6630b
+  depends:
+  - __osx >=10.13
+  constrains:
+  - libwebp 1.6.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365086
+  timestamp: 1752159528504
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+  sha256: 8896cd5deff6f57d102734f3e672bc17120613647288f9122bec69098e839af7
+  md5: bbeca862892e2898bdb45792a61c4afc
+  depends:
+  - __osx >=10.13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 323770
+  timestamp: 1727278927545
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.0-h0ad03eb_1.conda
+  sha256: 09a66ef83d5fc3fd12bcefb5507463941ab26db4ba0a7082a625ac0ef8b9c100
+  md5: 0284a6d6fb9236543e24b0286c3a0373
+  depends:
+  - __osx >=10.13
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - icu <0.0a0
+  - libxml2 2.15.0
+  license: MIT
+  license_family: MIT
+  size: 493439
+  timestamp: 1758641000703
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.0-h23bb396_1.conda
+  sha256: c033a18aae5aa957edb21045e0c889c004d692fe5f58347a5e8940755e7065e1
+  md5: 92b9ff13969bf3edc2654d58bcd63abc
+  depends:
+  - __osx >=10.13
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libxml2-16 2.15.0 h0ad03eb_1
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - icu <0.0a0
+  license: MIT
+  license_family: MIT
+  size: 40409
+  timestamp: 1758641022632
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+  sha256: 8412f96504fc5993a63edf1e211d042a1fd5b1d51dedec755d2058948fcced09
+  md5: 003a54a4e32b02f7355b50a837e699da
+  depends:
+  - __osx >=10.13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 57133
+  timestamp: 1727963183990
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-21.1.0-hf4e0ed4_0.conda
+  sha256: 78336131a08990390003ef05d14ecb49f3a47e4dac60b1bcebeccd87fa402925
+  md5: 5acc6c266fd33166fa3b33e48665ae0d
+  depends:
+  - __osx >=10.13
+  constrains:
+  - openmp 21.1.0|21.1.0.*
+  - intel-openmp <0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 311174
+  timestamp: 1756673275570
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.45.0-py311hb26b958_1.conda
+  sha256: 8ab976d91d696a99c7aa4919913b6edfe703184dd1fd511db44d9a02eaaf7415
+  md5: 56ec540bfb2d9744e67fef5ab7d1d50a
+  depends:
+  - __osx >=10.13
+  - libcxx >=19
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 26005607
+  timestamp: 1758282844153
+- conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.2-py311ha3cf9ac_1.conda
+  sha256: e9965b5d4c29b17b1512035b24a7c126ed7bdb6b39103b52cae099d5bb4194a9
+  md5: 1d6596ca7c7b66215c5c0d58b3cb0dd3
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24688
+  timestamp: 1733219887972
+- conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.10.6-py311h48d7e91_1.conda
+  sha256: d808d67d497f77376139c98fa2b5d9bcfcf6c12c24fa57d55b29ad1f569de30f
+  md5: 0d9bcc9297c8e179ee7e43b7af3b543a
+  depends:
+  - __osx >=10.13
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype
+  - kiwisolver >=1.3.1
+  - libcxx >=19
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - numpy >=1.23
+  - numpy >=1.23,<3
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8271784
+  timestamp: 1756870011797
+  purls:
+  - pkg:pypi/matplotlib?source=hash-mapping
+- conda: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.1.1-py311hd4d69bb_1.conda
+  sha256: f6a6ef1fb34547b473e68b1698e11b54cd0caa3819217d2fd9807586f0f4e242
+  md5: 5a924ec08e77329384e9d196ebd432de
+  depends:
+  - __osx >=10.13
+  - libcxx >=19
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 91405
+  timestamp: 1756678753596
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
+  sha256: ea4a5d27ded18443749aefa49dc79f6356da8506d508b5296f60b8d51e0c4bd9
+  md5: ced34dd9929f491ca6dab6a2927aff25
+  depends:
+  - __osx >=10.13
+  license: X11 AND BSD-3-Clause
+  size: 822259
+  timestamp: 1738196181298
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.62.0-py311hf901296_0.conda
+  sha256: 809cecb3cde414c62c489940beae378b9cf7ec4bdf1f26c9586d726b076d0139
+  md5: 3020f7d06d5da81c81cbe39ac875429f
+  depends:
+  - __osx >=10.13
+  - libcxx >=19
+  - llvm-openmp >=19.1.7
+  - llvm-openmp >=21.1.0
+  - llvmlite >=0.45.0,<0.46.0a0
+  - numpy >=1.23,<3
+  - numpy >=1.24,<2.4
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - cuda-python >=11.6
+  - cudatoolkit >=11.2
+  - cuda-version >=11.2
+  - libopenblas !=0.3.6
+  - tbb >=2021.6.0
+  - scipy >=1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5840140
+  timestamp: 1758871977230
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numcodecs-0.16.1-py311hf4bc098_1.conda
+  sha256: c604abfd23bf545940edd1834f82ad254ac3170663e4369a1622c7071f4238fc
+  md5: a662ebe85a933cba8cc4fdfc9cc91659
+  depends:
+  - __osx >=10.13
+  - deprecated
+  - libcxx >=19
+  - msgpack-python
+  - numpy >=1.23,<3
+  - numpy >=1.24
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - typing_extensions
+  license: MIT
+  license_family: MIT
+  size: 759045
+  timestamp: 1756543000407
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.3.3-py311hf157cb9_0.conda
+  sha256: 63a6c4f04df9ef36fe3b0eded7f2e668c74949995821d6dd59179764f0829a8e
+  md5: 3d5331d89f160b1af3c39fd7e3f1ba93
+  depends:
+  - python
+  - libcxx >=19
+  - __osx >=10.13
+  - liblapack >=3.9.0,<4.0a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8552704
+  timestamp: 1757504936115
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.4-h87e8dc5_0.conda
+  sha256: fdf4708a4e45b5fd9868646dd0c0a78429f4c0b8be490196c975e06403a841d0
+  md5: a67d3517ebbf615b91ef9fdc99934e0c
+  depends:
+  - __osx >=10.13
+  - libcxx >=19
+  - libpng >=1.6.50,<1.7.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 334875
+  timestamp: 1758489493148
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.5.3-h230baf5_1.conda
+  sha256: 8eeb0d7e01784c1644c93947ba5e6e55d79f9f9c8dd53b33a6523efb93afd56c
+  md5: f601470d724024fec8dbb98a2dd5b39c
+  depends:
+  - __osx >=10.13
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2742974
+  timestamp: 1758599496115
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.3.2-py311hf4bc098_0.conda
+  sha256: b61681152840b4690d714ef1c4d2ef1dfd1985e0fc5d5d811bcb629c484d2466
+  md5: 8df328d2c2b8f76d94c87c848a7b49a6
+  depends:
+  - __osx >=10.13
+  - libcxx >=19
+  - numpy >=1.22.4
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1
+  constrains:
+  - numexpr >=2.8.4
+  - fastparquet >=2022.12.0
+  - qtpy >=2.3.0
+  - scipy >=1.10.0
+  - sqlalchemy >=2.0.0
+  - lxml >=4.9.2
+  - html5lib >=1.1
+  - matplotlib >=3.6.3
+  - odfpy >=1.4.1
+  - xlrd >=2.0.1
+  - beautifulsoup4 >=4.11.2
+  - fsspec >=2022.11.0
+  - numba >=0.56.4
+  - blosc >=1.21.3
+  - pyqt5 >=5.15.9
+  - gcsfs >=2022.11.0
+  - tzdata >=2022.7
+  - xarray >=2022.12.0
+  - tabulate >=0.9.0
+  - psycopg2 >=2.9.6
+  - pyxlsb >=1.0.10
+  - bottleneck >=1.3.6
+  - pytables >=3.8.0
+  - xlsxwriter >=3.0.5
+  - zstandard >=0.19.0
+  - openpyxl >=3.1.0
+  - python-calamine >=0.1.7
+  - pandas-gbq >=0.19.0
+  - pyreadstat >=1.2.0
+  - pyarrow >=10.0.1
+  - s3fs >=2022.11.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14631576
+  timestamp: 1755779827936
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.3.0-py311ha88f94d_3.conda
+  sha256: 728fe6e04789c0d7c3431680f7348226dc8bb64c6882731780ee99dd661e9024
+  md5: c1ce8859b9cece7f0c500f918f24aa35
+  depends:
+  - python
+  - __osx >=10.13
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - lcms2 >=2.17,<3.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - libzlib >=1.3.1,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - openjpeg >=2.5.3,<3.0a0
+  license: HPND
+  size: 975592
+  timestamp: 1758208807855
+- conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.1.0-py311hf197a57_0.conda
+  sha256: 110261c6e7658d579ad2d9e7f3ec1dcd4e1fff9888d36cb01f21b6f8a7f4f4c9
+  md5: 95a32bf2fd778076287cbe1e224f1628
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 496994
+  timestamp: 1758169521099
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+  sha256: 05944ca3445f31614f8c674c560bca02ff05cb51637a96f665cb2bbe496099e5
+  md5: 8bcf980d2c6b17094961198284b8e862
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 8364
+  timestamp: 1726802331537
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.1-py311h2f44256_1.conda
+  sha256: d0800d251981e3d124bd960e799dd0c56e8b16cd1c6fb99a32990d62f492d754
+  md5: 840b246b6b86c37321e79ca56518273f
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4.6,<3.5.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 486295
+  timestamp: 1756813198835
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.1-py311hbc8e8a3_1.conda
+  sha256: 71394c6e3f77898e856dab863f283e92f65b03e02e12fcf228bd3715a3459431
+  md5: ab2c871073a077d149d6da6d03d10e44
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4.6,<3.5.0a0
+  - pyobjc-core 11.1.*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 385837
+  timestamp: 1756824131805
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.13-h9ccd52b_0_cpython.conda
+  sha256: d8e15db837c10242658979bc475298059bd6615524f2f71365ab8e54fbfea43c
+  md5: 6e28c31688c6f1fdea3dc3d48d33e1c0
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.7.0,<3.0a0
+  - libffi >=3.4.6,<3.5.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libsqlite >=3.50.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.5.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 15423460
+  timestamp: 1749049420299
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311ha3cf9ac_2.conda
+  sha256: 4855c51eedcde05f3d9666a0766050c7cbdff29b150d63c1adc4071637ba61d7
+  md5: f49b0da3b1e172263f4f1e2f261a490d
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 197287
+  timestamp: 1737454852180
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-27.1.0-py311h0ab6910_0.conda
+  sha256: a0200b5e781c22a5d7b64fd0edf5e9ab881772f7a15a6bc2359db8d0ac437bb3
+  md5: 840bdfbb93e35d650205af10883ff8a0
+  depends:
+  - python
+  - libcxx >=19
+  - __osx >=10.13
+  - zeromq >=4.3.5,<4.4.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 362304
+  timestamp: 1757387126324
+- conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+  sha256: 79d804fa6af9c750e8b09482559814ae18cd8df549ecb80a4873537a5a31e06e
+  md5: dd1ea9ff27c93db7c01a7b7656bd4ad4
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: LicenseRef-Qhull
+  size: 528122
+  timestamp: 1720814002588
+- conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h7cca4af_2.conda
+  sha256: 53017e80453c4c1d97aaf78369040418dea14cf8f46a2fa999f31bd70b36c877
+  md5: 342570f8e02f2f022147a7f841475784
+  depends:
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 256712
+  timestamp: 1740379577668
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.27.1-py311hd3d88a1_1.conda
+  sha256: 85357c87af076680c071a8ea843bea554d58694d011104b721cc13bbf9ad0e75
+  md5: 4b9839b15de18289ee5289a6dbcb8a45
+  depends:
+  - python
+  - __osx >=10.13
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 376118
+  timestamp: 1756737583772
+- conda: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.7.2-py311had5a2ce_0.conda
+  sha256: 7adab19ad8211ab267366046c199bda63b85a11833d73901cd8137cf555ddf51
+  md5: 35e84df764fb918f99c17602376d6a84
+  depends:
+  - __osx >=10.13
+  - joblib >=1.2.0
+  - libcxx >=19
+  - llvm-openmp >=19.1.7
+  - numpy >=1.22.0
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scipy >=1.8.0
+  - threadpoolctl >=3.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9157602
+  timestamp: 1757407090554
+- conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.16.2-py311h32c7e5c_0.conda
+  sha256: 8d8e69daa49c3c876fcacc31d31698d6d103e133c87c3d046fa67be4c0ad4a94
+  md5: 8bf3fee43462b21388d04251f37159e6
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=19
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - libgfortran5 >=15.1.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.6
+  - numpy >=1.23,<3
+  - numpy >=1.25.2
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15295538
+  timestamp: 1757683511655
+- conda: https://conda.anaconda.org/conda-forge/osx-64/statsmodels-0.14.5-py311ha2d3830_0.conda
+  sha256: 6dcc2a61a73de340317241d70f9f47499c69a62e508b8b251af738bff631f1de
+  md5: 2d429e456dd67796ed0e3114fb559f82
+  depends:
+  - __osx >=10.13
+  - numpy <3,>=1.22.3
+  - numpy >=1.23,<3
+  - packaging >=21.3
+  - pandas !=2.1.0,>=1.4
+  - patsy >=0.5.6
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scipy !=1.9.2,>=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11852156
+  timestamp: 1751918004113
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tbb-2022.2.0-hc025b3e_1.conda
+  sha256: 44d9b5795d8c72da1002ef504c16eadcb8615c9c8098c830c12ebacae31149ed
+  md5: 796b8d4a40afd4951d87ffd939c6a206
+  depends:
+  - __osx >=10.13
+  - libcxx >=19
+  - libhwloc >=2.12.1,<2.12.2.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 164273
+  timestamp: 1755776307318
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hf689a15_2.conda
+  sha256: b24468006a96b71a5f4372205ea7ec4b399b0f2a543541e86f883de54cd623fc
+  md5: 9864891a6946c2fe037c02fca7392ab4
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: TCL
+  license_family: BSD
+  size: 3259809
+  timestamp: 1748387843735
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.5.2-py311h13e5629_1.conda
+  sha256: 397226b6314aec2b076294816c941c1e9b7e3bbcf7a2e9dc9ba08f3ac10b0590
+  md5: 06fd6a712ee16b3e7998e8ee2e7fc8b1
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 869912
+  timestamp: 1756855230920
+- conda: https://conda.anaconda.org/conda-forge/osx-64/umap-learn-0.5.9.post2-py311h6eed73b_0.conda
+  sha256: 7ee998e66c77963170a53a80c47c8e568a527d5fc365335750f4f2021ce1b3bd
+  md5: 24e74513a8f65e2d772961ad0ab4c9be
+  depends:
+  - numba >=0.51.2
+  - numpy >=1.17
+  - pynndescent >=0.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scikit-learn >=0.22
+  - scipy >=1.3.1
+  - setuptools
+  - tbb >=2019.0
+  - tqdm
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 197095
+  timestamp: 1751544661566
+- conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-16.0.0-py311h13e5629_1.conda
+  sha256: cdd1276ff295078efb932f21305abda5392e8e43e7787050ea2d5ccbc04981ef
+  md5: 4199c0fe9c425eddb08f5741fcb772c5
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 400393
+  timestamp: 1756494700657
+- conda: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.17.3-py311h13e5629_1.conda
+  sha256: 69a040e11d6967e7a3b8a0a1730016e7668e7904686450fa8bc2ff74de68fe7a
+  md5: e61d11880c60001e858cc591ce35973f
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 61909
+  timestamp: 1756851726109
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.12-h6e16a3a_0.conda
+  sha256: b4d2225135aa44e551576c4f3cf999b3252da6ffe7b92f0ad45bb44b887976fc
+  md5: 4cf40e60b444d56512a64f39d12c20bd
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 13290
+  timestamp: 1734229077182
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
+  sha256: bb4d1ef9cafef535494adf9296130b6193b3a44375883185b5167de03eb1ac7f
+  md5: 9f438e1b6f4e73fd9e6d78bfe7c36743
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 18465
+  timestamp: 1727794980957
+- conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
+  sha256: a335161bfa57b64e6794c3c354e7d49449b28b8d8a7c4ed02bf04c3f009953f9
+  md5: a645bb90997d3fc2aea0adf6517059bd
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 79419
+  timestamp: 1753484072608
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h6c33b1e_9.conda
+  sha256: 30aa5a2e9c7b8dbf6659a2ccd8b74a9994cdf6f87591fcc592970daa6e7d3f3c
+  md5: d940d809c42fbf85b05814c3290660f5
+  depends:
+  - __osx >=10.13
+  - libcxx >=19
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 259628
+  timestamp: 1757371000392
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.25.0-py311h62e9434_0.conda
+  sha256: be241ea3ca603d68654beeab4c991c225c9361378a107f72c2433ddfdff88132
+  md5: 5425495af6b0b010230320d618022f20
+  depends:
+  - python
+  - cffi >=1.11
+  - zstd >=1.5.7,<1.5.8.0a0
+  - __osx >=10.13
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 462903
+  timestamp: 1757930157317
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h8210216_2.conda
+  sha256: c171c43d0c47eed45085112cb00c8c7d4f0caa5a32d47f2daca727e45fb98dca
+  md5: cd60a4a5a8d6a476b30d8aa4bb49251a
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 485754
+  timestamp: 1742433356230
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-25.1.0-py311h3696347_0.conda
+  sha256: f5b4102716a568877e212a9d4c677027b887f215d4735acfe4532efb2da59de1
+  md5: 3b4ba20f581ec2268df5a76c64232ae5
+  depends:
+  - __osx >=11.0
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 34325
+  timestamp: 1753995031680
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-h6caf38d_4.conda
+  sha256: 8aa8ee52b95fdc3ef09d476cbfa30df722809b16e6dca4a4f80e581012035b7b
+  md5: ce8659623cea44cc812bc0bfae4041c5
+  depends:
+  - __osx >=11.0
+  - brotli-bin 1.1.0 h6caf38d_4
+  - libbrotlidec 1.1.0 h6caf38d_4
+  - libbrotlienc 1.1.0 h6caf38d_4
+  license: MIT
+  license_family: MIT
+  size: 20003
+  timestamp: 1756599758165
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-h6caf38d_4.conda
+  sha256: e57d402b02c9287b7c02d9947d7b7b55a4f7d73341c210c233f6b388d4641e08
+  md5: ab57f389f304c4d2eb86d8ae46d219c3
+  depends:
+  - __osx >=11.0
+  - libbrotlidec 1.1.0 h6caf38d_4
+  - libbrotlienc 1.1.0 h6caf38d_4
+  license: MIT
+  license_family: MIT
+  size: 17373
+  timestamp: 1756599741779
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311hf719da1_4.conda
+  sha256: 64645da991de052f0e522486cf97f8457fb37ed5c30d67655d3a32d2b9f56167
+  md5: 4cd43bb7ba1a3cb4cd7a2e335f6d3c32
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 h6caf38d_4
+  license: MIT
+  license_family: MIT
+  size: 340889
+  timestamp: 1756599941690
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
+  sha256: b456200636bd5fecb2bec63f7e0985ad2097cf1b83d60ce0b6968dffa6d02aa1
+  md5: 58fd217444c2a5701a44244faf518206
+  depends:
+  - __osx >=11.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 125061
+  timestamp: 1757437486465
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.5-h5505292_0.conda
+  sha256: b4bb55d0806e41ffef94d0e3f3c97531f322b3cb0ca1f7cdf8e47f62538b7a2b
+  md5: f8cd1beb98240c7edb1a95883360ccfa
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 179696
+  timestamp: 1744128058734
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.0.0-py311hcfc1310_0.conda
+  sha256: 207802a43cca5e81e1c267daabbb9b393d8c766f23883b3a2cb099d34eb51345
+  md5: 419d91ef5b062ce19b3a513dcd566df8
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4.6,<3.5.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 294021
+  timestamp: 1758716481369
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.3-py311h57a9ea7_2.conda
+  sha256: 3d85887270eb5f9f82025c93956cef6ff12a1aab49dbf7cba5ca4ee0544d4182
+  md5: 66103afd2e02f1a416930dc352ae327b
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - numpy >=1.25
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 259587
+  timestamp: 1756545016847
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/crc32c-2.7.1-py311hb76fab6_2.conda
+  sha256: 0a08956eb045084cc90dd981e10e99a973f839880fc18a35fe864731cd4c8efa
+  md5: 0b2957e663ab045966e2c787ac5cc285
+  depends:
+  - python
+  - python 3.11.* *_cpython
+  - __osx >=11.0
+  - python_abi 3.11.* *_cp311
+  license: LGPL-2.1-or-later
+  size: 52342
+  timestamp: 1756602289074
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.17-py311hc58e375_0.conda
+  sha256: 27ab3612dea9db4fd46ed270366968f5cf333fc44376df8a314a2798f93cda82
+  md5: 0552b12026620a95945c3398ac847c83
+  depends:
+  - python
+  - __osx >=11.0
+  - libcxx >=19
+  - python 3.11.* *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2667017
+  timestamp: 1758162064247
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.60.0-py311ha9b3269_0.conda
+  sha256: 9f998f1e1d5fd8d34d036cc10a234edaf378d2a62e5489adfa702657ef69ee8c
+  md5: 6c1b150fab22004e7a90923bb2c9cd58
+  depends:
+  - __osx >=11.0
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2886266
+  timestamp: 1758132831761
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.14.1-hce30654_0.conda
+  sha256: 14427aecd72e973a73d5f9dfd0e40b6bc3791d253de09b7bf233f6a9a190fd17
+  md5: 1ec9a1ee7a2c9339774ad9bb6fe6caec
+  depends:
+  - libfreetype 2.14.1 hce30654_0
+  - libfreetype6 2.14.1 h6da58f4_0
+  license: GPL-2.0-only OR FTL
+  size: 173399
+  timestamp: 1757947175403
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.14.0-nompi_py311h1d03b57_101.conda
+  sha256: d8f56e7ad233e37b0e91f204b63ec28e83c19285f7d62dedc201525f6cc0f12b
+  md5: 67a61d95d3be80013fbdac3afb260528
+  depends:
+  - __osx >=11.0
+  - cached-property
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1170719
+  timestamp: 1756767948292
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.6-nompi_he65715a_103.conda
+  sha256: 8948a63fc4a56536ce7b2716b781616c3909507300d26e9f265a3c13d59708a0
+  md5: fcc9aca330f13d071bfc4de3d0942d78
+  depends:
+  - __osx >=11.0
+  - libaec >=1.1.4,<2.0a0
+  - libcurl >=8.14.1,<9.0a0
+  - libcxx >=19
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - libgfortran5 >=15.1.0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3308443
+  timestamp: 1753356976982
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+  sha256: 9ba12c93406f3df5ab0a43db8a4b4ef67a5871dfd401010fbe29b218b2cbe620
+  md5: 5eb22c1d7b3fc4abb50d92d621583137
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 11857802
+  timestamp: 1720853997952
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py311h267d04e_2.conda
+  sha256: 92b998fa9e68b7793b5b15882932f7703cdc1cc6e1348d0a1799567ef6f04428
+  md5: 0edc5f25c32d86d5b4327e0f4de539f9
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18716
+  timestamp: 1756754690458
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.9-py311h63e5c0c_1.conda
+  sha256: ad672ae48e23e59a6adbff2b51fb47bfc1bf430f8e991dbf086b2506caf9eb31
+  md5: d5778729cfb3846a9d329c8740f13420
+  depends:
+  - python
+  - python 3.11.* *_cpython
+  - libcxx >=19
+  - __osx >=11.0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 66093
+  timestamp: 1756467632843
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+  sha256: 4442f957c3c77d69d9da3521268cad5d54c9033f1a73f99cde0a3658937b159b
+  md5: c6dc8a0fdec13a0565936655c33069a1
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1155530
+  timestamp: 1719463474401
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.17-h7eeda09_0.conda
+  sha256: 310a62c2f074ebd5aa43b3cd4b00d46385ce680fa2132ecee255a200e2d2f15f
+  md5: 92a61fd30b19ebd5c1621a5bfe6d8b5f
+  depends:
+  - __osx >=11.0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 212125
+  timestamp: 1739161108467
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-hd64df32_1.conda
+  sha256: 12361697f8ffc9968907d1a7b5830e34c670e4a59b638117a2cdfed8f63a38f8
+  md5: a74332d9b60b62905e3d30709df08bf1
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 188306
+  timestamp: 1745264362794
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.4-h51d1e36_0.conda
+  sha256: 0ea6b73b3fb1511615d9648186a7409e73b7a8d9b3d890d39df797730e3d1dbb
+  md5: 8ed0f86b7a5529b98ec73b43a53ce800
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30173
+  timestamp: 1749993648288
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-36_h51639a9_openblas.conda
+  sha256: acedf4c86be500172ed84a1bf37425e5c538f0494341ebdc829001cd37707564
+  md5: 3bf1e49358861ce86825eaa47c092f29
+  depends:
+  - libopenblas >=0.3.30,<0.3.31.0a0
+  - libopenblas >=0.3.30,<1.0a0
+  constrains:
+  - liblapacke 3.9.0   36*_openblas
+  - libcblas   3.9.0   36*_openblas
+  - liblapack  3.9.0   36*_openblas
+  - mkl <2025
+  - blas 2.136   openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17733
+  timestamp: 1758397710974
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-h6caf38d_4.conda
+  sha256: 023b609ecc35bfee7935d65fcc5aba1a3ba6807cbba144a0730198c0914f7c79
+  md5: 231cffe69d41716afe4525c5c1cc5ddd
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 68938
+  timestamp: 1756599687687
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-h6caf38d_4.conda
+  sha256: 7f1cf83a00a494185fc087b00c355674a0f12e924b1b500d2c20519e98fdc064
+  md5: cb7e7fe96c9eee23a464afd57648d2cd
+  depends:
+  - __osx >=11.0
+  - libbrotlicommon 1.1.0 h6caf38d_4
+  license: MIT
+  license_family: MIT
+  size: 29015
+  timestamp: 1756599708339
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-h6caf38d_4.conda
+  sha256: a2f2c1c2369360147c46f48124a3a17f5122e78543275ff9788dc91a1d5819dc
+  md5: 4ce5651ae5cd6eebc5899f9bfe0eac3c
+  depends:
+  - __osx >=11.0
+  - libbrotlicommon 1.1.0 h6caf38d_4
+  license: MIT
+  license_family: MIT
+  size: 275791
+  timestamp: 1756599724058
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-36_hb0561ab_openblas.conda
+  sha256: ee8b3386c9fe8668eb9013ffea5c60f7546d0d298931f7ec0637b08d796029de
+  md5: 46aefc2fcef5f1f128d0549cb0fad584
+  depends:
+  - libblas 3.9.0 36_h51639a9_openblas
+  constrains:
+  - liblapack  3.9.0   36*_openblas
+  - liblapacke 3.9.0   36*_openblas
+  - blas 2.136   openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17717
+  timestamp: 1758397731650
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.14.1-h73640d1_0.conda
+  sha256: 0055b68137309db41ec34c938d95aec71d1f81bd9d998d5be18f32320c3ccba0
+  md5: 1af57c823803941dfc97305248a56d57
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.64.0,<2.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 403456
+  timestamp: 1749033320430
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.2-hf598326_0.conda
+  sha256: 3de00998c8271f599d6ed9aea60dc0b3e5b1b7ff9f26f8eac95f86f135aa9beb
+  md5: edfa256c5391f789384e470ce5c9f340
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 568154
+  timestamp: 1758698306949
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.24-h5773f1b_0.conda
+  sha256: 417d52b19c679e1881cce3f01cad3a2d542098fa2d6df5485aac40f01aede4d1
+  md5: 3baf58a5a87e7c2f4d243ce2f8f2fe5c
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 54790
+  timestamp: 1747040549847
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
+  sha256: 66aa216a403de0bb0c1340a88d1a06adaff66bae2cfd196731aa24db9859d631
+  md5: 44083d2d2c2025afca315c7a172eab2b
+  depends:
+  - ncurses
+  - __osx >=11.0
+  - ncurses >=6.5,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 107691
+  timestamp: 1738479560845
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+  sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
+  md5: 36d33e440c31857372a72137f78bacf5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 107458
+  timestamp: 1702146414478
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.1-hec049ff_0.conda
+  sha256: 8fbb17a56f51e7113ed511c5787e0dec0d4b10ef9df921c4fd1cccca0458f648
+  md5: b1ca5f21335782f71a8bd69bdc093f67
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.7.1.*
+  license: MIT
+  license_family: MIT
+  size: 65971
+  timestamp: 1752719657566
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
+  sha256: c6a530924a9b14e193ea9adfe92843de2a806d1b7dbfd341546ece9653129e60
+  md5: c215a60c2935b517dcda8cad4705734d
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 39839
+  timestamp: 1743434670405
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.1-hce30654_0.conda
+  sha256: 9de25a86066f078822d8dd95a83048d7dc2897d5d655c0e04a8a54fca13ef1ef
+  md5: f35fb38e89e2776994131fbf961fa44b
+  depends:
+  - libfreetype6 >=2.14.1
+  license: GPL-2.0-only OR FTL
+  size: 7810
+  timestamp: 1757947168537
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.14.1-h6da58f4_0.conda
+  sha256: cc4aec4c490123c0f248c1acd1aeab592afb6a44b1536734e20937cda748f7cd
+  md5: 6d4ede03e2a8e20eb51f7f681d2a2550
+  depends:
+  - __osx >=11.0
+  - libpng >=1.6.50,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - freetype >=2.14.1
+  license: GPL-2.0-only OR FTL
+  size: 346703
+  timestamp: 1757947166116
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.1.0-hfdf1602_1.conda
+  sha256: 981e3fac416e80b007a2798d6c1d4357ebebeb72a039aca1fb3a7effe9dcae86
+  md5: c98207b6e2b1a309abab696d229f163e
+  depends:
+  - libgfortran5 15.1.0 hb74de2c_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 134383
+  timestamp: 1756239485494
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.1.0-hb74de2c_1.conda
+  sha256: 1f8f5b2fdd0d2559d0f3bade8da8f57e9ee9b54685bd6081c6d6d9a2b0239b41
+  md5: 4281bd1c654cb4f5cab6392b3330451f
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 15.1.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 759679
+  timestamp: 1756238772083
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.12.1-default_h48b22c3_1002.conda
+  sha256: 90d3be72bfcb74541c6a8c48fdb3c903c2e7bf9ea66649d743c204a636e9e0bb
+  md5: 39a1c6805c7a3d2d5ad304ac015d5124
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2355866
+  timestamp: 1757624101657
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
+  sha256: de0336e800b2af9a40bdd694b03870ac4a848161b35c8a2325704f123f185f03
+  md5: 4d5a7445f0b25b6a3ddbb56e790f5251
+  depends:
+  - __osx >=11.0
+  license: LGPL-2.1-only
+  size: 750379
+  timestamp: 1754909073836
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.1.0-h5505292_0.conda
+  sha256: 78df2574fa6aa5b6f5fc367c03192f8ddf8e27dc23641468d54e031ff560b9d4
+  md5: 01caa4fbcaf0e6b08b3aef1151e91745
+  depends:
+  - __osx >=11.0
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 553624
+  timestamp: 1745268405713
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-36_hd9741b5_openblas.conda
+  sha256: ffadfc04f5fb9075715fc4db0b6f2e88c23931eb06a193531ee3ba936dedc433
+  md5: e0b918b8232902da02c2c5b4eb81f4d5
+  depends:
+  - libblas 3.9.0 36_h51639a9_openblas
+  constrains:
+  - libcblas   3.9.0   36*_openblas
+  - liblapacke 3.9.0   36*_openblas
+  - blas 2.136   openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17728
+  timestamp: 1758397741587
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
+  sha256: 0cb92a9e026e7bd4842f410a5c5c665c89b2eb97794ffddba519a626b8ce7285
+  md5: d6df911d4564d77c4374b02552cb17d1
+  depends:
+  - __osx >=11.0
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD
+  size: 92286
+  timestamp: 1749230283517
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.67.0-hc438710_0.conda
+  sha256: a07cb53b5ffa2d5a18afc6fd5a526a5a53dd9523fbc022148bd2f9395697c46d
+  md5: a4b4dd73c67df470d091312ab87bf6ae
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.34.5,<2.0a0
+  - libcxx >=19
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 575454
+  timestamp: 1756835746393
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.30-openmp_h60d53f8_2.conda
+  sha256: 7b8551a4d21cf0b19f9a162f1f283a201b17f1bd5a6579abbd0d004788c511fa
+  md5: d004259fd8d3d2798b16299d6ad6c9e9
+  depends:
+  - __osx >=11.0
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - llvm-openmp >=19.1.7
+  constrains:
+  - openblas >=0.3.30,<0.3.31.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4284696
+  timestamp: 1755471861128
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.50-h280e0eb_1.conda
+  sha256: a2e0240fb0c79668047b528976872307ea80cb330baf8bf6624ac2c6443449df
+  md5: 4d0f5ce02033286551a32208a5519884
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 287056
+  timestamp: 1753879907258
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
+  sha256: fade8223e1e1004367d7101dd17261003b60aa576df6d7802191f8972f7470b1
+  md5: a7ce36e284c5faaf93c220dfc39e3abd
+  depends:
+  - __osx >=11.0
+  license: ISC
+  size: 164972
+  timestamp: 1716828607917
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.50.4-h4237e3c_0.conda
+  sha256: 802ebe62e6bc59fc26b26276b793e0542cfff2d03c086440aeaf72fb8bbcec44
+  md5: 1dcb0468f5146e38fae99aef9656034b
+  depends:
+  - __osx >=11.0
+  - icu >=75.1,<76.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: blessing
+  size: 902645
+  timestamp: 1753948599139
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
+  sha256: 8bfe837221390ffc6f111ecca24fa12d4a6325da0c8d131333d63d6c37f27e0a
+  md5: b68e8f66b94b44aaa8de4583d3d4cc40
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279193
+  timestamp: 1745608793272
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.1-h7dc4979_0.conda
+  sha256: 6bc1b601f0d3ee853acd23884a007ac0a0290f3609dabb05a47fc5a0295e2b53
+  md5: 2bb9e04e2da869125e2dc334d665f00d
+  depends:
+  - __osx >=11.0
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=19
+  - libdeflate >=1.24,<1.26.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: HPND
+  size: 373640
+  timestamp: 1758278641520
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.6.0-h07db88b_0.conda
+  sha256: a4de3f371bb7ada325e1f27a4ef7bcc81b2b6a330e46fac9c2f78ac0755ea3dd
+  md5: e5e7d467f80da752be17796b87fe6385
+  depends:
+  - __osx >=11.0
+  constrains:
+  - libwebp 1.6.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 294974
+  timestamp: 1752159906788
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+  sha256: bd3816218924b1e43b275863e21a3e13a5db4a6da74cca8e60bc3c213eb62f71
+  md5: af523aae2eca6dfa1c8eec693f5b9a79
+  depends:
+  - __osx >=11.0
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 323658
+  timestamp: 1727278733917
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.0-h0ff4647_1.conda
+  sha256: 37e85b5a2df4fbd213c5cdf803c57e244722c2dc47300951645c22a2bff6dfe8
+  md5: 6b4f950d2dc566afd7382d2380eb2136
+  depends:
+  - __osx >=11.0
+  - icu >=75.1,<76.0a0
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - libxml2 2.15.0
+  license: MIT
+  license_family: MIT
+  size: 464871
+  timestamp: 1758641298001
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.0-h9329255_1.conda
+  sha256: 5714b6c1fdd7a981a027d4951e111b1826cc746a02405a0c15b0f95f984e274c
+  md5: 738e842efb251f6efd430f47432bf0ee
+  depends:
+  - __osx >=11.0
+  - icu >=75.1,<76.0a0
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libxml2-16 2.15.0 h0ff4647_1
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 40624
+  timestamp: 1758641317371
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
+  md5: 369964e85dc26bfe78f41399b366c435
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 46438
+  timestamp: 1727963202283
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-21.1.0-hbb9b287_0.conda
+  sha256: c6750073a128376a14bedacfa90caab4c17025c9687fcf6f96e863b28d543af4
+  md5: e57d95fec6eaa747e583323cba6cfe5c
+  depends:
+  - __osx >=11.0
+  constrains:
+  - intel-openmp <0.0a0
+  - openmp 21.1.0|21.1.0.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 286039
+  timestamp: 1756673290280
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.45.0-py311h27de090_1.conda
+  sha256: c01ad196f2f63c09a48cf49f7b6d74cdb328a03ed665a43a40ce503ab3e3d69b
+  md5: f9c9f860dc252a9cb144d98a5a6b70c6
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 24349935
+  timestamp: 1758282670403
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py311h4921393_1.conda
+  sha256: 4f738a7c80e34e5e5d558e946b06d08e7c40e3cc4bdf08140bf782c359845501
+  md5: 249e2f6f5393bb6b36b3d3a3eebdcdf9
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24976
+  timestamp: 1733219849253
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.10.6-py311h66dac5a_0.conda
+  sha256: 198ddbc9aa2a86987b87ebbcee9db2a5a1716bdd31ffd96c118f403e003e0474
+  md5: 5f6150ef5ff86560f9b77c8d1aa20b96
+  depends:
+  - __osx >=11.0
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype
+  - kiwisolver >=1.3.1
+  - libcxx >=19
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - numpy >=1.23
+  - numpy >=1.23,<3
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8225464
+  timestamp: 1756835662332
+  purls:
+  - pkg:pypi/matplotlib?source=hash-mapping
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.1-py311h57a9ea7_1.conda
+  sha256: f4dc6a233cf14f3d1eb376e8611d2ec9d9cf47318cda27e6472efeeb9bfd7ed2
+  md5: ebe143e3d985c76b790a1bd79e24d3f1
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 90851
+  timestamp: 1756678775075
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
+  sha256: 2827ada40e8d9ca69a153a45f7fd14f32b2ead7045d3bbb5d10964898fe65733
+  md5: 068d497125e4bf8a66bf707254fff5ae
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  size: 797030
+  timestamp: 1738196177597
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.62.0-py311h922685c_0.conda
+  sha256: cadfdd6976b0107ef8dad147dfb458e8e10b5bde2f3d48328f01cd4aee0cb0d6
+  md5: 50a75aa5f3b03ab7d62b27fd9b3415c3
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - llvm-openmp >=19.1.7
+  - llvm-openmp >=21.1.0
+  - llvmlite >=0.45.0,<0.46.0a0
+  - numpy >=1.23,<3
+  - numpy >=1.24,<2.4
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libopenblas >=0.3.18,!=0.3.20
+  - cudatoolkit >=11.2
+  - tbb >=2021.6.0
+  - cuda-python >=11.6
+  - cuda-version >=11.2
+  - scipy >=1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5837488
+  timestamp: 1758872127484
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numcodecs-0.16.1-py311hff7e5bb_1.conda
+  sha256: 5b5a5dca97fc0cfb3166142dea735406611f5b4ac453feb0999918b81213bb40
+  md5: bd416067f5988dc7f9a6583e1e26e5cb
+  depends:
+  - __osx >=11.0
+  - deprecated
+  - libcxx >=19
+  - msgpack-python
+  - numpy >=1.23,<3
+  - numpy >=1.24
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - typing_extensions
+  license: MIT
+  license_family: MIT
+  size: 663579
+  timestamp: 1756543145516
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.3.3-py311h8685306_0.conda
+  sha256: f9e65b819f7252557113240e83a7f33426a2086cdcd0f80f4ef95794b5bafc0f
+  md5: 679c1e8963299dddcaf216588f765350
+  depends:
+  - python
+  - libcxx >=19
+  - __osx >=11.0
+  - python 3.11.* *_cpython
+  - liblapack >=3.9.0,<4.0a0
+  - python_abi 3.11.* *_cp311
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7275121
+  timestamp: 1757504970437
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.4-hbfb3c88_0.conda
+  sha256: dd73e8f1da7dd6a5494c5586b835cbe2ec68bace55610b1c4bf927400fe9c0d7
+  md5: 6bf3d24692c157a41c01ce0bd17daeea
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libpng >=1.6.50,<1.7.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 319967
+  timestamp: 1758489514651
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.5.3-h5503f6c_1.conda
+  sha256: d5499ee2611a0ca9d84e9d60a5978d1f17350e94915c89026f5d9346ccf0a987
+  md5: 4b23b1e2aa9d81b16204e1304241ccae
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 3069376
+  timestamp: 1758598263612
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.3.2-py311hff7e5bb_0.conda
+  sha256: eb63f2d792b8eb69d1d53750fdde083f0bcf5b928cb069a1e557016a01ce4d71
+  md5: b28dbf599ee12914447e0b60530950d2
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - numpy >=1.22.4
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1
+  constrains:
+  - pandas-gbq >=0.19.0
+  - zstandard >=0.19.0
+  - pyarrow >=10.0.1
+  - lxml >=4.9.2
+  - xarray >=2022.12.0
+  - xlsxwriter >=3.0.5
+  - pytables >=3.8.0
+  - pyreadstat >=1.2.0
+  - psycopg2 >=2.9.6
+  - odfpy >=1.4.1
+  - qtpy >=2.3.0
+  - openpyxl >=3.1.0
+  - html5lib >=1.1
+  - fastparquet >=2022.12.0
+  - python-calamine >=0.1.7
+  - sqlalchemy >=2.0.0
+  - beautifulsoup4 >=4.11.2
+  - scipy >=1.10.0
+  - pyqt5 >=5.15.9
+  - gcsfs >=2022.11.0
+  - blosc >=1.21.3
+  - bottleneck >=1.3.6
+  - s3fs >=2022.11.0
+  - pyxlsb >=1.0.10
+  - xlrd >=2.0.1
+  - fsspec >=2022.11.0
+  - tabulate >=0.9.0
+  - matplotlib >=3.6.3
+  - numexpr >=2.8.4
+  - tzdata >=2022.7
+  - numba >=0.56.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14406952
+  timestamp: 1755779878619
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.3.0-py311h1f9957d_3.conda
+  sha256: 64642d655d8608aeca5e7a1ee041397d022f43e3f8983ca1f57b1c2de95fce84
+  md5: 2f097ccfbbcd052bb7f876f4dbcf821d
+  depends:
+  - python
+  - __osx >=11.0
+  - python 3.11.* *_cpython
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - openjpeg >=2.5.3,<3.0a0
+  - python_abi 3.11.* *_cp311
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libzlib >=1.3.1,<2.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - lcms2 >=2.17,<3.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  license: HPND
+  size: 965672
+  timestamp: 1758208741247
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.1.0-py311h9408147_0.conda
+  sha256: dee5cb79500da7270e8760a1f3466d8bb16ae1a8fcc9ad890e3c927823fda0b2
+  md5: eaa96e45535b5915b7df480d7d959fbc
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 497878
+  timestamp: 1758169740089
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+  sha256: 8ed65e17fbb0ca944bfb8093b60086e3f9dd678c3448b5de212017394c247ee3
+  md5: 415816daf82e0b23a736a069a75e9da7
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 8381
+  timestamp: 1726802424786
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-11.1-py311hf0763de_1.conda
+  sha256: c5cbb88710d690ae2f571037708026abb8f15de1a4d764e4b825aaad6c4549c8
+  md5: 8c42827190081e9c29a1007454890067
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4.6,<3.5.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 477833
+  timestamp: 1756813465248
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-11.1-py311hc5b188e_1.conda
+  sha256: 62db0aa2d3a23ae2ca2c28f2c462e63c0911903169c72a139a9e659e3ed02b19
+  md5: ee9a511c6ffa04ac806bd2987b2b093d
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4.6,<3.5.0a0
+  - pyobjc-core 11.1.*
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 387176
+  timestamp: 1756824223349
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.13-hc22306f_0_cpython.conda
+  sha256: 2c966293ef9e97e66b55747c7a97bc95ba0311ac1cf0d04be4a51aafac60dcb1
+  md5: 95facc4683b7b3b9cf8ae0ed10f30dce
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.7.0,<3.0a0
+  - libffi >=3.4.6,<3.5.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libsqlite >=3.50.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.5.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 14573820
+  timestamp: 1749048947732
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h4921393_2.conda
+  sha256: 2af6006c9f692742181f4aa2e0656eb112981ccb0b420b899d3dd42c881bd72f
+  md5: 250b2ee8777221153fd2de9c279a7efa
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 196951
+  timestamp: 1737454935552
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py311h13abfa4_0.conda
+  sha256: 5a213744d267241e23f849c7671dc97eb98d7789fb559bf5d423ae1884294c7e
+  md5: 0d16883d4ab2d3fcb38460d018d6762f
+  depends:
+  - python
+  - __osx >=11.0
+  - libcxx >=19
+  - python 3.11.* *_cpython
+  - zeromq >=4.3.5,<4.4.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 359600
+  timestamp: 1757387159663
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+  sha256: 873ac689484262a51fd79bc6103c1a1bedbf524924d7f0088fb80703042805e4
+  md5: 6483b1f59526e05d7d894e466b5b6924
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: LicenseRef-Qhull
+  size: 516376
+  timestamp: 1720814307311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
+  sha256: 7db04684d3904f6151eff8673270922d31da1eea7fa73254d01c437f49702e34
+  md5: 63ef3f6e6d6d5c589e64f11263dc5676
+  depends:
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 252359
+  timestamp: 1740379663071
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.27.1-py311h1c3fc1a_1.conda
+  sha256: 95714a24265b6b4d4b218e303dcb075ba435826cb1d5927792ec94a8196c3e72
+  md5: 5236ffaff99e6421aa4431b4c00ca47a
+  depends:
+  - python
+  - python 3.11.* *_cpython
+  - __osx >=11.0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 362213
+  timestamp: 1756737586989
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.7.2-py311h0f965f6_0.conda
+  sha256: ef398e0e3e57680fe0422ba56245c54b3d7114c7a6e31ff0367bfbd7c553c05b
+  md5: 5d571c9769910a3377d13230be348f47
+  depends:
+  - __osx >=11.0
+  - joblib >=1.2.0
+  - libcxx >=19
+  - llvm-openmp >=19.1.7
+  - numpy >=1.22.0
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - scipy >=1.8.0
+  - threadpoolctl >=3.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9169335
+  timestamp: 1757407114262
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.16.2-py311h2734c94_0.conda
+  sha256: 972cd4e6379ad2ff96e36fd629c4dd0b2f32328f858848bfab8ad9a95c7f1d5e
+  md5: dfe66d7dfba5ee328467bc10c4df4718
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=19
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - libgfortran5 >=15.1.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.6
+  - numpy >=1.23,<3
+  - numpy >=1.25.2
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14047114
+  timestamp: 1757684291857
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.5-py311h9dc9093_0.conda
+  sha256: a12928c2ed682227bbae9962519fb3316a9162db3c73a3afbb97138fdc3a7173
+  md5: 0bb11b13609c9212051ea0c20a2acf2e
+  depends:
+  - __osx >=11.0
+  - numpy <3,>=1.22.3
+  - numpy >=1.23,<3
+  - packaging >=21.3
+  - pandas !=2.1.0,>=1.4
+  - patsy >=0.5.6
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - scipy !=1.9.2,>=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11795676
+  timestamp: 1751917879126
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2022.2.0-h5b2e6d4_1.conda
+  sha256: 561cc8c407880ff6f3965778f78c860d93d3b9c5bd206ba9aac7c437794d4155
+  md5: 1cdd70110585806da18f400d30d9b497
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libhwloc >=2.12.1,<2.12.2.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 119970
+  timestamp: 1755776161308
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
+  sha256: cb86c522576fa95c6db4c878849af0bccfd3264daf0cc40dd18e7f4a7bfced0e
+  md5: 7362396c170252e7b7b0c8fb37fe9c78
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: TCL
+  license_family: BSD
+  size: 3125538
+  timestamp: 1748388189063
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.2-py311h3696347_1.conda
+  sha256: 4941963a1f0046b2813bfbe4c2ded15cb0b0048436fe62237d69467e8c0e1692
+  md5: 25833dd6cb94341239aec42dd5370c33
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 870380
+  timestamp: 1756855179889
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/umap-learn-0.5.9.post2-py311h267d04e_0.conda
+  sha256: 7c2e38f5af59440ca29b670712edd3b829d45c6e590e6b20a42859c99c7b609e
+  md5: c160abdbcb62729bb3a2ddc732aa2bae
+  depends:
+  - numba >=0.51.2
+  - numpy >=1.17
+  - pynndescent >=0.5
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - scikit-learn >=0.22
+  - scipy >=1.3.1
+  - setuptools
+  - tbb >=2019.0
+  - tqdm
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 197175
+  timestamp: 1751544539720
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-16.0.0-py311h3696347_1.conda
+  sha256: 800e8ed94f2d771b006891b5af4c4b510c4cab49e8966ac08297b68d904f0e15
+  md5: 348a90d4b670542a7757e2415021bcf0
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 410696
+  timestamp: 1756494744297
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.3-py311h3696347_1.conda
+  sha256: db6de7e82c923f05807b4ec4413ab706ee3183f6ef89ad906277c60dea013e92
+  md5: a2f91e76263f4b55cca328110ef4d50b
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 62705
+  timestamp: 1756851806189
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-h5505292_0.conda
+  sha256: f33e6f013fc36ebc200f09ddead83468544cb5c353a3b50499b07b8c34e28a8d
+  md5: 50901e0764b7701d8ed7343496f4f301
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 13593
+  timestamp: 1734229104321
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+  sha256: 9939a166d780700d81023546759102b33fdc2c5f11ef09f5f66c77210fd334c8
+  md5: 77c447f48cab5d3a15ac224edb86a968
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 18487
+  timestamp: 1727795205022
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
+  sha256: b03433b13d89f5567e828ea9f1a7d5c5d697bf374c28a4168d71e9464f5dafac
+  md5: 78a0fe9e9c50d2c381e8ee47e3ea437d
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 83386
+  timestamp: 1753484079473
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h888dc83_9.conda
+  sha256: b6f9c130646e5971f6cad708e1eee278f5c7eea3ca97ec2fdd36e7abb764a7b8
+  md5: 26f39dfe38a2a65437c29d69906a0f68
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 244772
+  timestamp: 1757371008525
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py311h5bb9006_0.conda
+  sha256: fb1443a1479a6d709b4af7a2cdcea3ef2a5e859378de19814086fa86ca6f934e
+  md5: c7e0f1b714bd12d39899a4f0c296dd86
+  depends:
+  - python
+  - cffi >=1.11
+  - zstd >=1.5.7,<1.5.8.0a0
+  - __osx >=11.0
+  - python 3.11.* *_cpython
+  - zstd >=1.5.7,<1.6.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 390089
+  timestamp: 1757930124840
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_2.conda
+  sha256: 0d02046f57f7a1a3feae3e9d1aa2113788311f3cf37a3244c71e61a93177ba67
+  md5: e6f69c7bcccdefa417f056fa593b40f0
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 399979
+  timestamp: 1742433432699
+- conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
+  sha256: 1a62cd1f215fe0902e7004089693a78347a30ad687781dfda2289cab000e652d
+  md5: 37e16618af5c4851a3f3d66dd0e11141
+  depends:
+  - libgomp >=7.5.0
+  - libwinpthread >=12.0.0.r2.ggc561118da
+  constrains:
+  - openmp_impl 9999
+  - msys2-conda-epoch <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49468
+  timestamp: 1718213032772
+- conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-25.1.0-py311h3485c13_0.conda
+  sha256: 4bde4487abbca4c8834a582928a80692a32ebba67e906ce676e931035a13d004
+  md5: fdb37c9bd914e2a2c20f204f9cb15e6b
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 38615
+  timestamp: 1753995128176
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-hfd05255_4.conda
+  sha256: df2a43cc4a99bd184cb249e62106dfa9f55b3d06df9b5fc67072b0336852ff65
+  md5: 441706c019985cf109ced06458e6f742
+  depends:
+  - brotli-bin 1.1.0 hfd05255_4
+  - libbrotlidec 1.1.0 hfd05255_4
+  - libbrotlienc 1.1.0 hfd05255_4
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 20233
+  timestamp: 1756599828380
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-hfd05255_4.conda
+  sha256: e92c783502d95743b49b650c9276e9c56c7264da55429a5e45655150a6d1b0cf
+  md5: ef022c8941d7dcc420c8533b0e419733
+  depends:
+  - libbrotlidec 1.1.0 hfd05255_4
+  - libbrotlienc 1.1.0 hfd05255_4
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 21425
+  timestamp: 1756599802301
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311h3e6a449_4.conda
+  sha256: d524edc172239fec70ad946e3b2fa1b9d7eea145ad80e9e66da25a4d815770ea
+  md5: 21d3a7fa95d27938158009cd08e461f2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - libbrotlicommon 1.1.0 hfd05255_4
+  license: MIT
+  license_family: MIT
+  size: 323289
+  timestamp: 1756600106141
+- conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
+  sha256: d882712855624641f48aa9dc3f5feea2ed6b4e6004585d3616386a18186fe692
+  md5: 1077e9333c41ff0be8edd1a5ec0ddace
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 55977
+  timestamp: 1757437738856
+- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.0.0-py311h3485c13_0.conda
+  sha256: 12f5d72b95dbd417367895a92c35922b24bb016d1497f24f3a243224ec6cb81b
+  md5: 573fd072e80c1a334e19a1f95024d94d
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 298353
+  timestamp: 1758716437777
+- conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.3-py311h3fd045d_2.conda
+  sha256: 620d21eedddae5c2f8edb8c549c46a7204356ceff6b2d6c5560e4b5ce59a757d
+  md5: 327d9807b7aa0889a859070c550731d4
+  depends:
+  - numpy >=1.25
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 225470
+  timestamp: 1756544991146
+- conda: https://conda.anaconda.org/conda-forge/win-64/crc32c-2.7.1-py311hf893f09_2.conda
+  sha256: 71d113a32a8c208c4bd847dd3fe0000bb2ef5d05cbe321451cff724252cc37d7
+  md5: 4f1c566d5a21fcd3618de2f8416803a4
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.11.* *_cp311
+  license: LGPL-2.1-or-later
+  size: 53052
+  timestamp: 1756602254059
+- conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.17-py311h5dfdfe8_0.conda
+  sha256: 2f426feb8da1a1cc20e4982a36c3dd0fd5f0a4045c4ba2a8bf8b16cef0b028ca
+  md5: abd693d9f8de989841dba4d651acb6e4
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 3935426
+  timestamp: 1758162063397
+- conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.60.0-py311h3f79411_0.conda
+  sha256: d70fb060458061c7d3fa6791019ef3c07488e8dc8ba46aa6ce49d59a8b79a229
+  md5: 651a6bad4727f609687e18fe2635962d
+  depends:
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - unicodedata2 >=15.1.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 2538188
+  timestamp: 1758132809610
+- conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.14.1-h57928b3_0.conda
+  sha256: a9b3313edea0bf14ea6147ea43a1059d0bf78771a1336d2c8282891efc57709a
+  md5: d69c21967f35eb2ce7f1f85d6b6022d3
+  depends:
+  - libfreetype 2.14.1 h57928b3_0
+  - libfreetype6 2.14.1 hdbac1cb_0
+  license: GPL-2.0-only OR FTL
+  size: 184553
+  timestamp: 1757946164012
+- conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.14.0-nompi_py311hc40ba4b_101.conda
+  sha256: 34aae9b53e14cf62373a5bd1f475151430e4257cad6626a5d38469367b049da3
+  md5: 2ffcf6af42f0eadff1fa73417b848096
+  depends:
+  - cached-property
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1076133
+  timestamp: 1756767224174
+- conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.6-nompi_he30205f_103.conda
+  sha256: 0a90263b97e9860cec6c2540160ff1a1fff2a609b3d96452f8716ae63489dac5
+  md5: f1f7aaf642cefd2190582550eaca4658
+  depends:
+  - libaec >=1.1.4,<2.0a0
+  - libcurl >=8.14.1,<9.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2031491
+  timestamp: 1753357255237
+- conda: https://conda.anaconda.org/conda-forge/win-64/icu-75.1-he0c23c2_0.conda
+  sha256: 1d04369a1860a1e9e371b9fc82dd0092b616adcf057d6c88371856669280e920
+  md5: 8579b6bb8d18be7c0b27fb08adeeeb40
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 14544252
+  timestamp: 1720853966338
+- conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_2.conda
+  sha256: 64bcf78dbbda7ec523672c4b3f085527fd109732518e33907eac6b8049125113
+  md5: c8f80d7bee5c66371969936eba774c45
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43432
+  timestamp: 1756754355044
+- conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.9-py311h275cad7_1.conda
+  sha256: e5e759b61a71e16ba4637c9b08bb8e5c01ee678a47f3e980a7cacb8b0bee58b8
+  md5: 62b8b3f148d7f47db02304a7de177d13
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73589
+  timestamp: 1756467536839
+- conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+  sha256: 18e8b3430d7d232dad132f574268f56b3eb1a19431d6d5de8c53c29e6c18fa81
+  md5: 31aec030344e962fbd7dbbbbd68e60a9
+  depends:
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 712034
+  timestamp: 1719463874284
+- conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.17-hbcf6048_0.conda
+  sha256: 7712eab5f1a35ca3ea6db48ead49e0d6ac7f96f8560da8023e61b3dbe4f3b25d
+  md5: 3538827f77b82a837fa681a4579e37a1
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 510641
+  timestamp: 1739161381270
+- conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h6470a55_1.conda
+  sha256: 868a3dff758cc676fa1286d3f36c3e0101cca56730f7be531ab84dc91ec58e9d
+  md5: c1b81da6d29a14b542da14a36c9fbf3f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 164701
+  timestamp: 1745264384716
+- conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.4-h20038f6_0.conda
+  sha256: 0be89085effce9fdcbb6aea7acdb157b18793162f68266ee0a75acf615d4929b
+  md5: 85a2bed45827d77d5b308cb2b165404f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 33847
+  timestamp: 1749993666162
+- conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-35_h5709861_mkl.conda
+  sha256: 4180e7ab27ed03ddf01d7e599002fcba1b32dcb68214ee25da823bac371ed362
+  md5: 45d98af023f8b4a7640b1f713ce6b602
+  depends:
+  - mkl >=2024.2.2,<2025.0a0
+  constrains:
+  - blas 2.135   mkl
+  - liblapack  3.9.0   35*_mkl
+  - libcblas   3.9.0   35*_mkl
+  - liblapacke 3.9.0   35*_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 66044
+  timestamp: 1757003486248
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hfd05255_4.conda
+  sha256: 65d0aaf1176761291987f37c8481be132060cc3dbe44b1550797bc27d1a0c920
+  md5: 58aec7a295039d8614175eae3a4f8778
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 71243
+  timestamp: 1756599708777
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hfd05255_4.conda
+  sha256: aa03aff197ed503e38145d0d0f17c30382ac1c6d697535db24c98c272ef57194
+  md5: bf0ced5177fec8c18a7b51d568590b7c
+  depends:
+  - libbrotlicommon 1.1.0 hfd05255_4
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 33430
+  timestamp: 1756599740173
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hfd05255_4.conda
+  sha256: a593cde3e728a1e0486a19537846380e3ce90ae9d6c22c1412466a49474eeeed
+  md5: 37f4669f8ac2f04d826440a8f3f42300
+  depends:
+  - libbrotlicommon 1.1.0 hfd05255_4
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 245418
+  timestamp: 1756599770744
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-35_h2a3cdd5_mkl.conda
+  sha256: 88939f6c1b5da75bd26ce663aa437e1224b26ee0dab5e60cecc77600975f397e
+  md5: 9639091d266e92438582d0cc4cfc8350
+  depends:
+  - libblas 3.9.0 35_h5709861_mkl
+  constrains:
+  - blas 2.135   mkl
+  - liblapack  3.9.0   35*_mkl
+  - liblapacke 3.9.0   35*_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 66398
+  timestamp: 1757003514529
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.14.1-h88aaa65_0.conda
+  sha256: b2cface2cf35d8522289df7fffc14370596db6f6dc481cc1b6ca313faeac19d8
+  md5: 836b9c08f34d2017dbcaec907c6a1138
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: curl
+  license_family: MIT
+  size: 368346
+  timestamp: 1749033492826
+- conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.24-h76ddb4d_0.conda
+  sha256: 65347475c0009078887ede77efe60db679ea06f2b56f7853b9310787fe5ad035
+  md5: 08d988e266c6ae77e03d164b83786dc4
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 156292
+  timestamp: 1747040812624
+- conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.1-hac47afa_0.conda
+  sha256: 8432ca842bdf8073ccecf016ccc9140c41c7114dc4ec77ca754551c01f780845
+  md5: 3608ffde260281fa641e70d6e34b1b96
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - expat 2.7.1.*
+  license: MIT
+  license_family: MIT
+  size: 141322
+  timestamp: 1752719767870
+- conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.6-h537db12_1.conda
+  sha256: d3b0b8812eab553d3464bbd68204f007f1ebadf96ce30eb0cbc5159f72e353f5
+  md5: 85d8fa5e55ed8f93f874b3b23ed54ec6
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 44978
+  timestamp: 1743435053850
+- conda: https://conda.anaconda.org/conda-forge/win-64/libfreetype-2.14.1-h57928b3_0.conda
+  sha256: 2029702ec55e968ce18ec38cc8cf29f4c8c4989a0d51797164dab4f794349a64
+  md5: 3235024fe48d4087721797ebd6c9d28c
+  depends:
+  - libfreetype6 >=2.14.1
+  license: GPL-2.0-only OR FTL
+  size: 8109
+  timestamp: 1757946135015
+- conda: https://conda.anaconda.org/conda-forge/win-64/libfreetype6-2.14.1-hdbac1cb_0.conda
+  sha256: 223710600b1a5567163f7d66545817f2f144e4ef8f84e99e90f6b8a4e19cb7ad
+  md5: 6e7c5c5ab485057b5d07fd8188ba5c28
+  depends:
+  - libpng >=1.6.50,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - freetype >=2.14.1
+  license: GPL-2.0-only OR FTL
+  size: 340264
+  timestamp: 1757946133889
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-15.1.0-h1383e82_5.conda
+  sha256: 9b997baa85ba495c04e1b30f097b80420c02dcaca6441c4bf2c6bb4b2c5d2114
+  md5: c84381a01ede0e28d632fdbeea2debb2
+  depends:
+  - _openmp_mutex >=4.5
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - libgomp 15.1.0 h1383e82_5
+  - msys2-conda-epoch <0.0a0
+  - libgcc-ng ==15.1.0=*_5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 668284
+  timestamp: 1757042801517
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-15.1.0-h1383e82_5.conda
+  sha256: 65fd558d8f3296e364b8ae694932a64642fdd26d8eb4cf7adf08941e449be926
+  md5: eae9a32a85152da8e6928a703a514d35
+  depends:
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - msys2-conda-epoch <0.0a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 535560
+  timestamp: 1757042749206
+- conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.12.1-default_h64bd3f2_1002.conda
+  sha256: 266dfe151066c34695dbdc824ba1246b99f016115ef79339cbcf005ac50527c1
+  md5: b0cac6e5b06ca5eeb14b4f7cf908619f
+  depends:
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2414731
+  timestamp: 1757624335056
+- conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
+  sha256: 0dcdb1a5f01863ac4e8ba006a8b0dc1a02d2221ec3319b5915a1863254d7efa7
+  md5: 64571d1dd6cdcfa25d0664a5950fdaa2
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: LGPL-2.1-only
+  size: 696926
+  timestamp: 1754909290005
+- conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.1.0-h2466b09_0.conda
+  sha256: e61b0adef3028b51251124e43eb6edf724c67c0f6736f1628b02511480ac354e
+  md5: 7c51d27540389de84852daa1cdb9c63c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 838154
+  timestamp: 1745268437136
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-35_hf9ab0e9_mkl.conda
+  sha256: 56e0992fb58eed8f0d5fa165b8621fa150b84aa9af1467ea0a7a9bb7e2fced4f
+  md5: 0c6ed9d722cecda18f50f17fb3c30002
+  depends:
+  - libblas 3.9.0 35_h5709861_mkl
+  constrains:
+  - blas 2.135   mkl
+  - libcblas   3.9.0   35*_mkl
+  - liblapacke 3.9.0   35*_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78485
+  timestamp: 1757003541803
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
+  sha256: 55764956eb9179b98de7cc0e55696f2eff8f7b83fc3ebff5e696ca358bca28cc
+  md5: c15148b2e18da456f5108ccb5e411446
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD
+  size: 104935
+  timestamp: 1749230611612
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.50-h7351971_1.conda
+  sha256: e84b041f91c94841cb9b97952ab7f058d001d4a15ed4ce226ec5fdb267cc0fa5
+  md5: 3ae6e9f5c47c495ebeed95651518be61
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 382709
+  timestamp: 1753879944850
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+  sha256: 7bcb3edccea30f711b6be9601e083ecf4f435b9407d70fc48fbcf9e5d69a0fc6
+  md5: 198bb594f202b205c7d18b936fa4524f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: ISC
+  size: 202344
+  timestamp: 1716828757533
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.50.4-hf5d6505_0.conda
+  sha256: 5dc4f07b2d6270ac0c874caec53c6984caaaa84bc0d3eb593b0edf3dc8492efa
+  md5: ccb20d946040f86f0c05b644d5eadeca
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: blessing
+  size: 1288499
+  timestamp: 1753948889360
+- conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-h9aa295b_0.conda
+  sha256: cbdf93898f2e27cefca5f3fe46519335d1fab25c4ea2a11b11502ff63e602c09
+  md5: 9dce2f112bfd3400f4f432b3d0ac07b2
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 292785
+  timestamp: 1745608759342
+- conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.1-h550210a_0.conda
+  sha256: d6cac6596ded0d5bbbc4198d7eb4db88da8c00236ebf5e2c8ad333ccde8965e2
+  md5: e23f29747d9d2aa2a39b594c114fac67
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.24,<1.26.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - zstd >=1.5.7,<1.6.0a0
+  license: HPND
+  size: 992060
+  timestamp: 1758278535260
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.6.0-h4d5522a_0.conda
+  sha256: 7b6316abfea1007e100922760e9b8c820d6fc19df3f42fb5aca684cfacb31843
+  md5: f9bbae5e2537e3b06e0f7310ba76c893
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - libwebp 1.6.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279176
+  timestamp: 1752159543911
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_9.conda
+  sha256: 373f2973b8a358528b22be5e8d84322c165b4c5577d24d94fd67ad1bb0a0f261
+  md5: 08bfa5da6e242025304b206d152479ef
+  depends:
+  - ucrt
+  constrains:
+  - pthreads-win32 <0.0a0
+  - msys2-conda-epoch <0.0a0
+  license: MIT AND BSD-3-Clause-Clear
+  size: 35794
+  timestamp: 1737099561703
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
+  sha256: 08dec73df0e161c96765468847298a420933a36bc4f09b50e062df8793290737
+  md5: a69bbf778a462da324489976c84cfc8c
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - pthread-stubs
+  - ucrt >=10.0.20348.0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 1208687
+  timestamp: 1727279378819
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-16-2.15.0-h06f855e_1.conda
+  sha256: f29159eef5af2adffe2fef2d89ff2f6feda07e194883f47a4cf366e9608fb91b
+  md5: a5d1a1f8745fcd93f39a4b80f389962f
+  depends:
+  - icu >=75.1,<76.0a0
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - libxml2 2.15.0
+  license: MIT
+  license_family: MIT
+  size: 518883
+  timestamp: 1758641386772
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.15.0-ha29bfb0_1.conda
+  sha256: 8890c03908a407649ac99257b63176b61d10dfa3468aa3db1994ac0973dc2803
+  md5: 1d6e5fbbe84eebcd62e7cdccec799ce8
+  depends:
+  - icu >=75.1,<76.0a0
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libxml2-16 2.15.0 h06f855e_1
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 43274
+  timestamp: 1758641414853
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+  sha256: ba945c6493449bed0e6e29883c4943817f7c79cbff52b83360f7b341277c6402
+  md5: 41fbfac52c601159df6c01f875de31b9
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 55476
+  timestamp: 1727963768015
+- conda: https://conda.anaconda.org/conda-forge/win-64/llvm-openmp-20.1.8-hfa2b4ca_2.conda
+  sha256: 8970b7f9057a1c2c18bfd743c6f5ce73b86197d7724423de4fa3d03911d5874b
+  md5: 2dc2edf349464c8b83a576175fc2ad42
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - intel-openmp <0.0a0
+  - openmp 20.1.8|20.1.8.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 344490
+  timestamp: 1756145011384
+- conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.44.0-py311h7c248df_2.conda
+  sha256: 6de812d5c747ee7d9c35377dda480e609b60a48cca06230481f550d7c64c225a
+  md5: 5a88a225dba32c6ae5f7a3b85fca9522
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18118948
+  timestamp: 1756303951134
+- conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py311h5082efb_1.conda
+  sha256: 6f756e13ccf1a521d3960bd3cadddf564e013e210eaeced411c5259f070da08e
+  md5: c1f2ddad665323278952a453912dc3bd
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28238
+  timestamp: 1733220208800
+- conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.10.6-py311h1675fdf_1.conda
+  sha256: ddf4dffdf128835c6feeb2e3c10e757802a4605adadafc15bed876dd6b75620a
+  md5: 076c701b94086fced31eef41e80927b0
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype
+  - kiwisolver >=1.3.1
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - numpy >=1.23
+  - numpy >=1.23,<3
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: PSF-2.0
+  license_family: PSF
+  size: 8049626
+  timestamp: 1756870061088
+  purls:
+  - pkg:pypi/matplotlib?source=hash-mapping
+- conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h57928b3_16.conda
+  sha256: ce841e7c3898764154a9293c0f92283c1eb28cdacf7a164c94b632a6af675d91
+  md5: 5cddc979c74b90cf5e5cda4f97d5d8bb
+  depends:
+  - llvm-openmp >=20.1.8
+  - tbb 2021.*
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 103088799
+  timestamp: 1753975600547
+- conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.1-py311h3fd045d_1.conda
+  sha256: 4da49f644d92f3e01fa1f2015d38e2571a20fe787cb294393c91952c2afe2986
+  md5: 108852c865da789f638275669e3f4a8e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: Apache
+  size: 88184
+  timestamp: 1756678810275
+- conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.61.2-py311hffedbe7_2.conda
+  sha256: 2281624e88744a7adce724bbc690b4d41139a8ce4dd13fef6bafd9a7b780d1cb
+  md5: e17a0784c637d66dc9ff19f9f3dfaa57
+  depends:
+  - llvmlite >=0.44.0,<0.45.0a0
+  - numpy >=1.21,<3
+  - numpy >=1.24,<2.3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - tbb >=2021.6.0
+  - scipy >=1.0
+  - cuda-version >=11.2
+  - cuda-python >=11.6
+  - libopenblas !=0.3.6
+  - cudatoolkit >=11.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5960483
+  timestamp: 1758565463163
+- conda: https://conda.anaconda.org/conda-forge/win-64/numcodecs-0.16.1-py311h11fd7f3_1.conda
+  sha256: 4660c97fc32a7d85e51abde01a5fca420db3675acfc7fa68eb8fb879d2aea6de
+  md5: 5e2e82669917cd986be9ec7626e181a3
+  depends:
+  - deprecated
+  - msgpack-python
+  - numpy >=1.23,<3
+  - numpy >=1.24
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - typing_extensions
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 519763
+  timestamp: 1756542994834
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.2.6-py311h5e411d1_0.conda
+  sha256: f4ea606273089836e4b2b2355209142c1514d8bf103346ed435e85008df0804d
+  md5: 6612dfa4e68dd90c539f2e9f40a42514
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7800740
+  timestamp: 1747545419079
+- conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.4-h24db6dd_0.conda
+  sha256: 226c270a7e3644448954c47959c00a9bf7845f6d600c2a643db187118d028eee
+  md5: 5af852046226bb3cb15c7f61c2ac020a
+  depends:
+  - libpng >=1.6.50,<1.7.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 244860
+  timestamp: 1758489556249
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.5.3-h725018a_1.conda
+  sha256: 72dc204b0d59a7262bc77ca0e86cba11cbc6706cb9b4d6656fe7fab9593347c9
+  md5: c84884e2c1f899de9a895a1f0b7c9cd8
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: Apache
+  size: 9276051
+  timestamp: 1758599639304
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.3.2-py311h11fd7f3_0.conda
+  sha256: 7eaadbdb9c58274daac8f5659ce448a570ea10e9bfc55c97a72a95a6e9b4d5aa
+  md5: 1528d744a31b20442ca7c1f365a28cc2
+  depends:
+  - numpy >=1.22.4
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - beautifulsoup4 >=4.11.2
+  - tzdata >=2022.7
+  - xlsxwriter >=3.0.5
+  - pytables >=3.8.0
+  - html5lib >=1.1
+  - s3fs >=2022.11.0
+  - matplotlib >=3.6.3
+  - pyarrow >=10.0.1
+  - lxml >=4.9.2
+  - python-calamine >=0.1.7
+  - pyxlsb >=1.0.10
+  - pandas-gbq >=0.19.0
+  - fastparquet >=2022.12.0
+  - bottleneck >=1.3.6
+  - xarray >=2022.12.0
+  - fsspec >=2022.11.0
+  - odfpy >=1.4.1
+  - pyqt5 >=5.15.9
+  - openpyxl >=3.1.0
+  - tabulate >=0.9.0
+  - psycopg2 >=2.9.6
+  - blosc >=1.21.3
+  - pyreadstat >=1.2.0
+  - qtpy >=2.3.0
+  - scipy >=1.10.0
+  - gcsfs >=2022.11.0
+  - numexpr >=2.8.4
+  - sqlalchemy >=2.0.0
+  - zstandard >=0.19.0
+  - xlrd >=2.0.1
+  - numba >=0.56.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14410335
+  timestamp: 1755779632554
+- conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.3.0-py311h26a3c52_3.conda
+  sha256: 4db44561791d6591b7524cbad15d350b9e4cbd12077a679ae9c5179e14e911f2
+  md5: a39fdaf84c646c3840a87816bac6f00a
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.11.* *_cp311
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lcms2 >=2.17,<3.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - openjpeg >=2.5.3,<3.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 948865
+  timestamp: 1758208682964
+- conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.1.0-py311h3485c13_0.conda
+  sha256: c40708f50f3d1fcb330b09e08976361fc0ee6e86b4df3292b8808588138e947f
+  md5: baea4de149034e2317e3a539b808175a
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 505412
+  timestamp: 1758169463875
+- conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
+  sha256: 7e446bafb4d692792310ed022fe284e848c6a868c861655a92435af7368bae7b
+  md5: 3c8f2573569bb816483e5cf57efbbe29
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 9389
+  timestamp: 1726802555076
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.13-h3f84c4b_0_cpython.conda
+  sha256: 723dbca1384f30bd2070f77dd83eefd0e8d7e4dda96ac3332fbf8fe5573a8abb
+  md5: bedbb6f7bb654839719cd528f9b298ad
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.7.0,<3.0a0
+  - libffi >=3.4.6,<3.5.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libsqlite >=3.50.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 18242669
+  timestamp: 1749048351218
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-311-py311hefeebc8_1.conda
+  sha256: e3ef7e0cc53111ab81b8a9dd3eabc1374d7420d4c9fce3c8631e73310203ad55
+  md5: c1cfe9f5d8e278cc4d2d4c7b0126634d
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.11.* *_cp311
+  license: PSF-2.0
+  license_family: PSF
+  size: 6729388
+  timestamp: 1756487145061
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.15-py311hda3d55a_0.conda
+  sha256: fbf3e3f2d5596e755bd4b83b5007fa629b184349781f46e137a4e80b6754c7c0
+  md5: 8a142e0fcd43513c2e876d97ba98c0fa
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 217009
+  timestamp: 1738661736085
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311h5082efb_2.conda
+  sha256: 6095e1d58c666f6a06c55338df09485eac34c76e43d92121d5786794e195aa4d
+  md5: e474ba674d780f0fa3b979ae9e81ba91
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 187430
+  timestamp: 1737454904007
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-27.1.0-py311hb77b9c8_0.conda
+  sha256: 1f146a62329093139fbe7fc109b595f19ca2b44beb921d0e1c6e61d2cb5ebef1
+  md5: 96460f14570e237d27b475ef8238fdf3
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - zeromq >=4.3.5,<4.3.6.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 363690
+  timestamp: 1757387035331
+- conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+  sha256: 887d53486a37bd870da62b8fa2ebe3993f912ad04bd755e7ed7c47ced97cbaa8
+  md5: 854fbdff64b572b5c0b470f334d34c11
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LicenseRef-Qhull
+  size: 1377020
+  timestamp: 1720814433486
+- conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.27.1-py311hf51aa87_1.conda
+  sha256: e61607627213b70e7be73570e7ef5e2d36b583512def108aaf78a6ab16f0cdd9
+  md5: 3c5b42969dae70e100154750d29d43cc
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 247101
+  timestamp: 1756737437304
+- conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.7.2-py311h8a15ebc_0.conda
+  sha256: 6b7db7a33e44b2ef36b77054f3f939a6bb7722e5a1e9a1b55bfe022eda0045a8
+  md5: f4ca4045c4da60540399bd67b4e1490f
+  depends:
+  - joblib >=1.2.0
+  - numpy >=1.22.0
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scipy >=1.8.0
+  - threadpoolctl >=3.1.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9040416
+  timestamp: 1757433538935
+- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.16.2-py311h9a1c30b_0.conda
+  sha256: 0bd54e04b152f4af55922b7ee792b42a1010c702d5b4d1ca47b062e67420e797
+  md5: a5b6b853ae5a10a0d6225659d5e6019c
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.6
+  - numpy >=1.23,<3
+  - numpy >=1.25.2
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15306714
+  timestamp: 1757683219896
+- conda: https://conda.anaconda.org/conda-forge/win-64/statsmodels-0.14.5-py311h17033d2_0.conda
+  sha256: e09d101d0044348e7a35f3a78f22bab0701a31059f02a63897cf87546e84e4f1
+  md5: 9cf4eebc1ad82ee44efc89bdde60a431
+  depends:
+  - numpy <3,>=1.22.3
+  - numpy >=1.23,<3
+  - packaging >=21.3
+  - pandas !=2.1.0,>=1.4
+  - patsy >=0.5.6
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scipy !=1.9.2,>=1.8
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11744906
+  timestamp: 1751917965278
+- conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-h18a62a1_3.conda
+  sha256: 30e82640a1ad9d9b5bee006da7e847566086f8fdb63d15b918794a7ef2df862c
+  md5: 72226638648e494aaafde8155d50dab2
+  depends:
+  - libhwloc >=2.12.1,<2.12.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: APACHE
+  size: 150266
+  timestamp: 1755776172092
+- conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
+  sha256: e3614b0eb4abcc70d98eae159db59d9b4059ed743ef402081151a948dce95896
+  md5: ebd0e761de9aa879a51d22cc721bd095
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: TCL
+  license_family: BSD
+  size: 3466348
+  timestamp: 1748388121356
+- conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.5.2-py311h3485c13_1.conda
+  sha256: 87527996d1297442bbc432369a5791af740762c1dda642d52cd55d32d5577937
+  md5: ec9179a7226659bd15d8085c8de15360
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: Apache
+  size: 871179
+  timestamp: 1756855104869
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+  sha256: 3005729dce6f3d3f5ec91dfc49fc75a0095f9cd23bab49efb899657297ac91a5
+  md5: 71b24316859acd00bdb8b38f5e2ce328
+  constrains:
+  - vc14_runtime >=14.29.30037
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-MicrosoftWindowsSDK10
+  size: 694692
+  timestamp: 1756385147981
+- conda: https://conda.anaconda.org/conda-forge/win-64/umap-learn-0.5.9.post2-py311h1ea47a8_0.conda
+  sha256: 32569facf3347208d6c29a5a510cbabd56c3180508445aa314b914a22c9eebe0
+  md5: 406406afb742e30518371835718efaba
+  depends:
+  - numba >=0.51.2
+  - numpy >=1.17
+  - pynndescent >=0.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scikit-learn >=0.22
+  - scipy >=1.3.1
+  - setuptools
+  - tbb >=2019.0
+  - tqdm
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 197502
+  timestamp: 1751544433219
+- conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-16.0.0-py311h3485c13_1.conda
+  sha256: d692506a8f0f9452c72d5b4b6d7d39bca7c383ab85749d82a77ad652ccbef940
+  md5: 969071f934c7c811f014688e5ec4178f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: Apache
+  size: 401855
+  timestamp: 1756494775091
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_31.conda
+  sha256: cb357591d069a1e6cb74199a8a43a7e3611f72a6caed9faa49dbb3d7a0a98e0b
+  md5: 28f4ca1e0337d0f27afb8602663c5723
+  depends:
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18249
+  timestamp: 1753739241465
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_31.conda
+  sha256: af4b4b354b87a9a8d05b8064ff1ea0b47083274f7c30b4eb96bc2312c9b5f08f
+  md5: 603e41da40a765fd47995faa021da946
+  depends:
+  - ucrt >=10.0.20348.0
+  - vcomp14 14.44.35208 h818238b_31
+  constrains:
+  - vs2015_runtime 14.44.35208.* *_31
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  size: 682424
+  timestamp: 1753739239305
+- conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_31.conda
+  sha256: 67b317b64f47635415776718d25170a9a6f9a1218c0f5a6202bfd687e07b6ea4
+  md5: a6b1d5c1fc3cb89f88f7179ee6a9afe3
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.44.35208.* *_31
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  size: 113963
+  timestamp: 1753739198723
+- conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: 9df10c5b607dd30e05ba08cbd940009305c75db242476f4e845ea06008b0a283
+  md5: 1cee351bf20b830d991dbe0bc8cd7dfe
+  license: MIT
+  license_family: MIT
+  size: 1176306
+- conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.17.3-py311h3485c13_1.conda
+  sha256: 96f1ea03084a6deeb0630372319a03d7774f982d24e9ad7394941efd5779591c
+  md5: fbf91bcdeeb11de218edce103104e353
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 64180
+  timestamp: 1756852365689
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.12-h0e40799_0.conda
+  sha256: 047836241b2712aab1e29474a6f728647bff3ab57de2806b0bb0a6cf9a2d2634
+  md5: 2ffbfae4548098297c033228256eb96e
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 108013
+  timestamp: 1734229474049
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.5-h0e40799_0.conda
+  sha256: 9075f98dcaa8e9957e4a3d9d30db05c7578a536950a31c200854c5c34e1edb2c
+  md5: 8393c0f7e7870b4eb45553326f81f0ff
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 69920
+  timestamp: 1727795651979
+- conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
+  sha256: 80ee68c1e7683a35295232ea79bcc87279d31ffeda04a1665efdb43cbd50a309
+  md5: 433699cba6602098ae8957a323da2664
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 63944
+  timestamp: 1753484092156
+- conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-h5bddc39_9.conda
+  sha256: 690cf749692c8ea556646d1a47b5824ad41b2f6dfd949e4cdb6c44a352fcb1aa
+  md5: a6c8f8ee856f7c3c1576e14b86cd8038
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 265212
+  timestamp: 1757370864284
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.25.0-py311hf893f09_0.conda
+  sha256: 3b66d3cb738a9993e8432d1a03402d207128166c4ef0c928e712958e51aff325
+  md5: d26077d20b4bba54f4c718ed1313805f
+  depends:
+  - python
+  - cffi >=1.11
+  - zstd >=1.5.7,<1.5.8.0a0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - zstd >=1.5.7,<1.6.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 375866
+  timestamp: 1757930134099
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-hbeecb71_2.conda
+  sha256: bc64864377d809b904e877a98d0584f43836c9f2ef27d3d2a1421fa6eae7ca04
+  md5: 21f56217d6125fb30c3c3f10c786d751
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 354697
+  timestamp: 1742433568506
+- pypi: https://files.pythonhosted.org/packages/02/3f/a6ec28c88e2d8e54d32598a1e0b5208a4baa72a8e7f6e241beab5731eb9d/interface_meta-1.3.0-py3-none-any.whl
+  name: interface-meta
+  version: 1.3.0
+  sha256: de35dc5241431886e709e20a14d6597ed07c9f1e8b4bfcffde2190ca5b700ee8
+  requires_python: '>=3.7,<4.0'
+- pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
+  name: toolz
+  version: 1.0.0
+  sha256: 292c8f1c4e7516bf9086f8850935c799a874039c8bcf959d47b600e4c44a6236
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/1a/9d/c2c8b51b32f829a16fe042db30ad1dcef7947bf1dcf77c2cfd7b6f37b83a/formulaic-1.2.1-py3-none-any.whl
+  name: formulaic
+  version: 1.2.1
+  sha256: 661d6d2467aa961b9afb3a1e2a187494239793c63eb729e422d1307afa98b43b
+  requires_dist:
+  - interface-meta>=1.2.0
+  - narwhals>=1.17
+  - numpy>=1.20.0
+  - pandas>=1.3
+  - scipy>=1.6
+  - typing-extensions>=4.2.0
+  - wrapt>=1.0; python_version < "3.13"
+  - wrapt>=1.17.0rc1; python_version >= "3.13"
+  - pyarrow>=1; extra == "arrow"
+  - sympy!=1.10,>=1.3; extra == "calculus"
+  - polars>=1; extra == "polars"
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/28/0e/b11ad5fd77e3dd0baad9cac3184315be7654ae401e3b0b0c324503f23d96/datashader-0.18.2-py3-none-any.whl
+  name: datashader
+  version: 0.18.2
+  sha256: 2aa90e867a46b1e75248f32a47c5b14bb5dc869524152f88c0af8369d47359e7
+  requires_dist:
+  - colorcet
+  - multipledispatch
+  - numba
+  - numpy
+  - packaging
+  - pandas
+  - param
+  - pyct
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  - pytest; extra == "tests"
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/40/7b/639411281256c84e8111bf6cb9676c44dbf5d8ad4cb042f4359b7e7b9e74/formulaic_contrasts-1.0.0-py3-none-any.whl
+  name: formulaic-contrasts
+  version: 1.0.0
+  sha256: e1220d315cf446bdec9385375ca4da43896e4ba68114ebea1b2a37efa5d097f5
+  requires_dist:
+  - formulaic
+  - pandas
+  - session-info
+  - pre-commit; extra == "dev"
+  - twine>=4.0.2; extra == "dev"
+  - docutils!=0.18.*,!=0.19.*,>=0.8; extra == "doc"
+  - ipykernel; extra == "doc"
+  - ipython; extra == "doc"
+  - myst-nb>=1.1; extra == "doc"
+  - pandas; extra == "doc"
+  - setuptools; extra == "doc"
+  - sphinx-autodoc-typehints; extra == "doc"
+  - sphinx-book-theme>=1; extra == "doc"
+  - sphinx-copybutton; extra == "doc"
+  - sphinx-tabs; extra == "doc"
+  - sphinx>=4; extra == "doc"
+  - sphinxcontrib-bibtex>=1; extra == "doc"
+  - sphinxext-opengraph; extra == "doc"
+  - statsmodels; extra == "doc"
+  - coverage; extra == "test"
+  - numpy; extra == "test"
+  - pytest; extra == "test"
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/43/8c/f637418a679fb49bc3368940e0705df3b43c85b2ff5ae91455e78401750b/pydeseq2-0.5.2-py3-none-any.whl
+  name: pydeseq2
+  version: 0.5.2
+  sha256: 60014562d85f8c1c56cc7d169a4f0e29e9d615a863b93401add5fc30a61513d9
+  requires_dist:
+  - anndata>=0.11.0
+  - formulaic>=1.0.2
+  - numpy>=1.23.0
+  - pandas>=1.4.0
+  - scikit-learn>=1.1.0
+  - scipy>=1.11.0
+  - formulaic-contrasts>=0.2.0
+  - matplotlib>=3.6.2
+  - pytest>=6.2.4; extra == "dev"
+  - pre-commit>=2.13.0; extra == "dev"
+  - numpydoc; extra == "dev"
+  - coverage; extra == "dev"
+  - mypy; extra == "dev"
+  - pandas-stubs; extra == "dev"
+  requires_python: '>=3.10.0'
+- pypi: https://files.pythonhosted.org/packages/4c/60/ef55d3aa66914e0d1fe751df85b222fe9e78c8782c8f930ad3240d52d92f/fastcluster-1.3.0-cp311-cp311-win_amd64.whl
+  name: fastcluster
+  version: 1.3.0
+  sha256: 5ae60778ac7ed46108c1175478ff09af0a19a2dbb02090a1c13bf9c5bffbf230
+  requires_dist: &id001
+  - numpy>=2
+  requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/51/c0/00c9809d8b9346eb238a6bbd5f83e846a4ce4503da94a4c08cb7284c325b/multipledispatch-1.0.0-py3-none-any.whl
+  name: multipledispatch
+  version: 1.0.0
+  sha256: 0c53cd8b077546da4e48869f49b13164bebafd0c2a5afceb6bb6a316e7fb46e4
+- pypi: https://files.pythonhosted.org/packages/58/a7/acc7690029de56ecc324f153f27286c82c08ebd3eefabc267877f6a9729e/panel_material_ui-0.5.1a0-py3-none-any.whl
+  name: panel-material-ui
+  version: 0.5.1a0
+  sha256: 7385b9b81b8448f2a9bd58ea4113b66768ff6d52700429b78b7e7fadc43704a1
+  requires_dist:
+  - bokeh>=3.8.0
+  - packaging
+  - panel>=1.8.0
+  - plotly; extra == "dev"
+  - pytest; extra == "dev"
+  - pytest-asyncio; extra == "dev"
+  - pytest-rerunfailures<16; extra == "dev"
+  - pytest-xdist; extra == "dev"
+  - watchfiles; extra == "dev"
+  - mypy; extra == "mypy"
+  - types-requests; extra == "mypy"
+  - typing-extensions; extra == "mypy"
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/7b/fa/427569f391a9951fe483222d3df6bb18a690d963810473fb0e305150cf86/fastcluster-1.3.0-cp311-cp311-macosx_10_9_universal2.whl
+  name: fastcluster
+  version: 1.3.0
+  sha256: 5ee25c5c36d2b68036aa0d9ff37ba316434824087e6b9884005f1eb09ceaf9ad
+  requires_dist: *id001
+  requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/7f/8f/99214dc3d59d6aef171821dc8cc3dea34db8fafb962c98c34b1527a76e51/holoviews-1.22.0a0-py3-none-any.whl
+  name: holoviews
+  version: 1.22.0a0
+  sha256: 31b0ef52e4f712eafbd96bad16edeed726d79b677c861100f76a0f380f01642e
+  requires_dist:
+  - bokeh>=3.1
+  - colorcet
+  - numpy>=1.21
+  - packaging
+  - pandas>=1.3
+  - panel>=1.0
+  - param<3.0,>=2.0
+  - pyviz-comms>=2.1
+  - matplotlib>=3; extra == "recommended"
+  - plotly>=4.0; extra == "recommended"
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/88/c7/4102536de33c19d090ed2b04e90e7452e2e3dc653cf3323208034eaaca27/stdlib_list-0.11.1-py3-none-any.whl
+  name: stdlib-list
+  version: 0.11.1
+  sha256: 9029ea5e3dfde8cd4294cfd4d1797be56a67fc4693c606181730148c3fd1da29
+  requires_dist:
+  - build; extra == "dev"
+  - stdlib-list[doc,lint,test]; extra == "dev"
+  - sphinx; extra == "doc"
+  - furo; extra == "doc"
+  - mypy; extra == "lint"
+  - ruff; extra == "lint"
+  - sphobjinv; extra == "support"
+  - pytest; extra == "test"
+  - pytest-cov; extra == "test"
+  - coverage[toml]; extra == "test"
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/8c/b2/23f4032cd1c9744aa8e9ecda43cd4d755fcb209f7f40fae035248f31a679/pyct-0.6.0-py3-none-any.whl
+  name: pyct
+  version: 0.6.0
+  sha256: cfaded7289fca72ddf6579b81459e3ec8db323a508e61c49aa318ee3cd6ff160
+  requires_dist:
+  - param>=1.7.0
+  - pyyaml; extra == "cmd"
+  - requests; extra == "cmd"
+  - pytest; extra == "tests"
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/8d/f0/73c24457c941b8b08f7d090853e40f4b2cdde88b5da721f3f28e98df77c9/xarray-2025.9.0-py3-none-any.whl
+  name: xarray
+  version: 2025.9.0
+  sha256: 79f0e25fb39571f612526ee998ee5404d8725a1db3951aabffdb287388885df0
+  requires_dist:
+  - numpy>=1.26
+  - packaging>=24.1
+  - pandas>=2.2
+  - scipy>=1.13; extra == "accel"
+  - bottleneck; extra == "accel"
+  - numbagg>=0.8; extra == "accel"
+  - numba>=0.59; extra == "accel"
+  - flox>=0.9; extra == "accel"
+  - opt_einsum; extra == "accel"
+  - numpy<2.3; extra == "accel"
+  - xarray[accel,etc,io,parallel,viz]; extra == "complete"
+  - netCDF4>=1.6.0; extra == "io"
+  - h5netcdf; extra == "io"
+  - pydap; extra == "io"
+  - scipy>=1.13; extra == "io"
+  - zarr>=2.18; extra == "io"
+  - fsspec; extra == "io"
+  - cftime; extra == "io"
+  - pooch; extra == "io"
+  - sparse>=0.15; extra == "etc"
+  - dask[complete]; extra == "parallel"
+  - cartopy>=0.23; extra == "viz"
+  - matplotlib; extra == "viz"
+  - nc-time-axis; extra == "viz"
+  - seaborn; extra == "viz"
+  - pandas-stubs; extra == "types"
+  - scipy-stubs; extra == "types"
+  - types-PyYAML; extra == "types"
+  - types-Pygments; extra == "types"
+  - types-colorama; extra == "types"
+  - types-decorator; extra == "types"
+  - types-defusedxml; extra == "types"
+  - types-docutils; extra == "types"
+  - types-networkx; extra == "types"
+  - types-pexpect; extra == "types"
+  - types-psutil; extra == "types"
+  - types-pycurl; extra == "types"
+  - types-openpyxl; extra == "types"
+  - types-python-dateutil; extra == "types"
+  - types-pytz; extra == "types"
+  - types-setuptools; extra == "types"
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/bd/b8/8d37825625c6558d8e2ad48be9429634ef84c69d6ea80e33a0f965c98cf7/hv_anndata-0.0.3a3-py3-none-any.whl
+  name: hv-anndata
+  version: 0.0.3a3
+  sha256: 164d0a6b39dac7eb8685e3dc0af73874dd23617c3e8762005b64673339b18f53
+  requires_dist:
+  - anndata
+  - bokeh
+  - datashader
+  - holoviews>=1.21.0rc0
+  - numpy
+  - pandas
+  - panel
+  - panel-material-ui>=0.4.0rc1
+  - param
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/c5/c4/f6b7c0ec5241a2bde90c7ba1eca6ba44f8488bcedafe9072c79593015ec0/session_info-1.0.1-py3-none-any.whl
+  name: session-info
+  version: 1.0.1
+  sha256: 451d191e51816070b9f21a6ff3f6eb5d6015ae2738e8db63ac4e6398260a5838
+  requires_dist:
+  - stdlib_list
+  requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/d5/9b/700f7d7d4f39e909f8c098a283797d61afc694934c87eb041dd87ba8f63f/fastcluster-1.3.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: fastcluster
+  version: 1.3.0
+  sha256: 7467e6da746dba310235546d0b6eef90a1652994dfd2c3022f7052effd142dee
+  requires_dist: *id001
+  requires_python: '>=3'

--- a/anndata_diffex/pixi.lock
+++ b/anndata_diffex/pixi.lock
@@ -8,7 +8,6 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
-    - url: https://conda.anaconda.org/nodefaults/
     indexes:
     - https://pypi.org/simple
     packages:

--- a/anndata_diffex/pixi.toml
+++ b/anndata_diffex/pixi.toml
@@ -1,0 +1,49 @@
+[workspace]
+name = "anndata_diffex"
+channels = ["conda-forge", "nodefaults"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2025-09-19"
+maintainers = ["droumis", "cvaske"]
+categories = ["Other Sciences"]
+labels = ["panel", "holoviews", "hvplot", "bokeh", "pydeseq2", "anndata", "scanpy"]
+title = "Differential Expression in Bulk RNA-seq with AnnData"
+description = "Conduct differential gene expression analysis on bulk RNA-seq (TCGA) data using AnnData and DESeq2"
+
+[dependencies]
+notebook = ">=6.5.2,<7"
+python = "3.11.*"
+numpy = ">=2.2.6"
+bokeh = ">=3.8.0"
+anndata = ">=0.12.2"
+scanpy = ">=1.11.4"
+hvplot = ">=0.12.1"
+pooch = ">=1.8.2"
+jupyterlab = ">=4.2.5"
+pip = "*"
+wheel = "*"
+
+[pypi-dependencies]
+fastcluster = ">=1.3.0"
+pydeseq2 = ">=0.5.2"
+hv-anndata = ">=v0.0.3a3"
+holoviews = ">=v1.22.0a0"
+stdlib-list = "*"
+
+[tasks.lab]
+cmd = "jupyter lab anndata_diffex.ipynb"
+depends-on = ["download"]
+
+[tasks.notebook]
+cmd = "jupyter notebook anndata_diffex.ipynb"
+depends-on = ["download"]
+
+[tasks.dashboard]
+cmd = "panel serve --rest-session-info --session-history -1 anndata_diffex.ipynb --show"
+depends-on = ["download"]
+
+[tasks.download]
+env = { FILENAME = "data/brca_test.h5ad" }
+cmd = "mkdir -p data && curl -fsSL -o $FILENAME https://storage.googleapis.com/tcga-anndata-public/test2025-04/brca_test.h5ad"
+outputs = ["data/brca_test.h5ad"]

--- a/anndata_diffex/pixi.toml
+++ b/anndata_diffex/pixi.toml
@@ -21,15 +21,15 @@ scanpy = ">=1.11.4"
 hvplot = ">=0.12.1"
 pooch = ">=1.8.2"
 jupyterlab = ">=4.2.5"
-pip = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [pypi-dependencies]
 fastcluster = ">=1.3.0"
 pydeseq2 = ">=0.5.2"
 hv-anndata = ">=v0.0.3a3"
 holoviews = ">=v1.22.0a0"
-stdlib-list = "*"
+stdlib-list = "*"  # promoted from anaconda-project lock
 
 [tasks.lab]
 cmd = "jupyter lab anndata_diffex.ipynb"

--- a/anndata_diffex/pixi.toml
+++ b/anndata_diffex/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "anndata_diffex"
-channels = ["conda-forge", "nodefaults"]
+channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/attractors/pixi.lock
+++ b/attractors/pixi.lock
@@ -7,718 +7,718 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.5.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.16.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.3.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.59.1-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.8-h955ad1f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dask-core-2024.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/datashader-0.16.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fsspec-2024.3.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numba-0.59.1-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.11.8-h955ad1f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2024.5.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.16.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.3.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.59.1-py311hdb55bb0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.8-hf27a42d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/dask-core-2024.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/datashader-0.16.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fsspec-2024.3.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numba-0.59.1-py311hdb55bb0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.11.8-hf27a42d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.5.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.16.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.3.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.59.1-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.8-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2024.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/datashader-0.16.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2024.3.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numba-0.59.1-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.11.8-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.5.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.16.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.3.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.59.1-py311hf62ec03_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.8-he1021f5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/dask-core-2024.5.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/datashader-0.16.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fsspec-2024.3.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numba-0.59.1-py311hf62ec03_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.11.8-he1021f5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
   sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
   md5: 613805add1c05b538ff06d217252feb7
   depends:
@@ -729,7 +729,7 @@ packages:
   license: BSD-3-Clause
   size: 20810
   timestamp: 1652859733309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
   sha256: 250f50edf43a786a32942e9ae67ce807e9b3ac4cb6b58b1170cb541fb24e391f
   md5: b48058294499d292ddf9a3b966dc9cc5
   depends:
@@ -743,7 +743,7 @@ packages:
   license_family: MIT
   size: 228473
   timestamp: 1706220559474
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
   sha256: 0d4f5274503916e1c683dcc16e8a7c4186557afa3f62399cd628e4eb535fe77a
   md5: 062acdb0f9ae976c25c2d15d589dc1d6
   depends:
@@ -754,7 +754,7 @@ packages:
   license_family: MIT
   size: 35809
   timestamp: 1676823571351
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
   sha256: 567dfdd5b986012421a736a5f1c1d5874d8d691dd483c838b55e1ab06c0b217d
   md5: 4e0aa1543f546b898523382ee8405e84
   depends:
@@ -763,7 +763,7 @@ packages:
   license_family: MIT
   size: 152577
   timestamp: 1695717917074
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
   sha256: 894fceb5b4f8740bcd146de8bd0f6eabf14e2407b149b790b4983b8432681e6b
   md5: 2f0ef211bf628cd22bbfa44c3f9bc035
   depends:
@@ -773,12 +773,12 @@ packages:
   license_family: MIT
   size: 271600
   timestamp: 1681493103694
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
   sha256: 9f027f156744dcbf28945aad6e422ef030c84c2a5d40116d3e40407c66853bf8
   md5: 7b52489e04f9a5585643d5578835fc68
   depends:
@@ -796,7 +796,7 @@ packages:
   license_family: BSD
   size: 6059952
   timestamp: 1712084450899
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
   sha256: 8e2b2073ff5c61d35714e8a36ce657a8ac741b7bedc2852a238c7f1625142705
   md5: d951ab54a682b6328327fec53b1e5e72
   depends:
@@ -807,7 +807,7 @@ packages:
   license_family: BSD
   size: 147642
   timestamp: 1707864274452
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
   sha256: 5d15605858771290fdaaae41a43941623757a25cb1292080d69d6d3857807935
   md5: 7f517469aa5380c52e55db9f37df104f
   depends:
@@ -818,7 +818,7 @@ packages:
   license: MIT
   size: 18652
   timestamp: 1714483267080
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
   sha256: a5094f078584e27c7cced4a9564ae904a329f5c1702a7c1ba092d581ba1544f1
   md5: 6ddf45dd8a21a9512481de9bc0e5a03f
   depends:
@@ -828,7 +828,7 @@ packages:
   license: MIT
   size: 19711
   timestamp: 1714483255915
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
   sha256: 93180c973816246f068b742d0bf64840f0ea48e31d4f9b0747ea2ffc34d8855d
   md5: f3a00096965a5ba1eb41d2c99a4662a2
   depends:
@@ -838,7 +838,7 @@ packages:
   license: MIT
   size: 361574
   timestamp: 1714483400014
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
   sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
   md5: f5058c8d5b2994b7334f18e022105a14
   depends:
@@ -847,14 +847,14 @@ packages:
   license_family: BSD
   size: 427542
   timestamp: 1714510571510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
   sha256: 394f74202c2efc8fcfd02b8953f508eb6a2961d224a2f9d15091caf5cbe1be67
   md5: 1202b4ed32215c6405bb42fbff355316
   license: MPL-2.0
   license_family: Other
   size: 137411
   timestamp: 1710764808838
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
   sha256: 6dc29d20180f6e002f37b251efa639716d3444e129a754dabf751f816aada7ef
   md5: 5dbfa083e6ab6318fac58fe0e0c94445
   depends:
@@ -863,7 +863,7 @@ packages:
   license_family: Other
   size: 165152
   timestamp: 1707229213375
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
   sha256: d138cc3fde270eba783baf1e2ba17c89800b2cbbf20976d0eb425b3436a4a184
   md5: 1875e89c1a939e4e7c5e7b731c72b838
   depends:
@@ -875,7 +875,7 @@ packages:
   license_family: MIT
   size: 302401
   timestamp: 1714483186060
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
   sha256: 9ddbf05887c7d7926418520cc7848e57f6d2431bc4ec6d30e090b02dbf865041
   md5: 57ae1141ad9a048fb2a75d7a3ef7430a
   depends:
@@ -884,7 +884,7 @@ packages:
   license_family: BSD
   size: 203190
   timestamp: 1698129926216
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
   sha256: a5beda842876d0d71598cd2a50ced5fb2731539bc4172fe501b93b60e0c6cd3f
   md5: d5293e5fe74a4e0d71bbf14c9a57f900
   depends:
@@ -893,7 +893,7 @@ packages:
   license_family: BSD
   size: 49509
   timestamp: 1683040113536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
   sha256: d9c102b9ec7f3a635936b6f73d4db126d748a25f65407353bd76b260dc7d1cd6
   md5: eec48dbdf5dac0ea26750cc26b58c1d9
   depends:
@@ -902,7 +902,7 @@ packages:
   license_family: CC
   size: 554986
   timestamp: 1709758392744
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
   sha256: 882481e441b9b93cbdfb32fbe32a6ad9f26197472f186a08fddb921f61346c02
   md5: 443c79196064f57c98199e9990544b2f
   depends:
@@ -912,7 +912,7 @@ packages:
   license_family: BSD
   size: 16902
   timestamp: 1709322958614
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
   sha256: e4877b41553e31b9f9f090dffab77a654255c63776e8b30fc91ec1f60afadbf1
   md5: c34d3f1520f1e8c9957eb236710058c4
   depends:
@@ -924,7 +924,7 @@ packages:
   license_family: BSD
   size: 281162
   timestamp: 1700583651472
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.5.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dask-core-2024.5.0-py311h06a4308_0.tar.bz2
   sha256: d7c1822466ff522e14771be1a4234a7e80da0a70fbae0b56422c419eb74fea2d
   md5: 4ac1601f900babedf8edf35bd98d2ec7
   depends:
@@ -941,7 +941,7 @@ packages:
   license_family: BSD
   size: 3104830
   timestamp: 1715838694654
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.16.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/datashader-0.16.0-py311h06a4308_0.tar.bz2
   sha256: 309e8323cc5e7506a2be851649d36be0b6a0e157194baf6ee4fc900a1b43fddd
   md5: c938e7730d42d87dba1658a8893d6338
   depends:
@@ -963,7 +963,7 @@ packages:
   license_family: BSD
   size: 18004747
   timestamp: 1699543167034
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
   sha256: 3b4cd8dc60572086f1a1cbb97e2712e0ffd55317ce8f0309d552eee7367855eb
   md5: 70a1263b6e19bf2d77c020a2e77277c9
   depends:
@@ -974,7 +974,7 @@ packages:
   license_family: MIT
   size: 2556575
   timestamp: 1690905285843
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
   sha256: 4b589e3265c74159130230c164ff2d8d381be65899a249def0b53f93ce83fd47
   md5: 245cb7173dcdba21cf368031cd87f706
   depends:
@@ -983,7 +983,7 @@ packages:
   license_family: MIT
   size: 17434
   timestamp: 1676823330845
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
   sha256: b75d12e85274660bb675a3e53d47a929872f2daa2ff5a76e98885ee3f2d19ad1
   md5: f2119d0885334060d0d7fe59e5220287
   depends:
@@ -1002,7 +1002,7 @@ packages:
   license_family: MIT
   size: 3237908
   timestamp: 1713551660998
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
   sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
   md5: a5dc8677d891dff2393b63189a3ad42f
   depends:
@@ -1013,7 +1013,7 @@ packages:
   license_family: Other
   size: 971975
   timestamp: 1666798278693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.3.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fsspec-2024.3.1-py311h06a4308_0.tar.bz2
   sha256: a78f34d0b919c5fce722d33afc278cd48f5eec2bf186c35dd18d59d85d45909b
   md5: 199586a3dcad8985bc4cb0e4262e06d1
   depends:
@@ -1022,7 +1022,7 @@ packages:
   license_family: BSD
   size: 364478
   timestamp: 1714461584790
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
   sha256: f48ccfb4214e2af41e73a3904e343ecd1eb1ae06578c26f55a5dd247771b2c86
   md5: d58e9eb09817935eb7342ceff889f481
   depends:
@@ -1039,7 +1039,7 @@ packages:
   license_family: BSD
   size: 5335524
   timestamp: 1707836581350
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
   sha256: a0ae6c5a6b615d73d9a243331f3f7d749b4feafdf2f334337fda8abd6c8355ed
   md5: e61d8dcd4dfd6d165e6e480cee846bf5
   depends:
@@ -1056,7 +1056,7 @@ packages:
   license_family: BSD
   size: 357992
   timestamp: 1715090462763
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
   sha256: e08e27531775de40f46b6ac7bf71856963baa0c008bd2b4d112e6341cd3e8f4c
   md5: bfc7682613c861cbcb4ac01485c05657
   depends:
@@ -1065,7 +1065,7 @@ packages:
   license_family: BSD
   size: 147174
   timestamp: 1714398938840
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
   sha256: c7ffa6006573483a05ef355770c3201f04dd04ab4b91ae01971a6cdc7fbdba35
   md5: 23d7d38e93d930ea5e2cc5f4079d3816
   depends:
@@ -1075,7 +1075,7 @@ packages:
   license_family: APACHE
   size: 49872
   timestamp: 1704813633807
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
   sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
   md5: 3add2ce56858a1b8f6a37342f82773d3
   depends:
@@ -1091,7 +1091,7 @@ packages:
   license_family: Proprietary
   size: 19310769
   timestamp: 1699647799237
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
   sha256: 0b670ab17ed2e1b592079bd64386dadc249ddc892e5ae1dd99f142a918ffc75d
   md5: 632575b9e442c1e5c146cf78424da610
   depends:
@@ -1112,7 +1112,7 @@ packages:
   license_family: BSD
   size: 227791
   timestamp: 1705934138566
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
   sha256: 65228eb868c3ec8aa71f958e60a675a919f016c2057392e02fd422fc841858f9
   md5: 68e23f14cd222c233e6b37262bc61c23
   depends:
@@ -1129,7 +1129,7 @@ packages:
   license_family: BSD
   size: 1612840
   timestamp: 1704833066871
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
   sha256: a2918ea8a3e2c56fc6d91191e84b2f35500c392b16ab687a0c03ded2e2e51239
   md5: 84fadd6b7fef393cccc0d123dae6cae8
   depends:
@@ -1139,7 +1139,7 @@ packages:
   license_family: MIT
   size: 1162207
   timestamp: 1679336523618
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
   sha256: 4520b83e425883981f97191986a08122fbaebc3f16b898368796314136779028
   md5: 42a8f32c4d842d3e5410b2bc1cc2fb57
   depends:
@@ -1149,7 +1149,7 @@ packages:
   license_family: BSD
   size: 352284
   timestamp: 1706733655761
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
   sha256: c21f8f407266d039e819c27fe9eb4fb26587e974f3bd059b37cbaec5073722d0
   md5: ba1f47411e9e07876c7a3e9d3be6a98e
   depends:
@@ -1158,7 +1158,7 @@ packages:
   license_family: Other
   size: 281400
   timestamp: 1677849152168
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
   sha256: 06b729aee6dd2a1e545f3ad64179cc0d4ef8a15e33db3be2995dd3e0868465ca
   md5: 8bb3215912588e47e2eeb4e7a09ad64f
   depends:
@@ -1171,7 +1171,7 @@ packages:
   license_family: MIT
   size: 180858
   timestamp: 1699041715847
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
   sha256: 9e3bac2d41bd432b721b009e7de981766fba396e6f238e923f304112bd88655a
   md5: 84ae4cf3f2d01fbebdac374971192be9
   depends:
@@ -1181,7 +1181,7 @@ packages:
   license_family: MIT
   size: 15525
   timestamp: 1699032521315
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
   sha256: 79ce6dff3d93649a2555b1d2a4ae9eb77175a1c00664cb8eb0e6f848d5cdd1b9
   md5: db395b0efd7018fcf3a4af879170c2a8
   depends:
@@ -1197,7 +1197,7 @@ packages:
   license_family: BSD
   size: 276856
   timestamp: 1676823504812
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
   sha256: fedc7e5560252af44b0dfbe6f7acfe20ab17a6a08e758f670a1cd820551afc7a
   md5: bd28d36963087f53a79b23fee697d665
   depends:
@@ -1208,7 +1208,7 @@ packages:
   license_family: BSD
   size: 93898
   timestamp: 1698937453304
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
   sha256: 2b896fe8b2187b7df824041826e14379476eb2e61d607d8cb38ac2b3df40aaa4
   md5: 8fc7e517da96c2c482331f6b08d07a17
   depends:
@@ -1224,7 +1224,7 @@ packages:
   license_family: BSD
   size: 41459
   timestamp: 1699282616532
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
   sha256: 87d372f5b23bcc2410e43b40b4ad059ea1625178b8a2b484fc63805ce517e594
   md5: 50204f372b1672871d6ab3db6a876374
   depends:
@@ -1251,7 +1251,7 @@ packages:
   license_family: BSD
   size: 594177
   timestamp: 1699467208489
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
   sha256: ddfee06ba9b149222c65d1d4270272840533aa63b56fe36363c84a891c71d328
   md5: ee128e5c0d8d9e1952e2387b66a5b8cb
   depends:
@@ -1261,7 +1261,7 @@ packages:
   license_family: BSD
   size: 27239
   timestamp: 1686870958829
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
   sha256: 0c6a074272ed58677ec17e4dbfceaffd2108841a61af92b32f156c5763108d1d
   md5: dd3d37841d0d20c70a60e8c939923894
   depends:
@@ -1273,7 +1273,7 @@ packages:
   license_family: BSD
   size: 19144
   timestamp: 1700168632051
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
   sha256: b040f0d0ee4588188ab6b83a93738b3ff6e6d1775424be97995bd0df0f4fb904
   md5: eae62735d710cf5ff6d51e6f59fcd999
   depends:
@@ -1284,7 +1284,7 @@ packages:
   license_family: BSD
   size: 78148
   timestamp: 1676827253282
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -1295,7 +1295,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
   sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
   md5: 9508af80612e4fa1b5d1abb43ca7e63c
   constrains:
@@ -1303,7 +1303,7 @@ packages:
   license: GPL-3.0-only
   size: 749072
   timestamp: 1652971360657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
   sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
   md5: 88199c75f2ac211728febced7785c24e
   depends:
@@ -1313,7 +1313,7 @@ packages:
   license_family: Apache
   size: 228278
   timestamp: 1635523146417
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
   sha256: bb990ea068c3b3dafd9c807e0e19570320cb2fe7d69cc326f1f0b5319b0654b2
   md5: 3ff70744e396b1af69656c574b05c3b9
   depends:
@@ -1321,7 +1321,7 @@ packages:
   license: MIT
   size: 66940
   timestamp: 1714483221853
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
   sha256: 3b87a816f72a00e1f0022a160e7eda70af89d3de2a2e08a72be1c17b31d759f3
   md5: 4f57d3a0a13ddaf1c06efb586b702f46
   depends:
@@ -1330,7 +1330,7 @@ packages:
   license: MIT
   size: 34446
   timestamp: 1714483232430
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
   sha256: 2cf15e89f910600f468edfde8d0f9b80a14fa2319ed89160dc7375dfd3764fdb
   md5: 463adc13f2feea3570d1eccac368d9e4
   depends:
@@ -1339,7 +1339,7 @@ packages:
   license: MIT
   size: 295090
   timestamp: 1714483244460
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
   sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
   md5: 55dde57e63a36b202e388a39dcee9a66
   depends:
@@ -1348,7 +1348,7 @@ packages:
   license_family: MIT
   size: 74096
   timestamp: 1695996494461
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
   sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
   md5: 1af9b4d62c708924417f2640ef22a68f
   depends:
@@ -1358,7 +1358,7 @@ packages:
   license_family: MIT
   size: 154016
   timestamp: 1714483282916
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
   sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
   md5: 641e72e5067bd6d5454405879e1cd2a7
   depends:
@@ -1373,7 +1373,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 8895144
   timestamp: 1654090827491
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
   sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
   md5: 27082517590f3b9fbffecc68513b461b
   depends:
@@ -1382,7 +1382,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 19860
   timestamp: 1654090819660
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
   sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
   md5: 0202c3c8ae4735cac6c7f3d1e1685964
   constrains:
@@ -1390,7 +1390,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 5228750
   timestamp: 1654090762569
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
   sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
   md5: 3080c2813e6e1d0f8a100a38b5b3456d
   depends:
@@ -1398,7 +1398,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 573231
   timestamp: 1654090775721
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
   sha256: 512fac06ddd97b4383503d4fbd8145102966055b29ccf86841a930dbb4ef3ab8
   md5: 833c0e514ff9c8ae0511630b024d60e0
   depends:
@@ -1411,7 +1411,7 @@ packages:
   license_family: Apache
   size: 37179832
   timestamp: 1683292829131
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
   sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
   md5: 1bffe1481ed4f88827248fb9001f8923
   depends:
@@ -1421,7 +1421,7 @@ packages:
   license_family: Other
   size: 362561
   timestamp: 1677841789536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -1429,7 +1429,7 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
   sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
   md5: 8c195584a5f5471b600ee180e4052773
   depends:
@@ -1437,7 +1437,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 6410287
   timestamp: 1654090800863
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
   sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
   md5: ef78eebd98289aceacdfa29182426adf
   depends:
@@ -1455,7 +1455,7 @@ packages:
   license_family: Other
   size: 664034
   timestamp: 1693575237924
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
   sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
   md5: 292768ec77416ae257cfdd44ea2071c8
   depends:
@@ -1464,7 +1464,7 @@ packages:
   license_family: BSD
   size: 29197
   timestamp: 1668082729834
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
   sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
   md5: 9cdeef1d044c7e035c006890f11569d3
   depends:
@@ -1475,7 +1475,7 @@ packages:
   license_family: BSD
   size: 436056
   timestamp: 1694776944891
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
   sha256: fd8e30beb8c9442f16e6617fac92dd0c89ec823e98f06e60f712147380ead35f
   md5: 7ed7caf2816c8b85b67b6f4e8833cbd5
   depends:
@@ -1485,7 +1485,7 @@ packages:
   license_family: MIT
   size: 41155
   timestamp: 1676837080881
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
   sha256: 05e355127db0d3ed67c4c383fd929ef1c3d7d3f19472f6e5433a866e94378bed
   md5: b7897895622e5ab6e62279f07fa1f587
   depends:
@@ -1497,7 +1497,7 @@ packages:
   license_family: BSD
   size: 4367002
   timestamp: 1706910875807
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
   sha256: 95fe76d2691feb13203b55ad2aba535bb848cae21ffd05b13ff51c7a45fa2332
   md5: 6a04ec16e3abc1c7e2104be32cd6c418
   depends:
@@ -1506,7 +1506,7 @@ packages:
   license_family: BSD
   size: 13458
   timestamp: 1676827287432
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
   sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
   md5: 76f089e76ec67583bb38428b51008097
   depends:
@@ -1516,7 +1516,7 @@ packages:
   license_family: BSD
   size: 164494
   timestamp: 1714510587156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
   sha256: 260e26dd509834c1b225ab7bdb97b9a86e00054fbdd5dfa49e68fa4dcf85a661
   md5: 8f5d7ddc69cc6f7d44c80d2251dea5d1
   depends:
@@ -1525,7 +1525,7 @@ packages:
   license_family: BSD
   size: 162339
   timestamp: 1676837095436
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
   sha256: 7f5b0804d0768619b7bd93b10488067d80bf42ec29f443f00b53ba11758a1241
   md5: 8afb45e45c0d93bfd142e682d4b021ef
   depends:
@@ -1535,7 +1535,7 @@ packages:
   license_family: MIT
   size: 134438
   timestamp: 1684280014220
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
   sha256: cb03570c99c983d7bfda94bc47d8eb00d4059b8548a171130775acc998004195
   md5: 5b1abbbf1e4f9b350b16fc9caf9e889b
   depends:
@@ -1547,7 +1547,7 @@ packages:
   license_family: BSD
   size: 26919
   timestamp: 1704206397615
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
   sha256: 85fea48bea278a77d102781a1cbb6bf69307207d741251e38a6515c5fd7e3523
   md5: d6ddba94f7c33c88c9825be8409991bf
   depends:
@@ -1569,7 +1569,7 @@ packages:
   license_family: PSF
   size: 9150942
   timestamp: 1713336680714
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
   sha256: 7ac07ea180b5928086075900afbc332fb1d3c81ddfacb54c891693c284056f14
   md5: fc83dd1b3d2ec3c0a297ead0c3405907
   depends:
@@ -1579,7 +1579,7 @@ packages:
   license_family: BSD
   size: 19573
   timestamp: 1676823852670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
   sha256: c9ba2f9c83820712dd97d6a1b54a1215b9820a0be02ac82380b4c50911b9400c
   md5: e5dc6b4a5b8e02733ce3bc9e9198a8d2
   depends:
@@ -1589,7 +1589,7 @@ packages:
   license_family: MIT
   size: 67750
   timestamp: 1676837123613
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
   sha256: 1a5141ef0de1cbff816f96bb4b212a40606e2fc11301a4c1358c8d63a6b2b027
   md5: 22ac3bc22b68fef4c1f3f6ab3c7bfe0b
   depends:
@@ -1598,7 +1598,7 @@ packages:
   license_family: MIT
   size: 23040
   timestamp: 1676827301164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
   sha256: 9aacfbbe6f638c58a4e8ff31374d1438d78b7db25d6ea6fd0c50ca2109f225d4
   md5: e602057e3b3d80da88c61d66e8851c5b
   depends:
@@ -1609,7 +1609,7 @@ packages:
   license_family: BSD
   size: 104681
   timestamp: 1676823696152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
   sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
   md5: ce77d0f05f846da4a6b9e23fe7f21d9b
   depends:
@@ -1623,7 +1623,7 @@ packages:
   license_family: Proprietary
   size: 206738176
   timestamp: 1699648006088
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
   sha256: 2aef0876d0df033f7fae8cddbd25d95fc1bfc067e60dd143bd8000fec0768b21
   md5: d6cdc670327bd1675bbea642849f04e1
   depends:
@@ -1634,7 +1634,7 @@ packages:
   license_family: BSD
   size: 59569
   timestamp: 1682948560323
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
   sha256: 691c4b2b47cf3fac55b4949d7c0f547246ef19cb3510749142cee4bd01ffb055
   md5: bbd69efa3f24ee747410f83118640d92
   depends:
@@ -1648,7 +1648,7 @@ packages:
   license_family: BSD
   size: 240723
   timestamp: 1695058405382
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
   sha256: 71f5c7beca4e81b465ecfc6ed51cb3d39f51dd88df0b29eff5def3d1f12969eb
   md5: 61d58663b7277cf4cc3cb8d9873d3ee8
   depends:
@@ -1663,7 +1663,7 @@ packages:
   license_family: BSD
   size: 331105
   timestamp: 1695059935112
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
   sha256: b558b3f6c144652b5e0d26497b3ce24c318a6b9ff8ea2079113c95e5553b3cf9
   md5: 0b185969ac2b065c27cbcc9641d93678
   depends:
@@ -1673,7 +1673,7 @@ packages:
   license_family: BSD
   size: 29568
   timestamp: 1676841232463
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
   sha256: 20d832ce714465ae1685d29e2f913fd105d385d003fe1bef71ef472e6f3489e6
   md5: ad76299b0c33b7a5c0d45905271165c1
   depends:
@@ -1699,7 +1699,7 @@ packages:
   license_family: BSD
   size: 8303422
   timestamp: 1699542957307
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
   sha256: bb45fb0a3973caa74fd8f845e0a519895f6a378807626e15ecf72c02f2eed794
   md5: 185f658ba8a74e326b7231c8fd0d62bf
   depends:
@@ -1712,7 +1712,7 @@ packages:
   license_family: BSD
   size: 121834
   timestamp: 1698934274227
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
   sha256: 8b2fc372a6655fd5b277d07b994ce43643553fbc37e63a60e9fe527a9026ec06
   md5: ed6ac14aed5a796b153d757862398997
   depends:
@@ -1739,7 +1739,7 @@ packages:
   license_family: BSD
   size: 523905
   timestamp: 1699022906468
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
   sha256: 7908ff6c516b15e8fb677be4071145e18adea7d4c13b8485a70a5ee2f573f8cb
   md5: 50c0e38207a131a5de6a14ef919ffcdc
   depends:
@@ -1752,7 +1752,7 @@ packages:
   license_family: BSD
   size: 169629
   timestamp: 1694616826002
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
   sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
   md5: 57ea097dc15f8d9f9eb90e1d919143b0
   depends:
@@ -1761,7 +1761,7 @@ packages:
   license_family: MIT
   size: 1157733
   timestamp: 1674734069410
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
   sha256: 266199dd4efde0ad342a9c500f4bc4299c5622219aea623b46315a9b4f6b8959
   md5: 2b21844d2b0024d0ffad0e6450cf0855
   depends:
@@ -1770,7 +1770,7 @@ packages:
   license_family: BSD
   size: 15860
   timestamp: 1708532713870
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
   sha256: 13d6c640710895e9732225cdedbe47fcd756887fffeb0cf9bc149ee7234dfc27
   md5: a87d55e3d071f2c435b10db49a9911af
   depends:
@@ -1795,7 +1795,7 @@ packages:
   license_family: BSD
   size: 730963
   timestamp: 1690984942516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
   sha256: ef2857e6d3d7eb246b3abddfbd3aa2d124dd8565391ace3876b77339babc50bb
   md5: d276d1b1774107987963135c78ca7390
   depends:
@@ -1805,7 +1805,7 @@ packages:
   license_family: BSD
   size: 26607
   timestamp: 1699455972519
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.59.1-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numba-0.59.1-py311ha02d727_0.tar.bz2
   sha256: 1b830d1d091462cff92de55f24339365a9d2c23b27d19799833b4780efe99c15
   md5: 06367b04f8f04c0dc4e356a2ca9dc854
   depends:
@@ -1828,7 +1828,7 @@ packages:
   license_family: BSD
   size: 6084284
   timestamp: 1711988494237
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
   sha256: 2f89f38a665ece47e8868b391fc70602fcee588e989bc1ca6f17f6094892a94e
   md5: b788c80b2d571531ea4f3f8335ae5423
   depends:
@@ -1843,7 +1843,7 @@ packages:
   license_family: MIT
   size: 168827
   timestamp: 1696515597877
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
   sha256: e09e1aff2c12d4ef3fec58fb627744e4b5c7d9eaede7175e293f77272d8b8bfd
   md5: fe8242cfd54d238507493612ae697ad4
   depends:
@@ -1860,7 +1860,7 @@ packages:
   license_family: BSD
   size: 10270
   timestamp: 1708639794640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
   sha256: a53ad723826651041a5057a1cf31bc8689b24d335ce61b196df5124974b05a8e
   md5: 7b29e7191c4170189d6080e61229f030
   depends:
@@ -1876,7 +1876,7 @@ packages:
   license_family: BSD
   size: 9163911
   timestamp: 1708639777712
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
   sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
   md5: b0afe23033c8c5344640bc25225fa579
   depends:
@@ -1887,7 +1887,7 @@ packages:
   license: BSD 2-Clause
   size: 516994
   timestamp: 1630084830020
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
   sha256: 6c7cb4097e4f3655b54a119304e50f0edbc4bd52f36c84629b64674cf8d468b8
   md5: f1e48c973646ded3c2e1a189a9d8b8c9
   depends:
@@ -1897,7 +1897,7 @@ packages:
   license_family: Apache
   size: 5498991
   timestamp: 1716318104769
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
   sha256: 280225061aeba00d7b85f46e55d7d79cd92c92f662dc749d9c53187978e8d083
   md5: c51c21da68080d89300703ad818c824a
   depends:
@@ -1906,7 +1906,7 @@ packages:
   license_family: APACHE
   size: 38606
   timestamp: 1699371264464
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
   sha256: bd3eacd22e85f88bedd9c7e97a59eacfb3c8bb80eb59be244825d6895a0e7ac1
   md5: 08ceb294ba8a9ae13630da789884736e
   depends:
@@ -1915,7 +1915,7 @@ packages:
   license_family: Apache
   size: 157904
   timestamp: 1710807470578
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
   sha256: a2ee3a6aaf54929b82b851b2eb5436e14e5a294303ef429d6dccd33bcdfc8002
   md5: b467a5c7ad672ccc2d498a67b9eeeaaa
   depends:
@@ -1966,7 +1966,7 @@ packages:
   license_family: BSD
   size: 17970687
   timestamp: 1709593080388
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
   sha256: aa05415302a27a82105e9d0800151f09fd1bb896b90854dc23989f9aecd9200b
   md5: 4974b1ae5f1a3b6d9fb26e7eb2c26733
   depends:
@@ -1990,7 +1990,7 @@ packages:
   license_family: BSD
   size: 21869200
   timestamp: 1714071532259
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
   sha256: c6c782537b96ab9caf3e25f5a33799c727e84664cdbab37a8d3359a221e2d2e3
   md5: 8f56d0f63e0589dd7e4a004678307813
   depends:
@@ -1999,7 +1999,7 @@ packages:
   license_family: BSD
   size: 263438
   timestamp: 1711136934516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
   sha256: a2e2beff710765f2e5135020121da4f227f5e1cbe142e17398a585f50a389d37
   md5: eaf734d49b6e576e12be1398a295643a
   depends:
@@ -2013,7 +2013,7 @@ packages:
   license_family: BSD
   size: 47447
   timestamp: 1698702703255
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
   sha256: 28ed719669260a20bec78971edaffb91ec917d2a3f0fac1cf9a8ba21590baa43
   md5: 0481d078fcd64f7f981532a514d9d50d
   depends:
@@ -2030,7 +2030,7 @@ packages:
   license_family: Other
   size: 960727
   timestamp: 1714399060039
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
   sha256: d527189038b376a982c18613df808f25dc40314b0dc8fe5549f3ae9f4288e497
   md5: 68dad015e796cc26364b55f92f61faa7
   depends:
@@ -2041,7 +2041,7 @@ packages:
   license_family: MIT
   size: 3451714
   timestamp: 1715097126399
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
   sha256: d2bbab8bfc57c7f46ca8994bc87df7e744d3f036b867bc4be1145ba6d8d7e091
   md5: de41707272a8e3ccab764f0b7010a27d
   depends:
@@ -2050,7 +2050,7 @@ packages:
   license_family: MIT
   size: 37394
   timestamp: 1692205565974
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
   sha256: e2a0e2a618aa33f0beff9583c7dc510b8d0737b023117346676aacbad33970d8
   md5: 66a6818307261b1a28ab12d1b7776fdf
   depends:
@@ -2059,7 +2059,7 @@ packages:
   license_family: Apache
   size: 121454
   timestamp: 1679340540306
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
   sha256: b7f591c19b10bf0daa7e6e3b45a9f4a0a0e83188e1f8a58037caea79e60f8d91
   md5: d945b4ccc135005839c504cc29df1745
   depends:
@@ -2071,7 +2071,7 @@ packages:
   license_family: BSD
   size: 749608
   timestamp: 1704404477511
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
   sha256: 96482b49191fdac59580a95e69508367083e1f7600145e11d7c2db634337eb26
   md5: 2d57bf8eacf3f291db845928241f724c
   depends:
@@ -2081,7 +2081,7 @@ packages:
   license_family: BSD
   size: 490805
   timestamp: 1679337420563
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
   sha256: eb75b4417565d25e2d1006db75aa8bd9da6b6c72a929954b01a31b9bf5f8b42e
   md5: bb56c0358b65665f4dd509a4635f6f3c
   depends:
@@ -2093,7 +2093,7 @@ packages:
   license_family: BSD
   size: 37802
   timestamp: 1676838557935
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
   sha256: ed927e4d058a8f4ea73edc7a43ed74877d93b88fdfa240b3b2777244386ced70
   md5: a1f0e05fc7e49712f81ad5478ec9d51e
   depends:
@@ -2102,7 +2102,7 @@ packages:
   license_family: BSD
   size: 2121496
   timestamp: 1684280065800
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
   sha256: ad219924e362ce7af458fa6547660181579e9a50e5aed1ffd9268cbe7c2650e3
   md5: 2b1ac40e0df3673d33b7f4c4f93ae1ef
   depends:
@@ -2111,7 +2111,7 @@ packages:
   license_family: MIT
   size: 207338
   timestamp: 1677811584327
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
   sha256: 114b55e00f4622c90fd2b404b21ad5f94a10283fcaaf86a42174b8d39b0a3e98
   md5: 2458e92683cc68671a6c8e1b86ce8817
   depends:
@@ -2120,7 +2120,7 @@ packages:
   license_family: BSD
   size: 35850
   timestamp: 1676822725516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.8-h955ad1f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.11.8-h955ad1f_0.tar.bz2
   sha256: 8bae0856b2f337f43cb5cbbf71ebf684ef47438210465b8733304d7d7f258559
   md5: 7fa94ac6e31488660ca09b2896b9d96d
   depends:
@@ -2142,7 +2142,7 @@ packages:
   license_family: PSF
   size: 36090392
   timestamp: 1708984519285
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
   sha256: a0f008717fab060ccd003dfebc09156d90b9afd14ac3626566aa1a8f3d3b7e2f
   md5: 357bf4fe94496cbae72ab4d780184b31
   depends:
@@ -2152,7 +2152,7 @@ packages:
   license_family: BSD
   size: 330924
   timestamp: 1716495762901
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
   sha256: aadc4078311c059265706a56265f0a57ceb538d36179d5203dd487d80d0e8f16
   md5: 59ec670fcd172447dbd9591b8fbfdd56
   depends:
@@ -2161,7 +2161,7 @@ packages:
   license_family: BSD
   size: 278741
   timestamp: 1679340144625
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
   sha256: d5058d0ecc3973316c1d5f1bfb03dd119e0dade85f4c2d21b412c8db4e1636f2
   md5: 93000e4d3603342779a2afda66fa91b8
   depends:
@@ -2170,7 +2170,7 @@ packages:
   license_family: BSD
   size: 17607
   timestamp: 1683823841946
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
   sha256: b85acb933fff864bfa89d034e8e3d85b1a9c2e69cbfc0d68c1d66ffd1443e67d
   md5: 0cdb92d2d684ee1095310f992ed0d9b2
   depends:
@@ -2179,7 +2179,7 @@ packages:
   license_family: MIT
   size: 266796
   timestamp: 1713974338678
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
   sha256: 511e8206a15445715b80be76493300930686b3fe1e512ae942d6ccca36df392a
   md5: 35a6e46ae970f8b71d78fb5a810f2e80
   depends:
@@ -2191,7 +2191,7 @@ packages:
   license_family: BSD
   size: 64013
   timestamp: 1711136926372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
   sha256: b2a1f649669f4336b74f6f20df711959bcd8024f8f8b94199dc0e040b06bd37a
   md5: f9e8e3f7068f717f75e555dc04545d8d
   depends:
@@ -2202,7 +2202,7 @@ packages:
   license_family: MIT
   size: 206433
   timestamp: 1698096204677
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
   sha256: 7c74db4292f31619606180f86f3c1e2d913495c2c9d1195c5d51681a6a841625
   md5: be1c05fae57d194924b9400f9b5ad3c6
   depends:
@@ -2213,7 +2213,7 @@ packages:
   license_family: Other
   size: 613277
   timestamp: 1709318516682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
   sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
   md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
   depends:
@@ -2223,7 +2223,7 @@ packages:
   license_family: GPL
   size: 467661
   timestamp: 1666648052561
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
   sha256: 89c2f4235277b9825cc805c5c44f0b1afcb683d7b5a3f513bc4bf243b643bb0c
   md5: db70eb57e33adf7b8bbdadd72214d48d
   depends:
@@ -2234,7 +2234,7 @@ packages:
   license_family: MIT
   size: 73679
   timestamp: 1699012111499
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
   sha256: 684037527327839d734e7eac2ee09ef5ddb4f77df22daf40c79e51db29d09543
   md5: 57c5bcb9eae9f1d93ccfd38025660de2
   depends:
@@ -2250,7 +2250,7 @@ packages:
   license_family: Apache
   size: 119414
   timestamp: 1707355661872
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
   sha256: fdae3f68ea84b99561aee6c566ab1c287d8f2ae2668424e9283a8ed86af8f1d2
   md5: cde5b71ccbb3630053340b2c8c7dbf10
   depends:
@@ -2260,7 +2260,7 @@ packages:
   license_family: MIT
   size: 9333
   timestamp: 1683077183576
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
   sha256: 0bf859b06a07857099fd4f524fe5e0875fda70029e9485d95c7efa97134fbc14
   md5: fd5815cc592fdbd4c831901541eadaba
   depends:
@@ -2269,7 +2269,7 @@ packages:
   license_family: MIT
   size: 9735
   timestamp: 1683059096795
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
   sha256: 474553d01aea57214a54a7443f227da84a58e29c49eb7605ba0043c55b7d167a
   md5: f01333e9f0a908e435db650f42fbd2db
   depends:
@@ -2279,7 +2279,7 @@ packages:
   license_family: MIT
   size: 1096668
   timestamp: 1698946168635
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
   sha256: b06b45da61807f76b6d800047f123fee2cc95eb84da508550e0908951c8d9f6f
   md5: 9b100efb9ba2fc7f9bcfaa8fd2ab6f9f
   depends:
@@ -2298,7 +2298,7 @@ packages:
   license_family: BSD
   size: 27615256
   timestamp: 1714076660659
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
   sha256: 51bcea0e575a626f6ffbd16d1153330fda93dbe3dd31dcd3a8f469ff61dd1e4e
   md5: 41d531c90be8c82bf79635ff3d409476
   depends:
@@ -2307,7 +2307,7 @@ packages:
   license_family: BSD
   size: 32295
   timestamp: 1699371262818
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
   sha256: 0a95988ea269c96354626dcab255b65b54bb5c503d24cdeb6ef2e1c42818bd59
   md5: 8bfb9f42492b3b53b8151d77e51c75d8
   depends:
@@ -2316,7 +2316,7 @@ packages:
   license_family: MIT
   size: 1594974
   timestamp: 1715024182643
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
   sha256: 1a84b00944bc5588e14a097460175f97df49acb4f1ff2498ffd9a1893068ed81
   md5: a456513471b2ecbed60430c21dd1ccc7
   depends:
@@ -2325,7 +2325,7 @@ packages:
   license_family: Other
   size: 17880
   timestamp: 1705431390054
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
   sha256: adcafd297d60af64107c113bb7b8b92160d0268a44ef9a3b79e56a88a0358ea7
   md5: 28ed704ed26b06d32662e3a6a87e59b0
   depends:
@@ -2334,7 +2334,7 @@ packages:
   license_family: MIT
   size: 88799
   timestamp: 1696347581401
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
   sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
   md5: f86119b3243fe3508160aa0406245738
   depends:
@@ -2347,7 +2347,7 @@ packages:
   license_family: Other
   size: 1723866
   timestamp: 1714488309729
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
   sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
   md5: 041a3caf09dc9ce8fc6c10925c4fe050
   depends:
@@ -2357,7 +2357,7 @@ packages:
   license_family: Apache
   size: 1888016
   timestamp: 1680167274961
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
   sha256: 856a8ab8c350c50247b79966c6cb80fb6d4de36eef49ddf75aebbbcaf854c82d
   md5: 442dde204d14d171aab9ee40e8de4de8
   depends:
@@ -2368,7 +2368,7 @@ packages:
   license_family: BSD
   size: 37456
   timestamp: 1677696176157
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
   sha256: f0a026ddc0ed041bfc60c8a1ca0b70b7a69232775b3181bfb35a39fda42d6994
   md5: 2902d5a5854865baaaf58dc59cf06b3c
   depends:
@@ -2378,7 +2378,7 @@ packages:
   license_family: BSD
   size: 49185
   timestamp: 1676823769869
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
   sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
   md5: e2512d57c8a1e91e7b20e265c6906546
   depends:
@@ -2388,7 +2388,7 @@ packages:
   license_family: BSD
   size: 3588922
   timestamp: 1714770676475
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
   sha256: e58ff4a82819446f3c92e5b1aa2a784c4b06643e751fe67cf115858296dbfa50
   md5: 32ee4723173f1fad5563b8afb5f1c8f1
   depends:
@@ -2397,7 +2397,7 @@ packages:
   license_family: BSD
   size: 135634
   timestamp: 1676827536101
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
   sha256: 1bf522ade750cf0b70d61e71916ff00569e2908db1e9dedb223fda2608ed8bde
   md5: 6793c74fe94211c0bfe6766c6dd490af
   depends:
@@ -2407,7 +2407,7 @@ packages:
   license_family: Apache
   size: 893808
   timestamp: 1696937055591
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
   sha256: 54f41afbea1c01a10e5703e64645de145f34ad6d89cf245fbc5cfaaff58a8743
   md5: 15b6c8bee4c28c6efb3e388178b37145
   depends:
@@ -2418,7 +2418,7 @@ packages:
   license_family: MOZILLA
   size: 154276
   timestamp: 1716395957568
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
   sha256: 0575785f6553e61cc6138abfd5de52305fac6f85971642fa1f056a76c66a52b2
   md5: f2c25e5dfdd23f70b83776a8832893cf
   depends:
@@ -2427,7 +2427,7 @@ packages:
   license_family: BSD
   size: 270865
   timestamp: 1676823316868
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
   sha256: 8c06c291c76e8c2022ffbb9fea4727a4bf1f9b03e498bafc56ba8ac4e7604ab9
   md5: 5adb7baf1091d09026a372cac930ce6c
   depends:
@@ -2437,7 +2437,7 @@ packages:
   license_family: PSF
   size: 8869
   timestamp: 1715268966416
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
   sha256: 118b0801167264c401e84bbf19175546092a5569cc098146f7362bbf890dc8d9
   md5: b3c2aa56d53b459f8365d8385f48d0c3
   depends:
@@ -2446,7 +2446,7 @@ packages:
   license_family: PSF
   size: 74489
   timestamp: 1715268960737
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
   sha256: 509b962773f0fe44a93a7f6196b254670a030eac8ea7f90727312e3ccd9294b2
   md5: 6c402d5bf4e01c8c3895c9ef41707b6e
   depends:
@@ -2455,7 +2455,7 @@ packages:
   license_family: MIT
   size: 11371
   timestamp: 1676828901104
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
   sha256: bbe7629e8ce52c82f13ed0d1fb919f3659ef466b274a7c74aa925a9bc7aee450
   md5: 7da527bbcf71270c1abed8ea52e7d44c
   depends:
@@ -2465,7 +2465,7 @@ packages:
   license_family: Apache
   size: 509031
   timestamp: 1713213062098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
   sha256: 5c6afad310db12b3658a652efc5de45c182164a0b537cb2cdae5885428b30d22
   md5: 89ea2fed160a633e0a6d152b61cb0dd2
   depends:
@@ -2481,7 +2481,7 @@ packages:
   license_family: MIT
   size: 209068
   timestamp: 1715635972793
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
   sha256: c3a5e0b855dc2de6c162708dfcf170a23eb9e7525d4252d8dce553369af4a330
   md5: a4c77e204b7787f820955166a1283168
   depends:
@@ -2490,7 +2490,7 @@ packages:
   license_family: BSD
   size: 25890
   timestamp: 1676823132898
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
   sha256: 42989f9970a8466cc4edb73463dfa194594dd1a5d42c9f820a1f86296d4af140
   md5: 655dfd4d2f17977cb81caa1c082d2b25
   depends:
@@ -2499,7 +2499,7 @@ packages:
   license_family: Apache
   size: 113505
   timestamp: 1715878346465
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
   sha256: eec0d2e0bce4b62278cacd7b0bee053160845e86507051a5434d2069bd290f36
   md5: a069e5aef64a6dac076cc9a3d28a17c9
   depends:
@@ -2508,7 +2508,7 @@ packages:
   license_family: MIT
   size: 136022
   timestamp: 1714717059748
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
   sha256: 85248e503721da67797546cb8a22e303c1739100834b219c5621f216e3794e8d
   md5: 2570956643f22d0f809b2467e02d3984
   depends:
@@ -2520,7 +2520,7 @@ packages:
   license_family: Apache
   size: 2465865
   timestamp: 1689041600364
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
   sha256: d18cdca154bf668826f869117ea996c4f9e8ef7d27b7c528332a7d17e5a8602c
   md5: 9f7353d72046b16dd6ef6b5689ac9bfd
   depends:
@@ -2529,7 +2529,7 @@ packages:
   license_family: BSD
   size: 54731
   timestamp: 1676828934954
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
   sha256: 9122d6e9dabb7a47f2bcb15d86b97c96c49a9048da3f8ae59675351710c14cc5
   md5: 660b2aead2ec87b751c86cd33934f44e
   depends:
@@ -2538,7 +2538,7 @@ packages:
   license_family: GPL2
   size: 716926
   timestamp: 1714510796277
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -2546,7 +2546,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
   sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
   md5: 943f1247a22b6b64171363bcee1eec27
   depends:
@@ -2557,7 +2557,7 @@ packages:
   license_family: Other
   size: 371663
   timestamp: 1705602144682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
   sha256: 7aa781d0850f97622755ed44772d2b215b253a8e211aede5f3f53e1b95b4143a
   md5: b1d8823f50228d4efb7b7a6e267ed776
   depends:
@@ -2566,7 +2566,7 @@ packages:
   license_family: MIT
   size: 24333
   timestamp: 1704207043644
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
   sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
   md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
   depends:
@@ -2575,7 +2575,7 @@ packages:
   license_family: Other
   size: 127143
   timestamp: 1714510716441
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
   sha256: af3c032f06352e87c450739cb8aafe1ff34ad28bf074b214ea98b3d29259a85d
   md5: 51fa34bd0e016ed7c5371cf6cb13ef6c
   depends:
@@ -2588,7 +2588,7 @@ packages:
   license_family: BSD
   size: 1044463
   timestamp: 1714678445052
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -2601,7 +2601,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -2611,7 +2611,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -2623,7 +2623,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
   sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
   md5: 544adf2677c47c9b9c891aea720678f1
   depends:
@@ -2631,7 +2631,7 @@ packages:
   license: MIT
   size: 33999
   timestamp: 1630003259346
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -2640,7 +2640,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -2649,7 +2649,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -2658,7 +2658,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -2667,7 +2667,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -2675,7 +2675,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -2684,7 +2684,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -2693,7 +2693,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -2703,7 +2703,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
   sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
   md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
   depends:
@@ -2712,7 +2712,7 @@ packages:
   license_family: BSD
   size: 5106
   timestamp: 1704404390460
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -2720,7 +2720,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -2729,21 +2729,21 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
   sha256: 459f38609d854888998a8d76028019dbacdce2bfe401eab57b8eb8ff16da9c7f
   md5: 2948a98ef4de5decb7e5eb888eae68ba
   license: BSD-3-Clause
   license_family: BSD
   size: 13056
   timestamp: 1682965564630
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
   sha256: 305e5fd9993f3e5506f386f98794c7d53b6e6c68d4d411ada724de49a17945fa
   md5: e1fbbd2d11d21aaec3c32f7d332c0e77
   license: BSD-3-Clause
   license_family: BSD
   size: 13818
   timestamp: 1712163766707
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -2752,7 +2752,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
   sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
   md5: 02caf3f47f1d06256068053297355740
   depends:
@@ -2761,7 +2761,7 @@ packages:
   license_family: Apache
   size: 152292
   timestamp: 1690578151230
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -2770,7 +2770,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -2782,14 +2782,14 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
   sha256: dc9f709bacbaf08a0941d2622d82f91f18b355e82c55348ec29f1391215ca7e0
   md5: ece0f5837a4de2d4d5f1abf8347cd10a
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 124922
   timestamp: 1708711884650
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -2797,7 +2797,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
   sha256: 5800a2466734dd1ef372bec0dd3f0880c5072fa1e8b0668f5054f834285e991c
   md5: 18194e51d4420ac08f29f3f86581b52e
   depends:
@@ -2811,7 +2811,7 @@ packages:
   license_family: MIT
   size: 229003
   timestamp: 1706220302459
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
   sha256: ab7672364f1fa55ec5d8311d85d40e5b57cbd3517b17670557b6fb822bcf759c
   md5: 6e0159a5865cb7e96a748bd8560035ee
   depends:
@@ -2820,7 +2820,7 @@ packages:
   license_family: BSD
   size: 11579
   timestamp: 1678317458652
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
   sha256: 51556902e09436d46878ef772805d06416ca96ffaa66340b5565c0245574aaf5
   md5: 4cb1b20635cf5431d34cc96ca1e8a751
   depends:
@@ -2830,7 +2830,7 @@ packages:
   license_family: MIT
   size: 33355
   timestamp: 1678317111825
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
   sha256: 188b74f717e3ce3595da404c0e027b8ccafa9c186e88325e8f02c29d7b4c0744
   md5: 04ad90eead5812a0263b42321056ab33
   depends:
@@ -2839,7 +2839,7 @@ packages:
   license_family: MIT
   size: 153694
   timestamp: 1695717975427
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
   sha256: bf3c60386619f08cf5105b4b903bbc109b3252c3b923fe055aa445908a01969c
   md5: 3f84a301921ec6400b7f1f1c4ba3260d
   depends:
@@ -2849,12 +2849,12 @@ packages:
   license_family: MIT
   size: 270017
   timestamp: 1681493109562
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
   sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
   md5: e2f3248e2a5009a02f7b8e54f83314ef
   size: 5620
   timestamp: 1528121955725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
   sha256: 126ae8e30b8464fb2dc94ce9163dcb2d5482f7214c7d8a48340c3f09f1409d5e
   md5: d5e0c054042910b4394a14c7eb4d8131
   depends:
@@ -2872,7 +2872,7 @@ packages:
   license_family: BSD
   size: 6080356
   timestamp: 1712084675745
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
   sha256: 9acafafcaebd653c2372ddc864525722e1c55b884b5eba22e28e2b2d946b853c
   md5: 22375cc3c2edada31b85af56c8e6dee6
   depends:
@@ -2882,7 +2882,7 @@ packages:
   license_family: BSD
   size: 155829
   timestamp: 1707864406086
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
   sha256: d8b1ccb15297dcfb3f9ebb8139c3e28a13d6c2e73c37612cb214ab6cc58b15fa
   md5: e5dec9f13de061640ad2697562a99b54
   depends:
@@ -2892,7 +2892,7 @@ packages:
   license: MIT
   size: 19732
   timestamp: 1714483415038
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
   sha256: e9fda4393edd0234c88efc2b88e0edf42c94eb49ea5b189a80afd733058be8fb
   md5: 13ceed558eb174d6b77ed1b0035f1785
   depends:
@@ -2901,7 +2901,7 @@ packages:
   license: MIT
   size: 18400
   timestamp: 1714483395748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
   sha256: a323af3251e426962ad16edf8f46a696ef502731faf12aee32ca289c40b11342
   md5: 658ce49e9f07dba7a1afe70fa2666e0a
   depends:
@@ -2910,21 +2910,21 @@ packages:
   license: MIT
   size: 393858
   timestamp: 1714483549536
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
   sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
   md5: c5a600d81b1b48578863af2973c743ac
   license: bzip2-1.0.8
   license_family: BSD
   size: 187637
   timestamp: 1714510590009
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
   sha256: 0c5f9766aa2dcc08ae71b6c0102046a56b30297d0bedc3039b7f72d1658baa43
   md5: 34583b436e62a2ce55d6a7e8eb818e33
   license: MPL-2.0
   license_family: Other
   size: 138712
   timestamp: 1710764814844
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
   sha256: 20b1fc398e925e6c8cea6a06d3bb614e2c0de886e3f14f85b0ba26e57ff40b7e
   md5: ac95cfe373c7fef7820e93189041b0cc
   depends:
@@ -2933,7 +2933,7 @@ packages:
   license_family: Other
   size: 166856
   timestamp: 1707229213510
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
   sha256: 6b5bebc13755b0a5ef423219eeecd1c25b97dbe83afad6e2552635387547d9f7
   md5: b7bc4192fcfed7fc7df1ce00bce97b02
   depends:
@@ -2944,7 +2944,7 @@ packages:
   license_family: MIT
   size: 291802
   timestamp: 1714483319125
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
   sha256: aceaa74365b0d8e69c817639393df3a713a802f40645ac0bd2f39adc871acf54
   md5: 52191c9d4f4fcaeea39574819ab2f14f
   depends:
@@ -2953,7 +2953,7 @@ packages:
   license_family: BSD
   size: 204365
   timestamp: 1698129979494
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
   sha256: 53099bea1cdfeac00bf4bf48e7c3321424af31b9726a7f67033ed06e5d924f04
   md5: 0302e97edbd24e02df7609a6072dc569
   depends:
@@ -2962,7 +2962,7 @@ packages:
   license_family: BSD
   size: 50495
   timestamp: 1683040190091
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
   sha256: 9270668e34b00a2605584a2db5130c83826855cd05b896ce949f3156fa197429
   md5: 2586aa55677e822e8285d777f9039ca9
   depends:
@@ -2971,7 +2971,7 @@ packages:
   license_family: CC
   size: 543487
   timestamp: 1709758497949
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
   sha256: 389c63a84b92a6254c9d361ebe970d537d0b88733efd5ac5c3ee58196fd2c5a9
   md5: c7bc5b3cbe76be83a27f00b7e4740727
   depends:
@@ -2981,7 +2981,7 @@ packages:
   license_family: BSD
   size: 17974
   timestamp: 1709323004148
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
   sha256: bebfc5aa6be12e61a134b580b07b67f7d8c045d6b113fca5b21fa1e83a2f03ce
   md5: 239df72a3921c951059fa8afc09643f6
   depends:
@@ -2992,7 +2992,7 @@ packages:
   license_family: BSD
   size: 287736
   timestamp: 1700583644534
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2024.5.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/dask-core-2024.5.0-py311hecd8cb5_0.tar.bz2
   sha256: 5e6d053acad4139e50c724bb862204097c82f5d9c00dc3c4dd280ec4e2e50f94
   md5: ebd1df3504dc6c94b7c587bba659be54
   depends:
@@ -3009,7 +3009,7 @@ packages:
   license_family: BSD
   size: 3107521
   timestamp: 1715838704477
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.16.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/datashader-0.16.0-py311hecd8cb5_0.tar.bz2
   sha256: 973b7d6f902d0021116a94004a4abc43b623a516033cd650360db52b7a5900da
   md5: 3d602a55412745fd7dc1f5fcfdc2fca6
   depends:
@@ -3031,7 +3031,7 @@ packages:
   license_family: BSD
   size: 18008805
   timestamp: 1699543215294
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
   sha256: e0e30590a78d99d51445ac4f668aefe1bf20025a35bdbac00f04647b95c9f152
   md5: bd0db635eefeea82a0c567b39c9a0e3d
   depends:
@@ -3041,7 +3041,7 @@ packages:
   license_family: MIT
   size: 2485698
   timestamp: 1690905283575
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
   sha256: d48b47b86b09dac1fa4542ec13e1bd4e23093638e684fa66ec3afdd9ce9337c1
   md5: 5a2d1828ab7c8eccd3c2610d13672977
   depends:
@@ -3050,7 +3050,7 @@ packages:
   license_family: MIT
   size: 17336
   timestamp: 1678316187749
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
   sha256: 54645c22fabc25b632114d1d3c403a6fad9149b51ab36719b2690a084f14a072
   md5: a8ad2f4abfb2e17ecf6e596342528156
   depends:
@@ -3068,7 +3068,7 @@ packages:
   license_family: MIT
   size: 3180691
   timestamp: 1713551771692
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -3078,7 +3078,7 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.3.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fsspec-2024.3.1-py311hecd8cb5_0.tar.bz2
   sha256: 296e72c622f7014041055d8c7b602385ad10893aa1c0b600248c95e7d116dfa9
   md5: 93d5cc02fe01e3b396f02df0ca682a79
   depends:
@@ -3087,7 +3087,7 @@ packages:
   license_family: BSD
   size: 365534
   timestamp: 1714461741656
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
   sha256: 4120472ee1c5d31efffeb045892bece27b9a15a30d77c35212f6508221635918
   md5: 9561a225b5171285250c9071f8cab074
   depends:
@@ -3104,7 +3104,7 @@ packages:
   license_family: BSD
   size: 5368257
   timestamp: 1707836808668
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 50dee40e4a9ea7a035baeecc85770c88d63d4e6b0c3c2519c1429e881171150c
   md5: 4d465f453dca5c65224dccbe953f600c
   depends:
@@ -3121,7 +3121,7 @@ packages:
   license_family: BSD
   size: 359293
   timestamp: 1715090716440
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
   sha256: 5c2458964157fe493ca18c513c693b70cb622087e5fa0c93e65fc45217edd811
   md5: 15629e52625221b51a443cefd9501d12
   depends:
@@ -3130,7 +3130,7 @@ packages:
   license_family: BSD
   size: 148522
   timestamp: 1714398885844
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
   sha256: 5a17849341e4d43fc6aff44486425852c16dee6e1cbcab1ed3f2167350f55359
   md5: 445ac9df262ad2dcd86246a9ba5654b2
   depends:
@@ -3140,7 +3140,7 @@ packages:
   license_family: APACHE
   size: 51118
   timestamp: 1704813615186
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
   sha256: e0127f50d444bf4474e8df07d602c7f6dd38690e8bb3fb28817c164940ffcde1
   md5: 583fcd7060cad6a77074d00d9ef62f44
   depends:
@@ -3149,7 +3149,7 @@ packages:
   license_family: Proprietary
   size: 731417
   timestamp: 1699647668990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
   sha256: eb58fa29b1ce9aa5fc774d4c466696457695dec3b206456614b4c9cac0a94e42
   md5: 3d3291ff58dff83dcd40ec54b435f4d2
   depends:
@@ -3171,7 +3171,7 @@ packages:
   license_family: BSD
   size: 229910
   timestamp: 1705934029588
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
   sha256: 73aa7662c00c73bab2dafefefc87a1b524961d2687410af624ecbd6703e483f3
   md5: 7e71e99766107a553752ed8f22b61cf0
   depends:
@@ -3188,7 +3188,7 @@ packages:
   license_family: BSD
   size: 1611976
   timestamp: 1704833049616
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
   sha256: e08cda2bcbdec124c63e951eb248c503bb1467c2a6000010c6bdc0726e0e00b7
   md5: 22c24f43b82da8b3920a913bbf452421
   depends:
@@ -3198,7 +3198,7 @@ packages:
   license_family: MIT
   size: 1168968
   timestamp: 1679336359851
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
   sha256: 3b262312f1fc76e490c067408771da0a12c7691379cddc3c86121255cda7a41d
   md5: cbf00a1bc151243cb6a33524b62f3663
   depends:
@@ -3208,14 +3208,14 @@ packages:
   license_family: BSD
   size: 353280
   timestamp: 1706733664000
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
   sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
   md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
   license: IJG
   license_family: Other
   size: 278924
   timestamp: 1677849185191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
   sha256: 99fc6ac82c56eb2a580f96db24a5b887f8abc8c24af445d3313d5ebb48598478
   md5: 71892160908a6daedb5fb7c404079ae4
   depends:
@@ -3228,7 +3228,7 @@ packages:
   license_family: MIT
   size: 182073
   timestamp: 1699041732321
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 0ea44d0c8044e70ab0eaf4d6f5f3e4753838dee106b5cbd36561e21a65cbac77
   md5: 1d045016dca889d702f1caf3a16162fc
   depends:
@@ -3238,7 +3238,7 @@ packages:
   license_family: MIT
   size: 16528
   timestamp: 1699032525791
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
   sha256: 70442ec4b0b7ebbdcf150963f61f797b861001092124f4ea39a16eb92a4d176e
   md5: 63d1503915a15ae4f9ad1c46112ca374
   depends:
@@ -3254,7 +3254,7 @@ packages:
   license_family: BSD
   size: 272720
   timestamp: 1678316970740
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
   sha256: 8601c674f4779900f6a949e47b814be68b722b0b3d394433bec9d197924ebd69
   md5: b8423f8caff3041a251fc3681f43496a
   depends:
@@ -3265,7 +3265,7 @@ packages:
   license_family: BSD
   size: 94990
   timestamp: 1698937583196
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
   sha256: 6a430c812ce0415a04d9cfe6c66d9012eced2d91c04960c88bc8ec1e9f1b5d6d
   md5: 30b3d5d6a8cf5d1604e5f5fb177917b5
   depends:
@@ -3281,7 +3281,7 @@ packages:
   license_family: BSD
   size: 42513
   timestamp: 1699282637015
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
   sha256: c2d206db117f7161e77236ebd6b0051fc73e1731c242d1e08597d736a0376c92
   md5: bdb61de2e20e02c93423d9de091c74ad
   depends:
@@ -3308,7 +3308,7 @@ packages:
   license_family: BSD
   size: 601837
   timestamp: 1699466514455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
   sha256: fd7964657f0a8fe8b167ba860b1f960e8b7b45309eb6c7c850d50ec283fe03b5
   md5: 2967bb345bc75f53182e263ff4743ca6
   depends:
@@ -3318,7 +3318,7 @@ packages:
   license_family: BSD
   size: 28223
   timestamp: 1686870845224
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
   sha256: 64cf59f0f74b0329b5069bc6135b4f40593f1dac52d85ad574d4b8e0a4b2cf16
   md5: 35e8b80eaa03a904fc7f1da39e7f654d
   depends:
@@ -3330,7 +3330,7 @@ packages:
   license_family: BSD
   size: 20234
   timestamp: 1700168776500
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
   sha256: a12382b50416803f559a03fb384ba492c1dafa351e1191a3f8dc361bee6c4f37
   md5: f2ae846b663bbb642f4b1e90eaad38a3
   depends:
@@ -3340,7 +3340,7 @@ packages:
   license_family: BSD
   size: 64817
   timestamp: 1678322501509
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -3350,7 +3350,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -3359,13 +3359,13 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 685c3bc9068bd485604b80bf03789e4dca95c410d33871bc1b882e47649fabed
   md5: 6cf8e55271e150ca0961d0ddedaa61bb
   license: MIT
   size: 66237
   timestamp: 1714483284541
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 69826cee54db9955f0120af21ec36d13f9211877fd67364f2068d0a54c6c97cd
   md5: 0851917257f490d35e1f73da8a1c723c
   depends:
@@ -3373,7 +3373,7 @@ packages:
   license: MIT
   size: 34042
   timestamp: 1714483343147
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 3f5a1f03b50b90b397a0ee432ad0cba13354abdaf7e5652c0fc60164b26a08b6
   md5: a50bdc871ef4bf14deb088d888b92b5e
   depends:
@@ -3381,28 +3381,28 @@ packages:
   license: MIT
   size: 311597
   timestamp: 1714483371586
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
   sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
   md5: 822a5b76117e56d3912f1f2153307528
   license: MIT
   license_family: MIT
   size: 136045
   timestamp: 1714483561919
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
   sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
   md5: e458587c87e3f2d20192f4e0738f2c63
   depends:
@@ -3411,7 +3411,7 @@ packages:
   license_family: GPL
   size: 149419
   timestamp: 1665498987619
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
   sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
   md5: 1058b661ec829b2ee3716ee2a5520641
   depends:
@@ -3422,7 +3422,7 @@ packages:
   license_family: GPL
   size: 1917987
   timestamp: 1665498925405
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
   sha256: 8176dd9a68815301a24ed51e72f3506f5f77c67a112efa0dd14971f2f3b3c8c1
   md5: b5e470c224000a6bda6f655c155b53e7
   depends:
@@ -3434,7 +3434,7 @@ packages:
   license_family: Apache
   size: 27861431
   timestamp: 1683292881730
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -3443,13 +3443,13 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -3466,7 +3466,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
   sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
   md5: 46a65d1fc24013217e06aaf6d65ffcad
   constrains:
@@ -3475,7 +3475,7 @@ packages:
   license_family: BSD
   size: 425478
   timestamp: 1694776947990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
   sha256: d28c465ec6d5f8d4962c597b249b58998300c8b4e3c937c578c3d15294ea863d
   md5: dcaed6ddd0723c7cce6bfad917be98b2
   depends:
@@ -3485,7 +3485,7 @@ packages:
   license_family: MIT
   size: 41176
   timestamp: 1678413498410
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
   sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
   md5: 5c740b4a18a558de0ccfe601703c423c
   constrains:
@@ -3494,7 +3494,7 @@ packages:
   license_family: Apache
   size: 338738
   timestamp: 1662635677689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
   sha256: 53808184421c81e661f9927ff564a0d0ecdf3b816c8aba8e2368434e055529d4
   md5: bee10bfbe90767fcb8f8f6ab3a05d85a
   depends:
@@ -3505,7 +3505,7 @@ packages:
   license_family: BSD
   size: 407784
   timestamp: 1706911015242
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
   sha256: 716a654df2e55052193150015bd5c9856b847893fc5a229fa8669725b1c56ff2
   md5: 687ba6c11de38ad7cc597f7188b491e7
   depends:
@@ -3514,7 +3514,7 @@ packages:
   license_family: BSD
   size: 13357
   timestamp: 1678322560230
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
   sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
   md5: 8f57dc3a3327bb6f7e1cba908856ac7f
   depends:
@@ -3523,7 +3523,7 @@ packages:
   license_family: BSD
   size: 183138
   timestamp: 1714510756758
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
   sha256: 6fb2953e169ee1ae38f24d29752051501992f19b96b5ebcea9af75737bdbcb42
   md5: 7f410cdae838c5030108d1b98a8c78f6
   depends:
@@ -3532,7 +3532,7 @@ packages:
   license_family: BSD
   size: 162478
   timestamp: 1678377892595
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
   sha256: cd97e09a12ffb49b2a30a782fa8c7933b28f5ffdbfc5c73a9ebaa95fc9447370
   md5: d1fb6ebc1e5728aa6377cfc71da08942
   depends:
@@ -3542,7 +3542,7 @@ packages:
   license_family: MIT
   size: 135859
   timestamp: 1684280005320
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
   sha256: 30c3b189462a9d0f4794d229adadf34b5f5a5f56f95c30d5afc17ef524579290
   md5: d4e9421243129d1d57c472dab045f3dc
   depends:
@@ -3553,7 +3553,7 @@ packages:
   license_family: BSD
   size: 26639
   timestamp: 1704206159955
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
   sha256: 080000a28b3ceca54eec6de0748c690ea5a4c390e358283eac03fe7a6dd87065
   md5: 51344eca57d7940fb01eb5e8914509e3
   depends:
@@ -3575,7 +3575,7 @@ packages:
   license_family: PSF
   size: 9099909
   timestamp: 1713336790553
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
   sha256: 07e7fd5bd64e55328b4b99d92e2e2600d791f1095bf905daab4cfc59f0f0a45b
   md5: cf53321779f4ca7e986c1468719b93f1
   depends:
@@ -3585,7 +3585,7 @@ packages:
   license_family: BSD
   size: 19500
   timestamp: 1678317565001
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
   sha256: 0770e02be1ea1216af493cfc03d5b8a702e14606fa93b0692bcdab1fed1b898c
   md5: ca6f06ceaf66a32bbf5dfdb6e373a5cf
   depends:
@@ -3595,7 +3595,7 @@ packages:
   license_family: MIT
   size: 67892
   timestamp: 1678417734353
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
   sha256: fbe95ed0501bb0f137048476fe41bc718dd659e8ecb066bc67ac17d6a50f4318
   md5: ec162bde8d1c8a107b257df218b17035
   depends:
@@ -3604,7 +3604,7 @@ packages:
   license_family: MIT
   size: 23030
   timestamp: 1678381838497
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
   sha256: c20dd678655e582129a858a1c5162bdc254082d3a3c035b0f72629d9276e5b75
   md5: 800a0738c728796e02d0386ce7d457aa
   depends:
@@ -3615,7 +3615,7 @@ packages:
   license_family: BSD
   size: 104585
   timestamp: 1678317269407
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
   sha256: c825bc3070f73318ffff88a7a0b7fc6d1858b058ced735efd1789053f1583918
   md5: dea5f96459c9a6df6b026ca57d387936
   depends:
@@ -3628,7 +3628,7 @@ packages:
   license_family: Proprietary
   size: 224299920
   timestamp: 1699647835748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
   sha256: a76c134ec258612ff7d55cb2a19b9e3461cbbd375a744bd29390af9cfcd283b2
   md5: 1c736f58992009f53f014aef163bae31
   depends:
@@ -3638,7 +3638,7 @@ packages:
   license_family: BSD
   size: 48442
   timestamp: 1682969160267
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
   sha256: bcfb0d1e075d043bcf05fa1a7ce3c142bf222d29693366af49a5a346c770812f
   md5: 59e4820b34049cbc6619a8ac97290abc
   depends:
@@ -3651,7 +3651,7 @@ packages:
   license_family: BSD
   size: 222137
   timestamp: 1695058350477
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
   sha256: 114e408c40b332393cf2792393e4d1ede3465abcb3d345fe647ee519565346c8
   md5: 86b13271578e1fa5e664edcf6fcb3ce4
   depends:
@@ -3665,7 +3665,7 @@ packages:
   license_family: BSD
   size: 296860
   timestamp: 1695059990370
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
   sha256: 638450a7ccb5f438ac65aa1c8d871fb5bb664e7261ec7e663d0302485c219a67
   md5: 574875bbeabff85b5d9cfdb62066aece
   depends:
@@ -3675,7 +3675,7 @@ packages:
   license_family: BSD
   size: 29473
   timestamp: 1678392919304
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
   sha256: a58960e88525a202ba193b4dd8227c4d9c3dd98b8b43edea34b05a9a9fd1121c
   md5: 71a37f987c3df6657548d098bd2a58e7
   depends:
@@ -3701,7 +3701,7 @@ packages:
   license_family: BSD
   size: 8286383
   timestamp: 1699543227340
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
   sha256: e08cb3ee6df01f4c1e1ac8bc4ed1a06e549ffcc8774fe2e2842c644bb8f74a86
   md5: 6ba0ae0fb14cbea1e3197707701dc180
   depends:
@@ -3714,7 +3714,7 @@ packages:
   license_family: BSD
   size: 123077
   timestamp: 1698934356774
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 2f946b5042eaac97206b5217fb203f3604ab3a60aecd99bdfc684925e3136c18
   md5: b24026076c381ff2009e7acb9e0a6e87
   depends:
@@ -3741,7 +3741,7 @@ packages:
   license_family: BSD
   size: 534650
   timestamp: 1699022791300
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
   sha256: ba368605a0af6f1dcbdcb6fddab9ce63224a85dd11bfb2b1acace1dc17899411
   md5: 91f3ea3fe44d619ee95a6ed3773a0814
   depends:
@@ -3754,14 +3754,14 @@ packages:
   license_family: BSD
   size: 170926
   timestamp: 1694616830121
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
   sha256: 42d803e1d8b54748db5d989ecd503826f564132df7cddc20f520460f55e523a1
   md5: cd3fa71626ebc098da4625fc6be79752
   depends:
@@ -3770,7 +3770,7 @@ packages:
   license_family: BSD
   size: 16952
   timestamp: 1708532805951
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
   sha256: 92d50872fad0d1fecfea42cbfdb69887def80927c169a88204d163c2d3c7d035
   md5: fe6780b8659ff5d6061268708a7b2032
   depends:
@@ -3795,7 +3795,7 @@ packages:
   license_family: BSD
   size: 716120
   timestamp: 1690984968401
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
   sha256: ed5608feb37a083d47b04203195260e801b64b5380f292cf18bb61e7ad827a2a
   md5: daa9c1c233673b727528548454aea664
   depends:
@@ -3805,7 +3805,7 @@ packages:
   license_family: BSD
   size: 27607
   timestamp: 1699456006797
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.59.1-py311hdb55bb0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numba-0.59.1-py311hdb55bb0_0.tar.bz2
   sha256: 733ece9d325b4baeaea505bd82be98ffe9e5f15669bf079ee4f2f15225bc70cb
   md5: c426b5fb76b3d219a2fbfa2792684ae2
   depends:
@@ -3826,7 +3826,7 @@ packages:
   license_family: BSD
   size: 6049873
   timestamp: 1711992424576
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
   sha256: cacba45c1eebf7d86748737717883a98cf40664231460fa41391c79f98d06f45
   md5: 3dbfae0d5b90e77f9358564ad442ac9d
   depends:
@@ -3840,7 +3840,7 @@ packages:
   license_family: MIT
   size: 165572
   timestamp: 1696515553184
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
   sha256: 1466c3af380b949612c79940124e426eccd59e335c205da0c00383a69358d1c0
   md5: df6be53592d40ba7e03d6ffe349760bf
   depends:
@@ -3856,7 +3856,7 @@ packages:
   license_family: BSD
   size: 11330
   timestamp: 1708639985606
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
   sha256: ace67d704fa7eea1480eb463f2d91bfc161be2ee20263c5a9939805ae3c2a9da
   md5: ec124589478fa12fba4f35f31c3a0692
   depends:
@@ -3871,7 +3871,7 @@ packages:
   license_family: BSD
   size: 8783230
   timestamp: 1708639945646
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
   sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
   md5: 93f5d7b66976154adeda219bea02ba45
   depends:
@@ -3881,7 +3881,7 @@ packages:
   license: BSD 2-Clause
   size: 484257
   timestamp: 1630093862501
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
   sha256: 891ffe9826f6f9ec9a4fc5d1bbb9a64f9de23f27705c2202f7d475b7cd14dd83
   md5: ab0d447c9eb4fcada05d853bd13a24ac
   depends:
@@ -3890,7 +3890,7 @@ packages:
   license_family: Apache
   size: 4970613
   timestamp: 1716319014066
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
   sha256: 8a0809f419065e014cb8e2c8a516cadca6088fb71fd1ef3ae2287d91e3360d59
   md5: 4dc0b9bc88476fcc5246d823ff1c289a
   depends:
@@ -3899,7 +3899,7 @@ packages:
   license_family: APACHE
   size: 39645
   timestamp: 1699371213055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
   sha256: 64fbbb03570788298d8b04d4ea6cb254fef5d5eec73265aeecd72cb565617f4d
   md5: 4b1195028bc26257df43fdd943638266
   depends:
@@ -3908,7 +3908,7 @@ packages:
   license_family: Apache
   size: 159450
   timestamp: 1710811009212
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
   sha256: 6abb7e0aeda0130f54925421900772e1bc46d1f04ae69ce1376524457686d49f
   md5: 232a6370c3fab0c41c6d4c7339e778ca
   depends:
@@ -3958,7 +3958,7 @@ packages:
   license_family: BSD
   size: 17296294
   timestamp: 1709591285369
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
   sha256: 10a5eb185aa5dcfecfa854c2e66b3779cb6d2dee85f1b2236f43234a1c1ba9e0
   md5: 2200abcb857e6bb8cb46b861cb4d2fd7
   depends:
@@ -3982,7 +3982,7 @@ packages:
   license_family: BSD
   size: 22071486
   timestamp: 1714072093679
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
   sha256: daf01c56a3c44555ecb61e9a0e899a7b58872c6b7631f00a04ee8d3199e9e568
   md5: 2163ed8005a14ecda15efe5586582cce
   depends:
@@ -3991,7 +3991,7 @@ packages:
   license_family: BSD
   size: 267508
   timestamp: 1711137004592
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
   sha256: 359b31da651ee35b9ca43974d26cd44e64f3cf412096c15dec7b720fa909a9b2
   md5: 108e24227f8fdfc4d635bb4eedfa6cef
   depends:
@@ -4005,7 +4005,7 @@ packages:
   license_family: BSD
   size: 48504
   timestamp: 1698702608965
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
   sha256: 90efc71d35ab62d5b8d7b648e016444e1c4c8b83238b6dc9f2c6c3db4b14c599
   md5: 6b6eeb0a14c5479db1dd39aa8d338150
   depends:
@@ -4021,7 +4021,7 @@ packages:
   license_family: Other
   size: 939480
   timestamp: 1714399174883
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
   sha256: f6b0ded7010706431f2a6d9776aa6033dfd19d2264b3cebf28072629160090a8
   md5: 02de6d0d9cc23fafe2e3597ed0e52693
   depends:
@@ -4032,7 +4032,7 @@ packages:
   license_family: MIT
   size: 3444268
   timestamp: 1715097155645
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 81719c31101d6c019150cedcc7b08adb3bdb357e8b2952e428dadaabc4dc985d
   md5: 105825168e0a17fb007f60b5f314e311
   depends:
@@ -4041,7 +4041,7 @@ packages:
   license_family: MIT
   size: 38405
   timestamp: 1692205731769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
   sha256: c0982f688127129e026d2b4cdacdd5684d00796ea7bdadd7d26b1101b095d723
   md5: 0d6910c74729fede645c010110f1c89e
   depends:
@@ -4050,7 +4050,7 @@ packages:
   license_family: Apache
   size: 121796
   timestamp: 1679340253537
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
   sha256: e32843723b10ecd9badde28e1085419c0b59ed8a96c7cacce6395e39e3a874f9
   md5: 5af0280a817d2c273304cd22328124af
   depends:
@@ -4062,7 +4062,7 @@ packages:
   license_family: BSD
   size: 763044
   timestamp: 1704404460779
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
   sha256: 117a435c2473e2a20cc81eaacb2b45ea5e7fe3c946eec2915936d344913ede44
   md5: 0f459ee59fda20e2077fdc2c777edfc8
   depends:
@@ -4071,7 +4071,7 @@ packages:
   license_family: BSD
   size: 497470
   timestamp: 1679337286052
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
   sha256: 667b5cf00d31293dede2ddadcc30ab967103d585d40647f34d6d830af97ee51f
   md5: 81d3876fa502fca91ba4136a5f3fc3d3
   depends:
@@ -4083,7 +4083,7 @@ packages:
   license_family: BSD
   size: 37821
   timestamp: 1678378977816
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
   sha256: dfb403f367c57327a4d080109df88383ecff18464de287a1ce936a7274e3656b
   md5: 997b674bad89963af875b93b06807f51
   depends:
@@ -4092,7 +4092,7 @@ packages:
   license_family: BSD
   size: 2120413
   timestamp: 1684280057020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
   sha256: 9d2c0f373ac1c5db329581793dd517092cdf9a59140f2516ed8c3a1f483c0bbd
   md5: ee10503a159e819abdc586666bdf0952
   depends:
@@ -4101,7 +4101,7 @@ packages:
   license_family: MIT
   size: 207552
   timestamp: 1678322848766
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 717e038567506ca58ce1cd4a3416892d02f4ebfdd332077cc3d110cfe3d36c58
   md5: 53bbfb400668f798eef6f8c7cf938e1f
   depends:
@@ -4110,7 +4110,7 @@ packages:
   license_family: BSD
   size: 35751
   timestamp: 1678315886516
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.8-hf27a42d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.11.8-hf27a42d_0.tar.bz2
   sha256: dea2e1371f27376636d240d98eb9d2d1f383df0264b354c2d97c90b60358f9ab
   md5: ff3603a0ff4f66a66856b3f09e29fec9
   depends:
@@ -4129,7 +4129,7 @@ packages:
   license_family: PSF
   size: 16812245
   timestamp: 1708984581993
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
   sha256: 04e100d0a1ea9722e24972657ec5935ad34c7c58957dabb821333e5eac80f717
   md5: 2b6de49ad07b26e1f7084f0fda958eb1
   depends:
@@ -4139,7 +4139,7 @@ packages:
   license_family: BSD
   size: 332276
   timestamp: 1716495830117
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
   sha256: 514249897265f66f6ecca0a4427eb02a43c33b3c24974db16d05db6bbe97881d
   md5: c9ea1437e5a3ba6a52ec2322505203e6
   depends:
@@ -4148,7 +4148,7 @@ packages:
   license_family: BSD
   size: 279116
   timestamp: 1679338758489
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
   sha256: 78b785b9b6ed46c86b0d3a32bdceea49f816672227fb63e726b2d46eadbdba0b
   md5: 79d783f74359141e0b06a848db33823b
   depends:
@@ -4157,7 +4157,7 @@ packages:
   license_family: BSD
   size: 18563
   timestamp: 1683823935261
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
   sha256: e358fe679e83ccdc8c433746ae6468e8e96d90d97d99530f8476ef5630b2c121
   md5: ce30a0a31d891e69dc9b7bf8b7f0c39c
   depends:
@@ -4166,7 +4166,7 @@ packages:
   license_family: MIT
   size: 268876
   timestamp: 1713974360942
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
   sha256: eeb5a5eed93b8e311ad4d3f4389e050f11bba2eaec9536e1c3ed2f849c6c999b
   md5: c18bd3e12de797d52a470c21a150dffe
   depends:
@@ -4178,7 +4178,7 @@ packages:
   license_family: BSD
   size: 65270
   timestamp: 1711136914884
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
   sha256: c3e11ed944da69c11b949bb918341a0d79ef603ee34a632d6a45fbf89ff924a1
   md5: fee7ff4d291f530b4cecb575f29807a0
   depends:
@@ -4188,7 +4188,7 @@ packages:
   license_family: MIT
   size: 197996
   timestamp: 1698096137432
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
   sha256: aa07b90a7ee65f76c8cba1ff99a5cdeb95cbe41881ae951f64ffff06674a1b2d
   md5: 58621e3d244137885f7dfbb35e50340a
   depends:
@@ -4198,7 +4198,7 @@ packages:
   license_family: Other
   size: 594801
   timestamp: 1709318510622
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -4207,7 +4207,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
   sha256: d784dc26c5de8e41845350a899e5779250b71f45d39e2aece62e739e9add7308
   md5: 7b077b7f46112bb31dc066396c51d3fa
   depends:
@@ -4218,7 +4218,7 @@ packages:
   license_family: MIT
   size: 74776
   timestamp: 1699012164201
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
   sha256: 3357b6b327b3d0a2cc0f02934a60bbd6df38f4ea7bbb3f50cb8e21332c9f5786
   md5: bf5e48b646e36ef2b788be9665c0e5ae
   depends:
@@ -4234,7 +4234,7 @@ packages:
   license_family: Apache
   size: 120768
   timestamp: 1707355762747
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
   sha256: 727fb8d957e02d03b928d049ffbc712316f176a2c331391766d646621b45655a
   md5: 7e0e416c642f3ee4ddfb084a811fb4df
   depends:
@@ -4244,7 +4244,7 @@ packages:
   license_family: MIT
   size: 10236
   timestamp: 1683077214314
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
   sha256: a8a67143ccb65cfd6f50055176b6c26179a83130a45d0a12e79dd2de68d8db63
   md5: a2065790f41e3eeb6efe0ef6daa75377
   depends:
@@ -4253,7 +4253,7 @@ packages:
   license_family: MIT
   size: 10600
   timestamp: 1683059285216
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
   sha256: 6aba582338faa0c26fe336bdb10c65b8f7808a6e383bd8f80f3e6b612ca209ec
   md5: a7486349b5f7370f6902c2050a23d268
   depends:
@@ -4262,7 +4262,7 @@ packages:
   license_family: MIT
   size: 319197
   timestamp: 1698946203341
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
   sha256: 86bda04163628ef7b35528fbb4fe1d56fef50d10570a859e5ae8a7fbb60f577c
   md5: 05e397dddd20d91460e3cedea0b3686f
   depends:
@@ -4281,7 +4281,7 @@ packages:
   license_family: BSD
   size: 27745043
   timestamp: 1714075585637
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
   sha256: beba0555707dac1e8484d73cee9e4128ac4b10e2a0d4209357481179022e8fdc
   md5: baa8b304607b3a9ae8a3d9acb354c31c
   depends:
@@ -4290,7 +4290,7 @@ packages:
   license_family: BSD
   size: 33343
   timestamp: 1699371216044
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
   sha256: c1df29188e321abe23651c73712a6d8ed3abdc89ad38a42c33f1835b3ab77abe
   md5: 6c984ea85326858942f7b635e0cc9ff8
   depends:
@@ -4299,7 +4299,7 @@ packages:
   license_family: MIT
   size: 1597325
   timestamp: 1715025837032
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
   sha256: 0eb44a16ef74a13ef7839209899d009cd94974fbc406a417d958c7bc8d955245
   md5: 41f239a5b67b1daf819849023aa5d12f
   depends:
@@ -4308,7 +4308,7 @@ packages:
   license_family: Other
   size: 19056
   timestamp: 1705431379885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
   sha256: 14775231982e1ea150189c956927ccfb1ad01a8c9395cdeea4d5a48b9b8ce664
   md5: 729badc4bf7ba8ccc70e0f9e58075c99
   depends:
@@ -4317,7 +4317,7 @@ packages:
   license_family: MIT
   size: 89812
   timestamp: 1696347694075
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
   sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
   md5: 6bef1694163a68ac4c37e5857b8da4f5
   depends:
@@ -4329,7 +4329,7 @@ packages:
   license_family: Other
   size: 1900191
   timestamp: 1714488351925
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -4338,7 +4338,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
   sha256: 3d5c2968f581006437df3932cd5d3c1c4afa78f0e13757b958440245d3248856
   md5: 605ea221d225ad8e79284dbcfdab0715
   depends:
@@ -4349,7 +4349,7 @@ packages:
   license_family: BSD
   size: 37699
   timestamp: 1678317755913
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
   sha256: ed059e32ce5a1c0511575f29d2fb6da12c54a37000bfa80f9e5aa9dfd9e04101
   md5: 4d2261a92d25136a68b8d01d101119f5
   depends:
@@ -4359,7 +4359,7 @@ packages:
   license_family: BSD
   size: 49145
   timestamp: 1678317386284
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
   sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
   md5: 523c006cc67c011383678c762015479b
   depends:
@@ -4368,7 +4368,7 @@ packages:
   license_family: BSD
   size: 3594448
   timestamp: 1714770737885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
   sha256: 424b8284072266eb59d055c0b7b58241bfb00009d445743ea261d4eeee73ea19
   md5: f3a47898a55087edb9d65d29c24d9b88
   depends:
@@ -4377,7 +4377,7 @@ packages:
   license_family: BSD
   size: 135757
   timestamp: 1678323030858
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
   sha256: 6ab71b48d145c69007cfb5b4a21def2cc83bba972b7cc91c7d52d0d7eeb055bf
   md5: f8970b0ad5c8b452b8722ceb4e5c17f7
   depends:
@@ -4386,7 +4386,7 @@ packages:
   license_family: Apache
   size: 895379
   timestamp: 1696937269468
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
   sha256: 3df84b9897f05a104c99e297dc29ad8f718982fc64c61b5a2204c19c578f47e5
   md5: deab971930d242221ed86bfd768dde40
   depends:
@@ -4397,7 +4397,7 @@ packages:
   license_family: MOZILLA
   size: 155545
   timestamp: 1716396266697
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 9e8dbede0bc54c77b974210be66503e7e8e45e0f1c71dc5c16cc9a9674d54259
   md5: b4fcab9e63bd7b3cdf458c953904807c
   depends:
@@ -4406,7 +4406,7 @@ packages:
   license_family: BSD
   size: 270874
   timestamp: 1678316116954
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
   sha256: 17e5688d09ffbcb8b71b34b86edc7374fa0b04d60a4d729d405ffc22ef63726c
   md5: e4bf44ddbbcb136332ccb47ac2b879a0
   depends:
@@ -4416,7 +4416,7 @@ packages:
   license_family: PSF
   size: 9890
   timestamp: 1715269046804
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
   sha256: 7d369ec970d1d5411e457c79f94197756c7088deff8183806ea71e633b26edf9
   md5: 9ffa197b26373667f50b21876862398e
   depends:
@@ -4425,7 +4425,7 @@ packages:
   license_family: PSF
   size: 75595
   timestamp: 1715269030928
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
   sha256: a9960485ced319ac91afe69eaaf703c7e6b3049f1e06a4a8c2818b64155943f0
   md5: 0a9c8ea92a14330a07edabac249e32a9
   depends:
@@ -4434,7 +4434,7 @@ packages:
   license_family: MIT
   size: 11399
   timestamp: 1678394892923
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
   sha256: d42ae57366d05e12f10074583568355752436d66ad018ffbcfa24135f593810a
   md5: 1a98e48aa0bd8b3ec09e2cbdbb236575
   depends:
@@ -4443,7 +4443,7 @@ packages:
   license_family: Apache
   size: 498952
   timestamp: 1713213079520
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
   sha256: 5dc693f0e0aeb30cb6033015b13e75c8a21c56b1262d9652788c3e73a5c5c4a5
   md5: 6b5cc9b43aa34431f8c30b5cdc22004b
   depends:
@@ -4459,7 +4459,7 @@ packages:
   license_family: MIT
   size: 210522
   timestamp: 1715636148762
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
   sha256: 597015e8a038a111f03ffbc9a217fcda549d75230c86ce53c1f23c53d6f1a0cb
   md5: 62e98aac883bccc1c87ca0d2ce2f08e0
   depends:
@@ -4468,7 +4468,7 @@ packages:
   license_family: BSD
   size: 25798
   timestamp: 1678317074170
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
   sha256: 1430e6f4b4dd9354b7bb88f7f7bc9cdbab26a034ad1ae5c278de0f5a99329372
   md5: be0832862b29bf5767a707ac6bd53b93
   depends:
@@ -4477,7 +4477,7 @@ packages:
   license_family: Apache
   size: 114834
   timestamp: 1715878445060
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
   sha256: 885a9b6046e76f7dc1a346b14c63b4083046137bfae036362c854458e20e4fc8
   md5: 3b279447ca282d065e681e567055b582
   depends:
@@ -4486,7 +4486,7 @@ packages:
   license_family: MIT
   size: 137340
   timestamp: 1714717062907
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
   sha256: cc6995f677d1628f42ae80ed47ff08d8d1c8ed12580a326af6e307f5febc594a
   md5: d01eb964863b95ef62061b77c9037ead
   depends:
@@ -4498,7 +4498,7 @@ packages:
   license_family: Apache
   size: 2471632
   timestamp: 1689041625741
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
   sha256: 5b6d5246955b5f9480ff7027eb002442a7ade24f5c354da54ed513042f76cedc
   md5: f32aa8a37d5e65a8dc30f9a1f46bc63d
   depends:
@@ -4507,20 +4507,20 @@ packages:
   license_family: BSD
   size: 54719
   timestamp: 1678325412288
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
   sha256: ed0152ad6b87ffd9e01f4a62bc358e805ad59637f898a801b0a9cf903ae8e1fb
   md5: 8a92f8c663608f24e14d8a2068b9d83a
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 415323
   timestamp: 1714511993944
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
   sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
   md5: c25b6d40f834647d0bbe767f6c776031
   depends:
@@ -4530,7 +4530,7 @@ packages:
   license_family: Other
   size: 329449
   timestamp: 1705602140856
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
   sha256: 36fa7ad990aabf3607bda1f33e847888210974586363b6d69cf1ed092c192c35
   md5: c981fe545122206cdeb647f2dc9e093d
   depends:
@@ -4539,14 +4539,14 @@ packages:
   license_family: MIT
   size: 25496
   timestamp: 1704207010227
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
   sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
   md5: f2519b551f99765d9d98950c5e2b4713
   license: Zlib
   license_family: Other
   size: 119782
   timestamp: 1714511811597
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
   sha256: 7feb73e79bdbd45404ddc7a30c43bf4cc68eced8ce448ce7c31f5db134276fc5
   md5: 48313bc6570c705cadbba3c356e0dc8e
   depends:
@@ -4558,7 +4558,7 @@ packages:
   license_family: BSD
   size: 1014151
   timestamp: 1714678461080
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
   sha256: 9ca3f0dfc2bdbc109e359ba7ab246e6ae952a14819148ad069454b52f2bda802
   md5: 51fb05873a644cac52f0d1e10cb7969a
   depends:
@@ -4572,7 +4572,7 @@ packages:
   license_family: MIT
   size: 228856
   timestamp: 1706220385566
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
   sha256: 43405cc7341ce3efb2e24013ad62c64f26a69926635adceaa5459ccbcafb3776
   md5: effa6d22f497e164cc8455f7f329c304
   depends:
@@ -4581,7 +4581,7 @@ packages:
   license_family: BSD
   size: 12510
   timestamp: 1677917870614
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
   sha256: 947efe1c50b3280e9a67cbb18636bdade53a40960fff3056850ff81ab87acbe3
   md5: 7d2d384ee32ccc12dcb0dc099e421482
   depends:
@@ -4591,7 +4591,7 @@ packages:
   license_family: MIT
   size: 35091
   timestamp: 1677915945226
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
   sha256: 8259b4a0973c825ac81f581afcbe86640bd0a94b33caa996167309241877635a
   md5: 49b8ddacfd3927bcaae139eadfb72ce1
   depends:
@@ -4600,7 +4600,7 @@ packages:
   license_family: MIT
   size: 153557
   timestamp: 1695717951839
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
   sha256: 11159a30daae77cfc1abe5e60c19261f65c005e6fbc460aecf72318514d737ad
   md5: 0c5002654a9cb21db1fdf8c1d2017df5
   depends:
@@ -4610,12 +4610,12 @@ packages:
   license_family: MIT
   size: 269772
   timestamp: 1681493072129
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
   sha256: 90439f37ede74ef464e76093e173a8e94a20ee4ad79c68c9e7570fbc67fc13cc
   md5: bb3b906307dd679fc3276be7581494f9
   depends:
@@ -4633,7 +4633,7 @@ packages:
   license_family: BSD
   size: 6073834
   timestamp: 1712084392983
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
   sha256: 688a071ba370f51b457cd32d70b7b38921ce9551203d06fa7fc2c30c4b79891d
   md5: b2353077a39ab997463768154dd58fec
   depends:
@@ -4643,7 +4643,7 @@ packages:
   license_family: BSD
   size: 134711
   timestamp: 1707864978809
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
   sha256: 048264434c33fdb53862cdd69b2e2bc4ce6f8a70b3211ad6d686d066eac2aa91
   md5: d55696ccaf6755931cd662dfb929aa0b
   depends:
@@ -4653,7 +4653,7 @@ packages:
   license: MIT
   size: 19737
   timestamp: 1714483270447
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
   sha256: 13627293296fcc231d8dc12d803dfc9621108c60df38b0e3c64e9e02ed55e564
   md5: 86efd4ad08cd80d3eab77873db84a255
   depends:
@@ -4662,7 +4662,7 @@ packages:
   license: MIT
   size: 19083
   timestamp: 1714483255364
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
   sha256: 2e542b2bb27f8379da3efcb83ef084cb26e6a9ab576c50487c2dd996afd5ccb1
   md5: e8cab9d1ef58a450f971690fcdb2ede2
   depends:
@@ -4671,21 +4671,21 @@ packages:
   license: MIT
   size: 380182
   timestamp: 1714483330655
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
   sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
   md5: 56d1386c7f1f338f0d18f82af6525273
   license: bzip2-1.0.8
   license_family: BSD
   size: 158748
   timestamp: 1714510571033
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
   sha256: bbfc668f445f3584936b326dcfe92bf71971ce16241f4f79db8aeb88d7aab41c
   md5: 10cc05ed51482e1dfcc31dbd13bb34c6
   license: MPL-2.0
   license_family: Other
   size: 138641
   timestamp: 1710764806818
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
   sha256: 512969f339a9a7b347cdb7b88f439819168089867f04732279f02759d8caf24e
   md5: 2009c2ee465fdd74dbd046de73726234
   depends:
@@ -4694,7 +4694,7 @@ packages:
   license_family: Other
   size: 166501
   timestamp: 1707229221324
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
   sha256: 8d26cd4d16545ad8afddd5521bc6894a50d5b8faff3abbe600bb9b062f3c3a0a
   md5: 66eb734b7d7008eb5fb537900767c7ae
   depends:
@@ -4705,7 +4705,7 @@ packages:
   license_family: MIT
   size: 286807
   timestamp: 1714483190838
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
   sha256: df81a27f221d11af4a709f272dc8ba3fd3f6d5ab4ffd883c40567bcf04f0cfd3
   md5: e49333e3ffe1fe2e701f50a6e6dccc52
   depends:
@@ -4714,7 +4714,7 @@ packages:
   license_family: BSD
   size: 204179
   timestamp: 1698129906257
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
   sha256: 53edaca56d853083d44cef6234fe4b3d076d107e915781ce54ec135c25e09f0e
   md5: 5d1d51e53c11bcb56cf863d58e37c077
   depends:
@@ -4723,7 +4723,7 @@ packages:
   license_family: BSD
   size: 50433
   timestamp: 1683040076511
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
   sha256: 808e56fb70f3d38599ee7a54c2a707b282ba9a401fa69a1f54cdc26425d9ce01
   md5: fc37321833175bda4fc5c21afe32db49
   depends:
@@ -4732,7 +4732,7 @@ packages:
   license_family: CC
   size: 539588
   timestamp: 1709758479776
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
   sha256: d9c126d8bcd1c89ea37186c172d6b1f73f45ada60e3ae1790a017b530baa0147
   md5: f0223aae3d622547f6accb212579c58e
   depends:
@@ -4742,7 +4742,7 @@ packages:
   license_family: BSD
   size: 17967
   timestamp: 1709322909223
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
   sha256: 1f908c688e47d03d92ac09d9541a1f1c773ac2ca485dd1d77441b1aaefc032db
   md5: 444c330471496a39a97e87f41ed70c96
   depends:
@@ -4753,7 +4753,7 @@ packages:
   license_family: BSD
   size: 281104
   timestamp: 1700583698464
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.5.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2024.5.0-py311hca03da5_0.tar.bz2
   sha256: 71c289b48cfb6e957d879c3150963cd80654f408e274a9bc816ee6b72d69e912
   md5: fd38d206222a32b3c71718acaf205013
   depends:
@@ -4770,7 +4770,7 @@ packages:
   license_family: BSD
   size: 3103523
   timestamp: 1715838626586
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.16.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/datashader-0.16.0-py311hca03da5_0.tar.bz2
   sha256: 2b7fcd83146c02c4d4b2e2adb2512172536118cb0f630c47a43b11c5005734bf
   md5: 6687cac2611e1868f6ad781167a671c1
   depends:
@@ -4792,7 +4792,7 @@ packages:
   license_family: BSD
   size: 17988386
   timestamp: 1699548972355
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
   sha256: b9356e3ada4872c7c950d2ac7e0f107c4786775191efdfda3a469dffb18f2714
   md5: 07ddd96675caf30ea77cafb1ea5662a4
   depends:
@@ -4802,7 +4802,7 @@ packages:
   license_family: MIT
   size: 2490144
   timestamp: 1690905181398
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
   sha256: b1481ffa475c65200626f051d5dcbdb264730b533e928dde608a79ce7a5b4e48
   md5: aada2761547a291d68f4c016a1a9bc7b
   depends:
@@ -4811,7 +4811,7 @@ packages:
   license_family: MIT
   size: 18265
   timestamp: 1677911915719
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
   sha256: eb82a0e2ca36d0973b5f6642e27609554edad4b72696f989776d5db8cd4a6a42
   md5: fa8d9dd8a2fabba964c6bb75ace8c572
   depends:
@@ -4829,7 +4829,7 @@ packages:
   license_family: MIT
   size: 3201601
   timestamp: 1713551611540
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -4839,7 +4839,7 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.3.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2024.3.1-py311hca03da5_0.tar.bz2
   sha256: aa53d9f23e86ac3398f6b935cea01dcd8a1b1821d9b1d37b16a5ba68a2dbe569
   md5: 2d5841b96988498045c28e3b3951d5ac
   depends:
@@ -4848,7 +4848,7 @@ packages:
   license_family: BSD
   size: 373029
   timestamp: 1714461571346
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
   sha256: 898d10bc1ededb43b7339ccf57fef404d96184de8ebaa788dba0b36a8c8a282d
   md5: a1925e4ff9f6124ca7d439430bc110fb
   depends:
@@ -4865,7 +4865,7 @@ packages:
   license_family: BSD
   size: 5399311
   timestamp: 1707836657705
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
   sha256: 765d5b7ef75ed7f52a110504cd88e9b0c9977b841f1beaeeabb17e629b462908
   md5: 0af9cd26a7c9eb8b77d3cbacb93a118b
   depends:
@@ -4882,7 +4882,7 @@ packages:
   license_family: BSD
   size: 360105
   timestamp: 1715090588763
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
   sha256: 4d4ab70ae0ce008c1cc96a4edfbf3866d5e636acc4799a545ea93acee51635f7
   md5: 86a085a440729020d1d7b0b74d6a0c6c
   depends:
@@ -4891,7 +4891,7 @@ packages:
   license_family: BSD
   size: 148448
   timestamp: 1714398923507
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
   sha256: ec139e4b87aadcacc0670ecbcc2a303d858d4ac38b9404458a4b676bce9d21d5
   md5: bfcfed281f8df0f18726ec5f843b2b26
   depends:
@@ -4901,7 +4901,7 @@ packages:
   license_family: APACHE
   size: 51053
   timestamp: 1704813595720
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
   sha256: 63670c8f31770e1746016f645ca6b42b35f92d1c37e8025793d9490fed9998c0
   md5: 9cb417b9fdf02b4e007a5b5781e5a8cc
   depends:
@@ -4923,7 +4923,7 @@ packages:
   license_family: BSD
   size: 229932
   timestamp: 1705934202146
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
   sha256: a40c76c412ec793ca26b97a9b5c496d253768438e1f7d4a0ee5f63ea79eed355
   md5: f609e4fe044318211cf0e37e289beebd
   depends:
@@ -4940,7 +4940,7 @@ packages:
   license_family: BSD
   size: 1614299
   timestamp: 1704833142734
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
   sha256: e57d10579b52a3cde45aa17e1bdd95dcb9d3346aa00eb02c51e38a42db83e18d
   md5: 05153120787fb09159b6e1ad902c6e10
   depends:
@@ -4950,7 +4950,7 @@ packages:
   license_family: MIT
   size: 1180481
   timestamp: 1678994989550
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
   sha256: 06512ef9a910fa72bf5697fe89e88c605d61f8478a9d8dd233c13f40e30f8446
   md5: cfa00c9ffd3407e29507525c020e5526
   depends:
@@ -4960,14 +4960,14 @@ packages:
   license_family: BSD
   size: 355730
   timestamp: 1706733720706
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
   sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
   md5: 055e12390b844ea6c6e956ee08a618e8
   license: IJG
   license_family: Other
   size: 273479
   timestamp: 1677849171867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
   sha256: 62025ce4a2b9244b9816c9e02487e0dda567600692b5f9ca71f425d084961c7e
   md5: d57b7063122e5bf25cdfc2a5ea7330a8
   depends:
@@ -4980,7 +4980,7 @@ packages:
   license_family: MIT
   size: 181872
   timestamp: 1699041739097
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
   sha256: 404b0847029f77bedd7902a170a046219e0dc5c0ec2be19ff45361cff25b2181
   md5: 3a02bbe8d45fdbcb2350f672be74c9f5
   depends:
@@ -4990,7 +4990,7 @@ packages:
   license_family: MIT
   size: 16524
   timestamp: 1699032463763
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
   sha256: 7deb8ad28c34c369573754304a03ea2acda8ee39102a56526ec689a4d9210109
   md5: 675ea1a746a78ff6bf8fc4b39139efff
   depends:
@@ -5006,7 +5006,7 @@ packages:
   license_family: BSD
   size: 277400
   timestamp: 1677914250715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
   sha256: 8220b1bbdde5e800810f7bf183a992af1a95825a837edf975fa8c4b51c5d806f
   md5: 3a06ddad06e04d5f0211c22cd81ca75a
   depends:
@@ -5017,7 +5017,7 @@ packages:
   license_family: BSD
   size: 94950
   timestamp: 1698937436979
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
   sha256: 8a9a9f9ddbf1b7744ef04a8c862438499a41d81a4beb4a49860156c273bb7497
   md5: 051355801f09eefe850ee8145151f934
   depends:
@@ -5033,7 +5033,7 @@ packages:
   license_family: BSD
   size: 42497
   timestamp: 1699282590553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
   sha256: 65c703cc996a705d0ee350070e313b1cae865f9d6e6490ebf1164c0f3ce22d93
   md5: 305ad8bcaad3e352d61b1e594093b467
   depends:
@@ -5060,7 +5060,7 @@ packages:
   license_family: BSD
   size: 596801
   timestamp: 1699466743685
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
   sha256: 501e929d345aaa9079c965552b942b4e8bde35b87ae89faef003687a40bab3a4
   md5: 54c7b8554a405acd7c8326c41ba93e63
   depends:
@@ -5070,7 +5070,7 @@ packages:
   license_family: BSD
   size: 28237
   timestamp: 1686870817418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
   sha256: 773e7c4571f482a744dfb18ae26fb22635f5d3f51389c838bd97f9044ea55cc4
   md5: 5161546aba5597318cb5653390cdecd8
   depends:
@@ -5082,7 +5082,7 @@ packages:
   license_family: BSD
   size: 20235
   timestamp: 1700168681687
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
   sha256: 8c1c64d51be73aad381992a9df19d8336910bdfc40f19940231df86e177d17cc
   md5: b1f786f96684a143cf30d1f6b8aebdb3
   depends:
@@ -5092,7 +5092,7 @@ packages:
   license_family: BSD
   size: 65045
   timestamp: 1677925371836
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -5102,7 +5102,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -5111,13 +5111,13 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
   sha256: 199042b87451abaf14546af124ae3380194cddda928e0d30ccb341e93084854c
   md5: eaa0442887994a82486c65d87f6b71e6
   license: MIT
   size: 68806
   timestamp: 1714483212137
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
   sha256: bd9a8a17fb14086446b710fa029d238e69274b83ee2e7e09093496f190de82b5
   md5: 66615d6a0cb5dcca3e20c019cde0ed2d
   depends:
@@ -5125,7 +5125,7 @@ packages:
   license: MIT
   size: 32975
   timestamp: 1714483225840
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
   sha256: e1bf77e8b975c30a69b08a08410622e27c8cff6f592ccfa590466b83d9e6d104
   md5: 8af86bdac01fe303d693d9b76c071059
   depends:
@@ -5133,28 +5133,28 @@ packages:
   license: MIT
   size: 310266
   timestamp: 1714483239194
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
   sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
   md5: f31e4eb9cd6447cc2f5ef0243a76540c
   license: MIT
   license_family: MIT
   size: 120460
   timestamp: 1714483461787
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -5163,7 +5163,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -5174,7 +5174,7 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
   sha256: d654027daea13ac9db36ab5fd5eff3ad398ec97c1777bf399f3ec680d2c145b9
   md5: baabb1f905054bfea3af8f5768572a34
   depends:
@@ -5186,7 +5186,7 @@ packages:
   license_family: Apache
   size: 26579907
   timestamp: 1683291669565
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -5197,7 +5197,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -5206,13 +5206,13 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -5229,7 +5229,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
   sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
   md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
   constrains:
@@ -5238,7 +5238,7 @@ packages:
   license_family: BSD
   size: 331675
   timestamp: 1694776939192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
   sha256: 41c62a460bb81a1a272aa28b219fab9c26510adac177ff1528b1980eabc6e868
   md5: 8d312c5628dc7ea833e9b4dcb73e9c45
   depends:
@@ -5248,7 +5248,7 @@ packages:
   license_family: MIT
   size: 42346
   timestamp: 1677973051421
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -5257,7 +5257,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
   sha256: 911c7577f591311bfb000121831234e7bc6332bff62fd00c2245371e67f473c0
   md5: 419681f23f179ba08e5fdf9884ea238d
   depends:
@@ -5268,7 +5268,7 @@ packages:
   license_family: BSD
   size: 410616
   timestamp: 1706910762686
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
   sha256: 5777bbef827f72975a36f3da80ab4af718dc781264f74ad7e3864755d620c0f0
   md5: 4240f1a79b812387919cc710a0469556
   depends:
@@ -5277,7 +5277,7 @@ packages:
   license_family: BSD
   size: 14318
   timestamp: 1677925438733
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
   sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
   md5: f5f7e6e7541d8dc3d3df270d488d2e24
   depends:
@@ -5286,7 +5286,7 @@ packages:
   license_family: BSD
   size: 176990
   timestamp: 1714510588159
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
   sha256: d024f5142416961a5e66e424d4d14aec652f9e9dd738b41a97f45674c2ffc9d5
   md5: 0e2d94b125d802f7b006cf19c71655a1
   depends:
@@ -5295,7 +5295,7 @@ packages:
   license_family: BSD
   size: 163084
   timestamp: 1677932947966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
   sha256: acfd84e29ff4dc2d85543bb973a07f22b4ba53c5d00bca84608ee7f13b2a8676
   md5: 5ca161cd51e2db358e768453b3ee485e
   depends:
@@ -5305,7 +5305,7 @@ packages:
   license_family: MIT
   size: 135871
   timestamp: 1684279980293
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
   sha256: b1bed54c7bfb7304cde9e8e6f798543d08e808e81286a5a48296fc94d621f9da
   md5: 774358285c9e496c9f5c121cc546c823
   depends:
@@ -5316,7 +5316,7 @@ packages:
   license_family: BSD
   size: 27438
   timestamp: 1704206026910
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
   sha256: 9229a6e15abf3147cfcffad4ca389dad940e45779963b4fc3fd56dfdcfca3234
   md5: 4e1897f3cb4923de48c016468c01c051
   depends:
@@ -5337,7 +5337,7 @@ packages:
   license_family: PSF
   size: 9100733
   timestamp: 1713336457304
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
   sha256: 3276d61fc353c537bb09d4b7473d7abe12be38806f42c8cc383b62f40850a5cc
   md5: 6e9c9d47f264b77d9a8461f0899848a7
   depends:
@@ -5347,7 +5347,7 @@ packages:
   license_family: BSD
   size: 20446
   timestamp: 1677918370379
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
   sha256: 43c96d30775b61b4968422a47f9605049428120669f0742bbb9e5ba145c7d11e
   md5: a31ca0d9284860adf5463cf45a5e3145
   depends:
@@ -5357,7 +5357,7 @@ packages:
   license_family: MIT
   size: 69243
   timestamp: 1677995336989
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
   sha256: 96d8c9f42a38651b7bafe5f3cb132601db76cd1e28fa58e2eaf090e634292fff
   md5: 5ebc793a17b6aa84d13f19433545ffa5
   depends:
@@ -5366,7 +5366,7 @@ packages:
   license_family: MIT
   size: 23895
   timestamp: 1677942274932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
   sha256: db9bd659ada23f1ded443d2db00dd13b5d5c0b30f5062544b1ee2c2b88d63d29
   md5: 03c48121614cf12abfe30eced9b34717
   depends:
@@ -5377,7 +5377,7 @@ packages:
   license_family: BSD
   size: 105333
   timestamp: 1677916687032
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
   sha256: 8b05894fdcbe5cfcdee94812b043de4cd7b4fa51d3e2aad25fc7cff50c8f82ab
   md5: c970d49137dce1c77f782ee5725950c1
   depends:
@@ -5387,7 +5387,7 @@ packages:
   license_family: BSD
   size: 30745
   timestamp: 1677960816849
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
   sha256: a8b3d349481dc694eb9a507f55c91e8981e2a3bc41743023ca01248c8a6d779a
   md5: 71e6e29ec3b98fb282c01b012a5df236
   depends:
@@ -5413,7 +5413,7 @@ packages:
   license_family: BSD
   size: 8294656
   timestamp: 1699543119360
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
   sha256: e8eee27fb667aa10b26f3bc4b93f449b7d991ded27b9cb457effee394ce05f6f
   md5: 6a3e5cd0e1141c01ffb91285bdccfe83
   depends:
@@ -5426,7 +5426,7 @@ packages:
   license_family: BSD
   size: 123043
   timestamp: 1698934328890
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
   sha256: 40230434aa2fbb33ece13632e8d4b7cd1ad68fdb8d1b00263af4a010795d25f8
   md5: f12ce7dad3620d6d53a442fa9d36a0b0
   depends:
@@ -5453,7 +5453,7 @@ packages:
   license_family: BSD
   size: 538067
   timestamp: 1699022954841
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
   sha256: a492acec8ceadc0911a75966ffa630a8eb15b2da8c7a8d544a645ba47771a2d1
   md5: 4002b1b88b2ecfdfc769036f43b0a895
   depends:
@@ -5466,14 +5466,14 @@ packages:
   license_family: BSD
   size: 170964
   timestamp: 1694616845237
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
   sha256: 417ace1ce51e81f3f92ddc26e0e3a83c1e19c9ebb7af7104452002a5573da534
   md5: 3e11de6cef096091bb733e07802f00b0
   depends:
@@ -5482,7 +5482,7 @@ packages:
   license_family: BSD
   size: 16979
   timestamp: 1708532698253
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
   sha256: 2e09ae8d10d7e5651727aab66a1e89b59e716295267a8295eaa53760c4c38533
   md5: 8d52be8699bf030546811bb69fbeb2b1
   depends:
@@ -5507,7 +5507,7 @@ packages:
   license_family: BSD
   size: 728383
   timestamp: 1690985022565
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
   sha256: b0cc542e2a6f42ba716e7e4ccf29eddcb155ad167fcdbc72d2db9c7873eb5639
   md5: 7acf81b17d2c4ceb3cd39dc9f173855c
   depends:
@@ -5517,7 +5517,7 @@ packages:
   license_family: BSD
   size: 27539
   timestamp: 1699455954000
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.59.1-py311h7aedaa7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numba-0.59.1-py311h7aedaa7_0.tar.bz2
   sha256: 4e0fb594095ce53c58f97eafc1c113e150929a6935e8ee54d86359cc7a9afd14
   md5: df6c4ead6e4bed95d012bdd5e79f10db
   depends:
@@ -5538,7 +5538,7 @@ packages:
   license_family: BSD
   size: 6062719
   timestamp: 1711988782214
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
   sha256: 151a3eb68d1189e69764ece1d8fb3544d31a22f5bbbc3e19d846de8dece304d2
   md5: eb6609e6bdc9c82d70df3f8c4c2de95b
   depends:
@@ -5549,7 +5549,7 @@ packages:
   license_family: MIT
   size: 153313
   timestamp: 1696515415712
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
   sha256: d3bb1d4be88320a5861cd3a0f086e9709f9b64c96c032cb9039cc4f17ec66a85
   md5: 0a7b97665c06fcd34a70e34abc177280
   depends:
@@ -5562,7 +5562,7 @@ packages:
   license_family: BSD
   size: 11288
   timestamp: 1708639168951
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
   sha256: 3e70248a7069ca12ccf56252869bfdb72211fd4e4c327e6994756496df786c79
   md5: ce4846006d98638cd86a532a72f8dfe4
   depends:
@@ -5576,7 +5576,7 @@ packages:
   license_family: BSD
   size: 7536860
   timestamp: 1708639153133
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
   sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
   md5: 371358a54bbdd307603888348d1a2c6f
   depends:
@@ -5586,7 +5586,7 @@ packages:
   license: BSD 2-Clause
   size: 412248
   timestamp: 1628861367714
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
   sha256: da78bd65c91881856baadf977534832f68db3938c1b5b713c8797be70b83c98c
   md5: f728656890f860eec5ad2899e657df3a
   depends:
@@ -5595,7 +5595,7 @@ packages:
   license_family: Apache
   size: 4763426
   timestamp: 1716318333548
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
   sha256: 77b0c0a0fb14d817390244ebd93c36d44a7867239963f211f7c0a72a3f98d382
   md5: b90336feb8a50d2eff880e89acb02f40
   depends:
@@ -5604,7 +5604,7 @@ packages:
   license_family: APACHE
   size: 39617
   timestamp: 1699371253760
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
   sha256: 4f6c3e8d8fc4c57975cab837ef109b9ee7af4f18aac72668334ac656e53c6edf
   md5: fbf1b507f9a80c5de3c957e8152124da
   depends:
@@ -5613,7 +5613,7 @@ packages:
   license_family: Apache
   size: 159289
   timestamp: 1710807498427
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
   sha256: 3af823879c340838c1040e99f653c3438ccce8dc559bd91c3f4ab2579282a002
   md5: 5b3df01fda0281dab4196bc36d1ca367
   depends:
@@ -5663,7 +5663,7 @@ packages:
   license_family: BSD
   size: 17082645
   timestamp: 1709591689205
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
   sha256: 8bf772501cf4b49a939de17bf378d3e395f452d3070d05871354bd2bc915d012
   md5: 753d2070a2aea47934ecf6ac1ea0bc04
   depends:
@@ -5687,7 +5687,7 @@ packages:
   license_family: BSD
   size: 21901817
   timestamp: 1714071405089
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
   sha256: 67feb8232961ad9d7672a49f6f86f0b86764f62a97d86d58b90ca7e8345bab76
   md5: 3afb6e6747bd29e9483d35dbf8b24f74
   depends:
@@ -5696,7 +5696,7 @@ packages:
   license_family: BSD
   size: 264413
   timestamp: 1711136882294
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
   sha256: 088245becd055af4de74e4ed13cc752ab546423f204b170ba2dd8809af30a2c7
   md5: 2eabea5ccc56ac088e0349626e59df06
   depends:
@@ -5710,7 +5710,7 @@ packages:
   license_family: BSD
   size: 48517
   timestamp: 1698702686783
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
   sha256: 174b680f4bb041e8146aae80f92390122459e0ef8c911cab22d01e2e92d44ab1
   md5: cfffc94779cd26a349bd409b5590b098
   depends:
@@ -5726,7 +5726,7 @@ packages:
   license_family: Other
   size: 916496
   timestamp: 1714399019350
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
   sha256: 102c3c35a9dfa0f10ec8f4a040a24295f9c736443ccae2f685348a44f62a4d68
   md5: 027b347e79e252aa17b534e1a02bccd6
   depends:
@@ -5737,7 +5737,7 @@ packages:
   license_family: MIT
   size: 3447682
   timestamp: 1715097070362
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
   sha256: b6200816d65673aa1707c20a768c9cff87dd8dbe1335f9c1478e5931dfa08ee0
   md5: 14b1e0fa73eb33f9c83048482dcce57b
   depends:
@@ -5746,7 +5746,7 @@ packages:
   license_family: MIT
   size: 38423
   timestamp: 1692205689597
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
   sha256: ebdf211edd98d88a23778551c7a9702106edd0695d4fc48e87c21f77521c1ffe
   md5: d8c505081a468f1b99c62466e2309417
   depends:
@@ -5755,7 +5755,7 @@ packages:
   license_family: Apache
   size: 123084
   timestamp: 1678996822234
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
   sha256: 07cfba50d9e94364bde077731a824ca4f537138b35ee6b66d07aee16ac9850f1
   md5: 919bf486280a11e6acb3c2c3a82f7473
   depends:
@@ -5767,7 +5767,7 @@ packages:
   license_family: BSD
   size: 763225
   timestamp: 1704404463402
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
   sha256: 8094436b2c44e68e72569c704633802aad82e977b1e16026848218679c8becf4
   md5: 2360e46d3e598dd5e2abed781fe166c5
   depends:
@@ -5776,7 +5776,7 @@ packages:
   license_family: BSD
   size: 502115
   timestamp: 1678995719872
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
   sha256: 4f17f70658e32a9a86661184cace6be3bb7bd61f9b55b513092beddf44552679
   md5: 0aa95279688b0433badea0b660ac8146
   depends:
@@ -5788,7 +5788,7 @@ packages:
   license_family: BSD
   size: 38653
   timestamp: 1677933613643
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
   sha256: 121b5b66721760c05f1d4eee91626229d1814663d3fb5f23126ef870aa496e26
   md5: 0c588c2ca790a05d422c06e8568201ad
   depends:
@@ -5797,7 +5797,7 @@ packages:
   license_family: BSD
   size: 2124200
   timestamp: 1684280082141
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
   sha256: 44b694db8e81d61960d28d60f9e9b573f03f7827881d302da334378881db4889
   md5: 6c94ba7caa599ff533e0ab55d898be8a
   depends:
@@ -5806,7 +5806,7 @@ packages:
   license_family: MIT
   size: 208454
   timestamp: 1677910948527
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
   sha256: 0bb3d2a57b332c5cf73ea40ea13c850ae24a1f9a3a41ed9267832d9e3c767572
   md5: 45a7fcf1641980d5114999736428502d
   depends:
@@ -5815,7 +5815,7 @@ packages:
   license_family: BSD
   size: 36755
   timestamp: 1677906514270
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.8-hb885b13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.11.8-hb885b13_0.tar.bz2
   sha256: 7db8bda1ad368413284ee399322d421feb385863426f8ce3167c0eee6788b8d6
   md5: b1b70eac1af7d86cc231d9b695ff1d3e
   depends:
@@ -5834,7 +5834,7 @@ packages:
   license_family: PSF
   size: 16417657
   timestamp: 1708983786954
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
   sha256: c3cbf5bd237b0a7458640191016b2701fe120c547df9afc835da76663a9c17f7
   md5: 843568c76b6b9384635b7fca74c79792
   depends:
@@ -5844,7 +5844,7 @@ packages:
   license_family: BSD
   size: 332222
   timestamp: 1716495881101
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
   sha256: f94b3cfea6f76ea9983e16d3c4c7e0a64f02c40cc2c3ad57189bca2e67030bd9
   md5: 0d100990ade57a02b60d1e8085db0bdf
   depends:
@@ -5853,7 +5853,7 @@ packages:
   license_family: BSD
   size: 280263
   timestamp: 1678996927464
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
   sha256: 252c86f5aef7f8dfce99a260c24cbb35a9adfea144a2acfabb224f516341544f
   md5: 745b888e19a644f48800799f82c01c21
   depends:
@@ -5862,7 +5862,7 @@ packages:
   license_family: BSD
   size: 18539
   timestamp: 1683823925189
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
   sha256: d945744eb133f19ca61325cac5128bdb053ae04de4a0ba6f69c061449cac8af7
   md5: 34baa81490d667381bc7021435b0e1f2
   depends:
@@ -5871,7 +5871,7 @@ packages:
   license_family: MIT
   size: 275858
   timestamp: 1713974457562
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
   sha256: 012585bdb5ae54c2cded50be703734e6dbf418b003635b6f6d7c1e36e7020c30
   md5: da7e99a707bd0cfa20db651b5c068bfd
   depends:
@@ -5883,7 +5883,7 @@ packages:
   license_family: BSD
   size: 65556
   timestamp: 1711136890180
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
   sha256: 4f04a43cbd612ab09cefbdc2e48ee61b51967dad59d859ce0502cc2c46c88fc5
   md5: c68bf65433b2151b51b2e699bc22c501
   depends:
@@ -5893,7 +5893,7 @@ packages:
   license_family: MIT
   size: 194632
   timestamp: 1698096151085
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
   sha256: ae8cdd5be5a7ad19ff82925a035859fafcc5942cd3899d127a508dbb9a235090
   md5: 252a7b997d08bf72f10b3bc2dc68333e
   depends:
@@ -5903,7 +5903,7 @@ packages:
   license_family: Other
   size: 580346
   timestamp: 1709318480624
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -5912,7 +5912,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
   sha256: 7a208abc002a2fc208ae25cb2cf932999a3e4980aa4c9edff315cb9ac62b12ce
   md5: bd22ebd3cff811577ea61f115ba7f4f2
   depends:
@@ -5923,7 +5923,7 @@ packages:
   license_family: MIT
   size: 74744
   timestamp: 1699012126255
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
   sha256: cc8d055a068fe5a7484284c3360d81db61656dd6118c743c740fcc47cd3da379
   md5: e5fad71ef3b99077b79052576e51bf9f
   depends:
@@ -5939,7 +5939,7 @@ packages:
   license_family: Apache
   size: 120672
   timestamp: 1707355664440
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
   sha256: 52368d9b557b8f54ef5ca4bf6cd5a3ec665171f2b2d2082cdd410bab88f4829c
   md5: ac76fb4d2eef3ecdd491cf5d3fb8620d
   depends:
@@ -5949,7 +5949,7 @@ packages:
   license_family: MIT
   size: 10204
   timestamp: 1683077239143
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
   sha256: 491d116c5f54ef340e3bce631835f7138cd1923d7b63e6ca9aa01b48110cb8f9
   md5: 9b81bd8ea808704f5433884b567f1f15
   depends:
@@ -5958,7 +5958,7 @@ packages:
   license_family: MIT
   size: 10557
   timestamp: 1683059079547
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
   sha256: b53a5f6119173d62e4e68a37ea8511c7fc87a00af72953e0048d075a799c7a7a
   md5: 76a16cf4edb9b12b2b96a2d323f060dc
   depends:
@@ -5967,7 +5967,7 @@ packages:
   license_family: MIT
   size: 342535
   timestamp: 1698945991201
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
   sha256: 9e8312f9452357202813aa289430c939302617f562dae9e90fdc3fb5e9be49d0
   md5: def02b749d0c0a3675d96aeb508a2306
   depends:
@@ -5985,7 +5985,7 @@ packages:
   license_family: BSD
   size: 26383719
   timestamp: 1714070280353
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
   sha256: c80d52567084b1caaed2862b77b70065ca17afaf0b020733e9d6c273b4a63e78
   md5: ddf7d88c1967f3f7a4ce1c975fd47e0d
   depends:
@@ -5994,7 +5994,7 @@ packages:
   license_family: BSD
   size: 33321
   timestamp: 1699371225235
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
   sha256: 6d38d171ef87340cf0fbbf4c70217df4826c65400c9290774f5cb35e381e3315
   md5: b9529a812f9862fc89461b6b90f184ba
   depends:
@@ -6003,7 +6003,7 @@ packages:
   license_family: MIT
   size: 1599110
   timestamp: 1715024190898
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
   sha256: cd71091a234874d2826fa063ec5222b3191c9f47e1b5281c352d9df3f31a06bf
   md5: 0db8e29016c6bff026c083d9923a7566
   depends:
@@ -6012,7 +6012,7 @@ packages:
   license_family: Other
   size: 19073
   timestamp: 1705431415504
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
   sha256: 3e18cdafc607c6d7623b1c8f041cbfbb50a27e298f961abdcce7e36834ac39e1
   md5: 9ee0da74c55d0b8d83edf246fd717f20
   depends:
@@ -6021,7 +6021,7 @@ packages:
   license_family: MIT
   size: 89862
   timestamp: 1696347657368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
   sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
   md5: d8c1e9910392d0bcb22a173f9ce30fa6
   depends:
@@ -6033,7 +6033,7 @@ packages:
   license_family: Other
   size: 1758290
   timestamp: 1714488307689
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
   sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
   md5: ae58720a18a2ed15eae214ad7a10d1b5
   depends:
@@ -6042,7 +6042,7 @@ packages:
   license_family: Apache
   size: 140125
   timestamp: 1680167256603
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
   sha256: b5c265e9ed9a1ff2238a09b83bdc1826950faa87fd6b685debe60888de6e7a50
   md5: 5827c8a32317894ce18576e334daba47
   depends:
@@ -6053,7 +6053,7 @@ packages:
   license_family: BSD
   size: 38559
   timestamp: 1677918962258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
   sha256: cfefd86d0f4981d22b7611b3dc60359b8698bf39f2b743cb90b7005aaca88e1e
   md5: a04dbcd6095f6b8f3ad195a78d48b262
   depends:
@@ -6063,7 +6063,7 @@ packages:
   license_family: BSD
   size: 50058
   timestamp: 1677917499177
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
   sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
   md5: 3c25b4f4768ccda28b20a03ba27e7759
   depends:
@@ -6072,7 +6072,7 @@ packages:
   license_family: BSD
   size: 3484151
   timestamp: 1714770744982
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
   sha256: 0836468fafb1f5badbb573922e37200c6929bf2926ecf8d2259dff43811e0727
   md5: 5bc56dcb4bdb7cf623b7cea499feaddb
   depends:
@@ -6081,7 +6081,7 @@ packages:
   license_family: BSD
   size: 136409
   timestamp: 1677925889207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
   sha256: 177246487449f87567fe56c8f20011a4350a132d1556c9f87474d7b2e8c1374f
   md5: d465118217b9f27d47dceff89c2e9f95
   depends:
@@ -6090,7 +6090,7 @@ packages:
   license_family: Apache
   size: 896655
   timestamp: 1696937042980
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
   sha256: 81efb240a49cede5ece3a8ad48f1d9dfdeb56260bf1a20e25ec53cdb202f7c3e
   md5: 81a17d13c75596841b95340a34bbe929
   depends:
@@ -6101,7 +6101,7 @@ packages:
   license_family: MOZILLA
   size: 155516
   timestamp: 1716396017482
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
   sha256: 65e760119352cd85c63d365d2576c09a9ddb060e5b029a265d50bc268eed9290
   md5: 14c241871b12dc3be52e6cd681267caf
   depends:
@@ -6110,7 +6110,7 @@ packages:
   license_family: BSD
   size: 271445
   timestamp: 1677911758960
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
   sha256: 96071e07e807414b7ae5a2fe958ac171e5795576b3a4c2f5e8c643fba43d760f
   md5: a34f2b216e35a37f966883dacda229e2
   depends:
@@ -6120,7 +6120,7 @@ packages:
   license_family: PSF
   size: 9902
   timestamp: 1715268985387
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
   sha256: b20e48aff4c781a52b6be66d77418e768527a621f5fc272ecb34ea03475b2bd7
   md5: 707738432f16f5e63909fcaa6e65850d
   depends:
@@ -6129,7 +6129,7 @@ packages:
   license_family: PSF
   size: 75604
   timestamp: 1715268976065
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
   sha256: 2ea2d0520b330d381a2ab241bdb9ae146ef815ee7c96ee52a9773fb9ae85f4fd
   md5: 66f7f8979cfb2cccffac972d70482130
   depends:
@@ -6138,7 +6138,7 @@ packages:
   license_family: MIT
   size: 12614
   timestamp: 1677963554857
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
   sha256: df7fe7740bd853b641d624e2ec97f1aacb2b82691936a8c04ef18fa9768539c2
   md5: d5c7626d45fd03b22797c18e47812beb
   depends:
@@ -6147,7 +6147,7 @@ packages:
   license_family: Apache
   size: 518048
   timestamp: 1713213046424
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
   sha256: 3fbcccceb4d7d99f60a6e6e013ab84c4532244c42ab9d65b6fdaab6bd30f7269
   md5: 6a7e05872852d4bcde959f7cc8407672
   depends:
@@ -6163,7 +6163,7 @@ packages:
   license_family: MIT
   size: 210307
   timestamp: 1715635933070
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
   sha256: 09738b7f9075386bf062b12ddb6fb72a06450d2481f6b5ca2026c811cd849569
   md5: 9afdec076c95746ac21235f971190e40
   depends:
@@ -6172,7 +6172,7 @@ packages:
   license_family: BSD
   size: 26727
   timestamp: 1677910175964
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
   sha256: b4ced7366de8eb7258f31d516616e70c62ed4a798780e57e208509d2b52ab435
   md5: 65a9a05a726734c1da667f9bd3c78c14
   depends:
@@ -6181,7 +6181,7 @@ packages:
   license_family: Apache
   size: 114733
   timestamp: 1715878377412
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
   sha256: aa301d9e42aadbe3dd5f301ccbf17fbadc347fd37d413c0cbcbd24403892a936
   md5: 77097d17d835a137af7950c628b66150
   depends:
@@ -6190,7 +6190,7 @@ packages:
   license_family: MIT
   size: 137260
   timestamp: 1714717037687
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
   sha256: cf030fc7020dc6d28530075468b8dc1edd843a1e393a2f81ca81c962e9af977b
   md5: cae3fc90233f3af8f433a253d035b6e6
   depends:
@@ -6202,7 +6202,7 @@ packages:
   license_family: Apache
   size: 2470844
   timestamp: 1689041497962
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
   sha256: 2cd108896df65636769e3804ecc2ca421ad9b54e64fa21922bbabe40c90c247a
   md5: b3a1e5077b28f71298d891fbfb5ff03e
   depends:
@@ -6211,20 +6211,20 @@ packages:
   license_family: BSD
   size: 55645
   timestamp: 1677927459979
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
   sha256: 5be8c968f2da5c4bf14f28d63e31b4c1b6993d980023769732c7f58f396c2e0b
   md5: 3f5f62d4e85e3bdd48d39189b01805a6
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 459197
   timestamp: 1714510992914
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
   sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
   md5: 3d57d1adadca9388aaaa1c529b65ba65
   depends:
@@ -6234,7 +6234,7 @@ packages:
   license_family: Other
   size: 322790
   timestamp: 1705602163804
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
   sha256: cf38c69cf62d8f07b91b14bef8e0b6fc5ac220bd3a6cd2ab0378283f0f11494a
   md5: 11660f745caf5eed1d03eafadb32678b
   depends:
@@ -6243,14 +6243,14 @@ packages:
   license_family: MIT
   size: 25470
   timestamp: 1704206932876
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
   sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
   md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
   license: Zlib
   license_family: Other
   size: 104928
   timestamp: 1714510936868
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
   sha256: a3f3eaf240991b6bd7b0596a78d0abb3321cc79db52fa24f6f559189778871c6
   md5: 71f035b4716322539e2461cb6667e946
   depends:
@@ -6262,7 +6262,7 @@ packages:
   license_family: BSD
   size: 825339
   timestamp: 1714678419523
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
   sha256: 6e6787755de0cf2fd776c9681a7b0fd0fb23e35e679a463cc2005b991c413910
   md5: ccad42ec9a2ad48939f089c528abc8f0
   depends:
@@ -6276,7 +6276,7 @@ packages:
   license_family: MIT
   size: 229694
   timestamp: 1706220431719
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
   sha256: f715f7c2e06149bd6d43258e41479d3171efe5e9d56050a0a5f5652ed9d05fff
   md5: 11a8ca43d69881b88f95ae681478866d
   depends:
@@ -6288,7 +6288,7 @@ packages:
   license_family: MIT
   size: 36089
   timestamp: 1676424516042
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
   sha256: 9adabcdd2a10f73fa5ba56adc901eeea2e379991a0d4cb9737eec7aa6b9fc5d8
   md5: fc80b572be85601706d425b21a58d497
   depends:
@@ -6297,7 +6297,7 @@ packages:
   license_family: MIT
   size: 153102
   timestamp: 1695718054194
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
   sha256: 38ccda1553733326d99a75436b4b0f7640bafbbfcdbc33838b0e59cf017de687
   md5: 3f6812578c5e0b3ba0d2a651cc766c15
   depends:
@@ -6307,12 +6307,12 @@ packages:
   license_family: MIT
   size: 266405
   timestamp: 1681493141116
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
   sha256: fe765d810e1612af7a42f34223077f0adc05dbd386b257be24661913d067fe30
   md5: 82e988aba03c8afa03fce78f7442806e
   depends:
@@ -6330,7 +6330,7 @@ packages:
   license_family: BSD
   size: 6086137
   timestamp: 1712084583317
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
   sha256: 5c12a5d7856d9977447360b3a99a5b99818707fe79781ba1779037f11b3fef53
   md5: 6a125ae352306a944aabc635a5fe13a3
   depends:
@@ -6342,7 +6342,7 @@ packages:
   license_family: BSD
   size: 139230
   timestamp: 1707864402762
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 751071782f597f87ed7f67437ef6cc669213902461b9795dd6eb0f4897eddc83
   md5: 5ad8fe62aad5e16cfdf2c5a7d1327fe7
   depends:
@@ -6354,7 +6354,7 @@ packages:
   license: MIT
   size: 19418
   timestamp: 1714483531456
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 9bd62d810867549b9c967c5915f3fa3f66cfbd6ede28b1cc152efd1261285c0a
   md5: 64cc76de3662b62bc8f0e42befd92c5d
   depends:
@@ -6365,7 +6365,7 @@ packages:
   license: MIT
   size: 32178
   timestamp: 1714483513837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
   sha256: 1547fa52134cf06b8d01bdf52114db7db60a89bf35c9c95be5b5a03b13dbd565
   md5: deb765cb7c4b7edc4d126f864f31747c
   depends:
@@ -6375,7 +6375,7 @@ packages:
   license: MIT
   size: 356401
   timestamp: 1714483740924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
   sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
   md5: 11e0af09a31e2d5df51c65a342032b85
   depends:
@@ -6385,14 +6385,14 @@ packages:
   license_family: BSD
   size: 112994
   timestamp: 1714511182837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
   sha256: 73391a74a5300ad3fb063ea0f0c3491d220128a0611a84036da2e23c1e93dc0e
   md5: 501ded4f9b5ed895077802defee912cf
   license: MPL-2.0
   license_family: Other
   size: 171644
   timestamp: 1710764856021
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
   sha256: cd6545642e380b13700f2f2a7a1fb54a273365047bd23108dbd03b197f5c0c9c
   md5: 929edc1c553d2da4d6c6c0745b033cc3
   depends:
@@ -6401,7 +6401,7 @@ packages:
   license_family: Other
   size: 166377
   timestamp: 1707229328635
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
   sha256: 5cb6ac90ad234248f3795945f69b0382397714a52712337b2f86339526b822d8
   md5: b90f3126f6315ea2e8ab242533062557
   depends:
@@ -6413,7 +6413,7 @@ packages:
   license_family: MIT
   size: 302693
   timestamp: 1714483562551
-- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
   sha256: 7153817dd49ec317b519802c7c22c836602e00cbd96d68385e83eaf4c9f5ba6a
   md5: cd829e5997611a602e29fa2fd5882635
   depends:
@@ -6423,7 +6423,7 @@ packages:
   license_family: BSD
   size: 204113
   timestamp: 1698130080270
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
   sha256: 03f00c22b6d92ee55b727b369e8dbdd9a4d590f2655b62b7c45ecd046741858e
   md5: 116f67c13bb0b3caee6cbde334ff6abb
   depends:
@@ -6432,7 +6432,7 @@ packages:
   license_family: BSD
   size: 49934
   timestamp: 1683040303796
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
   sha256: 4099898f02e1f6119fcda65e747c3cbfef0bf563c8855b79a0245160709d5b45
   md5: ab9705c34e67fb8c8faec69d63ff4064
   depends:
@@ -6441,7 +6441,7 @@ packages:
   license_family: BSD
   size: 36410
   timestamp: 1676422341506
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
   sha256: c722f50980d7416ffb2cfc7bf72649307a0bb78c5a24eccefcd049cb61d6b355
   md5: c7c9ff0513ff3c99700919293b702410
   depends:
@@ -6450,7 +6450,7 @@ packages:
   license_family: CC
   size: 543258
   timestamp: 1709758602437
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
   sha256: 8fb3e816a5ad1da05125462dbc9e2a7e933b001a871aa65703802c0a894c6277
   md5: ee4b2fa9fce130496d5c7c86c35a1a05
   depends:
@@ -6460,7 +6460,7 @@ packages:
   license_family: BSD
   size: 17723
   timestamp: 1709323150229
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
   sha256: eeb49cd151ecdccd40062e8123a3b7a9a8a1eda6567dd33ce909ff8ee1a97c89
   md5: b7fe1f7ead1ec2ac642d022942282fc8
   depends:
@@ -6472,7 +6472,7 @@ packages:
   license_family: BSD
   size: 232451
   timestamp: 1700583772701
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.5.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/dask-core-2024.5.0-py311haa95532_0.tar.bz2
   sha256: d4875dbaa16d83af1fc9a05d4d14dfd917f3840fa4d751160f070a7cbaa20230
   md5: e1d44a630a3508b624fcd37e1d7684d1
   depends:
@@ -6489,7 +6489,7 @@ packages:
   license_family: BSD
   size: 3173632
   timestamp: 1715838851049
-- conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.16.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/datashader-0.16.0-py311haa95532_0.tar.bz2
   sha256: 7c57396f00b4d63b1b597ccad75548f6e81f4e2b831c660fe14c6764d62148e8
   md5: 0d1d476cfdb705f2ed6cfe2f6a092ef4
   depends:
@@ -6511,7 +6511,7 @@ packages:
   license_family: BSD
   size: 18023517
   timestamp: 1699544725067
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
   sha256: 5c73f86e575f2ad683ee4a1c2df11020e270edd89d12f11199483d57b0b51826
   md5: e96a12895ce374476277b1b196ba24bd
   depends:
@@ -6522,7 +6522,7 @@ packages:
   license_family: MIT
   size: 3719519
   timestamp: 1690907216785
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
   sha256: 5d5fc8a24c804010b8cb5963227230352ea3ccf56bea9e8116e34f77223218f2
   md5: 8f989a72eed6293dfe0533c83057980d
   depends:
@@ -6531,7 +6531,7 @@ packages:
   license_family: MIT
   size: 17688
   timestamp: 1676423357100
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
   sha256: 27fb03eb57d25711a15e145f47a64320a9955b585efc9fd0a1a51cdd71b9fde3
   md5: eb3869e98f6f53dfec76e2eff4d6b61e
   depends:
@@ -6551,7 +6551,7 @@ packages:
   license_family: MIT
   size: 2732423
   timestamp: 1713552175344
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -6563,7 +6563,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.3.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fsspec-2024.3.1-py311haa95532_0.tar.bz2
   sha256: c906de92968266d481957c5776467523da53b7f4d6daadb63255bd5cefd252c3
   md5: 2710581e3de1c90426c77e4b73185262
   depends:
@@ -6572,7 +6572,7 @@ packages:
   license_family: BSD
   size: 372660
   timestamp: 1714461880258
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
   sha256: 68d59a361a93a5ae36542f667138b4ab072e1abff15b3aa2dc55575baf86a3e9
   md5: 383239566d9506b743c7bc65d709b7e1
   depends:
@@ -6589,7 +6589,7 @@ packages:
   license_family: BSD
   size: 5374020
   timestamp: 1707836834797
-- conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
   sha256: dee3fc68ed81398d232b3afe9a032837bdbef98c1b2478604d6abd397e3e7d64
   md5: 3f75535ca6dfee0745b221922f21f6de
   depends:
@@ -6606,13 +6606,13 @@ packages:
   license_family: BSD
   size: 353312
   timestamp: 1715090519918
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
   sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
   md5: 582d2c1135a89da757a038de831e7f39
   license: Intel proprietary
   size: 11086648
   timestamp: 1664812389803
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
   sha256: 102c803186db6d62eaf41a906f6c563ff0d62b53c1eaede8a381e18c0d005ed9
   md5: 9d30dec03058758a428cf152e0ae28b5
   depends:
@@ -6621,7 +6621,7 @@ packages:
   license_family: BSD
   size: 148193
   timestamp: 1714399061601
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
   sha256: db30abacf919b3f68ae1e6a94c467fd1e69fbf47ba7a86e6b491d8bfe4776f92
   md5: 9299876e7ddc3aea3487fd93340ceae7
   depends:
@@ -6631,7 +6631,7 @@ packages:
   license_family: APACHE
   size: 50842
   timestamp: 1704813715071
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
   sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
   md5: d215cc8ee7ca2cc83cc250cc5d822fe0
   depends:
@@ -6641,7 +6641,7 @@ packages:
   license_family: Proprietary
   size: 3929136
   timestamp: 1699647939158
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
   sha256: 864e9598f64105769b4ec02cc404fb507bc59e217324daf1686c00cfd12c0055
   md5: 6bb1c3be1f85799a3988afc2c3c5a4f0
   depends:
@@ -6662,7 +6662,7 @@ packages:
   license_family: BSD
   size: 229621
   timestamp: 1705934494547
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
   sha256: e0b44f0c3a4ead0fb8e58033c0be25524ee9ecf7f4cc632f03e9f6fac3484baa
   md5: 50cbc18d0c7b42a4553b52d0cef2c857
   depends:
@@ -6679,7 +6679,7 @@ packages:
   license_family: BSD
   size: 1637367
   timestamp: 1704834149957
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
   sha256: d81566367c79a28d4717157fc74293e846a47af99387ed479eb001a425dd398e
   md5: 28c76079c96ad7f8b1a5ed32b438c79a
   depends:
@@ -6689,7 +6689,7 @@ packages:
   license_family: MIT
   size: 1147434
   timestamp: 1679427525584
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
   sha256: f766a445df8e81447f27c830e162566b221fa1bfc41296a6c5e0789586ca1fbf
   md5: 55bc50633414fc8616ccbf4140a42d5f
   depends:
@@ -6699,7 +6699,7 @@ packages:
   license_family: BSD
   size: 353715
   timestamp: 1706733949898
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
   sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
   md5: 81f2c343dc4c65eea39c45383272068f
   depends:
@@ -6709,7 +6709,7 @@ packages:
   license_family: Other
   size: 407861
   timestamp: 1677849239400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
   sha256: 5e6698015a3b048093f5737f0e54bcbae415d0f9682dfdfeae3a8cfb4ea275e2
   md5: 0093a4214131046c4f68af0739dfbea4
   depends:
@@ -6722,7 +6722,7 @@ packages:
   license_family: MIT
   size: 201456
   timestamp: 1699041872445
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
   sha256: 9581be54128954080d7cef448b1728874c2ebbe5064f55adece422cf12eafa5a
   md5: 3adc105f87d5c7f0b1248bc3423f5b48
   depends:
@@ -6732,7 +6732,7 @@ packages:
   license_family: MIT
   size: 16187
   timestamp: 1699032556953
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
   sha256: ad8343bad7c8f0448cbcfbaf872cc94b56da81c52e5cdcee2a5d6b89f029eb75
   md5: addceff8d46c9d1d322618a9ce9e5b39
   depends:
@@ -6748,7 +6748,7 @@ packages:
   license_family: BSD
   size: 300354
   timestamp: 1676424060532
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
   sha256: 851ae576c2b72bf3172cd460feec4f5577dc06476a043e185279071b67549fab
   md5: fae4d214d00de6604738f39acbbb197e
   depends:
@@ -6760,7 +6760,7 @@ packages:
   license_family: BSD
   size: 119710
   timestamp: 1698937651636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
   sha256: d97ad90f9121ecf7f8d3af773b222c0bd244204ee73a3e44185491fa16d83104
   md5: 73ac0fa3c67e5eb283173d74a2771752
   depends:
@@ -6776,7 +6776,7 @@ packages:
   license_family: BSD
   size: 60625
   timestamp: 1699282918176
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
   sha256: 257e1102d2dc3f8b0c1708585c819e86f41abd101084cd0569e8e31652480875
   md5: 2128c6806bba6953e1a275f37e7a295b
   depends:
@@ -6804,7 +6804,7 @@ packages:
   license_family: BSD
   size: 614705
   timestamp: 1699467242943
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
   sha256: 90420847230e72a648417f5f77cebcf7f17b89f70788652c276acc0c440e135f
   md5: ef3d8dee197aa37897bf6d39d2dd878f
   depends:
@@ -6815,7 +6815,7 @@ packages:
   license_family: BSD
   size: 27639
   timestamp: 1686871052174
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
   sha256: 97faaf26ce5254ec3649a8ee7f480b1556e4e8e6e4356d2fab1e6a5532631a0f
   md5: da23bd831c50c877f63038b7e16720ad
   depends:
@@ -6827,7 +6827,7 @@ packages:
   license_family: BSD
   size: 20163
   timestamp: 1700168785472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
   sha256: 8a2f0909fad0387e57cb0e9ee30db2b20761a9106e794381ffeac387a298fb07
   md5: 6058b2efc3284e27aacec2e6e6280433
   depends:
@@ -6838,7 +6838,7 @@ packages:
   license_family: BSD
   size: 62334
   timestamp: 1676432044242
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
   sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
   md5: f5f73266281ab12377d5d47bdf07500a
   depends:
@@ -6850,7 +6850,7 @@ packages:
   license_family: MIT
   size: 905072
   timestamp: 1617648814933
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -6860,7 +6860,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 7c906c94a4d46ea963080a6ba5bd12c1274da66159877a544fbc70291eeed98d
   md5: 45a3d52534fac8aa54a55ee92211a918
   depends:
@@ -6869,7 +6869,7 @@ packages:
   license: MIT
   size: 80216
   timestamp: 1714483371043
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
   sha256: daad7edc6d56abf3e176479e8628162dbf1c56b3d24db30d708aebae694a5214
   md5: e8ecf229f7fcb4c0b76d8613627948f5
   depends:
@@ -6879,7 +6879,7 @@ packages:
   license: MIT
   size: 45189
   timestamp: 1714483420152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 84320217abffa9386186ec8d03b4651bb4b1900d3871adc965a9a9e1d3799907
   md5: 651312fa22168f71f9aec5f9ee2c2fcf
   depends:
@@ -6889,7 +6889,7 @@ packages:
   license: MIT
   size: 756116
   timestamp: 1714483464368
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -6899,7 +6899,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
   sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
   md5: cf949d76148be1e2a534218d9c57df86
   depends:
@@ -6909,7 +6909,7 @@ packages:
   license_family: MIT
   size: 155435
   timestamp: 1714484319443
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -6920,7 +6920,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -6929,7 +6929,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -6946,7 +6946,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
   sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
   md5: b1781519a200ccbfcb4a1194005aa3ef
   depends:
@@ -6958,7 +6958,7 @@ packages:
   license_family: BSD
   size: 338459
   timestamp: 1694777084290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
   sha256: 4534c822511a052a72c2b070a05e5d8d6f3550f18ea00a33f9d8a9a92b4382cc
   md5: 82f24e7660831445a2183216e280a6a4
   depends:
@@ -6968,7 +6968,7 @@ packages:
   license_family: MIT
   size: 41464
   timestamp: 1676474474981
-- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
   sha256: b2b50fb4e43e4c4da8db26cf362671e03774384732e1925d82e12dfce45c5ac3
   md5: 44ff317b1ff9bd2b1fbf39da56965b16
   depends:
@@ -6980,7 +6980,7 @@ packages:
   license_family: BSD
   size: 20842990
   timestamp: 1706911120234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
   sha256: 896b7a39bd4ad3621312130122b4fe84dcb67d7355166255c58ea9bc562eb0ae
   md5: 640b852a56296f48cf073e61a59c5256
   depends:
@@ -6989,7 +6989,7 @@ packages:
   license_family: BSD
   size: 13751
   timestamp: 1676428354074
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
   sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
   md5: 320f40b75d93f3b96931c6d13c23946c
   depends:
@@ -6999,7 +6999,7 @@ packages:
   license_family: BSD
   size: 158902
   timestamp: 1714512129889
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
   sha256: e0dc6e119b224bb31ef34b6ba270ffadc181d38b698c5318de8df7a5d2c4ccbd
   md5: 992ccd756f09408f0b74dfb9852a8b7f
   depends:
@@ -7008,7 +7008,7 @@ packages:
   license_family: BSD
   size: 182381
   timestamp: 1676437963591
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
   sha256: 050b5fd4b28132d8102a7e6b40179894dc7f5e41f7ad9ee19211e67446c5740f
   md5: 3ae0b2f6baec708554648ddafa81b756
   depends:
@@ -7018,7 +7018,7 @@ packages:
   license_family: MIT
   size: 154386
   timestamp: 1684279992864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
   sha256: 8269c73b7a9c03b95a121e318d0468f35eecc016093620b0560f35238cc5df51
   md5: 2914bea0ae29315f998e1abac79ccaa8
   depends:
@@ -7031,7 +7031,7 @@ packages:
   license_family: BSD
   size: 30214
   timestamp: 1704206218108
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
   sha256: 68fb7d113dbf185b571343847e3dbefdbe7d0b9b5902f1f390bc2a6e33a3f8ee
   md5: a72ff718390a1fde0b208a43e6b9b655
   depends:
@@ -7053,7 +7053,7 @@ packages:
   license_family: PSF
   size: 11366001
   timestamp: 1713336740870
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
   sha256: 43279276850eb6e621812448cddc1093524cee0b7f8ed58b4600b68a4fb659f2
   md5: 5968b2b5c1f3cf5c8c8c9aaa4d8d66a2
   depends:
@@ -7063,7 +7063,7 @@ packages:
   license_family: BSD
   size: 19886
   timestamp: 1676425829787
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
   sha256: 3062a8254ca351b54f15bea85cc928a3ba4d879bb98ce97ece39a9f7eca215a5
   md5: 8f1565663abb34ad7fdd512e76da5532
   depends:
@@ -7073,7 +7073,7 @@ packages:
   license_family: MIT
   size: 68031
   timestamp: 1676481862508
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
   sha256: cdff5215c292fe59649ca40ca72f5d26da352760c1d6a56feba14eb13f7bbf61
   md5: e0f3f32b22135dfeaec277bc87183ca9
   depends:
@@ -7082,7 +7082,7 @@ packages:
   license_family: MIT
   size: 23328
   timestamp: 1676442709081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
   sha256: 3b173a25605d2aaacc57ec0e425f1d1c51327eb2521c8742a736e2c76069bc8d
   md5: 169f1c93a443f95a88665f3008623ce1
   depends:
@@ -7093,7 +7093,7 @@ packages:
   license_family: BSD
   size: 104882
   timestamp: 1676425142412
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
   sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
   md5: 527155127b9fada5e5c5c69a624674b9
   depends:
@@ -7105,7 +7105,7 @@ packages:
   license_family: Proprietary
   size: 187498166
   timestamp: 1699648376430
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
   sha256: cea59ae60da314caecf08edb9bcb03126c6dd35837c8184bceaa194decca3341
   md5: 30936b7263cf0171f7c86400f12ef184
   depends:
@@ -7117,7 +7117,7 @@ packages:
   license_family: BSD
   size: 49080
   timestamp: 1682975093455
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
   sha256: 5070ceb0a406b1b8b99e2ec58f5d224cbe16ec78109c46720bd182b509e05c6e
   md5: 34de1af5c639f2d06c6c8d99488e4226
   depends:
@@ -7132,7 +7132,7 @@ packages:
   license_family: BSD
   size: 196201
   timestamp: 1695058367111
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
   sha256: 6b4b27302e458fa527321c59be7c335d61f86da7501c4d141db20a72fad68b55
   md5: 7db9b12da1290bb2c2fc6ee52a945905
   depends:
@@ -7147,7 +7147,7 @@ packages:
   license_family: BSD
   size: 256371
   timestamp: 1695060425702
-- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
   sha256: 39f09c1bc57b4800ebda331eddb462928435498705351b0432d51a4293294ad8
   md5: 5565984a02f41e97cb9a4c9126ced14b
   depends:
@@ -7157,7 +7157,7 @@ packages:
   license_family: BSD
   size: 29808
   timestamp: 1676442800892
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
   sha256: 5422fc4dc6708279223027e45dd1ccffe4dc2feb93c60c8a683946a398c60a1c
   md5: 62d16437707dd382c21a9ed1d8b375dc
   depends:
@@ -7183,7 +7183,7 @@ packages:
   license_family: BSD
   size: 8304222
   timestamp: 1699543942441
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
   sha256: e940f9178ee2fa0a7c12873ae35ebea0074371653e5cfa1be8aa8d9271fd343b
   md5: 355d0835215911738a28010dfa6aa382
   depends:
@@ -7196,7 +7196,7 @@ packages:
   license_family: BSD
   size: 141785
   timestamp: 1698934346590
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
   sha256: 47dd00c0179f4eb29c70d0453d340f7f5332af326b3d51c64ca3bf6a14be8e7e
   md5: f66afe718bdb57667b03ebda4cb2ac7e
   depends:
@@ -7223,7 +7223,7 @@ packages:
   license_family: BSD
   size: 561655
   timestamp: 1699023338436
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
   sha256: 4ee863a1ff697274c642b3101f82b279a354e3f033a87505655039f89127bb41
   md5: bfaf19be6644ad2344e118aa0acccb13
   depends:
@@ -7236,7 +7236,7 @@ packages:
   license_family: BSD
   size: 189809
   timestamp: 1694617194065
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
   sha256: 90fb3f14c49da1397982eae21cd09e8d60d491d76f94c57590c56723fe6dc172
   md5: 46a523661fe5c1bce7b4213fd428c3de
   depends:
@@ -7245,7 +7245,7 @@ packages:
   license_family: BSD
   size: 16732
   timestamp: 1708532795328
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
   sha256: 5db3fd8b4d97e2a6232e2f7c62f1ce82ae3876326aed9f8c3ea656eda83e55da
   md5: 39c36df9dac13398e8a54497dcc14611
   depends:
@@ -7270,7 +7270,7 @@ packages:
   license_family: BSD
   size: 755697
   timestamp: 1690986137327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
   sha256: e040ebcab948325fbe17e4ab15be62e1fafa7bad225457e59764adb60eb40db5
   md5: 4d40a09df8cb74a9f044eab317436d67
   depends:
@@ -7280,7 +7280,7 @@ packages:
   license_family: BSD
   size: 27282
   timestamp: 1699456187703
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.59.1-py311hf62ec03_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numba-0.59.1-py311hf62ec03_0.tar.bz2
   sha256: a20cb730d87b945125202c7f4e81490c24db708f373d1214e6b04f5d2b4177b3
   md5: a235c61c1928d09080158ffd42ffbccc
   depends:
@@ -7301,7 +7301,7 @@ packages:
   license_family: BSD
   size: 6100005
   timestamp: 1712021687877
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
   sha256: d3bd2a6614bb7e7f5ce3348d6674e71cce45cbde236beff32f0f08cd95a64ef0
   md5: e70f15643164f432d1df68635e7c322b
   depends:
@@ -7316,7 +7316,7 @@ packages:
   license_family: MIT
   size: 162691
   timestamp: 1696515822068
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
   sha256: 470fe9a0b3e196fa60d5550d8188f6074a207572fa0d353a4448d580872e7804
   md5: 6fdb8df0613fb2fb9f1732d335fa25f1
   depends:
@@ -7333,7 +7333,7 @@ packages:
   license_family: BSD
   size: 11053
   timestamp: 1708641901110
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
   sha256: 222c1711e7cf151e29077c7d4d86a865c9fd39615812d58a1daca6fd1b6bdfb5
   md5: 585bcd8bc3940a8a859f38ebafdcd77d
   depends:
@@ -7349,7 +7349,7 @@ packages:
   license_family: BSD
   size: 10723862
   timestamp: 1708641867155
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
   sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
   md5: ab07e2a27ac08afe3d0b4c0890b8486a
   depends:
@@ -7360,7 +7360,7 @@ packages:
   license: BSD 2-Clause
   size: 249316
   timestamp: 1630094024143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
   sha256: c8e066c2cb547914401ec29b7356914ca3cdf6ac37eead248fe0c41236a7838c
   md5: 5879739cc77497a518b2ebd55857183b
   depends:
@@ -7371,7 +7371,7 @@ packages:
   license_family: Apache
   size: 8118619
   timestamp: 1716319803768
-- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
   sha256: b2f5f50a1ddf811102636f3acebd76716c88ebb628754b91eda7a3a962adf26c
   md5: 712527b4d84c350dca4b67f511c04414
   depends:
@@ -7380,7 +7380,7 @@ packages:
   license_family: APACHE
   size: 39421
   timestamp: 1699371341381
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
   sha256: 432b8b7c4671878cbbe361e518544203f97bd2e4f24fa08cf65e8be583f25529
   md5: e62e7c668b080e0f6ce09fd548f69f7f
   depends:
@@ -7389,7 +7389,7 @@ packages:
   license_family: Apache
   size: 159066
   timestamp: 1710809127954
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
   sha256: 3ae55d8148580fc3f171c0fcc420488fbba05517cefd358fe013b45ec3594371
   md5: bfb42ed6826a1c8cded9539fc6e07029
   depends:
@@ -7440,7 +7440,7 @@ packages:
   license_family: BSD
   size: 16924671
   timestamp: 1709591125871
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
   sha256: b529eac4abff05f13760c51ad37adf24e744109a6fb30471b26dc1f6a1c23847
   md5: b690cc140a7866280131762a26c05f39
   depends:
@@ -7464,7 +7464,7 @@ packages:
   license_family: BSD
   size: 21902721
   timestamp: 1714073654508
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
   sha256: e77795e1af9bc27d45841d6b9c51e0e7da31e0eabaaffa99162245adc55d13a3
   md5: 14046398ac44f496bc9df300285ec586
   depends:
@@ -7473,7 +7473,7 @@ packages:
   license_family: BSD
   size: 267222
   timestamp: 1711137058994
-- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
   sha256: b0d7fbfcf1c5c682ed9934eb6a33e00a2517941f2bcb9d677379f4bb73b2c45c
   md5: 20c8f36595a48f5cda2f4f74c02a3ea2
   depends:
@@ -7487,7 +7487,7 @@ packages:
   license_family: BSD
   size: 48206
   timestamp: 1698702818841
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
   sha256: 6ca54ba8ce430caa8a1838b19869814d0b7fa3592a77f75298130983e635387b
   md5: e56c194e56d19dd8fd76f75a77f92c33
   depends:
@@ -7505,7 +7505,7 @@ packages:
   license_family: Other
   size: 1070844
   timestamp: 1714399290671
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
   sha256: 15001c7ee6cf6e0ef7afc2f313114f6103e7b6f641fac9a6899ee02d6537c822
   md5: 250ba95e77f5fcb3fe2aefa85157e859
   depends:
@@ -7516,7 +7516,7 @@ packages:
   license_family: MIT
   size: 3759346
   timestamp: 1715097175495
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
   sha256: e5f8cbfb5fc25d460a9117bfc5511959c5e86ccb193316033f87bd516e0c8881
   md5: 9f7e8b5eb651539386bb92c14e5c321b
   depends:
@@ -7525,7 +7525,7 @@ packages:
   license_family: MIT
   size: 37730
   timestamp: 1692205554840
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
   sha256: 6c5b53831273674361437fb546e08315fc11ca9275a174bca3887987e86ced5a
   md5: f8d91daf5173eb03157f484389adcdd4
   depends:
@@ -7534,7 +7534,7 @@ packages:
   license_family: Apache
   size: 122178
   timestamp: 1679591983138
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
   sha256: 546819d922b03f3a25ca9f98fd069d0588d481fc0603c6d74bd598fb6a93687f
   md5: 86c18e3e0b67ee099457475ed6caf2e6
   depends:
@@ -7546,7 +7546,7 @@ packages:
   license_family: BSD
   size: 751763
   timestamp: 1704404627180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
   sha256: ae06f0dfa2cfae51404afc6d6ad3a474a93015b5ba9a7d3ea24224b8e7547987
   md5: 3e19794c806cc3e84a3080a97c359b75
   depends:
@@ -7557,7 +7557,7 @@ packages:
   license_family: BSD
   size: 510466
   timestamp: 1679005998612
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
   sha256: e2af1efb1a5094a5962d93fa949ecab479a2ae7570e030f52eeac6761383c208
   md5: 4cb1359e22ddf8f3996afddce5f6205c
   depends:
@@ -7569,7 +7569,7 @@ packages:
   license_family: BSD
   size: 56638
   timestamp: 1676438592117
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
   sha256: d95c88d06f4f3f667bd9a39e5f18179e83b3cd4c115c06ce0fff390ff6d3a700
   md5: c6d00a8a4d89b1be99bfa3aff19d96b4
   depends:
@@ -7578,7 +7578,7 @@ packages:
   license_family: BSD
   size: 2134881
   timestamp: 1684280285492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
   sha256: 643a9a0eba1e2bd5980d21623d3b35188c24781ec251acc4d15714bd1ccb4c17
   md5: b3cda0394db05be6f0f6176abacb13f3
   depends:
@@ -7587,7 +7587,7 @@ packages:
   license_family: MIT
   size: 207985
   timestamp: 1678721438358
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
   sha256: 974c22de09078bf07c5db31fe12d8d89d6433508defc8237cbe52e08c69ed56b
   md5: 9cf10bfd49140a527cf4b1d912097e6d
   depends:
@@ -7597,7 +7597,7 @@ packages:
   license_family: BSD
   size: 36072
   timestamp: 1676426019064
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.8-he1021f5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.11.8-he1021f5_0.tar.bz2
   sha256: 1c557d91837e0205cd08180b604da06f28d7679df1ea1026e7954add3eb4d468
   md5: 3901bef86daffeb6ff2317543b292766
   depends:
@@ -7618,7 +7618,7 @@ packages:
   license_family: PSF
   size: 19539055
   timestamp: 1708983524626
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
   sha256: 2c61639b3bb56fc864c86558bceb7845b1731ac44bf1a94894172ea47a995bd4
   md5: 404805e547b4d50b5cd17e16bca87527
   depends:
@@ -7628,7 +7628,7 @@ packages:
   license_family: BSD
   size: 332043
   timestamp: 1716495838826
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
   sha256: 9acb33db60d9319595f52337cae3b88c2a2338cd66f1f9d8ae86d0a993c2067a
   md5: f4af8cf94d042b4dde487241bba1c457
   depends:
@@ -7637,7 +7637,7 @@ packages:
   license_family: BSD
   size: 279780
   timestamp: 1679500609851
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
   sha256: 48fe7373b012b51134b6b6ff67f18d2b4aae3a5c7700e4560ce002af7172f064
   md5: 0379cd17692152c12b662b0e4ea46b88
   depends:
@@ -7646,7 +7646,7 @@ packages:
   license_family: BSD
   size: 18008
   timestamp: 1683824373128
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
   sha256: 803274d986d0c4e3b5ec1018747ede86ef57137455b3e44a60e834717eafb92b
   md5: c9f134ddeff6fdf0373a45534ddb7079
   depends:
@@ -7655,7 +7655,7 @@ packages:
   license_family: MIT
   size: 273009
   timestamp: 1713974722039
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
   sha256: 6fbcba97c1dcb5157afd23f264c3cff069c7e4be5ea55980fc349eb8dc2cb49e
   md5: 8153e3f8b3283926bcf9403804a365f5
   depends:
@@ -7667,7 +7667,7 @@ packages:
   license_family: BSD
   size: 65050
   timestamp: 1711137009299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
   sha256: cd33dfee104dfbba4af38d06a09ccbae6a32e7c543afedab523303319ebb283d
   md5: 3dfc19af0306d80921e1403f1f551bba
   depends:
@@ -7677,7 +7677,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13679916
   timestamp: 1676423267293
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
   sha256: 102ff1d958209e3648bb49da3503cf752abab822011fdc4e12e88145c9e73772
   md5: 0553c2c381b6f5c836b23edc8c6db2ba
   depends:
@@ -7689,7 +7689,7 @@ packages:
   license_family: MIT
   size: 246689
   timestamp: 1677708371873
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
   sha256: bee5c4d0f41f06a9c0aac636885e36e8b81116aafde980f9ea48fdb64abb5567
   md5: 6c05a053240cb90765d6f8c2efdf905e
   depends:
@@ -7701,7 +7701,7 @@ packages:
   license_family: MIT
   size: 182228
   timestamp: 1698096268270
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
   sha256: ea39db411361d96545a04fb976940e9590147acb4ca9caacf7e8264780379347
   md5: b411b8be8e53e5059949dde02dd07faf
   depends:
@@ -7713,7 +7713,7 @@ packages:
   license_family: Other
   size: 565148
   timestamp: 1709319072176
-- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
   sha256: 47653b45a5f2d97b5bf0dbf0e620908880f9078da427eef69012effe3f19af67
   md5: 44e709ae67d89bccee2d4d46d358fee3
   depends:
@@ -7724,7 +7724,7 @@ packages:
   license_family: MIT
   size: 74493
   timestamp: 1699012356534
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
   sha256: d7bcba5262df162756885a773c3bf2dace27311bbbb1830a0f97aa60ac7c1239
   md5: daeb99ccfe39f725278203412aac0873
   depends:
@@ -7740,7 +7740,7 @@ packages:
   license_family: Apache
   size: 120468
   timestamp: 1707355917958
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
   sha256: d6daaa6b45272819176e4aeb467ae00e3db43386548464a9993688f292709d40
   md5: 9fe721d7f7420c259df4f07d4503f654
   depends:
@@ -7750,7 +7750,7 @@ packages:
   license_family: MIT
   size: 9683
   timestamp: 1683077110211
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
   sha256: 6051860575f9448aea5799d74469c928cd7cdeeca1eb53657872262a77b1a7a8
   md5: 60e193eca497130034facd5fed168249
   depends:
@@ -7759,7 +7759,7 @@ packages:
   license_family: MIT
   size: 10094
   timestamp: 1683059114376
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
   sha256: ecd310461c1b45ab92ddf15539cea5a6e837860561c974d2d7393f9a7933f116
   md5: 1762fec2838763e904141167e18b0389
   depends:
@@ -7770,7 +7770,7 @@ packages:
   license_family: MIT
   size: 215600
   timestamp: 1698947891859
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
   sha256: 0042fa2dc2ec8c2181f28f5ee4f45087ea58dca7acc6b89c48f3ce6eac8f9bdd
   md5: 755c9767608b233b94ec3a67c8e0da4b
   depends:
@@ -7788,7 +7788,7 @@ packages:
   license_family: BSD
   size: 32418527
   timestamp: 1714081783418
-- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
   sha256: 6fd52bae6360fbc8135d72e0c1e4fd407769fa4d0f4b59356e7aed3e000eb339
   md5: 49fd52885250da8aab17ed72e2e18b81
   depends:
@@ -7797,7 +7797,7 @@ packages:
   license_family: BSD
   size: 88901
   timestamp: 1699371435766
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
   sha256: a2ec4690bc07be9e7f3ad8e3003803eb4304a434d3f139633e2817318a9f7b20
   md5: dd2d225219924fc5c36598c919541271
   depends:
@@ -7806,7 +7806,7 @@ packages:
   license_family: MIT
   size: 1593050
   timestamp: 1715025622141
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
   sha256: 5d1b7e14dc04816692de0f8518ea8fcbefb26ab61cec83f96f2c44c1bee67fab
   md5: 505d2a70a875b5082dc857aa4dfab0d4
   depends:
@@ -7815,7 +7815,7 @@ packages:
   license_family: Other
   size: 18830
   timestamp: 1705431395254
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
   sha256: 5ff3b4ac3fbce4dd67a87856c04698d0397deb0ac288ff4e7eb02fbab57f1253
   md5: 0ca650a7001c6650809d3361de8cb005
   depends:
@@ -7824,7 +7824,7 @@ packages:
   license_family: MIT
   size: 89590
   timestamp: 1696347858925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
   sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
   md5: 833b93a2daade3407898f15588945d83
   depends:
@@ -7834,7 +7834,7 @@ packages:
   license_family: Other
   size: 1440481
   timestamp: 1714488344682
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -7844,7 +7844,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
   sha256: 78d89b50a29fbeb19a562f5dad95615e3f192bb4f3b86cd6ea75f2f825418232
   md5: 4a4040df560ea47704e0898c4c015808
   depends:
@@ -7855,7 +7855,7 @@ packages:
   license_family: BSD
   size: 38069
   timestamp: 1678228553220
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
   sha256: 70a3cc4a4e81a6421bc19cd410d1d6064aadb2b1cce38b020f85e5346716d8e7
   md5: 32a9a2539579a3d522dce3b5cb4f987b
   depends:
@@ -7865,7 +7865,7 @@ packages:
   license_family: BSD
   size: 49495
   timestamp: 1676425411739
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
   sha256: 0a95736cfd0bb25fc201cd6be4a2450ea8fc30eeb349d861812675b84c94fa74
   md5: a8a9fb30c6dd8e7a16d5dcd2333c3c49
   depends:
@@ -7876,7 +7876,7 @@ packages:
   license_family: BSD
   size: 3844176
   timestamp: 1714770894235
-- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
   sha256: ed5950ac0c12cc87f991a6f28112cf29057e2b7ad416ae4429a0b97c3efaf58c
   md5: b5e2a04879e6fd19f0eb5effded4dc61
   depends:
@@ -7885,7 +7885,7 @@ packages:
   license_family: BSD
   size: 135939
   timestamp: 1676431438808
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
   sha256: 4febf30c11674711b86c8c10da46a5e1613071388da999210912a31508864add
   md5: 1c109fc1112ea1f5f377bdf0d18ba75f
   depends:
@@ -7896,7 +7896,7 @@ packages:
   license_family: Apache
   size: 895633
   timestamp: 1696937216859
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
   sha256: 973dc7991dd5976ce2d27a94739712cac4d31f2d2958fbf23adb844f5ac999c8
   md5: ca74b36907b3f4f8a51bd5b2e4d8220b
   depends:
@@ -7908,7 +7908,7 @@ packages:
   license_family: MOZILLA
   size: 186541
   timestamp: 1716396206048
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
   sha256: e8c77efe880546252f244f995cbed5967809555127b4f818b97455d434b23415
   md5: 7397ac07045115960ebd8dec95326a7a
   depends:
@@ -7917,7 +7917,7 @@ packages:
   license_family: BSD
   size: 270819
   timestamp: 1676423321499
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
   sha256: ab3cce654f1e94793fff0cb03b750d9b20cdbf099263b1906c3c5eaf8b347ab6
   md5: c68ffc771312afb6f88b94c24d2bb689
   depends:
@@ -7927,7 +7927,7 @@ packages:
   license_family: PSF
   size: 9706
   timestamp: 1715268972001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
   sha256: 4089efea1753ebe2f6617b46cc368738f285b1d816d4a4f01ba71524f46851b4
   md5: 7f610528ecd0b317180efa2058c32323
   depends:
@@ -7936,7 +7936,7 @@ packages:
   license_family: PSF
   size: 75414
   timestamp: 1715268958140
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
   sha256: d091897f05318c22ca31028370f25355065999078f7db6f88ab27bf4cb030ec8
   md5: 1776502c1cfb351554eeda6cddaf255f
   depends:
@@ -7945,7 +7945,7 @@ packages:
   license_family: MIT
   size: 11588
   timestamp: 1676457729096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
   sha256: c16498f8238cc331618720d078b87995eceb6bbf20268a7a4e8efbf7b5859a9a
   md5: 770432c0ca1ab9d99ffe95e51d3a3e74
   depends:
@@ -7956,7 +7956,7 @@ packages:
   license_family: Apache
   size: 517433
   timestamp: 1713213261710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
   sha256: 3009bd4e7e8126309e606c81cb75d4b8d4fbb2bceac10ec43f7eb6eaaf717ac2
   md5: ee6e87af42008a762d3531771c1a2b18
   depends:
@@ -7972,7 +7972,7 @@ packages:
   license_family: MIT
   size: 210034
   timestamp: 1715636431813
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
   sha256: 906048f3b1dc326b367a08edc91816ff523b5f06cd45d985b4dbb7cfe8017559
   md5: e509c495aaa92d767d554cd43a990ee5
   depends:
@@ -7981,12 +7981,12 @@ packages:
   license_family: BSD
   size: 8900
   timestamp: 1715797316229
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
   sha256: ab224d078734a23527716388ddffc034d18254843881d0fc068c2efa35bacfe1
   md5: 73f5831d017e5572330d2459844718f3
   size: 2246565
   timestamp: 1715797302913
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
   sha256: 24ea3d3e0cb98d0d246338dbb4562b67967bb32002e3704e495a5c863476e831
   md5: c7b9cdbe87b3c9720aeca1164a0fd6df
   depends:
@@ -7995,7 +7995,7 @@ packages:
   license_family: BSD
   size: 26181
   timestamp: 1676424437003
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
   sha256: 92d27e41ce34387e59acb47572fcb2e92c4defaeadafd11ce190226022023e69
   md5: f1bf142d852987acbe4b0bc94e87d958
   depends:
@@ -8004,7 +8004,7 @@ packages:
   license_family: Apache
   size: 145306
   timestamp: 1715878654770
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
   sha256: 1b086d1b079fdb2f148c7dd82658f2b7f283c88f286e1216c0f1237319039b0f
   md5: 299e87f151a549d86a48bf24df15c607
   depends:
@@ -8013,7 +8013,7 @@ packages:
   license_family: MIT
   size: 168041
   timestamp: 1714717238470
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
   sha256: 17fadf35aa8917c107e7b369e9364ac7c09537776e7943d37e225e14b7026c94
   md5: 0e67c3b9624540581b894b11267a837b
   depends:
@@ -8021,13 +8021,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 10197
   timestamp: 1676425485716
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
   sha256: 25373efabba9a866849fe38a47c79e0fa323851b4bd4b5df357cc8d5617c2786
   md5: a958e9d32c3b65c21e11e5d9e8491c43
   depends:
@@ -8039,7 +8039,7 @@ packages:
   license_family: Apache
   size: 2467966
   timestamp: 1689041676824
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
   sha256: b849b368e27920838fe40a512b102879693a55cb187dd1c8d3a83fa8c05a8054
   md5: 7b1f6e9c71906a93039b3446b99a5498
   depends:
@@ -8048,7 +8048,7 @@ packages:
   license_family: BSD
   size: 55114
   timestamp: 1676434863173
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
   sha256: 344a5276a9928638dcde054dfe4e87c8cb40bd2d4d356378b9ab2f863ca62e4b
   md5: fe471fd8b5a3d77be6fa5dbf9b99dafb
   depends:
@@ -8058,7 +8058,7 @@ packages:
   license_family: GPL2
   size: 1432281
   timestamp: 1714515119689
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -8067,7 +8067,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
   sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
   md5: e5aed81295b61b6d1eb62830799a0297
   depends:
@@ -8078,7 +8078,7 @@ packages:
   license_family: Other
   size: 9125184
   timestamp: 1705602328351
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
   sha256: d932439798665be388bbf68f3d68da5b42ed4753a43587d3f49848a85f58add4
   md5: e2900345674e644e05540ffac6acca89
   depends:
@@ -8087,7 +8087,7 @@ packages:
   license_family: MIT
   size: 25247
   timestamp: 1704207149955
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
   sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
   md5: f295b54ab59f5b8658e2a322ac6aa721
   depends:
@@ -8097,7 +8097,7 @@ packages:
   license_family: Other
   size: 162161
   timestamp: 1714514792081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
   sha256: b2ff66b7f6efa0831f939e57e562c244332b690af08818a540d1a97fa07d8525
   md5: e548d528873d9a0006a36714cf36462a
   depends:

--- a/attractors/pixi.lock
+++ b/attractors/pixi.lock
@@ -1,0 +1,8112 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.16.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.3.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.59.1-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.8-h955ad1f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2024.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.16.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.3.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.59.1-py311hdb55bb0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.8-hf27a42d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.16.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.3.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.59.1-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.8-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.5.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.16.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.3.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.59.1-py311hf62ec03_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.8-he1021f5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+  sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
+  md5: 613805add1c05b538ff06d217252feb7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 20810
+  timestamp: 1652859733309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+  sha256: 250f50edf43a786a32942e9ae67ce807e9b3ac4cb6b58b1170cb541fb24e391f
+  md5: b48058294499d292ddf9a3b966dc9cc5
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 228473
+  timestamp: 1706220559474
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+  sha256: 0d4f5274503916e1c683dcc16e8a7c4186557afa3f62399cd628e4eb535fe77a
+  md5: 062acdb0f9ae976c25c2d15d589dc1d6
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 35809
+  timestamp: 1676823571351
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+  sha256: 567dfdd5b986012421a736a5f1c1d5874d8d691dd483c838b55e1ab06c0b217d
+  md5: 4e0aa1543f546b898523382ee8405e84
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 152577
+  timestamp: 1695717917074
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+  sha256: 894fceb5b4f8740bcd146de8bd0f6eabf14e2407b149b790b4983b8432681e6b
+  md5: 2f0ef211bf628cd22bbfa44c3f9bc035
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 271600
+  timestamp: 1681493103694
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
+  sha256: 9f027f156744dcbf28945aad6e422ef030c84c2a5d40116d3e40407c66853bf8
+  md5: 7b52489e04f9a5585643d5578835fc68
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6059952
+  timestamp: 1712084450899
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+  sha256: 8e2b2073ff5c61d35714e8a36ce657a8ac741b7bedc2852a238c7f1625142705
+  md5: d951ab54a682b6328327fec53b1e5e72
+  depends:
+  - libgcc-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 147642
+  timestamp: 1707864274452
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 5d15605858771290fdaaae41a43941623757a25cb1292080d69d6d3857807935
+  md5: 7f517469aa5380c52e55db9f37df104f
+  depends:
+  - brotli-bin 1.0.9 h5eee18b_8
+  - libbrotlidec 1.0.9 h5eee18b_8
+  - libbrotlienc 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 18652
+  timestamp: 1714483267080
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+  sha256: a5094f078584e27c7cced4a9564ae904a329f5c1702a7c1ba092d581ba1544f1
+  md5: 6ddf45dd8a21a9512481de9bc0e5a03f
+  depends:
+  - libbrotlidec 1.0.9 h5eee18b_8
+  - libbrotlienc 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 19711
+  timestamp: 1714483255915
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+  sha256: 93180c973816246f068b742d0bf64840f0ea48e31d4f9b0747ea2ffc34d8855d
+  md5: f3a00096965a5ba1eb41d2c99a4662a2
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 361574
+  timestamp: 1714483400014
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+  sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
+  md5: f5058c8d5b2994b7334f18e022105a14
+  depends:
+  - libgcc-ng >=11.2.0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 427542
+  timestamp: 1714510571510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+  sha256: 394f74202c2efc8fcfd02b8953f508eb6a2961d224a2f9d15091caf5cbe1be67
+  md5: 1202b4ed32215c6405bb42fbff355316
+  license: MPL-2.0
+  license_family: Other
+  size: 137411
+  timestamp: 1710764808838
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+  sha256: 6dc29d20180f6e002f37b251efa639716d3444e129a754dabf751f816aada7ef
+  md5: 5dbfa083e6ab6318fac58fe0e0c94445
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 165152
+  timestamp: 1707229213375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+  sha256: d138cc3fde270eba783baf1e2ba17c89800b2cbbf20976d0eb425b3436a4a184
+  md5: 1875e89c1a939e4e7c5e7b731c72b838
+  depends:
+  - libffi >=3.4,<3.5
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 302401
+  timestamp: 1714483186060
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+  sha256: 9ddbf05887c7d7926418520cc7848e57f6d2431bc4ec6d30e090b02dbf865041
+  md5: 57ae1141ad9a048fb2a75d7a3ef7430a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203190
+  timestamp: 1698129926216
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
+  sha256: a5beda842876d0d71598cd2a50ced5fb2731539bc4172fe501b93b60e0c6cd3f
+  md5: d5293e5fe74a4e0d71bbf14c9a57f900
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49509
+  timestamp: 1683040113536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+  sha256: d9c102b9ec7f3a635936b6f73d4db126d748a25f65407353bd76b260dc7d1cd6
+  md5: eec48dbdf5dac0ea26750cc26b58c1d9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 554986
+  timestamp: 1709758392744
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+  sha256: 882481e441b9b93cbdfb32fbe32a6ad9f26197472f186a08fddb921f61346c02
+  md5: 443c79196064f57c98199e9990544b2f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16902
+  timestamp: 1709322958614
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+  sha256: e4877b41553e31b9f9f090dffab77a654255c63776e8b30fc91ec1f60afadbf1
+  md5: c34d3f1520f1e8c9957eb236710058c4
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281162
+  timestamp: 1700583651472
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.5.0-py311h06a4308_0.tar.bz2
+  sha256: d7c1822466ff522e14771be1a4234a7e80da0a70fbae0b56422c419eb74fea2d
+  md5: 4ac1601f900babedf8edf35bd98d2ec7
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3104830
+  timestamp: 1715838694654
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.16.0-py311h06a4308_0.tar.bz2
+  sha256: 309e8323cc5e7506a2be851649d36be0b6a0e157194baf6ee4fc900a1b43fddd
+  md5: c938e7730d42d87dba1658a8893d6338
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy <2.0a0
+  - pandas <3.0.0
+  - param
+  - pillow
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18004747
+  timestamp: 1699543167034
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+  sha256: 3b4cd8dc60572086f1a1cbb97e2712e0ffd55317ce8f0309d552eee7367855eb
+  md5: 70a1263b6e19bf2d77c020a2e77277c9
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2556575
+  timestamp: 1690905285843
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+  sha256: 4b589e3265c74159130230c164ff2d8d381be65899a249def0b53f93ce83fd47
+  md5: 245cb7173dcdba21cf368031cd87f706
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17434
+  timestamp: 1676823330845
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+  sha256: b75d12e85274660bb675a3e53d47a929872f2daa2ff5a76e98885ee3f2d19ad1
+  md5: f2119d0885334060d0d7fe59e5220287
+  depends:
+  - brotli >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - fs >=2.2.0,<3
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  - zopfli >=0.1.4
+  - lz4 >=1.7.4.2
+  license: MIT
+  license_family: MIT
+  size: 3237908
+  timestamp: 1713551660998
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+  sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
+  md5: a5dc8677d891dff2393b63189a3ad42f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 971975
+  timestamp: 1666798278693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.3.1-py311h06a4308_0.tar.bz2
+  sha256: a78f34d0b919c5fce722d33afc278cd48f5eec2bf186c35dd18d59d85d45909b
+  md5: 199586a3dcad8985bc4cb0e4262e06d1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 364478
+  timestamp: 1714461584790
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
+  sha256: f48ccfb4214e2af41e73a3904e343ecd1eb1ae06578c26f55a5dd247771b2c86
+  md5: d58e9eb09817935eb7342ceff889f481
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5335524
+  timestamp: 1707836581350
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+  sha256: a0ae6c5a6b615d73d9a243331f3f7d749b4feafdf2f334337fda8abd6c8355ed
+  md5: e61d8dcd4dfd6d165e6e480cee846bf5
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 357992
+  timestamp: 1715090462763
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+  sha256: e08e27531775de40f46b6ac7bf71856963baa0c008bd2b4d112e6341cd3e8f4c
+  md5: bfc7682613c861cbcb4ac01485c05657
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147174
+  timestamp: 1714398938840
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+  sha256: c7ffa6006573483a05ef355770c3201f04dd04ab4b91ae01971a6cdc7fbdba35
+  md5: 23d7d38e93d930ea5e2cc5f4079d3816
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 49872
+  timestamp: 1704813633807
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+  sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
+  md5: 3add2ce56858a1b8f6a37342f82773d3
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<1.2.14
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 19310769
+  timestamp: 1699647799237
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+  sha256: 0b670ab17ed2e1b592079bd64386dadc249ddc892e5ae1dd99f142a918ffc75d
+  md5: 632575b9e442c1e5c146cf78424da610
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 227791
+  timestamp: 1705934138566
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+  sha256: 65228eb868c3ec8aa71f958e60a675a919f016c2057392e02fd422fc841858f9
+  md5: 68e23f14cd222c233e6b37262bc61c23
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1612840
+  timestamp: 1704833066871
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+  sha256: a2918ea8a3e2c56fc6d91191e84b2f35500c392b16ab687a0c03ded2e2e51239
+  md5: 84fadd6b7fef393cccc0d123dae6cae8
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1162207
+  timestamp: 1679336523618
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
+  sha256: 4520b83e425883981f97191986a08122fbaebc3f16b898368796314136779028
+  md5: 42a8f32c4d842d3e5410b2bc1cc2fb57
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 352284
+  timestamp: 1706733655761
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+  sha256: c21f8f407266d039e819c27fe9eb4fb26587e974f3bd059b37cbaec5073722d0
+  md5: ba1f47411e9e07876c7a3e9d3be6a98e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: IJG
+  license_family: Other
+  size: 281400
+  timestamp: 1677849152168
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+  sha256: 06b729aee6dd2a1e545f3ad64179cc0d4ef8a15e33db3be2995dd3e0868465ca
+  md5: 8bb3215912588e47e2eeb4e7a09ad64f
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 180858
+  timestamp: 1699041715847
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+  sha256: 9e3bac2d41bd432b721b009e7de981766fba396e6f238e923f304112bd88655a
+  md5: 84ae4cf3f2d01fbebdac374971192be9
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 15525
+  timestamp: 1699032521315
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+  sha256: 79ce6dff3d93649a2555b1d2a4ae9eb77175a1c00664cb8eb0e6f848d5cdd1b9
+  md5: db395b0efd7018fcf3a4af879170c2a8
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 276856
+  timestamp: 1676823504812
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+  sha256: fedc7e5560252af44b0dfbe6f7acfe20ab17a6a08e758f670a1cd820551afc7a
+  md5: bd28d36963087f53a79b23fee697d665
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 93898
+  timestamp: 1698937453304
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+  sha256: 2b896fe8b2187b7df824041826e14379476eb2e61d607d8cb38ac2b3df40aaa4
+  md5: 8fc7e517da96c2c482331f6b08d07a17
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41459
+  timestamp: 1699282616532
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+  sha256: 87d372f5b23bcc2410e43b40b4ad059ea1625178b8a2b484fc63805ce517e594
+  md5: 50204f372b1672871d6ab3db6a876374
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 594177
+  timestamp: 1699467208489
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+  sha256: ddfee06ba9b149222c65d1d4270272840533aa63b56fe36363c84a891c71d328
+  md5: ee128e5c0d8d9e1952e2387b66a5b8cb
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27239
+  timestamp: 1686870958829
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+  sha256: 0c6a074272ed58677ec17e4dbfceaffd2108841a61af92b32f156c5763108d1d
+  md5: dd3d37841d0d20c70a60e8c939923894
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19144
+  timestamp: 1700168632051
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+  sha256: b040f0d0ee4588188ab6b83a93738b3ff6e6d1775424be97995bd0df0f4fb904
+  md5: eae62735d710cf5ff6d51e6f59fcd999
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78148
+  timestamp: 1676827253282
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+  sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
+  md5: 88199c75f2ac211728febced7785c24e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 228278
+  timestamp: 1635523146417
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+  sha256: bb990ea068c3b3dafd9c807e0e19570320cb2fe7d69cc326f1f0b5319b0654b2
+  md5: 3ff70744e396b1af69656c574b05c3b9
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 66940
+  timestamp: 1714483221853
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 3b87a816f72a00e1f0022a160e7eda70af89d3de2a2e08a72be1c17b31d759f3
+  md5: 4f57d3a0a13ddaf1c06efb586b702f46
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 34446
+  timestamp: 1714483232430
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 2cf15e89f910600f468edfde8d0f9b80a14fa2319ed89160dc7375dfd3764fdb
+  md5: 463adc13f2feea3570d1eccac368d9e4
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 295090
+  timestamp: 1714483244460
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+  sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
+  md5: 55dde57e63a36b202e388a39dcee9a66
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 74096
+  timestamp: 1695996494461
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+  sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
+  md5: 1af9b4d62c708924417f2640ef22a68f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 154016
+  timestamp: 1714483282916
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
+  md5: 641e72e5067bd6d5454405879e1cd2a7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - _libgcc_mutex * main
+  - __glibc >=2.17
+  constrains:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - libgomp 11.2.0 h1234567_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 8895144
+  timestamp: 1654090827491
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+  sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
+  md5: 27082517590f3b9fbffecc68513b461b
+  depends:
+  - libgfortran5 11.2.0.*
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 19860
+  timestamp: 1654090819660
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+  sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
+  md5: 0202c3c8ae4735cac6c7f3d1e1685964
+  constrains:
+  - libgfortran-ng 11.2.0 *_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 5228750
+  timestamp: 1654090762569
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+  sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
+  md5: 3080c2813e6e1d0f8a100a38b5b3456d
+  depends:
+  - _libgcc_mutex 0.1 main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 573231
+  timestamp: 1654090775721
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+  sha256: 512fac06ddd97b4383503d4fbd8145102966055b29ccf86841a930dbb4ef3ab8
+  md5: 833c0e514ff9c8ae0511630b024d60e0
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 37179832
+  timestamp: 1683292829131
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+  sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
+  md5: 1bffe1481ed4f88827248fb9001f8923
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 362561
+  timestamp: 1677841789536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
+  md5: 8c195584a5f5471b600ee180e4052773
+  depends:
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 6410287
+  timestamp: 1654090800863
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+  sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
+  md5: ef78eebd98289aceacdfa29182426adf
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 664034
+  timestamp: 1693575237924
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+  sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
+  md5: 292768ec77416ae257cfdd44ea2071c8
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29197
+  timestamp: 1668082729834
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+  sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
+  md5: 9cdeef1d044c7e035c006890f11569d3
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 436056
+  timestamp: 1694776944891
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+  sha256: fd8e30beb8c9442f16e6617fac92dd0c89ec823e98f06e60f712147380ead35f
+  md5: 7ed7caf2816c8b85b67b6f4e8833cbd5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41155
+  timestamp: 1676837080881
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
+  sha256: 05e355127db0d3ed67c4c383fd929ef1c3d7d3f19472f6e5433a866e94378bed
+  md5: b7897895622e5ab6e62279f07fa1f587
+  depends:
+  - libgcc-ng >=11.2.0
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4367002
+  timestamp: 1706910875807
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+  sha256: 95fe76d2691feb13203b55ad2aba535bb848cae21ffd05b13ff51c7a45fa2332
+  md5: 6a04ec16e3abc1c7e2104be32cd6c418
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13458
+  timestamp: 1676827287432
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+  sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
+  md5: 76f089e76ec67583bb38428b51008097
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 164494
+  timestamp: 1714510587156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+  sha256: 260e26dd509834c1b225ab7bdb97b9a86e00054fbdd5dfa49e68fa4dcf85a661
+  md5: 8f5d7ddc69cc6f7d44c80d2251dea5d1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162339
+  timestamp: 1676837095436
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+  sha256: 7f5b0804d0768619b7bd93b10488067d80bf42ec29f443f00b53ba11758a1241
+  md5: 8afb45e45c0d93bfd142e682d4b021ef
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 134438
+  timestamp: 1684280014220
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+  sha256: cb03570c99c983d7bfda94bc47d8eb00d4059b8548a171130775acc998004195
+  md5: 5b1abbbf1e4f9b350b16fc9caf9e889b
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26919
+  timestamp: 1704206397615
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+  sha256: 85fea48bea278a77d102781a1cbb6bf69307207d741251e38a6515c5fd7e3523
+  md5: d6ddba94f7c33c88c9825be8409991bf
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9150942
+  timestamp: 1713336680714
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+  sha256: 7ac07ea180b5928086075900afbc332fb1d3c81ddfacb54c891693c284056f14
+  md5: fc83dd1b3d2ec3c0a297ead0c3405907
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19573
+  timestamp: 1676823852670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+  sha256: c9ba2f9c83820712dd97d6a1b54a1215b9820a0be02ac82380b4c50911b9400c
+  md5: e5dc6b4a5b8e02733ce3bc9e9198a8d2
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67750
+  timestamp: 1676837123613
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+  sha256: 1a5141ef0de1cbff816f96bb4b212a40606e2fc11301a4c1358c8d63a6b2b027
+  md5: 22ac3bc22b68fef4c1f3f6ab3c7bfe0b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23040
+  timestamp: 1676827301164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+  sha256: 9aacfbbe6f638c58a4e8ff31374d1438d78b7db25d6ea6fd0c50ca2109f225d4
+  md5: e602057e3b3d80da88c61d66e8851c5b
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104681
+  timestamp: 1676823696152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+  sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
+  md5: ce77d0f05f846da4a6b9e23fe7f21d9b
+  depends:
+  - intel-openmp 2023.*
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - tbb 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 206738176
+  timestamp: 1699648006088
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+  sha256: 2aef0876d0df033f7fae8cddbd25d95fc1bfc067e60dd143bd8000fec0768b21
+  md5: d6cdc670327bd1675bbea642849f04e1
+  depends:
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59569
+  timestamp: 1682948560323
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+  sha256: 691c4b2b47cf3fac55b4949d7c0f547246ef19cb3510749142cee4bd01ffb055
+  md5: bbd69efa3f24ee747410f83118640d92
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 240723
+  timestamp: 1695058405382
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+  sha256: 71f5c7beca4e81b465ecfc6ed51cb3d39f51dd88df0b29eff5def3d1f12969eb
+  md5: 61d58663b7277cf4cc3cb8d9873d3ee8
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331105
+  timestamp: 1695059935112
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+  sha256: b558b3f6c144652b5e0d26497b3ce24c318a6b9ff8ea2079113c95e5553b3cf9
+  md5: 0b185969ac2b065c27cbcc9641d93678
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29568
+  timestamp: 1676841232463
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
+  sha256: 20d832ce714465ae1685d29e2f913fd105d385d003fe1bef71ef472e6f3489e6
+  md5: ad76299b0c33b7a5c0d45905271165c1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8303422
+  timestamp: 1699542957307
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+  sha256: bb45fb0a3973caa74fd8f845e0a519895f6a378807626e15ecf72c02f2eed794
+  md5: 185f658ba8a74e326b7231c8fd0d62bf
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 121834
+  timestamp: 1698934274227
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+  sha256: 8b2fc372a6655fd5b277d07b994ce43643553fbc37e63a60e9fe527a9026ec06
+  md5: ed6ac14aed5a796b153d757862398997
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 523905
+  timestamp: 1699022906468
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+  sha256: 7908ff6c516b15e8fb677be4071145e18adea7d4c13b8485a70a5ee2f573f8cb
+  md5: 50c0e38207a131a5de6a14ef919ffcdc
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 169629
+  timestamp: 1694616826002
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+  sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
+  md5: 57ea097dc15f8d9f9eb90e1d919143b0
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1157733
+  timestamp: 1674734069410
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+  sha256: 266199dd4efde0ad342a9c500f4bc4299c5622219aea623b46315a9b4f6b8959
+  md5: 2b21844d2b0024d0ffad0e6450cf0855
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 15860
+  timestamp: 1708532713870
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
+  sha256: 13d6c640710895e9732225cdedbe47fcd756887fffeb0cf9bc149ee7234dfc27
+  md5: a87d55e3d071f2c435b10db49a9911af
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 730963
+  timestamp: 1690984942516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+  sha256: ef2857e6d3d7eb246b3abddfbd3aa2d124dd8565391ace3876b77339babc50bb
+  md5: d276d1b1774107987963135c78ca7390
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26607
+  timestamp: 1699455972519
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.59.1-py311ha02d727_0.tar.bz2
+  sha256: 1b830d1d091462cff92de55f24339365a9d2c23b27d19799833b4780efe99c15
+  md5: 06367b04f8f04c0dc4e356a2ca9dc854
+  depends:
+  - _openmp_mutex >=5.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - llvmlite >=0.42.0,<0.43.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  - libgomp
+  constrains:
+  - scipy >=1.0
+  - cudatoolkit >=10.2
+  - cuda-python >=11.6
+  - tbb >=2021.6,<2022
+  - libopenblas !=0.3.6
+  - numba-rvsdg 0.0.*
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6084284
+  timestamp: 1711988494237
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+  sha256: 2f89f38a665ece47e8868b391fc70602fcee588e989bc1ca6f17f6094892a94e
+  md5: b788c80b2d571531ea4f3f8335ae5423
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 168827
+  timestamp: 1696515597877
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+  sha256: e09e1aff2c12d4ef3fec58fb627744e4b5c7d9eaede7175e293f77272d8b8bfd
+  md5: fe8242cfd54d238507493612ae697ad4
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311hf175353_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10270
+  timestamp: 1708639794640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+  sha256: a53ad723826651041a5057a1cf31bc8689b24d335ce61b196df5124974b05a8e
+  md5: 7b29e7191c4170189d6080e61229f030
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311h08b1b3b_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9163911
+  timestamp: 1708639777712
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+  sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
+  md5: b0afe23033c8c5344640bc25225fa579
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 516994
+  timestamp: 1630084830020
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
+  sha256: 6c7cb4097e4f3655b54a119304e50f0edbc4bd52f36c84629b64674cf8d468b8
+  md5: f1e48c973646ded3c2e1a189a9d8b8c9
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 5498991
+  timestamp: 1716318104769
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+  sha256: 280225061aeba00d7b85f46e55d7d79cd92c92f662dc749d9c53187978e8d083
+  md5: c51c21da68080d89300703ad818c824a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38606
+  timestamp: 1699371264464
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+  sha256: bd3eacd22e85f88bedd9c7e97a59eacfb3c8bb80eb59be244825d6895a0e7ac1
+  md5: 08ceb294ba8a9ae13630da789884736e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 157904
+  timestamp: 1710807470578
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
+  sha256: a2ee3a6aaf54929b82b851b2eb5436e14e5a294303ef429d6dccd33bcdfc8002
+  md5: b467a5c7ad672ccc2d498a67b9eeeaaa
+  depends:
+  - bottleneck >=1.3.6
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - fsspec >=2022.11.0
+  - matplotlib-base >=3.6.3
+  - tabulate >=0.9.0
+  - odfpy>=1.4.1
+  - pyreadstat >=1.2.0
+  - pyarrow >=10.0.1
+  - python-calamine >=0.1.7
+  - s3fs >=2022.11.0
+  - beautifulsoup4 >=4.11.2
+  - gcsfs >=2022.11.0
+  - xlrd >=2.0.1
+  - dataframe-api-compat >=0.1.7
+  - pyqt >=5.15.9
+  - adbc-driver-postgresql >=0.8.0
+  - fastparquet >=2022.12.0
+  - psycopg2 >=2.9.6
+  - qtpy >=2.3.0
+  - openpyxl >=3.1.0
+  - xarray >=2022.12.0
+  - html5lib >=1.1
+  - jinja2 >=3.1.2
+  - pyxlsb >=1.0.10
+  - sqlalchemy >=2.0.0
+  - zstandard >=0.19.0
+  - pymysql >=1.0.2
+  - pandas-gbq >=0.19.0
+  - lxml >=4.9.2
+  - numba >=0.56.4
+  - xlsxwriter >=3.0.5
+  - blosc >=1.21.3
+  - adbc-driver-sqlite >=0.8.0
+  - pytables >=3.8.0
+  - scipy >=1.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17970687
+  timestamp: 1709593080388
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
+  sha256: aa05415302a27a82105e9d0800151f09fd1bb896b90854dc23989f9aecd9200b
+  md5: 4974b1ae5f1a3b6d9fb26e7eb2c26733
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.0.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21869200
+  timestamp: 1714071532259
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
+  sha256: c6c782537b96ab9caf3e25f5a33799c727e84664cdbab37a8d3359a221e2d2e3
+  md5: 8f56d0f63e0589dd7e4a004678307813
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 263438
+  timestamp: 1711136934516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+  sha256: a2e2beff710765f2e5135020121da4f227f5e1cbe142e17398a585f50a389d37
+  md5: eaf734d49b6e576e12be1398a295643a
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - pandas >=0.19.0
+  - numpy >= 1.9.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 47447
+  timestamp: 1698702703255
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+  sha256: 28ed719669260a20bec78971edaffb91ec917d2a3f0fac1cf9a8ba21590baa43
+  md5: 0481d078fcd64f7f981532a514d9d50d
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 960727
+  timestamp: 1714399060039
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
+  sha256: d527189038b376a982c18613df808f25dc40314b0dc8fe5549f3ae9f4288e497
+  md5: 68dad015e796cc26364b55f92f61faa7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3451714
+  timestamp: 1715097126399
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+  sha256: d2bbab8bfc57c7f46ca8994bc87df7e744d3f036b867bc4be1145ba6d8d7e091
+  md5: de41707272a8e3ccab764f0b7010a27d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37394
+  timestamp: 1692205565974
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+  sha256: e2a0e2a618aa33f0beff9583c7dc510b8d0737b023117346676aacbad33970d8
+  md5: 66a6818307261b1a28ab12d1b7776fdf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 121454
+  timestamp: 1679340540306
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+  sha256: b7f591c19b10bf0daa7e6e3b45a9f4a0a0e83188e1f8a58037caea79e60f8d91
+  md5: d945b4ccc135005839c504cc29df1745
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 749608
+  timestamp: 1704404477511
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+  sha256: 96482b49191fdac59580a95e69508367083e1f7600145e11d7c2db634337eb26
+  md5: 2d57bf8eacf3f291db845928241f724c
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 490805
+  timestamp: 1679337420563
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+  sha256: eb75b4417565d25e2d1006db75aa8bd9da6b6c72a929954b01a31b9bf5f8b42e
+  md5: bb56c0358b65665f4dd509a4635f6f3c
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37802
+  timestamp: 1676838557935
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+  sha256: ed927e4d058a8f4ea73edc7a43ed74877d93b88fdfa240b3b2777244386ced70
+  md5: a1f0e05fc7e49712f81ad5478ec9d51e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2121496
+  timestamp: 1684280065800
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+  sha256: ad219924e362ce7af458fa6547660181579e9a50e5aed1ffd9268cbe7c2650e3
+  md5: 2b1ac40e0df3673d33b7f4c4f93ae1ef
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207338
+  timestamp: 1677811584327
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+  sha256: 114b55e00f4622c90fd2b404b21ad5f94a10283fcaaf86a42174b8d39b0a3e98
+  md5: 2458e92683cc68671a6c8e1b86ce8817
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35850
+  timestamp: 1676822725516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.8-h955ad1f_0.tar.bz2
+  sha256: 8bae0856b2f337f43cb5cbbf71ebf684ef47438210465b8733304d7d7f258559
+  md5: 7fa94ac6e31488660ca09b2896b9d96d
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.35.1
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.5,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 36090392
+  timestamp: 1708984519285
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+  sha256: a0f008717fab060ccd003dfebc09156d90b9afd14ac3626566aa1a8f3d3b7e2f
+  md5: 357bf4fe94496cbae72ab4d780184b31
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 330924
+  timestamp: 1716495762901
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+  sha256: aadc4078311c059265706a56265f0a57ceb538d36179d5203dd487d80d0e8f16
+  md5: 59ec670fcd172447dbd9591b8fbfdd56
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 278741
+  timestamp: 1679340144625
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+  sha256: d5058d0ecc3973316c1d5f1bfb03dd119e0dade85f4c2d21b412c8db4e1636f2
+  md5: 93000e4d3603342779a2afda66fa91b8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17607
+  timestamp: 1683823841946
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+  sha256: b85acb933fff864bfa89d034e8e3d85b1a9c2e69cbfc0d68c1d66ffd1443e67d
+  md5: 0cdb92d2d684ee1095310f992ed0d9b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 266796
+  timestamp: 1713974338678
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+  sha256: 511e8206a15445715b80be76493300930686b3fe1e512ae942d6ccca36df392a
+  md5: 35a6e46ae970f8b71d78fb5a810f2e80
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64013
+  timestamp: 1711136926372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+  sha256: b2a1f649669f4336b74f6f20df711959bcd8024f8f8b94199dc0e040b06bd37a
+  md5: f9e8e3f7068f717f75e555dc04545d8d
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 206433
+  timestamp: 1698096204677
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+  sha256: 7c74db4292f31619606180f86f3c1e2d913495c2c9d1195c5d51681a6a841625
+  md5: be1c05fae57d194924b9400f9b5ad3c6
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 613277
+  timestamp: 1709318516682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+  sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
+  md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 467661
+  timestamp: 1666648052561
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+  sha256: 89c2f4235277b9825cc805c5c44f0b1afcb683d7b5a3f513bc4bf243b643bb0c
+  md5: db70eb57e33adf7b8bbdadd72214d48d
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 73679
+  timestamp: 1699012111499
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
+  sha256: 684037527327839d734e7eac2ee09ef5ddb4f77df22daf40c79e51db29d09543
+  md5: 57c5bcb9eae9f1d93ccfd38025660de2
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 119414
+  timestamp: 1707355661872
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+  sha256: fdae3f68ea84b99561aee6c566ab1c287d8f2ae2668424e9283a8ed86af8f1d2
+  md5: cde5b71ccbb3630053340b2c8c7dbf10
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9333
+  timestamp: 1683077183576
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+  sha256: 0bf859b06a07857099fd4f524fe5e0875fda70029e9485d95c7efa97134fbc14
+  md5: fd5815cc592fdbd4c831901541eadaba
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 9735
+  timestamp: 1683059096795
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+  sha256: 474553d01aea57214a54a7443f227da84a58e29c49eb7605ba0043c55b7d167a
+  md5: f01333e9f0a908e435db650f42fbd2db
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1096668
+  timestamp: 1698946168635
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
+  sha256: b06b45da61807f76b6d800047f123fee2cc95eb84da508550e0908951c8d9f6f
+  md5: 9b100efb9ba2fc7f9bcfaa8fd2ab6f9f
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libgfortran-ng
+  - libgfortran5 >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 4
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 27615256
+  timestamp: 1714076660659
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+  sha256: 51bcea0e575a626f6ffbd16d1153330fda93dbe3dd31dcd3a8f469ff61dd1e4e
+  md5: 41d531c90be8c82bf79635ff3d409476
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 32295
+  timestamp: 1699371262818
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+  sha256: 0a95988ea269c96354626dcab255b65b54bb5c503d24cdeb6ef2e1c42818bd59
+  md5: 8bfb9f42492b3b53b8151d77e51c75d8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1594974
+  timestamp: 1715024182643
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+  sha256: 1a84b00944bc5588e14a097460175f97df49acb4f1ff2498ffd9a1893068ed81
+  md5: a456513471b2ecbed60430c21dd1ccc7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17880
+  timestamp: 1705431390054
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+  sha256: adcafd297d60af64107c113bb7b8b92160d0268a44ef9a3b79e56a88a0358ea7
+  md5: 28ed704ed26b06d32662e3a6a87e59b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 88799
+  timestamp: 1696347581401
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+  sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
+  md5: f86119b3243fe3508160aa0406245738
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1723866
+  timestamp: 1714488309729
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+  sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
+  md5: 041a3caf09dc9ce8fc6c10925c4fe050
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1888016
+  timestamp: 1680167274961
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+  sha256: 856a8ab8c350c50247b79966c6cb80fb6d4de36eef49ddf75aebbbcaf854c82d
+  md5: 442dde204d14d171aab9ee40e8de4de8
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37456
+  timestamp: 1677696176157
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+  sha256: f0a026ddc0ed041bfc60c8a1ca0b70b7a69232775b3181bfb35a39fda42d6994
+  md5: 2902d5a5854865baaaf58dc59cf06b3c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49185
+  timestamp: 1676823769869
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+  sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
+  md5: e2512d57c8a1e91e7b20e265c6906546
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3588922
+  timestamp: 1714770676475
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+  sha256: e58ff4a82819446f3c92e5b1aa2a784c4b06643e751fe67cf115858296dbfa50
+  md5: 32ee4723173f1fad5563b8afb5f1c8f1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135634
+  timestamp: 1676827536101
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+  sha256: 1bf522ade750cf0b70d61e71916ff00569e2908db1e9dedb223fda2608ed8bde
+  md5: 6793c74fe94211c0bfe6766c6dd490af
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 893808
+  timestamp: 1696937055591
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
+  sha256: 54f41afbea1c01a10e5703e64645de145f34ad6d89cf245fbc5cfaaff58a8743
+  md5: 15b6c8bee4c28c6efb3e388178b37145
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 154276
+  timestamp: 1716395957568
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+  sha256: 0575785f6553e61cc6138abfd5de52305fac6f85971642fa1f056a76c66a52b2
+  md5: f2c25e5dfdd23f70b83776a8832893cf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270865
+  timestamp: 1676823316868
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+  sha256: 8c06c291c76e8c2022ffbb9fea4727a4bf1f9b03e498bafc56ba8ac4e7604ab9
+  md5: 5adb7baf1091d09026a372cac930ce6c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8869
+  timestamp: 1715268966416
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+  sha256: 118b0801167264c401e84bbf19175546092a5569cc098146f7362bbf890dc8d9
+  md5: b3c2aa56d53b459f8365d8385f48d0c3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 74489
+  timestamp: 1715268960737
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+  sha256: 509b962773f0fe44a93a7f6196b254670a030eac8ea7f90727312e3ccd9294b2
+  md5: 6c402d5bf4e01c8c3895c9ef41707b6e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11371
+  timestamp: 1676828901104
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+  sha256: bbe7629e8ce52c82f13ed0d1fb919f3659ef466b274a7c74aa925a9bc7aee450
+  md5: 7da527bbcf71270c1abed8ea52e7d44c
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 509031
+  timestamp: 1713213062098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
+  sha256: 5c6afad310db12b3658a652efc5de45c182164a0b537cb2cdae5885428b30d22
+  md5: 89ea2fed160a633e0a6d152b61cb0dd2
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - zstandard >=0.18.0
+  - requests >=2.26.0
+  - selenium >=4.4.3
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 209068
+  timestamp: 1715635972793
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+  sha256: c3a5e0b855dc2de6c162708dfcf170a23eb9e7525d4252d8dce553369af4a330
+  md5: a4c77e204b7787f820955166a1283168
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25890
+  timestamp: 1676823132898
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+  sha256: 42989f9970a8466cc4edb73463dfa194594dd1a5d42c9f820a1f86296d4af140
+  md5: 655dfd4d2f17977cb81caa1c082d2b25
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 113505
+  timestamp: 1715878346465
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+  sha256: eec0d2e0bce4b62278cacd7b0bee053160845e86507051a5434d2069bd290f36
+  md5: a069e5aef64a6dac076cc9a3d28a17c9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 136022
+  timestamp: 1714717059748
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+  sha256: 85248e503721da67797546cb8a22e303c1739100834b219c5621f216e3794e8d
+  md5: 2570956643f22d0f809b2467e02d3984
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2465865
+  timestamp: 1689041600364
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+  sha256: d18cdca154bf668826f869117ea996c4f9e8ef7d27b7c528332a7d17e5a8602c
+  md5: 9f7353d72046b16dd6ef6b5689ac9bfd
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54731
+  timestamp: 1676828934954
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+  sha256: 9122d6e9dabb7a47f2bcb15d86b97c96c49a9048da3f8ae59675351710c14cc5
+  md5: 660b2aead2ec87b751c86cd33934f44e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 716926
+  timestamp: 1714510796277
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+  sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
+  md5: 943f1247a22b6b64171363bcee1eec27
+  depends:
+  - libgcc-ng >=11.2.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=11.2.0
+  license: MPL-2.0
+  license_family: Other
+  size: 371663
+  timestamp: 1705602144682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
+  sha256: 7aa781d0850f97622755ed44772d2b215b253a8e211aede5f3f53e1b95b4143a
+  md5: b1d8823f50228d4efb7b7a6e267ed776
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 24333
+  timestamp: 1704207043644
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+  sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
+  md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Zlib
+  license_family: Other
+  size: 127143
+  timestamp: 1714510716441
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+  sha256: af3c032f06352e87c450739cb8aafe1ff34ad28bf074b214ea98b3d29259a85d
+  md5: 51fa34bd0e016ed7c5371cf6cb13ef6c
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1044463
+  timestamp: 1714678445052
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
+  md5: 544adf2677c47c9b9c891aea720678f1
+  depends:
+  - python >=3.5
+  license: MIT
+  size: 33999
+  timestamp: 1630003259346
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+  sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
+  md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
+  depends:
+  - prompt-toolkit >=3.0.43,<3.0.44.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5106
+  timestamp: 1704404390460
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+  sha256: 459f38609d854888998a8d76028019dbacdce2bfe401eab57b8eb8ff16da9c7f
+  md5: 2948a98ef4de5decb7e5eb888eae68ba
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13056
+  timestamp: 1682965564630
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
+  sha256: 305e5fd9993f3e5506f386f98794c7d53b6e6c68d4d411ada724de49a17945fa
+  md5: e1fbbd2d11d21aaec3c32f7d332c0e77
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13818
+  timestamp: 1712163766707
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+  sha256: dc9f709bacbaf08a0941d2622d82f91f18b355e82c55348ec29f1391215ca7e0
+  md5: ece0f5837a4de2d4d5f1abf8347cd10a
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 124922
+  timestamp: 1708711884650
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+  sha256: 5800a2466734dd1ef372bec0dd3f0880c5072fa1e8b0668f5054f834285e991c
+  md5: 18194e51d4420ac08f29f3f86581b52e
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 229003
+  timestamp: 1706220302459
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+  sha256: ab7672364f1fa55ec5d8311d85d40e5b57cbd3517b17670557b6fb822bcf759c
+  md5: 6e0159a5865cb7e96a748bd8560035ee
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 11579
+  timestamp: 1678317458652
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+  sha256: 51556902e09436d46878ef772805d06416ca96ffaa66340b5565c0245574aaf5
+  md5: 4cb1b20635cf5431d34cc96ca1e8a751
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 33355
+  timestamp: 1678317111825
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: 188b74f717e3ce3595da404c0e027b8ccafa9c186e88325e8f02c29d7b4c0744
+  md5: 04ad90eead5812a0263b42321056ab33
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153694
+  timestamp: 1695717975427
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+  sha256: bf3c60386619f08cf5105b4b903bbc109b3252c3b923fe055aa445908a01969c
+  md5: 3f84a301921ec6400b7f1f1c4ba3260d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 270017
+  timestamp: 1681493109562
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
+  sha256: 126ae8e30b8464fb2dc94ce9163dcb2d5482f7214c7d8a48340c3f09f1409d5e
+  md5: d5e0c054042910b4394a14c7eb4d8131
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6080356
+  timestamp: 1712084675745
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+  sha256: 9acafafcaebd653c2372ddc864525722e1c55b884b5eba22e28e2b2d946b853c
+  md5: 22375cc3c2edada31b85af56c8e6dee6
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 155829
+  timestamp: 1707864406086
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: d8b1ccb15297dcfb3f9ebb8139c3e28a13d6c2e73c37612cb214ab6cc58b15fa
+  md5: e5dec9f13de061640ad2697562a99b54
+  depends:
+  - brotli-bin 1.0.9 h6c40b1e_8
+  - libbrotlidec 1.0.9 h6c40b1e_8
+  - libbrotlienc 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 19732
+  timestamp: 1714483415038
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: e9fda4393edd0234c88efc2b88e0edf42c94eb49ea5b189a80afd733058be8fb
+  md5: 13ceed558eb174d6b77ed1b0035f1785
+  depends:
+  - libbrotlidec 1.0.9 h6c40b1e_8
+  - libbrotlienc 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 18400
+  timestamp: 1714483395748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+  sha256: a323af3251e426962ad16edf8f46a696ef502731faf12aee32ca289c40b11342
+  md5: 658ce49e9f07dba7a1afe70fa2666e0a
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 393858
+  timestamp: 1714483549536
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+  sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
+  md5: c5a600d81b1b48578863af2973c743ac
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 187637
+  timestamp: 1714510590009
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+  sha256: 0c5f9766aa2dcc08ae71b6c0102046a56b30297d0bedc3039b7f72d1658baa43
+  md5: 34583b436e62a2ce55d6a7e8eb818e33
+  license: MPL-2.0
+  license_family: Other
+  size: 138712
+  timestamp: 1710764814844
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+  sha256: 20b1fc398e925e6c8cea6a06d3bb614e2c0de886e3f14f85b0ba26e57ff40b7e
+  md5: ac95cfe373c7fef7820e93189041b0cc
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 166856
+  timestamp: 1707229213510
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+  sha256: 6b5bebc13755b0a5ef423219eeecd1c25b97dbe83afad6e2552635387547d9f7
+  md5: b7bc4192fcfed7fc7df1ce00bce97b02
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 291802
+  timestamp: 1714483319125
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+  sha256: aceaa74365b0d8e69c817639393df3a713a802f40645ac0bd2f39adc871acf54
+  md5: 52191c9d4f4fcaeea39574819ab2f14f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204365
+  timestamp: 1698129979494
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: 53099bea1cdfeac00bf4bf48e7c3321424af31b9726a7f67033ed06e5d924f04
+  md5: 0302e97edbd24e02df7609a6072dc569
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50495
+  timestamp: 1683040190091
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: 9270668e34b00a2605584a2db5130c83826855cd05b896ce949f3156fa197429
+  md5: 2586aa55677e822e8285d777f9039ca9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 543487
+  timestamp: 1709758497949
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: 389c63a84b92a6254c9d361ebe970d537d0b88733efd5ac5c3ee58196fd2c5a9
+  md5: c7bc5b3cbe76be83a27f00b7e4740727
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17974
+  timestamp: 1709323004148
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+  sha256: bebfc5aa6be12e61a134b580b07b67f7d8c045d6b113fca5b21fa1e83a2f03ce
+  md5: 239df72a3921c951059fa8afc09643f6
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 287736
+  timestamp: 1700583644534
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2024.5.0-py311hecd8cb5_0.tar.bz2
+  sha256: 5e6d053acad4139e50c724bb862204097c82f5d9c00dc3c4dd280ec4e2e50f94
+  md5: ebd1df3504dc6c94b7c587bba659be54
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3107521
+  timestamp: 1715838704477
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.16.0-py311hecd8cb5_0.tar.bz2
+  sha256: 973b7d6f902d0021116a94004a4abc43b623a516033cd650360db52b7a5900da
+  md5: 3d602a55412745fd7dc1f5fcfdc2fca6
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy <2.0a0
+  - pandas <3.0.0
+  - param
+  - pillow
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18008805
+  timestamp: 1699543215294
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+  sha256: e0e30590a78d99d51445ac4f668aefe1bf20025a35bdbac00f04647b95c9f152
+  md5: bd0db635eefeea82a0c567b39c9a0e3d
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2485698
+  timestamp: 1690905283575
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+  sha256: d48b47b86b09dac1fa4542ec13e1bd4e23093638e684fa66ec3afdd9ce9337c1
+  md5: 5a2d1828ab7c8eccd3c2610d13672977
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17336
+  timestamp: 1678316187749
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+  sha256: 54645c22fabc25b632114d1d3c403a6fad9149b51ab36719b2690a084f14a072
+  md5: a8ad2f4abfb2e17ecf6e596342528156
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lz4 >=1.7.4.2
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  license: MIT
+  license_family: MIT
+  size: 3180691
+  timestamp: 1713551771692
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.3.1-py311hecd8cb5_0.tar.bz2
+  sha256: 296e72c622f7014041055d8c7b602385ad10893aa1c0b600248c95e7d116dfa9
+  md5: 93d5cc02fe01e3b396f02df0ca682a79
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365534
+  timestamp: 1714461741656
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
+  sha256: 4120472ee1c5d31efffeb045892bece27b9a15a30d77c35212f6508221635918
+  md5: 9561a225b5171285250c9071f8cab074
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5368257
+  timestamp: 1707836808668
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 50dee40e4a9ea7a035baeecc85770c88d63d4e6b0c3c2519c1429e881171150c
+  md5: 4d465f453dca5c65224dccbe953f600c
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 359293
+  timestamp: 1715090716440
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+  sha256: 5c2458964157fe493ca18c513c693b70cb622087e5fa0c93e65fc45217edd811
+  md5: 15629e52625221b51a443cefd9501d12
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148522
+  timestamp: 1714398885844
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+  sha256: 5a17849341e4d43fc6aff44486425852c16dee6e1cbcab1ed3f2167350f55359
+  md5: 445ac9df262ad2dcd86246a9ba5654b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 51118
+  timestamp: 1704813615186
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+  sha256: e0127f50d444bf4474e8df07d602c7f6dd38690e8bb3fb28817c164940ffcde1
+  md5: 583fcd7060cad6a77074d00d9ef62f44
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 731417
+  timestamp: 1699647668990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+  sha256: eb58fa29b1ce9aa5fc774d4c466696457695dec3b206456614b4c9cac0a94e42
+  md5: 3d3291ff58dff83dcd40ec54b435f4d2
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229910
+  timestamp: 1705934029588
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+  sha256: 73aa7662c00c73bab2dafefefc87a1b524961d2687410af624ecbd6703e483f3
+  md5: 7e71e99766107a553752ed8f22b61cf0
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1611976
+  timestamp: 1704833049616
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+  sha256: e08cda2bcbdec124c63e951eb248c503bb1467c2a6000010c6bdc0726e0e00b7
+  md5: 22c24f43b82da8b3920a913bbf452421
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1168968
+  timestamp: 1679336359851
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
+  sha256: 3b262312f1fc76e490c067408771da0a12c7691379cddc3c86121255cda7a41d
+  md5: cbf00a1bc151243cb6a33524b62f3663
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353280
+  timestamp: 1706733664000
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
+  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
+  license: IJG
+  license_family: Other
+  size: 278924
+  timestamp: 1677849185191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+  sha256: 99fc6ac82c56eb2a580f96db24a5b887f8abc8c24af445d3313d5ebb48598478
+  md5: 71892160908a6daedb5fb7c404079ae4
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 182073
+  timestamp: 1699041732321
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 0ea44d0c8044e70ab0eaf4d6f5f3e4753838dee106b5cbd36561e21a65cbac77
+  md5: 1d045016dca889d702f1caf3a16162fc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16528
+  timestamp: 1699032525791
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+  sha256: 70442ec4b0b7ebbdcf150963f61f797b861001092124f4ea39a16eb92a4d176e
+  md5: 63d1503915a15ae4f9ad1c46112ca374
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 272720
+  timestamp: 1678316970740
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+  sha256: 8601c674f4779900f6a949e47b814be68b722b0b3d394433bec9d197924ebd69
+  md5: b8423f8caff3041a251fc3681f43496a
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94990
+  timestamp: 1698937583196
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: 6a430c812ce0415a04d9cfe6c66d9012eced2d91c04960c88bc8ec1e9f1b5d6d
+  md5: 30b3d5d6a8cf5d1604e5f5fb177917b5
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42513
+  timestamp: 1699282637015
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: c2d206db117f7161e77236ebd6b0051fc73e1731c242d1e08597d736a0376c92
+  md5: bdb61de2e20e02c93423d9de091c74ad
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 601837
+  timestamp: 1699466514455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+  sha256: fd7964657f0a8fe8b167ba860b1f960e8b7b45309eb6c7c850d50ec283fe03b5
+  md5: 2967bb345bc75f53182e263ff4743ca6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28223
+  timestamp: 1686870845224
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+  sha256: 64cf59f0f74b0329b5069bc6135b4f40593f1dac52d85ad574d4b8e0a4b2cf16
+  md5: 35e8b80eaa03a904fc7f1da39e7f654d
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20234
+  timestamp: 1700168776500
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+  sha256: a12382b50416803f559a03fb384ba492c1dafa351e1191a3f8dc361bee6c4f37
+  md5: f2ae846b663bbb642f4b1e90eaad38a3
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64817
+  timestamp: 1678322501509
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 685c3bc9068bd485604b80bf03789e4dca95c410d33871bc1b882e47649fabed
+  md5: 6cf8e55271e150ca0961d0ddedaa61bb
+  license: MIT
+  size: 66237
+  timestamp: 1714483284541
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 69826cee54db9955f0120af21ec36d13f9211877fd67364f2068d0a54c6c97cd
+  md5: 0851917257f490d35e1f73da8a1c723c
+  depends:
+  - libbrotlicommon 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 34042
+  timestamp: 1714483343147
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 3f5a1f03b50b90b397a0ee432ad0cba13354abdaf7e5652c0fc60164b26a08b6
+  md5: a50bdc871ef4bf14deb088d888b92b5e
+  depends:
+  - libbrotlicommon 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 311597
+  timestamp: 1714483371586
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+  sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
+  md5: 822a5b76117e56d3912f1f2153307528
+  license: MIT
+  license_family: MIT
+  size: 136045
+  timestamp: 1714483561919
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+  sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
+  md5: e458587c87e3f2d20192f4e0738f2c63
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 149419
+  timestamp: 1665498987619
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+  sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
+  md5: 1058b661ec829b2ee3716ee2a5520641
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1917987
+  timestamp: 1665498925405
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+  sha256: 8176dd9a68815301a24ed51e72f3506f5f77c67a112efa0dd14971f2f3b3c8c1
+  md5: b5e470c224000a6bda6f655c155b53e7
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 27861431
+  timestamp: 1683292881730
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: d28c465ec6d5f8d4962c597b249b58998300c8b4e3c937c578c3d15294ea863d
+  md5: dcaed6ddd0723c7cce6bfad917be98b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41176
+  timestamp: 1678413498410
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+  sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
+  md5: 5c740b4a18a558de0ccfe601703c423c
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 338738
+  timestamp: 1662635677689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
+  sha256: 53808184421c81e661f9927ff564a0d0ecdf3b816c8aba8e2368434e055529d4
+  md5: bee10bfbe90767fcb8f8f6ab3a05d85a
+  depends:
+  - libcxx >=14.0.6
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 407784
+  timestamp: 1706911015242
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: 716a654df2e55052193150015bd5c9856b847893fc5a229fa8669725b1c56ff2
+  md5: 687ba6c11de38ad7cc597f7188b491e7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13357
+  timestamp: 1678322560230
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+  sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
+  md5: 8f57dc3a3327bb6f7e1cba908856ac7f
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 183138
+  timestamp: 1714510756758
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+  sha256: 6fb2953e169ee1ae38f24d29752051501992f19b96b5ebcea9af75737bdbcb42
+  md5: 7f410cdae838c5030108d1b98a8c78f6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162478
+  timestamp: 1678377892595
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+  sha256: cd97e09a12ffb49b2a30a782fa8c7933b28f5ffdbfc5c73a9ebaa95fc9447370
+  md5: d1fb6ebc1e5728aa6377cfc71da08942
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135859
+  timestamp: 1684280005320
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+  sha256: 30c3b189462a9d0f4794d229adadf34b5f5a5f56f95c30d5afc17ef524579290
+  md5: d4e9421243129d1d57c472dab045f3dc
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26639
+  timestamp: 1704206159955
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+  sha256: 080000a28b3ceca54eec6de0748c690ea5a4c390e358283eac03fe7a6dd87065
+  md5: 51344eca57d7940fb01eb5e8914509e3
+  depends:
+  - __osx >=10.12
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9099909
+  timestamp: 1713336790553
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+  sha256: 07e7fd5bd64e55328b4b99d92e2e2600d791f1095bf905daab4cfc59f0f0a45b
+  md5: cf53321779f4ca7e986c1468719b93f1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19500
+  timestamp: 1678317565001
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0770e02be1ea1216af493cfc03d5b8a702e14606fa93b0692bcdab1fed1b898c
+  md5: ca6f06ceaf66a32bbf5dfdb6e373a5cf
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67892
+  timestamp: 1678417734353
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: fbe95ed0501bb0f137048476fe41bc718dd659e8ecb066bc67ac17d6a50f4318
+  md5: ec162bde8d1c8a107b257df218b17035
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23030
+  timestamp: 1678381838497
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+  sha256: c20dd678655e582129a858a1c5162bdc254082d3a3c035b0f72629d9276e5b75
+  md5: 800a0738c728796e02d0386ce7d457aa
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104585
+  timestamp: 1678317269407
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+  sha256: c825bc3070f73318ffff88a7a0b7fc6d1858b058ced735efd1789053f1583918
+  md5: dea5f96459c9a6df6b026ca57d387936
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224299920
+  timestamp: 1699647835748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+  sha256: a76c134ec258612ff7d55cb2a19b9e3461cbbd375a744bd29390af9cfcd283b2
+  md5: 1c736f58992009f53f014aef163bae31
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48442
+  timestamp: 1682969160267
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+  sha256: bcfb0d1e075d043bcf05fa1a7ce3c142bf222d29693366af49a5a346c770812f
+  md5: 59e4820b34049cbc6619a8ac97290abc
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 222137
+  timestamp: 1695058350477
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+  sha256: 114e408c40b332393cf2792393e4d1ede3465abcb3d345fe647ee519565346c8
+  md5: 86b13271578e1fa5e664edcf6fcb3ce4
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296860
+  timestamp: 1695059990370
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 638450a7ccb5f438ac65aa1c8d871fb5bb664e7261ec7e663d0302485c219a67
+  md5: 574875bbeabff85b5d9cfdb62066aece
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29473
+  timestamp: 1678392919304
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: a58960e88525a202ba193b4dd8227c4d9c3dd98b8b43edea34b05a9a9fd1121c
+  md5: 71a37f987c3df6657548d098bd2a58e7
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8286383
+  timestamp: 1699543227340
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: e08cb3ee6df01f4c1e1ac8bc4ed1a06e549ffcc8774fe2e2842c644bb8f74a86
+  md5: 6ba0ae0fb14cbea1e3197707701dc180
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123077
+  timestamp: 1698934356774
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 2f946b5042eaac97206b5217fb203f3604ab3a60aecd99bdfc684925e3136c18
+  md5: b24026076c381ff2009e7acb9e0a6e87
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 534650
+  timestamp: 1699022791300
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+  sha256: ba368605a0af6f1dcbdcb6fddab9ce63224a85dd11bfb2b1acace1dc17899411
+  md5: 91f3ea3fe44d619ee95a6ed3773a0814
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 170926
+  timestamp: 1694616830121
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 42d803e1d8b54748db5d989ecd503826f564132df7cddc20f520460f55e523a1
+  md5: cd3fa71626ebc098da4625fc6be79752
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16952
+  timestamp: 1708532805951
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
+  sha256: 92d50872fad0d1fecfea42cbfdb69887def80927c169a88204d163c2d3c7d035
+  md5: fe6780b8659ff5d6061268708a7b2032
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 716120
+  timestamp: 1690984968401
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+  sha256: ed5608feb37a083d47b04203195260e801b64b5380f292cf18bb61e7ad827a2a
+  md5: daa9c1c233673b727528548454aea664
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27607
+  timestamp: 1699456006797
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.59.1-py311hdb55bb0_0.tar.bz2
+  sha256: 733ece9d325b4baeaea505bd82be98ffe9e5f15669bf079ee4f2f15225bc70cb
+  md5: c426b5fb76b3d219a2fbfa2792684ae2
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.42.0,<0.43.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - cudatoolkit >=10.2
+  - numba-rvsdg 0.0.*
+  - cuda-python >=11.6
+  - scipy >=1.0
+  - tbb >=2021.6,<2022
+  - libopenblas !=0.3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6049873
+  timestamp: 1711992424576
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+  sha256: cacba45c1eebf7d86748737717883a98cf40664231460fa41391c79f98d06f45
+  md5: 3dbfae0d5b90e77f9358564ad442ac9d
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 165572
+  timestamp: 1696515553184
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+  sha256: 1466c3af380b949612c79940124e426eccd59e335c205da0c00383a69358d1c0
+  md5: df6be53592d40ba7e03d6ffe349760bf
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311h53bf9ac_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11330
+  timestamp: 1708639985606
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+  sha256: ace67d704fa7eea1480eb463f2d91bfc161be2ee20263c5a9939805ae3c2a9da
+  md5: ec124589478fa12fba4f35f31c3a0692
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311h728a8a3_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8783230
+  timestamp: 1708639945646
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
+  md5: 93f5d7b66976154adeda219bea02ba45
+  depends:
+  - libcxx >=10.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 484257
+  timestamp: 1630093862501
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
+  sha256: 891ffe9826f6f9ec9a4fc5d1bbb9a64f9de23f27705c2202f7d475b7cd14dd83
+  md5: ab0d447c9eb4fcada05d853bd13a24ac
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4970613
+  timestamp: 1716319014066
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+  sha256: 8a0809f419065e014cb8e2c8a516cadca6088fb71fd1ef3ae2287d91e3360d59
+  md5: 4dc0b9bc88476fcc5246d823ff1c289a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39645
+  timestamp: 1699371213055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+  sha256: 64fbbb03570788298d8b04d4ea6cb254fef5d5eec73265aeecd72cb565617f4d
+  md5: 4b1195028bc26257df43fdd943638266
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 159450
+  timestamp: 1710811009212
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
+  sha256: 6abb7e0aeda0130f54925421900772e1bc46d1f04ae69ce1376524457686d49f
+  md5: 232a6370c3fab0c41c6d4c7339e778ca
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - xarray >=2022.12.0
+  - xlrd >=2.0.1
+  - pytables >=3.8.0
+  - qtpy >=2.3.0
+  - scipy >=1.10.0
+  - adbc-driver-sqlite >=0.8.0
+  - pyqt >=5.15.9
+  - fastparquet >=2022.12.0
+  - pyxlsb >=1.0.10
+  - gcsfs >=2022.11.0
+  - matplotlib-base >=3.6.3
+  - tabulate >=0.9.0
+  - xlsxwriter >=3.0.5
+  - html5lib >=1.1
+  - python-calamine >=0.1.7
+  - pandas-gbq >=0.19.0
+  - odfpy>=1.4.1
+  - pyreadstat >=1.2.0
+  - dataframe-api-compat >=0.1.7
+  - beautifulsoup4 >=4.11.2
+  - lxml >=4.9.2
+  - sqlalchemy >=2.0.0
+  - jinja2 >=3.1.2
+  - s3fs >=2022.11.0
+  - psycopg2 >=2.9.6
+  - openpyxl >=3.1.0
+  - fsspec >=2022.11.0
+  - adbc-driver-postgresql >=0.8.0
+  - numba >=0.56.4
+  - blosc >=1.21.3
+  - pymysql >=1.0.2
+  - zstandard >=0.19.0
+  - pyarrow >=10.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17296294
+  timestamp: 1709591285369
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
+  sha256: 10a5eb185aa5dcfecfa854c2e66b3779cb6d2dee85f1b2236f43234a1c1ba9e0
+  md5: 2200abcb857e6bb8cb46b861cb4d2fd7
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.0.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22071486
+  timestamp: 1714072093679
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: daf01c56a3c44555ecb61e9a0e899a7b58872c6b7631f00a04ee8d3199e9e568
+  md5: 2163ed8005a14ecda15efe5586582cce
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 267508
+  timestamp: 1711137004592
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+  sha256: 359b31da651ee35b9ca43974d26cd44e64f3cf412096c15dec7b720fa909a9b2
+  md5: 108e24227f8fdfc4d635bb4eedfa6cef
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48504
+  timestamp: 1698702608965
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+  sha256: 90efc71d35ab62d5b8d7b648e016444e1c4c8b83238b6dc9f2c6c3db4b14c599
+  md5: 6b6eeb0a14c5479db1dd39aa8d338150
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 939480
+  timestamp: 1714399174883
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
+  sha256: f6b0ded7010706431f2a6d9776aa6033dfd19d2264b3cebf28072629160090a8
+  md5: 02de6d0d9cc23fafe2e3597ed0e52693
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3444268
+  timestamp: 1715097155645
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 81719c31101d6c019150cedcc7b08adb3bdb357e8b2952e428dadaabc4dc985d
+  md5: 105825168e0a17fb007f60b5f314e311
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38405
+  timestamp: 1692205731769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+  sha256: c0982f688127129e026d2b4cdacdd5684d00796ea7bdadd7d26b1101b095d723
+  md5: 0d6910c74729fede645c010110f1c89e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 121796
+  timestamp: 1679340253537
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+  sha256: e32843723b10ecd9badde28e1085419c0b59ed8a96c7cacce6395e39e3a874f9
+  md5: 5af0280a817d2c273304cd22328124af
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763044
+  timestamp: 1704404460779
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+  sha256: 117a435c2473e2a20cc81eaacb2b45ea5e7fe3c946eec2915936d344913ede44
+  md5: 0f459ee59fda20e2077fdc2c777edfc8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 497470
+  timestamp: 1679337286052
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+  sha256: 667b5cf00d31293dede2ddadcc30ab967103d585d40647f34d6d830af97ee51f
+  md5: 81d3876fa502fca91ba4136a5f3fc3d3
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37821
+  timestamp: 1678378977816
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+  sha256: dfb403f367c57327a4d080109df88383ecff18464de287a1ce936a7274e3656b
+  md5: 997b674bad89963af875b93b06807f51
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2120413
+  timestamp: 1684280057020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+  sha256: 9d2c0f373ac1c5db329581793dd517092cdf9a59140f2516ed8c3a1f483c0bbd
+  md5: ee10503a159e819abdc586666bdf0952
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207552
+  timestamp: 1678322848766
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 717e038567506ca58ce1cd4a3416892d02f4ebfdd332077cc3d110cfe3d36c58
+  md5: 53bbfb400668f798eef6f8c7cf938e1f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35751
+  timestamp: 1678315886516
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.8-hf27a42d_0.tar.bz2
+  sha256: dea2e1371f27376636d240d98eb9d2d1f383df0264b354c2d97c90b60358f9ab
+  md5: ff3603a0ff4f66a66856b3f09e29fec9
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.5,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16812245
+  timestamp: 1708984581993
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+  sha256: 04e100d0a1ea9722e24972657ec5935ad34c7c58957dabb821333e5eac80f717
+  md5: 2b6de49ad07b26e1f7084f0fda958eb1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332276
+  timestamp: 1716495830117
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+  sha256: 514249897265f66f6ecca0a4427eb02a43c33b3c24974db16d05db6bbe97881d
+  md5: c9ea1437e5a3ba6a52ec2322505203e6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279116
+  timestamp: 1679338758489
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+  sha256: 78b785b9b6ed46c86b0d3a32bdceea49f816672227fb63e726b2d46eadbdba0b
+  md5: 79d783f74359141e0b06a848db33823b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18563
+  timestamp: 1683823935261
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+  sha256: e358fe679e83ccdc8c433746ae6468e8e96d90d97d99530f8476ef5630b2c121
+  md5: ce30a0a31d891e69dc9b7bf8b7f0c39c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 268876
+  timestamp: 1713974360942
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+  sha256: eeb5a5eed93b8e311ad4d3f4389e050f11bba2eaec9536e1c3ed2f849c6c999b
+  md5: c18bd3e12de797d52a470c21a150dffe
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65270
+  timestamp: 1711136914884
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+  sha256: c3e11ed944da69c11b949bb918341a0d79ef603ee34a632d6a45fbf89ff924a1
+  md5: fee7ff4d291f530b4cecb575f29807a0
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 197996
+  timestamp: 1698096137432
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+  sha256: aa07b90a7ee65f76c8cba1ff99a5cdeb95cbe41881ae951f64ffff06674a1b2d
+  md5: 58621e3d244137885f7dfbb35e50340a
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 594801
+  timestamp: 1709318510622
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+  sha256: d784dc26c5de8e41845350a899e5779250b71f45d39e2aece62e739e9add7308
+  md5: 7b077b7f46112bb31dc066396c51d3fa
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74776
+  timestamp: 1699012164201
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
+  sha256: 3357b6b327b3d0a2cc0f02934a60bbd6df38f4ea7bbb3f50cb8e21332c9f5786
+  md5: bf5e48b646e36ef2b788be9665c0e5ae
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 120768
+  timestamp: 1707355762747
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+  sha256: 727fb8d957e02d03b928d049ffbc712316f176a2c331391766d646621b45655a
+  md5: 7e0e416c642f3ee4ddfb084a811fb4df
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10236
+  timestamp: 1683077214314
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+  sha256: a8a67143ccb65cfd6f50055176b6c26179a83130a45d0a12e79dd2de68d8db63
+  md5: a2065790f41e3eeb6efe0ef6daa75377
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10600
+  timestamp: 1683059285216
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+  sha256: 6aba582338faa0c26fe336bdb10c65b8f7808a6e383bd8f80f3e6b612ca209ec
+  md5: a7486349b5f7370f6902c2050a23d268
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 319197
+  timestamp: 1698946203341
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
+  sha256: 86bda04163628ef7b35528fbb4fe1d56fef50d10570a859e5ae8a7fbb60f577c
+  md5: 05e397dddd20d91460e3cedea0b3686f
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 4
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 27745043
+  timestamp: 1714075585637
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+  sha256: beba0555707dac1e8484d73cee9e4128ac4b10e2a0d4209357481179022e8fdc
+  md5: baa8b304607b3a9ae8a3d9acb354c31c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33343
+  timestamp: 1699371216044
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+  sha256: c1df29188e321abe23651c73712a6d8ed3abdc89ad38a42c33f1835b3ab77abe
+  md5: 6c984ea85326858942f7b635e0cc9ff8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1597325
+  timestamp: 1715025837032
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0eb44a16ef74a13ef7839209899d009cd94974fbc406a417d958c7bc8d955245
+  md5: 41f239a5b67b1daf819849023aa5d12f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19056
+  timestamp: 1705431379885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+  sha256: 14775231982e1ea150189c956927ccfb1ad01a8c9395cdeea4d5a48b9b8ce664
+  md5: 729badc4bf7ba8ccc70e0f9e58075c99
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89812
+  timestamp: 1696347694075
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+  sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
+  md5: 6bef1694163a68ac4c37e5857b8da4f5
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1900191
+  timestamp: 1714488351925
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+  sha256: 3d5c2968f581006437df3932cd5d3c1c4afa78f0e13757b958440245d3248856
+  md5: 605ea221d225ad8e79284dbcfdab0715
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37699
+  timestamp: 1678317755913
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: ed059e32ce5a1c0511575f29d2fb6da12c54a37000bfa80f9e5aa9dfd9e04101
+  md5: 4d2261a92d25136a68b8d01d101119f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49145
+  timestamp: 1678317386284
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+  sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
+  md5: 523c006cc67c011383678c762015479b
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3594448
+  timestamp: 1714770737885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+  sha256: 424b8284072266eb59d055c0b7b58241bfb00009d445743ea261d4eeee73ea19
+  md5: f3a47898a55087edb9d65d29c24d9b88
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135757
+  timestamp: 1678323030858
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+  sha256: 6ab71b48d145c69007cfb5b4a21def2cc83bba972b7cc91c7d52d0d7eeb055bf
+  md5: f8970b0ad5c8b452b8722ceb4e5c17f7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 895379
+  timestamp: 1696937269468
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
+  sha256: 3df84b9897f05a104c99e297dc29ad8f718982fc64c61b5a2204c19c578f47e5
+  md5: deab971930d242221ed86bfd768dde40
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 155545
+  timestamp: 1716396266697
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 9e8dbede0bc54c77b974210be66503e7e8e45e0f1c71dc5c16cc9a9674d54259
+  md5: b4fcab9e63bd7b3cdf458c953904807c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270874
+  timestamp: 1678316116954
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: 17e5688d09ffbcb8b71b34b86edc7374fa0b04d60a4d729d405ffc22ef63726c
+  md5: e4bf44ddbbcb136332ccb47ac2b879a0
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9890
+  timestamp: 1715269046804
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: 7d369ec970d1d5411e457c79f94197756c7088deff8183806ea71e633b26edf9
+  md5: 9ffa197b26373667f50b21876862398e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 75595
+  timestamp: 1715269030928
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+  sha256: a9960485ced319ac91afe69eaaf703c7e6b3049f1e06a4a8c2818b64155943f0
+  md5: 0a9c8ea92a14330a07edabac249e32a9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11399
+  timestamp: 1678394892923
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+  sha256: d42ae57366d05e12f10074583568355752436d66ad018ffbcfa24135f593810a
+  md5: 1a98e48aa0bd8b3ec09e2cbdbb236575
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 498952
+  timestamp: 1713213079520
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: 5dc693f0e0aeb30cb6033015b13e75c8a21c56b1262d9652788c3e73a5c5c4a5
+  md5: 6b5cc9b43aa34431f8c30b5cdc22004b
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - selenium >=4.4.3
+  - h2 >=4,<5
+  - requests >=2.26.0
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 210522
+  timestamp: 1715636148762
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+  sha256: 597015e8a038a111f03ffbc9a217fcda549d75230c86ce53c1f23c53d6f1a0cb
+  md5: 62e98aac883bccc1c87ca0d2ce2f08e0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25798
+  timestamp: 1678317074170
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: 1430e6f4b4dd9354b7bb88f7f7bc9cdbab26a034ad1ae5c278de0f5a99329372
+  md5: be0832862b29bf5767a707ac6bd53b93
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 114834
+  timestamp: 1715878445060
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+  sha256: 885a9b6046e76f7dc1a346b14c63b4083046137bfae036362c854458e20e4fc8
+  md5: 3b279447ca282d065e681e567055b582
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 137340
+  timestamp: 1714717062907
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: cc6995f677d1628f42ae80ed47ff08d8d1c8ed12580a326af6e307f5febc594a
+  md5: d01eb964863b95ef62061b77c9037ead
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2471632
+  timestamp: 1689041625741
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+  sha256: 5b6d5246955b5f9480ff7027eb002442a7ade24f5c354da54ed513042f76cedc
+  md5: f32aa8a37d5e65a8dc30f9a1f46bc63d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54719
+  timestamp: 1678325412288
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+  sha256: ed0152ad6b87ffd9e01f4a62bc358e805ad59637f898a801b0a9cf903ae8e1fb
+  md5: 8a92f8c663608f24e14d8a2068b9d83a
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 415323
+  timestamp: 1714511993944
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+  sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
+  md5: c25b6d40f834647d0bbe767f6c776031
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 329449
+  timestamp: 1705602140856
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
+  sha256: 36fa7ad990aabf3607bda1f33e847888210974586363b6d69cf1ed092c192c35
+  md5: c981fe545122206cdeb647f2dc9e093d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 25496
+  timestamp: 1704207010227
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+  sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
+  md5: f2519b551f99765d9d98950c5e2b4713
+  license: Zlib
+  license_family: Other
+  size: 119782
+  timestamp: 1714511811597
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+  sha256: 7feb73e79bdbd45404ddc7a30c43bf4cc68eced8ce448ce7c31f5db134276fc5
+  md5: 48313bc6570c705cadbba3c356e0dc8e
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1014151
+  timestamp: 1714678461080
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+  sha256: 9ca3f0dfc2bdbc109e359ba7ab246e6ae952a14819148ad069454b52f2bda802
+  md5: 51fb05873a644cac52f0d1e10cb7969a
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.23
+  - uvloop >=0.17
+  license: MIT
+  license_family: MIT
+  size: 228856
+  timestamp: 1706220385566
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+  sha256: 43405cc7341ce3efb2e24013ad62c64f26a69926635adceaa5459ccbcafb3776
+  md5: effa6d22f497e164cc8455f7f329c304
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 12510
+  timestamp: 1677917870614
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+  sha256: 947efe1c50b3280e9a67cbb18636bdade53a40960fff3056850ff81ab87acbe3
+  md5: 7d2d384ee32ccc12dcb0dc099e421482
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 35091
+  timestamp: 1677915945226
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+  sha256: 8259b4a0973c825ac81f581afcbe86640bd0a94b33caa996167309241877635a
+  md5: 49b8ddacfd3927bcaae139eadfb72ce1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153557
+  timestamp: 1695717951839
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+  sha256: 11159a30daae77cfc1abe5e60c19261f65c005e6fbc460aecf72318514d737ad
+  md5: 0c5002654a9cb21db1fdf8c1d2017df5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 269772
+  timestamp: 1681493072129
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
+  sha256: 90439f37ede74ef464e76093e173a8e94a20ee4ad79c68c9e7570fbc67fc13cc
+  md5: bb3b906307dd679fc3276be7581494f9
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6073834
+  timestamp: 1712084392983
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+  sha256: 688a071ba370f51b457cd32d70b7b38921ce9551203d06fa7fc2c30c4b79891d
+  md5: b2353077a39ab997463768154dd58fec
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134711
+  timestamp: 1707864978809
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+  sha256: 048264434c33fdb53862cdd69b2e2bc4ce6f8a70b3211ad6d686d066eac2aa91
+  md5: d55696ccaf6755931cd662dfb929aa0b
+  depends:
+  - brotli-bin 1.0.9 h80987f9_8
+  - libbrotlidec 1.0.9 h80987f9_8
+  - libbrotlienc 1.0.9 h80987f9_8
+  license: MIT
+  size: 19737
+  timestamp: 1714483270447
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+  sha256: 13627293296fcc231d8dc12d803dfc9621108c60df38b0e3c64e9e02ed55e564
+  md5: 86efd4ad08cd80d3eab77873db84a255
+  depends:
+  - libbrotlidec 1.0.9 h80987f9_8
+  - libbrotlienc 1.0.9 h80987f9_8
+  license: MIT
+  size: 19083
+  timestamp: 1714483255364
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+  sha256: 2e542b2bb27f8379da3efcb83ef084cb26e6a9ab576c50487c2dd996afd5ccb1
+  md5: e8cab9d1ef58a450f971690fcdb2ede2
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 380182
+  timestamp: 1714483330655
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+  sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
+  md5: 56d1386c7f1f338f0d18f82af6525273
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 158748
+  timestamp: 1714510571033
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+  sha256: bbfc668f445f3584936b326dcfe92bf71971ce16241f4f79db8aeb88d7aab41c
+  md5: 10cc05ed51482e1dfcc31dbd13bb34c6
+  license: MPL-2.0
+  license_family: Other
+  size: 138641
+  timestamp: 1710764806818
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+  sha256: 512969f339a9a7b347cdb7b88f439819168089867f04732279f02759d8caf24e
+  md5: 2009c2ee465fdd74dbd046de73726234
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 166501
+  timestamp: 1707229221324
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+  sha256: 8d26cd4d16545ad8afddd5521bc6894a50d5b8faff3abbe600bb9b062f3c3a0a
+  md5: 66eb734b7d7008eb5fb537900767c7ae
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 286807
+  timestamp: 1714483190838
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+  sha256: df81a27f221d11af4a709f272dc8ba3fd3f6d5ab4ffd883c40567bcf04f0cfd3
+  md5: e49333e3ffe1fe2e701f50a6e6dccc52
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204179
+  timestamp: 1698129906257
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
+  sha256: 53edaca56d853083d44cef6234fe4b3d076d107e915781ce54ec135c25e09f0e
+  md5: 5d1d51e53c11bcb56cf863d58e37c077
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50433
+  timestamp: 1683040076511
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+  sha256: 808e56fb70f3d38599ee7a54c2a707b282ba9a401fa69a1f54cdc26425d9ce01
+  md5: fc37321833175bda4fc5c21afe32db49
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 539588
+  timestamp: 1709758479776
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+  sha256: d9c126d8bcd1c89ea37186c172d6b1f73f45ada60e3ae1790a017b530baa0147
+  md5: f0223aae3d622547f6accb212579c58e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17967
+  timestamp: 1709322909223
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+  sha256: 1f908c688e47d03d92ac09d9541a1f1c773ac2ca485dd1d77441b1aaefc032db
+  md5: 444c330471496a39a97e87f41ed70c96
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281104
+  timestamp: 1700583698464
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.5.0-py311hca03da5_0.tar.bz2
+  sha256: 71c289b48cfb6e957d879c3150963cd80654f408e274a9bc816ee6b72d69e912
+  md5: fd38d206222a32b3c71718acaf205013
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3103523
+  timestamp: 1715838626586
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.16.0-py311hca03da5_0.tar.bz2
+  sha256: 2b7fcd83146c02c4d4b2e2adb2512172536118cb0f630c47a43b11c5005734bf
+  md5: 6687cac2611e1868f6ad781167a671c1
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy <2.0a0
+  - pandas <3.0.0
+  - param
+  - pillow
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17988386
+  timestamp: 1699548972355
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+  sha256: b9356e3ada4872c7c950d2ac7e0f107c4786775191efdfda3a469dffb18f2714
+  md5: 07ddd96675caf30ea77cafb1ea5662a4
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2490144
+  timestamp: 1690905181398
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+  sha256: b1481ffa475c65200626f051d5dcbdb264730b533e928dde608a79ce7a5b4e48
+  md5: aada2761547a291d68f4c016a1a9bc7b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 18265
+  timestamp: 1677911915719
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+  sha256: eb82a0e2ca36d0973b5f6642e27609554edad4b72696f989776d5db8cd4a6a42
+  md5: fa8d9dd8a2fabba964c6bb75ace8c572
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 3201601
+  timestamp: 1713551611540
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.3.1-py311hca03da5_0.tar.bz2
+  sha256: aa53d9f23e86ac3398f6b935cea01dcd8a1b1821d9b1d37b16a5ba68a2dbe569
+  md5: 2d5841b96988498045c28e3b3951d5ac
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 373029
+  timestamp: 1714461571346
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
+  sha256: 898d10bc1ededb43b7339ccf57fef404d96184de8ebaa788dba0b36a8c8a282d
+  md5: a1925e4ff9f6124ca7d439430bc110fb
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5399311
+  timestamp: 1707836657705
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+  sha256: 765d5b7ef75ed7f52a110504cd88e9b0c9977b841f1beaeeabb17e629b462908
+  md5: 0af9cd26a7c9eb8b77d3cbacb93a118b
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 360105
+  timestamp: 1715090588763
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+  sha256: 4d4ab70ae0ce008c1cc96a4edfbf3866d5e636acc4799a545ea93acee51635f7
+  md5: 86a085a440729020d1d7b0b74d6a0c6c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148448
+  timestamp: 1714398923507
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+  sha256: ec139e4b87aadcacc0670ecbcc2a303d858d4ac38b9404458a4b676bce9d21d5
+  md5: bfcfed281f8df0f18726ec5f843b2b26
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 51053
+  timestamp: 1704813595720
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+  sha256: 63670c8f31770e1746016f645ca6b42b35f92d1c37e8025793d9490fed9998c0
+  md5: 9cb417b9fdf02b4e007a5b5781e5a8cc
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229932
+  timestamp: 1705934202146
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+  sha256: a40c76c412ec793ca26b97a9b5c496d253768438e1f7d4a0ee5f63ea79eed355
+  md5: f609e4fe044318211cf0e37e289beebd
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1614299
+  timestamp: 1704833142734
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+  sha256: e57d10579b52a3cde45aa17e1bdd95dcb9d3346aa00eb02c51e38a42db83e18d
+  md5: 05153120787fb09159b6e1ad902c6e10
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1180481
+  timestamp: 1678994989550
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
+  sha256: 06512ef9a910fa72bf5697fe89e88c605d61f8478a9d8dd233c13f40e30f8446
+  md5: cfa00c9ffd3407e29507525c020e5526
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 355730
+  timestamp: 1706733720706
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
+  md5: 055e12390b844ea6c6e956ee08a618e8
+  license: IJG
+  license_family: Other
+  size: 273479
+  timestamp: 1677849171867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+  sha256: 62025ce4a2b9244b9816c9e02487e0dda567600692b5f9ca71f425d084961c7e
+  md5: d57b7063122e5bf25cdfc2a5ea7330a8
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 181872
+  timestamp: 1699041739097
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+  sha256: 404b0847029f77bedd7902a170a046219e0dc5c0ec2be19ff45361cff25b2181
+  md5: 3a02bbe8d45fdbcb2350f672be74c9f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16524
+  timestamp: 1699032463763
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+  sha256: 7deb8ad28c34c369573754304a03ea2acda8ee39102a56526ec689a4d9210109
+  md5: 675ea1a746a78ff6bf8fc4b39139efff
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 277400
+  timestamp: 1677914250715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+  sha256: 8220b1bbdde5e800810f7bf183a992af1a95825a837edf975fa8c4b51c5d806f
+  md5: 3a06ddad06e04d5f0211c22cd81ca75a
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94950
+  timestamp: 1698937436979
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+  sha256: 8a9a9f9ddbf1b7744ef04a8c862438499a41d81a4beb4a49860156c273bb7497
+  md5: 051355801f09eefe850ee8145151f934
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42497
+  timestamp: 1699282590553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+  sha256: 65c703cc996a705d0ee350070e313b1cae865f9d6e6490ebf1164c0f3ce22d93
+  md5: 305ad8bcaad3e352d61b1e594093b467
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 596801
+  timestamp: 1699466743685
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+  sha256: 501e929d345aaa9079c965552b942b4e8bde35b87ae89faef003687a40bab3a4
+  md5: 54c7b8554a405acd7c8326c41ba93e63
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28237
+  timestamp: 1686870817418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+  sha256: 773e7c4571f482a744dfb18ae26fb22635f5d3f51389c838bd97f9044ea55cc4
+  md5: 5161546aba5597318cb5653390cdecd8
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20235
+  timestamp: 1700168681687
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+  sha256: 8c1c64d51be73aad381992a9df19d8336910bdfc40f19940231df86e177d17cc
+  md5: b1f786f96684a143cf30d1f6b8aebdb3
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65045
+  timestamp: 1677925371836
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+  sha256: 199042b87451abaf14546af124ae3380194cddda928e0d30ccb341e93084854c
+  md5: eaa0442887994a82486c65d87f6b71e6
+  license: MIT
+  size: 68806
+  timestamp: 1714483212137
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+  sha256: bd9a8a17fb14086446b710fa029d238e69274b83ee2e7e09093496f190de82b5
+  md5: 66615d6a0cb5dcca3e20c019cde0ed2d
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_8
+  license: MIT
+  size: 32975
+  timestamp: 1714483225840
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+  sha256: e1bf77e8b975c30a69b08a08410622e27c8cff6f592ccfa590466b83d9e6d104
+  md5: 8af86bdac01fe303d693d9b76c071059
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_8
+  license: MIT
+  size: 310266
+  timestamp: 1714483239194
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+  sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
+  md5: f31e4eb9cd6447cc2f5ef0243a76540c
+  license: MIT
+  license_family: MIT
+  size: 120460
+  timestamp: 1714483461787
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+  sha256: d654027daea13ac9db36ab5fd5eff3ad398ec97c1777bf399f3ec680d2c145b9
+  md5: baabb1f905054bfea3af8f5768572a34
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 26579907
+  timestamp: 1683291669565
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+  sha256: 41c62a460bb81a1a272aa28b219fab9c26510adac177ff1528b1980eabc6e868
+  md5: 8d312c5628dc7ea833e9b4dcb73e9c45
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 42346
+  timestamp: 1677973051421
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
+  sha256: 911c7577f591311bfb000121831234e7bc6332bff62fd00c2245371e67f473c0
+  md5: 419681f23f179ba08e5fdf9884ea238d
+  depends:
+  - libcxx >=14.0.6
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 410616
+  timestamp: 1706910762686
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+  sha256: 5777bbef827f72975a36f3da80ab4af718dc781264f74ad7e3864755d620c0f0
+  md5: 4240f1a79b812387919cc710a0469556
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14318
+  timestamp: 1677925438733
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+  sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
+  md5: f5f7e6e7541d8dc3d3df270d488d2e24
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176990
+  timestamp: 1714510588159
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+  sha256: d024f5142416961a5e66e424d4d14aec652f9e9dd738b41a97f45674c2ffc9d5
+  md5: 0e2d94b125d802f7b006cf19c71655a1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 163084
+  timestamp: 1677932947966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+  sha256: acfd84e29ff4dc2d85543bb973a07f22b4ba53c5d00bca84608ee7f13b2a8676
+  md5: 5ca161cd51e2db358e768453b3ee485e
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135871
+  timestamp: 1684279980293
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+  sha256: b1bed54c7bfb7304cde9e8e6f798543d08e808e81286a5a48296fc94d621f9da
+  md5: 774358285c9e496c9f5c121cc546c823
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27438
+  timestamp: 1704206026910
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+  sha256: 9229a6e15abf3147cfcffad4ca389dad940e45779963b4fc3fd56dfdcfca3234
+  md5: 4e1897f3cb4923de48c016468c01c051
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9100733
+  timestamp: 1713336457304
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+  sha256: 3276d61fc353c537bb09d4b7473d7abe12be38806f42c8cc383b62f40850a5cc
+  md5: 6e9c9d47f264b77d9a8461f0899848a7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20446
+  timestamp: 1677918370379
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+  sha256: 43c96d30775b61b4968422a47f9605049428120669f0742bbb9e5ba145c7d11e
+  md5: a31ca0d9284860adf5463cf45a5e3145
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 69243
+  timestamp: 1677995336989
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+  sha256: 96d8c9f42a38651b7bafe5f3cb132601db76cd1e28fa58e2eaf090e634292fff
+  md5: 5ebc793a17b6aa84d13f19433545ffa5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23895
+  timestamp: 1677942274932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+  sha256: db9bd659ada23f1ded443d2db00dd13b5d5c0b30f5062544b1ee2c2b88d63d29
+  md5: 03c48121614cf12abfe30eced9b34717
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105333
+  timestamp: 1677916687032
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+  sha256: 8b05894fdcbe5cfcdee94812b043de4cd7b4fa51d3e2aad25fc7cff50c8f82ab
+  md5: c970d49137dce1c77f782ee5725950c1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 30745
+  timestamp: 1677960816849
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
+  sha256: a8b3d349481dc694eb9a507f55c91e8981e2a3bc41743023ca01248c8a6d779a
+  md5: 71e6e29ec3b98fb282c01b012a5df236
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8294656
+  timestamp: 1699543119360
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+  sha256: e8eee27fb667aa10b26f3bc4b93f449b7d991ded27b9cb457effee394ce05f6f
+  md5: 6a3e5cd0e1141c01ffb91285bdccfe83
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123043
+  timestamp: 1698934328890
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+  sha256: 40230434aa2fbb33ece13632e8d4b7cd1ad68fdb8d1b00263af4a010795d25f8
+  md5: f12ce7dad3620d6d53a442fa9d36a0b0
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - pyqtwebengine >=5.15
+  - tornado >=6.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 538067
+  timestamp: 1699022954841
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+  sha256: a492acec8ceadc0911a75966ffa630a8eb15b2da8c7a8d544a645ba47771a2d1
+  md5: 4002b1b88b2ecfdfc769036f43b0a895
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 170964
+  timestamp: 1694616845237
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+  sha256: 417ace1ce51e81f3f92ddc26e0e3a83c1e19c9ebb7af7104452002a5573da534
+  md5: 3e11de6cef096091bb733e07802f00b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16979
+  timestamp: 1708532698253
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
+  sha256: 2e09ae8d10d7e5651727aab66a1e89b59e716295267a8295eaa53760c4c38533
+  md5: 8d52be8699bf030546811bb69fbeb2b1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 728383
+  timestamp: 1690985022565
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+  sha256: b0cc542e2a6f42ba716e7e4ccf29eddcb155ad167fcdbc72d2db9c7873eb5639
+  md5: 7acf81b17d2c4ceb3cd39dc9f173855c
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27539
+  timestamp: 1699455954000
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.59.1-py311h7aedaa7_0.tar.bz2
+  sha256: 4e0fb594095ce53c58f97eafc1c113e150929a6935e8ee54d86359cc7a9afd14
+  md5: df6c4ead6e4bed95d012bdd5e79f10db
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.42.0,<0.43.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - libopenblas >=0.3.18, !=0.3.20
+  - numba-rvsdg 0.0.*
+  - cudatoolkit >=10.2
+  - tbb >=2021.6,<2022
+  - scipy >=1.0
+  - cuda-python >=11.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6062719
+  timestamp: 1711988782214
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+  sha256: 151a3eb68d1189e69764ece1d8fb3544d31a22f5bbbc3e19d846de8dece304d2
+  md5: eb6609e6bdc9c82d70df3f8c4c2de95b
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153313
+  timestamp: 1696515415712
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+  sha256: d3bb1d4be88320a5861cd3a0f086e9709f9b64c96c032cb9039cc4f17ec66a85
+  md5: 0a7b97665c06fcd34a70e34abc177280
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.26.4 py311hfbfe69c_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11288
+  timestamp: 1708639168951
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+  sha256: 3e70248a7069ca12ccf56252869bfdb72211fd4e4c327e6994756496df786c79
+  md5: ce4846006d98638cd86a532a72f8dfe4
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311he598dae_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7536860
+  timestamp: 1708639153133
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
+  md5: 371358a54bbdd307603888348d1a2c6f
+  depends:
+  - libcxx >=12.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD 2-Clause
+  size: 412248
+  timestamp: 1628861367714
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
+  sha256: da78bd65c91881856baadf977534832f68db3938c1b5b713c8797be70b83c98c
+  md5: f728656890f860eec5ad2899e657df3a
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4763426
+  timestamp: 1716318333548
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+  sha256: 77b0c0a0fb14d817390244ebd93c36d44a7867239963f211f7c0a72a3f98d382
+  md5: b90336feb8a50d2eff880e89acb02f40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39617
+  timestamp: 1699371253760
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+  sha256: 4f6c3e8d8fc4c57975cab837ef109b9ee7af4f18aac72668334ac656e53c6edf
+  md5: fbf1b507f9a80c5de3c957e8152124da
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 159289
+  timestamp: 1710807498427
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
+  sha256: 3af823879c340838c1040e99f653c3438ccce8dc559bd91c3f4ab2579282a002
+  md5: 5b3df01fda0281dab4196bc36d1ca367
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - odfpy>=1.4.1
+  - adbc-driver-postgresql >=0.8.0
+  - scipy >=1.10.0
+  - fastparquet >=2022.12.0
+  - pyxlsb >=1.0.10
+  - pymysql >=1.0.2
+  - sqlalchemy >=2.0.0
+  - pyreadstat >=1.2.0
+  - beautifulsoup4 >=4.11.2
+  - fsspec >=2022.11.0
+  - openpyxl >=3.1.0
+  - xlsxwriter >=3.0.5
+  - jinja2 >=3.1.2
+  - zstandard >=0.19.0
+  - numba >=0.56.4
+  - matplotlib-base >=3.6.3
+  - psycopg2 >=2.9.6
+  - xlrd >=2.0.1
+  - pyarrow >=10.0.1
+  - pytables >=3.8.0
+  - html5lib >=1.1
+  - blosc >=1.21.3
+  - gcsfs >=2022.11.0
+  - dataframe-api-compat >=0.1.7
+  - qtpy >=2.3.0
+  - adbc-driver-sqlite >=0.8.0
+  - lxml >=4.9.2
+  - xarray >=2022.12.0
+  - s3fs >=2022.11.0
+  - pandas-gbq >=0.19.0
+  - pyqt >=5.15.9
+  - tabulate >=0.9.0
+  - python-calamine >=0.1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17082645
+  timestamp: 1709591689205
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
+  sha256: 8bf772501cf4b49a939de17bf378d3e395f452d3070d05871354bd2bc915d012
+  md5: 753d2070a2aea47934ecf6ac1ea0bc04
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.0.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21901817
+  timestamp: 1714071405089
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
+  sha256: 67feb8232961ad9d7672a49f6f86f0b86764f62a97d86d58b90ca7e8345bab76
+  md5: 3afb6e6747bd29e9483d35dbf8b24f74
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264413
+  timestamp: 1711136882294
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+  sha256: 088245becd055af4de74e4ed13cc752ab546423f204b170ba2dd8809af30a2c7
+  md5: 2eabea5ccc56ac088e0349626e59df06
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48517
+  timestamp: 1698702686783
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+  sha256: 174b680f4bb041e8146aae80f92390122459e0ef8c911cab22d01e2e92d44ab1
+  md5: cfffc94779cd26a349bd409b5590b098
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 916496
+  timestamp: 1714399019350
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
+  sha256: 102c3c35a9dfa0f10ec8f4a040a24295f9c736443ccae2f685348a44f62a4d68
+  md5: 027b347e79e252aa17b534e1a02bccd6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3447682
+  timestamp: 1715097070362
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+  sha256: b6200816d65673aa1707c20a768c9cff87dd8dbe1335f9c1478e5931dfa08ee0
+  md5: 14b1e0fa73eb33f9c83048482dcce57b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38423
+  timestamp: 1692205689597
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+  sha256: ebdf211edd98d88a23778551c7a9702106edd0695d4fc48e87c21f77521c1ffe
+  md5: d8c505081a468f1b99c62466e2309417
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 123084
+  timestamp: 1678996822234
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+  sha256: 07cfba50d9e94364bde077731a824ca4f537138b35ee6b66d07aee16ac9850f1
+  md5: 919bf486280a11e6acb3c2c3a82f7473
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763225
+  timestamp: 1704404463402
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+  sha256: 8094436b2c44e68e72569c704633802aad82e977b1e16026848218679c8becf4
+  md5: 2360e46d3e598dd5e2abed781fe166c5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 502115
+  timestamp: 1678995719872
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+  sha256: 4f17f70658e32a9a86661184cace6be3bb7bd61f9b55b513092beddf44552679
+  md5: 0aa95279688b0433badea0b660ac8146
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38653
+  timestamp: 1677933613643
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+  sha256: 121b5b66721760c05f1d4eee91626229d1814663d3fb5f23126ef870aa496e26
+  md5: 0c588c2ca790a05d422c06e8568201ad
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2124200
+  timestamp: 1684280082141
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+  sha256: 44b694db8e81d61960d28d60f9e9b573f03f7827881d302da334378881db4889
+  md5: 6c94ba7caa599ff533e0ab55d898be8a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 208454
+  timestamp: 1677910948527
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+  sha256: 0bb3d2a57b332c5cf73ea40ea13c850ae24a1f9a3a41ed9267832d9e3c767572
+  md5: 45a7fcf1641980d5114999736428502d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36755
+  timestamp: 1677906514270
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.8-hb885b13_0.tar.bz2
+  sha256: 7db8bda1ad368413284ee399322d421feb385863426f8ce3167c0eee6788b8d6
+  md5: b1b70eac1af7d86cc231d9b695ff1d3e
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.5,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16417657
+  timestamp: 1708983786954
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+  sha256: c3cbf5bd237b0a7458640191016b2701fe120c547df9afc835da76663a9c17f7
+  md5: 843568c76b6b9384635b7fca74c79792
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332222
+  timestamp: 1716495881101
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+  sha256: f94b3cfea6f76ea9983e16d3c4c7e0a64f02c40cc2c3ad57189bca2e67030bd9
+  md5: 0d100990ade57a02b60d1e8085db0bdf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 280263
+  timestamp: 1678996927464
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+  sha256: 252c86f5aef7f8dfce99a260c24cbb35a9adfea144a2acfabb224f516341544f
+  md5: 745b888e19a644f48800799f82c01c21
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18539
+  timestamp: 1683823925189
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+  sha256: d945744eb133f19ca61325cac5128bdb053ae04de4a0ba6f69c061449cac8af7
+  md5: 34baa81490d667381bc7021435b0e1f2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 275858
+  timestamp: 1713974457562
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+  sha256: 012585bdb5ae54c2cded50be703734e6dbf418b003635b6f6d7c1e36e7020c30
+  md5: da7e99a707bd0cfa20db651b5c068bfd
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65556
+  timestamp: 1711136890180
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+  sha256: 4f04a43cbd612ab09cefbdc2e48ee61b51967dad59d859ce0502cc2c46c88fc5
+  md5: c68bf65433b2151b51b2e699bc22c501
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 194632
+  timestamp: 1698096151085
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+  sha256: ae8cdd5be5a7ad19ff82925a035859fafcc5942cd3899d127a508dbb9a235090
+  md5: 252a7b997d08bf72f10b3bc2dc68333e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 580346
+  timestamp: 1709318480624
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+  sha256: 7a208abc002a2fc208ae25cb2cf932999a3e4980aa4c9edff315cb9ac62b12ce
+  md5: bd22ebd3cff811577ea61f115ba7f4f2
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74744
+  timestamp: 1699012126255
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
+  sha256: cc8d055a068fe5a7484284c3360d81db61656dd6118c743c740fcc47cd3da379
+  md5: e5fad71ef3b99077b79052576e51bf9f
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 120672
+  timestamp: 1707355664440
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+  sha256: 52368d9b557b8f54ef5ca4bf6cd5a3ec665171f2b2d2082cdd410bab88f4829c
+  md5: ac76fb4d2eef3ecdd491cf5d3fb8620d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10204
+  timestamp: 1683077239143
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+  sha256: 491d116c5f54ef340e3bce631835f7138cd1923d7b63e6ca9aa01b48110cb8f9
+  md5: 9b81bd8ea808704f5433884b567f1f15
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10557
+  timestamp: 1683059079547
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+  sha256: b53a5f6119173d62e4e68a37ea8511c7fc87a00af72953e0048d075a799c7a7a
+  md5: 76a16cf4edb9b12b2b96a2d323f060dc
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 342535
+  timestamp: 1698945991201
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
+  sha256: 9e8312f9452357202813aa289430c939302617f562dae9e90fdc3fb5e9be49d0
+  md5: def02b749d0c0a3675d96aeb508a2306
+  depends:
+  - blas * openblas
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 4
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 26383719
+  timestamp: 1714070280353
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+  sha256: c80d52567084b1caaed2862b77b70065ca17afaf0b020733e9d6c273b4a63e78
+  md5: ddf7d88c1967f3f7a4ce1c975fd47e0d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33321
+  timestamp: 1699371225235
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+  sha256: 6d38d171ef87340cf0fbbf4c70217df4826c65400c9290774f5cb35e381e3315
+  md5: b9529a812f9862fc89461b6b90f184ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1599110
+  timestamp: 1715024190898
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+  sha256: cd71091a234874d2826fa063ec5222b3191c9f47e1b5281c352d9df3f31a06bf
+  md5: 0db8e29016c6bff026c083d9923a7566
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19073
+  timestamp: 1705431415504
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+  sha256: 3e18cdafc607c6d7623b1c8f041cbfbb50a27e298f961abdcce7e36834ac39e1
+  md5: 9ee0da74c55d0b8d83edf246fd717f20
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89862
+  timestamp: 1696347657368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+  sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
+  md5: d8c1e9910392d0bcb22a173f9ce30fa6
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1758290
+  timestamp: 1714488307689
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+  sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
+  md5: ae58720a18a2ed15eae214ad7a10d1b5
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 140125
+  timestamp: 1680167256603
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+  sha256: b5c265e9ed9a1ff2238a09b83bdc1826950faa87fd6b685debe60888de6e7a50
+  md5: 5827c8a32317894ce18576e334daba47
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38559
+  timestamp: 1677918962258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+  sha256: cfefd86d0f4981d22b7611b3dc60359b8698bf39f2b743cb90b7005aaca88e1e
+  md5: a04dbcd6095f6b8f3ad195a78d48b262
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50058
+  timestamp: 1677917499177
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+  sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
+  md5: 3c25b4f4768ccda28b20a03ba27e7759
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3484151
+  timestamp: 1714770744982
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+  sha256: 0836468fafb1f5badbb573922e37200c6929bf2926ecf8d2259dff43811e0727
+  md5: 5bc56dcb4bdb7cf623b7cea499feaddb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 136409
+  timestamp: 1677925889207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+  sha256: 177246487449f87567fe56c8f20011a4350a132d1556c9f87474d7b2e8c1374f
+  md5: d465118217b9f27d47dceff89c2e9f95
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 896655
+  timestamp: 1696937042980
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
+  sha256: 81efb240a49cede5ece3a8ad48f1d9dfdeb56260bf1a20e25ec53cdb202f7c3e
+  md5: 81a17d13c75596841b95340a34bbe929
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 155516
+  timestamp: 1716396017482
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+  sha256: 65e760119352cd85c63d365d2576c09a9ddb060e5b029a265d50bc268eed9290
+  md5: 14c241871b12dc3be52e6cd681267caf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 271445
+  timestamp: 1677911758960
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+  sha256: 96071e07e807414b7ae5a2fe958ac171e5795576b3a4c2f5e8c643fba43d760f
+  md5: a34f2b216e35a37f966883dacda229e2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9902
+  timestamp: 1715268985387
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+  sha256: b20e48aff4c781a52b6be66d77418e768527a621f5fc272ecb34ea03475b2bd7
+  md5: 707738432f16f5e63909fcaa6e65850d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 75604
+  timestamp: 1715268976065
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+  sha256: 2ea2d0520b330d381a2ab241bdb9ae146ef815ee7c96ee52a9773fb9ae85f4fd
+  md5: 66f7f8979cfb2cccffac972d70482130
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 12614
+  timestamp: 1677963554857
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+  sha256: df7fe7740bd853b641d624e2ec97f1aacb2b82691936a8c04ef18fa9768539c2
+  md5: d5c7626d45fd03b22797c18e47812beb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 518048
+  timestamp: 1713213046424
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
+  sha256: 3fbcccceb4d7d99f60a6e6e013ab84c4532244c42ab9d65b6fdaab6bd30f7269
+  md5: 6a7e05872852d4bcde959f7cc8407672
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - requests >=2.26.0
+  - selenium >=4.4.3
+  - zstandard >=0.18.0
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 210307
+  timestamp: 1715635933070
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+  sha256: 09738b7f9075386bf062b12ddb6fb72a06450d2481f6b5ca2026c811cd849569
+  md5: 9afdec076c95746ac21235f971190e40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26727
+  timestamp: 1677910175964
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+  sha256: b4ced7366de8eb7258f31d516616e70c62ed4a798780e57e208509d2b52ab435
+  md5: 65a9a05a726734c1da667f9bd3c78c14
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 114733
+  timestamp: 1715878377412
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+  sha256: aa301d9e42aadbe3dd5f301ccbf17fbadc347fd37d413c0cbcbd24403892a936
+  md5: 77097d17d835a137af7950c628b66150
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 137260
+  timestamp: 1714717037687
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+  sha256: cf030fc7020dc6d28530075468b8dc1edd843a1e393a2f81ca81c962e9af977b
+  md5: cae3fc90233f3af8f433a253d035b6e6
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2470844
+  timestamp: 1689041497962
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+  sha256: 2cd108896df65636769e3804ecc2ca421ad9b54e64fa21922bbabe40c90c247a
+  md5: b3a1e5077b28f71298d891fbfb5ff03e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55645
+  timestamp: 1677927459979
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+  sha256: 5be8c968f2da5c4bf14f28d63e31b4c1b6993d980023769732c7f58f396c2e0b
+  md5: 3f5f62d4e85e3bdd48d39189b01805a6
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 459197
+  timestamp: 1714510992914
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+  sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
+  md5: 3d57d1adadca9388aaaa1c529b65ba65
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 322790
+  timestamp: 1705602163804
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
+  sha256: cf38c69cf62d8f07b91b14bef8e0b6fc5ac220bd3a6cd2ab0378283f0f11494a
+  md5: 11660f745caf5eed1d03eafadb32678b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 25470
+  timestamp: 1704206932876
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+  sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
+  md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
+  license: Zlib
+  license_family: Other
+  size: 104928
+  timestamp: 1714510936868
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+  sha256: a3f3eaf240991b6bd7b0596a78d0abb3321cc79db52fa24f6f559189778871c6
+  md5: 71f035b4716322539e2461cb6667e946
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 825339
+  timestamp: 1714678419523
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+  sha256: 6e6787755de0cf2fd776c9681a7b0fd0fb23e35e679a463cc2005b991c413910
+  md5: ccad42ec9a2ad48939f089c528abc8f0
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 229694
+  timestamp: 1706220431719
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+  sha256: f715f7c2e06149bd6d43258e41479d3171efe5e9d56050a0a5f5652ed9d05fff
+  md5: 11a8ca43d69881b88f95ae681478866d
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 36089
+  timestamp: 1676424516042
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+  sha256: 9adabcdd2a10f73fa5ba56adc901eeea2e379991a0d4cb9737eec7aa6b9fc5d8
+  md5: fc80b572be85601706d425b21a58d497
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153102
+  timestamp: 1695718054194
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+  sha256: 38ccda1553733326d99a75436b4b0f7640bafbbfcdbc33838b0e59cf017de687
+  md5: 3f6812578c5e0b3ba0d2a651cc766c15
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 266405
+  timestamp: 1681493141116
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
+  sha256: fe765d810e1612af7a42f34223077f0adc05dbd386b257be24661913d067fe30
+  md5: 82e988aba03c8afa03fce78f7442806e
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6086137
+  timestamp: 1712084583317
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+  sha256: 5c12a5d7856d9977447360b3a99a5b99818707fe79781ba1779037f11b3fef53
+  md5: 6a125ae352306a944aabc635a5fe13a3
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 139230
+  timestamp: 1707864402762
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 751071782f597f87ed7f67437ef6cc669213902461b9795dd6eb0f4897eddc83
+  md5: 5ad8fe62aad5e16cfdf2c5a7d1327fe7
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_8
+  - libbrotlidec 1.0.9 h2bbff1b_8
+  - libbrotlienc 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 19418
+  timestamp: 1714483531456
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 9bd62d810867549b9c967c5915f3fa3f66cfbd6ede28b1cc152efd1261285c0a
+  md5: 64cc76de3662b62bc8f0e42befd92c5d
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_8
+  - libbrotlienc 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 32178
+  timestamp: 1714483513837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+  sha256: 1547fa52134cf06b8d01bdf52114db7db60a89bf35c9c95be5b5a03b13dbd565
+  md5: deb765cb7c4b7edc4d126f864f31747c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 356401
+  timestamp: 1714483740924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+  sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
+  md5: 11e0af09a31e2d5df51c65a342032b85
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 112994
+  timestamp: 1714511182837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+  sha256: 73391a74a5300ad3fb063ea0f0c3491d220128a0611a84036da2e23c1e93dc0e
+  md5: 501ded4f9b5ed895077802defee912cf
+  license: MPL-2.0
+  license_family: Other
+  size: 171644
+  timestamp: 1710764856021
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+  sha256: cd6545642e380b13700f2f2a7a1fb54a273365047bd23108dbd03b197f5c0c9c
+  md5: 929edc1c553d2da4d6c6c0745b033cc3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 166377
+  timestamp: 1707229328635
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+  sha256: 5cb6ac90ad234248f3795945f69b0382397714a52712337b2f86339526b822d8
+  md5: b90f3126f6315ea2e8ab242533062557
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 302693
+  timestamp: 1714483562551
+- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+  sha256: 7153817dd49ec317b519802c7c22c836602e00cbd96d68385e83eaf4c9f5ba6a
+  md5: cd829e5997611a602e29fa2fd5882635
+  depends:
+  - colorama
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204113
+  timestamp: 1698130080270
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
+  sha256: 03f00c22b6d92ee55b727b369e8dbdd9a4d590f2655b62b7c45ecd046741858e
+  md5: 116f67c13bb0b3caee6cbde334ff6abb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49934
+  timestamp: 1683040303796
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+  sha256: 4099898f02e1f6119fcda65e747c3cbfef0bf563c8855b79a0245160709d5b45
+  md5: ab9705c34e67fb8c8faec69d63ff4064
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36410
+  timestamp: 1676422341506
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+  sha256: c722f50980d7416ffb2cfc7bf72649307a0bb78c5a24eccefcd049cb61d6b355
+  md5: c7c9ff0513ff3c99700919293b702410
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 543258
+  timestamp: 1709758602437
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+  sha256: 8fb3e816a5ad1da05125462dbc9e2a7e933b001a871aa65703802c0a894c6277
+  md5: ee4b2fa9fce130496d5c7c86c35a1a05
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17723
+  timestamp: 1709323150229
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+  sha256: eeb49cd151ecdccd40062e8123a3b7a9a8a1eda6567dd33ce909ff8ee1a97c89
+  md5: b7fe1f7ead1ec2ac642d022942282fc8
+  depends:
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 232451
+  timestamp: 1700583772701
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.5.0-py311haa95532_0.tar.bz2
+  sha256: d4875dbaa16d83af1fc9a05d4d14dfd917f3840fa4d751160f070a7cbaa20230
+  md5: e1d44a630a3508b624fcd37e1d7684d1
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3173632
+  timestamp: 1715838851049
+- conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.16.0-py311haa95532_0.tar.bz2
+  sha256: 7c57396f00b4d63b1b597ccad75548f6e81f4e2b831c660fe14c6764d62148e8
+  md5: 0d1d476cfdb705f2ed6cfe2f6a092ef4
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy <2.0a0
+  - pandas <3.0.0
+  - param
+  - pillow
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18023517
+  timestamp: 1699544725067
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+  sha256: 5c73f86e575f2ad683ee4a1c2df11020e270edd89d12f11199483d57b0b51826
+  md5: e96a12895ce374476277b1b196ba24bd
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3719519
+  timestamp: 1690907216785
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+  sha256: 5d5fc8a24c804010b8cb5963227230352ea3ccf56bea9e8116e34f77223218f2
+  md5: 8f989a72eed6293dfe0533c83057980d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17688
+  timestamp: 1676423357100
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+  sha256: 27fb03eb57d25711a15e145f47a64320a9955b585efc9fd0a1a51cdd71b9fde3
+  md5: eb3869e98f6f53dfec76e2eff4d6b61e
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 2732423
+  timestamp: 1713552175344
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.3.1-py311haa95532_0.tar.bz2
+  sha256: c906de92968266d481957c5776467523da53b7f4d6daadb63255bd5cefd252c3
+  md5: 2710581e3de1c90426c77e4b73185262
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372660
+  timestamp: 1714461880258
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
+  sha256: 68d59a361a93a5ae36542f667138b4ab072e1abff15b3aa2dc55575baf86a3e9
+  md5: 383239566d9506b743c7bc65d709b7e1
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5374020
+  timestamp: 1707836834797
+- conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+  sha256: dee3fc68ed81398d232b3afe9a032837bdbef98c1b2478604d6abd397e3e7d64
+  md5: 3f75535ca6dfee0745b221922f21f6de
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353312
+  timestamp: 1715090519918
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+  sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
+  md5: 582d2c1135a89da757a038de831e7f39
+  license: Intel proprietary
+  size: 11086648
+  timestamp: 1664812389803
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+  sha256: 102c803186db6d62eaf41a906f6c563ff0d62b53c1eaede8a381e18c0d005ed9
+  md5: 9d30dec03058758a428cf152e0ae28b5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148193
+  timestamp: 1714399061601
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+  sha256: db30abacf919b3f68ae1e6a94c467fd1e69fbf47ba7a86e6b491d8bfe4776f92
+  md5: 9299876e7ddc3aea3487fd93340ceae7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 50842
+  timestamp: 1704813715071
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+  sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
+  md5: d215cc8ee7ca2cc83cc250cc5d822fe0
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3929136
+  timestamp: 1699647939158
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+  sha256: 864e9598f64105769b4ec02cc404fb507bc59e217324daf1686c00cfd12c0055
+  md5: 6bb1c3be1f85799a3988afc2c3c5a4f0
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229621
+  timestamp: 1705934494547
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+  sha256: e0b44f0c3a4ead0fb8e58033c0be25524ee9ecf7f4cc632f03e9f6fac3484baa
+  md5: 50cbc18d0c7b42a4553b52d0cef2c857
+  depends:
+  - colorama
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1637367
+  timestamp: 1704834149957
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+  sha256: d81566367c79a28d4717157fc74293e846a47af99387ed479eb001a425dd398e
+  md5: 28c76079c96ad7f8b1a5ed32b438c79a
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1147434
+  timestamp: 1679427525584
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
+  sha256: f766a445df8e81447f27c830e162566b221fa1bfc41296a6c5e0789586ca1fbf
+  md5: 55bc50633414fc8616ccbf4140a42d5f
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353715
+  timestamp: 1706733949898
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
+  md5: 81f2c343dc4c65eea39c45383272068f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 407861
+  timestamp: 1677849239400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+  sha256: 5e6698015a3b048093f5737f0e54bcbae415d0f9682dfdfeae3a8cfb4ea275e2
+  md5: 0093a4214131046c4f68af0739dfbea4
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 201456
+  timestamp: 1699041872445
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+  sha256: 9581be54128954080d7cef448b1728874c2ebbe5064f55adece422cf12eafa5a
+  md5: 3adc105f87d5c7f0b1248bc3423f5b48
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16187
+  timestamp: 1699032556953
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+  sha256: ad8343bad7c8f0448cbcfbaf872cc94b56da81c52e5cdcee2a5d6b89f029eb75
+  md5: addceff8d46c9d1d322618a9ce9e5b39
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 300354
+  timestamp: 1676424060532
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+  sha256: 851ae576c2b72bf3172cd460feec4f5577dc06476a043e185279071b67549fab
+  md5: fae4d214d00de6604738f39acbbb197e
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119710
+  timestamp: 1698937651636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+  sha256: d97ad90f9121ecf7f8d3af773b222c0bd244204ee73a3e44185491fa16d83104
+  md5: 73ac0fa3c67e5eb283173d74a2771752
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 60625
+  timestamp: 1699282918176
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+  sha256: 257e1102d2dc3f8b0c1708585c819e86f41abd101084cd0569e8e31652480875
+  md5: 2128c6806bba6953e1a275f37e7a295b
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pywinpty
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 614705
+  timestamp: 1699467242943
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+  sha256: 90420847230e72a648417f5f77cebcf7f17b89f70788652c276acc0c440e135f
+  md5: ef3d8dee197aa37897bf6d39d2dd878f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=2.0.10
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27639
+  timestamp: 1686871052174
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+  sha256: 97faaf26ce5254ec3649a8ee7f480b1556e4e8e6e4356d2fab1e6a5532631a0f
+  md5: da23bd831c50c877f63038b7e16720ad
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20163
+  timestamp: 1700168785472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+  sha256: 8a2f0909fad0387e57cb0e9ee30db2b20761a9106e794381ffeac387a298fb07
+  md5: 6058b2efc3284e27aacec2e6e6280433
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62334
+  timestamp: 1676432044242
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+  sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
+  md5: f5f73266281ab12377d5d47bdf07500a
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 905072
+  timestamp: 1617648814933
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 7c906c94a4d46ea963080a6ba5bd12c1274da66159877a544fbc70291eeed98d
+  md5: 45a3d52534fac8aa54a55ee92211a918
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 80216
+  timestamp: 1714483371043
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: daad7edc6d56abf3e176479e8628162dbf1c56b3d24db30d708aebae694a5214
+  md5: e8ecf229f7fcb4c0b76d8613627948f5
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 45189
+  timestamp: 1714483420152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 84320217abffa9386186ec8d03b4651bb4b1900d3871adc965a9a9e1d3799907
+  md5: 651312fa22168f71f9aec5f9ee2c2fcf
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 756116
+  timestamp: 1714483464368
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+  sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
+  md5: cf949d76148be1e2a534218d9c57df86
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 155435
+  timestamp: 1714484319443
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+  sha256: 4534c822511a052a72c2b070a05e5d8d6f3550f18ea00a33f9d8a9a92b4382cc
+  md5: 82f24e7660831445a2183216e280a6a4
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41464
+  timestamp: 1676474474981
+- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
+  sha256: b2b50fb4e43e4c4da8db26cf362671e03774384732e1925d82e12dfce45c5ac3
+  md5: 44ff317b1ff9bd2b1fbf39da56965b16
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 20842990
+  timestamp: 1706911120234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+  sha256: 896b7a39bd4ad3621312130122b4fe84dcb67d7355166255c58ea9bc562eb0ae
+  md5: 640b852a56296f48cf073e61a59c5256
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13751
+  timestamp: 1676428354074
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+  sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
+  md5: 320f40b75d93f3b96931c6d13c23946c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 158902
+  timestamp: 1714512129889
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+  sha256: e0dc6e119b224bb31ef34b6ba270ffadc181d38b698c5318de8df7a5d2c4ccbd
+  md5: 992ccd756f09408f0b74dfb9852a8b7f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 182381
+  timestamp: 1676437963591
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+  sha256: 050b5fd4b28132d8102a7e6b40179894dc7f5e41f7ad9ee19211e67446c5740f
+  md5: 3ae0b2f6baec708554648ddafa81b756
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 154386
+  timestamp: 1684279992864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+  sha256: 8269c73b7a9c03b95a121e318d0468f35eecc016093620b0560f35238cc5df51
+  md5: 2914bea0ae29315f998e1abac79ccaa8
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30214
+  timestamp: 1704206218108
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+  sha256: 68fb7d113dbf185b571343847e3dbefdbe7d0b9b5902f1f390bc2a6e33a3f8ee
+  md5: a72ff718390a1fde0b208a43e6b9b655
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 11366001
+  timestamp: 1713336740870
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+  sha256: 43279276850eb6e621812448cddc1093524cee0b7f8ed58b4600b68a4fb659f2
+  md5: 5968b2b5c1f3cf5c8c8c9aaa4d8d66a2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19886
+  timestamp: 1676425829787
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+  sha256: 3062a8254ca351b54f15bea85cc928a3ba4d879bb98ce97ece39a9f7eca215a5
+  md5: 8f1565663abb34ad7fdd512e76da5532
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 68031
+  timestamp: 1676481862508
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+  sha256: cdff5215c292fe59649ca40ca72f5d26da352760c1d6a56feba14eb13f7bbf61
+  md5: e0f3f32b22135dfeaec277bc87183ca9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23328
+  timestamp: 1676442709081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+  sha256: 3b173a25605d2aaacc57ec0e425f1d1c51327eb2521c8742a736e2c76069bc8d
+  md5: 169f1c93a443f95a88665f3008623ce1
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104882
+  timestamp: 1676425142412
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+  sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
+  md5: 527155127b9fada5e5c5c69a624674b9
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187498166
+  timestamp: 1699648376430
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+  sha256: cea59ae60da314caecf08edb9bcb03126c6dd35837c8184bceaa194decca3341
+  md5: 30936b7263cf0171f7c86400f12ef184
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49080
+  timestamp: 1682975093455
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+  sha256: 5070ceb0a406b1b8b99e2ec58f5d224cbe16ec78109c46720bd182b509e05c6e
+  md5: 34de1af5c639f2d06c6c8d99488e4226
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 196201
+  timestamp: 1695058367111
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+  sha256: 6b4b27302e458fa527321c59be7c335d61f86da7501c4d141db20a72fad68b55
+  md5: 7db9b12da1290bb2c2fc6ee52a945905
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 256371
+  timestamp: 1695060425702
+- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+  sha256: 39f09c1bc57b4800ebda331eddb462928435498705351b0432d51a4293294ad8
+  md5: 5565984a02f41e97cb9a4c9126ced14b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29808
+  timestamp: 1676442800892
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
+  sha256: 5422fc4dc6708279223027e45dd1ccffe4dc2feb93c60c8a683946a398c60a1c
+  md5: 62d16437707dd382c21a9ed1d8b375dc
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8304222
+  timestamp: 1699543942441
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+  sha256: e940f9178ee2fa0a7c12873ae35ebea0074371653e5cfa1be8aa8d9271fd343b
+  md5: 355d0835215911738a28010dfa6aa382
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141785
+  timestamp: 1698934346590
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+  sha256: 47dd00c0179f4eb29c70d0453d340f7f5332af326b3d51c64ca3bf6a14be8e7e
+  md5: f66afe718bdb57667b03ebda4cb2ac7e
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 561655
+  timestamp: 1699023338436
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+  sha256: 4ee863a1ff697274c642b3101f82b279a354e3f033a87505655039f89127bb41
+  md5: bfaf19be6644ad2344e118aa0acccb13
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189809
+  timestamp: 1694617194065
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+  sha256: 90fb3f14c49da1397982eae21cd09e8d60d491d76f94c57590c56723fe6dc172
+  md5: 46a523661fe5c1bce7b4213fd428c3de
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16732
+  timestamp: 1708532795328
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
+  sha256: 5db3fd8b4d97e2a6232e2f7c62f1ce82ae3876326aed9f8c3ea656eda83e55da
+  md5: 39c36df9dac13398e8a54497dcc14611
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 755697
+  timestamp: 1690986137327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+  sha256: e040ebcab948325fbe17e4ab15be62e1fafa7bad225457e59764adb60eb40db5
+  md5: 4d40a09df8cb74a9f044eab317436d67
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27282
+  timestamp: 1699456187703
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.59.1-py311hf62ec03_0.tar.bz2
+  sha256: a20cb730d87b945125202c7f4e81490c24db708f373d1214e6b04f5d2b4177b3
+  md5: a235c61c1928d09080158ffd42ffbccc
+  depends:
+  - llvmlite >=0.42.0,<0.43.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - cuda-python >=11.6
+  - tbb >=2021.6,<2022
+  - scipy >=1.0
+  - libopenblas !=0.3.6
+  - numba-rvsdg 0.0.*
+  - cudatoolkit >=10.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6100005
+  timestamp: 1712021687877
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+  sha256: d3bd2a6614bb7e7f5ce3348d6674e71cce45cbde236beff32f0f08cd95a64ef0
+  md5: e70f15643164f432d1df68635e7c322b
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 162691
+  timestamp: 1696515822068
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+  sha256: 470fe9a0b3e196fa60d5550d8188f6074a207572fa0d353a4448d580872e7804
+  md5: 6fdb8df0613fb2fb9f1732d335fa25f1
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311hd01c5d8_0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11053
+  timestamp: 1708641901110
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+  sha256: 222c1711e7cf151e29077c7d4d86a865c9fd39615812d58a1daca6fd1b6bdfb5
+  md5: 585bcd8bc3940a8a859f38ebafdcd77d
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.26.4 py311hdab7c0b_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10723862
+  timestamp: 1708641867155
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
+  md5: ab07e2a27ac08afe3d0b4c0890b8486a
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 2-Clause
+  size: 249316
+  timestamp: 1630094024143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
+  sha256: c8e066c2cb547914401ec29b7356914ca3cdf6ac37eead248fe0c41236a7838c
+  md5: 5879739cc77497a518b2ebd55857183b
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8118619
+  timestamp: 1716319803768
+- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+  sha256: b2f5f50a1ddf811102636f3acebd76716c88ebb628754b91eda7a3a962adf26c
+  md5: 712527b4d84c350dca4b67f511c04414
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39421
+  timestamp: 1699371341381
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+  sha256: 432b8b7c4671878cbbe361e518544203f97bd2e4f24fa08cf65e8be583f25529
+  md5: e62e7c668b080e0f6ce09fd548f69f7f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 159066
+  timestamp: 1710809127954
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
+  sha256: 3ae55d8148580fc3f171c0fcc420488fbba05517cefd358fe013b45ec3594371
+  md5: bfb42ed6826a1c8cded9539fc6e07029
+  depends:
+  - bottleneck >=1.3.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - python-calamine >=0.1.7
+  - xarray >=2022.12.0
+  - lxml >=4.9.2
+  - dataframe-api-compat >=0.1.7
+  - jinja2 >=3.1.2
+  - zstandard >=0.19.0
+  - blosc >=1.21.3
+  - matplotlib-base >=3.6.3
+  - adbc-driver-postgresql >=0.8.0
+  - xlrd >=2.0.1
+  - fastparquet >=2022.12.0
+  - pymysql >=1.0.2
+  - gcsfs >=2022.11.0
+  - pandas-gbq >=0.19.0
+  - xlsxwriter >=3.0.5
+  - pyarrow >=10.0.1
+  - html5lib >=1.1
+  - pyqt >=5.15.9
+  - psycopg2 >=2.9.6
+  - scipy >=1.10.0
+  - numba >=0.56.4
+  - qtpy >=2.3.0
+  - openpyxl >=3.1.0
+  - adbc-driver-sqlite >=0.8.0
+  - tabulate >=0.9.0
+  - pyreadstat >=1.2.0
+  - pytables >=3.8.0
+  - beautifulsoup4 >=4.11.2
+  - pyxlsb >=1.0.10
+  - sqlalchemy >=2.0.0
+  - s3fs >=2022.11.0
+  - fsspec >=2022.11.0
+  - odfpy>=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16924671
+  timestamp: 1709591125871
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
+  sha256: b529eac4abff05f13760c51ad37adf24e744109a6fb30471b26dc1f6a1c23847
+  md5: b690cc140a7866280131762a26c05f39
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.0.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21902721
+  timestamp: 1714073654508
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
+  sha256: e77795e1af9bc27d45841d6b9c51e0e7da31e0eabaaffa99162245adc55d13a3
+  md5: 14046398ac44f496bc9df300285ec586
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 267222
+  timestamp: 1711137058994
+- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+  sha256: b0d7fbfcf1c5c682ed9934eb6a33e00a2517941f2bcb9d677379f4bb73b2c45c
+  md5: 20c8f36595a48f5cda2f4f74c02a3ea2
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48206
+  timestamp: 1698702818841
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+  sha256: 6ca54ba8ce430caa8a1838b19869814d0b7fa3592a77f75298130983e635387b
+  md5: e56c194e56d19dd8fd76f75a77f92c33
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 1070844
+  timestamp: 1714399290671
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
+  sha256: 15001c7ee6cf6e0ef7afc2f313114f6103e7b6f641fac9a6899ee02d6537c822
+  md5: 250ba95e77f5fcb3fe2aefa85157e859
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3759346
+  timestamp: 1715097175495
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+  sha256: e5f8cbfb5fc25d460a9117bfc5511959c5e86ccb193316033f87bd516e0c8881
+  md5: 9f7e8b5eb651539386bb92c14e5c321b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37730
+  timestamp: 1692205554840
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+  sha256: 6c5b53831273674361437fb546e08315fc11ca9275a174bca3887987e86ced5a
+  md5: f8d91daf5173eb03157f484389adcdd4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 122178
+  timestamp: 1679591983138
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+  sha256: 546819d922b03f3a25ca9f98fd069d0588d481fc0603c6d74bd598fb6a93687f
+  md5: 86c18e3e0b67ee099457475ed6caf2e6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 751763
+  timestamp: 1704404627180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+  sha256: ae06f0dfa2cfae51404afc6d6ad3a474a93015b5ba9a7d3ea24224b8e7547987
+  md5: 3e19794c806cc3e84a3080a97c359b75
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 510466
+  timestamp: 1679005998612
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+  sha256: e2af1efb1a5094a5962d93fa949ecab479a2ae7570e030f52eeac6761383c208
+  md5: 4cb1359e22ddf8f3996afddce5f6205c
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 56638
+  timestamp: 1676438592117
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+  sha256: d95c88d06f4f3f667bd9a39e5f18179e83b3cd4c115c06ce0fff390ff6d3a700
+  md5: c6d00a8a4d89b1be99bfa3aff19d96b4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2134881
+  timestamp: 1684280285492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+  sha256: 643a9a0eba1e2bd5980d21623d3b35188c24781ec251acc4d15714bd1ccb4c17
+  md5: b3cda0394db05be6f0f6176abacb13f3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207985
+  timestamp: 1678721438358
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+  sha256: 974c22de09078bf07c5db31fe12d8d89d6433508defc8237cbe52e08c69ed56b
+  md5: 9cf10bfd49140a527cf4b1d912097e6d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36072
+  timestamp: 1676426019064
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.8-he1021f5_0.tar.bz2
+  sha256: 1c557d91837e0205cd08180b604da06f28d7679df1ea1026e7954add3eb4d468
+  md5: 3901bef86daffeb6ff2317543b292766
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - openssl >=3.0.13,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.5,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - openssl <3.5.7
+  license: PSF-2.0
+  license_family: PSF
+  size: 19539055
+  timestamp: 1708983524626
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+  sha256: 2c61639b3bb56fc864c86558bceb7845b1731ac44bf1a94894172ea47a995bd4
+  md5: 404805e547b4d50b5cd17e16bca87527
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332043
+  timestamp: 1716495838826
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+  sha256: 9acb33db60d9319595f52337cae3b88c2a2338cd66f1f9d8ae86d0a993c2067a
+  md5: f4af8cf94d042b4dde487241bba1c457
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279780
+  timestamp: 1679500609851
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+  sha256: 48fe7373b012b51134b6b6ff67f18d2b4aae3a5c7700e4560ce002af7172f064
+  md5: 0379cd17692152c12b662b0e4ea46b88
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18008
+  timestamp: 1683824373128
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+  sha256: 803274d986d0c4e3b5ec1018747ede86ef57137455b3e44a60e834717eafb92b
+  md5: c9f134ddeff6fdf0373a45534ddb7079
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 273009
+  timestamp: 1713974722039
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+  sha256: 6fbcba97c1dcb5157afd23f264c3cff069c7e4be5ea55980fc349eb8dc2cb49e
+  md5: 8153e3f8b3283926bcf9403804a365f5
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65050
+  timestamp: 1711137009299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+  sha256: cd33dfee104dfbba4af38d06a09ccbae6a32e7c543afedab523303319ebb283d
+  md5: 3dfc19af0306d80921e1403f1f551bba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13679916
+  timestamp: 1676423267293
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+  sha256: 102ff1d958209e3648bb49da3503cf752abab822011fdc4e12e88145c9e73772
+  md5: 0553c2c381b6f5c836b23edc8c6db2ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 246689
+  timestamp: 1677708371873
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+  sha256: bee5c4d0f41f06a9c0aac636885e36e8b81116aafde980f9ea48fdb64abb5567
+  md5: 6c05a053240cb90765d6f8c2efdf905e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 182228
+  timestamp: 1698096268270
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+  sha256: ea39db411361d96545a04fb976940e9590147acb4ca9caacf7e8264780379347
+  md5: b411b8be8e53e5059949dde02dd07faf
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 565148
+  timestamp: 1709319072176
+- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+  sha256: 47653b45a5f2d97b5bf0dbf0e620908880f9078da427eef69012effe3f19af67
+  md5: 44e709ae67d89bccee2d4d46d358fee3
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74493
+  timestamp: 1699012356534
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
+  sha256: d7bcba5262df162756885a773c3bf2dace27311bbbb1830a0f97aa60ac7c1239
+  md5: daeb99ccfe39f725278203412aac0873
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 120468
+  timestamp: 1707355917958
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+  sha256: d6daaa6b45272819176e4aeb467ae00e3db43386548464a9993688f292709d40
+  md5: 9fe721d7f7420c259df4f07d4503f654
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9683
+  timestamp: 1683077110211
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+  sha256: 6051860575f9448aea5799d74469c928cd7cdeeca1eb53657872262a77b1a7a8
+  md5: 60e193eca497130034facd5fed168249
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10094
+  timestamp: 1683059114376
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+  sha256: ecd310461c1b45ab92ddf15539cea5a6e837860561c974d2d7393f9a7933f116
+  md5: 1762fec2838763e904141167e18b0389
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 215600
+  timestamp: 1698947891859
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
+  sha256: 0042fa2dc2ec8c2181f28f5ee4f45087ea58dca7acc6b89c48f3ce6eac8f9bdd
+  md5: 755c9767608b233b94ec3a67c8e0da4b
+  depends:
+  - blas 1.0 mkl
+  - icc_rt >=2022.1.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 5
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 32418527
+  timestamp: 1714081783418
+- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+  sha256: 6fd52bae6360fbc8135d72e0c1e4fd407769fa4d0f4b59356e7aed3e000eb339
+  md5: 49fd52885250da8aab17ed72e2e18b81
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88901
+  timestamp: 1699371435766
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+  sha256: a2ec4690bc07be9e7f3ad8e3003803eb4304a434d3f139633e2817318a9f7b20
+  md5: dd2d225219924fc5c36598c919541271
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1593050
+  timestamp: 1715025622141
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+  sha256: 5d1b7e14dc04816692de0f8518ea8fcbefb26ab61cec83f96f2c44c1bee67fab
+  md5: 505d2a70a875b5082dc857aa4dfab0d4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 18830
+  timestamp: 1705431395254
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+  sha256: 5ff3b4ac3fbce4dd67a87856c04698d0397deb0ac288ff4e7eb02fbab57f1253
+  md5: 0ca650a7001c6650809d3361de8cb005
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89590
+  timestamp: 1696347858925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+  sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
+  md5: 833b93a2daade3407898f15588945d83
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1440481
+  timestamp: 1714488344682
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+  sha256: 78d89b50a29fbeb19a562f5dad95615e3f192bb4f3b86cd6ea75f2f825418232
+  md5: 4a4040df560ea47704e0898c4c015808
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38069
+  timestamp: 1678228553220
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+  sha256: 70a3cc4a4e81a6421bc19cd410d1d6064aadb2b1cce38b020f85e5346716d8e7
+  md5: 32a9a2539579a3d522dce3b5cb4f987b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49495
+  timestamp: 1676425411739
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+  sha256: 0a95736cfd0bb25fc201cd6be4a2450ea8fc30eeb349d861812675b84c94fa74
+  md5: a8a9fb30c6dd8e7a16d5dcd2333c3c49
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3844176
+  timestamp: 1714770894235
+- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+  sha256: ed5950ac0c12cc87f991a6f28112cf29057e2b7ad416ae4429a0b97c3efaf58c
+  md5: b5e2a04879e6fd19f0eb5effded4dc61
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135939
+  timestamp: 1676431438808
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+  sha256: 4febf30c11674711b86c8c10da46a5e1613071388da999210912a31508864add
+  md5: 1c109fc1112ea1f5f377bdf0d18ba75f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 895633
+  timestamp: 1696937216859
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
+  sha256: 973dc7991dd5976ce2d27a94739712cac4d31f2d2958fbf23adb844f5ac999c8
+  md5: ca74b36907b3f4f8a51bd5b2e4d8220b
+  depends:
+  - colorama
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 186541
+  timestamp: 1716396206048
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+  sha256: e8c77efe880546252f244f995cbed5967809555127b4f818b97455d434b23415
+  md5: 7397ac07045115960ebd8dec95326a7a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270819
+  timestamp: 1676423321499
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+  sha256: ab3cce654f1e94793fff0cb03b750d9b20cdbf099263b1906c3c5eaf8b347ab6
+  md5: c68ffc771312afb6f88b94c24d2bb689
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9706
+  timestamp: 1715268972001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+  sha256: 4089efea1753ebe2f6617b46cc368738f285b1d816d4a4f01ba71524f46851b4
+  md5: 7f610528ecd0b317180efa2058c32323
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 75414
+  timestamp: 1715268958140
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+  sha256: d091897f05318c22ca31028370f25355065999078f7db6f88ab27bf4cb030ec8
+  md5: 1776502c1cfb351554eeda6cddaf255f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11588
+  timestamp: 1676457729096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+  sha256: c16498f8238cc331618720d078b87995eceb6bbf20268a7a4e8efbf7b5859a9a
+  md5: 770432c0ca1ab9d99ffe95e51d3a3e74
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 517433
+  timestamp: 1713213261710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
+  sha256: 3009bd4e7e8126309e606c81cb75d4b8d4fbb2bceac10ec43f7eb6eaaf717ac2
+  md5: ee6e87af42008a762d3531771c1a2b18
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - selenium >=4.4.3
+  - requests >=2.26.0
+  - h2 >=4,<5
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 210034
+  timestamp: 1715636431813
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
+  sha256: 906048f3b1dc326b367a08edc91816ff523b5f06cd45d985b4dbb7cfe8017559
+  md5: e509c495aaa92d767d554cd43a990ee5
+  depends:
+  - vs2015_runtime >=14.29.30133
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8900
+  timestamp: 1715797316229
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
+  sha256: ab224d078734a23527716388ddffc034d18254843881d0fc068c2efa35bacfe1
+  md5: 73f5831d017e5572330d2459844718f3
+  size: 2246565
+  timestamp: 1715797302913
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+  sha256: 24ea3d3e0cb98d0d246338dbb4562b67967bb32002e3704e495a5c863476e831
+  md5: c7b9cdbe87b3c9720aeca1164a0fd6df
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26181
+  timestamp: 1676424437003
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+  sha256: 92d27e41ce34387e59acb47572fcb2e92c4defaeadafd11ce190226022023e69
+  md5: f1bf142d852987acbe4b0bc94e87d958
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145306
+  timestamp: 1715878654770
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+  sha256: 1b086d1b079fdb2f148c7dd82658f2b7f283c88f286e1216c0f1237319039b0f
+  md5: 299e87f151a549d86a48bf24df15c607
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 168041
+  timestamp: 1714717238470
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+  sha256: 17fadf35aa8917c107e7b369e9364ac7c09537776e7943d37e225e14b7026c94
+  md5: 0e67c3b9624540581b894b11267a837b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PUBLIC-DOMAIN
+  size: 10197
+  timestamp: 1676425485716
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+  sha256: 25373efabba9a866849fe38a47c79e0fa323851b4bd4b5df357cc8d5617c2786
+  md5: a958e9d32c3b65c21e11e5d9e8491c43
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2467966
+  timestamp: 1689041676824
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+  sha256: b849b368e27920838fe40a512b102879693a55cb187dd1c8d3a83fa8c05a8054
+  md5: 7b1f6e9c71906a93039b3446b99a5498
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55114
+  timestamp: 1676434863173
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+  sha256: 344a5276a9928638dcde054dfe4e87c8cb40bd2d4d356378b9ab2f863ca62e4b
+  md5: fe471fd8b5a3d77be6fa5dbf9b99dafb
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 1432281
+  timestamp: 1714515119689
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+  sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
+  md5: e5aed81295b61b6d1eb62830799a0297
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 9125184
+  timestamp: 1705602328351
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
+  sha256: d932439798665be388bbf68f3d68da5b42ed4753a43587d3f49848a85f58add4
+  md5: e2900345674e644e05540ffac6acca89
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 25247
+  timestamp: 1704207149955
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+  sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
+  md5: f295b54ab59f5b8658e2a322ac6aa721
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 162161
+  timestamp: 1714514792081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+  sha256: b2ff66b7f6efa0831f939e57e562c244332b690af08818a540d1a97fa07d8525
+  md5: e548d528873d9a0006a36714cf36462a
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1933522
+  timestamp: 1714679197977

--- a/attractors/pixi.toml
+++ b/attractors/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "attractors"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/attractors/pixi.toml
+++ b/attractors/pixi.toml
@@ -1,0 +1,41 @@
+[workspace]
+name = "attractors"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2018-09-17"
+maintainers = ["jbednar"]
+categories = ["Mathematics", "Featured"]
+labels = ["datashader", "panel", "hvplot", "holoviews", "param", "numba", "bokeh"]
+description = "Calculate and plot two-dimensional attractors of a variety of types"
+
+[dependencies]
+python = "3.11.8.*"
+bokeh = ">=3.4.0"
+notebook = ">=6,<7"
+pyyaml = ">=6.0.1"
+pandas = ">=2.2.1"
+numba = ">=0.59.1"
+datashader = ">=0.16.0"
+colorcet = ">=3.1.0"
+holoviews = ">=1.18.3"
+hvplot = ">=0.9.2"
+panel = ">=1.4.1"
+param = ">=2.0.1"
+pip = "*"
+setuptools = "*"
+wheel = "*"
+
+[target.osx-64.dependencies]
+libgfortran = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[activation.env]
+DASK_DATAFRAME__QUERY_PLANNING = "False"
+
+[tasks]
+dashboard = "panel serve --rest-session-info --session-history -1 attractors_panel.ipynb clifford_panel.ipynb --show"
+notebook = "jupyter notebook index.ipynb"

--- a/attractors/pixi.toml
+++ b/attractors/pixi.toml
@@ -23,15 +23,15 @@ holoviews = ">=1.18.3"
 hvplot = ">=0.9.2"
 panel = ">=1.4.1"
 param = ">=2.0.1"
-pip = "*"
-setuptools = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+setuptools = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [activation.env]
 DASK_DATAFRAME__QUERY_PLANNING = "False"

--- a/bay_trimesh/pixi.lock
+++ b/bay_trimesh/pixi.lock
@@ -7,980 +7,980 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py38h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.4.57-he6710b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.1.6-h2531618_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.9-he6710b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.8.185-hce553d0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.3.3-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py38hce1f21e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/branca-0.6.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py38heb0550a_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.18.1-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cairo-1.16.0-h19f5f5c_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cartopy-0.18.0-py38h0d9ca2b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py38hd667e15_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cfitsio-3.470-hf0d0db6_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cftime-1.5.1.1-py38hce1f21e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py38h130f0dd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/curl-7.82.0-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.11.0-py38h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py38h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py38h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2021.10.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fiona-1.8.13.post1-py38hc820daa_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/folium-0.14.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freexl-1.0.6-h27cfd23_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gdal-3.0.2-py38h2c27f0e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/geopandas-0.12.2-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/geopandas-base-0.12.2-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/geos-3.8.0-he6710b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/geotiff-1.7.0-hd69d5b1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf4-4.2.13-h3ca952b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf5-1.10.6-hb1b8bf9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.1.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py38hb070fc8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.12.2-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py38h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/joblib-1.2.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/json-c-0.13.1-h1bed415_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kealib-1.4.14-hb50703a_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py38h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.19.2-hac12032_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.73.0-h3ff78a5_11.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-7.82.0-h0b77cf5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdap4-3.19.1-h6ec2957_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20210910-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgdal-3.0.2-he6cead7_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libkml-1.3.0-h7ecb851_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.0.0-h3826bc1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnetcdf-4.8.1-h42ceab0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.46.0-hce63b2e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpq-12.9-hc2c5182_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libspatialindex-1.9.3-h2531618_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libspatialite-4.3.0a-hbedb2dc_20.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-h8f2d780_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h85742a9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libzip-1.5.1-h8d318fa_1004.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.37.0-py38h295c915_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mapclassify-2.5.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.0.1-py38h27cfd23_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py38ha18d171_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py38h7b6447c_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py38h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py38hd3c417c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py38h51133e4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py38hd09550d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py38_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.4.4-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/netcdf4-1.5.7-py38ha0f2276_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py38h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.54.1-py38h51133e4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py38h6abb31d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.20.3-py38hf144106_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.20.3-py38h74d4b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.3.5-py38h8c16a72_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py38h22f2fdc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pixman-0.40.0-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pkgutil-resolve-name-1.3.10-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/poppler-0.81.0-h01f5e8b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/poppler-data-0.4.11-h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/proj-6.2.1-h05a3930_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py38h27cfd23_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py38h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyproj-2.6.1.post1-py38hb3025e9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py38heee7806_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.8.13-h12debd9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.2.1-py38h2531618_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py38h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py38h295c915_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rtree-1.0.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scikit-learn-1.0.2-py38h51133e4_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.6.2-py38had2a1c9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/shapely-1.7.1-py38h1728cc4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py38h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/testpath-0.6.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tiledb-2.2.9-hffe1d7a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py38h27cfd23_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py38hb070fc8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.18-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py38_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py38h06a4308_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2022.11.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xerces-c-3.2.3-h780794e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py38h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.4.9-haebb681_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/click-7.1.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2021.10.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2021.10.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/geoviews-1.9.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/geoviews-core-1.9.1-pyh06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.6-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munch-2.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyshp-2.1.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/threadpoolctl-2.2.0-pyh0d69192_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py38h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-common-0.4.57-he6710b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-event-stream-0.1.6-h2531618_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-checksums-0.1.9-he6710b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-sdk-cpp-1.8.185-hce553d0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-2.3.3-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.4-py38hce1f21e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/branca-0.6.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py38heb0550a_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/c-ares-1.18.1-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cairo-1.16.0-h19f5f5c_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cartopy-0.18.0-py38h0d9ca2b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.0-py38hd667e15_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cfitsio-3.470-hf0d0db6_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cftime-1.5.1.1-py38hce1f21e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cloudpickle-2.2.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py38h130f0dd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/curl-7.82.0-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cytoolz-0.11.0-py38h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/datashape-0.5.4-py38h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.5.1-py38h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/distributed-2021.10.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fiona-1.8.13.post1-py38hc820daa_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/folium-0.14.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freexl-1.0.6-h27cfd23_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fsspec-2023.9.2-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gdal-3.0.2-py38h2c27f0e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/geopandas-0.12.2-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/geopandas-base-0.12.2-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/geos-3.8.0-he6710b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/geotiff-1.7.0-hd69d5b1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/hdf4-4.2.13-h3ca952b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/hdf5-1.10.6-hb1b8bf9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib_resources-6.1.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.19.2-py38hb070fc8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.12.2-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py38h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/joblib-1.2.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/json-c-0.13.1-h1bed415_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.2.2-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kealib-1.4.14-hb50703a_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.2-py38h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/krb5-1.19.2-hac12032_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libboost-1.73.0-h3ff78a5_11.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libcurl-7.82.0-h0b77cf5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libdap4-3.19.1-h6ec2957_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20210910-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgdal-3.0.2-he6cead7_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libkml-1.3.0-h7ecb851_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libllvm11-11.0.0-h3826bc1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libnetcdf-4.8.1-h42ceab0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libnghttp2-1.46.0-hce63b2e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpq-12.9-hc2c5182_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libspatialindex-1.9.3-h2531618_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libspatialite-4.3.0a-hbedb2dc_20.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libssh2-1.10.0-h8f2d780_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h85742a9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libzip-1.5.1-h8d318fa_1004.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.37.0-py38h295c915_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mapclassify-2.5.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.0.1-py38h27cfd23_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.5.1-py38ha18d171_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py38h7b6447c_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py38h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.1-py38hd3c417c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.2-py38h51133e4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/msgpack-python-1.0.3-py38hd09550d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py38_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.4.4-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/netcdf4-1.5.7-py38ha0f2276_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/networkx-3.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py38h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numba-0.54.1-py38h51133e4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.1-py38h6abb31d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.20.3-py38hf144106_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.20.3-py38h74d4b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-1.3.5-py38h8c16a72_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/partd-1.4.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-9.0.1-py38h22f2fdc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pixman-0.40.0-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pkgutil-resolve-name-1.3.10-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/poppler-0.81.0-h01f5e8b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/poppler-data-0.4.11-h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/proj-6.2.1-h05a3930_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.8.0-py38h27cfd23_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py38h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyproj-2.6.1.post1-py38hb3025e9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py38heee7806_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.8.13-h12debd9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-lmdb-1.2.1-py38h2531618_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0-py38h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-22.3.0-py38h295c915_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rtree-1.0.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scikit-learn-1.0.2-py38h51133e4_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scipy-1.6.2-py38had2a1c9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/shapely-1.7.1-py38h1728cc4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py38h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/testpath-0.6.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tiledb-2.2.9-hffe1d7a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.1-py38h27cfd23_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py38hb070fc8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.18-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py38_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py38h06a4308_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xarray-2022.11.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xerces-c-3.2.3-h780794e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py38h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zict-3.0.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.4.9-haebb681_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/click-7.1.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-2021.10.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-core-2021.10.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/geoviews-1.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/geoviews-core-1.9.1-pyh06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/holoviews-1.14.6-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munch-2.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pyshp-2.1.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/threadpoolctl-2.2.0-pyh0d69192_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2021.10.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2021.10.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/geoviews-1.9.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/geoviews-core-1.9.1-pyh06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.6-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munch-2.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyshp-2.1.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/threadpoolctl-2.2.0-pyh0d69192_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py38hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py38hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.3.3-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.73.0-hca72f7f_12.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py38h67323c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/branca-0.6.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py38he9d5cce_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cairo-1.16.0-h3ce6f7e_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cartopy-0.18.0-py38hf1ba7ce_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py38h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cftime-1.6.2-py38hacda100_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py38haf03e11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py38ha2381d6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/curl-8.2.1-hdb2fb19_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.0-py38hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py38hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py38hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2021.10.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/expat-2.5.0-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fiona-1.9.1-py38h07fba90_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/folium-0.14.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fontconfig-2.14.1-hb0a0c50_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freexl-1.0.6-h9ed2024_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gdal-3.6.2-py38h09faefc_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/geopandas-0.12.2-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/geopandas-base-0.12.2-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/geos-3.8.0-hb1e8313_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/geotiff-1.7.0-hf6ff7a4_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gettext-0.21.0-he85b6c0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/glib-2.69.1-hfff2838_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf4-4.2.13-h39711bb_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf5-1.10.6-h10fe05b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-58.2-h0a44026_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py38h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.12.2-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py38hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/joblib-1.2.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/json-c-0.16-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kealib-1.5.0-h72c422f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py38hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.73.0-h3fa6bed_12.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20221030-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgdal-3.6.2-hd170585_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libkml-1.3.0-h85bf17e_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm11-11.0.0-h46f1229_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnetcdf-4.8.1-ha5d86b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpq-12.15-hdb2fb19_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libspatialindex-1.9.3-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libspatialite-4.3.0a-hd1e8275_23.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h930c0e2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libzip-1.8.0-h272c8d6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.37.0-py38hc9110bb_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mapclassify-2.5.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.0.1-py38h9ed2024_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.7.1-py38hda11e5a_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py38h1de35cc_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py38h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py38h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py38ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py38haf03e11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py38_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.4.4-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/netcdf4-1.6.2-py38hd243f81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py38hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nspr-4.35-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nss-3.89.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.54.1-py38hae1ba45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.4-py38h47b59a4_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.20.3-py38h57dabd6_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.20.3-py38h34da072_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-1.3.5-py38h743cdd8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pcre-8.45-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pcre2-10.37-he7042d7_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py38h7d39338_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pixman-0.40.0-h9ed2024_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pkgutil-resolve-name-1.3.10-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pooch-1.7.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/poppler-22.12.0-ha8a1649_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/poppler-data-0.4.11-hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/postgresql-12.15-h8aab74b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/proj-6.2.1-hfd5b9e3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py38hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py38hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyproj-2.6.1.post1-py38hdfdfadc_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py38hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py38_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.8.18-h218abb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py38hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py38h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py38he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/qhull-2020.2-ha357a0b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rtree-1.0.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scikit-learn-1.2.2-py38hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.10.1-py38hf241641_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/shapely-2.0.1-py38h797b0b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py38hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/testpath-0.6.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tiledb-2.3.3-h74f4c1e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py38h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py38h01d92e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uriparser-0.9.7-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py38_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py38hecd8cb5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2022.11.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xerces-c-3.2.4-hd2b157f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py38hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-2021.10.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-core-2021.10.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/geoviews-1.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/geoviews-core-1.9.1-pyh06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/holoviews-1.14.6-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munch-2.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pyshp-2.1.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/threadpoolctl-2.2.0-pyh0d69192_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py38hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py38hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-2.3.3-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/boost-cpp-1.73.0-hca72f7f_12.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py38h67323c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/branca-0.6.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py38he9d5cce_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cairo-1.16.0-h3ce6f7e_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cartopy-0.18.0-py38hf1ba7ce_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py38h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cftime-1.6.2-py38hacda100_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cloudpickle-2.2.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py38haf03e11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py38ha2381d6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/curl-8.2.1-hdb2fb19_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cytoolz-0.12.0-py38hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/datashape-0.5.4-py38hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py38hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/distributed-2021.10.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/expat-2.5.0-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fiona-1.9.1-py38h07fba90_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/folium-0.14.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fontconfig-2.14.1-hb0a0c50_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freexl-1.0.6-h9ed2024_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fsspec-2023.9.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/gdal-3.6.2-py38h09faefc_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/geopandas-0.12.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/geopandas-base-0.12.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/geos-3.8.0-hb1e8313_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/geotiff-1.7.0-hf6ff7a4_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/gettext-0.21.0-he85b6c0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/glib-2.69.1-hfff2838_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/hdf4-4.2.13-h39711bb_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/hdf5-1.10.6-h10fe05b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/icu-58.2-h0a44026_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py38h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.12.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py38hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/joblib-1.2.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/json-c-0.16-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kealib-1.5.0-h72c422f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py38hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libboost-1.73.0-h3fa6bed_12.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libedit-3.1.20221030-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgdal-3.6.2-hd170585_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libkml-1.3.0-h85bf17e_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libllvm11-11.0.0-h46f1229_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libnetcdf-4.8.1-ha5d86b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpq-12.15-hdb2fb19_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libspatialindex-1.9.3-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libspatialite-4.3.0a-hd1e8275_23.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h930c0e2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libzip-1.8.0-h272c8d6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.37.0-py38hc9110bb_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mapclassify-2.5.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.0.1-py38h9ed2024_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.7.1-py38hda11e5a_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py38h1de35cc_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py38h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py38h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py38ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/msgpack-python-1.0.3-py38haf03e11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py38_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.4.4-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/netcdf4-1.6.2-py38hd243f81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/networkx-3.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py38hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nspr-4.35-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nss-3.89.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numba-0.54.1-py38hae1ba45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.4-py38h47b59a4_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.20.3-py38h57dabd6_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.20.3-py38h34da072_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-1.3.5-py38h743cdd8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/partd-1.4.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pcre-8.45-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pcre2-10.37-he7042d7_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py38h7d39338_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pixman-0.40.0-h9ed2024_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pkgutil-resolve-name-1.3.10-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pooch-1.7.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/poppler-22.12.0-ha8a1649_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/poppler-data-0.4.11-hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/postgresql-12.15-h8aab74b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/proj-6.2.1-hfd5b9e3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py38hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py38hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyproj-2.6.1.post1-py38hdfdfadc_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py38hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py38_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.8.18-h218abb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-lmdb-1.4.1-py38hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py38h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py38he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/qhull-2020.2-ha357a0b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rtree-1.0.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scikit-learn-1.2.2-py38hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scipy-1.10.1-py38hf241641_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/shapely-2.0.1-py38h797b0b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py38hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/testpath-0.6.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tiledb-2.3.3-h74f4c1e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py38h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py38h01d92e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uriparser-0.9.7-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py38_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py38hecd8cb5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xarray-2022.11.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xerces-c-3.2.4-hd2b157f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py38hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zict-3.0.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2021.10.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2021.10.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/geoviews-1.9.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/geoviews-core-1.9.1-pyh06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.6-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munch-2.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyshp-2.1.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/threadpoolctl-2.2.0-pyh0d69192_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/xarray-0.20.1-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py38hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py38h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-2.3.3-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.73.0-h1a28f6b_12.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py38heec5a64_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/branca-0.6.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py38hc377ac9_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cairo-1.16.0-h302bd0f_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cartopy-0.21.1-py38hf94de1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py38h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cftime-1.6.2-py38hb08c31d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py38h3c57c4d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.0-py38h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py38hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py38h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2021.10.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/expat-2.5.0-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fftw-3.3.9-h1a28f6b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fiona-1.9.1-py38h78102c4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/folium-0.14.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fontconfig-2.14.1-hee714a5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freexl-1.0.6-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gdal-3.6.2-py38h92c4280_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geopandas-0.12.2-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geopandas-base-0.12.2-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geos-3.9.1-hc377ac9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geotiff-1.7.0-h41f0982_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-0.21.0-h13f89a0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glib-2.69.1-h514c7bf_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf4-4.2.13-h5e329fb_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf5-1.12.1-h160e8cb_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-68.1-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py38h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.12.2-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py38hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/joblib-1.2.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/json-c-0.16-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kealib-1.5.0-hba2eb73_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py38h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.73.0-h49e8a49_12.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20221030-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgdal-3.6.2-h50c47ba_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libkml-1.3.0-hc4d7c42_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm11-11.1.0-h12f7ac0_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnetcdf-4.8.1-ha022005_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpq-12.15-h449679c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libspatialindex-1.9.3-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libspatialite-4.3.0a-h4707d77_23.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h372ba2a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzip-1.8.0-h0c481fb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.37.0-py38h8b39d70_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mapclassify-2.5.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.0.1-py38h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.5.0-py38h9197a36_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py38h1a28f6b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py38h525c30c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.4.4-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/netcdf4-1.6.2-py38h053bab8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py38hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nspr-4.35-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nss-3.89.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.54.0-py38hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.4-py38h79ee842_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.19.5-py38h831b0dc_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.19.5-py38hdc56644_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-1.3.5-py38h9197a36_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre-8.45-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre2-10.37-h37e8eca_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py38h3b245a6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pixman-0.40.0-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pkgutil-resolve-name-1.3.10-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pooch-1.7.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/poppler-22.12.0-h52f4003_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/poppler-data-0.4.11-hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/postgresql-12.15-h1ae2815_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/proj-7.2.0-heac154c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py38h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py38hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyproj-3.1.0-py38hfce2bd4_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py38h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.8.18-hc0d8a6c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py38h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py38h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py38hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/qhull-2020.2-h48ca7d4_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rtree-1.0.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scikit-learn-1.2.2-py38h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.10.0-py38h9d039d2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/shapely-2.0.1-py38h9ca3c36_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py38hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/testpath-0.6.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tiledb-2.3.3-h3ad0f7e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py38h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py38h86d0a89_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uriparser-0.9.7-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py38hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py38hca03da5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xerces-c-3.2.4-h389e118_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py38hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-2021.10.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-core-2021.10.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/geoviews-1.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/geoviews-core-1.9.1-pyh06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/holoviews-1.14.6-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munch-2.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pyshp-2.1.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/threadpoolctl-2.2.0-pyh0d69192_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/xarray-0.20.1-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py38hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py38h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-2.3.3-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/boost-cpp-1.73.0-h1a28f6b_12.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py38heec5a64_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/branca-0.6.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py38hc377ac9_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cairo-1.16.0-h302bd0f_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cartopy-0.21.1-py38hf94de1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py38h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cftime-1.6.2-py38hb08c31d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-2.2.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py38h3c57c4d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cytoolz-0.12.0-py38h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/datashape-0.5.4-py38hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py38h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/distributed-2021.10.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/expat-2.5.0-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fftw-3.3.9-h1a28f6b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fiona-1.9.1-py38h78102c4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/folium-0.14.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fontconfig-2.14.1-hee714a5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freexl-1.0.6-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2023.9.2-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/gdal-3.6.2-py38h92c4280_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/geopandas-0.12.2-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/geopandas-base-0.12.2-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/geos-3.9.1-hc377ac9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/geotiff-1.7.0-h41f0982_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/gettext-0.21.0-h13f89a0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/glib-2.69.1-h514c7bf_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/hdf4-4.2.13-h5e329fb_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/hdf5-1.12.1-h160e8cb_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/icu-68.1-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py38h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.12.2-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py38hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/joblib-1.2.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/json-c-0.16-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kealib-1.5.0-hba2eb73_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py38h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libboost-1.73.0-h49e8a49_12.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libedit-3.1.20221030-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgdal-3.6.2-h50c47ba_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libkml-1.3.0-hc4d7c42_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libllvm11-11.1.0-h12f7ac0_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libnetcdf-4.8.1-ha022005_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpq-12.15-h449679c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libspatialindex-1.9.3-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libspatialite-4.3.0a-h4707d77_23.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h372ba2a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libzip-1.8.0-h0c481fb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.37.0-py38h8b39d70_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mapclassify-2.5.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.0.1-py38h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.5.0-py38h9197a36_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py38h1a28f6b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/msgpack-python-1.0.3-py38h525c30c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.4.4-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/netcdf4-1.6.2-py38h053bab8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/networkx-3.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py38hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nspr-4.35-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nss-3.89.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numba-0.54.0-py38hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.4-py38h79ee842_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.19.5-py38h831b0dc_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.19.5-py38hdc56644_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-1.3.5-py38h9197a36_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pcre-8.45-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pcre2-10.37-h37e8eca_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py38h3b245a6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pixman-0.40.0-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pkgutil-resolve-name-1.3.10-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pooch-1.7.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/poppler-22.12.0-h52f4003_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/poppler-data-0.4.11-hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/postgresql-12.15-h1ae2815_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/proj-7.2.0-heac154c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py38h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py38hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyproj-3.1.0-py38hfce2bd4_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py38h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.8.18-hc0d8a6c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-lmdb-1.4.1-py38h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py38h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py38hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/qhull-2020.2-h48ca7d4_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rtree-1.0.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scikit-learn-1.2.2-py38h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.10.0-py38h9d039d2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/shapely-2.0.1-py38h9ca3c36_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py38hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/testpath-0.6.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tiledb-2.3.3-h3ad0f7e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py38h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py38h86d0a89_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uriparser-0.9.7-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py38hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py38hca03da5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xerces-c-3.2.4-h389e118_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py38hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zict-3.0.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2021.10.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2021.10.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/geoviews-1.9.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/geoviews-core-1.9.1-pyh06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.6-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munch-2.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyshp-2.1.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/threadpoolctl-2.2.0-pyh0d69192_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py38h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-2.3.3-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py38h080aedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/branca-0.6.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py38hd77b12b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cairo-1.16.0-haedb8bc_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cartopy-0.18.0-py38h80a4efb_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py38h2bbff1b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cftime-1.6.2-py38h080aedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py38h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py38h3438e0d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/curl-8.4.0-he2ea4bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.0-py38h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py38haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py38hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2021.10.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/expat-2.5.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fiona-1.9.1-py38hf11a4ad_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/folium-0.14.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fontconfig-2.14.1-h9c4af85_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freexl-1.0.6-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/gdal-3.6.2-py38h9eae49a_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/geopandas-0.12.2-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/geopandas-base-0.12.2-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/geos-3.8.0-h33f27b4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/geotiff-1.7.0-h4545760_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/glib-2.69.1-h5dc1a3c_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/hdf4-4.2.13-h712560f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/hdf5-1.10.6-h1756f20_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icu-58.2-ha925a31_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py38h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.12.2-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py38haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/joblib-1.2.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kealib-1.5.0-hde4a422_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py38hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.4.0-h86230a5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libgdal-3.6.2-h11d7215_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libkml-1.3.0-h63940dd_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libnetcdf-4.8.1-h6685c40_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.15-hb652d5d_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libspatialindex-1.9.3-h6c2663c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libspatialite-4.3.0a-h6ec8781_23.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-hcd4344a_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libzip-1.8.0-h49b8836_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.37.0-py38h23ce68f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mapclassify-2.5.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.0.1-py38h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.7.1-py38hf11a4ad_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py38he774522_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py38h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py38h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py38h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py38h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py38_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.4.4-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/netcdf4-1.6.2-py38hda396d2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py38haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.54.1-py38hf11a4ad_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.4-py38h7b80656_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.20.3-py38h749eb61_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.20.3-py38h5bfbeaa_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-1.3.5-py38h6214cd6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pcre-8.45-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pcre2-10.37-h0ff8eda_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py38h045eedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pixman-0.40.0-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pkgutil-resolve-name-1.3.10-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pooch-1.7.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/poppler-22.12.0-h0bf3bde_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/poppler-data-0.4.11-haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/postgresql-12.15-hb652d5d_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/proj-6.2.1-h3758d61_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py38h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py38haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyproj-2.6.1.post1-py38h593ac45_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py38h196d8e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.8.18-h6244533_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py38hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py38h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py38h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py38h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py38hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/qhull-2020.2-h59b6b97_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rtree-1.0.1-py38h2eaa2aa_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scikit-learn-1.2.2-py38hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.10.1-py38hdcfc7df_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/shapely-2.0.1-py38hd7f5953_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py38haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/testpath-0.6.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tiledb-2.3.3-h3649cd2_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py38h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py38hd4e2768_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uriparser-0.9.7-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py38_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py38haa95532_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2022.11.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xerces-c-3.2.4-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py38haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-2021.10.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-core-2021.10.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/geoviews-1.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/geoviews-core-1.9.1-pyh06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/holoviews-1.14.6-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munch-2.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pyshp-2.1.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/threadpoolctl-2.2.0-pyh0d69192_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py38h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-2.3.3-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py38h080aedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/branca-0.6.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py38hd77b12b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cairo-1.16.0-haedb8bc_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cartopy-0.18.0-py38h80a4efb_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py38h2bbff1b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cftime-1.6.2-py38h080aedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cloudpickle-2.2.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py38h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py38h3438e0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/curl-8.4.0-he2ea4bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cytoolz-0.12.0-py38h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/datashape-0.5.4-py38haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py38hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/distributed-2021.10.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/expat-2.5.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fiona-1.9.1-py38hf11a4ad_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/folium-0.14.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fontconfig-2.14.1-h9c4af85_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freexl-1.0.6-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fsspec-2023.9.2-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/gdal-3.6.2-py38h9eae49a_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/geopandas-0.12.2-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/geopandas-base-0.12.2-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/geos-3.8.0-h33f27b4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/geotiff-1.7.0-h4545760_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/glib-2.69.1-h5dc1a3c_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/hdf4-4.2.13-h712560f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/hdf5-1.10.6-h1756f20_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icu-58.2-ha925a31_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.4-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py38h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.12.2-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py38haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/joblib-1.2.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kealib-1.5.0-hde4a422_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py38hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/krb5-1.20.1-h5b6d351_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libcurl-8.4.0-h86230a5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libgdal-3.6.2-h11d7215_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libkml-1.3.0-h63940dd_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libnetcdf-4.8.1-h6685c40_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpq-12.15-hb652d5d_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libspatialindex-1.9.3-h6c2663c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libspatialite-4.3.0a-h6ec8781_23.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libssh2-1.10.0-hcd4344a_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libzip-1.8.0-h49b8836_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/llvmlite-0.37.0-py38h23ce68f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mapclassify-2.5.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.0.1-py38h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.7.1-py38hf11a4ad_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py38he774522_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py38h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py38h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py38h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/msgpack-python-1.0.3-py38h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py38_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-6.4.4-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/netcdf4-1.6.2-py38hda396d2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/networkx-3.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py38haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numba-0.54.1-py38hf11a4ad_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.4-py38h7b80656_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.20.3-py38h749eb61_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.20.3-py38h5bfbeaa_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-1.3.5-py38h6214cd6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/partd-1.4.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pcre-8.45-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pcre2-10.37-h0ff8eda_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py38h045eedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-23.3-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pixman-0.40.0-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pkgutil-resolve-name-1.3.10-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pooch-1.7.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/poppler-22.12.0-h0bf3bde_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/poppler-data-0.4.11-haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/postgresql-12.15-hb652d5d_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/proj-6.2.1-h3758d61_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py38h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py38haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyproj-2.6.1.post1-py38h593ac45_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py38h196d8e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.8.18-h6244533_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-lmdb-1.4.1-py38hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py38h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py38h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py38h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py38hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/qhull-2020.2-h59b6b97_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rtree-1.0.1-py38h2eaa2aa_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scikit-learn-1.2.2-py38hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scipy-1.10.1-py38hdcfc7df_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/shapely-2.0.1-py38hd7f5953_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py38haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/testpath-0.6.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tiledb-2.3.3-h3649cd2_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py38h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py38hd4e2768_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uriparser-0.9.7-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py38_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py38haa95532_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xarray-2022.11.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xerces-c-3.2.4-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py38haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zict-3.0.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
   sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
   md5: 613805add1c05b538ff06d217252feb7
   depends:
@@ -991,7 +991,7 @@ packages:
   license: BSD-3-Clause
   size: 20810
   timestamp: 1652859733309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py38h06a4308_0.tar.bz2
   sha256: 54481e7be198702a59018dbdcc65cc32cdbc32efd372380cdfc3ef6e2c8637e4
   md5: 54aa956eba07f586a9cdf1edd795ff6a
   depends:
@@ -1004,7 +1004,7 @@ packages:
   license_family: MIT
   size: 161551
   timestamp: 1644481732835
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py38h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py38h7f8727e_0.tar.bz2
   sha256: 754046398c314772a7d38b7d4c0d488a48db7b1b9c6a421686ef13178e1997b9
   md5: e785c0744d3ed83d813a42b7bb9b8794
   depends:
@@ -1015,7 +1015,7 @@ packages:
   license_family: MIT
   size: 35378
   timestamp: 1644569723962
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py38h06a4308_0.tar.bz2
   sha256: 07ae7d42a17dc80c2d86cde056d10fce0bccbf644079ede97e1528aab1c52e97
   md5: f542de27c6488185f93ac808b361e773
   depends:
@@ -1024,7 +1024,7 @@ packages:
   license_family: MIT
   size: 132589
   timestamp: 1695717870001
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.4.57-he6710b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-common-0.4.57-he6710b0_1.tar.bz2
   sha256: bc87abecbc7e34b42b5a7ec3a3470ee284ed82f5f638274f795810fd0aa85496
   md5: e883ae27a33cff702b8a20b5394e9ae0
   depends:
@@ -1034,7 +1034,7 @@ packages:
   license_family: Apache
   size: 164855
   timestamp: 1601398346279
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.1.6-h2531618_5.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-event-stream-0.1.6-h2531618_5.tar.bz2
   sha256: 4f7d93ed96f6692266a700971029b841dc972a6af39b85ba9525eebe2c40edbb
   md5: 6b7ceb5ff64fc9f4537bfe7a2d7fe4a0
   depends:
@@ -1046,7 +1046,7 @@ packages:
   license_family: Apache
   size: 25449
   timestamp: 1603894551837
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.9-he6710b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-checksums-0.1.9-he6710b0_0.tar.bz2
   sha256: 17d0e3361698b9a0a9b52836284b658886d25bf349f3a099b765eac23ceb4ebd
   md5: 0a7ed2b675a5af15d4979f4ca5c93d39
   depends:
@@ -1057,7 +1057,7 @@ packages:
   license_family: Apache
   size: 52520
   timestamp: 1601398555928
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.8.185-hce553d0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-sdk-cpp-1.8.185-hce553d0_0.tar.bz2
   sha256: 2842aafc907c01ccbe26ca11bddad6c55e9f93d30cf57431e327f5e57666be2c
   md5: 5b4e9429338430ef3b71802778ac2184
   depends:
@@ -1071,7 +1071,7 @@ packages:
   license_family: Apache
   size: 2442091
   timestamp: 1618434946994
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py38h06a4308_0.tar.bz2
   sha256: 46c2cda1632b14e34119fc00eebd1ea661d11e0a9af19b079223e1753f250312
   md5: 12ce8ee1ef9ce7702c16c066aaa97d4a
   depends:
@@ -1081,12 +1081,12 @@ packages:
   license_family: MIT
   size: 206754
   timestamp: 1681493123397
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.3.3-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-2.3.3-py38h06a4308_0.tar.bz2
   sha256: 3bfeca90afe6dfc7d2449c80d399b49a71789194d788a1885bcdffadf7ba4203
   md5: 259a031bf81c4dcfd23e8362fc66d82c
   depends:
@@ -1103,7 +1103,7 @@ packages:
   license_family: BSD
   size: 8626396
   timestamp: 1625766948987
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py38hce1f21e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.4-py38hce1f21e_0.tar.bz2
   sha256: 59962f0b66250d8d0e480250f76c6ced092eded23a21789b75504ee467e7b95a
   md5: c70915c3dd28d708301d7f62eceab737
   depends:
@@ -1114,7 +1114,7 @@ packages:
   license_family: BSD
   size: 141645
   timestamp: 1648028960341
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/branca-0.6.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/branca-0.6.0-py38h06a4308_0.tar.bz2
   sha256: acb11233689be4e3e08e59d81128e8c1a1df187e567a2a419a49a92fe52f6105
   md5: a988f72c736cebe811e041883110d68a
   depends:
@@ -1124,7 +1124,7 @@ packages:
   license_family: MIT
   size: 42267
   timestamp: 1675157693121
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
   sha256: 0bbcb6f78eac530c6a084459ffab3238647b266d0c74d695e6e6387dd119cc67
   md5: bdc971e2a9affb5125b68ad708172dab
   depends:
@@ -1133,7 +1133,7 @@ packages:
   license: MIT
   size: 411301
   timestamp: 1602517685375
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py38heb0550a_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py38heb0550a_2.tar.bz2
   sha256: 48861814b9de24db62eb44c63f5d860f6e8a0394e6a130eeb315aac35386a6ae
   md5: 5dc04b2ebe30cad3d57f18d761d4028c
   depends:
@@ -1143,7 +1143,7 @@ packages:
   license: MIT
   size: 372816
   timestamp: 1602517785841
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
   sha256: 168c2fc4d5899ee70e85fadc998e00827e1b856a6fc4a402ed465cd7c320d19f
   md5: f52e60deb7f4c82821be9a868e889348
   depends:
@@ -1152,7 +1152,7 @@ packages:
   license_family: BSD
   size: 107105
   timestamp: 1563219611337
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.18.1-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/c-ares-1.18.1-h7f8727e_0.tar.bz2
   sha256: 55032f8c149e5515300098ed4133bb92993419b976789b90c8fc3eaf88b3d979
   md5: 62ca289a9704ed465d3324295ef851d9
   depends:
@@ -1161,14 +1161,14 @@ packages:
   license_family: MIT
   size: 121863
   timestamp: 1641918271715
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
   sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
   md5: 3ef00f4c5278b688552efc259c463dc8
   license: MPL-2.0
   license_family: Other
   size: 132731
   timestamp: 1694009767372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cairo-1.16.0-h19f5f5c_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cairo-1.16.0-h19f5f5c_2.tar.bz2
   sha256: 053b2284fe86f4adbdf4b39ce4d9d9d0ae0f49b0d3ef966eee96bc17c3f028f9
   md5: ec69c918d097c392992a7fbe52d252d3
   depends:
@@ -1184,7 +1184,7 @@ packages:
   license_family: LGPL
   size: 1573265
   timestamp: 1654193721539
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cartopy-0.18.0-py38h0d9ca2b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cartopy-0.18.0-py38h0d9ca2b_1.tar.bz2
   sha256: 92589e250abbc4bd65e332a91d0729beecad606fc8dbf95698c44e9769e5c1da
   md5: 230643b4dd9216e446ad2111b40cd927
   depends:
@@ -1202,7 +1202,7 @@ packages:
   license: LGPL-3
   size: 2000219
   timestamp: 1612289540164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py38h06a4308_0.tar.bz2
   sha256: 03b5e29c8b52f1a8ec459e577733ea3b2bc57d0ab53ffe21497569a78e581680
   md5: 188d1325f374411714723488d38221d2
   depends:
@@ -1211,7 +1211,7 @@ packages:
   license_family: Other
   size: 159001
   timestamp: 1690232308159
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py38hd667e15_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.0-py38hd667e15_1.tar.bz2
   sha256: b87c8090413b0858c694d1e9e646177529bcffbb211822254174d46856c73914
   md5: 3c7b4ec905e563e91ffbabb11516809f
   depends:
@@ -1223,7 +1223,7 @@ packages:
   license_family: MIT
   size: 231275
   timestamp: 1642701149006
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cfitsio-3.470-hf0d0db6_6.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cfitsio-3.470-hf0d0db6_6.tar.bz2
   sha256: 23552cdff499c81a7558ddfc97bffdfb79e8095917214f8a123f1d33d9e6f267
   md5: 7ff507183f61b0613724b63050abb2c2
   depends:
@@ -1235,7 +1235,7 @@ packages:
   license: fitsio
   size: 1356419
   timestamp: 1601308736676
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cftime-1.5.1.1-py38hce1f21e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cftime-1.5.1.1-py38hce1f21e_0.tar.bz2
   sha256: 393f214c11ae1468b3ff1b594a3c89c9ffa02d17d54487dae1ba71e8ab9e77fa
   md5: b05f4834cc6556cdb21f0046fa24f033
   depends:
@@ -1246,7 +1246,7 @@ packages:
   license_family: MIT
   size: 221505
   timestamp: 1638357968908
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cloudpickle-2.2.1-py38h06a4308_0.tar.bz2
   sha256: 6dbf29428ab1fd359f4c577465da6494bf6f8acf0ae115942746b5c989424d94
   md5: 39055face0f3948ba69e73aa3ee13fdc
   depends:
@@ -1255,7 +1255,7 @@ packages:
   license_family: BSD
   size: 40493
   timestamp: 1683040085424
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py38h06a4308_0.tar.bz2
   sha256: 8a25abc45d27b1ca16489f03a390ad5f648cf198d4d341437e75e320a1303d0f
   md5: 442d8300d903dcc9050d9e9b1336cde1
   depends:
@@ -1265,7 +1265,7 @@ packages:
   license_family: CC
   size: 1974004
   timestamp: 1668084578291
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py38h06a4308_0.tar.bz2
   sha256: 93e6082d2635e03b9e7d87aea7ec3b4c98e8d40698a29ce01386b0f5cd038f75
   md5: 5944cf6bfa04b7b79479c6b5eec2a856
   depends:
@@ -1275,7 +1275,7 @@ packages:
   license_family: BSD
   size: 12695
   timestamp: 1671231231929
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py38h130f0dd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py38h130f0dd_0.tar.bz2
   sha256: f32275eb7bea86a368b1d41e1731089d8cc9a9e8ae4d6a12ce161522adad3192
   md5: a02567b1992539478f57554d00255594
   depends:
@@ -1289,7 +1289,7 @@ packages:
   license_family: BSD
   size: 2180436
   timestamp: 1694444927145
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/curl-7.82.0-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/curl-7.82.0-h7f8727e_0.tar.bz2
   sha256: f86745816a0abd3f9918777e3dd25e212b808cb21f1f769dbe1a417fdd34c294
   md5: 412fb1f9d310969821ce52adffaf80c7
   depends:
@@ -1299,7 +1299,7 @@ packages:
   license_family: MIT
   size: 102483
   timestamp: 1649731358187
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.11.0-py38h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cytoolz-0.11.0-py38h7b6447c_0.tar.bz2
   sha256: 551546153fbda8d618783ffe22c825e9f0ed09ee14c713cf2254c24b6a4795d0
   md5: dcb18da6963d56ec55b36d092c18b137
   depends:
@@ -1309,7 +1309,7 @@ packages:
   license: BSD-3-Clause
   size: 399499
   timestamp: 1600959049930
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py38h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/datashape-0.5.4-py38h06a4308_1.tar.bz2
   sha256: 823bbb3c8951739e8ff5fbf9470cf4ca06c790fe4646388922bf29800b02acad
   md5: 53492f02a308427dab7a204dcc2f343f
   depends:
@@ -1321,7 +1321,7 @@ packages:
   license_family: BSD
   size: 104159
   timestamp: 1613390257727
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py38h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.5.1-py38h295c915_0.tar.bz2
   sha256: 2e4214d51aa2a634a46fde19b92644798d92c450d055f1a3a62bc162a4b39cd6
   md5: 637c8337c96bc1125bebf2809ecd0ff7
   depends:
@@ -1332,7 +1332,7 @@ packages:
   license_family: MIT
   size: 2099690
   timestamp: 1637091855055
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2021.10.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/distributed-2021.10.0-py38h06a4308_0.tar.bz2
   sha256: 6302f38efee38870ea538d474353e6b60fbe43c8eb2ca7e10d0ca349197112bc
   md5: 88a5a1e59a29df1e4f51c4810453c860
   depends:
@@ -1357,7 +1357,7 @@ packages:
   license_family: BSD
   size: 1128129
   timestamp: 1635968239447
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py38h06a4308_0.tar.bz2
   sha256: fc256adb1e5c237867e04a2699c1eec3ea93256cfa7914880d59c69563f1c95d
   md5: 20c8874b5ae24bf4bea2303aeb5f7f03
   depends:
@@ -1366,7 +1366,7 @@ packages:
   license_family: MIT
   size: 16351
   timestamp: 1649926480666
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
   sha256: 27cde2cf0b1e10c2315bc1384fcb56537b424f6c2c872ca4662bc971e41910da
   md5: c12e8c75f3c7c4f5867827c5dc02dc2c
   depends:
@@ -1376,7 +1376,7 @@ packages:
   license_family: MIT
   size: 216001
   timestamp: 1644418571578
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fiona-1.8.13.post1-py38hc820daa_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fiona-1.8.13.post1-py38hc820daa_0.tar.bz2
   sha256: 2805161e64f6dfc78a52cfa0cb7512103adbd507981912d523e99c6ad4ec6426
   md5: c40804d0aabb8c8340b63a78a14d7a36
   depends:
@@ -1397,7 +1397,7 @@ packages:
   license: BSD-3-Clause
   size: 1094071
   timestamp: 1597154790852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/folium-0.14.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/folium-0.14.0-py38h06a4308_0.tar.bz2
   sha256: 02792c44f5e66b754fbeb6c07fbb4baa7bf43988bf9641402ee9d669855b3761
   md5: dead3a557dfe066fc55baf327a859857
   depends:
@@ -1410,7 +1410,7 @@ packages:
   license_family: MIT
   size: 113940
   timestamp: 1675353472060
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
   sha256: f80526def98864c9560dd3f6754d1c905edc001d18279f6e169913ee8f26a6a2
   md5: e2fda4383ff9a690a6ac174553e10414
   depends:
@@ -1421,7 +1421,7 @@ packages:
   license: MIT
   size: 306671
   timestamp: 1612452969808
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
   sha256: 8a121233d0b2cbb2463b67e798739ad2946f38933430a6a7fd1197cc6eab1c99
   md5: d2b24736491290a6c6d0138932111150
   depends:
@@ -1431,7 +1431,7 @@ packages:
   license: GPL-2.0-only and LicenseRef-FreeType
   size: 965280
   timestamp: 1635422707211
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freexl-1.0.6-h27cfd23_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freexl-1.0.6-h27cfd23_0.tar.bz2
   sha256: 8e060f863a4a3ae66733c03d400dce277b831e15fbd23f6beccd43501b15b74d
   md5: 4a608c3e1873b5f5d319d1a093291c42
   depends:
@@ -1439,7 +1439,7 @@ packages:
   license: MPL-1.1
   size: 47744
   timestamp: 1607116152702
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fsspec-2023.9.2-py38h06a4308_0.tar.bz2
   sha256: a99dc9db41b635292f5b5078a03ee745050b3fdfd7b402e8589e811c42e1af30
   md5: c2de12505cad821a4249f7c2b2f83205
   depends:
@@ -1448,7 +1448,7 @@ packages:
   license_family: BSD
   size: 260426
   timestamp: 1695734589016
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gdal-3.0.2-py38h2c27f0e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/gdal-3.0.2-py38h2c27f0e_2.tar.bz2
   sha256: bf22b18cdf698cefec0d85f6b3f5177c949054b56e30acfd5692bd6aaf0ce63f
   md5: 7a75f579140e4a48c5cb9c3a5cf8d676
   depends:
@@ -1460,7 +1460,7 @@ packages:
   license: MIT
   size: 1367460
   timestamp: 1643382663578
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/geopandas-0.12.2-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/geopandas-0.12.2-py38h06a4308_0.tar.bz2
   sha256: c3be7721dfbaecd526e21e055cf135a361f9174ba143fbad3d40e87af5b6cab3
   md5: 2195a5ccc9f71c4628f6c090861c15ac
   depends:
@@ -1475,7 +1475,7 @@ packages:
   license_family: BSD
   size: 6230
   timestamp: 1675672124803
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/geopandas-base-0.12.2-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/geopandas-base-0.12.2-py38h06a4308_0.tar.bz2
   sha256: 2cd41da7f5c9f9c018c4f14ee1383f3d6416283f5ba267b75bc0cb94a6c76ed8
   md5: 9c9b910f82d0ec74660ebca9261c113e
   depends:
@@ -1489,7 +1489,7 @@ packages:
   license_family: BSD
   size: 1256343
   timestamp: 1675672123162
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/geos-3.8.0-he6710b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/geos-3.8.0-he6710b0_0.tar.bz2
   sha256: 6d791f835f915ad4f34171399b7d3141e548446dcce384f7d11f28a04c002bb7
   md5: 7f115aea55f4cffe8c6c937240697f06
   depends:
@@ -1498,7 +1498,7 @@ packages:
   license: LGPL-2.1
   size: 1078422
   timestamp: 1573215838521
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/geotiff-1.7.0-hd69d5b1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/geotiff-1.7.0-hd69d5b1_0.tar.bz2
   sha256: 27f153e921dd9adae169043ffdca3903ad98344bde7c3e8ab8c771f2b4d116a0
   md5: 0be412b39ea3969b79829a2556698416
   depends:
@@ -1512,7 +1512,7 @@ packages:
   license_family: MIT
   size: 284741
   timestamp: 1625555192147
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
   sha256: 3c8ece1a7257b1d45f8fa25f46504bb709a1923d7175f2996e891366ec434b9d
   md5: 299bf4271d710651a1d71d3795580c2d
   depends:
@@ -1520,7 +1520,7 @@ packages:
   license: MIT
   size: 83592
   timestamp: 1603192039050
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
   sha256: bb98f022743e5df14d73db0edae49eb95a11abcc41c973fe2f30c3810bc5021e
   md5: 858d4f13f1b0e54ee8cc3dd7c67cf0de
   depends:
@@ -1534,7 +1534,7 @@ packages:
   license_family: LGPL
   size: 2021087
   timestamp: 1642701448286
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf4-4.2.13-h3ca952b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/hdf4-4.2.13-h3ca952b_2.tar.bz2
   sha256: 70e1f9fdc6b123d8270bcd8cdd555519372924d39419ef8692b36bfa9d0b4653
   md5: 35da658876a3e2a62dda54dcd5a7e5c2
   depends:
@@ -1546,7 +1546,7 @@ packages:
   license_family: BSD
   size: 937548
   timestamp: 1510862959026
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf5-1.10.6-hb1b8bf9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/hdf5-1.10.6-hb1b8bf9_0.tar.bz2
   sha256: ab8cb89a9c1e8341785c53c7aff84ed2e5ad42efe6897b54e0b2bf5712a77057
   md5: c2a4fff8bb9066058971622f9b2b3e00
   depends:
@@ -1558,7 +1558,7 @@ packages:
   license_family: BSD
   size: 5077151
   timestamp: 1593121597858
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
   sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
   md5: 9213e0336e3a5216c989cfe52648412e
   depends:
@@ -1567,7 +1567,7 @@ packages:
   license: MIT
   size: 23805906
   timestamp: 1588026213084
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py38h06a4308_0.tar.bz2
   sha256: 78c6e445d2365147307ab5631fb82bfb9f929ca0fe8849d7d7f4991e991fe125
   md5: 22a39ae9bbf0f9dab8b7c7dafed3d454
   depends:
@@ -1576,7 +1576,7 @@ packages:
   license_family: BSD
   size: 111304
   timestamp: 1666125659782
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py38h06a4308_0.tar.bz2
   sha256: b4c67d58af728ccc02ded656950609cbb90cfc5c9d23c67962e2118726fa4bdf
   md5: 6284754d30be21d201fa708661a40ee5
   depends:
@@ -1586,7 +1586,7 @@ packages:
   license_family: APACHE
   size: 37562
   timestamp: 1678997179162
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.1.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib_resources-6.1.0-py38h06a4308_0.tar.bz2
   sha256: db646d2d41469fbd8f4c652faa436784623be3e3faf4b294b179d1dc0119db03
   md5: 56fada4eb69b2eac5975f7b5e8587d0a
   depends:
@@ -1596,7 +1596,7 @@ packages:
   license_family: Apache
   size: 50548
   timestamp: 1698254754814
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
   sha256: 1b424413f28b840fc6d4bf467f37e9e405823b1e3b899005df80152d48936d64
   md5: 4aa8bcf74c81cd3600978f791191692a
   constrains:
@@ -1605,7 +1605,7 @@ packages:
   license_family: Proprietary
   size: 9246735
   timestamp: 1634546760713
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py38hb070fc8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.19.2-py38hb070fc8_0.tar.bz2
   sha256: 2f7bbc17d6f687a7e0436dca6ac387add5fe5894d29569efef0d177779b731a8
   md5: 8411fbef7b61093a89bcfb698e4a94c4
   depends:
@@ -1625,7 +1625,7 @@ packages:
   license_family: BSD
   size: 203314
   timestamp: 1671488427499
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.12.2-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.12.2-py38h06a4308_0.tar.bz2
   sha256: e413c50a320468c543fc0b434e914a1705f2078a3c349036db7457818e6c2865
   md5: 659aa6a467e962ab07c83300d5edbdc2
   depends:
@@ -1645,7 +1645,7 @@ packages:
   license_family: BSD
   size: 1232450
   timestamp: 1691532256204
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py38h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py38h06a4308_1.tar.bz2
   sha256: 3a960eb70bfc70b68e8a4c18789d6e4e38d957fcc131e0a2dd0c40d9a69d299f
   md5: 19ed6fe5573ad375cddc95056ecd13a0
   depends:
@@ -1655,7 +1655,7 @@ packages:
   license_family: MIT
   size: 1029639
   timestamp: 1644315273267
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/joblib-1.2.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/joblib-1.2.0-py38h06a4308_0.tar.bz2
   sha256: bf1488a9538701eb892c23588ecd66a7978c218da48f0222f2413651b56abf5a
   md5: 1da31afa747bdaa7297d23076f38a32d
   depends:
@@ -1664,7 +1664,7 @@ packages:
   license_family: BSD
   size: 403690
   timestamp: 1685113149323
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
   sha256: 85348bfb14db4fea84078d703e766a3c978c5a592a06e41266748826dd59d8ae
   md5: 6e1c0fb5260c590f7ef5235cb3d05863
   depends:
@@ -1673,7 +1673,7 @@ packages:
   license_family: Other
   size: 279884
   timestamp: 1651065953960
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/json-c-0.13.1-h1bed415_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/json-c-0.13.1-h1bed415_0.tar.bz2
   sha256: 3467b6700f6886bd0faa30eedcb9cc616f3c913c555e8ae92f8a2f8a14fbc9c5
   md5: d62003ffec6d7b46dd2f23c1d2ef1a22
   depends:
@@ -1681,7 +1681,7 @@ packages:
   license: MIT
   size: 71804
   timestamp: 1520912298499
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py38h06a4308_0.tar.bz2
   sha256: 405e9f469376ef4103dd20143182200becd1826e09c4ceaf1c3624ba1f550c46
   md5: 85499c4d81f591081111c92b80658c46
   depends:
@@ -1694,7 +1694,7 @@ packages:
   license_family: MIT
   size: 130909
   timestamp: 1676558687406
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.2.2-py38h06a4308_0.tar.bz2
   sha256: 363bf1ec4fc436281b982243c320d1e5f3f4f8eb32b165b3d9065ba8cec976e5
   md5: bdbcdf04055343c414aa431ccb1b788e
   depends:
@@ -1710,7 +1710,7 @@ packages:
   license_family: BSD
   size: 190946
   timestamp: 1650622858276
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py38h06a4308_0.tar.bz2
   sha256: ddfb7d8c465e40624168c4298783fc3241674c26652f22e6ed83766f2154f544
   md5: 55dcff614b00ebf9d9133a94b51525d3
   depends:
@@ -1721,7 +1721,7 @@ packages:
   license_family: BSD
   size: 91415
   timestamp: 1679906595114
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py38h06a4308_0.tar.bz2
   sha256: 93715877ed17774e2ab8914e61392b47ccbc287ecc0090b9f503652079307428
   md5: 0310c282f4db53891f1bbd904eb911ea
   depends:
@@ -1745,7 +1745,7 @@ packages:
   license_family: BSD
   size: 410727
   timestamp: 1671707735470
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kealib-1.4.14-hb50703a_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kealib-1.4.14-hb50703a_1.tar.bz2
   sha256: 6e331fc982591919ce61ce3a265f9179f7356443fa746491ac3fe07a4c956d92
   md5: fcd61c7464836aa82c15899a0516907b
   depends:
@@ -1756,7 +1756,7 @@ packages:
   license_family: MIT
   size: 185531
   timestamp: 1640000342243
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py38h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.2-py38h295c915_0.tar.bz2
   sha256: a1eb0041ef76935f9a6bd6b2615cba9dace682f1ea7ff45ea8f4f45acb3560bf
   md5: af1bbc1e7edc97963e8ced3d17542b19
   depends:
@@ -1767,7 +1767,7 @@ packages:
   license_family: BSD
   size: 92258
   timestamp: 1653292259825
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.19.2-hac12032_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/krb5-1.19.2-hac12032_0.tar.bz2
   sha256: 19b886c33c110a8a7a3616ebd9b5c18efc7653e42a40e36d6d6179ac591169b1
   md5: fe9cc044a22b2fc3a5a0699e2fde72fd
   depends:
@@ -1778,7 +1778,7 @@ packages:
   license: MIT
   size: 1447400
   timestamp: 1627388807149
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -1789,7 +1789,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
   sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
   md5: 9508af80612e4fa1b5d1abb43ca7e63c
   constrains:
@@ -1797,7 +1797,7 @@ packages:
   license: GPL-3.0-only
   size: 749072
   timestamp: 1652971360657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.73.0-h3ff78a5_11.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libboost-1.73.0-h3ff78a5_11.tar.bz2
   sha256: 55e595d5b5c5c2361c56a9ea3868ed5e97c99b3ffc614487b7aec7126722292a
   md5: b41dce08aea9e243db25a95f00708724
   depends:
@@ -1811,7 +1811,7 @@ packages:
   license: Boost-1.0
   size: 22298574
   timestamp: 1611677068430
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-7.82.0-h0b77cf5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libcurl-7.82.0-h0b77cf5_0.tar.bz2
   sha256: 765358a6dbb22f82dc3bb929b94df73b7b5fe6b4faf0caee83eff73c24c379f7
   md5: 58bfe76e3f31d4a36acd7a7f4092b6ce
   depends:
@@ -1825,7 +1825,7 @@ packages:
   license_family: MIT
   size: 359251
   timestamp: 1649731351073
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdap4-3.19.1-h6ec2957_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libdap4-3.19.1-h6ec2957_0.tar.bz2
   sha256: a9a73e8eeff093c5c4fb28e9f2e9c4fba2af8ec90961179429008c37a928f952
   md5: 6c12fa06df93e20a3b53d790e1fc7fc8
   depends:
@@ -1838,7 +1838,7 @@ packages:
   license: GNU LGPL
   size: 1616824
   timestamp: 1532084028670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20210910-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20210910-h7f8727e_0.tar.bz2
   sha256: 47d3ff15d11ffed8a2b8954d5e100b3806ff6898a12ec500d7afe043dc2076de
   md5: 5f295795bb8e419eacb4d6ffbba68ceb
   depends:
@@ -1848,7 +1848,7 @@ packages:
   license_family: BSD
   size: 195324
   timestamp: 1636026988621
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
   sha256: efdab884c85fda4461f7a393aa6d4e0e50d03cb59fb9c8a980b1307b8379ebe0
   md5: eeca774c6154c49340dd403b1928d5e9
   depends:
@@ -1857,7 +1857,7 @@ packages:
   license_family: BSD
   size: 108906
   timestamp: 1632891483341
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
   sha256: 3b4afe7665dcdb99bd4586a888b85b2e0325f8faecdd31c7780792080ee97872
   md5: 822b5201dde61bc838072dc5b670c88c
   depends:
@@ -1866,7 +1866,7 @@ packages:
   license: Custom
   size: 55183
   timestamp: 1594054267890
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
   sha256: c6fafbe73d2f93b91b6f4b65829f925f52a8f84746a57abd216b39da9ce8c494
   md5: 238f19c803a6ba7bd6dbd6989e03cbf1
   depends:
@@ -1874,7 +1874,7 @@ packages:
   license: GPL
   size: 8496776
   timestamp: 1560112207081
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgdal-3.0.2-he6cead7_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgdal-3.0.2-he6cead7_2.tar.bz2
   sha256: 1f3e00689fa84861e32cee9770b34e476f3f2ccc459bb8b4d0d78f9d9150bc8e
   md5: deb3f0e7bbb8d7faeb2a8cc37b7d94cd
   depends:
@@ -1916,13 +1916,13 @@ packages:
   - zstd >=1.4.9,<1.5.0a0
   size: 19859167
   timestamp: 1643382592086
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
   sha256: 83c6fdb30a240fbaa09f5d2e2ae8f092759cb710bc3fa628ccb18934fc237b7f
   md5: 6003e09e8cef9aca91b954abfdd0f39c
   license: GPL
   size: 1336385
   timestamp: 1534628456385
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
   sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
   md5: 3080c2813e6e1d0f8a100a38b5b3456d
   depends:
@@ -1930,7 +1930,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 573231
   timestamp: 1654090775721
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libkml-1.3.0-h7ecb851_5.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libkml-1.3.0-h7ecb851_5.tar.bz2
   sha256: 84ba7a094c39081a1a2d7226480fc20f80ec9535fdd4af499a80fac25af48b9d
   md5: 3c2d1e438121487642301abd252f7f6b
   depends:
@@ -1942,7 +1942,7 @@ packages:
   license: BSD 3-Clause
   size: 661183
   timestamp: 1622296726318
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.0.0-h3826bc1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libllvm11-11.0.0-h3826bc1_1.tar.bz2
   sha256: 1106ab3350c5fc6181019728ba7a575667135731590d309fed26dc32163f54f8
   md5: 6daa3aad932f5a099829b61c07368e0a
   depends:
@@ -1953,7 +1953,7 @@ packages:
   license_family: Apache
   size: 29802574
   timestamp: 1646054256176
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnetcdf-4.8.1-h42ceab0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libnetcdf-4.8.1-h42ceab0_1.tar.bz2
   sha256: 8291a338553b086e91121b081de2631dc8de2430cf9c45d2da21d8a646e9804e
   md5: a2566f0db9a998fdcee525ebc452f2b5
   depends:
@@ -1969,7 +1969,7 @@ packages:
   license_family: BSD
   size: 1575093
   timestamp: 1642426008501
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.46.0-hce63b2e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libnghttp2-1.46.0-hce63b2e_0.tar.bz2
   sha256: 35e522586539ca4b437626cdd3927adb8cdafae3bd73a9d725891d79aa7a3850
   md5: 97f632fd848c61ef9ac21fdf95ddd412
   depends:
@@ -1985,7 +1985,7 @@ packages:
   license_family: MIT
   size: 814126
   timestamp: 1637149827126
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
   sha256: bc3e6e79c32ff0ecea601aa108ae9cf4068f69703580e40e266ad4bcc52cff54
   md5: 9cb85601944ca7383b1769bff74b94e8
   depends:
@@ -1994,7 +1994,7 @@ packages:
   license: zlib/libpng
   size: 372914
   timestamp: 1556041895170
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpq-12.9-hc2c5182_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpq-12.9-hc2c5182_2.tar.bz2
   sha256: f07555b0450d8869006b598091b958dd08adf7a00dd64c3945a1c7976ffa39c1
   md5: 3912de5f8ecbc526228146d3edff2162
   depends:
@@ -2005,7 +2005,7 @@ packages:
   - zlib >=1.2.12,<2.0.0a0
   size: 2953122
   timestamp: 1655472390761
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -2013,7 +2013,7 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libspatialindex-1.9.3-h2531618_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libspatialindex-1.9.3-h2531618_0.tar.bz2
   sha256: b0f60b4c32f917a9c1b1048520cdfb5937ff7a07befa8a71022dfafae6e29ca4
   md5: 8365a8a1dd0aef199a1214831622a4ef
   depends:
@@ -2022,7 +2022,7 @@ packages:
   license: MIT
   size: 3283214
   timestamp: 1616086764247
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libspatialite-4.3.0a-hbedb2dc_20.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libspatialite-4.3.0a-hbedb2dc_20.tar.bz2
   sha256: 51e90612881c1ae93c1486e31ccea0ab74c2424c57ba9e58d0ec25667c082067
   md5: 28b616e9f1f5e597c78a6dd82f324cb8
   depends:
@@ -2037,7 +2037,7 @@ packages:
   license: LGPL-2.1
   size: 3292456
   timestamp: 1642781088363
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-h8f2d780_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libssh2-1.10.0-h8f2d780_0.tar.bz2
   sha256: 97549094b023e65e4a16581593d5b63dfa7b84cc383911b80b44eb71bb23f12c
   md5: f99f13daacf379a329e041ec148c4db7
   depends:
@@ -2047,13 +2047,13 @@ packages:
   license_family: BSD
   size: 311377
   timestamp: 1651087263509
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
   sha256: 43b0bd205f539583c088feb5b8d77b60c83d1df80c2a93dac9f2a1127001b2cf
   md5: 53fa39fdae936e9d07c4b2f5ef361993
   license: GPL3 with runtime exception
   size: 4246257
   timestamp: 1560112223556
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h85742a9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h85742a9_0.tar.bz2
   sha256: 5e249c94d0b7b3bf035d69c2f707964b5e39995987b359d17de28c0a54ee9405
   md5: d7ea21b29e29feec41890296b559555b
   depends:
@@ -2067,7 +2067,7 @@ packages:
   license: HPND
   size: 655372
   timestamp: 1616492392965
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
   sha256: 4e1dce80f23551a69761ad48b2372e35f58292ec9cc0ce061312330366a1a223
   md5: fda36b99463bad87974196da2d5bed08
   depends:
@@ -2075,7 +2075,7 @@ packages:
   license: BSD 3-Clause
   size: 18725
   timestamp: 1633507857274
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
   sha256: 146dbb1e4dbccdd57819e5102a8ca00970b8e33d6c6180e8007db89b184da569
   md5: c566a384259c1d2769852c3bddd81a67
   depends:
@@ -2089,7 +2089,7 @@ packages:
   license_family: BSD
   size: 90150
   timestamp: 1645441199289
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
   sha256: cffb5a063111f7a99a99c74770b23db5dde52325e25a7a46d1903d5ff4a82c88
   md5: eeb1bd66f28bed1956ab989d6eff7ae5
   depends:
@@ -2100,14 +2100,14 @@ packages:
   license_family: BSD
   size: 889956
   timestamp: 1645089138421
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
   sha256: 5d68e69709ae10bd6c4b58b6af447ad2f2bd24955994f3ec77103d1a6bf5e1f5
   md5: 49e523de8d364b7fabc3850eccbe9bda
   depends:
   - libgcc-ng >=7.5.0
   size: 623492
   timestamp: 1652448233146
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
   sha256: 71f6c4a97014d745c58df52b4dd60ddd75a8508d54fe5b97f42bd1f31cb1c067
   md5: 686e77514ec9f1ef0a6feed374f14d37
   depends:
@@ -2119,7 +2119,7 @@ packages:
   license_family: MIT
   size: 789469
   timestamp: 1653546418059
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libzip-1.5.1-h8d318fa_1004.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libzip-1.5.1-h8d318fa_1004.tar.bz2
   sha256: c66743f02b3aa64e282a6fe0bfd22dd22fdbbc820f6b09390f6faa25868eecd7
   md5: 86f9a212269ef9ba56f0ff8a91012e9e
   depends:
@@ -2131,7 +2131,7 @@ packages:
   license_family: BSD
   size: 88675
   timestamp: 1651789268252
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.37.0-py38h295c915_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.37.0-py38h295c915_2.tar.bz2
   sha256: 8d8519807e896d67349d97b0c4870eb1384224cd315e607e76834b62b41fa959
   md5: c87ba42e4cdcf46d0a8233934c6f42cd
   depends:
@@ -2142,7 +2142,7 @@ packages:
   license: BSD-2-Clause
   size: 508375
   timestamp: 1646151524759
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py38h06a4308_0.tar.bz2
   sha256: a2c16e4e68e414ea6f7680a6439e80f7d67fb693bf739fc10d2ef5afc3e3c2f4
   md5: dc8d6a9a1e475c5fc9de8531026a4c38
   depends:
@@ -2151,7 +2151,7 @@ packages:
   license_family: BSD
   size: 11040
   timestamp: 1652903148662
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
   sha256: 2c6a5dda7c510a961bc78e31d4232be5e8e0760c93454f5fd200c379355e0f5e
   md5: f35d4bf2fbb39e334992f6dd39f8721e
   depends:
@@ -2161,7 +2161,7 @@ packages:
   license_family: BSD
   size: 220865
   timestamp: 1627657046002
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mapclassify-2.5.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mapclassify-2.5.0-py38h06a4308_0.tar.bz2
   sha256: 5da141bfe8ca42e7a90914205d7df33058e23edb83f4b49465e4197c744d64c8
   md5: d419995013e0ac81bd88a370102edeed
   depends:
@@ -2175,7 +2175,7 @@ packages:
   license_family: BSD
   size: 65945
   timestamp: 1675157805003
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py38h06a4308_0.tar.bz2
   sha256: 67fb17f71cf101e66ccb210d8a5c3c10fd6966aaff214034fb6f860ca8d00e7f
   md5: 32d28f2c97744b2e954e30fa485b5c5c
   depends:
@@ -2185,7 +2185,7 @@ packages:
   license_family: BSD
   size: 122380
   timestamp: 1671541939225
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.0.1-py38h27cfd23_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.0.1-py38h27cfd23_0.tar.bz2
   sha256: b6cd835c2ab5bfcdd27a86d56982693cdc40b2e45df42d05e08c83916d4c3e38
   md5: 32d66308493c20bed8ca2a852155b9b9
   depends:
@@ -2195,7 +2195,7 @@ packages:
   license_family: BSD
   size: 23062
   timestamp: 1621528207169
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py38ha18d171_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.5.1-py38ha18d171_1.tar.bz2
   sha256: 2790aff6f95231024ff9c2d7ebc9733f8f95286792f28950380c30832c84e90f
   md5: 3171c7f58b5d259c202595cb0dad57a0
   depends:
@@ -2217,7 +2217,7 @@ packages:
   license_family: PSF
   size: 7744768
   timestamp: 1647442104672
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py38h06a4308_0.tar.bz2
   sha256: 228a70eddf0a99801e03179f1ab8ddd915bfb7ce351fe7f94c502163d615eb77
   md5: 28c78d14ef2a80747df2bf2353ef21d7
   depends:
@@ -2227,7 +2227,7 @@ packages:
   license_family: BSD
   size: 16341
   timestamp: 1662014640999
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py38h7b6447c_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py38h7b6447c_1000.tar.bz2
   sha256: e8ba4be2d51f4532870cdc96c212083c782a58da7281b7ecfede0b1d7ab3177b
   md5: 1ec38f43661f9db21e2cdae301ce9b42
   depends:
@@ -2237,7 +2237,7 @@ packages:
   license_family: BSD
   size: 55392
   timestamp: 1573489078577
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
   sha256: 7c4ded8b2ef036839f988560848d2c32e1aa4627fd37a32710e42c39f5c61ac2
   md5: bd20f4410b81f327e35ffa0657961146
   depends:
@@ -2248,7 +2248,7 @@ packages:
   license_family: Proprietary
   size: 229783051
   timestamp: 1634547157986
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py38h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py38h7f8727e_0.tar.bz2
   sha256: d4bc8c57703eb186f6a95bcb052042ae3bdc18e97e2be7362a1473055c70ea04
   md5: 350e1ec6d837a61b44bf3c26dc8d094b
   depends:
@@ -2260,7 +2260,7 @@ packages:
   license_family: BSD
   size: 63766
   timestamp: 1626183937671
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py38hd3c417c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.1-py38hd3c417c_0.tar.bz2
   sha256: f60b8a001aa29e29c20f2a1e7328a1f0cb10564fa624f4519fdb9bfdd30f3698
   md5: 856d2f4ee31539c64641c15d4d887e48
   depends:
@@ -2274,7 +2274,7 @@ packages:
   license: BSD 3-Clause
   size: 204397
   timestamp: 1634566418352
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py38h51133e4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.2-py38h51133e4_0.tar.bz2
   sha256: ea1b274cbae030a69bfac2b9668d3273377ffe5490463955d12034db11a5e95f
   md5: aef6e4c094fb094576b1c74919284787
   depends:
@@ -2288,7 +2288,7 @@ packages:
   license: BSD-3-Clause
   size: 349357
   timestamp: 1626186149062
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py38hd09550d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/msgpack-python-1.0.3-py38hd09550d_0.tar.bz2
   sha256: 0908b112893c3a7a563010e020c810d6aab61a0132ac6ef5ea3ba2e59541da6c
   md5: 17c600586128f5f226b9a5cda765f302
   depends:
@@ -2299,7 +2299,7 @@ packages:
   license_family: Apache
   size: 90061
   timestamp: 1652362785051
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py38_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py38_0.tar.bz2
   sha256: a00d1f914deb4b896a3d42d2cae73097e1f5f2f4bc371dd3ceed04118eb974b4
   md5: 7ccf826b74681264ec620255a556fd97
   depends:
@@ -2309,7 +2309,7 @@ packages:
   license_family: BSD
   size: 22859
   timestamp: 1573120615619
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py38h06a4308_0.tar.bz2
   sha256: f944e13c61956005bb065e814731663ffb03184bb97f7f4eb0f56c7f7b2a8326
   md5: 284f3746088fe4815f7ec26187b9e994
   depends:
@@ -2335,7 +2335,7 @@ packages:
   license_family: BSD
   size: 8264737
   timestamp: 1681756406572
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py38h06a4308_0.tar.bz2
   sha256: 27b620c69e97894d21c2477b29b49f32146c984d89cb6506ed13d4447719d3c0
   md5: 0a21ae11a8a79a3c621fee4baf252f2c
   depends:
@@ -2348,7 +2348,7 @@ packages:
   license_family: BSD
   size: 98761
   timestamp: 1650308401439
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.4.4-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.4.4-py38h06a4308_0.tar.bz2
   sha256: ef2905b389ee29f9fd05c83e0f2f845e16229766b91d656747c0e0fe96eb0f80
   md5: 027a64ac454988b784fff9947c1ae1d6
   depends:
@@ -2373,7 +2373,7 @@ packages:
   license_family: BSD
   size: 568315
   timestamp: 1649751975792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py38h06a4308_0.tar.bz2
   sha256: aa52cf81b5826bc6d7552f30c6aad7d8bef270da5cf836c024bbbdf5a148932a
   md5: 760c9190893e51e1c59041c24be42711
   depends:
@@ -2386,7 +2386,7 @@ packages:
   license_family: BSD
   size: 146963
   timestamp: 1694616862202
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
   sha256: 0807371380965e421cb5f3f2a30d790fd5c41db11dbb6d318e14294c3b1741ed
   md5: fca4bd4e3891aebf4fd7daf9b6d0ccfa
   depends:
@@ -2394,7 +2394,7 @@ packages:
   license: Free software (MIT-like)
   size: 1083412
   timestamp: 1636570020698
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py38h06a4308_0.tar.bz2
   sha256: e07b5e33856bad27cb9577f79214a113163e27bfaadbac1950643141da43f0f6
   md5: 839bb853e143fac8faccabe9c90ff79e
   depends:
@@ -2403,7 +2403,7 @@ packages:
   license_family: BSD
   size: 12944
   timestamp: 1672387169775
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/netcdf4-1.5.7-py38ha0f2276_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/netcdf4-1.5.7-py38ha0f2276_1.tar.bz2
   sha256: 35757876321c3dd186f36cd8dad716a51f666dd6c5766e63ea40d3247ee9d27e
   md5: 54e856517fdb869ba630bb39c49fd3b6
   depends:
@@ -2419,7 +2419,7 @@ packages:
   license_family: MIT
   size: 507985
   timestamp: 1643311809468
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/networkx-3.1-py38h06a4308_0.tar.bz2
   sha256: bacdb012adbcd871b900cab6e4e20de88d623829608ebd26ac49dccf58f4f3fb
   md5: d78ff982a19fd0f29479549f73ab0872
   depends:
@@ -2428,7 +2428,7 @@ packages:
   license_family: BSD
   size: 2949423
   timestamp: 1690562082101
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py38h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py38h06a4308_1.tar.bz2
   sha256: ec50325b0351817c4922457acc1319a68f12093f907c85aa96ee2356236f0f34
   md5: c43a610d54a7f1be888b4646caedf5bd
   depends:
@@ -2453,7 +2453,7 @@ packages:
   license_family: BSD
   size: 589052
   timestamp: 1690985075092
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py38h06a4308_0.tar.bz2
   sha256: e211f8e0dc8c60827aefd49737a3bcfb52f94acea9c38311d5fd51f3c5d8fe34
   md5: fd311495d2aca2cb0173cd3f37b36016
   depends:
@@ -2463,7 +2463,7 @@ packages:
   license_family: BSD
   size: 21957
   timestamp: 1668160706352
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.54.1-py38h51133e4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numba-0.54.1-py38h51133e4_0.tar.bz2
   sha256: 5c509ac6729a7f75bf469ed7a0eb69cb5c71063b980449f1cad3b1ff03e26a76
   md5: 4ef6b53caf47947b75331d8399539fbd
   depends:
@@ -2482,7 +2482,7 @@ packages:
   license_family: BSD
   size: 3879950
   timestamp: 1635186012359
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py38h6abb31d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.1-py38h6abb31d_0.tar.bz2
   sha256: 70b437d6697ff0ad278e948e915576380f58c3ba1b799d1d45a9ad780fff1fed
   md5: 2eca95d6ee550a5e314de57b46413961
   depends:
@@ -2498,7 +2498,7 @@ packages:
   license_family: MIT
   size: 136950
   timestamp: 1640704277727
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.20.3-py38hf144106_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.20.3-py38hf144106_0.tar.bz2
   sha256: 4a11292f4b5a8f9a18c81488146dbf356357baca8c9efe4c5962c56aea91354b
   md5: 65bc5e584d119d33a7f40fdae48861f8
   depends:
@@ -2513,7 +2513,7 @@ packages:
   license: BSD 3-Clause
   size: 22472
   timestamp: 1626271770716
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.20.3-py38h74d4b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.20.3-py38h74d4b33_0.tar.bz2
   sha256: 8c9108421eacb1905943b37da3eef6a435661d3a105b5091f2ed8f86e962b200
   md5: 68fb19b46268a5a8793ff193e756771a
   depends:
@@ -2527,7 +2527,7 @@ packages:
   license: BSD 3-Clause
   size: 5996323
   timestamp: 1626271757410
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
   sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
   md5: b0afe23033c8c5344640bc25225fa579
   depends:
@@ -2538,7 +2538,7 @@ packages:
   license: BSD 2-Clause
   size: 516994
   timestamp: 1630084830020
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
   sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
   md5: 5ad4571eba2479f77a9f849a6ae7724c
   depends:
@@ -2548,7 +2548,7 @@ packages:
   license_family: Apache
   size: 3998613
   timestamp: 1694465071784
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py38h06a4308_0.tar.bz2
   sha256: 583b4d92e7d967db9b158545b7971a629e2fabf0a10074fc3f957391543ce1ff
   md5: 14693d3ef7699c4a9030266bbcd718ad
   depends:
@@ -2557,7 +2557,7 @@ packages:
   license_family: Apache
   size: 72553
   timestamp: 1693575288897
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.3.5-py38h8c16a72_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-1.3.5-py38h8c16a72_0.tar.bz2
   sha256: 782e43bce03c78e838b215bd1ddf1daa9358448fe19556ef6a33b3ac70fe6831
   md5: e034743503afe301e28d05643bb703d7
   depends:
@@ -2573,7 +2573,7 @@ packages:
   license_family: BSD
   size: 12899827
   timestamp: 1641461402605
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/partd-1.4.0-py38h06a4308_0.tar.bz2
   sha256: efe972fd22443727d39d9efd2060123bf2fb69ea1a9353271e446e29f6530bb0
   md5: 24c261deb2957f3e1078cc146d809e26
   depends:
@@ -2587,7 +2587,7 @@ packages:
   license_family: BSD
   size: 34819
   timestamp: 1693937895456
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
   sha256: 4881cc5e0d5b20335bcfba4eaf29fdc95dedf2607903aabecdacffb64d3407d4
   md5: 4bac8a874e62f41ebab8345ca6076eb6
   depends:
@@ -2597,7 +2597,7 @@ packages:
   license_family: BSD
   size: 263308
   timestamp: 1624477853289
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py38h22f2fdc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-9.0.1-py38h22f2fdc_0.tar.bz2
   sha256: 4e2faa1845386c77f6a7a7b67d1283b1d2139e2a979f2c852e3c6f770b7b59cf
   md5: ece067a13def0fb55fcf2f6f7ad128b1
   depends:
@@ -2616,7 +2616,7 @@ packages:
   license_family: Other
   size: 732913
   timestamp: 1646306967387
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py38h06a4308_0.tar.bz2
   sha256: 4758820f8ee80d5da09151178c942918d156723fc67fc2cefa750a44fe52f5f1
   md5: 4063b7dbf0b17df97508784af2ff8bbc
   depends:
@@ -2627,7 +2627,7 @@ packages:
   license_family: MIT
   size: 2678540
   timestamp: 1697548822688
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pixman-0.40.0-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pixman-0.40.0-h7f8727e_1.tar.bz2
   sha256: e0f6c86339e683ea9e3f7e4ce743df653103209aedf995b5e674c148cb349ed8
   md5: c197093127a4cca3bb3227aab1a68573
   depends:
@@ -2635,7 +2635,7 @@ packages:
   license: MIT
   size: 645031
   timestamp: 1632711422664
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pkgutil-resolve-name-1.3.10-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pkgutil-resolve-name-1.3.10-py38h06a4308_0.tar.bz2
   sha256: 3253e3b4e00197f39259501fc30ee45ca37fedea540d096140feebe793a242e0
   md5: eef230cabc54459c3b9c52938028e376
   depends:
@@ -2644,7 +2644,7 @@ packages:
   license_family: PSF
   size: 9765
   timestamp: 1661463353650
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py38h06a4308_0.tar.bz2
   sha256: 4bf901b9310c1c68e71a78a9d2608ce439ca3dafed4f1223da5f7a4217a80cce
   md5: 9bc4d8193c88dbeb3ee43a8f44c56adf
   depends:
@@ -2653,7 +2653,7 @@ packages:
   license_family: MIT
   size: 32013
   timestamp: 1692205473871
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/poppler-0.81.0-h01f5e8b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/poppler-0.81.0-h01f5e8b_2.tar.bz2
   sha256: 9a5ad9ed809ea6cd5b11ff992519e2b1cffaf14e63e0d345c589270e9ea181f9
   md5: d1d02486a56bddedb4789c0802d67f18
   depends:
@@ -2675,14 +2675,14 @@ packages:
   license_family: GPL
   size: 13295029
   timestamp: 1623340073756
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/poppler-data-0.4.11-h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/poppler-data-0.4.11-h06a4308_1.tar.bz2
   sha256: cb8da35b87b1a486e8bb35a8978dcedc93a6d3cc9f9909665267d5fe5d1f93b2
   md5: 3e4df7dd4cb1e7fc2415c39951ebf4a4
   license: GPL-2.0-or-later and GPL-3.0-or-later and BSD-3-Clause
   license_family: GPL
   size: 3894636
   timestamp: 1673863550016
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/proj-6.2.1-h05a3930_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/proj-6.2.1-h05a3930_0.tar.bz2
   sha256: 4fc2839540e89f0b4b408fc07d4ea7f4e57ad8d84ca8c117df0622a165470301
   md5: 675fbf1eb0b5d8631be148dbfdd76942
   depends:
@@ -2694,7 +2694,7 @@ packages:
   license: MIT
   size: 10659620
   timestamp: 1643031993108
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py38h06a4308_0.tar.bz2
   sha256: fe048f508881e6f69ea1781ece59102037d83c102778669e8caf390009b20d74
   md5: 4718ad7bf83e664525c13ce1ded14c84
   depends:
@@ -2703,7 +2703,7 @@ packages:
   license_family: Apache
   size: 91025
   timestamp: 1659455269732
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py38h06a4308_0.tar.bz2
   sha256: 5206b4d6c7196f5a250d0ac786b41ba7243a89e190e089f7f680af3c8a30f561
   md5: 76ffbcff7bf187c82475bf7bfa427178
   depends:
@@ -2715,7 +2715,7 @@ packages:
   license_family: BSD
   size: 580511
   timestamp: 1672387395908
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py38h27cfd23_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.8.0-py38h27cfd23_1.tar.bz2
   sha256: 5a7da09bd13cfe53da03da7bbcd1a982b0200f53b00137bff3d3c24a6e860054
   md5: 79ae56161fb6b23fc900f4bf6943e031
   depends:
@@ -2725,7 +2725,7 @@ packages:
   license_family: BSD
   size: 351263
   timestamp: 1612298067868
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py38h06a4308_0.tar.bz2
   sha256: dd70dbec022d1fca1fb2168bb81eeb2d970d53494f4bb4ce36751d70ce960b79
   md5: b09b43fc9f274c994af65adefa36279f
   depends:
@@ -2737,7 +2737,7 @@ packages:
   license_family: BSD
   size: 29267
   timestamp: 1675441565524
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py38h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py38h06a4308_1.tar.bz2
   sha256: dae53aeb4103d375b1125eecc4dc3cdf5fcfa9288d24f3a9e1c5d9b0107a501c
   md5: 13fc002e79408c57aa79fb2c25e1b538
   depends:
@@ -2746,7 +2746,7 @@ packages:
   license_family: BSD
   size: 1887598
   timestamp: 1684280001176
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py38h06a4308_0.tar.bz2
   sha256: 5343573495dab43317505d1cbe5f84142064e5c055f097ffc6f82e8212dac1fb
   md5: 86d9d9f5614c8a27bc48994401114f1c
   depends:
@@ -2756,7 +2756,7 @@ packages:
   license_family: Apache
   size: 94531
   timestamp: 1690223548194
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py38h06a4308_0.tar.bz2
   sha256: 97972579f3c079aab5fb9a58855caded3b268bf90c0afdf5e6f39d75edd9a699
   md5: b47e7fcdef58cc3b2b8d920c73819e19
   depends:
@@ -2765,7 +2765,7 @@ packages:
   license_family: MIT
   size: 156616
   timestamp: 1661452605147
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyproj-2.6.1.post1-py38hb3025e9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyproj-2.6.1.post1-py38hb3025e9_1.tar.bz2
   sha256: 1db7b0212a027d883426d4c36cc8f9bf4c56232a97fe46cd373bec44b1c63ba6
   md5: 5ea29d28879ed23adea37d26809a274e
   depends:
@@ -2775,7 +2775,7 @@ packages:
   license: MIT
   size: 464988
   timestamp: 1614278003311
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py38heee7806_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py38heee7806_0.tar.bz2
   sha256: cdb902390f42cd9eeab33f1d55cf6b09baa7f9e4b00be46cb29ff7bd94d1e613
   md5: 7528db4bd42c5b961b3bf7fd41b028a1
   depends:
@@ -2785,7 +2785,7 @@ packages:
   license_family: MIT
   size: 97208
   timestamp: 1636110987189
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py38h06a4308_0.tar.bz2
   sha256: 0d1c9fb08b326f1292b74373b942b739bb99dd4ec54d2be09e5072503300b2a8
   md5: 3ec9d5960a2ea2ba666008fdfc9d0084
   depends:
@@ -2794,7 +2794,7 @@ packages:
   license_family: BSD
   size: 31276
   timestamp: 1605305807726
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.8.13-h12debd9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.8.13-h12debd9_0.tar.bz2
   sha256: 92d4fb3683a4be042f37b39cc5b0999ee1443e9df80dc1131ebf858c69146831
   md5: 747f76169a205d14310fab31a7ed5f31
   depends:
@@ -2813,7 +2813,7 @@ packages:
   license_family: PSF
   size: 23831626
   timestamp: 1648468088026
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py38h06a4308_0.tar.bz2
   sha256: cc0f3ceeae6369f8b1523c1f4fff5c16d14c455b938723671a6bc672a65b77ff
   md5: d914447598a4c8d1e61fd888dded2072
   depends:
@@ -2822,7 +2822,7 @@ packages:
   license_family: BSD
   size: 264015
   timestamp: 1661371299911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.2.1-py38h2531618_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-lmdb-1.2.1-py38h2531618_1.tar.bz2
   sha256: abfb8101b1d642a8055e900a153410aa9155c2ea34658d517b956139c63a76d9
   md5: cfb0c6464216dd11a338f990de0fd77e
   depends:
@@ -2833,7 +2833,7 @@ packages:
   license_family: Other
   size: 139712
   timestamp: 1619708194484
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py38h06a4308_0.tar.bz2
   sha256: 4734c44244182009ee87d481d86ab3617c5b39c1b4fffcbf62236544bcdee5bc
   md5: feb8c564e6ec229f489c95674f486935
   depends:
@@ -2842,7 +2842,7 @@ packages:
   license_family: MIT
   size: 253213
   timestamp: 1695131612977
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py38h06a4308_0.tar.bz2
   sha256: bc8e5299a2b352f3bb5fbaf9d8426af3a7762014f502474ea38a554af96e371a
   md5: 274de0d6efbcaa67dd3a5d1a92c18576
   depends:
@@ -2852,7 +2852,7 @@ packages:
   license_family: BSD
   size: 39982
   timestamp: 1685030807272
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py38h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0-py38h7f8727e_1.tar.bz2
   sha256: 4bba1dee9097258660877150dd378d5f39f688642add536c507aff94db35edaf
   md5: 4d28a98def54cf09f7ad028e43f0b33a
   depends:
@@ -2863,7 +2863,7 @@ packages:
   license_family: MIT
   size: 183855
   timestamp: 1635763881638
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py38h295c915_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-22.3.0-py38h295c915_2.tar.bz2
   sha256: de6699ca6cf7fd88e0074c457dd6aa6928ee5256c93b3a86daaf0b0501aef556
   md5: ccfebd6d36d1a727dc2922b2e21814ad
   depends:
@@ -2874,7 +2874,7 @@ packages:
   license_family: BSD
   size: 539827
   timestamp: 1638436432728
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
   sha256: 8c950c69bee969e2c66f88f0dc247b3ab75a753672a88009779d5f5dba193532
   md5: 150ac0eb929bab9dec912797bdfc7b95
   depends:
@@ -2884,7 +2884,7 @@ packages:
   license_family: GPL
   size: 433182
   timestamp: 1642022402894
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py38h06a4308_0.tar.bz2
   sha256: 6237774a1de06b391400f3ff5f02b721416580fb3230f4d1ac6a193a883ef5be
   md5: 6b60cf64194bce8c4d7fbe9f24c5ced4
   depends:
@@ -2900,7 +2900,7 @@ packages:
   license_family: Apache
   size: 94127
   timestamp: 1690400316882
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rtree-1.0.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rtree-1.0.1-py38h06a4308_0.tar.bz2
   sha256: c735d6921d8192d6eb56f69a37910c6faeaf36fa7ca23da049164913b15974bd
   md5: 3f04d5207ae2ac4b77eb041d90a60bfc
   depends:
@@ -2911,7 +2911,7 @@ packages:
   license_family: MIT
   size: 48757
   timestamp: 1675157906591
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scikit-learn-1.0.2-py38h51133e4_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/scikit-learn-1.0.2-py38h51133e4_1.tar.bz2
   sha256: 2bd93c83e2f4b834a876a84dab987eb8c470ea5fc7836023b67c801f803a17c5
   md5: 51493123a884f481a231bd0135efbb06
   depends:
@@ -2928,7 +2928,7 @@ packages:
   license_family: BSD
   size: 7971729
   timestamp: 1642617422064
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.6.2-py38had2a1c9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/scipy-1.6.2-py38had2a1c9_1.tar.bz2
   sha256: e601bf7ba1fe39b9e2faab62f0fb9b637ca6aeddc2ed70e7ec364e972c9d7fce
   md5: c2b98d3f055c38b93d740402f29347d5
   depends:
@@ -2943,7 +2943,7 @@ packages:
   license: BSD 3-Clause
   size: 21164725
   timestamp: 1618856307974
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py38h06a4308_0.tar.bz2
   sha256: 9f4cc75cff095f7a5f8bef8fdd23db5676b8a958661556f32712dd1b95427735
   md5: df8c6561cfa56fd8761cebba233cc885
   depends:
@@ -2952,7 +2952,7 @@ packages:
   license_family: MIT
   size: 1084829
   timestamp: 1690290959166
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/shapely-1.7.1-py38h1728cc4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/shapely-1.7.1-py38h1728cc4_0.tar.bz2
   sha256: 7e09fab4eba71c6bbfb16c0d6ccce87106e0a7f09a868db90f27850ed29c25a0
   md5: 6c73554c4de6df382fa254eba9fe2c3c
   depends:
@@ -2963,7 +2963,7 @@ packages:
   license: BSD-3-Clause
   size: 456532
   timestamp: 1632813570956
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py38h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py38h06a4308_1.tar.bz2
   sha256: 52850a7d4a19c13be2b62962055e8a8104f5dc79926ca70a1d1a52529527d30f
   md5: 884ea8d949dedfb11505f8d0e27c022e
   depends:
@@ -2972,7 +2972,7 @@ packages:
   license_family: Apache
   size: 15671
   timestamp: 1614030513783
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py38h06a4308_0.tar.bz2
   sha256: e888d0ed8d489e081102fb1c816479db50802243f40ba24079a76465709642e3
   md5: 20d72998dbdd62e71f8901634d630352
   depends:
@@ -2981,7 +2981,7 @@ packages:
   license_family: MIT
   size: 66454
   timestamp: 1696347666187
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
   sha256: 87965b7b46d93866d31696a1045216d64f077a06b2900c356aba87e8559c6188
   md5: fa334030245135b37027a882f3c468bf
   depends:
@@ -2992,7 +2992,7 @@ packages:
   license_family: Other
   size: 1561908
   timestamp: 1655328608308
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
   sha256: d4c0f3e57d8df6042151e65a706f8cd76c9325a47548f4ca3c3516e352dd8ca3
   md5: 1decb9dd0e7bcee086d83b8b4ab8c8eb
   depends:
@@ -3001,7 +3001,7 @@ packages:
   license: Apache-2.0
   size: 171277
   timestamp: 1641830509786
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py38h06a4308_0.tar.bz2
   sha256: b1aaff89c39b3dfd49e910e706f63fc361d4edd14350ea7f6b9fbfc1984ead35
   md5: 462c5ca383e788c3f7d20270e378991b
   depends:
@@ -3012,7 +3012,7 @@ packages:
   license_family: BSD
   size: 29863
   timestamp: 1671751945016
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/testpath-0.6.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/testpath-0.6.0-py38h06a4308_0.tar.bz2
   sha256: 5bc56eb1d33f8d60d675b53bf462ec49e9ac548614af880db53b651bfaae54a5
   md5: 23ebb7cf9ee5b1fe62a911fb71e272ee
   depends:
@@ -3021,7 +3021,7 @@ packages:
   license_family: BSD
   size: 93471
   timestamp: 1655908769769
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tiledb-2.2.9-hffe1d7a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tiledb-2.2.9-hffe1d7a_0.tar.bz2
   sha256: 8be642799a2a15ad1a444aa863fde9e5bf0671617f7046dab33429acc04a5221
   md5: 7c97ee1834361965bdd31312ca9650dc
   depends:
@@ -3038,7 +3038,7 @@ packages:
   license_family: MIT
   size: 1772055
   timestamp: 1621648801177
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
   sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
   md5: 5b8375e2092012db69d2123dc0c68630
   depends:
@@ -3048,7 +3048,7 @@ packages:
   license_family: BSD
   size: 3485432
   timestamp: 1654088939579
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py38h06a4308_0.tar.bz2
   sha256: 85077229bfc69efa66079274390675e2f81ffe092435103685d54166e5e69ba6
   md5: aec171353448852f51e81c68ef45dfaa
   depends:
@@ -3057,7 +3057,7 @@ packages:
   license_family: BSD
   size: 101498
   timestamp: 1667464200465
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py38h27cfd23_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.1-py38h27cfd23_0.tar.bz2
   sha256: d90c5e38c73cc80e7d69e7f7e8df47df5d32b6a31bef0d7a799e12132211624b
   md5: 5a07056c0968e39f39510f8b9526714c
   depends:
@@ -3067,7 +3067,7 @@ packages:
   license_family: Apache
   size: 663452
   timestamp: 1606942346182
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py38hb070fc8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py38hb070fc8_0.tar.bz2
   sha256: effd1650a61f827fe737a963c6b2463b3710bcde3ff32908cca3b3617064b3aa
   md5: 0769c92607812f43d1b10fdff177e247
   depends:
@@ -3080,7 +3080,7 @@ packages:
   license_family: MOZILLA
   size: 123487
   timestamp: 1679562034657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py38h06a4308_0.tar.bz2
   sha256: 235a049eda3efc73e47d54c57d3bd1567008e5b9b1b9aed4d72d800c217d77fa
   md5: 329270e6ef807c97c1141afdb85113fe
   depends:
@@ -3089,7 +3089,7 @@ packages:
   license_family: BSD
   size: 191687
   timestamp: 1671143939929
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py38h06a4308_0.tar.bz2
   sha256: 0214199a2e56a6ad98685dc0a40720eaa2c5e892b55b9353b53f433f677633a1
   md5: ca4a726759f04cc2bccfb478c5794ade
   depends:
@@ -3099,7 +3099,7 @@ packages:
   license_family: PSF
   size: 8762
   timestamp: 1690297626227
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py38h06a4308_0.tar.bz2
   sha256: 52599ac2dd2b4e6bf74d3577ff56ecb69902796d0dcc339b2423b0d52825d44a
   md5: 5ed3156dad316237ecfb1ee2dc5c535c
   depends:
@@ -3108,7 +3108,7 @@ packages:
   license_family: PSF
   size: 57757
   timestamp: 1690297620154
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.18-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.18-py38h06a4308_0.tar.bz2
   sha256: 269000563c12ffc371a206195aa601b1c3f987d88d5d3008a7ff32f564902b39
   md5: de0c6a9cc6d098a3c9d62a1dd9a890d7
   depends:
@@ -3123,7 +3123,7 @@ packages:
   license_family: MIT
   size: 187862
   timestamp: 1698257569604
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py38_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py38_1.tar.bz2
   sha256: c6fd7f78c18396f22bde60d84004159a5398d7eaad14ab1b6f7550e9605e3616
   md5: 46be58263b91ea0ce41774c6cef974b7
   depends:
@@ -3132,7 +3132,7 @@ packages:
   license_family: BSD
   size: 20211
   timestamp: 1573200372707
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py38h06a4308_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py38h06a4308_4.tar.bz2
   sha256: 14ffa5f5ce2a18bc7b59c1157c9a61db6c3af83adf5d7b7f386681dfd7571524
   md5: 8ea9442d80b018f9d1bcac1e59469232
   depends:
@@ -3142,7 +3142,7 @@ packages:
   license_family: BSD
   size: 70872
   timestamp: 1614804298366
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py38h06a4308_0.tar.bz2
   sha256: 461d94450fee3587c2b8666eaa56ba691b992eb1dfae3ca7e890092655f7812d
   md5: 933a3dc0c0be419cfee4f58a94682dce
   depends:
@@ -3151,7 +3151,7 @@ packages:
   license_family: MIT
   size: 101287
   timestamp: 1695741958427
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2022.11.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xarray-2022.11.0-py38h06a4308_0.tar.bz2
   sha256: 508985a639f29648f66f7dd3856ad0baf5501601582e52ad26cae4c0e7ca8ea8
   md5: cbef8e255222ff1c5727b7529031ccf8
   depends:
@@ -3163,7 +3163,7 @@ packages:
   license_family: Apache
   size: 1722500
   timestamp: 1668776634679
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xerces-c-3.2.3-h780794e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xerces-c-3.2.3-h780794e_0.tar.bz2
   sha256: 92db799484b158380af98f43d255e61469a759e1a3cf7e5dd0c900687880fd3b
   md5: 8dc5173488d49dc09105ca6359fd4986
   depends:
@@ -3174,7 +3174,7 @@ packages:
   license_family: Apache
   size: 3476121
   timestamp: 1599879004914
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py38h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py38h06a4308_1.tar.bz2
   sha256: 846ae02929f4570ad0979c56332af5b3b4da851419a051e7902bd3a6ec2a0755
   md5: 4d7632b5d03d4b2be70e952e890bcbd5
   depends:
@@ -3183,7 +3183,7 @@ packages:
   license_family: BSD
   size: 47860
   timestamp: 1675159165834
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
   sha256: 2ce360ff98c0ca4537d70c19266b5700810196c54ce2fbaff3b94a969846ee37
   md5: 94cb94dc47405b24b1b5bd0a3275ab59
   depends:
@@ -3192,7 +3192,7 @@ packages:
   license_family: GPL2
   size: 398058
   timestamp: 1651602137803
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -3200,7 +3200,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
   sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
   md5: 567b68192c387b5fc88178425577a0fe
   depends:
@@ -3210,7 +3210,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 366479
   timestamp: 1616055552392
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zict-3.0.0-py38h06a4308_0.tar.bz2
   sha256: 5e35fe343f2db943bb40881684974c9325d13b645baebd67d0ff6c81a1c411ff
   md5: c701afabfd0e39a192953874321cb29d
   depends:
@@ -3221,7 +3221,7 @@ packages:
   license_family: BSD
   size: 76355
   timestamp: 1695832914431
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py38h06a4308_0.tar.bz2
   sha256: bf2618c61988cae41c3428a3e4564f22016705b29b312ba2ffe02b2c7413e407
   md5: ea786d4d331b83592b3004c0d5015131
   depends:
@@ -3230,7 +3230,7 @@ packages:
   license_family: MIT
   size: 17966
   timestamp: 1672387151546
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
   sha256: 513444d83ac2405e898531492ea59f3a95641e357cc39c1048d6fffc1791a16b
   md5: 601d9449c280b9b145dc8c83b6f06119
   depends:
@@ -3239,7 +3239,7 @@ packages:
   license_family: Other
   size: 133595
   timestamp: 1650637720646
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.4.9-haebb681_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.4.9-haebb681_0.tar.bz2
   sha256: d1969321874e6d0a7b9994a043830e453a5caab9c3d89690351ba658700ab611
   md5: 77148a73936c37451810f0b1453569e9
   depends:
@@ -3251,7 +3251,7 @@ packages:
   license: BSD 3-Clause
   size: 828849
   timestamp: 1617228573594
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -3264,7 +3264,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -3274,7 +3274,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
   md5: b2aa5503875aba2f1d88cae9df9a96d5
   depends:
@@ -3283,7 +3283,7 @@ packages:
   license_family: BSD
   size: 13636
   timestamp: 1611930018941
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -3295,7 +3295,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
   sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
   md5: 544adf2677c47c9b9c891aea720678f1
   depends:
@@ -3303,7 +3303,7 @@ packages:
   license: MIT
   size: 33999
   timestamp: 1630003259346
-- conda: https://repo.anaconda.com/pkgs/main/noarch/click-7.1.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/click-7.1.2-pyhd3eb1b0_0.tar.bz2
   sha256: 13795c5b123ae6bd1102ad9a267a6b731da8557441a1e0265527bcd7f349393b
   md5: 62c4d9050c9d92ac315a9ae52ec9c0df
   depends:
@@ -3312,7 +3312,7 @@ packages:
   license_family: BSD
   size: 65208
   timestamp: 1610990606745
-- conda: https://repo.anaconda.com/pkgs/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: 159043b22b754bbfd41d70508ef60a42e3e0f74ebaccd4633726bcf944ab4249
   md5: 86fd637d64a91d9e916f19f349d45a97
   depends:
@@ -3321,7 +3321,7 @@ packages:
   license: BSD-3-Clause
   size: 10095
   timestamp: 1630665910221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
   sha256: bd00b5f84c5fee1a4f252c26d6575a93bcdc5e71832270685e002bf78b2f4eba
   md5: 7c9691bb77e3f20cf12ded06388b4aad
   depends:
@@ -3331,7 +3331,7 @@ packages:
   license_family: BSD
   size: 10160
   timestamp: 1622563293746
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -3340,7 +3340,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2021.10.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/dask-2021.10.0-pyhd3eb1b0_0.tar.bz2
   sha256: 79e7ff341f1aa75e0fb2f684b3d95eb24573c884fe2a02b792b12dda9c29da85
   md5: 1290c500828e2959c3654cf72bd19f21
   depends:
@@ -3358,7 +3358,7 @@ packages:
   license_family: BSD
   size: 19028
   timestamp: 1635969424133
-- conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2021.10.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/dask-core-2021.10.0-pyhd3eb1b0_0.tar.bz2
   sha256: f1441f9930ef17f102206bc46c909813985101d0e894d87a61124fac1525213f
   md5: d3cac1fc6af6b597c0e392517eeeb262
   depends:
@@ -3373,7 +3373,7 @@ packages:
   license_family: BSD
   size: 790776
   timestamp: 1635946371963
-- conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
   sha256: 2de2d79a0e9784a1bf55cdb83c035072da1879753d109c0a36bbd5a357385c37
   md5: 6cfe764bb04e756d7d1319a98a05dd70
   depends:
@@ -3395,7 +3395,7 @@ packages:
   license_family: BSD
   size: 14964307
   timestamp: 1623782401693
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -3404,7 +3404,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -3413,7 +3413,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -3422,7 +3422,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
   sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
   md5: 9eff1a842dbda8d1bae9a2c008b599bc
   depends:
@@ -3433,7 +3433,7 @@ packages:
   license_family: MIT
   size: 690443
   timestamp: 1625743217109
-- conda: https://repo.anaconda.com/pkgs/main/noarch/geoviews-1.9.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/geoviews-1.9.1-pyhd3eb1b0_0.tar.bz2
   sha256: 27eb00a0e6be1b8f23516e69822f43319fcda65d887cb27736aacebfa2dc9e54
   md5: 7de7f3bb8bcefa323aa0e68d022d9bd3
   depends:
@@ -3453,7 +3453,7 @@ packages:
   license: BSD-3-Clause
   size: 10159
   timestamp: 1617997243067
-- conda: https://repo.anaconda.com/pkgs/main/noarch/geoviews-core-1.9.1-pyh06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/geoviews-core-1.9.1-pyh06a4308_0.tar.bz2
   sha256: 52f1723f8fe3cd7708354a2b7259c6c517774c160ef607e3a914d5e55ec1d9ab
   md5: 02ac497f5296311a1452226744460e53
   depends:
@@ -3468,7 +3468,7 @@ packages:
   license: BSD-3-Clause
   size: 417321
   timestamp: 1617997156535
-- conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
   sha256: 9de8666e5b70aa2437737128eaa14ffe80a7b5235c2a6b7d3f39ccefd7816ba0
   md5: bb52e50c5ab1a5c7778c11376404dfdb
   depends:
@@ -3476,7 +3476,7 @@ packages:
   license: BSD 3-Clause
   size: 7933
   timestamp: 1630598543551
-- conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.6-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/holoviews-1.14.6-pyhd3eb1b0_1.tar.bz2
   sha256: 47722ce25b58c78a04cf7105515be98e8901ddf327032cb930fdcc826682ac66
   md5: d6216d6a97168f609d98e9fc91ffe9fa
   depends:
@@ -3495,7 +3495,7 @@ packages:
   license_family: BSD
   size: 3605565
   timestamp: 1632131635972
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -3503,7 +3503,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
   sha256: 9c97f6b9a2cfba7b99e6732505a567787fb86da32cbf2aa6b825069361807845
   md5: e3d2afca7f53449172cb027b2164df6b
   depends:
@@ -3513,7 +3513,7 @@ packages:
   license: BSD-3-Clause
   size: 96029
   timestamp: 1612213176846
-- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
   sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
   md5: 33624a42ee387bf9918ea98b4e7b31fc
   depends:
@@ -3523,7 +3523,7 @@ packages:
   license_family: BSD
   size: 8173
   timestamp: 1601490751973
-- conda: https://repo.anaconda.com/pkgs/main/noarch/munch-2.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/munch-2.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: a263721943f9afb44be6fe84b1cd129371cf07f6f5de6b5507dce9872a763e72
   md5: 58d8526d24479e39c8bdd9bb2978480d
   depends:
@@ -3533,7 +3533,7 @@ packages:
   license: MIT
   size: 13568
   timestamp: 1630566403911
-- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
   sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
   md5: 67857cc5e9044770d2b15f9d94a4521d
   depends:
@@ -3542,7 +3542,7 @@ packages:
   license_family: Apache
   size: 12810
   timestamp: 1600445183315
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -3551,7 +3551,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
   sha256: 011406e85cbb2a3d1e687620dd18ec798ab34a7478f46e7e81b9d8a11fdd914f
   md5: 7ed543858227e957d774766cd46acba9
   depends:
@@ -3568,7 +3568,7 @@ packages:
   license_family: BSD
   size: 10334744
   timestamp: 1628798011706
-- conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
   sha256: 110a3b50f89584ccb13980a617f6258b83b0bc56c8897c96d9e0da9fdc2c957c
   md5: 6266365b47ed65cdb4737603a385c691
   depends:
@@ -3577,7 +3577,7 @@ packages:
   license_family: BSD
   size: 69119
   timestamp: 1625476602265
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -3586,7 +3586,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -3596,7 +3596,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
   sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
   md5: e68a6f315f41a8d814d833652bf38b9b
   depends:
@@ -3604,7 +3604,7 @@ packages:
   license: MIT
   size: 13374
   timestamp: 1606932077143
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -3612,7 +3612,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -3621,7 +3621,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -3630,7 +3630,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pyshp-2.1.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pyshp-2.1.3-pyhd3eb1b0_0.tar.bz2
   sha256: c73f60b664d8be46325f8372be5b8833fa4b864939802af5bcd3e539fe2cf6e2
   md5: 1c6c5cc5d5265e03f16976a2d07da773
   depends:
@@ -3638,7 +3638,7 @@ packages:
   license: MIT
   size: 36844
   timestamp: 1610641859075
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
   sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
   md5: 2eb923cc014094f4acf7f849d67d73f8
   depends:
@@ -3648,7 +3648,7 @@ packages:
   license_family: BSD
   size: 246457
   timestamp: 1626374695070
-- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
   sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
   md5: 41db68b96e114e367c4f120a3b379e59
   depends:
@@ -3657,7 +3657,7 @@ packages:
   license_family: BSD
   size: 19391
   timestamp: 1632406728844
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -3666,7 +3666,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
   sha256: 4e47f6c49ce84509f1466e8a4d728447bf4bcd9bce7b456431a789a262547067
   md5: 4cad993b0f80bc23fb66a97592299cbb
   depends:
@@ -3675,7 +3675,7 @@ packages:
   license_family: Apache
   size: 26504
   timestamp: 1623949147884
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -3687,7 +3687,7 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
   sha256: ca2be6c7810a37cfc6db1f5383937b5d35c6d73c1fad8a9104de85f069b1df1c
   md5: 9ccb2fb33edb152403d6ef32bf758a9d
   depends:
@@ -3696,7 +3696,7 @@ packages:
   license_family: BSD
   size: 15614
   timestamp: 1629402049497
-- conda: https://repo.anaconda.com/pkgs/main/noarch/threadpoolctl-2.2.0-pyh0d69192_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/threadpoolctl-2.2.0-pyh0d69192_0.tar.bz2
   sha256: 16c52bfa6aa2ec07cbf96e260e85a48dd04ec86d3e3b3d7d62eed942f7403d86
   md5: 9047a4e29044b6c760b5d94f62622f4d
   depends:
@@ -3705,7 +3705,7 @@ packages:
   license_family: BSD
   size: 16320
   timestamp: 1629802282940
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -3713,7 +3713,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/noarch/xarray-0.20.1-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/xarray-0.20.1-pyhd3eb1b0_1.tar.bz2
   sha256: 26a02dd567e4fc62857c01ac9a885bf0754fd357893d1c12ff121238412dbf47
   md5: 05378c8aaf2d777f70c8ab45d9d66634
   depends:
@@ -3726,7 +3726,7 @@ packages:
   license_family: Apache
   size: 638342
   timestamp: 1639166152807
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py38hecd8cb5_0.tar.bz2
   sha256: 0cccac6d469f91909c7dc74bc152d8db27d2bde9956483b120d20ec348ae67d2
   md5: d4bd9f9d289eea1119c9f4753b3b0a6c
   depends:
@@ -3739,7 +3739,7 @@ packages:
   license_family: MIT
   size: 161790
   timestamp: 1644481760813
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py38hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py38hecd8cb5_1001.tar.bz2
   sha256: 80777c5e13c10f946bafdb2ccdb0a13010669bb4a0d424b15f81816427f9bc4e
   md5: 070364c2c941da9fefa521327645d2ff
   depends:
@@ -3748,7 +3748,7 @@ packages:
   license_family: BSD
   size: 10035
   timestamp: 1606859471981
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py38hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py38hca72f7f_0.tar.bz2
   sha256: be2b0feedb5668e85bdb044ecdf769e12a4acd0bf026e8c1858327cfbc44945c
   md5: e70cb13b190f8141882cef82fbabf6f0
   depends:
@@ -3758,7 +3758,7 @@ packages:
   license_family: MIT
   size: 36067
   timestamp: 1644569747309
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py38hecd8cb5_0.tar.bz2
   sha256: 802ff851f350213cc4a853b36dad9ac32e17ab1875d1eae907cbb6e649431564
   md5: 8c720af57f6c0123c6b049d0edd80e16
   depends:
@@ -3767,7 +3767,7 @@ packages:
   license_family: MIT
   size: 133707
   timestamp: 1695717877708
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py38hecd8cb5_0.tar.bz2
   sha256: acd1f9e887b18bea21e3e34b0ff0f3a1a2b721e69521bc80c2147ee48e25aadf
   md5: 9b4fac05a82d4113b319094316b193bf
   depends:
@@ -3777,12 +3777,12 @@ packages:
   license_family: MIT
   size: 206831
   timestamp: 1681493135398
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
   sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
   md5: e2f3248e2a5009a02f7b8e54f83314ef
   size: 5620
   timestamp: 1528121955725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
   sha256: 3699a260f422443de85b74084fe36f734be1a466eeebdfdf4195d52c9fdb5508
   md5: 132d056e66b3ae9148f53819f8368c94
   depends:
@@ -3794,7 +3794,7 @@ packages:
   license_family: BSD
   size: 66125
   timestamp: 1675247668924
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.3.3-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-2.3.3-py38hecd8cb5_0.tar.bz2
   sha256: 0409c51e441456e160cf6fb52b2491cc45aede022939cb64018912786b564f8a
   md5: bd420cae4de6a7f01c1d89d477d651f3
   depends:
@@ -3811,7 +3811,7 @@ packages:
   license_family: BSD
   size: 8619137
   timestamp: 1625767586586
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.73.0-hca72f7f_12.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/boost-cpp-1.73.0-hca72f7f_12.tar.bz2
   sha256: 794fc813728b709f3982dfab846bec15ba0b4b44dd574a7f486d508eca929777
   md5: c02652894bb5e54703ea671300cc03dd
   depends:
@@ -3820,7 +3820,7 @@ packages:
   license_family: OTHER
   size: 17652
   timestamp: 1655879884826
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py38h67323c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py38h67323c0_0.tar.bz2
   sha256: e53de3a8d348f91ec7568c800553a3e0f205852ce9e7fa0144201b35fd61172c
   md5: fcb7017fa37d45a11adcf435c93f0732
   depends:
@@ -3830,7 +3830,7 @@ packages:
   license_family: BSD
   size: 129184
   timestamp: 1657176017065
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/branca-0.6.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/branca-0.6.0-py38hecd8cb5_0.tar.bz2
   sha256: b6680dd868a30deddf86acc3c65bf7936389bee6eeb9768c78fc3ba8f967e392
   md5: 4790982d413fbb69732ba220e5c72a0a
   depends:
@@ -3840,7 +3840,7 @@ packages:
   license_family: MIT
   size: 43778
   timestamp: 1675157661567
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
   sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
   md5: 31d6d04cd2388d8f19004501271b3545
   depends:
@@ -3850,7 +3850,7 @@ packages:
   license: MIT
   size: 18982
   timestamp: 1659616229395
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
   sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
   md5: caf1073dc2ca5aeb832a2877394eae12
   depends:
@@ -3859,7 +3859,7 @@ packages:
   license: MIT
   size: 18233
   timestamp: 1659616216769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py38he9d5cce_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py38he9d5cce_7.tar.bz2
   sha256: bcaf78fe2cf03c6673f1b273774d02aa64c2700bbd37cd24a8477cb27ac65d7d
   md5: de254ca137e54af2736477f477dd3f10
   depends:
@@ -3868,28 +3868,28 @@ packages:
   license: MIT
   size: 393312
   timestamp: 1659616275061
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
   sha256: 4574ffa241157e108d19ece60107a3a689cefaaca43578e6c4a6b344c7330278
   md5: ab3b4e83407001e7f1603ca1fa0f4873
   license: bzip2
   license_family: BSD
   size: 106284
   timestamp: 1563219666100
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
   sha256: f913b61ba3c1651b36688415cc163a5d575475f7573b543f48a80e7a5002e4bb
   md5: f11d165eaa532ce04a35382841284298
   license: MIT
   license_family: MIT
   size: 107047
   timestamp: 1693902034820
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
   sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
   md5: ce3588e31faa79f546e0fc6a36c5543c
   license: MPL-2.0
   license_family: Other
   size: 133884
   timestamp: 1694009771475
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cairo-1.16.0-h3ce6f7e_5.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cairo-1.16.0-h3ce6f7e_5.tar.bz2
   sha256: 40610c1f84d17423e18948662190fab696d55b974b44c0e81efc8b4a18c74377
   md5: a562993d973bb938743ff338502108d8
   depends:
@@ -3903,7 +3903,7 @@ packages:
   license_family: LGPL
   size: 1434523
   timestamp: 1688495924565
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cartopy-0.18.0-py38hf1ba7ce_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cartopy-0.18.0-py38hf1ba7ce_1.tar.bz2
   sha256: 6a0cc038fc4e2d1711b9e33856b731ce8460164e0ad7ac288e9db1e4dfa25786
   md5: eab377b64536e10d3c4182c438076306
   depends:
@@ -3920,7 +3920,7 @@ packages:
   license: LGPL-3
   size: 1938628
   timestamp: 1612289897346
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py38hecd8cb5_0.tar.bz2
   sha256: c15d4e7d44baed9f04f039c2b53b4c22b0131bea5a7ec45b4bb7f34a9f77785c
   md5: 2341095fd443f53c4305934f61029fc0
   depends:
@@ -3929,7 +3929,7 @@ packages:
   license_family: Other
   size: 159837
   timestamp: 1690232318712
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py38h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py38h6c40b1e_3.tar.bz2
   sha256: 5aa74865b5eb126265ec6f4725df01a48bf7080821c79c60ab8d563a96834923
   md5: c7484c110ae9772e91e070550d358171
   depends:
@@ -3940,7 +3940,7 @@ packages:
   license_family: MIT
   size: 225626
   timestamp: 1670423374108
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
   sha256: 68a12eaeda90c9cdbce729f0d44d222c3f60ec4920bb781bf13fae3a89cb3dd1
   md5: a0970a5c1c77125369aded2d4e25f870
   depends:
@@ -3952,7 +3952,7 @@ packages:
   license_family: Other
   size: 1437665
   timestamp: 1655814938182
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cftime-1.6.2-py38hacda100_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cftime-1.6.2-py38hacda100_0.tar.bz2
   sha256: cc87300a3c5f04e44bbe8bffb56a474d51c2c481986aa74c468d51915257fb58
   md5: 5db49b76a5e813c9177a3481e99a8714
   depends:
@@ -3962,7 +3962,7 @@ packages:
   license_family: MIT
   size: 228349
   timestamp: 1678830530985
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py38hecd8cb5_0.tar.bz2
   sha256: d2b1550ca58a65e722b08e422d6065064a50d87a19a3fb99be81f36bcbf66fea
   md5: b6338c9d4466d41e3902db36cc0a22d9
   depends:
@@ -3971,7 +3971,7 @@ packages:
   license_family: BSD
   size: 152727
   timestamp: 1698129895844
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cloudpickle-2.2.1-py38hecd8cb5_0.tar.bz2
   sha256: 7783ca8cde172039022bf8f773b6641559829a436bf0deec2dd372224b5ccb05
   md5: 861f685e1db0c13ad18a4ac1086b8e52
   depends:
@@ -3980,7 +3980,7 @@ packages:
   license_family: BSD
   size: 41443
   timestamp: 1683040101633
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py38hecd8cb5_0.tar.bz2
   sha256: ed1004b253e18102c08d53bb6d65635adf73b8d95780adc813b564cabc302e19
   md5: 22dfb5da1e9b3ad955249a73b9d05f40
   depends:
@@ -3990,7 +3990,7 @@ packages:
   license_family: CC
   size: 1969200
   timestamp: 1668084617810
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py38hecd8cb5_0.tar.bz2
   sha256: c504c9ad1d0a4ba516a1199085caf74a2b7140921a253bb885df6c5fcf12efc8
   md5: 4517ff76687a031c86266080fa80df39
   depends:
@@ -4000,7 +4000,7 @@ packages:
   license_family: BSD
   size: 13753
   timestamp: 1671231158299
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py38haf03e11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py38haf03e11_0.tar.bz2
   sha256: 1473dda25c38fb08cbe01cecd833141002a9a70231e7743c77124a3f90d51626
   md5: 1456da04419043ef34f05b42758598da
   depends:
@@ -4011,7 +4011,7 @@ packages:
   license_family: BSD
   size: 225845
   timestamp: 1663827553065
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py38ha2381d6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py38ha2381d6_0.tar.bz2
   sha256: d0bb7704c09b048fcb02d40e520e1e0bdb760733b0b4881b91ff72a5df60b08a
   md5: ee45ddb3786ca048bad9f5134b0a1da2
   depends:
@@ -4024,7 +4024,7 @@ packages:
   license_family: BSD
   size: 1307346
   timestamp: 1694212384731
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/curl-8.2.1-hdb2fb19_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/curl-8.2.1-hdb2fb19_0.tar.bz2
   sha256: 130f332f702f2dcd9c91e8a0f4f1cdcf5581f8ba5e6869d067c12e3f2484704d
   md5: 4386a71e5b735aa2cb407c2ee14fbb7e
   depends:
@@ -4033,7 +4033,7 @@ packages:
   license_family: MIT
   size: 87770
   timestamp: 1693515526229
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.0-py38hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cytoolz-0.12.0-py38hca72f7f_0.tar.bz2
   sha256: a6a95826664084b16b583159ad4cce30ff90043baf645ed516f4ae7634776ab6
   md5: 999e3395ff83a25f72024852eb31921c
   depends:
@@ -4043,7 +4043,7 @@ packages:
   license_family: BSD
   size: 356978
   timestamp: 1667466007219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py38hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/datashape-0.5.4-py38hecd8cb5_1.tar.bz2
   sha256: 93795b6dc8f961dbe377760a32f38512e015d618109cbc030cac09f171be2078
   md5: fe229f4229cb5acdf2d397c2b12182d0
   depends:
@@ -4055,7 +4055,7 @@ packages:
   license_family: BSD
   size: 103937
   timestamp: 1613390235465
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py38hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py38hcec6c5f_0.tar.bz2
   sha256: 455dc5a3dba2409362ef2c91841cd68e3a73fb6f96267b291c9b7e1fa24e785a
   md5: 55f079cc255134e545e705a49eb5c18a
   depends:
@@ -4065,7 +4065,7 @@ packages:
   license_family: MIT
   size: 2051390
   timestamp: 1690905143314
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2021.10.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/distributed-2021.10.0-py38hecd8cb5_0.tar.bz2
   sha256: cd69702775d7ba1f9faffbf9afb9c97d159b8751db1845f66484af1549850346
   md5: 45b0bc9fbef7454dd87480f2e6beadc0
   depends:
@@ -4090,7 +4090,7 @@ packages:
   license_family: BSD
   size: 1122011
   timestamp: 1635968255567
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py38hecd8cb5_0.tar.bz2
   sha256: 0f432eeab9a2f0363540efcda4a1048b3d60d5e0b3e2cfb106748759caa28138
   md5: f0461cfd6eac119ca072171039b5f799
   depends:
@@ -4099,7 +4099,7 @@ packages:
   license_family: MIT
   size: 16516
   timestamp: 1649926487728
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/expat-2.5.0-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/expat-2.5.0-hcec6c5f_0.tar.bz2
   sha256: 4ed38bee31511bbea15cd0277637cb0118063db777aad9640c9599777837cc6a
   md5: 57cd2dedd78fd34dcd445e59bb50b901
   depends:
@@ -4108,7 +4108,7 @@ packages:
   license_family: MIT
   size: 153966
   timestamp: 1693497401154
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fiona-1.9.1-py38h07fba90_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fiona-1.9.1-py38h07fba90_0.tar.bz2
   sha256: 80d8e61fca4addfd994557a405e5b3e42e5d0ce485b8cbd768c65bd97b99d760
   md5: a01a0178fb5d2fb151d10c08f2f69852
   depends:
@@ -4129,7 +4129,7 @@ packages:
   license_family: BSD
   size: 1437902
   timestamp: 1678226542539
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/folium-0.14.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/folium-0.14.0-py38hecd8cb5_0.tar.bz2
   sha256: 631c5a1545d2b8ed989bfc18c61c29feda4604b7a260e00264a92a23f4a89653
   md5: f1eb9c433ccb9b3877603fb7028afd4a
   depends:
@@ -4142,7 +4142,7 @@ packages:
   license_family: MIT
   size: 115949
   timestamp: 1675353609091
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fontconfig-2.14.1-hb0a0c50_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fontconfig-2.14.1-hb0a0c50_2.tar.bz2
   sha256: cff12dd33d60375ba68efecddf15821eb8415a28424e76f5646c497b953bd534
   md5: 0cc9c9743f309dd8032fdaa2b1109bb0
   depends:
@@ -4154,7 +4154,7 @@ packages:
   license_family: MIT
   size: 283281
   timestamp: 1679578322712
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -4164,13 +4164,13 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freexl-1.0.6-h9ed2024_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freexl-1.0.6-h9ed2024_0.tar.bz2
   sha256: b2b7b310f0ff104a46ce3f3688ea17d2c9196471fad1011d2850ab0c27cd73cb
   md5: 59e2b2e4b54bbcf812da25edd37b50b0
   license: MPL-1.1
   size: 44336
   timestamp: 1607116125222
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fsspec-2023.9.2-py38hecd8cb5_0.tar.bz2
   sha256: f2a756f00876b7f6669810be125faf7ef9fec40eaa219b8aa273d928c911e58c
   md5: d17e19a59284ede5aeff0e8010fad6e7
   depends:
@@ -4179,7 +4179,7 @@ packages:
   license_family: BSD
   size: 261386
   timestamp: 1695734607249
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/gdal-3.6.2-py38h09faefc_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/gdal-3.6.2-py38h09faefc_1.tar.bz2
   sha256: 7cb60f305eacc8c163e22e937e9c944c27a2de24b22535c9b5f5ed8fe3360a13
   md5: 1e09654e04ac51dcf7f1584233140177
   depends:
@@ -4204,7 +4204,7 @@ packages:
   license_family: MIT
   size: 1978396
   timestamp: 1680121051020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/geopandas-0.12.2-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/geopandas-0.12.2-py38hecd8cb5_0.tar.bz2
   sha256: 6e59129ed7338a770b90ce1f939e79a8da2150d6490be934718f861ce30ba8c8
   md5: 26e0a2f8cc653c02f1b1c828feaefb51
   depends:
@@ -4219,7 +4219,7 @@ packages:
   license_family: BSD
   size: 7463
   timestamp: 1675672207035
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/geopandas-base-0.12.2-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/geopandas-base-0.12.2-py38hecd8cb5_0.tar.bz2
   sha256: 8a400afb3f8edbca9d130f91ee8075fef5e246c9aa060eef0e7ef3f3c18198cf
   md5: fc707c074cf2a2cc1b0b29ec4a65b93c
   depends:
@@ -4233,7 +4233,7 @@ packages:
   license_family: BSD
   size: 1281265
   timestamp: 1675672205197
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/geos-3.8.0-hb1e8313_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/geos-3.8.0-hb1e8313_0.tar.bz2
   sha256: ec1a020f11e34a94622a35fe338a640e688bd2a9959779e441496c575c1ebfd4
   md5: d43b2e34536205c250f9a9a699d39b84
   depends:
@@ -4241,7 +4241,7 @@ packages:
   license: LGPL-2.1
   size: 916394
   timestamp: 1592213531288
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/geotiff-1.7.0-hf6ff7a4_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/geotiff-1.7.0-hf6ff7a4_1.tar.bz2
   sha256: 8ba62452fe808af58a827b742261f04207717de62e791f368850af2b5b6043d7
   md5: eac42496164215cee9ac97a13d55be79
   depends:
@@ -4254,7 +4254,7 @@ packages:
   license_family: MIT
   size: 134338
   timestamp: 1679997088653
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/gettext-0.21.0-he85b6c0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/gettext-0.21.0-he85b6c0_1.tar.bz2
   sha256: 1905463c17dd8c1f1c1a03028f95d5cfae9d166d6dc0bd0a1b17b8e30792de13
   md5: f53f4a7175a223b7f9f50ac188e5c6b7
   depends:
@@ -4267,14 +4267,14 @@ packages:
   license_family: GPL
   size: 3540538
   timestamp: 1679578758653
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
   sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
   md5: e4a732941f74b8062c8bcbfe5c5c2b56
   license: MIT
   license_family: MIT
   size: 80252
   timestamp: 1676983220161
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/glib-2.69.1-hfff2838_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/glib-2.69.1-hfff2838_2.tar.bz2
   sha256: 4ee50c0be59fe9705d29b27b65921a3248dbd9566269d17f1daae96eaddaa41e
   md5: f497b3963d0d57dfa41fca5af8af4ed0
   depends:
@@ -4289,7 +4289,7 @@ packages:
   license_family: LGPL
   size: 3509291
   timestamp: 1669364513587
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf4-4.2.13-h39711bb_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/hdf4-4.2.13-h39711bb_2.tar.bz2
   sha256: 85d7f9697d1243b5d088737a3f5c43610f01250f78e9a9fa9da6cca7830d73cf
   md5: 637b7dadcfe411e14233764fd1d820a3
   depends:
@@ -4300,7 +4300,7 @@ packages:
   license_family: BSD
   size: 895428
   timestamp: 1510863932515
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf5-1.10.6-h10fe05b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/hdf5-1.10.6-h10fe05b_1.tar.bz2
   sha256: 0ec239cffba75bd5443fbafad7d533c3b395cf5f025194dfccc12e963df4e02e
   md5: d556a6e6efe810832e6b78147396ce58
   depends:
@@ -4311,7 +4311,7 @@ packages:
   license_family: BSD
   size: 5076375
   timestamp: 1655307890871
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-58.2-h0a44026_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/icu-58.2-h0a44026_3.tar.bz2
   sha256: c04f4cf3f9c4879c4d95b36cc842a5def9d1224aad73ef456fd069f162e3d603
   md5: 5c5aa862793c874be6ec8d6af7d1f4e4
   depends:
@@ -4319,7 +4319,7 @@ packages:
   license: MIT
   size: 23669475
   timestamp: 1588026009899
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py38hecd8cb5_0.tar.bz2
   sha256: 37193b4249722a002743fbd55aaa9d643884e85b7bb7b82e8fa409001d54d292
   md5: 145bb1e70f8ddefdcc2f9c9aa8183b0e
   depends:
@@ -4328,7 +4328,7 @@ packages:
   license_family: BSD
   size: 112446
   timestamp: 1666125605192
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py38hecd8cb5_0.tar.bz2
   sha256: bae1f77e166a4292856a91c650211749a6366a923f2d2da13e991b9eb05105fe
   md5: 339011881b7709b8c85d21ff1dfed022
   depends:
@@ -4338,7 +4338,7 @@ packages:
   license_family: APACHE
   size: 38818
   timestamp: 1678997187815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py38hecd8cb5_0.tar.bz2
   sha256: ab374287c5482933cff8230423177ba5877ac74ed858f8f15963935f9eba207a
   md5: da7d084f202c48e592c952cb79e314b7
   depends:
@@ -4348,7 +4348,7 @@ packages:
   license_family: Apache
   size: 51759
   timestamp: 1698254665985
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
   sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
   md5: 78baea934985ccd9514a366cc7e80ed4
   depends:
@@ -4357,7 +4357,7 @@ packages:
   license_family: Proprietary
   size: 727499
   timestamp: 1681801225190
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py38h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py38h20db666_0.tar.bz2
   sha256: d266aed27d5c4ac41eb43752788348ffc10d62391f3d26fc8acdfb62d2749aab
   md5: 463889395aa0fc1230b57391bba1e358
   depends:
@@ -4379,7 +4379,7 @@ packages:
   license_family: BSD
   size: 218394
   timestamp: 1691122129329
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.12.2-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.12.2-py38hecd8cb5_0.tar.bz2
   sha256: 9d76af4bc19372cc220b285d63598c90ba6e27476f0d9088eb818e3ce69d7ed1
   md5: 6a291fe69dc614fc91a22ec7f86bc85d
   depends:
@@ -4400,7 +4400,7 @@ packages:
   license_family: BSD
   size: 1235334
   timestamp: 1691532318531
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py38hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py38hecd8cb5_1.tar.bz2
   sha256: 7ec96f7caade4290a41855f36c601758482dba830cf878f603891cb34768202b
   md5: 524e7bc56614899dc780c19240e3f99d
   depends:
@@ -4410,7 +4410,7 @@ packages:
   license_family: MIT
   size: 1042868
   timestamp: 1644315328525
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/joblib-1.2.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/joblib-1.2.0-py38hecd8cb5_0.tar.bz2
   sha256: e03682853096c39af2687ca7d3f0e65b67273480a97c5f8e6f82bcd1340e5e84
   md5: 85c8db7ecf42aba70436eb9cbcfc7c0d
   depends:
@@ -4419,21 +4419,21 @@ packages:
   license_family: BSD
   size: 407742
   timestamp: 1685113334350
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
   sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
   md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
   license: IJG
   license_family: Other
   size: 278924
   timestamp: 1677849185191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/json-c-0.16-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/json-c-0.16-hca72f7f_0.tar.bz2
   sha256: 2258f53c5f89d5ef8151aa775041c91de132ae5b467c0fb89c283c0fedc46836
   md5: fc6b7ad3145ba86e7459b14fba98cd27
   license: MIT
   license_family: MIT
   size: 73431
   timestamp: 1659123708344
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py38hecd8cb5_0.tar.bz2
   sha256: 9febfb16ec7fd88b1b43e158e157feeec58614c75592fc706b3fabfef4b92dd4
   md5: b529959244a8951b78b036b4ec7f5a2d
   depends:
@@ -4446,7 +4446,7 @@ packages:
   license_family: MIT
   size: 132739
   timestamp: 1676559100279
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py38hecd8cb5_0.tar.bz2
   sha256: cc595a959c77802c0ae5aca9cc9e72071b951cac97463210744bae530c2b5b8c
   md5: 72993460036cd4ee6f80f4c63a1c7fd0
   depends:
@@ -4462,7 +4462,7 @@ packages:
   license_family: BSD
   size: 198052
   timestamp: 1676329716909
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py38hecd8cb5_0.tar.bz2
   sha256: d470142cb8f3ed5ad745b8d96eb86fd919948efb9b8c0759f3d2b2f48ab09673
   md5: d26049a63cd89fc91a269ce5d76e10e6
   depends:
@@ -4473,7 +4473,7 @@ packages:
   license_family: BSD
   size: 92746
   timestamp: 1679906726623
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py38hecd8cb5_0.tar.bz2
   sha256: a7d191a475ccecf28faa577807ca9c992987e1ae18dbae86f3d78808dea7aae2
   md5: 31ce21159341139a2bd7c2c83368f847
   depends:
@@ -4497,7 +4497,7 @@ packages:
   license_family: BSD
   size: 403237
   timestamp: 1671707790827
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kealib-1.5.0-h72c422f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kealib-1.5.0-h72c422f_0.tar.bz2
   sha256: f19ff41b92bab184778a6ff279dec6cbac94cf1de351d7e325380f64dec45121
   md5: f26b397f2c259e3ec664dabcc0584d23
   depends:
@@ -4507,7 +4507,7 @@ packages:
   license_family: MIT
   size: 169846
   timestamp: 1674215919519
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py38hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py38hcec6c5f_0.tar.bz2
   sha256: 4e9da4496ac7dcd7963447eab5c0de25f16dbba9a51422f68c95081a3657d384
   md5: 83af611855a3505d81184247683e8b80
   depends:
@@ -4517,7 +4517,7 @@ packages:
   license_family: BSD
   size: 64974
   timestamp: 1672387224650
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
   sha256: 8093a64350665d16ca2ad0acfcbba5c84b479c316a40db6b9d5f9b84b58f3b12
   md5: cd98cc17f8297a31b1dd62f061ea4f83
   depends:
@@ -4528,7 +4528,7 @@ packages:
   license_family: MIT
   size: 1289465
   timestamp: 1686931250022
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -4538,7 +4538,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -4547,7 +4547,7 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.73.0-h3fa6bed_12.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libboost-1.73.0-h3fa6bed_12.tar.bz2
   sha256: e2e5b6b7670d19a008d86f5aec94e9f9a6989281116e3c0d70aa8d787d8c572e
   md5: fa0eaa50e297abfae28fb3ea710890fd
   depends:
@@ -4562,13 +4562,13 @@ packages:
   license_family: OTHER
   size: 20158666
   timestamp: 1655879850274
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
   sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
   md5: 7dba7aa5b971febb55281659843586ba
   license: MIT
   size: 65470
   timestamp: 1659616172703
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
   sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
   md5: f78a158983f0bbaba56f34b976bc6dae
   depends:
@@ -4576,7 +4576,7 @@ packages:
   license: MIT
   size: 34189
   timestamp: 1659616189313
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
   sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
   md5: 36a1d885725d3ab4d1fadc5a29f978d2
   depends:
@@ -4584,7 +4584,7 @@ packages:
   license: MIT
   size: 327737
   timestamp: 1659616202869
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
   sha256: 83cf762f0d09c97dfb4a1c1cd9e635de2e54c384b057afbf3c0e2e8db07d862f
   md5: ae3a458da93940fea1fa83af80d91fd4
   depends:
@@ -4599,21 +4599,21 @@ packages:
   license_family: MIT
   size: 358556
   timestamp: 1693515516157
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20221030-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libedit-3.1.20221030-h6c40b1e_0.tar.bz2
   sha256: 67e38ccc55c2d996a8a0949080949c9803ddff84a96c4e34bc4c48fa95e5f35b
   md5: b549aa024097c9f2790ba6eb89bc53fd
   depends:
@@ -4622,21 +4622,21 @@ packages:
   license_family: BSD
   size: 168786
   timestamp: 1670840154554
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
   sha256: 4786264321edbff780633a5b752995eb3193ca4bce11b0fda179577f6cf1102c
   md5: 849fdd014c201a9d2c2aa7c7db38a778
   license: BSD-2-Clause
   license_family: BSD
   size: 103993
   timestamp: 1632891571494
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
   sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
   md5: 817848d0e2b2808acdc9b3fbbf581726
   license: MIT
   license_family: MIT
   size: 133887
   timestamp: 1683716590737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgdal-3.6.2-hd170585_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgdal-3.6.2-hd170585_1.tar.bz2
   sha256: 5fa6664d5bcb7dcdd40c9201c9bc470306e20eed90824adba7d7dce7067c94a8
   md5: 19ba4795c8359ec302ec02193b241ac1
   depends:
@@ -4684,7 +4684,7 @@ packages:
   license_family: MIT
   size: 10247112
   timestamp: 1680120970746
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
   sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
   md5: e458587c87e3f2d20192f4e0738f2c63
   depends:
@@ -4693,7 +4693,7 @@ packages:
   license_family: GPL
   size: 149419
   timestamp: 1665498987619
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
   sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
   md5: 1058b661ec829b2ee3716ee2a5520641
   depends:
@@ -4704,14 +4704,14 @@ packages:
   license_family: GPL
   size: 1917987
   timestamp: 1665498925405
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
   sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
   md5: c90372428e1e4eed4fdcd790979d06b4
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1409377
   timestamp: 1650983531933
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libkml-1.3.0-h85bf17e_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libkml-1.3.0-h85bf17e_7.tar.bz2
   sha256: 45936f0f5c7e616f02e028fa75b2177af1ad16587190d350b0c54489dba96cb2
   md5: 66ef0c8cf08472f25fba622bdc99921c
   depends:
@@ -4723,7 +4723,7 @@ packages:
   license_family: BSD
   size: 435832
   timestamp: 1693261846695
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm11-11.0.0-h46f1229_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libllvm11-11.0.0-h46f1229_1.tar.bz2
   sha256: 239cc0e95b4aa48c7f09ac402f1a44b7b83131893b26201a482a531ea27b14b9
   md5: 8aa9058bc551e8466cb15e8b6e539f6b
   depends:
@@ -4733,7 +4733,7 @@ packages:
   license_family: Apache
   size: 23039565
   timestamp: 1646077131507
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnetcdf-4.8.1-ha5d86b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libnetcdf-4.8.1-ha5d86b0_2.tar.bz2
   sha256: 987b646c7037ee6a1b33de92a37adc9eebe878f95706f82f128a2eaba71d245c
   md5: 288e0d83731d69449f6f53080254cb97
   depends:
@@ -4748,7 +4748,7 @@ packages:
   license_family: BSD
   size: 1529760
   timestamp: 1674628246735
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
   sha256: 331bc731419328a873e1a48d4257c58baa33d73b4b91ff7a3553b1c122120fb1
   md5: 43fba990695db8556ddd0ade21d59ecc
   depends:
@@ -4763,7 +4763,7 @@ packages:
   license_family: MIT
   size: 782018
   timestamp: 1686931556261
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -4772,7 +4772,7 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpq-12.15-hdb2fb19_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpq-12.15-hdb2fb19_1.tar.bz2
   sha256: e42c379349c26d271dcce50abf584296f068d09bf66d1bc4453ff93b704394d7
   md5: ccecdea3f8a09704e3f80e2dc4fd3385
   depends:
@@ -4780,13 +4780,13 @@ packages:
   - openssl >=1.1.1u,<1.1.2a
   size: 2908306
   timestamp: 1687380869057
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libspatialindex-1.9.3-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libspatialindex-1.9.3-h23ab428_0.tar.bz2
   sha256: aa1bca7ee910973ee9bb5b20d0f8c441aebf409983118a12e835edb65297ead5
   md5: 10a339fb0866adb3eda36b776263dc99
   depends:
@@ -4794,7 +4794,7 @@ packages:
   license: MIT
   size: 415040
   timestamp: 1616086763917
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libspatialite-4.3.0a-hd1e8275_23.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libspatialite-4.3.0a-hd1e8275_23.tar.bz2
   sha256: 3572fade2e68c5e8cb5f0a63e2f452e20b60ba1a1d04de13d8ff192dfca72311
   md5: 80f6d6f4086930bb36143ffc7a2538fe
   depends:
@@ -4811,7 +4811,7 @@ packages:
   license_family: LGPL
   size: 3210465
   timestamp: 1680110280321
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
   sha256: 8b1adbb78b6283c3d8df932d5aa7e8e249351aa1e206ba2949ee86052912e83f
   md5: 2e035c81c044bff1224224ac24161dfd
   depends:
@@ -4820,7 +4820,7 @@ packages:
   license_family: BSD
   size: 338461
   timestamp: 1686931232629
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -4837,7 +4837,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
   sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
   md5: c0b99f8e1c7475f23b1c7b4250b06e1c
   depends:
@@ -4851,7 +4851,7 @@ packages:
   license_family: BSD
   size: 88021
   timestamp: 1694778290062
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
   sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
   md5: 46a65d1fc24013217e06aaf6d65ffcad
   constrains:
@@ -4860,7 +4860,7 @@ packages:
   license_family: BSD
   size: 425478
   timestamp: 1694776947990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h930c0e2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h930c0e2_0.tar.bz2
   sha256: 9e3ea223370c83ea02a401f6842f9720473ffde3c89c1f85ad263a125c71a921
   md5: 7a163268ee1284dd0c786c1d5f5e9acd
   depends:
@@ -4872,7 +4872,7 @@ packages:
   license_family: MIT
   size: 670156
   timestamp: 1692647722456
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libzip-1.8.0-h272c8d6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libzip-1.8.0-h272c8d6_0.tar.bz2
   sha256: c575e9b13e704c531dab91ce87676d5a336c982273e5a361e42073b9e5817738
   md5: 5d543db811d31c7e5703726639d034d3
   depends:
@@ -4885,7 +4885,7 @@ packages:
   license_family: BSD
   size: 123384
   timestamp: 1652978539298
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
   sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
   md5: 5c740b4a18a558de0ccfe601703c423c
   constrains:
@@ -4894,7 +4894,7 @@ packages:
   license_family: Apache
   size: 338738
   timestamp: 1662635677689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.37.0-py38hc9110bb_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.37.0-py38hc9110bb_2.tar.bz2
   sha256: c0f35750a5291e487d6da02a7ce00f46311d3fa6ab954cbf91988b33769f4369
   md5: 5d9a380ca1172c43995b77fb7c1fd9f7
   depends:
@@ -4904,7 +4904,7 @@ packages:
   license: BSD-2-Clause
   size: 322446
   timestamp: 1646169198728
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py38hecd8cb5_0.tar.bz2
   sha256: 84ce38615938b0276a9f31ae7c26acbf7fb5fefcf3e26a1c027880e1c6453f92
   md5: a37ae112579913dab5c86a811d15193f
   depends:
@@ -4913,7 +4913,7 @@ packages:
   license_family: BSD
   size: 11870
   timestamp: 1652903183129
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
   sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
   md5: d5f58d056b4bfc67aec30c77035ba889
   depends:
@@ -4922,7 +4922,7 @@ packages:
   license_family: BSD
   size: 182491
   timestamp: 1670944720979
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mapclassify-2.5.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mapclassify-2.5.0-py38hecd8cb5_0.tar.bz2
   sha256: 790b0c9504d6179fbe46da43387e135c243c2b1b9bc003d6bf082fae22d176e0
   md5: 6b112d175d4450bd5f59c8474b210d91
   depends:
@@ -4936,7 +4936,7 @@ packages:
   license_family: BSD
   size: 67657
   timestamp: 1675157906046
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py38hecd8cb5_0.tar.bz2
   sha256: 037ef517fca2095c0cb00251dd62db209d3be9305771bd235c8fbd5eed3d35a4
   md5: d16c75e346d76898b659d4445b0b63e0
   depends:
@@ -4946,7 +4946,7 @@ packages:
   license_family: BSD
   size: 123565
   timestamp: 1671541981715
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.0.1-py38h9ed2024_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.0.1-py38h9ed2024_0.tar.bz2
   sha256: bb4aef869f67a6d58b86eba6cc2066362db305234abb7b384651bcb335dddabe
   md5: f6578b430efc56396dfd259c80d4974c
   depends:
@@ -4955,7 +4955,7 @@ packages:
   license_family: BSD
   size: 21418
   timestamp: 1621528247007
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.7.1-py38hda11e5a_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.7.1-py38hda11e5a_1.tar.bz2
   sha256: 7e479ed484b7b09b09386db872b838d7b643d0e38497c2883494a6f90a290b60
   md5: 461effe77be0d00a91d515bb2f46ecfd
   depends:
@@ -4979,7 +4979,7 @@ packages:
   license_family: PSF
   size: 7983835
   timestamp: 1679593834213
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py38hecd8cb5_0.tar.bz2
   sha256: 88df2ac9ce5c9f4e68e9bae5fe272f2e0ac6fda2aff312ad6af3a66149517c2c
   md5: c2314f5a0fff2fcb7a4d320ad59186cd
   depends:
@@ -4989,7 +4989,7 @@ packages:
   license_family: BSD
   size: 17337
   timestamp: 1662014707291
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py38h1de35cc_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py38h1de35cc_1001.tar.bz2
   sha256: 3eaeb0f57893acb1cb43d199c7cc59e1b53e7f64c6547174beaf20552b0acfd4
   md5: 702227bd4bbf517ed707701ee2142cb5
   depends:
@@ -4998,7 +4998,7 @@ packages:
   license_family: BSD
   size: 54586
   timestamp: 1594373290398
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
   sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
   md5: 25051fe272624544652dc6d814c2943a
   depends:
@@ -5011,7 +5011,7 @@ packages:
   license_family: Proprietary
   size: 224420228
   timestamp: 1691503125614
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py38h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py38h6c40b1e_1.tar.bz2
   sha256: 38905fb9453303e09abb46bb751bec48210c17a910dbd88293089b2297ffc02c
   md5: aabd6d138e77ca6b9bdb36b3f7f4ee89
   depends:
@@ -5021,7 +5021,7 @@ packages:
   license_family: BSD
   size: 48594
   timestamp: 1682969108154
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py38h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py38h6c40b1e_0.tar.bz2
   sha256: d2b5f01e04120955578805cbbc87797415fb606ba693ca8c958a30264d01a315
   md5: 21358f24bbe5ca2e59c62eeee702234d
   depends:
@@ -5034,7 +5034,7 @@ packages:
   license_family: BSD
   size: 210895
   timestamp: 1695058515685
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py38ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py38ha357a0b_0.tar.bz2
   sha256: e7be2820541896a80f39c83993b4e9ae7945ae5b1e6a761a8c6b145b2a353e12
   md5: 7cf5c49ea5302cf98b49cdfc36ab2aa8
   depends:
@@ -5048,7 +5048,7 @@ packages:
   license_family: BSD
   size: 296359
   timestamp: 1695059904922
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py38haf03e11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/msgpack-python-1.0.3-py38haf03e11_0.tar.bz2
   sha256: 1ee2650fe9020fdc057d5393c9fc85ab235c563e29f442d2dd7b56571af9c08d
   md5: 9136c45236ebf72976926d941f1f95fc
   depends:
@@ -5058,7 +5058,7 @@ packages:
   license_family: Apache
   size: 83201
   timestamp: 1652362886402
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py38_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py38_0.tar.bz2
   sha256: b82b619359eb11120d4c500d16b8fdaf1b83f2a77854cf2a48dc01f901ca7ac4
   md5: 5494980acd3e180125cd5c8c070e0e9d
   depends:
@@ -5068,7 +5068,7 @@ packages:
   license_family: BSD
   size: 22679
   timestamp: 1573471345595
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py38hecd8cb5_0.tar.bz2
   sha256: a9d5b4aa75b683cc36604780df7878e611db39e97a453182a2252fdc0514f04f
   md5: 36f22fcadaef201377a2375e9ef72624
   depends:
@@ -5094,7 +5094,7 @@ packages:
   license_family: BSD
   size: 8227633
   timestamp: 1681756469033
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py38hecd8cb5_0.tar.bz2
   sha256: ae0ee7d4e8555e1648255386b0e17ac521e06751d6d35a4a170fcf733b455737
   md5: 3280f19d5a1d0572dfcfb80fc6fe591a
   depends:
@@ -5107,7 +5107,7 @@ packages:
   license_family: BSD
   size: 98915
   timestamp: 1650308416274
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.4.4-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.4.4-py38hecd8cb5_0.tar.bz2
   sha256: b54ec7a429f2d6f17fd1abc853da1f231124c66b002a7b0ddd3aa6055c206d52
   md5: 5199f2adda1cfad649e5a99f468124c4
   depends:
@@ -5132,7 +5132,7 @@ packages:
   license_family: BSD
   size: 569496
   timestamp: 1649752091230
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py38hecd8cb5_0.tar.bz2
   sha256: c61d17856e2c0d42328b19d696cf8efb17f5b94b82ce4274297ae6da6b43d1aa
   md5: 559edbcca0fdf0886d4193fefeafa0fd
   depends:
@@ -5145,14 +5145,14 @@ packages:
   license_family: BSD
   size: 148374
   timestamp: 1694616871327
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py38hecd8cb5_0.tar.bz2
   sha256: a86f6ff3c35b00091de82733047e17233762b06c552be2ce02b7d6bc9e795e63
   md5: c82ad06bb34b7b27d83a6dee19967512
   depends:
@@ -5161,7 +5161,7 @@ packages:
   license_family: BSD
   size: 13997
   timestamp: 1672387206711
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/netcdf4-1.6.2-py38hd243f81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/netcdf4-1.6.2-py38hd243f81_0.tar.bz2
   sha256: 4489a03b122e004d8f01b7097b9a6cfe77d0dca431216e47fe0ba60ad92c350c
   md5: 1333d7cf7a7ddfeb3fac068678fcc2a1
   depends:
@@ -5175,7 +5175,7 @@ packages:
   license_family: MIT
   size: 470186
   timestamp: 1673455590760
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/networkx-3.1-py38hecd8cb5_0.tar.bz2
   sha256: 7d8c6bc1c5c0a2775fd583f3707200bc8263846221bd520ee630a1c243d20d1f
   md5: ee23b3a4d66ba22e2097726b8585ce3f
   depends:
@@ -5184,7 +5184,7 @@ packages:
   license_family: BSD
   size: 2967628
   timestamp: 1690562092895
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py38hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py38hecd8cb5_1.tar.bz2
   sha256: 8613463db0276c07fc3e6987dfb586808e2eaeae98593ae20b830d653e77f937
   md5: bad2beb2612fd46526324078f2665054
   depends:
@@ -5209,7 +5209,7 @@ packages:
   license_family: BSD
   size: 573777
   timestamp: 1690984889863
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py38hecd8cb5_0.tar.bz2
   sha256: cfa0ad758159d6d2f473ed1462e5c05567c1852d301268837085d4c8f84d4844
   md5: 1e7a8462fbd34616dd22b70650dd98a1
   depends:
@@ -5219,7 +5219,7 @@ packages:
   license_family: BSD
   size: 22859
   timestamp: 1668160699446
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nspr-4.35-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nspr-4.35-hcec6c5f_0.tar.bz2
   sha256: f006a4418ca8a5788d67fa836a89a236be9925b9dd7744a45cdec18d053a221d
   md5: 4d90323cc76987c69a1c1d3996af71c0
   depends:
@@ -5228,7 +5228,7 @@ packages:
   license_family: OTHER
   size: 257208
   timestamp: 1685541796770
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nss-3.89.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nss-3.89.1-hcec6c5f_0.tar.bz2
   sha256: 0ee6d4545add1a4649506c1a69cb491a908ca5e47b386f9196485c3b5a9c371b
   md5: 905b6e1c124eeba9dc9f338fd29932ec
   depends:
@@ -5240,7 +5240,7 @@ packages:
   license_family: OTHER
   size: 2130955
   timestamp: 1685543311945
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.54.1-py38hae1ba45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numba-0.54.1-py38hae1ba45_0.tar.bz2
   sha256: 99e23621b7fbd6a0160c4685bfd21132f245611743614be79976a24226f3c26e
   md5: 11330aca427ebf7cad6b5f35ff0d350c
   depends:
@@ -5257,7 +5257,7 @@ packages:
   license_family: BSD
   size: 3828589
   timestamp: 1635178402950
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.4-py38h47b59a4_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.4-py38h47b59a4_1.tar.bz2
   sha256: 1e384cd8e57ee5953d72e3725265b4c3414216e2d69198fa57a504d6d8577a20
   md5: b19be6f476ed0f602317ed31319b5d1c
   depends:
@@ -5271,7 +5271,7 @@ packages:
   license_family: MIT
   size: 135465
   timestamp: 1683227249056
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.20.3-py38h57dabd6_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.20.3-py38h57dabd6_1.tar.bz2
   sha256: bcc903c47db3499b7a2fa6319d7493ad5bba3ab6904d9931b5bccb2bb02776f3
   md5: 12094ed52582148fa77e8e3ff09fbd53
   depends:
@@ -5285,7 +5285,7 @@ packages:
   license: BSD 3-Clause
   size: 9717
   timestamp: 1682971749428
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.20.3-py38h34da072_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.20.3-py38h34da072_1.tar.bz2
   sha256: 1382e802dd5f43711a6e7625828d7683f188f0583c9f490d8726e8f5101044a5
   md5: c43950a67d03dcc08c150cf2c571f3cd
   depends:
@@ -5298,7 +5298,7 @@ packages:
   license: BSD 3-Clause
   size: 5978617
   timestamp: 1682971733309
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
   sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
   md5: 93f5d7b66976154adeda219bea02ba45
   depends:
@@ -5308,7 +5308,7 @@ packages:
   license: BSD 2-Clause
   size: 484257
   timestamp: 1630093862501
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
   sha256: f95f5173ab2a4529b56ff90deec905dd53877250acedd3887fb289b721396009
   md5: 2ab1a555331747f19e4aa7a335e33a85
   depends:
@@ -5317,7 +5317,7 @@ packages:
   license_family: Apache
   size: 3665304
   timestamp: 1694465313538
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py38hecd8cb5_0.tar.bz2
   sha256: 2c3de88c1ca11108d11a0dc02b7d545ea527542ffa1292a5aa1b84178c5ed507
   md5: becffc185d46d2fffee1e7d4e6e648bf
   depends:
@@ -5326,7 +5326,7 @@ packages:
   license_family: Apache
   size: 73666
   timestamp: 1693575349472
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-1.3.5-py38h743cdd8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-1.3.5-py38h743cdd8_0.tar.bz2
   sha256: 2b39342c15f995786dfc73a6189f2f62923f6d44e1551e6eaf5e0d6f5db0846e
   md5: f46bee1052d61f64e4c2f5e56033bfb4
   depends:
@@ -5341,7 +5341,7 @@ packages:
   license_family: BSD
   size: 12173268
   timestamp: 1641461704389
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/partd-1.4.0-py38hecd8cb5_0.tar.bz2
   sha256: a5a184f2e833c0468a405995dd01cff14816c0087cc7153c9efe549d8f82e6b4
   md5: a9df134cf7ec3746c15d364e7165bf11
   depends:
@@ -5355,7 +5355,7 @@ packages:
   license_family: BSD
   size: 35933
   timestamp: 1693937933289
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pcre-8.45-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pcre-8.45-h23ab428_0.tar.bz2
   sha256: 1600f8ae7c4e8177cba7f78123312c784afe662ebd7023958777cb77694c333b
   md5: 843db1a9eb10fcc9604c90b2e63272ee
   depends:
@@ -5364,7 +5364,7 @@ packages:
   license_family: BSD
   size: 226022
   timestamp: 1624478357519
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pcre2-10.37-he7042d7_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pcre2-10.37-he7042d7_1.tar.bz2
   sha256: 8e1e9118a99bf188da2583107b1964540088c90fa7c9598c396bfa39e25c3d3f
   md5: 9eae60b5dcb24bb8d36304e32cd94a04
   depends:
@@ -5374,7 +5374,7 @@ packages:
   license_family: BSD
   size: 1148469
   timestamp: 1641403899928
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py38h7d39338_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py38h7d39338_0.tar.bz2
   sha256: 35832b70a7f6f94f4aed70b341434cc5bf86688f7ef25a18df72019f8ec69415
   md5: 4ae44aafef83e1ac779f9baae27ce6a9
   depends:
@@ -5393,7 +5393,7 @@ packages:
   license_family: Other
   size: 718961
   timestamp: 1696580345211
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py38hecd8cb5_0.tar.bz2
   sha256: 04cc06ae2efdab84201a3318eeb275dd40a786925b600bf2eee08ab8ee30d1b0
   md5: c9fffe0ee653ea0a7d23dab4790d4d62
   depends:
@@ -5404,13 +5404,13 @@ packages:
   license_family: MIT
   size: 2677546
   timestamp: 1697548802897
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pixman-0.40.0-h9ed2024_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pixman-0.40.0-h9ed2024_1.tar.bz2
   sha256: 39981af6952de4e207cf6e5e769cb5b9c50f30cfd71a1fd97d6d3eef5feb5a6a
   md5: ecb58f854cae469740631c23643c9c95
   license: MIT
   size: 617807
   timestamp: 1632711594755
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pkgutil-resolve-name-1.3.10-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pkgutil-resolve-name-1.3.10-py38hecd8cb5_0.tar.bz2
   sha256: 9ba22e141b1f179f5ab88725ef16d4d5371de83196ce7882ae0b8bff008ccd9b
   md5: b0734f0be7a3dfd9265c2359dcc75e8a
   depends:
@@ -5419,7 +5419,7 @@ packages:
   license_family: PSF
   size: 10749
   timestamp: 1661463438375
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py38hecd8cb5_0.tar.bz2
   sha256: 59543706932970f7922342cc83ce3b7cca7df58ef4c0fef602e13ace586f9ae6
   md5: ca41bf67637034096f2414eaa100b518
   depends:
@@ -5428,7 +5428,7 @@ packages:
   license_family: MIT
   size: 33062
   timestamp: 1692205767198
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pooch-1.7.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pooch-1.7.0-py38hecd8cb5_0.tar.bz2
   sha256: 322e198616c7e83a60010d0f997cfad3f8ea07fea3adf27e049c364349324b8c
   md5: 1fccc3ef32139e3c02bef538caa5a4f2
   depends:
@@ -5444,7 +5444,7 @@ packages:
   license_family: BSD
   size: 82466
   timestamp: 1695850164306
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/poppler-22.12.0-ha8a1649_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/poppler-22.12.0-ha8a1649_3.tar.bz2
   sha256: 36845a06f9abfb4ee06e24d1f9e57c2f8cded0c323491221862d45f929df6a34
   md5: 8cb3c1e1fa4d3ed2f1589fdd2f686108
   depends:
@@ -5470,14 +5470,14 @@ packages:
   license_family: GPL
   size: 1833586
   timestamp: 1696000908395
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/poppler-data-0.4.11-hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/poppler-data-0.4.11-hecd8cb5_1.tar.bz2
   sha256: 31fbd1899e753b454dc825d85e2cd9a0506107e772f5d5d307d4f234586c0059
   md5: 54f685f65e667e076c4a7cb36f23f26e
   license: GPL-2.0-or-later and GPL-3.0-or-later and BSD-3-Clause
   license_family: GPL
   size: 3839936
   timestamp: 1673863552033
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/postgresql-12.15-h8aab74b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/postgresql-12.15-h8aab74b_1.tar.bz2
   sha256: 2e583070368fe478ccf62ff06b9dc5030c3924c9a7b9d653224ff5a3181e49f3
   md5: 60262eb903a3a8f1579fdce8b82cbe4c
   depends:
@@ -5488,7 +5488,7 @@ packages:
   - zlib >=1.2.13,<1.3.0a0
   size: 4284850
   timestamp: 1687380891439
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/proj-6.2.1-hfd5b9e3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/proj-6.2.1-hfd5b9e3_0.tar.bz2
   sha256: 411c065ddd7752b8ef73bf4b747a460ab1f106fdde3cb38aa1d32bcb69f42de0
   md5: 96a891da3640cae81b84ed0dc5bc35a2
   depends:
@@ -5499,7 +5499,7 @@ packages:
   license: MIT
   size: 10571782
   timestamp: 1573144315768
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py38hecd8cb5_0.tar.bz2
   sha256: cb719cdb0e7c35e0edabdf544042a3f47bc235d8f31f27cbed4f0f2d6c42e8fe
   md5: a76c1a1d816608f02aa155ed03d95821
   depends:
@@ -5508,7 +5508,7 @@ packages:
   license_family: Apache
   size: 91112
   timestamp: 1659455138351
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py38hecd8cb5_0.tar.bz2
   sha256: 53ab33079b69e9fd86b6adb34d389dcf0fd5e80c0cfed1d254ecf543c6b01e9c
   md5: 1dfdadc899943e5753e9a68769381bc2
   depends:
@@ -5520,7 +5520,7 @@ packages:
   license_family: BSD
   size: 581142
   timestamp: 1672387439093
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py38hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py38hca72f7f_0.tar.bz2
   sha256: 3e0fc9381b2c7a97dde3841b455a03648257ca105d3c99ee673e45dc2a3f233b
   md5: d3034fa818207ec94aa5876e3fd778ff
   depends:
@@ -5529,7 +5529,7 @@ packages:
   license_family: BSD
   size: 365816
   timestamp: 1656431564060
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py38hecd8cb5_0.tar.bz2
   sha256: 35c76d8e4ecfe2f9ddb8ca341e7c940b00dd7b2c628b4364f2cec55519ac5c6e
   md5: 53d45ee242138195f85f5fbea3de05c0
   depends:
@@ -5541,7 +5541,7 @@ packages:
   license_family: BSD
   size: 30803
   timestamp: 1675441540278
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py38hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py38hecd8cb5_1.tar.bz2
   sha256: ee5a34ab3a65b01adc661e9c67b1f9af2e5fb737ef477607f16b85ad30d1fb7f
   md5: a3220cef0db91e71e3de88c151de039b
   depends:
@@ -5550,7 +5550,7 @@ packages:
   license_family: BSD
   size: 1888474
   timestamp: 1684280131448
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py38hecd8cb5_0.tar.bz2
   sha256: f30efa3ad42fc694e69701c74c4109ccbf4ccf5bf23cf910589fed298257e3ea
   md5: b2190d1795a4ed71d6ba149d7b36aafe
   depends:
@@ -5560,7 +5560,7 @@ packages:
   license_family: Apache
   size: 95648
   timestamp: 1690223540439
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py38hecd8cb5_0.tar.bz2
   sha256: fa80f34c66064dad6d5c74c6a4a01f7ef842702cbbfeb73988ef3c9196d90a67
   md5: e14a6c52601b5efcae0156ff27b210a7
   depends:
@@ -5569,7 +5569,7 @@ packages:
   license_family: MIT
   size: 157601
   timestamp: 1661452654987
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyproj-2.6.1.post1-py38hdfdfadc_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyproj-2.6.1.post1-py38hdfdfadc_1.tar.bz2
   sha256: d921180e45ce90d690d54f52cf95373bea7da1e242d9cbcc0be7c4ea3f849b6e
   md5: 563afb1ed79040f10b13d9fb13de4db4
   depends:
@@ -5578,7 +5578,7 @@ packages:
   license: MIT
   size: 412999
   timestamp: 1614278007514
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py38hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py38hca72f7f_0.tar.bz2
   sha256: c4a075cf376eba5a9968473cdd79a32e2c036ce5b85477f58d83e57325e36169
   md5: a09f64f393f0f0d127456d3d27a73d4e
   depends:
@@ -5587,7 +5587,7 @@ packages:
   license_family: MIT
   size: 95161
   timestamp: 1636111183441
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py38_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py38_1.tar.bz2
   sha256: 3bf4d8aa47a883c367b98db7cc16efef613a0b08fb143bb9f78967c5d2c7416b
   md5: 6837a4c11fb0126b4422d0caaa1b6296
   depends:
@@ -5596,7 +5596,7 @@ packages:
   license_family: BSD
   size: 27255
   timestamp: 1594394684547
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.8.18-h218abb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.8.18-h218abb5_0.tar.bz2
   sha256: 0c1b0c532cfec52c6587073e036cef48d07057eda4727ac1db422193add8b1c3
   md5: 184d7340d5f85eb4d369ae695f3568a9
   depends:
@@ -5614,7 +5614,7 @@ packages:
   license_family: PSF
   size: 15528724
   timestamp: 1694439198827
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py38hecd8cb5_0.tar.bz2
   sha256: 3bdab73baf83e87b9f1b533797fe64a084cefb1be9d1527fa4f295f7a8f498d4
   md5: d67db0edf3d298995791f78ac59badc8
   depends:
@@ -5623,7 +5623,7 @@ packages:
   license_family: BSD
   size: 265379
   timestamp: 1661369089392
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py38hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-lmdb-1.4.1-py38hcec6c5f_0.tar.bz2
   sha256: 803a11fceb8ac73e82ea6eb489503c268c6a59176e0b3ce3c0853b86ff386373
   md5: 0b3a76ba820c7f1ec345ad82765eeffa
   depends:
@@ -5633,7 +5633,7 @@ packages:
   license_family: Other
   size: 140675
   timestamp: 1682522414875
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py38hecd8cb5_0.tar.bz2
   sha256: ec810a818f3bbb57ad53a8b12dce584d0b79b4b622eed16d242e381ddb772903
   md5: d014760a43e1879020e84d56b7d5f90a
   depends:
@@ -5642,7 +5642,7 @@ packages:
   license_family: MIT
   size: 270273
   timestamp: 1695131744910
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py38hecd8cb5_0.tar.bz2
   sha256: 1aa6076b424dd9f1e971c6c0d110fa3899cbff9e086b487aafd7cee5dcff85cd
   md5: 13cad45544b3a41837734ba9c5de6ae4
   depends:
@@ -5652,7 +5652,7 @@ packages:
   license_family: BSD
   size: 41018
   timestamp: 1685030968054
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py38h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py38h6c40b1e_0.tar.bz2
   sha256: 6cd5553c5b22de113263349ca0f11e7911dfeaba567b12800592553d8d560734
   md5: 8bd42962244d9d67486f55fc03a1798a
   depends:
@@ -5662,7 +5662,7 @@ packages:
   license_family: MIT
   size: 169452
   timestamp: 1698096213680
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py38he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py38he9d5cce_0.tar.bz2
   sha256: d5647ee78d185ab247cc6a5014ee668e3a669da9e1d9472290cca8e40c3c0fb0
   md5: dac86e4b28f69e45b46ad58800a0f740
   depends:
@@ -5673,7 +5673,7 @@ packages:
   license_family: BSD
   size: 468700
   timestamp: 1657724456285
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/qhull-2020.2-ha357a0b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/qhull-2020.2-ha357a0b_2.tar.bz2
   sha256: 35d47041555b4277b30abb836fbc815350a644ba3c4bd4f2e2ea73397c554f2f
   md5: 5f3c1d74767029f19e9c2bd8172b557b
   depends:
@@ -5682,7 +5682,7 @@ packages:
   license_family: Other
   size: 2019896
   timestamp: 1670915867737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -5691,7 +5691,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py38hecd8cb5_0.tar.bz2
   sha256: f6dae09ca297eea86cccd2b35f62804a5c34fd2800f5e869b6b2eeb643a6ee6e
   md5: 31d96e7ff6fe9b9de1b974cd9f52c6f3
   depends:
@@ -5707,7 +5707,7 @@ packages:
   license_family: Apache
   size: 95130
   timestamp: 1690400361635
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rtree-1.0.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rtree-1.0.1-py38hecd8cb5_0.tar.bz2
   sha256: c410c6db1f39395103ac57658f8aa2b6a5336c55a59ffce54cf18c20c971644a
   md5: 6de092af1261c354c13e72a7d8570438
   depends:
@@ -5718,7 +5718,7 @@ packages:
   license_family: MIT
   size: 50343
   timestamp: 1675157931683
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scikit-learn-1.2.2-py38hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/scikit-learn-1.2.2-py38hcec6c5f_0.tar.bz2
   sha256: 92b4ab33c2c754e8304faed43a4e32c96f1ae4ebab5b1dab6d7cd946a7b4920c
   md5: ebfa25ee1fa7859243884645d200e5d7
   depends:
@@ -5733,7 +5733,7 @@ packages:
   license_family: BSD
   size: 8791586
   timestamp: 1680201216606
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.10.1-py38hf241641_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/scipy-1.10.1-py38hf241641_1.tar.bz2
   sha256: 402a621edb67348e29d593fa3abfdc2e2caa0e4cb263a81ea4438b5ee16d06dc
   md5: 98bf265b20f94a8fef4f45d9caa71e9a
   depends:
@@ -5752,7 +5752,7 @@ packages:
   license_family: BSD
   size: 24792365
   timestamp: 1683295750615
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py38hecd8cb5_0.tar.bz2
   sha256: 17946446ccf4b46a8af54dd2bf2a34ca8dfe46691324c95f2bbf6d6b5de4d47e
   md5: 92e548df0d415142e553a332053535a1
   depends:
@@ -5761,7 +5761,7 @@ packages:
   license_family: MIT
   size: 1093502
   timestamp: 1690290995786
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/shapely-2.0.1-py38h797b0b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/shapely-2.0.1-py38h797b0b3_0.tar.bz2
   sha256: df3ff16522a0b189464f39de7b5e3633ebbb446c53b9e19d3e4b31d3bb2f7eb7
   md5: 1573a4924ae8289f70812c604ff29b07
   depends:
@@ -5772,7 +5772,7 @@ packages:
   license_family: BSD
   size: 436965
   timestamp: 1680636513687
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py38hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py38hecd8cb5_1.tar.bz2
   sha256: 017bd06e271ef74d2f3a15acc344c184bdd51b9854c9d79cfa78f25f19aa0408
   md5: eaeda6cdc02faf686088e8c711df089d
   depends:
@@ -5781,7 +5781,7 @@ packages:
   license_family: Apache
   size: 15486
   timestamp: 1614030487981
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py38hecd8cb5_0.tar.bz2
   sha256: 4617e621bcefd0cf9806da51451335cb422b6cff1de8ece9844136a14732e4cb
   md5: 3118681370d80225e19baf3f77171a69
   depends:
@@ -5790,7 +5790,7 @@ packages:
   license_family: MIT
   size: 67418
   timestamp: 1696347616672
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
   sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
   md5: 82e4db6a498480a75d53c55bd35b6478
   depends:
@@ -5802,7 +5802,7 @@ packages:
   license_family: Other
   size: 1801397
   timestamp: 1681394807900
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -5811,7 +5811,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py38hecd8cb5_0.tar.bz2
   sha256: 34533fc748e7cb5f8a860eb3f6601beb4f126998d1dd5fc5afd6d89f01969efe
   md5: cbda7f79b6003675241b015d49c85280
   depends:
@@ -5822,7 +5822,7 @@ packages:
   license_family: BSD
   size: 30949
   timestamp: 1671751869746
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/testpath-0.6.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/testpath-0.6.0-py38hecd8cb5_0.tar.bz2
   sha256: 7395e65b3ee88fbfec53c922125191a5646bcff130caeee8bfc1293754bfa07e
   md5: 3d501162e255b90663ac6e7eb60fb574
   depends:
@@ -5831,7 +5831,7 @@ packages:
   license_family: BSD
   size: 94394
   timestamp: 1655908839591
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tiledb-2.3.3-h74f4c1e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tiledb-2.3.3-h74f4c1e_2.tar.bz2
   sha256: e0353ceb9d9f6342fa277683c201c7eac0d81a294e1e5ff7e3c12c6c0323f3d9
   md5: f2c604676085095fdf60ba1af2b7cf56
   depends:
@@ -5846,7 +5846,7 @@ packages:
   license_family: MIT
   size: 3049983
   timestamp: 1655311430168
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
   sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
   md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
   depends:
@@ -5855,7 +5855,7 @@ packages:
   license_family: BSD
   size: 3536231
   timestamp: 1654088937695
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py38hecd8cb5_0.tar.bz2
   sha256: 92755ab4f8c11bd18c59efd108b72b366dc35b1d9675847b4839f0ec92ea917d
   md5: 9df5b054b202bc995ace5e8779ac643f
   depends:
@@ -5864,7 +5864,7 @@ packages:
   license_family: BSD
   size: 102499
   timestamp: 1667464228738
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py38h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py38h6c40b1e_0.tar.bz2
   sha256: 1adeadb9a4d3d5e74265ea1a8594f272609a20e6c35b70601d715f316cbd7861
   md5: 1bf7d52b412d9a9d6eea7c4bc42d75ff
   depends:
@@ -5873,7 +5873,7 @@ packages:
   license_family: Apache
   size: 678506
   timestamp: 1696937178616
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py38h01d92e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py38h01d92e1_0.tar.bz2
   sha256: 1d59bd9e6e54aa969fe325b8490a85c931f3541d86a15d1df88ffe275759498e
   md5: b87b6d512ac388f27a6aa5ced30a589d
   depends:
@@ -5886,7 +5886,7 @@ packages:
   license_family: MOZILLA
   size: 124900
   timestamp: 1679562063856
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py38hecd8cb5_0.tar.bz2
   sha256: a34dfcc544e6dcc136c8e78febfc22ceffe42843b6108baf95ca77e7344921ed
   md5: 9b33282f8a7cda21a2c8f4ce03acf197
   depends:
@@ -5895,7 +5895,7 @@ packages:
   license_family: BSD
   size: 192430
   timestamp: 1671143921787
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py38hecd8cb5_0.tar.bz2
   sha256: 756b45ece9d4f16600524a72c5659b6ef0bc0a6437f4ddbaff3bb5462539ffa0
   md5: 660bac6c0f1f3ddac617f31c7becbd4b
   depends:
@@ -5905,7 +5905,7 @@ packages:
   license_family: PSF
   size: 9656
   timestamp: 1690297531708
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py38hecd8cb5_0.tar.bz2
   sha256: 35d6099b39b0cb36387915d20c9524b210e2ab4a1d5104c81f2e6a0bfa0a356f
   md5: 0d02b08ce0dd3e09ddd67b8a515d51b7
   depends:
@@ -5914,14 +5914,14 @@ packages:
   license_family: PSF
   size: 58757
   timestamp: 1690297524304
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uriparser-0.9.7-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uriparser-0.9.7-h6c40b1e_0.tar.bz2
   sha256: 035b916c1eab3a6a27f0109d8e39fe37cbf8ebe0af948d88d7a3b96ab20dc999
   md5: e697defd6c59ca6d98ab4bb5f951eb21
   license: BSD-3-Clause
   license_family: BSD
   size: 44105
   timestamp: 1692186954114
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py38hecd8cb5_0.tar.bz2
   sha256: 226d60c3556917fd2c5443770362926724f6809eff074586dd6cda32abd71822
   md5: f1300fd1bd610b23456c52cd9e404b9b
   depends:
@@ -5936,7 +5936,7 @@ packages:
   license_family: MIT
   size: 188584
   timestamp: 1698257703550
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py38_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py38_1.tar.bz2
   sha256: dd878c7ccbe9acd4394ecb151ea22a700d7e17982d07e5cdab16e434ee0e276a
   md5: 816a3f635267b70b6a1b00c00c282a15
   depends:
@@ -5945,7 +5945,7 @@ packages:
   license_family: BSD
   size: 20010
   timestamp: 1573201122722
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py38hecd8cb5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py38hecd8cb5_4.tar.bz2
   sha256: 29f349097c7f4fc02e63acf3e8758ec7f5f8cecc204005ef4aaed944d3e95caf
   md5: 17db7bb8a9f23ae4f01b92f286794a8d
   depends:
@@ -5955,7 +5955,7 @@ packages:
   license_family: BSD
   size: 70774
   timestamp: 1614804275719
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py38hecd8cb5_0.tar.bz2
   sha256: a6e2e84f23ae1e6d7233ee6b356daad04aff65168dd1432413a2d7d87fe5d04f
   md5: a27b7b2a5e07004ea5e61fcdb13a82f5
   depends:
@@ -5964,7 +5964,7 @@ packages:
   license_family: MIT
   size: 102424
   timestamp: 1695742040522
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2022.11.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xarray-2022.11.0-py38hecd8cb5_0.tar.bz2
   sha256: 1b6d252572b3fe72c4716c24056cfe6b0f5d83a37a87b895b99d9e280a1fd0bc
   md5: 51856b1a836e1d7ee6b166d6c5fbadbb
   depends:
@@ -5976,7 +5976,7 @@ packages:
   license_family: Apache
   size: 1733083
   timestamp: 1668776637394
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xerces-c-3.2.4-hd2b157f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xerces-c-3.2.4-hd2b157f_0.tar.bz2
   sha256: c2b8fd888f90d09221594211e0bd51198f21319864b94ca3275e8329112088cc
   md5: 32aa5f3e7324f2a79b504dfe68b77abd
   depends:
@@ -5986,7 +5986,7 @@ packages:
   license_family: Apache
   size: 2851582
   timestamp: 1668712668309
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py38hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py38hecd8cb5_1.tar.bz2
   sha256: 9ff046886013ca543edb417264a93032d5622c1933afee67f42a1fb55adc1499
   md5: 7329105d84755727fa326092177e87ed
   depends:
@@ -5995,20 +5995,20 @@ packages:
   license_family: BSD
   size: 49845
   timestamp: 1675159128645
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
   sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
   md5: e243baa546432c8394a8059a44a5a3e4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 419227
   timestamp: 1683113010463
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
   sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
   md5: fe4ac85ee86d3a94ea3a4ebea3779763
   depends:
@@ -6017,7 +6017,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 321797
   timestamp: 1616055526986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zict-3.0.0-py38hecd8cb5_0.tar.bz2
   sha256: 8b48165e2712438ff12e1602626d500bcf01bc24f50d465fb828e11d08248210
   md5: f75ab2b6ef09cbedfb138841c634f46a
   depends:
@@ -6028,7 +6028,7 @@ packages:
   license_family: BSD
   size: 77592
   timestamp: 1695832909404
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py38hecd8cb5_0.tar.bz2
   sha256: 4be46abffdef57e0cb028ec6d32d85b583ec9dd5a0818e2c0fa0a3c9590182c1
   md5: 9ea7585b85fe7f016e6dae8e6424ca8a
   depends:
@@ -6037,14 +6037,14 @@ packages:
   license_family: MIT
   size: 19053
   timestamp: 1672387288981
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
   sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
   md5: 8e495591e369ac161857a72011c0a296
   license: Zlib
   license_family: Other
   size: 120272
   timestamp: 1666595024203
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
   sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
   md5: f1465fbd810b3746c6de6babfd4fe28a
   depends:
@@ -6056,7 +6056,7 @@ packages:
   license_family: BSD
   size: 1023573
   timestamp: 1681304595869
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py38hca03da5_0.tar.bz2
   sha256: 5d765891b15f4759f4fab35f1a388e0681457776bb6976ba7eb09cca760c11aa
   md5: 980b8c7687f2f36a5811f12156b48b00
   depends:
@@ -6069,7 +6069,7 @@ packages:
   license_family: MIT
   size: 155531
   timestamp: 1644482714703
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py38hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py38hca03da5_1001.tar.bz2
   sha256: 67836d5b3187b8fbd69a50fe643ecc601645aec6947653e7fbdcf3e137eb5c98
   md5: c6f73e643c6beef9c5a26ed2d621ddd2
   depends:
@@ -6078,7 +6078,7 @@ packages:
   license_family: BSD
   size: 10182
   timestamp: 1629146056221
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py38h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py38h1a28f6b_0.tar.bz2
   sha256: 405979005a60e67d5226c4d3ec3e91119a8cda26ca800c9ba503c47f4fe13471
   md5: cc74ce79b82fee9e8c5a6eafbd3183bb
   depends:
@@ -6088,7 +6088,7 @@ packages:
   license_family: MIT
   size: 35405
   timestamp: 1644845782338
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py38hca03da5_0.tar.bz2
   sha256: 9a9dae59d5f87a40caec410f55b2945a7d1218473bca79a336b31143400288f8
   md5: f5da1bd1fd8c75b61386a2a6fc4f576b
   depends:
@@ -6097,7 +6097,7 @@ packages:
   license_family: MIT
   size: 133786
   timestamp: 1695717921528
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py38hca03da5_0.tar.bz2
   sha256: d2bdaae4f918465304ccb1b0453bb60ec6ad60cce1d2962f9112537f6d93a655
   md5: 6916209d81024d66701244d461f78857
   depends:
@@ -6107,12 +6107,12 @@ packages:
   license_family: MIT
   size: 206634
   timestamp: 1681493108006
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
   sha256: d51b7b5841be320209706d8e9caf669c0e0094f3a40e9eea51701a564ca7c2ed
   md5: 61647f79e0ae70e914fee23c40c4caea
   depends:
@@ -6124,7 +6124,7 @@ packages:
   license_family: BSD
   size: 43179
   timestamp: 1675247655207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-2.3.3-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-2.3.3-py38hca03da5_0.tar.bz2
   sha256: a681e391e712a001b7a0eb5ce0d573df59b4c200d61aa7c49537f180a36553d6
   md5: 423c7d46a7c2c96c2dd230d4b5903038
   depends:
@@ -6141,7 +6141,7 @@ packages:
   license_family: BSD
   size: 8622795
   timestamp: 1628862374983
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.73.0-h1a28f6b_12.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/boost-cpp-1.73.0-h1a28f6b_12.tar.bz2
   sha256: 8f878b6cb432784e1a1d395069265a3643d8bb44cb5a1f552d4930895b728725
   md5: f3e6c2c3e302d06f9734ecb2f71c2b3b
   depends:
@@ -6150,7 +6150,7 @@ packages:
   license_family: OTHER
   size: 17659
   timestamp: 1655879787473
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py38heec5a64_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py38heec5a64_0.tar.bz2
   sha256: 54275861becb1f8a49bf272ee3d64ccb0af913ff7ad1346109519374e4781de0
   md5: ca54108331866869bb0a8498a1872a04
   depends:
@@ -6160,7 +6160,7 @@ packages:
   license_family: BSD
   size: 112738
   timestamp: 1657175740371
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/branca-0.6.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/branca-0.6.0-py38hca03da5_0.tar.bz2
   sha256: ac1eaa002f079cd9e2bd266bddf9639248040aa42b66d5ecbbf09505bc81af5a
   md5: 91eac1a9b07588b1399d3a1d1ab6cf11
   depends:
@@ -6170,7 +6170,7 @@ packages:
   license_family: MIT
   size: 43755
   timestamp: 1675157665571
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
   md5: f860193e14afc7ef3f5b990a2ac003d2
   depends:
@@ -6180,7 +6180,7 @@ packages:
   license: MIT
   size: 18936
   timestamp: 1659616204016
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
   sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
   md5: ad53130f3fd1f8d3c2fcbb7496e5585d
   depends:
@@ -6189,7 +6189,7 @@ packages:
   license: MIT
   size: 18715
   timestamp: 1659616188888
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py38hc377ac9_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py38hc377ac9_7.tar.bz2
   sha256: 487f05b8dfe6e421263c79d5076c065016666a5a18934decc1ddf4e6ec27dcce
   md5: 5d9427960704c8cb150813ddbef20349
   depends:
@@ -6198,28 +6198,28 @@ packages:
   license: MIT
   size: 365523
   timestamp: 1659616326026
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
   sha256: 019469288da4767fd021f488b907e2f4f3b34db686fa12055d52d9bb7bb4d872
   md5: 9f63c782a4d20150ae9a664ee87cce16
   license: bzip2-1.0.6
   license_family: BSD
   size: 150682
   timestamp: 1624215191959
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
   sha256: b0be79290b1df1cf1d07a1a9c3f3a92ae262643a6df3dc10dfbac22a82874dd4
   md5: 8fdcf1c08eee91fec7eefc22863c816a
   license: MIT
   license_family: MIT
   size: 106550
   timestamp: 1693902036526
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
   sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
   md5: 31ac2f5596cb7a44adf073c930641c54
   license: MPL-2.0
   license_family: Other
   size: 133817
   timestamp: 1694009762858
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cairo-1.16.0-h302bd0f_5.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cairo-1.16.0-h302bd0f_5.tar.bz2
   sha256: c2f6508a6ede7d131884e906dbf409c781eb3cb04b6ebfa6a29a2310e1a8e0da
   md5: 5febd95efbd8014e202562d7b0391869
   depends:
@@ -6233,7 +6233,7 @@ packages:
   license_family: LGPL
   size: 1403003
   timestamp: 1688495951297
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cartopy-0.21.1-py38hf94de1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cartopy-0.21.1-py38hf94de1b_0.tar.bz2
   sha256: 1da2935f34f56987496eea18111202c5abaf1f055f28bbd37628070ed5585bf4
   md5: 55978f94faf194a15d99d83c23f92fa7
   depends:
@@ -6252,7 +6252,7 @@ packages:
   license_family: LGPL
   size: 1738867
   timestamp: 1674677891009
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py38hca03da5_0.tar.bz2
   sha256: a660be158909caf4e0349c52e609dd1c0da9a71547e82722d35dbc0f86ffa02b
   md5: 70f68e080352f618320d096a932e98ed
   depends:
@@ -6261,7 +6261,7 @@ packages:
   license_family: Other
   size: 160131
   timestamp: 1690232261193
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py38h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py38h80987f9_3.tar.bz2
   sha256: 3eb4810d5ba58993acaeeda46418632d9081a61d90ab263c91cfd5f417ab9d36
   md5: 3d4c675ee824980291ba685d0072c5dc
   depends:
@@ -6272,7 +6272,7 @@ packages:
   license_family: MIT
   size: 225296
   timestamp: 1670423245933
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
   sha256: 3ba74ebffd6bc4bc451864f85048dec9b6ad085eb1904ce3e5450376e15f050e
   md5: 289f238ac78b174f01c8a2b252b17735
   depends:
@@ -6284,7 +6284,7 @@ packages:
   license_family: Other
   size: 1243641
   timestamp: 1655814869383
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cftime-1.6.2-py38hb08c31d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cftime-1.6.2-py38hb08c31d_0.tar.bz2
   sha256: c1800a5e4cf925ed2bc9345ed847d59e9f881d3362709b393805a500dfcfd40c
   md5: ab3531ecf88671eb669e596d4313be59
   depends:
@@ -6294,7 +6294,7 @@ packages:
   license_family: MIT
   size: 227194
   timestamp: 1678830418879
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py38hca03da5_0.tar.bz2
   sha256: aeb9fd657eacfb76ae352a33991bedc46d8f1080c0fee116c517ab6cea5ea8ab
   md5: 1ac72858d61f8028a48f2f855b0e9f43
   depends:
@@ -6303,7 +6303,7 @@ packages:
   license_family: BSD
   size: 152725
   timestamp: 1698129882125
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-2.2.1-py38hca03da5_0.tar.bz2
   sha256: 293280c1652ea7da893611321e0fa287fc4812538b661902dc47019b3b424136
   md5: cffd3a690fc0c02bb1d2e39b26851d1a
   depends:
@@ -6312,7 +6312,7 @@ packages:
   license_family: BSD
   size: 41293
   timestamp: 1683040141160
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py38hca03da5_0.tar.bz2
   sha256: e80c949f34e245cf1dc8349e30b9fa5c7245b2698e374fc0131f8d266d5f0e87
   md5: 8749acd61686f2fcd728f6b4e34fe31d
   depends:
@@ -6322,7 +6322,7 @@ packages:
   license_family: CC
   size: 1978833
   timestamp: 1668084538802
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py38hca03da5_0.tar.bz2
   sha256: 30f1aabfb4226ee1af8445279113059c737c0b35ebee2fe406a855290871339f
   md5: 22d8819694ea22c11b91b104be282549
   depends:
@@ -6332,7 +6332,7 @@ packages:
   license_family: BSD
   size: 13639
   timestamp: 1671231198163
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py38h3c57c4d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py38h3c57c4d_0.tar.bz2
   sha256: a3de72163db6c07ff509d3b2db4eb91fc3331c98e3367a2b94766681d14827a8
   md5: dcb73cc0e1fa2b83e0c7f0567de81e1f
   depends:
@@ -6345,7 +6345,7 @@ packages:
   license_family: BSD
   size: 1400831
   timestamp: 1694212028623
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.0-py38h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cytoolz-0.12.0-py38h1a28f6b_0.tar.bz2
   sha256: dd8d2e47fedd968ec0e2977b11b766f5a5845b687ed36a7a092c66849ca991f6
   md5: 73756e4c9a8c356d400d01ab3b288330
   depends:
@@ -6355,7 +6355,7 @@ packages:
   license_family: BSD
   size: 353644
   timestamp: 1667466090549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py38hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/datashape-0.5.4-py38hca03da5_1.tar.bz2
   sha256: abb41ec3bdd1a8b491056d8409044e7db430140cde7935bcb41826d746cb7194
   md5: 691ae819ca6bafeb6626cd7941f79c6b
   depends:
@@ -6367,7 +6367,7 @@ packages:
   license_family: BSD
   size: 103380
   timestamp: 1629793027649
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py38h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py38h313beb8_0.tar.bz2
   sha256: ad48c11fd3b44e89832e5851ba77d27951f258c039a53e15e9fe2bdc35b408c9
   md5: 3e3601bc2eb8e58c4cadb36ac4ea7689
   depends:
@@ -6377,7 +6377,7 @@ packages:
   license_family: MIT
   size: 2069572
   timestamp: 1690905388086
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2021.10.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/distributed-2021.10.0-py38hca03da5_0.tar.bz2
   sha256: af6ad263faeb788a1c344006af164abffa0b65db8224d8faf6ea632f5f9c9dbc
   md5: 8e23d4f835f8d1b6730d3cb0afe82bcc
   depends:
@@ -6402,7 +6402,7 @@ packages:
   license_family: BSD
   size: 1100354
   timestamp: 1635968569442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py38hca03da5_0.tar.bz2
   sha256: f66664b97ad6248c187d4d316c7ee511b8f01a7931026c679bda943d4d6eb28f
   md5: 0428cdc3df242a4a3bdfa628838ddd0a
   depends:
@@ -6411,7 +6411,7 @@ packages:
   license_family: MIT
   size: 15098
   timestamp: 1650293803801
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/expat-2.5.0-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/expat-2.5.0-h313beb8_0.tar.bz2
   sha256: 3152fc53c90a109c08340806e9f81c8a13183732d8d1785dcc3f376141ed9797
   md5: 6e369f9003279ffa8af8c12d3d524316
   depends:
@@ -6420,13 +6420,13 @@ packages:
   license_family: MIT
   size: 158521
   timestamp: 1693497374650
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fftw-3.3.9-h1a28f6b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fftw-3.3.9-h1a28f6b_1.tar.bz2
   sha256: dc457fe0cde973b789306f64f8cc0b5b0a5512e3685749e34ab8713d3cad9840
   md5: 9c5ac82ba31104f8cbff795ceb5c7901
   license: GPL 2
   size: 1638590
   timestamp: 1630601990060
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fiona-1.9.1-py38h78102c4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fiona-1.9.1-py38h78102c4_0.tar.bz2
   sha256: bd708fcfafaffba21bf3253229052e79e482c72e2ab9b7772ab838b3f0dc541b
   md5: 91797b200304cbdb33cc50e46d11305f
   depends:
@@ -6447,7 +6447,7 @@ packages:
   license_family: BSD
   size: 1436350
   timestamp: 1678226162254
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/folium-0.14.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/folium-0.14.0-py38hca03da5_0.tar.bz2
   sha256: 3e3c1d1329887984cb869b67d323ff24c6b452f30201265300d7ad9681d81399
   md5: a88600af4b80a16b107e14a9dd95c3b2
   depends:
@@ -6460,7 +6460,7 @@ packages:
   license_family: MIT
   size: 115944
   timestamp: 1675353478695
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fontconfig-2.14.1-hee714a5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fontconfig-2.14.1-hee714a5_2.tar.bz2
   sha256: ad796b7fa5324e97e0f1c1fb504501a1460487b01b3ee10cab046b7a63aaf650
   md5: 35aaca48edc362f082ec9bfb6fab3317
   depends:
@@ -6472,7 +6472,7 @@ packages:
   license_family: MIT
   size: 304030
   timestamp: 1679578352471
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -6482,14 +6482,14 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freexl-1.0.6-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freexl-1.0.6-h1a28f6b_0.tar.bz2
   sha256: 08445fe0217766a9a052c5694feb37e979442979d4f86b3d1e6a5573beccaf22
   md5: 31da24ce8729c7bc441d33896eb43e26
   license: MPL-1.1
   license_family: OTHER
   size: 46292
   timestamp: 1629472181136
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2023.9.2-py38hca03da5_0.tar.bz2
   sha256: abdba7dc1c5af2ace3c424fe9f342c50100e2841ba4c26a31a6bba8a1b27a87b
   md5: ebb3d0931751c5d88b9930f9b931f564
   depends:
@@ -6498,7 +6498,7 @@ packages:
   license_family: BSD
   size: 257365
   timestamp: 1695734535618
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gdal-3.6.2-py38h92c4280_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/gdal-3.6.2-py38h92c4280_1.tar.bz2
   sha256: 4751b643a7957b39566c5820a102eca2b49b785c1d1add8f889bcd1e67219a4b
   md5: c29bab24abec81a33f669d388ba2960e
   depends:
@@ -6523,7 +6523,7 @@ packages:
   license_family: MIT
   size: 1991674
   timestamp: 1680120959161
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geopandas-0.12.2-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/geopandas-0.12.2-py38hca03da5_0.tar.bz2
   sha256: a9efd9f67dcff0913f69bf61ed9a12d378679d12a2d64e792d1f249da5321d9a
   md5: 4bd3bb8fb36ec1d169280f74b8f7b244
   depends:
@@ -6538,7 +6538,7 @@ packages:
   license_family: BSD
   size: 7447
   timestamp: 1675672060033
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geopandas-base-0.12.2-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/geopandas-base-0.12.2-py38hca03da5_0.tar.bz2
   sha256: e6747b5a6160a75024401f1fc3631b38ba10b4622bf3265c26dac56db8983cb8
   md5: 89b87bb43ac02aac9342f9e713447f15
   depends:
@@ -6552,7 +6552,7 @@ packages:
   license_family: BSD
   size: 1268090
   timestamp: 1675672058289
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geos-3.9.1-hc377ac9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/geos-3.9.1-hc377ac9_1.tar.bz2
   sha256: c901ff0682a8dcca5e77934a285af51dc7cfe5b0d2c22608d043d2940aecfb52
   md5: 25182cc424f23f0544362ef982ce9138
   depends:
@@ -6560,7 +6560,7 @@ packages:
   license: LGPL-2.1
   size: 889806
   timestamp: 1629009640131
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geotiff-1.7.0-h41f0982_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/geotiff-1.7.0-h41f0982_1.tar.bz2
   sha256: a004048c9213703281d4b4c1b62c715bfd752e8dbbfdb3a74790ac38634a185f
   md5: 7f724be357545e2eb4866c6b9662b29f
   depends:
@@ -6573,7 +6573,7 @@ packages:
   license_family: MIT
   size: 134871
   timestamp: 1679997100247
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-0.21.0-h13f89a0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/gettext-0.21.0-h13f89a0_1.tar.bz2
   sha256: 769329b869e583a6cf391e811d5e7075f2f1d8e0b62f76690f12814e432d659b
   md5: 9831b982fc81c64bd52b63419913d209
   depends:
@@ -6586,14 +6586,14 @@ packages:
   license_family: GPL
   size: 3557268
   timestamp: 1679578832882
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
   sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
   md5: 1d0bd7e576c64c059ef781dd319ad82a
   license: MIT
   license_family: MIT
   size: 77591
   timestamp: 1676983230102
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glib-2.69.1-h514c7bf_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/glib-2.69.1-h514c7bf_2.tar.bz2
   sha256: 6632f8299a02990872948001cf8697a4e11c8b8f0e25cb8054166d558f32b86b
   md5: a4ed2c8e4115f5bc56b9490f94f9d7a3
   depends:
@@ -6608,7 +6608,7 @@ packages:
   license_family: LGPL
   size: 3463753
   timestamp: 1669364513617
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf4-4.2.13-h5e329fb_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/hdf4-4.2.13-h5e329fb_3.tar.bz2
   sha256: e9ccc7a4ec25606556785100e6ee1dd5d9b04ed1973978545a37bfe6be929ddc
   md5: 2a40342fd2402a56d833312609fcf16b
   depends:
@@ -6619,7 +6619,7 @@ packages:
   license_family: BSD
   size: 913497
   timestamp: 1629192094107
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf5-1.12.1-h160e8cb_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/hdf5-1.12.1-h160e8cb_2.tar.bz2
   sha256: 4f5dc26b65f4f1404408a52d90d867dcdaed53d6b1934b4069fca5ab69e2bf8f
   md5: 31c93ccfd519d969aedb84bf093b3c1d
   depends:
@@ -6632,7 +6632,7 @@ packages:
   license_family: BSD
   size: 6270448
   timestamp: 1655307672422
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-68.1-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/icu-68.1-hc377ac9_0.tar.bz2
   sha256: ec6fe8fb2533f8fae73866531ad8c93b20a2b060737d237445f115455c3ab96b
   md5: cec95fa3d8b36559af63caf4fb1f6caf
   depends:
@@ -6640,7 +6640,7 @@ packages:
   license: MIT
   size: 13742625
   timestamp: 1630597537784
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py38hca03da5_0.tar.bz2
   sha256: 43d84999da439d3cb9d848e995403b0c9812bf8d8dc5c6da1b687de1f0db1be3
   md5: 41853629097b1396141396e375b2038f
   depends:
@@ -6649,7 +6649,7 @@ packages:
   license_family: BSD
   size: 112264
   timestamp: 1666125657324
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py38hca03da5_0.tar.bz2
   sha256: ef81f5fa90a119336b095d23a2e169e0b7a0fc5547562a7c1b8ade307b724ea5
   md5: 1a49db098332a13986a8fcaf3a0c7f2a
   depends:
@@ -6659,7 +6659,7 @@ packages:
   license_family: APACHE
   size: 38781
   timestamp: 1678997135620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py38hca03da5_0.tar.bz2
   sha256: fef0bbba380ab777d70b67f3fe3a452511c871e293ec87023984d4c47408ee70
   md5: 71d0048775d5ac4884635c4283904230
   depends:
@@ -6669,7 +6669,7 @@ packages:
   license_family: Apache
   size: 51764
   timestamp: 1698254705506
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py38h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py38h33ce5c2_0.tar.bz2
   sha256: ea9d98485603942ed6157d9c4b44e88c9fc8c404a4e715d0d1d825d1010f9902
   md5: d4f50fe1aae26e1ab70f5b3b77b95a61
   depends:
@@ -6691,7 +6691,7 @@ packages:
   license_family: BSD
   size: 220282
   timestamp: 1691121881612
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.12.2-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.12.2-py38hca03da5_0.tar.bz2
   sha256: f7417bde08616c279e8a9d3f739d5149e05202c4d79f50cf5d7706fed80d5e94
   md5: a67b25df2a3f4e14754775388e8c7077
   depends:
@@ -6712,7 +6712,7 @@ packages:
   license_family: BSD
   size: 1242385
   timestamp: 1691532423653
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py38hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py38hca03da5_1.tar.bz2
   sha256: 4df8e1e529abac4bc0e5bea9a27b076f139e410eb1ed72c3c25c4fb0910cbc03
   md5: 4a21434ff4e0415292b5d9c4cd997dd7
   depends:
@@ -6722,7 +6722,7 @@ packages:
   license_family: MIT
   size: 1022307
   timestamp: 1644316004245
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/joblib-1.2.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/joblib-1.2.0-py38hca03da5_0.tar.bz2
   sha256: c9b2ba2e68ed6eb2f91fa79f212288d660d5b17b1f82d63995d7bb126a847545
   md5: a11f3edc7d8dc5b1485dacf6c515e5cd
   depends:
@@ -6731,21 +6731,21 @@ packages:
   license_family: BSD
   size: 401932
   timestamp: 1685113178453
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
   sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
   md5: 055e12390b844ea6c6e956ee08a618e8
   license: IJG
   license_family: Other
   size: 273479
   timestamp: 1677849171867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/json-c-0.16-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/json-c-0.16-h1a28f6b_0.tar.bz2
   sha256: bb74124d37db18c31b4fef64d64f5809f50e9505ea5500437759b7fce8b2266c
   md5: 0335d80562d5b6254f0d35791295241a
   license: MIT
   license_family: MIT
   size: 75219
   timestamp: 1659123705674
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py38hca03da5_0.tar.bz2
   sha256: 8ca52555bd96018684737062dd1ae9433102c7a08a092f2477f1d45794a78fc7
   md5: e81388e9397277c75d0e7a3c30eedae0
   depends:
@@ -6758,7 +6758,7 @@ packages:
   license_family: MIT
   size: 132864
   timestamp: 1676558857190
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py38hca03da5_0.tar.bz2
   sha256: a4b6892b15665ccf82b3d8e881f4a8ed54febb4a490ce5921277438ad154986f
   md5: fdcc463db49334d736ab371cce0a84cf
   depends:
@@ -6774,7 +6774,7 @@ packages:
   license_family: BSD
   size: 197158
   timestamp: 1676329125183
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py38hca03da5_0.tar.bz2
   sha256: 92d22ba2c10a476f08c1a1d1b0820f666a2477dbc2b2b2c44ed622cd31dc416a
   md5: ecec507491cef0e5deff4479a1acf00b
   depends:
@@ -6785,7 +6785,7 @@ packages:
   license_family: BSD
   size: 92791
   timestamp: 1679906603831
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py38hca03da5_0.tar.bz2
   sha256: dab44b851f1a67cda9d4aee9c2bf09d80b68aab4aa8a7200a820039d08025f69
   md5: 300aaffe4e4cce40942f4e88b6f2d5d9
   depends:
@@ -6809,7 +6809,7 @@ packages:
   license_family: BSD
   size: 399673
   timestamp: 1671707647012
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kealib-1.5.0-hba2eb73_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kealib-1.5.0-hba2eb73_1.tar.bz2
   sha256: ebb886d4072bc12e08a90a8e14b61a2bbd4a17e69993f848982da2f7d60ed3d9
   md5: 7da7333b8b4d51ab4408c66cd0bcd432
   depends:
@@ -6819,7 +6819,7 @@ packages:
   license_family: MIT
   size: 161523
   timestamp: 1687966978773
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py38h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py38h313beb8_0.tar.bz2
   sha256: 101c40cdf1df9e9dba602d371f2dff580f19836f3b1f7043468dbde93151efa4
   md5: 39dc576e64c3e1acb98a975530b87ac2
   depends:
@@ -6829,7 +6829,7 @@ packages:
   license_family: BSD
   size: 64180
   timestamp: 1672387223612
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
   sha256: e547a4a540ccc9db683d6d2e3e36b0d0ad99e1ad10b22b5f403af3e893b412ba
   md5: dc5ae0ece3c4990ba5fee7b266f2a019
   depends:
@@ -6840,7 +6840,7 @@ packages:
   license_family: MIT
   size: 1306804
   timestamp: 1686931342120
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -6850,7 +6850,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -6859,7 +6859,7 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.73.0-h49e8a49_12.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libboost-1.73.0-h49e8a49_12.tar.bz2
   sha256: 4342165ac2224b02089c3a8db136f067cabddb9f8a6a13e46b839d0b5263a841
   md5: e13a408297da09dd8d77e6e4904f4232
   depends:
@@ -6874,13 +6874,13 @@ packages:
   license_family: OTHER
   size: 20106750
   timestamp: 1655879742590
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
   md5: a0f206782751dfffed0dd51302a1bf26
   license: MIT
   size: 68012
   timestamp: 1659616138077
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
   md5: 4c6667cdd061d28e9bc4e4300e4d115e
   depends:
@@ -6888,7 +6888,7 @@ packages:
   license: MIT
   size: 31173
   timestamp: 1659616155596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
   md5: 637e9430e258ddf050623ef2360184d8
   depends:
@@ -6896,7 +6896,7 @@ packages:
   license: MIT
   size: 298430
   timestamp: 1659616172209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
   sha256: a94cc52c1ca2e421342d2fefc6d7774ff5118b9d01f4e22d33314f8520d33723
   md5: 440575339cec83722e83087db31127bf
   depends:
@@ -6911,21 +6911,21 @@ packages:
   license_family: MIT
   size: 342121
   timestamp: 1693515586487
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20221030-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libedit-3.1.20221030-h80987f9_0.tar.bz2
   sha256: 6304be2cb816e57ac178068d49befffba4354847f9ee1cfd0ec6acf9ba4ad94a
   md5: af25d1cc1334d44d2b96eb8133c1dac9
   depends:
@@ -6934,21 +6934,21 @@ packages:
   license_family: BSD
   size: 167428
   timestamp: 1670840153090
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
   sha256: 6fc572025852b210ecddcca3ab9ff3f1d5f6bd91f1933c6e296de6bb331f6b5d
   md5: 6dd7d9c5737bbd2a27d18f15318dc3e6
   license: BSD-2-Clause
   license_family: BSD
   size: 102059
   timestamp: 1628961869728
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
   sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
   md5: 55c615026c0869f8d3ba657f3bd38c43
   license: MIT
   license_family: MIT
   size: 120389
   timestamp: 1683716579036
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgdal-3.6.2-h50c47ba_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgdal-3.6.2-h50c47ba_1.tar.bz2
   sha256: 74611ad2a44f19518902d1be51a6ffa0ccfb917682ada620223a6c9001bb809c
   md5: 236fd482190d440791596dd691680163
   depends:
@@ -6996,7 +6996,7 @@ packages:
   license_family: MIT
   size: 9407038
   timestamp: 1680120832390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -7005,7 +7005,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -7016,14 +7016,14 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
   sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
   md5: a41117710dafe569c9cc4e83f6f29fe3
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1411339
   timestamp: 1650982753977
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libkml-1.3.0-hc4d7c42_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libkml-1.3.0-hc4d7c42_7.tar.bz2
   sha256: 3934364764ac9651132865f4bfaf3ae17f4bdbf2a96bd5ee7faec7995c556fb7
   md5: 8012eb6fc2f5750fea616fe03b1be95e
   depends:
@@ -7035,7 +7035,7 @@ packages:
   license_family: BSD
   size: 448001
   timestamp: 1693261840201
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm11-11.1.0-h12f7ac0_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libllvm11-11.1.0-h12f7ac0_6.tar.bz2
   sha256: 6450802cad40b813a99572891811830758393500f4c79a223e1046918872c3f7
   md5: 616a6976906afa0035a2dc2ea1c34195
   depends:
@@ -7045,7 +7045,7 @@ packages:
   license_family: Apache
   size: 21766415
   timestamp: 1665076236980
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnetcdf-4.8.1-ha022005_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libnetcdf-4.8.1-ha022005_4.tar.bz2
   sha256: 962a15d8bbf1bfa7f4f1bf2b6a547b770f16ac8f6f374ebf1205f95d6893090a
   md5: 37d8db4c0339cedc632314a34bb69886
   depends:
@@ -7060,7 +7060,7 @@ packages:
   license_family: BSD
   size: 1461182
   timestamp: 1691155105280
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
   sha256: 039483aadb821adffcc2aff761ec35474d633b6bc2f1eb7cce877a881d7ed290
   md5: d75b21db95481154cfa9d7a871f0f3bf
   depends:
@@ -7075,7 +7075,7 @@ packages:
   license_family: MIT
   size: 743061
   timestamp: 1686931613436
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -7086,7 +7086,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -7095,7 +7095,7 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpq-12.15-h449679c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpq-12.15-h449679c_1.tar.bz2
   sha256: 50200d127777088845f196d08938ae47e7806263f138397279e38d815108cac6
   md5: 15e25b0a643fbc872b0f30e08643654f
   depends:
@@ -7103,13 +7103,13 @@ packages:
   - openssl >=1.1.1u,<1.1.2a
   size: 2918646
   timestamp: 1687380617188
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libspatialindex-1.9.3-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libspatialindex-1.9.3-hc377ac9_0.tar.bz2
   sha256: 592a66a6145b5eee819a97caf509b996c84fe2c9ecd69c7e300f8b2a02050682
   md5: 65682197af5a83e3ce46b5d04d44ef3b
   depends:
@@ -7117,7 +7117,7 @@ packages:
   license: MIT
   size: 386585
   timestamp: 1629286650261
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libspatialite-4.3.0a-h4707d77_23.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libspatialite-4.3.0a-h4707d77_23.tar.bz2
   sha256: bde523cbf47065a1d2e47ee1f3516e83e47bc286490b5024720a1030bcdb542b
   md5: d821a08e51a17e131a16ca1e1bbfedf0
   depends:
@@ -7134,7 +7134,7 @@ packages:
   license_family: LGPL
   size: 3061330
   timestamp: 1680110261420
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
   sha256: 48a8617773b57a4b9a8539782bf88a317f49a644d3f858aa0ad3ab13afc03ae7
   md5: c3bc0fb3cc9a98ef1f2f83ef497fc5da
   depends:
@@ -7143,7 +7143,7 @@ packages:
   license_family: BSD
   size: 334616
   timestamp: 1686931322663
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -7160,7 +7160,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
   sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
   md5: 98d22e0124d55fae3c37c608dab1dcc9
   depends:
@@ -7174,7 +7174,7 @@ packages:
   license_family: BSD
   size: 89825
   timestamp: 1694778225280
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
   sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
   md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
   constrains:
@@ -7183,7 +7183,7 @@ packages:
   license_family: BSD
   size: 331675
   timestamp: 1694776939192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h372ba2a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h372ba2a_0.tar.bz2
   sha256: 2bbf6abf6f6580c2f54dafd83b850e5f0b362da0d1b3953a5969c95b8868d395
   md5: c20122a5fdee8e3b4d6c65d38459fc20
   depends:
@@ -7195,7 +7195,7 @@ packages:
   license_family: MIT
   size: 656627
   timestamp: 1692647717145
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzip-1.8.0-h0c481fb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libzip-1.8.0-h0c481fb_0.tar.bz2
   sha256: 7035bf74c9adbc5d98ed17a5618a7b6df97479fc60e1398fd29a9f8b42bcb1b1
   md5: 429d9725086eceeafd42a5369c5791b1
   depends:
@@ -7208,7 +7208,7 @@ packages:
   license_family: BSD
   size: 121284
   timestamp: 1652981900392
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -7217,7 +7217,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.37.0-py38h8b39d70_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.37.0-py38h8b39d70_0.tar.bz2
   sha256: b68c92256fc28c5cd36f83c823704abb4518df8295dfcd52461bf87674495632
   md5: db5a9dcb8384260ca22c3203359f8352
   depends:
@@ -7227,7 +7227,7 @@ packages:
   license: BSD-2-Clause
   size: 328720
   timestamp: 1643978389796
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py38hca03da5_0.tar.bz2
   sha256: 307477ab96bae938902afb6c1689017986654464719644c6d17f85e032e44abc
   md5: 37a8e89bd4b324c309facc82bdc64941
   depends:
@@ -7236,7 +7236,7 @@ packages:
   license_family: BSD
   size: 11872
   timestamp: 1652903134672
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
   sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
   md5: c99006da802a97c9aae30da8c16b4820
   depends:
@@ -7245,7 +7245,7 @@ packages:
   license_family: BSD
   size: 176131
   timestamp: 1670944706815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mapclassify-2.5.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mapclassify-2.5.0-py38hca03da5_0.tar.bz2
   sha256: 4a3ae7a24361575b0c18db6724e2684f0ad94aa8214fada7f0da8a2b826affbf
   md5: 7aca87f6fa869239e7d5c0bd5f76db1c
   depends:
@@ -7259,7 +7259,7 @@ packages:
   license_family: BSD
   size: 67601
   timestamp: 1675157803073
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py38hca03da5_0.tar.bz2
   sha256: 2c34852ea6fe459fc4e892f2b3c43cb22093c66bb0dd4c7a577affef3c1ad350
   md5: 9fd19f5fc3dc04e95a205552307c4316
   depends:
@@ -7269,7 +7269,7 @@ packages:
   license_family: BSD
   size: 123564
   timestamp: 1671541934866
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.0.1-py38h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.0.1-py38h1a28f6b_0.tar.bz2
   sha256: 232bdf1ba2292fccb52a13e04457d7ee6a9c3c65b34f1d772dbacbaa657d3332
   md5: d8a2f07ecfb16293475183b6b4dcf76c
   depends:
@@ -7278,7 +7278,7 @@ packages:
   license_family: BSD
   size: 22403
   timestamp: 1629137440910
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.5.0-py38h9197a36_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.5.0-py38h9197a36_0.tar.bz2
   sha256: 8c263600f46eb1febf203d992c68962113aef195255038464a781c79310dfb79
   md5: 4bd370ea10825ca3cfc96c90c383fbd3
   depends:
@@ -7298,7 +7298,7 @@ packages:
   license_family: PSF
   size: 7627542
   timestamp: 1638374169303
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py38hca03da5_0.tar.bz2
   sha256: 8ed7b59ced736b2c2dca4bf793fd22071920847c7c009ae08215618e0cf9634e
   md5: 0b7e6805f36a34f1fc27b8230830f22d
   depends:
@@ -7308,7 +7308,7 @@ packages:
   license_family: BSD
   size: 17305
   timestamp: 1662014548083
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py38h1a28f6b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py38h1a28f6b_1000.tar.bz2
   sha256: e492f6e1773997b51e94863f30dd711c5494a59cf686666cc71c1080dac7b871
   md5: 023961822c6aed9e5ea8f1e9cb392321
   depends:
@@ -7317,7 +7317,7 @@ packages:
   license_family: BSD
   size: 55707
   timestamp: 1629356096769
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py38h525c30c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/msgpack-python-1.0.3-py38h525c30c_0.tar.bz2
   sha256: ea6e79e88ff83790d1ce7dd4f77cd46a8904cfba65f8e1bd6ffee33bcc855373
   md5: 800b92ae3bbeae2f1e5374cfb2d05895
   depends:
@@ -7327,7 +7327,7 @@ packages:
   license_family: Apache
   size: 83473
   timestamp: 1652362704023
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py38hca03da5_0.tar.bz2
   sha256: 32ca9f80183284c18f43c656f85ce1ee6b367db95373afacaa9d8ee4d4f47781
   md5: 3bcae7fb685499f69ac281f0f2370679
   depends:
@@ -7337,7 +7337,7 @@ packages:
   license_family: BSD
   size: 23009
   timestamp: 1629282754789
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py38hca03da5_0.tar.bz2
   sha256: 03afb59c187b4cdec2bfcf65334cb9d4713a3d853977adc483dc0e9ee5e79d0c
   md5: 0fd1e2b527781364e0cb7372126ac18e
   depends:
@@ -7363,7 +7363,7 @@ packages:
   license_family: BSD
   size: 8293521
   timestamp: 1681756545565
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py38hca03da5_0.tar.bz2
   sha256: e0269bdd6a1782a56e6045538da9af40ce305c991665339fe470ca3c6a4f713d
   md5: 79956486ddf726287b0c21f0b5123bd3
   depends:
@@ -7376,7 +7376,7 @@ packages:
   license_family: BSD
   size: 96772
   timestamp: 1650373673399
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.4.4-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.4.4-py38hca03da5_0.tar.bz2
   sha256: acd1ef9f4592a4f932276284ac507298b67df93ff550fb26ee4ce3807c5d1318
   md5: 738f1de620bd6cbcf51abe62be995b11
   depends:
@@ -7401,7 +7401,7 @@ packages:
   license_family: BSD
   size: 578638
   timestamp: 1649751937473
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py38hca03da5_0.tar.bz2
   sha256: 35752b15fbeede3c09d4eb11119b0b19e44cd4920a0ae8b63d4fa429b5c88505
   md5: 1ccc6494ecdf62992dd685c7ea56be51
   depends:
@@ -7414,14 +7414,14 @@ packages:
   license_family: BSD
   size: 148332
   timestamp: 1694616807292
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py38hca03da5_0.tar.bz2
   sha256: fa202d7013e173bbd3a90f808dbc51038940f59912ae7ab4d11a87ccc16a384b
   md5: 958f9798ac78c8e0f381e2ec59413ce9
   depends:
@@ -7430,7 +7430,7 @@ packages:
   license_family: BSD
   size: 13964
   timestamp: 1672387151610
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/netcdf4-1.6.2-py38h053bab8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/netcdf4-1.6.2-py38h053bab8_0.tar.bz2
   sha256: dfc0fbee8057c63c9895a24e5c53dba028173e84860d109a3000724f947430bf
   md5: 8f16c4e9a19677abd081a27ee6a05432
   depends:
@@ -7444,7 +7444,7 @@ packages:
   license_family: MIT
   size: 458365
   timestamp: 1673455539600
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/networkx-3.1-py38hca03da5_0.tar.bz2
   sha256: 3e67e248242b27b2e11bbdd7689c4cc9b65bcfb9f9dc9c4bfa172e55d89238a9
   md5: 107c2cb41db5cecba88987430860dac8
   depends:
@@ -7453,7 +7453,7 @@ packages:
   license_family: BSD
   size: 2968202
   timestamp: 1690562086263
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py38hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py38hca03da5_1.tar.bz2
   sha256: 301193b31a4ead33aea2c01d00d8f3d292406e0310d6ebc8e4d8192319449187
   md5: 08262f4fb565edca50993fec64afbe21
   depends:
@@ -7478,7 +7478,7 @@ packages:
   license_family: BSD
   size: 586692
   timestamp: 1690984859816
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py38hca03da5_0.tar.bz2
   sha256: 2773a82bb679dac047f390713083cf7a88a206680fc536e5cc6c38b03931b8c4
   md5: fa962bc8ad8bef9a9b9c50fbda21f0c2
   depends:
@@ -7488,7 +7488,7 @@ packages:
   license_family: BSD
   size: 22863
   timestamp: 1668160601243
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nspr-4.35-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nspr-4.35-h313beb8_0.tar.bz2
   sha256: 49514dcfb22fb667890bebf464118e59f0c05b0574e39082cf06d4e171fc7f22
   md5: e7808cc8e4a810fe3d9390192c44c619
   depends:
@@ -7497,7 +7497,7 @@ packages:
   license_family: OTHER
   size: 252418
   timestamp: 1685541795239
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nss-3.89.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nss-3.89.1-h313beb8_0.tar.bz2
   sha256: 01fe9808891853091be4aea4f05882ce1991d737e9f409dfc31ee4daa199019e
   md5: 9c3977aa66fc7d91d83f63d79792ee1d
   depends:
@@ -7509,7 +7509,7 @@ packages:
   license_family: OTHER
   size: 2038812
   timestamp: 1685543329548
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.54.0-py38hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numba-0.54.0-py38hc377ac9_0.tar.bz2
   sha256: 8749d8b60b1cd973c9f78ac978465a1675ad7a6847cdd2460eb2aa16301a0f5b
   md5: 4fa37ae58e57c40fa8de32e362663b33
   depends:
@@ -7526,7 +7526,7 @@ packages:
   license_family: BSD
   size: 3814162
   timestamp: 1629980986750
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.4-py38h79ee842_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.4-py38h79ee842_1.tar.bz2
   sha256: 09acb2d02a5cf5fb8b10252aba95cbc1efc2a95c43f4b81710dc23542ef3c4d3
   md5: 23a179a3a80b2ec7c4e2ec6b9055210a
   depends:
@@ -7537,7 +7537,7 @@ packages:
   license_family: MIT
   size: 122400
   timestamp: 1683221874476
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.19.5-py38h831b0dc_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.19.5-py38h831b0dc_4.tar.bz2
   sha256: f89b2df3c65d019e213588e1afa0d2cf94cf4137d8879b4ad0487c06122d577f
   md5: b3f8d316bdd97b82869b82f4bdb0333a
   depends:
@@ -7549,7 +7549,7 @@ packages:
   license_family: BSD
   size: 11036
   timestamp: 1677549992401
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.19.5-py38hdc56644_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.19.5-py38hdc56644_4.tar.bz2
   sha256: 39f25d723d1610f87bfccd3df9af4a70d968d3f9971aeea44c2f45d4723ea09c
   md5: d0a97ae5572541f7cb23a02cffac9fd0
   depends:
@@ -7563,7 +7563,7 @@ packages:
   license_family: BSD
   size: 5031326
   timestamp: 1677549981194
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
   sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
   md5: 371358a54bbdd307603888348d1a2c6f
   depends:
@@ -7573,7 +7573,7 @@ packages:
   license: BSD 2-Clause
   size: 412248
   timestamp: 1628861367714
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
   sha256: 409ba99dd953129c0ccebb5dcbf2049920e5a755b88e7e392e4f91be924e26ef
   md5: f05f00606c10617a61c41f23652b9a00
   depends:
@@ -7582,7 +7582,7 @@ packages:
   license_family: Apache
   size: 3450897
   timestamp: 1694465216241
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py38hca03da5_0.tar.bz2
   sha256: 2224aecba4eb43cb6bf75641c07efee607ffa5f0e419214da969930bf6bc939a
   md5: 2d0973f43006d805567ae3092e3d2739
   depends:
@@ -7591,7 +7591,7 @@ packages:
   license_family: Apache
   size: 73637
   timestamp: 1693575275014
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-1.3.5-py38h9197a36_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-1.3.5-py38h9197a36_0.tar.bz2
   sha256: 1395f495dc78187e80fa7334ff1aa980d80044666aad4fca7eb23a5e5e1ec106
   md5: d5b2fd9291a5691a6dc90c1ca41073e5
   depends:
@@ -7606,7 +7606,7 @@ packages:
   license_family: BSD
   size: 11968643
   timestamp: 1641482506915
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.0-py38hca03da5_0.tar.bz2
   sha256: c0224dbf9acf3e85b0c0561d8a0c18563e37b2acbe30ca91308baf72f53b17c6
   md5: d59ed9b27032114d1b48fa3d9ab23f75
   depends:
@@ -7620,7 +7620,7 @@ packages:
   license_family: BSD
   size: 35906
   timestamp: 1693937909555
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre-8.45-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pcre-8.45-hc377ac9_0.tar.bz2
   sha256: 83ae22c702ab99a904992f322049a4b41ecd711b6088aae61420992452ec64bc
   md5: 92b1f6d5d3e70ce8adf51d1bcf0531a8
   depends:
@@ -7629,7 +7629,7 @@ packages:
   license_family: BSD
   size: 236201
   timestamp: 1629474194684
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre2-10.37-h37e8eca_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pcre2-10.37-h37e8eca_1.tar.bz2
   sha256: 4aa188dfa8f8cb24899e01875b804310ac81f43e618630b1828060c4dfd90d8a
   md5: 55a6179184fd02c74c6fbd80ea4fad2e
   depends:
@@ -7639,7 +7639,7 @@ packages:
   license_family: BSD
   size: 783351
   timestamp: 1641403689283
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py38h3b245a6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py38h3b245a6_0.tar.bz2
   sha256: 99e96dafcc446efb103cecf6f7ddb4161fc875e627fb1d51084a5865605e4ee2
   md5: 4a38b476dda6db5735a543a323038ec0
   depends:
@@ -7658,7 +7658,7 @@ packages:
   license_family: Other
   size: 720719
   timestamp: 1696580206985
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py38hca03da5_0.tar.bz2
   sha256: 8b2238d03fd4d4dd3e7c965256788e7bc9f390db9d8b086e2069cdc07c9cd9fc
   md5: 39f7e7530c1113ec41b105a10cc77ab5
   depends:
@@ -7669,13 +7669,13 @@ packages:
   license_family: MIT
   size: 2679861
   timestamp: 1697548818737
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pixman-0.40.0-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pixman-0.40.0-h1a28f6b_0.tar.bz2
   sha256: a7b1a6ddba772080777ac65570dffa9ed08dd866e053fa98f3aa38835c9b010b
   md5: a3abe939bd01b7f6fb4e4f3b6da91f7b
   license: MIT
   size: 269396
   timestamp: 1628926728556
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pkgutil-resolve-name-1.3.10-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pkgutil-resolve-name-1.3.10-py38hca03da5_0.tar.bz2
   sha256: febea10909ebabc1b963493f74e5b41224259cc550481e87d04e243d2eaf1125
   md5: baddd5bef9eb6f021ae8fa047545881b
   depends:
@@ -7684,7 +7684,7 @@ packages:
   license_family: PSF
   size: 10736
   timestamp: 1661463349093
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py38hca03da5_0.tar.bz2
   sha256: d97cb927d800e9a447c2b9e0983b0518d7f41b6c5947e62075f4bb5fe9fa3569
   md5: 5d344c031b607858aac0263ee037f1a0
   depends:
@@ -7693,7 +7693,7 @@ packages:
   license_family: MIT
   size: 33041
   timestamp: 1692205775190
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pooch-1.7.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pooch-1.7.0-py38hca03da5_0.tar.bz2
   sha256: 7447015165bf9b11fb4b6c839e95f2978ac012301d843aa79a5eb3a180d72cae
   md5: 5e0595b52a068b93fbc91a22480535fc
   depends:
@@ -7709,7 +7709,7 @@ packages:
   license_family: BSD
   size: 82434
   timestamp: 1695850137461
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/poppler-22.12.0-h52f4003_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/poppler-22.12.0-h52f4003_3.tar.bz2
   sha256: 9f8cf7e763c5ce4cf0a5ebfc8db8b885b3c4e70c9b9433a96f5500b7fba4f3cc
   md5: 40ae9e180cbf21de5afdfe4fd096849b
   depends:
@@ -7735,14 +7735,14 @@ packages:
   license_family: GPL
   size: 1749726
   timestamp: 1696000773528
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/poppler-data-0.4.11-hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/poppler-data-0.4.11-hca03da5_1.tar.bz2
   sha256: 964a66d899c6c661baabf19c89dfeb71586ca495efb5dfe141c3d4d1447e87e6
   md5: 2fd602e0516b7352f115305cba7708a9
   license: GPL-2.0-or-later and GPL-3.0-or-later and BSD-3-Clause
   license_family: GPL
   size: 3918339
   timestamp: 1673886276945
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/postgresql-12.15-h1ae2815_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/postgresql-12.15-h1ae2815_1.tar.bz2
   sha256: d7aa4c1f43d69d14c7fc79e1b4c6fd32b205488432670e50ddd5c9350836e237
   md5: 68f287d885bbf61b1851f31c0fd0d4cf
   depends:
@@ -7753,7 +7753,7 @@ packages:
   - zlib >=1.2.13,<2.0.0a0
   size: 4005629
   timestamp: 1687380646878
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/proj-7.2.0-heac154c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/proj-7.2.0-heac154c_1.tar.bz2
   sha256: cde1995bcc8f9aec04ba5590ff8b2c9761fd80d7421e8885367aeed9f1576c3b
   md5: 36c6e4df74d2c71d27ca552e9af62f4d
   depends:
@@ -7766,7 +7766,7 @@ packages:
   license: MIT
   size: 2900328
   timestamp: 1629967923612
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py38hca03da5_0.tar.bz2
   sha256: 41dadbf05754b86a3323059a67742e4d4fee178661d92705ef496ea14cd91d66
   md5: e55ee42cc29c11809f568d8d1cf4747c
   depends:
@@ -7775,7 +7775,7 @@ packages:
   license_family: Apache
   size: 91074
   timestamp: 1659455126069
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py38hca03da5_0.tar.bz2
   sha256: eb1bb190aabf2e071c38bb812cc5d22dc67bbf65d0b490058641cc206c8050fe
   md5: d81e45e0c8f7b64444d67c456e841672
   depends:
@@ -7787,7 +7787,7 @@ packages:
   license_family: BSD
   size: 579541
   timestamp: 1672387337842
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py38h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py38h1a28f6b_0.tar.bz2
   sha256: 3c5bd50929a4aa13c72095653118fd7cc44053bbe80949fd9f78d6bc78128487
   md5: cc9daac414bf6d0fc28087deceeeb54d
   depends:
@@ -7796,7 +7796,7 @@ packages:
   license_family: BSD
   size: 366992
   timestamp: 1656431324712
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py38hca03da5_0.tar.bz2
   sha256: 8d542e0301f4692b0810d9c6143400ac24ffe65c1c5276fb9167c9dd6dcfd894
   md5: a1b3ddffe3d0dfde327191c5a1d2d26f
   depends:
@@ -7808,7 +7808,7 @@ packages:
   license_family: BSD
   size: 30761
   timestamp: 1675441503308
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py38hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py38hca03da5_1.tar.bz2
   sha256: aa6b41d2921130aed4630653e555fd90f4531970297e8b3a434f9d6dc2357294
   md5: b0ba357ab09318153b94d105a7863e3b
   depends:
@@ -7817,7 +7817,7 @@ packages:
   license_family: BSD
   size: 1887242
   timestamp: 1684279996873
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py38hca03da5_0.tar.bz2
   sha256: 32f8719ee099ff80d53842ad8df81cead9d3e1f9df41b36e9460aa34bbc42d62
   md5: 26662ce6b5181b6f37f6b027f729d07d
   depends:
@@ -7827,7 +7827,7 @@ packages:
   license_family: Apache
   size: 95591
   timestamp: 1690223471024
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py38hca03da5_0.tar.bz2
   sha256: 3e4fed535277fc9d94c53d717ca10e7faf1d051f4d2fcefb1a02cd0e84585bc6
   md5: 156fde9f3f56a6b1b9cb7b8020748288
   depends:
@@ -7836,7 +7836,7 @@ packages:
   license_family: MIT
   size: 157834
   timestamp: 1661452633325
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyproj-3.1.0-py38hfce2bd4_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyproj-3.1.0-py38hfce2bd4_4.tar.bz2
   sha256: c945d9a0d5a5cc34a511e1c49d9c2cc48b316b3865345ce0709ca6016aedc327
   md5: 4890adfef3697b13da358e174c2e3bdd
   depends:
@@ -7846,7 +7846,7 @@ packages:
   license: MIT
   size: 456408
   timestamp: 1629968175553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py38h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py38h1a28f6b_0.tar.bz2
   sha256: 89f46d5896b289e6376efe1b6de185f8c7ab9896b2c64144841680b373f9a0f5
   md5: de0bfe11706d0fea87d1185c65d655eb
   depends:
@@ -7855,7 +7855,7 @@ packages:
   license_family: MIT
   size: 91828
   timestamp: 1629278499184
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py38hca03da5_0.tar.bz2
   sha256: 47d308dd037d9373cf00b341a34ad2cb2d2f2dbb06d3ac5e59ef05d3ec81b3bb
   md5: 6f20c9bfe7585ae23ec10ea950553603
   depends:
@@ -7864,7 +7864,7 @@ packages:
   license_family: BSD
   size: 27337
   timestamp: 1626781365102
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.8.18-hc0d8a6c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.8.18-hc0d8a6c_0.tar.bz2
   sha256: b8fe0d51772aebcd4664f4faba55a3ca42b0ae7b4a3261b955c0e260dee0f6d1
   md5: 40ca48fa679cca7093e7bf37bae3ea07
   depends:
@@ -7882,7 +7882,7 @@ packages:
   license_family: PSF
   size: 15400446
   timestamp: 1694438953629
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py38hca03da5_0.tar.bz2
   sha256: ad379c6a9b647dd1606107456d005228027d3c92e0fc55fcf47861df4527e46c
   md5: 12b99cac3003bc54b23d599c9999a8c4
   depends:
@@ -7891,7 +7891,7 @@ packages:
   license_family: BSD
   size: 266004
   timestamp: 1661368815072
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py38h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-lmdb-1.4.1-py38h313beb8_0.tar.bz2
   sha256: 7bb699635692c6b113d9ae0b6278026f33721b0af581d2012b3ae12452ef0299
   md5: b924257ab4a27121bdebb03f8145ca67
   depends:
@@ -7901,7 +7901,7 @@ packages:
   license_family: Other
   size: 136234
   timestamp: 1682522529684
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py38hca03da5_0.tar.bz2
   sha256: 14ae410c9709a138599b93c2a45268931430f53f0c348e4f4f5524f863f10110
   md5: 9e70f067fbed5f69c1a3341bfc43cc98
   depends:
@@ -7910,7 +7910,7 @@ packages:
   license_family: MIT
   size: 267242
   timestamp: 1695131671919
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py38hca03da5_0.tar.bz2
   sha256: 636dc028dfb88e2cc7f0e802b5a7a228c19295a06680a04453582e4bd6d039a8
   md5: 81d6910e095c2b42882b431eecee7fab
   depends:
@@ -7920,7 +7920,7 @@ packages:
   license_family: BSD
   size: 40945
   timestamp: 1685030821471
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py38h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py38h80987f9_0.tar.bz2
   sha256: 62218268c76f7a70fc7895163e57cbe73e9a87e828931d675693c1aa689e1b6c
   md5: bb8d0a68a05e6d8b1da8c659d656a2d6
   depends:
@@ -7930,7 +7930,7 @@ packages:
   license_family: MIT
   size: 166923
   timestamp: 1698096185614
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py38hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py38hc377ac9_0.tar.bz2
   sha256: 912d76d7e27223aec1ae9a7a21f9771a486242e2dfec4b173de6401b5e34bfd9
   md5: bae29a7c8e23e240f4ef632a8c9a8335
   depends:
@@ -7941,7 +7941,7 @@ packages:
   license_family: BSD
   size: 467169
   timestamp: 1657724377965
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/qhull-2020.2-h48ca7d4_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/qhull-2020.2-h48ca7d4_2.tar.bz2
   sha256: e033f2c9e52aa705d9c10d9a352bdad47a363299e42ad62bd7089ddf112ca355
   md5: b7e91b270376c6d7281413dc8779cdea
   depends:
@@ -7950,7 +7950,7 @@ packages:
   license_family: Other
   size: 1888397
   timestamp: 1670915845902
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -7959,7 +7959,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py38hca03da5_0.tar.bz2
   sha256: 3d88a7aa68ecc536d0fafffca9f09c6426ef76083546c11cd5d4d11303ea68e3
   md5: 0e3b8587269906972e6c043ea4bde568
   depends:
@@ -7975,7 +7975,7 @@ packages:
   license_family: Apache
   size: 95068
   timestamp: 1690400283875
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rtree-1.0.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rtree-1.0.1-py38hca03da5_0.tar.bz2
   sha256: 2d65bedc3aab0cc0760342a631aed093a264fb310e9f6fda9f61c73e5cc829b5
   md5: ae757c3132b6ada35d3b6ddb18f17461
   depends:
@@ -7986,7 +7986,7 @@ packages:
   license_family: MIT
   size: 50332
   timestamp: 1675157882997
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scikit-learn-1.2.2-py38h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/scikit-learn-1.2.2-py38h313beb8_0.tar.bz2
   sha256: 1aaa6ea9a6ced0fd47f11a6614d2201a9f0e9796c5c08785df26aca012ef4d64
   md5: 3a3ebd08b7b2cc6058d6671f56f0b175
   depends:
@@ -8001,7 +8001,7 @@ packages:
   license_family: BSD
   size: 8681465
   timestamp: 1680198977194
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.10.0-py38h9d039d2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.10.0-py38h9d039d2_0.tar.bz2
   sha256: 64fbf15727a6f04d77e6e47d77e57c324a29ebe0b015f4e37b4c7da7447f9a7b
   md5: 2debb6ee4ea2ea48a0f4997e2a0d45fe
   depends:
@@ -8019,7 +8019,7 @@ packages:
   license_family: BSD
   size: 23699483
   timestamp: 1675460648646
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py38hca03da5_0.tar.bz2
   sha256: 389b6d3e6795e946ca235a243ca94b195e500649c4f39982454ee182b0e215d3
   md5: 2d20be88e7f7ec8ea437e7a6586680c4
   depends:
@@ -8028,7 +8028,7 @@ packages:
   license_family: MIT
   size: 1092010
   timestamp: 1690290925244
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/shapely-2.0.1-py38h9ca3c36_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/shapely-2.0.1-py38h9ca3c36_0.tar.bz2
   sha256: 1fdd4f8f6b73ae348f98184e6c9c4c84589bf13289f2f5e8141d205d7dbafee2
   md5: 18aa822830da9b76307bcfc58e2c86de
   depends:
@@ -8039,7 +8039,7 @@ packages:
   license_family: BSD
   size: 424790
   timestamp: 1680636349114
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py38hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py38hca03da5_1.tar.bz2
   sha256: 50378d9f00c8f79c21419b782ff781b6adb1a77d77719ed74c9053cf52b897c2
   md5: a7364a86c299a0444670ec87480dc591
   depends:
@@ -8048,7 +8048,7 @@ packages:
   license_family: Apache
   size: 15629
   timestamp: 1629145936800
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py38hca03da5_0.tar.bz2
   sha256: 66064f3ee63df60cf0daa216111ce1aee0273a18b1eedf9ea72c96d49aaba5f2
   md5: e20848a40ca8adb4f4eb05eeecef05a6
   depends:
@@ -8057,7 +8057,7 @@ packages:
   license_family: MIT
   size: 67344
   timestamp: 1696347585538
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
   sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
   md5: 2302a79a045f152e183a52a81adfba62
   depends:
@@ -8069,7 +8069,7 @@ packages:
   license_family: Other
   size: 1674163
   timestamp: 1681394762218
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
   sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
   md5: ae58720a18a2ed15eae214ad7a10d1b5
   depends:
@@ -8078,7 +8078,7 @@ packages:
   license_family: Apache
   size: 140125
   timestamp: 1680167256603
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py38hca03da5_0.tar.bz2
   sha256: 633b552e3b2851778474918745474012c24478028d9199b7e70b405b49edec80
   md5: 21b71f9ea2e65e770b6703a71c6d1768
   depends:
@@ -8089,7 +8089,7 @@ packages:
   license_family: BSD
   size: 30932
   timestamp: 1671751893456
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/testpath-0.6.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/testpath-0.6.0-py38hca03da5_0.tar.bz2
   sha256: 83d3c353677f7d181cacc83dd397e7e54125876e5d436734d8043ea9675c96ec
   md5: 2e7036398cef211777ceaa78126e00ad
   depends:
@@ -8098,7 +8098,7 @@ packages:
   license_family: BSD
   size: 94385
   timestamp: 1655908588511
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tiledb-2.3.3-h3ad0f7e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tiledb-2.3.3-h3ad0f7e_2.tar.bz2
   sha256: 003459840c022a0f790ba41f7be4add583a0a8d69a541d32e4d3ff98668fa1c8
   md5: f61e22878730d78fa7c0137f466950c4
   depends:
@@ -8113,7 +8113,7 @@ packages:
   license_family: MIT
   size: 2811591
   timestamp: 1655311350211
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
   sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
   md5: 667e60c8b407d73cbba40f44901f4f00
   depends:
@@ -8122,7 +8122,7 @@ packages:
   license_family: BSD
   size: 3412693
   timestamp: 1654088929697
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py38hca03da5_0.tar.bz2
   sha256: 02190c624d356a6ad7b6dba56a32fd33f4cf94ab5c1f087869be84718791487b
   md5: 7fdd7e3d9b70d446d35425ed13e9c536
   depends:
@@ -8131,7 +8131,7 @@ packages:
   license_family: BSD
   size: 102470
   timestamp: 1667464107289
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py38h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py38h80987f9_0.tar.bz2
   sha256: 2df1261975825dfd4f07d820ae1c19bce98fa5dc0eb9b1c1903981049a2d0c25
   md5: 758253a280b0e84529b0eb1a3d85391d
   depends:
@@ -8140,7 +8140,7 @@ packages:
   license_family: Apache
   size: 679231
   timestamp: 1696937084224
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py38h86d0a89_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py38h86d0a89_0.tar.bz2
   sha256: 1dcb323fa0ac724c323048a005b4e315dedbab270c1baebf0d268696e87d06f3
   md5: ccf39817852d58221fef8da99dbe4ba8
   depends:
@@ -8153,7 +8153,7 @@ packages:
   license_family: MOZILLA
   size: 124901
   timestamp: 1679561992309
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py38hca03da5_0.tar.bz2
   sha256: 902b29577bf695b2386e0d323f80923abc28ea84bac34f6ca73cad9902976618
   md5: 97d9e41ecc76096448535e308c9ed75e
   depends:
@@ -8162,7 +8162,7 @@ packages:
   license_family: BSD
   size: 192784
   timestamp: 1671143956975
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py38hca03da5_0.tar.bz2
   sha256: 99d28957d07455915664e84f1e71b4aa82ba7108c605af28eebeb3b16875994d
   md5: 60e8669d7b5736e3a7ad3d3e95984e0b
   depends:
@@ -8172,7 +8172,7 @@ packages:
   license_family: PSF
   size: 9660
   timestamp: 1690297597919
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py38hca03da5_0.tar.bz2
   sha256: 4c3dca51a21645aca14489e54814d73e622aa7948baa6e29ef19e22fa1e34ed2
   md5: 760645401bdc1af5d0dd338800eab761
   depends:
@@ -8181,14 +8181,14 @@ packages:
   license_family: PSF
   size: 58735
   timestamp: 1690297590496
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uriparser-0.9.7-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uriparser-0.9.7-h80987f9_0.tar.bz2
   sha256: c7402bdd16743bbd3350752e7009e40024b7ea2d280f54a6f74a4246f99e0edf
   md5: 666f1bc2359d58c32ccbcbf4e9fcadd7
   license: BSD-3-Clause
   license_family: BSD
   size: 42998
   timestamp: 1692186946914
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py38hca03da5_0.tar.bz2
   sha256: 92d5dcc58c24c54e3d2d1df6da2f886705d34c813c28d377a6544a8d8647f9ef
   md5: 941369c8471738fd67ddca4881a21e85
   depends:
@@ -8203,7 +8203,7 @@ packages:
   license_family: MIT
   size: 188591
   timestamp: 1698257629160
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py38hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py38hca03da5_1.tar.bz2
   sha256: 82c0d07ca88c806b0816e8f4d5f79d24d8c373cc758ff06b1ad9976257162e67
   md5: 07036a73e921ca173dcabcff9321c34d
   depends:
@@ -8212,7 +8212,7 @@ packages:
   license_family: BSD
   size: 20079
   timestamp: 1629144417239
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py38hca03da5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py38hca03da5_4.tar.bz2
   sha256: d0bcd4656348071924bfaad2a9a7d7e4c5cd1b2eb65aaf6e38aa9b43ccc2c06e
   md5: 56579618078447f918a18fb47367db48
   depends:
@@ -8222,7 +8222,7 @@ packages:
   license_family: BSD
   size: 70949
   timestamp: 1629357088765
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py38hca03da5_0.tar.bz2
   sha256: d9653a6ef961ee875978492b7163e2b29deffeacc3ee271ede4f5e3e248e7d94
   md5: 4bc4db5c94f7b75b9d26c3caee12f1e3
   depends:
@@ -8231,7 +8231,7 @@ packages:
   license_family: MIT
   size: 102415
   timestamp: 1695742020723
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xerces-c-3.2.4-h389e118_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xerces-c-3.2.4-h389e118_0.tar.bz2
   sha256: df1b1f12d8728e7ab568b1487c604dfe847c60f29495137d5b28c4699c993a8e
   md5: fcd3374a1b02b3014d02f8a89c860828
   depends:
@@ -8241,7 +8241,7 @@ packages:
   license_family: Apache
   size: 2720249
   timestamp: 1668712626345
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py38hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py38hca03da5_1.tar.bz2
   sha256: fe2c19f54551b7ef1c3a5b33dec3125db65ced3cacd187c19004fcd0c3c96213
   md5: 58f495f8dc56ed6bf8533c8cfa7ca5bf
   depends:
@@ -8250,20 +8250,20 @@ packages:
   license_family: BSD
   size: 49427
   timestamp: 1675159104659
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
   sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
   md5: 2e75ad6a09c308268192efe03cc9ebf4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 411778
   timestamp: 1683113019715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
   sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
   md5: 30f666bf97c26587c5d2f68cc5f330ab
   depends:
@@ -8272,7 +8272,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 316901
   timestamp: 1629287855861
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zict-3.0.0-py38hca03da5_0.tar.bz2
   sha256: 75240abcfd39c449374aa916e1aa01e0758bae5f8532520568728a5670141696
   md5: 4eee6619cd3939d8fc2d881c21f4c248
   depends:
@@ -8283,7 +8283,7 @@ packages:
   license_family: BSD
   size: 77607
   timestamp: 1695832873064
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py38hca03da5_0.tar.bz2
   sha256: e38f8fcbdaf5b0ad01c66b0d407ae21cb534a3fc412d3eb5b1f2db67b40e5fc7
   md5: 0df4c72ef1d772e8122c8d6e361c854f
   depends:
@@ -8292,14 +8292,14 @@ packages:
   license_family: MIT
   size: 19037
   timestamp: 1672387185470
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
   sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
   md5: 467ae28215d1aa1c5688bc0c8a184269
   license: Zlib
   license_family: Other
   size: 103525
   timestamp: 1666595022664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
   sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
   md5: 7cfbed15f1feee1422810f7830075f53
   depends:
@@ -8311,7 +8311,7 @@ packages:
   license_family: BSD
   size: 779464
   timestamp: 1681304594848
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py38haa95532_0.tar.bz2
   sha256: cc82907bc0bda29497cdeab8310925dbf228c3f16ac983fcbb37ad765fa6db1b
   md5: 6ea4dc40a54dee3ab7644d64995212b8
   depends:
@@ -8324,7 +8324,7 @@ packages:
   license_family: MIT
   size: 162306
   timestamp: 1644463761471
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py38h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py38h2bbff1b_0.tar.bz2
   sha256: 03266238128a35b764faac4b242317894abfbd6aa87926925d742fe777540501
   md5: c69fc290a38779ea332ed0706d58b8e5
   depends:
@@ -8336,7 +8336,7 @@ packages:
   license_family: MIT
   size: 39205
   timestamp: 1644569956444
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py38haa95532_0.tar.bz2
   sha256: 3b1702c2673d9cbf3d3390d020f677e655c4630e5f58adcf93e6bff03f6690c1
   md5: 30739c44ce189fbb20be78431cf3fd2b
   depends:
@@ -8345,7 +8345,7 @@ packages:
   license_family: MIT
   size: 132981
   timestamp: 1695718251136
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py38haa95532_0.tar.bz2
   sha256: 53589b64f777641caa27ac2ef9571d99274f5e2c3edb5874748e682ac241e967
   md5: febac983b7b52735b196dad1bf458a2e
   depends:
@@ -8355,12 +8355,12 @@ packages:
   license_family: MIT
   size: 200008
   timestamp: 1681493159092
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
   sha256: cf9a8a0745c5fab48394d84a58fe2f06e5fa80c87d5cc8d6c8da2e1df52cc69f
   md5: 462987773ecda8cbf1f80734e84f080f
   depends:
@@ -8373,7 +8373,7 @@ packages:
   license_family: BSD
   size: 93601
   timestamp: 1675247818708
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-2.3.3-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-2.3.3-py38haa95532_0.tar.bz2
   sha256: 9c84abed617901f1d66065bd8650dd737cd242d4c6ec77e0d2bedc494846fbc7
   md5: 60bdddcdaa9d65aef49a0abd62247537
   depends:
@@ -8390,7 +8390,7 @@ packages:
   license_family: BSD
   size: 8659293
   timestamp: 1625767854760
-- conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
   sha256: 68ef338b27c035add89c0812ad469dd8c9e94f27130f770345ea20deb049d50b
   md5: 9ec19b145f655329532b608963cf32f4
   depends:
@@ -8401,7 +8401,7 @@ packages:
   license_family: OTHER
   size: 11334
   timestamp: 1696764270626
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py38h080aedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py38h080aedc_0.tar.bz2
   sha256: 44d13de563214c19fa278424b7038f5b68fa7a2885f65843314701ee6ecce4a1
   md5: 4596b9868dee3b6d493596be5ac8dcb2
   depends:
@@ -8413,7 +8413,7 @@ packages:
   license_family: BSD
   size: 119589
   timestamp: 1657175681565
-- conda: https://repo.anaconda.com/pkgs/main/win-64/branca-0.6.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/branca-0.6.0-py38haa95532_0.tar.bz2
   sha256: cb1291d8e5419384071119e2b66042de673081c53ca9bd2178536177fa8579c3
   md5: 56dffaeffdff286748e0bfb5c9a15c41
   depends:
@@ -8423,7 +8423,7 @@ packages:
   license_family: MIT
   size: 43078
   timestamp: 1675157787871
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
   md5: 507dfe693ef429f466d964b599f4af21
   depends:
@@ -8435,7 +8435,7 @@ packages:
   license: MIT
   size: 18650
   timestamp: 1659616328001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
   md5: d0bf43e8df60baae3b3105aa5c42a791
   depends:
@@ -8446,7 +8446,7 @@ packages:
   license: MIT
   size: 21153
   timestamp: 1659616312367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py38hd77b12b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py38hd77b12b_7.tar.bz2
   sha256: dbede6d8a4ccdc885b2d827ffd6be8a624a4ad7ab0a55469381dcfefa2cec9cb
   md5: 38b2003b07fbfe552a36d4733205c984
   depends:
@@ -8456,7 +8456,7 @@ packages:
   license: MIT
   size: 343217
   timestamp: 1659616387167
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
   sha256: 3a26c397d4e0d546b0c2f433074c20813c5f3ae98bcf07a165c648f369a850b9
   md5: 8f8069ce8c9eff1b0f124de2c0a63b86
   depends:
@@ -8465,14 +8465,14 @@ packages:
   license_family: BSD
   size: 154105
   timestamp: 1563219293348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
   sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
   md5: 092b417c11edcbe6bb9b765ab4a55d23
   license: MPL-2.0
   license_family: Other
   size: 164999
   timestamp: 1694009822357
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cairo-1.16.0-haedb8bc_5.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cairo-1.16.0-haedb8bc_5.tar.bz2
   sha256: 56af1f19db12dee9dbb177873726b3fdf6cbbd83736748c99ad7c536ff28ff28
   md5: f2923f93791571dd8a664da18b5de5d0
   depends:
@@ -8488,7 +8488,7 @@ packages:
   license_family: LGPL
   size: 2351737
   timestamp: 1688495984273
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cartopy-0.18.0-py38h80a4efb_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cartopy-0.18.0-py38h80a4efb_1.tar.bz2
   sha256: abe53c3493b29b3c9dbaf58bb16793a1b68976a1cc1cd11897f7732aeb6b302c
   md5: 6be9e3405efdb31178a694a6c8423fd6
   depends:
@@ -8506,7 +8506,7 @@ packages:
   license: LGPL-3
   size: 1905833
   timestamp: 1612289928244
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py38haa95532_0.tar.bz2
   sha256: 855f213e9d26f98a8a981cc1670caa4f9030a869592c25a6f865b1b5bfa1ffb5
   md5: a04188728a298ec4bf04665874236b75
   depends:
@@ -8515,7 +8515,7 @@ packages:
   license_family: Other
   size: 159050
   timestamp: 1690232498419
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py38h2bbff1b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py38h2bbff1b_3.tar.bz2
   sha256: c4ea45913ae72575af59c399ecd191b4f7a458267d7d68bd2388831be3b445fd
   md5: 298580960c7e95035ccfa980fc0c9d0a
   depends:
@@ -8527,7 +8527,7 @@ packages:
   license_family: MIT
   size: 228272
   timestamp: 1670423387289
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
   sha256: a65386e70bdad9aa1e07ad430309c3ddc249b74bea69388dfbda99fd00069665
   md5: e4174218de194962642b353f51a19d1e
   depends:
@@ -8537,7 +8537,7 @@ packages:
   license_family: Other
   size: 617890
   timestamp: 1655709069465
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cftime-1.6.2-py38h080aedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cftime-1.6.2-py38h080aedc_0.tar.bz2
   sha256: 3d98eda93343cd39b9351290b8c7ef366d98e7aa5a1b1665b1244558fef1183b
   md5: 5d692d8ba0f60750762e29737f935e4c
   depends:
@@ -8549,7 +8549,7 @@ packages:
   license_family: MIT
   size: 186171
   timestamp: 1678830486301
-- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py38haa95532_0.tar.bz2
   sha256: d6419f177081f538c07438fd0e30b3fd0550154068846a5a172d7ad0f3da7d29
   md5: 4a4023e7123dee6dd3de8d5c7ad10208
   depends:
@@ -8559,7 +8559,7 @@ packages:
   license_family: BSD
   size: 152529
   timestamp: 1698130021042
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cloudpickle-2.2.1-py38haa95532_0.tar.bz2
   sha256: 5c028560e4c4269f5778800240a6fc79d4d69989368bf61a1f2cb42447232540
   md5: 7953616427d956631a8b0f3768f8703c
   depends:
@@ -8568,7 +8568,7 @@ packages:
   license_family: BSD
   size: 40796
   timestamp: 1683040201265
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py38haa95532_0.tar.bz2
   sha256: b1c25c1a98c903b27e265b54acbed95f4a9b274c5b6ed13cf6b0f6f6f8b355a6
   md5: 056a4bcea84a785566fc6d5dee32c8d9
   depends:
@@ -8577,7 +8577,7 @@ packages:
   license_family: BSD
   size: 30328
   timestamp: 1672387462487
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py38haa95532_0.tar.bz2
   sha256: 98bff1cae2eb4f5cb3477eac3061c7b53d8dc0338f6c602a12a333151855b14d
   md5: 00cf4ae9ff27e19cafe87d2381e809b5
   depends:
@@ -8587,7 +8587,7 @@ packages:
   license_family: CC
   size: 1992783
   timestamp: 1668084685089
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py38haa95532_0.tar.bz2
   sha256: 6d58d6a7624bb59eda69c1183c3498bc4d3d52e1e130208bd7316a626505c58c
   md5: 276b81b8348545e07e93ab6c54342670
   depends:
@@ -8597,7 +8597,7 @@ packages:
   license_family: BSD
   size: 13449
   timestamp: 1671231315969
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py38h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py38h59b6b97_0.tar.bz2
   sha256: 70fde13d90524b164158f9b22303677d6e05ab15a84ffc00bdeafb2e1a584e84
   md5: fecf6e5becd8b5d19e3b5a1b33e9d915
   depends:
@@ -8609,7 +8609,7 @@ packages:
   license_family: BSD
   size: 184226
   timestamp: 1663827694272
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py38h3438e0d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py38h3438e0d_0.tar.bz2
   sha256: 889a3fcf229545b667b65cac80101b8ebe3d65bae0abb2bcc2a28e1338d175cc
   md5: cfb66cbfa54725a6f15aec83ec95a8c8
   depends:
@@ -8624,7 +8624,7 @@ packages:
   license_family: BSD
   size: 1221743
   timestamp: 1694446236622
-- conda: https://repo.anaconda.com/pkgs/main/win-64/curl-8.4.0-he2ea4bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/curl-8.4.0-he2ea4bf_0.tar.bz2
   sha256: 68e1a20c8a7fae2992f8ba32608171cfa077201471afa0177362aeecc72b9bda
   md5: f4adfca0be77fdf7fcbbf4caf99d20a6
   depends:
@@ -8635,7 +8635,7 @@ packages:
   license_family: MIT
   size: 153606
   timestamp: 1697023649068
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.0-py38h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cytoolz-0.12.0-py38h2bbff1b_0.tar.bz2
   sha256: b7572ea611a536f9b94b94c6240ec54642f67210a892ada77e06f01db0e65dd8
   md5: 32179fcabac5ca600e85429e289415ab
   depends:
@@ -8647,7 +8647,7 @@ packages:
   license_family: BSD
   size: 313232
   timestamp: 1667466210472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py38haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/datashape-0.5.4-py38haa95532_1.tar.bz2
   sha256: 792842a4d65fa3affa75fbef7b45b35e2d1fdc3a3afb805c60dea0363b473f9f
   md5: 3afae957ad0d8a21fab2c450d3a5e7f9
   depends:
@@ -8659,7 +8659,7 @@ packages:
   license_family: BSD
   size: 104651
   timestamp: 1613390448861
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py38hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py38hd77b12b_0.tar.bz2
   sha256: 2133716ef1744b2292e035a58e2ce7136507df2598a6bbb557f77d41c229e6a6
   md5: 8d89f8023cd7fb526d42b020dd298dde
   depends:
@@ -8670,7 +8670,7 @@ packages:
   license_family: MIT
   size: 3289647
   timestamp: 1690907575092
-- conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2021.10.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/distributed-2021.10.0-py38haa95532_0.tar.bz2
   sha256: 3f844e1222748cb8b1e3e24a4eeb6cd7277de06e52cec59c533ea2a1e2ea1487
   md5: ba62ad063fee7cd4e04a6997a1c1c171
   depends:
@@ -8696,7 +8696,7 @@ packages:
   license_family: BSD
   size: 1143116
   timestamp: 1635968418241
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py38haa95532_0.tar.bz2
   sha256: e86cd5e70eb1ade76f2e80d9351d377f81b63460b7b0261e0aa9825b7051df83
   md5: 0ea2c3493ad24b83dfb5919aa6af58e8
   depends:
@@ -8705,7 +8705,7 @@ packages:
   license_family: MIT
   size: 16900
   timestamp: 1649926672239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/expat-2.5.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/expat-2.5.0-hd77b12b_0.tar.bz2
   sha256: 700d0aedee50fdcfe4d4c4557e79cd1a7c0f4ed0e4c9300c2b24933b511f4896
   md5: 5e7da8f3ad8b0c31c45a16b93c83cfd7
   depends:
@@ -8715,7 +8715,7 @@ packages:
   license_family: MIT
   size: 330697
   timestamp: 1693497491435
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fiona-1.9.1-py38hf11a4ad_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fiona-1.9.1-py38hf11a4ad_0.tar.bz2
   sha256: 199d7044dc750989f19f2a5cc6c0061f75376c7c922b2540f49148a983747d21
   md5: a960ccd9ff6e8ed39b254c27a906bcdc
   depends:
@@ -8737,7 +8737,7 @@ packages:
   license_family: BSD
   size: 1345487
   timestamp: 1678226233640
-- conda: https://repo.anaconda.com/pkgs/main/win-64/folium-0.14.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/folium-0.14.0-py38haa95532_0.tar.bz2
   sha256: c8c5eb7fdc07e86f33b5ce97ac14a3aed086ba046e22c65d7b39820e27c13eac
   md5: fec37a80141c14d4e14b14534817f020
   depends:
@@ -8750,7 +8750,7 @@ packages:
   license_family: MIT
   size: 114803
   timestamp: 1675353801633
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fontconfig-2.14.1-h9c4af85_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fontconfig-2.14.1-h9c4af85_2.tar.bz2
   sha256: c1f6c98891b25459067503009afb0727528aa6b161638e04e8382b635415e914
   md5: 552be3449bf89f94a5a023bc242dc02f
   depends:
@@ -8765,7 +8765,7 @@ packages:
   license_family: MIT
   size: 207322
   timestamp: 1679578266134
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -8777,7 +8777,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freexl-1.0.6-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freexl-1.0.6-h2bbff1b_0.tar.bz2
   sha256: 9171aec35d7e9732010a911f9e9a596d4fb739d821ce72e1905cd2087e332730
   md5: af6308117a173c805775dcdb971c0d2d
   depends:
@@ -8787,7 +8787,7 @@ packages:
   license: MPL-1.1
   size: 60210
   timestamp: 1607116173150
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fsspec-2023.9.2-py38haa95532_0.tar.bz2
   sha256: d532383b2e3a33e47cb0fbf2c74363edffe0cbbb6de726c6331ba2bcfde24a5b
   md5: 10b25bc45db15a4da3685293f226697e
   depends:
@@ -8796,7 +8796,7 @@ packages:
   license_family: BSD
   size: 259923
   timestamp: 1695734621348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/gdal-3.6.2-py38h9eae49a_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/gdal-3.6.2-py38h9eae49a_1.tar.bz2
   sha256: 0e1d05edc76006e06dbcc4217029e72ef2b89b649e7c5201f04052f8d7b2cef5
   md5: 87515d7763a245c60243920737491286
   depends:
@@ -8821,7 +8821,7 @@ packages:
   license_family: MIT
   size: 2426560
   timestamp: 1680122233809
-- conda: https://repo.anaconda.com/pkgs/main/win-64/geopandas-0.12.2-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/geopandas-0.12.2-py38haa95532_0.tar.bz2
   sha256: 19300d2b9c3aeee1020d8b442189c6356fe48843c15e475322ae3b0a27506177
   md5: 5f3e66214b00c0a315dbc199055f5731
   depends:
@@ -8836,7 +8836,7 @@ packages:
   license_family: BSD
   size: 6951
   timestamp: 1675672406970
-- conda: https://repo.anaconda.com/pkgs/main/win-64/geopandas-base-0.12.2-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/geopandas-base-0.12.2-py38haa95532_0.tar.bz2
   sha256: 44d03b77a93e648178930b6d5d93e05528bdc5ff1aa27c424f71b924b24dafae
   md5: 61ec08f4b6dd648838b7c69df27f214c
   depends:
@@ -8850,7 +8850,7 @@ packages:
   license_family: BSD
   size: 1250994
   timestamp: 1675672388143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/geos-3.8.0-h33f27b4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/geos-3.8.0-h33f27b4_0.tar.bz2
   sha256: de43096c33bba4f0140d6954d74861f4338b4e610fbdd9b4651302eaacc5db93
   md5: 46f610ec4be6b8e985048510341c9c42
   depends:
@@ -8859,7 +8859,7 @@ packages:
   license: LGPL-2.1
   size: 1053138
   timestamp: 1573216029043
-- conda: https://repo.anaconda.com/pkgs/main/win-64/geotiff-1.7.0-h4545760_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/geotiff-1.7.0-h4545760_1.tar.bz2
   sha256: a2367b57c0cc49572becda0e87a94ff13c0d380797d61e0b37d8a6ccc43a79b9
   md5: 4622806fde6033429c7d9121c64e0f6b
   depends:
@@ -8873,7 +8873,7 @@ packages:
   license_family: MIT
   size: 139759
   timestamp: 1679997133093
-- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
   sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
   md5: 9f167d3e45441bc3633c1974b1b0ce8c
   depends:
@@ -8883,7 +8883,7 @@ packages:
   license_family: MIT
   size: 88421
   timestamp: 1676983264486
-- conda: https://repo.anaconda.com/pkgs/main/win-64/glib-2.69.1-h5dc1a3c_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/glib-2.69.1-h5dc1a3c_2.tar.bz2
   sha256: 224fdf140d6d31c14465399021788b01640b60483b2b4cb198d650dd6934baed
   md5: b49d0b97262be617d9d7e04263a7cbfb
   depends:
@@ -8897,7 +8897,7 @@ packages:
   license_family: LGPL
   size: 1921053
   timestamp: 1669364571724
-- conda: https://repo.anaconda.com/pkgs/main/win-64/hdf4-4.2.13-h712560f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/hdf4-4.2.13-h712560f_2.tar.bz2
   sha256: 8129c8aae5860d9975f3c88c2ef874d0a746a11074f922b6318446cc45f30768
   md5: b3a727bf1c1df5b021aaf6cc7e81deb2
   depends:
@@ -8908,7 +8908,7 @@ packages:
   license_family: BSD
   size: 2869081
   timestamp: 1510864340539
-- conda: https://repo.anaconda.com/pkgs/main/win-64/hdf5-1.10.6-h1756f20_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/hdf5-1.10.6-h1756f20_1.tar.bz2
   sha256: e428782d09e9484af561184f41c562972fe2c36cf1445b4481368e8a47eb3984
   md5: 56abd458659955a2521069adc6db12bf
   depends:
@@ -8920,13 +8920,13 @@ packages:
   license_family: BSD
   size: 20304975
   timestamp: 1655188499390
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
   sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
   md5: 582d2c1135a89da757a038de831e7f39
   license: Intel proprietary
   size: 11086648
   timestamp: 1664812389803
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icu-58.2-ha925a31_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icu-58.2-ha925a31_3.tar.bz2
   sha256: e7cb511301ce3788402dce7b700ca44e1f7bc38e498d27b41060a9b48704946d
   md5: 3b9fbd6eda81ae1b8b580b99d2d928f4
   depends:
@@ -8935,7 +8935,7 @@ packages:
   license: MIT
   size: 22885927
   timestamp: 1588025937921
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.4-py38haa95532_0.tar.bz2
   sha256: d54bade7902c52d01edf8b2ffc1bb30e5c81a1d1dc13a17e3a0a68a8c0657367
   md5: 16d7f359b91058de57d133feac4ea9c6
   depends:
@@ -8944,7 +8944,7 @@ packages:
   license_family: BSD
   size: 112140
   timestamp: 1666125760518
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py38haa95532_0.tar.bz2
   sha256: 26ecfc3b943ad504557a09f74c431146e34701fb480b03c0125b1cd9d01627aa
   md5: 25109c9d30c8a65bcf24581069793a7a
   depends:
@@ -8954,7 +8954,7 @@ packages:
   license_family: APACHE
   size: 38070
   timestamp: 1678997199756
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py38haa95532_0.tar.bz2
   sha256: 1a588a5585c3c3c5da6d05c05e172ff6fd80deb8d73c3bae27e551b2410a2dd2
   md5: 4fdae6815b68f7a397d4be1cb5cc63ba
   depends:
@@ -8964,7 +8964,7 @@ packages:
   license_family: Apache
   size: 51364
   timestamp: 1698254849400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
   sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
   md5: 9834848bd7c7759acf12e78d09388563
   depends:
@@ -8974,7 +8974,7 @@ packages:
   license_family: Proprietary
   size: 3891030
   timestamp: 1681801474383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py38h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py38h9909e9c_0.tar.bz2
   sha256: d24dcbc647703de21f2ca74334fec6d941acf02c27218af48b399a992efec0d4
   md5: 0a101e1ec2c76ebab4495f81409823a2
   depends:
@@ -8995,7 +8995,7 @@ packages:
   license_family: BSD
   size: 217167
   timestamp: 1691121830749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.12.2-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.12.2-py38haa95532_0.tar.bz2
   sha256: 7b756df85fb011088bf6bb638600c7457cf717dfa5ab69b0a6cf3649b66b1dcb
   md5: 8b27d8d58e3781bd451cf797e272d5e4
   depends:
@@ -9015,7 +9015,7 @@ packages:
   license_family: BSD
   size: 1252304
   timestamp: 1691532284562
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py38haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py38haa95532_1.tar.bz2
   sha256: 0ed05e1338f7fde869bcf8971fc416064a82d2077be035aa5d0fbadc4cc673fc
   md5: 7311067dee8f1de4b655c9b714906c2d
   depends:
@@ -9025,7 +9025,7 @@ packages:
   license_family: MIT
   size: 1038788
   timestamp: 1644315559456
-- conda: https://repo.anaconda.com/pkgs/main/win-64/joblib-1.2.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/joblib-1.2.0-py38haa95532_0.tar.bz2
   sha256: 09b5a40b2ef9c84c0db5d3b5aba940853d1680b440a562863b5d32d50b02fca0
   md5: 5ac7f98046a624683f52bd8168ec98ca
   depends:
@@ -9034,7 +9034,7 @@ packages:
   license_family: BSD
   size: 405576
   timestamp: 1685113539298
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
   sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
   md5: 81f2c343dc4c65eea39c45383272068f
   depends:
@@ -9044,7 +9044,7 @@ packages:
   license_family: Other
   size: 407861
   timestamp: 1677849239400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py38haa95532_0.tar.bz2
   sha256: fc8f2922ab6f8f32817976f004c994542acccf70872e196e856138842fcbd669
   md5: 6d0fe84d715d409fc5c5820b431f85c1
   depends:
@@ -9057,7 +9057,7 @@ packages:
   license_family: MIT
   size: 151200
   timestamp: 1676558871701
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py38haa95532_0.tar.bz2
   sha256: ea0ae2cfbbbf5a3737e348b40fd6dd7a1b6159525143af959eb1708b201a9577
   md5: 59112e5bdca43f39c392165f51477c30
   depends:
@@ -9073,7 +9073,7 @@ packages:
   license_family: BSD
   size: 229130
   timestamp: 1676330586941
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py38haa95532_0.tar.bz2
   sha256: a7df42fe4a642750c9b202a93f2b7445fe097b3f9cc7a746f33d09760f0ae116
   md5: dca06cfd9f70dc5fd611ef4082b5638a
   depends:
@@ -9085,7 +9085,7 @@ packages:
   license_family: BSD
   size: 116444
   timestamp: 1679906857031
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py38haa95532_0.tar.bz2
   sha256: da5dca6540e574387a96ac08a420f02873ce3fa47a7ee329c662075c1c9dbc22
   md5: b483a973fd9343c2153a2770348a524c
   depends:
@@ -9110,7 +9110,7 @@ packages:
   license_family: BSD
   size: 413080
   timestamp: 1671708067512
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kealib-1.5.0-hde4a422_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kealib-1.5.0-hde4a422_0.tar.bz2
   sha256: d5b2a9bfd41e9d1603916395965a6815bea4dd7dbcd64e2788e272de3cb4eaea
   md5: 41df1bb8fa244907112bfc4b1caac813
   depends:
@@ -9121,7 +9121,7 @@ packages:
   license_family: MIT
   size: 162295
   timestamp: 1674215955759
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py38hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py38hd77b12b_0.tar.bz2
   sha256: c287aa13a824a255ab68751645473a4f190590b77160b85d694a2f72e513e551
   md5: f35f9f31f1f8bd00c5e7fccc81a8edff
   depends:
@@ -9132,7 +9132,7 @@ packages:
   license_family: BSD
   size: 62238
   timestamp: 1672388388533
-- conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/krb5-1.20.1-h5b6d351_1.tar.bz2
   sha256: 1debf041a8f45a1310256364762d5793327b6bc02d8f8953816688329cb4ff58
   md5: 3cbe6c7e0aab01fea30638d752d42058
   depends:
@@ -9143,7 +9143,7 @@ packages:
   license_family: MIT
   size: 847845
   timestamp: 1686932219054
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
   sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
   md5: f5f73266281ab12377d5d47bdf07500a
   depends:
@@ -9155,7 +9155,7 @@ packages:
   license_family: MIT
   size: 905072
   timestamp: 1617648814933
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -9165,7 +9165,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
   sha256: 4184dd040fc38cb123a98588a8344aa8d1ba1932df5fcc6c188f6b21f5a0c306
   md5: da58cfa83f3d6c31ae12d8777cd1b64d
   depends:
@@ -9178,7 +9178,7 @@ packages:
   license_family: OTHER
   size: 29803292
   timestamp: 1696764164248
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
   sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
   md5: c345f51706eef530454f66b794e5e574
   depends:
@@ -9187,7 +9187,7 @@ packages:
   license: MIT
   size: 68189
   timestamp: 1659616216976
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
   md5: a7400cfb72042977bc047909ed504ce8
   depends:
@@ -9197,7 +9197,7 @@ packages:
   license: MIT
   size: 33743
   timestamp: 1659616248209
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
   md5: 6307f6854754ab5bd7c84e6998385bb1
   depends:
@@ -9207,7 +9207,7 @@ packages:
   license: MIT
   size: 733177
   timestamp: 1659616279453
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.4.0-h86230a5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libcurl-8.4.0-h86230a5_0.tar.bz2
   sha256: 391fed09fc96fd343eb34f36fa57fc9163c241528fade6cd93c54e098d3bb472
   md5: 5d93324d94f715944695a2135546617c
   depends:
@@ -9221,7 +9221,7 @@ packages:
   license_family: MIT
   size: 335562
   timestamp: 1697023614098
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -9231,7 +9231,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_0.tar.bz2
   sha256: 1b3b9be41dba504e468a336196de9fd09568ba42585e493888aaa3708f687d0a
   md5: 5cdcd99f18d9dedb772d272088e72b4c
   depends:
@@ -9241,7 +9241,7 @@ packages:
   license_family: MIT
   size: 116942
   timestamp: 1683716620230
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libgdal-3.6.2-h11d7215_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libgdal-3.6.2-h11d7215_1.tar.bz2
   sha256: 0fdb6521e98d0f95c7983a09c9c292bc8ffa88b9f0fc9c0fe34c6579dd6825a0
   md5: 7da0d24a0f3b04b079e5abdf5f509f14
   depends:
@@ -9288,7 +9288,7 @@ packages:
   license_family: MIT
   size: 9796897
   timestamp: 1680121634867
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
   sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
   md5: b812bc5d9c76242e2bb2ac87afe7d39b
   depends:
@@ -9298,7 +9298,7 @@ packages:
   license_family: GPL3
   size: 730280
   timestamp: 1650983734373
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libkml-1.3.0-h63940dd_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libkml-1.3.0-h63940dd_7.tar.bz2
   sha256: d202eef643f39fbe4b24ff4240052d2b58d67a4ba5fcbd80d09106191b85bff6
   md5: 6f63fe185daebe8da8c6b3dc941ad7b0
   depends:
@@ -9311,7 +9311,7 @@ packages:
   license_family: BSD
   size: 3074807
   timestamp: 1693262074974
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libnetcdf-4.8.1-h6685c40_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libnetcdf-4.8.1-h6685c40_2.tar.bz2
   sha256: d9a7edba417fce7865f98e9d2f6912d5aafce884ae78a868da275e726647dec1
   md5: 49ad63d5f22949042f21ce145ebd6c21
   depends:
@@ -9327,7 +9327,7 @@ packages:
   license_family: BSD
   size: 704268
   timestamp: 1674628735708
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -9338,7 +9338,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.15-hb652d5d_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpq-12.15-hb652d5d_1.tar.bz2
   sha256: 916d1428d6315fb1c4e3f70e56407ef96e1115610ffab4b82b302a002856c4e2
   md5: c0f92eda4de2df406dc6b5fc42d3e9b7
   depends:
@@ -9349,7 +9349,7 @@ packages:
   - zlib >=1.2.13,<2.0.0a0
   size: 3827913
   timestamp: 1687382952596
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -9358,7 +9358,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libspatialindex-1.9.3-h6c2663c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libspatialindex-1.9.3-h6c2663c_0.tar.bz2
   sha256: e3527de4b50ae741004bf5ddfd6c5c4fe4d778ffea475f858d2b29e76ced9796
   md5: 91aa29bbc065cd3b53c7410ab683c9dd
   depends:
@@ -9367,7 +9367,7 @@ packages:
   license: MIT
   size: 455875
   timestamp: 1616086916558
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libspatialite-4.3.0a-h6ec8781_23.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libspatialite-4.3.0a-h6ec8781_23.tar.bz2
   sha256: d0b2f30939b32e7c0066980e3b8e1706a179964a5185fa4e58b83dc88dae838a
   md5: 5d8cb7e60e307faec0c647b3ea1bbf3c
   depends:
@@ -9385,7 +9385,7 @@ packages:
   license_family: LGPL
   size: 4158299
   timestamp: 1680110288508
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-hcd4344a_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libssh2-1.10.0-hcd4344a_2.tar.bz2
   sha256: 0b1460332f394557429f75c871c89ad27fc2ddadbeb28bfcff8d1d8537f493ac
   md5: 38e889ec253fe997be7f94556a0855d4
   depends:
@@ -9396,7 +9396,7 @@ packages:
   license_family: BSD
   size: 230554
   timestamp: 1686932558863
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -9413,7 +9413,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
   sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
   md5: ba9418df9288a2f031a02fa35b774ce0
   depends:
@@ -9429,7 +9429,7 @@ packages:
   license_family: BSD
   size: 78524
   timestamp: 1694778314659
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
   sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
   md5: b1781519a200ccbfcb4a1194005aa3ef
   depends:
@@ -9441,7 +9441,7 @@ packages:
   license_family: BSD
   size: 338459
   timestamp: 1694777084290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
   sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
   md5: 6ece7f1a3248169837714d05d7f6ef0a
   depends:
@@ -9453,7 +9453,7 @@ packages:
   license_family: MIT
   size: 3513910
   timestamp: 1692971505729
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libzip-1.8.0-h49b8836_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libzip-1.8.0-h49b8836_0.tar.bz2
   sha256: 0b4c8aa6e1fc2b82ce0b77c02e0e418764f94c3ea0bb18bea45a3cd265e3456f
   md5: a51d3646b5ae61f0b7f40b55650932be
   depends:
@@ -9468,7 +9468,7 @@ packages:
   license_family: BSD
   size: 102924
   timestamp: 1652977143101
-- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.37.0-py38h23ce68f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/llvmlite-0.37.0-py38h23ce68f_2.tar.bz2
   sha256: fba3b632cf668b5bd075ab9b51a36c525bf56a7bf8f89daf5d751a1be91d5fce
   md5: b60c389cfd24d07e6fec628377f228d3
   depends:
@@ -9479,7 +9479,7 @@ packages:
   license: BSD-2-Clause
   size: 17077766
   timestamp: 1646168931623
-- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py38haa95532_0.tar.bz2
   sha256: badc76eab56488df2cba6ac632fcf24223c4967628fe7bc061d8e2c0cd5aa362
   md5: 201617fddcaf95a08884560594e8d496
   depends:
@@ -9488,7 +9488,7 @@ packages:
   license_family: BSD
   size: 12848
   timestamp: 1652904166019
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
   sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
   md5: 6970c7f46b0164cad1d210e7a1419959
   depends:
@@ -9498,7 +9498,7 @@ packages:
   license_family: BSD
   size: 143434
   timestamp: 1670944902624
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mapclassify-2.5.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mapclassify-2.5.0-py38haa95532_0.tar.bz2
   sha256: 7098b87a0e8aebfbb541e2b522336ca50f8d1813ef24299675c692e58e627598
   md5: 62a504db888e934901882fcb3057fe14
   depends:
@@ -9512,7 +9512,7 @@ packages:
   license_family: BSD
   size: 66964
   timestamp: 1675157980619
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py38haa95532_0.tar.bz2
   sha256: 5e648ae3ef2e9d544accfd1cb16ee5081eb69fad94fc3dadd10c55244cddbfbb
   md5: bd2cc8c49b69abde1d55e6f2a1e636a2
   depends:
@@ -9522,7 +9522,7 @@ packages:
   license_family: BSD
   size: 142697
   timestamp: 1671542078827
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.0.1-py38h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.0.1-py38h2bbff1b_0.tar.bz2
   sha256: 823854ff0e034eab1b283d26d106848cd18b1f6343ac6286ac3208ca55263c5c
   md5: 437ca9e6eaaac0b79b5bf95ca548ba84
   depends:
@@ -9533,7 +9533,7 @@ packages:
   license_family: BSD
   size: 25638
   timestamp: 1621528394552
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.7.1-py38hf11a4ad_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.7.1-py38hf11a4ad_1.tar.bz2
   sha256: c065a29f28f81852178da631b01569ae95ca5880d71c6010f3a733693c60502f
   md5: 63e015949790fd18e5841c5a41f1395f
   depends:
@@ -9557,7 +9557,7 @@ packages:
   license_family: PSF
   size: 7916424
   timestamp: 1679594157296
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py38haa95532_0.tar.bz2
   sha256: 2a832b73527801756ce9c8e7a2e9d2f0aa7b0e39e764cb1699c45dc9db00d67b
   md5: dcede4303efc5efc488deed47d24f03a
   depends:
@@ -9567,7 +9567,7 @@ packages:
   license_family: BSD
   size: 17983
   timestamp: 1661934096957
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py38he774522_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py38he774522_1000.tar.bz2
   sha256: 598c0f203150ac3fbb846a7ac20739720e2a5c2905a838a8a5c5c28016c5ff0d
   md5: 3eba69328760ac88d22f975ef8a21ffc
   depends:
@@ -9578,7 +9578,7 @@ packages:
   license_family: BSD
   size: 55782
   timestamp: 1573488915385
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
   sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
   md5: 5e763c995ff0c549f68a10bce70fede4
   depends:
@@ -9590,7 +9590,7 @@ packages:
   license_family: Proprietary
   size: 187489950
   timestamp: 1691503804820
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py38h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py38h2bbff1b_1.tar.bz2
   sha256: 1377f4b52bc0f0059fc384cc0eb2451d8b9db27eb85587e27d93eb1061a1ca9b
   md5: 3389c1f1869f6b1e894390155f8fbbf7
   depends:
@@ -9602,7 +9602,7 @@ packages:
   license_family: BSD
   size: 49712
   timestamp: 1682974986419
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py38h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py38h2bbff1b_0.tar.bz2
   sha256: 8b57b0ddc34eeaabdf91274eab9ac758ebebb6436f3f43a7459139271ee2d0a0
   md5: 4c623b331a7301525e92a02b0490a616
   depends:
@@ -9617,7 +9617,7 @@ packages:
   license_family: BSD
   size: 185379
   timestamp: 1695058741315
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py38h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py38h59b6b97_0.tar.bz2
   sha256: ac93a9e5da11442058b30e89bb24447d311f067a5a98c36c85c7de9f420f25e1
   md5: 048f410489ce4250a215211619ee512e
   depends:
@@ -9632,7 +9632,7 @@ packages:
   license_family: BSD
   size: 258368
   timestamp: 1695060288659
-- conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py38h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/msgpack-python-1.0.3-py38h59b6b97_0.tar.bz2
   sha256: dd4f2c677361273de293da946ae55d811590bbadc4a1da75fe77204694821b86
   md5: 22a646f00d2aa14becfb7594dc1efde5
   depends:
@@ -9643,7 +9643,7 @@ packages:
   license_family: Apache
   size: 82740
   timestamp: 1652329410469
-- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py38_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py38_0.tar.bz2
   sha256: f88f8146f2efe5744d2c8c03bc8c7275693b57fbad85212369cc742d81bd37bf
   md5: d16e6b7628a2b9eab9a5d30e4bed09fe
   depends:
@@ -9653,7 +9653,7 @@ packages:
   license_family: BSD
   size: 23139
   timestamp: 1573470511265
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py38haa95532_0.tar.bz2
   sha256: fcbce71d792cd2b5159b9b99c2ef3a6e016e0849c748f6d03e210eb1211c2f22
   md5: d4017e1c56ecbc61f338627609766654
   depends:
@@ -9679,7 +9679,7 @@ packages:
   license_family: BSD
   size: 8136600
   timestamp: 1681757180070
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py38haa95532_0.tar.bz2
   sha256: 47472930a12c665040fe0f788513e4c02ee261b0a3a2f8ecbeea64339efa6462
   md5: 56e16967a9119349ba7e5faa1998db96
   depends:
@@ -9692,7 +9692,7 @@ packages:
   license_family: BSD
   size: 118191
   timestamp: 1650290459535
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.4.4-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-6.4.4-py38haa95532_0.tar.bz2
   sha256: 25d7081cd52160451d6bd6990a358166f6d4dbcd547f6e37bf052f527b65998e
   md5: d81e870a5f4f7074d936b1972e74cd98
   depends:
@@ -9717,7 +9717,7 @@ packages:
   license_family: BSD
   size: 595183
   timestamp: 1649741085987
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py38haa95532_0.tar.bz2
   sha256: ff232852ab31227eb44dc6979033beda77b30575e4a2a83e67be156412b04761
   md5: dbf1de3d5b7add1831c3177e873bdbff
   depends:
@@ -9730,7 +9730,7 @@ packages:
   license_family: BSD
   size: 166793
   timestamp: 1694617317115
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py38haa95532_0.tar.bz2
   sha256: 71cc4e07a33737c33bb876f480c0d792151d5cfeeb4e013575deed361ae056af
   md5: 96a76accee4fdda338e71972f498451e
   depends:
@@ -9739,7 +9739,7 @@ packages:
   license_family: BSD
   size: 13604
   timestamp: 1672387428069
-- conda: https://repo.anaconda.com/pkgs/main/win-64/netcdf4-1.6.2-py38hda396d2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/netcdf4-1.6.2-py38hda396d2_0.tar.bz2
   sha256: 8ce85bf1a5722fc4de42b1dfd806826704f18f51b9c7e1401fc97195c96b18bb
   md5: c9d67b4d0f8dfe81889c7edbf0f5024e
   depends:
@@ -9755,7 +9755,7 @@ packages:
   license_family: MIT
   size: 384517
   timestamp: 1673455579546
-- conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/networkx-3.1-py38haa95532_0.tar.bz2
   sha256: 58d6a41a7dc757e0ec4b5cb0e3a93424f0510ea774c0ae7c452be53cd85907c6
   md5: 3024f1424c64f44a3137022e89b584d2
   depends:
@@ -9764,7 +9764,7 @@ packages:
   license_family: BSD
   size: 2939681
   timestamp: 1690562319019
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py38haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py38haa95532_1.tar.bz2
   sha256: fcdb8b81e4c22e86c52833e5d389585c256991b3e295f0876d2f1771f069771d
   md5: b1819adf1ca6a6ce01733d80218cc34e
   depends:
@@ -9789,7 +9789,7 @@ packages:
   license_family: BSD
   size: 607570
   timestamp: 1690985910096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py38haa95532_0.tar.bz2
   sha256: e994d3c43d5bba7258fe31eb384dfa07e67c0cf71317730fc04490234ad6706a
   md5: 856ca9314f23c4e5e97f00982197c1ce
   depends:
@@ -9799,7 +9799,7 @@ packages:
   license_family: BSD
   size: 22446
   timestamp: 1668160865802
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.54.1-py38hf11a4ad_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numba-0.54.1-py38hf11a4ad_0.tar.bz2
   sha256: dd51b1d7adf281d8a703c4ae8dadec5c85c08bacc3450ea87cff444c4c660ee6
   md5: c33911946122eab4ac2b17c226513973
   depends:
@@ -9816,7 +9816,7 @@ packages:
   license_family: BSD
   size: 3903613
   timestamp: 1635186300704
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.4-py38h7b80656_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.4-py38h7b80656_1.tar.bz2
   sha256: 53088668bec0e25ce85dbb3aae9bf29b1fc90e2542360f5221e02acddf05cabc
   md5: 990126d16909922f9617be3081ec5d58
   depends:
@@ -9831,7 +9831,7 @@ packages:
   license_family: MIT
   size: 131075
   timestamp: 1683222215685
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.20.3-py38h749eb61_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.20.3-py38h749eb61_1.tar.bz2
   sha256: 0aef06bc7fee8b249b34acb25c1301beeb42df4895b8381f4b20f05c9df99fb9
   md5: bcf3de738b91fc8da6c3f8597b90bee8
   depends:
@@ -9847,7 +9847,7 @@ packages:
   license: BSD 3-Clause
   size: 9869
   timestamp: 1682979878313
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.20.3-py38h5bfbeaa_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.20.3-py38h5bfbeaa_1.tar.bz2
   sha256: 4f0f5bd9ad2786806a96813f0e1c8f1be9173052dfcc81b212660a75733cd0f2
   md5: 390712b9c9036c4284ac2ba5838f20d7
   depends:
@@ -9862,7 +9862,7 @@ packages:
   license: BSD 3-Clause
   size: 5545046
   timestamp: 1682979860287
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
   sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
   md5: ab07e2a27ac08afe3d0b4c0890b8486a
   depends:
@@ -9873,7 +9873,7 @@ packages:
   license: BSD 2-Clause
   size: 249316
   timestamp: 1630094024143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
   sha256: 0474e14823c734edc088bef98b829149a47ed8b4654f9638926c2fe4bbc40f38
   md5: a67d4a763641de641ea9dfa8c4a5f567
   depends:
@@ -9884,7 +9884,7 @@ packages:
   license_family: Apache
   size: 6048217
   timestamp: 1694466133007
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py38haa95532_0.tar.bz2
   sha256: d962a58032a618fbca7c201c54997e7802b60513c4d661b87377adb1ab46cb6f
   md5: c1c21c251676c124b761ae7a7a788051
   depends:
@@ -9893,7 +9893,7 @@ packages:
   license_family: Apache
   size: 72936
   timestamp: 1693575419691
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-1.3.5-py38h6214cd6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-1.3.5-py38h6214cd6_0.tar.bz2
   sha256: 044cf746c1c820278d783dcfe6caf04d505be2608c6417b2fc158192baf4e2a9
   md5: 97ec40ac994c23be8948576a17ba3a1d
   depends:
@@ -9909,7 +9909,7 @@ packages:
   license_family: BSD
   size: 11702008
   timestamp: 1641443603564
-- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/partd-1.4.0-py38haa95532_0.tar.bz2
   sha256: 2fae146a4f47684169b2298631f57907b0a5cb5bb394b6bfc2fba481e3180c1a
   md5: 663c3cd2871f89973a8a157f9168412f
   depends:
@@ -9923,7 +9923,7 @@ packages:
   license_family: BSD
   size: 35211
   timestamp: 1693938085776
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pcre-8.45-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pcre-8.45-hd77b12b_0.tar.bz2
   sha256: ac2cd0e402baa915540cb15f57cf631a5af0cfe9036e6028add041c703a15320
   md5: 67c3599c838a8433fcfa8b7c034e8f20
   depends:
@@ -9933,7 +9933,7 @@ packages:
   license_family: BSD
   size: 507009
   timestamp: 1624478466152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pcre2-10.37-h0ff8eda_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pcre2-10.37-h0ff8eda_1.tar.bz2
   sha256: 9090e0360b59ce9ac59fa3f280fbc3cdc1821512f44cfa81fc1dd088c1869ddb
   md5: 1f4f9e2b96b1b1eb957b385de97c1d29
   depends:
@@ -9945,7 +9945,7 @@ packages:
   license_family: BSD
   size: 636679
   timestamp: 1641404048934
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py38h045eedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py38h045eedc_0.tar.bz2
   sha256: 432e6a6b53fa484a8bf5b3e898f5ed8caba5815b553d94db77620eac98d2f099
   md5: a6e9aa6452576aa3e697bdd3a6071b71
   depends:
@@ -9964,7 +9964,7 @@ packages:
   license_family: Other
   size: 806349
   timestamp: 1696580503229
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-23.3-py38haa95532_0.tar.bz2
   sha256: 6f59998aee706ab1de04d3f9ac2e4c859d379cde2913fc38ae4dc0d2e9b21238
   md5: 8f3809e14a26a9efa61c331a17653f3e
   depends:
@@ -9975,7 +9975,7 @@ packages:
   license_family: MIT
   size: 2999532
   timestamp: 1697548952949
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pixman-0.40.0-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pixman-0.40.0-h2bbff1b_1.tar.bz2
   sha256: 20923fa2937cde57e8d2f5d67391b37eef349a9e3f5ff589bc75fb3dd3e0074f
   md5: c62f32977c25875ced94e930d942db6b
   depends:
@@ -9984,7 +9984,7 @@ packages:
   license: MIT
   size: 497111
   timestamp: 1632711499953
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pkgutil-resolve-name-1.3.10-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pkgutil-resolve-name-1.3.10-py38haa95532_0.tar.bz2
   sha256: 63162f67b25860cac18a2c5e1701d0d39bb8db2b42f49a0f591c811181acea83
   md5: 33eee18c2582142bcf2fd33275134022
   depends:
@@ -9993,7 +9993,7 @@ packages:
   license_family: PSF
   size: 10410
   timestamp: 1661463539879
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py38haa95532_0.tar.bz2
   sha256: d9bdf22a0141d5d3e4e1455a93ecd6680980786b5fcd5516773217403057d389
   md5: 10961e0b088c531ddeafb3c4c278b8b5
   depends:
@@ -10002,7 +10002,7 @@ packages:
   license_family: MIT
   size: 32378
   timestamp: 1692205706184
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pooch-1.7.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pooch-1.7.0-py38haa95532_0.tar.bz2
   sha256: 269095712af2adf8aa3a1b5532596b7b19b3222d3b062f5af466ee5b423b854f
   md5: 6f17c938b517964b61675589037c6e36
   depends:
@@ -10018,7 +10018,7 @@ packages:
   license_family: BSD
   size: 81717
   timestamp: 1695850480881
-- conda: https://repo.anaconda.com/pkgs/main/win-64/poppler-22.12.0-h0bf3bde_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/poppler-22.12.0-h0bf3bde_3.tar.bz2
   sha256: 03fa4c3b0fc491cfc4736272a8a07b111255aee8029359ecc315e3253b20b977
   md5: deecd5672f83b496fddc7d797c491626
   depends:
@@ -10042,14 +10042,14 @@ packages:
   license_family: GPL
   size: 2826813
   timestamp: 1696001451072
-- conda: https://repo.anaconda.com/pkgs/main/win-64/poppler-data-0.4.11-haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/poppler-data-0.4.11-haa95532_1.tar.bz2
   sha256: 48c7975e4777318317369fe480f75531534cb8933a3e4de97cddf778a12f96dd
   md5: fc41b46e1055778a44677d2e0e97fe32
   license: GPL-2.0-or-later and GPL-3.0-or-later and BSD-3-Clause
   license_family: GPL
   size: 478379
   timestamp: 1673863618032
-- conda: https://repo.anaconda.com/pkgs/main/win-64/postgresql-12.15-hb652d5d_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/postgresql-12.15-hb652d5d_1.tar.bz2
   sha256: c5652e73142e3d90eb8d4ec7260febc0648e7ad9b7b4e0118300a4861160c1f1
   md5: 33c283fe8c4a9244729117e47a988bb2
   depends:
@@ -10061,7 +10061,7 @@ packages:
   - zlib >=1.2.13,<2.0.0a0
   size: 21968437
   timestamp: 1687383026031
-- conda: https://repo.anaconda.com/pkgs/main/win-64/proj-6.2.1-h3758d61_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/proj-6.2.1-h3758d61_0.tar.bz2
   sha256: 9cb0179c1caa52c3d7f72de80b961242efc92be8bd400b31143ebfc331f06bf6
   md5: f96fc9eec2355b3f566da8482185e4c0
   depends:
@@ -10073,7 +10073,7 @@ packages:
   license: MIT
   size: 8844536
   timestamp: 1643034508527
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py38haa95532_0.tar.bz2
   sha256: 62980fe41fb61641ff3a92bc46769c221e216d7b1b052624cca35cd6442e67a3
   md5: ceb8f341d88581897417b74581824ce5
   depends:
@@ -10082,7 +10082,7 @@ packages:
   license_family: Apache
   size: 90902
   timestamp: 1659455380536
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py38haa95532_0.tar.bz2
   sha256: 4b8a2b4c9060ee4c2870cd677e04020af7a7e6bd20201d548937246bd445f047
   md5: ba6637b69b09fac0ae052441137ef3f4
   depends:
@@ -10094,7 +10094,7 @@ packages:
   license_family: BSD
   size: 580833
   timestamp: 1672388085790
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py38h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py38h2bbff1b_0.tar.bz2
   sha256: 3f30894e9e48919717e4836d41d37fe94067c41f2714982d5b09041e8d03c625
   md5: 715eca27ac0ea2d6e5b9781ece861045
   depends:
@@ -10105,7 +10105,7 @@ packages:
   license_family: BSD
   size: 372631
   timestamp: 1656431598029
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py38haa95532_0.tar.bz2
   sha256: b6cd1020f33142369e4e5e3011fc52b761067feae88ef2faed1dd38921eea160
   md5: 89f633e2fe32f8964414004f4bf69a50
   depends:
@@ -10117,7 +10117,7 @@ packages:
   license_family: BSD
   size: 48367
   timestamp: 1675450405375
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py38haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py38haa95532_1.tar.bz2
   sha256: c99df0ff588b6cc027003901719fafcca53c7d5982224d10adafb0eba5d62f76
   md5: ea6a5a355c3e39e2d5e03418cf1c359f
   depends:
@@ -10126,7 +10126,7 @@ packages:
   license_family: BSD
   size: 1902776
   timestamp: 1684280088005
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py38haa95532_0.tar.bz2
   sha256: e3d8188a43ecb46e09895049962c12e4812973a8b5cc9bf40536bf30d94114e1
   md5: 30b5451442b0e7fbaa8c2e32b10a7a87
   depends:
@@ -10136,7 +10136,7 @@ packages:
   license_family: Apache
   size: 95013
   timestamp: 1690225579051
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py38haa95532_0.tar.bz2
   sha256: 0338ad6cc3998c5adc325f9df5916a84d9462176c060160b15bf016cd78df4c6
   md5: 7ac4db0e1a670a061b08208f6e819bb0
   depends:
@@ -10145,7 +10145,7 @@ packages:
   license_family: MIT
   size: 157552
   timestamp: 1661452635483
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyproj-2.6.1.post1-py38h593ac45_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyproj-2.6.1.post1-py38h593ac45_1.tar.bz2
   sha256: d5a483b023eaa9f6134c0893684b7d97684c4ef5a9a1956a97989d6b5325d25c
   md5: 0910fdf2951d77e03ae259e6cf40e07f
   depends:
@@ -10156,7 +10156,7 @@ packages:
   license: MIT
   size: 382998
   timestamp: 1614278213539
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py38h196d8e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py38h196d8e1_0.tar.bz2
   sha256: 839fdd83dbde870e40fd61d0157c9d3b58bbbe54b48dfb92004ed7878e8e0f52
   md5: f659bb4f74cbf970f9afb502cc9b399d
   depends:
@@ -10167,7 +10167,7 @@ packages:
   license_family: MIT
   size: 92785
   timestamp: 1636111597883
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py38haa95532_0.tar.bz2
   sha256: 9bf258afe075dd22aa6e33b71b122126eaeb1001906b5df614b2e81e88e17ddf
   md5: ca4e90d9e382f0033230a67499d51239
   depends:
@@ -10177,7 +10177,7 @@ packages:
   license_family: BSD
   size: 31587
   timestamp: 1605287884076
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.8.18-h6244533_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.8.18-h6244533_0.tar.bz2
   sha256: 91fe00fa9abb019a70c68be5a39887972a77473805abf160be8274ec3e8f5ea8
   md5: f4f6d4b6bb55b19eda46f2fc79288f10
   depends:
@@ -10190,7 +10190,7 @@ packages:
   license_family: PSF
   size: 22819210
   timestamp: 1694440319269
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py38haa95532_0.tar.bz2
   sha256: c3414f6a87ec84473869ac5821a62369f374b1df33def55a6d6487fd863ad56d
   md5: 7d51837a0deed7e1f8a410a2851ac755
   depends:
@@ -10199,7 +10199,7 @@ packages:
   license_family: BSD
   size: 269239
   timestamp: 1661376763966
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py38hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-lmdb-1.4.1-py38hd77b12b_0.tar.bz2
   sha256: cd4788fdafa155d2bb3b7159cc4f031370c9caab7b006b6afab11881f7fa9d3c
   md5: 83b3e3d6f925636bb2a0be77ae8b9d5c
   depends:
@@ -10210,7 +10210,7 @@ packages:
   license_family: Other
   size: 135460
   timestamp: 1682522629966
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py38haa95532_0.tar.bz2
   sha256: 5769ae7494f0298428d44e545fa4e29064c13cd546c3ffcd9324968c04c47862
   md5: 5b6b41bf0ff90b3e49ca04db5200707d
   depends:
@@ -10219,7 +10219,7 @@ packages:
   license_family: MIT
   size: 266165
   timestamp: 1695132007791
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py38haa95532_0.tar.bz2
   sha256: 5a516966dfa1bcd8df4413bb885f1f9ad30e2bdd49281bf825048b4ac51d6e8a
   md5: afa17e8c3e04681729286239700c293e
   depends:
@@ -10229,7 +10229,7 @@ packages:
   license_family: BSD
   size: 40311
   timestamp: 1685030879273
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py38h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py38h2bbff1b_0.tar.bz2
   sha256: d240e28ed9a4811cfc05231c91bf802759fcf62b3e7f204301033c957a6fd4fe
   md5: 5ed775395d75942dce0868bfcabeb62f
   depends:
@@ -10239,7 +10239,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13563755
   timestamp: 1669938230510
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py38h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py38h5da7b33_0.tar.bz2
   sha256: 0837ed20156196759f729786bf50d71f17d04259e4eba815015567879659ea54
   md5: e7ba4d7e36f0992af849c36116e4a6e9
   depends:
@@ -10251,7 +10251,7 @@ packages:
   license_family: MIT
   size: 239545
   timestamp: 1677611005756
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py38h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py38h2bbff1b_0.tar.bz2
   sha256: aa56d1d94abca5574bb8ec93c7438e9ba2262900342bb0b8de214526a211963e
   md5: 4af07057db56d4b735e45106276d148c
   depends:
@@ -10263,7 +10263,7 @@ packages:
   license_family: MIT
   size: 158294
   timestamp: 1698096182750
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py38hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py38hd77b12b_0.tar.bz2
   sha256: a9f77cc518cab258a8e0666ca7c6b5ee3c9a03908c764ed6383ea8af3d21da20
   md5: 84ed5b56ff20c3c08be5891e15b2ec20
   depends:
@@ -10275,7 +10275,7 @@ packages:
   license_family: BSD
   size: 478983
   timestamp: 1657616120754
-- conda: https://repo.anaconda.com/pkgs/main/win-64/qhull-2020.2-h59b6b97_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/qhull-2020.2-h59b6b97_2.tar.bz2
   sha256: 5d677c17afe37f24eb30f143fccf45450d81929227869256a277a66dd9a36325
   md5: 09ec672a48cc028863ef171fc8c5d418
   depends:
@@ -10285,7 +10285,7 @@ packages:
   license_family: Other
   size: 2338798
   timestamp: 1670915907181
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py38haa95532_0.tar.bz2
   sha256: 533172b07694e5f3bc8934fb77dded69c58be5b39831e28db73c0c0fcb4dedd8
   md5: 6a9975521209c95da6f71f4e1c3de96c
   depends:
@@ -10301,7 +10301,7 @@ packages:
   license_family: Apache
   size: 94333
   timestamp: 1690400706451
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rtree-1.0.1-py38h2eaa2aa_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rtree-1.0.1-py38h2eaa2aa_0.tar.bz2
   sha256: 9a6e7b73f09902586fb55249901373880e090c6932df63ca88b56ce1d3737d9b
   md5: 0f3ddae4fa0f4d289f5de6eaf54286ed
   depends:
@@ -10312,7 +10312,7 @@ packages:
   license_family: MIT
   size: 49908
   timestamp: 1675158069235
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scikit-learn-1.2.2-py38hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/scikit-learn-1.2.2-py38hd77b12b_0.tar.bz2
   sha256: bde25890660eeddea42854cf9c234c38129a7fb39b511827d48e3a199c82f555
   md5: 196ae5b5c42127b278a8141fa417958a
   depends:
@@ -10327,7 +10327,7 @@ packages:
   license_family: BSD
   size: 8133812
   timestamp: 1680205309832
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.10.1-py38hdcfc7df_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/scipy-1.10.1-py38hdcfc7df_1.tar.bz2
   sha256: bf0f58b61e8e18aa58f5bdf025e8ee649c778b8be27c5f5ddff495add793ad93
   md5: 09fa3db77bb4c0e9d4349268215dd515
   depends:
@@ -10347,7 +10347,7 @@ packages:
   license_family: BSD
   size: 22338144
   timestamp: 1683289522517
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py38haa95532_0.tar.bz2
   sha256: 9d9cea2d4a0c0bb8753b2749cb1abbc3d893eab2cb0bcf17405f5e01856e3e0c
   md5: ddd72dc387cefe69ec31c93c43f6958d
   depends:
@@ -10356,7 +10356,7 @@ packages:
   license_family: MIT
   size: 1099170
   timestamp: 1690291042913
-- conda: https://repo.anaconda.com/pkgs/main/win-64/shapely-2.0.1-py38hd7f5953_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/shapely-2.0.1-py38hd7f5953_0.tar.bz2
   sha256: fd756d3e5489f5140f6bb2cab97534b2e32ce1c49fb100ee3e948a1c76b237c6
   md5: d9a5aa3e5281cf9cfb5b92fca79c31fa
   depends:
@@ -10369,7 +10369,7 @@ packages:
   license_family: BSD
   size: 433564
   timestamp: 1680636417778
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py38haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py38haa95532_1.tar.bz2
   sha256: 23df5da4b5c41e12f2bf8181d2de18b30f9ceb2453ec669f4c9fe182380d5099
   md5: cb8e70978aba600c5092aa202d960f2a
   depends:
@@ -10378,7 +10378,7 @@ packages:
   license_family: Apache
   size: 15975
   timestamp: 1614030758438
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py38haa95532_0.tar.bz2
   sha256: 3a2bdd00f7f0fa19d73a8875e9f004cae98d3fa27f36c59cd4567f3282944e11
   md5: ccdd22fbfe632c7ffea52096483b2165
   depends:
@@ -10387,7 +10387,7 @@ packages:
   license_family: MIT
   size: 67208
   timestamp: 1696347669660
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
   sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
   md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
   depends:
@@ -10397,7 +10397,7 @@ packages:
   license_family: Other
   size: 1311308
   timestamp: 1681402905668
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -10407,7 +10407,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py38haa95532_0.tar.bz2
   sha256: d14d51a32e509950bb85e78c35dceed18cbeb223ec3e9e224e0d22d65e3461ae
   md5: 85fd7e0f17c59be2e562bebb896aa5a5
   depends:
@@ -10418,7 +10418,7 @@ packages:
   license_family: BSD
   size: 30613
   timestamp: 1671751910139
-- conda: https://repo.anaconda.com/pkgs/main/win-64/testpath-0.6.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/testpath-0.6.0-py38haa95532_0.tar.bz2
   sha256: 02df5aa5e16fa80d9bdc98607d418cc29f0f30616576ab01245db51d541232a6
   md5: c65c64ca1fb63d1cd355593a786c463e
   depends:
@@ -10427,7 +10427,7 @@ packages:
   license_family: BSD
   size: 94054
   timestamp: 1655908671820
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tiledb-2.3.3-h3649cd2_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tiledb-2.3.3-h3649cd2_2.tar.bz2
   sha256: ab11ec98f8198a47fde327726815112f717964039bec03b2090b1c52cf1dbd87
   md5: 6dd0fc1e3f661e96ed6f45f05ec91686
   depends:
@@ -10441,7 +10441,7 @@ packages:
   license_family: MIT
   size: 2568834
   timestamp: 1655305467392
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
   sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
   md5: 52cdcdb96383c010ca833a7c24b3935b
   depends:
@@ -10451,7 +10451,7 @@ packages:
   license_family: BSD
   size: 3690152
   timestamp: 1654036853710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py38haa95532_0.tar.bz2
   sha256: 8d7efb76d1afa3e7e4491e8496f46257bbee2eaf233549ca841f1bcbe4194489
   md5: e085f8c809e8c4296756e411b7ffa598
   depends:
@@ -10460,7 +10460,7 @@ packages:
   license_family: BSD
   size: 102335
   timestamp: 1667464250061
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py38h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py38h2bbff1b_0.tar.bz2
   sha256: f6813a60d8e7c33594685c273ffe5aa21150c4d012b639eea8fb3d87348849c0
   md5: 45f4b3e1d6c27dcaccc3f9e979cc6db3
   depends:
@@ -10471,7 +10471,7 @@ packages:
   license_family: Apache
   size: 680736
   timestamp: 1696937110611
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py38hd4e2768_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py38hd4e2768_0.tar.bz2
   sha256: f375977bd3677a51b5a0d1364ff22da9fba5b53999dd425423971c7aa940fffb
   md5: b1fe53809d11bf264402a8253ddd9145
   depends:
@@ -10485,7 +10485,7 @@ packages:
   license_family: MOZILLA
   size: 143474
   timestamp: 1679562394410
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py38haa95532_0.tar.bz2
   sha256: 9b45e11b7720e697c2a0b51046f460007a2b806a38f6dd3d04114cd5232dc714
   md5: a4cdc25c1dcbae810913de1be3828d08
   depends:
@@ -10494,7 +10494,7 @@ packages:
   license_family: BSD
   size: 192543
   timestamp: 1671143951537
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py38haa95532_0.tar.bz2
   sha256: c534e38eba3f4be51c2a008881713e6805b40f14a9187fbc33bcd8f2c32b3175
   md5: 0223b0eb7c46d88613a7be653bd868e3
   depends:
@@ -10504,7 +10504,7 @@ packages:
   license_family: PSF
   size: 9209
   timestamp: 1690297886768
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py38haa95532_0.tar.bz2
   sha256: 6a12cdeb628f07650a6b35dcc69bbee9c16e8143a21117939f98524700ea8522
   md5: 640032b60ddb37f74bbf62e81e8d38e7
   depends:
@@ -10513,7 +10513,7 @@ packages:
   license_family: PSF
   size: 58090
   timestamp: 1690297874460
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uriparser-0.9.7-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uriparser-0.9.7-h2bbff1b_0.tar.bz2
   sha256: f88e04209064e9a72fccc9284271405d9548106c2bf302e24fa1e8e8bb36a127
   md5: 8845191f3242c429e10220e3ed9ee73c
   depends:
@@ -10523,7 +10523,7 @@ packages:
   license_family: BSD
   size: 48486
   timestamp: 1692187056029
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py38haa95532_0.tar.bz2
   sha256: f864ed1dfb0e99339810a81b31b82e907791921cc2cc63ad0d24de214d4b96c2
   md5: 0f1d33693bc8a20a8a07db135c465524
   depends:
@@ -10538,7 +10538,7 @@ packages:
   license_family: MIT
   size: 188202
   timestamp: 1698257739300
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
   sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
   md5: 45ef24c486a484f079faf1dc90e4c7e9
   depends:
@@ -10547,12 +10547,12 @@ packages:
   license_family: BSD
   size: 8277
   timestamp: 1605602889180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
   sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
   md5: 4daaceb6cfc1af6274509081d8018ef1
   size: 2316783
   timestamp: 1605602872095
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py38_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py38_1.tar.bz2
   sha256: 40b0596a8728dd040d7afef235a73b20909f92fbe9a9ef202f3e5256d047bbdc
   md5: 492eeefe2b9f3274156a1b37699ea90e
   depends:
@@ -10561,7 +10561,7 @@ packages:
   license_family: BSD
   size: 20563
   timestamp: 1573199884688
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py38haa95532_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py38haa95532_4.tar.bz2
   sha256: 1f63ed0a34f6f82b24aacdb58981d706637148ec7809fed682c5be1c7f140aeb
   md5: 69b1c046853ea5dbb22891d693edba80
   depends:
@@ -10571,7 +10571,7 @@ packages:
   license_family: BSD
   size: 73415
   timestamp: 1614804523375
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py38haa95532_0.tar.bz2
   sha256: c7ab632355c3342435277a8a4bef6d659c703c9ce30e12a47adf80d7af2d6e7c
   md5: 72735ff308add1052ff64b94c6130810
   depends:
@@ -10580,7 +10580,7 @@ packages:
   license_family: MIT
   size: 120710
   timestamp: 1695742221226
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py38haa95532_0.tar.bz2
   sha256: e07f40fc2c8751784dba016e68ef289ae997bf018a773e71d83b23e1e30a55f3
   md5: 749ad2e1134684ca10f25aa30a35864b
   depends:
@@ -10588,13 +10588,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 34107
   timestamp: 1605306214957
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2022.11.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xarray-2022.11.0-py38haa95532_0.tar.bz2
   sha256: bbd799a929cfc29f95c6fc46c08d1939c87edc8fa0e96ba89ce44ce65f95479e
   md5: 4fcbc4128904506d54b173b01c6f7659
   depends:
@@ -10606,7 +10606,7 @@ packages:
   license_family: Apache
   size: 1727670
   timestamp: 1668777347091
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xerces-c-3.2.4-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xerces-c-3.2.4-hd77b12b_1.tar.bz2
   sha256: 2160b68a45de4b20ce5e63ba06a0db91913e325e5b796ef9f40d38bd2bb8260d
   md5: a6d582169295a9de869f242530796475
   depends:
@@ -10616,7 +10616,7 @@ packages:
   license_family: Apache
   size: 4221569
   timestamp: 1692995399482
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py38haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py38haa95532_1.tar.bz2
   sha256: 79a0c08ff87f51a742b9a0cb668482035a5b8b94bb9a651cd0242da916a23125
   md5: a8b49e46e8f6ccb6fc3e2e17a41764a6
   depends:
@@ -10625,7 +10625,7 @@ packages:
   license_family: BSD
   size: 48792
   timestamp: 1675159225274
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
   sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
   md5: c3f7871e9a33adeccee1b1e8e216918e
   depends:
@@ -10635,7 +10635,7 @@ packages:
   license_family: GPL2
   size: 1332571
   timestamp: 1683113347814
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -10644,7 +10644,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
   sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
   md5: 1ab55f8c4b5292ec360c572120bf823e
   depends:
@@ -10654,7 +10654,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 9430705
   timestamp: 1616055773485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zict-3.0.0-py38haa95532_0.tar.bz2
   sha256: 02aeb80c081705443df2555d6025dd2b49b01ceef49515998a18fd83cc5eaf0a
   md5: 6bbba9816851fd3ca6bcbb21528c59bd
   depends:
@@ -10665,7 +10665,7 @@ packages:
   license_family: BSD
   size: 76700
   timestamp: 1695833271895
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py38haa95532_0.tar.bz2
   sha256: 2cfcbb95a94a42777c57ce0d95533f0228225c264e79b157278266452c6e1afa
   md5: 86e9fe129facd043d463fcf8f3ce802d
   depends:
@@ -10674,7 +10674,7 @@ packages:
   license_family: MIT
   size: 18673
   timestamp: 1672387667602
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
   sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
   md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
   depends:
@@ -10684,7 +10684,7 @@ packages:
   license_family: Other
   size: 148931
   timestamp: 1666595229032
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
   sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
   md5: 8d6a1e767775fe0eb617cd6e22edc2ff
   depends:

--- a/bay_trimesh/pixi.lock
+++ b/bay_trimesh/pixi.lock
@@ -1,0 +1,10699 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py38h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.4.57-he6710b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.1.6-h2531618_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.9-he6710b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.8.185-hce553d0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.3.3-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py38hce1f21e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/branca-0.6.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py38heb0550a_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.18.1-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cairo-1.16.0-h19f5f5c_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cartopy-0.18.0-py38h0d9ca2b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py38hd667e15_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cfitsio-3.470-hf0d0db6_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cftime-1.5.1.1-py38hce1f21e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py38h130f0dd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/curl-7.82.0-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.11.0-py38h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py38h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py38h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2021.10.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fiona-1.8.13.post1-py38hc820daa_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/folium-0.14.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freexl-1.0.6-h27cfd23_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gdal-3.0.2-py38h2c27f0e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/geopandas-0.12.2-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/geopandas-base-0.12.2-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/geos-3.8.0-he6710b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/geotiff-1.7.0-hd69d5b1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf4-4.2.13-h3ca952b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf5-1.10.6-hb1b8bf9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.1.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py38hb070fc8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.12.2-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py38h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/joblib-1.2.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/json-c-0.13.1-h1bed415_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kealib-1.4.14-hb50703a_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py38h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.19.2-hac12032_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.73.0-h3ff78a5_11.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-7.82.0-h0b77cf5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdap4-3.19.1-h6ec2957_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20210910-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgdal-3.0.2-he6cead7_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libkml-1.3.0-h7ecb851_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.0.0-h3826bc1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnetcdf-4.8.1-h42ceab0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.46.0-hce63b2e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpq-12.9-hc2c5182_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libspatialindex-1.9.3-h2531618_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libspatialite-4.3.0a-hbedb2dc_20.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-h8f2d780_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h85742a9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libzip-1.5.1-h8d318fa_1004.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.37.0-py38h295c915_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mapclassify-2.5.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.0.1-py38h27cfd23_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py38ha18d171_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py38h7b6447c_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py38h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py38hd3c417c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py38h51133e4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py38hd09550d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py38_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.4.4-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/netcdf4-1.5.7-py38ha0f2276_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py38h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.54.1-py38h51133e4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py38h6abb31d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.20.3-py38hf144106_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.20.3-py38h74d4b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.3.5-py38h8c16a72_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py38h22f2fdc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pixman-0.40.0-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pkgutil-resolve-name-1.3.10-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/poppler-0.81.0-h01f5e8b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/poppler-data-0.4.11-h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/proj-6.2.1-h05a3930_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py38h27cfd23_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py38h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyproj-2.6.1.post1-py38hb3025e9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py38heee7806_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.8.13-h12debd9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.2.1-py38h2531618_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py38h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py38h295c915_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rtree-1.0.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scikit-learn-1.0.2-py38h51133e4_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.6.2-py38had2a1c9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/shapely-1.7.1-py38h1728cc4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py38h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/testpath-0.6.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tiledb-2.2.9-hffe1d7a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py38h27cfd23_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py38hb070fc8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.18-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py38_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py38h06a4308_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2022.11.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xerces-c-3.2.3-h780794e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py38h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.4.9-haebb681_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/click-7.1.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2021.10.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2021.10.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/geoviews-1.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/geoviews-core-1.9.1-pyh06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.6-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munch-2.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyshp-2.1.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/threadpoolctl-2.2.0-pyh0d69192_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2021.10.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2021.10.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/geoviews-1.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/geoviews-core-1.9.1-pyh06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.6-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munch-2.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyshp-2.1.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/threadpoolctl-2.2.0-pyh0d69192_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py38hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py38hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.3.3-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.73.0-hca72f7f_12.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py38h67323c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/branca-0.6.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py38he9d5cce_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cairo-1.16.0-h3ce6f7e_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cartopy-0.18.0-py38hf1ba7ce_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py38h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cftime-1.6.2-py38hacda100_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py38haf03e11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py38ha2381d6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/curl-8.2.1-hdb2fb19_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.0-py38hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py38hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py38hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2021.10.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/expat-2.5.0-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fiona-1.9.1-py38h07fba90_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/folium-0.14.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fontconfig-2.14.1-hb0a0c50_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freexl-1.0.6-h9ed2024_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gdal-3.6.2-py38h09faefc_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/geopandas-0.12.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/geopandas-base-0.12.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/geos-3.8.0-hb1e8313_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/geotiff-1.7.0-hf6ff7a4_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gettext-0.21.0-he85b6c0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/glib-2.69.1-hfff2838_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf4-4.2.13-h39711bb_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf5-1.10.6-h10fe05b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-58.2-h0a44026_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py38h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.12.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py38hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/joblib-1.2.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/json-c-0.16-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kealib-1.5.0-h72c422f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py38hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.73.0-h3fa6bed_12.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20221030-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgdal-3.6.2-hd170585_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libkml-1.3.0-h85bf17e_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm11-11.0.0-h46f1229_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnetcdf-4.8.1-ha5d86b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpq-12.15-hdb2fb19_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libspatialindex-1.9.3-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libspatialite-4.3.0a-hd1e8275_23.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h930c0e2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libzip-1.8.0-h272c8d6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.37.0-py38hc9110bb_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mapclassify-2.5.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.0.1-py38h9ed2024_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.7.1-py38hda11e5a_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py38h1de35cc_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py38h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py38h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py38ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py38haf03e11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py38_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.4.4-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/netcdf4-1.6.2-py38hd243f81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py38hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nspr-4.35-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nss-3.89.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.54.1-py38hae1ba45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.4-py38h47b59a4_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.20.3-py38h57dabd6_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.20.3-py38h34da072_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-1.3.5-py38h743cdd8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pcre-8.45-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pcre2-10.37-he7042d7_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py38h7d39338_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pixman-0.40.0-h9ed2024_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pkgutil-resolve-name-1.3.10-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pooch-1.7.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/poppler-22.12.0-ha8a1649_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/poppler-data-0.4.11-hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/postgresql-12.15-h8aab74b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/proj-6.2.1-hfd5b9e3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py38hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py38hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyproj-2.6.1.post1-py38hdfdfadc_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py38hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py38_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.8.18-h218abb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py38hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py38h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py38he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/qhull-2020.2-ha357a0b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rtree-1.0.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scikit-learn-1.2.2-py38hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.10.1-py38hf241641_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/shapely-2.0.1-py38h797b0b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py38hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/testpath-0.6.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tiledb-2.3.3-h74f4c1e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py38h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py38h01d92e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uriparser-0.9.7-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py38_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py38hecd8cb5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2022.11.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xerces-c-3.2.4-hd2b157f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py38hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2021.10.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2021.10.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/geoviews-1.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/geoviews-core-1.9.1-pyh06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.6-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munch-2.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyshp-2.1.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/threadpoolctl-2.2.0-pyh0d69192_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/xarray-0.20.1-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py38hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py38h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-2.3.3-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.73.0-h1a28f6b_12.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py38heec5a64_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/branca-0.6.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py38hc377ac9_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cairo-1.16.0-h302bd0f_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cartopy-0.21.1-py38hf94de1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py38h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cftime-1.6.2-py38hb08c31d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py38h3c57c4d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.0-py38h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py38hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py38h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2021.10.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/expat-2.5.0-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fftw-3.3.9-h1a28f6b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fiona-1.9.1-py38h78102c4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/folium-0.14.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fontconfig-2.14.1-hee714a5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freexl-1.0.6-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gdal-3.6.2-py38h92c4280_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geopandas-0.12.2-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geopandas-base-0.12.2-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geos-3.9.1-hc377ac9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geotiff-1.7.0-h41f0982_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-0.21.0-h13f89a0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glib-2.69.1-h514c7bf_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf4-4.2.13-h5e329fb_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf5-1.12.1-h160e8cb_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-68.1-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py38h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.12.2-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py38hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/joblib-1.2.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/json-c-0.16-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kealib-1.5.0-hba2eb73_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py38h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.73.0-h49e8a49_12.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20221030-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgdal-3.6.2-h50c47ba_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libkml-1.3.0-hc4d7c42_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm11-11.1.0-h12f7ac0_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnetcdf-4.8.1-ha022005_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpq-12.15-h449679c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libspatialindex-1.9.3-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libspatialite-4.3.0a-h4707d77_23.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h372ba2a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzip-1.8.0-h0c481fb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.37.0-py38h8b39d70_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mapclassify-2.5.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.0.1-py38h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.5.0-py38h9197a36_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py38h1a28f6b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py38h525c30c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.4.4-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/netcdf4-1.6.2-py38h053bab8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py38hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nspr-4.35-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nss-3.89.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.54.0-py38hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.4-py38h79ee842_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.19.5-py38h831b0dc_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.19.5-py38hdc56644_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-1.3.5-py38h9197a36_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre-8.45-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre2-10.37-h37e8eca_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py38h3b245a6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pixman-0.40.0-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pkgutil-resolve-name-1.3.10-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pooch-1.7.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/poppler-22.12.0-h52f4003_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/poppler-data-0.4.11-hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/postgresql-12.15-h1ae2815_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/proj-7.2.0-heac154c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py38h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py38hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyproj-3.1.0-py38hfce2bd4_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py38h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.8.18-hc0d8a6c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py38h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py38h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py38hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/qhull-2020.2-h48ca7d4_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rtree-1.0.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scikit-learn-1.2.2-py38h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.10.0-py38h9d039d2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/shapely-2.0.1-py38h9ca3c36_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py38hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/testpath-0.6.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tiledb-2.3.3-h3ad0f7e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py38h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py38h86d0a89_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uriparser-0.9.7-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py38hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py38hca03da5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xerces-c-3.2.4-h389e118_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py38hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2021.10.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2021.10.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/geoviews-1.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/geoviews-core-1.9.1-pyh06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.6-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munch-2.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyshp-2.1.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/threadpoolctl-2.2.0-pyh0d69192_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py38h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-2.3.3-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py38h080aedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/branca-0.6.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py38hd77b12b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cairo-1.16.0-haedb8bc_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cartopy-0.18.0-py38h80a4efb_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py38h2bbff1b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cftime-1.6.2-py38h080aedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py38h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py38h3438e0d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/curl-8.4.0-he2ea4bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.0-py38h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py38haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py38hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2021.10.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/expat-2.5.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fiona-1.9.1-py38hf11a4ad_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/folium-0.14.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fontconfig-2.14.1-h9c4af85_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freexl-1.0.6-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/gdal-3.6.2-py38h9eae49a_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/geopandas-0.12.2-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/geopandas-base-0.12.2-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/geos-3.8.0-h33f27b4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/geotiff-1.7.0-h4545760_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/glib-2.69.1-h5dc1a3c_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/hdf4-4.2.13-h712560f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/hdf5-1.10.6-h1756f20_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icu-58.2-ha925a31_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py38h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.12.2-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py38haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/joblib-1.2.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kealib-1.5.0-hde4a422_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py38hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.4.0-h86230a5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libgdal-3.6.2-h11d7215_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libkml-1.3.0-h63940dd_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libnetcdf-4.8.1-h6685c40_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.15-hb652d5d_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libspatialindex-1.9.3-h6c2663c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libspatialite-4.3.0a-h6ec8781_23.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-hcd4344a_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libzip-1.8.0-h49b8836_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.37.0-py38h23ce68f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mapclassify-2.5.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.0.1-py38h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.7.1-py38hf11a4ad_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py38he774522_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py38h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py38h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py38h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py38h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py38_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.4.4-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/netcdf4-1.6.2-py38hda396d2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py38haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.54.1-py38hf11a4ad_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.4-py38h7b80656_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.20.3-py38h749eb61_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.20.3-py38h5bfbeaa_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-1.3.5-py38h6214cd6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pcre-8.45-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pcre2-10.37-h0ff8eda_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py38h045eedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pixman-0.40.0-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pkgutil-resolve-name-1.3.10-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pooch-1.7.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/poppler-22.12.0-h0bf3bde_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/poppler-data-0.4.11-haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/postgresql-12.15-hb652d5d_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/proj-6.2.1-h3758d61_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py38h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py38haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyproj-2.6.1.post1-py38h593ac45_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py38h196d8e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.8.18-h6244533_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py38hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py38h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py38h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py38h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py38hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/qhull-2020.2-h59b6b97_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rtree-1.0.1-py38h2eaa2aa_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scikit-learn-1.2.2-py38hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.10.1-py38hdcfc7df_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/shapely-2.0.1-py38hd7f5953_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py38haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/testpath-0.6.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tiledb-2.3.3-h3649cd2_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py38h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py38hd4e2768_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uriparser-0.9.7-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py38_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py38haa95532_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2022.11.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xerces-c-3.2.4-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py38haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+  sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
+  md5: 613805add1c05b538ff06d217252feb7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 20810
+  timestamp: 1652859733309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py38h06a4308_0.tar.bz2
+  sha256: 54481e7be198702a59018dbdcc65cc32cdbc32efd372380cdfc3ef6e2c8637e4
+  md5: 54aa956eba07f586a9cdf1edd795ff6a
+  depends:
+  - idna >=2.8
+  - python >=3.8,<3.9.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 161551
+  timestamp: 1644481732835
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py38h7f8727e_0.tar.bz2
+  sha256: 754046398c314772a7d38b7d4c0d488a48db7b1b9c6a421686ef13178e1997b9
+  md5: e785c0744d3ed83d813a42b7bb9b8794
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=7.5.0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 35378
+  timestamp: 1644569723962
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py38h06a4308_0.tar.bz2
+  sha256: 07ae7d42a17dc80c2d86cde056d10fce0bccbf644079ede97e1528aab1c52e97
+  md5: f542de27c6488185f93ac808b361e773
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 132589
+  timestamp: 1695717870001
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.4.57-he6710b0_1.tar.bz2
+  sha256: bc87abecbc7e34b42b5a7ec3a3470ee284ed82f5f638274f795810fd0aa85496
+  md5: e883ae27a33cff702b8a20b5394e9ae0
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 164855
+  timestamp: 1601398346279
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.1.6-h2531618_5.tar.bz2
+  sha256: 4f7d93ed96f6692266a700971029b841dc972a6af39b85ba9525eebe2c40edbb
+  md5: 6b7ceb5ff64fc9f4537bfe7a2d7fe4a0
+  depends:
+  - aws-c-common >=0.4.57,<0.4.58.0a0
+  - aws-checksums >=0.1.9,<0.1.10.0a0
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 25449
+  timestamp: 1603894551837
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.9-he6710b0_0.tar.bz2
+  sha256: 17d0e3361698b9a0a9b52836284b658886d25bf349f3a099b765eac23ceb4ebd
+  md5: 0a7ed2b675a5af15d4979f4ca5c93d39
+  depends:
+  - aws-c-common >=0.4.57,<0.4.58.0a0
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52520
+  timestamp: 1601398555928
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.8.185-hce553d0_0.tar.bz2
+  sha256: 2842aafc907c01ccbe26ca11bddad6c55e9f93d30cf57431e327f5e57666be2c
+  md5: 5b4e9429338430ef3b71802778ac2184
+  depends:
+  - aws-c-common >=0.4.57,<0.4.58.0a0
+  - aws-c-event-stream >=0.1.6,<0.1.7.0a0
+  - libcurl >=7.71.1,<9.0a0
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - openssl >=1.1.1k,<1.1.2a
+  license: Apache-2.0
+  license_family: Apache
+  size: 2442091
+  timestamp: 1618434946994
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py38h06a4308_0.tar.bz2
+  sha256: 46c2cda1632b14e34119fc00eebd1ea661d11e0a9af19b079223e1753f250312
+  md5: 12ce8ee1ef9ce7702c16c066aaa97d4a
+  depends:
+  - python >=3.8,<3.9.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206754
+  timestamp: 1681493123397
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.3.3-py38h06a4308_0.tar.bz2
+  sha256: 3bfeca90afe6dfc7d2449c80d399b49a71789194d788a1885bcdffadf7ba4203
+  md5: 259a031bf81c4dcfd23e8362fc66d82c
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.1
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8626396
+  timestamp: 1625766948987
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py38hce1f21e_0.tar.bz2
+  sha256: 59962f0b66250d8d0e480250f76c6ced092eded23a21789b75504ee467e7b95a
+  md5: c70915c3dd28d708301d7f62eceab737
+  depends:
+  - libgcc-ng >=7.5.0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 141645
+  timestamp: 1648028960341
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/branca-0.6.0-py38h06a4308_0.tar.bz2
+  sha256: acb11233689be4e3e08e59d81128e8c1a1df187e567a2a419a49a92fe52f6105
+  md5: a988f72c736cebe811e041883110d68a
+  depends:
+  - jinja2
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 42267
+  timestamp: 1675157693121
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+  sha256: 0bbcb6f78eac530c6a084459ffab3238647b266d0c74d695e6e6387dd119cc67
+  md5: bdc971e2a9affb5125b68ad708172dab
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 411301
+  timestamp: 1602517685375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py38heb0550a_2.tar.bz2
+  sha256: 48861814b9de24db62eb44c63f5d860f6e8a0394e6a130eeb315aac35386a6ae
+  md5: 5dc04b2ebe30cad3d57f18d761d4028c
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  size: 372816
+  timestamp: 1602517785841
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
+  sha256: 168c2fc4d5899ee70e85fadc998e00827e1b856a6fc4a402ed465cd7c320d19f
+  md5: f52e60deb7f4c82821be9a868e889348
+  depends:
+  - libgcc-ng >=7.3.0
+  license: bzip2
+  license_family: BSD
+  size: 107105
+  timestamp: 1563219611337
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.18.1-h7f8727e_0.tar.bz2
+  sha256: 55032f8c149e5515300098ed4133bb92993419b976789b90c8fc3eaf88b3d979
+  md5: 62ca289a9704ed465d3324295ef851d9
+  depends:
+  - libgcc-ng >=7.5.0
+  license: MIT
+  license_family: MIT
+  size: 121863
+  timestamp: 1641918271715
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+  sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
+  md5: 3ef00f4c5278b688552efc259c463dc8
+  license: MPL-2.0
+  license_family: Other
+  size: 132731
+  timestamp: 1694009767372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cairo-1.16.0-h19f5f5c_2.tar.bz2
+  sha256: 053b2284fe86f4adbdf4b39ce4d9d9d0ae0f49b0d3ef966eee96bc17c3f028f9
+  md5: ec69c918d097c392992a7fbe52d252d3
+  depends:
+  - fontconfig >=2.13.1,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - glib >=2.69.1,<3.0a0
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libxcb >=1.15,<2.0a0
+  - pixman >=0.40.0,<1.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: LGPL-2.1-or-later or MPL-1.1
+  license_family: LGPL
+  size: 1573265
+  timestamp: 1654193721539
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cartopy-0.18.0-py38h0d9ca2b_1.tar.bz2
+  sha256: 92589e250abbc4bd65e332a91d0729beecad606fc8dbf95698c44e9769e5c1da
+  md5: 230643b4dd9216e446ad2111b40cd927
+  depends:
+  - geos >=3.8.0,<3.8.1.0a0
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - matplotlib-base >=1.5.1
+  - numpy >=1.16.6,<2.0a0
+  - proj >=6.2.1,<6.2.2.0a0
+  - pyshp >=1.1.4
+  - python >=3.8,<3.9.0a0
+  - scipy >=0.10
+  - shapely >=1.5.6
+  - six >=1.3.0
+  license: LGPL-3
+  size: 2000219
+  timestamp: 1612289540164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py38h06a4308_0.tar.bz2
+  sha256: 03b5e29c8b52f1a8ec459e577733ea3b2bc57d0ab53ffe21497569a78e581680
+  md5: 188d1325f374411714723488d38221d2
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159001
+  timestamp: 1690232308159
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py38hd667e15_1.tar.bz2
+  sha256: b87c8090413b0858c694d1e9e646177529bcffbb211822254174d46856c73914
+  md5: 3c7b4ec905e563e91ffbabb11516809f
+  depends:
+  - libffi >=3.3
+  - libgcc-ng >=7.5.0
+  - pycparser
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 231275
+  timestamp: 1642701149006
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cfitsio-3.470-hf0d0db6_6.tar.bz2
+  sha256: 23552cdff499c81a7558ddfc97bffdfb79e8095917214f8a123f1d33d9e6f267
+  md5: 7ff507183f61b0613724b63050abb2c2
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=7.71.1,<9.0a0
+  - libgcc-ng >=7.3.0
+  - libgfortran-ng >=7,<8.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: fitsio
+  size: 1356419
+  timestamp: 1601308736676
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cftime-1.5.1.1-py38hce1f21e_0.tar.bz2
+  sha256: 393f214c11ae1468b3ff1b594a3c89c9ffa02d17d54487dae1ba71e8ab9e77fa
+  md5: b05f4834cc6556cdb21f0046fa24f033
+  depends:
+  - libgcc-ng >=7.5.0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 221505
+  timestamp: 1638357968908
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py38h06a4308_0.tar.bz2
+  sha256: 6dbf29428ab1fd359f4c577465da6494bf6f8acf0ae115942746b5c989424d94
+  md5: 39055face0f3948ba69e73aa3ee13fdc
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40493
+  timestamp: 1683040085424
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py38h06a4308_0.tar.bz2
+  sha256: 8a25abc45d27b1ca16489f03a390ad5f648cf198d4d341437e75e320a1303d0f
+  md5: 442d8300d903dcc9050d9e9b1336cde1
+  depends:
+  - pyct >=0.4.4
+  - python >=3.8,<3.9.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1974004
+  timestamp: 1668084578291
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py38h06a4308_0.tar.bz2
+  sha256: 93e6082d2635e03b9e7d87aea7ec3b4c98e8d40698a29ce01386b0f5cd038f75
+  md5: 5944cf6bfa04b7b79479c6b5eec2a856
+  depends:
+  - python >=3.8,<3.9.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12695
+  timestamp: 1671231231929
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py38h130f0dd_0.tar.bz2
+  sha256: f32275eb7bea86a368b1d41e1731089d8cc9a9e8ae4d6a12ce161522adad3192
+  md5: a02567b1992539478f57554d00255594
+  depends:
+  - cffi >=1.12
+  - libgcc-ng
+  - openssl >=1.1.1v,<1.1.2a
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 2180436
+  timestamp: 1694444927145
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/curl-7.82.0-h7f8727e_0.tar.bz2
+  sha256: f86745816a0abd3f9918777e3dd25e212b808cb21f1f769dbe1a417fdd34c294
+  md5: 412fb1f9d310969821ce52adffaf80c7
+  depends:
+  - libcurl 7.82.0 h0b77cf5_0
+  - libgcc-ng >=7.5.0
+  license: curl
+  license_family: MIT
+  size: 102483
+  timestamp: 1649731358187
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.11.0-py38h7b6447c_0.tar.bz2
+  sha256: 551546153fbda8d618783ffe22c825e9f0ed09ee14c713cf2254c24b6a4795d0
+  md5: dcb18da6963d56ec55b36d092c18b137
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.8,<3.9.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  size: 399499
+  timestamp: 1600959049930
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py38h06a4308_1.tar.bz2
+  sha256: 823bbb3c8951739e8ff5fbf9470cf4ca06c790fe4646388922bf29800b02acad
+  md5: 53492f02a308427dab7a204dcc2f343f
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7
+  - python >=3.8,<3.9.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 104159
+  timestamp: 1613390257727
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py38h295c915_0.tar.bz2
+  sha256: 2e4214d51aa2a634a46fde19b92644798d92c450d055f1a3a62bc162a4b39cd6
+  md5: 637c8337c96bc1125bebf2809ecd0ff7
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 2099690
+  timestamp: 1637091855055
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2021.10.0-py38h06a4308_0.tar.bz2
+  sha256: 6302f38efee38870ea538d474353e6b60fbe43c8eb2ca7e10d0ca349197112bc
+  md5: 88a5a1e59a29df1e4f51c4810453c860
+  depends:
+  - click >=6.6
+  - cloudpickle >=1.5.0
+  - cytoolz >=0.8.2
+  - dask-core 2021.10.0.*
+  - jinja2
+  - msgpack-python >=0.6.0
+  - psutil >=5.0
+  - python >=3.8,<3.9.0a0
+  - pyyaml
+  - setuptools
+  - sortedcontainers !=2.0.0,!=2.0.1
+  - tblib >=1.6.0
+  - toolz >=0.8.2
+  - tornado >=6.0.3
+  - zict >=0.1.3
+  constrains:
+  - openssl !=1.1.1e,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1128129
+  timestamp: 1635968239447
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py38h06a4308_0.tar.bz2
+  sha256: fc256adb1e5c237867e04a2699c1eec3ea93256cfa7914880d59c69563f1c95d
+  md5: 20c8874b5ae24bf4bea2303aeb5f7f03
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16351
+  timestamp: 1649926480666
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
+  sha256: 27cde2cf0b1e10c2315bc1384fcb56537b424f6c2c872ca4662bc971e41910da
+  md5: c12e8c75f3c7c4f5867827c5dc02dc2c
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: MIT
+  license_family: MIT
+  size: 216001
+  timestamp: 1644418571578
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fiona-1.8.13.post1-py38hc820daa_0.tar.bz2
+  sha256: 2805161e64f6dfc78a52cfa0cb7512103adbd507981912d523e99c6ad4ec6426
+  md5: c40804d0aabb8c8340b63a78a14d7a36
+  depends:
+  - attrs >=17
+  - click >=4.0,<8
+  - click-plugins >=1.0
+  - cligj >=0.5
+  - gdal
+  - libgcc-ng >=7.3.0
+  - libgdal >=3.0.2,<3.1.0a0
+  - libstdcxx-ng >=7.3.0
+  - munch
+  - numpy >=1.14.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  - shapely
+  - six >=1.7
+  license: BSD-3-Clause
+  size: 1094071
+  timestamp: 1597154790852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/folium-0.14.0-py38h06a4308_0.tar.bz2
+  sha256: 02792c44f5e66b754fbeb6c07fbb4baa7bf43988bf9641402ee9d669855b3761
+  md5: dead3a557dfe066fc55baf327a859857
+  depends:
+  - branca >=0.6.0
+  - jinja2 >=2.9
+  - numpy
+  - python >=3.8,<3.9.0a0
+  - requests
+  license: MIT
+  license_family: MIT
+  size: 113940
+  timestamp: 1675353472060
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
+  sha256: f80526def98864c9560dd3f6754d1c905edc001d18279f6e169913ee8f26a6a2
+  md5: e2fda4383ff9a690a6ac174553e10414
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - libgcc-ng >=7.3.0
+  - libuuid >=1.0.3,<2.0a0
+  - libxml2 >=2.9.10,<2.10.0a0
+  license: MIT
+  size: 306671
+  timestamp: 1612452969808
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+  sha256: 8a121233d0b2cbb2463b67e798739ad2946f38933430a6a7fd1197cc6eab1c99
+  md5: d2b24736491290a6c6d0138932111150
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: GPL-2.0-only and LicenseRef-FreeType
+  size: 965280
+  timestamp: 1635422707211
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freexl-1.0.6-h27cfd23_0.tar.bz2
+  sha256: 8e060f863a4a3ae66733c03d400dce277b831e15fbd23f6beccd43501b15b74d
+  md5: 4a608c3e1873b5f5d319d1a093291c42
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MPL-1.1
+  size: 47744
+  timestamp: 1607116152702
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py38h06a4308_0.tar.bz2
+  sha256: a99dc9db41b635292f5b5078a03ee745050b3fdfd7b402e8589e811c42e1af30
+  md5: c2de12505cad821a4249f7c2b2f83205
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 260426
+  timestamp: 1695734589016
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gdal-3.0.2-py38h2c27f0e_2.tar.bz2
+  sha256: bf22b18cdf698cefec0d85f6b3f5177c949054b56e30acfd5692bd6aaf0ce63f
+  md5: 7a75f579140e4a48c5cb9c3a5cf8d676
+  depends:
+  - libgcc-ng >=7.5.0
+  - libgdal 3.0.2 he6cead7_2
+  - libstdcxx-ng >=7.5.0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  size: 1367460
+  timestamp: 1643382663578
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/geopandas-0.12.2-py38h06a4308_0.tar.bz2
+  sha256: c3be7721dfbaecd526e21e055cf135a361f9174ba143fbad3d40e87af5b6cab3
+  md5: 2195a5ccc9f71c4628f6c090861c15ac
+  depends:
+  - folium
+  - geopandas-base 0.12.2 py38h06a4308_0
+  - mapclassify >=2.4.0
+  - matplotlib-base >=3.2.0
+  - python >=3.8,<3.9.0a0
+  - rtree
+  - xyzservices
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6230
+  timestamp: 1675672124803
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/geopandas-base-0.12.2-py38h06a4308_0.tar.bz2
+  sha256: 2cd41da7f5c9f9c018c4f14ee1383f3d6416283f5ba267b75bc0cb94a6c76ed8
+  md5: 9c9b910f82d0ec74660ebca9261c113e
+  depends:
+  - fiona >=1.8
+  - packaging
+  - pandas >=1.0.0
+  - pyproj >=2.6.1.post1
+  - python >=3.8,<3.9.0a0
+  - shapely >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1256343
+  timestamp: 1675672123162
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/geos-3.8.0-he6710b0_0.tar.bz2
+  sha256: 6d791f835f915ad4f34171399b7d3141e548446dcce384f7d11f28a04c002bb7
+  md5: 7f115aea55f4cffe8c6c937240697f06
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: LGPL-2.1
+  size: 1078422
+  timestamp: 1573215838521
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/geotiff-1.7.0-hd69d5b1_0.tar.bz2
+  sha256: 27f153e921dd9adae169043ffdca3903ad98344bde7c3e8ab8c771f2b4d116a0
+  md5: 0be412b39ea3969b79829a2556698416
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  - proj >=6.2.1,<6.2.2.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 284741
+  timestamp: 1625555192147
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+  sha256: 3c8ece1a7257b1d45f8fa25f46504bb709a1923d7175f2996e891366ec434b9d
+  md5: 299bf4271d710651a1d71d3795580c2d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 83592
+  timestamp: 1603192039050
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
+  sha256: bb98f022743e5df14d73db0edae49eb95a11abcc41c973fe2f30c3810bc5021e
+  md5: 858d4f13f1b0e54ee8cc3dd7c67cf0de
+  depends:
+  - libffi >=3.3
+  - libffi >=3.3,<3.4.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - pcre >=8.45,<9.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 2021087
+  timestamp: 1642701448286
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf4-4.2.13-h3ca952b_2.tar.bz2
+  sha256: 70e1f9fdc6b123d8270bcd8cdd555519372924d39419ef8692b36bfa9d0b4653
+  md5: 35da658876a3e2a62dda54dcd5a7e5c2
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.2.0
+  - libstdcxx-ng >=7.2.0
+  - zlib >=1.2.11,<2.0.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 937548
+  timestamp: 1510862959026
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf5-1.10.6-hb1b8bf9_0.tar.bz2
+  sha256: ab8cb89a9c1e8341785c53c7aff84ed2e5ad42efe6897b54e0b2bf5712a77057
+  md5: c2a4fff8bb9066058971622f9b2b3e00
+  depends:
+  - libgcc-ng >=7.3.0
+  - libgfortran-ng >=7,<8.0a0
+  - libstdcxx-ng >=7.3.0
+  - zlib >=1.2.11,<2.0.0a0
+  license: HDF5
+  license_family: BSD
+  size: 5077151
+  timestamp: 1593121597858
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+  sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
+  md5: 9213e0336e3a5216c989cfe52648412e
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 23805906
+  timestamp: 1588026213084
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py38h06a4308_0.tar.bz2
+  sha256: 78c6e445d2365147307ab5631fb82bfb9f929ca0fe8849d7d7f4991e991fe125
+  md5: 22a39ae9bbf0f9dab8b7c7dafed3d454
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111304
+  timestamp: 1666125659782
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py38h06a4308_0.tar.bz2
+  sha256: b4c67d58af728ccc02ded656950609cbb90cfc5c9d23c67962e2118726fa4bdf
+  md5: 6284754d30be21d201fa708661a40ee5
+  depends:
+  - python >=3.8,<3.9.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 37562
+  timestamp: 1678997179162
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.1.0-py38h06a4308_0.tar.bz2
+  sha256: db646d2d41469fbd8f4c652faa436784623be3e3faf4b294b179d1dc0119db03
+  md5: 56fada4eb69b2eac5975f7b5e8587d0a
+  depends:
+  - python >=3.8,<3.9.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 50548
+  timestamp: 1698254754814
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+  sha256: 1b424413f28b840fc6d4bf467f37e9e405823b1e3b899005df80152d48936d64
+  md5: 4aa8bcf74c81cd3600978f791191692a
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 9246735
+  timestamp: 1634546760713
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py38hb070fc8_0.tar.bz2
+  sha256: 2f7bbc17d6f687a7e0436dca6ac387add5fe5894d29569efef0d177779b731a8
+  md5: 8411fbef7b61093a89bcfb698e4a94c4
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.0
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=17
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203314
+  timestamp: 1671488427499
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.12.2-py38h06a4308_0.tar.bz2
+  sha256: e413c50a320468c543fc0b434e914a1705f2078a3c349036db7457818e6c2865
+  md5: 659aa6a467e962ab07c83300d5edbdc2
+  depends:
+  - backcall
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.8,<3.9.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1232450
+  timestamp: 1691532256204
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py38h06a4308_1.tar.bz2
+  sha256: 3a960eb70bfc70b68e8a4c18789d6e4e38d957fcc131e0a2dd0c40d9a69d299f
+  md5: 19ed6fe5573ad375cddc95056ecd13a0
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 1029639
+  timestamp: 1644315273267
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/joblib-1.2.0-py38h06a4308_0.tar.bz2
+  sha256: bf1488a9538701eb892c23588ecd66a7978c218da48f0222f2413651b56abf5a
+  md5: 1da31afa747bdaa7297d23076f38a32d
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 403690
+  timestamp: 1685113149323
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+  sha256: 85348bfb14db4fea84078d703e766a3c978c5a592a06e41266748826dd59d8ae
+  md5: 6e1c0fb5260c590f7ef5235cb3d05863
+  depends:
+  - libgcc-ng >=7.5.0
+  license: IJG
+  license_family: Other
+  size: 279884
+  timestamp: 1651065953960
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/json-c-0.13.1-h1bed415_0.tar.bz2
+  sha256: 3467b6700f6886bd0faa30eedcb9cc616f3c913c555e8ae92f8a2f8a14fbc9c5
+  md5: d62003ffec6d7b46dd2f23c1d2ef1a22
+  depends:
+  - libgcc-ng >=7.2.0
+  license: MIT
+  size: 71804
+  timestamp: 1520912298499
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py38h06a4308_0.tar.bz2
+  sha256: 405e9f469376ef4103dd20143182200becd1826e09c4ceaf1c3624ba1f550c46
+  md5: 85499c4d81f591081111c92b80658c46
+  depends:
+  - attrs >=17.4.0
+  - importlib_resources >=1.4.0
+  - pkgutil-resolve-name >=1.3.10
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 130909
+  timestamp: 1676558687406
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py38h06a4308_0.tar.bz2
+  sha256: 363bf1ec4fc436281b982243c320d1e5f3f4f8eb32b165b3d9065ba8cec976e5
+  md5: bdbcdf04055343c414aa431ccb1b788e
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=22.3
+  - tornado >=6.0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 190946
+  timestamp: 1650622858276
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py38h06a4308_0.tar.bz2
+  sha256: ddfb7d8c465e40624168c4298783fc3241674c26652f22e6ed83766f2154f544
+  md5: 55dcff614b00ebf9d9133a94b51525d3
+  depends:
+  - platformdirs >=2.5
+  - python >=3.8,<3.9.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 91415
+  timestamp: 1679906595114
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py38h06a4308_0.tar.bz2
+  sha256: 93715877ed17774e2ab8914e61392b47ccbc287ecc0090b9f503652079307428
+  md5: 0310c282f4db53891f1bbd904eb911ea
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 410727
+  timestamp: 1671707735470
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kealib-1.4.14-hb50703a_1.tar.bz2
+  sha256: 6e331fc982591919ce61ce3a265f9179f7356443fa746491ac3fe07a4c956d92
+  md5: fcd61c7464836aa82c15899a0516907b
+  depends:
+  - hdf5 >=1.10.6,<1.10.7.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: MIT
+  license_family: MIT
+  size: 185531
+  timestamp: 1640000342243
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py38h295c915_0.tar.bz2
+  sha256: a1eb0041ef76935f9a6bd6b2615cba9dace682f1ea7ff45ea8f4f45acb3560bf
+  md5: af1bbc1e7edc97963e8ced3d17542b19
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92258
+  timestamp: 1653292259825
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.19.2-hac12032_0.tar.bz2
+  sha256: 19b886c33c110a8a7a3616ebd9b5c18efc7653e42a40e36d6d6179ac591169b1
+  md5: fe9cc044a22b2fc3a5a0699e2fde72fd
+  depends:
+  - libedit >=3.1.20210216,<3.2.0a0
+  - libedit >=3.1.20210216,<4.0a0
+  - libgcc-ng >=7.5.0
+  - openssl >=1.1.1k,<1.1.2a
+  license: MIT
+  size: 1447400
+  timestamp: 1627388807149
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.73.0-h3ff78a5_11.tar.bz2
+  sha256: 55e595d5b5c5c2361c56a9ea3868ed5e97c99b3ffc614487b7aec7126722292a
+  md5: b41dce08aea9e243db25a95f00708724
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  - zstd >=1.4.5,<1.5.0a0
+  license: Boost-1.0
+  size: 22298574
+  timestamp: 1611677068430
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-7.82.0-h0b77cf5_0.tar.bz2
+  sha256: 765358a6dbb22f82dc3bb929b94df73b7b5fe6b4faf0caee83eff73c24c379f7
+  md5: 58bfe76e3f31d4a36acd7a7f4092b6ce
+  depends:
+  - krb5 >=1.19.2,<1.20.0a0
+  - libgcc-ng >=7.5.0
+  - libnghttp2 >=1.46.0,<2.0a0
+  - libssh2 >=1.9.0,<2.0a0
+  - openssl >=1.1.1n,<1.1.2a
+  - zlib >=1.2.11,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 359251
+  timestamp: 1649731351073
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdap4-3.19.1-h6ec2957_0.tar.bz2
+  sha256: a9a73e8eeff093c5c4fb28e9f2e9c4fba2af8ec90961179429008c37a928f952
+  md5: 6c12fa06df93e20a3b53d790e1fc7fc8
+  depends:
+  - curl
+  - libcurl >=7.60.0,<9.0a0
+  - libgcc-ng >=7.2.0
+  - libstdcxx-ng >=7.2.0
+  - libuuid >=1.0.3,<2.0a0
+  - libxml2 >=2.9.8,<2.10.0a0
+  license: GNU LGPL
+  size: 1616824
+  timestamp: 1532084028670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20210910-h7f8727e_0.tar.bz2
+  sha256: 47d3ff15d11ffed8a2b8954d5e100b3806ff6898a12ec500d7afe043dc2076de
+  md5: 5f295795bb8e419eacb4d6ffbba68ceb
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.3,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 195324
+  timestamp: 1636026988621
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+  sha256: efdab884c85fda4461f7a393aa6d4e0e50d03cb59fb9c8a980b1307b8379ebe0
+  md5: eeca774c6154c49340dd403b1928d5e9
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 108906
+  timestamp: 1632891483341
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+  sha256: 3b4afe7665dcdb99bd4586a888b85b2e0325f8faecdd31c7780792080ee97872
+  md5: 822b5201dde61bc838072dc5b670c88c
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: Custom
+  size: 55183
+  timestamp: 1594054267890
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+  sha256: c6fafbe73d2f93b91b6f4b65829f925f52a8f84746a57abd216b39da9ce8c494
+  md5: 238f19c803a6ba7bd6dbd6989e03cbf1
+  depends:
+  - _libgcc_mutex * main
+  license: GPL
+  size: 8496776
+  timestamp: 1560112207081
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgdal-3.0.2-he6cead7_2.tar.bz2
+  sha256: 1f3e00689fa84861e32cee9770b34e476f3f2ccc459bb8b4d0d78f9d9150bc8e
+  md5: deb3f0e7bbb8d7faeb2a8cc37b7d94cd
+  depends:
+  - cfitsio >=3.470,<3.471.0a0
+  - expat >=2.2.10,<3.0a0
+  - freexl >=1.0.6,<2.0a0
+  - geos >=3.8.0,<3.8.1.0a0
+  - geotiff >=1.7.0,<1.8.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - hdf4 >=4.2.13,<4.2.14.0a0
+  - hdf5 >=1.10.6,<1.10.7.0a0
+  - icu >=58.2,<59.0a0
+  - jpeg >=9d,<10a
+  - json-c >=0.13.1,<0.14.0a0
+  - kealib >=1.4.14,<1.5.0a0
+  - libcurl >=7.80.0,<9.0a0
+  - libdap4 >=3.19.1,<3.20.0a0
+  - libgcc-ng >=7.5.0
+  - libkml >=1.3.0,<1.4.0a0
+  - libnetcdf >=4.8.1,<5.0a0
+  - libpng >=1.6.37,<1.7.0a0
+  - libpq >=12.9,<13.0a0
+  - libspatialite >=4.3.0a,<4.4.0a0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  - libuuid >=1.0.3,<2.0a0
+  - libwebp-base
+  - libxml2 >=2.9.12,<2.10.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - openssl >=1.1.1m,<1.1.2a
+  - pcre >=8.45,<9.0a0
+  - poppler >=0.81.0,<1.0a0
+  - proj >=6.2.1,<6.2.2.0a0
+  - sqlite >=3.37.0,<4.0a0
+  - tiledb >=2.2,<3.0a0
+  - xerces-c >=3.2.3,<3.3.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  - zstd >=1.4.9,<1.5.0a0
+  size: 19859167
+  timestamp: 1643382592086
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
+  sha256: 83c6fdb30a240fbaa09f5d2e2ae8f092759cb710bc3fa628ccb18934fc237b7f
+  md5: 6003e09e8cef9aca91b954abfdd0f39c
+  license: GPL
+  size: 1336385
+  timestamp: 1534628456385
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+  sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
+  md5: 3080c2813e6e1d0f8a100a38b5b3456d
+  depends:
+  - _libgcc_mutex 0.1 main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 573231
+  timestamp: 1654090775721
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libkml-1.3.0-h7ecb851_5.tar.bz2
+  sha256: 84ba7a094c39081a1a2d7226480fc20f80ec9535fdd4af499a80fac25af48b9d
+  md5: 3c2d1e438121487642301abd252f7f6b
+  depends:
+  - expat >=2.2.10,<3.0a0
+  - libboost >=1.73.0,<1.73.1.0a0
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - zlib >=1.2.11,<2.0.0a0
+  license: BSD 3-Clause
+  size: 661183
+  timestamp: 1622296726318
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.0.0-h3826bc1_1.tar.bz2
+  sha256: 1106ab3350c5fc6181019728ba7a575667135731590d309fed26dc32163f54f8
+  md5: 6daa3aad932f5a099829b61c07368e0a
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - zlib >=1.2.11,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 29802574
+  timestamp: 1646054256176
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnetcdf-4.8.1-h42ceab0_1.tar.bz2
+  sha256: 8291a338553b086e91121b081de2631dc8de2430cf9c45d2da21d8a646e9804e
+  md5: a2566f0db9a998fdcee525ebc452f2b5
+  depends:
+  - curl
+  - hdf4 >=4.2.13,<4.2.14.0a0
+  - hdf5 >=1.10.6,<1.10.7.0a0
+  - libcurl >=7.80.0,<9.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libzip
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1575093
+  timestamp: 1642426008501
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.46.0-hce63b2e_0.tar.bz2
+  sha256: 35e522586539ca4b437626cdd3927adb8cdafae3bd73a9d725891d79aa7a3850
+  md5: 97f632fd848c61ef9ac21fdf95ddd412
+  depends:
+  - c-ares >=1.17.1,<2.0a0
+  - c-ares >=1.7.5
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - openssl >=1.1.1l,<1.1.2a
+  - zlib >=1.2.11,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 814126
+  timestamp: 1637149827126
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+  sha256: bc3e6e79c32ff0ecea601aa108ae9cf4068f69703580e40e266ad4bcc52cff54
+  md5: 9cb85601944ca7383b1769bff74b94e8
+  depends:
+  - libgcc-ng >=7.3.0
+  - zlib >=1.2.11,<2.0.0a0
+  license: zlib/libpng
+  size: 372914
+  timestamp: 1556041895170
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpq-12.9-hc2c5182_2.tar.bz2
+  sha256: f07555b0450d8869006b598091b958dd08adf7a00dd64c3945a1c7976ffa39c1
+  md5: 3912de5f8ecbc526228146d3edff2162
+  depends:
+  - krb5 >=1.19.2,<1.20.0a0
+  - libgcc-ng >=7.5.0
+  - openssl >=1.1.1o,<1.1.2a
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  size: 2953122
+  timestamp: 1655472390761
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libspatialindex-1.9.3-h2531618_0.tar.bz2
+  sha256: b0f60b4c32f917a9c1b1048520cdfb5937ff7a07befa8a71022dfafae6e29ca4
+  md5: 8365a8a1dd0aef199a1214831622a4ef
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 3283214
+  timestamp: 1616086764247
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libspatialite-4.3.0a-hbedb2dc_20.tar.bz2
+  sha256: 51e90612881c1ae93c1486e31ccea0ab74c2424c57ba9e58d0ec25667c082067
+  md5: 28b616e9f1f5e597c78a6dd82f324cb8
+  depends:
+  - freexl >=1.0.6,<2.0a0
+  - geos >=3.8.0,<3.8.1.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libxml2 >=2.9.12,<2.10.0a0
+  - proj >=6.2.1,<6.2.2.0a0
+  - sqlite >=3.37.0,<4.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: LGPL-2.1
+  size: 3292456
+  timestamp: 1642781088363
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-h8f2d780_0.tar.bz2
+  sha256: 97549094b023e65e4a16581593d5b63dfa7b84cc383911b80b44eb71bb23f12c
+  md5: f99f13daacf379a329e041ec148c4db7
+  depends:
+  - libgcc-ng >=7.5.0
+  - openssl >=1.1.1n,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 311377
+  timestamp: 1651087263509
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+  sha256: 43b0bd205f539583c088feb5b8d77b60c83d1df80c2a93dac9f2a1127001b2cf
+  md5: 53fa39fdae936e9d07c4b2f5ef361993
+  license: GPL3 with runtime exception
+  size: 4246257
+  timestamp: 1560112223556
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h85742a9_0.tar.bz2
+  sha256: 5e249c94d0b7b3bf035d69c2f707964b5e39995987b359d17de28c0a54ee9405
+  md5: d7ea21b29e29feec41890296b559555b
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - libwebp-base
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  - zstd >=1.4.5,<1.5.0a0
+  license: HPND
+  size: 655372
+  timestamp: 1616492392965
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
+  sha256: 4e1dce80f23551a69761ad48b2372e35f58292ec9cc0ce061312330366a1a223
+  md5: fda36b99463bad87974196da2d5bed08
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD 3-Clause
+  size: 18725
+  timestamp: 1633507857274
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+  sha256: 146dbb1e4dbccdd57819e5102a8ca00970b8e33d6c6180e8007db89b184da569
+  md5: c566a384259c1d2769852c3bddd81a67
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9d,<10a
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 90150
+  timestamp: 1645441199289
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+  sha256: cffb5a063111f7a99a99c74770b23db5dde52325e25a7a46d1903d5ff4a82c88
+  md5: eeb1bd66f28bed1956ab989d6eff7ae5
+  depends:
+  - libgcc-ng >=7.5.0
+  constrains:
+  - libwebp 1.2.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 889956
+  timestamp: 1645089138421
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+  sha256: 5d68e69709ae10bd6c4b58b6af447ad2f2bd24955994f3ec77103d1a6bf5e1f5
+  md5: 49e523de8d364b7fabc3850eccbe9bda
+  depends:
+  - libgcc-ng >=7.5.0
+  size: 623492
+  timestamp: 1652448233146
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+  sha256: 71f6c4a97014d745c58df52b4dd60ddd75a8508d54fe5b97f42bd1f31cb1c067
+  md5: 686e77514ec9f1ef0a6feed374f14d37
+  depends:
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.5.0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 789469
+  timestamp: 1653546418059
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libzip-1.5.1-h8d318fa_1004.tar.bz2
+  sha256: c66743f02b3aa64e282a6fe0bfd22dd22fdbbc820f6b09390f6faa25868eecd7
+  md5: 86f9a212269ef9ba56f0ff8a91012e9e
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=7.5.0
+  - openssl >=1.1.1n,<1.1.2a
+  - zlib >=1.2.12,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88675
+  timestamp: 1651789268252
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.37.0-py38h295c915_2.tar.bz2
+  sha256: 8d8519807e896d67349d97b0c4870eb1384224cd315e607e76834b62b41fa959
+  md5: c87ba42e4cdcf46d0a8233934c6f42cd
+  depends:
+  - libgcc-ng >=7.5.0
+  - libllvm11 >=11.0.0,<11.1.0a0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  size: 508375
+  timestamp: 1646151524759
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py38h06a4308_0.tar.bz2
+  sha256: a2c16e4e68e414ea6f7680a6439e80f7d67fb693bf739fc10d2ef5afc3e3c2f4
+  md5: dc8d6a9a1e475c5fc9de8531026a4c38
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11040
+  timestamp: 1652903148662
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+  sha256: 2c6a5dda7c510a961bc78e31d4232be5e8e0760c93454f5fd200c379355e0f5e
+  md5: f35d4bf2fbb39e334992f6dd39f8721e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 220865
+  timestamp: 1627657046002
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mapclassify-2.5.0-py38h06a4308_0.tar.bz2
+  sha256: 5da141bfe8ca42e7a90914205d7df33058e23edb83f4b49465e4197c744d64c8
+  md5: d419995013e0ac81bd88a370102edeed
+  depends:
+  - networkx
+  - numpy >=1.3
+  - pandas >=1.0
+  - python >=3.8,<3.9.0a0
+  - scikit-learn
+  - scipy >=1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65945
+  timestamp: 1675157805003
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py38h06a4308_0.tar.bz2
+  sha256: 67fb17f71cf101e66ccb210d8a5c3c10fd6966aaff214034fb6f860ca8d00e7f
+  md5: 32d28f2c97744b2e954e30fa485b5c5c
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 122380
+  timestamp: 1671541939225
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.0.1-py38h27cfd23_0.tar.bz2
+  sha256: b6cd835c2ab5bfcdd27a86d56982693cdc40b2e45df42d05e08c83916d4c3e38
+  md5: 32d66308493c20bed8ca2a852155b9b9
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23062
+  timestamp: 1621528207169
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py38ha18d171_1.tar.bz2
+  sha256: 2790aff6f95231024ff9c2d7ebc9733f8f95286792f28950380c30832c84e90f
+  md5: 3171c7f58b5d259c202595cb0dad57a0
+  depends:
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.11.0,<3.0a0
+  - freetype >=2.3
+  - kiwisolver >=1.0.1
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - numpy >=1.19.2,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.2.1
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.7
+  - tk
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7744768
+  timestamp: 1647442104672
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py38h06a4308_0.tar.bz2
+  sha256: 228a70eddf0a99801e03179f1ab8ddd915bfb7ce351fe7f94c502163d615eb77
+  md5: 28c78d14ef2a80747df2bf2353ef21d7
+  depends:
+  - python >=3.8,<3.9.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16341
+  timestamp: 1662014640999
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py38h7b6447c_1000.tar.bz2
+  sha256: e8ba4be2d51f4532870cdc96c212083c782a58da7281b7ecfede0b1d7ab3177b
+  md5: 1ec38f43661f9db21e2cdae301ce9b42
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.8,<3.9.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 55392
+  timestamp: 1573489078577
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+  sha256: 7c4ded8b2ef036839f988560848d2c32e1aa4627fd37a32710e42c39f5c61ac2
+  md5: bd20f4410b81f327e35ffa0657961146
+  depends:
+  - intel-openmp 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 229783051
+  timestamp: 1634547157986
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py38h7f8727e_0.tar.bz2
+  sha256: d4bc8c57703eb186f6a95bcb052042ae3bdc18e97e2be7362a1473055c70ea04
+  md5: 350e1ec6d837a61b44bf3c26dc8d094b
+  depends:
+  - libgcc-ng >=7.5.0
+  - mkl >=2021.2.0,<2022.0a0
+  - python >=3.8,<3.9.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 63766
+  timestamp: 1626183937671
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py38hd3c417c_0.tar.bz2
+  sha256: f60b8a001aa29e29c20f2a1e7328a1f0cb10564fa624f4519fdb9bfdd30f3698
+  md5: 856d2f4ee31539c64641c15d4d887e48
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.3.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16,<2.0a0
+  - python >=3.8,<3.9.0a0
+  license: BSD 3-Clause
+  size: 204397
+  timestamp: 1634566418352
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py38h51133e4_0.tar.bz2
+  sha256: ea1b274cbae030a69bfac2b9668d3273377ffe5490463955d12034db11a5e95f
+  md5: aef6e4c094fb094576b1c74919284787
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.2.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  size: 349357
+  timestamp: 1626186149062
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py38hd09550d_0.tar.bz2
+  sha256: 0908b112893c3a7a563010e020c810d6aab61a0132ac6ef5ea3ba2e59541da6c
+  md5: 17c600586128f5f226b9a5cda765f302
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 90061
+  timestamp: 1652362785051
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py38_0.tar.bz2
+  sha256: a00d1f914deb4b896a3d42d2cae73097e1f5f2f4bc371dd3ceed04118eb974b4
+  md5: 7ccf826b74681264ec620255a556fd97
+  depends:
+  - python >=3.8,<3.9.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 22859
+  timestamp: 1573120615619
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py38h06a4308_0.tar.bz2
+  sha256: f944e13c61956005bb065e814731663ffb03184bb97f7f4eb0f56c7f7b2a8326
+  md5: 284f3746088fe4815f7ec26187b9e994
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8264737
+  timestamp: 1681756406572
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py38h06a4308_0.tar.bz2
+  sha256: 27b620c69e97894d21c2477b29b49f32146c984d89cb6506ed13d4447719d3c0
+  md5: 0a21ae11a8a79a3c621fee4baf252f2c
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.8,<3.9.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 98761
+  timestamp: 1650308401439
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.4.4-py38h06a4308_0.tar.bz2
+  sha256: ef2905b389ee29f9fd05c83e0f2f845e16229766b91d656747c0e0fe96eb0f80
+  md5: 027a64ac454988b784fff9947c1ae1d6
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=2.4
+  - jupyter_core
+  - jupyterlab_pygments
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0,<0.6.0
+  - nbformat >=4.4
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.8,<3.9.0a0
+  - testpath
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 568315
+  timestamp: 1649751975792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py38h06a4308_0.tar.bz2
+  sha256: aa52cf81b5826bc6d7552f30c6aad7d8bef270da5cf836c024bbbdf5a148932a
+  md5: 760c9190893e51e1c59041c24be42711
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.8,<3.9.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 146963
+  timestamp: 1694616862202
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+  sha256: 0807371380965e421cb5f3f2a30d790fd5c41db11dbb6d318e14294c3b1741ed
+  md5: fca4bd4e3891aebf4fd7daf9b6d0ccfa
+  depends:
+  - libgcc-ng >=7.5.0
+  license: Free software (MIT-like)
+  size: 1083412
+  timestamp: 1636570020698
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py38h06a4308_0.tar.bz2
+  sha256: e07b5e33856bad27cb9577f79214a113163e27bfaadbac1950643141da43f0f6
+  md5: 839bb853e143fac8faccabe9c90ff79e
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 12944
+  timestamp: 1672387169775
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/netcdf4-1.5.7-py38ha0f2276_1.tar.bz2
+  sha256: 35757876321c3dd186f36cd8dad716a51f666dd6c5766e63ea40d3247ee9d27e
+  md5: 54e856517fdb869ba630bb39c49fd3b6
+  depends:
+  - cftime
+  - hdf5
+  - libgcc-ng >=7.5.0
+  - libnetcdf >=4.8,<4.9.0a0
+  - libnetcdf >=4.8.1,<5.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 507985
+  timestamp: 1643311809468
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.1-py38h06a4308_0.tar.bz2
+  sha256: bacdb012adbcd871b900cab6e4e20de88d623829608ebd26ac49dccf58f4f3fb
+  md5: d78ff982a19fd0f29479549f73ab0872
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2949423
+  timestamp: 1690562082101
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py38h06a4308_1.tar.bz2
+  sha256: ec50325b0351817c4922457acc1319a68f12093f907c85aa96ee2356236f0f34
+  md5: c43a610d54a7f1be888b4646caedf5bd
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 589052
+  timestamp: 1690985075092
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py38h06a4308_0.tar.bz2
+  sha256: e211f8e0dc8c60827aefd49737a3bcfb52f94acea9c38311d5fd51f3c5d8fe34
+  md5: fd311495d2aca2cb0173cd3f37b36016
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21957
+  timestamp: 1668160706352
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.54.1-py38h51133e4_0.tar.bz2
+  sha256: 5c509ac6729a7f75bf469ed7a0eb69cb5c71063b980449f1cad3b1ff03e26a76
+  md5: 4ef6b53caf47947b75331d8399539fbd
+  depends:
+  - _openmp_mutex >=4.5
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - llvmlite >=0.37.0,<0.38.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  - tbb >=2021.4.0
+  - libgomp
+  constrains:
+  - numpy >=1.17,<1.21.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3879950
+  timestamp: 1635186012359
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py38h6abb31d_0.tar.bz2
+  sha256: 70b437d6697ff0ad278e948e915576380f58c3ba1b799d1d45a9ad780fff1fed
+  md5: 2eca95d6ee550a5e314de57b46413961
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16.6,<2.0a0
+  - packaging
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 136950
+  timestamp: 1640704277727
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.20.3-py38hf144106_0.tar.bz2
+  sha256: 4a11292f4b5a8f9a18c81488146dbf356357baca8c9efe4c5962c56aea91354b
+  md5: 65bc5e584d119d33a7f40fdae48861f8
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - mkl >=2021.3.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.20.3 py38h74d4b33_0
+  - python >=3.8,<3.9.0a0
+  license: BSD 3-Clause
+  size: 22472
+  timestamp: 1626271770716
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.20.3-py38h74d4b33_0.tar.bz2
+  sha256: 8c9108421eacb1905943b37da3eef6a435661d3a105b5091f2ed8f86e962b200
+  md5: 68fb19b46268a5a8793ff193e756771a
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - mkl >=2021.3.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - numpy 1.20.3 py38hf144106_0
+  license: BSD 3-Clause
+  size: 5996323
+  timestamp: 1626271757410
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+  sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
+  md5: b0afe23033c8c5344640bc25225fa579
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 516994
+  timestamp: 1630084830020
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+  sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
+  md5: 5ad4571eba2479f77a9f849a6ae7724c
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: OpenSSL
+  license_family: Apache
+  size: 3998613
+  timestamp: 1694465071784
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py38h06a4308_0.tar.bz2
+  sha256: 583b4d92e7d967db9b158545b7971a629e2fabf0a10074fc3f957391543ce1ff
+  md5: 14693d3ef7699c4a9030266bbcd718ad
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 72553
+  timestamp: 1693575288897
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.3.5-py38h8c16a72_0.tar.bz2
+  sha256: 782e43bce03c78e838b215bd1ddf1daa9358448fe19556ef6a33b3ac70fe6831
+  md5: e034743503afe301e28d05643bb703d7
+  depends:
+  - bottleneck >=1.2.1
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - numexpr >=2.7.0
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.7.3
+  - pytz >=2017.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12899827
+  timestamp: 1641461402605
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.0-py38h06a4308_0.tar.bz2
+  sha256: efe972fd22443727d39d9efd2060123bf2fb69ea1a9353271e446e29f6530bb0
+  md5: 24c261deb2957f3e1078cc146d809e26
+  depends:
+  - locket
+  - python >=3.8,<3.9.0a0
+  - toolz
+  constrains:
+  - pandas >=0.19.0
+  - numpy >= 1.9.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 34819
+  timestamp: 1693937895456
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
+  sha256: 4881cc5e0d5b20335bcfba4eaf29fdc95dedf2607903aabecdacffb64d3407d4
+  md5: 4bac8a874e62f41ebab8345ca6076eb6
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 263308
+  timestamp: 1624477853289
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py38h22f2fdc_0.tar.bz2
+  sha256: 4e2faa1845386c77f6a7a7b67d1283b1d2139e2a979f2c852e3c6f770b7b59cf
+  md5: ece067a13def0fb55fcf2f6f7ad128b1
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp >=0.3.0
+  - libwebp >=1.2.0,<1.3.0a0
+  - python >=3.8,<3.9.0a0
+  - tk
+  - zlib >=1.2.11,<2.0.0a0
+  license: LicenseRef-PIL
+  license_family: Other
+  size: 732913
+  timestamp: 1646306967387
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py38h06a4308_0.tar.bz2
+  sha256: 4758820f8ee80d5da09151178c942918d156723fc67fc2cefa750a44fe52f5f1
+  md5: 4063b7dbf0b17df97508784af2ff8bbc
+  depends:
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2678540
+  timestamp: 1697548822688
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pixman-0.40.0-h7f8727e_1.tar.bz2
+  sha256: e0f6c86339e683ea9e3f7e4ce743df653103209aedf995b5e674c148cb349ed8
+  md5: c197093127a4cca3bb3227aab1a68573
+  depends:
+  - libgcc-ng >=7.5.0
+  license: MIT
+  size: 645031
+  timestamp: 1632711422664
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pkgutil-resolve-name-1.3.10-py38h06a4308_0.tar.bz2
+  sha256: 3253e3b4e00197f39259501fc30ee45ca37fedea540d096140feebe793a242e0
+  md5: eef230cabc54459c3b9c52938028e376
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT AND PSF-2.0
+  license_family: PSF
+  size: 9765
+  timestamp: 1661463353650
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py38h06a4308_0.tar.bz2
+  sha256: 4bf901b9310c1c68e71a78a9d2608ce439ca3dafed4f1223da5f7a4217a80cce
+  md5: 9bc4d8193c88dbeb3ee43a8f44c56adf
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 32013
+  timestamp: 1692205473871
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/poppler-0.81.0-h01f5e8b_2.tar.bz2
+  sha256: 9a5ad9ed809ea6cd5b11ff992519e2b1cffaf14e63e0d345c589270e9ea181f9
+  md5: d1d02486a56bddedb4789c0802d67f18
+  depends:
+  - cairo >=1.14.12,<2.0a0
+  - curl
+  - fontconfig >=2.13.1,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - glib >=2.68.2,<3.0a0
+  - jpeg >=9b,<10a
+  - libcurl >=7.71.1,<9.0a0
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  - openjpeg >=2.3.0,<3.0a0
+  - poppler-data
+  - zlib >=1.2.11,<2.0.0a0
+  license: GPLv2
+  license_family: GPL
+  size: 13295029
+  timestamp: 1623340073756
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/poppler-data-0.4.11-h06a4308_1.tar.bz2
+  sha256: cb8da35b87b1a486e8bb35a8978dcedc93a6d3cc9f9909665267d5fe5d1f93b2
+  md5: 3e4df7dd4cb1e7fc2415c39951ebf4a4
+  license: GPL-2.0-or-later and GPL-3.0-or-later and BSD-3-Clause
+  license_family: GPL
+  size: 3894636
+  timestamp: 1673863550016
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/proj-6.2.1-h05a3930_0.tar.bz2
+  sha256: 4fc2839540e89f0b4b408fc07d4ea7f4e57ad8d84ca8c117df0622a165470301
+  md5: 675fbf1eb0b5d8631be148dbfdd76942
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - sqlite >=3.37.0,<4.0a0
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  size: 10659620
+  timestamp: 1643031993108
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py38h06a4308_0.tar.bz2
+  sha256: fe048f508881e6f69ea1781ece59102037d83c102778669e8caf390009b20d74
+  md5: 4718ad7bf83e664525c13ce1ded14c84
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91025
+  timestamp: 1659455269732
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py38h06a4308_0.tar.bz2
+  sha256: 5206b4d6c7196f5a250d0ac786b41ba7243a89e190e089f7f680af3c8a30f561
+  md5: 76ffbcff7bf187c82475bf7bfa427178
+  depends:
+  - python >=3.8,<3.9.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580511
+  timestamp: 1672387395908
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py38h27cfd23_1.tar.bz2
+  sha256: 5a7da09bd13cfe53da03da7bbcd1a982b0200f53b00137bff3d3c24a6e860054
+  md5: 79ae56161fb6b23fc900f4bf6943e031
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 351263
+  timestamp: 1612298067868
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py38h06a4308_0.tar.bz2
+  sha256: dd70dbec022d1fca1fb2168bb81eeb2d970d53494f4bb4ce36751d70ce960b79
+  md5: b09b43fc9f274c994af65adefa36279f
+  depends:
+  - param >=1.7.0
+  - python >=3.8,<3.9.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29267
+  timestamp: 1675441565524
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py38h06a4308_1.tar.bz2
+  sha256: dae53aeb4103d375b1125eecc4dc3cdf5fcfa9288d24f3a9e1c5d9b0107a501c
+  md5: 13fc002e79408c57aa79fb2c25e1b538
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1887598
+  timestamp: 1684280001176
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py38h06a4308_0.tar.bz2
+  sha256: 5343573495dab43317505d1cbe5f84142064e5c055f097ffc6f82e8212dac1fb
+  md5: 86d9d9f5614c8a27bc48994401114f1c
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94531
+  timestamp: 1690223548194
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py38h06a4308_0.tar.bz2
+  sha256: 97972579f3c079aab5fb9a58855caded3b268bf90c0afdf5e6f39d75edd9a699
+  md5: b47e7fcdef58cc3b2b8d920c73819e19
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 156616
+  timestamp: 1661452605147
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyproj-2.6.1.post1-py38hb3025e9_1.tar.bz2
+  sha256: 1db7b0212a027d883426d4c36cc8f9bf4c56232a97fe46cd373bec44b1c63ba6
+  md5: 5ea29d28879ed23adea37d26809a274e
+  depends:
+  - libgcc-ng >=7.3.0
+  - proj >=6.2.1,<6.2.2.0a0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  size: 464988
+  timestamp: 1614278003311
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py38heee7806_0.tar.bz2
+  sha256: cdb902390f42cd9eeab33f1d55cf6b09baa7f9e4b00be46cb29ff7bd94d1e613
+  md5: 7528db4bd42c5b961b3bf7fd41b028a1
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 97208
+  timestamp: 1636110987189
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py38h06a4308_0.tar.bz2
+  sha256: 0d1c9fb08b326f1292b74373b942b739bb99dd4ec54d2be09e5072503300b2a8
+  md5: 3ec9d5960a2ea2ba666008fdfc9d0084
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31276
+  timestamp: 1605305807726
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.8.13-h12debd9_0.tar.bz2
+  sha256: 92d4fb3683a4be042f37b39cc5b0999ee1443e9df80dc1131ebf858c69146831
+  md5: 747f76169a205d14310fab31a7ed5f31
+  depends:
+  - ld_impl_linux-64
+  - libffi >=3.3,<3.4.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - ncurses >=6.3,<7.0a0
+  - openssl >=1.1.1n,<1.1.2a
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.38.0,<4.0a0
+  - tk >=8.6.11,<8.7.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 23831626
+  timestamp: 1648468088026
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py38h06a4308_0.tar.bz2
+  sha256: cc0f3ceeae6369f8b1523c1f4fff5c16d14c455b938723671a6bc672a65b77ff
+  md5: d914447598a4c8d1e61fd888dded2072
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264015
+  timestamp: 1661371299911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.2.1-py38h2531618_1.tar.bz2
+  sha256: abfb8101b1d642a8055e900a153410aa9155c2ea34658d517b956139c63a76d9
+  md5: cfb0c6464216dd11a338f990de0fd77e
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - python >=3.8,<3.9.0a0
+  license: OpenLDAP
+  license_family: Other
+  size: 139712
+  timestamp: 1619708194484
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py38h06a4308_0.tar.bz2
+  sha256: 4734c44244182009ee87d481d86ab3617c5b39c1b4fffcbf62236544bcdee5bc
+  md5: feb8c564e6ec229f489c95674f486935
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 253213
+  timestamp: 1695131612977
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py38h06a4308_0.tar.bz2
+  sha256: bc8e5299a2b352f3bb5fbaf9d8426af3a7762014f502474ea38a554af96e371a
+  md5: 274de0d6efbcaa67dd3a5d1a92c18576
+  depends:
+  - param
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39982
+  timestamp: 1685030807272
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py38h7f8727e_1.tar.bz2
+  sha256: 4bba1dee9097258660877150dd378d5f39f688642add536c507aff94db35edaf
+  md5: 4d28a98def54cf09f7ad028e43f0b33a
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.8,<3.9.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 183855
+  timestamp: 1635763881638
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py38h295c915_2.tar.bz2
+  sha256: de6699ca6cf7fd88e0074c457dd6aa6928ee5256c93b3a86daaf0b0501aef556
+  md5: ccfebd6d36d1a727dc2922b2e21814ad
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.8,<3.9.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-clause
+  license_family: BSD
+  size: 539827
+  timestamp: 1638436432728
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+  sha256: 8c950c69bee969e2c66f88f0dc247b3ab75a753672a88009779d5f5dba193532
+  md5: 150ac0eb929bab9dec912797bdfc7b95
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 433182
+  timestamp: 1642022402894
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py38h06a4308_0.tar.bz2
+  sha256: 6237774a1de06b391400f3ff5f02b721416580fb3230f4d1ac6a193a883ef5be
+  md5: 6b60cf64194bce8c4d7fbe9f24c5ced4
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.8,<3.9.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94127
+  timestamp: 1690400316882
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rtree-1.0.1-py38h06a4308_0.tar.bz2
+  sha256: c735d6921d8192d6eb56f69a37910c6faeaf36fa7ca23da049164913b15974bd
+  md5: 3f04d5207ae2ac4b77eb041d90a60bfc
+  depends:
+  - libspatialindex >=1.8.5
+  - libspatialindex >=1.9.3,<1.9.4.0a0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 48757
+  timestamp: 1675157906591
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scikit-learn-1.0.2-py38h51133e4_1.tar.bz2
+  sha256: 2bd93c83e2f4b834a876a84dab987eb8c470ea5fc7836023b67c801f803a17c5
+  md5: 51493123a884f481a231bd0135efbb06
+  depends:
+  - _openmp_mutex
+  - joblib >=0.11
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - scipy >=1.1.0
+  - threadpoolctl >=2.0.0
+  - libgomp
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7971729
+  timestamp: 1642617422064
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.6.2-py38had2a1c9_1.tar.bz2
+  sha256: e601bf7ba1fe39b9e2faab62f0fb9b637ca6aeddc2ed70e7ec364e972c9d7fce
+  md5: c2b98d3f055c38b93d740402f29347d5
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.3.0
+  - libgfortran-ng >=7,<8.0a0
+  - libstdcxx-ng >=7.3.0
+  - mkl >=2021.2.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  license: BSD 3-Clause
+  size: 21164725
+  timestamp: 1618856307974
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py38h06a4308_0.tar.bz2
+  sha256: 9f4cc75cff095f7a5f8bef8fdd23db5676b8a958661556f32712dd1b95427735
+  md5: df8c6561cfa56fd8761cebba233cc885
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 1084829
+  timestamp: 1690290959166
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/shapely-1.7.1-py38h1728cc4_0.tar.bz2
+  sha256: 7e09fab4eba71c6bbfb16c0d6ccce87106e0a7f09a868db90f27850ed29c25a0
+  md5: 6c73554c4de6df382fa254eba9fe2c3c
+  depends:
+  - geos >=3.8.0,<3.8.1.0a0
+  - libgcc-ng >=7.5.0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  size: 456532
+  timestamp: 1632813570956
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py38h06a4308_1.tar.bz2
+  sha256: 52850a7d4a19c13be2b62962055e8a8104f5dc79926ca70a1d1a52529527d30f
+  md5: 884ea8d949dedfb11505f8d0e27c022e
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15671
+  timestamp: 1614030513783
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py38h06a4308_0.tar.bz2
+  sha256: e888d0ed8d489e081102fb1c816479db50802243f40ba24079a76465709642e3
+  md5: 20d72998dbdd62e71f8901634d630352
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 66454
+  timestamp: 1696347666187
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+  sha256: 87965b7b46d93866d31696a1045216d64f077a06b2900c356aba87e8559c6188
+  md5: fa334030245135b37027a882f3c468bf
+  depends:
+  - libgcc-ng >=7.5.0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: blessing
+  license_family: Other
+  size: 1561908
+  timestamp: 1655328608308
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
+  sha256: d4c0f3e57d8df6042151e65a706f8cd76c9325a47548f4ca3c3516e352dd8ca3
+  md5: 1decb9dd0e7bcee086d83b8b4ab8c8eb
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: Apache-2.0
+  size: 171277
+  timestamp: 1641830509786
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py38h06a4308_0.tar.bz2
+  sha256: b1aaff89c39b3dfd49e910e706f63fc361d4edd14350ea7f6b9fbfc1984ead35
+  md5: 462c5ca383e788c3f7d20270e378991b
+  depends:
+  - ptyprocess
+  - python >=3.8,<3.9.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29863
+  timestamp: 1671751945016
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/testpath-0.6.0-py38h06a4308_0.tar.bz2
+  sha256: 5bc56eb1d33f8d60d675b53bf462ec49e9ac548614af880db53b651bfaae54a5
+  md5: 23ebb7cf9ee5b1fe62a911fb71e272ee
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 93471
+  timestamp: 1655908769769
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tiledb-2.2.9-hffe1d7a_0.tar.bz2
+  sha256: 8be642799a2a15ad1a444aa863fde9e5bf0671617f7046dab33429acc04a5221
+  md5: 7c97ee1834361965bdd31312ca9650dc
+  depends:
+  - aws-sdk-cpp >=1.8.185,<1.8.186.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=7.71.1,<9.0a0
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=1.1.1k,<1.1.2a
+  - zlib >=1.2.11,<2.0.0a0
+  - zstd >=1.4.9,<1.5.0a0
+  license: MIT
+  license_family: MIT
+  size: 1772055
+  timestamp: 1621648801177
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+  sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
+  md5: 5b8375e2092012db69d2123dc0c68630
+  depends:
+  - libgcc-ng >=7.5.0
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3485432
+  timestamp: 1654088939579
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py38h06a4308_0.tar.bz2
+  sha256: 85077229bfc69efa66079274390675e2f81ffe092435103685d54166e5e69ba6
+  md5: aec171353448852f51e81c68ef45dfaa
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101498
+  timestamp: 1667464200465
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py38h27cfd23_0.tar.bz2
+  sha256: d90c5e38c73cc80e7d69e7f7e8df47df5d32b6a31bef0d7a799e12132211624b
+  md5: 5a07056c0968e39f39510f8b9526714c
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 663452
+  timestamp: 1606942346182
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py38hb070fc8_0.tar.bz2
+  sha256: effd1650a61f827fe737a963c6b2463b3710bcde3ff32908cca3b3617064b3aa
+  md5: 0769c92607812f43d1b10fdff177e247
+  depends:
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - ipywidgets >=6
+  - requests
+  - slack-sdk
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 123487
+  timestamp: 1679562034657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py38h06a4308_0.tar.bz2
+  sha256: 235a049eda3efc73e47d54c57d3bd1567008e5b9b1b9aed4d72d800c217d77fa
+  md5: 329270e6ef807c97c1141afdb85113fe
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 191687
+  timestamp: 1671143939929
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py38h06a4308_0.tar.bz2
+  sha256: 0214199a2e56a6ad98685dc0a40720eaa2c5e892b55b9353b53f433f677633a1
+  md5: ca4a726759f04cc2bccfb478c5794ade
+  depends:
+  - python >=3.8,<3.9.0a0
+  - typing_extensions 4.7.1 py38h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8762
+  timestamp: 1690297626227
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py38h06a4308_0.tar.bz2
+  sha256: 52599ac2dd2b4e6bf74d3577ff56ecb69902796d0dcc339b2423b0d52825d44a
+  md5: 5ed3156dad316237ecfb1ee2dc5c535c
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57757
+  timestamp: 1690297620154
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.18-py38h06a4308_0.tar.bz2
+  sha256: 269000563c12ffc371a206195aa601b1c3f987d88d5d3008a7ff32f564902b39
+  md5: de0c6a9cc6d098a3c9d62a1dd9a890d7
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 187862
+  timestamp: 1698257569604
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py38_1.tar.bz2
+  sha256: c6fd7f78c18396f22bde60d84004159a5398d7eaad14ab1b6f7550e9605e3616
+  md5: 46be58263b91ea0ce41774c6cef974b7
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20211
+  timestamp: 1573200372707
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py38h06a4308_4.tar.bz2
+  sha256: 14ffa5f5ce2a18bc7b59c1157c9a61db6c3af83adf5d7b7f386681dfd7571524
+  md5: 8ea9442d80b018f9d1bcac1e59469232
+  depends:
+  - python >=3.8,<3.9.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70872
+  timestamp: 1614804298366
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py38h06a4308_0.tar.bz2
+  sha256: 461d94450fee3587c2b8666eaa56ba691b992eb1dfae3ca7e890092655f7812d
+  md5: 933a3dc0c0be419cfee4f58a94682dce
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 101287
+  timestamp: 1695741958427
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2022.11.0-py38h06a4308_0.tar.bz2
+  sha256: 508985a639f29648f66f7dd3856ad0baf5501601582e52ad26cae4c0e7ca8ea8
+  md5: cbef8e255222ff1c5727b7529031ccf8
+  depends:
+  - numpy >=1.20
+  - packaging >=21.0
+  - pandas >=1.3
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1722500
+  timestamp: 1668776634679
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xerces-c-3.2.3-h780794e_0.tar.bz2
+  sha256: 92db799484b158380af98f43d255e61469a759e1a3cf7e5dd0c900687880fd3b
+  md5: 8dc5173488d49dc09105ca6359fd4986
+  depends:
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: Apache 2.0
+  license_family: Apache
+  size: 3476121
+  timestamp: 1599879004914
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py38h06a4308_1.tar.bz2
+  sha256: 846ae02929f4570ad0979c56332af5b3b4da851419a051e7902bd3a6ec2a0755
+  md5: 4d7632b5d03d4b2be70e952e890bcbd5
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 47860
+  timestamp: 1675159165834
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+  sha256: 2ce360ff98c0ca4537d70c19266b5700810196c54ce2fbaff3b94a969846ee37
+  md5: 94cb94dc47405b24b1b5bd0a3275ab59
+  depends:
+  - libgcc-ng >=7.5.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 398058
+  timestamp: 1651602137803
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+  sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
+  md5: 567b68192c387b5fc88178425577a0fe
+  depends:
+  - libgcc-ng >=7.3.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=7.3.0
+  license: LGPL-3.0-or-later
+  size: 366479
+  timestamp: 1616055552392
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py38h06a4308_0.tar.bz2
+  sha256: 5e35fe343f2db943bb40881684974c9325d13b645baebd67d0ff6c81a1c411ff
+  md5: c701afabfd0e39a192953874321cb29d
+  depends:
+  - heapdict
+  - python >=3.8,<3.9.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 76355
+  timestamp: 1695832914431
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py38h06a4308_0.tar.bz2
+  sha256: bf2618c61988cae41c3428a3e4564f22016705b29b312ba2ffe02b2c7413e407
+  md5: ea786d4d331b83592b3004c0d5015131
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 17966
+  timestamp: 1672387151546
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+  sha256: 513444d83ac2405e898531492ea59f3a95641e357cc39c1048d6fffc1791a16b
+  md5: 601d9449c280b9b145dc8c83b6f06119
+  depends:
+  - libgcc-ng >=7.5.0
+  license: Zlib
+  license_family: Other
+  size: 133595
+  timestamp: 1650637720646
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.4.9-haebb681_0.tar.bz2
+  sha256: d1969321874e6d0a7b9994a043830e453a5caab9c3d89690351ba658700ab611
+  md5: 77148a73936c37451810f0b1453569e9
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: BSD 3-Clause
+  size: 828849
+  timestamp: 1617228573594
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
+  md5: b2aa5503875aba2f1d88cae9df9a96d5
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13636
+  timestamp: 1611930018941
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
+  md5: 544adf2677c47c9b9c891aea720678f1
+  depends:
+  - python >=3.5
+  license: MIT
+  size: 33999
+  timestamp: 1630003259346
+- conda: https://repo.anaconda.com/pkgs/main/noarch/click-7.1.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 13795c5b123ae6bd1102ad9a267a6b731da8557441a1e0265527bcd7f349393b
+  md5: 62c4d9050c9d92ac315a9ae52ec9c0df
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65208
+  timestamp: 1610990606745
+- conda: https://repo.anaconda.com/pkgs/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 159043b22b754bbfd41d70508ef60a42e3e0f74ebaccd4633726bcf944ab4249
+  md5: 86fd637d64a91d9e916f19f349d45a97
+  depends:
+  - click >=3.0,<8.2
+  - python
+  license: BSD-3-Clause
+  size: 10095
+  timestamp: 1630665910221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
+  sha256: bd00b5f84c5fee1a4f252c26d6575a93bcdc5e71832270685e002bf78b2f4eba
+  md5: 7c9691bb77e3f20cf12ded06388b4aad
+  depends:
+  - click >=4.0
+  - python >=3.6
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 10160
+  timestamp: 1622563293746
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2021.10.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 79e7ff341f1aa75e0fb2f684b3d95eb24573c884fe2a02b792b12dda9c29da85
+  md5: 1290c500828e2959c3654cf72bd19f21
+  depends:
+  - bokeh >=1.0.0,!=2.0.0
+  - cytoolz >=0.8.2
+  - dask-core 2021.10.0.*
+  - distributed 2021.10.0.*
+  - jinja2
+  - numpy >=1.18
+  - pandas >=1.0
+  - python >=3.7
+  constrains:
+  - openssl !=1.1.1e,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19028
+  timestamp: 1635969424133
+- conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2021.10.0-pyhd3eb1b0_0.tar.bz2
+  sha256: f1441f9930ef17f102206bc46c909813985101d0e894d87a61124fac1525213f
+  md5: d3cac1fc6af6b597c0e392517eeeb262
+  depends:
+  - cloudpickle >=1.1.1
+  - fsspec >=0.6.0
+  - packaging >=20.0
+  - partd >=0.3.10
+  - python >=3.7
+  - pyyaml
+  - toolz >=0.8.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 790776
+  timestamp: 1635946371963
+- conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 2de2d79a0e9784a1bf55cdb83c035072da1879753d109c0a36bbd5a357385c37
+  md5: 6cfe764bb04e756d7d1319a98a05dd70
+  depends:
+  - bokeh
+  - colorcet >=0.9.0
+  - dask >=0.18.0
+  - datashape >=0.5.1
+  - numba >=0.51
+  - numpy >=1.7
+  - pandas >=0.24.1,<3.0.0
+  - param >=1.6.1,<2.0.0a0
+  - pillow >=3.1.1
+  - pyct >=0.4.5
+  - python >=2.7
+  - scipy
+  - toolz >=0.7.4
+  - xarray >=0.9.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14964307
+  timestamp: 1623782401693
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+  sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
+  md5: 9eff1a842dbda8d1bae9a2c008b599bc
+  depends:
+  - brotli >=1.0.1
+  - munkres
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 690443
+  timestamp: 1625743217109
+- conda: https://repo.anaconda.com/pkgs/main/noarch/geoviews-1.9.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 27eb00a0e6be1b8f23516e69822f43319fcda65d887cb27736aacebfa2dc9e54
+  md5: 7de7f3bb8bcefa323aa0e68d022d9bd3
+  depends:
+  - bokeh >=2.3.0,<2.4.0
+  - cartopy >=0.18.0
+  - datashader
+  - geopandas
+  - geoviews-core >=1.9.1,<1.9.2.0a0
+  - holoviews >=1.14.2
+  - netcdf4
+  - numpy >=1.0
+  - pandas <3.0.0
+  - param >=1.9.3,<2.0
+  - pyct
+  - python >=3.6
+  - xarray
+  license: BSD-3-Clause
+  size: 10159
+  timestamp: 1617997243067
+- conda: https://repo.anaconda.com/pkgs/main/noarch/geoviews-core-1.9.1-pyh06a4308_0.tar.bz2
+  sha256: 52f1723f8fe3cd7708354a2b7259c6c517774c160ef607e3a914d5e55ec1d9ab
+  md5: 02ac497f5296311a1452226744460e53
+  depends:
+  - bokeh >=2.3.0,<2.4.0
+  - cartopy >=0.18.0
+  - holoviews >=1.14.2
+  - numpy >=1.0
+  - param >=1.9.3
+  - python >=3.6
+  constrains:
+  - geoviews 1.9.1
+  license: BSD-3-Clause
+  size: 417321
+  timestamp: 1617997156535
+- conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 9de8666e5b70aa2437737128eaa14ffe80a7b5235c2a6b7d3f39ccefd7816ba0
+  md5: bb52e50c5ab1a5c7778c11376404dfdb
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 7933
+  timestamp: 1630598543551
+- conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.6-pyhd3eb1b0_1.tar.bz2
+  sha256: 47722ce25b58c78a04cf7105515be98e8901ddf327032cb930fdcc826682ac66
+  md5: d6216d6a97168f609d98e9fc91ffe9fa
+  depends:
+  - bokeh >=1.1.0
+  - colorcet
+  - ipython >=5.4.0
+  - matplotlib-base >=3
+  - notebook
+  - numpy >=1.0
+  - pandas >=0.20.0
+  - panel >=0.9.5
+  - param >=1.9.3,<2.0
+  - python >=2.7
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3605565
+  timestamp: 1632131635972
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 9c97f6b9a2cfba7b99e6732505a567787fb86da32cbf2aa6b825069361807845
+  md5: e3d2afca7f53449172cb027b2164df6b
+  depends:
+  - markupsafe >=0.23
+  - python
+  - setuptools
+  license: BSD-3-Clause
+  size: 96029
+  timestamp: 1612213176846
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+  sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
+  md5: 33624a42ee387bf9918ea98b4e7b31fc
+  depends:
+  - pygments >=2.4.1,<3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8173
+  timestamp: 1601490751973
+- conda: https://repo.anaconda.com/pkgs/main/noarch/munch-2.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: a263721943f9afb44be6fe84b1cd129371cf07f6f5de6b5507dce9872a763e72
+  md5: 58d8526d24479e39c8bdd9bb2978480d
+  depends:
+  - python
+  - setuptools >=17.1
+  - six
+  license: MIT
+  size: 13568
+  timestamp: 1630566403911
+- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+  sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
+  md5: 67857cc5e9044770d2b15f9d94a4521d
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12810
+  timestamp: 1600445183315
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 011406e85cbb2a3d1e687620dd18ec798ab34a7478f46e7e81b9d8a11fdd914f
+  md5: 7ed543858227e957d774766cd46acba9
+  depends:
+  - bleach
+  - bokeh >=2.3,<2.4
+  - markdown
+  - param >=1.10.0,<2.0.0a0
+  - pyct >=0.4.4
+  - python >=3
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10334744
+  timestamp: 1628798011706
+- conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 110a3b50f89584ccb13980a617f6258b83b0bc56c8897c96d9e0da9fdc2c957c
+  md5: 6266365b47ed65cdb4737603a385c691
+  depends:
+  - python >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 69119
+  timestamp: 1625476602265
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+  sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
+  md5: e68a6f315f41a8d814d833652bf38b9b
+  depends:
+  - python >=3
+  license: MIT
+  size: 13374
+  timestamp: 1606932077143
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pyshp-2.1.3-pyhd3eb1b0_0.tar.bz2
+  sha256: c73f60b664d8be46325f8372be5b8833fa4b864939802af5bcd3e539fe2cf6e2
+  md5: 1c6c5cc5d5265e03f16976a2d07da773
+  depends:
+  - python
+  license: MIT
+  size: 36844
+  timestamp: 1610641859075
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
+  md5: 2eb923cc014094f4acf7f849d67d73f8
+  depends:
+  - python
+  - six >=1.5
+  license: BSD-3-Clause and Apache
+  license_family: BSD
+  size: 246457
+  timestamp: 1626374695070
+- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
+  md5: 41db68b96e114e367c4f120a3b379e59
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19391
+  timestamp: 1632406728844
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 4e47f6c49ce84509f1466e8a4d728447bf4bcd9bce7b456431a789a262547067
+  md5: 4cad993b0f80bc23fb66a97592299cbb
+  depends:
+  - python >=2.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 26504
+  timestamp: 1623949147884
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+  sha256: ca2be6c7810a37cfc6db1f5383937b5d35c6d73c1fad8a9104de85f069b1df1c
+  md5: 9ccb2fb33edb152403d6ef32bf758a9d
+  depends:
+  - python
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 15614
+  timestamp: 1629402049497
+- conda: https://repo.anaconda.com/pkgs/main/noarch/threadpoolctl-2.2.0-pyh0d69192_0.tar.bz2
+  sha256: 16c52bfa6aa2ec07cbf96e260e85a48dd04ec86d3e3b3d7d62eed942f7403d86
+  md5: 9047a4e29044b6c760b5d94f62622f4d
+  depends:
+  - python >=3.6
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 16320
+  timestamp: 1629802282940
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/noarch/xarray-0.20.1-pyhd3eb1b0_1.tar.bz2
+  sha256: 26a02dd567e4fc62857c01ac9a885bf0754fd357893d1c12ff121238412dbf47
+  md5: 05378c8aaf2d777f70c8ab45d9d66634
+  depends:
+  - numpy >=1.17
+  - pandas >=1.0
+  - python >=3.7
+  - setuptools >=40.4
+  - typing-extensions
+  license: Apache-2.0
+  license_family: Apache
+  size: 638342
+  timestamp: 1639166152807
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py38hecd8cb5_0.tar.bz2
+  sha256: 0cccac6d469f91909c7dc74bc152d8db27d2bde9956483b120d20ec348ae67d2
+  md5: d4bd9f9d289eea1119c9f4753b3b0a6c
+  depends:
+  - idna >=2.8
+  - python >=3.8,<3.9.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 161790
+  timestamp: 1644481760813
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py38hecd8cb5_1001.tar.bz2
+  sha256: 80777c5e13c10f946bafdb2ccdb0a13010669bb4a0d424b15f81816427f9bc4e
+  md5: 070364c2c941da9fefa521327645d2ff
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10035
+  timestamp: 1606859471981
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py38hca72f7f_0.tar.bz2
+  sha256: be2b0feedb5668e85bdb044ecdf769e12a4acd0bf026e8c1858327cfbc44945c
+  md5: e70cb13b190f8141882cef82fbabf6f0
+  depends:
+  - cffi >=1.0.1
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 36067
+  timestamp: 1644569747309
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py38hecd8cb5_0.tar.bz2
+  sha256: 802ff851f350213cc4a853b36dad9ac32e17ab1875d1eae907cbb6e649431564
+  md5: 8c720af57f6c0123c6b049d0edd80e16
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 133707
+  timestamp: 1695717877708
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py38hecd8cb5_0.tar.bz2
+  sha256: acd1f9e887b18bea21e3e34b0ff0f3a1a2b721e69521bc80c2147ee48e25aadf
+  md5: 9b4fac05a82d4113b319094316b193bf
+  depends:
+  - python >=3.8,<3.9.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206831
+  timestamp: 1681493135398
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
+  sha256: 3699a260f422443de85b74084fe36f734be1a466eeebdfdf4195d52c9fdb5508
+  md5: 132d056e66b3ae9148f53819f8368c94
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - zlib >=1.2.12,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 66125
+  timestamp: 1675247668924
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.3.3-py38hecd8cb5_0.tar.bz2
+  sha256: 0409c51e441456e160cf6fb52b2491cc45aede022939cb64018912786b564f8a
+  md5: bd420cae4de6a7f01c1d89d477d651f3
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.1
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8619137
+  timestamp: 1625767586586
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.73.0-hca72f7f_12.tar.bz2
+  sha256: 794fc813728b709f3982dfab846bec15ba0b4b44dd574a7f486d508eca929777
+  md5: c02652894bb5e54703ea671300cc03dd
+  depends:
+  - libboost 1.73.0 h3fa6bed_12
+  license: BSL-1.0
+  license_family: OTHER
+  size: 17652
+  timestamp: 1655879884826
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py38h67323c0_0.tar.bz2
+  sha256: e53de3a8d348f91ec7568c800553a3e0f205852ce9e7fa0144201b35fd61172c
+  md5: fcb7017fa37d45a11adcf435c93f0732
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 129184
+  timestamp: 1657176017065
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/branca-0.6.0-py38hecd8cb5_0.tar.bz2
+  sha256: b6680dd868a30deddf86acc3c65bf7936389bee6eeb9768c78fc3ba8f967e392
+  md5: 4790982d413fbb69732ba220e5c72a0a
+  depends:
+  - jinja2
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 43778
+  timestamp: 1675157661567
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
+  md5: 31d6d04cd2388d8f19004501271b3545
+  depends:
+  - brotli-bin 1.0.9 hca72f7f_7
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18982
+  timestamp: 1659616229395
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
+  md5: caf1073dc2ca5aeb832a2877394eae12
+  depends:
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18233
+  timestamp: 1659616216769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py38he9d5cce_7.tar.bz2
+  sha256: bcaf78fe2cf03c6673f1b273774d02aa64c2700bbd37cd24a8477cb27ac65d7d
+  md5: de254ca137e54af2736477f477dd3f10
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  size: 393312
+  timestamp: 1659616275061
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
+  sha256: 4574ffa241157e108d19ece60107a3a689cefaaca43578e6c4a6b344c7330278
+  md5: ab3b4e83407001e7f1603ca1fa0f4873
+  license: bzip2
+  license_family: BSD
+  size: 106284
+  timestamp: 1563219666100
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+  sha256: f913b61ba3c1651b36688415cc163a5d575475f7573b543f48a80e7a5002e4bb
+  md5: f11d165eaa532ce04a35382841284298
+  license: MIT
+  license_family: MIT
+  size: 107047
+  timestamp: 1693902034820
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+  sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
+  md5: ce3588e31faa79f546e0fc6a36c5543c
+  license: MPL-2.0
+  license_family: Other
+  size: 133884
+  timestamp: 1694009771475
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cairo-1.16.0-h3ce6f7e_5.tar.bz2
+  sha256: 40610c1f84d17423e18948662190fab696d55b974b44c0e81efc8b4a18c74377
+  md5: a562993d973bb938743ff338502108d8
+  depends:
+  - fontconfig >=2.14.1,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - glib >=2.69.1,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - pixman >=0.40.0,<1.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: LGPL-2.1-or-later or MPL-1.1
+  license_family: LGPL
+  size: 1434523
+  timestamp: 1688495924565
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cartopy-0.18.0-py38hf1ba7ce_1.tar.bz2
+  sha256: 6a0cc038fc4e2d1711b9e33856b731ce8460164e0ad7ac288e9db1e4dfa25786
+  md5: eab377b64536e10d3c4182c438076306
+  depends:
+  - geos >=3.8.0,<3.8.1.0a0
+  - libcxx >=10.0.0
+  - matplotlib-base >=1.5.1
+  - numpy >=1.16.6,<2.0a0
+  - proj >=6.2.1,<6.2.2.0a0
+  - pyshp >=1.1.4
+  - python >=3.8,<3.9.0a0
+  - scipy >=0.10
+  - shapely >=1.5.6
+  - six >=1.3.0
+  license: LGPL-3
+  size: 1938628
+  timestamp: 1612289897346
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py38hecd8cb5_0.tar.bz2
+  sha256: c15d4e7d44baed9f04f039c2b53b4c22b0131bea5a7ec45b4bb7f34a9f77785c
+  md5: 2341095fd443f53c4305934f61029fc0
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159837
+  timestamp: 1690232318712
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py38h6c40b1e_3.tar.bz2
+  sha256: 5aa74865b5eb126265ec6f4725df01a48bf7080821c79c60ab8d563a96834923
+  md5: c7484c110ae9772e91e070550d358171
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 225626
+  timestamp: 1670423374108
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
+  sha256: 68a12eaeda90c9cdbce729f0d44d222c3f60ec4920bb781bf13fae3a89cb3dd1
+  md5: a0970a5c1c77125369aded2d4e25f870
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=7.82.0,<9.0a0
+  - libgfortran 5.*
+  - zlib >=1.2.12,<1.3.0a0
+  license: Other
+  license_family: Other
+  size: 1437665
+  timestamp: 1655814938182
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cftime-1.6.2-py38hacda100_0.tar.bz2
+  sha256: cc87300a3c5f04e44bbe8bffb56a474d51c2c481986aa74c468d51915257fb58
+  md5: 5db49b76a5e813c9177a3481e99a8714
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 228349
+  timestamp: 1678830530985
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py38hecd8cb5_0.tar.bz2
+  sha256: d2b1550ca58a65e722b08e422d6065064a50d87a19a3fb99be81f36bcbf66fea
+  md5: b6338c9d4466d41e3902db36cc0a22d9
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 152727
+  timestamp: 1698129895844
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py38hecd8cb5_0.tar.bz2
+  sha256: 7783ca8cde172039022bf8f773b6641559829a436bf0deec2dd372224b5ccb05
+  md5: 861f685e1db0c13ad18a4ac1086b8e52
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41443
+  timestamp: 1683040101633
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py38hecd8cb5_0.tar.bz2
+  sha256: ed1004b253e18102c08d53bb6d65635adf73b8d95780adc813b564cabc302e19
+  md5: 22dfb5da1e9b3ad955249a73b9d05f40
+  depends:
+  - pyct >=0.4.4
+  - python >=3.8,<3.9.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1969200
+  timestamp: 1668084617810
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py38hecd8cb5_0.tar.bz2
+  sha256: c504c9ad1d0a4ba516a1199085caf74a2b7140921a253bb885df6c5fcf12efc8
+  md5: 4517ff76687a031c86266080fa80df39
+  depends:
+  - python >=3.8,<3.9.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13753
+  timestamp: 1671231158299
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py38haf03e11_0.tar.bz2
+  sha256: 1473dda25c38fb08cbe01cecd833141002a9a70231e7743c77124a3f90d51626
+  md5: 1456da04419043ef34f05b42758598da
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 225845
+  timestamp: 1663827553065
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py38ha2381d6_0.tar.bz2
+  sha256: d0bb7704c09b048fcb02d40e520e1e0bdb760733b0b4881b91ff72a5df60b08a
+  md5: ee45ddb3786ca048bad9f5134b0a1da2
+  depends:
+  - cffi >=1.12
+  - openssl >=1.1.1v,<1.1.2a
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1307346
+  timestamp: 1694212384731
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/curl-8.2.1-hdb2fb19_0.tar.bz2
+  sha256: 130f332f702f2dcd9c91e8a0f4f1cdcf5581f8ba5e6869d067c12e3f2484704d
+  md5: 4386a71e5b735aa2cb407c2ee14fbb7e
+  depends:
+  - libcurl 8.2.1 ha585b31_0
+  license: curl
+  license_family: MIT
+  size: 87770
+  timestamp: 1693515526229
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.0-py38hca72f7f_0.tar.bz2
+  sha256: a6a95826664084b16b583159ad4cce30ff90043baf645ed516f4ae7634776ab6
+  md5: 999e3395ff83a25f72024852eb31921c
+  depends:
+  - python >=3.8,<3.9.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 356978
+  timestamp: 1667466007219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py38hecd8cb5_1.tar.bz2
+  sha256: 93795b6dc8f961dbe377760a32f38512e015d618109cbc030cac09f171be2078
+  md5: fe229f4229cb5acdf2d397c2b12182d0
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7
+  - python >=3.8,<3.9.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 103937
+  timestamp: 1613390235465
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py38hcec6c5f_0.tar.bz2
+  sha256: 455dc5a3dba2409362ef2c91841cd68e3a73fb6f96267b291c9b7e1fa24e785a
+  md5: 55f079cc255134e545e705a49eb5c18a
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 2051390
+  timestamp: 1690905143314
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2021.10.0-py38hecd8cb5_0.tar.bz2
+  sha256: cd69702775d7ba1f9faffbf9afb9c97d159b8751db1845f66484af1549850346
+  md5: 45b0bc9fbef7454dd87480f2e6beadc0
+  depends:
+  - click >=6.6
+  - cloudpickle >=1.5.0
+  - cytoolz >=0.8.2
+  - dask-core 2021.10.0.*
+  - jinja2
+  - msgpack-python >=0.6.0
+  - psutil >=5.0
+  - python >=3.8,<3.9.0a0
+  - pyyaml
+  - setuptools
+  - sortedcontainers !=2.0.0,!=2.0.1
+  - tblib >=1.6.0
+  - toolz >=0.8.2
+  - tornado >=6.0.3
+  - zict >=0.1.3
+  constrains:
+  - openssl !=1.1.1e,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1122011
+  timestamp: 1635968255567
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py38hecd8cb5_0.tar.bz2
+  sha256: 0f432eeab9a2f0363540efcda4a1048b3d60d5e0b3e2cfb106748759caa28138
+  md5: f0461cfd6eac119ca072171039b5f799
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16516
+  timestamp: 1649926487728
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/expat-2.5.0-hcec6c5f_0.tar.bz2
+  sha256: 4ed38bee31511bbea15cd0277637cb0118063db777aad9640c9599777837cc6a
+  md5: 57cd2dedd78fd34dcd445e59bb50b901
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 153966
+  timestamp: 1693497401154
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fiona-1.9.1-py38h07fba90_0.tar.bz2
+  sha256: 80d8e61fca4addfd994557a405e5b3e42e5d0ce485b8cbd768c65bd97b99d760
+  md5: a01a0178fb5d2fb151d10c08f2f69852
+  depends:
+  - attrs >=19.2.0
+  - certifi
+  - click >=8.0,<9.dev0
+  - click-plugins >=1.0
+  - cligj >=0.5
+  - gdal
+  - libcxx >=14.0.6
+  - libgdal >=3.6.2,<3.7.0a0
+  - munch >=2.3.2
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  - shapely
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1437902
+  timestamp: 1678226542539
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/folium-0.14.0-py38hecd8cb5_0.tar.bz2
+  sha256: 631c5a1545d2b8ed989bfc18c61c29feda4604b7a260e00264a92a23f4a89653
+  md5: f1eb9c433ccb9b3877603fb7028afd4a
+  depends:
+  - branca >=0.6.0
+  - jinja2 >=2.9
+  - numpy
+  - python >=3.8,<3.9.0a0
+  - requests
+  license: MIT
+  license_family: MIT
+  size: 115949
+  timestamp: 1675353609091
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fontconfig-2.14.1-hb0a0c50_2.tar.bz2
+  sha256: cff12dd33d60375ba68efecddf15821eb8415a28424e76f5646c497b953bd534
+  md5: 0cc9c9743f309dd8032fdaa2b1109bb0
+  depends:
+  - expat >=2.4.9,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - libxml2 >=2.10.3,<2.11.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 283281
+  timestamp: 1679578322712
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freexl-1.0.6-h9ed2024_0.tar.bz2
+  sha256: b2b7b310f0ff104a46ce3f3688ea17d2c9196471fad1011d2850ab0c27cd73cb
+  md5: 59e2b2e4b54bbcf812da25edd37b50b0
+  license: MPL-1.1
+  size: 44336
+  timestamp: 1607116125222
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py38hecd8cb5_0.tar.bz2
+  sha256: f2a756f00876b7f6669810be125faf7ef9fec40eaa219b8aa273d928c911e58c
+  md5: d17e19a59284ede5aeff0e8010fad6e7
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 261386
+  timestamp: 1695734607249
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/gdal-3.6.2-py38h09faefc_1.tar.bz2
+  sha256: 7cb60f305eacc8c163e22e937e9c944c27a2de24b22535c9b5f5ed8fe3360a13
+  md5: 1e09654e04ac51dcf7f1584233140177
+  depends:
+  - blosc >=1.21.3,<2.0a0
+  - cfitsio >=3.470,<3.471.0a0
+  - expat >=2.4.9,<3.0a0
+  - freexl >=1.0.6,<2.0a0
+  - geos >=3.8.0,<3.8.1.0a0
+  - geotiff >=1.7.0,<1.8.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - hdf4 >=4.2.13,<4.2.14.0a0
+  - hdf5 >=1.10.6,<1.10.7.0a0
+  - libcxx >=14.0.6
+  - libgdal 3.6.2 hd170585_1
+  - libiconv >=1.16,<2.0a0
+  - libxml2 >=2.10.3,<2.11.0a0
+  - numpy >=1.16.6,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - openssl >=1.1.1t,<1.1.2a
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 1978396
+  timestamp: 1680121051020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/geopandas-0.12.2-py38hecd8cb5_0.tar.bz2
+  sha256: 6e59129ed7338a770b90ce1f939e79a8da2150d6490be934718f861ce30ba8c8
+  md5: 26e0a2f8cc653c02f1b1c828feaefb51
+  depends:
+  - folium
+  - geopandas-base 0.12.2 py38hecd8cb5_0
+  - mapclassify >=2.4.0
+  - matplotlib-base >=3.2.0
+  - python >=3.8,<3.9.0a0
+  - rtree
+  - xyzservices
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7463
+  timestamp: 1675672207035
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/geopandas-base-0.12.2-py38hecd8cb5_0.tar.bz2
+  sha256: 8a400afb3f8edbca9d130f91ee8075fef5e246c9aa060eef0e7ef3f3c18198cf
+  md5: fc707c074cf2a2cc1b0b29ec4a65b93c
+  depends:
+  - fiona >=1.8
+  - packaging
+  - pandas >=1.0.0
+  - pyproj >=2.6.1.post1
+  - python >=3.8,<3.9.0a0
+  - shapely >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1281265
+  timestamp: 1675672205197
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/geos-3.8.0-hb1e8313_0.tar.bz2
+  sha256: ec1a020f11e34a94622a35fe338a640e688bd2a9959779e441496c575c1ebfd4
+  md5: d43b2e34536205c250f9a9a699d39b84
+  depends:
+  - libcxx >=10.0.0
+  license: LGPL-2.1
+  size: 916394
+  timestamp: 1592213531288
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/geotiff-1.7.0-hf6ff7a4_1.tar.bz2
+  sha256: 8ba62452fe808af58a827b742261f04207717de62e791f368850af2b5b6043d7
+  md5: eac42496164215cee9ac97a13d55be79
+  depends:
+  - jpeg >=9e,<10a
+  - libcxx >=14.0.6
+  - libtiff >=4.1.0,<4.7.0
+  - proj >=6.2.1,<6.2.2.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 134338
+  timestamp: 1679997088653
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/gettext-0.21.0-he85b6c0_1.tar.bz2
+  sha256: 1905463c17dd8c1f1c1a03028f95d5cfae9d166d6dc0bd0a1b17b8e30792de13
+  md5: f53f4a7175a223b7f9f50ac188e5c6b7
+  depends:
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - libxml2 >=2.10.3,<2.11.0a0
+  - llvm-openmp >=14.0.6
+  - ncurses >=6.4,<7.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 3540538
+  timestamp: 1679578758653
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+  sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
+  md5: e4a732941f74b8062c8bcbfe5c5c2b56
+  license: MIT
+  license_family: MIT
+  size: 80252
+  timestamp: 1676983220161
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/glib-2.69.1-hfff2838_2.tar.bz2
+  sha256: 4ee50c0be59fe9705d29b27b65921a3248dbd9566269d17f1daae96eaddaa41e
+  md5: f497b3963d0d57dfa41fca5af8af4ed0
+  depends:
+  - gettext >=0.21.0,<1.0a0
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.16,<2.0a0
+  - pcre >=8.45,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 3509291
+  timestamp: 1669364513587
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf4-4.2.13-h39711bb_2.tar.bz2
+  sha256: 85d7f9697d1243b5d088737a3f5c43610f01250f78e9a9fa9da6cca7830d73cf
+  md5: 637b7dadcfe411e14233764fd1d820a3
+  depends:
+  - jpeg >=9b,<10a
+  - libcxx >=4.0.1
+  - zlib >=1.2.11,<1.3.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 895428
+  timestamp: 1510863932515
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf5-1.10.6-h10fe05b_1.tar.bz2
+  sha256: 0ec239cffba75bd5443fbafad7d533c3b395cf5f025194dfccc12e963df4e02e
+  md5: d556a6e6efe810832e6b78147396ce58
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran 5.*
+  - zlib >=1.2.12,<1.3.0a0
+  license: HDF5
+  license_family: BSD
+  size: 5076375
+  timestamp: 1655307890871
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-58.2-h0a44026_3.tar.bz2
+  sha256: c04f4cf3f9c4879c4d95b36cc842a5def9d1224aad73ef456fd069f162e3d603
+  md5: 5c5aa862793c874be6ec8d6af7d1f4e4
+  depends:
+  - libcxx >=4.0.1
+  license: MIT
+  size: 23669475
+  timestamp: 1588026009899
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py38hecd8cb5_0.tar.bz2
+  sha256: 37193b4249722a002743fbd55aaa9d643884e85b7bb7b82e8fa409001d54d292
+  md5: 145bb1e70f8ddefdcc2f9c9aa8183b0e
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 112446
+  timestamp: 1666125605192
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py38hecd8cb5_0.tar.bz2
+  sha256: bae1f77e166a4292856a91c650211749a6366a923f2d2da13e991b9eb05105fe
+  md5: 339011881b7709b8c85d21ff1dfed022
+  depends:
+  - python >=3.8,<3.9.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38818
+  timestamp: 1678997187815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py38hecd8cb5_0.tar.bz2
+  sha256: ab374287c5482933cff8230423177ba5877ac74ed858f8f15963935f9eba207a
+  md5: da7d084f202c48e592c952cb79e314b7
+  depends:
+  - python >=3.8,<3.9.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51759
+  timestamp: 1698254665985
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+  sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
+  md5: 78baea934985ccd9514a366cc7e80ed4
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 727499
+  timestamp: 1681801225190
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py38h20db666_0.tar.bz2
+  sha256: d266aed27d5c4ac41eb43752788348ffc10d62391f3d26fc8acdfb62d2749aab
+  md5: 463889395aa0fc1230b57391bba1e358
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 218394
+  timestamp: 1691122129329
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.12.2-py38hecd8cb5_0.tar.bz2
+  sha256: 9d76af4bc19372cc220b285d63598c90ba6e27476f0d9088eb818e3ce69d7ed1
+  md5: 6a291fe69dc614fc91a22ec7f86bc85d
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.8,<3.9.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1235334
+  timestamp: 1691532318531
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py38hecd8cb5_1.tar.bz2
+  sha256: 7ec96f7caade4290a41855f36c601758482dba830cf878f603891cb34768202b
+  md5: 524e7bc56614899dc780c19240e3f99d
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 1042868
+  timestamp: 1644315328525
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/joblib-1.2.0-py38hecd8cb5_0.tar.bz2
+  sha256: e03682853096c39af2687ca7d3f0e65b67273480a97c5f8e6f82bcd1340e5e84
+  md5: 85c8db7ecf42aba70436eb9cbcfc7c0d
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 407742
+  timestamp: 1685113334350
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
+  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
+  license: IJG
+  license_family: Other
+  size: 278924
+  timestamp: 1677849185191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/json-c-0.16-hca72f7f_0.tar.bz2
+  sha256: 2258f53c5f89d5ef8151aa775041c91de132ae5b467c0fb89c283c0fedc46836
+  md5: fc6b7ad3145ba86e7459b14fba98cd27
+  license: MIT
+  license_family: MIT
+  size: 73431
+  timestamp: 1659123708344
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py38hecd8cb5_0.tar.bz2
+  sha256: 9febfb16ec7fd88b1b43e158e157feeec58614c75592fc706b3fabfef4b92dd4
+  md5: b529959244a8951b78b036b4ec7f5a2d
+  depends:
+  - attrs >=17.4.0
+  - importlib_resources >=1.4.0
+  - pkgutil-resolve-name >=1.3.10
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 132739
+  timestamp: 1676559100279
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py38hecd8cb5_0.tar.bz2
+  sha256: cc595a959c77802c0ae5aca9cc9e72071b951cac97463210744bae530c2b5b8c
+  md5: 72993460036cd4ee6f80f4c63a1c7fd0
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 198052
+  timestamp: 1676329716909
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py38hecd8cb5_0.tar.bz2
+  sha256: d470142cb8f3ed5ad745b8d96eb86fd919948efb9b8c0759f3d2b2f48ab09673
+  md5: d26049a63cd89fc91a269ce5d76e10e6
+  depends:
+  - platformdirs >=2.5
+  - python >=3.8,<3.9.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92746
+  timestamp: 1679906726623
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py38hecd8cb5_0.tar.bz2
+  sha256: a7d191a475ccecf28faa577807ca9c992987e1ae18dbae86f3d78808dea7aae2
+  md5: 31ce21159341139a2bd7c2c83368f847
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 403237
+  timestamp: 1671707790827
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kealib-1.5.0-h72c422f_0.tar.bz2
+  sha256: f19ff41b92bab184778a6ff279dec6cbac94cf1de351d7e325380f64dec45121
+  md5: f26b397f2c259e3ec664dabcc0584d23
+  depends:
+  - hdf5 >=1.10.6,<1.10.7.0a0
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 169846
+  timestamp: 1674215919519
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py38hcec6c5f_0.tar.bz2
+  sha256: 4e9da4496ac7dcd7963447eab5c0de25f16dbba9a51422f68c95081a3657d384
+  md5: 83af611855a3505d81184247683e8b80
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64974
+  timestamp: 1672387224650
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
+  sha256: 8093a64350665d16ca2ad0acfcbba5c84b479c316a40db6b9d5f9b84b58f3b12
+  md5: cd98cc17f8297a31b1dd62f061ea4f83
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - openssl >=1.1.1u,<1.1.2a
+  license: MIT
+  license_family: MIT
+  size: 1289465
+  timestamp: 1686931250022
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.73.0-h3fa6bed_12.tar.bz2
+  sha256: e2e5b6b7670d19a008d86f5aec94e9f9a6989281116e3c0d70aa8d787d8c572e
+  md5: fa0eaa50e297abfae28fb3ea710890fd
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=58.2,<59.0a0
+  - libcxx >=12.0.0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 20158666
+  timestamp: 1655879850274
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
+  md5: 7dba7aa5b971febb55281659843586ba
+  license: MIT
+  size: 65470
+  timestamp: 1659616172703
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
+  md5: f78a158983f0bbaba56f34b976bc6dae
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 34189
+  timestamp: 1659616189313
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
+  md5: 36a1d885725d3ab4d1fadc5a29f978d2
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 327737
+  timestamp: 1659616202869
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
+  sha256: 83cf762f0d09c97dfb4a1c1cd9e635de2e54c384b057afbf3c0e2e8db07d862f
+  md5: ae3a458da93940fea1fa83af80d91fd4
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.52.0
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - zlib >=1.2.13,<1.3.0a0
+  license: curl
+  license_family: MIT
+  size: 358556
+  timestamp: 1693515516157
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20221030-h6c40b1e_0.tar.bz2
+  sha256: 67e38ccc55c2d996a8a0949080949c9803ddff84a96c4e34bc4c48fa95e5f35b
+  md5: b549aa024097c9f2790ba6eb89bc53fd
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 168786
+  timestamp: 1670840154554
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+  sha256: 4786264321edbff780633a5b752995eb3193ca4bce11b0fda179577f6cf1102c
+  md5: 849fdd014c201a9d2c2aa7c7db38a778
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 103993
+  timestamp: 1632891571494
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+  sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
+  md5: 817848d0e2b2808acdc9b3fbbf581726
+  license: MIT
+  license_family: MIT
+  size: 133887
+  timestamp: 1683716590737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgdal-3.6.2-hd170585_1.tar.bz2
+  sha256: 5fa6664d5bcb7dcdd40c9201c9bc470306e20eed90824adba7d7dce7067c94a8
+  md5: 19ba4795c8359ec302ec02193b241ac1
+  depends:
+  - blosc >=1.21.3,<2.0a0
+  - cfitsio >=3.470,<3.471.0a0
+  - expat >=2.4.9,<3.0a0
+  - freexl >=1.0.6,<2.0a0
+  - geos >=3.8.0,<3.8.1.0a0
+  - geotiff >=1.7.0,<1.8.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - hdf4 >=4.2.13,<4.2.14.0a0
+  - hdf5 >=1.10.6,<1.10.7.0a0
+  - icu >=58.2,<59.0a0
+  - jpeg >=9e,<10a
+  - json-c >=0.16,<0.17.0a0
+  - kealib >=1.5.0,<1.6.0a0
+  - lerc >=3.0,<4.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libiconv >=1.16,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libnetcdf >=4.8.1,<5.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=12.9,<13.0a0
+  - libspatialite >=4.3.0a,<4.4.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base
+  - libxml2 >=2.10.3,<2.11.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - openssl >=1.1.1t,<1.1.2a
+  - pcre2 >=10.37,<10.38.0a0
+  - poppler <=22.12.0
+  - postgresql
+  - proj >=6.2.1,<6.2.2.0a0
+  - qhull
+  - sqlite >=3.41.1,<4.0a0
+  - tiledb >=2.3.3,<2.4.0a0
+  - xerces-c >=3.2.4,<3.3.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 10247112
+  timestamp: 1680120970746
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+  sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
+  md5: e458587c87e3f2d20192f4e0738f2c63
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 149419
+  timestamp: 1665498987619
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+  sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
+  md5: 1058b661ec829b2ee3716ee2a5520641
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1917987
+  timestamp: 1665498925405
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+  sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
+  md5: c90372428e1e4eed4fdcd790979d06b4
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1409377
+  timestamp: 1650983531933
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libkml-1.3.0-h85bf17e_7.tar.bz2
+  sha256: 45936f0f5c7e616f02e028fa75b2177af1ad16587190d350b0c54489dba96cb2
+  md5: 66ef0c8cf08472f25fba622bdc99921c
+  depends:
+  - expat >=2.4.9,<3.0a0
+  - libcxx >=14.0.6
+  - uriparser >=0.9.7,<1.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 435832
+  timestamp: 1693261846695
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm11-11.0.0-h46f1229_1.tar.bz2
+  sha256: 239cc0e95b4aa48c7f09ac402f1a44b7b83131893b26201a482a531ea27b14b9
+  md5: 8aa9058bc551e8466cb15e8b6e539f6b
+  depends:
+  - libcxx >=10.0.0
+  - zlib >=1.2.11,<1.3.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 23039565
+  timestamp: 1646077131507
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnetcdf-4.8.1-ha5d86b0_2.tar.bz2
+  sha256: 987b646c7037ee6a1b33de92a37adc9eebe878f95706f82f128a2eaba71d245c
+  md5: 288e0d83731d69449f6f53080254cb97
+  depends:
+  - curl
+  - hdf4 >=4.2.13,<4.2.14.0a0
+  - hdf5 >=1.10.6,<1.10.7.0a0
+  - libcurl >=7.87.0,<9.0a0
+  - libcxx >=14.0.6
+  - libzip
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1529760
+  timestamp: 1674628246735
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
+  sha256: 331bc731419328a873e1a48d4257c58baa33d73b4b91ff7a3553b1c122120fb1
+  md5: 43fba990695db8556ddd0ade21d59ecc
+  depends:
+  - c-ares >=1.19.0,<2.0a0
+  - c-ares >=1.7.5
+  - libcxx >=14.0.6
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - openssl >=1.1.1u,<1.1.2a
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 782018
+  timestamp: 1686931556261
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpq-12.15-hdb2fb19_1.tar.bz2
+  sha256: e42c379349c26d271dcce50abf584296f068d09bf66d1bc4453ff93b704394d7
+  md5: ccecdea3f8a09704e3f80e2dc4fd3385
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - openssl >=1.1.1u,<1.1.2a
+  size: 2908306
+  timestamp: 1687380869057
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libspatialindex-1.9.3-h23ab428_0.tar.bz2
+  sha256: aa1bca7ee910973ee9bb5b20d0f8c441aebf409983118a12e835edb65297ead5
+  md5: 10a339fb0866adb3eda36b776263dc99
+  depends:
+  - libcxx >=10.0.0
+  license: MIT
+  size: 415040
+  timestamp: 1616086763917
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libspatialite-4.3.0a-hd1e8275_23.tar.bz2
+  sha256: 3572fade2e68c5e8cb5f0a63e2f452e20b60ba1a1d04de13d8ff192dfca72311
+  md5: 80f6d6f4086930bb36143ffc7a2538fe
+  depends:
+  - freexl >=1.0.6,<2.0a0
+  - geos >=3.8.0,<3.8.1.0a0
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - libxml2 >=2.10,<2.11.0a0
+  - libxml2 >=2.10.3,<2.11.0a0
+  - proj >=6.2.1,<6.2.2.0a0
+  - sqlite >=3.41.1,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 3210465
+  timestamp: 1680110280321
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
+  sha256: 8b1adbb78b6283c3d8df932d5aa7e8e249351aa1e206ba2949ee86052912e83f
+  md5: 2e035c81c044bff1224224ac24161dfd
+  depends:
+  - openssl >=1.1.1u,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338461
+  timestamp: 1686931232629
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+  sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
+  md5: c0b99f8e1c7475f23b1c7b4250b06e1c
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88021
+  timestamp: 1694778290062
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h930c0e2_0.tar.bz2
+  sha256: 9e3ea223370c83ea02a401f6842f9720473ffde3c89c1f85ad263a125c71a921
+  md5: 7a163268ee1284dd0c786c1d5f5e9acd
+  depends:
+  - icu >=58.2,<59.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 670156
+  timestamp: 1692647722456
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libzip-1.8.0-h272c8d6_0.tar.bz2
+  sha256: c575e9b13e704c531dab91ce87676d5a336c982273e5a361e42073b9e5817738
+  md5: 5d543db811d31c7e5703726639d034d3
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - openssl >=1.1.1o,<1.1.2a
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123384
+  timestamp: 1652978539298
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+  sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
+  md5: 5c740b4a18a558de0ccfe601703c423c
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 338738
+  timestamp: 1662635677689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.37.0-py38hc9110bb_2.tar.bz2
+  sha256: c0f35750a5291e487d6da02a7ce00f46311d3fa6ab954cbf91988b33769f4369
+  md5: 5d9a380ca1172c43995b77fb7c1fd9f7
+  depends:
+  - libcxx >=12.0.0
+  - libllvm11 >=11.0.0,<11.1.0a0
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  size: 322446
+  timestamp: 1646169198728
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py38hecd8cb5_0.tar.bz2
+  sha256: 84ce38615938b0276a9f31ae7c26acbf7fb5fefcf3e26a1c027880e1c6453f92
+  md5: a37ae112579913dab5c86a811d15193f
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11870
+  timestamp: 1652903183129
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+  sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
+  md5: d5f58d056b4bfc67aec30c77035ba889
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 182491
+  timestamp: 1670944720979
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mapclassify-2.5.0-py38hecd8cb5_0.tar.bz2
+  sha256: 790b0c9504d6179fbe46da43387e135c243c2b1b9bc003d6bf082fae22d176e0
+  md5: 6b112d175d4450bd5f59c8474b210d91
+  depends:
+  - networkx
+  - numpy >=1.3
+  - pandas >=1.0
+  - python >=3.8,<3.9.0a0
+  - scikit-learn
+  - scipy >=1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 67657
+  timestamp: 1675157906046
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py38hecd8cb5_0.tar.bz2
+  sha256: 037ef517fca2095c0cb00251dd62db209d3be9305771bd235c8fbd5eed3d35a4
+  md5: d16c75e346d76898b659d4445b0b63e0
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123565
+  timestamp: 1671541981715
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.0.1-py38h9ed2024_0.tar.bz2
+  sha256: bb4aef869f67a6d58b86eba6cc2066362db305234abb7b384651bcb335dddabe
+  md5: f6578b430efc56396dfd259c80d4974c
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21418
+  timestamp: 1621528247007
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.7.1-py38hda11e5a_1.tar.bz2
+  sha256: 7e479ed484b7b09b09386db872b838d7b643d0e38497c2883494a6f90a290b60
+  md5: 461effe77be0d00a91d515bb2f46ecfd
+  depends:
+  - __osx >=10.11
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=5.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.16.6,<2.0a0
+  - numpy >=1.20
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7983835
+  timestamp: 1679593834213
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py38hecd8cb5_0.tar.bz2
+  sha256: 88df2ac9ce5c9f4e68e9bae5fe272f2e0ac6fda2aff312ad6af3a66149517c2c
+  md5: c2314f5a0fff2fcb7a4d320ad59186cd
+  depends:
+  - python >=3.8,<3.9.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17337
+  timestamp: 1662014707291
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py38h1de35cc_1001.tar.bz2
+  sha256: 3eaeb0f57893acb1cb43d199c7cc59e1b53e7f64c6547174beaf20552b0acfd4
+  md5: 702227bd4bbf517ed707701ee2142cb5
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 54586
+  timestamp: 1594373290398
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+  sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
+  md5: 25051fe272624544652dc6d814c2943a
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224420228
+  timestamp: 1691503125614
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py38h6c40b1e_1.tar.bz2
+  sha256: 38905fb9453303e09abb46bb751bec48210c17a910dbd88293089b2297ffc02c
+  md5: aabd6d138e77ca6b9bdb36b3f7f4ee89
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48594
+  timestamp: 1682969108154
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py38h6c40b1e_0.tar.bz2
+  sha256: d2b5f01e04120955578805cbbc87797415fb606ba693ca8c958a30264d01a315
+  md5: 21358f24bbe5ca2e59c62eeee702234d
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 210895
+  timestamp: 1695058515685
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py38ha357a0b_0.tar.bz2
+  sha256: e7be2820541896a80f39c83993b4e9ae7945ae5b1e6a761a8c6b145b2a353e12
+  md5: 7cf5c49ea5302cf98b49cdfc36ab2aa8
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy
+  - python >=3.8,<3.9.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296359
+  timestamp: 1695059904922
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py38haf03e11_0.tar.bz2
+  sha256: 1ee2650fe9020fdc057d5393c9fc85ab235c563e29f442d2dd7b56571af9c08d
+  md5: 9136c45236ebf72976926d941f1f95fc
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 83201
+  timestamp: 1652362886402
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py38_0.tar.bz2
+  sha256: b82b619359eb11120d4c500d16b8fdaf1b83f2a77854cf2a48dc01f901ca7ac4
+  md5: 5494980acd3e180125cd5c8c070e0e9d
+  depends:
+  - python >=3.8,<3.9.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 22679
+  timestamp: 1573471345595
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py38hecd8cb5_0.tar.bz2
+  sha256: a9d5b4aa75b683cc36604780df7878e611db39e97a453182a2252fdc0514f04f
+  md5: 36f22fcadaef201377a2375e9ef72624
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8227633
+  timestamp: 1681756469033
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py38hecd8cb5_0.tar.bz2
+  sha256: ae0ee7d4e8555e1648255386b0e17ac521e06751d6d35a4a170fcf733b455737
+  md5: 3280f19d5a1d0572dfcfb80fc6fe591a
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.8,<3.9.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 98915
+  timestamp: 1650308416274
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.4.4-py38hecd8cb5_0.tar.bz2
+  sha256: b54ec7a429f2d6f17fd1abc853da1f231124c66b002a7b0ddd3aa6055c206d52
+  md5: 5199f2adda1cfad649e5a99f468124c4
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=2.4
+  - jupyter_core
+  - jupyterlab_pygments
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0,<0.6.0
+  - nbformat >=4.4
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.8,<3.9.0a0
+  - testpath
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 569496
+  timestamp: 1649752091230
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py38hecd8cb5_0.tar.bz2
+  sha256: c61d17856e2c0d42328b19d696cf8efb17f5b94b82ce4274297ae6da6b43d1aa
+  md5: 559edbcca0fdf0886d4193fefeafa0fd
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.8,<3.9.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148374
+  timestamp: 1694616871327
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py38hecd8cb5_0.tar.bz2
+  sha256: a86f6ff3c35b00091de82733047e17233762b06c552be2ce02b7d6bc9e795e63
+  md5: c82ad06bb34b7b27d83a6dee19967512
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13997
+  timestamp: 1672387206711
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/netcdf4-1.6.2-py38hd243f81_0.tar.bz2
+  sha256: 4489a03b122e004d8f01b7097b9a6cfe77d0dca431216e47fe0ba60ad92c350c
+  md5: 1333d7cf7a7ddfeb3fac068678fcc2a1
+  depends:
+  - cftime
+  - hdf5
+  - libnetcdf >=4.8,<4.9.0a0
+  - libnetcdf >=4.8.1,<5.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 470186
+  timestamp: 1673455590760
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.1-py38hecd8cb5_0.tar.bz2
+  sha256: 7d8c6bc1c5c0a2775fd583f3707200bc8263846221bd520ee630a1c243d20d1f
+  md5: ee23b3a4d66ba22e2097726b8585ce3f
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2967628
+  timestamp: 1690562092895
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py38hecd8cb5_1.tar.bz2
+  sha256: 8613463db0276c07fc3e6987dfb586808e2eaeae98593ae20b830d653e77f937
+  md5: bad2beb2612fd46526324078f2665054
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 573777
+  timestamp: 1690984889863
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py38hecd8cb5_0.tar.bz2
+  sha256: cfa0ad758159d6d2f473ed1462e5c05567c1852d301268837085d4c8f84d4844
+  md5: 1e7a8462fbd34616dd22b70650dd98a1
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22859
+  timestamp: 1668160699446
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nspr-4.35-hcec6c5f_0.tar.bz2
+  sha256: f006a4418ca8a5788d67fa836a89a236be9925b9dd7744a45cdec18d053a221d
+  md5: 4d90323cc76987c69a1c1d3996af71c0
+  depends:
+  - libcxx >=14.0.6
+  license: MPL-2.0
+  license_family: OTHER
+  size: 257208
+  timestamp: 1685541796770
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nss-3.89.1-hcec6c5f_0.tar.bz2
+  sha256: 0ee6d4545add1a4649506c1a69cb491a908ca5e47b386f9196485c3b5a9c371b
+  md5: 905b6e1c124eeba9dc9f338fd29932ec
+  depends:
+  - libcxx >=14.0.6
+  - nspr >=4.35,<5.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MPL-2.0
+  license_family: OTHER
+  size: 2130955
+  timestamp: 1685543311945
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.54.1-py38hae1ba45_0.tar.bz2
+  sha256: 99e23621b7fbd6a0160c4685bfd21132f245611743614be79976a24226f3c26e
+  md5: 11330aca427ebf7cad6b5f35ff0d350c
+  depends:
+  - libcxx >=12.0.0
+  - llvm-openmp >=12.0.0
+  - llvmlite >=0.37.0,<0.38.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  - tbb >=2021.4.0
+  constrains:
+  - numpy >=1.17,<1.21.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3828589
+  timestamp: 1635178402950
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.4-py38h47b59a4_1.tar.bz2
+  sha256: 1e384cd8e57ee5953d72e3725265b4c3414216e2d69198fa57a504d6d8577a20
+  md5: b19be6f476ed0f602317ed31319b5d1c
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 135465
+  timestamp: 1683227249056
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.20.3-py38h57dabd6_1.tar.bz2
+  sha256: bcc903c47db3499b7a2fa6319d7493ad5bba3ab6904d9931b5bccb2bb02776f3
+  md5: 12094ed52582148fa77e8e3ff09fbd53
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.20.3 py38h34da072_1
+  - python >=3.8,<3.9.0a0
+  license: BSD 3-Clause
+  size: 9717
+  timestamp: 1682971749428
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.20.3-py38h34da072_1.tar.bz2
+  sha256: 1382e802dd5f43711a6e7625828d7683f188f0583c9f490d8726e8f5101044a5
+  md5: c43950a67d03dcc08c150cf2c571f3cd
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - numpy 1.20.3 py38h57dabd6_1
+  license: BSD 3-Clause
+  size: 5978617
+  timestamp: 1682971733309
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
+  md5: 93f5d7b66976154adeda219bea02ba45
+  depends:
+  - libcxx >=10.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 484257
+  timestamp: 1630093862501
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
+  sha256: f95f5173ab2a4529b56ff90deec905dd53877250acedd3887fb289b721396009
+  md5: 2ab1a555331747f19e4aa7a335e33a85
+  depends:
+  - ca-certificates
+  license: OpenSSL
+  license_family: Apache
+  size: 3665304
+  timestamp: 1694465313538
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py38hecd8cb5_0.tar.bz2
+  sha256: 2c3de88c1ca11108d11a0dc02b7d545ea527542ffa1292a5aa1b84178c5ed507
+  md5: becffc185d46d2fffee1e7d4e6e648bf
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73666
+  timestamp: 1693575349472
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-1.3.5-py38h743cdd8_0.tar.bz2
+  sha256: 2b39342c15f995786dfc73a6189f2f62923f6d44e1551e6eaf5e0d6f5db0846e
+  md5: f46bee1052d61f64e4c2f5e56033bfb4
+  depends:
+  - bottleneck >=1.2.1
+  - libcxx >=12.0.0
+  - numexpr >=2.7.0
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.7.3
+  - pytz >=2017.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12173268
+  timestamp: 1641461704389
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.0-py38hecd8cb5_0.tar.bz2
+  sha256: a5a184f2e833c0468a405995dd01cff14816c0087cc7153c9efe549d8f82e6b4
+  md5: a9df134cf7ec3746c15d364e7165bf11
+  depends:
+  - locket
+  - python >=3.8,<3.9.0a0
+  - toolz
+  constrains:
+  - pandas >=0.19.0
+  - numpy >= 1.9.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35933
+  timestamp: 1693937933289
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pcre-8.45-h23ab428_0.tar.bz2
+  sha256: 1600f8ae7c4e8177cba7f78123312c784afe662ebd7023958777cb77694c333b
+  md5: 843db1a9eb10fcc9604c90b2e63272ee
+  depends:
+  - libcxx >=10.0.0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 226022
+  timestamp: 1624478357519
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pcre2-10.37-he7042d7_1.tar.bz2
+  sha256: 8e1e9118a99bf188da2583107b1964540088c90fa7c9598c396bfa39e25c3d3f
+  md5: 9eae60b5dcb24bb8d36304e32cd94a04
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - zlib >=1.2.11,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1148469
+  timestamp: 1641403899928
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py38h7d39338_0.tar.bz2
+  sha256: 35832b70a7f6f94f4aed70b341434cc5bf86688f7ef25a18df72019f8ec69415
+  md5: 4ae44aafef83e1ac779f9baae27ce6a9
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.8,<3.9.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND
+  license_family: Other
+  size: 718961
+  timestamp: 1696580345211
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py38hecd8cb5_0.tar.bz2
+  sha256: 04cc06ae2efdab84201a3318eeb275dd40a786925b600bf2eee08ab8ee30d1b0
+  md5: c9fffe0ee653ea0a7d23dab4790d4d62
+  depends:
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2677546
+  timestamp: 1697548802897
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pixman-0.40.0-h9ed2024_1.tar.bz2
+  sha256: 39981af6952de4e207cf6e5e769cb5b9c50f30cfd71a1fd97d6d3eef5feb5a6a
+  md5: ecb58f854cae469740631c23643c9c95
+  license: MIT
+  size: 617807
+  timestamp: 1632711594755
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pkgutil-resolve-name-1.3.10-py38hecd8cb5_0.tar.bz2
+  sha256: 9ba22e141b1f179f5ab88725ef16d4d5371de83196ce7882ae0b8bff008ccd9b
+  md5: b0734f0be7a3dfd9265c2359dcc75e8a
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT AND PSF-2.0
+  license_family: PSF
+  size: 10749
+  timestamp: 1661463438375
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py38hecd8cb5_0.tar.bz2
+  sha256: 59543706932970f7922342cc83ce3b7cca7df58ef4c0fef602e13ace586f9ae6
+  md5: ca41bf67637034096f2414eaa100b518
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 33062
+  timestamp: 1692205767198
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pooch-1.7.0-py38hecd8cb5_0.tar.bz2
+  sha256: 322e198616c7e83a60010d0f997cfad3f8ea07fea3adf27e049c364349324b8c
+  md5: 1fccc3ef32139e3c02bef538caa5a4f2
+  depends:
+  - packaging >=20.0
+  - platformdirs >=2.5.0
+  - python >=3.8,<3.9.0a0
+  - requests >=2.19.0
+  constrains:
+  - tqdm >=4.41.0,<5.0.0
+  - xxhash >=1.4.3
+  - paramiko >=2.7.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 82466
+  timestamp: 1695850164306
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/poppler-22.12.0-ha8a1649_3.tar.bz2
+  sha256: 36845a06f9abfb4ee06e24d1f9e57c2f8cded0c323491221862d45f929df6a34
+  md5: 8cb3c1e1fa4d3ed2f1589fdd2f686108
+  depends:
+  - boost-cpp >=1.73.0,<2.0a0
+  - cairo >=1.16.0,<2.0a0
+  - fontconfig >=2.14.1,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - gettext >=0.21.0,<1.0a0
+  - glib >=2.69.1,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - nspr >=4.35,<5.0a0
+  - nss >=3.89.1,<4.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - poppler-data
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 1833586
+  timestamp: 1696000908395
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/poppler-data-0.4.11-hecd8cb5_1.tar.bz2
+  sha256: 31fbd1899e753b454dc825d85e2cd9a0506107e772f5d5d307d4f234586c0059
+  md5: 54f685f65e667e076c4a7cb36f23f26e
+  license: GPL-2.0-or-later and GPL-3.0-or-later and BSD-3-Clause
+  license_family: GPL
+  size: 3839936
+  timestamp: 1673863552033
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/postgresql-12.15-h8aab74b_1.tar.bz2
+  sha256: 2e583070368fe478ccf62ff06b9dc5030c3924c9a7b9d653224ff5a3181e49f3
+  md5: 60262eb903a3a8f1579fdce8b82cbe4c
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libpq 12.15 hdb2fb19_1
+  - openssl >=1.1.1u,<1.1.2a
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  size: 4284850
+  timestamp: 1687380891439
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/proj-6.2.1-hfd5b9e3_0.tar.bz2
+  sha256: 411c065ddd7752b8ef73bf4b747a460ab1f106fdde3cb38aa1d32bcb69f42de0
+  md5: 96a891da3640cae81b84ed0dc5bc35a2
+  depends:
+  - libcxx >=4.0.1
+  - sqlite >=3.30.1,<4.0a0
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  size: 10571782
+  timestamp: 1573144315768
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py38hecd8cb5_0.tar.bz2
+  sha256: cb719cdb0e7c35e0edabdf544042a3f47bc235d8f31f27cbed4f0f2d6c42e8fe
+  md5: a76c1a1d816608f02aa155ed03d95821
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91112
+  timestamp: 1659455138351
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py38hecd8cb5_0.tar.bz2
+  sha256: 53ab33079b69e9fd86b6adb34d389dcf0fd5e80c0cfed1d254ecf543c6b01e9c
+  md5: 1dfdadc899943e5753e9a68769381bc2
+  depends:
+  - python >=3.8,<3.9.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 581142
+  timestamp: 1672387439093
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py38hca72f7f_0.tar.bz2
+  sha256: 3e0fc9381b2c7a97dde3841b455a03648257ca105d3c99ee673e45dc2a3f233b
+  md5: d3034fa818207ec94aa5876e3fd778ff
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365816
+  timestamp: 1656431564060
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py38hecd8cb5_0.tar.bz2
+  sha256: 35c76d8e4ecfe2f9ddb8ca341e7c940b00dd7b2c628b4364f2cec55519ac5c6e
+  md5: 53d45ee242138195f85f5fbea3de05c0
+  depends:
+  - param >=1.7.0
+  - python >=3.8,<3.9.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30803
+  timestamp: 1675441540278
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py38hecd8cb5_1.tar.bz2
+  sha256: ee5a34ab3a65b01adc661e9c67b1f9af2e5fb737ef477607f16b85ad30d1fb7f
+  md5: a3220cef0db91e71e3de88c151de039b
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1888474
+  timestamp: 1684280131448
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py38hecd8cb5_0.tar.bz2
+  sha256: f30efa3ad42fc694e69701c74c4109ccbf4ccf5bf23cf910589fed298257e3ea
+  md5: b2190d1795a4ed71d6ba149d7b36aafe
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95648
+  timestamp: 1690223540439
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py38hecd8cb5_0.tar.bz2
+  sha256: fa80f34c66064dad6d5c74c6a4a01f7ef842702cbbfeb73988ef3c9196d90a67
+  md5: e14a6c52601b5efcae0156ff27b210a7
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 157601
+  timestamp: 1661452654987
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyproj-2.6.1.post1-py38hdfdfadc_1.tar.bz2
+  sha256: d921180e45ce90d690d54f52cf95373bea7da1e242d9cbcc0be7c4ea3f849b6e
+  md5: 563afb1ed79040f10b13d9fb13de4db4
+  depends:
+  - proj >=6.2.1,<6.2.2.0a0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  size: 412999
+  timestamp: 1614278007514
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py38hca72f7f_0.tar.bz2
+  sha256: c4a075cf376eba5a9968473cdd79a32e2c036ce5b85477f58d83e57325e36169
+  md5: a09f64f393f0f0d127456d3d27a73d4e
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 95161
+  timestamp: 1636111183441
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py38_1.tar.bz2
+  sha256: 3bf4d8aa47a883c367b98db7cc16efef613a0b08fb143bb9f78967c5d2c7416b
+  md5: 6837a4c11fb0126b4422d0caaa1b6296
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 27255
+  timestamp: 1594394684547
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.8.18-h218abb5_0.tar.bz2
+  sha256: 0c1b0c532cfec52c6587073e036cef48d07057eda4727ac1db422193add8b1c3
+  md5: 184d7340d5f85eb4d369ae695f3568a9
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 15528724
+  timestamp: 1694439198827
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py38hecd8cb5_0.tar.bz2
+  sha256: 3bdab73baf83e87b9f1b533797fe64a084cefb1be9d1527fa4f295f7a8f498d4
+  md5: d67db0edf3d298995791f78ac59badc8
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 265379
+  timestamp: 1661369089392
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py38hcec6c5f_0.tar.bz2
+  sha256: 803a11fceb8ac73e82ea6eb489503c268c6a59176e0b3ce3c0853b86ff386373
+  md5: 0b3a76ba820c7f1ec345ad82765eeffa
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.8,<3.9.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 140675
+  timestamp: 1682522414875
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py38hecd8cb5_0.tar.bz2
+  sha256: ec810a818f3bbb57ad53a8b12dce584d0b79b4b622eed16d242e381ddb772903
+  md5: d014760a43e1879020e84d56b7d5f90a
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 270273
+  timestamp: 1695131744910
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py38hecd8cb5_0.tar.bz2
+  sha256: 1aa6076b424dd9f1e971c6c0d110fa3899cbff9e086b487aafd7cee5dcff85cd
+  md5: 13cad45544b3a41837734ba9c5de6ae4
+  depends:
+  - param
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41018
+  timestamp: 1685030968054
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py38h6c40b1e_0.tar.bz2
+  sha256: 6cd5553c5b22de113263349ca0f11e7911dfeaba567b12800592553d8d560734
+  md5: 8bd42962244d9d67486f55fc03a1798a
+  depends:
+  - python >=3.8,<3.9.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 169452
+  timestamp: 1698096213680
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py38he9d5cce_0.tar.bz2
+  sha256: d5647ee78d185ab247cc6a5014ee668e3a669da9e1d9472290cca8e40c3c0fb0
+  md5: dac86e4b28f69e45b46ad58800a0f740
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.8,<3.9.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 468700
+  timestamp: 1657724456285
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/qhull-2020.2-ha357a0b_2.tar.bz2
+  sha256: 35d47041555b4277b30abb836fbc815350a644ba3c4bd4f2e2ea73397c554f2f
+  md5: 5f3c1d74767029f19e9c2bd8172b557b
+  depends:
+  - libcxx >=14.0.6
+  license: Qhull
+  license_family: Other
+  size: 2019896
+  timestamp: 1670915867737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py38hecd8cb5_0.tar.bz2
+  sha256: f6dae09ca297eea86cccd2b35f62804a5c34fd2800f5e869b6b2eeb643a6ee6e
+  md5: 31d96e7ff6fe9b9de1b974cd9f52c6f3
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.8,<3.9.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95130
+  timestamp: 1690400361635
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rtree-1.0.1-py38hecd8cb5_0.tar.bz2
+  sha256: c410c6db1f39395103ac57658f8aa2b6a5336c55a59ffce54cf18c20c971644a
+  md5: 6de092af1261c354c13e72a7d8570438
+  depends:
+  - libspatialindex >=1.8.5
+  - libspatialindex >=1.9.3,<1.9.4.0a0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 50343
+  timestamp: 1675157931683
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scikit-learn-1.2.2-py38hcec6c5f_0.tar.bz2
+  sha256: 92b4ab33c2c754e8304faed43a4e32c96f1ae4ebab5b1dab6d7cd946a7b4920c
+  md5: ebfa25ee1fa7859243884645d200e5d7
+  depends:
+  - joblib >=1.1.1
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - scipy >=1.3.2
+  - threadpoolctl >=2.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8791586
+  timestamp: 1680201216606
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.10.1-py38hf241641_1.tar.bz2
+  sha256: 402a621edb67348e29d593fa3abfdc2e2caa0e4cb263a81ea4438b5ee16d06dc
+  md5: 98bf265b20f94a8fef4f45d9caa71e9a
+  depends:
+  - blas 1.0 mkl
+  - intel-openmp >=2023.1.0,<2024.0a0
+  - libcxx >=14.0.6
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.19.5,<1.27.0
+  - pooch
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24792365
+  timestamp: 1683295750615
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py38hecd8cb5_0.tar.bz2
+  sha256: 17946446ccf4b46a8af54dd2bf2a34ca8dfe46691324c95f2bbf6d6b5de4d47e
+  md5: 92e548df0d415142e553a332053535a1
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093502
+  timestamp: 1690290995786
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/shapely-2.0.1-py38h797b0b3_0.tar.bz2
+  sha256: df3ff16522a0b189464f39de7b5e3633ebbb446c53b9e19d3e4b31d3bb2f7eb7
+  md5: 1573a4924ae8289f70812c604ff29b07
+  depends:
+  - geos >=3.8.0,<3.8.1.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 436965
+  timestamp: 1680636513687
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py38hecd8cb5_1.tar.bz2
+  sha256: 017bd06e271ef74d2f3a15acc344c184bdd51b9854c9d79cfa78f25f19aa0408
+  md5: eaeda6cdc02faf686088e8c711df089d
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15486
+  timestamp: 1614030487981
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py38hecd8cb5_0.tar.bz2
+  sha256: 4617e621bcefd0cf9806da51451335cb422b6cff1de8ece9844136a14732e4cb
+  md5: 3118681370d80225e19baf3f77171a69
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 67418
+  timestamp: 1696347616672
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+  sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
+  md5: 82e4db6a498480a75d53c55bd35b6478
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1801397
+  timestamp: 1681394807900
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py38hecd8cb5_0.tar.bz2
+  sha256: 34533fc748e7cb5f8a860eb3f6601beb4f126998d1dd5fc5afd6d89f01969efe
+  md5: cbda7f79b6003675241b015d49c85280
+  depends:
+  - ptyprocess
+  - python >=3.8,<3.9.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30949
+  timestamp: 1671751869746
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/testpath-0.6.0-py38hecd8cb5_0.tar.bz2
+  sha256: 7395e65b3ee88fbfec53c922125191a5646bcff130caeee8bfc1293754bfa07e
+  md5: 3d501162e255b90663ac6e7eb60fb574
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94394
+  timestamp: 1655908839591
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tiledb-2.3.3-h74f4c1e_2.tar.bz2
+  sha256: e0353ceb9d9f6342fa277683c201c7eac0d81a294e1e5ff7e3c12c6c0323f3d9
+  md5: f2c604676085095fdf60ba1af2b7cf56
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=7.82.0,<9.0a0
+  - libcxx >=12.0.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=1.1.1o,<1.1.2a
+  - zlib >=1.2.12,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 3049983
+  timestamp: 1655311430168
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+  sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
+  md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
+  depends:
+  - zlib >=1.2.12,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3536231
+  timestamp: 1654088937695
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py38hecd8cb5_0.tar.bz2
+  sha256: 92755ab4f8c11bd18c59efd108b72b366dc35b1d9675847b4839f0ec92ea917d
+  md5: 9df5b054b202bc995ace5e8779ac643f
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102499
+  timestamp: 1667464228738
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py38h6c40b1e_0.tar.bz2
+  sha256: 1adeadb9a4d3d5e74265ea1a8594f272609a20e6c35b70601d715f316cbd7861
+  md5: 1bf7d52b412d9a9d6eea7c4bc42d75ff
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 678506
+  timestamp: 1696937178616
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py38h01d92e1_0.tar.bz2
+  sha256: 1d59bd9e6e54aa969fe325b8490a85c931f3541d86a15d1df88ffe275759498e
+  md5: b87b6d512ac388f27a6aa5ced30a589d
+  depends:
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 124900
+  timestamp: 1679562063856
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py38hecd8cb5_0.tar.bz2
+  sha256: a34dfcc544e6dcc136c8e78febfc22ceffe42843b6108baf95ca77e7344921ed
+  md5: 9b33282f8a7cda21a2c8f4ce03acf197
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192430
+  timestamp: 1671143921787
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py38hecd8cb5_0.tar.bz2
+  sha256: 756b45ece9d4f16600524a72c5659b6ef0bc0a6437f4ddbaff3bb5462539ffa0
+  md5: 660bac6c0f1f3ddac617f31c7becbd4b
+  depends:
+  - python >=3.8,<3.9.0a0
+  - typing_extensions 4.7.1 py38hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9656
+  timestamp: 1690297531708
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py38hecd8cb5_0.tar.bz2
+  sha256: 35d6099b39b0cb36387915d20c9524b210e2ab4a1d5104c81f2e6a0bfa0a356f
+  md5: 0d02b08ce0dd3e09ddd67b8a515d51b7
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58757
+  timestamp: 1690297524304
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uriparser-0.9.7-h6c40b1e_0.tar.bz2
+  sha256: 035b916c1eab3a6a27f0109d8e39fe37cbf8ebe0af948d88d7a3b96ab20dc999
+  md5: e697defd6c59ca6d98ab4bb5f951eb21
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 44105
+  timestamp: 1692186954114
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py38hecd8cb5_0.tar.bz2
+  sha256: 226d60c3556917fd2c5443770362926724f6809eff074586dd6cda32abd71822
+  md5: f1300fd1bd610b23456c52cd9e404b9b
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 188584
+  timestamp: 1698257703550
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py38_1.tar.bz2
+  sha256: dd878c7ccbe9acd4394ecb151ea22a700d7e17982d07e5cdab16e434ee0e276a
+  md5: 816a3f635267b70b6a1b00c00c282a15
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20010
+  timestamp: 1573201122722
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py38hecd8cb5_4.tar.bz2
+  sha256: 29f349097c7f4fc02e63acf3e8758ec7f5f8cecc204005ef4aaed944d3e95caf
+  md5: 17db7bb8a9f23ae4f01b92f286794a8d
+  depends:
+  - python >=3.8,<3.9.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70774
+  timestamp: 1614804275719
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py38hecd8cb5_0.tar.bz2
+  sha256: a6e2e84f23ae1e6d7233ee6b356daad04aff65168dd1432413a2d7d87fe5d04f
+  md5: a27b7b2a5e07004ea5e61fcdb13a82f5
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 102424
+  timestamp: 1695742040522
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2022.11.0-py38hecd8cb5_0.tar.bz2
+  sha256: 1b6d252572b3fe72c4716c24056cfe6b0f5d83a37a87b895b99d9e280a1fd0bc
+  md5: 51856b1a836e1d7ee6b166d6c5fbadbb
+  depends:
+  - numpy >=1.20
+  - packaging >=21.0
+  - pandas >=1.3
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1733083
+  timestamp: 1668776637394
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xerces-c-3.2.4-hd2b157f_0.tar.bz2
+  sha256: c2b8fd888f90d09221594211e0bd51198f21319864b94ca3275e8329112088cc
+  md5: 32aa5f3e7324f2a79b504dfe68b77abd
+  depends:
+  - icu >=58.2,<59.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 2851582
+  timestamp: 1668712668309
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py38hecd8cb5_1.tar.bz2
+  sha256: 9ff046886013ca543edb417264a93032d5622c1933afee67f42a1fb55adc1499
+  md5: 7329105d84755727fa326092177e87ed
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49845
+  timestamp: 1675159128645
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+  sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
+  md5: e243baa546432c8394a8059a44a5a3e4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 419227
+  timestamp: 1683113010463
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+  sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
+  md5: fe4ac85ee86d3a94ea3a4ebea3779763
+  depends:
+  - libcxx >=10.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 321797
+  timestamp: 1616055526986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py38hecd8cb5_0.tar.bz2
+  sha256: 8b48165e2712438ff12e1602626d500bcf01bc24f50d465fb828e11d08248210
+  md5: f75ab2b6ef09cbedfb138841c634f46a
+  depends:
+  - heapdict
+  - python >=3.8,<3.9.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 77592
+  timestamp: 1695832909404
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py38hecd8cb5_0.tar.bz2
+  sha256: 4be46abffdef57e0cb028ec6d32d85b583ec9dd5a0818e2c0fa0a3c9590182c1
+  md5: 9ea7585b85fe7f016e6dae8e6424ca8a
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 19053
+  timestamp: 1672387288981
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+  sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
+  md5: 8e495591e369ac161857a72011c0a296
+  license: Zlib
+  license_family: Other
+  size: 120272
+  timestamp: 1666595024203
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+  sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
+  md5: f1465fbd810b3746c6de6babfd4fe28a
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1023573
+  timestamp: 1681304595869
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py38hca03da5_0.tar.bz2
+  sha256: 5d765891b15f4759f4fab35f1a388e0681457776bb6976ba7eb09cca760c11aa
+  md5: 980b8c7687f2f36a5811f12156b48b00
+  depends:
+  - idna >=2.8
+  - python >=3.8,<3.9.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 155531
+  timestamp: 1644482714703
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py38hca03da5_1001.tar.bz2
+  sha256: 67836d5b3187b8fbd69a50fe643ecc601645aec6947653e7fbdcf3e137eb5c98
+  md5: c6f73e643c6beef9c5a26ed2d621ddd2
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10182
+  timestamp: 1629146056221
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py38h1a28f6b_0.tar.bz2
+  sha256: 405979005a60e67d5226c4d3ec3e91119a8cda26ca800c9ba503c47f4fe13471
+  md5: cc74ce79b82fee9e8c5a6eafbd3183bb
+  depends:
+  - cffi >=1.0.1
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 35405
+  timestamp: 1644845782338
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py38hca03da5_0.tar.bz2
+  sha256: 9a9dae59d5f87a40caec410f55b2945a7d1218473bca79a336b31143400288f8
+  md5: f5da1bd1fd8c75b61386a2a6fc4f576b
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 133786
+  timestamp: 1695717921528
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py38hca03da5_0.tar.bz2
+  sha256: d2bdaae4f918465304ccb1b0453bb60ec6ad60cce1d2962f9112537f6d93a655
+  md5: 6916209d81024d66701244d461f78857
+  depends:
+  - python >=3.8,<3.9.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206634
+  timestamp: 1681493108006
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
+  sha256: d51b7b5841be320209706d8e9caf669c0e0094f3a40e9eea51701a564ca7c2ed
+  md5: 61647f79e0ae70e914fee23c40c4caea
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43179
+  timestamp: 1675247655207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-2.3.3-py38hca03da5_0.tar.bz2
+  sha256: a681e391e712a001b7a0eb5ce0d573df59b4c200d61aa7c49537f180a36553d6
+  md5: 423c7d46a7c2c96c2dd230d4b5903038
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.1
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8622795
+  timestamp: 1628862374983
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.73.0-h1a28f6b_12.tar.bz2
+  sha256: 8f878b6cb432784e1a1d395069265a3643d8bb44cb5a1f552d4930895b728725
+  md5: f3e6c2c3e302d06f9734ecb2f71c2b3b
+  depends:
+  - libboost 1.73.0 h49e8a49_12
+  license: BSL-1.0
+  license_family: OTHER
+  size: 17659
+  timestamp: 1655879787473
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py38heec5a64_0.tar.bz2
+  sha256: 54275861becb1f8a49bf272ee3d64ccb0af913ff7ad1346109519374e4781de0
+  md5: ca54108331866869bb0a8498a1872a04
+  depends:
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 112738
+  timestamp: 1657175740371
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/branca-0.6.0-py38hca03da5_0.tar.bz2
+  sha256: ac1eaa002f079cd9e2bd266bddf9639248040aa42b66d5ecbbf09505bc81af5a
+  md5: 91eac1a9b07588b1399d3a1d1ab6cf11
+  depends:
+  - jinja2
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 43755
+  timestamp: 1675157665571
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
+  md5: f860193e14afc7ef3f5b990a2ac003d2
+  depends:
+  - brotli-bin 1.0.9 h1a28f6b_7
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18936
+  timestamp: 1659616204016
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
+  md5: ad53130f3fd1f8d3c2fcbb7496e5585d
+  depends:
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18715
+  timestamp: 1659616188888
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py38hc377ac9_7.tar.bz2
+  sha256: 487f05b8dfe6e421263c79d5076c065016666a5a18934decc1ddf4e6ec27dcce
+  md5: 5d9427960704c8cb150813ddbef20349
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  size: 365523
+  timestamp: 1659616326026
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
+  sha256: 019469288da4767fd021f488b907e2f4f3b34db686fa12055d52d9bb7bb4d872
+  md5: 9f63c782a4d20150ae9a664ee87cce16
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 150682
+  timestamp: 1624215191959
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+  sha256: b0be79290b1df1cf1d07a1a9c3f3a92ae262643a6df3dc10dfbac22a82874dd4
+  md5: 8fdcf1c08eee91fec7eefc22863c816a
+  license: MIT
+  license_family: MIT
+  size: 106550
+  timestamp: 1693902036526
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+  sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
+  md5: 31ac2f5596cb7a44adf073c930641c54
+  license: MPL-2.0
+  license_family: Other
+  size: 133817
+  timestamp: 1694009762858
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cairo-1.16.0-h302bd0f_5.tar.bz2
+  sha256: c2f6508a6ede7d131884e906dbf409c781eb3cb04b6ebfa6a29a2310e1a8e0da
+  md5: 5febd95efbd8014e202562d7b0391869
+  depends:
+  - fontconfig >=2.14.1,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - glib >=2.69.1,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - pixman >=0.40.0,<1.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: LGPL-2.1-or-later or MPL-1.1
+  license_family: LGPL
+  size: 1403003
+  timestamp: 1688495951297
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cartopy-0.21.1-py38hf94de1b_0.tar.bz2
+  sha256: 1da2935f34f56987496eea18111202c5abaf1f055f28bbd37628070ed5585bf4
+  md5: 55978f94faf194a15d99d83c23f92fa7
+  depends:
+  - geos >=3.7.2
+  - geos >=3.9.1,<3.9.2.0a0
+  - libcxx >=14.0.6
+  - matplotlib-base >=3.1
+  - numpy >=1.19.5,<2.0a0
+  - pyproj >=3.0.0
+  - pyshp >=2.1
+  - python >=3.8,<3.9.0a0
+  - shapely >=1.6.4
+  constrains:
+  - scipy >=1.3.1
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 1738867
+  timestamp: 1674677891009
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py38hca03da5_0.tar.bz2
+  sha256: a660be158909caf4e0349c52e609dd1c0da9a71547e82722d35dbc0f86ffa02b
+  md5: 70f68e080352f618320d096a932e98ed
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 160131
+  timestamp: 1690232261193
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py38h80987f9_3.tar.bz2
+  sha256: 3eb4810d5ba58993acaeeda46418632d9081a61d90ab263c91cfd5f417ab9d36
+  md5: 3d4c675ee824980291ba685d0072c5dc
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 225296
+  timestamp: 1670423245933
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
+  sha256: 3ba74ebffd6bc4bc451864f85048dec9b6ad085eb1904ce3e5450376e15f050e
+  md5: 289f238ac78b174f01c8a2b252b17735
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=7.82.0,<9.0a0
+  - libgfortran5
+  - zlib >=1.2.12,<2.0.0a0
+  license: Other
+  license_family: Other
+  size: 1243641
+  timestamp: 1655814869383
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cftime-1.6.2-py38hb08c31d_0.tar.bz2
+  sha256: c1800a5e4cf925ed2bc9345ed847d59e9f881d3362709b393805a500dfcfd40c
+  md5: ab3531ecf88671eb669e596d4313be59
+  depends:
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 227194
+  timestamp: 1678830418879
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py38hca03da5_0.tar.bz2
+  sha256: aeb9fd657eacfb76ae352a33991bedc46d8f1080c0fee116c517ab6cea5ea8ab
+  md5: 1ac72858d61f8028a48f2f855b0e9f43
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 152725
+  timestamp: 1698129882125
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py38hca03da5_0.tar.bz2
+  sha256: 293280c1652ea7da893611321e0fa287fc4812538b661902dc47019b3b424136
+  md5: cffd3a690fc0c02bb1d2e39b26851d1a
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41293
+  timestamp: 1683040141160
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py38hca03da5_0.tar.bz2
+  sha256: e80c949f34e245cf1dc8349e30b9fa5c7245b2698e374fc0131f8d266d5f0e87
+  md5: 8749acd61686f2fcd728f6b4e34fe31d
+  depends:
+  - pyct >=0.4.4
+  - python >=3.8,<3.9.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1978833
+  timestamp: 1668084538802
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py38hca03da5_0.tar.bz2
+  sha256: 30f1aabfb4226ee1af8445279113059c737c0b35ebee2fe406a855290871339f
+  md5: 22d8819694ea22c11b91b104be282549
+  depends:
+  - python >=3.8,<3.9.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13639
+  timestamp: 1671231198163
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py38h3c57c4d_0.tar.bz2
+  sha256: a3de72163db6c07ff509d3b2db4eb91fc3331c98e3367a2b94766681d14827a8
+  md5: dcb73cc0e1fa2b83e0c7f0567de81e1f
+  depends:
+  - cffi >=1.12
+  - openssl >=1.1.1v,<1.1.2a
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1400831
+  timestamp: 1694212028623
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.0-py38h1a28f6b_0.tar.bz2
+  sha256: dd8d2e47fedd968ec0e2977b11b766f5a5845b687ed36a7a092c66849ca991f6
+  md5: 73756e4c9a8c356d400d01ab3b288330
+  depends:
+  - python >=3.8,<3.9.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353644
+  timestamp: 1667466090549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py38hca03da5_1.tar.bz2
+  sha256: abb41ec3bdd1a8b491056d8409044e7db430140cde7935bcb41826d746cb7194
+  md5: 691ae819ca6bafeb6626cd7941f79c6b
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7
+  - python >=3.8,<3.9.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 103380
+  timestamp: 1629793027649
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py38h313beb8_0.tar.bz2
+  sha256: ad48c11fd3b44e89832e5851ba77d27951f258c039a53e15e9fe2bdc35b408c9
+  md5: 3e3601bc2eb8e58c4cadb36ac4ea7689
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 2069572
+  timestamp: 1690905388086
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2021.10.0-py38hca03da5_0.tar.bz2
+  sha256: af6ad263faeb788a1c344006af164abffa0b65db8224d8faf6ea632f5f9c9dbc
+  md5: 8e23d4f835f8d1b6730d3cb0afe82bcc
+  depends:
+  - click >=6.6
+  - cloudpickle >=1.5.0
+  - cytoolz >=0.8.2
+  - dask-core 2021.10.0.*
+  - jinja2
+  - msgpack-python >=0.6.0
+  - psutil >=5.0
+  - python >=3.8,<3.9.0a0
+  - pyyaml
+  - setuptools
+  - sortedcontainers !=2.0.0,!=2.0.1
+  - tblib >=1.6.0
+  - toolz >=0.8.2
+  - tornado >=6.0.3
+  - zict >=0.1.3
+  constrains:
+  - openssl !=1.1.1e,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1100354
+  timestamp: 1635968569442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py38hca03da5_0.tar.bz2
+  sha256: f66664b97ad6248c187d4d316c7ee511b8f01a7931026c679bda943d4d6eb28f
+  md5: 0428cdc3df242a4a3bdfa628838ddd0a
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT License
+  license_family: MIT
+  size: 15098
+  timestamp: 1650293803801
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/expat-2.5.0-h313beb8_0.tar.bz2
+  sha256: 3152fc53c90a109c08340806e9f81c8a13183732d8d1785dcc3f376141ed9797
+  md5: 6e369f9003279ffa8af8c12d3d524316
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 158521
+  timestamp: 1693497374650
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fftw-3.3.9-h1a28f6b_1.tar.bz2
+  sha256: dc457fe0cde973b789306f64f8cc0b5b0a5512e3685749e34ab8713d3cad9840
+  md5: 9c5ac82ba31104f8cbff795ceb5c7901
+  license: GPL 2
+  size: 1638590
+  timestamp: 1630601990060
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fiona-1.9.1-py38h78102c4_0.tar.bz2
+  sha256: bd708fcfafaffba21bf3253229052e79e482c72e2ab9b7772ab838b3f0dc541b
+  md5: 91797b200304cbdb33cc50e46d11305f
+  depends:
+  - attrs >=19.2.0
+  - certifi
+  - click >=8.0,<9.dev0
+  - click-plugins >=1.0
+  - cligj >=0.5
+  - gdal
+  - libcxx >=14.0.6
+  - libgdal >=3.6.2,<3.7.0a0
+  - munch >=2.3.2
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  - shapely
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1436350
+  timestamp: 1678226162254
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/folium-0.14.0-py38hca03da5_0.tar.bz2
+  sha256: 3e3c1d1329887984cb869b67d323ff24c6b452f30201265300d7ad9681d81399
+  md5: a88600af4b80a16b107e14a9dd95c3b2
+  depends:
+  - branca >=0.6.0
+  - jinja2 >=2.9
+  - numpy
+  - python >=3.8,<3.9.0a0
+  - requests
+  license: MIT
+  license_family: MIT
+  size: 115944
+  timestamp: 1675353478695
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fontconfig-2.14.1-hee714a5_2.tar.bz2
+  sha256: ad796b7fa5324e97e0f1c1fb504501a1460487b01b3ee10cab046b7a63aaf650
+  md5: 35aaca48edc362f082ec9bfb6fab3317
+  depends:
+  - expat >=2.4.9,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - libxml2 >=2.10.3,<2.11.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 304030
+  timestamp: 1679578352471
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freexl-1.0.6-h1a28f6b_0.tar.bz2
+  sha256: 08445fe0217766a9a052c5694feb37e979442979d4f86b3d1e6a5573beccaf22
+  md5: 31da24ce8729c7bc441d33896eb43e26
+  license: MPL-1.1
+  license_family: OTHER
+  size: 46292
+  timestamp: 1629472181136
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py38hca03da5_0.tar.bz2
+  sha256: abdba7dc1c5af2ace3c424fe9f342c50100e2841ba4c26a31a6bba8a1b27a87b
+  md5: ebb3d0931751c5d88b9930f9b931f564
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 257365
+  timestamp: 1695734535618
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gdal-3.6.2-py38h92c4280_1.tar.bz2
+  sha256: 4751b643a7957b39566c5820a102eca2b49b785c1d1add8f889bcd1e67219a4b
+  md5: c29bab24abec81a33f669d388ba2960e
+  depends:
+  - blosc >=1.21.3,<2.0a0
+  - cfitsio >=3.470,<3.471.0a0
+  - expat >=2.4.9,<3.0a0
+  - freexl >=1.0.6,<2.0a0
+  - geos >=3.9.1,<3.9.2.0a0
+  - geotiff >=1.7.0,<1.8.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - hdf4 >=4.2.13,<4.2.14.0a0
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - libcxx >=14.0.6
+  - libgdal 3.6.2 h50c47ba_1
+  - libiconv >=1.16,<2.0a0
+  - libxml2 >=2.10.3,<2.11.0a0
+  - numpy >=1.19.5,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - openssl >=1.1.1t,<1.1.2a
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 1991674
+  timestamp: 1680120959161
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geopandas-0.12.2-py38hca03da5_0.tar.bz2
+  sha256: a9efd9f67dcff0913f69bf61ed9a12d378679d12a2d64e792d1f249da5321d9a
+  md5: 4bd3bb8fb36ec1d169280f74b8f7b244
+  depends:
+  - folium
+  - geopandas-base 0.12.2 py38hca03da5_0
+  - mapclassify >=2.4.0
+  - matplotlib-base >=3.2.0
+  - python >=3.8,<3.9.0a0
+  - rtree
+  - xyzservices
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7447
+  timestamp: 1675672060033
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geopandas-base-0.12.2-py38hca03da5_0.tar.bz2
+  sha256: e6747b5a6160a75024401f1fc3631b38ba10b4622bf3265c26dac56db8983cb8
+  md5: 89b87bb43ac02aac9342f9e713447f15
+  depends:
+  - fiona >=1.8
+  - packaging
+  - pandas >=1.0.0
+  - pyproj >=2.6.1.post1
+  - python >=3.8,<3.9.0a0
+  - shapely >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1268090
+  timestamp: 1675672058289
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geos-3.9.1-hc377ac9_1.tar.bz2
+  sha256: c901ff0682a8dcca5e77934a285af51dc7cfe5b0d2c22608d043d2940aecfb52
+  md5: 25182cc424f23f0544362ef982ce9138
+  depends:
+  - libcxx >=12.0.0
+  license: LGPL-2.1
+  size: 889806
+  timestamp: 1629009640131
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geotiff-1.7.0-h41f0982_1.tar.bz2
+  sha256: a004048c9213703281d4b4c1b62c715bfd752e8dbbfdb3a74790ac38634a185f
+  md5: 7f724be357545e2eb4866c6b9662b29f
+  depends:
+  - jpeg >=9e,<10a
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - proj >=7.2.0,<7.2.1.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 134871
+  timestamp: 1679997100247
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-0.21.0-h13f89a0_1.tar.bz2
+  sha256: 769329b869e583a6cf391e811d5e7075f2f1d8e0b62f76690f12814e432d659b
+  md5: 9831b982fc81c64bd52b63419913d209
+  depends:
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - libxml2 >=2.10.3,<2.11.0a0
+  - llvm-openmp >=14.0.6
+  - ncurses >=6.4,<7.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 3557268
+  timestamp: 1679578832882
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+  sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
+  md5: 1d0bd7e576c64c059ef781dd319ad82a
+  license: MIT
+  license_family: MIT
+  size: 77591
+  timestamp: 1676983230102
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glib-2.69.1-h514c7bf_2.tar.bz2
+  sha256: 6632f8299a02990872948001cf8697a4e11c8b8f0e25cb8054166d558f32b86b
+  md5: a4ed2c8e4115f5bc56b9490f94f9d7a3
+  depends:
+  - gettext >=0.21.0,<1.0a0
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.16,<2.0a0
+  - pcre >=8.45,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 3463753
+  timestamp: 1669364513617
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf4-4.2.13-h5e329fb_3.tar.bz2
+  sha256: e9ccc7a4ec25606556785100e6ee1dd5d9b04ed1973978545a37bfe6be929ddc
+  md5: 2a40342fd2402a56d833312609fcf16b
+  depends:
+  - jpeg >=9b,<10a
+  - libcxx >=12.0.0
+  - zlib >=1.2.11,<2.0.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 913497
+  timestamp: 1629192094107
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf5-1.12.1-h160e8cb_2.tar.bz2
+  sha256: 4f5dc26b65f4f1404408a52d90d867dcdaed53d6b1934b4069fca5ab69e2bf8f
+  md5: 31c93ccfd519d969aedb84bf093b3c1d
+  depends:
+  - libcurl >=7.82.0,<9.0a0
+  - libcxx >=12.0.0
+  - libgfortran5
+  - openssl >=1.1.1o,<1.1.2a
+  - zlib >=1.2.12,<2.0.0a0
+  license: HDF5
+  license_family: BSD
+  size: 6270448
+  timestamp: 1655307672422
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-68.1-hc377ac9_0.tar.bz2
+  sha256: ec6fe8fb2533f8fae73866531ad8c93b20a2b060737d237445f115455c3ab96b
+  md5: cec95fa3d8b36559af63caf4fb1f6caf
+  depends:
+  - libcxx >=12.0.0
+  license: MIT
+  size: 13742625
+  timestamp: 1630597537784
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py38hca03da5_0.tar.bz2
+  sha256: 43d84999da439d3cb9d848e995403b0c9812bf8d8dc5c6da1b687de1f0db1be3
+  md5: 41853629097b1396141396e375b2038f
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 112264
+  timestamp: 1666125657324
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py38hca03da5_0.tar.bz2
+  sha256: ef81f5fa90a119336b095d23a2e169e0b7a0fc5547562a7c1b8ade307b724ea5
+  md5: 1a49db098332a13986a8fcaf3a0c7f2a
+  depends:
+  - python >=3.8,<3.9.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38781
+  timestamp: 1678997135620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py38hca03da5_0.tar.bz2
+  sha256: fef0bbba380ab777d70b67f3fe3a452511c871e293ec87023984d4c47408ee70
+  md5: 71d0048775d5ac4884635c4283904230
+  depends:
+  - python >=3.8,<3.9.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51764
+  timestamp: 1698254705506
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py38h33ce5c2_0.tar.bz2
+  sha256: ea9d98485603942ed6157d9c4b44e88c9fc8c404a4e715d0d1d825d1010f9902
+  md5: d4f50fe1aae26e1ab70f5b3b77b95a61
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 220282
+  timestamp: 1691121881612
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.12.2-py38hca03da5_0.tar.bz2
+  sha256: f7417bde08616c279e8a9d3f739d5149e05202c4d79f50cf5d7706fed80d5e94
+  md5: a67b25df2a3f4e14754775388e8c7077
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.8,<3.9.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1242385
+  timestamp: 1691532423653
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py38hca03da5_1.tar.bz2
+  sha256: 4df8e1e529abac4bc0e5bea9a27b076f139e410eb1ed72c3c25c4fb0910cbc03
+  md5: 4a21434ff4e0415292b5d9c4cd997dd7
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 1022307
+  timestamp: 1644316004245
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/joblib-1.2.0-py38hca03da5_0.tar.bz2
+  sha256: c9b2ba2e68ed6eb2f91fa79f212288d660d5b17b1f82d63995d7bb126a847545
+  md5: a11f3edc7d8dc5b1485dacf6c515e5cd
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 401932
+  timestamp: 1685113178453
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
+  md5: 055e12390b844ea6c6e956ee08a618e8
+  license: IJG
+  license_family: Other
+  size: 273479
+  timestamp: 1677849171867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/json-c-0.16-h1a28f6b_0.tar.bz2
+  sha256: bb74124d37db18c31b4fef64d64f5809f50e9505ea5500437759b7fce8b2266c
+  md5: 0335d80562d5b6254f0d35791295241a
+  license: MIT
+  license_family: MIT
+  size: 75219
+  timestamp: 1659123705674
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py38hca03da5_0.tar.bz2
+  sha256: 8ca52555bd96018684737062dd1ae9433102c7a08a092f2477f1d45794a78fc7
+  md5: e81388e9397277c75d0e7a3c30eedae0
+  depends:
+  - attrs >=17.4.0
+  - importlib_resources >=1.4.0
+  - pkgutil-resolve-name >=1.3.10
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 132864
+  timestamp: 1676558857190
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py38hca03da5_0.tar.bz2
+  sha256: a4b6892b15665ccf82b3d8e881f4a8ed54febb4a490ce5921277438ad154986f
+  md5: fdcc463db49334d736ab371cce0a84cf
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 197158
+  timestamp: 1676329125183
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py38hca03da5_0.tar.bz2
+  sha256: 92d22ba2c10a476f08c1a1d1b0820f666a2477dbc2b2b2c44ed622cd31dc416a
+  md5: ecec507491cef0e5deff4479a1acf00b
+  depends:
+  - platformdirs >=2.5
+  - python >=3.8,<3.9.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92791
+  timestamp: 1679906603831
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py38hca03da5_0.tar.bz2
+  sha256: dab44b851f1a67cda9d4aee9c2bf09d80b68aab4aa8a7200a820039d08025f69
+  md5: 300aaffe4e4cce40942f4e88b6f2d5d9
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 399673
+  timestamp: 1671707647012
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kealib-1.5.0-hba2eb73_1.tar.bz2
+  sha256: ebb886d4072bc12e08a90a8e14b61a2bbd4a17e69993f848982da2f7d60ed3d9
+  md5: 7da7333b8b4d51ab4408c66cd0bcd432
+  depends:
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 161523
+  timestamp: 1687966978773
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py38h313beb8_0.tar.bz2
+  sha256: 101c40cdf1df9e9dba602d371f2dff580f19836f3b1f7043468dbde93151efa4
+  md5: 39dc576e64c3e1acb98a975530b87ac2
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64180
+  timestamp: 1672387223612
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
+  sha256: e547a4a540ccc9db683d6d2e3e36b0d0ad99e1ad10b22b5f403af3e893b412ba
+  md5: dc5ae0ece3c4990ba5fee7b266f2a019
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - openssl >=1.1.1u,<1.1.2a
+  license: MIT
+  license_family: MIT
+  size: 1306804
+  timestamp: 1686931342120
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.73.0-h49e8a49_12.tar.bz2
+  sha256: 4342165ac2224b02089c3a8db136f067cabddb9f8a6a13e46b839d0b5263a841
+  md5: e13a408297da09dd8d77e6e4904f4232
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=68.1,<69.0a0
+  - libcxx >=12.0.0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 20106750
+  timestamp: 1655879742590
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
+  md5: a0f206782751dfffed0dd51302a1bf26
+  license: MIT
+  size: 68012
+  timestamp: 1659616138077
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
+  md5: 4c6667cdd061d28e9bc4e4300e4d115e
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 31173
+  timestamp: 1659616155596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
+  md5: 637e9430e258ddf050623ef2360184d8
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 298430
+  timestamp: 1659616172209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
+  sha256: a94cc52c1ca2e421342d2fefc6d7774ff5118b9d01f4e22d33314f8520d33723
+  md5: 440575339cec83722e83087db31127bf
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.52.0
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 342121
+  timestamp: 1693515586487
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20221030-h80987f9_0.tar.bz2
+  sha256: 6304be2cb816e57ac178068d49befffba4354847f9ee1cfd0ec6acf9ba4ad94a
+  md5: af25d1cc1334d44d2b96eb8133c1dac9
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 167428
+  timestamp: 1670840153090
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+  sha256: 6fc572025852b210ecddcca3ab9ff3f1d5f6bd91f1933c6e296de6bb331f6b5d
+  md5: 6dd7d9c5737bbd2a27d18f15318dc3e6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 102059
+  timestamp: 1628961869728
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+  sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
+  md5: 55c615026c0869f8d3ba657f3bd38c43
+  license: MIT
+  license_family: MIT
+  size: 120389
+  timestamp: 1683716579036
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgdal-3.6.2-h50c47ba_1.tar.bz2
+  sha256: 74611ad2a44f19518902d1be51a6ffa0ccfb917682ada620223a6c9001bb809c
+  md5: 236fd482190d440791596dd691680163
+  depends:
+  - blosc >=1.21.3,<2.0a0
+  - cfitsio >=3.470,<3.471.0a0
+  - expat >=2.4.9,<3.0a0
+  - freexl >=1.0.6,<2.0a0
+  - geos >=3.9.1,<3.9.2.0a0
+  - geotiff >=1.7.0,<1.8.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - hdf4 >=4.2.13,<4.2.14.0a0
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - icu >=68.1,<69.0a0
+  - jpeg >=9e,<10a
+  - json-c >=0.16,<0.17.0a0
+  - kealib >=1.5.0,<1.6.0a0
+  - lerc >=3.0,<4.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libiconv >=1.16,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libnetcdf >=4.8.1,<5.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=12.9,<13.0a0
+  - libspatialite >=4.3.0a,<4.4.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base
+  - libxml2 >=2.10.3,<2.11.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - openssl >=1.1.1t,<1.1.2a
+  - pcre2 >=10.37,<10.38.0a0
+  - poppler <=22.12.0
+  - postgresql
+  - proj >=7.2.0,<7.2.1.0a0
+  - qhull
+  - sqlite >=3.41.1,<4.0a0
+  - tiledb >=2.3.3,<2.4.0a0
+  - xerces-c >=3.2.4,<3.3.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 9407038
+  timestamp: 1680120832390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+  sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
+  md5: a41117710dafe569c9cc4e83f6f29fe3
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1411339
+  timestamp: 1650982753977
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libkml-1.3.0-hc4d7c42_7.tar.bz2
+  sha256: 3934364764ac9651132865f4bfaf3ae17f4bdbf2a96bd5ee7faec7995c556fb7
+  md5: 8012eb6fc2f5750fea616fe03b1be95e
+  depends:
+  - expat >=2.4.9,<3.0a0
+  - libcxx >=14.0.6
+  - uriparser >=0.9.7,<1.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 448001
+  timestamp: 1693261840201
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm11-11.1.0-h12f7ac0_6.tar.bz2
+  sha256: 6450802cad40b813a99572891811830758393500f4c79a223e1046918872c3f7
+  md5: 616a6976906afa0035a2dc2ea1c34195
+  depends:
+  - libcxx >=4.0.0
+  - zlib
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 21766415
+  timestamp: 1665076236980
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnetcdf-4.8.1-ha022005_4.tar.bz2
+  sha256: 962a15d8bbf1bfa7f4f1bf2b6a547b770f16ac8f6f374ebf1205f95d6893090a
+  md5: 37d8db4c0339cedc632314a34bb69886
+  depends:
+  - hdf4 >=4.2.13,<4.2.14.0a0
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  - libzip
+  - openssl >=1.1.1v,<1.1.2a
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1461182
+  timestamp: 1691155105280
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
+  sha256: 039483aadb821adffcc2aff761ec35474d633b6bc2f1eb7cce877a881d7ed290
+  md5: d75b21db95481154cfa9d7a871f0f3bf
+  depends:
+  - c-ares >=1.19.0,<2.0a0
+  - c-ares >=1.7.5
+  - libcxx >=14.0.6
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - openssl >=1.1.1u,<1.1.2a
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 743061
+  timestamp: 1686931613436
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpq-12.15-h449679c_1.tar.bz2
+  sha256: 50200d127777088845f196d08938ae47e7806263f138397279e38d815108cac6
+  md5: 15e25b0a643fbc872b0f30e08643654f
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - openssl >=1.1.1u,<1.1.2a
+  size: 2918646
+  timestamp: 1687380617188
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libspatialindex-1.9.3-hc377ac9_0.tar.bz2
+  sha256: 592a66a6145b5eee819a97caf509b996c84fe2c9ecd69c7e300f8b2a02050682
+  md5: 65682197af5a83e3ce46b5d04d44ef3b
+  depends:
+  - libcxx >=12.0.0
+  license: MIT
+  size: 386585
+  timestamp: 1629286650261
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libspatialite-4.3.0a-h4707d77_23.tar.bz2
+  sha256: bde523cbf47065a1d2e47ee1f3516e83e47bc286490b5024720a1030bcdb542b
+  md5: d821a08e51a17e131a16ca1e1bbfedf0
+  depends:
+  - freexl >=1.0.6,<2.0a0
+  - geos >=3.9.1,<3.9.2.0a0
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - libxml2 >=2.10,<2.11.0a0
+  - libxml2 >=2.10.3,<2.11.0a0
+  - proj >=7.2.0,<7.2.1.0a0
+  - sqlite >=3.41.1,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 3061330
+  timestamp: 1680110261420
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
+  sha256: 48a8617773b57a4b9a8539782bf88a317f49a644d3f858aa0ad3ab13afc03ae7
+  md5: c3bc0fb3cc9a98ef1f2f83ef497fc5da
+  depends:
+  - openssl >=1.1.1u,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 334616
+  timestamp: 1686931322663
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+  sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
+  md5: 98d22e0124d55fae3c37c608dab1dcc9
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 89825
+  timestamp: 1694778225280
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h372ba2a_0.tar.bz2
+  sha256: 2bbf6abf6f6580c2f54dafd83b850e5f0b362da0d1b3953a5969c95b8868d395
+  md5: c20122a5fdee8e3b4d6c65d38459fc20
+  depends:
+  - icu >=68.1,<69.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 656627
+  timestamp: 1692647717145
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzip-1.8.0-h0c481fb_0.tar.bz2
+  sha256: 7035bf74c9adbc5d98ed17a5618a7b6df97479fc60e1398fd29a9f8b42bcb1b1
+  md5: 429d9725086eceeafd42a5369c5791b1
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - openssl >=1.1.1o,<1.1.2a
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 121284
+  timestamp: 1652981900392
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.37.0-py38h8b39d70_0.tar.bz2
+  sha256: b68c92256fc28c5cd36f83c823704abb4518df8295dfcd52461bf87674495632
+  md5: db5a9dcb8384260ca22c3203359f8352
+  depends:
+  - libcxx >=12.0.0
+  - libllvm11 >=11.1.0,<11.2.0a0
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  size: 328720
+  timestamp: 1643978389796
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py38hca03da5_0.tar.bz2
+  sha256: 307477ab96bae938902afb6c1689017986654464719644c6d17f85e032e44abc
+  md5: 37a8e89bd4b324c309facc82bdc64941
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11872
+  timestamp: 1652903134672
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+  sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
+  md5: c99006da802a97c9aae30da8c16b4820
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176131
+  timestamp: 1670944706815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mapclassify-2.5.0-py38hca03da5_0.tar.bz2
+  sha256: 4a3ae7a24361575b0c18db6724e2684f0ad94aa8214fada7f0da8a2b826affbf
+  md5: 7aca87f6fa869239e7d5c0bd5f76db1c
+  depends:
+  - networkx
+  - numpy >=1.3
+  - pandas >=1.0
+  - python >=3.8,<3.9.0a0
+  - scikit-learn
+  - scipy >=1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 67601
+  timestamp: 1675157803073
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py38hca03da5_0.tar.bz2
+  sha256: 2c34852ea6fe459fc4e892f2b3c43cb22093c66bb0dd4c7a577affef3c1ad350
+  md5: 9fd19f5fc3dc04e95a205552307c4316
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123564
+  timestamp: 1671541934866
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.0.1-py38h1a28f6b_0.tar.bz2
+  sha256: 232bdf1ba2292fccb52a13e04457d7ee6a9c3c65b34f1d772dbacbaa657d3332
+  md5: d8a2f07ecfb16293475183b6b4dcf76c
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22403
+  timestamp: 1629137440910
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.5.0-py38h9197a36_0.tar.bz2
+  sha256: 8c263600f46eb1febf203d992c68962113aef195255038464a781c79310dfb79
+  md5: 4bd370ea10825ca3cfc96c90c383fbd3
+  depends:
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.11.0,<3.0a0
+  - freetype >=2.3
+  - kiwisolver >=1.0.1
+  - libcxx >=12.0.0
+  - numpy >=1.19.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.2.1
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7627542
+  timestamp: 1638374169303
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py38hca03da5_0.tar.bz2
+  sha256: 8ed7b59ced736b2c2dca4bf793fd22071920847c7c009ae08215618e0cf9634e
+  md5: 0b7e6805f36a34f1fc27b8230830f22d
+  depends:
+  - python >=3.8,<3.9.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17305
+  timestamp: 1662014548083
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py38h1a28f6b_1000.tar.bz2
+  sha256: e492f6e1773997b51e94863f30dd711c5494a59cf686666cc71c1080dac7b871
+  md5: 023961822c6aed9e5ea8f1e9cb392321
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 55707
+  timestamp: 1629356096769
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py38h525c30c_0.tar.bz2
+  sha256: ea6e79e88ff83790d1ce7dd4f77cd46a8904cfba65f8e1bd6ffee33bcc855373
+  md5: 800b92ae3bbeae2f1e5374cfb2d05895
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 83473
+  timestamp: 1652362704023
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py38hca03da5_0.tar.bz2
+  sha256: 32ca9f80183284c18f43c656f85ce1ee6b367db95373afacaa9d8ee4d4f47781
+  md5: 3bcae7fb685499f69ac281f0f2370679
+  depends:
+  - python >=3.8,<3.9.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 23009
+  timestamp: 1629282754789
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py38hca03da5_0.tar.bz2
+  sha256: 03afb59c187b4cdec2bfcf65334cb9d4713a3d853977adc483dc0e9ee5e79d0c
+  md5: 0fd1e2b527781364e0cb7372126ac18e
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8293521
+  timestamp: 1681756545565
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py38hca03da5_0.tar.bz2
+  sha256: e0269bdd6a1782a56e6045538da9af40ce305c991665339fe470ca3c6a4f713d
+  md5: 79956486ddf726287b0c21f0b5123bd3
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.8,<3.9.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 96772
+  timestamp: 1650373673399
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.4.4-py38hca03da5_0.tar.bz2
+  sha256: acd1ef9f4592a4f932276284ac507298b67df93ff550fb26ee4ce3807c5d1318
+  md5: 738f1de620bd6cbcf51abe62be995b11
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=2.4
+  - jupyter_core
+  - jupyterlab_pygments
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0,<0.6.0
+  - nbformat >=4.4
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.8,<3.9.0a0
+  - testpath
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 578638
+  timestamp: 1649751937473
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py38hca03da5_0.tar.bz2
+  sha256: 35752b15fbeede3c09d4eb11119b0b19e44cd4920a0ae8b63d4fa429b5c88505
+  md5: 1ccc6494ecdf62992dd685c7ea56be51
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.8,<3.9.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148332
+  timestamp: 1694616807292
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py38hca03da5_0.tar.bz2
+  sha256: fa202d7013e173bbd3a90f808dbc51038940f59912ae7ab4d11a87ccc16a384b
+  md5: 958f9798ac78c8e0f381e2ec59413ce9
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13964
+  timestamp: 1672387151610
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/netcdf4-1.6.2-py38h053bab8_0.tar.bz2
+  sha256: dfc0fbee8057c63c9895a24e5c53dba028173e84860d109a3000724f947430bf
+  md5: 8f16c4e9a19677abd081a27ee6a05432
+  depends:
+  - cftime
+  - hdf5
+  - libnetcdf >=4.8,<4.9.0a0
+  - libnetcdf >=4.8.1,<5.0a0
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 458365
+  timestamp: 1673455539600
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.1-py38hca03da5_0.tar.bz2
+  sha256: 3e67e248242b27b2e11bbdd7689c4cc9b65bcfb9f9dc9c4bfa172e55d89238a9
+  md5: 107c2cb41db5cecba88987430860dac8
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2968202
+  timestamp: 1690562086263
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py38hca03da5_1.tar.bz2
+  sha256: 301193b31a4ead33aea2c01d00d8f3d292406e0310d6ebc8e4d8192319449187
+  md5: 08262f4fb565edca50993fec64afbe21
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 586692
+  timestamp: 1690984859816
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py38hca03da5_0.tar.bz2
+  sha256: 2773a82bb679dac047f390713083cf7a88a206680fc536e5cc6c38b03931b8c4
+  md5: fa962bc8ad8bef9a9b9c50fbda21f0c2
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22863
+  timestamp: 1668160601243
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nspr-4.35-h313beb8_0.tar.bz2
+  sha256: 49514dcfb22fb667890bebf464118e59f0c05b0574e39082cf06d4e171fc7f22
+  md5: e7808cc8e4a810fe3d9390192c44c619
+  depends:
+  - libcxx >=14.0.6
+  license: MPL-2.0
+  license_family: OTHER
+  size: 252418
+  timestamp: 1685541795239
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nss-3.89.1-h313beb8_0.tar.bz2
+  sha256: 01fe9808891853091be4aea4f05882ce1991d737e9f409dfc31ee4daa199019e
+  md5: 9c3977aa66fc7d91d83f63d79792ee1d
+  depends:
+  - libcxx >=14.0.6
+  - nspr >=4.35,<5.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MPL-2.0
+  license_family: OTHER
+  size: 2038812
+  timestamp: 1685543329548
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.54.0-py38hc377ac9_0.tar.bz2
+  sha256: 8749d8b60b1cd973c9f78ac978465a1675ad7a6847cdd2460eb2aa16301a0f5b
+  md5: 4fa37ae58e57c40fa8de32e362663b33
+  depends:
+  - libcxx >=12.0.0
+  - llvm-openmp >=12.0.0
+  - llvmlite >=0.37.0,<0.38.0a0
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  - tbb >=2021.3.0
+  constrains:
+  - numpy >=1.17,<1.21.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3814162
+  timestamp: 1629980986750
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.4-py38h79ee842_1.tar.bz2
+  sha256: 09acb2d02a5cf5fb8b10252aba95cbc1efc2a95c43f4b81710dc23542ef3c4d3
+  md5: 23a179a3a80b2ec7c4e2ec6b9055210a
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 122400
+  timestamp: 1683221874476
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.19.5-py38h831b0dc_4.tar.bz2
+  sha256: f89b2df3c65d019e213588e1afa0d2cf94cf4137d8879b4ad0487c06122d577f
+  md5: b3f8d316bdd97b82869b82f4bdb0333a
+  depends:
+  - blas * openblas
+  - libopenblas >=0.3.20,<1.0a0
+  - numpy-base 1.19.5 py38hdc56644_4
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11036
+  timestamp: 1677549992401
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.19.5-py38hdc56644_4.tar.bz2
+  sha256: 39f25d723d1610f87bfccd3df9af4a70d968d3f9971aeea44c2f45d4723ea09c
+  md5: d0a97ae5572541f7cb23a02cffac9fd0
+  depends:
+  - blas * openblas
+  - libgfortran5
+  - libopenblas >=0.3.20,<1.0a0
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - numpy 1.19.5 py38h831b0dc_4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5031326
+  timestamp: 1677549981194
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
+  md5: 371358a54bbdd307603888348d1a2c6f
+  depends:
+  - libcxx >=12.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD 2-Clause
+  size: 412248
+  timestamp: 1628861367714
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
+  sha256: 409ba99dd953129c0ccebb5dcbf2049920e5a755b88e7e392e4f91be924e26ef
+  md5: f05f00606c10617a61c41f23652b9a00
+  depends:
+  - ca-certificates
+  license: OpenSSL
+  license_family: Apache
+  size: 3450897
+  timestamp: 1694465216241
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py38hca03da5_0.tar.bz2
+  sha256: 2224aecba4eb43cb6bf75641c07efee607ffa5f0e419214da969930bf6bc939a
+  md5: 2d0973f43006d805567ae3092e3d2739
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73637
+  timestamp: 1693575275014
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-1.3.5-py38h9197a36_0.tar.bz2
+  sha256: 1395f495dc78187e80fa7334ff1aa980d80044666aad4fca7eb23a5e5e1ec106
+  md5: d5b2fd9291a5691a6dc90c1ca41073e5
+  depends:
+  - bottleneck >=1.2.1
+  - libcxx >=12.0.0
+  - numexpr >=2.7.0
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.7.3
+  - pytz >=2017.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11968643
+  timestamp: 1641482506915
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.0-py38hca03da5_0.tar.bz2
+  sha256: c0224dbf9acf3e85b0c0561d8a0c18563e37b2acbe30ca91308baf72f53b17c6
+  md5: d59ed9b27032114d1b48fa3d9ab23f75
+  depends:
+  - locket
+  - python >=3.8,<3.9.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35906
+  timestamp: 1693937909555
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre-8.45-hc377ac9_0.tar.bz2
+  sha256: 83ae22c702ab99a904992f322049a4b41ecd711b6088aae61420992452ec64bc
+  md5: 92b1f6d5d3e70ce8adf51d1bcf0531a8
+  depends:
+  - libcxx >=12.0.0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 236201
+  timestamp: 1629474194684
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre2-10.37-h37e8eca_1.tar.bz2
+  sha256: 4aa188dfa8f8cb24899e01875b804310ac81f43e618630b1828060c4dfd90d8a
+  md5: 55a6179184fd02c74c6fbd80ea4fad2e
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 783351
+  timestamp: 1641403689283
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py38h3b245a6_0.tar.bz2
+  sha256: 99e96dafcc446efb103cecf6f7ddb4161fc875e627fb1d51084a5865605e4ee2
+  md5: 4a38b476dda6db5735a543a323038ec0
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.8,<3.9.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 720719
+  timestamp: 1696580206985
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py38hca03da5_0.tar.bz2
+  sha256: 8b2238d03fd4d4dd3e7c965256788e7bc9f390db9d8b086e2069cdc07c9cd9fc
+  md5: 39f7e7530c1113ec41b105a10cc77ab5
+  depends:
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2679861
+  timestamp: 1697548818737
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pixman-0.40.0-h1a28f6b_0.tar.bz2
+  sha256: a7b1a6ddba772080777ac65570dffa9ed08dd866e053fa98f3aa38835c9b010b
+  md5: a3abe939bd01b7f6fb4e4f3b6da91f7b
+  license: MIT
+  size: 269396
+  timestamp: 1628926728556
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pkgutil-resolve-name-1.3.10-py38hca03da5_0.tar.bz2
+  sha256: febea10909ebabc1b963493f74e5b41224259cc550481e87d04e243d2eaf1125
+  md5: baddd5bef9eb6f021ae8fa047545881b
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT AND PSF-2.0
+  license_family: PSF
+  size: 10736
+  timestamp: 1661463349093
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py38hca03da5_0.tar.bz2
+  sha256: d97cb927d800e9a447c2b9e0983b0518d7f41b6c5947e62075f4bb5fe9fa3569
+  md5: 5d344c031b607858aac0263ee037f1a0
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 33041
+  timestamp: 1692205775190
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pooch-1.7.0-py38hca03da5_0.tar.bz2
+  sha256: 7447015165bf9b11fb4b6c839e95f2978ac012301d843aa79a5eb3a180d72cae
+  md5: 5e0595b52a068b93fbc91a22480535fc
+  depends:
+  - packaging >=20.0
+  - platformdirs >=2.5.0
+  - python >=3.8,<3.9.0a0
+  - requests >=2.19.0
+  constrains:
+  - tqdm >=4.41.0,<5.0.0
+  - xxhash >=1.4.3
+  - paramiko >=2.7.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 82434
+  timestamp: 1695850137461
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/poppler-22.12.0-h52f4003_3.tar.bz2
+  sha256: 9f8cf7e763c5ce4cf0a5ebfc8db8b885b3c4e70c9b9433a96f5500b7fba4f3cc
+  md5: 40ae9e180cbf21de5afdfe4fd096849b
+  depends:
+  - boost-cpp >=1.73.0,<2.0a0
+  - cairo >=1.16.0,<2.0a0
+  - fontconfig >=2.14.1,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - gettext >=0.21.0,<1.0a0
+  - glib >=2.69.1,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - nspr >=4.35,<5.0a0
+  - nss >=3.89.1,<4.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - poppler-data
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 1749726
+  timestamp: 1696000773528
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/poppler-data-0.4.11-hca03da5_1.tar.bz2
+  sha256: 964a66d899c6c661baabf19c89dfeb71586ca495efb5dfe141c3d4d1447e87e6
+  md5: 2fd602e0516b7352f115305cba7708a9
+  license: GPL-2.0-or-later and GPL-3.0-or-later and BSD-3-Clause
+  license_family: GPL
+  size: 3918339
+  timestamp: 1673886276945
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/postgresql-12.15-h1ae2815_1.tar.bz2
+  sha256: d7aa4c1f43d69d14c7fc79e1b4c6fd32b205488432670e50ddd5c9350836e237
+  md5: 68f287d885bbf61b1851f31c0fd0d4cf
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libpq 12.15 h449679c_1
+  - openssl >=1.1.1u,<1.1.2a
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  size: 4005629
+  timestamp: 1687380646878
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/proj-7.2.0-heac154c_1.tar.bz2
+  sha256: cde1995bcc8f9aec04ba5590ff8b2c9761fd80d7421e8885367aeed9f1576c3b
+  md5: 36c6e4df74d2c71d27ca552e9af62f4d
+  depends:
+  - libcurl >=7.71.1,<9.0a0
+  - libcxx >=12.0.0
+  - libtiff >=4.2.0,<4.7.0
+  - sqlite >=3.36.0,<4.0a0
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  size: 2900328
+  timestamp: 1629967923612
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py38hca03da5_0.tar.bz2
+  sha256: 41dadbf05754b86a3323059a67742e4d4fee178661d92705ef496ea14cd91d66
+  md5: e55ee42cc29c11809f568d8d1cf4747c
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91074
+  timestamp: 1659455126069
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py38hca03da5_0.tar.bz2
+  sha256: eb1bb190aabf2e071c38bb812cc5d22dc67bbf65d0b490058641cc206c8050fe
+  md5: d81e45e0c8f7b64444d67c456e841672
+  depends:
+  - python >=3.8,<3.9.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 579541
+  timestamp: 1672387337842
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py38h1a28f6b_0.tar.bz2
+  sha256: 3c5bd50929a4aa13c72095653118fd7cc44053bbe80949fd9f78d6bc78128487
+  md5: cc9daac414bf6d0fc28087deceeeb54d
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 366992
+  timestamp: 1656431324712
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py38hca03da5_0.tar.bz2
+  sha256: 8d542e0301f4692b0810d9c6143400ac24ffe65c1c5276fb9167c9dd6dcfd894
+  md5: a1b3ddffe3d0dfde327191c5a1d2d26f
+  depends:
+  - param >=1.7.0
+  - python >=3.8,<3.9.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30761
+  timestamp: 1675441503308
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py38hca03da5_1.tar.bz2
+  sha256: aa6b41d2921130aed4630653e555fd90f4531970297e8b3a434f9d6dc2357294
+  md5: b0ba357ab09318153b94d105a7863e3b
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1887242
+  timestamp: 1684279996873
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py38hca03da5_0.tar.bz2
+  sha256: 32f8719ee099ff80d53842ad8df81cead9d3e1f9df41b36e9460aa34bbc42d62
+  md5: 26662ce6b5181b6f37f6b027f729d07d
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95591
+  timestamp: 1690223471024
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py38hca03da5_0.tar.bz2
+  sha256: 3e4fed535277fc9d94c53d717ca10e7faf1d051f4d2fcefb1a02cd0e84585bc6
+  md5: 156fde9f3f56a6b1b9cb7b8020748288
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 157834
+  timestamp: 1661452633325
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyproj-3.1.0-py38hfce2bd4_4.tar.bz2
+  sha256: c945d9a0d5a5cc34a511e1c49d9c2cc48b316b3865345ce0709ca6016aedc327
+  md5: 4890adfef3697b13da358e174c2e3bdd
+  depends:
+  - certifi
+  - proj >=7.2.0,<7.2.1.0a0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  size: 456408
+  timestamp: 1629968175553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py38h1a28f6b_0.tar.bz2
+  sha256: 89f46d5896b289e6376efe1b6de185f8c7ab9896b2c64144841680b373f9a0f5
+  md5: de0bfe11706d0fea87d1185c65d655eb
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 91828
+  timestamp: 1629278499184
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py38hca03da5_0.tar.bz2
+  sha256: 47d308dd037d9373cf00b341a34ad2cb2d2f2dbb06d3ac5e59ef05d3ec81b3bb
+  md5: 6f20c9bfe7585ae23ec10ea950553603
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 27337
+  timestamp: 1626781365102
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.8.18-hc0d8a6c_0.tar.bz2
+  sha256: b8fe0d51772aebcd4664f4faba55a3ca42b0ae7b4a3261b955c0e260dee0f6d1
+  md5: 40ca48fa679cca7093e7bf37bae3ea07
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 15400446
+  timestamp: 1694438953629
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py38hca03da5_0.tar.bz2
+  sha256: ad379c6a9b647dd1606107456d005228027d3c92e0fc55fcf47861df4527e46c
+  md5: 12b99cac3003bc54b23d599c9999a8c4
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 266004
+  timestamp: 1661368815072
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py38h313beb8_0.tar.bz2
+  sha256: 7bb699635692c6b113d9ae0b6278026f33721b0af581d2012b3ae12452ef0299
+  md5: b924257ab4a27121bdebb03f8145ca67
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.8,<3.9.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 136234
+  timestamp: 1682522529684
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py38hca03da5_0.tar.bz2
+  sha256: 14ae410c9709a138599b93c2a45268931430f53f0c348e4f4f5524f863f10110
+  md5: 9e70f067fbed5f69c1a3341bfc43cc98
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 267242
+  timestamp: 1695131671919
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py38hca03da5_0.tar.bz2
+  sha256: 636dc028dfb88e2cc7f0e802b5a7a228c19295a06680a04453582e4bd6d039a8
+  md5: 81d6910e095c2b42882b431eecee7fab
+  depends:
+  - param
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40945
+  timestamp: 1685030821471
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py38h80987f9_0.tar.bz2
+  sha256: 62218268c76f7a70fc7895163e57cbe73e9a87e828931d675693c1aa689e1b6c
+  md5: bb8d0a68a05e6d8b1da8c659d656a2d6
+  depends:
+  - python >=3.8,<3.9.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 166923
+  timestamp: 1698096185614
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py38hc377ac9_0.tar.bz2
+  sha256: 912d76d7e27223aec1ae9a7a21f9771a486242e2dfec4b173de6401b5e34bfd9
+  md5: bae29a7c8e23e240f4ef632a8c9a8335
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.8,<3.9.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 467169
+  timestamp: 1657724377965
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/qhull-2020.2-h48ca7d4_2.tar.bz2
+  sha256: e033f2c9e52aa705d9c10d9a352bdad47a363299e42ad62bd7089ddf112ca355
+  md5: b7e91b270376c6d7281413dc8779cdea
+  depends:
+  - libcxx >=14.0.6
+  license: Qhull
+  license_family: Other
+  size: 1888397
+  timestamp: 1670915845902
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py38hca03da5_0.tar.bz2
+  sha256: 3d88a7aa68ecc536d0fafffca9f09c6426ef76083546c11cd5d4d11303ea68e3
+  md5: 0e3b8587269906972e6c043ea4bde568
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.8,<3.9.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95068
+  timestamp: 1690400283875
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rtree-1.0.1-py38hca03da5_0.tar.bz2
+  sha256: 2d65bedc3aab0cc0760342a631aed093a264fb310e9f6fda9f61c73e5cc829b5
+  md5: ae757c3132b6ada35d3b6ddb18f17461
+  depends:
+  - libspatialindex >=1.8.5
+  - libspatialindex >=1.9.3,<1.9.4.0a0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 50332
+  timestamp: 1675157882997
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scikit-learn-1.2.2-py38h313beb8_0.tar.bz2
+  sha256: 1aaa6ea9a6ced0fd47f11a6614d2201a9f0e9796c5c08785df26aca012ef4d64
+  md5: 3a3ebd08b7b2cc6058d6671f56f0b175
+  depends:
+  - joblib >=1.1.1
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - scipy >=1.3.2
+  - threadpoolctl >=2.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8681465
+  timestamp: 1680198977194
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.10.0-py38h9d039d2_0.tar.bz2
+  sha256: 64fbf15727a6f04d77e6e47d77e57c324a29ebe0b015f4e37b4c7da7447f9a7b
+  md5: 2debb6ee4ea2ea48a0f4997e2a0d45fe
+  depends:
+  - blas * openblas
+  - fftw >=3.3.9,<4.0a0
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.19.5,<1.27.0
+  - pooch
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23699483
+  timestamp: 1675460648646
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py38hca03da5_0.tar.bz2
+  sha256: 389b6d3e6795e946ca235a243ca94b195e500649c4f39982454ee182b0e215d3
+  md5: 2d20be88e7f7ec8ea437e7a6586680c4
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 1092010
+  timestamp: 1690290925244
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/shapely-2.0.1-py38h9ca3c36_0.tar.bz2
+  sha256: 1fdd4f8f6b73ae348f98184e6c9c4c84589bf13289f2f5e8141d205d7dbafee2
+  md5: 18aa822830da9b76307bcfc58e2c86de
+  depends:
+  - geos >=3.9.1,<3.9.2.0a0
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 424790
+  timestamp: 1680636349114
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py38hca03da5_1.tar.bz2
+  sha256: 50378d9f00c8f79c21419b782ff781b6adb1a77d77719ed74c9053cf52b897c2
+  md5: a7364a86c299a0444670ec87480dc591
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15629
+  timestamp: 1629145936800
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py38hca03da5_0.tar.bz2
+  sha256: 66064f3ee63df60cf0daa216111ce1aee0273a18b1eedf9ea72c96d49aaba5f2
+  md5: e20848a40ca8adb4f4eb05eeecef05a6
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 67344
+  timestamp: 1696347585538
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+  sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
+  md5: 2302a79a045f152e183a52a81adfba62
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1674163
+  timestamp: 1681394762218
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+  sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
+  md5: ae58720a18a2ed15eae214ad7a10d1b5
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 140125
+  timestamp: 1680167256603
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py38hca03da5_0.tar.bz2
+  sha256: 633b552e3b2851778474918745474012c24478028d9199b7e70b405b49edec80
+  md5: 21b71f9ea2e65e770b6703a71c6d1768
+  depends:
+  - ptyprocess
+  - python >=3.8,<3.9.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30932
+  timestamp: 1671751893456
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/testpath-0.6.0-py38hca03da5_0.tar.bz2
+  sha256: 83d3c353677f7d181cacc83dd397e7e54125876e5d436734d8043ea9675c96ec
+  md5: 2e7036398cef211777ceaa78126e00ad
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94385
+  timestamp: 1655908588511
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tiledb-2.3.3-h3ad0f7e_2.tar.bz2
+  sha256: 003459840c022a0f790ba41f7be4add583a0a8d69a541d32e4d3ff98668fa1c8
+  md5: f61e22878730d78fa7c0137f466950c4
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=7.82.0,<9.0a0
+  - libcxx >=12.0.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=1.1.1o,<1.1.2a
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 2811591
+  timestamp: 1655311350211
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+  sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
+  md5: 667e60c8b407d73cbba40f44901f4f00
+  depends:
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3412693
+  timestamp: 1654088929697
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py38hca03da5_0.tar.bz2
+  sha256: 02190c624d356a6ad7b6dba56a32fd33f4cf94ab5c1f087869be84718791487b
+  md5: 7fdd7e3d9b70d446d35425ed13e9c536
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102470
+  timestamp: 1667464107289
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py38h80987f9_0.tar.bz2
+  sha256: 2df1261975825dfd4f07d820ae1c19bce98fa5dc0eb9b1c1903981049a2d0c25
+  md5: 758253a280b0e84529b0eb1a3d85391d
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 679231
+  timestamp: 1696937084224
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py38h86d0a89_0.tar.bz2
+  sha256: 1dcb323fa0ac724c323048a005b4e315dedbab270c1baebf0d268696e87d06f3
+  md5: ccf39817852d58221fef8da99dbe4ba8
+  depends:
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - ipywidgets >=6
+  - slack-sdk
+  - requests
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 124901
+  timestamp: 1679561992309
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py38hca03da5_0.tar.bz2
+  sha256: 902b29577bf695b2386e0d323f80923abc28ea84bac34f6ca73cad9902976618
+  md5: 97d9e41ecc76096448535e308c9ed75e
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192784
+  timestamp: 1671143956975
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py38hca03da5_0.tar.bz2
+  sha256: 99d28957d07455915664e84f1e71b4aa82ba7108c605af28eebeb3b16875994d
+  md5: 60e8669d7b5736e3a7ad3d3e95984e0b
+  depends:
+  - python >=3.8,<3.9.0a0
+  - typing_extensions 4.7.1 py38hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9660
+  timestamp: 1690297597919
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py38hca03da5_0.tar.bz2
+  sha256: 4c3dca51a21645aca14489e54814d73e622aa7948baa6e29ef19e22fa1e34ed2
+  md5: 760645401bdc1af5d0dd338800eab761
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58735
+  timestamp: 1690297590496
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uriparser-0.9.7-h80987f9_0.tar.bz2
+  sha256: c7402bdd16743bbd3350752e7009e40024b7ea2d280f54a6f74a4246f99e0edf
+  md5: 666f1bc2359d58c32ccbcbf4e9fcadd7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42998
+  timestamp: 1692186946914
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py38hca03da5_0.tar.bz2
+  sha256: 92d5dcc58c24c54e3d2d1df6da2f886705d34c813c28d377a6544a8d8647f9ef
+  md5: 941369c8471738fd67ddca4881a21e85
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 188591
+  timestamp: 1698257629160
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py38hca03da5_1.tar.bz2
+  sha256: 82c0d07ca88c806b0816e8f4d5f79d24d8c373cc758ff06b1ad9976257162e67
+  md5: 07036a73e921ca173dcabcff9321c34d
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20079
+  timestamp: 1629144417239
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py38hca03da5_4.tar.bz2
+  sha256: d0bcd4656348071924bfaad2a9a7d7e4c5cd1b2eb65aaf6e38aa9b43ccc2c06e
+  md5: 56579618078447f918a18fb47367db48
+  depends:
+  - python >=3.8,<3.9.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70949
+  timestamp: 1629357088765
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py38hca03da5_0.tar.bz2
+  sha256: d9653a6ef961ee875978492b7163e2b29deffeacc3ee271ede4f5e3e248e7d94
+  md5: 4bc4db5c94f7b75b9d26c3caee12f1e3
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 102415
+  timestamp: 1695742020723
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xerces-c-3.2.4-h389e118_0.tar.bz2
+  sha256: df1b1f12d8728e7ab568b1487c604dfe847c60f29495137d5b28c4699c993a8e
+  md5: fcd3374a1b02b3014d02f8a89c860828
+  depends:
+  - icu >=68.1,<69.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 2720249
+  timestamp: 1668712626345
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py38hca03da5_1.tar.bz2
+  sha256: fe2c19f54551b7ef1c3a5b33dec3125db65ced3cacd187c19004fcd0c3c96213
+  md5: 58f495f8dc56ed6bf8533c8cfa7ca5bf
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49427
+  timestamp: 1675159104659
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+  sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
+  md5: 2e75ad6a09c308268192efe03cc9ebf4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 411778
+  timestamp: 1683113019715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+  sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
+  md5: 30f666bf97c26587c5d2f68cc5f330ab
+  depends:
+  - libcxx >=12.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 316901
+  timestamp: 1629287855861
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py38hca03da5_0.tar.bz2
+  sha256: 75240abcfd39c449374aa916e1aa01e0758bae5f8532520568728a5670141696
+  md5: 4eee6619cd3939d8fc2d881c21f4c248
+  depends:
+  - heapdict
+  - python >=3.8,<3.9.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 77607
+  timestamp: 1695832873064
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py38hca03da5_0.tar.bz2
+  sha256: e38f8fcbdaf5b0ad01c66b0d407ae21cb534a3fc412d3eb5b1f2db67b40e5fc7
+  md5: 0df4c72ef1d772e8122c8d6e361c854f
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 19037
+  timestamp: 1672387185470
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+  sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
+  md5: 467ae28215d1aa1c5688bc0c8a184269
+  license: Zlib
+  license_family: Other
+  size: 103525
+  timestamp: 1666595022664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+  sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
+  md5: 7cfbed15f1feee1422810f7830075f53
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 779464
+  timestamp: 1681304594848
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py38haa95532_0.tar.bz2
+  sha256: cc82907bc0bda29497cdeab8310925dbf228c3f16ac983fcbb37ad765fa6db1b
+  md5: 6ea4dc40a54dee3ab7644d64995212b8
+  depends:
+  - idna >=2.8
+  - python >=3.8,<3.9.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162306
+  timestamp: 1644463761471
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py38h2bbff1b_0.tar.bz2
+  sha256: 03266238128a35b764faac4b242317894abfbd6aa87926925d742fe777540501
+  md5: c69fc290a38779ea332ed0706d58b8e5
+  depends:
+  - cffi >=1.0.1
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 39205
+  timestamp: 1644569956444
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py38haa95532_0.tar.bz2
+  sha256: 3b1702c2673d9cbf3d3390d020f677e655c4630e5f58adcf93e6bff03f6690c1
+  md5: 30739c44ce189fbb20be78431cf3fd2b
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 132981
+  timestamp: 1695718251136
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py38haa95532_0.tar.bz2
+  sha256: 53589b64f777641caa27ac2ef9571d99274f5e2c3edb5874748e682ac241e967
+  md5: febac983b7b52735b196dad1bf458a2e
+  depends:
+  - python >=3.8,<3.9.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 200008
+  timestamp: 1681493159092
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
+  sha256: cf9a8a0745c5fab48394d84a58fe2f06e5fa80c87d5cc8d6c8da2e1df52cc69f
+  md5: 462987773ecda8cbf1f80734e84f080f
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 93601
+  timestamp: 1675247818708
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-2.3.3-py38haa95532_0.tar.bz2
+  sha256: 9c84abed617901f1d66065bd8650dd737cd242d4c6ec77e0d2bedc494846fbc7
+  md5: 60bdddcdaa9d65aef49a0abd62247537
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.1
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8659293
+  timestamp: 1625767854760
+- conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+  sha256: 68ef338b27c035add89c0812ad469dd8c9e94f27130f770345ea20deb049d50b
+  md5: 9ec19b145f655329532b608963cf32f4
+  depends:
+  - libboost 1.82.0 h3399ecb_2
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 11334
+  timestamp: 1696764270626
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py38h080aedc_0.tar.bz2
+  sha256: 44d13de563214c19fa278424b7038f5b68fa7a2885f65843314701ee6ecce4a1
+  md5: 4596b9868dee3b6d493596be5ac8dcb2
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 119589
+  timestamp: 1657175681565
+- conda: https://repo.anaconda.com/pkgs/main/win-64/branca-0.6.0-py38haa95532_0.tar.bz2
+  sha256: cb1291d8e5419384071119e2b66042de673081c53ca9bd2178536177fa8579c3
+  md5: 56dffaeffdff286748e0bfb5c9a15c41
+  depends:
+  - jinja2
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 43078
+  timestamp: 1675157787871
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
+  md5: 507dfe693ef429f466d964b599f4af21
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_7
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 18650
+  timestamp: 1659616328001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
+  md5: d0bf43e8df60baae3b3105aa5c42a791
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 21153
+  timestamp: 1659616312367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py38hd77b12b_7.tar.bz2
+  sha256: dbede6d8a4ccdc885b2d827ffd6be8a624a4ad7ab0a55469381dcfefa2cec9cb
+  md5: 38b2003b07fbfe552a36d4733205c984
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 343217
+  timestamp: 1659616387167
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
+  sha256: 3a26c397d4e0d546b0c2f433074c20813c5f3ae98bcf07a165c648f369a850b9
+  md5: 8f8069ce8c9eff1b0f124de2c0a63b86
+  depends:
+  - vc >=14.1,<15.0a0
+  license: bzip2
+  license_family: BSD
+  size: 154105
+  timestamp: 1563219293348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+  sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
+  md5: 092b417c11edcbe6bb9b765ab4a55d23
+  license: MPL-2.0
+  license_family: Other
+  size: 164999
+  timestamp: 1694009822357
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cairo-1.16.0-haedb8bc_5.tar.bz2
+  sha256: 56af1f19db12dee9dbb177873726b3fdf6cbbd83736748c99ad7c536ff28ff28
+  md5: f2923f93791571dd8a664da18b5de5d0
+  depends:
+  - fontconfig >=2.14.1,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - glib >=2.69.1,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - pixman >=0.40.0,<1.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: LGPL-2.1-or-later or MPL-1.1
+  license_family: LGPL
+  size: 2351737
+  timestamp: 1688495984273
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cartopy-0.18.0-py38h80a4efb_1.tar.bz2
+  sha256: abe53c3493b29b3c9dbaf58bb16793a1b68976a1cc1cd11897f7732aeb6b302c
+  md5: 6be9e3405efdb31178a694a6c8423fd6
+  depends:
+  - geos >=3.8.0,<3.8.1.0a0
+  - matplotlib-base >=1.5.1
+  - numpy >=1.16.6,<2.0a0
+  - proj >=6.2.1,<6.2.2.0a0
+  - pyshp >=1.1.4
+  - python >=3.8,<3.9.0a0
+  - scipy >=0.10
+  - shapely >=1.5.6
+  - six >=1.3.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-3
+  size: 1905833
+  timestamp: 1612289928244
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py38haa95532_0.tar.bz2
+  sha256: 855f213e9d26f98a8a981cc1670caa4f9030a869592c25a6f865b1b5bfa1ffb5
+  md5: a04188728a298ec4bf04665874236b75
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159050
+  timestamp: 1690232498419
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py38h2bbff1b_3.tar.bz2
+  sha256: c4ea45913ae72575af59c399ecd191b4f7a458267d7d68bd2388831be3b445fd
+  md5: 298580960c7e95035ccfa980fc0c9d0a
+  depends:
+  - pycparser
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 228272
+  timestamp: 1670423387289
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
+  sha256: a65386e70bdad9aa1e07ad430309c3ddc249b74bea69388dfbda99fd00069665
+  md5: e4174218de194962642b353f51a19d1e
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  license_family: Other
+  size: 617890
+  timestamp: 1655709069465
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cftime-1.6.2-py38h080aedc_0.tar.bz2
+  sha256: 3d98eda93343cd39b9351290b8c7ef366d98e7aa5a1b1665b1244558fef1183b
+  md5: 5d692d8ba0f60750762e29737f935e4c
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 186171
+  timestamp: 1678830486301
+- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py38haa95532_0.tar.bz2
+  sha256: d6419f177081f538c07438fd0e30b3fd0550154068846a5a172d7ad0f3da7d29
+  md5: 4a4023e7123dee6dd3de8d5c7ad10208
+  depends:
+  - colorama
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 152529
+  timestamp: 1698130021042
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py38haa95532_0.tar.bz2
+  sha256: 5c028560e4c4269f5778800240a6fc79d4d69989368bf61a1f2cb42447232540
+  md5: 7953616427d956631a8b0f3768f8703c
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40796
+  timestamp: 1683040201265
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py38haa95532_0.tar.bz2
+  sha256: b1c25c1a98c903b27e265b54acbed95f4a9b274c5b6ed13cf6b0f6f6f8b355a6
+  md5: 056a4bcea84a785566fc6d5dee32c8d9
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30328
+  timestamp: 1672387462487
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py38haa95532_0.tar.bz2
+  sha256: 98bff1cae2eb4f5cb3477eac3061c7b53d8dc0338f6c602a12a333151855b14d
+  md5: 00cf4ae9ff27e19cafe87d2381e809b5
+  depends:
+  - pyct >=0.4.4
+  - python >=3.8,<3.9.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1992783
+  timestamp: 1668084685089
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py38haa95532_0.tar.bz2
+  sha256: 6d58d6a7624bb59eda69c1183c3498bc4d3d52e1e130208bd7316a626505c58c
+  md5: 276b81b8348545e07e93ab6c54342670
+  depends:
+  - python >=3.8,<3.9.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13449
+  timestamp: 1671231315969
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py38h59b6b97_0.tar.bz2
+  sha256: 70fde13d90524b164158f9b22303677d6e05ab15a84ffc00bdeafb2e1a584e84
+  md5: fecf6e5becd8b5d19e3b5a1b33e9d915
+  depends:
+  - numpy >=1.16
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184226
+  timestamp: 1663827694272
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py38h3438e0d_0.tar.bz2
+  sha256: 889a3fcf229545b667b65cac80101b8ebe3d65bae0abb2bcc2a28e1338d175cc
+  md5: cfb66cbfa54725a6f15aec83ec95a8c8
+  depends:
+  - cffi >=1.12
+  - openssl >=1.1.1v,<1.1.2a
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1221743
+  timestamp: 1694446236622
+- conda: https://repo.anaconda.com/pkgs/main/win-64/curl-8.4.0-he2ea4bf_0.tar.bz2
+  sha256: 68e1a20c8a7fae2992f8ba32608171cfa077201471afa0177362aeecc72b9bda
+  md5: f4adfca0be77fdf7fcbbf4caf99d20a6
+  depends:
+  - libcurl 8.4.0 h86230a5_0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: curl
+  license_family: MIT
+  size: 153606
+  timestamp: 1697023649068
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.0-py38h2bbff1b_0.tar.bz2
+  sha256: b7572ea611a536f9b94b94c6240ec54642f67210a892ada77e06f01db0e65dd8
+  md5: 32179fcabac5ca600e85429e289415ab
+  depends:
+  - python >=3.8,<3.9.0a0
+  - toolz >=0.10.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 313232
+  timestamp: 1667466210472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py38haa95532_1.tar.bz2
+  sha256: 792842a4d65fa3affa75fbef7b45b35e2d1fdc3a3afb805c60dea0363b473f9f
+  md5: 3afae957ad0d8a21fab2c450d3a5e7f9
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7
+  - python >=3.8,<3.9.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 104651
+  timestamp: 1613390448861
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py38hd77b12b_0.tar.bz2
+  sha256: 2133716ef1744b2292e035a58e2ce7136507df2598a6bbb557f77d41c229e6a6
+  md5: 8d89f8023cd7fb526d42b020dd298dde
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3289647
+  timestamp: 1690907575092
+- conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2021.10.0-py38haa95532_0.tar.bz2
+  sha256: 3f844e1222748cb8b1e3e24a4eeb6cd7277de06e52cec59c533ea2a1e2ea1487
+  md5: ba62ad063fee7cd4e04a6997a1c1c171
+  depends:
+  - click >=6.6
+  - cloudpickle >=1.5.0
+  - colorama
+  - cytoolz >=0.8.2
+  - dask-core 2021.10.0.*
+  - jinja2
+  - msgpack-python >=0.6.0
+  - psutil >=5.0
+  - python >=3.8,<3.9.0a0
+  - pyyaml
+  - setuptools
+  - sortedcontainers !=2.0.0,!=2.0.1
+  - tblib >=1.6.0
+  - toolz >=0.8.2
+  - tornado >=6.0.3
+  - zict >=0.1.3
+  constrains:
+  - openssl !=1.1.1e,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1143116
+  timestamp: 1635968418241
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py38haa95532_0.tar.bz2
+  sha256: e86cd5e70eb1ade76f2e80d9351d377f81b63460b7b0261e0aa9825b7051df83
+  md5: 0ea2c3493ad24b83dfb5919aa6af58e8
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16900
+  timestamp: 1649926672239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/expat-2.5.0-hd77b12b_0.tar.bz2
+  sha256: 700d0aedee50fdcfe4d4c4557e79cd1a7c0f4ed0e4c9300c2b24933b511f4896
+  md5: 5e7da8f3ad8b0c31c45a16b93c83cfd7
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 330697
+  timestamp: 1693497491435
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fiona-1.9.1-py38hf11a4ad_0.tar.bz2
+  sha256: 199d7044dc750989f19f2a5cc6c0061f75376c7c922b2540f49148a983747d21
+  md5: a960ccd9ff6e8ed39b254c27a906bcdc
+  depends:
+  - attrs >=19.2.0
+  - certifi
+  - click >=8.0,<9.dev0
+  - click-plugins >=1.0
+  - cligj >=0.5
+  - gdal
+  - libgdal >=3.6.2,<3.7.0a0
+  - munch >=2.3.2
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  - shapely
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1345487
+  timestamp: 1678226233640
+- conda: https://repo.anaconda.com/pkgs/main/win-64/folium-0.14.0-py38haa95532_0.tar.bz2
+  sha256: c8c5eb7fdc07e86f33b5ce97ac14a3aed086ba046e22c65d7b39820e27c13eac
+  md5: fec37a80141c14d4e14b14534817f020
+  depends:
+  - branca >=0.6.0
+  - jinja2 >=2.9
+  - numpy
+  - python >=3.8,<3.9.0a0
+  - requests
+  license: MIT
+  license_family: MIT
+  size: 114803
+  timestamp: 1675353801633
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fontconfig-2.14.1-h9c4af85_2.tar.bz2
+  sha256: c1f6c98891b25459067503009afb0727528aa6b161638e04e8382b635415e914
+  md5: 552be3449bf89f94a5a023bc242dc02f
+  depends:
+  - expat >=2.4.9,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - libiconv >=1.16,<2.0a0
+  - libxml2 >=2.10.3,<2.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 207322
+  timestamp: 1679578266134
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freexl-1.0.6-h2bbff1b_0.tar.bz2
+  sha256: 9171aec35d7e9732010a911f9e9a596d4fb739d821ce72e1905cd2087e332730
+  md5: af6308117a173c805775dcdb971c0d2d
+  depends:
+  - libiconv >=1.15,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MPL-1.1
+  size: 60210
+  timestamp: 1607116173150
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py38haa95532_0.tar.bz2
+  sha256: d532383b2e3a33e47cb0fbf2c74363edffe0cbbb6de726c6331ba2bcfde24a5b
+  md5: 10b25bc45db15a4da3685293f226697e
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 259923
+  timestamp: 1695734621348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/gdal-3.6.2-py38h9eae49a_1.tar.bz2
+  sha256: 0e1d05edc76006e06dbcc4217029e72ef2b89b649e7c5201f04052f8d7b2cef5
+  md5: 87515d7763a245c60243920737491286
+  depends:
+  - blosc >=1.21.3,<2.0a0
+  - cfitsio >=3.470,<3.471.0a0
+  - expat >=2.4.9,<3.0a0
+  - freexl >=1.0.6,<2.0a0
+  - geos >=3.8.0,<3.8.1.0a0
+  - geotiff >=1.7.0,<1.8.0a0
+  - hdf4 >=4.2.13,<4.2.14.0a0
+  - hdf5 >=1.10.6,<1.10.7.0a0
+  - libgdal 3.6.2 h11d7215_1
+  - libiconv >=1.16,<2.0a0
+  - libxml2 >=2.10.3,<2.11.0a0
+  - numpy >=1.16.6,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - openssl >=1.1.1t,<1.1.2a
+  - python >=3.8,<3.9.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 2426560
+  timestamp: 1680122233809
+- conda: https://repo.anaconda.com/pkgs/main/win-64/geopandas-0.12.2-py38haa95532_0.tar.bz2
+  sha256: 19300d2b9c3aeee1020d8b442189c6356fe48843c15e475322ae3b0a27506177
+  md5: 5f3e66214b00c0a315dbc199055f5731
+  depends:
+  - folium
+  - geopandas-base 0.12.2 py38haa95532_0
+  - mapclassify >=2.4.0
+  - matplotlib-base >=3.2.0
+  - python >=3.8,<3.9.0a0
+  - rtree
+  - xyzservices
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6951
+  timestamp: 1675672406970
+- conda: https://repo.anaconda.com/pkgs/main/win-64/geopandas-base-0.12.2-py38haa95532_0.tar.bz2
+  sha256: 44d03b77a93e648178930b6d5d93e05528bdc5ff1aa27c424f71b924b24dafae
+  md5: 61ec08f4b6dd648838b7c69df27f214c
+  depends:
+  - fiona >=1.8
+  - packaging
+  - pandas >=1.0.0
+  - pyproj >=2.6.1.post1
+  - python >=3.8,<3.9.0a0
+  - shapely >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1250994
+  timestamp: 1675672388143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/geos-3.8.0-h33f27b4_0.tar.bz2
+  sha256: de43096c33bba4f0140d6954d74861f4338b4e610fbdd9b4651302eaacc5db93
+  md5: 46f610ec4be6b8e985048510341c9c42
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1
+  size: 1053138
+  timestamp: 1573216029043
+- conda: https://repo.anaconda.com/pkgs/main/win-64/geotiff-1.7.0-h4545760_1.tar.bz2
+  sha256: a2367b57c0cc49572becda0e87a94ff13c0d380797d61e0b37d8a6ccc43a79b9
+  md5: 4622806fde6033429c7d9121c64e0f6b
+  depends:
+  - jpeg >=9e,<10a
+  - libtiff >=4.1.0,<4.7.0
+  - proj >=6.2.1,<6.2.2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 139759
+  timestamp: 1679997133093
+- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+  sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
+  md5: 9f167d3e45441bc3633c1974b1b0ce8c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 88421
+  timestamp: 1676983264486
+- conda: https://repo.anaconda.com/pkgs/main/win-64/glib-2.69.1-h5dc1a3c_2.tar.bz2
+  sha256: 224fdf140d6d31c14465399021788b01640b60483b2b4cb198d650dd6934baed
+  md5: b49d0b97262be617d9d7e04263a7cbfb
+  depends:
+  - libffi >=3.4,<3.5
+  - libiconv >=1.16,<2.0a0
+  - pcre >=8.45,<9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 1921053
+  timestamp: 1669364571724
+- conda: https://repo.anaconda.com/pkgs/main/win-64/hdf4-4.2.13-h712560f_2.tar.bz2
+  sha256: 8129c8aae5860d9975f3c88c2ef874d0a746a11074f922b6318446cc45f30768
+  md5: b3a727bf1c1df5b021aaf6cc7e81deb2
+  depends:
+  - jpeg >=9b,<10a
+  - vc 14.*
+  - zlib >=1.2.11,<2.0.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 2869081
+  timestamp: 1510864340539
+- conda: https://repo.anaconda.com/pkgs/main/win-64/hdf5-1.10.6-h1756f20_1.tar.bz2
+  sha256: e428782d09e9484af561184f41c562972fe2c36cf1445b4481368e8a47eb3984
+  md5: 56abd458659955a2521069adc6db12bf
+  depends:
+  - icc_rt >=2019.0.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: HDF5
+  license_family: BSD
+  size: 20304975
+  timestamp: 1655188499390
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+  sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
+  md5: 582d2c1135a89da757a038de831e7f39
+  license: Intel proprietary
+  size: 11086648
+  timestamp: 1664812389803
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icu-58.2-ha925a31_3.tar.bz2
+  sha256: e7cb511301ce3788402dce7b700ca44e1f7bc38e498d27b41060a9b48704946d
+  md5: 3b9fbd6eda81ae1b8b580b99d2d928f4
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 22885927
+  timestamp: 1588025937921
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py38haa95532_0.tar.bz2
+  sha256: d54bade7902c52d01edf8b2ffc1bb30e5c81a1d1dc13a17e3a0a68a8c0657367
+  md5: 16d7f359b91058de57d133feac4ea9c6
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 112140
+  timestamp: 1666125760518
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py38haa95532_0.tar.bz2
+  sha256: 26ecfc3b943ad504557a09f74c431146e34701fb480b03c0125b1cd9d01627aa
+  md5: 25109c9d30c8a65bcf24581069793a7a
+  depends:
+  - python >=3.8,<3.9.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38070
+  timestamp: 1678997199756
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py38haa95532_0.tar.bz2
+  sha256: 1a588a5585c3c3c5da6d05c05e172ff6fd80deb8d73c3bae27e551b2410a2dd2
+  md5: 4fdae6815b68f7a397d4be1cb5cc63ba
+  depends:
+  - python >=3.8,<3.9.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51364
+  timestamp: 1698254849400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+  sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
+  md5: 9834848bd7c7759acf12e78d09388563
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3891030
+  timestamp: 1681801474383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py38h9909e9c_0.tar.bz2
+  sha256: d24dcbc647703de21f2ca74334fec6d941acf02c27218af48b399a992efec0d4
+  md5: 0a101e1ec2c76ebab4495f81409823a2
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217167
+  timestamp: 1691121830749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.12.2-py38haa95532_0.tar.bz2
+  sha256: 7b756df85fb011088bf6bb638600c7457cf717dfa5ab69b0a6cf3649b66b1dcb
+  md5: 8b27d8d58e3781bd451cf797e272d5e4
+  depends:
+  - backcall
+  - colorama
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.8,<3.9.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1252304
+  timestamp: 1691532284562
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py38haa95532_1.tar.bz2
+  sha256: 0ed05e1338f7fde869bcf8971fc416064a82d2077be035aa5d0fbadc4cc673fc
+  md5: 7311067dee8f1de4b655c9b714906c2d
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 1038788
+  timestamp: 1644315559456
+- conda: https://repo.anaconda.com/pkgs/main/win-64/joblib-1.2.0-py38haa95532_0.tar.bz2
+  sha256: 09b5a40b2ef9c84c0db5d3b5aba940853d1680b440a562863b5d32d50b02fca0
+  md5: 5ac7f98046a624683f52bd8168ec98ca
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 405576
+  timestamp: 1685113539298
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
+  md5: 81f2c343dc4c65eea39c45383272068f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 407861
+  timestamp: 1677849239400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py38haa95532_0.tar.bz2
+  sha256: fc8f2922ab6f8f32817976f004c994542acccf70872e196e856138842fcbd669
+  md5: 6d0fe84d715d409fc5c5820b431f85c1
+  depends:
+  - attrs >=17.4.0
+  - importlib_resources >=1.4.0
+  - pkgutil-resolve-name >=1.3.10
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 151200
+  timestamp: 1676558871701
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py38haa95532_0.tar.bz2
+  sha256: ea0ae2cfbbbf5a3737e348b40fd6dd7a1b6159525143af959eb1708b201a9577
+  md5: 59112e5bdca43f39c392165f51477c30
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229130
+  timestamp: 1676330586941
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py38haa95532_0.tar.bz2
+  sha256: a7df42fe4a642750c9b202a93f2b7445fe097b3f9cc7a746f33d09760f0ae116
+  md5: dca06cfd9f70dc5fd611ef4082b5638a
+  depends:
+  - platformdirs >=2.5
+  - python >=3.8,<3.9.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116444
+  timestamp: 1679906857031
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py38haa95532_0.tar.bz2
+  sha256: da5dca6540e574387a96ac08a420f02873ce3fa47a7ee329c662075c1c9dbc22
+  md5: b483a973fd9343c2153a2770348a524c
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.8,<3.9.0a0
+  - pywinpty
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 413080
+  timestamp: 1671708067512
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kealib-1.5.0-hde4a422_0.tar.bz2
+  sha256: d5b2a9bfd41e9d1603916395965a6815bea4dd7dbcd64e2788e272de3cb4eaea
+  md5: 41df1bb8fa244907112bfc4b1caac813
+  depends:
+  - hdf5 >=1.10.6,<1.10.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 162295
+  timestamp: 1674215955759
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py38hd77b12b_0.tar.bz2
+  sha256: c287aa13a824a255ab68751645473a4f190590b77160b85d694a2f72e513e551
+  md5: f35f9f31f1f8bd00c5e7fccc81a8edff
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62238
+  timestamp: 1672388388533
+- conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_1.tar.bz2
+  sha256: 1debf041a8f45a1310256364762d5793327b6bc02d8f8953816688329cb4ff58
+  md5: 3cbe6c7e0aab01fea30638d752d42058
+  depends:
+  - openssl <1.1.2a
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 847845
+  timestamp: 1686932219054
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+  sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
+  md5: f5f73266281ab12377d5d47bdf07500a
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 905072
+  timestamp: 1617648814933
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+  sha256: 4184dd040fc38cb123a98588a8344aa8d1ba1932df5fcc6c188f6b21f5a0c306
+  md5: da58cfa83f3d6c31ae12d8777cd1b64d
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 29803292
+  timestamp: 1696764164248
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
+  md5: c345f51706eef530454f66b794e5e574
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 68189
+  timestamp: 1659616216976
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
+  md5: a7400cfb72042977bc047909ed504ce8
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 33743
+  timestamp: 1659616248209
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
+  md5: 6307f6854754ab5bd7c84e6998385bb1
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 733177
+  timestamp: 1659616279453
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.4.0-h86230a5_0.tar.bz2
+  sha256: 391fed09fc96fd343eb34f36fa57fc9163c241528fade6cd93c54e098d3bb472
+  md5: 5d93324d94f715944695a2135546617c
+  depends:
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl <1.1.2a
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 335562
+  timestamp: 1697023614098
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_0.tar.bz2
+  sha256: 1b3b9be41dba504e468a336196de9fd09568ba42585e493888aaa3708f687d0a
+  md5: 5cdcd99f18d9dedb772d272088e72b4c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 116942
+  timestamp: 1683716620230
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libgdal-3.6.2-h11d7215_1.tar.bz2
+  sha256: 0fdb6521e98d0f95c7983a09c9c292bc8ffa88b9f0fc9c0fe34c6579dd6825a0
+  md5: 7da0d24a0f3b04b079e5abdf5f509f14
+  depends:
+  - blosc >=1.21.3,<2.0a0
+  - cfitsio >=3.470,<3.471.0a0
+  - expat >=2.4.9,<3.0a0
+  - freexl >=1.0.6,<2.0a0
+  - geos >=3.8.0,<3.8.1.0a0
+  - geotiff >=1.7.0,<1.8.0a0
+  - hdf4 >=4.2.13,<4.2.14.0a0
+  - hdf5 >=1.10.6,<1.10.7.0a0
+  - icu >=58.2,<59.0a0
+  - jpeg >=9e,<10a
+  - kealib >=1.5.0,<1.6.0a0
+  - lerc >=3.0,<4.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libiconv >=1.16,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libnetcdf >=4.8.1,<5.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=12.9,<13.0a0
+  - libspatialite >=4.3.0a,<4.4.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base
+  - libxml2 >=2.10.3,<2.11.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - openssl >=1.1.1t,<1.1.2a
+  - pcre2 >=10.37,<10.38.0a0
+  - poppler <=22.12.0
+  - postgresql
+  - proj >=6.2.1,<6.2.2.0a0
+  - qhull
+  - sqlite >=3.41.1,<4.0a0
+  - tiledb >=2.3.3,<2.4.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - xerces-c >=3.2.4,<3.3.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 9796897
+  timestamp: 1680121634867
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+  sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
+  md5: b812bc5d9c76242e2bb2ac87afe7d39b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 730280
+  timestamp: 1650983734373
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libkml-1.3.0-h63940dd_7.tar.bz2
+  sha256: d202eef643f39fbe4b24ff4240052d2b58d67a4ba5fcbd80d09106191b85bff6
+  md5: 6f63fe185daebe8da8c6b3dc941ad7b0
+  depends:
+  - expat >=2.4.9,<3.0a0
+  - uriparser >=0.9.7,<1.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3074807
+  timestamp: 1693262074974
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libnetcdf-4.8.1-h6685c40_2.tar.bz2
+  sha256: d9a7edba417fce7865f98e9d2f6912d5aafce884ae78a868da275e726647dec1
+  md5: 49ad63d5f22949042f21ce145ebd6c21
+  depends:
+  - curl
+  - hdf4 >=4.2.13,<4.2.14.0a0
+  - hdf5 >=1.10.6,<1.10.7.0a0
+  - libcurl >=7.87.0,<9.0a0
+  - libzip
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 704268
+  timestamp: 1674628735708
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.15-hb652d5d_1.tar.bz2
+  sha256: 916d1428d6315fb1c4e3f70e56407ef96e1115610ffab4b82b302a002856c4e2
+  md5: c0f92eda4de2df406dc6b5fc42d3e9b7
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - openssl >=1.1.1u,<1.1.2a
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  size: 3827913
+  timestamp: 1687382952596
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libspatialindex-1.9.3-h6c2663c_0.tar.bz2
+  sha256: e3527de4b50ae741004bf5ddfd6c5c4fe4d778ffea475f858d2b29e76ced9796
+  md5: 91aa29bbc065cd3b53c7410ab683c9dd
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 455875
+  timestamp: 1616086916558
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libspatialite-4.3.0a-h6ec8781_23.tar.bz2
+  sha256: d0b2f30939b32e7c0066980e3b8e1706a179964a5185fa4e58b83dc88dae838a
+  md5: 5d8cb7e60e307faec0c647b3ea1bbf3c
+  depends:
+  - freexl >=1.0.6,<2.0a0
+  - geos >=3.8.0,<3.8.1.0a0
+  - libiconv >=1.16,<2.0a0
+  - libxml2 >=2.10,<2.11.0a0
+  - libxml2 >=2.10.3,<2.11.0a0
+  - proj >=6.2.1,<6.2.2.0a0
+  - sqlite >=3.41.1,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 4158299
+  timestamp: 1680110288508
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-hcd4344a_2.tar.bz2
+  sha256: 0b1460332f394557429f75c871c89ad27fc2ddadbeb28bfcff8d1d8537f493ac
+  md5: 38e889ec253fe997be7f94556a0855d4
+  depends:
+  - openssl >=1.1.1u,<1.1.2a
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 230554
+  timestamp: 1686932558863
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+  sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
+  md5: ba9418df9288a2f031a02fa35b774ce0
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78524
+  timestamp: 1694778314659
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+  sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
+  md5: 6ece7f1a3248169837714d05d7f6ef0a
+  depends:
+  - libiconv >=1.16,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 3513910
+  timestamp: 1692971505729
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libzip-1.8.0-h49b8836_0.tar.bz2
+  sha256: 0b4c8aa6e1fc2b82ce0b77c02e0e418764f94c3ea0bb18bea45a3cd265e3456f
+  md5: a51d3646b5ae61f0b7f40b55650932be
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - openssl >=1.1.1o,<1.1.2a
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102924
+  timestamp: 1652977143101
+- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.37.0-py38h23ce68f_2.tar.bz2
+  sha256: fba3b632cf668b5bd075ab9b51a36c525bf56a7bf8f89daf5d751a1be91d5fce
+  md5: b60c389cfd24d07e6fec628377f228d3
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: BSD-2-Clause
+  size: 17077766
+  timestamp: 1646168931623
+- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py38haa95532_0.tar.bz2
+  sha256: badc76eab56488df2cba6ac632fcf24223c4967628fe7bc061d8e2c0cd5aa362
+  md5: 201617fddcaf95a08884560594e8d496
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 12848
+  timestamp: 1652904166019
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+  sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
+  md5: 6970c7f46b0164cad1d210e7a1419959
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143434
+  timestamp: 1670944902624
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mapclassify-2.5.0-py38haa95532_0.tar.bz2
+  sha256: 7098b87a0e8aebfbb541e2b522336ca50f8d1813ef24299675c692e58e627598
+  md5: 62a504db888e934901882fcb3057fe14
+  depends:
+  - networkx
+  - numpy >=1.3
+  - pandas >=1.0
+  - python >=3.8,<3.9.0a0
+  - scikit-learn
+  - scipy >=1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 66964
+  timestamp: 1675157980619
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py38haa95532_0.tar.bz2
+  sha256: 5e648ae3ef2e9d544accfd1cb16ee5081eb69fad94fc3dadd10c55244cddbfbb
+  md5: bd2cc8c49b69abde1d55e6f2a1e636a2
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142697
+  timestamp: 1671542078827
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.0.1-py38h2bbff1b_0.tar.bz2
+  sha256: 823854ff0e034eab1b283d26d106848cd18b1f6343ac6286ac3208ca55263c5c
+  md5: 437ca9e6eaaac0b79b5bf95ca548ba84
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25638
+  timestamp: 1621528394552
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.7.1-py38hf11a4ad_1.tar.bz2
+  sha256: c065a29f28f81852178da631b01569ae95ca5880d71c6010f3a733693c60502f
+  md5: 63e015949790fd18e5841c5a41f1395f
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=5.2.0
+  - kiwisolver >=1.0.1
+  - numpy >=1.16.6,<2.0a0
+  - numpy >=1.20
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7916424
+  timestamp: 1679594157296
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py38haa95532_0.tar.bz2
+  sha256: 2a832b73527801756ce9c8e7a2e9d2f0aa7b0e39e764cb1699c45dc9db00d67b
+  md5: dcede4303efc5efc488deed47d24f03a
+  depends:
+  - python >=3.8,<3.9.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17983
+  timestamp: 1661934096957
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py38he774522_1000.tar.bz2
+  sha256: 598c0f203150ac3fbb846a7ac20739720e2a5c2905a838a8a5c5c28016c5ff0d
+  md5: 3eba69328760ac88d22f975ef8a21ffc
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 55782
+  timestamp: 1573488915385
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+  sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
+  md5: 5e763c995ff0c549f68a10bce70fede4
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187489950
+  timestamp: 1691503804820
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py38h2bbff1b_1.tar.bz2
+  sha256: 1377f4b52bc0f0059fc384cc0eb2451d8b9db27eb85587e27d93eb1061a1ca9b
+  md5: 3389c1f1869f6b1e894390155f8fbbf7
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49712
+  timestamp: 1682974986419
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py38h2bbff1b_0.tar.bz2
+  sha256: 8b57b0ddc34eeaabdf91274eab9ac758ebebb6436f3f43a7459139271ee2d0a0
+  md5: 4c623b331a7301525e92a02b0490a616
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 185379
+  timestamp: 1695058741315
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py38h59b6b97_0.tar.bz2
+  sha256: ac93a9e5da11442058b30e89bb24447d311f067a5a98c36c85c7de9f420f25e1
+  md5: 048f410489ce4250a215211619ee512e
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 258368
+  timestamp: 1695060288659
+- conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py38h59b6b97_0.tar.bz2
+  sha256: dd4f2c677361273de293da946ae55d811590bbadc4a1da75fe77204694821b86
+  md5: 22a646f00d2aa14becfb7594dc1efde5
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 82740
+  timestamp: 1652329410469
+- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py38_0.tar.bz2
+  sha256: f88f8146f2efe5744d2c8c03bc8c7275693b57fbad85212369cc742d81bd37bf
+  md5: d16e6b7628a2b9eab9a5d30e4bed09fe
+  depends:
+  - python >=3.8,<3.9.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 23139
+  timestamp: 1573470511265
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py38haa95532_0.tar.bz2
+  sha256: fcbce71d792cd2b5159b9b99c2ef3a6e016e0849c748f6d03e210eb1211c2f22
+  md5: d4017e1c56ecbc61f338627609766654
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8136600
+  timestamp: 1681757180070
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py38haa95532_0.tar.bz2
+  sha256: 47472930a12c665040fe0f788513e4c02ee261b0a3a2f8ecbeea64339efa6462
+  md5: 56e16967a9119349ba7e5faa1998db96
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.8,<3.9.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 118191
+  timestamp: 1650290459535
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.4.4-py38haa95532_0.tar.bz2
+  sha256: 25d7081cd52160451d6bd6990a358166f6d4dbcd547f6e37bf052f527b65998e
+  md5: d81e870a5f4f7074d936b1972e74cd98
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=2.4
+  - jupyter_core
+  - jupyterlab_pygments
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0,<0.6.0
+  - nbformat >=4.4
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.8,<3.9.0a0
+  - testpath
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 595183
+  timestamp: 1649741085987
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py38haa95532_0.tar.bz2
+  sha256: ff232852ab31227eb44dc6979033beda77b30575e4a2a83e67be156412b04761
+  md5: dbf1de3d5b7add1831c3177e873bdbff
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.8,<3.9.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 166793
+  timestamp: 1694617317115
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py38haa95532_0.tar.bz2
+  sha256: 71cc4e07a33737c33bb876f480c0d792151d5cfeeb4e013575deed361ae056af
+  md5: 96a76accee4fdda338e71972f498451e
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13604
+  timestamp: 1672387428069
+- conda: https://repo.anaconda.com/pkgs/main/win-64/netcdf4-1.6.2-py38hda396d2_0.tar.bz2
+  sha256: 8ce85bf1a5722fc4de42b1dfd806826704f18f51b9c7e1401fc97195c96b18bb
+  md5: c9d67b4d0f8dfe81889c7edbf0f5024e
+  depends:
+  - cftime
+  - hdf5
+  - libnetcdf >=4.8,<4.9.0a0
+  - libnetcdf >=4.8.1,<5.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 384517
+  timestamp: 1673455579546
+- conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.1-py38haa95532_0.tar.bz2
+  sha256: 58d6a41a7dc757e0ec4b5cb0e3a93424f0510ea774c0ae7c452be53cd85907c6
+  md5: 3024f1424c64f44a3137022e89b584d2
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2939681
+  timestamp: 1690562319019
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py38haa95532_1.tar.bz2
+  sha256: fcdb8b81e4c22e86c52833e5d389585c256991b3e295f0876d2f1771f069771d
+  md5: b1819adf1ca6a6ce01733d80218cc34e
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 607570
+  timestamp: 1690985910096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py38haa95532_0.tar.bz2
+  sha256: e994d3c43d5bba7258fe31eb384dfa07e67c0cf71317730fc04490234ad6706a
+  md5: 856ca9314f23c4e5e97f00982197c1ce
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22446
+  timestamp: 1668160865802
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.54.1-py38hf11a4ad_0.tar.bz2
+  sha256: dd51b1d7adf281d8a703c4ae8dadec5c85c08bacc3450ea87cff444c4c660ee6
+  md5: c33911946122eab4ac2b17c226513973
+  depends:
+  - llvmlite >=0.37.0,<0.38.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  - tbb >=2021.4.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - numpy >=1.17,<1.21.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3903613
+  timestamp: 1635186300704
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.4-py38h7b80656_1.tar.bz2
+  sha256: 53088668bec0e25ce85dbb3aae9bf29b1fc90e2542360f5221e02acddf05cabc
+  md5: 990126d16909922f9617be3081ec5d58
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 131075
+  timestamp: 1683222215685
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.20.3-py38h749eb61_1.tar.bz2
+  sha256: 0aef06bc7fee8b249b34acb25c1301beeb42df4895b8381f4b20f05c9df99fb9
+  md5: bcf3de738b91fc8da6c3f8597b90bee8
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.20.3 py38h5bfbeaa_1
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 3-Clause
+  size: 9869
+  timestamp: 1682979878313
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.20.3-py38h5bfbeaa_1.tar.bz2
+  sha256: 4f0f5bd9ad2786806a96813f0e1c8f1be9173052dfcc81b212660a75733cd0f2
+  md5: 390712b9c9036c4284ac2ba5838f20d7
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - numpy 1.20.3 py38h749eb61_1
+  license: BSD 3-Clause
+  size: 5545046
+  timestamp: 1682979860287
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
+  md5: ab07e2a27ac08afe3d0b4c0890b8486a
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 2-Clause
+  size: 249316
+  timestamp: 1630094024143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
+  sha256: 0474e14823c734edc088bef98b829149a47ed8b4654f9638926c2fe4bbc40f38
+  md5: a67d4a763641de641ea9dfa8c4a5f567
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: OpenSSL
+  license_family: Apache
+  size: 6048217
+  timestamp: 1694466133007
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py38haa95532_0.tar.bz2
+  sha256: d962a58032a618fbca7c201c54997e7802b60513c4d661b87377adb1ab46cb6f
+  md5: c1c21c251676c124b761ae7a7a788051
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 72936
+  timestamp: 1693575419691
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-1.3.5-py38h6214cd6_0.tar.bz2
+  sha256: 044cf746c1c820278d783dcfe6caf04d505be2608c6417b2fc158192baf4e2a9
+  md5: 97ec40ac994c23be8948576a17ba3a1d
+  depends:
+  - bottleneck >=1.2.1
+  - numexpr >=2.7.0
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.7.3
+  - pytz >=2017.3
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11702008
+  timestamp: 1641443603564
+- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.0-py38haa95532_0.tar.bz2
+  sha256: 2fae146a4f47684169b2298631f57907b0a5cb5bb394b6bfc2fba481e3180c1a
+  md5: 663c3cd2871f89973a8a157f9168412f
+  depends:
+  - locket
+  - python >=3.8,<3.9.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35211
+  timestamp: 1693938085776
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pcre-8.45-hd77b12b_0.tar.bz2
+  sha256: ac2cd0e402baa915540cb15f57cf631a5af0cfe9036e6028add041c703a15320
+  md5: 67c3599c838a8433fcfa8b7c034e8f20
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 507009
+  timestamp: 1624478466152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pcre2-10.37-h0ff8eda_1.tar.bz2
+  sha256: 9090e0360b59ce9ac59fa3f280fbc3cdc1821512f44cfa81fc1dd088c1869ddb
+  md5: 1f4f9e2b96b1b1eb957b385de97c1d29
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 636679
+  timestamp: 1641404048934
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py38h045eedc_0.tar.bz2
+  sha256: 432e6a6b53fa484a8bf5b3e898f5ed8caba5815b553d94db77620eac98d2f099
+  md5: a6e9aa6452576aa3e697bdd3a6071b71
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.8,<3.9.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 806349
+  timestamp: 1696580503229
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py38haa95532_0.tar.bz2
+  sha256: 6f59998aee706ab1de04d3f9ac2e4c859d379cde2913fc38ae4dc0d2e9b21238
+  md5: 8f3809e14a26a9efa61c331a17653f3e
+  depends:
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2999532
+  timestamp: 1697548952949
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pixman-0.40.0-h2bbff1b_1.tar.bz2
+  sha256: 20923fa2937cde57e8d2f5d67391b37eef349a9e3f5ff589bc75fb3dd3e0074f
+  md5: c62f32977c25875ced94e930d942db6b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 497111
+  timestamp: 1632711499953
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pkgutil-resolve-name-1.3.10-py38haa95532_0.tar.bz2
+  sha256: 63162f67b25860cac18a2c5e1701d0d39bb8db2b42f49a0f591c811181acea83
+  md5: 33eee18c2582142bcf2fd33275134022
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT AND PSF-2.0
+  license_family: PSF
+  size: 10410
+  timestamp: 1661463539879
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py38haa95532_0.tar.bz2
+  sha256: d9bdf22a0141d5d3e4e1455a93ecd6680980786b5fcd5516773217403057d389
+  md5: 10961e0b088c531ddeafb3c4c278b8b5
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 32378
+  timestamp: 1692205706184
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pooch-1.7.0-py38haa95532_0.tar.bz2
+  sha256: 269095712af2adf8aa3a1b5532596b7b19b3222d3b062f5af466ee5b423b854f
+  md5: 6f17c938b517964b61675589037c6e36
+  depends:
+  - packaging >=20.0
+  - platformdirs >=2.5.0
+  - python >=3.8,<3.9.0a0
+  - requests >=2.19.0
+  constrains:
+  - paramiko >=2.7.0
+  - xxhash >=1.4.3
+  - tqdm >=4.41.0,<5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 81717
+  timestamp: 1695850480881
+- conda: https://repo.anaconda.com/pkgs/main/win-64/poppler-22.12.0-h0bf3bde_3.tar.bz2
+  sha256: 03fa4c3b0fc491cfc4736272a8a07b111255aee8029359ecc315e3253b20b977
+  md5: deecd5672f83b496fddc7d797c491626
+  depends:
+  - boost-cpp >=1.73.0,<2.0a0
+  - cairo >=1.16.0,<2.0a0
+  - fontconfig >=2.14.1,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - glib >=2.69.1,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libiconv >=1.16,<2.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - openjpeg >=2.3.0,<3.0a0
+  - poppler-data
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 2826813
+  timestamp: 1696001451072
+- conda: https://repo.anaconda.com/pkgs/main/win-64/poppler-data-0.4.11-haa95532_1.tar.bz2
+  sha256: 48c7975e4777318317369fe480f75531534cb8933a3e4de97cddf778a12f96dd
+  md5: fc41b46e1055778a44677d2e0e97fe32
+  license: GPL-2.0-or-later and GPL-3.0-or-later and BSD-3-Clause
+  license_family: GPL
+  size: 478379
+  timestamp: 1673863618032
+- conda: https://repo.anaconda.com/pkgs/main/win-64/postgresql-12.15-hb652d5d_1.tar.bz2
+  sha256: c5652e73142e3d90eb8d4ec7260febc0648e7ad9b7b4e0118300a4861160c1f1
+  md5: 33c283fe8c4a9244729117e47a988bb2
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libpq 12.15 hb652d5d_1
+  - openssl >=1.1.1u,<1.1.2a
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  size: 21968437
+  timestamp: 1687383026031
+- conda: https://repo.anaconda.com/pkgs/main/win-64/proj-6.2.1-h3758d61_0.tar.bz2
+  sha256: 9cb0179c1caa52c3d7f72de80b961242efc92be8bd400b31143ebfc331f06bf6
+  md5: f96fc9eec2355b3f566da8482185e4c0
+  depends:
+  - sqlite >=3.37.0,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  size: 8844536
+  timestamp: 1643034508527
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py38haa95532_0.tar.bz2
+  sha256: 62980fe41fb61641ff3a92bc46769c221e216d7b1b052624cca35cd6442e67a3
+  md5: ceb8f341d88581897417b74581824ce5
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 90902
+  timestamp: 1659455380536
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py38haa95532_0.tar.bz2
+  sha256: 4b8a2b4c9060ee4c2870cd677e04020af7a7e6bd20201d548937246bd445f047
+  md5: ba6637b69b09fac0ae052441137ef3f4
+  depends:
+  - python >=3.8,<3.9.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580833
+  timestamp: 1672388085790
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py38h2bbff1b_0.tar.bz2
+  sha256: 3f30894e9e48919717e4836d41d37fe94067c41f2714982d5b09041e8d03c625
+  md5: 715eca27ac0ea2d6e5b9781ece861045
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372631
+  timestamp: 1656431598029
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py38haa95532_0.tar.bz2
+  sha256: b6cd1020f33142369e4e5e3011fc52b761067feae88ef2faed1dd38921eea160
+  md5: 89f633e2fe32f8964414004f4bf69a50
+  depends:
+  - param >=1.7.0
+  - python >=3.8,<3.9.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48367
+  timestamp: 1675450405375
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py38haa95532_1.tar.bz2
+  sha256: c99df0ff588b6cc027003901719fafcca53c7d5982224d10adafb0eba5d62f76
+  md5: ea6a5a355c3e39e2d5e03418cf1c359f
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1902776
+  timestamp: 1684280088005
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py38haa95532_0.tar.bz2
+  sha256: e3d8188a43ecb46e09895049962c12e4812973a8b5cc9bf40536bf30d94114e1
+  md5: 30b5451442b0e7fbaa8c2e32b10a7a87
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95013
+  timestamp: 1690225579051
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py38haa95532_0.tar.bz2
+  sha256: 0338ad6cc3998c5adc325f9df5916a84d9462176c060160b15bf016cd78df4c6
+  md5: 7ac4db0e1a670a061b08208f6e819bb0
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 157552
+  timestamp: 1661452635483
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyproj-2.6.1.post1-py38h593ac45_1.tar.bz2
+  sha256: d5a483b023eaa9f6134c0893684b7d97684c4ef5a9a1956a97989d6b5325d25c
+  md5: 0910fdf2951d77e03ae259e6cf40e07f
+  depends:
+  - proj >=6.2.1,<6.2.2.0a0
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 382998
+  timestamp: 1614278213539
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py38h196d8e1_0.tar.bz2
+  sha256: 839fdd83dbde870e40fd61d0157c9d3b58bbbe54b48dfb92004ed7878e8e0f52
+  md5: f659bb4f74cbf970f9afb502cc9b399d
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 92785
+  timestamp: 1636111597883
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py38haa95532_0.tar.bz2
+  sha256: 9bf258afe075dd22aa6e33b71b122126eaeb1001906b5df614b2e81e88e17ddf
+  md5: ca4e90d9e382f0033230a67499d51239
+  depends:
+  - python >=3.8,<3.9.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31587
+  timestamp: 1605287884076
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.8.18-h6244533_0.tar.bz2
+  sha256: 91fe00fa9abb019a70c68be5a39887972a77473805abf160be8274ec3e8f5ea8
+  md5: f4f6d4b6bb55b19eda46f2fc79288f10
+  depends:
+  - libffi >=3.4,<3.5
+  - openssl >=1.1.1v,<1.1.2a
+  - sqlite >=3.41.2,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 22819210
+  timestamp: 1694440319269
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py38haa95532_0.tar.bz2
+  sha256: c3414f6a87ec84473869ac5821a62369f374b1df33def55a6d6487fd863ad56d
+  md5: 7d51837a0deed7e1f8a410a2851ac755
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269239
+  timestamp: 1661376763966
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py38hd77b12b_0.tar.bz2
+  sha256: cd4788fdafa155d2bb3b7159cc4f031370c9caab7b006b6afab11881f7fa9d3c
+  md5: 83b3e3d6f925636bb2a0be77ae8b9d5c
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 135460
+  timestamp: 1682522629966
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py38haa95532_0.tar.bz2
+  sha256: 5769ae7494f0298428d44e545fa4e29064c13cd546c3ffcd9324968c04c47862
+  md5: 5b6b41bf0ff90b3e49ca04db5200707d
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 266165
+  timestamp: 1695132007791
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py38haa95532_0.tar.bz2
+  sha256: 5a516966dfa1bcd8df4413bb885f1f9ad30e2bdd49281bf825048b4ac51d6e8a
+  md5: afa17e8c3e04681729286239700c293e
+  depends:
+  - param
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40311
+  timestamp: 1685030879273
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py38h2bbff1b_0.tar.bz2
+  sha256: d240e28ed9a4811cfc05231c91bf802759fcf62b3e7f204301033c957a6fd4fe
+  md5: 5ed775395d75942dce0868bfcabeb62f
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13563755
+  timestamp: 1669938230510
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py38h5da7b33_0.tar.bz2
+  sha256: 0837ed20156196759f729786bf50d71f17d04259e4eba815015567879659ea54
+  md5: e7ba4d7e36f0992af849c36116e4a6e9
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 239545
+  timestamp: 1677611005756
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py38h2bbff1b_0.tar.bz2
+  sha256: aa56d1d94abca5574bb8ec93c7438e9ba2262900342bb0b8de214526a211963e
+  md5: 4af07057db56d4b735e45106276d148c
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 158294
+  timestamp: 1698096182750
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py38hd77b12b_0.tar.bz2
+  sha256: a9f77cc518cab258a8e0666ca7c6b5ee3c9a03908c764ed6383ea8af3d21da20
+  md5: 84ed5b56ff20c3c08be5891e15b2ec20
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.4,<4.3.5.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 478983
+  timestamp: 1657616120754
+- conda: https://repo.anaconda.com/pkgs/main/win-64/qhull-2020.2-h59b6b97_2.tar.bz2
+  sha256: 5d677c17afe37f24eb30f143fccf45450d81929227869256a277a66dd9a36325
+  md5: 09ec672a48cc028863ef171fc8c5d418
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Qhull
+  license_family: Other
+  size: 2338798
+  timestamp: 1670915907181
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py38haa95532_0.tar.bz2
+  sha256: 533172b07694e5f3bc8934fb77dded69c58be5b39831e28db73c0c0fcb4dedd8
+  md5: 6a9975521209c95da6f71f4e1c3de96c
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.8,<3.9.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94333
+  timestamp: 1690400706451
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rtree-1.0.1-py38h2eaa2aa_0.tar.bz2
+  sha256: 9a6e7b73f09902586fb55249901373880e090c6932df63ca88b56ce1d3737d9b
+  md5: 0f3ddae4fa0f4d289f5de6eaf54286ed
+  depends:
+  - libspatialindex >=1.8.5
+  - libspatialindex >=1.9.3,<1.9.4.0a0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 49908
+  timestamp: 1675158069235
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scikit-learn-1.2.2-py38hd77b12b_0.tar.bz2
+  sha256: bde25890660eeddea42854cf9c234c38129a7fb39b511827d48e3a199c82f555
+  md5: 196ae5b5c42127b278a8141fa417958a
+  depends:
+  - joblib >=1.1.1
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - scipy >=1.3.2
+  - threadpoolctl >=2.0.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8133812
+  timestamp: 1680205309832
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.10.1-py38hdcfc7df_1.tar.bz2
+  sha256: bf0f58b61e8e18aa58f5bdf025e8ee649c778b8be27c5f5ddff495add793ad93
+  md5: 09fa3db77bb4c0e9d4349268215dd515
+  depends:
+  - blas 1.0 mkl
+  - icc_rt >=2022.1.0
+  - intel-openmp >=2023.1.0,<2024.0a0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.19.5,<1.27.0
+  - pooch
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22338144
+  timestamp: 1683289522517
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py38haa95532_0.tar.bz2
+  sha256: 9d9cea2d4a0c0bb8753b2749cb1abbc3d893eab2cb0bcf17405f5e01856e3e0c
+  md5: ddd72dc387cefe69ec31c93c43f6958d
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 1099170
+  timestamp: 1690291042913
+- conda: https://repo.anaconda.com/pkgs/main/win-64/shapely-2.0.1-py38hd7f5953_0.tar.bz2
+  sha256: fd756d3e5489f5140f6bb2cab97534b2e32ce1c49fb100ee3e948a1c76b237c6
+  md5: d9a5aa3e5281cf9cfb5b92fca79c31fa
+  depends:
+  - geos >=3.8.0,<3.8.1.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 433564
+  timestamp: 1680636417778
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py38haa95532_1.tar.bz2
+  sha256: 23df5da4b5c41e12f2bf8181d2de18b30f9ceb2453ec669f4c9fe182380d5099
+  md5: cb8e70978aba600c5092aa202d960f2a
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15975
+  timestamp: 1614030758438
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py38haa95532_0.tar.bz2
+  sha256: 3a2bdd00f7f0fa19d73a8875e9f004cae98d3fa27f36c59cd4567f3282944e11
+  md5: ccdd22fbfe632c7ffea52096483b2165
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 67208
+  timestamp: 1696347669660
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+  sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
+  md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1311308
+  timestamp: 1681402905668
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py38haa95532_0.tar.bz2
+  sha256: d14d51a32e509950bb85e78c35dceed18cbeb223ec3e9e224e0d22d65e3461ae
+  md5: 85fd7e0f17c59be2e562bebb896aa5a5
+  depends:
+  - python >=3.8,<3.9.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30613
+  timestamp: 1671751910139
+- conda: https://repo.anaconda.com/pkgs/main/win-64/testpath-0.6.0-py38haa95532_0.tar.bz2
+  sha256: 02df5aa5e16fa80d9bdc98607d418cc29f0f30616576ab01245db51d541232a6
+  md5: c65c64ca1fb63d1cd355593a786c463e
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94054
+  timestamp: 1655908671820
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tiledb-2.3.3-h3649cd2_2.tar.bz2
+  sha256: ab11ec98f8198a47fde327726815112f717964039bec03b2090b1c52cf1dbd87
+  md5: 6dd0fc1e3f661e96ed6f45f05ec91686
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 2568834
+  timestamp: 1655305467392
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+  sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
+  md5: 52cdcdb96383c010ca833a7c24b3935b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Tcl/Tk
+  license_family: BSD
+  size: 3690152
+  timestamp: 1654036853710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py38haa95532_0.tar.bz2
+  sha256: 8d7efb76d1afa3e7e4491e8496f46257bbee2eaf233549ca841f1bcbe4194489
+  md5: e085f8c809e8c4296756e411b7ffa598
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102335
+  timestamp: 1667464250061
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py38h2bbff1b_0.tar.bz2
+  sha256: f6813a60d8e7c33594685c273ffe5aa21150c4d012b639eea8fb3d87348849c0
+  md5: 45f4b3e1d6c27dcaccc3f9e979cc6db3
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680736
+  timestamp: 1696937110611
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py38hd4e2768_0.tar.bz2
+  sha256: f375977bd3677a51b5a0d1364ff22da9fba5b53999dd425423971c7aa940fffb
+  md5: b1fe53809d11bf264402a8253ddd9145
+  depends:
+  - colorama
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 143474
+  timestamp: 1679562394410
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py38haa95532_0.tar.bz2
+  sha256: 9b45e11b7720e697c2a0b51046f460007a2b806a38f6dd3d04114cd5232dc714
+  md5: a4cdc25c1dcbae810913de1be3828d08
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192543
+  timestamp: 1671143951537
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py38haa95532_0.tar.bz2
+  sha256: c534e38eba3f4be51c2a008881713e6805b40f14a9187fbc33bcd8f2c32b3175
+  md5: 0223b0eb7c46d88613a7be653bd868e3
+  depends:
+  - python >=3.8,<3.9.0a0
+  - typing_extensions 4.7.1 py38haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9209
+  timestamp: 1690297886768
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py38haa95532_0.tar.bz2
+  sha256: 6a12cdeb628f07650a6b35dcc69bbee9c16e8143a21117939f98524700ea8522
+  md5: 640032b60ddb37f74bbf62e81e8d38e7
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58090
+  timestamp: 1690297874460
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uriparser-0.9.7-h2bbff1b_0.tar.bz2
+  sha256: f88e04209064e9a72fccc9284271405d9548106c2bf302e24fa1e8e8bb36a127
+  md5: 8845191f3242c429e10220e3ed9ee73c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48486
+  timestamp: 1692187056029
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py38haa95532_0.tar.bz2
+  sha256: f864ed1dfb0e99339810a81b31b82e907791921cc2cc63ad0d24de214d4b96c2
+  md5: 0f1d33693bc8a20a8a07db135c465524
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 188202
+  timestamp: 1698257739300
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+  sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
+  md5: 45ef24c486a484f079faf1dc90e4c7e9
+  depends:
+  - vs2015_runtime >=14.27.29016
+  license: Modified BSD License (3-clause)
+  license_family: BSD
+  size: 8277
+  timestamp: 1605602889180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+  sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
+  md5: 4daaceb6cfc1af6274509081d8018ef1
+  size: 2316783
+  timestamp: 1605602872095
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py38_1.tar.bz2
+  sha256: 40b0596a8728dd040d7afef235a73b20909f92fbe9a9ef202f3e5256d047bbdc
+  md5: 492eeefe2b9f3274156a1b37699ea90e
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20563
+  timestamp: 1573199884688
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py38haa95532_4.tar.bz2
+  sha256: 1f63ed0a34f6f82b24aacdb58981d706637148ec7809fed682c5be1c7f140aeb
+  md5: 69b1c046853ea5dbb22891d693edba80
+  depends:
+  - python >=3.8,<3.9.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73415
+  timestamp: 1614804523375
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py38haa95532_0.tar.bz2
+  sha256: c7ab632355c3342435277a8a4bef6d659c703c9ce30e12a47adf80d7af2d6e7c
+  md5: 72735ff308add1052ff64b94c6130810
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 120710
+  timestamp: 1695742221226
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py38haa95532_0.tar.bz2
+  sha256: e07f40fc2c8751784dba016e68ef289ae997bf018a773e71d83b23e1e30a55f3
+  md5: 749ad2e1134684ca10f25aa30a35864b
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: PUBLIC-DOMAIN
+  size: 34107
+  timestamp: 1605306214957
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2022.11.0-py38haa95532_0.tar.bz2
+  sha256: bbd799a929cfc29f95c6fc46c08d1939c87edc8fa0e96ba89ce44ce65f95479e
+  md5: 4fcbc4128904506d54b173b01c6f7659
+  depends:
+  - numpy >=1.20
+  - packaging >=21.0
+  - pandas >=1.3
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1727670
+  timestamp: 1668777347091
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xerces-c-3.2.4-hd77b12b_1.tar.bz2
+  sha256: 2160b68a45de4b20ce5e63ba06a0db91913e325e5b796ef9f40d38bd2bb8260d
+  md5: a6d582169295a9de869f242530796475
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4221569
+  timestamp: 1692995399482
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py38haa95532_1.tar.bz2
+  sha256: 79a0c08ff87f51a742b9a0cb668482035a5b8b94bb9a651cd0242da916a23125
+  md5: a8b49e46e8f6ccb6fc3e2e17a41764a6
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48792
+  timestamp: 1675159225274
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+  sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
+  md5: c3f7871e9a33adeccee1b1e8e216918e
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 1332571
+  timestamp: 1683113347814
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+  sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
+  md5: 1ab55f8c4b5292ec360c572120bf823e
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-3.0-or-later
+  size: 9430705
+  timestamp: 1616055773485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py38haa95532_0.tar.bz2
+  sha256: 02aeb80c081705443df2555d6025dd2b49b01ceef49515998a18fd83cc5eaf0a
+  md5: 6bbba9816851fd3ca6bcbb21528c59bd
+  depends:
+  - heapdict
+  - python >=3.8,<3.9.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 76700
+  timestamp: 1695833271895
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py38haa95532_0.tar.bz2
+  sha256: 2cfcbb95a94a42777c57ce0d95533f0228225c264e79b157278266452c6e1afa
+  md5: 86e9fe129facd043d463fcf8f3ce802d
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 18673
+  timestamp: 1672387667602
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+  sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
+  md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 148931
+  timestamp: 1666595229032
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+  sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
+  md5: 8d6a1e767775fe0eb617cd6e22edc2ff
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1871867
+  timestamp: 1681304638261

--- a/bay_trimesh/pixi.toml
+++ b/bay_trimesh/pixi.toml
@@ -25,14 +25,14 @@ numpy = "<1.21"
 numba = "<0.55"
 jinja2 = "<3"
 markupSafe = "2.0.1.*"
-pip = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks.notebook]
 cmd = "jupyter notebook bay_trimesh.ipynb"

--- a/bay_trimesh/pixi.toml
+++ b/bay_trimesh/pixi.toml
@@ -1,0 +1,44 @@
+[workspace]
+name = "bay_trimesh"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2019-05-15"
+maintainers = ["philippjfr"]
+categories = ["Geospatial"]
+labels = ["geoviews", "datashader", "bokeh"]
+description = "Visualizing water depth into the Chesapeake and Delaware Bays"
+
+[dependencies]
+python = "3.8.*"
+notebook = "<7"
+colorcet = "*"
+datashader = "0.13.0.*"
+geoviews = "1.9.1.*"
+holoviews = "1.14.6.*"
+pandas = "<1.4"
+bokeh = "2.3.3.*"
+dask = "2021.10.0.*"
+param = "1.11.1.*"
+numpy = "<1.21"
+numba = "<0.55"
+jinja2 = "<3"
+markupSafe = "2.0.1.*"
+pip = "*"
+wheel = "*"
+
+[target.osx-64.dependencies]
+libgfortran = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks.notebook]
+cmd = "jupyter notebook bay_trimesh.ipynb"
+depends-on = ["download"]
+
+[tasks.download]
+env = { FILENAME = "data" }
+cmd = "mkdir -p $FILENAME && curl -fsSL -o .DATA.zip https://s3.amazonaws.com/datashader-data/Chesapeake_and_Delaware_Bays.zip && python -m zipfile -e .DATA.zip $FILENAME && rm .DATA.zip"
+outputs = ["data"]

--- a/bay_trimesh/pixi.toml
+++ b/bay_trimesh/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "bay_trimesh"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/boids/pixi.lock
+++ b/boids/pixi.lock
@@ -7,615 +7,615 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.15.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.15.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.4.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.15.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.7.2-py39hee32256_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.22.3-py39h47b59a4_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.22.3-py39hcfaf2c3_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-1.4.4-py39he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-0.14.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-2.4.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.15.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.7.2-py39hee32256_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.22.3-py39h47b59a4_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.22.3-py39hcfaf2c3_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-1.4.4-py39he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-0.14.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-2.4.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.15.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.7.2-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.22.3-py39h25ab29e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.22.3-py39h974a1f5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-1.4.4-py39hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-0.14.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-2.4.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.15.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.7.2-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.22.3-py39h25ab29e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.22.3-py39h974a1f5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-1.4.4-py39hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-0.14.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-2.4.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.15.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.7.2-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.22.3-py39h6917f2d_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.22.3-py39h46c4fa8_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-1.4.4-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-0.14.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-2.4.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.15.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.7.2-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.22.3-py39h6917f2d_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.22.3-py39h46c4fa8_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-0.14.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
   sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
   md5: 2cf39d906cc321896ffe3e5d33d80c5c
   depends:
@@ -628,7 +628,7 @@ packages:
   license_family: MIT
   size: 162166
   timestamp: 1644463608931
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
   sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
   md5: 2972a84e0e22ae3244bbd2f1eebcf536
   depends:
@@ -639,7 +639,7 @@ packages:
   license_family: MIT
   size: 35352
   timestamp: 1644569715988
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
   sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
   md5: a68016b4b06460def24cb69d932986f3
   depends:
@@ -648,7 +648,7 @@ packages:
   license_family: MIT
   size: 132486
   timestamp: 1695717963702
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
   sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
   md5: 2f6356a2f530314b4059c08c79a3d8bc
   depends:
@@ -658,12 +658,12 @@ packages:
   license_family: MIT
   size: 205868
   timestamp: 1681493113570
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
   sha256: 2d8e75f31f75ea5eb8b9021b4c21eb2846a254a097e06eb68e66fc36a82e1bed
   md5: ae374a11c789a55555f70b29b9eff1f9
   depends:
@@ -679,7 +679,7 @@ packages:
   license_family: BSD
   size: 14430294
   timestamp: 1658136783940
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
   sha256: f84f9caa7eb9d489fd9634419fdf766d39293a5df1104b840fa0cdc5823a5c60
   md5: 922555c0435d6b2537cf8ced534b048c
   depends:
@@ -690,7 +690,7 @@ packages:
   license_family: BSD
   size: 141903
   timestamp: 1648028958291
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
   sha256: 0bbcb6f78eac530c6a084459ffab3238647b266d0c74d695e6e6387dd119cc67
   md5: bdc971e2a9affb5125b68ad708172dab
   depends:
@@ -699,7 +699,7 @@ packages:
   license: MIT
   size: 411301
   timestamp: 1602517685375
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
   sha256: 8c2071f706c2b445dabb781f7f8f008b23a29957468ec6894f050bfb3a2d5bf4
   md5: c203ffc7bbba991c7089d4b383cfd92c
   depends:
@@ -710,14 +710,14 @@ packages:
   license_family: MIT
   size: 357797
   timestamp: 1605539534667
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
   sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
   md5: 3ef00f4c5278b688552efc259c463dc8
   license: MPL-2.0
   license_family: Other
   size: 132731
   timestamp: 1694009767372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
   sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
   md5: d5cb3d97cf5e85ffe5e94037ed8a1169
   depends:
@@ -726,7 +726,7 @@ packages:
   license_family: Other
   size: 159077
   timestamp: 1690232254640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
   sha256: 674707b9c42e65c903c9786ee5a56b4d42aa054f1e75b328db8a2c1bfa368739
   md5: 76ae217198b014b89b267cf41b8251dd
   depends:
@@ -738,7 +738,7 @@ packages:
   license_family: MIT
   size: 231920
   timestamp: 1642701209740
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
   sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
   md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
   depends:
@@ -748,7 +748,7 @@ packages:
   license_family: CC
   size: 1917831
   timestamp: 1668084545510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
   sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
   md5: 13702d3b4b744784e5bd559c7050dd6f
   depends:
@@ -758,7 +758,7 @@ packages:
   license_family: BSD
   size: 12719
   timestamp: 1671231205875
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
   sha256: 821af57c20a85b4e92268fbf65fbaec2f273da5bb21889d9643756ef6e473237
   md5: f57e0f502500ffebdbec081ef61ad1d4
   depends:
@@ -772,7 +772,7 @@ packages:
   license_family: BSD
   size: 2179774
   timestamp: 1694445209134
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
   sha256: 3a39a2d6f161080c706292e3bf480f62d2444b1d6d67b3d7db50458202ee31f1
   md5: 0524ffca60f845eb392bbb56d56f0ce5
   depends:
@@ -783,7 +783,7 @@ packages:
   license_family: MIT
   size: 2094615
   timestamp: 1637091869922
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
   sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
   md5: 2e6ec51066d825ef3c317abe78d6049e
   depends:
@@ -792,7 +792,7 @@ packages:
   license_family: MIT
   size: 16413
   timestamp: 1649926472708
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
   sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
   md5: b4d923222d45314856b5378cb115214d
   depends:
@@ -801,7 +801,7 @@ packages:
   license_family: BSD
   size: 26728
   timestamp: 1668714462023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
   sha256: 8a121233d0b2cbb2463b67e798739ad2946f38933430a6a7fd1197cc6eab1c99
   md5: d2b24736491290a6c6d0138932111150
   depends:
@@ -811,7 +811,7 @@ packages:
   license: GPL-2.0-only and LicenseRef-FreeType
   size: 965280
   timestamp: 1635422707211
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
   sha256: 3c8ece1a7257b1d45f8fa25f46504bb709a1923d7175f2996e891366ec434b9d
   md5: 299bf4271d710651a1d71d3795580c2d
   depends:
@@ -819,7 +819,7 @@ packages:
   license: MIT
   size: 83592
   timestamp: 1603192039050
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.15.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.15.3-py39h06a4308_0.tar.bz2
   sha256: 54f35df9586b95021561266b7aaffb3849a871d635c3e9c8f61e5127d21553d6
   md5: 497e5242e8e513702f00a2b625b0674b
   depends:
@@ -839,7 +839,7 @@ packages:
   license_family: BSD
   size: 4452572
   timestamp: 1671782975232
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
   sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
   md5: 9213e0336e3a5216c989cfe52648412e
   depends:
@@ -848,7 +848,7 @@ packages:
   license: MIT
   size: 23805906
   timestamp: 1588026213084
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
   sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
   md5: 1eb52f9f45cea2fb9ce27b19f990160e
   depends:
@@ -857,7 +857,7 @@ packages:
   license_family: BSD
   size: 110793
   timestamp: 1666125606878
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
   sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
   md5: 126b3c1933b7364ff03f67455b687e99
   depends:
@@ -867,7 +867,7 @@ packages:
   license_family: APACHE
   size: 37588
   timestamp: 1678997134023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
   sha256: 1b424413f28b840fc6d4bf467f37e9e405823b1e3b899005df80152d48936d64
   md5: 4aa8bcf74c81cd3600978f791191692a
   constrains:
@@ -876,7 +876,7 @@ packages:
   license_family: Proprietary
   size: 9246735
   timestamp: 1634546760713
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
   sha256: b51b2e0dd37a74784ba19db22aded3f4c843b6fddb4a74399f65f36fc018aaa2
   md5: 0d56ab1950f952284b895ac0f78284a7
   depends:
@@ -896,7 +896,7 @@ packages:
   license_family: BSD
   size: 203541
   timestamp: 1671488675347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
   sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
   md5: ff47e0be879e817713ce2a9daa76e2b0
   depends:
@@ -917,7 +917,7 @@ packages:
   license_family: BSD
   size: 1261116
   timestamp: 1694181530670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
   sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
   md5: 5ef6c6a0d1ac79143c7359d305155167
   depends:
@@ -927,7 +927,7 @@ packages:
   license_family: MIT
   size: 1021637
   timestamp: 1644297140650
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
   sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
   md5: eaeb023688f781e7dd89e74310c38195
   depends:
@@ -937,7 +937,7 @@ packages:
   license_family: BSD
   size: 211775
   timestamp: 1666908212136
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
   sha256: 85348bfb14db4fea84078d703e766a3c978c5a592a06e41266748826dd59d8ae
   md5: 6e1c0fb5260c590f7ef5235cb3d05863
   depends:
@@ -946,7 +946,7 @@ packages:
   license_family: Other
   size: 279884
   timestamp: 1651065953960
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
   sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
   md5: 0d2c3c5edf671b575532d5a3e8bf15fc
   depends:
@@ -957,7 +957,7 @@ packages:
   license_family: MIT
   size: 131510
   timestamp: 1676558716852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
   sha256: 92bc012f9eb4ad71158cf4826fd3e125fcebff53b529276a81224acda48be547
   md5: c5fd100e3062e831cbdf33331042f627
   depends:
@@ -973,7 +973,7 @@ packages:
   license_family: BSD
   size: 190884
   timestamp: 1650622553813
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
   sha256: 0192bd48cd96c60dc3054d5addd8cdb4a29a218843181318371f79daec8242f8
   md5: d851b401dc13d04e6848bb36e12efc1c
   depends:
@@ -984,7 +984,7 @@ packages:
   license_family: BSD
   size: 91534
   timestamp: 1679906652183
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
   sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
   md5: a4beb461f0a60998a090d760b5c6c907
   depends:
@@ -1008,7 +1008,7 @@ packages:
   license_family: BSD
   size: 411564
   timestamp: 1671707702849
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
   sha256: 974df3dc76089be57b327acd6634384def84249003f58678ca1142bb274a75d9
   md5: 81b969d1a00153759b30554a1f11ddfd
   depends:
@@ -1019,7 +1019,7 @@ packages:
   license_family: BSD
   size: 92144
   timestamp: 1653292217019
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -1030,7 +1030,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
   sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
   md5: 9508af80612e4fa1b5d1abb43ca7e63c
   constrains:
@@ -1038,7 +1038,7 @@ packages:
   license: GPL-3.0-only
   size: 749072
   timestamp: 1652971360657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
   sha256: 3b4afe7665dcdb99bd4586a888b85b2e0325f8faecdd31c7780792080ee97872
   md5: 822b5201dde61bc838072dc5b670c88c
   depends:
@@ -1047,7 +1047,7 @@ packages:
   license: Custom
   size: 55183
   timestamp: 1594054267890
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
   sha256: c6fafbe73d2f93b91b6f4b65829f925f52a8f84746a57abd216b39da9ce8c494
   md5: 238f19c803a6ba7bd6dbd6989e03cbf1
   depends:
@@ -1055,7 +1055,7 @@ packages:
   license: GPL
   size: 8496776
   timestamp: 1560112207081
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
   sha256: bc3e6e79c32ff0ecea601aa108ae9cf4068f69703580e40e266ad4bcc52cff54
   md5: 9cb85601944ca7383b1769bff74b94e8
   depends:
@@ -1064,7 +1064,7 @@ packages:
   license: zlib/libpng
   size: 372914
   timestamp: 1556041895170
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -1072,13 +1072,13 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
   sha256: 43b0bd205f539583c088feb5b8d77b60c83d1df80c2a93dac9f2a1127001b2cf
   md5: 53fa39fdae936e9d07c4b2f5ef361993
   license: GPL3 with runtime exception
   size: 4246257
   timestamp: 1560112223556
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
   sha256: 711ea05b4c35bdafc762a172b01db896b17942f474c2b1a519f91370964bf9bc
   md5: b25d56d33596623a6a4a9d9baaa4f602
   depends:
@@ -1092,7 +1092,7 @@ packages:
   license: HPND
   size: 592974
   timestamp: 1653047881023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
   sha256: 146dbb1e4dbccdd57819e5102a8ca00970b8e33d6c6180e8007db89b184da569
   md5: c566a384259c1d2769852c3bddd81a67
   depends:
@@ -1106,7 +1106,7 @@ packages:
   license_family: BSD
   size: 90150
   timestamp: 1645441199289
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
   sha256: cffb5a063111f7a99a99c74770b23db5dde52325e25a7a46d1903d5ff4a82c88
   md5: eeb1bd66f28bed1956ab989d6eff7ae5
   depends:
@@ -1117,7 +1117,7 @@ packages:
   license_family: BSD
   size: 889956
   timestamp: 1645089138421
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
   sha256: 71f6c4a97014d745c58df52b4dd60ddd75a8508d54fe5b97f42bd1f31cb1c067
   md5: 686e77514ec9f1ef0a6feed374f14d37
   depends:
@@ -1129,7 +1129,7 @@ packages:
   license_family: MIT
   size: 789469
   timestamp: 1653546418059
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
   sha256: ea3355a67c5173f3944f09861043ca66eb7dbeff8f385d13528b3aabc0801d0c
   md5: 66e2aa12181bb2911485bdbe125d24c5
   depends:
@@ -1139,7 +1139,7 @@ packages:
   license: MIT
   size: 584199
   timestamp: 1654075843119
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
   sha256: 64b022d706b76c33965a250fdc8c6008443c41bff8ab27bb1df3cb70419576fd
   md5: ec4f05846aacf634df15c389235725cc
   depends:
@@ -1151,7 +1151,7 @@ packages:
   license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
   size: 1538261
   timestamp: 1646624639995
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
   sha256: 2c6a5dda7c510a961bc78e31d4232be5e8e0760c93454f5fd200c379355e0f5e
   md5: f35d4bf2fbb39e334992f6dd39f8721e
   depends:
@@ -1161,7 +1161,7 @@ packages:
   license_family: BSD
   size: 220865
   timestamp: 1627657046002
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
   sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
   md5: 421f82c8274b44660dba629134faa6af
   depends:
@@ -1171,7 +1171,7 @@ packages:
   license_family: BSD
   size: 122221
   timestamp: 1671541990505
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
   sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
   md5: feb0e452205b44ac45d9b5e55c21a3b1
   depends:
@@ -1183,7 +1183,7 @@ packages:
   license_family: BSD
   size: 22819
   timestamp: 1654597913064
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
   sha256: dc51b316ef5dcfb82a9c0afdc40879146ae59516f6cea7db776077783dfd2d76
   md5: b0b6b57c140f026b8806051107336576
   depends:
@@ -1205,7 +1205,7 @@ packages:
   license_family: PSF
   size: 7729454
   timestamp: 1647442028622
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
   sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
   md5: c04ef34af33da4c71bcc99b7ec24d210
   depends:
@@ -1215,7 +1215,7 @@ packages:
   license_family: BSD
   size: 16391
   timestamp: 1662014553452
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
   sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
   md5: f6c734d73e6e3dbc1b62766cf18ff3e4
   depends:
@@ -1225,7 +1225,7 @@ packages:
   license_family: BSD
   size: 58153
   timestamp: 1607364912263
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
   sha256: 7c4ded8b2ef036839f988560848d2c32e1aa4627fd37a32710e42c39f5c61ac2
   md5: bd20f4410b81f327e35ffa0657961146
   depends:
@@ -1236,7 +1236,7 @@ packages:
   license_family: Proprietary
   size: 229783051
   timestamp: 1634547157986
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
   sha256: 5394f5efd53afb2c1b0abf571ce3d9cb684b6c7e255f140ba2acaa703d6113be
   md5: d3cb2bfa63e30153f5527797dcc87280
   depends:
@@ -1248,7 +1248,7 @@ packages:
   license_family: BSD
   size: 63551
   timestamp: 1626176932911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
   sha256: c244d23da2749857a993f84969fd35ffd183ab8f462986df6d33ae0f705fe034
   md5: 9b1f8ccc2488d0e04eb73211e2987483
   depends:
@@ -1262,7 +1262,7 @@ packages:
   license: BSD 3-Clause
   size: 204136
   timestamp: 1634566416657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
   sha256: f81f426f8ef306d636664bc49e7cdd70e2b4306d7c6bcb9c75fe35a45ab2087a
   md5: 77aa1d7f958d36bf227e6ff4a34d2e3d
   depends:
@@ -1276,7 +1276,7 @@ packages:
   license: BSD-3-Clause
   size: 365386
   timestamp: 1626186165897
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
   sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
   md5: 95c83d71814c504b5504df4f14548f1a
   depends:
@@ -1302,7 +1302,7 @@ packages:
   license_family: BSD
   size: 8257558
   timestamp: 1681756322140
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
   sha256: 1b92d72b083f3350359b8fb2e3b5dc846f49650c9e46a6a74354b1b7f0d42730
   md5: 996babe4314515ddd41008a53cb5d47f
   depends:
@@ -1315,7 +1315,7 @@ packages:
   license_family: BSD
   size: 98791
   timestamp: 1650290544347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
   sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
   md5: 1710a25086c8098367eb36b9d441448b
   depends:
@@ -1343,7 +1343,7 @@ packages:
   license_family: BSD
   size: 569683
   timestamp: 1668450704669
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
   sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
   md5: 385cc9e53404776782502c0fdb08820f
   depends:
@@ -1356,7 +1356,7 @@ packages:
   license_family: BSD
   size: 147046
   timestamp: 1694616899309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
   sha256: 0807371380965e421cb5f3f2a30d790fd5c41db11dbb6d318e14294c3b1741ed
   md5: fca4bd4e3891aebf4fd7daf9b6d0ccfa
   depends:
@@ -1364,7 +1364,7 @@ packages:
   license: Free software (MIT-like)
   size: 1083412
   timestamp: 1636570020698
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
   sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
   md5: bbbcbebc20a4fdcadce398d0ca04f95e
   depends:
@@ -1373,7 +1373,7 @@ packages:
   license_family: BSD
   size: 13109
   timestamp: 1672387143252
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.2-py39h06a4308_0.tar.bz2
   sha256: 2450e0c106fce4b926d038f5a6a29621bc2593c7888bf77ae627476fdc12e1c9
   md5: 8281e36033cdf8417d49af27f0878895
   depends:
@@ -1398,7 +1398,7 @@ packages:
   license_family: BSD
   size: 523970
   timestamp: 1668180119805
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
   sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
   md5: 70db71df4ee1cdd38090c0f7b80ba61f
   depends:
@@ -1408,7 +1408,7 @@ packages:
   license_family: BSD
   size: 21944
   timestamp: 1668160644514
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
   sha256: 15a12c8bebcda45c577e61cea412d9aafaa433e39f9e91fd61bbfab66fcee3ab
   md5: 5239d8330e8bd34972fb80918dce79e7
   depends:
@@ -1424,7 +1424,7 @@ packages:
   license_family: MIT
   size: 136437
   timestamp: 1640689905588
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
   sha256: ff8d0426c7096e086db818265c3edf4a820accbfb15afae0407ca578de151fa9
   md5: d7bcf0b9ba2d85cf532059ec119d2750
   depends:
@@ -1440,7 +1440,7 @@ packages:
   license: BSD-3-Clause
   size: 9965
   timestamp: 1652801901707
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
   sha256: abfdeda143b6b667d50a82ea119043fc1469ee02f094a41a2402433ff408099e
   md5: e8dc29adc0282f4658e0e2f25ff207a2
   depends:
@@ -1455,7 +1455,7 @@ packages:
   license: BSD-3-Clause
   size: 7095882
   timestamp: 1652801886819
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
   sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
   md5: 5ad4571eba2479f77a9f849a6ae7724c
   depends:
@@ -1465,7 +1465,7 @@ packages:
   license_family: Apache
   size: 3998613
   timestamp: 1694465071784
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
   sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
   md5: 77a22ed6d0d448c5288d0f695bc9ac49
   depends:
@@ -1474,7 +1474,7 @@ packages:
   license_family: Apache
   size: 72527
   timestamp: 1693575234886
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
   sha256: e7a0abb0f00a94000876f2095f0cf531ad3803ffbd868a780b3f06816b54492c
   md5: 97ef7e1fe923d22a8e2307f3f39a92d5
   depends:
@@ -1490,7 +1490,7 @@ packages:
   license_family: BSD
   size: 13221005
   timestamp: 1650622404234
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
   sha256: 49fdb57b2ed2ce4d6bb7a2c5adec36ba59522518a41fb941f9e39a9f43750cc5
   md5: 871b65444733b7da5823ee0dc9826722
   depends:
@@ -1511,7 +1511,7 @@ packages:
   license_family: BSD
   size: 14712394
   timestamp: 1676379803902
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
   sha256: 64a732ce2661cdb6bd8f9d1484ac10afeb73082b1c2b44728d212e0117d2860e
   md5: ada303f0cf43a4e99cfa7f243b23b681
   depends:
@@ -1520,7 +1520,7 @@ packages:
   license_family: BSD
   size: 141832
   timestamp: 1684915385689
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
   sha256: 8bcb1c67693f42a3170eb77ef4cdbb81b605fdf40816953e69a33a065c101638
   md5: b7689507fb5f879dc766aaa8a4c37351
   depends:
@@ -1539,7 +1539,7 @@ packages:
   license_family: Other
   size: 734566
   timestamp: 1646325095608
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
   sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
   md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
   depends:
@@ -1550,7 +1550,7 @@ packages:
   license_family: MIT
   size: 2674850
   timestamp: 1697548887851
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
   sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
   md5: fe56f0479dd414c846191116366262c3
   depends:
@@ -1559,7 +1559,7 @@ packages:
   license_family: MIT
   size: 31999
   timestamp: 1692205535111
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
   sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
   md5: 44d2a857d13bdf9d99aaac039a249d47
   depends:
@@ -1568,7 +1568,7 @@ packages:
   license_family: Apache
   size: 91137
   timestamp: 1659455142164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
   sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
   md5: eb899a739d9b58dd747f1f6bd52d4cf3
   depends:
@@ -1580,7 +1580,7 @@ packages:
   license_family: BSD
   size: 579771
   timestamp: 1672387338600
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
   sha256: 6973cfe0565ba3b5ad6d1de9e34848fbbadd78b507b2e23e1c079636b8f8f317
   md5: a924535045fb356e23e7a3cc8116b638
   depends:
@@ -1590,7 +1590,7 @@ packages:
   license_family: BSD
   size: 350026
   timestamp: 1612298042840
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
   sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
   md5: f36ecb722522cbe2e3737424edf1b5e1
   depends:
@@ -1602,7 +1602,7 @@ packages:
   license_family: BSD
   size: 29312
   timestamp: 1675441510984
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
   sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
   md5: 6d03295e544251e608a28c8d7c48115e
   depends:
@@ -1611,7 +1611,7 @@ packages:
   license_family: BSD
   size: 1862058
   timestamp: 1684280096752
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
   sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
   md5: 1f09617aecd6f3c2f2e20692c0759f34
   depends:
@@ -1621,7 +1621,7 @@ packages:
   license_family: Apache
   size: 94434
   timestamp: 1690223520097
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
   sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
   md5: ffceed627867508d73af1636ab5ebf42
   depends:
@@ -1630,7 +1630,7 @@ packages:
   license_family: MIT
   size: 156324
   timestamp: 1661452578573
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
   sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
   md5: 0e3341a4fe434167bf74b613eb6afd81
   depends:
@@ -1640,7 +1640,7 @@ packages:
   license_family: MIT
   size: 97194
   timestamp: 1636110999719
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
   sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
   md5: c5f3f7f10ad30f0945e75252615ab6e5
   depends:
@@ -1649,7 +1649,7 @@ packages:
   license_family: BSD
   size: 31331
   timestamp: 1605305847037
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
   sha256: c4b9e332a6f2b7524e8c88e2b39a2568a48e556fd9a44c30759c43611d4d023d
   md5: bb118745c9b08fc5028f45e77f371e68
   depends:
@@ -1669,7 +1669,7 @@ packages:
   license_family: PSF
   size: 24553777
   timestamp: 1654084160832
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
   sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
   md5: 0caa188a695319bdb13f53b0a2b3accc
   depends:
@@ -1678,7 +1678,7 @@ packages:
   license_family: BSD
   size: 264864
   timestamp: 1661371117920
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
   sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
   md5: bcb44ecbea441ee0d4659133d060d71f
   depends:
@@ -1687,7 +1687,7 @@ packages:
   license_family: MIT
   size: 257904
   timestamp: 1695131670290
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
   sha256: e937081facacb141dc2c9cdcced92baa9a2662e4a56100b6041df0b6b7692570
   md5: f3ac39b2349258198a9b3316636fe5d5
   depends:
@@ -1697,7 +1697,7 @@ packages:
   license_family: BSD
   size: 39972
   timestamp: 1685030752528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
   sha256: 3da9cbbd49fac566433748bd245d09d7d5fcd28b04c0397cbbf6d5bb92f5c4a5
   md5: df73a5d2f6e089d51e71e91935a82c65
   depends:
@@ -1708,7 +1708,7 @@ packages:
   license_family: MIT
   size: 183753
   timestamp: 1635775763162
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
   sha256: 26005d191bb15070aad70707ed6493f32678a67978bd3b83d4c9679cab44e717
   md5: 2dc75d5a4ccb64310939c3a72d34ae20
   depends:
@@ -1719,7 +1719,7 @@ packages:
   license_family: BSD
   size: 521583
   timestamp: 1638435042256
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
   sha256: 8c950c69bee969e2c66f88f0dc247b3ab75a753672a88009779d5f5dba193532
   md5: 150ac0eb929bab9dec912797bdfc7b95
   depends:
@@ -1729,7 +1729,7 @@ packages:
   license_family: GPL
   size: 433182
   timestamp: 1642022402894
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
   sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
   md5: c7de00b4ac2778c4e5a7816320d75391
   depends:
@@ -1745,7 +1745,7 @@ packages:
   license_family: Apache
   size: 94028
   timestamp: 1690400356879
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
   sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
   md5: 1581cafc84708ed9aafaaee1cbbf6065
   depends:
@@ -1754,7 +1754,7 @@ packages:
   license_family: MIT
   size: 1089416
   timestamp: 1690290900608
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
   sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
   md5: e19ffbfb24b990275d24fcea2bd1699b
   depends:
@@ -1763,7 +1763,7 @@ packages:
   license_family: Apache
   size: 15702
   timestamp: 1614030498860
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
   sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
   md5: ca061ce25c0f58628643abec8d6a8244
   depends:
@@ -1772,7 +1772,7 @@ packages:
   license_family: MIT
   size: 66330
   timestamp: 1696347637947
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
   sha256: 87965b7b46d93866d31696a1045216d64f077a06b2900c356aba87e8559c6188
   md5: fa334030245135b37027a882f3c468bf
   depends:
@@ -1783,7 +1783,7 @@ packages:
   license_family: Other
   size: 1561908
   timestamp: 1655328608308
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
   sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
   md5: 0e76eab58fe488e91f0aee73f46de031
   depends:
@@ -1794,7 +1794,7 @@ packages:
   license_family: BSD
   size: 29816
   timestamp: 1671751864131
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
   sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
   md5: b413a210eca82fe867e991eed085201b
   depends:
@@ -1804,7 +1804,7 @@ packages:
   license_family: BSD
   size: 38882
   timestamp: 1668168876032
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
   sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
   md5: 5b8375e2092012db69d2123dc0c68630
   depends:
@@ -1814,7 +1814,7 @@ packages:
   license_family: BSD
   size: 3485432
   timestamp: 1654088939579
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
   sha256: b746e39272888b9cc1a2a711b7b8836f2e26f4457850e43ad18bf0765e21dc3d
   md5: 200e86f8d53aeebf4b7dcfc944fd7920
   depends:
@@ -1824,7 +1824,7 @@ packages:
   license_family: Apache
   size: 661662
   timestamp: 1606942359431
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
   sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
   md5: 67a8320961ff24e92eebb661536e5cf7
   depends:
@@ -1837,7 +1837,7 @@ packages:
   license_family: MOZILLA
   size: 123763
   timestamp: 1679561904852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
   sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
   md5: 0f0b91a158dd3692cbb7a7763b657bfe
   depends:
@@ -1846,7 +1846,7 @@ packages:
   license_family: BSD
   size: 192032
   timestamp: 1671143995098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
   md5: 8515e64a3de7581360d713fe4c0a094e
   depends:
@@ -1856,7 +1856,7 @@ packages:
   license_family: PSF
   size: 8789
   timestamp: 1690297588156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
   md5: 60170012374b2a5007842fa5870d78c5
   depends:
@@ -1865,7 +1865,7 @@ packages:
   license_family: PSF
   size: 57479
   timestamp: 1690297581658
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
   sha256: 870f20a3c006a74b291910f69c3469a409bd21437142864b29cfafeb89ca7c34
   md5: 1b2f1589e3ebc3e0c6ecb38dba93e4ae
   depends:
@@ -1880,7 +1880,7 @@ packages:
   license_family: MIT
   size: 186761
   timestamp: 1686163186447
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
   sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
   md5: f8d03a15b974fc7810d9f54ae849fc8e
   depends:
@@ -1889,7 +1889,7 @@ packages:
   license_family: BSD
   size: 20781
   timestamp: 1607365390528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
   sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
   md5: d7db5d6ce1db80eade8a082ff78bf479
   depends:
@@ -1899,7 +1899,7 @@ packages:
   license_family: BSD
   size: 71044
   timestamp: 1614804011510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
   sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
   md5: b3899f8bda32734727bd5a73df1d7d17
   depends:
@@ -1908,7 +1908,7 @@ packages:
   license_family: MIT
   size: 101520
   timestamp: 1695742037911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
   sha256: 2ce360ff98c0ca4537d70c19266b5700810196c54ce2fbaff3b94a969846ee37
   md5: 94cb94dc47405b24b1b5bd0a3275ab59
   depends:
@@ -1917,7 +1917,7 @@ packages:
   license_family: GPL2
   size: 398058
   timestamp: 1651602137803
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -1925,7 +1925,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
   sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
   md5: 567b68192c387b5fc88178425577a0fe
   depends:
@@ -1935,7 +1935,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 366479
   timestamp: 1616055552392
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
   sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
   md5: 3818a9531fe74433c3b7d5144c9a58cc
   depends:
@@ -1944,7 +1944,7 @@ packages:
   license_family: MIT
   size: 18021
   timestamp: 1672387231268
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
   sha256: 513444d83ac2405e898531492ea59f3a95641e357cc39c1048d6fffc1791a16b
   md5: 601d9449c280b9b145dc8c83b6f06119
   depends:
@@ -1953,7 +1953,7 @@ packages:
   license_family: Other
   size: 133595
   timestamp: 1650637720646
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
   sha256: 1c049c23788a00b6f38bdc801245e0e60af98718d4db4c958658bcc67ff158c7
   md5: b1737dfd2e06ad69ec5cfec341e207c6
   depends:
@@ -1966,7 +1966,7 @@ packages:
   license_family: BSD
   size: 827172
   timestamp: 1650622223170
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -1979,7 +1979,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -1989,7 +1989,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
   md5: b2aa5503875aba2f1d88cae9df9a96d5
   depends:
@@ -1998,7 +1998,7 @@ packages:
   license_family: BSD
   size: 13636
   timestamp: 1611930018941
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -2010,7 +2010,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
   sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
   md5: 544adf2677c47c9b9c891aea720678f1
   depends:
@@ -2018,7 +2018,7 @@ packages:
   license: MIT
   size: 33999
   timestamp: 1630003259346
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -2027,7 +2027,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -2036,7 +2036,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -2045,7 +2045,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -2054,7 +2054,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
   sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
   md5: 9eff1a842dbda8d1bae9a2c008b599bc
   depends:
@@ -2065,7 +2065,7 @@ packages:
   license_family: MIT
   size: 690443
   timestamp: 1625743217109
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -2073,7 +2073,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
   sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
   md5: 33624a42ee387bf9918ea98b4e7b31fc
   depends:
@@ -2083,7 +2083,7 @@ packages:
   license_family: BSD
   size: 8173
   timestamp: 1601490751973
-- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
   sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
   md5: 67857cc5e9044770d2b15f9d94a4521d
   depends:
@@ -2092,7 +2092,7 @@ packages:
   license_family: Apache
   size: 12810
   timestamp: 1600445183315
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -2101,7 +2101,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -2110,7 +2110,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -2120,7 +2120,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
   sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
   md5: e68a6f315f41a8d814d833652bf38b9b
   depends:
@@ -2128,7 +2128,7 @@ packages:
   license: MIT
   size: 13374
   timestamp: 1606932077143
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -2136,7 +2136,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -2145,7 +2145,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -2154,7 +2154,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
   sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
   md5: 2eb923cc014094f4acf7f849d67d73f8
   depends:
@@ -2164,7 +2164,7 @@ packages:
   license_family: BSD
   size: 246457
   timestamp: 1626374695070
-- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
   sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
   md5: 41db68b96e114e367c4f120a3b379e59
   depends:
@@ -2173,7 +2173,7 @@ packages:
   license_family: BSD
   size: 19391
   timestamp: 1632406728844
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -2182,7 +2182,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -2194,14 +2194,14 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
   sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
   md5: a815d3bdb160bcc71687f2dda70d3ca4
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 122218
   timestamp: 1680170368293
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -2209,7 +2209,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
   sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
   md5: 447a49f7bad119faa80d7f14aa296c95
   depends:
@@ -2222,7 +2222,7 @@ packages:
   license_family: MIT
   size: 162176
   timestamp: 1644481750133
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
   sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
   md5: 8810f48fe4a4792de0fd3520b502d08b
   depends:
@@ -2231,7 +2231,7 @@ packages:
   license_family: BSD
   size: 10019
   timestamp: 1606859473259
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
   sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
   md5: 00a446b6dfc61af223df4de29fe8ad94
   depends:
@@ -2241,7 +2241,7 @@ packages:
   license_family: MIT
   size: 34305
   timestamp: 1644569782044
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
   sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
   md5: bd92dd8bd5b9d24e632b62a075426e50
   depends:
@@ -2250,7 +2250,7 @@ packages:
   license_family: MIT
   size: 133634
   timestamp: 1695718025321
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
   sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
   md5: f8ae051b591a9027adc16de1be9748f4
   depends:
@@ -2260,12 +2260,12 @@ packages:
   license_family: MIT
   size: 206198
   timestamp: 1681493096349
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
   sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
   md5: e2f3248e2a5009a02f7b8e54f83314ef
   size: 5620
   timestamp: 1528121955725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.4.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-2.4.3-py39hecd8cb5_0.tar.bz2
   sha256: 1f5dcdfd5854f527041cc8ad99de5b1e9de2cf89fc07d6ceebe773d0311a92b7
   md5: 6188865467aabac07a36811fc37b0982
   depends:
@@ -2281,7 +2281,7 @@ packages:
   license_family: BSD
   size: 14356265
   timestamp: 1658136884702
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
   sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
   md5: 0d79760d544d0bd8acb4adc4ef813418
   depends:
@@ -2291,7 +2291,7 @@ packages:
   license_family: BSD
   size: 137075
   timestamp: 1657175654487
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
   sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
   md5: 31d6d04cd2388d8f19004501271b3545
   depends:
@@ -2301,7 +2301,7 @@ packages:
   license: MIT
   size: 18982
   timestamp: 1659616229395
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
   sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
   md5: caf1073dc2ca5aeb832a2877394eae12
   depends:
@@ -2310,7 +2310,7 @@ packages:
   license: MIT
   size: 18233
   timestamp: 1659616216769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
   sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
   md5: aa1ed20c38af535c8d6a955314759d7b
   depends:
@@ -2319,14 +2319,14 @@ packages:
   license: MIT
   size: 394588
   timestamp: 1659616312678
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
   sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
   md5: ce3588e31faa79f546e0fc6a36c5543c
   license: MPL-2.0
   license_family: Other
   size: 133884
   timestamp: 1694009771475
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
   sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
   md5: 21eb7f53076d0a69513cfd258f6ef63c
   depends:
@@ -2335,7 +2335,7 @@ packages:
   license_family: Other
   size: 159756
   timestamp: 1690232346868
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
   sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
   md5: a40a04d9cda1e665565bc6c832d598b6
   depends:
@@ -2346,7 +2346,7 @@ packages:
   license_family: MIT
   size: 225258
   timestamp: 1670423337502
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
   sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
   md5: b2cc5f37f7bb069d061306e7eac2a011
   depends:
@@ -2356,7 +2356,7 @@ packages:
   license_family: CC
   size: 1913396
   timestamp: 1668084575248
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
   sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
   md5: 103d8c039e342115720a84d59c119d46
   depends:
@@ -2366,7 +2366,7 @@ packages:
   license_family: BSD
   size: 13774
   timestamp: 1671231190250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
   sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
   md5: f69f09e0346172f225390d2b3b0d7873
   depends:
@@ -2377,7 +2377,7 @@ packages:
   license_family: BSD
   size: 246628
   timestamp: 1663827484947
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
   sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
   md5: cb80c7ac65b48a737654f371fe31c460
   depends:
@@ -2390,7 +2390,7 @@ packages:
   license_family: BSD
   size: 1307228
   timestamp: 1694212041712
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
   sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
   md5: 04cbe8f4bc62c34fac9d42d1124059bf
   depends:
@@ -2400,7 +2400,7 @@ packages:
   license_family: MIT
   size: 2052734
   timestamp: 1690905361158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
   sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
   md5: ef0e825982f242085574f502dfff4f6b
   depends:
@@ -2409,7 +2409,7 @@ packages:
   license_family: MIT
   size: 16594
   timestamp: 1649926538106
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
   sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
   md5: 24747a300246c016b3a7f04dabd02d4a
   depends:
@@ -2418,7 +2418,7 @@ packages:
   license_family: BSD
   size: 27709
   timestamp: 1668714497209
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -2428,14 +2428,14 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
   sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
   md5: e4a732941f74b8062c8bcbfe5c5c2b56
   license: MIT
   license_family: MIT
   size: 80252
   timestamp: 1676983220161
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.15.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.15.3-py39hecd8cb5_0.tar.bz2
   sha256: 205aa54194966c4a2d16f5abe17b4b044d51a623987324354e765e3b68269eea
   md5: 75f3ecdc22a04ba4fd24962102138c60
   depends:
@@ -2455,7 +2455,7 @@ packages:
   license_family: BSD
   size: 4438088
   timestamp: 1671783268805
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
   sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
   md5: f3ce6fe6eb760c236e5f7d04df5faa81
   depends:
@@ -2464,7 +2464,7 @@ packages:
   license_family: MIT
   size: 28138484
   timestamp: 1692293212596
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
   sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
   md5: 6dd72c43fea25b748ec7a9f6c0407e15
   depends:
@@ -2473,7 +2473,7 @@ packages:
   license_family: BSD
   size: 111810
   timestamp: 1666125671024
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
   sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
   md5: 03cdb7e679924b329ecab8f12cb8fc67
   depends:
@@ -2483,7 +2483,7 @@ packages:
   license_family: APACHE
   size: 38813
   timestamp: 1678997212422
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
   sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
   md5: e113c4e6e758dd68faf196586bf5564d
   depends:
@@ -2493,7 +2493,7 @@ packages:
   license_family: Apache
   size: 51873
   timestamp: 1698254765815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
   sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
   md5: 78baea934985ccd9514a366cc7e80ed4
   depends:
@@ -2502,7 +2502,7 @@ packages:
   license_family: Proprietary
   size: 727499
   timestamp: 1681801225190
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
   sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
   md5: da9b63e42f281f7e77b289f4b654b83b
   depends:
@@ -2524,7 +2524,7 @@ packages:
   license_family: BSD
   size: 218436
   timestamp: 1691121840155
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
   sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
   md5: 6a7cb9b49593b29933fa2b503d533a08
   depends:
@@ -2546,7 +2546,7 @@ packages:
   license_family: BSD
   size: 1257205
   timestamp: 1694181720454
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
   sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
   md5: d861ef66f5c0a282d60b65778a9de2f3
   depends:
@@ -2556,7 +2556,7 @@ packages:
   license_family: MIT
   size: 1048450
   timestamp: 1644315332508
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
   sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
   md5: f7e603c965052deed8b789c35855a42f
   depends:
@@ -2566,14 +2566,14 @@ packages:
   license_family: BSD
   size: 213537
   timestamp: 1666908270815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
   sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
   md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
   license: IJG
   license_family: Other
   size: 278924
   timestamp: 1677849185191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
   sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
   md5: a82a17e78f725dcbd71ff8dac6db05c7
   depends:
@@ -2584,7 +2584,7 @@ packages:
   license_family: MIT
   size: 133134
   timestamp: 1676558895333
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
   sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
   md5: ee9270379a9ebdb6297e4b6849b3f7f0
   depends:
@@ -2600,7 +2600,7 @@ packages:
   license_family: BSD
   size: 195479
   timestamp: 1676329410154
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 32b898a97dca7770858ab31294238fde11ab61a84831a52f320e5ee5405a147c
   md5: 926e754b8fad288b583ef2933deae1a5
   depends:
@@ -2611,7 +2611,7 @@ packages:
   license_family: BSD
   size: 92938
   timestamp: 1679906616072
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
   sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
   md5: 7e60995b3119417213e5faedda147499
   depends:
@@ -2635,7 +2635,7 @@ packages:
   license_family: BSD
   size: 403165
   timestamp: 1671707664990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
   sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
   md5: cd470bdb28bb0e8b3535c93a3a6dad07
   depends:
@@ -2645,7 +2645,7 @@ packages:
   license_family: BSD
   size: 65431
   timestamp: 1672387389172
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -2655,7 +2655,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -2664,13 +2664,13 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
   sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
   md5: 7dba7aa5b971febb55281659843586ba
   license: MIT
   size: 65470
   timestamp: 1659616172703
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
   sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
   md5: f78a158983f0bbaba56f34b976bc6dae
   depends:
@@ -2678,7 +2678,7 @@ packages:
   license: MIT
   size: 34189
   timestamp: 1659616189313
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
   sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
   md5: 36a1d885725d3ab4d1fadc5a29f978d2
   depends:
@@ -2686,35 +2686,35 @@ packages:
   license: MIT
   size: 327737
   timestamp: 1659616202869
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
   sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
   md5: 817848d0e2b2808acdc9b3fbbf581726
   license: MIT
   license_family: MIT
   size: 133887
   timestamp: 1683716590737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
   sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
   md5: c90372428e1e4eed4fdcd790979d06b4
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1409377
   timestamp: 1650983531933
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -2723,13 +2723,13 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -2746,7 +2746,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
   sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
   md5: c0b99f8e1c7475f23b1c7b4250b06e1c
   depends:
@@ -2760,7 +2760,7 @@ packages:
   license_family: BSD
   size: 88021
   timestamp: 1694778290062
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
   sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
   md5: 46a65d1fc24013217e06aaf6d65ffcad
   constrains:
@@ -2769,7 +2769,7 @@ packages:
   license_family: BSD
   size: 425478
   timestamp: 1694776947990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
   sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
   md5: 06866415ef22d5322f9bdc9956b59c4d
   depends:
@@ -2781,7 +2781,7 @@ packages:
   license_family: MIT
   size: 678174
   timestamp: 1692970318885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
   sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
   md5: 2edc6c894d6d0321304396e9bd40df94
   depends:
@@ -2791,7 +2791,7 @@ packages:
   license_family: MIT
   size: 241774
   timestamp: 1692973618934
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
   sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
   md5: 8bbd981ca0129d7beeacd3cd7623f714
   depends:
@@ -2802,7 +2802,7 @@ packages:
   license_family: Other
   size: 1491074
   timestamp: 1695058597986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
   sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
   md5: d5f58d056b4bfc67aec30c77035ba889
   depends:
@@ -2811,7 +2811,7 @@ packages:
   license_family: BSD
   size: 182491
   timestamp: 1670944720979
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
   sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
   md5: 1affd16b166571a91feae04baf5fd3da
   depends:
@@ -2821,7 +2821,7 @@ packages:
   license_family: BSD
   size: 123431
   timestamp: 1671542016019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
   sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
   md5: 3681ebf029211ceab26af6f5d35abf39
   depends:
@@ -2832,7 +2832,7 @@ packages:
   license_family: BSD
   size: 22254
   timestamp: 1654598220251
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.7.2-py39hee32256_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.7.2-py39hee32256_0.tar.bz2
   sha256: 907176b863fbec590c41e5a5f491591903913f3af4722dac41515bc18e93e6b5
   md5: 0f2b67bd2ebdbdf18a607f1b7d115627
   depends:
@@ -2856,7 +2856,7 @@ packages:
   license_family: PSF
   size: 8025111
   timestamp: 1693813054077
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
   sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
   md5: 6eb64ecfcd754502e271db0bb51d2cfd
   depends:
@@ -2866,7 +2866,7 @@ packages:
   license_family: BSD
   size: 17374
   timestamp: 1662014643620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
   sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
   md5: 2a4d604717a647ad21af766289cbbfc3
   depends:
@@ -2875,7 +2875,7 @@ packages:
   license_family: BSD
   size: 58057
   timestamp: 1607364912348
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
   sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
   md5: 25051fe272624544652dc6d814c2943a
   depends:
@@ -2888,7 +2888,7 @@ packages:
   license_family: Proprietary
   size: 224420228
   timestamp: 1691503125614
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
   sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
   md5: 37d8cf85a63f7aa9af1624894a7d606d
   depends:
@@ -2898,7 +2898,7 @@ packages:
   license_family: BSD
   size: 48590
   timestamp: 1682969183093
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
   sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
   md5: 0b2aee6666135bbd36b46d6ac66160f7
   depends:
@@ -2911,7 +2911,7 @@ packages:
   license_family: BSD
   size: 210705
   timestamp: 1695058433223
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
   sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
   md5: e22fb55ce380d0ebd44cce3f20d5349e
   depends:
@@ -2925,7 +2925,7 @@ packages:
   license_family: BSD
   size: 296614
   timestamp: 1695060155673
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
   sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
   md5: 1a5d4004e64e3cfb7a2a297b9117c285
   depends:
@@ -2951,7 +2951,7 @@ packages:
   license_family: BSD
   size: 8213832
   timestamp: 1681756573646
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
   sha256: 2975bd1f98ca9ec7354ee378f86f8322ec90f568374776fd90e80c534fbee882
   md5: 798627089e0ccba26695a26d9cb127ec
   depends:
@@ -2964,7 +2964,7 @@ packages:
   license_family: BSD
   size: 99066
   timestamp: 1650308465824
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
   sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
   md5: e572c1264a7af20b486f64ac8c9e1f57
   depends:
@@ -2992,7 +2992,7 @@ packages:
   license_family: BSD
   size: 573356
   timestamp: 1668450732828
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
   sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
   md5: b67569a7c30af9ffa5cde6e4b52ac68b
   depends:
@@ -3005,14 +3005,14 @@ packages:
   license_family: BSD
   size: 148342
   timestamp: 1694616917184
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
   sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
   md5: 97b81f34efbe86c5220fe82eb584fd62
   depends:
@@ -3021,7 +3021,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387288528
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.2-py39hecd8cb5_0.tar.bz2
   sha256: 911ba9e41d3ab14e6191809a62e55676e65dbc5fc4558462d24da3ea76a8f85e
   md5: b8416d645fa5f55483f51f06049197f5
   depends:
@@ -3046,7 +3046,7 @@ packages:
   license_family: BSD
   size: 521789
   timestamp: 1668180098296
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
   sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
   md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
   depends:
@@ -3056,7 +3056,7 @@ packages:
   license_family: BSD
   size: 22858
   timestamp: 1668160618784
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
   sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
   md5: 185e9c41abb88ee59b52ec0f5f65d506
   depends:
@@ -3070,7 +3070,7 @@ packages:
   license_family: MIT
   size: 138305
   timestamp: 1696515469702
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.22.3-py39h47b59a4_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.22.3-py39h47b59a4_2.tar.bz2
   sha256: cc66489ce399329d20cda69e5833ba9981f36279d226b606f7ea24a7606317c8
   md5: 93be40a70e9f80f6ef198b55ce897ff8
   depends:
@@ -3085,7 +3085,7 @@ packages:
   license: BSD-3-Clause
   size: 10445
   timestamp: 1682972834243
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.22.3-py39hcfaf2c3_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.22.3-py39hcfaf2c3_2.tar.bz2
   sha256: 0164d04fb286ebc3ea94a79fa52a21b18164d840fb79b223f21c2e38591f0784
   md5: de8b44dd081637d75ba9acef451b0020
   depends:
@@ -3099,7 +3099,7 @@ packages:
   license: BSD-3-Clause
   size: 6752725
   timestamp: 1682972820395
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
   sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
   md5: 93f5d7b66976154adeda219bea02ba45
   depends:
@@ -3109,7 +3109,7 @@ packages:
   license: BSD 2-Clause
   size: 484257
   timestamp: 1630093862501
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
   sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
   md5: 5e8713ef1215406254988163eaf34020
   depends:
@@ -3118,7 +3118,7 @@ packages:
   license_family: Apache
   size: 4965606
   timestamp: 1695323060401
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
   sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
   md5: 4154929ace2ad6ee16aea815635a6d1f
   depends:
@@ -3127,7 +3127,7 @@ packages:
   license_family: Apache
   size: 73598
   timestamp: 1693575307570
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-1.4.4-py39he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-1.4.4-py39he9d5cce_0.tar.bz2
   sha256: 9c8c14f79f0a2b8ffb3f19cc9bf80eabac6d27c39266eeb6dffa76354cbb96c0
   md5: 4e87084b61971e7a8198fbae451403fe
   depends:
@@ -3142,7 +3142,7 @@ packages:
   license_family: BSD
   size: 12634563
   timestamp: 1663773428164
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-0.14.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-0.14.3-py39hecd8cb5_0.tar.bz2
   sha256: c63341d41ad75c475a793800d229886be5aba866e1885f23778f23093b15f891
   md5: 1eaea439a84cf758cbaab861a140f67f
   depends:
@@ -3163,7 +3163,7 @@ packages:
   license_family: BSD
   size: 14708005
   timestamp: 1676380263675
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
   sha256: 914f1ec8d911083c006c4c2d3b4c0c528e79abba3ae5f1dad825bd896870270d
   md5: 949e0e4c0ce43c92eb52241892230873
   depends:
@@ -3172,7 +3172,7 @@ packages:
   license_family: BSD
   size: 142949
   timestamp: 1684915417020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
   sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
   md5: be0a90921f3bf4f0d6950fb786093de7
   depends:
@@ -3191,7 +3191,7 @@ packages:
   license_family: Other
   size: 719901
   timestamp: 1696580194417
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
   sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
   md5: 81ae9ec2d7fcf6934847bff558b619f5
   depends:
@@ -3202,7 +3202,7 @@ packages:
   license_family: MIT
   size: 2672987
   timestamp: 1697548890181
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
   sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
   md5: 1a822c206e2abddc5d6d821721af227f
   depends:
@@ -3211,7 +3211,7 @@ packages:
   license_family: MIT
   size: 33013
   timestamp: 1692205801265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
   sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
   md5: 1604d33dbdb2446c642970f8b354bedb
   depends:
@@ -3220,7 +3220,7 @@ packages:
   license_family: Apache
   size: 91266
   timestamp: 1659455269141
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
   sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
   md5: d1b3bcc35655a3123acb1fa2ad1a8511
   depends:
@@ -3232,7 +3232,7 @@ packages:
   license_family: BSD
   size: 580828
   timestamp: 1672387372015
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
   sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
   md5: 7540555d1fb192236db9a7c5c9d3601c
   depends:
@@ -3241,7 +3241,7 @@ packages:
   license_family: BSD
   size: 365765
   timestamp: 1656431373327
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
   sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
   md5: 0a73533fb6e0dc717ab906a537bc747d
   depends:
@@ -3253,7 +3253,7 @@ packages:
   license_family: BSD
   size: 30803
   timestamp: 1675441638631
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
   sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
   md5: 0a959fbad46ab38ade48dbd358002674
   depends:
@@ -3262,7 +3262,7 @@ packages:
   license_family: BSD
   size: 1864757
   timestamp: 1684280094736
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
   sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
   md5: ea24b5076ef79e4567c5a3f0cb22b470
   depends:
@@ -3272,7 +3272,7 @@ packages:
   license_family: Apache
   size: 95330
   timestamp: 1690223465114
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
   sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
   md5: bcaea6d4a47e9c874becaa700c78dcf7
   depends:
@@ -3281,7 +3281,7 @@ packages:
   license_family: MIT
   size: 157216
   timestamp: 1661452617825
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
   sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
   md5: 707110d1b49cb1864acb0bbaa103591e
   depends:
@@ -3290,7 +3290,7 @@ packages:
   license_family: MIT
   size: 95016
   timestamp: 1636111184034
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
   sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
   md5: 113a443b9c706f9f9c6187c0eaa3de27
   depends:
@@ -3299,7 +3299,7 @@ packages:
   license_family: BSD
   size: 31178
   timestamp: 1605305861851
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
   sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
   md5: 85a8d0001db70e52a479155228cb1fe0
   depends:
@@ -3318,7 +3318,7 @@ packages:
   license_family: PSF
   size: 13324979
   timestamp: 1694439878265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
   sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
   md5: 47c5e22e31ec05a7bc0ce90065a53afd
   depends:
@@ -3327,7 +3327,7 @@ packages:
   license_family: BSD
   size: 265348
   timestamp: 1661368839620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
   sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
   md5: ce9a69e1668aa1e133f2aa6d4e8d346f
   depends:
@@ -3336,7 +3336,7 @@ packages:
   license_family: MIT
   size: 254958
   timestamp: 1695131709704
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 9ee098c09f31fad7ff1856e5ce2619172eaf979997e7a427d1e05cce32c2af00
   md5: cac1d1898b69ae9646dfbf082910635d
   depends:
@@ -3346,7 +3346,7 @@ packages:
   license_family: BSD
   size: 40946
   timestamp: 1685030787453
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
   sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
   md5: 637f08b19dd8fd87347d8c44f9e3e202
   depends:
@@ -3356,7 +3356,7 @@ packages:
   license_family: MIT
   size: 170776
   timestamp: 1698096100056
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
   sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
   md5: 8ce3ac7d8a04e469b566f1b090d01140
   depends:
@@ -3367,7 +3367,7 @@ packages:
   license_family: BSD
   size: 470617
   timestamp: 1657724324011
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -3376,7 +3376,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
   sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
   md5: 6f2d41dd76a03b7f85a1ed49af1763d6
   depends:
@@ -3392,7 +3392,7 @@ packages:
   license_family: Apache
   size: 95100
   timestamp: 1690400262627
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
   md5: b0321e6f14e139fc15b1f8b4acb35d2f
   depends:
@@ -3401,7 +3401,7 @@ packages:
   license_family: MIT
   size: 1093966
   timestamp: 1690290944588
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
   sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
   md5: 62b64576a0aa5f6c3fb05f56650d25e1
   depends:
@@ -3410,7 +3410,7 @@ packages:
   license_family: Apache
   size: 15535
   timestamp: 1614030509324
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
   sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
   md5: 15b5595b31e39f08eaacbe2e502d8fb3
   depends:
@@ -3419,7 +3419,7 @@ packages:
   license_family: MIT
   size: 67292
   timestamp: 1696347733587
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
   sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
   md5: 82e4db6a498480a75d53c55bd35b6478
   depends:
@@ -3431,7 +3431,7 @@ packages:
   license_family: Other
   size: 1801397
   timestamp: 1681394807900
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -3440,7 +3440,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
   sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
   md5: 63b957927b9949ccb19da28ec4612706
   depends:
@@ -3451,7 +3451,7 @@ packages:
   license_family: BSD
   size: 30902
   timestamp: 1671751919031
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
   sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
   md5: e346257a2fa8e2cb48c762138a5d009b
   depends:
@@ -3461,7 +3461,7 @@ packages:
   license_family: BSD
   size: 39915
   timestamp: 1668168959656
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
   sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
   md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
   depends:
@@ -3470,7 +3470,7 @@ packages:
   license_family: BSD
   size: 3536231
   timestamp: 1654088937695
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
   sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
   md5: a1bbf0abfb8c45541122c0eb2feee317
   depends:
@@ -3479,7 +3479,7 @@ packages:
   license_family: Apache
   size: 680464
   timestamp: 1696937112175
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
   sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
   md5: d689f6203c0a9d04fb229c73d7e80a7a
   depends:
@@ -3492,7 +3492,7 @@ packages:
   license_family: MOZILLA
   size: 125145
   timestamp: 1679561909274
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
   md5: 8a292c1ee22489bef2e84bc3aaf4098e
   depends:
@@ -3501,7 +3501,7 @@ packages:
   license_family: BSD
   size: 193141
   timestamp: 1671143985219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
   md5: 8bf0bfffc11ad06a1c94e145941b0ad4
   depends:
@@ -3511,7 +3511,7 @@ packages:
   license_family: PSF
   size: 9651
   timestamp: 1690297655669
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
   md5: 343514a174b3485fde55a73f56398dd7
   depends:
@@ -3520,7 +3520,7 @@ packages:
   license_family: PSF
   size: 58456
   timestamp: 1690297648002
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
   sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
   md5: c2242e8fd24003a74ddf37416661e06d
   depends:
@@ -3535,7 +3535,7 @@ packages:
   license_family: MIT
   size: 188757
   timestamp: 1698257668273
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
   sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
   md5: 41f445e36b6b6722a9444508eef069f8
   depends:
@@ -3544,7 +3544,7 @@ packages:
   license_family: BSD
   size: 20583
   timestamp: 1607365395045
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
   sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
   md5: 409ee46ed24267b6da6fb32d13e1f21e
   depends:
@@ -3554,7 +3554,7 @@ packages:
   license_family: BSD
   size: 70730
   timestamp: 1614804271285
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
   sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
   md5: eb74e74d8e4fd533c55eb98b7b5e83bc
   depends:
@@ -3563,20 +3563,20 @@ packages:
   license_family: MIT
   size: 102637
   timestamp: 1695742077778
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
   sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
   md5: e243baa546432c8394a8059a44a5a3e4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 419227
   timestamp: 1683113010463
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
   sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
   md5: fe4ac85ee86d3a94ea3a4ebea3779763
   depends:
@@ -3585,7 +3585,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 321797
   timestamp: 1616055526986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
   sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
   md5: bc7073d9d4c0211cc4a1207c98fb765a
   depends:
@@ -3594,14 +3594,14 @@ packages:
   license_family: MIT
   size: 19091
   timestamp: 1672387204865
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
   sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
   md5: 8e495591e369ac161857a72011c0a296
   license: Zlib
   license_family: Other
   size: 120272
   timestamp: 1666595024203
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
   sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
   md5: f1465fbd810b3746c6de6babfd4fe28a
   depends:
@@ -3613,7 +3613,7 @@ packages:
   license_family: BSD
   size: 1023573
   timestamp: 1681304595869
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
   sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
   md5: cf55cb8d7031b30c70c56fc7c782b5c7
   depends:
@@ -3626,7 +3626,7 @@ packages:
   license_family: MIT
   size: 156104
   timestamp: 1644482799136
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
   sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
   md5: 84fce327d9f0d594e86f565e5c21962e
   depends:
@@ -3635,7 +3635,7 @@ packages:
   license_family: BSD
   size: 10183
   timestamp: 1629146082730
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
   sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
   md5: 84b8b998a741b37abf5312c1c03696ef
   depends:
@@ -3645,7 +3645,7 @@ packages:
   license_family: MIT
   size: 33979
   timestamp: 1644845817952
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
   sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
   md5: 77b746931c8f31c3ae393ccb5819d43d
   depends:
@@ -3654,7 +3654,7 @@ packages:
   license_family: MIT
   size: 133628
   timestamp: 1695717890677
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
   sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
   md5: 3df6e8ba34208dea068890e5d5318cc0
   depends:
@@ -3664,12 +3664,12 @@ packages:
   license_family: MIT
   size: 206759
   timestamp: 1681493095987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-2.4.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-2.4.3-py39hca03da5_0.tar.bz2
   sha256: 7926e4d65d56b72cbce30732a5e24b075c4a9893ddb0160b90d6d08104636e49
   md5: db35093fddb91beafe2274068cebee9f
   depends:
@@ -3685,7 +3685,7 @@ packages:
   license_family: BSD
   size: 14425917
   timestamp: 1658136781676
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
   sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
   md5: bb55f81435cb6e11d264242274fccd1a
   depends:
@@ -3695,7 +3695,7 @@ packages:
   license_family: BSD
   size: 115947
   timestamp: 1657175645380
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
   md5: f860193e14afc7ef3f5b990a2ac003d2
   depends:
@@ -3705,7 +3705,7 @@ packages:
   license: MIT
   size: 18936
   timestamp: 1659616204016
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
   sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
   md5: ad53130f3fd1f8d3c2fcbb7496e5585d
   depends:
@@ -3714,7 +3714,7 @@ packages:
   license: MIT
   size: 18715
   timestamp: 1659616188888
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
   sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
   md5: 0982c046fb976e9f9fb19e7510187a18
   depends:
@@ -3723,14 +3723,14 @@ packages:
   license: MIT
   size: 366983
   timestamp: 1659616245272
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
   sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
   md5: 31ac2f5596cb7a44adf073c930641c54
   license: MPL-2.0
   license_family: Other
   size: 133817
   timestamp: 1694009762858
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
   sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
   md5: cf1f6c3c34a1e1b9ab22b04233d860f6
   depends:
@@ -3739,7 +3739,7 @@ packages:
   license_family: Other
   size: 159783
   timestamp: 1690232303987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
   sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
   md5: 0eb268e38b5174d471a6e87d9d6102b1
   depends:
@@ -3750,7 +3750,7 @@ packages:
   license_family: MIT
   size: 225355
   timestamp: 1670423312966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
   sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
   md5: e68c94666cd60221b575c3814c89bac0
   depends:
@@ -3760,7 +3760,7 @@ packages:
   license_family: CC
   size: 1946451
   timestamp: 1668084573824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
   sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
   md5: 1773ae2b080cdd55827e27673351551e
   depends:
@@ -3770,7 +3770,7 @@ packages:
   license_family: BSD
   size: 13646
   timestamp: 1671231171682
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
   sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
   md5: 53bfd99ad1b09164d537209cffd98161
   depends:
@@ -3781,7 +3781,7 @@ packages:
   license_family: BSD
   size: 244040
   timestamp: 1663827469853
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
   sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
   md5: b62455043c8eb2434466885b19fed2de
   depends:
@@ -3794,7 +3794,7 @@ packages:
   license_family: BSD
   size: 1399573
   timestamp: 1694211828228
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
   sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
   md5: eb3cdc0fc210838b9271512a6a1b7c85
   depends:
@@ -3804,7 +3804,7 @@ packages:
   license_family: MIT
   size: 2067708
   timestamp: 1690905319109
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
   sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
   md5: f44b80b9405410e5bde6bfe0b31d5b3f
   depends:
@@ -3813,7 +3813,7 @@ packages:
   license_family: MIT
   size: 15135
   timestamp: 1650293774207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
   sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
   md5: f87027ccce1361d0f82c0edf1a10d53b
   depends:
@@ -3822,7 +3822,7 @@ packages:
   license_family: BSD
   size: 27677
   timestamp: 1668714367519
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -3832,14 +3832,14 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
   sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
   md5: 1d0bd7e576c64c059ef781dd319ad82a
   license: MIT
   license_family: MIT
   size: 77591
   timestamp: 1676983230102
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.15.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.15.3-py39hca03da5_0.tar.bz2
   sha256: 1d443901ba6ebeeadb1075590b00e6b747c1eee36da0481ecab78735b2335210
   md5: 8c837f31d918e77b82434379585a5cfb
   depends:
@@ -3859,7 +3859,7 @@ packages:
   license_family: BSD
   size: 4513741
   timestamp: 1671783108945
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
   sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
   md5: 69eb3b03765627b6159ed23cdde78396
   depends:
@@ -3868,7 +3868,7 @@ packages:
   license_family: MIT
   size: 28399065
   timestamp: 1692293207812
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
   sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
   md5: 83366cbd3beb073112f4644a613b6bca
   depends:
@@ -3877,7 +3877,7 @@ packages:
   license_family: BSD
   size: 111933
   timestamp: 1666125627512
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
   sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
   md5: 647c1a2f8460ffa8c670a1915bbdb494
   depends:
@@ -3887,7 +3887,7 @@ packages:
   license_family: APACHE
   size: 38790
   timestamp: 1678997152549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
   sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
   md5: 35e541905426c686ef2ff010a0e502fd
   depends:
@@ -3897,7 +3897,7 @@ packages:
   license_family: Apache
   size: 51860
   timestamp: 1698254731870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
   sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
   md5: 187d7720aedf38759d122cccb4576f2c
   depends:
@@ -3919,7 +3919,7 @@ packages:
   license_family: BSD
   size: 219976
   timestamp: 1691121991680
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
   sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
   md5: e8e7f10741f9cfa737b310b334940441
   depends:
@@ -3941,7 +3941,7 @@ packages:
   license_family: BSD
   size: 1255894
   timestamp: 1694181494549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
   sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
   md5: ff209e75aee17af2e358b0008fbe8c88
   depends:
@@ -3951,7 +3951,7 @@ packages:
   license_family: MIT
   size: 1022945
   timestamp: 1644315931223
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
   sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
   md5: d3e78ef296b3c74910d003bd10b475d6
   depends:
@@ -3961,14 +3961,14 @@ packages:
   license_family: BSD
   size: 213972
   timestamp: 1666908195870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
   sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
   md5: 055e12390b844ea6c6e956ee08a618e8
   license: IJG
   license_family: Other
   size: 273479
   timestamp: 1677849171867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
   sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
   md5: 783e2ad3d36472648c5ccc9f3051db3c
   depends:
@@ -3979,7 +3979,7 @@ packages:
   license_family: MIT
   size: 133077
   timestamp: 1676558732505
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
   sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
   md5: 0677598f673f9729b5990316170a999d
   depends:
@@ -3995,7 +3995,7 @@ packages:
   license_family: BSD
   size: 197129
   timestamp: 1676329661580
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
   sha256: 05f9ca0fdcfdc2e217438be27fead588c843a3aadf7d034467c83216d1e5c214
   md5: 2d648b77d817ba38293c0728711ba8f5
   depends:
@@ -4006,7 +4006,7 @@ packages:
   license_family: BSD
   size: 92852
   timestamp: 1679906632236
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
   sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
   md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
   depends:
@@ -4030,7 +4030,7 @@ packages:
   license_family: BSD
   size: 401319
   timestamp: 1671707682572
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
   sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
   md5: 247558a0aecf1ef7e77a4343761353d6
   depends:
@@ -4040,7 +4040,7 @@ packages:
   license_family: BSD
   size: 64600
   timestamp: 1672387273585
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -4050,7 +4050,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -4059,13 +4059,13 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
   md5: a0f206782751dfffed0dd51302a1bf26
   license: MIT
   size: 68012
   timestamp: 1659616138077
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
   md5: 4c6667cdd061d28e9bc4e4300e4d115e
   depends:
@@ -4073,7 +4073,7 @@ packages:
   license: MIT
   size: 31173
   timestamp: 1659616155596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
   md5: 637e9430e258ddf050623ef2360184d8
   depends:
@@ -4081,28 +4081,28 @@ packages:
   license: MIT
   size: 298430
   timestamp: 1659616172209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
   sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
   md5: 55c615026c0869f8d3ba657f3bd38c43
   license: MIT
   license_family: MIT
   size: 120389
   timestamp: 1683716579036
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -4111,7 +4111,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -4122,14 +4122,14 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
   sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
   md5: a41117710dafe569c9cc4e83f6f29fe3
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1411339
   timestamp: 1650982753977
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -4140,7 +4140,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -4149,13 +4149,13 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -4172,7 +4172,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
   sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
   md5: 98d22e0124d55fae3c37c608dab1dcc9
   depends:
@@ -4186,7 +4186,7 @@ packages:
   license_family: BSD
   size: 89825
   timestamp: 1694778225280
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
   sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
   md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
   constrains:
@@ -4195,7 +4195,7 @@ packages:
   license_family: BSD
   size: 331675
   timestamp: 1694776939192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
   sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
   md5: 0ba499df6755eae5d2d23aa4ab004553
   depends:
@@ -4207,7 +4207,7 @@ packages:
   license_family: MIT
   size: 642657
   timestamp: 1692970217410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
   sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
   md5: c73101971e5ab6a8e8688239884eac81
   depends:
@@ -4217,7 +4217,7 @@ packages:
   license_family: MIT
   size: 241607
   timestamp: 1692973585084
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -4226,7 +4226,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
   sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
   md5: 353dff9d5d996c2a260f66381b2ce3e8
   depends:
@@ -4237,7 +4237,7 @@ packages:
   license_family: Other
   size: 1470815
   timestamp: 1695058433965
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
   sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
   md5: c99006da802a97c9aae30da8c16b4820
   depends:
@@ -4246,7 +4246,7 @@ packages:
   license_family: BSD
   size: 176131
   timestamp: 1670944706815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
   sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
   md5: 60bd1e037cda86205526f77405d78129
   depends:
@@ -4256,7 +4256,7 @@ packages:
   license_family: BSD
   size: 123361
   timestamp: 1671541992772
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
   sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
   md5: 34dfd76da78de2eae95bbda390d746d6
   depends:
@@ -4267,7 +4267,7 @@ packages:
   license_family: BSD
   size: 23092
   timestamp: 1654598007056
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.7.2-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.7.2-py39h46d7db6_0.tar.bz2
   sha256: b7b71b39d154fd61dba887e03a2111d1ab8e49b471e2e5a87ce49d7010bcdd6c
   md5: 827a271d1eefd47e86e212d785b15fcd
   depends:
@@ -4290,7 +4290,7 @@ packages:
   license_family: PSF
   size: 7935161
   timestamp: 1693812618061
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
   sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
   md5: eb79dabbeedee7da85dfbfb145bb8a26
   depends:
@@ -4300,7 +4300,7 @@ packages:
   license_family: BSD
   size: 17342
   timestamp: 1662014601345
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
   sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
   md5: 56db7bd3ff511cd839bda081523b3edd
   depends:
@@ -4309,7 +4309,7 @@ packages:
   license_family: BSD
   size: 55683
   timestamp: 1629356128780
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
   sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
   md5: 176e0dcaeb28393881bacf69941e3889
   depends:
@@ -4335,7 +4335,7 @@ packages:
   license_family: BSD
   size: 8289638
   timestamp: 1681756329011
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
   sha256: afc6f332c51a3defc69e4c4e641988c0556039b9cd42be22f3db5292c88ccf37
   md5: 2bc409c7258160a9b739d08d5ffb5998
   depends:
@@ -4348,7 +4348,7 @@ packages:
   license_family: BSD
   size: 96942
   timestamp: 1650373637069
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
   sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
   md5: 150ea9fadddf21993d3328d3e48a18b7
   depends:
@@ -4376,7 +4376,7 @@ packages:
   license_family: BSD
   size: 557688
   timestamp: 1668450759059
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
   sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
   md5: 37163b32508f9f589b3e6462a3a47546
   depends:
@@ -4389,14 +4389,14 @@ packages:
   license_family: BSD
   size: 148426
   timestamp: 1694616771736
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
   sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
   md5: 6cdf7cbc43bf40e92b056a5576bd0086
   depends:
@@ -4405,7 +4405,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387216468
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.2-py39hca03da5_0.tar.bz2
   sha256: 1d6fd0252649eb318e6d3c5830b70d90cd4661e571e93271a6aa4e456c5dd17f
   md5: e113ccf02cbc861cae60311efc0c6b4f
   depends:
@@ -4430,7 +4430,7 @@ packages:
   license_family: BSD
   size: 514962
   timestamp: 1668179928420
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
   sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
   md5: 7de782e4fb34bfa95ef2fc79d27d727d
   depends:
@@ -4440,7 +4440,7 @@ packages:
   license_family: BSD
   size: 22840
   timestamp: 1668160634885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
   sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
   md5: 1a7b23113372c5667dbfe45976b9cc5c
   depends:
@@ -4451,7 +4451,7 @@ packages:
   license_family: MIT
   size: 126357
   timestamp: 1696515322390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.22.3-py39h25ab29e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.22.3-py39h25ab29e_0.tar.bz2
   sha256: fd57c9e37203025e56a8385455f4551dae96e3f0f8ca066c7b125c53c1b3e071
   md5: 7c80ee34c22620f29ba8e9c5e9cf31ff
   depends:
@@ -4463,7 +4463,7 @@ packages:
   license: BSD-3-Clause
   size: 10740
   timestamp: 1652801810602
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.22.3-py39h974a1f5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.22.3-py39h974a1f5_0.tar.bz2
   sha256: 1015638dedb768465a55775445926b3d408994d5b58268a460739bd253288cf3
   md5: 00fced2d07d02ffef0d6378fb1dae193
   depends:
@@ -4476,7 +4476,7 @@ packages:
   license: BSD-3-Clause
   size: 6067353
   timestamp: 1652801779788
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
   sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
   md5: 371358a54bbdd307603888348d1a2c6f
   depends:
@@ -4486,7 +4486,7 @@ packages:
   license: BSD 2-Clause
   size: 412248
   timestamp: 1628861367714
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
   sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
   md5: fa15d3b44ae1360ac9b640bbd5b6923c
   depends:
@@ -4495,7 +4495,7 @@ packages:
   license_family: Apache
   size: 4746123
   timestamp: 1695322833432
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
   sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
   md5: d73db95f07a282021efdf8bc09713261
   depends:
@@ -4504,7 +4504,7 @@ packages:
   license_family: Apache
   size: 73620
   timestamp: 1693575195999
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-1.4.4-py39hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-1.4.4-py39hc377ac9_0.tar.bz2
   sha256: 64a5c7f7365b8c837621daeeef7e9b5341829768cb89f72026e6827a75e677b6
   md5: ef101f092953ed17f9f0b7efa2a3cb03
   depends:
@@ -4519,7 +4519,7 @@ packages:
   license_family: BSD
   size: 12433056
   timestamp: 1663773462190
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-0.14.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-0.14.3-py39hca03da5_0.tar.bz2
   sha256: cb0fd0d862204d53fcd866cbe971602c3e7be58d5cc8f9dde2fd3cdf9376439e
   md5: 274366470779c9c9a91141a769c8457f
   depends:
@@ -4540,7 +4540,7 @@ packages:
   license_family: BSD
   size: 14650720
   timestamp: 1676379977310
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
   sha256: 0d64f2438be25524bbfeb8646e4fb3c18499d747398a03ed15d41b350b03e001
   md5: 6a4908a5c9f7b3f17f09ebc34b1b691c
   depends:
@@ -4549,7 +4549,7 @@ packages:
   license_family: BSD
   size: 142857
   timestamp: 1684915417403
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
   sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
   md5: 6e01c592ae3b8ff2d12cae76f2f4276b
   depends:
@@ -4568,7 +4568,7 @@ packages:
   license_family: Other
   size: 715239
   timestamp: 1696580071596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
   sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
   md5: 9fb8f460c130d56caf33c6bbe46fbe8a
   depends:
@@ -4579,7 +4579,7 @@ packages:
   license_family: MIT
   size: 2678841
   timestamp: 1697548790931
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
   sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
   md5: 390b8c3cd74281abecdbfd51476922f9
   depends:
@@ -4588,7 +4588,7 @@ packages:
   license_family: MIT
   size: 33033
   timestamp: 1692205747301
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
   sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
   md5: 7896828fb3565fefad43f980d50c8723
   depends:
@@ -4597,7 +4597,7 @@ packages:
   license_family: Apache
   size: 91190
   timestamp: 1659455206354
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
   sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
   md5: d934c74eb66d01af0f45f0881f4bab77
   depends:
@@ -4609,7 +4609,7 @@ packages:
   license_family: BSD
   size: 580588
   timestamp: 1672387390426
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
   sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
   md5: 9858166e5ffb624c8b9d281f4000d725
   depends:
@@ -4618,7 +4618,7 @@ packages:
   license_family: BSD
   size: 367167
   timestamp: 1656431368885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
   sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
   md5: 4d2b45c6be8221e6a3e44c2d5838426f
   depends:
@@ -4630,7 +4630,7 @@ packages:
   license_family: BSD
   size: 30843
   timestamp: 1675441531640
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
   sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
   md5: 02521df4e2e79f75faa9cbb3560ab1dd
   depends:
@@ -4639,7 +4639,7 @@ packages:
   license_family: BSD
   size: 1861763
   timestamp: 1684280026169
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
   sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
   md5: bdebe59bffc7adbad83fdcd9d429a5f5
   depends:
@@ -4649,7 +4649,7 @@ packages:
   license_family: Apache
   size: 95234
   timestamp: 1690223494699
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
   sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
   md5: d716e5c9b5eec45ce1df8eb52cab817a
   depends:
@@ -4658,7 +4658,7 @@ packages:
   license_family: MIT
   size: 157408
   timestamp: 1661452601692
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
   sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
   md5: 1907629863ed8e7c35ead232dae7693f
   depends:
@@ -4667,7 +4667,7 @@ packages:
   license_family: MIT
   size: 91636
   timestamp: 1628941083263
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
   sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
   md5: 847b9bddf2a86e1609c0d53bbc23ea79
   depends:
@@ -4676,7 +4676,7 @@ packages:
   license_family: BSD
   size: 27378
   timestamp: 1626781391140
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
   sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
   md5: 18aa18bd0d260605923877921d26cc74
   depends:
@@ -4695,7 +4695,7 @@ packages:
   license_family: PSF
   size: 13194025
   timestamp: 1694438901368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
   sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
   md5: 45642a99c83e7aed74d1ffab1f20145b
   depends:
@@ -4704,7 +4704,7 @@ packages:
   license_family: BSD
   size: 266647
   timestamp: 1661368655993
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
   sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
   md5: fec748525144049a2fc7f52f9755232c
   depends:
@@ -4713,7 +4713,7 @@ packages:
   license_family: MIT
   size: 257235
   timestamp: 1695131702047
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
   sha256: 960192a143672e9c1d6fe4027af448512d91eee7501e5c245c21b865cf8bf429
   md5: 76d491244218505f071ba56a308673df
   depends:
@@ -4723,7 +4723,7 @@ packages:
   license_family: BSD
   size: 40950
   timestamp: 1685030774581
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
   sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
   md5: 3445d25415998c807efbe64d3a7e03c8
   depends:
@@ -4733,7 +4733,7 @@ packages:
   license_family: MIT
   size: 167068
   timestamp: 1698096118071
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
   sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
   md5: e6e92da28e9b0e428ed4b7df417bec25
   depends:
@@ -4744,7 +4744,7 @@ packages:
   license_family: BSD
   size: 472418
   timestamp: 1657724315435
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -4753,7 +4753,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
   sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
   md5: dba22515f36d3c266de5896350813ea2
   depends:
@@ -4769,7 +4769,7 @@ packages:
   license_family: Apache
   size: 95103
   timestamp: 1690400315537
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
   sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
   md5: 3cd7eb43e285faba76faf67667e26b00
   depends:
@@ -4778,7 +4778,7 @@ packages:
   license_family: MIT
   size: 1093916
   timestamp: 1690290951258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
   sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
   md5: c5e9aef0d6895de1c927e9d796cd7cd3
   depends:
@@ -4787,7 +4787,7 @@ packages:
   license_family: Apache
   size: 15691
   timestamp: 1629145910454
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
   sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
   md5: 0f7c229e774146ffc4e29dedf75372bf
   depends:
@@ -4796,7 +4796,7 @@ packages:
   license_family: MIT
   size: 67279
   timestamp: 1696347632563
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
   sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
   md5: 2302a79a045f152e183a52a81adfba62
   depends:
@@ -4808,7 +4808,7 @@ packages:
   license_family: Other
   size: 1674163
   timestamp: 1681394762218
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
   sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
   md5: 4ae67163d55cf9df83d4027ebc38c501
   depends:
@@ -4819,7 +4819,7 @@ packages:
   license_family: BSD
   size: 30894
   timestamp: 1671751931536
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
   sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
   md5: dbb5c0cddb6661a89afee647fd3dc01e
   depends:
@@ -4829,7 +4829,7 @@ packages:
   license_family: BSD
   size: 39875
   timestamp: 1668168874870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
   sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
   md5: 667e60c8b407d73cbba40f44901f4f00
   depends:
@@ -4838,7 +4838,7 @@ packages:
   license_family: BSD
   size: 3412693
   timestamp: 1654088929697
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
   sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
   md5: 884f788a5f6a664c9b79f7a4a60362d0
   depends:
@@ -4847,7 +4847,7 @@ packages:
   license_family: Apache
   size: 680561
   timestamp: 1696937004165
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
   sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
   md5: 639a4f489af172c866c18442948e5874
   depends:
@@ -4860,7 +4860,7 @@ packages:
   license_family: MOZILLA
   size: 125170
   timestamp: 1679561942932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
   sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
   md5: e5b90eba83fddba6d7aa6072b5bf7c91
   depends:
@@ -4869,7 +4869,7 @@ packages:
   license_family: BSD
   size: 193017
   timestamp: 1671143921826
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
   md5: 644ef8830437070f60efcfcd6a987198
   depends:
@@ -4879,7 +4879,7 @@ packages:
   license_family: PSF
   size: 9670
   timestamp: 1690297532002
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
   md5: a902a833bb186a2f1a4b2b89b1195136
   depends:
@@ -4888,7 +4888,7 @@ packages:
   license_family: PSF
   size: 58466
   timestamp: 1690297524418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
   sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
   md5: f3f1d2c1028dad2f11ff950a15c99dbf
   depends:
@@ -4903,7 +4903,7 @@ packages:
   license_family: MIT
   size: 188640
   timestamp: 1698257577209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
   sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
   md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
   depends:
@@ -4912,7 +4912,7 @@ packages:
   license_family: BSD
   size: 20091
   timestamp: 1629144441130
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
   sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
   md5: 3089c63bf8f4d0423e1a287da286d83e
   depends:
@@ -4922,7 +4922,7 @@ packages:
   license_family: BSD
   size: 70923
   timestamp: 1629357115820
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
   sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
   md5: 5886b30b312445471268444f41f39dc7
   depends:
@@ -4931,20 +4931,20 @@ packages:
   license_family: MIT
   size: 102583
   timestamp: 1695741976083
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
   sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
   md5: 2e75ad6a09c308268192efe03cc9ebf4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 411778
   timestamp: 1683113019715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
   sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
   md5: 30f666bf97c26587c5d2f68cc5f330ab
   depends:
@@ -4953,7 +4953,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 316901
   timestamp: 1629287855861
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
   sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
   md5: 584e591d36dcd5ba5c45404f0f7ebb2d
   depends:
@@ -4962,14 +4962,14 @@ packages:
   license_family: MIT
   size: 19076
   timestamp: 1672387153578
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
   sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
   md5: 467ae28215d1aa1c5688bc0c8a184269
   license: Zlib
   license_family: Other
   size: 103525
   timestamp: 1666595022664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
   sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
   md5: 7cfbed15f1feee1422810f7830075f53
   depends:
@@ -4981,7 +4981,7 @@ packages:
   license_family: BSD
   size: 779464
   timestamp: 1681304594848
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
   sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
   md5: ed14f9bc6e55220483f1a5a388625a08
   depends:
@@ -4994,7 +4994,7 @@ packages:
   license_family: MIT
   size: 162772
   timestamp: 1644481986085
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
   sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
   md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
   depends:
@@ -5006,7 +5006,7 @@ packages:
   license_family: MIT
   size: 39253
   timestamp: 1644551767970
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
   sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
   md5: b24d13c443a26f65a0778b475a5726bc
   depends:
@@ -5015,7 +5015,7 @@ packages:
   license_family: MIT
   size: 132830
   timestamp: 1695717959996
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
   sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
   md5: 302c3c0696e17eaa62e140e3892644ae
   depends:
@@ -5025,12 +5025,12 @@ packages:
   license_family: MIT
   size: 199723
   timestamp: 1681493196911
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-2.4.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-2.4.3-py39haa95532_0.tar.bz2
   sha256: a8150eba2526f695999bf260643c51779153bece456d86bb5ceaf2320dc28436
   md5: af8143c21529c930f9d54b9fa12df1f9
   depends:
@@ -5046,7 +5046,7 @@ packages:
   license_family: BSD
   size: 14460067
   timestamp: 1658137245730
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
   sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
   md5: bf930260f679bc74227bbb18bc36ae82
   depends:
@@ -5058,7 +5058,7 @@ packages:
   license_family: BSD
   size: 119700
   timestamp: 1657176150595
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
   md5: 507dfe693ef429f466d964b599f4af21
   depends:
@@ -5070,7 +5070,7 @@ packages:
   license: MIT
   size: 18650
   timestamp: 1659616328001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
   md5: d0bf43e8df60baae3b3105aa5c42a791
   depends:
@@ -5081,7 +5081,7 @@ packages:
   license: MIT
   size: 21153
   timestamp: 1659616312367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
   sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
   md5: 7bd24bf94c24e810aecaaf84a0978e6f
   depends:
@@ -5091,14 +5091,14 @@ packages:
   license: MIT
   size: 343204
   timestamp: 1659616543542
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
   sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
   md5: 092b417c11edcbe6bb9b765ab4a55d23
   license: MPL-2.0
   license_family: Other
   size: 164999
   timestamp: 1694009822357
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
   sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
   md5: 708a750d370b9d6875651021e21c4446
   depends:
@@ -5107,7 +5107,7 @@ packages:
   license_family: Other
   size: 159322
   timestamp: 1690232335307
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
   sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
   md5: c35736da3ea26782425e78061268cf5e
   depends:
@@ -5119,7 +5119,7 @@ packages:
   license_family: MIT
   size: 228713
   timestamp: 1670423312743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
   sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
   md5: 457a4339a53c033d48ce0c72e5038d2e
   depends:
@@ -5128,7 +5128,7 @@ packages:
   license_family: BSD
   size: 30330
   timestamp: 1672387265402
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
   sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
   md5: 59ec65fd9e06b81a65cc12986c67d5da
   depends:
@@ -5138,7 +5138,7 @@ packages:
   license_family: CC
   size: 1939614
   timestamp: 1668084794027
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
   sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
   md5: 3489c1a2b73fc957b5a62cc59349e25b
   depends:
@@ -5148,7 +5148,7 @@ packages:
   license_family: BSD
   size: 13438
   timestamp: 1671231196438
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
   sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
   md5: 3492b96083c1e904cc32d26ea7f1e1d8
   depends:
@@ -5160,7 +5160,7 @@ packages:
   license_family: BSD
   size: 184280
   timestamp: 1663827558327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
   sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
   md5: f46d904bc6f220327e70474971341f52
   depends:
@@ -5175,7 +5175,7 @@ packages:
   license_family: BSD
   size: 1220835
   timestamp: 1694445639066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
   sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
   md5: 2ff4fb509788b0e47ac684ba151394d0
   depends:
@@ -5186,7 +5186,7 @@ packages:
   license_family: MIT
   size: 3289966
   timestamp: 1690907040646
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
   sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
   md5: 0f166c3e70541d8bee6e9d0cb60fb66e
   depends:
@@ -5195,7 +5195,7 @@ packages:
   license_family: MIT
   size: 16979
   timestamp: 1649926678161
-- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
   sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
   md5: ea93d413944ca6a8677eb1b284b136ae
   depends:
@@ -5204,7 +5204,7 @@ packages:
   license_family: BSD
   size: 27388
   timestamp: 1668714577678
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -5216,7 +5216,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
   sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
   md5: 9f167d3e45441bc3633c1974b1b0ce8c
   depends:
@@ -5226,7 +5226,7 @@ packages:
   license_family: MIT
   size: 88421
   timestamp: 1676983264486
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.15.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.15.3-py39haa95532_0.tar.bz2
   sha256: b4ec747508b48b8f660ac4569d1a5fd2956673d2a3b82287c42d8ad5710008c4
   md5: 1ae2dc42ab5a058f691716ddc5c890e6
   depends:
@@ -5246,7 +5246,7 @@ packages:
   license_family: BSD
   size: 4464293
   timestamp: 1671783118101
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
   sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
   md5: 30fdefd1541c789c163751291a8faa88
   depends:
@@ -5255,7 +5255,7 @@ packages:
   license_family: BSD
   size: 111448
   timestamp: 1666125667599
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
   sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
   md5: a10f07c7a3510272a296f9fed458a4ed
   depends:
@@ -5265,7 +5265,7 @@ packages:
   license_family: APACHE
   size: 38098
   timestamp: 1678997241511
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
   sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
   md5: fad9cf2023d807da8d44996e9d4399a0
   depends:
@@ -5275,7 +5275,7 @@ packages:
   license_family: Apache
   size: 51490
   timestamp: 1698254721864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
   sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
   md5: 9834848bd7c7759acf12e78d09388563
   depends:
@@ -5285,7 +5285,7 @@ packages:
   license_family: Proprietary
   size: 3891030
   timestamp: 1681801474383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
   sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
   md5: 1285c8c628bc912c54d0968574c9f4c9
   depends:
@@ -5306,7 +5306,7 @@ packages:
   license_family: BSD
   size: 217232
   timestamp: 1691122695748
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
   sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
   md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
   depends:
@@ -5327,7 +5327,7 @@ packages:
   license_family: BSD
   size: 1279433
   timestamp: 1694181820978
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
   sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
   md5: f5fcce35d3f21cdfc5893c5a7a86c651
   depends:
@@ -5337,7 +5337,7 @@ packages:
   license_family: MIT
   size: 1035394
   timestamp: 1644315567034
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
   sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
   md5: f67fe3337528e2886f1ac3ab8ac37985
   depends:
@@ -5347,7 +5347,7 @@ packages:
   license_family: BSD
   size: 213110
   timestamp: 1666908350218
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
   sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
   md5: 81f2c343dc4c65eea39c45383272068f
   depends:
@@ -5357,7 +5357,7 @@ packages:
   license_family: Other
   size: 407861
   timestamp: 1677849239400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
   sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
   md5: bd9526d38a145fe311a8aa36bc11e071
   depends:
@@ -5368,7 +5368,7 @@ packages:
   license_family: MIT
   size: 152006
   timestamp: 1676558783570
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
   sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
   md5: a00e6a62956fde3c4135464353ee8a53
   depends:
@@ -5384,7 +5384,7 @@ packages:
   license_family: BSD
   size: 229158
   timestamp: 1676330909084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
   sha256: db8335d6531b03c7bdfe789ebacc52631ac6ea4a37700bb3da1f6a53a1acd724
   md5: ebeba61994cc225ea5f4f42caa511019
   depends:
@@ -5396,7 +5396,7 @@ packages:
   license_family: BSD
   size: 116681
   timestamp: 1679906658986
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
   sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
   md5: 5efa1332f7c0a8d9638eda02170c4ce5
   depends:
@@ -5421,7 +5421,7 @@ packages:
   license_family: BSD
   size: 413653
   timestamp: 1671707957673
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
   sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
   md5: 891fe66a24d8714737b2874985ee1303
   depends:
@@ -5432,7 +5432,7 @@ packages:
   license_family: BSD
   size: 62298
   timestamp: 1672388166096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -5442,7 +5442,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
   sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
   md5: c345f51706eef530454f66b794e5e574
   depends:
@@ -5451,7 +5451,7 @@ packages:
   license: MIT
   size: 68189
   timestamp: 1659616216976
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
   md5: a7400cfb72042977bc047909ed504ce8
   depends:
@@ -5461,7 +5461,7 @@ packages:
   license: MIT
   size: 33743
   timestamp: 1659616248209
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
   md5: 6307f6854754ab5bd7c84e6998385bb1
   depends:
@@ -5471,7 +5471,7 @@ packages:
   license: MIT
   size: 733177
   timestamp: 1659616279453
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -5481,7 +5481,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
   sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
   md5: b812bc5d9c76242e2bb2ac87afe7d39b
   depends:
@@ -5491,7 +5491,7 @@ packages:
   license_family: GPL3
   size: 730280
   timestamp: 1650983734373
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -5502,7 +5502,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -5511,7 +5511,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -5528,7 +5528,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
   sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
   md5: ba9418df9288a2f031a02fa35b774ce0
   depends:
@@ -5544,7 +5544,7 @@ packages:
   license_family: BSD
   size: 78524
   timestamp: 1694778314659
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
   sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
   md5: b1781519a200ccbfcb4a1194005aa3ef
   depends:
@@ -5556,7 +5556,7 @@ packages:
   license_family: BSD
   size: 338459
   timestamp: 1694777084290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
   sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
   md5: 6ece7f1a3248169837714d05d7f6ef0a
   depends:
@@ -5568,7 +5568,7 @@ packages:
   license_family: MIT
   size: 3513910
   timestamp: 1692971505729
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
   sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
   md5: bd7ec244935e83e850a4ff34e8e2e64f
   depends:
@@ -5579,7 +5579,7 @@ packages:
   license_family: MIT
   size: 513971
   timestamp: 1692973657152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
   sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
   md5: fb7881e74b59262df0fa4ec981964efc
   depends:
@@ -5592,7 +5592,7 @@ packages:
   license_family: Other
   size: 1244887
   timestamp: 1695058550693
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
   sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
   md5: 6970c7f46b0164cad1d210e7a1419959
   depends:
@@ -5602,7 +5602,7 @@ packages:
   license_family: BSD
   size: 143434
   timestamp: 1670944902624
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
   sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
   md5: 1015298551c040c6d5e26eebbae12ef5
   depends:
@@ -5612,7 +5612,7 @@ packages:
   license_family: BSD
   size: 142316
   timestamp: 1671542240512
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
   sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
   md5: 466da740fafef3d6bce114220f0be306
   depends:
@@ -5625,7 +5625,7 @@ packages:
   license_family: BSD
   size: 28510
   timestamp: 1654508162239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.7.2-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.7.2-py39h4ed8f06_0.tar.bz2
   sha256: e2d6d88886fb6c1e669fd016b46ecb9bf29ae5d6da5a801044370afd17c38c1b
   md5: 04601ee54cd0bd3ebe755b81106397bd
   depends:
@@ -5649,7 +5649,7 @@ packages:
   license_family: PSF
   size: 7936938
   timestamp: 1693813261086
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
   sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
   md5: a9fa43e694b25cd49b8b08a9eefd696e
   depends:
@@ -5659,7 +5659,7 @@ packages:
   license_family: BSD
   size: 18054
   timestamp: 1661915903969
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
   sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
   md5: 248c468abced874f0231d3cc23177c77
   depends:
@@ -5670,7 +5670,7 @@ packages:
   license_family: BSD
   size: 58488
   timestamp: 1607359497934
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
   sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
   md5: 5e763c995ff0c549f68a10bce70fede4
   depends:
@@ -5682,7 +5682,7 @@ packages:
   license_family: Proprietary
   size: 187489950
   timestamp: 1691503804820
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
   sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
   md5: dd0c2ece6a743c373c9b5a5919b4818f
   depends:
@@ -5694,7 +5694,7 @@ packages:
   license_family: BSD
   size: 49744
   timestamp: 1682975040154
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
   sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
   md5: 57cea8df7ab85f2a98f64d23afcb1f90
   depends:
@@ -5709,7 +5709,7 @@ packages:
   license_family: BSD
   size: 184956
   timestamp: 1695058491736
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
   sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
   md5: 8769cdd201d905069800488fe31574e5
   depends:
@@ -5724,7 +5724,7 @@ packages:
   license_family: BSD
   size: 256221
   timestamp: 1695060152521
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
   sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
   md5: d9781492332e6326f9fca87f3a8efacd
   depends:
@@ -5750,7 +5750,7 @@ packages:
   license_family: BSD
   size: 8135792
   timestamp: 1681756491399
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
   sha256: 2dd3178d3c570e30b9490ebabfd7bfac806afad8302d3dee0edc619805034397
   md5: bef9da0f0694c45b6aaa4e6447479eaf
   depends:
@@ -5763,7 +5763,7 @@ packages:
   license_family: BSD
   size: 118324
   timestamp: 1650290466135
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
   sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
   md5: f1d8ce412e115986c403f223b3b47d0f
   depends:
@@ -5791,7 +5791,7 @@ packages:
   license_family: BSD
   size: 596314
   timestamp: 1668451106600
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
   sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
   md5: f96bbef0985d7e66ebf00c0d55e30e23
   depends:
@@ -5804,7 +5804,7 @@ packages:
   license_family: BSD
   size: 167045
   timestamp: 1694617078743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
   sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
   md5: 6e6ba64c8dc5025aeac606404a8df36a
   depends:
@@ -5813,7 +5813,7 @@ packages:
   license_family: BSD
   size: 13786
   timestamp: 1672387480065
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.2-py39haa95532_0.tar.bz2
   sha256: 434ad797fda12fc09b467e16f587fca1de155b71d183c72e831e93944e9b93dd
   md5: 6666362eb1ef4397e0e222e20445b856
   depends:
@@ -5838,7 +5838,7 @@ packages:
   license_family: BSD
   size: 554826
   timestamp: 1668180355143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
   sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
   md5: 4269a1f93882205b90d4b2ae78fc82d5
   depends:
@@ -5848,7 +5848,7 @@ packages:
   license_family: BSD
   size: 22417
   timestamp: 1668160717305
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
   sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
   md5: a18a576b7024cfd6f905c526a786a916
   depends:
@@ -5863,7 +5863,7 @@ packages:
   license_family: MIT
   size: 135285
   timestamp: 1696515698492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.22.3-py39h6917f2d_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.22.3-py39h6917f2d_2.tar.bz2
   sha256: b70978e0e60c26074991b1652747d612827754378f058adf2715138899002d60
   md5: 70469e853bc618c24e9915052f971fd7
   depends:
@@ -5879,7 +5879,7 @@ packages:
   license: BSD-3-Clause
   size: 10601
   timestamp: 1682981321777
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.22.3-py39h46c4fa8_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.22.3-py39h46c4fa8_2.tar.bz2
   sha256: 21ea94d97361abfb0ac5197b6ac020253657c0033ceaea6fb18713fb9cf9f58d
   md5: b3b783e57bd203378d2124c7e171e5e3
   depends:
@@ -5894,7 +5894,7 @@ packages:
   license: BSD-3-Clause
   size: 6403234
   timestamp: 1682981297386
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
   sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
   md5: ab07e2a27ac08afe3d0b4c0890b8486a
   depends:
@@ -5905,7 +5905,7 @@ packages:
   license: BSD 2-Clause
   size: 249316
   timestamp: 1630094024143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
   sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
   md5: 73b17037d87b5a58feb34dafc0538f7f
   depends:
@@ -5916,7 +5916,7 @@ packages:
   license_family: Apache
   size: 8058396
   timestamp: 1695324589828
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
   sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
   md5: df1d746ba8d5d6ba01ac1373b9b71e1a
   depends:
@@ -5925,7 +5925,7 @@ packages:
   license_family: Apache
   size: 73016
   timestamp: 1693575484990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-1.4.4-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-1.4.4-py39hd77b12b_0.tar.bz2
   sha256: d81d8ef52a07a9cd294e98d4e069ad86f990cfe3b3064bfde540a3f04e0ee9a4
   md5: 25de49536214af419d337679d8040cba
   depends:
@@ -5941,7 +5941,7 @@ packages:
   license_family: BSD
   size: 11584490
   timestamp: 1663773415594
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-0.14.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-0.14.3-py39haa95532_0.tar.bz2
   sha256: 00a343d88532d207ef3f8387af638b82608a8904ef11c9a1495693bb4658c49a
   md5: 0f761c1e7e55d96c6504348291a2d7c4
   depends:
@@ -5962,7 +5962,7 @@ packages:
   license_family: BSD
   size: 14717609
   timestamp: 1676380051970
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
   sha256: 2773f47b2d745ab483cf7fcbd5b5e2f7020d45462d32d2ccd5cf232ca13c6f67
   md5: ca16cd208037bd58d2da267c338da4a4
   depends:
@@ -5971,7 +5971,7 @@ packages:
   license_family: BSD
   size: 142229
   timestamp: 1684915524241
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
   sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
   md5: 427c1450bebb632f43bbc8c83006e4cd
   depends:
@@ -5990,7 +5990,7 @@ packages:
   license_family: Other
   size: 806931
   timestamp: 1696580240310
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
   sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
   md5: 21790cd3e2b8a45c4104aff0a68330d0
   depends:
@@ -6001,7 +6001,7 @@ packages:
   license_family: MIT
   size: 3001751
   timestamp: 1697549357662
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
   sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
   md5: 56f44a1054da2d10777e375838191070
   depends:
@@ -6010,7 +6010,7 @@ packages:
   license_family: MIT
   size: 32355
   timestamp: 1692205784293
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
   sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
   md5: 8a35ad65651086575ce55371f22feda8
   depends:
@@ -6019,7 +6019,7 @@ packages:
   license_family: Apache
   size: 91045
   timestamp: 1659455316472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
   sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
   md5: 186eb95f816a2eff80c3c7f7d964c7b0
   depends:
@@ -6031,7 +6031,7 @@ packages:
   license_family: BSD
   size: 578514
   timestamp: 1672388155359
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
   sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
   md5: 47b6cbe6ce9289e47d16900b03596a91
   depends:
@@ -6042,7 +6042,7 @@ packages:
   license_family: BSD
   size: 372807
   timestamp: 1656431445633
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
   sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
   md5: 07165c444adc7c7ccc8a345875adc5ef
   depends:
@@ -6054,7 +6054,7 @@ packages:
   license_family: BSD
   size: 48408
   timestamp: 1675450623287
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
   sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
   md5: d58e76a31e2f6e7410ba4afd7f385b0d
   depends:
@@ -6063,7 +6063,7 @@ packages:
   license_family: BSD
   size: 1877445
   timestamp: 1684280183367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
   sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
   md5: 0e5b0fe7debbf558ce97090f6b67cdae
   depends:
@@ -6073,7 +6073,7 @@ packages:
   license_family: Apache
   size: 94633
   timestamp: 1690225630423
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
   sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
   md5: 0fde797653e4ab589506121fb1e37555
   depends:
@@ -6082,7 +6082,7 @@ packages:
   license_family: MIT
   size: 157119
   timestamp: 1661452591647
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
   sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
   md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
   depends:
@@ -6093,7 +6093,7 @@ packages:
   license_family: MIT
   size: 92679
   timestamp: 1636093365041
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
   sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
   md5: f870859d4dc7a8d82cf3546bd9035f33
   depends:
@@ -6103,7 +6103,7 @@ packages:
   license_family: BSD
   size: 54520
   timestamp: 1605307564142
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
   sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
   md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
   depends:
@@ -6116,7 +6116,7 @@ packages:
   license_family: PSF
   size: 21172845
   timestamp: 1694442462066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
   sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
   md5: 9d99075052265ae3d718582d3b875038
   depends:
@@ -6125,7 +6125,7 @@ packages:
   license_family: BSD
   size: 269964
   timestamp: 1661376543480
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
   sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
   md5: fa9074d94236c9b768bfd2c858875b27
   depends:
@@ -6134,7 +6134,7 @@ packages:
   license_family: MIT
   size: 264836
   timestamp: 1695131770282
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
   sha256: 97243a31c39f4990c0e9d4f2307f2f7fb9421553303923bc105067ec4340bdff
   md5: 8078c5760f27398eaf1082226647d137
   depends:
@@ -6144,7 +6144,7 @@ packages:
   license_family: BSD
   size: 40145
   timestamp: 1685031143383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
   sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
   md5: 3d2841085778006c2e79f9c7300f8b9d
   depends:
@@ -6154,7 +6154,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13565975
   timestamp: 1669937633869
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
   sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
   md5: 54a4bc0724041dd173088419d6ede2af
   depends:
@@ -6166,7 +6166,7 @@ packages:
   license_family: MIT
   size: 239062
   timestamp: 1677611495106
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
   sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
   md5: f39f84115e228bad4bceaefdd637f022
   depends:
@@ -6178,7 +6178,7 @@ packages:
   license_family: MIT
   size: 158558
   timestamp: 1698096358091
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
   sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
   md5: df398a3a1668fd2a22061764e20ea91d
   depends:
@@ -6190,7 +6190,7 @@ packages:
   license_family: BSD
   size: 460913
   timestamp: 1657616061604
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
   sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
   md5: 38db77ece9dc76feffb9ef7638e38258
   depends:
@@ -6206,7 +6206,7 @@ packages:
   license_family: Apache
   size: 94397
   timestamp: 1690400496655
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
   sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
   md5: 3e284ae6b48ee30c364ffdc5601610b0
   depends:
@@ -6215,7 +6215,7 @@ packages:
   license_family: MIT
   size: 1099842
   timestamp: 1690291374842
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
   sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
   md5: 993b3886b334bd1f49d34206f21997b4
   depends:
@@ -6224,7 +6224,7 @@ packages:
   license_family: Apache
   size: 15998
   timestamp: 1614030572433
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
   sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
   md5: 7ac9604ad7564ac0c71bff5db198656f
   depends:
@@ -6233,7 +6233,7 @@ packages:
   license_family: MIT
   size: 67012
   timestamp: 1696347795139
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
   sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
   md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
   depends:
@@ -6243,7 +6243,7 @@ packages:
   license_family: Other
   size: 1311308
   timestamp: 1681402905668
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -6253,7 +6253,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
   sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
   md5: 28b9869d8d3a839918fac4a08f38cbc2
   depends:
@@ -6264,7 +6264,7 @@ packages:
   license_family: BSD
   size: 30546
   timestamp: 1671752127904
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
   sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
   md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
   depends:
@@ -6274,7 +6274,7 @@ packages:
   license_family: BSD
   size: 39590
   timestamp: 1668168880994
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
   sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
   md5: 52cdcdb96383c010ca833a7c24b3935b
   depends:
@@ -6284,7 +6284,7 @@ packages:
   license_family: BSD
   size: 3690152
   timestamp: 1654036853710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
   sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
   md5: 0e054ab29119cf4c1f778613acf972f9
   depends:
@@ -6295,7 +6295,7 @@ packages:
   license_family: Apache
   size: 681780
   timestamp: 1696937326924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
   sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
   md5: b6ad839ebba536ad1c3cc58d0e2123f0
   depends:
@@ -6309,7 +6309,7 @@ packages:
   license_family: MOZILLA
   size: 143681
   timestamp: 1679562248929
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
   sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
   md5: fe78de10019085146f1cc6c94fdc2620
   depends:
@@ -6318,7 +6318,7 @@ packages:
   license_family: BSD
   size: 192822
   timestamp: 1671143999327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
   md5: ca5fc3fbdb09b6de068a8b7a8869369f
   depends:
@@ -6328,7 +6328,7 @@ packages:
   license_family: PSF
   size: 9208
   timestamp: 1690298120549
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
   md5: a86e87a10e5fdff486265e0c675fb99f
   depends:
@@ -6337,7 +6337,7 @@ packages:
   license_family: PSF
   size: 57922
   timestamp: 1690298106990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
   sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
   md5: 0d31859e0a097aedbcc1627db33b3d92
   depends:
@@ -6352,7 +6352,7 @@ packages:
   license_family: MIT
   size: 188367
   timestamp: 1698257883295
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
   sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
   md5: 45ef24c486a484f079faf1dc90e4c7e9
   depends:
@@ -6361,12 +6361,12 @@ packages:
   license_family: BSD
   size: 8277
   timestamp: 1605602889180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
   sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
   md5: 4daaceb6cfc1af6274509081d8018ef1
   size: 2316783
   timestamp: 1605602872095
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
   sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
   md5: 916c16904615c7af3b5d37cb6694f45e
   depends:
@@ -6375,7 +6375,7 @@ packages:
   license_family: BSD
   size: 21084
   timestamp: 1607347371925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
   sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
   md5: da69e6987fcc757e83a358ceaa13f62b
   depends:
@@ -6385,7 +6385,7 @@ packages:
   license_family: BSD
   size: 73391
   timestamp: 1614804425587
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
   sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
   md5: 23b9f4634b2e5450be617114f62c74f9
   depends:
@@ -6394,7 +6394,7 @@ packages:
   license_family: MIT
   size: 120873
   timestamp: 1695742300539
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
   sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
   md5: 120f0b088290fc17bd6618fc10a2f0c4
   depends:
@@ -6402,13 +6402,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 34293
   timestamp: 1605306211299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
   sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
   md5: c3f7871e9a33adeccee1b1e8e216918e
   depends:
@@ -6418,7 +6418,7 @@ packages:
   license_family: GPL2
   size: 1332571
   timestamp: 1683113347814
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -6427,7 +6427,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
   sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
   md5: 1ab55f8c4b5292ec360c572120bf823e
   depends:
@@ -6437,7 +6437,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 9430705
   timestamp: 1616055773485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
   sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
   md5: 6875e0bf3828707dc9165d694c0d0a7d
   depends:
@@ -6446,7 +6446,7 @@ packages:
   license_family: MIT
   size: 18725
   timestamp: 1672387612937
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
   sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
   md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
   depends:
@@ -6456,7 +6456,7 @@ packages:
   license_family: Other
   size: 148931
   timestamp: 1666595229032
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
   sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
   md5: 8d6a1e767775fe0eb617cd6e22edc2ff
   depends:

--- a/boids/pixi.lock
+++ b/boids/pixi.lock
@@ -1,0 +1,6471 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.15.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.4.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.15.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.7.2-py39hee32256_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.22.3-py39h47b59a4_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.22.3-py39hcfaf2c3_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-1.4.4-py39he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-0.14.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-2.4.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.15.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.7.2-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.22.3-py39h25ab29e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.22.3-py39h974a1f5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-1.4.4-py39hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-0.14.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-2.4.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.15.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.7.2-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.22.3-py39h6917f2d_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.22.3-py39h46c4fa8_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-0.14.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+  sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
+  md5: 2cf39d906cc321896ffe3e5d33d80c5c
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162166
+  timestamp: 1644463608931
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+  sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
+  md5: 2972a84e0e22ae3244bbd2f1eebcf536
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 35352
+  timestamp: 1644569715988
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+  sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
+  md5: a68016b4b06460def24cb69d932986f3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132486
+  timestamp: 1695717963702
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+  sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
+  md5: 2f6356a2f530314b4059c08c79a3d8bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 205868
+  timestamp: 1681493113570
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+  sha256: 2d8e75f31f75ea5eb8b9021b4c21eb2846a254a097e06eb68e66fc36a82e1bed
+  md5: ae374a11c789a55555f70b29b9eff1f9
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3,<2.0a0
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14430294
+  timestamp: 1658136783940
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+  sha256: f84f9caa7eb9d489fd9634419fdf766d39293a5df1104b840fa0cdc5823a5c60
+  md5: 922555c0435d6b2537cf8ced534b048c
+  depends:
+  - libgcc-ng >=7.5.0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 141903
+  timestamp: 1648028958291
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+  sha256: 0bbcb6f78eac530c6a084459ffab3238647b266d0c74d695e6e6387dd119cc67
+  md5: bdc971e2a9affb5125b68ad708172dab
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 411301
+  timestamp: 1602517685375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+  sha256: 8c2071f706c2b445dabb781f7f8f008b23a29957468ec6894f050bfb3a2d5bf4
+  md5: c203ffc7bbba991c7089d4b383cfd92c
+  depends:
+  - cffi >=1.0.0
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 357797
+  timestamp: 1605539534667
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+  sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
+  md5: 3ef00f4c5278b688552efc259c463dc8
+  license: MPL-2.0
+  license_family: Other
+  size: 132731
+  timestamp: 1694009767372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+  sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
+  md5: d5cb3d97cf5e85ffe5e94037ed8a1169
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159077
+  timestamp: 1690232254640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+  sha256: 674707b9c42e65c903c9786ee5a56b4d42aa054f1e75b328db8a2c1bfa368739
+  md5: 76ae217198b014b89b267cf41b8251dd
+  depends:
+  - libffi >=3.3
+  - libgcc-ng >=7.5.0
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 231920
+  timestamp: 1642701209740
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+  sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
+  md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1917831
+  timestamp: 1668084545510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+  sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
+  md5: 13702d3b4b744784e5bd559c7050dd6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12719
+  timestamp: 1671231205875
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+  sha256: 821af57c20a85b4e92268fbf65fbaec2f273da5bb21889d9643756ef6e473237
+  md5: f57e0f502500ffebdbec081ef61ad1d4
+  depends:
+  - cffi >=1.12
+  - libgcc-ng
+  - openssl >=1.1.1v,<1.1.2a
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 2179774
+  timestamp: 1694445209134
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+  sha256: 3a39a2d6f161080c706292e3bf480f62d2444b1d6d67b3d7db50458202ee31f1
+  md5: 0524ffca60f845eb392bbb56d56f0ce5
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2094615
+  timestamp: 1637091869922
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+  sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
+  md5: 2e6ec51066d825ef3c317abe78d6049e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16413
+  timestamp: 1649926472708
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+  sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
+  md5: b4d923222d45314856b5378cb115214d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26728
+  timestamp: 1668714462023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+  sha256: 8a121233d0b2cbb2463b67e798739ad2946f38933430a6a7fd1197cc6eab1c99
+  md5: d2b24736491290a6c6d0138932111150
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: GPL-2.0-only and LicenseRef-FreeType
+  size: 965280
+  timestamp: 1635422707211
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+  sha256: 3c8ece1a7257b1d45f8fa25f46504bb709a1923d7175f2996e891366ec434b9d
+  md5: 299bf4271d710651a1d71d3795580c2d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 83592
+  timestamp: 1603192039050
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.15.3-py39h06a4308_0.tar.bz2
+  sha256: 54f35df9586b95021561266b7aaffb3849a871d635c3e9c8f61e5127d21553d6
+  md5: 497e5242e8e513702f00a2b625b0674b
+  depends:
+  - bokeh >=2.4.3,<3.0
+  - colorcet
+  - ipython >=5.4.0
+  - matplotlib-base >=3
+  - notebook
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.9.3,<2.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4452572
+  timestamp: 1671782975232
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+  sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
+  md5: 9213e0336e3a5216c989cfe52648412e
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 23805906
+  timestamp: 1588026213084
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+  sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
+  md5: 1eb52f9f45cea2fb9ce27b19f990160e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110793
+  timestamp: 1666125606878
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+  sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
+  md5: 126b3c1933b7364ff03f67455b687e99
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 37588
+  timestamp: 1678997134023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+  sha256: 1b424413f28b840fc6d4bf467f37e9e405823b1e3b899005df80152d48936d64
+  md5: 4aa8bcf74c81cd3600978f791191692a
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 9246735
+  timestamp: 1634546760713
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+  sha256: b51b2e0dd37a74784ba19db22aded3f4c843b6fddb4a74399f65f36fc018aaa2
+  md5: 0d56ab1950f952284b895ac0f78284a7
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.0
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203541
+  timestamp: 1671488675347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+  sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
+  md5: ff47e0be879e817713ce2a9daa76e2b0
+  depends:
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1261116
+  timestamp: 1694181530670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+  sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
+  md5: 5ef6c6a0d1ac79143c7359d305155167
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1021637
+  timestamp: 1644297140650
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+  sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
+  md5: eaeb023688f781e7dd89e74310c38195
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 211775
+  timestamp: 1666908212136
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+  sha256: 85348bfb14db4fea84078d703e766a3c978c5a592a06e41266748826dd59d8ae
+  md5: 6e1c0fb5260c590f7ef5235cb3d05863
+  depends:
+  - libgcc-ng >=7.5.0
+  license: IJG
+  license_family: Other
+  size: 279884
+  timestamp: 1651065953960
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+  sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
+  md5: 0d2c3c5edf671b575532d5a3e8bf15fc
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 131510
+  timestamp: 1676558716852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+  sha256: 92bc012f9eb4ad71158cf4826fd3e125fcebff53b529276a81224acda48be547
+  md5: c5fd100e3062e831cbdf33331042f627
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=22.3
+  - tornado >=6.0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 190884
+  timestamp: 1650622553813
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+  sha256: 0192bd48cd96c60dc3054d5addd8cdb4a29a218843181318371f79daec8242f8
+  md5: d851b401dc13d04e6848bb36e12efc1c
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 91534
+  timestamp: 1679906652183
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+  sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
+  md5: a4beb461f0a60998a090d760b5c6c907
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411564
+  timestamp: 1671707702849
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+  sha256: 974df3dc76089be57b327acd6634384def84249003f58678ca1142bb274a75d9
+  md5: 81b969d1a00153759b30554a1f11ddfd
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92144
+  timestamp: 1653292217019
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+  sha256: 3b4afe7665dcdb99bd4586a888b85b2e0325f8faecdd31c7780792080ee97872
+  md5: 822b5201dde61bc838072dc5b670c88c
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: Custom
+  size: 55183
+  timestamp: 1594054267890
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+  sha256: c6fafbe73d2f93b91b6f4b65829f925f52a8f84746a57abd216b39da9ce8c494
+  md5: 238f19c803a6ba7bd6dbd6989e03cbf1
+  depends:
+  - _libgcc_mutex * main
+  license: GPL
+  size: 8496776
+  timestamp: 1560112207081
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+  sha256: bc3e6e79c32ff0ecea601aa108ae9cf4068f69703580e40e266ad4bcc52cff54
+  md5: 9cb85601944ca7383b1769bff74b94e8
+  depends:
+  - libgcc-ng >=7.3.0
+  - zlib >=1.2.11,<2.0.0a0
+  license: zlib/libpng
+  size: 372914
+  timestamp: 1556041895170
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+  sha256: 43b0bd205f539583c088feb5b8d77b60c83d1df80c2a93dac9f2a1127001b2cf
+  md5: 53fa39fdae936e9d07c4b2f5ef361993
+  license: GPL3 with runtime exception
+  size: 4246257
+  timestamp: 1560112223556
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+  sha256: 711ea05b4c35bdafc762a172b01db896b17942f474c2b1a519f91370964bf9bc
+  md5: b25d56d33596623a6a4a9d9baaa4f602
+  depends:
+  - jpeg >=9e,<10a
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libwebp-base
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  size: 592974
+  timestamp: 1653047881023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+  sha256: 146dbb1e4dbccdd57819e5102a8ca00970b8e33d6c6180e8007db89b184da569
+  md5: c566a384259c1d2769852c3bddd81a67
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9d,<10a
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 90150
+  timestamp: 1645441199289
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+  sha256: cffb5a063111f7a99a99c74770b23db5dde52325e25a7a46d1903d5ff4a82c88
+  md5: eeb1bd66f28bed1956ab989d6eff7ae5
+  depends:
+  - libgcc-ng >=7.5.0
+  constrains:
+  - libwebp 1.2.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 889956
+  timestamp: 1645089138421
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+  sha256: 71f6c4a97014d745c58df52b4dd60ddd75a8508d54fe5b97f42bd1f31cb1c067
+  md5: 686e77514ec9f1ef0a6feed374f14d37
+  depends:
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.5.0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 789469
+  timestamp: 1653546418059
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+  sha256: ea3355a67c5173f3944f09861043ca66eb7dbeff8f385d13528b3aabc0801d0c
+  md5: 66e2aa12181bb2911485bdbe125d24c5
+  depends:
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.5.0
+  - libxml2 >=2.9.14,<2.10.0a0
+  license: MIT
+  size: 584199
+  timestamp: 1654075843119
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+  sha256: 64b022d706b76c33965a250fdc8c6008443c41bff8ab27bb1df3cb70419576fd
+  md5: ec4f05846aacf634df15c389235725cc
+  depends:
+  - libgcc-ng >=7.5.0
+  - libxml2 >=2.9.12,<2.10.0a0
+  - libxslt >=1.1.28
+  - libxslt >=1.1.34,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  size: 1538261
+  timestamp: 1646624639995
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+  sha256: 2c6a5dda7c510a961bc78e31d4232be5e8e0760c93454f5fd200c379355e0f5e
+  md5: f35d4bf2fbb39e334992f6dd39f8721e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 220865
+  timestamp: 1627657046002
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+  sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
+  md5: 421f82c8274b44660dba629134faa6af
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 122221
+  timestamp: 1671541990505
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+  sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
+  md5: feb0e452205b44ac45d9b5e55c21a3b1
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22819
+  timestamp: 1654597913064
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+  sha256: dc51b316ef5dcfb82a9c0afdc40879146ae59516f6cea7db776077783dfd2d76
+  md5: b0b6b57c140f026b8806051107336576
+  depends:
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.11.0,<3.0a0
+  - freetype >=2.3
+  - kiwisolver >=1.0.1
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - numpy >=1.19.2,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.2.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  - tk
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7729454
+  timestamp: 1647442028622
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+  sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
+  md5: c04ef34af33da4c71bcc99b7ec24d210
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16391
+  timestamp: 1662014553452
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+  sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
+  md5: f6c734d73e6e3dbc1b62766cf18ff3e4
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58153
+  timestamp: 1607364912263
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+  sha256: 7c4ded8b2ef036839f988560848d2c32e1aa4627fd37a32710e42c39f5c61ac2
+  md5: bd20f4410b81f327e35ffa0657961146
+  depends:
+  - intel-openmp 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 229783051
+  timestamp: 1634547157986
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+  sha256: 5394f5efd53afb2c1b0abf571ce3d9cb684b6c7e255f140ba2acaa703d6113be
+  md5: d3cb2bfa63e30153f5527797dcc87280
+  depends:
+  - libgcc-ng >=7.5.0
+  - mkl >=2021.2.0,<2022.0a0
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 63551
+  timestamp: 1626176932911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+  sha256: c244d23da2749857a993f84969fd35ffd183ab8f462986df6d33ae0f705fe034
+  md5: 9b1f8ccc2488d0e04eb73211e2987483
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.3.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  size: 204136
+  timestamp: 1634566416657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+  sha256: f81f426f8ef306d636664bc49e7cdd70e2b4306d7c6bcb9c75fe35a45ab2087a
+  md5: 77aa1d7f958d36bf227e6ff4a34d2e3d
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.2.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  size: 365386
+  timestamp: 1626186165897
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+  sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
+  md5: 95c83d71814c504b5504df4f14548f1a
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8257558
+  timestamp: 1681756322140
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+  sha256: 1b92d72b083f3350359b8fb2e3b5dc846f49650c9e46a6a74354b1b7f0d42730
+  md5: 996babe4314515ddd41008a53cb5d47f
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 98791
+  timestamp: 1650290544347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+  sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
+  md5: 1710a25086c8098367eb36b9d441448b
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 569683
+  timestamp: 1668450704669
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+  sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
+  md5: 385cc9e53404776782502c0fdb08820f
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147046
+  timestamp: 1694616899309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+  sha256: 0807371380965e421cb5f3f2a30d790fd5c41db11dbb6d318e14294c3b1741ed
+  md5: fca4bd4e3891aebf4fd7daf9b6d0ccfa
+  depends:
+  - libgcc-ng >=7.5.0
+  license: Free software (MIT-like)
+  size: 1083412
+  timestamp: 1636570020698
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+  sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
+  md5: bbbcbebc20a4fdcadce398d0ca04f95e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13109
+  timestamp: 1672387143252
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.2-py39h06a4308_0.tar.bz2
+  sha256: 2450e0c106fce4b926d038f5a6a29621bc2593c7888bf77ae627476fdc12e1c9
+  md5: 8281e36033cdf8417d49af27f0878895
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 523970
+  timestamp: 1668180119805
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+  sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
+  md5: 70db71df4ee1cdd38090c0f7b80ba61f
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21944
+  timestamp: 1668160644514
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+  sha256: 15a12c8bebcda45c577e61cea412d9aafaa433e39f9e91fd61bbfab66fcee3ab
+  md5: 5239d8330e8bd34972fb80918dce79e7
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16.6,<2.0a0
+  - packaging
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 136437
+  timestamp: 1640689905588
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+  sha256: ff8d0426c7096e086db818265c3edf4a820accbfb15afae0407ca578de151fa9
+  md5: d7bcf0b9ba2d85cf532059ec119d2750
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.22.3 py39hf524024_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  size: 9965
+  timestamp: 1652801901707
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+  sha256: abfdeda143b6b667d50a82ea119043fc1469ee02f094a41a2402433ff408099e
+  md5: e8dc29adc0282f4658e0e2f25ff207a2
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.22.3 py39he7a7128_0
+  license: BSD-3-Clause
+  size: 7095882
+  timestamp: 1652801886819
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+  sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
+  md5: 5ad4571eba2479f77a9f849a6ae7724c
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: OpenSSL
+  license_family: Apache
+  size: 3998613
+  timestamp: 1694465071784
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+  sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
+  md5: 77a22ed6d0d448c5288d0f695bc9ac49
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 72527
+  timestamp: 1693575234886
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+  sha256: e7a0abb0f00a94000876f2095f0cf531ad3803ffbd868a780b3f06816b54492c
+  md5: 97ef7e1fe923d22a8e2307f3f39a92d5
+  depends:
+  - bottleneck >=1.3.1
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - numexpr >=2.7.1
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13221005
+  timestamp: 1650622404234
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+  sha256: 49fdb57b2ed2ce4d6bb7a2c5adec36ba59522518a41fb941f9e39a9f43750cc5
+  md5: 871b65444733b7da5823ee0dc9826722
+  depends:
+  - bleach
+  - bokeh >=2.4.0,<2.5.0
+  - markdown
+  - param >=1.12.0,<2.0.0a0
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - setuptools >=42
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >1.14.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14712394
+  timestamp: 1676379803902
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+  sha256: 64a732ce2661cdb6bd8f9d1484ac10afeb73082b1c2b44728d212e0117d2860e
+  md5: ada303f0cf43a4e99cfa7f243b23b681
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141832
+  timestamp: 1684915385689
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+  sha256: 8bcb1c67693f42a3170eb77ef4cdbb81b605fdf40816953e69a33a065c101638
+  md5: b7689507fb5f879dc766aaa8a4c37351
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp >=0.3.0
+  - libwebp >=1.2.0,<1.3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk
+  - zlib >=1.2.11,<2.0.0a0
+  license: LicenseRef-PIL
+  license_family: Other
+  size: 734566
+  timestamp: 1646325095608
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+  sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
+  md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2674850
+  timestamp: 1697548887851
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+  sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
+  md5: fe56f0479dd414c846191116366262c3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 31999
+  timestamp: 1692205535111
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+  sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
+  md5: 44d2a857d13bdf9d99aaac039a249d47
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91137
+  timestamp: 1659455142164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+  sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
+  md5: eb899a739d9b58dd747f1f6bd52d4cf3
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 579771
+  timestamp: 1672387338600
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+  sha256: 6973cfe0565ba3b5ad6d1de9e34848fbbadd78b507b2e23e1c079636b8f8f317
+  md5: a924535045fb356e23e7a3cc8116b638
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 350026
+  timestamp: 1612298042840
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+  sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
+  md5: f36ecb722522cbe2e3737424edf1b5e1
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29312
+  timestamp: 1675441510984
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+  sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
+  md5: 6d03295e544251e608a28c8d7c48115e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1862058
+  timestamp: 1684280096752
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+  sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
+  md5: 1f09617aecd6f3c2f2e20692c0759f34
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94434
+  timestamp: 1690223520097
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+  sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
+  md5: ffceed627867508d73af1636ab5ebf42
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 156324
+  timestamp: 1661452578573
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+  sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
+  md5: 0e3341a4fe434167bf74b613eb6afd81
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 97194
+  timestamp: 1636110999719
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+  sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
+  md5: c5f3f7f10ad30f0945e75252615ab6e5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31331
+  timestamp: 1605305847037
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+  sha256: c4b9e332a6f2b7524e8c88e2b39a2568a48e556fd9a44c30759c43611d4d023d
+  md5: bb118745c9b08fc5028f45e77f371e68
+  depends:
+  - ld_impl_linux-64
+  - libffi >=3.3,<3.4.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - ncurses >=6.3,<7.0a0
+  - openssl >=1.1.1o,<1.1.2a
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.38.3,<4.0a0
+  - tk >=8.6.11,<8.7.0a0
+  - tzdata
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 24553777
+  timestamp: 1654084160832
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+  sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
+  md5: 0caa188a695319bdb13f53b0a2b3accc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264864
+  timestamp: 1661371117920
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+  sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
+  md5: bcb44ecbea441ee0d4659133d060d71f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257904
+  timestamp: 1695131670290
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+  sha256: e937081facacb141dc2c9cdcced92baa9a2662e4a56100b6041df0b6b7692570
+  md5: f3ac39b2349258198a9b3316636fe5d5
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39972
+  timestamp: 1685030752528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+  sha256: 3da9cbbd49fac566433748bd245d09d7d5fcd28b04c0397cbbf6d5bb92f5c4a5
+  md5: df73a5d2f6e089d51e71e91935a82c65
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 183753
+  timestamp: 1635775763162
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+  sha256: 26005d191bb15070aad70707ed6493f32678a67978bd3b83d4c9679cab44e717
+  md5: 2dc75d5a4ccb64310939c3a72d34ae20
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-clause
+  license_family: BSD
+  size: 521583
+  timestamp: 1638435042256
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+  sha256: 8c950c69bee969e2c66f88f0dc247b3ab75a753672a88009779d5f5dba193532
+  md5: 150ac0eb929bab9dec912797bdfc7b95
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 433182
+  timestamp: 1642022402894
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+  sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
+  md5: c7de00b4ac2778c4e5a7816320d75391
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94028
+  timestamp: 1690400356879
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+  sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
+  md5: 1581cafc84708ed9aafaaee1cbbf6065
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1089416
+  timestamp: 1690290900608
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+  sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
+  md5: e19ffbfb24b990275d24fcea2bd1699b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15702
+  timestamp: 1614030498860
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+  sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
+  md5: ca061ce25c0f58628643abec8d6a8244
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 66330
+  timestamp: 1696347637947
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+  sha256: 87965b7b46d93866d31696a1045216d64f077a06b2900c356aba87e8559c6188
+  md5: fa334030245135b37027a882f3c468bf
+  depends:
+  - libgcc-ng >=7.5.0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: blessing
+  license_family: Other
+  size: 1561908
+  timestamp: 1655328608308
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+  sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
+  md5: 0e76eab58fe488e91f0aee73f46de031
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29816
+  timestamp: 1671751864131
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+  sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
+  md5: b413a210eca82fe867e991eed085201b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38882
+  timestamp: 1668168876032
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+  sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
+  md5: 5b8375e2092012db69d2123dc0c68630
+  depends:
+  - libgcc-ng >=7.5.0
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3485432
+  timestamp: 1654088939579
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+  sha256: b746e39272888b9cc1a2a711b7b8836f2e26f4457850e43ad18bf0765e21dc3d
+  md5: 200e86f8d53aeebf4b7dcfc944fd7920
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 661662
+  timestamp: 1606942359431
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+  sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
+  md5: 67a8320961ff24e92eebb661536e5cf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - requests
+  - slack-sdk
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 123763
+  timestamp: 1679561904852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+  sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
+  md5: 0f0b91a158dd3692cbb7a7763b657bfe
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192032
+  timestamp: 1671143995098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
+  md5: 8515e64a3de7581360d713fe4c0a094e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8789
+  timestamp: 1690297588156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
+  md5: 60170012374b2a5007842fa5870d78c5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57479
+  timestamp: 1690297581658
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+  sha256: 870f20a3c006a74b291910f69c3469a409bd21437142864b29cfafeb89ca7c34
+  md5: 1b2f1589e3ebc3e0c6ecb38dba93e4ae
+  depends:
+  - brotlipy >=0.6.0
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 186761
+  timestamp: 1686163186447
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+  sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
+  md5: f8d03a15b974fc7810d9f54ae849fc8e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20781
+  timestamp: 1607365390528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+  sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
+  md5: d7db5d6ce1db80eade8a082ff78bf479
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 71044
+  timestamp: 1614804011510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+  sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
+  md5: b3899f8bda32734727bd5a73df1d7d17
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 101520
+  timestamp: 1695742037911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+  sha256: 2ce360ff98c0ca4537d70c19266b5700810196c54ce2fbaff3b94a969846ee37
+  md5: 94cb94dc47405b24b1b5bd0a3275ab59
+  depends:
+  - libgcc-ng >=7.5.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 398058
+  timestamp: 1651602137803
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+  sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
+  md5: 567b68192c387b5fc88178425577a0fe
+  depends:
+  - libgcc-ng >=7.3.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=7.3.0
+  license: LGPL-3.0-or-later
+  size: 366479
+  timestamp: 1616055552392
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+  sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
+  md5: 3818a9531fe74433c3b7d5144c9a58cc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18021
+  timestamp: 1672387231268
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+  sha256: 513444d83ac2405e898531492ea59f3a95641e357cc39c1048d6fffc1791a16b
+  md5: 601d9449c280b9b145dc8c83b6f06119
+  depends:
+  - libgcc-ng >=7.5.0
+  license: Zlib
+  license_family: Other
+  size: 133595
+  timestamp: 1650637720646
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+  sha256: 1c049c23788a00b6f38bdc801245e0e60af98718d4db4c958658bcc67ff158c7
+  md5: b1737dfd2e06ad69ec5cfec341e207c6
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 827172
+  timestamp: 1650622223170
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
+  md5: b2aa5503875aba2f1d88cae9df9a96d5
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13636
+  timestamp: 1611930018941
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
+  md5: 544adf2677c47c9b9c891aea720678f1
+  depends:
+  - python >=3.5
+  license: MIT
+  size: 33999
+  timestamp: 1630003259346
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+  sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
+  md5: 9eff1a842dbda8d1bae9a2c008b599bc
+  depends:
+  - brotli >=1.0.1
+  - munkres
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 690443
+  timestamp: 1625743217109
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+  sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
+  md5: 33624a42ee387bf9918ea98b4e7b31fc
+  depends:
+  - pygments >=2.4.1,<3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8173
+  timestamp: 1601490751973
+- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+  sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
+  md5: 67857cc5e9044770d2b15f9d94a4521d
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12810
+  timestamp: 1600445183315
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+  sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
+  md5: e68a6f315f41a8d814d833652bf38b9b
+  depends:
+  - python >=3
+  license: MIT
+  size: 13374
+  timestamp: 1606932077143
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
+  md5: 2eb923cc014094f4acf7f849d67d73f8
+  depends:
+  - python
+  - six >=1.5
+  license: BSD-3-Clause and Apache
+  license_family: BSD
+  size: 246457
+  timestamp: 1626374695070
+- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
+  md5: 41db68b96e114e367c4f120a3b379e59
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19391
+  timestamp: 1632406728844
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+  sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
+  md5: a815d3bdb160bcc71687f2dda70d3ca4
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 122218
+  timestamp: 1680170368293
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
+  md5: 447a49f7bad119faa80d7f14aa296c95
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162176
+  timestamp: 1644481750133
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+  sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
+  md5: 8810f48fe4a4792de0fd3520b502d08b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10019
+  timestamp: 1606859473259
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+  sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
+  md5: 00a446b6dfc61af223df4de29fe8ad94
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 34305
+  timestamp: 1644569782044
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
+  md5: bd92dd8bd5b9d24e632b62a075426e50
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133634
+  timestamp: 1695718025321
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+  sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
+  md5: f8ae051b591a9027adc16de1be9748f4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206198
+  timestamp: 1681493096349
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.4.3-py39hecd8cb5_0.tar.bz2
+  sha256: 1f5dcdfd5854f527041cc8ad99de5b1e9de2cf89fc07d6ceebe773d0311a92b7
+  md5: 6188865467aabac07a36811fc37b0982
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3,<2.0a0
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14356265
+  timestamp: 1658136884702
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+  sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
+  md5: 0d79760d544d0bd8acb4adc4ef813418
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 137075
+  timestamp: 1657175654487
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
+  md5: 31d6d04cd2388d8f19004501271b3545
+  depends:
+  - brotli-bin 1.0.9 hca72f7f_7
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18982
+  timestamp: 1659616229395
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
+  md5: caf1073dc2ca5aeb832a2877394eae12
+  depends:
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18233
+  timestamp: 1659616216769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+  sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
+  md5: aa1ed20c38af535c8d6a955314759d7b
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 394588
+  timestamp: 1659616312678
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+  sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
+  md5: ce3588e31faa79f546e0fc6a36c5543c
+  license: MPL-2.0
+  license_family: Other
+  size: 133884
+  timestamp: 1694009771475
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+  sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
+  md5: 21eb7f53076d0a69513cfd258f6ef63c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159756
+  timestamp: 1690232346868
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+  sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
+  md5: a40a04d9cda1e665565bc6c832d598b6
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225258
+  timestamp: 1670423337502
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+  sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
+  md5: b2cc5f37f7bb069d061306e7eac2a011
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1913396
+  timestamp: 1668084575248
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
+  md5: 103d8c039e342115720a84d59c119d46
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13774
+  timestamp: 1671231190250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+  sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
+  md5: f69f09e0346172f225390d2b3b0d7873
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 246628
+  timestamp: 1663827484947
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+  sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
+  md5: cb80c7ac65b48a737654f371fe31c460
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1307228
+  timestamp: 1694212041712
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+  sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
+  md5: 04cbe8f4bc62c34fac9d42d1124059bf
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2052734
+  timestamp: 1690905361158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
+  md5: ef0e825982f242085574f502dfff4f6b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16594
+  timestamp: 1649926538106
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
+  md5: 24747a300246c016b3a7f04dabd02d4a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27709
+  timestamp: 1668714497209
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+  sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
+  md5: e4a732941f74b8062c8bcbfe5c5c2b56
+  license: MIT
+  license_family: MIT
+  size: 80252
+  timestamp: 1676983220161
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.15.3-py39hecd8cb5_0.tar.bz2
+  sha256: 205aa54194966c4a2d16f5abe17b4b044d51a623987324354e765e3b68269eea
+  md5: 75f3ecdc22a04ba4fd24962102138c60
+  depends:
+  - bokeh >=2.4.3,<3.0
+  - colorcet
+  - ipython >=5.4.0
+  - matplotlib-base >=3
+  - notebook
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.9.3,<2.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4438088
+  timestamp: 1671783268805
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+  sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
+  md5: f3ce6fe6eb760c236e5f7d04df5faa81
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28138484
+  timestamp: 1692293212596
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+  sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
+  md5: 6dd72c43fea25b748ec7a9f6c0407e15
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111810
+  timestamp: 1666125671024
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
+  md5: 03cdb7e679924b329ecab8f12cb8fc67
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38813
+  timestamp: 1678997212422
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
+  md5: e113c4e6e758dd68faf196586bf5564d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51873
+  timestamp: 1698254765815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+  sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
+  md5: 78baea934985ccd9514a366cc7e80ed4
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 727499
+  timestamp: 1681801225190
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+  sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
+  md5: da9b63e42f281f7e77b289f4b654b83b
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 218436
+  timestamp: 1691121840155
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+  sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
+  md5: 6a7cb9b49593b29933fa2b503d533a08
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1257205
+  timestamp: 1694181720454
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+  sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
+  md5: d861ef66f5c0a282d60b65778a9de2f3
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1048450
+  timestamp: 1644315332508
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
+  md5: f7e603c965052deed8b789c35855a42f
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213537
+  timestamp: 1666908270815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
+  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
+  license: IJG
+  license_family: Other
+  size: 278924
+  timestamp: 1677849185191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+  sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
+  md5: a82a17e78f725dcbd71ff8dac6db05c7
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133134
+  timestamp: 1676558895333
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+  sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
+  md5: ee9270379a9ebdb6297e4b6849b3f7f0
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 195479
+  timestamp: 1676329410154
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 32b898a97dca7770858ab31294238fde11ab61a84831a52f320e5ee5405a147c
+  md5: 926e754b8fad288b583ef2933deae1a5
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92938
+  timestamp: 1679906616072
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+  sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
+  md5: 7e60995b3119417213e5faedda147499
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 403165
+  timestamp: 1671707664990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+  sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
+  md5: cd470bdb28bb0e8b3535c93a3a6dad07
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65431
+  timestamp: 1672387389172
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
+  md5: 7dba7aa5b971febb55281659843586ba
+  license: MIT
+  size: 65470
+  timestamp: 1659616172703
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
+  md5: f78a158983f0bbaba56f34b976bc6dae
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 34189
+  timestamp: 1659616189313
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
+  md5: 36a1d885725d3ab4d1fadc5a29f978d2
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 327737
+  timestamp: 1659616202869
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+  sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
+  md5: 817848d0e2b2808acdc9b3fbbf581726
+  license: MIT
+  license_family: MIT
+  size: 133887
+  timestamp: 1683716590737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+  sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
+  md5: c90372428e1e4eed4fdcd790979d06b4
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1409377
+  timestamp: 1650983531933
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+  sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
+  md5: c0b99f8e1c7475f23b1c7b4250b06e1c
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88021
+  timestamp: 1694778290062
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+  sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
+  md5: 06866415ef22d5322f9bdc9956b59c4d
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 678174
+  timestamp: 1692970318885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+  sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
+  md5: 2edc6c894d6d0321304396e9bd40df94
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241774
+  timestamp: 1692973618934
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+  sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
+  md5: 8bbd981ca0129d7beeacd3cd7623f714
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1491074
+  timestamp: 1695058597986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+  sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
+  md5: d5f58d056b4bfc67aec30c77035ba889
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 182491
+  timestamp: 1670944720979
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+  sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
+  md5: 1affd16b166571a91feae04baf5fd3da
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123431
+  timestamp: 1671542016019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+  sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
+  md5: 3681ebf029211ceab26af6f5d35abf39
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22254
+  timestamp: 1654598220251
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.7.2-py39hee32256_0.tar.bz2
+  sha256: 907176b863fbec590c41e5a5f491591903913f3af4722dac41515bc18e93e6b5
+  md5: 0f2b67bd2ebdbdf18a607f1b7d115627
+  depends:
+  - __osx >=10.11
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=5.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.20,<2.0a0
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8025111
+  timestamp: 1693813054077
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+  sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
+  md5: 6eb64ecfcd754502e271db0bb51d2cfd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17374
+  timestamp: 1662014643620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+  sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
+  md5: 2a4d604717a647ad21af766289cbbfc3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58057
+  timestamp: 1607364912348
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+  sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
+  md5: 25051fe272624544652dc6d814c2943a
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224420228
+  timestamp: 1691503125614
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+  sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
+  md5: 37d8cf85a63f7aa9af1624894a7d606d
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48590
+  timestamp: 1682969183093
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+  sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
+  md5: 0b2aee6666135bbd36b46d6ac66160f7
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 210705
+  timestamp: 1695058433223
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+  sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
+  md5: e22fb55ce380d0ebd44cce3f20d5349e
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296614
+  timestamp: 1695060155673
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+  sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
+  md5: 1a5d4004e64e3cfb7a2a297b9117c285
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8213832
+  timestamp: 1681756573646
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+  sha256: 2975bd1f98ca9ec7354ee378f86f8322ec90f568374776fd90e80c534fbee882
+  md5: 798627089e0ccba26695a26d9cb127ec
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99066
+  timestamp: 1650308465824
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+  sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
+  md5: e572c1264a7af20b486f64ac8c9e1f57
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 573356
+  timestamp: 1668450732828
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+  sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
+  md5: b67569a7c30af9ffa5cde6e4b52ac68b
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148342
+  timestamp: 1694616917184
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+  sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
+  md5: 97b81f34efbe86c5220fe82eb584fd62
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387288528
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.2-py39hecd8cb5_0.tar.bz2
+  sha256: 911ba9e41d3ab14e6191809a62e55676e65dbc5fc4558462d24da3ea76a8f85e
+  md5: b8416d645fa5f55483f51f06049197f5
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 521789
+  timestamp: 1668180098296
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+  sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
+  md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22858
+  timestamp: 1668160618784
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+  sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
+  md5: 185e9c41abb88ee59b52ec0f5f65d506
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 138305
+  timestamp: 1696515469702
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.22.3-py39h47b59a4_2.tar.bz2
+  sha256: cc66489ce399329d20cda69e5833ba9981f36279d226b606f7ea24a7606317c8
+  md5: 93be40a70e9f80f6ef198b55ce897ff8
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.22.3 py39hcfaf2c3_2
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  size: 10445
+  timestamp: 1682972834243
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.22.3-py39hcfaf2c3_2.tar.bz2
+  sha256: 0164d04fb286ebc3ea94a79fa52a21b18164d840fb79b223f21c2e38591f0784
+  md5: de8b44dd081637d75ba9acef451b0020
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.22.3 py39h47b59a4_2
+  license: BSD-3-Clause
+  size: 6752725
+  timestamp: 1682972820395
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
+  md5: 93f5d7b66976154adeda219bea02ba45
+  depends:
+  - libcxx >=10.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 484257
+  timestamp: 1630093862501
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+  sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
+  md5: 5e8713ef1215406254988163eaf34020
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4965606
+  timestamp: 1695323060401
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+  sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
+  md5: 4154929ace2ad6ee16aea815635a6d1f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73598
+  timestamp: 1693575307570
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-1.4.4-py39he9d5cce_0.tar.bz2
+  sha256: 9c8c14f79f0a2b8ffb3f19cc9bf80eabac6d27c39266eeb6dffa76354cbb96c0
+  md5: 4e87084b61971e7a8198fbae451403fe
+  depends:
+  - bottleneck >=1.3.1
+  - libcxx >=12.0.0
+  - numexpr >=2.7.1
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12634563
+  timestamp: 1663773428164
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-0.14.3-py39hecd8cb5_0.tar.bz2
+  sha256: c63341d41ad75c475a793800d229886be5aba866e1885f23778f23093b15f891
+  md5: 1eaea439a84cf758cbaab861a140f67f
+  depends:
+  - bleach
+  - bokeh >=2.4.0,<2.5.0
+  - markdown
+  - param >=1.12.0,<2.0.0a0
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - setuptools >=42
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >1.14.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14708005
+  timestamp: 1676380263675
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+  sha256: 914f1ec8d911083c006c4c2d3b4c0c528e79abba3ae5f1dad825bd896870270d
+  md5: 949e0e4c0ce43c92eb52241892230873
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142949
+  timestamp: 1684915417020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+  sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
+  md5: be0a90921f3bf4f0d6950fb786093de7
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND
+  license_family: Other
+  size: 719901
+  timestamp: 1696580194417
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+  sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
+  md5: 81ae9ec2d7fcf6934847bff558b619f5
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2672987
+  timestamp: 1697548890181
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+  sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
+  md5: 1a822c206e2abddc5d6d821721af227f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33013
+  timestamp: 1692205801265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+  sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
+  md5: 1604d33dbdb2446c642970f8b354bedb
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91266
+  timestamp: 1659455269141
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+  sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
+  md5: d1b3bcc35655a3123acb1fa2ad1a8511
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580828
+  timestamp: 1672387372015
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+  sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
+  md5: 7540555d1fb192236db9a7c5c9d3601c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365765
+  timestamp: 1656431373327
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
+  md5: 0a73533fb6e0dc717ab906a537bc747d
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30803
+  timestamp: 1675441638631
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+  sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
+  md5: 0a959fbad46ab38ade48dbd358002674
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1864757
+  timestamp: 1684280094736
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+  sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
+  md5: ea24b5076ef79e4567c5a3f0cb22b470
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95330
+  timestamp: 1690223465114
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+  sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
+  md5: bcaea6d4a47e9c874becaa700c78dcf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157216
+  timestamp: 1661452617825
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+  sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
+  md5: 707110d1b49cb1864acb0bbaa103591e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 95016
+  timestamp: 1636111184034
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
+  md5: 113a443b9c706f9f9c6187c0eaa3de27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31178
+  timestamp: 1605305861851
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+  sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
+  md5: 85a8d0001db70e52a479155228cb1fe0
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13324979
+  timestamp: 1694439878265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+  sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
+  md5: 47c5e22e31ec05a7bc0ce90065a53afd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 265348
+  timestamp: 1661368839620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+  sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
+  md5: ce9a69e1668aa1e133f2aa6d4e8d346f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 254958
+  timestamp: 1695131709704
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 9ee098c09f31fad7ff1856e5ce2619172eaf979997e7a427d1e05cce32c2af00
+  md5: cac1d1898b69ae9646dfbf082910635d
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40946
+  timestamp: 1685030787453
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+  sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
+  md5: 637f08b19dd8fd87347d8c44f9e3e202
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 170776
+  timestamp: 1698096100056
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+  sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
+  md5: 8ce3ac7d8a04e469b566f1b090d01140
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 470617
+  timestamp: 1657724324011
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
+  md5: 6f2d41dd76a03b7f85a1ed49af1763d6
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95100
+  timestamp: 1690400262627
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
+  md5: b0321e6f14e139fc15b1f8b4acb35d2f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093966
+  timestamp: 1690290944588
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+  sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
+  md5: 62b64576a0aa5f6c3fb05f56650d25e1
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15535
+  timestamp: 1614030509324
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+  sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
+  md5: 15b5595b31e39f08eaacbe2e502d8fb3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67292
+  timestamp: 1696347733587
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+  sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
+  md5: 82e4db6a498480a75d53c55bd35b6478
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1801397
+  timestamp: 1681394807900
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+  sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
+  md5: 63b957927b9949ccb19da28ec4612706
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30902
+  timestamp: 1671751919031
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+  sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
+  md5: e346257a2fa8e2cb48c762138a5d009b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39915
+  timestamp: 1668168959656
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+  sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
+  md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
+  depends:
+  - zlib >=1.2.12,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3536231
+  timestamp: 1654088937695
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+  sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
+  md5: a1bbf0abfb8c45541122c0eb2feee317
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680464
+  timestamp: 1696937112175
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+  sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
+  md5: d689f6203c0a9d04fb229c73d7e80a7a
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125145
+  timestamp: 1679561909274
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
+  md5: 8a292c1ee22489bef2e84bc3aaf4098e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193141
+  timestamp: 1671143985219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
+  md5: 8bf0bfffc11ad06a1c94e145941b0ad4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9651
+  timestamp: 1690297655669
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
+  md5: 343514a174b3485fde55a73f56398dd7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58456
+  timestamp: 1690297648002
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+  sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
+  md5: c2242e8fd24003a74ddf37416661e06d
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188757
+  timestamp: 1698257668273
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+  sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
+  md5: 41f445e36b6b6722a9444508eef069f8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20583
+  timestamp: 1607365395045
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+  sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
+  md5: 409ee46ed24267b6da6fb32d13e1f21e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70730
+  timestamp: 1614804271285
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+  sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
+  md5: eb74e74d8e4fd533c55eb98b7b5e83bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102637
+  timestamp: 1695742077778
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+  sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
+  md5: e243baa546432c8394a8059a44a5a3e4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 419227
+  timestamp: 1683113010463
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+  sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
+  md5: fe4ac85ee86d3a94ea3a4ebea3779763
+  depends:
+  - libcxx >=10.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 321797
+  timestamp: 1616055526986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
+  md5: bc7073d9d4c0211cc4a1207c98fb765a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19091
+  timestamp: 1672387204865
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+  sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
+  md5: 8e495591e369ac161857a72011c0a296
+  license: Zlib
+  license_family: Other
+  size: 120272
+  timestamp: 1666595024203
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+  sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
+  md5: f1465fbd810b3746c6de6babfd4fe28a
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1023573
+  timestamp: 1681304595869
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+  sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
+  md5: cf55cb8d7031b30c70c56fc7c782b5c7
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 156104
+  timestamp: 1644482799136
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+  sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
+  md5: 84fce327d9f0d594e86f565e5c21962e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10183
+  timestamp: 1629146082730
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+  sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
+  md5: 84b8b998a741b37abf5312c1c03696ef
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33979
+  timestamp: 1644845817952
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+  sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
+  md5: 77b746931c8f31c3ae393ccb5819d43d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133628
+  timestamp: 1695717890677
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+  sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
+  md5: 3df6e8ba34208dea068890e5d5318cc0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206759
+  timestamp: 1681493095987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-2.4.3-py39hca03da5_0.tar.bz2
+  sha256: 7926e4d65d56b72cbce30732a5e24b075c4a9893ddb0160b90d6d08104636e49
+  md5: db35093fddb91beafe2274068cebee9f
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3,<2.0a0
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14425917
+  timestamp: 1658136781676
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+  sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
+  md5: bb55f81435cb6e11d264242274fccd1a
+  depends:
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 115947
+  timestamp: 1657175645380
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
+  md5: f860193e14afc7ef3f5b990a2ac003d2
+  depends:
+  - brotli-bin 1.0.9 h1a28f6b_7
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18936
+  timestamp: 1659616204016
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
+  md5: ad53130f3fd1f8d3c2fcbb7496e5585d
+  depends:
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18715
+  timestamp: 1659616188888
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+  sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
+  md5: 0982c046fb976e9f9fb19e7510187a18
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 366983
+  timestamp: 1659616245272
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+  sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
+  md5: 31ac2f5596cb7a44adf073c930641c54
+  license: MPL-2.0
+  license_family: Other
+  size: 133817
+  timestamp: 1694009762858
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+  sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
+  md5: cf1f6c3c34a1e1b9ab22b04233d860f6
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159783
+  timestamp: 1690232303987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+  sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
+  md5: 0eb268e38b5174d471a6e87d9d6102b1
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225355
+  timestamp: 1670423312966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+  sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
+  md5: e68c94666cd60221b575c3814c89bac0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1946451
+  timestamp: 1668084573824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+  sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
+  md5: 1773ae2b080cdd55827e27673351551e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13646
+  timestamp: 1671231171682
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+  sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
+  md5: 53bfd99ad1b09164d537209cffd98161
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 244040
+  timestamp: 1663827469853
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+  sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
+  md5: b62455043c8eb2434466885b19fed2de
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1399573
+  timestamp: 1694211828228
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+  sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
+  md5: eb3cdc0fc210838b9271512a6a1b7c85
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2067708
+  timestamp: 1690905319109
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+  sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
+  md5: f44b80b9405410e5bde6bfe0b31d5b3f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 15135
+  timestamp: 1650293774207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+  sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
+  md5: f87027ccce1361d0f82c0edf1a10d53b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27677
+  timestamp: 1668714367519
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+  sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
+  md5: 1d0bd7e576c64c059ef781dd319ad82a
+  license: MIT
+  license_family: MIT
+  size: 77591
+  timestamp: 1676983230102
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.15.3-py39hca03da5_0.tar.bz2
+  sha256: 1d443901ba6ebeeadb1075590b00e6b747c1eee36da0481ecab78735b2335210
+  md5: 8c837f31d918e77b82434379585a5cfb
+  depends:
+  - bokeh >=2.4.3,<3.0
+  - colorcet
+  - ipython >=5.4.0
+  - matplotlib-base >=3
+  - notebook
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.9.3,<2.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4513741
+  timestamp: 1671783108945
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+  sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
+  md5: 69eb3b03765627b6159ed23cdde78396
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28399065
+  timestamp: 1692293207812
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+  sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
+  md5: 83366cbd3beb073112f4644a613b6bca
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111933
+  timestamp: 1666125627512
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+  sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
+  md5: 647c1a2f8460ffa8c670a1915bbdb494
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38790
+  timestamp: 1678997152549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+  sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
+  md5: 35e541905426c686ef2ff010a0e502fd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51860
+  timestamp: 1698254731870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+  sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
+  md5: 187d7720aedf38759d122cccb4576f2c
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 219976
+  timestamp: 1691121991680
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+  sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
+  md5: e8e7f10741f9cfa737b310b334940441
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1255894
+  timestamp: 1694181494549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+  sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
+  md5: ff209e75aee17af2e358b0008fbe8c88
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1022945
+  timestamp: 1644315931223
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+  sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
+  md5: d3e78ef296b3c74910d003bd10b475d6
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213972
+  timestamp: 1666908195870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
+  md5: 055e12390b844ea6c6e956ee08a618e8
+  license: IJG
+  license_family: Other
+  size: 273479
+  timestamp: 1677849171867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+  sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
+  md5: 783e2ad3d36472648c5ccc9f3051db3c
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133077
+  timestamp: 1676558732505
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+  sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
+  md5: 0677598f673f9729b5990316170a999d
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 197129
+  timestamp: 1676329661580
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+  sha256: 05f9ca0fdcfdc2e217438be27fead588c843a3aadf7d034467c83216d1e5c214
+  md5: 2d648b77d817ba38293c0728711ba8f5
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92852
+  timestamp: 1679906632236
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+  sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
+  md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 401319
+  timestamp: 1671707682572
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+  sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
+  md5: 247558a0aecf1ef7e77a4343761353d6
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64600
+  timestamp: 1672387273585
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
+  md5: a0f206782751dfffed0dd51302a1bf26
+  license: MIT
+  size: 68012
+  timestamp: 1659616138077
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
+  md5: 4c6667cdd061d28e9bc4e4300e4d115e
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 31173
+  timestamp: 1659616155596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
+  md5: 637e9430e258ddf050623ef2360184d8
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 298430
+  timestamp: 1659616172209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+  sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
+  md5: 55c615026c0869f8d3ba657f3bd38c43
+  license: MIT
+  license_family: MIT
+  size: 120389
+  timestamp: 1683716579036
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+  sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
+  md5: a41117710dafe569c9cc4e83f6f29fe3
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1411339
+  timestamp: 1650982753977
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+  sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
+  md5: 98d22e0124d55fae3c37c608dab1dcc9
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 89825
+  timestamp: 1694778225280
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+  sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
+  md5: 0ba499df6755eae5d2d23aa4ab004553
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 642657
+  timestamp: 1692970217410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+  sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
+  md5: c73101971e5ab6a8e8688239884eac81
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241607
+  timestamp: 1692973585084
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+  sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
+  md5: 353dff9d5d996c2a260f66381b2ce3e8
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1470815
+  timestamp: 1695058433965
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+  sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
+  md5: c99006da802a97c9aae30da8c16b4820
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176131
+  timestamp: 1670944706815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+  sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
+  md5: 60bd1e037cda86205526f77405d78129
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123361
+  timestamp: 1671541992772
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+  sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
+  md5: 34dfd76da78de2eae95bbda390d746d6
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23092
+  timestamp: 1654598007056
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.7.2-py39h46d7db6_0.tar.bz2
+  sha256: b7b71b39d154fd61dba887e03a2111d1ab8e49b471e2e5a87ce49d7010bcdd6c
+  md5: 827a271d1eefd47e86e212d785b15fcd
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=5.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.20,<2.0a0
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7935161
+  timestamp: 1693812618061
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+  sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
+  md5: eb79dabbeedee7da85dfbfb145bb8a26
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17342
+  timestamp: 1662014601345
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+  sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
+  md5: 56db7bd3ff511cd839bda081523b3edd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 55683
+  timestamp: 1629356128780
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+  sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
+  md5: 176e0dcaeb28393881bacf69941e3889
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8289638
+  timestamp: 1681756329011
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+  sha256: afc6f332c51a3defc69e4c4e641988c0556039b9cd42be22f3db5292c88ccf37
+  md5: 2bc409c7258160a9b739d08d5ffb5998
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 96942
+  timestamp: 1650373637069
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+  sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
+  md5: 150ea9fadddf21993d3328d3e48a18b7
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 557688
+  timestamp: 1668450759059
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+  sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
+  md5: 37163b32508f9f589b3e6462a3a47546
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148426
+  timestamp: 1694616771736
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+  sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
+  md5: 6cdf7cbc43bf40e92b056a5576bd0086
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387216468
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.2-py39hca03da5_0.tar.bz2
+  sha256: 1d6fd0252649eb318e6d3c5830b70d90cd4661e571e93271a6aa4e456c5dd17f
+  md5: e113ccf02cbc861cae60311efc0c6b4f
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 514962
+  timestamp: 1668179928420
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+  sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
+  md5: 7de782e4fb34bfa95ef2fc79d27d727d
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22840
+  timestamp: 1668160634885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+  sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
+  md5: 1a7b23113372c5667dbfe45976b9cc5c
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 126357
+  timestamp: 1696515322390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.22.3-py39h25ab29e_0.tar.bz2
+  sha256: fd57c9e37203025e56a8385455f4551dae96e3f0f8ca066c7b125c53c1b3e071
+  md5: 7c80ee34c22620f29ba8e9c5e9cf31ff
+  depends:
+  - blas * openblas
+  - libcxx >=12.0.0
+  - libopenblas >=0.3.17,<1.0a0
+  - numpy-base 1.22.3 py39h974a1f5_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  size: 10740
+  timestamp: 1652801810602
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.22.3-py39h974a1f5_0.tar.bz2
+  sha256: 1015638dedb768465a55775445926b3d408994d5b58268a460739bd253288cf3
+  md5: 00fced2d07d02ffef0d6378fb1dae193
+  depends:
+  - blas * openblas
+  - libcxx >=12.0.0
+  - libopenblas >=0.3.17,<1.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.22.3 py39h25ab29e_0
+  license: BSD-3-Clause
+  size: 6067353
+  timestamp: 1652801779788
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
+  md5: 371358a54bbdd307603888348d1a2c6f
+  depends:
+  - libcxx >=12.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD 2-Clause
+  size: 412248
+  timestamp: 1628861367714
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+  sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
+  md5: fa15d3b44ae1360ac9b640bbd5b6923c
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4746123
+  timestamp: 1695322833432
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+  sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
+  md5: d73db95f07a282021efdf8bc09713261
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73620
+  timestamp: 1693575195999
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-1.4.4-py39hc377ac9_0.tar.bz2
+  sha256: 64a5c7f7365b8c837621daeeef7e9b5341829768cb89f72026e6827a75e677b6
+  md5: ef101f092953ed17f9f0b7efa2a3cb03
+  depends:
+  - bottleneck >=1.3.1
+  - libcxx >=12.0.0
+  - numexpr >=2.7.1
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12433056
+  timestamp: 1663773462190
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-0.14.3-py39hca03da5_0.tar.bz2
+  sha256: cb0fd0d862204d53fcd866cbe971602c3e7be58d5cc8f9dde2fd3cdf9376439e
+  md5: 274366470779c9c9a91141a769c8457f
+  depends:
+  - bleach
+  - bokeh >=2.4.0,<2.5.0
+  - markdown
+  - param >=1.12.0,<2.0.0a0
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - setuptools >=42
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >1.14.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14650720
+  timestamp: 1676379977310
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+  sha256: 0d64f2438be25524bbfeb8646e4fb3c18499d747398a03ed15d41b350b03e001
+  md5: 6a4908a5c9f7b3f17f09ebc34b1b691c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142857
+  timestamp: 1684915417403
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+  sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
+  md5: 6e01c592ae3b8ff2d12cae76f2f4276b
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 715239
+  timestamp: 1696580071596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+  sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
+  md5: 9fb8f460c130d56caf33c6bbe46fbe8a
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2678841
+  timestamp: 1697548790931
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+  sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
+  md5: 390b8c3cd74281abecdbfd51476922f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33033
+  timestamp: 1692205747301
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+  sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
+  md5: 7896828fb3565fefad43f980d50c8723
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91190
+  timestamp: 1659455206354
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+  sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
+  md5: d934c74eb66d01af0f45f0881f4bab77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580588
+  timestamp: 1672387390426
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+  sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
+  md5: 9858166e5ffb624c8b9d281f4000d725
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 367167
+  timestamp: 1656431368885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+  sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
+  md5: 4d2b45c6be8221e6a3e44c2d5838426f
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30843
+  timestamp: 1675441531640
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+  sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
+  md5: 02521df4e2e79f75faa9cbb3560ab1dd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1861763
+  timestamp: 1684280026169
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+  sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
+  md5: bdebe59bffc7adbad83fdcd9d429a5f5
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95234
+  timestamp: 1690223494699
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+  sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
+  md5: d716e5c9b5eec45ce1df8eb52cab817a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157408
+  timestamp: 1661452601692
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+  sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
+  md5: 1907629863ed8e7c35ead232dae7693f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 91636
+  timestamp: 1628941083263
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+  sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
+  md5: 847b9bddf2a86e1609c0d53bbc23ea79
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 27378
+  timestamp: 1626781391140
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+  sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
+  md5: 18aa18bd0d260605923877921d26cc74
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13194025
+  timestamp: 1694438901368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+  sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
+  md5: 45642a99c83e7aed74d1ffab1f20145b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 266647
+  timestamp: 1661368655993
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+  sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
+  md5: fec748525144049a2fc7f52f9755232c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257235
+  timestamp: 1695131702047
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+  sha256: 960192a143672e9c1d6fe4027af448512d91eee7501e5c245c21b865cf8bf429
+  md5: 76d491244218505f071ba56a308673df
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40950
+  timestamp: 1685030774581
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+  sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
+  md5: 3445d25415998c807efbe64d3a7e03c8
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 167068
+  timestamp: 1698096118071
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+  sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
+  md5: e6e92da28e9b0e428ed4b7df417bec25
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 472418
+  timestamp: 1657724315435
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+  sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
+  md5: dba22515f36d3c266de5896350813ea2
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95103
+  timestamp: 1690400315537
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+  sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
+  md5: 3cd7eb43e285faba76faf67667e26b00
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093916
+  timestamp: 1690290951258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+  sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
+  md5: c5e9aef0d6895de1c927e9d796cd7cd3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15691
+  timestamp: 1629145910454
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+  sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
+  md5: 0f7c229e774146ffc4e29dedf75372bf
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67279
+  timestamp: 1696347632563
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+  sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
+  md5: 2302a79a045f152e183a52a81adfba62
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1674163
+  timestamp: 1681394762218
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+  sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
+  md5: 4ae67163d55cf9df83d4027ebc38c501
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30894
+  timestamp: 1671751931536
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+  sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
+  md5: dbb5c0cddb6661a89afee647fd3dc01e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39875
+  timestamp: 1668168874870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+  sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
+  md5: 667e60c8b407d73cbba40f44901f4f00
+  depends:
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3412693
+  timestamp: 1654088929697
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+  sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
+  md5: 884f788a5f6a664c9b79f7a4a60362d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680561
+  timestamp: 1696937004165
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+  sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
+  md5: 639a4f489af172c866c18442948e5874
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - slack-sdk
+  - requests
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125170
+  timestamp: 1679561942932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+  sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
+  md5: e5b90eba83fddba6d7aa6072b5bf7c91
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193017
+  timestamp: 1671143921826
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
+  md5: 644ef8830437070f60efcfcd6a987198
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9670
+  timestamp: 1690297532002
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
+  md5: a902a833bb186a2f1a4b2b89b1195136
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58466
+  timestamp: 1690297524418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+  sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
+  md5: f3f1d2c1028dad2f11ff950a15c99dbf
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188640
+  timestamp: 1698257577209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+  sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
+  md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20091
+  timestamp: 1629144441130
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+  sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
+  md5: 3089c63bf8f4d0423e1a287da286d83e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70923
+  timestamp: 1629357115820
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+  sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
+  md5: 5886b30b312445471268444f41f39dc7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102583
+  timestamp: 1695741976083
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+  sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
+  md5: 2e75ad6a09c308268192efe03cc9ebf4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 411778
+  timestamp: 1683113019715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+  sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
+  md5: 30f666bf97c26587c5d2f68cc5f330ab
+  depends:
+  - libcxx >=12.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 316901
+  timestamp: 1629287855861
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+  sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
+  md5: 584e591d36dcd5ba5c45404f0f7ebb2d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19076
+  timestamp: 1672387153578
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+  sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
+  md5: 467ae28215d1aa1c5688bc0c8a184269
+  license: Zlib
+  license_family: Other
+  size: 103525
+  timestamp: 1666595022664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+  sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
+  md5: 7cfbed15f1feee1422810f7830075f53
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 779464
+  timestamp: 1681304594848
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+  sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
+  md5: ed14f9bc6e55220483f1a5a388625a08
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162772
+  timestamp: 1644481986085
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+  sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
+  md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 39253
+  timestamp: 1644551767970
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+  sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
+  md5: b24d13c443a26f65a0778b475a5726bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132830
+  timestamp: 1695717959996
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+  sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
+  md5: 302c3c0696e17eaa62e140e3892644ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 199723
+  timestamp: 1681493196911
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-2.4.3-py39haa95532_0.tar.bz2
+  sha256: a8150eba2526f695999bf260643c51779153bece456d86bb5ceaf2320dc28436
+  md5: af8143c21529c930f9d54b9fa12df1f9
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3,<2.0a0
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14460067
+  timestamp: 1658137245730
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+  sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
+  md5: bf930260f679bc74227bbb18bc36ae82
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 119700
+  timestamp: 1657176150595
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
+  md5: 507dfe693ef429f466d964b599f4af21
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_7
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 18650
+  timestamp: 1659616328001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
+  md5: d0bf43e8df60baae3b3105aa5c42a791
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 21153
+  timestamp: 1659616312367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+  sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
+  md5: 7bd24bf94c24e810aecaaf84a0978e6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 343204
+  timestamp: 1659616543542
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+  sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
+  md5: 092b417c11edcbe6bb9b765ab4a55d23
+  license: MPL-2.0
+  license_family: Other
+  size: 164999
+  timestamp: 1694009822357
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+  sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
+  md5: 708a750d370b9d6875651021e21c4446
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159322
+  timestamp: 1690232335307
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+  sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
+  md5: c35736da3ea26782425e78061268cf5e
+  depends:
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 228713
+  timestamp: 1670423312743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+  sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
+  md5: 457a4339a53c033d48ce0c72e5038d2e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30330
+  timestamp: 1672387265402
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+  sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
+  md5: 59ec65fd9e06b81a65cc12986c67d5da
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1939614
+  timestamp: 1668084794027
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+  sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
+  md5: 3489c1a2b73fc957b5a62cc59349e25b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13438
+  timestamp: 1671231196438
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+  sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
+  md5: 3492b96083c1e904cc32d26ea7f1e1d8
+  depends:
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184280
+  timestamp: 1663827558327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+  sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
+  md5: f46d904bc6f220327e70474971341f52
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1220835
+  timestamp: 1694445639066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+  sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
+  md5: 2ff4fb509788b0e47ac684ba151394d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3289966
+  timestamp: 1690907040646
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+  sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
+  md5: 0f166c3e70541d8bee6e9d0cb60fb66e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16979
+  timestamp: 1649926678161
+- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+  sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
+  md5: ea93d413944ca6a8677eb1b284b136ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27388
+  timestamp: 1668714577678
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+  sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
+  md5: 9f167d3e45441bc3633c1974b1b0ce8c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 88421
+  timestamp: 1676983264486
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.15.3-py39haa95532_0.tar.bz2
+  sha256: b4ec747508b48b8f660ac4569d1a5fd2956673d2a3b82287c42d8ad5710008c4
+  md5: 1ae2dc42ab5a058f691716ddc5c890e6
+  depends:
+  - bokeh >=2.4.3,<3.0
+  - colorcet
+  - ipython >=5.4.0
+  - matplotlib-base >=3
+  - notebook
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.9.3,<2.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4464293
+  timestamp: 1671783118101
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+  sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
+  md5: 30fdefd1541c789c163751291a8faa88
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111448
+  timestamp: 1666125667599
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+  sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
+  md5: a10f07c7a3510272a296f9fed458a4ed
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38098
+  timestamp: 1678997241511
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+  sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
+  md5: fad9cf2023d807da8d44996e9d4399a0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51490
+  timestamp: 1698254721864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+  sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
+  md5: 9834848bd7c7759acf12e78d09388563
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3891030
+  timestamp: 1681801474383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+  sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
+  md5: 1285c8c628bc912c54d0968574c9f4c9
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217232
+  timestamp: 1691122695748
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+  sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
+  md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
+  depends:
+  - backcall
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1279433
+  timestamp: 1694181820978
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+  sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
+  md5: f5fcce35d3f21cdfc5893c5a7a86c651
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1035394
+  timestamp: 1644315567034
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+  sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
+  md5: f67fe3337528e2886f1ac3ab8ac37985
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213110
+  timestamp: 1666908350218
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
+  md5: 81f2c343dc4c65eea39c45383272068f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 407861
+  timestamp: 1677849239400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+  sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
+  md5: bd9526d38a145fe311a8aa36bc11e071
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 152006
+  timestamp: 1676558783570
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+  sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
+  md5: a00e6a62956fde3c4135464353ee8a53
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229158
+  timestamp: 1676330909084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+  sha256: db8335d6531b03c7bdfe789ebacc52631ac6ea4a37700bb3da1f6a53a1acd724
+  md5: ebeba61994cc225ea5f4f42caa511019
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116681
+  timestamp: 1679906658986
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+  sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
+  md5: 5efa1332f7c0a8d9638eda02170c4ce5
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pywinpty
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 413653
+  timestamp: 1671707957673
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+  sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
+  md5: 891fe66a24d8714737b2874985ee1303
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62298
+  timestamp: 1672388166096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
+  md5: c345f51706eef530454f66b794e5e574
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 68189
+  timestamp: 1659616216976
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
+  md5: a7400cfb72042977bc047909ed504ce8
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 33743
+  timestamp: 1659616248209
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
+  md5: 6307f6854754ab5bd7c84e6998385bb1
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 733177
+  timestamp: 1659616279453
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+  sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
+  md5: b812bc5d9c76242e2bb2ac87afe7d39b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 730280
+  timestamp: 1650983734373
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+  sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
+  md5: ba9418df9288a2f031a02fa35b774ce0
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78524
+  timestamp: 1694778314659
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+  sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
+  md5: 6ece7f1a3248169837714d05d7f6ef0a
+  depends:
+  - libiconv >=1.16,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 3513910
+  timestamp: 1692971505729
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+  sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
+  md5: bd7ec244935e83e850a4ff34e8e2e64f
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 513971
+  timestamp: 1692973657152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+  sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
+  md5: fb7881e74b59262df0fa4ec981964efc
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1244887
+  timestamp: 1695058550693
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+  sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
+  md5: 6970c7f46b0164cad1d210e7a1419959
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143434
+  timestamp: 1670944902624
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+  sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
+  md5: 1015298551c040c6d5e26eebbae12ef5
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142316
+  timestamp: 1671542240512
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+  sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
+  md5: 466da740fafef3d6bce114220f0be306
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28510
+  timestamp: 1654508162239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.7.2-py39h4ed8f06_0.tar.bz2
+  sha256: e2d6d88886fb6c1e669fd016b46ecb9bf29ae5d6da5a801044370afd17c38c1b
+  md5: 04601ee54cd0bd3ebe755b81106397bd
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=5.2.0
+  - kiwisolver >=1.0.1
+  - numpy >=1.20,<2.0a0
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7936938
+  timestamp: 1693813261086
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+  sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
+  md5: a9fa43e694b25cd49b8b08a9eefd696e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18054
+  timestamp: 1661915903969
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+  sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
+  md5: 248c468abced874f0231d3cc23177c77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58488
+  timestamp: 1607359497934
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+  sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
+  md5: 5e763c995ff0c549f68a10bce70fede4
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187489950
+  timestamp: 1691503804820
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+  sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
+  md5: dd0c2ece6a743c373c9b5a5919b4818f
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49744
+  timestamp: 1682975040154
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+  sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
+  md5: 57cea8df7ab85f2a98f64d23afcb1f90
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184956
+  timestamp: 1695058491736
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+  sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
+  md5: 8769cdd201d905069800488fe31574e5
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 256221
+  timestamp: 1695060152521
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+  sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
+  md5: d9781492332e6326f9fca87f3a8efacd
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8135792
+  timestamp: 1681756491399
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+  sha256: 2dd3178d3c570e30b9490ebabfd7bfac806afad8302d3dee0edc619805034397
+  md5: bef9da0f0694c45b6aaa4e6447479eaf
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 118324
+  timestamp: 1650290466135
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+  sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
+  md5: f1d8ce412e115986c403f223b3b47d0f
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 596314
+  timestamp: 1668451106600
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+  sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
+  md5: f96bbef0985d7e66ebf00c0d55e30e23
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 167045
+  timestamp: 1694617078743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+  sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
+  md5: 6e6ba64c8dc5025aeac606404a8df36a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13786
+  timestamp: 1672387480065
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.2-py39haa95532_0.tar.bz2
+  sha256: 434ad797fda12fc09b467e16f587fca1de155b71d183c72e831e93944e9b93dd
+  md5: 6666362eb1ef4397e0e222e20445b856
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 554826
+  timestamp: 1668180355143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+  sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
+  md5: 4269a1f93882205b90d4b2ae78fc82d5
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22417
+  timestamp: 1668160717305
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+  sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
+  md5: a18a576b7024cfd6f905c526a786a916
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 135285
+  timestamp: 1696515698492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.22.3-py39h6917f2d_2.tar.bz2
+  sha256: b70978e0e60c26074991b1652747d612827754378f058adf2715138899002d60
+  md5: 70469e853bc618c24e9915052f971fd7
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.22.3 py39h46c4fa8_2
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  size: 10601
+  timestamp: 1682981321777
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.22.3-py39h46c4fa8_2.tar.bz2
+  sha256: 21ea94d97361abfb0ac5197b6ac020253657c0033ceaea6fb18713fb9cf9f58d
+  md5: b3b783e57bd203378d2124c7e171e5e3
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - numpy 1.22.3 py39h6917f2d_2
+  license: BSD-3-Clause
+  size: 6403234
+  timestamp: 1682981297386
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
+  md5: ab07e2a27ac08afe3d0b4c0890b8486a
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 2-Clause
+  size: 249316
+  timestamp: 1630094024143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+  sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
+  md5: 73b17037d87b5a58feb34dafc0538f7f
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8058396
+  timestamp: 1695324589828
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+  sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
+  md5: df1d746ba8d5d6ba01ac1373b9b71e1a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73016
+  timestamp: 1693575484990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-1.4.4-py39hd77b12b_0.tar.bz2
+  sha256: d81d8ef52a07a9cd294e98d4e069ad86f990cfe3b3064bfde540a3f04e0ee9a4
+  md5: 25de49536214af419d337679d8040cba
+  depends:
+  - bottleneck >=1.3.1
+  - numexpr >=2.7.1
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11584490
+  timestamp: 1663773415594
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-0.14.3-py39haa95532_0.tar.bz2
+  sha256: 00a343d88532d207ef3f8387af638b82608a8904ef11c9a1495693bb4658c49a
+  md5: 0f761c1e7e55d96c6504348291a2d7c4
+  depends:
+  - bleach
+  - bokeh >=2.4.0,<2.5.0
+  - markdown
+  - param >=1.12.0,<2.0.0a0
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - setuptools >=42
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >1.14.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14717609
+  timestamp: 1676380051970
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+  sha256: 2773f47b2d745ab483cf7fcbd5b5e2f7020d45462d32d2ccd5cf232ca13c6f67
+  md5: ca16cd208037bd58d2da267c338da4a4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142229
+  timestamp: 1684915524241
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+  sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
+  md5: 427c1450bebb632f43bbc8c83006e4cd
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 806931
+  timestamp: 1696580240310
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+  sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
+  md5: 21790cd3e2b8a45c4104aff0a68330d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3001751
+  timestamp: 1697549357662
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+  sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
+  md5: 56f44a1054da2d10777e375838191070
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 32355
+  timestamp: 1692205784293
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+  sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
+  md5: 8a35ad65651086575ce55371f22feda8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91045
+  timestamp: 1659455316472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+  sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
+  md5: 186eb95f816a2eff80c3c7f7d964c7b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 578514
+  timestamp: 1672388155359
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+  sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
+  md5: 47b6cbe6ce9289e47d16900b03596a91
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372807
+  timestamp: 1656431445633
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+  sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
+  md5: 07165c444adc7c7ccc8a345875adc5ef
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48408
+  timestamp: 1675450623287
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+  sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
+  md5: d58e76a31e2f6e7410ba4afd7f385b0d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1877445
+  timestamp: 1684280183367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+  sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
+  md5: 0e5b0fe7debbf558ce97090f6b67cdae
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94633
+  timestamp: 1690225630423
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+  sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
+  md5: 0fde797653e4ab589506121fb1e37555
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157119
+  timestamp: 1661452591647
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+  sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
+  md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 92679
+  timestamp: 1636093365041
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+  sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
+  md5: f870859d4dc7a8d82cf3546bd9035f33
+  depends:
+  - python >=3.9,<3.10.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 54520
+  timestamp: 1605307564142
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+  sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
+  md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
+  depends:
+  - openssl >=3.0.10,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 21172845
+  timestamp: 1694442462066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+  sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
+  md5: 9d99075052265ae3d718582d3b875038
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269964
+  timestamp: 1661376543480
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+  sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
+  md5: fa9074d94236c9b768bfd2c858875b27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 264836
+  timestamp: 1695131770282
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+  sha256: 97243a31c39f4990c0e9d4f2307f2f7fb9421553303923bc105067ec4340bdff
+  md5: 8078c5760f27398eaf1082226647d137
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40145
+  timestamp: 1685031143383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+  sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
+  md5: 3d2841085778006c2e79f9c7300f8b9d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13565975
+  timestamp: 1669937633869
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+  sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
+  md5: 54a4bc0724041dd173088419d6ede2af
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 239062
+  timestamp: 1677611495106
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+  sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
+  md5: f39f84115e228bad4bceaefdd637f022
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 158558
+  timestamp: 1698096358091
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+  sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
+  md5: df398a3a1668fd2a22061764e20ea91d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.4,<4.3.5.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 460913
+  timestamp: 1657616061604
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+  sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
+  md5: 38db77ece9dc76feffb9ef7638e38258
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94397
+  timestamp: 1690400496655
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+  sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
+  md5: 3e284ae6b48ee30c364ffdc5601610b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1099842
+  timestamp: 1690291374842
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+  sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
+  md5: 993b3886b334bd1f49d34206f21997b4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15998
+  timestamp: 1614030572433
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+  sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
+  md5: 7ac9604ad7564ac0c71bff5db198656f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67012
+  timestamp: 1696347795139
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+  sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
+  md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1311308
+  timestamp: 1681402905668
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+  sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
+  md5: 28b9869d8d3a839918fac4a08f38cbc2
+  depends:
+  - python >=3.9,<3.10.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30546
+  timestamp: 1671752127904
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+  sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
+  md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39590
+  timestamp: 1668168880994
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+  sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
+  md5: 52cdcdb96383c010ca833a7c24b3935b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Tcl/Tk
+  license_family: BSD
+  size: 3690152
+  timestamp: 1654036853710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+  sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
+  md5: 0e054ab29119cf4c1f778613acf972f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 681780
+  timestamp: 1696937326924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+  sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
+  md5: b6ad839ebba536ad1c3cc58d0e2123f0
+  depends:
+  - colorama
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 143681
+  timestamp: 1679562248929
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+  sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
+  md5: fe78de10019085146f1cc6c94fdc2620
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192822
+  timestamp: 1671143999327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
+  md5: ca5fc3fbdb09b6de068a8b7a8869369f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9208
+  timestamp: 1690298120549
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
+  md5: a86e87a10e5fdff486265e0c675fb99f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57922
+  timestamp: 1690298106990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+  sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
+  md5: 0d31859e0a097aedbcc1627db33b3d92
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188367
+  timestamp: 1698257883295
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+  sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
+  md5: 45ef24c486a484f079faf1dc90e4c7e9
+  depends:
+  - vs2015_runtime >=14.27.29016
+  license: Modified BSD License (3-clause)
+  license_family: BSD
+  size: 8277
+  timestamp: 1605602889180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+  sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
+  md5: 4daaceb6cfc1af6274509081d8018ef1
+  size: 2316783
+  timestamp: 1605602872095
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+  sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
+  md5: 916c16904615c7af3b5d37cb6694f45e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21084
+  timestamp: 1607347371925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+  sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
+  md5: da69e6987fcc757e83a358ceaa13f62b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73391
+  timestamp: 1614804425587
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+  sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
+  md5: 23b9f4634b2e5450be617114f62c74f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 120873
+  timestamp: 1695742300539
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+  sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
+  md5: 120f0b088290fc17bd6618fc10a2f0c4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PUBLIC-DOMAIN
+  size: 34293
+  timestamp: 1605306211299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+  sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
+  md5: c3f7871e9a33adeccee1b1e8e216918e
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 1332571
+  timestamp: 1683113347814
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+  sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
+  md5: 1ab55f8c4b5292ec360c572120bf823e
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-3.0-or-later
+  size: 9430705
+  timestamp: 1616055773485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+  sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
+  md5: 6875e0bf3828707dc9165d694c0d0a7d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18725
+  timestamp: 1672387612937
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+  sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
+  md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 148931
+  timestamp: 1666595229032
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+  sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
+  md5: 8d6a1e767775fe0eb617cd6e22edc2ff
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1871867
+  timestamp: 1681304638261

--- a/boids/pixi.toml
+++ b/boids/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "boids"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
 
 [tool.metadata]

--- a/boids/pixi.toml
+++ b/boids/pixi.toml
@@ -1,0 +1,28 @@
+[workspace]
+name = "boids"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2015-01-01"
+maintainers = ["jlstevens"]
+categories = ["Other Sciences", "Mathematics"]
+labels = ["holoviews", "bokeh"]
+description = "Boids models of swarm intelligence using HoloViews"
+no_data_ingestion = true
+
+[dependencies]
+python = "3.9.*"
+notebook = "6.5.2.*"
+bokeh = "2.4.3.*"
+holoviews = "1.15.3.*"
+numpy = "1.22.*"
+pandas = "<1.5"
+pip = "*"
+wheel = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks]
+notebook = "jupyter notebook boids.ipynb"

--- a/boids/pixi.toml
+++ b/boids/pixi.toml
@@ -18,11 +18,11 @@ bokeh = "2.4.3.*"
 holoviews = "1.15.3.*"
 numpy = "1.22.*"
 pandas = "<1.5"
-pip = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks]
 notebook = "jupyter notebook boids.ipynb"

--- a/carbon_flux/pixi.lock
+++ b/carbon_flux/pixi.lock
@@ -7,7 +7,6 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://conda.anaconda.org/nodefaults/
     - url: https://conda.anaconda.org/conda-forge/
     packages:
       linux-64:

--- a/carbon_flux/pixi.lock
+++ b/carbon_flux/pixi.lock
@@ -1,0 +1,11692 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/nodefaults/
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.13-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311h9ecbd09_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.31-hd5d0ea3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.7.4-hae4d56a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.29-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.19-h2bff981_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.3-h6c1f5b1_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.10-hf2c527e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.20-hc9e6898_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.7-hfbb250a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.6.7-h7f2cdf9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.19-h2bff981_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.20-h2bff981_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.28.5-h5cd2d59_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.407-h9eeb5ce_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.20.0-py311h38be061_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/awscrt-0.22.0-py311h4e8466f_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.14.0-h5cfcd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.10.0-h113e628_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.13.0-h3cf044e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.8.0-h736e048_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.12.0-ha633028_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-hef167b5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hfdbb021_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.3-heb4867d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hebfffa5_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.24.0-py311h7db5c69_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.4-py311h9f3472d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.1-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cramjam-2.8.4rc3-py311ha8c6e60_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-43.0.1-py311hafd3f86_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.27-h54b06d7_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.0.0-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.8-py311hfdbb021_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.19-py311h38be061_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.3.0-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.4-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fastparquet-2024.5.0-py311h9f3472d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.54.1-py311h2dc5d0c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.13.0-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hda332d3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.4-nompi_h2d575fe_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.7-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_h5888daf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-17.0.0-hdb9dd6d_23_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-17.0.0-h5888daf_23_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-17.0.0-h5888daf_23_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-17.0.0-he882d9a_23_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp19.1-19.1.3-default_hb5137d0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-19.1.3-default_h9c6a7e4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.123-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.2-h2ff4ddf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.30.0-h438788a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.30.0-h0121fbd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.65.5-hf5c653b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm19-19.1.3-ha7bfdaf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h2564987_115.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.4-h7f98852_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-17.0.0-h6bd9018_23_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.0-h04577a9_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.27.5-h5b01275_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hbbce691_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.21.0-h0e7cc3e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-he137b08_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.7.0-h2c5496b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-hb346dea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.39-h76b75d6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.11.2-h6991a6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.43.0-py311h9c9ff8c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.3-py311h2cbdf9a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py311h2dc5d0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.9.2-py311h38be061_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.2-py311h2b939e6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.0-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-9.0.1-h266115a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-9.0.1-he0572af_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.2-nompi_py311h7c29e4f_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.60.0-py311h4bc866e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.0.2-py311h71ddf71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.8-hedd0468_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.2-h690cf93_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py311h7db5c69_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.0.0-py311h49e9ac3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.5.0-h12925eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-17.0.0-py311hbd00459_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-17.0.0-py311h4854187_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.0-py311h0f98d5a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.8.0.2-py311h9053184_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.10-hc5c86c4_3_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py311h7deb3e3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.8.0-h6e8976b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h77b4e00_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.21.0-py311h9e33e62_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.17.21-py311h2582759_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.8-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.5-h3931f03_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.5.2-py311h57cc02b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py311he9a78e4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.6-py311h2fdb869_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.47.0-h9eae976_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.1-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.23.1-h3e06ad9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-hb711507_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.43-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-he73a12e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.10-h4f16b4b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.6-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.1-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.4-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.5-hb9d3cd8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.13.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.13.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.5.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh41d4057_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.38-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.38-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_0.conda
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.13.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.13.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.5.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.38-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.38-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h3336109_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.31-hc566b99_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.7.4-h40772b6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.29-ha44c9a9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.19-h40772b6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.3-h453e538_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.10-h592d179_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.20-h99e8e40_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.7-h86759dc_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.6.7-h24045d9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.19-h40772b6_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.20-h40772b6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.28.5-h791b958_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.407-h96db62b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/awscli-2.20.0-py311h6eed73b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/awscrt-0.22.0-py311hefc6fae_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.14.0-h9a36307_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.10.0-ha4e2ba9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.13.0-h3d2f5f1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.8.0-h1ccc5ac_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-files-datalake-cpp-12.12.0-h86941f0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.6-h7d75f6d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hd89902b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.3-hf13058a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.8.30-h8857fd0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cartopy-0.24.0-py311haeb46be_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.1-py311h137bacd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cftime-1.6.4-py311h0034819_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.1-py311h4e34fa0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cramjam-2.8.4rc3-py311h4c0077b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cryptography-43.0.1-py311he4fabbe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.0.0-py311h3336109_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.8-py311hc356e98_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/docutils-0.19-py311h6eed73b_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fastparquet-2024.5.0-py311hde34974_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.54.1-py311h8b4e8a7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.13.0-hac325c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hac325c4_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h2790a97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.4-nompi_h1607680_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.7-py311hf2f7c97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240722.0-cxx17_hac325c4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-17.0.0-h0c1ea87_23_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-17.0.0-h240833e_23_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-17.0.0-h240833e_23_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-17.0.0-hdefb866_23_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-25_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-25_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.10.1-h58e7537_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.3-hf95d169_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.22-h00291cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.4-h240833e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.30.0-hade041e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.30.0-h8126ed0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.65.5-hb88832f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-25_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-hc8e404f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.2-nompi_h976d569_115.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.64.0-hc7306c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_hbf64a52_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-17.0.0-hc957f30_23_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.44-h4b8f8c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-5.27.5-h62b0dff_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2024.07.02-hd530cb8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.0-h2f8c449_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.21.0-h75589b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-h583c2ba_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.5-h495214b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzip-1.11.2-h31df5bb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.3-hf78d878_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.43.0-py311h25b8078_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-4.3.3-py311h12b7ed1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.2-py311h8b4e8a7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.9.2-py311h6eed73b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.2-py311h8b21175_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.1.0-py311hf2f7c97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/netcdf4-1.7.2-nompi_py311h62486fc_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.60.0-py311h0e5bd6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.0.2-py311h394b0bb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hd471939_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.2-h52ea4d3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.3-py311haeb46be_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.0.0-py311h1f68098_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.5.0-h70d2bda_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.0-py311h1314207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-17.0.0-py311he764780_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-17.0.0-py311he02522f_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.3.1-py311hd6939f8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.3.1-py311hd6939f8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.7.0-py311h50e4d0a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.10-ha513fb2_3_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311h3336109_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.2.0-py311h4d3da15_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2024.07.02-h2fb0a26_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.21.0-py311h3b9c2be_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.17.21-py311h5547dcb_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.8-py311h1314207_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.5.2-py311ha1d5734_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.1-py311hed734c1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.6-py311h9a2ae1f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-he1e6707_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.47.0-h6285a30_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.1-py311h3336109_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-15.1.0-py311h1314207_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h00291cd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-he4ceba3_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-hd23fc13_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.13.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.13.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.5.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.38-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.38-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311h460d6c5_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.31-h5a2a37f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.7.4-hd45b2be_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.29-h7ab814d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.19-hd45b2be_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.4.3-h4346b05_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.8.10-ha971391_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.14.20-h5ad5fc2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.10.7-hd3a49e8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.6.7-hb6e36da_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.19-hd45b2be_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.20-hd45b2be_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.28.5-h2612a5e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.407-hced06f0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/awscli-2.20.0-py311h267d04e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/awscrt-0.22.0-py311h83cc776_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.14.0-hd50102c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.10.0-hc602bab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.13.0-h7585a09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.8.0-h9ca1f76_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.12.0-hcdd55da_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h5499902_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311h3f08180_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.3-h5505292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cartopy-0.24.0-py311h9cb3ce9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py311h3a79f62_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.4-py311h0f07fe1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.1-py311h210dab8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cramjam-2.8.4rc3-py311h18e95ce_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-43.0.1-py311h47c44cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.0.0-py311h460d6c5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.8-py311h155a34a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/docutils-0.19-py311h267d04e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fastparquet-2024.5.0-py311ha7f2236_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.54.1-py311h56c23cb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.13.0-hf9b8971_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.4-nompi_ha698983_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py311h267d04e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.7-py311h2c37856_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_hf9b8971_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-17.0.0-h20d9b6e_23_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-17.0.0-h286801f_23_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-17.0.0-h286801f_23_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-17.0.0-hdcc9e87_23_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-25_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-25_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.10.1-h13a7ad3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.3-ha82da77_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.22-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.30.0-h2e6cea1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.30.0-h90fd6fa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.65.5-h3d9cf25_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-25_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnetcdf-4.9.2-nompi_h853a48d_115.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-17.0.0-hda0ea68_23_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.27.5-h53f8970_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2024.07.02-h2348fd5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.47.0-hbaaea75_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.21.0-h64651cc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-hfce79cd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-h1a8c8d9_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.13.5-h376fa9f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzip-1.11.2-h1336266_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.3-hb52a8e5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.43.0-py311hc367efa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-4.3.3-py311hebe0b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py311h56c23cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-3.9.2-py311ha1ab1f8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.9.2-py311hbe3227e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.0-py311h2c37856_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/netcdf4-1.7.2-nompi_py311hd13e3db_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.60.0-py311h9506ed5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.0.2-py311h6de8079_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h39f12f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.2-h4a9587e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py311h9cb3ce9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.0.0-py311h3894ae9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.5.0-h61a8e3e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py311hae2e1ce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-17.0.0-py311h35c05fe_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-17.0.0-py311he04fa90_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.3.1-py311h09e6bbd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.3.1-py311h09e6bbd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.0-py311hb4b81e0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.10-hc51fdd5_3_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h460d6c5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.0-py311h730b646_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2024.07.02-hcd0e937_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.21.0-py311h3ff9189_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.17.21-py311he2be06e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.8-py311hae2e1ce_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.5.2-py311h9e23f0f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.1-py311hf1db568_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.6-py311hac502b4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.47.0-hcd14bea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.1-py311h460d6c5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-15.1.0-py311hae2e1ce_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h9f5b81c_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.10-py311hd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.13.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.13.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.5.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh5737063_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh5737063_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.38-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.38-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311he736701_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.31-hd4326aa_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.7.4-h891f644_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.29-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.19-h891f644_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.3-h0311a85_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.10-h71eeabb_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.20-h5c5bb51_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.7-h595efa6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.6.7-h1c89dc9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.19-h891f644_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.20-h891f644_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.28.5-hf2a67f4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.407-hfa5b0db_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/awscli-2.20.0-py311h1ea47a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/awscrt-0.22.0-py311hb961b49_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.6-h85f69ea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311hda3d55a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.34.3-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h32b962e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cartopy-0.24.0-py311hcf9f919_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cftime-1.6.4-py311h0a17f05_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.1-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cramjam-2.8.4rc3-py311ha637bb9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-43.0.1-py311hfd75b31_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.0.0-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.8-py311hda3d55a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/docutils-0.19-py311h1ea47a8_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/double-conversion-3.3.0-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fastparquet-2024.5.0-py311h0a17f05_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.15.0-h765892d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.54.1-py311h5082efb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.13.0-h5a68840_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-h63175ca_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-9.0.0-h2bedf89_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.4-nompi_hd5d9e70_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/icu-75.1-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.7-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_he0c23c2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-17.0.0-h1a545c8_23_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-17.0.0-hac47afa_23_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-17.0.0-hac47afa_23_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-17.0.0-ha9530af_23_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-19.1.3-default_ha5278ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.22-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.4-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-14.2.0-h1383e82_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.82.2-h7025463_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-14.2.0-h1383e82_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.30.0-ha00044d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.30.0-he5eb982_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.65.5-ha20e22e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_he239ae6_115.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-17.0.0-h59f2d37_23_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.27.5-hcaed137_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2024.07.02-h4eb7d71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.0-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.21.0-hbe90ef8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hfc51747_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-h82a8f57_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.5-h442d1da_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxslt-1.1.39-h3df6e99_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzip-1.11.2-h3135430_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.43.0-py311h7deaa30_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-4.3.3-py311h8b5e962_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py311h5082efb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-3.9.2-py311h1ea47a8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.2-py311h8f1b1e4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.0-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/netcdf4-1.7.2-nompi_py311hc43f1c8_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.60.0-py311h0673bce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.0.2-py311h35ffc71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.4.0-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.2-h1c5a4bf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py311hcf9f919_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.0.0-py311h4fbf6a9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.5.0-hd9569ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-17.0.0-py311h06a5be4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-17.0.0-py311hdea38fa_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.7.0-py311h90dcb63_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.8.0.2-py311h4238720_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.10-hce54a09_3_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-307-py311hda3d55a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.14-py311hda3d55a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.2.0-py311h484c95c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.8.0-hfb098fa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2024.07.02-hd3b24a8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.21.0-py311h533ab2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.17.21-py311ha68e1ae_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.8-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.5.2-py311hdcb8d17_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py311hf16d85f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.6-py311hd54bd37_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.47.0-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.7.0-h91493d7_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.1-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-15.1.0-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h8a93ad2_22.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-hcc2c482_22.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_22.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-h0e40799_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.5-h0e40799_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  license: None
+  size: 2562
+  timestamp: 1578324546067
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23621
+  timestamp: 1650670423406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.13-hb9d3cd8_0.conda
+  sha256: f507b58f77eabc0cc133723cb7fc45c053d551f234df85e70fb3ede082b0cd53
+  md5: ae1370588aa6a5157c34c73e9bbb36a0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  license_family: GPL
+  size: 560238
+  timestamp: 1731489643707
+- conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311h9ecbd09_5.conda
+  sha256: d1af1fbcb698c2e07b0d1d2b98384dd6021fa55c8bcb920e3652e0b0c393881b
+  md5: 18143eab7fcd6662c604b85850f0db1e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.0.1
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 35025
+  timestamp: 1725356735679
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.31-hd5d0ea3_3.conda
+  sha256: 7ed62cde8328b46a6abce032fe485ac895b3e9708e104894d1a009df4464ad6a
+  md5: bafc68489a651309865dde375cf3cbf6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-http >=0.8.10,<0.8.11.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - aws-c-sdkutils >=0.1.19,<0.1.20.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 107528
+  timestamp: 1729532890379
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.7.4-hae4d56a_2.conda
+  sha256: 4bfed63898a1697364ce9621e1fc09c98f143777b0ca60655eb812efa5bf246d
+  md5: cdc628e4ffb4ffcd476e3847267e1689
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - libgcc >=13
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 47181
+  timestamp: 1728755555430
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.29-hb9d3cd8_0.conda
+  sha256: b3b50f518e9afad383f6851bf7000cf8b343d7d3ca71558df233ee7b4bfc2919
+  md5: acc51b49fd7467c8dfe4343001b812b4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 237231
+  timestamp: 1728706773555
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.19-h2bff981_2.conda
+  sha256: 908a416ff3f62b09bed436e1f77418f54115412244734d3960b11d586dd0749f
+  md5: 87a059d4d2ab89409496416119dd7152
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 18983
+  timestamp: 1728750679322
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.3-h6c1f5b1_5.conda
+  sha256: 8d2e539e0d85910cad5a76a926733640f674831eda6ca1c7189ef3007a776694
+  md5: a7687d8db2bffc90a3ff09bca039fef3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - aws-checksums >=0.1.20,<0.1.21.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 53733
+  timestamp: 1729527387622
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.10-hf2c527e_3.conda
+  sha256: 864d8dcefc774bbcf95ce55bc5c15a650a469c23b826d93b086d61c020b4759d
+  md5: 85f604aa878f86f15122e129338e4d85
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-compression >=0.2.19,<0.2.20.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 197277
+  timestamp: 1729517838846
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.20-hc9e6898_0.conda
+  sha256: 51ade965ea729146026b5b3237c7f57464608dd1cf723dc4d1e393949d00eeef
+  md5: 005953b39123ac13a959329010a6b1e5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - libgcc >=13
+  - s2n >=1.5.5,<1.5.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 158898
+  timestamp: 1729105763896
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.7-hfbb250a_3.conda
+  sha256: ed69c3cb9001a71868bd64615cd5b13e313f337e9d81685d2c90b4f5b004f2e1
+  md5: f9bceff531a0b88a5c45083ac357f6f2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-http >=0.8.10,<0.8.11.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 194643
+  timestamp: 1729534125666
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.6.7-h7f2cdf9_1.conda
+  sha256: 3751a4b9a513319cc75ff692abd11c7466c71c9738df054c6beefb678ef6eb8e
+  md5: 9a58eac43e65ed1452787ae1ff1ecd6f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-auth >=0.7.31,<0.7.32.0a0
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-http >=0.8.10,<0.8.11.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - aws-checksums >=0.1.20,<0.1.21.0a0
+  - libgcc >=13
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 112840
+  timestamp: 1729544207376
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.19-h2bff981_4.conda
+  sha256: ef65ca9eb9f32ada6fb1b47759374e7ef4f85db002f2265ebc8fd61718284cbc
+  md5: 5a8afd37e2dfe464d68e63d1c38b08c5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 55957
+  timestamp: 1728755888042
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.20-h2bff981_1.conda
+  sha256: e1793f2e52fe04ef3a6b2069abda7960d061c6f7af1f0d5f616d43e7a7c40e3c
+  md5: 8b424cf6b3cfc5cffe98bf4d16c032fb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 72862
+  timestamp: 1728750748391
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.28.5-h5cd2d59_1.conda
+  sha256: c0425c0c10b1d2a474bc60b7c40f75034674938b4c00876dc1866e86d7253b36
+  md5: b582b095ca7e320a411e87ffcf6a4c6b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-auth >=0.7.31,<0.7.32.0a0
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-event-stream >=0.4.3,<0.4.4.0a0
+  - aws-c-http >=0.8.10,<0.8.11.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - aws-c-mqtt >=0.10.7,<0.10.8.0a0
+  - aws-c-s3 >=0.6.7,<0.6.8.0a0
+  - aws-c-sdkutils >=0.1.19,<0.1.20.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 350574
+  timestamp: 1729557116578
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.407-h9eeb5ce_2.conda
+  sha256: df191f1a1eca94d88945667b0e43ff62c7a00d02bc47dbb798e16a574a35e664
+  md5: d77b9537552f9c1363ce89b90c04c6be
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-event-stream >=0.4.3,<0.4.4.0a0
+  - aws-checksums >=0.1.20,<0.1.21.0a0
+  - aws-crt-cpp >=0.28.5,<0.28.6.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2917541
+  timestamp: 1729597235304
+- conda: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.20.0-py311h38be061_0.conda
+  sha256: fd99a6333324576ef1b2ad5319d2ff607ddd7b5dcfb3b7f86df9c7191641f46b
+  md5: 668b59863b2d58a7541f08082a964cc5
+  depends:
+  - awscrt >=0.19.18,<=0.22.0
+  - colorama >=0.2.5,<0.4.7
+  - cryptography >=40.0.0,<43.0.2
+  - distro >=1.5.0,<1.9.0
+  - docutils >=0.10,<0.20
+  - jmespath >=0.7.1,<1.1.0
+  - prompt_toolkit >=3.0.24,<3.0.39
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.1,<=2.9.0
+  - python_abi 3.11.* *_cp311
+  - ruamel.yaml >=0.15.0,<=0.17.21
+  - ruamel.yaml.clib >=0.2.0,<=0.2.8
+  - urllib3 >=1.25.4,<1.27
+  license: Apache-2.0
+  license_family: APACHE
+  size: 12712102
+  timestamp: 1731486682805
+- conda: https://conda.anaconda.org/conda-forge/linux-64/awscrt-0.22.0-py311h4e8466f_6.conda
+  sha256: feea000bc8f9a09352899032b55651491fec8eec5015ec4178166cb49b77cf20
+  md5: 73ca7f07d7a5ccfaff0c61a63aa152fc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-auth >=0.7.31,<0.7.32.0a0
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-event-stream >=0.4.3,<0.4.4.0a0
+  - aws-c-http >=0.8.10,<0.8.11.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - aws-c-mqtt >=0.10.7,<0.10.8.0a0
+  - aws-c-s3 >=0.6.7,<0.6.8.0a0
+  - aws-checksums >=0.1.20,<0.1.21.0a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - s2n >=1.5.5,<1.5.6.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 196314
+  timestamp: 1729557382799
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.14.0-h5cfcd09_0.conda
+  sha256: fe07debdb089a3db17f40a7f20d283d75284bb4fc269ef727b8ba6fc93f7cb5a
+  md5: 0a8838771cc2e985cd295e01ae83baf1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 345117
+  timestamp: 1728053909574
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.10.0-h113e628_0.conda
+  sha256: 286b31616c191486626cb49e9ceb5920d29394b9e913c23adb7eb637629ba4de
+  md5: 73f73f60854f325a55f1d31459f2ab73
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 232351
+  timestamp: 1728486729511
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.13.0-h3cf044e_1.conda
+  sha256: 2606260e5379eed255bcdc6adc39b93fb31477337bcd911c121fc43cd29bf394
+  md5: 7eb66060455c7a47d9dcdbfa9f46579b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  size: 549342
+  timestamp: 1728578123088
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.8.0-h736e048_1.conda
+  sha256: 273475f002b091b66ce7366da04bf164c3732c03f8692ab2ee2d23335b6a82ba
+  md5: 13de36be8de3ae3f05ba127631599213
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.12.7,<2.14.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 149312
+  timestamp: 1728563338704
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.12.0-ha633028_1.conda
+  sha256: 5371e4f3f920933bb89b926a85a67f24388227419abd6e99f6086481e5e8d5f2
+  md5: 7c1980f89dd41b097549782121a73490
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  size: 287366
+  timestamp: 1728729530295
+- conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-hef167b5_0.conda
+  sha256: 6cc260f9c6d32c5e728a2099a52fdd7ee69a782fff7b400d0606fcd32e0f5fd1
+  md5: 54fe76ab3d0189acaef95156874db7f9
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48842
+  timestamp: 1719266029046
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_2.conda
+  sha256: fcb0b5b28ba7492093e54f3184435144e074dfceab27ac8e6a9457e736565b0b
+  md5: 98514fe74548d768907ce7a13f680e8f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli-bin 1.1.0 hb9d3cd8_2
+  - libbrotlidec 1.1.0 hb9d3cd8_2
+  - libbrotlienc 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 19264
+  timestamp: 1725267697072
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_2.conda
+  sha256: 261364d7445513b9a4debc345650fad13c627029bfc800655a266bf1e375bc65
+  md5: c63b5e52939e795ba8d26e35d767a843
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlidec 1.1.0 hb9d3cd8_2
+  - libbrotlienc 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 18881
+  timestamp: 1725267688731
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hfdbb021_2.conda
+  sha256: 949913bbd1f74d1af202d3e4bff2e0a4e792ec00271dc4dd08641d4221aa2e12
+  md5: d21daab070d76490cb39a8f1d1729d79
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  license: MIT
+  license_family: MIT
+  size: 350367
+  timestamp: 1725267768486
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+  sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
+  md5: 62ee74e96c5ebb0af99386de58cf9553
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 252783
+  timestamp: 1720974456583
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.3-heb4867d_0.conda
+  sha256: 1015d731c05ef7de298834833d680b08dea58980b907f644345bd457f9498c99
+  md5: 09a6c610d002e54e18353c06ef61a253
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 205575
+  timestamp: 1731181837907
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
+  sha256: afee721baa6d988e27fef1832f68d6f32ac8cc99cdf6015732224c2841a09cea
+  md5: c27d1c142233b5bc9ca570c6e2e0c244
+  license: ISC
+  size: 159003
+  timestamp: 1725018903918
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hebfffa5_3.conda
+  sha256: aee5b9e6ef71cdfb2aee9beae3ea91910ca761c01c0ef32052e3f94a252fa173
+  md5: fceaedf1cdbcb02df9699a0d9b005292
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libgcc-ng >=12
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.2,<1.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 983604
+  timestamp: 1721138900054
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.24.0-py311h7db5c69_0.conda
+  sha256: 992dd015dcb428c7bbd92f1de18fa3eb1f2cb084625ccf676a91727172361f2d
+  md5: 20ba399d57a2b5de789a5b24341481a1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - matplotlib-base >=3.6
+  - numpy >=1.19,<3
+  - packaging >=21
+  - pyproj >=3.3.1
+  - pyshp >=2.3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - shapely >=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1534682
+  timestamp: 1728342432383
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
+  sha256: bc47aa39c8254e9e487b8bcd74cfa3b4a3de3648869eb1a0b89905986b668e35
+  md5: 55553ecd5328336368db611f350b7039
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 302115
+  timestamp: 1725560701719
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.4-py311h9f3472d_1.conda
+  sha256: 8fa32d106c8757eac936105a5a14eb2eac0c66398cfa954855cb0bd220f003a5
+  md5: 2c3c4f115d28ed9e001a271d5d8585aa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 249930
+  timestamp: 1725400597307
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.1-py311hd18a35c_0.conda
+  sha256: 08be6120dc9369f07858677dde2a8474644cc7ec2ae146b39a6953aadc536dfd
+  md5: 351cb68d2081e249069748b6e60b3cd2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 278209
+  timestamp: 1731428493722
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cramjam-2.8.4rc3-py311ha8c6e60_2.conda
+  sha256: 0100e13ffd47c8492249996e9c4b2305ad0b5100e55c06dba17386aa4559abc8
+  md5: df564e7715f2f17d1f341c5a75cf2b79
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  size: 1735070
+  timestamp: 1726116728088
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-43.0.1-py311hafd3f86_0.conda
+  sha256: 9a63941972809ca9c4397b60f4e1a71a5014b3ae92995e12f94baaf743642561
+  md5: 2653b58a992032d6c3ff4d82fc1c6c82
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.12
+  - libgcc >=13
+  - openssl >=3.3.2,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1501817
+  timestamp: 1725443251219
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.27-h54b06d7_7.conda
+  sha256: d2ea5e52da745c4249e1a818095a28f9c57bd4df22cbfc645352defa468e86c2
+  md5: dce22f70b4e5a407ce88f2be046f4ceb
+  depends:
+  - krb5 >=1.21.1,<1.22.0a0
+  - libgcc-ng >=12
+  - libntlm
+  - libstdcxx-ng >=12
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause-Attribution
+  license_family: BSD
+  size: 219527
+  timestamp: 1690061203707
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.0.0-py311h9ecbd09_1.conda
+  sha256: 42544e13dc4bb018cec0579ad7a6158c1f296e32fa0995ffd8abb116734dc427
+  md5: 765c19c0b6df9c143ac8f959d1a1a238
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 393854
+  timestamp: 1728335173137
+- conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
+  sha256: 8f5f995699a2d9dbdd62c61385bfeeb57c82a681a7c8c5313c395aa0ccab68a5
+  md5: ecfff944ba3960ecb334b9a2663d708d
+  depends:
+  - expat >=2.4.2,<3.0a0
+  - libgcc-ng >=9.4.0
+  - libglib >=2.70.2,<3.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 618596
+  timestamp: 1640112124844
+- conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.8-py311hfdbb021_0.conda
+  sha256: 4a326b01252ebae38a84cb8c37470283ebb37fd1db71469e0e23ca253a0fbe83
+  md5: 698c1e95b2af120f318a0bdec35552b6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2532053
+  timestamp: 1731045057237
+- conda: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.19-py311h38be061_1.tar.bz2
+  sha256: ec7760e5a1d065b97ac32d12f7c70f19937040d8bb52a9f16573b65c6832c67a
+  md5: 599159b0740e9b82e7eef0e8471be3c2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1
+    and GPL-3.0-or-later
+  size: 977628
+  timestamp: 1666754970660
+- conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.3.0-h59595ed_0.conda
+  sha256: 9eee491a73b67fd64379cf715f85f8681568ebc1f02f9e11b4c50d46a3323544
+  md5: c2f83a5ddadadcdb08fe05863295ee97
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78645
+  timestamp: 1686489937183
+- conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.4-h5888daf_0.conda
+  sha256: 1848c7db9e264e3b8036ee133d570dd880422983cd20dd9585a505289606d276
+  md5: 1d6afef758879ef5ee78127eb4cd2c4a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libexpat 2.6.4 h5888daf_0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 138145
+  timestamp: 1730967050578
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fastparquet-2024.5.0-py311h9f3472d_2.conda
+  sha256: 579056abb96527b5811f074cdcf0b4964de78ea6cceb2b023163c8f3b1e03a25
+  md5: de60889fdf79370f423c621f3427efb4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cramjam >=2.3
+  - fsspec
+  - libgcc >=13
+  - numpy >=1.19,<3
+  - numpy >=1.20.3
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 531185
+  timestamp: 1729689490701
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
+  sha256: 7093aa19d6df5ccb6ca50329ef8510c6acb6b0d8001191909397368b65b02113
+  md5: 8f5b0b297b59e1ac160ad4beec99dbee
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freetype >=2.12.1,<3.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libgcc >=13
+  - libuuid >=2.38.1,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 265599
+  timestamp: 1730283881107
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.54.1-py311h2dc5d0c_1.conda
+  sha256: cdef0c6c6597a759b7db2c31eeab773c1097f053ab40f81f0919e2b2a2f56293
+  md5: 7336fc1b2ead4cbdda1268dd6b7a6c38
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli
+  - libgcc >=13
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2876108
+  timestamp: 1729530501689
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+  sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
+  md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 634972
+  timestamp: 1694615932610
+- conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.13.0-h5888daf_0.conda
+  sha256: 5c70d6d16e044859edca85feb9d4f1c3c6062aaf88d650826f5ccdf8c44336de
+  md5: 40b4ab956c90390e407bb177f8a58bab
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: LGPL-2.1-only
+  size: 1869233
+  timestamp: 1725676083126
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
+  sha256: 6c33bf0c4d8f418546ba9c250db4e4221040936aef8956353bc764d4877bc39a
+  md5: d411fc29e338efb48c5fd4576d71d881
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119654
+  timestamp: 1726600001928
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
+  sha256: dc824dc1d0aa358e28da2ecbbb9f03d932d976c8dca11214aa1dcdfcbd054ba2
+  md5: ff862eebdfeb2fd048ae9dc92510baca
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 143452
+  timestamp: 1718284177264
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
+  sha256: 0595b009f20f8f60f13a6398e7cdcbd2acea5f986633adcf85f5a2283c992add
+  md5: f87c7b7c2cb45f323ffbce941c78ab7c
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 96855
+  timestamp: 1711634169756
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hda332d3_1.conda
+  sha256: 973afa37840b4e55e2540018902255cfb0d953aaed6353bb83a4d120f5256767
+  md5: 76b32dcf243444aea9c6b804bcfa40b8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=75.1,<76.0a0
+  - libgcc-ng >=12
+  - libglib >=2.80.3,<3.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 1603653
+  timestamp: 1721186240105
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
+  sha256: 0d09b6dc1ce5c4005ae1c6a19dc10767932ef9a5e9c755cfdbb5189ac8fb0684
+  md5: bd77f8da987968ec3927990495dc22e4
+  depends:
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 756742
+  timestamp: 1695661547874
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.4-nompi_h2d575fe_103.conda
+  sha256: 50bcd6cd6e8853321e87d359571d187f8e18fa1c73b711074e551417c2163483
+  md5: f8416d7ff13707bd8eb75d6b8235857e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3940636
+  timestamp: 1730830832687
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+  sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
+  md5: 8b189310083baabfb622af68fd9d3ae3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 12129203
+  timestamp: 1720853576813
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_1.conda
+  sha256: 2f082f7b12a7c6824e051321c1029452562ad6d496ad2e8c8b7b3dea1c8feb92
+  md5: 5ca76f61b00a15a9be0612d4d883badc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17645
+  timestamp: 1725303065473
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+  sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
+  md5: 30186d27e2c9fa62b45fb1476b7200e3
+  depends:
+  - libgcc-ng >=10.3.0
+  license: LGPL-2.1-or-later
+  size: 117831
+  timestamp: 1646151697040
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.7-py311hd18a35c_0.conda
+  sha256: 4af11cbc063096a284fe1689b33424e7e49732a27fd396d74c7dee03d1e788ee
+  md5: be34c90cce87090d24da64a7c239ca96
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 72393
+  timestamp: 1725459421768
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+  sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
+  md5: 3f43953b7d3fb3aaa1d0d0723d91e368
+  depends:
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1370023
+  timestamp: 1719463201255
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+  sha256: 5c878d104b461b7ef922abe6320711c0d01772f4cd55de18b674f88547870041
+  md5: 51bb7010fc86f70eee639b4bb7a894f5
+  depends:
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 245247
+  timestamp: 1701647787198
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+  sha256: 7c91cea91b13f4314d125d1bedb9d03a29ebbd5080ccdea70260363424646dbe
+  md5: 048b02e3962f066da18efe3a21b77672
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - binutils_impl_linux-64 2.43
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 669211
+  timestamp: 1729655358674
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+  sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
+  md5: 76bbff344f0134279f225174e9064c8f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 281798
+  timestamp: 1657977462600
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_h5888daf_1.conda
+  sha256: 8f91429091183c26950f1e7ffa730e8632f0627ba35d2fccd71df31628c9b4e5
+  md5: e1f604644fe8d78e22660e2fec6756bc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  constrains:
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1310521
+  timestamp: 1727295454064
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
+  sha256: 2ef420a655528bca9d269086cf33b7e90d2f54ad941b437fb1ed5eca87cee017
+  md5: 5e97e271911b8b2001a8b71860c32faa
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 35446
+  timestamp: 1711021212685
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-17.0.0-hdb9dd6d_23_cpu.conda
+  sha256: 1dd7b539d7e1f1be0d7023a4b1354eef997fa1989ff254c277e3e04fee48f708
+  md5: 1f25431c67b54906beb3efb5ac44366d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-crt-cpp >=0.28.5,<0.28.6.0a0
+  - aws-sdk-cpp >=1.11.407,<1.11.408.0a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-identity-cpp >=1.10.0,<1.10.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-files-datalake-cpp >=12.12.0,<12.12.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libgcc >=13
+  - libgoogle-cloud >=2.30.0,<2.31.0a0
+  - libgoogle-cloud-storage >=2.30.0,<2.31.0a0
+  - libre2-11 >=2024.7.2
+  - libstdcxx >=13
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.2,<2.0.3.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  - libutf8proc <2.9
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - parquet-cpp <0.0a0
+  - arrow-cpp <0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 8493999
+  timestamp: 1729637282132
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-17.0.0-h5888daf_23_cpu.conda
+  sha256: eb7b1de3dc5b5492ba3dbb3f152fb9c04089e849076a6ab61347c175a388d4e0
+  md5: e42d71ffa1086ba8ab91b87cd0837920
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 17.0.0 hdb9dd6d_23_cpu
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 608712
+  timestamp: 1729637315146
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-17.0.0-h5888daf_23_cpu.conda
+  sha256: 28d8ecd3c39582e7aac8b40fcb77a43acb7d8ec5c4a25da3a10e5062f7b74be6
+  md5: 4c186ee1685724c5140a05faf9385023
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 17.0.0 hdb9dd6d_23_cpu
+  - libarrow-acero 17.0.0 h5888daf_23_cpu
+  - libgcc >=13
+  - libparquet 17.0.0 h6bd9018_23_cpu
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 582536
+  timestamp: 1729637372400
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-17.0.0-he882d9a_23_cpu.conda
+  sha256: 2e38274c09e49bf93295d45ba05b7b595ad996c017b9ce36cabb9b17cdf0c0bb
+  md5: ca3bb13cd30224fc0f5436fb8db18be6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 17.0.0 hdb9dd6d_23_cpu
+  - libarrow-acero 17.0.0 h5888daf_23_cpu
+  - libarrow-dataset 17.0.0 h5888daf_23_cpu
+  - libgcc >=13
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 515177
+  timestamp: 1729637398860
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
+  sha256: d6d12dc437d060f838820e9e61bf73baab651f91935ac594cf10beb9ef1b4450
+  md5: 8ea26d42ca88ec5258802715fe1ee10b
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - liblapack 3.9.0 25_linux64_openblas
+  - libcblas 3.9.0 25_linux64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 25_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15677
+  timestamp: 1729642900350
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
+  sha256: d9db2de60ea917298e658143354a530e9ca5f9c63471c65cf47ab39fd2f429e3
+  md5: 41b599ed2b02abcfdd84302bff174b23
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 68851
+  timestamp: 1725267660471
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
+  sha256: 2892d512cad096cb03f1b66361deeab58b64e15ba525d6592bb6d609e7045edf
+  md5: 9566f0bd264fbd463002e759b8a82401
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 32696
+  timestamp: 1725267669305
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
+  sha256: 779f58174e99de3600e939fa46eddb453ec5d3c60bb46cdaa8b4c127224dbf29
+  md5: 06f70867945ea6a84d35836af780f1de
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 281750
+  timestamp: 1725267679782
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
+  sha256: ab87b0477078837c91d9cda62a9faca18fba7c57cc77aa779ae24b3ac783b5dd
+  md5: 5dbd1b0fc0d01ec5e0e1fbe667281a11
+  depends:
+  - libblas 3.9.0 25_linux64_openblas
+  constrains:
+  - liblapack 3.9.0 25_linux64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 25_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15613
+  timestamp: 1729642905619
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp19.1-19.1.3-default_hb5137d0_0.conda
+  sha256: 576c1826a91f93ef7c433fc6481334d21177996bd72ff6901f58fae8f6a765db
+  md5: 311e6a1d041db3d6a8a8437750d4234f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libllvm19 >=19.1.3,<19.2.0a0
+  - libstdcxx >=13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 20548148
+  timestamp: 1730335997703
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-19.1.3-default_h9c6a7e4_0.conda
+  sha256: 7537cfefd76ffb0208484a2dc7d35d3752c6c42c80edabbc5f0dcae354d4b41e
+  md5: b8a8cd77810b20754f358f2327812552
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libllvm19 >=19.1.3,<19.2.0a0
+  - libstdcxx >=13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 11827604
+  timestamp: 1730336232401
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+  sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
+  md5: c965a5aa0d5c1c37ffc62dff36e28400
+  depends:
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20440
+  timestamp: 1633683576494
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
+  sha256: bc67b9b21078c99c6bd8595fe7e1ed6da1f721007726e717f0449de7032798c4
+  md5: d4529f4dff3057982a7617c7ac58fde3
+  depends:
+  - krb5 >=1.21.1,<1.22.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4519402
+  timestamp: 1689195353551
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
+  sha256: 54e6114dfce566c3a22ad3b7b309657e3600cdb668398e95f1301360d5d52c99
+  md5: 6e801c50a40301f6978c53976917b277
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 424900
+  timestamp: 1726659794676
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
+  sha256: 780f0530a3adfc1497ba49d626931c6afc978c540e1abfde6ccd57128ded6ad6
+  md5: b422943d5d772b7cc858b36ad2a92db5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 72242
+  timestamp: 1728177071251
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.123-hb9d3cd8_0.conda
+  sha256: 5f274243fc7480b721a4ed6623c72d07b86a508a1363a85f0f16451ab655ace8
+  md5: ee605e794bdc14e2b7f84c4faa0d8c2c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=13
+  - libpciaccess >=0.18,<0.19.0a0
+  license: MIT
+  license_family: MIT
+  size: 303108
+  timestamp: 1724719521496
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+  sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
+  md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 123878
+  timestamp: 1597616541093
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
+  sha256: 7fd5408d359d05a969133e47af580183fbf38e2235b562193d427bb9dad79723
+  md5: c151d5eb730e9b7480e6d48c0fc44048
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_2
+  license: LicenseRef-libglvnd
+  size: 44840
+  timestamp: 1731330973553
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+  md5: 172bf1cd1ff8629f2b1179945ed45055
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 112766
+  timestamp: 1702146165126
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+  sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
+  md5: a1cfcc585f0c42bf8d5546bb1dfb668d
+  depends:
+  - libgcc-ng >=12
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 427426
+  timestamp: 1685725977222
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
+  sha256: 56541b98447b58e52d824bd59d6382d609e11de1f8adf20b23143e353d2b8d26
+  md5: db833e03127376d461e1e13e76f09b6c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 73304
+  timestamp: 1730967041968
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+  sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+  md5: d645c6d2ac96843a2bfaccd2d62b3ac3
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 58292
+  timestamp: 1636488182923
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
+  sha256: 53eb8a79365e58849e7b1a068d31f4f9e718dc938d6f2c03e960345739a03569
+  md5: 3cb76c3f10d3bc7f1105b2fc9db984df
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 14.2.0 h77fa898_1
+  - libgcc-ng ==14.2.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 848745
+  timestamp: 1729027721139
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+  sha256: 3a76969c80e9af8b6e7a55090088bc41da4cffcde9e2c71b17f44d37b7cb87f7
+  md5: e39480b9ca41323497b05492a63bc35b
+  depends:
+  - libgcc 14.2.0 h77fa898_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54142
+  timestamp: 1729027726517
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+  sha256: fc9e7f22a17faf74da904ebfc4d88699013d2992e55505e4aa0eb01770290977
+  md5: f1fd30127802683586f768875127a987
+  depends:
+  - libgfortran5 14.2.0 hd5240d6_1
+  constrains:
+  - libgfortran-ng ==14.2.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 53997
+  timestamp: 1729027752995
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
+  sha256: d149a37ca73611e425041f33b9d8dbed6e52ec506fe8cc1fc0ee054bddeb6d5d
+  md5: 9822b874ea29af082e5d36098d25427d
+  depends:
+  - libgcc >=14.2.0
+  constrains:
+  - libgfortran 14.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1462645
+  timestamp: 1729027735353
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
+  sha256: dc2752241fa3d9e40ce552c1942d0a4b5eeb93740c9723873f6fcf8d39ef8d2d
+  md5: 928b8be80851f5d8ffb016f9c81dae7a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_2
+  - libglx 1.7.0 ha4b6fd6_2
+  license: LicenseRef-libglvnd
+  size: 134712
+  timestamp: 1731330998354
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.2-h2ff4ddf_0.conda
+  sha256: 49ee9401d483a76423461c50dcd37f91d070efaec7e4dc2828d8cdd2ce694231
+  md5: 13e8e54035ddd2b91875ba399f0f7c04
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  constrains:
+  - glib 2.82.2 *_0
+  license: LGPL-2.1-or-later
+  size: 3931898
+  timestamp: 1729191404130
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
+  sha256: 1175f8a7a0c68b7f81962699751bb6574e6f07db4c9f72825f978e3016f46850
+  md5: 434ca7e50e40f4918ab701e3facd59a0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: LicenseRef-libglvnd
+  size: 132463
+  timestamp: 1731330968309
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
+  sha256: 2d35a679624a93ce5b3e9dd301fff92343db609b79f0363e6d0ceb3a6478bfa7
+  md5: c8013e438185f33b13814c5c488acd5c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_2
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: LicenseRef-libglvnd
+  size: 75504
+  timestamp: 1731330988898
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+  sha256: 1911c29975ec99b6b906904040c855772ccb265a1c79d5d75c8ceec4ed89cd63
+  md5: cc3573974587f12dda90d96e3e55a702
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 460992
+  timestamp: 1729027639220
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.30.0-h438788a_0.conda
+  sha256: 506a0997b586536a6bbe8fd260bd50b625a541850507486fa66abc5a99104bce
+  md5: ab8466a39822527f7786b0d0b2aac223
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libgrpc >=1.65.5,<1.66.0a0
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - libstdcxx >=13
+  - openssl >=3.3.2,<4.0a0
+  constrains:
+  - libgoogle-cloud 2.30.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1200100
+  timestamp: 1728022256338
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.30.0-h0121fbd_0.conda
+  sha256: 9fad535d14a204f3646a29f9884c024b69d84120bea5489e14e7dc895b543646
+  md5: ad86b6c98964772688298a727cb20ef8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libgcc >=13
+  - libgoogle-cloud 2.30.0 h438788a_0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  size: 782269
+  timestamp: 1728022391174
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.65.5-hf5c653b_0.conda
+  sha256: d279abd46262e817c7a00aeb4df9b5ed4de38130130b248e2c50875e982f30fa
+  md5: 3b0048cabc6815a4d8874a0240519d32
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - c-ares >=1.32.3,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - libre2-11 >=2023.9.1
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.65.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 7229891
+  timestamp: 1727200905306
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+  sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
+  md5: d66573916ffcf376178462f1b61c941e
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  size: 705775
+  timestamp: 1702682170569
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+  sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
+  md5: ea25936bb4080d843790b586850f82b8
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 618575
+  timestamp: 1694474974816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
+  sha256: 9d1ff017714edb2d84868f0f931a4a0e7c289a971062b2ac66cfc8145df7e20e
+  md5: 4dc03a53fc69371a6158d0ed37214cd3
+  depends:
+  - libblas 3.9.0 25_linux64_openblas
+  constrains:
+  - liblapacke 3.9.0 25_linux64_openblas
+  - libcblas 3.9.0 25_linux64_openblas
+  - blas * openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15608
+  timestamp: 1729642910812
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
+  sha256: 225cc7c3b20ac1db1bdb37fa18c95bf8aecef4388e984ab2f7540a9f4382106a
+  md5: 73301c133ded2bf71906aa2104edae8b
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 31484415
+  timestamp: 1690557554081
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm19-19.1.3-ha7bfdaf_0.conda
+  sha256: 44502d37011472549367110a58ea78ff6c627f9436d1e4ebb5b34f80763dbf2a
+  md5: 8bd654307c455162668cd66e36494000
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.13.4,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 40124530
+  timestamp: 1730301303455
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h2564987_115.conda
+  sha256: 77d9536095a076414b787a0c2497bb35fcd72f71eb899fae5acb9853a64b4ec4
+  md5: c5ce70b76c77a6c9a3107be8d8e8ab0b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - blosc >=1.21.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzip >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zlib
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 835104
+  timestamp: 1728055792846
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+  sha256: b0f2b3695b13a989f75d8fd7f4778e1c7aabe3b36db83f0fe80b2cd812c0e975
+  md5: 19e57602824042dfd0446292ef90488b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - c-ares >=1.32.3,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 647599
+  timestamp: 1729571887612
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+  sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+  md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  license_family: GPL
+  size: 33408
+  timestamp: 1697359010159
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.4-h7f98852_1002.tar.bz2
+  sha256: 63244b73156033ea3b7c2a1581526e79b4670349d64b15f645dcdb12de441d1a
+  md5: e728e874159b042d92b90238a3cb0dc2
+  depends:
+  - libgcc-ng >=9.3.0
+  license: LGPL-2.1-or-later
+  size: 33201
+  timestamp: 1609781914458
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
+  sha256: 99ba271d8a80a1af2723f2e124ffd91d850074c0389c067e6d96d72a2dbfeabe
+  md5: 62857b389e42b36b686331bec0922050
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.2.0
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5578513
+  timestamp: 1730772671118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
+  sha256: 215086c108d80349e96051ad14131b751d17af3ed2cb5a34edd62fa89bfe8ead
+  md5: 7df50d44d4a14d6c31a2c54f2cd92157
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_2
+  license: LicenseRef-libglvnd
+  size: 50757
+  timestamp: 1731330993524
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-17.0.0-h6bd9018_23_cpu.conda
+  sha256: 7d152eadd92c9e5f1300176234edc5b07f85b41086877fca42451b3428c3429d
+  md5: e6f187fae27f67a238abbb13e610b93a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 17.0.0 hdb9dd6d_23_cpu
+  - libgcc >=13
+  - libstdcxx >=13
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 1189878
+  timestamp: 1729637358113
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
+  sha256: c0a30ac74eba66ea76a4f0a39acc7833f5ed783a632ca3bb6665b2d81aabd2fb
+  md5: 48f4330bfcd959c3cfb704d424903c82
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 28361
+  timestamp: 1707101388552
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
+  sha256: e5b14f7a01c2db4362d8591f42f82f336ed48d5e4079e4d1f65d0c2a3637ea78
+  md5: f4cc49d7aa68316213e4b12be35308d1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 290661
+  timestamp: 1726234747153
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.0-h04577a9_4.conda
+  sha256: 2f7e72e32f495cfb0492b8091d97dbe1c0700428fe167f3a781bb46e88dee4e5
+  md5: 392cae2a58fbcb9db8c2147c6d6d1620
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - openldap >=2.6.8,<2.7.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: PostgreSQL
+  size: 2602277
+  timestamp: 1729085182543
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.27.5-h5b01275_2.conda
+  sha256: 79ac9726cd0a1cb1ba335f7fc7ccac5f679a66d71d9553ca88a805b8787d55ce
+  md5: 66ed3107adbdfc25ba70454ba11e6d1e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2940269
+  timestamp: 1727424395109
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hbbce691_1.conda
+  sha256: f8ad6a4f6d4fd54ebe3e5e712a01e663222fc57f49d16b6b8b10c30990dafb8f
+  md5: 2124de47357b7a516c0a3efd8f88c143
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 211096
+  timestamp: 1728778964655
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
+  sha256: 0105bd108f19ea8e6a78d2d994a6d4a8db16d19a41212070d2d1d48a63c34161
+  md5: a587892d3c13b6621a6091be690dbca2
+  depends:
+  - libgcc-ng >=12
+  license: ISC
+  size: 205978
+  timestamp: 1716828628198
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_1.conda
+  sha256: 8a9aadf996a2399f65b679c6e7f29139d5059f699c63e6d7b50e20db10c00508
+  md5: b6f02b52a174e612e89548f4663ce56a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 875349
+  timestamp: 1730208050020
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+  sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
+  md5: 1f5a58e686b13bcfde88b93f547d23fe
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 271133
+  timestamp: 1685837707056
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+  sha256: 4661af0eb9bdcbb5fb33e5d0023b001ad4be828fccdcc56500059d56f9869462
+  md5: 234a5554c53625688d51062645337328
+  depends:
+  - libgcc 14.2.0 h77fa898_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3893695
+  timestamp: 1729027746910
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+  sha256: 25bb30b827d4f6d6f0522cc0579e431695503822f144043b93c50237017fffd8
+  md5: 8371ac6457591af2cf6159439c1fd051
+  depends:
+  - libstdcxx 14.2.0 hc0a3c3a_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54105
+  timestamp: 1729027780628
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.21.0-h0e7cc3e_0.conda
+  sha256: ebb395232973c18745b86c9a399a4725b2c39293c9a91b8e59251be013db42f0
+  md5: dcb95c0a98ba9ff737f7ae482aef7833
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 425773
+  timestamp: 1727205853307
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-he137b08_1.conda
+  sha256: 9890121db85f6ef463fe12eb04ef1471176e3ef3b5e2d62e8d6dac713df00df4
+  md5: 63872517c98aa305da58a757c443698e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.22,<1.26.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx >=13
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 428156
+  timestamp: 1728232228989
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
+  sha256: 49082ee8d01339b225f7f8c60f32a2a2c05fe3b16f31b554b4fb2c1dea237d1c
+  md5: ede4266dc02e875fe1ea77b25dd43747
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 101070
+  timestamp: 1667316029302
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33601
+  timestamp: 1680112270483
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+  sha256: 49bc5f6b1e11cb2babf2a2a731d1a680a5e08a858280876a779dbda06c78c35f
+  md5: b26e8aa824079e1be0294e7152ca4559
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 438953
+  timestamp: 1713199854503
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+  sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
+  md5: 92ed62436b625154323d40d5f2f11dd7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 395888
+  timestamp: 1727278577118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
+  md5: 5aa797f8787fe7a17d1b0821485b5adc
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 100393
+  timestamp: 1702724383534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.7.0-h2c5496b_1.conda
+  sha256: 6804c2a7062d10de6f159f7106dc45ebccc8d42bfb925f7919e26e567fa6da6b
+  md5: e2eaefa4de2b7237af7c907b8bbc760a
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - xkeyboard-config
+  - xorg-libxau >=1.0.11,<2.0a0
+  license: MIT/X11 Derivative
+  license_family: MIT
+  size: 593336
+  timestamp: 1718819935698
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-hb346dea_0.conda
+  sha256: 8c9d6a3a421ac5bf965af495d1b0a08c6fb2245ba156550bc064a7b4f8fc7bd8
+  md5: c81a9f1118541aaa418ccb22190c817e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=13
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 689626
+  timestamp: 1731489608971
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.39-h76b75d6_0.conda
+  sha256: 684e9b67ef7b9ca0ca993762eeb39705ec58e2e7f958555c758da7ef416db9f3
+  md5: e71f31f8cfb0a91439f2086fc8aa0461
+  depends:
+  - libgcc-ng >=12
+  - libxml2 >=2.12.1,<2.14.0a0
+  license: MIT
+  license_family: MIT
+  size: 254297
+  timestamp: 1701628814990
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.11.2-h6991a6a_0.conda
+  sha256: 991e7348b0f650d495fb6d8aa9f8c727bdf52dabf5853c0cc671439b160dce48
+  md5: a7b27c075c9b7f459f1c022090697cba
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 109043
+  timestamp: 1730442108429
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
+  md5: edb0dca6bc32e4f4789199455a1dbeb8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 60963
+  timestamp: 1727963148474
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.43.0-py311h9c9ff8c_1.conda
+  sha256: fb8b3eeea19f1160343d2c84f3b3e888f8c45db563375660905e1e73a793fc74
+  md5: 9ab40f5700784bf16ff7cf8012a646e8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3471295
+  timestamp: 1725305248888
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.3-py311h2cbdf9a_1.conda
+  sha256: 83f560beb20f61bb8c6e43a0656f1e744934d41a48b8a19408e6596cf8ce99a8
+  md5: 867a4aa23ae6c0e9c84cf9aa4f2df0fe
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39383
+  timestamp: 1725089531914
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+  sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
+  md5: 318b08df404f9c9be5712aaa5a6f0bb0
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143402
+  timestamp: 1674727076728
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py311h2dc5d0c_0.conda
+  sha256: 364a0d55abc4c60bc575c81a4acc9e98ea27565147d4d4dc672bad4b2d069710
+  md5: 15e4dadd59e93baad7275249f10b9472
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25591
+  timestamp: 1729351519326
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.9.2-py311h38be061_2.conda
+  sha256: 887bdf8f0b4c001c9a96e163032efdc11e4de36d68cdc3aa7a6c3ca18cc888f0
+  md5: 713b57fc1ebd395598f709a26c2d27fd
+  depends:
+  - matplotlib-base >=3.9.2,<3.9.3.0a0
+  - pyside6 >=6.7.2
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tornado >=5
+  license: PSF-2.0
+  license_family: PSF
+  size: 16787
+  timestamp: 1731025345618
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.2-py311h2b939e6_2.conda
+  sha256: 92fd9a8c19130064daba8b95bde172c77cbb6105cd7bc928bb0b1174c4a1faec
+  md5: 2e8401a7780e33e9ca76034d0ed24c3c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  - tk >=8.6.13,<8.7.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8014605
+  timestamp: 1731025323671
+- conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.0-py311hd18a35c_0.conda
+  sha256: 9033fa7084cbfd10e1b7ed3b74cee17169a0731ec98244d05c372fc4a935d5c9
+  md5: 682f76920687f7d9283039eb542fdacf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 104809
+  timestamp: 1725975116412
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-9.0.1-h266115a_2.conda
+  sha256: bf0c230c35ca70e2c98530eb064a99f0c4d4596793a0be3ca8a3cbd92094ef82
+  md5: 85c0dc0bcd110c998b01856975486ee7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - openssl >=3.3.2,<4.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 649443
+  timestamp: 1729804130603
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-9.0.1-he0572af_2.conda
+  sha256: e376189cd11304f4089971b372dac8a1cbbab6eacda8ca978ead2c220d16b8a4
+  md5: 57a9e7ee3c0840d3c8c9012473978629
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - mysql-common 9.0.1 h266115a_2
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1372671
+  timestamp: 1729804203990
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+  sha256: 6a1d5d8634c1a07913f1c525db6455918cbc589d745fac46d9d6e30340c8731a
+  md5: 70caf8bb6cf39a0b6b7efc885f51c0fe
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: X11 AND BSD-3-Clause
+  size: 889086
+  timestamp: 1724658547447
+- conda: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.2-nompi_py311h7c29e4f_100.conda
+  sha256: bc94802624f241fdb7999d414a7bd5e4a6d3a0e6ae5454bdf428819c07261754
+  md5: 11395670c4eeda7a60c13c313a83727f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - certifi
+  - cftime
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libgcc >=13
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 1154059
+  timestamp: 1729667693885
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.60.0-py311h4bc866e_0.conda
+  sha256: b48178613ba637b647c5738772d3efabfca502ea579b5ec10784a33d5acb0789
+  md5: e32a210e9caf97383c35685fd2343512
+  depends:
+  - _openmp_mutex >=4.5
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libopenblas !=0.3.6
+  - cuda-version >=11.2
+  - cuda-python >=11.6
+  - tbb >=2021.6.0
+  - scipy >=1.0
+  - cudatoolkit >=11.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5801568
+  timestamp: 1718888179690
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.0.2-py311h71ddf71_0.conda
+  sha256: f4e20d4045ad117499eaf44aaad2a17dd810b332c9407b9c4e7c155d56157a6f
+  md5: cb1476d753a69a42978fe7b303721df7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=13
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8961918
+  timestamp: 1724749067277
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
+  sha256: 5600a0b82df042bd27d01e4e687187411561dfc11cc05143a08ce29b64bf2af2
+  md5: 7f2e286780f072ed750df46dc2631138
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.43,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 341592
+  timestamp: 1709159244431
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.8-hedd0468_0.conda
+  sha256: 902652f7a106caa6ea9db2c44118078e23a499bf091ce8ea01d8498c156e8219
+  md5: dcd0ed5147d8876b0848a552b416ce76
+  depends:
+  - cyrus-sasl >=2.1.27,<3.0a0
+  - krb5 >=1.21.2,<1.22.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.3.0,<4.0a0
+  license: OLDAP-2.8
+  license_family: BSD
+  size: 780492
+  timestamp: 1716377814828
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
+  sha256: 814b9dff1847b132c676ee6cc1a8cb2d427320779b93e1b6d76552275c128705
+  md5: 23cc74f77eb99315c0360ec3533147a9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 2947466
+  timestamp: 1731377666602
+- conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.2-h690cf93_1.conda
+  sha256: ce023f259ffd93b4678cc582fc4b15a8a991a7b8edd9def8b6838bf7e7962bec
+  md5: 0044701dd48af57d3d5467a704ef9ebd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1184634
+  timestamp: 1727242386732
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py311h7db5c69_1.conda
+  sha256: dce121d3838996b77b810ca9097cc17068552075c761408a9b2eb788cf8fd1b0
+  md5: 643f8cb35133eb1be4919fb953f0a25f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15695466
+  timestamp: 1726879158862
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
+  sha256: 1087716b399dab91cc9511d6499036ccdc53eb29a288bebcb19cf465c51d7c0d
+  md5: df359c09c41cd186fffb93a2d87aa6f5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 952308
+  timestamp: 1723488734144
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.0.0-py311h49e9ac3_0.conda
+  sha256: f0f792596ae99cba01f829d064058b1e99ca84080fc89f72d925bfe473cfc1b6
+  md5: 2bd3d0f839ec0d1eaca817c9d1feb7c2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 42421065
+  timestamp: 1729065780130
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
+  sha256: 366d28e2a0a191d6c535e234741e0cd1d94d713f76073d8af4a5ccb2a266121e
+  md5: 71004cbf7924e19c02746ccde9fd7123
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 386826
+  timestamp: 1706549500138
+- conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.5.0-h12925eb_0.conda
+  sha256: 936de8754054d97223e87cc87b72641d2c7582d536ee9eee4b0443fa66e2733f
+  md5: 8c29983ebe50cc7e0998c34bc7614222
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcurl >=8.10.0,<9.0a0
+  - libgcc >=13
+  - libsqlite >=3.46.1,<4.0a0
+  - libstdcxx >=13
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 3093445
+  timestamp: 1726489083290
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py311h9ecbd09_0.conda
+  sha256: 2ac3f1ed6e6a2a0c67a3922f4b5faf382855ad02cc0c85c5d56291c7a94296d0
+  md5: 0ffc1f53106a38f059b151c465891ed3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 505408
+  timestamp: 1729847169876
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+  sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
+  md5: b3c17d95b5a10c6e64a21fa17573e70e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 8252
+  timestamp: 1726802366959
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-17.0.0-py311hbd00459_2.conda
+  sha256: c90d275efa91b3b89335451a7942ba0784f9869da584b7a8c0abae2b26a08b36
+  md5: 824d752b0e2037090bb3d75e35e05533
+  depends:
+  - libarrow-acero 17.0.0.*
+  - libarrow-dataset 17.0.0.*
+  - libarrow-substrait 17.0.0.*
+  - libparquet 17.0.0.*
+  - numpy >=1.19,<3
+  - pyarrow-core 17.0.0 *_2_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25615
+  timestamp: 1730169788262
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-17.0.0-py311h4854187_2_cpu.conda
+  sha256: 4d98ea27ae10b241b45d4b5c5988c0aacb232d3a3a23e28b03649df9c029cea2
+  md5: a04e64d38ca1fab46b12eb5bfc4f0026
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 17.0.0.* *cpu
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4643528
+  timestamp: 1730169489406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.0-py311h0f98d5a_0.conda
+  sha256: 194440401fba9fb3903aa921abcf3da468172700b5b5c9b21f98fb7be469a54f
+  md5: 22531205a97c116251713008d65dfefd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - certifi
+  - libgcc >=13
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 562000
+  timestamp: 1727795513365
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.8.0.2-py311h9053184_0.conda
+  sha256: b83df2ce1bb467b89a25a9bf09005d796a84f4f24873e3b0aba33d2abf465cdb
+  md5: a09628d42965b2102f929650b6c90f0d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libclang13 >=19.1.2
+  - libegl >=1.7.0,<2.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libstdcxx >=13
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libxslt >=1.1.39,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - qt6-main 6.8.0.*
+  - qt6-main >=6.8.0,<6.9.0a0
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 10848140
+  timestamp: 1730213073843
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.10-hc5c86c4_3_cpython.conda
+  sha256: b7fa3bd48e3a3d30f65608e07759cefd27885c6388b3f612af85ce40282e6936
+  md5: 9e1ad55c87368e662177661a998feed5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 30543977
+  timestamp: 1729043512711
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
+  sha256: 2660b8059b3ee854bc5d3c6b1fce946e5bd2fe8fbca7827de2c5885ead6209de
+  md5: 139a8d40c8a2f430df31048949e450de
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6211
+  timestamp: 1723823324668
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h9ecbd09_1.conda
+  sha256: e721e5ff389a7b2135917c04b27391be3d3382e261bb60a369b1620655365c3d
+  md5: abeb54d40f439b86f75ea57045ab8496
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 212644
+  timestamp: 1725456264282
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py311h7deb3e3_3.conda
+  sha256: 3fdef7b3c43474b7225868776a373289a8fd92787ffdf8bed11cf7f39b4ac741
+  md5: e0897de1d8979a3bb20ef031ae1f7d28
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 389074
+  timestamp: 1728642373938
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+  sha256: 776363493bad83308ba30bcb88c2552632581b143e8ee25b1982c8c743e73abc
+  md5: 353823361b1d27eb3960efb076dfcaf6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-Qhull
+  size: 552937
+  timestamp: 1720813982144
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.8.0-h6e8976b_0.conda
+  sha256: f21949a55d07f72f910b0256401ae7b666d04810d110236aee86063da7babc51
+  md5: 6d1c5d2d904d24c17cbb538a95855a4e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - alsa-lib >=1.2.12,<1.3.0a0
+  - dbus >=1.13.6,<2.0a0
+  - double-conversion >=3.3.0,<3.4.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=9.0.0
+  - icu >=75.1,<76.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libclang-cpp19.1 >=19.1.0,<19.2.0a0
+  - libclang13 >=19.1.0
+  - libcups >=2.3.3,<2.4.0a0
+  - libdrm >=2.4.123,<2.5.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libglib >=2.82.1,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libllvm19 >=19.1.0,<19.2.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libpq >=17.0,<18.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libxkbcommon >=1.7.0,<2.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - mysql-libs >=9.0.1,<9.1.0a0
+  - openssl >=3.3.2,<4.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - wayland >=1.23.1,<2.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xcb-util-cursor >=0.1.5,<0.2.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxcomposite >=0.4.6,<1.0a0
+  - xorg-libxcursor >=1.2.2,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrandr >=1.5.4,<2.0a0
+  - xorg-libxtst >=1.2.5,<2.0a0
+  - xorg-libxxf86vm >=1.1.5,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - qt 6.8.0
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 51315820
+  timestamp: 1728406028000
+- conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h77b4e00_1.conda
+  sha256: c1721cb80f7201652fc9801f49c214c88aee835d957f2376e301bd40a8415742
+  md5: 01093ff37c1b5e6bf9f17c0116747d11
+  depends:
+  - libre2-11 2024.07.02 hbbce691_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26665
+  timestamp: 1728778975855
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+  sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
+  md5: 47d31b792659ce70f470b5c82fdfb7a4
+  depends:
+  - libgcc-ng >=12
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 281456
+  timestamp: 1679532220005
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.21.0-py311h9e33e62_0.conda
+  sha256: 41b1c00f08d2b09243ca184af6f4fe8ca9fee418a62aec1cf1555bfd0b1b2eac
+  md5: befdb32741d8686b860232ca80178d63
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  size: 334025
+  timestamp: 1730922823065
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.17.21-py311h2582759_3.conda
+  sha256: bbf5aff9519226e7cf98a7df4b4d0b0de97991c64515a6ddcaca91d4c822226e
+  md5: d47e33b1053996205f29896708c91a3d
+  depends:
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ruamel.yaml.clib >=0.1.2
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 259873
+  timestamp: 1678273124540
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.8-py311h9ecbd09_1.conda
+  sha256: e38364ad63e29ea0134b2d6661c71d78a384a6f0f0c6248a270c97a73a970de8
+  md5: e56869fca385961323e43783b89bef66
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 147191
+  timestamp: 1728724593073
+- conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.5-h3931f03_0.conda
+  sha256: a6fa0afa836f8f26dea0abc180ca2549bb517932d9a88a121e707135d4bcb715
+  md5: 334dba9982ab9f5d62033c61698a8683
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 353081
+  timestamp: 1728534228471
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.5.2-py311h57cc02b_1.conda
+  sha256: b6489f65911847d1f9807e254e9af0815548454b911df4d0b5019f9ab16fe530
+  md5: d1b6d7a73364d9fe20d2863bd2c43e3a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - joblib >=1.2.0
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scipy
+  - threadpoolctl >=3.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10596895
+  timestamp: 1726083362968
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py311he9a78e4_1.conda
+  sha256: 59482b974c36c375fdfd0bc3e5a3003ea2d2ae72b64b8f3deaeef5a851dbc91d
+  md5: 49ba89bf4d8a995efb99517d1c7aeb1e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=13
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17592106
+  timestamp: 1729481734425
+- conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.6-py311h2fdb869_2.conda
+  sha256: c09f263d503aa59d9bb31425c175bd202917669d1047f830942407b23de231ab
+  md5: 4c78235905053663d1c9e23df3f11b65
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - libgcc >=13
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 581316
+  timestamp: 1727273591182
+- conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
+  sha256: dc7c8e0e8c3e8702aae81c52d940bfaabe756953ee51b1f1757e891bab62cf7f
+  md5: 6b7dcc7349efd123d493d2dbe85a045f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42465
+  timestamp: 1720003704360
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.47.0-h9eae976_1.conda
+  sha256: 8ea1a085fa95d806301aeec0df6985c3ad0852a9a46aa62dd737d228c7862f9f
+  md5: 53abf1ef70b9ae213b22caa5350f97a9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libsqlite 3.47.0 hadc24fc_1
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 883666
+  timestamp: 1730208056779
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+  sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
+  md5: d453b98d9c83e71da0741bb0ff4d76bc
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3318875
+  timestamp: 1699202167581
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.1-py311h9ecbd09_1.conda
+  sha256: 21390d0c5708581959ebd89702433c1d06a56ddd834797a194b217f98e38df53
+  md5: 616fed0b6f5c925250be779b05d1d7f7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 856725
+  timestamp: 1724956239832
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py311h9ecbd09_1.conda
+  sha256: 5f277c801ca392512de9aa497fd8be3e168950600c438778dfc4234943c474fc
+  md5: 00895577e2b4c24dca76675ab1862551
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 368413
+  timestamp: 1729704640193
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.23.1-h3e06ad9_0.conda
+  sha256: 0884b2023a32d2620192cf2e2fc6784b8d1e31cf9f137e49e00802d4daf7d1c1
+  md5: 0a732427643ae5e0486a727927791da1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libexpat >=2.6.2,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=13
+  - libstdcxx-ng >=13
+  license: MIT
+  license_family: MIT
+  size: 321561
+  timestamp: 1724530461598
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-hb711507_2.conda
+  sha256: 416aa55d946ce4ab173ab338796564893a2f820e80e04e098ff00c25fb981263
+  md5: 8637c3e5821654d0edf97e2b0404b443
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 19965
+  timestamp: 1718843348208
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.5-hb9d3cd8_0.conda
+  sha256: c7b35db96f6e32a9e5346f97adc968ef2f33948e3d7084295baebc0e33abdd5b
+  md5: eb44b3b6deb1cab08d72cb61686fe64c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libxcb >=1.13
+  - libxcb >=1.16,<2.0.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  license: MIT
+  license_family: MIT
+  size: 20296
+  timestamp: 1726125844850
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+  sha256: 94b12ff8b30260d9de4fd7a28cca12e028e572cbc504fd42aa2646ec4a5bded7
+  md5: a0901183f08b6c7107aab109733a3c91
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  license: MIT
+  license_family: MIT
+  size: 24551
+  timestamp: 1718880534789
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+  sha256: 546e3ee01e95a4c884b6401284bb22da449a2f4daf508d038fdfa0712fe4cc69
+  md5: ad748ccca349aec3e91743e08b5e2b50
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 14314
+  timestamp: 1718846569232
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+  sha256: 2d401dadc43855971ce008344a4b5bd804aca9487d8ebd83328592217daca3df
+  md5: 0e0cbe0564d03a99afd5fd7b362feecd
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 16978
+  timestamp: 1718848865819
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+  sha256: 31d44f297ad87a1e6510895740325a635dd204556aa7e079194a0034cdd7e66a
+  md5: 608e0ef8256b81d04456e8d211eee3e8
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 51689
+  timestamp: 1718844051451
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.43-hb9d3cd8_0.conda
+  sha256: 0d89b5873515a1f05d311f37ea4e087bbccc0418afa38f2f6189e97280db3179
+  md5: f725c7425d6d7c15e31f3b99a88ea02f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 389475
+  timestamp: 1727840188958
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hb9d3cd8_1.conda
+  sha256: ec276da68d1c4a3d34a63195b35ca5b248d4aff0812464dcd843d74649b5cec4
+  md5: 19608a9656912805b2b9a2f6bd257b04
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 58159
+  timestamp: 1727531850109
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-he73a12e_1.conda
+  sha256: 70e903370977d44c9120a5641ab563887bd48446e9ef6fc2a3f5f60531c2cd6c
+  md5: 05a8ea5f446de33006171a7afe6ae857
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libuuid >=2.38.1,<3.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 27516
+  timestamp: 1727634669421
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.10-h4f16b4b_0.conda
+  sha256: c4650634607864630fb03696474a0535f6fce5fda7d81a6462346e071b53dfa7
+  md5: 0b666058a179b744a622d0a4a0c56353
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libxcb >=1.17.0,<2.0a0
+  - xorg-xorgproto
+  license: MIT
+  license_family: MIT
+  size: 838308
+  timestamp: 1727356837875
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
+  sha256: 532a046fee0b3a402db867b6ec55c84ba4cdedb91d817147c8feeae9766be3d6
+  md5: 77cbc488235ebbaab2b6e912d3934bae
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 14679
+  timestamp: 1727034741045
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.6-hb9d3cd8_2.conda
+  sha256: 753f73e990c33366a91fd42cc17a3d19bb9444b9ca5ff983605fa9e953baf57f
+  md5: d3c295b50f092ab525ffe3c2aa4b7413
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: MIT
+  license_family: MIT
+  size: 13603
+  timestamp: 1727884600744
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+  sha256: 832f538ade441b1eee863c8c91af9e69b356cd3e9e1350fff4fe36cc573fc91a
+  md5: 2ccd714aa2242315acaf0a67faea780b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 32533
+  timestamp: 1730908305254
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+  sha256: 43b9772fd6582bf401846642c4635c47a9b0e36ca08116b3ec3df36ab96e0ec0
+  md5: b5fcc7172d22516e1f965490e65e33a4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: MIT
+  license_family: MIT
+  size: 13217
+  timestamp: 1727891438799
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+  sha256: 6b250f3e59db07c2514057944a3ea2044d6a8cdde8a47b6497c254520fade1ee
+  md5: 8035c64cb77ed555e3f150b7b3972480
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 19901
+  timestamp: 1727794976192
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
+  sha256: da5dc921c017c05f38a38bd75245017463104457b63a1ce633ed41f214159c14
+  md5: febbab7d15033c913d53c7a2c102309d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 50060
+  timestamp: 1727752228921
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.1-hb9d3cd8_0.conda
+  sha256: 2fef37e660985794617716eb915865ce157004a4d567ed35ec16514960ae9271
+  md5: 4bdb303603e9821baf5fe5fdff1dc8f8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 19575
+  timestamp: 1727794961233
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+  sha256: 1a724b47d98d7880f26da40e45f01728e7638e6ec69f35a3e11f92acd05f9e7a
+  md5: 17dcc85db3c7886650b8908b183d6876
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: MIT
+  license_family: MIT
+  size: 47179
+  timestamp: 1727799254088
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.4-hb9d3cd8_0.conda
+  sha256: ac0f037e0791a620a69980914a77cb6bb40308e26db11698029d6708f5aa8e0d
+  md5: 2de7f99d6581a4a7adbff607b5c278ca
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 29599
+  timestamp: 1727794874300
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hb9d3cd8_1.conda
+  sha256: f1217e902c0b1d8bc5d3ce65e483ebf38b049c823c9117b7198cfb16bd2b9143
+  md5: a7a49a8b85122b49214798321e2e96b4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-xorgproto
+  license: MIT
+  license_family: MIT
+  size: 37780
+  timestamp: 1727529943015
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+  sha256: 752fdaac5d58ed863bbf685bb6f98092fe1a488ea8ebb7ed7b606ccfce08637a
+  md5: 7bbe9a0cc0df0ac5f5a8ad6d6a11af2f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxi >=1.7.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 32808
+  timestamp: 1727964811275
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.5-hb9d3cd8_4.conda
+  sha256: 0b8f062a5b4a2c3833267285b7d41b3542f54d2c935c86ca98504c3e5296354c
+  md5: 7da9007c0582712c4bad4131f89c8372
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 18072
+  timestamp: 1728920051869
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
+  sha256: 1316680be6edddee0156b86ec1102fc8286f51c1a5440366ed1db596a2dc3731
+  md5: 7c21106b851ec72c037b162c216d8f05
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 565425
+  timestamp: 1726846388217
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+  sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+  md5: 2161070d867d1b1204ea749c8eec4ef0
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1 and GPL-2.0
+  size: 418368
+  timestamp: 1660346797927
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+  sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
+  md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 89141
+  timestamp: 1641346969816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_6.conda
+  sha256: e67288b1c98a31ee58a5c07bdd873dbe08e75f752e1ad605d5e8c0697339903e
+  md5: 113506c8d2d558e733f5c38f6bf08c50
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - libstdcxx >=13
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 335528
+  timestamp: 1728364029042
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+  sha256: 5d7c0e5f0005f74112a34a7425179f4eb6e73c92f5d109e6af4ddeca407c92ab
+  md5: c9f075ab2f33b3bbee9e62d4ad0a6cd8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib 1.3.1 hb9d3cd8_2
+  license: Zlib
+  license_family: Other
+  size: 92286
+  timestamp: 1727963153079
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+  sha256: c558b9cc01d9c1444031bd1ce4b9cff86f9085765f17627a6cd85fc623c8a02b
+  md5: 4d056880988120e29d75bfff282e0f45
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 554846
+  timestamp: 1714722996770
+- conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+  sha256: 4b54b7ce79d818e3cce54ae4d552dba51b7afac160ceecdefd04b3917a37c502
+  md5: 688697ec5e9588bdded167d19577625b
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.9
+  - sniffio >=1.1
+  - typing_extensions >=4.1
+  constrains:
+  - uvloop >=0.21.0b1
+  - trio >=0.26.1
+  license: MIT
+  license_family: MIT
+  size: 109864
+  timestamp: 1728935803440
+- conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
+  sha256: 45ae2d41f4a4dcf8707633d3d7ae376fc62f0c09b1d063c3049c3f6f8c911670
+  md5: cc4834a9ee7cc49ce8d25177c47b10d8
+  depends:
+  - python >=3.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 10241
+  timestamp: 1707233195627
+- conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+  sha256: 130766446f5507bd44df957b6b5c898a8bd98f024bb426ed6cb9ff1ad67fc677
+  md5: 3afef1f55a1366b4d3b6a0d92e2235e4
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.7
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 18602
+  timestamp: 1692818472638
+- conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+  sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
+  md5: b77d8c2313158e6e461ca0efb1c2c508
+  depends:
+  - python >=3.8
+  - python-dateutil >=2.7.0
+  - types-python-dateutil >=2.8.10
+  license: Apache-2.0
+  license_family: Apache
+  size: 100096
+  timestamp: 1696129131844
+- conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+  sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
+  md5: 5f25798dcefd8252ce5f9dc494d5f571
+  depends:
+  - python >=3.5
+  - six >=1.12.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 28922
+  timestamp: 1698341257884
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+  sha256: 28dba85a7e0f7fb57d7315e13f603d1e41b83c5b88aa2a602596b52c833a2ff8
+  md5: 6732fa52eb8e66e5afeb32db8701a791
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 56048
+  timestamp: 1722977241383
+- conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+  sha256: 7b05b2d0669029326c623b9df7a29fa49d1982a9e7e31b2fea34b4c9a4a72317
+  md5: 332493000404d8411859539a5a630865
+  depends:
+  - python >=3.6
+  - soupsieve >=1.2
+  license: MIT
+  license_family: MIT
+  size: 118200
+  timestamp: 1705564819537
+- conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
+  sha256: 01be7fb5163e7c31356a18c259ddc19a5431b8b974dc65e2427b88c2d30034f3
+  md5: 461bcfab8e65c166e297222ae919a2d4
+  depends:
+  - python >=3.9
+  - webencodings
+  license: Apache-2.0 AND MIT
+  license_family: Apache
+  size: 132652
+  timestamp: 1730286301829
+- conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.5.2-pyhd8ed1ab_0.conda
+  sha256: 8af284264eb1cb9c08586ac8c212dcafc929ef1de3db9d0d7f8ca75190a30f4b
+  md5: 38d785787ec83d0431b3855328395113
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.10
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4798991
+  timestamp: 1724417639170
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+  sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
+  md5: 9b347a7ec10940d3f7941ff6c460b551
+  depends:
+  - cached_property >=1.5.2,<1.5.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4134
+  timestamp: 1615209571450
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+  sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+  md5: 576d629e47797577ab0f1b351297ef4a
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11065
+  timestamp: 1615209567874
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+  sha256: 7020770df338c45ac6b560185956c32f0a5abf4b76179c037f115fc7d687819f
+  md5: 12f7d00853807b0531775e9be891cb11
+  depends:
+  - python >=3.7
+  license: ISC
+  size: 163752
+  timestamp: 1725278204397
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_0.conda
+  sha256: 1873ac45ea61f95750cb0b4e5e675d1c5b3def937e80c7eebb19297f76810be8
+  md5: a374efa97290b8799046df7c5ca17164
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 47314
+  timestamp: 1728479405343
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+  sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
+  md5: f3ad426304898027fc619827ff428eca
+  depends:
+  - __unix
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84437
+  timestamp: 1692311973840
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
+  sha256: 90236b113b9a20041736e80b80ee965167f9aac0468315c55e2bad902d673fb0
+  md5: 3549ecbceb6cd77b91a105511b7d0786
+  depends:
+  - __win
+  - colorama
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 85051
+  timestamp: 1692312207348
+- conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+  sha256: 5a33d0d3ef33121c546eaf78b3dac2141fc4d30bbaeb3959bbc66fcd5e99ced6
+  md5: c88ca2bb7099167912e3b26463fff079
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25952
+  timestamp: 1729059365471
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+  sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+  md5: 3faab06a954c2a04039983f2c4a50d99
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25170
+  timestamp: 1666700778190
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+  sha256: 79a6b4fff545e0b18f86ad93276a1797eb6ac3f7e1851e03f02d63b19655731b
+  md5: 4d155b600b63bc6ba89d91fab74238f8
+  depends:
+  - python >=3.7
+  license: CC-BY-4.0
+  size: 173517
+  timestamp: 1709713413736
+- conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+  sha256: e923acf02708a8a0b591f3bce4bdc11c8e63b73198b99b35fe6cd96bfb6a0dbe
+  md5: 948d84721b578d426294e17a02e24cbb
+  depends:
+  - python >=3.6
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12134
+  timestamp: 1710320435158
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.10-py311hd8ed1ab_3.conda
+  sha256: 3b2460b6cce53ce95f1f3aeb8ef7a50b356226dc48d45265ce5e585fc5e8cbed
+  md5: b6d1a583921c24bb45feef32262b10aa
+  depends:
+  - python 3.11.10.*
+  - python_abi * *_cp311
+  license: Python-2.0
+  size: 45741
+  timestamp: 1729041746101
+- conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+  sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
+  md5: 5cd86562580f274031ede6aa6aa24441
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13458
+  timestamp: 1696677888423
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.11.2-pyhd8ed1ab_0.conda
+  sha256: 4f9566a7455442a9d4eeaaf00dde0ba8c93b163f2c877ea28ffe4c9cc8edf4c7
+  md5: 2271232349fb358aeafb6a8a7fd575a8
+  depends:
+  - bokeh >=3.1.0
+  - cytoolz >=0.11.0
+  - dask-core >=2024.11.2,<2024.11.3.0a0
+  - dask-expr >=1.1,<1.2
+  - distributed >=2024.11.2,<2024.11.3.0a0
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.24
+  - pandas >=2.0
+  - pyarrow >=14.0.1
+  - python >=3.10
+  constrains:
+  - openssl !=1.1.1e
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7438
+  timestamp: 1731527931906
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.11.2-pyhd8ed1ab_0.conda
+  sha256: f7991985162a9ef8b506192cddfe95a5bee45a42b70c00bea39693dcb340f38d
+  md5: 86269596fa40b5b59b1eb8187f04ca1c
+  depends:
+  - click >=8.1
+  - cloudpickle >=3.0.0
+  - fsspec >=2021.09.0
+  - importlib_metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.4.0
+  - python >=3.10
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 903582
+  timestamp: 1731512203592
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.19-pyhd8ed1ab_0.conda
+  sha256: 5f2c9e8f49c016a249d07eb46bae5b4085f3750827d12aff8aa0db1be4665165
+  md5: 09ea33eb6525cc703ce1d39c88378320
+  depends:
+  - dask-core 2024.11.2
+  - pandas >=2
+  - pyarrow >=14.0.1
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 185913
+  timestamp: 1731515130979
+- conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+  sha256: 8f35e2d76173d300f5e5f504d67238097c16457267d421a8ab10d1e5bd9b734d
+  md5: 1316959270592fbf8e2278a336de3ab9
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy
+  - packaging
+  - pandas
+  - param
+  - pillow
+  - pyct
+  - python >=3.9
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17230062
+  timestamp: 1720435590279
+- conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+  md5: 43afe5ab04e35e17ba28649471dd7364
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 12072
+  timestamp: 1641555714315
+- conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
+  md5: 961b3a227b437d82ad7054484cfa71b2
+  depends:
+  - python >=3.6
+  license: PSF-2.0
+  license_family: PSF
+  size: 24062
+  timestamp: 1615232388757
+- conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.11.2-pyhd8ed1ab_0.conda
+  sha256: f2d5369065a399791502929422370c4b0ee091eab6f173eefb79608f9e3fc80c
+  md5: 82613fc096ecd4a0a0f50681e0e1f994
+  depends:
+  - click >=8.0
+  - cloudpickle >=3.0.0
+  - cytoolz >=0.11.2
+  - dask-core >=2024.11.2,<2024.11.3.0a0
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.2
+  - packaging >=20.0
+  - psutil >=5.8.0
+  - python >=3.10
+  - pyyaml >=5.4.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.11.2
+  - tornado >=6.2.0
+  - urllib3 >=1.26.5
+  - zict >=3.0.0
+  constrains:
+  - openssl !=1.1.1e
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 804212
+  timestamp: 1731514505114
+- conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda
+  sha256: 0d01c4da6d4f0a935599210f82ac0630fa9aeb4fc37cbbc78043a932a39ec4f3
+  md5: 67999c5465064480fa8016d00ac768f6
+  depends:
+  - python >=3.6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 40854
+  timestamp: 1675116355989
+- conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
+  md5: 3cf04868fee0a029769bd41f4b2fbf2d
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 9199
+  timestamp: 1643888357950
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+  sha256: e0edd30c4b7144406bb4da975e6bb97d6bc9c0e999aa4efe66ae108cada5d5b5
+  md5: d02ae936e42063ca46af6cdad2dbd1e0
+  depends:
+  - python >=3.7
+  license: MIT and PSF-2.0
+  size: 20418
+  timestamp: 1720869435725
+- conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+  sha256: a52d7516e2e11d3eb10908e10d3eb3f8ef267fea99ed9b09d52d96c4db3441b8
+  md5: d0441db20c827c11721889a241df1220
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 28337
+  timestamp: 1725214501850
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+  sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+  md5: 0c96522c6bdaed4b1566d11387caaf45
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 397370
+  timestamp: 1566932522327
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+  sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+  md5: 34893075a5c9e55cdafac56607368fc6
+  license: OFL-1.1
+  license_family: Other
+  size: 96530
+  timestamp: 1620479909603
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+  sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+  md5: 4d59c254e01d9cde7957100457e2d5fb
+  license: OFL-1.1
+  license_family: Other
+  size: 700814
+  timestamp: 1620479612257
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+  sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+  md5: 49023d73832ef61042f6a237cb2687e7
+  license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
+  license_family: Other
+  size: 1620504
+  timestamp: 1727511233259
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+  sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+  md5: fee5683a3f04bd15cbd8318b096a27ab
+  depends:
+  - fonts-conda-forge
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3667
+  timestamp: 1566974674465
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+  sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
+  md5: f766549260d6815b0c52253f1fb1bb29
+  depends:
+  - font-ttf-dejavu-sans-mono
+  - font-ttf-inconsolata
+  - font-ttf-source-code-pro
+  - font-ttf-ubuntu
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4102
+  timestamp: 1566932280397
+- conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 6cfd1f9bcd2358a69fb571f4b3af049b630d52647d906822dbedac03e84e4f63
+  md5: 642d35437078749ef23a5dca2c9bb1f3
+  depends:
+  - cached-property >=1.3.0
+  - python >=2.7,<4
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 14395
+  timestamp: 1638810388635
+- conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+  sha256: 40bb76981dd49d5869b48925a8975bb7bbe4e33e1e40af4ec06f6bf4a62effd7
+  md5: 816dbc4679a64e4417cd1385d661bb31
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 134745
+  timestamp: 1729608972363
+- conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_1.conda
+  sha256: 1b0853491a299e95d57ccf3f3c9053a1b7e49fc9b2ad959f321b0717e567e249
+  md5: cad8d8e1583463e7642adc72a76dc3c5
+  depends:
+  - numpy >=1.22
+  - packaging
+  - pandas >=1.4.0
+  - python >=3.9
+  - shapely >=2.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 239539
+  timestamp: 1726898022361
+- conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.13.0-hd8ed1ab_0.conda
+  sha256: bdc277a4094d55c388f97136c717d92e8d302df4efe836c97bd5e72387dcb86c
+  md5: 698044f99f2a768ea97ad4eaf60eeaea
+  depends:
+  - datashader
+  - geopandas-base
+  - geoviews-core 1.13.0 pyha770c72_0
+  - netcdf4
+  - pandas
+  - pyct
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7882
+  timestamp: 1726570503187
+- conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.13.0-pyha770c72_0.conda
+  sha256: a2453b6df701d38c5d141247946e0d21814fa1f056c6e85aa4003ede2f20d82e
+  md5: e59925a00efb42c08cf0fef58f779bb4
+  depends:
+  - bokeh >=3.5.0,<3.6.0
+  - cartopy >=0.18.0
+  - holoviews >=1.16.0
+  - numpy >=1.0
+  - packaging
+  - panel >=1.0.0
+  - param >=1.9.3
+  - pyproj
+  - python >=3.10
+  - shapely
+  - xyzservices
+  constrains:
+  - geoviews 1.13.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 402368
+  timestamp: 1726561614409
+- conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+  sha256: 369d234fb83fb37e0e8abe7a78981a533cec37053c5c15177ad6caade729118d
+  md5: a765e03fa67caf58525b08bbbd5b4f76
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.9
+  - pyviz_comms >=2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4037867
+  timestamp: 1730736003074
+- conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+  sha256: a0fb47776b6816990b94eab6e1a27025f643fa94646b845277d3aa8bce8fb2f1
+  md5: dbc57da07daee81a9cd76586217c7cbb
+  depends:
+  - bokeh >=3.1
+  - colorcet >=2
+  - holoviews >=1.19.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 246908
+  timestamp: 1729160766015
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
+  sha256: 8c57fd68e6be5eecba4462e983aed7e85761a519aab80e834bbd7794d4b545b2
+  md5: 7ba2ede0e7c795ff95088daf0dc59753
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49837
+  timestamp: 1726459583613
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
+  sha256: 7194700ce1a5ad2621fd68e894dd8c1ceaff9a38723e6e0e5298fdef13017b1c
+  md5: 54198435fce4d64d8a89af22573012a8
+  depends:
+  - python >=3.8
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 28646
+  timestamp: 1726082927916
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.5.0-hd8ed1ab_0.conda
+  sha256: 313b8a05211bacd6b15ab2621cb73d7f41ea5c6cae98db53367d47833f03fef1
+  md5: 2a92e152208121afadf85a5e1f3a5f4d
+  depends:
+  - importlib-metadata >=8.5.0,<8.5.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 9385
+  timestamp: 1726082930346
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_0.conda
+  sha256: 2cb9db3e40033c3df72d3defc678a012840378fd55a67e4351363d4b321a0dc1
+  md5: c808991d29b9838fb4d96ce8267ec9ec
+  depends:
+  - python >=3.8
+  - zipp >=3.1.0
+  constrains:
+  - importlib-resources >=6.4.5,<6.4.6.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 32725
+  timestamp: 1725921462405
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+  sha256: 33cfd339bb4efac56edf93474b37ddc049e08b1b4930cf036c893cc1f5a1f32a
+  md5: b40131ab6a36ac2c09b7c57d4d3fbf99
+  depends:
+  - __linux
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119084
+  timestamp: 1719845605084
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+  sha256: dc569094125127c0078aa536f78733f383dd7e09507277ef8bcd1789786e7086
+  md5: 18df5fc4944a679e085e0e8f31775fc8
+  depends:
+  - __win
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119853
+  timestamp: 1719845858082
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+  sha256: 072534d4d379225b2c3a4e38bc7730b65ae171ac7f0c2d401141043336e97980
+  md5: 9eb15d654daa0ef5a98802f586bb4ffc
+  depends:
+  - __osx
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119568
+  timestamp: 1719845667420
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh31c8845_0.conda
+  sha256: b28ec68a49d8ddc41b92f3161f536d63e62eb5493021e41bb172b5f0af54ca2d
+  md5: 28e743c2963d1cecaa75f7612ade74c4
+  depends:
+  - __osx
+  - appnope
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt_toolkit >=3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 591141
+  timestamp: 1698846944668
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh41d4057_0.conda
+  sha256: 31322d58f412787f5beeb01db4d16f10f8ae4e0cc2ec99fafef1e690374fe298
+  md5: f39d0b60e268fe547f1367edbab457d4
+  depends:
+  - __linux
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt_toolkit >=3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 589731
+  timestamp: 1698846745397
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh5737063_0.conda
+  sha256: e9da075dab85ad01df4355e264220e156273f719a62f6fad588a686616e86a9c
+  md5: f303446f1ce22bd9173650d3e722e87b
+  depends:
+  - __win
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt_toolkit >=3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 592050
+  timestamp: 1698847371880
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_1.conda
+  sha256: 72fbbe8bc511f20268d347c1a06e279128237e096c4c174b2f9164a661c6b13e
+  md5: f8ed9f18dce81e4ee55c858cc2f8548a
+  depends:
+  - python >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28064
+  timestamp: 1716278507729
+- conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
+  md5: 4cb68948e0b8429534380243d063a27a
+  depends:
+  - arrow >=0.15.0
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 17189
+  timestamp: 1638811664194
+- conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhff2d567_0.conda
+  sha256: d37dad14c00d06d33bfb99c378d0abd7645224a9491c433af5028f24863341ab
+  md5: 11ead81b00e0f7cc901fceb7ccfb92c1
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.9
+  license: Apache-2.0 AND MIT
+  size: 842916
+  timestamp: 1731317305873
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+  sha256: 27380d870d42d00350d2d52598cddaf02f9505fb24be09488da0c9b8d1428f2d
+  md5: 7b86ecb7d3557821c649b3c31e3eb9f2
+  depends:
+  - markupsafe >=2.0
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111565
+  timestamp: 1715127275924
+- conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 95ac5f9ee95fd4e34dc051746fc86016d3d4f6abefed113e2ede049d59ec2991
+  md5: 2cfa3e1cf3fb51bb9b17acc5b5e9ea11
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 21003
+  timestamp: 1655568358125
+- conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
+  sha256: 8ad719524b1039510fcbd75eb776123189d75e2c09228189257ddbcab86f5b64
+  md5: 25df261d4523d9f9783bcdb7208d872f
+  depends:
+  - python >=3.8
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 219731
+  timestamp: 1714665585214
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+  sha256: 7d0c4c0346b26be9f220682b7c5c0d84606d48c6dbc36fc238e4452dda733aff
+  md5: da304c192ad59975202859b367d0f6a2
+  depends:
+  - attrs >=22.2.0
+  - importlib_resources >=1.4.0
+  - jsonschema-specifications >=2023.03.6
+  - pkgutil-resolve-name >=1.3.10
+  - python >=3.8
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 74323
+  timestamp: 1720529611305
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+  sha256: 82f8bed0f21dc0b3aff40dd4e39d77e85b93b0417bc5659b001e0109341b8b98
+  md5: 720745920222587ef942acfbc578b584
+  depends:
+  - python >=3.8
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 16165
+  timestamp: 1728418976382
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+  sha256: 007a0a506a0d1805b099629cb0ee743ad0afe7d9749e57339f32c168119e0139
+  md5: 16b37612b3a2fd77f409329e213b530c
+  depends:
+  - fqdn
+  - idna
+  - isoduration
+  - jsonpointer >1.13
+  - jsonschema >=4.23.0,<4.23.1.0a0
+  - rfc3339-validator
+  - rfc3986-validator >0.1.0
+  - uri-template
+  - webcolors >=24.6.0
+  license: MIT
+  license_family: MIT
+  size: 7143
+  timestamp: 1720529619500
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+  sha256: 38e67f3e0d631f4aeeab4bbd4062dcb6f4ae9dc35803053c995d02912a999b65
+  md5: 5cbf9a31a19d4ef9103adb7d71fd45fd
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.7
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99449
+  timestamp: 1673616104031
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+  sha256: 732b1e8536bc22a5a174baa79842d79db2f4956d90293dd82dc1b3f6099bcccd
+  md5: 0a2980dada0dd7fd0998f0342308b1b1
+  depends:
+  - __unix
+  - platformdirs >=2.5
+  - python >=3.8
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 57671
+  timestamp: 1727163547058
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh5737063_1.conda
+  sha256: 7c903b2d62414c3e8da1f78db21f45b98de387aae195f8ca959794113ba4b3fd
+  md5: 46d87d1c0ea5da0aae36f77fa406e20d
+  depends:
+  - __win
+  - cpython
+  - platformdirs >=2.5
+  - python >=3.8
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 58269
+  timestamp: 1727164026641
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+  sha256: cd3f41dc093162a41d4bae171e40a1b9b115c4d488e9bb837a8fa9d084931fb9
+  md5: ed45423c41b3da15ea1df39b1f80c2ca
+  depends:
+  - jsonschema-with-format-nongpl >=4.18.0
+  - python >=3.8
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21475
+  timestamp: 1710805759187
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+  sha256: edab71a05feceac54bdb90e755a257545af7832b9911607c1a70f09be44ba985
+  md5: ca23c71f70a7c7935b3d03f0f1a5801d
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert-core >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.8
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 323978
+  timestamp: 1720816754998
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+  sha256: 038efbc7e4b2e72d49ed193cfb2bbbe9fbab2459786ce9350301f466a32567db
+  md5: 219b3833aa8ed91d47d1be6ca03f30be
+  depends:
+  - python >=3.8
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19818
+  timestamp: 1710262791393
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+  sha256: 4aa622bbcf97e44cd1adf0100b7ff71b7e20268f043bdf6feae4d16152f1f242
+  md5: afcd1b53bcac8844540358e33f33d28f
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.7
+  constrains:
+  - jupyterlab >=4.0.8,<5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18776
+  timestamp: 1707149279640
+- conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+  sha256: aa99d44e8c83865026575a8af253141c53e0b3ab05f053befaa7757c8525064f
+  md5: f1b64ca4faf563605cf6f6ca93f9ff3f
+  depends:
+  - python >=3.7
+  - uc-micro-py
+  license: MIT
+  license_family: MIT
+  size: 24035
+  timestamp: 1707129321841
+- conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
+  md5: 91e27ef3d05cc772ce627e51cff111c4
+  depends:
+  - python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 8250
+  timestamp: 1650660473123
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+  sha256: fce1fde00359696983989699c00f9891194c4ebafea647a8d21b7e2e3329b56e
+  md5: 06e9bebf748a0dea03ecbe1f0e27e909
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78331
+  timestamp: 1710435316163
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+  sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
+  md5: 93a8e71256479c62074356ef6ebf501b
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 64356
+  timestamp: 1686175179621
+- conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+  sha256: 7ea68676ea35fbb095420bbcc1c82c4767b8be7bb56abb6989b7f89d957a3bab
+  md5: 779345c95648be40d22aaa89de7d4254
+  depends:
+  - python >=3.6
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14599
+  timestamp: 1713250613726
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+  sha256: 5cedc99412278b37e9596f1f991d49f5a1663fe79767cf814a288134a1400ba9
+  md5: 5387f2cfa28f8a3afa3368bb4ba201e8
+  depends:
+  - markdown-it-py >=1.0.0,<4.0.0
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 42126
+  timestamp: 1725995333692
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+  sha256: 64073dfb6bb429d52fff30891877b48c7ec0f89625b1bf844905b66a81cce6e1
+  md5: 776a8dd9e824f77abac30e6ef43a8f7a
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 14680
+  timestamp: 1704317789138
+- conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+  sha256: f95cb70007e3cc2ba44e17c29a056b499e6dadf08746706d0c817c8e2f47e05c
+  md5: 5cbee699846772cc939bef23a0d524ed
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 66022
+  timestamp: 1698947249750
+- conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+  sha256: c6216a21154373b340c64f321f22fec51db4ee6156c2e642fa58368103ac5d09
+  md5: 121a57fce7fff0857ec70fa03200962f
+  depends:
+  - python >=3.6
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17254
+  timestamp: 1721907640382
+- conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+  sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
+  md5: 2ba8498c1018c1e9c61eb99b973dfe19
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12452
+  timestamp: 1600387789153
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_0.conda
+  sha256: da3330a8ffff1f5b15b558543fbec69e05a48750ed50b53369b93da788abedc5
+  md5: 6275b55edf34cfa1f01ba40b699dd915
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5493243
+  timestamp: 1716838925077
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
+  sha256: 589d72d36d61a23b39d6fff2c488f93e29e20de4fc6f5d315b5f2c16e81028bf
+  md5: 15b51397e0fe8ea7d7da60d83eb76ebc
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.8
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27851
+  timestamp: 1710317767117
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+  sha256: 074d858c5808e0a832acc0da37cd70de1565e8d6e17a62d5a11b3902b5e78319
+  md5: e2d2abb421c13456a9a9f80272fdf543
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<3.1
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.8
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - nbconvert =7.16.4=*_1
+  - pandoc >=2.9.2,<4.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189599
+  timestamp: 1718135529468
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+  sha256: 36fe73da4d37bc7ac2d1540526ecd294fbd09acda04e096181ab8f1ccd2b464c
+  md5: 0b57b5368ab7fc7cdc9e3511fa867214
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.8
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101232
+  timestamp: 1712239122969
+- conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+  sha256: 30db21d1f7e59b3408b831a7e0417b83b53ee6223afae56482c5f26da3ceb49a
+  md5: 6598c056f64dc8800d40add25e4e2c34
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11638
+  timestamp: 1705850780510
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+  sha256: e37db45223e432bcad809897177e05fff31828dfcfc3ef18f046ae44ec01286c
+  md5: f81a6fe643390df9347984644727d796
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert-core >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.7
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 308643
+  timestamp: 1715849037288
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+  sha256: 9b5fdef9ebe89222baa9da2796ebe7bc02ec6c5a1f61327b651d6b92cf9a0230
+  md5: 3d85618e2c97ab896b5b5e298d32b5b3
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16880
+  timestamp: 1707957948029
+- conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+  sha256: 5e238e5e646414d517a13f6786c7227206ace58271e3ef63f6adca4d6a4c2839
+  md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
+  depends:
+  - python >=3.6
+  - typing_utils
+  license: Apache-2.0
+  license_family: APACHE
+  size: 30232
+  timestamp: 1706394723472
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_0.conda
+  sha256: 0f8273bf66c2a5c1de72312a509deae07f163bb0ae8de8273c52e6fe945a0850
+  md5: c16469afe1ec91aaafcf4bea966c0465
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: APACHE
+  size: 60345
+  timestamp: 1731457074006
+- conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
+  md5: 457c2c8c08e54905d6954e79cb5b5db9
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11627
+  timestamp: 1631603397334
+- conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+  sha256: 5a05f572a610cada2fcccef8d555fddf2d01bef80da32411150735e6177d1eab
+  md5: 41c7413071c2bae37472214a3525e6bf
+  depends:
+  - bleach
+  - bokeh >=3.5.0,<3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.1.0,<3.0
+  - python >=3.10
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20670374
+  timestamp: 1731497809631
+- conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+  sha256: db644c81c1f47e1fa8134d5de935ec4269d765fbef8d44bd454eb187c7524472
+  md5: bd991333d5bc659bb82bfb5a5d4c1576
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 103339
+  timestamp: 1719325288387
+- conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+  sha256: bfe404eebb930cc41782d34f8fc04c0388ea692eeebe2c5fc28df8ec8d4d61ae
+  md5: 81534b420deb77da8833f2289b8d47ac
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 75191
+  timestamp: 1712320447201
+- conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+  sha256: 472fc587c63ec4f6eba0cc0b06008a6371e0a08a5986de3cf4e8024a47b4fe6c
+  md5: 0badf9c54e24cecfb0ad2f99d680c163
+  depends:
+  - locket
+  - python >=3.9
+  - toolz
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20884
+  timestamp: 1715026639309
+- conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+  sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
+  md5: 629f3203c99b32e0988910c93e77f3b6
+  depends:
+  - ptyprocess >=0.5
+  - python >=3.7
+  license: ISC
+  size: 53600
+  timestamp: 1706113273252
+- conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+  sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
+  md5: 415f0ebb6198cc2801c73438a9fb5761
+  depends:
+  - python >=3
+  license: MIT
+  license_family: MIT
+  size: 9332
+  timestamp: 1602536313357
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+  sha256: 499313e72e20225f84c2e9690bbaf5b952c8d7e0bf34b728278538f766b81628
+  md5: 5dd546fe99b44fda83963d15f84263b7
+  depends:
+  - python >=3.8,<3.13.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 1243168
+  timestamp: 1730203795600
+- conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+  sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
+  md5: 405678b942f2481cecdb3e010f4925d9
+  depends:
+  - python >=3.6
+  license: MIT AND PSF-2.0
+  size: 10778
+  timestamp: 1694617398467
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
+  sha256: c81bdeadc4adcda216b2c7b373f0335f5c78cc480d1d55d10f21823590d7e46f
+  md5: fd8f2b18b65bbf62e8f653100690c8d2
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 20625
+  timestamp: 1726613611845
+- conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
+  sha256: 01f0c3dd00081637ed920a922b17bcc8ed49608404ee466ced806856e671f6b9
+  md5: 07e9550ddff45150bfc7da146268e165
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: Apache
+  size: 49024
+  timestamp: 1726902073034
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.38-pyha770c72_0.conda
+  sha256: 78c2f3c6195ec350d7d6e5fa3e43274ca8191c181c97a867e2920faaeec0e9bc
+  md5: 59ba1bf8ea558751a0d391249a248765
+  depends:
+  - python >=3.7
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.38
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269375
+  timestamp: 1677601102637
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.38-hd8ed1ab_0.conda
+  sha256: c0f24a75d27918eb33f86902aa6024783d128a89eb3a169bcb22f24163a422b3
+  md5: 45b74f64d8808eda7e6f6e6b1d641fd2
+  depends:
+  - prompt-toolkit >=3.0.38,<3.0.39.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6402
+  timestamp: 1677601110741
+- conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+  sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+  md5: 359eeb6536da0e687af562ed265ec263
+  depends:
+  - python
+  license: ISC
+  size: 16546
+  timestamp: 1609419417991
+- conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+  sha256: dcfcb3cee1ae0a89729601582cc3edea20ba13c9493967a03a693c67567af0c8
+  md5: 0f051f09d992e0d08941706ad519ee0e
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 16551
+  timestamp: 1721585805256
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+  sha256: 406001ebf017688b1a1554b49127ca3a4ac4626ec0fd51dc75ffa4415b720b64
+  md5: 844d9eb3b43095b031874477f7d70088
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105098
+  timestamp: 1711811634025
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+  sha256: 0e1e17a37d53be84c33b88218f10afb5f8137f19a727fdc56e45ae0b8b439a57
+  md5: 24c245c82396be3297c0aa26b69e18d8
+  depends:
+  - param >=1.7.0
+  - python >=3.7
+  - pyyaml
+  - requests
+  - setuptools >=61.0
+  constrains:
+  - pyct-core <0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20096
+  timestamp: 1701103924264
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+  sha256: 78267adf4e76d0d64ea2ffab008c501156c108bb08fecb703816fb63e279780b
+  md5: b7f5c092b8f9800150d998a71b76d5a1
+  depends:
+  - python >=3.8
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 879295
+  timestamp: 1714846885370
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_1.conda
+  sha256: b846e3965cd106438cf0b9dc0de8d519670ac065f822a7d66862e9423e0229cb
+  md5: 035c17fbf099f50ff60bf2eb303b0a83
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 92444
+  timestamp: 1728880549923
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 41eced0d5e855bc52018f200b239d627daa38ad78a655ffa2f1efd95b07b6bce
+  md5: 92a889dc236a5197612bc85bee6d7174
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 964060
+  timestamp: 1659003065197
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
+  sha256: b3a612bc887f3dd0fb7c4199ad8e342bd148cf69a9b74fd9468a18cf2bef07b7
+  md5: 56cd9fe388baac0e90c7149cfac95b60
+  depends:
+  - __win
+  - python >=3.8
+  - win_inet_pton
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19348
+  timestamp: 1661605138291
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+  sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+  md5: 2a7de29fb590ca14b5243c4c812c8025
+  depends:
+  - __unix
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18981
+  timestamp: 1661604969727
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+  sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
+  md5: 2cf4264fffb9e6eff6031c5b6884d61c
+  depends:
+  - python >=3.7
+  - six >=1.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 222742
+  timestamp: 1709299922152
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
+  sha256: 7d8c931b89c9980434986b4deb22c2917b58d9936c3974139b9c10ae86fdfe60
+  md5: b98d2018c01ce9980c03ee2850690fab
+  depends:
+  - python >=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 226165
+  timestamp: 1718477110630
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+  sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
+  md5: a61bf9ec79426938ff785eb69dbb1960
+  depends:
+  - python >=3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13383
+  timestamp: 1677079727691
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_0.conda
+  sha256: fe3f62ce2bc714bdaa222ab3f0344a2815ad9e853c6df38d15c9f25de8a3a6d4
+  md5: 986287f89929b2d629bd6ef6497dc307
+  depends:
+  - python >=3.6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 142527
+  timestamp: 1727140688093
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+  sha256: 1a7d6b233f7e6e3bbcbad054c8fd51e690a67b129a899a056a5e45dd9f00cb41
+  md5: 3eeeeb9e4827ace8c0c1419c85d590ad
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 188538
+  timestamp: 1706886944988
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+  sha256: a7979e8e4936c430f5fe3d04fc2d67b42dab84fb4a502c4961a17dcb2327fec0
+  md5: 02b4e3a3014c1ac490ee4a4316f2d229
+  depends:
+  - param
+  - python >=3.6
+  constrains:
+  - jupyterlab >=4.0,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48061
+  timestamp: 1722535734510
+- conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+  sha256: be8d6d9e86b1a3fef5424127ff81782f8ca63d3058980859609f6f1ecdd34cb3
+  md5: 0fc8b52192a8898627c3efae1003e9f6
+  depends:
+  - attrs >=22.2.0
+  - python >=3.8
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 42210
+  timestamp: 1714619625532
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+  sha256: 5845ffe82a6fa4d437a2eae1e32a1ad308d7ad349f61e337c0a890fe04c513cc
+  md5: 5ede4753180c7a550a443c430dc8ab52
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.8
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 58810
+  timestamp: 1717057174842
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
+  md5: fed45fc5ea0813240707998abe49f520
+  depends:
+  - python >=3.5
+  - six
+  license: MIT
+  license_family: MIT
+  size: 8064
+  timestamp: 1638811838081
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+  sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
+  md5: 912a71cc01012ee38e6b90ddd561e36f
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 7818
+  timestamp: 1598024297745
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_0.conda
+  sha256: c4401b071e86ddfa0ea4f34b85308db2516b6aeca50053535996864cfdee7b3f
+  md5: 778594b20097b5a948c59e50ae42482a
+  depends:
+  - __linux
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22868
+  timestamp: 1712585140895
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
+  sha256: f911307db932c92510da6c3c15b461aef935720776643a1fbf3683f61001068b
+  md5: c3cb67fc72fb38020fe7923dbbcf69b0
+  depends:
+  - __osx
+  - pyobjc-framework-cocoa
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23165
+  timestamp: 1712585504123
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_0.conda
+  sha256: d8aa230501a33250af2deee03006a2579f0335e7240a9c7286834788dcdcfaa8
+  md5: 5a86a21050ca3831ec7f77fb302f1132
+  depends:
+  - __win
+  - python >=3.7
+  - pywin32
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23319
+  timestamp: 1712585816346
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.3.0-pyhd8ed1ab_0.conda
+  sha256: a36d020b9f32fc3f1a6488a1c4a9c13988c6468faf6895bf30ca69521a61230e
+  md5: 2ce9825396daf72baabaade36cee16da
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 779561
+  timestamp: 1730382173961
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+  sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
+  md5: e5f25f8dbc060e9a8d912e432202afc2
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 14259
+  timestamp: 1620240338595
+- conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+  sha256: bc12100b2d8836b93c55068b463190505b8064d0fc7d025e89f20ebf22fe6c2b
+  md5: 490730480d76cf9c8f8f2849719c6e2b
+  depends:
+  - python >=3.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 15064
+  timestamp: 1708953086199
+- conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
+  md5: 6d6552722448103793743dabfbda532d
+  depends:
+  - python >=2.7
+  license: Apache-2.0
+  license_family: APACHE
+  size: 26314
+  timestamp: 1621217159824
+- conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+  sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
+  md5: 3f144b2c34f8cb5a9abd9ed23a39c561
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 36754
+  timestamp: 1693929424267
+- conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+  sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
+  md5: e7df0fdd404616638df5ece6e69ba7af
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 26205
+  timestamp: 1669632203115
+- conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+  sha256: 2e2c255b6f24a6d75b9938cb184520e27db697db2c24f04e18342443ae847c0a
+  md5: 04eedddeb68ad39871c8127dd1c21f4f
+  depends:
+  - python >=3.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17386
+  timestamp: 1702066480361
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+  sha256: b300557c0382478cf661ddb520263508e4b3b5871b471410450ef2846e8c352c
+  md5: efba281bbdae5f6b0a1d53c6d4a97c93
+  depends:
+  - __linux
+  - ptyprocess
+  - python >=3.8
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22452
+  timestamp: 1710262728753
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+  sha256: 4daae56fc8da17784578fbdd064f17e3b3076b394730a14119e571707568dc8a
+  md5: 00b54981b923f5aefcd5e8547de056d5
+  depends:
+  - __osx
+  - ptyprocess
+  - python >=3.8
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22717
+  timestamp: 1710265922593
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
+  sha256: 8cb078291fd7882904e3de594d299c8de16dd3af7405787fce6919a385cfc238
+  md5: 4abd500577430a942a995fd0d09b76a2
+  depends:
+  - __win
+  - python >=3.8
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22883
+  timestamp: 1710262943966
+- conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
+  sha256: 45e402941f6bed094022c5726a2ca494e6224b85180d2367fb6ddd9aea68079d
+  md5: df68d78237980a159bd7149f33c0e8fd
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23548
+  timestamp: 1714400228771
+- conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+  sha256: cad582d6f978276522f84bd209a5ddac824742fe2d452af6acf900f8650a73a2
+  md5: f1acf5fdefa8300de697982bcb1761c9
+  depends:
+  - python >=3.5
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28285
+  timestamp: 1729802975370
+- conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+  sha256: 6371cf3cf8292f2abdcc2bf783d6e70203d72f8ff0c1625f55a486711e276c75
+  md5: 34feccdd4177f2d3d53c73fc44fd9a37
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 52623
+  timestamp: 1728059623353
+- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.0-pyhd8ed1ab_0.conda
+  sha256: fb25b18cec1ebae56e7d7ebbd3e504f063b61a0fac17b1ca798fcaf205bdc874
+  md5: 196a9e6ab4e036ceafa516ea036619b0
+  depends:
+  - colorama
+  - python >=3.7
+  license: MPL-2.0 or MIT
+  size: 89434
+  timestamp: 1730926216380
+- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+  sha256: 8a64fa0f19022828513667c2c7176cfd125001f3f4b9bc00d33732e627dd2592
+  md5: 3df84416a021220d8b5700c613af2dc5
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110187
+  timestamp: 1713535244513
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
+  sha256: 8489af986daebfbcd13d3748ba55431259206e37f184ab42a57e107fecd85e02
+  md5: 3d326f8a2aa2d14d51d8c513426b5def
+  depends:
+  - python >=3.6
+  license: Apache-2.0 AND MIT
+  size: 21765
+  timestamp: 1727940339297
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+  sha256: d3b9a8ed6da7c9f9553c5fd8a4fca9c3e0ab712fa5f497859f82337d67533b73
+  md5: 52d648bd608f5737b123f510bb5514b5
+  depends:
+  - typing_extensions 4.12.2 pyha770c72_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 10097
+  timestamp: 1717802659025
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+  sha256: 0fce54f8ec3e59f5ef3bb7641863be4e1bf1279623e5af3d3fa726e8f7628ddb
+  md5: ebe6952715e1d5eb567eeebf25250fa7
+  depends:
+  - python >=3.8
+  license: PSF-2.0
+  license_family: PSF
+  size: 39888
+  timestamp: 1717802653893
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 9e3758b620397f56fb709f796969de436d63b7117897159619b87938e1f78739
+  md5: eb67e3cace64c66233e2d35949e20f92
+  depends:
+  - python >=3.6.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 13829
+  timestamp: 1622899345711
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+  sha256: 4fde5c3008bf5d2db82f2b50204464314cc3c91c1d953652f7bd01d9e52aefdf
+  md5: 8ac3367aafb1cc0a068483c580af8015
+  license: LicenseRef-Public-Domain
+  size: 122354
+  timestamp: 1728047496079
+- conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+  sha256: 54293cd94da3a6b978b353eb7897555055d925ad0008bc73e85cca19e2587ed0
+  md5: 3b7fc78d7be7b450952aaa916fb78877
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 11162
+  timestamp: 1707507514699
+- conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+  sha256: b76904b53721dc88a46352324c79d2b077c2f74a9f7208ad2c4249892669ae94
+  md5: 0944dc65cb4a9b5b68522c3bb585d41c
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 23999
+  timestamp: 1688655976471
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
+  sha256: 543ebab5241418a4e0d4d9e356ef13e4361504810a067a01481660bb35eb5643
+  md5: 6bb37c314b3cc1515dcf086ffe01c46e
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 115125
+  timestamp: 1718728467518
+- conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+  sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
+  md5: 68f0738df502a14213624b288c60c9ad
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 32709
+  timestamp: 1704731373922
+- conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
+  sha256: ec71f97c332a7d328ae038990b8090cbfa772f82845b5d2233defd167b7cc5ac
+  md5: eb48b812eb4fbb9ff238a6651fdbbcae
+  depends:
+  - python >=3.5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18378
+  timestamp: 1723294800217
+- conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+  sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
+  md5: daf5160ff9cde3a468556965329085b9
+  depends:
+  - python >=2.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15600
+  timestamp: 1694681458271
+- conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+  sha256: 44a5e3b97feef24cd719f7851cca9af9799dc9c17d3e0298d5856baab2d682f5
+  md5: f372c576b8774922da83cda2b12f9d29
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: APACHE
+  size: 47066
+  timestamp: 1713923494501
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.0-pyhd8ed1ab_0.conda
+  sha256: 8a51067f8e1a2cb0b5e89672dbcc0369e344a92e869c38b2946584aa09ab7088
+  md5: f9751d7c71df27b2d29f5cab3378982e
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 62755
+  timestamp: 1731120002488
+- conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_7.conda
+  sha256: c5297692ab34aade5e21107abaf623d6f93847662e25f655320038d2bfa1a812
+  md5: c998c13b2f998af57c3b88c7a47979e0
+  depends:
+  - __win
+  - python >=3.6
+  license: LicenseRef-Public-Domain
+  size: 9602
+  timestamp: 1727796413384
+- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.10.0-pyhd8ed1ab_0.conda
+  sha256: a35c8291de55f96ecc9121d1ebd4995977ea2f51d9e529e97749abc108afb0e4
+  md5: 53e365732dfa053c4d19fc6b927392c4
+  depends:
+  - numpy >=1.24
+  - packaging >=23.1
+  - pandas >=2.1
+  - python >=3.10
+  constrains:
+  - matplotlib-base >=3.7
+  - netcdf4 >=1.6.0
+  - numba >=0.57
+  - hdf5 >=1.12
+  - sparse >=0.14
+  - cftime >=1.6
+  - zarr >=2.16
+  - flox >=0.7
+  - pint >=0.22
+  - toolz >=0.12
+  - scipy >=1.11
+  - seaborn-base >=0.12
+  - distributed >=2023.9
+  - iris >=3.7
+  - cartopy >=0.22
+  - bottleneck >=1.3
+  - dask-core >=2023.9
+  - h5py >=3.8
+  - h5netcdf >=1.2
+  - nc-time-axis >=1.4
+  license: Apache-2.0
+  license_family: APACHE
+  size: 813754
+  timestamp: 1729867978934
+- conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_0.conda
+  sha256: 2dd2825b5a246461a95a0affaf7e1d459f7cc0ae68ad2dd8aab360c2e5859488
+  md5: 156c91e778c1d4d57b709f8c5333fd06
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 46887
+  timestamp: 1725366457240
+- conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+  sha256: 3d65c081514569ab3642ba7e6c2a6b4615778b596db6b1c82ee30a2d912539e5
+  md5: cf30c2c15b82aacb07f9c09e28ff2275
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36325
+  timestamp: 1681770298596
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_0.conda
+  sha256: 232a30e4b0045c9de5e168dda0328dc0e28df9439cdecdfb97dd79c1c82c4cec
+  md5: fee389bf8a4843bd7a2248ce11b7f188
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 21702
+  timestamp: 1731262194278
+- conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h3336109_5.conda
+  sha256: fa5eb633b320e10fc2138f3d842d8a8ca72815f106acbab49a68ec9783e4d70d
+  md5: 29b46bd410067f668c4cef7fdc78fe25
+  depends:
+  - __osx >=10.13
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 32275
+  timestamp: 1725356815696
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.31-hc566b99_3.conda
+  sha256: f6f981900fca0af93753e464c2e73ef4629f5f98d6f1b126befa186575e21799
+  md5: af34a904eecd797f41b183c329623ec2
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-http >=0.8.10,<0.8.11.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - aws-c-sdkutils >=0.1.19,<0.1.20.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94612
+  timestamp: 1729533030938
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.7.4-h40772b6_2.conda
+  sha256: 4770ffec772090bbddc354c24bc2e6425d3071b1e09fa589606689fabcaff25f
+  md5: a5c1b1cb5a03d4a5b67e98df8da31aa1
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 39297
+  timestamp: 1728755588333
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.29-ha44c9a9_0.conda
+  sha256: 2a1f37f67fabac89ef9f4f9e105c33993cab22edb94801d03555a5ab44b9c557
+  md5: 51d626987f9327896b2e3ac2d36f2163
+  depends:
+  - __osx >=10.13
+  license: Apache-2.0
+  license_family: Apache
+  size: 226610
+  timestamp: 1728706789415
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.19-h40772b6_2.conda
+  sha256: e4e7c8ebc1761f263927af2eedddbba0b5698e05a073100b953b0d0d33cc969b
+  md5: 083875412346dcc097c6b1ca4aaa4abf
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18004
+  timestamp: 1728750733091
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.3-h453e538_5.conda
+  sha256: c063159d6af211df4f774d4f65c206a8d12488feb96fb097f6a73c6a9193723f
+  md5: 9c3a1df30fb65e0e8e04ff24ba46d63b
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - aws-checksums >=0.1.20,<0.1.21.0a0
+  - libcxx >=17
+  license: Apache-2.0
+  license_family: Apache
+  size: 46843
+  timestamp: 1729527584644
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.10-h592d179_3.conda
+  sha256: 0ff999f7aad671d0c1992cb7dc8314f792e3022664d752e8d720fe9a4703c16e
+  md5: 7d1b1a2784fe1f61ca10c79c4fc4ed4c
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-compression >=0.2.19,<0.2.20.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 164061
+  timestamp: 1729517894484
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.20-h99e8e40_0.conda
+  sha256: 4aa7165dbf4e0d6d4f866c6924ebbcb94522b952fe66e152bd1e19aefd3e58dc
+  md5: 64cef8703c997b27425801b5a96f3f7c
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 139031
+  timestamp: 1729105799829
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.7-h86759dc_3.conda
+  sha256: fa8363c23ff61eb438393baf23357cf4ca9b05ae907cba295e1b75883e8744ad
+  md5: 4d53c7c1db218db67b22f5011e83c0f6
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-http >=0.8.10,<0.8.11.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 164379
+  timestamp: 1729534328438
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.6.7-h24045d9_1.conda
+  sha256: 38b126e0671a6db4c1ea5a84e6734bebf7cafc279ce8731a185f9c1ecd085737
+  md5: d833468ff5c331bff5870896f376e6d7
+  depends:
+  - __osx >=10.13
+  - aws-c-auth >=0.7.31,<0.7.32.0a0
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-http >=0.8.10,<0.8.11.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - aws-checksums >=0.1.20,<0.1.21.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 97737
+  timestamp: 1729544344228
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.19-h40772b6_4.conda
+  sha256: a74a1bdc601ab112d849b414908aa01451f8d0de27c0b233155fea07d69e0551
+  md5: 8d7e97d7c9829f54acbf018a88f2f20e
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 50711
+  timestamp: 1728755916895
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.20-h40772b6_1.conda
+  sha256: a32f81d6349580b38a917f1643677650b931fc67fab9c9b123e47c3de4844d21
+  md5: a40738142e8dfc05b328ff240ad56c02
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 70907
+  timestamp: 1728750777703
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.28.5-h791b958_1.conda
+  sha256: ff8761131a23cdfb311be72679a3af065116c37b981e75a78ba08444b1907062
+  md5: df4bc6e227af5a8d7e561ba012459017
+  depends:
+  - __osx >=10.13
+  - aws-c-auth >=0.7.31,<0.7.32.0a0
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-event-stream >=0.4.3,<0.4.4.0a0
+  - aws-c-http >=0.8.10,<0.8.11.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - aws-c-mqtt >=0.10.7,<0.10.8.0a0
+  - aws-c-s3 >=0.6.7,<0.6.8.0a0
+  - aws-c-sdkutils >=0.1.19,<0.1.20.0a0
+  - libcxx >=17
+  license: Apache-2.0
+  license_family: Apache
+  size: 294712
+  timestamp: 1729557265215
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.407-h96db62b_2.conda
+  sha256: ae6f335b8be1249b0925ab6515e35f9db8587a39dcbe69ba5b13d65b087822ef
+  md5: 079a53ff89dcb7a3fdc267b7c67f4b1a
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-event-stream >=0.4.3,<0.4.4.0a0
+  - aws-checksums >=0.1.20,<0.1.21.0a0
+  - aws-crt-cpp >=0.28.5,<0.28.6.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2774431
+  timestamp: 1729597614944
+- conda: https://conda.anaconda.org/conda-forge/osx-64/awscli-2.20.0-py311h6eed73b_0.conda
+  sha256: 47ab0fc7a2f6fb08a8e2b2e776a4f936afac89eb106f411374398540b011b2a4
+  md5: af80a42a3584c98253c3e8f88a6874fe
+  depends:
+  - awscrt >=0.19.18,<=0.22.0
+  - colorama >=0.2.5,<0.4.7
+  - cryptography >=40.0.0,<43.0.2
+  - distro >=1.5.0,<1.9.0
+  - docutils >=0.10,<0.20
+  - jmespath >=0.7.1,<1.1.0
+  - prompt_toolkit >=3.0.24,<3.0.39
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.1,<=2.9.0
+  - python_abi 3.11.* *_cp311
+  - ruamel.yaml >=0.15.0,<=0.17.21
+  - ruamel.yaml.clib >=0.2.0,<=0.2.8
+  - urllib3 >=1.25.4,<1.27
+  license: Apache-2.0
+  license_family: APACHE
+  size: 12763392
+  timestamp: 1731486921859
+- conda: https://conda.anaconda.org/conda-forge/osx-64/awscrt-0.22.0-py311hefc6fae_6.conda
+  sha256: 30677172cc6cec711b068e29a39f538b7eaf71a0d513f3b6c6dfc162cc20b4ea
+  md5: 7abd474c45ee79760fb63d71a4021423
+  depends:
+  - __osx >=10.13
+  - aws-c-auth >=0.7.31,<0.7.32.0a0
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-event-stream >=0.4.3,<0.4.4.0a0
+  - aws-c-http >=0.8.10,<0.8.11.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - aws-c-mqtt >=0.10.7,<0.10.8.0a0
+  - aws-c-s3 >=0.6.7,<0.6.8.0a0
+  - aws-checksums >=0.1.20,<0.1.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 185376
+  timestamp: 1729557544443
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.14.0-h9a36307_0.conda
+  sha256: c7694fc16b9aebeb6ee5e4f80019b477a181d961a3e4d9b6a66b77777eb754fe
+  md5: 1082a031824b12a2be731d600cfa5ccb
+  depends:
+  - __osx >=10.13
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 303166
+  timestamp: 1728053999891
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.10.0-ha4e2ba9_0.conda
+  sha256: b9899b9698a6c7353fc5078c449105aae58635d217befbc8ca9d5a527198019b
+  md5: ad56b6a4b8931d37a2cf5bc724a46f01
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 175344
+  timestamp: 1728487066445
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.13.0-h3d2f5f1_1.conda
+  sha256: 31984e52450230d04ca98d5232dbe256e5ef6e32b15d46124135c6e64790010d
+  md5: 3df4fb5d6d0e7b3fb28e071aff23787e
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 445040
+  timestamp: 1728578180436
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.8.0-h1ccc5ac_1.conda
+  sha256: 51fb67d2991d105b8f7b97b4810cd63bac4dc421a4a9c83c15a98ca520a42e1e
+  md5: 5b3e79eb148d6e30d6c697788bad9960
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - libxml2 >=2.12.7,<2.14.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 126229
+  timestamp: 1728563580392
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-files-datalake-cpp-12.12.0-h86941f0_1.conda
+  sha256: 12d95251a8793ea2e78f494e69353a930e9ea06bbaaaa4ccb6e5b3e35ee0744f
+  md5: 60452336e7f61f6fdaaff69264ee112e
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 200991
+  timestamp: 1728729588371
+- conda: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.6-h7d75f6d_0.conda
+  sha256: 65e5f5dd3d68ed0d9d35e79d64f8141283cad2b55dcd9a04480ceea0e436aca8
+  md5: 3e5669e51737d04f4806dd3e8c424663
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 47051
+  timestamp: 1719266142315
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h00291cd_2.conda
+  sha256: 624954bc08b3d7885a58c7d547282cfb9a201ce79b748b358f801de53e20f523
+  md5: 2db0c38a7f2321c5bdaf32b181e832c7
+  depends:
+  - __osx >=10.13
+  - brotli-bin 1.1.0 h00291cd_2
+  - libbrotlidec 1.1.0 h00291cd_2
+  - libbrotlienc 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 19450
+  timestamp: 1725267851605
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h00291cd_2.conda
+  sha256: 642a8492491109fd8270c1e2c33b18126712df0cedb94aaa2b1c6b02505a4bfa
+  md5: 049933ecbf552479a12c7917f0a4ce59
+  depends:
+  - __osx >=10.13
+  - libbrotlidec 1.1.0 h00291cd_2
+  - libbrotlienc 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 16643
+  timestamp: 1725267837325
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hd89902b_2.conda
+  sha256: 004cefbd18f581636a8dcb1964fb73478f15d496769226ec896c1d4a0161b7d8
+  md5: d75f06ee06001794aa83a05e885f1520
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 363793
+  timestamp: 1725267947069
+- conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+  sha256: cad153608b81fb24fc8c509357daa9ae4e49dfc535b2cb49b91e23dbd68fc3c5
+  md5: 7ed4301d437b59045be7e051a0308211
+  depends:
+  - __osx >=10.13
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 134188
+  timestamp: 1720974491916
+- conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.3-hf13058a_0.conda
+  sha256: e1bc2520ba9bfa55cd487efabd6bfaa49ccd944847895472133ba919810c9978
+  md5: c36355bc08d4623c210b00f9935ee632
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 183798
+  timestamp: 1731181957603
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.8.30-h8857fd0_0.conda
+  sha256: 593f302d0f44c2c771e1614ee6d56fffdc7d616e6f187669c8b0e34ffce3e1ae
+  md5: b7e5424e7f06547a903d28e4651dbb21
+  license: ISC
+  size: 158665
+  timestamp: 1725019059295
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cartopy-0.24.0-py311haeb46be_0.conda
+  sha256: 5de8435aff6492d4f6aac711be102d121ebdc4bf4ef12602943cd7ed670435ef
+  md5: e9759395bf751096605fbf4a21627650
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - matplotlib-base >=3.6
+  - numpy >=1.19,<3
+  - packaging >=21
+  - pyproj >=3.3.1
+  - pyshp >=2.3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - shapely >=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1518753
+  timestamp: 1728342398327
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.1-py311h137bacd_0.conda
+  sha256: 012ee7b1ed4f9b0490d6e90c72decf148d7575173c7eaf851cd87fd434d2cacc
+  md5: a4b0f531064fa3dd5e3afbb782ea2cd5
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 288762
+  timestamp: 1725560945833
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cftime-1.6.4-py311h0034819_1.conda
+  sha256: 025d33877c4e3558bd3d8c8d11bcd11760d61634d1b1be819203c5b00b770132
+  md5: cda3610885501f18aec020da7f92cf25
+  depends:
+  - __osx >=10.13
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 211019
+  timestamp: 1725400678395
+- conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.1-py311h4e34fa0_0.conda
+  sha256: 373e17f22bca3e13aac2245bb0c8a15c4a54d1ffa4c3278308eeb8d3c9435c0e
+  md5: 6bc3882064e277827934e2c6e5281661
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 255123
+  timestamp: 1731428577146
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cramjam-2.8.4rc3-py311h4c0077b_2.conda
+  sha256: 12e0366947ced36e1a5f467f96456ddec1d7c0f528f4403df70d6545d480be40
+  md5: 69812eb9983792ef3a9700590ff190aa
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 1684554
+  timestamp: 1726116938197
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cryptography-43.0.1-py311he4fabbe_0.conda
+  sha256: df659f32385a64d55efba4d92526bab06acb05fd5f77c88c3c688c92103f2c1d
+  md5: c8c6e5dfcd560fc8a0e13586e1e678cc
+  depends:
+  - __osx >=10.13
+  - cffi >=1.12
+  - openssl >=3.3.2,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=10.13
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1384620
+  timestamp: 1725443467013
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.0.0-py311h3336109_1.conda
+  sha256: fd921e8aa9ec5d26b2aebaef91dd4bc1e6d4fd2114f2fc566578122ff95cdb3c
+  md5: d7a579f4ad0ad76e49fb62151ad6fd6f
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 344088
+  timestamp: 1728335202437
+- conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.8-py311hc356e98_0.conda
+  sha256: 34f83a442443323f02e7674a5accadd376324535db561415c7ce6796c88cb5dc
+  md5: 89062c093aafdfa2155f13967177ef8a
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2492179
+  timestamp: 1731045106437
+- conda: https://conda.anaconda.org/conda-forge/osx-64/docutils-0.19-py311h6eed73b_1.tar.bz2
+  sha256: 3dde82219d807a1538464698ca1863f658a39d31a85e6bfa26ef20584617ffd4
+  md5: 268664c5447607a94cd67a0be91f83cd
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1
+    and GPL-3.0-or-later
+  size: 973200
+  timestamp: 1666755137227
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fastparquet-2024.5.0-py311hde34974_2.conda
+  sha256: d6d2ae502db842938596f0472f602876875dd0447fd0c91cd457b9102ff90067
+  md5: 7bfb9fbf607a4f38333dcc9b224c9965
+  depends:
+  - __osx >=10.13
+  - cramjam >=2.3
+  - fsspec
+  - numpy >=1.19,<3
+  - numpy >=1.20.3
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 501928
+  timestamp: 1729689755933
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.54.1-py311h8b4e8a7_1.conda
+  sha256: 6e87394a492e41d3529a6368012b92bc05d6299c2f77608960dab6d51c764aa9
+  md5: 0dda445e469108be9318f003a580aaac
+  depends:
+  - __osx >=10.13
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2799599
+  timestamp: 1729530496062
+- conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+  sha256: b292cf5a25f094eeb4b66e37d99a97894aafd04a5683980852a8cbddccdc8e4e
+  md5: 25152fce119320c980e5470e64834b50
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 599300
+  timestamp: 1694616137838
+- conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.13.0-hac325c4_0.conda
+  sha256: 7e3201780fda37f23623e384557eb66047942db1c2fe0a7453c0caf301ec8bbb
+  md5: 905fbe84dd83254e4e0db610123dd32d
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  license: LGPL-2.1-only
+  size: 1577166
+  timestamp: 1725676182968
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hac325c4_1005.conda
+  sha256: c0bea66f71a6f4baa8d4f0248e17f65033d558d9e882c0af571b38bcca3e4b46
+  md5: a26de8814083a6971f14f9c8c3cb36c2
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84946
+  timestamp: 1726600054963
+- conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h2790a97_0.conda
+  sha256: dd56547db8625eb5c91bb0a9fbe8bd6f5c7fbf5b6059d46365e94472c46b24f9
+  md5: 06cf91665775b0da395229cd4331b27d
+  depends:
+  - __osx >=10.13
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 117017
+  timestamp: 1718284325443
+- conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
+  sha256: 8c767cc71226e9eb62649c903c68ba73c5f5e7e3696ec0319d1f90586cebec7d
+  md5: 7ce543bf38dbfae0de9af112ee178af2
+  depends:
+  - libcxx >=15.0.7
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 724103
+  timestamp: 1695661907511
+- conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.4-nompi_h1607680_103.conda
+  sha256: bcec9cfa16cd8a3562255d3a97930716cf7c788aad6338baf6bd7bd7c803aa32
+  md5: 23eb36be1235e5986845d9f7d1acedc0
+  depends:
+  - __osx >=10.13
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3733556
+  timestamp: 1730831490461
+- conda: https://conda.anaconda.org/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
+  sha256: 2e64307532f482a0929412976c8450c719d558ba20c0962832132fd0d07ba7a7
+  md5: d68d48a3060eb5abdc1cdc8e2a3a5966
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 11761697
+  timestamp: 1720853679409
+- conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_1.conda
+  sha256: 2499e5ebb3efa4186d6922122224d16bac791a5c0adad5b48b2bcd1e1e2afc8d
+  md5: b6c1710105dad14d47001a339cd14da6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17727
+  timestamp: 1725302991176
+- conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.7-py311hf2f7c97_0.conda
+  sha256: 00b477bff9138ca51edd94f7b31ce9fe2cd13a1dc8768abcf037a22eccf26940
+  md5: 24b0e3e3444be9fabcc8457c409e297f
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 60398
+  timestamp: 1725459431458
+- conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+  sha256: 83b52685a4ce542772f0892a0f05764ac69d57187975579a0835ff255ae3ef9c
+  md5: d4765c524b1d91567886bde656fb514b
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1185323
+  timestamp: 1719463492984
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
+  sha256: 222ebc0a55544b9922f61e75015d02861e65b48f12113af41d48ba0814e14e4e
+  md5: 1442db8f03517834843666c422238c9b
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 224432
+  timestamp: 1701648089496
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+  sha256: e41790fc0f4089726369b3c7f813117bbc14b533e0ed8b94cf75aba252e82497
+  md5: f9d6a4c82889d5ecedec1d90eb673c55
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 290319
+  timestamp: 1657977526749
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240722.0-cxx17_hac325c4_1.conda
+  sha256: b548e80280242ad1d93d8d7fb48a30af7e4124959ba2031c65c9675b98163652
+  md5: 40373920232a6ac0404eee9cf39a9f09
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  constrains:
+  - abseil-cpp =20240722.0
+  - libabseil-static =20240722.0=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1170354
+  timestamp: 1727295597292
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
+  sha256: dae5921339c5d89f4bf58a95fd4e9c76270dbf7f6a94f3c5081b574905fcccf8
+  md5: 66d3c1f6dd4636216b4fca7a748d50eb
+  depends:
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 28602
+  timestamp: 1711021419744
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-17.0.0-h0c1ea87_23_cpu.conda
+  sha256: 8609ce58adc7548f07279cb8f478309ae75e14eaac28f4f39f71d638dd97b18b
+  md5: 4cbf66188b3b782153f79d5052eca944
+  depends:
+  - __osx >=10.13
+  - aws-crt-cpp >=0.28.5,<0.28.6.0a0
+  - aws-sdk-cpp >=1.11.407,<1.11.408.0a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-identity-cpp >=1.10.0,<1.10.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-files-datalake-cpp >=12.12.0,<12.12.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=18
+  - libgoogle-cloud >=2.30.0,<2.31.0a0
+  - libgoogle-cloud-storage >=2.30.0,<2.31.0a0
+  - libre2-11 >=2024.7.2
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.2,<2.0.3.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  - libutf8proc <2.9
+  constrains:
+  - parquet-cpp <0.0a0
+  - arrow-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5932212
+  timestamp: 1729637038430
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-17.0.0-h240833e_23_cpu.conda
+  sha256: ca086903475349ff1e3072e17835f26a4e5e8c6ee17eca8460ea11dbaf2627cd
+  md5: 11e8e7d670241ce626c6144f81c75e6d
+  depends:
+  - __osx >=10.13
+  - libarrow 17.0.0 h0c1ea87_23_cpu
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: APACHE
+  size: 519534
+  timestamp: 1729637143493
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-17.0.0-h240833e_23_cpu.conda
+  sha256: fa404ba2befaff7c2c062b7bb3d17ee0277d226f774570e6a1e69be8e8e41a21
+  md5: 45575d438b15a1acdce8dd0093252fa9
+  depends:
+  - __osx >=10.13
+  - libarrow 17.0.0 h0c1ea87_23_cpu
+  - libarrow-acero 17.0.0 h240833e_23_cpu
+  - libcxx >=18
+  - libparquet 17.0.0 hc957f30_23_cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 511742
+  timestamp: 1729638142042
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-17.0.0-hdefb866_23_cpu.conda
+  sha256: 628f457c1b5c321e283c21bed2b994aca5a8ad4d36d5d2ad77d4659d339ad26a
+  md5: 980de8fd67d2d926d6f92a15066ce359
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 17.0.0 h0c1ea87_23_cpu
+  - libarrow-acero 17.0.0 h240833e_23_cpu
+  - libarrow-dataset 17.0.0 h240833e_23_cpu
+  - libcxx >=18
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 459750
+  timestamp: 1729638278533
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-25_osx64_openblas.conda
+  sha256: 1b22b5322a311a775bca637b26317645cf07e35f125cede9278c6c45db6e7105
+  md5: da0a6f87958893e1d2e2bbc7e7a6541f
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - liblapack 3.9.0 25_osx64_openblas
+  - liblapacke 3.9.0 25_osx64_openblas
+  - blas * openblas
+  - libcblas 3.9.0 25_osx64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15952
+  timestamp: 1729643159199
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h00291cd_2.conda
+  sha256: b377056470a9fb4a100aa3c51b3581aab6496ba84d21cd99bcc1d5ef0359b1b6
+  md5: 58f2c4bdd56c46cc7451596e4ae68e0b
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 67267
+  timestamp: 1725267768667
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h00291cd_2.conda
+  sha256: 4d49ea72e2f44d2d7a8be5472e4bd0bc2c6b89c55569de2c43576363a0685c0c
+  md5: 34709a1f5df44e054c4a12ab536c5459
+  depends:
+  - __osx >=10.13
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 29872
+  timestamp: 1725267807289
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h00291cd_2.conda
+  sha256: 477d236d389473413a1ccd2bec1b66b2f1d2d7d1b4a57bb56421b7b611a56cd1
+  md5: 691f0dcb36f1ae67f5c489f20ae987ea
+  depends:
+  - __osx >=10.13
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 296353
+  timestamp: 1725267822076
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-25_osx64_openblas.conda
+  sha256: b04ae297aa5396df3135514866db72845b111c92524570f923625473f11cfbe2
+  md5: ab304b75ea67f850cf7adf9156e3f62f
+  depends:
+  - libblas 3.9.0 25_osx64_openblas
+  constrains:
+  - liblapack 3.9.0 25_osx64_openblas
+  - liblapacke 3.9.0 25_osx64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15842
+  timestamp: 1729643166929
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+  sha256: 3043869ac1ee84554f177695e92f2f3c2c507b260edad38a0bf3981fce1632ff
+  md5: 23d6d5a69918a438355d7cbc4c3d54c9
+  depends:
+  - libcxx >=11.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20128
+  timestamp: 1633683906221
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.10.1-h58e7537_0.conda
+  sha256: 662fe145459ed58dee882e525588d1da4dcc4cbd10cfca0725d1fc3840461798
+  md5: 6c8669d8228a2bbd0283911cc6d6726e
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 402588
+  timestamp: 1726660264675
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.3-hf95d169_0.conda
+  sha256: 466f259bb13a8058fef28843977c090d21ad337b71a842ccc0407bccf8d27011
+  md5: 86801fc56d4641e3ef7a63f5d996b960
+  depends:
+  - __osx >=10.13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 528991
+  timestamp: 1730314340106
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.22-h00291cd_0.conda
+  sha256: 681035346974c3315685dc40898e26f65f1c00cbb0b5fd80cc2599e207a34b31
+  md5: a15785ccc62ae2a8febd299424081efb
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 70407
+  timestamp: 1728177128525
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+  sha256: dbd3c3f2eca1d21c52e4c03b21930bbce414c4592f8ce805801575b9e9256095
+  md5: 6016a8a1d0e63cac3de2c352cd40208b
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 105382
+  timestamp: 1597616576726
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+  sha256: 0d238488564a7992942aa165ff994eca540f687753b4f0998b29b4e4d030ff43
+  md5: 899db79329439820b7e8f8de41bca902
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 106663
+  timestamp: 1702146352558
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+  sha256: e0bd9af2a29f8dd74309c0ae4f17a7c2b8c4b89f875ff1d6540c941eefbd07fb
+  md5: e38e467e577bd193a7d5de7c2c540b04
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372661
+  timestamp: 1685726378869
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.4-h240833e_0.conda
+  sha256: d10f43d0c5df6c8cf55259bce0fe14d2377eed625956cddce06f58827d288c59
+  md5: 20307f4049a735a78a29073be1be2626
+  depends:
+  - __osx >=10.13
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 70758
+  timestamp: 1730967204736
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+  sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
+  md5: ccb34fb14960ad8b125962d3d79b31a9
+  license: MIT
+  license_family: MIT
+  size: 51348
+  timestamp: 1636488394370
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+  sha256: 4874422e567b68334705c135c17e5acdca1404de8255673ce30ad3510e00be0d
+  md5: 0b6e23a012ee7a9a5f6b244f5a92c1d5
+  depends:
+  - libgfortran5 13.2.0 h2873a65_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110106
+  timestamp: 1707328956438
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+  sha256: da3db4b947e30aec7596a3ef92200d17e774cccbbf7efc47802529a4ca5ca31b
+  md5: e4fb4d23ec2870ff3c40d10afe305aec
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1571379
+  timestamp: 1707328880361
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.30.0-hade041e_0.conda
+  sha256: faf1c644b68306e3a58b471edaaac67f57c193ca543533fe7f29f698e9b9c626
+  md5: a431e45b599ada6817543683cf61115c
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - libgrpc >=1.65.5,<1.66.0a0
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - openssl >=3.3.2,<4.0a0
+  constrains:
+  - libgoogle-cloud 2.30.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 864474
+  timestamp: 1728021663496
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.30.0-h8126ed0_0.conda
+  sha256: 104333dad7dc1ea4467f7f14dedab7ed4bdfc664493605767550262e7488bdb3
+  md5: fdfef310fda223057e1e4962146ddf97
+  depends:
+  - __osx >=10.13
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libcxx >=17
+  - libgoogle-cloud 2.30.0 hade041e_0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  size: 553911
+  timestamp: 1728022491695
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.65.5-hb88832f_0.conda
+  sha256: b862af63c5b362743527fde9b7411b6a2d1270f858acbabc2beeee306465b405
+  md5: 8ef969b891fe57caf3acfb5495ec0ab9
+  depends:
+  - __osx >=10.13
+  - c-ares >=1.33.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - libre2-11 >=2023.9.1
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.65.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5152392
+  timestamp: 1727200873427
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
+  sha256: 23d4923baeca359423a7347c2ed7aaf48c68603df0cf8b87cc94a10b0d4e9a23
+  md5: 6c3628d047e151efba7cf08c5e54d1ca
+  license: LGPL-2.1-only
+  size: 666538
+  timestamp: 1702682713201
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+  sha256: d9572fd1024adc374aae7c247d0f29fdf4b122f1e3586fe62acc18067f40d02f
+  md5: 72507f8e3961bc968af17435060b6dd6
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 579748
+  timestamp: 1694475265912
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-25_osx64_openblas.conda
+  sha256: 2a9a6143d103e7e21511cbf439521645bdd506bfabfcac9d6398dd0562c6905c
+  md5: dda0e24b4605ebbd381e48606a107bed
+  depends:
+  - libblas 3.9.0 25_osx64_openblas
+  constrains:
+  - liblapacke 3.9.0 25_osx64_openblas
+  - blas * openblas
+  - libcblas 3.9.0 25_osx64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15852
+  timestamp: 1729643174413
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-hc8e404f_4.conda
+  sha256: 0df3902a300cfe092425f86144d5e00ef67be3cd1cc89fd63084d45262a772ad
+  md5: ed06753e2ba7c66ed0ca7f19578fcb68
+  depends:
+  - libcxx >=15
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 22467131
+  timestamp: 1690563140552
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.2-nompi_h976d569_115.conda
+  sha256: 90fbe85be42ce31b4d41b54fe2d686049435c08ffbc60f8b6a9c39de51102031
+  md5: cece37517cf646a6a710080f8fc1528d
+  depends:
+  - __osx >=10.13
+  - blosc >=1.21.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzip >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zlib
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 724239
+  timestamp: 1728056183743
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.64.0-hc7306c3_0.conda
+  sha256: 0dcfdcf3a445d2d7de4f3b186ab0a794dc872f4ea21622f9b997be72712c027f
+  md5: ab21007194b97beade22ceb7a3f6fee5
+  depends:
+  - __osx >=10.13
+  - c-ares >=1.34.2,<2.0a0
+  - libcxx >=17
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 606663
+  timestamp: 1729572019083
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_hbf64a52_1.conda
+  sha256: cef5856952688ce9303f85f5bc62c99e8c2256b4c679f63afdfb381f222e90c7
+  md5: cd2c572c02a73b88c4d378eb31110e85
+  depends:
+  - __osx >=10.13
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - llvm-openmp >=18.1.8
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6165715
+  timestamp: 1730773348340
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-17.0.0-hc957f30_23_cpu.conda
+  sha256: 7e53ed94db52097559788956eb6a8fe30364a608494c65020a46131d04987b5d
+  md5: 609496ae41aa7f56173b7df97d1621a8
+  depends:
+  - __osx >=10.13
+  - libarrow 17.0.0 h0c1ea87_23_cpu
+  - libcxx >=18
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 926425
+  timestamp: 1729638068091
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.44-h4b8f8c9_0.conda
+  sha256: 12b44e58f8832798d7a5c0a7480c95e905dbd6c3558dec09739062411f9e08d1
+  md5: f32ac2c8dd390dbf169f550887ed09d9
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 268073
+  timestamp: 1726234803010
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-5.27.5-h62b0dff_2.conda
+  sha256: ac77bce3b9a58e6fa72bed339af0d47faf1dec3bc717e4e05e2e729dc42bd2b3
+  md5: e3b68d9a164d807f70df49e17bc54931
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2332719
+  timestamp: 1727424047974
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2024.07.02-hd530cb8_1.conda
+  sha256: 2fac39fb704ded9584d1a9e7511163830016803f83852a724c2ccef1cc16e17b
+  md5: 1e14c67a5e8a9273a98b83fbc0905b99
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 178580
+  timestamp: 1728779037721
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
+  sha256: d3975cfe60e81072666da8c76b993af018cf2e73fe55acba2b5ba0928efaccf5
+  md5: 6af4b059e26492da6013e79cbcb4d069
+  depends:
+  - __osx >=10.13
+  license: ISC
+  size: 210249
+  timestamp: 1716828641383
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.0-h2f8c449_1.conda
+  sha256: a0f7381c867898a45018b1e5cf1aca68659d292d58252e8f489a4270b010fed8
+  md5: af445c495253a871c3d809e1199bb12b
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 915300
+  timestamp: 1730208101739
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+  sha256: f3886763b88f4b24265db6036535ef77b7b77ce91b1cbe588c0fbdd861eec515
+  md5: ca3a72efba692c59a90d4b9fc0dfe774
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 259556
+  timestamp: 1685837820566
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.21.0-h75589b3_0.conda
+  sha256: 3f82eddd6de435a408538ac81a7a2c0c155877534761ec9cd7a2906c005cece2
+  md5: 7a472cd20d9ae866aeb6e292b33381d6
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 332651
+  timestamp: 1727206546431
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-h583c2ba_1.conda
+  sha256: 4d58c695dfed6f308d0fd3ff552e0078bb98bc0be2ea0bf55820eb6e86fa5355
+  md5: 4b78bcdcc8780cede8b3d090deba874d
+  depends:
+  - __osx >=10.13
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=17
+  - libdeflate >=1.22,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 395980
+  timestamp: 1728232302162
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
+  sha256: 55a7f96b2802e94def207fdfe92bc52c24d705d139bb6cdb3d936cbe85e1c505
+  md5: db98dc3e58cbc11583180609c429c17d
+  license: MIT
+  license_family: MIT
+  size: 98942
+  timestamp: 1667316472080
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
+  sha256: 7bafd8f4c637778cd0aa390bf3a894feef0e1fcf6ea6000c7ffc25c4c5a65538
+  md5: b2c0047ea73819d992484faacbbe1c24
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 355099
+  timestamp: 1713200298965
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+  sha256: 8896cd5deff6f57d102734f3e672bc17120613647288f9122bec69098e839af7
+  md5: bbeca862892e2898bdb45792a61c4afc
+  depends:
+  - __osx >=10.13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 323770
+  timestamp: 1727278927545
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.5-h495214b_0.conda
+  sha256: 66e1bf40699daf83b39e1281f06c64cf83499de3a9c05d59477fadded6d85b18
+  md5: 8711bc6fb054192dc432741dcd233ac3
+  depends:
+  - __osx >=10.13
+  - icu >=75.1,<76.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 608931
+  timestamp: 1731489767386
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzip-1.11.2-h31df5bb_0.conda
+  sha256: 434a4d1ad23c1c8deb7ec2da94aca05e22bc29dee445b4f7642e1c2f20fc0b0b
+  md5: 3cf12c97a18312c9243a895580bf5be6
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 129542
+  timestamp: 1730442392952
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+  sha256: 8412f96504fc5993a63edf1e211d042a1fd5b1d51dedec755d2058948fcced09
+  md5: 003a54a4e32b02f7355b50a837e699da
+  depends:
+  - __osx >=10.13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 57133
+  timestamp: 1727963183990
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.3-hf78d878_0.conda
+  sha256: 3d28e9938ab1400322ba76968cdbee035009d611bbee94ec6b38a154551954b4
+  md5: 18a8498d57d871da066beaa09263a638
+  depends:
+  - __osx >=10.13
+  constrains:
+  - openmp 19.1.3|19.1.3.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 305524
+  timestamp: 1730364180247
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.43.0-py311h25b8078_1.conda
+  sha256: 8f47684beb89f6c03d10a06929365218cdf4454aee52f0bf83a97da4597c429c
+  md5: 19d1706a45751962b116123dcbc578f0
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 379249
+  timestamp: 1725305363038
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-4.3.3-py311h12b7ed1_1.conda
+  sha256: 47515c300a34c47be42b3196f6f5d400fd3f80f0ae25c73eb10ad367cef450cb
+  md5: ab30eba2d9fe565ff640369016e74fe5
+  depends:
+  - __osx >=10.13
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36652
+  timestamp: 1725089602246
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+  sha256: 39aa0c01696e4e202bf5e337413de09dfeec061d89acd5f28e9968b4e93c3f48
+  md5: aa04f7143228308662696ac24023f991
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 156415
+  timestamp: 1674727335352
+- conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.2-py311h8b4e8a7_0.conda
+  sha256: dd3554cee0aedc19a0cd56b52555c26fb0392e97749ceb202ddac7de55e3acf2
+  md5: 87074906abc091b40ac46e7881b7e45d
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24409
+  timestamp: 1729351443593
+- conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.9.2-py311h6eed73b_2.conda
+  sha256: 66bca9cbbc072c7ee6b2b8ee5376a35ea7b088b17a31273a4f218c3625dd3e87
+  md5: 551824529b100cbb0a26efcf3a008594
+  depends:
+  - matplotlib-base >=3.9.2,<3.9.3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tornado >=5
+  license: PSF-2.0
+  license_family: PSF
+  size: 17004
+  timestamp: 1731025399138
+- conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.2-py311h8b21175_2.conda
+  sha256: 26efe199ae6d1cadd2cab43d75f05b6b9b9236db731d605c4a079fe3706b7ea7
+  md5: baafa77537c20f3b575f5729de00d487
+  depends:
+  - __osx >=10.13
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8100228
+  timestamp: 1731025375118
+- conda: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.1.0-py311hf2f7c97_0.conda
+  sha256: b56b1e7d156b88cc0c62734acf56d4ee809723614f659e4203028e7eeac16a78
+  md5: 6804cd42195bf94efd1b892688c96412
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 90868
+  timestamp: 1725975178961
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
+  sha256: b0b3180039ef19502525a2abd5833c00f9624af830fd391f851934d57bffb9af
+  md5: e102bbf8a6ceeaf429deab8032fc8977
+  depends:
+  - __osx >=10.13
+  license: X11 AND BSD-3-Clause
+  size: 822066
+  timestamp: 1724658603042
+- conda: https://conda.anaconda.org/conda-forge/osx-64/netcdf4-1.7.2-nompi_py311h62486fc_100.conda
+  sha256: 9980fad2c45510c6e7311825566fb9b9e5fe526e14b14d7f69d51abde6b55717
+  md5: 2c509bde20d3dd0a0d1f1283aa2d434a
+  depends:
+  - __osx >=10.13
+  - certifi
+  - cftime
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 1055069
+  timestamp: 1729662554732
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.60.0-py311h0e5bd6a_0.conda
+  sha256: 47fbc7925d5ee5ba9d841e542752288fc7059f44c0b95c34e11c609f4754e517
+  md5: 8bd1ff28924ea52b539528d85f70a1ac
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - llvm-openmp >=16.0.6
+  - llvm-openmp >=18.1.8
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libopenblas !=0.3.6
+  - cuda-python >=11.6
+  - scipy >=1.0
+  - tbb >=2021.6.0
+  - cudatoolkit >=11.2
+  - cuda-version >=11.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5773011
+  timestamp: 1718888442395
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.0.2-py311h394b0bb_0.conda
+  sha256: 9c244959047306c7551a94e71f9227e46ee59782e5f5fe81be713d7a4ce3b26f
+  md5: 2711f0de1d44b82d1e023b73b612e901
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8106762
+  timestamp: 1724749068929
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
+  sha256: dc9c405119b9b54f8ca5984da27ba498bd848ab4f0f580da6f293009ca5adc13
+  md5: 05a14cc9d725dd74995927968d6547e3
+  depends:
+  - libcxx >=16
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 331273
+  timestamp: 1709159538792
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hd471939_0.conda
+  sha256: ba7e068ed469d6625e32ae60e6ad893e655b6695280dadf7e065ed0b6f3b885c
+  md5: ec99d2ce0b3033a75cbad01bbc7c5b71
+  depends:
+  - __osx >=10.13
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2590683
+  timestamp: 1731378034404
+- conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.2-h52ea4d3_1.conda
+  sha256: 9004a65831743a3a52cc74312d454fb52d8a37141188f3a96f29d33e58215047
+  md5: c217341f1416bab5d027e776981dccf4
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 475535
+  timestamp: 1727242441383
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.3-py311haeb46be_1.conda
+  sha256: ad35c52521f0946caf06e19fd3dfad55f7b30e46648f96214f59d8ca2dac95ad
+  md5: ca32a9963a1b5c636b5131831ded81f3
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14864168
+  timestamp: 1726879042435
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.0.0-py311h1f68098_0.conda
+  sha256: 3826fe546e711787ce5b42e2f9176589846631945a528176da0fb61e751d3749
+  md5: ab73babea5e9a94d4f0f3c8fead83459
+  depends:
+  - __osx >=10.13
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 42126861
+  timestamp: 1729065932260
+- conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.5.0-h70d2bda_0.conda
+  sha256: 9530508868971b9866486c6cb370a18ca97d6960ccb010f9ca0eaeb539b16910
+  md5: bc2d54e486a633b5f6c3f18c1fe734fb
+  depends:
+  - __osx >=10.13
+  - libcurl >=8.10.0,<9.0a0
+  - libcxx >=17
+  - libsqlite >=3.46.1,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2790379
+  timestamp: 1726489327240
+- conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.0-py311h1314207_0.conda
+  sha256: 340d19b16a2f5b663b4f000188467831b107dcaa5b15522e172d6a27820d3b01
+  md5: 446e328d89429c077ccd74d7e9d8853e
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 512211
+  timestamp: 1729847190327
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+  sha256: 05944ca3445f31614f8c674c560bca02ff05cb51637a96f665cb2bbe496099e5
+  md5: 8bcf980d2c6b17094961198284b8e862
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 8364
+  timestamp: 1726802331537
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-17.0.0-py311he764780_2.conda
+  sha256: 7b80995b7c951dc56262eb23fff7c2e9dace48b0e8b6c2bf47387c60dc402220
+  md5: a284dc4a1812aea8a1088e85ab93ceac
+  depends:
+  - libarrow-acero 17.0.0.*
+  - libarrow-dataset 17.0.0.*
+  - libarrow-substrait 17.0.0.*
+  - libparquet 17.0.0.*
+  - numpy >=1.19,<3
+  - pyarrow-core 17.0.0 *_2_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25729
+  timestamp: 1730169378394
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-17.0.0-py311he02522f_2_cpu.conda
+  sha256: b38bbebcb522da041652ce4f6fbec624feccd7ff6aec6adc211c3ba2c4b34c52
+  md5: 03dc837f08169a5abfbfe5a84666f95d
+  depends:
+  - __osx >=10.13
+  - libarrow 17.0.0.* *cpu
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4115396
+  timestamp: 1730169353166
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.3.1-py311hd6939f8_1.conda
+  sha256: 48de2a78d71e6c1a2681c1fbcf1f1503a29c58cc42cfc0fafa5c1b59a10eda94
+  md5: c8e529b8f6a408dfc6a2bc0c607e2338
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 491149
+  timestamp: 1725739585987
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.3.1-py311hd6939f8_1.conda
+  sha256: bf6179d71edb920cedf7ce4395f4447d5ae96a9deb5a44dcc1a6abffea0de4aa
+  md5: f3f565f99289de1cd140bdbea51b94eb
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 10.3.1.*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 381020
+  timestamp: 1725875173947
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.7.0-py311h50e4d0a_0.conda
+  sha256: a269c953b5c7d789e330db13cb693d6aec6f176cc249cd36607850e826f3deae
+  md5: 53d4a946f02d1b811035310cf575990c
+  depends:
+  - __osx >=10.13
+  - certifi
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 498197
+  timestamp: 1727795466468
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.10-ha513fb2_3_cpython.conda
+  sha256: 670ba83b2aab2204f3254ed47ac0e4b8cad82478e5821727aeab69a2912aa1a0
+  md5: 1a88c32ab9e997380ba1f9306624f805
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 15442415
+  timestamp: 1729043110107
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
+  sha256: 9b092850a268aca99600b724bae849f51209ecd5628e609b4699debc59ff1945
+  md5: e6d62858c06df0be0e6255c753d74787
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6303
+  timestamp: 1723823062672
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311h3336109_1.conda
+  sha256: d8f4513c53a7c0be9f1cdb9d1af31ac85cf8a6f0e4194715e36e915c03104662
+  md5: b0132bec7165a53403dcc393ff761a9e
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 193941
+  timestamp: 1725456465818
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.2.0-py311h4d3da15_3.conda
+  sha256: 6aa664170031e36302616978404175c6ada3bd4a14c71bac826fa6a7ec15f815
+  md5: 48a614f384285254a3224d086dc84ce3
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 366412
+  timestamp: 1728642446264
+- conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+  sha256: 79d804fa6af9c750e8b09482559814ae18cd8df549ecb80a4873537a5a31e06e
+  md5: dd1ea9ff27c93db7c01a7b7656bd4ad4
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: LicenseRef-Qhull
+  size: 528122
+  timestamp: 1720814002588
+- conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2024.07.02-h2fb0a26_1.conda
+  sha256: 49ec4ed6249efe9cda173745e036137f8de1f0b22edf9b0ca4f9c6409b2b68f9
+  md5: aa8ea927cdbdf690efeae3e575716131
+  depends:
+  - libre2-11 2024.07.02 hd530cb8_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26864
+  timestamp: 1728779054104
+- conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+  sha256: 41e7d30a097d9b060037f0c6a2b1d4c4ae7e942c06c943d23f9d481548478568
+  md5: f17f77f2acf4d344734bda76829ce14e
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 255870
+  timestamp: 1679532707590
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.21.0-py311h3b9c2be_0.conda
+  sha256: 234429609e71e568d1dcd7113e9a3c53c231079166ec89364b7c1158ea989776
+  md5: 230b5b87921887039af74b783d8ff095
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 301356
+  timestamp: 1730922990073
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.17.21-py311h5547dcb_3.conda
+  sha256: 3a049c90ccd277151ec2cf2a4fb169e794d6780c22830bf4b50431e35bded7e5
+  md5: da5e0f0b7d5db68eb540cde291027995
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ruamel.yaml.clib >=0.1.2
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 260543
+  timestamp: 1678273295515
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.8-py311h1314207_1.conda
+  sha256: 2224456be9be9dad8b06e6daf01d9f81baa51b690de982cf7777dd559b600530
+  md5: 32492fd2af5579535b7caab695f73749
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 120842
+  timestamp: 1728724629512
+- conda: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.5.2-py311ha1d5734_1.conda
+  sha256: 2bec7d70f518550b2d573f2cbe083db95dd65e5b4f0fb417a0c94300bfd146e1
+  md5: 2797c34b77d64a38c092dd9b21ed908b
+  depends:
+  - __osx >=10.13
+  - joblib >=1.2.0
+  - libcxx >=17
+  - llvm-openmp >=17.0.6
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scipy
+  - threadpoolctl >=3.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9712928
+  timestamp: 1726083255913
+- conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.1-py311hed734c1_1.conda
+  sha256: 2515954fe9f8202c35e9b2df6d65650f8ffcfa7dc99ed068b25968e8af5f1b23
+  md5: 22812381ffcab544161a257666f1c203
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16391177
+  timestamp: 1729481689967
+- conda: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.6-py311h9a2ae1f_2.conda
+  sha256: 6bc887207108f5757da724c139c2c9026094a136b0f0004f9624905b4fb69f65
+  md5: b43481859216598390d3b6610ab42e40
+  depends:
+  - __osx >=10.13
+  - geos >=3.13.0,<3.13.1.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 548018
+  timestamp: 1727273592519
+- conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-he1e6707_0.conda
+  sha256: a979319cd4916f0e7450aa92bb3cf4c2518afa80be50de99f31d075e693a6dd9
+  md5: ddceef5df973c8ff7d6b32353c0cb358
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37036
+  timestamp: 1720003862906
+- conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.47.0-h6285a30_1.conda
+  sha256: 34eaf24c2d0b034374d7a85026650fe28e17321fa471e5c5f654b48c5cbd3c2a
+  md5: c1d1f4d014063068fd6c402cf741e317
+  depends:
+  - __osx >=10.13
+  - libsqlite 3.47.0 h2f8c449_1
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 929527
+  timestamp: 1730208118175
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+  sha256: 30412b2e9de4ff82d8c2a7e5d06a15f4f4fef1809a72138b6ccb53a33b26faf5
+  md5: bf830ba5afc507c6232d4ef0fb1a882d
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3270220
+  timestamp: 1699202389792
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.1-py311h3336109_1.conda
+  sha256: 2e54c0d478b8d0793f89b855749aa74acaa185d08d353d8e5aa95f8e89eb6123
+  md5: 5e051c4c2b80c381173b2c1719265617
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 856251
+  timestamp: 1724956238423
+- conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-15.1.0-py311h1314207_1.conda
+  sha256: c0be0b59fa67c3f9915d3dcd77d972656b9966b4516b3c044efe350860f7e054
+  md5: 574fd9b8168c1b109003c3c431c0bb7e
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 363667
+  timestamp: 1729704694220
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h00291cd_1.conda
+  sha256: 96177823ec38336b0f4b7e7c2413da61f8d008d800cc4a5b8ad21f9128fb7de0
+  md5: c6cc91149a08402bbb313c5dc0142567
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 13176
+  timestamp: 1727034772877
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
+  sha256: bb4d1ef9cafef535494adf9296130b6193b3a44375883185b5167de03eb1ac7f
+  md5: 9f438e1b6f4e73fd9e6d78bfe7c36743
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 18465
+  timestamp: 1727794980957
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+  sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
+  md5: a72f9d4ea13d55d745ff1ed594747f10
+  license: LGPL-2.1 and GPL-2.0
+  size: 238119
+  timestamp: 1660346964847
+- conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+  sha256: 5301417e2c8dea45b401ffee8df3957d2447d4ce80c83c5ff151fc6bfe1c4148
+  md5: d7e08fcf8259d742156188e8762b4d20
+  license: MIT
+  license_family: MIT
+  size: 84237
+  timestamp: 1641347062780
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-he4ceba3_6.conda
+  sha256: 0e2a6ced111fd99b66b76ec797804ab798ec190a88a2779060f7a8787c343ee0
+  md5: 00ec9f2a5e21bbbd22ffbbc12b3df286
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.3,<1.22.0a0
+  - libcxx >=17
+  - libsodium >=1.0.20,<1.0.21.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 290634
+  timestamp: 1728364170966
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-hd23fc13_2.conda
+  sha256: 219edbdfe7f073564375819732cbf7cc0d7c7c18d3f546a09c2dfaf26e4d69f3
+  md5: c989e0295dcbdc08106fe5d9e935f0b9
+  depends:
+  - __osx >=10.13
+  - libzlib 1.3.1 hd23fc13_2
+  license: Zlib
+  license_family: Other
+  size: 88544
+  timestamp: 1727963189976
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
+  sha256: efa04a98cb149643fa54c4dad5a0179e36a5fbc88427ea0eec88ceed87fd0f96
+  md5: 4cb2cd56f039b129bb0e491c1164167e
+  depends:
+  - __osx >=10.9
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 498900
+  timestamp: 1714723303098
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311h460d6c5_5.conda
+  sha256: 6eabd1bcefc235b7943688d865519577d7668a2f4dc3a24ee34d81eb4bfe77d1
+  md5: 1e8260965552c6ec86453b7d15a598de
+  depends:
+  - __osx >=11.0
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 33008
+  timestamp: 1725356833036
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.31-h5a2a37f_3.conda
+  sha256: bc8b91f85a1c94efd5e9d7d21208524410f947df1f4a20f72cb9bb3af71ed1b0
+  md5: def8e8e7f73b7e7e6ae9ddf24fe0a76c
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-http >=0.8.10,<0.8.11.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - aws-c-sdkutils >=0.1.19,<0.1.20.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 92471
+  timestamp: 1729533153684
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.7.4-hd45b2be_2.conda
+  sha256: d701872d79184dbb759aa033e6a6e4ec5c6f1b58e3255e53b756d0246d19986a
+  md5: de4bf687ac70a2b861a94b87164669c9
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 39794
+  timestamp: 1728755626145
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.29-h7ab814d_0.conda
+  sha256: 8d2c330f0de571f1bf6f2db7650a1aa8c4060a2ccd25b48f392a4d3ea8222daa
+  md5: d4a90d217342b08daa7e80049fdaa6c9
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 220687
+  timestamp: 1728706817796
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.19-hd45b2be_2.conda
+  sha256: 86900c68f95a2ca79cb9bcb8a3e8fd0a7912cfa3754a6a1e6b78d35c0b8db58b
+  md5: 9c634af661f50e923419e0df92633d31
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18065
+  timestamp: 1728750721405
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.4.3-h4346b05_5.conda
+  sha256: 964bec469cdcc85a884e9495d6e6e1f0d29466548d3e2c0e505f16423ffbb0af
+  md5: aab99996abd51162bd43f08f097dc2dc
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - aws-checksums >=0.1.20,<0.1.21.0a0
+  - libcxx >=17
+  license: Apache-2.0
+  license_family: Apache
+  size: 47034
+  timestamp: 1729527508472
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.8.10-ha971391_3.conda
+  sha256: 2069d4fc929d4d1640f431ba8251fbde3277a74f88c70d70f8e55f60cb98b1ec
+  md5: 5b29041dad1cbfdb84235be72186327d
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-compression >=0.2.19,<0.2.20.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 153160
+  timestamp: 1729518093000
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.14.20-h5ad5fc2_0.conda
+  sha256: 24f5f8efef5fffa40206672c8bb7d1d6197827d987162dae4fbdabda9e23c5d7
+  md5: ccd6c008209f3354884f53c21a2d05a2
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 137310
+  timestamp: 1729105831743
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.10.7-hd3a49e8_3.conda
+  sha256: c43c84e05cd4aef0d17811f84c8ab922ac093d952c976f4010a9e13cf0546a7f
+  md5: 81d0b32ebdeb21ef85e26540505206f6
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-http >=0.8.10,<0.8.11.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 135164
+  timestamp: 1729533679531
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.6.7-hb6e36da_1.conda
+  sha256: 0f16a42b83889c4609f078189577eb0cc7fb9df88c96266530b94dd308143802
+  md5: d71c47f8d9e27df2970133618a998edd
+  depends:
+  - __osx >=11.0
+  - aws-c-auth >=0.7.31,<0.7.32.0a0
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-http >=0.8.10,<0.8.11.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - aws-checksums >=0.1.20,<0.1.21.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 96603
+  timestamp: 1729544300652
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.19-hd45b2be_4.conda
+  sha256: cc374eef1b367fb9acc83b2e74830f62742d3e53e1f0f6a0d01939b16ed1e3d5
+  md5: 7ccdd0f21ffbc77b11963f00892ca8b5
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 49543
+  timestamp: 1728755942076
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.20-hd45b2be_1.conda
+  sha256: d935ca7faa780cfa1053fe1bffb77611a54b4df791897a22048e770b250c651f
+  md5: ab0b68aafe787311cb8397fd2e60982d
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 70087
+  timestamp: 1728750818479
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.28.5-h2612a5e_1.conda
+  sha256: 0a5ffbd23335d57adc7eb45bd0af3659174572d48b3cb876774c7631d179d321
+  md5: 4417ec449f112392430f33da23207e5b
+  depends:
+  - __osx >=11.0
+  - aws-c-auth >=0.7.31,<0.7.32.0a0
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-event-stream >=0.4.3,<0.4.4.0a0
+  - aws-c-http >=0.8.10,<0.8.11.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - aws-c-mqtt >=0.10.7,<0.10.8.0a0
+  - aws-c-s3 >=0.6.7,<0.6.8.0a0
+  - aws-c-sdkutils >=0.1.19,<0.1.20.0a0
+  - libcxx >=17
+  license: Apache-2.0
+  license_family: Apache
+  size: 231122
+  timestamp: 1729557371597
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.407-hced06f0_2.conda
+  sha256: 2ba0ef1743630d15f7582f60f1404437f3d53629e4ed3b849c5ae411550ea574
+  md5: a4dfb1fdfee0e30b9fa8eb78f49bb3f3
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-event-stream >=0.4.3,<0.4.4.0a0
+  - aws-checksums >=0.1.20,<0.1.21.0a0
+  - aws-crt-cpp >=0.28.5,<0.28.6.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2712118
+  timestamp: 1729597991705
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/awscli-2.20.0-py311h267d04e_0.conda
+  sha256: d7ad3d8a16322659f27a94bedca41c021577ce976143e16a52379ea62e0167e0
+  md5: 37aaf47b2173c53d1c29d8a9153bfb47
+  depends:
+  - awscrt >=0.19.18,<=0.22.0
+  - colorama >=0.2.5,<0.4.7
+  - cryptography >=40.0.0,<43.0.2
+  - distro >=1.5.0,<1.9.0
+  - docutils >=0.10,<0.20
+  - jmespath >=0.7.1,<1.1.0
+  - prompt_toolkit >=3.0.24,<3.0.39
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.1,<=2.9.0
+  - python_abi 3.11.* *_cp311
+  - ruamel.yaml >=0.15.0,<=0.17.21
+  - ruamel.yaml.clib >=0.2.0,<=0.2.8
+  - urllib3 >=1.25.4,<1.27
+  license: Apache-2.0
+  license_family: APACHE
+  size: 12767223
+  timestamp: 1731486978248
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/awscrt-0.22.0-py311h83cc776_6.conda
+  sha256: b3c8761b5cf4ae0a7ec1b765b7f7a2f7bd89eb76f0dd9589fef969eb927f9362
+  md5: ef6a3d3c26c53d78fc8534827502a161
+  depends:
+  - __osx >=11.0
+  - aws-c-auth >=0.7.31,<0.7.32.0a0
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-event-stream >=0.4.3,<0.4.4.0a0
+  - aws-c-http >=0.8.10,<0.8.11.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - aws-c-mqtt >=0.10.7,<0.10.8.0a0
+  - aws-c-s3 >=0.6.7,<0.6.8.0a0
+  - aws-checksums >=0.1.20,<0.1.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 185917
+  timestamp: 1729557695399
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.14.0-hd50102c_0.conda
+  sha256: f5b91329ed59ffc0be8747784c6e4cc7e56250c54032883a83bc11808ef6a87e
+  md5: f093a11dcf3cdcca010b20a818fcc6dc
+  depends:
+  - __osx >=11.0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 294299
+  timestamp: 1728054014060
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.10.0-hc602bab_0.conda
+  sha256: bde446b916fff5150606f8ed3e6058ffc55a3aa72381e46f1ab346590b1ae40a
+  md5: d7b71593a937459f2d4b67e1a4727dc2
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 166907
+  timestamp: 1728486882502
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.13.0-h7585a09_1.conda
+  sha256: 08d52d130addc0fb55d5ba10d9fa483e39be25d69bac7f4c676c2c3069207590
+  md5: 704238ef05d46144dae2e6b5853df8bc
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 438636
+  timestamp: 1728578216193
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.8.0-h9ca1f76_1.conda
+  sha256: 77ab04e8fe5636a2de9c718f72a43645f7502cd208868c8a91ffba385547d585
+  md5: 7a187cd7b1445afc80253bb186a607cc
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - libxml2 >=2.12.7,<2.14.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 121278
+  timestamp: 1728563418777
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.12.0-hcdd55da_1.conda
+  sha256: f48523f8aa0b5b80f45a92f0556b388dd96f44ac2dc2f44a01d08c1822eec97d
+  md5: c49fbc5233fcbaa86391162ff1adef38
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 196032
+  timestamp: 1728729672889
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h5499902_0.conda
+  sha256: 5a1e635a371449a750b776cab64ad83f5218b58b3f137ebd33ad3ec17f1ce92e
+  md5: e94ca7aec8544f700d45b24aff2dd4d7
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33201
+  timestamp: 1719266149627
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hd74edd7_2.conda
+  sha256: a086f36ff68d6e30da625e910547f6211385246fb2474b144ac8c47c32254576
+  md5: 215e3dc8f2f837906d066e7f01aa77c0
+  depends:
+  - __osx >=11.0
+  - brotli-bin 1.1.0 hd74edd7_2
+  - libbrotlidec 1.1.0 hd74edd7_2
+  - libbrotlienc 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 19588
+  timestamp: 1725268044856
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hd74edd7_2.conda
+  sha256: 28f1af63b49fddf58084fb94e5512ad46e9c453eb4be1d97449c67059e5b0680
+  md5: b8512db2145dc3ae8d86cdc21a8d421e
+  depends:
+  - __osx >=11.0
+  - libbrotlidec 1.1.0 hd74edd7_2
+  - libbrotlienc 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 16772
+  timestamp: 1725268026061
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311h3f08180_2.conda
+  sha256: f507d65e740777a629ceacb062c768829ab76fde01446b191699a734521ecaad
+  md5: c8793a23206344faa25f4e0b5d0e7908
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 339584
+  timestamp: 1725268241628
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+  sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
+  md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
+  depends:
+  - __osx >=11.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 122909
+  timestamp: 1720974522888
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.3-h5505292_0.conda
+  sha256: e9e0f737286f9f4173c76fb01a11ffbe87cfc2da4e99760e1e18f47851d7ae06
+  md5: d0155a4f41f28628c7409ea000eeb19c
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 178951
+  timestamp: 1731182071026
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
+  sha256: 2db1733f4b644575dbbdd7994a8f338e6ef937f5ebdb74acd557e9dda0211709
+  md5: 40dec13fd8348dbe303e57be74bd3d35
+  license: ISC
+  size: 158482
+  timestamp: 1725019034582
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cartopy-0.24.0-py311h9cb3ce9_0.conda
+  sha256: f48faa9de55ee315c9d3f6ecad6949e1f0e18ebafa9e86f5f723dde6aa0915aa
+  md5: 27811d1c187c3f00ba249abcbee8f1bd
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - matplotlib-base >=3.6
+  - numpy >=1.19,<3
+  - packaging >=21
+  - pyproj >=3.3.1
+  - pyshp >=2.3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - shapely >=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1515694
+  timestamp: 1728342455991
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py311h3a79f62_0.conda
+  sha256: 253605b305cc4548b8f97eb7c2e146697e0c7672b099c4862ec5ca7e8e995307
+  md5: a42272c5dbb6ffbc1a5af70f24c7b448
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 288211
+  timestamp: 1725560745212
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.4-py311h0f07fe1_1.conda
+  sha256: a77f11a4e202e7e856b368e7bae7a463d4193d5263927ca8c6e02eee6e5a0703
+  md5: f239945e88a60c79f705944b22ab56d3
+  depends:
+  - __osx >=11.0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 206517
+  timestamp: 1725400747908
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.1-py311h210dab8_0.conda
+  sha256: 8e755206b38a6e14861c79a74b51af76124bdf5c266dd6a584305e03d37c2e0c
+  md5: 7f9e9df2d62cf69aed450f6957a23e61
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 247202
+  timestamp: 1731428753912
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cramjam-2.8.4rc3-py311h18e95ce_2.conda
+  sha256: 23a14a672cdfef67a7c8f5251ed617b7757012ac59330a4661f91e5c2617d401
+  md5: 45167faa77195ef4c7dba1cd5279834b
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 1506529
+  timestamp: 1726116981392
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-43.0.1-py311h47c44cf_0.conda
+  sha256: b04dd0b66524981f0388d9534bd63e5b8f485b0c531631bc262e21d5b9979ea4
+  md5: 6985f02e7a6b0ce770044c17cd90ac6e
+  depends:
+  - __osx >=11.0
+  - cffi >=1.12
+  - openssl >=3.3.2,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=11.0
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1360631
+  timestamp: 1725443831251
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.0.0-py311h460d6c5_1.conda
+  sha256: cff9cd6a8652a73d9e1d73c51bfd1bac6b526e705885b1ec8f0c159bd34046d2
+  md5: 72740cbbba07d1fb0f37448e1e1c7ef9
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 341441
+  timestamp: 1728335223644
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.8-py311h155a34a_0.conda
+  sha256: 959e7cdeb6627d64228a6cbaf91e5bd674465d81619b410c8ce772fa9db1a594
+  md5: 376b9971d7b47dab0b5197bd3efc74d4
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2489339
+  timestamp: 1731045144242
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/docutils-0.19-py311h267d04e_1.tar.bz2
+  sha256: e6e04b96cbfc40303d08e63f2c0a3a2c9c47704360fb77fc1385121249294387
+  md5: 0db0a38a4d71859f2629b0811c613210
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1
+    and GPL-3.0-or-later
+  size: 975156
+  timestamp: 1666755185967
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fastparquet-2024.5.0-py311ha7f2236_2.conda
+  sha256: da589aec423df612a6f884281a9d581a08cfb3ae9b29c67f062e91f66fc6686e
+  md5: 34600ec5bb0acdcd0701cd8e8b775564
+  depends:
+  - __osx >=11.0
+  - cramjam >=2.3
+  - fsspec
+  - numpy >=1.19,<3
+  - numpy >=1.20.3
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 501232
+  timestamp: 1729689620782
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.54.1-py311h56c23cb_1.conda
+  sha256: 25a2f4bc2e1fb7ab428f39c86305664b5c0c43d22bc88fc665d6902360e66f47
+  md5: 435d43c6653a8e3e6ec5b4b686cba58a
+  depends:
+  - __osx >=11.0
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2782220
+  timestamp: 1729530656712
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+  sha256: 791673127e037a2dc0eebe122dc4f904cb3f6e635bb888f42cbe1a76b48748d9
+  md5: e6085e516a3e304ce41a8ee08b9b89ad
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 596430
+  timestamp: 1694616332835
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.13.0-hf9b8971_0.conda
+  sha256: 273381020b72bde1597d4e07e855ed50ffac083512e61ccbdd99d93f03c6cbf2
+  md5: 45b2e9adb9663644b1eefa5300b9eef3
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: LGPL-2.1-only
+  size: 1481430
+  timestamp: 1725676193541
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
+  sha256: fd56ed8a1dab72ab90d8a8929b6f916a6d9220ca297ff077f8f04c5ed3408e20
+  md5: 57a511a5905caa37540eb914dfcbf1fb
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 82090
+  timestamp: 1726600145480
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
+  sha256: 9fc77de416953aa959039db72bc41bfa4600ae3ff84acad04a7d0c1ab9552602
+  md5: fef68d0a95aa5b84b5c1a4f6f3bf40e1
+  depends:
+  - __osx >=11.0
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 112215
+  timestamp: 1718284365403
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
+  sha256: c3b01e3c3fe4ca1c4d28c287eaa5168a4f2fd3ffd76690082ac919244c22fa90
+  md5: ff5d749fd711dc7759e127db38005924
+  depends:
+  - libcxx >=15.0.7
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 762257
+  timestamp: 1695661864625
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.4-nompi_ha698983_103.conda
+  sha256: 01c2792588db2ac16e758a2898e4ec40955a2abcbc30f0212b7a669e1d094cae
+  md5: b779eb51bbfdf8d1b4539199b76839b4
+  depends:
+  - __osx >=11.0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3495866
+  timestamp: 1730831045992
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py311h267d04e_1.conda
+  sha256: 736304347653ed421b13c56ba6f4f87c1d78d24cd3fa74db0db6fb70c814fa65
+  md5: 5bce88ac1bef7d47c62cb574b25891ae
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18253
+  timestamp: 1725303181400
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.7-py311h2c37856_0.conda
+  sha256: 8ffc46f6e99c95c48426cf34c033d16cde3bcf100cd74d1d74a33943a85a6ec8
+  md5: ee572d19da1346db8e78cb8e7d5d2330
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59357
+  timestamp: 1725459504453
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+  sha256: 4442f957c3c77d69d9da3521268cad5d54c9033f1a73f99cde0a3658937b159b
+  md5: c6dc8a0fdec13a0565936655c33069a1
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1155530
+  timestamp: 1719463474401
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
+  sha256: 151e0c84feb7e0747fabcc85006b8973b22f5abbc3af76a9add0b0ef0320ebe4
+  md5: 66f6c134e76fe13cce8a9ea5814b5dd5
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 211959
+  timestamp: 1701647962657
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+  sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
+  md5: de462d5aacda3b30721b512c5da4e742
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 215721
+  timestamp: 1657977558796
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_hf9b8971_1.conda
+  sha256: 90bf08a75506dfcf28a70977da8ab050bcf594cd02abd3a9d84a22c9e8161724
+  md5: 706da5e791c569a7b9814877098a6a0a
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  constrains:
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1179072
+  timestamp: 1727295571173
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
+  sha256: 896189b7b48a194c46a3556ea04943ef81cbe0498521231f8eb25816a68bc8ed
+  md5: 6f0b8e56d2e7bae12a18fc5b2cd9f310
+  depends:
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 28451
+  timestamp: 1711021498493
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-17.0.0-h20d9b6e_23_cpu.conda
+  sha256: 6c82777388d19e2581d1a9fc912d3f9d092bb80dadd0f6c90a61ae06c4e06f60
+  md5: b1b47fac6eb1571209d9b7c393426f2f
+  depends:
+  - __osx >=11.0
+  - aws-crt-cpp >=0.28.5,<0.28.6.0a0
+  - aws-sdk-cpp >=1.11.407,<1.11.408.0a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-identity-cpp >=1.10.0,<1.10.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-files-datalake-cpp >=12.12.0,<12.12.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=18
+  - libgoogle-cloud >=2.30.0,<2.31.0a0
+  - libgoogle-cloud-storage >=2.30.0,<2.31.0a0
+  - libre2-11 >=2024.7.2
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.2,<2.0.3.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  - libutf8proc <2.9
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - parquet-cpp <0.0a0
+  - arrow-cpp <0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5302076
+  timestamp: 1729637467474
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-17.0.0-h286801f_23_cpu.conda
+  sha256: cb00602de44e1e2706323a7f7f8f01ad3a22eedef510d6c24450928e55d1d5ce
+  md5: 1d92a15f57e5c721b232003e5ca70180
+  depends:
+  - __osx >=11.0
+  - libarrow 17.0.0 h20d9b6e_23_cpu
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: APACHE
+  size: 480369
+  timestamp: 1729637560349
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-17.0.0-h286801f_23_cpu.conda
+  sha256: 32aa0869e7725fc5cc63be198de071f5fc483a8c213cfe5ecb25430bee4ffd2a
+  md5: 7e7ce652d48e8430cfdda6affe585d2c
+  depends:
+  - __osx >=11.0
+  - libarrow 17.0.0 h20d9b6e_23_cpu
+  - libarrow-acero 17.0.0 h286801f_23_cpu
+  - libcxx >=18
+  - libparquet 17.0.0 hda0ea68_23_cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 486738
+  timestamp: 1729638623222
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-17.0.0-hdcc9e87_23_cpu.conda
+  sha256: 4e72b09ea0c0217dea8f82f9998103f25d27d75e05eebf44631a7f34bd6aa391
+  md5: 544f4c5229f74a1c8d1df589e15c0941
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 17.0.0 h20d9b6e_23_cpu
+  - libarrow-acero 17.0.0 h286801f_23_cpu
+  - libarrow-dataset 17.0.0 h286801f_23_cpu
+  - libcxx >=18
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 444988
+  timestamp: 1729638776658
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-25_osxarm64_openblas.conda
+  sha256: f1fb9a11af0b2878bd8804b4c77d3733c40076218bcbdb35f575b1c0c9fddf11
+  md5: f8cf4d920ff36ce471619010eff59cac
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - blas * openblas
+  - liblapack 3.9.0 25_osxarm64_openblas
+  - liblapacke 3.9.0 25_osxarm64_openblas
+  - libcblas 3.9.0 25_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15913
+  timestamp: 1729643265495
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hd74edd7_2.conda
+  sha256: 839dacb741bdbb25e58f42088a2001b649f4f12195aeb700b5ddfca3267749e5
+  md5: d0bf1dff146b799b319ea0434b93f779
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 68426
+  timestamp: 1725267943211
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hd74edd7_2.conda
+  sha256: 6c6862eb274f21a7c0b60e5345467a12e6dda8b9af4438c66d496a2c1a538264
+  md5: 55e66e68ce55523a6811633dd1ac74e2
+  depends:
+  - __osx >=11.0
+  - libbrotlicommon 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 28378
+  timestamp: 1725267980316
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hd74edd7_2.conda
+  sha256: eeb1eb0d58b9d02bc1b98dc0a058f104ab168eb2f7d1c7bfa0570a12cfcdb7b7
+  md5: 4f3a434504c67b2c42565c0b85c1885c
+  depends:
+  - __osx >=11.0
+  - libbrotlicommon 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 279644
+  timestamp: 1725268003553
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-25_osxarm64_openblas.conda
+  sha256: d9fa5b6b11252132a3383bbf87bd2f1b9d6248bef1b7e113c2a8ae41b0376218
+  md5: 4df0fae81f0b5bf47d48c882b086da11
+  depends:
+  - libblas 3.9.0 25_osxarm64_openblas
+  constrains:
+  - blas * openblas
+  - liblapack 3.9.0 25_osxarm64_openblas
+  - liblapacke 3.9.0 25_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15837
+  timestamp: 1729643270793
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+  sha256: 58477b67cc719060b5b069ba57161e20ba69b8695d154a719cb4b60caf577929
+  md5: 32bd82a6a625ea6ce090a81c3d34edeb
+  depends:
+  - libcxx >=11.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18765
+  timestamp: 1633683992603
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.10.1-h13a7ad3_0.conda
+  sha256: 983a977c5627f975a930542c8aabb46089ec6ea72f28d9c4d3ee8eafaf2fc25a
+  md5: d84030d0863ffe7dea00b9a807fee961
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 379948
+  timestamp: 1726660033582
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.3-ha82da77_0.conda
+  sha256: 6d062760c6439e75b9a44d800d89aff60fe3441998d87506c62dc94c50412ef4
+  md5: bf691071fba4734984231617783225bc
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 520771
+  timestamp: 1730314603920
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.22-hd74edd7_0.conda
+  sha256: 3552894ca62bebc33d05982937cda25a4fa19e56a82af2ff20944ff4c2532fda
+  md5: 2d3e3f3d8ab315748420ef58d5a3ae0f
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 54089
+  timestamp: 1728177149927
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+  sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
+  md5: 30e4362988a2623e9eb34337b83e01f9
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 96607
+  timestamp: 1597616630749
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+  sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
+  md5: 36d33e440c31857372a72137f78bacf5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 107458
+  timestamp: 1702146414478
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+  sha256: 8c136d7586259bb5c0d2b913aaadc5b9737787ae4f40e3ad1beaf96c80b919b7
+  md5: 1a109764bff3bdc7bdd84088347d71dc
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 368167
+  timestamp: 1685726248899
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
+  sha256: e42ab5ace927ee7c84e3f0f7d813671e1cf3529f5f06ee5899606630498c2745
+  md5: 38d2656dd914feb0cab8c629370768bf
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 64693
+  timestamp: 1730967175868
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+  md5: 086914b672be056eb70fd4285b6783b6
+  license: MIT
+  license_family: MIT
+  size: 39020
+  timestamp: 1636488587153
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+  sha256: 44e541b4821c96b28b27fef5630883a60ce4fee91fd9c79f25a199f8f73f337b
+  md5: 4a55d9e169114b2b90d3ec4604cd7bbf
+  depends:
+  - libgfortran5 13.2.0 hf226fd6_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110233
+  timestamp: 1707330749033
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+  sha256: bafc679eedb468a86aa4636061c55966186399ee0a04b605920d208d97ac579a
+  md5: 66ac81d54e95c534ae488726c1f698ea
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 997381
+  timestamp: 1707330687590
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.30.0-h2e6cea1_0.conda
+  sha256: 2c58299d8275cfcf575166ba59baa9ac2b32c0c5a2677ee7a51e1d67b2d28f92
+  md5: be857dc2a7d747d9aa191ed6c701bde7
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - libgrpc >=1.65.5,<1.66.0a0
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - openssl >=3.3.2,<4.0a0
+  constrains:
+  - libgoogle-cloud 2.30.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 845094
+  timestamp: 1728021687922
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.30.0-h90fd6fa_0.conda
+  sha256: 1c531f3f5867c5ec9d3d8a7f0babee5ca106f6bf39510b277503d9aea55afeae
+  md5: 34381339cf47d7af329026d1474f30ff
+  depends:
+  - __osx >=11.0
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libcxx >=17
+  - libgoogle-cloud 2.30.0 h2e6cea1_0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  size: 538215
+  timestamp: 1728022502810
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.65.5-h3d9cf25_0.conda
+  sha256: a92096af0fa67bb03fe2d40dfb11e7746603842a78fddce9f06e3ced9d93b61e
+  md5: b829a3509f5d89b21fa481ebc8edd953
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.33.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - libre2-11 >=2023.9.1
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.65.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4614162
+  timestamp: 1727200966365
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
+  sha256: bc7de5097b97bcafcf7deaaed505f7ce02f648aac8eccc0d5a47cc599a1d0304
+  md5: 69bda57310071cf6d2b86caf11573d2d
+  license: LGPL-2.1-only
+  size: 676469
+  timestamp: 1702682458114
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+  sha256: a42054eaa38e84fc1e5ab443facac4bbc9d1b6b6f23f54b7bf4f1eb687e1d993
+  md5: 3ff1e053dc3a2b8e36b9bfa4256a58d1
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 547541
+  timestamp: 1694475104253
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-25_osxarm64_openblas.conda
+  sha256: fdd742407672a9af20e70764550cf18b3ab67f12e48bf04163b90492fbc401e7
+  md5: 19bbddfec972d401838330453186108d
+  depends:
+  - libblas 3.9.0 25_osxarm64_openblas
+  constrains:
+  - blas * openblas
+  - liblapacke 3.9.0 25_osxarm64_openblas
+  - libcblas 3.9.0 25_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15823
+  timestamp: 1729643275943
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_4.conda
+  sha256: 6f603914fe8633a615f0d2f1383978eb279eeb552079a78449c9fbb43f22a349
+  md5: 9f3dce5d26ea56a9000cd74c034582bd
+  depends:
+  - libcxx >=15
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 20571387
+  timestamp: 1690559110016
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnetcdf-4.9.2-nompi_h853a48d_115.conda
+  sha256: 8d7c9ede65241de34aa5aa4c1cf04964fd6e027e2a7d4e8cce654b2350c0f2d3
+  md5: 94b3a12456a4e257e65c6b962c785190
+  depends:
+  - __osx >=11.0
+  - blosc >=1.21.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzip >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zlib
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 678786
+  timestamp: 1728055979264
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
+  sha256: 00cc685824f39f51be5233b54e19f45abd60de5d8847f1a56906f8936648b72f
+  md5: 3408c02539cee5f1141f9f11450b6a51
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.34.2,<2.0a0
+  - libcxx >=17
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 566719
+  timestamp: 1729572385640
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
+  sha256: 62bb669c37a845129096f73d446cdb6bb170e4927f2fea2b661329680dbbc373
+  md5: 40803a48d947c8639da6704e9a44d3ce
+  depends:
+  - __osx >=11.0
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - llvm-openmp >=18.1.8
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4165774
+  timestamp: 1730772154295
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-17.0.0-hda0ea68_23_cpu.conda
+  sha256: 474dedc49ac025dd5d8351b5c7b04546d62359c8cbf04e104a95c7575bb51f47
+  md5: 4de8cf7a52a9c6c6cf43d7d710c944eb
+  depends:
+  - __osx >=11.0
+  - libarrow 17.0.0 h20d9b6e_23_cpu
+  - libcxx >=18
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 861625
+  timestamp: 1729638566767
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
+  sha256: 38f8759a3eb8060deabd4db41f0f023514d853e46ddcbd0ba21768fc4e563bb1
+  md5: fb36e93f0ea6a6f5d2b99984f34b049e
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 263385
+  timestamp: 1726234714421
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.27.5-h53f8970_2.conda
+  sha256: 787d86c041c03d33b24e28df5f881f47c74c3fe9053b791f14616dc51f32a687
+  md5: e9d021f82c48bb08b0b2c321b2f7778c
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2375066
+  timestamp: 1727423411355
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2024.07.02-h2348fd5_1.conda
+  sha256: 6facca42cfc85a05b33e484a8b0df7857cc092db34806946d022270098d8d20f
+  md5: 5a7065309a66097738be6a06fd04b7ef
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 165956
+  timestamp: 1728779107218
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
+  sha256: fade8223e1e1004367d7101dd17261003b60aa576df6d7802191f8972f7470b1
+  md5: a7ce36e284c5faaf93c220dfc39e3abd
+  depends:
+  - __osx >=11.0
+  license: ISC
+  size: 164972
+  timestamp: 1716828607917
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.47.0-hbaaea75_1.conda
+  sha256: 5a96caa566c11e5a5ebdcdb86a0759a7fb27d3c5f42e6a0fd0d6023c1e935d9e
+  md5: 07a14fbe439eef078cc479deca321161
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 837683
+  timestamp: 1730208293578
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
+  sha256: bb57d0c53289721fff1eeb3103a1c6a988178e88d8a8f4345b0b91a35f0e0015
+  md5: 029f7dc931a3b626b94823bc77830b01
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 255610
+  timestamp: 1685837894256
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.21.0-h64651cc_0.conda
+  sha256: 7a6c7d5f58cbbc2ccd6493b4b821639fdb0701b9b04c737a949e8cb6adf1c9ad
+  md5: 7ce2bd2f650f8c31ad7ba4c7bfea61b7
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 324342
+  timestamp: 1727206096912
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-hfce79cd_1.conda
+  sha256: 97ba24c74750b6e731b3fe0d2a751cda6148b4937d2cc3f72d43bf7b3885c39d
+  md5: b9abf45f7c64caf3303725f1aa0e9a4d
+  depends:
+  - __osx >=11.0
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=17
+  - libdeflate >=1.22,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 366323
+  timestamp: 1728232400072
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-h1a8c8d9_0.tar.bz2
+  sha256: a3faddac08efd930fa3a1cc254b5053b4ed9428c49a888d437bf084d403c931a
+  md5: f8c9c41a122ab3abdf8943b13f4957ee
+  license: MIT
+  license_family: MIT
+  size: 103492
+  timestamp: 1667316405233
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+  sha256: 0d4bad713a512d79bfeb4d61821f447afab8b0792aca823f505ce6b195e9fde5
+  md5: c0af0edfebe780b19940e94871f1a765
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 287750
+  timestamp: 1713200194013
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+  sha256: bd3816218924b1e43b275863e21a3e13a5db4a6da74cca8e60bc3c213eb62f71
+  md5: af523aae2eca6dfa1c8eec693f5b9a79
+  depends:
+  - __osx >=11.0
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 323658
+  timestamp: 1727278733917
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.13.5-h376fa9f_0.conda
+  sha256: d443703d324f3dbd628d58ea498ab0e474c06d5771e7f55baf215fdbc11ceb87
+  md5: adea92805465ed3dcf0776b428e34744
+  depends:
+  - __osx >=11.0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - icu <0.0a0
+  license: MIT
+  license_family: MIT
+  size: 582076
+  timestamp: 1731489850179
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzip-1.11.2-h1336266_0.conda
+  sha256: 507599a77c1ce823c2d3acaefaae4ead0686f183f3980467a4c4b8ba209eff40
+  md5: 7177414f275db66735a17d316b0a81d6
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 125507
+  timestamp: 1730442214849
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
+  md5: 369964e85dc26bfe78f41399b366c435
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 46438
+  timestamp: 1727963202283
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.3-hb52a8e5_0.conda
+  sha256: 49a8940e727aa82ee034fa9a60b3fcababec41b3192d955772aab635a5374b82
+  md5: dd695d23e78d1ca4fecce969b1e1db61
+  depends:
+  - __osx >=11.0
+  constrains:
+  - openmp 19.1.3|19.1.3.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 280488
+  timestamp: 1730364082380
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.43.0-py311hc367efa_1.conda
+  sha256: c352b894bb07ed59d1cdaed1a64e52b054f4ff02119600a97ccf39cce06dbe5f
+  md5: d14048893b6cc8aec00b4e0e6eb78de2
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 378145
+  timestamp: 1725305457011
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-4.3.3-py311hebe0b09_1.conda
+  sha256: d68fb0bf5d74c83432155406de87b50b8c10712d331bbbab616c52d945751981
+  md5: 74df239a2926df48e2543bb6754baf61
+  depends:
+  - __osx >=11.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 108602
+  timestamp: 1725089854895
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+  sha256: fc343b8c82efe40819b986e29ba748366514e5ab94a1e1138df195af5f45fa24
+  md5: 45505bec548634f7d05e02fb25262cb9
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 141188
+  timestamp: 1674727268278
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py311h56c23cb_0.conda
+  sha256: 74bbdf6dbfe561026fed5c7d5c1a123e6dff0fedc5bc7ed0c6e9037c95ca96d7
+  md5: be48a4cc178a91af3b1ccd58c14efde2
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25180
+  timestamp: 1729351536390
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-3.9.2-py311ha1ab1f8_2.conda
+  sha256: f622d0b4dad661c64593c8642379d3d5895e8952dad8f7780e873f0d839fab38
+  md5: 79700d72e2a219fca397f238e10b3a90
+  depends:
+  - matplotlib-base >=3.9.2,<3.9.3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tornado >=5
+  license: PSF-2.0
+  license_family: PSF
+  size: 16967
+  timestamp: 1731025485043
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.9.2-py311hbe3227e_2.conda
+  sha256: bf2f04ad5d57b2042eb58fe1f969e4b263e8edcee971396005aa4dbb39ceab14
+  md5: 2c4e7ee255a37a3dc2ab9ee684b407f4
+  depends:
+  - __osx >=11.0
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 7902037
+  timestamp: 1731025458642
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.0-py311h2c37856_0.conda
+  sha256: aafa8572c72283801148845772fd9d494765bdcf1b8ae6f435e1caff4f1c97f3
+  md5: 6c826762702474fb0def6cedd2db5316
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 91131
+  timestamp: 1725975234150
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+  sha256: 27d0b9ff78ad46e1f3a6c96c479ab44beda5f96def88e2fe626e0a49429d8afc
+  md5: cb2b0ea909b97b3d70cd3921d1445e1a
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  size: 802321
+  timestamp: 1724658775723
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/netcdf4-1.7.2-nompi_py311hd13e3db_100.conda
+  sha256: deaffc773f838f2677791aedf3bfd4dc72e3f4bc1b5e46c831734aa11ef32101
+  md5: e4c8b38c12de3bb2be288862acd8e5ca
+  depends:
+  - __osx >=11.0
+  - certifi
+  - cftime
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 1048689
+  timestamp: 1729663101204
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.60.0-py311h9506ed5_0.conda
+  sha256: 70435f94de8b5328b039ffff9dfdd00c8c0a503cb1a86f4b70ae9cbdd7e4ec1f
+  md5: 5e14ce0b9976d6d0370c9f5032c81bb7
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - llvm-openmp >=16.0.6
+  - llvm-openmp >=18.1.7
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - cuda-version >=11.2
+  - cudatoolkit >=11.2
+  - scipy >=1.0
+  - cuda-python >=11.6
+  - libopenblas >=0.3.18, !=0.3.20
+  - tbb >=2021.6.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5778831
+  timestamp: 1718888718616
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.0.2-py311h6de8079_0.conda
+  sha256: ed06d3eb948a581da08675dbbfedc6019bf10d74c03865ecbc2acd4ba625974c
+  md5: 2bd1d7e02190016932c5e02ed1aece33
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6995279
+  timestamp: 1724749148131
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
+  sha256: 472d6eaffc1996e6af35ec8e91c967f472a536a470079bfa56383cc0dbf4d463
+  md5: 5029846003f0bc14414b9128a1f7c84b
+  depends:
+  - libcxx >=16
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 316603
+  timestamp: 1709159627299
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h39f12f2_0.conda
+  sha256: bd1d58ced46e75efa3b842c61642fd12272c69e9fe4d7261078bc082153a1d53
+  md5: df307bbc703324722df0293c9ca2e418
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2935176
+  timestamp: 1731377561525
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.2-h4a9587e_1.conda
+  sha256: ee0100b8b449be287d24fffce69444232a47142ca95bbc3d0cdc38ede9d690fb
+  md5: 47749df556fda8cc1848804bf6011645
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 445128
+  timestamp: 1727242589123
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py311h9cb3ce9_1.conda
+  sha256: 0a08027b25e4f6034d7733c7366f44283246d61cb82d1721f8789d50ebfef287
+  md5: 9ffa9dee175c76e68ea5de5aa1168d83
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14807397
+  timestamp: 1726879116250
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.0.0-py311h3894ae9_0.conda
+  sha256: 6d5307fed000e6b72b98d54dd1fea7b155f9a6453476a937522b89dde7b3d673
+  md5: a9a4adae1c4178f50ac3d1fd5d64bb85
+  depends:
+  - __osx >=11.0
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 41856994
+  timestamp: 1729066060042
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.5.0-h61a8e3e_0.conda
+  sha256: df44f24dc325fff7480f20fb404dad03015b9e646aa25e0eb24d1edd3930164e
+  md5: 7b9888f46634eb49eece8fa6e16406d6
+  depends:
+  - __osx >=11.0
+  - libcurl >=8.10.0,<9.0a0
+  - libcxx >=17
+  - libsqlite >=3.46.1,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2732379
+  timestamp: 1726489115567
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py311hae2e1ce_0.conda
+  sha256: 6237f04371995fa8e8f16481dcd4e01d2733a82750180a362a9f4953ffbb3cde
+  md5: e226eba0c52ecd6786e73c8ad7f41e79
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 514316
+  timestamp: 1729847396776
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+  sha256: 8ed65e17fbb0ca944bfb8093b60086e3f9dd678c3448b5de212017394c247ee3
+  md5: 415816daf82e0b23a736a069a75e9da7
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 8381
+  timestamp: 1726802424786
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-17.0.0-py311h35c05fe_2.conda
+  sha256: dd31365596b92d1225ad5f4ee8698faea6a01a52a4a3bb0ad369b437b09ce6d3
+  md5: e9e6452c510ec99ca0a5f00f4c300bcf
+  depends:
+  - libarrow-acero 17.0.0.*
+  - libarrow-dataset 17.0.0.*
+  - libarrow-substrait 17.0.0.*
+  - libparquet 17.0.0.*
+  - numpy >=1.19,<3
+  - pyarrow-core 17.0.0 *_2_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25766
+  timestamp: 1730169580244
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-17.0.0-py311he04fa90_2_cpu.conda
+  sha256: 310f2a3ea7cf22b81c7b785ce513956d79b4f094d4b5b788eb54b4adb4e9ba7e
+  md5: f3a2918db5b64a0d725a341775d83deb
+  depends:
+  - __osx >=11.0
+  - libarrow 17.0.0.* *cpu
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4025429
+  timestamp: 1730169540048
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.3.1-py311h09e6bbd_1.conda
+  sha256: 698b08ca54169a744a1a087130ece9528f18da5e3be33ff6799ac6337d2a5e7f
+  md5: a0a43da9ec3ffb6195e7621fd959f430
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 485377
+  timestamp: 1725739643057
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.3.1-py311h09e6bbd_1.conda
+  sha256: 1d9f2c68ba6c7812f0c1e4a9bf9a5ad0a691b7b7b7694cb7ec0f05f1c24906f1
+  md5: 9c3fc1bf9718d8340f41b0fab06ecdaa
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 10.3.1.*
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 384333
+  timestamp: 1725875205492
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.0-py311hb4b81e0_0.conda
+  sha256: c2c06cca4ce9fd72f1bf8d69703a8c5c2252efd497619d09f47d95d18d3cccf9
+  md5: e3c2e5ded5b6e4b3c2600d033929645c
+  depends:
+  - __osx >=11.0
+  - certifi
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 501267
+  timestamp: 1727795522741
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.10-hc51fdd5_3_cpython.conda
+  sha256: 95a2c487176867ded825e23eab1e581398f75c5323da0cb7577c3cff3d2f955b
+  md5: 2a47a0061d7d3030e45b66d23f01d101
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 14598065
+  timestamp: 1729042279642
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
+  sha256: adc05729b7e0aca7b436e60a86f10822a92185dfcb48d66d6444e3629d3a1f6a
+  md5: 3b855e3734344134cb56c410f729c340
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6308
+  timestamp: 1723823096865
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h460d6c5_1.conda
+  sha256: 9ae182eef4e96a7c2f46cc9add19496276612663e17429500432631dce31a831
+  md5: d32590e7bd388f18b036c6fc402a0cb1
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 192321
+  timestamp: 1725456528007
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.0-py311h730b646_3.conda
+  sha256: 7e75589d9c3723ecf314435f15a7b486cebafa89ebf00bb616354e37587dc7ae
+  md5: b6f3e527de0c0384cd78cfa779bd6ddf
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365841
+  timestamp: 1728642472021
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+  sha256: 873ac689484262a51fd79bc6103c1a1bedbf524924d7f0088fb80703042805e4
+  md5: 6483b1f59526e05d7d894e466b5b6924
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: LicenseRef-Qhull
+  size: 516376
+  timestamp: 1720814307311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2024.07.02-hcd0e937_1.conda
+  sha256: eebddde6cb10b146507810b701ef6df122d5309cd5151a39d0828aa44dc53725
+  md5: 19e29f2ccc9168eb0a39dc40c04c0e21
+  depends:
+  - libre2-11 2024.07.02 h2348fd5_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26860
+  timestamp: 1728779123653
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+  sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
+  md5: 8cbb776a2f641b943d413b3e19df71f4
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 250351
+  timestamp: 1679532511311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.21.0-py311h3ff9189_0.conda
+  sha256: 309be68ba0cac227dbc288576b1b35a4f57cea85ca8891689399c384ac04b254
+  md5: ae72e9942de84200f16d91a1c3418116
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 294014
+  timestamp: 1730923248201
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.17.21-py311he2be06e_3.conda
+  sha256: 01a5e068e125b71e85e732f0e449296592881e74a7718d21cde3f4c9cf35d215
+  md5: c964b671afc5b881fc3e20e5db12bf46
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - ruamel.yaml.clib >=0.1.2
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 260384
+  timestamp: 1678273424672
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.8-py311hae2e1ce_1.conda
+  sha256: 4a61547188dff0aa1cbab2cc6a6ce3ca354fe7b48c5bbf765d676df8c29e5d80
+  md5: 11dccbe06e61a3d95223ce75013a7c80
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 117234
+  timestamp: 1728724716033
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.5.2-py311h9e23f0f_1.conda
+  sha256: cc9f8c3f12ef7cce384285c11e76e981349771542edf14ba069b8b2f22744b5e
+  md5: ad77674e1f893b3ffe27ffa532e2724f
+  depends:
+  - __osx >=11.0
+  - joblib >=1.2.0
+  - libcxx >=17
+  - llvm-openmp >=17.0.6
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - scipy
+  - threadpoolctl >=3.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9729967
+  timestamp: 1726083178729
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.1-py311hf1db568_1.conda
+  sha256: 082a72e5f197aefb59e9f40176df835407e5f71ec832541ba14d4326d3686552
+  md5: 1163490da89fd85d00d29b4d4be7cf0c
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15242433
+  timestamp: 1729481958579
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.6-py311hac502b4_2.conda
+  sha256: ce20ddfb0c8c96eebf3123d5c56e6d32c56b01650eb4b0da86603dad7b0bbf32
+  md5: b3088a6bbd05fb8481257a97cbc65b48
+  depends:
+  - __osx >=11.0
+  - geos >=3.13.0,<3.13.1.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 543087
+  timestamp: 1727273733033
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
+  sha256: cb7a9440241c6092e0f1c795fdca149c4767023e783eaf9cfebc501f906b4897
+  md5: 69d0f9694f3294418ee935da3d5f7272
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35708
+  timestamp: 1720003794374
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.47.0-hcd14bea_1.conda
+  sha256: f9975914a78d600182ec68c963a98c6c0a07eda9b9eee7d6e8bdac9310858ad2
+  md5: ca42c22ab1d212895e58fee9ba32875f
+  depends:
+  - __osx >=11.0
+  - libsqlite 3.47.0 hbaaea75_1
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 840459
+  timestamp: 1730208324005
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+  sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
+  md5: b50a57ba89c32b62428b71a875291c9b
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3145523
+  timestamp: 1699202432999
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.1-py311h460d6c5_1.conda
+  sha256: bba4940ef7522c3b4ae6eacd296e5e110de3659f7e4c3654d4fc2bb213c2091c
+  md5: 8ba6d177509dc4fac7af09749556eed0
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 859139
+  timestamp: 1724956356600
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-15.1.0-py311hae2e1ce_1.conda
+  sha256: e4b1dcf79f4d4656e538ba24c845350b147d0d9f066771f8b3f396bea828b965
+  md5: ade7687026adce6296650b21e7463758
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 372655
+  timestamp: 1729704815727
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
+  sha256: 7113618021cf6c80831a429b2ebb9d639f3c43cf7fe2257d235dc6ae0ab43289
+  md5: 7e0125f8fb619620a0011dc9297e2493
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 13515
+  timestamp: 1727034783560
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+  sha256: 9939a166d780700d81023546759102b33fdc2c5f11ef09f5f66c77210fd334c8
+  md5: 77c447f48cab5d3a15ac224edb86a968
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 18487
+  timestamp: 1727795205022
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+  sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
+  md5: 39c6b54e94014701dd157f4f576ed211
+  license: LGPL-2.1 and GPL-2.0
+  size: 235693
+  timestamp: 1660346961024
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+  sha256: 93181a04ba8cfecfdfb162fc958436d868cc37db504c58078eab4c1a3e57fbb7
+  md5: 4bb3f014845110883a3c5ee811fd84b4
+  license: MIT
+  license_family: MIT
+  size: 88016
+  timestamp: 1641347076660
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h9f5b81c_6.conda
+  sha256: 5c5061c976141eccbbb2aec21483ddd10fd1df4fd9bcf638e3fd57b2bd85721f
+  md5: 84121ef1717cdfbecedeae70142706cc
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libcxx >=17
+  - libsodium >=1.0.20,<1.0.21.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 280870
+  timestamp: 1728363954972
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
+  sha256: 58f8860756680a4831c1bf4f294e2354d187f2e999791d53b1941834c4b37430
+  md5: e3170d898ca6cb48f1bb567afb92f775
+  depends:
+  - __osx >=11.0
+  - libzlib 1.3.1 h8359307_2
+  license: Zlib
+  license_family: Other
+  size: 77606
+  timestamp: 1727963209370
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+  sha256: 2d4fd1ff7ee79cd954ca8e81abf11d9d49954dd1fef80f27289e2402ae9c2e09
+  md5: d96942c06c3e84bfcc5efb038724a7fd
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 405089
+  timestamp: 1714723101397
+- conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
+  sha256: 1a62cd1f215fe0902e7004089693a78347a30ad687781dfda2289cab000e652d
+  md5: 37e16618af5c4851a3f3d66dd0e11141
+  depends:
+  - libgomp >=7.5.0
+  - libwinpthread >=12.0.0.r2.ggc561118da
+  constrains:
+  - openmp_impl 9999
+  - msys2-conda-epoch <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49468
+  timestamp: 1718213032772
+- conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311he736701_5.conda
+  sha256: 8bbce5e61e012a06e248f58bb675fdc82ba2900c78590696d185150fb9cea91f
+  md5: 8917bf795c40ec1839ed9d0ab3ad9735
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 34883
+  timestamp: 1725357113431
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.31-hd4326aa_3.conda
+  sha256: d27e5f659f10d50c114238feeb36d2c5c0581a93496c12469733ba03a0f14529
+  md5: 61791dff53fa5b26d064bb9450dcd3bb
+  depends:
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-http >=0.8.10,<0.8.11.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - aws-c-sdkutils >=0.1.19,<0.1.20.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 102388
+  timestamp: 1729533186004
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.7.4-h891f644_2.conda
+  sha256: 1458b30f5a7305c98885ffc0f392b4161ac7459b9500377e662e25c5878c27bc
+  md5: 728652c109a9ed14aee25d6ca1e33da6
+  depends:
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 47297
+  timestamp: 1728756066306
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.29-h2466b09_0.conda
+  sha256: 4d8b757985dccad92608f173ba299a4781ff755670858b92f6bbdb8cf78cf851
+  md5: 1a55ee7e7eb4477195128275b8747026
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 235092
+  timestamp: 1728707219604
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.19-h891f644_2.conda
+  sha256: ad9b85a2b60d6da4ae729d039d26ffb6aaaaeb1227546e18c020634b6155ca54
+  md5: 690cae4ce0e03c0ac7ccab5ae0c7f4c2
+  depends:
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 22761
+  timestamp: 1728750939878
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.3-h0311a85_5.conda
+  sha256: b295fba66de525bbe50658a4b63d59d230e71523510ace5bfad851bc49779ea7
+  md5: c9e5bd904f2fc755b9c57ceecc5e48d7
+  depends:
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - aws-checksums >=0.1.20,<0.1.21.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 54214
+  timestamp: 1729527798400
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.10-h71eeabb_3.conda
+  sha256: 2b207010c59cda5052d7b8e7c5a792b47df5f5f4e41ee041ef71bb8b7126cfad
+  md5: a7163ccb295b5f679e8ee0bb0c7f226d
+  depends:
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-compression >=0.2.19,<0.2.20.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 182245
+  timestamp: 1729518148022
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.20-h5c5bb51_0.conda
+  sha256: b46a909b38a2e4b16d8784b6833b7a4475b82059a63c7a8e15c133895d3b9760
+  md5: ef8deed78a8ff619df29951bc9ad41e1
+  depends:
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 160768
+  timestamp: 1729106086718
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.7-h595efa6_3.conda
+  sha256: d48ba15a700165875978d7e34d7cb34b7fb026f3797aedbc52f1c0907693336e
+  md5: 5d741cd742624c7542e479bede7cdd4a
+  depends:
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-http >=0.8.10,<0.8.11.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 187157
+  timestamp: 1729534285088
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.6.7-h1c89dc9_1.conda
+  sha256: 325cd967bd41e987f123d13cb56c028b92ecec96b6182e85a940624a656b91a9
+  md5: 940398ca0856f5679cf90f80b96f50d0
+  depends:
+  - aws-c-auth >=0.7.31,<0.7.32.0a0
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-http >=0.8.10,<0.8.11.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - aws-checksums >=0.1.20,<0.1.21.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 109224
+  timestamp: 1729544620208
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.19-h891f644_4.conda
+  sha256: 487280bbee81934a2fe1d75873d47512b849bcf0c3db0152141a833fa3323fec
+  md5: 4a689865568b5cb5e1aecbf759a563c0
+  depends:
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 55175
+  timestamp: 1728756284819
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.20-h891f644_1.conda
+  sha256: 08476aa93e31656038abc01855a8f9caf0f26da192239f7404920c8d24512913
+  md5: d0269d6abbe51548175d5a25764a7aa2
+  depends:
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 75884
+  timestamp: 1728751179874
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.28.5-hf2a67f4_1.conda
+  sha256: 1ead73a8b541c9ad916820ef126f4a9cd78220c1860f8fce338cb4b6b9495de1
+  md5: edc64cfc32f91451906a645a9e2aabd4
+  depends:
+  - aws-c-auth >=0.7.31,<0.7.32.0a0
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-event-stream >=0.4.3,<0.4.4.0a0
+  - aws-c-http >=0.8.10,<0.8.11.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - aws-c-mqtt >=0.10.7,<0.10.8.0a0
+  - aws-c-s3 >=0.6.7,<0.6.8.0a0
+  - aws-c-sdkutils >=0.1.19,<0.1.20.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 255544
+  timestamp: 1729557573669
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.407-hfa5b0db_2.conda
+  sha256: 31c8cb777a279df714b5106f4c998a00edeb0e69b0c3a3b071105c80ae77895e
+  md5: 3851c28c9b8bb118fade2879514590f0
+  depends:
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-event-stream >=0.4.3,<0.4.4.0a0
+  - aws-checksums >=0.1.20,<0.1.21.0a0
+  - aws-crt-cpp >=0.28.5,<0.28.6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 2812580
+  timestamp: 1729598489560
+- conda: https://conda.anaconda.org/conda-forge/win-64/awscli-2.20.0-py311h1ea47a8_0.conda
+  sha256: 29e3b535634290d00bb7b47cab43c331dddd9ec4035bb5649a2f6f882f17ffa8
+  md5: 3ab69e8b3e3797759ab3f5ae23e8a753
+  depends:
+  - awscrt >=0.19.18,<=0.22.0
+  - colorama >=0.2.5,<0.4.7
+  - cryptography >=40.0.0,<43.0.2
+  - distro >=1.5.0,<1.9.0
+  - docutils >=0.10,<0.20
+  - jmespath >=0.7.1,<1.1.0
+  - prompt_toolkit >=3.0.24,<3.0.39
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.1,<=2.9.0
+  - python_abi 3.11.* *_cp311
+  - ruamel.yaml >=0.15.0,<=0.17.21
+  - ruamel.yaml.clib >=0.2.0,<=0.2.8
+  - urllib3 >=1.25.4,<1.27
+  license: Apache-2.0
+  license_family: APACHE
+  size: 12759410
+  timestamp: 1731487179902
+- conda: https://conda.anaconda.org/conda-forge/win-64/awscrt-0.22.0-py311hb961b49_6.conda
+  sha256: 57aa069c597ea01539caba3e242448e6f2e0861f856486dae6ad36ff46eb4f5e
+  md5: ef7341a3e0fd7f288652f8eeb518e511
+  depends:
+  - aws-c-auth >=0.7.31,<0.7.32.0a0
+  - aws-c-cal >=0.7.4,<0.7.5.0a0
+  - aws-c-common >=0.9.29,<0.9.30.0a0
+  - aws-c-event-stream >=0.4.3,<0.4.4.0a0
+  - aws-c-http >=0.8.10,<0.8.11.0a0
+  - aws-c-io >=0.14.20,<0.14.21.0a0
+  - aws-c-mqtt >=0.10.7,<0.10.8.0a0
+  - aws-c-s3 >=0.6.7,<0.6.8.0a0
+  - aws-checksums >=0.1.20,<0.1.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 2215989
+  timestamp: 1729557988432
+- conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.6-h85f69ea_0.conda
+  sha256: 1289853b41df5355f45664f1cb015c868df1f570cf743e9e4a5bda8efe8c42fa
+  md5: 2390269374fded230fcbca8332a4adc0
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50135
+  timestamp: 1719266616208
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-h2466b09_2.conda
+  sha256: d8fd7d1b446706776117d2dcad1c0289b9f5e1521cb13405173bad38568dd252
+  md5: 378f1c9421775dfe644731cb121c8979
+  depends:
+  - brotli-bin 1.1.0 h2466b09_2
+  - libbrotlidec 1.1.0 h2466b09_2
+  - libbrotlienc 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 19697
+  timestamp: 1725268293988
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-h2466b09_2.conda
+  sha256: f3bf2893613540ac256c68f211861c4de618d96291719e32178d894114ac2bc2
+  md5: d22534a9be5771fc58eb7564947f669d
+  depends:
+  - libbrotlidec 1.1.0 h2466b09_2
+  - libbrotlienc 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 20837
+  timestamp: 1725268270219
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311hda3d55a_2.conda
+  sha256: aa3ac5dbf63db2f145235708973c626c2189ee4040d769fdf0076286fa45dc26
+  md5: a0ea2839841a06740a1c110ba3317b42
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  license: MIT
+  license_family: MIT
+  size: 322114
+  timestamp: 1725268368720
+- conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+  sha256: 35a5dad92e88fdd7fc405e864ec239486f4f31eec229e31686e61a140a8e573b
+  md5: 276e7ffe9ffe39688abc665ef0f45596
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 54927
+  timestamp: 1720974860185
+- conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.34.3-h2466b09_0.conda
+  sha256: 1ddad30ee6de501a65b2431427800cb79fdb34a1650f291bb477a6c1c78fc1f1
+  md5: 7dd8f0c4af6a36df3b402fa12e19854c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 192873
+  timestamp: 1731182126180
+- conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
+  sha256: 0fcac3a7ffcc556649e034a1802aedf795e64227eaa7194d207b01eaf26454c4
+  md5: 4c4fd67c18619be5aa65dc5b6c72e490
+  license: ISC
+  size: 158773
+  timestamp: 1725019107649
+- conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h32b962e_3.conda
+  sha256: 127101c9c2d1a56f8791c19141ceff13fd1d1a1da28cfaca549dc99d210cec6a
+  md5: 8f43723a4925c51e55c2d81725a97db4
+  depends:
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.4,<1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 1516680
+  timestamp: 1721139332360
+- conda: https://conda.anaconda.org/conda-forge/win-64/cartopy-0.24.0-py311hcf9f919_0.conda
+  sha256: 5ee7140b550932896f416f3765d3ff4acd326fe8b50909eda6186dd3ce34f320
+  md5: 38e9d8fdeccfc01fa09f0bf6d30e3da2
+  depends:
+  - matplotlib-base >=3.6
+  - numpy >=1.19,<3
+  - packaging >=21
+  - pyproj >=3.3.1
+  - pyshp >=2.3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - shapely >=1.8
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1584457
+  timestamp: 1728342837436
+- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py311he736701_0.conda
+  sha256: 9689fbd8a31fdf273f826601e90146006f6631619767a67955048c7ad7798a1d
+  md5: e1c69be23bd05471a6c623e91680ad59
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 297627
+  timestamp: 1725561079708
+- conda: https://conda.anaconda.org/conda-forge/win-64/cftime-1.6.4-py311h0a17f05_1.conda
+  sha256: 1ab7b1dd6e6610042b48adc47dd85f4b0bdfe19230585a75fdec2d1bb4c64f3a
+  md5: a46fb98d896ccf723aa9f1bba8ccdef1
+  depends:
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 187832
+  timestamp: 1725401239339
+- conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.1-py311h3257749_0.conda
+  sha256: dbb0c161dd75e72e66c13f31715941adb094a45471016f89d6a1cfab30967ba8
+  md5: 91d8504588e1b3c77e605503e5a1bc11
+  depends:
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 216693
+  timestamp: 1731429286140
+- conda: https://conda.anaconda.org/conda-forge/win-64/cramjam-2.8.4rc3-py311ha637bb9_2.conda
+  sha256: 9c2e07e669b3be4378e975d304cd0d3bedae5dd76b73a1fd161b973d38bab359
+  md5: e72dc449f2e92f334fee1fcf2696c874
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1508887
+  timestamp: 1726117665966
+- conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-43.0.1-py311hfd75b31_0.conda
+  sha256: 9b4acacc86a8b8a677f7d3a9d7212fb76d33609645537d50e7bfc2353b2e6327
+  md5: 024aba4649a459359a57016519e5a083
+  depends:
+  - cffi >=1.12
+  - openssl >=3.3.2,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1270296
+  timestamp: 1725444117716
+- conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.0.0-py311he736701_1.conda
+  sha256: e8f2027af0cf22feebad76ccbbb3139437fd07b5c6c35497b45e8de2d1f636ea
+  md5: b0845b4087a24616d2fecc716397b3f6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 322558
+  timestamp: 1728335601937
+- conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.8-py311hda3d55a_0.conda
+  sha256: ee15fa3cb625d02cba59cb8b60575de721d44798029be8b2c961a613f714ff7e
+  md5: 77d256e98801d3f1066993c6602579c0
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 3631650
+  timestamp: 1731045182872
+- conda: https://conda.anaconda.org/conda-forge/win-64/docutils-0.19-py311h1ea47a8_1.tar.bz2
+  sha256: 40c678c6bda27aeb7ad8b1714f189201599d2068a0fa75087548b62f8afe9bc7
+  md5: 52b2142036004451e1881d97e9d01e8a
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1
+    and GPL-3.0-or-later
+  size: 1033837
+  timestamp: 1666755622310
+- conda: https://conda.anaconda.org/conda-forge/win-64/double-conversion-3.3.0-h63175ca_0.conda
+  sha256: 735d40b44a0f39386d1e2988384b6d78a98efd4fa1818e7f2f6fb01f91e16b64
+  md5: 1a8bc18b24014167b2184c5afbe6037e
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70425
+  timestamp: 1686490368655
+- conda: https://conda.anaconda.org/conda-forge/win-64/fastparquet-2024.5.0-py311h0a17f05_2.conda
+  sha256: 2b5359b8d29a777a97355769ac0bac2923afac9c9c43b5eb09a76caa234eac39
+  md5: 154637444b91a81234d1a148d2aebbea
+  depends:
+  - cramjam >=2.3
+  - fsspec
+  - numpy >=1.19,<3
+  - numpy >=1.20.3
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 491607
+  timestamp: 1729689860514
+- conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.15.0-h765892d_1.conda
+  sha256: ed122fc858fb95768ca9ca77e73c8d9ddc21d4b2e13aaab5281e27593e840691
+  md5: 9bb0026a2131b09404c59c4290c697cd
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 192355
+  timestamp: 1730284147944
+- conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.54.1-py311h5082efb_1.conda
+  sha256: 829c0f2b1656bef5569e41ca2c9ca1dc70704f6adf2b437b10781c6b2a92f748
+  md5: 9479dd6402cf6085d1f27b4c557d1405
+  depends:
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - unicodedata2 >=15.1.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 2469782
+  timestamp: 1729530692321
+- conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+  sha256: 2c53ee8879e05e149a9e525481d36adfd660a6abda26fd731376fa64ff03e728
+  md5: 3761b23693f768dc75a8fd0a73ca053f
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-only OR FTL
+  size: 510306
+  timestamp: 1694616398888
+- conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.13.0-h5a68840_0.conda
+  sha256: 2b46d6f304f70dfca304169299908b558bd1e83992acb5077766eefa3d3fe35f
+  md5: 08a30fe29a645fc5c768c0968db116d3
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-only
+  size: 1665961
+  timestamp: 1725676536384
+- conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-h63175ca_1003.conda
+  sha256: 25040a4f371b9b51663f546bac620122c237fa1d5d32968e21b0751af9b7f56f
+  md5: 3194499ee7d1a67404a87d0eefdd92c6
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 95406
+  timestamp: 1711634622644
+- conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-9.0.0-h2bedf89_1.conda
+  sha256: 20f42ec76e075902c22c1f8ddc71fb88eff0b93e74f5705c1e72220030965810
+  md5: 254f119aaed2c0be271c1114ae18d09b
+  depends:
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=75.1,<76.0a0
+  - libglib >=2.80.3,<3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1095620
+  timestamp: 1721187287831
+- conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
+  sha256: 52fa5dde69758c19c69ab68a3d7ebfb2c9042e3a55d405c29a59d3b0584fd790
+  md5: 84344a916a73727c1326841007b52ca8
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 779637
+  timestamp: 1695662145568
+- conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.4-nompi_hd5d9e70_103.conda
+  sha256: c7fefe41464651e807f61d42803a670f25dbe0cb59677af97b9dda3e8cb675fd
+  md5: 6d72be86cae448cfc7bf93d51cd642bb
+  depends:
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2049966
+  timestamp: 1730830694091
+- conda: https://conda.anaconda.org/conda-forge/win-64/icu-75.1-he0c23c2_0.conda
+  sha256: 1d04369a1860a1e9e371b9fc82dd0092b616adcf057d6c88371856669280e920
+  md5: 8579b6bb8d18be7c0b27fb08adeeeb40
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 14544252
+  timestamp: 1720853966338
+- conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+  sha256: 0fd2b0b84c854029041b0ede8f4c2369242ee92acc0092f8407b1fe9238a8209
+  md5: 2d89243bfb53652c182a7c73182cce4f
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 1852356
+  timestamp: 1723739573141
+- conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_1.conda
+  sha256: 9a667eeae67936e710ff69ee7ce0e784d6052eeba9670b268c565a55178098c4
+  md5: 943f7fab631e12750641efd7279a268c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42891
+  timestamp: 1725303340467
+- conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.7-py311h3257749_0.conda
+  sha256: a2079e13d1345a5dd61df6be933e828e805051256e7260009ba93fce55aebd75
+  md5: 18fd1ac3d79a8d6550eaea5ceaa00036
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55867
+  timestamp: 1725459681416
+- conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+  sha256: 18e8b3430d7d232dad132f574268f56b3eb1a19431d6d5de8c53c29e6c18fa81
+  md5: 31aec030344e962fbd7dbbbbd68e60a9
+  depends:
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 712034
+  timestamp: 1719463874284
+- conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
+  sha256: f9fd9e80e46358a57d9bb97b1e37a03da4022143b019aa3c4476d8a7795de290
+  md5: d3592435917b62a8becff3a60db674f6
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 507632
+  timestamp: 1701648249706
+- conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+  sha256: f4f39d7f6a2f9b407f8fb567a6c25755270421731d70f0ff331f5de4fa367488
+  md5: 1900cb3cab5055833cfddb0ba233b074
+  depends:
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30037
+  license: Apache-2.0
+  license_family: Apache
+  size: 194365
+  timestamp: 1657977692274
+- conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_he0c23c2_1.conda
+  sha256: 52ff148dee1871ef1d5c298bae20309707e866b44714a0a333a5ed2cf9a38832
+  md5: 3f59a73b07a05530b252ecb07dd882b9
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1777570
+  timestamp: 1727296115119
+- conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
+  sha256: f5c293d3cfc00f71dfdb64bd65ab53625565f8778fc2d5790575bef238976ebf
+  md5: 8723000f6ffdbdaef16025f0a01b64c5
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 32567
+  timestamp: 1711021603471
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-17.0.0-h1a545c8_23_cpu.conda
+  sha256: 1c6616332a74fcf89495616af44e8c190790a9b8f39ba328791f69a498039ec9
+  md5: 10cfd8749606ba86e7dd6cbe9901e969
+  depends:
+  - aws-crt-cpp >=0.28.5,<0.28.6.0a0
+  - aws-sdk-cpp >=1.11.407,<1.11.408.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgoogle-cloud >=2.30.0,<2.31.0a0
+  - libgoogle-cloud-storage >=2.30.0,<2.31.0a0
+  - libre2-11 >=2024.7.2
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.2,<2.0.3.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.40.33810
+  - zstd >=1.5.6,<1.6.0a0
+  - libutf8proc <2.9
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - parquet-cpp <0.0a0
+  - arrow-cpp <0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5115507
+  timestamp: 1729639342634
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-17.0.0-hac47afa_23_cpu.conda
+  sha256: 6aa8aa618d1ccd179bdcccb0d6a82f387621b118f09fa21c5088b060d0390137
+  md5: e9ef6b3ac57738c3730c2b0a2e10e014
+  depends:
+  - libarrow 17.0.0 h1a545c8_23_cpu
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.40.33810
+  license: Apache-2.0
+  license_family: APACHE
+  size: 444853
+  timestamp: 1729639395691
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-17.0.0-hac47afa_23_cpu.conda
+  sha256: 416e988c86159d4b3e6c0b5a5442786956755e215989bf05a28435e0bcd20949
+  md5: bbea4494c1f3265b767a2761fb5a912d
+  depends:
+  - libarrow 17.0.0 h1a545c8_23_cpu
+  - libarrow-acero 17.0.0 hac47afa_23_cpu
+  - libparquet 17.0.0 h59f2d37_23_cpu
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.40.33810
+  license: Apache-2.0
+  license_family: APACHE
+  size: 432526
+  timestamp: 1729639567113
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-17.0.0-ha9530af_23_cpu.conda
+  sha256: c458c9c2701e5c4dbce64896b87d7fc05d5af333dbcac024aaf6d86967c8db06
+  md5: 81999ab4221a4738fe9fe785914bc031
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 17.0.0 h1a545c8_23_cpu
+  - libarrow-acero 17.0.0 hac47afa_23_cpu
+  - libarrow-dataset 17.0.0 hac47afa_23_cpu
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.40.33810
+  license: Apache-2.0
+  license_family: APACHE
+  size: 364768
+  timestamp: 1729639638523
+- conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_mkl.conda
+  sha256: 5468bb91c44b41ce060bbd997c797b2f91e2b7ce91a7cbf4ddf7e7b734a8dc98
+  md5: 499208e81242efb6e5abc7366c91c816
+  depends:
+  - mkl 2024.2.2 h66d3029_14
+  constrains:
+  - blas * mkl
+  - libcblas 3.9.0 25_win64_mkl
+  - liblapack 3.9.0 25_win64_mkl
+  - liblapacke 3.9.0 25_win64_mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3736641
+  timestamp: 1729643534444
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-h2466b09_2.conda
+  sha256: 33e8851c6cc8e2d93059792cd65445bfe6be47e4782f826f01593898ec95764c
+  md5: f7dc9a8f21d74eab46456df301da2972
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 70526
+  timestamp: 1725268159739
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-h2466b09_2.conda
+  sha256: 234fc92f4c4f1cf22f6464b2b15bfc872fa583c74bf3ab9539ff38892c43612f
+  md5: 9bae75ce723fa34e98e239d21d752a7e
+  depends:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 32685
+  timestamp: 1725268208844
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-h2466b09_2.conda
+  sha256: 3d0dd7ef505962f107b7ea8f894e0b3dd01bf46852b362c8a7fc136b039bc9e1
+  md5: 85741a24d97954a991e55e34bc55990b
+  depends:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 245929
+  timestamp: 1725268238259
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_mkl.conda
+  sha256: 21528cdfe67dafdb2d21925515a167f13963e002c2b6d06d68984767f731850c
+  md5: 3ed189ba03a9888a8013aaee0d67c49d
+  depends:
+  - libblas 3.9.0 25_win64_mkl
+  constrains:
+  - blas * mkl
+  - liblapack 3.9.0 25_win64_mkl
+  - liblapacke 3.9.0 25_win64_mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3732258
+  timestamp: 1729643561581
+- conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-19.1.3-default_ha5278ca_0.conda
+  sha256: 02e9e0ee3f9a7b375d1a268f90f1f2ffe31bccacb904b9f36270255e9a02df6e
+  md5: fe6aa50eeb307558f8974f115305388f
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 26749218
+  timestamp: 1730355727736
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+  sha256: 75e60fbe436ba8a11c170c89af5213e8bec0418f88b7771ab7e3d9710b70c54e
+  md5: cd4cc2d0c610c8cb5419ccc979f2d6ce
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25694
+  timestamp: 1633684287072
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
+  sha256: dfbac497c4fee74f67391f9c4a40cab559468b7d04ff9fad4b404a26b5e1d5b8
+  md5: 7ead800e22ff7b4bccb73e42a8f7a0f4
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: curl
+  license_family: MIT
+  size: 342388
+  timestamp: 1726660508261
+- conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.22-h2466b09_0.conda
+  sha256: 579c634b7de8869cb1d76eccd4c032dc275d5a017212128502ea4dc828a5b361
+  md5: a3439ce12d4e3cd887270d9436f9a4c8
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 155506
+  timestamp: 1728177485361
+- conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+  sha256: af03882afb7a7135288becf340c2f0cf8aa8221138a9a7b108aaeb308a486da1
+  md5: 25efbd786caceef438be46da78a7b5ef
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 410555
+  timestamp: 1685726568668
+- conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.4-he0c23c2_0.conda
+  sha256: 0c0447bf20d1013d5603499de93a16b6faa92d7ead870d96305c0f065b6a5a12
+  md5: eb383771c680aa792feb529eaf9df82f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 139068
+  timestamp: 1730967442102
+- conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+  sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
+  md5: 2c96d1b6915b408893f9472569dee135
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 42063
+  timestamp: 1636489106777
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-14.2.0-h1383e82_1.conda
+  sha256: ef840e797714440bb10b69446d815966fff41fdac79f79c4e19c475d81cd375d
+  md5: 75fdd34824997a0f9950a703b15d8ac5
+  depends:
+  - _openmp_mutex >=4.5
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - libgcc-ng ==14.2.0=*_1
+  - libgomp 14.2.0 h1383e82_1
+  - msys2-conda-epoch <0.0a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 666386
+  timestamp: 1729089506769
+- conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.82.2-h7025463_0.conda
+  sha256: 7dfbf492b736f8d379f8c3b32a823f0bf2167ff69963e4c940339b146a04c54a
+  md5: 3e379c1b908a7101ecbc503def24613f
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - glib 2.82.2 *_0
+  license: LGPL-2.1-or-later
+  size: 3810166
+  timestamp: 1729192227078
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-14.2.0-h1383e82_1.conda
+  sha256: d8739b834608f35775209b032f0c2be752ef187863c7ec847afcebe2f681be4e
+  md5: 9e2d4d1214df6f21cba12f6eff4972f9
+  depends:
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - msys2-conda-epoch <0.0a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 524249
+  timestamp: 1729089441747
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.30.0-ha00044d_0.conda
+  sha256: 2bc9b941eea49287ada92875734f717e4f24fcf9e55c0cdf2e4ead896ad92931
+  md5: 6abd86bf0b053dd2fe698568a3f38821
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgrpc >=1.65.5,<1.66.0a0
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libgoogle-cloud 2.30.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 14593
+  timestamp: 1728022894892
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.30.0-he5eb982_0.conda
+  sha256: 2bc1e02125d7a2ca86debc5c7580f3027472439739effc10d96960285593b7de
+  md5: 116f6a285dbe98e6d4126a88de2878dd
+  depends:
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libgoogle-cloud 2.30.0 ha00044d_0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 14456
+  timestamp: 1728023196706
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.65.5-ha20e22e_0.conda
+  sha256: f3aee23aac459be6206081ac9c996d3a7480deb1faab6088c268d29a890b9875
+  md5: b550afe2fea16769fa9ef3fcbeadf0c1
+  depends:
+  - c-ares >=1.33.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - libre2-11 >=2023.9.1
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - re2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - grpc-cpp =1.65.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 16648528
+  timestamp: 1727201450991
+- conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+  sha256: 5f844dd19b046d43174ad80c6ea75b5d504020e3b63cfbc4ace97b8730d35c7b
+  md5: e1eb10b1cca179f2baa3601e4efc8712
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-only
+  size: 636146
+  timestamp: 1702682547199
+- conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
+  sha256: c7e4600f28bcada8ea81456a6530c2329312519efcf0c886030ada38976b0511
+  md5: 2cf0cf76cc15d360dfa2f17fd6cf9772
+  depends:
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 95568
+  timestamp: 1723629479451
+- conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+  sha256: 4e7808e3098b4b4ed7e287f63bb24f9045cc4d95bfd39f0db870fc2837d74dff
+  md5: 3f1b948619c45b1ca714d60c7389092c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 822966
+  timestamp: 1694475223854
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_mkl.conda
+  sha256: 98c13a28596389539abe3f608c6fbd2826df47671f77c58a331df878c6140c53
+  md5: f716ef84564c574e8e74ae725f5d5f93
+  depends:
+  - libblas 3.9.0 25_win64_mkl
+  constrains:
+  - blas * mkl
+  - libcblas 3.9.0 25_win64_mkl
+  - liblapacke 3.9.0 25_win64_mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3736560
+  timestamp: 1729643588182
+- conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_he239ae6_115.conda
+  sha256: bdf67732b92836287bdf6618093dada2ec20f2be4102d031a80f736e082cc410
+  md5: 582fd971ca8f54b59f007f2c1f1a113e
+  depends:
+  - blosc >=1.21.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzip >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 625327
+  timestamp: 1728056291410
+- conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-17.0.0-h59f2d37_23_cpu.conda
+  sha256: 5c7b2460e5488e43e60746440b54c9037c2fa1bd17e75acc41f08b351abee22a
+  md5: e1eda32bf3aa52960e070623f1c8ae2d
+  depends:
+  - libarrow 17.0.0 h1a545c8_23_cpu
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.3.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.40.33810
+  license: Apache-2.0
+  license_family: APACHE
+  size: 801566
+  timestamp: 1729639529628
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
+  sha256: 0d3d6ff9225f6918ac225e3839c0d91e5af1da08a4ebf59cac1bfd86018db945
+  md5: 639ac6b55a40aa5de7b8c1b4d78f9e81
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: zlib-acknowledgement
+  size: 348933
+  timestamp: 1726235196095
+- conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.27.5-hcaed137_2.conda
+  sha256: f039a07e6a52542e298ad0cf39d95d261f02c62256c82a60e246f291b2535e1b
+  md5: 0155746155856bc39091b5242c9b52d7
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6090012
+  timestamp: 1727424307861
+- conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2024.07.02-h4eb7d71_1.conda
+  sha256: 39908d18620d48406ea3492bf111eface5b3a88c1a2d166c6d513b03f450df5d
+  md5: d8dbfb066c8e3e85439687613d32057d
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 260860
+  timestamp: 1728779502416
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+  sha256: 7bcb3edccea30f711b6be9601e083ecf4f435b9407d70fc48fbcf9e5d69a0fc6
+  md5: 198bb594f202b205c7d18b936fa4524f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: ISC
+  size: 202344
+  timestamp: 1716828757533
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.0-h2466b09_1.conda
+  sha256: 3342d6fe787f5830f7e8466d9c65c914bfd8d67220fb5673041b338cbba47afe
+  md5: 5b1f36012cc3d09c4eb9f24ad0e2c379
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 892175
+  timestamp: 1730208431651
+- conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+  sha256: 813fd04eed2a2d5d9c36e53c554f9c1f08e9324e2922bd60c9c52dbbed2dbcec
+  md5: dc262d03aae04fe26825062879141a41
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 266806
+  timestamp: 1685838242099
+- conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.21.0-hbe90ef8_0.conda
+  sha256: 81ca4873ba09055c307f8777fb7d967b5c26291f38095785ae52caed75946488
+  md5: 7699570e1f97de7001a7107aabf2d677
+  depends:
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 633857
+  timestamp: 1727206429954
+- conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hfc51747_1.conda
+  sha256: 902cb9f7f54d17dcfd54ce050b1ce2bc944b9bbd1748913342c2ea1e1140f8bb
+  md5: eac317ed1cc6b9c0af0c27297e364665
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.22,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 978865
+  timestamp: 1728232594877
+- conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-h82a8f57_0.tar.bz2
+  sha256: 6efa83e3f2fb9acaf096a18d21d0f679d110934798348c5defc780d4b759a76c
+  md5: 076894846fe9f068f91c57d158c90cba
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 104389
+  timestamp: 1667316359211
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+  sha256: d0ca51cb1de9192be9a3238e71fbcca5a535619c499c4f4c9b2ed41c14d36770
+  md5: abd61d0ab127ec5cd68f62c2969e6f34
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 274359
+  timestamp: 1713200524021
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_8.conda
+  sha256: 6d5e158813ab8d553fbb0fedd0abe7bf92970b0be3a9ddf12da0f6cbad78f506
+  md5: 03cccbba200ee0523bde1f3dad60b1f3
+  depends:
+  - ucrt
+  constrains:
+  - pthreads-win32 <0.0a0
+  - msys2-conda-epoch <0.0a0
+  license: MIT AND BSD-3-Clause-Clear
+  size: 35433
+  timestamp: 1724681489463
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
+  sha256: 08dec73df0e161c96765468847298a420933a36bc4f09b50e062df8793290737
+  md5: a69bbf778a462da324489976c84cfc8c
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - pthread-stubs
+  - ucrt >=10.0.20348.0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 1208687
+  timestamp: 1727279378819
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.5-h442d1da_0.conda
+  sha256: 020466b17c143190bd5a6540be2ceef4c1f8d514408bd5f0adaafcd9d0057b5c
+  md5: 1fbabbec60a3c7c519a5973b06c3b2f4
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1511585
+  timestamp: 1731489892312
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxslt-1.1.39-h3df6e99_0.conda
+  sha256: 6e3d99466d2076c35e7ac8dcdfe604da3d593f55b74a5b8e96c2b2ff63c247aa
+  md5: 279ee338c9b34871d578cb3c7aa68f70
+  depends:
+  - libxml2 >=2.12.1,<2.14.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 418542
+  timestamp: 1701629338549
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzip-1.11.2-h3135430_0.conda
+  sha256: 8ed49d8aa0ff908e16c82f92154174027c8906429e8b63d71f0b27ecc987b43e
+  md5: 09066edc7810e4bd1b41ad01a6cc4706
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 146856
+  timestamp: 1730442305774
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+  sha256: ba945c6493449bed0e6e29883c4943817f7c79cbff52b83360f7b341277c6402
+  md5: 41fbfac52c601159df6c01f875de31b9
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 55476
+  timestamp: 1727963768015
+- conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.43.0-py311h7deaa30_1.conda
+  sha256: 7df8480fc6c32b6f5e0b6f928332759559e9c2d6c43f94e6b51ea5d2129442a9
+  md5: c59d60615d5c5a9e9539a106478d332c
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - vs2015_runtime
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17126019
+  timestamp: 1725305442517
+- conda: https://conda.anaconda.org/conda-forge/win-64/lz4-4.3.3-py311h8b5e962_1.conda
+  sha256: 24bb321c5da9660f56759000001a6f227780348a21098164f55049b58ac78a11
+  md5: 8672eca07a3b500a9aa0483c43742f82
+  depends:
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 76663
+  timestamp: 1725090098178
+- conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+  sha256: a0954b4b1590735ea5f3d0f4579c3883f8ac837387afd5b398b241fda85124ab
+  md5: e34720eb20a33fc3bfb8451dd837ab7a
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134235
+  timestamp: 1674728465431
+- conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py311h5082efb_0.conda
+  sha256: 8a2022af5237e0fdf7e646856f1122735b71e4cdeaf42684b533ec4bad5a885f
+  md5: 84e78e335b0f9292060f1ac6d8ce0e3e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28244
+  timestamp: 1729351760960
+- conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-3.9.2-py311h1ea47a8_2.conda
+  sha256: 0dce90ff9df1035c7ff52dee9e2162c4f02c71349affd4e1a350e37a5bb8c832
+  md5: cb2afb11b4f7af8a7c8df50e4e51b484
+  depends:
+  - matplotlib-base >=3.9.2,<3.9.3.0a0
+  - pyside6 >=6.7.2
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tornado >=5
+  license: PSF-2.0
+  license_family: PSF
+  size: 17462
+  timestamp: 1731026303647
+- conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.2-py311h8f1b1e4_2.conda
+  sha256: 45d3c5e41275b8333d0622a8f7642d049d9cbbe6c80cf7beb1aa371f1e79dffe
+  md5: f7d8036f3808253ae132500eaa8d65d9
+  depends:
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 7939436
+  timestamp: 1731026260055
+- conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_14.conda
+  sha256: 098ba4a3cb82f627bc79dc0ab1111b44859c9ef4aaa8d75ce043bce107770cb3
+  md5: f011e7cc21918dc9d1efe0209e27fa16
+  depends:
+  - intel-openmp 2024.*
+  - tbb 2021.*
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 103019089
+  timestamp: 1727378392081
+- conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.0-py311h3257749_0.conda
+  sha256: 4e6a7979b434308ce5588970cb613952e3340bb2f9e63aaad7e5069ef1f08d1d
+  md5: 36562593204b081d0da8a8bfabfb278b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 89472
+  timestamp: 1725975909671
+- conda: https://conda.anaconda.org/conda-forge/win-64/netcdf4-1.7.2-nompi_py311hc43f1c8_100.conda
+  sha256: 83089e3b03bdfc048a1e2a0b860e6882031a72eac8c7aecd13b0e9402745f07c
+  md5: 5871f94c855c953ca3abc768f1420f3c
+  depends:
+  - certifi
+  - cftime
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1013027
+  timestamp: 1729662815776
+- conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.60.0-py311h0673bce_0.conda
+  sha256: b3359607051ec34c3eeb90447ece326822b6883882cf0e425cb1108dbcaebdc9
+  md5: 5d6eb2107dd921d651e46d059a82ab95
+  depends:
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - cudatoolkit >=11.2
+  - libopenblas !=0.3.6
+  - cuda-version >=11.2
+  - tbb >=2021.6.0
+  - scipy >=1.0
+  - cuda-python >=11.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5807308
+  timestamp: 1718888792863
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.0.2-py311h35ffc71_0.conda
+  sha256: c373acdeea9897da86ecf757417d7591d28043ffa2da57e4b723b15daa936caa
+  md5: 573b96ee4daa4fe59211982afc575afc
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7507136
+  timestamp: 1724749843736
+- conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
+  sha256: dda71cbe094234ab208f3552dec1f4ca6f2e614175d010808d6cb66ecf0bc753
+  md5: 7e7099ad94ac3b599808950cec30ad4e
+  depends:
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 237974
+  timestamp: 1709159764160
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.4.0-h2466b09_0.conda
+  sha256: e03045a0837e01ff5c75e9273a572553e7522290799807f918c917a9826a6484
+  md5: d0d805d9b5524a14efb51b3bff965e83
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 8491156
+  timestamp: 1731379715927
+- conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.2-h1c5a4bf_1.conda
+  sha256: 08274ce3433d35c03da8ccc00f8908ed37af9e24d16c5c7befbc3eaf135add04
+  md5: 524025f3ad525a28d11044d8991c5e98
+  depends:
+  - libprotobuf >=5.27.5,<5.27.6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 895548
+  timestamp: 1727242629823
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py311hcf9f919_1.conda
+  sha256: f5477bf3a2b7919481009ce87212d7bbd16c61a5bb05c692a7c336fb45646534
+  md5: 5965b8926efba14e6fde98cc8713c083
+  depends:
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14587131
+  timestamp: 1726879538736
+- conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_2.conda
+  sha256: f4a12cbf8a7c5bfa2592b9dc92b492c438781898e5b02f397979b0be6e1b5851
+  md5: a3a3baddcfb8c80db84bec3cb7746fb8
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 820831
+  timestamp: 1723489427046
+- conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.0.0-py311h4fbf6a9_0.conda
+  sha256: 0d38ec638a5b266adb894f6fe4c874b46b98180a984007bf40cb030a22e8cc1e
+  md5: 44897ebc5704d3de316af26740325513
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: HPND
+  size: 42185657
+  timestamp: 1729066269713
+- conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
+  sha256: 51de4d7fb41597b06d60f1b82e269dafcb55e994e08fdcca8e4d6f7d42bedd07
+  md5: b98135614135d5f458b75ab9ebb9558c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 461854
+  timestamp: 1709239971654
+- conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.5.0-hd9569ee_0.conda
+  sha256: ebd1fee2834cf5971a08dfb665606f775302aa22e98d5d893d35323805311419
+  md5: 4cfbffd1cd2bbff30e975a71b1769597
+  depends:
+  - libcurl >=8.10.0,<9.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2709612
+  timestamp: 1726489723807
+- conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py311he736701_0.conda
+  sha256: 303c988247c4b1638f1cc90cd40465f5c74ca0ecfd83114033af637654dc2b6b
+  md5: 307267e6a028bca3382d98e06a372ebf
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 521434
+  timestamp: 1729847606018
+- conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
+  sha256: 7e446bafb4d692792310ed022fe284e848c6a868c861655a92435af7368bae7b
+  md5: 3c8f2573569bb816483e5cf57efbbe29
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 9389
+  timestamp: 1726802555076
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-17.0.0-py311h06a5be4_2.conda
+  sha256: a4c150263a19ee7617a6afe71f68dfdb8ffd365fc80e786072151ca65bdb8035
+  md5: c61edb9b6abafa66ab5a837c20a8f38f
+  depends:
+  - libarrow-acero 17.0.0.*
+  - libarrow-dataset 17.0.0.*
+  - libarrow-substrait 17.0.0.*
+  - libparquet 17.0.0.*
+  - numpy >=1.19,<3
+  - pyarrow-core 17.0.0 *_2_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 26153
+  timestamp: 1730169918688
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-17.0.0-py311hdea38fa_2_cpu.conda
+  sha256: cc380b044ef40b9ddad0579a60fa7f691d521c4869faf387d3e4d38fc66f9dab
+  md5: a4a7a58593dc449165286eb14a4e37d4
+  depends:
+  - libarrow 17.0.0.* *cpu
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3611862
+  timestamp: 1730169343140
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.7.0-py311h90dcb63_0.conda
+  sha256: 36644db864de2ae57573d61bff0c46f3e5cb1efc86bd43756fdec9365ee8b5b3
+  md5: 423256766e9b9ba6c01c39b0ea992f1e
+  depends:
+  - certifi
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 760981
+  timestamp: 1727796239898
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.8.0.2-py311h4238720_0.conda
+  sha256: 94a50845a3b86a2d9d502aa2c49e6a36b5c3d87ec427a5f53f5c64c9ab26fc23
+  md5: 92dc1944a809ba689308a8cbbff5a01e
+  depends:
+  - libclang13 >=19.1.2
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libxslt >=1.1.39,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - qt6-main 6.8.0.*
+  - qt6-main >=6.8.0,<6.9.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 9695551
+  timestamp: 1730213513960
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.10-hce54a09_3_cpython.conda
+  sha256: 3931c546219d069918389e4dbe12057af4cc68a1060577a04014c6b5fc618aa0
+  md5: 5d54d429c0eb2273d1cc69763de6edaf
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 18206702
+  timestamp: 1729041779073
+- conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-5_cp311.conda
+  sha256: 9b210e5807dd9c9ed71ff192a95f1872da597ddd10e7cefec93a922fe22e598a
+  md5: 895b873644c11ccc0ab7dba2d8513ae6
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6707
+  timestamp: 1723823225752
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-307-py311hda3d55a_3.conda
+  sha256: 78a4ede098bbc122a3dff4e0e27255e30b236101818e8f499779c89670c58cd6
+  md5: 1bc10dbe3b8d03071070c962a2bdf65f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 6023110
+  timestamp: 1728636767562
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.14-py311hda3d55a_0.conda
+  sha256: 337097e3f3b71f782c43fb702893f86f080e140da467415dcaf039a7fbb8e551
+  md5: 64553b300529aa8987f6ca92c914c844
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 210973
+  timestamp: 1729202625177
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311he736701_1.conda
+  sha256: 86608f1b4f6b1819a74b6b1344c34304745fd7e84bfc9900269f57cf28178d31
+  md5: d0c5f3c595039890be0c9af47d23b9ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 187901
+  timestamp: 1725456808581
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.2.0-py311h484c95c_3.conda
+  sha256: 4d3fc4cfac284efb83a903601586cc6ee18fb556d4bf84d3bd66af76517c463e
+  md5: 4836b00658e11b466b823216f6df2424
+  depends:
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 371084
+  timestamp: 1728642713666
+- conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+  sha256: 887d53486a37bd870da62b8fa2ebe3993f912ad04bd755e7ed7c47ced97cbaa8
+  md5: 854fbdff64b572b5c0b470f334d34c11
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LicenseRef-Qhull
+  size: 1377020
+  timestamp: 1720814433486
+- conda: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.8.0-hfb098fa_0.conda
+  sha256: 71603164b962f50f663d7281f6c7c290be451e8cce399d4d91d86cfb156fd1d8
+  md5: 053046ca73b71bbcc81c6dc114264d24
+  depends:
+  - double-conversion >=3.3.0,<3.4.0a0
+  - harfbuzz >=9.0.0
+  - icu >=75.1,<76.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libclang13 >=19.1.0
+  - libglib >=2.82.1,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - qt 6.8.0
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 93521358
+  timestamp: 1728406725577
+- conda: https://conda.anaconda.org/conda-forge/win-64/re2-2024.07.02-hd3b24a8_1.conda
+  sha256: 5ac1c50d731c323bb52c78113792a71c5f8f060e5767c0a202120a948e0fc85b
+  md5: b4abdc84c969587219e7e759116a3e8b
+  depends:
+  - libre2-11 2024.07.02 h4eb7d71_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 214858
+  timestamp: 1728779526745
+- conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.21.0-py311h533ab2d_0.conda
+  sha256: 217c9ce9bcb50ea55ba1148a7b85ae945015c68ecae914707eff0fce5c175cdf
+  md5: 56ff25ebb744a6aa97ff02b8c263c892
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 211208
+  timestamp: 1730923228503
+- conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.17.21-py311ha68e1ae_3.conda
+  sha256: 62a768088784bc989a41a315d9e127fb5d92ba083da5282b553ba5efbaf1c3c0
+  md5: dcc9c25e92865290ac1a82c94d4f40df
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ruamel.yaml.clib >=0.1.2
+  - setuptools
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 255682
+  timestamp: 1678273390767
+- conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.8-py311he736701_1.conda
+  sha256: b37ff39296be036d305042efd1c8937ec501bdcd86dab5d20e028a2317901674
+  md5: 70501916c5ff292d6ee84e3831139d19
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 110651
+  timestamp: 1728725069480
+- conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.5.2-py311hdcb8d17_1.conda
+  sha256: 3f23a54f327af0227115b1ac3a8d6b32926e87bfe0097e3c906bd205bb9340b7
+  md5: c3e550b20baa56f911022f6304c8f547
+  depends:
+  - joblib >=1.2.0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scipy
+  - threadpoolctl >=3.1.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9491082
+  timestamp: 1726083711620
+- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py311hf16d85f_1.conda
+  sha256: bd3c3ec5ba203143818fa3ca300060a459d78da566049b49ed2ef20e04ea5b96
+  md5: b7c132408b0ee7408dcfa998ef6f7939
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15858505
+  timestamp: 1729482598163
+- conda: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.6-py311hd54bd37_2.conda
+  sha256: 7861137aee7b42c15fdbfed908e25285b2672a5c060b40891624d036bdbc1ec2
+  md5: b38f0e907cf3431ea635f1a5d871a85e
+  depends:
+  - geos >=3.13.0,<3.13.1.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 548238
+  timestamp: 1727274233608
+- conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
+  sha256: 5b9450f619aabcfbf3d284a272964250b2e1971ab0f7a7ef9143dda0ecc537b8
+  md5: 7635a408509e20dcfc7653ca305ad799
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59350
+  timestamp: 1720004197144
+- conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.47.0-h2466b09_1.conda
+  sha256: bc2a5ab86dbe2352790d1742265b3b6ae9a7aa5cf80345a37f26ec3e04cf9b4a
+  md5: 93084a590e8b7d2b62b7d5b1763d5bde
+  depends:
+  - libsqlite 3.47.0 h2466b09_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 914686
+  timestamp: 1730208443157
+- conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.7.0-h91493d7_0.tar.bz2
+  sha256: c3d607499a6e097f4b8b27048ee7166319fd3dfe98aea9e69a69a3d087b986e3
+  md5: f57be598137919e4f7e7d159960d66a1
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 178574
+  timestamp: 1668617991077
+- conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+  sha256: 2c4e914f521ccb2718946645108c9bd3fc3216ba69aea20c2c3cedbd8db32bb1
+  md5: fc048363eb8f03cd1737600a5d08aafe
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: TCL
+  license_family: BSD
+  size: 3503410
+  timestamp: 1699202577803
+- conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.1-py311he736701_1.conda
+  sha256: 8e448bc682a6540a0aadc1f821c0d60f03d70272350caa2af519316fd1753f68
+  md5: f361535f90629358e3ea8f2161b239f3
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 860730
+  timestamp: 1724956581349
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+  sha256: db8dead3dd30fb1a032737554ce91e2819b43496a0db09927edf01c32b577450
+  md5: 6797b005cd0f439c4c5c9ac565783700
+  constrains:
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-MicrosoftWindowsSDK10
+  size: 559710
+  timestamp: 1728377334097
+- conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-15.1.0-py311he736701_1.conda
+  sha256: 07d55566e05bbadc32e989bbe50853e579fea0f8809503719d7d1438302d27be
+  md5: 6230613721d6d805d0276025ee4d7b2b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 365349
+  timestamp: 1729705070270
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h8a93ad2_22.conda
+  sha256: b72e7410ec0a748d21e9e997234fc474e3367cee8f509b07eb8182d3584a38d8
+  md5: a47cd756e88d8a80dfae678842d4acc9
+  depends:
+  - vc14_runtime >=14.40.33810
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17462
+  timestamp: 1728400826503
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-hcc2c482_22.conda
+  sha256: 4c669c65007f88a7cdd560192f7e6d5679d191ac71610db724e18b2410964d64
+  md5: ce23a4b980ee0556a118ed96550ff3f3
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.40.33810.* *_22
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  size: 750719
+  timestamp: 1728401055788
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_22.conda
+  sha256: 80aa9932203d65a96f817b8be4fafc176fb2b3fe6cf6899ede678b8f0317fbff
+  md5: 8c6b061d44cafdfc8e8c6eb5f100caf0
+  depends:
+  - vc14_runtime >=14.40.33810
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17453
+  timestamp: 1728400827536
+- conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: 9df10c5b607dd30e05ba08cbd940009305c75db242476f4e845ea06008b0a283
+  md5: 1cee351bf20b830d991dbe0bc8cd7dfe
+  license: MIT
+  license_family: MIT
+  size: 1176306
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-h0e40799_1.conda
+  sha256: f44bc6f568a9697b7e1eadc2d00ef5de0fe62efcf5e27e5ecc46f81046082faf
+  md5: ca66d6f8fe86dd53664e8de5087ef6b1
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 107925
+  timestamp: 1727035280560
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.5-h0e40799_0.conda
+  sha256: 9075f98dcaa8e9957e4a3d9d30db05c7578a536950a31c200854c5c34e1edb2c
+  md5: 8393c0f7e7870b4eb45553326f81f0ff
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 69920
+  timestamp: 1727795651979
+- conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+  sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
+  md5: 515d77642eaa3639413c6b1bc3f94219
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: LGPL-2.1 and GPL-2.0
+  size: 217804
+  timestamp: 1660346976440
+- conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+  sha256: 4e2246383003acbad9682c7c63178e2e715ad0eb84f03a8df1fbfba455dfedc5
+  md5: adbfb9f45d1004a26763652246a33764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 63274
+  timestamp: 1641347623319
+- conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_6.conda
+  sha256: c37130692742cc43eedf4e23270c7d1634235acff50760025e9583f8b46b64e6
+  md5: 33a78bbc44d6550c361abb058a0556e2
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 2701749
+  timestamp: 1728364260886
+- conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
+  sha256: 8c688797ba23b9ab50cef404eca4d004a948941b6ee533ead0ff3bf52012528c
+  md5: be60c4e8efa55fddc17b4131aa47acbd
+  depends:
+  - libzlib 1.3.1 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Zlib
+  license_family: Other
+  size: 107439
+  timestamp: 1727963788936
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+  sha256: 768e30dc513568491818fb068ee867c57c514b553915536da09e5d10b4ebf3c3
+  md5: 9a17230f95733c04dc40a2b1e5491d74
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 349143
+  timestamp: 1714723445995

--- a/carbon_flux/pixi.toml
+++ b/carbon_flux/pixi.toml
@@ -27,8 +27,8 @@ matplotlib = ">=3.8.4"
 pandas = ">=2.2.2"
 scikit-learn = ">=1.5.1"
 numpy = ">=1.26.4"
-pip = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [activation.env]
 AWS_EC2_METADATA_DISABLED = "True"

--- a/carbon_flux/pixi.toml
+++ b/carbon_flux/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "carbon_flux"
-channels = ["nodefaults", "conda-forge"]
+channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/carbon_flux/pixi.toml
+++ b/carbon_flux/pixi.toml
@@ -1,0 +1,47 @@
+[workspace]
+name = "carbon_flux"
+channels = ["nodefaults", "conda-forge"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2018-11-28"
+maintainers = ["jbednar", "jlstevens"]
+categories = ["Other Sciences"]
+labels = ["hvplot", "panel", "datashader", "geoviews", "scikit-learn", "dask", "bokeh"]
+description = "Analysis of NASA Goddard/University of Alabama carbon monitoring project NEE Data Fusion"
+
+[dependencies]
+python = "3.11.*"
+awscli = ">=2.18.8"
+notebook = "<7"
+bokeh = ">=3.4.1"
+dask = ">=2024.5.0"
+colorcet = ">=3.1.0"
+datashader = ">=0.16.3"
+hvplot = ">=0.10.0"
+fastparquet = ">=2024.2.0"
+holoviews = ">=1.20.0"
+geoviews = ">=1.12.0"
+param = ">=2.1.1"
+matplotlib = ">=3.8.4"
+pandas = ">=2.2.2"
+scikit-learn = ">=1.5.1"
+numpy = ">=1.26.4"
+pip = "*"
+wheel = "*"
+
+[activation.env]
+AWS_EC2_METADATA_DISABLED = "True"
+
+[tasks.pre-build]
+cmd = "aws s3 sync s3://earth-data/carbon_flux/nee_data_fusion/ data/ --no-sign-request --exclude \"*\" --include \"*.csv\""
+depends-on = ["download"]
+
+[tasks.notebook]
+cmd = "jupyter notebook carbon_flux.ipynb"
+depends-on = ["download"]
+
+[tasks.download]
+env = { FILENAME = "data/allflux_metadata.txt" }
+cmd = "mkdir -p data && curl -fsSL -o $FILENAME https://earth-data.s3.amazonaws.com/carbon_flux/nee_data_fusion/allflux_metadata.txt"
+outputs = ["data/allflux_metadata.txt"]

--- a/census/pixi.lock
+++ b/census/pixi.lock
@@ -1,0 +1,11759 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.60.0-py310h5dc88bb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.0.1-py310h7cbd5c2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2023.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2023.5.0-pyhd8ed1ab_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.10.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aom-3.6.0-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-25.1.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py310h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-19.0.0-hfcf91c8_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/asttokens-3.0.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-25.4.0-py310h06a4308_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-auth-0.8.5-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-cal-0.8.5-hdbd6064_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.11.1-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-compression-0.3.1-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.5.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-http-0.9.3-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-io-0.17.0-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-mqtt-0.12.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-s3-0.7.11-hdbd6064_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-sdkutils-0.2.3-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.2.3-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-crt-cpp-0.31.0-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.11.528-h74f24ce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.14.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bleach-6.3.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.2.1-py310h2f386ee_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py310h6a678d5_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlicffi-1.0.9.2-py310h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2025.12.2-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cairo-1.16.0-he5ede1b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2026.01.04-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py310h1fdaa30_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/charset-normalizer-3.4.4-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.2.1-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.1.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.3.1-py310hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cramjam-2.9.1-py310h922eef2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cycler-0.12.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-1.0.1-py310h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.15.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dav1d-1.2.1-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.8.11-py310h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/decorator-5.2.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.3.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/executing-2.2.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.7.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-2024.2.0-py310ha9d4c09_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.14.1-h55d465d_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.55.3-py310h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.13.3-h4a9f257_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fribidi-1.0.10-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2026.1.0-py310h7040dfc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/graphite2-1.3.14-h295c915_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/harfbuzz-10.2.0-hdfddeaa_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.16.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.11-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-8.7.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.30.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.6-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.25.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2025.9.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.9.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.12.0-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.17.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.5.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.3.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.8-py310h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.21.3-h143b758_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.16-h92b89f2_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-4.0.0-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libabseil-20250127.0-cxx17_h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libavif-1.1.1-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.14.1-h31d0fb7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.22-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-8.2.0-hdf63c60_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libglib-2.84.2-h37c7471_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgrpc-1.71.0-h2d74bed_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hecde1de_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libopenblas-0.3.29-ha39b09d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-5.29.3-h3cdef7c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libre2-11-2024.07.02-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.11.1-h251f7ec_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.7.0-hde9077f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.17.0-h9b100fa_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.13.8-hfdd30dd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.43.0-py310h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py310h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.10-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-3.0.2-py310h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.10.0-py310hbfdbfaf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.2.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.5.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-3.1.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.1.1-py310h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-1.0.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.3.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.10.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.16.6-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-core-7.16.6-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-pandoc-7.16.6-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.4-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py310heeff2f4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py310h8a23956_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-h0d4d230_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.17-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-2.1.1-hd396ef6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.7.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-25.0-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandoc-3.8-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandocfilters-1.5.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.2.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/parso-0.8.5-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pexpect-4.9.0-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-11.3.0-py310hb1c3d2d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pixman-0.40.0-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-4.5.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.21.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.52-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py310h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pthread-stubs-0.3-h0ce48e5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pure_eval-0.2.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-19.0.0-py310h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pycparser-2.23-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.6.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.19.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.2.5-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.10.18-h1a3bd86_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py310h06a4308_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.21.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-4.0.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.6.2-py310h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python_abi-3.10-3_cp310.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2025.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.6-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py310h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py310h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2024.07.02-hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.37.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.5-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.22.3-py310h4aa5aa6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/s2n-1.5.14-hdbd6064_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.15.3-py310h5e4e545_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-80.9.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/six-1.17.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/stack_data-0.6.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tblib-3.2.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.18.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.4.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h993c535_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-1.1.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.5.1-py310h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.67.1-py310h7040dfc_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.15.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.15.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py310h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.5.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wcwidth-0.2.14-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.45.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libx11-1.8.12-h9b100fa_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxau-1.0.12-h9b100fa_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxdmcp-1.1.5-h9b100fa_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxext-1.3.6-h9b100fa_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxrender-0.9.12-h9b100fa_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-xorgproto-2024.1-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2025.4.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.6.4-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.23.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/html5lib-1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/importlib_metadata-8.7.0-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-25.3-pyhc872135_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.52-hd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2025.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2025c-he532380_0.tar.bz2
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2023.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2023.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.0.1-py310h5e4fcda_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.10-2_cp310.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/importlib_metadata-8.7.0-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-25.3-pyhc872135_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.52-hd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2025.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2025c-he532380_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.7.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aom-3.6.0-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py310h46256e1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-19.0.0-hb704434_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/asttokens-3.0.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.3.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-auth-0.9.0-h46256e1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-cal-0.9.2-h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.12.3-h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-compression-0.3.1-h46256e1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.5.5-h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-http-0.10.2-h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-io-0.20.1-h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-mqtt-0.13.2-he61ece7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-s3-0.8.3-h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-sdkutils-0.2.4-h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.2.7-h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-crt-cpp-0.32.10-h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.11.528-he026a02_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.13.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bleach-6.2.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py310h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py310h6d0c2b6_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotlicffi-1.0.9.2-py310h6d0c2b6_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2025.7.15-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cairo-1.16.0-h08824b9_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2025.8.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py310h9205ec4_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.2.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.1.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.3.1-py310h1962661_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cramjam-2.9.1-py310hc8aab72_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-1.0.1-py310h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.15.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py310hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dav1d-1.2.1-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.8.11-py310h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.2.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/expat-2.7.1-h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-2024.2.0-py310h7b7cdfe_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fontconfig-2.14.1-h269ac6a_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.55.3-py310h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.13.3-h02243ff_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fribidi-1.0.10-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2025.7.0-py310he13d532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gettext-0.21.0-h4e8c18a_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/graphite2-1.3.14-he9d5cce_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/harfbuzz-10.2.0-h060d35a_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.16.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py310hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.30.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.6-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.25.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.8.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.12.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.16.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.5.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.3.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.8-py310h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.16-h31d93a5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-4.0.0-h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libabseil-20250127.0-cxx17_h548131f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libavif-1.1.1-h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h46256e1_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h46256e1_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h46256e1_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.14.1-h1448931_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-19.1.7-haebbb44_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.22-h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libglib-2.84.2-heb90364_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgrpc-1.71.0-hf2926fd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.29-h3f8574a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-5.29.3-h66a43dd_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libre2-11-2024.07.02-hab2016f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.11.1-h3a17b82_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.7.0-h2dfa3ea_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.13.8-h6070cd6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-19.1.7-h5048363_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.44.0-py310hfa5e528_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-4.3.2-py310h46256e1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.8-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py310hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-3.0.2-py310h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.10.0-py310h919b35b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-3.1.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.1.1-py310h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.3.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.10.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.6-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-core-7.16.6-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-pandoc-7.16.6-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.5-h923df54_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.61.2-py310h2d33a94_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py310hf6dca73_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py310hd8f4981_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-h2d09ccc_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.17-hee2dfae_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-2.1.1-h4dda5a6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-25.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandoc-2.12-hecd8cb5_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/parso-0.8.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pcre2-10.42-h9b97e30_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pexpect-4.9.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-11.3.0-py310h25d8182_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pixman-0.46.4-hb254d66_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-4.3.7-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.21.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py310h46256e1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-19.0.0-py310h6d0c2b6_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.19.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.2.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.10.18-hc958d9f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py310hecd8cb5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.20.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-3.2.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.6.2-py310h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2025.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py310h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py310h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2024.07.02-h1962661_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.3-h49f2429_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.22.3-py310h83de92b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.15.3-py310h97975f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py310hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-78.1.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/six-1.17.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.50.2-hc8b0dd6_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tblib-3.1.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.4.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.15-h3a5a201_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-1.0.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.5.1-py310h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.67.1-py310h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.12.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.12.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py310h46256e1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.5.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wcwidth-0.2.13-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py310hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.45.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py310hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.6.4-h46256e1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.21.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2023.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2023.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.2-h8088a28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-devel-5.8.2-h8088a28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.51.2-h1b79a29_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.0-h5503f6c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.0.1-py310h1cdf563_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.19-hcd7f573_2_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.8.2-hd0f0c4f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-gpl-tools-5.8.2-hd0f0c4f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-tools-5.8.2-h8088a28_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/html5lib-1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/importlib_metadata-8.7.0-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-25.3-pyhc872135_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.52-hd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2025.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2025c-he532380_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.10.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aom-3.12.1-ha237518_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.4-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-25.1.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-25.1.0-py310h254cc4a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-21.0.0-hc027f7d_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/asttokens-3.0.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-25.4.0-py310hca03da5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-auth-0.9.0-h79febb2_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-cal-0.9.2-h79febb2_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.12.4-h79febb2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-compression-0.3.1-h79febb2_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.5.6-h79febb2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-http-0.10.4-h79febb2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-io-0.21.4-h79febb2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-mqtt-0.13.3-h387b88a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-s3-0.8.7-h79febb2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-sdkutils-0.2.4-h79febb2_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.2.7-h79febb2_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-crt-cpp-0.34.0-hee39554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.11.638-h35fa3df_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.14.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bleach-6.3.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py310h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotlicffi-1.2.0.0-py310h50f4ffc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.34.5-h2ca31fc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2025.12.2-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cairo-1.18.4-h191e429_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2026.01.04-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-2.0.0-py310h73c2a22_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/charset-normalizer-3.4.4-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.2.1-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.1.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.3.1-py310h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cramjam-2.11.0-py310h6fe787a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cycler-0.12.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-1.1.0-py310haa24f5a_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.15.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dav1d-1.2.1-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.8.16-py310h50f4ffc_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/decorator-5.2.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.3.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/executing-2.2.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/expat-2.7.3-h50f4ffc_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-2025.12.0-py310h03d0aa3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fontconfig-2.15.0-h29935d0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.61.0-py310haa24f5a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.13.3-h47d26ad_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fribidi-1.0.16-h8859324_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2026.1.0-py310h7eb115d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-0.21.0-hbdbcc25_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/graphite2-1.3.14-hc377ac9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/harfbuzz-10.2.0-he637ebf_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.16.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.11-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-8.7.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.30.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jansson-2.14-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.6-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9f-h2f69dba_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.25.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2025.9.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.9.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.12.0-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.17.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.5.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.3.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.9-py310haeee614_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.17-h7418793_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-4.0.0-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libabseil-20250814.1-cxx17_hbea547f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libavif-1.3.0-h839b4eb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.2.0-hbd7815e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.2.0-h1e834b2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.2.0-h5439a07_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.17.0-h5bd1c32_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-20.1.8-hd7fd590_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.22-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libexpat-2.7.3-h50f4ffc_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-15.2.0-hb654fa1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libglib-2.86.3-hcacd345_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgrpc-1.74.1-h941cc20_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libhwloc-2.12.1-default_h2915d5d_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libidn2-2.3.8-h9681e36_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm20-20.1.8-h1701f07_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.67.1-h8189af8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.30-hf2bb037_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenjpeg-2.5.4-haa24f5a_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.50-h5c318fc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-6.33.0-h6acce77_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libre2-11-2025.11.05-hd4f4e8d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.20-h897f8a9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.11.1-h3e2b118_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.22.0-hbe873a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.7.1-h367c460_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libunistring-1.3-h1799b2a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.6.0-h92b2d59_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.13.9-h528a072_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzlib-1.3.1-h5f15de7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-20.1.8-he822017_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.46.0-py310hc8eb11b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.4.5-py310hbc89d72_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.10-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-3.0.2-py310h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.10.8-py310haa222d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.2.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.5.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-3.1.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.1.1-py310h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-1.0.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.3.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.10.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.6-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-core-7.16.6-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-pandoc-7.16.6-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.5-hee39554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.4-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.63.1-py310hadc56cb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py310h901140f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py310hae06d03_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-2.2.0-hd6530ca_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.7.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-25.0-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandoc-3.8-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandocfilters-1.5.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/parso-0.8.5-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre2-10.46-h1dacb4a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pexpect-4.9.0-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-12.0.0-py310he2d6fe4_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pixman-0.46.4-h09dc60e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-4.5.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.21.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.52-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-7.0.0-py310haa24f5a_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pure_eval-0.2.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-21.0.0-py310h3f644e9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycparser-2.23-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.6.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.19.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.2.5-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py310hca03da5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.21.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-4.0.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.7.5-py310h3d52de1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python_abi-3.10-3_cp310.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2025.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.6-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.3-py310h091b9d3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py310h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2025.11.05-h1413154_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.3-h0b18652_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.37.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.5-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.28.0-py310h931abed_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.15.3-py310h132fc3c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-80.9.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/six-1.17.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.2.2-hc0f95ea_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/stack_data-0.6.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2022.3.0-h50665e7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tblib-3.2.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.18.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.4.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.15-hcd8a7d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-1.1.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.5.4-py310haa24f5a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.67.1-py310h7eb115d_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.15.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.15.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.6.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wcwidth-0.2.14-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.45.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2025.4.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h2c7f8f0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.23.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.3.1-h5f15de7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.7-h817c040_0.tar.bz2
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2023.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2023.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.0.1-py310h1c4a608_1.conda
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/html5lib-1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/importlib_metadata-8.7.0-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-25.3-pyhc872135_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.52-hd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2025.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2025c-he532380_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.10.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aom-3.12.1-h00a0c3c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-25.1.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-25.1.0-py310h02ab6af_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-21.0.0-hcdc3a1c_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/asttokens-3.0.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-25.4.0-py310haa95532_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-auth-0.9.0-h02ab6af_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-cal-0.9.2-h02ab6af_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.12.4-h02ab6af_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-compression-0.3.1-h02ab6af_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.5.6-h02ab6af_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-http-0.10.4-h02ab6af_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-io-0.21.4-h02ab6af_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-mqtt-0.13.3-h02ab6af_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-s3-0.8.7-h02ab6af_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-sdkutils-0.2.4-h02ab6af_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.2.7-h02ab6af_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-crt-cpp-0.34.0-h885b0b7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.11.638-hf0af688_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.14.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bleach-6.3.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py310h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotlicffi-1.2.0.0-py310h885b0b7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.34.5-h731ff69_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2025.12.2-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cairo-1.18.4-he9e932c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2026.01.04-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-2.0.0-py310h02ab6af_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/charset-normalizer-3.4.4-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.2.1-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.1.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.3.1-py310h214f63a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cramjam-2.11.0-py310h7b75cbd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cycler-0.12.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-1.1.0-py310h02ab6af_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.15.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/dav1d-1.2.1-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.8.16-py310h885b0b7_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/decorator-5.2.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.3.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/executing-2.2.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/expat-2.7.3-h885b0b7_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-2025.12.0-py310h540bb41_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fontconfig-2.15.0-hd211d86_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.61.0-py310h02ab6af_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freeglut-3.8.0-hfcef157_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.13.3-h0620614_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fribidi-1.0.16-haf45083_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2026.1.0-py310h4442805_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/graphite2-1.3.14-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/harfbuzz-10.2.0-he2f9f60_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.16.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.11-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-8.7.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2025.0.0-haa95532_1164.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.30.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.6-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9f-ha349fce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.25.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2025.9.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.9.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.12.0-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.17.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.5.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.3.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.9-py310h03f52e7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.17-h3732fa5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-4.0.0-h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libabseil-20250814.1-cxx17_hcd311fc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libavif-1.3.0-h5bd13ec_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.2.0-h907acca_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.2.0-h02c67a5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.2.0-h483e6b9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.17.0-h97e0424_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.22-h5bf469e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libexpat-2.7.3-h885b0b7_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libglib-2.86.3-h9bccc14_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libgrpc-1.74.1-hde67744_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libhwloc-2.12.1-default_hfa10c62_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libllvm20-20.1.8-h3aa9ab2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libopenjpeg-2.5.4-h02ab6af_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.50-h46444df_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-6.33.0-h2a56892_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libre2-11-2025.11.05-ha6b10e7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.20-h83e8143_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.11.1-h2addb87_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.22.0-ha2884a9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.7.1-h3a18249_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.6.0-hbf3958f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.13.9-h6201b9f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libzlib-1.3.1-h02ab6af_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.46.0-py310hd5b4e5d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.4.5-py310hb1efef3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.10-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-3.0.2-py310h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.10.8-py310h26e45b9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.2.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.5.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-3.1.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2025.0.0-h5da7b33_930.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.5.2-py310h0b37514_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-2.1.1-py310h300f80d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.3.0-py310ha5e6156_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.1.1-py310h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-1.0.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.3.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.10.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.6-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-core-7.16.6-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-pandoc-7.16.6-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.4-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.63.1-py310h54bf9d2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py310h12f7302_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py310he4e2855_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.18-h543e019_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/orc-2.2.0-h79e1e1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.7.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-25.0-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandoc-3.8-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandocfilters-1.5.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/parso-0.8.5-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pcre2-10.46-h5740b90_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-12.0.0-py310h4212202_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pixman-0.46.4-h4043f72_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-4.5.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.21.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.52-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-7.0.0-py310h02ab6af_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pure_eval-0.2.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-21.0.0-py310h42c1672_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pycparser-2.23-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.6.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.19.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.2.5-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.10.19-h981015d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py310haa95532_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.21.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-4.0.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.7.5-py310h5823743_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python_abi-3.10-3_cp310.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2025.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.6-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-311-py310h885b0b7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.15-py310h72d21ff_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.3-py310hb9a58be_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py310h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2025.11.05-hc24cdf5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.37.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.5-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.28.0-py310h114bc41_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.15.3-py310h1bbe36f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-80.9.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/six-1.17.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.2.2-hab6b7b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.51.1-hda9a48d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/stack_data-0.6.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2022.3.0-h90c84d6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-devel-2022.3.0-h90c84d6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tblib-3.2.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.18.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.4.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.15-hf199647_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-1.1.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.5.4-py310h02ab6af_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.67.1-py310h4442805_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.15.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.15.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ucrt-10.0.22621.0-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.6.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.42-haa95532_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc14_runtime-14.44.35208-h4927774_10.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.44.35208-ha6b5a95_10.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wcwidth-0.2.14-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.45.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2025.4.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.6.4-h4754444_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-h6c54ac7_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.23.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.3.1-h02ab6af_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.7-h56299aa_0.tar.bz2
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  license: None
+  size: 2562
+  timestamp: 1578324546067
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23621
+  timestamp: 1650670423406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
+  sha256: 53eb8a79365e58849e7b1a068d31f4f9e718dc938d6f2c03e960345739a03569
+  md5: 3cb76c3f10d3bc7f1105b2fc9db984df
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 14.2.0 h77fa898_1
+  - libgcc-ng ==14.2.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 848745
+  timestamp: 1729027721139
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+  sha256: 3a76969c80e9af8b6e7a55090088bc41da4cffcde9e2c71b17f44d37b7cb87f7
+  md5: e39480b9ca41323497b05492a63bc35b
+  depends:
+  - libgcc 14.2.0 h77fa898_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54142
+  timestamp: 1729027726517
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
+  sha256: d149a37ca73611e425041f33b9d8dbed6e52ec506fe8cc1fc0ee054bddeb6d5d
+  md5: 9822b874ea29af082e5d36098d25427d
+  depends:
+  - libgcc >=14.2.0
+  constrains:
+  - libgfortran 14.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1462645
+  timestamp: 1729027735353
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+  sha256: 1911c29975ec99b6b906904040c855772ccb265a1c79d5d75c8ceec4ed89cd63
+  md5: cc3573974587f12dda90d96e3e55a702
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 460992
+  timestamp: 1729027639220
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+  sha256: 4661af0eb9bdcbb5fb33e5d0023b001ad4be828fccdcc56500059d56f9869462
+  md5: 234a5554c53625688d51062645337328
+  depends:
+  - libgcc 14.2.0 h77fa898_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3893695
+  timestamp: 1729027746910
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+  sha256: 25bb30b827d4f6d6f0522cc0579e431695503822f144043b93c50237017fffd8
+  md5: 8371ac6457591af2cf6159439c1fd051
+  depends:
+  - libstdcxx 14.2.0 hc0a3c3a_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54105
+  timestamp: 1729027780628
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.60.0-py310h5dc88bb_0.conda
+  sha256: c76c5baa087c2be3374bdb5eee37caf0c70f390c02a48aeb5e4337b600e5e319
+  md5: 73e2e2c0ffad216572ce01952ff0099c
+  depends:
+  - _openmp_mutex >=4.5
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - cuda-version >=11.2
+  - libopenblas !=0.3.6
+  - scipy >=1.0
+  - tbb >=2021.6.0
+  - cuda-python >=11.6
+  - cudatoolkit >=11.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4376821
+  timestamp: 1718888164099
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.0.1-py310h7cbd5c2_1.conda
+  sha256: 4af68421353f552c6d321bfc8b76040eaa89fa35c0a7854be8acaddf154be63e
+  md5: 25fc16ee9a1df69e91c8213530f2cc8c
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.21.6,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.10.* *_cp310
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12276275
+  timestamp: 1683494701898
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-2023.5.0-pyhd8ed1ab_0.conda
+  sha256: 45e25cb3be14adee51c2eb3b488dc495d28d48f95d77901050a85b9557ae668b
+  md5: 01400176e0f139c44f96d5fa69b1ada7
+  depends:
+  - bokeh >=2.4.2,!=3.0.*
+  - cytoolz >=0.10.0
+  - dask-core >=2023.5.0,<2023.5.1.0a0
+  - distributed >=2023.5.0,<2023.5.1.0a0
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.21
+  - pandas >=1.3
+  - pyarrow >=7.0
+  - python >=3.8
+  constrains:
+  - openssl !=1.1.1e
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7387
+  timestamp: 1683912494502
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.5.0-pyhd8ed1ab_0.conda
+  sha256: fb32160cb448e9cf0462d22f07235e3dc43894cc2d36e1029303e09e05f2e7ce
+  md5: 03ed2d040648a5ba1063bf1cb0d87b78
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib_metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.8
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 844935
+  timestamp: 1683908850606
+- conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2023.5.0-pyhd8ed1ab_0.conda
+  sha256: 00e9a9c276149f8446d9fdc870808fea2967d133dd82a43591adbc3cab33cc25
+  md5: 85a1eddc3a535eca09d9d7e107cc473b
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - cytoolz >=0.10.1
+  - dask-core >=2023.5.0,<2023.5.1.0a0
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.0
+  - packaging >=20.0
+  - psutil >=5.7.0
+  - python >=3.8
+  - pyyaml >=5.3.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.10.0
+  - tornado >=6.0.3
+  - urllib3 >=1.24.3
+  - zict >=2.2.0
+  constrains:
+  - openssl !=1.1.1e
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 767826
+  timestamp: 1683910921725
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+  sha256: c18ab120a0613ada4391b15981d86ff777b5690ca461ea7e9e49531e8f374745
+  md5: 63ccfdc3a3ce25b027b8767eb722fca8
+  depends:
+  - python >=3.9
+  - zipp >=3.20
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 34641
+  timestamp: 1747934053147
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+  sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae
+  md5: edb16f14d920fb3faf17f5ce582942d6
+  depends:
+  - python >=3.10
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.52
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 273927
+  timestamp: 1756321848365
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.0.1-py310h5e4fcda_1.conda
+  sha256: e82dc86f8caf3d29dcfd1d6cb412594c1f1b7bba95708701240eb0e4c92a57ad
+  md5: 24acbaa1a659e357cba1ad1cf4eb9bac
+  depends:
+  - libcxx >=15.0.7
+  - numpy >=1.21.6,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.10.* *_cp310
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11656203
+  timestamp: 1683494933685
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.10-2_cp310.tar.bz2
+  sha256: c79e3da64d6f79377d58d6313463001c7520a23141466816ccb07aed8700afc2
+  md5: 502ca4a8b43b424316f380d864832877
+  depends:
+  - python 3.10.*
+  constrains:
+  - pypy <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4107
+  timestamp: 1633504549137
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.2-h8088a28_0.conda
+  sha256: 7bfc7ffb2d6a9629357a70d4eadeadb6f88fa26ebc28f606b1c1e5e5ed99dc7e
+  md5: 009f0d956d7bfb00de86901d16e486c7
+  depends:
+  - __osx >=11.0
+  constrains:
+  - xz 5.8.2.*
+  license: 0BSD
+  size: 92242
+  timestamp: 1768752982486
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-devel-5.8.2-h8088a28_0.conda
+  sha256: 755db226a10a0b7776d4019f76c7dfe1eb6b495bc6791a143d2db88dec32ea52
+  md5: ffd253880bfba4a94d048661d57e4f79
+  depends:
+  - __osx >=11.0
+  - liblzma 5.8.2 h8088a28_0
+  license: 0BSD
+  size: 117463
+  timestamp: 1768753005332
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.51.2-h1b79a29_0.conda
+  sha256: f942afee5568a0bfba020e52c3f22b788e14017a8dc302652d2ca500756a8a5a
+  md5: faedef456ba5004af365d450eb38217d
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: blessing
+  size: 905482
+  timestamp: 1768148270069
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.0-h5503f6c_0.conda
+  sha256: ebe93dafcc09e099782fe3907485d4e1671296bc14f8c383cb6f3dfebb773988
+  md5: b34dc4172653c13dcf453862f251af2b
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 3108371
+  timestamp: 1762839712322
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.0.1-py310h1cdf563_1.conda
+  sha256: 3c58acbef4b6f2c36bbd871420ab25510efe6ed6e45725e9865818fcad6dbc1e
+  md5: bfd0dc55031e132249605f1751ce3d90
+  depends:
+  - libcxx >=15.0.7
+  - numpy >=1.21.6,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.10.* *_cp310
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11699175
+  timestamp: 1683495414497
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.19-hcd7f573_2_cpython.conda
+  sha256: 7bac6cc075d1d7897f06fa14c1bc87eb16b9524c6002e0c72b0ed3326af51695
+  md5: feb559b139819a7326f992711cb50872
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.7.1,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libsqlite >=3.50.4,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.5.4,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.10.* *_cp310
+  license: Python-2.0
+  size: 11674631
+  timestamp: 1761173465015
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.8.2-hd0f0c4f_0.conda
+  sha256: 1f16a26d80e20db470196baa680906af92e31e6d873d2f7bc1c79c499797a261
+  md5: b86b8e8daf1c8ac572bff820e6160473
+  depends:
+  - __osx >=11.0
+  - liblzma 5.8.2 h8088a28_0
+  - liblzma-devel 5.8.2 h8088a28_0
+  - xz-gpl-tools 5.8.2 hd0f0c4f_0
+  - xz-tools 5.8.2 h8088a28_0
+  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  size: 24143
+  timestamp: 1768753074129
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-gpl-tools-5.8.2-hd0f0c4f_0.conda
+  sha256: 63ebc0691cb36c293b5c829237598b336efd7f368b4c75a64544e70ae6ac3582
+  md5: 3c8f80ff660321d5259ebc3743265566
+  depends:
+  - __osx >=11.0
+  - liblzma 5.8.2 h8088a28_0
+  constrains:
+  - xz 5.8.2.*
+  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  size: 34000
+  timestamp: 1768753049327
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-tools-5.8.2-h8088a28_0.conda
+  sha256: 2059328bb4eeb8c30e9d187a67c66ca3d848fbc3025547f99f846bc7aadb6423
+  md5: c2650d5190be15af804ae1d8a76b0cca
+  depends:
+  - __osx >=11.0
+  - liblzma 5.8.2 h8088a28_0
+  constrains:
+  - xz 5.8.2.*
+  license: 0BSD AND LGPL-2.1-or-later
+  size: 85638
+  timestamp: 1768753028023
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.0.1-py310h1c4a608_1.conda
+  sha256: e25db651e4f03be56b73745d8e06ffad59a5ea7ab337015cfb7e8c3643b2103f
+  md5: c634a1e9a4e0362056ec1343bd5f8ece
+  depends:
+  - numpy >=1.21.6,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.10.* *_cp310
+  - pytz >=2020.1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10967789
+  timestamp: 1683494697127
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.10.0-py310h06a4308_0.tar.bz2
+  sha256: abbfda764359368de21c7436312c6563b30cd8d8599fe6fa342a34b4f7ba8d53
+  md5: 5569e34c441e89bee95ad58b6d234723
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.10,<3.11.0a0
+  - sniffio >=1.1
+  - typing_extensions >=4.5
+  constrains:
+  - trio >=0.26.1
+  - uvloop >=0.21
+  license: MIT
+  license_family: MIT
+  size: 234126
+  timestamp: 1758622433186
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aom-3.6.0-h6a678d5_0.tar.bz2
+  sha256: daddb86497522fd6fb8447c0aaebb763e685348b86fadb4ca6425f50f9d85f08
+  md5: 2d31ed3210e7119160eb02564154b4c1
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2958771
+  timestamp: 1688660715607
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-25.1.0-py310h06a4308_0.tar.bz2
+  sha256: 5d770fe7a7b35df064e0d9c305a2f8621a3ab8903a73aa4bcd69590123f4bfd7
+  md5: 71214c4fc2f59a08d85835f35dde8915
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 30003
+  timestamp: 1766067878915
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py310h5eee18b_1.tar.bz2
+  sha256: 37044ec265a347e5046d26bea0ba8c413cf394ae982443d016f979ff83cf8aec
+  md5: b25aaff8fb956ee9884149f047044529
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 35243
+  timestamp: 1736182472515
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-19.0.0-hfcf91c8_3.tar.bz2
+  sha256: eafc932db81db5d5de11955dc43e14f5d3613f68e73bde3c80d50ae1f51c8d84
+  md5: 80c9fac93e83d88a798b446c90a98c97
+  depends:
+  - aws-crt-cpp >=0.31.0,<0.31.1.0a0
+  - aws-sdk-cpp >=1.11.528,<1.11.529.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.5.0,<0.6.0a0
+  - libabseil * cxx17*
+  - libabseil >=20250127.0,<20250127.1.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libgcc-ng >=11.2.0
+  - libgrpc >=1.71.0,<1.72.0a0
+  - libprotobuf >=5.29.3,<5.29.4.0a0
+  - libre2-11 >=2024.7.2,<2025.0a0
+  - libstdcxx-ng >=11.2.0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.16,<4.0a0
+  - orc >=2.1.1,<2.1.2.0a0
+  - re2
+  - snappy >=1.1.10,<2.0a0
+  - utf8proc >=2.6.1,<2.9.0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 14351200
+  timestamp: 1752071210807
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/asttokens-3.0.0-py310h06a4308_0.tar.bz2
+  sha256: e2ad4b4fa11972e4e571c046db88fb7d43c0b28ba14ace893a8d93ab2fbf2b81
+  md5: 9a3e5b47264bd6638d1e18f06cbaa0da
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - astroid >=2, <4
+  license: Apache-2.0
+  license_family: Apache
+  size: 41338
+  timestamp: 1743630548795
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-25.4.0-py310h06a4308_2.tar.bz2
+  sha256: b855b5873ef5e922c5a6e186bc7dd68bdc61b9d230f922b05f366b26ff4dd29c
+  md5: 29cdc9324b4e79917fd81b8be9739878
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 147932
+  timestamp: 1762356898864
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-auth-0.8.5-h5eee18b_0.tar.bz2
+  sha256: 6f083d45d1b88acba5b659257d13bc7977384af01d71feb79db99c61247c9824
+  md5: a1dea5958821d769433dece6f5bfc28b
+  depends:
+  - aws-c-cal >=0.8.5,<0.8.6.0a0
+  - aws-c-common >=0.11.1,<0.11.2.0a0
+  - aws-c-http >=0.9.3,<0.9.4.0a0
+  - aws-c-io >=0.17.0,<0.17.1.0a0
+  - aws-c-sdkutils >=0.2.3,<0.2.4.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 113020
+  timestamp: 1741636490767
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-cal-0.8.5-hdbd6064_0.tar.bz2
+  sha256: 919165ca4af55c55692ab743fae0e0445bb2f459dfbab7049ba69b337267aa29
+  md5: 74c9b5c1d74cb02b894afc30590043ca
+  depends:
+  - aws-c-common >=0.11.1,<0.11.2.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.16,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51916
+  timestamp: 1741619298908
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.11.1-h5eee18b_0.tar.bz2
+  sha256: 299d84dc2e887b2662edeae6a7bf82e38ebe65cdacc490cdf8540a1a101a5d35
+  md5: 78afbab375162eaed27c8ad96bc678e6
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 244092
+  timestamp: 1741187507018
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-compression-0.3.1-h5eee18b_0.tar.bz2
+  sha256: 3b807bdd74ec5a32c025c467bf0366ce57deaff4db7e2e3971971fe45da256cc
+  md5: 23ac7afb17c69ab9c2c4abe151f72e88
+  depends:
+  - aws-c-common >=0.11.1,<0.11.2.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18015
+  timestamp: 1741621679895
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.5.4-h6a678d5_0.tar.bz2
+  sha256: b2314842775b0e9dd99c13429b8343aca88bfcc3892d14e1f7aa1e0822ebe6f1
+  md5: e964513a3b1a14b9d36ff2e05c53b67c
+  depends:
+  - aws-c-common >=0.11.1,<0.11.2.0a0
+  - aws-c-io >=0.17.0,<0.17.1.0a0
+  - aws-checksums >=0.2.3,<0.2.4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 54364
+  timestamp: 1741624425817
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-http-0.9.3-h5eee18b_0.tar.bz2
+  sha256: 4221e2f1d1d35621451cc81cfe5a674842281b0c80efba03d84f2c7c224bc8c0
+  md5: 3919b569ed7c4a3348cdecaf61c56d69
+  depends:
+  - aws-c-cal >=0.8.5,<0.8.6.0a0
+  - aws-c-common >=0.11.1,<0.11.2.0a0
+  - aws-c-compression >=0.3.1,<0.3.2.0a0
+  - aws-c-io >=0.17.0,<0.17.1.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 202691
+  timestamp: 1741630114714
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-io-0.17.0-h5eee18b_0.tar.bz2
+  sha256: 5406990cdecebcb3028e0a9c73e40cc8df877fdb8fd879f74bdcf5b91d132e71
+  md5: c37dbb806c7ec4b99ac6ba14585c088a
+  depends:
+  - aws-c-cal >=0.8.5,<0.8.6.0a0
+  - aws-c-common >=0.11.1,<0.11.2.0a0
+  - libgcc-ng >=11.2.0
+  - s2n >=1.5.14,<1.5.15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 162848
+  timestamp: 1741623323159
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-mqtt-0.12.2-h5eee18b_0.tar.bz2
+  sha256: fb17eb171a9a58ae446d9a87312074d2c78237a52bcc895b422873d950873033
+  md5: a27a93333136832672e53c19607290f4
+  depends:
+  - aws-c-common >=0.11.1,<0.11.2.0a0
+  - aws-c-http >=0.9.3,<0.9.4.0a0
+  - aws-c-io >=0.17.0,<0.17.1.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203968
+  timestamp: 1741633978327
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-s3-0.7.11-hdbd6064_0.tar.bz2
+  sha256: 15257a299c2e4cc7c1744ae4afaba823a0e02af2392acbf41b93ca1202c69212
+  md5: ae66d6778532b99b9e21ccf30c3ce18e
+  depends:
+  - aws-c-auth >=0.8.5,<0.8.6.0a0
+  - aws-c-cal >=0.8.5,<0.8.6.0a0
+  - aws-c-common >=0.11.1,<0.11.2.0a0
+  - aws-c-http >=0.9.3,<0.9.4.0a0
+  - aws-c-io >=0.17.0,<0.17.1.0a0
+  - aws-checksums >=0.2.3,<0.2.4.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.16,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 117898
+  timestamp: 1741640978198
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-sdkutils-0.2.3-h5eee18b_0.tar.bz2
+  sha256: 958313779f2e4ad5a8f839a7d9aead42e15ba491acffe33f8ed94e3af31bca96
+  md5: 43f69c324d8659b074846ca048107040
+  depends:
+  - aws-c-common >=0.11.1,<0.11.2.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 57176
+  timestamp: 1741618764786
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.2.3-h5eee18b_0.tar.bz2
+  sha256: 4080a560f612f7a9acae06740c0090c96c6e4223108c331edd8c765c0f159d4c
+  md5: 78d91ce1d325d466ab4726be2abbabe5
+  depends:
+  - aws-c-common >=0.11.1,<0.11.2.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 76665
+  timestamp: 1741620766571
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-crt-cpp-0.31.0-h6a678d5_0.tar.bz2
+  sha256: daf6c79d76ebee86c5a55505cf6aa78017f774e574158e4e042825eb67617b7f
+  md5: ef23f55e2ce9d7ff29ec7e453ae55ed7
+  depends:
+  - aws-c-auth >=0.8.5,<0.8.6.0a0
+  - aws-c-cal >=0.8.5,<0.8.6.0a0
+  - aws-c-common >=0.11.1,<0.11.2.0a0
+  - aws-c-event-stream >=0.5.4,<0.5.5.0a0
+  - aws-c-http >=0.9.3,<0.9.4.0a0
+  - aws-c-io >=0.17.0,<0.17.1.0a0
+  - aws-c-mqtt >=0.12.2,<0.12.3.0a0
+  - aws-c-s3 >=0.7.11,<0.7.12.0a0
+  - aws-c-sdkutils >=0.2.3,<0.2.4.0a0
+  - aws-checksums >=0.2.3,<0.2.4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 387393
+  timestamp: 1746472666358
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.11.528-h74f24ce_0.tar.bz2
+  sha256: f4fe4b8467a9ad34bc9794c7612323e85a16dd36411d4493a0f548a791700e6b
+  md5: 3c056c68455a1348d99570137925580f
+  depends:
+  - aws-c-common >=0.11.1,<0.11.2.0a0
+  - aws-c-event-stream >=0.5.4,<0.5.5.0a0
+  - aws-crt-cpp >=0.31.0,<0.31.1.0a0
+  - libcurl >=8.1.1,<9.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3963356
+  timestamp: 1746483074698
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.14.2-py310h06a4308_0.tar.bz2
+  sha256: c984f63ebf2541fe0bf36123178979bef536645582461f71447969b45711b0ef
+  md5: 2ec2b3e0904f2f4e04cd1e7cbb9da511
+  depends:
+  - python >=3.10,<3.11.0a0
+  - soupsieve >1.2
+  - typing-extensions >=4.0.0
+  license: MIT
+  license_family: MIT
+  size: 215565
+  timestamp: 1764159345301
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-openblas.tar.bz2
+  sha256: ed246aa0bf2809030f911cefd5b16a2c4de0d1b21f75f76e5178122d2213727e
+  md5: 671f6e045d03a842f379145e7fc43c0d
+  size: 49374
+  timestamp: 1528224118045
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bleach-6.3.0-py310h06a4308_0.tar.bz2
+  sha256: 0d6a0f09bd196528ffd1a852906daac1c584c78817f9c2483a1a15f755c723c9
+  md5: 51c22195cf90c95981c9220ba64809c8
+  depends:
+  - html5lib 1.1
+  - python >=3.10,<3.11.0a0
+  - webencodings
+  constrains:
+  - tinycss2 >=1.1.0,<1.5
+  license: Apache-2.0
+  license_family: Apache
+  size: 83011
+  timestamp: 1764153589371
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.2.1-py310h2f386ee_0.tar.bz2
+  sha256: a857bde1809f0d09a5d70c5f789c999477215c981a99467f830399a43d3c2ca5
+  md5: 19dd80d22dc95b7935a3460b60a6ad7d
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6466579
+  timestamp: 1690546270826
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+  sha256: 3606c8607c29229222667f66421f79df167d33043fe9245cdd4e2c4520ecc721
+  md5: eca33dcef14fa044193e43492dca8585
+  depends:
+  - libboost 1.82.0 h109eef0_2
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 10768
+  timestamp: 1696762269985
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py310h6a678d5_9.tar.bz2
+  sha256: 530a6e5a44a3c34e07b656e9dc56844163db466a653a33a1c04f6f97673b6675
+  md5: 7ad8f8fa79e8d0ac068da2b32d1b1d53
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  size: 361192
+  timestamp: 1736182598029
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlicffi-1.0.9.2-py310h6a678d5_1.tar.bz2
+  sha256: b619cb415b6ad50adb8646421497176d2c933eb664691db779619d1867d46cec
+  md5: 99534d95312f31bd604298feeed6dcf5
+  depends:
+  - cffi >=1.0.0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  size: 369154
+  timestamp: 1736182502505
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+  sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
+  md5: f5058c8d5b2994b7334f18e022105a14
+  depends:
+  - libgcc-ng >=11.2.0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 427542
+  timestamp: 1714510571510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+  sha256: 5b4c80587ae4ec915505469f79d866f27c80456156667c8548d31c67c2c1653e
+  md5: c3d6bfae757760082261779c406a880d
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 116270
+  timestamp: 1693902021950
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2025.12.2-h06a4308_0.tar.bz2
+  sha256: 95324964958e1ed79aed1355a2230717c8c94df9604bfd453eeaf09df2ffaebe
+  md5: b28be3dd7696ca4faf4750d1c5a370aa
+  license: MPL-2.0
+  license_family: Other
+  size: 135071
+  timestamp: 1764713819705
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cairo-1.16.0-he5ede1b_6.tar.bz2
+  sha256: 7d75a8ee9b6117e9157f34d7551ba284b40aa9ad0527df743adc040c62229ff7
+  md5: 568ffb2b495741473c74b28e4aa750d2
+  depends:
+  - fontconfig >=2.14.1,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libglib >=2.78.4,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - pixman >=0.40.0,<1.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: LGPL-2.1-or-later or MPL-1.1
+  license_family: LGPL
+  size: 1583916
+  timestamp: 1748950812947
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2026.01.04-py310h06a4308_0.tar.bz2
+  sha256: 1e995ddea8928d81e73d0611a57ea8dafc34c88adbab2d72d2f8a890cd61702c
+  md5: 801b984c7eee035d935cdd9f6158c4c9
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 154321
+  timestamp: 1767659158857
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py310h1fdaa30_1.tar.bz2
+  sha256: 512cf77e1ca8e532217268c856783e48e6c642742b7325ba50784aa59fe5a5e3
+  md5: 280f1924ea783118998cfc20ab196d46
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 242947
+  timestamp: 1736182601685
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/charset-normalizer-3.4.4-py310h06a4308_0.tar.bz2
+  sha256: 42c9c51f5fc2d56a7408116adadc628e80d9eb776a2d969a9e46d1c9e245544b
+  md5: 32d9d6cf5594605c7b4456b9ff5274e8
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 84312
+  timestamp: 1761744890463
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.2.1-py310h06a4308_1.tar.bz2
+  sha256: abcf61ae4bf99635771816e33de5b18b206c6481f5ed4c266dda4ce3ba447fc3
+  md5: 05ef57693fdea278146d9b5601ab00fa
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 284210
+  timestamp: 1764332308741
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.1.2-py310h06a4308_0.tar.bz2
+  sha256: 296afa98ab7b46d4df62b35b99f22f269ea23a48c7a50ce7626d72258c3c1624
+  md5: 3e123b2130ee1cdde1d939bd5fb69e9c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64645
+  timestamp: 1764930505723
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py310h06a4308_0.tar.bz2
+  sha256: 4b9150ff168d17abf2e28a14e436e10653d87082c8865f1dae6081932d572c0a
+  md5: 3b3d0971e24b952e00cc35e7193eeade
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 502279
+  timestamp: 1709758414744
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.3-py310h06a4308_0.tar.bz2
+  sha256: 917b1f2ef3f429f7d56484736eb4a83c2bcbf73a4cbb8681a9ca7dc21eb565cf
+  md5: 126e41a84e468e937e6bcb87b0a14268
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14935
+  timestamp: 1763119209814
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.3.1-py310hdb19cb5_0.tar.bz2
+  sha256: b5a23181c83817e0467d06f8e49b3ef04e2eba9b8dd7059dbd8fde0d4fca34c2
+  md5: d5535fe50ad08cf5d44a0b1a9d53a34e
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.23
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281389
+  timestamp: 1732540260436
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cramjam-2.9.1-py310h922eef2_0.tar.bz2
+  sha256: c25f6ad2fc00da6906545f04e919a09420596374ed7f966c7e39a6a386f322fc
+  md5: 33b125d02a6ad6160bfeec2ea704ebb1
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1702343
+  timestamp: 1742393518779
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cycler-0.12.1-py310h06a4308_0.tar.bz2
+  sha256: 668393e866c3006c8996b8fbfb3585e066ab8c51b2f723df750918f693394456
+  md5: ed4c2057124c0fc252f250e05389a506
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17250
+  timestamp: 1766067933258
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-1.0.1-py310h5eee18b_0.tar.bz2
+  sha256: b06d02013a56821311dfaf0714369bb9bb651cb0861e6bc09d33d77f7a2b8f00
+  md5: dd26ee06b9fb1b94c781bcccce95ce93
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  - toolz >=0.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 409831
+  timestamp: 1736803962478
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.15.1-py310h06a4308_0.tar.bz2
+  sha256: ed8a95624b732e3d231e25699f194ea59ab08a6fc3be77a785e69498dcd08e6a
+  md5: 7f2b0e05b7e2e4ff11c5af694b395706
+  depends:
+  - colorcet
+  - dask-core
+  - datashape
+  - numba
+  - numpy <2.0a0
+  - pandas
+  - param <2.0.0a0
+  - pillow
+  - pyct
+  - python >=3.10,<3.11.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17653851
+  timestamp: 1689587803745
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py310h06a4308_1.tar.bz2
+  sha256: c33f7bed0d5df9b603477cfab6687d3390110320a5e8cc02d981fff81f4ab799
+  md5: 091e596b0565d13b12bf261aaad3cde7
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 103863
+  timestamp: 1640808953510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dav1d-1.2.1-h5eee18b_0.tar.bz2
+  sha256: 9f015999d24a376602b5876f542bcb41a7db66fa73064091cccdc1b06195392c
+  md5: 29684f3832212a3c977960c62c421119
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 889577
+  timestamp: 1688746033126
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.8.11-py310h6a678d5_0.tar.bz2
+  sha256: 8f53bfc56cf73a1e33b04b0f50bc0292bf8257939448a23d97639e70a81c92bc
+  md5: 90b185aa0a0d514c2dbfc60cfdf909a5
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 2441923
+  timestamp: 1736267733673
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/decorator-5.2.1-py310h06a4308_0.tar.bz2
+  sha256: 532b652661cdf08b37d56f96a7ece83fbecef5c39e19c882f498e1970845adf8
+  md5: a9c68c15240e7e5fd8189143fa9eaed2
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 36087
+  timestamp: 1757341248978
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py310h06a4308_0.tar.bz2
+  sha256: 413921f9bdd75ddbf9667fc35d4f7b8ac6ce751ab992297635e0cad2a8a9174e
+  md5: 57314b5e1702906d03bfcff4d7eab35a
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16500
+  timestamp: 1649908359372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.3.0-py310h06a4308_0.tar.bz2
+  sha256: 546bb94ef7ecf42cbcf7633442ea81521e8bb95cd7c36ee8eee71e5026ce3e4e
+  md5: 9b8f3d8f70ab3d0b4031b369b8b2463b
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing-extensions >=4.6.0
+  license: MIT
+  license_family: MIT
+  size: 39742
+  timestamp: 1761560363287
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/executing-2.2.1-py310h06a4308_0.tar.bz2
+  sha256: a5ce1f19e87d3c2692890f40d501dcadae9a23b8926a58f40562b72fd5dd5880
+  md5: a6fa4e3262c3748c5f7508c98f00f305
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 806158
+  timestamp: 1757061247536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.7.1-h6a678d5_0.tar.bz2
+  sha256: 7d01d98ce0be581925188a56b3d94aa48dd43889348ecca925b4e81ac24e7a3d
+  md5: 9d007a4778f2aa30429cad8658da8abd
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 203122
+  timestamp: 1744659862400
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-2024.2.0-py310ha9d4c09_0.tar.bz2
+  sha256: 7457e53a052fdf545d03915c463dc20c881e146197dd58d278b88738c1206c2e
+  md5: 900356335a8718301c4ba4e26843ff82
+  depends:
+  - cramjam >=2.3.0
+  - fsspec
+  - libgcc-ng >=11.2.0
+  - numpy >=1.21.6,<2.0a0
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 644290
+  timestamp: 1715262407016
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.14.1-h55d465d_3.tar.bz2
+  sha256: dcb04f684a0182e8161eb607488cef61ad121b72eda8794b1072aad621663016
+  md5: 7fbedeb920dc384a9873983a4abf62a7
+  depends:
+  - expat >=2.6.2,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - libxml2 >=2.13.1,<2.14.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 343714
+  timestamp: 1722921016734
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.55.3-py310h5eee18b_0.tar.bz2
+  sha256: 867d3cad6184f11ff6738eec004e943dd6e8cb91b1061483155f6abe5c666965
+  md5: f16c3083fa7bcd0cf9c26f0e6daed735
+  depends:
+  - brotli-python >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - uharfbuzz >=0.23.0
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 2769008
+  timestamp: 1737039145077
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.13.3-h4a9f257_0.tar.bz2
+  sha256: ccf7727d01e047af9588805a2cc0f2b7769993dba6cc579545af0575ee3d5bcb
+  md5: 640d50632b00b45f4e5813176dfbded7
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.39,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only or FTL
+  license_family: Other
+  size: 966286
+  timestamp: 1743636649933
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fribidi-1.0.10-h7b6447c_0.tar.bz2
+  sha256: 6d2cad4f0c819ae368a2a2796592d9ce1d23bef8bedd722a6f9fe941e95434c9
+  md5: 65d93572c4ff2ee0cc8241221aee7f12
+  depends:
+  - libgcc-ng >=7.3.0
+  license: LGPL-2.1
+  size: 117929
+  timestamp: 1597684734171
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2026.1.0-py310h7040dfc_0.tar.bz2
+  sha256: e66e0771ca6a5af7b955bc3868117da06ad15aaf17bc610e9d20aa842ada13dc
+  md5: 581a3c864268bd13acb36e1bd6a598f6
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - pyarrow >=1
+  - gcsfs >2024.2.0
+  - s3fs >2024.2.0
+  - aiohttp !=4.0.0a0,!=4.0.0a1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 575303
+  timestamp: 1768898292059
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+  sha256: 2fc1136056f41fe92de719fb821550346704965dd12a5fa35069cdb4948d5c17
+  md5: fd089b0fba2b03aafe3adb6cdaa9ac3b
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203421
+  timestamp: 1706888218007
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+  sha256: f1e190d4ee766add8131a2b011723c472284de2bbb5e07c8f895f30e3c591df7
+  md5: 82029e0758feac811afec2a6ef9e6155
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 108438
+  timestamp: 1706895276199
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/graphite2-1.3.14-h295c915_1.tar.bz2
+  sha256: 5fc3a4233c2dd83c4afeaab51465e6e786427636908c77553a3ea80b32eacb79
+  md5: 09fcddfe703ce76b4b2d7dd0b6d2f928
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 103592
+  timestamp: 1654175396761
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/harfbuzz-10.2.0-hdfddeaa_1.tar.bz2
+  sha256: cb5ee33152020ac39163877caf6603fb9beaea2daf6d8ab5fa669db37f71557c
+  md5: d7147d8b40bbfc4559bf6c7e9faa49ac
+  depends:
+  - cairo >=1.16.0,<2.0a0
+  - freetype >=2.13.3,<3.0a0
+  - graphite2 >=1.3.14,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libgcc-ng >=11.2.0
+  - libglib >=2.78.4,<3.0a0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 2977363
+  timestamp: 1748952001874
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.16.0-py310h06a4308_0.tar.bz2
+  sha256: 2b849aebf272c7bc74d1d210f3aff93951bd3609bd7b30f19569aac362421443
+  md5: 569bc69326f865320e18d5f17d63d6a3
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4466109
+  timestamp: 1684937185991
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+  sha256: b35b281dbf69b826c6ae04fcd7b6a2d1f098277a669a199906a1f23b4b0931a5
+  md5: 2a793fe24f85aa5819fe69c450cba6f7
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 29021241
+  timestamp: 1692293243228
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.11-py310h06a4308_0.tar.bz2
+  sha256: b0ab2eb4f721714f94600dec6c3258c09ed502906aba5f76673c43fe0275a98a
+  md5: e8786e6495b614015706a30a54849fba
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 240491
+  timestamp: 1761911994219
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-8.7.0-py310h06a4308_0.tar.bz2
+  sha256: 76eb48a2d414c225ba4b3bed57ec12a92c4e93c7e462f6118566a9cd0d53511e
+  md5: 075aec0321d27194e1bd7720428bc406
+  depends:
+  - python >=3.10,<3.11.0a0
+  - zipp >=3.20
+  license: Apache-2.0
+  license_family: APACHE
+  size: 59449
+  timestamp: 1763996594184
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py310h06a4308_1.tar.bz2
+  sha256: fceecbb42f1a41ffc8cfbfbf9e995265920688c86e7135e7f649312025bbfb4e
+  md5: c7384d24293abcb9bc18bdffe1c97152
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 191545
+  timestamp: 1737660922324
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.30.0-py310h06a4308_0.tar.bz2
+  sha256: 9df41684b7d7506dd2702dd74f3afb9bc4bea849f901ef76f849ca114a4390cf
+  md5: 08c2d0de2a139f85480469fc07a3c442
+  depends:
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.10,<3.11.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1298491
+  timestamp: 1734548088973
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.2-py310h06a4308_0.tar.bz2
+  sha256: 57744d3a15f089747399f270a139e4ef44c3c7c854b884f430cf7028f94a8926
+  md5: 4b8138b4fd41dcfd2b6152c8b317484d
+  depends:
+  - parso >=0.8.4,<0.9.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1045330
+  timestamp: 1733987540677
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.6-py310h06a4308_0.tar.bz2
+  sha256: d3d58cebab668a8eb9b1e23545793221599bc82e8515a2a4f0c70a1fcfdf2004
+  md5: 25d39bd5b6059e59c24c2bb2713e7c86
+  depends:
+  - markupsafe >=2.0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281407
+  timestamp: 1741710870060
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+  sha256: 8316ae3abee25edab89788ee6e9eef79c398aba192559f514674a04ee1860bca
+  md5: 112209aed451545a622ab217c70f6972
+  depends:
+  - libgcc-ng >=11.2.0
+  license: IJG
+  license_family: Other
+  size: 283506
+  timestamp: 1722872662693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.25.1-py310h06a4308_0.tar.bz2
+  sha256: 35de3921e7b671c943d0287267b605f1ad0a6f2040c778ee9c94caee5bb98034
+  md5: afead1e8a406de4fa52b6e510a50fef2
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.10,<3.11.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 146923
+  timestamp: 1767955404239
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2025.9.1-py310h06a4308_0.tar.bz2
+  sha256: 9904af49013c3ccbb19d1500f9e9f6798f376494abd69cef9f05e40f270966a5
+  md5: 6402150ca6b96741c8dc11166ee9c917
+  depends:
+  - python >=3.10,<3.11.0a0
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 15809
+  timestamp: 1762788451804
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py310h06a4308_0.tar.bz2
+  sha256: 7732f241da3062efc233c313d00bec20e04a4e1c7e9613432d2b9ff4cba37a08
+  md5: d6492166b889eb2eb2e0add30516de59
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 195965
+  timestamp: 1676329563637
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.9.1-py310h06a4308_0.tar.bz2
+  sha256: 932f8aab8fb99fc4b049dd5641bfacce52c1c122ef729e76eca1015131791dae
+  md5: 397f6e8ebbbe992c2bd003bea62a480d
+  depends:
+  - platformdirs >=2.5
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84379
+  timestamp: 1764588305605
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.12.0-py310h06a4308_1.tar.bz2
+  sha256: 0674927db8afbf9dc4246f1ca057b2d89b50a31f92b854ae547a514a5099d262
+  md5: 03b0e40d6ac76394f141da7ae99cb622
+  depends:
+  - jsonschema >=4.18.0
+  - packaging
+  - python >=3.10,<3.11.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36465
+  timestamp: 1765813615367
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.17.0-py310h06a4308_0.tar.bz2
+  sha256: f928225d6136efbd32eda654ab4a74750c9f588066a2c89912ee153b5e9b5c75
+  md5: 82250bcbafaa9995a06b489cbbda7ec3
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.11.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert-core >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 556606
+  timestamp: 1764955137960
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.5.3-py310h06a4308_0.tar.bz2
+  sha256: 42239aedde736c08830b12fd96eecab71bce970cd89883e3e65e0f7fdebeaf8a
+  md5: 461810503757697f89b8775e1f9389ab
+  depends:
+  - python >=3.10,<3.11.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24617
+  timestamp: 1744706782649
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.3.0-py310h06a4308_0.tar.bz2
+  sha256: 56537f83531273d0d7d81bd19cfda35a27c5674aa6d01d151fff3e7d581964dd
+  md5: 9796920db889b6bfa350974d61c40cfa
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jupyterlab >=4.0.0,<5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18403
+  timestamp: 1741124259057
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.8-py310h6a678d5_0.tar.bz2
+  sha256: 4ec4d3bcd641b0a60a8e59362251b254672edbbab0bc98888a5081bcacb8a973
+  md5: 35605107ff8a64d87cb195e63e8fe9e3
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78988
+  timestamp: 1737039216718
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.21.3-h143b758_0.tar.bz2
+  sha256: ec1b9363745638328bb8f13b5c861f0a9d935a7aba4fdacd8eadb6b11f689d8e
+  md5: 8518a044cdf2b6eabe6612b0e50dfbb2
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.15,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1435864
+  timestamp: 1726642725309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.16-h92b89f2_1.tar.bz2
+  sha256: 08fa5cfcef7255ceaefe5458cf101ef5042ec5b875332fd5bc1b4ace759d7bcd
+  md5: efd070d9777836a113c921b903b8850c
+  depends:
+  - jpeg >=9e,<10a
+  - libgcc-ng >=11.2.0
+  - libtiff >=4.7.0,<5.0a0
+  license: MIT
+  license_family: MIT
+  size: 271381
+  timestamp: 1744358151897
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+  sha256: 069d33aebaf4db4ae410d4acb4851860a69d2c8f326fd45ab2a67b67fe276e6d
+  md5: 61689da52cf1fcebda8c9fb2872f94bf
+  constrains:
+  - binutils_impl_linux-64 2.40
+  license: GPL-3.0-only
+  size: 723073
+  timestamp: 1727336193185
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-4.0.0-h6a678d5_0.tar.bz2
+  sha256: 3b35e98ab9e27e3c6ce1a4988087410c4f10f8f2dc7b32e5fd0597ae3330a6f0
+  md5: 2a9cf942ef9eac2d34261363e6fbacad
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 283535
+  timestamp: 1734423401417
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libabseil-20250127.0-cxx17_h6a678d5_0.tar.bz2
+  sha256: b9542c27dae38d32b31e7016966fb1475adc534859779428d3472dee97d9d61b
+  md5: 9bbf1a9ff8592aefac52b7f593108bda
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  constrains:
+  - abseil-cpp =20250127.0
+  - libabseil-static =20250127.0=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1372361
+  timestamp: 1742310183334
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libavif-1.1.1-h5eee18b_0.tar.bz2
+  sha256: bae27493578d97fe898dea7efc6924b47e77a3f41663aba631750d7d9441676e
+  md5: f0c3d33d8a3239ca357544f1dbd06866
+  depends:
+  - aom >=3.6.0,<3.7.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - libgcc-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 139817
+  timestamp: 1733819960382
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+  sha256: e2754627e8aeb98777318939e6773b9eadbdc219dd8961aca946354d9d30f481
+  md5: 4ed89646229bee3e594cd2cc8f6060f9
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 23778916
+  timestamp: 1696762223408
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_9.tar.bz2
+  sha256: f4443a37d6eb1f35aed3b36d67ee10df39dccde535f3a6761fad44c0a516843d
+  md5: 69b08a79ab20702c6bd5f77cc4063267
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 67000
+  timestamp: 1736182526370
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_9.tar.bz2
+  sha256: 51a57fc34ce6d44b35d76562b945a55efdcd663880bb1a153c44fe176fbc5c1a
+  md5: 72d59a9872154e939d5759c7eb2c5db1
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_9
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 34506
+  timestamp: 1736182538544
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_9.tar.bz2
+  sha256: 5a43fa99f57fe609b374888359cecef39556ebf9c5fb6fd35eb9694f054b65eb
+  md5: 3c5dbc154e879dcfd5e71c8cd56202ff
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_9
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 295241
+  timestamp: 1736182548938
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.14.1-h31d0fb7_0.tar.bz2
+  sha256: f61641d7be89c499cee3aa96d7dc1c0eacd535b37e861f2092f58453c437d24c
+  md5: f75e87739ef4299f3e78fc33aa35d27f
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc-ng >=11.2.0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.57.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.11.1,<2.0a0
+  - openssl >=3.0.16,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 484046
+  timestamp: 1752139688862
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.22-h5eee18b_0.tar.bz2
+  sha256: 99b22a8ac9907bf834b06bc1d4c046a46e0d1fe8f044e03b287ca80490ffd7b3
+  md5: c75f9e8e2f44baf9a36b4d7ac80eb2bc
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 78335
+  timestamp: 1734423317784
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+  sha256: 5bd3af246b6a93ea0912179ae66e0ad9157ca0142263010d84b65724e6db0bec
+  md5: 5cb0cc0e1783419cf8fc1c65fee0f62f
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 195807
+  timestamp: 1703006263489
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+  sha256: efdab884c85fda4461f7a393aa6d4e0e50d03cb59fb9c8a980b1307b8379ebe0
+  md5: eeca774c6154c49340dd403b1928d5e9
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 108906
+  timestamp: 1632891483341
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+  sha256: 4b2518a1aa3859031a531cd1077e8a60d5b3a0dc7c83210ef27ff9ce2c78c3e3
+  md5: 49f152ee4045544c10799d32bba85c07
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 480247
+  timestamp: 1685052130829
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+  sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
+  md5: 1af9b4d62c708924417f2640ef22a68f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 154016
+  timestamp: 1714483282916
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-8.2.0-hdf63c60_1.tar.bz2
+  sha256: a8601d00368c4fe633397e5580208896f659107879ed9230bd6b30f395d69514
+  md5: 01fe37923779d22d1034b2cbd1d50bdd
+  license: GPL
+  size: 1842939
+  timestamp: 1534516119090
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libglib-2.84.2-h37c7471_0.tar.bz2
+  sha256: 50e6fdb923d4e7b90e5d7600aeccc93bf3d8865898070c6bc27a43aa1c7e249e
+  md5: 86c63a3eb5728db150d6464d4d394ffd
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libiconv >=1.16,<2.0a0
+  - libstdcxx-ng >=11.2.0
+  - pcre2 >=10.42,<10.43.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - glib 2.84.2 *_0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 1791515
+  timestamp: 1751358612530
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgrpc-1.71.0-h2d74bed_0.tar.bz2
+  sha256: 181ed071a6f98ece393a0bd3df8ad53b8afc470e57d7b12a70a806ec928158c4
+  md5: cf2580c4038f8b7e8cb9d9cf18ec3f82
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20250127.0,<20250127.1.0a0
+  - libgcc-ng >=11.2.0
+  - libprotobuf >=5.29.3,<5.29.4.0a0
+  - libre2-11 >=2024.7.2,<2025.0a0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.16,<4.0a0
+  - re2
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - grpc-cpp =1.71.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 9474643
+  timestamp: 1742491299361
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
+  sha256: ed544d8aa7e77fc42c39c276b879955e6615b517c42fecd2624033a5050832eb
+  md5: 21ee76e09ab0a7315cbed14933d97773
+  depends:
+  - libgcc-ng >=11.2.0
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1436714
+  timestamp: 1714483320555
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hecde1de_4.tar.bz2
+  sha256: c50e6a07e8004849e1cf9f0a164e36a79ac9d14a14fa7d33dc5e370315800489
+  md5: 457cfe8b5e65d583e6797a1ba2b5fb4d
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 37206574
+  timestamp: 1726769447337
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+  sha256: 6c67d781d3c074ae46b18567f230bce4a4afa209e8b914dc2cb448502774886e
+  md5: c9627c386bbc8a1a1a0a2e736ea44501
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - c-ares >=1.7.5
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 722387
+  timestamp: 1697018420830
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libopenblas-0.3.29-ha39b09d_0.tar.bz2
+  sha256: 521446ffdea7187e5d2fc61eecc554bbbf95494572e7252b57b121c78047c828
+  md5: 983e8dab4c5bc280776cdfe782230cf8
+  depends:
+  - libgcc-ng >=11.2.0
+  - libgfortran-ng
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11322426
+  timestamp: 1746646475188
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+  sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
+  md5: 1bffe1481ed4f88827248fb9001f8923
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 362561
+  timestamp: 1677841789536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-5.29.3-h3cdef7c_1.tar.bz2
+  sha256: 7089fa06a2313070b619a0df0c4036307a5ec7840c81a5b216811435982f58ef
+  md5: f7ef4af3a445243ba533826ffb0587f6
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20250127.0,<20250127.1.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3943753
+  timestamp: 1750090313373
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libre2-11-2024.07.02-h6a678d5_0.tar.bz2
+  sha256: 779d94075b22ecbad29a6d33ff03b3648561ab31de78e8f3f2c415ff5881d9fe
+  md5: ed0f770ac72ae50c86a37cb55c2cbb43
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20250127.0,<20250127.1.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  constrains:
+  - re2 2024-07-02 *_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 337884
+  timestamp: 1742313337449
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.11.1-h251f7ec_0.tar.bz2
+  sha256: 2fee5719b7bcaac278f03d4e5c15f17cf5840ed563de6730b4778c0fd62b8d9f
+  md5: 162db824b70ea49175750d732102ec58
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.15,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 301096
+  timestamp: 1732891131339
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+  sha256: 974e4035c5d51cd41fa7a7f02fadc1980069c00526c1646fa18ea94e667fb137
+  md5: 188de945b4279a812953011e8c4580c2
+  depends:
+  - boost-cpp >=1.73
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.9,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4630795
+  timestamp: 1687975185557
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.7.0-hde9077f_0.tar.bz2
+  sha256: ff6117708d9f4f8c04c6403929f845021dabd7af9bdb83786b66438e28786cf7
+  md5: b129437725e45a37328d75a0c8d248ad
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.22,<1.23.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - xz >=5.6.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 456857
+  timestamp: 1744351956669
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+  sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
+  md5: 292768ec77416ae257cfdd44ea2071c8
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29197
+  timestamp: 1668082729834
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+  sha256: a062fad27450b94279d1688aabd11a95eedee7814462ef6364337d55412b4a7e
+  md5: e0521f84b9770830e654432364ac930e
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 484011
+  timestamp: 1729160032020
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.17.0-h9b100fa_0.tar.bz2
+  sha256: e11c67f57db0b5989d520aadbeb1d7704b8d2797f2c92788ca45b86ace646a22
+  md5: 623e472cf0c02599f01c49879dab1bb6
+  depends:
+  - libgcc-ng >=11.2.0
+  - pthread-stubs
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdmcp >=1.1.5,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 416529
+  timestamp: 1746022211479
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.13.8-hfdd30dd_0.tar.bz2
+  sha256: e53b41cdc18f63d3b810a4b8d88631a51c5be3ad1dd03048dfc0345126762c7f
+  md5: e4a39fa5eebd8091471dbc4a20e3d499
+  depends:
+  - icu >=73.1,<74.0a0
+  - libgcc-ng >=11.2.0
+  - xz >=5.6.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 740082
+  timestamp: 1745948067005
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.3-py310h06a4308_0.tar.bz2
+  sha256: 8579906267b2f3c1a325d6b13efdaeffc15ef3365167974ce368875373f6dce9
+  md5: 031d0ce2bc61822d54796a98ebf9ade0
+  depends:
+  - python >=3.10,<3.11.0a0
+  - uc-micro-py
+  license: MIT
+  license_family: MIT
+  size: 41148
+  timestamp: 1758717669501
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.43.0-py310h6a678d5_1.tar.bz2
+  sha256: bc744e675b5f07ce3cdf8675bbf276dced52030b1bb172fa35fc3422f96b8d84
+  md5: 87ffe0b77940756c228b9a7f370b0161
+  depends:
+  - libgcc-ng >=11.2.0
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4377042
+  timestamp: 1736366919587
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py310h06a4308_0.tar.bz2
+  sha256: 4210b70b38fd509ac973d347a654f2cd670b7559411ae783e07b48c071a809e2
+  md5: e36d89397033bfc417932702d7519138
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11131
+  timestamp: 1652903185157
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py310h5eee18b_1.tar.bz2
+  sha256: 0b371dc20684c9bc75fe226fde6938a1a6c917960640b373e1dbced6d92c0d11
+  md5: ad213ca1a2ea7a55cde34add229efa09
+  depends:
+  - libgcc-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38171
+  timestamp: 1736366811184
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+  sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
+  md5: 76f089e76ec67583bb38428b51008097
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 164494
+  timestamp: 1714510587156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.10-py310h06a4308_0.tar.bz2
+  sha256: 2f4c57255ccf10cd834c359cefdd6e943eefdb4f3e4ee34221c232e3ebff0fb2
+  md5: f11728db9854bc44849d41a5ce9d73ad
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141406
+  timestamp: 1767787329524
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py310h06a4308_1.tar.bz2
+  sha256: 7e14cb93cf0c535ae8e0aef73c7c9ad9aa55813398438762c5f0b30347788111
+  md5: 88cc67a13bca127dea58eac5d6edca75
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 106714
+  timestamp: 1684279935424
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-3.0.2-py310h5eee18b_0.tar.bz2
+  sha256: 9d2641e958beba2e4370c8d5eb76e0dfe3a738f1c3e70ffdb3afafd817352e14
+  md5: bb6d0b2c0618e23e4f196097e1492eb1
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25441
+  timestamp: 1738584136961
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.10.0-py310hbfdbfaf_0.tar.bz2
+  sha256: 6c6040fce753be85022882830475ba80b408b268b8cfddc1094e1158358d90d7
+  md5: 3abb7c3e9c10500495a4927b3d4b6cf7
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.23,<3.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8827119
+  timestamp: 1736278649293
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.2.1-py310h06a4308_0.tar.bz2
+  sha256: 57562aa6679456ed114fbc9039ec25eabc78d831f064536ceac57221163e7f89
+  md5: 793ce9ec1c6d804bcd20acb7e327f4d8
+  depends:
+  - python >=3.10,<3.11.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17759
+  timestamp: 1762779230516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.5.0-py310h06a4308_0.tar.bz2
+  sha256: a917c4dda950197c46edbe2a71455075d6592c451b967f7bc849032c610396eb
+  md5: 8d324dbe2df2ebfd361663dc31b116eb
+  depends:
+  - markdown-it-py >=2.0.0,<5.0.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 93089
+  timestamp: 1756380105501
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.2-py310h06a4308_0.tar.bz2
+  sha256: f730fea9e7baf588e79ed06f00d649228fb5275ab4705fe345cfc51f7d8e6179
+  md5: 9627af519c9842ca4fe0bd1762de5451
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 23005
+  timestamp: 1758552201657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-3.1.2-py310h06a4308_0.tar.bz2
+  sha256: 9c5a5ea9e66b5a2d3c11e610e4b53ce7581429490ae9a293e646832c39cdb37b
+  md5: a6eef436694ede76ce321abac489b2cf
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing-extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 108757
+  timestamp: 1741124034897
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.1.1-py310h6a678d5_0.tar.bz2
+  sha256: a73c55f96869f89237787be84e8b1f8652f561664333a6e9528eae3ce1a1f35f
+  md5: 758d8c2143873b95349083e7ee3f49f7
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 112441
+  timestamp: 1750958667714
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-1.0.0-py310h06a4308_0.tar.bz2
+  sha256: 101faba8e1111502468e4387ac865fccc67b153fc941b6bf0b6eb155012f06f3
+  md5: d870313c8e47e9c54882e54f49d38be0
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27969
+  timestamp: 1756978466262
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.3.3-py310h06a4308_0.tar.bz2
+  sha256: 2af0cbd97c0e7fd5f3ad6f4e5cfbdebf55e63b25a68c0a91fa08b4f2269fc2ea
+  md5: 855c0972438d1988b6af902f728c23e6
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10073462
+  timestamp: 1765189235500
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.10.2-py310h06a4308_0.tar.bz2
+  sha256: 8fb758fdd598d898e7b3c4160605cef4a46d063d50da66b9bf2f24a5cfb43e0f
+  md5: a68c26ac5ef72f2e8e5b86bed4f3673a
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43266
+  timestamp: 1741124067667
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.16.6-py310h06a4308_0.tar.bz2
+  sha256: e14913bbb0ce70a657eb6c9a81f9fc4a7614049246a7834c8448417c96466df8
+  md5: c939fc869fb7e595917582ea9be089d7
+  depends:
+  - nbconvert-core 7.16.6 py310h06a4308_0
+  - nbconvert-pandoc 7.16.6 py310h06a4308_0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7239
+  timestamp: 1741184696173
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-core-7.16.6-py310h06a4308_0.tar.bz2
+  sha256: 0ef8e24a7c1d552375d21e717a7bd67d5852e468502a6cd9371fb83c6f1317ee
+  md5: a21c10c88801e37d7c2ff9719ef7bf6f
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.10,<3.11.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - nbconvert =7.16.6=*_0
+  - pandoc >=2.9.2,<4.0.0
+  license: BSD-3-Clause
+  size: 492277
+  timestamp: 1741184683803
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-pandoc-7.16.6-py310h06a4308_0.tar.bz2
+  sha256: f422ca91bf5eb612df2802a0a0c7cfcb9396c4867bb46b66ef2361652c0310db
+  md5: 669e550e8415b2e36c3085eab1517bc3
+  depends:
+  - nbconvert-core 7.16.6 py310h06a4308_0
+  - pandoc
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  size: 7255
+  timestamp: 1741184690183
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py310h06a4308_0.tar.bz2
+  sha256: 138c44f0b4b278db0e66e7ad3a9f24d0301c4ee1257e5eb944ba954eb7169a58
+  md5: 850a5b1738512bdb0d43e89efed45b2e
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.10,<3.11.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148192
+  timestamp: 1728049506559
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+  sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
+  md5: 57ea097dc15f8d9f9eb90e1d919143b0
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1157733
+  timestamp: 1674734069410
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py310h06a4308_0.tar.bz2
+  sha256: 505a9df53a9a36030f56020d63431baa3c67c31fd66712dfa06cdc5c7265ddbd
+  md5: 2abf153bb3d9a67452fd20cf560ef446
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13461
+  timestamp: 1708532806698
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py310h06a4308_0.tar.bz2
+  sha256: 553f9e01eda64ec5d1aa519f13a4fd0f23862a1e992a01d3b6343168ed622326
+  md5: 7730093be33fc93230d1ea8fa8b175c6
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 597059
+  timestamp: 1717630909616
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.4-py310h06a4308_0.tar.bz2
+  sha256: 7a3e8e688ecd70198bc86c87d444e917a2aca54571b29aa9fd3c885439a8c539
+  md5: ba52e1a8807e22b62c2a4c801d2fac62
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22717
+  timestamp: 1741707885283
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py310heeff2f4_0.tar.bz2
+  sha256: 15220fabe72d5ad3fabec8accf6a6d944d820cc3ff9cbc0014f5721d4897a837
+  md5: b347b1595018d55d4ac5f37ec4e548fa
+  depends:
+  - blas * openblas
+  - libgcc-ng >=11.2.0
+  - libopenblas >=0.3.21,<1.0a0
+  - libstdcxx-ng >=11.2.0
+  - numpy-base 1.26.4 py310h8a23956_0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10239
+  timestamp: 1708642234067
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py310h8a23956_0.tar.bz2
+  sha256: dd9125e2414f782fe7c7e5f27fec790fd25d393c788c749ff8dcadb581904ac9
+  md5: efe9461875c38b57f9319df2efab4d7c
+  depends:
+  - blas * openblas
+  - libgcc-ng >=11.2.0
+  - libopenblas >=0.3.21,<1.0a0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - numpy 1.26.4 py310heeff2f4_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7988052
+  timestamp: 1708642218364
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-h0d4d230_1.tar.bz2
+  sha256: fffbcdfad95da7b730daab3efd9459fee691b3df1f1596946151bbb2331eb66b
+  md5: 4d782ea84a81c0848c934aa547dd0015
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=11.2.0
+  - libtiff >=4.7.0,<5.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 480447
+  timestamp: 1744358327748
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.17-h5eee18b_0.tar.bz2
+  sha256: a45808a4cebddf649d6dfcee827e8e34251fe9eb3050315c2cd72b1c6b756446
+  md5: d3a2f19f695a4526fa448d7ea6b2f83b
+  depends:
+  - ca-certificates
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 5511537
+  timestamp: 1753176689082
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-2.1.1-hd396ef6_0.tar.bz2
+  sha256: cb3336cd7c4e203ac8569b2d099de4311f23ffcaed5fb4460007e8ff0036e2dc
+  md5: e139db542a782385bbb2050e3ae5b91a
+  depends:
+  - libgcc-ng >=11.2.0
+  - libprotobuf >=5.29.3,<5.29.4.0a0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.10,<2.0a0
+  - tzdata
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1530037
+  timestamp: 1742827660382
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.7.0-py310h06a4308_0.tar.bz2
+  sha256: 049c1bedb7989f763ba15bbbe3507e697406b8a30ead13867513e4b69b3ef502
+  md5: 077d450b10ea891a505b7e0ed38d79d0
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 35489
+  timestamp: 1762349106829
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-25.0-py310h06a4308_1.tar.bz2
+  sha256: f96f8b6153c0e6e7186c1feccbd8ace6c50fb929388db8baae2f785d20e6481a
+  md5: 69a9e023b6fb79c25994af0e376ed740
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 164792
+  timestamp: 1761049131159
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandoc-3.8-h06a4308_0.tar.bz2
+  sha256: eefd4f0c1b20f1ba3488c3582a7bd9d7ee40bcd6bc19dca68a57fa4ce3ff2b71
+  md5: 91630b42f575821e4d6d90b0ba4e48b0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 27443501
+  timestamp: 1758806891999
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandocfilters-1.5.1-py310h06a4308_0.tar.bz2
+  sha256: 724c596e76603028fa844c568b775d8af664fa9aa316e5592f9862261a09c4f1
+  md5: b5031a304a5769e031c7397eadd2e4dc
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15799
+  timestamp: 1756977793365
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.2.3-py310h06a4308_0.tar.bz2
+  sha256: 5beb5f73469aecefb2d8bb8854bd880918ddd558d73c82bbf5029162fdf6ae46
+  md5: 2e47ef6ab1c6a37402fd68af65717c88
+  depends:
+  - bleach
+  - bokeh >=3.1.1,<3.3
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.16.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17018743
+  timestamp: 1695145997102
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py310h06a4308_0.tar.bz2
+  sha256: 4f7b793253454afb7a0834872d2f47381172bc1d879c581a4d80c12427ee0883
+  md5: ba2287f1560613eeb38bcccccff8cc0c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 143006
+  timestamp: 1684915415304
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/parso-0.8.5-py310h06a4308_0.tar.bz2
+  sha256: ca304c4120a648ce1a2e97644e4015c8cc90b8400a70455886151a280ecdd8f5
+  md5: ddbc924d85a14dba9b6226bb4481d787
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT AND PSF
+  license_family: OTHER
+  size: 179490
+  timestamp: 1762781877282
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.2-py310h06a4308_0.tar.bz2
+  sha256: 576e6da785c41275be6e38070f7fa2034ad73846203925ac4a10fd2f38c07322
+  md5: ae324fc1dc8632e8a890b233f52431da
+  depends:
+  - locket
+  - python >=3.10,<3.11.0a0
+  - toolz
+  constrains:
+  - pandas >=1.3.0
+  - numpy >= 1.20.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35820
+  timestamp: 1736803462306
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
+  sha256: 71beb7373390a7c5e9bf8663d64e2b0a426755fe68adb26ed72b6570634f635e
+  md5: cd7c1793b37ba076f8515b49dbd850bd
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3346886
+  timestamp: 1714657706306
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pexpect-4.9.0-py310h06a4308_1.tar.bz2
+  sha256: c24d2ac71e4144240b6016641c98379d9d60fe53d7202d9bddf8664c184aa64b
+  md5: 821625e73032acf825777070473a8b9e
+  depends:
+  - ptyprocess >=0.5
+  - python >=3.10,<3.11.0a0
+  license: ISC
+  license_family: Other
+  size: 133817
+  timestamp: 1762535956211
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-11.3.0-py310hb1c3d2d_0.tar.bz2
+  sha256: 14d14287de2b08f46e2c388d58f5b692d2a12abd0ee4fc1d5bb68f4b32599459
+  md5: 6d3da245f796e2119cccb32b8b0a2636
+  depends:
+  - freetype >=2.13.3,<3.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=10.2.0,<11.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.16,<3.0a0
+  - libavif >=1.1.1,<2.0a0
+  - libgcc-ng >=11.2.0
+  - libtiff >=4.7.0,<5.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 881619
+  timestamp: 1752524765856
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pixman-0.40.0-h7f8727e_1.tar.bz2
+  sha256: e0f6c86339e683ea9e3f7e4ce743df653103209aedf995b5e674c148cb349ed8
+  md5: c197093127a4cca3bb3227aab1a68573
+  depends:
+  - libgcc-ng >=7.5.0
+  license: MIT
+  size: 645031
+  timestamp: 1632711422664
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-4.5.0-py310h06a4308_0.tar.bz2
+  sha256: f81a96256840a86a79c19a26fd9d6c3c9ee40bede5817a17e2d8a51e207819d0
+  md5: 57d32965daa4d9a6fbb3d97702dc7217
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 35482
+  timestamp: 1762356506533
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.21.1-py310h06a4308_0.tar.bz2
+  sha256: 36c25b20ae4eff3142ab08bff4f437f1a56c8e772ca2c2983232720667c10a35
+  md5: e6659420e7897fbb1434c92b26311e99
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 117617
+  timestamp: 1744271753344
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.52-py310h06a4308_1.tar.bz2
+  sha256: 656739ef7a4f4d6b774ed1ff6e42348f7394628aa76074ef51354bdba5ff19c7
+  md5: db7562bcff3eb9ad4bb6d63c362cbf3f
+  depends:
+  - python >=3.10,<3.11.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.52
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 615354
+  timestamp: 1761744865318
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py310h5eee18b_1.tar.bz2
+  sha256: 6ee952fcb5f8fe9095845d7548346c6683cf006e04847725d66b79796a6fdea7
+  md5: ed33372f4fa80e15f771642e975ab591
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 357156
+  timestamp: 1736367182335
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pthread-stubs-0.3-h0ce48e5_1.tar.bz2
+  sha256: a0dd2e926abb989d755d196c803b0e3aff3f375eeccb329468e96d00387db929
+  md5: de7d258a4efcd8a63df73099c8e5d954
+  depends:
+  - libgcc-ng >=7.2.0
+  license: MIT
+  license_family: MIT
+  size: 4895
+  timestamp: 1505733967605
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pure_eval-0.2.3-py310h06a4308_0.tar.bz2
+  sha256: 640e7636abd9a68ae7f9ace85196eef239d28286f756aeff936d825f6d66a9d0
+  md5: 106a82fe461b7c7e2d146d5d9e3bd836
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 28198
+  timestamp: 1757067064968
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-19.0.0-py310h6a678d5_1.tar.bz2
+  sha256: 3013fa7035cca0688a4e2d60bc9c22e1ac9bc8ff6d99a95c582e9d13a608540c
+  md5: f53c0dbd57f89cfe74fa7532cc20f84e
+  depends:
+  - arrow-cpp >=19.0.0,<19.0.1.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.19,<3
+  - numpy >=1.23.5,<3
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8652260
+  timestamp: 1738230392588
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pycparser-2.23-py310h06a4308_0.tar.bz2
+  sha256: 973083740eef1117d5b82661e94a6064494073277a51614551e68cd07523c2a2
+  md5: fd97d3683dda9e99a18fadd19bb467e6
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 244550
+  timestamp: 1757496058790
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.6.0-py310h06a4308_0.tar.bz2
+  sha256: 995b4d4a435098865765cbe6a1f341e73beddc76d835d1f7bcc49ee7a93265e3
+  md5: acc87f527a5425100608d03700f1ee26
+  depends:
+  - param >=1.7.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 31635
+  timestamp: 1759932155736
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.19.2-py310h06a4308_0.tar.bz2
+  sha256: b9b70eab364d94048aee2e43430b64050f52069b352122997509a49bbeedbdf8
+  md5: 76b8bc20c235ceb479d28ec951c78125
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5190762
+  timestamp: 1762431426950
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.2.5-py310h06a4308_0.tar.bz2
+  sha256: 53c4534a5f68bc2c7456d544acc5a3ba6163194adcbfe0e87b3692dee78b5a5c
+  md5: 41efb0261cd638f81a6de131aa8fc001
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 545275
+  timestamp: 1763973801641
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py310h06a4308_1.tar.bz2
+  sha256: 37cbe65046cea6c06c85aa436e0eb7619de5166a2c031b2d8d8b08d2426b4b00
+  md5: 34afbea8f9fbd5c624d232c45c34e39a
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 28669
+  timestamp: 1761753024240
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.10.18-h1a3bd86_0.tar.bz2
+  sha256: 8cc08ec7cdc5975a7c5d90fc4ced9000ad854597330afaf46907ed7901873cf3
+  md5: 1c38b046f738a87bd1efc7a122f2d51d
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - expat >=2.7.1,<3.0a0
+  - ld_impl_linux-64 >=2.35.1
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.16,<4.0a0
+  - readline >=8.2,<9.0a0
+  - sqlite >=3.45.3,<4.0a0
+  - tk >=8.6.14,<8.7.0a0
+  - tzdata
+  - xz >=5.6.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 28836167
+  timestamp: 1749130011684
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py310h06a4308_2.tar.bz2
+  sha256: 3d3157145577a8a683deaa078c1d1221b8e1a35bdb36c530d55ec2a6471a16e4
+  md5: 254b3b65bd03143d723337c95b02d206
+  depends:
+  - python >=3.10,<3.11.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 289681
+  timestamp: 1716495830895
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.21.2-py310h06a4308_0.tar.bz2
+  sha256: 84d5b35fd6c2939f2b702981e6affd96e0894d8c4b41b64c3a788bed75522cc5
+  md5: 60d999a748eb949bfcdf8f9ea9981dbb
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 273276
+  timestamp: 1763718600177
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-4.0.0-py310h06a4308_0.tar.bz2
+  sha256: b447d9c4e3420eb8206c7746c3aca0c3586a3ea874a7755c7d7325e5d52f4be8
+  md5: a89c5c5aaea6e0e25c6572a1a8a8402c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30486
+  timestamp: 1764590188555
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.6.2-py310h6a678d5_0.tar.bz2
+  sha256: 8688a12652a9c794bb5f64e5af1e5ae4297a1568df092d67a5631663623ab6f1
+  md5: 945d1ed2f55055c3306d74b10dd6ae20
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 139192
+  timestamp: 1736540636116
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python_abi-3.10-3_cp310.tar.bz2
+  sha256: dc1317a68e33ed38e8899ff464e7f81fba8095784e642648b4b41c20f16fbcc1
+  md5: 30c6ee2a53db622eabc8c62f6ae1ff9b
+  constrains:
+  - python 3.10.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4943
+  timestamp: 1764349600680
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2025.2-py310h06a4308_0.tar.bz2
+  sha256: 541af7ae28e66b99c0d2b86832f117b2c5de289e4b37e59e8d9bc45dbfa249a6
+  md5: d223b25b67304c5340e4207e2c0a162a
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 278205
+  timestamp: 1752135989523
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.6-py310h06a4308_0.tar.bz2
+  sha256: 25fa44670f5e4f6f5ecc32be154823fdd48d964b668438cdaa61116ee9499e0f
+  md5: 5136b3a1fd9d89defe13acb06f2ec546
+  depends:
+  - param
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jupyterlab >=4.0,<5.dev0
+  - setuptools >=40.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 61752
+  timestamp: 1758102142873
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py310h5eee18b_0.tar.bz2
+  sha256: 907a3739b1ba6b35da0b945801c76be949eb223e31edd08068a2c722df4feeb7
+  md5: 643fc9d0796daee0cf623fa174b2e1fd
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 191566
+  timestamp: 1728658021098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py310h5eee18b_0.tar.bz2
+  sha256: fe70739caee72cbd02f03ad9c3b3682e78f075ce566c9d0120cf16a6d63b5c98
+  md5: c3e4d19c84b33fddc558e3c91492a9ab
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 534100
+  timestamp: 1709318359822
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2024.07.02-hdb19cb5_0.tar.bz2
+  sha256: b8d8aaffc0ffc491fd5425d04b32c26d60158e839e246feb8b5be22b6bb293c9
+  md5: 9893756bb114209b1884424b5b6db7b5
+  depends:
+  - libre2-11 2024.07.02 h6a678d5_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24699
+  timestamp: 1742313347696
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+  sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
+  md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 467661
+  timestamp: 1666648052561
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.37.0-py310h06a4308_0.tar.bz2
+  sha256: 23b92ab948a88a26f340f85729081575e4945ba5caa34abcff0c91d73beb9918
+  md5: 76ca0b8ef7c7e6c6270948ec50cdb88f
+  depends:
+  - attrs >=22.2.0
+  - python >=3.10,<3.11.0a0
+  - rpds-py >=0.7.0
+  - typing_extensions >=4.4.0
+  license: MIT
+  license_family: MIT
+  size: 63483
+  timestamp: 1762536906415
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.5-py310h06a4308_1.tar.bz2
+  sha256: 504443a25051307d9682959789029c2befd1438e7a23840e906db52e9a560288
+  md5: 4be0dd3804b1fe0895bc6a656128a5aa
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.10,<3.11.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 143964
+  timestamp: 1762359604800
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py310h06a4308_0.tar.bz2
+  sha256: 0c8e89e2795a59c995078e0433ea4baaba3e24cc5f9890bf714d8c6aacdff786
+  md5: 836d6322df28a02fddfc5ba4cfc19db6
+  depends:
+  - python >=3.10,<3.11.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 8984
+  timestamp: 1683077147812
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py310h06a4308_0.tar.bz2
+  sha256: 2f18f6e75730725b37333f8ddd744e299144ddb3313a318cb083581e85568ed3
+  md5: 67222dc42d8db7e4023f3b5243871532
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 9327
+  timestamp: 1683059043499
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.22.3-py310h4aa5aa6_0.tar.bz2
+  sha256: d4ed1403b205788cb12f03edec7818506fd555db77ab12fecd447dd29f474bbd
+  md5: 306f8c2e6a16dfd440e1372d120fca58
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 388111
+  timestamp: 1736541328751
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/s2n-1.5.14-hdbd6064_0.tar.bz2
+  sha256: f49f0b9a59838483116f60aac4642e301ce1ff59a63145f6ebfe4a3a51c2a067
+  md5: ef157cf0f02dfba163b2878eb8daa182
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.16,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 372712
+  timestamp: 1741622141600
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.15.3-py310h5e4e545_0.tar.bz2
+  sha256: fed140f051a337081770f80a5d5b5cc91f0911ec230e97886a4d841c5d70c884
+  md5: 4d0afd4919d1afe5f0f48dbab754c072
+  depends:
+  - blas * openblas
+  - libgcc-ng >=11.2.0
+  - libgfortran-ng
+  - libgfortran5 >=11.2.0
+  - libopenblas >=0.3.29,<1.0a0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.23.5,<2.5
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 26104014
+  timestamp: 1747239553434
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.3-py310h06a4308_0.tar.bz2
+  sha256: d155355a04b8cb0967b2e8a9041bcd575e5340ae2f014ab8ad5235473251c83b
+  md5: 14f8813e7d8441e8d41dd805db3dbdd6
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30152
+  timestamp: 1768170649755
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-80.9.0-py310h06a4308_0.tar.bz2
+  sha256: 7ac28150ace62743852ad9bfb25a25e1276ae63798bdca27d1d83cd7c6e4c5e9
+  md5: 7377ec30de44bfcf4682e0e806aee013
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1848732
+  timestamp: 1759863212286
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/six-1.17.0-py310h06a4308_0.tar.bz2
+  sha256: 9ddc3ec5ce426525733aa70ffe49fb63b11980c59d741e7b9dfaf94b58c71e95
+  md5: 12488977cb73aa6fe24a576a54e98bd1
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 31545
+  timestamp: 1744271571309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
+  sha256: 8fd98235b37194986a5eb663c95a4a6db8c9e20a627f5c79ff8d9be3fd0e36f7
+  md5: 25ac00d957eda056675f8fa3eafdf6df
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 52749
+  timestamp: 1723557449203
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.1-py310h06a4308_0.tar.bz2
+  sha256: 594e7b45877bff0d2343c90649cfe1d060d22851091e7d486bc47ccbc8bd0d18
+  md5: 9a404492cf95ffa5ad337775219fa3d9
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 16931
+  timestamp: 1764329165829
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py310h06a4308_0.tar.bz2
+  sha256: 7b2292b384f32587828c2c7a1a099bead9d2071a8969af87349f00fe9fcd98b2
+  md5: 5106026a40ffd8c8ea10c146563947cf
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 66920
+  timestamp: 1696347609464
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+  sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
+  md5: f86119b3243fe3508160aa0406245738
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1723866
+  timestamp: 1714488309729
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/stack_data-0.6.3-py310h06a4308_0.tar.bz2
+  sha256: 78cd002bf56b46ca14eb1e2e038a072013ea81512ce2b31820eae6dd7f45d7c9
+  md5: a9d265498183197842b70b3582314640
+  depends:
+  - asttokens >=2.1.0
+  - executing >=1.2.0
+  - pure_eval
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 53575
+  timestamp: 1757067053400
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tblib-3.2.2-py310h06a4308_0.tar.bz2
+  sha256: 4cde79d20dafd77c8e4bcf510ee1a49f5088562af5f9b2c9817759e4ce129eae
+  md5: f4091946ff83c622b11c950eb47cabcb
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 25786
+  timestamp: 1768309874671
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.18.1-py310h06a4308_0.tar.bz2
+  sha256: 0d09faeec0f862aaf5321ce81efb636a9601cc6968fc667b17393585b8ebf6aa
+  md5: 3057a59616b72de74cfa0f14c9fc3e5e
+  depends:
+  - ptyprocess
+  - python >=3.10,<3.11.0a0
+  - tornado >=6.1.0
+  constrains:
+  - mypy >=1.6,<2
+  - traitlets >=5.11.1
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 27439
+  timestamp: 1757934882111
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.4.0-py310h06a4308_0.tar.bz2
+  sha256: c5c71eefdfdc43ab7040af2c99d5154c72d359af0bad183cb15263442a993b2b
+  md5: dddfe7cad08f37f0903d3741a6632f3c
+  depends:
+  - python >=3.10,<3.11.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92385
+  timestamp: 1738337698289
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h993c535_1.tar.bz2
+  sha256: c3d62dd8113a34606c374d4a4d640fadf7a92bdff68054ee9570905bf78fefa5
+  md5: 872a777615d59aab42033137a6f65fd4
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3573019
+  timestamp: 1748849507196
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-1.1.0-py310h06a4308_0.tar.bz2
+  sha256: b82f518356d65ce9c8cff0d84b853d949264d213755b5b3bcd2d2579152f0675
+  md5: e18d26fd244639337d83b079060d213b
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 108237
+  timestamp: 1764677628892
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.5.1-py310h5eee18b_0.tar.bz2
+  sha256: 7e0d6bcb396d8ce35a2bd20fc8c64ee8ceb2f931570cf7b85d45672b1a8e2628
+  md5: 53c6456d5a29c6aad071347a887e7ef5
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 712546
+  timestamp: 1748956958838
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.67.1-py310h7040dfc_1.tar.bz2
+  sha256: ac0182b0cc4cee40b9d4f3a9e259f151a89932763b8cf49262dacf50f7ee9c03
+  md5: 7231f8bc5f13f14f5f627d43708e3017
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 127660
+  timestamp: 1762863371102
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py310h06a4308_0.tar.bz2
+  sha256: d03a4c457adcaaab213fa99b1aaa060afddb5a99214fc8a30b271639d2f5c2ca
+  md5: 7c2b898dfd6dd4d772a82291e59f9c00
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 167463
+  timestamp: 1718227133814
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.15.0-py310h06a4308_0.tar.bz2
+  sha256: 846cacccda4d45b2c725f7e190f80e301409ee82145716e542adee3bababf7b3
+  md5: 2919a6811736c652c52717d14aa5299a
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing_extensions 4.15.0 py310h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 10999
+  timestamp: 1756280988392
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.15.0-py310h06a4308_0.tar.bz2
+  sha256: 3d2e3a1115f8a40c93d3a609c6183069305a106eaad55bc4c1c99a8350e22b1d
+  md5: aaf6c712d1f488f54e42220f3d1bb315
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 77743
+  timestamp: 1756280982899
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.3-py310h06a4308_0.tar.bz2
+  sha256: fd834e2f0759ec72a6df4d8f8a6f4cec68d97963bdb6183a5a510e6ac222607e
+  md5: b6bd7a2ea87f54e9e3858c28a3003041
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 11695
+  timestamp: 1758552128770
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py310h5eee18b_1.tar.bz2
+  sha256: 21724674f6af0574571211913d864c47c9af5442df7ada85c0526c154f5e2b52
+  md5: d855fdf91e57b0e7af2630e764b3282a
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 512342
+  timestamp: 1736541114890
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.5.0-py310h06a4308_0.tar.bz2
+  sha256: 29701c47495d1ba5022d138da23a9e4639fc1457801be8fa0300b48e8c5e0a2f
+  md5: 5293384adb65015438cb5f3e42aed5de
+  depends:
+  - brotlicffi >=0.8.0
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - zstandard>=0.18.0
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 306375
+  timestamp: 1750775691038
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+  sha256: a8d11b0f08217607b99ba560edf66423ca1e36f4ffbb6e2377e61670e2b5f36b
+  md5: 431e82b081b08aef0259df0437e04c75
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 97535
+  timestamp: 1706894675990
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wcwidth-0.2.14-py310h06a4308_0.tar.bz2
+  sha256: 048fd0dc987a9ea3ff2332dee5abbec23b77cc1dd0e13cc1cb6c30f3f0ff703e
+  md5: 078f9462450c876689a465affd87f2a4
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 77223
+  timestamp: 1767779175249
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py310h06a4308_1.tar.bz2
+  sha256: a375f3ad671266b27503b33f62ceaa7be112c0e47836e38a6c6a76225aff927d
+  md5: 49b82f30a2a45b2ce167a876cdc9e21c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21391
+  timestamp: 1640795864430
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py310h06a4308_0.tar.bz2
+  sha256: c1e745d9d00966bfb077d1356a1fe848cc4ea12309f8904d1f33bc0f6ec5dddc
+  md5: 4df68f6567bcf5ef5cd6dc6449e653bf
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 86991
+  timestamp: 1715878322248
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.45.1-py310h06a4308_0.tar.bz2
+  sha256: e1be60576340af91684bbdb81cdddf6b24e956959725b2b733bf03dec42ec357
+  md5: 84c86eb7e16be1a72fa1fa74e96ab9f6
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 110631
+  timestamp: 1737990293068
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py310h06a4308_0.tar.bz2
+  sha256: 99aeddd48fdb5599e4a4a61bb7b763ca6d5956c4d04aed8aac383843b966a087
+  md5: 23e2468c2df96e0a149dcdf731a879af
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1804197
+  timestamp: 1689041511624
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libx11-1.8.12-h9b100fa_1.tar.bz2
+  sha256: 86bf3c43d0d024f752537c4aa4b0851a06194dafd02a77410a0b3b553e686e80
+  md5: f0b98becde0651fe764283bce9423e87
+  depends:
+  - libgcc-ng >=11.2.0
+  - libxcb >=1.17.0,<2.0a0
+  - xorg-xorgproto >=2024.1
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 943936
+  timestamp: 1746110020649
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxau-1.0.12-h9b100fa_0.tar.bz2
+  sha256: a15b598100bd3f09786fd4af7c56f8a3362800409c295f0a6445796ce2d6996e
+  md5: 962cde7b3951cf7244e2ed2d059900a6
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 13895
+  timestamp: 1745958707989
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxdmcp-1.1.5-h9b100fa_0.tar.bz2
+  sha256: e7cf0b26943b81f01ab679c4c6aea62a16ac4c78097cb739c2e504039ced08f8
+  md5: 06a53975cfb6a6c46f7c60a0860a546c
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 20172
+  timestamp: 1745992279492
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxext-1.3.6-h9b100fa_0.tar.bz2
+  sha256: 9785e9166d299958b2ae78a813a6e8277a92797755ccd6c73e565e3be76aa9fd
+  md5: 8187c859d4a6d3c4e6c555b1ea5e6c7e
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 52828
+  timestamp: 1746169291297
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxrender-0.9.12-h9b100fa_0.tar.bz2
+  sha256: 937aa384aaeb1c1ffce4d3bec21e3eec48f36a3c6c961af39ca3fd69a69c9feb
+  md5: a948f60eeaa06c1dea46f17d26a3636a
+  depends:
+  - libgcc-ng >=11.2.0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-xorgproto >=2024.1,<2025.0a0
+  license: MIT
+  license_family: MIT
+  size: 33513
+  timestamp: 1746172581202
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-xorgproto-2024.1-h5eee18b_1.tar.bz2
+  sha256: 910e8c8adf8340730f4ed603ce6b8c05390b4befc982302255b221c5a5393812
+  md5: 47fbf3dec64342c6034a77c9b5a02155
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - xorg-xextproto <0.0.0a
+  - xorg-xproto <0.0.0a
+  - xorg-recordproto <0.0.0a
+  - xorg-randrproto <0.0.0a
+  - xorg-xf86dgaproto <0.0.0a
+  - xorg-xf86vidmodeproto <0.0.0a
+  - xorg-xcmiscproto <0.0.0a
+  - xorg-applewmproto <0.0.0a
+  - xorg-damageproto <0.0.0a
+  - xorg-xf86driproto <0.0.0a
+  - xorg-renderproto <0.0.0a
+  - xorg-kbproto <0.0.0a
+  - xorg-glproto <0.0.0a
+  - xorg-inputproto <0.0.0a
+  - xorg-scrnsaverproto <0.0.0a
+  - xorg-compositeproto <0.0.0a
+  - xorg-videoproto <0.0.0a
+  - xorg-xwaylandproto <0.0.0a
+  - xorg-dri3proto <0.0.0a
+  - xorg-fixesproto <0.0.0a
+  - xorg-dri2proto <0.0.0a
+  - xorg-resourceproto <0.0.0a
+  - xorg-dpmsproto <0.0.0a
+  - xorg-xineramaproto <0.0.0a
+  - xorg-fontsproto <0.0.0a
+  - xorg-dmxproto <0.0.0a
+  - xorg-xf86bigfontproto <0.0.0a
+  - xorg-presentproto <0.0.0a
+  - xorg-bigreqsproto <0.0.0a
+  license: MIT
+  license_family: MIT
+  size: 573057
+  timestamp: 1746046234466
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2025.4.0-py310h06a4308_0.tar.bz2
+  sha256: 81136cf442d1cd71bb1a27da7789f369754b414902c7e5b4a8bec4e9b81f8a34
+  md5: e2838f91fc2999cab129048f4d8d53c9
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 81845
+  timestamp: 1758720217429
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.6.4-h5eee18b_1.tar.bz2
+  sha256: bcebbfa8a53efd5eaa77a0cd7f120b2e3a397e67aa78ebe907f1b35ae7148b0f
+  md5: c924da317917a16d9d8551701b53ef7b
+  depends:
+  - libgcc-ng >=11.2.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 580712
+  timestamp: 1739468299256
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+  sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
+  md5: 943f1247a22b6b64171363bcee1eec27
+  depends:
+  - libgcc-ng >=11.2.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=11.2.0
+  license: MPL-2.0
+  license_family: Other
+  size: 371663
+  timestamp: 1705602144682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py310h06a4308_1.tar.bz2
+  sha256: 6d38f6679fbdcfd87fce10bba821fad89516ccd0778456e76aa3e364d5b65ea4
+  md5: 3f6176bb618980bd5271c3c3eef26cf3
+  depends:
+  - heapdict
+  - python >=3.10,<3.11.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 77721
+  timestamp: 1764604338489
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.23.0-py310h06a4308_0.tar.bz2
+  sha256: c61f6f94b2aeacf30415825d3cc0c285d4ea2253258bad80d0734329745e52bc
+  md5: fdc9904076d90cb015cb4c37234b6725
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 26749
+  timestamp: 1763977879371
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+  sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
+  md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Zlib
+  license_family: Other
+  size: 127143
+  timestamp: 1714510716441
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
+  sha256: a65c6277a3045e4ea72f617f977134c18366d8142ce51512f5a3cf325226a8bf
+  md5: d941bb6fdc55cc1b3f67b3beb23d1795
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1081416
+  timestamp: 1728487031624
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+  sha256: c0dd89ffac001588171152a285ddbbaea209ebe4116010f985f898b7e87c2f35
+  md5: 731ae7d446633bc729f3493a52d4365b
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 43502
+  timestamp: 1721748373551
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 9de8666e5b70aa2437737128eaa14ffe80a7b5235c2a6b7d3f39ccefd7816ba0
+  md5: bb52e50c5ab1a5c7778c11376404dfdb
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 7933
+  timestamp: 1630598543551
+- conda: https://repo.anaconda.com/pkgs/main/noarch/html5lib-1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: f6fb005d06bca169e166cef5c4e35bb5e8a0812b3286b06f2e34e4538b74d9b0
+  md5: 7a9fa936878258757f23ffe4b2e8ecf7
+  depends:
+  - python
+  - six >=1.9
+  - webencodings
+  license: MIT
+  license_family: MIT
+  size: 91697
+  timestamp: 1629144473059
+- conda: https://repo.anaconda.com/pkgs/main/noarch/importlib_metadata-8.7.0-hd3eb1b0_0.tar.bz2
+  sha256: 1c6b30f2d0308616efe57c4ad8df197a9aab57506072c910441c05841812cc47
+  md5: bd7e9d3594c372b54e55cd5927a8c7da
+  depends:
+  - importlib-metadata >=8.7.0,<8.7.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 7828
+  timestamp: 1763996596589
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pip-25.3-pyhc872135_0.tar.bz2
+  sha256: f42662741eec5e80875cae0cc6aa675d6ef837ff362fe78da3fe4d2051d97fd2
+  md5: aba2c25dd1abef550bbd9079388094b9
+  depends:
+  - python >=3.9,<3.14.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 1491662
+  timestamp: 1763132238756
+- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.52-hd3eb1b0_1.tar.bz2
+  sha256: 427c8439a70b1dc4dc9b2160c4f7a601e92d227c6aea89fa5334462b3620e44b
+  md5: ed7fc2b35f998892eaa2368c2896813e
+  depends:
+  - prompt-toolkit >=3.0.52,<3.0.53.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4757
+  timestamp: 1761744877741
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 669d6fb95d8d66db7c702b6eabe0de44dd3cb8aa498555d8856e68a88c67102f
+  md5: 411f14f0ca954f26efb6e8c5590fee04
+  depends:
+  - python
+  license: ISC
+  size: 17217
+  timestamp: 1762424191887
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2025.3-pyhd3eb1b0_0.tar.bz2
+  sha256: e5898ccadcef4df826521cd517c180c4e07247e194724e9b8910f8210b6d69fd
+  md5: 3dcbd823b57fd1f8fb60322b2012336c
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 160508
+  timestamp: 1768296658143
+- conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 4e47f6c49ce84509f1466e8a4d728447bf4bcd9bce7b456431a789a262547067
+  md5: 4cad993b0f80bc23fb66a97592299cbb
+  depends:
+  - python >=2.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 26504
+  timestamp: 1623949147884
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2025c-he532380_0.tar.bz2
+  sha256: 5a174cb8bb7ea91fd49070811f2dac162292471769b64d6f44e4c6f372945b89
+  md5: ac2e43b8492bdb5ddb1a0042b8ef6fdf
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 128611
+  timestamp: 1768849111957
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.7.0-py310hecd8cb5_0.tar.bz2
+  sha256: 04ce736b59bd9e213c3fb4151b6e0f6d59840e394025bdb92cac7661373769e0
+  md5: 65577b53b70cfe96b57f723f5146d901
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.10,<3.11.0a0
+  - sniffio >=1.1
+  - typing_extensions >=4.5
+  constrains:
+  - uvloop >=0.21
+  - trio >=0.26.1
+  license: MIT
+  license_family: MIT
+  size: 199531
+  timestamp: 1745334699780
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aom-3.6.0-hcec6c5f_0.tar.bz2
+  sha256: e9e15fb1d52051c9dbb25b1f2e613eb60cf8dbe0793062c3a274e61e6a0871dc
+  md5: cb548680c2222c567784653166056c1a
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3463290
+  timestamp: 1688660834942
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.4-py310hecd8cb5_0.tar.bz2
+  sha256: 4f4df763f8911bb82588996a87899a5079cbe2ecb7589badf46cf8605a9b7134
+  md5: 56da8541dc2d9346a165e6d6c4aa5404
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14092
+  timestamp: 1750775028274
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py310h46256e1_1.tar.bz2
+  sha256: a4a9081afc64da95a83a1e3ec7ae20bd170abd225e047b9764799c250b6fb51b
+  md5: 50137bc57835df12d7e45b783ab4a651
+  depends:
+  - cffi >=1.0.1
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 34065
+  timestamp: 1736182752094
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-19.0.0-hb704434_4.tar.bz2
+  sha256: 72fbbd0d97eb15c51048c952305f662e2dcab57770a84df2a64e4b287a47d25d
+  md5: 3d6188260627f639a6beffac0f1ddc77
+  depends:
+  - __osx >=10.13
+  - __osx >=10.15
+  - aws-crt-cpp >=0.32.10,<0.32.11.0a0
+  - aws-sdk-cpp >=1.11.528,<1.11.529.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.5.0,<0.6.0a0
+  - libabseil * cxx17*
+  - libabseil >=20250127.0,<20250127.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libcxx >=14.0.6
+  - libgrpc >=1.71.0,<1.72.0a0
+  - libprotobuf >=5.29.3,<5.29.4.0a0
+  - libre2-11 >=2024.7.2,<2025.0a0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.17,<4.0a0
+  - orc >=2.1.1,<2.1.2.0a0
+  - snappy >=1.1.10,<2.0a0
+  - utf8proc >=2.6.1,<2.9.0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 11008261
+  timestamp: 1753354974558
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/asttokens-3.0.0-py310hecd8cb5_0.tar.bz2
+  sha256: 58b71899725c64bc1babdd5a62ec62d691eb1f198644107dee1900770d724f34
+  md5: 7df30edcf90249ed538669c399ff4ea7
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - astroid >=2, <4
+  license: Apache-2.0
+  license_family: Apache
+  size: 42610
+  timestamp: 1743630570941
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.3.0-py310hecd8cb5_0.tar.bz2
+  sha256: edb893561ab56dda0e91311a7aa1c83fc74cb00d24d24688d9dfe392acc8edb6
+  md5: f69cc0458896627608598d4581279439
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 143058
+  timestamp: 1734533234106
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-auth-0.9.0-h46256e1_1.tar.bz2
+  sha256: 96026e45c0323175d9b64f5d920f12b378084f073a976a085aecdb99444d96a0
+  md5: 615a32002bcc08afbc447936cc05248c
+  depends:
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  - aws-c-http >=0.10.2,<0.10.3.0a0
+  - aws-c-io >=0.20.1,<0.20.2.0a0
+  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 104429
+  timestamp: 1751616022363
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-cal-0.9.2-h46256e1_0.tar.bz2
+  sha256: a9cec0d1b0203ef753a6f50c8906def16a8aed1650fec9afb474b92e197002bb
+  md5: 723c26e0e063602466ac83626194d0b3
+  depends:
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 45237
+  timestamp: 1751013576163
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.12.3-h46256e1_0.tar.bz2
+  sha256: f40292bb94de0f4162f1dbffc8761a695ad7c6d1f706c7fe09171dbdfb397e61
+  md5: 70a05786dd6a8039a307033ee1c3b607
+  license: Apache-2.0
+  license_family: Apache
+  size: 239922
+  timestamp: 1750946944096
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-compression-0.3.1-h46256e1_1.tar.bz2
+  sha256: f2e79303d77b5dff25a5e012bf4c7ff28b687495afe2ca42cc2b539f0b7d9146
+  md5: cba72961d70b2d66cc16795bfa0c6e06
+  depends:
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 19452
+  timestamp: 1751274936497
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.5.5-h46256e1_0.tar.bz2
+  sha256: 487f725caa9148810c5426c271bbfd85b69ff249e69b989ee231a312028c5420
+  md5: e4f3f90bb820d73dd267714dd041da5c
+  depends:
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  - aws-c-io >=0.20.1,<0.20.2.0a0
+  - aws-checksums >=0.2.7,<0.2.8.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 50511
+  timestamp: 1751547512013
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-http-0.10.2-h46256e1_0.tar.bz2
+  sha256: 42140d0f2e3f6117376d82d61a3b97da79f1f608781763709d234696f41722dc
+  md5: 994a5c3abe9d2908e78445c3e47c0175
+  depends:
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  - aws-c-compression >=0.3.1,<0.3.2.0a0
+  - aws-c-io >=0.20.1,<0.20.2.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 179776
+  timestamp: 1751547499916
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-io-0.20.1-h46256e1_0.tar.bz2
+  sha256: 98c409eced7e171096a692c5e6d3d021ee24bbbef9a825a7f850c608c0089c7f
+  md5: 52c91296281c0d09c36a84be51868f08
+  depends:
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 169964
+  timestamp: 1751543230640
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-mqtt-0.13.2-he61ece7_0.tar.bz2
+  sha256: d8de78df5baaefa66ff224a3d3a6f4a2aba0bc8b0a192ba38e30bc57d5e8c811
+  md5: e7d8ccd207a35563cd7a7c3a26e4ec4e
+  depends:
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  - aws-c-http >=0.10.2,<0.10.3.0a0
+  - aws-c-io >=0.20.1,<0.20.2.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 178714
+  timestamp: 1751616848250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-s3-0.8.3-h46256e1_0.tar.bz2
+  sha256: 3abce724fda58cd918fba299e79ed0c19d7e335d7442b962dccec843a4ee2c6d
+  md5: eb1dbfeb590dc2f712e5a754fe177b35
+  depends:
+  - aws-c-auth >=0.9.0,<0.9.1.0a0
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  - aws-c-http >=0.10.2,<0.10.3.0a0
+  - aws-c-io >=0.20.1,<0.20.2.0a0
+  - aws-checksums >=0.2.7,<0.2.8.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 112348
+  timestamp: 1751617837546
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-sdkutils-0.2.4-h46256e1_0.tar.bz2
+  sha256: b426872a11c72814d724517f5c3e15b00ee5c1f8727a895fb9d7beaa6c55e9c8
+  md5: edbe9bb5b5682a0aeaf9c185bb5d9eb1
+  depends:
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 55325
+  timestamp: 1751543943921
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.2.7-h46256e1_0.tar.bz2
+  sha256: fa9ff08be6539887f407f599364fbf10c4a65ac1cb94a3c14c46bbcd59fb0509
+  md5: 2ebd3c04978b5179a0d354f75d697f31
+  depends:
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 78299
+  timestamp: 1751543211691
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-crt-cpp-0.32.10-h6d0c2b6_0.tar.bz2
+  sha256: 5ed6669490ede03841e299b75d2dbc231943e1562068a76bcce30f0400373b19
+  md5: c383e7a264154a95e33aef5bfee97283
+  depends:
+  - aws-c-auth >=0.9.0,<0.9.1.0a0
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  - aws-c-event-stream >=0.5.5,<0.5.6.0a0
+  - aws-c-http >=0.10.2,<0.10.3.0a0
+  - aws-c-io >=0.20.1,<0.20.2.0a0
+  - aws-c-mqtt >=0.13.2,<0.13.3.0a0
+  - aws-c-s3 >=0.8.3,<0.8.4.0a0
+  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  - aws-checksums >=0.2.7,<0.2.8.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 348831
+  timestamp: 1751882095826
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.11.528-he026a02_1.tar.bz2
+  sha256: 08a258f3fd363585f0f25ea2125afbe0a308bb83c398e024974f0ddf966c0c30
+  md5: a595285155ed6533415a61d45b9def7e
+  depends:
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  - aws-c-event-stream >=0.5.5,<0.5.6.0a0
+  - aws-crt-cpp >=0.32.10,<0.32.11.0a0
+  - libcurl >=8.12.1,<9.0a0
+  - libcxx >=14.0.6
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3781792
+  timestamp: 1751884084218
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.13.4-py310hecd8cb5_0.tar.bz2
+  sha256: 58c8c63c66b519701e1678cfda7ccdb3a3818314f5105dc82d1a1f11eb35a694
+  md5: dc19f09ebf6caf4c914a76399f4e8930
+  depends:
+  - python >=3.10,<3.11.0a0
+  - soupsieve >1.2
+  - typing-extensions
+  license: MIT
+  license_family: MIT
+  size: 291221
+  timestamp: 1752599126191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
+  sha256: 695ac69739e73351dfebfb01ea39c5e1dbfdcfb475590d6560ae318bfbad3a97
+  md5: 38fd73cba341639c45d8c747b08c9cc1
+  size: 49130
+  timestamp: 1528225884020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bleach-6.2.0-py310hecd8cb5_0.tar.bz2
+  sha256: 80f284948e221e50a375d27ced28b60fc14e9b94c70b7afebab6c94f1591e57b
+  md5: d44ba8f9caf313fdf5186c7f50e857c8
+  depends:
+  - python >=3.10,<3.11.0a0
+  - webencodings
+  constrains:
+  - tinycss2 >=1.1.0,<1.5
+  license: Apache-2.0
+  license_family: Apache
+  size: 298162
+  timestamp: 1732292174114
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py310h20db666_0.tar.bz2
+  sha256: 40d9035be55844db55fdfe31e85752d99c165d1355d792c08a91f9ccda834e10
+  md5: 3f953aa83d5a9ffd1393177be2ef719f
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6484731
+  timestamp: 1690546214635
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+  sha256: 81102f2762d8eb2f07c69fbf7ca7dad879a257a053085492d4c1b4006eb35fb8
+  md5: 3c42777bc9330fe91177ea813b9ec252
+  depends:
+  - libboost 1.82.0 hf53b9f2_2
+  - libcxx >=14.0.6
+  license: BSL-1.0
+  license_family: OTHER
+  size: 11744
+  timestamp: 1696762233693
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py310h6d0c2b6_9.tar.bz2
+  sha256: 9080f1318589a3b2f9966718f01963e9f9cf8e8272cac125a6c8fc4e38f16bb3
+  md5: 17cef8e1c1b82fa69cda3cc46983b9fb
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  size: 394148
+  timestamp: 1736182872336
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotlicffi-1.0.9.2-py310h6d0c2b6_1.tar.bz2
+  sha256: 4145d38aea691d904e3bb534a3e28e8566123b4700afea820648e9705ec05a3a
+  md5: 0af9b9bd02f621a5763b9ce0e020e243
+  depends:
+  - cffi >=1.0.0
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  size: 400640
+  timestamp: 1736183240938
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+  sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
+  md5: c5a600d81b1b48578863af2973c743ac
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 187637
+  timestamp: 1714510590009
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+  sha256: f913b61ba3c1651b36688415cc163a5d575475f7573b543f48a80e7a5002e4bb
+  md5: f11d165eaa532ce04a35382841284298
+  license: MIT
+  license_family: MIT
+  size: 107047
+  timestamp: 1693902034820
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2025.7.15-hecd8cb5_0.tar.bz2
+  sha256: bc99be41a6fdebe3af9dbf3a36e6865ce978bc1d4d844c6de3fb3d8b0ca52b31
+  md5: 6f9db756c5105f55c9e5a35793181034
+  license: MPL-2.0
+  license_family: Other
+  size: 137725
+  timestamp: 1754645326236
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cairo-1.16.0-h08824b9_6.tar.bz2
+  sha256: 7a77bcd8be87ca8b6dc9572c64fe102a5e7bb2f1d03393ca41a9e63b6e0c6aee
+  md5: f1d0286d509462bdb20e4f1fa32fd7cb
+  depends:
+  - fontconfig >=2.14.1,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - libglib >=2.78.4,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - pixman >=0.40.0,<1.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: LGPL-2.1-or-later or MPL-1.1
+  license_family: LGPL
+  size: 1418284
+  timestamp: 1748950888581
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2025.8.3-py310hecd8cb5_0.tar.bz2
+  sha256: 9413b76282f8191c632f8afc8708a0ac41801e15f798fbcb1b71e905e1bd6db4
+  md5: bf10e29862310b92aefbd929ea0e6c5a
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 165421
+  timestamp: 1754570785132
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py310h9205ec4_1.tar.bz2
+  sha256: c2c7d0141b9a5b74bcafd4ece47ba49c99ca2171e3f545fe2f9314dbf8c3e8ab
+  md5: 9476cb1cd12dc1357b0e09715c1cda30
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 233330
+  timestamp: 1736183923379
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.2.1-py310hecd8cb5_0.tar.bz2
+  sha256: 1ce7f9f311f52ce720709932e0a1bdd780a1533414a5eaafe2eebd84be17f5e1
+  md5: 5d9d9fb650c63997792407a27f50c644
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 289482
+  timestamp: 1754478135731
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.1.1-py310hecd8cb5_0.tar.bz2
+  sha256: 7a2fe1500648be7ed2353a255103b6d7dc2acb7ac2bc4d7a80ed56a694ca6d96
+  md5: 53d483aa4a33ddcacc66d8d5178504d6
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39146
+  timestamp: 1751309490058
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py310hecd8cb5_0.tar.bz2
+  sha256: 38b6b20387ada75d20393cc99de9c8a1f2b7fcd03b28720df4eef55d44ec393e
+  md5: 881ffce8c467163639bd6ed6ef941189
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 499171
+  timestamp: 1709758463351
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py310hecd8cb5_0.tar.bz2
+  sha256: cafb4b7adcb72b498a482a6b846f949e1aee350f96a79d9146b38f969b2e0a90
+  md5: a404bca7f71823adc5ef078d63b788a9
+  depends:
+  - python >=3.10,<3.11.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15750
+  timestamp: 1709322968401
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.3.1-py310h1962661_0.tar.bz2
+  sha256: b417230b26b1ce73a43ef4d6d4aa665d7cb49574ed484612b4f9c5f4ef563171
+  md5: 3063ab79f0ba0cc1349db7b443216df3
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.23
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 282429
+  timestamp: 1732540159621
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cramjam-2.9.1-py310hc8aab72_0.tar.bz2
+  sha256: 5f83837fcd846dc511820bd092e6388916c5fd7efa887afcbab092f1fceaf253
+  md5: dd8a561663d4290e3cc00158150bf4ae
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - __osx >=10.12
+  license: MIT
+  license_family: MIT
+  size: 1656958
+  timestamp: 1742393449092
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-1.0.1-py310h46256e1_0.tar.bz2
+  sha256: 1d9a57bbd23aa5dd39f0ebbc54f35b47f06bb92d7411ebf2b6cfcdc9d7c4c1b1
+  md5: e206caf5e2a578c3d6c501a2bef43194
+  depends:
+  - python >=3.10,<3.11.0a0
+  - toolz >=0.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 377760
+  timestamp: 1736804097424
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.15.1-py310hecd8cb5_0.tar.bz2
+  sha256: 5ebff2d98d1e5797562ba6a56abe643e83602f950bebcaf3c98aa3e784f5f150
+  md5: 69934087a995025dc10f36d3cd1d1111
+  depends:
+  - colorcet
+  - dask-core
+  - datashape
+  - numba
+  - numpy <2.0a0
+  - pandas
+  - param <2.0.0a0
+  - pillow
+  - pyct
+  - python >=3.10,<3.11.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17662937
+  timestamp: 1689604033927
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py310hecd8cb5_1.tar.bz2
+  sha256: 6b3905da23b8fdf7323cfe47995b73b8129a75c1708c088b30a5df0b2fc421b2
+  md5: bb78d03307832de66ed78b15009022a8
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 103789
+  timestamp: 1642543991102
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/dav1d-1.2.1-h6c40b1e_0.tar.bz2
+  sha256: 53b960dc320a73701d8faf90316a203b01b294e0a7235c7bf49bb853d71b2214
+  md5: 7a196bd419ee0f888fbbe0e6d449adda
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 812727
+  timestamp: 1688746099942
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.8.11-py310h6d0c2b6_0.tar.bz2
+  sha256: f0f253e5d75f3ba81ad47d7c8ffa0893d9e3498f93add77ab2407e51b599df26
+  md5: 3b248ee0a819e5a27d7e86b3eb3c6eb0
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 2367714
+  timestamp: 1736267739614
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py310hecd8cb5_0.tar.bz2
+  sha256: 670e9476a114ca61020f1a69803661de5cc6f01a26296a4c73bbbda94164dc4e
+  md5: 12f8f558c520d5a1e25ba2967edbee89
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16685
+  timestamp: 1649926502410
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.2.0-py310hecd8cb5_0.tar.bz2
+  sha256: a31f9c19d1b9f9355dee09bc356853ee2c9b4ffc99525810a7189e3d148c2c18
+  md5: 36fd0124a6a901c880c4f80087db5803
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 30923
+  timestamp: 1706031435284
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/expat-2.7.1-h6d0c2b6_0.tar.bz2
+  sha256: 82a4c50f5e4de65f6f85e0a78f09dc63ba1cfde730d2811cd811af275a9d00dc
+  md5: 2710e707ee0cca3ce20178498880b07d
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 164184
+  timestamp: 1744659891613
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-2024.2.0-py310h7b7cdfe_0.tar.bz2
+  sha256: bde273a9a8515071f7bc8ef51eb434e1e66b9a338578bd0bd906c3cc9a302dd3
+  md5: adeb3a54825919246130f923bbe45db2
+  depends:
+  - cramjam >=2.3.0
+  - fsspec
+  - numpy >=1.21.6,<2.0a0
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 633724
+  timestamp: 1715262975637
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fontconfig-2.14.1-h269ac6a_3.tar.bz2
+  sha256: c05a2895ae7758e77eb03ab269d3181461de6909dbf93426bb2e580245230cc6
+  md5: 1f34b1ef1a777b25daa69662f286b4bd
+  depends:
+  - expat >=2.6.2,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - libxml2 >=2.13.1,<2.14.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 281575
+  timestamp: 1722921216503
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.55.3-py310h46256e1_0.tar.bz2
+  sha256: 569b44d8b937da6e3e5f2e42c0a5f1fe2a00cdb7496342120eed37953d4d30f0
+  md5: ef6da35662deeedf8aa5a19f7fc6f5ba
+  depends:
+  - brotli-python >=1.0.1
+  - python >=3.10,<3.11.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - lxml >=4.0
+  - fs >=2.2.0,<3
+  - uharfbuzz >=0.23.0
+  license: MIT
+  license_family: MIT
+  size: 2694120
+  timestamp: 1737040009567
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.13.3-h02243ff_0.tar.bz2
+  sha256: 7a7fdc574ecd7867034e0cdf29cc9e7d2ba18b598314e0e84fa3a4036515c20a
+  md5: 293e13416fb9ee0f144ee9ebeb686f1a
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2.0-only or FTL
+  license_family: Other
+  size: 943295
+  timestamp: 1743636677947
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fribidi-1.0.10-haf1e3a3_0.tar.bz2
+  sha256: 380c89b34c225e97b618f9dee0dcc4a230dbd611a3d2fd4e37136fca9625eb09
+  md5: 58df1c8d8878f3fe462eb75826d5fbd7
+  license: LGPL-2.1
+  size: 67815
+  timestamp: 1597699493723
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2025.7.0-py310he13d532_0.tar.bz2
+  sha256: a4a9a73d05fe246d30db0f4f31d55e8907b9b348bcabdec661b2eeb8a854e45c
+  md5: 14bb184a5d35316e7431da1089d1d561
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - pyarrow >=1
+  - aiohttp !=4.0.0a0,!=4.0.0a1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 555290
+  timestamp: 1753796226579
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/gettext-0.21.0-h4e8c18a_2.tar.bz2
+  sha256: 9f2052e2c2f4e1d48b4315c3976c53afc5ff69399166f24432bb8c02f868fc27
+  md5: eb9c4555f936f3998c0c5e462c44f0e9
+  depends:
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - libxml2 >=2.13.1,<2.14.0a0
+  - llvm-openmp >=14.0.6
+  - ncurses >=6.4,<7.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 3595681
+  timestamp: 1722923856325
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+  sha256: 3c7aa54548409f9343e891820ea43c195b5e4e4dce6b761bc3ae9f6c8be0fc86
+  md5: ed9629d6dc1612ec425eb8d27478b0f6
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 140316
+  timestamp: 1706888243476
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+  sha256: aed47f9ca4dd140b9c8a183e53d4b89eba84a20041d2038983cdfea8096104ef
+  md5: c0d981d7d43eaad55950ff5e57206e70
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 97828
+  timestamp: 1706895273858
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/graphite2-1.3.14-he9d5cce_1.tar.bz2
+  sha256: 5fb77afc56bab49baed51609a5f62d814a1602ca6b6c9be2335250bd90f7b4a6
+  md5: 620cdc76e94f58e22d16e8c9bbbd331d
+  depends:
+  - libcxx >=12.0.0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 87249
+  timestamp: 1654175417832
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/harfbuzz-10.2.0-h060d35a_1.tar.bz2
+  sha256: 9e418cb0008b11f5945612ad7c0b1c7d786a68aa25d7af7f6525e1ee2568f9a9
+  md5: 1c81c148a18b11c22449220bcc80e0f8
+  depends:
+  - cairo >=1.16.0,<2.0a0
+  - freetype >=2.13.3,<3.0a0
+  - graphite2 >=1.3.14,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libcxx >=14.0.6
+  - libglib >=2.78.4,<3.0a0
+  license: MIT
+  license_family: MIT
+  size: 2792420
+  timestamp: 1748953771332
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.16.0-py310hecd8cb5_0.tar.bz2
+  sha256: 8db742e6e3dc9b44a0cdccde3935b20b00dd024814f86b797cf95cada949e011
+  md5: cfc40754b31a02a66c452d8ba868594a
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4471610
+  timestamp: 1684937042999
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+  sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
+  md5: f3ce6fe6eb760c236e5f7d04df5faa81
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28138484
+  timestamp: 1692293212596
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py310hecd8cb5_0.tar.bz2
+  sha256: c21b5d635595e087aa1135dd3b6dca63054aff33d58d70100c0b0f6648d0dae3
+  md5: b548aefceda441a37555005da1b9a4c8
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 140710
+  timestamp: 1714398998249
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py310hecd8cb5_1.tar.bz2
+  sha256: 14152cac71fbe490f7cb5c55cdd579d539db2c03e7aa053070405003a818b8e4
+  md5: 5284bf705342b8998b32fe90f734f660
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193089
+  timestamp: 1737663232337
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.30.0-py310hecd8cb5_0.tar.bz2
+  sha256: cb0223d29b35cf307ed043e433b56c47cbb1d7c95f03df7170b0038baf3f75c1
+  md5: 6464ffc2b762b4624b995df86a18d517
+  depends:
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.10,<3.11.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1294016
+  timestamp: 1734550898575
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.2-py310hecd8cb5_0.tar.bz2
+  sha256: 4b577d3dbe27fa6cf633cba900290e21507a43b49c6cbb8558e8f9222f275439
+  md5: 9901907744df4b8302f3aa287a654bea
+  depends:
+  - parso >=0.8.4,<0.9.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1062952
+  timestamp: 1733987465642
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.6-py310hecd8cb5_0.tar.bz2
+  sha256: d3246337bed0a9f6281034e33720e86823788f2426929d3fd34d68b1d0e91f31
+  md5: e0c4befba7234c764b066e1336f71ef4
+  depends:
+  - markupsafe >=2.0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 280482
+  timestamp: 1741715320823
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+  sha256: 855982a798d9af8e70635a250528a5da3b2b0cf7095e2804858caf139c8a239b
+  md5: 112a5602fe42a84a5bafa038abeddf4f
+  license: IJG
+  license_family: Other
+  size: 279686
+  timestamp: 1722872676718
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.25.0-py310hecd8cb5_0.tar.bz2
+  sha256: 0952e397b2eb51edf107705c3a0e41f471d269dd8daec8cbf1500768b5c93d5d
+  md5: 215f162197580b2334b6d080b15abc3a
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.10,<3.11.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 149650
+  timestamp: 1753206496757
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py310hecd8cb5_0.tar.bz2
+  sha256: b61904f8e4c3d1726f4bbec37d1edfd69a989cab0098cfa9c422d2cf9f49ba78
+  md5: 221013125db975c3b57e7ebc93e73b2a
+  depends:
+  - python >=3.10,<3.11.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 15941
+  timestamp: 1699032432155
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py310hecd8cb5_0.tar.bz2
+  sha256: 1b382008e5e5b7d7bbe5da1767d4d35021869c5ff1b7fdb17f10fa9634cd8e1e
+  md5: 32e23b69e39f05ec0c83b75738996fa2
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 200146
+  timestamp: 1676330021017
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.8.1-py310hecd8cb5_0.tar.bz2
+  sha256: 02a2f1d7e0009cd5fd308b6309bf53522d53a638c1cd867e91f1d6f445c1b2a7
+  md5: 62369059a2eb81101c7143ea0cbcca4b
+  depends:
+  - platformdirs >=2.5
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 87307
+  timestamp: 1751991867907
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.12.0-py310hecd8cb5_0.tar.bz2
+  sha256: c3d537fa353ee08bd64234d626e6c209ba19035338a7c78ed86600ef72ba0a37
+  md5: 57475a601c4bd5e5b7fa966b1a187f8e
+  depends:
+  - jsonschema >=4.18.0
+  - packaging
+  - python >=3.10,<3.11.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37872
+  timestamp: 1741184725811
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.16.0-py310hecd8cb5_0.tar.bz2
+  sha256: 2156a4b108cacb8d2972b76aa09edee6b11c862df99b0fcca2c95fe365c8020d
+  md5: 68ba18942ade8ddc360062d12f923419
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.11.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert-core >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 513979
+  timestamp: 1751996686958
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.5.3-py310hecd8cb5_0.tar.bz2
+  sha256: 5b630b062a1637bc43ebef156708b91fba46f92b63a1b2ca7093f5cda2d3a32d
+  md5: 066cb4979d5982803d57c4ae82c449a9
+  depends:
+  - python >=3.10,<3.11.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25936
+  timestamp: 1744706845282
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.3.0-py310hecd8cb5_0.tar.bz2
+  sha256: 5165a7ec95c350bc4e9c764903c97d0f3b07f74f2a67c184c44bee1b807aeefc
+  md5: b7c2813ee05852058413012c80bc285e
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jupyterlab >=4.0.0,<5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21718
+  timestamp: 1741124601995
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.8-py310h6d0c2b6_0.tar.bz2
+  sha256: 5af425f0056e4865bfb9aa113563ce058c47ba590712d2189968a416f8492896
+  md5: 8926b9c4708dd93b08d7474f821f013e
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 68685
+  timestamp: 1737040226477
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.16-h31d93a5_1.tar.bz2
+  sha256: a05cf581d30821ee034e16325788c770147f9f5627e8166d88776c054e4a7928
+  md5: 6348d6db77d4455269c9ba4c31b6ab64
+  depends:
+  - jpeg >=9e,<10a
+  - libtiff >=4.7.0,<5.0a0
+  license: MIT
+  license_family: MIT
+  size: 264117
+  timestamp: 1744358217760
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-4.0.0-h6d0c2b6_0.tar.bz2
+  sha256: 50da46ac4a032a38d2d9e714e945079e05a46ae451437a52ad09b4cd5d925f5b
+  md5: 234c885b9f326ecf78b5294fb709ddee
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 295348
+  timestamp: 1734423413199
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libabseil-20250127.0-cxx17_h548131f_0.tar.bz2
+  sha256: 277ca3393da63ec5f6794ddb6d0f322b59bcae3ef1cb6efb36ceb12fffcf8e74
+  md5: fd181f8692ed17972994e3a111961aa3
+  depends:
+  - libcxx >=14.0.6
+  constrains:
+  - __osx >=10.15
+  - libabseil-static =20250127.0=cxx17*
+  - abseil-cpp =20250127.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1252067
+  timestamp: 1742310226263
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libavif-1.1.1-h46256e1_0.tar.bz2
+  sha256: eead0160c02cb5c0e852402a61732603d70b13d2fd2e09e49b8dcf1f87eb490f
+  md5: e2ffd343ff3434dd03c0410455c324f0
+  depends:
+  - aom >=3.6.0,<3.7.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 137625
+  timestamp: 1733819995977
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+  sha256: 127dbf93874f1bb3493b312fecb5ffedb8f2a41d2470e2cbeb889eb58d89ebf7
+  md5: 07502b61e43a2039e4312b40d53c1db1
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 22584954
+  timestamp: 1696762195023
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h46256e1_9.tar.bz2
+  sha256: 8f058b4b23c8d56f8411c8f6eec834ea30e8a2ce7a98685ad9c2a4817aabae4a
+  md5: b64809b5c2030ac3e571c9f6b5b34335
+  license: MIT
+  size: 66530
+  timestamp: 1736182753663
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h46256e1_9.tar.bz2
+  sha256: 6269fa97423611d7310bb23d6929e1fee3246a10440cd931718d4d447f6d4215
+  md5: 23d3558e675675ea0281bbfcac49453a
+  depends:
+  - libbrotlicommon 1.0.9 h46256e1_9
+  license: MIT
+  size: 34461
+  timestamp: 1736182772158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h46256e1_9.tar.bz2
+  sha256: 738524a5398e731ba9c74b799bf5e972721af4a4dc6a5425d2e17780e3e15912
+  md5: b562c3b15ef8b86391171d2f1b85cae6
+  depends:
+  - libbrotlicommon 1.0.9 h46256e1_9
+  license: MIT
+  size: 311811
+  timestamp: 1736182791956
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.14.1-h1448931_1.tar.bz2
+  sha256: 45c46b982fd5795c9bb1652da2d908f5e35f5895fb56efdca24244301e7320ef
+  md5: cb0c3108ef81ae36b219767a516735be
+  depends:
+  - __osx >=10.15
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.57.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.11.1,<2.0a0
+  - openssl >=3.0.17,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 450383
+  timestamp: 1753959350533
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-19.1.7-haebbb44_3.tar.bz2
+  sha256: e7941e24012a8d13c0f878e46ece21bc65312a941fbd45dcb9fb5acb251a41aa
+  md5: b4aa2806a2e1a23b4ff2b5884ef8f894
+  depends:
+  - __osx >=10.15
+  constrains:
+  - llvm-openmp  19.1.7
+  - clang 19.1.7
+  - llvm-tools  19.1.7
+  - llvm 19.1.7
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 394979
+  timestamp: 1755029133023
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.22-h46256e1_0.tar.bz2
+  sha256: 5267b5015a03aa90883f57b3cc5dda014082e5ab88e2d3b30fe809c37b96094c
+  md5: a6bdcc6561a095bc0ac11482e84c37c8
+  license: MIT
+  license_family: MIT
+  size: 84141
+  timestamp: 1734423352364
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+  sha256: 4786264321edbff780633a5b752995eb3193ca4bce11b0fda179577f6cf1102c
+  md5: 849fdd014c201a9d2c2aa7c7db38a778
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 103993
+  timestamp: 1632891571494
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+  sha256: a60941a0365ee3e8b9ff721f75b0608c234b5652f53337a918b787839de4bb53
+  md5: 4d61f019594ebccfb3f4fb87ee778416
+  depends:
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 414942
+  timestamp: 1685052318462
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+  sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
+  md5: 822a5b76117e56d3912f1f2153307528
+  license: MIT
+  license_family: MIT
+  size: 136045
+  timestamp: 1714483561919
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+  sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
+  md5: e458587c87e3f2d20192f4e0738f2c63
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 149419
+  timestamp: 1665498987619
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+  sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
+  md5: 1058b661ec829b2ee3716ee2a5520641
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1917987
+  timestamp: 1665498925405
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libglib-2.84.2-heb90364_0.tar.bz2
+  sha256: 9098195739bb2da11d190879694a543221bce176c148b71a00740cab5c155826
+  md5: 670803b0ad44bd20cf3d0255d7361f6a
+  depends:
+  - gettext >=0.21.0,<1.0a0
+  - libcxx >=14.0.6
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.16,<2.0a0
+  - pcre2 >=10.42,<10.43.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  constrains:
+  - glib 2.84.2 *_0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 3434948
+  timestamp: 1751359726038
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgrpc-1.71.0-hf2926fd_0.tar.bz2
+  sha256: d4885e3b55f8400c130ea5422db608c6d1523a9c7622c27032e5db43d718c20c
+  md5: 3c9f991f714e5744bcef6a0493eeeacc
+  depends:
+  - __osx >=10.13
+  - __osx >=10.15
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20250127.0,<20250127.1.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=5.29.3,<5.29.4.0a0
+  - libre2-11 >=2024.7.2,<2025.0a0
+  - openssl >=3.0.16,<4.0a0
+  - re2
+  - zlib >=1.2.13,<1.3.0a0
+  constrains:
+  - grpc-cpp =1.71.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 7444739
+  timestamp: 1742493869382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
+  sha256: 9ff6ed0f0b9f9f27f449e95d11aa1c4e9e80028fd9d2a8caca5a15d8df88f435
+  md5: 7b4b557afc66aba367da14d97d71934c
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1409885
+  timestamp: 1714483704680
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+  sha256: 7bfcf69c31a4eb15dfab661c93463ce8dfb7b3de4356945fa5c1ca50a5ae0cb0
+  md5: 4934bb34818fa3d99b32b9cb59fed205
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - c-ares >=1.7.5
+  - libcxx >=14.0.6
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 784918
+  timestamp: 1697018436251
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.29-h3f8574a_0.tar.bz2
+  sha256: 3a3a9861ff781d55b4f38925c3f6059cb7811f5813ca85bf5a656e7b69d92bba
+  md5: a33a5f061ffab5a47e96ba9fd5385555
+  depends:
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10583047
+  timestamp: 1746648378310
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-5.29.3-h66a43dd_1.tar.bz2
+  sha256: 7537dd0807904c3cc02f8fb89794cd00e5b692ce8b241f508cc65af1145f782b
+  md5: ca9332c808158259dd3bbaef5575fdb9
+  depends:
+  - __osx >=10.13
+  - __osx >=10.15
+  - libabseil * cxx17*
+  - libabseil >=20250127.0,<20250127.1.0a0
+  - libcxx >=14.0.6
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3365003
+  timestamp: 1750090199893
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libre2-11-2024.07.02-hab2016f_0.tar.bz2
+  sha256: f17f9e5fbd59567d10df1d9072ffa4b93df45ac41d3d58ab574fab7ec82b0278
+  md5: 226b106e49b0a5485422b6c500e41183
+  depends:
+  - __osx >=10.15
+  - libabseil * cxx17*
+  - libabseil >=20250127.0,<20250127.1.0a0
+  - libcxx >=14.0.6
+  constrains:
+  - re2 2024-07-02 *_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 248148
+  timestamp: 1742313370721
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.11.1-h3a17b82_0.tar.bz2
+  sha256: 1107001cf2ab50223d97fe24d4747262f52883abe47263e301a506b195485017
+  md5: a42788d25cc9b4a03d4434e231db7445
+  depends:
+  - openssl >=3.0.15,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 292312
+  timestamp: 1732891162787
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+  sha256: 21ba71cdc65b56c6daefeeab55959e5a7edadfd697cfa8b2ed5c1b3e2a98586b
+  md5: cbbd369ee87aba597c942727bada4eee
+  depends:
+  - boost-cpp >=1.73
+  - libcxx >=14.0.6
+  - libevent >=2.1.12,<2.1.13.0a0
+  - openssl >=3.0.9,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 364326
+  timestamp: 1687975317748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.7.0-h2dfa3ea_0.tar.bz2
+  sha256: f8ac3d26791c4dfaae827fc791d5ced3d7394314a46d40c7d236fd51b3f5d5a5
+  md5: 7b6486e03e7f3ebf5e489c7cd27fcb97
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.22,<1.23.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - xz >=5.6.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 450903
+  timestamp: 1744352034365
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+  sha256: 246c0d82766042c1a9194eecc71690918c68afa3528ff0c2c82796ce901df40b
+  md5: f33be4ed3bff89ed8f68df6c75158510
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 449215
+  timestamp: 1729160070984
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.13.8-h6070cd6_0.tar.bz2
+  sha256: 8be62db7da3121a108dc243ac6e17e7b0387f08057f7c3c0e21e9254046d592a
+  md5: 07248330f39881a95f902e2f614435b9
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.6.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 647795
+  timestamp: 1745948063293
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py310hecd8cb5_0.tar.bz2
+  sha256: 8e083eacdfa973821efce45fb1de838ccdab56cbee31a6ce70de0683ad2165f7
+  md5: 8f970cf73b7f71b2d2c624992e9cd6f7
+  depends:
+  - python >=3.10,<3.11.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 36179
+  timestamp: 1659783413376
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-19.1.7-h5048363_2.tar.bz2
+  sha256: 73835edf76319d3b67d61da80811c0de1cf0daf9cac3f73158b71868ca74a372
+  md5: 4aada712b7ccbef49d8da3cf7b52f142
+  depends:
+  - __osx >=10.15
+  constrains:
+  - openmp 19.1.7|19.1.7.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 382001
+  timestamp: 1755220355531
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.44.0-py310hfa5e528_1.tar.bz2
+  sha256: 51981bd778db0a2e53314c874817c40afd5c4466ff05e2e84aac6768f34b8525
+  md5: a08fd21bd60ec1bf12d277e728ffc947
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 25034759
+  timestamp: 1741215188737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py310hecd8cb5_0.tar.bz2
+  sha256: ef2cc69591855744d4c5d1aeb6b325d0f9886404709cba541be075fe6f696fd5
+  md5: 46e2880168e6de564dd817fde7bf07b1
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11932
+  timestamp: 1652903221378
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-4.3.2-py310h46256e1_1.tar.bz2
+  sha256: 9da88b73981867050f0095c60030639ac2836506ec923c48c57ca2b9bc1ab9aa
+  md5: 24abee418effd96d6ea6c0ba97085344
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35888
+  timestamp: 1736368136507
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+  sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
+  md5: 8f57dc3a3327bb6f7e1cba908856ac7f
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 183138
+  timestamp: 1714510756758
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.8-py310hecd8cb5_0.tar.bz2
+  sha256: 58f8c91ba797503d1f35cb44df40ebe6627796d31d5bfa81fcaa26f64aefaca6
+  md5: d16ed165f9140a11c27e5aaf5702cadf
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141256
+  timestamp: 1746114609822
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py310hecd8cb5_1.tar.bz2
+  sha256: 444bec52a8b4f0e0169f69b0d2ee1409dc04a48509ea394d053e8fa3418e724b
+  md5: e95bbbc56e3c08f0018638c6ee82e567
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 108187
+  timestamp: 1684279943281
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-3.0.2-py310h46256e1_0.tar.bz2
+  sha256: 6b2b6539c570b8d4c763834d1876e26013ebe15ce244f8a46b1515a09c5f056b
+  md5: 2f5b14671a4c1487a378edde34849ed0
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25717
+  timestamp: 1738584336873
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.10.0-py310h919b35b_0.tar.bz2
+  sha256: 1517e6b6862b34086796475bc0a8748c32ff0c6f10a162ff0d96451cdc9c94c8
+  md5: 805d4f20ed3edfc0ab0512dce7422d31
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23,<3.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8832382
+  timestamp: 1736279414715
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py310hecd8cb5_0.tar.bz2
+  sha256: b0b7bf33159ad955ac6503e0008bb4f6d42a431d39750d8748f1cfd437c33982
+  md5: 95dcb73cba7ccc8d9d54ded71c43f200
+  depends:
+  - python >=3.10,<3.11.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17405
+  timestamp: 1662014515076
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py310hecd8cb5_0.tar.bz2
+  sha256: 25de39c78f2dd34019fd7c7f46110a096abaf50fe8ed08ddbbdb905aa5fa4154
+  md5: 0a554b7362b3c3ee587f2486e58c9d4c
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 53950
+  timestamp: 1659721329388
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py310hecd8cb5_0.tar.bz2
+  sha256: f7319ca119de06ffc0efc159c00b0eb4aa1c8c95b0de062532590cb8da37be9e
+  md5: 3d14c228ee0ce206ba6889c36a0815c7
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 19643
+  timestamp: 1659716168738
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-3.1.2-py310hecd8cb5_0.tar.bz2
+  sha256: 12af34728c9db5f442757cf6ceb67b0c1bf92d491c9cbaabe3fd48cf10ca0b11
+  md5: be4cff18fc933ac4d27e70a91e876038
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing-extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110310
+  timestamp: 1741124154811
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.1.1-py310h6d0c2b6_0.tar.bz2
+  sha256: 3ad1033fc21028c478dc736261ede3ebed405d7f9af575759ee0cec9797b8047
+  md5: ce39d257fb9233e31d684c9acfafb9f2
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 103764
+  timestamp: 1750958927569
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py310hecd8cb5_0.tar.bz2
+  sha256: 1b5957084c6043397d20cc0caa110e51050113c316b836810cc509c1f9378ab2
+  md5: d1c02fb4d2d5d701c11984fdda8505a3
+  depends:
+  - python >=3.10,<3.11.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 22942
+  timestamp: 1642534330262
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.3.1-py310hecd8cb5_0.tar.bz2
+  sha256: 2c9b6777ea2b60a127da7d04b8cc7a537c516ac582d17648527b2c92ecebb1aa
+  md5: 99753d275fc0b85f7b56a85598c083e5
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15319992
+  timestamp: 1751012354760
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.10.2-py310hecd8cb5_0.tar.bz2
+  sha256: 2b8552974160634bd0ffc6ecc4cda7989170e489202ec7f4c791a56cb9190bbd
+  md5: c79699a2a5411019332347b88d6dfdca
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 44542
+  timestamp: 1741124342748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.6-py310hecd8cb5_0.tar.bz2
+  sha256: a56dff21ea63d60f2495dea5becdef90d9abcb78de4c60c1ce012a9a88491f6d
+  md5: 0cc9d3c07444b3cebebbcc4cd4470d67
+  depends:
+  - nbconvert-core 7.16.6 py310hecd8cb5_0
+  - nbconvert-pandoc 7.16.6 py310hecd8cb5_0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8345
+  timestamp: 1741197611074
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-core-7.16.6-py310hecd8cb5_0.tar.bz2
+  sha256: a55c682367bd6dd6a5176f06b780ae0f7191fbaa67353172d0cea212fd60d307
+  md5: 9f2accb2aed72cc195e6d845b13fb5bc
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.10,<3.11.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pandoc >=2.9.2,<4.0.0
+  - nbconvert =7.16.6=*_0
+  license: BSD-3-Clause
+  size: 503735
+  timestamp: 1741197592000
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-pandoc-7.16.6-py310hecd8cb5_0.tar.bz2
+  sha256: 139ae76b3016d362d36f0e78037be039dbe2ee611745553fdc9507730aba5738
+  md5: 4a3f14b45b4acfe4d7a6b7b6bb6774b5
+  depends:
+  - nbconvert-core 7.16.6 py310hecd8cb5_0
+  - pandoc
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  size: 8371
+  timestamp: 1741197603522
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py310hecd8cb5_0.tar.bz2
+  sha256: 5002aeb376cc6933cc225bea4841515fb2b54704696e3065610996f05750224e
+  md5: e2a7b4c2bb90517f0a29ad683c4c1e56
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.10,<3.11.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 149697
+  timestamp: 1728049994459
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.5-h923df54_0.tar.bz2
+  sha256: 4743a0d696d67f8018bff466bb82ed736695d16c2bc2398ec768f1c7a60a2a03
+  md5: 0e927c5a5178eca5ff1954c5142f95bf
+  depends:
+  - __osx >=10.15
+  license: MIT AND X11
+  license_family: MIT
+  size: 1096224
+  timestamp: 1753947521640
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py310hecd8cb5_0.tar.bz2
+  sha256: cc408a3c4fb28427161701204d608cbb03b5cbd1d4560f61b03a3aadd35fa9a5
+  md5: e1eae3de565ba8e2f102a67f9c425520
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14541
+  timestamp: 1708532847720
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py310hecd8cb5_0.tar.bz2
+  sha256: 3f78085783bed38080cc1c039b6816bc2d08134f803a96b472f89b22ea1c51dd
+  md5: c2050f983311834a8c1dab82b21eac30
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 562151
+  timestamp: 1717630928303
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.4-py310hecd8cb5_0.tar.bz2
+  sha256: 78ba378c4dd9fa950f35737b8c9a7eddbb6395d396199e9c2ccab6809246d203
+  md5: 6b7e246b685f82042c3c14fff8a3c6aa
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23981
+  timestamp: 1741712310288
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.61.2-py310h2d33a94_0.tar.bz2
+  sha256: 164662134dc84475ddd35ed0681831be5ce35e210e0e1258916499ffb70f2f82
+  md5: f9be7f931bc42702eb8b501e0ee68f3a
+  depends:
+  - libcxx >=17
+  - llvm-openmp >=17.0.6
+  - llvmlite >=0.44.0dev0,<0.45
+  - numpy >=1.21,<3
+  - numpy >=1.24,<2.3,!=2.0.1
+  - python >=3.10,<3.11.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - cuda-version >=11.2
+  - tbb >=2021.6,<2022
+  - cudatoolkit >=11.2
+  - libopenblas !=0.3.6
+  - cuda-python >=11.6
+  - scipy >=1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4689037
+  timestamp: 1750804238252
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py310hf6dca73_0.tar.bz2
+  sha256: 879eba95cd6f3c9db63acf22db294be7e49f82fe3b4df555f2e9edb0edc5e9f7
+  md5: b113dcbda7bb76a7fbf1f94efc6c184a
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.26.4 py310hd8f4981_0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11299
+  timestamp: 1708642941361
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py310hd8f4981_0.tar.bz2
+  sha256: 8b6c290f94d2baa1072961a8075632c82fd3c57902194b83a26b5fedd406e8ba
+  md5: 3cc589b83f466f12da41d16f33b7b0cc
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - numpy 1.26.4 py310hf6dca73_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7635155
+  timestamp: 1708642899725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-h2d09ccc_1.tar.bz2
+  sha256: ec45b94cde6b5c7dc456a665d66af1c59b2684fb102eb1c1316b57ca2a679598
+  md5: 9b8c31394a3a8fbf86f9751f2810f270
+  depends:
+  - libcxx >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.7.0,<5.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 548341
+  timestamp: 1744358392735
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.17-hee2dfae_0.tar.bz2
+  sha256: 72fedfc0ab6ce7fbd255281d5e5a1ba502dcc92d6da82d0bb2e75b34daaee686
+  md5: 650ebe2983c6b653f70b5bb8fddd288e
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4968293
+  timestamp: 1753177400112
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-2.1.1-h4dda5a6_0.tar.bz2
+  sha256: a680d9e048239f49e1a8339a12f16919e931c9bfcd4a9cc59d98104cc8b4564d
+  md5: bd07ddb5a5d2c5e63117b6f1253b0c0a
+  depends:
+  - __osx >=10.13
+  - __osx >=10.15
+  - libcxx >=14.0.6
+  - libprotobuf >=5.29.3,<5.29.4.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.10,<2.0a0
+  - tzdata
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 568412
+  timestamp: 1742827702826
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py310hecd8cb5_0.tar.bz2
+  sha256: c7e6eeaed43f22e96664e0e3facadc1466824665cde18889fca81e9a3fc7b675
+  md5: 91dd93c48df10568852a9186a64b5451
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 31881
+  timestamp: 1699371179971
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-25.0-py310hecd8cb5_0.tar.bz2
+  sha256: abf8ae51761c551fbd56aecbeb899f6bae4001baf0d08a7fad56c344b7894127
+  md5: 6e0cfcd89494f5ade395d73e6eec8dd8
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 168644
+  timestamp: 1753775657823
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandoc-2.12-hecd8cb5_3.tar.bz2
+  sha256: 0eca2711e91cf2e3595f89380e4ea3069b1e0a2ddc31943bcc9ca4bc92ac67ed
+  md5: ef3e53d304f18fbbf26eab22e12dd459
+  license: GPL-2.0
+  license_family: GPL
+  size: 15066232
+  timestamp: 1677512250755
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py310hecd8cb5_0.tar.bz2
+  sha256: 4b2d5305590fbf66d22508e1b9ca7afbce87a25f6a1142d6de6b2815c9ba98d1
+  md5: dc07447e3ab88d2f1147ccec800be296
+  depends:
+  - bleach
+  - bokeh >=3.1.1,<3.3
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.16.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17078623
+  timestamp: 1695146541406
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py310hecd8cb5_0.tar.bz2
+  sha256: 08f766f3c49a9b1bd0addb34fb0ce0739d319003aa4d7580d25b8b344b3dac8d
+  md5: 7b31c764364be71df61cd206249ccae2
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 144060
+  timestamp: 1684915450654
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/parso-0.8.4-py310hecd8cb5_0.tar.bz2
+  sha256: f7ba154156340b9f75545b7d26e5f2cf69f0185d96246819d8f548cd428ecd0c
+  md5: fca994a54cf21a6dc314ff792710027d
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 179723
+  timestamp: 1733963463157
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.2-py310hecd8cb5_0.tar.bz2
+  sha256: a08dc050c9417f9c927f4078d4a9caf36469639d9f7b61dfb22f7d69d68ae273
+  md5: 4217cbccb0273e065107ae7987a944de
+  depends:
+  - locket
+  - python >=3.10,<3.11.0a0
+  - toolz
+  constrains:
+  - pandas >=1.3.0
+  - numpy >= 1.20.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37126
+  timestamp: 1736803635027
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pcre2-10.42-h9b97e30_1.tar.bz2
+  sha256: e18ec8727b8f74eb87a3c8945953c97de9b065aabcad272ece12972b854d964c
+  md5: 2a4a10038d1f8d6bb80609fdeb0ac324
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3403226
+  timestamp: 1714657724735
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pexpect-4.9.0-py310hecd8cb5_0.tar.bz2
+  sha256: b93d16a01da1b7323908eed650cc9e366fef6985b73fd62d139eaabc170df7c1
+  md5: 4ad7137b638c5fec97eceaff9cfcdc85
+  depends:
+  - ptyprocess >=0.5
+  - python >=3.10,<3.11.0a0
+  license: ISC
+  license_family: Other
+  size: 136555
+  timestamp: 1750072650728
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-11.3.0-py310h25d8182_0.tar.bz2
+  sha256: 3da3cf725de05b2f4abb11d84c7a8ac86154336b1ae59311e705cb5bbe1676da
+  md5: 305f888b1129db4c770da0e5c66880a2
+  depends:
+  - freetype >=2.13.3,<3.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=10.2.0,<11.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.16,<3.0a0
+  - libavif >=1.1.1,<2.0a0
+  - libtiff >=4.7.0,<5.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 843888
+  timestamp: 1752524992655
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pixman-0.46.4-hb254d66_0.tar.bz2
+  sha256: 7005c05abb43fc40a8ca7084e280cd220ff33435f092620933764f2e3eebf061
+  md5: 556ab56a032687ccd6c36c958f68507b
+  depends:
+  - __osx >=10.15
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 317220
+  timestamp: 1755256461837
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-4.3.7-py310hecd8cb5_0.tar.bz2
+  sha256: a9e17076739556296626355de84beb7f151fc8d760fc47da4506e5547201b231
+  md5: 3c19f5043a072da4c5f106d6cb714b3f
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 36747
+  timestamp: 1744273202490
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.21.1-py310hecd8cb5_0.tar.bz2
+  sha256: 29f210529d1aec1ac72a3c65e3e6d3e9619d8aef9d5aa08ad2c9acb9d9e72bb9
+  md5: ea6b58813b50b69e16c5fbcc443eeba8
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 119027
+  timestamp: 1744272075296
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py310h46256e1_1.tar.bz2
+  sha256: dfb4fcd9d82312b2db1ae9969f20e1fc434e497143968465de5240548a82fa24
+  md5: 39ac3015ad7072371b661659506629ee
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 369973
+  timestamp: 1736369641178
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-19.0.0-py310h6d0c2b6_1.tar.bz2
+  sha256: ade1c9436bb061575ea27413ba7cdbff90c11dcb159438cb3fbf4567c609df64
+  md5: 04f94dba87e4facaf732e562d2218041
+  depends:
+  - arrow-cpp >=19.0.0,<19.0.1.0a0
+  - libcxx >=14.0.6
+  - numpy >=1.19,<3
+  - numpy >=1.23.5,<3
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 7854916
+  timestamp: 1738240236612
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py310hecd8cb5_0.tar.bz2
+  sha256: 6f28fc0782ff0a1f9f44be058392efcda61a916f4687f0e349c6a0b633154a31
+  md5: 89243bf420e88ab976e19b1a91228465
+  depends:
+  - param >=1.7.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30981
+  timestamp: 1675441597598
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.19.1-py310hecd8cb5_0.tar.bz2
+  sha256: f0a57fe3601d78dcdce5de0b018247c3e7dca5f4ac509bc83b0c86a505bae0e1
+  md5: c3fbbcb8ae23361e7c31e243488e5dc1
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1999471
+  timestamp: 1744664264223
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.2.0-py310hecd8cb5_0.tar.bz2
+  sha256: 2900f7c5a4239523c79454eb49b084c4878a14663046547b3c23634d213f1828
+  md5: f050a05a10a265c4c09705936b9fe3c8
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 427323
+  timestamp: 1731445863523
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py310hecd8cb5_0.tar.bz2
+  sha256: 7e7ad33a42ffc0cf30a64115bbf6a4fb77e6f4ff859b5cdc1c5af35e34a77a36
+  md5: 8b1372e62747adb48891711705ecf67c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 28205
+  timestamp: 1642536392594
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.10.18-hc958d9f_0.tar.bz2
+  sha256: be184972bfebd315eee337e2b81bf1db60414401030a09297dc3c32a7bfecbcc
+  md5: a026603c7d0a2d8cfff763af711008dc
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - expat >=2.7.1,<3.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.16,<4.0a0
+  - readline >=8.2,<9.0a0
+  - sqlite >=3.45.3,<4.0a0
+  - tk >=8.6.14,<8.7.0a0
+  - tzdata
+  - xz >=5.6.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13959734
+  timestamp: 1749129690581
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py310hecd8cb5_2.tar.bz2
+  sha256: 7c48377410f36fe4c89693d59a4ade0440dd6fdf16ae1932eb46076efb1f04db
+  md5: c70567e92a388519519e994567e2a653
+  depends:
+  - python >=3.10,<3.11.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 290910
+  timestamp: 1716495929291
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.20.0-py310hecd8cb5_0.tar.bz2
+  sha256: 1824cbd95f76d8180c6de480c6471a685cf490ec52a5391d78f9d154b9b6f381
+  md5: cc764d70876d00b055033f9589affac7
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 268904
+  timestamp: 1731939855247
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-3.2.1-py310hecd8cb5_0.tar.bz2
+  sha256: 6c5d18562bcd36368005ee163c01769495a1c8cc47a276bd80c8354e7edc914f
+  md5: 7f9af140142b85a50eb5bd81c07948ff
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 25751
+  timestamp: 1734370142498
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.6.2-py310h6d0c2b6_0.tar.bz2
+  sha256: e43f9317dc12ba06dbd6a6a73117d4fca4ef21a223645e0b567d7863038c578b
+  md5: 1b402707af511827e9c871d789039006
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 135996
+  timestamp: 1736542261908
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2025.2-py310hecd8cb5_0.tar.bz2
+  sha256: 23fcba29a54e2ac2b2947139288ab1c4856a5051e94fc40096e81dc1e838b731
+  md5: 6f790f50660241828b47a2c9802d2321
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 273194
+  timestamp: 1752135919021
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py310hecd8cb5_0.tar.bz2
+  sha256: 75bc3472ad099223406433761e03c124f6cdc66f6b7d1ef12ec3d36534cb7973
+  md5: 1dca0ce5eeb9bb9fea1d39d443c393b8
+  depends:
+  - param
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 61754
+  timestamp: 1711137017218
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py310h46256e1_0.tar.bz2
+  sha256: e8721601f26109e9779eeb82cfacade26f10f0c389249a91532ff4ccdd573c5d
+  md5: e70e174b046cf351add8e693633c6659
+  depends:
+  - python >=3.10,<3.11.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 177213
+  timestamp: 1728659110037
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py310h6c40b1e_0.tar.bz2
+  sha256: 585628aeb5d2000ec14e9bd76f8363c00b658a4e0ef9273a1c696f01809219b6
+  md5: 9af99dc6230418c58c5ad25843de03c7
+  depends:
+  - python >=3.10,<3.11.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 506986
+  timestamp: 1709318572722
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2024.07.02-h1962661_0.tar.bz2
+  sha256: dc28e43c897ddc8090794d4d324f444f487427ce21dd4fe66e30e14ac6f035a4
+  md5: f0fca2467445f9576db5d51d148bc59f
+  depends:
+  - libre2-11 2024.07.02 hab2016f_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25957
+  timestamp: 1742313381620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.3-h49f2429_0.tar.bz2
+  sha256: c52e82271868de2e5ad836d2468dc5096e506dbd240c6ed40578360401172998
+  md5: f55273b4ccdec25a8ea30dc7bf4ec286
+  depends:
+  - __osx >=10.15
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 544215
+  timestamp: 1754485725566
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py310hecd8cb5_0.tar.bz2
+  sha256: c5e89495acc097c738e4dd7a26cdff24b6aa0ad82d6f0c6b9b3e7db242435894
+  md5: 4278d32b0db8529403a6eb55703dc8ef
+  depends:
+  - attrs >=22.2.0
+  - python >=3.10,<3.11.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 59367
+  timestamp: 1699012203616
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.4-py310hecd8cb5_0.tar.bz2
+  sha256: 89dbd8675bf2b100a1f44fad3da3601914349067a7fb8c9094f13002d2e81603
+  md5: f376a44cc5b6363e6c5ed7c7054d0f8d
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.10,<3.11.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 147905
+  timestamp: 1750426886517
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py310hecd8cb5_0.tar.bz2
+  sha256: ecec0cef15dd4d80f2fa892b449e16041dace4ab669617ed9e2e6ee77d0873e4
+  md5: 5b3b337fc9f8d9194cbead0e20fa0b99
+  depends:
+  - python >=3.10,<3.11.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9862
+  timestamp: 1683077133588
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py310hecd8cb5_0.tar.bz2
+  sha256: cc9d506a3f77d20dd2a3fc2567bfb0880a43bb110af639c134e18ec6bdecfaca
+  md5: 5ba77c0b6356bda301de8c3d4e45a662
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 10239
+  timestamp: 1683059221325
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.22.3-py310h83de92b_0.tar.bz2
+  sha256: a1f4c63ab813711a1c33e6fd63f7bff4de835e1c5af8407309ed35b33875a8f1
+  md5: 0ab24b411158a63f88fa977de6cd7adc
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - __osx >=10.12
+  license: MIT
+  license_family: MIT
+  size: 369785
+  timestamp: 1736546721438
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.15.3-py310h97975f9_0.tar.bz2
+  sha256: 6ec7d278acf25122efac4aa2022dc66af163628112bbc6eb38b93ca46af5f62b
+  md5: b4653f229b9779eac43cbe8b1d51fb9b
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.29,<1.0a0
+  - numpy >=1.23.5,<2.5
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 25318541
+  timestamp: 1747238587238
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py310hecd8cb5_1.tar.bz2
+  sha256: d5d38365836cadf3281852d707362ffbc6a980e28843b94ee3423b63ab73820b
+  md5: 7ea5c662bf9d269fc90ba37813eac5ad
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28461
+  timestamp: 1736543367399
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-78.1.1-py310hecd8cb5_0.tar.bz2
+  sha256: 879fe62859d69224d91d336cad00f7d19d4532246254b223981f5443278629ed
+  md5: 0a444642ddca99901e21e9f7f8c44be7
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1807442
+  timestamp: 1746025469825
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/six-1.17.0-py310hecd8cb5_0.tar.bz2
+  sha256: d0426afff8b3ac82aeda0633b2724490524d32af487530b4d7e749898712b4a8
+  md5: d2e50f651fb4c9e03e584bed9e9fb468
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 32827
+  timestamp: 1744271837902
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
+  sha256: 9eaab5afd89c87ca139915589626785039fac30f05f8fb19e9eefe27eb935ce6
+  md5: babdcd3370f85ded3d313902dcebecfb
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 46224
+  timestamp: 1723557464934
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py310hecd8cb5_0.tar.bz2
+  sha256: e0b8413f1bebc17ea35f3b4bc1e6a28dcc69db7f791ea80d31bfa8bdbd99023d
+  md5: 9c9a20ac1397b11a4ffa611d253f83a4
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17891
+  timestamp: 1705431327614
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py310hecd8cb5_0.tar.bz2
+  sha256: 97a6ef8790155b089dc6c1c7559cac226dc8966fb7189276d43e56361fef921b
+  md5: c5fe7f5450316dd0f7c407fc6d5c4590
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 67950
+  timestamp: 1696347655636
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.50.2-hc8b0dd6_1.tar.bz2
+  sha256: 5311229c22218bbf87ba01e50defb5a8de514e405a91f7e59574230824cb6d83
+  md5: 31cf95da9abaa8b074c16cc23fa27537
+  depends:
+  - __osx >=10.15
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1766409
+  timestamp: 1752773664751
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tblib-3.1.0-py310hecd8cb5_0.tar.bz2
+  sha256: 988476806eee1c92268c034d37cd01bbb8f4c60391cb700a257bfa0812af3d58
+  md5: 72ee2b8fe8cfb8727d5e0e7b9a6df579
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 26813
+  timestamp: 1749730032727
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py310hecd8cb5_0.tar.bz2
+  sha256: 92b0454b4739557af9a8f52f040828cb343935e874144e25eebf620be61cfb85
+  md5: 39fb00364e1ae13b9fc9af51c0540648
+  depends:
+  - ptyprocess
+  - python >=3.10,<3.11.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 31114
+  timestamp: 1671751965362
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.4.0-py310hecd8cb5_0.tar.bz2
+  sha256: d29027de113f7435ab5cccc3453e31fb957077f48d89749b22a755a85f402df7
+  md5: e389ae44710b71bfcc408c94a714cf49
+  depends:
+  - python >=3.10,<3.11.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 93516
+  timestamp: 1738340133842
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.15-h3a5a201_0.tar.bz2
+  sha256: 54c8b3a35c5460310938e410d702270d074fc47148eca783d179caa15a4211ee
+  md5: 4b6f17480d699587812e55f1c6472f95
+  depends:
+  - __osx >=10.15
+  - zlib >=1.2.13,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3652025
+  timestamp: 1755243942533
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-1.0.0-py310hecd8cb5_0.tar.bz2
+  sha256: aa3af456242e77190eccc22e48274bfad613414959a11860812475818f902aaf
+  md5: 917e5116fac39e63824fb26f9abafb2f
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 107153
+  timestamp: 1736796469698
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.5.1-py310h46256e1_0.tar.bz2
+  sha256: a97ba60d8394dbf6eac9ce884487245f786fb8d02afd21b01146973cd1c1dd11
+  md5: cb674ea8ceef2162d730c43e17c640a7
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 714681
+  timestamp: 1748957006646
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.67.1-py310h20db666_0.tar.bz2
+  sha256: c7b4e8267ecf53dbfb3bcd6b1d8a7b71dc3ba6bdde2dc953a2d96f31ba1ec29f
+  md5: 0659d7a3dead5448e30616dd6f75526a
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 128956
+  timestamp: 1738946277961
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py310hecd8cb5_0.tar.bz2
+  sha256: dda3761c9a87fd90628b32cc8827587856783f9df3afc59d2f412b704fce6a48
+  md5: 9f14e3c1632913c7cfec1d02df9efca0
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 168327
+  timestamp: 1718227095682
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.12.2-py310hecd8cb5_0.tar.bz2
+  sha256: 7d1f74307d5d734b8c9097ebc2d3479c66a0a9357ac0285cda523e29be7e20c2
+  md5: e60873d80e41c4982c942e51ce32909a
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing_extensions 4.12.2 py310hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 10061
+  timestamp: 1734715076387
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.12.2-py310hecd8cb5_0.tar.bz2
+  sha256: 7a5935df5c79028631aea7bb1b3acc0246603f9a728c3d58314bb64f31601ec7
+  md5: e50cdd4fc03177771c32ccff779845bf
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 66246
+  timestamp: 1734715070548
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py310hecd8cb5_0.tar.bz2
+  sha256: 7669c43d362b42ed8c5d52c9660420df67f8f4ce59194d95c038b01b66f085d1
+  md5: 62dcb988e38541d7073093a64453dbb4
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 11601
+  timestamp: 1659769547734
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py310h46256e1_1.tar.bz2
+  sha256: f6f8782a5819de11bda699f33fba2fe021cb649b6159eee23fc34a63c7eff5c1
+  md5: 670d37976f4ff25b3493f251cbd58290
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 499079
+  timestamp: 1736544528316
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.5.0-py310hecd8cb5_0.tar.bz2
+  sha256: 47c794f8d516c71124129b3cedbc70fe9ec6e4b0e2bdc58eabd412f3263bde12
+  md5: 018d47ae2923ae3696c75c585cd708f1
+  depends:
+  - brotlicffi >=0.8.0
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - h2 >=4,<5
+  - zstandard>=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 299892
+  timestamp: 1750776005248
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+  sha256: 0f8c3eb254be9c1957e748e385e20e62509d11052990c4755012be62434c9129
+  md5: 53229ba93f6e38308ae42ecfc6eaad9d
+  license: MIT
+  license_family: MIT
+  size: 96768
+  timestamp: 1706894705048
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wcwidth-0.2.13-py310hecd8cb5_0.tar.bz2
+  sha256: ccbce44a46406c34cae232cf6c3236685d92f2ed0f988741e71b32ae6b5193ff
+  md5: df3a9f552c35e5dcab7624bfe78bdf5b
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 79225
+  timestamp: 1750353281400
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py310hecd8cb5_1.tar.bz2
+  sha256: aae85a1650806382831d1edd5b7e8912329c2d5859dd63258f2b422d0bee1761
+  md5: 7502e3b07c9f996017a9171d056b3865
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21319
+  timestamp: 1642539070002
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py310hecd8cb5_0.tar.bz2
+  sha256: df09c3d9eb682cfb34e3d892d1a8dafe3a4b252b18cc6539c8f1c331b1a72a39
+  md5: 6632d513deb34751cfee6129f71ab6d1
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 88313
+  timestamp: 1715878355449
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.45.1-py310hecd8cb5_0.tar.bz2
+  sha256: 81167843a2e44d893a2133da83739f3c2e32dfd9b9e2895df39714583e6ed966
+  md5: 5500aa5ed79cc8588872dfeabf40b458
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 111866
+  timestamp: 1737991632950
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py310hecd8cb5_0.tar.bz2
+  sha256: 1c101b0f6db62313e4d845ccbec9256e97a01b3a9bebb84174c6bd5a302ba809
+  md5: 3490e2adaefd69ec35a5f0eefa902ef7
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1812032
+  timestamp: 1689041517180
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py310hecd8cb5_1.tar.bz2
+  sha256: b7c324c44d31162d3ae297d38d95157f1d8b27c8dd6de2ee369e2426eb1c7d67
+  md5: cb55c97b4ce01dec47958aefa7845582
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49600
+  timestamp: 1675159097509
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.6.4-h46256e1_1.tar.bz2
+  sha256: c46b5b4e5159739c03830541c7261691d556a897ddabdf1a4024fe40d22bdefe
+  md5: 5a0422426246e10734acfb8dd2b9fac6
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 286200
+  timestamp: 1739468347605
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+  sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
+  md5: c25b6d40f834647d0bbe767f6c776031
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 329449
+  timestamp: 1705602140856
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py310hecd8cb5_0.tar.bz2
+  sha256: 5a12afd890a62af36fa68990182fec6ce14a15836b0985ba5efcaf477e374368
+  md5: ab35b58320c81d4687504c7f6ec1d107
+  depends:
+  - heapdict
+  - python >=3.10,<3.11.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78791
+  timestamp: 1695832967750
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.21.0-py310hecd8cb5_0.tar.bz2
+  sha256: 39093c8982b24650d28be1ff138fedf7eb3ffc6f904ddd227f56b9d28241fedf
+  md5: 602a7d8d4582fe29d24e4cd02f09eb01
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 26953
+  timestamp: 1732630810165
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+  sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
+  md5: f2519b551f99765d9d98950c5e2b4713
+  license: Zlib
+  license_family: Other
+  size: 119782
+  timestamp: 1714511811597
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
+  sha256: a1f470eabe211500d2ec7866ecf421c067f159045f0245f19e9ba8272c5a177e
+  md5: f8bd5fb9fac17a47c64ae56355faba24
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1033188
+  timestamp: 1728487057684
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.10.0-py310hca03da5_0.tar.bz2
+  sha256: c4b5fd397d14ed2d6df8c5234111dadee4b74e70803d30a282294043f05b894f
+  md5: d943073a1944b389d6f9ee2ebb872cef
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.10,<3.11.0a0
+  - sniffio >=1.1
+  - typing_extensions >=4.5
+  constrains:
+  - uvloop >=0.21
+  - trio >=0.26.1
+  license: MIT
+  license_family: MIT
+  size: 239915
+  timestamp: 1758623432239
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aom-3.12.1-ha237518_0.tar.bz2
+  sha256: 79f552871db4783edccced363e93cb97435416987172648b990e83344a2b6e4f
+  md5: c9cc75d00521b3feb03c42bd94a086b7
+  depends:
+  - __osx >=11.1
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2869476
+  timestamp: 1754917631646
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.4-py310hca03da5_0.tar.bz2
+  sha256: 28658d79a8ee2c4a6c56da614199dd6ec3c9500d2b54fc6f29af216a324ef886
+  md5: bd11d61b23646d3417d6af5f53b16c64
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14108
+  timestamp: 1750774892344
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-25.1.0-py310hca03da5_0.tar.bz2
+  sha256: 8c173f247fa0e90818f38f4384660d2ad8be71f1f5a65b36da97ab4bbdc51031
+  md5: 1c479cc5a3a5d2ae315c4974f4c7b896
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 29895
+  timestamp: 1766067842566
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-25.1.0-py310h254cc4a_0.tar.bz2
+  sha256: f12d534cb21bf0415f3a877f098720143252554e2140e64b7ddb1a7bcb3989ff
+  md5: ad1c0838d5b185a23762742d2a7d1941
+  depends:
+  - __osx >=12.1
+  - cffi >=1.0.1
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 34390
+  timestamp: 1757924888870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-21.0.0-hc027f7d_2.tar.bz2
+  sha256: 1ceddc438be2d9fb229184abaed4ca658f11e1ffc155133cff74dfe2ca9a2486
+  md5: ba5e8bdf9b4cdd7db528f8afcc18e5e8
+  depends:
+  - __osx >=12.1
+  - aws-crt-cpp >=0.34.0,<0.34.1.0a0
+  - aws-sdk-cpp >=1.11.638,<1.11.639.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.5.0,<0.6.0a0
+  - libabseil * cxx17*
+  - libabseil >=20250814.1,<20250815.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libcxx >=20
+  - libgrpc >=1.74.1,<1.75.0a0
+  - libprotobuf >=6.33.0,<6.33.1.0a0
+  - libre2-11 >=2025.11.5,<2026.0a0
+  - libthrift >=0.22.0,<0.23.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.18,<4.0a0
+  - orc >=2.2.0,<2.2.1.0a0
+  - snappy >=1.2.1,<2.0a0
+  - utf8proc >=2.6.1,<2.9.0
+  - zlib >=1.2.13,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 10807131
+  timestamp: 1766073785214
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/asttokens-3.0.0-py310hca03da5_0.tar.bz2
+  sha256: dac76910bf0b466fb69f1c319fce5c452d3a9b29ddff3ef08c54fd11eeefa44c
+  md5: c730feef0907ab3e8aba7f2b798d131b
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - astroid >=2, <4
+  license: Apache-2.0
+  license_family: Apache
+  size: 42600
+  timestamp: 1743630474730
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-25.4.0-py310hca03da5_2.tar.bz2
+  sha256: 89b7466fc0dbfefc4eec4433ccf98328ae852b60e1b5247bf9c5a823ad19f19a
+  md5: ba1b0fcf9e8b79c14036ac83f7f0f234
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 147989
+  timestamp: 1762356911308
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-auth-0.9.0-h79febb2_2.tar.bz2
+  sha256: e58d2ea9caa584df650a24543ca1f54c1e16778d8c6570ceb6b2137a148d6252
+  md5: 08ebe096b6f9bf86873885791ec05c01
+  depends:
+  - __osx >=11.1
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - aws-c-http >=0.10.4,<0.10.5.0a0
+  - aws-c-io >=0.21.4,<0.21.5.0a0
+  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 104047
+  timestamp: 1756801724494
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-cal-0.9.2-h79febb2_1.tar.bz2
+  sha256: ab497b92dafd089f2629103fc0677c9452b4c390e18eb43007e8dd8e0ab68fa8
+  md5: abcda967af4749911b88c1e25ceb6d2b
+  depends:
+  - __osx >=11.1
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 46403
+  timestamp: 1756730573239
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.12.4-h79febb2_0.tar.bz2
+  sha256: 969feab675d48144eee60f7aa6b731a516769d853fe02cc46e7baef0517ba3d9
+  md5: 597fb9544356279405db55808e24aabd
+  depends:
+  - __osx >=11.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 236969
+  timestamp: 1756721626554
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-compression-0.3.1-h79febb2_2.tar.bz2
+  sha256: 0e079411b1dc8970c9e7407064cf64339b09ac8981cbae1b212545563fb4b2fb
+  md5: 115586f5b399e8552e1ba0ad06048cfe
+  depends:
+  - __osx >=11.1
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 20227
+  timestamp: 1756734195919
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.5.6-h79febb2_0.tar.bz2
+  sha256: 3ed938b9ce0d0aa39f56313bbfef27d6dd95866df27a43473bbc229eba821e09
+  md5: fcd436a40bcd779f49df65d68875c4c9
+  depends:
+  - __osx >=11.1
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - aws-c-io >=0.21.4,<0.21.5.0a0
+  - aws-checksums >=0.2.7,<0.2.8.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52287
+  timestamp: 1756758196659
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-http-0.10.4-h79febb2_0.tar.bz2
+  sha256: 89d387df3a34e1ae4334a371e7cdcb8485a4e24c59e36e633412b66f0f29ac23
+  md5: f89a68ff62ebe085116ef76c13aff54e
+  depends:
+  - __osx >=11.1
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - aws-c-compression >=0.3.1,<0.3.2.0a0
+  - aws-c-io >=0.21.4,<0.21.5.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 180034
+  timestamp: 1756758208457
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-io-0.21.4-h79febb2_0.tar.bz2
+  sha256: a47df9261a3059ef5099717655a2af0290f90d128cfebe331747afd394bc686d
+  md5: 99f20a7ee41c1921cab3d4195cb5bfa6
+  depends:
+  - __osx >=11.1
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 171178
+  timestamp: 1756734350358
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-mqtt-0.13.3-h387b88a_0.tar.bz2
+  sha256: 2914081a3bc97a5b681fd105e848292a1d141e3fdd325226fd3c57dd33fc4b09
+  md5: b28e8c725662d459b290bc077627a2e2
+  depends:
+  - __osx >=11.1
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - aws-c-http >=0.10.4,<0.10.5.0a0
+  - aws-c-io >=0.21.4,<0.21.5.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 180341
+  timestamp: 1756801745396
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-s3-0.8.7-h79febb2_0.tar.bz2
+  sha256: 340b21fc5a853ca36b5d93351423ff4976bdcaf82a28270c87fd10fb541970dc
+  md5: f8c80bbab373976425783a84e442dbc0
+  depends:
+  - __osx >=11.1
+  - aws-c-auth >=0.9.0,<0.9.1.0a0
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - aws-c-http >=0.10.4,<0.10.5.0a0
+  - aws-c-io >=0.21.4,<0.21.5.0a0
+  - aws-checksums >=0.2.7,<0.2.8.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 113931
+  timestamp: 1756803951772
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-sdkutils-0.2.4-h79febb2_1.tar.bz2
+  sha256: a8f68e1d5f9f82b23e644d1bee3462d4ad44e881b605897a21328c1e8c782444
+  md5: f1f952a9a62432f43f2fddf65e00bd42
+  depends:
+  - __osx >=11.1
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 55465
+  timestamp: 1756730733896
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.2.7-h79febb2_1.tar.bz2
+  sha256: 593ac7e6b00ad25d1c6d616a70bde41c37bf3671991ae07500d6d6be90eb1c39
+  md5: ba01addb9b493090d50617bbf6f5f91d
+  depends:
+  - __osx >=11.1
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 78629
+  timestamp: 1756730921033
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-crt-cpp-0.34.0-hee39554_0.tar.bz2
+  sha256: 1d7b424e0acb26f4e00d2d8513063bf1cac2d22421c04ffdce28dff9510ca934
+  md5: 314e9583ed922e388959b864658cfd0f
+  depends:
+  - __osx >=11.1
+  - aws-c-auth >=0.9.0,<0.9.1.0a0
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - aws-c-event-stream >=0.5.6,<0.5.7.0a0
+  - aws-c-http >=0.10.4,<0.10.5.0a0
+  - aws-c-io >=0.21.4,<0.21.5.0a0
+  - aws-c-mqtt >=0.13.3,<0.13.4.0a0
+  - aws-c-s3 >=0.8.7,<0.8.8.0a0
+  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  - aws-checksums >=0.2.7,<0.2.8.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 354570
+  timestamp: 1756806714995
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.11.638-h35fa3df_0.tar.bz2
+  sha256: 7a3a600335e070a16e732af8e5e022d8f072a1e888918eb4a471fcbd12762ac3
+  md5: 01bc21fbf9f74b0df62c4e97462eef32
+  depends:
+  - __osx >=11.1
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - aws-c-event-stream >=0.5.6,<0.5.7.0a0
+  - aws-crt-cpp >=0.34.0,<0.34.1.0a0
+  - libcurl >=8.15.0,<9.0a0
+  - libcxx >=14.0.6
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3778934
+  timestamp: 1756812349648
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.14.2-py310hca03da5_0.tar.bz2
+  sha256: 882cf96799e70998e3a8740d73ee70e06f2208fcf05da492507eea441258e127
+  md5: 71b570513fad15a429da7f9ee4055bee
+  depends:
+  - python >=3.10,<3.11.0a0
+  - soupsieve >1.2
+  - typing-extensions >=4.0.0
+  license: MIT
+  license_family: MIT
+  size: 216287
+  timestamp: 1764159508299
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bleach-6.3.0-py310hca03da5_0.tar.bz2
+  sha256: 45c601638b4a6bae6f71f837cf1029f171f60ad5678957869282a956f580e757
+  md5: 5279645ba256e1f66eb0d2a3c94cde19
+  depends:
+  - html5lib 1.1
+  - python >=3.10,<3.11.0a0
+  - webencodings
+  constrains:
+  - tinycss2 >=1.1.0,<1.5
+  license: Apache-2.0
+  license_family: Apache
+  size: 82797
+  timestamp: 1764153588663
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py310h33ce5c2_0.tar.bz2
+  sha256: b0f9f35148a0c19833db161db41322512880a3fc7ea5853745864122650d0117
+  md5: d199b3fbf3bcf4b165bb779aca7ad26c
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6476634
+  timestamp: 1690546122888
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotlicffi-1.2.0.0-py310h50f4ffc_0.tar.bz2
+  sha256: 93a21f3dcc1b94ac80b86ad48191a70409887e21ecb16da8818c24519fbc0071
+  md5: ae23e701a1aa25394b2e527bd7aa3eba
+  depends:
+  - __osx >=12.1
+  - cffi >=1.0.0
+  - libcxx >=20
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 430061
+  timestamp: 1764961200905
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+  sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
+  md5: 56d1386c7f1f338f0d18f82af6525273
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 158748
+  timestamp: 1714510571033
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.34.5-h2ca31fc_0.tar.bz2
+  sha256: 3bbd4f2259c370c72e3af3e4664b4755890581a06077446190530ae149880cd7
+  md5: 383f8208f4e5fa7038704823ada319f8
+  depends:
+  - __osx >=11.1
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 190299
+  timestamp: 1756141933569
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2025.12.2-hca03da5_0.tar.bz2
+  sha256: 1083c19fbd27a92f84c2bf5fa4c24e849677e94f1cd39c11ec2cc41d0afddc53
+  md5: 2b15e4d759711c1ebe4c688ab4bd50ef
+  license: MPL-2.0
+  license_family: Other
+  size: 135036
+  timestamp: 1764713818379
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cairo-1.18.4-h191e429_0.tar.bz2
+  sha256: 7a77249506242f7f6489686e8d3d066e9324cafe36334549ac80f01d35c4df48
+  md5: c062ce1b28b012153da845b80783037c
+  depends:
+  - __osx >=11.1
+  - fontconfig >=2.14.1,<3.0a0
+  - freetype >=2.13.3,<3.0a0
+  - libglib >=2.84.2,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - pixman >=0.46.4,<1.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: LGPL-2.1-or-later or MPL-1.1
+  license_family: LGPL
+  size: 652115
+  timestamp: 1756136709395
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2026.01.04-py310hca03da5_0.tar.bz2
+  sha256: ca86028ad52392d5a3f673e42c3c851dcf94a8debb5ea123f685c07d1707272e
+  md5: 81bdb095bb6838293d3ac6df09dc5537
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 154134
+  timestamp: 1767659162459
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-2.0.0-py310h73c2a22_1.tar.bz2
+  sha256: 227b22b9f8ecf7e0d06a63ee1412c5bb8ffa64461b06e5dcd289b2a7e1001fbb
+  md5: 938b05bd1ccff72adc471f9bd95ebcae
+  depends:
+  - __osx >=12.1
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 236977
+  timestamp: 1761832805842
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/charset-normalizer-3.4.4-py310hca03da5_0.tar.bz2
+  sha256: 72a7e1d39e7dc309367f183f49be99612c1e192825da666e7a829cb96e0ff49b
+  md5: 678b345524b733c39690084401e173a4
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 84369
+  timestamp: 1761744861829
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.2.1-py310hca03da5_1.tar.bz2
+  sha256: f363ea14e21deb3b3782e410c6287e9ae1d0a45f66481bfc37f39bebca3faa05
+  md5: 1d5f2d52bd470c6e8bea78e2ed409473
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 283568
+  timestamp: 1764332259310
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.1.2-py310hca03da5_0.tar.bz2
+  sha256: 3f4449089a05dc5f866904773b8a9fd7b5ab9e254855d08a703162c05b785de8
+  md5: a44129d24259cd940e9e2a0e9efc60e8
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64525
+  timestamp: 1764930370640
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py310hca03da5_0.tar.bz2
+  sha256: 227fe006de1e483775d205cad12d909da267c42a328fae304b8ebf9fbf5818cf
+  md5: 4f0ced86c3e12c6ae37bbb69ae883468
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 495012
+  timestamp: 1709758412929
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.3-py310hca03da5_0.tar.bz2
+  sha256: 78441525b2291b511a889079a69bbaecb9aee5f7b3b1efa3d6bb06a29c6e1b31
+  md5: 3079b844d92ec9469435c08ec4869fe7
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14812
+  timestamp: 1763119174254
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.3.1-py310h48ca7d4_0.tar.bz2
+  sha256: 95282a2e74d7369fdf21e98189bdf1d662ba779679f01ca9fcfc32c018c59d25
+  md5: 4250cc6830136878e70342948f049b6f
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.23
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279657
+  timestamp: 1732540233373
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cramjam-2.11.0-py310h6fe787a_0.tar.bz2
+  sha256: 9a317ced18e6916ca59a4e7361d88558a4ffb0948d0085e5e0cd49c061ddb5b6
+  md5: 3fc1092cc740787e46e558d5ec7b687c
+  depends:
+  - __osx >=12.1
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1765182
+  timestamp: 1762433072542
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cycler-0.12.1-py310hca03da5_0.tar.bz2
+  sha256: f0d8372a6762e3cca23b18a5d2450f35623a99c23d96cbe4485aeecc52b151e3
+  md5: c3c7653aaa14370208a12330a56f2273
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17140
+  timestamp: 1766067958754
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-1.1.0-py310haa24f5a_1.tar.bz2
+  sha256: 37155497ab1eae8e532ba044ac6683f8a3a4200310b09b31d298f89beaf2d9e3
+  md5: 00ff5628c07800c824314b687ca1a83c
+  depends:
+  - __osx >=12.1
+  - python >=3.10,<3.11.0a0
+  - toolz >=0.8.0
+  constrains:
+  - cython >=0.29
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 825914
+  timestamp: 1764692874968
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.15.1-py310hca03da5_0.tar.bz2
+  sha256: 0d5a57908c4a77480ea47747206f2f24d923cb61e4c43aa9e3250ca58ea12a3c
+  md5: 711b2ae78257f2233e50943703f9a994
+  depends:
+  - colorcet
+  - dask-core
+  - datashape
+  - numba
+  - numpy <2.0a0
+  - pandas
+  - param <2.0.0a0
+  - pillow
+  - pyct
+  - python >=3.10,<3.11.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17665724
+  timestamp: 1689587754855
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py310hca03da5_1.tar.bz2
+  sha256: b34be91d041bb250d2f03fd4e995b08c5768272137c69c4c067a3e2d00cba1f5
+  md5: ab843d7bc0da8dcf38f8ac133b9827be
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 104228
+  timestamp: 1643973184510
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dav1d-1.2.1-h80987f9_0.tar.bz2
+  sha256: cdc3829b4dacd2c09ffcea509947b99dbe12eff4c9fd5f0d412795e2d3648b04
+  md5: cb80d50ff320b1865a31c59c9602ea4b
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 397700
+  timestamp: 1688746000695
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.8.16-py310h50f4ffc_1.tar.bz2
+  sha256: 618057eedf293fe2fb6bdb5f2be960b22dbc03342f9a987f6f840d0fe1facacc
+  md5: 04960331a0d78373d183c5dde15a4d94
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 2628404
+  timestamp: 1762421685312
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/decorator-5.2.1-py310hca03da5_0.tar.bz2
+  sha256: 16e8cbba884c360b1a8c2c70a441dff5f29baa3903d83bcc48d26d08b335e6d9
+  md5: fbc1ae312a953912716ecf80f97dba3e
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 36036
+  timestamp: 1757341256453
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py310hca03da5_0.tar.bz2
+  sha256: 1d532b889e0e71fe68f59e0fd328fe4c42c11660de3a32a0e31fe149f02a3eb5
+  md5: f5ec34d95710f724fd4b4c064ed0abcd
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT License
+  license_family: MIT
+  size: 15257
+  timestamp: 1650293833649
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.3.0-py310hca03da5_0.tar.bz2
+  sha256: c6982aa40584379b0b6654b2f04937455ecab79adab7501620b3c9e7c3e62345
+  md5: 39794daa82fa0d2332b8f59b5f4236a1
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing-extensions >=4.6.0
+  license: MIT
+  license_family: MIT
+  size: 39801
+  timestamp: 1761560378167
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/executing-2.2.1-py310hca03da5_0.tar.bz2
+  sha256: fcca7fce19e95faee717484dcdc4e4ba73f590d5d9230c4d4d937a0270afd02b
+  md5: 342fc164589193f2bba5804b8d6e381c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 840787
+  timestamp: 1757061255001
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/expat-2.7.3-h50f4ffc_4.tar.bz2
+  sha256: 06f70e6fd587c4af48a22ea484488c8c010cbe271aeba680c18430c27e01111e
+  md5: 5ac841489cce930929d2c645ee46962a
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  - libexpat 2.7.3 h50f4ffc_4
+  license: MIT
+  license_family: MIT
+  size: 21722
+  timestamp: 1765208110863
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-2025.12.0-py310h03d0aa3_0.tar.bz2
+  sha256: 069d1bc27cd0cef704a1deabefcd4dbf0e4b7e631aa650c72089432e380a891c
+  md5: 91b6edeff7ba247fde1e0d7936afbc99
+  depends:
+  - __osx >=12.1
+  - cramjam >=2.3.0
+  - fsspec
+  - numpy >=1.21,<3
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 639411
+  timestamp: 1767955453222
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fontconfig-2.15.0-h29935d0_0.tar.bz2
+  sha256: 0c9d906d3ae6a0e06c43e96179479aba91b329e116652920aaca57c27069d5a8
+  md5: 383eb3d8ab46fbb3a6463f12062ee4f5
+  depends:
+  - __osx >=12.1
+  - expat >=2.7.1,<3.0a0
+  - freetype >=2.13.3,<3.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 288789
+  timestamp: 1759153863923
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.61.0-py310haa24f5a_0.tar.bz2
+  sha256: 0ccecfdd93e7a85f89f419427bc8ec56c4e1570dc4f3d328a4faa38fd4337b34
+  md5: 9d7c6b1cf6173ae5cc5e4df61b1bd61d
+  depends:
+  - __osx >=12.1
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - lxml >=4.0
+  - zopfli >=0.1.4
+  - unicodedata2 >=17.0.0
+  - uharfbuzz >=0.45.0
+  - brotli-python >=1.0.1
+  - lz4 >=1.7.4.2
+  - skia-pathops >=0.5.0
+  license: MIT
+  license_family: MIT
+  size: 5187737
+  timestamp: 1765445239804
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.13.3-h47d26ad_0.tar.bz2
+  sha256: 4a2d6a43554c8e979add8b233706697c8216db1e4b793b5cd89a36d160813651
+  md5: 06993a434722239b6dad560bd10be839
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only or FTL
+  license_family: Other
+  size: 901356
+  timestamp: 1743636674921
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fribidi-1.0.16-h8859324_0.tar.bz2
+  sha256: 95f3be9ed9936c88fe5facc58ed5e5e89d6b2dba4c16474f705ce76589c4d7d2
+  md5: 776e35afcdd937d7a1141e82f8a0971d
+  depends:
+  - __osx >=12.1
+  license: LGPL-2.1
+  size: 62403
+  timestamp: 1768428376416
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2026.1.0-py310h7eb115d_0.tar.bz2
+  sha256: 3255875354b4f3d209aabf96d3d2d0952c1257590ca89cb72e4915f00b201999
+  md5: 5cddb2a1255529085d61844c1f2d0764
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - s3fs >2024.2.0
+  - gcsfs >2024.2.0
+  - pyarrow >=1
+  - aiohttp !=4.0.0a0,!=4.0.0a1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 571265
+  timestamp: 1768898134705
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-0.21.0-hbdbcc25_2.tar.bz2
+  sha256: a9703c804e8377c081602e701536bb9ee3e45d73682ed991d4ab89b512f4dd6b
+  md5: f2541033cfec7a7244448619f81a5b0d
+  depends:
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - libxml2 >=2.13.1,<2.14.0a0
+  - llvm-openmp >=14.0.6
+  - ncurses >=6.4,<7.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 3546065
+  timestamp: 1722922815248
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+  sha256: 25e05b93a99914a5fd1a298a2c5b25479fbd571b0db9caa7c6ad4336f060f62c
+  md5: e213b68bb0274e0e54c610a041e059f5
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 150168
+  timestamp: 1706888198288
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+  sha256: bbbcf47ef9249635b5199be1414b0b59687cc04ea9630d50ecc609dc200c095e
+  md5: 5820c373d6847a68551cadb8984a8277
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 95638
+  timestamp: 1706895270850
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/graphite2-1.3.14-hc377ac9_1.tar.bz2
+  sha256: eda72845d574c722f8c2912d9e60bd95092691de92ccf90a9184d05b459ddbf4
+  md5: d5a91162086ce20929bff85220aa26ba
+  depends:
+  - libcxx >=12.0.0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 82282
+  timestamp: 1654175384566
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/harfbuzz-10.2.0-he637ebf_1.tar.bz2
+  sha256: dffc233275fadb16612f0b0eeba97f8daa285821729d83d8c7d2d68f64599e3a
+  md5: 3f97af46d370ee250dc9e2abb552c081
+  depends:
+  - cairo >=1.16.0,<2.0a0
+  - freetype >=2.13.3,<3.0a0
+  - graphite2 >=1.3.14,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libcxx >=14.0.6
+  - libglib >=2.78.4,<3.0a0
+  license: MIT
+  license_family: MIT
+  size: 2679539
+  timestamp: 1748952137021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.16.0-py310hca03da5_0.tar.bz2
+  sha256: 005656499e7971d24aaf39eedb46e149c990549fd3d40da31dae3e7f39cd91e8
+  md5: 7c7f7a16ca020ef4eb0f6b270aee2d2e
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4608554
+  timestamp: 1684937085659
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+  sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
+  md5: 69eb3b03765627b6159ed23cdde78396
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28399065
+  timestamp: 1692293207812
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.11-py310hca03da5_0.tar.bz2
+  sha256: 4a535b1aa180eeab57c5e3f866134d5dca4b02d87f5282145cf6b98afbc71736
+  md5: 6c89cd68d9bbfddc40a7db8e5d0d708f
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 239221
+  timestamp: 1761912023379
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-8.7.0-py310hca03da5_0.tar.bz2
+  sha256: f97ead44962e3bc7d2f4ed92fbce24d0306f43e0c8fedd7c6fc8c3d91cd71141
+  md5: 297f2ebf3d0c97f7c1655f5368ca9645
+  depends:
+  - python >=3.10,<3.11.0a0
+  - zipp >=3.20
+  license: Apache-2.0
+  license_family: APACHE
+  size: 59233
+  timestamp: 1763996595934
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py310hca03da5_1.tar.bz2
+  sha256: 10882d46d9df4b33306f0ae9bd114d853699cb3383f68f052711101f450ea55e
+  md5: f00868ddced6839c17b68b6dc7dd7d88
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193150
+  timestamp: 1737661074253
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.30.0-py310hca03da5_0.tar.bz2
+  sha256: 3d3a99de5f6fbf0f3491dd8f5de3a7707c33d4bee8d4e703ae7d6163e5711c16
+  md5: 3bed0b1b68c3f561801199f2d27d579a
+  depends:
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.10,<3.11.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1296306
+  timestamp: 1734548092647
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jansson-2.14-h80987f9_1.tar.bz2
+  sha256: a7f6b1a5be13fa86c4c94dcebb4309d1ec8ab9ed821b401db9e0afcd844eb366
+  md5: 0382b3637c88a9384cdd784cfdbcc28d
+  license: MIT
+  license_family: MIT
+  size: 37982
+  timestamp: 1705704639712
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.2-py310hca03da5_0.tar.bz2
+  sha256: 17c139d48f3f13458fa42455aed27cc67c36915c594b41c789ec0596d2b8af84
+  md5: 039499f7e2e77e05838b4e41f79f8850
+  depends:
+  - parso >=0.8.4,<0.9.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1050141
+  timestamp: 1733987485937
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.6-py310hca03da5_0.tar.bz2
+  sha256: e2782da2156231487e1809ea074db75ad59b04baa433d2c9f14cef8e8d489bb7
+  md5: 6b2b5f9f3dd7e4249bbae35b27457daf
+  depends:
+  - markupsafe >=2.0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279736
+  timestamp: 1741710984403
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9f-h2f69dba_0.tar.bz2
+  sha256: 3bcf11af8b08f140845c7b826bdf1e0c4d5ccdb0c244f4bdf926c19d347c3c77
+  md5: ac568efe96ed793f13c9bb93045196a5
+  depends:
+  - __osx >=12.1
+  license: IJG
+  license_family: Other
+  size: 270667
+  timestamp: 1757499055900
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.25.1-py310hca03da5_0.tar.bz2
+  sha256: 42317c3f2654374f20f42cce1c8e3c2e258f869825352e435fb4bd51ec05334a
+  md5: 32dc305c91d01423f0f6dc47554b64a9
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.10,<3.11.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 146673
+  timestamp: 1767955669156
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2025.9.1-py310hca03da5_0.tar.bz2
+  sha256: a06c22b900b0e26408f97922c691b67959faa131cdc1972340247b624f984b73
+  md5: 9b852d473edca7382e7245bf317e059d
+  depends:
+  - python >=3.10,<3.11.0a0
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 15777
+  timestamp: 1762788436186
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py310hca03da5_0.tar.bz2
+  sha256: f723762f6638ac41a57cf16527d87ca94e3d1e60cd404fd58d694bf4b15c6267
+  md5: cc8524666e2ac097a9c54a077e3a776c
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 199244
+  timestamp: 1676329389846
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.9.1-py310hca03da5_0.tar.bz2
+  sha256: 04aa54c1377ffbd43511b4f38f405403150cf28107d0e5a4f2f0721540749b13
+  md5: a997db37cb2d5396eaaa549a5d72e67e
+  depends:
+  - platformdirs >=2.5
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84151
+  timestamp: 1764588305883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.12.0-py310hca03da5_1.tar.bz2
+  sha256: ce3f245c414dc8a026fadaba43fd35c1956632721f56338595d79f944cb1587e
+  md5: 6203a1608d6de1be1fd36793a3ce07cf
+  depends:
+  - jsonschema >=4.18.0
+  - packaging
+  - python >=3.10,<3.11.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36371
+  timestamp: 1765813622000
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.17.0-py310hca03da5_0.tar.bz2
+  sha256: c990801c83b45a265ff0306f2d0533fd22ecd3027dc5f57d7d83da9f6f6b7eda
+  md5: b8d5110d0bc5299fc49cf983ad1e4866
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.11.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert-core >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 544682
+  timestamp: 1764955108827
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.5.3-py310hca03da5_0.tar.bz2
+  sha256: e18560f96ccf2f118cac9d8923f29c06234126a98b2b2a99a96a5afbd3e87f5c
+  md5: d8e7fe75fdffeb074f942e6158cbdea8
+  depends:
+  - python >=3.10,<3.11.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25842
+  timestamp: 1744706740906
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.3.0-py310hca03da5_0.tar.bz2
+  sha256: 43889d463a225b5ea59a44cdfbd81c91743f7602a7c9a264a4e89255cc6f5959
+  md5: fa899214d8435f8be9a08de95993a5ca
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jupyterlab >=4.0.0,<5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21751
+  timestamp: 1741124234166
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.9-py310haeee614_0.tar.bz2
+  sha256: 1c9291e6d93dfc50edbd29cc25ff5aea376edc3e3debd14d1e0084814e6e92bd
+  md5: 5c1fb986ac1e8ed5ae34b9c0317f7641
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 69578
+  timestamp: 1764159449993
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.17-h7418793_0.tar.bz2
+  sha256: f21b37c1baa5879b854b467f309e5d70137152fb9ebc403d9b8687fd342c8029
+  md5: 52f968607c5c02fc89027cf0e8116408
+  depends:
+  - __osx >=12.1
+  - jpeg >=9e,<10a
+  - libtiff >=4.7.1,<5.0a0
+  license: MIT
+  license_family: MIT
+  size: 239932
+  timestamp: 1764162757281
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-4.0.0-h313beb8_0.tar.bz2
+  sha256: f123fe7eb47ac10d174364902a64c311b1875f4863b1b3791e6b3fca8e0ab272
+  md5: b62145f1eeed0a89b5d76c3bb9b409d5
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 222115
+  timestamp: 1734423410079
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libabseil-20250814.1-cxx17_hbea547f_0.tar.bz2
+  sha256: 2e446d4ca0cfc02f04d8279dee8067510bf59b9365ed33e888af54ed481becb5
+  md5: cdb38b4b55b22337f11a180fd383ab12
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  constrains:
+  - abseil-cpp =20250814.1
+  - libabseil-static =20250814.1=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1384863
+  timestamp: 1763134076326
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libavif-1.3.0-h839b4eb_0.tar.bz2
+  sha256: e213b9c16635d78ce69ad5a482762447ac6d45e3e4eba5c6c3f88b282b173e28
+  md5: 5bb0d6ef4d1b35ef896dc80bd2bf18e6
+  depends:
+  - __osx >=12.1
+  - aom >=3.12.1,<3.13.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 136581
+  timestamp: 1763972822425
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.2.0-hbd7815e_0.tar.bz2
+  sha256: ddd9f6bd1ee66f421aca5092ad5de76d4b28e55cde53d3794b23615f1420f958
+  md5: 6135ac603a6265cbeb776b5347778a69
+  depends:
+  - __osx >=12.1
+  license: MIT
+  license_family: MIT
+  size: 75424
+  timestamp: 1762363445823
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.2.0-h1e834b2_0.tar.bz2
+  sha256: f8a64bc27e98fdf4eb3fb5cb5b1ebf99dfe5849ac4f6474894730da209779955
+  md5: aeff9fd8304bb741c40af4e1389468bf
+  depends:
+  - __osx >=12.1
+  - libbrotlicommon 1.2.0 hbd7815e_0
+  license: MIT
+  license_family: MIT
+  size: 30858
+  timestamp: 1762363457191
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.2.0-h5439a07_0.tar.bz2
+  sha256: 0b546374b04f57c9902cc9bb17b60ba59a0feeec6ba0bcda7d3211ce848ce384
+  md5: 68f6208a928c22623c4a3989d176227e
+  depends:
+  - __osx >=12.1
+  - libbrotlicommon 1.2.0 hbd7815e_0
+  license: MIT
+  license_family: MIT
+  size: 343397
+  timestamp: 1762363468368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.17.0-h5bd1c32_0.tar.bz2
+  sha256: e3f203cc39e7bc5a7aca36014971c749940b3a52595b04dcecc79d2f055bbd34
+  md5: 90848db57b98bd5401f2be932468e4e2
+  depends:
+  - __osx >=12.1
+  - libidn2 >=2,<3.0a0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.67.1,<1.68.0a0
+  - libssh2 >=1.11.1
+  - libssh2 >=1.11.1,<2.0a0
+  - openssl >=3.0.18,<4.0a0
+  - zlib >=1.2.13,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 427767
+  timestamp: 1766164060872
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-20.1.8-hd7fd590_1.tar.bz2
+  sha256: ed4762445fd69f6d44caa455350219812333d2eb7c25745737077f0ffaaebed5
+  md5: 22f065ac144a8e31f39864bdadb754a1
+  depends:
+  - __osx >=12.1
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 416981
+  timestamp: 1760650493890
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.22-h80987f9_0.tar.bz2
+  sha256: 695c939431f7fd074d175e62944daca33ff51f3abfe1ee5c51d92d89ad663da8
+  md5: 8985f8e47c5bd81416ed08c28d7f305a
+  license: MIT
+  license_family: MIT
+  size: 60900
+  timestamp: 1734423344642
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+  sha256: 6fc572025852b210ecddcca3ab9ff3f1d5f6bd91f1933c6e296de6bb331f6b5d
+  md5: 6dd7d9c5737bbd2a27d18f15318dc3e6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 102059
+  timestamp: 1628961869728
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+  sha256: 9e7b9bb9367d8725a751cdfa0b2d270434d303ea196cfaacc605ee26be09874a
+  md5: 44d1843cc2f17eb2674f35b95468f551
+  depends:
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 415467
+  timestamp: 1685052299052
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libexpat-2.7.3-h50f4ffc_4.tar.bz2
+  sha256: 41f36111cab90098f7611f1f3d6ee314a181d5c4f0397a293cd3d926285eaca0
+  md5: dfe821bb629af64f1c6554175a57beb7
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  constrains:
+  - expat 2.7.3.*
+  license: MIT
+  license_family: MIT
+  size: 117121
+  timestamp: 1765208107172
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+  sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
+  md5: f31e4eb9cd6447cc2f5ef0243a76540c
+  license: MIT
+  license_family: MIT
+  size: 120460
+  timestamp: 1714483461787
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-15.2.0-hb654fa1_1.tar.bz2
+  sha256: 2cb88ce7a8a97e5fd3d248af24237cb7df6e6ada54e3f7d8ee4e24972f45cb52
+  md5: 5eb56f5a5b38bc5b9e8166d98cd6281f
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 15.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 940802
+  timestamp: 1764069178918
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libglib-2.86.3-hcacd345_0.tar.bz2
+  sha256: 43744652a5cd0c736d8b032df175d1206362d9d87b437a455d192d63d69f2ea2
+  md5: 46118d0fa07774e7d8f48f45ed37dfb1
+  depends:
+  - __osx >=12.1
+  - gettext >=0.21.0,<1.0a0
+  - libcxx >=20
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.16,<2.0a0
+  - pcre2 >=10.46,<10.47.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 4722696
+  timestamp: 1768844855642
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgrpc-1.74.1-h941cc20_0.tar.bz2
+  sha256: 99aa0fd6257a24877a641bae05e79f8275d6b55695fc5b3e31dc27eab02023f3
+  md5: 82e88d110bb7e6fc038a5c204eef53b1
+  depends:
+  - __osx >=12.1
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20250814.1,<20250815.0a0
+  - libcxx >=20
+  - libprotobuf >=6.33.0,<6.33.1.0a0
+  - libre2-11 >=2025.11.5,<2026.0a0
+  - openssl >=3.0.18,<4.0a0
+  - re2
+  - zlib >=1.2.13,<2.0a0
+  constrains:
+  - grpc-cpp =1.74.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 8034284
+  timestamp: 1763140382845
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libhwloc-2.12.1-default_h2915d5d_1000.tar.bz2
+  sha256: bf0f407e7030be2559076e314477b781e176cc2931a83895966ffac72fdd097f
+  md5: 15d2c5b625e3d55025388d5dbaa5e954
+  depends:
+  - __osx >=11.1
+  - libcxx >=14.0.6
+  - libxml2 >=2.13.8,<2.14.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2694773
+  timestamp: 1755246474116
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+  sha256: 72d242814b990900c9410d4738cc685f70ea71231742293cffbb475d8df100f8
+  md5: f9976688992b7ac4b56f5600ee15b5c4
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1407202
+  timestamp: 1714483550601
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libidn2-2.3.8-h9681e36_0.tar.bz2
+  sha256: 45b8f73f24015dcb6882ed7890f6d77f9fa01491a0d024e2e568389b662c1cf3
+  md5: da34b3554c8263877326f8279ec476dc
+  depends:
+  - __osx >=12.1
+  - gettext >=0.21.0,<1.0a0
+  - libiconv >=1.16,<2.0a0
+  - libunistring >=1,<2.0a0
+  license: LGPL-2.0 AND LGPL-3.0-or-later AND GPL-3.0-or-later
+  license_family: OTHER
+  size: 146822
+  timestamp: 1760364408172
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm20-20.1.8-h1701f07_0.tar.bz2
+  sha256: 34b1de6807e5ebaca05b5416e8ceb911aa46b37066c6d3eab1457af69671de4e
+  md5: c959c83dbd14c1c03bc097c92f378fcd
+  depends:
+  - __osx >=11.1
+  - libcxx >=20.1.8
+  - libxml2 >=2.13.8,<2.14.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 36677616
+  timestamp: 1756223115172
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.67.1-h8189af8_0.tar.bz2
+  sha256: 323d884e7f598fd3bcb4da9cff1793dd8bcbaf60b232e8c9e5405be1bf621b9c
+  md5: 3f1d5ddcb5466d78bdf977db891ca710
+  depends:
+  - __osx >=12.1
+  - c-ares >=1.34.5,<2.0a0
+  - c-ares >=1.7.5
+  - jansson >=2.14,<3.0a0
+  - jansson >=2.5
+  - libcxx >=20
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - libxml2 >=2.13.9,<2.14.0a0
+  - libxml2 >=2.6.26
+  - openssl >=1.1.1
+  - openssl >=3.0.18,<4.0a0
+  - zlib >=1.2.13,<2.0a0
+  - zlib >=1.2.3
+  license: MIT
+  license_family: MIT
+  size: 797407
+  timestamp: 1762785206846
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.30-hf2bb037_2.tar.bz2
+  sha256: 2a2d102454cd14f901a65cbe4995544e92e51c3fba5dded06a2cbfad5d6123dc
+  md5: 033fd4da8f096b4151efd76d62bde317
+  depends:
+  - __osx >=12.1
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7176568
+  timestamp: 1762889555793
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenjpeg-2.5.4-haa24f5a_1.tar.bz2
+  sha256: c46a84770b38a02643143fecc11078578da47274958d5d83600598bbee25c535
+  md5: e48491140c5f4f2e1929650b9b9050d6
+  depends:
+  - __osx >=12.1
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 206857
+  timestamp: 1761732760564
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.50-h5c318fc_0.tar.bz2
+  sha256: 89737d000b641d4eb4cd05127e11cc7363af5c293fac8a320143108fa82b49c1
+  md5: 29df2749e97ffcca138f3e885e9f7075
+  depends:
+  - __osx >=12.1
+  - zlib >=1.2.13,<2.0a0
+  license: Zlib
+  license_family: Other
+  size: 231699
+  timestamp: 1761139814654
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-6.33.0-h6acce77_1.tar.bz2
+  sha256: 9fbd47e29f6662945d12d4160d7d55cde598286f7037d774677f05b2c3c5f4d6
+  md5: 82cda30faf0db92f6ce38a2328a10aea
+  depends:
+  - __osx >=12.1
+  - libabseil * cxx17*
+  - libabseil >=20250814.1,<20250815.0a0
+  - libcxx >=20
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3698939
+  timestamp: 1768234555824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libre2-11-2025.11.05-hd4f4e8d_0.tar.bz2
+  sha256: eae369e9bb8f682edb211f6987a38d618c76c4f56ddc10783e4b5673cf510c9d
+  md5: 540ffdfa70492900229e3a82818bd76c
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20250814.1,<20250815.0a0
+  - libcxx >=20
+  constrains:
+  - re2 2025-11-05 *_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 227551
+  timestamp: 1763136456176
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.20-h897f8a9_0.tar.bz2
+  sha256: 9444698c6ed655f721883bdaf199f3cbd2af4abb1ac4c2a95e112aee43a0af80
+  md5: 60bae7154adab7af8d18a30438ee311e
+  depends:
+  - __osx >=11.1
+  license: ISC
+  license_family: Other
+  size: 283896
+  timestamp: 1754318852350
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.11.1-h3e2b118_0.tar.bz2
+  sha256: 7a4a378fd967c667ec1ed6db98eb697a92838bbb2a0058d592f4615f70fbc1c7
+  md5: e65d37b5b4b531889526b0995b8589d2
+  depends:
+  - openssl >=3.0.15,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 287605
+  timestamp: 1732891144732
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.22.0-hbe873a3_0.tar.bz2
+  sha256: 146c7242da7d5c32182593b10e16d5776594f1e4053892f499bab1fcada3106c
+  md5: ad50b94c68172f0b0cb28fc42011c2f4
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  - libevent >=2.1.12,<2.1.13.0a0
+  - openssl >=3.0.18,<4.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 368542
+  timestamp: 1761570501833
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.7.1-h367c460_0.tar.bz2
+  sha256: 4746813e88ed50c2596587d71d195fd25773965266c2c416e730770d8b61a211
+  md5: 9844a048fee5c941f38260ec52284944
+  depends:
+  - __osx >=12.1
+  - jpeg >=9e,<10a
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=20
+  - libdeflate >=1.22,<1.23.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - xz >=5.6.4,<6.0a0
+  - zlib >=1.2.13,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 413466
+  timestamp: 1763980753540
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libunistring-1.3-h1799b2a_0.tar.bz2
+  sha256: 09ffed353754c619ec1b2edf5281d08db40f5c14906f48ec7c8cffba2dd21f52
+  md5: 5063c8b7332461c9a798cad6f7e5bae2
+  depends:
+  - __osx >=11.1
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 793250
+  timestamp: 1755086959740
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.6.0-h92b2d59_0.tar.bz2
+  sha256: 2e10800da4643073ad4225ddfb9e7e8d27ab8d46cbc267d04d69361dea831ba5
+  md5: 6cb156c1ab2ead24b04b0df70eab2c53
+  depends:
+  - __osx >=12.1
+  constrains:
+  - libwebp 1.6.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 373602
+  timestamp: 1763980649775
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.13.9-h528a072_0.tar.bz2
+  sha256: 7a441e0c213896ab6dfda5e73eba83c3302ae4e7063611af1ca7022bb3b24a97
+  md5: 00ab7473cbcbba76e63a7908bef50e0b
+  depends:
+  - __osx >=12.1
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.6.4,<6.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 630698
+  timestamp: 1761768989755
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzlib-1.3.1-h5f15de7_0.tar.bz2
+  sha256: a6e20d9d0356775be38a01a10e164fbab070c717839e2de673ccde0741c149e9
+  md5: 5100278a1b3a2bd906ca68347dd2985a
+  depends:
+  - __osx >=11.1
+  constrains:
+  - zlib 1.3.1
+  license: Zlib
+  license_family: OTHER
+  size: 54057
+  timestamp: 1756475936697
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.3-py310hca03da5_0.tar.bz2
+  sha256: 777eec11964051b2a86045784c99e9a007dd204f71e690e0f34d91672bb850be
+  md5: 68d8f2d21fde62e1a40870ffe5568cce
+  depends:
+  - python >=3.10,<3.11.0a0
+  - uc-micro-py
+  license: MIT
+  license_family: MIT
+  size: 41067
+  timestamp: 1758717880404
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-20.1.8-he822017_0.tar.bz2
+  sha256: 898774d2a539aee5ad5f90ef0ace8e3a200334a226395a4db4d09407b3db19e5
+  md5: 62539f1114bb3746387ab4eea137f15d
+  depends:
+  - __osx >=11.1
+  constrains:
+  - openmp 20.1.8|20.1.8.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 356849
+  timestamp: 1756229534992
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.46.0-py310hc8eb11b_0.tar.bz2
+  sha256: 768ee93046f839b743e661d095b6279cbbf44b5be3fbe565c8562082c1ffd118
+  md5: 74be30811f264aa0cc77a793632b8542
+  depends:
+  - __osx >=12.1
+  - libcxx >=19
+  - libllvm20 >=20.1.8,<20.2.0a0
+  - python >=3.10,<3.11.0a0
+  - zlib >=1.2.13,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-2-Clause AND Apache-2.0 WITH LLVM-exception
+  size: 30623884
+  timestamp: 1765874234669
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py310hca03da5_0.tar.bz2
+  sha256: a2dfd5de8c8946e1da759975b43bb4048bf720792f63e44a8197ebf78da18560
+  md5: eb339d709764df9583302fd4796f609d
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11926
+  timestamp: 1652903163430
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.4.5-py310hbc89d72_0.tar.bz2
+  sha256: 5a8953d3bf14c92c72b12bea7dfb6d25bd50b642860eadd308fa17faee58b027
+  md5: 075608853093931ff9d6855738509595
+  depends:
+  - __osx >=12.1
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48437
+  timestamp: 1762954028771
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+  sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
+  md5: f5f7e6e7541d8dc3d3df270d488d2e24
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176990
+  timestamp: 1714510588159
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.10-py310hca03da5_0.tar.bz2
+  sha256: 11c0695d8012237448aefc0a3f9d94aeada9980fa0a0da4a6c53a77ac54dad11
+  md5: ca9812acff77ee49a3ab624dfc9e8e3f
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141832
+  timestamp: 1767787334129
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py310hca03da5_1.tar.bz2
+  sha256: b0e240d3ef06e292105f4e1b161426170e5897144c142d23df66935ab4108dc5
+  md5: 8c6193fc54f6c300530527f642efadf1
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 108119
+  timestamp: 1684279956548
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-3.0.2-py310h80987f9_0.tar.bz2
+  sha256: e4f9fba9ea625b3f7904983bf7ac296f75a14293788b46fc0c0e2bedcf765a74
+  md5: 8f167785f0da6e2620ce06eeb4383073
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26662
+  timestamp: 1738584253000
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.10.8-py310haa222d5_0.tar.bz2
+  sha256: 70060cd1b55d4ce2f7c15e0b86d82c439d8aad26a2050354cac99b0e3fc3a255
+  md5: 590dc67703f1ff5bfa1f9c207156838d
+  depends:
+  - __osx >=12.1
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.13.3,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=20
+  - numpy >=1.21,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=3
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9828894
+  timestamp: 1768297770420
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.2.1-py310hca03da5_0.tar.bz2
+  sha256: dd8c784bc3c6547812b01d842cc23ef40179e8615808f1c68e9c23e1c98dc0f2
+  md5: 90d1c020883a3aa8df5e3b4f1135048e
+  depends:
+  - python >=3.10,<3.11.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17658
+  timestamp: 1762779191788
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.5.0-py310hca03da5_0.tar.bz2
+  sha256: 663d102af0235439f15c8ee31a2632c76d7229fec25125948a2539e5df3106d6
+  md5: d4e1ac8058d2c0581b417475c7a56e6a
+  depends:
+  - markdown-it-py >=2.0.0,<5.0.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 94534
+  timestamp: 1756380016476
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.2-py310hca03da5_0.tar.bz2
+  sha256: 4fad21d528143caf81c1960252036f6089ebdf20855c9b558268d751f4cd207a
+  md5: 8fc5cf9ac9a1b29d3c71c1ae1b96e72f
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 22983
+  timestamp: 1758552189289
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-3.1.2-py310hca03da5_0.tar.bz2
+  sha256: cf8f8b874e78a53ab3b7535734f52518cda20f69305d7c36b3eee888ebdb2ed5
+  md5: 7b2eac8ded50875934a5cbcfc86fe50e
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing-extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110285
+  timestamp: 1741124114775
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.1.1-py310h313beb8_0.tar.bz2
+  sha256: b140a1dfc93627df81c4dbb71fe802e80833f4f45210e463e3740b6851983b21
+  md5: b5debd0c7b0fb0482c758e16e4e20de9
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 103675
+  timestamp: 1750958675449
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-1.0.0-py310hca03da5_0.tar.bz2
+  sha256: c99ec24ebd3bb43b5e1dacf31c1294b5ae36d3fe6957c35c19b93b7d4dc5895b
+  md5: e57d5eac6a1276aa19f1e444f74e699a
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27946
+  timestamp: 1756978478132
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.3.3-py310hca03da5_0.tar.bz2
+  sha256: 036562e3d3a0eab1bf9618c832c62785346b3abbfe432b9ba800831596af80e4
+  md5: 8227539fb980c2084ee1e283008d8400
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10046354
+  timestamp: 1765189113589
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.10.2-py310hca03da5_0.tar.bz2
+  sha256: 1c1ff77c9e1618312cb0a8c6248bea01e93ddd481dc5fa02c596f667b853a01b
+  md5: d656a40c878bfab5227f3c2e3bf9a955
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 44613
+  timestamp: 1741124081761
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.6-py310hca03da5_0.tar.bz2
+  sha256: 1d38e8e7c5e078374b00664c568d105efd2829558554be285660584f2d715c21
+  md5: 4b087200d12eafd3229191c65a6cb05a
+  depends:
+  - nbconvert-core 7.16.6 py310hca03da5_0
+  - nbconvert-pandoc 7.16.6 py310hca03da5_0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8348
+  timestamp: 1741185304690
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-core-7.16.6-py310hca03da5_0.tar.bz2
+  sha256: 3699321a00daf6828e3d74e28a6964b2a5777f7d2ec11109a115560e725a4506
+  md5: 2b0488dbd36a57757baebe5f44320a62
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.10,<3.11.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - nbconvert =7.16.6=*_0
+  - pandoc >=2.9.2,<4.0.0
+  - tornado >=6.1
+  license: BSD-3-Clause
+  size: 491446
+  timestamp: 1741185291370
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-pandoc-7.16.6-py310hca03da5_0.tar.bz2
+  sha256: 82c560cf2b119845cb95c0ebc1e1efcd085e297b8cbd68e22b88143ae5472c40
+  md5: 07056286248325f3ba6d458e015268d1
+  depends:
+  - nbconvert-core 7.16.6 py310hca03da5_0
+  - pandoc
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  size: 8385
+  timestamp: 1741185298668
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py310hca03da5_0.tar.bz2
+  sha256: 1d56811db3dcf64f81534f8c062f13f5a0ad32a477ac34f13fc8a8d312b138d1
+  md5: d7bbf5d0fee20be1955640948e289403
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.10,<3.11.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 149708
+  timestamp: 1728049678663
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.5-hee39554_0.tar.bz2
+  sha256: 2a681571241e64b59404209591d926176c08415680d1105a7562f87ac3eefa5e
+  md5: 7be781c500828a66aa1422dae789f590
+  depends:
+  - __osx >=11.1
+  license: MIT AND X11
+  license_family: MIT
+  size: 1097704
+  timestamp: 1753947535285
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py310hca03da5_0.tar.bz2
+  sha256: 737ecaada7f80f42da43affef97fc31a8dcd3f2a0be14b377b34583a7d334fdf
+  md5: 914980d852a22de592f571dba8d4fe62
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14550
+  timestamp: 1708532774873
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py310hca03da5_0.tar.bz2
+  sha256: e860480e342b6f29f1b4b2fab22d8809d12a1c286d0ea451b9c4314bc53c4341
+  md5: 032486f67208f870056780ddc879afad
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 595602
+  timestamp: 1717630793498
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.4-py310hca03da5_0.tar.bz2
+  sha256: 514d5149ff4de6d4bbf9c264ce1901d7511f60dce629f9835cd51c787a8c5443
+  md5: a6743bbf22ccb926527549692e9ae2fc
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23965
+  timestamp: 1741707798225
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.63.1-py310hadc56cb_0.tar.bz2
+  sha256: c51c6fff707840a37b9a579fceb514e7bc23227f1bd6b648a79d2297e29f7d2d
+  md5: a606486484240b0af3b709d10df72364
+  depends:
+  - __osx >=12.1
+  - libcxx >=19
+  - llvm-openmp >=19.1.7
+  - llvm-openmp >=20.1.8
+  - llvmlite >=0.46.0dev0,<0.47
+  - numpy >=1.21,<3
+  - numpy >=1.22,<2.4,!=2.0.1
+  - python >=3.10,<3.11.0a0
+  - tbb >=2022.0.0
+  constrains:
+  - scipy >=1.0
+  - libopenblas >=0.3.18, !=0.3.20
+  - tbb >=2022
+  - cudatoolkit >=11.2
+  - cuda-python >=11.6
+  - cuda-version >=11.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4963519
+  timestamp: 1765905895462
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py310h901140f_1.tar.bz2
+  sha256: 510f4a9c39d30dca5f829874d63b181a26ef891ecd788327d334e8adf47068e3
+  md5: 8ac4533f0fb71bbbe8126cad1336f19e
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.29,<1.0a0
+  - numpy-base 1.26.4 py310hae06d03_1
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13544
+  timestamp: 1755591306153
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py310hae06d03_1.tar.bz2
+  sha256: c8d8bbae2d2af18e21220ff87aa34b31eee95214bfa70289514819a5ea2db5bb
+  md5: fa4d86c7835a8504c467f4d1e29f0943
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.29,<1.0a0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - numpy 1.26.4 py310h901140f_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6385014
+  timestamp: 1755591289372
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-2.2.0-hd6530ca_1.tar.bz2
+  sha256: 4c0ca4f0bae7cd420fafd7f007f216a4d6d46dc4fc457d60fc6cfb5f598df524
+  md5: f91095f70046fd40580ef6f3907a6cd5
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  - libprotobuf >=6.33.0,<6.33.1.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.2.1,<2.0a0
+  - tzdata
+  - zlib >=1.2.13,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 501418
+  timestamp: 1764689799173
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.7.0-py310hca03da5_0.tar.bz2
+  sha256: e63d75a1093cbcdca0286701203ce1bd96a070637dd2bd46a0aeedcc5f50f1ca
+  md5: 71fdb84bfcd3b6525b42230fa92d186c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 35466
+  timestamp: 1762349107715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-25.0-py310hca03da5_1.tar.bz2
+  sha256: c55183468ffe0f1b2ed206b1d3077120cf593d6236c3fbdb398a8ce850525550
+  md5: d9d689074c64ee253cdcbde633df4d40
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 166383
+  timestamp: 1761049099489
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandoc-3.8-hca03da5_0.tar.bz2
+  sha256: 18fa30b94acf2fd11bd1338c59ee4e6477f4b9919b5aa3ece430ac62ed056c17
+  md5: dfeec073104efa8f790bce4622376bdc
+  depends:
+  - libffi >=3.4,<3.5
+  - libiconv
+  - zlib
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 33948406
+  timestamp: 1758806899964
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandocfilters-1.5.1-py310hca03da5_0.tar.bz2
+  sha256: adc7c92bc45d9af33c1c9e347cbac9d9cc36fe353fe35d32177c1dd7d3e72298
+  md5: 3fcd4a2eadd6c9ea9f16c8f716c3e3c1
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15729
+  timestamp: 1756977681212
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py310hca03da5_0.tar.bz2
+  sha256: 88811223659197b175b924057b7b5926c7093cded6f9a9aed5efb6452c2be8f1
+  md5: dfb4aca8097e63f3db61cad638723639
+  depends:
+  - bleach
+  - bokeh >=3.1.1,<3.3
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.16.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17074981
+  timestamp: 1695146365895
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py310hca03da5_0.tar.bz2
+  sha256: 958c77578e3569111c33fc9ddf8ec012f4d575818488d2704cf5d3a4c00a52c2
+  md5: b0818352d65dc7ea4998a5790de52397
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 144036
+  timestamp: 1684915352915
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/parso-0.8.5-py310hca03da5_0.tar.bz2
+  sha256: 15f7a4f63fc7de0ec4448f69aa6efe738daedc589272f0ffb05c4e270ccae0a2
+  md5: 53f63a8a2389e564ae3845214f74e5be
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT AND PSF
+  license_family: OTHER
+  size: 179396
+  timestamp: 1762781726489
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.2-py310hca03da5_0.tar.bz2
+  sha256: 956cb716d024eca203ec36364c7416bbb69b6015d77e343660c85999a3661559
+  md5: bce9e46f4f6222c6f16e88e74b954056
+  depends:
+  - locket
+  - python >=3.10,<3.11.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.20.0
+  - pandas >=1.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37147
+  timestamp: 1736803487891
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre2-10.46-h1dacb4a_0.tar.bz2
+  sha256: 0d134802cfb73e7e1caf8d90d90f6f3d2c78073275fe95a100087f58a9d5cd9c
+  md5: 39d21a3f042a3633baaf29084fe28504
+  depends:
+  - __osx >=12.1
+  - bzip2 >=1.0.8,<2.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause WITH PCRE2-exception
+  license_family: BSD
+  size: 2062999
+  timestamp: 1759825795666
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pexpect-4.9.0-py310hca03da5_1.tar.bz2
+  sha256: 5f07d3951c74a08f1e581af8e7825fba4b9954ca98075200a4378c346a9deec7
+  md5: aa6d3a61eff333ec6df9fb1f40a36587
+  depends:
+  - ptyprocess >=0.5
+  - python >=3.10,<3.11.0a0
+  license: ISC
+  license_family: Other
+  size: 133802
+  timestamp: 1762535957454
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-12.0.0-py310he2d6fe4_1.tar.bz2
+  sha256: 1fed263d24deb60dd6bc4b9ff0078fe886866804872ddf149e838091764648bb
+  md5: a4d86f82d97c3e289eb055c4a1216483
+  depends:
+  - __osx >=12.1
+  - freetype >=2.13.3,<3.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=10.2.0,<11.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.16,<3.0a0
+  - libavif >=1.1.1,<2.0a0
+  - libopenjpeg >=2.5.4,<2.6.0a0
+  - libtiff >=4.7.0,<5.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 875440
+  timestamp: 1762528273314
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pixman-0.46.4-h09dc60e_0.tar.bz2
+  sha256: 39e89e5aba886ffe7cf1f59febee53bab0d6a022c8e545574fd90610adb24c50
+  md5: 86debb34b77b24a2ea2d2a35fff6bc2b
+  depends:
+  - __osx >=11.1
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 218161
+  timestamp: 1755256415721
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-4.5.0-py310hca03da5_0.tar.bz2
+  sha256: a4bbbc0c26f1496184bcad1f88a22ea54c028bdc92ca5e38274cc92874b9c526
+  md5: af4e74d6641d57ba9846b8c581054320
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 35439
+  timestamp: 1762356654667
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.21.1-py310hca03da5_0.tar.bz2
+  sha256: 5a8533a080cc6245c964f6e969c1671eeb110c2cfa1db784ba0621d65f95875f
+  md5: c83abab6f07cd497b854bc82cd6bff2d
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 119078
+  timestamp: 1744271794783
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.52-py310hca03da5_1.tar.bz2
+  sha256: 0fc2cea56dbda261a53ab69cce316811cd555a3c8c6f4911f017af39becfe6d6
+  md5: a76d5d69767cb467affa28945a752083
+  depends:
+  - python >=3.10,<3.11.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.52
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 620401
+  timestamp: 1761744881930
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-7.0.0-py310haa24f5a_1.tar.bz2
+  sha256: 1b165f2ff4a59ae59249d66e857867304c84b504e9e170d068e8149ebe58246d
+  md5: f3c55d3817be1bb6132fe4245de5ea77
+  depends:
+  - __osx >=12.1
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 436377
+  timestamp: 1761896358529
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pure_eval-0.2.3-py310hca03da5_0.tar.bz2
+  sha256: 406a3b6bff6aa595e687bd03cb8255b4cf5ec65fe615c363a052f53649d501f9
+  md5: 0602c310460796ffb7bee6e23a0f8000
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 28121
+  timestamp: 1757067106603
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-21.0.0-py310h3f644e9_1.tar.bz2
+  sha256: 47222a9e2f4511fcf541facbcf8a76b699285f4f0ba4e30a54a785f339f44879
+  md5: 081428edda751b66c6b8da64e7f01c91
+  depends:
+  - __osx >=12.1
+  - arrow-cpp >=21.0.0,<21.0.1.0a0
+  - libcxx >=20
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 11732261
+  timestamp: 1764939547856
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycparser-2.23-py310hca03da5_0.tar.bz2
+  sha256: 100dc1d651d1f641709c62d4271f64fc27ab14a827853f036a6894e49def6729
+  md5: 8d9ffb119e380db61d6d1ab77de217ee
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 230860
+  timestamp: 1757496114753
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.6.0-py310hca03da5_0.tar.bz2
+  sha256: af17093fd74b48a3f8d570713d9b19424b1ea9ae30d2b42d43ffe18016c8fcf4
+  md5: c5af9fbbffa28657b7eef190d7b3be47
+  depends:
+  - param >=1.7.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 31643
+  timestamp: 1759932162176
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.19.2-py310hca03da5_0.tar.bz2
+  sha256: 12d929a207a3d74d6198d9facb1900f2ca48ddd47f38eb70fe577724eaf8cb08
+  md5: 5f767750241c0a2efd8ad1f38a0eed31
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5198164
+  timestamp: 1762431588510
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.2.5-py310hca03da5_0.tar.bz2
+  sha256: 8f9885421d3a1a78298e78b31bbab237ca131ed561956c3c484b518ef1d4aa1e
+  md5: 18563e3a05fbb6f867e65d5b2a55f2ae
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 542561
+  timestamp: 1763973807801
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py310hca03da5_1.tar.bz2
+  sha256: c1b70ade729060a012b80bd2794ecc8cb8cb9e1ede23363cb1084c0f43212562
+  md5: 4f397cdc65ae9e5f94e85d2e2696444c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 28611
+  timestamp: 1761753032161
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py310hca03da5_2.tar.bz2
+  sha256: 7fe61148813d911c333451fa5b1752ed4da89b230a83a23b3cb3886e0ad7e1ed
+  md5: 8eef9f7a02ea012f3ae3c4cec6d09185
+  depends:
+  - python >=3.10,<3.11.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 290933
+  timestamp: 1716495762679
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.21.2-py310hca03da5_0.tar.bz2
+  sha256: 7566e28c47d6f4a51ab16597a3d368e7d28aaaca31ca0c020eebce24704f14d1
+  md5: fdf66c5d0248a052e1531848cfc99a83
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 274352
+  timestamp: 1763718718783
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-4.0.0-py310hca03da5_0.tar.bz2
+  sha256: 2715ec629c81e90bf98c1830da242c63738e2945f13420e36bb16f0acc5f86e6
+  md5: ad1c1928d92866af4ffbe167b5448334
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30312
+  timestamp: 1764590114914
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.7.5-py310h3d52de1_0.tar.bz2
+  sha256: d99a2ac70f6147ac423087c7103ae45b7a84196e750090af041af42c1af2628d
+  md5: e2ec3e559655397dc439a8cd631f790a
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  - python >=3.10,<3.11.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 133239
+  timestamp: 1764243655549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python_abi-3.10-3_cp310.tar.bz2
+  sha256: 5217861fac2702d4388e2382df07f5f31e665fea44ffc21611d368e585ebac18
+  md5: e5fe0fea06870e8e54cb5d3a4cd22689
+  constrains:
+  - python 3.10.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4818
+  timestamp: 1764349560577
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2025.2-py310hca03da5_0.tar.bz2
+  sha256: 30ed7d9887e6f918d5e0c03cd679dc838046986adadec3a5192f4df311494372
+  md5: f2049ee43ae3b0618e4cb0afd7c2d092
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 274546
+  timestamp: 1752135897269
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.6-py310hca03da5_0.tar.bz2
+  sha256: 3ea793270acc459707cf3d0f494822dd55cff50548b47d2937e5afd67d645e63
+  md5: 1e655f80537cbbb65b8a801f02643a88
+  depends:
+  - param
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - setuptools >=40.8.0
+  - jupyterlab >=4.0,<5.dev0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62032
+  timestamp: 1758102151024
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.3-py310h091b9d3_0.tar.bz2
+  sha256: 01384765626233037c7b03f88838109ed7a84538f35199dfcb29cf9c193cacae
+  md5: 21c66892dae4955d34c9b2f2f41acfa0
+  depends:
+  - __osx >=12.1
+  - python >=3.10,<3.11.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 220626
+  timestamp: 1763465529919
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py310h80987f9_0.tar.bz2
+  sha256: 8cf1caefcef4460f7f38ebb80e78f8d606b6b737940d5462151efca10938d431
+  md5: b9ccfe7a0e895ae9cf67bbe76da592d3
+  depends:
+  - python >=3.10,<3.11.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 493253
+  timestamp: 1709318540883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2025.11.05-h1413154_0.tar.bz2
+  sha256: 63cf1c5cc06c78237036f37362e809d45a20ee510d2f72ddfd85d2a7653049a5
+  md5: 054832430f68947c7e527a9b63c94d62
+  depends:
+  - libre2-11 2025.11.05 hd4f4e8d_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24789
+  timestamp: 1763136464537
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.3-h0b18652_0.tar.bz2
+  sha256: 5df88605e8e3f6b47524706f2dd68a58fdf506cba30f8dd74307abce57fc3e90
+  md5: e17d25d83f388ee42cdb452ff88e6c2c
+  depends:
+  - __osx >=11.1
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 575000
+  timestamp: 1754485689285
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.37.0-py310hca03da5_0.tar.bz2
+  sha256: 87150d2a0cb2a706ecc060e3c85651855e73ee0999c76c5c58fc39531b86ccbb
+  md5: d4352f42edfb1a6d3a5a788fb5d1fef0
+  depends:
+  - attrs >=22.2.0
+  - python >=3.10,<3.11.0a0
+  - rpds-py >=0.7.0
+  - typing_extensions >=4.4.0
+  license: MIT
+  license_family: MIT
+  size: 63492
+  timestamp: 1762536905670
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.5-py310hca03da5_1.tar.bz2
+  sha256: abeb7567717455f40eae375bf30bc327888de6856fbaae22b7d958fad6addd8a
+  md5: 497a1ed810bdb926ee0255e48d9da584
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.10,<3.11.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 143984
+  timestamp: 1762359615557
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py310hca03da5_0.tar.bz2
+  sha256: 4f7adb8857af54586f8a27fecbd31626160f964ab18efd5a693182a91fe4a287
+  md5: 2e2a4c3a1f320aedaf65ea0deec06aa5
+  depends:
+  - python >=3.10,<3.11.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9834
+  timestamp: 1683077089689
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py310hca03da5_0.tar.bz2
+  sha256: cc20aee97ef5f28b78867fd74e2e9a5785985c3fa56d31f983fea00c2805b76d
+  md5: d566a3096aee8f6ea77d12124075ae14
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 10216
+  timestamp: 1683059019921
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.28.0-py310h931abed_0.tar.bz2
+  sha256: 178d7c2e46c1e5a5531501dad2eb98ad76422265357b0ea1f6115fe10f166f4b
+  md5: 7defbd7e5cdc58f91e2998f2e6581da9
+  depends:
+  - __osx >=12.1
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 362435
+  timestamp: 1762366562904
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.15.3-py310h132fc3c_1.tar.bz2
+  sha256: 190f81d9cdc986fcfacbe6483b858f08fc7602e6b8cc9b35a926e3c2f8158484
+  md5: a8a9667de3082b61ca7ebeff7db67dc2
+  depends:
+  - __osx >=12.1
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.30,<1.0a0
+  - numpy >=1.23.5,<2.5
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 25528191
+  timestamp: 1759222169154
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.3-py310hca03da5_0.tar.bz2
+  sha256: 9c4da1e0dd2e2790bf5e16f4e1bbfc3370f1be2c7f960b7ee68d35a0b5abb8bd
+  md5: dca5908c382e45bed6ed9eceebd99c40
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30085
+  timestamp: 1768170620278
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-80.9.0-py310hca03da5_0.tar.bz2
+  sha256: a81cee67e0142167d58b2711afbf9c66fc4a625768ae2467f410834bd3552d0c
+  md5: 8639226a9a06989223f8c91ba9b2e1c6
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1829337
+  timestamp: 1759863068598
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/six-1.17.0-py310hca03da5_0.tar.bz2
+  sha256: 4926d2eb38d4ce722db69295f0739399294ec731202ce5f608582824b70865d1
+  md5: beb00121d49e92e8b4eba6f5d5b32ed7
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 32797
+  timestamp: 1744271537182
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.2.2-hc0f95ea_1.tar.bz2
+  sha256: fc41613709784859d6f314ddbd30742424fecbb39411af8eaf56c5bbdc7fcc2e
+  md5: 8ac92e96fa542a92b19d5e4847c6e6fe
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  license: BSD-3-Clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 44150
+  timestamp: 1767632418824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.1-py310hca03da5_0.tar.bz2
+  sha256: 5c154ab5bd5c227d07c67e4600db48c6457546cd036064db51c660825a34af68
+  md5: 436bf0420abe610c073d2db5aaee64ee
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 16762
+  timestamp: 1764329173600
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py310hca03da5_0.tar.bz2
+  sha256: 83f37d7fdb2ae2499a0d56b0d8b73aaea225272a1133ec83b7cb5a0b76dcc038
+  md5: 4cf31645d894294b7542e108702346c3
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 67932
+  timestamp: 1696347608160
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/stack_data-0.6.3-py310hca03da5_0.tar.bz2
+  sha256: 5bd239cae4437f2460fa14dbf86569ff47414091b2461add28bd2a484ff6bfa2
+  md5: 35a226cb7995afe3cee9845e98643875
+  depends:
+  - asttokens >=2.1.0
+  - executing >=1.2.0
+  - pure_eval
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 53547
+  timestamp: 1757067086266
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2022.3.0-h50665e7_0.tar.bz2
+  sha256: fc73600986294e5139faf41cd4fb8410a9f81ec2a970ca4bc13e42c4e59a33ca
+  md5: a36929454b1d6e1423ef5ea084892007
+  depends:
+  - __osx >=12.1
+  - libcxx >=20
+  - libhwloc >=2.12.1,<2.12.2.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 142729
+  timestamp: 1764336786030
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tblib-3.2.2-py310hca03da5_0.tar.bz2
+  sha256: 98a58d71c738bac13c8718ef7aa97feab970549cb235efde01f74e36a0917199
+  md5: 048e04bcc47de193e46c527d63bd89e2
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 25620
+  timestamp: 1768309871116
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.18.1-py310hca03da5_0.tar.bz2
+  sha256: 6350647617b298485d28382efc58f407553da851902e0d73d48648297467e662
+  md5: 39645e1c0378bcf302f6906eedfd80aa
+  depends:
+  - ptyprocess
+  - python >=3.10,<3.11.0a0
+  - tornado >=6.1.0
+  constrains:
+  - traitlets >=5.11.1
+  - mypy >=1.6,<2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 27411
+  timestamp: 1757934781863
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.4.0-py310hca03da5_0.tar.bz2
+  sha256: ea14bd78ca65c40e2da218760168b5b0a9c83799baf205fdb7937c0d02773304
+  md5: 7690a8aca2bc27cf2130958f7136b684
+  depends:
+  - python >=3.10,<3.11.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 93761
+  timestamp: 1738338925148
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.15-hcd8a7d5_0.tar.bz2
+  sha256: 63d203f86e045a2163b383d6aab0adcbbf31f2038a542b8d3d390161d139af7c
+  md5: 3ce72515b1e0ae76f42e8697526e4044
+  depends:
+  - __osx >=11.1
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3513169
+  timestamp: 1755244020166
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-1.1.0-py310hca03da5_0.tar.bz2
+  sha256: 8b66b7d5ca45420f3c23183c26d4f6e65736af4c3e148cf6503d2a6ab734657b
+  md5: 6da18275b0ec945c96740e369709a683
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 108240
+  timestamp: 1764677612042
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.5.4-py310haa24f5a_0.tar.bz2
+  sha256: cffa25f81a98747dff1a1f2387e5f08a00d5ab86e3a9164399f8a4025a758a63
+  md5: 60d4a5315f4e08541ab4d5cf3c334a98
+  depends:
+  - __osx >=12.1
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 721374
+  timestamp: 1765992676076
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.67.1-py310h7eb115d_1.tar.bz2
+  sha256: 66f959f2955cefa73f76986dd6737ce36a5d841b59df7661a37113d287618af6
+  md5: c7e55c5a22b024db5a077f41af1e256f
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 127794
+  timestamp: 1762863371812
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py310hca03da5_0.tar.bz2
+  sha256: e9de8f52d147e7dd072058d19202ee179841a56f792224729723a470571b717f
+  md5: 3369365fe73af0c8b47246afdce17709
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 168051
+  timestamp: 1718227147763
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.15.0-py310hca03da5_0.tar.bz2
+  sha256: eb15045f6b0ba093c5a74db4ac60dbf2b168aa48d1831d4f3d5120cf3947f346
+  md5: 57035c4c118645f841643447eac45712
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing_extensions 4.15.0 py310hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 12045
+  timestamp: 1756281809414
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.15.0-py310hca03da5_0.tar.bz2
+  sha256: eafc4ff0d095a318bf30816f1a82975f46b372890befff11ea40ffb284186264
+  md5: 0271e52cfca1a1a534e6e12d413edf3e
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 78882
+  timestamp: 1756281796859
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.3-py310hca03da5_0.tar.bz2
+  sha256: 658385f4dccc5490bd61555a263ac804c9e1af93dc1770d57c2a486b1bc0e528
+  md5: 2e125102827a75e1a446286c6cf9cd13
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 11752
+  timestamp: 1758552140200
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.6.3-py310hca03da5_0.tar.bz2
+  sha256: bdefa57de5569d63335eacef4013186f329d1f0622b91cde0d816472c11fd73d
+  md5: 15129a89e43a55b7bbb9df7f9b64684f
+  depends:
+  - brotlicffi >=1.2.0
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - backports.zstd >=1.0.0
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 303788
+  timestamp: 1767810429921
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+  sha256: 20ae100fd04de16356f26e7c9dab514015e57a9d54fb78767aa5ed97de7846fb
+  md5: f620d98b3d0072945948310c86f0f1c5
+  license: MIT
+  license_family: MIT
+  size: 157385
+  timestamp: 1706894678643
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wcwidth-0.2.14-py310hca03da5_0.tar.bz2
+  sha256: bf69c77d24643a88ebac3d36a969d6a27f018e10aa5dd208dadc20a383717797
+  md5: 6182f7db1721eb4d0c08c19635061895
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 77080
+  timestamp: 1767780842289
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py310hca03da5_1.tar.bz2
+  sha256: 380724b46ae0ae1edb42bc668055aa2f27af3054d866b1e67e5acbb8481cd3a7
+  md5: 6bf29c754086a9d03490af7ef3f22e6d
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21597
+  timestamp: 1643962111312
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py310hca03da5_0.tar.bz2
+  sha256: 3f533f0c2bc844c53f530c8a25f1e1fe27b94d38a76b9601bca8dd0379b5ec05
+  md5: 52665fad203685a097d2f3eca1085240
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 88221
+  timestamp: 1715878353350
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.45.1-py310hca03da5_0.tar.bz2
+  sha256: 7be9941a14a8bb95a46bdabd115c9fbea8fa13c5d21952a717d9b7abb5d05703
+  md5: 6d5b497315633d3a4ecd903dc811f316
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 111877
+  timestamp: 1737990437659
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py310hca03da5_0.tar.bz2
+  sha256: 27799dc34dc007484c93c06823631ca50216f651801061db60b36fbf0b4afcf4
+  md5: 15bd618a92cbd03ec24cd6fbfe81fa68
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1818414
+  timestamp: 1689041533776
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2025.4.0-py310hca03da5_0.tar.bz2
+  sha256: 1bf8dbb49472bfef30b610c68bd5fa03c959ae2c2d5912d7a830f9295b4ee5dc
+  md5: de9718ed62ad4de459e8ad087fb14c08
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 80274
+  timestamp: 1758720221660
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h2c7f8f0_1.tar.bz2
+  sha256: 130edb44cc453a587b8f7905d6e58985c551f155ef6b3dedffedefe22910876f
+  md5: a286e58e7683b512b727797350c54859
+  depends:
+  - __osx >=12.1
+  - libcxx >=17
+  - libsodium >=1.0.20,<1.0.21.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 329284
+  timestamp: 1757676534886
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py310hca03da5_1.tar.bz2
+  sha256: aa43299af42ff172ac93a6d87425fc739d986ee1e5511d56c905073bd55cb896
+  md5: 5cd09b8b6d496a6b8fb98807a1789814
+  depends:
+  - heapdict
+  - python >=3.10,<3.11.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 77632
+  timestamp: 1764604341481
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.23.0-py310hca03da5_0.tar.bz2
+  sha256: f693534a9289bbd9f6295c48f875899f9c5e1b47a9327ed61bc198c90a4ea1b4
+  md5: 58f235296fb183a8d38ce47a919a8cf1
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 26691
+  timestamp: 1763977878981
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.3.1-h5f15de7_0.tar.bz2
+  sha256: 318fc34152890a08929b5edc9d9ce9184940a79a0559d19076fca67f83c1a5f4
+  md5: 44de0889dce735949a754be896c636bd
+  depends:
+  - __osx >=11.1
+  - libzlib 1.3.1 h5f15de7_0
+  license: Zlib
+  license_family: OTHER
+  size: 83252
+  timestamp: 1756475938331
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.7-h817c040_0.tar.bz2
+  sha256: 452a7c80738952b6fbb97fd36060173a1fe0345293d3e93799b16f478bb19802
+  md5: 23c24ffdb88e129bd8b1825398e159c2
+  depends:
+  - __osx >=12.1
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.6.4,<6.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 807221
+  timestamp: 1758039171969
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.10.0-py310haa95532_0.tar.bz2
+  sha256: a3bc51d7164a7091d6b938f392f39b60c8bc4029b6f524bc8d2f19981b02ea3d
+  md5: 5d7332098a868c22aa87c5321df1e120
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.10,<3.11.0a0
+  - sniffio >=1.1
+  - typing_extensions >=4.5
+  constrains:
+  - trio >=0.26.1
+  license: MIT
+  license_family: MIT
+  size: 237153
+  timestamp: 1758622478058
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aom-3.12.1-h00a0c3c_0.tar.bz2
+  sha256: afcf68df9772f1fdc03df5a4bcc4d935c0df6b4832dc7307e11eda0f109580b5
+  md5: 63f14c1b98dd27cddab5824c45264fe1
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 7569923
+  timestamp: 1754917837280
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-25.1.0-py310haa95532_0.tar.bz2
+  sha256: 971623cf3d58650bf9ab692644a8f1c52ae750464a1c400735fc4cb380cd8ec0
+  md5: 7427400ad2aba3c881628d210030afcd
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 29877
+  timestamp: 1766067927256
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-25.1.0-py310h02ab6af_0.tar.bz2
+  sha256: 5ff53830ce5017edddc3d5bff5ef7c5deb75fdbd6422924c7bb919ef7083fbf9
+  md5: fab6d15b391faa8eb6305e9a59e8e13e
+  depends:
+  - cffi >=1.0.1
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 45791
+  timestamp: 1757925097385
+- conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-21.0.0-hcdc3a1c_2.tar.bz2
+  sha256: ad7b859cfabbd67070201f6764e7a71292ec3b7ad85b7642b7cc7e8da566fef1
+  md5: b1b720729c1f23f4e32b848a270f2d81
+  depends:
+  - aws-crt-cpp >=0.34.0,<0.34.1.0a0
+  - aws-sdk-cpp >=1.11.638,<1.11.639.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-ares >=1.34.5,<2.0a0
+  - glog >=0.5.0,<0.6.0a0
+  - libabseil * cxx17*
+  - libabseil >=20250814.1,<20250815.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libgrpc >=1.74.1,<1.75.0a0
+  - libprotobuf >=6.33.0,<6.33.1.0a0
+  - libre2-11 >=2025.11.5,<2026.0a0
+  - libthrift >=0.22.0,<0.23.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.18,<4.0a0
+  - orc >=2.2.0,<2.2.1.0a0
+  - snappy >=1.2.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - utf8proc >=2.6.1,<2.9.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  - zlib >=1.2.13,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 9524047
+  timestamp: 1766074720971
+- conda: https://repo.anaconda.com/pkgs/main/win-64/asttokens-3.0.0-py310haa95532_0.tar.bz2
+  sha256: 1c9d9ce62751b3daf87ab3461cac87aca6f44f3ceaeff796cf84225858f19c85
+  md5: 3ae87016267f6d95f7c73d30e6f73cfc
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - astroid >=2, <4
+  license: Apache-2.0
+  license_family: Apache
+  size: 42514
+  timestamp: 1743630679017
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-25.4.0-py310haa95532_2.tar.bz2
+  sha256: e6262d17162552769cef0c2f997b693a8f140a03781c39fbb4217c43c7516fed
+  md5: 6d04ad51e3910db6d973400ca422a91a
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 148441
+  timestamp: 1762356979461
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-auth-0.9.0-h02ab6af_2.tar.bz2
+  sha256: bd9c9bce700ded8c333f9e4b363bcf07a91f61955685ffed5c7a2fd443ad972b
+  md5: 27ea578f57dd3eae7df38ec5b28290f9
+  depends:
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - aws-c-http >=0.10.4,<0.10.5.0a0
+  - aws-c-io >=0.21.4,<0.21.5.0a0
+  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: Apache-2.0
+  license_family: Apache
+  size: 123878
+  timestamp: 1756801804971
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-cal-0.9.2-h02ab6af_1.tar.bz2
+  sha256: 322a0607f2662f8167c2662cdc1ded1327b142f613adf5cc7ec4e29c93cbaf4b
+  md5: c03308f73e20579246d466f71cb384d1
+  depends:
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: Apache-2.0
+  license_family: Apache
+  size: 63583
+  timestamp: 1756728836183
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.12.4-h02ab6af_0.tar.bz2
+  sha256: d0c244ec6d3091b6eadfc37f82d2cb8428340ac146ab0344bb0db6dcbd937989
+  md5: e51620188276409e7db54903b6e1458a
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: Apache-2.0
+  license_family: Apache
+  size: 266591
+  timestamp: 1756721692676
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-compression-0.3.1-h02ab6af_2.tar.bz2
+  sha256: 35185133195ba9570e5e9309799eed40b35348f3f6449a0878ed6aed2b0ecbcd
+  md5: cbcf19057bcf127aa0b70eab0ab3bf3d
+  depends:
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: Apache-2.0
+  license_family: Apache
+  size: 34700
+  timestamp: 1756733067533
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.5.6-h02ab6af_0.tar.bz2
+  sha256: fbca6cfe807f75f4954156dc00acd82995ce262192ff8befaca4bf184db93400
+  md5: 746c5ef81b1708d63fb1176ccdfb42e9
+  depends:
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - aws-c-io >=0.21.4,<0.21.5.0a0
+  - aws-checksums >=0.2.7,<0.2.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: Apache-2.0
+  license_family: Apache
+  size: 70206
+  timestamp: 1756758244313
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-http-0.10.4-h02ab6af_0.tar.bz2
+  sha256: 3e82b2d374ec8ebbc990a87f642813a9eaa2db5b197c4f720be80f9197c0b867
+  md5: f426efdcb9b0fcf29419c0efadd2fc59
+  depends:
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - aws-c-compression >=0.3.1,<0.3.2.0a0
+  - aws-c-io >=0.21.4,<0.21.5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: Apache-2.0
+  license_family: Apache
+  size: 220219
+  timestamp: 1756758354665
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-io-0.21.4-h02ab6af_0.tar.bz2
+  sha256: 6a120c721ae1585ddc12e777cbb0d1580a7689d96a9eec0019d75f27016a5172
+  md5: c600cad0f41d8aa3a96d6a8f62f5e44b
+  depends:
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: Apache-2.0
+  license_family: Apache
+  size: 187201
+  timestamp: 1756733521397
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-mqtt-0.13.3-h02ab6af_0.tar.bz2
+  sha256: a1ca3152f6cf4398f42bcc4089db0511982f376552867da8c182f09bccedf6d1
+  md5: 1f2352365a5667b336036fb9246c5cc0
+  depends:
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - aws-c-http >=0.10.4,<0.10.5.0a0
+  - aws-c-io >=0.21.4,<0.21.5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: Apache-2.0
+  license_family: Apache
+  size: 229132
+  timestamp: 1756802273539
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-s3-0.8.7-h02ab6af_0.tar.bz2
+  sha256: 159c65e6245d3b7a2ccf619ed2dee9ca3521a691c2c0e9603ede8280b3357dfc
+  md5: dac7ef22f3005aa3490f950d5c7da26d
+  depends:
+  - aws-c-auth >=0.9.0,<0.9.1.0a0
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - aws-c-http >=0.10.4,<0.10.5.0a0
+  - aws-c-io >=0.21.4,<0.21.5.0a0
+  - aws-checksums >=0.2.7,<0.2.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: Apache-2.0
+  license_family: Apache
+  size: 134713
+  timestamp: 1756804011727
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-sdkutils-0.2.4-h02ab6af_1.tar.bz2
+  sha256: 5f4e41a6278c4e446d8b0024b8c82fd20f0d100a065bac4e7ed2b3bc236f5a5e
+  md5: 8bc0c0540d57e3d440e27a3079000c22
+  depends:
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: Apache-2.0
+  license_family: Apache
+  size: 70139
+  timestamp: 1756729016503
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.2.7-h02ab6af_1.tar.bz2
+  sha256: b4d7ff44b6558b9510bf055a74576ea561f18acb97803a36af153fdc7e869baa
+  md5: c9660c993e801fce502014e328a13a13
+  depends:
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: Apache-2.0
+  license_family: Apache
+  size: 114486
+  timestamp: 1756730232119
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-crt-cpp-0.34.0-h885b0b7_0.tar.bz2
+  sha256: fcefc8f9686c6e467a05d5d71daa41a9ac392ce4654fce4bc88a00c3b211165c
+  md5: bb60149050224f7679b347adf9a535c4
+  depends:
+  - aws-c-auth >=0.9.0,<0.9.1.0a0
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - aws-c-event-stream >=0.5.6,<0.5.7.0a0
+  - aws-c-http >=0.10.4,<0.10.5.0a0
+  - aws-c-io >=0.21.4,<0.21.5.0a0
+  - aws-c-mqtt >=0.13.3,<0.13.4.0a0
+  - aws-c-s3 >=0.8.7,<0.8.8.0a0
+  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  - aws-checksums >=0.2.7,<0.2.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: Apache-2.0
+  license_family: Apache
+  size: 385228
+  timestamp: 1756806822189
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.11.638-hf0af688_0.tar.bz2
+  sha256: 9a82a8af6083dde32f0bd9ca7ac4b0d4b4fb433efa022a90b9a6208e007c6785
+  md5: 0f372da778cdf151dc42f468feeb2048
+  depends:
+  - aws-c-common >=0.12.4,<0.12.5.0a0
+  - aws-c-event-stream >=0.5.6,<0.5.7.0a0
+  - aws-crt-cpp >=0.34.0,<0.34.1.0a0
+  - libcurl >=8.15.0,<9.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3926385
+  timestamp: 1756812622029
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.14.2-py310haa95532_0.tar.bz2
+  sha256: 6d128890050484d8d7c26523bdb408d83577cfc4bc4c35c665e1d73bbf7528f2
+  md5: 2bf3f8fdbf9ddf05101a156571ae9f93
+  depends:
+  - python >=3.10,<3.11.0a0
+  - soupsieve >1.2
+  - typing-extensions >=4.0.0
+  license: MIT
+  license_family: MIT
+  size: 217746
+  timestamp: 1764159515001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bleach-6.3.0-py310haa95532_0.tar.bz2
+  sha256: 5ebd69c74ed0cd3db17d96708a90a55e4f4135009086625826f87e309b3374cc
+  md5: 386d1540728ccdbed3a45df274fa2665
+  depends:
+  - html5lib 1.1
+  - python >=3.10,<3.11.0a0
+  - webencodings
+  constrains:
+  - tinycss2 >=1.1.0,<1.5
+  license: Apache-2.0
+  license_family: Apache
+  size: 83021
+  timestamp: 1764153747179
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py310h9909e9c_0.tar.bz2
+  sha256: 2ccaa7e04dde683da73d56723ef56400645fa1afd2d8e331928be62f7b7107c2
+  md5: 266b810907097ebc53c36a71a872f4e4
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6497005
+  timestamp: 1690546680130
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotlicffi-1.2.0.0-py310h885b0b7_0.tar.bz2
+  sha256: 4031245a70c0d5c99e016fab73b5769452e26a52fe3217b59cebee6ba58feccf
+  md5: bebb15305b4df4dee21ce59328e4b337
+  depends:
+  - cffi >=1.0.0
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 396380
+  timestamp: 1764961468276
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+  sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
+  md5: 11e0af09a31e2d5df51c65a342032b85
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 112994
+  timestamp: 1714511182837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.34.5-h731ff69_0.tar.bz2
+  sha256: f595d66fb4adf84437bd0a61a9ad83fbb5c7c2af013456519e23f1bf72bcc92e
+  md5: 6b624b2841ac96b13b99e80eb7c227ec
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 220992
+  timestamp: 1756141648148
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2025.12.2-haa95532_0.tar.bz2
+  sha256: 3f3274071d65e440e6acd9e3fe0aeadfed53363894d6da5300411ea85e09a6d9
+  md5: a78079075b6b91f913f941cab35a3a9f
+  license: MPL-2.0
+  license_family: Other
+  size: 168160
+  timestamp: 1764713881285
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cairo-1.18.4-he9e932c_0.tar.bz2
+  sha256: 01340c8369f55b16e6dc76270303f49b5c829d294a6521632d3a200faedb0a05
+  md5: 00f766daa02f2f92e71846467ce68f15
+  depends:
+  - fontconfig >=2.14.1,<3.0a0
+  - freetype >=2.13.3,<3.0a0
+  - libglib >=2.84.2,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - pixman >=0.46.4,<1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  - zlib >=1.2.13,<2.0.0a0
+  license: LGPL-2.1-or-later or MPL-1.1
+  license_family: LGPL
+  size: 672719
+  timestamp: 1756136839925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2026.01.04-py310haa95532_0.tar.bz2
+  sha256: 5d92b8e32bfcf9e3aee1f023f0690cc00842f1603ba9df9ef9ca74924591b4d8
+  md5: efb575e802016c0d5c829c1f5803f38b
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 154171
+  timestamp: 1767659251469
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-2.0.0-py310h02ab6af_1.tar.bz2
+  sha256: e8999f8feb57e790a76093f77f7c1eb728bd0f7bb5d9e23fedc06b499cd0b2e4
+  md5: 333a72f045ddf029bf328530213c7b1c
+  depends:
+  - pycparser
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 253622
+  timestamp: 1761832851865
+- conda: https://repo.anaconda.com/pkgs/main/win-64/charset-normalizer-3.4.4-py310haa95532_0.tar.bz2
+  sha256: b3e1fbe1b6dbf5daf2df5dbed71ca33aadb2160a701a35ecfbad398a0d896781
+  md5: e3dafd6ced671c248e63413aaa36f83c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 114946
+  timestamp: 1761744990792
+- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.2.1-py310haa95532_1.tar.bz2
+  sha256: 87dc119b4ad1bccd563cd1b0c33c17f1f5108a8e7d867e66306013d99b5b5d79
+  md5: cf4788ebd74a3280a96003004f6e845e
+  depends:
+  - colorama
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 285681
+  timestamp: 1764332384742
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.1.2-py310haa95532_0.tar.bz2
+  sha256: cd3c6550cc89750339b70aaaeed23f151b8bfedcffd0527948e544b7b13f7be6
+  md5: 47208e1d2c12472f764251aa14913a4d
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64510
+  timestamp: 1764930594059
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py310haa95532_0.tar.bz2
+  sha256: 9d1b2c34fa17a72e4e7b265cb5a421bb1a6dc893b35209739f1b710f79ebcc19
+  md5: 269703fa9499eb42cfd7b9fd349ecd22
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30646
+  timestamp: 1672387329696
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py310haa95532_0.tar.bz2
+  sha256: d7e9ef9b790e0d531490ee8eb3d727ace2a9f30d94e547029e1d0a84747c168a
+  md5: 95fcb8f56ad31f96ae9b8767ad30cd35
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 498954
+  timestamp: 1709758473914
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.3-py310haa95532_0.tar.bz2
+  sha256: d0190b02cc9e86b423584a4949137623c88031df482ace7bfb1b3db679fc516d
+  md5: 6d4d9b71fd37f1181b0576be4c5f0e1b
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14915
+  timestamp: 1763119271246
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.3.1-py310h214f63a_0.tar.bz2
+  sha256: b33d9792d18c1ef1cdbdee252a7340ea47d2ef5a174edaf77eb5c9bcfa88a956
+  md5: ffdd9900f86e96fc95ab0a7095a347f6
+  depends:
+  - numpy >=1.23
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 230563
+  timestamp: 1732540222453
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cramjam-2.11.0-py310h7b75cbd_0.tar.bz2
+  sha256: 93e8ea1a5ffa04184320412a68fe7489305b7f4e048e79ec53eb0a8666fa6b33
+  md5: 4a9ac6b00c81aff2da60e00e0cece7ff
+  depends:
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 1790999
+  timestamp: 1762433235435
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cycler-0.12.1-py310haa95532_0.tar.bz2
+  sha256: 9407b0227acbc99e084d450855e19544d56fa8a48768f498eff1448bf061d8ba
+  md5: 51f468daddd144a69cbced0001baf73f
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17150
+  timestamp: 1766068093613
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-1.1.0-py310h02ab6af_1.tar.bz2
+  sha256: 6a06214e62d3415e84d45544fbb4b0f4b7e9ec1579168c1e306b7de7faa7ced7
+  md5: 4bbb0a2240dfcddc1ddbb0b0a650e1ce
+  depends:
+  - python >=3.10,<3.11.0a0
+  - toolz >=0.8.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  constrains:
+  - cython >=0.29
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 801966
+  timestamp: 1764692978148
+- conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.15.1-py310haa95532_0.tar.bz2
+  sha256: 0822558a2a06c1e086a79a1b625430680c7b0c013df6b50de81c6e139b991a08
+  md5: 59c61b5197b47deda2e98e40a34511aa
+  depends:
+  - colorcet
+  - dask-core
+  - datashape
+  - numba
+  - numpy <2.0a0
+  - pandas
+  - param <2.0.0a0
+  - pillow
+  - pyct
+  - python >=3.10,<3.11.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17686916
+  timestamp: 1689588294039
+- conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py310haa95532_1.tar.bz2
+  sha256: 6a56a78d48087626732e4472bcf286cddb4eeb62e659d7efebaeb4a461cc0109
+  md5: f225dd204c5eae66bc59c6e29ae1757b
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 104152
+  timestamp: 1642109356544
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dav1d-1.2.1-h2bbff1b_0.tar.bz2
+  sha256: e59970edb08a1dc24d761f88657aed895d7715f66ac9a9acfda440c29fda05e0
+  md5: d3d303a3ffcedb8f4a92f29ac9e67bdc
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 723931
+  timestamp: 1688746263355
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.8.16-py310h885b0b7_1.tar.bz2
+  sha256: 7d3ce12b75a188396bbb11a74ef3ae72fdf057d6d3ea4ae6f393ef2d800c3aee
+  md5: 17b9a4b03222a61a013189f10192715b
+  depends:
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 3777324
+  timestamp: 1762421756833
+- conda: https://repo.anaconda.com/pkgs/main/win-64/decorator-5.2.1-py310haa95532_0.tar.bz2
+  sha256: e6936056323bc41213516e0e37194d56a29815db727f5ea220155d7e6d9bb6af
+  md5: be7f28595c5e285be426e3aaf6a51adf
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 36196
+  timestamp: 1757341292902
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py310haa95532_0.tar.bz2
+  sha256: 542db7e187d0a9fe16b6eacb6bb93e5d574d1956687553a85a33fd580ab6ab7c
+  md5: efac5662f2dbe0fabf392e1dd89eb105
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17084
+  timestamp: 1649926751338
+- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.3.0-py310haa95532_0.tar.bz2
+  sha256: 1c20d1c9309251ac1088bb36a50dad7d2d2abd157b087ef7bd3562468f793da3
+  md5: 9cdbc43d47b4bf390e5e9799fa9a844d
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing-extensions >=4.6.0
+  license: MIT
+  license_family: MIT
+  size: 39821
+  timestamp: 1761560475511
+- conda: https://repo.anaconda.com/pkgs/main/win-64/executing-2.2.1-py310haa95532_0.tar.bz2
+  sha256: 4e336f96f89e36a260033fb5ec7a09f7cb94ec758ac65754a583d19ea4135855
+  md5: 6c230dcc8ca82394941f40b5baf6a4f6
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 786366
+  timestamp: 1757061289467
+- conda: https://repo.anaconda.com/pkgs/main/win-64/expat-2.7.3-h885b0b7_4.tar.bz2
+  sha256: c32db944928767e18657ac8b566fc24a316a202251875818acb04261a1c36823
+  md5: 685781ee0e4a296c0376b430a9ee762b
+  depends:
+  - libexpat 2.7.3 h885b0b7_4
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 34984
+  timestamp: 1765208254263
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-2025.12.0-py310h540bb41_0.tar.bz2
+  sha256: 680cdf2a4b4aed87412f9fa076064a7a13f1113e9056efb3713aef71cf5d8c42
+  md5: 5483c722f369d671c77fe402cb8ec88c
+  depends:
+  - cramjam >=2.3.0
+  - fsspec
+  - numpy >=1.21,<3
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: Apache-2.0
+  license_family: Apache
+  size: 623877
+  timestamp: 1767955557648
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fontconfig-2.15.0-hd211d86_0.tar.bz2
+  sha256: 5b9db457b3e5ca111979618cfad681fd2329d89765fd35797e66d5b97ba85eab
+  md5: e804fd8f2c14db57d7d49ec9ffceef00
+  depends:
+  - expat >=2.7.1,<3.0a0
+  - freetype >=2.13.3,<3.0a0
+  - libiconv >=1.16,<2.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  - zlib >=1.2.13,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 247964
+  timestamp: 1759153864775
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.61.0-py310h02ab6af_0.tar.bz2
+  sha256: e58dfeebd6bcf469d73054ee84f2305258feac2142dc6e00a0c36e53c9079e6e
+  md5: a776e1e95b17fdd07157042eedf1f538
+  depends:
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  constrains:
+  - unicodedata2 >=17.0.0
+  - brotli-python >=1.0.1
+  - uharfbuzz >=0.45.0
+  - zopfli >=0.1.4
+  - lz4 >=1.7.4.2
+  - skia-pathops >=0.5.0
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 4109940
+  timestamp: 1765445332157
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freeglut-3.8.0-hfcef157_0.tar.bz2
+  sha256: b0b77d293e133733c06e8e312f984922f862b5c023fff349e676fc9167806d14
+  md5: 4bad53679c11d7f3cbce95a45636fc64
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 165089
+  timestamp: 1764693337022
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.13.3-h0620614_0.tar.bz2
+  sha256: f39fc9b2289fd2abfef82badce03940e3c8360930628e6233456d4a3ac110f5b
+  md5: a67a8ec05803a940acbb45c798d502dc
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only or FTL
+  license_family: Other
+  size: 549086
+  timestamp: 1743636775521
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fribidi-1.0.16-haf45083_0.tar.bz2
+  sha256: ab9b2cf79482e47f67505706b71a2fa81e75cf08c003600db62a44d16b46b7f8
+  md5: 7c35b11142ea6a739135e78033fb5454
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: LGPL-2.1
+  size: 79586
+  timestamp: 1768428461478
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2026.1.0-py310h4442805_0.tar.bz2
+  sha256: 1d82def23ef84bec8f6ad794b77d31381f40a94a3b93c25172be538b4b709b13
+  md5: 1e19ecba4bfb8d3516ca7928707fcb9f
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - pyarrow >=1
+  - s3fs >2024.2.0
+  - aiohttp !=4.0.0a0,!=4.0.0a1
+  - gcsfs >2024.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 561291
+  timestamp: 1768898410672
+- conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+  sha256: 7cb0df7aa62796b0081e1708003529c02411aca6a540bae97beaec919aa64e74
+  md5: ea81fd813e10055553a8d7597c8be98f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 322778
+  timestamp: 1706888324269
+- conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+  sha256: ed1fa1a40c6739b48ff3a2d51c3df20e4983b59684b04d93e1337c5f2e93a954
+  md5: 1797f64343a42395207cd452e6a6a751
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94476
+  timestamp: 1706895442146
+- conda: https://repo.anaconda.com/pkgs/main/win-64/graphite2-1.3.14-hd77b12b_1.tar.bz2
+  sha256: ba3646855133e9f24939b2587aebde03560ef8db3ffae043d75115406a06d3d1
+  md5: 4d49aebabfe7d2a3b50a1985c1813e42
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 99175
+  timestamp: 1654175958308
+- conda: https://repo.anaconda.com/pkgs/main/win-64/harfbuzz-10.2.0-he2f9f60_1.tar.bz2
+  sha256: 77ee7fe027d9d87d1a911b6c2b948159f54b13191cd6dc3126f6fad0e7c879a0
+  md5: caccb3f93d885fcc8c837a5c6993e323
+  depends:
+  - cairo >=1.16.0,<2.0a0
+  - freetype >=2.13.3,<3.0a0
+  - graphite2 >=1.3.14,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libglib >=2.78.4,<3.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 1423092
+  timestamp: 1748952117569
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.16.0-py310haa95532_0.tar.bz2
+  sha256: 80dab81197cb65dd03857939975857152a165020834e33cde4902d3530a76448
+  md5: 832df2e9eb6b43f3a58bdd699e29a9ef
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4484147
+  timestamp: 1684953934888
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+  sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
+  md5: 582d2c1135a89da757a038de831e7f39
+  license: Intel proprietary
+  size: 11086648
+  timestamp: 1664812389803
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+  sha256: 945f4521793d7d279532d1ccd5157201c5cbf64f846bfe60249d01e1b4edf295
+  md5: 0accae23d095c165ac731f4a1f3ca497
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 37021132
+  timestamp: 1692294548916
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.11-py310haa95532_0.tar.bz2
+  sha256: 535cc6d5a6c095b73ffead6ce4b9c69cadc07679834d77fd77928cab63eb4d7b
+  md5: 03b70371a6a9647f2f200068843734ae
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 240459
+  timestamp: 1761912086033
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-8.7.0-py310haa95532_0.tar.bz2
+  sha256: 04dbf37836f2b5d77b9967da0f24e238f499ad3072a24868fa2c3a7825387aee
+  md5: 654dc0bc1deaeb5e0ecbfa3a7c5d0e94
+  depends:
+  - python >=3.10,<3.11.0a0
+  - zipp >=3.20
+  license: Apache-2.0
+  license_family: APACHE
+  size: 59393
+  timestamp: 1763996667819
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2025.0.0-haa95532_1164.tar.bz2
+  sha256: 88546c6d7c8b78e2c3544620b6b91d732fce350e1791dde62b204b46d379dd0d
+  md5: 00e8bffbde950cf35c70f9cd0e12d959
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 3510949
+  timestamp: 1741121239324
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py310haa95532_1.tar.bz2
+  sha256: e8c8c414a5123ce1ea5b7452a4390078904199d9daa41aef6b5841af7b6cbcb8
+  md5: 779b9fa1eed5c462229fcfdd12d5e4d3
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192952
+  timestamp: 1737660811516
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.30.0-py310haa95532_0.tar.bz2
+  sha256: fcbcefd91289bb0fa6e92a17d0f47f52cc5ee1f3217bd502d6e92d77d07e9cf8
+  md5: 63240b64215e78893789bdb71559188d
+  depends:
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.10,<3.11.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1341963
+  timestamp: 1734548588627
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.2-py310haa95532_0.tar.bz2
+  sha256: 319b732a5d60fe93e0ef46a2f4256a3089a689d84f5cdc1dc01e1251150d8406
+  md5: 4ec2b623b48bcb1c189daee89c74c889
+  depends:
+  - parso >=0.8.4,<0.9.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1042668
+  timestamp: 1733988364778
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.6-py310haa95532_0.tar.bz2
+  sha256: 0b9ea1f35b895507c4e871720d75f374f291378b7273626b1e90697cb0de998d
+  md5: 47fa15da412fc404d6366f2fc00517b3
+  depends:
+  - markupsafe >=2.0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 282811
+  timestamp: 1741712027136
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9f-ha349fce_0.tar.bz2
+  sha256: 9c588e7b9d8f1942dcbfae6303e9268982cef141adfb4a3aa57c1a17ef56b97b
+  md5: 8ffada6365cd9284debe6642d92e6a25
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: IJG
+  license_family: Other
+  size: 470225
+  timestamp: 1757499108897
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.25.1-py310haa95532_0.tar.bz2
+  sha256: cdaf69bc05a906a91258dcb3de08175d311667753113c1bab3b0e2810305dd99
+  md5: 8eaf4eac1edecc8b1d5a5b4df14ec098
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.10,<3.11.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 177886
+  timestamp: 1767955632383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2025.9.1-py310haa95532_0.tar.bz2
+  sha256: 34d102c2187027546c51c483478ee908c1d18efdb03c717876d72b4c88329705
+  md5: 1f938f95b26dcb756202999f426ff59f
+  depends:
+  - python >=3.10,<3.11.0a0
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 15849
+  timestamp: 1762788689711
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py310haa95532_0.tar.bz2
+  sha256: ac6b6415f82a703882ba07242d9b7a3aa7241d75795c29838e1f136f48f8f228
+  md5: 9614757161de6dbd60002f047add9c65
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 231452
+  timestamp: 1676331217788
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.9.1-py310haa95532_0.tar.bz2
+  sha256: eaeefc06ec082546c22100e68a2bf928e3e785b06a7b62ab7edbcc7831082ce4
+  md5: 70a6362da9dbda1f200a2afb4dac3b27
+  depends:
+  - platformdirs >=2.5
+  - python >=3.10,<3.11.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 122565
+  timestamp: 1764588401954
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.12.0-py310haa95532_1.tar.bz2
+  sha256: 2f77b74514c9eab3cea291a1c27fd8113638e577cee9a9fbb9aeedf0cf39535d
+  md5: 16de8407cea04c51f9dfc85ff14500fc
+  depends:
+  - jsonschema >=4.18.0
+  - packaging
+  - python >=3.10,<3.11.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65534
+  timestamp: 1765813669617
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.17.0-py310haa95532_0.tar.bz2
+  sha256: 112fd8f3b1dc0f10fc68fee2c3c8cd3a65bdd648c2e4bda19f64cc6ffdd97737
+  md5: 02051f736f21c5274329b69117f4c09a
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.11.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert-core >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.10,<3.11.0a0
+  - pywinpty >=2.0.1
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580639
+  timestamp: 1764955377839
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.5.3-py310haa95532_0.tar.bz2
+  sha256: a17c5eaa8cb9b56c1d076339b19f09d4523f32097f10a5ea0b21c29ed80f64d1
+  md5: 0106f465fe6099492d9f93f070824051
+  depends:
+  - python >=3.10,<3.11.0a0
+  - pywinpty >=2.0.10
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25786
+  timestamp: 1744706768584
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.3.0-py310haa95532_0.tar.bz2
+  sha256: a244a27b572c77aa7109d64d034b7cddb7b9fa3a4af1c5f40475ecce5ce8cb98
+  md5: e28baa3eac15f59dedd324248998ba68
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jupyterlab >=4.0.0,<5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19548
+  timestamp: 1741124343838
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.9-py310h03f52e7_0.tar.bz2
+  sha256: d1136bd7fb66883e4f03b2437e44833b0784b6f14a7d0e237029013c37a101e0
+  md5: c589b1d0c3aeea2182cc04149fb9f129
+  depends:
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94005
+  timestamp: 1764159412460
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.17-h3732fa5_0.tar.bz2
+  sha256: ba0c961acef9ca69f5cb75178947e4b4e97068fb296e4cb6dd4ed469bbfcfb73
+  md5: 9378999eb90e498ba0bb04616e7d22d7
+  depends:
+  - jpeg >=9e,<10a
+  - libtiff >=4.7.1,<5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 1091201
+  timestamp: 1764162840085
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-4.0.0-h5da7b33_0.tar.bz2
+  sha256: 3a915692cf3e21e7cc4259faea2e17535530515acb3bc8fa00832d646bdeecf0
+  md5: eda551db9b747f0606eddd001343ed36
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 207263
+  timestamp: 1734423494890
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libabseil-20250814.1-cxx17_hcd311fc_0.tar.bz2
+  sha256: 33f0142d9e83bdfd1d46ecc2cdfdbc9f757f2403b512d3a0f9f15e703787150b
+  md5: 87aa7060141e2f750a0e227bf10e9520
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc >=14.42,<15.0a0
+  - vc14_runtime >=14.29.30133
+  - vs2015_runtime >=14.42.34433,<15.0a0
+  constrains:
+  - libabseil-static =20250814.1=cxx17*
+  - abseil-cpp =20250814.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2342401
+  timestamp: 1763134165026
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libavif-1.3.0-h5bd13ec_0.tar.bz2
+  sha256: 74c7793351bb9c2b8962af208dbfb447a9e1ee7998f9c0f019aaf84650cb4046
+  md5: dfd8d4f89a5f66caf8abb99e26451a75
+  depends:
+  - aom >=3.12.1,<3.13.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 149645
+  timestamp: 1763972861412
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.2.0-h907acca_0.tar.bz2
+  sha256: ffac6733681c36db8615166d9dd46f2b65aada2e6910ea94b5671fa46efc9b27
+  md5: 56e196ce8bea259a3be91d8940f8dcfe
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 88727
+  timestamp: 1762363782214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.2.0-h02c67a5_0.tar.bz2
+  sha256: cb8cdb907cf39e5d9b3a8ee728c212ab8a57ca44ee32a49bbd9551dabf3687c0
+  md5: 61b8956b21e5bbd7e7e703c7ce1cb78a
+  depends:
+  - libbrotlicommon 1.2.0 h907acca_0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 45496
+  timestamp: 1762363799309
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.2.0-h483e6b9_0.tar.bz2
+  sha256: 5fcc35661f1f6d318209220b03398116f097de97ab834434f7b2f49049c25205
+  md5: 055a7403502e6d367b4061cee8f6476a
+  depends:
+  - libbrotlicommon 1.2.0 h907acca_0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 293712
+  timestamp: 1762363815702
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.17.0-h97e0424_0.tar.bz2
+  sha256: a838e88926609bf0d333c24164d9bff502e9308633728f1e21f5074278cc5492
+  md5: a29a1b2c36005f799e7a1f6eee090a8c
+  depends:
+  - libssh2 >=1.11.1
+  - libssh2 >=1.11.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  - zlib >=1.2.13,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 415229
+  timestamp: 1766164150992
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.22-h5bf469e_0.tar.bz2
+  sha256: 46c58457ec8c074d5af22fe36a182d5c29e76f6248e7d1d5cb76c66beefe52aa
+  md5: 5bd6c216dd03f3ccf9d108b7c8a29367
+  depends:
+  - vc >=14.40,<15.0a0
+  - vs2015_runtime >=14.42.34433,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 223776
+  timestamp: 1734423384478
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libexpat-2.7.3-h885b0b7_4.tar.bz2
+  sha256: 932e6826a4562efc61e8b43189e12656cbcc7e2372558edff2ff983c1ede0bf4
+  md5: e6beea803122dfc0483fb6266187511c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  constrains:
+  - expat 2.7.3.*
+  license: MIT
+  license_family: MIT
+  size: 148787
+  timestamp: 1765208241996
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+  sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
+  md5: cf949d76148be1e2a534218d9c57df86
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 155435
+  timestamp: 1714484319443
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libglib-2.86.3-h9bccc14_0.tar.bz2
+  sha256: 6a9567ae069cb0bb1a6a7bd7c32307f24576610ddd0c3500708c510720e83567
+  md5: 49293643c30180298ae7cf94f10e9fa9
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.16,<2.0a0
+  - pcre2 >=10.46,<10.47.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  - zlib >=1.2.13,<2.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 2870448
+  timestamp: 1768845293182
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libgrpc-1.74.1-hde67744_0.tar.bz2
+  sha256: d3ab9f17ad5ede0427dbfe0bcb45cde286e573f8bdbe43423273752ad6b38c95
+  md5: 9d684e539102061467d1ee5b47ff6b00
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20250814.1,<20250815.0a0
+  - libprotobuf >=6.33.0,<6.33.1.0a0
+  - libre2-11 >=2025.11.5,<2026.0a0
+  - openssl >=3.0.18,<4.0a0
+  - re2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc >=14.42,<15.0a0
+  - vc14_runtime >=14.29.30133
+  - vs2015_runtime >=14.42.34433,<15.0a0
+  - zlib >=1.2.13,<2.0a0
+  constrains:
+  - grpc-cpp =1.74.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 19928541
+  timestamp: 1763141897575
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libhwloc-2.12.1-default_hfa10c62_1000.tar.bz2
+  sha256: 57c4f52df69562710280423a3c019bb3821ebd2733f9e9df714de7846eef8ff7
+  md5: 7f30659fb2c9bce856d02d972771a9df
+  depends:
+  - libxml2 >=2.13.8,<2.14.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2892706
+  timestamp: 1755247386628
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_3.tar.bz2
+  sha256: 4085f304bede2d9d04dbff5ebd53b3f5fbfaee1cbc120018a9efc0e89d027877
+  md5: 7e6fe99f2af88b389cf7e371cad6f18f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 744054
+  timestamp: 1714484485224
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libllvm20-20.1.8-h3aa9ab2_0.tar.bz2
+  sha256: b2f2adf01e9fd75b02f22c2c7b4cb9e9bf573a4fd2d5309239dbcb991d12a9ea
+  md5: 626e87f8e4941eca1639aa0f9e640807
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 22659
+  timestamp: 1756245073102
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libopenjpeg-2.5.4-h02ab6af_1.tar.bz2
+  sha256: 2c9074b3004276687d2d06d242f0845e88cc823049afadd0acc6fcb914470f6f
+  md5: bdae6b6bd1f52508c43e7fe5d1e19c93
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 206706
+  timestamp: 1761733072883
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.50-h46444df_0.tar.bz2
+  sha256: eac2eb340003b909310dbfb03c5aa6f793dc34fe808e876f752bb16b0ac334b8
+  md5: af888074f61c82f867bc7b1218f3c817
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  - zlib >=1.2.13,<2.0a0
+  license: Zlib
+  license_family: Other
+  size: 304388
+  timestamp: 1761139979647
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-6.33.0-h2a56892_1.tar.bz2
+  sha256: 58d9beb3140410ad50e593dc81482ebba2d1057f1e96419580839c891ebd0cd6
+  md5: 3ba9e90c397512fbd5588e210fef35e3
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20250814.1,<20250815.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc >=14.42,<15.0a0
+  - vc14_runtime >=14.29.30133
+  - vs2015_runtime >=14.42.34433,<15.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8530337
+  timestamp: 1768235117966
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libre2-11-2025.11.05-ha6b10e7_0.tar.bz2
+  sha256: 5ac7855e733dab7b48b2a120ea0bbd305590388d9a03e51d14b2ff916f1f27b4
+  md5: 71be7826d3c4ded1391af09ff1d81721
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20250814.1,<20250815.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - re2 2025-11-05 *_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 305229
+  timestamp: 1763136507557
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.20-h83e8143_0.tar.bz2
+  sha256: 58ec5e4c935e2f46582d60528f97c8c36f53a03bf871dba840c55359209cac92
+  md5: de57d4ea71e8535472ba800d3d53777d
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: ISC
+  license_family: Other
+  size: 599171
+  timestamp: 1754318812535
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.11.1-h2addb87_0.tar.bz2
+  sha256: c63c4909596a8fe198b94f8cccd91dd8445b92b1b3951a15fb836d88115f93af
+  md5: 2ded634970ea802078cc2b68f903d45f
+  depends:
+  - openssl >=3.0.15,<4.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 310776
+  timestamp: 1732891385479
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.22.0-ha2884a9_0.tar.bz2
+  sha256: b289699c93a37ed7525017b91c78d63f7d62297bedba6c3df8dafa3b4de9526d
+  md5: 2ca6d5b790591a08a617e1c0aab1a88d
+  depends:
+  - openssl >=3.0.18,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  - zlib >=1.2.13,<2.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 719710
+  timestamp: 1761570611452
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.7.1-h3a18249_0.tar.bz2
+  sha256: fd316598e94c9908369fd2c6f133d131d8757acaa118b31a8c5aba82a401b1f3
+  md5: f12ff2a4efd1dd089d07f39f6a1bb01a
+  depends:
+  - freeglut >=3.4.0,<4.0a0
+  - jpeg >=9e,<10a
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.22,<1.23.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  - xz >=5.6.4,<6.0a0
+  - zlib >=1.2.13,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1322118
+  timestamp: 1763980764230
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.6.0-hbf3958f_0.tar.bz2
+  sha256: efaca434d867f85aea21048795f6eab41037fe3dc4fefba82406e08f22aa7e10
+  md5: eeb1c3e25645f6b4a178a8b98d9e7ef3
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  constrains:
+  - libwebp 1.6.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 357482
+  timestamp: 1763980689462
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.13.9-h6201b9f_0.tar.bz2
+  sha256: 7978d915fcef2d6fd7be02e4451b21f6a966cf33340f0d89b85d5036fa0a8b20
+  md5: a64a07868009040e6a7cd7be5a68ee4f
+  depends:
+  - libiconv >=1.16,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  - zlib >=1.2.13,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 3583805
+  timestamp: 1761769014771
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libzlib-1.3.1-h02ab6af_0.tar.bz2
+  sha256: 2e77123a785ea2f599c49a1b100988e6a8bf89183556f15fb43056d24d7ee565
+  md5: 2e50a625ac549de0dfc3348639d84174
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  constrains:
+  - zlib 1.3.1
+  license: Zlib
+  license_family: OTHER
+  size: 85278
+  timestamp: 1756476045869
+- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.3-py310haa95532_0.tar.bz2
+  sha256: 5695293566be21e0bcb993cea7c66aae69e6bfd76d045378b421d7ccd14b90ad
+  md5: 1842ddb5cf92d5b4bdc0717363e78fcc
+  depends:
+  - python >=3.10,<3.11.0a0
+  - uc-micro-py
+  license: MIT
+  license_family: MIT
+  size: 41227
+  timestamp: 1758717707032
+- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.46.0-py310hd5b4e5d_0.tar.bz2
+  sha256: 3f45a28459b98a5193130184aab14cf2653744e3fa7af2d168c2e11de57346ad
+  md5: 7bab90d38a5380d628c6db55562f60eb
+  depends:
+  - libllvm20 >=20.1.8,<20.2.0a0
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - zlib >=1.2.13,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-2-Clause AND Apache-2.0 WITH LLVM-exception
+  size: 28303443
+  timestamp: 1765874359177
+- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py310haa95532_0.tar.bz2
+  sha256: c2e861d3109533539f2fc7a8ebaeb1aafbb0960aca546ea7ed5a91376c796399
+  md5: 4d016b3bc975ab61c5786a6676693a9c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 12966
+  timestamp: 1652904192742
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.4.5-py310hb1efef3_0.tar.bz2
+  sha256: 1e6d9f2847fc2d6ee8e11bce840a767121dafee16f897028c19bd4416e4f7baa
+  md5: d655e33b6a2675dabb14ef6497e5d812
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 115730
+  timestamp: 1762954309056
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+  sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
+  md5: 320f40b75d93f3b96931c6d13c23946c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 158902
+  timestamp: 1714512129889
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.10-py310haa95532_0.tar.bz2
+  sha256: f791b1effb36864d04e0b95f87cab1d37f4eeaceb8becb860b39e724aac62a4e
+  md5: f2d3d9e31aa9875a056dee9c3f334646
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 172863
+  timestamp: 1767787396667
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py310haa95532_1.tar.bz2
+  sha256: ab424b8036257c53eb5110f8d8817ed959718c275e2dff88407332ce783519ed
+  md5: 24f0c3faa37da73027d950da5b6cd3d3
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 126331
+  timestamp: 1684280061614
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-3.0.2-py310h827c3e9_0.tar.bz2
+  sha256: c1ef624624b17f89a96cbbb209ff1930e813228894cb20293d27e761b7af8958
+  md5: fa287059f9b6bc4ed3e17d1b8e3ac43e
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39661
+  timestamp: 1738584143805
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.10.8-py310h26e45b9_0.tar.bz2
+  sha256: 811ff34bed8d1ad56e76235afabac89f23b54341f60a15425049e78fdb04868b
+  md5: 1012ff06aa6564191b25bce86d67b89c
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.13.3,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.21,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=3
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.7
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 11727382
+  timestamp: 1768296973478
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.2.1-py310haa95532_0.tar.bz2
+  sha256: 59f0e860744f465e530b408e289db768e8f8d74f32d22d9d3fdc3661e5ec206a
+  md5: 8ae3f96083f01e1abfcbfcdad81d9908
+  depends:
+  - python >=3.10,<3.11.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17747
+  timestamp: 1762779302361
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.5.0-py310haa95532_0.tar.bz2
+  sha256: 170f9482381b6fe35fc8e8dab872aa428fa12469b3ee8ef8c7520da0333bc79f
+  md5: 7d16c3aba04c6a543dcd25b3884072fe
+  depends:
+  - markdown-it-py >=2.0.0,<5.0.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 94334
+  timestamp: 1756381168746
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.2-py310haa95532_0.tar.bz2
+  sha256: da4e81a2e730121ed45c604bbf505d90911e01dd1943e544cf62eabad7cf8ce6
+  md5: 28609f259bcf1efe81446ed3e3dc891c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 23096
+  timestamp: 1758552323170
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-3.1.2-py310haa95532_0.tar.bz2
+  sha256: b41dd06a57751372dc78e51affe74839c4b688ddca2f8a244e35bc5756b1343d
+  md5: d8e6fadd622f012d348a9e11114c2593
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing-extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110095
+  timestamp: 1741124237397
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2025.0.0-h5da7b33_930.tar.bz2
+  sha256: 788e1480084c5a9ac3d9446ad9a7fa2fd2da224ba8a66e006f2c854603c26b4e
+  md5: 183d05fbc22c0ab21195d6003f64afb1
+  depends:
+  - intel-openmp 2025.*
+  - tbb-devel 2022.*
+  - vc >=14.2,<15.0a0
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 123317137
+  timestamp: 1741121449798
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.5.2-py310h0b37514_0.tar.bz2
+  sha256: 45393290bf1abdc7f722dd0b5c4970e623b3dbf5078dca88d8bf69d1b831c9e5
+  md5: f92a08d21f84a940e00568de2c596693
+  depends:
+  - mkl >=2025.0.0,<2026.0a0
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 83062
+  timestamp: 1759414273260
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-2.1.1-py310h300f80d_0.tar.bz2
+  sha256: 108a4d95d9d124f474196fb762f3e43fa08ed10dc05a1f7397922f3818636e68
+  md5: 8a04bed2e5442088d6f95350c172a841
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2025.0.0,<2026.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.26.4,<3
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  constrains:
+  - scipy >=1.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 165795
+  timestamp: 1761593070473
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.3.0-py310ha5e6156_0.tar.bz2
+  sha256: d5b693440e90158a53d75ce8c9d911ac35d39222d9d1bb65939c63b4286940dc
+  md5: e49c6a7e98ee746c94c52ad05ee2f410
+  depends:
+  - mkl >=2025.0.0,<2026.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.26.4,<3
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 308058
+  timestamp: 1761593152981
+- conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.1.1-py310h5da7b33_0.tar.bz2
+  sha256: 0fbe7c64660b1bb73aad181ae38b8c18b69d640f7247ca9024b80011a6cd821d
+  md5: ece91b6ed3a0184ec0d6fb5cc422e85d
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 109237
+  timestamp: 1750958968007
+- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-1.0.0-py310haa95532_0.tar.bz2
+  sha256: feca0b9fb67fb94a160fb84fde44996dcdf15b8fbd8d5b76c7cd7c416ee38480
+  md5: 66f33716c87dccd161bf3b0b3aac2863
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28062
+  timestamp: 1756978500768
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.3.3-py310haa95532_0.tar.bz2
+  sha256: 7f9808edbb56990b501e81a97f6ce33bac84cfbe876a10989d7431bb5bc6177b
+  md5: 411c46097d465b253e7e0ac8bfa85459
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10150145
+  timestamp: 1765189547205
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.10.2-py310haa95532_0.tar.bz2
+  sha256: 2b1785eee35d711bb68314d23a064721dd4c9a68806ba0e80beb883810ef7873
+  md5: 6a580bc052e7179fd8207df8d8c8fe12
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73721
+  timestamp: 1741124473679
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.6-py310haa95532_0.tar.bz2
+  sha256: 7c3d3e6ee26b8e54cc2a974c430760470df9f04312a6046dd02731e779abfc19
+  md5: 384c8fe3ac51a9b00519b922d13811da
+  depends:
+  - nbconvert-core 7.16.6 py310haa95532_0
+  - nbconvert-pandoc 7.16.6 py310haa95532_0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8243
+  timestamp: 1741194892742
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-core-7.16.6-py310haa95532_0.tar.bz2
+  sha256: dce355e463531d936296899ecb596d5a0e05560e28e82d782f4f49a8ba287744
+  md5: 9f99f01e47455dbeb0fcc573c920068f
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.10,<3.11.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - pandoc >=2.9.2,<4.0.0
+  - tornado >=6.1
+  - nbconvert =7.16.6=*_0
+  license: BSD-3-Clause
+  size: 531083
+  timestamp: 1741194860707
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-pandoc-7.16.6-py310haa95532_0.tar.bz2
+  sha256: dd02e532d2cdb1595faffaa342ff2077352b4f789e2fa080985c1112520c175e
+  md5: 7a64635f74a898db8cc5fc94c845ec1e
+  depends:
+  - nbconvert-core 7.16.6 py310haa95532_0
+  - pandoc
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  size: 8265
+  timestamp: 1741194878108
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py310haa95532_0.tar.bz2
+  sha256: b60400ded73de1554aebeb8c292d55bc8c98b3c5701b35285019468fb4c4ac9f
+  md5: b12bb18cd2fb67bf7bc0f2be962dd557
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.10,<3.11.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 180615
+  timestamp: 1728050835184
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py310haa95532_0.tar.bz2
+  sha256: e18ba942bb3f8a0ace571cfe58557aa5088acac13d094fde0302cf6452b2f7bf
+  md5: eb32799be5cf9de16c3688a34cb2b409
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14318
+  timestamp: 1708533067532
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py310haa95532_0.tar.bz2
+  sha256: e8e153535f8e002678562c80d96e6a0abf6fc132c07a5c1b98759985d2e934ea
+  md5: e4776c87a5f45a19ac3a76c4f429f9f5
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 649666
+  timestamp: 1717631447182
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.4-py310haa95532_0.tar.bz2
+  sha256: ad7ca45f0fd4367d991de584c84719b4fc08e4f83d817996fdb9e41817e30666
+  md5: 34d2aa88757595e757a9a2f6234b1731
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23809
+  timestamp: 1741707972451
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.63.1-py310h54bf9d2_0.tar.bz2
+  sha256: ddb45892db5149617e97a875c8e01cc76c779b8082b7b0a72c271396c1c5a773
+  md5: 0462e3f72565cc5c03ab2d8f37be112f
+  depends:
+  - llvmlite >=0.46.0dev0,<0.47
+  - numpy >=1.21,<3
+  - numpy >=1.22,<2.4,!=2.0.1
+  - python >=3.10,<3.11.0a0
+  - tbb >=2022.0.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - scipy >=1.0
+  - cuda-python >=11.6
+  - cuda-version >=11.2
+  - tbb >=2022
+  - cudatoolkit >=11.2
+  - libopenblas !=0.3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4684566
+  timestamp: 1765906176603
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py310h12f7302_1.tar.bz2
+  sha256: 31746de75b5502248a15da5ec1852a7773ac257e184d7d2a5e303fbd7ebb5c2d
+  md5: fc00573edd76a59e4fe5ac180661cc18
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2025.0.0,<2026.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py310he4e2855_1
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13387
+  timestamp: 1755595042232
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py310he4e2855_1.tar.bz2
+  sha256: eeb48933573ce52974db91b8340c78d8264a960e89a31d3c043e30c9b48c7889
+  md5: b7ae7a125db14819a81ae4229317bebd
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2025.0.0,<2026.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  constrains:
+  - numpy 1.26.4 py310h12f7302_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10046118
+  timestamp: 1755595016406
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.18-h543e019_0.tar.bz2
+  sha256: 59d81d1e37b3abdd377bcfa43741e4b77209b150d2c1c55b1fb7e6ef724fd4c7
+  md5: 48b99fea9541b04984ba3af1dac0f1bc
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: Apache-2.0
+  license_family: Apache
+  size: 8353123
+  timestamp: 1759490461024
+- conda: https://repo.anaconda.com/pkgs/main/win-64/orc-2.2.0-h79e1e1e_1.tar.bz2
+  sha256: 9a80063950d261a967f72cc0028becc082be56a79fb107273e541916ad70176e
+  md5: 8263c942be7be180746d24374a17d5dd
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20250814.1,<20250815.0a0
+  - libprotobuf >=6.33.0,<6.33.1.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.2.1,<2.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  - zlib >=1.2.13,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1473905
+  timestamp: 1764689909240
+- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.7.0-py310haa95532_0.tar.bz2
+  sha256: f460578737a2f23fb5b1847cf0b580721ee31e324f1e3da531c2e1a567ee37a3
+  md5: 0c626aa0cb02167440f199a04713faea
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 35653
+  timestamp: 1762349146753
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-25.0-py310haa95532_1.tar.bz2
+  sha256: 4b0ec37a59609d162d5bd46191f7672ed011d2ed058e3220bc465492778ffbc8
+  md5: aec5f6c40353b6501fb88eaccbc7ff43
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 168318
+  timestamp: 1761049138959
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandoc-3.8-haa95532_0.tar.bz2
+  sha256: 2f78bba1f41497d7ca63eee3cddd258386c87900b0abdd218f479a605c092026
+  md5: 79df078a732c569f5f243ab4f4b16146
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 32908716
+  timestamp: 1758807035109
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandocfilters-1.5.1-py310haa95532_0.tar.bz2
+  sha256: 37df9288d8b891ffb73f2c6de940397d2b6be0f22fa276a50765c33976a730ea
+  md5: 3df457829a5660b7e38a54277432d06b
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15845
+  timestamp: 1756977656103
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py310haa95532_0.tar.bz2
+  sha256: 2f62ba591aea27c6f15773bdfdc09558fcadd11559e48aadc3ea69960bf1e113
+  md5: ae943e3adf679487f8c691397d9fe533
+  depends:
+  - bleach
+  - bokeh >=3.1.1,<3.3
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.16.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17018899
+  timestamp: 1695146622867
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py310haa95532_0.tar.bz2
+  sha256: 7d8d0ef93307680696d575a445b442de32320fa3eb4b2fc090164ff0ac7e17a8
+  md5: 3eeea45a3f84b3b563e5990a36429dcb
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 143435
+  timestamp: 1684915381677
+- conda: https://repo.anaconda.com/pkgs/main/win-64/parso-0.8.5-py310haa95532_0.tar.bz2
+  sha256: d958b3cef4efc4e4e583bb5c63f7af764ab980c4a892811f60b675a6c321b79b
+  md5: 174cfb66d566fc943e1cb1c081d8c74c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT AND PSF
+  license_family: OTHER
+  size: 180264
+  timestamp: 1762781965864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.2-py310haa95532_0.tar.bz2
+  sha256: 9e89f1a2c6a2623e57943c87029f11c84949fda4ec2b5e87f5791feeea6d7ae7
+  md5: 9cb905acc9d134cde747bbdc42054db3
+  depends:
+  - locket
+  - python >=3.10,<3.11.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.20.0
+  - pandas >=1.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37003
+  timestamp: 1736803791927
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pcre2-10.46-h5740b90_0.tar.bz2
+  sha256: 094769f189ebd4d4b6cad745a07c163b3d2c41afcbeefeea2136cbf1f4ad5602
+  md5: 4ab3e048e11018a0461ceca64796424c
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  - zlib >=1.2.13,<2.0a0
+  license: BSD-3-Clause WITH PCRE2-exception
+  license_family: BSD
+  size: 3007931
+  timestamp: 1759825896688
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-12.0.0-py310h4212202_1.tar.bz2
+  sha256: 6258971772d50b7240b11588522b90f8db1f0831ce0a80b573f496fad8250567
+  md5: d22d36ff0b73e3e4d3c0b76ab74e39f9
+  depends:
+  - freetype >=2.13.3,<3.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=10.2.0,<11.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.16,<3.0a0
+  - libavif >=1.1.1,<2.0a0
+  - libopenjpeg >=2.5.4,<2.6.0a0
+  - libtiff >=4.7.0,<5.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  - zlib >=1.2.13,<2.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 838435
+  timestamp: 1762528415821
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pixman-0.46.4-h4043f72_0.tar.bz2
+  sha256: 362952382855bddac08440d2c03d819f22430cbd946817aa6d6925703a33319a
+  md5: a90b06706795b88b913313bec06734ea
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 270570
+  timestamp: 1755256536068
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-4.5.0-py310haa95532_0.tar.bz2
+  sha256: 4632d3c8c010000b3639aad509bfb31db1c51d6ffa57760bab7347c70fa1aa21
+  md5: ac8779589205e503ec30c3d4d5aec668
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 35567
+  timestamp: 1762356649178
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.21.1-py310haa95532_0.tar.bz2
+  sha256: 328a570bd4e31f361be29cf17494e4daf90bbc2581bf0e4140fe7e576803b3d5
+  md5: 6f422683a09b4d1aae04be9d7676aca4
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 118891
+  timestamp: 1744271703425
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.52-py310haa95532_1.tar.bz2
+  sha256: 57af9abfd6cfcce5918afefe735a54e832b8e83f608eb398b6e6c30bf873699b
+  md5: ca27bcf16ab9b23e939bb523dcbc255d
+  depends:
+  - python >=3.10,<3.11.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.52
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 621394
+  timestamp: 1761745060545
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-7.0.0-py310h02ab6af_1.tar.bz2
+  sha256: 4d8c216bbe04e37781a080853a5f896c2608c11451b70974ad5c1d3024c7c366
+  md5: 88caa251b1032c255cdc20a4762ecaa5
+  depends:
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 429272
+  timestamp: 1761896636025
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pure_eval-0.2.3-py310haa95532_0.tar.bz2
+  sha256: 113730924bfe8cb16b70a11a1a7c2bcfd26d014ab341ecf6daf97fbd2fc1cec6
+  md5: bfccfa6fb5d7eccb649bd55984faac8e
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 28270
+  timestamp: 1757067109554
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-21.0.0-py310h42c1672_1.tar.bz2
+  sha256: 05a006a15679f821fb2041f94f6f442cce0c1a955253bf4bcbd3098fd0e0bdec
+  md5: 6bca35b930e5c9b083b9e382ee81c0d2
+  depends:
+  - arrow-cpp >=21.0.0,<21.0.1.0a0
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: Apache-2.0
+  license_family: Apache
+  size: 5374561
+  timestamp: 1764939694679
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pycparser-2.23-py310haa95532_0.tar.bz2
+  sha256: 3ba6aa3dd169162d7d611022cec5c1ffff11874ad799c5b3bb5d80e31bf39d30
+  md5: 64b0d5dd1f61e80585dc9f9a66fdbeff
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 232495
+  timestamp: 1757496100500
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.6.0-py310haa95532_0.tar.bz2
+  sha256: 72b581bd12b0cba91c3d79ebd8143c98c709c6749b6864da06c78f552a72e2ed
+  md5: 9e7890bb994c7d28c1b0eefe470582fd
+  depends:
+  - param >=1.7.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 60870
+  timestamp: 1759932207666
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.19.2-py310haa95532_0.tar.bz2
+  sha256: 33c50248605a91f9d03a9f49e84c0508f00c112be085a0d00dae6b61d6f7485f
+  md5: d0374446d5d31123493f86dc61e7f3f2
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - colorama >=0.4.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5228792
+  timestamp: 1762431478812
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.2.5-py310haa95532_0.tar.bz2
+  sha256: b7358a41c4b5161d01da1d6baefa9b200e458bc99cd79f04e46677f2ea1d4f91
+  md5: b6f745c157414da3024be95304f470ef
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 549696
+  timestamp: 1763973934465
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py310haa95532_1.tar.bz2
+  sha256: eeea16f6b3bb9f5f15b662df3fb28c151274e87ae9eff11ae4c5ad41f6da44a7
+  md5: c8991a20c9e7b71aa9d73111e2ba511f
+  depends:
+  - python >=3.10,<3.11.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 28712
+  timestamp: 1761753068988
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.10.19-h981015d_0.tar.bz2
+  sha256: d2463c7b7f725e6e88815b35113d64edc23580af947fa75892c3ccf2c7f78e2b
+  md5: d644a3d91ead219de83075a9e8f7029b
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - expat >=2.7.1,<3.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - openssl >=3.0.18,<4.0a0
+  - sqlite >=3.50.2,<4.0a0
+  - tk >=8.6.15,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  - xz >=5.6.4,<6.0a0
+  - zlib >=1.2.13,<2.0a0
+  constrains:
+  - openssl <3.5.7
+  license: PSF-2.0
+  license_family: PSF
+  size: 17508706
+  timestamp: 1761065071419
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py310haa95532_2.tar.bz2
+  sha256: 8e12b59e93c1b5489ed6fdbd044d5626158356ea840953f0da6bfd15caf21d71
+  md5: 2a984d495e1cd2dd84c0049f248d61ab
+  depends:
+  - python >=3.10,<3.11.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 290793
+  timestamp: 1716495894571
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.21.2-py310haa95532_0.tar.bz2
+  sha256: be66b02f646185d14bdd7c646cade064f2924d755e29be53684902244a023b5c
+  md5: 0e57a5d9275ec185c257dc4c9b03d472
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 272322
+  timestamp: 1763718767803
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-4.0.0-py310haa95532_0.tar.bz2
+  sha256: b746d931836bfc9d020512b41a9a3bb6ff3939115516cc907087eb3cc107c60f
+  md5: e54be7a3cadbea0bf6ad516fc93d8c6e
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30469
+  timestamp: 1764590285196
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.7.5-py310h5823743_0.tar.bz2
+  sha256: 386c205910b56f64f6bc7678a097946ffc494e414d221624ce2d1fad37abb25b
+  md5: 3a6f432e5bf93649e4f88e865109f646
+  depends:
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: OLDAP-2.8
+  license_family: Other
+  size: 150634
+  timestamp: 1764243911976
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python_abi-3.10-3_cp310.tar.bz2
+  sha256: bfa6752b2dab58c27c79ed9636d638fc7a8ec876ecdfab6a517f0802652c3c05
+  md5: dd185883263018563eca7243a40a8f24
+  constrains:
+  - python 3.10.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4962
+  timestamp: 1764349791676
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2025.2-py310haa95532_0.tar.bz2
+  sha256: e8a0c1087ced217ccc53e7550050ce6f3deb6ed3c8c4cac41a1e270beb9344aa
+  md5: c235e2dd675763a64387702a35c27a4e
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 279238
+  timestamp: 1752136432982
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.6-py310haa95532_0.tar.bz2
+  sha256: d6b3d90b8a9fea1a2562e7e4136ab3059970d2ae2ca9fa154f09513f9f0c9fb1
+  md5: 4bd9aebdcccf408f889661bb44f08938
+  depends:
+  - param
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jupyterlab >=4.0,<5.dev0
+  - setuptools >=40.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62050
+  timestamp: 1758102194153
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-311-py310h885b0b7_0.tar.bz2
+  sha256: 8dc23c410c1645d5081c95db235da30a0f9109b1c58747a4cc219fdd125ec909
+  md5: 41df4be9302646515a884a02a70e6927
+  depends:
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  license_family: Other
+  size: 15017954
+  timestamp: 1754671659175
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.15-py310h72d21ff_0.tar.bz2
+  sha256: 7161580ca9426fc71909125e2eb63529cd11c345488c9429ec5c06c6a92c655d
+  md5: 8e824996fe2ca2603d5332cebaa40ec6
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - winpty >=0.4.3,<1.0a0
+  license: MIT
+  license_family: MIT
+  size: 247926
+  timestamp: 1741872556102
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.3-py310hb9a58be_0.tar.bz2
+  sha256: 2b8bf2765adcad3774c45ea6fa09cc4f680cd36f71bbfdc8d3e4d5228682a276
+  md5: 234f4ecd5f20e8bd2cddede1e4b19979
+  depends:
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 219564
+  timestamp: 1763465569630
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py310h2bbff1b_0.tar.bz2
+  sha256: a2f884b8700f604220f7f196ca023ae9a90a0cb25ee113c091647254b0f0f6eb
+  md5: 019a502ef2b8f2363d3925570a01da73
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 474370
+  timestamp: 1709318932082
+- conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2025.11.05-hc24cdf5_0.tar.bz2
+  sha256: 62685e276af944e516d613e1263e7d2039a436ca89b324838be454d27d2dedf4
+  md5: 8f14673595d8cddd64d16124ddd1080e
+  depends:
+  - libre2-11 2025.11.05 ha6b10e7_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 274609
+  timestamp: 1763136519172
+- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.37.0-py310haa95532_0.tar.bz2
+  sha256: 7b259a6e433e9f9be58256f529d8271d873bcd447663eda6d54aff8ef68f9ebb
+  md5: 1219002ce84e916b5af05b2872bc2cc1
+  depends:
+  - attrs >=22.2.0
+  - python >=3.10,<3.11.0a0
+  - rpds-py >=0.7.0
+  - typing_extensions >=4.4.0
+  license: MIT
+  license_family: MIT
+  size: 63593
+  timestamp: 1762536949358
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.5-py310haa95532_1.tar.bz2
+  sha256: cbb04f23a80037a687c747d3fff2659bb60ebabdee9adf491755bf37079d0567
+  md5: c2881674c7405974700d46aa957d60b7
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.10,<3.11.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 144290
+  timestamp: 1762359651688
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py310haa95532_0.tar.bz2
+  sha256: 558cf5fcbf151bf419079e13b5f3cc5f0a51af0596661bef50290903e52cdc24
+  md5: a86808657e019161b1e8e0a492afe6e2
+  depends:
+  - python >=3.10,<3.11.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9367
+  timestamp: 1683077232021
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py310haa95532_0.tar.bz2
+  sha256: e069e307e66cf1289bad542f9293e7a79b902d15d330c875ccce709b2b2523dd
+  md5: 9f21f24f35c99c432df830795e3a33f4
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 9734
+  timestamp: 1683059168209
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.28.0-py310h114bc41_0.tar.bz2
+  sha256: 5905ba54d9887b1ce1df26b1cf76810986c709b659734dee1252658618536fd9
+  md5: 924f92d78a6b931ccee76c6ef2a2a3c6
+  depends:
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MIT
+  license_family: MIT
+  size: 255945
+  timestamp: 1762366811349
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.15.3-py310h1bbe36f_1.tar.bz2
+  sha256: ffa0365a6aa7e911799157143a29cd660798ccebf4ca6dca63454dc8cf61d754
+  md5: 272cf47fcf114dc3548cbbe97520c506
+  depends:
+  - blas 1.0 mkl
+  - icc_rt >=2022.1.0
+  - mkl >=2025.0.0,<2026.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.5
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 32031380
+  timestamp: 1759222877751
+- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.3-py310haa95532_0.tar.bz2
+  sha256: 14e0535b74363bd37bd4229697a5a7a7c80c8d759a9cadacd1ecd10a70ad5380
+  md5: 6589581ae4a1324f3d3a3df51bacf56d
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59103
+  timestamp: 1768170838371
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-80.9.0-py310haa95532_0.tar.bz2
+  sha256: bb93511774e89c5c967507da18c9c675cbd3ffaabdc240676232c8ff793b4ae7
+  md5: f2e80a46ffd3ee1069cb94e9cddb9df4
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1844446
+  timestamp: 1759863388037
+- conda: https://repo.anaconda.com/pkgs/main/win-64/six-1.17.0-py310haa95532_0.tar.bz2
+  sha256: 402e2cb276d03a4d2d8fd3951e7d7f2fcf31c596c71ce553b16cb514119b8a32
+  md5: 262b035440f7e5f45c5340f1610200ee
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 32580
+  timestamp: 1744271586206
+- conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.2.2-hab6b7b3_1.tar.bz2
+  sha256: f177814848e0f18215f54a25126d7e9307398bcd291c9716871286494361681a
+  md5: ba9632d870849506421dc45297feecd3
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: BSD-3-Clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 118521
+  timestamp: 1767632526284
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.1-py310haa95532_0.tar.bz2
+  sha256: fb58a4ec186065216c81cb14aa4ec028ceddf62b9ad71280c6f8634edac582be
+  md5: c854b692a497b3b46036f14217516afd
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 16874
+  timestamp: 1764329254779
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py310haa95532_0.tar.bz2
+  sha256: a23892e537aa5387f4a7e817dfdcc4b9c5fec6b40a1695f99ecb7e3896f8f1b3
+  md5: 022293f076961b460cfe654421c3a69a
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 67725
+  timestamp: 1696347732280
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.51.1-hda9a48d_0.tar.bz2
+  sha256: 8ee81897ab4d69bef962efa9c373c205baf21bb416c36921963db07cbcdceec2
+  md5: 337d1804c595354abf87d7434cae4ab4
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: blessing
+  license_family: Other
+  size: 1505061
+  timestamp: 1767608649031
+- conda: https://repo.anaconda.com/pkgs/main/win-64/stack_data-0.6.3-py310haa95532_0.tar.bz2
+  sha256: cfbd746be170e60c003b2346a83486117a8a62801a7a3422d249b6e90800e06e
+  md5: cf955a0d11c9f9ca9c27359585e7f44b
+  depends:
+  - asttokens >=2.1.0
+  - executing >=1.2.0
+  - pure_eval
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 53765
+  timestamp: 1757067083583
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2022.3.0-h90c84d6_0.tar.bz2
+  sha256: 3af1170b68d17007d78febb7bf390bfa8343a962d867e8c6590724b82247a03d
+  md5: 386ac0fdc3bf21317e03762cf90695c2
+  depends:
+  - libhwloc >=2.12.1,<2.12.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: Apache-2.0
+  license_family: Apache
+  size: 203521
+  timestamp: 1764336927072
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-devel-2022.3.0-h90c84d6_0.tar.bz2
+  sha256: 05a3ea61861cb61b2edc601ceda6a8c25f6f278d9516aa56c4d65691e2831490
+  md5: b6cf67b3fb0b28202c8d54b668b42c1f
+  depends:
+  - libhwloc >=2.12.1,<2.12.2.0a0
+  - tbb 2022.3.0 h90c84d6_0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: Apache-2.0
+  license_family: Apache
+  size: 1272952
+  timestamp: 1764336942662
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tblib-3.2.2-py310haa95532_0.tar.bz2
+  sha256: fefe0fb5179167d09eab8ffbe018b136fe7cd3c16dbd31156d68e2b24355bf35
+  md5: bb341768e1520044fb9d98e4df934a03
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 25687
+  timestamp: 1768310054045
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.18.1-py310haa95532_0.tar.bz2
+  sha256: 87fbe4474cb9f4fda75066d5e3b7b43a480229d1fdda2c5512279a6e04333582
+  md5: 07b0432e19c2419ea6e3e7333a863b3a
+  depends:
+  - python >=3.10,<3.11.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  constrains:
+  - mypy >=1.6,<2
+  - traitlets >=5.11.1
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 27578
+  timestamp: 1757934990782
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.4.0-py310haa95532_0.tar.bz2
+  sha256: fa8f86c77759b2e75a748f87105019e271e27151a9f0ec08b9a8884336b458ff
+  md5: 84d91cf7523126598a8e39d02f493fd1
+  depends:
+  - python >=3.10,<3.11.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 93531
+  timestamp: 1738337989299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.15-hf199647_0.tar.bz2
+  sha256: dc4ac74ef5703abc317f7762eea416a50a7e7b36deee9ff2cd9061e9292bc5e8
+  md5: cac27313b231546bc9d937fcb21ae5f5
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3874380
+  timestamp: 1755244051664
+- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-1.1.0-py310haa95532_0.tar.bz2
+  sha256: e0a4418964d6504e8997732b43b0f663d3ab858b365d8d737e6dd8c2086cf8a5
+  md5: 6c29a7cc9ccc26c5e68eb4bfc5264698
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 108387
+  timestamp: 1764677784817
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.5.4-py310h02ab6af_0.tar.bz2
+  sha256: 040e82cca36a9171514ebfd26db3b6708f0f214d75f2c926292403dee870ddc4
+  md5: 87202c2637e5e66a91ff0777a837a6fe
+  depends:
+  - python >=3.10,<3.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: Apache-2.0
+  license_family: Apache
+  size: 728368
+  timestamp: 1765992835272
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.67.1-py310h4442805_1.tar.bz2
+  sha256: 6cc08e755a64113fa05d9aeae7843b20a4c19262422fbe9a5d876b072c125ef1
+  md5: e23516f4255378296c3224cc952efab3
+  depends:
+  - colorama
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 158835
+  timestamp: 1762863484601
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py310haa95532_0.tar.bz2
+  sha256: 69030849e5c9fb4b81997b209da56a31f39f70b17cd81ad5fa87a03829aa9c04
+  md5: 7dd354534a9f7c43229a6707470c5936
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 167935
+  timestamp: 1718227167930
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.15.0-py310haa95532_0.tar.bz2
+  sha256: 72667741205012b4a40a245afef11ea55f568beb40f7b0833caf0735341b9298
+  md5: b02dcf0af865ac8331b335a29a49c14d
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing_extensions 4.15.0 py310haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 12020
+  timestamp: 1756281344566
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.15.0-py310haa95532_0.tar.bz2
+  sha256: 592b90e9e3316df59e60bdcdc7a08558f45d299ab0c4415ec2777f6668b27c9e
+  md5: f23a8c512a31322faad3b9234c6d70d4
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 78964
+  timestamp: 1756281334161
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.3-py310haa95532_0.tar.bz2
+  sha256: 39cf0decc41cbb49e268c41446620a72426242ad6bd45e879db9a793ebc9edb8
+  md5: fe4ff63c5c84ac259436527f8a3d7cf7
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 11898
+  timestamp: 1758552222421
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ucrt-10.0.22621.0-haa95532_0.tar.bz2
+  sha256: 551c5227a32ab5edb1a9b3617da50f4a5b1db6ac978f30984dc4feb530bfd572
+  md5: b89556d8841d1ca1d37e1d4b660d58ba
+  constrains:
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-MicrosoftWindowsSDK10
+  size: 1284620
+  timestamp: 1752158202557
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.6.3-py310haa95532_0.tar.bz2
+  sha256: 01dfe6be9953413f28c88ea084a47ebb040e8f88ef0ce904b2e2d185048c701b
+  md5: 2ddef262068d2d727e2f4b406a9a7e3f
+  depends:
+  - brotlicffi >=1.2.0
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - h2 >=4,<5
+  - backports.zstd >=1.0.0
+  license: MIT
+  license_family: MIT
+  size: 309295
+  timestamp: 1767810529507
+- conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+  sha256: 2ef16d0252e04063d44d0683831d55b485f713fe5af2c2efd61753fb4f27d7e4
+  md5: 256ab1d5dce70111a1f4807a5a9fc322
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 100982
+  timestamp: 1706894771410
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.42-haa95532_5.tar.bz2
+  sha256: b6259eccee818ace89c5ad2667e252c3b23b12503a943a6a057b9feb36278f4e
+  md5: 515894551c4f3754e750e88ce534e9cc
+  depends:
+  - vs2015_runtime >=14.42.34433
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9972
+  timestamp: 1744721179868
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc14_runtime-14.44.35208-h4927774_10.tar.bz2
+  sha256: 3149d0e594b29dbd69065e6826730da17eb6e5cd3e2f15379ae9e1b29d8791e2
+  md5: bb49becbcb3d1e4bc4b8dd076ea4199c
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.44.35208.* *_10
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  size: 1534690
+  timestamp: 1752199754308
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.44.35208-ha6b5a95_10.tar.bz2
+  sha256: 5fc445cc95515cb218fb3ac9e7e45a767237d68b53f42ca2b0fb4b3d561109e5
+  md5: ee159e59f61b9c7fc28cc73d81fdfeab
+  depends:
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19128
+  timestamp: 1752199762272
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wcwidth-0.2.14-py310haa95532_0.tar.bz2
+  sha256: d121f999a9465b51fb52efebff7e70bab3204c75abf1fe46edea595861caae23
+  md5: 3f332e9838e3ddeb3ca29a7fc4259d34
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 77152
+  timestamp: 1767779258839
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py310haa95532_1.tar.bz2
+  sha256: 5feccb42695e0a5f0d8e47806ec4a38d80812946bedff171a1b6bde5513843e7
+  md5: 8719f9841803cf96f733f59aafbd147e
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21579
+  timestamp: 1642093965560
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py310haa95532_0.tar.bz2
+  sha256: f371d3506e4e8480ffde0e9d0fb1b44c2bfdbea57b23cccd609ca3aa034b3f83
+  md5: 85953c8badca12976eb5d368835fcefb
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 118154
+  timestamp: 1715878578248
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.45.1-py310haa95532_0.tar.bz2
+  sha256: 18705434a4ff1378bd84d1e2131ccf6f002a9bbe057d03dcec33fbf643a06721
+  md5: 4afe1fc2823ea86f8f12bcc80bcee9cb
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 142232
+  timestamp: 1737990665883
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py310haa95532_1.tar.bz2
+  sha256: a3563cafe1f5c60e3b29c53859b0b729d5371bb30eef69ed9a0b80a2b817ed11
+  md5: 6e2f0604292a3156603b56329f2d1785
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: PUBLIC-DOMAIN
+  size: 8793
+  timestamp: 1761746313924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py310haa95532_0.tar.bz2
+  sha256: fb467c7eacdf962bcb8f24476709a65db51ea60ee4ddb75f12ed30b4ea69d531
+  md5: 85a71410f54365f053f787ab5782859b
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1813278
+  timestamp: 1689041769969
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2025.4.0-py310haa95532_0.tar.bz2
+  sha256: 785a9e09a5c33ad72935cf6605b5e88910d0fe025fbde89791c9456e7417e94f
+  md5: beb986b2708d5c1ab3f387ef1ad69ce0
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 79249
+  timestamp: 1758720256560
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.6.4-h4754444_1.tar.bz2
+  sha256: d3458fa18024725ca330e84a0f63b531133a781b33e360b35c50cd278cc66ec4
+  md5: 3f6d85e0ee495eb5fdae370f7f456e4c
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 290014
+  timestamp: 1739468425589
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-h6c54ac7_1.tar.bz2
+  sha256: 23510bfdd00463d170c7962d34b355e0e3739748705cff3e7f6c09f931ccf7f6
+  md5: 857aaa8d36ad69c6fc3b07c45418ca6e
+  depends:
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: MPL-2.0
+  license_family: Other
+  size: 8402466
+  timestamp: 1757676535552
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py310haa95532_1.tar.bz2
+  sha256: d70ed088345da7a4d6fbfbd82e027fbdc40f20a7c4ce380dc163dc86e4af0bd7
+  md5: db8c2be78a4edc8bedc315ea7e95cfb4
+  depends:
+  - heapdict
+  - python >=3.10,<3.11.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 77772
+  timestamp: 1764604410317
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.23.0-py310haa95532_0.tar.bz2
+  sha256: d401c280ed4475911fe42fda035cf7fb784a39ed152e6be24dd6ddca8c78545a
+  md5: 91cb520ff74939dc731749aa72d1827c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 26805
+  timestamp: 1763977979094
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.3.1-h02ab6af_0.tar.bz2
+  sha256: a42852305292e1991c2f45f542df0007a58c0a6e2a59964517b0bd45787215d5
+  md5: 576e63267d028c9a24bddf1a4e8ab36d
+  depends:
+  - libzlib 1.3.1 h02ab6af_0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  license: Zlib
+  license_family: OTHER
+  size: 118318
+  timestamp: 1756476083170
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.7-h56299aa_0.tar.bz2
+  sha256: b9b207c204156bea7425eca2141c01974511e6acc557957e64409293721eb000
+  md5: 63b4871fee1e1959f7b7006b63b2cb2b
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30133
+  - xz >=5.6.4,<6.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 2021720
+  timestamp: 1758039218319

--- a/census/pixi.lock
+++ b/census/pixi.lock
@@ -7,8 +7,8 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     - url: https://conda.anaconda.org/conda-forge/
     packages:
       linux-64:
@@ -25,244 +25,244 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2023.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2023.5.0-pyhd8ed1ab_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.10.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aom-3.6.0-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-25.1.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py310h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-19.0.0-hfcf91c8_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/asttokens-3.0.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-25.4.0-py310h06a4308_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-auth-0.8.5-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-cal-0.8.5-hdbd6064_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.11.1-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-compression-0.3.1-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.5.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-http-0.9.3-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-io-0.17.0-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-mqtt-0.12.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-s3-0.7.11-hdbd6064_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-sdkutils-0.2.3-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.2.3-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-crt-cpp-0.31.0-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.11.528-h74f24ce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.14.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bleach-6.3.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.2.1-py310h2f386ee_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py310h6a678d5_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlicffi-1.0.9.2-py310h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2025.12.2-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cairo-1.16.0-he5ede1b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2026.01.04-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py310h1fdaa30_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/charset-normalizer-3.4.4-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.2.1-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.1.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.3.1-py310hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cramjam-2.9.1-py310h922eef2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cycler-0.12.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-1.0.1-py310h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.15.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dav1d-1.2.1-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.8.11-py310h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/decorator-5.2.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.3.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/executing-2.2.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.7.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-2024.2.0-py310ha9d4c09_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.14.1-h55d465d_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.55.3-py310h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.13.3-h4a9f257_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fribidi-1.0.10-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2026.1.0-py310h7040dfc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/graphite2-1.3.14-h295c915_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/harfbuzz-10.2.0-hdfddeaa_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.16.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.11-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-8.7.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.30.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.6-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.25.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2025.9.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.9.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.12.0-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.17.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.5.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.3.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.8-py310h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.21.3-h143b758_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.16-h92b89f2_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-4.0.0-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libabseil-20250127.0-cxx17_h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libavif-1.1.1-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.14.1-h31d0fb7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.22-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-8.2.0-hdf63c60_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libglib-2.84.2-h37c7471_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgrpc-1.71.0-h2d74bed_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hecde1de_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libopenblas-0.3.29-ha39b09d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-5.29.3-h3cdef7c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libre2-11-2024.07.02-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.11.1-h251f7ec_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.7.0-hde9077f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.17.0-h9b100fa_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.13.8-hfdd30dd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.43.0-py310h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py310h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.10-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-3.0.2-py310h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.10.0-py310hbfdbfaf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.2.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.5.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-3.1.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.1.1-py310h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-1.0.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.3.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.10.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.16.6-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-core-7.16.6-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-pandoc-7.16.6-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.4-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py310heeff2f4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py310h8a23956_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-h0d4d230_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.17-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-2.1.1-hd396ef6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.7.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-25.0-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandoc-3.8-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandocfilters-1.5.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.2.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/parso-0.8.5-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pexpect-4.9.0-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-11.3.0-py310hb1c3d2d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pixman-0.40.0-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-4.5.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.21.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.52-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py310h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pthread-stubs-0.3-h0ce48e5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pure_eval-0.2.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-19.0.0-py310h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pycparser-2.23-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.6.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.19.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.2.5-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.10.18-h1a3bd86_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py310h06a4308_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.21.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-4.0.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.6.2-py310h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python_abi-3.10-3_cp310.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2025.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.6-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py310h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py310h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2024.07.02-hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.37.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.5-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.22.3-py310h4aa5aa6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/s2n-1.5.14-hdbd6064_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.15.3-py310h5e4e545_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-80.9.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/six-1.17.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/stack_data-0.6.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tblib-3.2.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.18.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.4.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h993c535_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-1.1.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.5.1-py310h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.67.1-py310h7040dfc_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.15.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.15.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py310h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.5.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wcwidth-0.2.14-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.45.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libx11-1.8.12-h9b100fa_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxau-1.0.12-h9b100fa_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxdmcp-1.1.5-h9b100fa_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxext-1.3.6-h9b100fa_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxrender-0.9.12-h9b100fa_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-xorgproto-2024.1-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2025.4.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.6.4-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.23.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/html5lib-1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/importlib_metadata-8.7.0-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-25.3-pyhc872135_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.52-hd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2025.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2025c-he532380_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-4.10.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aom-3.6.0-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-25.1.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py310h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/arrow-cpp-19.0.0-hfcf91c8_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/asttokens-3.0.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-25.4.0-py310h06a4308_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-auth-0.8.5-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-cal-0.8.5-hdbd6064_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-common-0.11.1-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-compression-0.3.1-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-event-stream-0.5.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-http-0.9.3-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-io-0.17.0-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-mqtt-0.12.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-s3-0.7.11-hdbd6064_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-sdkutils-0.2.3-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-checksums-0.2.3-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-crt-cpp-0.31.0-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-sdk-cpp-1.11.528-h74f24ce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.14.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bleach-6.3.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-3.2.1-py310h2f386ee_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py310h6a678d5_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotlicffi-1.0.9.2-py310h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2025.12.2-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cairo-1.16.0-he5ede1b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2026.01.04-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.17.1-py310h1fdaa30_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/charset-normalizer-3.4.4-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/click-8.2.1-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cloudpickle-3.1.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.2.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/contourpy-1.3.1-py310hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cramjam-2.9.1-py310h922eef2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cycler-0.12.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cytoolz-1.0.1-py310h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/datashader-0.15.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/datashape-0.5.4-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dav1d-1.2.1-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.8.11-py310h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/decorator-5.2.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.3.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/executing-2.2.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/expat-2.7.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fastparquet-2024.2.0-py310ha9d4c09_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fontconfig-2.14.1-h55d465d_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fonttools-4.55.3-py310h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.13.3-h4a9f257_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fribidi-1.0.10-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fsspec-2026.1.0-py310h7040dfc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/graphite2-1.3.14-h295c915_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/harfbuzz-10.2.0-hdfddeaa_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.16.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.11-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-8.7.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.29.5-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.30.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.19.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.6-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.25.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2025.9.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.9.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.12.0-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.17.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.5.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyterlab_pygments-0.3.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.8-py310h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/krb5-1.21.3-h143b758_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.16-h92b89f2_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lerc-4.0.0-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libabseil-20250127.0-cxx17_h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libavif-1.1.1-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libcurl-8.14.1-h31d0fb7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.22-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-8.2.0-hdf63c60_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libglib-2.84.2-h37c7471_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgrpc-1.71.0-h2d74bed_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libllvm14-14.0.6-hecde1de_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libopenblas-0.3.29-ha39b09d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libprotobuf-5.29.3-h3cdef7c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libre2-11-2024.07.02-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libssh2-1.11.1-h251f7ec_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.7.0-hde9077f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxcb-1.17.0-h9b100fa_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxml2-2.13.8-hfdd30dd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.43.0-py310h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-4.3.2-py310h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.10-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-3.0.2-py310h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.10.0-py310hbfdbfaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.2.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.5.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-3.1.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/msgpack-python-1.1.1-py310h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/multipledispatch-1.0.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-1.3.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.10.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.16.6-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-core-7.16.6-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-pandoc-7.16.6-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.10.4-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.7-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.4-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.4-py310heeff2f4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.4-py310h8a23956_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.5.2-h0d4d230_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.17-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/orc-2.1.1-hd396ef6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/overrides-7.7.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-25.0-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandoc-3.8-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandocfilters-1.5.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-1.2.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/parso-0.8.5-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/partd-1.4.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pexpect-4.9.0-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-11.3.0-py310hb1c3d2d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pixman-0.40.0-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-4.5.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.21.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.52-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py310h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pthread-stubs-0.3-h0ce48e5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pure_eval-0.2.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyarrow-19.0.0-py310h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pycparser-2.23-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyct-0.6.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.19.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.2.5-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.10.18-h1a3bd86_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py310h06a4308_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.21.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-json-logger-4.0.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-lmdb-1.6.2-py310h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python_abi-3.10-3_cp310.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2025.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.6-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.2-py310h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-24.0.1-py310h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/re2-2024.07.02-hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/referencing-0.37.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.32.5-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.22.3-py310h4aa5aa6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/s2n-1.5.14-hdbd6064_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scipy-1.15.3-py310h5e4e545_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-80.9.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/six-1.17.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/stack_data-0.6.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tblib-3.2.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.18.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.4.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h993c535_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/toolz-1.1.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.5.1-py310h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.67.1-py310h7040dfc_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.14.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.15.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.15.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py310h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-2.5.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wcwidth-0.2.14-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.45.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xorg-libx11-1.8.12-h9b100fa_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xorg-libxau-1.0.12-h9b100fa_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xorg-libxdmcp-1.1.5-h9b100fa_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xorg-libxext-1.3.6-h9b100fa_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xorg-libxrender-0.9.12-h9b100fa_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xorg-xorgproto-2024.1-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xyzservices-2025.4.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.6.4-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zict-3.0.0-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.23.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/html5lib-1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/importlib_metadata-8.7.0-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pip-25.3-pyhc872135_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.52-hd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2025.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2025c-he532380_0.tar.bz2
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2023.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.5.0-pyhd8ed1ab_0.conda
@@ -271,233 +271,233 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.0.1-py310h5e4fcda_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.10-2_cp310.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/importlib_metadata-8.7.0-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-25.3-pyhc872135_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.52-hd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2025.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2025c-he532380_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.7.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aom-3.6.0-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.4-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py310h46256e1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-19.0.0-hb704434_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/asttokens-3.0.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.3.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-auth-0.9.0-h46256e1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-cal-0.9.2-h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.12.3-h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-compression-0.3.1-h46256e1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.5.5-h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-http-0.10.2-h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-io-0.20.1-h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-mqtt-0.13.2-he61ece7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-s3-0.8.3-h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-sdkutils-0.2.4-h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.2.7-h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-crt-cpp-0.32.10-h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.11.528-he026a02_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.13.4-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bleach-6.2.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py310h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py310h6d0c2b6_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotlicffi-1.0.9.2-py310h6d0c2b6_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2025.7.15-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cairo-1.16.0-h08824b9_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2025.8.3-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py310h9205ec4_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.2.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.1.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.3.1-py310h1962661_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cramjam-2.9.1-py310hc8aab72_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-1.0.1-py310h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.15.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py310hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dav1d-1.2.1-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.8.11-py310h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.2.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/expat-2.7.1-h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-2024.2.0-py310h7b7cdfe_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fontconfig-2.14.1-h269ac6a_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.55.3-py310h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.13.3-h02243ff_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fribidi-1.0.10-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2025.7.0-py310he13d532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gettext-0.21.0-h4e8c18a_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/graphite2-1.3.14-he9d5cce_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/harfbuzz-10.2.0-h060d35a_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.16.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py310hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.30.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.6-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.25.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.8.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.12.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.16.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.5.3-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.3.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.8-py310h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.16-h31d93a5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-4.0.0-h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libabseil-20250127.0-cxx17_h548131f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libavif-1.1.1-h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h46256e1_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h46256e1_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h46256e1_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.14.1-h1448931_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-19.1.7-haebbb44_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.22-h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libglib-2.84.2-heb90364_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgrpc-1.71.0-hf2926fd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.29-h3f8574a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-5.29.3-h66a43dd_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libre2-11-2024.07.02-hab2016f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.11.1-h3a17b82_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.7.0-h2dfa3ea_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.13.8-h6070cd6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-19.1.7-h5048363_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.44.0-py310hfa5e528_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-4.3.2-py310h46256e1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.8-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py310hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-3.0.2-py310h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.10.0-py310h919b35b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-3.1.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.1.1-py310h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.3.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.10.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.6-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-core-7.16.6-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-pandoc-7.16.6-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.5-h923df54_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.4-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.61.2-py310h2d33a94_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py310hf6dca73_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py310hd8f4981_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-h2d09ccc_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.17-hee2dfae_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-2.1.1-h4dda5a6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-25.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandoc-2.12-hecd8cb5_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/parso-0.8.4-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pcre2-10.42-h9b97e30_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pexpect-4.9.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-11.3.0-py310h25d8182_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pixman-0.46.4-hb254d66_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-4.3.7-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.21.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py310h46256e1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-19.0.0-py310h6d0c2b6_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.19.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.2.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.10.18-hc958d9f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py310hecd8cb5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.20.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-3.2.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.6.2-py310h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2025.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py310h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py310h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2024.07.02-h1962661_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.3-h49f2429_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.4-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.22.3-py310h83de92b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.15.3-py310h97975f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py310hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-78.1.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/six-1.17.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.50.2-hc8b0dd6_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tblib-3.1.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.4.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.15-h3a5a201_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-1.0.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.5.1-py310h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.67.1-py310h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.12.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.12.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py310h46256e1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.5.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wcwidth-0.2.13-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py310hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.45.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py310hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.6.4-h46256e1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.21.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/importlib_metadata-8.7.0-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pip-25.3-pyhc872135_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.52-hd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2025.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2025c-he532380_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-4.7.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aom-3.6.0-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py310h46256e1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/arrow-cpp-19.0.0-hb704434_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/asttokens-3.0.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-24.3.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-auth-0.9.0-h46256e1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-cal-0.9.2-h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-common-0.12.3-h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-compression-0.3.1-h46256e1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-event-stream-0.5.5-h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-http-0.10.2-h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-io-0.20.1-h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-mqtt-0.13.2-he61ece7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-s3-0.8.3-h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-sdkutils-0.2.4-h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-checksums-0.2.7-h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-crt-cpp-0.32.10-h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-sdk-cpp-1.11.528-he026a02_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.13.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bleach-6.2.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-3.2.1-py310h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py310h6d0c2b6_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotlicffi-1.0.9.2-py310h6d0c2b6_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2025.7.15-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cairo-1.16.0-h08824b9_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2025.8.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.17.1-py310h9205ec4_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/click-8.2.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cloudpickle-3.1.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.3.1-py310h1962661_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cramjam-2.9.1-py310hc8aab72_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cytoolz-1.0.1-py310h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/datashader-0.15.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/datashape-0.5.4-py310hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/dav1d-1.2.1-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.8.11-py310h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.2.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/expat-2.7.1-h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fastparquet-2024.2.0-py310h7b7cdfe_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fontconfig-2.14.1-h269ac6a_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fonttools-4.55.3-py310h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.13.3-h02243ff_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fribidi-1.0.10-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fsspec-2025.7.0-py310he13d532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/gettext-0.21.0-h4e8c18a_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/graphite2-1.3.14-he9d5cce_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/harfbuzz-10.2.0-h060d35a_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.16.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.29.5-py310hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.30.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.19.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.6-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.25.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.8.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.12.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.16.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.5.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyterlab_pygments-0.3.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.8-py310h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.16-h31d93a5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-4.0.0-h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libabseil-20250127.0-cxx17_h548131f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libavif-1.1.1-h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h46256e1_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h46256e1_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h46256e1_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcurl-8.14.1-h1448931_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-19.1.7-haebbb44_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.22-h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libglib-2.84.2-heb90364_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgrpc-1.71.0-hf2926fd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libopenblas-0.3.29-h3f8574a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libprotobuf-5.29.3-h66a43dd_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libre2-11-2024.07.02-hab2016f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libssh2-1.11.1-h3a17b82_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.7.0-h2dfa3ea_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxml2-2.13.8-h6070cd6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-19.1.7-h5048363_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.44.0-py310hfa5e528_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-4.3.2-py310h46256e1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.8-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py310hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-3.0.2-py310h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.10.0-py310h919b35b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-3.1.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/msgpack-python-1.1.1-py310h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-1.3.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.10.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.16.6-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-core-7.16.6-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-pandoc-7.16.6-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.10.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.5-h923df54_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.7-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numba-0.61.2-py310h2d33a94_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.4-py310hf6dca73_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.4-py310hd8f4981_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.5.2-h2d09ccc_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.17-hee2dfae_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/orc-2.1.1-h4dda5a6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-25.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandoc-2.12-hecd8cb5_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-1.2.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-1.13.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/parso-0.8.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/partd-1.4.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pcre2-10.42-h9b97e30_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pexpect-4.9.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-11.3.0-py310h25d8182_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pixman-0.46.4-hb254d66_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-4.3.7-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.21.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py310h46256e1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyarrow-19.0.0-py310h6d0c2b6_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.19.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.2.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.10.18-hc958d9f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py310hecd8cb5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.20.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-json-logger-3.2.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-lmdb-1.6.2-py310h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2025.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.2-py310h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-24.0.1-py310h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/re2-2024.07.02-h1962661_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.3-h49f2429_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.32.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.22.3-py310h83de92b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scipy-1.15.3-py310h97975f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py310hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-78.1.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/six-1.17.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.50.2-hc8b0dd6_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tblib-3.1.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.4.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.15-h3a5a201_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/toolz-1.0.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.5.1-py310h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.67.1-py310h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.14.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.12.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.12.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py310h46256e1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-2.5.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wcwidth-0.2.13-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py310hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.45.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py310hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.6.4-h46256e1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zict-3.0.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.21.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2023.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.5.0-pyhd8ed1ab_0.conda
@@ -511,474 +511,474 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.8.2-hd0f0c4f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-gpl-tools-5.8.2-hd0f0c4f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-tools-5.8.2-h8088a28_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/html5lib-1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/importlib_metadata-8.7.0-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-25.3-pyhc872135_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.52-hd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2025.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2025c-he532380_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.10.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aom-3.12.1-ha237518_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.4-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-25.1.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-25.1.0-py310h254cc4a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-21.0.0-hc027f7d_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/asttokens-3.0.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-25.4.0-py310hca03da5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-auth-0.9.0-h79febb2_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-cal-0.9.2-h79febb2_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.12.4-h79febb2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-compression-0.3.1-h79febb2_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.5.6-h79febb2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-http-0.10.4-h79febb2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-io-0.21.4-h79febb2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-mqtt-0.13.3-h387b88a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-s3-0.8.7-h79febb2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-sdkutils-0.2.4-h79febb2_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.2.7-h79febb2_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-crt-cpp-0.34.0-hee39554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.11.638-h35fa3df_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.14.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bleach-6.3.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py310h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotlicffi-1.2.0.0-py310h50f4ffc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.34.5-h2ca31fc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2025.12.2-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cairo-1.18.4-h191e429_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2026.01.04-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-2.0.0-py310h73c2a22_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/charset-normalizer-3.4.4-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.2.1-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.1.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.3.1-py310h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cramjam-2.11.0-py310h6fe787a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cycler-0.12.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-1.1.0-py310haa24f5a_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.15.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dav1d-1.2.1-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.8.16-py310h50f4ffc_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/decorator-5.2.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.3.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/executing-2.2.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/expat-2.7.3-h50f4ffc_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-2025.12.0-py310h03d0aa3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fontconfig-2.15.0-h29935d0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.61.0-py310haa24f5a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.13.3-h47d26ad_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fribidi-1.0.16-h8859324_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2026.1.0-py310h7eb115d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-0.21.0-hbdbcc25_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/graphite2-1.3.14-hc377ac9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/harfbuzz-10.2.0-he637ebf_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.16.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.11-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-8.7.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.30.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jansson-2.14-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.6-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9f-h2f69dba_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.25.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2025.9.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.9.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.12.0-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.17.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.5.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.3.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.9-py310haeee614_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.17-h7418793_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-4.0.0-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libabseil-20250814.1-cxx17_hbea547f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libavif-1.3.0-h839b4eb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.2.0-hbd7815e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.2.0-h1e834b2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.2.0-h5439a07_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.17.0-h5bd1c32_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-20.1.8-hd7fd590_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.22-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libexpat-2.7.3-h50f4ffc_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-15.2.0-hb654fa1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libglib-2.86.3-hcacd345_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgrpc-1.74.1-h941cc20_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libhwloc-2.12.1-default_h2915d5d_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libidn2-2.3.8-h9681e36_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm20-20.1.8-h1701f07_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.67.1-h8189af8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.30-hf2bb037_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenjpeg-2.5.4-haa24f5a_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.50-h5c318fc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-6.33.0-h6acce77_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libre2-11-2025.11.05-hd4f4e8d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.20-h897f8a9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.11.1-h3e2b118_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.22.0-hbe873a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.7.1-h367c460_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libunistring-1.3-h1799b2a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.6.0-h92b2d59_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.13.9-h528a072_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzlib-1.3.1-h5f15de7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-20.1.8-he822017_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.46.0-py310hc8eb11b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.4.5-py310hbc89d72_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.10-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-3.0.2-py310h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.10.8-py310haa222d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.2.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.5.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-3.1.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.1.1-py310h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-1.0.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.3.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.10.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.6-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-core-7.16.6-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-pandoc-7.16.6-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.5-hee39554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.4-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.63.1-py310hadc56cb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py310h901140f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py310hae06d03_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-2.2.0-hd6530ca_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.7.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-25.0-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandoc-3.8-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandocfilters-1.5.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/parso-0.8.5-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre2-10.46-h1dacb4a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pexpect-4.9.0-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-12.0.0-py310he2d6fe4_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pixman-0.46.4-h09dc60e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-4.5.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.21.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.52-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-7.0.0-py310haa24f5a_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pure_eval-0.2.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-21.0.0-py310h3f644e9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycparser-2.23-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.6.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.19.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.2.5-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py310hca03da5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.21.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-4.0.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.7.5-py310h3d52de1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python_abi-3.10-3_cp310.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2025.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.6-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.3-py310h091b9d3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py310h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2025.11.05-h1413154_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.3-h0b18652_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.37.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.5-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.28.0-py310h931abed_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.15.3-py310h132fc3c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-80.9.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/six-1.17.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.2.2-hc0f95ea_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/stack_data-0.6.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2022.3.0-h50665e7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tblib-3.2.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.18.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.4.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.15-hcd8a7d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-1.1.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.5.4-py310haa24f5a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.67.1-py310h7eb115d_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.15.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.15.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.6.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wcwidth-0.2.14-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.45.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2025.4.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h2c7f8f0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.23.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.3.1-h5f15de7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.7-h817c040_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/html5lib-1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/importlib_metadata-8.7.0-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pip-25.3-pyhc872135_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.52-hd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2025.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2025c-he532380_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.10.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aom-3.12.1-ha237518_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.4-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-25.1.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-25.1.0-py310h254cc4a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/arrow-cpp-21.0.0-hc027f7d_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/asttokens-3.0.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-25.4.0-py310hca03da5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-auth-0.9.0-h79febb2_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-cal-0.9.2-h79febb2_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-common-0.12.4-h79febb2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-compression-0.3.1-h79febb2_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-event-stream-0.5.6-h79febb2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-http-0.10.4-h79febb2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-io-0.21.4-h79febb2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-mqtt-0.13.3-h387b88a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-s3-0.8.7-h79febb2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-sdkutils-0.2.4-h79febb2_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-checksums-0.2.7-h79febb2_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-crt-cpp-0.34.0-hee39554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-sdk-cpp-1.11.638-h35fa3df_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.14.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bleach-6.3.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.2.1-py310h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotlicffi-1.2.0.0-py310h50f4ffc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/c-ares-1.34.5-h2ca31fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2025.12.2-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cairo-1.18.4-h191e429_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2026.01.04-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-2.0.0-py310h73c2a22_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/charset-normalizer-3.4.4-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/click-8.2.1-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-3.1.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.3.1-py310h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cramjam-2.11.0-py310h6fe787a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cycler-0.12.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cytoolz-1.1.0-py310haa24f5a_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/datashader-0.15.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/datashape-0.5.4-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/dav1d-1.2.1-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.8.16-py310h50f4ffc_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/decorator-5.2.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.3.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/executing-2.2.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/expat-2.7.3-h50f4ffc_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fastparquet-2025.12.0-py310h03d0aa3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fontconfig-2.15.0-h29935d0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.61.0-py310haa24f5a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.13.3-h47d26ad_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fribidi-1.0.16-h8859324_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2026.1.0-py310h7eb115d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/gettext-0.21.0-hbdbcc25_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/graphite2-1.3.14-hc377ac9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/harfbuzz-10.2.0-he637ebf_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.16.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.11-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-8.7.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.29.5-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.30.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jansson-2.14-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.19.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.6-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9f-h2f69dba_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.25.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2025.9.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.9.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.12.0-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.17.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.5.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_pygments-0.3.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.9-py310haeee614_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.17-h7418793_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-4.0.0-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libabseil-20250814.1-cxx17_hbea547f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libavif-1.3.0-h839b4eb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.2.0-hbd7815e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.2.0-h1e834b2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.2.0-h5439a07_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcurl-8.17.0-h5bd1c32_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-20.1.8-hd7fd590_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.22-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libexpat-2.7.3-h50f4ffc_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-15.2.0-hb654fa1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libglib-2.86.3-hcacd345_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgrpc-1.74.1-h941cc20_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libhwloc-2.12.1-default_h2915d5d_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libidn2-2.3.8-h9681e36_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libllvm20-20.1.8-h1701f07_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libnghttp2-1.67.1-h8189af8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.30-hf2bb037_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenjpeg-2.5.4-haa24f5a_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.50-h5c318fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libprotobuf-6.33.0-h6acce77_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libre2-11-2025.11.05-hd4f4e8d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.20-h897f8a9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libssh2-1.11.1-h3e2b118_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libthrift-0.22.0-hbe873a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.7.1-h367c460_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libunistring-1.3-h1799b2a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.6.0-h92b2d59_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.13.9-h528a072_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libzlib-1.3.1-h5f15de7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-20.1.8-he822017_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.46.0-py310hc8eb11b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-4.4.5-py310hbc89d72_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.10-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-3.0.2-py310h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.10.8-py310haa222d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.2.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.5.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-3.1.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/msgpack-python-1.1.1-py310h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-1.0.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-1.3.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.10.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.16.6-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-core-7.16.6-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-pandoc-7.16.6-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.10.4-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.5-hee39554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.7-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.4-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numba-0.63.1-py310hadc56cb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.4-py310h901140f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.4-py310hae06d03_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/orc-2.2.0-hd6530ca_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.7.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-25.0-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandoc-3.8-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandocfilters-1.5.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-1.2.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-1.13.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/parso-0.8.5-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pcre2-10.46-h1dacb4a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pexpect-4.9.0-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-12.0.0-py310he2d6fe4_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pixman-0.46.4-h09dc60e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-4.5.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.21.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.52-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-7.0.0-py310haa24f5a_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pure_eval-0.2.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyarrow-21.0.0-py310h3f644e9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pycparser-2.23-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.6.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.19.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.2.5-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py310hca03da5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.21.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-4.0.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-lmdb-1.7.5-py310h3d52de1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python_abi-3.10-3_cp310.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2025.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.6-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.3-py310h091b9d3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-24.0.1-py310h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/re2-2025.11.05-h1413154_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.3-h0b18652_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.37.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.32.5-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.28.0-py310h931abed_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.15.3-py310h132fc3c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-80.9.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/six-1.17.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/snappy-1.2.2-hc0f95ea_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/stack_data-0.6.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tbb-2022.3.0-h50665e7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tblib-3.2.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.18.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.4.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.15-hcd8a7d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/toolz-1.1.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.5.4-py310haa24f5a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.67.1-py310h7eb115d_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.14.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.15.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.15.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.6.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wcwidth-0.2.14-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.45.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2025.4.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h2c7f8f0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zict-3.0.0-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.23.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.3.1-h5f15de7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.7-h817c040_0.tar.bz2
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2023.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2023.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.0.1-py310h1c4a608_1.conda
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/html5lib-1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/importlib_metadata-8.7.0-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pip-25.3-pyhc872135_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.52-hd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2025.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2025c-he532380_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.10.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aom-3.12.1-h00a0c3c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-25.1.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-25.1.0-py310h02ab6af_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-21.0.0-hcdc3a1c_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/asttokens-3.0.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-25.4.0-py310haa95532_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-auth-0.9.0-h02ab6af_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-cal-0.9.2-h02ab6af_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.12.4-h02ab6af_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-compression-0.3.1-h02ab6af_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.5.6-h02ab6af_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-http-0.10.4-h02ab6af_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-io-0.21.4-h02ab6af_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-mqtt-0.13.3-h02ab6af_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-s3-0.8.7-h02ab6af_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-sdkutils-0.2.4-h02ab6af_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.2.7-h02ab6af_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-crt-cpp-0.34.0-h885b0b7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.11.638-hf0af688_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.14.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bleach-6.3.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py310h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotlicffi-1.2.0.0-py310h885b0b7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.34.5-h731ff69_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2025.12.2-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cairo-1.18.4-he9e932c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2026.01.04-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-2.0.0-py310h02ab6af_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/charset-normalizer-3.4.4-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.2.1-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.1.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.3.1-py310h214f63a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cramjam-2.11.0-py310h7b75cbd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cycler-0.12.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-1.1.0-py310h02ab6af_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.15.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/dav1d-1.2.1-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.8.16-py310h885b0b7_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/decorator-5.2.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.3.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/executing-2.2.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/expat-2.7.3-h885b0b7_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-2025.12.0-py310h540bb41_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fontconfig-2.15.0-hd211d86_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.61.0-py310h02ab6af_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freeglut-3.8.0-hfcef157_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.13.3-h0620614_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fribidi-1.0.16-haf45083_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2026.1.0-py310h4442805_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/graphite2-1.3.14-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/harfbuzz-10.2.0-he2f9f60_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.16.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.11-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-8.7.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2025.0.0-haa95532_1164.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.30.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.6-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9f-ha349fce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.25.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2025.9.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.9.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.12.0-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.17.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.5.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.3.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.9-py310h03f52e7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.17-h3732fa5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-4.0.0-h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libabseil-20250814.1-cxx17_hcd311fc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libavif-1.3.0-h5bd13ec_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.2.0-h907acca_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.2.0-h02c67a5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.2.0-h483e6b9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.17.0-h97e0424_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.22-h5bf469e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libexpat-2.7.3-h885b0b7_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libglib-2.86.3-h9bccc14_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libgrpc-1.74.1-hde67744_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libhwloc-2.12.1-default_hfa10c62_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libllvm20-20.1.8-h3aa9ab2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libopenjpeg-2.5.4-h02ab6af_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.50-h46444df_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-6.33.0-h2a56892_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libre2-11-2025.11.05-ha6b10e7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.20-h83e8143_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.11.1-h2addb87_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.22.0-ha2884a9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.7.1-h3a18249_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.6.0-hbf3958f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.13.9-h6201b9f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libzlib-1.3.1-h02ab6af_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.46.0-py310hd5b4e5d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.4.5-py310hb1efef3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.10-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-3.0.2-py310h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.10.8-py310h26e45b9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.2.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.5.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-3.1.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2025.0.0-h5da7b33_930.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.5.2-py310h0b37514_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-2.1.1-py310h300f80d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.3.0-py310ha5e6156_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.1.1-py310h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-1.0.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.3.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.10.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.6-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-core-7.16.6-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-pandoc-7.16.6-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.4-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.63.1-py310h54bf9d2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py310h12f7302_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py310he4e2855_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.18-h543e019_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/orc-2.2.0-h79e1e1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.7.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-25.0-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandoc-3.8-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandocfilters-1.5.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/parso-0.8.5-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pcre2-10.46-h5740b90_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-12.0.0-py310h4212202_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pixman-0.46.4-h4043f72_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-4.5.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.21.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.52-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-7.0.0-py310h02ab6af_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pure_eval-0.2.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-21.0.0-py310h42c1672_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pycparser-2.23-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.6.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.19.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.2.5-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.10.19-h981015d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py310haa95532_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.21.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-4.0.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.7.5-py310h5823743_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python_abi-3.10-3_cp310.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2025.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.6-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-311-py310h885b0b7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.15-py310h72d21ff_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.3-py310hb9a58be_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py310h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2025.11.05-hc24cdf5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.37.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.5-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.28.0-py310h114bc41_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.15.3-py310h1bbe36f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-80.9.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/six-1.17.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.2.2-hab6b7b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.51.1-hda9a48d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/stack_data-0.6.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2022.3.0-h90c84d6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-devel-2022.3.0-h90c84d6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tblib-3.2.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.18.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.4.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.15-hf199647_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-1.1.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.5.4-py310h02ab6af_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.67.1-py310h4442805_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.15.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.15.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ucrt-10.0.22621.0-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.6.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.42-haa95532_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc14_runtime-14.44.35208-h4927774_10.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.44.35208-ha6b5a95_10.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wcwidth-0.2.14-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.45.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2025.4.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.6.4-h4754444_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-h6c54ac7_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.23.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.3.1-h02ab6af_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.7-h56299aa_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/html5lib-1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/importlib_metadata-8.7.0-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pip-25.3-pyhc872135_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.52-hd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2025.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2025c-he532380_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-4.10.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aom-3.12.1-h00a0c3c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-25.1.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-25.1.0-py310h02ab6af_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/arrow-cpp-21.0.0-hcdc3a1c_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/asttokens-3.0.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-25.4.0-py310haa95532_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-auth-0.9.0-h02ab6af_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-cal-0.9.2-h02ab6af_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-common-0.12.4-h02ab6af_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-compression-0.3.1-h02ab6af_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-event-stream-0.5.6-h02ab6af_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-http-0.10.4-h02ab6af_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-io-0.21.4-h02ab6af_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-mqtt-0.13.3-h02ab6af_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-s3-0.8.7-h02ab6af_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-sdkutils-0.2.4-h02ab6af_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-checksums-0.2.7-h02ab6af_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-crt-cpp-0.34.0-h885b0b7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-sdk-cpp-1.11.638-hf0af688_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.14.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bleach-6.3.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-3.2.1-py310h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotlicffi-1.2.0.0-py310h885b0b7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/c-ares-1.34.5-h731ff69_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2025.12.2-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cairo-1.18.4-he9e932c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2026.01.04-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-2.0.0-py310h02ab6af_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/charset-normalizer-3.4.4-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/click-8.2.1-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cloudpickle-3.1.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.2.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.3.1-py310h214f63a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cramjam-2.11.0-py310h7b75cbd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cycler-0.12.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cytoolz-1.1.0-py310h02ab6af_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/datashader-0.15.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/datashape-0.5.4-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/dav1d-1.2.1-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.8.16-py310h885b0b7_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/decorator-5.2.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.3.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/executing-2.2.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/expat-2.7.3-h885b0b7_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fastparquet-2025.12.0-py310h540bb41_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fontconfig-2.15.0-hd211d86_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fonttools-4.61.0-py310h02ab6af_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freeglut-3.8.0-hfcef157_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.13.3-h0620614_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fribidi-1.0.16-haf45083_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fsspec-2026.1.0-py310h4442805_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/graphite2-1.3.14-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/harfbuzz-10.2.0-he2f9f60_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.16.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.11-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-8.7.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2025.0.0-haa95532_1164.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.29.5-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.30.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.19.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.6-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9f-ha349fce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.25.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2025.9.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.9.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.12.0-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.17.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.5.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyterlab_pygments-0.3.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.9-py310h03f52e7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lcms2-2.17-h3732fa5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-4.0.0-h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libabseil-20250814.1-cxx17_hcd311fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libavif-1.3.0-h5bd13ec_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.2.0-h907acca_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.2.0-h02c67a5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.2.0-h483e6b9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libcurl-8.17.0-h97e0424_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.22-h5bf469e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libexpat-2.7.3-h885b0b7_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libglib-2.86.3-h9bccc14_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libgrpc-1.74.1-hde67744_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libhwloc-2.12.1-default_hfa10c62_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libllvm20-20.1.8-h3aa9ab2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libopenjpeg-2.5.4-h02ab6af_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.50-h46444df_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libprotobuf-6.33.0-h2a56892_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libre2-11-2025.11.05-ha6b10e7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.20-h83e8143_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libssh2-1.11.1-h2addb87_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libthrift-0.22.0-ha2884a9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.7.1-h3a18249_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.6.0-hbf3958f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxml2-2.13.9-h6201b9f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libzlib-1.3.1-h02ab6af_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/llvmlite-0.46.0-py310hd5b4e5d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-4.4.5-py310hb1efef3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.10-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-3.0.2-py310h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.10.8-py310h26e45b9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.2.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.5.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-3.1.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2025.0.0-h5da7b33_930.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.5.2-py310h0b37514_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-2.1.1-py310h300f80d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.3.0-py310ha5e6156_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/msgpack-python-1.1.1-py310h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/multipledispatch-1.0.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-1.3.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.10.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-7.16.6-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-core-7.16.6-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-pandoc-7.16.6-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.10.4-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.7-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.4-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numba-0.63.1-py310h54bf9d2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py310h12f7302_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py310he4e2855_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.18-h543e019_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/orc-2.2.0-h79e1e1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/overrides-7.7.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-25.0-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandoc-3.8-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandocfilters-1.5.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-1.2.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-1.13.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/parso-0.8.5-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/partd-1.4.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pcre2-10.46-h5740b90_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-12.0.0-py310h4212202_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pixman-0.46.4-h4043f72_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-4.5.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.21.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.52-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-7.0.0-py310h02ab6af_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pure_eval-0.2.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyarrow-21.0.0-py310h42c1672_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pycparser-2.23-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyct-0.6.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.19.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.2.5-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.10.19-h981015d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py310haa95532_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.21.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-json-logger-4.0.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-lmdb-1.7.5-py310h5823743_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python_abi-3.10-3_cp310.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2025.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.6-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-311-py310h885b0b7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.15-py310h72d21ff_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.3-py310hb9a58be_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-24.0.1-py310h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/re2-2025.11.05-hc24cdf5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/referencing-0.37.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.32.5-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rpds-py-0.28.0-py310h114bc41_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scipy-1.15.3-py310h1bbe36f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-80.9.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/six-1.17.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/snappy-1.2.2-hab6b7b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.51.1-hda9a48d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/stack_data-0.6.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2022.3.0-h90c84d6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-devel-2022.3.0-h90c84d6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tblib-3.2.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.18.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.4.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.15-hf199647_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/toolz-1.1.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.5.4-py310h02ab6af_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.67.1-py310h4442805_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.14.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.15.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.15.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ucrt-10.0.22621.0-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-2.6.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.42-haa95532_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc14_runtime-14.44.35208-h4927774_10.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.44.35208-ha6b5a95_10.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wcwidth-0.2.14-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.45.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2025.4.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.6.4-h4754444_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-h6c54ac7_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zict-3.0.0-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.23.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.3.1-h02ab6af_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.7-h56299aa_0.tar.bz2
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -1336,7 +1336,7 @@ packages:
   license_family: BSD
   size: 10967789
   timestamp: 1683494697127
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.10.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-4.10.0-py310h06a4308_0.tar.bz2
   sha256: abbfda764359368de21c7436312c6563b30cd8d8599fe6fa342a34b4f7ba8d53
   md5: 5569e34c441e89bee95ad58b6d234723
   depends:
@@ -1352,7 +1352,7 @@ packages:
   license_family: MIT
   size: 234126
   timestamp: 1758622433186
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aom-3.6.0-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aom-3.6.0-h6a678d5_0.tar.bz2
   sha256: daddb86497522fd6fb8447c0aaebb763e685348b86fadb4ca6425f50f9d85f08
   md5: 2d31ed3210e7119160eb02564154b4c1
   depends:
@@ -1362,7 +1362,7 @@ packages:
   license_family: BSD
   size: 2958771
   timestamp: 1688660715607
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-25.1.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-25.1.0-py310h06a4308_0.tar.bz2
   sha256: 5d770fe7a7b35df064e0d9c305a2f8621a3ab8903a73aa4bcd69590123f4bfd7
   md5: 71214c4fc2f59a08d85835f35dde8915
   depends:
@@ -1374,7 +1374,7 @@ packages:
   license_family: MIT
   size: 30003
   timestamp: 1766067878915
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py310h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py310h5eee18b_1.tar.bz2
   sha256: 37044ec265a347e5046d26bea0ba8c413cf394ae982443d016f979ff83cf8aec
   md5: b25aaff8fb956ee9884149f047044529
   depends:
@@ -1385,7 +1385,7 @@ packages:
   license_family: MIT
   size: 35243
   timestamp: 1736182472515
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-19.0.0-hfcf91c8_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/arrow-cpp-19.0.0-hfcf91c8_3.tar.bz2
   sha256: eafc932db81db5d5de11955dc43e14f5d3613f68e73bde3c80d50ae1f51c8d84
   md5: 80c9fac93e83d88a798b446c90a98c97
   depends:
@@ -1417,7 +1417,7 @@ packages:
   license_family: Apache
   size: 14351200
   timestamp: 1752071210807
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/asttokens-3.0.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/asttokens-3.0.0-py310h06a4308_0.tar.bz2
   sha256: e2ad4b4fa11972e4e571c046db88fb7d43c0b28ba14ace893a8d93ab2fbf2b81
   md5: 9a3e5b47264bd6638d1e18f06cbaa0da
   depends:
@@ -1428,7 +1428,7 @@ packages:
   license_family: Apache
   size: 41338
   timestamp: 1743630548795
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-25.4.0-py310h06a4308_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-25.4.0-py310h06a4308_2.tar.bz2
   sha256: b855b5873ef5e922c5a6e186bc7dd68bdc61b9d230f922b05f366b26ff4dd29c
   md5: 29cdc9324b4e79917fd81b8be9739878
   depends:
@@ -1437,7 +1437,7 @@ packages:
   license_family: MIT
   size: 147932
   timestamp: 1762356898864
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-auth-0.8.5-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-auth-0.8.5-h5eee18b_0.tar.bz2
   sha256: 6f083d45d1b88acba5b659257d13bc7977384af01d71feb79db99c61247c9824
   md5: a1dea5958821d769433dece6f5bfc28b
   depends:
@@ -1451,7 +1451,7 @@ packages:
   license_family: Apache
   size: 113020
   timestamp: 1741636490767
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-cal-0.8.5-hdbd6064_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-cal-0.8.5-hdbd6064_0.tar.bz2
   sha256: 919165ca4af55c55692ab743fae0e0445bb2f459dfbab7049ba69b337267aa29
   md5: 74c9b5c1d74cb02b894afc30590043ca
   depends:
@@ -1462,7 +1462,7 @@ packages:
   license_family: Apache
   size: 51916
   timestamp: 1741619298908
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.11.1-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-common-0.11.1-h5eee18b_0.tar.bz2
   sha256: 299d84dc2e887b2662edeae6a7bf82e38ebe65cdacc490cdf8540a1a101a5d35
   md5: 78afbab375162eaed27c8ad96bc678e6
   depends:
@@ -1471,7 +1471,7 @@ packages:
   license_family: Apache
   size: 244092
   timestamp: 1741187507018
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-compression-0.3.1-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-compression-0.3.1-h5eee18b_0.tar.bz2
   sha256: 3b807bdd74ec5a32c025c467bf0366ce57deaff4db7e2e3971971fe45da256cc
   md5: 23ac7afb17c69ab9c2c4abe151f72e88
   depends:
@@ -1481,7 +1481,7 @@ packages:
   license_family: Apache
   size: 18015
   timestamp: 1741621679895
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.5.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-event-stream-0.5.4-h6a678d5_0.tar.bz2
   sha256: b2314842775b0e9dd99c13429b8343aca88bfcc3892d14e1f7aa1e0822ebe6f1
   md5: e964513a3b1a14b9d36ff2e05c53b67c
   depends:
@@ -1494,7 +1494,7 @@ packages:
   license_family: Apache
   size: 54364
   timestamp: 1741624425817
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-http-0.9.3-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-http-0.9.3-h5eee18b_0.tar.bz2
   sha256: 4221e2f1d1d35621451cc81cfe5a674842281b0c80efba03d84f2c7c224bc8c0
   md5: 3919b569ed7c4a3348cdecaf61c56d69
   depends:
@@ -1507,7 +1507,7 @@ packages:
   license_family: Apache
   size: 202691
   timestamp: 1741630114714
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-io-0.17.0-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-io-0.17.0-h5eee18b_0.tar.bz2
   sha256: 5406990cdecebcb3028e0a9c73e40cc8df877fdb8fd879f74bdcf5b91d132e71
   md5: c37dbb806c7ec4b99ac6ba14585c088a
   depends:
@@ -1519,7 +1519,7 @@ packages:
   license_family: Apache
   size: 162848
   timestamp: 1741623323159
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-mqtt-0.12.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-mqtt-0.12.2-h5eee18b_0.tar.bz2
   sha256: fb17eb171a9a58ae446d9a87312074d2c78237a52bcc895b422873d950873033
   md5: a27a93333136832672e53c19607290f4
   depends:
@@ -1531,7 +1531,7 @@ packages:
   license_family: Apache
   size: 203968
   timestamp: 1741633978327
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-s3-0.7.11-hdbd6064_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-s3-0.7.11-hdbd6064_0.tar.bz2
   sha256: 15257a299c2e4cc7c1744ae4afaba823a0e02af2392acbf41b93ca1202c69212
   md5: ae66d6778532b99b9e21ccf30c3ce18e
   depends:
@@ -1547,7 +1547,7 @@ packages:
   license_family: Apache
   size: 117898
   timestamp: 1741640978198
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-sdkutils-0.2.3-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-sdkutils-0.2.3-h5eee18b_0.tar.bz2
   sha256: 958313779f2e4ad5a8f839a7d9aead42e15ba491acffe33f8ed94e3af31bca96
   md5: 43f69c324d8659b074846ca048107040
   depends:
@@ -1557,7 +1557,7 @@ packages:
   license_family: Apache
   size: 57176
   timestamp: 1741618764786
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.2.3-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-checksums-0.2.3-h5eee18b_0.tar.bz2
   sha256: 4080a560f612f7a9acae06740c0090c96c6e4223108c331edd8c765c0f159d4c
   md5: 78d91ce1d325d466ab4726be2abbabe5
   depends:
@@ -1567,7 +1567,7 @@ packages:
   license_family: Apache
   size: 76665
   timestamp: 1741620766571
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-crt-cpp-0.31.0-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-crt-cpp-0.31.0-h6a678d5_0.tar.bz2
   sha256: daf6c79d76ebee86c5a55505cf6aa78017f774e574158e4e042825eb67617b7f
   md5: ef23f55e2ce9d7ff29ec7e453ae55ed7
   depends:
@@ -1587,7 +1587,7 @@ packages:
   license_family: Apache
   size: 387393
   timestamp: 1746472666358
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.11.528-h74f24ce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-sdk-cpp-1.11.528-h74f24ce_0.tar.bz2
   sha256: f4fe4b8467a9ad34bc9794c7612323e85a16dd36411d4493a0f548a791700e6b
   md5: 3c056c68455a1348d99570137925580f
   depends:
@@ -1602,7 +1602,7 @@ packages:
   license_family: Apache
   size: 3963356
   timestamp: 1746483074698
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.14.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.14.2-py310h06a4308_0.tar.bz2
   sha256: c984f63ebf2541fe0bf36123178979bef536645582461f71447969b45711b0ef
   md5: 2ec2b3e0904f2f4e04cd1e7cbb9da511
   depends:
@@ -1613,12 +1613,12 @@ packages:
   license_family: MIT
   size: 215565
   timestamp: 1764159345301
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-openblas.tar.bz2
   sha256: ed246aa0bf2809030f911cefd5b16a2c4de0d1b21f75f76e5178122d2213727e
   md5: 671f6e045d03a842f379145e7fc43c0d
   size: 49374
   timestamp: 1528224118045
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bleach-6.3.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bleach-6.3.0-py310h06a4308_0.tar.bz2
   sha256: 0d6a0f09bd196528ffd1a852906daac1c584c78817f9c2483a1a15f755c723c9
   md5: 51c22195cf90c95981c9220ba64809c8
   depends:
@@ -1631,7 +1631,7 @@ packages:
   license_family: Apache
   size: 83011
   timestamp: 1764153589371
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.2.1-py310h2f386ee_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-3.2.1-py310h2f386ee_0.tar.bz2
   sha256: a857bde1809f0d09a5d70c5f789c999477215c981a99467f830399a43d3c2ca5
   md5: 19dd80d22dc95b7935a3460b60a6ad7d
   depends:
@@ -1649,7 +1649,7 @@ packages:
   license_family: BSD
   size: 6466579
   timestamp: 1690546270826
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
   sha256: 3606c8607c29229222667f66421f79df167d33043fe9245cdd4e2c4520ecc721
   md5: eca33dcef14fa044193e43492dca8585
   depends:
@@ -1660,7 +1660,7 @@ packages:
   license_family: OTHER
   size: 10768
   timestamp: 1696762269985
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py310h6a678d5_9.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py310h6a678d5_9.tar.bz2
   sha256: 530a6e5a44a3c34e07b656e9dc56844163db466a653a33a1c04f6f97673b6675
   md5: 7ad8f8fa79e8d0ac068da2b32d1b1d53
   depends:
@@ -1670,7 +1670,7 @@ packages:
   license: MIT
   size: 361192
   timestamp: 1736182598029
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlicffi-1.0.9.2-py310h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotlicffi-1.0.9.2-py310h6a678d5_1.tar.bz2
   sha256: b619cb415b6ad50adb8646421497176d2c933eb664691db779619d1867d46cec
   md5: 99534d95312f31bd604298feeed6dcf5
   depends:
@@ -1681,7 +1681,7 @@ packages:
   license: MIT
   size: 369154
   timestamp: 1736182502505
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
   sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
   md5: f5058c8d5b2994b7334f18e022105a14
   depends:
@@ -1690,7 +1690,7 @@ packages:
   license_family: BSD
   size: 427542
   timestamp: 1714510571510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
   sha256: 5b4c80587ae4ec915505469f79d866f27c80456156667c8548d31c67c2c1653e
   md5: c3d6bfae757760082261779c406a880d
   depends:
@@ -1699,14 +1699,14 @@ packages:
   license_family: MIT
   size: 116270
   timestamp: 1693902021950
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2025.12.2-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2025.12.2-h06a4308_0.tar.bz2
   sha256: 95324964958e1ed79aed1355a2230717c8c94df9604bfd453eeaf09df2ffaebe
   md5: b28be3dd7696ca4faf4750d1c5a370aa
   license: MPL-2.0
   license_family: Other
   size: 135071
   timestamp: 1764713819705
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cairo-1.16.0-he5ede1b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cairo-1.16.0-he5ede1b_6.tar.bz2
   sha256: 7d75a8ee9b6117e9157f34d7551ba284b40aa9ad0527df743adc040c62229ff7
   md5: 568ffb2b495741473c74b28e4aa750d2
   depends:
@@ -1725,7 +1725,7 @@ packages:
   license_family: LGPL
   size: 1583916
   timestamp: 1748950812947
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2026.01.04-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2026.01.04-py310h06a4308_0.tar.bz2
   sha256: 1e995ddea8928d81e73d0611a57ea8dafc34c88adbab2d72d2f8a890cd61702c
   md5: 801b984c7eee035d935cdd9f6158c4c9
   depends:
@@ -1734,7 +1734,7 @@ packages:
   license_family: Other
   size: 154321
   timestamp: 1767659158857
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py310h1fdaa30_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.17.1-py310h1fdaa30_1.tar.bz2
   sha256: 512cf77e1ca8e532217268c856783e48e6c642742b7325ba50784aa59fe5a5e3
   md5: 280f1924ea783118998cfc20ab196d46
   depends:
@@ -1746,7 +1746,7 @@ packages:
   license_family: MIT
   size: 242947
   timestamp: 1736182601685
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/charset-normalizer-3.4.4-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/charset-normalizer-3.4.4-py310h06a4308_0.tar.bz2
   sha256: 42c9c51f5fc2d56a7408116adadc628e80d9eb776a2d969a9e46d1c9e245544b
   md5: 32d9d6cf5594605c7b4456b9ff5274e8
   depends:
@@ -1755,7 +1755,7 @@ packages:
   license_family: MIT
   size: 84312
   timestamp: 1761744890463
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.2.1-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/click-8.2.1-py310h06a4308_1.tar.bz2
   sha256: abcf61ae4bf99635771816e33de5b18b206c6481f5ed4c266dda4ce3ba447fc3
   md5: 05ef57693fdea278146d9b5601ab00fa
   depends:
@@ -1764,7 +1764,7 @@ packages:
   license_family: BSD
   size: 284210
   timestamp: 1764332308741
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.1.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cloudpickle-3.1.2-py310h06a4308_0.tar.bz2
   sha256: 296afa98ab7b46d4df62b35b99f22f269ea23a48c7a50ce7626d72258c3c1624
   md5: 3e123b2130ee1cdde1d939bd5fb69e9c
   depends:
@@ -1773,7 +1773,7 @@ packages:
   license_family: BSD
   size: 64645
   timestamp: 1764930505723
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py310h06a4308_0.tar.bz2
   sha256: 4b9150ff168d17abf2e28a14e436e10653d87082c8865f1dae6081932d572c0a
   md5: 3b3d0971e24b952e00cc35e7193eeade
   depends:
@@ -1782,7 +1782,7 @@ packages:
   license_family: CC
   size: 502279
   timestamp: 1709758414744
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.2.3-py310h06a4308_0.tar.bz2
   sha256: 917b1f2ef3f429f7d56484736eb4a83c2bcbf73a4cbb8681a9ca7dc21eb565cf
   md5: 126e41a84e468e937e6bcb87b0a14268
   depends:
@@ -1791,7 +1791,7 @@ packages:
   license_family: BSD
   size: 14935
   timestamp: 1763119209814
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.3.1-py310hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/contourpy-1.3.1-py310hdb19cb5_0.tar.bz2
   sha256: b5a23181c83817e0467d06f8e49b3ef04e2eba9b8dd7059dbd8fde0d4fca34c2
   md5: d5535fe50ad08cf5d44a0b1a9d53a34e
   depends:
@@ -1803,7 +1803,7 @@ packages:
   license_family: BSD
   size: 281389
   timestamp: 1732540260436
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cramjam-2.9.1-py310h922eef2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cramjam-2.9.1-py310h922eef2_0.tar.bz2
   sha256: c25f6ad2fc00da6906545f04e919a09420596374ed7f966c7e39a6a386f322fc
   md5: 33b125d02a6ad6160bfeec2ea704ebb1
   depends:
@@ -1813,7 +1813,7 @@ packages:
   license_family: MIT
   size: 1702343
   timestamp: 1742393518779
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cycler-0.12.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cycler-0.12.1-py310h06a4308_0.tar.bz2
   sha256: 668393e866c3006c8996b8fbfb3585e066ab8c51b2f723df750918f693394456
   md5: ed4c2057124c0fc252f250e05389a506
   depends:
@@ -1822,7 +1822,7 @@ packages:
   license_family: BSD
   size: 17250
   timestamp: 1766067933258
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-1.0.1-py310h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cytoolz-1.0.1-py310h5eee18b_0.tar.bz2
   sha256: b06d02013a56821311dfaf0714369bb9bb651cb0861e6bc09d33d77f7a2b8f00
   md5: dd26ee06b9fb1b94c781bcccce95ce93
   depends:
@@ -1833,7 +1833,7 @@ packages:
   license_family: BSD
   size: 409831
   timestamp: 1736803962478
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.15.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/datashader-0.15.1-py310h06a4308_0.tar.bz2
   sha256: ed8a95624b732e3d231e25699f194ea59ab08a6fc3be77a785e69498dcd08e6a
   md5: 7f2b0e05b7e2e4ff11c5af694b395706
   depends:
@@ -1855,7 +1855,7 @@ packages:
   license_family: BSD
   size: 17653851
   timestamp: 1689587803745
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/datashape-0.5.4-py310h06a4308_1.tar.bz2
   sha256: c33f7bed0d5df9b603477cfab6687d3390110320a5e8cc02d981fff81f4ab799
   md5: 091e596b0565d13b12bf261aaad3cde7
   depends:
@@ -1867,7 +1867,7 @@ packages:
   license_family: BSD
   size: 103863
   timestamp: 1640808953510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dav1d-1.2.1-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dav1d-1.2.1-h5eee18b_0.tar.bz2
   sha256: 9f015999d24a376602b5876f542bcb41a7db66fa73064091cccdc1b06195392c
   md5: 29684f3832212a3c977960c62c421119
   depends:
@@ -1876,7 +1876,7 @@ packages:
   license_family: BSD
   size: 889577
   timestamp: 1688746033126
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.8.11-py310h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.8.11-py310h6a678d5_0.tar.bz2
   sha256: 8f53bfc56cf73a1e33b04b0f50bc0292bf8257939448a23d97639e70a81c92bc
   md5: 90b185aa0a0d514c2dbfc60cfdf909a5
   depends:
@@ -1887,7 +1887,7 @@ packages:
   license_family: MIT
   size: 2441923
   timestamp: 1736267733673
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/decorator-5.2.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/decorator-5.2.1-py310h06a4308_0.tar.bz2
   sha256: 532b652661cdf08b37d56f96a7ece83fbecef5c39e19c882f498e1970845adf8
   md5: a9c68c15240e7e5fd8189143fa9eaed2
   depends:
@@ -1896,7 +1896,7 @@ packages:
   license_family: BSD
   size: 36087
   timestamp: 1757341248978
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py310h06a4308_0.tar.bz2
   sha256: 413921f9bdd75ddbf9667fc35d4f7b8ac6ce751ab992297635e0cad2a8a9174e
   md5: 57314b5e1702906d03bfcff4d7eab35a
   depends:
@@ -1905,7 +1905,7 @@ packages:
   license_family: MIT
   size: 16500
   timestamp: 1649908359372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.3.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.3.0-py310h06a4308_0.tar.bz2
   sha256: 546bb94ef7ecf42cbcf7633442ea81521e8bb95cd7c36ee8eee71e5026ce3e4e
   md5: 9b8f3d8f70ab3d0b4031b369b8b2463b
   depends:
@@ -1915,7 +1915,7 @@ packages:
   license_family: MIT
   size: 39742
   timestamp: 1761560363287
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/executing-2.2.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/executing-2.2.1-py310h06a4308_0.tar.bz2
   sha256: a5ce1f19e87d3c2692890f40d501dcadae9a23b8926a58f40562b72fd5dd5880
   md5: a6fa4e3262c3748c5f7508c98f00f305
   depends:
@@ -1924,7 +1924,7 @@ packages:
   license_family: MIT
   size: 806158
   timestamp: 1757061247536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.7.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/expat-2.7.1-h6a678d5_0.tar.bz2
   sha256: 7d01d98ce0be581925188a56b3d94aa48dd43889348ecca925b4e81ac24e7a3d
   md5: 9d007a4778f2aa30429cad8658da8abd
   depends:
@@ -1934,7 +1934,7 @@ packages:
   license_family: MIT
   size: 203122
   timestamp: 1744659862400
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-2024.2.0-py310ha9d4c09_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fastparquet-2024.2.0-py310ha9d4c09_0.tar.bz2
   sha256: 7457e53a052fdf545d03915c463dc20c881e146197dd58d278b88738c1206c2e
   md5: 900356335a8718301c4ba4e26843ff82
   depends:
@@ -1949,7 +1949,7 @@ packages:
   license_family: Apache
   size: 644290
   timestamp: 1715262407016
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.14.1-h55d465d_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fontconfig-2.14.1-h55d465d_3.tar.bz2
   sha256: dcb04f684a0182e8161eb607488cef61ad121b72eda8794b1072aad621663016
   md5: 7fbedeb920dc384a9873983a4abf62a7
   depends:
@@ -1963,7 +1963,7 @@ packages:
   license_family: MIT
   size: 343714
   timestamp: 1722921016734
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.55.3-py310h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fonttools-4.55.3-py310h5eee18b_0.tar.bz2
   sha256: 867d3cad6184f11ff6738eec004e943dd6e8cb91b1061483155f6abe5c666965
   md5: f16c3083fa7bcd0cf9c26f0e6daed735
   depends:
@@ -1982,7 +1982,7 @@ packages:
   license_family: MIT
   size: 2769008
   timestamp: 1737039145077
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.13.3-h4a9f257_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.13.3-h4a9f257_0.tar.bz2
   sha256: ccf7727d01e047af9588805a2cc0f2b7769993dba6cc579545af0575ee3d5bcb
   md5: 640d50632b00b45f4e5813176dfbded7
   depends:
@@ -1993,7 +1993,7 @@ packages:
   license_family: Other
   size: 966286
   timestamp: 1743636649933
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fribidi-1.0.10-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fribidi-1.0.10-h7b6447c_0.tar.bz2
   sha256: 6d2cad4f0c819ae368a2a2796592d9ce1d23bef8bedd722a6f9fe941e95434c9
   md5: 65d93572c4ff2ee0cc8241221aee7f12
   depends:
@@ -2001,7 +2001,7 @@ packages:
   license: LGPL-2.1
   size: 117929
   timestamp: 1597684734171
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2026.1.0-py310h7040dfc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fsspec-2026.1.0-py310h7040dfc_0.tar.bz2
   sha256: e66e0771ca6a5af7b955bc3868117da06ad15aaf17bc610e9d20aa842ada13dc
   md5: 581a3c864268bd13acb36e1bd6a598f6
   depends:
@@ -2015,7 +2015,7 @@ packages:
   license_family: BSD
   size: 575303
   timestamp: 1768898292059
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
   sha256: 2fc1136056f41fe92de719fb821550346704965dd12a5fa35069cdb4948d5c17
   md5: fd089b0fba2b03aafe3adb6cdaa9ac3b
   depends:
@@ -2025,7 +2025,7 @@ packages:
   license_family: BSD
   size: 203421
   timestamp: 1706888218007
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
   sha256: f1e190d4ee766add8131a2b011723c472284de2bbb5e07c8f895f30e3c591df7
   md5: 82029e0758feac811afec2a6ef9e6155
   depends:
@@ -2036,7 +2036,7 @@ packages:
   license_family: BSD
   size: 108438
   timestamp: 1706895276199
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/graphite2-1.3.14-h295c915_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/graphite2-1.3.14-h295c915_1.tar.bz2
   sha256: 5fc3a4233c2dd83c4afeaab51465e6e786427636908c77553a3ea80b32eacb79
   md5: 09fcddfe703ce76b4b2d7dd0b6d2f928
   depends:
@@ -2046,7 +2046,7 @@ packages:
   license_family: LGPL
   size: 103592
   timestamp: 1654175396761
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/harfbuzz-10.2.0-hdfddeaa_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/harfbuzz-10.2.0-hdfddeaa_1.tar.bz2
   sha256: cb5ee33152020ac39163877caf6603fb9beaea2daf6d8ab5fa669db37f71557c
   md5: d7147d8b40bbfc4559bf6c7e9faa49ac
   depends:
@@ -2061,7 +2061,7 @@ packages:
   license_family: MIT
   size: 2977363
   timestamp: 1748952001874
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.16.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.16.0-py310h06a4308_0.tar.bz2
   sha256: 2b849aebf272c7bc74d1d210f3aff93951bd3609bd7b30f19569aac362421443
   md5: 569bc69326f865320e18d5f17d63d6a3
   depends:
@@ -2078,7 +2078,7 @@ packages:
   license_family: BSD
   size: 4466109
   timestamp: 1684937185991
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
   sha256: b35b281dbf69b826c6ae04fcd7b6a2d1f098277a669a199906a1f23b4b0931a5
   md5: 2a793fe24f85aa5819fe69c450cba6f7
   depends:
@@ -2088,7 +2088,7 @@ packages:
   license_family: MIT
   size: 29021241
   timestamp: 1692293243228
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.11-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.11-py310h06a4308_0.tar.bz2
   sha256: b0ab2eb4f721714f94600dec6c3258c09ed502906aba5f76673c43fe0275a98a
   md5: e8786e6495b614015706a30a54849fba
   depends:
@@ -2097,7 +2097,7 @@ packages:
   license_family: BSD
   size: 240491
   timestamp: 1761911994219
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-8.7.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-8.7.0-py310h06a4308_0.tar.bz2
   sha256: 76eb48a2d414c225ba4b3bed57ec12a92c4e93c7e462f6118566a9cd0d53511e
   md5: 075aec0321d27194e1bd7720428bc406
   depends:
@@ -2107,7 +2107,7 @@ packages:
   license_family: APACHE
   size: 59449
   timestamp: 1763996594184
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.29.5-py310h06a4308_1.tar.bz2
   sha256: fceecbb42f1a41ffc8cfbfbf9e995265920688c86e7135e7f649312025bbfb4e
   md5: c7384d24293abcb9bc18bdffe1c97152
   depends:
@@ -2128,7 +2128,7 @@ packages:
   license_family: BSD
   size: 191545
   timestamp: 1737660922324
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.30.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.30.0-py310h06a4308_0.tar.bz2
   sha256: 9df41684b7d7506dd2702dd74f3afb9bc4bea849f901ef76f849ca114a4390cf
   md5: 08c2d0de2a139f85480469fc07a3c442
   depends:
@@ -2147,7 +2147,7 @@ packages:
   license_family: BSD
   size: 1298491
   timestamp: 1734548088973
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.19.2-py310h06a4308_0.tar.bz2
   sha256: 57744d3a15f089747399f270a139e4ef44c3c7c854b884f430cf7028f94a8926
   md5: 4b8138b4fd41dcfd2b6152c8b317484d
   depends:
@@ -2157,7 +2157,7 @@ packages:
   license_family: MIT
   size: 1045330
   timestamp: 1733987540677
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.6-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.6-py310h06a4308_0.tar.bz2
   sha256: d3d58cebab668a8eb9b1e23545793221599bc82e8515a2a4f0c70a1fcfdf2004
   md5: 25d39bd5b6059e59c24c2bb2713e7c86
   depends:
@@ -2169,7 +2169,7 @@ packages:
   license_family: BSD
   size: 281407
   timestamp: 1741710870060
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
   sha256: 8316ae3abee25edab89788ee6e9eef79c398aba192559f514674a04ee1860bca
   md5: 112209aed451545a622ab217c70f6972
   depends:
@@ -2178,7 +2178,7 @@ packages:
   license_family: Other
   size: 283506
   timestamp: 1722872662693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.25.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.25.1-py310h06a4308_0.tar.bz2
   sha256: 35de3921e7b671c943d0287267b605f1ad0a6f2040c778ee9c94caee5bb98034
   md5: afead1e8a406de4fa52b6e510a50fef2
   depends:
@@ -2191,7 +2191,7 @@ packages:
   license_family: MIT
   size: 146923
   timestamp: 1767955404239
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2025.9.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2025.9.1-py310h06a4308_0.tar.bz2
   sha256: 9904af49013c3ccbb19d1500f9e9f6798f376494abd69cef9f05e40f270966a5
   md5: 6402150ca6b96741c8dc11166ee9c917
   depends:
@@ -2201,7 +2201,7 @@ packages:
   license_family: MIT
   size: 15809
   timestamp: 1762788451804
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py310h06a4308_0.tar.bz2
   sha256: 7732f241da3062efc233c313d00bec20e04a4e1c7e9613432d2b9ff4cba37a08
   md5: d6492166b889eb2eb2e0add30516de59
   depends:
@@ -2217,7 +2217,7 @@ packages:
   license_family: BSD
   size: 195965
   timestamp: 1676329563637
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.9.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.9.1-py310h06a4308_0.tar.bz2
   sha256: 932f8aab8fb99fc4b049dd5641bfacce52c1c122ef729e76eca1015131791dae
   md5: 397f6e8ebbbe992c2bd003bea62a480d
   depends:
@@ -2228,7 +2228,7 @@ packages:
   license_family: BSD
   size: 84379
   timestamp: 1764588305605
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.12.0-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.12.0-py310h06a4308_1.tar.bz2
   sha256: 0674927db8afbf9dc4246f1ca057b2d89b50a31f92b854ae547a514a5099d262
   md5: 03b0e40d6ac76394f141da7ae99cb622
   depends:
@@ -2245,7 +2245,7 @@ packages:
   license_family: BSD
   size: 36465
   timestamp: 1765813615367
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.17.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.17.0-py310h06a4308_0.tar.bz2
   sha256: f928225d6136efbd32eda654ab4a74750c9f588066a2c89912ee153b5e9b5c75
   md5: 82250bcbafaa9995a06b489cbbda7ec3
   depends:
@@ -2272,7 +2272,7 @@ packages:
   license_family: BSD
   size: 556606
   timestamp: 1764955137960
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.5.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.5.3-py310h06a4308_0.tar.bz2
   sha256: 42239aedde736c08830b12fd96eecab71bce970cd89883e3e65e0f7fdebeaf8a
   md5: 461810503757697f89b8775e1f9389ab
   depends:
@@ -2282,7 +2282,7 @@ packages:
   license_family: BSD
   size: 24617
   timestamp: 1744706782649
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.3.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyterlab_pygments-0.3.0-py310h06a4308_0.tar.bz2
   sha256: 56537f83531273d0d7d81bd19cfda35a27c5674aa6d01d151fff3e7d581964dd
   md5: 9796920db889b6bfa350974d61c40cfa
   depends:
@@ -2294,7 +2294,7 @@ packages:
   license_family: BSD
   size: 18403
   timestamp: 1741124259057
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.8-py310h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.8-py310h6a678d5_0.tar.bz2
   sha256: 4ec4d3bcd641b0a60a8e59362251b254672edbbab0bc98888a5081bcacb8a973
   md5: 35605107ff8a64d87cb195e63e8fe9e3
   depends:
@@ -2305,7 +2305,7 @@ packages:
   license_family: BSD
   size: 78988
   timestamp: 1737039216718
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.21.3-h143b758_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/krb5-1.21.3-h143b758_0.tar.bz2
   sha256: ec1b9363745638328bb8f13b5c861f0a9d935a7aba4fdacd8eadb6b11f689d8e
   md5: 8518a044cdf2b6eabe6612b0e50dfbb2
   depends:
@@ -2317,7 +2317,7 @@ packages:
   license_family: MIT
   size: 1435864
   timestamp: 1726642725309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.16-h92b89f2_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.16-h92b89f2_1.tar.bz2
   sha256: 08fa5cfcef7255ceaefe5458cf101ef5042ec5b875332fd5bc1b4ace759d7bcd
   md5: efd070d9777836a113c921b903b8850c
   depends:
@@ -2328,7 +2328,7 @@ packages:
   license_family: MIT
   size: 271381
   timestamp: 1744358151897
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
   sha256: 069d33aebaf4db4ae410d4acb4851860a69d2c8f326fd45ab2a67b67fe276e6d
   md5: 61689da52cf1fcebda8c9fb2872f94bf
   constrains:
@@ -2336,7 +2336,7 @@ packages:
   license: GPL-3.0-only
   size: 723073
   timestamp: 1727336193185
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-4.0.0-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lerc-4.0.0-h6a678d5_0.tar.bz2
   sha256: 3b35e98ab9e27e3c6ce1a4988087410c4f10f8f2dc7b32e5fd0597ae3330a6f0
   md5: 2a9cf942ef9eac2d34261363e6fbacad
   depends:
@@ -2346,7 +2346,7 @@ packages:
   license_family: Apache
   size: 283535
   timestamp: 1734423401417
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libabseil-20250127.0-cxx17_h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libabseil-20250127.0-cxx17_h6a678d5_0.tar.bz2
   sha256: b9542c27dae38d32b31e7016966fb1475adc534859779428d3472dee97d9d61b
   md5: 9bbf1a9ff8592aefac52b7f593108bda
   depends:
@@ -2359,7 +2359,7 @@ packages:
   license_family: Apache
   size: 1372361
   timestamp: 1742310183334
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libavif-1.1.1-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libavif-1.1.1-h5eee18b_0.tar.bz2
   sha256: bae27493578d97fe898dea7efc6924b47e77a3f41663aba631750d7d9441676e
   md5: f0c3d33d8a3239ca357544f1dbd06866
   depends:
@@ -2370,7 +2370,7 @@ packages:
   license_family: BSD
   size: 139817
   timestamp: 1733819960382
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
   sha256: e2754627e8aeb98777318939e6773b9eadbdc219dd8961aca946354d9d30f481
   md5: 4ed89646229bee3e594cd2cc8f6060f9
   depends:
@@ -2385,7 +2385,7 @@ packages:
   license_family: OTHER
   size: 23778916
   timestamp: 1696762223408
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_9.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_9.tar.bz2
   sha256: f4443a37d6eb1f35aed3b36d67ee10df39dccde535f3a6761fad44c0a516843d
   md5: 69b08a79ab20702c6bd5f77cc4063267
   depends:
@@ -2393,7 +2393,7 @@ packages:
   license: MIT
   size: 67000
   timestamp: 1736182526370
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_9.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_9.tar.bz2
   sha256: 51a57fc34ce6d44b35d76562b945a55efdcd663880bb1a153c44fe176fbc5c1a
   md5: 72d59a9872154e939d5759c7eb2c5db1
   depends:
@@ -2402,7 +2402,7 @@ packages:
   license: MIT
   size: 34506
   timestamp: 1736182538544
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_9.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_9.tar.bz2
   sha256: 5a43fa99f57fe609b374888359cecef39556ebf9c5fb6fd35eb9694f054b65eb
   md5: 3c5dbc154e879dcfd5e71c8cd56202ff
   depends:
@@ -2411,7 +2411,7 @@ packages:
   license: MIT
   size: 295241
   timestamp: 1736182548938
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.14.1-h31d0fb7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libcurl-8.14.1-h31d0fb7_0.tar.bz2
   sha256: f61641d7be89c499cee3aa96d7dc1c0eacd535b37e861f2092f58453c437d24c
   md5: f75e87739ef4299f3e78fc33aa35d27f
   depends:
@@ -2428,7 +2428,7 @@ packages:
   license_family: MIT
   size: 484046
   timestamp: 1752139688862
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.22-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.22-h5eee18b_0.tar.bz2
   sha256: 99b22a8ac9907bf834b06bc1d4c046a46e0d1fe8f044e03b287ca80490ffd7b3
   md5: c75f9e8e2f44baf9a36b4d7ac80eb2bc
   depends:
@@ -2437,7 +2437,7 @@ packages:
   license_family: MIT
   size: 78335
   timestamp: 1734423317784
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
   sha256: 5bd3af246b6a93ea0912179ae66e0ad9157ca0142263010d84b65724e6db0bec
   md5: 5cb0cc0e1783419cf8fc1c65fee0f62f
   depends:
@@ -2447,7 +2447,7 @@ packages:
   license_family: BSD
   size: 195807
   timestamp: 1703006263489
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
   sha256: efdab884c85fda4461f7a393aa6d4e0e50d03cb59fb9c8a980b1307b8379ebe0
   md5: eeca774c6154c49340dd403b1928d5e9
   depends:
@@ -2456,7 +2456,7 @@ packages:
   license_family: BSD
   size: 108906
   timestamp: 1632891483341
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
   sha256: 4b2518a1aa3859031a531cd1077e8a60d5b3a0dc7c83210ef27ff9ce2c78c3e3
   md5: 49f152ee4045544c10799d32bba85c07
   depends:
@@ -2467,7 +2467,7 @@ packages:
   license_family: BSD
   size: 480247
   timestamp: 1685052130829
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
   sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
   md5: 1af9b4d62c708924417f2640ef22a68f
   depends:
@@ -2477,13 +2477,13 @@ packages:
   license_family: MIT
   size: 154016
   timestamp: 1714483282916
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-8.2.0-hdf63c60_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-8.2.0-hdf63c60_1.tar.bz2
   sha256: a8601d00368c4fe633397e5580208896f659107879ed9230bd6b30f395d69514
   md5: 01fe37923779d22d1034b2cbd1d50bdd
   license: GPL
   size: 1842939
   timestamp: 1534516119090
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libglib-2.84.2-h37c7471_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libglib-2.84.2-h37c7471_0.tar.bz2
   sha256: 50e6fdb923d4e7b90e5d7600aeccc93bf3d8865898070c6bc27a43aa1c7e249e
   md5: 86c63a3eb5728db150d6464d4d394ffd
   depends:
@@ -2499,7 +2499,7 @@ packages:
   license_family: LGPL
   size: 1791515
   timestamp: 1751358612530
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgrpc-1.71.0-h2d74bed_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgrpc-1.71.0-h2d74bed_0.tar.bz2
   sha256: 181ed071a6f98ece393a0bd3df8ad53b8afc470e57d7b12a70a806ec928158c4
   md5: cf2580c4038f8b7e8cb9d9cf18ec3f82
   depends:
@@ -2519,7 +2519,7 @@ packages:
   license_family: APACHE
   size: 9474643
   timestamp: 1742491299361
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
   sha256: ed544d8aa7e77fc42c39c276b879955e6615b517c42fecd2624033a5050832eb
   md5: 21ee76e09ab0a7315cbed14933d97773
   depends:
@@ -2528,7 +2528,7 @@ packages:
   license_family: GPL3
   size: 1436714
   timestamp: 1714483320555
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hecde1de_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libllvm14-14.0.6-hecde1de_4.tar.bz2
   sha256: c50e6a07e8004849e1cf9f0a164e36a79ac9d14a14fa7d33dc5e370315800489
   md5: 457cfe8b5e65d583e6797a1ba2b5fb4d
   depends:
@@ -2540,7 +2540,7 @@ packages:
   license_family: Apache
   size: 37206574
   timestamp: 1726769447337
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
   sha256: 6c67d781d3c074ae46b18567f230bce4a4afa209e8b914dc2cb448502774886e
   md5: c9627c386bbc8a1a1a0a2e736ea44501
   depends:
@@ -2556,7 +2556,7 @@ packages:
   license_family: MIT
   size: 722387
   timestamp: 1697018420830
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libopenblas-0.3.29-ha39b09d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libopenblas-0.3.29-ha39b09d_0.tar.bz2
   sha256: 521446ffdea7187e5d2fc61eecc554bbbf95494572e7252b57b121c78047c828
   md5: 983e8dab4c5bc280776cdfe782230cf8
   depends:
@@ -2567,7 +2567,7 @@ packages:
   license_family: BSD
   size: 11322426
   timestamp: 1746646475188
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
   sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
   md5: 1bffe1481ed4f88827248fb9001f8923
   depends:
@@ -2577,7 +2577,7 @@ packages:
   license_family: Other
   size: 362561
   timestamp: 1677841789536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-5.29.3-h3cdef7c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libprotobuf-5.29.3-h3cdef7c_1.tar.bz2
   sha256: 7089fa06a2313070b619a0df0c4036307a5ec7840c81a5b216811435982f58ef
   md5: f7ef4af3a445243ba533826ffb0587f6
   depends:
@@ -2590,7 +2590,7 @@ packages:
   license_family: BSD
   size: 3943753
   timestamp: 1750090313373
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libre2-11-2024.07.02-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libre2-11-2024.07.02-h6a678d5_0.tar.bz2
   sha256: 779d94075b22ecbad29a6d33ff03b3648561ab31de78e8f3f2c415ff5881d9fe
   md5: ed0f770ac72ae50c86a37cb55c2cbb43
   depends:
@@ -2604,7 +2604,7 @@ packages:
   license_family: BSD
   size: 337884
   timestamp: 1742313337449
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -2612,7 +2612,7 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.11.1-h251f7ec_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libssh2-1.11.1-h251f7ec_0.tar.bz2
   sha256: 2fee5719b7bcaac278f03d4e5c15f17cf5840ed563de6730b4778c0fd62b8d9f
   md5: 162db824b70ea49175750d732102ec58
   depends:
@@ -2623,7 +2623,7 @@ packages:
   license_family: BSD
   size: 301096
   timestamp: 1732891131339
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
   sha256: 974e4035c5d51cd41fa7a7f02fadc1980069c00526c1646fa18ea94e667fb137
   md5: 188de945b4279a812953011e8c4580c2
   depends:
@@ -2637,7 +2637,7 @@ packages:
   license_family: Apache
   size: 4630795
   timestamp: 1687975185557
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.7.0-hde9077f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.7.0-hde9077f_0.tar.bz2
   sha256: ff6117708d9f4f8c04c6403929f845021dabd7af9bdb83786b66438e28786cf7
   md5: b129437725e45a37328d75a0c8d248ad
   depends:
@@ -2654,7 +2654,7 @@ packages:
   license_family: Other
   size: 456857
   timestamp: 1744351956669
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
   sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
   md5: 292768ec77416ae257cfdd44ea2071c8
   depends:
@@ -2663,7 +2663,7 @@ packages:
   license_family: BSD
   size: 29197
   timestamp: 1668082729834
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
   sha256: a062fad27450b94279d1688aabd11a95eedee7814462ef6364337d55412b4a7e
   md5: e0521f84b9770830e654432364ac930e
   depends:
@@ -2674,7 +2674,7 @@ packages:
   license_family: BSD
   size: 484011
   timestamp: 1729160032020
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.17.0-h9b100fa_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxcb-1.17.0-h9b100fa_0.tar.bz2
   sha256: e11c67f57db0b5989d520aadbeb1d7704b8d2797f2c92788ca45b86ace646a22
   md5: 623e472cf0c02599f01c49879dab1bb6
   depends:
@@ -2686,7 +2686,7 @@ packages:
   license_family: MIT
   size: 416529
   timestamp: 1746022211479
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.13.8-hfdd30dd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxml2-2.13.8-hfdd30dd_0.tar.bz2
   sha256: e53b41cdc18f63d3b810a4b8d88631a51c5be3ad1dd03048dfc0345126762c7f
   md5: e4a39fa5eebd8091471dbc4a20e3d499
   depends:
@@ -2698,7 +2698,7 @@ packages:
   license_family: MIT
   size: 740082
   timestamp: 1745948067005
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.3-py310h06a4308_0.tar.bz2
   sha256: 8579906267b2f3c1a325d6b13efdaeffc15ef3365167974ce368875373f6dce9
   md5: 031d0ce2bc61822d54796a98ebf9ade0
   depends:
@@ -2708,7 +2708,7 @@ packages:
   license_family: MIT
   size: 41148
   timestamp: 1758717669501
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.43.0-py310h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.43.0-py310h6a678d5_1.tar.bz2
   sha256: bc744e675b5f07ce3cdf8675bbf276dced52030b1bb172fa35fc3422f96b8d84
   md5: 87ffe0b77940756c228b9a7f370b0161
   depends:
@@ -2720,7 +2720,7 @@ packages:
   license_family: BSD
   size: 4377042
   timestamp: 1736366919587
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py310h06a4308_0.tar.bz2
   sha256: 4210b70b38fd509ac973d347a654f2cd670b7559411ae783e07b48c071a809e2
   md5: e36d89397033bfc417932702d7519138
   depends:
@@ -2729,7 +2729,7 @@ packages:
   license_family: BSD
   size: 11131
   timestamp: 1652903185157
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py310h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-4.3.2-py310h5eee18b_1.tar.bz2
   sha256: 0b371dc20684c9bc75fe226fde6938a1a6c917960640b373e1dbced6d92c0d11
   md5: ad213ca1a2ea7a55cde34add229efa09
   depends:
@@ -2740,7 +2740,7 @@ packages:
   license_family: BSD
   size: 38171
   timestamp: 1736366811184
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
   sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
   md5: 76f089e76ec67583bb38428b51008097
   depends:
@@ -2750,7 +2750,7 @@ packages:
   license_family: BSD
   size: 164494
   timestamp: 1714510587156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.10-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.10-py310h06a4308_0.tar.bz2
   sha256: 2f4c57255ccf10cd834c359cefdd6e943eefdb4f3e4ee34221c232e3ebff0fb2
   md5: f11728db9854bc44849d41a5ce9d73ad
   depends:
@@ -2759,7 +2759,7 @@ packages:
   license_family: BSD
   size: 141406
   timestamp: 1767787329524
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py310h06a4308_1.tar.bz2
   sha256: 7e14cb93cf0c535ae8e0aef73c7c9ad9aa55813398438762c5f0b30347788111
   md5: 88cc67a13bca127dea58eac5d6edca75
   depends:
@@ -2769,7 +2769,7 @@ packages:
   license_family: MIT
   size: 106714
   timestamp: 1684279935424
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-3.0.2-py310h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-3.0.2-py310h5eee18b_0.tar.bz2
   sha256: 9d2641e958beba2e4370c8d5eb76e0dfe3a738f1c3e70ffdb3afafd817352e14
   md5: bb6d0b2c0618e23e4f196097e1492eb1
   depends:
@@ -2781,7 +2781,7 @@ packages:
   license_family: BSD
   size: 25441
   timestamp: 1738584136961
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.10.0-py310hbfdbfaf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.10.0-py310hbfdbfaf_0.tar.bz2
   sha256: 6c6040fce753be85022882830475ba80b408b268b8cfddc1094e1158358d90d7
   md5: 3abb7c3e9c10500495a4927b3d4b6cf7
   depends:
@@ -2802,7 +2802,7 @@ packages:
   license_family: PSF
   size: 8827119
   timestamp: 1736278649293
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.2.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.2.1-py310h06a4308_0.tar.bz2
   sha256: 57562aa6679456ed114fbc9039ec25eabc78d831f064536ceac57221163e7f89
   md5: 793ce9ec1c6d804bcd20acb7e327f4d8
   depends:
@@ -2812,7 +2812,7 @@ packages:
   license_family: BSD
   size: 17759
   timestamp: 1762779230516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.5.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.5.0-py310h06a4308_0.tar.bz2
   sha256: a917c4dda950197c46edbe2a71455075d6592c451b967f7bc849032c610396eb
   md5: 8d324dbe2df2ebfd361663dc31b116eb
   depends:
@@ -2822,7 +2822,7 @@ packages:
   license_family: MIT
   size: 93089
   timestamp: 1756380105501
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.2-py310h06a4308_0.tar.bz2
   sha256: f730fea9e7baf588e79ed06f00d649228fb5275ab4705fe345cfc51f7d8e6179
   md5: 9627af519c9842ca4fe0bd1762de5451
   depends:
@@ -2831,7 +2831,7 @@ packages:
   license_family: MIT
   size: 23005
   timestamp: 1758552201657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-3.1.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-3.1.2-py310h06a4308_0.tar.bz2
   sha256: 9c5a5ea9e66b5a2d3c11e610e4b53ce7581429490ae9a293e646832c39cdb37b
   md5: a6eef436694ede76ce321abac489b2cf
   depends:
@@ -2841,7 +2841,7 @@ packages:
   license_family: BSD
   size: 108757
   timestamp: 1741124034897
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.1.1-py310h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/msgpack-python-1.1.1-py310h6a678d5_0.tar.bz2
   sha256: a73c55f96869f89237787be84e8b1f8652f561664333a6e9528eae3ce1a1f35f
   md5: 758d8c2143873b95349083e7ee3f49f7
   depends:
@@ -2852,7 +2852,7 @@ packages:
   license_family: Apache
   size: 112441
   timestamp: 1750958667714
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-1.0.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/multipledispatch-1.0.0-py310h06a4308_0.tar.bz2
   sha256: 101faba8e1111502468e4387ac865fccc67b153fc941b6bf0b6eb155012f06f3
   md5: d870313c8e47e9c54882e54f49d38be0
   depends:
@@ -2861,7 +2861,7 @@ packages:
   license_family: BSD
   size: 27969
   timestamp: 1756978466262
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.3.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-1.3.3-py310h06a4308_0.tar.bz2
   sha256: 2af0cbd97c0e7fd5f3ad6f4e5cfbdebf55e63b25a68c0a91fa08b4f2269fc2ea
   md5: 855c0972438d1988b6af902f728c23e6
   depends:
@@ -2874,7 +2874,7 @@ packages:
   license_family: BSD
   size: 10073462
   timestamp: 1765189235500
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.10.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.10.2-py310h06a4308_0.tar.bz2
   sha256: 8fb758fdd598d898e7b3c4160605cef4a46d063d50da66b9bf2f24a5cfb43e0f
   md5: a68c26ac5ef72f2e8e5b86bed4f3673a
   depends:
@@ -2887,7 +2887,7 @@ packages:
   license_family: BSD
   size: 43266
   timestamp: 1741124067667
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.16.6-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.16.6-py310h06a4308_0.tar.bz2
   sha256: e14913bbb0ce70a657eb6c9a81f9fc4a7614049246a7834c8448417c96466df8
   md5: c939fc869fb7e595917582ea9be089d7
   depends:
@@ -2898,7 +2898,7 @@ packages:
   license_family: BSD
   size: 7239
   timestamp: 1741184696173
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-core-7.16.6-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-core-7.16.6-py310h06a4308_0.tar.bz2
   sha256: 0ef8e24a7c1d552375d21e717a7bd67d5852e468502a6cd9371fb83c6f1317ee
   md5: a21c10c88801e37d7c2ff9719ef7bf6f
   depends:
@@ -2925,7 +2925,7 @@ packages:
   license: BSD-3-Clause
   size: 492277
   timestamp: 1741184683803
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-pandoc-7.16.6-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-pandoc-7.16.6-py310h06a4308_0.tar.bz2
   sha256: f422ca91bf5eb612df2802a0a0c7cfcb9396c4867bb46b66ef2361652c0310db
   md5: 669e550e8415b2e36c3085eab1517bc3
   depends:
@@ -2935,7 +2935,7 @@ packages:
   license: BSD-3-Clause
   size: 7255
   timestamp: 1741184690183
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.10.4-py310h06a4308_0.tar.bz2
   sha256: 138c44f0b4b278db0e66e7ad3a9f24d0301c4ee1257e5eb944ba954eb7169a58
   md5: 850a5b1738512bdb0d43e89efed45b2e
   depends:
@@ -2948,7 +2948,7 @@ packages:
   license_family: BSD
   size: 148192
   timestamp: 1728049506559
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
   sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
   md5: 57ea097dc15f8d9f9eb90e1d919143b0
   depends:
@@ -2957,7 +2957,7 @@ packages:
   license_family: MIT
   size: 1157733
   timestamp: 1674734069410
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py310h06a4308_0.tar.bz2
   sha256: 505a9df53a9a36030f56020d63431baa3c67c31fd66712dfa06cdc5c7265ddbd
   md5: 2abf153bb3d9a67452fd20cf560ef446
   depends:
@@ -2966,7 +2966,7 @@ packages:
   license_family: BSD
   size: 13461
   timestamp: 1708532806698
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.7-py310h06a4308_0.tar.bz2
   sha256: 553f9e01eda64ec5d1aa519f13a4fd0f23862a1e992a01d3b6343168ed622326
   md5: 7730093be33fc93230d1ea8fa8b175c6
   depends:
@@ -2991,7 +2991,7 @@ packages:
   license_family: BSD
   size: 597059
   timestamp: 1717630909616
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.4-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.4-py310h06a4308_0.tar.bz2
   sha256: 7a3e8e688ecd70198bc86c87d444e917a2aca54571b29aa9fd3c885439a8c539
   md5: ba52e1a8807e22b62c2a4c801d2fac62
   depends:
@@ -3001,7 +3001,7 @@ packages:
   license_family: BSD
   size: 22717
   timestamp: 1741707885283
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py310heeff2f4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.4-py310heeff2f4_0.tar.bz2
   sha256: 15220fabe72d5ad3fabec8accf6a6d944d820cc3ff9cbc0014f5721d4897a837
   md5: b347b1595018d55d4ac5f37ec4e548fa
   depends:
@@ -3015,7 +3015,7 @@ packages:
   license_family: BSD
   size: 10239
   timestamp: 1708642234067
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py310h8a23956_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.4-py310h8a23956_0.tar.bz2
   sha256: dd9125e2414f782fe7c7e5f27fec790fd25d393c788c749ff8dcadb581904ac9
   md5: efe9461875c38b57f9319df2efab4d7c
   depends:
@@ -3030,7 +3030,7 @@ packages:
   license_family: BSD
   size: 7988052
   timestamp: 1708642218364
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-h0d4d230_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.5.2-h0d4d230_1.tar.bz2
   sha256: fffbcdfad95da7b730daab3efd9459fee691b3df1f1596946151bbb2331eb66b
   md5: 4d782ea84a81c0848c934aa547dd0015
   depends:
@@ -3042,7 +3042,7 @@ packages:
   license_family: BSD
   size: 480447
   timestamp: 1744358327748
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.17-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.17-h5eee18b_0.tar.bz2
   sha256: a45808a4cebddf649d6dfcee827e8e34251fe9eb3050315c2cd72b1c6b756446
   md5: d3a2f19f695a4526fa448d7ea6b2f83b
   depends:
@@ -3052,7 +3052,7 @@ packages:
   license_family: Apache
   size: 5511537
   timestamp: 1753176689082
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-2.1.1-hd396ef6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/orc-2.1.1-hd396ef6_0.tar.bz2
   sha256: cb3336cd7c4e203ac8569b2d099de4311f23ffcaed5fb4460007e8ff0036e2dc
   md5: e139db542a782385bbb2050e3ae5b91a
   depends:
@@ -3068,7 +3068,7 @@ packages:
   license_family: Apache
   size: 1530037
   timestamp: 1742827660382
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.7.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/overrides-7.7.0-py310h06a4308_0.tar.bz2
   sha256: 049c1bedb7989f763ba15bbbe3507e697406b8a30ead13867513e4b69b3ef502
   md5: 077d450b10ea891a505b7e0ed38d79d0
   depends:
@@ -3077,7 +3077,7 @@ packages:
   license_family: APACHE
   size: 35489
   timestamp: 1762349106829
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-25.0-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-25.0-py310h06a4308_1.tar.bz2
   sha256: f96f8b6153c0e6e7186c1feccbd8ace6c50fb929388db8baae2f785d20e6481a
   md5: 69a9e023b6fb79c25994af0e376ed740
   depends:
@@ -3086,14 +3086,14 @@ packages:
   license_family: Apache
   size: 164792
   timestamp: 1761049131159
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandoc-3.8-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandoc-3.8-h06a4308_0.tar.bz2
   sha256: eefd4f0c1b20f1ba3488c3582a7bd9d7ee40bcd6bc19dca68a57fa4ce3ff2b71
   md5: 91630b42f575821e4d6d90b0ba4e48b0
   license: GPL-2.0-or-later
   license_family: GPL
   size: 27443501
   timestamp: 1758806891999
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandocfilters-1.5.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandocfilters-1.5.1-py310h06a4308_0.tar.bz2
   sha256: 724c596e76603028fa844c568b775d8af664fa9aa316e5592f9862261a09c4f1
   md5: b5031a304a5769e031c7397eadd2e4dc
   depends:
@@ -3102,7 +3102,7 @@ packages:
   license_family: BSD
   size: 15799
   timestamp: 1756977793365
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.2.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-1.2.3-py310h06a4308_0.tar.bz2
   sha256: 5beb5f73469aecefb2d8bb8854bd880918ddd558d73c82bbf5029162fdf6ae46
   md5: 2e47ef6ab1c6a37402fd68af65717c88
   depends:
@@ -3126,7 +3126,7 @@ packages:
   license_family: BSD
   size: 17018743
   timestamp: 1695145997102
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py310h06a4308_0.tar.bz2
   sha256: 4f7b793253454afb7a0834872d2f47381172bc1d879c581a4d80c12427ee0883
   md5: ba2287f1560613eeb38bcccccff8cc0c
   depends:
@@ -3135,7 +3135,7 @@ packages:
   license_family: BSD
   size: 143006
   timestamp: 1684915415304
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/parso-0.8.5-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/parso-0.8.5-py310h06a4308_0.tar.bz2
   sha256: ca304c4120a648ce1a2e97644e4015c8cc90b8400a70455886151a280ecdd8f5
   md5: ddbc924d85a14dba9b6226bb4481d787
   depends:
@@ -3144,7 +3144,7 @@ packages:
   license_family: OTHER
   size: 179490
   timestamp: 1762781877282
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/partd-1.4.2-py310h06a4308_0.tar.bz2
   sha256: 576e6da785c41275be6e38070f7fa2034ad73846203925ac4a10fd2f38c07322
   md5: ae324fc1dc8632e8a890b233f52431da
   depends:
@@ -3158,7 +3158,7 @@ packages:
   license_family: BSD
   size: 35820
   timestamp: 1736803462306
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
   sha256: 71beb7373390a7c5e9bf8663d64e2b0a426755fe68adb26ed72b6570634f635e
   md5: cd7c1793b37ba076f8515b49dbd850bd
   depends:
@@ -3169,7 +3169,7 @@ packages:
   license_family: BSD
   size: 3346886
   timestamp: 1714657706306
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pexpect-4.9.0-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pexpect-4.9.0-py310h06a4308_1.tar.bz2
   sha256: c24d2ac71e4144240b6016641c98379d9d60fe53d7202d9bddf8664c184aa64b
   md5: 821625e73032acf825777070473a8b9e
   depends:
@@ -3179,7 +3179,7 @@ packages:
   license_family: Other
   size: 133817
   timestamp: 1762535956211
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-11.3.0-py310hb1c3d2d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-11.3.0-py310hb1c3d2d_0.tar.bz2
   sha256: 14d14287de2b08f46e2c388d58f5b692d2a12abd0ee4fc1d5bb68f4b32599459
   md5: 6d3da245f796e2119cccb32b8b0a2636
   depends:
@@ -3200,7 +3200,7 @@ packages:
   license_family: Other
   size: 881619
   timestamp: 1752524765856
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pixman-0.40.0-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pixman-0.40.0-h7f8727e_1.tar.bz2
   sha256: e0f6c86339e683ea9e3f7e4ce743df653103209aedf995b5e674c148cb349ed8
   md5: c197093127a4cca3bb3227aab1a68573
   depends:
@@ -3208,7 +3208,7 @@ packages:
   license: MIT
   size: 645031
   timestamp: 1632711422664
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-4.5.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-4.5.0-py310h06a4308_0.tar.bz2
   sha256: f81a96256840a86a79c19a26fd9d6c3c9ee40bede5817a17e2d8a51e207819d0
   md5: 57d32965daa4d9a6fbb3d97702dc7217
   depends:
@@ -3217,7 +3217,7 @@ packages:
   license_family: MIT
   size: 35482
   timestamp: 1762356506533
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.21.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.21.1-py310h06a4308_0.tar.bz2
   sha256: 36c25b20ae4eff3142ab08bff4f437f1a56c8e772ca2c2983232720667c10a35
   md5: e6659420e7897fbb1434c92b26311e99
   depends:
@@ -3226,7 +3226,7 @@ packages:
   license_family: Apache
   size: 117617
   timestamp: 1744271753344
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.52-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.52-py310h06a4308_1.tar.bz2
   sha256: 656739ef7a4f4d6b774ed1ff6e42348f7394628aa76074ef51354bdba5ff19c7
   md5: db7562bcff3eb9ad4bb6d63c362cbf3f
   depends:
@@ -3238,7 +3238,7 @@ packages:
   license_family: BSD
   size: 615354
   timestamp: 1761744865318
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py310h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py310h5eee18b_1.tar.bz2
   sha256: 6ee952fcb5f8fe9095845d7548346c6683cf006e04847725d66b79796a6fdea7
   md5: ed33372f4fa80e15f771642e975ab591
   depends:
@@ -3248,7 +3248,7 @@ packages:
   license_family: BSD
   size: 357156
   timestamp: 1736367182335
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pthread-stubs-0.3-h0ce48e5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pthread-stubs-0.3-h0ce48e5_1.tar.bz2
   sha256: a0dd2e926abb989d755d196c803b0e3aff3f375eeccb329468e96d00387db929
   md5: de7d258a4efcd8a63df73099c8e5d954
   depends:
@@ -3257,7 +3257,7 @@ packages:
   license_family: MIT
   size: 4895
   timestamp: 1505733967605
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pure_eval-0.2.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pure_eval-0.2.3-py310h06a4308_0.tar.bz2
   sha256: 640e7636abd9a68ae7f9ace85196eef239d28286f756aeff936d825f6d66a9d0
   md5: 106a82fe461b7c7e2d146d5d9e3bd836
   depends:
@@ -3266,7 +3266,7 @@ packages:
   license_family: MIT
   size: 28198
   timestamp: 1757067064968
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-19.0.0-py310h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyarrow-19.0.0-py310h6a678d5_1.tar.bz2
   sha256: 3013fa7035cca0688a4e2d60bc9c22e1ac9bc8ff6d99a95c582e9d13a608540c
   md5: f53c0dbd57f89cfe74fa7532cc20f84e
   depends:
@@ -3280,7 +3280,7 @@ packages:
   license_family: Apache
   size: 8652260
   timestamp: 1738230392588
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pycparser-2.23-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pycparser-2.23-py310h06a4308_0.tar.bz2
   sha256: 973083740eef1117d5b82661e94a6064494073277a51614551e68cd07523c2a2
   md5: fd97d3683dda9e99a18fadd19bb467e6
   depends:
@@ -3289,7 +3289,7 @@ packages:
   license_family: BSD
   size: 244550
   timestamp: 1757496058790
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.6.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyct-0.6.0-py310h06a4308_0.tar.bz2
   sha256: 995b4d4a435098865765cbe6a1f341e73beddc76d835d1f7bcc49ee7a93265e3
   md5: acc87f527a5425100608d03700f1ee26
   depends:
@@ -3301,7 +3301,7 @@ packages:
   license_family: BSD
   size: 31635
   timestamp: 1759932155736
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.19.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.19.2-py310h06a4308_0.tar.bz2
   sha256: b9b70eab364d94048aee2e43430b64050f52069b352122997509a49bbeedbdf8
   md5: 76b8bc20c235ceb479d28ec951c78125
   depends:
@@ -3310,7 +3310,7 @@ packages:
   license_family: BSD
   size: 5190762
   timestamp: 1762431426950
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.2.5-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.2.5-py310h06a4308_0.tar.bz2
   sha256: 53c4534a5f68bc2c7456d544acc5a3ba6163194adcbfe0e87b3692dee78b5a5c
   md5: 41efb0261cd638f81a6de131aa8fc001
   depends:
@@ -3319,7 +3319,7 @@ packages:
   license_family: MIT
   size: 545275
   timestamp: 1763973801641
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py310h06a4308_1.tar.bz2
   sha256: 37cbe65046cea6c06c85aa436e0eb7619de5166a2c031b2d8d8b08d2426b4b00
   md5: 34afbea8f9fbd5c624d232c45c34e39a
   depends:
@@ -3328,7 +3328,7 @@ packages:
   license_family: BSD
   size: 28669
   timestamp: 1761753024240
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.10.18-h1a3bd86_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.10.18-h1a3bd86_0.tar.bz2
   sha256: 8cc08ec7cdc5975a7c5d90fc4ced9000ad854597330afaf46907ed7901873cf3
   md5: 1c38b046f738a87bd1efc7a122f2d51d
   depends:
@@ -3351,7 +3351,7 @@ packages:
   license_family: PSF
   size: 28836167
   timestamp: 1749130011684
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py310h06a4308_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py310h06a4308_2.tar.bz2
   sha256: 3d3157145577a8a683deaa078c1d1221b8e1a35bdb36c530d55ec2a6471a16e4
   md5: 254b3b65bd03143d723337c95b02d206
   depends:
@@ -3361,7 +3361,7 @@ packages:
   license_family: BSD
   size: 289681
   timestamp: 1716495830895
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.21.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.21.2-py310h06a4308_0.tar.bz2
   sha256: 84d5b35fd6c2939f2b702981e6affd96e0894d8c4b41b64c3a788bed75522cc5
   md5: 60d999a748eb949bfcdf8f9ea9981dbb
   depends:
@@ -3370,7 +3370,7 @@ packages:
   license_family: BSD
   size: 273276
   timestamp: 1763718600177
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-4.0.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-json-logger-4.0.0-py310h06a4308_0.tar.bz2
   sha256: b447d9c4e3420eb8206c7746c3aca0c3586a3ea874a7755c7d7325e5d52f4be8
   md5: a89c5c5aaea6e0e25c6572a1a8a8402c
   depends:
@@ -3379,7 +3379,7 @@ packages:
   license_family: BSD
   size: 30486
   timestamp: 1764590188555
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.6.2-py310h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-lmdb-1.6.2-py310h6a678d5_0.tar.bz2
   sha256: 8688a12652a9c794bb5f64e5af1e5ae4297a1568df092d67a5631663623ab6f1
   md5: 945d1ed2f55055c3306d74b10dd6ae20
   depends:
@@ -3390,7 +3390,7 @@ packages:
   license_family: Other
   size: 139192
   timestamp: 1736540636116
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python_abi-3.10-3_cp310.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python_abi-3.10-3_cp310.tar.bz2
   sha256: dc1317a68e33ed38e8899ff464e7f81fba8095784e642648b4b41c20f16fbcc1
   md5: 30c6ee2a53db622eabc8c62f6ae1ff9b
   constrains:
@@ -3399,7 +3399,7 @@ packages:
   license_family: BSD
   size: 4943
   timestamp: 1764349600680
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2025.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2025.2-py310h06a4308_0.tar.bz2
   sha256: 541af7ae28e66b99c0d2b86832f117b2c5de289e4b37e59e8d9bc45dbfa249a6
   md5: d223b25b67304c5340e4207e2c0a162a
   depends:
@@ -3408,7 +3408,7 @@ packages:
   license_family: MIT
   size: 278205
   timestamp: 1752135989523
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.6-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.6-py310h06a4308_0.tar.bz2
   sha256: 25fa44670f5e4f6f5ecc32be154823fdd48d964b668438cdaa61116ee9499e0f
   md5: 5136b3a1fd9d89defe13acb06f2ec546
   depends:
@@ -3421,7 +3421,7 @@ packages:
   license_family: BSD
   size: 61752
   timestamp: 1758102142873
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py310h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.2-py310h5eee18b_0.tar.bz2
   sha256: 907a3739b1ba6b35da0b945801c76be949eb223e31edd08068a2c722df4feeb7
   md5: 643fc9d0796daee0cf623fa174b2e1fd
   depends:
@@ -3432,7 +3432,7 @@ packages:
   license_family: MIT
   size: 191566
   timestamp: 1728658021098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py310h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-24.0.1-py310h5eee18b_0.tar.bz2
   sha256: fe70739caee72cbd02f03ad9c3b3682e78f075ce566c9d0120cf16a6d63b5c98
   md5: c3e4d19c84b33fddc558e3c91492a9ab
   depends:
@@ -3443,7 +3443,7 @@ packages:
   license_family: Other
   size: 534100
   timestamp: 1709318359822
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2024.07.02-hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/re2-2024.07.02-hdb19cb5_0.tar.bz2
   sha256: b8d8aaffc0ffc491fd5425d04b32c26d60158e839e246feb8b5be22b6bb293c9
   md5: 9893756bb114209b1884424b5b6db7b5
   depends:
@@ -3452,7 +3452,7 @@ packages:
   license_family: BSD
   size: 24699
   timestamp: 1742313347696
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
   sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
   md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
   depends:
@@ -3462,7 +3462,7 @@ packages:
   license_family: GPL
   size: 467661
   timestamp: 1666648052561
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.37.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/referencing-0.37.0-py310h06a4308_0.tar.bz2
   sha256: 23b92ab948a88a26f340f85729081575e4945ba5caa34abcff0c91d73beb9918
   md5: 76ca0b8ef7c7e6c6270948ec50cdb88f
   depends:
@@ -3474,7 +3474,7 @@ packages:
   license_family: MIT
   size: 63483
   timestamp: 1762536906415
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.5-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.32.5-py310h06a4308_1.tar.bz2
   sha256: 504443a25051307d9682959789029c2befd1438e7a23840e906db52e9a560288
   md5: 4be0dd3804b1fe0895bc6a656128a5aa
   depends:
@@ -3490,7 +3490,7 @@ packages:
   license_family: Apache
   size: 143964
   timestamp: 1762359604800
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py310h06a4308_0.tar.bz2
   sha256: 0c8e89e2795a59c995078e0433ea4baaba3e24cc5f9890bf714d8c6aacdff786
   md5: 836d6322df28a02fddfc5ba4cfc19db6
   depends:
@@ -3500,7 +3500,7 @@ packages:
   license_family: MIT
   size: 8984
   timestamp: 1683077147812
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py310h06a4308_0.tar.bz2
   sha256: 2f18f6e75730725b37333f8ddd744e299144ddb3313a318cb083581e85568ed3
   md5: 67222dc42d8db7e4023f3b5243871532
   depends:
@@ -3509,7 +3509,7 @@ packages:
   license_family: MIT
   size: 9327
   timestamp: 1683059043499
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.22.3-py310h4aa5aa6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.22.3-py310h4aa5aa6_0.tar.bz2
   sha256: d4ed1403b205788cb12f03edec7818506fd555db77ab12fecd447dd29f474bbd
   md5: 306f8c2e6a16dfd440e1372d120fca58
   depends:
@@ -3519,7 +3519,7 @@ packages:
   license_family: MIT
   size: 388111
   timestamp: 1736541328751
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/s2n-1.5.14-hdbd6064_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/s2n-1.5.14-hdbd6064_0.tar.bz2
   sha256: f49f0b9a59838483116f60aac4642e301ce1ff59a63145f6ebfe4a3a51c2a067
   md5: ef157cf0f02dfba163b2878eb8daa182
   depends:
@@ -3529,7 +3529,7 @@ packages:
   license_family: Apache
   size: 372712
   timestamp: 1741622141600
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.15.3-py310h5e4e545_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/scipy-1.15.3-py310h5e4e545_0.tar.bz2
   sha256: fed140f051a337081770f80a5d5b5cc91f0911ec230e97886a4d841c5d70c884
   md5: 4d0afd4919d1afe5f0f48dbab754c072
   depends:
@@ -3546,7 +3546,7 @@ packages:
   license_family: BSD
   size: 26104014
   timestamp: 1747239553434
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.3-py310h06a4308_0.tar.bz2
   sha256: d155355a04b8cb0967b2e8a9041bcd575e5340ae2f014ab8ad5235473251c83b
   md5: 14f8813e7d8441e8d41dd805db3dbdd6
   depends:
@@ -3555,7 +3555,7 @@ packages:
   license_family: BSD
   size: 30152
   timestamp: 1768170649755
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-80.9.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-80.9.0-py310h06a4308_0.tar.bz2
   sha256: 7ac28150ace62743852ad9bfb25a25e1276ae63798bdca27d1d83cd7c6e4c5e9
   md5: 7377ec30de44bfcf4682e0e806aee013
   depends:
@@ -3564,7 +3564,7 @@ packages:
   license_family: MIT
   size: 1848732
   timestamp: 1759863212286
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/six-1.17.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/six-1.17.0-py310h06a4308_0.tar.bz2
   sha256: 9ddc3ec5ce426525733aa70ffe49fb63b11980c59d741e7b9dfaf94b58c71e95
   md5: 12488977cb73aa6fe24a576a54e98bd1
   depends:
@@ -3573,7 +3573,7 @@ packages:
   license_family: MIT
   size: 31545
   timestamp: 1744271571309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
   sha256: 8fd98235b37194986a5eb663c95a4a6db8c9e20a627f5c79ff8d9be3fd0e36f7
   md5: 25ac00d957eda056675f8fa3eafdf6df
   depends:
@@ -3583,7 +3583,7 @@ packages:
   license_family: BSD
   size: 52749
   timestamp: 1723557449203
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.1-py310h06a4308_0.tar.bz2
   sha256: 594e7b45877bff0d2343c90649cfe1d060d22851091e7d486bc47ccbc8bd0d18
   md5: 9a404492cf95ffa5ad337775219fa3d9
   depends:
@@ -3592,7 +3592,7 @@ packages:
   license_family: Other
   size: 16931
   timestamp: 1764329165829
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py310h06a4308_0.tar.bz2
   sha256: 7b2292b384f32587828c2c7a1a099bead9d2071a8969af87349f00fe9fcd98b2
   md5: 5106026a40ffd8c8ea10c146563947cf
   depends:
@@ -3601,7 +3601,7 @@ packages:
   license_family: MIT
   size: 66920
   timestamp: 1696347609464
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
   sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
   md5: f86119b3243fe3508160aa0406245738
   depends:
@@ -3614,7 +3614,7 @@ packages:
   license_family: Other
   size: 1723866
   timestamp: 1714488309729
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/stack_data-0.6.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/stack_data-0.6.3-py310h06a4308_0.tar.bz2
   sha256: 78cd002bf56b46ca14eb1e2e038a072013ea81512ce2b31820eae6dd7f45d7c9
   md5: a9d265498183197842b70b3582314640
   depends:
@@ -3626,7 +3626,7 @@ packages:
   license_family: MIT
   size: 53575
   timestamp: 1757067053400
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tblib-3.2.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tblib-3.2.2-py310h06a4308_0.tar.bz2
   sha256: 4cde79d20dafd77c8e4bcf510ee1a49f5088562af5f9b2c9817759e4ce129eae
   md5: f4091946ff83c622b11c950eb47cabcb
   depends:
@@ -3635,7 +3635,7 @@ packages:
   license_family: BSD
   size: 25786
   timestamp: 1768309874671
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.18.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.18.1-py310h06a4308_0.tar.bz2
   sha256: 0d09faeec0f862aaf5321ce81efb636a9601cc6968fc667b17393585b8ebf6aa
   md5: 3057a59616b72de74cfa0f14c9fc3e5e
   depends:
@@ -3649,7 +3649,7 @@ packages:
   license_family: BSD
   size: 27439
   timestamp: 1757934882111
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.4.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.4.0-py310h06a4308_0.tar.bz2
   sha256: c5c71eefdfdc43ab7040af2c99d5154c72d359af0bad183cb15263442a993b2b
   md5: dddfe7cad08f37f0903d3741a6632f3c
   depends:
@@ -3659,7 +3659,7 @@ packages:
   license_family: BSD
   size: 92385
   timestamp: 1738337698289
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h993c535_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h993c535_1.tar.bz2
   sha256: c3d62dd8113a34606c374d4a4d640fadf7a92bdff68054ee9570905bf78fefa5
   md5: 872a777615d59aab42033137a6f65fd4
   depends:
@@ -3670,7 +3670,7 @@ packages:
   license_family: BSD
   size: 3573019
   timestamp: 1748849507196
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-1.1.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/toolz-1.1.0-py310h06a4308_0.tar.bz2
   sha256: b82f518356d65ce9c8cff0d84b853d949264d213755b5b3bcd2d2579152f0675
   md5: e18d26fd244639337d83b079060d213b
   depends:
@@ -3679,7 +3679,7 @@ packages:
   license_family: BSD
   size: 108237
   timestamp: 1764677628892
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.5.1-py310h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.5.1-py310h5eee18b_0.tar.bz2
   sha256: 7e0d6bcb396d8ce35a2bd20fc8c64ee8ceb2f931570cf7b85d45672b1a8e2628
   md5: 53c6456d5a29c6aad071347a887e7ef5
   depends:
@@ -3689,7 +3689,7 @@ packages:
   license_family: Apache
   size: 712546
   timestamp: 1748956958838
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.67.1-py310h7040dfc_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.67.1-py310h7040dfc_1.tar.bz2
   sha256: ac0182b0cc4cee40b9d4f3a9e259f151a89932763b8cf49262dacf50f7ee9c03
   md5: 7231f8bc5f13f14f5f627d43708e3017
   depends:
@@ -3700,7 +3700,7 @@ packages:
   license_family: MOZILLA
   size: 127660
   timestamp: 1762863371102
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.14.3-py310h06a4308_0.tar.bz2
   sha256: d03a4c457adcaaab213fa99b1aaa060afddb5a99214fc8a30b271639d2f5c2ca
   md5: 7c2b898dfd6dd4d772a82291e59f9c00
   depends:
@@ -3709,7 +3709,7 @@ packages:
   license_family: BSD
   size: 167463
   timestamp: 1718227133814
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.15.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.15.0-py310h06a4308_0.tar.bz2
   sha256: 846cacccda4d45b2c725f7e190f80e301409ee82145716e542adee3bababf7b3
   md5: 2919a6811736c652c52717d14aa5299a
   depends:
@@ -3719,7 +3719,7 @@ packages:
   license_family: PSF
   size: 10999
   timestamp: 1756280988392
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.15.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.15.0-py310h06a4308_0.tar.bz2
   sha256: 3d2e3a1115f8a40c93d3a609c6183069305a106eaad55bc4c1c99a8350e22b1d
   md5: aaf6c712d1f488f54e42220f3d1bb315
   depends:
@@ -3728,7 +3728,7 @@ packages:
   license_family: PSF
   size: 77743
   timestamp: 1756280982899
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.3-py310h06a4308_0.tar.bz2
   sha256: fd834e2f0759ec72a6df4d8f8a6f4cec68d97963bdb6183a5a510e6ac222607e
   md5: b6bd7a2ea87f54e9e3858c28a3003041
   depends:
@@ -3737,7 +3737,7 @@ packages:
   license_family: MIT
   size: 11695
   timestamp: 1758552128770
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py310h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py310h5eee18b_1.tar.bz2
   sha256: 21724674f6af0574571211913d864c47c9af5442df7ada85c0526c154f5e2b52
   md5: d855fdf91e57b0e7af2630e764b3282a
   depends:
@@ -3747,7 +3747,7 @@ packages:
   license_family: Apache
   size: 512342
   timestamp: 1736541114890
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.5.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-2.5.0-py310h06a4308_0.tar.bz2
   sha256: 29701c47495d1ba5022d138da23a9e4639fc1457801be8fa0300b48e8c5e0a2f
   md5: 5293384adb65015438cb5f3e42aed5de
   depends:
@@ -3761,7 +3761,7 @@ packages:
   license_family: MIT
   size: 306375
   timestamp: 1750775691038
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
   sha256: a8d11b0f08217607b99ba560edf66423ca1e36f4ffbb6e2377e61670e2b5f36b
   md5: 431e82b081b08aef0259df0437e04c75
   depends:
@@ -3770,7 +3770,7 @@ packages:
   license_family: MIT
   size: 97535
   timestamp: 1706894675990
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wcwidth-0.2.14-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wcwidth-0.2.14-py310h06a4308_0.tar.bz2
   sha256: 048fd0dc987a9ea3ff2332dee5abbec23b77cc1dd0e13cc1cb6c30f3f0ff703e
   md5: 078f9462450c876689a465affd87f2a4
   depends:
@@ -3779,7 +3779,7 @@ packages:
   license_family: MIT
   size: 77223
   timestamp: 1767779175249
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py310h06a4308_1.tar.bz2
   sha256: a375f3ad671266b27503b33f62ceaa7be112c0e47836e38a6c6a76225aff927d
   md5: 49b82f30a2a45b2ce167a876cdc9e21c
   depends:
@@ -3788,7 +3788,7 @@ packages:
   license_family: BSD
   size: 21391
   timestamp: 1640795864430
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py310h06a4308_0.tar.bz2
   sha256: c1e745d9d00966bfb077d1356a1fe848cc4ea12309f8904d1f33bc0f6ec5dddc
   md5: 4df68f6567bcf5ef5cd6dc6449e653bf
   depends:
@@ -3797,7 +3797,7 @@ packages:
   license_family: Apache
   size: 86991
   timestamp: 1715878322248
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.45.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.45.1-py310h06a4308_0.tar.bz2
   sha256: e1be60576340af91684bbdb81cdddf6b24e956959725b2b733bf03dec42ec357
   md5: 84c86eb7e16be1a72fa1fa74e96ab9f6
   depends:
@@ -3806,7 +3806,7 @@ packages:
   license_family: MIT
   size: 110631
   timestamp: 1737990293068
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py310h06a4308_0.tar.bz2
   sha256: 99aeddd48fdb5599e4a4a61bb7b763ca6d5956c4d04aed8aac383843b966a087
   md5: 23e2468c2df96e0a149dcdf731a879af
   depends:
@@ -3818,7 +3818,7 @@ packages:
   license_family: Apache
   size: 1804197
   timestamp: 1689041511624
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libx11-1.8.12-h9b100fa_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xorg-libx11-1.8.12-h9b100fa_1.tar.bz2
   sha256: 86bf3c43d0d024f752537c4aa4b0851a06194dafd02a77410a0b3b553e686e80
   md5: f0b98becde0651fe764283bce9423e87
   depends:
@@ -3830,7 +3830,7 @@ packages:
   license_family: MIT
   size: 943936
   timestamp: 1746110020649
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxau-1.0.12-h9b100fa_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xorg-libxau-1.0.12-h9b100fa_0.tar.bz2
   sha256: a15b598100bd3f09786fd4af7c56f8a3362800409c295f0a6445796ce2d6996e
   md5: 962cde7b3951cf7244e2ed2d059900a6
   depends:
@@ -3839,7 +3839,7 @@ packages:
   license_family: MIT
   size: 13895
   timestamp: 1745958707989
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxdmcp-1.1.5-h9b100fa_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xorg-libxdmcp-1.1.5-h9b100fa_0.tar.bz2
   sha256: e7cf0b26943b81f01ab679c4c6aea62a16ac4c78097cb739c2e504039ced08f8
   md5: 06a53975cfb6a6c46f7c60a0860a546c
   depends:
@@ -3848,7 +3848,7 @@ packages:
   license_family: MIT
   size: 20172
   timestamp: 1745992279492
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxext-1.3.6-h9b100fa_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xorg-libxext-1.3.6-h9b100fa_0.tar.bz2
   sha256: 9785e9166d299958b2ae78a813a6e8277a92797755ccd6c73e565e3be76aa9fd
   md5: 8187c859d4a6d3c4e6c555b1ea5e6c7e
   depends:
@@ -3859,7 +3859,7 @@ packages:
   license_family: MIT
   size: 52828
   timestamp: 1746169291297
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-libxrender-0.9.12-h9b100fa_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xorg-libxrender-0.9.12-h9b100fa_0.tar.bz2
   sha256: 937aa384aaeb1c1ffce4d3bec21e3eec48f36a3c6c961af39ca3fd69a69c9feb
   md5: a948f60eeaa06c1dea46f17d26a3636a
   depends:
@@ -3870,7 +3870,7 @@ packages:
   license_family: MIT
   size: 33513
   timestamp: 1746172581202
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xorg-xorgproto-2024.1-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xorg-xorgproto-2024.1-h5eee18b_1.tar.bz2
   sha256: 910e8c8adf8340730f4ed603ce6b8c05390b4befc982302255b221c5a5393812
   md5: 47fbf3dec64342c6034a77c9b5a02155
   depends:
@@ -3909,7 +3909,7 @@ packages:
   license_family: MIT
   size: 573057
   timestamp: 1746046234466
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2025.4.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xyzservices-2025.4.0-py310h06a4308_0.tar.bz2
   sha256: 81136cf442d1cd71bb1a27da7789f369754b414902c7e5b4a8bec4e9b81f8a34
   md5: e2838f91fc2999cab129048f4d8d53c9
   depends:
@@ -3918,7 +3918,7 @@ packages:
   license_family: BSD
   size: 81845
   timestamp: 1758720217429
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.6.4-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.6.4-h5eee18b_1.tar.bz2
   sha256: bcebbfa8a53efd5eaa77a0cd7f120b2e3a397e67aa78ebe907f1b35ae7148b0f
   md5: c924da317917a16d9d8551701b53ef7b
   depends:
@@ -3927,7 +3927,7 @@ packages:
   license_family: GPL2
   size: 580712
   timestamp: 1739468299256
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -3935,7 +3935,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
   sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
   md5: 943f1247a22b6b64171363bcee1eec27
   depends:
@@ -3946,7 +3946,7 @@ packages:
   license_family: Other
   size: 371663
   timestamp: 1705602144682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zict-3.0.0-py310h06a4308_1.tar.bz2
   sha256: 6d38f6679fbdcfd87fce10bba821fad89516ccd0778456e76aa3e364d5b65ea4
   md5: 3f6176bb618980bd5271c3c3eef26cf3
   depends:
@@ -3957,7 +3957,7 @@ packages:
   license_family: BSD
   size: 77721
   timestamp: 1764604338489
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.23.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.23.0-py310h06a4308_0.tar.bz2
   sha256: c61f6f94b2aeacf30415825d3cc0c285d4ea2253258bad80d0734329745e52bc
   md5: fdc9904076d90cb015cb4c37234b6725
   depends:
@@ -3966,7 +3966,7 @@ packages:
   license_family: MIT
   size: 26749
   timestamp: 1763977879371
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
   sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
   md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
   depends:
@@ -3975,7 +3975,7 @@ packages:
   license_family: Other
   size: 127143
   timestamp: 1714510716441
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
   sha256: a65c6277a3045e4ea72f617f977134c18366d8142ce51512f5a3cf325226a8bf
   md5: d941bb6fdc55cc1b3f67b3beb23d1795
   depends:
@@ -3988,7 +3988,7 @@ packages:
   license_family: BSD
   size: 1081416
   timestamp: 1728487031624
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -4001,7 +4001,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
   sha256: c0dd89ffac001588171152a285ddbbaea209ebe4116010f985f898b7e87c2f35
   md5: 731ae7d446633bc729f3493a52d4365b
   depends:
@@ -4010,7 +4010,7 @@ packages:
   license_family: MIT
   size: 43502
   timestamp: 1721748373551
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -4019,7 +4019,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -4028,7 +4028,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -4037,7 +4037,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -4046,7 +4046,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
   sha256: 9de8666e5b70aa2437737128eaa14ffe80a7b5235c2a6b7d3f39ccefd7816ba0
   md5: bb52e50c5ab1a5c7778c11376404dfdb
   depends:
@@ -4054,7 +4054,7 @@ packages:
   license: BSD 3-Clause
   size: 7933
   timestamp: 1630598543551
-- conda: https://repo.anaconda.com/pkgs/main/noarch/html5lib-1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/html5lib-1.1-pyhd3eb1b0_0.tar.bz2
   sha256: f6fb005d06bca169e166cef5c4e35bb5e8a0812b3286b06f2e34e4538b74d9b0
   md5: 7a9fa936878258757f23ffe4b2e8ecf7
   depends:
@@ -4065,7 +4065,7 @@ packages:
   license_family: MIT
   size: 91697
   timestamp: 1629144473059
-- conda: https://repo.anaconda.com/pkgs/main/noarch/importlib_metadata-8.7.0-hd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/importlib_metadata-8.7.0-hd3eb1b0_0.tar.bz2
   sha256: 1c6b30f2d0308616efe57c4ad8df197a9aab57506072c910441c05841812cc47
   md5: bd7e9d3594c372b54e55cd5927a8c7da
   depends:
@@ -4074,7 +4074,7 @@ packages:
   license_family: APACHE
   size: 7828
   timestamp: 1763996596589
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -4082,7 +4082,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -4091,7 +4091,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pip-25.3-pyhc872135_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pip-25.3-pyhc872135_0.tar.bz2
   sha256: f42662741eec5e80875cae0cc6aa675d6ef837ff362fe78da3fe4d2051d97fd2
   md5: aba2c25dd1abef550bbd9079388094b9
   depends:
@@ -4102,7 +4102,7 @@ packages:
   license_family: MIT
   size: 1491662
   timestamp: 1763132238756
-- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.52-hd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.52-hd3eb1b0_1.tar.bz2
   sha256: 427c8439a70b1dc4dc9b2160c4f7a601e92d227c6aea89fa5334462b3620e44b
   md5: ed7fc2b35f998892eaa2368c2896813e
   depends:
@@ -4111,7 +4111,7 @@ packages:
   license_family: BSD
   size: 4757
   timestamp: 1761744877741
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_3.tar.bz2
   sha256: 669d6fb95d8d66db7c702b6eabe0de44dd3cb8aa498555d8856e68a88c67102f
   md5: 411f14f0ca954f26efb6e8c5590fee04
   depends:
@@ -4119,7 +4119,7 @@ packages:
   license: ISC
   size: 17217
   timestamp: 1762424191887
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -4128,7 +4128,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -4137,7 +4137,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2025.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2025.3-pyhd3eb1b0_0.tar.bz2
   sha256: e5898ccadcef4df826521cd517c180c4e07247e194724e9b8910f8210b6d69fd
   md5: 3dcbd823b57fd1f8fb60322b2012336c
   depends:
@@ -4146,7 +4146,7 @@ packages:
   license_family: Apache
   size: 160508
   timestamp: 1768296658143
-- conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
   sha256: 4e47f6c49ce84509f1466e8a4d728447bf4bcd9bce7b456431a789a262547067
   md5: 4cad993b0f80bc23fb66a97592299cbb
   depends:
@@ -4155,7 +4155,7 @@ packages:
   license_family: Apache
   size: 26504
   timestamp: 1623949147884
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -4167,14 +4167,14 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2025c-he532380_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2025c-he532380_0.tar.bz2
   sha256: 5a174cb8bb7ea91fd49070811f2dac162292471769b64d6f44e4c6f372945b89
   md5: ac2e43b8492bdb5ddb1a0042b8ef6fdf
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 128611
   timestamp: 1768849111957
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.7.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-4.7.0-py310hecd8cb5_0.tar.bz2
   sha256: 04ce736b59bd9e213c3fb4151b6e0f6d59840e394025bdb92cac7661373769e0
   md5: 65577b53b70cfe96b57f723f5146d901
   depends:
@@ -4190,7 +4190,7 @@ packages:
   license_family: MIT
   size: 199531
   timestamp: 1745334699780
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aom-3.6.0-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aom-3.6.0-hcec6c5f_0.tar.bz2
   sha256: e9e15fb1d52051c9dbb25b1f2e613eb60cf8dbe0793062c3a274e61e6a0871dc
   md5: cb548680c2222c567784653166056c1a
   depends:
@@ -4199,7 +4199,7 @@ packages:
   license_family: BSD
   size: 3463290
   timestamp: 1688660834942
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.4-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.4-py310hecd8cb5_0.tar.bz2
   sha256: 4f4df763f8911bb82588996a87899a5079cbe2ecb7589badf46cf8605a9b7134
   md5: 56da8541dc2d9346a165e6d6c4aa5404
   depends:
@@ -4208,7 +4208,7 @@ packages:
   license_family: BSD
   size: 14092
   timestamp: 1750775028274
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py310h46256e1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py310h46256e1_1.tar.bz2
   sha256: a4a9081afc64da95a83a1e3ec7ae20bd170abd225e047b9764799c250b6fb51b
   md5: 50137bc57835df12d7e45b783ab4a651
   depends:
@@ -4218,7 +4218,7 @@ packages:
   license_family: MIT
   size: 34065
   timestamp: 1736182752094
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-19.0.0-hb704434_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/arrow-cpp-19.0.0-hb704434_4.tar.bz2
   sha256: 72fbbd0d97eb15c51048c952305f662e2dcab57770a84df2a64e4b287a47d25d
   md5: 3d6188260627f639a6beffac0f1ddc77
   depends:
@@ -4248,7 +4248,7 @@ packages:
   license_family: Apache
   size: 11008261
   timestamp: 1753354974558
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/asttokens-3.0.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/asttokens-3.0.0-py310hecd8cb5_0.tar.bz2
   sha256: 58b71899725c64bc1babdd5a62ec62d691eb1f198644107dee1900770d724f34
   md5: 7df30edcf90249ed538669c399ff4ea7
   depends:
@@ -4259,7 +4259,7 @@ packages:
   license_family: Apache
   size: 42610
   timestamp: 1743630570941
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.3.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-24.3.0-py310hecd8cb5_0.tar.bz2
   sha256: edb893561ab56dda0e91311a7aa1c83fc74cb00d24d24688d9dfe392acc8edb6
   md5: f69cc0458896627608598d4581279439
   depends:
@@ -4268,7 +4268,7 @@ packages:
   license_family: MIT
   size: 143058
   timestamp: 1734533234106
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-auth-0.9.0-h46256e1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-auth-0.9.0-h46256e1_1.tar.bz2
   sha256: 96026e45c0323175d9b64f5d920f12b378084f073a976a085aecdb99444d96a0
   md5: 615a32002bcc08afbc447936cc05248c
   depends:
@@ -4281,7 +4281,7 @@ packages:
   license_family: Apache
   size: 104429
   timestamp: 1751616022363
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-cal-0.9.2-h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-cal-0.9.2-h46256e1_0.tar.bz2
   sha256: a9cec0d1b0203ef753a6f50c8906def16a8aed1650fec9afb474b92e197002bb
   md5: 723c26e0e063602466ac83626194d0b3
   depends:
@@ -4290,14 +4290,14 @@ packages:
   license_family: Apache
   size: 45237
   timestamp: 1751013576163
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.12.3-h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-common-0.12.3-h46256e1_0.tar.bz2
   sha256: f40292bb94de0f4162f1dbffc8761a695ad7c6d1f706c7fe09171dbdfb397e61
   md5: 70a05786dd6a8039a307033ee1c3b607
   license: Apache-2.0
   license_family: Apache
   size: 239922
   timestamp: 1750946944096
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-compression-0.3.1-h46256e1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-compression-0.3.1-h46256e1_1.tar.bz2
   sha256: f2e79303d77b5dff25a5e012bf4c7ff28b687495afe2ca42cc2b539f0b7d9146
   md5: cba72961d70b2d66cc16795bfa0c6e06
   depends:
@@ -4306,7 +4306,7 @@ packages:
   license_family: Apache
   size: 19452
   timestamp: 1751274936497
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.5.5-h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-event-stream-0.5.5-h46256e1_0.tar.bz2
   sha256: 487f725caa9148810c5426c271bbfd85b69ff249e69b989ee231a312028c5420
   md5: e4f3f90bb820d73dd267714dd041da5c
   depends:
@@ -4317,7 +4317,7 @@ packages:
   license_family: Apache
   size: 50511
   timestamp: 1751547512013
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-http-0.10.2-h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-http-0.10.2-h46256e1_0.tar.bz2
   sha256: 42140d0f2e3f6117376d82d61a3b97da79f1f608781763709d234696f41722dc
   md5: 994a5c3abe9d2908e78445c3e47c0175
   depends:
@@ -4329,7 +4329,7 @@ packages:
   license_family: Apache
   size: 179776
   timestamp: 1751547499916
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-io-0.20.1-h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-io-0.20.1-h46256e1_0.tar.bz2
   sha256: 98c409eced7e171096a692c5e6d3d021ee24bbbef9a825a7f850c608c0089c7f
   md5: 52c91296281c0d09c36a84be51868f08
   depends:
@@ -4339,7 +4339,7 @@ packages:
   license_family: Apache
   size: 169964
   timestamp: 1751543230640
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-mqtt-0.13.2-he61ece7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-mqtt-0.13.2-he61ece7_0.tar.bz2
   sha256: d8de78df5baaefa66ff224a3d3a6f4a2aba0bc8b0a192ba38e30bc57d5e8c811
   md5: e7d8ccd207a35563cd7a7c3a26e4ec4e
   depends:
@@ -4350,7 +4350,7 @@ packages:
   license_family: Apache
   size: 178714
   timestamp: 1751616848250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-s3-0.8.3-h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-s3-0.8.3-h46256e1_0.tar.bz2
   sha256: 3abce724fda58cd918fba299e79ed0c19d7e335d7442b962dccec843a4ee2c6d
   md5: eb1dbfeb590dc2f712e5a754fe177b35
   depends:
@@ -4364,7 +4364,7 @@ packages:
   license_family: Apache
   size: 112348
   timestamp: 1751617837546
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-sdkutils-0.2.4-h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-sdkutils-0.2.4-h46256e1_0.tar.bz2
   sha256: b426872a11c72814d724517f5c3e15b00ee5c1f8727a895fb9d7beaa6c55e9c8
   md5: edbe9bb5b5682a0aeaf9c185bb5d9eb1
   depends:
@@ -4373,7 +4373,7 @@ packages:
   license_family: Apache
   size: 55325
   timestamp: 1751543943921
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.2.7-h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-checksums-0.2.7-h46256e1_0.tar.bz2
   sha256: fa9ff08be6539887f407f599364fbf10c4a65ac1cb94a3c14c46bbcd59fb0509
   md5: 2ebd3c04978b5179a0d354f75d697f31
   depends:
@@ -4382,7 +4382,7 @@ packages:
   license_family: Apache
   size: 78299
   timestamp: 1751543211691
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-crt-cpp-0.32.10-h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-crt-cpp-0.32.10-h6d0c2b6_0.tar.bz2
   sha256: 5ed6669490ede03841e299b75d2dbc231943e1562068a76bcce30f0400373b19
   md5: c383e7a264154a95e33aef5bfee97283
   depends:
@@ -4401,7 +4401,7 @@ packages:
   license_family: Apache
   size: 348831
   timestamp: 1751882095826
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.11.528-he026a02_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-sdk-cpp-1.11.528-he026a02_1.tar.bz2
   sha256: 08a258f3fd363585f0f25ea2125afbe0a308bb83c398e024974f0ddf966c0c30
   md5: a595285155ed6533415a61d45b9def7e
   depends:
@@ -4415,7 +4415,7 @@ packages:
   license_family: Apache
   size: 3781792
   timestamp: 1751884084218
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.13.4-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.13.4-py310hecd8cb5_0.tar.bz2
   sha256: 58c8c63c66b519701e1678cfda7ccdb3a3818314f5105dc82d1a1f11eb35a694
   md5: dc19f09ebf6caf4c914a76399f4e8930
   depends:
@@ -4426,12 +4426,12 @@ packages:
   license_family: MIT
   size: 291221
   timestamp: 1752599126191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-openblas.tar.bz2
   sha256: 695ac69739e73351dfebfb01ea39c5e1dbfdcfb475590d6560ae318bfbad3a97
   md5: 38fd73cba341639c45d8c747b08c9cc1
   size: 49130
   timestamp: 1528225884020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bleach-6.2.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bleach-6.2.0-py310hecd8cb5_0.tar.bz2
   sha256: 80f284948e221e50a375d27ced28b60fc14e9b94c70b7afebab6c94f1591e57b
   md5: d44ba8f9caf313fdf5186c7f50e857c8
   depends:
@@ -4443,7 +4443,7 @@ packages:
   license_family: Apache
   size: 298162
   timestamp: 1732292174114
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py310h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-3.2.1-py310h20db666_0.tar.bz2
   sha256: 40d9035be55844db55fdfe31e85752d99c165d1355d792c08a91f9ccda834e10
   md5: 3f953aa83d5a9ffd1393177be2ef719f
   depends:
@@ -4461,7 +4461,7 @@ packages:
   license_family: BSD
   size: 6484731
   timestamp: 1690546214635
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
   sha256: 81102f2762d8eb2f07c69fbf7ca7dad879a257a053085492d4c1b4006eb35fb8
   md5: 3c42777bc9330fe91177ea813b9ec252
   depends:
@@ -4471,7 +4471,7 @@ packages:
   license_family: OTHER
   size: 11744
   timestamp: 1696762233693
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py310h6d0c2b6_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py310h6d0c2b6_9.tar.bz2
   sha256: 9080f1318589a3b2f9966718f01963e9f9cf8e8272cac125a6c8fc4e38f16bb3
   md5: 17cef8e1c1b82fa69cda3cc46983b9fb
   depends:
@@ -4480,7 +4480,7 @@ packages:
   license: MIT
   size: 394148
   timestamp: 1736182872336
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotlicffi-1.0.9.2-py310h6d0c2b6_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotlicffi-1.0.9.2-py310h6d0c2b6_1.tar.bz2
   sha256: 4145d38aea691d904e3bb534a3e28e8566123b4700afea820648e9705ec05a3a
   md5: 0af9b9bd02f621a5763b9ce0e020e243
   depends:
@@ -4490,28 +4490,28 @@ packages:
   license: MIT
   size: 400640
   timestamp: 1736183240938
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
   sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
   md5: c5a600d81b1b48578863af2973c743ac
   license: bzip2-1.0.8
   license_family: BSD
   size: 187637
   timestamp: 1714510590009
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
   sha256: f913b61ba3c1651b36688415cc163a5d575475f7573b543f48a80e7a5002e4bb
   md5: f11d165eaa532ce04a35382841284298
   license: MIT
   license_family: MIT
   size: 107047
   timestamp: 1693902034820
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2025.7.15-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2025.7.15-hecd8cb5_0.tar.bz2
   sha256: bc99be41a6fdebe3af9dbf3a36e6865ce978bc1d4d844c6de3fb3d8b0ca52b31
   md5: 6f9db756c5105f55c9e5a35793181034
   license: MPL-2.0
   license_family: Other
   size: 137725
   timestamp: 1754645326236
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cairo-1.16.0-h08824b9_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cairo-1.16.0-h08824b9_6.tar.bz2
   sha256: 7a77bcd8be87ca8b6dc9572c64fe102a5e7bb2f1d03393ca41a9e63b6e0c6aee
   md5: f1d0286d509462bdb20e4f1fa32fd7cb
   depends:
@@ -4525,7 +4525,7 @@ packages:
   license_family: LGPL
   size: 1418284
   timestamp: 1748950888581
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2025.8.3-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2025.8.3-py310hecd8cb5_0.tar.bz2
   sha256: 9413b76282f8191c632f8afc8708a0ac41801e15f798fbcb1b71e905e1bd6db4
   md5: bf10e29862310b92aefbd929ea0e6c5a
   depends:
@@ -4534,7 +4534,7 @@ packages:
   license_family: Other
   size: 165421
   timestamp: 1754570785132
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py310h9205ec4_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.17.1-py310h9205ec4_1.tar.bz2
   sha256: c2c7d0141b9a5b74bcafd4ece47ba49c99ca2171e3f545fe2f9314dbf8c3e8ab
   md5: 9476cb1cd12dc1357b0e09715c1cda30
   depends:
@@ -4545,7 +4545,7 @@ packages:
   license_family: MIT
   size: 233330
   timestamp: 1736183923379
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.2.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/click-8.2.1-py310hecd8cb5_0.tar.bz2
   sha256: 1ce7f9f311f52ce720709932e0a1bdd780a1533414a5eaafe2eebd84be17f5e1
   md5: 5d9d9fb650c63997792407a27f50c644
   depends:
@@ -4554,7 +4554,7 @@ packages:
   license_family: BSD
   size: 289482
   timestamp: 1754478135731
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.1.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cloudpickle-3.1.1-py310hecd8cb5_0.tar.bz2
   sha256: 7a2fe1500648be7ed2353a255103b6d7dc2acb7ac2bc4d7a80ed56a694ca6d96
   md5: 53d483aa4a33ddcacc66d8d5178504d6
   depends:
@@ -4563,7 +4563,7 @@ packages:
   license_family: BSD
   size: 39146
   timestamp: 1751309490058
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py310hecd8cb5_0.tar.bz2
   sha256: 38b6b20387ada75d20393cc99de9c8a1f2b7fcd03b28720df4eef55d44ec393e
   md5: 881ffce8c467163639bd6ed6ef941189
   depends:
@@ -4572,7 +4572,7 @@ packages:
   license_family: CC
   size: 499171
   timestamp: 1709758463351
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py310hecd8cb5_0.tar.bz2
   sha256: cafb4b7adcb72b498a482a6b846f949e1aee350f96a79d9146b38f969b2e0a90
   md5: a404bca7f71823adc5ef078d63b788a9
   depends:
@@ -4582,7 +4582,7 @@ packages:
   license_family: BSD
   size: 15750
   timestamp: 1709322968401
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.3.1-py310h1962661_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.3.1-py310h1962661_0.tar.bz2
   sha256: b417230b26b1ce73a43ef4d6d4aa665d7cb49574ed484612b4f9c5f4ef563171
   md5: 3063ab79f0ba0cc1349db7b443216df3
   depends:
@@ -4593,7 +4593,7 @@ packages:
   license_family: BSD
   size: 282429
   timestamp: 1732540159621
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cramjam-2.9.1-py310hc8aab72_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cramjam-2.9.1-py310hc8aab72_0.tar.bz2
   sha256: 5f83837fcd846dc511820bd092e6388916c5fd7efa887afcbab092f1fceaf253
   md5: dd8a561663d4290e3cc00158150bf4ae
   depends:
@@ -4604,7 +4604,7 @@ packages:
   license_family: MIT
   size: 1656958
   timestamp: 1742393449092
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-1.0.1-py310h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cytoolz-1.0.1-py310h46256e1_0.tar.bz2
   sha256: 1d9a57bbd23aa5dd39f0ebbc54f35b47f06bb92d7411ebf2b6cfcdc9d7c4c1b1
   md5: e206caf5e2a578c3d6c501a2bef43194
   depends:
@@ -4614,7 +4614,7 @@ packages:
   license_family: BSD
   size: 377760
   timestamp: 1736804097424
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.15.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/datashader-0.15.1-py310hecd8cb5_0.tar.bz2
   sha256: 5ebff2d98d1e5797562ba6a56abe643e83602f950bebcaf3c98aa3e784f5f150
   md5: 69934087a995025dc10f36d3cd1d1111
   depends:
@@ -4636,7 +4636,7 @@ packages:
   license_family: BSD
   size: 17662937
   timestamp: 1689604033927
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py310hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/datashape-0.5.4-py310hecd8cb5_1.tar.bz2
   sha256: 6b3905da23b8fdf7323cfe47995b73b8129a75c1708c088b30a5df0b2fc421b2
   md5: bb78d03307832de66ed78b15009022a8
   depends:
@@ -4648,14 +4648,14 @@ packages:
   license_family: BSD
   size: 103789
   timestamp: 1642543991102
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/dav1d-1.2.1-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/dav1d-1.2.1-h6c40b1e_0.tar.bz2
   sha256: 53b960dc320a73701d8faf90316a203b01b294e0a7235c7bf49bb853d71b2214
   md5: 7a196bd419ee0f888fbbe0e6d449adda
   license: BSD-2-Clause
   license_family: BSD
   size: 812727
   timestamp: 1688746099942
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.8.11-py310h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.8.11-py310h6d0c2b6_0.tar.bz2
   sha256: f0f253e5d75f3ba81ad47d7c8ffa0893d9e3498f93add77ab2407e51b599df26
   md5: 3b248ee0a819e5a27d7e86b3eb3c6eb0
   depends:
@@ -4665,7 +4665,7 @@ packages:
   license_family: MIT
   size: 2367714
   timestamp: 1736267739614
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py310hecd8cb5_0.tar.bz2
   sha256: 670e9476a114ca61020f1a69803661de5cc6f01a26296a4c73bbbda94164dc4e
   md5: 12f8f558c520d5a1e25ba2967edbee89
   depends:
@@ -4674,7 +4674,7 @@ packages:
   license_family: MIT
   size: 16685
   timestamp: 1649926502410
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.2.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.2.0-py310hecd8cb5_0.tar.bz2
   sha256: a31f9c19d1b9f9355dee09bc356853ee2c9b4ffc99525810a7189e3d148c2c18
   md5: 36fd0124a6a901c880c4f80087db5803
   depends:
@@ -4683,7 +4683,7 @@ packages:
   license_family: MIT
   size: 30923
   timestamp: 1706031435284
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/expat-2.7.1-h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/expat-2.7.1-h6d0c2b6_0.tar.bz2
   sha256: 82a4c50f5e4de65f6f85e0a78f09dc63ba1cfde730d2811cd811af275a9d00dc
   md5: 2710e707ee0cca3ce20178498880b07d
   depends:
@@ -4692,7 +4692,7 @@ packages:
   license_family: MIT
   size: 164184
   timestamp: 1744659891613
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-2024.2.0-py310h7b7cdfe_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fastparquet-2024.2.0-py310h7b7cdfe_0.tar.bz2
   sha256: bde273a9a8515071f7bc8ef51eb434e1e66b9a338578bd0bd906c3cc9a302dd3
   md5: adeb3a54825919246130f923bbe45db2
   depends:
@@ -4706,7 +4706,7 @@ packages:
   license_family: Apache
   size: 633724
   timestamp: 1715262975637
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fontconfig-2.14.1-h269ac6a_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fontconfig-2.14.1-h269ac6a_3.tar.bz2
   sha256: c05a2895ae7758e77eb03ab269d3181461de6909dbf93426bb2e580245230cc6
   md5: 1f34b1ef1a777b25daa69662f286b4bd
   depends:
@@ -4718,7 +4718,7 @@ packages:
   license_family: MIT
   size: 281575
   timestamp: 1722921216503
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.55.3-py310h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fonttools-4.55.3-py310h46256e1_0.tar.bz2
   sha256: 569b44d8b937da6e3e5f2e42c0a5f1fe2a00cdb7496342120eed37953d4d30f0
   md5: ef6da35662deeedf8aa5a19f7fc6f5ba
   depends:
@@ -4736,7 +4736,7 @@ packages:
   license_family: MIT
   size: 2694120
   timestamp: 1737040009567
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.13.3-h02243ff_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.13.3-h02243ff_0.tar.bz2
   sha256: 7a7fdc574ecd7867034e0cdf29cc9e7d2ba18b598314e0e84fa3a4036515c20a
   md5: 293e13416fb9ee0f144ee9ebeb686f1a
   depends:
@@ -4746,13 +4746,13 @@ packages:
   license_family: Other
   size: 943295
   timestamp: 1743636677947
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fribidi-1.0.10-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fribidi-1.0.10-haf1e3a3_0.tar.bz2
   sha256: 380c89b34c225e97b618f9dee0dcc4a230dbd611a3d2fd4e37136fca9625eb09
   md5: 58df1c8d8878f3fe462eb75826d5fbd7
   license: LGPL-2.1
   size: 67815
   timestamp: 1597699493723
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2025.7.0-py310he13d532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fsspec-2025.7.0-py310he13d532_0.tar.bz2
   sha256: a4a9a73d05fe246d30db0f4f31d55e8907b9b348bcabdec661b2eeb8a854e45c
   md5: 14bb184a5d35316e7431da1089d1d561
   depends:
@@ -4764,7 +4764,7 @@ packages:
   license_family: BSD
   size: 555290
   timestamp: 1753796226579
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/gettext-0.21.0-h4e8c18a_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/gettext-0.21.0-h4e8c18a_2.tar.bz2
   sha256: 9f2052e2c2f4e1d48b4315c3976c53afc5ff69399166f24432bb8c02f868fc27
   md5: eb9c4555f936f3998c0c5e462c44f0e9
   depends:
@@ -4777,7 +4777,7 @@ packages:
   license_family: GPL
   size: 3595681
   timestamp: 1722923856325
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
   sha256: 3c7aa54548409f9343e891820ea43c195b5e4e4dce6b761bc3ae9f6c8be0fc86
   md5: ed9629d6dc1612ec425eb8d27478b0f6
   depends:
@@ -4786,7 +4786,7 @@ packages:
   license_family: BSD
   size: 140316
   timestamp: 1706888243476
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
   sha256: aed47f9ca4dd140b9c8a183e53d4b89eba84a20041d2038983cdfea8096104ef
   md5: c0d981d7d43eaad55950ff5e57206e70
   depends:
@@ -4796,7 +4796,7 @@ packages:
   license_family: BSD
   size: 97828
   timestamp: 1706895273858
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/graphite2-1.3.14-he9d5cce_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/graphite2-1.3.14-he9d5cce_1.tar.bz2
   sha256: 5fb77afc56bab49baed51609a5f62d814a1602ca6b6c9be2335250bd90f7b4a6
   md5: 620cdc76e94f58e22d16e8c9bbbd331d
   depends:
@@ -4805,7 +4805,7 @@ packages:
   license_family: LGPL
   size: 87249
   timestamp: 1654175417832
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/harfbuzz-10.2.0-h060d35a_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/harfbuzz-10.2.0-h060d35a_1.tar.bz2
   sha256: 9e418cb0008b11f5945612ad7c0b1c7d786a68aa25d7af7f6525e1ee2568f9a9
   md5: 1c81c148a18b11c22449220bcc80e0f8
   depends:
@@ -4819,7 +4819,7 @@ packages:
   license_family: MIT
   size: 2792420
   timestamp: 1748953771332
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.16.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.16.0-py310hecd8cb5_0.tar.bz2
   sha256: 8db742e6e3dc9b44a0cdccde3935b20b00dd024814f86b797cf95cada949e011
   md5: cfc40754b31a02a66c452d8ba868594a
   depends:
@@ -4836,7 +4836,7 @@ packages:
   license_family: BSD
   size: 4471610
   timestamp: 1684937042999
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
   sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
   md5: f3ce6fe6eb760c236e5f7d04df5faa81
   depends:
@@ -4845,7 +4845,7 @@ packages:
   license_family: MIT
   size: 28138484
   timestamp: 1692293212596
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py310hecd8cb5_0.tar.bz2
   sha256: c21b5d635595e087aa1135dd3b6dca63054aff33d58d70100c0b0f6648d0dae3
   md5: b548aefceda441a37555005da1b9a4c8
   depends:
@@ -4854,7 +4854,7 @@ packages:
   license_family: BSD
   size: 140710
   timestamp: 1714398998249
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py310hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.29.5-py310hecd8cb5_1.tar.bz2
   sha256: 14152cac71fbe490f7cb5c55cdd579d539db2c03e7aa053070405003a818b8e4
   md5: 5284bf705342b8998b32fe90f734f660
   depends:
@@ -4876,7 +4876,7 @@ packages:
   license_family: BSD
   size: 193089
   timestamp: 1737663232337
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.30.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.30.0-py310hecd8cb5_0.tar.bz2
   sha256: cb0223d29b35cf307ed043e433b56c47cbb1d7c95f03df7170b0038baf3f75c1
   md5: 6464ffc2b762b4624b995df86a18d517
   depends:
@@ -4895,7 +4895,7 @@ packages:
   license_family: BSD
   size: 1294016
   timestamp: 1734550898575
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.19.2-py310hecd8cb5_0.tar.bz2
   sha256: 4b577d3dbe27fa6cf633cba900290e21507a43b49c6cbb8558e8f9222f275439
   md5: 9901907744df4b8302f3aa287a654bea
   depends:
@@ -4905,7 +4905,7 @@ packages:
   license_family: MIT
   size: 1062952
   timestamp: 1733987465642
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.6-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.6-py310hecd8cb5_0.tar.bz2
   sha256: d3246337bed0a9f6281034e33720e86823788f2426929d3fd34d68b1d0e91f31
   md5: e0c4befba7234c764b066e1336f71ef4
   depends:
@@ -4917,14 +4917,14 @@ packages:
   license_family: BSD
   size: 280482
   timestamp: 1741715320823
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
   sha256: 855982a798d9af8e70635a250528a5da3b2b0cf7095e2804858caf139c8a239b
   md5: 112a5602fe42a84a5bafa038abeddf4f
   license: IJG
   license_family: Other
   size: 279686
   timestamp: 1722872676718
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.25.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.25.0-py310hecd8cb5_0.tar.bz2
   sha256: 0952e397b2eb51edf107705c3a0e41f471d269dd8daec8cbf1500768b5c93d5d
   md5: 215f162197580b2334b6d080b15abc3a
   depends:
@@ -4937,7 +4937,7 @@ packages:
   license_family: MIT
   size: 149650
   timestamp: 1753206496757
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py310hecd8cb5_0.tar.bz2
   sha256: b61904f8e4c3d1726f4bbec37d1edfd69a989cab0098cfa9c422d2cf9f49ba78
   md5: 221013125db975c3b57e7ebc93e73b2a
   depends:
@@ -4947,7 +4947,7 @@ packages:
   license_family: MIT
   size: 15941
   timestamp: 1699032432155
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py310hecd8cb5_0.tar.bz2
   sha256: 1b382008e5e5b7d7bbe5da1767d4d35021869c5ff1b7fdb17f10fa9634cd8e1e
   md5: 32e23b69e39f05ec0c83b75738996fa2
   depends:
@@ -4963,7 +4963,7 @@ packages:
   license_family: BSD
   size: 200146
   timestamp: 1676330021017
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.8.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.8.1-py310hecd8cb5_0.tar.bz2
   sha256: 02a2f1d7e0009cd5fd308b6309bf53522d53a638c1cd867e91f1d6f445c1b2a7
   md5: 62369059a2eb81101c7143ea0cbcca4b
   depends:
@@ -4974,7 +4974,7 @@ packages:
   license_family: BSD
   size: 87307
   timestamp: 1751991867907
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.12.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.12.0-py310hecd8cb5_0.tar.bz2
   sha256: c3d537fa353ee08bd64234d626e6c209ba19035338a7c78ed86600ef72ba0a37
   md5: 57475a601c4bd5e5b7fa966b1a187f8e
   depends:
@@ -4991,7 +4991,7 @@ packages:
   license_family: BSD
   size: 37872
   timestamp: 1741184725811
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.16.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.16.0-py310hecd8cb5_0.tar.bz2
   sha256: 2156a4b108cacb8d2972b76aa09edee6b11c862df99b0fcca2c95fe365c8020d
   md5: 68ba18942ade8ddc360062d12f923419
   depends:
@@ -5018,7 +5018,7 @@ packages:
   license_family: BSD
   size: 513979
   timestamp: 1751996686958
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.5.3-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.5.3-py310hecd8cb5_0.tar.bz2
   sha256: 5b630b062a1637bc43ebef156708b91fba46f92b63a1b2ca7093f5cda2d3a32d
   md5: 066cb4979d5982803d57c4ae82c449a9
   depends:
@@ -5028,7 +5028,7 @@ packages:
   license_family: BSD
   size: 25936
   timestamp: 1744706845282
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.3.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyterlab_pygments-0.3.0-py310hecd8cb5_0.tar.bz2
   sha256: 5165a7ec95c350bc4e9c764903c97d0f3b07f74f2a67c184c44bee1b807aeefc
   md5: b7c2813ee05852058413012c80bc285e
   depends:
@@ -5040,7 +5040,7 @@ packages:
   license_family: BSD
   size: 21718
   timestamp: 1741124601995
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.8-py310h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.8-py310h6d0c2b6_0.tar.bz2
   sha256: 5af425f0056e4865bfb9aa113563ce058c47ba590712d2189968a416f8492896
   md5: 8926b9c4708dd93b08d7474f821f013e
   depends:
@@ -5050,7 +5050,7 @@ packages:
   license_family: BSD
   size: 68685
   timestamp: 1737040226477
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.16-h31d93a5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.16-h31d93a5_1.tar.bz2
   sha256: a05cf581d30821ee034e16325788c770147f9f5627e8166d88776c054e4a7928
   md5: 6348d6db77d4455269c9ba4c31b6ab64
   depends:
@@ -5060,7 +5060,7 @@ packages:
   license_family: MIT
   size: 264117
   timestamp: 1744358217760
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-4.0.0-h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-4.0.0-h6d0c2b6_0.tar.bz2
   sha256: 50da46ac4a032a38d2d9e714e945079e05a46ae451437a52ad09b4cd5d925f5b
   md5: 234c885b9f326ecf78b5294fb709ddee
   depends:
@@ -5069,7 +5069,7 @@ packages:
   license_family: Apache
   size: 295348
   timestamp: 1734423413199
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libabseil-20250127.0-cxx17_h548131f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libabseil-20250127.0-cxx17_h548131f_0.tar.bz2
   sha256: 277ca3393da63ec5f6794ddb6d0f322b59bcae3ef1cb6efb36ceb12fffcf8e74
   md5: fd181f8692ed17972994e3a111961aa3
   depends:
@@ -5082,7 +5082,7 @@ packages:
   license_family: Apache
   size: 1252067
   timestamp: 1742310226263
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libavif-1.1.1-h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libavif-1.1.1-h46256e1_0.tar.bz2
   sha256: eead0160c02cb5c0e852402a61732603d70b13d2fd2e09e49b8dcf1f87eb490f
   md5: e2ffd343ff3434dd03c0410455c324f0
   depends:
@@ -5092,7 +5092,7 @@ packages:
   license_family: BSD
   size: 137625
   timestamp: 1733819995977
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
   sha256: 127dbf93874f1bb3493b312fecb5ffedb8f2a41d2470e2cbeb889eb58d89ebf7
   md5: 07502b61e43a2039e4312b40d53c1db1
   depends:
@@ -5107,13 +5107,13 @@ packages:
   license_family: OTHER
   size: 22584954
   timestamp: 1696762195023
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h46256e1_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h46256e1_9.tar.bz2
   sha256: 8f058b4b23c8d56f8411c8f6eec834ea30e8a2ce7a98685ad9c2a4817aabae4a
   md5: b64809b5c2030ac3e571c9f6b5b34335
   license: MIT
   size: 66530
   timestamp: 1736182753663
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h46256e1_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h46256e1_9.tar.bz2
   sha256: 6269fa97423611d7310bb23d6929e1fee3246a10440cd931718d4d447f6d4215
   md5: 23d3558e675675ea0281bbfcac49453a
   depends:
@@ -5121,7 +5121,7 @@ packages:
   license: MIT
   size: 34461
   timestamp: 1736182772158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h46256e1_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h46256e1_9.tar.bz2
   sha256: 738524a5398e731ba9c74b799bf5e972721af4a4dc6a5425d2e17780e3e15912
   md5: b562c3b15ef8b86391171d2f1b85cae6
   depends:
@@ -5129,7 +5129,7 @@ packages:
   license: MIT
   size: 311811
   timestamp: 1736182791956
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.14.1-h1448931_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcurl-8.14.1-h1448931_1.tar.bz2
   sha256: 45c46b982fd5795c9bb1652da2d908f5e35f5895fb56efdca24244301e7320ef
   md5: cb0c3108ef81ae36b219767a516735be
   depends:
@@ -5145,7 +5145,7 @@ packages:
   license_family: MIT
   size: 450383
   timestamp: 1753959350533
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-19.1.7-haebbb44_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-19.1.7-haebbb44_3.tar.bz2
   sha256: e7941e24012a8d13c0f878e46ece21bc65312a941fbd45dcb9fb5acb251a41aa
   md5: b4aa2806a2e1a23b4ff2b5884ef8f894
   depends:
@@ -5159,21 +5159,21 @@ packages:
   license_family: Apache
   size: 394979
   timestamp: 1755029133023
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.22-h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.22-h46256e1_0.tar.bz2
   sha256: 5267b5015a03aa90883f57b3cc5dda014082e5ab88e2d3b30fe809c37b96094c
   md5: a6bdcc6561a095bc0ac11482e84c37c8
   license: MIT
   license_family: MIT
   size: 84141
   timestamp: 1734423352364
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
   sha256: 4786264321edbff780633a5b752995eb3193ca4bce11b0fda179577f6cf1102c
   md5: 849fdd014c201a9d2c2aa7c7db38a778
   license: BSD-2-Clause
   license_family: BSD
   size: 103993
   timestamp: 1632891571494
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
   sha256: a60941a0365ee3e8b9ff721f75b0608c234b5652f53337a918b787839de4bb53
   md5: 4d61f019594ebccfb3f4fb87ee778416
   depends:
@@ -5183,14 +5183,14 @@ packages:
   license_family: BSD
   size: 414942
   timestamp: 1685052318462
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
   sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
   md5: 822a5b76117e56d3912f1f2153307528
   license: MIT
   license_family: MIT
   size: 136045
   timestamp: 1714483561919
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
   sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
   md5: e458587c87e3f2d20192f4e0738f2c63
   depends:
@@ -5199,7 +5199,7 @@ packages:
   license_family: GPL
   size: 149419
   timestamp: 1665498987619
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
   sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
   md5: 1058b661ec829b2ee3716ee2a5520641
   depends:
@@ -5210,7 +5210,7 @@ packages:
   license_family: GPL
   size: 1917987
   timestamp: 1665498925405
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libglib-2.84.2-heb90364_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libglib-2.84.2-heb90364_0.tar.bz2
   sha256: 9098195739bb2da11d190879694a543221bce176c148b71a00740cab5c155826
   md5: 670803b0ad44bd20cf3d0255d7361f6a
   depends:
@@ -5226,7 +5226,7 @@ packages:
   license_family: LGPL
   size: 3434948
   timestamp: 1751359726038
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgrpc-1.71.0-hf2926fd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgrpc-1.71.0-hf2926fd_0.tar.bz2
   sha256: d4885e3b55f8400c130ea5422db608c6d1523a9c7622c27032e5db43d718c20c
   md5: 3c9f991f714e5744bcef6a0493eeeacc
   depends:
@@ -5247,14 +5247,14 @@ packages:
   license_family: APACHE
   size: 7444739
   timestamp: 1742493869382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
   sha256: 9ff6ed0f0b9f9f27f449e95d11aa1c4e9e80028fd9d2a8caca5a15d8df88f435
   md5: 7b4b557afc66aba367da14d97d71934c
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1409885
   timestamp: 1714483704680
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
   sha256: 7bfcf69c31a4eb15dfab661c93463ce8dfb7b3de4356945fa5c1ca50a5ae0cb0
   md5: 4934bb34818fa3d99b32b9cb59fed205
   depends:
@@ -5269,7 +5269,7 @@ packages:
   license_family: MIT
   size: 784918
   timestamp: 1697018436251
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.29-h3f8574a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libopenblas-0.3.29-h3f8574a_0.tar.bz2
   sha256: 3a3a9861ff781d55b4f38925c3f6059cb7811f5813ca85bf5a656e7b69d92bba
   md5: a33a5f061ffab5a47e96ba9fd5385555
   depends:
@@ -5279,7 +5279,7 @@ packages:
   license_family: BSD
   size: 10583047
   timestamp: 1746648378310
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -5288,7 +5288,7 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-5.29.3-h66a43dd_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libprotobuf-5.29.3-h66a43dd_1.tar.bz2
   sha256: 7537dd0807904c3cc02f8fb89794cd00e5b692ce8b241f508cc65af1145f782b
   md5: ca9332c808158259dd3bbaef5575fdb9
   depends:
@@ -5302,7 +5302,7 @@ packages:
   license_family: BSD
   size: 3365003
   timestamp: 1750090199893
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libre2-11-2024.07.02-hab2016f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libre2-11-2024.07.02-hab2016f_0.tar.bz2
   sha256: f17f9e5fbd59567d10df1d9072ffa4b93df45ac41d3d58ab574fab7ec82b0278
   md5: 226b106e49b0a5485422b6c500e41183
   depends:
@@ -5316,13 +5316,13 @@ packages:
   license_family: BSD
   size: 248148
   timestamp: 1742313370721
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.11.1-h3a17b82_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libssh2-1.11.1-h3a17b82_0.tar.bz2
   sha256: 1107001cf2ab50223d97fe24d4747262f52883abe47263e301a506b195485017
   md5: a42788d25cc9b4a03d4434e231db7445
   depends:
@@ -5332,7 +5332,7 @@ packages:
   license_family: BSD
   size: 292312
   timestamp: 1732891162787
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
   sha256: 21ba71cdc65b56c6daefeeab55959e5a7edadfd697cfa8b2ed5c1b3e2a98586b
   md5: cbbd369ee87aba597c942727bada4eee
   depends:
@@ -5345,7 +5345,7 @@ packages:
   license_family: Apache
   size: 364326
   timestamp: 1687975317748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.7.0-h2dfa3ea_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.7.0-h2dfa3ea_0.tar.bz2
   sha256: f8ac3d26791c4dfaae827fc791d5ced3d7394314a46d40c7d236fd51b3f5d5a5
   md5: 7b6486e03e7f3ebf5e489c7cd27fcb97
   depends:
@@ -5361,7 +5361,7 @@ packages:
   license_family: Other
   size: 450903
   timestamp: 1744352034365
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
   sha256: 246c0d82766042c1a9194eecc71690918c68afa3528ff0c2c82796ce901df40b
   md5: f33be4ed3bff89ed8f68df6c75158510
   constrains:
@@ -5370,7 +5370,7 @@ packages:
   license_family: BSD
   size: 449215
   timestamp: 1729160070984
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.13.8-h6070cd6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxml2-2.13.8-h6070cd6_0.tar.bz2
   sha256: 8be62db7da3121a108dc243ac6e17e7b0387f08057f7c3c0e21e9254046d592a
   md5: 07248330f39881a95f902e2f614435b9
   depends:
@@ -5382,7 +5382,7 @@ packages:
   license_family: MIT
   size: 647795
   timestamp: 1745948063293
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py310hecd8cb5_0.tar.bz2
   sha256: 8e083eacdfa973821efce45fb1de838ccdab56cbee31a6ce70de0683ad2165f7
   md5: 8f970cf73b7f71b2d2c624992e9cd6f7
   depends:
@@ -5392,7 +5392,7 @@ packages:
   license_family: MIT
   size: 36179
   timestamp: 1659783413376
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-19.1.7-h5048363_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-19.1.7-h5048363_2.tar.bz2
   sha256: 73835edf76319d3b67d61da80811c0de1cf0daf9cac3f73158b71868ca74a372
   md5: 4aada712b7ccbef49d8da3cf7b52f142
   depends:
@@ -5403,7 +5403,7 @@ packages:
   license_family: Apache
   size: 382001
   timestamp: 1755220355531
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.44.0-py310hfa5e528_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.44.0-py310hfa5e528_1.tar.bz2
   sha256: 51981bd778db0a2e53314c874817c40afd5c4466ff05e2e84aac6768f34b8525
   md5: a08fd21bd60ec1bf12d277e728ffc947
   depends:
@@ -5415,7 +5415,7 @@ packages:
   license_family: BSD
   size: 25034759
   timestamp: 1741215188737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py310hecd8cb5_0.tar.bz2
   sha256: ef2cc69591855744d4c5d1aeb6b325d0f9886404709cba541be075fe6f696fd5
   md5: 46e2880168e6de564dd817fde7bf07b1
   depends:
@@ -5424,7 +5424,7 @@ packages:
   license_family: BSD
   size: 11932
   timestamp: 1652903221378
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-4.3.2-py310h46256e1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-4.3.2-py310h46256e1_1.tar.bz2
   sha256: 9da88b73981867050f0095c60030639ac2836506ec923c48c57ca2b9bc1ab9aa
   md5: 24abee418effd96d6ea6c0ba97085344
   depends:
@@ -5434,7 +5434,7 @@ packages:
   license_family: BSD
   size: 35888
   timestamp: 1736368136507
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
   sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
   md5: 8f57dc3a3327bb6f7e1cba908856ac7f
   depends:
@@ -5443,7 +5443,7 @@ packages:
   license_family: BSD
   size: 183138
   timestamp: 1714510756758
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.8-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.8-py310hecd8cb5_0.tar.bz2
   sha256: 58f8c91ba797503d1f35cb44df40ebe6627796d31d5bfa81fcaa26f64aefaca6
   md5: d16ed165f9140a11c27e5aaf5702cadf
   depends:
@@ -5452,7 +5452,7 @@ packages:
   license_family: BSD
   size: 141256
   timestamp: 1746114609822
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py310hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py310hecd8cb5_1.tar.bz2
   sha256: 444bec52a8b4f0e0169f69b0d2ee1409dc04a48509ea394d053e8fa3418e724b
   md5: e95bbbc56e3c08f0018638c6ee82e567
   depends:
@@ -5462,7 +5462,7 @@ packages:
   license_family: MIT
   size: 108187
   timestamp: 1684279943281
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-3.0.2-py310h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-3.0.2-py310h46256e1_0.tar.bz2
   sha256: 6b2b6539c570b8d4c763834d1876e26013ebe15ce244f8a46b1515a09c5f056b
   md5: 2f5b14671a4c1487a378edde34849ed0
   depends:
@@ -5473,7 +5473,7 @@ packages:
   license_family: BSD
   size: 25717
   timestamp: 1738584336873
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.10.0-py310h919b35b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.10.0-py310h919b35b_0.tar.bz2
   sha256: 1517e6b6862b34086796475bc0a8748c32ff0c6f10a162ff0d96451cdc9c94c8
   md5: 805d4f20ed3edfc0ab0512dce7422d31
   depends:
@@ -5493,7 +5493,7 @@ packages:
   license_family: PSF
   size: 8832382
   timestamp: 1736279414715
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py310hecd8cb5_0.tar.bz2
   sha256: b0b7bf33159ad955ac6503e0008bb4f6d42a431d39750d8748f1cfd437c33982
   md5: 95dcb73cba7ccc8d9d54ded71c43f200
   depends:
@@ -5503,7 +5503,7 @@ packages:
   license_family: BSD
   size: 17405
   timestamp: 1662014515076
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py310hecd8cb5_0.tar.bz2
   sha256: 25de39c78f2dd34019fd7c7f46110a096abaf50fe8ed08ddbbdb905aa5fa4154
   md5: 0a554b7362b3c3ee587f2486e58c9d4c
   depends:
@@ -5513,7 +5513,7 @@ packages:
   license_family: MIT
   size: 53950
   timestamp: 1659721329388
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py310hecd8cb5_0.tar.bz2
   sha256: f7319ca119de06ffc0efc159c00b0eb4aa1c8c95b0de062532590cb8da37be9e
   md5: 3d14c228ee0ce206ba6889c36a0815c7
   depends:
@@ -5522,7 +5522,7 @@ packages:
   license_family: MIT
   size: 19643
   timestamp: 1659716168738
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-3.1.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-3.1.2-py310hecd8cb5_0.tar.bz2
   sha256: 12af34728c9db5f442757cf6ceb67b0c1bf92d491c9cbaabe3fd48cf10ca0b11
   md5: be4cff18fc933ac4d27e70a91e876038
   depends:
@@ -5532,7 +5532,7 @@ packages:
   license_family: BSD
   size: 110310
   timestamp: 1741124154811
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.1.1-py310h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/msgpack-python-1.1.1-py310h6d0c2b6_0.tar.bz2
   sha256: 3ad1033fc21028c478dc736261ede3ebed405d7f9af575759ee0cec9797b8047
   md5: ce39d257fb9233e31d684c9acfafb9f2
   depends:
@@ -5542,7 +5542,7 @@ packages:
   license_family: Apache
   size: 103764
   timestamp: 1750958927569
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py310hecd8cb5_0.tar.bz2
   sha256: 1b5957084c6043397d20cc0caa110e51050113c316b836810cc509c1f9378ab2
   md5: d1c02fb4d2d5d701c11984fdda8505a3
   depends:
@@ -5552,7 +5552,7 @@ packages:
   license_family: BSD
   size: 22942
   timestamp: 1642534330262
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.3.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-1.3.1-py310hecd8cb5_0.tar.bz2
   sha256: 2c9b6777ea2b60a127da7d04b8cc7a537c516ac582d17648527b2c92ecebb1aa
   md5: 99753d275fc0b85f7b56a85598c083e5
   depends:
@@ -5565,7 +5565,7 @@ packages:
   license_family: BSD
   size: 15319992
   timestamp: 1751012354760
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.10.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.10.2-py310hecd8cb5_0.tar.bz2
   sha256: 2b8552974160634bd0ffc6ecc4cda7989170e489202ec7f4c791a56cb9190bbd
   md5: c79699a2a5411019332347b88d6dfdca
   depends:
@@ -5578,7 +5578,7 @@ packages:
   license_family: BSD
   size: 44542
   timestamp: 1741124342748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.6-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.16.6-py310hecd8cb5_0.tar.bz2
   sha256: a56dff21ea63d60f2495dea5becdef90d9abcb78de4c60c1ce012a9a88491f6d
   md5: 0cc9d3c07444b3cebebbcc4cd4470d67
   depends:
@@ -5589,7 +5589,7 @@ packages:
   license_family: BSD
   size: 8345
   timestamp: 1741197611074
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-core-7.16.6-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-core-7.16.6-py310hecd8cb5_0.tar.bz2
   sha256: a55c682367bd6dd6a5176f06b780ae0f7191fbaa67353172d0cea212fd60d307
   md5: 9f2accb2aed72cc195e6d845b13fb5bc
   depends:
@@ -5616,7 +5616,7 @@ packages:
   license: BSD-3-Clause
   size: 503735
   timestamp: 1741197592000
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-pandoc-7.16.6-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-pandoc-7.16.6-py310hecd8cb5_0.tar.bz2
   sha256: 139ae76b3016d362d36f0e78037be039dbe2ee611745553fdc9507730aba5738
   md5: 4a3f14b45b4acfe4d7a6b7b6bb6774b5
   depends:
@@ -5626,7 +5626,7 @@ packages:
   license: BSD-3-Clause
   size: 8371
   timestamp: 1741197603522
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.10.4-py310hecd8cb5_0.tar.bz2
   sha256: 5002aeb376cc6933cc225bea4841515fb2b54704696e3065610996f05750224e
   md5: e2a7b4c2bb90517f0a29ad683c4c1e56
   depends:
@@ -5639,7 +5639,7 @@ packages:
   license_family: BSD
   size: 149697
   timestamp: 1728049994459
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.5-h923df54_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.5-h923df54_0.tar.bz2
   sha256: 4743a0d696d67f8018bff466bb82ed736695d16c2bc2398ec768f1c7a60a2a03
   md5: 0e927c5a5178eca5ff1954c5142f95bf
   depends:
@@ -5648,7 +5648,7 @@ packages:
   license_family: MIT
   size: 1096224
   timestamp: 1753947521640
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py310hecd8cb5_0.tar.bz2
   sha256: cc408a3c4fb28427161701204d608cbb03b5cbd1d4560f61b03a3aadd35fa9a5
   md5: e1eae3de565ba8e2f102a67f9c425520
   depends:
@@ -5657,7 +5657,7 @@ packages:
   license_family: BSD
   size: 14541
   timestamp: 1708532847720
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.7-py310hecd8cb5_0.tar.bz2
   sha256: 3f78085783bed38080cc1c039b6816bc2d08134f803a96b472f89b22ea1c51dd
   md5: c2050f983311834a8c1dab82b21eac30
   depends:
@@ -5682,7 +5682,7 @@ packages:
   license_family: BSD
   size: 562151
   timestamp: 1717630928303
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.4-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.4-py310hecd8cb5_0.tar.bz2
   sha256: 78ba378c4dd9fa950f35737b8c9a7eddbb6395d396199e9c2ccab6809246d203
   md5: 6b7e246b685f82042c3c14fff8a3c6aa
   depends:
@@ -5692,7 +5692,7 @@ packages:
   license_family: BSD
   size: 23981
   timestamp: 1741712310288
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.61.2-py310h2d33a94_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numba-0.61.2-py310h2d33a94_0.tar.bz2
   sha256: 164662134dc84475ddd35ed0681831be5ce35e210e0e1258916499ffb70f2f82
   md5: f9be7f931bc42702eb8b501e0ee68f3a
   depends:
@@ -5714,7 +5714,7 @@ packages:
   license_family: BSD
   size: 4689037
   timestamp: 1750804238252
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py310hf6dca73_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.4-py310hf6dca73_0.tar.bz2
   sha256: 879eba95cd6f3c9db63acf22db294be7e49f82fe3b4df555f2e9edb0edc5e9f7
   md5: b113dcbda7bb76a7fbf1f94efc6c184a
   depends:
@@ -5727,7 +5727,7 @@ packages:
   license_family: BSD
   size: 11299
   timestamp: 1708642941361
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py310hd8f4981_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.4-py310hd8f4981_0.tar.bz2
   sha256: 8b6c290f94d2baa1072961a8075632c82fd3c57902194b83a26b5fedd406e8ba
   md5: 3cc589b83f466f12da41d16f33b7b0cc
   depends:
@@ -5741,7 +5741,7 @@ packages:
   license_family: BSD
   size: 7635155
   timestamp: 1708642899725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-h2d09ccc_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.5.2-h2d09ccc_1.tar.bz2
   sha256: ec45b94cde6b5c7dc456a665d66af1c59b2684fb102eb1c1316b57ca2a679598
   md5: 9b8c31394a3a8fbf86f9751f2810f270
   depends:
@@ -5752,7 +5752,7 @@ packages:
   license_family: BSD
   size: 548341
   timestamp: 1744358392735
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.17-hee2dfae_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.17-hee2dfae_0.tar.bz2
   sha256: 72fedfc0ab6ce7fbd255281d5e5a1ba502dcc92d6da82d0bb2e75b34daaee686
   md5: 650ebe2983c6b653f70b5bb8fddd288e
   depends:
@@ -5761,7 +5761,7 @@ packages:
   license_family: Apache
   size: 4968293
   timestamp: 1753177400112
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-2.1.1-h4dda5a6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/orc-2.1.1-h4dda5a6_0.tar.bz2
   sha256: a680d9e048239f49e1a8339a12f16919e931c9bfcd4a9cc59d98104cc8b4564d
   md5: bd07ddb5a5d2c5e63117b6f1253b0c0a
   depends:
@@ -5778,7 +5778,7 @@ packages:
   license_family: Apache
   size: 568412
   timestamp: 1742827702826
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py310hecd8cb5_0.tar.bz2
   sha256: c7e6eeaed43f22e96664e0e3facadc1466824665cde18889fca81e9a3fc7b675
   md5: 91dd93c48df10568852a9186a64b5451
   depends:
@@ -5787,7 +5787,7 @@ packages:
   license_family: APACHE
   size: 31881
   timestamp: 1699371179971
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-25.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-25.0-py310hecd8cb5_0.tar.bz2
   sha256: abf8ae51761c551fbd56aecbeb899f6bae4001baf0d08a7fad56c344b7894127
   md5: 6e0cfcd89494f5ade395d73e6eec8dd8
   depends:
@@ -5796,14 +5796,14 @@ packages:
   license_family: Apache
   size: 168644
   timestamp: 1753775657823
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandoc-2.12-hecd8cb5_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandoc-2.12-hecd8cb5_3.tar.bz2
   sha256: 0eca2711e91cf2e3595f89380e4ea3069b1e0a2ddc31943bcc9ca4bc92ac67ed
   md5: ef3e53d304f18fbbf26eab22e12dd459
   license: GPL-2.0
   license_family: GPL
   size: 15066232
   timestamp: 1677512250755
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-1.2.3-py310hecd8cb5_0.tar.bz2
   sha256: 4b2d5305590fbf66d22508e1b9ca7afbce87a25f6a1142d6de6b2815c9ba98d1
   md5: dc07447e3ab88d2f1147ccec800be296
   depends:
@@ -5827,7 +5827,7 @@ packages:
   license_family: BSD
   size: 17078623
   timestamp: 1695146541406
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-1.13.0-py310hecd8cb5_0.tar.bz2
   sha256: 08f766f3c49a9b1bd0addb34fb0ce0739d319003aa4d7580d25b8b344b3dac8d
   md5: 7b31c764364be71df61cd206249ccae2
   depends:
@@ -5836,7 +5836,7 @@ packages:
   license_family: BSD
   size: 144060
   timestamp: 1684915450654
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/parso-0.8.4-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/parso-0.8.4-py310hecd8cb5_0.tar.bz2
   sha256: f7ba154156340b9f75545b7d26e5f2cf69f0185d96246819d8f548cd428ecd0c
   md5: fca994a54cf21a6dc314ff792710027d
   depends:
@@ -5845,7 +5845,7 @@ packages:
   license_family: MIT
   size: 179723
   timestamp: 1733963463157
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/partd-1.4.2-py310hecd8cb5_0.tar.bz2
   sha256: a08dc050c9417f9c927f4078d4a9caf36469639d9f7b61dfb22f7d69d68ae273
   md5: 4217cbccb0273e065107ae7987a944de
   depends:
@@ -5859,7 +5859,7 @@ packages:
   license_family: BSD
   size: 37126
   timestamp: 1736803635027
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pcre2-10.42-h9b97e30_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pcre2-10.42-h9b97e30_1.tar.bz2
   sha256: e18ec8727b8f74eb87a3c8945953c97de9b065aabcad272ece12972b854d964c
   md5: 2a4a10038d1f8d6bb80609fdeb0ac324
   depends:
@@ -5869,7 +5869,7 @@ packages:
   license_family: BSD
   size: 3403226
   timestamp: 1714657724735
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pexpect-4.9.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pexpect-4.9.0-py310hecd8cb5_0.tar.bz2
   sha256: b93d16a01da1b7323908eed650cc9e366fef6985b73fd62d139eaabc170df7c1
   md5: 4ad7137b638c5fec97eceaff9cfcdc85
   depends:
@@ -5879,7 +5879,7 @@ packages:
   license_family: Other
   size: 136555
   timestamp: 1750072650728
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-11.3.0-py310h25d8182_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-11.3.0-py310h25d8182_0.tar.bz2
   sha256: 3da3cf725de05b2f4abb11d84c7a8ac86154336b1ae59311e705cb5bbe1676da
   md5: 305f888b1129db4c770da0e5c66880a2
   depends:
@@ -5898,7 +5898,7 @@ packages:
   license_family: Other
   size: 843888
   timestamp: 1752524992655
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pixman-0.46.4-hb254d66_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pixman-0.46.4-hb254d66_0.tar.bz2
   sha256: 7005c05abb43fc40a8ca7084e280cd220ff33435f092620933764f2e3eebf061
   md5: 556ab56a032687ccd6c36c958f68507b
   depends:
@@ -5908,7 +5908,7 @@ packages:
   license_family: MIT
   size: 317220
   timestamp: 1755256461837
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-4.3.7-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-4.3.7-py310hecd8cb5_0.tar.bz2
   sha256: a9e17076739556296626355de84beb7f151fc8d760fc47da4506e5547201b231
   md5: 3c19f5043a072da4c5f106d6cb714b3f
   depends:
@@ -5917,7 +5917,7 @@ packages:
   license_family: MIT
   size: 36747
   timestamp: 1744273202490
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.21.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.21.1-py310hecd8cb5_0.tar.bz2
   sha256: 29f210529d1aec1ac72a3c65e3e6d3e9619d8aef9d5aa08ad2c9acb9d9e72bb9
   md5: ea6b58813b50b69e16c5fbcc443eeba8
   depends:
@@ -5926,7 +5926,7 @@ packages:
   license_family: Apache
   size: 119027
   timestamp: 1744272075296
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py310h46256e1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py310h46256e1_1.tar.bz2
   sha256: dfb4fcd9d82312b2db1ae9969f20e1fc434e497143968465de5240548a82fa24
   md5: 39ac3015ad7072371b661659506629ee
   depends:
@@ -5935,7 +5935,7 @@ packages:
   license_family: BSD
   size: 369973
   timestamp: 1736369641178
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-19.0.0-py310h6d0c2b6_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyarrow-19.0.0-py310h6d0c2b6_1.tar.bz2
   sha256: ade1c9436bb061575ea27413ba7cdbff90c11dcb159438cb3fbf4567c609df64
   md5: 04f94dba87e4facaf732e562d2218041
   depends:
@@ -5948,7 +5948,7 @@ packages:
   license_family: Apache
   size: 7854916
   timestamp: 1738240236612
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py310hecd8cb5_0.tar.bz2
   sha256: 6f28fc0782ff0a1f9f44be058392efcda61a916f4687f0e349c6a0b633154a31
   md5: 89243bf420e88ab976e19b1a91228465
   depends:
@@ -5960,7 +5960,7 @@ packages:
   license_family: BSD
   size: 30981
   timestamp: 1675441597598
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.19.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.19.1-py310hecd8cb5_0.tar.bz2
   sha256: f0a57fe3601d78dcdce5de0b018247c3e7dca5f4ac509bc83b0c86a505bae0e1
   md5: c3fbbcb8ae23361e7c31e243488e5dc1
   depends:
@@ -5969,7 +5969,7 @@ packages:
   license_family: BSD
   size: 1999471
   timestamp: 1744664264223
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.2.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.2.0-py310hecd8cb5_0.tar.bz2
   sha256: 2900f7c5a4239523c79454eb49b084c4878a14663046547b3c23634d213f1828
   md5: f050a05a10a265c4c09705936b9fe3c8
   depends:
@@ -5978,7 +5978,7 @@ packages:
   license_family: MIT
   size: 427323
   timestamp: 1731445863523
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py310hecd8cb5_0.tar.bz2
   sha256: 7e7ad33a42ffc0cf30a64115bbf6a4fb77e6f4ff859b5cdc1c5af35e34a77a36
   md5: 8b1372e62747adb48891711705ecf67c
   depends:
@@ -5987,7 +5987,7 @@ packages:
   license_family: BSD
   size: 28205
   timestamp: 1642536392594
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.10.18-hc958d9f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.10.18-hc958d9f_0.tar.bz2
   sha256: be184972bfebd315eee337e2b81bf1db60414401030a09297dc3c32a7bfecbcc
   md5: a026603c7d0a2d8cfff763af711008dc
   depends:
@@ -6007,7 +6007,7 @@ packages:
   license_family: PSF
   size: 13959734
   timestamp: 1749129690581
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py310hecd8cb5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py310hecd8cb5_2.tar.bz2
   sha256: 7c48377410f36fe4c89693d59a4ade0440dd6fdf16ae1932eb46076efb1f04db
   md5: c70567e92a388519519e994567e2a653
   depends:
@@ -6017,7 +6017,7 @@ packages:
   license_family: BSD
   size: 290910
   timestamp: 1716495929291
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.20.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.20.0-py310hecd8cb5_0.tar.bz2
   sha256: 1824cbd95f76d8180c6de480c6471a685cf490ec52a5391d78f9d154b9b6f381
   md5: cc764d70876d00b055033f9589affac7
   depends:
@@ -6026,7 +6026,7 @@ packages:
   license_family: BSD
   size: 268904
   timestamp: 1731939855247
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-3.2.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-json-logger-3.2.1-py310hecd8cb5_0.tar.bz2
   sha256: 6c5d18562bcd36368005ee163c01769495a1c8cc47a276bd80c8354e7edc914f
   md5: 7f9af140142b85a50eb5bd81c07948ff
   depends:
@@ -6035,7 +6035,7 @@ packages:
   license_family: BSD
   size: 25751
   timestamp: 1734370142498
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.6.2-py310h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-lmdb-1.6.2-py310h6d0c2b6_0.tar.bz2
   sha256: e43f9317dc12ba06dbd6a6a73117d4fca4ef21a223645e0b567d7863038c578b
   md5: 1b402707af511827e9c871d789039006
   depends:
@@ -6045,7 +6045,7 @@ packages:
   license_family: Other
   size: 135996
   timestamp: 1736542261908
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2025.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2025.2-py310hecd8cb5_0.tar.bz2
   sha256: 23fcba29a54e2ac2b2947139288ab1c4856a5051e94fc40096e81dc1e838b731
   md5: 6f790f50660241828b47a2c9802d2321
   depends:
@@ -6054,7 +6054,7 @@ packages:
   license_family: MIT
   size: 273194
   timestamp: 1752135919021
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py310hecd8cb5_0.tar.bz2
   sha256: 75bc3472ad099223406433761e03c124f6cdc66f6b7d1ef12ec3d36534cb7973
   md5: 1dca0ce5eeb9bb9fea1d39d443c393b8
   depends:
@@ -6066,7 +6066,7 @@ packages:
   license_family: BSD
   size: 61754
   timestamp: 1711137017218
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py310h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.2-py310h46256e1_0.tar.bz2
   sha256: e8721601f26109e9779eeb82cfacade26f10f0c389249a91532ff4ccdd573c5d
   md5: e70e174b046cf351add8e693633c6659
   depends:
@@ -6076,7 +6076,7 @@ packages:
   license_family: MIT
   size: 177213
   timestamp: 1728659110037
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py310h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-24.0.1-py310h6c40b1e_0.tar.bz2
   sha256: 585628aeb5d2000ec14e9bd76f8363c00b658a4e0ef9273a1c696f01809219b6
   md5: 9af99dc6230418c58c5ad25843de03c7
   depends:
@@ -6086,7 +6086,7 @@ packages:
   license_family: Other
   size: 506986
   timestamp: 1709318572722
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2024.07.02-h1962661_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/re2-2024.07.02-h1962661_0.tar.bz2
   sha256: dc28e43c897ddc8090794d4d324f444f487427ce21dd4fe66e30e14ac6f035a4
   md5: f0fca2467445f9576db5d51d148bc59f
   depends:
@@ -6095,7 +6095,7 @@ packages:
   license_family: BSD
   size: 25957
   timestamp: 1742313381620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.3-h49f2429_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.3-h49f2429_0.tar.bz2
   sha256: c52e82271868de2e5ad836d2468dc5096e506dbd240c6ed40578360401172998
   md5: f55273b4ccdec25a8ea30dc7bf4ec286
   depends:
@@ -6105,7 +6105,7 @@ packages:
   license_family: GPL
   size: 544215
   timestamp: 1754485725566
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py310hecd8cb5_0.tar.bz2
   sha256: c5e89495acc097c738e4dd7a26cdff24b6aa0ad82d6f0c6b9b3e7db242435894
   md5: 4278d32b0db8529403a6eb55703dc8ef
   depends:
@@ -6116,7 +6116,7 @@ packages:
   license_family: MIT
   size: 59367
   timestamp: 1699012203616
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.4-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.32.4-py310hecd8cb5_0.tar.bz2
   sha256: 89dbd8675bf2b100a1f44fad3da3601914349067a7fb8c9094f13002d2e81603
   md5: f376a44cc5b6363e6c5ed7c7054d0f8d
   depends:
@@ -6132,7 +6132,7 @@ packages:
   license_family: Apache
   size: 147905
   timestamp: 1750426886517
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py310hecd8cb5_0.tar.bz2
   sha256: ecec0cef15dd4d80f2fa892b449e16041dace4ab669617ed9e2e6ee77d0873e4
   md5: 5b3b337fc9f8d9194cbead0e20fa0b99
   depends:
@@ -6142,7 +6142,7 @@ packages:
   license_family: MIT
   size: 9862
   timestamp: 1683077133588
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py310hecd8cb5_0.tar.bz2
   sha256: cc9d506a3f77d20dd2a3fc2567bfb0880a43bb110af639c134e18ec6bdecfaca
   md5: 5ba77c0b6356bda301de8c3d4e45a662
   depends:
@@ -6151,7 +6151,7 @@ packages:
   license_family: MIT
   size: 10239
   timestamp: 1683059221325
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.22.3-py310h83de92b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.22.3-py310h83de92b_0.tar.bz2
   sha256: a1f4c63ab813711a1c33e6fd63f7bff4de835e1c5af8407309ed35b33875a8f1
   md5: 0ab24b411158a63f88fa977de6cd7adc
   depends:
@@ -6162,7 +6162,7 @@ packages:
   license_family: MIT
   size: 369785
   timestamp: 1736546721438
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.15.3-py310h97975f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/scipy-1.15.3-py310h97975f9_0.tar.bz2
   sha256: 6ec7d278acf25122efac4aa2022dc66af163628112bbc6eb38b93ca46af5f62b
   md5: b4653f229b9779eac43cbe8b1d51fb9b
   depends:
@@ -6179,7 +6179,7 @@ packages:
   license_family: BSD
   size: 25318541
   timestamp: 1747238587238
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py310hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py310hecd8cb5_1.tar.bz2
   sha256: d5d38365836cadf3281852d707362ffbc6a980e28843b94ee3423b63ab73820b
   md5: 7ea5c662bf9d269fc90ba37813eac5ad
   depends:
@@ -6188,7 +6188,7 @@ packages:
   license_family: BSD
   size: 28461
   timestamp: 1736543367399
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-78.1.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-78.1.1-py310hecd8cb5_0.tar.bz2
   sha256: 879fe62859d69224d91d336cad00f7d19d4532246254b223981f5443278629ed
   md5: 0a444642ddca99901e21e9f7f8c44be7
   depends:
@@ -6197,7 +6197,7 @@ packages:
   license_family: MIT
   size: 1807442
   timestamp: 1746025469825
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/six-1.17.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/six-1.17.0-py310hecd8cb5_0.tar.bz2
   sha256: d0426afff8b3ac82aeda0633b2724490524d32af487530b4d7e749898712b4a8
   md5: d2e50f651fb4c9e03e584bed9e9fb468
   depends:
@@ -6206,7 +6206,7 @@ packages:
   license_family: MIT
   size: 32827
   timestamp: 1744271837902
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
   sha256: 9eaab5afd89c87ca139915589626785039fac30f05f8fb19e9eefe27eb935ce6
   md5: babdcd3370f85ded3d313902dcebecfb
   depends:
@@ -6215,7 +6215,7 @@ packages:
   license_family: BSD
   size: 46224
   timestamp: 1723557464934
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py310hecd8cb5_0.tar.bz2
   sha256: e0b8413f1bebc17ea35f3b4bc1e6a28dcc69db7f791ea80d31bfa8bdbd99023d
   md5: 9c9a20ac1397b11a4ffa611d253f83a4
   depends:
@@ -6224,7 +6224,7 @@ packages:
   license_family: Other
   size: 17891
   timestamp: 1705431327614
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py310hecd8cb5_0.tar.bz2
   sha256: 97a6ef8790155b089dc6c1c7559cac226dc8966fb7189276d43e56361fef921b
   md5: c5fe7f5450316dd0f7c407fc6d5c4590
   depends:
@@ -6233,7 +6233,7 @@ packages:
   license_family: MIT
   size: 67950
   timestamp: 1696347655636
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.50.2-hc8b0dd6_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.50.2-hc8b0dd6_1.tar.bz2
   sha256: 5311229c22218bbf87ba01e50defb5a8de514e405a91f7e59574230824cb6d83
   md5: 31cf95da9abaa8b074c16cc23fa27537
   depends:
@@ -6246,7 +6246,7 @@ packages:
   license_family: Other
   size: 1766409
   timestamp: 1752773664751
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -6255,7 +6255,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tblib-3.1.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tblib-3.1.0-py310hecd8cb5_0.tar.bz2
   sha256: 988476806eee1c92268c034d37cd01bbb8f4c60391cb700a257bfa0812af3d58
   md5: 72ee2b8fe8cfb8727d5e0e7b9a6df579
   depends:
@@ -6264,7 +6264,7 @@ packages:
   license_family: BSD
   size: 26813
   timestamp: 1749730032727
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py310hecd8cb5_0.tar.bz2
   sha256: 92b0454b4739557af9a8f52f040828cb343935e874144e25eebf620be61cfb85
   md5: 39fb00364e1ae13b9fc9af51c0540648
   depends:
@@ -6275,7 +6275,7 @@ packages:
   license_family: BSD
   size: 31114
   timestamp: 1671751965362
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.4.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.4.0-py310hecd8cb5_0.tar.bz2
   sha256: d29027de113f7435ab5cccc3453e31fb957077f48d89749b22a755a85f402df7
   md5: e389ae44710b71bfcc408c94a714cf49
   depends:
@@ -6285,7 +6285,7 @@ packages:
   license_family: BSD
   size: 93516
   timestamp: 1738340133842
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.15-h3a5a201_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.15-h3a5a201_0.tar.bz2
   sha256: 54c8b3a35c5460310938e410d702270d074fc47148eca783d179caa15a4211ee
   md5: 4b6f17480d699587812e55f1c6472f95
   depends:
@@ -6295,7 +6295,7 @@ packages:
   license_family: BSD
   size: 3652025
   timestamp: 1755243942533
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-1.0.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/toolz-1.0.0-py310hecd8cb5_0.tar.bz2
   sha256: aa3af456242e77190eccc22e48274bfad613414959a11860812475818f902aaf
   md5: 917e5116fac39e63824fb26f9abafb2f
   depends:
@@ -6304,7 +6304,7 @@ packages:
   license_family: BSD
   size: 107153
   timestamp: 1736796469698
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.5.1-py310h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.5.1-py310h46256e1_0.tar.bz2
   sha256: a97ba60d8394dbf6eac9ce884487245f786fb8d02afd21b01146973cd1c1dd11
   md5: cb674ea8ceef2162d730c43e17c640a7
   depends:
@@ -6313,7 +6313,7 @@ packages:
   license_family: Apache
   size: 714681
   timestamp: 1748957006646
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.67.1-py310h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.67.1-py310h20db666_0.tar.bz2
   sha256: c7b4e8267ecf53dbfb3bcd6b1d8a7b71dc3ba6bdde2dc953a2d96f31ba1ec29f
   md5: 0659d7a3dead5448e30616dd6f75526a
   depends:
@@ -6324,7 +6324,7 @@ packages:
   license_family: MOZILLA
   size: 128956
   timestamp: 1738946277961
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.14.3-py310hecd8cb5_0.tar.bz2
   sha256: dda3761c9a87fd90628b32cc8827587856783f9df3afc59d2f412b704fce6a48
   md5: 9f14e3c1632913c7cfec1d02df9efca0
   depends:
@@ -6333,7 +6333,7 @@ packages:
   license_family: BSD
   size: 168327
   timestamp: 1718227095682
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.12.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.12.2-py310hecd8cb5_0.tar.bz2
   sha256: 7d1f74307d5d734b8c9097ebc2d3479c66a0a9357ac0285cda523e29be7e20c2
   md5: e60873d80e41c4982c942e51ce32909a
   depends:
@@ -6343,7 +6343,7 @@ packages:
   license_family: PSF
   size: 10061
   timestamp: 1734715076387
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.12.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.12.2-py310hecd8cb5_0.tar.bz2
   sha256: 7a5935df5c79028631aea7bb1b3acc0246603f9a728c3d58314bb64f31601ec7
   md5: e50cdd4fc03177771c32ccff779845bf
   depends:
@@ -6352,7 +6352,7 @@ packages:
   license_family: PSF
   size: 66246
   timestamp: 1734715070548
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py310hecd8cb5_0.tar.bz2
   sha256: 7669c43d362b42ed8c5d52c9660420df67f8f4ce59194d95c038b01b66f085d1
   md5: 62dcb988e38541d7073093a64453dbb4
   depends:
@@ -6361,7 +6361,7 @@ packages:
   license_family: MIT
   size: 11601
   timestamp: 1659769547734
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py310h46256e1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py310h46256e1_1.tar.bz2
   sha256: f6f8782a5819de11bda699f33fba2fe021cb649b6159eee23fc34a63c7eff5c1
   md5: 670d37976f4ff25b3493f251cbd58290
   depends:
@@ -6370,7 +6370,7 @@ packages:
   license_family: Apache
   size: 499079
   timestamp: 1736544528316
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.5.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-2.5.0-py310hecd8cb5_0.tar.bz2
   sha256: 47c794f8d516c71124129b3cedbc70fe9ec6e4b0e2bdc58eabd412f3263bde12
   md5: 018d47ae2923ae3696c75c585cd708f1
   depends:
@@ -6384,14 +6384,14 @@ packages:
   license_family: MIT
   size: 299892
   timestamp: 1750776005248
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
   sha256: 0f8c3eb254be9c1957e748e385e20e62509d11052990c4755012be62434c9129
   md5: 53229ba93f6e38308ae42ecfc6eaad9d
   license: MIT
   license_family: MIT
   size: 96768
   timestamp: 1706894705048
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wcwidth-0.2.13-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wcwidth-0.2.13-py310hecd8cb5_0.tar.bz2
   sha256: ccbce44a46406c34cae232cf6c3236685d92f2ed0f988741e71b32ae6b5193ff
   md5: df3a9f552c35e5dcab7624bfe78bdf5b
   depends:
@@ -6400,7 +6400,7 @@ packages:
   license_family: MIT
   size: 79225
   timestamp: 1750353281400
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py310hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py310hecd8cb5_1.tar.bz2
   sha256: aae85a1650806382831d1edd5b7e8912329c2d5859dd63258f2b422d0bee1761
   md5: 7502e3b07c9f996017a9171d056b3865
   depends:
@@ -6409,7 +6409,7 @@ packages:
   license_family: BSD
   size: 21319
   timestamp: 1642539070002
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py310hecd8cb5_0.tar.bz2
   sha256: df09c3d9eb682cfb34e3d892d1a8dafe3a4b252b18cc6539c8f1c331b1a72a39
   md5: 6632d513deb34751cfee6129f71ab6d1
   depends:
@@ -6418,7 +6418,7 @@ packages:
   license_family: Apache
   size: 88313
   timestamp: 1715878355449
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.45.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.45.1-py310hecd8cb5_0.tar.bz2
   sha256: 81167843a2e44d893a2133da83739f3c2e32dfd9b9e2895df39714583e6ed966
   md5: 5500aa5ed79cc8588872dfeabf40b458
   depends:
@@ -6427,7 +6427,7 @@ packages:
   license_family: MIT
   size: 111866
   timestamp: 1737991632950
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py310hecd8cb5_0.tar.bz2
   sha256: 1c101b0f6db62313e4d845ccbec9256e97a01b3a9bebb84174c6bd5a302ba809
   md5: 3490e2adaefd69ec35a5f0eefa902ef7
   depends:
@@ -6439,7 +6439,7 @@ packages:
   license_family: Apache
   size: 1812032
   timestamp: 1689041517180
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py310hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py310hecd8cb5_1.tar.bz2
   sha256: b7c324c44d31162d3ae297d38d95157f1d8b27c8dd6de2ee369e2426eb1c7d67
   md5: cb55c97b4ce01dec47958aefa7845582
   depends:
@@ -6448,20 +6448,20 @@ packages:
   license_family: BSD
   size: 49600
   timestamp: 1675159097509
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.6.4-h46256e1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.6.4-h46256e1_1.tar.bz2
   sha256: c46b5b4e5159739c03830541c7261691d556a897ddabdf1a4024fe40d22bdefe
   md5: 5a0422426246e10734acfb8dd2b9fac6
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 286200
   timestamp: 1739468347605
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
   sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
   md5: c25b6d40f834647d0bbe767f6c776031
   depends:
@@ -6471,7 +6471,7 @@ packages:
   license_family: Other
   size: 329449
   timestamp: 1705602140856
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zict-3.0.0-py310hecd8cb5_0.tar.bz2
   sha256: 5a12afd890a62af36fa68990182fec6ce14a15836b0985ba5efcaf477e374368
   md5: ab35b58320c81d4687504c7f6ec1d107
   depends:
@@ -6482,7 +6482,7 @@ packages:
   license_family: BSD
   size: 78791
   timestamp: 1695832967750
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.21.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.21.0-py310hecd8cb5_0.tar.bz2
   sha256: 39093c8982b24650d28be1ff138fedf7eb3ffc6f904ddd227f56b9d28241fedf
   md5: 602a7d8d4582fe29d24e4cd02f09eb01
   depends:
@@ -6491,14 +6491,14 @@ packages:
   license_family: MIT
   size: 26953
   timestamp: 1732630810165
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
   sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
   md5: f2519b551f99765d9d98950c5e2b4713
   license: Zlib
   license_family: Other
   size: 119782
   timestamp: 1714511811597
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
   sha256: a1f470eabe211500d2ec7866ecf421c067f159045f0245f19e9ba8272c5a177e
   md5: f8bd5fb9fac17a47c64ae56355faba24
   depends:
@@ -6509,7 +6509,7 @@ packages:
   license_family: BSD
   size: 1033188
   timestamp: 1728487057684
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.10.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.10.0-py310hca03da5_0.tar.bz2
   sha256: c4b5fd397d14ed2d6df8c5234111dadee4b74e70803d30a282294043f05b894f
   md5: d943073a1944b389d6f9ee2ebb872cef
   depends:
@@ -6525,7 +6525,7 @@ packages:
   license_family: MIT
   size: 239915
   timestamp: 1758623432239
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aom-3.12.1-ha237518_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aom-3.12.1-ha237518_0.tar.bz2
   sha256: 79f552871db4783edccced363e93cb97435416987172648b990e83344a2b6e4f
   md5: c9cc75d00521b3feb03c42bd94a086b7
   depends:
@@ -6535,7 +6535,7 @@ packages:
   license_family: BSD
   size: 2869476
   timestamp: 1754917631646
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.4-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.4-py310hca03da5_0.tar.bz2
   sha256: 28658d79a8ee2c4a6c56da614199dd6ec3c9500d2b54fc6f29af216a324ef886
   md5: bd11d61b23646d3417d6af5f53b16c64
   depends:
@@ -6544,7 +6544,7 @@ packages:
   license_family: BSD
   size: 14108
   timestamp: 1750774892344
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-25.1.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-25.1.0-py310hca03da5_0.tar.bz2
   sha256: 8c173f247fa0e90818f38f4384660d2ad8be71f1f5a65b36da97ab4bbdc51031
   md5: 1c479cc5a3a5d2ae315c4974f4c7b896
   depends:
@@ -6556,7 +6556,7 @@ packages:
   license_family: MIT
   size: 29895
   timestamp: 1766067842566
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-25.1.0-py310h254cc4a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-25.1.0-py310h254cc4a_0.tar.bz2
   sha256: f12d534cb21bf0415f3a877f098720143252554e2140e64b7ddb1a7bcb3989ff
   md5: ad1c0838d5b185a23762742d2a7d1941
   depends:
@@ -6567,7 +6567,7 @@ packages:
   license_family: MIT
   size: 34390
   timestamp: 1757924888870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-21.0.0-hc027f7d_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/arrow-cpp-21.0.0-hc027f7d_2.tar.bz2
   sha256: 1ceddc438be2d9fb229184abaed4ca658f11e1ffc155133cff74dfe2ca9a2486
   md5: ba5e8bdf9b4cdd7db528f8afcc18e5e8
   depends:
@@ -6596,7 +6596,7 @@ packages:
   license_family: Apache
   size: 10807131
   timestamp: 1766073785214
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/asttokens-3.0.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/asttokens-3.0.0-py310hca03da5_0.tar.bz2
   sha256: dac76910bf0b466fb69f1c319fce5c452d3a9b29ddff3ef08c54fd11eeefa44c
   md5: c730feef0907ab3e8aba7f2b798d131b
   depends:
@@ -6607,7 +6607,7 @@ packages:
   license_family: Apache
   size: 42600
   timestamp: 1743630474730
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-25.4.0-py310hca03da5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-25.4.0-py310hca03da5_2.tar.bz2
   sha256: 89b7466fc0dbfefc4eec4433ccf98328ae852b60e1b5247bf9c5a823ad19f19a
   md5: ba1b0fcf9e8b79c14036ac83f7f0f234
   depends:
@@ -6616,7 +6616,7 @@ packages:
   license_family: MIT
   size: 147989
   timestamp: 1762356911308
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-auth-0.9.0-h79febb2_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-auth-0.9.0-h79febb2_2.tar.bz2
   sha256: e58d2ea9caa584df650a24543ca1f54c1e16778d8c6570ceb6b2137a148d6252
   md5: 08ebe096b6f9bf86873885791ec05c01
   depends:
@@ -6630,7 +6630,7 @@ packages:
   license_family: Apache
   size: 104047
   timestamp: 1756801724494
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-cal-0.9.2-h79febb2_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-cal-0.9.2-h79febb2_1.tar.bz2
   sha256: ab497b92dafd089f2629103fc0677c9452b4c390e18eb43007e8dd8e0ab68fa8
   md5: abcda967af4749911b88c1e25ceb6d2b
   depends:
@@ -6640,7 +6640,7 @@ packages:
   license_family: Apache
   size: 46403
   timestamp: 1756730573239
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.12.4-h79febb2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-common-0.12.4-h79febb2_0.tar.bz2
   sha256: 969feab675d48144eee60f7aa6b731a516769d853fe02cc46e7baef0517ba3d9
   md5: 597fb9544356279405db55808e24aabd
   depends:
@@ -6649,7 +6649,7 @@ packages:
   license_family: Apache
   size: 236969
   timestamp: 1756721626554
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-compression-0.3.1-h79febb2_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-compression-0.3.1-h79febb2_2.tar.bz2
   sha256: 0e079411b1dc8970c9e7407064cf64339b09ac8981cbae1b212545563fb4b2fb
   md5: 115586f5b399e8552e1ba0ad06048cfe
   depends:
@@ -6659,7 +6659,7 @@ packages:
   license_family: Apache
   size: 20227
   timestamp: 1756734195919
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.5.6-h79febb2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-event-stream-0.5.6-h79febb2_0.tar.bz2
   sha256: 3ed938b9ce0d0aa39f56313bbfef27d6dd95866df27a43473bbc229eba821e09
   md5: fcd436a40bcd779f49df65d68875c4c9
   depends:
@@ -6671,7 +6671,7 @@ packages:
   license_family: Apache
   size: 52287
   timestamp: 1756758196659
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-http-0.10.4-h79febb2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-http-0.10.4-h79febb2_0.tar.bz2
   sha256: 89d387df3a34e1ae4334a371e7cdcb8485a4e24c59e36e633412b66f0f29ac23
   md5: f89a68ff62ebe085116ef76c13aff54e
   depends:
@@ -6684,7 +6684,7 @@ packages:
   license_family: Apache
   size: 180034
   timestamp: 1756758208457
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-io-0.21.4-h79febb2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-io-0.21.4-h79febb2_0.tar.bz2
   sha256: a47df9261a3059ef5099717655a2af0290f90d128cfebe331747afd394bc686d
   md5: 99f20a7ee41c1921cab3d4195cb5bfa6
   depends:
@@ -6695,7 +6695,7 @@ packages:
   license_family: Apache
   size: 171178
   timestamp: 1756734350358
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-mqtt-0.13.3-h387b88a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-mqtt-0.13.3-h387b88a_0.tar.bz2
   sha256: 2914081a3bc97a5b681fd105e848292a1d141e3fdd325226fd3c57dd33fc4b09
   md5: b28e8c725662d459b290bc077627a2e2
   depends:
@@ -6707,7 +6707,7 @@ packages:
   license_family: Apache
   size: 180341
   timestamp: 1756801745396
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-s3-0.8.7-h79febb2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-s3-0.8.7-h79febb2_0.tar.bz2
   sha256: 340b21fc5a853ca36b5d93351423ff4976bdcaf82a28270c87fd10fb541970dc
   md5: f8c80bbab373976425783a84e442dbc0
   depends:
@@ -6722,7 +6722,7 @@ packages:
   license_family: Apache
   size: 113931
   timestamp: 1756803951772
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-sdkutils-0.2.4-h79febb2_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-sdkutils-0.2.4-h79febb2_1.tar.bz2
   sha256: a8f68e1d5f9f82b23e644d1bee3462d4ad44e881b605897a21328c1e8c782444
   md5: f1f952a9a62432f43f2fddf65e00bd42
   depends:
@@ -6732,7 +6732,7 @@ packages:
   license_family: Apache
   size: 55465
   timestamp: 1756730733896
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.2.7-h79febb2_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-checksums-0.2.7-h79febb2_1.tar.bz2
   sha256: 593ac7e6b00ad25d1c6d616a70bde41c37bf3671991ae07500d6d6be90eb1c39
   md5: ba01addb9b493090d50617bbf6f5f91d
   depends:
@@ -6742,7 +6742,7 @@ packages:
   license_family: Apache
   size: 78629
   timestamp: 1756730921033
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-crt-cpp-0.34.0-hee39554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-crt-cpp-0.34.0-hee39554_0.tar.bz2
   sha256: 1d7b424e0acb26f4e00d2d8513063bf1cac2d22421c04ffdce28dff9510ca934
   md5: 314e9583ed922e388959b864658cfd0f
   depends:
@@ -6762,7 +6762,7 @@ packages:
   license_family: Apache
   size: 354570
   timestamp: 1756806714995
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.11.638-h35fa3df_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-sdk-cpp-1.11.638-h35fa3df_0.tar.bz2
   sha256: 7a3a600335e070a16e732af8e5e022d8f072a1e888918eb4a471fcbd12762ac3
   md5: 01bc21fbf9f74b0df62c4e97462eef32
   depends:
@@ -6777,7 +6777,7 @@ packages:
   license_family: Apache
   size: 3778934
   timestamp: 1756812349648
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.14.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.14.2-py310hca03da5_0.tar.bz2
   sha256: 882cf96799e70998e3a8740d73ee70e06f2208fcf05da492507eea441258e127
   md5: 71b570513fad15a429da7f9ee4055bee
   depends:
@@ -6788,12 +6788,12 @@ packages:
   license_family: MIT
   size: 216287
   timestamp: 1764159508299
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bleach-6.3.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bleach-6.3.0-py310hca03da5_0.tar.bz2
   sha256: 45c601638b4a6bae6f71f837cf1029f171f60ad5678957869282a956f580e757
   md5: 5279645ba256e1f66eb0d2a3c94cde19
   depends:
@@ -6806,7 +6806,7 @@ packages:
   license_family: Apache
   size: 82797
   timestamp: 1764153588663
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py310h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.2.1-py310h33ce5c2_0.tar.bz2
   sha256: b0f9f35148a0c19833db161db41322512880a3fc7ea5853745864122650d0117
   md5: d199b3fbf3bcf4b165bb779aca7ad26c
   depends:
@@ -6824,7 +6824,7 @@ packages:
   license_family: BSD
   size: 6476634
   timestamp: 1690546122888
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotlicffi-1.2.0.0-py310h50f4ffc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotlicffi-1.2.0.0-py310h50f4ffc_0.tar.bz2
   sha256: 93a21f3dcc1b94ac80b86ad48191a70409887e21ecb16da8818c24519fbc0071
   md5: ae23e701a1aa25394b2e527bd7aa3eba
   depends:
@@ -6836,14 +6836,14 @@ packages:
   license_family: MIT
   size: 430061
   timestamp: 1764961200905
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
   sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
   md5: 56d1386c7f1f338f0d18f82af6525273
   license: bzip2-1.0.8
   license_family: BSD
   size: 158748
   timestamp: 1714510571033
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.34.5-h2ca31fc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/c-ares-1.34.5-h2ca31fc_0.tar.bz2
   sha256: 3bbd4f2259c370c72e3af3e4664b4755890581a06077446190530ae149880cd7
   md5: 383f8208f4e5fa7038704823ada319f8
   depends:
@@ -6853,14 +6853,14 @@ packages:
   license_family: MIT
   size: 190299
   timestamp: 1756141933569
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2025.12.2-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2025.12.2-hca03da5_0.tar.bz2
   sha256: 1083c19fbd27a92f84c2bf5fa4c24e849677e94f1cd39c11ec2cc41d0afddc53
   md5: 2b15e4d759711c1ebe4c688ab4bd50ef
   license: MPL-2.0
   license_family: Other
   size: 135036
   timestamp: 1764713818379
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cairo-1.18.4-h191e429_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cairo-1.18.4-h191e429_0.tar.bz2
   sha256: 7a77249506242f7f6489686e8d3d066e9324cafe36334549ac80f01d35c4df48
   md5: c062ce1b28b012153da845b80783037c
   depends:
@@ -6875,7 +6875,7 @@ packages:
   license_family: LGPL
   size: 652115
   timestamp: 1756136709395
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2026.01.04-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2026.01.04-py310hca03da5_0.tar.bz2
   sha256: ca86028ad52392d5a3f673e42c3c851dcf94a8debb5ea123f685c07d1707272e
   md5: 81bdb095bb6838293d3ac6df09dc5537
   depends:
@@ -6884,7 +6884,7 @@ packages:
   license_family: Other
   size: 154134
   timestamp: 1767659162459
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-2.0.0-py310h73c2a22_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-2.0.0-py310h73c2a22_1.tar.bz2
   sha256: 227b22b9f8ecf7e0d06a63ee1412c5bb8ffa64461b06e5dcd289b2a7e1001fbb
   md5: 938b05bd1ccff72adc471f9bd95ebcae
   depends:
@@ -6896,7 +6896,7 @@ packages:
   license_family: MIT
   size: 236977
   timestamp: 1761832805842
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/charset-normalizer-3.4.4-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/charset-normalizer-3.4.4-py310hca03da5_0.tar.bz2
   sha256: 72a7e1d39e7dc309367f183f49be99612c1e192825da666e7a829cb96e0ff49b
   md5: 678b345524b733c39690084401e173a4
   depends:
@@ -6905,7 +6905,7 @@ packages:
   license_family: MIT
   size: 84369
   timestamp: 1761744861829
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.2.1-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/click-8.2.1-py310hca03da5_1.tar.bz2
   sha256: f363ea14e21deb3b3782e410c6287e9ae1d0a45f66481bfc37f39bebca3faa05
   md5: 1d5f2d52bd470c6e8bea78e2ed409473
   depends:
@@ -6914,7 +6914,7 @@ packages:
   license_family: BSD
   size: 283568
   timestamp: 1764332259310
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.1.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-3.1.2-py310hca03da5_0.tar.bz2
   sha256: 3f4449089a05dc5f866904773b8a9fd7b5ab9e254855d08a703162c05b785de8
   md5: a44129d24259cd940e9e2a0e9efc60e8
   depends:
@@ -6923,7 +6923,7 @@ packages:
   license_family: BSD
   size: 64525
   timestamp: 1764930370640
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py310hca03da5_0.tar.bz2
   sha256: 227fe006de1e483775d205cad12d909da267c42a328fae304b8ebf9fbf5818cf
   md5: 4f0ced86c3e12c6ae37bbb69ae883468
   depends:
@@ -6932,7 +6932,7 @@ packages:
   license_family: CC
   size: 495012
   timestamp: 1709758412929
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.3-py310hca03da5_0.tar.bz2
   sha256: 78441525b2291b511a889079a69bbaecb9aee5f7b3b1efa3d6bb06a29c6e1b31
   md5: 3079b844d92ec9469435c08ec4869fe7
   depends:
@@ -6941,7 +6941,7 @@ packages:
   license_family: BSD
   size: 14812
   timestamp: 1763119174254
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.3.1-py310h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.3.1-py310h48ca7d4_0.tar.bz2
   sha256: 95282a2e74d7369fdf21e98189bdf1d662ba779679f01ca9fcfc32c018c59d25
   md5: 4250cc6830136878e70342948f049b6f
   depends:
@@ -6952,7 +6952,7 @@ packages:
   license_family: BSD
   size: 279657
   timestamp: 1732540233373
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cramjam-2.11.0-py310h6fe787a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cramjam-2.11.0-py310h6fe787a_0.tar.bz2
   sha256: 9a317ced18e6916ca59a4e7361d88558a4ffb0948d0085e5e0cd49c061ddb5b6
   md5: 3fc1092cc740787e46e558d5ec7b687c
   depends:
@@ -6962,7 +6962,7 @@ packages:
   license_family: MIT
   size: 1765182
   timestamp: 1762433072542
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cycler-0.12.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cycler-0.12.1-py310hca03da5_0.tar.bz2
   sha256: f0d8372a6762e3cca23b18a5d2450f35623a99c23d96cbe4485aeecc52b151e3
   md5: c3c7653aaa14370208a12330a56f2273
   depends:
@@ -6971,7 +6971,7 @@ packages:
   license_family: BSD
   size: 17140
   timestamp: 1766067958754
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-1.1.0-py310haa24f5a_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cytoolz-1.1.0-py310haa24f5a_1.tar.bz2
   sha256: 37155497ab1eae8e532ba044ac6683f8a3a4200310b09b31d298f89beaf2d9e3
   md5: 00ff5628c07800c824314b687ca1a83c
   depends:
@@ -6984,7 +6984,7 @@ packages:
   license_family: BSD
   size: 825914
   timestamp: 1764692874968
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.15.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/datashader-0.15.1-py310hca03da5_0.tar.bz2
   sha256: 0d5a57908c4a77480ea47747206f2f24d923cb61e4c43aa9e3250ca58ea12a3c
   md5: 711b2ae78257f2233e50943703f9a994
   depends:
@@ -7006,7 +7006,7 @@ packages:
   license_family: BSD
   size: 17665724
   timestamp: 1689587754855
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/datashape-0.5.4-py310hca03da5_1.tar.bz2
   sha256: b34be91d041bb250d2f03fd4e995b08c5768272137c69c4c067a3e2d00cba1f5
   md5: ab843d7bc0da8dcf38f8ac133b9827be
   depends:
@@ -7018,14 +7018,14 @@ packages:
   license_family: BSD
   size: 104228
   timestamp: 1643973184510
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dav1d-1.2.1-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/dav1d-1.2.1-h80987f9_0.tar.bz2
   sha256: cdc3829b4dacd2c09ffcea509947b99dbe12eff4c9fd5f0d412795e2d3648b04
   md5: cb80d50ff320b1865a31c59c9602ea4b
   license: BSD-2-Clause
   license_family: BSD
   size: 397700
   timestamp: 1688746000695
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.8.16-py310h50f4ffc_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.8.16-py310h50f4ffc_1.tar.bz2
   sha256: 618057eedf293fe2fb6bdb5f2be960b22dbc03342f9a987f6f840d0fe1facacc
   md5: 04960331a0d78373d183c5dde15a4d94
   depends:
@@ -7036,7 +7036,7 @@ packages:
   license_family: MIT
   size: 2628404
   timestamp: 1762421685312
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/decorator-5.2.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/decorator-5.2.1-py310hca03da5_0.tar.bz2
   sha256: 16e8cbba884c360b1a8c2c70a441dff5f29baa3903d83bcc48d26d08b335e6d9
   md5: fbc1ae312a953912716ecf80f97dba3e
   depends:
@@ -7045,7 +7045,7 @@ packages:
   license_family: BSD
   size: 36036
   timestamp: 1757341256453
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py310hca03da5_0.tar.bz2
   sha256: 1d532b889e0e71fe68f59e0fd328fe4c42c11660de3a32a0e31fe149f02a3eb5
   md5: f5ec34d95710f724fd4b4c064ed0abcd
   depends:
@@ -7054,7 +7054,7 @@ packages:
   license_family: MIT
   size: 15257
   timestamp: 1650293833649
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.3.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.3.0-py310hca03da5_0.tar.bz2
   sha256: c6982aa40584379b0b6654b2f04937455ecab79adab7501620b3c9e7c3e62345
   md5: 39794daa82fa0d2332b8f59b5f4236a1
   depends:
@@ -7064,7 +7064,7 @@ packages:
   license_family: MIT
   size: 39801
   timestamp: 1761560378167
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/executing-2.2.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/executing-2.2.1-py310hca03da5_0.tar.bz2
   sha256: fcca7fce19e95faee717484dcdc4e4ba73f590d5d9230c4d4d937a0270afd02b
   md5: 342fc164589193f2bba5804b8d6e381c
   depends:
@@ -7073,7 +7073,7 @@ packages:
   license_family: MIT
   size: 840787
   timestamp: 1757061255001
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/expat-2.7.3-h50f4ffc_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/expat-2.7.3-h50f4ffc_4.tar.bz2
   sha256: 06f70e6fd587c4af48a22ea484488c8c010cbe271aeba680c18430c27e01111e
   md5: 5ac841489cce930929d2c645ee46962a
   depends:
@@ -7084,7 +7084,7 @@ packages:
   license_family: MIT
   size: 21722
   timestamp: 1765208110863
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-2025.12.0-py310h03d0aa3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fastparquet-2025.12.0-py310h03d0aa3_0.tar.bz2
   sha256: 069d1bc27cd0cef704a1deabefcd4dbf0e4b7e631aa650c72089432e380a891c
   md5: 91b6edeff7ba247fde1e0d7936afbc99
   depends:
@@ -7099,7 +7099,7 @@ packages:
   license_family: Apache
   size: 639411
   timestamp: 1767955453222
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fontconfig-2.15.0-h29935d0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fontconfig-2.15.0-h29935d0_0.tar.bz2
   sha256: 0c9d906d3ae6a0e06c43e96179479aba91b329e116652920aaca57c27069d5a8
   md5: 383eb3d8ab46fbb3a6463f12062ee4f5
   depends:
@@ -7112,7 +7112,7 @@ packages:
   license_family: MIT
   size: 288789
   timestamp: 1759153863923
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.61.0-py310haa24f5a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.61.0-py310haa24f5a_0.tar.bz2
   sha256: 0ccecfdd93e7a85f89f419427bc8ec56c4e1570dc4f3d328a4faa38fd4337b34
   md5: 9d7c6b1cf6173ae5cc5e4df61b1bd61d
   depends:
@@ -7130,7 +7130,7 @@ packages:
   license_family: MIT
   size: 5187737
   timestamp: 1765445239804
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.13.3-h47d26ad_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.13.3-h47d26ad_0.tar.bz2
   sha256: 4a2d6a43554c8e979add8b233706697c8216db1e4b793b5cd89a36d160813651
   md5: 06993a434722239b6dad560bd10be839
   depends:
@@ -7140,7 +7140,7 @@ packages:
   license_family: Other
   size: 901356
   timestamp: 1743636674921
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fribidi-1.0.16-h8859324_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fribidi-1.0.16-h8859324_0.tar.bz2
   sha256: 95f3be9ed9936c88fe5facc58ed5e5e89d6b2dba4c16474f705ce76589c4d7d2
   md5: 776e35afcdd937d7a1141e82f8a0971d
   depends:
@@ -7148,7 +7148,7 @@ packages:
   license: LGPL-2.1
   size: 62403
   timestamp: 1768428376416
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2026.1.0-py310h7eb115d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2026.1.0-py310h7eb115d_0.tar.bz2
   sha256: 3255875354b4f3d209aabf96d3d2d0952c1257590ca89cb72e4915f00b201999
   md5: 5cddb2a1255529085d61844c1f2d0764
   depends:
@@ -7162,7 +7162,7 @@ packages:
   license_family: BSD
   size: 571265
   timestamp: 1768898134705
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-0.21.0-hbdbcc25_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/gettext-0.21.0-hbdbcc25_2.tar.bz2
   sha256: a9703c804e8377c081602e701536bb9ee3e45d73682ed991d4ab89b512f4dd6b
   md5: f2541033cfec7a7244448619f81a5b0d
   depends:
@@ -7175,7 +7175,7 @@ packages:
   license_family: GPL
   size: 3546065
   timestamp: 1722922815248
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
   sha256: 25e05b93a99914a5fd1a298a2c5b25479fbd571b0db9caa7c6ad4336f060f62c
   md5: e213b68bb0274e0e54c610a041e059f5
   depends:
@@ -7184,7 +7184,7 @@ packages:
   license_family: BSD
   size: 150168
   timestamp: 1706888198288
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
   sha256: bbbcf47ef9249635b5199be1414b0b59687cc04ea9630d50ecc609dc200c095e
   md5: 5820c373d6847a68551cadb8984a8277
   depends:
@@ -7194,7 +7194,7 @@ packages:
   license_family: BSD
   size: 95638
   timestamp: 1706895270850
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/graphite2-1.3.14-hc377ac9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/graphite2-1.3.14-hc377ac9_1.tar.bz2
   sha256: eda72845d574c722f8c2912d9e60bd95092691de92ccf90a9184d05b459ddbf4
   md5: d5a91162086ce20929bff85220aa26ba
   depends:
@@ -7203,7 +7203,7 @@ packages:
   license_family: LGPL
   size: 82282
   timestamp: 1654175384566
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/harfbuzz-10.2.0-he637ebf_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/harfbuzz-10.2.0-he637ebf_1.tar.bz2
   sha256: dffc233275fadb16612f0b0eeba97f8daa285821729d83d8c7d2d68f64599e3a
   md5: 3f97af46d370ee250dc9e2abb552c081
   depends:
@@ -7217,7 +7217,7 @@ packages:
   license_family: MIT
   size: 2679539
   timestamp: 1748952137021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.16.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.16.0-py310hca03da5_0.tar.bz2
   sha256: 005656499e7971d24aaf39eedb46e149c990549fd3d40da31dae3e7f39cd91e8
   md5: 7c7f7a16ca020ef4eb0f6b270aee2d2e
   depends:
@@ -7234,7 +7234,7 @@ packages:
   license_family: BSD
   size: 4608554
   timestamp: 1684937085659
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
   sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
   md5: 69eb3b03765627b6159ed23cdde78396
   depends:
@@ -7243,7 +7243,7 @@ packages:
   license_family: MIT
   size: 28399065
   timestamp: 1692293207812
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.11-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.11-py310hca03da5_0.tar.bz2
   sha256: 4a535b1aa180eeab57c5e3f866134d5dca4b02d87f5282145cf6b98afbc71736
   md5: 6c89cd68d9bbfddc40a7db8e5d0d708f
   depends:
@@ -7252,7 +7252,7 @@ packages:
   license_family: BSD
   size: 239221
   timestamp: 1761912023379
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-8.7.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-8.7.0-py310hca03da5_0.tar.bz2
   sha256: f97ead44962e3bc7d2f4ed92fbce24d0306f43e0c8fedd7c6fc8c3d91cd71141
   md5: 297f2ebf3d0c97f7c1655f5368ca9645
   depends:
@@ -7262,7 +7262,7 @@ packages:
   license_family: APACHE
   size: 59233
   timestamp: 1763996595934
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.29.5-py310hca03da5_1.tar.bz2
   sha256: 10882d46d9df4b33306f0ae9bd114d853699cb3383f68f052711101f450ea55e
   md5: f00868ddced6839c17b68b6dc7dd7d88
   depends:
@@ -7284,7 +7284,7 @@ packages:
   license_family: BSD
   size: 193150
   timestamp: 1737661074253
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.30.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.30.0-py310hca03da5_0.tar.bz2
   sha256: 3d3a99de5f6fbf0f3491dd8f5de3a7707c33d4bee8d4e703ae7d6163e5711c16
   md5: 3bed0b1b68c3f561801199f2d27d579a
   depends:
@@ -7303,14 +7303,14 @@ packages:
   license_family: BSD
   size: 1296306
   timestamp: 1734548092647
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jansson-2.14-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jansson-2.14-h80987f9_1.tar.bz2
   sha256: a7f6b1a5be13fa86c4c94dcebb4309d1ec8ab9ed821b401db9e0afcd844eb366
   md5: 0382b3637c88a9384cdd784cfdbcc28d
   license: MIT
   license_family: MIT
   size: 37982
   timestamp: 1705704639712
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.19.2-py310hca03da5_0.tar.bz2
   sha256: 17c139d48f3f13458fa42455aed27cc67c36915c594b41c789ec0596d2b8af84
   md5: 039499f7e2e77e05838b4e41f79f8850
   depends:
@@ -7320,7 +7320,7 @@ packages:
   license_family: MIT
   size: 1050141
   timestamp: 1733987485937
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.6-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.6-py310hca03da5_0.tar.bz2
   sha256: e2782da2156231487e1809ea074db75ad59b04baa433d2c9f14cef8e8d489bb7
   md5: 6b2b5f9f3dd7e4249bbae35b27457daf
   depends:
@@ -7332,7 +7332,7 @@ packages:
   license_family: BSD
   size: 279736
   timestamp: 1741710984403
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9f-h2f69dba_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9f-h2f69dba_0.tar.bz2
   sha256: 3bcf11af8b08f140845c7b826bdf1e0c4d5ccdb0c244f4bdf926c19d347c3c77
   md5: ac568efe96ed793f13c9bb93045196a5
   depends:
@@ -7341,7 +7341,7 @@ packages:
   license_family: Other
   size: 270667
   timestamp: 1757499055900
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.25.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.25.1-py310hca03da5_0.tar.bz2
   sha256: 42317c3f2654374f20f42cce1c8e3c2e258f869825352e435fb4bd51ec05334a
   md5: 32dc305c91d01423f0f6dc47554b64a9
   depends:
@@ -7354,7 +7354,7 @@ packages:
   license_family: MIT
   size: 146673
   timestamp: 1767955669156
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2025.9.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2025.9.1-py310hca03da5_0.tar.bz2
   sha256: a06c22b900b0e26408f97922c691b67959faa131cdc1972340247b624f984b73
   md5: 9b852d473edca7382e7245bf317e059d
   depends:
@@ -7364,7 +7364,7 @@ packages:
   license_family: MIT
   size: 15777
   timestamp: 1762788436186
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py310hca03da5_0.tar.bz2
   sha256: f723762f6638ac41a57cf16527d87ca94e3d1e60cd404fd58d694bf4b15c6267
   md5: cc8524666e2ac097a9c54a077e3a776c
   depends:
@@ -7380,7 +7380,7 @@ packages:
   license_family: BSD
   size: 199244
   timestamp: 1676329389846
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.9.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.9.1-py310hca03da5_0.tar.bz2
   sha256: 04aa54c1377ffbd43511b4f38f405403150cf28107d0e5a4f2f0721540749b13
   md5: a997db37cb2d5396eaaa549a5d72e67e
   depends:
@@ -7391,7 +7391,7 @@ packages:
   license_family: BSD
   size: 84151
   timestamp: 1764588305883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.12.0-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.12.0-py310hca03da5_1.tar.bz2
   sha256: ce3f245c414dc8a026fadaba43fd35c1956632721f56338595d79f944cb1587e
   md5: 6203a1608d6de1be1fd36793a3ce07cf
   depends:
@@ -7408,7 +7408,7 @@ packages:
   license_family: BSD
   size: 36371
   timestamp: 1765813622000
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.17.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.17.0-py310hca03da5_0.tar.bz2
   sha256: c990801c83b45a265ff0306f2d0533fd22ecd3027dc5f57d7d83da9f6f6b7eda
   md5: b8d5110d0bc5299fc49cf983ad1e4866
   depends:
@@ -7435,7 +7435,7 @@ packages:
   license_family: BSD
   size: 544682
   timestamp: 1764955108827
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.5.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.5.3-py310hca03da5_0.tar.bz2
   sha256: e18560f96ccf2f118cac9d8923f29c06234126a98b2b2a99a96a5afbd3e87f5c
   md5: d8e7fe75fdffeb074f942e6158cbdea8
   depends:
@@ -7445,7 +7445,7 @@ packages:
   license_family: BSD
   size: 25842
   timestamp: 1744706740906
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.3.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_pygments-0.3.0-py310hca03da5_0.tar.bz2
   sha256: 43889d463a225b5ea59a44cdfbd81c91743f7602a7c9a264a4e89255cc6f5959
   md5: fa899214d8435f8be9a08de95993a5ca
   depends:
@@ -7457,7 +7457,7 @@ packages:
   license_family: BSD
   size: 21751
   timestamp: 1741124234166
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.9-py310haeee614_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.9-py310haeee614_0.tar.bz2
   sha256: 1c9291e6d93dfc50edbd29cc25ff5aea376edc3e3debd14d1e0084814e6e92bd
   md5: 5c1fb986ac1e8ed5ae34b9c0317f7641
   depends:
@@ -7468,7 +7468,7 @@ packages:
   license_family: BSD
   size: 69578
   timestamp: 1764159449993
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.17-h7418793_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.17-h7418793_0.tar.bz2
   sha256: f21b37c1baa5879b854b467f309e5d70137152fb9ebc403d9b8687fd342c8029
   md5: 52f968607c5c02fc89027cf0e8116408
   depends:
@@ -7479,7 +7479,7 @@ packages:
   license_family: MIT
   size: 239932
   timestamp: 1764162757281
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-4.0.0-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-4.0.0-h313beb8_0.tar.bz2
   sha256: f123fe7eb47ac10d174364902a64c311b1875f4863b1b3791e6b3fca8e0ab272
   md5: b62145f1eeed0a89b5d76c3bb9b409d5
   depends:
@@ -7488,7 +7488,7 @@ packages:
   license_family: Apache
   size: 222115
   timestamp: 1734423410079
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libabseil-20250814.1-cxx17_hbea547f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libabseil-20250814.1-cxx17_hbea547f_0.tar.bz2
   sha256: 2e446d4ca0cfc02f04d8279dee8067510bf59b9365ed33e888af54ed481becb5
   md5: cdb38b4b55b22337f11a180fd383ab12
   depends:
@@ -7501,7 +7501,7 @@ packages:
   license_family: Apache
   size: 1384863
   timestamp: 1763134076326
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libavif-1.3.0-h839b4eb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libavif-1.3.0-h839b4eb_0.tar.bz2
   sha256: e213b9c16635d78ce69ad5a482762447ac6d45e3e4eba5c6c3f88b282b173e28
   md5: 5bb0d6ef4d1b35ef896dc80bd2bf18e6
   depends:
@@ -7512,7 +7512,7 @@ packages:
   license_family: BSD
   size: 136581
   timestamp: 1763972822425
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.2.0-hbd7815e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.2.0-hbd7815e_0.tar.bz2
   sha256: ddd9f6bd1ee66f421aca5092ad5de76d4b28e55cde53d3794b23615f1420f958
   md5: 6135ac603a6265cbeb776b5347778a69
   depends:
@@ -7521,7 +7521,7 @@ packages:
   license_family: MIT
   size: 75424
   timestamp: 1762363445823
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.2.0-h1e834b2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.2.0-h1e834b2_0.tar.bz2
   sha256: f8a64bc27e98fdf4eb3fb5cb5b1ebf99dfe5849ac4f6474894730da209779955
   md5: aeff9fd8304bb741c40af4e1389468bf
   depends:
@@ -7531,7 +7531,7 @@ packages:
   license_family: MIT
   size: 30858
   timestamp: 1762363457191
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.2.0-h5439a07_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.2.0-h5439a07_0.tar.bz2
   sha256: 0b546374b04f57c9902cc9bb17b60ba59a0feeec6ba0bcda7d3211ce848ce384
   md5: 68f6208a928c22623c4a3989d176227e
   depends:
@@ -7541,7 +7541,7 @@ packages:
   license_family: MIT
   size: 343397
   timestamp: 1762363468368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.17.0-h5bd1c32_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcurl-8.17.0-h5bd1c32_0.tar.bz2
   sha256: e3f203cc39e7bc5a7aca36014971c749940b3a52595b04dcecc79d2f055bbd34
   md5: 90848db57b98bd5401f2be932468e4e2
   depends:
@@ -7558,7 +7558,7 @@ packages:
   license_family: MIT
   size: 427767
   timestamp: 1766164060872
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-20.1.8-hd7fd590_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-20.1.8-hd7fd590_1.tar.bz2
   sha256: ed4762445fd69f6d44caa455350219812333d2eb7c25745737077f0ffaaebed5
   md5: 22f065ac144a8e31f39864bdadb754a1
   depends:
@@ -7567,21 +7567,21 @@ packages:
   license_family: Apache
   size: 416981
   timestamp: 1760650493890
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.22-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.22-h80987f9_0.tar.bz2
   sha256: 695c939431f7fd074d175e62944daca33ff51f3abfe1ee5c51d92d89ad663da8
   md5: 8985f8e47c5bd81416ed08c28d7f305a
   license: MIT
   license_family: MIT
   size: 60900
   timestamp: 1734423344642
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
   sha256: 6fc572025852b210ecddcca3ab9ff3f1d5f6bd91f1933c6e296de6bb331f6b5d
   md5: 6dd7d9c5737bbd2a27d18f15318dc3e6
   license: BSD-2-Clause
   license_family: BSD
   size: 102059
   timestamp: 1628961869728
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
   sha256: 9e7b9bb9367d8725a751cdfa0b2d270434d303ea196cfaacc605ee26be09874a
   md5: 44d1843cc2f17eb2674f35b95468f551
   depends:
@@ -7591,7 +7591,7 @@ packages:
   license_family: BSD
   size: 415467
   timestamp: 1685052299052
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libexpat-2.7.3-h50f4ffc_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libexpat-2.7.3-h50f4ffc_4.tar.bz2
   sha256: 41f36111cab90098f7611f1f3d6ee314a181d5c4f0397a293cd3d926285eaca0
   md5: dfe821bb629af64f1c6554175a57beb7
   depends:
@@ -7603,14 +7603,14 @@ packages:
   license_family: MIT
   size: 117121
   timestamp: 1765208107172
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
   sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
   md5: f31e4eb9cd6447cc2f5ef0243a76540c
   license: MIT
   license_family: MIT
   size: 120460
   timestamp: 1714483461787
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-15.2.0-hb654fa1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-15.2.0-hb654fa1_1.tar.bz2
   sha256: 2cb88ce7a8a97e5fd3d248af24237cb7df6e6ada54e3f7d8ee4e24972f45cb52
   md5: 5eb56f5a5b38bc5b9e8166d98cd6281f
   depends:
@@ -7621,7 +7621,7 @@ packages:
   license_family: GPL
   size: 940802
   timestamp: 1764069178918
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libglib-2.86.3-hcacd345_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libglib-2.86.3-hcacd345_0.tar.bz2
   sha256: 43744652a5cd0c736d8b032df175d1206362d9d87b437a455d192d63d69f2ea2
   md5: 46118d0fa07774e7d8f48f45ed37dfb1
   depends:
@@ -7636,7 +7636,7 @@ packages:
   license_family: LGPL
   size: 4722696
   timestamp: 1768844855642
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgrpc-1.74.1-h941cc20_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgrpc-1.74.1-h941cc20_0.tar.bz2
   sha256: 99aa0fd6257a24877a641bae05e79f8275d6b55695fc5b3e31dc27eab02023f3
   md5: 82e88d110bb7e6fc038a5c204eef53b1
   depends:
@@ -7656,7 +7656,7 @@ packages:
   license_family: APACHE
   size: 8034284
   timestamp: 1763140382845
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libhwloc-2.12.1-default_h2915d5d_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libhwloc-2.12.1-default_h2915d5d_1000.tar.bz2
   sha256: bf0f407e7030be2559076e314477b781e176cc2931a83895966ffac72fdd097f
   md5: 15d2c5b625e3d55025388d5dbaa5e954
   depends:
@@ -7667,14 +7667,14 @@ packages:
   license_family: BSD
   size: 2694773
   timestamp: 1755246474116
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
   sha256: 72d242814b990900c9410d4738cc685f70ea71231742293cffbb475d8df100f8
   md5: f9976688992b7ac4b56f5600ee15b5c4
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1407202
   timestamp: 1714483550601
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libidn2-2.3.8-h9681e36_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libidn2-2.3.8-h9681e36_0.tar.bz2
   sha256: 45b8f73f24015dcb6882ed7890f6d77f9fa01491a0d024e2e568389b662c1cf3
   md5: da34b3554c8263877326f8279ec476dc
   depends:
@@ -7686,7 +7686,7 @@ packages:
   license_family: OTHER
   size: 146822
   timestamp: 1760364408172
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm20-20.1.8-h1701f07_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libllvm20-20.1.8-h1701f07_0.tar.bz2
   sha256: 34b1de6807e5ebaca05b5416e8ceb911aa46b37066c6d3eab1457af69671de4e
   md5: c959c83dbd14c1c03bc097c92f378fcd
   depends:
@@ -7699,7 +7699,7 @@ packages:
   license_family: Apache
   size: 36677616
   timestamp: 1756223115172
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.67.1-h8189af8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libnghttp2-1.67.1-h8189af8_0.tar.bz2
   sha256: 323d884e7f598fd3bcb4da9cff1793dd8bcbaf60b232e8c9e5405be1bf621b9c
   md5: 3f1d5ddcb5466d78bdf977db891ca710
   depends:
@@ -7721,7 +7721,7 @@ packages:
   license_family: MIT
   size: 797407
   timestamp: 1762785206846
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.30-hf2bb037_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.30-hf2bb037_2.tar.bz2
   sha256: 2a2d102454cd14f901a65cbe4995544e92e51c3fba5dded06a2cbfad5d6123dc
   md5: 033fd4da8f096b4151efd76d62bde317
   depends:
@@ -7732,7 +7732,7 @@ packages:
   license_family: BSD
   size: 7176568
   timestamp: 1762889555793
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenjpeg-2.5.4-haa24f5a_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenjpeg-2.5.4-haa24f5a_1.tar.bz2
   sha256: c46a84770b38a02643143fecc11078578da47274958d5d83600598bbee25c535
   md5: e48491140c5f4f2e1929650b9b9050d6
   depends:
@@ -7741,7 +7741,7 @@ packages:
   license_family: BSD
   size: 206857
   timestamp: 1761732760564
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.50-h5c318fc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.50-h5c318fc_0.tar.bz2
   sha256: 89737d000b641d4eb4cd05127e11cc7363af5c293fac8a320143108fa82b49c1
   md5: 29df2749e97ffcca138f3e885e9f7075
   depends:
@@ -7751,7 +7751,7 @@ packages:
   license_family: Other
   size: 231699
   timestamp: 1761139814654
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-6.33.0-h6acce77_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libprotobuf-6.33.0-h6acce77_1.tar.bz2
   sha256: 9fbd47e29f6662945d12d4160d7d55cde598286f7037d774677f05b2c3c5f4d6
   md5: 82cda30faf0db92f6ce38a2328a10aea
   depends:
@@ -7764,7 +7764,7 @@ packages:
   license_family: BSD
   size: 3698939
   timestamp: 1768234555824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libre2-11-2025.11.05-hd4f4e8d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libre2-11-2025.11.05-hd4f4e8d_0.tar.bz2
   sha256: eae369e9bb8f682edb211f6987a38d618c76c4f56ddc10783e4b5673cf510c9d
   md5: 540ffdfa70492900229e3a82818bd76c
   depends:
@@ -7777,7 +7777,7 @@ packages:
   license_family: BSD
   size: 227551
   timestamp: 1763136456176
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.20-h897f8a9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.20-h897f8a9_0.tar.bz2
   sha256: 9444698c6ed655f721883bdaf199f3cbd2af4abb1ac4c2a95e112aee43a0af80
   md5: 60bae7154adab7af8d18a30438ee311e
   depends:
@@ -7786,7 +7786,7 @@ packages:
   license_family: Other
   size: 283896
   timestamp: 1754318852350
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.11.1-h3e2b118_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libssh2-1.11.1-h3e2b118_0.tar.bz2
   sha256: 7a4a378fd967c667ec1ed6db98eb697a92838bbb2a0058d592f4615f70fbc1c7
   md5: e65d37b5b4b531889526b0995b8589d2
   depends:
@@ -7796,7 +7796,7 @@ packages:
   license_family: BSD
   size: 287605
   timestamp: 1732891144732
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.22.0-hbe873a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libthrift-0.22.0-hbe873a3_0.tar.bz2
   sha256: 146c7242da7d5c32182593b10e16d5776594f1e4053892f499bab1fcada3106c
   md5: ad50b94c68172f0b0cb28fc42011c2f4
   depends:
@@ -7809,7 +7809,7 @@ packages:
   license_family: Apache
   size: 368542
   timestamp: 1761570501833
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.7.1-h367c460_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.7.1-h367c460_0.tar.bz2
   sha256: 4746813e88ed50c2596587d71d195fd25773965266c2c416e730770d8b61a211
   md5: 9844a048fee5c941f38260ec52284944
   depends:
@@ -7826,7 +7826,7 @@ packages:
   license_family: Other
   size: 413466
   timestamp: 1763980753540
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libunistring-1.3-h1799b2a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libunistring-1.3-h1799b2a_0.tar.bz2
   sha256: 09ffed353754c619ec1b2edf5281d08db40f5c14906f48ec7c8cffba2dd21f52
   md5: 5063c8b7332461c9a798cad6f7e5bae2
   depends:
@@ -7835,7 +7835,7 @@ packages:
   license_family: LGPL
   size: 793250
   timestamp: 1755086959740
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.6.0-h92b2d59_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.6.0-h92b2d59_0.tar.bz2
   sha256: 2e10800da4643073ad4225ddfb9e7e8d27ab8d46cbc267d04d69361dea831ba5
   md5: 6cb156c1ab2ead24b04b0df70eab2c53
   depends:
@@ -7846,7 +7846,7 @@ packages:
   license_family: BSD
   size: 373602
   timestamp: 1763980649775
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.13.9-h528a072_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.13.9-h528a072_0.tar.bz2
   sha256: 7a441e0c213896ab6dfda5e73eba83c3302ae4e7063611af1ca7022bb3b24a97
   md5: 00ab7473cbcbba76e63a7908bef50e0b
   depends:
@@ -7859,7 +7859,7 @@ packages:
   license_family: MIT
   size: 630698
   timestamp: 1761768989755
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzlib-1.3.1-h5f15de7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libzlib-1.3.1-h5f15de7_0.tar.bz2
   sha256: a6e20d9d0356775be38a01a10e164fbab070c717839e2de673ccde0741c149e9
   md5: 5100278a1b3a2bd906ca68347dd2985a
   depends:
@@ -7870,7 +7870,7 @@ packages:
   license_family: OTHER
   size: 54057
   timestamp: 1756475936697
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.3-py310hca03da5_0.tar.bz2
   sha256: 777eec11964051b2a86045784c99e9a007dd204f71e690e0f34d91672bb850be
   md5: 68d8f2d21fde62e1a40870ffe5568cce
   depends:
@@ -7880,7 +7880,7 @@ packages:
   license_family: MIT
   size: 41067
   timestamp: 1758717880404
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-20.1.8-he822017_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-20.1.8-he822017_0.tar.bz2
   sha256: 898774d2a539aee5ad5f90ef0ace8e3a200334a226395a4db4d09407b3db19e5
   md5: 62539f1114bb3746387ab4eea137f15d
   depends:
@@ -7891,7 +7891,7 @@ packages:
   license_family: Apache
   size: 356849
   timestamp: 1756229534992
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.46.0-py310hc8eb11b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.46.0-py310hc8eb11b_0.tar.bz2
   sha256: 768ee93046f839b743e661d095b6279cbbf44b5be3fbe565c8562082c1ffd118
   md5: 74be30811f264aa0cc77a793632b8542
   depends:
@@ -7904,7 +7904,7 @@ packages:
   license: BSD-2-Clause AND Apache-2.0 WITH LLVM-exception
   size: 30623884
   timestamp: 1765874234669
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py310hca03da5_0.tar.bz2
   sha256: a2dfd5de8c8946e1da759975b43bb4048bf720792f63e44a8197ebf78da18560
   md5: eb339d709764df9583302fd4796f609d
   depends:
@@ -7913,7 +7913,7 @@ packages:
   license_family: BSD
   size: 11926
   timestamp: 1652903163430
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.4.5-py310hbc89d72_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-4.4.5-py310hbc89d72_0.tar.bz2
   sha256: 5a8953d3bf14c92c72b12bea7dfb6d25bd50b642860eadd308fa17faee58b027
   md5: 075608853093931ff9d6855738509595
   depends:
@@ -7924,7 +7924,7 @@ packages:
   license_family: BSD
   size: 48437
   timestamp: 1762954028771
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
   sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
   md5: f5f7e6e7541d8dc3d3df270d488d2e24
   depends:
@@ -7933,7 +7933,7 @@ packages:
   license_family: BSD
   size: 176990
   timestamp: 1714510588159
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.10-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.10-py310hca03da5_0.tar.bz2
   sha256: 11c0695d8012237448aefc0a3f9d94aeada9980fa0a0da4a6c53a77ac54dad11
   md5: ca9812acff77ee49a3ab624dfc9e8e3f
   depends:
@@ -7942,7 +7942,7 @@ packages:
   license_family: BSD
   size: 141832
   timestamp: 1767787334129
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py310hca03da5_1.tar.bz2
   sha256: b0e240d3ef06e292105f4e1b161426170e5897144c142d23df66935ab4108dc5
   md5: 8c6193fc54f6c300530527f642efadf1
   depends:
@@ -7952,7 +7952,7 @@ packages:
   license_family: MIT
   size: 108119
   timestamp: 1684279956548
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-3.0.2-py310h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-3.0.2-py310h80987f9_0.tar.bz2
   sha256: e4f9fba9ea625b3f7904983bf7ac296f75a14293788b46fc0c0e2bedcf765a74
   md5: 8f167785f0da6e2620ce06eeb4383073
   depends:
@@ -7963,7 +7963,7 @@ packages:
   license_family: BSD
   size: 26662
   timestamp: 1738584253000
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.10.8-py310haa222d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.10.8-py310haa222d5_0.tar.bz2
   sha256: 70060cd1b55d4ce2f7c15e0b86d82c439d8aad26a2050354cac99b0e3fc3a255
   md5: 590dc67703f1ff5bfa1f9c207156838d
   depends:
@@ -7985,7 +7985,7 @@ packages:
   license_family: PSF
   size: 9828894
   timestamp: 1768297770420
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.2.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.2.1-py310hca03da5_0.tar.bz2
   sha256: dd8c784bc3c6547812b01d842cc23ef40179e8615808f1c68e9c23e1c98dc0f2
   md5: 90d1c020883a3aa8df5e3b4f1135048e
   depends:
@@ -7995,7 +7995,7 @@ packages:
   license_family: BSD
   size: 17658
   timestamp: 1762779191788
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.5.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.5.0-py310hca03da5_0.tar.bz2
   sha256: 663d102af0235439f15c8ee31a2632c76d7229fec25125948a2539e5df3106d6
   md5: d4e1ac8058d2c0581b417475c7a56e6a
   depends:
@@ -8005,7 +8005,7 @@ packages:
   license_family: MIT
   size: 94534
   timestamp: 1756380016476
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.2-py310hca03da5_0.tar.bz2
   sha256: 4fad21d528143caf81c1960252036f6089ebdf20855c9b558268d751f4cd207a
   md5: 8fc5cf9ac9a1b29d3c71c1ae1b96e72f
   depends:
@@ -8014,7 +8014,7 @@ packages:
   license_family: MIT
   size: 22983
   timestamp: 1758552189289
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-3.1.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-3.1.2-py310hca03da5_0.tar.bz2
   sha256: cf8f8b874e78a53ab3b7535734f52518cda20f69305d7c36b3eee888ebdb2ed5
   md5: 7b2eac8ded50875934a5cbcfc86fe50e
   depends:
@@ -8024,7 +8024,7 @@ packages:
   license_family: BSD
   size: 110285
   timestamp: 1741124114775
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.1.1-py310h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/msgpack-python-1.1.1-py310h313beb8_0.tar.bz2
   sha256: b140a1dfc93627df81c4dbb71fe802e80833f4f45210e463e3740b6851983b21
   md5: b5debd0c7b0fb0482c758e16e4e20de9
   depends:
@@ -8034,7 +8034,7 @@ packages:
   license_family: Apache
   size: 103675
   timestamp: 1750958675449
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-1.0.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-1.0.0-py310hca03da5_0.tar.bz2
   sha256: c99ec24ebd3bb43b5e1dacf31c1294b5ae36d3fe6957c35c19b93b7d4dc5895b
   md5: e57d5eac6a1276aa19f1e444f74e699a
   depends:
@@ -8043,7 +8043,7 @@ packages:
   license_family: BSD
   size: 27946
   timestamp: 1756978478132
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.3.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-1.3.3-py310hca03da5_0.tar.bz2
   sha256: 036562e3d3a0eab1bf9618c832c62785346b3abbfe432b9ba800831596af80e4
   md5: 8227539fb980c2084ee1e283008d8400
   depends:
@@ -8056,7 +8056,7 @@ packages:
   license_family: BSD
   size: 10046354
   timestamp: 1765189113589
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.10.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.10.2-py310hca03da5_0.tar.bz2
   sha256: 1c1ff77c9e1618312cb0a8c6248bea01e93ddd481dc5fa02c596f667b853a01b
   md5: d656a40c878bfab5227f3c2e3bf9a955
   depends:
@@ -8069,7 +8069,7 @@ packages:
   license_family: BSD
   size: 44613
   timestamp: 1741124081761
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.6-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.16.6-py310hca03da5_0.tar.bz2
   sha256: 1d38e8e7c5e078374b00664c568d105efd2829558554be285660584f2d715c21
   md5: 4b087200d12eafd3229191c65a6cb05a
   depends:
@@ -8080,7 +8080,7 @@ packages:
   license_family: BSD
   size: 8348
   timestamp: 1741185304690
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-core-7.16.6-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-core-7.16.6-py310hca03da5_0.tar.bz2
   sha256: 3699321a00daf6828e3d74e28a6964b2a5777f7d2ec11109a115560e725a4506
   md5: 2b0488dbd36a57757baebe5f44320a62
   depends:
@@ -8107,7 +8107,7 @@ packages:
   license: BSD-3-Clause
   size: 491446
   timestamp: 1741185291370
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-pandoc-7.16.6-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-pandoc-7.16.6-py310hca03da5_0.tar.bz2
   sha256: 82c560cf2b119845cb95c0ebc1e1efcd085e297b8cbd68e22b88143ae5472c40
   md5: 07056286248325f3ba6d458e015268d1
   depends:
@@ -8117,7 +8117,7 @@ packages:
   license: BSD-3-Clause
   size: 8385
   timestamp: 1741185298668
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.10.4-py310hca03da5_0.tar.bz2
   sha256: 1d56811db3dcf64f81534f8c062f13f5a0ad32a477ac34f13fc8a8d312b138d1
   md5: d7bbf5d0fee20be1955640948e289403
   depends:
@@ -8130,7 +8130,7 @@ packages:
   license_family: BSD
   size: 149708
   timestamp: 1728049678663
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.5-hee39554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.5-hee39554_0.tar.bz2
   sha256: 2a681571241e64b59404209591d926176c08415680d1105a7562f87ac3eefa5e
   md5: 7be781c500828a66aa1422dae789f590
   depends:
@@ -8139,7 +8139,7 @@ packages:
   license_family: MIT
   size: 1097704
   timestamp: 1753947535285
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py310hca03da5_0.tar.bz2
   sha256: 737ecaada7f80f42da43affef97fc31a8dcd3f2a0be14b377b34583a7d334fdf
   md5: 914980d852a22de592f571dba8d4fe62
   depends:
@@ -8148,7 +8148,7 @@ packages:
   license_family: BSD
   size: 14550
   timestamp: 1708532774873
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.7-py310hca03da5_0.tar.bz2
   sha256: e860480e342b6f29f1b4b2fab22d8809d12a1c286d0ea451b9c4314bc53c4341
   md5: 032486f67208f870056780ddc879afad
   depends:
@@ -8173,7 +8173,7 @@ packages:
   license_family: BSD
   size: 595602
   timestamp: 1717630793498
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.4-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.4-py310hca03da5_0.tar.bz2
   sha256: 514d5149ff4de6d4bbf9c264ce1901d7511f60dce629f9835cd51c787a8c5443
   md5: a6743bbf22ccb926527549692e9ae2fc
   depends:
@@ -8183,7 +8183,7 @@ packages:
   license_family: BSD
   size: 23965
   timestamp: 1741707798225
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.63.1-py310hadc56cb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numba-0.63.1-py310hadc56cb_0.tar.bz2
   sha256: c51c6fff707840a37b9a579fceb514e7bc23227f1bd6b648a79d2297e29f7d2d
   md5: a606486484240b0af3b709d10df72364
   depends:
@@ -8207,7 +8207,7 @@ packages:
   license_family: BSD
   size: 4963519
   timestamp: 1765905895462
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py310h901140f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.4-py310h901140f_1.tar.bz2
   sha256: 510f4a9c39d30dca5f829874d63b181a26ef891ecd788327d334e8adf47068e3
   md5: 8ac4533f0fb71bbbe8126cad1336f19e
   depends:
@@ -8220,7 +8220,7 @@ packages:
   license_family: BSD
   size: 13544
   timestamp: 1755591306153
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py310hae06d03_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.4-py310hae06d03_1.tar.bz2
   sha256: c8d8bbae2d2af18e21220ff87aa34b31eee95214bfa70289514819a5ea2db5bb
   md5: fa4d86c7835a8504c467f4d1e29f0943
   depends:
@@ -8234,7 +8234,7 @@ packages:
   license_family: BSD
   size: 6385014
   timestamp: 1755591289372
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-2.2.0-hd6530ca_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/orc-2.2.0-hd6530ca_1.tar.bz2
   sha256: 4c0ca4f0bae7cd420fafd7f007f216a4d6d46dc4fc457d60fc6cfb5f598df524
   md5: f91095f70046fd40580ef6f3907a6cd5
   depends:
@@ -8250,7 +8250,7 @@ packages:
   license_family: Apache
   size: 501418
   timestamp: 1764689799173
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.7.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.7.0-py310hca03da5_0.tar.bz2
   sha256: e63d75a1093cbcdca0286701203ce1bd96a070637dd2bd46a0aeedcc5f50f1ca
   md5: 71fdb84bfcd3b6525b42230fa92d186c
   depends:
@@ -8259,7 +8259,7 @@ packages:
   license_family: APACHE
   size: 35466
   timestamp: 1762349107715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-25.0-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-25.0-py310hca03da5_1.tar.bz2
   sha256: c55183468ffe0f1b2ed206b1d3077120cf593d6236c3fbdb398a8ce850525550
   md5: d9d689074c64ee253cdcbde633df4d40
   depends:
@@ -8268,7 +8268,7 @@ packages:
   license_family: Apache
   size: 166383
   timestamp: 1761049099489
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandoc-3.8-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandoc-3.8-hca03da5_0.tar.bz2
   sha256: 18fa30b94acf2fd11bd1338c59ee4e6477f4b9919b5aa3ece430ac62ed056c17
   md5: dfeec073104efa8f790bce4622376bdc
   depends:
@@ -8279,7 +8279,7 @@ packages:
   license_family: GPL
   size: 33948406
   timestamp: 1758806899964
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandocfilters-1.5.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandocfilters-1.5.1-py310hca03da5_0.tar.bz2
   sha256: adc7c92bc45d9af33c1c9e347cbac9d9cc36fe353fe35d32177c1dd7d3e72298
   md5: 3fcd4a2eadd6c9ea9f16c8f716c3e3c1
   depends:
@@ -8288,7 +8288,7 @@ packages:
   license_family: BSD
   size: 15729
   timestamp: 1756977681212
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-1.2.3-py310hca03da5_0.tar.bz2
   sha256: 88811223659197b175b924057b7b5926c7093cded6f9a9aed5efb6452c2be8f1
   md5: dfb4aca8097e63f3db61cad638723639
   depends:
@@ -8312,7 +8312,7 @@ packages:
   license_family: BSD
   size: 17074981
   timestamp: 1695146365895
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-1.13.0-py310hca03da5_0.tar.bz2
   sha256: 958c77578e3569111c33fc9ddf8ec012f4d575818488d2704cf5d3a4c00a52c2
   md5: b0818352d65dc7ea4998a5790de52397
   depends:
@@ -8321,7 +8321,7 @@ packages:
   license_family: BSD
   size: 144036
   timestamp: 1684915352915
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/parso-0.8.5-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/parso-0.8.5-py310hca03da5_0.tar.bz2
   sha256: 15f7a4f63fc7de0ec4448f69aa6efe738daedc589272f0ffb05c4e270ccae0a2
   md5: 53f63a8a2389e564ae3845214f74e5be
   depends:
@@ -8330,7 +8330,7 @@ packages:
   license_family: OTHER
   size: 179396
   timestamp: 1762781726489
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.2-py310hca03da5_0.tar.bz2
   sha256: 956cb716d024eca203ec36364c7416bbb69b6015d77e343660c85999a3661559
   md5: bce9e46f4f6222c6f16e88e74b954056
   depends:
@@ -8344,7 +8344,7 @@ packages:
   license_family: BSD
   size: 37147
   timestamp: 1736803487891
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre2-10.46-h1dacb4a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pcre2-10.46-h1dacb4a_0.tar.bz2
   sha256: 0d134802cfb73e7e1caf8d90d90f6f3d2c78073275fe95a100087f58a9d5cd9c
   md5: 39d21a3f042a3633baaf29084fe28504
   depends:
@@ -8355,7 +8355,7 @@ packages:
   license_family: BSD
   size: 2062999
   timestamp: 1759825795666
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pexpect-4.9.0-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pexpect-4.9.0-py310hca03da5_1.tar.bz2
   sha256: 5f07d3951c74a08f1e581af8e7825fba4b9954ca98075200a4378c346a9deec7
   md5: aa6d3a61eff333ec6df9fb1f40a36587
   depends:
@@ -8365,7 +8365,7 @@ packages:
   license_family: Other
   size: 133802
   timestamp: 1762535957454
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-12.0.0-py310he2d6fe4_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-12.0.0-py310he2d6fe4_1.tar.bz2
   sha256: 1fed263d24deb60dd6bc4b9ff0078fe886866804872ddf149e838091764648bb
   md5: a4d86f82d97c3e289eb055c4a1216483
   depends:
@@ -8385,7 +8385,7 @@ packages:
   license_family: Other
   size: 875440
   timestamp: 1762528273314
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pixman-0.46.4-h09dc60e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pixman-0.46.4-h09dc60e_0.tar.bz2
   sha256: 39e89e5aba886ffe7cf1f59febee53bab0d6a022c8e545574fd90610adb24c50
   md5: 86debb34b77b24a2ea2d2a35fff6bc2b
   depends:
@@ -8395,7 +8395,7 @@ packages:
   license_family: MIT
   size: 218161
   timestamp: 1755256415721
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-4.5.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-4.5.0-py310hca03da5_0.tar.bz2
   sha256: a4bbbc0c26f1496184bcad1f88a22ea54c028bdc92ca5e38274cc92874b9c526
   md5: af4e74d6641d57ba9846b8c581054320
   depends:
@@ -8404,7 +8404,7 @@ packages:
   license_family: MIT
   size: 35439
   timestamp: 1762356654667
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.21.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.21.1-py310hca03da5_0.tar.bz2
   sha256: 5a8533a080cc6245c964f6e969c1671eeb110c2cfa1db784ba0621d65f95875f
   md5: c83abab6f07cd497b854bc82cd6bff2d
   depends:
@@ -8413,7 +8413,7 @@ packages:
   license_family: Apache
   size: 119078
   timestamp: 1744271794783
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.52-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.52-py310hca03da5_1.tar.bz2
   sha256: 0fc2cea56dbda261a53ab69cce316811cd555a3c8c6f4911f017af39becfe6d6
   md5: a76d5d69767cb467affa28945a752083
   depends:
@@ -8425,7 +8425,7 @@ packages:
   license_family: BSD
   size: 620401
   timestamp: 1761744881930
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-7.0.0-py310haa24f5a_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-7.0.0-py310haa24f5a_1.tar.bz2
   sha256: 1b165f2ff4a59ae59249d66e857867304c84b504e9e170d068e8149ebe58246d
   md5: f3c55d3817be1bb6132fe4245de5ea77
   depends:
@@ -8435,7 +8435,7 @@ packages:
   license_family: BSD
   size: 436377
   timestamp: 1761896358529
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pure_eval-0.2.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pure_eval-0.2.3-py310hca03da5_0.tar.bz2
   sha256: 406a3b6bff6aa595e687bd03cb8255b4cf5ec65fe615c363a052f53649d501f9
   md5: 0602c310460796ffb7bee6e23a0f8000
   depends:
@@ -8444,7 +8444,7 @@ packages:
   license_family: MIT
   size: 28121
   timestamp: 1757067106603
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-21.0.0-py310h3f644e9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyarrow-21.0.0-py310h3f644e9_1.tar.bz2
   sha256: 47222a9e2f4511fcf541facbcf8a76b699285f4f0ba4e30a54a785f339f44879
   md5: 081428edda751b66c6b8da64e7f01c91
   depends:
@@ -8456,7 +8456,7 @@ packages:
   license_family: Apache
   size: 11732261
   timestamp: 1764939547856
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pycparser-2.23-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pycparser-2.23-py310hca03da5_0.tar.bz2
   sha256: 100dc1d651d1f641709c62d4271f64fc27ab14a827853f036a6894e49def6729
   md5: 8d9ffb119e380db61d6d1ab77de217ee
   depends:
@@ -8465,7 +8465,7 @@ packages:
   license_family: BSD
   size: 230860
   timestamp: 1757496114753
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.6.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.6.0-py310hca03da5_0.tar.bz2
   sha256: af17093fd74b48a3f8d570713d9b19424b1ea9ae30d2b42d43ffe18016c8fcf4
   md5: c5af9fbbffa28657b7eef190d7b3be47
   depends:
@@ -8477,7 +8477,7 @@ packages:
   license_family: BSD
   size: 31643
   timestamp: 1759932162176
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.19.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.19.2-py310hca03da5_0.tar.bz2
   sha256: 12d929a207a3d74d6198d9facb1900f2ca48ddd47f38eb70fe577724eaf8cb08
   md5: 5f767750241c0a2efd8ad1f38a0eed31
   depends:
@@ -8486,7 +8486,7 @@ packages:
   license_family: BSD
   size: 5198164
   timestamp: 1762431588510
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.2.5-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.2.5-py310hca03da5_0.tar.bz2
   sha256: 8f9885421d3a1a78298e78b31bbab237ca131ed561956c3c484b518ef1d4aa1e
   md5: 18563e3a05fbb6f867e65d5b2a55f2ae
   depends:
@@ -8495,7 +8495,7 @@ packages:
   license_family: MIT
   size: 542561
   timestamp: 1763973807801
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py310hca03da5_1.tar.bz2
   sha256: c1b70ade729060a012b80bd2794ecc8cb8cb9e1ede23363cb1084c0f43212562
   md5: 4f397cdc65ae9e5f94e85d2e2696444c
   depends:
@@ -8504,7 +8504,7 @@ packages:
   license_family: BSD
   size: 28611
   timestamp: 1761753032161
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py310hca03da5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py310hca03da5_2.tar.bz2
   sha256: 7fe61148813d911c333451fa5b1752ed4da89b230a83a23b3cb3886e0ad7e1ed
   md5: 8eef9f7a02ea012f3ae3c4cec6d09185
   depends:
@@ -8514,7 +8514,7 @@ packages:
   license_family: BSD
   size: 290933
   timestamp: 1716495762679
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.21.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.21.2-py310hca03da5_0.tar.bz2
   sha256: 7566e28c47d6f4a51ab16597a3d368e7d28aaaca31ca0c020eebce24704f14d1
   md5: fdf66c5d0248a052e1531848cfc99a83
   depends:
@@ -8523,7 +8523,7 @@ packages:
   license_family: BSD
   size: 274352
   timestamp: 1763718718783
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-4.0.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-4.0.0-py310hca03da5_0.tar.bz2
   sha256: 2715ec629c81e90bf98c1830da242c63738e2945f13420e36bb16f0acc5f86e6
   md5: ad1c1928d92866af4ffbe167b5448334
   depends:
@@ -8532,7 +8532,7 @@ packages:
   license_family: BSD
   size: 30312
   timestamp: 1764590114914
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.7.5-py310h3d52de1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-lmdb-1.7.5-py310h3d52de1_0.tar.bz2
   sha256: d99a2ac70f6147ac423087c7103ae45b7a84196e750090af041af42c1af2628d
   md5: e2ec3e559655397dc439a8cd631f790a
   depends:
@@ -8543,7 +8543,7 @@ packages:
   license_family: Other
   size: 133239
   timestamp: 1764243655549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python_abi-3.10-3_cp310.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python_abi-3.10-3_cp310.tar.bz2
   sha256: 5217861fac2702d4388e2382df07f5f31e665fea44ffc21611d368e585ebac18
   md5: e5fe0fea06870e8e54cb5d3a4cd22689
   constrains:
@@ -8552,7 +8552,7 @@ packages:
   license_family: BSD
   size: 4818
   timestamp: 1764349560577
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2025.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2025.2-py310hca03da5_0.tar.bz2
   sha256: 30ed7d9887e6f918d5e0c03cd679dc838046986adadec3a5192f4df311494372
   md5: f2049ee43ae3b0618e4cb0afd7c2d092
   depends:
@@ -8561,7 +8561,7 @@ packages:
   license_family: MIT
   size: 274546
   timestamp: 1752135897269
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.6-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.6-py310hca03da5_0.tar.bz2
   sha256: 3ea793270acc459707cf3d0f494822dd55cff50548b47d2937e5afd67d645e63
   md5: 1e655f80537cbbb65b8a801f02643a88
   depends:
@@ -8574,7 +8574,7 @@ packages:
   license_family: BSD
   size: 62032
   timestamp: 1758102151024
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.3-py310h091b9d3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.3-py310h091b9d3_0.tar.bz2
   sha256: 01384765626233037c7b03f88838109ed7a84538f35199dfcb29cf9c193cacae
   md5: 21c66892dae4955d34c9b2f2f41acfa0
   depends:
@@ -8585,7 +8585,7 @@ packages:
   license_family: MIT
   size: 220626
   timestamp: 1763465529919
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py310h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-24.0.1-py310h80987f9_0.tar.bz2
   sha256: 8cf1caefcef4460f7f38ebb80e78f8d606b6b737940d5462151efca10938d431
   md5: b9ccfe7a0e895ae9cf67bbe76da592d3
   depends:
@@ -8595,7 +8595,7 @@ packages:
   license_family: Other
   size: 493253
   timestamp: 1709318540883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2025.11.05-h1413154_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/re2-2025.11.05-h1413154_0.tar.bz2
   sha256: 63cf1c5cc06c78237036f37362e809d45a20ee510d2f72ddfd85d2a7653049a5
   md5: 054832430f68947c7e527a9b63c94d62
   depends:
@@ -8604,7 +8604,7 @@ packages:
   license_family: BSD
   size: 24789
   timestamp: 1763136464537
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.3-h0b18652_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.3-h0b18652_0.tar.bz2
   sha256: 5df88605e8e3f6b47524706f2dd68a58fdf506cba30f8dd74307abce57fc3e90
   md5: e17d25d83f388ee42cdb452ff88e6c2c
   depends:
@@ -8614,7 +8614,7 @@ packages:
   license_family: GPL
   size: 575000
   timestamp: 1754485689285
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.37.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.37.0-py310hca03da5_0.tar.bz2
   sha256: 87150d2a0cb2a706ecc060e3c85651855e73ee0999c76c5c58fc39531b86ccbb
   md5: d4352f42edfb1a6d3a5a788fb5d1fef0
   depends:
@@ -8626,7 +8626,7 @@ packages:
   license_family: MIT
   size: 63492
   timestamp: 1762536905670
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.5-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.32.5-py310hca03da5_1.tar.bz2
   sha256: abeb7567717455f40eae375bf30bc327888de6856fbaae22b7d958fad6addd8a
   md5: 497a1ed810bdb926ee0255e48d9da584
   depends:
@@ -8642,7 +8642,7 @@ packages:
   license_family: Apache
   size: 143984
   timestamp: 1762359615557
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py310hca03da5_0.tar.bz2
   sha256: 4f7adb8857af54586f8a27fecbd31626160f964ab18efd5a693182a91fe4a287
   md5: 2e2a4c3a1f320aedaf65ea0deec06aa5
   depends:
@@ -8652,7 +8652,7 @@ packages:
   license_family: MIT
   size: 9834
   timestamp: 1683077089689
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py310hca03da5_0.tar.bz2
   sha256: cc20aee97ef5f28b78867fd74e2e9a5785985c3fa56d31f983fea00c2805b76d
   md5: d566a3096aee8f6ea77d12124075ae14
   depends:
@@ -8661,7 +8661,7 @@ packages:
   license_family: MIT
   size: 10216
   timestamp: 1683059019921
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.28.0-py310h931abed_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.28.0-py310h931abed_0.tar.bz2
   sha256: 178d7c2e46c1e5a5531501dad2eb98ad76422265357b0ea1f6115fe10f166f4b
   md5: 7defbd7e5cdc58f91e2998f2e6581da9
   depends:
@@ -8671,7 +8671,7 @@ packages:
   license_family: MIT
   size: 362435
   timestamp: 1762366562904
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.15.3-py310h132fc3c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.15.3-py310h132fc3c_1.tar.bz2
   sha256: 190f81d9cdc986fcfacbe6483b858f08fc7602e6b8cc9b35a926e3c2f8158484
   md5: a8a9667de3082b61ca7ebeff7db67dc2
   depends:
@@ -8689,7 +8689,7 @@ packages:
   license_family: BSD
   size: 25528191
   timestamp: 1759222169154
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.3-py310hca03da5_0.tar.bz2
   sha256: 9c4da1e0dd2e2790bf5e16f4e1bbfc3370f1be2c7f960b7ee68d35a0b5abb8bd
   md5: dca5908c382e45bed6ed9eceebd99c40
   depends:
@@ -8698,7 +8698,7 @@ packages:
   license_family: BSD
   size: 30085
   timestamp: 1768170620278
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-80.9.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-80.9.0-py310hca03da5_0.tar.bz2
   sha256: a81cee67e0142167d58b2711afbf9c66fc4a625768ae2467f410834bd3552d0c
   md5: 8639226a9a06989223f8c91ba9b2e1c6
   depends:
@@ -8707,7 +8707,7 @@ packages:
   license_family: MIT
   size: 1829337
   timestamp: 1759863068598
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/six-1.17.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/six-1.17.0-py310hca03da5_0.tar.bz2
   sha256: 4926d2eb38d4ce722db69295f0739399294ec731202ce5f608582824b70865d1
   md5: beb00121d49e92e8b4eba6f5d5b32ed7
   depends:
@@ -8716,7 +8716,7 @@ packages:
   license_family: MIT
   size: 32797
   timestamp: 1744271537182
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.2.2-hc0f95ea_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/snappy-1.2.2-hc0f95ea_1.tar.bz2
   sha256: fc41613709784859d6f314ddbd30742424fecbb39411af8eaf56c5bbdc7fcc2e
   md5: 8ac92e96fa542a92b19d5e4847c6e6fe
   depends:
@@ -8726,7 +8726,7 @@ packages:
   license_family: BSD
   size: 44150
   timestamp: 1767632418824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.1-py310hca03da5_0.tar.bz2
   sha256: 5c154ab5bd5c227d07c67e4600db48c6457546cd036064db51c660825a34af68
   md5: 436bf0420abe610c073d2db5aaee64ee
   depends:
@@ -8735,7 +8735,7 @@ packages:
   license_family: Other
   size: 16762
   timestamp: 1764329173600
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py310hca03da5_0.tar.bz2
   sha256: 83f37d7fdb2ae2499a0d56b0d8b73aaea225272a1133ec83b7cb5a0b76dcc038
   md5: 4cf31645d894294b7542e108702346c3
   depends:
@@ -8744,7 +8744,7 @@ packages:
   license_family: MIT
   size: 67932
   timestamp: 1696347608160
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/stack_data-0.6.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/stack_data-0.6.3-py310hca03da5_0.tar.bz2
   sha256: 5bd239cae4437f2460fa14dbf86569ff47414091b2461add28bd2a484ff6bfa2
   md5: 35a226cb7995afe3cee9845e98643875
   depends:
@@ -8756,7 +8756,7 @@ packages:
   license_family: MIT
   size: 53547
   timestamp: 1757067086266
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2022.3.0-h50665e7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tbb-2022.3.0-h50665e7_0.tar.bz2
   sha256: fc73600986294e5139faf41cd4fb8410a9f81ec2a970ca4bc13e42c4e59a33ca
   md5: a36929454b1d6e1423ef5ea084892007
   depends:
@@ -8767,7 +8767,7 @@ packages:
   license_family: Apache
   size: 142729
   timestamp: 1764336786030
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tblib-3.2.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tblib-3.2.2-py310hca03da5_0.tar.bz2
   sha256: 98a58d71c738bac13c8718ef7aa97feab970549cb235efde01f74e36a0917199
   md5: 048e04bcc47de193e46c527d63bd89e2
   depends:
@@ -8776,7 +8776,7 @@ packages:
   license_family: BSD
   size: 25620
   timestamp: 1768309871116
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.18.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.18.1-py310hca03da5_0.tar.bz2
   sha256: 6350647617b298485d28382efc58f407553da851902e0d73d48648297467e662
   md5: 39645e1c0378bcf302f6906eedfd80aa
   depends:
@@ -8790,7 +8790,7 @@ packages:
   license_family: BSD
   size: 27411
   timestamp: 1757934781863
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.4.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.4.0-py310hca03da5_0.tar.bz2
   sha256: ea14bd78ca65c40e2da218760168b5b0a9c83799baf205fdb7937c0d02773304
   md5: 7690a8aca2bc27cf2130958f7136b684
   depends:
@@ -8800,7 +8800,7 @@ packages:
   license_family: BSD
   size: 93761
   timestamp: 1738338925148
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.15-hcd8a7d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.15-hcd8a7d5_0.tar.bz2
   sha256: 63d203f86e045a2163b383d6aab0adcbbf31f2038a542b8d3d390161d139af7c
   md5: 3ce72515b1e0ae76f42e8697526e4044
   depends:
@@ -8810,7 +8810,7 @@ packages:
   license_family: BSD
   size: 3513169
   timestamp: 1755244020166
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-1.1.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/toolz-1.1.0-py310hca03da5_0.tar.bz2
   sha256: 8b66b7d5ca45420f3c23183c26d4f6e65736af4c3e148cf6503d2a6ab734657b
   md5: 6da18275b0ec945c96740e369709a683
   depends:
@@ -8819,7 +8819,7 @@ packages:
   license_family: BSD
   size: 108240
   timestamp: 1764677612042
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.5.4-py310haa24f5a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.5.4-py310haa24f5a_0.tar.bz2
   sha256: cffa25f81a98747dff1a1f2387e5f08a00d5ab86e3a9164399f8a4025a758a63
   md5: 60d4a5315f4e08541ab4d5cf3c334a98
   depends:
@@ -8829,7 +8829,7 @@ packages:
   license_family: Apache
   size: 721374
   timestamp: 1765992676076
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.67.1-py310h7eb115d_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.67.1-py310h7eb115d_1.tar.bz2
   sha256: 66f959f2955cefa73f76986dd6737ce36a5d841b59df7661a37113d287618af6
   md5: c7e55c5a22b024db5a077f41af1e256f
   depends:
@@ -8840,7 +8840,7 @@ packages:
   license_family: MOZILLA
   size: 127794
   timestamp: 1762863371812
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.14.3-py310hca03da5_0.tar.bz2
   sha256: e9de8f52d147e7dd072058d19202ee179841a56f792224729723a470571b717f
   md5: 3369365fe73af0c8b47246afdce17709
   depends:
@@ -8849,7 +8849,7 @@ packages:
   license_family: BSD
   size: 168051
   timestamp: 1718227147763
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.15.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.15.0-py310hca03da5_0.tar.bz2
   sha256: eb15045f6b0ba093c5a74db4ac60dbf2b168aa48d1831d4f3d5120cf3947f346
   md5: 57035c4c118645f841643447eac45712
   depends:
@@ -8859,7 +8859,7 @@ packages:
   license_family: PSF
   size: 12045
   timestamp: 1756281809414
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.15.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.15.0-py310hca03da5_0.tar.bz2
   sha256: eafc4ff0d095a318bf30816f1a82975f46b372890befff11ea40ffb284186264
   md5: 0271e52cfca1a1a534e6e12d413edf3e
   depends:
@@ -8868,7 +8868,7 @@ packages:
   license_family: PSF
   size: 78882
   timestamp: 1756281796859
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.3-py310hca03da5_0.tar.bz2
   sha256: 658385f4dccc5490bd61555a263ac804c9e1af93dc1770d57c2a486b1bc0e528
   md5: 2e125102827a75e1a446286c6cf9cd13
   depends:
@@ -8877,7 +8877,7 @@ packages:
   license_family: MIT
   size: 11752
   timestamp: 1758552140200
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.6.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.6.3-py310hca03da5_0.tar.bz2
   sha256: bdefa57de5569d63335eacef4013186f329d1f0622b91cde0d816472c11fd73d
   md5: 15129a89e43a55b7bbb9df7f9b64684f
   depends:
@@ -8891,14 +8891,14 @@ packages:
   license_family: MIT
   size: 303788
   timestamp: 1767810429921
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
   sha256: 20ae100fd04de16356f26e7c9dab514015e57a9d54fb78767aa5ed97de7846fb
   md5: f620d98b3d0072945948310c86f0f1c5
   license: MIT
   license_family: MIT
   size: 157385
   timestamp: 1706894678643
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wcwidth-0.2.14-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wcwidth-0.2.14-py310hca03da5_0.tar.bz2
   sha256: bf69c77d24643a88ebac3d36a969d6a27f018e10aa5dd208dadc20a383717797
   md5: 6182f7db1721eb4d0c08c19635061895
   depends:
@@ -8907,7 +8907,7 @@ packages:
   license_family: MIT
   size: 77080
   timestamp: 1767780842289
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py310hca03da5_1.tar.bz2
   sha256: 380724b46ae0ae1edb42bc668055aa2f27af3054d866b1e67e5acbb8481cd3a7
   md5: 6bf29c754086a9d03490af7ef3f22e6d
   depends:
@@ -8916,7 +8916,7 @@ packages:
   license_family: BSD
   size: 21597
   timestamp: 1643962111312
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py310hca03da5_0.tar.bz2
   sha256: 3f533f0c2bc844c53f530c8a25f1e1fe27b94d38a76b9601bca8dd0379b5ec05
   md5: 52665fad203685a097d2f3eca1085240
   depends:
@@ -8925,7 +8925,7 @@ packages:
   license_family: Apache
   size: 88221
   timestamp: 1715878353350
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.45.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.45.1-py310hca03da5_0.tar.bz2
   sha256: 7be9941a14a8bb95a46bdabd115c9fbea8fa13c5d21952a717d9b7abb5d05703
   md5: 6d5b497315633d3a4ecd903dc811f316
   depends:
@@ -8934,7 +8934,7 @@ packages:
   license_family: MIT
   size: 111877
   timestamp: 1737990437659
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py310hca03da5_0.tar.bz2
   sha256: 27799dc34dc007484c93c06823631ca50216f651801061db60b36fbf0b4afcf4
   md5: 15bd618a92cbd03ec24cd6fbfe81fa68
   depends:
@@ -8946,7 +8946,7 @@ packages:
   license_family: Apache
   size: 1818414
   timestamp: 1689041533776
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2025.4.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2025.4.0-py310hca03da5_0.tar.bz2
   sha256: 1bf8dbb49472bfef30b610c68bd5fa03c959ae2c2d5912d7a830f9295b4ee5dc
   md5: de9718ed62ad4de459e8ad087fb14c08
   depends:
@@ -8955,13 +8955,13 @@ packages:
   license_family: BSD
   size: 80274
   timestamp: 1758720221660
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h2c7f8f0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h2c7f8f0_1.tar.bz2
   sha256: 130edb44cc453a587b8f7905d6e58985c551f155ef6b3dedffedefe22910876f
   md5: a286e58e7683b512b727797350c54859
   depends:
@@ -8972,7 +8972,7 @@ packages:
   license_family: Other
   size: 329284
   timestamp: 1757676534886
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zict-3.0.0-py310hca03da5_1.tar.bz2
   sha256: aa43299af42ff172ac93a6d87425fc739d986ee1e5511d56c905073bd55cb896
   md5: 5cd09b8b6d496a6b8fb98807a1789814
   depends:
@@ -8983,7 +8983,7 @@ packages:
   license_family: BSD
   size: 77632
   timestamp: 1764604341481
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.23.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.23.0-py310hca03da5_0.tar.bz2
   sha256: f693534a9289bbd9f6295c48f875899f9c5e1b47a9327ed61bc198c90a4ea1b4
   md5: 58f235296fb183a8d38ce47a919a8cf1
   depends:
@@ -8992,7 +8992,7 @@ packages:
   license_family: MIT
   size: 26691
   timestamp: 1763977878981
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.3.1-h5f15de7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.3.1-h5f15de7_0.tar.bz2
   sha256: 318fc34152890a08929b5edc9d9ce9184940a79a0559d19076fca67f83c1a5f4
   md5: 44de0889dce735949a754be896c636bd
   depends:
@@ -9002,7 +9002,7 @@ packages:
   license_family: OTHER
   size: 83252
   timestamp: 1756475938331
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.7-h817c040_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.7-h817c040_0.tar.bz2
   sha256: 452a7c80738952b6fbb97fd36060173a1fe0345293d3e93799b16f478bb19802
   md5: 23c24ffdb88e129bd8b1825398e159c2
   depends:
@@ -9014,7 +9014,7 @@ packages:
   license_family: BSD
   size: 807221
   timestamp: 1758039171969
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.10.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-4.10.0-py310haa95532_0.tar.bz2
   sha256: a3bc51d7164a7091d6b938f392f39b60c8bc4029b6f524bc8d2f19981b02ea3d
   md5: 5d7332098a868c22aa87c5321df1e120
   depends:
@@ -9029,7 +9029,7 @@ packages:
   license_family: MIT
   size: 237153
   timestamp: 1758622478058
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aom-3.12.1-h00a0c3c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aom-3.12.1-h00a0c3c_0.tar.bz2
   sha256: afcf68df9772f1fdc03df5a4bcc4d935c0df6b4832dc7307e11eda0f109580b5
   md5: 63f14c1b98dd27cddab5824c45264fe1
   depends:
@@ -9040,7 +9040,7 @@ packages:
   license_family: BSD
   size: 7569923
   timestamp: 1754917837280
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-25.1.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-25.1.0-py310haa95532_0.tar.bz2
   sha256: 971623cf3d58650bf9ab692644a8f1c52ae750464a1c400735fc4cb380cd8ec0
   md5: 7427400ad2aba3c881628d210030afcd
   depends:
@@ -9052,7 +9052,7 @@ packages:
   license_family: MIT
   size: 29877
   timestamp: 1766067927256
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-25.1.0-py310h02ab6af_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-25.1.0-py310h02ab6af_0.tar.bz2
   sha256: 5ff53830ce5017edddc3d5bff5ef7c5deb75fdbd6422924c7bb919ef7083fbf9
   md5: fab6d15b391faa8eb6305e9a59e8e13e
   depends:
@@ -9065,7 +9065,7 @@ packages:
   license_family: MIT
   size: 45791
   timestamp: 1757925097385
-- conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-21.0.0-hcdc3a1c_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/arrow-cpp-21.0.0-hcdc3a1c_2.tar.bz2
   sha256: ad7b859cfabbd67070201f6764e7a71292ec3b7ad85b7642b7cc7e8da566fef1
   md5: b1b720729c1f23f4e32b848a270f2d81
   depends:
@@ -9096,7 +9096,7 @@ packages:
   license_family: Apache
   size: 9524047
   timestamp: 1766074720971
-- conda: https://repo.anaconda.com/pkgs/main/win-64/asttokens-3.0.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/asttokens-3.0.0-py310haa95532_0.tar.bz2
   sha256: 1c9d9ce62751b3daf87ab3461cac87aca6f44f3ceaeff796cf84225858f19c85
   md5: 3ae87016267f6d95f7c73d30e6f73cfc
   depends:
@@ -9107,7 +9107,7 @@ packages:
   license_family: Apache
   size: 42514
   timestamp: 1743630679017
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-25.4.0-py310haa95532_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-25.4.0-py310haa95532_2.tar.bz2
   sha256: e6262d17162552769cef0c2f997b693a8f140a03781c39fbb4217c43c7516fed
   md5: 6d04ad51e3910db6d973400ca422a91a
   depends:
@@ -9116,7 +9116,7 @@ packages:
   license_family: MIT
   size: 148441
   timestamp: 1762356979461
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-auth-0.9.0-h02ab6af_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-auth-0.9.0-h02ab6af_2.tar.bz2
   sha256: bd9c9bce700ded8c333f9e4b363bcf07a91f61955685ffed5c7a2fd443ad972b
   md5: 27ea578f57dd3eae7df38ec5b28290f9
   depends:
@@ -9132,7 +9132,7 @@ packages:
   license_family: Apache
   size: 123878
   timestamp: 1756801804971
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-cal-0.9.2-h02ab6af_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-cal-0.9.2-h02ab6af_1.tar.bz2
   sha256: 322a0607f2662f8167c2662cdc1ded1327b142f613adf5cc7ec4e29c93cbaf4b
   md5: c03308f73e20579246d466f71cb384d1
   depends:
@@ -9144,7 +9144,7 @@ packages:
   license_family: Apache
   size: 63583
   timestamp: 1756728836183
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.12.4-h02ab6af_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-common-0.12.4-h02ab6af_0.tar.bz2
   sha256: d0c244ec6d3091b6eadfc37f82d2cb8428340ac146ab0344bb0db6dcbd937989
   md5: e51620188276409e7db54903b6e1458a
   depends:
@@ -9155,7 +9155,7 @@ packages:
   license_family: Apache
   size: 266591
   timestamp: 1756721692676
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-compression-0.3.1-h02ab6af_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-compression-0.3.1-h02ab6af_2.tar.bz2
   sha256: 35185133195ba9570e5e9309799eed40b35348f3f6449a0878ed6aed2b0ecbcd
   md5: cbcf19057bcf127aa0b70eab0ab3bf3d
   depends:
@@ -9167,7 +9167,7 @@ packages:
   license_family: Apache
   size: 34700
   timestamp: 1756733067533
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.5.6-h02ab6af_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-event-stream-0.5.6-h02ab6af_0.tar.bz2
   sha256: fbca6cfe807f75f4954156dc00acd82995ce262192ff8befaca4bf184db93400
   md5: 746c5ef81b1708d63fb1176ccdfb42e9
   depends:
@@ -9181,7 +9181,7 @@ packages:
   license_family: Apache
   size: 70206
   timestamp: 1756758244313
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-http-0.10.4-h02ab6af_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-http-0.10.4-h02ab6af_0.tar.bz2
   sha256: 3e82b2d374ec8ebbc990a87f642813a9eaa2db5b197c4f720be80f9197c0b867
   md5: f426efdcb9b0fcf29419c0efadd2fc59
   depends:
@@ -9196,7 +9196,7 @@ packages:
   license_family: Apache
   size: 220219
   timestamp: 1756758354665
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-io-0.21.4-h02ab6af_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-io-0.21.4-h02ab6af_0.tar.bz2
   sha256: 6a120c721ae1585ddc12e777cbb0d1580a7689d96a9eec0019d75f27016a5172
   md5: c600cad0f41d8aa3a96d6a8f62f5e44b
   depends:
@@ -9209,7 +9209,7 @@ packages:
   license_family: Apache
   size: 187201
   timestamp: 1756733521397
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-mqtt-0.13.3-h02ab6af_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-mqtt-0.13.3-h02ab6af_0.tar.bz2
   sha256: a1ca3152f6cf4398f42bcc4089db0511982f376552867da8c182f09bccedf6d1
   md5: 1f2352365a5667b336036fb9246c5cc0
   depends:
@@ -9223,7 +9223,7 @@ packages:
   license_family: Apache
   size: 229132
   timestamp: 1756802273539
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-s3-0.8.7-h02ab6af_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-s3-0.8.7-h02ab6af_0.tar.bz2
   sha256: 159c65e6245d3b7a2ccf619ed2dee9ca3521a691c2c0e9603ede8280b3357dfc
   md5: dac7ef22f3005aa3490f950d5c7da26d
   depends:
@@ -9240,7 +9240,7 @@ packages:
   license_family: Apache
   size: 134713
   timestamp: 1756804011727
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-sdkutils-0.2.4-h02ab6af_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-sdkutils-0.2.4-h02ab6af_1.tar.bz2
   sha256: 5f4e41a6278c4e446d8b0024b8c82fd20f0d100a065bac4e7ed2b3bc236f5a5e
   md5: 8bc0c0540d57e3d440e27a3079000c22
   depends:
@@ -9252,7 +9252,7 @@ packages:
   license_family: Apache
   size: 70139
   timestamp: 1756729016503
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.2.7-h02ab6af_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-checksums-0.2.7-h02ab6af_1.tar.bz2
   sha256: b4d7ff44b6558b9510bf055a74576ea561f18acb97803a36af153fdc7e869baa
   md5: c9660c993e801fce502014e328a13a13
   depends:
@@ -9264,7 +9264,7 @@ packages:
   license_family: Apache
   size: 114486
   timestamp: 1756730232119
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-crt-cpp-0.34.0-h885b0b7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-crt-cpp-0.34.0-h885b0b7_0.tar.bz2
   sha256: fcefc8f9686c6e467a05d5d71daa41a9ac392ce4654fce4bc88a00c3b211165c
   md5: bb60149050224f7679b347adf9a535c4
   depends:
@@ -9285,7 +9285,7 @@ packages:
   license_family: Apache
   size: 385228
   timestamp: 1756806822189
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.11.638-hf0af688_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-sdk-cpp-1.11.638-hf0af688_0.tar.bz2
   sha256: 9a82a8af6083dde32f0bd9ca7ac4b0d4b4fb433efa022a90b9a6208e007c6785
   md5: 0f372da778cdf151dc42f468feeb2048
   depends:
@@ -9301,7 +9301,7 @@ packages:
   license_family: Apache
   size: 3926385
   timestamp: 1756812622029
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.14.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.14.2-py310haa95532_0.tar.bz2
   sha256: 6d128890050484d8d7c26523bdb408d83577cfc4bc4c35c665e1d73bbf7528f2
   md5: 2bf3f8fdbf9ddf05101a156571ae9f93
   depends:
@@ -9312,12 +9312,12 @@ packages:
   license_family: MIT
   size: 217746
   timestamp: 1764159515001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bleach-6.3.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bleach-6.3.0-py310haa95532_0.tar.bz2
   sha256: 5ebd69c74ed0cd3db17d96708a90a55e4f4135009086625826f87e309b3374cc
   md5: 386d1540728ccdbed3a45df274fa2665
   depends:
@@ -9330,7 +9330,7 @@ packages:
   license_family: Apache
   size: 83021
   timestamp: 1764153747179
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py310h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-3.2.1-py310h9909e9c_0.tar.bz2
   sha256: 2ccaa7e04dde683da73d56723ef56400645fa1afd2d8e331928be62f7b7107c2
   md5: 266b810907097ebc53c36a71a872f4e4
   depends:
@@ -9348,7 +9348,7 @@ packages:
   license_family: BSD
   size: 6497005
   timestamp: 1690546680130
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotlicffi-1.2.0.0-py310h885b0b7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotlicffi-1.2.0.0-py310h885b0b7_0.tar.bz2
   sha256: 4031245a70c0d5c99e016fab73b5769452e26a52fe3217b59cebee6ba58feccf
   md5: bebb15305b4df4dee21ce59328e4b337
   depends:
@@ -9361,7 +9361,7 @@ packages:
   license_family: MIT
   size: 396380
   timestamp: 1764961468276
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
   sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
   md5: 11e0af09a31e2d5df51c65a342032b85
   depends:
@@ -9371,7 +9371,7 @@ packages:
   license_family: BSD
   size: 112994
   timestamp: 1714511182837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.34.5-h731ff69_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/c-ares-1.34.5-h731ff69_0.tar.bz2
   sha256: f595d66fb4adf84437bd0a61a9ad83fbb5c7c2af013456519e23f1bf72bcc92e
   md5: 6b624b2841ac96b13b99e80eb7c227ec
   depends:
@@ -9382,14 +9382,14 @@ packages:
   license_family: MIT
   size: 220992
   timestamp: 1756141648148
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2025.12.2-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2025.12.2-haa95532_0.tar.bz2
   sha256: 3f3274071d65e440e6acd9e3fe0aeadfed53363894d6da5300411ea85e09a6d9
   md5: a78079075b6b91f913f941cab35a3a9f
   license: MPL-2.0
   license_family: Other
   size: 168160
   timestamp: 1764713881285
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cairo-1.18.4-he9e932c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cairo-1.18.4-he9e932c_0.tar.bz2
   sha256: 01340c8369f55b16e6dc76270303f49b5c829d294a6521632d3a200faedb0a05
   md5: 00f766daa02f2f92e71846467ce68f15
   depends:
@@ -9406,7 +9406,7 @@ packages:
   license_family: LGPL
   size: 672719
   timestamp: 1756136839925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2026.01.04-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2026.01.04-py310haa95532_0.tar.bz2
   sha256: 5d92b8e32bfcf9e3aee1f023f0690cc00842f1603ba9df9ef9ca74924591b4d8
   md5: efb575e802016c0d5c829c1f5803f38b
   depends:
@@ -9415,7 +9415,7 @@ packages:
   license_family: Other
   size: 154171
   timestamp: 1767659251469
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-2.0.0-py310h02ab6af_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-2.0.0-py310h02ab6af_1.tar.bz2
   sha256: e8999f8feb57e790a76093f77f7c1eb728bd0f7bb5d9e23fedc06b499cd0b2e4
   md5: 333a72f045ddf029bf328530213c7b1c
   depends:
@@ -9428,7 +9428,7 @@ packages:
   license_family: MIT
   size: 253622
   timestamp: 1761832851865
-- conda: https://repo.anaconda.com/pkgs/main/win-64/charset-normalizer-3.4.4-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/charset-normalizer-3.4.4-py310haa95532_0.tar.bz2
   sha256: b3e1fbe1b6dbf5daf2df5dbed71ca33aadb2160a701a35ecfbad398a0d896781
   md5: e3dafd6ced671c248e63413aaa36f83c
   depends:
@@ -9437,7 +9437,7 @@ packages:
   license_family: MIT
   size: 114946
   timestamp: 1761744990792
-- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.2.1-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/click-8.2.1-py310haa95532_1.tar.bz2
   sha256: 87dc119b4ad1bccd563cd1b0c33c17f1f5108a8e7d867e66306013d99b5b5d79
   md5: cf4788ebd74a3280a96003004f6e845e
   depends:
@@ -9447,7 +9447,7 @@ packages:
   license_family: BSD
   size: 285681
   timestamp: 1764332384742
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.1.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cloudpickle-3.1.2-py310haa95532_0.tar.bz2
   sha256: cd3c6550cc89750339b70aaaeed23f151b8bfedcffd0527948e544b7b13f7be6
   md5: 47208e1d2c12472f764251aa14913a4d
   depends:
@@ -9456,7 +9456,7 @@ packages:
   license_family: BSD
   size: 64510
   timestamp: 1764930594059
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py310haa95532_0.tar.bz2
   sha256: 9d1b2c34fa17a72e4e7b265cb5a421bb1a6dc893b35209739f1b710f79ebcc19
   md5: 269703fa9499eb42cfd7b9fd349ecd22
   depends:
@@ -9465,7 +9465,7 @@ packages:
   license_family: BSD
   size: 30646
   timestamp: 1672387329696
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py310haa95532_0.tar.bz2
   sha256: d7e9ef9b790e0d531490ee8eb3d727ace2a9f30d94e547029e1d0a84747c168a
   md5: 95fcb8f56ad31f96ae9b8767ad30cd35
   depends:
@@ -9474,7 +9474,7 @@ packages:
   license_family: CC
   size: 498954
   timestamp: 1709758473914
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.2.3-py310haa95532_0.tar.bz2
   sha256: d0190b02cc9e86b423584a4949137623c88031df482ace7bfb1b3db679fc516d
   md5: 6d4d9b71fd37f1181b0576be4c5f0e1b
   depends:
@@ -9483,7 +9483,7 @@ packages:
   license_family: BSD
   size: 14915
   timestamp: 1763119271246
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.3.1-py310h214f63a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.3.1-py310h214f63a_0.tar.bz2
   sha256: b33d9792d18c1ef1cdbdee252a7340ea47d2ef5a174edaf77eb5c9bcfa88a956
   md5: ffdd9900f86e96fc95ab0a7095a347f6
   depends:
@@ -9495,7 +9495,7 @@ packages:
   license_family: BSD
   size: 230563
   timestamp: 1732540222453
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cramjam-2.11.0-py310h7b75cbd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cramjam-2.11.0-py310h7b75cbd_0.tar.bz2
   sha256: 93e8ea1a5ffa04184320412a68fe7489305b7f4e048e79ec53eb0a8666fa6b33
   md5: 4a9ac6b00c81aff2da60e00e0cece7ff
   depends:
@@ -9507,7 +9507,7 @@ packages:
   license_family: MIT
   size: 1790999
   timestamp: 1762433235435
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cycler-0.12.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cycler-0.12.1-py310haa95532_0.tar.bz2
   sha256: 9407b0227acbc99e084d450855e19544d56fa8a48768f498eff1448bf061d8ba
   md5: 51f468daddd144a69cbced0001baf73f
   depends:
@@ -9516,7 +9516,7 @@ packages:
   license_family: BSD
   size: 17150
   timestamp: 1766068093613
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-1.1.0-py310h02ab6af_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cytoolz-1.1.0-py310h02ab6af_1.tar.bz2
   sha256: 6a06214e62d3415e84d45544fbb4b0f4b7e9ec1579168c1e306b7de7faa7ced7
   md5: 4bbb0a2240dfcddc1ddbb0b0a650e1ce
   depends:
@@ -9531,7 +9531,7 @@ packages:
   license_family: BSD
   size: 801966
   timestamp: 1764692978148
-- conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.15.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/datashader-0.15.1-py310haa95532_0.tar.bz2
   sha256: 0822558a2a06c1e086a79a1b625430680c7b0c013df6b50de81c6e139b991a08
   md5: 59c61b5197b47deda2e98e40a34511aa
   depends:
@@ -9553,7 +9553,7 @@ packages:
   license_family: BSD
   size: 17686916
   timestamp: 1689588294039
-- conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/datashape-0.5.4-py310haa95532_1.tar.bz2
   sha256: 6a56a78d48087626732e4472bcf286cddb4eeb62e659d7efebaeb4a461cc0109
   md5: f225dd204c5eae66bc59c6e29ae1757b
   depends:
@@ -9565,7 +9565,7 @@ packages:
   license_family: BSD
   size: 104152
   timestamp: 1642109356544
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dav1d-1.2.1-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/dav1d-1.2.1-h2bbff1b_0.tar.bz2
   sha256: e59970edb08a1dc24d761f88657aed895d7715f66ac9a9acfda440c29fda05e0
   md5: d3d303a3ffcedb8f4a92f29ac9e67bdc
   depends:
@@ -9575,7 +9575,7 @@ packages:
   license_family: BSD
   size: 723931
   timestamp: 1688746263355
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.8.16-py310h885b0b7_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.8.16-py310h885b0b7_1.tar.bz2
   sha256: 7d3ce12b75a188396bbb11a74ef3ae72fdf057d6d3ea4ae6f393ef2d800c3aee
   md5: 17b9a4b03222a61a013189f10192715b
   depends:
@@ -9587,7 +9587,7 @@ packages:
   license_family: MIT
   size: 3777324
   timestamp: 1762421756833
-- conda: https://repo.anaconda.com/pkgs/main/win-64/decorator-5.2.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/decorator-5.2.1-py310haa95532_0.tar.bz2
   sha256: e6936056323bc41213516e0e37194d56a29815db727f5ea220155d7e6d9bb6af
   md5: be7f28595c5e285be426e3aaf6a51adf
   depends:
@@ -9596,7 +9596,7 @@ packages:
   license_family: BSD
   size: 36196
   timestamp: 1757341292902
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py310haa95532_0.tar.bz2
   sha256: 542db7e187d0a9fe16b6eacb6bb93e5d574d1956687553a85a33fd580ab6ab7c
   md5: efac5662f2dbe0fabf392e1dd89eb105
   depends:
@@ -9605,7 +9605,7 @@ packages:
   license_family: MIT
   size: 17084
   timestamp: 1649926751338
-- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.3.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.3.0-py310haa95532_0.tar.bz2
   sha256: 1c20d1c9309251ac1088bb36a50dad7d2d2abd157b087ef7bd3562468f793da3
   md5: 9cdbc43d47b4bf390e5e9799fa9a844d
   depends:
@@ -9615,7 +9615,7 @@ packages:
   license_family: MIT
   size: 39821
   timestamp: 1761560475511
-- conda: https://repo.anaconda.com/pkgs/main/win-64/executing-2.2.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/executing-2.2.1-py310haa95532_0.tar.bz2
   sha256: 4e336f96f89e36a260033fb5ec7a09f7cb94ec758ac65754a583d19ea4135855
   md5: 6c230dcc8ca82394941f40b5baf6a4f6
   depends:
@@ -9624,7 +9624,7 @@ packages:
   license_family: MIT
   size: 786366
   timestamp: 1757061289467
-- conda: https://repo.anaconda.com/pkgs/main/win-64/expat-2.7.3-h885b0b7_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/expat-2.7.3-h885b0b7_4.tar.bz2
   sha256: c32db944928767e18657ac8b566fc24a316a202251875818acb04261a1c36823
   md5: 685781ee0e4a296c0376b430a9ee762b
   depends:
@@ -9636,7 +9636,7 @@ packages:
   license_family: MIT
   size: 34984
   timestamp: 1765208254263
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-2025.12.0-py310h540bb41_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fastparquet-2025.12.0-py310h540bb41_0.tar.bz2
   sha256: 680cdf2a4b4aed87412f9fa076064a7a13f1113e9056efb3713aef71cf5d8c42
   md5: 5483c722f369d671c77fe402cb8ec88c
   depends:
@@ -9653,7 +9653,7 @@ packages:
   license_family: Apache
   size: 623877
   timestamp: 1767955557648
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fontconfig-2.15.0-hd211d86_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fontconfig-2.15.0-hd211d86_0.tar.bz2
   sha256: 5b9db457b3e5ca111979618cfad681fd2329d89765fd35797e66d5b97ba85eab
   md5: e804fd8f2c14db57d7d49ec9ffceef00
   depends:
@@ -9669,7 +9669,7 @@ packages:
   license_family: MIT
   size: 247964
   timestamp: 1759153864775
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.61.0-py310h02ab6af_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fonttools-4.61.0-py310h02ab6af_0.tar.bz2
   sha256: e58dfeebd6bcf469d73054ee84f2305258feac2142dc6e00a0c36e53c9079e6e
   md5: a776e1e95b17fdd07157042eedf1f538
   depends:
@@ -9689,7 +9689,7 @@ packages:
   license_family: MIT
   size: 4109940
   timestamp: 1765445332157
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freeglut-3.8.0-hfcef157_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freeglut-3.8.0-hfcef157_0.tar.bz2
   sha256: b0b77d293e133733c06e8e312f984922f862b5c023fff349e676fc9167806d14
   md5: 4bad53679c11d7f3cbce95a45636fc64
   depends:
@@ -9700,7 +9700,7 @@ packages:
   license_family: MIT
   size: 165089
   timestamp: 1764693337022
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.13.3-h0620614_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.13.3-h0620614_0.tar.bz2
   sha256: f39fc9b2289fd2abfef82badce03940e3c8360930628e6233456d4a3ac110f5b
   md5: a67a8ec05803a940acbb45c798d502dc
   depends:
@@ -9712,7 +9712,7 @@ packages:
   license_family: Other
   size: 549086
   timestamp: 1743636775521
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fribidi-1.0.16-haf45083_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fribidi-1.0.16-haf45083_0.tar.bz2
   sha256: ab9b2cf79482e47f67505706b71a2fa81e75cf08c003600db62a44d16b46b7f8
   md5: 7c35b11142ea6a739135e78033fb5454
   depends:
@@ -9722,7 +9722,7 @@ packages:
   license: LGPL-2.1
   size: 79586
   timestamp: 1768428461478
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2026.1.0-py310h4442805_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fsspec-2026.1.0-py310h4442805_0.tar.bz2
   sha256: 1d82def23ef84bec8f6ad794b77d31381f40a94a3b93c25172be538b4b709b13
   md5: 1e19ecba4bfb8d3516ca7928707fcb9f
   depends:
@@ -9736,7 +9736,7 @@ packages:
   license_family: BSD
   size: 561291
   timestamp: 1768898410672
-- conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
   sha256: 7cb0df7aa62796b0081e1708003529c02411aca6a540bae97beaec919aa64e74
   md5: ea81fd813e10055553a8d7597c8be98f
   depends:
@@ -9746,7 +9746,7 @@ packages:
   license_family: BSD
   size: 322778
   timestamp: 1706888324269
-- conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
   sha256: ed1fa1a40c6739b48ff3a2d51c3df20e4983b59684b04d93e1337c5f2e93a954
   md5: 1797f64343a42395207cd452e6a6a751
   depends:
@@ -9757,7 +9757,7 @@ packages:
   license_family: BSD
   size: 94476
   timestamp: 1706895442146
-- conda: https://repo.anaconda.com/pkgs/main/win-64/graphite2-1.3.14-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/graphite2-1.3.14-hd77b12b_1.tar.bz2
   sha256: ba3646855133e9f24939b2587aebde03560ef8db3ffae043d75115406a06d3d1
   md5: 4d49aebabfe7d2a3b50a1985c1813e42
   depends:
@@ -9767,7 +9767,7 @@ packages:
   license_family: LGPL
   size: 99175
   timestamp: 1654175958308
-- conda: https://repo.anaconda.com/pkgs/main/win-64/harfbuzz-10.2.0-he2f9f60_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/harfbuzz-10.2.0-he2f9f60_1.tar.bz2
   sha256: 77ee7fe027d9d87d1a911b6c2b948159f54b13191cd6dc3126f6fad0e7c879a0
   md5: caccb3f93d885fcc8c837a5c6993e323
   depends:
@@ -9782,7 +9782,7 @@ packages:
   license_family: MIT
   size: 1423092
   timestamp: 1748952117569
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.16.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.16.0-py310haa95532_0.tar.bz2
   sha256: 80dab81197cb65dd03857939975857152a165020834e33cde4902d3530a76448
   md5: 832df2e9eb6b43f3a58bdd699e29a9ef
   depends:
@@ -9799,13 +9799,13 @@ packages:
   license_family: BSD
   size: 4484147
   timestamp: 1684953934888
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
   sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
   md5: 582d2c1135a89da757a038de831e7f39
   license: Intel proprietary
   size: 11086648
   timestamp: 1664812389803
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
   sha256: 945f4521793d7d279532d1ccd5157201c5cbf64f846bfe60249d01e1b4edf295
   md5: 0accae23d095c165ac731f4a1f3ca497
   depends:
@@ -9815,7 +9815,7 @@ packages:
   license_family: MIT
   size: 37021132
   timestamp: 1692294548916
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.11-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.11-py310haa95532_0.tar.bz2
   sha256: 535cc6d5a6c095b73ffead6ce4b9c69cadc07679834d77fd77928cab63eb4d7b
   md5: 03b70371a6a9647f2f200068843734ae
   depends:
@@ -9824,7 +9824,7 @@ packages:
   license_family: BSD
   size: 240459
   timestamp: 1761912086033
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-8.7.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-8.7.0-py310haa95532_0.tar.bz2
   sha256: 04dbf37836f2b5d77b9967da0f24e238f499ad3072a24868fa2c3a7825387aee
   md5: 654dc0bc1deaeb5e0ecbfa3a7c5d0e94
   depends:
@@ -9834,14 +9834,14 @@ packages:
   license_family: APACHE
   size: 59393
   timestamp: 1763996667819
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2025.0.0-haa95532_1164.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2025.0.0-haa95532_1164.tar.bz2
   sha256: 88546c6d7c8b78e2c3544620b6b91d732fce350e1791dde62b204b46d379dd0d
   md5: 00e8bffbde950cf35c70f9cd0e12d959
   license: LicenseRef-IntelSimplifiedSoftwareOct2022
   license_family: Proprietary
   size: 3510949
   timestamp: 1741121239324
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.29.5-py310haa95532_1.tar.bz2
   sha256: e8c8c414a5123ce1ea5b7452a4390078904199d9daa41aef6b5841af7b6cbcb8
   md5: 779b9fa1eed5c462229fcfdd12d5e4d3
   depends:
@@ -9862,7 +9862,7 @@ packages:
   license_family: BSD
   size: 192952
   timestamp: 1737660811516
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.30.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.30.0-py310haa95532_0.tar.bz2
   sha256: fcbcefd91289bb0fa6e92a17d0f47f52cc5ee1f3217bd502d6e92d77d07e9cf8
   md5: 63240b64215e78893789bdb71559188d
   depends:
@@ -9881,7 +9881,7 @@ packages:
   license_family: BSD
   size: 1341963
   timestamp: 1734548588627
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.19.2-py310haa95532_0.tar.bz2
   sha256: 319b732a5d60fe93e0ef46a2f4256a3089a689d84f5cdc1dc01e1251150d8406
   md5: 4ec2b623b48bcb1c189daee89c74c889
   depends:
@@ -9891,7 +9891,7 @@ packages:
   license_family: MIT
   size: 1042668
   timestamp: 1733988364778
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.6-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.6-py310haa95532_0.tar.bz2
   sha256: 0b9ea1f35b895507c4e871720d75f374f291378b7273626b1e90697cb0de998d
   md5: 47fa15da412fc404d6366f2fc00517b3
   depends:
@@ -9903,7 +9903,7 @@ packages:
   license_family: BSD
   size: 282811
   timestamp: 1741712027136
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9f-ha349fce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9f-ha349fce_0.tar.bz2
   sha256: 9c588e7b9d8f1942dcbfae6303e9268982cef141adfb4a3aa57c1a17ef56b97b
   md5: 8ffada6365cd9284debe6642d92e6a25
   depends:
@@ -9914,7 +9914,7 @@ packages:
   license_family: Other
   size: 470225
   timestamp: 1757499108897
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.25.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.25.1-py310haa95532_0.tar.bz2
   sha256: cdaf69bc05a906a91258dcb3de08175d311667753113c1bab3b0e2810305dd99
   md5: 8eaf4eac1edecc8b1d5a5b4df14ec098
   depends:
@@ -9927,7 +9927,7 @@ packages:
   license_family: MIT
   size: 177886
   timestamp: 1767955632383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2025.9.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2025.9.1-py310haa95532_0.tar.bz2
   sha256: 34d102c2187027546c51c483478ee908c1d18efdb03c717876d72b4c88329705
   md5: 1f938f95b26dcb756202999f426ff59f
   depends:
@@ -9937,7 +9937,7 @@ packages:
   license_family: MIT
   size: 15849
   timestamp: 1762788689711
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py310haa95532_0.tar.bz2
   sha256: ac6b6415f82a703882ba07242d9b7a3aa7241d75795c29838e1f136f48f8f228
   md5: 9614757161de6dbd60002f047add9c65
   depends:
@@ -9953,7 +9953,7 @@ packages:
   license_family: BSD
   size: 231452
   timestamp: 1676331217788
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.9.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.9.1-py310haa95532_0.tar.bz2
   sha256: eaeefc06ec082546c22100e68a2bf928e3e785b06a7b62ab7edbcc7831082ce4
   md5: 70a6362da9dbda1f200a2afb4dac3b27
   depends:
@@ -9965,7 +9965,7 @@ packages:
   license_family: BSD
   size: 122565
   timestamp: 1764588401954
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.12.0-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.12.0-py310haa95532_1.tar.bz2
   sha256: 2f77b74514c9eab3cea291a1c27fd8113638e577cee9a9fbb9aeedf0cf39535d
   md5: 16de8407cea04c51f9dfc85ff14500fc
   depends:
@@ -9982,7 +9982,7 @@ packages:
   license_family: BSD
   size: 65534
   timestamp: 1765813669617
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.17.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.17.0-py310haa95532_0.tar.bz2
   sha256: 112fd8f3b1dc0f10fc68fee2c3c8cd3a65bdd648c2e4bda19f64cc6ffdd97737
   md5: 02051f736f21c5274329b69117f4c09a
   depends:
@@ -10010,7 +10010,7 @@ packages:
   license_family: BSD
   size: 580639
   timestamp: 1764955377839
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.5.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.5.3-py310haa95532_0.tar.bz2
   sha256: a17c5eaa8cb9b56c1d076339b19f09d4523f32097f10a5ea0b21c29ed80f64d1
   md5: 0106f465fe6099492d9f93f070824051
   depends:
@@ -10021,7 +10021,7 @@ packages:
   license_family: BSD
   size: 25786
   timestamp: 1744706768584
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.3.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyterlab_pygments-0.3.0-py310haa95532_0.tar.bz2
   sha256: a244a27b572c77aa7109d64d034b7cddb7b9fa3a4af1c5f40475ecce5ce8cb98
   md5: e28baa3eac15f59dedd324248998ba68
   depends:
@@ -10033,7 +10033,7 @@ packages:
   license_family: BSD
   size: 19548
   timestamp: 1741124343838
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.9-py310h03f52e7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.9-py310h03f52e7_0.tar.bz2
   sha256: d1136bd7fb66883e4f03b2437e44833b0784b6f14a7d0e237029013c37a101e0
   md5: c589b1d0c3aeea2182cc04149fb9f129
   depends:
@@ -10045,7 +10045,7 @@ packages:
   license_family: BSD
   size: 94005
   timestamp: 1764159412460
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.17-h3732fa5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lcms2-2.17-h3732fa5_0.tar.bz2
   sha256: ba0c961acef9ca69f5cb75178947e4b4e97068fb296e4cb6dd4ed469bbfcfb73
   md5: 9378999eb90e498ba0bb04616e7d22d7
   depends:
@@ -10058,7 +10058,7 @@ packages:
   license_family: MIT
   size: 1091201
   timestamp: 1764162840085
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-4.0.0-h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-4.0.0-h5da7b33_0.tar.bz2
   sha256: 3a915692cf3e21e7cc4259faea2e17535530515acb3bc8fa00832d646bdeecf0
   md5: eda551db9b747f0606eddd001343ed36
   depends:
@@ -10068,7 +10068,7 @@ packages:
   license_family: Apache
   size: 207263
   timestamp: 1734423494890
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libabseil-20250814.1-cxx17_hcd311fc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libabseil-20250814.1-cxx17_hcd311fc_0.tar.bz2
   sha256: 33f0142d9e83bdfd1d46ecc2cdfdbc9f757f2403b512d3a0f9f15e703787150b
   md5: 87aa7060141e2f750a0e227bf10e9520
   depends:
@@ -10084,7 +10084,7 @@ packages:
   license_family: Apache
   size: 2342401
   timestamp: 1763134165026
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libavif-1.3.0-h5bd13ec_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libavif-1.3.0-h5bd13ec_0.tar.bz2
   sha256: 74c7793351bb9c2b8962af208dbfb447a9e1ee7998f9c0f019aaf84650cb4046
   md5: dfd8d4f89a5f66caf8abb99e26451a75
   depends:
@@ -10097,7 +10097,7 @@ packages:
   license_family: BSD
   size: 149645
   timestamp: 1763972861412
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.2.0-h907acca_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.2.0-h907acca_0.tar.bz2
   sha256: ffac6733681c36db8615166d9dd46f2b65aada2e6910ea94b5671fa46efc9b27
   md5: 56e196ce8bea259a3be91d8940f8dcfe
   depends:
@@ -10108,7 +10108,7 @@ packages:
   license_family: MIT
   size: 88727
   timestamp: 1762363782214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.2.0-h02c67a5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.2.0-h02c67a5_0.tar.bz2
   sha256: cb8cdb907cf39e5d9b3a8ee728c212ab8a57ca44ee32a49bbd9551dabf3687c0
   md5: 61b8956b21e5bbd7e7e703c7ce1cb78a
   depends:
@@ -10120,7 +10120,7 @@ packages:
   license_family: MIT
   size: 45496
   timestamp: 1762363799309
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.2.0-h483e6b9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.2.0-h483e6b9_0.tar.bz2
   sha256: 5fcc35661f1f6d318209220b03398116f097de97ab834434f7b2f49049c25205
   md5: 055a7403502e6d367b4061cee8f6476a
   depends:
@@ -10132,7 +10132,7 @@ packages:
   license_family: MIT
   size: 293712
   timestamp: 1762363815702
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.17.0-h97e0424_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libcurl-8.17.0-h97e0424_0.tar.bz2
   sha256: a838e88926609bf0d333c24164d9bff502e9308633728f1e21f5074278cc5492
   md5: a29a1b2c36005f799e7a1f6eee090a8c
   depends:
@@ -10147,7 +10147,7 @@ packages:
   license_family: MIT
   size: 415229
   timestamp: 1766164150992
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.22-h5bf469e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.22-h5bf469e_0.tar.bz2
   sha256: 46c58457ec8c074d5af22fe36a182d5c29e76f6248e7d1d5cb76c66beefe52aa
   md5: 5bd6c216dd03f3ccf9d108b7c8a29367
   depends:
@@ -10157,7 +10157,7 @@ packages:
   license_family: MIT
   size: 223776
   timestamp: 1734423384478
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libexpat-2.7.3-h885b0b7_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libexpat-2.7.3-h885b0b7_4.tar.bz2
   sha256: 932e6826a4562efc61e8b43189e12656cbcc7e2372558edff2ff983c1ede0bf4
   md5: e6beea803122dfc0483fb6266187511c
   depends:
@@ -10170,7 +10170,7 @@ packages:
   license_family: MIT
   size: 148787
   timestamp: 1765208241996
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
   sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
   md5: cf949d76148be1e2a534218d9c57df86
   depends:
@@ -10180,7 +10180,7 @@ packages:
   license_family: MIT
   size: 155435
   timestamp: 1714484319443
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libglib-2.86.3-h9bccc14_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libglib-2.86.3-h9bccc14_0.tar.bz2
   sha256: 6a9567ae069cb0bb1a6a7bd7c32307f24576610ddd0c3500708c510720e83567
   md5: 49293643c30180298ae7cf94f10e9fa9
   depends:
@@ -10195,7 +10195,7 @@ packages:
   license_family: LGPL
   size: 2870448
   timestamp: 1768845293182
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libgrpc-1.74.1-hde67744_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libgrpc-1.74.1-hde67744_0.tar.bz2
   sha256: d3ab9f17ad5ede0427dbfe0bcb45cde286e573f8bdbe43423273752ad6b38c95
   md5: 9d684e539102061467d1ee5b47ff6b00
   depends:
@@ -10218,7 +10218,7 @@ packages:
   license_family: APACHE
   size: 19928541
   timestamp: 1763141897575
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libhwloc-2.12.1-default_hfa10c62_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libhwloc-2.12.1-default_hfa10c62_1000.tar.bz2
   sha256: 57c4f52df69562710280423a3c019bb3821ebd2733f9e9df714de7846eef8ff7
   md5: 7f30659fb2c9bce856d02d972771a9df
   depends:
@@ -10230,7 +10230,7 @@ packages:
   license_family: BSD
   size: 2892706
   timestamp: 1755247386628
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_3.tar.bz2
   sha256: 4085f304bede2d9d04dbff5ebd53b3f5fbfaee1cbc120018a9efc0e89d027877
   md5: 7e6fe99f2af88b389cf7e371cad6f18f
   depends:
@@ -10240,7 +10240,7 @@ packages:
   license_family: GPL3
   size: 744054
   timestamp: 1714484485224
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libllvm20-20.1.8-h3aa9ab2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libllvm20-20.1.8-h3aa9ab2_0.tar.bz2
   sha256: b2f2adf01e9fd75b02f22c2c7b4cb9e9bf573a4fd2d5309239dbcb991d12a9ea
   md5: 626e87f8e4941eca1639aa0f9e640807
   depends:
@@ -10253,7 +10253,7 @@ packages:
   license_family: Apache
   size: 22659
   timestamp: 1756245073102
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libopenjpeg-2.5.4-h02ab6af_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libopenjpeg-2.5.4-h02ab6af_1.tar.bz2
   sha256: 2c9074b3004276687d2d06d242f0845e88cc823049afadd0acc6fcb914470f6f
   md5: bdae6b6bd1f52508c43e7fe5d1e19c93
   depends:
@@ -10264,7 +10264,7 @@ packages:
   license_family: BSD
   size: 206706
   timestamp: 1761733072883
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.50-h46444df_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.50-h46444df_0.tar.bz2
   sha256: eac2eb340003b909310dbfb03c5aa6f793dc34fe808e876f752bb16b0ac334b8
   md5: af888074f61c82f867bc7b1218f3c817
   depends:
@@ -10276,7 +10276,7 @@ packages:
   license_family: Other
   size: 304388
   timestamp: 1761139979647
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-6.33.0-h2a56892_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libprotobuf-6.33.0-h2a56892_1.tar.bz2
   sha256: 58d9beb3140410ad50e593dc81482ebba2d1057f1e96419580839c891ebd0cd6
   md5: 3ba9e90c397512fbd5588e210fef35e3
   depends:
@@ -10292,7 +10292,7 @@ packages:
   license_family: BSD
   size: 8530337
   timestamp: 1768235117966
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libre2-11-2025.11.05-ha6b10e7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libre2-11-2025.11.05-ha6b10e7_0.tar.bz2
   sha256: 5ac7855e733dab7b48b2a120ea0bbd305590388d9a03e51d14b2ff916f1f27b4
   md5: 71be7826d3c4ded1391af09ff1d81721
   depends:
@@ -10307,7 +10307,7 @@ packages:
   license_family: BSD
   size: 305229
   timestamp: 1763136507557
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.20-h83e8143_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.20-h83e8143_0.tar.bz2
   sha256: 58ec5e4c935e2f46582d60528f97c8c36f53a03bf871dba840c55359209cac92
   md5: de57d4ea71e8535472ba800d3d53777d
   depends:
@@ -10318,7 +10318,7 @@ packages:
   license_family: Other
   size: 599171
   timestamp: 1754318812535
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.11.1-h2addb87_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libssh2-1.11.1-h2addb87_0.tar.bz2
   sha256: c63c4909596a8fe198b94f8cccd91dd8445b92b1b3951a15fb836d88115f93af
   md5: 2ded634970ea802078cc2b68f903d45f
   depends:
@@ -10330,7 +10330,7 @@ packages:
   license_family: BSD
   size: 310776
   timestamp: 1732891385479
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.22.0-ha2884a9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libthrift-0.22.0-ha2884a9_0.tar.bz2
   sha256: b289699c93a37ed7525017b91c78d63f7d62297bedba6c3df8dafa3b4de9526d
   md5: 2ca6d5b790591a08a617e1c0aab1a88d
   depends:
@@ -10343,7 +10343,7 @@ packages:
   license_family: Apache
   size: 719710
   timestamp: 1761570611452
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.7.1-h3a18249_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.7.1-h3a18249_0.tar.bz2
   sha256: fd316598e94c9908369fd2c6f133d131d8757acaa118b31a8c5aba82a401b1f3
   md5: f12ff2a4efd1dd089d07f39f6a1bb01a
   depends:
@@ -10362,7 +10362,7 @@ packages:
   license_family: Other
   size: 1322118
   timestamp: 1763980764230
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.6.0-hbf3958f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.6.0-hbf3958f_0.tar.bz2
   sha256: efaca434d867f85aea21048795f6eab41037fe3dc4fefba82406e08f22aa7e10
   md5: eeb1c3e25645f6b4a178a8b98d9e7ef3
   depends:
@@ -10375,7 +10375,7 @@ packages:
   license_family: BSD
   size: 357482
   timestamp: 1763980689462
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.13.9-h6201b9f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxml2-2.13.9-h6201b9f_0.tar.bz2
   sha256: 7978d915fcef2d6fd7be02e4451b21f6a966cf33340f0d89b85d5036fa0a8b20
   md5: a64a07868009040e6a7cd7be5a68ee4f
   depends:
@@ -10388,7 +10388,7 @@ packages:
   license_family: MIT
   size: 3583805
   timestamp: 1761769014771
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libzlib-1.3.1-h02ab6af_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libzlib-1.3.1-h02ab6af_0.tar.bz2
   sha256: 2e77123a785ea2f599c49a1b100988e6a8bf89183556f15fb43056d24d7ee565
   md5: 2e50a625ac549de0dfc3348639d84174
   depends:
@@ -10401,7 +10401,7 @@ packages:
   license_family: OTHER
   size: 85278
   timestamp: 1756476045869
-- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.3-py310haa95532_0.tar.bz2
   sha256: 5695293566be21e0bcb993cea7c66aae69e6bfd76d045378b421d7ccd14b90ad
   md5: 1842ddb5cf92d5b4bdc0717363e78fcc
   depends:
@@ -10411,7 +10411,7 @@ packages:
   license_family: MIT
   size: 41227
   timestamp: 1758717707032
-- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.46.0-py310hd5b4e5d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/llvmlite-0.46.0-py310hd5b4e5d_0.tar.bz2
   sha256: 3f45a28459b98a5193130184aab14cf2653744e3fa7af2d168c2e11de57346ad
   md5: 7bab90d38a5380d628c6db55562f60eb
   depends:
@@ -10425,7 +10425,7 @@ packages:
   license: BSD-2-Clause AND Apache-2.0 WITH LLVM-exception
   size: 28303443
   timestamp: 1765874359177
-- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py310haa95532_0.tar.bz2
   sha256: c2e861d3109533539f2fc7a8ebaeb1aafbb0960aca546ea7ed5a91376c796399
   md5: 4d016b3bc975ab61c5786a6676693a9c
   depends:
@@ -10434,7 +10434,7 @@ packages:
   license_family: BSD
   size: 12966
   timestamp: 1652904192742
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.4.5-py310hb1efef3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-4.4.5-py310hb1efef3_0.tar.bz2
   sha256: 1e6d9f2847fc2d6ee8e11bce840a767121dafee16f897028c19bd4416e4f7baa
   md5: d655e33b6a2675dabb14ef6497e5d812
   depends:
@@ -10447,7 +10447,7 @@ packages:
   license_family: BSD
   size: 115730
   timestamp: 1762954309056
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
   sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
   md5: 320f40b75d93f3b96931c6d13c23946c
   depends:
@@ -10457,7 +10457,7 @@ packages:
   license_family: BSD
   size: 158902
   timestamp: 1714512129889
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.10-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.10-py310haa95532_0.tar.bz2
   sha256: f791b1effb36864d04e0b95f87cab1d37f4eeaceb8becb860b39e724aac62a4e
   md5: f2d3d9e31aa9875a056dee9c3f334646
   depends:
@@ -10466,7 +10466,7 @@ packages:
   license_family: BSD
   size: 172863
   timestamp: 1767787396667
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py310haa95532_1.tar.bz2
   sha256: ab424b8036257c53eb5110f8d8817ed959718c275e2dff88407332ce783519ed
   md5: 24f0c3faa37da73027d950da5b6cd3d3
   depends:
@@ -10476,7 +10476,7 @@ packages:
   license_family: MIT
   size: 126331
   timestamp: 1684280061614
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-3.0.2-py310h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-3.0.2-py310h827c3e9_0.tar.bz2
   sha256: c1ef624624b17f89a96cbbb209ff1930e813228894cb20293d27e761b7af8958
   md5: fa287059f9b6bc4ed3e17d1b8e3ac43e
   depends:
@@ -10489,7 +10489,7 @@ packages:
   license_family: BSD
   size: 39661
   timestamp: 1738584143805
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.10.8-py310h26e45b9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.10.8-py310h26e45b9_0.tar.bz2
   sha256: 811ff34bed8d1ad56e76235afabac89f23b54341f60a15425049e78fdb04868b
   md5: 1012ff06aa6564191b25bce86d67b89c
   depends:
@@ -10512,7 +10512,7 @@ packages:
   license_family: PSF
   size: 11727382
   timestamp: 1768296973478
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.2.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.2.1-py310haa95532_0.tar.bz2
   sha256: 59f0e860744f465e530b408e289db768e8f8d74f32d22d9d3fdc3661e5ec206a
   md5: 8ae3f96083f01e1abfcbfcdad81d9908
   depends:
@@ -10522,7 +10522,7 @@ packages:
   license_family: BSD
   size: 17747
   timestamp: 1762779302361
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.5.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.5.0-py310haa95532_0.tar.bz2
   sha256: 170f9482381b6fe35fc8e8dab872aa428fa12469b3ee8ef8c7520da0333bc79f
   md5: 7d16c3aba04c6a543dcd25b3884072fe
   depends:
@@ -10532,7 +10532,7 @@ packages:
   license_family: MIT
   size: 94334
   timestamp: 1756381168746
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.2-py310haa95532_0.tar.bz2
   sha256: da4e81a2e730121ed45c604bbf505d90911e01dd1943e544cf62eabad7cf8ce6
   md5: 28609f259bcf1efe81446ed3e3dc891c
   depends:
@@ -10541,7 +10541,7 @@ packages:
   license_family: MIT
   size: 23096
   timestamp: 1758552323170
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-3.1.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-3.1.2-py310haa95532_0.tar.bz2
   sha256: b41dd06a57751372dc78e51affe74839c4b688ddca2f8a244e35bc5756b1343d
   md5: d8e6fadd622f012d348a9e11114c2593
   depends:
@@ -10551,7 +10551,7 @@ packages:
   license_family: BSD
   size: 110095
   timestamp: 1741124237397
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2025.0.0-h5da7b33_930.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2025.0.0-h5da7b33_930.tar.bz2
   sha256: 788e1480084c5a9ac3d9446ad9a7fa2fd2da224ba8a66e006f2c854603c26b4e
   md5: 183d05fbc22c0ab21195d6003f64afb1
   depends:
@@ -10562,7 +10562,7 @@ packages:
   license_family: Proprietary
   size: 123317137
   timestamp: 1741121449798
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.5.2-py310h0b37514_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.5.2-py310h0b37514_0.tar.bz2
   sha256: 45393290bf1abdc7f722dd0b5c4970e623b3dbf5078dca88d8bf69d1b831c9e5
   md5: f92a08d21f84a940e00568de2c596693
   depends:
@@ -10575,7 +10575,7 @@ packages:
   license_family: BSD
   size: 83062
   timestamp: 1759414273260
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-2.1.1-py310h300f80d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-2.1.1-py310h300f80d_0.tar.bz2
   sha256: 108a4d95d9d124f474196fb762f3e43fa08ed10dc05a1f7397922f3818636e68
   md5: 8a04bed2e5442088d6f95350c172a841
   depends:
@@ -10593,7 +10593,7 @@ packages:
   license_family: BSD
   size: 165795
   timestamp: 1761593070473
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.3.0-py310ha5e6156_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.3.0-py310ha5e6156_0.tar.bz2
   sha256: d5b693440e90158a53d75ce8c9d911ac35d39222d9d1bb65939c63b4286940dc
   md5: e49c6a7e98ee746c94c52ad05ee2f410
   depends:
@@ -10609,7 +10609,7 @@ packages:
   license_family: BSD
   size: 308058
   timestamp: 1761593152981
-- conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.1.1-py310h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/msgpack-python-1.1.1-py310h5da7b33_0.tar.bz2
   sha256: 0fbe7c64660b1bb73aad181ae38b8c18b69d640f7247ca9024b80011a6cd821d
   md5: ece91b6ed3a0184ec0d6fb5cc422e85d
   depends:
@@ -10620,7 +10620,7 @@ packages:
   license_family: Apache
   size: 109237
   timestamp: 1750958968007
-- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-1.0.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/multipledispatch-1.0.0-py310haa95532_0.tar.bz2
   sha256: feca0b9fb67fb94a160fb84fde44996dcdf15b8fbd8d5b76c7cd7c416ee38480
   md5: 66f33716c87dccd161bf3b0b3aac2863
   depends:
@@ -10629,7 +10629,7 @@ packages:
   license_family: BSD
   size: 28062
   timestamp: 1756978500768
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.3.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-1.3.3-py310haa95532_0.tar.bz2
   sha256: 7f9808edbb56990b501e81a97f6ce33bac84cfbe876a10989d7431bb5bc6177b
   md5: 411c46097d465b253e7e0ac8bfa85459
   depends:
@@ -10642,7 +10642,7 @@ packages:
   license_family: BSD
   size: 10150145
   timestamp: 1765189547205
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.10.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.10.2-py310haa95532_0.tar.bz2
   sha256: 2b1785eee35d711bb68314d23a064721dd4c9a68806ba0e80beb883810ef7873
   md5: 6a580bc052e7179fd8207df8d8c8fe12
   depends:
@@ -10655,7 +10655,7 @@ packages:
   license_family: BSD
   size: 73721
   timestamp: 1741124473679
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.6-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-7.16.6-py310haa95532_0.tar.bz2
   sha256: 7c3d3e6ee26b8e54cc2a974c430760470df9f04312a6046dd02731e779abfc19
   md5: 384c8fe3ac51a9b00519b922d13811da
   depends:
@@ -10666,7 +10666,7 @@ packages:
   license_family: BSD
   size: 8243
   timestamp: 1741194892742
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-core-7.16.6-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-core-7.16.6-py310haa95532_0.tar.bz2
   sha256: dce355e463531d936296899ecb596d5a0e05560e28e82d782f4f49a8ba287744
   md5: 9f99f01e47455dbeb0fcc573c920068f
   depends:
@@ -10693,7 +10693,7 @@ packages:
   license: BSD-3-Clause
   size: 531083
   timestamp: 1741194860707
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-pandoc-7.16.6-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-pandoc-7.16.6-py310haa95532_0.tar.bz2
   sha256: dd02e532d2cdb1595faffaa342ff2077352b4f789e2fa080985c1112520c175e
   md5: 7a64635f74a898db8cc5fc94c845ec1e
   depends:
@@ -10703,7 +10703,7 @@ packages:
   license: BSD-3-Clause
   size: 8265
   timestamp: 1741194878108
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.10.4-py310haa95532_0.tar.bz2
   sha256: b60400ded73de1554aebeb8c292d55bc8c98b3c5701b35285019468fb4c4ac9f
   md5: b12bb18cd2fb67bf7bc0f2be962dd557
   depends:
@@ -10716,7 +10716,7 @@ packages:
   license_family: BSD
   size: 180615
   timestamp: 1728050835184
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py310haa95532_0.tar.bz2
   sha256: e18ba942bb3f8a0ace571cfe58557aa5088acac13d094fde0302cf6452b2f7bf
   md5: eb32799be5cf9de16c3688a34cb2b409
   depends:
@@ -10725,7 +10725,7 @@ packages:
   license_family: BSD
   size: 14318
   timestamp: 1708533067532
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.7-py310haa95532_0.tar.bz2
   sha256: e8e153535f8e002678562c80d96e6a0abf6fc132c07a5c1b98759985d2e934ea
   md5: e4776c87a5f45a19ac3a76c4f429f9f5
   depends:
@@ -10750,7 +10750,7 @@ packages:
   license_family: BSD
   size: 649666
   timestamp: 1717631447182
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.4-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.4-py310haa95532_0.tar.bz2
   sha256: ad7ca45f0fd4367d991de584c84719b4fc08e4f83d817996fdb9e41817e30666
   md5: 34d2aa88757595e757a9a2f6234b1731
   depends:
@@ -10760,7 +10760,7 @@ packages:
   license_family: BSD
   size: 23809
   timestamp: 1741707972451
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.63.1-py310h54bf9d2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numba-0.63.1-py310h54bf9d2_0.tar.bz2
   sha256: ddb45892db5149617e97a875c8e01cc76c779b8082b7b0a72c271396c1c5a773
   md5: 0462e3f72565cc5c03ab2d8f37be112f
   depends:
@@ -10783,7 +10783,7 @@ packages:
   license_family: BSD
   size: 4684566
   timestamp: 1765906176603
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py310h12f7302_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py310h12f7302_1.tar.bz2
   sha256: 31746de75b5502248a15da5ec1852a7773ac257e184d7d2a5e303fbd7ebb5c2d
   md5: fc00573edd76a59e4fe5ac180661cc18
   depends:
@@ -10801,7 +10801,7 @@ packages:
   license_family: BSD
   size: 13387
   timestamp: 1755595042232
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py310he4e2855_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py310he4e2855_1.tar.bz2
   sha256: eeb48933573ce52974db91b8340c78d8264a960e89a31d3c043e30c9b48c7889
   md5: b7ae7a125db14819a81ae4229317bebd
   depends:
@@ -10818,7 +10818,7 @@ packages:
   license_family: BSD
   size: 10046118
   timestamp: 1755595016406
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.18-h543e019_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.18-h543e019_0.tar.bz2
   sha256: 59d81d1e37b3abdd377bcfa43741e4b77209b150d2c1c55b1fb7e6ef724fd4c7
   md5: 48b99fea9541b04984ba3af1dac0f1bc
   depends:
@@ -10830,7 +10830,7 @@ packages:
   license_family: Apache
   size: 8353123
   timestamp: 1759490461024
-- conda: https://repo.anaconda.com/pkgs/main/win-64/orc-2.2.0-h79e1e1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/orc-2.2.0-h79e1e1e_1.tar.bz2
   sha256: 9a80063950d261a967f72cc0028becc082be56a79fb107273e541916ad70176e
   md5: 8263c942be7be180746d24374a17d5dd
   depends:
@@ -10849,7 +10849,7 @@ packages:
   license_family: Apache
   size: 1473905
   timestamp: 1764689909240
-- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.7.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/overrides-7.7.0-py310haa95532_0.tar.bz2
   sha256: f460578737a2f23fb5b1847cf0b580721ee31e324f1e3da531c2e1a567ee37a3
   md5: 0c626aa0cb02167440f199a04713faea
   depends:
@@ -10858,7 +10858,7 @@ packages:
   license_family: APACHE
   size: 35653
   timestamp: 1762349146753
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-25.0-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-25.0-py310haa95532_1.tar.bz2
   sha256: 4b0ec37a59609d162d5bd46191f7672ed011d2ed058e3220bc465492778ffbc8
   md5: aec5f6c40353b6501fb88eaccbc7ff43
   depends:
@@ -10867,14 +10867,14 @@ packages:
   license_family: Apache
   size: 168318
   timestamp: 1761049138959
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandoc-3.8-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandoc-3.8-haa95532_0.tar.bz2
   sha256: 2f78bba1f41497d7ca63eee3cddd258386c87900b0abdd218f479a605c092026
   md5: 79df078a732c569f5f243ab4f4b16146
   license: GPL-2.0-or-later
   license_family: GPL
   size: 32908716
   timestamp: 1758807035109
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandocfilters-1.5.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandocfilters-1.5.1-py310haa95532_0.tar.bz2
   sha256: 37df9288d8b891ffb73f2c6de940397d2b6be0f22fa276a50765c33976a730ea
   md5: 3df457829a5660b7e38a54277432d06b
   depends:
@@ -10883,7 +10883,7 @@ packages:
   license_family: BSD
   size: 15845
   timestamp: 1756977656103
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-1.2.3-py310haa95532_0.tar.bz2
   sha256: 2f62ba591aea27c6f15773bdfdc09558fcadd11559e48aadc3ea69960bf1e113
   md5: ae943e3adf679487f8c691397d9fe533
   depends:
@@ -10907,7 +10907,7 @@ packages:
   license_family: BSD
   size: 17018899
   timestamp: 1695146622867
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-1.13.0-py310haa95532_0.tar.bz2
   sha256: 7d8d0ef93307680696d575a445b442de32320fa3eb4b2fc090164ff0ac7e17a8
   md5: 3eeea45a3f84b3b563e5990a36429dcb
   depends:
@@ -10916,7 +10916,7 @@ packages:
   license_family: BSD
   size: 143435
   timestamp: 1684915381677
-- conda: https://repo.anaconda.com/pkgs/main/win-64/parso-0.8.5-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/parso-0.8.5-py310haa95532_0.tar.bz2
   sha256: d958b3cef4efc4e4e583bb5c63f7af764ab980c4a892811f60b675a6c321b79b
   md5: 174cfb66d566fc943e1cb1c081d8c74c
   depends:
@@ -10925,7 +10925,7 @@ packages:
   license_family: OTHER
   size: 180264
   timestamp: 1762781965864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/partd-1.4.2-py310haa95532_0.tar.bz2
   sha256: 9e89f1a2c6a2623e57943c87029f11c84949fda4ec2b5e87f5791feeea6d7ae7
   md5: 9cb905acc9d134cde747bbdc42054db3
   depends:
@@ -10939,7 +10939,7 @@ packages:
   license_family: BSD
   size: 37003
   timestamp: 1736803791927
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pcre2-10.46-h5740b90_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pcre2-10.46-h5740b90_0.tar.bz2
   sha256: 094769f189ebd4d4b6cad745a07c163b3d2c41afcbeefeea2136cbf1f4ad5602
   md5: 4ab3e048e11018a0461ceca64796424c
   depends:
@@ -10952,7 +10952,7 @@ packages:
   license_family: BSD
   size: 3007931
   timestamp: 1759825896688
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-12.0.0-py310h4212202_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-12.0.0-py310h4212202_1.tar.bz2
   sha256: 6258971772d50b7240b11588522b90f8db1f0831ce0a80b573f496fad8250567
   md5: d22d36ff0b73e3e4d3c0b76ab74e39f9
   depends:
@@ -10974,7 +10974,7 @@ packages:
   license_family: Other
   size: 838435
   timestamp: 1762528415821
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pixman-0.46.4-h4043f72_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pixman-0.46.4-h4043f72_0.tar.bz2
   sha256: 362952382855bddac08440d2c03d819f22430cbd946817aa6d6925703a33319a
   md5: a90b06706795b88b913313bec06734ea
   depends:
@@ -10985,7 +10985,7 @@ packages:
   license_family: MIT
   size: 270570
   timestamp: 1755256536068
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-4.5.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-4.5.0-py310haa95532_0.tar.bz2
   sha256: 4632d3c8c010000b3639aad509bfb31db1c51d6ffa57760bab7347c70fa1aa21
   md5: ac8779589205e503ec30c3d4d5aec668
   depends:
@@ -10994,7 +10994,7 @@ packages:
   license_family: MIT
   size: 35567
   timestamp: 1762356649178
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.21.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.21.1-py310haa95532_0.tar.bz2
   sha256: 328a570bd4e31f361be29cf17494e4daf90bbc2581bf0e4140fe7e576803b3d5
   md5: 6f422683a09b4d1aae04be9d7676aca4
   depends:
@@ -11003,7 +11003,7 @@ packages:
   license_family: Apache
   size: 118891
   timestamp: 1744271703425
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.52-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.52-py310haa95532_1.tar.bz2
   sha256: 57af9abfd6cfcce5918afefe735a54e832b8e83f608eb398b6e6c30bf873699b
   md5: ca27bcf16ab9b23e939bb523dcbc255d
   depends:
@@ -11015,7 +11015,7 @@ packages:
   license_family: BSD
   size: 621394
   timestamp: 1761745060545
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-7.0.0-py310h02ab6af_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-7.0.0-py310h02ab6af_1.tar.bz2
   sha256: 4d8c216bbe04e37781a080853a5f896c2608c11451b70974ad5c1d3024c7c366
   md5: 88caa251b1032c255cdc20a4762ecaa5
   depends:
@@ -11027,7 +11027,7 @@ packages:
   license_family: BSD
   size: 429272
   timestamp: 1761896636025
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pure_eval-0.2.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pure_eval-0.2.3-py310haa95532_0.tar.bz2
   sha256: 113730924bfe8cb16b70a11a1a7c2bcfd26d014ab341ecf6daf97fbd2fc1cec6
   md5: bfccfa6fb5d7eccb649bd55984faac8e
   depends:
@@ -11036,7 +11036,7 @@ packages:
   license_family: MIT
   size: 28270
   timestamp: 1757067109554
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-21.0.0-py310h42c1672_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyarrow-21.0.0-py310h42c1672_1.tar.bz2
   sha256: 05a006a15679f821fb2041f94f6f442cce0c1a955253bf4bcbd3098fd0e0bdec
   md5: 6bca35b930e5c9b083b9e382ee81c0d2
   depends:
@@ -11049,7 +11049,7 @@ packages:
   license_family: Apache
   size: 5374561
   timestamp: 1764939694679
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pycparser-2.23-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pycparser-2.23-py310haa95532_0.tar.bz2
   sha256: 3ba6aa3dd169162d7d611022cec5c1ffff11874ad799c5b3bb5d80e31bf39d30
   md5: 64b0d5dd1f61e80585dc9f9a66fdbeff
   depends:
@@ -11058,7 +11058,7 @@ packages:
   license_family: BSD
   size: 232495
   timestamp: 1757496100500
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.6.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyct-0.6.0-py310haa95532_0.tar.bz2
   sha256: 72b581bd12b0cba91c3d79ebd8143c98c709c6749b6864da06c78f552a72e2ed
   md5: 9e7890bb994c7d28c1b0eefe470582fd
   depends:
@@ -11070,7 +11070,7 @@ packages:
   license_family: BSD
   size: 60870
   timestamp: 1759932207666
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.19.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.19.2-py310haa95532_0.tar.bz2
   sha256: 33c50248605a91f9d03a9f49e84c0508f00c112be085a0d00dae6b61d6f7485f
   md5: d0374446d5d31123493f86dc61e7f3f2
   depends:
@@ -11081,7 +11081,7 @@ packages:
   license_family: BSD
   size: 5228792
   timestamp: 1762431478812
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.2.5-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.2.5-py310haa95532_0.tar.bz2
   sha256: b7358a41c4b5161d01da1d6baefa9b200e458bc99cd79f04e46677f2ea1d4f91
   md5: b6f745c157414da3024be95304f470ef
   depends:
@@ -11090,7 +11090,7 @@ packages:
   license_family: MIT
   size: 549696
   timestamp: 1763973934465
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py310haa95532_1.tar.bz2
   sha256: eeea16f6b3bb9f5f15b662df3fb28c151274e87ae9eff11ae4c5ad41f6da44a7
   md5: c8991a20c9e7b71aa9d73111e2ba511f
   depends:
@@ -11100,7 +11100,7 @@ packages:
   license_family: BSD
   size: 28712
   timestamp: 1761753068988
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.10.19-h981015d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.10.19-h981015d_0.tar.bz2
   sha256: d2463c7b7f725e6e88815b35113d64edc23580af947fa75892c3ccf2c7f78e2b
   md5: d644a3d91ead219de83075a9e8f7029b
   depends:
@@ -11123,7 +11123,7 @@ packages:
   license_family: PSF
   size: 17508706
   timestamp: 1761065071419
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py310haa95532_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py310haa95532_2.tar.bz2
   sha256: 8e12b59e93c1b5489ed6fdbd044d5626158356ea840953f0da6bfd15caf21d71
   md5: 2a984d495e1cd2dd84c0049f248d61ab
   depends:
@@ -11133,7 +11133,7 @@ packages:
   license_family: BSD
   size: 290793
   timestamp: 1716495894571
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.21.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.21.2-py310haa95532_0.tar.bz2
   sha256: be66b02f646185d14bdd7c646cade064f2924d755e29be53684902244a023b5c
   md5: 0e57a5d9275ec185c257dc4c9b03d472
   depends:
@@ -11142,7 +11142,7 @@ packages:
   license_family: BSD
   size: 272322
   timestamp: 1763718767803
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-4.0.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-json-logger-4.0.0-py310haa95532_0.tar.bz2
   sha256: b746d931836bfc9d020512b41a9a3bb6ff3939115516cc907087eb3cc107c60f
   md5: e54be7a3cadbea0bf6ad516fc93d8c6e
   depends:
@@ -11151,7 +11151,7 @@ packages:
   license_family: BSD
   size: 30469
   timestamp: 1764590285196
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.7.5-py310h5823743_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-lmdb-1.7.5-py310h5823743_0.tar.bz2
   sha256: 386c205910b56f64f6bc7678a097946ffc494e414d221624ce2d1fad37abb25b
   md5: 3a6f432e5bf93649e4f88e865109f646
   depends:
@@ -11163,7 +11163,7 @@ packages:
   license_family: Other
   size: 150634
   timestamp: 1764243911976
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python_abi-3.10-3_cp310.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python_abi-3.10-3_cp310.tar.bz2
   sha256: bfa6752b2dab58c27c79ed9636d638fc7a8ec876ecdfab6a517f0802652c3c05
   md5: dd185883263018563eca7243a40a8f24
   constrains:
@@ -11172,7 +11172,7 @@ packages:
   license_family: BSD
   size: 4962
   timestamp: 1764349791676
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2025.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2025.2-py310haa95532_0.tar.bz2
   sha256: e8a0c1087ced217ccc53e7550050ce6f3deb6ed3c8c4cac41a1e270beb9344aa
   md5: c235e2dd675763a64387702a35c27a4e
   depends:
@@ -11181,7 +11181,7 @@ packages:
   license_family: MIT
   size: 279238
   timestamp: 1752136432982
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.6-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.6-py310haa95532_0.tar.bz2
   sha256: d6b3d90b8a9fea1a2562e7e4136ab3059970d2ae2ca9fa154f09513f9f0c9fb1
   md5: 4bd9aebdcccf408f889661bb44f08938
   depends:
@@ -11194,7 +11194,7 @@ packages:
   license_family: BSD
   size: 62050
   timestamp: 1758102194153
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-311-py310h885b0b7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-311-py310h885b0b7_0.tar.bz2
   sha256: 8dc23c410c1645d5081c95db235da30a0f9109b1c58747a4cc219fdd125ec909
   md5: 41df4be9302646515a884a02a70e6927
   depends:
@@ -11206,7 +11206,7 @@ packages:
   license_family: Other
   size: 15017954
   timestamp: 1754671659175
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.15-py310h72d21ff_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.15-py310h72d21ff_0.tar.bz2
   sha256: 7161580ca9426fc71909125e2eb63529cd11c345488c9429ec5c06c6a92c655d
   md5: 8e824996fe2ca2603d5332cebaa40ec6
   depends:
@@ -11218,7 +11218,7 @@ packages:
   license_family: MIT
   size: 247926
   timestamp: 1741872556102
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.3-py310hb9a58be_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.3-py310hb9a58be_0.tar.bz2
   sha256: 2b8bf2765adcad3774c45ea6fa09cc4f680cd36f71bbfdc8d3e4d5228682a276
   md5: 234f4ecd5f20e8bd2cddede1e4b19979
   depends:
@@ -11231,7 +11231,7 @@ packages:
   license_family: MIT
   size: 219564
   timestamp: 1763465569630
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py310h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-24.0.1-py310h2bbff1b_0.tar.bz2
   sha256: a2f884b8700f604220f7f196ca023ae9a90a0cb25ee113c091647254b0f0f6eb
   md5: 019a502ef2b8f2363d3925570a01da73
   depends:
@@ -11243,7 +11243,7 @@ packages:
   license_family: Other
   size: 474370
   timestamp: 1709318932082
-- conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2025.11.05-hc24cdf5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/re2-2025.11.05-hc24cdf5_0.tar.bz2
   sha256: 62685e276af944e516d613e1263e7d2039a436ca89b324838be454d27d2dedf4
   md5: 8f14673595d8cddd64d16124ddd1080e
   depends:
@@ -11252,7 +11252,7 @@ packages:
   license_family: BSD
   size: 274609
   timestamp: 1763136519172
-- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.37.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/referencing-0.37.0-py310haa95532_0.tar.bz2
   sha256: 7b259a6e433e9f9be58256f529d8271d873bcd447663eda6d54aff8ef68f9ebb
   md5: 1219002ce84e916b5af05b2872bc2cc1
   depends:
@@ -11264,7 +11264,7 @@ packages:
   license_family: MIT
   size: 63593
   timestamp: 1762536949358
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.5-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.32.5-py310haa95532_1.tar.bz2
   sha256: cbb04f23a80037a687c747d3fff2659bb60ebabdee9adf491755bf37079d0567
   md5: c2881674c7405974700d46aa957d60b7
   depends:
@@ -11280,7 +11280,7 @@ packages:
   license_family: Apache
   size: 144290
   timestamp: 1762359651688
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py310haa95532_0.tar.bz2
   sha256: 558cf5fcbf151bf419079e13b5f3cc5f0a51af0596661bef50290903e52cdc24
   md5: a86808657e019161b1e8e0a492afe6e2
   depends:
@@ -11290,7 +11290,7 @@ packages:
   license_family: MIT
   size: 9367
   timestamp: 1683077232021
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py310haa95532_0.tar.bz2
   sha256: e069e307e66cf1289bad542f9293e7a79b902d15d330c875ccce709b2b2523dd
   md5: 9f21f24f35c99c432df830795e3a33f4
   depends:
@@ -11299,7 +11299,7 @@ packages:
   license_family: MIT
   size: 9734
   timestamp: 1683059168209
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.28.0-py310h114bc41_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rpds-py-0.28.0-py310h114bc41_0.tar.bz2
   sha256: 5905ba54d9887b1ce1df26b1cf76810986c709b659734dee1252658618536fd9
   md5: 924f92d78a6b931ccee76c6ef2a2a3c6
   depends:
@@ -11311,7 +11311,7 @@ packages:
   license_family: MIT
   size: 255945
   timestamp: 1762366811349
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.15.3-py310h1bbe36f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/scipy-1.15.3-py310h1bbe36f_1.tar.bz2
   sha256: ffa0365a6aa7e911799157143a29cd660798ccebf4ca6dca63454dc8cf61d754
   md5: 272cf47fcf114dc3548cbbe97520c506
   depends:
@@ -11329,7 +11329,7 @@ packages:
   license_family: BSD
   size: 32031380
   timestamp: 1759222877751
-- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.3-py310haa95532_0.tar.bz2
   sha256: 14e0535b74363bd37bd4229697a5a7a7c80c8d759a9cadacd1ecd10a70ad5380
   md5: 6589581ae4a1324f3d3a3df51bacf56d
   depends:
@@ -11338,7 +11338,7 @@ packages:
   license_family: BSD
   size: 59103
   timestamp: 1768170838371
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-80.9.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-80.9.0-py310haa95532_0.tar.bz2
   sha256: bb93511774e89c5c967507da18c9c675cbd3ffaabdc240676232c8ff793b4ae7
   md5: f2e80a46ffd3ee1069cb94e9cddb9df4
   depends:
@@ -11347,7 +11347,7 @@ packages:
   license_family: MIT
   size: 1844446
   timestamp: 1759863388037
-- conda: https://repo.anaconda.com/pkgs/main/win-64/six-1.17.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/six-1.17.0-py310haa95532_0.tar.bz2
   sha256: 402e2cb276d03a4d2d8fd3951e7d7f2fcf31c596c71ce553b16cb514119b8a32
   md5: 262b035440f7e5f45c5340f1610200ee
   depends:
@@ -11356,7 +11356,7 @@ packages:
   license_family: MIT
   size: 32580
   timestamp: 1744271586206
-- conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.2.2-hab6b7b3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/snappy-1.2.2-hab6b7b3_1.tar.bz2
   sha256: f177814848e0f18215f54a25126d7e9307398bcd291c9716871286494361681a
   md5: ba9632d870849506421dc45297feecd3
   depends:
@@ -11367,7 +11367,7 @@ packages:
   license_family: BSD
   size: 118521
   timestamp: 1767632526284
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.1-py310haa95532_0.tar.bz2
   sha256: fb58a4ec186065216c81cb14aa4ec028ceddf62b9ad71280c6f8634edac582be
   md5: c854b692a497b3b46036f14217516afd
   depends:
@@ -11376,7 +11376,7 @@ packages:
   license_family: Other
   size: 16874
   timestamp: 1764329254779
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py310haa95532_0.tar.bz2
   sha256: a23892e537aa5387f4a7e817dfdcc4b9c5fec6b40a1695f99ecb7e3896f8f1b3
   md5: 022293f076961b460cfe654421c3a69a
   depends:
@@ -11385,7 +11385,7 @@ packages:
   license_family: MIT
   size: 67725
   timestamp: 1696347732280
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.51.1-hda9a48d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.51.1-hda9a48d_0.tar.bz2
   sha256: 8ee81897ab4d69bef962efa9c373c205baf21bb416c36921963db07cbcdceec2
   md5: 337d1804c595354abf87d7434cae4ab4
   depends:
@@ -11396,7 +11396,7 @@ packages:
   license_family: Other
   size: 1505061
   timestamp: 1767608649031
-- conda: https://repo.anaconda.com/pkgs/main/win-64/stack_data-0.6.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/stack_data-0.6.3-py310haa95532_0.tar.bz2
   sha256: cfbd746be170e60c003b2346a83486117a8a62801a7a3422d249b6e90800e06e
   md5: cf955a0d11c9f9ca9c27359585e7f44b
   depends:
@@ -11408,7 +11408,7 @@ packages:
   license_family: MIT
   size: 53765
   timestamp: 1757067083583
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2022.3.0-h90c84d6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2022.3.0-h90c84d6_0.tar.bz2
   sha256: 3af1170b68d17007d78febb7bf390bfa8343a962d867e8c6590724b82247a03d
   md5: 386ac0fdc3bf21317e03762cf90695c2
   depends:
@@ -11420,7 +11420,7 @@ packages:
   license_family: Apache
   size: 203521
   timestamp: 1764336927072
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-devel-2022.3.0-h90c84d6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-devel-2022.3.0-h90c84d6_0.tar.bz2
   sha256: 05a3ea61861cb61b2edc601ceda6a8c25f6f278d9516aa56c4d65691e2831490
   md5: b6cf67b3fb0b28202c8d54b668b42c1f
   depends:
@@ -11433,7 +11433,7 @@ packages:
   license_family: Apache
   size: 1272952
   timestamp: 1764336942662
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tblib-3.2.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tblib-3.2.2-py310haa95532_0.tar.bz2
   sha256: fefe0fb5179167d09eab8ffbe018b136fe7cd3c16dbd31156d68e2b24355bf35
   md5: bb341768e1520044fb9d98e4df934a03
   depends:
@@ -11442,7 +11442,7 @@ packages:
   license_family: BSD
   size: 25687
   timestamp: 1768310054045
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.18.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.18.1-py310haa95532_0.tar.bz2
   sha256: 87fbe4474cb9f4fda75066d5e3b7b43a480229d1fdda2c5512279a6e04333582
   md5: 07b0432e19c2419ea6e3e7333a863b3a
   depends:
@@ -11456,7 +11456,7 @@ packages:
   license_family: BSD
   size: 27578
   timestamp: 1757934990782
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.4.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.4.0-py310haa95532_0.tar.bz2
   sha256: fa8f86c77759b2e75a748f87105019e271e27151a9f0ec08b9a8884336b458ff
   md5: 84d91cf7523126598a8e39d02f493fd1
   depends:
@@ -11466,7 +11466,7 @@ packages:
   license_family: BSD
   size: 93531
   timestamp: 1738337989299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.15-hf199647_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.15-hf199647_0.tar.bz2
   sha256: dc4ac74ef5703abc317f7762eea416a50a7e7b36deee9ff2cd9061e9292bc5e8
   md5: cac27313b231546bc9d937fcb21ae5f5
   depends:
@@ -11478,7 +11478,7 @@ packages:
   license_family: BSD
   size: 3874380
   timestamp: 1755244051664
-- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-1.1.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/toolz-1.1.0-py310haa95532_0.tar.bz2
   sha256: e0a4418964d6504e8997732b43b0f663d3ab858b365d8d737e6dd8c2086cf8a5
   md5: 6c29a7cc9ccc26c5e68eb4bfc5264698
   depends:
@@ -11487,7 +11487,7 @@ packages:
   license_family: BSD
   size: 108387
   timestamp: 1764677784817
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.5.4-py310h02ab6af_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.5.4-py310h02ab6af_0.tar.bz2
   sha256: 040e82cca36a9171514ebfd26db3b6708f0f214d75f2c926292403dee870ddc4
   md5: 87202c2637e5e66a91ff0777a837a6fe
   depends:
@@ -11499,7 +11499,7 @@ packages:
   license_family: Apache
   size: 728368
   timestamp: 1765992835272
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.67.1-py310h4442805_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.67.1-py310h4442805_1.tar.bz2
   sha256: 6cc08e755a64113fa05d9aeae7843b20a4c19262422fbe9a5d876b072c125ef1
   md5: e23516f4255378296c3224cc952efab3
   depends:
@@ -11511,7 +11511,7 @@ packages:
   license_family: MOZILLA
   size: 158835
   timestamp: 1762863484601
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.14.3-py310haa95532_0.tar.bz2
   sha256: 69030849e5c9fb4b81997b209da56a31f39f70b17cd81ad5fa87a03829aa9c04
   md5: 7dd354534a9f7c43229a6707470c5936
   depends:
@@ -11520,7 +11520,7 @@ packages:
   license_family: BSD
   size: 167935
   timestamp: 1718227167930
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.15.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.15.0-py310haa95532_0.tar.bz2
   sha256: 72667741205012b4a40a245afef11ea55f568beb40f7b0833caf0735341b9298
   md5: b02dcf0af865ac8331b335a29a49c14d
   depends:
@@ -11530,7 +11530,7 @@ packages:
   license_family: PSF
   size: 12020
   timestamp: 1756281344566
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.15.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.15.0-py310haa95532_0.tar.bz2
   sha256: 592b90e9e3316df59e60bdcdc7a08558f45d299ab0c4415ec2777f6668b27c9e
   md5: f23a8c512a31322faad3b9234c6d70d4
   depends:
@@ -11539,7 +11539,7 @@ packages:
   license_family: PSF
   size: 78964
   timestamp: 1756281334161
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.3-py310haa95532_0.tar.bz2
   sha256: 39cf0decc41cbb49e268c41446620a72426242ad6bd45e879db9a793ebc9edb8
   md5: fe4ff63c5c84ac259436527f8a3d7cf7
   depends:
@@ -11548,7 +11548,7 @@ packages:
   license_family: MIT
   size: 11898
   timestamp: 1758552222421
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ucrt-10.0.22621.0-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ucrt-10.0.22621.0-haa95532_0.tar.bz2
   sha256: 551c5227a32ab5edb1a9b3617da50f4a5b1db6ac978f30984dc4feb530bfd572
   md5: b89556d8841d1ca1d37e1d4b660d58ba
   constrains:
@@ -11556,7 +11556,7 @@ packages:
   license: LicenseRef-MicrosoftWindowsSDK10
   size: 1284620
   timestamp: 1752158202557
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.6.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-2.6.3-py310haa95532_0.tar.bz2
   sha256: 01dfe6be9953413f28c88ea084a47ebb040e8f88ef0ce904b2e2d185048c701b
   md5: 2ddef262068d2d727e2f4b406a9a7e3f
   depends:
@@ -11570,7 +11570,7 @@ packages:
   license_family: MIT
   size: 309295
   timestamp: 1767810529507
-- conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
   sha256: 2ef16d0252e04063d44d0683831d55b485f713fe5af2c2efd61753fb4f27d7e4
   md5: 256ab1d5dce70111a1f4807a5a9fc322
   depends:
@@ -11580,7 +11580,7 @@ packages:
   license_family: MIT
   size: 100982
   timestamp: 1706894771410
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.42-haa95532_5.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.42-haa95532_5.tar.bz2
   sha256: b6259eccee818ace89c5ad2667e252c3b23b12503a943a6a057b9feb36278f4e
   md5: 515894551c4f3754e750e88ce534e9cc
   depends:
@@ -11589,7 +11589,7 @@ packages:
   license_family: BSD
   size: 9972
   timestamp: 1744721179868
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc14_runtime-14.44.35208-h4927774_10.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc14_runtime-14.44.35208-h4927774_10.tar.bz2
   sha256: 3149d0e594b29dbd69065e6826730da17eb6e5cd3e2f15379ae9e1b29d8791e2
   md5: bb49becbcb3d1e4bc4b8dd076ea4199c
   depends:
@@ -11600,7 +11600,7 @@ packages:
   license_family: Proprietary
   size: 1534690
   timestamp: 1752199754308
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.44.35208-ha6b5a95_10.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.44.35208-ha6b5a95_10.tar.bz2
   sha256: 5fc445cc95515cb218fb3ac9e7e45a767237d68b53f42ca2b0fb4b3d561109e5
   md5: ee159e59f61b9c7fc28cc73d81fdfeab
   depends:
@@ -11609,7 +11609,7 @@ packages:
   license_family: BSD
   size: 19128
   timestamp: 1752199762272
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wcwidth-0.2.14-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wcwidth-0.2.14-py310haa95532_0.tar.bz2
   sha256: d121f999a9465b51fb52efebff7e70bab3204c75abf1fe46edea595861caae23
   md5: 3f332e9838e3ddeb3ca29a7fc4259d34
   depends:
@@ -11618,7 +11618,7 @@ packages:
   license_family: MIT
   size: 77152
   timestamp: 1767779258839
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py310haa95532_1.tar.bz2
   sha256: 5feccb42695e0a5f0d8e47806ec4a38d80812946bedff171a1b6bde5513843e7
   md5: 8719f9841803cf96f733f59aafbd147e
   depends:
@@ -11627,7 +11627,7 @@ packages:
   license_family: BSD
   size: 21579
   timestamp: 1642093965560
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py310haa95532_0.tar.bz2
   sha256: f371d3506e4e8480ffde0e9d0fb1b44c2bfdbea57b23cccd609ca3aa034b3f83
   md5: 85953c8badca12976eb5d368835fcefb
   depends:
@@ -11636,7 +11636,7 @@ packages:
   license_family: Apache
   size: 118154
   timestamp: 1715878578248
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.45.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.45.1-py310haa95532_0.tar.bz2
   sha256: 18705434a4ff1378bd84d1e2131ccf6f002a9bbe057d03dcec33fbf643a06721
   md5: 4afe1fc2823ea86f8f12bcc80bcee9cb
   depends:
@@ -11645,7 +11645,7 @@ packages:
   license_family: MIT
   size: 142232
   timestamp: 1737990665883
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py310haa95532_1.tar.bz2
   sha256: a3563cafe1f5c60e3b29c53859b0b729d5371bb30eef69ed9a0b80a2b817ed11
   md5: 6e2f0604292a3156603b56329f2d1785
   depends:
@@ -11653,13 +11653,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 8793
   timestamp: 1761746313924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py310haa95532_0.tar.bz2
   sha256: fb467c7eacdf962bcb8f24476709a65db51ea60ee4ddb75f12ed30b4ea69d531
   md5: 85a71410f54365f053f787ab5782859b
   depends:
@@ -11671,7 +11671,7 @@ packages:
   license_family: Apache
   size: 1813278
   timestamp: 1689041769969
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2025.4.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2025.4.0-py310haa95532_0.tar.bz2
   sha256: 785a9e09a5c33ad72935cf6605b5e88910d0fe025fbde89791c9456e7417e94f
   md5: beb986b2708d5c1ab3f387ef1ad69ce0
   depends:
@@ -11680,7 +11680,7 @@ packages:
   license_family: BSD
   size: 79249
   timestamp: 1758720256560
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.6.4-h4754444_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.6.4-h4754444_1.tar.bz2
   sha256: d3458fa18024725ca330e84a0f63b531133a781b33e360b35c50cd278cc66ec4
   md5: 3f6d85e0ee495eb5fdae370f7f456e4c
   depends:
@@ -11690,7 +11690,7 @@ packages:
   license_family: GPL2
   size: 290014
   timestamp: 1739468425589
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -11699,7 +11699,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-h6c54ac7_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-h6c54ac7_1.tar.bz2
   sha256: 23510bfdd00463d170c7962d34b355e0e3739748705cff3e7f6c09f931ccf7f6
   md5: 857aaa8d36ad69c6fc3b07c45418ca6e
   depends:
@@ -11711,7 +11711,7 @@ packages:
   license_family: Other
   size: 8402466
   timestamp: 1757676535552
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zict-3.0.0-py310haa95532_1.tar.bz2
   sha256: d70ed088345da7a4d6fbfbd82e027fbdc40f20a7c4ce380dc163dc86e4af0bd7
   md5: db8c2be78a4edc8bedc315ea7e95cfb4
   depends:
@@ -11722,7 +11722,7 @@ packages:
   license_family: BSD
   size: 77772
   timestamp: 1764604410317
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.23.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.23.0-py310haa95532_0.tar.bz2
   sha256: d401c280ed4475911fe42fda035cf7fb784a39ed152e6be24dd6ddca8c78545a
   md5: 91cb520ff74939dc731749aa72d1827c
   depends:
@@ -11731,7 +11731,7 @@ packages:
   license_family: MIT
   size: 26805
   timestamp: 1763977979094
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.3.1-h02ab6af_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.3.1-h02ab6af_0.tar.bz2
   sha256: a42852305292e1991c2f45f542df0007a58c0a6e2a59964517b0bd45787215d5
   md5: 576e63267d028c9a24bddf1a4e8ab36d
   depends:
@@ -11743,7 +11743,7 @@ packages:
   license_family: OTHER
   size: 118318
   timestamp: 1756476083170
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.7-h56299aa_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.7-h56299aa_0.tar.bz2
   sha256: b9b207c204156bea7425eca2141c01974511e6acc557957e64409293721eb000
   md5: 63b4871fee1e1959f7b7006b63b2cb2b
   depends:

--- a/census/pixi.toml
+++ b/census/pixi.toml
@@ -21,9 +21,9 @@ fastparquet = ">=2024.2.0"
 holoviews = "1.16.0.*"
 pandas = "2.0.1.*"
 xyzservices = ">=2022.9"
-pip = "*"
-setuptools = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+setuptools = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [tasks.notebook]
 cmd = "jupyter notebook census.ipynb"

--- a/census/pixi.toml
+++ b/census/pixi.toml
@@ -1,0 +1,35 @@
+[workspace]
+name = "census"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2", "conda-forge"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2016-03-27"
+maintainers = ["jbednar"]
+categories = ["Geospatial"]
+labels = ["datashader", "holoviews", "dask", "bokeh"]
+title = "Census 2010"
+description = "Visualize 2010 Census demographic data"
+
+[dependencies]
+python = "3.10.*"
+notebook = "<7"
+colorcet = ">=3.1.0"
+dask = "2023.5.0.*"
+datashader = "0.15.1.*"
+fastparquet = ">=2024.2.0"
+holoviews = "1.16.0.*"
+pandas = "2.0.1.*"
+xyzservices = ">=2022.9"
+pip = "*"
+setuptools = "*"
+wheel = "*"
+
+[tasks.notebook]
+cmd = "jupyter notebook census.ipynb"
+depends-on = ["download"]
+
+[tasks.download]
+env = { FILENAME = "data/census2010.parq" }
+cmd = "mkdir -p $FILENAME && curl -fsSL -o .DATA.zip https://s3.amazonaws.com/datashader-data/census2010.parq.zip && python -m zipfile -e .DATA.zip $FILENAME && rm .DATA.zip"
+outputs = ["data/census2010.parq"]

--- a/census/pixi.toml
+++ b/census/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "census"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2", "conda-forge"]
+channels = ["main", "msys2", "conda-forge"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/convert-pixi.py
+++ b/convert-pixi.py
@@ -1,0 +1,1329 @@
+#!/usr/bin/env python
+"""Convert an anaconda-project (spec + lock) to pixi (pixi.toml + pixi.lock).
+
+Strategy: direct translation (no re-solve).
+  * pixi.toml  <- anaconda-project.yml   (loose spec / matchspecs)
+  * pixi.lock  <- anaconda-project-lock.yml (exact name=version=build pins)
+
+The anaconda lock only stores ``name=version=build`` per platform.  A valid
+pixi.lock additionally needs each package's URL + sha256/md5 + depends metadata.
+That gap is filled by fetching ``repodata.json`` once per channel+subdir: the
+compressed download is kept verbatim on disk (these are frozen legacy projects,
+so the snapshot never needs refreshing) and each run walks it with simdjson,
+converting only the few hundred records the lock actually pins.
+
+After writing pixi.lock, it is cross-checked against the anaconda lock's
+name=version=build pins (pass --no-verify to skip).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import hashlib
+import json
+import posixpath
+import re
+import sys
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import orjson
+import simdjson
+import tomllib
+import yaml
+import zstandard
+
+if sys.stdout.isatty():
+    GREEN, RED, YELLOW, RESET, CLEAR = (
+        "\033[0;32m",
+        "\033[0;31m",
+        "\033[0;33m",
+        "\033[0m",
+        "\033[F\033[K",
+    )
+else:
+    GREEN = RED = YELLOW = RESET = CLEAR = ""
+
+
+# anaconda-project channel name -> explicit pixi channel URLs.  ``defaults`` is a
+# conda metachannel that pixi does not expand on its own (it would resolve to the
+# non-existent conda.anaconda.org/defaults), so we map it to the real repo URLs.
+CHANNEL_MAP = {
+    "defaults": [
+        "https://repo.anaconda.com/pkgs/main",
+        # "https://repo.anaconda.com/pkgs/r",
+        "https://repo.anaconda.com/pkgs/msys2",
+    ],
+}
+
+
+def resolve_channels(names: list[str]) -> list[str]:
+    """Expand anaconda-project channel names to pixi channel URLs."""
+    urls: list[str] = []
+    for name in names:
+        for url in CHANNEL_MAP.get(name, [name]):
+            if url not in urls:
+                urls.append(url)
+    return urls
+
+
+def _lock_channel_url(c: str) -> str:
+    """Return the full URL for a channel as it appears in pixi.lock."""
+    c = c.rstrip("/")
+    if not c.startswith(("https://", "http://")):
+        c = f"https://conda.anaconda.org/{c}"
+    return c + "/"
+
+
+# anaconda-project lock buckets that are not real subdirs -> the platforms they
+# apply to.  Their packages are ``noarch``.  Concrete subdir buckets map to the
+# matching platform only.
+NONARCH_BUCKETS = {
+    "all": None,  # filled with every project platform at runtime
+    "unix": ["linux-64", "osx-64", "osx-arm64"],
+    "osx": ["osx-64", "osx-arm64"],
+    "linux": ["linux-64"],
+    "win": ["win-64"],
+}
+
+
+# --------------------------------------------------------------------------- #
+# parsing the anaconda-project files
+# --------------------------------------------------------------------------- #
+def load_yaml(path: Path) -> dict:
+    with path.open() as fh:
+        return yaml.safe_load(fh)
+
+
+def matchspec_to_pixi(entry: str) -> tuple[str, str]:
+    """``python=3.10`` -> ('python', '3.10.*'); ``notebook <7`` -> (.., '<7')."""
+    entry = entry.strip()
+    m = re.match(r"^([A-Za-z0-9_.\-]+)\s*(.*)$", entry)
+    if not m:
+        raise ValueError(f"cannot parse package spec: {entry!r}")
+    name, rest = m.group(1), m.group(2).strip()
+    if not rest:
+        return name, "*"
+    if rest.startswith("=="):
+        return name, rest
+    if rest.startswith("="):  # conda single '=' -> fuzzy match
+        ver = rest[1:].strip()
+        return name, ver if ver.endswith("*") else f"{ver}.*"
+    if rest[0] in "<>!~":  # explicit operator
+        op_len = 2 if rest[1:2] == "=" else 1
+        return name, rest[:op_len] + rest[op_len:].strip()
+    return name, rest if rest.endswith("*") else f"{rest}.*"  # bare version
+
+
+def split_packages(packages: list) -> tuple[list[str], list[str]]:
+    """Split anaconda-project's ``packages`` list into (conda specs, pip specs).
+
+    Pip requirements are nested as a single ``- pip: [...]`` entry among the
+    otherwise flat list of conda matchspecs.
+    """
+    conda, pip = [], []
+    for p in packages:
+        if isinstance(p, dict) and "pip" in p:
+            pip.extend(p["pip"])
+        else:
+            conda.append(p)
+    return conda, pip
+
+
+def pip_requirement_to_pypi(entry: str) -> tuple[str, str, list[str]]:
+    """``fastcluster>=1.3.0`` -> ('fastcluster', '>=1.3.0', []);
+    ``mne[hdf5]>=1.8.0`` -> ('mne', '>=1.8.0', ['hdf5'])."""
+    entry = entry.strip()
+    m = re.match(r"^([A-Za-z0-9_.\-]+)(\[[^\]]*\])?\s*(.*)$", entry)
+    if not m:
+        raise ValueError(f"cannot parse pip requirement: {entry!r}")
+    name, extras_str, rest = m.group(1), m.group(2), m.group(3).strip()
+    extras = [e.strip() for e in extras_str[1:-1].split(",")] if extras_str else []
+    if not rest:
+        return name, "*", extras
+    if rest.startswith("=") and not rest.startswith("=="):  # conda-style single '='
+        rest = "=" + rest
+    return name, rest, extras
+
+
+def _dep_line(name: str, ver: str) -> str:
+    key = name if re.match(r"^[A-Za-z0-9_-]+$", name) else f'"{name}"'
+    return f"{key} = {json.dumps(ver)}"
+
+
+def _pypi_dep_line(name: str, ver: str, extras: list[str]) -> str:
+    key = name if re.match(r"^[A-Za-z0-9_-]+$", name) else f'"{name}"'
+    if not extras:
+        return f"{key} = {json.dumps(ver)}"
+    extras_toml = ", ".join(json.dumps(e) for e in extras)
+    return f"{key} = {{ version = {json.dumps(ver)}, extras = [{extras_toml}] }}"
+
+
+def _command_str(spec: dict) -> str | None:
+    if "notebook" in spec:
+        return f"jupyter notebook {spec['notebook']}"
+    if "unix" in spec:
+        return spec["unix"].strip()
+    return None
+
+
+def build_pixi_tasks(commands: dict, depends_on: list[str] | None = None) -> str:
+    """Render [tasks] from anaconda-project's ``commands`` block.
+
+    ``notebook: <file>`` commands have no direct pixi equivalent, so they are
+    translated to ``jupyter notebook <file>``. ``supports_http_options`` is dropped:
+    pixi already forwards trailing args (``pixi run <task> --port ...``) to
+    the underlying command, so there is nothing extra to represent.
+
+    When ``depends_on`` is given (the project's download tasks), each command
+    is rendered as a ``[tasks.<name>]`` table with a ``depends-on`` so the data
+    is fetched before the command runs.
+    """
+    if depends_on:
+        deps = ", ".join(f'"{d}"' for d in depends_on)
+        blocks = []
+        for name, spec in commands.items():
+            cmd = _command_str(spec)
+            if cmd is None:
+                continue
+            blocks.append(f"[tasks.{name}]\ncmd = {json.dumps(cmd)}\ndepends-on = [{deps}]")
+        return "\n\n".join(blocks) + "\n"
+    lines = ["[tasks]"]
+    for name, spec in commands.items():
+        cmd = _command_str(spec)
+        if cmd is None:
+            continue
+        lines.append(f"{name} = {json.dumps(cmd)}")
+    return "\n".join(lines) + "\n"
+
+
+def build_activation_env(variables: dict) -> str:
+    """Render ``[activation.env]`` from anaconda-project's ``variables`` block.
+
+    anaconda-project accepts two forms per variable: a bare scalar
+    (``INTAKE_CACHE_DIR: data``) and a mapping carrying a ``description`` and an
+    optional ``default`` (``DS_DATASET: {description: ..., default: nyc_taxi_50k}``).
+    Only the ``default`` holds a value, so the mapping form collapses to it -
+    matching ``proj_env_vars`` in dodo.py. A mapping *without* a ``default`` is
+    anaconda-project's way of declaring a variable the user must supply, so there
+    is nothing to pre-set and the entry is skipped.
+
+    Values are always emitted as strings: these are environment variables, and
+    the libraries reading them (e.g. ``DASK_DATAFRAME__QUERY_PLANNING=False``)
+    expect the string, not a TOML boolean.
+    """
+    lines = []
+    for name, value in variables.items():
+        if isinstance(value, dict):
+            if "default" not in value:
+                continue
+            value = value["default"]
+        if value is None:
+            continue
+        lines.append(f"{name} = {json.dumps(str(value))}")
+    if not lines:
+        return ""
+    return "[activation.env]\n" + "\n".join(lines) + "\n"
+
+
+def build_download_tasks(downloads: dict) -> tuple[list[str], list[str]]:
+    """Render ``[tasks.download...]`` entries from anaconda-project's ``downloads`` block.
+
+    Each entry fetches ``url`` to ``filename``; ``outputs`` lets pixi skip the
+    task once the file already exists, so it is safe to wire in as a
+    ``depends-on`` of every other task. ``unzip: true`` mirrors
+    anaconda-project's own unzip behaviour (``ziputils.unpack_zip``): the
+    archive is extracted straight into a directory at ``filename`` rather than
+    into its parent, since these datasets are typically written out as a
+    directory of parts (e.g. a dask-written ``*.parq``) rather than a single
+    file matching that name. Extraction goes through ``python -m zipfile -e``
+    rather than ``unzip`` so the task only needs the environment's python, which
+    pixi guarantees, instead of an ``unzip`` binary on the host. A single
+    download is just named ``download``;
+    multiple downloads are disambiguated as ``download-<name>`` and joined by an
+    aggregate ``download`` task depending on all of them. That way ``download``
+    is the one entry point every other task (and dodo.py) can depend on,
+    whatever the number of downloads.
+
+    The returned names are what other tasks should depend on - i.e. just
+    ``["download"]`` when there is anything to fetch - not every task rendered.
+    """
+    if not downloads:
+        return [], []
+    blocks: list[str] = []
+    subtasks: list[str] = []
+    single = len(downloads) == 1
+    for key, spec in downloads.items():
+        task = "download" if single else f"download-{key}"
+        subtasks.append(task)
+        url, filename = spec["url"], spec["filename"]
+        dest_dir = posixpath.dirname(filename) or "."
+        env_line = f"env = {{ FILENAME = {json.dumps(filename)} }}\n"
+        if spec.get("unzip"):
+            archive = f".{key}.zip"
+            cmd = f"mkdir -p $FILENAME && curl -fsSL -o {archive} {url} && python -m zipfile -e {archive} $FILENAME && rm {archive}"
+        else:
+            cmd = f"mkdir -p {dest_dir} && curl -fsSL -o $FILENAME {url}"
+        blocks.append(
+            f"[tasks.{task}]\n{env_line}cmd = {json.dumps(cmd)}\noutputs = [{json.dumps(filename)}]"
+        )
+    if single:
+        return blocks, subtasks
+    deps = ", ".join(json.dumps(t) for t in subtasks)
+    return [f"[tasks.download]\ndepends-on = [{deps}]", *blocks], ["download"]
+
+
+# --------------------------------------------------------------------------- #
+# project metadata: examples_config (anaconda-project.yml) -> [tool.metadata]
+# --------------------------------------------------------------------------- #
+# Emission order of the keys carried over to [tool.metadata]: dodo.py's
+# required_config + optional_config whitelist, plus ``description``, which used
+# to sit at the root of the YAML rather than inside examples_config.  Keys are
+# left in snake_case so every lookup and validation message in dodo.py keeps
+# working verbatim.
+TOOL_METADATA_KEYS = (
+    "created",
+    "last_updated",
+    "maintainers",
+    "categories",
+    "labels",
+    "title",
+    "description",
+    "no_data_ingestion",
+    "skip_notebooks_evaluation",
+    "skip_test",
+    "notebooks_to_skip",
+    "gh_runner",
+)
+
+# Keys deliberately not carried over: AE5 deployments are retired, so the
+# website and CI no longer read them.
+TOOL_METADATA_DROPPED = ("deployments",)
+
+
+def _toml_value(value) -> str:
+    """Render one metadata value as TOML.
+
+    ``created`` / ``last_updated`` come out as *quoted* ISO strings
+    (``created = "2018-09-17"``).  A bare TOML local date would be more
+    idiomatic, but pixi 0.76.1's manifest parser rejects TOML dates outright -
+    ``created = 2018-09-17`` fails the whole manifest with "invalid number",
+    even inside an otherwise inert ``[tool.*]`` table.
+    """
+    if isinstance(value, bool):  # before int: bool is an int subclass
+        return "true" if value else "false"
+    if isinstance(value, datetime.datetime):
+        value = value.date()
+    if isinstance(value, datetime.date):
+        return json.dumps(value.isoformat())
+    if isinstance(value, (int, float, str)):
+        return json.dumps(value)
+    if isinstance(value, (list, tuple)):
+        return "[" + ", ".join(_toml_value(v) for v in value) + "]"
+    raise ValueError(f"cannot render metadata value as TOML: {value!r}")
+
+
+def build_tool_metadata(metadata: dict) -> str:
+    """Render ``[tool.metadata]``, the project metadata CI and the website read.
+
+    pixi accepts arbitrary ``[tool.*]`` tables and ignores them for dependency
+    solving, so this block is inert for locking.  Unknown keys are still
+    emitted (dropping them would lose metadata silently) but reported, since
+    dodo.py validates the key set.
+    """
+    if not metadata:
+        return ""
+    unknown = [k for k in metadata if k not in TOOL_METADATA_KEYS + TOOL_METADATA_DROPPED]
+    if unknown:
+        print(f"{YELLOW}unrecognised metadata keys kept as-is: {', '.join(unknown)}{RESET}")
+    dropped = [k for k in TOOL_METADATA_DROPPED if k in metadata]
+    if dropped:
+        print(f"{YELLOW}dropping retired metadata keys: {', '.join(dropped)}{RESET}")
+    keys = [k for k in TOOL_METADATA_KEYS if k in metadata] + unknown
+    lines = ["[tool.metadata]"]
+    for key in keys:
+        lines.append(f"{key} = {_toml_value(metadata[key])}")
+    return "\n".join(lines) + "\n"
+
+
+def load_tool_metadata(project: dict, pixi_toml: Path) -> dict:
+    """The metadata to emit, from ``pixi.toml`` if it has it, else from the YAML.
+
+    ``examples_config`` in anaconda-project.yml is the pre-migration home of
+    this metadata; once it has moved, ``[tool.metadata]`` in pixi.toml is the
+    single source of truth and the YAML no longer carries it, so a regeneration
+    must read back what is already there rather than silently drop it.
+
+    ``description`` is the one key that was never part of ``examples_config``:
+    it lives at the root of the YAML (and used to be emitted as ``[workspace]
+    description``), so it is folded in here.
+    """
+    metadata: dict = {}
+    if pixi_toml.exists():
+        parsed = tomllib.loads(pixi_toml.read_text())
+        metadata = dict(parsed.get("tool", {}).get("metadata") or {})
+    if not metadata:
+        metadata = dict(project.get("examples_config") or {})
+    if "description" not in metadata and project.get("description"):
+        metadata["description"] = project["description"]
+    return metadata
+
+
+def build_pixi_toml(
+    project,
+    channels,
+    conda_specs,
+    pip_specs,
+    conda_global_extras,
+    target_extras,
+    pypi_global_extras,
+    metadata=None,
+) -> str:
+    """Render pixi.toml.
+
+    ``conda_global_extras`` / ``target_extras`` / ``pypi_global_extras`` are
+    packages present in the lock but not reachable from the declared deps;
+    they are added as dependencies so the lock's contents equal the
+    dependency closure (else pixi rewrites the lock).
+
+    ``metadata`` is the project metadata emitted as ``[tool.metadata]`` (see
+    ``load_tool_metadata``).  ``[workspace]`` deliberately carries nothing but
+    what pixi itself needs (``name`` / ``channels`` / ``platforms``): the
+    ``description``, ``authors`` and ``version`` keys it used to hold were just
+    copies of ``description``, ``maintainers`` and ``created``, and a second
+    home for a value only invites the two drifting apart.
+    """
+    platforms = project.get("platforms", [])
+    metadata = metadata or {}
+    deps = [matchspec_to_pixi(p) for p in conda_specs]
+    seen_dep_names: set[str] = set()
+    deps = [(n, v) for n, v in deps if not (n in seen_dep_names or seen_dep_names.add(n))]
+    pip_deps = [pip_requirement_to_pypi(p) for p in pip_specs]
+
+    lines = ["[workspace]", f"name = {json.dumps(project['name'])}"]
+    lines.append("channels = [" + ", ".join(json.dumps(c) for c in channels) + "]")
+    lines.append("platforms = [" + ", ".join(json.dumps(p) for p in platforms) + "]")
+    tool_metadata = build_tool_metadata(metadata)
+    if tool_metadata:
+        lines.append("")
+        lines.append(tool_metadata.rstrip("\n"))
+    lines.append("")
+    lines.append("[dependencies]")
+    for name, ver in deps:
+        lines.append(_dep_line(name, ver))
+    for name in sorted(conda_global_extras):
+        lines.append(_dep_line(name, "*"))
+    for plat in platforms:
+        names = sorted(target_extras.get(plat, ()))
+        if names:
+            lines.append("")
+            lines.append(f"[target.{plat}.dependencies]")
+            for name in names:
+                lines.append(_dep_line(name, "*"))
+    if pip_deps or pypi_global_extras:
+        lines.append("")
+        lines.append("[pypi-dependencies]")
+        for name, ver, extras in pip_deps:
+            lines.append(_pypi_dep_line(name, ver, extras))
+        for name in sorted(pypi_global_extras):
+            lines.append(_dep_line(name, "*"))
+    download_blocks, download_names = build_download_tasks(project.get("downloads") or {})
+    activation = build_activation_env(project.get("variables") or {})
+    if activation:
+        lines.append("")
+        lines.append(activation.rstrip("\n"))
+    if project.get("commands"):
+        lines.append("")
+        lines.append(build_pixi_tasks(project["commands"], download_names).rstrip("\n"))
+    if download_blocks:
+        lines.append("")
+        lines.append("\n\n".join(download_blocks))
+    return "\n".join(lines) + "\n"
+
+
+def parse_lock(
+    lock: dict, platforms: list[str]
+) -> tuple[dict[str, list[tuple[str, str, str]]], list[tuple[str, str]]]:
+    """Return ({platform: [(name, version, build), ...]}, [(pip_name, pip_version), ...]).
+
+    Which subdir a bucket implies is deliberately not recorded: a package is
+    resolved from its platform's own subdir or from ``noarch`` regardless of
+    the bucket it was listed under (anaconda-project's buckets are not always
+    truthful - a concrete ``win-64`` bucket can hold a package that only ships
+    for linux).
+    """
+    env = lock["env_specs"]
+    # single env spec named 'default' expected, but be tolerant
+    spec = env.get("default") or next(iter(env.values()))
+    buckets = dict(spec["packages"])
+    # the ``pip`` bucket lists name==version pairs with no build/subdir and
+    # applies to every platform (anaconda-project solves pip deps once, not
+    # per-platform), so it is pulled out before the conda bucket loop below.
+    pip_entries = [tuple(e.split("==")) for e in buckets.pop("pip", [])]
+
+    per_platform: dict[str, list[tuple[str, str, str]]] = {p: [] for p in platforms}
+    for bucket, entries in buckets.items():
+        targets = (NONARCH_BUCKETS[bucket] or platforms) if bucket in NONARCH_BUCKETS else [bucket]
+        for entry in entries:
+            name, version, build = entry.split("=")
+            for plat in targets:
+                if plat in per_platform:
+                    per_platform[plat].append((name, version, build))
+    return per_platform, pip_entries
+
+
+# --------------------------------------------------------------------------- #
+# enrichment via repodata.json (downloaded once per channel+subdir, then cached)
+# --------------------------------------------------------------------------- #
+def _plain(value):
+    """Detach a lazily parsed simdjson value from the parser that owns it."""
+    if isinstance(value, simdjson.Array):
+        return value.as_list()
+    if isinstance(value, simdjson.Object):
+        return value.as_dict()
+    return value
+
+
+def _filename_key(filename: str) -> tuple[str, str, str] | None:
+    """``zlib-1.3.1-h4bc722e_2.conda`` -> ('zlib', '1.3.1', 'h4bc722e_2')."""
+    stem = filename.removesuffix(".conda").removesuffix(".tar.bz2")
+    try:
+        name, version, build = stem.rsplit("-", 2)
+    except ValueError:
+        return None
+    return name, version, build
+
+
+class Enricher:
+    """Resolve the lock's ``name=version=build`` pins to full repodata records.
+
+    A channel+subdir holds up to a few hundred thousand packages while a lock
+    pins a few hundred, so repodata is never deserialised wholesale: simdjson
+    parses the document lazily and only records whose *filename* matches a pin
+    are converted to Python objects.  Two levels of cache keep repeat runs off
+    that path entirely - the compressed download is kept verbatim, and the
+    resolved records are memoised per pin set.  Neither is ever invalidated:
+    these projects are frozen, so re-fetching could only introduce drift.
+    """
+
+    def __init__(
+        self,
+        cache_dir: Path,
+        channels: list[str],
+        pins_by_platform: dict[str, set[tuple[str, str, str]]],
+    ):
+        self.cache_dir = cache_dir / "repodata"
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.channels = [_lock_channel_url(c).rstrip("/") for c in channels]
+        # (subdir, name, version, build) -> record-with-url, filled in as repodata
+        # is read.  The subdir belongs in the key: a pin can exist in several
+        # subdirs (e.g. _openmp_mutex=4.5=2_gnu ships for both linux-64 and
+        # win-64), and without it the first subdir read would answer for every
+        # platform, putting a foreign URL in the lock.
+        self._index: dict[tuple[str, str, str, str], dict] = {}
+        self._loaded: set[tuple[str, str]] = set()  # (channel, subdir) already read
+        self._pins_by_platform = pins_by_platform
+        self._pins = {pin for pins in pins_by_platform.values() for pin in pins}
+        # the only filenames worth converting
+        self._wanted = {
+            f"{n}-{v}-{b}.{ext}": (n, v, b)
+            for n, v, b in self._pins
+            for ext in ("conda", "tar.bz2")
+        }
+        # pins that no subdir they are needed in could supply (see _resolve_drift)
+        self._pending: set[tuple[str, str, str]] = set()
+
+    # Fields needed by record_to_locked() and lookup()'s fallback sort.
+    _KEEP = frozenset(
+        (
+            "name",
+            "version",
+            "build",
+            "build_number",
+            "subdir",
+            "depends",
+            "constrains",
+            "license",
+            "license_family",
+            "md5",
+            "sha256",
+            "size",
+            "timestamp",
+        )
+    )
+
+    def _cache_path(self, channel: str, subdir: str) -> Path:
+        slug = hashlib.sha1(f"{channel}/{subdir}".encode()).hexdigest()[:16]
+        return self.cache_dir / f"{slug}.json.zst"
+
+    def _memo_path(self) -> Path:
+        """Cache file for the records this exact set of pins resolves to."""
+        sig = "\n".join(
+            ["v2-subdir-keyed", *sorted(self._KEEP), *self.channels]
+            + [
+                f"{plat}:{n}={v}={b}"
+                for plat in sorted(self._pins_by_platform)
+                for n, v, b in sorted(self._pins_by_platform[plat])
+            ]
+        )
+        slug = hashlib.sha1(sig.encode()).hexdigest()[:16]
+        return self.cache_dir.parent / "resolved" / f"{slug}.json"
+
+    def _repodata(self, channel: str, subdir: str) -> bytes | None:
+        """repodata.json for one channel+subdir, downloaded at most once ever.
+
+        Returns None for a subdir the channel does not publish; that 404 is
+        remembered as an empty cache file so later runs stay offline.
+        """
+        cache_file = self._cache_path(channel, subdir)
+        if cache_file.exists():
+            blob = cache_file.read_bytes()
+        else:
+            url = f"{channel}/{subdir}/repodata.json.zst"
+            print(f"fetching {url}...")
+            try:
+                with urllib.request.urlopen(url) as resp:
+                    blob = resp.read()
+            except urllib.error.HTTPError as exc:
+                if exc.code != 404:
+                    raise
+                blob = b""
+            print(CLEAR, end="")
+            cache_file.write_bytes(blob)
+        return zstandard.decompress(blob) if blob else None
+
+    def _read(self, channel: str, subdir: str, stems: tuple[str, ...] | None = None) -> None:
+        """Index one channel+subdir, converting only the records we asked for.
+
+        Without ``stems`` a record is taken when its filename is exactly one of
+        the pins; with ``stems`` any build of those ``name-version-`` prefixes
+        is taken instead (see _resolve_drift).
+        """
+        raw = self._repodata(channel, subdir)
+        if raw is None:
+            return
+        # A parser owns the document it parsed, so keep it local: nothing may
+        # outlive this call except the plain dicts built below.
+        doc = simdjson.Parser().parse(raw)
+        # ``packages`` (.tar.bz2) before ``packages.conda``, and first match
+        # wins, so channel order decides which URL a pin resolves to.
+        for section in ("packages", "packages.conda"):
+            packages = doc.get(section)
+            if packages is None:
+                continue
+            for filename in packages.keys():
+                if stems is None:
+                    key = self._wanted.get(filename)
+                else:
+                    key = _filename_key(filename) if filename.startswith(stems) else None
+                if key is None:
+                    continue
+                subdir_key = (subdir, *key)
+                if subdir_key in self._index:
+                    continue
+                rec = packages[filename]
+                entry = {f: _plain(rec[f]) for f in self._KEEP if f in rec}
+                entry["url"] = f"{channel}/{subdir}/{filename}"
+                self._index[subdir_key] = entry
+                self._pending.discard(key)
+
+    def _load(self, channel: str, subdir: str) -> None:
+        if (channel, subdir) in self._loaded:
+            return
+        self._loaded.add((channel, subdir))
+        self._read(channel, subdir)
+
+    def _resolve_drift(self) -> None:
+        """Re-read for pins whose exact build has left the channel.
+
+        Rare, so it is only paid for when the filename-exact pass came up
+        short: the outstanding ``name-version`` are searched again, this time
+        accepting any build, which is what lookup()'s fallback picks from.
+        """
+        if not self._pending:
+            return
+        stems = tuple(sorted({f"{n}-{v}-" for n, v, _ in self._pending}))
+        for channel, subdir in list(self._loaded):
+            self._read(channel, subdir, stems)
+
+    def _unresolved(self) -> set[tuple[str, str, str]]:
+        """Pins that no subdir they are pinned for can supply.
+
+        A pin is only satisfied by a record in its own platform's subdir or in
+        ``noarch``; finding it under some *other* platform proves nothing, so
+        the check is per platform rather than over the index as a whole.
+        """
+        return {
+            pin
+            for plat, pins in self._pins_by_platform.items()
+            for pin in pins
+            if (plat, *pin) not in self._index and ("noarch", *pin) not in self._index
+        }
+
+    def prefetch(self) -> None:
+        """Resolve every pin, reading each channel+subdir at most once.
+
+        The result is memoised, so converting the same project again costs one
+        small JSON read instead of a walk over every channel's repodata.
+        """
+        memo = self._memo_path()
+        if memo.exists():
+            self._index = {tuple(key): entry for key, entry in orjson.loads(memo.read_bytes())}
+            self._pending.clear()
+            return
+        for plat in self._pins_by_platform:
+            for ch in self.channels:
+                self._load(ch, plat)
+                self._load(ch, "noarch")
+        self._pending = self._unresolved()
+        self._resolve_drift()
+        memo.parent.mkdir(parents=True, exist_ok=True)
+        memo.write_bytes(orjson.dumps(list(self._index.items())))
+
+    def lookup(self, name, version, build, platform) -> dict:
+        """Record for one pin on one platform, from that platform's own subdir.
+
+        Only ``platform``'s subdir and ``noarch`` may answer: a record from
+        another platform's subdir would put a URL in the lock that cannot be
+        installed there (and whose ``depends`` belong to that other platform).
+        """
+        subdirs = (platform, "noarch")
+        for subdir in subdirs:
+            if (subdir, name, version, build) in self._index:
+                return self._index[(subdir, name, version, build)]
+        # Fallback: exact build is gone from the channel. Prefer the newest
+        # build_number among the builds still published for this platform.
+        cands = [
+            r
+            for (sd, n, v, _), r in self._index.items()
+            if (n, v) == (name, version) and sd in subdirs
+        ]
+        if not cands:
+            available = sorted(
+                f"{sd}/{r.get('build')}"
+                for (sd, n, v, _), r in self._index.items()
+                if (n, v) == (name, version)
+            )
+            raise LookupError(
+                f"no record for {name}=={version}=={build} in subdir {platform} or noarch; "
+                "available builds: " + (", ".join(available) or "none")
+            )
+        cands.sort(key=lambda r: r.get("build_number", 0), reverse=True)
+        return cands[0]
+
+
+# --------------------------------------------------------------------------- #
+# enrichment via the PyPI JSON API (for the anaconda-project ``pip:`` bucket)
+# --------------------------------------------------------------------------- #
+def _wheel_tags(filename: str) -> tuple[str, str, str]:
+    """``name-1.0-py3-none-any.whl`` -> ('py3', 'none', 'any')."""
+    stem = filename[: -len(".whl")]
+    python_tag, abi_tag, platform_tag = stem.split("-")[-3:]
+    return python_tag, abi_tag, platform_tag
+
+
+def _platform_tag_ok(tag: str, platform: str) -> bool:
+    if platform == "linux-64":
+        return "manylinux" in tag and "x86_64" in tag
+    if platform == "linux-aarch64":
+        return "manylinux" in tag and "aarch64" in tag
+    if platform == "osx-64":
+        return tag.startswith("macosx") and ("x86_64" in tag or "universal2" in tag)
+    if platform == "osx-arm64":
+        return tag.startswith("macosx") and ("arm64" in tag or "universal2" in tag)
+    if platform == "win-64":
+        return tag == "win_amd64"
+    return False
+
+
+def _platform_tags_ok(tag: str, platform: str) -> bool:
+    """A wheel may carry several platform tags (``a.b``); any match will do."""
+    return any(_platform_tag_ok(t, platform) for t in tag.split("."))
+
+
+def _cpython_version(tag: str) -> tuple[int, int] | None:
+    """``cp311`` -> (3, 11).  The major is always the first digit."""
+    if not re.fullmatch(r"cp\d\d+", tag):
+        return None
+    return int(tag[2]), int(tag[3:])
+
+
+def _abi3_version(python_tag: str, abi_tag: str) -> tuple[int, int] | None:
+    """Lowest cpython an ``abi3`` wheel supports, or None if it is not abi3.
+
+    ``cp39-abi3`` is built against the stable ABI, so pip installs it on 3.9
+    *and every later* cpython - the exact python-tag match below never sees
+    these, which is how such packages used to end up locked as sdists.
+    """
+    if abi_tag != "abi3":
+        return None
+    versions = [v for t in python_tag.split(".") if (v := _cpython_version(t))]
+    return min(versions) if versions else None
+
+
+def _is_pure_python(python_tag: str) -> bool:
+    return all(t.startswith("py") for t in python_tag.split("."))
+
+
+def _pick_wheel(files: list[dict], platform: str, py_tag: str) -> dict | None:
+    """Pick the wheel matching ``platform``/``py_tag``, preferring pure-python wheels."""
+    target = _cpython_version(py_tag)
+    exact: list[dict] = []
+    abi3: list[tuple[tuple[int, int], dict]] = []
+    pure_platform: list[dict] = []
+    for f in files:
+        python_tag, abi_tag, platform_tag = _wheel_tags(f["filename"])
+        if platform_tag == "any":
+            if _is_pure_python(python_tag):
+                return f
+            continue
+        if not _platform_tags_ok(platform_tag, platform):
+            continue
+        if py_tag in python_tag.split("."):
+            exact.append(f)
+        elif (v := _abi3_version(python_tag, abi_tag)) and target and v <= target:
+            abi3.append((v, f))
+        elif _is_pure_python(python_tag):
+            pure_platform.append(f)
+    if exact:
+        return exact[0]
+    if abi3:
+        return max(abi3, key=lambda t: t[0])[1]  # newest stable-ABI build
+    if pure_platform:
+        return pure_platform[0]
+    return None
+
+
+class PypiEnricher:
+    def __init__(self, cache_dir: Path):
+        self.cache_dir = cache_dir
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.mem: dict[str, dict] = {}
+
+    def _cache_file(self, name: str, version: str) -> Path:
+        return self.cache_dir / f"{name}@{version}.json"
+
+    def _fetch(self, name: str, version: str) -> dict:
+        url = f"https://pypi.org/pypi/{name}/{version}/json"
+        req = urllib.request.Request(url)
+        with urllib.request.urlopen(req) as resp:
+            return orjson.loads(resp.read())
+
+    def _release(self, name: str, version: str) -> dict:
+        key = f"{name}=={version}"
+        if key in self.mem:
+            return self.mem[key]
+        cache_file = self._cache_file(name, version)
+        if cache_file.exists():
+            data = orjson.loads(cache_file.read_bytes())
+        else:
+            data = self._fetch(name, version)
+            cache_file.write_bytes(orjson.dumps(data))
+        self.mem[key] = data
+        return data
+
+    def prefetch(self, entries: list[tuple[str, str]]) -> None:
+        """Warm the cache for many (name, version) pairs via the PyPI JSON API,
+        run concurrently since each is an independent HTTP request."""
+        todo = [
+            e
+            for e in dict.fromkeys(entries)
+            if f"{e[0]}=={e[1]}" not in self.mem and not self._cache_file(*e).exists()
+        ]
+        if not todo:
+            return
+        print(f"fetching pypi metadata for {len(todo)} packages...")
+        with ThreadPoolExecutor() as ex:
+            futures = {ex.submit(self._release, *e): e for e in todo}
+            for fut in as_completed(futures):
+                fut.result()
+        print(CLEAR, end="")
+
+    def lookup(self, name: str, version: str, platform: str, py_tag: str) -> dict:
+        data = self._release(name, version)
+        files = [f for f in data["urls"] if f["packagetype"] == "bdist_wheel"]
+        chosen = _pick_wheel(files, platform, py_tag)
+        if chosen is None:
+            # No wheel for this release at all (some old releases only ever
+            # shipped an sdist) - fall back to it; pip builds it at install time.
+            sdists = [f for f in data["urls"] if f["packagetype"] == "sdist"]
+            if not sdists:
+                raise LookupError(
+                    f"no compatible wheel for {name}=={version} on {platform} ({py_tag})"
+                )
+            chosen = sdists[0]
+        return {
+            "name": data["info"]["name"],
+            "version": version,
+            "url": chosen["url"],
+            "sha256": chosen["digests"]["sha256"],
+            "requires_dist": data["info"].get("requires_dist") or [],
+            "requires_python": data["info"].get("requires_python") or "",
+        }
+
+
+# --------------------------------------------------------------------------- #
+# emit pixi.lock (v6)
+# --------------------------------------------------------------------------- #
+def record_to_locked(rec: dict) -> dict:
+    url = rec.get("url")
+    entry = {"conda": url}
+    for field in (
+        "sha256",
+        "md5",
+        "depends",
+        "constrains",
+        "license",
+        "license_family",
+        "size",
+        "timestamp",
+    ):
+        if rec.get(field) not in (None, [], ""):
+            entry[field] = rec[field]
+    return entry
+
+
+def record_to_locked_pypi(rec: dict) -> dict:
+    entry = {
+        "pypi": rec["url"],
+        "name": rec["name"],
+        "version": rec["version"],
+        "sha256": rec["sha256"],
+    }
+    if rec.get("requires_dist"):
+        entry["requires_dist"] = rec["requires_dist"]
+    if rec.get("requires_python"):
+        entry["requires_python"] = rec["requires_python"]
+    return entry
+
+
+def _python_tag_for(per_platform_entries: list[tuple[str, str, str]]) -> str:
+    for name, version, _build in per_platform_entries:
+        if name == "python":
+            major, minor = version.split(".")[:2]
+            return f"cp{major}{minor}"
+    raise ValueError("no 'python' package found in lock; cannot pick pypi wheels")
+
+
+def _canonical_pypi(name: str) -> str:
+    """PEP 503 normalisation: ``Zope.Interface`` -> 'zope-interface'."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _pypi_req_name(req: str) -> str:
+    """Name of a PEP 508 requirement: ``h5io; extra == "hdf5"`` -> 'h5io'."""
+    head = req.split(";", 1)[0].strip()
+    return _canonical_pypi(re.split(r"[\s<>=!~,()\[\]]", head, maxsplit=1)[0])
+
+
+def base_package_purls(
+    conda_names: set[str], pypi_req_names: set[str], locked_pypi: set[str]
+) -> dict[str, str]:
+    """Map conda ``<x>-base`` package name -> the pypi name ``x`` it provides.
+
+    conda-forge often ships "<name>" (full) and "<name>-base" (core only,
+    e.g. mne/mne-base, matplotlib/matplotlib-base) and registers the "-base"
+    package with its hash-mapping service as already providing the plain pypi
+    name - which is why anaconda-project's solver found ``mne[hdf5]`` and
+    pydeseq2's ``matplotlib>=3.6.2`` satisfied without a pip install.  pixi
+    matches conda packages to pypi requirements by name, so only this renaming
+    needs stating explicitly: a real ``pixi lock`` does it with a ``purls``
+    entry (``pkg:pypi/mne?source=hash-mapping``), and since the anaconda lock
+    already tells us the "-base" package and its version are present, that fact
+    can be reproduced without invoking pixi.  Without it pixi reports the
+    requirement as unsatisfiable and rewrites the lock.
+    """
+    purls: dict[str, str] = {}
+    for cname in conda_names:
+        if not cname.endswith("-base"):
+            continue
+        pypi_name = _canonical_pypi(cname[: -len("-base")])
+        if pypi_name in pypi_req_names and pypi_name not in locked_pypi:
+            purls[cname] = pypi_name
+    return purls
+
+
+def build_pixi_lock(
+    per_platform,
+    pip_specs,
+    pip_entries,
+    enricher,
+    pypi_enricher,
+    platforms,
+    channels,
+    swallowed=frozenset(),
+):
+    """Emit the pixi.lock document plus the per-platform dependency graph.
+
+    ``swallowed`` names were dropped from the conda side because pip overrides
+    them (see ``main``).  Conda packages that still depend on them would leave
+    the lock with a requirement nothing can satisfy - pixi reports exactly that
+    as "out of date" - so those dependency entries are dropped from the locked
+    metadata as well.  The graph keeps them: it is matched by name against the
+    pypi package that took over, which is what actually provides the import.
+    """
+    pkg_by_url: dict[str, dict] = {}
+    conda_name_by_url: dict[str, str] = {}
+    env_pkgs: dict[str, list[tuple[str, str]]] = {p: [] for p in platforms}
+    graph: dict[str, list[dict]] = {p: [] for p in platforms}
+    has_pypi = False
+    relaxed: set[str] = set()
+    # every pypi name something in this environment requires: the declared pip
+    # specs plus the requirements of each locked wheel
+    pypi_req_names = {_canonical_pypi(pip_requirement_to_pypi(p)[0]) for p in pip_specs}
+
+    enricher.prefetch()
+    if pip_entries:
+        pypi_enricher.prefetch(pip_entries)
+
+    for plat in platforms:
+        for name, version, build in per_platform[plat]:
+            rec = enricher.lookup(name, version, build, plat)
+            url = rec["url"]
+            env_pkgs[plat].append(("conda", url))
+            graph[plat].append({"name": rec["name"], "depends": rec.get("depends") or []})
+            if url not in pkg_by_url:
+                entry = record_to_locked(rec)
+                if swallowed and entry.get("depends"):
+                    kept = [d for d in entry["depends"] if _dep_name(d) not in swallowed]
+                    if len(kept) != len(entry["depends"]):
+                        relaxed.add(rec["name"])
+                        entry["depends"] = kept
+                pkg_by_url[url] = entry
+                conda_name_by_url[url] = rec["name"]
+
+        if pip_entries:
+            has_pypi = True
+            py_tag = _python_tag_for(per_platform[plat])
+            for name, version in pip_entries:
+                rec = pypi_enricher.lookup(name, version, plat, py_tag)
+                url = rec["url"]
+                env_pkgs[plat].append(("pypi", url))
+                graph[plat].append(
+                    {"name": rec["name"], "depends": rec.get("requires_dist") or []}
+                )
+                pypi_req_names.update(_pypi_req_name(r) for r in rec.get("requires_dist") or [])
+                if url not in pkg_by_url:
+                    pkg_by_url[url] = record_to_locked_pypi(rec)
+
+    purls = base_package_purls(
+        set(conda_name_by_url.values()),
+        pypi_req_names,
+        {_canonical_pypi(n) for n, _ in pip_entries},
+    )
+    for url, cname in conda_name_by_url.items():
+        if cname in purls:
+            pkg_by_url[url]["purls"] = [f"pkg:pypi/{purls[cname]}?source=hash-mapping"]
+
+    # Mirror the manifest channel set/order so pixi considers the lock current.
+    # v7 adds the top-level ``platforms`` block; package ordering is cosmetic
+    # (pixi re-sorts on write) and does not affect the up-to-date check.
+    default_env = {
+        "channels": [{"url": _lock_channel_url(c)} for c in channels],
+    }
+    if has_pypi:
+        default_env["indexes"] = ["https://pypi.org/simple"]
+    default_env["packages"] = {
+        p: [{kind: u} for kind, u in sorted(set(env_pkgs[p]), key=lambda t: t[1])]
+        for p in sorted(platforms)
+    }
+    lock = {
+        "version": 7,
+        "platforms": [{"name": p} for p in sorted(platforms)],
+        "environments": {"default": default_env},
+        "packages": [pkg_by_url[u] for u in sorted(pkg_by_url)],
+    }
+    if relaxed:
+        print(
+            "dropped conda dependencies on pip-overridden packages from: "
+            + ", ".join(sorted(relaxed))
+        )
+    if purls:
+        print(
+            "tagging conda '-base' packages as already providing their pypi name: "
+            + ", ".join(f"{base} -> {name}" for base, name in sorted(purls.items()))
+        )
+    return lock, graph
+
+
+def verify_lock(
+    project_dir: Path, pixi_lock: dict, platforms: list[str], swallowed: set[str] = frozenset()
+) -> bool:
+    """Cross-check the generated pixi.lock against the anaconda lock pins.
+
+    ``swallowed`` names are dropped from the conda side of the comparison:
+    they are intentionally omitted from the conda lock because pip overrides
+    them (see ``main``), so the anaconda lock's conda pin for them is expected
+    to be absent rather than missing.
+    """
+    alock = load_yaml(project_dir / "anaconda-project-lock.yml")
+    spec = alock["env_specs"].get("default") or next(iter(alock["env_specs"].values()))
+
+    expected: dict[str, set[tuple[str, str, str]]] = {p: set() for p in platforms}
+    expected_pypi: set[tuple[str, str]] = set()
+    for bucket, entries in spec["packages"].items():
+        if bucket == "pip":
+            expected_pypi = {(n.lower(), v) for n, v in (e.split("==") for e in entries)}
+            continue
+        targets = (NONARCH_BUCKETS[bucket] or platforms) if bucket in NONARCH_BUCKETS else [bucket]
+        for entry in entries:
+            name, version, build = entry.split("=")
+            if name in swallowed:
+                continue
+            for plat in targets:
+                if plat in expected:
+                    expected[plat].add((name, version, build))
+
+    pypi_meta = {
+        p["pypi"]: (p["name"].lower(), p["version"]) for p in pixi_lock["packages"] if "pypi" in p
+    }
+    got: dict[str, set[tuple[str, str, str]]] = {p: set() for p in platforms}
+    got_pypi: dict[str, set[tuple[str, str]]] = {p: set() for p in platforms}
+    for plat, items in pixi_lock["environments"]["default"]["packages"].items():
+        for item in items:
+            if "pypi" in item:
+                got_pypi[plat].add(pypi_meta[item["pypi"]])
+                continue
+            fn = item["conda"].rsplit("/", 1)[1]
+            fn = fn.removesuffix(".conda").removesuffix(".tar.bz2")
+            name, version, build = fn.rsplit("-", 2)
+            got[plat].add((name, version, build))
+
+    ok = True
+    for plat in platforms:
+        anaconda_only = expected[plat] - got[plat]
+        pixi_only = got[plat] - expected[plat]
+
+        # The pinned build can vanish from the channel between when the anaconda
+        # lock was generated and now (see Enricher.lookup's fallback). When the
+        # only discrepancy for a name=version is the build string, that's
+        # expected channel drift, not a real mismatch.
+        anaconda_by_nv = {(n, v): b for n, v, b in anaconda_only}
+        pixi_by_nv = {(n, v): b for n, v, b in pixi_only}
+        drifted = anaconda_by_nv.keys() & pixi_by_nv.keys()
+        anaconda_only = {m for m in anaconda_only if (m[0], m[1]) not in drifted}
+        pixi_only = {x for x in pixi_only if (x[0], x[1]) not in drifted}
+
+        print(
+            f"{plat}: expected={len(expected[plat])} got={len(got[plat])} "
+            f"anaconda-only={len(anaconda_only)} pixi-only={len(pixi_only)}"
+        )
+        for name, version in sorted(drifted):
+            print(
+                f"   BUILD-DRIFT   {name}={version}: "
+                f"{anaconda_by_nv[(name, version)]} -> {pixi_by_nv[(name, version)]}"
+            )
+        for m in sorted(anaconda_only):
+            ok = False
+            print(f"{RED}   ANACONDA-ONLY {m[0]}={m[1]}={m[2]}{RESET}")
+        for x in sorted(pixi_only):
+            ok = False
+            print(f"{RED}   PIXI-ONLY     {x[0]}={x[1]}={x[2]}{RESET}")
+
+    if expected_pypi:
+        for plat in platforms:
+            anaconda_only_pypi = expected_pypi - got_pypi[plat]
+            pixi_only_pypi = got_pypi[plat] - expected_pypi
+            print(
+                f"{plat} (pypi): expected={len(expected_pypi)} got={len(got_pypi[plat])} "
+                f"anaconda-only={len(anaconda_only_pypi)} pixi-only={len(pixi_only_pypi)}"
+            )
+            for m in sorted(anaconda_only_pypi):
+                ok = False
+                print(f"{RED}   ANACONDA-ONLY {m[0]}=={m[1]}{RESET}")
+            for x in sorted(pixi_only_pypi):
+                ok = False
+                print(f"{RED}   PIXI-ONLY     {x[0]}=={x[1]}{RESET}")
+
+    result = f"{GREEN}exact match{RESET}" if ok else f"{RED}MISMATCH{RESET}"
+    print(f"\nRESULT: {result}")
+    return ok
+
+
+def check_pixi_manifest(pixi_lock: dict, enricher: Enricher) -> bool:
+    """Validate the generated lock by cross-checking every locked conda package
+    against the repodata index already loaded by ``enricher``.
+
+    Each locked package URL must resolve to an entry in the repodata for the
+    *same subdir*, with matching name, version, and build — catching any
+    corruption or URL drift introduced during lock generation, including a
+    package pointing at another platform's copy.
+    """
+    ok = True
+    for pkg in pixi_lock["packages"]:
+        if "conda" not in pkg:
+            continue
+        url = pkg["conda"]
+        _channel, subdir, filename = url.rsplit("/", 2)
+        stem = filename.removesuffix(".conda").removesuffix(".tar.bz2")
+        try:
+            name, version, build = stem.rsplit("-", 2)
+        except ValueError:
+            print(f"{RED}  MALFORMED URL  {url}{RESET}")
+            ok = False
+            continue
+        key = (subdir, name, version, build)
+        if key not in enricher._index:
+            print(f"{RED}  NOT IN REPODATA  {subdir}/{name}={version}={build}{RESET}")
+            ok = False
+        elif enricher._index[key]["url"] != url:
+            print(f"{YELLOW}  URL DRIFT  {name}={version}={build}: {url}{RESET}")
+    if ok:
+        print(f"{GREEN}repodata check passed{RESET}")
+    return ok
+
+
+def _dep_name(spec: str) -> str:
+    return re.split(r"[\s<>=!~|]", spec.strip(), maxsplit=1)[0]
+
+
+def unreachable_roots(graph, declared, platforms):
+    """Per platform, packages in the lock not reachable from ``declared`` deps.
+
+    pixi treats a lock as outdated if it contains packages outside the closure
+    of the manifest's dependencies, so these must be promoted to dependencies.
+    Returns (global_extras, target_extras) where global_extras are present on
+    every platform and target_extras maps platform -> names for the rest.
+    """
+    extra_platforms: dict[str, set[str]] = {}
+    locked_platforms: dict[str, set[str]] = {}
+    for plat in platforms:
+        by_name = {p["name"]: p for p in graph[plat]}
+        seen: set[str] = set()
+        stack = [d for d in declared if d in by_name]
+        while stack:
+            n = stack.pop()
+            if n in seen:
+                continue
+            seen.add(n)
+            for dep in by_name[n]["depends"]:
+                dn = _dep_name(dep)
+                if dn in by_name and dn not in seen:
+                    stack.append(dn)
+        for name in by_name:
+            locked_platforms.setdefault(name, set()).add(plat)
+            if name not in seen:
+                extra_platforms.setdefault(name, set()).add(plat)
+
+    nplat = set(platforms)
+    global_extras, target_extras = set(), {p: set() for p in platforms}
+    for name in extra_platforms:
+        if locked_platforms[name] == nplat:
+            global_extras.add(name)  # safe everywhere -> single global dep
+        else:
+            for plat in locked_platforms[name]:
+                target_extras[plat].add(name)
+    return global_extras, target_extras
+
+
+# --------------------------------------------------------------------------- #
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("project_dir", type=Path, nargs="?", default=Path.cwd())
+    ap.add_argument(
+        "--out-dir",
+        type=Path,
+        default=None,
+        help="where to write pixi.toml/pixi.lock (default: project_dir)",
+    )
+    ap.add_argument("--cache-dir", type=Path, default=Path(__file__).resolve().parent / "cache")
+    ap.add_argument(
+        "--no-verify",
+        action="store_true",
+        help="skip cross-checking the generated pixi.lock against the anaconda lock pins",
+    )
+    args = ap.parse_args()
+
+    project_dir = args.project_dir.resolve()
+    out_dir = (args.out_dir or project_dir).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    project = load_yaml(project_dir / "anaconda-project.yml")
+    lock = load_yaml(project_dir / "anaconda-project-lock.yml")
+    platforms = project["platforms"]
+    channels = resolve_channels(project.get("channels", []))
+
+    conda_specs, pip_specs = split_packages(project.get("packages", []))
+
+    # Build the lock first: it yields the dependency graph used to detect which
+    # locked packages must be promoted to manifest dependencies.
+    per_platform, pip_entries = parse_lock(lock, platforms)
+    pypi_names_lower = {name.casefold() for name, _ in pip_entries}
+
+    # A package locked by both conda (usually transitively) and pip is a pip
+    # override: anaconda-project installs the pip wheel on top, but pixi's
+    # solver pins the conda version and conflicts with the pypi requirement.
+    # Swallow the conda side so only the pypi package is locked.
+    # Comparison is case-insensitive (e.g. conda "markdown" vs pip "Markdown").
+    swallowed = {
+        name
+        for plat in platforms
+        for name, *_ in per_platform[plat]
+        if name.casefold() in pypi_names_lower
+    }
+    if swallowed:
+        print(f"swallowing conda packages overridden by pip: {', '.join(sorted(swallowed))}")
+        per_platform = {
+            plat: [e for e in entries if e[0] not in swallowed]
+            for plat, entries in per_platform.items()
+        }
+
+    enricher = Enricher(
+        args.cache_dir,
+        channels,
+        {plat: {(n, v, b) for n, v, b in entries} for plat, entries in per_platform.items()},
+    )
+    pypi_enricher = PypiEnricher(args.cache_dir / "pypi")
+    pixi_lock, graph = build_pixi_lock(
+        per_platform,
+        pip_specs,
+        pip_entries,
+        enricher,
+        pypi_enricher,
+        platforms,
+        channels,
+        swallowed,
+    )
+    with (out_dir / "pixi.lock").open("w") as fh:
+        yaml.safe_dump(pixi_lock, fh, sort_keys=False, default_flow_style=False)
+    print(f"{GREEN}wrote {out_dir / 'pixi.lock'}{RESET}")
+
+    declared = [matchspec_to_pixi(p)[0] for p in conda_specs] + [
+        pip_requirement_to_pypi(p)[0] for p in pip_specs
+    ]
+    global_extras, target_extras = unreachable_roots(graph, declared, platforms)
+    if global_extras or any(target_extras.values()):
+        print(
+            "promoted unreachable lock packages to dependencies:",
+            ", ".join(sorted(global_extras | {n for v in target_extras.values() for n in v})),
+        )
+    pypi_global_extras = {n for n in global_extras if n.casefold() in pypi_names_lower}
+    conda_global_extras = {n for n in global_extras if n.casefold() not in pypi_names_lower}
+    toml_text = build_pixi_toml(
+        project,
+        channels,
+        conda_specs,
+        pip_specs,
+        conda_global_extras,
+        target_extras,
+        pypi_global_extras,
+        load_tool_metadata(project, project_dir / "pixi.toml"),
+    )
+    (out_dir / "pixi.toml").write_text(toml_text)
+    print(f"{GREEN}wrote {out_dir / 'pixi.toml'}{RESET}")
+
+    if not check_pixi_manifest(pixi_lock, enricher):
+        return 1
+
+    if not args.no_verify:
+        print()
+        if not verify_lock(project_dir, pixi_lock, platforms, swallowed):
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/convert-pixi.py
+++ b/convert-pixi.py
@@ -409,21 +409,21 @@ def build_pixi_toml(
     for name, ver in deps:
         lines.append(_dep_line(name, ver))
     for name in sorted(conda_global_extras):
-        lines.append(_dep_line(name, "*"))
+        lines.append(_dep_line(name, "*") + "  # promoted from anaconda-project lock")
     for plat in platforms:
         names = sorted(target_extras.get(plat, ()))
         if names:
             lines.append("")
             lines.append(f"[target.{plat}.dependencies]")
             for name in names:
-                lines.append(_dep_line(name, "*"))
+                lines.append(_dep_line(name, "*") + "  # promoted from anaconda-project lock")
     if pip_deps or pypi_global_extras:
         lines.append("")
         lines.append("[pypi-dependencies]")
         for name, ver, extras in pip_deps:
             lines.append(_pypi_dep_line(name, ver, extras))
         for name in sorted(pypi_global_extras):
-            lines.append(_dep_line(name, "*"))
+            lines.append(_dep_line(name, "*") + "  # promoted from anaconda-project lock")
     download_blocks, download_names = build_download_tasks(project.get("downloads") or {})
     activation = build_activation_env(project.get("variables") or {})
     if activation:

--- a/convert-pixi.py
+++ b/convert-pixi.py
@@ -48,15 +48,9 @@ else:
     GREEN = RED = YELLOW = RESET = CLEAR = ""
 
 
-# anaconda-project channel name -> explicit pixi channel URLs.  ``defaults`` is a
-# conda metachannel that pixi does not expand on its own (it would resolve to the
-# non-existent conda.anaconda.org/defaults), so we map it to the real repo URLs.
 CHANNEL_MAP = {
-    "defaults": [
-        "https://repo.anaconda.com/pkgs/main",
-        # "https://repo.anaconda.com/pkgs/r",
-        "https://repo.anaconda.com/pkgs/msys2",
-    ],
+    "defaults": ["main", "msys2"],  # also "r" but not added
+    "nodefaults": [],
 }
 
 

--- a/datashader_dashboard/pixi.lock
+++ b/datashader_dashboard/pixi.lock
@@ -7,909 +7,909 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-anon-usage-0.4.4-py38hfc0e8ea_100.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-client-1.12.3-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-project-0.11.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py38h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-4.0.1-py38hced866c_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-24.2.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.4.57-he6710b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.1.6-h2531618_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.9-he6710b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.8.185-hce553d0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.73.0-h27cfd23_11.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py38ha9d4c09_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py38h6a678d5_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.9.24-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.8.30-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py38h1fdaa30_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.0.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-pack-0.7.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-handling-2.3.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-streaming-0.10.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.0.5-py38hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.2-py38h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py38h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py38h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2.30.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/double-conversion-3.1.5-he6710b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.2.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-0.5.0-py38h7deecbd_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py38h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.6.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/grpc-cpp-1.26.0-hf8bcb03_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.4.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intake-0.6.8-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.12.2-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.23.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py38h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py38h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h568e23c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.73.0-h3ff78a5_11.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.2.1-h91b91d3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-h8f2d780_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.1.0-h9e868ea_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.52.0-ha637b67_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-3.11.2-hd408876_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-h37d81fd_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.13.0-hfb8234f_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h85742a9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.38.0-py38h4ff587b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py38h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.7.2-py38h1128e8f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py38h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py38h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py38hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py38hd09550d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py38_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.16.4-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.55.1-py38h51133e4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.4-py38hc78ab66_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.21.6-py38h5f9d8c6_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.21.6-py38hb5e798b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h9ca470c_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-1.6.7-h973521d_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.5.3-py38h417a72b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.4.0-py38h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.2-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pkgutil-resolve-name-1.3.10-py38h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pooch-1.7.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py38h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-4.0.1-py38he0739d4_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py38h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.8.18-h7a1cb2a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py38h06a4308_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py38h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-snappy-0.6.1-py38h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py38h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py38h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-toolbelt-1.0.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py38hb02cf49_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel.yaml.clib-0.2.8-py38h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel_yaml-0.17.21-py38h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.10.1-py38hf6e8229_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-60.9.3-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/thrift-0.17.0-py38h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.1-py38h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.5-py38h2f386ee_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py38h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uriparser-0.9.7-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.3-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py38_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.44.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2022.11.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py38h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.20.2-py38h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstandard-0.19.0-py38h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.4.9-haebb681_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2.30.0-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2.30.0-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.8-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/hvplot-0.7.3-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/intake-parquet-0.2.3-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.7-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anaconda-anon-usage-0.4.4-py38hfc0e8ea_100.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anaconda-client-1.12.3-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anaconda-project-0.11.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-4.2.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py38h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/arrow-cpp-4.0.1-py38hced866c_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-24.2.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-common-0.4.57-he6710b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-event-stream-0.1.6-h2531618_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-checksums-0.1.9-he6710b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-sdk-cpp-1.8.185-hce553d0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.3-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-2.4.3-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/boost-cpp-1.73.0-h27cfd23_11.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.7-py38ha9d4c09_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py38h6a678d5_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2024.9.24-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2024.8.30-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.17.1-py38h1fdaa30_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cloudpickle-3.0.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/conda-pack-0.7.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/conda-package-handling-2.3.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/conda-package-streaming-0.10.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/contourpy-1.0.5-py38hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cytoolz-0.12.2-py38h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/datashape-0.5.4-py38h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py38h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/distributed-2.30.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/double-conversion-3.1.5-he6710b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.2.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fastparquet-0.5.0-py38h7deecbd_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fonttools-4.51.0-py38h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fsspec-2024.6.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/grpc-cpp-1.26.0-hf8bcb03_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-7.0.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib_resources-6.4.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intake-0.6.8-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.29.5-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.12.2-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.19.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.4-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.23.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.7.2-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.10.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.14.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py38h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyterlab_pygments-0.2.2-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py38h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/krb5-1.20.1-h568e23c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libboost-1.73.0-h3ff78a5_11.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libcurl-8.2.1-h91b91d3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libevent-2.1.12-h8f2d780_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libllvm11-11.1.0-h9e868ea_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libnghttp2-1.52.0-ha637b67_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libprotobuf-3.11.2-hd408876_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libssh2-1.10.0-h37d81fd_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libthrift-0.13.0-hfb8234f_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h85742a9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.38.0-py38h4ff587b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py38h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.7.2-py38h1128e8f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py38h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py38h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py38hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/msgpack-python-1.0.3-py38hd09550d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py38_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-1.1.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.16.4-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.10.4-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.7-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numba-0.55.1-py38h51133e4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.4-py38hc78ab66_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.21.6-py38h5f9d8c6_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.21.6-py38hb5e798b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h9ca470c_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/orc-1.6.7-h973521d_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-24.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-1.5.3-py38h417a72b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-10.4.0-py38h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-24.2-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pkgutil-resolve-name-1.3.10-py38h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pooch-1.7.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py38h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyarrow-4.0.1-py38he0739d4_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py38h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.8.18-h7a1cb2a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py38h06a4308_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-json-logger-2.0.7-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-lmdb-1.4.1-py38h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-snappy-0.6.1-py38h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.2-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.2-py38h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-24.0.1-py38h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.32.3-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-toolbelt-1.0.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py38hb02cf49_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ruamel.yaml.clib-0.2.8-py38h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ruamel_yaml-0.17.21-py38h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scipy-1.10.1-py38hf6e8229_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-60.9.3-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/thrift-0.17.0-py38h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.4.1-py38h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.66.5-py38h2f386ee_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.14.3-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.11.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.11.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py38h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/uriparser-0.9.7-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-2.2.3-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py38_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.44.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xarray-2022.11.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py38h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zict-3.0.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.20.2-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstandard-0.19.0-py38h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.4.9-haebb681_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-2.30.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-core-2.30.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/holoviews-1.14.8-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/hvplot-0.7.3-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/intake-parquet-0.2.3-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/panel-0.12.7-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2.30.0-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2.30.0-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.8-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/hvplot-0.7.3-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/intake-parquet-0.2.3-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.7-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anaconda-anon-usage-0.4.4-py38hfb7c958_100.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anaconda-client-1.12.3-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anaconda-project-0.11.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py38hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py38hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-4.0.1-py38hf7c73f6_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.2.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.4.57-hb1e8313_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.1.6-h23ab428_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.9-hb1e8313_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.8.185-he271ece_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.4.3-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.73.0-h9ed2024_11.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py38h7b7cdfe_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py38hcec6c5f_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.9.24-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.8.30-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py38h9205ec4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.0.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/conda-pack-0.7.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/conda-package-handling-2.3.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/conda-package-streaming-0.10.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py38haf03e11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.2-py38h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py38hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py38hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2.30.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/double-conversion-3.1.5-haf313ee_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.2.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-0.5.0-py38h67323c0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py38h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.6.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/grpc-cpp-1.26.0-h044775b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-58.2-h0a44026_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.4.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intake-0.6.8-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.12.2-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.23.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py38hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py38hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.73.0-hd4c2dcd_11.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h0a4fc7d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm11-11.1.0-h46f1229_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-3.11.2-hd9629dc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.13.0-h054ceb0_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.2.0-h87d7836_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.38.0-py38h8346a28_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py38h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.7.2-py38hee32256_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py38h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py38h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py38ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py38haf03e11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py38_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.4-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.55.1-py38hae1ba45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.4-py38h47b59a4_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.21.6-py38h827a554_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.21.6-py38ha186be2_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h7231236_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-1.6.7-h001ef8f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-1.5.3-py38h07fba90_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.4.0-py38h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.2-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pkgutil-resolve-name-1.3.10-py38hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pooch-1.7.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py38hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-4.0.1-py38hdf3e9eb_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py38hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py38_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.8.18-h218abb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py38hecd8cb5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py38hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-snappy-0.6.1-py38hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py38h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py38h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-toolbelt-1.0.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py38hf2ad997_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ruamel.yaml.clib-0.2.8-py38h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ruamel_yaml-0.17.21-py38hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.10.1-py38hf241641_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-60.9.3-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/thrift-0.17.0-py38he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.1-py38h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.5-py38h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py38h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uriparser-0.9.7-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.3-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py38_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.44.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2022.11.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py38hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.20.2-py38hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstandard-0.19.0-py38h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.4.9-h322a384_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-2.30.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-core-2.30.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/holoviews-1.14.8-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/hvplot-0.7.3-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/intake-parquet-0.2.3-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/panel-0.12.7-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anaconda-anon-usage-0.4.4-py38hfb7c958_100.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anaconda-client-1.12.3-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anaconda-project-0.11.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-4.2.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py38hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py38hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/arrow-cpp-4.0.1-py38hf7c73f6_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-24.2.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-common-0.4.57-hb1e8313_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-event-stream-0.1.6-h23ab428_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-checksums-0.1.9-hb1e8313_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-sdk-cpp-1.8.185-he271ece_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.3-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-2.4.3-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/boost-cpp-1.73.0-h9ed2024_11.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.7-py38h7b7cdfe_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py38hcec6c5f_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2024.9.24-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2024.8.30-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.17.1-py38h9205ec4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cloudpickle-3.0.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/conda-pack-0.7.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/conda-package-handling-2.3.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/conda-package-streaming-0.10.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py38haf03e11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cytoolz-0.12.2-py38h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/datashape-0.5.4-py38hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py38hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/distributed-2.30.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/double-conversion-3.1.5-haf313ee_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.2.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fastparquet-0.5.0-py38h67323c0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fonttools-4.51.0-py38h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fsspec-2024.6.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/grpc-cpp-1.26.0-h044775b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/icu-58.2-h0a44026_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-7.0.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.4.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intake-0.6.8-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.29.5-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.12.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.19.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.4-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.23.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.7.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.10.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.14.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py38hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyterlab_pygments-0.2.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py38hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libboost-1.73.0-hd4c2dcd_11.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libevent-2.1.12-h0a4fc7d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libllvm11-11.1.0-h46f1229_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libprotobuf-3.11.2-hd9629dc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libthrift-0.13.0-h054ceb0_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.2.0-h87d7836_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.38.0-py38h8346a28_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py38h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.7.2-py38hee32256_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py38h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py38h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py38ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/msgpack-python-1.0.3-py38haf03e11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py38_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-1.1.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.16.4-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.10.4-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.7-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numba-0.55.1-py38hae1ba45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.4-py38h47b59a4_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.21.6-py38h827a554_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.21.6-py38ha186be2_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h7231236_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/orc-1.6.7-h001ef8f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-24.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-1.5.3-py38h07fba90_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.4.0-py38h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-24.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pkgutil-resolve-name-1.3.10-py38hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pooch-1.7.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py38hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyarrow-4.0.1-py38hdf3e9eb_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py38hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py38_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.8.18-h218abb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py38hecd8cb5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-json-logger-2.0.7-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-lmdb-1.4.1-py38hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-snappy-0.6.1-py38hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.2-py38h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-24.0.1-py38h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.32.3-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-toolbelt-1.0.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py38hf2ad997_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ruamel.yaml.clib-0.2.8-py38h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ruamel_yaml-0.17.21-py38hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scipy-1.10.1-py38hf241641_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-60.9.3-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/thrift-0.17.0-py38he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.4.1-py38h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.66.5-py38h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.14.3-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.11.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.11.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py38h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uriparser-0.9.7-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-2.2.3-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py38_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.44.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xarray-2022.11.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py38hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zict-3.0.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.20.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstandard-0.19.0-py38h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.4.9-h322a384_0.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2.10.1-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2.10.1-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/distributed-2.10.0-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.8-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/hvplot-0.7.3-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/intake-parquet-0.2.3-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.7-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/abseil-cpp-20210324.2-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-anon-usage-0.4.4-py38hd6b623d_100.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-client-1.12.3-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-project-0.11.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py38hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py38h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-4.0.1-py38hd7469ad_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-24.2.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.6.8-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.1.6-h313beb8_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.11-h80987f9_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.8.185-h4a942e0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-2.4.3-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.73.0-h1a28f6b_11.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py38hbda83bc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py38h313beb8_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.9.24-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.8.30-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py38h3eb5a62_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.0.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-pack-0.7.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-handling-2.3.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-streaming-0.10.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py38h525c30c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.2-py38h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py38hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py38h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/double-conversion-3.1.5-hc377ac9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.2.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-0.5.0-py38heec5a64_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py38h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.6.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpc-cpp-1.39.0-h95c9599_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-68.1-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.4.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/intake-0.6.8-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.12.2-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.23.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py38hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py38h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.73.0-h49e8a49_11.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-hf27765b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm11-11.1.0-h12f7ac0_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-3.17.2-h98b2900_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.13.0-hd358383_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.2.0-h11e2f9f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.38.0-py38h98b2900_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py38h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.7.2-py38h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py38h525c30c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.4-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.55.1-py38h9197a36_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.4-py38h79ee842_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.21.6-py38hb93e574_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.21.6-py38haf87e8b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.4.0-h0ed58ac_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-1.6.9-hb65cfe6_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-1.5.3-py38h78102c4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.4.0-py38h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.2-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pkgutil-resolve-name-1.3.10-py38hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pooch-1.7.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py38h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-4.0.1-py38hd776c02_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py38hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.8.18-hc0d8a6c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py38hca03da5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py38h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-snappy-0.6.1-py38h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.2-py38h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py38h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-toolbelt-1.0.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py38hf0e4da2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel.yaml.clib-0.2.8-py38h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel_yaml-0.17.21-py38h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.10.1-py38h9d039d2_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-60.9.3-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/thrift-0.17.0-py38hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.1-py38h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.5-py38h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py38h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uriparser-0.9.7-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.3-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py38hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.44.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2022.11.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py38hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.20.2-py38hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstandard-0.19.0-py38h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.4.9-h8574219_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-2.10.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-core-2.10.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/distributed-2.10.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/holoviews-1.14.8-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/hvplot-0.7.3-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/intake-parquet-0.2.3-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/panel-0.12.7-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/abseil-cpp-20210324.2-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anaconda-anon-usage-0.4.4-py38hd6b623d_100.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anaconda-client-1.12.3-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anaconda-project-0.11.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.2.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py38hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py38h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/arrow-cpp-4.0.1-py38hd7469ad_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-24.2.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-common-0.6.8-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-event-stream-0.1.6-h313beb8_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-checksums-0.1.11-h80987f9_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-sdk-cpp-1.8.185-h4a942e0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.3-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-2.4.3-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/boost-cpp-1.73.0-h1a28f6b_11.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.7-py38hbda83bc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py38h313beb8_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2024.9.24-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.8.30-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.17.1-py38h3eb5a62_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-3.0.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/conda-pack-0.7.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/conda-package-handling-2.3.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/conda-package-streaming-0.10.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py38h525c30c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cytoolz-0.12.2-py38h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/datashape-0.5.4-py38hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py38h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/double-conversion-3.1.5-hc377ac9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.2.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fastparquet-0.5.0-py38heec5a64_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.51.0-py38h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2024.6.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/grpc-cpp-1.39.0-h95c9599_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/icu-68.1-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-7.0.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.4.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/intake-0.6.8-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.29.5-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.12.2-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.19.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.4-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.23.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.7.2-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.10.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.14.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py38hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_pygments-0.2.2-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py38h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libboost-1.73.0-h49e8a49_11.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libevent-2.1.12-hf27765b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libllvm11-11.1.0-h12f7ac0_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libprotobuf-3.17.2-h98b2900_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libthrift-0.13.0-hd358383_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.2.0-h11e2f9f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.38.0-py38h98b2900_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py38h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.7.2-py38h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/msgpack-python-1.0.3-py38h525c30c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-1.1.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.16.4-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.10.4-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.7-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numba-0.55.1-py38h9197a36_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.4-py38h79ee842_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.21.6-py38hb93e574_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.21.6-py38haf87e8b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.4.0-h0ed58ac_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/orc-1.6.9-hb65cfe6_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-24.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-1.5.3-py38h78102c4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.4.0-py38h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-24.2-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pkgutil-resolve-name-1.3.10-py38hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pooch-1.7.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py38h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyarrow-4.0.1-py38hd776c02_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py38hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.8.18-hc0d8a6c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py38hca03da5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-2.0.7-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-lmdb-1.4.1-py38h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-snappy-0.6.1-py38h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.2-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.2-py38h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-24.0.1-py38h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.32.3-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-toolbelt-1.0.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py38hf0e4da2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ruamel.yaml.clib-0.2.8-py38h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ruamel_yaml-0.17.21-py38h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.10.1-py38h9d039d2_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-60.9.3-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/thrift-0.17.0-py38hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.4.1-py38h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.66.5-py38h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.14.3-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.11.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.11.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py38h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uriparser-0.9.7-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.2.3-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py38hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.44.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xarray-2022.11.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py38hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zict-3.0.0-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.20.2-py38hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstandard-0.19.0-py38h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.4.9-h8574219_1.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2.30.0-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2.30.0-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.8-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/hvplot-0.7.3-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/intake-parquet-0.2.3-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.7-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-anon-usage-0.4.4-py38hfc23b7f_100.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-client-1.12.3-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-project-0.11.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py38h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-4.0.1-py38h0d1d0e5_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-24.2.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.4.57-ha925a31_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.1.6-hd77b12b_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.9-ha925a31_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.8.185-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-2.4.3-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.73.0-h2bbff1b_12.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py38h9128911_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py38hd77b12b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.9.24-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.8.30-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py38h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.0.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/conda-pack-0.7.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-handling-2.3.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-streaming-0.10.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py38h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.2-py38h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py38haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py38hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2.30.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/double-conversion-3.1.5-ha925a31_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.2.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-0.5.0-py38h080aedc_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py38h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.6.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/grpc-cpp-1.26.0-h351948d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.4.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intake-0.6.8-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.12.2-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.23.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py38haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py38hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.73.0-h6c2663c_12.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.9.1-h0416ee5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-3.11.2-h7bd577a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-hcd4344a_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.38.0-py38h23ce68f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py38h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.7.2-py38h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py38h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py38h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py38h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py38h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py38_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.4-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.55.1-py38hf11a4ad_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.4-py38h7b80656_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.21.6-py38h85e1a82_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.21.6-py38hb5c95e7_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-1.5.3-py38hf11a4ad_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.4.0-py38h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.2-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pkgutil-resolve-name-1.3.10-py38haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pooch-1.7.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py38h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-4.0.1-py38h953b917_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py38haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.8.18-h6244533_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py38haa95532_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py38hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-snappy-0.6.1-py38hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py38h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py38h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.2-py38h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py38h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-toolbelt-1.0.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py38h062c2fa_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ruamel.yaml.clib-0.2.8-py38h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ruamel_yaml-0.17.21-py38h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.10.1-py38hdcfc7df_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-60.9.3-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/thrift-0.17.0-py38hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.1-py38h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.5-py38h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py38h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uriparser-0.9.7-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.3-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.40-h2eaa2aa_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.40.33807-h98bb1dd_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py38_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.44.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2022.11.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py38haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.20.2-py38haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstandard-0.23.0-py38h4fc1ca9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-2.30.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-core-2.30.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/holoviews-1.14.8-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/hvplot-0.7.3-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/intake-parquet-0.2.3-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/panel-0.12.7-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anaconda-anon-usage-0.4.4-py38hfc23b7f_100.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anaconda-client-1.12.3-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anaconda-project-0.11.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-4.2.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py38h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/arrow-cpp-4.0.1-py38h0d1d0e5_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-24.2.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-common-0.4.57-ha925a31_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-event-stream-0.1.6-hd77b12b_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-checksums-0.1.9-ha925a31_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-sdk-cpp-1.8.185-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.3-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-2.4.3-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/boost-cpp-1.73.0-h2bbff1b_12.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.7-py38h9128911_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py38hd77b12b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2024.9.24-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2024.8.30-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.17.1-py38h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cloudpickle-3.0.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/conda-pack-0.7.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/conda-package-handling-2.3.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/conda-package-streaming-0.10.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py38h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cytoolz-0.12.2-py38h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/datashape-0.5.4-py38haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py38hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/distributed-2.30.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/double-conversion-3.1.5-ha925a31_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.2.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fastparquet-0.5.0-py38h080aedc_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fonttools-4.51.0-py38h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fsspec-2024.6.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/grpc-cpp-1.26.0-h351948d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.7-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-7.0.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.4.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intake-0.6.8-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.29.5-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.12.2-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.19.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.4-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.23.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.7.2-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.10.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.14.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py38haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyterlab_pygments-0.2.2-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py38hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libboost-1.73.0-h6c2663c_12.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libcurl-8.9.1-h0416ee5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libprotobuf-3.11.2-h7bd577a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libssh2-1.10.0-hcd4344a_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/llvmlite-0.38.0-py38h23ce68f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py38h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.7.2-py38h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py38h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py38h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py38h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/msgpack-python-1.0.3-py38h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py38_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-1.1.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-7.16.4-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.10.4-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.7-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numba-0.55.1-py38hf11a4ad_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.4-py38h7b80656_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.21.6-py38h85e1a82_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.21.6-py38hb5c95e7_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-24.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-1.5.3-py38hf11a4ad_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.4.0-py38h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-24.2-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pkgutil-resolve-name-1.3.10-py38haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pooch-1.7.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py38h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyarrow-4.0.1-py38h953b917_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py38haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.8.18-h6244533_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py38haa95532_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-json-logger-2.0.7-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-lmdb-1.4.1-py38hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-snappy-0.6.1-py38hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.2-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py38h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py38h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.2-py38h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-24.0.1-py38h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.32.3-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-toolbelt-1.0.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py38h062c2fa_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ruamel.yaml.clib-0.2.8-py38h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ruamel_yaml-0.17.21-py38h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scipy-1.10.1-py38hdcfc7df_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-60.9.3-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/thrift-0.17.0-py38hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.4.1-py38h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.66.5-py38h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.14.3-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.11.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.11.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py38h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uriparser-0.9.7-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-2.2.3-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.40-h2eaa2aa_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.40.33807-h98bb1dd_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py38_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.44.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xarray-2022.11.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py38haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zict-3.0.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.20.2-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstandard-0.23.0-py38h4fc1ca9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
   sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
   md5: 613805add1c05b538ff06d217252feb7
   depends:
@@ -920,7 +920,7 @@ packages:
   license: BSD-3-Clause
   size: 20810
   timestamp: 1652859733309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-anon-usage-0.4.4-py38hfc0e8ea_100.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anaconda-anon-usage-0.4.4-py38hfc0e8ea_100.tar.bz2
   sha256: b73d3f04aff05d074c30e87e5585386e601ce2f1c53a5272237f23c6a71e17ca
   md5: 5d167486fd7cb6ec609ff51377886a9a
   depends:
@@ -932,7 +932,7 @@ packages:
   license_family: BSD
   size: 23841
   timestamp: 1710966364697
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-client-1.12.3-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anaconda-client-1.12.3-py38h06a4308_0.tar.bz2
   sha256: d6bdfa40fb99b38abf42ab435b01f8083fa4c21597e9d5073ad0c92b9bf1bf47
   md5: 9c13bfe061d4fd4df4fdfb7f8a48b66c
   depends:
@@ -955,7 +955,7 @@ packages:
   license_family: BSD
   size: 140194
   timestamp: 1708640877290
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-project-0.11.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anaconda-project-0.11.1-py38h06a4308_0.tar.bz2
   sha256: 697c8858e553c32cddc67601012a5e33f80e8f8c929e9f5b15b27dc7cbac3844
   md5: 6b0c787dc9dfa7e388804388324565f8
   depends:
@@ -971,7 +971,7 @@ packages:
   license_family: BSD
   size: 544176
   timestamp: 1660339965043
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-4.2.0-py38h06a4308_0.tar.bz2
   sha256: 81c0b302c60444025a3f58629dc650ee00ef381266c49fcb9eb65d625610c2a9
   md5: 25af24630b7e1521684421423eb0af86
   depends:
@@ -987,7 +987,7 @@ packages:
   license_family: MIT
   size: 173515
   timestamp: 1706220222537
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py38h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py38h7f8727e_0.tar.bz2
   sha256: 754046398c314772a7d38b7d4c0d488a48db7b1b9c6a421686ef13178e1997b9
   md5: e785c0744d3ed83d813a42b7bb9b8794
   depends:
@@ -998,7 +998,7 @@ packages:
   license_family: MIT
   size: 35378
   timestamp: 1644569723962
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-4.0.1-py38hced866c_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/arrow-cpp-4.0.1-py38hced866c_3.tar.bz2
   sha256: ecbaa1c83b0b862d4ed773fe54c0da6ed9405283a251eadfee671c96db00e5b4
   md5: 3d0d127e914827662f83ec94c3171ff7
   depends:
@@ -1031,7 +1031,7 @@ packages:
   license_family: Apache
   size: 8738938
   timestamp: 1622563173502
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-24.2.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-24.2.0-py38h06a4308_0.tar.bz2
   sha256: 7cee7158a2a214c72a5bdb5953eafe138f895c7ebc5d948f0711a58c5779fd59
   md5: 117b0e2a4d24435fc67cf639dfe6b9a8
   depends:
@@ -1040,7 +1040,7 @@ packages:
   license_family: MIT
   size: 141122
   timestamp: 1729089430211
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.4.57-he6710b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-common-0.4.57-he6710b0_1.tar.bz2
   sha256: bc87abecbc7e34b42b5a7ec3a3470ee284ed82f5f638274f795810fd0aa85496
   md5: e883ae27a33cff702b8a20b5394e9ae0
   depends:
@@ -1050,7 +1050,7 @@ packages:
   license_family: Apache
   size: 164855
   timestamp: 1601398346279
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.1.6-h2531618_5.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-event-stream-0.1.6-h2531618_5.tar.bz2
   sha256: 4f7d93ed96f6692266a700971029b841dc972a6af39b85ba9525eebe2c40edbb
   md5: 6b7ceb5ff64fc9f4537bfe7a2d7fe4a0
   depends:
@@ -1062,7 +1062,7 @@ packages:
   license_family: Apache
   size: 25449
   timestamp: 1603894551837
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.9-he6710b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-checksums-0.1.9-he6710b0_0.tar.bz2
   sha256: 17d0e3361698b9a0a9b52836284b658886d25bf349f3a099b765eac23ceb4ebd
   md5: 0a7ed2b675a5af15d4979f4ca5c93d39
   depends:
@@ -1073,7 +1073,7 @@ packages:
   license_family: Apache
   size: 52520
   timestamp: 1601398555928
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.8.185-hce553d0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-sdk-cpp-1.8.185-hce553d0_0.tar.bz2
   sha256: 2842aafc907c01ccbe26ca11bddad6c55e9f93d30cf57431e327f5e57666be2c
   md5: 5b4e9429338430ef3b71802778ac2184
   depends:
@@ -1087,7 +1087,7 @@ packages:
   license_family: Apache
   size: 2442091
   timestamp: 1618434946994
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.3-py38h06a4308_0.tar.bz2
   sha256: 6739f4b541ac211695cdd0b3111d414d05a4fa76b6c2bff75f16c18f71acff9b
   md5: 61d90626295e5947ebe5b20336aebbe5
   depends:
@@ -1097,12 +1097,12 @@ packages:
   license_family: MIT
   size: 213661
   timestamp: 1718029873484
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-2.4.3-py38h06a4308_0.tar.bz2
   sha256: c5ab37760e889de86ff84573af7b2209b522b71a8204aaddcf56aaa9e1ed7a2e
   md5: cdb0ee83e9c478d96d12c837716659ee
   depends:
@@ -1118,7 +1118,7 @@ packages:
   license_family: BSD
   size: 14441483
   timestamp: 1658136913187
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.73.0-h27cfd23_11.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/boost-cpp-1.73.0-h27cfd23_11.tar.bz2
   sha256: 22618c69b5ccb053932032e6ae383043b3f421321f59eadb9fc642ffcb19e4f8
   md5: 09641ed5d9055c5fe4e326ae1516b514
   depends:
@@ -1127,7 +1127,7 @@ packages:
   license: Boost-1.0
   size: 24776
   timestamp: 1611677121434
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py38ha9d4c09_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.7-py38ha9d4c09_0.tar.bz2
   sha256: 303969d4cad67aea4c419a5fa7898e14a9eb687f842f9bbbd26d38a57cb587d7
   md5: 85573eff55231ce12b2524b1bc9cd680
   depends:
@@ -1138,7 +1138,7 @@ packages:
   license_family: BSD
   size: 128997
   timestamp: 1707864355732
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
   sha256: 5d15605858771290fdaaae41a43941623757a25cb1292080d69d6d3857807935
   md5: 7f517469aa5380c52e55db9f37df104f
   depends:
@@ -1149,7 +1149,7 @@ packages:
   license: MIT
   size: 18652
   timestamp: 1714483267080
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
   sha256: a5094f078584e27c7cced4a9564ae904a329f5c1702a7c1ba092d581ba1544f1
   md5: 6ddf45dd8a21a9512481de9bc0e5a03f
   depends:
@@ -1159,7 +1159,7 @@ packages:
   license: MIT
   size: 19711
   timestamp: 1714483255915
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py38h6a678d5_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py38h6a678d5_8.tar.bz2
   sha256: 32a5fa6d1daec0cf439cd62c837635c8b8ff43501040c6741a7aa07cb0cff7a0
   md5: 40ee797fbc97009e705f319281714347
   depends:
@@ -1169,7 +1169,7 @@ packages:
   license: MIT
   size: 361224
   timestamp: 1714483375944
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
   sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
   md5: f5058c8d5b2994b7334f18e022105a14
   depends:
@@ -1178,7 +1178,7 @@ packages:
   license_family: BSD
   size: 427542
   timestamp: 1714510571510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
   sha256: 5b4c80587ae4ec915505469f79d866f27c80456156667c8548d31c67c2c1653e
   md5: c3d6bfae757760082261779c406a880d
   depends:
@@ -1187,14 +1187,14 @@ packages:
   license_family: MIT
   size: 116270
   timestamp: 1693902021950
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.9.24-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2024.9.24-h06a4308_0.tar.bz2
   sha256: e9f2e55d34b1b0b9b48e48a1d6e4503653f8b7059114d23f758b7c68dde2334a
   md5: 4a091502b44d4090f30f0be847a8139c
   license: MPL-2.0
   license_family: Other
   size: 139901
   timestamp: 1727794854964
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.8.30-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2024.8.30-py38h06a4308_0.tar.bz2
   sha256: d7e2a831580f09a3919fd16f00835527dc0bcae5c1dd996996d446fb93066aaf
   md5: bbe57eaf0c4b8ec3e13e09f5889211c6
   depends:
@@ -1203,7 +1203,7 @@ packages:
   license_family: Other
   size: 167786
   timestamp: 1725551758984
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py38h1fdaa30_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.17.1-py38h1fdaa30_0.tar.bz2
   sha256: a76a4d5f1a562134ce1600dc06c86404e866b1e9e1fdb8c77879fb7fec95c58e
   md5: 8164a1a89ade4f794d748c1b254e32bf
   depends:
@@ -1215,7 +1215,7 @@ packages:
   license_family: MIT
   size: 240177
   timestamp: 1726856583659
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py38h06a4308_0.tar.bz2
   sha256: 280c41c89637ee535905d1d49ef30b9ce8cc9c4ede2071cf06e48958c737eedb
   md5: 89f82ddfd7c0a44207eeaf297b34bd49
   depends:
@@ -1224,7 +1224,7 @@ packages:
   license_family: BSD
   size: 151614
   timestamp: 1698129899368
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.0.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cloudpickle-3.0.0-py38h06a4308_0.tar.bz2
   sha256: f5ddbcb0abbf7b452e84f6d0e8706e34ba337f6a804dbbc64b6507f655d7c0f0
   md5: 7cf157c1f64d9b7093f6584871534037
   depends:
@@ -1233,7 +1233,7 @@ packages:
   license_family: BSD
   size: 34658
   timestamp: 1721657412717
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py38h06a4308_0.tar.bz2
   sha256: 8bd52fa912bfcc27891c1fe081e388c11e241a9efe0d1f4d17081f30e500ddcd
   md5: 0ef58a5e5789b24ddc9a51ce1e2db211
   depends:
@@ -1242,7 +1242,7 @@ packages:
   license_family: CC
   size: 551692
   timestamp: 1709758436168
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py38h06a4308_0.tar.bz2
   sha256: 18c20e63bb1281245e576c826f982d2f5ab8ec4f91d84ae065fcc8f60868707d
   md5: cfe4d8a38291f0cddc185d90f9c375a3
   depends:
@@ -1252,7 +1252,7 @@ packages:
   license_family: BSD
   size: 14521
   timestamp: 1709322872304
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-pack-0.7.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/conda-pack-0.7.1-py38h06a4308_0.tar.bz2
   sha256: 7604210cac50634de3a0425d1ddb3e99a6beb86277550b4e68397b9a79ecc795
   md5: 77cd6565ede632e85c1f3f1d17365549
   depends:
@@ -1262,7 +1262,7 @@ packages:
   license_family: BSD
   size: 51285
   timestamp: 1710258126481
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-handling-2.3.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/conda-package-handling-2.3.0-py38h06a4308_0.tar.bz2
   sha256: 68649d880c52d4dd2e9e4af325fed2c1c8e387ada2e53d1a524f453fe6781b5d
   md5: eeb5999b6dbf1cee2569620ab71f78c2
   depends:
@@ -1273,7 +1273,7 @@ packages:
   license_family: BSD
   size: 278214
   timestamp: 1718138355562
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-streaming-0.10.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/conda-package-streaming-0.10.0-py38h06a4308_0.tar.bz2
   sha256: c3da4c862053f648ef73f7c414fc02e24d1d09f000a7a2ddca06fae5daa90141
   md5: bcbb81867de45effea4600d2eda4f9e1
   depends:
@@ -1283,7 +1283,7 @@ packages:
   license_family: BSD
   size: 27259
   timestamp: 1718136125239
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.0.5-py38hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/contourpy-1.0.5-py38hdb19cb5_0.tar.bz2
   sha256: 1c3fd4d2cbfac81ba9226f4bc61f56199da0633660569a1c4668754e8aaef5b4
   md5: 1fbceb30a5aeb9fb6e296b554d311973
   depends:
@@ -1295,7 +1295,7 @@ packages:
   license_family: BSD
   size: 233599
   timestamp: 1663827474400
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.2-py38h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cytoolz-0.12.2-py38h5eee18b_0.tar.bz2
   sha256: f0d4c0db6c12988306f1986c7f9194b08098a65716938b7c535cadbf55abe658
   md5: 6897882ef37ea2e4a490ddecce92e790
   depends:
@@ -1306,7 +1306,7 @@ packages:
   license_family: BSD
   size: 424601
   timestamp: 1701723878901
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py38h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/datashape-0.5.4-py38h06a4308_1.tar.bz2
   sha256: 823bbb3c8951739e8ff5fbf9470cf4ca06c790fe4646388922bf29800b02acad
   md5: 53492f02a308427dab7a204dcc2f343f
   depends:
@@ -1318,7 +1318,7 @@ packages:
   license_family: BSD
   size: 104159
   timestamp: 1613390257727
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py38h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py38h6a678d5_0.tar.bz2
   sha256: ef74961984f61916dba94fe5c7bbe3cf5d209e09b83baf1e0e9e5edb45f505bb
   md5: 6530fae52928cdb84020738094760e12
   depends:
@@ -1329,7 +1329,7 @@ packages:
   license_family: MIT
   size: 2162264
   timestamp: 1690905165766
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2.30.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/distributed-2.30.1-py38h06a4308_0.tar.bz2
   sha256: a931cd3bcc60d6609f0f951f82ab8e9c78bdc57eef789b999d9c31f03f072837
   md5: 053a1a3d214bcc1c95405c30331d9652
   depends:
@@ -1353,7 +1353,7 @@ packages:
   license_family: BSD
   size: 1105808
   timestamp: 1605066559613
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/double-conversion-3.1.5-he6710b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/double-conversion-3.1.5-he6710b0_1.tar.bz2
   sha256: 636ed92de3d236204a971cacd93c731fa5142c52940a37411fef8ab23243ebde
   md5: d58335091a21fb84be6017f879a9cec9
   depends:
@@ -1363,7 +1363,7 @@ packages:
   license_family: BSD
   size: 239084
   timestamp: 1567108307419
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py38h06a4308_0.tar.bz2
   sha256: fc256adb1e5c237867e04a2699c1eec3ea93256cfa7914880d59c69563f1c95d
   md5: 20c8874b5ae24bf4bea2303aeb5f7f03
   depends:
@@ -1372,7 +1372,7 @@ packages:
   license_family: MIT
   size: 16351
   timestamp: 1649926480666
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.2.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.2.0-py38h06a4308_0.tar.bz2
   sha256: 840e4c00530b9e0041072398837245562cac3cb674445fa3bf060bfdff08d850
   md5: 82c4ff737ffdbae28faddaca00a8500c
   depends:
@@ -1381,7 +1381,7 @@ packages:
   license_family: MIT
   size: 29482
   timestamp: 1706031454101
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-0.5.0-py38h7deecbd_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fastparquet-0.5.0-py38h7deecbd_2.tar.bz2
   sha256: f0cff0cfb1d7b0b2bbfe78e224b206fd49670914364d4f21a5acc56981bc8376
   md5: 8ca5334ce12675d3863a98ea51a9267b
   depends:
@@ -1398,7 +1398,7 @@ packages:
   license_family: Apache
   size: 192321
   timestamp: 1658500714903
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py38h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fonttools-4.51.0-py38h5eee18b_0.tar.bz2
   sha256: bb820ee5acdfa020de4529682848aec90b4b4f7b72c30e93922670ca68c8af0b
   md5: 3933e8679a5a9a9fdf2628bac353def4
   depends:
@@ -1417,7 +1417,7 @@ packages:
   license_family: MIT
   size: 2709838
   timestamp: 1713551599721
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
   sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
   md5: a5dc8677d891dff2393b63189a3ad42f
   depends:
@@ -1428,7 +1428,7 @@ packages:
   license_family: Other
   size: 971975
   timestamp: 1666798278693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.6.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fsspec-2024.6.1-py38h06a4308_0.tar.bz2
   sha256: 784dd97601a10e944381209ff05576880d21cdd8c52b35aa15ebfcfda80a144e
   md5: 21ccb0ee71a1baa9be31aeb82b4f8009
   depends:
@@ -1439,7 +1439,7 @@ packages:
   license_family: BSD
   size: 282839
   timestamp: 1724855608255
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
   sha256: 2fc1136056f41fe92de719fb821550346704965dd12a5fa35069cdb4948d5c17
   md5: fd089b0fba2b03aafe3adb6cdaa9ac3b
   depends:
@@ -1449,7 +1449,7 @@ packages:
   license_family: BSD
   size: 203421
   timestamp: 1706888218007
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
   sha256: f1e190d4ee766add8131a2b011723c472284de2bbb5e07c8f895f30e3c591df7
   md5: 82029e0758feac811afec2a6ef9e6155
   depends:
@@ -1460,7 +1460,7 @@ packages:
   license_family: BSD
   size: 108438
   timestamp: 1706895276199
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/grpc-cpp-1.26.0-hf8bcb03_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/grpc-cpp-1.26.0-hf8bcb03_0.tar.bz2
   sha256: 47eb032ccafbedd87787960a1ebea8d7dcee67cc0879420251430b67c8dbe3aa
   md5: 3f4fca8649aa196df2ed0377d313bf33
   depends:
@@ -1476,7 +1476,7 @@ packages:
   license_family: APACHE
   size: 6323465
   timestamp: 1580397868189
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
   sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
   md5: 9213e0336e3a5216c989cfe52648412e
   depends:
@@ -1485,7 +1485,7 @@ packages:
   license: MIT
   size: 23805906
   timestamp: 1588026213084
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py38h06a4308_0.tar.bz2
   sha256: 47ca02ff580ebdfdb6f537e53eb997ba9fa16919e6de799217729df19044778f
   md5: abbda5a815f8e6ff448015463a04104b
   depends:
@@ -1494,7 +1494,7 @@ packages:
   license_family: BSD
   size: 122729
   timestamp: 1714398916443
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-7.0.1-py38h06a4308_0.tar.bz2
   sha256: 22fd000f3311c85981922a4bf98ea1f5fcf16511867b4a9efb1aa127889539e1
   md5: ed207312594da3e585cee48578ad03c3
   depends:
@@ -1504,7 +1504,7 @@ packages:
   license_family: APACHE
   size: 41143
   timestamp: 1704813599672
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.4.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib_resources-6.4.0-py38h06a4308_0.tar.bz2
   sha256: ecb9acc656df8b75d58155ee02094c58e3b12da44c9cd0612b963c1f835176e9
   md5: 078b461a82b6e3566d085b35f9a986a3
   depends:
@@ -1514,7 +1514,7 @@ packages:
   license_family: APACHE
   size: 57044
   timestamp: 1720641149749
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intake-0.6.8-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intake-0.6.8-py38h06a4308_0.tar.bz2
   sha256: 2935149f9ddffca37129022af2257b1e1f1ed6778432e22bb2fee13b4957d2cd
   md5: 8f810d7f901ed1c2d2135830ef944f01
   depends:
@@ -1537,7 +1537,7 @@ packages:
   license_family: BSD
   size: 190444
   timestamp: 1678787690195
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
   sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
   md5: 3add2ce56858a1b8f6a37342f82773d3
   depends:
@@ -1553,7 +1553,7 @@ packages:
   license_family: Proprietary
   size: 19310769
   timestamp: 1699647799237
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.29.5-py38h06a4308_0.tar.bz2
   sha256: 02bf224c27e9a3ec27ab87ca29958c0e14a874f8229a3c7b0c0839021d3623fd
   md5: 32f787d90395709049530ed5dc713dde
   depends:
@@ -1574,7 +1574,7 @@ packages:
   license_family: BSD
   size: 189966
   timestamp: 1728665757818
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.12.2-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.12.2-py38h06a4308_0.tar.bz2
   sha256: e413c50a320468c543fc0b434e914a1705f2078a3c349036db7457818e6c2865
   md5: 659aa6a467e962ab07c83300d5edbdc2
   depends:
@@ -1594,7 +1594,7 @@ packages:
   license_family: BSD
   size: 1232450
   timestamp: 1691532256204
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.19.1-py38h06a4308_0.tar.bz2
   sha256: a673641439b85d304ac1aa414df4695f4392e45cda13fd2ddd0a3c3dc1469535
   md5: 7d5ec56787be4ebbec5a16718ee9ca44
   depends:
@@ -1604,7 +1604,7 @@ packages:
   license_family: MIT
   size: 1041775
   timestamp: 1721058483437
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.4-py38h06a4308_0.tar.bz2
   sha256: 3a395f908d68944947e3c8c029e45c547165aab1436136bbd9ff8c75a3e13991
   md5: e17c73db8358f07cb8122c933fca1fa5
   depends:
@@ -1616,7 +1616,7 @@ packages:
   license_family: BSD
   size: 269362
   timestamp: 1716993428097
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
   sha256: 8316ae3abee25edab89788ee6e9eef79c398aba192559f514674a04ee1860bca
   md5: 112209aed451545a622ab217c70f6972
   depends:
@@ -1625,7 +1625,7 @@ packages:
   license_family: Other
   size: 283506
   timestamp: 1722872662693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.23.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.23.0-py38h06a4308_0.tar.bz2
   sha256: bbd39adbb30919396738406c1f89c628943f2d5e7cb186b760183adc63d26722
   md5: 860c6a74f3979368e0c469d55fb558a3
   depends:
@@ -1640,7 +1640,7 @@ packages:
   license_family: MIT
   size: 143131
   timestamp: 1728486771164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py38h06a4308_0.tar.bz2
   sha256: ceb19fccf3b8605f59c6e9d5cc269d27f988ee6cd4f869b33cf92657d4d4a5ab
   md5: c6faaeb8e78882bc809204faf308b607
   depends:
@@ -1651,7 +1651,7 @@ packages:
   license_family: MIT
   size: 14884
   timestamp: 1699032456771
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py38h06a4308_0.tar.bz2
   sha256: 4c8a46b9b7ec7121a00b2d731b1da19fc5bf9f742be31b2d73985d1b384d6a38
   md5: 966714096421f7371663c8bfa72bfa89
   depends:
@@ -1667,7 +1667,7 @@ packages:
   license_family: BSD
   size: 193526
   timestamp: 1676329113709
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.7.2-py38h06a4308_0.tar.bz2
   sha256: 3086b9066f87c9e39b1f460a577bf4c9f90e8fb77c35dfe6a97e38c7453cff04
   md5: d5870ff588e1ab9894b1e358c15c4b4d
   depends:
@@ -1678,7 +1678,7 @@ packages:
   license_family: BSD
   size: 82166
   timestamp: 1718818351134
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.10.0-py38h06a4308_0.tar.bz2
   sha256: 8196dfb81170e31ddd1a3fde2af70d37402db7c5ebca2fa7a631a2dc45efe43e
   md5: 0761392754dde3344652bc219afd45e4
   depends:
@@ -1694,7 +1694,7 @@ packages:
   license_family: BSD
   size: 35403
   timestamp: 1718738195926
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.14.1-py38h06a4308_0.tar.bz2
   sha256: 91fec7e3c7106a59899c66f91138659a64f2b113e043dce6ec122e2d0992dc85
   md5: 6de544720ab8c1885e4a44d63c4ba256
   depends:
@@ -1721,7 +1721,7 @@ packages:
   license_family: BSD
   size: 497539
   timestamp: 1718827343800
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py38h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py38h06a4308_1.tar.bz2
   sha256: 44db85c9fa468cc638218817e7ccac8acb2c72d2b57c73feb35a84971821270f
   md5: f45fb644c3b4a54fdbce4b2d4c48ee5b
   depends:
@@ -1731,7 +1731,7 @@ packages:
   license_family: BSD
   size: 23572
   timestamp: 1686870759447
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyterlab_pygments-0.2.2-py38h06a4308_0.tar.bz2
   sha256: c70ef82b953dc472e041ed773afb291965a05df6645fa1e86d1f5c862b884bec
   md5: 6a86c99c914f182b3cf5a3ae62048627
   depends:
@@ -1743,7 +1743,7 @@ packages:
   license_family: BSD
   size: 18833
   timestamp: 1700168696651
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py38h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py38h6a678d5_0.tar.bz2
   sha256: cf12730976bd3123a14fced370792fb29703bb3415a9dc461c1a7b102fff4074
   md5: 8a0f9997ddc49e6a31cf204b04149b3d
   depends:
@@ -1754,7 +1754,7 @@ packages:
   license_family: BSD
   size: 77848
   timestamp: 1672387224889
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h568e23c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/krb5-1.20.1-h568e23c_1.tar.bz2
   sha256: 126a5fd5e59cc90c1a2c688a801dea7f352f0bb218c2f949d0f3d21db35fbe1b
   md5: 64d1d86c812dc1843bcbb4cab2e8f60f
   depends:
@@ -1766,7 +1766,7 @@ packages:
   license_family: MIT
   size: 1426697
   timestamp: 1686931184185
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -1777,7 +1777,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
   sha256: 069d33aebaf4db4ae410d4acb4851860a69d2c8f326fd45ab2a67b67fe276e6d
   md5: 61689da52cf1fcebda8c9fb2872f94bf
   constrains:
@@ -1785,7 +1785,7 @@ packages:
   license: GPL-3.0-only
   size: 723073
   timestamp: 1727336193185
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.73.0-h3ff78a5_11.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libboost-1.73.0-h3ff78a5_11.tar.bz2
   sha256: 55e595d5b5c5c2361c56a9ea3868ed5e97c99b3ffc614487b7aec7126722292a
   md5: b41dce08aea9e243db25a95f00708724
   depends:
@@ -1799,7 +1799,7 @@ packages:
   license: Boost-1.0
   size: 22298574
   timestamp: 1611677068430
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
   sha256: bb990ea068c3b3dafd9c807e0e19570320cb2fe7d69cc326f1f0b5319b0654b2
   md5: 3ff70744e396b1af69656c574b05c3b9
   depends:
@@ -1807,7 +1807,7 @@ packages:
   license: MIT
   size: 66940
   timestamp: 1714483221853
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
   sha256: 3b87a816f72a00e1f0022a160e7eda70af89d3de2a2e08a72be1c17b31d759f3
   md5: 4f57d3a0a13ddaf1c06efb586b702f46
   depends:
@@ -1816,7 +1816,7 @@ packages:
   license: MIT
   size: 34446
   timestamp: 1714483232430
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
   sha256: 2cf15e89f910600f468edfde8d0f9b80a14fa2319ed89160dc7375dfd3764fdb
   md5: 463adc13f2feea3570d1eccac368d9e4
   depends:
@@ -1825,7 +1825,7 @@ packages:
   license: MIT
   size: 295090
   timestamp: 1714483244460
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.2.1-h91b91d3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libcurl-8.2.1-h91b91d3_0.tar.bz2
   sha256: 8daa34822b26916b12867746d55790aa5b719e096e412aba86c5a9f13b19ee36
   md5: bd594551d7447f93c8a1575be1b1f12e
   depends:
@@ -1841,7 +1841,7 @@ packages:
   license_family: MIT
   size: 386369
   timestamp: 1693515365220
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
   sha256: 5bd3af246b6a93ea0912179ae66e0ad9157ca0142263010d84b65724e6db0bec
   md5: 5cb0cc0e1783419cf8fc1c65fee0f62f
   depends:
@@ -1851,7 +1851,7 @@ packages:
   license_family: BSD
   size: 195807
   timestamp: 1703006263489
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
   sha256: efdab884c85fda4461f7a393aa6d4e0e50d03cb59fb9c8a980b1307b8379ebe0
   md5: eeca774c6154c49340dd403b1928d5e9
   depends:
@@ -1860,7 +1860,7 @@ packages:
   license_family: BSD
   size: 108906
   timestamp: 1632891483341
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-h8f2d780_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libevent-2.1.12-h8f2d780_0.tar.bz2
   sha256: 2b9470932f5c923f19fcc14c8d1c7ed5f58a468588c09d6b04e0a905c07a297f
   md5: 2e3534102d10ade546c0feb056bbffbe
   depends:
@@ -1870,7 +1870,7 @@ packages:
   license_family: BSD
   size: 491177
   timestamp: 1642102679055
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
   sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
   md5: 1af9b4d62c708924417f2640ef22a68f
   depends:
@@ -1880,7 +1880,7 @@ packages:
   license_family: MIT
   size: 154016
   timestamp: 1714483282916
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
   sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
   md5: 641e72e5067bd6d5454405879e1cd2a7
   depends:
@@ -1895,7 +1895,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 8895144
   timestamp: 1654090827491
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
   sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
   md5: 27082517590f3b9fbffecc68513b461b
   depends:
@@ -1904,7 +1904,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 19860
   timestamp: 1654090819660
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
   sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
   md5: 0202c3c8ae4735cac6c7f3d1e1685964
   constrains:
@@ -1912,7 +1912,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 5228750
   timestamp: 1654090762569
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
   sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
   md5: 3080c2813e6e1d0f8a100a38b5b3456d
   depends:
@@ -1920,7 +1920,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 573231
   timestamp: 1654090775721
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.1.0-h9e868ea_6.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libllvm11-11.1.0-h9e868ea_6.tar.bz2
   sha256: 0fd833e8a519f75e2c4b6cdbec75b8fffc1cd015b2b795d1566855e486705736
   md5: c2b4c6491de2bf531083a51092ecd077
   depends:
@@ -1931,7 +1931,7 @@ packages:
   license_family: Apache
   size: 30349190
   timestamp: 1665079289108
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.52.0-ha637b67_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libnghttp2-1.52.0-ha637b67_1.tar.bz2
   sha256: 71a65b3c05426b92e8a3002e7d42cd303255439f8a4442b4fc5aa882aef3128e
   md5: 113b010119638c67e3b6c8570d88f5be
   depends:
@@ -1947,7 +1947,7 @@ packages:
   license_family: MIT
   size: 716614
   timestamp: 1686931412665
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
   sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
   md5: 1bffe1481ed4f88827248fb9001f8923
   depends:
@@ -1957,7 +1957,7 @@ packages:
   license_family: Other
   size: 362561
   timestamp: 1677841789536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-3.11.2-hd408876_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libprotobuf-3.11.2-hd408876_0.tar.bz2
   sha256: 49de2670c8035b28619dc023b3cbf32bb5af9bfaefc80ddc06bfe4f242acfff5
   md5: 0cb203fe2cf64272f676d502fe735282
   depends:
@@ -1968,7 +1968,7 @@ packages:
   license_family: BSD
   size: 5055824
   timestamp: 1576541584171
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -1976,7 +1976,7 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-h37d81fd_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libssh2-1.10.0-h37d81fd_2.tar.bz2
   sha256: 41f2e9a088031bd209d50f37f727fb9647be9316db3e149f9f2bac0057f7184d
   md5: 778c268743d6cf857178bd1ecf6c9525
   depends:
@@ -1986,7 +1986,7 @@ packages:
   license_family: BSD
   size: 311794
   timestamp: 1686931200150
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
   sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
   md5: 8c195584a5f5471b600ee180e4052773
   depends:
@@ -1994,7 +1994,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 6410287
   timestamp: 1654090800863
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.13.0-hfb8234f_6.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libthrift-0.13.0-hfb8234f_6.tar.bz2
   sha256: 3a8318fe49dc8c591e48a74faef05863266d539ab4ae32b146e80adb38909901
   md5: a90d894593c49e8880ba0f8b58bb1a47
   depends:
@@ -2006,7 +2006,7 @@ packages:
   license: Apache-2.0
   size: 3397616
   timestamp: 1612012797813
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h85742a9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h85742a9_0.tar.bz2
   sha256: 5e249c94d0b7b3bf035d69c2f707964b5e39995987b359d17de28c0a54ee9405
   md5: d7ea21b29e29feec41890296b559555b
   depends:
@@ -2020,7 +2020,7 @@ packages:
   license: HPND
   size: 655372
   timestamp: 1616492392965
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
   sha256: a062fad27450b94279d1688aabd11a95eedee7814462ef6364337d55412b4a7e
   md5: e0521f84b9770830e654432364ac930e
   depends:
@@ -2031,7 +2031,7 @@ packages:
   license_family: BSD
   size: 484011
   timestamp: 1729160032020
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.38.0-py38h4ff587b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.38.0-py38h4ff587b_0.tar.bz2
   sha256: f1780772574d60a05acbc2e8b815d872aff742deef0771c3a9478e3ddd134d38
   md5: eb87b15618c4c17eb79f676d79163df6
   depends:
@@ -2043,7 +2043,7 @@ packages:
   license: BSD-2-Clause
   size: 2828020
   timestamp: 1647870575953
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py38h06a4308_0.tar.bz2
   sha256: a2c16e4e68e414ea6f7680a6439e80f7d67fb693bf739fc10d2ef5afc3e3c2f4
   md5: dc8d6a9a1e475c5fc9de8531026a4c38
   depends:
@@ -2052,7 +2052,7 @@ packages:
   license_family: BSD
   size: 11040
   timestamp: 1652903148662
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
   sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
   md5: 76f089e76ec67583bb38428b51008097
   depends:
@@ -2062,7 +2062,7 @@ packages:
   license_family: BSD
   size: 164494
   timestamp: 1714510587156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py38h06a4308_0.tar.bz2
   sha256: 67fb17f71cf101e66ccb210d8a5c3c10fd6966aaff214034fb6f860ca8d00e7f
   md5: 32d28f2c97744b2e954e30fa485b5c5c
   depends:
@@ -2072,7 +2072,7 @@ packages:
   license_family: BSD
   size: 122380
   timestamp: 1671541939225
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py38h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py38h5eee18b_0.tar.bz2
   sha256: 3315d71ae2bde9dd4ccdf6e46f4712cd2dc1e13ecb06c56dd16664f78a57e741
   md5: b9289ff19edb3f17a61626227f6bfedb
   depends:
@@ -2084,7 +2084,7 @@ packages:
   license_family: BSD
   size: 23620
   timestamp: 1704206039363
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.7.2-py38h1128e8f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.7.2-py38h1128e8f_0.tar.bz2
   sha256: 25805e84b2627e7334324cf45b51f849fc206b7607f5f6ec4d1f2a5694b7ee70
   md5: f51b424771ea1f1be2850492133e8003
   depends:
@@ -2110,7 +2110,7 @@ packages:
   license_family: PSF
   size: 8040239
   timestamp: 1693812835140
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py38h06a4308_0.tar.bz2
   sha256: 228a70eddf0a99801e03179f1ab8ddd915bfb7ce351fe7f94c502163d615eb77
   md5: 28c78d14ef2a80747df2bf2353ef21d7
   depends:
@@ -2120,7 +2120,7 @@ packages:
   license_family: BSD
   size: 16341
   timestamp: 1662014640999
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py38h06a4308_0.tar.bz2
   sha256: ae9df84d25f410f1d5ad3af4fb29bd8507211e9f10717f4d47d60bddf9bf02bb
   md5: 0219b4aefc356586a8045ae2a77ae3fd
   depends:
@@ -2131,7 +2131,7 @@ packages:
   license_family: BSD
   size: 89740
   timestamp: 1661496287860
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
   sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
   md5: ce77d0f05f846da4a6b9e23fe7f21d9b
   depends:
@@ -2145,7 +2145,7 @@ packages:
   license_family: Proprietary
   size: 206738176
   timestamp: 1699648006088
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py38h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py38h5eee18b_1.tar.bz2
   sha256: 7f2c07976bdaebb69efcfb1bf64de1ca257eaf88b5d5447c4f5c257a78ad3aa7
   md5: 47e5af1bb13950ed4a58ad1242346ab9
   depends:
@@ -2156,7 +2156,7 @@ packages:
   license_family: BSD
   size: 59130
   timestamp: 1682948582735
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py38h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py38h5eee18b_0.tar.bz2
   sha256: 44f1cdba39f689ff98eddb1a04ff82764d97abcb56ec2d678bf62598bc2dc7ff
   md5: 5c51e3c46bc1fc14bda340ab435815f9
   depends:
@@ -2170,7 +2170,7 @@ packages:
   license_family: BSD
   size: 232579
   timestamp: 1695058229487
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py38hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py38hdb19cb5_0.tar.bz2
   sha256: f850ff1f529ce4f666d59c720fbcadf01d2ff8527c86351b5ebd9af6e7f159a5
   md5: cc6bf1a1158ddcb35b445a6f92c493c1
   depends:
@@ -2185,7 +2185,7 @@ packages:
   license_family: BSD
   size: 351977
   timestamp: 1695060063199
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py38hd09550d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/msgpack-python-1.0.3-py38hd09550d_0.tar.bz2
   sha256: 0908b112893c3a7a563010e020c810d6aab61a0132ac6ef5ea3ba2e59541da6c
   md5: 17c600586128f5f226b9a5cda765f302
   depends:
@@ -2196,7 +2196,7 @@ packages:
   license_family: Apache
   size: 90061
   timestamp: 1652362785051
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py38_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py38_0.tar.bz2
   sha256: a00d1f914deb4b896a3d42d2cae73097e1f5f2f4bc371dd3ceed04118eb974b4
   md5: 7ccf826b74681264ec620255a556fd97
   depends:
@@ -2206,7 +2206,7 @@ packages:
   license_family: BSD
   size: 22859
   timestamp: 1573120615619
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-1.1.0-py38h06a4308_0.tar.bz2
   sha256: 7beb432f70eb809cf22e4b70566521577e3e7019fed80ecdc0258bc2f58bbd26
   md5: 7dab3154938b1fa1762e914748e7ff52
   depends:
@@ -2219,7 +2219,7 @@ packages:
   license_family: BSD
   size: 8262331
   timestamp: 1717622901423
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py38h06a4308_0.tar.bz2
   sha256: cee53dab019b4f0193da1f2e86692d7fc9a1011405fb0269af8eb9fd9b4edcd8
   md5: 3e8bc494e90187872110355d50826fc8
   depends:
@@ -2232,7 +2232,7 @@ packages:
   license_family: BSD
   size: 99495
   timestamp: 1698934306037
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.16.4-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.16.4-py38h06a4308_0.tar.bz2
   sha256: 2a6defeff9124fea41f275c0f4bf4e0743762263337bc0f8c93a2dc063502991
   md5: 5e13491bb29ab7412ce61bfec2b5d842
   depends:
@@ -2260,7 +2260,7 @@ packages:
   license_family: BSD
   size: 484450
   timestamp: 1728049956665
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.10.4-py38h06a4308_0.tar.bz2
   sha256: 5bbe6e2bfb56fdc2e5e09d013e27fa71ab1112c8c065cdf95879b6681a9c3c68
   md5: 4d788b68bfc705f210d91a6b9f54b657
   depends:
@@ -2273,7 +2273,7 @@ packages:
   license_family: BSD
   size: 147353
   timestamp: 1728049448967
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
   sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
   md5: 57ea097dc15f8d9f9eb90e1d919143b0
   depends:
@@ -2282,7 +2282,7 @@ packages:
   license_family: MIT
   size: 1157733
   timestamp: 1674734069410
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py38h06a4308_0.tar.bz2
   sha256: abc7728d9fb67fe1d502bc52c3246480ee95775397d4ad2e7954fc8244b6f719
   md5: 01b8e8a4a9f726ff37aad0ea1e9f4f21
   depends:
@@ -2291,7 +2291,7 @@ packages:
   license_family: BSD
   size: 13262
   timestamp: 1708532744673
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.7-py38h06a4308_0.tar.bz2
   sha256: 4324fe1c5b6ea1a82f3806f207a461446e9590ea4d66137e0413435370cb5b32
   md5: 1f52e201a1a7ed2cf3bf2e63e0ff5170
   depends:
@@ -2316,7 +2316,7 @@ packages:
   license_family: BSD
   size: 590667
   timestamp: 1717630791981
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py38h06a4308_0.tar.bz2
   sha256: 160a299bd78be87d52f154c9ec85d43955de772e4200f4abfef2a79c19525c55
   md5: 9a888294999ac54e7eff7e601b333f97
   depends:
@@ -2326,7 +2326,7 @@ packages:
   license_family: BSD
   size: 22512
   timestamp: 1699455935349
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.55.1-py38h51133e4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numba-0.55.1-py38h51133e4_0.tar.bz2
   sha256: fcdc28d72bb3c6543e25887a22c590e417ee9ef9f33bb222299c405fe8e9cf6e
   md5: 1e4aa23ed16619a38328e98d5439ec43
   depends:
@@ -2349,7 +2349,7 @@ packages:
   license_family: BSD
   size: 3974836
   timestamp: 1648040615744
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.4-py38hc78ab66_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.4-py38hc78ab66_1.tar.bz2
   sha256: d8b99ff74402673cad0cfb6632cd78898edc81d39f74e14f0a2edf8bd12b248a
   md5: 224331b9fed2aa79bba09029046f3559
   depends:
@@ -2364,7 +2364,7 @@ packages:
   license_family: MIT
   size: 137430
   timestamp: 1683221985825
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.21.6-py38h5f9d8c6_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.21.6-py38h5f9d8c6_1.tar.bz2
   sha256: 9453b13f747fa5b5c21be91cfc9c3561cd7f563283b90c21e32527fdf3469397
   md5: a97dc5386c7800376c6af350377fb935
   depends:
@@ -2381,7 +2381,7 @@ packages:
   license_family: BSD
   size: 10525
   timestamp: 1715093080458
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.21.6-py38hb5e798b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.21.6-py38hb5e798b_1.tar.bz2
   sha256: 26ec52adae69a0e530b873c847805682d5a148cf72c0be8af614c33cb018edbc
   md5: 475c0ef71c5b1ed3bcb9d50ac66bf79f
   depends:
@@ -2397,7 +2397,7 @@ packages:
   license_family: BSD
   size: 6460591
   timestamp: 1715093067227
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h9ca470c_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h9ca470c_2.tar.bz2
   sha256: 1321f3ca2ede0bbc5ece4e517b2e8dff9979a210490fae6db8341eff93c07f71
   md5: 318311815f091b048801c57d417eb354
   depends:
@@ -2409,7 +2409,7 @@ packages:
   license_family: BSD
   size: 510171
   timestamp: 1720655553385
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
   sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
   md5: 5ad4571eba2479f77a9f849a6ae7724c
   depends:
@@ -2419,7 +2419,7 @@ packages:
   license_family: Apache
   size: 3998613
   timestamp: 1694465071784
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-1.6.7-h973521d_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/orc-1.6.7-h973521d_2.tar.bz2
   sha256: b75f8a4605fbed3541e188f14fc214a2da97c518d4d53b00ed8bab6e4107d32d
   md5: ce4459058a7a9cd79a2e42b0fbeea46a
   depends:
@@ -2433,7 +2433,7 @@ packages:
   license_family: Apache
   size: 752109
   timestamp: 1619508612546
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py38h06a4308_0.tar.bz2
   sha256: 87db6b9901308dec0b86f44a2a10e21de92f20ae0fdb87bf3e39603c102c416f
   md5: cfb74e123b06268d01f7c9a3966aa7be
   depends:
@@ -2442,7 +2442,7 @@ packages:
   license_family: APACHE
   size: 30720
   timestamp: 1699371206753
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-24.1-py38h06a4308_0.tar.bz2
   sha256: 1ec769b2709f782eaab539d1473efcf2262554fa5cc9b990cc6a8ffb42c501e8
   md5: f887b8ba0d9a5e9b0155c19f04a4f199
   depends:
@@ -2451,7 +2451,7 @@ packages:
   license_family: Apache
   size: 134112
   timestamp: 1720102012525
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.5.3-py38h417a72b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-1.5.3-py38h417a72b_0.tar.bz2
   sha256: 4c934fb2200a7ccf76bc8186a1e9af020e74804443ea26236bd29ebe68c36828
   md5: ae0c17ae4b81998382ca50e84ead99c5
   depends:
@@ -2498,7 +2498,7 @@ packages:
   license_family: BSD
   size: 13895571
   timestamp: 1677836949366
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py38h06a4308_0.tar.bz2
   sha256: 6c07adf761815b29425cf9246290948e4af424c507f023cb99b40a0114eaf291
   md5: 7389a12089a593eaa6f1a6f7ffea24cc
   depends:
@@ -2512,7 +2512,7 @@ packages:
   license_family: BSD
   size: 35439
   timestamp: 1698702667558
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.4.0-py38h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-10.4.0-py38h5eee18b_0.tar.bz2
   sha256: ed2ab1d5a7d18394964181de3ed75801f7255d028e0ab54f7e566cf478ca0b5a
   md5: 45939d83fd677381152eda133eec3c81
   depends:
@@ -2529,7 +2529,7 @@ packages:
   license_family: Other
   size: 824516
   timestamp: 1721059658996
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.2-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-24.2-py38h06a4308_0.tar.bz2
   sha256: f6428d9c0c14bc4e1fbc4fdf0ee52bdde47472137701f4b94cb7a9e176cd3a7f
   md5: becd6b1a295078bb1f621906afa1c553
   depends:
@@ -2540,7 +2540,7 @@ packages:
   license_family: MIT
   size: 2270681
   timestamp: 1723484696377
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pkgutil-resolve-name-1.3.10-py38h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pkgutil-resolve-name-1.3.10-py38h06a4308_1.tar.bz2
   sha256: 661608426deb4f3b1b2f020cbb8412a29a00adf0952c7472938cd253aefefe0a
   md5: eb54508863baff357d4d30c244a3fd52
   depends:
@@ -2549,7 +2549,7 @@ packages:
   license_family: PSF
   size: 10289
   timestamp: 1704297556344
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py38h06a4308_0.tar.bz2
   sha256: 4bf901b9310c1c68e71a78a9d2608ce439ca3dafed4f1223da5f7a4217a80cce
   md5: 9bc4d8193c88dbeb3ee43a8f44c56adf
   depends:
@@ -2558,7 +2558,7 @@ packages:
   license_family: MIT
   size: 32013
   timestamp: 1692205473871
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pooch-1.7.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pooch-1.7.0-py38h06a4308_0.tar.bz2
   sha256: 9568858a898a582ad1f9c94ce7cc0558760ea905d1007daf60c4f566925d2f0d
   md5: fef969ba49e5d1fc3de02d3c7014f735
   depends:
@@ -2574,7 +2574,7 @@ packages:
   license_family: BSD
   size: 81182
   timestamp: 1695850193601
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py38h06a4308_0.tar.bz2
   sha256: fe048f508881e6f69ea1781ece59102037d83c102778669e8caf390009b20d74
   md5: 4718ad7bf83e664525c13ce1ded14c84
   depends:
@@ -2583,7 +2583,7 @@ packages:
   license_family: Apache
   size: 91025
   timestamp: 1659455269732
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py38h06a4308_0.tar.bz2
   sha256: a3637fc4733632458e4e6e67fdc80493fd1215ca91f0c2cc39cf51964759c6d8
   md5: b386e6d389ff544f0285b00e904c7e95
   depends:
@@ -2595,7 +2595,7 @@ packages:
   license_family: BSD
   size: 577603
   timestamp: 1704404419144
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py38h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py38h5eee18b_0.tar.bz2
   sha256: cdb9ea9d076f82f3d266806ff90c4bafeb3533958abb5bd14cbc3702c433b924
   md5: 38b4a8eb4ece574a3db5b1dafeb10bd7
   depends:
@@ -2605,7 +2605,7 @@ packages:
   license_family: BSD
   size: 352826
   timestamp: 1656431426074
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-4.0.1-py38he0739d4_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyarrow-4.0.1-py38he0739d4_3.tar.bz2
   sha256: 8def5287701f4a4cd91ec466e6ba427662bdad16cd703ed3cdaa8f3a4d1f7b20
   md5: 6a13b7e3ecc306344b3cf347a0b96c15
   depends:
@@ -2624,7 +2624,7 @@ packages:
   license: Apache 2.0
   size: 2549724
   timestamp: 1623164893443
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py38h06a4308_0.tar.bz2
   sha256: dd70dbec022d1fca1fb2168bb81eeb2d970d53494f4bb4ce36751d70ce960b79
   md5: b09b43fc9f274c994af65adefa36279f
   depends:
@@ -2636,7 +2636,7 @@ packages:
   license_family: BSD
   size: 29267
   timestamp: 1675441565524
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py38h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py38h06a4308_1.tar.bz2
   sha256: dae53aeb4103d375b1125eecc4dc3cdf5fcfa9288d24f3a9e1c5d9b0107a501c
   md5: 13fc002e79408c57aa79fb2c25e1b538
   depends:
@@ -2645,7 +2645,7 @@ packages:
   license_family: BSD
   size: 1887598
   timestamp: 1684280001176
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py38h06a4308_0.tar.bz2
   sha256: 97972579f3c079aab5fb9a58855caded3b268bf90c0afdf5e6f39d75edd9a699
   md5: b47e7fcdef58cc3b2b8d920c73819e19
   depends:
@@ -2654,7 +2654,7 @@ packages:
   license_family: MIT
   size: 156616
   timestamp: 1661452605147
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py38h06a4308_0.tar.bz2
   sha256: 0d1c9fb08b326f1292b74373b942b739bb99dd4ec54d2be09e5072503300b2a8
   md5: 3ec9d5960a2ea2ba666008fdfc9d0084
   depends:
@@ -2663,7 +2663,7 @@ packages:
   license_family: BSD
   size: 31276
   timestamp: 1605305807726
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.8.18-h7a1cb2a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.8.18-h7a1cb2a_0.tar.bz2
   sha256: 22039cf20fe6bc950116e35abb1f4d502829c953eac840da5412ee69a12c2df7
   md5: ad9945c8a45c246f7bde30d257948a97
   depends:
@@ -2683,7 +2683,7 @@ packages:
   license_family: PSF
   size: 27401609
   timestamp: 1694439093219
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py38h06a4308_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py38h06a4308_2.tar.bz2
   sha256: 264578f50162cfd8de5c4edd1416a93cb69fcfc8a509cb39663347493ec4c5ca
   md5: 3a08ef6644fe6ff5376c1eb2571de450
   depends:
@@ -2693,7 +2693,7 @@ packages:
   license_family: BSD
   size: 288493
   timestamp: 1716495786779
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py38h06a4308_0.tar.bz2
   sha256: cc0f3ceeae6369f8b1523c1f4fff5c16d14c455b938723671a6bc672a65b77ff
   md5: d914447598a4c8d1e61fd888dded2072
   depends:
@@ -2702,7 +2702,7 @@ packages:
   license_family: BSD
   size: 264015
   timestamp: 1661371299911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-json-logger-2.0.7-py38h06a4308_0.tar.bz2
   sha256: 9e72df5780c5468e484a870990357e7dd88fd688b68f94477ea4b1e0a526cec7
   md5: 4b57c40b9575802121f6f2545c9d4d8c
   depends:
@@ -2711,7 +2711,7 @@ packages:
   license_family: BSD
   size: 15240
   timestamp: 1683823938836
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py38h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-lmdb-1.4.1-py38h6a678d5_0.tar.bz2
   sha256: ec3d6a1528a21405dc596978c9c58475ff48fd242c2b11f42c60a011ad231c26
   md5: 50ad6fcf916088079a753864eefacd9b
   depends:
@@ -2722,7 +2722,7 @@ packages:
   license_family: Other
   size: 138887
   timestamp: 1682522425747
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-snappy-0.6.1-py38h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-snappy-0.6.1-py38h6a678d5_0.tar.bz2
   sha256: 03ce88dea3ec4e2bf79feb1346d21bf9a67a643c7c8819cd1ec4ca49815a4e69
   md5: e446ea0658eae84604ad98a55baf195d
   depends:
@@ -2734,7 +2734,7 @@ packages:
   license_family: BSD
   size: 31654
   timestamp: 1670943981941
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py38h06a4308_0.tar.bz2
   sha256: 8b7c69d2780fcec5894ecda13af509413dc589908c92c4920f4d08ead124a46c
   md5: 59a144ef47cca86e501e9684e68f06d8
   depends:
@@ -2743,7 +2743,7 @@ packages:
   license_family: MIT
   size: 265176
   timestamp: 1713974389718
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.2-py38h06a4308_0.tar.bz2
   sha256: b33e5b0baa74dc546e3091f953f81017d7b63d6ce63ac20b07f3baae476990c4
   md5: 71a56f4fde17a6a1e148b5152e3398b4
   depends:
@@ -2755,7 +2755,7 @@ packages:
   license_family: BSD
   size: 60475
   timestamp: 1711136855967
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py38h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.2-py38h5eee18b_0.tar.bz2
   sha256: 1af16076c370a18f9e6d2076e11eb96cd4781c19aa59839856f85598a9e0407c
   md5: 39a7632480bbea971c82ae6ebc72ad29
   depends:
@@ -2766,7 +2766,7 @@ packages:
   license_family: MIT
   size: 195687
   timestamp: 1728658113822
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py38h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-24.0.1-py38h5eee18b_0.tar.bz2
   sha256: 669ae9d52664a1c512121f65738fc4b72ea48e7740d505eb5a1fc0ab46d7c298
   md5: 6830baa48917ead8a9f964750f982e39
   depends:
@@ -2777,7 +2777,7 @@ packages:
   license_family: Other
   size: 537148
   timestamp: 1709318412975
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
   sha256: 8a640736bef635346409582dbfe2b7d0ecc9da215c90173ff8a9a5fe22569107
   md5: 6b583dce61c6feb352ef0f49f413af1e
   depends:
@@ -2786,7 +2786,7 @@ packages:
   license: BSD-3-Clause
   size: 235004
   timestamp: 1652449537852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
   sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
   md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
   depends:
@@ -2796,7 +2796,7 @@ packages:
   license_family: GPL
   size: 467661
   timestamp: 1666648052561
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py38h06a4308_0.tar.bz2
   sha256: a3432cb1874b026257556818b0189596ee688c843ece775d87d50fa473aeaf7a
   md5: 676d5b658acaec19857aedbb5b63ab60
   depends:
@@ -2807,7 +2807,7 @@ packages:
   license_family: MIT
   size: 57804
   timestamp: 1699012146060
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.32.3-py38h06a4308_0.tar.bz2
   sha256: b1dd651b0f64482231e61cc798cea901e5cb205899df5f4743b300eb86037626
   md5: 1841b3307caa5d954cac15d2faf5a117
   depends:
@@ -2823,7 +2823,7 @@ packages:
   license_family: Apache
   size: 97103
   timestamp: 1721410986042
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-toolbelt-1.0.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-toolbelt-1.0.0-py38h06a4308_0.tar.bz2
   sha256: 1dd6a1f10795fcd90aa3bae1a5d111b8cf96dd0069d46e90fad4879701927bc5
   md5: bc84efd3289e47d03f9b37fde9b6bf67
   depends:
@@ -2833,7 +2833,7 @@ packages:
   license_family: Apache
   size: 68644
   timestamp: 1690874122636
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py38h06a4308_0.tar.bz2
   sha256: 06ac06dd4fcc3150d96e3f20ac036fddf3aba52de71152ba4ea3c179e2f7b97c
   md5: 22ed3bdce8a230c356fc1c611c4096f1
   depends:
@@ -2843,7 +2843,7 @@ packages:
   license_family: MIT
   size: 8921
   timestamp: 1683077077347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py38h06a4308_0.tar.bz2
   sha256: 75ee060a1f1aadcb6ff9dd4fb2c6c7aefc1f04a98dadf0428501560ad8216c15
   md5: 5d6765b7e819ca4ac4fc8f5919ada81b
   depends:
@@ -2852,7 +2852,7 @@ packages:
   license_family: MIT
   size: 9339
   timestamp: 1683059016277
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py38hb02cf49_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py38hb02cf49_0.tar.bz2
   sha256: 4b25f3d2bbcf20dfe2f089e559c96cc69b89465ba88bedd3ecd39d7fc51dd3ce
   md5: 54fa7a1d5d517ac44dd42290cdde0a1e
   depends:
@@ -2862,7 +2862,7 @@ packages:
   license_family: MIT
   size: 1095726
   timestamp: 1698946060598
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel.yaml.clib-0.2.8-py38h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ruamel.yaml.clib-0.2.8-py38h5eee18b_0.tar.bz2
   sha256: df56f3b7e0e0946ef24f1407767f6bb60dd0034e59878e0260c8ca268b36136f
   md5: 9c42dc97360f54f198f0d50bb607b252
   depends:
@@ -2872,7 +2872,7 @@ packages:
   license_family: MIT
   size: 162968
   timestamp: 1727769985866
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel_yaml-0.17.21-py38h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ruamel_yaml-0.17.21-py38h5eee18b_0.tar.bz2
   sha256: 2877260caacd68bdc571872b1c154efb3ad8da7670da93290c9ca9962dd9c413
   md5: 47b6bae0c0ac9572a171bed14dae2205
   depends:
@@ -2883,7 +2883,7 @@ packages:
   license_family: MIT
   size: 172808
   timestamp: 1667489860744
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.10.1-py38hf6e8229_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/scipy-1.10.1-py38hf6e8229_1.tar.bz2
   sha256: 0c85129009042b51564cd6d73c2c370c06d9226690ac31e2825a6eb740cfb7db
   md5: 760fa69bb5943dfdbb945b9af2736098
   depends:
@@ -2902,7 +2902,7 @@ packages:
   license_family: BSD
   size: 26848491
   timestamp: 1683289243499
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py38h06a4308_0.tar.bz2
   sha256: 59a0f406ae8e46050a3d5673138dbdf609311b66e9be7b77fbdfdf4cb9c4e7f2
   md5: ed3a1aa9fc47e9a3ed11a02afd53b4c4
   depends:
@@ -2911,7 +2911,7 @@ packages:
   license_family: BSD
   size: 26843
   timestamp: 1699371234046
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-60.9.3-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-60.9.3-py38h06a4308_0.tar.bz2
   sha256: ed5062cd53379f9c81d66f84f00d31ae95a8fd4d97ecdfad0ff02a9026c68a32
   md5: c959c8379b1b75fc48906fb26a525c0b
   depends:
@@ -2920,7 +2920,7 @@ packages:
   license_family: MIT
   size: 1226928
   timestamp: 1685710625243
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
   sha256: 8fd98235b37194986a5eb663c95a4a6db8c9e20a627f5c79ff8d9be3fd0e36f7
   md5: 25ac00d957eda056675f8fa3eafdf6df
   depends:
@@ -2930,7 +2930,7 @@ packages:
   license_family: BSD
   size: 52749
   timestamp: 1723557449203
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py38h06a4308_0.tar.bz2
   sha256: 8989039abb908ce3599d8e84a7d3828a75df4a596220c7447c01034ee3958b12
   md5: b248bf15175453bcd8bc4f100d6c265f
   depends:
@@ -2939,7 +2939,7 @@ packages:
   license_family: Other
   size: 16628
   timestamp: 1705431447220
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py38h06a4308_0.tar.bz2
   sha256: e888d0ed8d489e081102fb1c816479db50802243f40ba24079a76465709642e3
   md5: 20d72998dbdd62e71f8901634d630352
   depends:
@@ -2948,7 +2948,7 @@ packages:
   license_family: MIT
   size: 66454
   timestamp: 1696347666187
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
   sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
   md5: f86119b3243fe3508160aa0406245738
   depends:
@@ -2961,7 +2961,7 @@ packages:
   license_family: Other
   size: 1723866
   timestamp: 1714488309729
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
   sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
   md5: 041a3caf09dc9ce8fc6c10925c4fe050
   depends:
@@ -2971,7 +2971,7 @@ packages:
   license_family: Apache
   size: 1888016
   timestamp: 1680167274961
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py38h06a4308_0.tar.bz2
   sha256: b1aaff89c39b3dfd49e910e706f63fc361d4edd14350ea7f6b9fbfc1984ead35
   md5: 462c5ca383e788c3f7d20270e378991b
   depends:
@@ -2982,7 +2982,7 @@ packages:
   license_family: BSD
   size: 29863
   timestamp: 1671751945016
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/thrift-0.17.0-py38h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/thrift-0.17.0-py38h6a678d5_0.tar.bz2
   sha256: 7d67b37f3ae90d50c18c837292445fdda1d31d79c4663bcd1e93a8b1c1e1edb3
   md5: da914586bf315379c27fa9dca6f3b337
   depends:
@@ -2994,7 +2994,7 @@ packages:
   license_family: APACHE
   size: 129600
   timestamp: 1666296532746
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py38h06a4308_0.tar.bz2
   sha256: d8d4ab14d89a1e994b979923a985519d12b7a5dd25c552e861690486237f2e80
   md5: 806aa4861199d75d60b7b964cd04dc6c
   depends:
@@ -3004,7 +3004,7 @@ packages:
   license_family: BSD
   size: 39305
   timestamp: 1668168903676
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
   sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
   md5: e2512d57c8a1e91e7b20e265c6906546
   depends:
@@ -3014,7 +3014,7 @@ packages:
   license_family: BSD
   size: 3588922
   timestamp: 1714770676475
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py38h06a4308_0.tar.bz2
   sha256: 85077229bfc69efa66079274390675e2f81ffe092435103685d54166e5e69ba6
   md5: aec171353448852f51e81c68ef45dfaa
   depends:
@@ -3023,7 +3023,7 @@ packages:
   license_family: BSD
   size: 101498
   timestamp: 1667464200465
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.1-py38h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.4.1-py38h5eee18b_0.tar.bz2
   sha256: 37ad1a8ed6875bba449a9839a5b3057ec7d84416fd367cb801a0030897613695
   md5: 3a320f4ea5564e6e1212e432e9831209
   depends:
@@ -3033,7 +3033,7 @@ packages:
   license_family: Apache
   size: 690997
   timestamp: 1718740214723
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.5-py38h2f386ee_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.66.5-py38h2f386ee_0.tar.bz2
   sha256: 13bb2cdf26bf9f457715868bc8d564403e1d7f554f50be62116317606142adad
   md5: f27d9bfb20b3096021630baad71306b5
   depends:
@@ -3044,7 +3044,7 @@ packages:
   license_family: MOZILLA
   size: 126200
   timestamp: 1724854064090
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.14.3-py38h06a4308_0.tar.bz2
   sha256: 6ea9a22d64233b05d17b4f4f5a5bbdb14e8308ca9dead52044b536c4fe1ad27e
   md5: f8c9739fb4ced58bc2f89ab2931ecf74
   depends:
@@ -3053,7 +3053,7 @@ packages:
   license_family: BSD
   size: 165512
   timestamp: 1718227109478
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.11.0-py38h06a4308_0.tar.bz2
   sha256: 3acf29373ab34a497504885fba0595b39dbd642f2450f92758ce99bc3ba13ecb
   md5: 8822ef2a13080ddc2f89f366f36d29bf
   depends:
@@ -3063,7 +3063,7 @@ packages:
   license_family: PSF
   size: 8851
   timestamp: 1715268883008
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.11.0-py38h06a4308_0.tar.bz2
   sha256: 57e7f4a868d7d45fa947cb85331bdd41e4068577aca9567677b4a11e485dfee7
   md5: d02fe804a0d9b77bc62088df3d339eb8
   depends:
@@ -3072,7 +3072,7 @@ packages:
   license_family: PSF
   size: 60065
   timestamp: 1715268877859
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py38h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py38h5eee18b_0.tar.bz2
   sha256: 6757ef7ad0fd3e71e67cfb339a93f0fa21b1d94339cf7c6c664b8968a76a48c3
   md5: 02f47f685a18714a1d9c56a6cac33f57
   depends:
@@ -3082,7 +3082,7 @@ packages:
   license_family: Apache
   size: 509402
   timestamp: 1713212980627
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uriparser-0.9.7-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/uriparser-0.9.7-h5eee18b_0.tar.bz2
   sha256: fa1281c13f5c8d18b36bb69705e4cd632ccc456b603f27ca63f68a787d03b0be
   md5: 48e34041c9a0bd924018a6fab5d167b6
   depends:
@@ -3091,7 +3091,7 @@ packages:
   license_family: BSD
   size: 48752
   timestamp: 1692186947656
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.3-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-2.2.3-py38h06a4308_0.tar.bz2
   sha256: ba6f85a22f58193fc6c363407863f0f8d863a63982bbd275b30cf24605a82640
   md5: 33066cef597b40b2fdad2c24dc53d85e
   depends:
@@ -3107,7 +3107,7 @@ packages:
   license_family: MIT
   size: 170359
   timestamp: 1727769831965
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
   sha256: a8d11b0f08217607b99ba560edf66423ca1e36f4ffbb6e2377e61670e2b5f36b
   md5: 431e82b081b08aef0259df0437e04c75
   depends:
@@ -3116,7 +3116,7 @@ packages:
   license_family: MIT
   size: 97535
   timestamp: 1706894675990
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py38_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py38_1.tar.bz2
   sha256: c6fd7f78c18396f22bde60d84004159a5398d7eaad14ab1b6f7550e9605e3616
   md5: 46be58263b91ea0ce41774c6cef974b7
   depends:
@@ -3125,7 +3125,7 @@ packages:
   license_family: BSD
   size: 20211
   timestamp: 1573200372707
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py38h06a4308_0.tar.bz2
   sha256: 59d5cd812cd18b04f1a3238aa26dd9ab585c8d3e93d35c063a31a11c0b5f3f6e
   md5: 14118d274fbb8ee0e1a04f3b24a506d4
   depends:
@@ -3134,7 +3134,7 @@ packages:
   license_family: Apache
   size: 85935
   timestamp: 1715878368094
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.44.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.44.0-py38h06a4308_0.tar.bz2
   sha256: 40a959027f73c61485d644618f3e85a47edd808efc29aa28d553a1f91b24486d
   md5: 101d43682ed48e252d50321745c212b2
   depends:
@@ -3143,7 +3143,7 @@ packages:
   license_family: MIT
   size: 104159
   timestamp: 1726165121976
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2022.11.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xarray-2022.11.0-py38h06a4308_0.tar.bz2
   sha256: 508985a639f29648f66f7dd3856ad0baf5501601582e52ad26cae4c0e7ca8ea8
   md5: cbef8e255222ff1c5727b7529031ccf8
   depends:
@@ -3155,7 +3155,7 @@ packages:
   license_family: Apache
   size: 1722500
   timestamp: 1668776634679
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py38h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py38h06a4308_1.tar.bz2
   sha256: 846ae02929f4570ad0979c56332af5b3b4da851419a051e7902bd3a6ec2a0755
   md5: 4d7632b5d03d4b2be70e952e890bcbd5
   depends:
@@ -3164,7 +3164,7 @@ packages:
   license_family: BSD
   size: 47860
   timestamp: 1675159165834
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
   sha256: 9122d6e9dabb7a47f2bcb15d86b97c96c49a9048da3f8ae59675351710c14cc5
   md5: 660b2aead2ec87b751c86cd33934f44e
   depends:
@@ -3173,7 +3173,7 @@ packages:
   license_family: GPL2
   size: 716926
   timestamp: 1714510796277
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -3181,7 +3181,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
   sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
   md5: 943f1247a22b6b64171363bcee1eec27
   depends:
@@ -3192,7 +3192,7 @@ packages:
   license_family: Other
   size: 371663
   timestamp: 1705602144682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zict-3.0.0-py38h06a4308_0.tar.bz2
   sha256: 5e35fe343f2db943bb40881684974c9325d13b645baebd67d0ff6c81a1c411ff
   md5: c701afabfd0e39a192953874321cb29d
   depends:
@@ -3203,7 +3203,7 @@ packages:
   license_family: BSD
   size: 76355
   timestamp: 1695832914431
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.20.2-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.20.2-py38h06a4308_0.tar.bz2
   sha256: aaed1be6cdebd13b8a23edd214e573030fb6bf917859119c51190008d9d28f02
   md5: de5f5b5ed6f9a918c6d55701e7d504ed
   depends:
@@ -3212,7 +3212,7 @@ packages:
   license_family: MIT
   size: 25065
   timestamp: 1729012379362
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
   sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
   md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
   depends:
@@ -3221,7 +3221,7 @@ packages:
   license_family: Other
   size: 127143
   timestamp: 1714510716441
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstandard-0.19.0-py38h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstandard-0.19.0-py38h5eee18b_0.tar.bz2
   sha256: 9e109b0d4fa7072697e7a428ea2eda4208a7c831409113df603011ef65a18844
   md5: b3a4956643e78cfe65b59823bbf0c633
   depends:
@@ -3232,7 +3232,7 @@ packages:
   license_family: BSD
   size: 683175
   timestamp: 1677013289650
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.4.9-haebb681_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.4.9-haebb681_0.tar.bz2
   sha256: d1969321874e6d0a7b9994a043830e453a5caab9c3d89690351ba658700ab611
   md5: 77148a73936c37451810f0b1453569e9
   depends:
@@ -3244,7 +3244,7 @@ packages:
   license: BSD 3-Clause
   size: 828849
   timestamp: 1617228573594
-- conda: https://repo.anaconda.com/pkgs/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
   sha256: 8f312df57fbcba29977fcc1a66017f231820699053ca3b91450fabc16ec09858
   md5: a1914956aa26b608c4f2d17edadca061
   depends:
@@ -3252,7 +3252,7 @@ packages:
   license: MIT
   size: 12124
   timestamp: 1629143509659
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -3265,7 +3265,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -3275,7 +3275,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
   md5: b2aa5503875aba2f1d88cae9df9a96d5
   depends:
@@ -3284,7 +3284,7 @@ packages:
   license_family: BSD
   size: 13636
   timestamp: 1611930018941
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -3296,7 +3296,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
   sha256: c0dd89ffac001588171152a285ddbbaea209ebe4116010f985f898b7e87c2f35
   md5: 731ae7d446633bc729f3493a52d4365b
   depends:
@@ -3305,7 +3305,7 @@ packages:
   license_family: MIT
   size: 43502
   timestamp: 1721748373551
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -3314,7 +3314,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2.10.1-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/dask-2.10.1-py_0.tar.bz2
   sha256: d4becea2d64e1106512c982ca3d9ffa8fbf466662c57dbfe98bd208a62b373bd
   md5: 50bb7d044b57c15ab9a3c3ee4d266e87
   depends:
@@ -3332,7 +3332,7 @@ packages:
   license: BSD 3-Clause
   size: 12803
   timestamp: 1580416204172
-- conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2.30.0-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/dask-2.30.0-py_0.tar.bz2
   sha256: 82cdea73f212a463cbaa0a50d08e19721321581dc9fcf133998bdd9552b0d86f
   md5: 28589ce41c675a730271246aaf4ca043
   depends:
@@ -3352,7 +3352,7 @@ packages:
   license: BSD-3-Clause
   size: 4721
   timestamp: 1602100743497
-- conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2.10.1-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/dask-core-2.10.1-py_0.tar.bz2
   sha256: 173ade2e7ebfc04793c322b106c0a5d1f74b569f00c1fbedc7e68129e4cf9a29
   md5: 200e9b73fb7dfad8a8e45b0b037ac2c3
   depends:
@@ -3360,7 +3360,7 @@ packages:
   license: BSD 3-Clause
   size: 608527
   timestamp: 1580416068743
-- conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2.30.0-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/dask-core-2.30.0-py_0.tar.bz2
   sha256: 23632b4a11f021ada7f099dee7a5b60a8c22959009aaac26ff6dd230e1a65ad9
   md5: ae95e7ad795342ff2e60921a9e26cbb9
   depends:
@@ -3369,7 +3369,7 @@ packages:
   license: BSD-3-Clause
   size: 654836
   timestamp: 1602083734965
-- conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
   sha256: 2de2d79a0e9784a1bf55cdb83c035072da1879753d109c0a36bbd5a357385c37
   md5: 6cfe764bb04e756d7d1319a98a05dd70
   depends:
@@ -3391,7 +3391,7 @@ packages:
   license_family: BSD
   size: 14964307
   timestamp: 1623782401693
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -3400,7 +3400,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -3409,7 +3409,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/distributed-2.10.0-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/distributed-2.10.0-py_0.tar.bz2
   sha256: 2dd32f8766f111ead89689f114c3acd347d8e11fc1f34a2f5817fd1d0a99b079
   md5: 877de7e546a6dee328d56eb0d230bf5f
   depends:
@@ -3431,7 +3431,7 @@ packages:
   license_family: BSD
   size: 433845
   timestamp: 1580308740998
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -3440,7 +3440,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
   sha256: 9de8666e5b70aa2437737128eaa14ffe80a7b5235c2a6b7d3f39ccefd7816ba0
   md5: bb52e50c5ab1a5c7778c11376404dfdb
   depends:
@@ -3448,7 +3448,7 @@ packages:
   license: BSD 3-Clause
   size: 7933
   timestamp: 1630598543551
-- conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.8-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/holoviews-1.14.8-pyhd3eb1b0_0.tar.bz2
   sha256: 94de7b53f559782e16abf255670eaa585c6397bccacec3579309ccd49080ff48
   md5: 86af6b7b7508ce6485cabf669d123917
   depends:
@@ -3467,7 +3467,7 @@ packages:
   license_family: BSD
   size: 3632336
   timestamp: 1645454472973
-- conda: https://repo.anaconda.com/pkgs/main/noarch/hvplot-0.7.3-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/hvplot-0.7.3-pyhd3eb1b0_1.tar.bz2
   sha256: 2db2e41ca95838a7f3cfb80ba343cb54422f65183d09db8ae4f1c65cf35baa57
   md5: 39d9b853f76c737215516ba3a9b5cef6
   depends:
@@ -3481,7 +3481,7 @@ packages:
   license_family: BSD
   size: 3084696
   timestamp: 1627305211559
-- conda: https://repo.anaconda.com/pkgs/main/noarch/intake-parquet-0.2.3-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/intake-parquet-0.2.3-py_0.tar.bz2
   sha256: c1f589c23bfebb6d72e66a0911ddcc7ac0eae5ed372c3f7fbb064c1d5db8a285
   md5: 55c292a9447943801b55e2e2d9cc2509
   depends:
@@ -3495,7 +3495,7 @@ packages:
   license: BSD-2-Clause
   size: 11483
   timestamp: 1574273854612
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -3503,7 +3503,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -3512,7 +3512,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.7-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/panel-0.12.7-pyhd3eb1b0_0.tar.bz2
   sha256: 9575be12f17a1b774cab176de08b3fb0761c15aefd74a907f15c948ff80a696e
   md5: 71f9319d31ce3a3465c750b0f0b600db
   depends:
@@ -3530,7 +3530,7 @@ packages:
   license_family: BSD
   size: 10317537
   timestamp: 1649079073252
-- conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
   sha256: 110a3b50f89584ccb13980a617f6258b83b0bc56c8897c96d9e0da9fdc2c957c
   md5: 6266365b47ed65cdb4737603a385c691
   depends:
@@ -3539,7 +3539,7 @@ packages:
   license_family: BSD
   size: 69119
   timestamp: 1625476602265
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -3548,7 +3548,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -3558,7 +3558,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
   sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
   md5: e68a6f315f41a8d814d833652bf38b9b
   depends:
@@ -3566,7 +3566,7 @@ packages:
   license: MIT
   size: 13374
   timestamp: 1606932077143
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -3574,7 +3574,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -3583,7 +3583,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -3592,7 +3592,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -3601,7 +3601,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
   sha256: 4e47f6c49ce84509f1466e8a4d728447bf4bcd9bce7b456431a789a262547067
   md5: 4cad993b0f80bc23fb66a97592299cbb
   depends:
@@ -3610,7 +3610,7 @@ packages:
   license_family: Apache
   size: 26504
   timestamp: 1623949147884
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -3622,7 +3622,7 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
   sha256: ca2be6c7810a37cfc6db1f5383937b5d35c6d73c1fad8a9104de85f069b1df1c
   md5: 9ccb2fb33edb152403d6ef32bf758a9d
   depends:
@@ -3631,7 +3631,7 @@ packages:
   license_family: BSD
   size: 15614
   timestamp: 1629402049497
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -3639,7 +3639,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anaconda-anon-usage-0.4.4-py38hfb7c958_100.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anaconda-anon-usage-0.4.4-py38hfb7c958_100.tar.bz2
   sha256: c42ac05e8036ebf544c64ad503010ee947da1a483e891f7a1c7a1a667d90cc54
   md5: 343935e1348e98e1e4daacaff9c27193
   depends:
@@ -3651,7 +3651,7 @@ packages:
   license_family: BSD
   size: 24989
   timestamp: 1710965120689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anaconda-client-1.12.3-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anaconda-client-1.12.3-py38hecd8cb5_0.tar.bz2
   sha256: 67b466a4aa0b9b81dc0fb28679bd87e7773ecb892b654c4fb38cce7ed8b17986
   md5: 5d9c4dac680de70eb782bc3fe9b01513
   depends:
@@ -3674,7 +3674,7 @@ packages:
   license_family: BSD
   size: 141723
   timestamp: 1708643614831
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anaconda-project-0.11.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anaconda-project-0.11.1-py38hecd8cb5_0.tar.bz2
   sha256: b08e74d8fda2c9ed4db6b9ec7ffe3831991ed04d4e28da023803819ffaffe53e
   md5: 25c25318c81c1b330cb07085db95df91
   depends:
@@ -3690,7 +3690,7 @@ packages:
   license_family: BSD
   size: 544572
   timestamp: 1660340117928
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-4.2.0-py38hecd8cb5_0.tar.bz2
   sha256: 841e19d35111483ab74e9e68e7dbfc90af61c58bd9cb885e0ed4683b76061c3b
   md5: cd70416e2aef5e40458dc45d998112e4
   depends:
@@ -3706,7 +3706,7 @@ packages:
   license_family: MIT
   size: 174509
   timestamp: 1706220384805
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py38hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py38hecd8cb5_1001.tar.bz2
   sha256: 80777c5e13c10f946bafdb2ccdb0a13010669bb4a0d424b15f81816427f9bc4e
   md5: 070364c2c941da9fefa521327645d2ff
   depends:
@@ -3715,7 +3715,7 @@ packages:
   license_family: BSD
   size: 10035
   timestamp: 1606859471981
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py38hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py38hca72f7f_0.tar.bz2
   sha256: be2b0feedb5668e85bdb044ecdf769e12a4acd0bf026e8c1858327cfbc44945c
   md5: e70cb13b190f8141882cef82fbabf6f0
   depends:
@@ -3725,7 +3725,7 @@ packages:
   license_family: MIT
   size: 36067
   timestamp: 1644569747309
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-4.0.1-py38hf7c73f6_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/arrow-cpp-4.0.1-py38hf7c73f6_3.tar.bz2
   sha256: f516886b5fb1f35524330c46c1a6d214da163ed61df4e41b7226fbfbf8bcd188
   md5: 41f8fe04dcb65b5e4307c65d32ce1c13
   depends:
@@ -3757,7 +3757,7 @@ packages:
   license_family: Apache
   size: 6721110
   timestamp: 1622568910960
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.2.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-24.2.0-py38hecd8cb5_0.tar.bz2
   sha256: b6551cea8b2039a15a6a72455d99427eeccb278945d9bbee9be1aa3903124344
   md5: ed320a21707928e48cbdefcc85e20230
   depends:
@@ -3766,7 +3766,7 @@ packages:
   license_family: MIT
   size: 142507
   timestamp: 1729089494991
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.4.57-hb1e8313_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-common-0.4.57-hb1e8313_1.tar.bz2
   sha256: bd9839857a0f4d642d6496858ed2c5e967f5eeaeec366e095f33fed2b88b3549
   md5: f018d20252f808fe7f03f27138f874ff
   depends:
@@ -3775,7 +3775,7 @@ packages:
   license_family: Apache
   size: 146436
   timestamp: 1601398327280
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.1.6-h23ab428_5.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-event-stream-0.1.6-h23ab428_5.tar.bz2
   sha256: 1689c53ae4727d42bdf984a464ba466849693dbfb5757949a5b8ab818870910c
   md5: c9ac87fa2e6ef38b35fd88bdf1e4180d
   depends:
@@ -3786,7 +3786,7 @@ packages:
   license_family: Apache
   size: 21727
   timestamp: 1603894602135
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.9-hb1e8313_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-checksums-0.1.9-hb1e8313_0.tar.bz2
   sha256: 10dec822bbe1407f99fe8581984f189689d926663405a9a0399736a513e0b3b4
   md5: 6eaf9d2a4e00dcec0a2c18ecfc8a0b58
   depends:
@@ -3796,7 +3796,7 @@ packages:
   license_family: Apache
   size: 50452
   timestamp: 1601399158653
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.8.185-he271ece_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-sdk-cpp-1.8.185-he271ece_0.tar.bz2
   sha256: 0ed049475b0a3544b08a0f7e94e6394e23e8b76fe1dde47937ef4b59654ec1cc
   md5: 7128a60cf4a8f9c50e6906174f03dde9
   depends:
@@ -3809,7 +3809,7 @@ packages:
   license_family: Apache
   size: 2166135
   timestamp: 1618434980968
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.3-py38hecd8cb5_0.tar.bz2
   sha256: 6031699148ace6354937a51715e561f40d77af434fa2b26c987741916f85460d
   md5: 9d0bc20499d3430a0bc67433d022ad64
   depends:
@@ -3819,12 +3819,12 @@ packages:
   license_family: MIT
   size: 215514
   timestamp: 1718029893541
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
   sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
   md5: e2f3248e2a5009a02f7b8e54f83314ef
   size: 5620
   timestamp: 1528121955725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.4.3-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-2.4.3-py38hecd8cb5_0.tar.bz2
   sha256: cd22b796fa325c5f5de4d0cf07a84585691a169608ec52ac1f68100fa0269179
   md5: 49f52f875f0d7da5613f13c2561b2dc1
   depends:
@@ -3840,7 +3840,7 @@ packages:
   license_family: BSD
   size: 14317307
   timestamp: 1658136803878
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.73.0-h9ed2024_11.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/boost-cpp-1.73.0-h9ed2024_11.tar.bz2
   sha256: f478e0b090b48866d284b333f8ceca2fb51048144308edfea7484b4d1cf34ca0
   md5: 301bdc5957da60059a0702422f8ee9ba
   depends:
@@ -3848,7 +3848,7 @@ packages:
   license: Boost-1.0
   size: 24652
   timestamp: 1611677363789
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py38h7b7cdfe_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.7-py38h7b7cdfe_0.tar.bz2
   sha256: 41358c330c8c1711ce64d0b9c712490f6b8108bde090787c3f8fc667640a4bd4
   md5: 41a7b98c2da95583ce53750687667ac2
   depends:
@@ -3858,7 +3858,7 @@ packages:
   license_family: BSD
   size: 129675
   timestamp: 1707864289994
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
   sha256: d8b1ccb15297dcfb3f9ebb8139c3e28a13d6c2e73c37612cb214ab6cc58b15fa
   md5: e5dec9f13de061640ad2697562a99b54
   depends:
@@ -3868,7 +3868,7 @@ packages:
   license: MIT
   size: 19732
   timestamp: 1714483415038
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
   sha256: e9fda4393edd0234c88efc2b88e0edf42c94eb49ea5b189a80afd733058be8fb
   md5: 13ceed558eb174d6b77ed1b0035f1785
   depends:
@@ -3877,7 +3877,7 @@ packages:
   license: MIT
   size: 18400
   timestamp: 1714483395748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py38hcec6c5f_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py38hcec6c5f_8.tar.bz2
   sha256: ac2c0b58eb6a0fd21d3fe905ab7461355a40c71c05eca7b66abffae79fbd94db
   md5: 920ae839f622108e2120af192ca06624
   depends:
@@ -3886,28 +3886,28 @@ packages:
   license: MIT
   size: 395500
   timestamp: 1714483616978
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
   sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
   md5: c5a600d81b1b48578863af2973c743ac
   license: bzip2-1.0.8
   license_family: BSD
   size: 187637
   timestamp: 1714510590009
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
   sha256: f913b61ba3c1651b36688415cc163a5d575475f7573b543f48a80e7a5002e4bb
   md5: f11d165eaa532ce04a35382841284298
   license: MIT
   license_family: MIT
   size: 107047
   timestamp: 1693902034820
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.9.24-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2024.9.24-hecd8cb5_0.tar.bz2
   sha256: 7031fa5cac3aca09b273742f9d7bdde4fb85edefc21cb3407a779a5a81438394
   md5: c25cd4336a986ed75c92636e17953a48
   license: MPL-2.0
   license_family: Other
   size: 141521
   timestamp: 1727794863285
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.8.30-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2024.8.30-py38hecd8cb5_0.tar.bz2
   sha256: 8884779658a664baff5d678262dcd6eb5a7264d740940276b350ec9794771347
   md5: 9073e4a414ada62c28cc075ca4f46f43
   depends:
@@ -3916,7 +3916,7 @@ packages:
   license_family: Other
   size: 168893
   timestamp: 1725551852092
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py38h9205ec4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.17.1-py38h9205ec4_0.tar.bz2
   sha256: f7eed6bdf70e018d4c1dbdf8c432a2ebbc3aede20cb13233326d954daeef6a99
   md5: bd42db53fafca5d38216f70c4a772881
   depends:
@@ -3927,7 +3927,7 @@ packages:
   license_family: MIT
   size: 231771
   timestamp: 1726856528238
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py38hecd8cb5_0.tar.bz2
   sha256: d2b1550ca58a65e722b08e422d6065064a50d87a19a3fb99be81f36bcbf66fea
   md5: b6338c9d4466d41e3902db36cc0a22d9
   depends:
@@ -3936,7 +3936,7 @@ packages:
   license_family: BSD
   size: 152727
   timestamp: 1698129895844
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.0.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cloudpickle-3.0.0-py38hecd8cb5_0.tar.bz2
   sha256: 3d1018a815d8bb46b063b992fb952f28098f908fd512905c1e2f8a62ca9af3a3
   md5: 5834511b3b4271913ec2ac1d645298cc
   depends:
@@ -3945,7 +3945,7 @@ packages:
   license_family: BSD
   size: 35735
   timestamp: 1721657500337
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py38hecd8cb5_0.tar.bz2
   sha256: 2672f4f98c47dcdbae2ef13141c53724a9ee6553b8c9174a63150063fc9dd5c2
   md5: 2496f87b7c0a5104253e560d74edcd38
   depends:
@@ -3954,7 +3954,7 @@ packages:
   license_family: CC
   size: 550079
   timestamp: 1709758428723
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py38hecd8cb5_0.tar.bz2
   sha256: 82c6cf7fe4543f39bd6cd3907cec85e8f60c6297845e422976bb4de7f5bf0088
   md5: 62f25c84914f0f89a5554f7171b908e1
   depends:
@@ -3964,7 +3964,7 @@ packages:
   license_family: BSD
   size: 15601
   timestamp: 1709323080843
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/conda-pack-0.7.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/conda-pack-0.7.1-py38hecd8cb5_0.tar.bz2
   sha256: 9c18c2468eac9d37d06661c8515f547432d39917a78014756aea240affd3c23f
   md5: 9a8a3736fa4d8394038c492bb05c973a
   depends:
@@ -3974,7 +3974,7 @@ packages:
   license_family: BSD
   size: 52486
   timestamp: 1710258154887
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/conda-package-handling-2.3.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/conda-package-handling-2.3.0-py38hecd8cb5_0.tar.bz2
   sha256: c863c2ed06aab4d8dc7dfdf6ded102466540cd0c5ddf51eccff0dae5dfcf45d9
   md5: a9ce61d98f6ea52528b047fd89bbfc0d
   depends:
@@ -3985,7 +3985,7 @@ packages:
   license_family: BSD
   size: 279495
   timestamp: 1718138312911
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/conda-package-streaming-0.10.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/conda-package-streaming-0.10.0-py38hecd8cb5_0.tar.bz2
   sha256: e2e7d06ec01909534ef8fbed03d102d5fdc9f50637ab075a015335dd7e9d0d8f
   md5: 8e98825a22a87b641144dfb0c41e3411
   depends:
@@ -3995,7 +3995,7 @@ packages:
   license_family: BSD
   size: 28400
   timestamp: 1718136271863
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py38haf03e11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py38haf03e11_0.tar.bz2
   sha256: 1473dda25c38fb08cbe01cecd833141002a9a70231e7743c77124a3f90d51626
   md5: 1456da04419043ef34f05b42758598da
   depends:
@@ -4006,7 +4006,7 @@ packages:
   license_family: BSD
   size: 225845
   timestamp: 1663827553065
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.2-py38h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cytoolz-0.12.2-py38h6c40b1e_0.tar.bz2
   sha256: 5e9904234e11b1424d8e952ddb7aed84bab2a70d871ae645ae2bd809c47114f9
   md5: 4c3802b624f9665a8e3e94dcf483fa9b
   depends:
@@ -4016,7 +4016,7 @@ packages:
   license_family: BSD
   size: 364975
   timestamp: 1701729590010
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py38hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/datashape-0.5.4-py38hecd8cb5_1.tar.bz2
   sha256: 93795b6dc8f961dbe377760a32f38512e015d618109cbc030cac09f171be2078
   md5: fe229f4229cb5acdf2d397c2b12182d0
   depends:
@@ -4028,7 +4028,7 @@ packages:
   license_family: BSD
   size: 103937
   timestamp: 1613390235465
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py38hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py38hcec6c5f_0.tar.bz2
   sha256: 455dc5a3dba2409362ef2c91841cd68e3a73fb6f96267b291c9b7e1fa24e785a
   md5: 55f079cc255134e545e705a49eb5c18a
   depends:
@@ -4038,7 +4038,7 @@ packages:
   license_family: MIT
   size: 2051390
   timestamp: 1690905143314
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2.30.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/distributed-2.30.1-py38hecd8cb5_0.tar.bz2
   sha256: a8c45816df2dfadbe7dc2deed3ee2cc4502548f0583b866d6c15de5543da9ce3
   md5: 8b40ccb3121dd0d6faf73210d4bfc3f2
   depends:
@@ -4062,7 +4062,7 @@ packages:
   license_family: BSD
   size: 1106542
   timestamp: 1605066580663
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/double-conversion-3.1.5-haf313ee_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/double-conversion-3.1.5-haf313ee_1.tar.bz2
   sha256: 2bdfa7559274e301134763f91c68549e3d8e96c588590e96426bee8d8980aafa
   md5: 53d71f9c190485c09e175ad286f4f17f
   depends:
@@ -4071,7 +4071,7 @@ packages:
   license_family: BSD
   size: 243792
   timestamp: 1567108378542
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py38hecd8cb5_0.tar.bz2
   sha256: 0f432eeab9a2f0363540efcda4a1048b3d60d5e0b3e2cfb106748759caa28138
   md5: f0461cfd6eac119ca072171039b5f799
   depends:
@@ -4080,7 +4080,7 @@ packages:
   license_family: MIT
   size: 16516
   timestamp: 1649926487728
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.2.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.2.0-py38hecd8cb5_0.tar.bz2
   sha256: 441b384d467faff32fc8de30e666514ab8a6258ccb510035802546ec6c257183
   md5: 6b891fd873db20fadb139335d08ac5f0
   depends:
@@ -4089,7 +4089,7 @@ packages:
   license_family: MIT
   size: 30672
   timestamp: 1706031564908
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-0.5.0-py38h67323c0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fastparquet-0.5.0-py38h67323c0_2.tar.bz2
   sha256: f44bcd182cc2cb5e2c56d355cf88bb370690aed796e1d7ba2fc802e6e51b6416
   md5: 9aeb353e8180e28443b01e358955247e
   depends:
@@ -4105,7 +4105,7 @@ packages:
   license_family: Apache
   size: 191073
   timestamp: 1658500689000
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py38h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fonttools-4.51.0-py38h6c40b1e_0.tar.bz2
   sha256: f43c12493a44a51e00c3cdb2322440c49c2d4e2ec0744bd713a631be70001517
   md5: 278ae8e1e11f718ec07e77340bc116fe
   depends:
@@ -4123,7 +4123,7 @@ packages:
   license_family: MIT
   size: 2633630
   timestamp: 1713551956146
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -4133,7 +4133,7 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.6.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fsspec-2024.6.1-py38hecd8cb5_0.tar.bz2
   sha256: 49d9c40471e4cf7f59eca2c9593962a0b1e317a7b24e9699f3f3e478297b9f0d
   md5: 9677bcec7b6e7ad83b4191cacef68b60
   depends:
@@ -4144,7 +4144,7 @@ packages:
   license_family: BSD
   size: 284765
   timestamp: 1724855821423
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
   sha256: 3c7aa54548409f9343e891820ea43c195b5e4e4dce6b761bc3ae9f6c8be0fc86
   md5: ed9629d6dc1612ec425eb8d27478b0f6
   depends:
@@ -4153,7 +4153,7 @@ packages:
   license_family: BSD
   size: 140316
   timestamp: 1706888243476
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
   sha256: aed47f9ca4dd140b9c8a183e53d4b89eba84a20041d2038983cdfea8096104ef
   md5: c0d981d7d43eaad55950ff5e57206e70
   depends:
@@ -4163,7 +4163,7 @@ packages:
   license_family: BSD
   size: 97828
   timestamp: 1706895273858
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/grpc-cpp-1.26.0-h044775b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/grpc-cpp-1.26.0-h044775b_0.tar.bz2
   sha256: 6598d58756721bdaaeb23ddb1c30eb8bc4c4fdc6ef73eca56465c0c12c366e0e
   md5: 71981798545e520d35049dd3fa07350e
   depends:
@@ -4178,7 +4178,7 @@ packages:
   license_family: APACHE
   size: 5168647
   timestamp: 1580397726198
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-58.2-h0a44026_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/icu-58.2-h0a44026_3.tar.bz2
   sha256: c04f4cf3f9c4879c4d95b36cc842a5def9d1224aad73ef456fd069f162e3d603
   md5: 5c5aa862793c874be6ec8d6af7d1f4e4
   depends:
@@ -4186,7 +4186,7 @@ packages:
   license: MIT
   size: 23669475
   timestamp: 1588026009899
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py38hecd8cb5_0.tar.bz2
   sha256: c924e82966f232e105da559f9a58f105f13ff03660b4d84a1507fa82c931ba7f
   md5: db4484cfb238d23601641490f80569b8
   depends:
@@ -4195,7 +4195,7 @@ packages:
   license_family: BSD
   size: 124051
   timestamp: 1714398923029
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-7.0.1-py38hecd8cb5_0.tar.bz2
   sha256: 3158194afae37da6797a2146fed4da68f548172461cf697727dd8d8673b089f2
   md5: 8e5f8d717cfa9d009d29ba465ee3aee2
   depends:
@@ -4205,7 +4205,7 @@ packages:
   license_family: APACHE
   size: 42299
   timestamp: 1704813585523
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.4.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.4.0-py38hecd8cb5_0.tar.bz2
   sha256: 531b00944ee7aba2ef0accac6d18d1b0bb04d05ca320fd5c1b27e69b0b3e8fd0
   md5: 30c382387a7c041ddd037f3ebbe1b0ce
   depends:
@@ -4215,7 +4215,7 @@ packages:
   license_family: APACHE
   size: 58401
   timestamp: 1720641231783
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intake-0.6.8-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intake-0.6.8-py38hecd8cb5_0.tar.bz2
   sha256: bf38dd1c31e7972eb1e2017ee43eb2ae77d7a6e4ed66c4c198fdad4f87af0a6b
   md5: 3043756621f9503851e591b05190a0c6
   depends:
@@ -4238,7 +4238,7 @@ packages:
   license_family: BSD
   size: 192144
   timestamp: 1678787642849
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
   sha256: e0127f50d444bf4474e8df07d602c7f6dd38690e8bb3fb28817c164940ffcde1
   md5: 583fcd7060cad6a77074d00d9ef62f44
   depends:
@@ -4247,7 +4247,7 @@ packages:
   license_family: Proprietary
   size: 731417
   timestamp: 1699647668990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.29.5-py38hecd8cb5_0.tar.bz2
   sha256: 8bf93ec3b6e49e270c4dda4ba49327e2af0f496176ad3a13aecf9926bdae3d21
   md5: b2edef890b73c905c323bd18c7590008
   depends:
@@ -4269,7 +4269,7 @@ packages:
   license_family: BSD
   size: 191374
   timestamp: 1728665881223
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.12.2-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.12.2-py38hecd8cb5_0.tar.bz2
   sha256: 9d76af4bc19372cc220b285d63598c90ba6e27476f0d9088eb818e3ce69d7ed1
   md5: 6a291fe69dc614fc91a22ec7f86bc85d
   depends:
@@ -4290,7 +4290,7 @@ packages:
   license_family: BSD
   size: 1235334
   timestamp: 1691532318531
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.19.1-py38hecd8cb5_0.tar.bz2
   sha256: 677297a0b7640bff35fd15cdb013b40962dfc9306ca2769eb1c6d2447e79de10
   md5: 0d3b57b4975069bfffce9753363cb5be
   depends:
@@ -4300,7 +4300,7 @@ packages:
   license_family: MIT
   size: 1052163
   timestamp: 1721058526649
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.4-py38hecd8cb5_0.tar.bz2
   sha256: 583d3f15b66cf0ae1a0e933e532b6aa2c35df841bb206330479752961aa57f6e
   md5: a09697fd44605d88790ff1039114440e
   depends:
@@ -4312,14 +4312,14 @@ packages:
   license_family: BSD
   size: 271327
   timestamp: 1716993463036
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
   sha256: 855982a798d9af8e70635a250528a5da3b2b0cf7095e2804858caf139c8a239b
   md5: 112a5602fe42a84a5bafa038abeddf4f
   license: IJG
   license_family: Other
   size: 279686
   timestamp: 1722872676718
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.23.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.23.0-py38hecd8cb5_0.tar.bz2
   sha256: 415e06dd2d89aeb0fd25649fcc914e33b4733d10892c9f331f1aaf77cb4c816e
   md5: 77d35a34cd2dd79f34de76b7c20d5d4e
   depends:
@@ -4334,7 +4334,7 @@ packages:
   license_family: MIT
   size: 144307
   timestamp: 1728486978880
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py38hecd8cb5_0.tar.bz2
   sha256: c208cadc5de183c46d2962f47e13dced0e1fcac5351821747536bfcbfd138779
   md5: 6999d899e1ac321e4ea7a094c007a78f
   depends:
@@ -4345,7 +4345,7 @@ packages:
   license_family: MIT
   size: 15921
   timestamp: 1699032479293
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py38hecd8cb5_0.tar.bz2
   sha256: cc595a959c77802c0ae5aca9cc9e72071b951cac97463210744bae530c2b5b8c
   md5: 72993460036cd4ee6f80f4c63a1c7fd0
   depends:
@@ -4361,7 +4361,7 @@ packages:
   license_family: BSD
   size: 198052
   timestamp: 1676329716909
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.7.2-py38hecd8cb5_0.tar.bz2
   sha256: f981708f6bd38ef8c1e5ebb5f8aa240ea221a04bd8bdd4821876cc4bd7461a87
   md5: 15ebadb3ff038bbecf6b957e73e5a54a
   depends:
@@ -4372,7 +4372,7 @@ packages:
   license_family: BSD
   size: 83398
   timestamp: 1718818388375
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.10.0-py38hecd8cb5_0.tar.bz2
   sha256: 07f3dcc542fe2faa4b36c4c4f7b72c3f8734d7facd2e492a734a1776103eee21
   md5: a10fced6217b9ed7c044d1af0942689c
   depends:
@@ -4388,7 +4388,7 @@ packages:
   license_family: BSD
   size: 36640
   timestamp: 1718738234692
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.14.1-py38hecd8cb5_0.tar.bz2
   sha256: dfbac50959b9c86448bb57f0fb6bb3f0388a7f1bacdc03266fa2df84f9b7e086
   md5: 8f68f8cd2ec7337cdc6bf5c53aeb9e97
   depends:
@@ -4415,7 +4415,7 @@ packages:
   license_family: BSD
   size: 510344
   timestamp: 1718827865183
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py38hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py38hecd8cb5_1.tar.bz2
   sha256: 6c936d19322b7cc5ce067b2e8ce763ff5d944ac53b16dfc58e26a891ae867838
   md5: ad45f9900cf10fd64f55a4ede690792d
   depends:
@@ -4425,7 +4425,7 @@ packages:
   license_family: BSD
   size: 24606
   timestamp: 1686870930580
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyterlab_pygments-0.2.2-py38hecd8cb5_0.tar.bz2
   sha256: 2ff3ee82e821881366f6c8be7a5cf3e7ab4b3982fc7607df7a735ad1772c3878
   md5: f0808af4af6c96e3be7515f7044f52ee
   depends:
@@ -4437,7 +4437,7 @@ packages:
   license_family: BSD
   size: 19888
   timestamp: 1700168715614
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py38hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py38hcec6c5f_0.tar.bz2
   sha256: 4e9da4496ac7dcd7963447eab5c0de25f16dbba9a51422f68c95081a3657d384
   md5: 83af611855a3505d81184247683e8b80
   depends:
@@ -4447,7 +4447,7 @@ packages:
   license_family: BSD
   size: 64974
   timestamp: 1672387224650
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
   sha256: 8093a64350665d16ca2ad0acfcbba5c84b479c316a40db6b9d5f9b84b58f3b12
   md5: cd98cc17f8297a31b1dd62f061ea4f83
   depends:
@@ -4458,7 +4458,7 @@ packages:
   license_family: MIT
   size: 1289465
   timestamp: 1686931250022
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -4468,7 +4468,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.73.0-hd4c2dcd_11.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libboost-1.73.0-hd4c2dcd_11.tar.bz2
   sha256: 20993ad3c87ca634e993ffd55a44e3b6afd240a21e67afe775ec1789a4a9a15d
   md5: eeb40fe4ff49dd8385047b3640400a5a
   depends:
@@ -4482,13 +4482,13 @@ packages:
   license: Boost-1.0
   size: 20248484
   timestamp: 1611677312412
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 685c3bc9068bd485604b80bf03789e4dca95c410d33871bc1b882e47649fabed
   md5: 6cf8e55271e150ca0961d0ddedaa61bb
   license: MIT
   size: 66237
   timestamp: 1714483284541
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 69826cee54db9955f0120af21ec36d13f9211877fd67364f2068d0a54c6c97cd
   md5: 0851917257f490d35e1f73da8a1c723c
   depends:
@@ -4496,7 +4496,7 @@ packages:
   license: MIT
   size: 34042
   timestamp: 1714483343147
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 3f5a1f03b50b90b397a0ee432ad0cba13354abdaf7e5652c0fc60164b26a08b6
   md5: a50bdc871ef4bf14deb088d888b92b5e
   depends:
@@ -4504,7 +4504,7 @@ packages:
   license: MIT
   size: 311597
   timestamp: 1714483371586
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
   sha256: 83cf762f0d09c97dfb4a1c1cd9e635de2e54c384b057afbf3c0e2e8db07d862f
   md5: ae3a458da93940fea1fa83af80d91fd4
   depends:
@@ -4519,14 +4519,14 @@ packages:
   license_family: MIT
   size: 358556
   timestamp: 1693515516157
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
   sha256: e84e6cbacb12de6fe86955449502d3956696ae583060d0d4911ea6f503cfb9ad
   md5: 1d200c536be4172db41c49e81a3e6350
   depends:
@@ -4535,14 +4535,14 @@ packages:
   license_family: BSD
   size: 169586
   timestamp: 1703006265367
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
   sha256: 4786264321edbff780633a5b752995eb3193ca4bce11b0fda179577f6cf1102c
   md5: 849fdd014c201a9d2c2aa7c7db38a778
   license: BSD-2-Clause
   license_family: BSD
   size: 103993
   timestamp: 1632891571494
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h0a4fc7d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libevent-2.1.12-h0a4fc7d_0.tar.bz2
   sha256: 3b246ea89fd2f97e3f0b04bdfc8e1ce4b18aed99bb5a9fbba274fa2d7fc3b844
   md5: 86c45e25eed8fe34d41e3c8fd440311a
   depends:
@@ -4551,14 +4551,14 @@ packages:
   license_family: BSD
   size: 445216
   timestamp: 1642102789153
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
   sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
   md5: 822a5b76117e56d3912f1f2153307528
   license: MIT
   license_family: MIT
   size: 136045
   timestamp: 1714483561919
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
   sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
   md5: e458587c87e3f2d20192f4e0738f2c63
   depends:
@@ -4567,7 +4567,7 @@ packages:
   license_family: GPL
   size: 149419
   timestamp: 1665498987619
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
   sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
   md5: 1058b661ec829b2ee3716ee2a5520641
   depends:
@@ -4578,14 +4578,14 @@ packages:
   license_family: GPL
   size: 1917987
   timestamp: 1665498925405
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
   sha256: 9ff6ed0f0b9f9f27f449e95d11aa1c4e9e80028fd9d2a8caca5a15d8df88f435
   md5: 7b4b557afc66aba367da14d97d71934c
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1409885
   timestamp: 1714483704680
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm11-11.1.0-h46f1229_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libllvm11-11.1.0-h46f1229_6.tar.bz2
   sha256: 5f31ea9ceb555ff984674f2b7eae2262f7c124c861982d863b93f3a532273349
   md5: 4e8a6604f36e94ae35c22ade431277b7
   depends:
@@ -4595,7 +4595,7 @@ packages:
   license_family: Apache
   size: 23102665
   timestamp: 1665077532507
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
   sha256: 331bc731419328a873e1a48d4257c58baa33d73b4b91ff7a3553b1c122120fb1
   md5: 43fba990695db8556ddd0ade21d59ecc
   depends:
@@ -4610,7 +4610,7 @@ packages:
   license_family: MIT
   size: 782018
   timestamp: 1686931556261
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -4619,7 +4619,7 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-3.11.2-hd9629dc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libprotobuf-3.11.2-hd9629dc_0.tar.bz2
   sha256: 2d484c76caf27dac35c377d5b1ea03d151188bf882ce68acf06df62a38fca011
   md5: 15b2885391989958783fc4704f0f947c
   depends:
@@ -4629,13 +4629,13 @@ packages:
   license_family: BSD
   size: 4689094
   timestamp: 1576541928521
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
   sha256: 8b1adbb78b6283c3d8df932d5aa7e8e249351aa1e206ba2949ee86052912e83f
   md5: 2e035c81c044bff1224224ac24161dfd
   depends:
@@ -4644,7 +4644,7 @@ packages:
   license_family: BSD
   size: 338461
   timestamp: 1686931232629
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.13.0-h054ceb0_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libthrift-0.13.0-h054ceb0_6.tar.bz2
   sha256: 65de01fc98ac03b9679b294128a09690605bf9500f1002ad6b22f0373f943bcc
   md5: 54c1a871b02da02e6a4a8d85f4daf6d6
   depends:
@@ -4655,7 +4655,7 @@ packages:
   license: Apache-2.0
   size: 373773
   timestamp: 1612013222710
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.2.0-h87d7836_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.2.0-h87d7836_0.tar.bz2
   sha256: f4a89b1128569497da1c5d947c31a6314e50ca752e7ca402871e34e8897d2122
   md5: 789fd41c56c85c2c9401e6f244ad87c2
   depends:
@@ -4668,7 +4668,7 @@ packages:
   license: HPND
   size: 620073
   timestamp: 1616492373485
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
   sha256: 246c0d82766042c1a9194eecc71690918c68afa3528ff0c2c82796ce901df40b
   md5: f33be4ed3bff89ed8f68df6c75158510
   constrains:
@@ -4677,7 +4677,7 @@ packages:
   license_family: BSD
   size: 449215
   timestamp: 1729160070984
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
   sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
   md5: 5c740b4a18a558de0ccfe601703c423c
   constrains:
@@ -4686,7 +4686,7 @@ packages:
   license_family: Apache
   size: 338738
   timestamp: 1662635677689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.38.0-py38h8346a28_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.38.0-py38h8346a28_0.tar.bz2
   sha256: e1d230a453b5615198e2ed8c12bdfb5a97bdf547bc4a3c63b7326859d8203885
   md5: 99352eab44f1f5cfc6101a6dffb4afbb
   depends:
@@ -4697,7 +4697,7 @@ packages:
   license: BSD-2-Clause
   size: 246923
   timestamp: 1647870639307
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py38hecd8cb5_0.tar.bz2
   sha256: 84ce38615938b0276a9f31ae7c26acbf7fb5fefcf3e26a1c027880e1c6453f92
   md5: a37ae112579913dab5c86a811d15193f
   depends:
@@ -4706,7 +4706,7 @@ packages:
   license_family: BSD
   size: 11870
   timestamp: 1652903183129
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
   sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
   md5: 8f57dc3a3327bb6f7e1cba908856ac7f
   depends:
@@ -4715,7 +4715,7 @@ packages:
   license_family: BSD
   size: 183138
   timestamp: 1714510756758
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py38hecd8cb5_0.tar.bz2
   sha256: 037ef517fca2095c0cb00251dd62db209d3be9305771bd235c8fbd5eed3d35a4
   md5: d16c75e346d76898b659d4445b0b63e0
   depends:
@@ -4725,7 +4725,7 @@ packages:
   license_family: BSD
   size: 123565
   timestamp: 1671541981715
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py38h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py38h6c40b1e_0.tar.bz2
   sha256: 01313a41f4405cf7950796ff0c2be8b217fa1e166c84cd346cb47c32fc4ac444
   md5: 0e051f25f4d33a9f8787f8a6ddb9e3af
   depends:
@@ -4736,7 +4736,7 @@ packages:
   license_family: BSD
   size: 23389
   timestamp: 1704206382062
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.7.2-py38hee32256_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.7.2-py38hee32256_0.tar.bz2
   sha256: 23ad53d7332a98769b5ebfd0e18f7b984088842fe87d532a2413980b548a466b
   md5: d3af319c00981ce5345d2f4b6a2b14fc
   depends:
@@ -4760,7 +4760,7 @@ packages:
   license_family: PSF
   size: 8023811
   timestamp: 1693812942688
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py38hecd8cb5_0.tar.bz2
   sha256: 88df2ac9ce5c9f4e68e9bae5fe272f2e0ac6fda2aff312ad6af3a66149517c2c
   md5: c2314f5a0fff2fcb7a4d320ad59186cd
   depends:
@@ -4770,7 +4770,7 @@ packages:
   license_family: BSD
   size: 17337
   timestamp: 1662014707291
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py38hecd8cb5_0.tar.bz2
   sha256: 3a090dbd75981245b7ba4d043b374aed341c5335adeda1ed5d2b92e970229a6c
   md5: d1c6fac66449aa61b64ca834f1e27171
   depends:
@@ -4781,7 +4781,7 @@ packages:
   license_family: BSD
   size: 90757
   timestamp: 1661496417142
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
   sha256: c825bc3070f73318ffff88a7a0b7fc6d1858b058ced735efd1789053f1583918
   md5: dea5f96459c9a6df6b026ca57d387936
   depends:
@@ -4794,7 +4794,7 @@ packages:
   license_family: Proprietary
   size: 224299920
   timestamp: 1699647835748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py38h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py38h6c40b1e_1.tar.bz2
   sha256: 38905fb9453303e09abb46bb751bec48210c17a910dbd88293089b2297ffc02c
   md5: aabd6d138e77ca6b9bdb36b3f7f4ee89
   depends:
@@ -4804,7 +4804,7 @@ packages:
   license_family: BSD
   size: 48594
   timestamp: 1682969108154
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py38h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py38h6c40b1e_0.tar.bz2
   sha256: d2b5f01e04120955578805cbbc87797415fb606ba693ca8c958a30264d01a315
   md5: 21358f24bbe5ca2e59c62eeee702234d
   depends:
@@ -4817,7 +4817,7 @@ packages:
   license_family: BSD
   size: 210895
   timestamp: 1695058515685
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py38ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py38ha357a0b_0.tar.bz2
   sha256: e7be2820541896a80f39c83993b4e9ae7945ae5b1e6a761a8c6b145b2a353e12
   md5: 7cf5c49ea5302cf98b49cdfc36ab2aa8
   depends:
@@ -4831,7 +4831,7 @@ packages:
   license_family: BSD
   size: 296359
   timestamp: 1695059904922
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py38haf03e11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/msgpack-python-1.0.3-py38haf03e11_0.tar.bz2
   sha256: 1ee2650fe9020fdc057d5393c9fc85ab235c563e29f442d2dd7b56571af9c08d
   md5: 9136c45236ebf72976926d941f1f95fc
   depends:
@@ -4841,7 +4841,7 @@ packages:
   license_family: Apache
   size: 83201
   timestamp: 1652362886402
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py38_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py38_0.tar.bz2
   sha256: b82b619359eb11120d4c500d16b8fdaf1b83f2a77854cf2a48dc01f901ca7ac4
   md5: 5494980acd3e180125cd5c8c070e0e9d
   depends:
@@ -4851,7 +4851,7 @@ packages:
   license_family: BSD
   size: 22679
   timestamp: 1573471345595
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-1.1.0-py38hecd8cb5_0.tar.bz2
   sha256: 1dc4e87e5b24e673ef117566d965681172a9ee905adb44f4eea6b0b082d19b6a
   md5: c0946783531d986e7fb33009588b9f23
   depends:
@@ -4864,7 +4864,7 @@ packages:
   license_family: BSD
   size: 8194350
   timestamp: 1717622952021
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py38hecd8cb5_0.tar.bz2
   sha256: 638bcc1c3e8ded3381440c5228c9482091757242e5cda0ec25992314e7368653
   md5: 4cfb37881bd4bcc8b871e39abc7e0649
   depends:
@@ -4877,7 +4877,7 @@ packages:
   license_family: BSD
   size: 100672
   timestamp: 1698934403672
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.4-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.16.4-py38hecd8cb5_0.tar.bz2
   sha256: 0a03c2f90cc4eb4f1360208e808c1136f320da2ba16878a2741a198a0b062344
   md5: 17ae803f164e09457b4a0b458d196e1d
   depends:
@@ -4905,7 +4905,7 @@ packages:
   license_family: BSD
   size: 490312
   timestamp: 1728050636817
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.10.4-py38hecd8cb5_0.tar.bz2
   sha256: 150e24bf4ce826d53e796d1afd9f8bfc0b0a2d1dd93434a1039c079b63bc807f
   md5: 4a63ec451e31396bcf28c7811cdfe4b3
   depends:
@@ -4918,14 +4918,14 @@ packages:
   license_family: BSD
   size: 149002
   timestamp: 1728050063689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py38hecd8cb5_0.tar.bz2
   sha256: d15c23a6d8df660a9e9d1bd7bddc73d6a33b72f4e7a60bd5c31d186310e64c44
   md5: cbff13b569745c3776edcbefd9584844
   depends:
@@ -4934,7 +4934,7 @@ packages:
   license_family: BSD
   size: 14374
   timestamp: 1708532763871
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.7-py38hecd8cb5_0.tar.bz2
   sha256: 5f33a0b11861de03735aa0de38fab3b359f8c2402729dde6332ac62560be0941
   md5: 21b4064e6bae8999118fc923eba3f37f
   depends:
@@ -4959,7 +4959,7 @@ packages:
   license_family: BSD
   size: 558008
   timestamp: 1717631022461
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py38hecd8cb5_0.tar.bz2
   sha256: d59fd18830bbb0d25281a51879290851b3c5336b91b3c59b0011003ec127ebe9
   md5: 470134ded59467dd71c9ce988176e0e5
   depends:
@@ -4969,7 +4969,7 @@ packages:
   license_family: BSD
   size: 23491
   timestamp: 1699456117584
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.55.1-py38hae1ba45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numba-0.55.1-py38hae1ba45_0.tar.bz2
   sha256: 5451e058145995f9591f4e196b76b4fd69536ac5f7ea3fc867a1e505acb4ba15
   md5: cd19316da2764ee8ce0e3089e7f5d174
   depends:
@@ -4990,7 +4990,7 @@ packages:
   license_family: BSD
   size: 3939315
   timestamp: 1648042686030
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.4-py38h47b59a4_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.4-py38h47b59a4_1.tar.bz2
   sha256: 1e384cd8e57ee5953d72e3725265b4c3414216e2d69198fa57a504d6d8577a20
   md5: b19be6f476ed0f602317ed31319b5d1c
   depends:
@@ -5004,7 +5004,7 @@ packages:
   license_family: MIT
   size: 135465
   timestamp: 1683227249056
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.21.6-py38h827a554_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.21.6-py38h827a554_1.tar.bz2
   sha256: 6f340cf791cf5fbefbc320e4dcef041d3ce75371ffe187824dfc4822e3dbd944
   md5: 2aeb9bcf08048fc68bca7e5b89bbe0e6
   depends:
@@ -5020,7 +5020,7 @@ packages:
   license_family: BSD
   size: 11590
   timestamp: 1715093222808
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.21.6-py38ha186be2_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.21.6-py38ha186be2_1.tar.bz2
   sha256: 43f2a1220e7786d7a8c339f39769eb6c640fec67542923e57efc19c6090688e7
   md5: 17104540c935718c9f5c93c81e08228c
   depends:
@@ -5035,7 +5035,7 @@ packages:
   license_family: BSD
   size: 6319935
   timestamp: 1715093194701
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h7231236_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h7231236_2.tar.bz2
   sha256: f6ca5e20df95f1067063a94923eea358b3b1297c5dae5ece4a23a1414b26e94f
   md5: 4417110c601925584eb73c75420ded80
   depends:
@@ -5046,7 +5046,7 @@ packages:
   license_family: BSD
   size: 511233
   timestamp: 1720655581725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
   sha256: f95f5173ab2a4529b56ff90deec905dd53877250acedd3887fb289b721396009
   md5: 2ab1a555331747f19e4aa7a335e33a85
   depends:
@@ -5055,7 +5055,7 @@ packages:
   license_family: Apache
   size: 3665304
   timestamp: 1694465313538
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-1.6.7-h001ef8f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/orc-1.6.7-h001ef8f_2.tar.bz2
   sha256: 5a74d458cae412d785abd6c0e6b23235521f5455b26a86097f286f1854613e91
   md5: 68a35293ee1c94e83b87e4c1aa42c7c5
   depends:
@@ -5068,7 +5068,7 @@ packages:
   license_family: Apache
   size: 395608
   timestamp: 1619512311990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py38hecd8cb5_0.tar.bz2
   sha256: 2230f3fc9b1cabbf2007c10212d3d8e678b11d68ff75fd13b30c5b81d3d1d6b4
   md5: bc85dc53ec6bf72853e8fc353de654e9
   depends:
@@ -5077,7 +5077,7 @@ packages:
   license_family: APACHE
   size: 31823
   timestamp: 1699371280670
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-24.1-py38hecd8cb5_0.tar.bz2
   sha256: 5e79ed5782abd62a1a1f5dc0a9dcb16a49bd9fc1c2b2be8d432f231a4f3dfe15
   md5: e37192ce90f7ca932bedac50c1828d9e
   depends:
@@ -5086,7 +5086,7 @@ packages:
   license_family: Apache
   size: 135811
   timestamp: 1720101893151
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-1.5.3-py38h07fba90_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-1.5.3-py38h07fba90_0.tar.bz2
   sha256: 223d738265fc6329bb3306e7aa0a023479001055c23a1aa0e9d8a9f9d450076e
   md5: 17e31a8fbfa7024538e4c0b0207b5880
   depends:
@@ -5132,7 +5132,7 @@ packages:
   license_family: BSD
   size: 13072249
   timestamp: 1677852446342
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py38hecd8cb5_0.tar.bz2
   sha256: 679fd79d2bad66c7e22d25cd36c8907bc5e78526ba0d3f4ef574e86687d87932
   md5: 3a7594f77efa0162990c665701e1912d
   depends:
@@ -5146,7 +5146,7 @@ packages:
   license_family: BSD
   size: 36483
   timestamp: 1698702678191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.4.0-py38h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.4.0-py38h46256e1_0.tar.bz2
   sha256: bd2de69d792f911df8756fae161051412ebdcd4ab502837f051a9b1bf8e56548
   md5: abba45a1032afb818d41bad893779e8a
   depends:
@@ -5162,7 +5162,7 @@ packages:
   license_family: Other
   size: 796810
   timestamp: 1721059746469
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.2-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-24.2-py38hecd8cb5_0.tar.bz2
   sha256: def5a63d0eb12efd92fe21850c5b29dbf7e7cd0abcc11a9ad180ae47f073619d
   md5: 172dc71d2204e23892b938413cb26e19
   depends:
@@ -5173,7 +5173,7 @@ packages:
   license_family: MIT
   size: 2272447
   timestamp: 1723484850699
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pkgutil-resolve-name-1.3.10-py38hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pkgutil-resolve-name-1.3.10-py38hecd8cb5_1.tar.bz2
   sha256: a2825fda7b7bcdaa5469e4dae47a9b54fca5ae0b4e3f545db867061e6f0efea8
   md5: dd887c90f3020a1bc7006d31f0c07bdd
   depends:
@@ -5182,7 +5182,7 @@ packages:
   license_family: PSF
   size: 11442
   timestamp: 1704297495056
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py38hecd8cb5_0.tar.bz2
   sha256: 59543706932970f7922342cc83ce3b7cca7df58ef4c0fef602e13ace586f9ae6
   md5: ca41bf67637034096f2414eaa100b518
   depends:
@@ -5191,7 +5191,7 @@ packages:
   license_family: MIT
   size: 33062
   timestamp: 1692205767198
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pooch-1.7.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pooch-1.7.0-py38hecd8cb5_0.tar.bz2
   sha256: 322e198616c7e83a60010d0f997cfad3f8ea07fea3adf27e049c364349324b8c
   md5: 1fccc3ef32139e3c02bef538caa5a4f2
   depends:
@@ -5207,7 +5207,7 @@ packages:
   license_family: BSD
   size: 82466
   timestamp: 1695850164306
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py38hecd8cb5_0.tar.bz2
   sha256: cb719cdb0e7c35e0edabdf544042a3f47bc235d8f31f27cbed4f0f2d6c42e8fe
   md5: a76c1a1d816608f02aa155ed03d95821
   depends:
@@ -5216,7 +5216,7 @@ packages:
   license_family: Apache
   size: 91112
   timestamp: 1659455138351
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py38hecd8cb5_0.tar.bz2
   sha256: 90ce9ecb0155fa242f9dee60314307b67e0ee3ac6996c159f0aeb5f8226b6981
   md5: 9c3b03ca9cd7c208571fdbd9ba5f3722
   depends:
@@ -5228,7 +5228,7 @@ packages:
   license_family: BSD
   size: 578057
   timestamp: 1704404412093
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py38hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py38hca72f7f_0.tar.bz2
   sha256: 3e0fc9381b2c7a97dde3841b455a03648257ca105d3c99ee673e45dc2a3f233b
   md5: d3034fa818207ec94aa5876e3fd778ff
   depends:
@@ -5237,7 +5237,7 @@ packages:
   license_family: BSD
   size: 365816
   timestamp: 1656431564060
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-4.0.1-py38hdf3e9eb_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyarrow-4.0.1-py38hdf3e9eb_3.tar.bz2
   sha256: 550cb24b4aa71074e972d57c6da38a2b458ffb5a18fa1510019cdb76565e397e
   md5: b7a80dfd62ca5906daa693a840b2d545
   depends:
@@ -5255,7 +5255,7 @@ packages:
   license: Apache 2.0
   size: 2481281
   timestamp: 1623164904136
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py38hecd8cb5_0.tar.bz2
   sha256: 35c76d8e4ecfe2f9ddb8ca341e7c940b00dd7b2c628b4364f2cec55519ac5c6e
   md5: 53d45ee242138195f85f5fbea3de05c0
   depends:
@@ -5267,7 +5267,7 @@ packages:
   license_family: BSD
   size: 30803
   timestamp: 1675441540278
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py38hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py38hecd8cb5_1.tar.bz2
   sha256: ee5a34ab3a65b01adc661e9c67b1f9af2e5fb737ef477607f16b85ad30d1fb7f
   md5: a3220cef0db91e71e3de88c151de039b
   depends:
@@ -5276,7 +5276,7 @@ packages:
   license_family: BSD
   size: 1888474
   timestamp: 1684280131448
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py38hecd8cb5_0.tar.bz2
   sha256: fa80f34c66064dad6d5c74c6a4a01f7ef842702cbbfeb73988ef3c9196d90a67
   md5: e14a6c52601b5efcae0156ff27b210a7
   depends:
@@ -5285,7 +5285,7 @@ packages:
   license_family: MIT
   size: 157601
   timestamp: 1661452654987
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py38_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py38_1.tar.bz2
   sha256: 3bf4d8aa47a883c367b98db7cc16efef613a0b08fb143bb9f78967c5d2c7416b
   md5: 6837a4c11fb0126b4422d0caaa1b6296
   depends:
@@ -5294,7 +5294,7 @@ packages:
   license_family: BSD
   size: 27255
   timestamp: 1594394684547
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.8.18-h218abb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.8.18-h218abb5_0.tar.bz2
   sha256: 0c1b0c532cfec52c6587073e036cef48d07057eda4727ac1db422193add8b1c3
   md5: 184d7340d5f85eb4d369ae695f3568a9
   depends:
@@ -5312,7 +5312,7 @@ packages:
   license_family: PSF
   size: 15528724
   timestamp: 1694439198827
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py38hecd8cb5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py38hecd8cb5_2.tar.bz2
   sha256: 5582feaf474175f9a39fe9655041156721d57aa67fa3749fc9884686973d9fca
   md5: dc7441373044444d950b7f985c71691b
   depends:
@@ -5322,7 +5322,7 @@ packages:
   license_family: BSD
   size: 289785
   timestamp: 1716495986341
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py38hecd8cb5_0.tar.bz2
   sha256: 3bdab73baf83e87b9f1b533797fe64a084cefb1be9d1527fa4f295f7a8f498d4
   md5: d67db0edf3d298995791f78ac59badc8
   depends:
@@ -5331,7 +5331,7 @@ packages:
   license_family: BSD
   size: 265379
   timestamp: 1661369089392
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-json-logger-2.0.7-py38hecd8cb5_0.tar.bz2
   sha256: b517732d28776219a570b5264aad5074b7ca96ee89b5ad04065dc16b6264c710
   md5: b6de501d6a5bc6cf781f4181a13832d3
   depends:
@@ -5340,7 +5340,7 @@ packages:
   license_family: BSD
   size: 16222
   timestamp: 1683823894978
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py38hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-lmdb-1.4.1-py38hcec6c5f_0.tar.bz2
   sha256: 803a11fceb8ac73e82ea6eb489503c268c6a59176e0b3ce3c0853b86ff386373
   md5: 0b3a76ba820c7f1ec345ad82765eeffa
   depends:
@@ -5350,7 +5350,7 @@ packages:
   license_family: Other
   size: 140675
   timestamp: 1682522414875
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-snappy-0.6.1-py38hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-snappy-0.6.1-py38hcec6c5f_0.tar.bz2
   sha256: aff80eab3d3bd2a996d0e58ae6a9ccc7aca2d136aabc957684fee9dc5df10c5c
   md5: 63afd720f9f859b1df3b2f72cfec9433
   depends:
@@ -5361,7 +5361,7 @@ packages:
   license_family: BSD
   size: 31543
   timestamp: 1670944075249
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py38hecd8cb5_0.tar.bz2
   sha256: fe4b78e7150559976de32624b8a0272f049bb7c1255b8fb179cbfc81c30de3e3
   md5: 5ebd790aefad84c43f2b24f85c5679bc
   depends:
@@ -5370,7 +5370,7 @@ packages:
   license_family: MIT
   size: 255558
   timestamp: 1713974414573
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py38hecd8cb5_0.tar.bz2
   sha256: 1d7fc1716c0124d70eec1871da8ee2b108e915e2fcf6248436118ceb0e82bfae
   md5: 2a4448bbd92f8a33e1e8fb04ebf48e2f
   depends:
@@ -5382,7 +5382,7 @@ packages:
   license_family: BSD
   size: 61610
   timestamp: 1711136949236
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py38h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.2-py38h46256e1_0.tar.bz2
   sha256: 0cacbcec0922022bb35f37e61071050be8d48bcdf1cc2d3d2617fa58d58d79bf
   md5: 3cb8af201bee52dfccd08cb0e9502ca5
   depends:
@@ -5392,7 +5392,7 @@ packages:
   license_family: MIT
   size: 177138
   timestamp: 1728659222455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py38h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-24.0.1-py38h6c40b1e_0.tar.bz2
   sha256: 780059b7ecbe0039877c9fb4694a287888a5ba09df01b9b03898f38cfa478c70
   md5: 72c8bc8105a687a24846b100d8137146
   depends:
@@ -5402,7 +5402,7 @@ packages:
   license_family: Other
   size: 506048
   timestamp: 1709318384581
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
   sha256: c69f556df9a27328c56943f3b5918cbb953cfbca987e20394d823a6174781202
   md5: ab294ae71ecdfaa307a961cc71dd890d
   depends:
@@ -5410,7 +5410,7 @@ packages:
   license: BSD-3-Clause
   size: 205638
   timestamp: 1652449553607
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -5419,7 +5419,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py38hecd8cb5_0.tar.bz2
   sha256: fbcea67a73af453330816c8fea3aa044bda75f292a1b97390a9aee725f855baf
   md5: 14748afcba729835202de23627c6a65a
   depends:
@@ -5430,7 +5430,7 @@ packages:
   license_family: MIT
   size: 58798
   timestamp: 1699012243225
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.32.3-py38hecd8cb5_0.tar.bz2
   sha256: 4ede1df4d0ba54813783f6f8e9aa984aebfec5d17e06a7416068aac4f21b3fe2
   md5: f38446b6c558a0d468a0e24ad28d5a70
   depends:
@@ -5446,7 +5446,7 @@ packages:
   license_family: Apache
   size: 98509
   timestamp: 1721411124535
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-toolbelt-1.0.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-toolbelt-1.0.0-py38hecd8cb5_0.tar.bz2
   sha256: 3d3ca7b724662b43d343c585c3b2017aa786a457d9b1d6bdcc36ad3eee8f9073
   md5: 904104151a27446e34efa89d9e0a65d7
   depends:
@@ -5456,7 +5456,7 @@ packages:
   license_family: Apache
   size: 69866
   timestamp: 1690874175366
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py38hecd8cb5_0.tar.bz2
   sha256: 543d50ee7da2e1bb4113aae35ed0078c524b6a2dd0597c4d8eafc7b9c0ff74a4
   md5: 54c2663e4127781a5dfeeaf0591c72f5
   depends:
@@ -5466,7 +5466,7 @@ packages:
   license_family: MIT
   size: 9832
   timestamp: 1683077172537
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py38hecd8cb5_0.tar.bz2
   sha256: 075834abb477e903e6055562b5f8e765a7ab5cc12715d6842ba497373eef4e13
   md5: 8b2bff424e3921364d511ad691a0f5d7
   depends:
@@ -5475,7 +5475,7 @@ packages:
   license_family: MIT
   size: 10211
   timestamp: 1683059253756
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py38hf2ad997_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py38hf2ad997_0.tar.bz2
   sha256: f3643369ddba0092399144fdd924b8cd41d8542ea0e07624fc55cb974bece013
   md5: 1b1c11994c9be771cf73009f5aae3cb2
   depends:
@@ -5484,7 +5484,7 @@ packages:
   license_family: MIT
   size: 319417
   timestamp: 1698946428421
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ruamel.yaml.clib-0.2.8-py38h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ruamel.yaml.clib-0.2.8-py38h46256e1_0.tar.bz2
   sha256: 99f2860c388a2e4d009b8515b4245e5395474409970c7bc728e403f6c5aeb26b
   md5: c620d6f39bde0f76cf6dc5127b61ad67
   depends:
@@ -5493,7 +5493,7 @@ packages:
   license_family: MIT
   size: 142294
   timestamp: 1727769981406
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ruamel_yaml-0.17.21-py38hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ruamel_yaml-0.17.21-py38hca72f7f_0.tar.bz2
   sha256: 9bbf0af30a1f1dc810fc46bd80331521d782a3a21276685946201ebb713d41bc
   md5: 25a6ab14b8a94c1d7c11c0b1eb92597b
   depends:
@@ -5503,7 +5503,7 @@ packages:
   license_family: MIT
   size: 173869
   timestamp: 1667489796800
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.10.1-py38hf241641_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/scipy-1.10.1-py38hf241641_1.tar.bz2
   sha256: 402a621edb67348e29d593fa3abfdc2e2caa0e4cb263a81ea4438b5ee16d06dc
   md5: 98bf265b20f94a8fef4f45d9caa71e9a
   depends:
@@ -5522,7 +5522,7 @@ packages:
   license_family: BSD
   size: 24792365
   timestamp: 1683295750615
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py38hecd8cb5_0.tar.bz2
   sha256: 87e86c8667a87b9bfe09df1d98c77355c94ce1eb56c8b297782868f63753870e
   md5: 605714e602ef77f4feb2132da8f67a99
   depends:
@@ -5531,7 +5531,7 @@ packages:
   license_family: BSD
   size: 27880
   timestamp: 1699371249360
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-60.9.3-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-60.9.3-py38hecd8cb5_0.tar.bz2
   sha256: 47c33bb5fe1277cf9e33191ae3629f646049af0f7618b8c67b3eba0d1b768cfa
   md5: 3ef3eb157e83c0224d30b99805e131ed
   depends:
@@ -5540,7 +5540,7 @@ packages:
   license_family: MIT
   size: 1229042
   timestamp: 1685710558686
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
   sha256: 9eaab5afd89c87ca139915589626785039fac30f05f8fb19e9eefe27eb935ce6
   md5: babdcd3370f85ded3d313902dcebecfb
   depends:
@@ -5549,7 +5549,7 @@ packages:
   license_family: BSD
   size: 46224
   timestamp: 1723557464934
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py38hecd8cb5_0.tar.bz2
   sha256: 5790b43ac502fb2e1688a505227bcae00f328adf35f2b8ea08c7527f6a52ceec
   md5: 41d9d12aac6e182a2212d409524f517c
   depends:
@@ -5558,7 +5558,7 @@ packages:
   license_family: Other
   size: 17801
   timestamp: 1705431355713
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py38hecd8cb5_0.tar.bz2
   sha256: 4617e621bcefd0cf9806da51451335cb422b6cff1de8ece9844136a14732e4cb
   md5: 3118681370d80225e19baf3f77171a69
   depends:
@@ -5567,7 +5567,7 @@ packages:
   license_family: MIT
   size: 67418
   timestamp: 1696347616672
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
   sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
   md5: 6bef1694163a68ac4c37e5857b8da4f5
   depends:
@@ -5579,7 +5579,7 @@ packages:
   license_family: Other
   size: 1900191
   timestamp: 1714488351925
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -5588,7 +5588,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py38hecd8cb5_0.tar.bz2
   sha256: 34533fc748e7cb5f8a860eb3f6601beb4f126998d1dd5fc5afd6d89f01969efe
   md5: cbda7f79b6003675241b015d49c85280
   depends:
@@ -5599,7 +5599,7 @@ packages:
   license_family: BSD
   size: 30949
   timestamp: 1671751869746
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/thrift-0.17.0-py38he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/thrift-0.17.0-py38he9d5cce_0.tar.bz2
   sha256: df4c68d6a2227c2d168ae30d4d51c3d64d40999d67c859d3a3c239c6f321cc7b
   md5: e36eb226622a7c95b42af3e8ec8dbeb6
   depends:
@@ -5610,7 +5610,7 @@ packages:
   license_family: APACHE
   size: 127256
   timestamp: 1666296634923
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py38hecd8cb5_0.tar.bz2
   sha256: 0ee666490997aafc34aec0c78efe2d7871f6fed54c4250d69b11aaf29ad5ed71
   md5: 17b450ce8eecf4c027a24177061f47c1
   depends:
@@ -5620,7 +5620,7 @@ packages:
   license_family: BSD
   size: 40304
   timestamp: 1668168892749
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
   sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
   md5: 523c006cc67c011383678c762015479b
   depends:
@@ -5629,7 +5629,7 @@ packages:
   license_family: BSD
   size: 3594448
   timestamp: 1714770737885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py38hecd8cb5_0.tar.bz2
   sha256: 92755ab4f8c11bd18c59efd108b72b366dc35b1d9675847b4839f0ec92ea917d
   md5: 9df5b054b202bc995ace5e8779ac643f
   depends:
@@ -5638,7 +5638,7 @@ packages:
   license_family: BSD
   size: 102499
   timestamp: 1667464228738
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.1-py38h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.4.1-py38h46256e1_0.tar.bz2
   sha256: e91d2185325b0db7af231e0127c60b853ab195626a5c9a5677b63834e932b3cc
   md5: cf5302c00a7fc65804713179493dd0a4
   depends:
@@ -5647,7 +5647,7 @@ packages:
   license_family: Apache
   size: 691403
   timestamp: 1718740319993
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.5-py38h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.66.5-py38h20db666_0.tar.bz2
   sha256: 07cc0dbcdaad3dd2d5ac26119b94c282073c032f99751d0e9875a09d536680df
   md5: dd9474b77b8284acd0224f0aaeb0da75
   depends:
@@ -5658,7 +5658,7 @@ packages:
   license_family: MOZILLA
   size: 127540
   timestamp: 1724854005635
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.14.3-py38hecd8cb5_0.tar.bz2
   sha256: c908c64f9e7bb7d8a82ff5514c12b108ee795fbb23bbfe005a793528f8b61e5d
   md5: cc023730ced97b41337b7b8609b122ff
   depends:
@@ -5667,7 +5667,7 @@ packages:
   license_family: BSD
   size: 166202
   timestamp: 1718227152314
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.11.0-py38hecd8cb5_0.tar.bz2
   sha256: 93c6a2fddc40b6c22315055cfad894b1363eaa687c787de038f18c4d4331bcf5
   md5: e9248594338ba6cfa777dd3002b1ea63
   depends:
@@ -5677,7 +5677,7 @@ packages:
   license_family: PSF
   size: 9883
   timestamp: 1715268913768
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.11.0-py38hecd8cb5_0.tar.bz2
   sha256: 5208c1df58a2a734192f017121c7ceae4256a564e0aebf259edaf07a4e8e7639
   md5: bd38f7b27a5b01d995baa65dcf6da4b0
   depends:
@@ -5686,7 +5686,7 @@ packages:
   license_family: PSF
   size: 61208
   timestamp: 1715268896023
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py38h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py38h6c40b1e_0.tar.bz2
   sha256: 6f1ca9025b998e7e0413ffd4642a62136e255916c80d8879aaa27b929d1e9ca5
   md5: aa519109824b4ccbe60831ade4dadf9b
   depends:
@@ -5695,14 +5695,14 @@ packages:
   license_family: Apache
   size: 495756
   timestamp: 1713213117152
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uriparser-0.9.7-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uriparser-0.9.7-h6c40b1e_0.tar.bz2
   sha256: 035b916c1eab3a6a27f0109d8e39fe37cbf8ebe0af948d88d7a3b96ab20dc999
   md5: e697defd6c59ca6d98ab4bb5f951eb21
   license: BSD-3-Clause
   license_family: BSD
   size: 44105
   timestamp: 1692186954114
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.3-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-2.2.3-py38hecd8cb5_0.tar.bz2
   sha256: 2d1b2caa90394200cb0d2c6ef761817406690724f0cf8908b550d4f9d8273a94
   md5: f5a429836e40cb3537df29bb3ffd33af
   depends:
@@ -5718,14 +5718,14 @@ packages:
   license_family: MIT
   size: 171729
   timestamp: 1727769941485
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
   sha256: 0f8c3eb254be9c1957e748e385e20e62509d11052990c4755012be62434c9129
   md5: 53229ba93f6e38308ae42ecfc6eaad9d
   license: MIT
   license_family: MIT
   size: 96768
   timestamp: 1706894705048
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py38_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py38_1.tar.bz2
   sha256: dd878c7ccbe9acd4394ecb151ea22a700d7e17982d07e5cdab16e434ee0e276a
   md5: 816a3f635267b70b6a1b00c00c282a15
   depends:
@@ -5734,7 +5734,7 @@ packages:
   license_family: BSD
   size: 20010
   timestamp: 1573201122722
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py38hecd8cb5_0.tar.bz2
   sha256: e53ac6ec30c9355785d20e1c6acbdacd7c22a7961aac6bf6659d7515a44913a7
   md5: 6f77ea179fa388f1de3b76b7bc4b2bc6
   depends:
@@ -5743,7 +5743,7 @@ packages:
   license_family: Apache
   size: 87316
   timestamp: 1715878486929
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.44.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.44.0-py38hecd8cb5_0.tar.bz2
   sha256: bc1589dbd5052d2b9af1c03c3eaaf945cc6fc8aa311af6cc89df03bcfeabe806
   md5: d51e9bfbcc0b8d3b4b6212bb4f0f806e
   depends:
@@ -5752,7 +5752,7 @@ packages:
   license_family: MIT
   size: 105504
   timestamp: 1726165062547
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2022.11.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xarray-2022.11.0-py38hecd8cb5_0.tar.bz2
   sha256: 1b6d252572b3fe72c4716c24056cfe6b0f5d83a37a87b895b99d9e280a1fd0bc
   md5: 51856b1a836e1d7ee6b166d6c5fbadbb
   depends:
@@ -5764,7 +5764,7 @@ packages:
   license_family: Apache
   size: 1733083
   timestamp: 1668776637394
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py38hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py38hecd8cb5_1.tar.bz2
   sha256: 9ff046886013ca543edb417264a93032d5622c1933afee67f42a1fb55adc1499
   md5: 7329105d84755727fa326092177e87ed
   depends:
@@ -5773,20 +5773,20 @@ packages:
   license_family: BSD
   size: 49845
   timestamp: 1675159128645
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
   sha256: ed0152ad6b87ffd9e01f4a62bc358e805ad59637f898a801b0a9cf903ae8e1fb
   md5: 8a92f8c663608f24e14d8a2068b9d83a
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 415323
   timestamp: 1714511993944
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
   sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
   md5: c25b6d40f834647d0bbe767f6c776031
   depends:
@@ -5796,7 +5796,7 @@ packages:
   license_family: Other
   size: 329449
   timestamp: 1705602140856
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zict-3.0.0-py38hecd8cb5_0.tar.bz2
   sha256: 8b48165e2712438ff12e1602626d500bcf01bc24f50d465fb828e11d08248210
   md5: f75ab2b6ef09cbedfb138841c634f46a
   depends:
@@ -5807,7 +5807,7 @@ packages:
   license_family: BSD
   size: 77592
   timestamp: 1695832909404
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.20.2-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.20.2-py38hecd8cb5_0.tar.bz2
   sha256: 72df95ef4994a942f96a6f98fb03eae94486269ed1d96c7d18e59f69f880ced5
   md5: 5e931d7e6382f8a4bb170020b2392eb2
   depends:
@@ -5816,14 +5816,14 @@ packages:
   license_family: MIT
   size: 26156
   timestamp: 1729012706821
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
   sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
   md5: f2519b551f99765d9d98950c5e2b4713
   license: Zlib
   license_family: Other
   size: 119782
   timestamp: 1714511811597
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstandard-0.19.0-py38h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstandard-0.19.0-py38h6c40b1e_0.tar.bz2
   sha256: 30c8b8101c3daaecae4ddc5a030c747b5a3de6b9c6ce6b954e0d20bad5ab76dc
   md5: e482612cda3fb1db6a0b27c47705ac6c
   depends:
@@ -5833,7 +5833,7 @@ packages:
   license_family: BSD
   size: 727778
   timestamp: 1677014223914
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.4.9-h322a384_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.4.9-h322a384_0.tar.bz2
   sha256: ed01d890a98233cc45445b26de77400cbcf78e99093fca2659eba0e7306f093f
   md5: 4195b3ecf8824e566141c000c05ef981
   depends:
@@ -5844,7 +5844,7 @@ packages:
   license: BSD 3-Clause
   size: 844959
   timestamp: 1617228583339
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/abseil-cpp-20210324.2-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/abseil-cpp-20210324.2-hc377ac9_0.tar.bz2
   sha256: 2afa9a145b00fa79ec3ffa504fada1a56bd5dc17280b28eea76010cbb6f655eb
   md5: 0ebdcd9f0a6e2149ebc59495f1505700
   depends:
@@ -5853,7 +5853,7 @@ packages:
   license_family: Apache
   size: 970554
   timestamp: 1628722050846
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-anon-usage-0.4.4-py38hd6b623d_100.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anaconda-anon-usage-0.4.4-py38hd6b623d_100.tar.bz2
   sha256: 60b77f617e6d0608dba0eb425bb8a5121a9d704c33a340c489fb0bf464cbf6fc
   md5: cdf0430d5a668976aa05b2967654b184
   depends:
@@ -5865,7 +5865,7 @@ packages:
   license_family: BSD
   size: 24984
   timestamp: 1710965170065
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-client-1.12.3-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anaconda-client-1.12.3-py38hca03da5_0.tar.bz2
   sha256: 24db2b2ee73453c7df739ef945e2163a17e8ae93207f049e41d1cdd34b111e4a
   md5: 60ad3a91403ac9beace23a5d5bf56a69
   depends:
@@ -5888,7 +5888,7 @@ packages:
   license_family: BSD
   size: 141755
   timestamp: 1708640752645
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-project-0.11.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anaconda-project-0.11.1-py38hca03da5_0.tar.bz2
   sha256: 9e40218df829262a29dd0bee31e5999f2187e27f12630908a9516ee89882c04a
   md5: 6614194c494344a478ee3de1a4f4bd2b
   depends:
@@ -5904,7 +5904,7 @@ packages:
   license_family: BSD
   size: 541925
   timestamp: 1660339956833
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.2.0-py38hca03da5_0.tar.bz2
   sha256: 28f2865a85e01f0aff2f3f851e2e179f7b16398e515e2e0647810bd79375b9f7
   md5: 2da1e9a6d51bd35df47f52a4df116ec4
   depends:
@@ -5920,7 +5920,7 @@ packages:
   license_family: MIT
   size: 175017
   timestamp: 1706220446315
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py38hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py38hca03da5_1001.tar.bz2
   sha256: 67836d5b3187b8fbd69a50fe643ecc601645aec6947653e7fbdcf3e137eb5c98
   md5: c6f73e643c6beef9c5a26ed2d621ddd2
   depends:
@@ -5929,7 +5929,7 @@ packages:
   license_family: BSD
   size: 10182
   timestamp: 1629146056221
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py38h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py38h1a28f6b_0.tar.bz2
   sha256: 405979005a60e67d5226c4d3ec3e91119a8cda26ca800c9ba503c47f4fe13471
   md5: cc74ce79b82fee9e8c5a6eafbd3183bb
   depends:
@@ -5939,7 +5939,7 @@ packages:
   license_family: MIT
   size: 35405
   timestamp: 1644845782338
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-4.0.1-py38hd7469ad_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/arrow-cpp-4.0.1-py38hd7469ad_3.tar.bz2
   sha256: 0bdcddf1701967e559487deb66e35caa9c83fdef4eb088ade99c0b0b82d564be
   md5: 04a1bbc057d96970f10807e6a698ad37
   depends:
@@ -5972,7 +5972,7 @@ packages:
   license_family: Apache
   size: 6696038
   timestamp: 1629785258120
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-24.2.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-24.2.0-py38hca03da5_0.tar.bz2
   sha256: c9dcdb7cf6581feed802a7608f7867cc9ebae3ceda8df60b76284fd99fdf1471
   md5: b3e4d004f34199ab25ecbf06b02b5e9a
   depends:
@@ -5981,14 +5981,14 @@ packages:
   license_family: MIT
   size: 142493
   timestamp: 1729089470273
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.6.8-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-common-0.6.8-h80987f9_1.tar.bz2
   sha256: 4d63ff9d0b424c5dc2e20bb8324a348869dee0340511effadfd1d622842a8322
   md5: 3137a10d16bb223ae981d566d60d984b
   license: Apache-2.0
   license_family: Apache
   size: 153917
   timestamp: 1685977852438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.1.6-h313beb8_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-event-stream-0.1.6-h313beb8_6.tar.bz2
   sha256: f41918089bd42945e10d71aaf30eacede92db2b57193c2c931a710c314a39730
   md5: b0a63224a995df6e07fdebba41a3c1a6
   depends:
@@ -5999,7 +5999,7 @@ packages:
   license_family: Apache
   size: 24245
   timestamp: 1686021087869
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.11-h80987f9_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-checksums-0.1.11-h80987f9_2.tar.bz2
   sha256: 5068b5773e8ce07dfc34718fb6c4be364a4c79d821138d68c3d246873bd562b9
   md5: 1efb7da0ab9ee77370640b77f74f9c7c
   depends:
@@ -6008,7 +6008,7 @@ packages:
   license_family: Apache
   size: 51725
   timestamp: 1685998294585
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.8.185-h4a942e0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-sdk-cpp-1.8.185-h4a942e0_0.tar.bz2
   sha256: 0f257afff29f6c681b9fd8620767ce2af7b07f9068c3f0e649289ca9151591bf
   md5: 9358450895bb23ccbd49c553dbd66589
   depends:
@@ -6021,7 +6021,7 @@ packages:
   license_family: Apache
   size: 2171325
   timestamp: 1628727158397
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.3-py38hca03da5_0.tar.bz2
   sha256: 67f1952cdd12d6e9f5e99484ddcbeaf41f3ce0b6119c74081a165060d7eb4919
   md5: 777c1359eae877da3662717e4b7142ef
   depends:
@@ -6031,12 +6031,12 @@ packages:
   license_family: MIT
   size: 216423
   timestamp: 1718029890286
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-2.4.3-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-2.4.3-py38hca03da5_0.tar.bz2
   sha256: d7ee7ab367d941b407ed37be32c0fb990f9a0484c8dd467cf2e1f802bd35d44e
   md5: baf403ea360ec6e3f7722ce2e241ba10
   depends:
@@ -6052,7 +6052,7 @@ packages:
   license_family: BSD
   size: 14433721
   timestamp: 1658136849401
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.73.0-h1a28f6b_11.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/boost-cpp-1.73.0-h1a28f6b_11.tar.bz2
   sha256: 48da0930dccb522c698dbb2ebfd939d1a88f2da2c66c2e9f544294db34e3e88b
   md5: ef2630c4a64729b3102a867db7e0bed9
   depends:
@@ -6060,7 +6060,7 @@ packages:
   license: Boost-1.0
   size: 16313
   timestamp: 1628697190453
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py38hbda83bc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.7-py38hbda83bc_0.tar.bz2
   sha256: 23bdef5475e66b317e63ae82ea693d9f4746e1e52d9e01602c29bd54b08ed0dc
   md5: a3f9fba7288f70620a8837a2796309e3
   depends:
@@ -6070,7 +6070,7 @@ packages:
   license_family: BSD
   size: 113866
   timestamp: 1707865034650
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
   sha256: 048264434c33fdb53862cdd69b2e2bc4ce6f8a70b3211ad6d686d066eac2aa91
   md5: d55696ccaf6755931cd662dfb929aa0b
   depends:
@@ -6080,7 +6080,7 @@ packages:
   license: MIT
   size: 19737
   timestamp: 1714483270447
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
   sha256: 13627293296fcc231d8dc12d803dfc9621108c60df38b0e3c64e9e02ed55e564
   md5: 86efd4ad08cd80d3eab77873db84a255
   depends:
@@ -6089,7 +6089,7 @@ packages:
   license: MIT
   size: 19083
   timestamp: 1714483255364
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py38h313beb8_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py38h313beb8_8.tar.bz2
   sha256: 24efac2f9b2d8916d63c7e2a2f9247c6409933596957e484b1c1ff9688f4081d
   md5: 178d4327a0f98919062d86bb1dc44ad9
   depends:
@@ -6098,28 +6098,28 @@ packages:
   license: MIT
   size: 379250
   timestamp: 1714483360289
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
   sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
   md5: 56d1386c7f1f338f0d18f82af6525273
   license: bzip2-1.0.8
   license_family: BSD
   size: 158748
   timestamp: 1714510571033
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
   sha256: b0be79290b1df1cf1d07a1a9c3f3a92ae262643a6df3dc10dfbac22a82874dd4
   md5: 8fdcf1c08eee91fec7eefc22863c816a
   license: MIT
   license_family: MIT
   size: 106550
   timestamp: 1693902036526
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.9.24-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2024.9.24-hca03da5_0.tar.bz2
   sha256: b3b13d44d3e05c88f411d245c052b547652be3f3ce7ba21970ba1bbf20a8ea33
   md5: d8091745a1bfd921bf15b2f73111d299
   license: MPL-2.0
   license_family: Other
   size: 141261
   timestamp: 1727794860441
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.8.30-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.8.30-py38hca03da5_0.tar.bz2
   sha256: 8c852260def7ce0e5cbdf2f5ca2aef20153b650f04d3a0d4b9bcba0417935d28
   md5: 049897bccbeee81f51d4f45a578191db
   depends:
@@ -6128,7 +6128,7 @@ packages:
   license_family: Other
   size: 169227
   timestamp: 1725551901662
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py38h3eb5a62_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.17.1-py38h3eb5a62_0.tar.bz2
   sha256: faba6265a92bc533a0aae6fd8756f005c3d529e23af6ac89b0268b33392ebd7d
   md5: b6bd692e4b80d220f2171be64c6617e9
   depends:
@@ -6139,7 +6139,7 @@ packages:
   license_family: MIT
   size: 231418
   timestamp: 1726856551295
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py38hca03da5_0.tar.bz2
   sha256: aeb9fd657eacfb76ae352a33991bedc46d8f1080c0fee116c517ab6cea5ea8ab
   md5: 1ac72858d61f8028a48f2f855b0e9f43
   depends:
@@ -6148,7 +6148,7 @@ packages:
   license_family: BSD
   size: 152725
   timestamp: 1698129882125
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.0.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-3.0.0-py38hca03da5_0.tar.bz2
   sha256: 0fb1d1a980a8428f9de5d3bdf92c2a323e20916abd3f22533bad6213b2d230de
   md5: b58f391e710cafeb009c2fefb2f4f60b
   depends:
@@ -6157,7 +6157,7 @@ packages:
   license_family: BSD
   size: 35709
   timestamp: 1721657490117
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py38hca03da5_0.tar.bz2
   sha256: 379b85e4352895ddf2591837ea32d6ad23a6b8b6300578d975a403fd24cc97c4
   md5: 1219dda9082a89e5faf90bed3f7d8e58
   depends:
@@ -6166,7 +6166,7 @@ packages:
   license_family: CC
   size: 546256
   timestamp: 1709758505234
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py38hca03da5_0.tar.bz2
   sha256: b0e7c3a535edb3c56155853702fd9b8d07cab871bc523a1311643ba9b844ae8a
   md5: 116f6e9f04b53d76ae4770bc5630c5cd
   depends:
@@ -6176,7 +6176,7 @@ packages:
   license_family: BSD
   size: 15628
   timestamp: 1709322880704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-pack-0.7.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/conda-pack-0.7.1-py38hca03da5_0.tar.bz2
   sha256: f55ff4685cb721fedb6727dede01aa219677386b17ce07ccc5e81b6df4e274b9
   md5: 318d3731b4b28a57be258a40d3b7e154
   depends:
@@ -6186,7 +6186,7 @@ packages:
   license_family: BSD
   size: 52484
   timestamp: 1710258102226
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-handling-2.3.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/conda-package-handling-2.3.0-py38hca03da5_0.tar.bz2
   sha256: ef64ef06a8c987006212b60095e9936eaccf7f1289e459b34f452d6071664576
   md5: 43e51f437dd5406aefe666e371d94f94
   depends:
@@ -6197,7 +6197,7 @@ packages:
   license_family: BSD
   size: 279557
   timestamp: 1718138371764
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-streaming-0.10.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/conda-package-streaming-0.10.0-py38hca03da5_0.tar.bz2
   sha256: 38b426455f094aab74b29ace5f5608a99e0b2faee765e18e8c63afdfe70b482b
   md5: 2d6e31b5e8b8a5526290b117a857f2e9
   depends:
@@ -6207,7 +6207,7 @@ packages:
   license_family: BSD
   size: 28408
   timestamp: 1718136108403
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py38h525c30c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py38h525c30c_0.tar.bz2
   sha256: e556127f6eaabe27e373eeb452fcc21094ca7e1543f5010560c3ddf374ae4ca5
   md5: b9ecfe24d5af60f9262569185f942672
   depends:
@@ -6218,7 +6218,7 @@ packages:
   license_family: BSD
   size: 219507
   timestamp: 1663827520740
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.2-py38h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cytoolz-0.12.2-py38h80987f9_0.tar.bz2
   sha256: c54d48568bf8bf0be1dd68a939c77c84ed0f613aaadca3fdbc54b493f3288f47
   md5: 6b8cd5e594d17d7dd57ecb68c2bd60e9
   depends:
@@ -6228,7 +6228,7 @@ packages:
   license_family: BSD
   size: 376182
   timestamp: 1701723652583
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py38hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/datashape-0.5.4-py38hca03da5_1.tar.bz2
   sha256: abb41ec3bdd1a8b491056d8409044e7db430140cde7935bcb41826d746cb7194
   md5: 691ae819ca6bafeb6626cd7941f79c6b
   depends:
@@ -6240,7 +6240,7 @@ packages:
   license_family: BSD
   size: 103380
   timestamp: 1629793027649
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py38h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py38h313beb8_0.tar.bz2
   sha256: ad48c11fd3b44e89832e5851ba77d27951f258c039a53e15e9fe2bdc35b408c9
   md5: 3e3601bc2eb8e58c4cadb36ac4ea7689
   depends:
@@ -6250,7 +6250,7 @@ packages:
   license_family: MIT
   size: 2069572
   timestamp: 1690905388086
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/double-conversion-3.1.5-hc377ac9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/double-conversion-3.1.5-hc377ac9_1.tar.bz2
   sha256: 97cc38b53813d6130d471697c8d81a4ad25b27725ceaa319a48872c9799c209c
   md5: 2321b87d960f0b87e11b090c100a6ea3
   depends:
@@ -6259,7 +6259,7 @@ packages:
   license_family: BSD
   size: 84871
   timestamp: 1628726723927
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py38hca03da5_0.tar.bz2
   sha256: f66664b97ad6248c187d4d316c7ee511b8f01a7931026c679bda943d4d6eb28f
   md5: 0428cdc3df242a4a3bdfa628838ddd0a
   depends:
@@ -6268,7 +6268,7 @@ packages:
   license_family: MIT
   size: 15098
   timestamp: 1650293803801
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.2.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.2.0-py38hca03da5_0.tar.bz2
   sha256: 310641ebbfa63719ff3b35cdd983b9c3351031cc5eab0b2b7b6d49df7304c9ed
   md5: eb78cc3f6accfccaa539169f05792c86
   depends:
@@ -6277,7 +6277,7 @@ packages:
   license_family: MIT
   size: 30667
   timestamp: 1706031410529
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-0.5.0-py38heec5a64_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fastparquet-0.5.0-py38heec5a64_2.tar.bz2
   sha256: 031bde74cce3eedcf66c0f24920618c9fda6761f92196c7045966b8e71ebaf9d
   md5: 1039effc5936c6c18aea90a5dfa598b9
   depends:
@@ -6293,7 +6293,7 @@ packages:
   license_family: Apache
   size: 178976
   timestamp: 1658500800834
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py38h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.51.0-py38h80987f9_0.tar.bz2
   sha256: 48c3079c65295ae0bc0580e28dbe4678fe93718cd27ab9021ccddf5ca21ae15e
   md5: f89a39cc1e2676e301825572410d4185
   depends:
@@ -6311,7 +6311,7 @@ packages:
   license_family: MIT
   size: 2651106
   timestamp: 1713551559037
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -6321,7 +6321,7 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.6.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2024.6.1-py38hca03da5_0.tar.bz2
   sha256: 28e233da85b3bdb00596dddf5101a9fb7d11c269c49fef411ad22a4b36982fcb
   md5: 96e90706674f64f007a04cc76b6564ef
   depends:
@@ -6332,7 +6332,7 @@ packages:
   license_family: BSD
   size: 283942
   timestamp: 1724855647496
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
   sha256: 25e05b93a99914a5fd1a298a2c5b25479fbd571b0db9caa7c6ad4336f060f62c
   md5: e213b68bb0274e0e54c610a041e059f5
   depends:
@@ -6341,7 +6341,7 @@ packages:
   license_family: BSD
   size: 150168
   timestamp: 1706888198288
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
   sha256: bbbcf47ef9249635b5199be1414b0b59687cc04ea9630d50ecc609dc200c095e
   md5: 5820c373d6847a68551cadb8984a8277
   depends:
@@ -6351,7 +6351,7 @@ packages:
   license_family: BSD
   size: 95638
   timestamp: 1706895270850
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpc-cpp-1.39.0-h95c9599_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/grpc-cpp-1.39.0-h95c9599_4.tar.bz2
   sha256: 75bb44c5d98d877628ced328bfdca3492e431ce72a062455ab6ac78395a69bff
   md5: 3a1501eedd9a32d8ecb4dcd6f73448c2
   depends:
@@ -6363,7 +6363,7 @@ packages:
   license_family: APACHE
   size: 4070563
   timestamp: 1628724381812
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-68.1-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/icu-68.1-hc377ac9_0.tar.bz2
   sha256: ec6fe8fb2533f8fae73866531ad8c93b20a2b060737d237445f115455c3ab96b
   md5: cec95fa3d8b36559af63caf4fb1f6caf
   depends:
@@ -6371,7 +6371,7 @@ packages:
   license: MIT
   size: 13742625
   timestamp: 1630597537784
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py38hca03da5_0.tar.bz2
   sha256: a508f907748131396bb44a1cca85fd0b8eee2237c29a8e23d967fe68727fd127
   md5: 732faa6938941374d108ed353740eeb2
   depends:
@@ -6380,7 +6380,7 @@ packages:
   license_family: BSD
   size: 123964
   timestamp: 1714398948249
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-7.0.1-py38hca03da5_0.tar.bz2
   sha256: ff08831e4a62c9528fbcb331c9be605d2c4e2ec2d71128793dbd87a480fd054a
   md5: 1e57a6dc02bd6f2ee3cdd70a7794f54e
   depends:
@@ -6390,7 +6390,7 @@ packages:
   license_family: APACHE
   size: 42298
   timestamp: 1704813583946
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.4.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.4.0-py38hca03da5_0.tar.bz2
   sha256: 622698b1727d55935754c257e6c3005b8c0633cb0225c4b2e994b8d7a0254cf1
   md5: 0f380b26154b0b14678d5dd9a8b66df4
   depends:
@@ -6400,7 +6400,7 @@ packages:
   license_family: APACHE
   size: 58424
   timestamp: 1720641160944
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/intake-0.6.8-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/intake-0.6.8-py38hca03da5_0.tar.bz2
   sha256: 60d9381a538cb3dfc2250a0a4281cdbe77430f4a48f1b16110e7b9808222b2f8
   md5: 8f55d7cbfb979f707c530a1f71c65d4b
   depends:
@@ -6423,7 +6423,7 @@ packages:
   license_family: BSD
   size: 191897
   timestamp: 1678787700406
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.29.5-py38hca03da5_0.tar.bz2
   sha256: 72acf602933ba769334f923f645f498eb1d052696cc961af4fdfcbfdff27c1ef
   md5: 773dbcc0f6bb909323f696c3c5076e6a
   depends:
@@ -6445,7 +6445,7 @@ packages:
   license_family: BSD
   size: 191331
   timestamp: 1728666033067
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.12.2-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.12.2-py38hca03da5_0.tar.bz2
   sha256: f7417bde08616c279e8a9d3f739d5149e05202c4d79f50cf5d7706fed80d5e94
   md5: a67b25df2a3f4e14754775388e8c7077
   depends:
@@ -6466,7 +6466,7 @@ packages:
   license_family: BSD
   size: 1242385
   timestamp: 1691532423653
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.19.1-py38hca03da5_0.tar.bz2
   sha256: fda297381d9c2da66efa9c845e4c764deaf46a16012d8a680fe4a8c510e931ee
   md5: ade737eb483390ebc89c5102190ad99f
   depends:
@@ -6476,7 +6476,7 @@ packages:
   license_family: MIT
   size: 1052301
   timestamp: 1721058391830
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.4-py38hca03da5_0.tar.bz2
   sha256: 8b0f213e785795bb63b0b4c20321b8aa4b096bbadcb624416fff81a62283c1b2
   md5: aa4c5ef07d7c3249f20f0f8575aa4606
   depends:
@@ -6488,14 +6488,14 @@ packages:
   license_family: BSD
   size: 273949
   timestamp: 1716993525900
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
   sha256: 9d5cbffa98f3a4391f66b0c5ce1f411f0bfb0eb83137dc7146fb7bae23cb3570
   md5: 95c92318023482e4e8c698ae6c4597fe
   license: IJG
   license_family: Other
   size: 274078
   timestamp: 1722872672311
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.23.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.23.0-py38hca03da5_0.tar.bz2
   sha256: 110ef5328904d5a40a40d21474d57464fedf6f92f05990814a5b2dab8af4609d
   md5: 3e01db51574132ba92d00e4d258c3171
   depends:
@@ -6510,7 +6510,7 @@ packages:
   license_family: MIT
   size: 144295
   timestamp: 1728486740994
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py38hca03da5_0.tar.bz2
   sha256: f784a7bc4378ab9fd4f6fd029c98d9c385958c8fe0e28659fcda5443230d3644
   md5: b72ba5229db3f2c52a78b6e2a6859104
   depends:
@@ -6521,7 +6521,7 @@ packages:
   license_family: MIT
   size: 15903
   timestamp: 1699032491522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py38hca03da5_0.tar.bz2
   sha256: a4b6892b15665ccf82b3d8e881f4a8ed54febb4a490ce5921277438ad154986f
   md5: fdcc463db49334d736ab371cce0a84cf
   depends:
@@ -6537,7 +6537,7 @@ packages:
   license_family: BSD
   size: 197158
   timestamp: 1676329125183
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.7.2-py38hca03da5_0.tar.bz2
   sha256: 8034378465e39aea20a186e64a37ccd4bc3128a126d819fa804f47b8aeff5b6b
   md5: eda46d70e61985ee006130b1b001eae2
   depends:
@@ -6548,7 +6548,7 @@ packages:
   license_family: BSD
   size: 83336
   timestamp: 1718818320320
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.10.0-py38hca03da5_0.tar.bz2
   sha256: 4bc9447dce7341b8dc02e6c1656aa09aaf33e35116e597c23acd53e1df8c3731
   md5: b7a9a713f82ce712aa2671d8d9564dd2
   depends:
@@ -6564,7 +6564,7 @@ packages:
   license_family: BSD
   size: 36651
   timestamp: 1718738130884
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.14.1-py38hca03da5_0.tar.bz2
   sha256: e70f6282b06199b3c4a216f95ff7cb990822066c479c9cc9f3b236b9e441fff2
   md5: a4191f11720393a3763a4bfe99136627
   depends:
@@ -6591,7 +6591,7 @@ packages:
   license_family: BSD
   size: 499781
   timestamp: 1718827351354
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py38hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py38hca03da5_1.tar.bz2
   sha256: 686fb84761ec3c869d5cd9439501c4379aaf4b387bbe6745d9d3ae109c230b33
   md5: 6e8e629672befe7ca2a80cb6b487f210
   depends:
@@ -6601,7 +6601,7 @@ packages:
   license_family: BSD
   size: 24611
   timestamp: 1686870751342
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_pygments-0.2.2-py38hca03da5_0.tar.bz2
   sha256: 0b2042dc589c647a7fc0cab57390d307f4a87567caeb1bd52279182403fc3443
   md5: 2ebc0db3cfbfe3e7a6ae4d020c143474
   depends:
@@ -6613,7 +6613,7 @@ packages:
   license_family: BSD
   size: 19911
   timestamp: 1700168711162
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py38h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py38h313beb8_0.tar.bz2
   sha256: 101c40cdf1df9e9dba602d371f2dff580f19836f3b1f7043468dbde93151efa4
   md5: 39dc576e64c3e1acb98a975530b87ac2
   depends:
@@ -6623,7 +6623,7 @@ packages:
   license_family: BSD
   size: 64180
   timestamp: 1672387223612
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
   sha256: e547a4a540ccc9db683d6d2e3e36b0d0ad99e1ad10b22b5f403af3e893b412ba
   md5: dc5ae0ece3c4990ba5fee7b266f2a019
   depends:
@@ -6634,7 +6634,7 @@ packages:
   license_family: MIT
   size: 1306804
   timestamp: 1686931342120
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -6644,7 +6644,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.73.0-h49e8a49_11.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libboost-1.73.0-h49e8a49_11.tar.bz2
   sha256: 486b171085a4676e2a5a73f6af9e08540f9156e0aa3de832552077fe15d63d7c
   md5: 99050efb6b22dc526cb246d41b3472f8
   depends:
@@ -6658,13 +6658,13 @@ packages:
   license: Boost-1.0
   size: 20047550
   timestamp: 1628697166702
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
   sha256: 199042b87451abaf14546af124ae3380194cddda928e0d30ccb341e93084854c
   md5: eaa0442887994a82486c65d87f6b71e6
   license: MIT
   size: 68806
   timestamp: 1714483212137
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
   sha256: bd9a8a17fb14086446b710fa029d238e69274b83ee2e7e09093496f190de82b5
   md5: 66615d6a0cb5dcca3e20c019cde0ed2d
   depends:
@@ -6672,7 +6672,7 @@ packages:
   license: MIT
   size: 32975
   timestamp: 1714483225840
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
   sha256: e1bf77e8b975c30a69b08a08410622e27c8cff6f592ccfa590466b83d9e6d104
   md5: 8af86bdac01fe303d693d9b76c071059
   depends:
@@ -6680,7 +6680,7 @@ packages:
   license: MIT
   size: 310266
   timestamp: 1714483239194
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
   sha256: a94cc52c1ca2e421342d2fefc6d7774ff5118b9d01f4e22d33314f8520d33723
   md5: 440575339cec83722e83087db31127bf
   depends:
@@ -6695,14 +6695,14 @@ packages:
   license_family: MIT
   size: 342121
   timestamp: 1693515586487
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
   sha256: 9597df5344a718d37837966aa05091faf210260898fad5e7a64b87f17de9e90d
   md5: 678a1f87940ef6cc421a092301b8c3fe
   depends:
@@ -6711,14 +6711,14 @@ packages:
   license_family: BSD
   size: 167208
   timestamp: 1703006281321
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
   sha256: 6fc572025852b210ecddcca3ab9ff3f1d5f6bd91f1933c6e296de6bb331f6b5d
   md5: 6dd7d9c5737bbd2a27d18f15318dc3e6
   license: BSD-2-Clause
   license_family: BSD
   size: 102059
   timestamp: 1628961869728
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-hf27765b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libevent-2.1.12-hf27765b_0.tar.bz2
   sha256: 60321df3cac6e0b97561448810d8575945e48fb0d13f1480f83733d56801223e
   md5: c9637ab2110623a8e6f5a0c0e0576029
   depends:
@@ -6727,14 +6727,14 @@ packages:
   license_family: BSD
   size: 441685
   timestamp: 1642102532464
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
   sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
   md5: f31e4eb9cd6447cc2f5ef0243a76540c
   license: MIT
   license_family: MIT
   size: 120460
   timestamp: 1714483461787
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -6743,7 +6743,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -6754,14 +6754,14 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
   sha256: 72d242814b990900c9410d4738cc685f70ea71231742293cffbb475d8df100f8
   md5: f9976688992b7ac4b56f5600ee15b5c4
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1407202
   timestamp: 1714483550601
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm11-11.1.0-h12f7ac0_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libllvm11-11.1.0-h12f7ac0_6.tar.bz2
   sha256: 6450802cad40b813a99572891811830758393500f4c79a223e1046918872c3f7
   md5: 616a6976906afa0035a2dc2ea1c34195
   depends:
@@ -6771,7 +6771,7 @@ packages:
   license_family: Apache
   size: 21766415
   timestamp: 1665076236980
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
   sha256: 039483aadb821adffcc2aff761ec35474d633b6bc2f1eb7cce877a881d7ed290
   md5: d75b21db95481154cfa9d7a871f0f3bf
   depends:
@@ -6786,7 +6786,7 @@ packages:
   license_family: MIT
   size: 743061
   timestamp: 1686931613436
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -6797,7 +6797,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -6806,7 +6806,7 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-3.17.2-h98b2900_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libprotobuf-3.17.2-h98b2900_1.tar.bz2
   sha256: 9cd490d1cd43354342449c06ca8f095a072ca176411069a43fa8ec79aa17b53f
   md5: b4c568c2d63dec6cdcf5d357c7092676
   depends:
@@ -6816,13 +6816,13 @@ packages:
   license_family: BSD
   size: 2226344
   timestamp: 1628722420059
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
   sha256: 48a8617773b57a4b9a8539782bf88a317f49a644d3f858aa0ad3ab13afc03ae7
   md5: c3bc0fb3cc9a98ef1f2f83ef497fc5da
   depends:
@@ -6831,7 +6831,7 @@ packages:
   license_family: BSD
   size: 334616
   timestamp: 1686931322663
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.13.0-hd358383_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libthrift-0.13.0-hd358383_6.tar.bz2
   sha256: 7cb7e1185aec58681f95642da63e80ac72aed29e18cacba0a309a06942d5875e
   md5: 3c2b2e2f5b18a6d583a938cd68491874
   depends:
@@ -6840,7 +6840,7 @@ packages:
   license: Apache-2.0
   size: 339509
   timestamp: 1628698596572
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.2.0-h11e2f9f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.2.0-h11e2f9f_0.tar.bz2
   sha256: 6f511d10c2685d42a517eb5b16b497e87196d96e695b71cb6a0258f7d168846a
   md5: 608d57c863b14a1db913c8b4540f451a
   depends:
@@ -6853,7 +6853,7 @@ packages:
   license: HPND
   size: 629973
   timestamp: 1630681745273
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
   sha256: 479cf759232c2361af87493ecd124e7d3a8940030e42e1931234c35bea73c3bd
   md5: cd8fe2c981594a457c6af3a0d5de0bd5
   constrains:
@@ -6862,7 +6862,7 @@ packages:
   license_family: BSD
   size: 341817
   timestamp: 1729160040909
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -6871,7 +6871,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.38.0-py38h98b2900_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.38.0-py38h98b2900_0.tar.bz2
   sha256: 0c7c08a0530765a16b54970a98b21cdfa86b3f180710847d6a285e592252e090
   md5: c16800ff23a2b9a46ff4ef21a4995265
   depends:
@@ -6882,7 +6882,7 @@ packages:
   license: BSD-2-Clause
   size: 249023
   timestamp: 1647870534530
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py38hca03da5_0.tar.bz2
   sha256: 307477ab96bae938902afb6c1689017986654464719644c6d17f85e032e44abc
   md5: 37a8e89bd4b324c309facc82bdc64941
   depends:
@@ -6891,7 +6891,7 @@ packages:
   license_family: BSD
   size: 11872
   timestamp: 1652903134672
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
   sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
   md5: f5f7e6e7541d8dc3d3df270d488d2e24
   depends:
@@ -6900,7 +6900,7 @@ packages:
   license_family: BSD
   size: 176990
   timestamp: 1714510588159
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py38hca03da5_0.tar.bz2
   sha256: 2c34852ea6fe459fc4e892f2b3c43cb22093c66bb0dd4c7a577affef3c1ad350
   md5: 9fd19f5fc3dc04e95a205552307c4316
   depends:
@@ -6910,7 +6910,7 @@ packages:
   license_family: BSD
   size: 123564
   timestamp: 1671541934866
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py38h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py38h80987f9_0.tar.bz2
   sha256: 4634fd37c3d8f59513a161a77f0b321c70e1c2071a072e3df07078763b87d756
   md5: 3625d24a3da36877ad3b544ba36f59f3
   depends:
@@ -6921,7 +6921,7 @@ packages:
   license_family: BSD
   size: 24237
   timestamp: 1704206125570
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.7.2-py38h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.7.2-py38h46d7db6_0.tar.bz2
   sha256: eba3eda0b2737e4f41e1cabf9ffcdd3acd17ef999434bf1d1b2427a1c6aa13fb
   md5: a1c7b52fb0f692f252786792cc2d1a21
   depends:
@@ -6944,7 +6944,7 @@ packages:
   license_family: PSF
   size: 7945401
   timestamp: 1693812744579
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py38hca03da5_0.tar.bz2
   sha256: 8ed7b59ced736b2c2dca4bf793fd22071920847c7c009ae08215618e0cf9634e
   md5: 0b7e6805f36a34f1fc27b8230830f22d
   depends:
@@ -6954,7 +6954,7 @@ packages:
   license_family: BSD
   size: 17305
   timestamp: 1662014548083
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py38hca03da5_0.tar.bz2
   sha256: b4275ded138c6ce902d42866827734fbd5fe65efb43f15e28481e1f26f893ba5
   md5: d8af1a41be60a01c137b64f607e5a81d
   depends:
@@ -6965,7 +6965,7 @@ packages:
   license_family: BSD
   size: 90753
   timestamp: 1661496288720
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py38h525c30c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/msgpack-python-1.0.3-py38h525c30c_0.tar.bz2
   sha256: ea6e79e88ff83790d1ce7dd4f77cd46a8904cfba65f8e1bd6ffee33bcc855373
   md5: 800b92ae3bbeae2f1e5374cfb2d05895
   depends:
@@ -6975,7 +6975,7 @@ packages:
   license_family: Apache
   size: 83473
   timestamp: 1652362704023
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py38hca03da5_0.tar.bz2
   sha256: 32ca9f80183284c18f43c656f85ce1ee6b367db95373afacaa9d8ee4d4f47781
   md5: 3bcae7fb685499f69ac281f0f2370679
   depends:
@@ -6985,7 +6985,7 @@ packages:
   license_family: BSD
   size: 23009
   timestamp: 1629282754789
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-1.1.0-py38hca03da5_0.tar.bz2
   sha256: 4e11e578aabb2026e95fd7d36f03807236c60a2d4560c74b3ea10cdb03e5b6ea
   md5: 87c6582d4115677d2c27f3868256731b
   depends:
@@ -6998,7 +6998,7 @@ packages:
   license_family: BSD
   size: 8254608
   timestamp: 1717623018829
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py38hca03da5_0.tar.bz2
   sha256: adf787ddce8532e7a46e3feab3f6564a202832aef03a0c1094afb3dddb050b12
   md5: 556fe6d9e904476dbaff8c8f04417125
   depends:
@@ -7011,7 +7011,7 @@ packages:
   license_family: BSD
   size: 100614
   timestamp: 1698934298210
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.4-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.16.4-py38hca03da5_0.tar.bz2
   sha256: 701d58560c331403e20c42d9601850b30f9e78500681ae5f5698a46de6bc584e
   md5: 55094ecec7635c91ad5f04b03078db8f
   depends:
@@ -7039,7 +7039,7 @@ packages:
   license_family: BSD
   size: 487310
   timestamp: 1728049463745
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.10.4-py38hca03da5_0.tar.bz2
   sha256: a83c85cc61e1332883676cfa4898ae9d7f73efba9255ef25378196e8afef006a
   md5: a095073d4cccaa0b71b2793373d93a48
   depends:
@@ -7052,14 +7052,14 @@ packages:
   license_family: BSD
   size: 148914
   timestamp: 1728049459080
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py38hca03da5_0.tar.bz2
   sha256: 4a6267fbf767cc385c0732b993dfec44880fc68d08b4d3fddb80bebbd3ef704d
   md5: 9507b7eb054874fefa67e35d37076378
   depends:
@@ -7068,7 +7068,7 @@ packages:
   license_family: BSD
   size: 14353
   timestamp: 1708532749964
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.7-py38hca03da5_0.tar.bz2
   sha256: 10d1928d0a260ae041391c76e5a514de992fab696e3a69638b0250e01d8ca6a3
   md5: 838bbdf9615c7095293a6e37a1e45d55
   depends:
@@ -7093,7 +7093,7 @@ packages:
   license_family: BSD
   size: 590395
   timestamp: 1717630909286
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py38hca03da5_0.tar.bz2
   sha256: 76ae630b0ba82cd152d6a2c8b192c2d7c92cd1edef5a8d00e48d6451294443d5
   md5: 8acf1b7ef6217c23492a1f96c960d2c0
   depends:
@@ -7103,7 +7103,7 @@ packages:
   license_family: BSD
   size: 23456
   timestamp: 1699456018740
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.55.1-py38h9197a36_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numba-0.55.1-py38h9197a36_0.tar.bz2
   sha256: 0a96640ac2b62e64f14be7669adffd2a3ea23ec5acecacbdd185f8b57311ef7c
   md5: caffb2954404712119d0fb4e4c4298b4
   depends:
@@ -7122,7 +7122,7 @@ packages:
   license_family: BSD
   size: 3949466
   timestamp: 1648041424485
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.4-py38h79ee842_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.4-py38h79ee842_1.tar.bz2
   sha256: 09acb2d02a5cf5fb8b10252aba95cbc1efc2a95c43f4b81710dc23542ef3c4d3
   md5: 23a179a3a80b2ec7c4e2ec6b9055210a
   depends:
@@ -7133,7 +7133,7 @@ packages:
   license_family: MIT
   size: 122400
   timestamp: 1683221874476
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.21.6-py38hb93e574_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.21.6-py38hb93e574_1.tar.bz2
   sha256: cc3f4442cfc670eac18e5e9ae8748c52c67442a9a9aaa06e515fbbcec738d3cd
   md5: a22ecfcfb22c78874d5a926648c39140
   depends:
@@ -7146,7 +7146,7 @@ packages:
   license_family: BSD
   size: 11572
   timestamp: 1715092856174
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.21.6-py38haf87e8b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.21.6-py38haf87e8b_1.tar.bz2
   sha256: e4cd2b6ac40ad3ea9ef8041874987403040de0b4e872acf8c4f241f1cd54d7e0
   md5: d5adaf69f53bfd3d244a479122766441
   depends:
@@ -7160,7 +7160,7 @@ packages:
   license_family: BSD
   size: 5634222
   timestamp: 1715092844625
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.4.0-h0ed58ac_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.4.0-h0ed58ac_2.tar.bz2
   sha256: 4525a4cd7dfca8166bbb79901dda003d702709a2d18c91aa0f99971a38c2d26b
   md5: f6b519d5bcdee6a12e3c502a8d32d1e3
   depends:
@@ -7171,7 +7171,7 @@ packages:
   license_family: BSD
   size: 398391
   timestamp: 1720655561402
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
   sha256: 409ba99dd953129c0ccebb5dcbf2049920e5a755b88e7e392e4f91be924e26ef
   md5: f05f00606c10617a61c41f23652b9a00
   depends:
@@ -7180,7 +7180,7 @@ packages:
   license_family: Apache
   size: 3450897
   timestamp: 1694465216241
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-1.6.9-hb65cfe6_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/orc-1.6.9-hb65cfe6_2.tar.bz2
   sha256: 727b0fd0fe3931e0533163117371bb15a330f426527b4d3fcf5a8161b161d662
   md5: 0723387d2a25e32a4dfc5c26f71470eb
   depends:
@@ -7193,7 +7193,7 @@ packages:
   license_family: Apache
   size: 395216
   timestamp: 1628726496508
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py38hca03da5_0.tar.bz2
   sha256: e657a6896930e27bd599c8f910cf3ee2a48e7268df40852df6aebbe8f7372f98
   md5: 1bd77f6090aafa15b1298b62fdb0f4e3
   depends:
@@ -7202,7 +7202,7 @@ packages:
   license_family: APACHE
   size: 31785
   timestamp: 1699371166226
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-24.1-py38hca03da5_0.tar.bz2
   sha256: 7c1c21869595db9155b6533f65621216e69fb356262462e3ab68007cb164cef0
   md5: 35c62f901fa3146e0788ba3f6771930a
   depends:
@@ -7211,7 +7211,7 @@ packages:
   license_family: Apache
   size: 135755
   timestamp: 1720101953462
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-1.5.3-py38h78102c4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-1.5.3-py38h78102c4_0.tar.bz2
   sha256: 7978b817632759b250df429e7126dd060a25f737c8f1b1e0b3e738e2e837f83a
   md5: d0a4733ea677c7fc44e0f734c4d71173
   depends:
@@ -7257,7 +7257,7 @@ packages:
   license_family: BSD
   size: 12897659
   timestamp: 1677852540117
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py38hca03da5_0.tar.bz2
   sha256: 682c8a19b724a018aed66ec0230abafa6b965c7d559bdf6e4f0cdd66d742fa0b
   md5: 4f04ec230eca5cca5c8f3b7905d4babb
   depends:
@@ -7271,7 +7271,7 @@ packages:
   license_family: BSD
   size: 36423
   timestamp: 1698702661554
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.4.0-py38h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.4.0-py38h80987f9_0.tar.bz2
   sha256: f7e6fd55efa1cc7b9382f120259f0908a2eb08821198f8a60749959dd653a34d
   md5: 484fadaaf73b93083cafb78b82e3845e
   depends:
@@ -7287,7 +7287,7 @@ packages:
   license_family: Other
   size: 774844
   timestamp: 1721059629077
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.2-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-24.2-py38hca03da5_0.tar.bz2
   sha256: 542299bd98725d1ff099492364f1815b393eb7a93969203331f7b38cfd76bf07
   md5: d7fc6193b0382d675516c8a2ac117a0b
   depends:
@@ -7298,7 +7298,7 @@ packages:
   license_family: MIT
   size: 2268520
   timestamp: 1723484744931
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pkgutil-resolve-name-1.3.10-py38hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pkgutil-resolve-name-1.3.10-py38hca03da5_1.tar.bz2
   sha256: fedc4ab0ed057e5cc494b93199a04238bee875262b884b8fdf3e7e6b5fcfbd1f
   md5: 446f233dffdb852c88e7c25240aecad2
   depends:
@@ -7307,7 +7307,7 @@ packages:
   license_family: PSF
   size: 11424
   timestamp: 1704297549606
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py38hca03da5_0.tar.bz2
   sha256: d97cb927d800e9a447c2b9e0983b0518d7f41b6c5947e62075f4bb5fe9fa3569
   md5: 5d344c031b607858aac0263ee037f1a0
   depends:
@@ -7316,7 +7316,7 @@ packages:
   license_family: MIT
   size: 33041
   timestamp: 1692205775190
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pooch-1.7.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pooch-1.7.0-py38hca03da5_0.tar.bz2
   sha256: 7447015165bf9b11fb4b6c839e95f2978ac012301d843aa79a5eb3a180d72cae
   md5: 5e0595b52a068b93fbc91a22480535fc
   depends:
@@ -7332,7 +7332,7 @@ packages:
   license_family: BSD
   size: 82434
   timestamp: 1695850137461
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py38hca03da5_0.tar.bz2
   sha256: 41dadbf05754b86a3323059a67742e4d4fee178661d92705ef496ea14cd91d66
   md5: e55ee42cc29c11809f568d8d1cf4747c
   depends:
@@ -7341,7 +7341,7 @@ packages:
   license_family: Apache
   size: 91074
   timestamp: 1659455126069
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py38hca03da5_0.tar.bz2
   sha256: 82e9c96b00a5df66f065910354275a72252b134e88471f61313a583d0f2a7a6d
   md5: db5c82c2e4e896a9dee28c63f479a3b5
   depends:
@@ -7353,7 +7353,7 @@ packages:
   license_family: BSD
   size: 577739
   timestamp: 1704404418283
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py38h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py38h1a28f6b_0.tar.bz2
   sha256: 3c5bd50929a4aa13c72095653118fd7cc44053bbe80949fd9f78d6bc78128487
   md5: cc9daac414bf6d0fc28087deceeeb54d
   depends:
@@ -7362,7 +7362,7 @@ packages:
   license_family: BSD
   size: 366992
   timestamp: 1656431324712
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-4.0.1-py38hd776c02_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyarrow-4.0.1-py38hd776c02_3.tar.bz2
   sha256: 435dcfe0ba89e22ebecdac0cbd1ca510af4995f185281f00c90bac912f384afe
   md5: 1999261b72f05788afc91efb8478c6fa
   depends:
@@ -7381,7 +7381,7 @@ packages:
   license_family: Apache
   size: 2289517
   timestamp: 1629806264952
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py38hca03da5_0.tar.bz2
   sha256: 8d542e0301f4692b0810d9c6143400ac24ffe65c1c5276fb9167c9dd6dcfd894
   md5: a1b3ddffe3d0dfde327191c5a1d2d26f
   depends:
@@ -7393,7 +7393,7 @@ packages:
   license_family: BSD
   size: 30761
   timestamp: 1675441503308
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py38hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py38hca03da5_1.tar.bz2
   sha256: aa6b41d2921130aed4630653e555fd90f4531970297e8b3a434f9d6dc2357294
   md5: b0ba357ab09318153b94d105a7863e3b
   depends:
@@ -7402,7 +7402,7 @@ packages:
   license_family: BSD
   size: 1887242
   timestamp: 1684279996873
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py38hca03da5_0.tar.bz2
   sha256: 3e4fed535277fc9d94c53d717ca10e7faf1d051f4d2fcefb1a02cd0e84585bc6
   md5: 156fde9f3f56a6b1b9cb7b8020748288
   depends:
@@ -7411,7 +7411,7 @@ packages:
   license_family: MIT
   size: 157834
   timestamp: 1661452633325
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py38hca03da5_0.tar.bz2
   sha256: 47d308dd037d9373cf00b341a34ad2cb2d2f2dbb06d3ac5e59ef05d3ec81b3bb
   md5: 6f20c9bfe7585ae23ec10ea950553603
   depends:
@@ -7420,7 +7420,7 @@ packages:
   license_family: BSD
   size: 27337
   timestamp: 1626781365102
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.8.18-hc0d8a6c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.8.18-hc0d8a6c_0.tar.bz2
   sha256: b8fe0d51772aebcd4664f4faba55a3ca42b0ae7b4a3261b955c0e260dee0f6d1
   md5: 40ca48fa679cca7093e7bf37bae3ea07
   depends:
@@ -7438,7 +7438,7 @@ packages:
   license_family: PSF
   size: 15400446
   timestamp: 1694438953629
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py38hca03da5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py38hca03da5_2.tar.bz2
   sha256: 41f88ff1be9938bcdcb16a540c075b31de446d6016e7983ad808996a735bbdea
   md5: 8002b4dbdf9f70089c6fa0c97665708a
   depends:
@@ -7448,7 +7448,7 @@ packages:
   license_family: BSD
   size: 289646
   timestamp: 1716495792628
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py38hca03da5_0.tar.bz2
   sha256: ad379c6a9b647dd1606107456d005228027d3c92e0fc55fcf47861df4527e46c
   md5: 12b99cac3003bc54b23d599c9999a8c4
   depends:
@@ -7457,7 +7457,7 @@ packages:
   license_family: BSD
   size: 266004
   timestamp: 1661368815072
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-2.0.7-py38hca03da5_0.tar.bz2
   sha256: e137e80a106edbc2022b1f97486cad410964f4a441b3af51edcfcb8ad44a79c2
   md5: b18235f9fe5703c71919675cf48ab64e
   depends:
@@ -7466,7 +7466,7 @@ packages:
   license_family: BSD
   size: 16216
   timestamp: 1683823878940
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py38h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-lmdb-1.4.1-py38h313beb8_0.tar.bz2
   sha256: 7bb699635692c6b113d9ae0b6278026f33721b0af581d2012b3ae12452ef0299
   md5: b924257ab4a27121bdebb03f8145ca67
   depends:
@@ -7476,7 +7476,7 @@ packages:
   license_family: Other
   size: 136234
   timestamp: 1682522529684
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-snappy-0.6.1-py38h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-snappy-0.6.1-py38h313beb8_0.tar.bz2
   sha256: c8c0be587dbbbf2ddf82f89dc467cf5f7b04f0681d039fa4339d46f93aad2b4c
   md5: 86015e59fdf126735b3883215090605d
   depends:
@@ -7487,7 +7487,7 @@ packages:
   license_family: BSD
   size: 31988
   timestamp: 1670944029362
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py38hca03da5_0.tar.bz2
   sha256: 8a7c66044c09cd88710e6203e8d08d7610af303ffe33e04704561e2f31167070
   md5: 8c596a7bbd3dcbd778895b2067cb8616
   depends:
@@ -7496,7 +7496,7 @@ packages:
   license_family: MIT
   size: 263184
   timestamp: 1713974341209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.2-py38hca03da5_0.tar.bz2
   sha256: 0d8a57ff7231fa121da3a10f898f143bfb9cb5cf7eca7b4517cb9f5eddc215ba
   md5: 4c584d908fdd1ed46f52d7da71b0e64a
   depends:
@@ -7508,7 +7508,7 @@ packages:
   license_family: BSD
   size: 61647
   timestamp: 1711136973061
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.2-py38h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.2-py38h80987f9_0.tar.bz2
   sha256: 37772c03d7b07ddeac464f53082bb242a09646f2afab652632b2b62afacbb47d
   md5: 66c894f8f96e0ae8ee41ffc1e9b749e4
   depends:
@@ -7518,7 +7518,7 @@ packages:
   license_family: MIT
   size: 174515
   timestamp: 1728658192597
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py38h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-24.0.1-py38h80987f9_0.tar.bz2
   sha256: 267226c5c0d201a0af1504195996b72500ec9032eb00f1bbdeacab181a8c4ba9
   md5: 915661c8ddc03d019ae838014dae6751
   depends:
@@ -7528,7 +7528,7 @@ packages:
   license_family: Other
   size: 492414
   timestamp: 1709318397182
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
   sha256: 089c6b9bebfa690f380710f219ab0fcc1acec9f2e187d4174a08222c45f58afc
   md5: 11b832c6c10a6d2b0e687a20c3037c97
   depends:
@@ -7536,7 +7536,7 @@ packages:
   license: BSD-3-Clause
   size: 194532
   timestamp: 1652449531448
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -7545,7 +7545,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py38hca03da5_0.tar.bz2
   sha256: fa7d3b858bc4aaedc8e4677a9a9be4f028c8f7ea40b1ecf347f77ea5be549efc
   md5: 2f06c17502cd018dd3c59de09be9462c
   depends:
@@ -7556,7 +7556,7 @@ packages:
   license_family: MIT
   size: 58821
   timestamp: 1699012156655
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.32.3-py38hca03da5_0.tar.bz2
   sha256: a4ebbee44103435a3ef216810441b5768b24ae2ea1a8fb6aeefbb9e048733a36
   md5: 53e5f7207000f7127428fff746f4dcbf
   depends:
@@ -7572,7 +7572,7 @@ packages:
   license_family: Apache
   size: 98381
   timestamp: 1721414901875
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-toolbelt-1.0.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-toolbelt-1.0.0-py38hca03da5_0.tar.bz2
   sha256: 36c9437965619412e17244b47c9e3b3ca641654c29925d45ab7f732c20120668
   md5: a19fd003f158986ddcc9d05b3aed4d44
   depends:
@@ -7582,7 +7582,7 @@ packages:
   license_family: Apache
   size: 69842
   timestamp: 1690874029512
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py38hca03da5_0.tar.bz2
   sha256: 93971fe5d4da96fe249ffc24fa02fd133ffd1a6c418b952818cd321e92d0bd25
   md5: aaf80726c3917533c8de574b61257c62
   depends:
@@ -7592,7 +7592,7 @@ packages:
   license_family: MIT
   size: 9831
   timestamp: 1683077167663
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py38hca03da5_0.tar.bz2
   sha256: d747131e1149e5a925f71062cc83055a3cddb9dd0294c7a7c8e945b94b258ac7
   md5: ed9d9a90ee3b3d4f882b37beacd201b7
   depends:
@@ -7601,7 +7601,7 @@ packages:
   license_family: MIT
   size: 10207
   timestamp: 1683059108876
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py38hf0e4da2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py38hf0e4da2_0.tar.bz2
   sha256: 992b4cabaed63572d9464581d79be13185a1a73acbdcf5dd1c206d7401ef8ebc
   md5: f3ada05e3a42a31dac9a296231a233da
   depends:
@@ -7610,7 +7610,7 @@ packages:
   license_family: MIT
   size: 342736
   timestamp: 1698946135494
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel.yaml.clib-0.2.8-py38h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ruamel.yaml.clib-0.2.8-py38h80987f9_0.tar.bz2
   sha256: aca8f39c5c4fa7a351e1f008b6829d8dbe3de693312ad76f4a374571fe51d638
   md5: 1d37f1dc1bd231f14fcefadb580d44b9
   depends:
@@ -7619,7 +7619,7 @@ packages:
   license_family: MIT
   size: 137906
   timestamp: 1727769950470
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel_yaml-0.17.21-py38h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ruamel_yaml-0.17.21-py38h1a28f6b_0.tar.bz2
   sha256: deac6268ce178b4468f78941c19b725c4209be5d1b3bc0f035991f2344b9dada
   md5: 58a0f98d894a5d27d6541bfe0e56f05c
   depends:
@@ -7629,7 +7629,7 @@ packages:
   license_family: MIT
   size: 173669
   timestamp: 1667489769162
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.10.1-py38h9d039d2_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.10.1-py38h9d039d2_1.tar.bz2
   sha256: c8d2d402fba9c78ee8ae329e578ef43ace1b1915b4241dc7d17695965ec22cef
   md5: 2729777751cf61baa4f46afb04e60869
   depends:
@@ -7646,7 +7646,7 @@ packages:
   license_family: BSD
   size: 23732952
   timestamp: 1683287971462
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py38hca03da5_0.tar.bz2
   sha256: 4e66c129581eb6bdc2e1d0c53f6e553a13ffccac2e0ba16279b9ea98e8046abd
   md5: 60ff2d59453516f7b71d81f08edbbbbc
   depends:
@@ -7655,7 +7655,7 @@ packages:
   license_family: BSD
   size: 27867
   timestamp: 1699371166275
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-60.9.3-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-60.9.3-py38hca03da5_0.tar.bz2
   sha256: 203159876cea0cb8272a8e2474a69b3397b85be1c5581708c55baa11e499345c
   md5: 9053ec6629f2dde2b3f6dd8e1e0cfc8b
   depends:
@@ -7664,7 +7664,7 @@ packages:
   license_family: MIT
   size: 1234476
   timestamp: 1685710970693
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
   sha256: 499623019bea7cd167924f7fa841237b11b81a1e9cafe9b8ffde47d329275167
   md5: 290d04cffc69bf26a4ed9f1aa9ad42e4
   depends:
@@ -7673,7 +7673,7 @@ packages:
   license_family: BSD
   size: 46038
   timestamp: 1723557442909
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py38hca03da5_0.tar.bz2
   sha256: d6bb01a559093b9d5db71368c89d70aefbeae33306bdf3dc35f5f11be44972ea
   md5: f1989d879f942c875fd029d0946a9e98
   depends:
@@ -7682,7 +7682,7 @@ packages:
   license_family: Other
   size: 17804
   timestamp: 1705431317307
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py38hca03da5_0.tar.bz2
   sha256: 66064f3ee63df60cf0daa216111ce1aee0273a18b1eedf9ea72c96d49aaba5f2
   md5: e20848a40ca8adb4f4eb05eeecef05a6
   depends:
@@ -7691,7 +7691,7 @@ packages:
   license_family: MIT
   size: 67344
   timestamp: 1696347585538
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
   sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
   md5: d8c1e9910392d0bcb22a173f9ce30fa6
   depends:
@@ -7703,7 +7703,7 @@ packages:
   license_family: Other
   size: 1758290
   timestamp: 1714488307689
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
   sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
   md5: ae58720a18a2ed15eae214ad7a10d1b5
   depends:
@@ -7712,7 +7712,7 @@ packages:
   license_family: Apache
   size: 140125
   timestamp: 1680167256603
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py38hca03da5_0.tar.bz2
   sha256: 633b552e3b2851778474918745474012c24478028d9199b7e70b405b49edec80
   md5: 21b71f9ea2e65e770b6703a71c6d1768
   depends:
@@ -7723,7 +7723,7 @@ packages:
   license_family: BSD
   size: 30932
   timestamp: 1671751893456
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/thrift-0.17.0-py38hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/thrift-0.17.0-py38hc377ac9_0.tar.bz2
   sha256: 80fdd145ab10c9d3d98845bd46a9ca8ba6e84611f9f1b50462e44cebfb52918c
   md5: 6823d96b30037e7152accd6839e6bf0a
   depends:
@@ -7734,7 +7734,7 @@ packages:
   license_family: APACHE
   size: 126231
   timestamp: 1666296572296
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py38hca03da5_0.tar.bz2
   sha256: 2626c19604e8a205eb1f91d0e4236b569560b174405497540189997012f36002
   md5: 782d9a537331c94371690bdf3ee55b22
   depends:
@@ -7744,7 +7744,7 @@ packages:
   license_family: BSD
   size: 40306
   timestamp: 1668168901778
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
   sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
   md5: 3c25b4f4768ccda28b20a03ba27e7759
   depends:
@@ -7753,7 +7753,7 @@ packages:
   license_family: BSD
   size: 3484151
   timestamp: 1714770744982
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py38hca03da5_0.tar.bz2
   sha256: 02190c624d356a6ad7b6dba56a32fd33f4cf94ab5c1f087869be84718791487b
   md5: 7fdd7e3d9b70d446d35425ed13e9c536
   depends:
@@ -7762,7 +7762,7 @@ packages:
   license_family: BSD
   size: 102470
   timestamp: 1667464107289
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.1-py38h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.4.1-py38h80987f9_0.tar.bz2
   sha256: be634f2409dce7960f17fccd1241c123a5dc692838290039844c2ed6f44aa702
   md5: c0537c090585f03336fd8896095f2811
   depends:
@@ -7771,7 +7771,7 @@ packages:
   license_family: Apache
   size: 691093
   timestamp: 1718740173610
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.5-py38h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.66.5-py38h33ce5c2_0.tar.bz2
   sha256: 27aaba649b3445b76666c7d8137e817325652e9a8032a46d03eb5de3b79eac5b
   md5: ca4786226af4cb4d62f2d5bfcbcf4622
   depends:
@@ -7782,7 +7782,7 @@ packages:
   license_family: MOZILLA
   size: 127294
   timestamp: 1724854139658
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.14.3-py38hca03da5_0.tar.bz2
   sha256: d8889a05a34b398d5da8c5352344a4c6a08d129116e7e15d0ed99235ba324df8
   md5: b2e9152fb770ae8ad72ee9c5a8bdc3d8
   depends:
@@ -7791,7 +7791,7 @@ packages:
   license_family: BSD
   size: 166133
   timestamp: 1718227174920
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.11.0-py38hca03da5_0.tar.bz2
   sha256: 27ddb99ddf9d8bac997e1ca6f0a2ce46dd20609ed92eb6a35e91f73e7481401d
   md5: 85be9d34a417d69e18cfc18e7d983099
   depends:
@@ -7801,7 +7801,7 @@ packages:
   license_family: PSF
   size: 9867
   timestamp: 1715268872086
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.11.0-py38hca03da5_0.tar.bz2
   sha256: 9d8eff664fd8d2b0f05365e2dd36474bcb27b9c307dd9c72228413e72104e61e
   md5: 662b1da1ffc40d344a13ffda65e1b408
   depends:
@@ -7810,7 +7810,7 @@ packages:
   license_family: PSF
   size: 61167
   timestamp: 1715268862691
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py38h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py38h80987f9_0.tar.bz2
   sha256: 52bd150b9ce7947062a034b72de3d714c972e5c30f995498b1c2e210ffcf5fdc
   md5: 0833ec866761890dd3676188ca2b0d44
   depends:
@@ -7819,14 +7819,14 @@ packages:
   license_family: Apache
   size: 517952
   timestamp: 1713213106526
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uriparser-0.9.7-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uriparser-0.9.7-h80987f9_0.tar.bz2
   sha256: c7402bdd16743bbd3350752e7009e40024b7ea2d280f54a6f74a4246f99e0edf
   md5: 666f1bc2359d58c32ccbcbf4e9fcadd7
   license: BSD-3-Clause
   license_family: BSD
   size: 42998
   timestamp: 1692186946914
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.3-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.2.3-py38hca03da5_0.tar.bz2
   sha256: 1fde07cc5797259f6ae7e852889ffbf3d23041921e1c6a9a5c6f40980ac9d183
   md5: 41dc4cb2907f51a37879f22209300222
   depends:
@@ -7842,14 +7842,14 @@ packages:
   license_family: MIT
   size: 171705
   timestamp: 1727769851662
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
   sha256: 20ae100fd04de16356f26e7c9dab514015e57a9d54fb78767aa5ed97de7846fb
   md5: f620d98b3d0072945948310c86f0f1c5
   license: MIT
   license_family: MIT
   size: 157385
   timestamp: 1706894678643
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py38hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py38hca03da5_1.tar.bz2
   sha256: 82c0d07ca88c806b0816e8f4d5f79d24d8c373cc758ff06b1ad9976257162e67
   md5: 07036a73e921ca173dcabcff9321c34d
   depends:
@@ -7858,7 +7858,7 @@ packages:
   license_family: BSD
   size: 20079
   timestamp: 1629144417239
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py38hca03da5_0.tar.bz2
   sha256: 9c53db1b26bbf44492aab1e3ad33626e71e6b60a860d8b6c39947f243865d8b1
   md5: 3fc0071c22c57e32c9a8e28c676ddebe
   depends:
@@ -7867,7 +7867,7 @@ packages:
   license_family: Apache
   size: 87386
   timestamp: 1715878426593
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.44.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.44.0-py38hca03da5_0.tar.bz2
   sha256: 05bd35ece727f081d7451648f66e3060c91d5134ee53ba992b20e933cf882160
   md5: 752673e61de53f3190be492a804b45c7
   depends:
@@ -7876,7 +7876,7 @@ packages:
   license_family: MIT
   size: 105309
   timestamp: 1726165145323
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2022.11.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xarray-2022.11.0-py38hca03da5_0.tar.bz2
   sha256: fbbc84d300a1f4ad3019d0c5828c77440f8dfe684458e4d573030d5fa5c525d8
   md5: d77d04cfa8a09aabf3f44f1c78a4f433
   depends:
@@ -7888,7 +7888,7 @@ packages:
   license_family: Apache
   size: 1722966
   timestamp: 1668776739525
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py38hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py38hca03da5_1.tar.bz2
   sha256: fe2c19f54551b7ef1c3a5b33dec3125db65ced3cacd187c19004fcd0c3c96213
   md5: 58f495f8dc56ed6bf8533c8cfa7ca5bf
   depends:
@@ -7897,20 +7897,20 @@ packages:
   license_family: BSD
   size: 49427
   timestamp: 1675159104659
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
   sha256: 5be8c968f2da5c4bf14f28d63e31b4c1b6993d980023769732c7f58f396c2e0b
   md5: 3f5f62d4e85e3bdd48d39189b01805a6
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 459197
   timestamp: 1714510992914
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
   sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
   md5: 3d57d1adadca9388aaaa1c529b65ba65
   depends:
@@ -7920,7 +7920,7 @@ packages:
   license_family: Other
   size: 322790
   timestamp: 1705602163804
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zict-3.0.0-py38hca03da5_0.tar.bz2
   sha256: 75240abcfd39c449374aa916e1aa01e0758bae5f8532520568728a5670141696
   md5: 4eee6619cd3939d8fc2d881c21f4c248
   depends:
@@ -7931,7 +7931,7 @@ packages:
   license_family: BSD
   size: 77607
   timestamp: 1695832873064
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.20.2-py38hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.20.2-py38hca03da5_0.tar.bz2
   sha256: bbb4125e7639b8a5ae8c290f261f3ebdd24479f312aaf38f83011a1282d039e2
   md5: b8de52e13dacda97339139bf981a6d44
   depends:
@@ -7940,14 +7940,14 @@ packages:
   license_family: MIT
   size: 26146
   timestamp: 1729012401220
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
   sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
   md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
   license: Zlib
   license_family: Other
   size: 104928
   timestamp: 1714510936868
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstandard-0.19.0-py38h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstandard-0.19.0-py38h80987f9_0.tar.bz2
   sha256: 9bd2da6a9d9485365fbf6b12ab9c5f122cbeb78816df5a3fad27481638b507cb
   md5: 84c762a0604f8ef4ef55ae876d74a450
   depends:
@@ -7957,7 +7957,7 @@ packages:
   license_family: BSD
   size: 587117
   timestamp: 1677013818820
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.4.9-h8574219_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.4.9-h8574219_1.tar.bz2
   sha256: 10ea544b7e6e01215a261f44984988ffad408dad2f242a6a8c81148f9c814a20
   md5: 1bb8a29937652e6aaac6fa2d698093f5
   depends:
@@ -7968,7 +7968,7 @@ packages:
   license: BSD 3-Clause
   size: 738884
   timestamp: 1629301647081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-anon-usage-0.4.4-py38hfc23b7f_100.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anaconda-anon-usage-0.4.4-py38hfc23b7f_100.tar.bz2
   sha256: f6c1893483d42f35d337dabb31aa035196eb635974886ff7bf3cc9e08a85b1c5
   md5: e6e2a7fff3b385971a103d91113d49c7
   depends:
@@ -7980,7 +7980,7 @@ packages:
   license_family: BSD
   size: 24734
   timestamp: 1710965553924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-client-1.12.3-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anaconda-client-1.12.3-py38haa95532_0.tar.bz2
   sha256: 6ac864345954e4ee3639d7a30b266d5931a221aeac8cde33e65704bff2e88f96
   md5: e1c3ba37f4fa34ee67c50801c96f420e
   depends:
@@ -8003,7 +8003,7 @@ packages:
   license_family: BSD
   size: 167108
   timestamp: 1708641386095
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-project-0.11.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anaconda-project-0.11.1-py38haa95532_0.tar.bz2
   sha256: b65f6c130e7e0a9b05c9c8fc6241afae418defe8719dbbd1396aed5d5befd547
   md5: 8002dc76c531873a826d7a5a94b89432
   depends:
@@ -8019,7 +8019,7 @@ packages:
   license_family: BSD
   size: 564785
   timestamp: 1660340170214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-4.2.0-py38haa95532_0.tar.bz2
   sha256: 3d0035b5e9cd3f60305ebf4187cdff92c9645923fd77fa22471036805ec456ee
   md5: 275f0773468598c4cc07466550dc6a04
   depends:
@@ -8035,7 +8035,7 @@ packages:
   license_family: MIT
   size: 174407
   timestamp: 1706220863088
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py38h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py38h2bbff1b_0.tar.bz2
   sha256: 03266238128a35b764faac4b242317894abfbd6aa87926925d742fe777540501
   md5: c69fc290a38779ea332ed0706d58b8e5
   depends:
@@ -8047,7 +8047,7 @@ packages:
   license_family: MIT
   size: 39205
   timestamp: 1644569956444
-- conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-4.0.1-py38h0d1d0e5_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/arrow-cpp-4.0.1-py38h0d1d0e5_3.tar.bz2
   sha256: 9306f5d5d57580f39292827b9f91f6ab7b8a6ea8eeb3aae278ffb6bc9cc4f279
   md5: fd6efa3f258e456117c49d5ebb9189da
   depends:
@@ -8078,7 +8078,7 @@ packages:
   license_family: Apache
   size: 5591239
   timestamp: 1622568685233
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-24.2.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-24.2.0-py38haa95532_0.tar.bz2
   sha256: 479d27dd9acc222ebf5e61a280e72d5831659bd239ff5d379992189b91de241e
   md5: d8cb2df09f080f155289683ecf27cfce
   depends:
@@ -8087,7 +8087,7 @@ packages:
   license_family: MIT
   size: 142137
   timestamp: 1729089722587
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.4.57-ha925a31_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-common-0.4.57-ha925a31_1.tar.bz2
   sha256: 91a78979ae6c1f5ff02dd1076aa62e2da7e610647203cd8985e0ea25465f2a74
   md5: 7878a5b35caf8db44fffffe0ba320951
   depends:
@@ -8097,7 +8097,7 @@ packages:
   license_family: Apache
   size: 155676
   timestamp: 1601398472136
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.1.6-hd77b12b_5.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-event-stream-0.1.6-hd77b12b_5.tar.bz2
   sha256: 08437ce1c93997e5f5e8a6a7a8835b9b3a96d8be97c7752644fc9b2ae9788c8e
   md5: 1883d49fb78e0858f007a73e042e5c3a
   depends:
@@ -8109,7 +8109,7 @@ packages:
   license_family: Apache
   size: 27050
   timestamp: 1603894719881
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.9-ha925a31_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-checksums-0.1.9-ha925a31_0.tar.bz2
   sha256: 6947f2b605db23cf0f80f7009fc09eba477c7ae80d55ec81f640ed8b1854a1a6
   md5: 067a7194f4f3d8e8bbe37d8825503cd3
   depends:
@@ -8120,7 +8120,7 @@ packages:
   license_family: Apache
   size: 54104
   timestamp: 1601398697615
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.8.185-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-sdk-cpp-1.8.185-hd77b12b_0.tar.bz2
   sha256: ba257fb24561340ca04c372d9624954b8a57af11999eb9dea42faac47f20e5b9
   md5: 93b4a964f3722da3eb9ad019e7e88f3f
   depends:
@@ -8133,7 +8133,7 @@ packages:
   license_family: Apache
   size: 3226667
   timestamp: 1618435213786
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.3-py38haa95532_0.tar.bz2
   sha256: 5592505a5157820f49f24f56edadce386b621bab138606b2f0749140a8ff98fa
   md5: 8467b1abc968461e85ed656f99c3fb77
   depends:
@@ -8143,12 +8143,12 @@ packages:
   license_family: MIT
   size: 208895
   timestamp: 1718029925816
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-2.4.3-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-2.4.3-py38haa95532_0.tar.bz2
   sha256: 4921e5a1d6f8a4296808ced9c89eb8a6f73a2a3a028a47e62d40565ac80a7af2
   md5: 353550e48fa7a8330b0ea85159b91729
   depends:
@@ -8164,7 +8164,7 @@ packages:
   license_family: BSD
   size: 14459500
   timestamp: 1658136931040
-- conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.73.0-h2bbff1b_12.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/boost-cpp-1.73.0-h2bbff1b_12.tar.bz2
   sha256: de7cc4bbb2534251c2cde2cfd73d4ebed8c4362361320b16f8273439f188e29e
   md5: b4ce3ffcb9ae44d4f1cc025479066509
   depends:
@@ -8175,7 +8175,7 @@ packages:
   license_family: OTHER
   size: 16711
   timestamp: 1655891172252
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py38h9128911_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.7-py38h9128911_0.tar.bz2
   sha256: 8b89a41936ad7ae8cec3d3f1986f7fd57e278107574f00fbdf0e75d73c10c3b6
   md5: 993db813da8f36a4268bb912c6ae3876
   depends:
@@ -8187,7 +8187,7 @@ packages:
   license_family: BSD
   size: 120519
   timestamp: 1707864574013
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 751071782f597f87ed7f67437ef6cc669213902461b9795dd6eb0f4897eddc83
   md5: 5ad8fe62aad5e16cfdf2c5a7d1327fe7
   depends:
@@ -8199,7 +8199,7 @@ packages:
   license: MIT
   size: 19418
   timestamp: 1714483531456
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 9bd62d810867549b9c967c5915f3fa3f66cfbd6ede28b1cc152efd1261285c0a
   md5: 64cc76de3662b62bc8f0e42befd92c5d
   depends:
@@ -8210,7 +8210,7 @@ packages:
   license: MIT
   size: 32178
   timestamp: 1714483513837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py38hd77b12b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py38hd77b12b_8.tar.bz2
   sha256: 0d34db197ab3b14e13acb32e6fd6b3b0b58ba12ecbe2632706bcbfa98174da5b
   md5: de7ca67e3b631f083a0e2d60a805e431
   depends:
@@ -8220,7 +8220,7 @@ packages:
   license: MIT
   size: 356351
   timestamp: 1714483811008
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
   sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
   md5: 11e0af09a31e2d5df51c65a342032b85
   depends:
@@ -8230,7 +8230,7 @@ packages:
   license_family: BSD
   size: 112994
   timestamp: 1714511182837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
   sha256: 41a6c5a90b88ec7010bb6dd89390754e476b52c3ab2d519bdab9556da8829479
   md5: b047426a545e287f45e8abfbfcb0de55
   depends:
@@ -8240,14 +8240,14 @@ packages:
   license_family: MIT
   size: 118041
   timestamp: 1693902191485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.9.24-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2024.9.24-haa95532_0.tar.bz2
   sha256: 5434767b7168e529c2c6a4bc201c783adbc3bc6480564a6fe3f869b12ed96c83
   md5: bb0627482bac2339842e495e7d6686d2
   license: MPL-2.0
   license_family: Other
   size: 175262
   timestamp: 1727794875480
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.8.30-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2024.8.30-py38haa95532_0.tar.bz2
   sha256: d76252bfe88b57c31b1d6b32f45c3e021828ecdde48c86f7d91d7280efb49b5b
   md5: 2f53dcf4fd273552a45fc4d91ee8ba75
   depends:
@@ -8256,7 +8256,7 @@ packages:
   license_family: Other
   size: 168638
   timestamp: 1725551864682
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py38h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.17.1-py38h827c3e9_0.tar.bz2
   sha256: c6fb618f35a21c5d0145d78c9f9669249f42fa9bc42e97abe896aa8cbd47b35e
   md5: ce7050b90688819020af308d0d8efaeb
   depends:
@@ -8268,7 +8268,7 @@ packages:
   license_family: MIT
   size: 251178
   timestamp: 1726856534727
-- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py38haa95532_0.tar.bz2
   sha256: d6419f177081f538c07438fd0e30b3fd0550154068846a5a172d7ad0f3da7d29
   md5: 4a4023e7123dee6dd3de8d5c7ad10208
   depends:
@@ -8278,7 +8278,7 @@ packages:
   license_family: BSD
   size: 152529
   timestamp: 1698130021042
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.0.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cloudpickle-3.0.0-py38haa95532_0.tar.bz2
   sha256: 409ba6333f104911fa90f94b1fbb504c6f00f1d11c3d2a6318e0ca76fd34805c
   md5: 48e9c16440f00106b1249c977840e4f3
   depends:
@@ -8287,7 +8287,7 @@ packages:
   license_family: BSD
   size: 35481
   timestamp: 1721657467285
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py38haa95532_0.tar.bz2
   sha256: b1c25c1a98c903b27e265b54acbed95f4a9b274c5b6ed13cf6b0f6f6f8b355a6
   md5: 056a4bcea84a785566fc6d5dee32c8d9
   depends:
@@ -8296,7 +8296,7 @@ packages:
   license_family: BSD
   size: 30328
   timestamp: 1672387462487
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py38haa95532_0.tar.bz2
   sha256: 7da28ca3414ac1f6263983a7e2da3337c276e2af2057ad0dff3c6ea500248260
   md5: 496b518d3c346b450e9a537954334e43
   depends:
@@ -8305,7 +8305,7 @@ packages:
   license_family: CC
   size: 549769
   timestamp: 1709758725166
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py38haa95532_0.tar.bz2
   sha256: 4c7f192b9a0e9d0c2d77c3e75e85a5d97b6762892cbcb19546254b8e2739124a
   md5: 2b01b19c1dd5105ff1483b96b3fe109f
   depends:
@@ -8315,7 +8315,7 @@ packages:
   license_family: BSD
   size: 15323
   timestamp: 1709323030816
-- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-pack-0.7.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/conda-pack-0.7.1-py38haa95532_0.tar.bz2
   sha256: 76bf960b1799b2b74143da3cfad092cd53d342bd77f8d985fb2e430c0fe21e4b
   md5: 18430d9a28c9c8823f93bcd4a33893d0
   depends:
@@ -8325,7 +8325,7 @@ packages:
   license_family: BSD
   size: 70897
   timestamp: 1710258190226
-- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-handling-2.3.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/conda-package-handling-2.3.0-py38haa95532_0.tar.bz2
   sha256: 477edbc65ca4758ecdda4d4a605b7033f6a93cfb8011e7e9f4742602fd4a9527
   md5: 95d62c313a391f5473d7a6298129859f
   depends:
@@ -8336,7 +8336,7 @@ packages:
   license_family: BSD
   size: 309146
   timestamp: 1718138562716
-- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-streaming-0.10.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/conda-package-streaming-0.10.0-py38haa95532_0.tar.bz2
   sha256: c04fca47f49fcf6fd04eab50990c40870c22dbc0cb760e88651a1ffa465c0972
   md5: 98fa6c62a279826f71684136b879c4d8
   depends:
@@ -8346,7 +8346,7 @@ packages:
   license_family: BSD
   size: 28101
   timestamp: 1718136203874
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py38h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py38h59b6b97_0.tar.bz2
   sha256: 70fde13d90524b164158f9b22303677d6e05ab15a84ffc00bdeafb2e1a584e84
   md5: fecf6e5becd8b5d19e3b5a1b33e9d915
   depends:
@@ -8358,7 +8358,7 @@ packages:
   license_family: BSD
   size: 184226
   timestamp: 1663827694272
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.2-py38h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cytoolz-0.12.2-py38h2bbff1b_0.tar.bz2
   sha256: 7c66ca2b9c44c10602ae8fee1475204428722e9d9fc5c2fe03e9eca900831268
   md5: 1a2f13dcf6b44e18faecea2bf5a8abea
   depends:
@@ -8370,7 +8370,7 @@ packages:
   license_family: BSD
   size: 343415
   timestamp: 1701723732354
-- conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py38haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/datashape-0.5.4-py38haa95532_1.tar.bz2
   sha256: 792842a4d65fa3affa75fbef7b45b35e2d1fdc3a3afb805c60dea0363b473f9f
   md5: 3afae957ad0d8a21fab2c450d3a5e7f9
   depends:
@@ -8382,7 +8382,7 @@ packages:
   license_family: BSD
   size: 104651
   timestamp: 1613390448861
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py38hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py38hd77b12b_0.tar.bz2
   sha256: 2133716ef1744b2292e035a58e2ce7136507df2598a6bbb557f77d41c229e6a6
   md5: 8d89f8023cd7fb526d42b020dd298dde
   depends:
@@ -8393,7 +8393,7 @@ packages:
   license_family: MIT
   size: 3289647
   timestamp: 1690907575092
-- conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2.30.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/distributed-2.30.1-py38haa95532_0.tar.bz2
   sha256: 52637610ad7cb0eb4444d5799c0972793fbcc371c32b5e7056ab02b9f69c0c0a
   md5: bc99a7bec1d016e479252d1ed0afb1f4
   depends:
@@ -8417,7 +8417,7 @@ packages:
   license_family: BSD
   size: 1154079
   timestamp: 1605066746927
-- conda: https://repo.anaconda.com/pkgs/main/win-64/double-conversion-3.1.5-ha925a31_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/double-conversion-3.1.5-ha925a31_1.tar.bz2
   sha256: ed66a25d2123f70d55896b17d9b774a88618eb9288d60c23f6419b199f88c3d8
   md5: 8ca5980f204acf7ec2ceb5f6437b7bfb
   depends:
@@ -8426,7 +8426,7 @@ packages:
   license_family: BSD
   size: 257849
   timestamp: 1567108291976
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py38haa95532_0.tar.bz2
   sha256: e86cd5e70eb1ade76f2e80d9351d377f81b63460b7b0261e0aa9825b7051df83
   md5: 0ea2c3493ad24b83dfb5919aa6af58e8
   depends:
@@ -8435,7 +8435,7 @@ packages:
   license_family: MIT
   size: 16900
   timestamp: 1649926672239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.2.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.2.0-py38haa95532_0.tar.bz2
   sha256: 4d164e7a24b1cdec81846df6258202b10e9199a85eece63eb9c494e54329c0aa
   md5: 723144b57a4f6fd5af73a04efe77bda5
   depends:
@@ -8444,7 +8444,7 @@ packages:
   license_family: MIT
   size: 30386
   timestamp: 1706031611837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-0.5.0-py38h080aedc_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fastparquet-0.5.0-py38h080aedc_2.tar.bz2
   sha256: af094b4bd8c2581f0dd1c4a33ec0334d63fccc13e5fa4210e1911086667d83ab
   md5: 1f3bd3efe3f06d9ece34bd2f0d01446a
   depends:
@@ -8462,7 +8462,7 @@ packages:
   license_family: Apache
   size: 190803
   timestamp: 1658471877164
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py38h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fonttools-4.51.0-py38h2bbff1b_0.tar.bz2
   sha256: 2e3e06327bf5073705b5fcadd719033c48caccc2fbe83e4e65e4ccb804261a75
   md5: b2c8a0b2e87ed3b6362a69dfb7d9c0a8
   depends:
@@ -8482,7 +8482,7 @@ packages:
   license_family: MIT
   size: 2210226
   timestamp: 1713552355020
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -8494,7 +8494,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.6.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fsspec-2024.6.1-py38haa95532_0.tar.bz2
   sha256: d181cbd59a4fe2da8298b521fcd49a90cd7d9fee6c2f13352aa775fa6e6f4b7b
   md5: eb5d9f820b1aee3f5951cee4a172b087
   depends:
@@ -8505,7 +8505,7 @@ packages:
   license_family: BSD
   size: 283622
   timestamp: 1724855699390
-- conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
   sha256: 7cb0df7aa62796b0081e1708003529c02411aca6a540bae97beaec919aa64e74
   md5: ea81fd813e10055553a8d7597c8be98f
   depends:
@@ -8515,7 +8515,7 @@ packages:
   license_family: BSD
   size: 322778
   timestamp: 1706888324269
-- conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
   sha256: ed1fa1a40c6739b48ff3a2d51c3df20e4983b59684b04d93e1337c5f2e93a954
   md5: 1797f64343a42395207cd452e6a6a751
   depends:
@@ -8526,7 +8526,7 @@ packages:
   license_family: BSD
   size: 94476
   timestamp: 1706895442146
-- conda: https://repo.anaconda.com/pkgs/main/win-64/grpc-cpp-1.26.0-h351948d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/grpc-cpp-1.26.0-h351948d_0.tar.bz2
   sha256: 6a5c2deb25813a4f37de9d26c4f0f95f496441ba4c8fc614297a9a8581e6409c
   md5: 0910c37b2a35ac6a036d94806fccaaa8
   depends:
@@ -8542,13 +8542,13 @@ packages:
   license_family: APACHE
   size: 15441619
   timestamp: 1580397193694
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
   sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
   md5: 582d2c1135a89da757a038de831e7f39
   license: Intel proprietary
   size: 11086648
   timestamp: 1664812389803
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.7-py38haa95532_0.tar.bz2
   sha256: c386cd6fbb827f5a7633a7c19ae24a0755b2c425e65487a35e3a2770afe1b5e5
   md5: 669cfec4ebd7d248d60b64cceeeb9269
   depends:
@@ -8557,7 +8557,7 @@ packages:
   license_family: BSD
   size: 123732
   timestamp: 1714399007175
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-7.0.1-py38haa95532_0.tar.bz2
   sha256: 0ab24097111b49edd25180744c960d59c95f668b59a0445f605a2dddca8f2134
   md5: a3ef8887a20b4d7e08766c138594ba21
   depends:
@@ -8567,7 +8567,7 @@ packages:
   license_family: APACHE
   size: 42044
   timestamp: 1704813734562
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.4.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.4.0-py38haa95532_0.tar.bz2
   sha256: f62e105e261a50c48eb27c8042d36c3c885fa53af33ae915d0d1fcc8f92657a2
   md5: bc76f454be39b4089a37cce831e1d7fa
   depends:
@@ -8577,7 +8577,7 @@ packages:
   license_family: APACHE
   size: 58000
   timestamp: 1720641211265
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intake-0.6.8-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intake-0.6.8-py38haa95532_0.tar.bz2
   sha256: 3619cb62b311c1e003bbcae471d727ba3f43be7b61a53e86bb024013aff5382d
   md5: 3dcf56a37c02b514e93ef2ed1560664f
   depends:
@@ -8600,7 +8600,7 @@ packages:
   license_family: BSD
   size: 217089
   timestamp: 1678787837720
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
   sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
   md5: d215cc8ee7ca2cc83cc250cc5d822fe0
   depends:
@@ -8610,7 +8610,7 @@ packages:
   license_family: Proprietary
   size: 3929136
   timestamp: 1699647939158
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.29.5-py38haa95532_0.tar.bz2
   sha256: c01fc087034c420bde517ea426e20287935acde54763aded5142487019fff190
   md5: 831252005dbd46e30eb896422009dfc7
   depends:
@@ -8631,7 +8631,7 @@ packages:
   license_family: BSD
   size: 190983
   timestamp: 1728665891426
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.12.2-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.12.2-py38haa95532_0.tar.bz2
   sha256: 7b756df85fb011088bf6bb638600c7457cf717dfa5ab69b0a6cf3649b66b1dcb
   md5: 8b27d8d58e3781bd451cf797e272d5e4
   depends:
@@ -8651,7 +8651,7 @@ packages:
   license_family: BSD
   size: 1252304
   timestamp: 1691532284562
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.19.1-py38haa95532_0.tar.bz2
   sha256: b69208002b5f026eac88aca66d9d4e5e377a9b7679d5866a2b282c2ad2b8411b
   md5: fec574df4927cf80f12bdac37b7aadeb
   depends:
@@ -8661,7 +8661,7 @@ packages:
   license_family: MIT
   size: 1046264
   timestamp: 1721059296716
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.4-py38haa95532_0.tar.bz2
   sha256: a19bcdbc051e1315815a0998dbd60883724564ee4c45e9ccfa232bffaa697dc7
   md5: 5a627e62dfd3f5e2accb35b13aec8b3b
   depends:
@@ -8673,7 +8673,7 @@ packages:
   license_family: BSD
   size: 274259
   timestamp: 1716993611805
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
   sha256: 0238fb10912d9345a9d327ff314a179de38369f8e1d0de0b5f4fab04defab0e4
   md5: 16a420ea83811cfa0c7cadba8f9f0995
   depends:
@@ -8683,7 +8683,7 @@ packages:
   license_family: Other
   size: 409932
   timestamp: 1722872751697
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.23.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.23.0-py38haa95532_0.tar.bz2
   sha256: 99537ee46afa298aa7ec2278432233f9c0e810d7d4c344d53cbc6da7cecd82ae
   md5: 2784059f8402336c99cd61f900ea676e
   depends:
@@ -8698,7 +8698,7 @@ packages:
   license_family: MIT
   size: 175019
   timestamp: 1728486987655
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py38haa95532_0.tar.bz2
   sha256: 46748dfa778aa7e78f52cd6baa49186202b553384c111320c65393c0218e173b
   md5: 7da1b58fa7d52c2f0aec56bdac48469e
   depends:
@@ -8709,7 +8709,7 @@ packages:
   license_family: MIT
   size: 15538
   timestamp: 1699032485491
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py38haa95532_0.tar.bz2
   sha256: ea0ae2cfbbbf5a3737e348b40fd6dd7a1b6159525143af959eb1708b201a9577
   md5: 59112e5bdca43f39c392165f51477c30
   depends:
@@ -8725,7 +8725,7 @@ packages:
   license_family: BSD
   size: 229130
   timestamp: 1676330586941
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.7.2-py38haa95532_0.tar.bz2
   sha256: e4dfb00cba8e246c1fff06ca8293c340105e137bcf798a8f2a51485f7b519fd8
   md5: cbcc47e0922603aadbee4f3aeb1a297f
   depends:
@@ -8737,7 +8737,7 @@ packages:
   license_family: BSD
   size: 120988
   timestamp: 1718818639896
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.10.0-py38haa95532_0.tar.bz2
   sha256: c8749746c00951825d71c842f37b4ab26894c5d7eec8369a321f9423251d708b
   md5: 729dcc20a62d5e3944e635100bcd296e
   depends:
@@ -8753,7 +8753,7 @@ packages:
   license_family: BSD
   size: 65509
   timestamp: 1718738196257
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.14.1-py38haa95532_0.tar.bz2
   sha256: 4e928b0efc2ec2c71eb8c470fdf7260c298c1f5d7270023d90278d25dd21278b
   md5: d67b9417b1d9498d27ed576f2cf826e8
   depends:
@@ -8781,7 +8781,7 @@ packages:
   license_family: BSD
   size: 543655
   timestamp: 1718827185412
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py38haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py38haa95532_1.tar.bz2
   sha256: a0f0717e24e574353b2748dbd41bc037de7eadf39266698eeed268ab3feaaa5f
   md5: 71cd4edfa064a841e3686bd695d119c2
   depends:
@@ -8792,7 +8792,7 @@ packages:
   license_family: BSD
   size: 23926
   timestamp: 1686871157357
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyterlab_pygments-0.2.2-py38haa95532_0.tar.bz2
   sha256: fb37beaea4fd5d8d84d7edd51335a5f2a0f272a7af85ca19cf79cd8be9002e6a
   md5: c3f6014574ca4e53a2a006b306a50b93
   depends:
@@ -8804,7 +8804,7 @@ packages:
   license_family: BSD
   size: 19776
   timestamp: 1700168833321
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py38hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py38hd77b12b_0.tar.bz2
   sha256: c287aa13a824a255ab68751645473a4f190590b77160b85d694a2f72e513e551
   md5: f35f9f31f1f8bd00c5e7fccc81a8edff
   depends:
@@ -8815,7 +8815,7 @@ packages:
   license_family: BSD
   size: 62238
   timestamp: 1672388388533
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
   sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
   md5: f5f73266281ab12377d5d47bdf07500a
   depends:
@@ -8827,7 +8827,7 @@ packages:
   license_family: MIT
   size: 905072
   timestamp: 1617648814933
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -8837,7 +8837,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.73.0-h6c2663c_12.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libboost-1.73.0-h6c2663c_12.tar.bz2
   sha256: 6389f1c26b4d967ee5022da998216a8a82262264cdf20093f77fcf01e5c885bd
   md5: 45400838317566b4aa24afa5a497eb26
   depends:
@@ -8850,7 +8850,7 @@ packages:
   license_family: OTHER
   size: 36835586
   timestamp: 1655891021895
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 7c906c94a4d46ea963080a6ba5bd12c1274da66159877a544fbc70291eeed98d
   md5: 45a3d52534fac8aa54a55ee92211a918
   depends:
@@ -8859,7 +8859,7 @@ packages:
   license: MIT
   size: 80216
   timestamp: 1714483371043
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
   sha256: daad7edc6d56abf3e176479e8628162dbf1c56b3d24db30d708aebae694a5214
   md5: e8ecf229f7fcb4c0b76d8613627948f5
   depends:
@@ -8869,7 +8869,7 @@ packages:
   license: MIT
   size: 45189
   timestamp: 1714483420152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 84320217abffa9386186ec8d03b4651bb4b1900d3871adc965a9a9e1d3799907
   md5: 651312fa22168f71f9aec5f9ee2c2fcf
   depends:
@@ -8879,7 +8879,7 @@ packages:
   license: MIT
   size: 756116
   timestamp: 1714483464368
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.9.1-h0416ee5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libcurl-8.9.1-h0416ee5_0.tar.bz2
   sha256: 8823321b1f3a4dec2ba437b74f054b6188c4e86f15e9830a851c036f1000b116
   md5: eb83a06e2e659553014b6ac66f379e09
   depends:
@@ -8892,7 +8892,7 @@ packages:
   license_family: MIT
   size: 371549
   timestamp: 1725033449018
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -8902,7 +8902,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
   sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
   md5: cf949d76148be1e2a534218d9c57df86
   depends:
@@ -8912,7 +8912,7 @@ packages:
   license_family: MIT
   size: 155435
   timestamp: 1714484319443
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -8923,7 +8923,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-3.11.2-h7bd577a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libprotobuf-3.11.2-h7bd577a_0.tar.bz2
   sha256: a71d1d07f93bdc6e8e63f577ba026921f5e032cc5fdae9ef345aa510c78bc752
   md5: 9e79055f48d08a25ce7cc272596d539f
   depends:
@@ -8934,7 +8934,7 @@ packages:
   license_family: BSD
   size: 2376980
   timestamp: 1576541111355
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -8943,7 +8943,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-hcd4344a_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libssh2-1.10.0-hcd4344a_2.tar.bz2
   sha256: 0b1460332f394557429f75c871c89ad27fc2ddadbeb28bfcff8d1d8537f493ac
   md5: 38e889ec253fe997be7f94556a0855d4
   depends:
@@ -8954,7 +8954,7 @@ packages:
   license_family: BSD
   size: 230554
   timestamp: 1686932558863
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -8971,7 +8971,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
   sha256: e54ee28f6ba01b3addf61ee9dfbdedc16eac8654fc334f713b5f181cf037d0f2
   md5: 47aa151852fc9b07e7573d22f0af945d
   depends:
@@ -8983,7 +8983,7 @@ packages:
   license_family: BSD
   size: 339944
   timestamp: 1729160123353
-- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.38.0-py38h23ce68f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/llvmlite-0.38.0-py38h23ce68f_0.tar.bz2
   sha256: 760fcf2ec2968ae8ca484f3ab2ca9e52d2d6ef0cb5ad2799541ccf3d05673441
   md5: 320710850571e79f10811b51c93e496b
   depends:
@@ -8994,7 +8994,7 @@ packages:
   license: BSD-2-Clause
   size: 17093250
   timestamp: 1650372279371
-- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py38haa95532_0.tar.bz2
   sha256: badc76eab56488df2cba6ac632fcf24223c4967628fe7bc061d8e2c0cd5aa362
   md5: 201617fddcaf95a08884560594e8d496
   depends:
@@ -9003,7 +9003,7 @@ packages:
   license_family: BSD
   size: 12848
   timestamp: 1652904166019
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
   sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
   md5: 320f40b75d93f3b96931c6d13c23946c
   depends:
@@ -9013,7 +9013,7 @@ packages:
   license_family: BSD
   size: 158902
   timestamp: 1714512129889
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py38haa95532_0.tar.bz2
   sha256: 5e648ae3ef2e9d544accfd1cb16ee5081eb69fad94fc3dadd10c55244cddbfbb
   md5: bd2cc8c49b69abde1d55e6f2a1e636a2
   depends:
@@ -9023,7 +9023,7 @@ packages:
   license_family: BSD
   size: 142697
   timestamp: 1671542078827
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py38h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py38h2bbff1b_0.tar.bz2
   sha256: 4bd5defe37fb5920e0a5d22d9d479f11a22199d4fa81f8d497acf59f3623c516
   md5: b163be173efae86ec41fdce35af0eff5
   depends:
@@ -9036,7 +9036,7 @@ packages:
   license_family: BSD
   size: 26878
   timestamp: 1704206131128
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.7.2-py38h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.7.2-py38h4ed8f06_0.tar.bz2
   sha256: 5fed7c0f03a7ff005e68293d8c4c50640fd468f5d0e1cce79a6251a68ddc49a1
   md5: a959d9f4974e5402f833d529726cfa9c
   depends:
@@ -9060,7 +9060,7 @@ packages:
   license_family: PSF
   size: 7949779
   timestamp: 1693813405191
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py38haa95532_0.tar.bz2
   sha256: 2a832b73527801756ce9c8e7a2e9d2f0aa7b0e39e764cb1699c45dc9db00d67b
   md5: dcede4303efc5efc488deed47d24f03a
   depends:
@@ -9070,7 +9070,7 @@ packages:
   license_family: BSD
   size: 17983
   timestamp: 1661934096957
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py38haa95532_0.tar.bz2
   sha256: ea8b7772c23b5c958b10ec4546d3b235b72d4e7010a69837705a273f30f723c6
   md5: 6fa331a0ea7406d505e4db8ac77ac52a
   depends:
@@ -9081,7 +9081,7 @@ packages:
   license_family: BSD
   size: 90547
   timestamp: 1661496403308
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
   sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
   md5: 527155127b9fada5e5c5c69a624674b9
   depends:
@@ -9093,7 +9093,7 @@ packages:
   license_family: Proprietary
   size: 187498166
   timestamp: 1699648376430
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py38h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py38h2bbff1b_1.tar.bz2
   sha256: 1377f4b52bc0f0059fc384cc0eb2451d8b9db27eb85587e27d93eb1061a1ca9b
   md5: 3389c1f1869f6b1e894390155f8fbbf7
   depends:
@@ -9105,7 +9105,7 @@ packages:
   license_family: BSD
   size: 49712
   timestamp: 1682974986419
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py38h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py38h2bbff1b_0.tar.bz2
   sha256: 8b57b0ddc34eeaabdf91274eab9ac758ebebb6436f3f43a7459139271ee2d0a0
   md5: 4c623b331a7301525e92a02b0490a616
   depends:
@@ -9120,7 +9120,7 @@ packages:
   license_family: BSD
   size: 185379
   timestamp: 1695058741315
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py38h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py38h59b6b97_0.tar.bz2
   sha256: ac93a9e5da11442058b30e89bb24447d311f067a5a98c36c85c7de9f420f25e1
   md5: 048f410489ce4250a215211619ee512e
   depends:
@@ -9135,7 +9135,7 @@ packages:
   license_family: BSD
   size: 258368
   timestamp: 1695060288659
-- conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py38h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/msgpack-python-1.0.3-py38h59b6b97_0.tar.bz2
   sha256: dd4f2c677361273de293da946ae55d811590bbadc4a1da75fe77204694821b86
   md5: 22a646f00d2aa14becfb7594dc1efde5
   depends:
@@ -9146,7 +9146,7 @@ packages:
   license_family: Apache
   size: 82740
   timestamp: 1652329410469
-- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py38_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py38_0.tar.bz2
   sha256: f88f8146f2efe5744d2c8c03bc8c7275693b57fbad85212369cc742d81bd37bf
   md5: d16e6b7628a2b9eab9a5d30e4bed09fe
   depends:
@@ -9156,7 +9156,7 @@ packages:
   license_family: BSD
   size: 23139
   timestamp: 1573470511265
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-1.1.0-py38haa95532_0.tar.bz2
   sha256: 2ab502a9b31418d85cbd1319e9b8104d1ef0015b28a891f735da8631f44af768
   md5: cbae91562cd589d6d76cf10ce4dd4c1e
   depends:
@@ -9169,7 +9169,7 @@ packages:
   license_family: BSD
   size: 8281201
   timestamp: 1717624456711
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py38haa95532_0.tar.bz2
   sha256: 65c24d874d1c62890a57e33897b16c4bff02c6e18e143e6be09bc082469f30a2
   md5: 91d05567335fe9223f8907b7748f97e6
   depends:
@@ -9182,7 +9182,7 @@ packages:
   license_family: BSD
   size: 119185
   timestamp: 1698934529462
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.4-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-7.16.4-py38haa95532_0.tar.bz2
   sha256: c52e733ea7497dd72da30fcb06c139bb656d35161ca648f14810b596a6f41650
   md5: f27743ec5bd0a51f662112f3f28fadf2
   depends:
@@ -9210,7 +9210,7 @@ packages:
   license_family: BSD
   size: 532532
   timestamp: 1728052034971
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.10.4-py38haa95532_0.tar.bz2
   sha256: 65fd08b31f88c92774b94786b24479a58308870aaee9de3f6dbd7a8337843a21
   md5: 074b08f8443141c0bac37cef71014eb3
   depends:
@@ -9223,7 +9223,7 @@ packages:
   license_family: BSD
   size: 179794
   timestamp: 1728050494082
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py38haa95532_0.tar.bz2
   sha256: 0125eed930e1d15be1098e841f63bbf4fd5186778be3b87e97086dc08198e65a
   md5: 37cb3974b360b02a0d7c068ffe6c99cd
   depends:
@@ -9232,7 +9232,7 @@ packages:
   license_family: BSD
   size: 14074
   timestamp: 1708533000967
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.7-py38haa95532_0.tar.bz2
   sha256: 25adc81e4fa738a62d444a90845a6b74b79192d3a7970ba7103f25ff06b3e3e6
   md5: 2cb53eb03403e743dc7c26fffdf478c5
   depends:
@@ -9257,7 +9257,7 @@ packages:
   license_family: BSD
   size: 645231
   timestamp: 1717631098005
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py38haa95532_0.tar.bz2
   sha256: b41f263dfa0efed39e09ec81e5122d01750e252a001b4bf7fb9d4ef70eade059
   md5: bac6bd350f68d94ed7125e57bc7b6611
   depends:
@@ -9267,7 +9267,7 @@ packages:
   license_family: BSD
   size: 23169
   timestamp: 1699455980387
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.55.1-py38hf11a4ad_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numba-0.55.1-py38hf11a4ad_0.tar.bz2
   sha256: 560f621fd180153e433ef842fd894b62613b48baa69b9c410561f8199e861a36
   md5: d5d6bc1ddbd7e58ddaca95d6fbfb641c
   depends:
@@ -9288,7 +9288,7 @@ packages:
   license_family: BSD
   size: 4001663
   timestamp: 1650390943901
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.4-py38h7b80656_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.4-py38h7b80656_1.tar.bz2
   sha256: 53088668bec0e25ce85dbb3aae9bf29b1fc90e2542360f5221e02acddf05cabc
   md5: 990126d16909922f9617be3081ec5d58
   depends:
@@ -9303,7 +9303,7 @@ packages:
   license_family: MIT
   size: 131075
   timestamp: 1683222215685
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.21.6-py38h85e1a82_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.21.6-py38h85e1a82_1.tar.bz2
   sha256: 8bff17e4297663ba95055fbb08b1c31d9a22407a88b0e475b464b9bac203e7d5
   md5: 6c03a716acb80196ea30da5ad16a6609
   depends:
@@ -9320,7 +9320,7 @@ packages:
   license_family: BSD
   size: 11277
   timestamp: 1715093260243
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.21.6-py38hb5c95e7_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.21.6-py38hb5c95e7_1.tar.bz2
   sha256: f4413d46e69e82484043c2837db61cb43bd06e528ae97a9f0bb5ec01a28b0828
   md5: 68e4bfadb4f8459dfc1c443bd08c048d
   depends:
@@ -9336,7 +9336,7 @@ packages:
   license_family: BSD
   size: 6028720
   timestamp: 1715093236825
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
   sha256: e2afce0548808d27293a03661ee5f7ac3e18f82a92c9fb23f420eb5e92126fc6
   md5: 9dd921a785844abe0aa842c3800d405a
   depends:
@@ -9348,7 +9348,7 @@ packages:
   license_family: BSD
   size: 286986
   timestamp: 1722872761369
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
   sha256: 0474e14823c734edc088bef98b829149a47ed8b4654f9638926c2fe4bbc40f38
   md5: a67d4a763641de641ea9dfa8c4a5f567
   depends:
@@ -9359,7 +9359,7 @@ packages:
   license_family: Apache
   size: 6048217
   timestamp: 1694466133007
-- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py38haa95532_0.tar.bz2
   sha256: efb6be1d02844963cc1706a5ea6e1c8f199206371e5e0f064016171fa402f7cd
   md5: bd06733558646e2cf0db9f87d2cc50ae
   depends:
@@ -9368,7 +9368,7 @@ packages:
   license_family: APACHE
   size: 31537
   timestamp: 1699371229746
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-24.1-py38haa95532_0.tar.bz2
   sha256: 5ca458cebb6508f241c9de41eb5f7d2fbcbe1a7ed418e9e64ad7a19bcb8b4d88
   md5: d4074f1df7234e38afca8f3004b7f615
   depends:
@@ -9377,7 +9377,7 @@ packages:
   license_family: Apache
   size: 135333
   timestamp: 1720102440368
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-1.5.3-py38hf11a4ad_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-1.5.3-py38hf11a4ad_0.tar.bz2
   sha256: 4c36f591c3b6692de0cdd2508f5f0f3bad8331f0b2c78892131419b74ed28ea8
   md5: 2d357b4544d802559b28ae989b81141c
   depends:
@@ -9424,7 +9424,7 @@ packages:
   license_family: BSD
   size: 12129620
   timestamp: 1677836062764
-- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py38haa95532_0.tar.bz2
   sha256: ba83b43ae4dc81ad1843dbcb377ea14d31a6f8671b2c73d7016ccbf953930358
   md5: 0cc57d9c8d9aca634a55e4cddcc3618d
   depends:
@@ -9438,7 +9438,7 @@ packages:
   license_family: BSD
   size: 36170
   timestamp: 1698702748557
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.4.0-py38h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.4.0-py38h827c3e9_0.tar.bz2
   sha256: cd5b77567e0af37dfaa4e78951eb66ffefedaa582192c1f12e66d5f33ba6e373
   md5: 67a25493edf9d34f87d7b597bfc31498
   depends:
@@ -9456,7 +9456,7 @@ packages:
   license_family: Other
   size: 925815
   timestamp: 1721059710712
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.2-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-24.2-py38haa95532_0.tar.bz2
   sha256: fb6fb47fc4673736f721a5f11881669fea0f04f16a461999192d5a2237e82855
   md5: 50e60af1a108b49a4f968cf13f5fe128
   depends:
@@ -9467,7 +9467,7 @@ packages:
   license_family: MIT
   size: 2546968
   timestamp: 1723485712114
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pkgutil-resolve-name-1.3.10-py38haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pkgutil-resolve-name-1.3.10-py38haa95532_1.tar.bz2
   sha256: 8778945e8ff311e1c6c21240f7d826a0b20b91d9c8a19cec0d2a6431f9568613
   md5: bb26a71a59437bef6cb29ffbc894bb0f
   depends:
@@ -9476,7 +9476,7 @@ packages:
   license_family: PSF
   size: 11194
   timestamp: 1704297782483
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py38haa95532_0.tar.bz2
   sha256: d9bdf22a0141d5d3e4e1455a93ecd6680980786b5fcd5516773217403057d389
   md5: 10961e0b088c531ddeafb3c4c278b8b5
   depends:
@@ -9485,7 +9485,7 @@ packages:
   license_family: MIT
   size: 32378
   timestamp: 1692205706184
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pooch-1.7.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pooch-1.7.0-py38haa95532_0.tar.bz2
   sha256: 269095712af2adf8aa3a1b5532596b7b19b3222d3b062f5af466ee5b423b854f
   md5: 6f17c938b517964b61675589037c6e36
   depends:
@@ -9501,7 +9501,7 @@ packages:
   license_family: BSD
   size: 81717
   timestamp: 1695850480881
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py38haa95532_0.tar.bz2
   sha256: 62980fe41fb61641ff3a92bc46769c221e216d7b1b052624cca35cd6442e67a3
   md5: ceb8f341d88581897417b74581824ce5
   depends:
@@ -9510,7 +9510,7 @@ packages:
   license_family: Apache
   size: 90902
   timestamp: 1659455380536
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py38haa95532_0.tar.bz2
   sha256: 56412c7866ec9f23b48aaf2d15083190a8e0a05a7f79a12cdca914d6eaea69f9
   md5: f02031632580590333b5f15c1b86e17e
   depends:
@@ -9522,7 +9522,7 @@ packages:
   license_family: BSD
   size: 577480
   timestamp: 1704404521896
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py38h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py38h2bbff1b_0.tar.bz2
   sha256: 3f30894e9e48919717e4836d41d37fe94067c41f2714982d5b09041e8d03c625
   md5: 715eca27ac0ea2d6e5b9781ece861045
   depends:
@@ -9533,7 +9533,7 @@ packages:
   license_family: BSD
   size: 372631
   timestamp: 1656431598029
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-4.0.1-py38h953b917_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyarrow-4.0.1-py38h953b917_3.tar.bz2
   sha256: 95a2efa1b80ac7e0ff05cb71f6df7ec7222e65d6473a06c8a06228e5ef58651a
   md5: 7af9abedef308517097a60c6f64b3dfb
   depends:
@@ -9551,7 +9551,7 @@ packages:
   license: Apache 2.0
   size: 2281467
   timestamp: 1623165272688
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py38haa95532_0.tar.bz2
   sha256: b6cd1020f33142369e4e5e3011fc52b761067feae88ef2faed1dd38921eea160
   md5: 89f633e2fe32f8964414004f4bf69a50
   depends:
@@ -9563,7 +9563,7 @@ packages:
   license_family: BSD
   size: 48367
   timestamp: 1675450405375
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py38haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py38haa95532_1.tar.bz2
   sha256: c99df0ff588b6cc027003901719fafcca53c7d5982224d10adafb0eba5d62f76
   md5: ea6a5a355c3e39e2d5e03418cf1c359f
   depends:
@@ -9572,7 +9572,7 @@ packages:
   license_family: BSD
   size: 1902776
   timestamp: 1684280088005
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py38haa95532_0.tar.bz2
   sha256: 0338ad6cc3998c5adc325f9df5916a84d9462176c060160b15bf016cd78df4c6
   md5: 7ac4db0e1a670a061b08208f6e819bb0
   depends:
@@ -9581,7 +9581,7 @@ packages:
   license_family: MIT
   size: 157552
   timestamp: 1661452635483
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py38haa95532_0.tar.bz2
   sha256: 9bf258afe075dd22aa6e33b71b122126eaeb1001906b5df614b2e81e88e17ddf
   md5: ca4e90d9e382f0033230a67499d51239
   depends:
@@ -9591,7 +9591,7 @@ packages:
   license_family: BSD
   size: 31587
   timestamp: 1605287884076
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.8.18-h6244533_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.8.18-h6244533_0.tar.bz2
   sha256: 91fe00fa9abb019a70c68be5a39887972a77473805abf160be8274ec3e8f5ea8
   md5: f4f6d4b6bb55b19eda46f2fc79288f10
   depends:
@@ -9604,7 +9604,7 @@ packages:
   license_family: PSF
   size: 22819210
   timestamp: 1694440319269
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py38haa95532_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py38haa95532_2.tar.bz2
   sha256: e8c094344f0a47aceb531888edff39c19378e6e48d5d2fcb5b88961de8006ed3
   md5: cef16f6a3eee24f584b827910705c98f
   depends:
@@ -9614,7 +9614,7 @@ packages:
   license_family: BSD
   size: 289551
   timestamp: 1716496055846
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py38haa95532_0.tar.bz2
   sha256: c3414f6a87ec84473869ac5821a62369f374b1df33def55a6d6487fd863ad56d
   md5: 7d51837a0deed7e1f8a410a2851ac755
   depends:
@@ -9623,7 +9623,7 @@ packages:
   license_family: BSD
   size: 269239
   timestamp: 1661376763966
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-json-logger-2.0.7-py38haa95532_0.tar.bz2
   sha256: c0f8465a6322d76cea2b4e15de63ba737d04e93246b5662d09da5306776f8e5b
   md5: 2e301dbd230172c15e53749f3369d424
   depends:
@@ -9632,7 +9632,7 @@ packages:
   license_family: BSD
   size: 15628
   timestamp: 1683824193853
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py38hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-lmdb-1.4.1-py38hd77b12b_0.tar.bz2
   sha256: cd4788fdafa155d2bb3b7159cc4f031370c9caab7b006b6afab11881f7fa9d3c
   md5: 83b3e3d6f925636bb2a0be77ae8b9d5c
   depends:
@@ -9643,7 +9643,7 @@ packages:
   license_family: Other
   size: 135460
   timestamp: 1682522629966
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-snappy-0.6.1-py38hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-snappy-0.6.1-py38hd77b12b_0.tar.bz2
   sha256: 46f80b10a0e3a3fe822aa91cd415de31529bd6551201ea580e08de55463d6f89
   md5: 65f21ec0a3ea88d9259ec048270c459e
   depends:
@@ -9655,7 +9655,7 @@ packages:
   license_family: BSD
   size: 34181
   timestamp: 1670944177415
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py38haa95532_0.tar.bz2
   sha256: f158ef25e17ac404ec86a1ea70b669b030d6c0de9a0fda3d771e549b1fa4267e
   md5: 2439ebab6b108f6dff71470d0ab8c155
   depends:
@@ -9664,7 +9664,7 @@ packages:
   license_family: MIT
   size: 265962
   timestamp: 1713974451306
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.2-py38haa95532_0.tar.bz2
   sha256: a0fe49498b6c35394183fb24e8139b7d6f9deb2dc9320d26d437e89217ab0fa7
   md5: 06591ea102b7a839361a515a29be6949
   depends:
@@ -9676,7 +9676,7 @@ packages:
   license_family: BSD
   size: 61364
   timestamp: 1711137144810
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py38h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py38h2bbff1b_0.tar.bz2
   sha256: d240e28ed9a4811cfc05231c91bf802759fcf62b3e7f204301033c957a6fd4fe
   md5: 5ed775395d75942dce0868bfcabeb62f
   depends:
@@ -9686,7 +9686,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13563755
   timestamp: 1669938230510
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py38h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py38h5da7b33_0.tar.bz2
   sha256: 0837ed20156196759f729786bf50d71f17d04259e4eba815015567879659ea54
   md5: e7ba4d7e36f0992af849c36116e4a6e9
   depends:
@@ -9698,7 +9698,7 @@ packages:
   license_family: MIT
   size: 239545
   timestamp: 1677611005756
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.2-py38h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.2-py38h827c3e9_0.tar.bz2
   sha256: 0a9e19302123ae09e99c03b98ecb9a462d7b4d0a18ab91d888e75a76bb357237
   md5: 5410f7fc0a7dfa882954e7b73e9f2b6e
   depends:
@@ -9710,7 +9710,7 @@ packages:
   license_family: MIT
   size: 179036
   timestamp: 1728658282508
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py38h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-24.0.1-py38h2bbff1b_0.tar.bz2
   sha256: cadac9c8b38ed3df5c6ceb3706c4b4b4fc8d6e8c4d54627fa2938532e91c1186
   md5: 30258aac1269a14121b87c672af7cea8
   depends:
@@ -9722,7 +9722,7 @@ packages:
   license_family: Other
   size: 474436
   timestamp: 1709318658150
-- conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
   sha256: 720f3dd1f933d035b1393951ffd1b6437fc5e19b1999e74096044514a46053fb
   md5: add2dfb15b518144663fc3b897d66da7
   depends:
@@ -9731,7 +9731,7 @@ packages:
   license: BSD-3-Clause
   size: 493391
   timestamp: 1652432364793
-- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py38haa95532_0.tar.bz2
   sha256: f4519afbba3dc9cd3c7764b4b89000a5df6ed758e016bede3d11a00d4c3d0655
   md5: 802a7a1a9471a1f27bede2c9482be4c7
   depends:
@@ -9742,7 +9742,7 @@ packages:
   license_family: MIT
   size: 58577
   timestamp: 1699012264752
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.32.3-py38haa95532_0.tar.bz2
   sha256: 35f31650b4b53c381f16a7d59146198bb0db1a8b7b805e168f76e6de3975bc69
   md5: 6d7108711a7ef5c0f4ae3b3553439ca6
   depends:
@@ -9758,7 +9758,7 @@ packages:
   license_family: Apache
   size: 98240
   timestamp: 1721411091470
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-toolbelt-1.0.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-toolbelt-1.0.0-py38haa95532_0.tar.bz2
   sha256: 3f38c36947d874b4f3334348c3453846d19cfabd4718079417fc435128bac73c
   md5: bee36c697375e9b8b0ed9d4139c8d1ed
   depends:
@@ -9768,7 +9768,7 @@ packages:
   license_family: Apache
   size: 69084
   timestamp: 1690874189975
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py38haa95532_0.tar.bz2
   sha256: 53437dd569219b71d83e3799ebd2e5514e940f50d6fb908ab3966427e8ddf16b
   md5: e456bebb8b2a3779967277571db652fb
   depends:
@@ -9778,7 +9778,7 @@ packages:
   license_family: MIT
   size: 9290
   timestamp: 1683077294639
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py38haa95532_0.tar.bz2
   sha256: d2b272af194723b9d2e30ffd94f630798a66796878710bc8ba337da81b306055
   md5: 173612d663a52a177d44462181a35899
   depends:
@@ -9787,7 +9787,7 @@ packages:
   license_family: MIT
   size: 9691
   timestamp: 1683059225771
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py38h062c2fa_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py38h062c2fa_0.tar.bz2
   sha256: 620dd3556af2db0bfbf9c21667f106b57e9f16e36b4903b0afdd822a4f76de9b
   md5: 84dba3563407bc92522ad7d008a82ac1
   depends:
@@ -9798,7 +9798,7 @@ packages:
   license_family: MIT
   size: 215611
   timestamp: 1698947727458
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ruamel.yaml.clib-0.2.8-py38h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ruamel.yaml.clib-0.2.8-py38h827c3e9_0.tar.bz2
   sha256: 30e74f49beebd5a3d54f00c7c0ce560b9194d35b9ec3992c5bc5396878c728cb
   md5: d318bc73b1041d2e15ac6cf4fd568277
   depends:
@@ -9809,7 +9809,7 @@ packages:
   license_family: MIT
   size: 135777
   timestamp: 1727769944390
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ruamel_yaml-0.17.21-py38h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ruamel_yaml-0.17.21-py38h2bbff1b_0.tar.bz2
   sha256: 9c1d6c0365f2ebbad98225b08d5fd30e4940169e15d1431b5189fbd0af15561b
   md5: 1e3c0468635d9afcd6ecac24d5800a26
   depends:
@@ -9821,7 +9821,7 @@ packages:
   license_family: MIT
   size: 174039
   timestamp: 1667490202777
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.10.1-py38hdcfc7df_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/scipy-1.10.1-py38hdcfc7df_1.tar.bz2
   sha256: bf0f58b61e8e18aa58f5bdf025e8ee649c778b8be27c5f5ddff495add793ad93
   md5: 09fa3db77bb4c0e9d4349268215dd515
   depends:
@@ -9841,7 +9841,7 @@ packages:
   license_family: BSD
   size: 22338144
   timestamp: 1683289522517
-- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py38haa95532_0.tar.bz2
   sha256: 2c2d4128023c4537559caa7c5ddd53cf773c6a914b4f3354db2899d205175430
   md5: 6a95122f18e9da1d1a5670319d00c098
   depends:
@@ -9850,7 +9850,7 @@ packages:
   license_family: BSD
   size: 83165
   timestamp: 1699371260823
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-60.9.3-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-60.9.3-py38haa95532_0.tar.bz2
   sha256: 36bb8e035e4d832ac9bea36f80cb533f35962c690e0941fd0f2d4d32db7cb061
   md5: d3ad664c69463374f13539d41222cc96
   depends:
@@ -9859,7 +9859,7 @@ packages:
   license_family: MIT
   size: 1205019
   timestamp: 1685710613748
-- conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
   sha256: 5e5f855a70cf4c9dc6f2ac8d9fa51a3f095bf4db8e2ee3ff213ef5432556d7cd
   md5: 9c1f7331a4116e5c27d8af7453f8ee47
   depends:
@@ -9869,7 +9869,7 @@ packages:
   license_family: BSD
   size: 119274
   timestamp: 1723557526373
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py38haa95532_0.tar.bz2
   sha256: 728311a6829f37c3a02e82cef0cb6fa0afe9cc87a25a4dda903f9532c9252555
   md5: 783fa55ced605a2ae1bb9204fb8b7b37
   depends:
@@ -9878,7 +9878,7 @@ packages:
   license_family: Other
   size: 17519
   timestamp: 1705431546158
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py38haa95532_0.tar.bz2
   sha256: 3a2bdd00f7f0fa19d73a8875e9f004cae98d3fa27f36c59cd4567f3282944e11
   md5: ccdd22fbfe632c7ffea52096483b2165
   depends:
@@ -9887,7 +9887,7 @@ packages:
   license_family: MIT
   size: 67208
   timestamp: 1696347669660
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
   sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
   md5: 833b93a2daade3407898f15588945d83
   depends:
@@ -9897,7 +9897,7 @@ packages:
   license_family: Other
   size: 1440481
   timestamp: 1714488344682
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -9907,7 +9907,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py38haa95532_0.tar.bz2
   sha256: d14d51a32e509950bb85e78c35dceed18cbeb223ec3e9e224e0d22d65e3461ae
   md5: 85fd7e0f17c59be2e562bebb896aa5a5
   depends:
@@ -9918,7 +9918,7 @@ packages:
   license_family: BSD
   size: 30613
   timestamp: 1671751910139
-- conda: https://repo.anaconda.com/pkgs/main/win-64/thrift-0.17.0-py38hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/thrift-0.17.0-py38hd77b12b_0.tar.bz2
   sha256: 197f94f383678caf1d0e2a0654c9ed7458c83f8cc5815e6290d81e1cc065a608
   md5: 60bb17422fd2875317b1291962bca208
   depends:
@@ -9930,7 +9930,7 @@ packages:
   license_family: APACHE
   size: 123880
   timestamp: 1666297055932
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py38haa95532_0.tar.bz2
   sha256: 4be11dd7c28be1483dc46313028839da5aa8a59b0626ee20608096787d361468
   md5: e32a18bc0812d900753ca292ac13aa9a
   depends:
@@ -9940,7 +9940,7 @@ packages:
   license_family: BSD
   size: 39998
   timestamp: 1668169047244
-- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py38haa95532_0.tar.bz2
   sha256: 8d7efb76d1afa3e7e4491e8496f46257bbee2eaf233549ca841f1bcbe4194489
   md5: e085f8c809e8c4296756e411b7ffa598
   depends:
@@ -9949,7 +9949,7 @@ packages:
   license_family: BSD
   size: 102335
   timestamp: 1667464250061
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.1-py38h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.4.1-py38h827c3e9_0.tar.bz2
   sha256: 5e9b1f8b60181248cb26c42e5c83ee51e3556ff9df8f7d5e9922bc7289093f5b
   md5: 2e39dc0430d827b40520a34b592a0672
   depends:
@@ -9960,7 +9960,7 @@ packages:
   license_family: Apache
   size: 706661
   timestamp: 1718740573799
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.5-py38h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.66.5-py38h9909e9c_0.tar.bz2
   sha256: 022915ff2dfd53e2fc3735921eece63b1347803ba3e043ee7831524b824ffec8
   md5: 135ac2b699e79cfff0cf5c33b510ea84
   depends:
@@ -9972,7 +9972,7 @@ packages:
   license_family: MOZILLA
   size: 158027
   timestamp: 1724854216605
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.14.3-py38haa95532_0.tar.bz2
   sha256: a41fa042ae4366f1f82368825c77e0d3b08c6b8dcb49cccf6e5673c2c771f855
   md5: 50c1dee824e554ce4fe9b1d481528b70
   depends:
@@ -9981,7 +9981,7 @@ packages:
   license_family: BSD
   size: 166617
   timestamp: 1718227282769
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.11.0-py38haa95532_0.tar.bz2
   sha256: a8362181d2dbc1dcfe0b75396ff3c1a66c8327d9ad4f4cad4c55d4bb1f4b8069
   md5: 76cf1c2b7dafa987beb53fcbe362dac1
   depends:
@@ -9991,7 +9991,7 @@ packages:
   license_family: PSF
   size: 9653
   timestamp: 1715269022029
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.11.0-py38haa95532_0.tar.bz2
   sha256: c3d7e68393ea6ee3d038fe47db1a488294442f7c5124d26cb4df740aed4d56f9
   md5: 119df8c6748ebedc816518bf34ff1abe
   depends:
@@ -10000,7 +10000,7 @@ packages:
   license_family: PSF
   size: 60977
   timestamp: 1715269013136
-- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py38h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py38h2bbff1b_0.tar.bz2
   sha256: f88c0257dd2545da3579db91e8d4b3652cea5b283e08cde45a88956d2d7224be
   md5: 7f43d8d3be634fb410ce3d3b2638bcba
   depends:
@@ -10011,7 +10011,7 @@ packages:
   license_family: Apache
   size: 513340
   timestamp: 1713213091943
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uriparser-0.9.7-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uriparser-0.9.7-h2bbff1b_0.tar.bz2
   sha256: f88e04209064e9a72fccc9284271405d9548106c2bf302e24fa1e8e8bb36a127
   md5: 8845191f3242c429e10220e3ed9ee73c
   depends:
@@ -10021,7 +10021,7 @@ packages:
   license_family: BSD
   size: 48486
   timestamp: 1692187056029
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.3-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-2.2.3-py38haa95532_0.tar.bz2
   sha256: 498f32de934c366c83797e62db791f557eb40eb55b8d252343502146473e9831
   md5: 14823eff3cdd21b5786b1b0baa3d10fd
   depends:
@@ -10037,7 +10037,7 @@ packages:
   license_family: MIT
   size: 171470
   timestamp: 1727770062754
-- conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
   sha256: 2ef16d0252e04063d44d0683831d55b485f713fe5af2c2efd61753fb4f27d7e4
   md5: 256ab1d5dce70111a1f4807a5a9fc322
   depends:
@@ -10047,7 +10047,7 @@ packages:
   license_family: MIT
   size: 100982
   timestamp: 1706894771410
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.40-h2eaa2aa_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.40-h2eaa2aa_1.tar.bz2
   sha256: 5bbfaacd95bb901683d6d2e7a1ee10f67172acc1e012f73f80bfef5237ae3ae4
   md5: f37ef4381071123903074612dad356f4
   depends:
@@ -10056,12 +10056,12 @@ packages:
   license_family: BSD
   size: 9122
   timestamp: 1726064402583
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.40.33807-h98bb1dd_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.40.33807-h98bb1dd_1.tar.bz2
   sha256: d82b5b2b1a9a1b37da109039274c125355ce478a199c07c7826ac0fdc2178491
   md5: a0f93c06400da31b9e6e0538eab91216
   size: 2611238
   timestamp: 1726064391949
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py38_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py38_1.tar.bz2
   sha256: 40b0596a8728dd040d7afef235a73b20909f92fbe9a9ef202f3e5256d047bbdc
   md5: 492eeefe2b9f3274156a1b37699ea90e
   depends:
@@ -10070,7 +10070,7 @@ packages:
   license_family: BSD
   size: 20563
   timestamp: 1573199884688
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py38haa95532_0.tar.bz2
   sha256: 7ee947d6276b7806b642180f0e120bcb7ef712943201b9484b6c5c99af74380a
   md5: e7488420416136007b3cbdcef4d5c224
   depends:
@@ -10079,7 +10079,7 @@ packages:
   license_family: Apache
   size: 117163
   timestamp: 1715878730190
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.44.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.44.0-py38haa95532_0.tar.bz2
   sha256: d599c12d4d6fafe21ec915e19acfba2ba8a1f4636dd3cc94cad30555eadc12d7
   md5: fbea4f9065c4c82926cb066b52fdea01
   depends:
@@ -10088,7 +10088,7 @@ packages:
   license_family: MIT
   size: 135624
   timestamp: 1726165065426
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py38haa95532_0.tar.bz2
   sha256: e07f40fc2c8751784dba016e68ef289ae997bf018a773e71d83b23e1e30a55f3
   md5: 749ad2e1134684ca10f25aa30a35864b
   depends:
@@ -10096,13 +10096,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 34107
   timestamp: 1605306214957
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2022.11.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xarray-2022.11.0-py38haa95532_0.tar.bz2
   sha256: bbd799a929cfc29f95c6fc46c08d1939c87edc8fa0e96ba89ce44ce65f95479e
   md5: 4fcbc4128904506d54b173b01c6f7659
   depends:
@@ -10114,7 +10114,7 @@ packages:
   license_family: Apache
   size: 1727670
   timestamp: 1668777347091
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py38haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py38haa95532_1.tar.bz2
   sha256: 79a0c08ff87f51a742b9a0cb668482035a5b8b94bb9a651cd0242da916a23125
   md5: a8b49e46e8f6ccb6fc3e2e17a41764a6
   depends:
@@ -10123,7 +10123,7 @@ packages:
   license_family: BSD
   size: 48792
   timestamp: 1675159225274
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
   sha256: 344a5276a9928638dcde054dfe4e87c8cb40bd2d4d356378b9ab2f863ca62e4b
   md5: fe471fd8b5a3d77be6fa5dbf9b99dafb
   depends:
@@ -10133,7 +10133,7 @@ packages:
   license_family: GPL2
   size: 1432281
   timestamp: 1714515119689
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -10142,7 +10142,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
   sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
   md5: e5aed81295b61b6d1eb62830799a0297
   depends:
@@ -10153,7 +10153,7 @@ packages:
   license_family: Other
   size: 9125184
   timestamp: 1705602328351
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zict-3.0.0-py38haa95532_0.tar.bz2
   sha256: 02aeb80c081705443df2555d6025dd2b49b01ceef49515998a18fd83cc5eaf0a
   md5: 6bbba9816851fd3ca6bcbb21528c59bd
   depends:
@@ -10164,7 +10164,7 @@ packages:
   license_family: BSD
   size: 76700
   timestamp: 1695833271895
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.20.2-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.20.2-py38haa95532_0.tar.bz2
   sha256: 461dabc31cf1f9c955265ca732b4c49cde49f5d68ba69f552afd6b7cac8ebab0
   md5: c12ee2fe3b832b11f929676873ac8530
   depends:
@@ -10173,7 +10173,7 @@ packages:
   license_family: MIT
   size: 25916
   timestamp: 1729012487676
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
   sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
   md5: f295b54ab59f5b8658e2a322ac6aa721
   depends:
@@ -10183,7 +10183,7 @@ packages:
   license_family: Other
   size: 162161
   timestamp: 1714514792081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstandard-0.23.0-py38h4fc1ca9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstandard-0.23.0-py38h4fc1ca9_0.tar.bz2
   sha256: e1813703d909837e47350ecf070eb8e2e4c238026028f4bbd8ec1550a7aaecac
   md5: 11594a3e51725ac2c7903e112b674582
   depends:
@@ -10197,7 +10197,7 @@ packages:
   license_family: BSD
   size: 380046
   timestamp: 1728569372889
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
   sha256: 1f68cd378c6cdec34a5a3a21c56c9b8422b0f037b868b3db72065c0a2ca27921
   md5: d455a04486eddfb94c280974c0c33ae3
   depends:

--- a/datashader_dashboard/pixi.lock
+++ b/datashader_dashboard/pixi.lock
@@ -1,0 +1,10212 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-anon-usage-0.4.4-py38hfc0e8ea_100.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-client-1.12.3-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-project-0.11.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py38h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-4.0.1-py38hced866c_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-24.2.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.4.57-he6710b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.1.6-h2531618_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.9-he6710b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.8.185-hce553d0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.73.0-h27cfd23_11.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py38ha9d4c09_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py38h6a678d5_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.9.24-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.8.30-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py38h1fdaa30_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.0.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-pack-0.7.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-handling-2.3.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-streaming-0.10.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.0.5-py38hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.2-py38h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py38h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py38h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2.30.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/double-conversion-3.1.5-he6710b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.2.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-0.5.0-py38h7deecbd_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py38h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.6.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/grpc-cpp-1.26.0-hf8bcb03_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.4.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intake-0.6.8-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.12.2-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.23.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py38h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py38h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h568e23c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.73.0-h3ff78a5_11.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.2.1-h91b91d3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-h8f2d780_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.1.0-h9e868ea_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.52.0-ha637b67_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-3.11.2-hd408876_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-h37d81fd_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.13.0-hfb8234f_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h85742a9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.38.0-py38h4ff587b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py38h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.7.2-py38h1128e8f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py38h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py38h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py38hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py38hd09550d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py38_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.16.4-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.55.1-py38h51133e4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.4-py38hc78ab66_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.21.6-py38h5f9d8c6_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.21.6-py38hb5e798b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h9ca470c_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-1.6.7-h973521d_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.5.3-py38h417a72b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.4.0-py38h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.2-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pkgutil-resolve-name-1.3.10-py38h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pooch-1.7.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py38h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-4.0.1-py38he0739d4_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py38h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.8.18-h7a1cb2a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py38h06a4308_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py38h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-snappy-0.6.1-py38h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py38h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py38h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-toolbelt-1.0.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py38hb02cf49_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel.yaml.clib-0.2.8-py38h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel_yaml-0.17.21-py38h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.10.1-py38hf6e8229_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-60.9.3-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/thrift-0.17.0-py38h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.1-py38h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.5-py38h2f386ee_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py38h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uriparser-0.9.7-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.3-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py38_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.44.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2022.11.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py38h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.20.2-py38h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstandard-0.19.0-py38h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.4.9-haebb681_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2.30.0-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2.30.0-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.8-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/hvplot-0.7.3-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/intake-parquet-0.2.3-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.7-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2.30.0-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2.30.0-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.8-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/hvplot-0.7.3-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/intake-parquet-0.2.3-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.7-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anaconda-anon-usage-0.4.4-py38hfb7c958_100.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anaconda-client-1.12.3-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anaconda-project-0.11.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py38hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py38hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-4.0.1-py38hf7c73f6_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.2.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.4.57-hb1e8313_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.1.6-h23ab428_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.9-hb1e8313_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.8.185-he271ece_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.4.3-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.73.0-h9ed2024_11.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py38h7b7cdfe_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py38hcec6c5f_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.9.24-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.8.30-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py38h9205ec4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.0.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/conda-pack-0.7.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/conda-package-handling-2.3.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/conda-package-streaming-0.10.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py38haf03e11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.2-py38h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py38hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py38hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2.30.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/double-conversion-3.1.5-haf313ee_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.2.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-0.5.0-py38h67323c0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py38h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.6.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/grpc-cpp-1.26.0-h044775b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-58.2-h0a44026_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.4.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intake-0.6.8-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.12.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.23.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py38hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py38hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.73.0-hd4c2dcd_11.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h0a4fc7d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm11-11.1.0-h46f1229_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-3.11.2-hd9629dc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.13.0-h054ceb0_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.2.0-h87d7836_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.38.0-py38h8346a28_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py38h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.7.2-py38hee32256_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py38h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py38h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py38ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py38haf03e11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py38_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.4-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.55.1-py38hae1ba45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.4-py38h47b59a4_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.21.6-py38h827a554_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.21.6-py38ha186be2_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h7231236_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-1.6.7-h001ef8f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-1.5.3-py38h07fba90_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.4.0-py38h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pkgutil-resolve-name-1.3.10-py38hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pooch-1.7.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py38hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-4.0.1-py38hdf3e9eb_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py38hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py38_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.8.18-h218abb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py38hecd8cb5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py38hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-snappy-0.6.1-py38hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py38h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py38h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-toolbelt-1.0.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py38hf2ad997_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ruamel.yaml.clib-0.2.8-py38h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ruamel_yaml-0.17.21-py38hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.10.1-py38hf241641_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-60.9.3-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/thrift-0.17.0-py38he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.1-py38h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.5-py38h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py38h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uriparser-0.9.7-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.3-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py38_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.44.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2022.11.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py38hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.20.2-py38hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstandard-0.19.0-py38h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.4.9-h322a384_0.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2.10.1-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2.10.1-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/distributed-2.10.0-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.8-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/hvplot-0.7.3-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/intake-parquet-0.2.3-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.7-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/abseil-cpp-20210324.2-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-anon-usage-0.4.4-py38hd6b623d_100.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-client-1.12.3-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-project-0.11.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py38hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py38h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-4.0.1-py38hd7469ad_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-24.2.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.6.8-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.1.6-h313beb8_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.11-h80987f9_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.8.185-h4a942e0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-2.4.3-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.73.0-h1a28f6b_11.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py38hbda83bc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py38h313beb8_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.9.24-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.8.30-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py38h3eb5a62_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.0.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-pack-0.7.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-handling-2.3.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-streaming-0.10.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py38h525c30c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.2-py38h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py38hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py38h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/double-conversion-3.1.5-hc377ac9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.2.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-0.5.0-py38heec5a64_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py38h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.6.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpc-cpp-1.39.0-h95c9599_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-68.1-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.4.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/intake-0.6.8-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.12.2-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.23.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py38hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py38h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.73.0-h49e8a49_11.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-hf27765b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm11-11.1.0-h12f7ac0_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-3.17.2-h98b2900_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.13.0-hd358383_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.2.0-h11e2f9f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.38.0-py38h98b2900_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py38h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.7.2-py38h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py38h525c30c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.4-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.55.1-py38h9197a36_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.4-py38h79ee842_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.21.6-py38hb93e574_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.21.6-py38haf87e8b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.4.0-h0ed58ac_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-1.6.9-hb65cfe6_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-1.5.3-py38h78102c4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.4.0-py38h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.2-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pkgutil-resolve-name-1.3.10-py38hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pooch-1.7.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py38h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-4.0.1-py38hd776c02_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py38hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.8.18-hc0d8a6c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py38hca03da5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py38h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-snappy-0.6.1-py38h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.2-py38h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py38h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-toolbelt-1.0.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py38hf0e4da2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel.yaml.clib-0.2.8-py38h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel_yaml-0.17.21-py38h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.10.1-py38h9d039d2_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-60.9.3-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/thrift-0.17.0-py38hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.1-py38h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.5-py38h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py38h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uriparser-0.9.7-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.3-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py38hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.44.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2022.11.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py38hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.20.2-py38hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstandard-0.19.0-py38h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.4.9-h8574219_1.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2.30.0-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2.30.0-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.8-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/hvplot-0.7.3-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/intake-parquet-0.2.3-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.7-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-anon-usage-0.4.4-py38hfc23b7f_100.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-client-1.12.3-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-project-0.11.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py38h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-4.0.1-py38h0d1d0e5_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-24.2.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.4.57-ha925a31_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.1.6-hd77b12b_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.9-ha925a31_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.8.185-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-2.4.3-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.73.0-h2bbff1b_12.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py38h9128911_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py38hd77b12b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.9.24-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.8.30-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py38h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.0.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/conda-pack-0.7.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-handling-2.3.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-streaming-0.10.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py38h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.2-py38h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py38haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py38hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2.30.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/double-conversion-3.1.5-ha925a31_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.2.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-0.5.0-py38h080aedc_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py38h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.6.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/grpc-cpp-1.26.0-h351948d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.4.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intake-0.6.8-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.12.2-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.23.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py38haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py38hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.73.0-h6c2663c_12.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.9.1-h0416ee5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-3.11.2-h7bd577a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-hcd4344a_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.38.0-py38h23ce68f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py38h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.7.2-py38h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py38h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py38h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py38h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py38h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py38_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.4-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.55.1-py38hf11a4ad_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.4-py38h7b80656_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.21.6-py38h85e1a82_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.21.6-py38hb5c95e7_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-1.5.3-py38hf11a4ad_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.4.0-py38h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.2-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pkgutil-resolve-name-1.3.10-py38haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pooch-1.7.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py38h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-4.0.1-py38h953b917_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py38haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.8.18-h6244533_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py38haa95532_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py38hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-snappy-0.6.1-py38hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py38h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py38h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.2-py38h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py38h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-toolbelt-1.0.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py38h062c2fa_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ruamel.yaml.clib-0.2.8-py38h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ruamel_yaml-0.17.21-py38h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.10.1-py38hdcfc7df_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-60.9.3-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/thrift-0.17.0-py38hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.1-py38h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.5-py38h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py38h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uriparser-0.9.7-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.3-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.40-h2eaa2aa_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.40.33807-h98bb1dd_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py38_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.44.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2022.11.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py38haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.20.2-py38haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstandard-0.23.0-py38h4fc1ca9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+  sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
+  md5: 613805add1c05b538ff06d217252feb7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 20810
+  timestamp: 1652859733309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-anon-usage-0.4.4-py38hfc0e8ea_100.tar.bz2
+  sha256: b73d3f04aff05d074c30e87e5585386e601ce2f1c53a5272237f23c6a71e17ca
+  md5: 5d167486fd7cb6ec609ff51377886a9a
+  depends:
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - anaconda-ident <0.6.0
+  - conda >=23.7,<26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23841
+  timestamp: 1710966364697
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-client-1.12.3-py38h06a4308_0.tar.bz2
+  sha256: d6bdfa40fb99b38abf42ab435b01f8083fa4c21597e9d5073ad0c92b9bf1bf47
+  md5: 9c13bfe061d4fd4df4fdfb7f8a48b66c
+  depends:
+  - anaconda-anon-usage >=0.4.0
+  - conda-package-handling >=1.7.3
+  - defusedxml >=0.7.1
+  - nbformat >=4.4.0
+  - platformdirs >=3.10.0,<5.0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.6.1
+  - pytz >=2021.3
+  - pyyaml >=3.12
+  - requests >=2.20.0
+  - requests-toolbelt >=0.9.1
+  - setuptools >=58.0.4
+  - six >=1.15.0
+  - tqdm >=4.56.0
+  - urllib3 >=1.26.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 140194
+  timestamp: 1708640877290
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anaconda-project-0.11.1-py38h06a4308_0.tar.bz2
+  sha256: 697c8858e553c32cddc67601012a5e33f80e8f8c929e9f5b15b27dc7cbac3844
+  md5: 6b0c787dc9dfa7e388804388324565f8
+  depends:
+  - anaconda-client
+  - conda-pack
+  - jinja2
+  - python >=3.8,<3.9.0a0
+  - requests
+  - ruamel_yaml
+  - tornado >=4.2
+  - tqdm
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 544176
+  timestamp: 1660339965043
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py38h06a4308_0.tar.bz2
+  sha256: 81c0b302c60444025a3f58629dc650ee00ef381266c49fcb9eb65d625610c2a9
+  md5: 25af24630b7e1521684421423eb0af86
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.8,<3.9.0a0
+  - sniffio >=1.1
+  - typing_extensions >=4.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 173515
+  timestamp: 1706220222537
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py38h7f8727e_0.tar.bz2
+  sha256: 754046398c314772a7d38b7d4c0d488a48db7b1b9c6a421686ef13178e1997b9
+  md5: e785c0744d3ed83d813a42b7bb9b8794
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=7.5.0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 35378
+  timestamp: 1644569723962
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-4.0.1-py38hced866c_3.tar.bz2
+  sha256: ecbaa1c83b0b862d4ed773fe54c0da6ed9405283a251eadfee671c96db00e5b4
+  md5: 3d0d127e914827662f83ec94c3171ff7
+  depends:
+  - aws-sdk-cpp >=1.8.185,<1.8.186.0a0
+  - boost-cpp
+  - brotli >=1.0.9,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-ares >=1.17.1,<2.0a0
+  - double-conversion
+  - gflags >=2.2.2,<2.3.0a0
+  - glog
+  - grpc-cpp
+  - libboost >=1.73.0,<1.73.1.0a0
+  - libgcc-ng >=7.3.0
+  - libprotobuf >=3.11.2,<3.12.0a0
+  - libstdcxx-ng >=7.3.0
+  - libthrift >=0.13.0,<0.14.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - numpy >=1.11,<2.0a0
+  - openssl >=1.1.1k,<1.1.2a
+  - orc >=1.6.7,<1.6.8.0a0
+  - python >=3.8,<3.9.0a0
+  - re2
+  - snappy >=1.1.8,<2.0a0
+  - uriparser
+  - utf8proc <2.9.0
+  - zlib
+  - zstd >=1.4.9,<1.5.0a0
+  license: Apache 2.0
+  license_family: Apache
+  size: 8738938
+  timestamp: 1622563173502
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-24.2.0-py38h06a4308_0.tar.bz2
+  sha256: 7cee7158a2a214c72a5bdb5953eafe138f895c7ebc5d948f0711a58c5779fd59
+  md5: 117b0e2a4d24435fc67cf639dfe6b9a8
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 141122
+  timestamp: 1729089430211
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.4.57-he6710b0_1.tar.bz2
+  sha256: bc87abecbc7e34b42b5a7ec3a3470ee284ed82f5f638274f795810fd0aa85496
+  md5: e883ae27a33cff702b8a20b5394e9ae0
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 164855
+  timestamp: 1601398346279
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.1.6-h2531618_5.tar.bz2
+  sha256: 4f7d93ed96f6692266a700971029b841dc972a6af39b85ba9525eebe2c40edbb
+  md5: 6b7ceb5ff64fc9f4537bfe7a2d7fe4a0
+  depends:
+  - aws-c-common >=0.4.57,<0.4.58.0a0
+  - aws-checksums >=0.1.9,<0.1.10.0a0
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 25449
+  timestamp: 1603894551837
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.9-he6710b0_0.tar.bz2
+  sha256: 17d0e3361698b9a0a9b52836284b658886d25bf349f3a099b765eac23ceb4ebd
+  md5: 0a7ed2b675a5af15d4979f4ca5c93d39
+  depends:
+  - aws-c-common >=0.4.57,<0.4.58.0a0
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52520
+  timestamp: 1601398555928
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.8.185-hce553d0_0.tar.bz2
+  sha256: 2842aafc907c01ccbe26ca11bddad6c55e9f93d30cf57431e327f5e57666be2c
+  md5: 5b4e9429338430ef3b71802778ac2184
+  depends:
+  - aws-c-common >=0.4.57,<0.4.58.0a0
+  - aws-c-event-stream >=0.1.6,<0.1.7.0a0
+  - libcurl >=7.71.1,<9.0a0
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - openssl >=1.1.1k,<1.1.2a
+  license: Apache-2.0
+  license_family: Apache
+  size: 2442091
+  timestamp: 1618434946994
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py38h06a4308_0.tar.bz2
+  sha256: 6739f4b541ac211695cdd0b3111d414d05a4fa76b6c2bff75f16c18f71acff9b
+  md5: 61d90626295e5947ebe5b20336aebbe5
+  depends:
+  - python >=3.8,<3.9.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 213661
+  timestamp: 1718029873484
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py38h06a4308_0.tar.bz2
+  sha256: c5ab37760e889de86ff84573af7b2209b522b71a8204aaddcf56aaa9e1ed7a2e
+  md5: cdb0ee83e9c478d96d12c837716659ee
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.8,<3.9.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14441483
+  timestamp: 1658136913187
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.73.0-h27cfd23_11.tar.bz2
+  sha256: 22618c69b5ccb053932032e6ae383043b3f421321f59eadb9fc642ffcb19e4f8
+  md5: 09641ed5d9055c5fe4e326ae1516b514
+  depends:
+  - libboost 1.73.0 h3ff78a5_11
+  - libgcc-ng >=7.3.0
+  license: Boost-1.0
+  size: 24776
+  timestamp: 1611677121434
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py38ha9d4c09_0.tar.bz2
+  sha256: 303969d4cad67aea4c419a5fa7898e14a9eb687f842f9bbbd26d38a57cb587d7
+  md5: 85573eff55231ce12b2524b1bc9cd680
+  depends:
+  - libgcc-ng >=11.2.0
+  - numpy >=1.21.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 128997
+  timestamp: 1707864355732
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 5d15605858771290fdaaae41a43941623757a25cb1292080d69d6d3857807935
+  md5: 7f517469aa5380c52e55db9f37df104f
+  depends:
+  - brotli-bin 1.0.9 h5eee18b_8
+  - libbrotlidec 1.0.9 h5eee18b_8
+  - libbrotlienc 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 18652
+  timestamp: 1714483267080
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+  sha256: a5094f078584e27c7cced4a9564ae904a329f5c1702a7c1ba092d581ba1544f1
+  md5: 6ddf45dd8a21a9512481de9bc0e5a03f
+  depends:
+  - libbrotlidec 1.0.9 h5eee18b_8
+  - libbrotlienc 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 19711
+  timestamp: 1714483255915
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py38h6a678d5_8.tar.bz2
+  sha256: 32a5fa6d1daec0cf439cd62c837635c8b8ff43501040c6741a7aa07cb0cff7a0
+  md5: 40ee797fbc97009e705f319281714347
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  size: 361224
+  timestamp: 1714483375944
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+  sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
+  md5: f5058c8d5b2994b7334f18e022105a14
+  depends:
+  - libgcc-ng >=11.2.0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 427542
+  timestamp: 1714510571510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+  sha256: 5b4c80587ae4ec915505469f79d866f27c80456156667c8548d31c67c2c1653e
+  md5: c3d6bfae757760082261779c406a880d
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 116270
+  timestamp: 1693902021950
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.9.24-h06a4308_0.tar.bz2
+  sha256: e9f2e55d34b1b0b9b48e48a1d6e4503653f8b7059114d23f758b7c68dde2334a
+  md5: 4a091502b44d4090f30f0be847a8139c
+  license: MPL-2.0
+  license_family: Other
+  size: 139901
+  timestamp: 1727794854964
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.8.30-py38h06a4308_0.tar.bz2
+  sha256: d7e2a831580f09a3919fd16f00835527dc0bcae5c1dd996996d446fb93066aaf
+  md5: bbe57eaf0c4b8ec3e13e09f5889211c6
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 167786
+  timestamp: 1725551758984
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py38h1fdaa30_0.tar.bz2
+  sha256: a76a4d5f1a562134ce1600dc06c86404e866b1e9e1fdb8c77879fb7fec95c58e
+  md5: 8164a1a89ade4f794d748c1b254e32bf
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 240177
+  timestamp: 1726856583659
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py38h06a4308_0.tar.bz2
+  sha256: 280c41c89637ee535905d1d49ef30b9ce8cc9c4ede2071cf06e48958c737eedb
+  md5: 89f82ddfd7c0a44207eeaf297b34bd49
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 151614
+  timestamp: 1698129899368
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.0.0-py38h06a4308_0.tar.bz2
+  sha256: f5ddbcb0abbf7b452e84f6d0e8706e34ba337f6a804dbbc64b6507f655d7c0f0
+  md5: 7cf157c1f64d9b7093f6584871534037
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 34658
+  timestamp: 1721657412717
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py38h06a4308_0.tar.bz2
+  sha256: 8bd52fa912bfcc27891c1fe081e388c11e241a9efe0d1f4d17081f30e500ddcd
+  md5: 0ef58a5e5789b24ddc9a51ce1e2db211
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 551692
+  timestamp: 1709758436168
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py38h06a4308_0.tar.bz2
+  sha256: 18c20e63bb1281245e576c826f982d2f5ab8ec4f91d84ae065fcc8f60868707d
+  md5: cfe4d8a38291f0cddc185d90f9c375a3
+  depends:
+  - python >=3.8,<3.9.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14521
+  timestamp: 1709322872304
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-pack-0.7.1-py38h06a4308_0.tar.bz2
+  sha256: 7604210cac50634de3a0425d1ddb3e99a6beb86277550b4e68397b9a79ecc795
+  md5: 77cd6565ede632e85c1f3f1d17365549
+  depends:
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 51285
+  timestamp: 1710258126481
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-handling-2.3.0-py38h06a4308_0.tar.bz2
+  sha256: 68649d880c52d4dd2e9e4af325fed2c1c8e387ada2e53d1a524f453fe6781b5d
+  md5: eeb5999b6dbf1cee2569620ab71f78c2
+  depends:
+  - conda-package-streaming >=0.9.0
+  - python >=3.8,<3.9.0a0
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 278214
+  timestamp: 1718138355562
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/conda-package-streaming-0.10.0-py38h06a4308_0.tar.bz2
+  sha256: c3da4c862053f648ef73f7c414fc02e24d1d09f000a7a2ddca06fae5daa90141
+  md5: bcbb81867de45effea4600d2eda4f9e1
+  depends:
+  - python >=3.8,<3.9.0a0
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27259
+  timestamp: 1718136125239
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.0.5-py38hdb19cb5_0.tar.bz2
+  sha256: 1c3fd4d2cbfac81ba9226f4bc61f56199da0633660569a1c4668754e8aaef5b4
+  md5: 1fbceb30a5aeb9fb6e296b554d311973
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.16
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 233599
+  timestamp: 1663827474400
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.2-py38h5eee18b_0.tar.bz2
+  sha256: f0d4c0db6c12988306f1986c7f9194b08098a65716938b7c535cadbf55abe658
+  md5: 6897882ef37ea2e4a490ddecce92e790
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.8,<3.9.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 424601
+  timestamp: 1701723878901
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py38h06a4308_1.tar.bz2
+  sha256: 823bbb3c8951739e8ff5fbf9470cf4ca06c790fe4646388922bf29800b02acad
+  md5: 53492f02a308427dab7a204dcc2f343f
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7
+  - python >=3.8,<3.9.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 104159
+  timestamp: 1613390257727
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py38h6a678d5_0.tar.bz2
+  sha256: ef74961984f61916dba94fe5c7bbe3cf5d209e09b83baf1e0e9e5edb45f505bb
+  md5: 6530fae52928cdb84020738094760e12
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 2162264
+  timestamp: 1690905165766
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2.30.1-py38h06a4308_0.tar.bz2
+  sha256: a931cd3bcc60d6609f0f951f82ab8e9c78bdc57eef789b999d9c31f03f072837
+  md5: 053a1a3d214bcc1c95405c30331d9652
+  depends:
+  - click >=6.6
+  - cloudpickle >=1.5.0
+  - cytoolz >=0.8.2
+  - dask-core >=2.9.0
+  - msgpack-python >=0.6.0
+  - psutil >=5.0
+  - python >=3.8,<3.9.0a0
+  - pyyaml
+  - setuptools
+  - sortedcontainers !=2.0.0,!=2.0.1
+  - tblib >=1.6.0
+  - toolz >=0.8.2
+  - tornado >=6.0.3
+  - zict >=0.1.3
+  constrains:
+  - openssl !=1.1.1e,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1105808
+  timestamp: 1605066559613
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/double-conversion-3.1.5-he6710b0_1.tar.bz2
+  sha256: 636ed92de3d236204a971cacd93c731fa5142c52940a37411fef8ab23243ebde
+  md5: d58335091a21fb84be6017f879a9cec9
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 239084
+  timestamp: 1567108307419
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py38h06a4308_0.tar.bz2
+  sha256: fc256adb1e5c237867e04a2699c1eec3ea93256cfa7914880d59c69563f1c95d
+  md5: 20c8874b5ae24bf4bea2303aeb5f7f03
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16351
+  timestamp: 1649926480666
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.2.0-py38h06a4308_0.tar.bz2
+  sha256: 840e4c00530b9e0041072398837245562cac3cb674445fa3bf060bfdff08d850
+  md5: 82c4ff737ffdbae28faddaca00a8500c
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 29482
+  timestamp: 1706031454101
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-0.5.0-py38h7deecbd_2.tar.bz2
+  sha256: f0cff0cfb1d7b0b2bbfe78e224b206fd49670914364d4f21a5acc56981bc8376
+  md5: 8ca5334ce12675d3863a98ea51a9267b
+  depends:
+  - libgcc-ng >=11.2.0
+  - numba >=0.49
+  - numpy >=1.16.6,<2.0a0
+  - packaging
+  - pandas >=1.1.0
+  - python >=3.8,<3.9.0a0
+  - thrift >=0.11
+  constrains:
+  - numpy >=1.18,<1.22
+  license: Apache-2.0
+  license_family: Apache
+  size: 192321
+  timestamp: 1658500714903
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py38h5eee18b_0.tar.bz2
+  sha256: bb820ee5acdfa020de4529682848aec90b4b4f7b72c30e93922670ca68c8af0b
+  md5: 3933e8679a5a9a9fdf2628bac353def4
+  depends:
+  - brotli >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.8,<3.9.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - fs >=2.2.0,<3
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  - zopfli >=0.1.4
+  - lz4 >=1.7.4.2
+  license: MIT
+  license_family: MIT
+  size: 2709838
+  timestamp: 1713551599721
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+  sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
+  md5: a5dc8677d891dff2393b63189a3ad42f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 971975
+  timestamp: 1666798278693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.6.1-py38h06a4308_0.tar.bz2
+  sha256: 784dd97601a10e944381209ff05576880d21cdd8c52b35aa15ebfcfda80a144e
+  md5: 21ccb0ee71a1baa9be31aeb82b4f8009
+  depends:
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - pyarrow >=1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 282839
+  timestamp: 1724855608255
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+  sha256: 2fc1136056f41fe92de719fb821550346704965dd12a5fa35069cdb4948d5c17
+  md5: fd089b0fba2b03aafe3adb6cdaa9ac3b
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203421
+  timestamp: 1706888218007
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+  sha256: f1e190d4ee766add8131a2b011723c472284de2bbb5e07c8f895f30e3c591df7
+  md5: 82029e0758feac811afec2a6ef9e6155
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 108438
+  timestamp: 1706895276199
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/grpc-cpp-1.26.0-hf8bcb03_0.tar.bz2
+  sha256: 47eb032ccafbedd87787960a1ebea8d7dcee67cc0879420251430b67c8dbe3aa
+  md5: 3f4fca8649aa196df2ed0377d313bf33
+  depends:
+  - c-ares
+  - gflags >=2.2.2,<2.3.0a0
+  - libgcc-ng >=7.3.0
+  - libprotobuf >=3.11.2,<3.11.3.0a0
+  - libprotobuf >=3.11.2,<3.12.0a0
+  - libstdcxx-ng >=7.3.0
+  - openssl >=1.1.1d,<1.1.2a
+  - zlib >=1.2.11,<2.0.0a0
+  license: Apache 2.0
+  license_family: APACHE
+  size: 6323465
+  timestamp: 1580397868189
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+  sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
+  md5: 9213e0336e3a5216c989cfe52648412e
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 23805906
+  timestamp: 1588026213084
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py38h06a4308_0.tar.bz2
+  sha256: 47ca02ff580ebdfdb6f537e53eb997ba9fa16919e6de799217729df19044778f
+  md5: abbda5a815f8e6ff448015463a04104b
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 122729
+  timestamp: 1714398916443
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py38h06a4308_0.tar.bz2
+  sha256: 22fd000f3311c85981922a4bf98ea1f5fcf16511867b4a9efb1aa127889539e1
+  md5: ed207312594da3e585cee48578ad03c3
+  depends:
+  - python >=3.8,<3.9.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 41143
+  timestamp: 1704813599672
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.4.0-py38h06a4308_0.tar.bz2
+  sha256: ecb9acc656df8b75d58155ee02094c58e3b12da44c9cd0612b963c1f835176e9
+  md5: 078b461a82b6e3566d085b35f9a986a3
+  depends:
+  - python >=3.8,<3.9.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 57044
+  timestamp: 1720641149749
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intake-0.6.8-py38h06a4308_0.tar.bz2
+  sha256: 2935149f9ddffca37129022af2257b1e1f1ed6778432e22bb2fee13b4957d2cd
+  md5: 8f810d7f901ed1c2d2135830ef944f01
+  depends:
+  - appdirs
+  - dask >=1.0
+  - entrypoints
+  - fsspec >=2021.7.0
+  - jinja2
+  - msgpack-python
+  - python >=3.8,<3.9.0a0
+  - python-snappy
+  - pyyaml
+  - requests
+  - tornado
+  constrains:
+  - panel >=0.7.0
+  - hvplot
+  - bokeh
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 190444
+  timestamp: 1678787690195
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+  sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
+  md5: 3add2ce56858a1b8f6a37342f82773d3
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<1.2.14
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 19310769
+  timestamp: 1699647799237
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py38h06a4308_0.tar.bz2
+  sha256: 02bf224c27e9a3ec27ab87ca29958c0e14a874f8229a3c7b0c0839021d3623fd
+  md5: 32f787d90395709049530ed5dc713dde
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189966
+  timestamp: 1728665757818
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.12.2-py38h06a4308_0.tar.bz2
+  sha256: e413c50a320468c543fc0b434e914a1705f2078a3c349036db7457818e6c2865
+  md5: 659aa6a467e962ab07c83300d5edbdc2
+  depends:
+  - backcall
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.8,<3.9.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1232450
+  timestamp: 1691532256204
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.1-py38h06a4308_0.tar.bz2
+  sha256: a673641439b85d304ac1aa414df4695f4392e45cda13fd2ddd0a3c3dc1469535
+  md5: 7d5ec56787be4ebbec5a16718ee9ca44
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 1041775
+  timestamp: 1721058483437
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py38h06a4308_0.tar.bz2
+  sha256: 3a395f908d68944947e3c8c029e45c547165aab1436136bbd9ff8c75a3e13991
+  md5: e17c73db8358f07cb8122c933fca1fa5
+  depends:
+  - markupsafe >=2.0
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269362
+  timestamp: 1716993428097
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+  sha256: 8316ae3abee25edab89788ee6e9eef79c398aba192559f514674a04ee1860bca
+  md5: 112209aed451545a622ab217c70f6972
+  depends:
+  - libgcc-ng >=11.2.0
+  license: IJG
+  license_family: Other
+  size: 283506
+  timestamp: 1722872662693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.23.0-py38h06a4308_0.tar.bz2
+  sha256: bbd39adbb30919396738406c1f89c628943f2d5e7cb186b760183adc63d26722
+  md5: 860c6a74f3979368e0c469d55fb558a3
+  depends:
+  - attrs >=22.2.0
+  - importlib_resources >=1.4.0
+  - jsonschema-specifications >=2023.03.6
+  - pkgutil-resolve-name >=1.3.10
+  - python >=3.8,<3.9.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 143131
+  timestamp: 1728486771164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py38h06a4308_0.tar.bz2
+  sha256: ceb19fccf3b8605f59c6e9d5cc269d27f988ee6cd4f869b33cf92657d4d4a5ab
+  md5: c6faaeb8e78882bc809204faf308b607
+  depends:
+  - importlib_resources >=1.4.0
+  - python >=3.8,<3.9.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 14884
+  timestamp: 1699032456771
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py38h06a4308_0.tar.bz2
+  sha256: 4c8a46b9b7ec7121a00b2d731b1da19fc5bf9f742be31b2d73985d1b384d6a38
+  md5: 966714096421f7371663c8bfa72bfa89
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193526
+  timestamp: 1676329113709
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py38h06a4308_0.tar.bz2
+  sha256: 3086b9066f87c9e39b1f460a577bf4c9f90e8fb77c35dfe6a97e38c7453cff04
+  md5: d5870ff588e1ab9894b1e358c15c4b4d
+  depends:
+  - platformdirs >=2.5
+  - python >=3.8,<3.9.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 82166
+  timestamp: 1718818351134
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py38h06a4308_0.tar.bz2
+  sha256: 8196dfb81170e31ddd1a3fde2af70d37402db7c5ebca2fa7a631a2dc45efe43e
+  md5: 0761392754dde3344652bc219afd45e4
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.8,<3.9.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35403
+  timestamp: 1718738195926
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py38h06a4308_0.tar.bz2
+  sha256: 91fec7e3c7106a59899c66f91138659a64f2b113e043dce6ec122e2d0992dc85
+  md5: 6de544720ab8c1885e4a44d63c4ba256
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 497539
+  timestamp: 1718827343800
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py38h06a4308_1.tar.bz2
+  sha256: 44db85c9fa468cc638218817e7ccac8acb2c72d2b57c73feb35a84971821270f
+  md5: f45fb644c3b4a54fdbce4b2d4c48ee5b
+  depends:
+  - python >=3.8,<3.9.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23572
+  timestamp: 1686870759447
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py38h06a4308_0.tar.bz2
+  sha256: c70ef82b953dc472e041ed773afb291965a05df6645fa1e86d1f5c862b884bec
+  md5: 6a86c99c914f182b3cf5a3ae62048627
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18833
+  timestamp: 1700168696651
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py38h6a678d5_0.tar.bz2
+  sha256: cf12730976bd3123a14fced370792fb29703bb3415a9dc461c1a7b102fff4074
+  md5: 8a0f9997ddc49e6a31cf204b04149b3d
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 77848
+  timestamp: 1672387224889
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h568e23c_1.tar.bz2
+  sha256: 126a5fd5e59cc90c1a2c688a801dea7f352f0bb218c2f949d0f3d21db35fbe1b
+  md5: 64d1d86c812dc1843bcbb4cab2e8f60f
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=1.1.1u,<1.1.2a
+  license: MIT
+  license_family: MIT
+  size: 1426697
+  timestamp: 1686931184185
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+  sha256: 069d33aebaf4db4ae410d4acb4851860a69d2c8f326fd45ab2a67b67fe276e6d
+  md5: 61689da52cf1fcebda8c9fb2872f94bf
+  constrains:
+  - binutils_impl_linux-64 2.40
+  license: GPL-3.0-only
+  size: 723073
+  timestamp: 1727336193185
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.73.0-h3ff78a5_11.tar.bz2
+  sha256: 55e595d5b5c5c2361c56a9ea3868ed5e97c99b3ffc614487b7aec7126722292a
+  md5: b41dce08aea9e243db25a95f00708724
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  - zstd >=1.4.5,<1.5.0a0
+  license: Boost-1.0
+  size: 22298574
+  timestamp: 1611677068430
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+  sha256: bb990ea068c3b3dafd9c807e0e19570320cb2fe7d69cc326f1f0b5319b0654b2
+  md5: 3ff70744e396b1af69656c574b05c3b9
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 66940
+  timestamp: 1714483221853
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 3b87a816f72a00e1f0022a160e7eda70af89d3de2a2e08a72be1c17b31d759f3
+  md5: 4f57d3a0a13ddaf1c06efb586b702f46
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 34446
+  timestamp: 1714483232430
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 2cf15e89f910600f468edfde8d0f9b80a14fa2319ed89160dc7375dfd3764fdb
+  md5: 463adc13f2feea3570d1eccac368d9e4
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 295090
+  timestamp: 1714483244460
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.2.1-h91b91d3_0.tar.bz2
+  sha256: 8daa34822b26916b12867746d55790aa5b719e096e412aba86c5a9f13b19ee36
+  md5: bd594551d7447f93c8a1575be1b1f12e
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libgcc-ng >=11.2.0
+  - libnghttp2 >=1.52.0
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 386369
+  timestamp: 1693515365220
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+  sha256: 5bd3af246b6a93ea0912179ae66e0ad9157ca0142263010d84b65724e6db0bec
+  md5: 5cb0cc0e1783419cf8fc1c65fee0f62f
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 195807
+  timestamp: 1703006263489
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+  sha256: efdab884c85fda4461f7a393aa6d4e0e50d03cb59fb9c8a980b1307b8379ebe0
+  md5: eeca774c6154c49340dd403b1928d5e9
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 108906
+  timestamp: 1632891483341
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-h8f2d780_0.tar.bz2
+  sha256: 2b9470932f5c923f19fcc14c8d1c7ed5f58a468588c09d6b04e0a905c07a297f
+  md5: 2e3534102d10ade546c0feb056bbffbe
+  depends:
+  - libgcc-ng >=7.5.0
+  - openssl >=1.1.1m,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 491177
+  timestamp: 1642102679055
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+  sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
+  md5: 1af9b4d62c708924417f2640ef22a68f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 154016
+  timestamp: 1714483282916
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
+  md5: 641e72e5067bd6d5454405879e1cd2a7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - _libgcc_mutex * main
+  - __glibc >=2.17
+  constrains:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - libgomp 11.2.0 h1234567_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 8895144
+  timestamp: 1654090827491
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+  sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
+  md5: 27082517590f3b9fbffecc68513b461b
+  depends:
+  - libgfortran5 11.2.0.*
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 19860
+  timestamp: 1654090819660
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+  sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
+  md5: 0202c3c8ae4735cac6c7f3d1e1685964
+  constrains:
+  - libgfortran-ng 11.2.0 *_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 5228750
+  timestamp: 1654090762569
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+  sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
+  md5: 3080c2813e6e1d0f8a100a38b5b3456d
+  depends:
+  - _libgcc_mutex 0.1 main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 573231
+  timestamp: 1654090775721
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.1.0-h9e868ea_6.tar.bz2
+  sha256: 0fd833e8a519f75e2c4b6cdbec75b8fffc1cd015b2b795d1566855e486705736
+  md5: c2b4c6491de2bf531083a51092ecd077
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 30349190
+  timestamp: 1665079289108
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.52.0-ha637b67_1.tar.bz2
+  sha256: 71a65b3c05426b92e8a3002e7d42cd303255439f8a4442b4fc5aa882aef3128e
+  md5: 113b010119638c67e3b6c8570d88f5be
+  depends:
+  - c-ares >=1.19.0,<2.0a0
+  - c-ares >=1.7.5
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=1.1.1u,<1.1.2a
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 716614
+  timestamp: 1686931412665
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+  sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
+  md5: 1bffe1481ed4f88827248fb9001f8923
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 362561
+  timestamp: 1677841789536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-3.11.2-hd408876_0.tar.bz2
+  sha256: 49de2670c8035b28619dc023b3cbf32bb5af9bfaefc80ddc06bfe4f242acfff5
+  md5: 0cb203fe2cf64272f676d502fe735282
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - zlib >=1.2.11,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5055824
+  timestamp: 1576541584171
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-h37d81fd_2.tar.bz2
+  sha256: 41f2e9a088031bd209d50f37f727fb9647be9316db3e149f9f2bac0057f7184d
+  md5: 778c268743d6cf857178bd1ecf6c9525
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl >=1.1.1u,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 311794
+  timestamp: 1686931200150
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
+  md5: 8c195584a5f5471b600ee180e4052773
+  depends:
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 6410287
+  timestamp: 1654090800863
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.13.0-hfb8234f_6.tar.bz2
+  sha256: 3a8318fe49dc8c591e48a74faef05863266d539ab4ae32b146e80adb38909901
+  md5: a90d894593c49e8880ba0f8b58bb1a47
+  depends:
+  - libevent
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - openssl <1.1.2a
+  - zlib
+  license: Apache-2.0
+  size: 3397616
+  timestamp: 1612012797813
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h85742a9_0.tar.bz2
+  sha256: 5e249c94d0b7b3bf035d69c2f707964b5e39995987b359d17de28c0a54ee9405
+  md5: d7ea21b29e29feec41890296b559555b
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - libwebp-base
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  - zstd >=1.4.5,<1.5.0a0
+  license: HPND
+  size: 655372
+  timestamp: 1616492392965
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+  sha256: a062fad27450b94279d1688aabd11a95eedee7814462ef6364337d55412b4a7e
+  md5: e0521f84b9770830e654432364ac930e
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 484011
+  timestamp: 1729160032020
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.38.0-py38h4ff587b_0.tar.bz2
+  sha256: f1780772574d60a05acbc2e8b815d872aff742deef0771c3a9478e3ddd134d38
+  md5: eb87b15618c4c17eb79f676d79163df6
+  depends:
+  - libgcc-ng >=7.5.0
+  - libllvm11 >=11.1.0,<11.2.0a0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.8,<3.9.0a0
+  - zlib
+  license: BSD-2-Clause
+  size: 2828020
+  timestamp: 1647870575953
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py38h06a4308_0.tar.bz2
+  sha256: a2c16e4e68e414ea6f7680a6439e80f7d67fb693bf739fc10d2ef5afc3e3c2f4
+  md5: dc8d6a9a1e475c5fc9de8531026a4c38
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11040
+  timestamp: 1652903148662
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+  sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
+  md5: 76f089e76ec67583bb38428b51008097
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 164494
+  timestamp: 1714510587156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py38h06a4308_0.tar.bz2
+  sha256: 67fb17f71cf101e66ccb210d8a5c3c10fd6966aaff214034fb6f860ca8d00e7f
+  md5: 32d28f2c97744b2e954e30fa485b5c5c
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 122380
+  timestamp: 1671541939225
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py38h5eee18b_0.tar.bz2
+  sha256: 3315d71ae2bde9dd4ccdf6e46f4712cd2dc1e13ecb06c56dd16664f78a57e741
+  md5: b9289ff19edb3f17a61626227f6bfedb
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23620
+  timestamp: 1704206039363
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.7.2-py38h1128e8f_0.tar.bz2
+  sha256: 25805e84b2627e7334324cf45b51f849fc206b7607f5f6ec4d1f2a5694b7ee70
+  md5: f51b424771ea1f1be2850492133e8003
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=5.2.0
+  - kiwisolver >=1.0.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.20
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.7
+  - tk >=8.6.12,<8.7
+  - tk >=8.6.12,<8.7.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8040239
+  timestamp: 1693812835140
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py38h06a4308_0.tar.bz2
+  sha256: 228a70eddf0a99801e03179f1ab8ddd915bfb7ce351fe7f94c502163d615eb77
+  md5: 28c78d14ef2a80747df2bf2353ef21d7
+  depends:
+  - python >=3.8,<3.9.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16341
+  timestamp: 1662014640999
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py38h06a4308_0.tar.bz2
+  sha256: ae9df84d25f410f1d5ad3af4fb29bd8507211e9f10717f4d47d60bddf9bf02bb
+  md5: 0219b4aefc356586a8045ae2a77ae3fd
+  depends:
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 89740
+  timestamp: 1661496287860
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+  sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
+  md5: ce77d0f05f846da4a6b9e23fe7f21d9b
+  depends:
+  - intel-openmp 2023.*
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - tbb 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 206738176
+  timestamp: 1699648006088
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py38h5eee18b_1.tar.bz2
+  sha256: 7f2c07976bdaebb69efcfb1bf64de1ca257eaf88b5d5447c4f5c257a78ad3aa7
+  md5: 47e5af1bb13950ed4a58ad1242346ab9
+  depends:
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59130
+  timestamp: 1682948582735
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py38h5eee18b_0.tar.bz2
+  sha256: 44f1cdba39f689ff98eddb1a04ff82764d97abcb56ec2d678bf62598bc2dc7ff
+  md5: 5c51e3c46bc1fc14bda340ab435815f9
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 232579
+  timestamp: 1695058229487
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py38hdb19cb5_0.tar.bz2
+  sha256: f850ff1f529ce4f666d59c720fbcadf01d2ff8527c86351b5ebd9af6e7f159a5
+  md5: cc6bf1a1158ddcb35b445a6f92c493c1
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy
+  - python >=3.8,<3.9.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 351977
+  timestamp: 1695060063199
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py38hd09550d_0.tar.bz2
+  sha256: 0908b112893c3a7a563010e020c810d6aab61a0132ac6ef5ea3ba2e59541da6c
+  md5: 17c600586128f5f226b9a5cda765f302
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 90061
+  timestamp: 1652362785051
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py38_0.tar.bz2
+  sha256: a00d1f914deb4b896a3d42d2cae73097e1f5f2f4bc371dd3ceed04118eb974b4
+  md5: 7ccf826b74681264ec620255a556fd97
+  depends:
+  - python >=3.8,<3.9.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 22859
+  timestamp: 1573120615619
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py38h06a4308_0.tar.bz2
+  sha256: 7beb432f70eb809cf22e4b70566521577e3e7019fed80ecdc0258bc2f58bbd26
+  md5: 7dab3154938b1fa1762e914748e7ff52
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8262331
+  timestamp: 1717622901423
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py38h06a4308_0.tar.bz2
+  sha256: cee53dab019b4f0193da1f2e86692d7fc9a1011405fb0269af8eb9fd9b4edcd8
+  md5: 3e8bc494e90187872110355d50826fc8
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.8,<3.9.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99495
+  timestamp: 1698934306037
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.16.4-py38h06a4308_0.tar.bz2
+  sha256: 2a6defeff9124fea41f275c0f4bf4e0743762263337bc0f8c93a2dc063502991
+  md5: 5e13491bb29ab7412ce61bfec2b5d842
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - importlib-metadata >=3.6
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.8,<3.9.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 484450
+  timestamp: 1728049956665
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py38h06a4308_0.tar.bz2
+  sha256: 5bbe6e2bfb56fdc2e5e09d013e27fa71ab1112c8c065cdf95879b6681a9c3c68
+  md5: 4d788b68bfc705f210d91a6b9f54b657
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.8,<3.9.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147353
+  timestamp: 1728049448967
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+  sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
+  md5: 57ea097dc15f8d9f9eb90e1d919143b0
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1157733
+  timestamp: 1674734069410
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py38h06a4308_0.tar.bz2
+  sha256: abc7728d9fb67fe1d502bc52c3246480ee95775397d4ad2e7954fc8244b6f719
+  md5: 01b8e8a4a9f726ff37aad0ea1e9f4f21
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13262
+  timestamp: 1708532744673
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py38h06a4308_0.tar.bz2
+  sha256: 4324fe1c5b6ea1a82f3806f207a461446e9590ea4d66137e0413435370cb5b32
+  md5: 1f52e201a1a7ed2cf3bf2e63e0ff5170
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 590667
+  timestamp: 1717630791981
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py38h06a4308_0.tar.bz2
+  sha256: 160a299bd78be87d52f154c9ec85d43955de772e4200f4abfef2a79c19525c55
+  md5: 9a888294999ac54e7eff7e601b333f97
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22512
+  timestamp: 1699455935349
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.55.1-py38h51133e4_0.tar.bz2
+  sha256: fcdc28d72bb3c6543e25887a22c590e417ee9ef9f33bb222299c405fe8e9cf6e
+  md5: 1e4aa23ed16619a38328e98d5439ec43
+  depends:
+  - _openmp_mutex >=4.5
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - llvmlite >=0.38.0,<0.39.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  - tbb >=2021.5.0
+  - libgomp
+  constrains:
+  - cudatoolkit >=9.2
+  - scipy >=1.0
+  - libopenblas !=0.3.6
+  - tbb  >=2021.0
+  - numpy >=1.18,<1.22
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3974836
+  timestamp: 1648040615744
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.4-py38hc78ab66_1.tar.bz2
+  sha256: d8b99ff74402673cad0cfb6632cd78898edc81d39f74e14f0a2edf8bd12b248a
+  md5: 224331b9fed2aa79bba09029046f3559
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 137430
+  timestamp: 1683221985825
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.21.6-py38h5f9d8c6_1.tar.bz2
+  sha256: 9453b13f747fa5b5c21be91cfc9c3561cd7f563283b90c21e32527fdf3469397
+  md5: a97dc5386c7800376c6af350377fb935
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.21.6 py38hb5e798b_1
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10525
+  timestamp: 1715093080458
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.21.6-py38hb5e798b_1.tar.bz2
+  sha256: 26ec52adae69a0e530b873c847805682d5a148cf72c0be8af614c33cb018edbc
+  md5: 475c0ef71c5b1ed3bcb9d50ac66bf79f
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - numpy 1.21.6 py38h5f9d8c6_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6460591
+  timestamp: 1715093067227
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h9ca470c_2.tar.bz2
+  sha256: 1321f3ca2ede0bbc5ece4e517b2e8dff9979a210490fae6db8341eff93c07f71
+  md5: 318311815f091b048801c57d417eb354
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=11.2.0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 510171
+  timestamp: 1720655553385
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+  sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
+  md5: 5ad4571eba2479f77a9f849a6ae7724c
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: OpenSSL
+  license_family: Apache
+  size: 3998613
+  timestamp: 1694465071784
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-1.6.7-h973521d_2.tar.bz2
+  sha256: b75f8a4605fbed3541e188f14fc214a2da97c518d4d53b00ed8bab6e4107d32d
+  md5: ce4459058a7a9cd79a2e42b0fbeea46a
+  depends:
+  - libgcc-ng >=7.3.0
+  - libprotobuf >=3.11.2,<3.12.0a0
+  - libstdcxx-ng >=7.3.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.8,<2.0a0
+  - zstd >=1.4.9,<1.5.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 752109
+  timestamp: 1619508612546
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py38h06a4308_0.tar.bz2
+  sha256: 87db6b9901308dec0b86f44a2a10e21de92f20ae0fdb87bf3e39603c102c416f
+  md5: cfb74e123b06268d01f7c9a3966aa7be
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 30720
+  timestamp: 1699371206753
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.1-py38h06a4308_0.tar.bz2
+  sha256: 1ec769b2709f782eaab539d1473efcf2262554fa5cc9b990cc6a8ffb42c501e8
+  md5: f887b8ba0d9a5e9b0155c19f04a4f199
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 134112
+  timestamp: 1720102012525
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.5.3-py38h417a72b_0.tar.bz2
+  sha256: 4c934fb2200a7ccf76bc8186a1e9af020e74804443ea26236bd29ebe68c36828
+  md5: ae0c17ae4b81998382ca50e84ead99c5
+  depends:
+  - bottleneck >=1.3.2
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numexpr >=2.7.3
+  - numpy >=1.20.3,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  constrains:
+  - xarray >=0.19.0
+  - matplotlib-base >=3.3.2
+  - fastparquet >=0.4.0
+  - numba >=0.53.1
+  - xlsxwriter >=1.4.3
+  - lxml >=4.6.3
+  - pytables >=3.6.1
+  - scipy >=1.7.1
+  - blosc >=1.21.0
+  - pandas-gbq >=0.15.0
+  - zstandard >=0.15.2
+  - xlwt >=1.3.0
+  - html5lib >=1.1
+  - xlrd >=2.0.1
+  - psycopg2 >=2.8.6
+  - openpyxl >=3.0.7
+  - pyreadstat >=1.1.2
+  - gcsfs >=2021.7.0
+  - pyxlsb >=1.0.8
+  - tzdata >=2022a
+  - python-snappy >=0.6.0
+  - fsspec >=2021.7.0
+  - sqlalchemy >=1.4.16
+  - pyarrow >=1.0.1
+  - s3fs >=2021.08.0
+  - pymysql >=1.0.2
+  - tabulate >=0.8.9
+  - beautifulsoup4 >=4.9.3
+  - brotli >=0.7.0
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13895571
+  timestamp: 1677836949366
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py38h06a4308_0.tar.bz2
+  sha256: 6c07adf761815b29425cf9246290948e4af424c507f023cb99b40a0114eaf291
+  md5: 7389a12089a593eaa6f1a6f7ffea24cc
+  depends:
+  - locket
+  - python >=3.8,<3.9.0a0
+  - toolz
+  constrains:
+  - pandas >=0.19.0
+  - numpy >= 1.9.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35439
+  timestamp: 1698702667558
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.4.0-py38h5eee18b_0.tar.bz2
+  sha256: ed2ab1d5a7d18394964181de3ed75801f7255d028e0ab54f7e566cf478ca0b5a
+  md5: 45939d83fd677381152eda133eec3c81
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.8,<3.9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 824516
+  timestamp: 1721059658996
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.2-py38h06a4308_0.tar.bz2
+  sha256: f6428d9c0c14bc4e1fbc4fdf0ee52bdde47472137701f4b94cb7a9e176cd3a7f
+  md5: becd6b1a295078bb1f621906afa1c553
+  depends:
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2270681
+  timestamp: 1723484696377
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pkgutil-resolve-name-1.3.10-py38h06a4308_1.tar.bz2
+  sha256: 661608426deb4f3b1b2f020cbb8412a29a00adf0952c7472938cd253aefefe0a
+  md5: eb54508863baff357d4d30c244a3fd52
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT AND PSF-2.0
+  license_family: PSF
+  size: 10289
+  timestamp: 1704297556344
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py38h06a4308_0.tar.bz2
+  sha256: 4bf901b9310c1c68e71a78a9d2608ce439ca3dafed4f1223da5f7a4217a80cce
+  md5: 9bc4d8193c88dbeb3ee43a8f44c56adf
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 32013
+  timestamp: 1692205473871
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pooch-1.7.0-py38h06a4308_0.tar.bz2
+  sha256: 9568858a898a582ad1f9c94ce7cc0558760ea905d1007daf60c4f566925d2f0d
+  md5: fef969ba49e5d1fc3de02d3c7014f735
+  depends:
+  - packaging >=20.0
+  - platformdirs >=2.5.0
+  - python >=3.8,<3.9.0a0
+  - requests >=2.19.0
+  constrains:
+  - paramiko >=2.7.0
+  - xxhash >=1.4.3
+  - tqdm >=4.41.0,<5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 81182
+  timestamp: 1695850193601
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py38h06a4308_0.tar.bz2
+  sha256: fe048f508881e6f69ea1781ece59102037d83c102778669e8caf390009b20d74
+  md5: 4718ad7bf83e664525c13ce1ded14c84
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91025
+  timestamp: 1659455269732
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py38h06a4308_0.tar.bz2
+  sha256: a3637fc4733632458e4e6e67fdc80493fd1215ca91f0c2cc39cf51964759c6d8
+  md5: b386e6d389ff544f0285b00e904c7e95
+  depends:
+  - python >=3.8,<3.9.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 577603
+  timestamp: 1704404419144
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py38h5eee18b_0.tar.bz2
+  sha256: cdb9ea9d076f82f3d266806ff90c4bafeb3533958abb5bd14cbc3702c433b924
+  md5: 38b4a8eb4ece574a3db5b1dafeb10bd7
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 352826
+  timestamp: 1656431426074
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-4.0.1-py38he0739d4_3.tar.bz2
+  sha256: 8def5287701f4a4cd91ec466e6ba427662bdad16cd703ed3cdaa8f3a4d1f7b20
+  md5: 6a13b7e3ecc306344b3cf347a0b96c15
+  depends:
+  - arrow-cpp >=4.0.1,<4.0.2.0a0
+  - arrow-cpp >=4.0.1,<5.0a0
+  - boost-cpp
+  - gflags
+  - glog
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - numpy >=1.11,<2.0a0
+  - pandas
+  - python >=3.8,<3.9.0a0
+  - six
+  - snappy
+  license: Apache 2.0
+  size: 2549724
+  timestamp: 1623164893443
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py38h06a4308_0.tar.bz2
+  sha256: dd70dbec022d1fca1fb2168bb81eeb2d970d53494f4bb4ce36751d70ce960b79
+  md5: b09b43fc9f274c994af65adefa36279f
+  depends:
+  - param >=1.7.0
+  - python >=3.8,<3.9.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29267
+  timestamp: 1675441565524
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py38h06a4308_1.tar.bz2
+  sha256: dae53aeb4103d375b1125eecc4dc3cdf5fcfa9288d24f3a9e1c5d9b0107a501c
+  md5: 13fc002e79408c57aa79fb2c25e1b538
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1887598
+  timestamp: 1684280001176
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py38h06a4308_0.tar.bz2
+  sha256: 97972579f3c079aab5fb9a58855caded3b268bf90c0afdf5e6f39d75edd9a699
+  md5: b47e7fcdef58cc3b2b8d920c73819e19
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 156616
+  timestamp: 1661452605147
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py38h06a4308_0.tar.bz2
+  sha256: 0d1c9fb08b326f1292b74373b942b739bb99dd4ec54d2be09e5072503300b2a8
+  md5: 3ec9d5960a2ea2ba666008fdfc9d0084
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31276
+  timestamp: 1605305807726
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.8.18-h7a1cb2a_0.tar.bz2
+  sha256: 22039cf20fe6bc950116e35abb1f4d502829c953eac840da5412ee69a12c2df7
+  md5: ad9945c8a45c246f7bde30d257948a97
+  depends:
+  - ld_impl_linux-64
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 27401609
+  timestamp: 1694439093219
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py38h06a4308_2.tar.bz2
+  sha256: 264578f50162cfd8de5c4edd1416a93cb69fcfc8a509cb39663347493ec4c5ca
+  md5: 3a08ef6644fe6ff5376c1eb2571de450
+  depends:
+  - python >=3.8,<3.9.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 288493
+  timestamp: 1716495786779
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py38h06a4308_0.tar.bz2
+  sha256: cc0f3ceeae6369f8b1523c1f4fff5c16d14c455b938723671a6bc672a65b77ff
+  md5: d914447598a4c8d1e61fd888dded2072
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264015
+  timestamp: 1661371299911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py38h06a4308_0.tar.bz2
+  sha256: 9e72df5780c5468e484a870990357e7dd88fd688b68f94477ea4b1e0a526cec7
+  md5: 4b57c40b9575802121f6f2545c9d4d8c
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 15240
+  timestamp: 1683823938836
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py38h6a678d5_0.tar.bz2
+  sha256: ec3d6a1528a21405dc596978c9c58475ff48fd242c2b11f42c60a011ad231c26
+  md5: 50ad6fcf916088079a753864eefacd9b
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.8,<3.9.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 138887
+  timestamp: 1682522425747
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-snappy-0.6.1-py38h6a678d5_0.tar.bz2
+  sha256: 03ce88dea3ec4e2bf79feb1346d21bf9a67a643c7c8819cd1ec4ca49815a4e69
+  md5: e446ea0658eae84604ad98a55baf195d
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.8,<3.9.0a0
+  - snappy >=1.1.9,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 31654
+  timestamp: 1670943981941
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py38h06a4308_0.tar.bz2
+  sha256: 8b7c69d2780fcec5894ecda13af509413dc589908c92c4920f4d08ead124a46c
+  md5: 59a144ef47cca86e501e9684e68f06d8
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 265176
+  timestamp: 1713974389718
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py38h06a4308_0.tar.bz2
+  sha256: b33e5b0baa74dc546e3091f953f81017d7b63d6ce63ac20b07f3baae476990c4
+  md5: 71a56f4fde17a6a1e148b5152e3398b4
+  depends:
+  - param
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 60475
+  timestamp: 1711136855967
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py38h5eee18b_0.tar.bz2
+  sha256: 1af16076c370a18f9e6d2076e11eb96cd4781c19aa59839856f85598a9e0407c
+  md5: 39a7632480bbea971c82ae6ebc72ad29
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.8,<3.9.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 195687
+  timestamp: 1728658113822
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py38h5eee18b_0.tar.bz2
+  sha256: 669ae9d52664a1c512121f65738fc4b72ea48e7740d505eb5a1fc0ab46d7c298
+  md5: 6830baa48917ead8a9f964750f982e39
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.8,<3.9.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 537148
+  timestamp: 1709318412975
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+  sha256: 8a640736bef635346409582dbfe2b7d0ecc9da215c90173ff8a9a5fe22569107
+  md5: 6b583dce61c6feb352ef0f49f413af1e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-3-Clause
+  size: 235004
+  timestamp: 1652449537852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+  sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
+  md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 467661
+  timestamp: 1666648052561
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py38h06a4308_0.tar.bz2
+  sha256: a3432cb1874b026257556818b0189596ee688c843ece775d87d50fa473aeaf7a
+  md5: 676d5b658acaec19857aedbb5b63ab60
+  depends:
+  - attrs >=22.2.0
+  - python >=3.8,<3.9.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 57804
+  timestamp: 1699012146060
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py38h06a4308_0.tar.bz2
+  sha256: b1dd651b0f64482231e61cc798cea901e5cb205899df5f4743b300eb86037626
+  md5: 1841b3307caa5d954cac15d2faf5a117
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.8,<3.9.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 97103
+  timestamp: 1721410986042
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-toolbelt-1.0.0-py38h06a4308_0.tar.bz2
+  sha256: 1dd6a1f10795fcd90aa3bae1a5d111b8cf96dd0069d46e90fad4879701927bc5
+  md5: bc84efd3289e47d03f9b37fde9b6bf67
+  depends:
+  - python >=3.8,<3.9.0a0
+  - requests >=2.0.1,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 68644
+  timestamp: 1690874122636
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py38h06a4308_0.tar.bz2
+  sha256: 06ac06dd4fcc3150d96e3f20ac036fddf3aba52de71152ba4ea3c179e2f7b97c
+  md5: 22ed3bdce8a230c356fc1c611c4096f1
+  depends:
+  - python >=3.8,<3.9.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 8921
+  timestamp: 1683077077347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py38h06a4308_0.tar.bz2
+  sha256: 75ee060a1f1aadcb6ff9dd4fb2c6c7aefc1f04a98dadf0428501560ad8216c15
+  md5: 5d6765b7e819ca4ac4fc8f5919ada81b
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 9339
+  timestamp: 1683059016277
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py38hb02cf49_0.tar.bz2
+  sha256: 4b25f3d2bbcf20dfe2f089e559c96cc69b89465ba88bedd3ecd39d7fc51dd3ce
+  md5: 54fa7a1d5d517ac44dd42290cdde0a1e
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 1095726
+  timestamp: 1698946060598
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel.yaml.clib-0.2.8-py38h5eee18b_0.tar.bz2
+  sha256: df56f3b7e0e0946ef24f1407767f6bb60dd0034e59878e0260c8ca268b36136f
+  md5: 9c42dc97360f54f198f0d50bb607b252
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 162968
+  timestamp: 1727769985866
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ruamel_yaml-0.17.21-py38h5eee18b_0.tar.bz2
+  sha256: 2877260caacd68bdc571872b1c154efb3ad8da7670da93290c9ca9962dd9c413
+  md5: 47b6bae0c0ac9572a171bed14dae2205
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.8,<3.9.0a0
+  - ruamel.yaml.clib >=0.2.6
+  license: MIT
+  license_family: MIT
+  size: 172808
+  timestamp: 1667489860744
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.10.1-py38hf6e8229_1.tar.bz2
+  sha256: 0c85129009042b51564cd6d73c2c370c06d9226690ac31e2825a6eb740cfb7db
+  md5: 760fa69bb5943dfdbb945b9af2736098
+  depends:
+  - blas 1.0 mkl
+  - intel-openmp >=2023.1.0,<2024.0a0
+  - libgcc-ng >=11.2.0
+  - libgfortran-ng
+  - libgfortran5 >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.19.5,<1.27.0
+  - pooch
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26848491
+  timestamp: 1683289243499
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py38h06a4308_0.tar.bz2
+  sha256: 59a0f406ae8e46050a3d5673138dbdf609311b66e9be7b77fbdfdf4cb9c4e7f2
+  md5: ed3a1aa9fc47e9a3ed11a02afd53b4c4
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26843
+  timestamp: 1699371234046
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-60.9.3-py38h06a4308_0.tar.bz2
+  sha256: ed5062cd53379f9c81d66f84f00d31ae95a8fd4d97ecdfad0ff02a9026c68a32
+  md5: c959c8379b1b75fc48906fb26a525c0b
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 1226928
+  timestamp: 1685710625243
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
+  sha256: 8fd98235b37194986a5eb663c95a4a6db8c9e20a627f5c79ff8d9be3fd0e36f7
+  md5: 25ac00d957eda056675f8fa3eafdf6df
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 52749
+  timestamp: 1723557449203
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py38h06a4308_0.tar.bz2
+  sha256: 8989039abb908ce3599d8e84a7d3828a75df4a596220c7447c01034ee3958b12
+  md5: b248bf15175453bcd8bc4f100d6c265f
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 16628
+  timestamp: 1705431447220
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py38h06a4308_0.tar.bz2
+  sha256: e888d0ed8d489e081102fb1c816479db50802243f40ba24079a76465709642e3
+  md5: 20d72998dbdd62e71f8901634d630352
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 66454
+  timestamp: 1696347666187
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+  sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
+  md5: f86119b3243fe3508160aa0406245738
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1723866
+  timestamp: 1714488309729
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+  sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
+  md5: 041a3caf09dc9ce8fc6c10925c4fe050
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1888016
+  timestamp: 1680167274961
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py38h06a4308_0.tar.bz2
+  sha256: b1aaff89c39b3dfd49e910e706f63fc361d4edd14350ea7f6b9fbfc1984ead35
+  md5: 462c5ca383e788c3f7d20270e378991b
+  depends:
+  - ptyprocess
+  - python >=3.8,<3.9.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29863
+  timestamp: 1671751945016
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/thrift-0.17.0-py38h6a678d5_0.tar.bz2
+  sha256: 7d67b37f3ae90d50c18c837292445fdda1d31d79c4663bcd1e93a8b1c1e1edb3
+  md5: da914586bf315379c27fa9dca6f3b337
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.8,<3.9.0a0
+  - six >=1.7.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 129600
+  timestamp: 1666296532746
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py38h06a4308_0.tar.bz2
+  sha256: d8d4ab14d89a1e994b979923a985519d12b7a5dd25c552e861690486237f2e80
+  md5: 806aa4861199d75d60b7b964cd04dc6c
+  depends:
+  - python >=3.8,<3.9.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39305
+  timestamp: 1668168903676
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+  sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
+  md5: e2512d57c8a1e91e7b20e265c6906546
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3588922
+  timestamp: 1714770676475
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py38h06a4308_0.tar.bz2
+  sha256: 85077229bfc69efa66079274390675e2f81ffe092435103685d54166e5e69ba6
+  md5: aec171353448852f51e81c68ef45dfaa
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101498
+  timestamp: 1667464200465
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.1-py38h5eee18b_0.tar.bz2
+  sha256: 37ad1a8ed6875bba449a9839a5b3057ec7d84416fd367cb801a0030897613695
+  md5: 3a320f4ea5564e6e1212e432e9831209
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 690997
+  timestamp: 1718740214723
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.5-py38h2f386ee_0.tar.bz2
+  sha256: 13bb2cdf26bf9f457715868bc8d564403e1d7f554f50be62116317606142adad
+  md5: f27d9bfb20b3096021630baad71306b5
+  depends:
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 126200
+  timestamp: 1724854064090
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py38h06a4308_0.tar.bz2
+  sha256: 6ea9a22d64233b05d17b4f4f5a5bbdb14e8308ca9dead52044b536c4fe1ad27e
+  md5: f8c9739fb4ced58bc2f89ab2931ecf74
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 165512
+  timestamp: 1718227109478
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py38h06a4308_0.tar.bz2
+  sha256: 3acf29373ab34a497504885fba0595b39dbd642f2450f92758ce99bc3ba13ecb
+  md5: 8822ef2a13080ddc2f89f366f36d29bf
+  depends:
+  - python >=3.8,<3.9.0a0
+  - typing_extensions 4.11.0 py38h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8851
+  timestamp: 1715268883008
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py38h06a4308_0.tar.bz2
+  sha256: 57e7f4a868d7d45fa947cb85331bdd41e4068577aca9567677b4a11e485dfee7
+  md5: d02fe804a0d9b77bc62088df3d339eb8
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 60065
+  timestamp: 1715268877859
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py38h5eee18b_0.tar.bz2
+  sha256: 6757ef7ad0fd3e71e67cfb339a93f0fa21b1d94339cf7c6c664b8968a76a48c3
+  md5: 02f47f685a18714a1d9c56a6cac33f57
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 509402
+  timestamp: 1713212980627
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uriparser-0.9.7-h5eee18b_0.tar.bz2
+  sha256: fa1281c13f5c8d18b36bb69705e4cd632ccc456b603f27ca63f68a787d03b0be
+  md5: 48e34041c9a0bd924018a6fab5d167b6
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48752
+  timestamp: 1692186947656
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.3-py38h06a4308_0.tar.bz2
+  sha256: ba6f85a22f58193fc6c363407863f0f8d863a63982bbd275b30cf24605a82640
+  md5: 33066cef597b40b2fdad2c24dc53d85e
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - requests >=2.26.0
+  - selenium >=4.4.3
+  - zstandard >=0.18.0
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 170359
+  timestamp: 1727769831965
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+  sha256: a8d11b0f08217607b99ba560edf66423ca1e36f4ffbb6e2377e61670e2b5f36b
+  md5: 431e82b081b08aef0259df0437e04c75
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 97535
+  timestamp: 1706894675990
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py38_1.tar.bz2
+  sha256: c6fd7f78c18396f22bde60d84004159a5398d7eaad14ab1b6f7550e9605e3616
+  md5: 46be58263b91ea0ce41774c6cef974b7
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20211
+  timestamp: 1573200372707
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py38h06a4308_0.tar.bz2
+  sha256: 59d5cd812cd18b04f1a3238aa26dd9ab585c8d3e93d35c063a31a11c0b5f3f6e
+  md5: 14118d274fbb8ee0e1a04f3b24a506d4
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 85935
+  timestamp: 1715878368094
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.44.0-py38h06a4308_0.tar.bz2
+  sha256: 40a959027f73c61485d644618f3e85a47edd808efc29aa28d553a1f91b24486d
+  md5: 101d43682ed48e252d50321745c212b2
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 104159
+  timestamp: 1726165121976
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2022.11.0-py38h06a4308_0.tar.bz2
+  sha256: 508985a639f29648f66f7dd3856ad0baf5501601582e52ad26cae4c0e7ca8ea8
+  md5: cbef8e255222ff1c5727b7529031ccf8
+  depends:
+  - numpy >=1.20
+  - packaging >=21.0
+  - pandas >=1.3
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1722500
+  timestamp: 1668776634679
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py38h06a4308_1.tar.bz2
+  sha256: 846ae02929f4570ad0979c56332af5b3b4da851419a051e7902bd3a6ec2a0755
+  md5: 4d7632b5d03d4b2be70e952e890bcbd5
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 47860
+  timestamp: 1675159165834
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+  sha256: 9122d6e9dabb7a47f2bcb15d86b97c96c49a9048da3f8ae59675351710c14cc5
+  md5: 660b2aead2ec87b751c86cd33934f44e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 716926
+  timestamp: 1714510796277
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+  sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
+  md5: 943f1247a22b6b64171363bcee1eec27
+  depends:
+  - libgcc-ng >=11.2.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=11.2.0
+  license: MPL-2.0
+  license_family: Other
+  size: 371663
+  timestamp: 1705602144682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py38h06a4308_0.tar.bz2
+  sha256: 5e35fe343f2db943bb40881684974c9325d13b645baebd67d0ff6c81a1c411ff
+  md5: c701afabfd0e39a192953874321cb29d
+  depends:
+  - heapdict
+  - python >=3.8,<3.9.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 76355
+  timestamp: 1695832914431
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.20.2-py38h06a4308_0.tar.bz2
+  sha256: aaed1be6cdebd13b8a23edd214e573030fb6bf917859119c51190008d9d28f02
+  md5: de5f5b5ed6f9a918c6d55701e7d504ed
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 25065
+  timestamp: 1729012379362
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+  sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
+  md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Zlib
+  license_family: Other
+  size: 127143
+  timestamp: 1714510716441
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstandard-0.19.0-py38h5eee18b_0.tar.bz2
+  sha256: 9e109b0d4fa7072697e7a428ea2eda4208a7c831409113df603011ef65a18844
+  md5: b3a4956643e78cfe65b59823bbf0c633
+  depends:
+  - cffi >=1.11
+  - libgcc-ng >=11.2.0
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 683175
+  timestamp: 1677013289650
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.4.9-haebb681_0.tar.bz2
+  sha256: d1969321874e6d0a7b9994a043830e453a5caab9c3d89690351ba658700ab611
+  md5: 77148a73936c37451810f0b1453569e9
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: BSD 3-Clause
+  size: 828849
+  timestamp: 1617228573594
+- conda: https://repo.anaconda.com/pkgs/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 8f312df57fbcba29977fcc1a66017f231820699053ca3b91450fabc16ec09858
+  md5: a1914956aa26b608c4f2d17edadca061
+  depends:
+  - python
+  license: MIT
+  size: 12124
+  timestamp: 1629143509659
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
+  md5: b2aa5503875aba2f1d88cae9df9a96d5
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13636
+  timestamp: 1611930018941
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+  sha256: c0dd89ffac001588171152a285ddbbaea209ebe4116010f985f898b7e87c2f35
+  md5: 731ae7d446633bc729f3493a52d4365b
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 43502
+  timestamp: 1721748373551
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2.10.1-py_0.tar.bz2
+  sha256: d4becea2d64e1106512c982ca3d9ffa8fbf466662c57dbfe98bd208a62b373bd
+  md5: 50bb7d044b57c15ab9a3c3ee4d266e87
+  depends:
+  - bokeh >=1.0.0
+  - cloudpickle >=0.2.1
+  - cytoolz >=0.7.3
+  - dask-core 2.10.1.*
+  - distributed >=2.10.0
+  - fsspec >=0.6.0
+  - numpy >=1.13.0
+  - pandas >=0.21.0
+  - partd >=0.3.10
+  - python >=3.6
+  - toolz >=0.7.3
+  license: BSD 3-Clause
+  size: 12803
+  timestamp: 1580416204172
+- conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2.30.0-py_0.tar.bz2
+  sha256: 82cdea73f212a463cbaa0a50d08e19721321581dc9fcf133998bdd9552b0d86f
+  md5: 28589ce41c675a730271246aaf4ca043
+  depends:
+  - bokeh >=1.0.0,!=2.0.0
+  - cloudpickle >=0.2.2
+  - cytoolz >=0.8.2
+  - dask-core 2.30.0.*
+  - distributed >=2.30.0
+  - fsspec >=0.6.0
+  - numpy >=1.13.0
+  - pandas >=0.23.0
+  - partd >=0.3.10
+  - python >=3.6
+  - toolz >=0.8.2
+  constrains:
+  - openssl !=1.1.1e,<1.1.2a
+  license: BSD-3-Clause
+  size: 4721
+  timestamp: 1602100743497
+- conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2.10.1-py_0.tar.bz2
+  sha256: 173ade2e7ebfc04793c322b106c0a5d1f74b569f00c1fbedc7e68129e4cf9a29
+  md5: 200e9b73fb7dfad8a8e45b0b037ac2c3
+  depends:
+  - python >=3.6
+  license: BSD 3-Clause
+  size: 608527
+  timestamp: 1580416068743
+- conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2.30.0-py_0.tar.bz2
+  sha256: 23632b4a11f021ada7f099dee7a5b60a8c22959009aaac26ff6dd230e1a65ad9
+  md5: ae95e7ad795342ff2e60921a9e26cbb9
+  depends:
+  - python >=3.6
+  - pyyaml
+  license: BSD-3-Clause
+  size: 654836
+  timestamp: 1602083734965
+- conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 2de2d79a0e9784a1bf55cdb83c035072da1879753d109c0a36bbd5a357385c37
+  md5: 6cfe764bb04e756d7d1319a98a05dd70
+  depends:
+  - bokeh
+  - colorcet >=0.9.0
+  - dask >=0.18.0
+  - datashape >=0.5.1
+  - numba >=0.51
+  - numpy >=1.7
+  - pandas >=0.24.1,<3.0.0
+  - param >=1.6.1,<2.0.0a0
+  - pillow >=3.1.1
+  - pyct >=0.4.5
+  - python >=2.7
+  - scipy
+  - toolz >=0.7.4
+  - xarray >=0.9.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14964307
+  timestamp: 1623782401693
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/distributed-2.10.0-py_0.tar.bz2
+  sha256: 2dd32f8766f111ead89689f114c3acd347d8e11fc1f34a2f5817fd1d0a99b079
+  md5: 877de7e546a6dee328d56eb0d230bf5f
+  depends:
+  - click >=6.6
+  - cloudpickle >=0.2.2
+  - cytoolz >=0.7.4
+  - dask-core >=2.9.0
+  - msgpack-python
+  - psutil >=5.0
+  - python >=3.6
+  - pyyaml
+  - setuptools
+  - sortedcontainers !=2.0.0,!=2.0.1
+  - tblib
+  - toolz >=0.7.4
+  - tornado >=5
+  - zict >=0.1.3
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 433845
+  timestamp: 1580308740998
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 9de8666e5b70aa2437737128eaa14ffe80a7b5235c2a6b7d3f39ccefd7816ba0
+  md5: bb52e50c5ab1a5c7778c11376404dfdb
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 7933
+  timestamp: 1630598543551
+- conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.8-pyhd3eb1b0_0.tar.bz2
+  sha256: 94de7b53f559782e16abf255670eaa585c6397bccacec3579309ccd49080ff48
+  md5: 86af6b7b7508ce6485cabf669d123917
+  depends:
+  - bokeh >=1.1.0
+  - colorcet
+  - ipython >=5.4.0
+  - matplotlib-base >=3
+  - notebook
+  - numpy >=1.0
+  - pandas >=0.20.0
+  - panel >=0.8.0
+  - param >=1.9.3,<2.0
+  - python >=2.7
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3632336
+  timestamp: 1645454472973
+- conda: https://repo.anaconda.com/pkgs/main/noarch/hvplot-0.7.3-pyhd3eb1b0_1.tar.bz2
+  sha256: 2db2e41ca95838a7f3cfb80ba343cb54422f65183d09db8ae4f1c65cf35baa57
+  md5: 39d9b853f76c737215516ba3a9b5cef6
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15
+  - pandas
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3084696
+  timestamp: 1627305211559
+- conda: https://repo.anaconda.com/pkgs/main/noarch/intake-parquet-0.2.3-py_0.tar.bz2
+  sha256: c1f589c23bfebb6d72e66a0911ddcc7ac0eae5ed372c3f7fbb064c1d5db8a285
+  md5: 55c292a9447943801b55e2e2d9cc2509
+  depends:
+  - dask
+  - fastparquet
+  - intake >=0.3
+  - jinja2
+  - pandas
+  - pyarrow
+  - python >=3.5
+  license: BSD-2-Clause
+  size: 11483
+  timestamp: 1574273854612
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.7-pyhd3eb1b0_0.tar.bz2
+  sha256: 9575be12f17a1b774cab176de08b3fb0761c15aefd74a907f15c948ff80a696e
+  md5: 71f9319d31ce3a3465c750b0f0b600db
+  depends:
+  - bleach
+  - bokeh >=2.4.0,<2.5.0
+  - markdown
+  - param >=1.10.0,<2.0.0a0
+  - pyct >=0.4.4
+  - python >=3.6
+  - pyviz_comms >=0.7.4
+  - requests
+  - setuptools >=42,<61
+  - tqdm >=4.48.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10317537
+  timestamp: 1649079073252
+- conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 110a3b50f89584ccb13980a617f6258b83b0bc56c8897c96d9e0da9fdc2c957c
+  md5: 6266365b47ed65cdb4737603a385c691
+  depends:
+  - python >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 69119
+  timestamp: 1625476602265
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+  sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
+  md5: e68a6f315f41a8d814d833652bf38b9b
+  depends:
+  - python >=3
+  license: MIT
+  size: 13374
+  timestamp: 1606932077143
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 4e47f6c49ce84509f1466e8a4d728447bf4bcd9bce7b456431a789a262547067
+  md5: 4cad993b0f80bc23fb66a97592299cbb
+  depends:
+  - python >=2.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 26504
+  timestamp: 1623949147884
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+  sha256: ca2be6c7810a37cfc6db1f5383937b5d35c6d73c1fad8a9104de85f069b1df1c
+  md5: 9ccb2fb33edb152403d6ef32bf758a9d
+  depends:
+  - python
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 15614
+  timestamp: 1629402049497
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anaconda-anon-usage-0.4.4-py38hfb7c958_100.tar.bz2
+  sha256: c42ac05e8036ebf544c64ad503010ee947da1a483e891f7a1c7a1a667d90cc54
+  md5: 343935e1348e98e1e4daacaff9c27193
+  depends:
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - anaconda-ident <0.6.0
+  - conda >=23.7,<26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24989
+  timestamp: 1710965120689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anaconda-client-1.12.3-py38hecd8cb5_0.tar.bz2
+  sha256: 67b466a4aa0b9b81dc0fb28679bd87e7773ecb892b654c4fb38cce7ed8b17986
+  md5: 5d9c4dac680de70eb782bc3fe9b01513
+  depends:
+  - anaconda-anon-usage >=0.4.0
+  - conda-package-handling >=1.7.3
+  - defusedxml >=0.7.1
+  - nbformat >=4.4.0
+  - platformdirs >=3.10.0,<5.0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.6.1
+  - pytz >=2021.3
+  - pyyaml >=3.12
+  - requests >=2.20.0
+  - requests-toolbelt >=0.9.1
+  - setuptools >=58.0.4
+  - six >=1.15.0
+  - tqdm >=4.56.0
+  - urllib3 >=1.26.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141723
+  timestamp: 1708643614831
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anaconda-project-0.11.1-py38hecd8cb5_0.tar.bz2
+  sha256: b08e74d8fda2c9ed4db6b9ec7ffe3831991ed04d4e28da023803819ffaffe53e
+  md5: 25c25318c81c1b330cb07085db95df91
+  depends:
+  - anaconda-client
+  - conda-pack
+  - jinja2
+  - python >=3.8,<3.9.0a0
+  - requests
+  - ruamel_yaml
+  - tornado >=4.2
+  - tqdm
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 544572
+  timestamp: 1660340117928
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py38hecd8cb5_0.tar.bz2
+  sha256: 841e19d35111483ab74e9e68e7dbfc90af61c58bd9cb885e0ed4683b76061c3b
+  md5: cd70416e2aef5e40458dc45d998112e4
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.8,<3.9.0a0
+  - sniffio >=1.1
+  - typing_extensions >=4.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 174509
+  timestamp: 1706220384805
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py38hecd8cb5_1001.tar.bz2
+  sha256: 80777c5e13c10f946bafdb2ccdb0a13010669bb4a0d424b15f81816427f9bc4e
+  md5: 070364c2c941da9fefa521327645d2ff
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10035
+  timestamp: 1606859471981
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py38hca72f7f_0.tar.bz2
+  sha256: be2b0feedb5668e85bdb044ecdf769e12a4acd0bf026e8c1858327cfbc44945c
+  md5: e70cb13b190f8141882cef82fbabf6f0
+  depends:
+  - cffi >=1.0.1
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 36067
+  timestamp: 1644569747309
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-4.0.1-py38hf7c73f6_3.tar.bz2
+  sha256: f516886b5fb1f35524330c46c1a6d214da163ed61df4e41b7226fbfbf8bcd188
+  md5: 41f8fe04dcb65b5e4307c65d32ce1c13
+  depends:
+  - aws-sdk-cpp >=1.8.185,<1.8.186.0a0
+  - boost-cpp
+  - brotli >=1.0.9,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-ares >=1.17.1,<2.0a0
+  - double-conversion
+  - gflags >=2.2.2,<2.3.0a0
+  - glog
+  - grpc-cpp
+  - libboost >=1.73.0,<1.73.1.0a0
+  - libcxx >=10.0.0
+  - libprotobuf >=3.11.2,<3.12.0a0
+  - libthrift >=0.13.0,<0.14.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - numpy >=1.11,<2.0a0
+  - openssl >=1.1.1k,<1.1.2a
+  - orc >=1.6.7,<1.6.8.0a0
+  - python >=3.8,<3.9.0a0
+  - re2
+  - snappy >=1.1.8,<2.0a0
+  - uriparser
+  - utf8proc <2.9.0
+  - zlib
+  - zstd >=1.4.9,<1.5.0a0
+  license: Apache 2.0
+  license_family: Apache
+  size: 6721110
+  timestamp: 1622568910960
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.2.0-py38hecd8cb5_0.tar.bz2
+  sha256: b6551cea8b2039a15a6a72455d99427eeccb278945d9bbee9be1aa3903124344
+  md5: ed320a21707928e48cbdefcc85e20230
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 142507
+  timestamp: 1729089494991
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.4.57-hb1e8313_1.tar.bz2
+  sha256: bd9839857a0f4d642d6496858ed2c5e967f5eeaeec366e095f33fed2b88b3549
+  md5: f018d20252f808fe7f03f27138f874ff
+  depends:
+  - libcxx >=10.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 146436
+  timestamp: 1601398327280
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.1.6-h23ab428_5.tar.bz2
+  sha256: 1689c53ae4727d42bdf984a464ba466849693dbfb5757949a5b8ab818870910c
+  md5: c9ac87fa2e6ef38b35fd88bdf1e4180d
+  depends:
+  - aws-c-common >=0.4.57,<0.4.58.0a0
+  - aws-checksums >=0.1.9,<0.1.10.0a0
+  - libcxx >=10.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 21727
+  timestamp: 1603894602135
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.9-hb1e8313_0.tar.bz2
+  sha256: 10dec822bbe1407f99fe8581984f189689d926663405a9a0399736a513e0b3b4
+  md5: 6eaf9d2a4e00dcec0a2c18ecfc8a0b58
+  depends:
+  - aws-c-common >=0.4.57,<0.4.58.0a0
+  - libcxx >=10.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 50452
+  timestamp: 1601399158653
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.8.185-he271ece_0.tar.bz2
+  sha256: 0ed049475b0a3544b08a0f7e94e6394e23e8b76fe1dde47937ef4b59654ec1cc
+  md5: 7128a60cf4a8f9c50e6906174f03dde9
+  depends:
+  - aws-c-common >=0.4.57,<0.4.58.0a0
+  - aws-c-event-stream >=0.1.6,<0.1.7.0a0
+  - libcurl >=7.71.1,<9.0a0
+  - libcxx >=10.0.0
+  - openssl >=1.1.1k,<1.1.2a
+  license: Apache-2.0
+  license_family: Apache
+  size: 2166135
+  timestamp: 1618434980968
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py38hecd8cb5_0.tar.bz2
+  sha256: 6031699148ace6354937a51715e561f40d77af434fa2b26c987741916f85460d
+  md5: 9d0bc20499d3430a0bc67433d022ad64
+  depends:
+  - python >=3.8,<3.9.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 215514
+  timestamp: 1718029893541
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.4.3-py38hecd8cb5_0.tar.bz2
+  sha256: cd22b796fa325c5f5de4d0cf07a84585691a169608ec52ac1f68100fa0269179
+  md5: 49f52f875f0d7da5613f13c2561b2dc1
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.8,<3.9.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14317307
+  timestamp: 1658136803878
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.73.0-h9ed2024_11.tar.bz2
+  sha256: f478e0b090b48866d284b333f8ceca2fb51048144308edfea7484b4d1cf34ca0
+  md5: 301bdc5957da60059a0702422f8ee9ba
+  depends:
+  - libboost 1.73.0 hd4c2dcd_11
+  license: Boost-1.0
+  size: 24652
+  timestamp: 1611677363789
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py38h7b7cdfe_0.tar.bz2
+  sha256: 41358c330c8c1711ce64d0b9c712490f6b8108bde090787c3f8fc667640a4bd4
+  md5: 41a7b98c2da95583ce53750687667ac2
+  depends:
+  - numpy >=1.21.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 129675
+  timestamp: 1707864289994
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: d8b1ccb15297dcfb3f9ebb8139c3e28a13d6c2e73c37612cb214ab6cc58b15fa
+  md5: e5dec9f13de061640ad2697562a99b54
+  depends:
+  - brotli-bin 1.0.9 h6c40b1e_8
+  - libbrotlidec 1.0.9 h6c40b1e_8
+  - libbrotlienc 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 19732
+  timestamp: 1714483415038
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: e9fda4393edd0234c88efc2b88e0edf42c94eb49ea5b189a80afd733058be8fb
+  md5: 13ceed558eb174d6b77ed1b0035f1785
+  depends:
+  - libbrotlidec 1.0.9 h6c40b1e_8
+  - libbrotlienc 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 18400
+  timestamp: 1714483395748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py38hcec6c5f_8.tar.bz2
+  sha256: ac2c0b58eb6a0fd21d3fe905ab7461355a40c71c05eca7b66abffae79fbd94db
+  md5: 920ae839f622108e2120af192ca06624
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  size: 395500
+  timestamp: 1714483616978
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+  sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
+  md5: c5a600d81b1b48578863af2973c743ac
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 187637
+  timestamp: 1714510590009
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+  sha256: f913b61ba3c1651b36688415cc163a5d575475f7573b543f48a80e7a5002e4bb
+  md5: f11d165eaa532ce04a35382841284298
+  license: MIT
+  license_family: MIT
+  size: 107047
+  timestamp: 1693902034820
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.9.24-hecd8cb5_0.tar.bz2
+  sha256: 7031fa5cac3aca09b273742f9d7bdde4fb85edefc21cb3407a779a5a81438394
+  md5: c25cd4336a986ed75c92636e17953a48
+  license: MPL-2.0
+  license_family: Other
+  size: 141521
+  timestamp: 1727794863285
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.8.30-py38hecd8cb5_0.tar.bz2
+  sha256: 8884779658a664baff5d678262dcd6eb5a7264d740940276b350ec9794771347
+  md5: 9073e4a414ada62c28cc075ca4f46f43
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 168893
+  timestamp: 1725551852092
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py38h9205ec4_0.tar.bz2
+  sha256: f7eed6bdf70e018d4c1dbdf8c432a2ebbc3aede20cb13233326d954daeef6a99
+  md5: bd42db53fafca5d38216f70c4a772881
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 231771
+  timestamp: 1726856528238
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py38hecd8cb5_0.tar.bz2
+  sha256: d2b1550ca58a65e722b08e422d6065064a50d87a19a3fb99be81f36bcbf66fea
+  md5: b6338c9d4466d41e3902db36cc0a22d9
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 152727
+  timestamp: 1698129895844
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.0.0-py38hecd8cb5_0.tar.bz2
+  sha256: 3d1018a815d8bb46b063b992fb952f28098f908fd512905c1e2f8a62ca9af3a3
+  md5: 5834511b3b4271913ec2ac1d645298cc
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35735
+  timestamp: 1721657500337
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py38hecd8cb5_0.tar.bz2
+  sha256: 2672f4f98c47dcdbae2ef13141c53724a9ee6553b8c9174a63150063fc9dd5c2
+  md5: 2496f87b7c0a5104253e560d74edcd38
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 550079
+  timestamp: 1709758428723
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py38hecd8cb5_0.tar.bz2
+  sha256: 82c6cf7fe4543f39bd6cd3907cec85e8f60c6297845e422976bb4de7f5bf0088
+  md5: 62f25c84914f0f89a5554f7171b908e1
+  depends:
+  - python >=3.8,<3.9.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15601
+  timestamp: 1709323080843
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/conda-pack-0.7.1-py38hecd8cb5_0.tar.bz2
+  sha256: 9c18c2468eac9d37d06661c8515f547432d39917a78014756aea240affd3c23f
+  md5: 9a8a3736fa4d8394038c492bb05c973a
+  depends:
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 52486
+  timestamp: 1710258154887
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/conda-package-handling-2.3.0-py38hecd8cb5_0.tar.bz2
+  sha256: c863c2ed06aab4d8dc7dfdf6ded102466540cd0c5ddf51eccff0dae5dfcf45d9
+  md5: a9ce61d98f6ea52528b047fd89bbfc0d
+  depends:
+  - conda-package-streaming >=0.9.0
+  - python >=3.8,<3.9.0a0
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279495
+  timestamp: 1718138312911
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/conda-package-streaming-0.10.0-py38hecd8cb5_0.tar.bz2
+  sha256: e2e7d06ec01909534ef8fbed03d102d5fdc9f50637ab075a015335dd7e9d0d8f
+  md5: 8e98825a22a87b641144dfb0c41e3411
+  depends:
+  - python >=3.8,<3.9.0a0
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28400
+  timestamp: 1718136271863
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py38haf03e11_0.tar.bz2
+  sha256: 1473dda25c38fb08cbe01cecd833141002a9a70231e7743c77124a3f90d51626
+  md5: 1456da04419043ef34f05b42758598da
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 225845
+  timestamp: 1663827553065
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.2-py38h6c40b1e_0.tar.bz2
+  sha256: 5e9904234e11b1424d8e952ddb7aed84bab2a70d871ae645ae2bd809c47114f9
+  md5: 4c3802b624f9665a8e3e94dcf483fa9b
+  depends:
+  - python >=3.8,<3.9.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 364975
+  timestamp: 1701729590010
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py38hecd8cb5_1.tar.bz2
+  sha256: 93795b6dc8f961dbe377760a32f38512e015d618109cbc030cac09f171be2078
+  md5: fe229f4229cb5acdf2d397c2b12182d0
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7
+  - python >=3.8,<3.9.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 103937
+  timestamp: 1613390235465
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py38hcec6c5f_0.tar.bz2
+  sha256: 455dc5a3dba2409362ef2c91841cd68e3a73fb6f96267b291c9b7e1fa24e785a
+  md5: 55f079cc255134e545e705a49eb5c18a
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 2051390
+  timestamp: 1690905143314
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2.30.1-py38hecd8cb5_0.tar.bz2
+  sha256: a8c45816df2dfadbe7dc2deed3ee2cc4502548f0583b866d6c15de5543da9ce3
+  md5: 8b40ccb3121dd0d6faf73210d4bfc3f2
+  depends:
+  - click >=6.6
+  - cloudpickle >=1.5.0
+  - cytoolz >=0.8.2
+  - dask-core >=2.9.0
+  - msgpack-python >=0.6.0
+  - psutil >=5.0
+  - python >=3.8,<3.9.0a0
+  - pyyaml
+  - setuptools
+  - sortedcontainers !=2.0.0,!=2.0.1
+  - tblib >=1.6.0
+  - toolz >=0.8.2
+  - tornado >=6.0.3
+  - zict >=0.1.3
+  constrains:
+  - openssl !=1.1.1e,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1106542
+  timestamp: 1605066580663
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/double-conversion-3.1.5-haf313ee_1.tar.bz2
+  sha256: 2bdfa7559274e301134763f91c68549e3d8e96c588590e96426bee8d8980aafa
+  md5: 53d71f9c190485c09e175ad286f4f17f
+  depends:
+  - libcxx >=4.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 243792
+  timestamp: 1567108378542
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py38hecd8cb5_0.tar.bz2
+  sha256: 0f432eeab9a2f0363540efcda4a1048b3d60d5e0b3e2cfb106748759caa28138
+  md5: f0461cfd6eac119ca072171039b5f799
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16516
+  timestamp: 1649926487728
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.2.0-py38hecd8cb5_0.tar.bz2
+  sha256: 441b384d467faff32fc8de30e666514ab8a6258ccb510035802546ec6c257183
+  md5: 6b891fd873db20fadb139335d08ac5f0
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 30672
+  timestamp: 1706031564908
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-0.5.0-py38h67323c0_2.tar.bz2
+  sha256: f44bcd182cc2cb5e2c56d355cf88bb370690aed796e1d7ba2fc802e6e51b6416
+  md5: 9aeb353e8180e28443b01e358955247e
+  depends:
+  - numba >=0.49
+  - numpy >=1.16.6,<2.0a0
+  - packaging
+  - pandas >=1.1.0
+  - python >=3.8,<3.9.0a0
+  - thrift >=0.11
+  constrains:
+  - numpy >=1.18,<1.22
+  license: Apache-2.0
+  license_family: Apache
+  size: 191073
+  timestamp: 1658500689000
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py38h6c40b1e_0.tar.bz2
+  sha256: f43c12493a44a51e00c3cdb2322440c49c2d4e2ec0744bd713a631be70001517
+  md5: 278ae8e1e11f718ec07e77340bc116fe
+  depends:
+  - brotli >=1.0.1
+  - python >=3.8,<3.9.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lz4 >=1.7.4.2
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  license: MIT
+  license_family: MIT
+  size: 2633630
+  timestamp: 1713551956146
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.6.1-py38hecd8cb5_0.tar.bz2
+  sha256: 49d9c40471e4cf7f59eca2c9593962a0b1e317a7b24e9699f3f3e478297b9f0d
+  md5: 9677bcec7b6e7ad83b4191cacef68b60
+  depends:
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - pyarrow >=1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 284765
+  timestamp: 1724855821423
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+  sha256: 3c7aa54548409f9343e891820ea43c195b5e4e4dce6b761bc3ae9f6c8be0fc86
+  md5: ed9629d6dc1612ec425eb8d27478b0f6
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 140316
+  timestamp: 1706888243476
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+  sha256: aed47f9ca4dd140b9c8a183e53d4b89eba84a20041d2038983cdfea8096104ef
+  md5: c0d981d7d43eaad55950ff5e57206e70
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 97828
+  timestamp: 1706895273858
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/grpc-cpp-1.26.0-h044775b_0.tar.bz2
+  sha256: 6598d58756721bdaaeb23ddb1c30eb8bc4c4fdc6ef73eca56465c0c12c366e0e
+  md5: 71981798545e520d35049dd3fa07350e
+  depends:
+  - c-ares
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=4.0.1
+  - libprotobuf >=3.11.2,<3.11.3.0a0
+  - libprotobuf >=3.11.2,<3.12.0a0
+  - openssl >=1.1.1d,<1.1.2a
+  - zlib >=1.2.11,<1.3.0a0
+  license: Apache 2.0
+  license_family: APACHE
+  size: 5168647
+  timestamp: 1580397726198
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-58.2-h0a44026_3.tar.bz2
+  sha256: c04f4cf3f9c4879c4d95b36cc842a5def9d1224aad73ef456fd069f162e3d603
+  md5: 5c5aa862793c874be6ec8d6af7d1f4e4
+  depends:
+  - libcxx >=4.0.1
+  license: MIT
+  size: 23669475
+  timestamp: 1588026009899
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py38hecd8cb5_0.tar.bz2
+  sha256: c924e82966f232e105da559f9a58f105f13ff03660b4d84a1507fa82c931ba7f
+  md5: db4484cfb238d23601641490f80569b8
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 124051
+  timestamp: 1714398923029
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py38hecd8cb5_0.tar.bz2
+  sha256: 3158194afae37da6797a2146fed4da68f548172461cf697727dd8d8673b089f2
+  md5: 8e5f8d717cfa9d009d29ba465ee3aee2
+  depends:
+  - python >=3.8,<3.9.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 42299
+  timestamp: 1704813585523
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.4.0-py38hecd8cb5_0.tar.bz2
+  sha256: 531b00944ee7aba2ef0accac6d18d1b0bb04d05ca320fd5c1b27e69b0b3e8fd0
+  md5: 30c382387a7c041ddd037f3ebbe1b0ce
+  depends:
+  - python >=3.8,<3.9.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 58401
+  timestamp: 1720641231783
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intake-0.6.8-py38hecd8cb5_0.tar.bz2
+  sha256: bf38dd1c31e7972eb1e2017ee43eb2ae77d7a6e4ed66c4c198fdad4f87af0a6b
+  md5: 3043756621f9503851e591b05190a0c6
+  depends:
+  - appdirs
+  - dask >=1.0
+  - entrypoints
+  - fsspec >=2021.7.0
+  - jinja2
+  - msgpack-python
+  - python >=3.8,<3.9.0a0
+  - python-snappy
+  - pyyaml
+  - requests
+  - tornado
+  constrains:
+  - bokeh
+  - panel >=0.7.0
+  - hvplot
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 192144
+  timestamp: 1678787642849
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+  sha256: e0127f50d444bf4474e8df07d602c7f6dd38690e8bb3fb28817c164940ffcde1
+  md5: 583fcd7060cad6a77074d00d9ef62f44
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 731417
+  timestamp: 1699647668990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py38hecd8cb5_0.tar.bz2
+  sha256: 8bf93ec3b6e49e270c4dda4ba49327e2af0f496176ad3a13aecf9926bdae3d21
+  md5: b2edef890b73c905c323bd18c7590008
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 191374
+  timestamp: 1728665881223
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.12.2-py38hecd8cb5_0.tar.bz2
+  sha256: 9d76af4bc19372cc220b285d63598c90ba6e27476f0d9088eb818e3ce69d7ed1
+  md5: 6a291fe69dc614fc91a22ec7f86bc85d
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.8,<3.9.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1235334
+  timestamp: 1691532318531
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.1-py38hecd8cb5_0.tar.bz2
+  sha256: 677297a0b7640bff35fd15cdb013b40962dfc9306ca2769eb1c6d2447e79de10
+  md5: 0d3b57b4975069bfffce9753363cb5be
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 1052163
+  timestamp: 1721058526649
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py38hecd8cb5_0.tar.bz2
+  sha256: 583d3f15b66cf0ae1a0e933e532b6aa2c35df841bb206330479752961aa57f6e
+  md5: a09697fd44605d88790ff1039114440e
+  depends:
+  - markupsafe >=2.0
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 271327
+  timestamp: 1716993463036
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+  sha256: 855982a798d9af8e70635a250528a5da3b2b0cf7095e2804858caf139c8a239b
+  md5: 112a5602fe42a84a5bafa038abeddf4f
+  license: IJG
+  license_family: Other
+  size: 279686
+  timestamp: 1722872676718
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.23.0-py38hecd8cb5_0.tar.bz2
+  sha256: 415e06dd2d89aeb0fd25649fcc914e33b4733d10892c9f331f1aaf77cb4c816e
+  md5: 77d35a34cd2dd79f34de76b7c20d5d4e
+  depends:
+  - attrs >=22.2.0
+  - importlib_resources >=1.4.0
+  - jsonschema-specifications >=2023.03.6
+  - pkgutil-resolve-name >=1.3.10
+  - python >=3.8,<3.9.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 144307
+  timestamp: 1728486978880
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py38hecd8cb5_0.tar.bz2
+  sha256: c208cadc5de183c46d2962f47e13dced0e1fcac5351821747536bfcbfd138779
+  md5: 6999d899e1ac321e4ea7a094c007a78f
+  depends:
+  - importlib_resources >=1.4.0
+  - python >=3.8,<3.9.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 15921
+  timestamp: 1699032479293
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py38hecd8cb5_0.tar.bz2
+  sha256: cc595a959c77802c0ae5aca9cc9e72071b951cac97463210744bae530c2b5b8c
+  md5: 72993460036cd4ee6f80f4c63a1c7fd0
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 198052
+  timestamp: 1676329716909
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py38hecd8cb5_0.tar.bz2
+  sha256: f981708f6bd38ef8c1e5ebb5f8aa240ea221a04bd8bdd4821876cc4bd7461a87
+  md5: 15ebadb3ff038bbecf6b957e73e5a54a
+  depends:
+  - platformdirs >=2.5
+  - python >=3.8,<3.9.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 83398
+  timestamp: 1718818388375
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py38hecd8cb5_0.tar.bz2
+  sha256: 07f3dcc542fe2faa4b36c4c4f7b72c3f8734d7facd2e492a734a1776103eee21
+  md5: a10fced6217b9ed7c044d1af0942689c
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.8,<3.9.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36640
+  timestamp: 1718738234692
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py38hecd8cb5_0.tar.bz2
+  sha256: dfbac50959b9c86448bb57f0fb6bb3f0388a7f1bacdc03266fa2df84f9b7e086
+  md5: 8f68f8cd2ec7337cdc6bf5c53aeb9e97
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 510344
+  timestamp: 1718827865183
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py38hecd8cb5_1.tar.bz2
+  sha256: 6c936d19322b7cc5ce067b2e8ce763ff5d944ac53b16dfc58e26a891ae867838
+  md5: ad45f9900cf10fd64f55a4ede690792d
+  depends:
+  - python >=3.8,<3.9.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24606
+  timestamp: 1686870930580
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py38hecd8cb5_0.tar.bz2
+  sha256: 2ff3ee82e821881366f6c8be7a5cf3e7ab4b3982fc7607df7a735ad1772c3878
+  md5: f0808af4af6c96e3be7515f7044f52ee
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19888
+  timestamp: 1700168715614
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py38hcec6c5f_0.tar.bz2
+  sha256: 4e9da4496ac7dcd7963447eab5c0de25f16dbba9a51422f68c95081a3657d384
+  md5: 83af611855a3505d81184247683e8b80
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64974
+  timestamp: 1672387224650
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
+  sha256: 8093a64350665d16ca2ad0acfcbba5c84b479c316a40db6b9d5f9b84b58f3b12
+  md5: cd98cc17f8297a31b1dd62f061ea4f83
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - openssl >=1.1.1u,<1.1.2a
+  license: MIT
+  license_family: MIT
+  size: 1289465
+  timestamp: 1686931250022
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.73.0-hd4c2dcd_11.tar.bz2
+  sha256: 20993ad3c87ca634e993ffd55a44e3b6afd240a21e67afe775ec1789a4a9a15d
+  md5: eeb40fe4ff49dd8385047b3640400a5a
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=58.2,<59.0a0
+  - libcxx >=10.0.0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.11,<1.3.0a0
+  - zstd >=1.4.5,<1.5.0a0
+  license: Boost-1.0
+  size: 20248484
+  timestamp: 1611677312412
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 685c3bc9068bd485604b80bf03789e4dca95c410d33871bc1b882e47649fabed
+  md5: 6cf8e55271e150ca0961d0ddedaa61bb
+  license: MIT
+  size: 66237
+  timestamp: 1714483284541
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 69826cee54db9955f0120af21ec36d13f9211877fd67364f2068d0a54c6c97cd
+  md5: 0851917257f490d35e1f73da8a1c723c
+  depends:
+  - libbrotlicommon 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 34042
+  timestamp: 1714483343147
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 3f5a1f03b50b90b397a0ee432ad0cba13354abdaf7e5652c0fc60164b26a08b6
+  md5: a50bdc871ef4bf14deb088d888b92b5e
+  depends:
+  - libbrotlicommon 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 311597
+  timestamp: 1714483371586
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
+  sha256: 83cf762f0d09c97dfb4a1c1cd9e635de2e54c384b057afbf3c0e2e8db07d862f
+  md5: ae3a458da93940fea1fa83af80d91fd4
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.52.0
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - zlib >=1.2.13,<1.3.0a0
+  license: curl
+  license_family: MIT
+  size: 358556
+  timestamp: 1693515516157
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+  sha256: e84e6cbacb12de6fe86955449502d3956696ae583060d0d4911ea6f503cfb9ad
+  md5: 1d200c536be4172db41c49e81a3e6350
+  depends:
+  - ncurses >=6.4,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 169586
+  timestamp: 1703006265367
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+  sha256: 4786264321edbff780633a5b752995eb3193ca4bce11b0fda179577f6cf1102c
+  md5: 849fdd014c201a9d2c2aa7c7db38a778
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 103993
+  timestamp: 1632891571494
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h0a4fc7d_0.tar.bz2
+  sha256: 3b246ea89fd2f97e3f0b04bdfc8e1ce4b18aed99bb5a9fbba274fa2d7fc3b844
+  md5: 86c45e25eed8fe34d41e3c8fd440311a
+  depends:
+  - openssl >=1.1.1m,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 445216
+  timestamp: 1642102789153
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+  sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
+  md5: 822a5b76117e56d3912f1f2153307528
+  license: MIT
+  license_family: MIT
+  size: 136045
+  timestamp: 1714483561919
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+  sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
+  md5: e458587c87e3f2d20192f4e0738f2c63
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 149419
+  timestamp: 1665498987619
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+  sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
+  md5: 1058b661ec829b2ee3716ee2a5520641
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1917987
+  timestamp: 1665498925405
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
+  sha256: 9ff6ed0f0b9f9f27f449e95d11aa1c4e9e80028fd9d2a8caca5a15d8df88f435
+  md5: 7b4b557afc66aba367da14d97d71934c
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1409885
+  timestamp: 1714483704680
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm11-11.1.0-h46f1229_6.tar.bz2
+  sha256: 5f31ea9ceb555ff984674f2b7eae2262f7c124c861982d863b93f3a532273349
+  md5: 4e8a6604f36e94ae35c22ade431277b7
+  depends:
+  - libcxx >=4.0.0
+  - zlib
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 23102665
+  timestamp: 1665077532507
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
+  sha256: 331bc731419328a873e1a48d4257c58baa33d73b4b91ff7a3553b1c122120fb1
+  md5: 43fba990695db8556ddd0ade21d59ecc
+  depends:
+  - c-ares >=1.19.0,<2.0a0
+  - c-ares >=1.7.5
+  - libcxx >=14.0.6
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - openssl >=1.1.1u,<1.1.2a
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 782018
+  timestamp: 1686931556261
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-3.11.2-hd9629dc_0.tar.bz2
+  sha256: 2d484c76caf27dac35c377d5b1ea03d151188bf882ce68acf06df62a38fca011
+  md5: 15b2885391989958783fc4704f0f947c
+  depends:
+  - libcxx >=4.0.1
+  - zlib >=1.2.11,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4689094
+  timestamp: 1576541928521
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
+  sha256: 8b1adbb78b6283c3d8df932d5aa7e8e249351aa1e206ba2949ee86052912e83f
+  md5: 2e035c81c044bff1224224ac24161dfd
+  depends:
+  - openssl >=1.1.1u,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338461
+  timestamp: 1686931232629
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.13.0-h054ceb0_6.tar.bz2
+  sha256: 65de01fc98ac03b9679b294128a09690605bf9500f1002ad6b22f0373f943bcc
+  md5: 54c1a871b02da02e6a4a8d85f4daf6d6
+  depends:
+  - libcxx >=10.0.0
+  - libevent
+  - openssl <1.1.2a
+  - zlib
+  license: Apache-2.0
+  size: 373773
+  timestamp: 1612013222710
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.2.0-h87d7836_0.tar.bz2
+  sha256: f4a89b1128569497da1c5d947c31a6314e50ca752e7ca402871e34e8897d2122
+  md5: 789fd41c56c85c2c9401e6f244ad87c2
+  depends:
+  - jpeg >=9b,<10a
+  - libcxx >=10.0.0
+  - libwebp-base
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.11,<1.3.0a0
+  - zstd >=1.4.5,<1.5.0a0
+  license: HPND
+  size: 620073
+  timestamp: 1616492373485
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+  sha256: 246c0d82766042c1a9194eecc71690918c68afa3528ff0c2c82796ce901df40b
+  md5: f33be4ed3bff89ed8f68df6c75158510
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 449215
+  timestamp: 1729160070984
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+  sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
+  md5: 5c740b4a18a558de0ccfe601703c423c
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 338738
+  timestamp: 1662635677689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.38.0-py38h8346a28_0.tar.bz2
+  sha256: e1d230a453b5615198e2ed8c12bdfb5a97bdf547bc4a3c63b7326859d8203885
+  md5: 99352eab44f1f5cfc6101a6dffb4afbb
+  depends:
+  - libcxx >=12.0.0
+  - libllvm11 >=11.1.0,<11.2.0a0
+  - python >=3.8,<3.9.0a0
+  - zlib
+  license: BSD-2-Clause
+  size: 246923
+  timestamp: 1647870639307
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py38hecd8cb5_0.tar.bz2
+  sha256: 84ce38615938b0276a9f31ae7c26acbf7fb5fefcf3e26a1c027880e1c6453f92
+  md5: a37ae112579913dab5c86a811d15193f
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11870
+  timestamp: 1652903183129
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+  sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
+  md5: 8f57dc3a3327bb6f7e1cba908856ac7f
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 183138
+  timestamp: 1714510756758
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py38hecd8cb5_0.tar.bz2
+  sha256: 037ef517fca2095c0cb00251dd62db209d3be9305771bd235c8fbd5eed3d35a4
+  md5: d16c75e346d76898b659d4445b0b63e0
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123565
+  timestamp: 1671541981715
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py38h6c40b1e_0.tar.bz2
+  sha256: 01313a41f4405cf7950796ff0c2be8b217fa1e166c84cd346cb47c32fc4ac444
+  md5: 0e051f25f4d33a9f8787f8a6ddb9e3af
+  depends:
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23389
+  timestamp: 1704206382062
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.7.2-py38hee32256_0.tar.bz2
+  sha256: 23ad53d7332a98769b5ebfd0e18f7b984088842fe87d532a2413980b548a466b
+  md5: d3af319c00981ce5345d2f4b6a2b14fc
+  depends:
+  - __osx >=10.11
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=5.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.20
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8023811
+  timestamp: 1693812942688
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py38hecd8cb5_0.tar.bz2
+  sha256: 88df2ac9ce5c9f4e68e9bae5fe272f2e0ac6fda2aff312ad6af3a66149517c2c
+  md5: c2314f5a0fff2fcb7a4d320ad59186cd
+  depends:
+  - python >=3.8,<3.9.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17337
+  timestamp: 1662014707291
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py38hecd8cb5_0.tar.bz2
+  sha256: 3a090dbd75981245b7ba4d043b374aed341c5335adeda1ed5d2b92e970229a6c
+  md5: d1c6fac66449aa61b64ca834f1e27171
+  depends:
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 90757
+  timestamp: 1661496417142
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+  sha256: c825bc3070f73318ffff88a7a0b7fc6d1858b058ced735efd1789053f1583918
+  md5: dea5f96459c9a6df6b026ca57d387936
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224299920
+  timestamp: 1699647835748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py38h6c40b1e_1.tar.bz2
+  sha256: 38905fb9453303e09abb46bb751bec48210c17a910dbd88293089b2297ffc02c
+  md5: aabd6d138e77ca6b9bdb36b3f7f4ee89
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48594
+  timestamp: 1682969108154
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py38h6c40b1e_0.tar.bz2
+  sha256: d2b5f01e04120955578805cbbc87797415fb606ba693ca8c958a30264d01a315
+  md5: 21358f24bbe5ca2e59c62eeee702234d
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 210895
+  timestamp: 1695058515685
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py38ha357a0b_0.tar.bz2
+  sha256: e7be2820541896a80f39c83993b4e9ae7945ae5b1e6a761a8c6b145b2a353e12
+  md5: 7cf5c49ea5302cf98b49cdfc36ab2aa8
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy
+  - python >=3.8,<3.9.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296359
+  timestamp: 1695059904922
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py38haf03e11_0.tar.bz2
+  sha256: 1ee2650fe9020fdc057d5393c9fc85ab235c563e29f442d2dd7b56571af9c08d
+  md5: 9136c45236ebf72976926d941f1f95fc
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 83201
+  timestamp: 1652362886402
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py38_0.tar.bz2
+  sha256: b82b619359eb11120d4c500d16b8fdaf1b83f2a77854cf2a48dc01f901ca7ac4
+  md5: 5494980acd3e180125cd5c8c070e0e9d
+  depends:
+  - python >=3.8,<3.9.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 22679
+  timestamp: 1573471345595
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py38hecd8cb5_0.tar.bz2
+  sha256: 1dc4e87e5b24e673ef117566d965681172a9ee905adb44f4eea6b0b082d19b6a
+  md5: c0946783531d986e7fb33009588b9f23
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8194350
+  timestamp: 1717622952021
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py38hecd8cb5_0.tar.bz2
+  sha256: 638bcc1c3e8ded3381440c5228c9482091757242e5cda0ec25992314e7368653
+  md5: 4cfb37881bd4bcc8b871e39abc7e0649
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.8,<3.9.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100672
+  timestamp: 1698934403672
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.4-py38hecd8cb5_0.tar.bz2
+  sha256: 0a03c2f90cc4eb4f1360208e808c1136f320da2ba16878a2741a198a0b062344
+  md5: 17ae803f164e09457b4a0b458d196e1d
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - importlib-metadata >=3.6
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.8,<3.9.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - pyqtwebengine >=5.15
+  - tornado >=6.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 490312
+  timestamp: 1728050636817
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py38hecd8cb5_0.tar.bz2
+  sha256: 150e24bf4ce826d53e796d1afd9f8bfc0b0a2d1dd93434a1039c079b63bc807f
+  md5: 4a63ec451e31396bcf28c7811cdfe4b3
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.8,<3.9.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 149002
+  timestamp: 1728050063689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py38hecd8cb5_0.tar.bz2
+  sha256: d15c23a6d8df660a9e9d1bd7bddc73d6a33b72f4e7a60bd5c31d186310e64c44
+  md5: cbff13b569745c3776edcbefd9584844
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14374
+  timestamp: 1708532763871
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py38hecd8cb5_0.tar.bz2
+  sha256: 5f33a0b11861de03735aa0de38fab3b359f8c2402729dde6332ac62560be0941
+  md5: 21b4064e6bae8999118fc923eba3f37f
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 558008
+  timestamp: 1717631022461
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py38hecd8cb5_0.tar.bz2
+  sha256: d59fd18830bbb0d25281a51879290851b3c5336b91b3c59b0011003ec127ebe9
+  md5: 470134ded59467dd71c9ce988176e0e5
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23491
+  timestamp: 1699456117584
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.55.1-py38hae1ba45_0.tar.bz2
+  sha256: 5451e058145995f9591f4e196b76b4fd69536ac5f7ea3fc867a1e505acb4ba15
+  md5: cd19316da2764ee8ce0e3089e7f5d174
+  depends:
+  - libcxx >=12.0.0
+  - llvm-openmp >=12.0.0
+  - llvmlite >=0.38.0,<0.39.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  - tbb >=2021.5.0
+  constrains:
+  - libopenblas !=0.3.6
+  - tbb  >=2021.0
+  - cudatoolkit >=9.0
+  - scipy >=1.0
+  - numpy >=1.18,<1.22
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3939315
+  timestamp: 1648042686030
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.4-py38h47b59a4_1.tar.bz2
+  sha256: 1e384cd8e57ee5953d72e3725265b4c3414216e2d69198fa57a504d6d8577a20
+  md5: b19be6f476ed0f602317ed31319b5d1c
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 135465
+  timestamp: 1683227249056
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.21.6-py38h827a554_1.tar.bz2
+  sha256: 6f340cf791cf5fbefbc320e4dcef041d3ce75371ffe187824dfc4822e3dbd944
+  md5: 2aeb9bcf08048fc68bca7e5b89bbe0e6
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.21.6 py38ha186be2_1
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11590
+  timestamp: 1715093222808
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.21.6-py38ha186be2_1.tar.bz2
+  sha256: 43f2a1220e7786d7a8c339f39769eb6c640fec67542923e57efc19c6090688e7
+  md5: 17104540c935718c9f5c93c81e08228c
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - numpy 1.21.6 py38h827a554_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6319935
+  timestamp: 1715093194701
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h7231236_2.tar.bz2
+  sha256: f6ca5e20df95f1067063a94923eea358b3b1297c5dae5ece4a23a1414b26e94f
+  md5: 4417110c601925584eb73c75420ded80
+  depends:
+  - libcxx >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 511233
+  timestamp: 1720655581725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
+  sha256: f95f5173ab2a4529b56ff90deec905dd53877250acedd3887fb289b721396009
+  md5: 2ab1a555331747f19e4aa7a335e33a85
+  depends:
+  - ca-certificates
+  license: OpenSSL
+  license_family: Apache
+  size: 3665304
+  timestamp: 1694465313538
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-1.6.7-h001ef8f_2.tar.bz2
+  sha256: 5a74d458cae412d785abd6c0e6b23235521f5455b26a86097f286f1854613e91
+  md5: 68a35293ee1c94e83b87e4c1aa42c7c5
+  depends:
+  - libcxx >=10.0.0
+  - libprotobuf >=3.11.2,<3.12.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.8,<2.0a0
+  - zstd >=1.4.9,<1.5.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 395608
+  timestamp: 1619512311990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py38hecd8cb5_0.tar.bz2
+  sha256: 2230f3fc9b1cabbf2007c10212d3d8e678b11d68ff75fd13b30c5b81d3d1d6b4
+  md5: bc85dc53ec6bf72853e8fc353de654e9
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 31823
+  timestamp: 1699371280670
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.1-py38hecd8cb5_0.tar.bz2
+  sha256: 5e79ed5782abd62a1a1f5dc0a9dcb16a49bd9fc1c2b2be8d432f231a4f3dfe15
+  md5: e37192ce90f7ca932bedac50c1828d9e
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 135811
+  timestamp: 1720101893151
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-1.5.3-py38h07fba90_0.tar.bz2
+  sha256: 223d738265fc6329bb3306e7aa0a023479001055c23a1aa0e9d8a9f9d450076e
+  md5: 17e31a8fbfa7024538e4c0b0207b5880
+  depends:
+  - bottleneck >=1.3.2
+  - libcxx >=14.0.6
+  - numexpr >=2.7.3
+  - numpy >=1.20.3,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  constrains:
+  - tabulate >=0.8.9
+  - pymysql >=1.0.2
+  - s3fs >=2021.08.0
+  - pyreadstat >=1.1.2
+  - zstandard >=0.15.2
+  - html5lib >=1.1
+  - fastparquet >=0.4.0
+  - gcsfs >=2021.7.0
+  - tzdata >=2022a
+  - openpyxl >=3.0.7
+  - xarray >=0.19.0
+  - pytables >=3.6.1
+  - python-snappy >=0.6.0
+  - brotli >=0.7.0
+  - xlsxwriter >=1.4.3
+  - xlwt >=1.3.0
+  - sqlalchemy >=1.4.16
+  - beautifulsoup4 >=4.9.3
+  - blosc >=1.21.0
+  - jinja2 >=3.0.0
+  - scipy >=1.7.1
+  - psycopg2 >=2.8.6
+  - xlrd >=2.0.1
+  - pandas-gbq >=0.15.0
+  - numba >=0.53.1
+  - pyarrow >=1.0.1
+  - lxml >=4.6.3
+  - matplotlib-base >=3.3.2
+  - fsspec >=2021.7.0
+  - pyxlsb >=1.0.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13072249
+  timestamp: 1677852446342
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py38hecd8cb5_0.tar.bz2
+  sha256: 679fd79d2bad66c7e22d25cd36c8907bc5e78526ba0d3f4ef574e86687d87932
+  md5: 3a7594f77efa0162990c665701e1912d
+  depends:
+  - locket
+  - python >=3.8,<3.9.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36483
+  timestamp: 1698702678191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.4.0-py38h46256e1_0.tar.bz2
+  sha256: bd2de69d792f911df8756fae161051412ebdcd4ab502837f051a9b1bf8e56548
+  md5: abba45a1032afb818d41bad893779e8a
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.8,<3.9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 796810
+  timestamp: 1721059746469
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.2-py38hecd8cb5_0.tar.bz2
+  sha256: def5a63d0eb12efd92fe21850c5b29dbf7e7cd0abcc11a9ad180ae47f073619d
+  md5: 172dc71d2204e23892b938413cb26e19
+  depends:
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2272447
+  timestamp: 1723484850699
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pkgutil-resolve-name-1.3.10-py38hecd8cb5_1.tar.bz2
+  sha256: a2825fda7b7bcdaa5469e4dae47a9b54fca5ae0b4e3f545db867061e6f0efea8
+  md5: dd887c90f3020a1bc7006d31f0c07bdd
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT AND PSF-2.0
+  license_family: PSF
+  size: 11442
+  timestamp: 1704297495056
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py38hecd8cb5_0.tar.bz2
+  sha256: 59543706932970f7922342cc83ce3b7cca7df58ef4c0fef602e13ace586f9ae6
+  md5: ca41bf67637034096f2414eaa100b518
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 33062
+  timestamp: 1692205767198
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pooch-1.7.0-py38hecd8cb5_0.tar.bz2
+  sha256: 322e198616c7e83a60010d0f997cfad3f8ea07fea3adf27e049c364349324b8c
+  md5: 1fccc3ef32139e3c02bef538caa5a4f2
+  depends:
+  - packaging >=20.0
+  - platformdirs >=2.5.0
+  - python >=3.8,<3.9.0a0
+  - requests >=2.19.0
+  constrains:
+  - tqdm >=4.41.0,<5.0.0
+  - xxhash >=1.4.3
+  - paramiko >=2.7.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 82466
+  timestamp: 1695850164306
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py38hecd8cb5_0.tar.bz2
+  sha256: cb719cdb0e7c35e0edabdf544042a3f47bc235d8f31f27cbed4f0f2d6c42e8fe
+  md5: a76c1a1d816608f02aa155ed03d95821
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91112
+  timestamp: 1659455138351
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py38hecd8cb5_0.tar.bz2
+  sha256: 90ce9ecb0155fa242f9dee60314307b67e0ee3ac6996c159f0aeb5f8226b6981
+  md5: 9c3b03ca9cd7c208571fdbd9ba5f3722
+  depends:
+  - python >=3.8,<3.9.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 578057
+  timestamp: 1704404412093
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py38hca72f7f_0.tar.bz2
+  sha256: 3e0fc9381b2c7a97dde3841b455a03648257ca105d3c99ee673e45dc2a3f233b
+  md5: d3034fa818207ec94aa5876e3fd778ff
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365816
+  timestamp: 1656431564060
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-4.0.1-py38hdf3e9eb_3.tar.bz2
+  sha256: 550cb24b4aa71074e972d57c6da38a2b458ffb5a18fa1510019cdb76565e397e
+  md5: b7a80dfd62ca5906daa693a840b2d545
+  depends:
+  - arrow-cpp >=4.0.1,<4.0.2.0a0
+  - arrow-cpp >=4.0.1,<5.0a0
+  - boost-cpp
+  - gflags
+  - glog
+  - libcxx >=10.0.0
+  - numpy >=1.11,<2.0a0
+  - pandas
+  - python >=3.8,<3.9.0a0
+  - six
+  - snappy
+  license: Apache 2.0
+  size: 2481281
+  timestamp: 1623164904136
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py38hecd8cb5_0.tar.bz2
+  sha256: 35c76d8e4ecfe2f9ddb8ca341e7c940b00dd7b2c628b4364f2cec55519ac5c6e
+  md5: 53d45ee242138195f85f5fbea3de05c0
+  depends:
+  - param >=1.7.0
+  - python >=3.8,<3.9.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30803
+  timestamp: 1675441540278
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py38hecd8cb5_1.tar.bz2
+  sha256: ee5a34ab3a65b01adc661e9c67b1f9af2e5fb737ef477607f16b85ad30d1fb7f
+  md5: a3220cef0db91e71e3de88c151de039b
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1888474
+  timestamp: 1684280131448
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py38hecd8cb5_0.tar.bz2
+  sha256: fa80f34c66064dad6d5c74c6a4a01f7ef842702cbbfeb73988ef3c9196d90a67
+  md5: e14a6c52601b5efcae0156ff27b210a7
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 157601
+  timestamp: 1661452654987
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py38_1.tar.bz2
+  sha256: 3bf4d8aa47a883c367b98db7cc16efef613a0b08fb143bb9f78967c5d2c7416b
+  md5: 6837a4c11fb0126b4422d0caaa1b6296
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 27255
+  timestamp: 1594394684547
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.8.18-h218abb5_0.tar.bz2
+  sha256: 0c1b0c532cfec52c6587073e036cef48d07057eda4727ac1db422193add8b1c3
+  md5: 184d7340d5f85eb4d369ae695f3568a9
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 15528724
+  timestamp: 1694439198827
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py38hecd8cb5_2.tar.bz2
+  sha256: 5582feaf474175f9a39fe9655041156721d57aa67fa3749fc9884686973d9fca
+  md5: dc7441373044444d950b7f985c71691b
+  depends:
+  - python >=3.8,<3.9.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 289785
+  timestamp: 1716495986341
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py38hecd8cb5_0.tar.bz2
+  sha256: 3bdab73baf83e87b9f1b533797fe64a084cefb1be9d1527fa4f295f7a8f498d4
+  md5: d67db0edf3d298995791f78ac59badc8
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 265379
+  timestamp: 1661369089392
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py38hecd8cb5_0.tar.bz2
+  sha256: b517732d28776219a570b5264aad5074b7ca96ee89b5ad04065dc16b6264c710
+  md5: b6de501d6a5bc6cf781f4181a13832d3
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16222
+  timestamp: 1683823894978
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py38hcec6c5f_0.tar.bz2
+  sha256: 803a11fceb8ac73e82ea6eb489503c268c6a59176e0b3ce3c0853b86ff386373
+  md5: 0b3a76ba820c7f1ec345ad82765eeffa
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.8,<3.9.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 140675
+  timestamp: 1682522414875
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-snappy-0.6.1-py38hcec6c5f_0.tar.bz2
+  sha256: aff80eab3d3bd2a996d0e58ae6a9ccc7aca2d136aabc957684fee9dc5df10c5c
+  md5: 63afd720f9f859b1df3b2f72cfec9433
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.8,<3.9.0a0
+  - snappy >=1.1.9,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 31543
+  timestamp: 1670944075249
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py38hecd8cb5_0.tar.bz2
+  sha256: fe4b78e7150559976de32624b8a0272f049bb7c1255b8fb179cbfc81c30de3e3
+  md5: 5ebd790aefad84c43f2b24f85c5679bc
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 255558
+  timestamp: 1713974414573
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py38hecd8cb5_0.tar.bz2
+  sha256: 1d7fc1716c0124d70eec1871da8ee2b108e915e2fcf6248436118ceb0e82bfae
+  md5: 2a4448bbd92f8a33e1e8fb04ebf48e2f
+  depends:
+  - param
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 61610
+  timestamp: 1711136949236
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py38h46256e1_0.tar.bz2
+  sha256: 0cacbcec0922022bb35f37e61071050be8d48bcdf1cc2d3d2617fa58d58d79bf
+  md5: 3cb8af201bee52dfccd08cb0e9502ca5
+  depends:
+  - python >=3.8,<3.9.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 177138
+  timestamp: 1728659222455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py38h6c40b1e_0.tar.bz2
+  sha256: 780059b7ecbe0039877c9fb4694a287888a5ba09df01b9b03898f38cfa478c70
+  md5: 72c8bc8105a687a24846b100d8137146
+  depends:
+  - python >=3.8,<3.9.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 506048
+  timestamp: 1709318384581
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+  sha256: c69f556df9a27328c56943f3b5918cbb953cfbca987e20394d823a6174781202
+  md5: ab294ae71ecdfaa307a961cc71dd890d
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-3-Clause
+  size: 205638
+  timestamp: 1652449553607
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py38hecd8cb5_0.tar.bz2
+  sha256: fbcea67a73af453330816c8fea3aa044bda75f292a1b97390a9aee725f855baf
+  md5: 14748afcba729835202de23627c6a65a
+  depends:
+  - attrs >=22.2.0
+  - python >=3.8,<3.9.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 58798
+  timestamp: 1699012243225
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py38hecd8cb5_0.tar.bz2
+  sha256: 4ede1df4d0ba54813783f6f8e9aa984aebfec5d17e06a7416068aac4f21b3fe2
+  md5: f38446b6c558a0d468a0e24ad28d5a70
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.8,<3.9.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 98509
+  timestamp: 1721411124535
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-toolbelt-1.0.0-py38hecd8cb5_0.tar.bz2
+  sha256: 3d3ca7b724662b43d343c585c3b2017aa786a457d9b1d6bdcc36ad3eee8f9073
+  md5: 904104151a27446e34efa89d9e0a65d7
+  depends:
+  - python >=3.8,<3.9.0a0
+  - requests >=2.0.1,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 69866
+  timestamp: 1690874175366
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py38hecd8cb5_0.tar.bz2
+  sha256: 543d50ee7da2e1bb4113aae35ed0078c524b6a2dd0597c4d8eafc7b9c0ff74a4
+  md5: 54c2663e4127781a5dfeeaf0591c72f5
+  depends:
+  - python >=3.8,<3.9.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9832
+  timestamp: 1683077172537
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py38hecd8cb5_0.tar.bz2
+  sha256: 075834abb477e903e6055562b5f8e765a7ab5cc12715d6842ba497373eef4e13
+  md5: 8b2bff424e3921364d511ad691a0f5d7
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 10211
+  timestamp: 1683059253756
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py38hf2ad997_0.tar.bz2
+  sha256: f3643369ddba0092399144fdd924b8cd41d8542ea0e07624fc55cb974bece013
+  md5: 1b1c11994c9be771cf73009f5aae3cb2
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 319417
+  timestamp: 1698946428421
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ruamel.yaml.clib-0.2.8-py38h46256e1_0.tar.bz2
+  sha256: 99f2860c388a2e4d009b8515b4245e5395474409970c7bc728e403f6c5aeb26b
+  md5: c620d6f39bde0f76cf6dc5127b61ad67
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 142294
+  timestamp: 1727769981406
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ruamel_yaml-0.17.21-py38hca72f7f_0.tar.bz2
+  sha256: 9bbf0af30a1f1dc810fc46bd80331521d782a3a21276685946201ebb713d41bc
+  md5: 25a6ab14b8a94c1d7c11c0b1eb92597b
+  depends:
+  - python >=3.8,<3.9.0a0
+  - ruamel.yaml.clib >=0.2.6
+  license: MIT
+  license_family: MIT
+  size: 173869
+  timestamp: 1667489796800
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.10.1-py38hf241641_1.tar.bz2
+  sha256: 402a621edb67348e29d593fa3abfdc2e2caa0e4cb263a81ea4438b5ee16d06dc
+  md5: 98bf265b20f94a8fef4f45d9caa71e9a
+  depends:
+  - blas 1.0 mkl
+  - intel-openmp >=2023.1.0,<2024.0a0
+  - libcxx >=14.0.6
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.19.5,<1.27.0
+  - pooch
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24792365
+  timestamp: 1683295750615
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py38hecd8cb5_0.tar.bz2
+  sha256: 87e86c8667a87b9bfe09df1d98c77355c94ce1eb56c8b297782868f63753870e
+  md5: 605714e602ef77f4feb2132da8f67a99
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27880
+  timestamp: 1699371249360
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-60.9.3-py38hecd8cb5_0.tar.bz2
+  sha256: 47c33bb5fe1277cf9e33191ae3629f646049af0f7618b8c67b3eba0d1b768cfa
+  md5: 3ef3eb157e83c0224d30b99805e131ed
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 1229042
+  timestamp: 1685710558686
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
+  sha256: 9eaab5afd89c87ca139915589626785039fac30f05f8fb19e9eefe27eb935ce6
+  md5: babdcd3370f85ded3d313902dcebecfb
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 46224
+  timestamp: 1723557464934
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py38hecd8cb5_0.tar.bz2
+  sha256: 5790b43ac502fb2e1688a505227bcae00f328adf35f2b8ea08c7527f6a52ceec
+  md5: 41d9d12aac6e182a2212d409524f517c
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17801
+  timestamp: 1705431355713
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py38hecd8cb5_0.tar.bz2
+  sha256: 4617e621bcefd0cf9806da51451335cb422b6cff1de8ece9844136a14732e4cb
+  md5: 3118681370d80225e19baf3f77171a69
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 67418
+  timestamp: 1696347616672
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+  sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
+  md5: 6bef1694163a68ac4c37e5857b8da4f5
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1900191
+  timestamp: 1714488351925
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py38hecd8cb5_0.tar.bz2
+  sha256: 34533fc748e7cb5f8a860eb3f6601beb4f126998d1dd5fc5afd6d89f01969efe
+  md5: cbda7f79b6003675241b015d49c85280
+  depends:
+  - ptyprocess
+  - python >=3.8,<3.9.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30949
+  timestamp: 1671751869746
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/thrift-0.17.0-py38he9d5cce_0.tar.bz2
+  sha256: df4c68d6a2227c2d168ae30d4d51c3d64d40999d67c859d3a3c239c6f321cc7b
+  md5: e36eb226622a7c95b42af3e8ec8dbeb6
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.8,<3.9.0a0
+  - six >=1.7.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 127256
+  timestamp: 1666296634923
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py38hecd8cb5_0.tar.bz2
+  sha256: 0ee666490997aafc34aec0c78efe2d7871f6fed54c4250d69b11aaf29ad5ed71
+  md5: 17b450ce8eecf4c027a24177061f47c1
+  depends:
+  - python >=3.8,<3.9.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40304
+  timestamp: 1668168892749
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+  sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
+  md5: 523c006cc67c011383678c762015479b
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3594448
+  timestamp: 1714770737885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py38hecd8cb5_0.tar.bz2
+  sha256: 92755ab4f8c11bd18c59efd108b72b366dc35b1d9675847b4839f0ec92ea917d
+  md5: 9df5b054b202bc995ace5e8779ac643f
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102499
+  timestamp: 1667464228738
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.1-py38h46256e1_0.tar.bz2
+  sha256: e91d2185325b0db7af231e0127c60b853ab195626a5c9a5677b63834e932b3cc
+  md5: cf5302c00a7fc65804713179493dd0a4
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 691403
+  timestamp: 1718740319993
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.5-py38h20db666_0.tar.bz2
+  sha256: 07cc0dbcdaad3dd2d5ac26119b94c282073c032f99751d0e9875a09d536680df
+  md5: dd9474b77b8284acd0224f0aaeb0da75
+  depends:
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 127540
+  timestamp: 1724854005635
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py38hecd8cb5_0.tar.bz2
+  sha256: c908c64f9e7bb7d8a82ff5514c12b108ee795fbb23bbfe005a793528f8b61e5d
+  md5: cc023730ced97b41337b7b8609b122ff
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 166202
+  timestamp: 1718227152314
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py38hecd8cb5_0.tar.bz2
+  sha256: 93c6a2fddc40b6c22315055cfad894b1363eaa687c787de038f18c4d4331bcf5
+  md5: e9248594338ba6cfa777dd3002b1ea63
+  depends:
+  - python >=3.8,<3.9.0a0
+  - typing_extensions 4.11.0 py38hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9883
+  timestamp: 1715268913768
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py38hecd8cb5_0.tar.bz2
+  sha256: 5208c1df58a2a734192f017121c7ceae4256a564e0aebf259edaf07a4e8e7639
+  md5: bd38f7b27a5b01d995baa65dcf6da4b0
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 61208
+  timestamp: 1715268896023
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py38h6c40b1e_0.tar.bz2
+  sha256: 6f1ca9025b998e7e0413ffd4642a62136e255916c80d8879aaa27b929d1e9ca5
+  md5: aa519109824b4ccbe60831ade4dadf9b
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 495756
+  timestamp: 1713213117152
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uriparser-0.9.7-h6c40b1e_0.tar.bz2
+  sha256: 035b916c1eab3a6a27f0109d8e39fe37cbf8ebe0af948d88d7a3b96ab20dc999
+  md5: e697defd6c59ca6d98ab4bb5f951eb21
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 44105
+  timestamp: 1692186954114
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.3-py38hecd8cb5_0.tar.bz2
+  sha256: 2d1b2caa90394200cb0d2c6ef761817406690724f0cf8908b550d4f9d8273a94
+  md5: f5a429836e40cb3537df29bb3ffd33af
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - requests >=2.26.0
+  - selenium >=4.4.3
+  - h2 >=4,<5
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 171729
+  timestamp: 1727769941485
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+  sha256: 0f8c3eb254be9c1957e748e385e20e62509d11052990c4755012be62434c9129
+  md5: 53229ba93f6e38308ae42ecfc6eaad9d
+  license: MIT
+  license_family: MIT
+  size: 96768
+  timestamp: 1706894705048
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py38_1.tar.bz2
+  sha256: dd878c7ccbe9acd4394ecb151ea22a700d7e17982d07e5cdab16e434ee0e276a
+  md5: 816a3f635267b70b6a1b00c00c282a15
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20010
+  timestamp: 1573201122722
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py38hecd8cb5_0.tar.bz2
+  sha256: e53ac6ec30c9355785d20e1c6acbdacd7c22a7961aac6bf6659d7515a44913a7
+  md5: 6f77ea179fa388f1de3b76b7bc4b2bc6
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 87316
+  timestamp: 1715878486929
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.44.0-py38hecd8cb5_0.tar.bz2
+  sha256: bc1589dbd5052d2b9af1c03c3eaaf945cc6fc8aa311af6cc89df03bcfeabe806
+  md5: d51e9bfbcc0b8d3b4b6212bb4f0f806e
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 105504
+  timestamp: 1726165062547
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2022.11.0-py38hecd8cb5_0.tar.bz2
+  sha256: 1b6d252572b3fe72c4716c24056cfe6b0f5d83a37a87b895b99d9e280a1fd0bc
+  md5: 51856b1a836e1d7ee6b166d6c5fbadbb
+  depends:
+  - numpy >=1.20
+  - packaging >=21.0
+  - pandas >=1.3
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1733083
+  timestamp: 1668776637394
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py38hecd8cb5_1.tar.bz2
+  sha256: 9ff046886013ca543edb417264a93032d5622c1933afee67f42a1fb55adc1499
+  md5: 7329105d84755727fa326092177e87ed
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49845
+  timestamp: 1675159128645
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+  sha256: ed0152ad6b87ffd9e01f4a62bc358e805ad59637f898a801b0a9cf903ae8e1fb
+  md5: 8a92f8c663608f24e14d8a2068b9d83a
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 415323
+  timestamp: 1714511993944
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+  sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
+  md5: c25b6d40f834647d0bbe767f6c776031
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 329449
+  timestamp: 1705602140856
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py38hecd8cb5_0.tar.bz2
+  sha256: 8b48165e2712438ff12e1602626d500bcf01bc24f50d465fb828e11d08248210
+  md5: f75ab2b6ef09cbedfb138841c634f46a
+  depends:
+  - heapdict
+  - python >=3.8,<3.9.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 77592
+  timestamp: 1695832909404
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.20.2-py38hecd8cb5_0.tar.bz2
+  sha256: 72df95ef4994a942f96a6f98fb03eae94486269ed1d96c7d18e59f69f880ced5
+  md5: 5e931d7e6382f8a4bb170020b2392eb2
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 26156
+  timestamp: 1729012706821
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+  sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
+  md5: f2519b551f99765d9d98950c5e2b4713
+  license: Zlib
+  license_family: Other
+  size: 119782
+  timestamp: 1714511811597
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstandard-0.19.0-py38h6c40b1e_0.tar.bz2
+  sha256: 30c8b8101c3daaecae4ddc5a030c747b5a3de6b9c6ce6b954e0d20bad5ab76dc
+  md5: e482612cda3fb1db6a0b27c47705ac6c
+  depends:
+  - cffi >=1.11
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 727778
+  timestamp: 1677014223914
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.4.9-h322a384_0.tar.bz2
+  sha256: ed01d890a98233cc45445b26de77400cbcf78e99093fca2659eba0e7306f093f
+  md5: 4195b3ecf8824e566141c000c05ef981
+  depends:
+  - libcxx >=10.0.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.11,<1.3.0a0
+  license: BSD 3-Clause
+  size: 844959
+  timestamp: 1617228583339
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/abseil-cpp-20210324.2-hc377ac9_0.tar.bz2
+  sha256: 2afa9a145b00fa79ec3ffa504fada1a56bd5dc17280b28eea76010cbb6f655eb
+  md5: 0ebdcd9f0a6e2149ebc59495f1505700
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 970554
+  timestamp: 1628722050846
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-anon-usage-0.4.4-py38hd6b623d_100.tar.bz2
+  sha256: 60b77f617e6d0608dba0eb425bb8a5121a9d704c33a340c489fb0bf464cbf6fc
+  md5: cdf0430d5a668976aa05b2967654b184
+  depends:
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - anaconda-ident <0.6.0
+  - conda >=23.7,<26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24984
+  timestamp: 1710965170065
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-client-1.12.3-py38hca03da5_0.tar.bz2
+  sha256: 24db2b2ee73453c7df739ef945e2163a17e8ae93207f049e41d1cdd34b111e4a
+  md5: 60ad3a91403ac9beace23a5d5bf56a69
+  depends:
+  - anaconda-anon-usage >=0.4.0
+  - conda-package-handling >=1.7.3
+  - defusedxml >=0.7.1
+  - nbformat >=4.4.0
+  - platformdirs >=3.10.0,<5.0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.6.1
+  - pytz >=2021.3
+  - pyyaml >=3.12
+  - requests >=2.20.0
+  - requests-toolbelt >=0.9.1
+  - setuptools >=58.0.4
+  - six >=1.15.0
+  - tqdm >=4.56.0
+  - urllib3 >=1.26.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141755
+  timestamp: 1708640752645
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anaconda-project-0.11.1-py38hca03da5_0.tar.bz2
+  sha256: 9e40218df829262a29dd0bee31e5999f2187e27f12630908a9516ee89882c04a
+  md5: 6614194c494344a478ee3de1a4f4bd2b
+  depends:
+  - anaconda-client
+  - conda-pack
+  - jinja2
+  - python >=3.8,<3.9.0a0
+  - requests
+  - ruamel_yaml
+  - tornado >=4.2
+  - tqdm
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 541925
+  timestamp: 1660339956833
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py38hca03da5_0.tar.bz2
+  sha256: 28f2865a85e01f0aff2f3f851e2e179f7b16398e515e2e0647810bd79375b9f7
+  md5: 2da1e9a6d51bd35df47f52a4df116ec4
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.8,<3.9.0a0
+  - sniffio >=1.1
+  - typing_extensions >=4.1
+  constrains:
+  - trio >=0.23
+  - uvloop >=0.17
+  license: MIT
+  license_family: MIT
+  size: 175017
+  timestamp: 1706220446315
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py38hca03da5_1001.tar.bz2
+  sha256: 67836d5b3187b8fbd69a50fe643ecc601645aec6947653e7fbdcf3e137eb5c98
+  md5: c6f73e643c6beef9c5a26ed2d621ddd2
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10182
+  timestamp: 1629146056221
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py38h1a28f6b_0.tar.bz2
+  sha256: 405979005a60e67d5226c4d3ec3e91119a8cda26ca800c9ba503c47f4fe13471
+  md5: cc74ce79b82fee9e8c5a6eafbd3183bb
+  depends:
+  - cffi >=1.0.1
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 35405
+  timestamp: 1644845782338
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-4.0.1-py38hd7469ad_3.tar.bz2
+  sha256: 0bdcddf1701967e559487deb66e35caa9c83fdef4eb088ade99c0b0b82d564be
+  md5: 04a1bbc057d96970f10807e6a698ad37
+  depends:
+  - abseil-cpp >=20210324.2,<20210324.3.0a0
+  - aws-sdk-cpp >=1.8.185,<1.8.186.0a0
+  - boost-cpp
+  - brotli
+  - bzip2 >=1.0.8,<2.0a0
+  - c-ares >=1.17.1,<2.0a0
+  - double-conversion
+  - gflags >=2.2.2,<2.3.0a0
+  - glog
+  - grpc-cpp
+  - libboost >=1.73.0,<1.73.1.0a0
+  - libcxx >=12.0.0
+  - libprotobuf >=3.17.2,<3.18.0a0
+  - libthrift >=0.13.0,<0.14.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - numpy >=1.11,<2.0a0
+  - openssl >=1.1.1j,<1.1.2a
+  - orc >=1.6.9,<1.6.10.0a0
+  - python >=3.8,<3.9.0a0
+  - re2
+  - snappy >=1.1.8,<2.0a0
+  - uriparser
+  - utf8proc <2.9.0
+  - zlib
+  - zstd >=1.4.9,<1.5.0a0
+  license: Apache 2.0
+  license_family: Apache
+  size: 6696038
+  timestamp: 1629785258120
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-24.2.0-py38hca03da5_0.tar.bz2
+  sha256: c9dcdb7cf6581feed802a7608f7867cc9ebae3ceda8df60b76284fd99fdf1471
+  md5: b3e4d004f34199ab25ecbf06b02b5e9a
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 142493
+  timestamp: 1729089470273
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.6.8-h80987f9_1.tar.bz2
+  sha256: 4d63ff9d0b424c5dc2e20bb8324a348869dee0340511effadfd1d622842a8322
+  md5: 3137a10d16bb223ae981d566d60d984b
+  license: Apache-2.0
+  license_family: Apache
+  size: 153917
+  timestamp: 1685977852438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.1.6-h313beb8_6.tar.bz2
+  sha256: f41918089bd42945e10d71aaf30eacede92db2b57193c2c931a710c314a39730
+  md5: b0a63224a995df6e07fdebba41a3c1a6
+  depends:
+  - aws-c-common >=0.6.8,<0.6.9.0a0
+  - aws-checksums >=0.1.11,<0.1.12.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 24245
+  timestamp: 1686021087869
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.11-h80987f9_2.tar.bz2
+  sha256: 5068b5773e8ce07dfc34718fb6c4be364a4c79d821138d68c3d246873bd562b9
+  md5: 1efb7da0ab9ee77370640b77f74f9c7c
+  depends:
+  - aws-c-common >=0.6.8,<0.6.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51725
+  timestamp: 1685998294585
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.8.185-h4a942e0_0.tar.bz2
+  sha256: 0f257afff29f6c681b9fd8620767ce2af7b07f9068c3f0e649289ca9151591bf
+  md5: 9358450895bb23ccbd49c553dbd66589
+  depends:
+  - aws-c-common >=0.6.8,<0.6.9.0a0
+  - aws-c-event-stream >=0.1.6,<0.1.7.0a0
+  - libcurl >=7.71.1,<9.0a0
+  - libcxx >=12.0.0
+  - openssl >=1.1.1j,<1.1.2a
+  license: Apache-2.0
+  license_family: Apache
+  size: 2171325
+  timestamp: 1628727158397
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py38hca03da5_0.tar.bz2
+  sha256: 67f1952cdd12d6e9f5e99484ddcbeaf41f3ce0b6119c74081a165060d7eb4919
+  md5: 777c1359eae877da3662717e4b7142ef
+  depends:
+  - python >=3.8,<3.9.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 216423
+  timestamp: 1718029890286
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-2.4.3-py38hca03da5_0.tar.bz2
+  sha256: d7ee7ab367d941b407ed37be32c0fb990f9a0484c8dd467cf2e1f802bd35d44e
+  md5: baf403ea360ec6e3f7722ce2e241ba10
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.8,<3.9.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14433721
+  timestamp: 1658136849401
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.73.0-h1a28f6b_11.tar.bz2
+  sha256: 48da0930dccb522c698dbb2ebfd939d1a88f2da2c66c2e9f544294db34e3e88b
+  md5: ef2630c4a64729b3102a867db7e0bed9
+  depends:
+  - libboost 1.73.0 h49e8a49_11
+  license: Boost-1.0
+  size: 16313
+  timestamp: 1628697190453
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py38hbda83bc_0.tar.bz2
+  sha256: 23bdef5475e66b317e63ae82ea693d9f4746e1e52d9e01602c29bd54b08ed0dc
+  md5: a3f9fba7288f70620a8837a2796309e3
+  depends:
+  - numpy >=1.21.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 113866
+  timestamp: 1707865034650
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+  sha256: 048264434c33fdb53862cdd69b2e2bc4ce6f8a70b3211ad6d686d066eac2aa91
+  md5: d55696ccaf6755931cd662dfb929aa0b
+  depends:
+  - brotli-bin 1.0.9 h80987f9_8
+  - libbrotlidec 1.0.9 h80987f9_8
+  - libbrotlienc 1.0.9 h80987f9_8
+  license: MIT
+  size: 19737
+  timestamp: 1714483270447
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+  sha256: 13627293296fcc231d8dc12d803dfc9621108c60df38b0e3c64e9e02ed55e564
+  md5: 86efd4ad08cd80d3eab77873db84a255
+  depends:
+  - libbrotlidec 1.0.9 h80987f9_8
+  - libbrotlienc 1.0.9 h80987f9_8
+  license: MIT
+  size: 19083
+  timestamp: 1714483255364
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py38h313beb8_8.tar.bz2
+  sha256: 24efac2f9b2d8916d63c7e2a2f9247c6409933596957e484b1c1ff9688f4081d
+  md5: 178d4327a0f98919062d86bb1dc44ad9
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  size: 379250
+  timestamp: 1714483360289
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+  sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
+  md5: 56d1386c7f1f338f0d18f82af6525273
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 158748
+  timestamp: 1714510571033
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+  sha256: b0be79290b1df1cf1d07a1a9c3f3a92ae262643a6df3dc10dfbac22a82874dd4
+  md5: 8fdcf1c08eee91fec7eefc22863c816a
+  license: MIT
+  license_family: MIT
+  size: 106550
+  timestamp: 1693902036526
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.9.24-hca03da5_0.tar.bz2
+  sha256: b3b13d44d3e05c88f411d245c052b547652be3f3ce7ba21970ba1bbf20a8ea33
+  md5: d8091745a1bfd921bf15b2f73111d299
+  license: MPL-2.0
+  license_family: Other
+  size: 141261
+  timestamp: 1727794860441
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.8.30-py38hca03da5_0.tar.bz2
+  sha256: 8c852260def7ce0e5cbdf2f5ca2aef20153b650f04d3a0d4b9bcba0417935d28
+  md5: 049897bccbeee81f51d4f45a578191db
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 169227
+  timestamp: 1725551901662
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py38h3eb5a62_0.tar.bz2
+  sha256: faba6265a92bc533a0aae6fd8756f005c3d529e23af6ac89b0268b33392ebd7d
+  md5: b6bd692e4b80d220f2171be64c6617e9
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 231418
+  timestamp: 1726856551295
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py38hca03da5_0.tar.bz2
+  sha256: aeb9fd657eacfb76ae352a33991bedc46d8f1080c0fee116c517ab6cea5ea8ab
+  md5: 1ac72858d61f8028a48f2f855b0e9f43
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 152725
+  timestamp: 1698129882125
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.0.0-py38hca03da5_0.tar.bz2
+  sha256: 0fb1d1a980a8428f9de5d3bdf92c2a323e20916abd3f22533bad6213b2d230de
+  md5: b58f391e710cafeb009c2fefb2f4f60b
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35709
+  timestamp: 1721657490117
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py38hca03da5_0.tar.bz2
+  sha256: 379b85e4352895ddf2591837ea32d6ad23a6b8b6300578d975a403fd24cc97c4
+  md5: 1219dda9082a89e5faf90bed3f7d8e58
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 546256
+  timestamp: 1709758505234
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py38hca03da5_0.tar.bz2
+  sha256: b0e7c3a535edb3c56155853702fd9b8d07cab871bc523a1311643ba9b844ae8a
+  md5: 116f6e9f04b53d76ae4770bc5630c5cd
+  depends:
+  - python >=3.8,<3.9.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15628
+  timestamp: 1709322880704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-pack-0.7.1-py38hca03da5_0.tar.bz2
+  sha256: f55ff4685cb721fedb6727dede01aa219677386b17ce07ccc5e81b6df4e274b9
+  md5: 318d3731b4b28a57be258a40d3b7e154
+  depends:
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 52484
+  timestamp: 1710258102226
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-handling-2.3.0-py38hca03da5_0.tar.bz2
+  sha256: ef64ef06a8c987006212b60095e9936eaccf7f1289e459b34f452d6071664576
+  md5: 43e51f437dd5406aefe666e371d94f94
+  depends:
+  - conda-package-streaming >=0.9.0
+  - python >=3.8,<3.9.0a0
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279557
+  timestamp: 1718138371764
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/conda-package-streaming-0.10.0-py38hca03da5_0.tar.bz2
+  sha256: 38b426455f094aab74b29ace5f5608a99e0b2faee765e18e8c63afdfe70b482b
+  md5: 2d6e31b5e8b8a5526290b117a857f2e9
+  depends:
+  - python >=3.8,<3.9.0a0
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28408
+  timestamp: 1718136108403
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py38h525c30c_0.tar.bz2
+  sha256: e556127f6eaabe27e373eeb452fcc21094ca7e1543f5010560c3ddf374ae4ca5
+  md5: b9ecfe24d5af60f9262569185f942672
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 219507
+  timestamp: 1663827520740
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.2-py38h80987f9_0.tar.bz2
+  sha256: c54d48568bf8bf0be1dd68a939c77c84ed0f613aaadca3fdbc54b493f3288f47
+  md5: 6b8cd5e594d17d7dd57ecb68c2bd60e9
+  depends:
+  - python >=3.8,<3.9.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 376182
+  timestamp: 1701723652583
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py38hca03da5_1.tar.bz2
+  sha256: abb41ec3bdd1a8b491056d8409044e7db430140cde7935bcb41826d746cb7194
+  md5: 691ae819ca6bafeb6626cd7941f79c6b
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7
+  - python >=3.8,<3.9.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 103380
+  timestamp: 1629793027649
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py38h313beb8_0.tar.bz2
+  sha256: ad48c11fd3b44e89832e5851ba77d27951f258c039a53e15e9fe2bdc35b408c9
+  md5: 3e3601bc2eb8e58c4cadb36ac4ea7689
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 2069572
+  timestamp: 1690905388086
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/double-conversion-3.1.5-hc377ac9_1.tar.bz2
+  sha256: 97cc38b53813d6130d471697c8d81a4ad25b27725ceaa319a48872c9799c209c
+  md5: 2321b87d960f0b87e11b090c100a6ea3
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84871
+  timestamp: 1628726723927
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py38hca03da5_0.tar.bz2
+  sha256: f66664b97ad6248c187d4d316c7ee511b8f01a7931026c679bda943d4d6eb28f
+  md5: 0428cdc3df242a4a3bdfa628838ddd0a
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT License
+  license_family: MIT
+  size: 15098
+  timestamp: 1650293803801
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.2.0-py38hca03da5_0.tar.bz2
+  sha256: 310641ebbfa63719ff3b35cdd983b9c3351031cc5eab0b2b7b6d49df7304c9ed
+  md5: eb78cc3f6accfccaa539169f05792c86
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 30667
+  timestamp: 1706031410529
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-0.5.0-py38heec5a64_2.tar.bz2
+  sha256: 031bde74cce3eedcf66c0f24920618c9fda6761f92196c7045966b8e71ebaf9d
+  md5: 1039effc5936c6c18aea90a5dfa598b9
+  depends:
+  - numba >=0.49
+  - numpy >=1.19.5,<2.0a0
+  - packaging
+  - pandas >=1.1.0
+  - python >=3.8,<3.9.0a0
+  - thrift >=0.11
+  constrains:
+  - numpy >=1.18,<1.22
+  license: Apache-2.0
+  license_family: Apache
+  size: 178976
+  timestamp: 1658500800834
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py38h80987f9_0.tar.bz2
+  sha256: 48c3079c65295ae0bc0580e28dbe4678fe93718cd27ab9021ccddf5ca21ae15e
+  md5: f89a39cc1e2676e301825572410d4185
+  depends:
+  - brotli >=1.0.1
+  - python >=3.8,<3.9.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 2651106
+  timestamp: 1713551559037
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.6.1-py38hca03da5_0.tar.bz2
+  sha256: 28e233da85b3bdb00596dddf5101a9fb7d11c269c49fef411ad22a4b36982fcb
+  md5: 96e90706674f64f007a04cc76b6564ef
+  depends:
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - pyarrow >=1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 283942
+  timestamp: 1724855647496
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+  sha256: 25e05b93a99914a5fd1a298a2c5b25479fbd571b0db9caa7c6ad4336f060f62c
+  md5: e213b68bb0274e0e54c610a041e059f5
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 150168
+  timestamp: 1706888198288
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+  sha256: bbbcf47ef9249635b5199be1414b0b59687cc04ea9630d50ecc609dc200c095e
+  md5: 5820c373d6847a68551cadb8984a8277
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 95638
+  timestamp: 1706895270850
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpc-cpp-1.39.0-h95c9599_4.tar.bz2
+  sha256: 75bb44c5d98d877628ced328bfdca3492e431ce72a062455ab6ac78395a69bff
+  md5: 3a1501eedd9a32d8ecb4dcd6f73448c2
+  depends:
+  - libcxx >=12.0.0
+  - libprotobuf >=3.17.2,<3.17.3.0a0
+  - libprotobuf >=3.17.2,<3.18.0a0
+  - zlib
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4070563
+  timestamp: 1628724381812
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-68.1-hc377ac9_0.tar.bz2
+  sha256: ec6fe8fb2533f8fae73866531ad8c93b20a2b060737d237445f115455c3ab96b
+  md5: cec95fa3d8b36559af63caf4fb1f6caf
+  depends:
+  - libcxx >=12.0.0
+  license: MIT
+  size: 13742625
+  timestamp: 1630597537784
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py38hca03da5_0.tar.bz2
+  sha256: a508f907748131396bb44a1cca85fd0b8eee2237c29a8e23d967fe68727fd127
+  md5: 732faa6938941374d108ed353740eeb2
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123964
+  timestamp: 1714398948249
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py38hca03da5_0.tar.bz2
+  sha256: ff08831e4a62c9528fbcb331c9be605d2c4e2ec2d71128793dbd87a480fd054a
+  md5: 1e57a6dc02bd6f2ee3cdd70a7794f54e
+  depends:
+  - python >=3.8,<3.9.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 42298
+  timestamp: 1704813583946
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.4.0-py38hca03da5_0.tar.bz2
+  sha256: 622698b1727d55935754c257e6c3005b8c0633cb0225c4b2e994b8d7a0254cf1
+  md5: 0f380b26154b0b14678d5dd9a8b66df4
+  depends:
+  - python >=3.8,<3.9.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 58424
+  timestamp: 1720641160944
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/intake-0.6.8-py38hca03da5_0.tar.bz2
+  sha256: 60d9381a538cb3dfc2250a0a4281cdbe77430f4a48f1b16110e7b9808222b2f8
+  md5: 8f55d7cbfb979f707c530a1f71c65d4b
+  depends:
+  - appdirs
+  - dask >=1.0
+  - entrypoints
+  - fsspec >=2021.7.0
+  - jinja2
+  - msgpack-python
+  - python >=3.8,<3.9.0a0
+  - python-snappy
+  - pyyaml
+  - requests
+  - tornado
+  constrains:
+  - panel >=0.7.0
+  - hvplot
+  - bokeh
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 191897
+  timestamp: 1678787700406
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py38hca03da5_0.tar.bz2
+  sha256: 72acf602933ba769334f923f645f498eb1d052696cc961af4fdfcbfdff27c1ef
+  md5: 773dbcc0f6bb909323f696c3c5076e6a
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 191331
+  timestamp: 1728666033067
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.12.2-py38hca03da5_0.tar.bz2
+  sha256: f7417bde08616c279e8a9d3f739d5149e05202c4d79f50cf5d7706fed80d5e94
+  md5: a67b25df2a3f4e14754775388e8c7077
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.8,<3.9.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1242385
+  timestamp: 1691532423653
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.1-py38hca03da5_0.tar.bz2
+  sha256: fda297381d9c2da66efa9c845e4c764deaf46a16012d8a680fe4a8c510e931ee
+  md5: ade737eb483390ebc89c5102190ad99f
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 1052301
+  timestamp: 1721058391830
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py38hca03da5_0.tar.bz2
+  sha256: 8b0f213e785795bb63b0b4c20321b8aa4b096bbadcb624416fff81a62283c1b2
+  md5: aa4c5ef07d7c3249f20f0f8575aa4606
+  depends:
+  - markupsafe >=2.0
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 273949
+  timestamp: 1716993525900
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+  sha256: 9d5cbffa98f3a4391f66b0c5ce1f411f0bfb0eb83137dc7146fb7bae23cb3570
+  md5: 95c92318023482e4e8c698ae6c4597fe
+  license: IJG
+  license_family: Other
+  size: 274078
+  timestamp: 1722872672311
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.23.0-py38hca03da5_0.tar.bz2
+  sha256: 110ef5328904d5a40a40d21474d57464fedf6f92f05990814a5b2dab8af4609d
+  md5: 3e01db51574132ba92d00e4d258c3171
+  depends:
+  - attrs >=22.2.0
+  - importlib_resources >=1.4.0
+  - jsonschema-specifications >=2023.03.6
+  - pkgutil-resolve-name >=1.3.10
+  - python >=3.8,<3.9.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 144295
+  timestamp: 1728486740994
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py38hca03da5_0.tar.bz2
+  sha256: f784a7bc4378ab9fd4f6fd029c98d9c385958c8fe0e28659fcda5443230d3644
+  md5: b72ba5229db3f2c52a78b6e2a6859104
+  depends:
+  - importlib_resources >=1.4.0
+  - python >=3.8,<3.9.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 15903
+  timestamp: 1699032491522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py38hca03da5_0.tar.bz2
+  sha256: a4b6892b15665ccf82b3d8e881f4a8ed54febb4a490ce5921277438ad154986f
+  md5: fdcc463db49334d736ab371cce0a84cf
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 197158
+  timestamp: 1676329125183
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py38hca03da5_0.tar.bz2
+  sha256: 8034378465e39aea20a186e64a37ccd4bc3128a126d819fa804f47b8aeff5b6b
+  md5: eda46d70e61985ee006130b1b001eae2
+  depends:
+  - platformdirs >=2.5
+  - python >=3.8,<3.9.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 83336
+  timestamp: 1718818320320
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py38hca03da5_0.tar.bz2
+  sha256: 4bc9447dce7341b8dc02e6c1656aa09aaf33e35116e597c23acd53e1df8c3731
+  md5: b7a9a713f82ce712aa2671d8d9564dd2
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.8,<3.9.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36651
+  timestamp: 1718738130884
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py38hca03da5_0.tar.bz2
+  sha256: e70f6282b06199b3c4a216f95ff7cb990822066c479c9cc9f3b236b9e441fff2
+  md5: a4191f11720393a3763a4bfe99136627
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 499781
+  timestamp: 1718827351354
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py38hca03da5_1.tar.bz2
+  sha256: 686fb84761ec3c869d5cd9439501c4379aaf4b387bbe6745d9d3ae109c230b33
+  md5: 6e8e629672befe7ca2a80cb6b487f210
+  depends:
+  - python >=3.8,<3.9.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24611
+  timestamp: 1686870751342
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py38hca03da5_0.tar.bz2
+  sha256: 0b2042dc589c647a7fc0cab57390d307f4a87567caeb1bd52279182403fc3443
+  md5: 2ebc0db3cfbfe3e7a6ae4d020c143474
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19911
+  timestamp: 1700168711162
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py38h313beb8_0.tar.bz2
+  sha256: 101c40cdf1df9e9dba602d371f2dff580f19836f3b1f7043468dbde93151efa4
+  md5: 39dc576e64c3e1acb98a975530b87ac2
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64180
+  timestamp: 1672387223612
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
+  sha256: e547a4a540ccc9db683d6d2e3e36b0d0ad99e1ad10b22b5f403af3e893b412ba
+  md5: dc5ae0ece3c4990ba5fee7b266f2a019
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - openssl >=1.1.1u,<1.1.2a
+  license: MIT
+  license_family: MIT
+  size: 1306804
+  timestamp: 1686931342120
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.73.0-h49e8a49_11.tar.bz2
+  sha256: 486b171085a4676e2a5a73f6af9e08540f9156e0aa3de832552077fe15d63d7c
+  md5: 99050efb6b22dc526cb246d41b3472f8
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=68.1,<69.0a0
+  - libcxx >=12.0.0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  - zstd >=1.4.9,<1.5.0a0
+  license: Boost-1.0
+  size: 20047550
+  timestamp: 1628697166702
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+  sha256: 199042b87451abaf14546af124ae3380194cddda928e0d30ccb341e93084854c
+  md5: eaa0442887994a82486c65d87f6b71e6
+  license: MIT
+  size: 68806
+  timestamp: 1714483212137
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+  sha256: bd9a8a17fb14086446b710fa029d238e69274b83ee2e7e09093496f190de82b5
+  md5: 66615d6a0cb5dcca3e20c019cde0ed2d
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_8
+  license: MIT
+  size: 32975
+  timestamp: 1714483225840
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+  sha256: e1bf77e8b975c30a69b08a08410622e27c8cff6f592ccfa590466b83d9e6d104
+  md5: 8af86bdac01fe303d693d9b76c071059
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_8
+  license: MIT
+  size: 310266
+  timestamp: 1714483239194
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
+  sha256: a94cc52c1ca2e421342d2fefc6d7774ff5118b9d01f4e22d33314f8520d33723
+  md5: 440575339cec83722e83087db31127bf
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.52.0
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 342121
+  timestamp: 1693515586487
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+  sha256: 9597df5344a718d37837966aa05091faf210260898fad5e7a64b87f17de9e90d
+  md5: 678a1f87940ef6cc421a092301b8c3fe
+  depends:
+  - ncurses >=6.4,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 167208
+  timestamp: 1703006281321
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+  sha256: 6fc572025852b210ecddcca3ab9ff3f1d5f6bd91f1933c6e296de6bb331f6b5d
+  md5: 6dd7d9c5737bbd2a27d18f15318dc3e6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 102059
+  timestamp: 1628961869728
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-hf27765b_0.tar.bz2
+  sha256: 60321df3cac6e0b97561448810d8575945e48fb0d13f1480f83733d56801223e
+  md5: c9637ab2110623a8e6f5a0c0e0576029
+  depends:
+  - openssl >=1.1.1m,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 441685
+  timestamp: 1642102532464
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+  sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
+  md5: f31e4eb9cd6447cc2f5ef0243a76540c
+  license: MIT
+  license_family: MIT
+  size: 120460
+  timestamp: 1714483461787
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+  sha256: 72d242814b990900c9410d4738cc685f70ea71231742293cffbb475d8df100f8
+  md5: f9976688992b7ac4b56f5600ee15b5c4
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1407202
+  timestamp: 1714483550601
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm11-11.1.0-h12f7ac0_6.tar.bz2
+  sha256: 6450802cad40b813a99572891811830758393500f4c79a223e1046918872c3f7
+  md5: 616a6976906afa0035a2dc2ea1c34195
+  depends:
+  - libcxx >=4.0.0
+  - zlib
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 21766415
+  timestamp: 1665076236980
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
+  sha256: 039483aadb821adffcc2aff761ec35474d633b6bc2f1eb7cce877a881d7ed290
+  md5: d75b21db95481154cfa9d7a871f0f3bf
+  depends:
+  - c-ares >=1.19.0,<2.0a0
+  - c-ares >=1.7.5
+  - libcxx >=14.0.6
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - openssl >=1.1.1u,<1.1.2a
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 743061
+  timestamp: 1686931613436
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-3.17.2-h98b2900_1.tar.bz2
+  sha256: 9cd490d1cd43354342449c06ca8f095a072ca176411069a43fa8ec79aa17b53f
+  md5: b4c568c2d63dec6cdcf5d357c7092676
+  depends:
+  - libcxx >=12.0.0
+  - zlib >=1.2.11,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2226344
+  timestamp: 1628722420059
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
+  sha256: 48a8617773b57a4b9a8539782bf88a317f49a644d3f858aa0ad3ab13afc03ae7
+  md5: c3bc0fb3cc9a98ef1f2f83ef497fc5da
+  depends:
+  - openssl >=1.1.1u,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 334616
+  timestamp: 1686931322663
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.13.0-hd358383_6.tar.bz2
+  sha256: 7cb7e1185aec58681f95642da63e80ac72aed29e18cacba0a309a06942d5875e
+  md5: 3c2b2e2f5b18a6d583a938cd68491874
+  depends:
+  - libcxx >=12.0.0
+  - libevent >=2.1.8,<2.2.0a0
+  license: Apache-2.0
+  size: 339509
+  timestamp: 1628698596572
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.2.0-h11e2f9f_0.tar.bz2
+  sha256: 6f511d10c2685d42a517eb5b16b497e87196d96e695b71cb6a0258f7d168846a
+  md5: 608d57c863b14a1db913c8b4540f451a
+  depends:
+  - jpeg >=9d,<10a
+  - libcxx >=12.0.0
+  - libwebp-base
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  - zstd >=1.4.9,<1.5.0a0
+  license: HPND
+  size: 629973
+  timestamp: 1630681745273
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
+  sha256: 479cf759232c2361af87493ecd124e7d3a8940030e42e1931234c35bea73c3bd
+  md5: cd8fe2c981594a457c6af3a0d5de0bd5
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 341817
+  timestamp: 1729160040909
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.38.0-py38h98b2900_0.tar.bz2
+  sha256: 0c7c08a0530765a16b54970a98b21cdfa86b3f180710847d6a285e592252e090
+  md5: c16800ff23a2b9a46ff4ef21a4995265
+  depends:
+  - libcxx >=12.0.0
+  - libllvm11 >=11.1.0,<11.2.0a0
+  - python >=3.8,<3.9.0a0
+  - zlib
+  license: BSD-2-Clause
+  size: 249023
+  timestamp: 1647870534530
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py38hca03da5_0.tar.bz2
+  sha256: 307477ab96bae938902afb6c1689017986654464719644c6d17f85e032e44abc
+  md5: 37a8e89bd4b324c309facc82bdc64941
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11872
+  timestamp: 1652903134672
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+  sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
+  md5: f5f7e6e7541d8dc3d3df270d488d2e24
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176990
+  timestamp: 1714510588159
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py38hca03da5_0.tar.bz2
+  sha256: 2c34852ea6fe459fc4e892f2b3c43cb22093c66bb0dd4c7a577affef3c1ad350
+  md5: 9fd19f5fc3dc04e95a205552307c4316
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123564
+  timestamp: 1671541934866
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py38h80987f9_0.tar.bz2
+  sha256: 4634fd37c3d8f59513a161a77f0b321c70e1c2071a072e3df07078763b87d756
+  md5: 3625d24a3da36877ad3b544ba36f59f3
+  depends:
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24237
+  timestamp: 1704206125570
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.7.2-py38h46d7db6_0.tar.bz2
+  sha256: eba3eda0b2737e4f41e1cabf9ffcdd3acd17ef999434bf1d1b2427a1c6aa13fb
+  md5: a1c7b52fb0f692f252786792cc2d1a21
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=5.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.20
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7945401
+  timestamp: 1693812744579
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py38hca03da5_0.tar.bz2
+  sha256: 8ed7b59ced736b2c2dca4bf793fd22071920847c7c009ae08215618e0cf9634e
+  md5: 0b7e6805f36a34f1fc27b8230830f22d
+  depends:
+  - python >=3.8,<3.9.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17305
+  timestamp: 1662014548083
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py38hca03da5_0.tar.bz2
+  sha256: b4275ded138c6ce902d42866827734fbd5fe65efb43f15e28481e1f26f893ba5
+  md5: d8af1a41be60a01c137b64f607e5a81d
+  depends:
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 90753
+  timestamp: 1661496288720
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py38h525c30c_0.tar.bz2
+  sha256: ea6e79e88ff83790d1ce7dd4f77cd46a8904cfba65f8e1bd6ffee33bcc855373
+  md5: 800b92ae3bbeae2f1e5374cfb2d05895
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 83473
+  timestamp: 1652362704023
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py38hca03da5_0.tar.bz2
+  sha256: 32ca9f80183284c18f43c656f85ce1ee6b367db95373afacaa9d8ee4d4f47781
+  md5: 3bcae7fb685499f69ac281f0f2370679
+  depends:
+  - python >=3.8,<3.9.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 23009
+  timestamp: 1629282754789
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py38hca03da5_0.tar.bz2
+  sha256: 4e11e578aabb2026e95fd7d36f03807236c60a2d4560c74b3ea10cdb03e5b6ea
+  md5: 87c6582d4115677d2c27f3868256731b
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8254608
+  timestamp: 1717623018829
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py38hca03da5_0.tar.bz2
+  sha256: adf787ddce8532e7a46e3feab3f6564a202832aef03a0c1094afb3dddb050b12
+  md5: 556fe6d9e904476dbaff8c8f04417125
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.8,<3.9.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100614
+  timestamp: 1698934298210
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.4-py38hca03da5_0.tar.bz2
+  sha256: 701d58560c331403e20c42d9601850b30f9e78500681ae5f5698a46de6bc584e
+  md5: 55094ecec7635c91ad5f04b03078db8f
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - importlib-metadata >=3.6
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.8,<3.9.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - pyqtwebengine >=5.15
+  - tornado >=6.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 487310
+  timestamp: 1728049463745
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py38hca03da5_0.tar.bz2
+  sha256: a83c85cc61e1332883676cfa4898ae9d7f73efba9255ef25378196e8afef006a
+  md5: a095073d4cccaa0b71b2793373d93a48
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.8,<3.9.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148914
+  timestamp: 1728049459080
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py38hca03da5_0.tar.bz2
+  sha256: 4a6267fbf767cc385c0732b993dfec44880fc68d08b4d3fddb80bebbd3ef704d
+  md5: 9507b7eb054874fefa67e35d37076378
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14353
+  timestamp: 1708532749964
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py38hca03da5_0.tar.bz2
+  sha256: 10d1928d0a260ae041391c76e5a514de992fab696e3a69638b0250e01d8ca6a3
+  md5: 838bbdf9615c7095293a6e37a1e45d55
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 590395
+  timestamp: 1717630909286
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py38hca03da5_0.tar.bz2
+  sha256: 76ae630b0ba82cd152d6a2c8b192c2d7c92cd1edef5a8d00e48d6451294443d5
+  md5: 8acf1b7ef6217c23492a1f96c960d2c0
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23456
+  timestamp: 1699456018740
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.55.1-py38h9197a36_0.tar.bz2
+  sha256: 0a96640ac2b62e64f14be7669adffd2a3ea23ec5acecacbdd185f8b57311ef7c
+  md5: caffb2954404712119d0fb4e4c4298b4
+  depends:
+  - libcxx >=12.0.0
+  - llvm-openmp >=12.0.0
+  - llvmlite >=0.38.0,<0.39.0a0
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  - tbb >=2021.5.0
+  constrains:
+  - numpy >=1.18,<1.22
+  - scipy >=1.0
+  - tbb  >=2021.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3949466
+  timestamp: 1648041424485
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.4-py38h79ee842_1.tar.bz2
+  sha256: 09acb2d02a5cf5fb8b10252aba95cbc1efc2a95c43f4b81710dc23542ef3c4d3
+  md5: 23a179a3a80b2ec7c4e2ec6b9055210a
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 122400
+  timestamp: 1683221874476
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.21.6-py38hb93e574_1.tar.bz2
+  sha256: cc3f4442cfc670eac18e5e9ae8748c52c67442a9a9aaa06e515fbbcec738d3cd
+  md5: a22ecfcfb22c78874d5a926648c39140
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.20,<1.0a0
+  - numpy-base 1.21.6 py38haf87e8b_1
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11572
+  timestamp: 1715092856174
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.21.6-py38haf87e8b_1.tar.bz2
+  sha256: e4cd2b6ac40ad3ea9ef8041874987403040de0b4e872acf8c4f241f1cd54d7e0
+  md5: d5adaf69f53bfd3d244a479122766441
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.20,<1.0a0
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - numpy 1.21.6 py38hb93e574_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5634222
+  timestamp: 1715092844625
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.4.0-h0ed58ac_2.tar.bz2
+  sha256: 4525a4cd7dfca8166bbb79901dda003d702709a2d18c91aa0f99971a38c2d26b
+  md5: f6b519d5bcdee6a12e3c502a8d32d1e3
+  depends:
+  - libcxx >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 398391
+  timestamp: 1720655561402
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
+  sha256: 409ba99dd953129c0ccebb5dcbf2049920e5a755b88e7e392e4f91be924e26ef
+  md5: f05f00606c10617a61c41f23652b9a00
+  depends:
+  - ca-certificates
+  license: OpenSSL
+  license_family: Apache
+  size: 3450897
+  timestamp: 1694465216241
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-1.6.9-hb65cfe6_2.tar.bz2
+  sha256: 727b0fd0fe3931e0533163117371bb15a330f426527b4d3fcf5a8161b161d662
+  md5: 0723387d2a25e32a4dfc5c26f71470eb
+  depends:
+  - libcxx >=12.0.0
+  - libprotobuf >=3.17.2,<3.18.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.8,<2.0a0
+  - zstd >=1.4.9,<1.5.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 395216
+  timestamp: 1628726496508
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py38hca03da5_0.tar.bz2
+  sha256: e657a6896930e27bd599c8f910cf3ee2a48e7268df40852df6aebbe8f7372f98
+  md5: 1bd77f6090aafa15b1298b62fdb0f4e3
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 31785
+  timestamp: 1699371166226
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.1-py38hca03da5_0.tar.bz2
+  sha256: 7c1c21869595db9155b6533f65621216e69fb356262462e3ab68007cb164cef0
+  md5: 35c62f901fa3146e0788ba3f6771930a
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 135755
+  timestamp: 1720101953462
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-1.5.3-py38h78102c4_0.tar.bz2
+  sha256: 7978b817632759b250df429e7126dd060a25f737c8f1b1e0b3e738e2e837f83a
+  md5: d0a4733ea677c7fc44e0f734c4d71173
+  depends:
+  - bottleneck >=1.3.2
+  - libcxx >=14.0.6
+  - numexpr >=2.7.3
+  - numpy >=1.21,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  constrains:
+  - pyxlsb >=1.0.8
+  - pandas-gbq >=0.15.0
+  - fsspec >=2021.7.0
+  - xlsxwriter >=1.4.3
+  - lxml >=4.6.3
+  - xarray >=0.19.0
+  - tzdata >=2022a
+  - xlwt >=1.3.0
+  - beautifulsoup4 >=4.9.3
+  - fastparquet >=0.4.0
+  - jinja2 >=3.0.0
+  - brotli >=0.7.0
+  - pyarrow >=1.0.1
+  - matplotlib-base >=3.3.2
+  - pyreadstat >=1.1.2
+  - gcsfs >=2021.7.0
+  - pytables >=3.6.1
+  - sqlalchemy >=1.4.16
+  - html5lib >=1.1
+  - tabulate >=0.8.9
+  - python-snappy >=0.6.0
+  - scipy >=1.7.1
+  - blosc >=1.21.0
+  - numba >=0.53.1
+  - openpyxl >=3.0.7
+  - xlrd >=2.0.1
+  - zstandard >=0.15.2
+  - s3fs >=2021.08.0
+  - pymysql >=1.0.2
+  - psycopg2 >=2.8.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12897659
+  timestamp: 1677852540117
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py38hca03da5_0.tar.bz2
+  sha256: 682c8a19b724a018aed66ec0230abafa6b965c7d559bdf6e4f0cdd66d742fa0b
+  md5: 4f04ec230eca5cca5c8f3b7905d4babb
+  depends:
+  - locket
+  - python >=3.8,<3.9.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36423
+  timestamp: 1698702661554
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.4.0-py38h80987f9_0.tar.bz2
+  sha256: f7e6fd55efa1cc7b9382f120259f0908a2eb08821198f8a60749959dd653a34d
+  md5: 484fadaaf73b93083cafb78b82e3845e
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.8,<3.9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 774844
+  timestamp: 1721059629077
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.2-py38hca03da5_0.tar.bz2
+  sha256: 542299bd98725d1ff099492364f1815b393eb7a93969203331f7b38cfd76bf07
+  md5: d7fc6193b0382d675516c8a2ac117a0b
+  depends:
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2268520
+  timestamp: 1723484744931
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pkgutil-resolve-name-1.3.10-py38hca03da5_1.tar.bz2
+  sha256: fedc4ab0ed057e5cc494b93199a04238bee875262b884b8fdf3e7e6b5fcfbd1f
+  md5: 446f233dffdb852c88e7c25240aecad2
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT AND PSF-2.0
+  license_family: PSF
+  size: 11424
+  timestamp: 1704297549606
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py38hca03da5_0.tar.bz2
+  sha256: d97cb927d800e9a447c2b9e0983b0518d7f41b6c5947e62075f4bb5fe9fa3569
+  md5: 5d344c031b607858aac0263ee037f1a0
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 33041
+  timestamp: 1692205775190
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pooch-1.7.0-py38hca03da5_0.tar.bz2
+  sha256: 7447015165bf9b11fb4b6c839e95f2978ac012301d843aa79a5eb3a180d72cae
+  md5: 5e0595b52a068b93fbc91a22480535fc
+  depends:
+  - packaging >=20.0
+  - platformdirs >=2.5.0
+  - python >=3.8,<3.9.0a0
+  - requests >=2.19.0
+  constrains:
+  - tqdm >=4.41.0,<5.0.0
+  - xxhash >=1.4.3
+  - paramiko >=2.7.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 82434
+  timestamp: 1695850137461
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py38hca03da5_0.tar.bz2
+  sha256: 41dadbf05754b86a3323059a67742e4d4fee178661d92705ef496ea14cd91d66
+  md5: e55ee42cc29c11809f568d8d1cf4747c
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91074
+  timestamp: 1659455126069
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py38hca03da5_0.tar.bz2
+  sha256: 82e9c96b00a5df66f065910354275a72252b134e88471f61313a583d0f2a7a6d
+  md5: db5c82c2e4e896a9dee28c63f479a3b5
+  depends:
+  - python >=3.8,<3.9.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 577739
+  timestamp: 1704404418283
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py38h1a28f6b_0.tar.bz2
+  sha256: 3c5bd50929a4aa13c72095653118fd7cc44053bbe80949fd9f78d6bc78128487
+  md5: cc9daac414bf6d0fc28087deceeeb54d
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 366992
+  timestamp: 1656431324712
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-4.0.1-py38hd776c02_3.tar.bz2
+  sha256: 435dcfe0ba89e22ebecdac0cbd1ca510af4995f185281f00c90bac912f384afe
+  md5: 1999261b72f05788afc91efb8478c6fa
+  depends:
+  - arrow-cpp >=4.0.1,<4.0.2.0a0
+  - arrow-cpp >=4.0.1,<5.0a0
+  - boost-cpp
+  - gflags
+  - glog
+  - libcxx >=12.0.0
+  - numpy >=1.16.6,<2.0a0
+  - pandas
+  - python >=3.8,<3.9.0a0
+  - six
+  - snappy
+  license: Apache-2.0
+  license_family: Apache
+  size: 2289517
+  timestamp: 1629806264952
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py38hca03da5_0.tar.bz2
+  sha256: 8d542e0301f4692b0810d9c6143400ac24ffe65c1c5276fb9167c9dd6dcfd894
+  md5: a1b3ddffe3d0dfde327191c5a1d2d26f
+  depends:
+  - param >=1.7.0
+  - python >=3.8,<3.9.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30761
+  timestamp: 1675441503308
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py38hca03da5_1.tar.bz2
+  sha256: aa6b41d2921130aed4630653e555fd90f4531970297e8b3a434f9d6dc2357294
+  md5: b0ba357ab09318153b94d105a7863e3b
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1887242
+  timestamp: 1684279996873
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py38hca03da5_0.tar.bz2
+  sha256: 3e4fed535277fc9d94c53d717ca10e7faf1d051f4d2fcefb1a02cd0e84585bc6
+  md5: 156fde9f3f56a6b1b9cb7b8020748288
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 157834
+  timestamp: 1661452633325
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py38hca03da5_0.tar.bz2
+  sha256: 47d308dd037d9373cf00b341a34ad2cb2d2f2dbb06d3ac5e59ef05d3ec81b3bb
+  md5: 6f20c9bfe7585ae23ec10ea950553603
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 27337
+  timestamp: 1626781365102
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.8.18-hc0d8a6c_0.tar.bz2
+  sha256: b8fe0d51772aebcd4664f4faba55a3ca42b0ae7b4a3261b955c0e260dee0f6d1
+  md5: 40ca48fa679cca7093e7bf37bae3ea07
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 15400446
+  timestamp: 1694438953629
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py38hca03da5_2.tar.bz2
+  sha256: 41f88ff1be9938bcdcb16a540c075b31de446d6016e7983ad808996a735bbdea
+  md5: 8002b4dbdf9f70089c6fa0c97665708a
+  depends:
+  - python >=3.8,<3.9.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 289646
+  timestamp: 1716495792628
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py38hca03da5_0.tar.bz2
+  sha256: ad379c6a9b647dd1606107456d005228027d3c92e0fc55fcf47861df4527e46c
+  md5: 12b99cac3003bc54b23d599c9999a8c4
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 266004
+  timestamp: 1661368815072
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py38hca03da5_0.tar.bz2
+  sha256: e137e80a106edbc2022b1f97486cad410964f4a441b3af51edcfcb8ad44a79c2
+  md5: b18235f9fe5703c71919675cf48ab64e
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16216
+  timestamp: 1683823878940
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py38h313beb8_0.tar.bz2
+  sha256: 7bb699635692c6b113d9ae0b6278026f33721b0af581d2012b3ae12452ef0299
+  md5: b924257ab4a27121bdebb03f8145ca67
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.8,<3.9.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 136234
+  timestamp: 1682522529684
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-snappy-0.6.1-py38h313beb8_0.tar.bz2
+  sha256: c8c0be587dbbbf2ddf82f89dc467cf5f7b04f0681d039fa4339d46f93aad2b4c
+  md5: 86015e59fdf126735b3883215090605d
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.8,<3.9.0a0
+  - snappy >=1.1.9,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 31988
+  timestamp: 1670944029362
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py38hca03da5_0.tar.bz2
+  sha256: 8a7c66044c09cd88710e6203e8d08d7610af303ffe33e04704561e2f31167070
+  md5: 8c596a7bbd3dcbd778895b2067cb8616
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 263184
+  timestamp: 1713974341209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py38hca03da5_0.tar.bz2
+  sha256: 0d8a57ff7231fa121da3a10f898f143bfb9cb5cf7eca7b4517cb9f5eddc215ba
+  md5: 4c584d908fdd1ed46f52d7da71b0e64a
+  depends:
+  - param
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 61647
+  timestamp: 1711136973061
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.2-py38h80987f9_0.tar.bz2
+  sha256: 37772c03d7b07ddeac464f53082bb242a09646f2afab652632b2b62afacbb47d
+  md5: 66c894f8f96e0ae8ee41ffc1e9b749e4
+  depends:
+  - python >=3.8,<3.9.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 174515
+  timestamp: 1728658192597
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py38h80987f9_0.tar.bz2
+  sha256: 267226c5c0d201a0af1504195996b72500ec9032eb00f1bbdeacab181a8c4ba9
+  md5: 915661c8ddc03d019ae838014dae6751
+  depends:
+  - python >=3.8,<3.9.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 492414
+  timestamp: 1709318397182
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+  sha256: 089c6b9bebfa690f380710f219ab0fcc1acec9f2e187d4174a08222c45f58afc
+  md5: 11b832c6c10a6d2b0e687a20c3037c97
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-3-Clause
+  size: 194532
+  timestamp: 1652449531448
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py38hca03da5_0.tar.bz2
+  sha256: fa7d3b858bc4aaedc8e4677a9a9be4f028c8f7ea40b1ecf347f77ea5be549efc
+  md5: 2f06c17502cd018dd3c59de09be9462c
+  depends:
+  - attrs >=22.2.0
+  - python >=3.8,<3.9.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 58821
+  timestamp: 1699012156655
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py38hca03da5_0.tar.bz2
+  sha256: a4ebbee44103435a3ef216810441b5768b24ae2ea1a8fb6aeefbb9e048733a36
+  md5: 53e5f7207000f7127428fff746f4dcbf
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.8,<3.9.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 98381
+  timestamp: 1721414901875
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-toolbelt-1.0.0-py38hca03da5_0.tar.bz2
+  sha256: 36c9437965619412e17244b47c9e3b3ca641654c29925d45ab7f732c20120668
+  md5: a19fd003f158986ddcc9d05b3aed4d44
+  depends:
+  - python >=3.8,<3.9.0a0
+  - requests >=2.0.1,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 69842
+  timestamp: 1690874029512
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py38hca03da5_0.tar.bz2
+  sha256: 93971fe5d4da96fe249ffc24fa02fd133ffd1a6c418b952818cd321e92d0bd25
+  md5: aaf80726c3917533c8de574b61257c62
+  depends:
+  - python >=3.8,<3.9.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9831
+  timestamp: 1683077167663
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py38hca03da5_0.tar.bz2
+  sha256: d747131e1149e5a925f71062cc83055a3cddb9dd0294c7a7c8e945b94b258ac7
+  md5: ed9d9a90ee3b3d4f882b37beacd201b7
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 10207
+  timestamp: 1683059108876
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py38hf0e4da2_0.tar.bz2
+  sha256: 992b4cabaed63572d9464581d79be13185a1a73acbdcf5dd1c206d7401ef8ebc
+  md5: f3ada05e3a42a31dac9a296231a233da
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 342736
+  timestamp: 1698946135494
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel.yaml.clib-0.2.8-py38h80987f9_0.tar.bz2
+  sha256: aca8f39c5c4fa7a351e1f008b6829d8dbe3de693312ad76f4a374571fe51d638
+  md5: 1d37f1dc1bd231f14fcefadb580d44b9
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 137906
+  timestamp: 1727769950470
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ruamel_yaml-0.17.21-py38h1a28f6b_0.tar.bz2
+  sha256: deac6268ce178b4468f78941c19b725c4209be5d1b3bc0f035991f2344b9dada
+  md5: 58a0f98d894a5d27d6541bfe0e56f05c
+  depends:
+  - python >=3.8,<3.9.0a0
+  - ruamel.yaml.clib >=0.2.6
+  license: MIT
+  license_family: MIT
+  size: 173669
+  timestamp: 1667489769162
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.10.1-py38h9d039d2_1.tar.bz2
+  sha256: c8d2d402fba9c78ee8ae329e578ef43ace1b1915b4241dc7d17695965ec22cef
+  md5: 2729777751cf61baa4f46afb04e60869
+  depends:
+  - blas * openblas
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.21,<1.27.0
+  - pooch
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23732952
+  timestamp: 1683287971462
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py38hca03da5_0.tar.bz2
+  sha256: 4e66c129581eb6bdc2e1d0c53f6e553a13ffccac2e0ba16279b9ea98e8046abd
+  md5: 60ff2d59453516f7b71d81f08edbbbbc
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27867
+  timestamp: 1699371166275
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-60.9.3-py38hca03da5_0.tar.bz2
+  sha256: 203159876cea0cb8272a8e2474a69b3397b85be1c5581708c55baa11e499345c
+  md5: 9053ec6629f2dde2b3f6dd8e1e0cfc8b
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 1234476
+  timestamp: 1685710970693
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
+  sha256: 499623019bea7cd167924f7fa841237b11b81a1e9cafe9b8ffde47d329275167
+  md5: 290d04cffc69bf26a4ed9f1aa9ad42e4
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 46038
+  timestamp: 1723557442909
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py38hca03da5_0.tar.bz2
+  sha256: d6bb01a559093b9d5db71368c89d70aefbeae33306bdf3dc35f5f11be44972ea
+  md5: f1989d879f942c875fd029d0946a9e98
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17804
+  timestamp: 1705431317307
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py38hca03da5_0.tar.bz2
+  sha256: 66064f3ee63df60cf0daa216111ce1aee0273a18b1eedf9ea72c96d49aaba5f2
+  md5: e20848a40ca8adb4f4eb05eeecef05a6
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 67344
+  timestamp: 1696347585538
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+  sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
+  md5: d8c1e9910392d0bcb22a173f9ce30fa6
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1758290
+  timestamp: 1714488307689
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+  sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
+  md5: ae58720a18a2ed15eae214ad7a10d1b5
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 140125
+  timestamp: 1680167256603
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py38hca03da5_0.tar.bz2
+  sha256: 633b552e3b2851778474918745474012c24478028d9199b7e70b405b49edec80
+  md5: 21b71f9ea2e65e770b6703a71c6d1768
+  depends:
+  - ptyprocess
+  - python >=3.8,<3.9.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30932
+  timestamp: 1671751893456
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/thrift-0.17.0-py38hc377ac9_0.tar.bz2
+  sha256: 80fdd145ab10c9d3d98845bd46a9ca8ba6e84611f9f1b50462e44cebfb52918c
+  md5: 6823d96b30037e7152accd6839e6bf0a
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.8,<3.9.0a0
+  - six >=1.7.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 126231
+  timestamp: 1666296572296
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py38hca03da5_0.tar.bz2
+  sha256: 2626c19604e8a205eb1f91d0e4236b569560b174405497540189997012f36002
+  md5: 782d9a537331c94371690bdf3ee55b22
+  depends:
+  - python >=3.8,<3.9.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40306
+  timestamp: 1668168901778
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+  sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
+  md5: 3c25b4f4768ccda28b20a03ba27e7759
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3484151
+  timestamp: 1714770744982
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py38hca03da5_0.tar.bz2
+  sha256: 02190c624d356a6ad7b6dba56a32fd33f4cf94ab5c1f087869be84718791487b
+  md5: 7fdd7e3d9b70d446d35425ed13e9c536
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102470
+  timestamp: 1667464107289
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.1-py38h80987f9_0.tar.bz2
+  sha256: be634f2409dce7960f17fccd1241c123a5dc692838290039844c2ed6f44aa702
+  md5: c0537c090585f03336fd8896095f2811
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 691093
+  timestamp: 1718740173610
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.5-py38h33ce5c2_0.tar.bz2
+  sha256: 27aaba649b3445b76666c7d8137e817325652e9a8032a46d03eb5de3b79eac5b
+  md5: ca4786226af4cb4d62f2d5bfcbcf4622
+  depends:
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 127294
+  timestamp: 1724854139658
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py38hca03da5_0.tar.bz2
+  sha256: d8889a05a34b398d5da8c5352344a4c6a08d129116e7e15d0ed99235ba324df8
+  md5: b2e9152fb770ae8ad72ee9c5a8bdc3d8
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 166133
+  timestamp: 1718227174920
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py38hca03da5_0.tar.bz2
+  sha256: 27ddb99ddf9d8bac997e1ca6f0a2ce46dd20609ed92eb6a35e91f73e7481401d
+  md5: 85be9d34a417d69e18cfc18e7d983099
+  depends:
+  - python >=3.8,<3.9.0a0
+  - typing_extensions 4.11.0 py38hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9867
+  timestamp: 1715268872086
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py38hca03da5_0.tar.bz2
+  sha256: 9d8eff664fd8d2b0f05365e2dd36474bcb27b9c307dd9c72228413e72104e61e
+  md5: 662b1da1ffc40d344a13ffda65e1b408
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 61167
+  timestamp: 1715268862691
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py38h80987f9_0.tar.bz2
+  sha256: 52bd150b9ce7947062a034b72de3d714c972e5c30f995498b1c2e210ffcf5fdc
+  md5: 0833ec866761890dd3676188ca2b0d44
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 517952
+  timestamp: 1713213106526
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uriparser-0.9.7-h80987f9_0.tar.bz2
+  sha256: c7402bdd16743bbd3350752e7009e40024b7ea2d280f54a6f74a4246f99e0edf
+  md5: 666f1bc2359d58c32ccbcbf4e9fcadd7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42998
+  timestamp: 1692186946914
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.3-py38hca03da5_0.tar.bz2
+  sha256: 1fde07cc5797259f6ae7e852889ffbf3d23041921e1c6a9a5c6f40980ac9d183
+  md5: 41dc4cb2907f51a37879f22209300222
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - h2 >=4,<5
+  - selenium >=4.4.3
+  - requests >=2.26.0
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 171705
+  timestamp: 1727769851662
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+  sha256: 20ae100fd04de16356f26e7c9dab514015e57a9d54fb78767aa5ed97de7846fb
+  md5: f620d98b3d0072945948310c86f0f1c5
+  license: MIT
+  license_family: MIT
+  size: 157385
+  timestamp: 1706894678643
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py38hca03da5_1.tar.bz2
+  sha256: 82c0d07ca88c806b0816e8f4d5f79d24d8c373cc758ff06b1ad9976257162e67
+  md5: 07036a73e921ca173dcabcff9321c34d
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20079
+  timestamp: 1629144417239
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py38hca03da5_0.tar.bz2
+  sha256: 9c53db1b26bbf44492aab1e3ad33626e71e6b60a860d8b6c39947f243865d8b1
+  md5: 3fc0071c22c57e32c9a8e28c676ddebe
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 87386
+  timestamp: 1715878426593
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.44.0-py38hca03da5_0.tar.bz2
+  sha256: 05bd35ece727f081d7451648f66e3060c91d5134ee53ba992b20e933cf882160
+  md5: 752673e61de53f3190be492a804b45c7
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 105309
+  timestamp: 1726165145323
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2022.11.0-py38hca03da5_0.tar.bz2
+  sha256: fbbc84d300a1f4ad3019d0c5828c77440f8dfe684458e4d573030d5fa5c525d8
+  md5: d77d04cfa8a09aabf3f44f1c78a4f433
+  depends:
+  - numpy >=1.20
+  - packaging >=21.0
+  - pandas >=1.3
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1722966
+  timestamp: 1668776739525
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py38hca03da5_1.tar.bz2
+  sha256: fe2c19f54551b7ef1c3a5b33dec3125db65ced3cacd187c19004fcd0c3c96213
+  md5: 58f495f8dc56ed6bf8533c8cfa7ca5bf
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49427
+  timestamp: 1675159104659
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+  sha256: 5be8c968f2da5c4bf14f28d63e31b4c1b6993d980023769732c7f58f396c2e0b
+  md5: 3f5f62d4e85e3bdd48d39189b01805a6
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 459197
+  timestamp: 1714510992914
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+  sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
+  md5: 3d57d1adadca9388aaaa1c529b65ba65
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 322790
+  timestamp: 1705602163804
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py38hca03da5_0.tar.bz2
+  sha256: 75240abcfd39c449374aa916e1aa01e0758bae5f8532520568728a5670141696
+  md5: 4eee6619cd3939d8fc2d881c21f4c248
+  depends:
+  - heapdict
+  - python >=3.8,<3.9.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 77607
+  timestamp: 1695832873064
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.20.2-py38hca03da5_0.tar.bz2
+  sha256: bbb4125e7639b8a5ae8c290f261f3ebdd24479f312aaf38f83011a1282d039e2
+  md5: b8de52e13dacda97339139bf981a6d44
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 26146
+  timestamp: 1729012401220
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+  sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
+  md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
+  license: Zlib
+  license_family: Other
+  size: 104928
+  timestamp: 1714510936868
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstandard-0.19.0-py38h80987f9_0.tar.bz2
+  sha256: 9bd2da6a9d9485365fbf6b12ab9c5f122cbeb78816df5a3fad27481638b507cb
+  md5: 84c762a0604f8ef4ef55ae876d74a450
+  depends:
+  - cffi >=1.11
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 587117
+  timestamp: 1677013818820
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.4.9-h8574219_1.tar.bz2
+  sha256: 10ea544b7e6e01215a261f44984988ffad408dad2f242a6a8c81148f9c814a20
+  md5: 1bb8a29937652e6aaac6fa2d698093f5
+  depends:
+  - libcxx >=12.0.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: BSD 3-Clause
+  size: 738884
+  timestamp: 1629301647081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-anon-usage-0.4.4-py38hfc23b7f_100.tar.bz2
+  sha256: f6c1893483d42f35d337dabb31aa035196eb635974886ff7bf3cc9e08a85b1c5
+  md5: e6e2a7fff3b385971a103d91113d49c7
+  depends:
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - anaconda-ident <0.6.0
+  - conda >=23.7,<26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24734
+  timestamp: 1710965553924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-client-1.12.3-py38haa95532_0.tar.bz2
+  sha256: 6ac864345954e4ee3639d7a30b266d5931a221aeac8cde33e65704bff2e88f96
+  md5: e1c3ba37f4fa34ee67c50801c96f420e
+  depends:
+  - anaconda-anon-usage >=0.4.0
+  - conda-package-handling >=1.7.3
+  - defusedxml >=0.7.1
+  - nbformat >=4.4.0
+  - platformdirs >=3.10.0,<5.0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.6.1
+  - pytz >=2021.3
+  - pyyaml >=3.12
+  - requests >=2.20.0
+  - requests-toolbelt >=0.9.1
+  - setuptools >=58.0.4
+  - six >=1.15.0
+  - tqdm >=4.56.0
+  - urllib3 >=1.26.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 167108
+  timestamp: 1708641386095
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anaconda-project-0.11.1-py38haa95532_0.tar.bz2
+  sha256: b65f6c130e7e0a9b05c9c8fc6241afae418defe8719dbbd1396aed5d5befd547
+  md5: 8002dc76c531873a826d7a5a94b89432
+  depends:
+  - anaconda-client
+  - conda-pack
+  - jinja2
+  - python >=3.8,<3.9.0a0
+  - requests
+  - ruamel_yaml
+  - tornado >=4.2
+  - tqdm
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 564785
+  timestamp: 1660340170214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py38haa95532_0.tar.bz2
+  sha256: 3d0035b5e9cd3f60305ebf4187cdff92c9645923fd77fa22471036805ec456ee
+  md5: 275f0773468598c4cc07466550dc6a04
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.8,<3.9.0a0
+  - sniffio >=1.1
+  - typing_extensions >=4.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 174407
+  timestamp: 1706220863088
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py38h2bbff1b_0.tar.bz2
+  sha256: 03266238128a35b764faac4b242317894abfbd6aa87926925d742fe777540501
+  md5: c69fc290a38779ea332ed0706d58b8e5
+  depends:
+  - cffi >=1.0.1
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 39205
+  timestamp: 1644569956444
+- conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-4.0.1-py38h0d1d0e5_3.tar.bz2
+  sha256: 9306f5d5d57580f39292827b9f91f6ab7b8a6ea8eeb3aae278ffb6bc9cc4f279
+  md5: fd6efa3f258e456117c49d5ebb9189da
+  depends:
+  - aws-sdk-cpp >=1.8.185,<1.8.186.0a0
+  - boost-cpp
+  - brotli
+  - bzip2 >=1.0.8,<2.0a0
+  - c-ares >=1.17.1,<2.0a0
+  - double-conversion
+  - gflags
+  - glog
+  - grpc-cpp
+  - libboost >=1.73.0,<1.73.1.0a0
+  - libprotobuf >=3.11.2,<3.12.0a0
+  - lz4-c
+  - numpy >=1.11,<2.0a0
+  - openssl >=1.1.1k,<1.1.2a
+  - python >=3.8,<3.9.0a0
+  - re2
+  - snappy
+  - uriparser
+  - utf8proc <2.9.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib
+  - zstd
+  license: Apache 2.0
+  license_family: Apache
+  size: 5591239
+  timestamp: 1622568685233
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-24.2.0-py38haa95532_0.tar.bz2
+  sha256: 479d27dd9acc222ebf5e61a280e72d5831659bd239ff5d379992189b91de241e
+  md5: d8cb2df09f080f155289683ecf27cfce
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 142137
+  timestamp: 1729089722587
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.4.57-ha925a31_1.tar.bz2
+  sha256: 91a78979ae6c1f5ff02dd1076aa62e2da7e610647203cd8985e0ea25465f2a74
+  md5: 7878a5b35caf8db44fffffe0ba320951
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 155676
+  timestamp: 1601398472136
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.1.6-hd77b12b_5.tar.bz2
+  sha256: 08437ce1c93997e5f5e8a6a7a8835b9b3a96d8be97c7752644fc9b2ae9788c8e
+  md5: 1883d49fb78e0858f007a73e042e5c3a
+  depends:
+  - aws-c-common >=0.4.57,<0.4.58.0a0
+  - aws-checksums >=0.1.9,<0.1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 27050
+  timestamp: 1603894719881
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.9-ha925a31_0.tar.bz2
+  sha256: 6947f2b605db23cf0f80f7009fc09eba477c7ae80d55ec81f640ed8b1854a1a6
+  md5: 067a7194f4f3d8e8bbe37d8825503cd3
+  depends:
+  - aws-c-common >=0.4.57,<0.4.58.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 54104
+  timestamp: 1601398697615
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.8.185-hd77b12b_0.tar.bz2
+  sha256: ba257fb24561340ca04c372d9624954b8a57af11999eb9dea42faac47f20e5b9
+  md5: 93b4a964f3722da3eb9ad019e7e88f3f
+  depends:
+  - aws-c-common >=0.4.57,<0.4.58.0a0
+  - aws-c-event-stream >=0.1.6,<0.1.7.0a0
+  - libcurl >=7.71.1,<9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3226667
+  timestamp: 1618435213786
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py38haa95532_0.tar.bz2
+  sha256: 5592505a5157820f49f24f56edadce386b621bab138606b2f0749140a8ff98fa
+  md5: 8467b1abc968461e85ed656f99c3fb77
+  depends:
+  - python >=3.8,<3.9.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 208895
+  timestamp: 1718029925816
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-2.4.3-py38haa95532_0.tar.bz2
+  sha256: 4921e5a1d6f8a4296808ced9c89eb8a6f73a2a3a028a47e62d40565ac80a7af2
+  md5: 353550e48fa7a8330b0ea85159b91729
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.8,<3.9.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14459500
+  timestamp: 1658136931040
+- conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.73.0-h2bbff1b_12.tar.bz2
+  sha256: de7cc4bbb2534251c2cde2cfd73d4ebed8c4362361320b16f8273439f188e29e
+  md5: b4ce3ffcb9ae44d4f1cc025479066509
+  depends:
+  - libboost 1.73.0 h6c2663c_12
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 16711
+  timestamp: 1655891172252
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py38h9128911_0.tar.bz2
+  sha256: 8b89a41936ad7ae8cec3d3f1986f7fd57e278107574f00fbdf0e75d73c10c3b6
+  md5: 993db813da8f36a4268bb912c6ae3876
+  depends:
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 120519
+  timestamp: 1707864574013
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 751071782f597f87ed7f67437ef6cc669213902461b9795dd6eb0f4897eddc83
+  md5: 5ad8fe62aad5e16cfdf2c5a7d1327fe7
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_8
+  - libbrotlidec 1.0.9 h2bbff1b_8
+  - libbrotlienc 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 19418
+  timestamp: 1714483531456
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 9bd62d810867549b9c967c5915f3fa3f66cfbd6ede28b1cc152efd1261285c0a
+  md5: 64cc76de3662b62bc8f0e42befd92c5d
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_8
+  - libbrotlienc 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 32178
+  timestamp: 1714483513837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py38hd77b12b_8.tar.bz2
+  sha256: 0d34db197ab3b14e13acb32e6fd6b3b0b58ba12ecbe2632706bcbfa98174da5b
+  md5: de7ca67e3b631f083a0e2d60a805e431
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 356351
+  timestamp: 1714483811008
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+  sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
+  md5: 11e0af09a31e2d5df51c65a342032b85
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 112994
+  timestamp: 1714511182837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+  sha256: 41a6c5a90b88ec7010bb6dd89390754e476b52c3ab2d519bdab9556da8829479
+  md5: b047426a545e287f45e8abfbfcb0de55
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 118041
+  timestamp: 1693902191485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.9.24-haa95532_0.tar.bz2
+  sha256: 5434767b7168e529c2c6a4bc201c783adbc3bc6480564a6fe3f869b12ed96c83
+  md5: bb0627482bac2339842e495e7d6686d2
+  license: MPL-2.0
+  license_family: Other
+  size: 175262
+  timestamp: 1727794875480
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.8.30-py38haa95532_0.tar.bz2
+  sha256: d76252bfe88b57c31b1d6b32f45c3e021828ecdde48c86f7d91d7280efb49b5b
+  md5: 2f53dcf4fd273552a45fc4d91ee8ba75
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 168638
+  timestamp: 1725551864682
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py38h827c3e9_0.tar.bz2
+  sha256: c6fb618f35a21c5d0145d78c9f9669249f42fa9bc42e97abe896aa8cbd47b35e
+  md5: ce7050b90688819020af308d0d8efaeb
+  depends:
+  - pycparser
+  - python >=3.8,<3.9.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 251178
+  timestamp: 1726856534727
+- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py38haa95532_0.tar.bz2
+  sha256: d6419f177081f538c07438fd0e30b3fd0550154068846a5a172d7ad0f3da7d29
+  md5: 4a4023e7123dee6dd3de8d5c7ad10208
+  depends:
+  - colorama
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 152529
+  timestamp: 1698130021042
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.0.0-py38haa95532_0.tar.bz2
+  sha256: 409ba6333f104911fa90f94b1fbb504c6f00f1d11c3d2a6318e0ca76fd34805c
+  md5: 48e9c16440f00106b1249c977840e4f3
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35481
+  timestamp: 1721657467285
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py38haa95532_0.tar.bz2
+  sha256: b1c25c1a98c903b27e265b54acbed95f4a9b274c5b6ed13cf6b0f6f6f8b355a6
+  md5: 056a4bcea84a785566fc6d5dee32c8d9
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30328
+  timestamp: 1672387462487
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py38haa95532_0.tar.bz2
+  sha256: 7da28ca3414ac1f6263983a7e2da3337c276e2af2057ad0dff3c6ea500248260
+  md5: 496b518d3c346b450e9a537954334e43
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 549769
+  timestamp: 1709758725166
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py38haa95532_0.tar.bz2
+  sha256: 4c7f192b9a0e9d0c2d77c3e75e85a5d97b6762892cbcb19546254b8e2739124a
+  md5: 2b01b19c1dd5105ff1483b96b3fe109f
+  depends:
+  - python >=3.8,<3.9.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15323
+  timestamp: 1709323030816
+- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-pack-0.7.1-py38haa95532_0.tar.bz2
+  sha256: 76bf960b1799b2b74143da3cfad092cd53d342bd77f8d985fb2e430c0fe21e4b
+  md5: 18430d9a28c9c8823f93bcd4a33893d0
+  depends:
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70897
+  timestamp: 1710258190226
+- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-handling-2.3.0-py38haa95532_0.tar.bz2
+  sha256: 477edbc65ca4758ecdda4d4a605b7033f6a93cfb8011e7e9f4742602fd4a9527
+  md5: 95d62c313a391f5473d7a6298129859f
+  depends:
+  - conda-package-streaming >=0.9.0
+  - python >=3.8,<3.9.0a0
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 309146
+  timestamp: 1718138562716
+- conda: https://repo.anaconda.com/pkgs/main/win-64/conda-package-streaming-0.10.0-py38haa95532_0.tar.bz2
+  sha256: c04fca47f49fcf6fd04eab50990c40870c22dbc0cb760e88651a1ffa465c0972
+  md5: 98fa6c62a279826f71684136b879c4d8
+  depends:
+  - python >=3.8,<3.9.0a0
+  - zstandard >=0.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28101
+  timestamp: 1718136203874
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py38h59b6b97_0.tar.bz2
+  sha256: 70fde13d90524b164158f9b22303677d6e05ab15a84ffc00bdeafb2e1a584e84
+  md5: fecf6e5becd8b5d19e3b5a1b33e9d915
+  depends:
+  - numpy >=1.16
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184226
+  timestamp: 1663827694272
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.2-py38h2bbff1b_0.tar.bz2
+  sha256: 7c66ca2b9c44c10602ae8fee1475204428722e9d9fc5c2fe03e9eca900831268
+  md5: 1a2f13dcf6b44e18faecea2bf5a8abea
+  depends:
+  - python >=3.8,<3.9.0a0
+  - toolz >=0.10.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 343415
+  timestamp: 1701723732354
+- conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py38haa95532_1.tar.bz2
+  sha256: 792842a4d65fa3affa75fbef7b45b35e2d1fdc3a3afb805c60dea0363b473f9f
+  md5: 3afae957ad0d8a21fab2c450d3a5e7f9
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7
+  - python >=3.8,<3.9.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 104651
+  timestamp: 1613390448861
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py38hd77b12b_0.tar.bz2
+  sha256: 2133716ef1744b2292e035a58e2ce7136507df2598a6bbb557f77d41c229e6a6
+  md5: 8d89f8023cd7fb526d42b020dd298dde
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3289647
+  timestamp: 1690907575092
+- conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2.30.1-py38haa95532_0.tar.bz2
+  sha256: 52637610ad7cb0eb4444d5799c0972793fbcc371c32b5e7056ab02b9f69c0c0a
+  md5: bc99a7bec1d016e479252d1ed0afb1f4
+  depends:
+  - click >=6.6
+  - cloudpickle >=1.5.0
+  - cytoolz >=0.8.2
+  - dask-core >=2.9.0
+  - msgpack-python >=0.6.0
+  - psutil >=5.0
+  - python >=3.8,<3.9.0a0
+  - pyyaml
+  - setuptools
+  - sortedcontainers !=2.0.0,!=2.0.1
+  - tblib >=1.6.0
+  - toolz >=0.8.2
+  - tornado >=6.0.3
+  - zict >=0.1.3
+  constrains:
+  - openssl !=1.1.1e,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1154079
+  timestamp: 1605066746927
+- conda: https://repo.anaconda.com/pkgs/main/win-64/double-conversion-3.1.5-ha925a31_1.tar.bz2
+  sha256: ed66a25d2123f70d55896b17d9b774a88618eb9288d60c23f6419b199f88c3d8
+  md5: 8ca5980f204acf7ec2ceb5f6437b7bfb
+  depends:
+  - vc >=14.1,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 257849
+  timestamp: 1567108291976
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py38haa95532_0.tar.bz2
+  sha256: e86cd5e70eb1ade76f2e80d9351d377f81b63460b7b0261e0aa9825b7051df83
+  md5: 0ea2c3493ad24b83dfb5919aa6af58e8
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16900
+  timestamp: 1649926672239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.2.0-py38haa95532_0.tar.bz2
+  sha256: 4d164e7a24b1cdec81846df6258202b10e9199a85eece63eb9c494e54329c0aa
+  md5: 723144b57a4f6fd5af73a04efe77bda5
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 30386
+  timestamp: 1706031611837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-0.5.0-py38h080aedc_2.tar.bz2
+  sha256: af094b4bd8c2581f0dd1c4a33ec0334d63fccc13e5fa4210e1911086667d83ab
+  md5: 1f3bd3efe3f06d9ece34bd2f0d01446a
+  depends:
+  - numba >=0.49
+  - numpy >=1.16.6,<2.0a0
+  - packaging
+  - pandas >=1.1.0
+  - python >=3.8,<3.9.0a0
+  - thrift >=0.11
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - numpy >=1.18,<1.22
+  license: Apache-2.0
+  license_family: Apache
+  size: 190803
+  timestamp: 1658471877164
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py38h2bbff1b_0.tar.bz2
+  sha256: 2e3e06327bf5073705b5fcadd719033c48caccc2fbe83e4e65e4ccb804261a75
+  md5: b2c8a0b2e87ed3b6362a69dfb7d9c0a8
+  depends:
+  - brotli >=1.0.1
+  - python >=3.8,<3.9.0a0
+  - unicodedata2 >=15.1.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 2210226
+  timestamp: 1713552355020
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.6.1-py38haa95532_0.tar.bz2
+  sha256: d181cbd59a4fe2da8298b521fcd49a90cd7d9fee6c2f13352aa775fa6e6f4b7b
+  md5: eb5d9f820b1aee3f5951cee4a172b087
+  depends:
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - pyarrow >=1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 283622
+  timestamp: 1724855699390
+- conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+  sha256: 7cb0df7aa62796b0081e1708003529c02411aca6a540bae97beaec919aa64e74
+  md5: ea81fd813e10055553a8d7597c8be98f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 322778
+  timestamp: 1706888324269
+- conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+  sha256: ed1fa1a40c6739b48ff3a2d51c3df20e4983b59684b04d93e1337c5f2e93a954
+  md5: 1797f64343a42395207cd452e6a6a751
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94476
+  timestamp: 1706895442146
+- conda: https://repo.anaconda.com/pkgs/main/win-64/grpc-cpp-1.26.0-h351948d_0.tar.bz2
+  sha256: 6a5c2deb25813a4f37de9d26c4f0f95f496441ba4c8fc614297a9a8581e6409c
+  md5: 0910c37b2a35ac6a036d94806fccaaa8
+  depends:
+  - c-ares
+  - gflags >=2.2.2,<2.3.0a0
+  - libprotobuf >=3.11.2,<3.11.3.0a0
+  - libprotobuf >=3.11.2,<3.12.0a0
+  - openssl >=1.1.1d,<1.1.2a
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: Apache 2.0
+  license_family: APACHE
+  size: 15441619
+  timestamp: 1580397193694
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+  sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
+  md5: 582d2c1135a89da757a038de831e7f39
+  license: Intel proprietary
+  size: 11086648
+  timestamp: 1664812389803
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py38haa95532_0.tar.bz2
+  sha256: c386cd6fbb827f5a7633a7c19ae24a0755b2c425e65487a35e3a2770afe1b5e5
+  md5: 669cfec4ebd7d248d60b64cceeeb9269
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123732
+  timestamp: 1714399007175
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py38haa95532_0.tar.bz2
+  sha256: 0ab24097111b49edd25180744c960d59c95f668b59a0445f605a2dddca8f2134
+  md5: a3ef8887a20b4d7e08766c138594ba21
+  depends:
+  - python >=3.8,<3.9.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 42044
+  timestamp: 1704813734562
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.4.0-py38haa95532_0.tar.bz2
+  sha256: f62e105e261a50c48eb27c8042d36c3c885fa53af33ae915d0d1fcc8f92657a2
+  md5: bc76f454be39b4089a37cce831e1d7fa
+  depends:
+  - python >=3.8,<3.9.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 58000
+  timestamp: 1720641211265
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intake-0.6.8-py38haa95532_0.tar.bz2
+  sha256: 3619cb62b311c1e003bbcae471d727ba3f43be7b61a53e86bb024013aff5382d
+  md5: 3dcf56a37c02b514e93ef2ed1560664f
+  depends:
+  - appdirs
+  - dask >=1.0
+  - entrypoints
+  - fsspec >=2021.7.0
+  - jinja2
+  - msgpack-python
+  - python >=3.8,<3.9.0a0
+  - python-snappy
+  - pyyaml
+  - requests
+  - tornado
+  constrains:
+  - hvplot
+  - panel >=0.7.0
+  - bokeh
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 217089
+  timestamp: 1678787837720
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+  sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
+  md5: d215cc8ee7ca2cc83cc250cc5d822fe0
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3929136
+  timestamp: 1699647939158
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py38haa95532_0.tar.bz2
+  sha256: c01fc087034c420bde517ea426e20287935acde54763aded5142487019fff190
+  md5: 831252005dbd46e30eb896422009dfc7
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 190983
+  timestamp: 1728665891426
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.12.2-py38haa95532_0.tar.bz2
+  sha256: 7b756df85fb011088bf6bb638600c7457cf717dfa5ab69b0a6cf3649b66b1dcb
+  md5: 8b27d8d58e3781bd451cf797e272d5e4
+  depends:
+  - backcall
+  - colorama
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.8,<3.9.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1252304
+  timestamp: 1691532284562
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.1-py38haa95532_0.tar.bz2
+  sha256: b69208002b5f026eac88aca66d9d4e5e377a9b7679d5866a2b282c2ad2b8411b
+  md5: fec574df4927cf80f12bdac37b7aadeb
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 1046264
+  timestamp: 1721059296716
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py38haa95532_0.tar.bz2
+  sha256: a19bcdbc051e1315815a0998dbd60883724564ee4c45e9ccfa232bffaa697dc7
+  md5: 5a627e62dfd3f5e2accb35b13aec8b3b
+  depends:
+  - markupsafe >=2.0
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 274259
+  timestamp: 1716993611805
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+  sha256: 0238fb10912d9345a9d327ff314a179de38369f8e1d0de0b5f4fab04defab0e4
+  md5: 16a420ea83811cfa0c7cadba8f9f0995
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 409932
+  timestamp: 1722872751697
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.23.0-py38haa95532_0.tar.bz2
+  sha256: 99537ee46afa298aa7ec2278432233f9c0e810d7d4c344d53cbc6da7cecd82ae
+  md5: 2784059f8402336c99cd61f900ea676e
+  depends:
+  - attrs >=22.2.0
+  - importlib_resources >=1.4.0
+  - jsonschema-specifications >=2023.03.6
+  - pkgutil-resolve-name >=1.3.10
+  - python >=3.8,<3.9.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 175019
+  timestamp: 1728486987655
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py38haa95532_0.tar.bz2
+  sha256: 46748dfa778aa7e78f52cd6baa49186202b553384c111320c65393c0218e173b
+  md5: 7da1b58fa7d52c2f0aec56bdac48469e
+  depends:
+  - importlib_resources >=1.4.0
+  - python >=3.8,<3.9.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 15538
+  timestamp: 1699032485491
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py38haa95532_0.tar.bz2
+  sha256: ea0ae2cfbbbf5a3737e348b40fd6dd7a1b6159525143af959eb1708b201a9577
+  md5: 59112e5bdca43f39c392165f51477c30
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229130
+  timestamp: 1676330586941
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py38haa95532_0.tar.bz2
+  sha256: e4dfb00cba8e246c1fff06ca8293c340105e137bcf798a8f2a51485f7b519fd8
+  md5: cbcc47e0922603aadbee4f3aeb1a297f
+  depends:
+  - platformdirs >=2.5
+  - python >=3.8,<3.9.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 120988
+  timestamp: 1718818639896
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py38haa95532_0.tar.bz2
+  sha256: c8749746c00951825d71c842f37b4ab26894c5d7eec8369a321f9423251d708b
+  md5: 729dcc20a62d5e3944e635100bcd296e
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.8,<3.9.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65509
+  timestamp: 1718738196257
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py38haa95532_0.tar.bz2
+  sha256: 4e928b0efc2ec2c71eb8c470fdf7260c298c1f5d7270023d90278d25dd21278b
+  md5: d67b9417b1d9498d27ed576f2cf826e8
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.8,<3.9.0a0
+  - pywinpty >=2.0.1
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 543655
+  timestamp: 1718827185412
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py38haa95532_1.tar.bz2
+  sha256: a0f0717e24e574353b2748dbd41bc037de7eadf39266698eeed268ab3feaaa5f
+  md5: 71cd4edfa064a841e3686bd695d119c2
+  depends:
+  - python >=3.8,<3.9.0a0
+  - pywinpty >=2.0.10
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23926
+  timestamp: 1686871157357
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py38haa95532_0.tar.bz2
+  sha256: fb37beaea4fd5d8d84d7edd51335a5f2a0f272a7af85ca19cf79cd8be9002e6a
+  md5: c3f6014574ca4e53a2a006b306a50b93
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19776
+  timestamp: 1700168833321
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py38hd77b12b_0.tar.bz2
+  sha256: c287aa13a824a255ab68751645473a4f190590b77160b85d694a2f72e513e551
+  md5: f35f9f31f1f8bd00c5e7fccc81a8edff
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62238
+  timestamp: 1672388388533
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+  sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
+  md5: f5f73266281ab12377d5d47bdf07500a
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 905072
+  timestamp: 1617648814933
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.73.0-h6c2663c_12.tar.bz2
+  sha256: 6389f1c26b4d967ee5022da998216a8a82262264cdf20093f77fcf01e5c885bd
+  md5: 45400838317566b4aa24afa5a497eb26
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 36835586
+  timestamp: 1655891021895
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 7c906c94a4d46ea963080a6ba5bd12c1274da66159877a544fbc70291eeed98d
+  md5: 45a3d52534fac8aa54a55ee92211a918
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 80216
+  timestamp: 1714483371043
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: daad7edc6d56abf3e176479e8628162dbf1c56b3d24db30d708aebae694a5214
+  md5: e8ecf229f7fcb4c0b76d8613627948f5
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 45189
+  timestamp: 1714483420152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 84320217abffa9386186ec8d03b4651bb4b1900d3871adc965a9a9e1d3799907
+  md5: 651312fa22168f71f9aec5f9ee2c2fcf
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 756116
+  timestamp: 1714483464368
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.9.1-h0416ee5_0.tar.bz2
+  sha256: 8823321b1f3a4dec2ba437b74f054b6188c4e86f15e9830a851c036f1000b116
+  md5: eb83a06e2e659553014b6ac66f379e09
+  depends:
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 371549
+  timestamp: 1725033449018
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+  sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
+  md5: cf949d76148be1e2a534218d9c57df86
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 155435
+  timestamp: 1714484319443
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-3.11.2-h7bd577a_0.tar.bz2
+  sha256: a71d1d07f93bdc6e8e63f577ba026921f5e032cc5fdae9ef345aa510c78bc752
+  md5: 9e79055f48d08a25ce7cc272596d539f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2376980
+  timestamp: 1576541111355
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-hcd4344a_2.tar.bz2
+  sha256: 0b1460332f394557429f75c871c89ad27fc2ddadbeb28bfcff8d1d8537f493ac
+  md5: 38e889ec253fe997be7f94556a0855d4
+  depends:
+  - openssl >=1.1.1u,<1.1.2a
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 230554
+  timestamp: 1686932558863
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
+  sha256: e54ee28f6ba01b3addf61ee9dfbdedc16eac8654fc334f713b5f181cf037d0f2
+  md5: 47aa151852fc9b07e7573d22f0af945d
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 339944
+  timestamp: 1729160123353
+- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.38.0-py38h23ce68f_0.tar.bz2
+  sha256: 760fcf2ec2968ae8ca484f3ab2ca9e52d2d6ef0cb5ad2799541ccf3d05673441
+  md5: 320710850571e79f10811b51c93e496b
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib
+  license: BSD-2-Clause
+  size: 17093250
+  timestamp: 1650372279371
+- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py38haa95532_0.tar.bz2
+  sha256: badc76eab56488df2cba6ac632fcf24223c4967628fe7bc061d8e2c0cd5aa362
+  md5: 201617fddcaf95a08884560594e8d496
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 12848
+  timestamp: 1652904166019
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+  sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
+  md5: 320f40b75d93f3b96931c6d13c23946c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 158902
+  timestamp: 1714512129889
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py38haa95532_0.tar.bz2
+  sha256: 5e648ae3ef2e9d544accfd1cb16ee5081eb69fad94fc3dadd10c55244cddbfbb
+  md5: bd2cc8c49b69abde1d55e6f2a1e636a2
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142697
+  timestamp: 1671542078827
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py38h2bbff1b_0.tar.bz2
+  sha256: 4bd5defe37fb5920e0a5d22d9d479f11a22199d4fa81f8d497acf59f3623c516
+  md5: b163be173efae86ec41fdce35af0eff5
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26878
+  timestamp: 1704206131128
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.7.2-py38h4ed8f06_0.tar.bz2
+  sha256: 5fed7c0f03a7ff005e68293d8c4c50640fd468f5d0e1cce79a6251a68ddc49a1
+  md5: a959d9f4974e5402f833d529726cfa9c
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=5.2.0
+  - kiwisolver >=1.0.1
+  - numpy >=1.20
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7949779
+  timestamp: 1693813405191
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py38haa95532_0.tar.bz2
+  sha256: 2a832b73527801756ce9c8e7a2e9d2f0aa7b0e39e764cb1699c45dc9db00d67b
+  md5: dcede4303efc5efc488deed47d24f03a
+  depends:
+  - python >=3.8,<3.9.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17983
+  timestamp: 1661934096957
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py38haa95532_0.tar.bz2
+  sha256: ea8b7772c23b5c958b10ec4546d3b235b72d4e7010a69837705a273f30f723c6
+  md5: 6fa331a0ea7406d505e4db8ac77ac52a
+  depends:
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 90547
+  timestamp: 1661496403308
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+  sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
+  md5: 527155127b9fada5e5c5c69a624674b9
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187498166
+  timestamp: 1699648376430
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py38h2bbff1b_1.tar.bz2
+  sha256: 1377f4b52bc0f0059fc384cc0eb2451d8b9db27eb85587e27d93eb1061a1ca9b
+  md5: 3389c1f1869f6b1e894390155f8fbbf7
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49712
+  timestamp: 1682974986419
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py38h2bbff1b_0.tar.bz2
+  sha256: 8b57b0ddc34eeaabdf91274eab9ac758ebebb6436f3f43a7459139271ee2d0a0
+  md5: 4c623b331a7301525e92a02b0490a616
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 185379
+  timestamp: 1695058741315
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py38h59b6b97_0.tar.bz2
+  sha256: ac93a9e5da11442058b30e89bb24447d311f067a5a98c36c85c7de9f420f25e1
+  md5: 048f410489ce4250a215211619ee512e
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 258368
+  timestamp: 1695060288659
+- conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py38h59b6b97_0.tar.bz2
+  sha256: dd4f2c677361273de293da946ae55d811590bbadc4a1da75fe77204694821b86
+  md5: 22a646f00d2aa14becfb7594dc1efde5
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 82740
+  timestamp: 1652329410469
+- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py38_0.tar.bz2
+  sha256: f88f8146f2efe5744d2c8c03bc8c7275693b57fbad85212369cc742d81bd37bf
+  md5: d16e6b7628a2b9eab9a5d30e4bed09fe
+  depends:
+  - python >=3.8,<3.9.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 23139
+  timestamp: 1573470511265
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py38haa95532_0.tar.bz2
+  sha256: 2ab502a9b31418d85cbd1319e9b8104d1ef0015b28a891f735da8631f44af768
+  md5: cbae91562cd589d6d76cf10ce4dd4c1e
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8281201
+  timestamp: 1717624456711
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py38haa95532_0.tar.bz2
+  sha256: 65c24d874d1c62890a57e33897b16c4bff02c6e18e143e6be09bc082469f30a2
+  md5: 91d05567335fe9223f8907b7748f97e6
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.8,<3.9.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119185
+  timestamp: 1698934529462
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.4-py38haa95532_0.tar.bz2
+  sha256: c52e733ea7497dd72da30fcb06c139bb656d35161ca648f14810b596a6f41650
+  md5: f27743ec5bd0a51f662112f3f28fadf2
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - importlib-metadata >=3.6
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.8,<3.9.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 532532
+  timestamp: 1728052034971
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py38haa95532_0.tar.bz2
+  sha256: 65fd08b31f88c92774b94786b24479a58308870aaee9de3f6dbd7a8337843a21
+  md5: 074b08f8443141c0bac37cef71014eb3
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.8,<3.9.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 179794
+  timestamp: 1728050494082
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py38haa95532_0.tar.bz2
+  sha256: 0125eed930e1d15be1098e841f63bbf4fd5186778be3b87e97086dc08198e65a
+  md5: 37cb3974b360b02a0d7c068ffe6c99cd
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14074
+  timestamp: 1708533000967
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py38haa95532_0.tar.bz2
+  sha256: 25adc81e4fa738a62d444a90845a6b74b79192d3a7970ba7103f25ff06b3e3e6
+  md5: 2cb53eb03403e743dc7c26fffdf478c5
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.8,<3.9.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 645231
+  timestamp: 1717631098005
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py38haa95532_0.tar.bz2
+  sha256: b41f263dfa0efed39e09ec81e5122d01750e252a001b4bf7fb9d4ef70eade059
+  md5: bac6bd350f68d94ed7125e57bc7b6611
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23169
+  timestamp: 1699455980387
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.55.1-py38hf11a4ad_0.tar.bz2
+  sha256: 560f621fd180153e433ef842fd894b62613b48baa69b9c410561f8199e861a36
+  md5: d5d6bc1ddbd7e58ddaca95d6fbfb641c
+  depends:
+  - llvmlite >=0.38.0,<0.39.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  - tbb >=2021.5.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - numpy >=1.18,<1.22
+  - cudatoolkit >=9.2
+  - scipy >=1.0
+  - libopenblas !=0.3.6
+  - tbb  >=2021.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4001663
+  timestamp: 1650390943901
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.4-py38h7b80656_1.tar.bz2
+  sha256: 53088668bec0e25ce85dbb3aae9bf29b1fc90e2542360f5221e02acddf05cabc
+  md5: 990126d16909922f9617be3081ec5d58
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 131075
+  timestamp: 1683222215685
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.21.6-py38h85e1a82_1.tar.bz2
+  sha256: 8bff17e4297663ba95055fbb08b1c31d9a22407a88b0e475b464b9bac203e7d5
+  md5: 6c03a716acb80196ea30da5ad16a6609
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.21.6 py38hb5c95e7_1
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11277
+  timestamp: 1715093260243
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.21.6-py38hb5c95e7_1.tar.bz2
+  sha256: f4413d46e69e82484043c2837db61cb43bd06e528ae97a9f0bb5ec01a28b0828
+  md5: 68e4bfadb4f8459dfc1c443bd08c048d
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - numpy 1.21.6 py38h85e1a82_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6028720
+  timestamp: 1715093236825
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+  sha256: e2afce0548808d27293a03661ee5f7ac3e18f82a92c9fb23f420eb5e92126fc6
+  md5: 9dd921a785844abe0aa842c3800d405a
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.7.0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 286986
+  timestamp: 1722872761369
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
+  sha256: 0474e14823c734edc088bef98b829149a47ed8b4654f9638926c2fe4bbc40f38
+  md5: a67d4a763641de641ea9dfa8c4a5f567
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: OpenSSL
+  license_family: Apache
+  size: 6048217
+  timestamp: 1694466133007
+- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py38haa95532_0.tar.bz2
+  sha256: efb6be1d02844963cc1706a5ea6e1c8f199206371e5e0f064016171fa402f7cd
+  md5: bd06733558646e2cf0db9f87d2cc50ae
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 31537
+  timestamp: 1699371229746
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.1-py38haa95532_0.tar.bz2
+  sha256: 5ca458cebb6508f241c9de41eb5f7d2fbcbe1a7ed418e9e64ad7a19bcb8b4d88
+  md5: d4074f1df7234e38afca8f3004b7f615
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 135333
+  timestamp: 1720102440368
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-1.5.3-py38hf11a4ad_0.tar.bz2
+  sha256: 4c36f591c3b6692de0cdd2508f5f0f3bad8331f0b2c78892131419b74ed28ea8
+  md5: 2d357b4544d802559b28ae989b81141c
+  depends:
+  - bottleneck >=1.3.2
+  - numexpr >=2.7.3
+  - numpy >=1.20.3,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - python-snappy >=0.6.0
+  - tzdata >=2022a
+  - gcsfs >=2021.7.0
+  - html5lib >=1.1
+  - openpyxl >=3.0.7
+  - psycopg2 >=2.8.6
+  - pyarrow >=1.0.1
+  - brotli >=0.7.0
+  - scipy >=1.7.1
+  - xarray >=0.19.0
+  - beautifulsoup4 >=4.9.3
+  - fastparquet >=0.4.0
+  - jinja2 >=3.0.0
+  - zstandard >=0.15.2
+  - tabulate >=0.8.9
+  - pyxlsb >=1.0.8
+  - sqlalchemy >=1.4.16
+  - xlrd >=2.0.1
+  - xlsxwriter >=1.4.3
+  - fsspec >=2021.7.0
+  - pymysql >=1.0.2
+  - blosc >=1.21.0
+  - pandas-gbq >=0.15.0
+  - numba >=0.53.1
+  - lxml >=4.6.3
+  - pytables >=3.6.1
+  - matplotlib-base >=3.3.2
+  - pyreadstat >=1.1.2
+  - xlwt >=1.3.0
+  - s3fs >=2021.08.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12129620
+  timestamp: 1677836062764
+- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py38haa95532_0.tar.bz2
+  sha256: ba83b43ae4dc81ad1843dbcb377ea14d31a6f8671b2c73d7016ccbf953930358
+  md5: 0cc57d9c8d9aca634a55e4cddcc3618d
+  depends:
+  - locket
+  - python >=3.8,<3.9.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36170
+  timestamp: 1698702748557
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.4.0-py38h827c3e9_0.tar.bz2
+  sha256: cd5b77567e0af37dfaa4e78951eb66ffefedaa582192c1f12e66d5f33ba6e373
+  md5: 67a25493edf9d34f87d7b597bfc31498
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.8,<3.9.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 925815
+  timestamp: 1721059710712
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.2-py38haa95532_0.tar.bz2
+  sha256: fb6fb47fc4673736f721a5f11881669fea0f04f16a461999192d5a2237e82855
+  md5: 50e60af1a108b49a4f968cf13f5fe128
+  depends:
+  - python >=3.8,<3.9.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2546968
+  timestamp: 1723485712114
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pkgutil-resolve-name-1.3.10-py38haa95532_1.tar.bz2
+  sha256: 8778945e8ff311e1c6c21240f7d826a0b20b91d9c8a19cec0d2a6431f9568613
+  md5: bb26a71a59437bef6cb29ffbc894bb0f
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT AND PSF-2.0
+  license_family: PSF
+  size: 11194
+  timestamp: 1704297782483
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py38haa95532_0.tar.bz2
+  sha256: d9bdf22a0141d5d3e4e1455a93ecd6680980786b5fcd5516773217403057d389
+  md5: 10961e0b088c531ddeafb3c4c278b8b5
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 32378
+  timestamp: 1692205706184
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pooch-1.7.0-py38haa95532_0.tar.bz2
+  sha256: 269095712af2adf8aa3a1b5532596b7b19b3222d3b062f5af466ee5b423b854f
+  md5: 6f17c938b517964b61675589037c6e36
+  depends:
+  - packaging >=20.0
+  - platformdirs >=2.5.0
+  - python >=3.8,<3.9.0a0
+  - requests >=2.19.0
+  constrains:
+  - paramiko >=2.7.0
+  - xxhash >=1.4.3
+  - tqdm >=4.41.0,<5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 81717
+  timestamp: 1695850480881
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py38haa95532_0.tar.bz2
+  sha256: 62980fe41fb61641ff3a92bc46769c221e216d7b1b052624cca35cd6442e67a3
+  md5: ceb8f341d88581897417b74581824ce5
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 90902
+  timestamp: 1659455380536
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py38haa95532_0.tar.bz2
+  sha256: 56412c7866ec9f23b48aaf2d15083190a8e0a05a7f79a12cdca914d6eaea69f9
+  md5: f02031632580590333b5f15c1b86e17e
+  depends:
+  - python >=3.8,<3.9.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 577480
+  timestamp: 1704404521896
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py38h2bbff1b_0.tar.bz2
+  sha256: 3f30894e9e48919717e4836d41d37fe94067c41f2714982d5b09041e8d03c625
+  md5: 715eca27ac0ea2d6e5b9781ece861045
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372631
+  timestamp: 1656431598029
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-4.0.1-py38h953b917_3.tar.bz2
+  sha256: 95a2efa1b80ac7e0ff05cb71f6df7ec7222e65d6473a06c8a06228e5ef58651a
+  md5: 7af9abedef308517097a60c6f64b3dfb
+  depends:
+  - arrow-cpp >=4.0.1,<4.0.2.0a0
+  - arrow-cpp >=4.0.1,<5.0a0
+  - boost-cpp
+  - glog
+  - numpy >=1.11,<2.0a0
+  - pandas
+  - python >=3.8,<3.9.0a0
+  - six
+  - snappy
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache 2.0
+  size: 2281467
+  timestamp: 1623165272688
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py38haa95532_0.tar.bz2
+  sha256: b6cd1020f33142369e4e5e3011fc52b761067feae88ef2faed1dd38921eea160
+  md5: 89f633e2fe32f8964414004f4bf69a50
+  depends:
+  - param >=1.7.0
+  - python >=3.8,<3.9.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48367
+  timestamp: 1675450405375
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py38haa95532_1.tar.bz2
+  sha256: c99df0ff588b6cc027003901719fafcca53c7d5982224d10adafb0eba5d62f76
+  md5: ea6a5a355c3e39e2d5e03418cf1c359f
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1902776
+  timestamp: 1684280088005
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py38haa95532_0.tar.bz2
+  sha256: 0338ad6cc3998c5adc325f9df5916a84d9462176c060160b15bf016cd78df4c6
+  md5: 7ac4db0e1a670a061b08208f6e819bb0
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 157552
+  timestamp: 1661452635483
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py38haa95532_0.tar.bz2
+  sha256: 9bf258afe075dd22aa6e33b71b122126eaeb1001906b5df614b2e81e88e17ddf
+  md5: ca4e90d9e382f0033230a67499d51239
+  depends:
+  - python >=3.8,<3.9.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31587
+  timestamp: 1605287884076
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.8.18-h6244533_0.tar.bz2
+  sha256: 91fe00fa9abb019a70c68be5a39887972a77473805abf160be8274ec3e8f5ea8
+  md5: f4f6d4b6bb55b19eda46f2fc79288f10
+  depends:
+  - libffi >=3.4,<3.5
+  - openssl >=1.1.1v,<1.1.2a
+  - sqlite >=3.41.2,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 22819210
+  timestamp: 1694440319269
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py38haa95532_2.tar.bz2
+  sha256: e8c094344f0a47aceb531888edff39c19378e6e48d5d2fcb5b88961de8006ed3
+  md5: cef16f6a3eee24f584b827910705c98f
+  depends:
+  - python >=3.8,<3.9.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 289551
+  timestamp: 1716496055846
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py38haa95532_0.tar.bz2
+  sha256: c3414f6a87ec84473869ac5821a62369f374b1df33def55a6d6487fd863ad56d
+  md5: 7d51837a0deed7e1f8a410a2851ac755
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269239
+  timestamp: 1661376763966
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py38haa95532_0.tar.bz2
+  sha256: c0f8465a6322d76cea2b4e15de63ba737d04e93246b5662d09da5306776f8e5b
+  md5: 2e301dbd230172c15e53749f3369d424
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 15628
+  timestamp: 1683824193853
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py38hd77b12b_0.tar.bz2
+  sha256: cd4788fdafa155d2bb3b7159cc4f031370c9caab7b006b6afab11881f7fa9d3c
+  md5: 83b3e3d6f925636bb2a0be77ae8b9d5c
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 135460
+  timestamp: 1682522629966
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-snappy-0.6.1-py38hd77b12b_0.tar.bz2
+  sha256: 46f80b10a0e3a3fe822aa91cd415de31529bd6551201ea580e08de55463d6f89
+  md5: 65f21ec0a3ea88d9259ec048270c459e
+  depends:
+  - python >=3.8,<3.9.0a0
+  - snappy >=1.1.9,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 34181
+  timestamp: 1670944177415
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py38haa95532_0.tar.bz2
+  sha256: f158ef25e17ac404ec86a1ea70b669b030d6c0de9a0fda3d771e549b1fa4267e
+  md5: 2439ebab6b108f6dff71470d0ab8c155
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 265962
+  timestamp: 1713974451306
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py38haa95532_0.tar.bz2
+  sha256: a0fe49498b6c35394183fb24e8139b7d6f9deb2dc9320d26d437e89217ab0fa7
+  md5: 06591ea102b7a839361a515a29be6949
+  depends:
+  - param
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 61364
+  timestamp: 1711137144810
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py38h2bbff1b_0.tar.bz2
+  sha256: d240e28ed9a4811cfc05231c91bf802759fcf62b3e7f204301033c957a6fd4fe
+  md5: 5ed775395d75942dce0868bfcabeb62f
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13563755
+  timestamp: 1669938230510
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py38h5da7b33_0.tar.bz2
+  sha256: 0837ed20156196759f729786bf50d71f17d04259e4eba815015567879659ea54
+  md5: e7ba4d7e36f0992af849c36116e4a6e9
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 239545
+  timestamp: 1677611005756
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.2-py38h827c3e9_0.tar.bz2
+  sha256: 0a9e19302123ae09e99c03b98ecb9a462d7b4d0a18ab91d888e75a76bb357237
+  md5: 5410f7fc0a7dfa882954e7b73e9f2b6e
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 179036
+  timestamp: 1728658282508
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py38h2bbff1b_0.tar.bz2
+  sha256: cadac9c8b38ed3df5c6ceb3706c4b4b4fc8d6e8c4d54627fa2938532e91c1186
+  md5: 30258aac1269a14121b87c672af7cea8
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 474436
+  timestamp: 1709318658150
+- conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+  sha256: 720f3dd1f933d035b1393951ffd1b6437fc5e19b1999e74096044514a46053fb
+  md5: add2dfb15b518144663fc3b897d66da7
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  size: 493391
+  timestamp: 1652432364793
+- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py38haa95532_0.tar.bz2
+  sha256: f4519afbba3dc9cd3c7764b4b89000a5df6ed758e016bede3d11a00d4c3d0655
+  md5: 802a7a1a9471a1f27bede2c9482be4c7
+  depends:
+  - attrs >=22.2.0
+  - python >=3.8,<3.9.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 58577
+  timestamp: 1699012264752
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py38haa95532_0.tar.bz2
+  sha256: 35f31650b4b53c381f16a7d59146198bb0db1a8b7b805e168f76e6de3975bc69
+  md5: 6d7108711a7ef5c0f4ae3b3553439ca6
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.8,<3.9.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 98240
+  timestamp: 1721411091470
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-toolbelt-1.0.0-py38haa95532_0.tar.bz2
+  sha256: 3f38c36947d874b4f3334348c3453846d19cfabd4718079417fc435128bac73c
+  md5: bee36c697375e9b8b0ed9d4139c8d1ed
+  depends:
+  - python >=3.8,<3.9.0a0
+  - requests >=2.0.1,<3.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 69084
+  timestamp: 1690874189975
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py38haa95532_0.tar.bz2
+  sha256: 53437dd569219b71d83e3799ebd2e5514e940f50d6fb908ab3966427e8ddf16b
+  md5: e456bebb8b2a3779967277571db652fb
+  depends:
+  - python >=3.8,<3.9.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9290
+  timestamp: 1683077294639
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py38haa95532_0.tar.bz2
+  sha256: d2b272af194723b9d2e30ffd94f630798a66796878710bc8ba337da81b306055
+  md5: 173612d663a52a177d44462181a35899
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 9691
+  timestamp: 1683059225771
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py38h062c2fa_0.tar.bz2
+  sha256: 620dd3556af2db0bfbf9c21667f106b57e9f16e36b4903b0afdd822a4f76de9b
+  md5: 84dba3563407bc92522ad7d008a82ac1
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 215611
+  timestamp: 1698947727458
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ruamel.yaml.clib-0.2.8-py38h827c3e9_0.tar.bz2
+  sha256: 30e74f49beebd5a3d54f00c7c0ce560b9194d35b9ec3992c5bc5396878c728cb
+  md5: d318bc73b1041d2e15ac6cf4fd568277
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 135777
+  timestamp: 1727769944390
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ruamel_yaml-0.17.21-py38h2bbff1b_0.tar.bz2
+  sha256: 9c1d6c0365f2ebbad98225b08d5fd30e4940169e15d1431b5189fbd0af15561b
+  md5: 1e3c0468635d9afcd6ecac24d5800a26
+  depends:
+  - python >=3.8,<3.9.0a0
+  - ruamel.yaml.clib >=0.2.6
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 174039
+  timestamp: 1667490202777
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.10.1-py38hdcfc7df_1.tar.bz2
+  sha256: bf0f58b61e8e18aa58f5bdf025e8ee649c778b8be27c5f5ddff495add793ad93
+  md5: 09fa3db77bb4c0e9d4349268215dd515
+  depends:
+  - blas 1.0 mkl
+  - icc_rt >=2022.1.0
+  - intel-openmp >=2023.1.0,<2024.0a0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.19.5,<1.27.0
+  - pooch
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22338144
+  timestamp: 1683289522517
+- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py38haa95532_0.tar.bz2
+  sha256: 2c2d4128023c4537559caa7c5ddd53cf773c6a914b4f3354db2899d205175430
+  md5: 6a95122f18e9da1d1a5670319d00c098
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 83165
+  timestamp: 1699371260823
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-60.9.3-py38haa95532_0.tar.bz2
+  sha256: 36bb8e035e4d832ac9bea36f80cb533f35962c690e0941fd0f2d4d32db7cb061
+  md5: d3ad664c69463374f13539d41222cc96
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 1205019
+  timestamp: 1685710613748
+- conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
+  sha256: 5e5f855a70cf4c9dc6f2ac8d9fa51a3f095bf4db8e2ee3ff213ef5432556d7cd
+  md5: 9c1f7331a4116e5c27d8af7453f8ee47
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 119274
+  timestamp: 1723557526373
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py38haa95532_0.tar.bz2
+  sha256: 728311a6829f37c3a02e82cef0cb6fa0afe9cc87a25a4dda903f9532c9252555
+  md5: 783fa55ced605a2ae1bb9204fb8b7b37
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17519
+  timestamp: 1705431546158
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py38haa95532_0.tar.bz2
+  sha256: 3a2bdd00f7f0fa19d73a8875e9f004cae98d3fa27f36c59cd4567f3282944e11
+  md5: ccdd22fbfe632c7ffea52096483b2165
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 67208
+  timestamp: 1696347669660
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+  sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
+  md5: 833b93a2daade3407898f15588945d83
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1440481
+  timestamp: 1714488344682
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py38haa95532_0.tar.bz2
+  sha256: d14d51a32e509950bb85e78c35dceed18cbeb223ec3e9e224e0d22d65e3461ae
+  md5: 85fd7e0f17c59be2e562bebb896aa5a5
+  depends:
+  - python >=3.8,<3.9.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30613
+  timestamp: 1671751910139
+- conda: https://repo.anaconda.com/pkgs/main/win-64/thrift-0.17.0-py38hd77b12b_0.tar.bz2
+  sha256: 197f94f383678caf1d0e2a0654c9ed7458c83f8cc5815e6290d81e1cc065a608
+  md5: 60bb17422fd2875317b1291962bca208
+  depends:
+  - python >=3.8,<3.9.0a0
+  - six >=1.7.2
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 123880
+  timestamp: 1666297055932
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py38haa95532_0.tar.bz2
+  sha256: 4be11dd7c28be1483dc46313028839da5aa8a59b0626ee20608096787d361468
+  md5: e32a18bc0812d900753ca292ac13aa9a
+  depends:
+  - python >=3.8,<3.9.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39998
+  timestamp: 1668169047244
+- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py38haa95532_0.tar.bz2
+  sha256: 8d7efb76d1afa3e7e4491e8496f46257bbee2eaf233549ca841f1bcbe4194489
+  md5: e085f8c809e8c4296756e411b7ffa598
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102335
+  timestamp: 1667464250061
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.1-py38h827c3e9_0.tar.bz2
+  sha256: 5e9b1f8b60181248cb26c42e5c83ee51e3556ff9df8f7d5e9922bc7289093f5b
+  md5: 2e39dc0430d827b40520a34b592a0672
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 706661
+  timestamp: 1718740573799
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.5-py38h9909e9c_0.tar.bz2
+  sha256: 022915ff2dfd53e2fc3735921eece63b1347803ba3e043ee7831524b824ffec8
+  md5: 135ac2b699e79cfff0cf5c33b510ea84
+  depends:
+  - colorama
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 158027
+  timestamp: 1724854216605
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py38haa95532_0.tar.bz2
+  sha256: a41fa042ae4366f1f82368825c77e0d3b08c6b8dcb49cccf6e5673c2c771f855
+  md5: 50c1dee824e554ce4fe9b1d481528b70
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 166617
+  timestamp: 1718227282769
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py38haa95532_0.tar.bz2
+  sha256: a8362181d2dbc1dcfe0b75396ff3c1a66c8327d9ad4f4cad4c55d4bb1f4b8069
+  md5: 76cf1c2b7dafa987beb53fcbe362dac1
+  depends:
+  - python >=3.8,<3.9.0a0
+  - typing_extensions 4.11.0 py38haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9653
+  timestamp: 1715269022029
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py38haa95532_0.tar.bz2
+  sha256: c3d7e68393ea6ee3d038fe47db1a488294442f7c5124d26cb4df740aed4d56f9
+  md5: 119df8c6748ebedc816518bf34ff1abe
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 60977
+  timestamp: 1715269013136
+- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py38h2bbff1b_0.tar.bz2
+  sha256: f88c0257dd2545da3579db91e8d4b3652cea5b283e08cde45a88956d2d7224be
+  md5: 7f43d8d3be634fb410ce3d3b2638bcba
+  depends:
+  - python >=3.8,<3.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 513340
+  timestamp: 1713213091943
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uriparser-0.9.7-h2bbff1b_0.tar.bz2
+  sha256: f88e04209064e9a72fccc9284271405d9548106c2bf302e24fa1e8e8bb36a127
+  md5: 8845191f3242c429e10220e3ed9ee73c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48486
+  timestamp: 1692187056029
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.3-py38haa95532_0.tar.bz2
+  sha256: 498f32de934c366c83797e62db791f557eb40eb55b8d252343502146473e9831
+  md5: 14823eff3cdd21b5786b1b0baa3d10fd
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.8,<3.9.0a0
+  constrains:
+  - selenium >=4.4.3
+  - zstandard >=0.18.0
+  - h2 >=4,<5
+  - requests >=2.26.0
+  license: MIT
+  license_family: MIT
+  size: 171470
+  timestamp: 1727770062754
+- conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+  sha256: 2ef16d0252e04063d44d0683831d55b485f713fe5af2c2efd61753fb4f27d7e4
+  md5: 256ab1d5dce70111a1f4807a5a9fc322
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 100982
+  timestamp: 1706894771410
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.40-h2eaa2aa_1.tar.bz2
+  sha256: 5bbfaacd95bb901683d6d2e7a1ee10f67172acc1e012f73f80bfef5237ae3ae4
+  md5: f37ef4381071123903074612dad356f4
+  depends:
+  - vs2015_runtime >=14.40.33807
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9122
+  timestamp: 1726064402583
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.40.33807-h98bb1dd_1.tar.bz2
+  sha256: d82b5b2b1a9a1b37da109039274c125355ce478a199c07c7826ac0fdc2178491
+  md5: a0f93c06400da31b9e6e0538eab91216
+  size: 2611238
+  timestamp: 1726064391949
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py38_1.tar.bz2
+  sha256: 40b0596a8728dd040d7afef235a73b20909f92fbe9a9ef202f3e5256d047bbdc
+  md5: 492eeefe2b9f3274156a1b37699ea90e
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20563
+  timestamp: 1573199884688
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py38haa95532_0.tar.bz2
+  sha256: 7ee947d6276b7806b642180f0e120bcb7ef712943201b9484b6c5c99af74380a
+  md5: e7488420416136007b3cbdcef4d5c224
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 117163
+  timestamp: 1715878730190
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.44.0-py38haa95532_0.tar.bz2
+  sha256: d599c12d4d6fafe21ec915e19acfba2ba8a1f4636dd3cc94cad30555eadc12d7
+  md5: fbea4f9065c4c82926cb066b52fdea01
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 135624
+  timestamp: 1726165065426
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py38haa95532_0.tar.bz2
+  sha256: e07f40fc2c8751784dba016e68ef289ae997bf018a773e71d83b23e1e30a55f3
+  md5: 749ad2e1134684ca10f25aa30a35864b
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: PUBLIC-DOMAIN
+  size: 34107
+  timestamp: 1605306214957
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2022.11.0-py38haa95532_0.tar.bz2
+  sha256: bbd799a929cfc29f95c6fc46c08d1939c87edc8fa0e96ba89ce44ce65f95479e
+  md5: 4fcbc4128904506d54b173b01c6f7659
+  depends:
+  - numpy >=1.20
+  - packaging >=21.0
+  - pandas >=1.3
+  - python >=3.8,<3.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1727670
+  timestamp: 1668777347091
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py38haa95532_1.tar.bz2
+  sha256: 79a0c08ff87f51a742b9a0cb668482035a5b8b94bb9a651cd0242da916a23125
+  md5: a8b49e46e8f6ccb6fc3e2e17a41764a6
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48792
+  timestamp: 1675159225274
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+  sha256: 344a5276a9928638dcde054dfe4e87c8cb40bd2d4d356378b9ab2f863ca62e4b
+  md5: fe471fd8b5a3d77be6fa5dbf9b99dafb
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 1432281
+  timestamp: 1714515119689
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+  sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
+  md5: e5aed81295b61b6d1eb62830799a0297
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 9125184
+  timestamp: 1705602328351
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py38haa95532_0.tar.bz2
+  sha256: 02aeb80c081705443df2555d6025dd2b49b01ceef49515998a18fd83cc5eaf0a
+  md5: 6bbba9816851fd3ca6bcbb21528c59bd
+  depends:
+  - heapdict
+  - python >=3.8,<3.9.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 76700
+  timestamp: 1695833271895
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.20.2-py38haa95532_0.tar.bz2
+  sha256: 461dabc31cf1f9c955265ca732b4c49cde49f5d68ba69f552afd6b7cac8ebab0
+  md5: c12ee2fe3b832b11f929676873ac8530
+  depends:
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 25916
+  timestamp: 1729012487676
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+  sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
+  md5: f295b54ab59f5b8658e2a322ac6aa721
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 162161
+  timestamp: 1714514792081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstandard-0.23.0-py38h4fc1ca9_0.tar.bz2
+  sha256: e1813703d909837e47350ecf070eb8e2e4c238026028f4bbd8ec1550a7aaecac
+  md5: 11594a3e51725ac2c7903e112b674582
+  depends:
+  - cffi >=1.11
+  - python >=3.8,<3.9.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 380046
+  timestamp: 1728569372889
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
+  sha256: 1f68cd378c6cdec34a5a3a21c56c9b8422b0f037b868b3db72065c0a2ca27921
+  md5: d455a04486eddfb94c280974c0c33ae3
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1971698
+  timestamp: 1728487049972

--- a/datashader_dashboard/pixi.toml
+++ b/datashader_dashboard/pixi.toml
@@ -1,0 +1,53 @@
+[workspace]
+name = "datashader_dashboard"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2018-11-12"
+maintainers = ["jsignell", "jbednar"]
+categories = ["Geospatial"]
+labels = ["datashader", "panel", "holoviews", "bokeh", "param"]
+description = "Interactive dashboard for making Datashader plots from any dataset that has latitude and longitude"
+
+[dependencies]
+python = "3.8.*"
+notebook = "<7"
+bokeh = "<2.5"
+colorcet = "*"
+datashader = "<0.14"
+fastparquet = "0.5.*"
+holoviews = "<1.15"
+hvplot = "<0.8"
+intake = "<0.7"
+intake-parquet = "<0.3"
+panel = "<0.13"
+param = "<1.12"
+python-snappy = "<0.7"
+anaconda-project = "*"
+numba = "<0.56"
+numpy = ">=1.20,<1.22"
+pyarrow = "<6"
+dask = "<2020"
+xyzservices = "*"
+pip = "*"
+wheel = "*"
+
+[target.osx-64.dependencies]
+libgfortran = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[activation.env]
+DS_DATASET = "nyc_taxi_50k"
+INTAKE_CACHE_DIR = "data"
+
+[tasks]
+dashboard = "panel serve --rest-session-info --session-history -1 datashader_dashboard.ipynb --show"
+census = "anaconda-project prepare --directory ../census\nDS_DATASET=census panel serve datashader_dashboard.ipynb"
+nyc_taxi = "anaconda-project prepare --directory ../nyc_taxi\nDS_DATASET=nyc_taxi panel serve datashader_dashboard.ipynb"
+opensky = "anaconda-project prepare --directory ../opensky\nDS_DATASET=opensky panel serve datashader_dashboard.ipynb"
+osm = "DS_DATASET=osm-1b panel serve datashader_dashboard.ipynb"
+notebook = "jupyter notebook datashader_dashboard.ipynb"
+pre = "anaconda-project prepare --directory nyc_taxi"

--- a/datashader_dashboard/pixi.toml
+++ b/datashader_dashboard/pixi.toml
@@ -44,10 +44,13 @@ DS_DATASET = "nyc_taxi_50k"
 INTAKE_CACHE_DIR = "data"
 
 [tasks]
-dashboard = "panel serve --rest-session-info --session-history -1 datashader_dashboard.ipynb --show"
-census = "anaconda-project prepare --directory ../census\nDS_DATASET=census panel serve datashader_dashboard.ipynb"
-nyc_taxi = "anaconda-project prepare --directory ../nyc_taxi\nDS_DATASET=nyc_taxi panel serve datashader_dashboard.ipynb"
-opensky = "anaconda-project prepare --directory ../opensky\nDS_DATASET=opensky panel serve datashader_dashboard.ipynb"
-osm = "DS_DATASET=osm-1b panel serve datashader_dashboard.ipynb"
-notebook = "jupyter notebook datashader_dashboard.ipynb"
-pre = "anaconda-project prepare --directory nyc_taxi"
+dashboard = { cmd = "panel serve --rest-session-info --session-history -1 datashader_dashboard.ipynb --show" }
+notebook = { cmd = "jupyter notebook datashader_dashboard.ipynb" }
+census = { cmd = "panel serve datashader_dashboard.ipynb", env = { DS_DATASET = "census" }, depends-on = ["download-census"] }
+nyc_taxi = { cmd = "panel serve datashader_dashboard.ipynb", env = { DS_DATASET = "nyc_taxi" }, depends-on = ["download-nyc_taxi"] }
+opensky = { cmd = "panel serve datashader_dashboard.ipynb", env = { DS_DATASET = "opensky" }, depends-on = ["download-opensky"] }
+osm = { cmd = "panel serve datashader_dashboard.ipynb", env = { DS_DATASET = "osm-1b" } }
+pre = { depends-on = ["download-nyc_taxi"] }
+download-census = { cmd = "pixi run --manifest-path pixi.toml download", cwd = "../census" }
+download-nyc_taxi = { cmd = "pixi run --manifest-path pixi.toml download", cwd = "../nyc_taxi" }
+download-opensky = { cmd = "pixi run --manifest-path pixi.toml download", cwd = "../opensky" }

--- a/datashader_dashboard/pixi.toml
+++ b/datashader_dashboard/pixi.toml
@@ -30,14 +30,14 @@ numpy = ">=1.20,<1.22"
 pyarrow = "<6"
 dask = "<2020"
 xyzservices = "*"
-pip = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [activation.env]
 DS_DATASET = "nyc_taxi_50k"

--- a/datashader_dashboard/pixi.toml
+++ b/datashader_dashboard/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "datashader_dashboard"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/euler/pixi.lock
+++ b/euler/pixi.lock
@@ -7,631 +7,631 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py310h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py310h9102076_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py310h7f8727e_1002.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py310hd667e15_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py310h130f0dd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py310h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py310h2f386ee_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py310h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py310h1f438cf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py310h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py310ha18d171_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py310h7f8727e_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py310h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py310hd6ae3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py310h00e6091_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.7.3-py310hd732450_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py310hfa59a62_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py310h9585f30_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py310h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py310h22f2fdc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py310h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py310h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.10.4-h12debd9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py310h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py310h295c915_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py310h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py310h2f386ee_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py310h06a4308_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py310h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-2.4.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.4-py310h9102076_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotlipy-0.7.0-py310h7f8727e_1002.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.0-py310hd667e15_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py310h130f0dd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.5.1-py310h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.17.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.19.2-py310h2f386ee_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.2.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.2-py310h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lxml-4.8.0-py310h1f438cf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py310h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.5.1-py310ha18d171_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py310h7f8727e_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py310h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.1-py310hd6ae3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.2-py310h00e6091_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.7.3-py310hd732450_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.22.3-py310hfa59a62_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.22.3-py310h9585f30_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-1.4.2-py310h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-0.14.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-9.0.1-py310h22f2fdc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.8.0-py310h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py310h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.10.4-h12debd9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0-py310h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-22.3.0-py310h295c915_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.1-py310h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py310h2f386ee_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.16-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py310h06a4308_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py310hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py310hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py310h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py310h4e76f89_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py310he9d5cce_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py310h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py310haf03e11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py310h30e54ef_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py310hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.17.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py310h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py310hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py310hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py310h946e0e5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py310hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py310hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py310hb47e01b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py310hca72f7f_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py310h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py310h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py310ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py310hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py310h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py310h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py310ha186be2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py310h3ea8b11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py310h7d39338_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py310hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py310hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py310hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.10.13-h5ee71fb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py310h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py310he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py310hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py310h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py310h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py310hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py310hecd8cb5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py310hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py310hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py310hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-3.2.1-py310h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py310h4e76f89_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py310he9d5cce_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py310h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py310haf03e11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py310h30e54ef_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py310hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.17.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py310h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py310hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py310hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py310h946e0e5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py310hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py310hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py310hb47e01b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py310hca72f7f_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py310h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py310h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py310ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py310hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py310h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.0-py310h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.0-py310ha186be2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-2.1.1-py310h3ea8b11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-1.2.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-1.13.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py310h7d39338_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py310hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py310hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py310hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.10.13-h5ee71fb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py310h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py310he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py310hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py310h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py310h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py310hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py310hecd8cb5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py310hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py310hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py310h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py310h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py310h96f19d2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py310hc377ac9_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py310h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py310h525c30c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py310hd4332d6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py310h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.17.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py310h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py310h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py310h50ffb84_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py310h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py310h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py310h1a28f6b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py310hecc3335_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py310h3b2db8e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py310ha9811e2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py310h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py310h3b245a6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py310h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py310h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.10.13-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py310h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py310hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py310h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py310h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py310hca03da5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py310hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py310h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.2.1-py310h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py310h96f19d2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py310hc377ac9_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py310h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py310h525c30c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py310hd4332d6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py310h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.17.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py310h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py310h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py310h50ffb84_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py310h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py310h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py310h1a28f6b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py310hecc3335_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.0-py310h3b2db8e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.0-py310ha9811e2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.1.1-py310h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-1.2.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-1.13.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py310h3b245a6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py310h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py310h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.10.13-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py310h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py310hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py310h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py310h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py310hca03da5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py310h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py310h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py310h9128911_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py310hd77b12b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py310h2bbff1b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py310h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py310h89fc84f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py310hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.17.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py310h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py310hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py310h09808a7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py310h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py310h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py310h2bbff1b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py310h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py310h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py310h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py310h2cd9be0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py310h055cbcc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py310h65a83cf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py310h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py310h045eedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py310h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py310h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.10.13-he1021f5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py310h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py310h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py310h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py310hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py310h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py310h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py310haa95532_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py310h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-3.2.1-py310h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py310h9128911_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py310hd77b12b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py310h2bbff1b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py310h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py310h89fc84f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py310hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.17.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.4-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py310h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py310hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py310h09808a7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py310h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py310h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py310h2bbff1b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py310h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py310h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py310h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py310h2cd9be0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.26.0-py310h055cbcc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.0-py310h65a83cf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-2.1.1-py310h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-1.2.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-1.13.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py310h045eedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-23.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py310h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py310h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.10.13-he1021f5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py310h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py310h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py310h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py310hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py310h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py310h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py310haa95532_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py310h06a4308_0.tar.bz2
   sha256: 1b165b1adae42121fc400da4825e3071cc8b257f4070aefe0bf4a5e8decf5932
   md5: 113dcf34ca0d120a07b96997e221c3e2
   depends:
@@ -644,7 +644,7 @@ packages:
   license_family: MIT
   size: 165033
   timestamp: 1644481743158
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py310h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py310h7f8727e_0.tar.bz2
   sha256: f4d21ee48ca45cc62ae063f6de973c5599505d628e7675e512eb86f73f851410
   md5: 96b990f76f2e61e914f5ad1958f6e7bd
   depends:
@@ -655,7 +655,7 @@ packages:
   license_family: MIT
   size: 85215
   timestamp: 1644553401362
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py310h06a4308_0.tar.bz2
   sha256: f60c5386ecc0cb0c21dd5bc93c5c30ca76ddf08270271298346c8caeadceb188
   md5: 94e998805409e8ef3347727446f28c63
   depends:
@@ -664,7 +664,7 @@ packages:
   license_family: MIT
   size: 133035
   timestamp: 1695718011394
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py310h06a4308_0.tar.bz2
   sha256: d66cc22aa4d912b413bebff069c9b297bac6796a2b9943072906c30322f84330
   md5: 6e1e2d8b3f95b30317cea5cc6ac9cf44
   depends:
@@ -674,12 +674,12 @@ packages:
   license_family: MIT
   size: 209536
   timestamp: 1681493093356
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-2.4.3-py310h06a4308_0.tar.bz2
   sha256: 7933a04f65cd54c879f49409b89fa55906f9ac3cf5919ce7ef9e216960e727dc
   md5: 88353150bcecb679f62737785330e203
   depends:
@@ -695,7 +695,7 @@ packages:
   license_family: BSD
   size: 14453101
   timestamp: 1658136717996
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py310h9102076_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.4-py310h9102076_0.tar.bz2
   sha256: df2d57eb8f638e2dff6295dfdade084b9c2521d27cb0dcec5e0b1f69eb2a35b4
   md5: 7321ee7373824f289d534d3a9635aeba
   depends:
@@ -706,7 +706,7 @@ packages:
   license_family: BSD
   size: 345385
   timestamp: 1648010842036
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
   sha256: 0bbcb6f78eac530c6a084459ffab3238647b266d0c74d695e6e6387dd119cc67
   md5: bdc971e2a9affb5125b68ad708172dab
   depends:
@@ -715,7 +715,7 @@ packages:
   license: MIT
   size: 411301
   timestamp: 1602517685375
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py310h7f8727e_1002.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotlipy-0.7.0-py310h7f8727e_1002.tar.bz2
   sha256: 1142d98a4a741c3a981a077792c898235662d7e0435219872ceadaf9914ea4f2
   md5: 681b7a6c60515233e7940082b9983832
   depends:
@@ -726,7 +726,7 @@ packages:
   license_family: MIT
   size: 883596
   timestamp: 1640803794269
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
   sha256: 168c2fc4d5899ee70e85fadc998e00827e1b856a6fc4a402ed465cd7c320d19f
   md5: f52e60deb7f4c82821be9a868e889348
   depends:
@@ -735,14 +735,14 @@ packages:
   license_family: BSD
   size: 107105
   timestamp: 1563219611337
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
   sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
   md5: 3ef00f4c5278b688552efc259c463dc8
   license: MPL-2.0
   license_family: Other
   size: 132731
   timestamp: 1694009767372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py310h06a4308_0.tar.bz2
   sha256: 138d75d6dedc1e41d6111ac9cf021a4116119d1ee10b23037f031802d332c02f
   md5: 4bfd5bc443cc66da42dacb9ecc7f8f34
   depends:
@@ -751,7 +751,7 @@ packages:
   license_family: Other
   size: 158825
   timestamp: 1690232282667
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py310hd667e15_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.0-py310hd667e15_1.tar.bz2
   sha256: d94845e933aa2794857a2addef91366c0ef67a84433f1e1a26e7ff4fb0a938bd
   md5: 5c83b10bcb81d4179f36368771f0d1fa
   depends:
@@ -763,7 +763,7 @@ packages:
   license_family: MIT
   size: 416321
   timestamp: 1642753394042
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py310h06a4308_0.tar.bz2
   sha256: 42a75e0216721a4a866e7edc3e81870c8cf8e9f8c3f2cace5318a1bc91d93328
   md5: 2e415f3e186472953ca1abdd872ff076
   depends:
@@ -773,7 +773,7 @@ packages:
   license_family: CC
   size: 1947957
   timestamp: 1668084644133
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py310h06a4308_0.tar.bz2
   sha256: 810d05cf52bfc487a64d6c664fc822e10ec307553fe6c0bbc85dbe39487e689f
   md5: ccaf333120348af98f94afdfa8363aac
   depends:
@@ -783,7 +783,7 @@ packages:
   license_family: BSD
   size: 12768
   timestamp: 1671231151980
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py310h130f0dd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py310h130f0dd_0.tar.bz2
   sha256: d2a8f02d97dfaa1759c11ac815223a8c6a2e1108c91f0a0dcb031970040b55e9
   md5: 105134bfa872c5a8617ffe18b361319b
   depends:
@@ -797,7 +797,7 @@ packages:
   license_family: BSD
   size: 2185827
   timestamp: 1694445068014
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py310h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.5.1-py310h295c915_0.tar.bz2
   sha256: 8a4e935d3f3dbe68dd81d084f0ae09f6e1cf22b1ccb2ae7479ccba16307e1157
   md5: aa967d228c67e44ca5c6142535b04c87
   depends:
@@ -808,7 +808,7 @@ packages:
   license_family: MIT
   size: 2108292
   timestamp: 1640789547774
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py310h06a4308_0.tar.bz2
   sha256: 413921f9bdd75ddbf9667fc35d4f7b8ac6ce751ab992297635e0cad2a8a9174e
   md5: 57314b5e1702906d03bfcff4d7eab35a
   depends:
@@ -817,7 +817,7 @@ packages:
   license_family: MIT
   size: 16500
   timestamp: 1649908359372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py310h06a4308_0.tar.bz2
   sha256: cfc573ac839d44c53498b07641283668461cf6d503913ea6eaf38e48b7f8c861
   md5: a74f333ec7df6a6ec4793f890560fbdf
   depends:
@@ -826,7 +826,7 @@ packages:
   license_family: BSD
   size: 26988
   timestamp: 1668714404585
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
   sha256: 8a121233d0b2cbb2463b67e798739ad2946f38933430a6a7fd1197cc6eab1c99
   md5: d2b24736491290a6c6d0138932111150
   depends:
@@ -836,7 +836,7 @@ packages:
   license: GPL-2.0-only and LicenseRef-FreeType
   size: 965280
   timestamp: 1635422707211
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
   sha256: 3c8ece1a7257b1d45f8fa25f46504bb709a1923d7175f2996e891366ec434b9d
   md5: 299bf4271d710651a1d71d3795580c2d
   depends:
@@ -844,7 +844,7 @@ packages:
   license: MIT
   size: 83592
   timestamp: 1603192039050
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.17.1-py310h06a4308_0.tar.bz2
   sha256: 5998a5b93bd6d3be81b8cdd77e16f468de647f928d94412b974b8e10bf23e285
   md5: 9b7c1a117126ce96c31467488ac559a1
   depends:
@@ -861,7 +861,7 @@ packages:
   license_family: BSD
   size: 4521155
   timestamp: 1693378240723
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
   sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
   md5: 9213e0336e3a5216c989cfe52648412e
   depends:
@@ -870,7 +870,7 @@ packages:
   license: MIT
   size: 23805906
   timestamp: 1588026213084
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py310h06a4308_0.tar.bz2
   sha256: e71243f2719dce357ad12b215c23257a3ea353e8fabe954112ca4a204665a5b6
   md5: aaedbfe2ce4396b9ae3598d8b1abb21d
   depends:
@@ -879,7 +879,7 @@ packages:
   license_family: BSD
   size: 115993
   timestamp: 1666125633476
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
   sha256: 1b424413f28b840fc6d4bf467f37e9e405823b1e3b899005df80152d48936d64
   md5: 4aa8bcf74c81cd3600978f791191692a
   constrains:
@@ -888,7 +888,7 @@ packages:
   license_family: Proprietary
   size: 9246735
   timestamp: 1634546760713
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py310h2f386ee_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.19.2-py310h2f386ee_0.tar.bz2
   sha256: 7dd3a2d36e69778e77cbb5bb53bd8cee420f6cef7e5b9e7db5d3eae5ab15e7f9
   md5: c3310faa0f2fabb44a61384e8deee2f7
   depends:
@@ -908,7 +908,7 @@ packages:
   license_family: BSD
   size: 205933
   timestamp: 1671488556575
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py310h06a4308_0.tar.bz2
   sha256: e42ccdf6926cacfe67157d2f1eaf7bbb8f8db5976de6631e4bf95068c094a06b
   md5: 9792abf6fa1ee2aafc8bc295f815eec4
   depends:
@@ -928,7 +928,7 @@ packages:
   license_family: BSD
   size: 1275466
   timestamp: 1694181402009
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py310h06a4308_1.tar.bz2
   sha256: 791097a544c793a7befc7778383c10e534c909adab9a446e38977d98a0fb0bb7
   md5: 304ff041f756d6bac257f77c63a72aff
   depends:
@@ -938,7 +938,7 @@ packages:
   license_family: MIT
   size: 1036683
   timestamp: 1644315282525
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py310h06a4308_0.tar.bz2
   sha256: b9e48b8c30ebc01e30a49ced6ee45bdd89d153f412936db53f80b0d53227861b
   md5: 76227e72320c19ab16d6bda143f12096
   depends:
@@ -948,7 +948,7 @@ packages:
   license_family: BSD
   size: 216531
   timestamp: 1666908186956
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
   sha256: 85348bfb14db4fea84078d703e766a3c978c5a592a06e41266748826dd59d8ae
   md5: 6e1c0fb5260c590f7ef5235cb3d05863
   depends:
@@ -957,7 +957,7 @@ packages:
   license_family: Other
   size: 279884
   timestamp: 1651065953960
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py310h06a4308_0.tar.bz2
   sha256: 76a783faccefbbbfe6b408d2cb3ad4c364a058df6610080d858ef4f0a38f76af
   md5: 871812adc9bb6e34d64620d7b539862b
   depends:
@@ -968,7 +968,7 @@ packages:
   license_family: MIT
   size: 133051
   timestamp: 1676558776772
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.2.2-py310h06a4308_0.tar.bz2
   sha256: 1b898bebca729e6ef210e274706fb8a037baa10f61f3e0d51f970dcd44684e8d
   md5: 9d97708df2ccb59b58082da5bc84c07f
   depends:
@@ -984,7 +984,7 @@ packages:
   license_family: BSD
   size: 193313
   timestamp: 1650623162029
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py310h06a4308_0.tar.bz2
   sha256: 0f122770cc027c9a69678db1067d949c6629e30116acb0b7a3a5b35e2b5d8b06
   md5: b6ee7e9337a0ce9731b54c194ce72d73
   depends:
@@ -995,7 +995,7 @@ packages:
   license_family: BSD
   size: 91958
   timestamp: 1679906681642
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py310h06a4308_0.tar.bz2
   sha256: 8f74a19dd1efe33431c591688de139ef34c3c7cb7f397d67a835ea7ab71807c1
   md5: ad34dede640c1068b2df718e9eb56e7a
   depends:
@@ -1019,7 +1019,7 @@ packages:
   license_family: BSD
   size: 413980
   timestamp: 1671707770227
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py310h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.2-py310h295c915_0.tar.bz2
   sha256: 782f57a582753d54f0a92191a7dd7feeb2092b2b4b4c9d0f2a070cf36d2db676
   md5: dd78f06c5539e774ae2d302f82961709
   depends:
@@ -1030,7 +1030,7 @@ packages:
   license_family: BSD
   size: 1056439
   timestamp: 1653292125501
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -1041,7 +1041,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
   sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
   md5: 9508af80612e4fa1b5d1abb43ca7e63c
   constrains:
@@ -1049,7 +1049,7 @@ packages:
   license: GPL-3.0-only
   size: 749072
   timestamp: 1652971360657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
   sha256: 3b4afe7665dcdb99bd4586a888b85b2e0325f8faecdd31c7780792080ee97872
   md5: 822b5201dde61bc838072dc5b670c88c
   depends:
@@ -1058,7 +1058,7 @@ packages:
   license: Custom
   size: 55183
   timestamp: 1594054267890
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
   sha256: c6fafbe73d2f93b91b6f4b65829f925f52a8f84746a57abd216b39da9ce8c494
   md5: 238f19c803a6ba7bd6dbd6989e03cbf1
   depends:
@@ -1066,7 +1066,7 @@ packages:
   license: GPL
   size: 8496776
   timestamp: 1560112207081
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
   sha256: bc3e6e79c32ff0ecea601aa108ae9cf4068f69703580e40e266ad4bcc52cff54
   md5: 9cb85601944ca7383b1769bff74b94e8
   depends:
@@ -1075,7 +1075,7 @@ packages:
   license: zlib/libpng
   size: 372914
   timestamp: 1556041895170
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -1083,13 +1083,13 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
   sha256: 43b0bd205f539583c088feb5b8d77b60c83d1df80c2a93dac9f2a1127001b2cf
   md5: 53fa39fdae936e9d07c4b2f5ef361993
   license: GPL3 with runtime exception
   size: 4246257
   timestamp: 1560112223556
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
   sha256: 711ea05b4c35bdafc762a172b01db896b17942f474c2b1a519f91370964bf9bc
   md5: b25d56d33596623a6a4a9d9baaa4f602
   depends:
@@ -1103,7 +1103,7 @@ packages:
   license: HPND
   size: 592974
   timestamp: 1653047881023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
   sha256: 4e1dce80f23551a69761ad48b2372e35f58292ec9cc0ce061312330366a1a223
   md5: fda36b99463bad87974196da2d5bed08
   depends:
@@ -1111,7 +1111,7 @@ packages:
   license: BSD 3-Clause
   size: 18725
   timestamp: 1633507857274
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
   sha256: 146dbb1e4dbccdd57819e5102a8ca00970b8e33d6c6180e8007db89b184da569
   md5: c566a384259c1d2769852c3bddd81a67
   depends:
@@ -1125,7 +1125,7 @@ packages:
   license_family: BSD
   size: 90150
   timestamp: 1645441199289
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
   sha256: cffb5a063111f7a99a99c74770b23db5dde52325e25a7a46d1903d5ff4a82c88
   md5: eeb1bd66f28bed1956ab989d6eff7ae5
   depends:
@@ -1136,7 +1136,7 @@ packages:
   license_family: BSD
   size: 889956
   timestamp: 1645089138421
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
   sha256: 71f6c4a97014d745c58df52b4dd60ddd75a8508d54fe5b97f42bd1f31cb1c067
   md5: 686e77514ec9f1ef0a6feed374f14d37
   depends:
@@ -1148,7 +1148,7 @@ packages:
   license_family: MIT
   size: 789469
   timestamp: 1653546418059
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
   sha256: ea3355a67c5173f3944f09861043ca66eb7dbeff8f385d13528b3aabc0801d0c
   md5: 66e2aa12181bb2911485bdbe125d24c5
   depends:
@@ -1158,7 +1158,7 @@ packages:
   license: MIT
   size: 584199
   timestamp: 1654075843119
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py310h1f438cf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lxml-4.8.0-py310h1f438cf_0.tar.bz2
   sha256: 4772edafba1c0cdc703ae02a3f2f37299b99fefe2dcd135e329df4ceeb2184e4
   md5: 272fd5ca6590d8388145f32d1a3df749
   depends:
@@ -1170,7 +1170,7 @@ packages:
   license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
   size: 5977342
   timestamp: 1646642809299
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
   sha256: 2c6a5dda7c510a961bc78e31d4232be5e8e0760c93454f5fd200c379355e0f5e
   md5: f35d4bf2fbb39e334992f6dd39f8721e
   depends:
@@ -1180,7 +1180,7 @@ packages:
   license_family: BSD
   size: 220865
   timestamp: 1627657046002
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py310h06a4308_0.tar.bz2
   sha256: 93b9aa3ffe66b9ea121fcb1a32a2502006df7073fa29a00ccc00b185b00721ce
   md5: 37edf1dc070689d9f64021285157aa25
   depends:
@@ -1189,7 +1189,7 @@ packages:
   license_family: BSD
   size: 122987
   timestamp: 1671541964893
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py310h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py310h7f8727e_0.tar.bz2
   sha256: efd169bd41fbc65ffd85725f6a76db92a343085108cc43b9e875c8d2783644b3
   md5: d30b31c701efc1ab22fd8f7a1e489978
   depends:
@@ -1201,7 +1201,7 @@ packages:
   license_family: BSD
   size: 37487
   timestamp: 1654598030197
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py310ha18d171_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.5.1-py310ha18d171_1.tar.bz2
   sha256: 27423a429435c9698361c0fad4e09a081e79a10b0dbee172b6694ff75e4bbd7c
   md5: 06666f989a2eea665569e9d83774f6f7
   depends:
@@ -1223,7 +1223,7 @@ packages:
   license_family: PSF
   size: 7760687
   timestamp: 1647441945703
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py310h06a4308_0.tar.bz2
   sha256: be8075a8d70b0da67859d63016219e3dd1bc84a1b484abcbd8b95eff52884d88
   md5: 6336be55da6cebfaf1cbbdc573524fc1
   depends:
@@ -1233,7 +1233,7 @@ packages:
   license_family: BSD
   size: 16451
   timestamp: 1662014606193
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py310h7f8727e_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py310h7f8727e_1000.tar.bz2
   sha256: 2074ac064fd4472eef8858d01cbf8475e775503f6b10803b2882c7d77fa394b9
   md5: 33fe473ae7a1202e28c9143014029f62
   depends:
@@ -1243,7 +1243,7 @@ packages:
   license_family: BSD
   size: 55705
   timestamp: 1640791663692
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
   sha256: 7c4ded8b2ef036839f988560848d2c32e1aa4627fd37a32710e42c39f5c61ac2
   md5: bd20f4410b81f327e35ffa0657961146
   depends:
@@ -1254,7 +1254,7 @@ packages:
   license_family: Proprietary
   size: 229783051
   timestamp: 1634547157986
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py310h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py310h7f8727e_0.tar.bz2
   sha256: 6704d413c29ff9976ad9f08373806c21ef2444ce072a67663023a0d87d3de13f
   md5: 83252b73851c784755a30c4932db6377
   depends:
@@ -1266,7 +1266,7 @@ packages:
   license_family: BSD
   size: 217747
   timestamp: 1641844379720
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py310hd6ae3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.1-py310hd6ae3a3_0.tar.bz2
   sha256: 546faf25232afb3cf37280589e1f819a5aca6e1aeaed96d5eb9a3a1ddf369a45
   md5: 899b76e4629a62b66a7fee96ca02a487
   depends:
@@ -1280,7 +1280,7 @@ packages:
   license: BSD 3-Clause
   size: 713451
   timestamp: 1641843696839
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py310h00e6091_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.2-py310h00e6091_0.tar.bz2
   sha256: 8a0e862e81fd6dd43d5c4f683f50ba06d2a8a58686640b914104fe68dd84fc6b
   md5: 4d23da9a63b3973bff5e8e9b9651c70d
   depends:
@@ -1294,7 +1294,7 @@ packages:
   license: BSD-3-Clause
   size: 1269509
   timestamp: 1641843589171
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py310h06a4308_0.tar.bz2
   sha256: 5b9f37faeaf52cd23fc141e5f1a049cf3dcedf25c76dedf3532cde2f8cd25821
   md5: 7a7a4eeed6ac4bc307b911271049b6ff
   depends:
@@ -1320,7 +1320,7 @@ packages:
   license_family: BSD
   size: 8253050
   timestamp: 1681756239192
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py310h06a4308_0.tar.bz2
   sha256: e98c9c94fbc68a28dff1d259f5e5a12b181644ed0461dd8939076830d4caa87e
   md5: dbb43e77b5e495a1bd256459f9dd2d76
   depends:
@@ -1333,7 +1333,7 @@ packages:
   license_family: BSD
   size: 99326
   timestamp: 1650290293630
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py310h06a4308_0.tar.bz2
   sha256: 4ebad67463b41dfcde529483f1492a7e06c02bdee3157bc7e71060a8790ae5e0
   md5: a6ccc2e18be71a21400c65170c469a08
   depends:
@@ -1361,7 +1361,7 @@ packages:
   license_family: BSD
   size: 571994
   timestamp: 1668450742267
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py310h06a4308_0.tar.bz2
   sha256: 5c1ca15ce50d3a917f28b91b5c8269f5ef669eef183cd664c34e1a03644da6e9
   md5: 3cf6f2cdd2bd9bc97c41407ca6db2db3
   depends:
@@ -1374,7 +1374,7 @@ packages:
   license_family: BSD
   size: 147752
   timestamp: 1694616791091
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
   sha256: 0807371380965e421cb5f3f2a30d790fd5c41db11dbb6d318e14294c3b1741ed
   md5: fca4bd4e3891aebf4fd7daf9b6d0ccfa
   depends:
@@ -1382,7 +1382,7 @@ packages:
   license: Free software (MIT-like)
   size: 1083412
   timestamp: 1636570020698
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py310h06a4308_0.tar.bz2
   sha256: 284c8c75d3c557d80d81d7861582218d9822794f24aa3ffaa1a4b6b87e141cae
   md5: 85a509faa4a3c9f1b3a3df32bab735e1
   depends:
@@ -1391,7 +1391,7 @@ packages:
   license_family: BSD
   size: 13184
   timestamp: 1672387223720
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py310h06a4308_1.tar.bz2
   sha256: 812032fa5ade7c5eb9d0e44767949bbd2a1a42824c7aa084ed77e4852b73109c
   md5: db64e78374173c35f054ce9c40c35a9e
   depends:
@@ -1416,7 +1416,7 @@ packages:
   license_family: BSD
   size: 598038
   timestamp: 1690984876373
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py310h06a4308_0.tar.bz2
   sha256: 048da58667248b6ccc7f4d9977466081e8bbf7f831abe9a922e2fe9740f8d1e3
   md5: 133b837755ea8399962afb015afb561f
   depends:
@@ -1426,7 +1426,7 @@ packages:
   license_family: BSD
   size: 21992
   timestamp: 1668160675427
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.7.3-py310hd732450_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.7.3-py310hd732450_1.tar.bz2
   sha256: 9b1a3e57ea29f06538e8d284a398ef9b81b416ab84166e066256e77fbedd0c4e
   md5: 15601802201565b422c212a6f1ee79e5
   depends:
@@ -1441,7 +1441,7 @@ packages:
   license: MIT
   size: 453854
   timestamp: 1640792037686
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py310hfa59a62_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.22.3-py310hfa59a62_0.tar.bz2
   sha256: 0f0090d4b68693b026e33e1d32bb5dc12becf89093d6fc5089eae40e1f2797eb
   md5: 7ca0065abe7f21dda202e48001dc97be
   depends:
@@ -1457,7 +1457,7 @@ packages:
   license: BSD-3-Clause
   size: 9998
   timestamp: 1652802638914
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py310h9585f30_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.22.3-py310h9585f30_0.tar.bz2
   sha256: 735d104050e9b2ca083c51a2fbbac025fd79cf1e0def76c73f9e90792a2ef8d4
   md5: 9d47c84ae5205503a3b4b6c01dd8003f
   depends:
@@ -1472,7 +1472,7 @@ packages:
   license: BSD-3-Clause
   size: 16444261
   timestamp: 1652802619412
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
   sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
   md5: 5ad4571eba2479f77a9f849a6ae7724c
   depends:
@@ -1482,7 +1482,7 @@ packages:
   license_family: Apache
   size: 3998613
   timestamp: 1694465071784
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py310h06a4308_0.tar.bz2
   sha256: bf13f5c15c9ebba82cbc6dff583f8f87600e81bfebae36999aaf0d17a9b5bae9
   md5: 6ec943237961f65bfe1678776460d76f
   depends:
@@ -1491,7 +1491,7 @@ packages:
   license_family: Apache
   size: 73334
   timestamp: 1693575207627
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py310h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-1.4.2-py310h295c915_0.tar.bz2
   sha256: 8b0a47627fdc2fd665e861a23ecd1b1f2abfde4fcfc17a0239c264e3da477946
   md5: 721ffb229e89749055bb7e11df71f93a
   depends:
@@ -1507,7 +1507,7 @@ packages:
   license_family: BSD
   size: 35190591
   timestamp: 1650622912131
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-0.14.3-py310h06a4308_0.tar.bz2
   sha256: f0736d7b759129952e028fd791b9c662e37f034cfbfd321103197cf74bc771d4
   md5: 38d315540dd820d0c5982c3491182d2e
   depends:
@@ -1528,7 +1528,7 @@ packages:
   license_family: BSD
   size: 14736179
   timestamp: 1676380048816
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py310h06a4308_0.tar.bz2
   sha256: 4f7b793253454afb7a0834872d2f47381172bc1d879c581a4d80c12427ee0883
   md5: ba2287f1560613eeb38bcccccff8cc0c
   depends:
@@ -1537,7 +1537,7 @@ packages:
   license_family: BSD
   size: 143006
   timestamp: 1684915415304
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py310h22f2fdc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-9.0.1-py310h22f2fdc_0.tar.bz2
   sha256: ee09fb4a72b37685c9c4e16eda990f402e52878d54c24a6160d0c6a6ea8528ac
   md5: d2c2bc0c866b0605b74f2a9977d0f70a
   depends:
@@ -1556,7 +1556,7 @@ packages:
   license_family: Other
   size: 1368886
   timestamp: 1646325112795
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py310h06a4308_0.tar.bz2
   sha256: 5f010145b4cba3c102d03ea4135abf773b4547f2a62d689d005498466e55d35c
   md5: ff1a8e92055b4aa68ef2234c3677f6ea
   depends:
@@ -1567,7 +1567,7 @@ packages:
   license_family: MIT
   size: 2760212
   timestamp: 1697548855340
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py310h06a4308_0.tar.bz2
   sha256: 95ee7eb5dc731152d97631e2c59572b4838b5cf96f0c7fabb7eb0258590e8267
   md5: 93b487d749f5b5c021ec09b98b7aa5ad
   depends:
@@ -1576,7 +1576,7 @@ packages:
   license_family: MIT
   size: 32180
   timestamp: 1692205504671
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py310h06a4308_0.tar.bz2
   sha256: acf569ca3e503deaaf44343cad7311d56554b3390cc695e1253c04059d50b023
   md5: 02e7296fb89eadc1d5b8f6afcca292d1
   depends:
@@ -1585,7 +1585,7 @@ packages:
   license_family: Apache
   size: 92080
   timestamp: 1659455234403
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py310h06a4308_0.tar.bz2
   sha256: 07901e769b841cd002b264c4d12bbf3a052f31ed17dea6ac621af292b62948fe
   md5: ef68e03bc5a6817d90d8a9517efd5f50
   depends:
@@ -1597,7 +1597,7 @@ packages:
   license_family: BSD
   size: 600626
   timestamp: 1672387422560
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py310h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.8.0-py310h7f8727e_1.tar.bz2
   sha256: 41f2a918ac201c093e4673d9bccbee6f53c540db25bd678961b1559372bd1507
   md5: 0166f0d92de7dd688ea527168ca9dea4
   depends:
@@ -1607,7 +1607,7 @@ packages:
   license_family: BSD
   size: 402345
   timestamp: 1640792653691
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py310h06a4308_0.tar.bz2
   sha256: f28841b5157e89b26186c8e6f941e4f601a0bbb20807245d88a6af6dcca800cd
   md5: 2b2a9be6bf17df2c01ceb1e622de6fab
   depends:
@@ -1619,7 +1619,7 @@ packages:
   license_family: BSD
   size: 29492
   timestamp: 1675441593109
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py310h06a4308_1.tar.bz2
   sha256: eba38026b96d0b3543a2a529cde8a1d82654da5cbb3030ecfe67b4247f0c8f50
   md5: a719d98f31e467f11ddf83a7e5893b49
   depends:
@@ -1628,7 +1628,7 @@ packages:
   license_family: BSD
   size: 1887228
   timestamp: 1684280033582
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py310h06a4308_0.tar.bz2
   sha256: 39de2ecacca6f1a1e3cb00d90d9aa37eafd270b4dd73d34dd34b8f9ba3b39851
   md5: 296f73e59bf7f4ab81960e2a1f03aed4
   depends:
@@ -1638,7 +1638,7 @@ packages:
   license_family: Apache
   size: 94805
   timestamp: 1690223492156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py310h06a4308_0.tar.bz2
   sha256: 853b025e248d71d2f09ec9422b76c09cb46fdedd9a065295dd9305dac36aa286
   md5: 683beb480351e058d66b538273fbfb8a
   depends:
@@ -1647,7 +1647,7 @@ packages:
   license_family: MIT
   size: 158193
   timestamp: 1661452647484
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py310h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py310h7f8727e_0.tar.bz2
   sha256: e5362c4925b888dc7ca4ca8378663c473b2279b2643b76e182b977f0f9363d2d
   md5: fa93b46d0393c943b54aa9a01669b651
   depends:
@@ -1657,7 +1657,7 @@ packages:
   license_family: MIT
   size: 124226
   timestamp: 1640807221148
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py310h06a4308_0.tar.bz2
   sha256: d01fa02148ff1717b3c13b3afc1d9f7189fa7b15d1a612d79793f6c1534875d7
   md5: 5ad7b13cb48fc3f12d94907489550019
   depends:
@@ -1666,7 +1666,7 @@ packages:
   license_family: BSD
   size: 28253
   timestamp: 1640793693853
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.10.4-h12debd9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.10.4-h12debd9_0.tar.bz2
   sha256: 3ac2d9165dbc89e4b309a2fa192c01f7e65a2fd47fad588bad44c66c19ad9af8
   md5: f931504bb2eeaf18f20388fd0ad44be4
   depends:
@@ -1687,7 +1687,7 @@ packages:
   license_family: PSF
   size: 25334822
   timestamp: 1648716756622
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py310h06a4308_0.tar.bz2
   sha256: 079d9c3369fc6dcd6fdb2b828167d29634783038fd9cc22b454115186ddbd928
   md5: 7f9649b98bcdc1b5b0c4b22c5db5b9de
   depends:
@@ -1696,7 +1696,7 @@ packages:
   license_family: BSD
   size: 265085
   timestamp: 1661371188626
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py310h06a4308_0.tar.bz2
   sha256: 192ef817854e3b5084928ec7870179a2fdbecfd7329b8d653163cb720496889b
   md5: b21c15ce377c91611d625e38bbad4ef3
   depends:
@@ -1705,7 +1705,7 @@ packages:
   license_family: MIT
   size: 260414
   timestamp: 1695131699017
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py310h06a4308_0.tar.bz2
   sha256: 6e119d30921348b2de45aa8379dba61fd10008d0badbf053e55f3ec33ffe6383
   md5: 06008f770b5b8ecb4466f9fe2176388e
   depends:
@@ -1715,7 +1715,7 @@ packages:
   license_family: BSD
   size: 39891
   timestamp: 1685030914537
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py310h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0-py310h7f8727e_0.tar.bz2
   sha256: 2249185121c4179d5efac551a3ebeace1d5b63d5f4f08211a4fdf1536cd218f1
   md5: 02982f901d86037ecc12cd93108d2c19
   depends:
@@ -1726,7 +1726,7 @@ packages:
   license_family: MIT
   size: 496996
   timestamp: 1640794093967
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py310h295c915_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-22.3.0-py310h295c915_2.tar.bz2
   sha256: 6e02808cda36e9049ffb1aa8848e34d79b433f0ec63da0760af2c6eabaee0b34
   md5: 16950ca6a2533f8b599a6ecfe19b1a15
   depends:
@@ -1737,7 +1737,7 @@ packages:
   license_family: BSD
   size: 1298077
   timestamp: 1640794137148
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
   sha256: 8c950c69bee969e2c66f88f0dc247b3ab75a753672a88009779d5f5dba193532
   md5: 150ac0eb929bab9dec912797bdfc7b95
   depends:
@@ -1747,7 +1747,7 @@ packages:
   license_family: GPL
   size: 433182
   timestamp: 1642022402894
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py310h06a4308_0.tar.bz2
   sha256: 6daaeba3024898ff16a157d7a2c13ad6f4fc8029403ae2e7433bec0ff7e5ae7c
   md5: 702eb5472fbc61f44be857463101342e
   depends:
@@ -1763,7 +1763,7 @@ packages:
   license_family: Apache
   size: 95060
   timestamp: 1690400239227
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py310h06a4308_0.tar.bz2
   sha256: e8b2265971c9357df26399051465b044e9f55e702d297a1018ed029e424b0fbc
   md5: 8eb5d51a70ed92bc2bfb96a7a65605c4
   depends:
@@ -1772,7 +1772,7 @@ packages:
   license_family: MIT
   size: 1097106
   timestamp: 1690290871845
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py310h06a4308_1.tar.bz2
   sha256: e07c6ad52415ceac1405a370e644e4a36a4f0b0d220e495057cd222c12f85c91
   md5: c15dcab2d9945d0997d49db7bbb2b12f
   depends:
@@ -1781,7 +1781,7 @@ packages:
   license_family: Apache
   size: 15636
   timestamp: 1640794815222
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py310h06a4308_0.tar.bz2
   sha256: 7b2292b384f32587828c2c7a1a099bead9d2071a8969af87349f00fe9fcd98b2
   md5: 5106026a40ffd8c8ea10c146563947cf
   depends:
@@ -1790,7 +1790,7 @@ packages:
   license_family: MIT
   size: 66920
   timestamp: 1696347609464
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
   sha256: 87965b7b46d93866d31696a1045216d64f077a06b2900c356aba87e8559c6188
   md5: fa334030245135b37027a882f3c468bf
   depends:
@@ -1801,7 +1801,7 @@ packages:
   license_family: Other
   size: 1561908
   timestamp: 1655328608308
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py310h06a4308_0.tar.bz2
   sha256: 0baaf2c1c9c5bdd29a149877e8cce8400fd190cb9d451b74af58adc91147984f
   md5: 00362c34088a3a02bcca1ad72df5f58a
   depends:
@@ -1812,7 +1812,7 @@ packages:
   license_family: BSD
   size: 30045
   timestamp: 1671752107828
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py310h06a4308_0.tar.bz2
   sha256: c839dba354cb1f6b7bf7d7a0fda8c65c1fb1ec2d2165a37cd5abe8ee1ed2ecfc
   md5: 12d717c4e3873e295865c1666ff125ef
   depends:
@@ -1822,7 +1822,7 @@ packages:
   license_family: BSD
   size: 39119
   timestamp: 1668168931128
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
   sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
   md5: 5b8375e2092012db69d2123dc0c68630
   depends:
@@ -1832,7 +1832,7 @@ packages:
   license_family: BSD
   size: 3485432
   timestamp: 1654088939579
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py310h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.1-py310h7f8727e_0.tar.bz2
   sha256: dcfeb70e565c04cfec6e5aee9c5c17fe4adc75fb8bbb6eb15d4a8b8cd65459cc
   md5: 55bf10237c01dee421799c36a1330d29
   depends:
@@ -1842,7 +1842,7 @@ packages:
   license_family: Apache
   size: 681452
   timestamp: 1640795414786
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py310h2f386ee_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py310h2f386ee_0.tar.bz2
   sha256: a30a5199c6949d7bf07df14ac82f75eaada108f7d0b379442c538cf7fb660406
   md5: 8db7239ae56fe0026c80a98aea04691b
   depends:
@@ -1855,7 +1855,7 @@ packages:
   license_family: MOZILLA
   size: 124632
   timestamp: 1679561970726
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py310h06a4308_0.tar.bz2
   sha256: 82014300af56f45295fd7bbe0a21919ddae0a720f4725a40db456d8d74d8e2fd
   md5: fc14d3692ef44fee5d3b267adbf97c74
   depends:
@@ -1864,7 +1864,7 @@ packages:
   license_family: BSD
   size: 194158
   timestamp: 1671143967706
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py310h06a4308_0.tar.bz2
   sha256: acc535e01009949fe351d05ffbcd491985953f775e525d57a4dcaf16fd5bb5ba
   md5: c3464201dae5b16d65862ad1dd96bdf1
   depends:
@@ -1874,7 +1874,7 @@ packages:
   license_family: PSF
   size: 8788
   timestamp: 1690297549545
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py310h06a4308_0.tar.bz2
   sha256: 72dee2f0c6a640cb1de55990730e48f94bc07638ef7dc35b009938ff8b59f278
   md5: da05d1cae290b53411057861262f06bc
   depends:
@@ -1883,7 +1883,7 @@ packages:
   license_family: PSF
   size: 57936
   timestamp: 1690297542878
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.16-py310h06a4308_0.tar.bz2
   sha256: 314e95ee2129eb99b43f57cbf59bdedadf436ba256732720787ef10a830e1118
   md5: ba5d23f2c9ed2f483c2d0228fd5b8b64
   depends:
@@ -1898,7 +1898,7 @@ packages:
   license_family: MIT
   size: 188260
   timestamp: 1686163269682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py310h06a4308_1.tar.bz2
   sha256: a375f3ad671266b27503b33f62ceaa7be112c0e47836e38a6c6a76225aff927d
   md5: 49b82f30a2a45b2ce167a876cdc9e21c
   depends:
@@ -1907,7 +1907,7 @@ packages:
   license_family: BSD
   size: 21391
   timestamp: 1640795864430
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py310h06a4308_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py310h06a4308_4.tar.bz2
   sha256: 7e971edc178e66023da0a1c6e35536806a3b77e50273392e2edf8ce0d0328064
   md5: bcd8414adfe572fc3d04850d1fae2845
   depends:
@@ -1917,7 +1917,7 @@ packages:
   license_family: BSD
   size: 71305
   timestamp: 1640795883083
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py310h06a4308_0.tar.bz2
   sha256: 386d7927763c6f2638f29ef11c05454c596c0046c46aa55a8348dc1e0b65bf52
   md5: 17ad3bf81caf45682f2f905921246e84
   depends:
@@ -1926,7 +1926,7 @@ packages:
   license_family: MIT
   size: 102423
   timestamp: 1695741985155
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
   sha256: 2ce360ff98c0ca4537d70c19266b5700810196c54ce2fbaff3b94a969846ee37
   md5: 94cb94dc47405b24b1b5bd0a3275ab59
   depends:
@@ -1935,7 +1935,7 @@ packages:
   license_family: GPL2
   size: 398058
   timestamp: 1651602137803
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -1943,7 +1943,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
   sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
   md5: 567b68192c387b5fc88178425577a0fe
   depends:
@@ -1953,7 +1953,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 366479
   timestamp: 1616055552392
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
   sha256: 513444d83ac2405e898531492ea59f3a95641e357cc39c1048d6fffc1791a16b
   md5: 601d9449c280b9b145dc8c83b6f06119
   depends:
@@ -1962,7 +1962,7 @@ packages:
   license_family: Other
   size: 133595
   timestamp: 1650637720646
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
   sha256: 1c049c23788a00b6f38bdc801245e0e60af98718d4db4c958658bcc67ff158c7
   md5: b1737dfd2e06ad69ec5cfec341e207c6
   depends:
@@ -1975,7 +1975,7 @@ packages:
   license_family: BSD
   size: 827172
   timestamp: 1650622223170
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -1988,7 +1988,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -1998,7 +1998,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
   md5: b2aa5503875aba2f1d88cae9df9a96d5
   depends:
@@ -2007,7 +2007,7 @@ packages:
   license_family: BSD
   size: 13636
   timestamp: 1611930018941
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -2019,7 +2019,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
   sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
   md5: 544adf2677c47c9b9c891aea720678f1
   depends:
@@ -2027,7 +2027,7 @@ packages:
   license: MIT
   size: 33999
   timestamp: 1630003259346
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -2036,7 +2036,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -2045,7 +2045,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -2054,7 +2054,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -2063,7 +2063,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
   sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
   md5: 9eff1a842dbda8d1bae9a2c008b599bc
   depends:
@@ -2074,7 +2074,7 @@ packages:
   license_family: MIT
   size: 690443
   timestamp: 1625743217109
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -2082,7 +2082,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
   sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
   md5: 33624a42ee387bf9918ea98b4e7b31fc
   depends:
@@ -2092,7 +2092,7 @@ packages:
   license_family: BSD
   size: 8173
   timestamp: 1601490751973
-- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
   sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
   md5: 67857cc5e9044770d2b15f9d94a4521d
   depends:
@@ -2101,7 +2101,7 @@ packages:
   license_family: Apache
   size: 12810
   timestamp: 1600445183315
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -2110,7 +2110,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -2119,7 +2119,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -2129,7 +2129,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
   sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
   md5: e68a6f315f41a8d814d833652bf38b9b
   depends:
@@ -2137,7 +2137,7 @@ packages:
   license: MIT
   size: 13374
   timestamp: 1606932077143
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -2145,7 +2145,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -2154,7 +2154,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -2163,7 +2163,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
   sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
   md5: 2eb923cc014094f4acf7f849d67d73f8
   depends:
@@ -2173,7 +2173,7 @@ packages:
   license_family: BSD
   size: 246457
   timestamp: 1626374695070
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
   sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
   md5: 02caf3f47f1d06256068053297355740
   depends:
@@ -2182,7 +2182,7 @@ packages:
   license_family: Apache
   size: 152292
   timestamp: 1690578151230
-- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
   sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
   md5: 41db68b96e114e367c4f120a3b379e59
   depends:
@@ -2191,7 +2191,7 @@ packages:
   license_family: BSD
   size: 19391
   timestamp: 1632406728844
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -2200,7 +2200,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -2212,14 +2212,14 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
   sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
   md5: a815d3bdb160bcc71687f2dda70d3ca4
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 122218
   timestamp: 1680170368293
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -2227,7 +2227,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py310hecd8cb5_0.tar.bz2
   sha256: ab44806f981c5fd6a92e43ffd04aff3bf016de91628af7437fc74ef2b6043973
   md5: ad7fce73167b8a72df4d1ae073542706
   depends:
@@ -2240,7 +2240,7 @@ packages:
   license_family: MIT
   size: 165345
   timestamp: 1644481776414
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py310hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py310hecd8cb5_1001.tar.bz2
   sha256: 09c3f6c4328480f28458ea1610756de82424aef128aa9cded81f8f0766a81485
   md5: d6b76a162e56bfc828c021c67e0c68ac
   depends:
@@ -2249,7 +2249,7 @@ packages:
   license_family: BSD
   size: 10049
   timestamp: 1642500631813
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py310hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py310hca72f7f_0.tar.bz2
   sha256: 4de7fc8c8f18ca65bf023bbc60d0e4bf7d17ea01323f264668df29b736cc6580
   md5: 7f6d95177dc7630deefb205c1e2bdbab
   depends:
@@ -2259,7 +2259,7 @@ packages:
   license_family: MIT
   size: 36335
   timestamp: 1644569785995
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py310hecd8cb5_0.tar.bz2
   sha256: 19452fd77b0af5c1711d99cdf0d515bad131a173689e03d4bcdf287c49152563
   md5: fdeae028483b25ed5cc0c1dbb106ed7f
   depends:
@@ -2268,7 +2268,7 @@ packages:
   license_family: MIT
   size: 134180
   timestamp: 1695717928999
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py310hecd8cb5_0.tar.bz2
   sha256: e32cef7941693f83b5c72e6a5c814ae79d358c529529d091464dee165d92d4c3
   md5: 70b35ee64f157dbbc5adda90f9194bae
   depends:
@@ -2278,12 +2278,12 @@ packages:
   license_family: MIT
   size: 209623
   timestamp: 1681493122682
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
   sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
   md5: e2f3248e2a5009a02f7b8e54f83314ef
   size: 5620
   timestamp: 1528121955725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py310h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-3.2.1-py310h20db666_0.tar.bz2
   sha256: 40d9035be55844db55fdfe31e85752d99c165d1355d792c08a91f9ccda834e10
   md5: 3f953aa83d5a9ffd1393177be2ef719f
   depends:
@@ -2301,7 +2301,7 @@ packages:
   license_family: BSD
   size: 6484731
   timestamp: 1690546214635
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py310h4e76f89_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py310h4e76f89_0.tar.bz2
   sha256: 1d0019c5cce0bdefaaf784c235036abf124ac8c3be5c3fc361fd3f4c8946e847
   md5: ba6e64e3b27d07a725022a867307fa60
   depends:
@@ -2311,7 +2311,7 @@ packages:
   license_family: BSD
   size: 140869
   timestamp: 1657175784357
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
   sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
   md5: 31d6d04cd2388d8f19004501271b3545
   depends:
@@ -2321,7 +2321,7 @@ packages:
   license: MIT
   size: 18982
   timestamp: 1659616229395
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
   sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
   md5: caf1073dc2ca5aeb832a2877394eae12
   depends:
@@ -2330,7 +2330,7 @@ packages:
   license: MIT
   size: 18233
   timestamp: 1659616216769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py310he9d5cce_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py310he9d5cce_7.tar.bz2
   sha256: f292b68dc123e7d16d2e6403360f7c4279b118a553771eefb8d69cb9ccdc55fa
   md5: f8c7836d6d091f568645a7cf484604ab
   depends:
@@ -2339,21 +2339,21 @@ packages:
   license: MIT
   size: 399745
   timestamp: 1659616391600
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
   sha256: 4574ffa241157e108d19ece60107a3a689cefaaca43578e6c4a6b344c7330278
   md5: ab3b4e83407001e7f1603ca1fa0f4873
   license: bzip2
   license_family: BSD
   size: 106284
   timestamp: 1563219666100
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
   sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
   md5: ce3588e31faa79f546e0fc6a36c5543c
   license: MPL-2.0
   license_family: Other
   size: 133884
   timestamp: 1694009771475
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py310hecd8cb5_0.tar.bz2
   sha256: d9bec3e7e31f68d954604656a2326af62f08bcd687c05a142449d0d5c8cde1b3
   md5: 5be325b9c245a807ebbacae214faf403
   depends:
@@ -2362,7 +2362,7 @@ packages:
   license_family: Other
   size: 159842
   timestamp: 1690232263011
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py310h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py310h6c40b1e_3.tar.bz2
   sha256: 0d8b97f3e71f6e4a475338f9c3f2fc9ea48cf38cdfe01a098dd55e55e8f98e41
   md5: ea3b438028199e3d6bd7ae93786d2834
   depends:
@@ -2373,7 +2373,7 @@ packages:
   license_family: MIT
   size: 227222
   timestamp: 1670423265293
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py310hecd8cb5_0.tar.bz2
   sha256: 23a65cddc91ac3a24ca12a4b6cddf1d55997e9fdfba9456a7b68d2516b4233bd
   md5: 31e701ceaf45deab0ea36be55a28c4b4
   depends:
@@ -2383,7 +2383,7 @@ packages:
   license_family: CC
   size: 1921660
   timestamp: 1668084532737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py310hecd8cb5_0.tar.bz2
   sha256: eb9d8c1b21655250196a8fc27ea6713973a494ff4ea744344a28ab9cfa799dc8
   md5: 0c9f7d21c1f8951251c85b92e684c8cb
   depends:
@@ -2393,7 +2393,7 @@ packages:
   license_family: BSD
   size: 13815
   timestamp: 1671231253863
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py310haf03e11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py310haf03e11_0.tar.bz2
   sha256: 2a957b3fec7dfb81fd8281c5a50c794dd2ca2dee6c89a41d19220ebff0237765
   md5: aeeea7b1bc519916c95da894e200d315
   depends:
@@ -2404,7 +2404,7 @@ packages:
   license_family: BSD
   size: 246640
   timestamp: 1663827690536
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py310h30e54ef_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py310h30e54ef_0.tar.bz2
   sha256: 037989d5057008a5f17d3d375e210cf2290bb6691dad6b9a34951fe57bf04b44
   md5: cf5739b661e75d50538d7df9e8396666
   depends:
@@ -2417,7 +2417,7 @@ packages:
   license_family: BSD
   size: 1312180
   timestamp: 1694211808108
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py310hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py310hcec6c5f_0.tar.bz2
   sha256: e2d11b07b8139917def31e4f4c1318396eae6762e18c771851cbebfe628cb157
   md5: e3f9f6c8343ecf7dc8f311670be764fc
   depends:
@@ -2427,7 +2427,7 @@ packages:
   license_family: MIT
   size: 2068510
   timestamp: 1690905208269
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py310hecd8cb5_0.tar.bz2
   sha256: 670e9476a114ca61020f1a69803661de5cc6f01a26296a4c73bbbda94164dc4e
   md5: 12f8f558c520d5a1e25ba2967edbee89
   depends:
@@ -2436,7 +2436,7 @@ packages:
   license_family: MIT
   size: 16685
   timestamp: 1649926502410
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py310hecd8cb5_0.tar.bz2
   sha256: cf6ea491b82e836c5554fcb36224b22c987afa536a347d77fcef9ce60a762678
   md5: dc1626b688c0694a85b2671bd78cab86
   depends:
@@ -2445,7 +2445,7 @@ packages:
   license_family: BSD
   size: 27897
   timestamp: 1668714443581
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -2455,14 +2455,14 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
   sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
   md5: e4a732941f74b8062c8bcbfe5c5c2b56
   license: MIT
   license_family: MIT
   size: 80252
   timestamp: 1676983220161
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.17.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.17.1-py310hecd8cb5_0.tar.bz2
   sha256: 4d89c45e4f6ca1b63f69d7dcccbd5934b060e13c5d2711ecf25ea6022af473b8
   md5: 9eabc7dbf073a8276ef1b5c40bf56982
   depends:
@@ -2479,7 +2479,7 @@ packages:
   license_family: BSD
   size: 4626418
   timestamp: 1693378265446
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
   sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
   md5: f3ce6fe6eb760c236e5f7d04df5faa81
   depends:
@@ -2488,7 +2488,7 @@ packages:
   license_family: MIT
   size: 28138484
   timestamp: 1692293212596
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py310hecd8cb5_0.tar.bz2
   sha256: dbeeaa099425216cbe0dad8e44951521772e71ee124ef3c30073751cc59aa957
   md5: b9a7575212d1d752f9a9b917ba5c6685
   depends:
@@ -2497,7 +2497,7 @@ packages:
   license_family: BSD
   size: 117040
   timestamp: 1666125702178
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
   sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
   md5: 78baea934985ccd9514a366cc7e80ed4
   depends:
@@ -2506,7 +2506,7 @@ packages:
   license_family: Proprietary
   size: 727499
   timestamp: 1681801225190
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py310h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py310h20db666_0.tar.bz2
   sha256: b288ab7930ec37a7cb6f3558b82f67ac57b69ae561304f68d39d6b5663763096
   md5: 69565782f10218ec53c3e7b50121388b
   depends:
@@ -2528,7 +2528,7 @@ packages:
   license_family: BSD
   size: 220460
   timestamp: 1691121691261
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py310hecd8cb5_0.tar.bz2
   sha256: 6308545b6b7a988e38a16159af2dac1d0b15f6cacade56cd571d6846275059d3
   md5: ce8b3d8d7a177c5b0d6c8cb27369bfb0
   depends:
@@ -2549,7 +2549,7 @@ packages:
   license_family: BSD
   size: 1274856
   timestamp: 1694181561315
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py310hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py310hecd8cb5_1.tar.bz2
   sha256: e9462e4328da66b87f57311ba1a334cc4e6ee0e6fb6c617feadf54acec4ea14b
   md5: 195c8c18c39ccb0f9673fd0aa8fdb365
   depends:
@@ -2559,7 +2559,7 @@ packages:
   license_family: MIT
   size: 1034798
   timestamp: 1644315303585
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py310hecd8cb5_0.tar.bz2
   sha256: 76b44a192decbb67a6496d1501db38511944c3b53adc10ff7a59e104b587cf1b
   md5: c362453df8790e78cfe5ef1d952ff6dd
   depends:
@@ -2569,14 +2569,14 @@ packages:
   license_family: BSD
   size: 217435
   timestamp: 1666908206435
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
   sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
   md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
   license: IJG
   license_family: Other
   size: 278924
   timestamp: 1677849185191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py310hecd8cb5_0.tar.bz2
   sha256: efe759e046a43f2570267f508af9a1fb7598c7d4e08d8f552d69be79cf411c78
   md5: 05619f81c3e3b0fc7a156e320ec7111d
   depends:
@@ -2587,7 +2587,7 @@ packages:
   license_family: MIT
   size: 134344
   timestamp: 1676558794739
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py310hecd8cb5_0.tar.bz2
   sha256: 1b382008e5e5b7d7bbe5da1767d4d35021869c5ff1b7fdb17f10fa9634cd8e1e
   md5: 32e23b69e39f05ec0c83b75738996fa2
   depends:
@@ -2603,7 +2603,7 @@ packages:
   license_family: BSD
   size: 200146
   timestamp: 1676330021017
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py310hecd8cb5_0.tar.bz2
   sha256: 1a18653cd4662d7930a527077bc2aa5e904e6e58ba60fca37b88316678b83174
   md5: c8843d773865ac5e8d07d270f37f8b17
   depends:
@@ -2614,7 +2614,7 @@ packages:
   license_family: BSD
   size: 93428
   timestamp: 1679906653176
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py310hecd8cb5_0.tar.bz2
   sha256: db6767e015c939d2cfeb472adda2643ace0e3851d8a4fd83f4cc6e44cbe1221c
   md5: 8e0febc4fb146683e2415f08b2e6d85b
   depends:
@@ -2638,7 +2638,7 @@ packages:
   license_family: BSD
   size: 405529
   timestamp: 1671707749359
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py310hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py310hcec6c5f_0.tar.bz2
   sha256: bde3b255886d59e9af9450489ba42e205865a223ec48c4bd3396405480715c97
   md5: f4ed6fff2814558c3b717017465d8e2a
   depends:
@@ -2648,7 +2648,7 @@ packages:
   license_family: BSD
   size: 65413
   timestamp: 1672387282474
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -2658,7 +2658,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -2667,13 +2667,13 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
   sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
   md5: 7dba7aa5b971febb55281659843586ba
   license: MIT
   size: 65470
   timestamp: 1659616172703
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
   sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
   md5: f78a158983f0bbaba56f34b976bc6dae
   depends:
@@ -2681,7 +2681,7 @@ packages:
   license: MIT
   size: 34189
   timestamp: 1659616189313
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
   sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
   md5: 36a1d885725d3ab4d1fadc5a29f978d2
   depends:
@@ -2689,35 +2689,35 @@ packages:
   license: MIT
   size: 327737
   timestamp: 1659616202869
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
   sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
   md5: 817848d0e2b2808acdc9b3fbbf581726
   license: MIT
   license_family: MIT
   size: 133887
   timestamp: 1683716590737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
   sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
   md5: c90372428e1e4eed4fdcd790979d06b4
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1409377
   timestamp: 1650983531933
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -2726,13 +2726,13 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -2749,7 +2749,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
   sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
   md5: c0b99f8e1c7475f23b1c7b4250b06e1c
   depends:
@@ -2763,7 +2763,7 @@ packages:
   license_family: BSD
   size: 88021
   timestamp: 1694778290062
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
   sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
   md5: 46a65d1fc24013217e06aaf6d65ffcad
   constrains:
@@ -2772,7 +2772,7 @@ packages:
   license_family: BSD
   size: 425478
   timestamp: 1694776947990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
   sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
   md5: 06866415ef22d5322f9bdc9956b59c4d
   depends:
@@ -2784,7 +2784,7 @@ packages:
   license_family: MIT
   size: 678174
   timestamp: 1692970318885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
   sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
   md5: 2edc6c894d6d0321304396e9bd40df94
   depends:
@@ -2794,7 +2794,7 @@ packages:
   license_family: MIT
   size: 241774
   timestamp: 1692973618934
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py310hecd8cb5_0.tar.bz2
   sha256: 8e083eacdfa973821efce45fb1de838ccdab56cbee31a6ce70de0683ad2165f7
   md5: 8f970cf73b7f71b2d2c624992e9cd6f7
   depends:
@@ -2804,7 +2804,7 @@ packages:
   license_family: MIT
   size: 36179
   timestamp: 1659783413376
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py310h946e0e5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py310h946e0e5_0.tar.bz2
   sha256: cceee8661c23a21fdbd31ebaf5f862f88dde52d3afcd7c26cc782209972a6ebe
   md5: 16e6b7f845a0ae234cc7abf553857259
   depends:
@@ -2815,7 +2815,7 @@ packages:
   license_family: Other
   size: 1515705
   timestamp: 1695058495195
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
   sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
   md5: d5f58d056b4bfc67aec30c77035ba889
   depends:
@@ -2824,7 +2824,7 @@ packages:
   license_family: BSD
   size: 182491
   timestamp: 1670944720979
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py310hecd8cb5_0.tar.bz2
   sha256: bc2f8a9d82b05e7d2e9da576d86565f085b18ad824a61729c808a35d9aa899ae
   md5: 2b5c8d5d297342184b21138a02a4cec1
   depends:
@@ -2833,7 +2833,7 @@ packages:
   license_family: BSD
   size: 124321
   timestamp: 1671541949029
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py310hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py310hecd8cb5_1.tar.bz2
   sha256: 444bec52a8b4f0e0169f69b0d2ee1409dc04a48509ea394d053e8fa3418e724b
   md5: e95bbbc56e3c08f0018638c6ee82e567
   depends:
@@ -2843,7 +2843,7 @@ packages:
   license_family: MIT
   size: 108187
   timestamp: 1684279943281
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py310hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py310hca72f7f_0.tar.bz2
   sha256: a08565836c11f37e47a37bde257199924adc6b83fbf1c8d57a5a70e6b2151e03
   md5: 783ab31d6fd7c0ec3450e9b687d60672
   depends:
@@ -2854,7 +2854,7 @@ packages:
   license_family: BSD
   size: 22639
   timestamp: 1654597944890
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py310hb47e01b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py310hb47e01b_0.tar.bz2
   sha256: 3371092d530ff8e27265385843474dbb6567b77df77ca44ffe9715b3bf337c1f
   md5: 1a37eac45ba97a9133f9c04198bbb8e9
   depends:
@@ -2876,7 +2876,7 @@ packages:
   license_family: PSF
   size: 8207820
   timestamp: 1698692275293
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py310hecd8cb5_0.tar.bz2
   sha256: b0b7bf33159ad955ac6503e0008bb4f6d42a431d39750d8748f1cfd437c33982
   md5: 95dcb73cba7ccc8d9d54ded71c43f200
   depends:
@@ -2886,7 +2886,7 @@ packages:
   license_family: BSD
   size: 17405
   timestamp: 1662014515076
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py310hecd8cb5_0.tar.bz2
   sha256: 25de39c78f2dd34019fd7c7f46110a096abaf50fe8ed08ddbbdb905aa5fa4154
   md5: 0a554b7362b3c3ee587f2486e58c9d4c
   depends:
@@ -2896,7 +2896,7 @@ packages:
   license_family: MIT
   size: 53950
   timestamp: 1659721329388
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py310hecd8cb5_0.tar.bz2
   sha256: f7319ca119de06ffc0efc159c00b0eb4aa1c8c95b0de062532590cb8da37be9e
   md5: 3d14c228ee0ce206ba6889c36a0815c7
   depends:
@@ -2905,7 +2905,7 @@ packages:
   license_family: MIT
   size: 19643
   timestamp: 1659716168738
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py310hca72f7f_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py310hca72f7f_1000.tar.bz2
   sha256: b129a6779958bbb963454e068103a6f102d34864bc928b5f46fd19d122a745a6
   md5: 7cfba0a36a59a4f70c4e9fcc39fa8d5c
   depends:
@@ -2914,7 +2914,7 @@ packages:
   license_family: BSD
   size: 55621
   timestamp: 1642534192191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
   sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
   md5: 25051fe272624544652dc6d814c2943a
   depends:
@@ -2927,7 +2927,7 @@ packages:
   license_family: Proprietary
   size: 224420228
   timestamp: 1691503125614
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py310h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py310h6c40b1e_1.tar.bz2
   sha256: 773d3474db4c2929410078d134b4990cbee452a432d78e2596d9dff19d086391
   md5: 195f192460854e93de48e9680245b77e
   depends:
@@ -2937,7 +2937,7 @@ packages:
   license_family: BSD
   size: 48109
   timestamp: 1682969136581
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py310h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py310h6c40b1e_0.tar.bz2
   sha256: 14ee8d02bebd80653a0d8a733074a333354b44a01facaab5c629b0a4929fcbfb
   md5: 547d8d08cf840264effcef3064b00e9a
   depends:
@@ -2950,7 +2950,7 @@ packages:
   license_family: BSD
   size: 210701
   timestamp: 1695058263687
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py310ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py310ha357a0b_0.tar.bz2
   sha256: 20fc55fb2eb0e8c06c28e814cc8056f22b2e9e96ed7ff8b4be2d2e25222856d9
   md5: 61bdf81fd58feec3a44e196398b1300f
   depends:
@@ -2964,7 +2964,7 @@ packages:
   license_family: BSD
   size: 296201
   timestamp: 1695060071873
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py310hecd8cb5_0.tar.bz2
   sha256: f27a95f8b4c9ec17770b91fe707594651f7cb179f08d3b930be4b64b3682a833
   md5: daf8c86dc56b8661a2480e9881fa7200
   depends:
@@ -2990,7 +2990,7 @@ packages:
   license_family: BSD
   size: 8220896
   timestamp: 1681756363497
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py310hecd8cb5_0.tar.bz2
   sha256: 085d6403ec0ec4d4f0d95aae1cc1290ad30c256f13dca2eb40e9ba1303f9a062
   md5: d57325e2862d4b24564d8349f6630e52
   depends:
@@ -3003,7 +3003,7 @@ packages:
   license_family: BSD
   size: 99493
   timestamp: 1650308474923
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py310hecd8cb5_0.tar.bz2
   sha256: f77d94aaabd8c0402fd7423b081180d28f92a3ae1c8ef596a4a9fe0d7f58424b
   md5: 713212d6bbc8c47f24ee3edb9ca7baee
   depends:
@@ -3031,7 +3031,7 @@ packages:
   license_family: BSD
   size: 574237
   timestamp: 1668450820509
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py310hecd8cb5_0.tar.bz2
   sha256: 200687f529720b1a54320822026f40037a559a3eb3a59fd4025e0dd0ec3b9901
   md5: 3035217993e7b73cb4a4919013344699
   depends:
@@ -3044,14 +3044,14 @@ packages:
   license_family: BSD
   size: 149101
   timestamp: 1694616785694
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py310hecd8cb5_0.tar.bz2
   sha256: 77fcc055b810d404d839a214cbc06e8e234cce991e467983b3629df585c261e8
   md5: 68d1f87ac6334f78182d0e27641d88d2
   depends:
@@ -3060,7 +3060,7 @@ packages:
   license_family: BSD
   size: 14179
   timestamp: 1672387168383
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py310hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py310hecd8cb5_1.tar.bz2
   sha256: 218236846df8a0900c96fffe6f750ec0e231ae048b7483a85e6f5ae645b0c548
   md5: 99fb68f5d037199fe8434f0efdc156fc
   depends:
@@ -3085,7 +3085,7 @@ packages:
   license_family: BSD
   size: 578675
   timestamp: 1690985127411
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py310hecd8cb5_0.tar.bz2
   sha256: a8774377f121ac341dde9dd8abb12bc66b4da190bffa1f174ccdcb0dfbab77a5
   md5: bfd9bf83d0562607c255dbec00bbddb0
   depends:
@@ -3095,7 +3095,7 @@ packages:
   license_family: BSD
   size: 22873
   timestamp: 1668160738644
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py310h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py310h827a554_0.tar.bz2
   sha256: b2634d72414fd2395f38dbca97b6f5ad6160e1bfac2f05a73de43bb60b690629
   md5: 8fdb739c2f53afe8b38108439c1deea9
   depends:
@@ -3109,7 +3109,7 @@ packages:
   license_family: MIT
   size: 139299
   timestamp: 1696515370721
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py310h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.0-py310h827a554_0.tar.bz2
   sha256: 6e4a3e3184090c941916975e48e1f2f157c5e4bd3473d867adb059b0147d39eb
   md5: d573e7ba7699271b27ce831e01e5a753
   depends:
@@ -3125,7 +3125,7 @@ packages:
   license_family: BSD
   size: 10389
   timestamp: 1695830676422
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py310ha186be2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.0-py310ha186be2_0.tar.bz2
   sha256: 7ae570d5e9669d4b69ea4ed7b49517afad8e657260a3fbc466155c71f9182887
   md5: 1ed5fb43c01ff836a6f3e5e854cd1899
   depends:
@@ -3140,7 +3140,7 @@ packages:
   license_family: BSD
   size: 7610228
   timestamp: 1695830639474
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
   sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
   md5: 93f5d7b66976154adeda219bea02ba45
   depends:
@@ -3150,7 +3150,7 @@ packages:
   license: BSD 2-Clause
   size: 484257
   timestamp: 1630093862501
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
   sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
   md5: 5e8713ef1215406254988163eaf34020
   depends:
@@ -3159,7 +3159,7 @@ packages:
   license_family: Apache
   size: 4965606
   timestamp: 1695323060401
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py310hecd8cb5_0.tar.bz2
   sha256: 089feb98ce46c010cc25d3660d5bb16bcf7bd10a967bef18184fb15714fc0a32
   md5: 43ef133d834ebf2f1dc2b7fba3d50ce6
   depends:
@@ -3168,7 +3168,7 @@ packages:
   license_family: Apache
   size: 74480
   timestamp: 1693575260353
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py310h3ea8b11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-2.1.1-py310h3ea8b11_0.tar.bz2
   sha256: 254e46f19c0826956dbdf42b5f15028c4da8ef44141c42d008289ae98337e938
   md5: 17a3e1285f42272d75ed890b655b041a
   depends:
@@ -3215,7 +3215,7 @@ packages:
   license_family: BSD
   size: 13608325
   timestamp: 1697479408057
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-1.2.3-py310hecd8cb5_0.tar.bz2
   sha256: 4b2d5305590fbf66d22508e1b9ca7afbce87a25f6a1142d6de6b2815c9ba98d1
   md5: dc07447e3ab88d2f1147ccec800be296
   depends:
@@ -3239,7 +3239,7 @@ packages:
   license_family: BSD
   size: 17078623
   timestamp: 1695146541406
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-1.13.0-py310hecd8cb5_0.tar.bz2
   sha256: 08f766f3c49a9b1bd0addb34fb0ce0739d319003aa4d7580d25b8b344b3dac8d
   md5: 7b31c764364be71df61cd206249ccae2
   depends:
@@ -3248,7 +3248,7 @@ packages:
   license_family: BSD
   size: 144060
   timestamp: 1684915450654
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py310h7d39338_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py310h7d39338_0.tar.bz2
   sha256: d5e918ed8236a338d9f436a09eb46c30e5f9e347996994e5c90c473586227c24
   md5: 857a827b9265d61c8ddc60a1ee07b439
   depends:
@@ -3267,7 +3267,7 @@ packages:
   license_family: Other
   size: 725546
   timestamp: 1696580269946
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py310hecd8cb5_0.tar.bz2
   sha256: eefa0d8918708629f5025ce521b9b15f7cddd0e87101bfdae3000bcfd2bf3da7
   md5: 70535b7f63e00d50a7acc6bdd85586fd
   depends:
@@ -3278,7 +3278,7 @@ packages:
   license_family: MIT
   size: 2766709
   timestamp: 1697548926659
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py310hecd8cb5_0.tar.bz2
   sha256: dd5966a641fed108397a18417e59eca23b954459d8dfaf1c2b02006147bf803a
   md5: 0ba5d202a0f8fa8addb28c3c5f411150
   depends:
@@ -3287,7 +3287,7 @@ packages:
   license_family: MIT
   size: 33266
   timestamp: 1692205694975
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py310hecd8cb5_0.tar.bz2
   sha256: c9dbcf730bb1f746db302a11fa5f42071e9d873f303f5dee75b239ede7bf3980
   md5: 1327ba70c886ab04a2519bfed39bee65
   depends:
@@ -3296,7 +3296,7 @@ packages:
   license_family: Apache
   size: 92145
   timestamp: 1659455228077
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py310hecd8cb5_0.tar.bz2
   sha256: 0183e61dfefdba63f97fe57d2931e70094e050f823d8762878dc48e8d3dfb42e
   md5: f188d7613b2cfb91b28004918aa19021
   depends:
@@ -3308,7 +3308,7 @@ packages:
   license_family: BSD
   size: 601686
   timestamp: 1672387406503
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py310hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py310hca72f7f_0.tar.bz2
   sha256: 5a156c5d275cd9741ece740b8e0c73cf18ed8c6964fbbf8fe77c128477ee4e8d
   md5: a13323d851b7c615fe3c85924773d118
   depends:
@@ -3317,7 +3317,7 @@ packages:
   license_family: BSD
   size: 370312
   timestamp: 1656431483235
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py310hecd8cb5_0.tar.bz2
   sha256: 6f28fc0782ff0a1f9f44be058392efcda61a916f4687f0e349c6a0b633154a31
   md5: 89243bf420e88ab976e19b1a91228465
   depends:
@@ -3329,7 +3329,7 @@ packages:
   license_family: BSD
   size: 30981
   timestamp: 1675441597598
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py310hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py310hecd8cb5_1.tar.bz2
   sha256: 864b005b3d12d53740f42f89e7d3468b43917f6054b2a27d49d6a072a7269aae
   md5: 29606753a2e301fe9542067780a50ec1
   depends:
@@ -3338,7 +3338,7 @@ packages:
   license_family: BSD
   size: 1889082
   timestamp: 1684280018937
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py310hecd8cb5_0.tar.bz2
   sha256: 487b805533d5b50277d9c89f51a3aa7e7b729c69da0405b226ba038d339bb8a5
   md5: 61b06079b67e16ce1867a92c96d863b4
   depends:
@@ -3348,7 +3348,7 @@ packages:
   license_family: Apache
   size: 95852
   timestamp: 1690223503122
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py310hecd8cb5_0.tar.bz2
   sha256: db519ef731035a089ea668c083e4808dd7cbcfe7e86888980bef6c27cac0a641
   md5: 47485dc392cbae53021ae382b8dc08ae
   depends:
@@ -3357,7 +3357,7 @@ packages:
   license_family: MIT
   size: 159281
   timestamp: 1661452701242
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py310hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py310hca72f7f_0.tar.bz2
   sha256: dfd09b8d92159b9e9231af7e5918985449be9ff425a994a088356a67f2d0fb98
   md5: 490a33ca92bfe105ba93c28b4c795ff8
   depends:
@@ -3366,7 +3366,7 @@ packages:
   license_family: MIT
   size: 92153
   timestamp: 1642541595890
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py310hecd8cb5_0.tar.bz2
   sha256: 7e7ad33a42ffc0cf30a64115bbf6a4fb77e6f4ff859b5cdc1c5af35e34a77a36
   md5: 8b1372e62747adb48891711705ecf67c
   depends:
@@ -3375,7 +3375,7 @@ packages:
   license_family: BSD
   size: 28205
   timestamp: 1642536392594
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.10.13-h5ee71fb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.10.13-h5ee71fb_0.tar.bz2
   sha256: 5ba093f7f0e5088ce22ea87d6880a134bd0d1d67eed734cd7a339e8c0d688294
   md5: 733726b31b54c2859abf39e515c391c1
   depends:
@@ -3394,7 +3394,7 @@ packages:
   license_family: PSF
   size: 14070954
   timestamp: 1694439953107
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py310hecd8cb5_0.tar.bz2
   sha256: 3d314468af451dbeb0ed8ac8388d85a0edb0dc4ff87e7679b0d8295e23b679ae
   md5: 99de5095f6d8989cd8a0a60457a26e80
   depends:
@@ -3403,7 +3403,7 @@ packages:
   license_family: BSD
   size: 267017
   timestamp: 1661368961839
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py310hecd8cb5_0.tar.bz2
   sha256: 44eef36e967a2562a043a9db7f0fa137878b7adf7ff578d9378b9e020efa6bb0
   md5: a36782f1fbc6a6d2e176522e3d5b79d0
   depends:
@@ -3412,7 +3412,7 @@ packages:
   license_family: MIT
   size: 263007
   timestamp: 1695131673910
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py310hecd8cb5_0.tar.bz2
   sha256: ccda239903a1c14577c76e9ec451630bd7dec7df91e7afcd2b4bc3ee111192ea
   md5: cf498337272068feb029e4f873e400fe
   depends:
@@ -3422,7 +3422,7 @@ packages:
   license_family: BSD
   size: 41072
   timestamp: 1685030909072
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py310h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py310h6c40b1e_0.tar.bz2
   sha256: 59d597cc950bf5197924d433b42e72273f6dbbdaeeceb053f6050cad1fc1005e
   md5: 2df629ea5b0b5e5e5327ab360e81f64a
   depends:
@@ -3432,7 +3432,7 @@ packages:
   license_family: MIT
   size: 167875
   timestamp: 1698096174693
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py310he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py310he9d5cce_0.tar.bz2
   sha256: e56762c3fa93a7894e98e05e1b846e750a65687142687fc14b5f51acc09b6c94
   md5: c597bda474adc66bd51ef3c45b5120ef
   depends:
@@ -3443,7 +3443,7 @@ packages:
   license_family: BSD
   size: 496650
   timestamp: 1657724393960
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -3452,7 +3452,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py310hecd8cb5_0.tar.bz2
   sha256: 39749df47bb595363c366aefa9724fb0251eae23ed1fd77b7e269a4f8a32c4c9
   md5: b03a080689f8cfab8c86693d9816024a
   depends:
@@ -3468,7 +3468,7 @@ packages:
   license_family: Apache
   size: 96142
   timestamp: 1690400412604
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py310hecd8cb5_0.tar.bz2
   sha256: 1824642ef4461a0a77d5e4e3d6af8a08d46252ed09f95d00f722b63ecb2a7b66
   md5: 867cc0219069dcb5cd578910c58dda98
   depends:
@@ -3477,7 +3477,7 @@ packages:
   license_family: MIT
   size: 1101438
   timestamp: 1690291040658
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py310hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py310hecd8cb5_1.tar.bz2
   sha256: 8b7cc3fd8e5f649e4d7d09cd47e0602839ee5735d8467aa16cab962a082ae3e8
   md5: 5f805498c07279470db32b3e23387420
   depends:
@@ -3486,7 +3486,7 @@ packages:
   license_family: Apache
   size: 15556
   timestamp: 1642537667959
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py310hecd8cb5_0.tar.bz2
   sha256: 97a6ef8790155b089dc6c1c7559cac226dc8966fb7189276d43e56361fef921b
   md5: c5fe7f5450316dd0f7c407fc6d5c4590
   depends:
@@ -3495,7 +3495,7 @@ packages:
   license_family: MIT
   size: 67950
   timestamp: 1696347655636
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
   sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
   md5: 82e4db6a498480a75d53c55bd35b6478
   depends:
@@ -3507,7 +3507,7 @@ packages:
   license_family: Other
   size: 1801397
   timestamp: 1681394807900
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -3516,7 +3516,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py310hecd8cb5_0.tar.bz2
   sha256: 92b0454b4739557af9a8f52f040828cb343935e874144e25eebf620be61cfb85
   md5: 39fb00364e1ae13b9fc9af51c0540648
   depends:
@@ -3527,7 +3527,7 @@ packages:
   license_family: BSD
   size: 31114
   timestamp: 1671751965362
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py310hecd8cb5_0.tar.bz2
   sha256: 47192486a825a7723642a5ff51a6e6e1951c2d32c7788da5de2485cc06b30211
   md5: 857b3344cb9298976756ca71dc731d60
   depends:
@@ -3537,7 +3537,7 @@ packages:
   license_family: BSD
   size: 40085
   timestamp: 1668168926166
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
   sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
   md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
   depends:
@@ -3546,7 +3546,7 @@ packages:
   license_family: BSD
   size: 3536231
   timestamp: 1654088937695
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py310h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py310h6c40b1e_0.tar.bz2
   sha256: 52fb9d05259365350eca75a97b42f8b9bcb7b090ebd6bd95d21f337f73c25e1c
   md5: d2bfc5dd6b421d2a3f58d6255fdedcc6
   depends:
@@ -3555,7 +3555,7 @@ packages:
   license_family: Apache
   size: 689288
   timestamp: 1696937228662
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py310h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py310h20db666_0.tar.bz2
   sha256: 6876f55e026d8964844f80442aea51b2b5893c2f6e9afffc9a52b938de74a171
   md5: 76f0e82559e0d2cb25cd00721d0ec899
   depends:
@@ -3568,7 +3568,7 @@ packages:
   license_family: MOZILLA
   size: 126000
   timestamp: 1679562147426
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py310hecd8cb5_0.tar.bz2
   sha256: 87e0bd4e5178668a54ae6e6dcb3cd3ec495f5d67d63bfcda92c80c13b4c5818a
   md5: 6fa79103a143c775db1fb39a353e3b57
   depends:
@@ -3577,7 +3577,7 @@ packages:
   license_family: BSD
   size: 194911
   timestamp: 1671143953318
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py310hecd8cb5_0.tar.bz2
   sha256: bd72de8e84b90728ea4b4e8388c4505bec7d09e29956c2432191a2db70206a34
   md5: 28f471989dd29ca9c4dc30f062b20f76
   depends:
@@ -3587,7 +3587,7 @@ packages:
   license_family: PSF
   size: 9682
   timestamp: 1690297614212
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py310hecd8cb5_0.tar.bz2
   sha256: 2f6971494a97a047be714d050b2abf622d39189e58a07033eba98372f7575c56
   md5: aea017906d38d594a3efdea15d38ef95
   depends:
@@ -3596,7 +3596,7 @@ packages:
   license_family: PSF
   size: 58932
   timestamp: 1690297606654
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py310hecd8cb5_0.tar.bz2
   sha256: 7669c43d362b42ed8c5d52c9660420df67f8f4ce59194d95c038b01b66f085d1
   md5: 62dcb988e38541d7073093a64453dbb4
   depends:
@@ -3605,7 +3605,7 @@ packages:
   license_family: MIT
   size: 11601
   timestamp: 1659769547734
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py310hecd8cb5_0.tar.bz2
   sha256: 08d5f8a7db2a4e1708f75e8a87c977fbebcc2d936c2e52f246989cf80df44f94
   md5: 03a75bef86c8f0bcf385b666513755d5
   depends:
@@ -3620,7 +3620,7 @@ packages:
   license_family: MIT
   size: 190398
   timestamp: 1698257632441
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py310hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py310hecd8cb5_1.tar.bz2
   sha256: aae85a1650806382831d1edd5b7e8912329c2d5859dd63258f2b422d0bee1761
   md5: 7502e3b07c9f996017a9171d056b3865
   depends:
@@ -3629,7 +3629,7 @@ packages:
   license_family: BSD
   size: 21319
   timestamp: 1642539070002
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py310hecd8cb5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py310hecd8cb5_4.tar.bz2
   sha256: bfcc4c35eae2d90abc18b87a0add0517e6ea10677cc2037d5378f9de0409003a
   md5: ee812330edd951833ed8ba1ac49084d0
   depends:
@@ -3639,7 +3639,7 @@ packages:
   license_family: BSD
   size: 71241
   timestamp: 1642513589037
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py310hecd8cb5_0.tar.bz2
   sha256: 05a3708b6a166574a7f062e6a8ae36052c291bfca26a9fc66f90ccd3f424f2a1
   md5: a67133ecf7cdafd527c93a608369c20f
   depends:
@@ -3648,7 +3648,7 @@ packages:
   license_family: MIT
   size: 103558
   timestamp: 1695741971042
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py310hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py310hecd8cb5_1.tar.bz2
   sha256: b7c324c44d31162d3ae297d38d95157f1d8b27c8dd6de2ee369e2426eb1c7d67
   md5: cb55c97b4ce01dec47958aefa7845582
   depends:
@@ -3657,20 +3657,20 @@ packages:
   license_family: BSD
   size: 49600
   timestamp: 1675159097509
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
   sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
   md5: e243baa546432c8394a8059a44a5a3e4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 419227
   timestamp: 1683113010463
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
   sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
   md5: fe4ac85ee86d3a94ea3a4ebea3779763
   depends:
@@ -3679,14 +3679,14 @@ packages:
   license: LGPL-3.0-or-later
   size: 321797
   timestamp: 1616055526986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
   sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
   md5: 8e495591e369ac161857a72011c0a296
   license: Zlib
   license_family: Other
   size: 120272
   timestamp: 1666595024203
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
   sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
   md5: f1465fbd810b3746c6de6babfd4fe28a
   depends:
@@ -3698,7 +3698,7 @@ packages:
   license_family: BSD
   size: 1023573
   timestamp: 1681304595869
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py310hca03da5_0.tar.bz2
   sha256: b161c187c7a5303d7c39c503ae770312213b5ef48ea860e46a20e9356c7b027d
   md5: 992ef1ea267b882a65a0a0174059a014
   depends:
@@ -3711,7 +3711,7 @@ packages:
   license_family: MIT
   size: 158997
   timestamp: 1644482619945
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py310hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py310hca03da5_1001.tar.bz2
   sha256: ab80767485355b86e85012079c6774f34b8a50cca22f6af691717dae8a6eecd3
   md5: 313a6fb125023514957826391bd2bc9a
   depends:
@@ -3720,7 +3720,7 @@ packages:
   license_family: BSD
   size: 10379
   timestamp: 1643965069164
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py310h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py310h1a28f6b_0.tar.bz2
   sha256: 88db781405798fc0a4bd4d2cfa4817d72a1717595814792b06baf438a74f971e
   md5: 74f12ced47a5a18208005eb36438fb97
   depends:
@@ -3730,7 +3730,7 @@ packages:
   license_family: MIT
   size: 36148
   timestamp: 1644845853887
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py310hca03da5_0.tar.bz2
   sha256: fe75ee2d49ecc10cd6b9caaf2800e687c9dd7b9fed6bef30f3ed2c547f7d9135
   md5: e38c094d6bb9e888c27e80421838f70b
   depends:
@@ -3739,7 +3739,7 @@ packages:
   license_family: MIT
   size: 134144
   timestamp: 1695717859882
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py310hca03da5_0.tar.bz2
   sha256: a9e8d204acd18d88e3d7bafdf4b186760aa70cbe05af7b772e2e89c0d622fcbe
   md5: ba1e27ad80d1ea30735bc6d50ad8de7e
   depends:
@@ -3749,12 +3749,12 @@ packages:
   license_family: MIT
   size: 210172
   timestamp: 1681493083831
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py310h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.2.1-py310h33ce5c2_0.tar.bz2
   sha256: b0f9f35148a0c19833db161db41322512880a3fc7ea5853745864122650d0117
   md5: d199b3fbf3bcf4b165bb779aca7ad26c
   depends:
@@ -3772,7 +3772,7 @@ packages:
   license_family: BSD
   size: 6476634
   timestamp: 1690546122888
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py310h96f19d2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py310h96f19d2_0.tar.bz2
   sha256: bb95775b0373a658338db915d396e3b15bfaa4638e3b1c871e93f403f175955a
   md5: 89f546ea159e7f93abe4478b57de86c9
   depends:
@@ -3782,7 +3782,7 @@ packages:
   license_family: BSD
   size: 120152
   timestamp: 1657175824776
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
   md5: f860193e14afc7ef3f5b990a2ac003d2
   depends:
@@ -3792,7 +3792,7 @@ packages:
   license: MIT
   size: 18936
   timestamp: 1659616204016
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
   sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
   md5: ad53130f3fd1f8d3c2fcbb7496e5585d
   depends:
@@ -3801,7 +3801,7 @@ packages:
   license: MIT
   size: 18715
   timestamp: 1659616188888
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py310hc377ac9_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py310hc377ac9_7.tar.bz2
   sha256: a9ddfe62150d43572c17bacfc7fe21cca54ee0ec70257bdb3f46341b4f4e5811
   md5: 447494f240be6ba630419e2e0d4da439
   depends:
@@ -3810,21 +3810,21 @@ packages:
   license: MIT
   size: 372230
   timestamp: 1659616285486
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
   sha256: 019469288da4767fd021f488b907e2f4f3b34db686fa12055d52d9bb7bb4d872
   md5: 9f63c782a4d20150ae9a664ee87cce16
   license: bzip2-1.0.6
   license_family: BSD
   size: 150682
   timestamp: 1624215191959
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
   sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
   md5: 31ac2f5596cb7a44adf073c930641c54
   license: MPL-2.0
   license_family: Other
   size: 133817
   timestamp: 1694009762858
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py310hca03da5_0.tar.bz2
   sha256: 5250d84793f93e22c917b89c6e0c0b3d679ab851e21f14961ac09140060b44ea
   md5: 87f8474b08ef5467ece8b01444b3207f
   depends:
@@ -3833,7 +3833,7 @@ packages:
   license_family: Other
   size: 159793
   timestamp: 1690232325493
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py310h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py310h80987f9_3.tar.bz2
   sha256: 906fc6df2c6cf27d54fd51f7330fd5d5af8e30c435edf69957461a2d8411ba94
   md5: dcbdc86631c5c07e3492c49d7084efcb
   depends:
@@ -3844,7 +3844,7 @@ packages:
   license_family: MIT
   size: 227157
   timestamp: 1670423279818
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py310hca03da5_0.tar.bz2
   sha256: f79e98ee1009bda17065a22a17ea14a839d436c5807a6044e0a300b10d93c8c9
   md5: 69845f1299334fe1eee4ca3c6fd6cd77
   depends:
@@ -3854,7 +3854,7 @@ packages:
   license_family: CC
   size: 1942655
   timestamp: 1668084604892
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py310hca03da5_0.tar.bz2
   sha256: 0d96460ec2d66be2d1dd8183c82e6ec69b1185d25553a560c2adf0bd9b200f91
   md5: 8393a8d161630af4f51009518141f713
   depends:
@@ -3864,7 +3864,7 @@ packages:
   license_family: BSD
   size: 13688
   timestamp: 1671231144978
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py310h525c30c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py310h525c30c_0.tar.bz2
   sha256: e3ff8b4c9b051ab09155a8065ce900c1a36b2d43eba37686245f697cc3388f63
   md5: 4fe4492dce62492dfe12bc22541adc55
   depends:
@@ -3875,7 +3875,7 @@ packages:
   license_family: BSD
   size: 244141
   timestamp: 1663827577910
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py310hd4332d6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py310hd4332d6_0.tar.bz2
   sha256: bae16cbe2ee81bedfeed997406503e120a92e3ba170da657d28633c5a588de6f
   md5: 49bad9c3a61a06a888ae65cbee351ca6
   depends:
@@ -3888,7 +3888,7 @@ packages:
   license_family: BSD
   size: 1404143
   timestamp: 1694211691189
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py310h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py310h313beb8_0.tar.bz2
   sha256: cac66c2a69e5bee96de7a9a5be0ecace698915c107c9fa9047e884ca671413fe
   md5: 28e9929e5bb06bf8df0b540b2069ba33
   depends:
@@ -3898,7 +3898,7 @@ packages:
   license_family: MIT
   size: 2075348
   timestamp: 1690905262055
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py310hca03da5_0.tar.bz2
   sha256: 1d532b889e0e71fe68f59e0fd328fe4c42c11660de3a32a0e31fe149f02a3eb5
   md5: f5ec34d95710f724fd4b4c064ed0abcd
   depends:
@@ -3907,7 +3907,7 @@ packages:
   license_family: MIT
   size: 15257
   timestamp: 1650293833649
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py310hca03da5_0.tar.bz2
   sha256: e07e960cb79989d664cd2028560a3af63bddec35a1bf1b2443e97c007884c786
   md5: 4be55fb58220d2ec53b7c7c2da96cb8e
   depends:
@@ -3916,7 +3916,7 @@ packages:
   license_family: BSD
   size: 27899
   timestamp: 1668714429621
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -3926,14 +3926,14 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
   sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
   md5: 1d0bd7e576c64c059ef781dd319ad82a
   license: MIT
   license_family: MIT
   size: 77591
   timestamp: 1676983230102
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.17.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.17.1-py310hca03da5_0.tar.bz2
   sha256: 3f16f886fb136d2b57f708f5d0e04616f4dd4da5e2e8309d9c10d9c54c4babf9
   md5: 1645f835fdbc218e042c4d7e9141d81c
   depends:
@@ -3950,7 +3950,7 @@ packages:
   license_family: BSD
   size: 4501591
   timestamp: 1693378202363
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
   sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
   md5: 69eb3b03765627b6159ed23cdde78396
   depends:
@@ -3959,7 +3959,7 @@ packages:
   license_family: MIT
   size: 28399065
   timestamp: 1692293207812
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py310hca03da5_0.tar.bz2
   sha256: 5017baf9a8738093eed8cb5aa3e0194c33c8d8f8fdf371a5d14a1954c9ff726a
   md5: bbb580008f67de323af6c3ae9a74937c
   depends:
@@ -3968,7 +3968,7 @@ packages:
   license_family: BSD
   size: 117075
   timestamp: 1666125600066
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py310h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py310h33ce5c2_0.tar.bz2
   sha256: dc9d40c2f7718f40ac7d9660f717d3dd5bb108470c1a3254b5d2bb68c83e71b8
   md5: 4fbeb0ce7491c146ce1dba75fa9a37a0
   depends:
@@ -3990,7 +3990,7 @@ packages:
   license_family: BSD
   size: 222070
   timestamp: 1691121668519
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py310hca03da5_0.tar.bz2
   sha256: fdf971d7a35b30a12db7fdd122e193fe7bc3d00abb584cb0f0a328316e154011
   md5: 1246d35ee1e4e48f0be379f9c71b2cad
   depends:
@@ -4011,7 +4011,7 @@ packages:
   license_family: BSD
   size: 1275330
   timestamp: 1694181377825
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py310hca03da5_1.tar.bz2
   sha256: bf77c0425ac78e734e7ad96610b53e8c6d79c8ba81e43157344f37f2fc2e53fb
   md5: a29c97649beaa0409e53883280b57456
   depends:
@@ -4021,7 +4021,7 @@ packages:
   license_family: MIT
   size: 1026561
   timestamp: 1644316081070
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py310hca03da5_0.tar.bz2
   sha256: 7c3cbf001d0a289e29ce708d973d5e780a36fd923f3fe02185a104ae5cb4cf53
   md5: 62745f1b50b4627d478d87e45a82ca12
   depends:
@@ -4031,14 +4031,14 @@ packages:
   license_family: BSD
   size: 218104
   timestamp: 1666908165640
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
   sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
   md5: 055e12390b844ea6c6e956ee08a618e8
   license: IJG
   license_family: Other
   size: 273479
   timestamp: 1677849171867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py310hca03da5_0.tar.bz2
   sha256: 61cac8c3c495c9bd4929cd425d579e2af6cec549170f7d16cf6ddbc8f6622bd8
   md5: 30956a5c5dab2c9358d6d27cb08bc489
   depends:
@@ -4049,7 +4049,7 @@ packages:
   license_family: MIT
   size: 134350
   timestamp: 1676558790619
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py310hca03da5_0.tar.bz2
   sha256: f723762f6638ac41a57cf16527d87ca94e3d1e60cd404fd58d694bf4b15c6267
   md5: cc8524666e2ac097a9c54a077e3a776c
   depends:
@@ -4065,7 +4065,7 @@ packages:
   license_family: BSD
   size: 199244
   timestamp: 1676329389846
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py310hca03da5_0.tar.bz2
   sha256: a3001bf850c4eb6bd991e5755d384483003b0e6384e470a06d44d3049b643f90
   md5: 83e9dbb1e2ee32a633c902d284fe1295
   depends:
@@ -4076,7 +4076,7 @@ packages:
   license_family: BSD
   size: 93396
   timestamp: 1679906691116
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py310hca03da5_0.tar.bz2
   sha256: cbc4401a0093ec9fd49e7dea062fd9b7a2d957243918169998bfbc935d4f9015
   md5: b6039d2abd7aeb7095546c6cce193893
   depends:
@@ -4100,7 +4100,7 @@ packages:
   license_family: BSD
   size: 402719
   timestamp: 1671707717154
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py310h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py310h313beb8_0.tar.bz2
   sha256: 379b8b9c8e45b813e6d31a712c2d5c8ae5801570b4717626971fabe87938c51f
   md5: 2ff257d592914060b35560de4fe1c83f
   depends:
@@ -4110,7 +4110,7 @@ packages:
   license_family: BSD
   size: 64635
   timestamp: 1672387310531
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -4120,7 +4120,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -4129,13 +4129,13 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
   md5: a0f206782751dfffed0dd51302a1bf26
   license: MIT
   size: 68012
   timestamp: 1659616138077
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
   md5: 4c6667cdd061d28e9bc4e4300e4d115e
   depends:
@@ -4143,7 +4143,7 @@ packages:
   license: MIT
   size: 31173
   timestamp: 1659616155596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
   md5: 637e9430e258ddf050623ef2360184d8
   depends:
@@ -4151,28 +4151,28 @@ packages:
   license: MIT
   size: 298430
   timestamp: 1659616172209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
   sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
   md5: 55c615026c0869f8d3ba657f3bd38c43
   license: MIT
   license_family: MIT
   size: 120389
   timestamp: 1683716579036
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -4181,7 +4181,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -4192,14 +4192,14 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
   sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
   md5: a41117710dafe569c9cc4e83f6f29fe3
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1411339
   timestamp: 1650982753977
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -4210,7 +4210,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -4219,13 +4219,13 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -4242,7 +4242,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
   sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
   md5: 98d22e0124d55fae3c37c608dab1dcc9
   depends:
@@ -4256,7 +4256,7 @@ packages:
   license_family: BSD
   size: 89825
   timestamp: 1694778225280
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
   sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
   md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
   constrains:
@@ -4265,7 +4265,7 @@ packages:
   license_family: BSD
   size: 331675
   timestamp: 1694776939192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
   sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
   md5: 0ba499df6755eae5d2d23aa4ab004553
   depends:
@@ -4277,7 +4277,7 @@ packages:
   license_family: MIT
   size: 642657
   timestamp: 1692970217410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
   sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
   md5: c73101971e5ab6a8e8688239884eac81
   depends:
@@ -4287,7 +4287,7 @@ packages:
   license_family: MIT
   size: 241607
   timestamp: 1692973585084
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py310hca03da5_0.tar.bz2
   sha256: 4e992da1d64efc2158c185b23883dee1e50ccc7a1ccb61d1b0546e6eb44bc536
   md5: aad3f66e7d96961764d2b5d0ab08efb3
   depends:
@@ -4297,7 +4297,7 @@ packages:
   license_family: MIT
   size: 36178
   timestamp: 1659783445874
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -4306,7 +4306,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py310h50ffb84_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py310h50ffb84_0.tar.bz2
   sha256: 1d4faae7e0c5d9abb237903c0b2305c74c43487c61ae667d154ee7c58c3aedef
   md5: 94d59d770946de5d7d08d46739d91aa3
   depends:
@@ -4317,7 +4317,7 @@ packages:
   license_family: Other
   size: 1490661
   timestamp: 1695058336218
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
   sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
   md5: c99006da802a97c9aae30da8c16b4820
   depends:
@@ -4326,7 +4326,7 @@ packages:
   license_family: BSD
   size: 176131
   timestamp: 1670944706815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py310hca03da5_0.tar.bz2
   sha256: 8303fcbfcdf8ab390e505f34c5ac6fa057815139d8e6cf7380dc108eb772485c
   md5: c769729b709fa4dd0a8da5be358de878
   depends:
@@ -4335,7 +4335,7 @@ packages:
   license_family: BSD
   size: 124217
   timestamp: 1671541964591
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py310hca03da5_1.tar.bz2
   sha256: b0e240d3ef06e292105f4e1b161426170e5897144c142d23df66935ab4108dc5
   md5: 8c6193fc54f6c300530527f642efadf1
   depends:
@@ -4345,7 +4345,7 @@ packages:
   license_family: MIT
   size: 108119
   timestamp: 1684279956548
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py310h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py310h1a28f6b_0.tar.bz2
   sha256: 408f7c132e7feae166a93d69bb85dc663f67d9a9ebce63de72cc9711863a970a
   md5: 7d61620437de9f62ee1d54ce53fee7d0
   depends:
@@ -4356,7 +4356,7 @@ packages:
   license_family: BSD
   size: 23377
   timestamp: 1654598111449
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py310h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py310h46d7db6_0.tar.bz2
   sha256: 17ad3ab86fbd774cb1129c10d735c431867ca6ee8e86c848980c01d5518fd3c6
   md5: 5f445a9b6e63e0e59991635fba7c34bc
   depends:
@@ -4377,7 +4377,7 @@ packages:
   license_family: PSF
   size: 8157070
   timestamp: 1698692208753
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py310hca03da5_0.tar.bz2
   sha256: 9cfad1d0d85bf4079262292b47e62355c7c1847f641ca8dfc46c4226bce2d785
   md5: b1a3a7ea89adee337db085727216abda
   depends:
@@ -4387,7 +4387,7 @@ packages:
   license_family: BSD
   size: 17383
   timestamp: 1662014500374
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py310hca03da5_0.tar.bz2
   sha256: 66e7f61e59f392a603639c284ce06bd2930a59270990089f602cdf2628467eb8
   md5: cf0c798d425a37c0404fd04da7afb640
   depends:
@@ -4397,7 +4397,7 @@ packages:
   license_family: MIT
   size: 54195
   timestamp: 1659721278389
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py310hca03da5_0.tar.bz2
   sha256: 7f85b9bd603910fee4f7ecac3fbc3eb4b978ab16ad2acd88d3d5a03b89c6bace
   md5: 984724161f039112bf536366c1332531
   depends:
@@ -4406,7 +4406,7 @@ packages:
   license_family: MIT
   size: 19648
   timestamp: 1659716071039
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py310h1a28f6b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py310h1a28f6b_1000.tar.bz2
   sha256: 6e5268ec49ec14a878619202872f376916e1f921ced05d95665e0161667c12de
   md5: 15a84e69027161b6891ee3e2573f00b7
   depends:
@@ -4415,7 +4415,7 @@ packages:
   license_family: BSD
   size: 55998
   timestamp: 1643966749532
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py310hca03da5_0.tar.bz2
   sha256: ee416a11885d65898b2d8bd22c91515f7ca34fb617c49540218a0d1e646c8e99
   md5: c6a3eb6ef4ccc860faa9f2e46f27787c
   depends:
@@ -4441,7 +4441,7 @@ packages:
   license_family: BSD
   size: 8291033
   timestamp: 1681756229533
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py310hca03da5_0.tar.bz2
   sha256: aec5ec1774397f5621e5593b0dc108a4e327b07314ea39b2529ca7a02607e730
   md5: 2699cbb6b7f2d98bf310172cec26ac11
   depends:
@@ -4454,7 +4454,7 @@ packages:
   license_family: BSD
   size: 97422
   timestamp: 1650373598939
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py310hca03da5_0.tar.bz2
   sha256: 298ce036c5bd3c96985385065a0a3970e6c015016a9b4605c8c9a85c5101f1ae
   md5: 3e0f7d130ecce4d47961fc086b9c8241
   depends:
@@ -4482,7 +4482,7 @@ packages:
   license_family: BSD
   size: 565126
   timestamp: 1668450717170
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py310hca03da5_0.tar.bz2
   sha256: 2ca888da7d4d25058cdf603b290ce3be700da9e7d6f48ab798077636318cee7c
   md5: 3b5870300d3ad885ee18c9ab13d620f5
   depends:
@@ -4495,14 +4495,14 @@ packages:
   license_family: BSD
   size: 149217
   timestamp: 1694616882123
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py310hca03da5_0.tar.bz2
   sha256: c60275ef60945a4be7a627d6f75aeda4d8845811ddef0ef8d9da5ff5e4313dd1
   md5: d09b0cf5410d5cf474e0b53d733b70e0
   depends:
@@ -4511,7 +4511,7 @@ packages:
   license_family: BSD
   size: 14207
   timestamp: 1672387183579
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py310hca03da5_1.tar.bz2
   sha256: 58ce1240d519353f46c912c05670e30a371a9a19678ed782178a90a2d8bbbb20
   md5: f4546e01c9182b6d82a95c99a2fc3230
   depends:
@@ -4536,7 +4536,7 @@ packages:
   license_family: BSD
   size: 588419
   timestamp: 1690984916773
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py310hca03da5_0.tar.bz2
   sha256: 9e43edd9d03f5aab39d7897befc25be58d2248440acac582a82a8d2530d3bd46
   md5: a2502e574a6a844b3276dfcf826a4b2e
   depends:
@@ -4546,7 +4546,7 @@ packages:
   license_family: BSD
   size: 22925
   timestamp: 1668160667137
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py310hecc3335_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py310hecc3335_0.tar.bz2
   sha256: a6a8b0d7b49057b07ebc0cc221674604d526bb7066afc62404b635e32ae8cf67
   md5: 34dd4756c394fb45a284a7ae913df3e3
   depends:
@@ -4557,7 +4557,7 @@ packages:
   license_family: MIT
   size: 127427
   timestamp: 1696515372844
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py310h3b2db8e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.0-py310h3b2db8e_0.tar.bz2
   sha256: 8e5f3e37e16e4f6d95513820d177c1ce51856bd3490248dc2cc5bad7243a440e
   md5: 0d387b30c16c06ad842c0a74e2a79f15
   depends:
@@ -4570,7 +4570,7 @@ packages:
   license_family: BSD
   size: 10380
   timestamp: 1695831144544
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py310ha9811e2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.0-py310ha9811e2_0.tar.bz2
   sha256: c0d375c130284bd551fd695b90ecdad52fd41fd2a21399d8158af8736e0217f9
   md5: 912d2cc8df65d3e1083b6333b2c92fde
   depends:
@@ -4584,7 +4584,7 @@ packages:
   license_family: BSD
   size: 6350032
   timestamp: 1695831132292
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
   sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
   md5: 371358a54bbdd307603888348d1a2c6f
   depends:
@@ -4594,7 +4594,7 @@ packages:
   license: BSD 2-Clause
   size: 412248
   timestamp: 1628861367714
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
   sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
   md5: fa15d3b44ae1360ac9b640bbd5b6923c
   depends:
@@ -4603,7 +4603,7 @@ packages:
   license_family: Apache
   size: 4746123
   timestamp: 1695322833432
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py310hca03da5_0.tar.bz2
   sha256: 93237eb96c47bb1d3af5a4df6da6604a45cd66c57793708afeef3878ae85e4eb
   md5: e482a7583e0bf5b5f5671c4a1b658af8
   depends:
@@ -4612,7 +4612,7 @@ packages:
   license_family: Apache
   size: 74436
   timestamp: 1693575224188
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py310h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.1.1-py310h46d7db6_0.tar.bz2
   sha256: 2f073b4803a981e2fc5b4e21b84a669a2e4c49c4f5233fe33a30c50a1cb11be5
   md5: c75f1ef14f245572becd5761a5c551d5
   depends:
@@ -4659,7 +4659,7 @@ packages:
   license_family: BSD
   size: 13400109
   timestamp: 1697477349034
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-1.2.3-py310hca03da5_0.tar.bz2
   sha256: 88811223659197b175b924057b7b5926c7093cded6f9a9aed5efb6452c2be8f1
   md5: dfb4aca8097e63f3db61cad638723639
   depends:
@@ -4683,7 +4683,7 @@ packages:
   license_family: BSD
   size: 17074981
   timestamp: 1695146365895
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-1.13.0-py310hca03da5_0.tar.bz2
   sha256: 958c77578e3569111c33fc9ddf8ec012f4d575818488d2704cf5d3a4c00a52c2
   md5: b0818352d65dc7ea4998a5790de52397
   depends:
@@ -4692,7 +4692,7 @@ packages:
   license_family: BSD
   size: 144036
   timestamp: 1684915352915
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py310h3b245a6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py310h3b245a6_0.tar.bz2
   sha256: a3d70106b4fd77ac519bf8bfcd141684874d0f0d4fea10d28e06319d388309de
   md5: 133adf01151d7d098cdbe71a9b6c87e5
   depends:
@@ -4711,7 +4711,7 @@ packages:
   license_family: Other
   size: 723566
   timestamp: 1696580116818
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py310hca03da5_0.tar.bz2
   sha256: 05c3517553b868e97fe5af7c168b896a4a5f4c948d9d96a9659eda79dfabda4a
   md5: 2d67c116129367a525bd758831df8355
   depends:
@@ -4722,7 +4722,7 @@ packages:
   license_family: MIT
   size: 2757569
   timestamp: 1697548846423
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py310hca03da5_0.tar.bz2
   sha256: f90967e7b1263de747709a00d54c5c41ef7efe03ece8b480cd2f811ed6da7e68
   md5: 68b0d1ba5f14b5296c2e880e3ce8e1cf
   depends:
@@ -4731,7 +4731,7 @@ packages:
   license_family: MIT
   size: 33194
   timestamp: 1692205719500
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py310hca03da5_0.tar.bz2
   sha256: cbcf62345c0121e1962743f0cde11b553c58338922df9b295b5f32e1e9160435
   md5: e347b5b10b9679c069716037fc8114b5
   depends:
@@ -4740,7 +4740,7 @@ packages:
   license_family: Apache
   size: 92103
   timestamp: 1659455169618
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py310hca03da5_0.tar.bz2
   sha256: 5edeee8adcb94bd9394247e5ba36b9ab551e708026c9183a6b1dfc29f6223c83
   md5: 77bb249fcdbd15c68965c3d8cbcfb007
   depends:
@@ -4752,7 +4752,7 @@ packages:
   license_family: BSD
   size: 601509
   timestamp: 1672387364356
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py310h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py310h1a28f6b_0.tar.bz2
   sha256: ddcca2ed0751d233e1953dcd1a373b1d778bd6c303e4bae3713fa7d20a814ed7
   md5: 2cb18e1233648dbd160770e5941bf588
   depends:
@@ -4761,7 +4761,7 @@ packages:
   license_family: BSD
   size: 372012
   timestamp: 1656431417953
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py310hca03da5_0.tar.bz2
   sha256: 7cbbdf3a39c721a4c72adf205043864da01ea31af29835014e8379e7c368b1cc
   md5: 0539e1b90082304925156fc822aad965
   depends:
@@ -4773,7 +4773,7 @@ packages:
   license_family: BSD
   size: 30983
   timestamp: 1675441560368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py310hca03da5_1.tar.bz2
   sha256: 5a345e4a9a6f8ff0264bd5a8238e591192915b99f44c75aef66033aecea15ec7
   md5: e2c9a794ff909ab32cc84c4fc6964a6d
   depends:
@@ -4782,7 +4782,7 @@ packages:
   license_family: BSD
   size: 1882595
   timestamp: 1684280055553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py310hca03da5_0.tar.bz2
   sha256: 271d303a73878efe49bd997962fb5ba474fb118cd03d44958a3f61d446d87521
   md5: bf861f951e567d14d903c7139c629d01
   depends:
@@ -4792,7 +4792,7 @@ packages:
   license_family: Apache
   size: 95814
   timestamp: 1690223518556
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py310hca03da5_0.tar.bz2
   sha256: 952097983b02f9cb5b1679bb251bffcb4f3465ac8393a09b0f630571e2cb9367
   md5: 16c9d43c3fbdfa9ff458e83ab1a2152f
   depends:
@@ -4801,7 +4801,7 @@ packages:
   license_family: MIT
   size: 159251
   timestamp: 1661452569469
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py310h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py310h1a28f6b_0.tar.bz2
   sha256: 80726e6021556bc2e26aca83b5959a45382273825f26013d15f9efd5720c93ba
   md5: 31392a859bf368e1e89f58ab59c72aa2
   depends:
@@ -4810,7 +4810,7 @@ packages:
   license_family: MIT
   size: 93727
   timestamp: 1643962200324
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py310hca03da5_0.tar.bz2
   sha256: 70946f5858f17fec169e726e761cce1d1f3e6a99ef3a8e72007c1df51e09d5a3
   md5: f9c6d792e5983df39d7dbb8389340e9a
   depends:
@@ -4819,7 +4819,7 @@ packages:
   license_family: BSD
   size: 28542
   timestamp: 1643961550827
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.10.13-hb885b13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.10.13-hb885b13_0.tar.bz2
   sha256: b927da0c1d2fc87459dea7cd33221f7dfc3f1d9f552abebdcbb35437dea6c2cd
   md5: 2058a138c3146791d7a04dc629716925
   depends:
@@ -4838,7 +4838,7 @@ packages:
   license_family: PSF
   size: 13888559
   timestamp: 1694438370078
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py310hca03da5_0.tar.bz2
   sha256: 79a47f968466e21cf9b323b9704f5f6e317f8865b1d20e01e290ab2003662f33
   md5: fac5645515e04c5ac0e47d80133671e2
   depends:
@@ -4847,7 +4847,7 @@ packages:
   license_family: BSD
   size: 267399
   timestamp: 1661368747513
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py310hca03da5_0.tar.bz2
   sha256: cb8650f9dbf55d92986b06947853974c670c58f549185b5ca2ec51df1f605532
   md5: b947a5ed2ee1aec93707bdab5bd13c23
   depends:
@@ -4856,7 +4856,7 @@ packages:
   license_family: MIT
   size: 253158
   timestamp: 1695131613841
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py310hca03da5_0.tar.bz2
   sha256: 7a8c9f6dcf55a081acbbeae8c42cfaa8f8f64b080a594c655987118e6abf616b
   md5: 7d17c4a9489fa213690b2c2976a763e7
   depends:
@@ -4866,7 +4866,7 @@ packages:
   license_family: BSD
   size: 41041
   timestamp: 1685030908266
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py310h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py310h80987f9_0.tar.bz2
   sha256: c3f5a9a25cdc410c00c59ea282ab308deb29f6ec08993e6a3eddf5134f399e62
   md5: e16c05a8ef62c241107fd99c5da05086
   depends:
@@ -4876,7 +4876,7 @@ packages:
   license_family: MIT
   size: 164816
   timestamp: 1698096085371
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py310hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py310hc377ac9_0.tar.bz2
   sha256: 2d8e1c3ebc2dd93e2276dfe3a819b7bc13b11847cd0b340ce15ae38e6133def7
   md5: 200930199ebb3996d82d40e15a959d14
   depends:
@@ -4887,7 +4887,7 @@ packages:
   license_family: BSD
   size: 491130
   timestamp: 1657724255034
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -4896,7 +4896,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py310hca03da5_0.tar.bz2
   sha256: 8e63cb176caf9b27833a45bec02246794098c9af4e1aec1d64de575975d93369
   md5: 8665a78622dbfca8b9cd1e449bcf14f3
   depends:
@@ -4912,7 +4912,7 @@ packages:
   license_family: Apache
   size: 96229
   timestamp: 1690400346206
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py310hca03da5_0.tar.bz2
   sha256: b1c75800067d9c147f57b5652ca11b86c215b0d1f4f997a0f7308d64f2eb8fcc
   md5: 5ac42342de04ece0c99e92baff7ea120
   depends:
@@ -4921,7 +4921,7 @@ packages:
   license_family: MIT
   size: 1101462
   timestamp: 1690290898451
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py310hca03da5_1.tar.bz2
   sha256: 000195489823f3e343b2542cd1a867f0cc2cfb4b86335adaf470fd854c7ecfc6
   md5: e62f5514aba294eb7ed6e791f5c1ca7a
   depends:
@@ -4930,7 +4930,7 @@ packages:
   license_family: Apache
   size: 15853
   timestamp: 1643964348442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py310hca03da5_0.tar.bz2
   sha256: 83f37d7fdb2ae2499a0d56b0d8b73aaea225272a1133ec83b7cb5a0b76dcc038
   md5: 4cf31645d894294b7542e108702346c3
   depends:
@@ -4939,7 +4939,7 @@ packages:
   license_family: MIT
   size: 67932
   timestamp: 1696347608160
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
   sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
   md5: 2302a79a045f152e183a52a81adfba62
   depends:
@@ -4951,7 +4951,7 @@ packages:
   license_family: Other
   size: 1674163
   timestamp: 1681394762218
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py310hca03da5_0.tar.bz2
   sha256: 683dfdcb2fa481064ecb68361103214c5c3f2734cceb055af3f93a2ae4863c01
   md5: 88e05e239da5183806dbebb6ac49cddf
   depends:
@@ -4962,7 +4962,7 @@ packages:
   license_family: BSD
   size: 31121
   timestamp: 1671751855788
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py310hca03da5_0.tar.bz2
   sha256: 1ff9b75217073a26f736b2fe32f9ccb77b145d7ff9099d5091b43276f92b1f12
   md5: 11474a3502e9b8c16e301569b7f3d8db
   depends:
@@ -4972,7 +4972,7 @@ packages:
   license_family: BSD
   size: 40061
   timestamp: 1668168847595
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
   sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
   md5: 667e60c8b407d73cbba40f44901f4f00
   depends:
@@ -4981,7 +4981,7 @@ packages:
   license_family: BSD
   size: 3412693
   timestamp: 1654088929697
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py310h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py310h80987f9_0.tar.bz2
   sha256: 48bf87c05fd656d65b64b12af2691d4c2f9fa9430f4b1b9b26a71a2264d442f3
   md5: 8d14ebb07457c238388f473cd0e4c706
   depends:
@@ -4990,7 +4990,7 @@ packages:
   license_family: Apache
   size: 688875
   timestamp: 1696937122724
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py310h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py310h33ce5c2_0.tar.bz2
   sha256: 5cac533c8684214f579bfdf8d8d4653953a525d7ed46772589fc528ee7960da7
   md5: 68442822b452de7cefb52492283a9306
   depends:
@@ -5003,7 +5003,7 @@ packages:
   license_family: MOZILLA
   size: 125939
   timestamp: 1679561891996
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py310hca03da5_0.tar.bz2
   sha256: 5d0e4a55ff115223ac5d160d461a1b6b9e2f238533c2209ca01fa09971da81c3
   md5: f012387fad7bb86a0412e2b296a3abae
   depends:
@@ -5012,7 +5012,7 @@ packages:
   license_family: BSD
   size: 195245
   timestamp: 1671143991865
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py310hca03da5_0.tar.bz2
   sha256: 564936845bc19e1ab445cdbec6a88332b5b65d30a6a54618000c462d7728e1f7
   md5: b92c68a3cd0f41c7168542112961df97
   depends:
@@ -5022,7 +5022,7 @@ packages:
   license_family: PSF
   size: 9653
   timestamp: 1690297564582
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py310hca03da5_0.tar.bz2
   sha256: de2bc98656fe8401dc78d4f2b2cef4b109c1548643ad3a339f5c52489c7eb598
   md5: 81f2601c88a0a620488e2f2ee345b644
   depends:
@@ -5031,7 +5031,7 @@ packages:
   license_family: PSF
   size: 58886
   timestamp: 1690297556078
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py310hca03da5_0.tar.bz2
   sha256: 824583d1b434a796b37b52eed6e4356ee22fb743bbef86fb59d059d100d9bbbb
   md5: d7f13af76ca65f6145c835983c1b42df
   depends:
@@ -5040,7 +5040,7 @@ packages:
   license_family: MIT
   size: 11622
   timestamp: 1659769445368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py310hca03da5_0.tar.bz2
   sha256: 24ede438e165023d63588e2450d925530c8d9b90686f24926c062129d34d5bea
   md5: 834ed587e0ca438269b20130dda88ece
   depends:
@@ -5055,7 +5055,7 @@ packages:
   license_family: MIT
   size: 190320
   timestamp: 1698257654517
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py310hca03da5_1.tar.bz2
   sha256: 380724b46ae0ae1edb42bc668055aa2f27af3054d866b1e67e5acbb8481cd3a7
   md5: 6bf29c754086a9d03490af7ef3f22e6d
   depends:
@@ -5064,7 +5064,7 @@ packages:
   license_family: BSD
   size: 21597
   timestamp: 1643962111312
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py310hca03da5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py310hca03da5_4.tar.bz2
   sha256: 1af1e23c6dfdce91baa30e99db00d69fe7cfcc0aaf552be2edde3ed62008bf33
   md5: d4ebbbf7f634114a203c3de7192e757a
   depends:
@@ -5074,7 +5074,7 @@ packages:
   license_family: BSD
   size: 71591
   timestamp: 1643972675082
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py310hca03da5_0.tar.bz2
   sha256: 63ab5b0021036bc3301b65ae76a529d74396017a26374decfdff9a17d2c66b14
   md5: acbbff48bc203d9111378db9dd1bbf31
   depends:
@@ -5083,7 +5083,7 @@ packages:
   license_family: MIT
   size: 103521
   timestamp: 1695741952847
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py310hca03da5_1.tar.bz2
   sha256: d1ff32f75206387e8ab53e1b2253668fb79d18f79811f4547fd204093a9d75f7
   md5: 7083a0ee005b52138b63e2c3ef37df4b
   depends:
@@ -5092,20 +5092,20 @@ packages:
   license_family: BSD
   size: 49594
   timestamp: 1675159129875
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
   sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
   md5: 2e75ad6a09c308268192efe03cc9ebf4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 411778
   timestamp: 1683113019715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
   sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
   md5: 30f666bf97c26587c5d2f68cc5f330ab
   depends:
@@ -5114,14 +5114,14 @@ packages:
   license: LGPL-3.0-or-later
   size: 316901
   timestamp: 1629287855861
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
   sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
   md5: 467ae28215d1aa1c5688bc0c8a184269
   license: Zlib
   license_family: Other
   size: 103525
   timestamp: 1666595022664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
   sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
   md5: 7cfbed15f1feee1422810f7830075f53
   depends:
@@ -5133,7 +5133,7 @@ packages:
   license_family: BSD
   size: 779464
   timestamp: 1681304594848
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py310haa95532_0.tar.bz2
   sha256: 13fd982429e1737c4d19c8c886bf0ed3486217cf5c152006144c877deb332259
   md5: 3820014684604f5d3252b882f8aaab33
   depends:
@@ -5146,7 +5146,7 @@ packages:
   license_family: MIT
   size: 165811
   timestamp: 1644481936737
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py310h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py310h2bbff1b_0.tar.bz2
   sha256: b1f650ded18f00b931bca2cfbe25d23234ebc094ceb1ff90ca0f9748773d77b0
   md5: 2ab6af43f2a175c8cd55263ce03730e9
   depends:
@@ -5158,7 +5158,7 @@ packages:
   license_family: MIT
   size: 39303
   timestamp: 1644569997665
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py310haa95532_0.tar.bz2
   sha256: b52ffec0004d25c4678f19f9d9bf697dba0639d5efae5c4ce8cafea0a236a293
   md5: ec8397c5b9126de5ac348175c3c8ea5a
   depends:
@@ -5167,7 +5167,7 @@ packages:
   license_family: MIT
   size: 133182
   timestamp: 1695718150313
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py310haa95532_0.tar.bz2
   sha256: c4c4c977a91a6cdf710bd55479d84fcbc3336a48d7029254030657b00d915ded
   md5: 8ebad46690b1b1b28880d4ace9e21e8f
   depends:
@@ -5177,12 +5177,12 @@ packages:
   license_family: MIT
   size: 203162
   timestamp: 1681493178971
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py310h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-3.2.1-py310h9909e9c_0.tar.bz2
   sha256: 2ccaa7e04dde683da73d56723ef56400645fa1afd2d8e331928be62f7b7107c2
   md5: 266b810907097ebc53c36a71a872f4e4
   depends:
@@ -5200,7 +5200,7 @@ packages:
   license_family: BSD
   size: 6497005
   timestamp: 1690546680130
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py310h9128911_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py310h9128911_0.tar.bz2
   sha256: 42430813ea87898081645bafbbcb5b0c7d9bff4b740d3025e7e9de9aae82a0cb
   md5: 853f10d144193bf07981313f3f45be2e
   depends:
@@ -5212,7 +5212,7 @@ packages:
   license_family: BSD
   size: 119901
   timestamp: 1657176406189
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
   md5: 507dfe693ef429f466d964b599f4af21
   depends:
@@ -5224,7 +5224,7 @@ packages:
   license: MIT
   size: 18650
   timestamp: 1659616328001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
   md5: d0bf43e8df60baae3b3105aa5c42a791
   depends:
@@ -5235,7 +5235,7 @@ packages:
   license: MIT
   size: 21153
   timestamp: 1659616312367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py310hd77b12b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py310hd77b12b_7.tar.bz2
   sha256: d02d1373de2b868fa66dfdf2ec4297a5aec01725f0c76e64fef14db6e0f1b821
   md5: 6fcc544ea32b1fcb4e2eb2b673e44fab
   depends:
@@ -5245,7 +5245,7 @@ packages:
   license: MIT
   size: 342821
   timestamp: 1659616440229
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
   sha256: 3a26c397d4e0d546b0c2f433074c20813c5f3ae98bcf07a165c648f369a850b9
   md5: 8f8069ce8c9eff1b0f124de2c0a63b86
   depends:
@@ -5254,14 +5254,14 @@ packages:
   license_family: BSD
   size: 154105
   timestamp: 1563219293348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
   sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
   md5: 092b417c11edcbe6bb9b765ab4a55d23
   license: MPL-2.0
   license_family: Other
   size: 164999
   timestamp: 1694009822357
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py310haa95532_0.tar.bz2
   sha256: 5ee23e62406d6e08785f0e4633df85e7ca014fee65fc7e8237793eaab630807d
   md5: 9c41b340ab32284504915b516a9d66ff
   depends:
@@ -5270,7 +5270,7 @@ packages:
   license_family: Other
   size: 159587
   timestamp: 1690232391364
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py310h2bbff1b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py310h2bbff1b_3.tar.bz2
   sha256: e63d5278445148548991bd341db1602e30df6b543b00a5b08358e8387ad090e6
   md5: 133c206236d294bb655c080030e57952
   depends:
@@ -5282,7 +5282,7 @@ packages:
   license_family: MIT
   size: 230624
   timestamp: 1670423542690
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py310haa95532_0.tar.bz2
   sha256: 9d1b2c34fa17a72e4e7b265cb5a421bb1a6dc893b35209739f1b710f79ebcc19
   md5: 269703fa9499eb42cfd7b9fd349ecd22
   depends:
@@ -5291,7 +5291,7 @@ packages:
   license_family: BSD
   size: 30646
   timestamp: 1672387329696
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py310haa95532_0.tar.bz2
   sha256: 5cdb9f54359011390717ffe4b5ea95190ded7f3f7efd2a6823e39e7f55f51cb7
   md5: b52ec73e9b507f251db3e30c371805fc
   depends:
@@ -5301,7 +5301,7 @@ packages:
   license_family: CC
   size: 1948637
   timestamp: 1668085014506
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py310haa95532_0.tar.bz2
   sha256: bae568885d7c36869fd0c51846178adb5c3708485481447d71a4b902c2711a85
   md5: 737ebccb5ecc85d3dade710714f8987a
   depends:
@@ -5311,7 +5311,7 @@ packages:
   license_family: BSD
   size: 13525
   timestamp: 1671231256091
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py310h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py310h59b6b97_0.tar.bz2
   sha256: 173e74e92fcd519d9e7a0770194f7d27b573f6bae4d506261ab1c743a1824295
   md5: b9d7146c86ea3fc2eb35fc13cc3b9dc2
   depends:
@@ -5323,7 +5323,7 @@ packages:
   license_family: BSD
   size: 184388
   timestamp: 1663827960541
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py310h89fc84f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py310h89fc84f_0.tar.bz2
   sha256: d8f3f911996fae2cbbac0bbf36c6fcb219b56d6ecbc8f42eebbcf12d520e852c
   md5: 04006c1bd5e2631d658c932f86d1466c
   depends:
@@ -5338,7 +5338,7 @@ packages:
   license_family: BSD
   size: 1226697
   timestamp: 1694445334623
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py310hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py310hd77b12b_0.tar.bz2
   sha256: 847a1d4e079ce688c7e984cbf0c5c8a271c8e818c394433375b5a4f2b27beed1
   md5: 3e4eb1dbd11005205430e157cc260dd6
   depends:
@@ -5349,7 +5349,7 @@ packages:
   license_family: MIT
   size: 3304234
   timestamp: 1690907391803
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py310haa95532_0.tar.bz2
   sha256: 542db7e187d0a9fe16b6eacb6bb93e5d574d1956687553a85a33fd580ab6ab7c
   md5: efac5662f2dbe0fabf392e1dd89eb105
   depends:
@@ -5358,7 +5358,7 @@ packages:
   license_family: MIT
   size: 17084
   timestamp: 1649926751338
-- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py310haa95532_0.tar.bz2
   sha256: e39245b05e8e366255b4be0cb933d782e1878be9245df60170800b15f508442e
   md5: 9b633859a365fd5f57ff3a516c1cb630
   depends:
@@ -5367,7 +5367,7 @@ packages:
   license_family: BSD
   size: 27635
   timestamp: 1668714412704
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -5379,7 +5379,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
   sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
   md5: 9f167d3e45441bc3633c1974b1b0ce8c
   depends:
@@ -5389,7 +5389,7 @@ packages:
   license_family: MIT
   size: 88421
   timestamp: 1676983264486
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.17.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.17.1-py310haa95532_0.tar.bz2
   sha256: 86172e61afc03050a78493b413832f2387e7cfd68d9d32453536e62f4626f6b8
   md5: b7311d1b87f5f363f4a4c6886d66525f
   depends:
@@ -5406,7 +5406,7 @@ packages:
   license_family: BSD
   size: 4593112
   timestamp: 1693379101528
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.4-py310haa95532_0.tar.bz2
   sha256: cd9a29cd845807b2a9697878823e6100893eec51edba1f621ffa32264fb0cb4d
   md5: 407278e6cde931bab12b6b228233c12b
   depends:
@@ -5415,7 +5415,7 @@ packages:
   license_family: BSD
   size: 116780
   timestamp: 1666125624542
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
   sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
   md5: 9834848bd7c7759acf12e78d09388563
   depends:
@@ -5425,7 +5425,7 @@ packages:
   license_family: Proprietary
   size: 3891030
   timestamp: 1681801474383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py310h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py310h9909e9c_0.tar.bz2
   sha256: 15c175ea1869f4426dd50cb553e2a1e98aa6c0b47af072f99c6b06beb073b85d
   md5: 2c8adfc1ab10d1322349e1f76709fdfb
   depends:
@@ -5446,7 +5446,7 @@ packages:
   license_family: BSD
   size: 218950
   timestamp: 1691122141007
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py310haa95532_0.tar.bz2
   sha256: 23a5271531047c5e32399f465811f9e33db997568934f5c9a81e0d30b8c414ef
   md5: e3cdadcd40721ba52683bf56d526ec9d
   depends:
@@ -5466,7 +5466,7 @@ packages:
   license_family: BSD
   size: 1294993
   timestamp: 1694182107536
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py310haa95532_1.tar.bz2
   sha256: 0afd0d4f99429141bc4d58779e6ef67a5e38df2847c8a063fc2bcfab15456c9f
   md5: b7c6ad4ecb2e14de462b2e252beb9702
   depends:
@@ -5476,7 +5476,7 @@ packages:
   license_family: MIT
   size: 1054863
   timestamp: 1644315579242
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py310haa95532_0.tar.bz2
   sha256: bacd57df0050f020aa5d1903e9b1ae68b31fec8b1e1de1e7d4fc1138e7a6b246
   md5: e5c0ae2823b3401b98a266952536ef55
   depends:
@@ -5486,7 +5486,7 @@ packages:
   license_family: BSD
   size: 217598
   timestamp: 1666908197686
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
   sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
   md5: 81f2c343dc4c65eea39c45383272068f
   depends:
@@ -5496,7 +5496,7 @@ packages:
   license_family: Other
   size: 407861
   timestamp: 1677849239400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py310haa95532_0.tar.bz2
   sha256: 32526ef7954f7718c03b9d1f7ea55a542bb61918093df1a8b778557513b3c395
   md5: 8fef9e2c122553e30b3a52af7051c2ed
   depends:
@@ -5507,7 +5507,7 @@ packages:
   license_family: MIT
   size: 153127
   timestamp: 1676558962296
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py310haa95532_0.tar.bz2
   sha256: ac6b6415f82a703882ba07242d9b7a3aa7241d75795c29838e1f136f48f8f228
   md5: 9614757161de6dbd60002f047add9c65
   depends:
@@ -5523,7 +5523,7 @@ packages:
   license_family: BSD
   size: 231452
   timestamp: 1676331217788
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py310haa95532_0.tar.bz2
   sha256: e3d2d18e8e7598227bef203111240994ff26c6456306bef872abde12342abbd8
   md5: f72fd5f0195fa76e3764fdef27bc5113
   depends:
@@ -5535,7 +5535,7 @@ packages:
   license_family: BSD
   size: 117219
   timestamp: 1679906755172
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py310haa95532_0.tar.bz2
   sha256: 4495e6a31ba2f15bc110c1d2d04cf054a9be7732adea1de3670f6d816de7ebfe
   md5: b3dc66383a9768cd7589eec50ae475d7
   depends:
@@ -5560,7 +5560,7 @@ packages:
   license_family: BSD
   size: 416122
   timestamp: 1671707734329
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py310hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py310hd77b12b_0.tar.bz2
   sha256: 10f79ef1927aca5f33da1e87a065bef0edd0e7bf1c346172d0f54b9b6472cbd0
   md5: ffd45a996d8abf95243ca820e62e696a
   depends:
@@ -5571,7 +5571,7 @@ packages:
   license_family: BSD
   size: 62337
   timestamp: 1672388276172
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -5581,7 +5581,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
   sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
   md5: c345f51706eef530454f66b794e5e574
   depends:
@@ -5590,7 +5590,7 @@ packages:
   license: MIT
   size: 68189
   timestamp: 1659616216976
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
   md5: a7400cfb72042977bc047909ed504ce8
   depends:
@@ -5600,7 +5600,7 @@ packages:
   license: MIT
   size: 33743
   timestamp: 1659616248209
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
   md5: 6307f6854754ab5bd7c84e6998385bb1
   depends:
@@ -5610,7 +5610,7 @@ packages:
   license: MIT
   size: 733177
   timestamp: 1659616279453
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -5620,7 +5620,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_0.tar.bz2
   sha256: 1b3b9be41dba504e468a336196de9fd09568ba42585e493888aaa3708f687d0a
   md5: 5cdcd99f18d9dedb772d272088e72b4c
   depends:
@@ -5630,7 +5630,7 @@ packages:
   license_family: MIT
   size: 116942
   timestamp: 1683716620230
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
   sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
   md5: b812bc5d9c76242e2bb2ac87afe7d39b
   depends:
@@ -5640,7 +5640,7 @@ packages:
   license_family: GPL3
   size: 730280
   timestamp: 1650983734373
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -5651,7 +5651,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -5660,7 +5660,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -5677,7 +5677,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
   sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
   md5: ba9418df9288a2f031a02fa35b774ce0
   depends:
@@ -5693,7 +5693,7 @@ packages:
   license_family: BSD
   size: 78524
   timestamp: 1694778314659
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
   sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
   md5: b1781519a200ccbfcb4a1194005aa3ef
   depends:
@@ -5705,7 +5705,7 @@ packages:
   license_family: BSD
   size: 338459
   timestamp: 1694777084290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
   sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
   md5: 6ece7f1a3248169837714d05d7f6ef0a
   depends:
@@ -5717,7 +5717,7 @@ packages:
   license_family: MIT
   size: 3513910
   timestamp: 1692971505729
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
   sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
   md5: bd7ec244935e83e850a4ff34e8e2e64f
   depends:
@@ -5728,7 +5728,7 @@ packages:
   license_family: MIT
   size: 513971
   timestamp: 1692973657152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py310haa95532_0.tar.bz2
   sha256: b957593b060cc76d1e8376af052749f66268e81df18e7e8020b5d8fe5fe84690
   md5: 4cea845047b0d40302f260127d1d02d9
   depends:
@@ -5738,7 +5738,7 @@ packages:
   license_family: MIT
   size: 35946
   timestamp: 1659783477621
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py310h09808a7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py310h09808a7_0.tar.bz2
   sha256: ac823b3cb63c74d34df292cca72bd71c8576e84165ab0cfebfb973042711b7a3
   md5: 34bb76c12bbfcfa7e0412be5dce83860
   depends:
@@ -5751,7 +5751,7 @@ packages:
   license_family: Other
   size: 1222879
   timestamp: 1695058396030
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
   sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
   md5: 6970c7f46b0164cad1d210e7a1419959
   depends:
@@ -5761,7 +5761,7 @@ packages:
   license_family: BSD
   size: 143434
   timestamp: 1670944902624
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py310haa95532_0.tar.bz2
   sha256: 88e0ad9a62f0e385ed4a36fc1bbb088a49065fafa4f08daac7c846fce26b6540
   md5: af908af5ac51eafcb7e6332cd02c0d21
   depends:
@@ -5770,7 +5770,7 @@ packages:
   license_family: BSD
   size: 143240
   timestamp: 1671542001479
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py310haa95532_1.tar.bz2
   sha256: ab424b8036257c53eb5110f8d8817ed959718c275e2dff88407332ce783519ed
   md5: 24f0c3faa37da73027d950da5b6cd3d3
   depends:
@@ -5780,7 +5780,7 @@ packages:
   license_family: MIT
   size: 126331
   timestamp: 1684280061614
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py310h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py310h2bbff1b_0.tar.bz2
   sha256: cca6779dde2ebc8bb63aee472c86fc8d5996710be2a73b840dc76ef8e07e68cb
   md5: 78c57d6739e4fa5af54a97b14571f861
   depends:
@@ -5793,7 +5793,7 @@ packages:
   license_family: BSD
   size: 28649
   timestamp: 1654508138547
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py310h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py310h4ed8f06_0.tar.bz2
   sha256: 4d00cf08045a80ab68bd61865c2f5ced6cfc360341a67e93f198a7a4e5577f16
   md5: 5bf45bd512276669b9f86860b52afa8d
   depends:
@@ -5815,7 +5815,7 @@ packages:
   license_family: PSF
   size: 8123888
   timestamp: 1698692488191
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py310haa95532_0.tar.bz2
   sha256: cb2d90330a1c1bb4ae18110e7bc14f50287c6d603cf9c270cf98b72962ce3ea9
   md5: 7e5b432f39238f991ea8e6c21fc7cc68
   depends:
@@ -5825,7 +5825,7 @@ packages:
   license_family: BSD
   size: 18107
   timestamp: 1661934176570
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py310haa95532_0.tar.bz2
   sha256: 8cac05d7cf61a8d4011fce8e0f3b109f8d94f06ea0dc9e0a7f0e8b208a054193
   md5: 2cd828af0c9e8a8ecce14355b5619667
   depends:
@@ -5835,7 +5835,7 @@ packages:
   license_family: MIT
   size: 53824
   timestamp: 1659721375084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py310haa95532_0.tar.bz2
   sha256: 31152e14e45c00f079582bf2f32742b0ee2e23bd28904715092661fb7fd1d5b8
   md5: 5205f987d201c5de2925956b8f9d8caa
   depends:
@@ -5844,7 +5844,7 @@ packages:
   license_family: MIT
   size: 19459
   timestamp: 1659716154851
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py310h2bbff1b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py310h2bbff1b_1000.tar.bz2
   sha256: 7b9b506f48183d7c27e0fbd96f67e4aaf666a2f0af31ab4e8c2a33db072f1ee9
   md5: 4cb169fc0c073895a990bc57fd9250af
   depends:
@@ -5855,7 +5855,7 @@ packages:
   license_family: BSD
   size: 55776
   timestamp: 1642084197341
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
   sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
   md5: 5e763c995ff0c549f68a10bce70fede4
   depends:
@@ -5867,7 +5867,7 @@ packages:
   license_family: Proprietary
   size: 187489950
   timestamp: 1691503804820
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py310h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py310h2bbff1b_1.tar.bz2
   sha256: 5f8249f157c4899b9c8339286067f77514e678ffa21aa03ab17812e8e96fb9d5
   md5: a6d45a65a7468b522cb88a8f54a97b40
   depends:
@@ -5879,7 +5879,7 @@ packages:
   license_family: BSD
   size: 49079
   timestamp: 1682974931077
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py310h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py310h2bbff1b_0.tar.bz2
   sha256: a9a69c26aebf41ea1b73fb1b93dc938c5b3fcc01a5b329924e01ffa3d3dca567
   md5: 6f4bc20ffabe932e1203d21c88d534a3
   depends:
@@ -5894,7 +5894,7 @@ packages:
   license_family: BSD
   size: 185058
   timestamp: 1695058617399
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py310h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py310h59b6b97_0.tar.bz2
   sha256: 78df91f430b13e4fb883f56c8079c0333160cd932a0f78115676eb55bebae2e3
   md5: cdbed1b6da0f67e2bf567d558e8df8ab
   depends:
@@ -5909,7 +5909,7 @@ packages:
   license_family: BSD
   size: 255283
   timestamp: 1695060019544
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py310haa95532_0.tar.bz2
   sha256: 0ecd16a20a7a7d0ccea061c7e0c7cfecfe9db556f86fd319cbcfe445e7f976ba
   md5: 58fb8247372e5f24411d2cd24bdd849d
   depends:
@@ -5935,7 +5935,7 @@ packages:
   license_family: BSD
   size: 8136529
   timestamp: 1681757529551
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py310haa95532_0.tar.bz2
   sha256: 8d0818da57652774f6bfa9656e68ada801d274bc53e33fa965b33cf1ffbf9b1d
   md5: 58807f326752a62ecba3ecbddfa2ee27
   depends:
@@ -5948,7 +5948,7 @@ packages:
   license_family: BSD
   size: 118835
   timestamp: 1650308692306
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py310haa95532_0.tar.bz2
   sha256: 0b833ca97add638a8cee5cd359f10c03388cd3f52a17d916ea8a484316e72ee3
   md5: 89416eb2988dd462bc1022d5fdea6ed8
   depends:
@@ -5976,7 +5976,7 @@ packages:
   license_family: BSD
   size: 598189
   timestamp: 1668450985682
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py310haa95532_0.tar.bz2
   sha256: fc524bd0412e44df58c74a2fe1bcffd5144c8e6b02dabc85e37c6b10e25dbd6d
   md5: 4721b97a4af2754a2931451abac90f66
   depends:
@@ -5989,7 +5989,7 @@ packages:
   license_family: BSD
   size: 167757
   timestamp: 1694616965307
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py310haa95532_0.tar.bz2
   sha256: 3a6a1bbb486a2bb074afe240dd4e36788a06d555d6e608ec2c5ddabce7129718
   md5: f2402bfc230f8ce5967ecc9106d02080
   depends:
@@ -5998,7 +5998,7 @@ packages:
   license_family: BSD
   size: 13892
   timestamp: 1672387381251
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py310haa95532_1.tar.bz2
   sha256: e12ff0ea72619dc0ca38a03b11c6ab9f81f9e3c89c5f13c97b5d6cb5526265f9
   md5: bd0c794050c1f8636a8dbc0e427d578f
   depends:
@@ -6023,7 +6023,7 @@ packages:
   license_family: BSD
   size: 612787
   timestamp: 1690985469949
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py310haa95532_0.tar.bz2
   sha256: 9b3509d9f413cb1e11bde8e46b8c3ade4803e76ae69cad2f103886ddd483f7d8
   md5: bb52427ea8777cb067600a5bbd10d75e
   depends:
@@ -6033,7 +6033,7 @@ packages:
   license_family: BSD
   size: 22564
   timestamp: 1668160647721
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py310h2cd9be0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py310h2cd9be0_0.tar.bz2
   sha256: fe4e6cd63421465b633b1dfbfe563f65cb98663aa7635c3faf3a91dc0efae606
   md5: 46e661250fef8884a0d0299b35993ba4
   depends:
@@ -6048,7 +6048,7 @@ packages:
   license_family: MIT
   size: 136272
   timestamp: 1696515576284
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py310h055cbcc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.26.0-py310h055cbcc_0.tar.bz2
   sha256: 1a9e2b92f92fb8b93b3b60be5548bbd3d158a31abbaf35e4543490165078810f
   md5: c88f44adc8655bbcc10800b0df493165
   depends:
@@ -6065,7 +6065,7 @@ packages:
   license_family: BSD
   size: 9907
   timestamp: 1695833681433
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py310h65a83cf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.0-py310h65a83cf_0.tar.bz2
   sha256: c4ce94f43e3af82b3903b2effc243533b98a1e0ef42c069fa0b24724bb6455b4
   md5: 25d52b1b2ce9e6b0908a9c7106d1e323
   depends:
@@ -6081,7 +6081,7 @@ packages:
   license_family: BSD
   size: 6785892
   timestamp: 1695833656818
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
   sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
   md5: ab07e2a27ac08afe3d0b4c0890b8486a
   depends:
@@ -6092,7 +6092,7 @@ packages:
   license: BSD 2-Clause
   size: 249316
   timestamp: 1630094024143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
   sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
   md5: 73b17037d87b5a58feb34dafc0538f7f
   depends:
@@ -6103,7 +6103,7 @@ packages:
   license_family: Apache
   size: 8058396
   timestamp: 1695324589828
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py310haa95532_0.tar.bz2
   sha256: e928dff568c116cf8eab555dc97a0316adf7ac91f237ba74d766603700180b3f
   md5: 5a70390791e717492016c3c2ea854a0e
   depends:
@@ -6112,7 +6112,7 @@ packages:
   license_family: Apache
   size: 73714
   timestamp: 1693575355290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py310h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-2.1.1-py310h4ed8f06_0.tar.bz2
   sha256: 4d40962b81389e06c1aa893ed74b72a831326d18379a9d90bb0214b07c42c9fb
   md5: 12e0e47046bfdd743cc3f296ea7307f5
   depends:
@@ -6160,7 +6160,7 @@ packages:
   license_family: BSD
   size: 12627118
   timestamp: 1697477662723
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-1.2.3-py310haa95532_0.tar.bz2
   sha256: 2f62ba591aea27c6f15773bdfdc09558fcadd11559e48aadc3ea69960bf1e113
   md5: ae943e3adf679487f8c691397d9fe533
   depends:
@@ -6184,7 +6184,7 @@ packages:
   license_family: BSD
   size: 17018899
   timestamp: 1695146622867
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-1.13.0-py310haa95532_0.tar.bz2
   sha256: 7d8d0ef93307680696d575a445b442de32320fa3eb4b2fc090164ff0ac7e17a8
   md5: 3eeea45a3f84b3b563e5990a36429dcb
   depends:
@@ -6193,7 +6193,7 @@ packages:
   license_family: BSD
   size: 143435
   timestamp: 1684915381677
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py310h045eedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py310h045eedc_0.tar.bz2
   sha256: e14f0ffad04b6052df8d5c062d2c5f4aebc9c427575d9a3b94a1b8f4935851bd
   md5: dcdcca0969f743b7c0afcb7bd32ce1af
   depends:
@@ -6212,7 +6212,7 @@ packages:
   license_family: Other
   size: 813714
   timestamp: 1696580634199
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-23.3-py310haa95532_0.tar.bz2
   sha256: 5cce15ad567bf7eb300af6c1ec94cb39db5b73143836089e755b0c8092f2a3fd
   md5: dcf2b3a10dc331ceef151b651e07626e
   depends:
@@ -6223,7 +6223,7 @@ packages:
   license_family: MIT
   size: 3090037
   timestamp: 1697549089299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py310haa95532_0.tar.bz2
   sha256: e471553584e2ed5971404849a37358d13f08fabe18b0ef3ef33a3a0bc1a22fa3
   md5: c5ebdddd493f77c393cc043a457a231b
   depends:
@@ -6232,7 +6232,7 @@ packages:
   license_family: MIT
   size: 32580
   timestamp: 1692205629751
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py310haa95532_0.tar.bz2
   sha256: c71476dc289e2c3e6711914cd2a8065b9b23b050d358f2edf1d6e7ce92c432ab
   md5: e0882c5fb058a7242e98c9c390dccde2
   depends:
@@ -6241,7 +6241,7 @@ packages:
   license_family: Apache
   size: 91989
   timestamp: 1659455185228
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py310haa95532_0.tar.bz2
   sha256: 4b35a6959ddc76b30270c6140878f38a8d144f916f2270455d876cc3fed5541a
   md5: f2d689ceb3c687d5242da49928cc59c0
   depends:
@@ -6253,7 +6253,7 @@ packages:
   license_family: BSD
   size: 600281
   timestamp: 1672387969503
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py310h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py310h2bbff1b_0.tar.bz2
   sha256: 8ba826d7c49fd587064175395cb0b4c956fff616b1866b4b8eaefa6baabc3415
   md5: 8cfb596037d09d397df9bfddc7ea62a5
   depends:
@@ -6264,7 +6264,7 @@ packages:
   license_family: BSD
   size: 375863
   timestamp: 1656431373274
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py310haa95532_0.tar.bz2
   sha256: 9294dbfe51fbdba2a81b4fbf42f45cfd1e9a5ca8103e9835feecc026e72ab397
   md5: 676088abc6448a356286bfb0cccf9d07
   depends:
@@ -6276,7 +6276,7 @@ packages:
   license_family: BSD
   size: 48605
   timestamp: 1675450476501
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py310haa95532_1.tar.bz2
   sha256: 0425af15c734660310fd267c19aca5c8bac712f737e4b97d8fcefe38c0a9886d
   md5: 3aa71810eb4ca6e3edd0398763f6f269
   depends:
@@ -6285,7 +6285,7 @@ packages:
   license_family: BSD
   size: 1903399
   timestamp: 1684280387582
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py310haa95532_0.tar.bz2
   sha256: 48d4e140b012d95051d40ea19668b4660a5b35423233a4a86e09086e2803cdd8
   md5: 3909ea700a127b6a649ea8b5859ebf2e
   depends:
@@ -6295,7 +6295,7 @@ packages:
   license_family: Apache
   size: 95255
   timestamp: 1690225526774
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py310haa95532_0.tar.bz2
   sha256: 29adffad9359f41e32bddcd4e0202f88e1f82254f739a767d702fb7665163fda
   md5: 70d08505015f3ab10c9d31c86441a1e1
   depends:
@@ -6304,7 +6304,7 @@ packages:
   license_family: MIT
   size: 158947
   timestamp: 1661452750809
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py310h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py310h2bbff1b_0.tar.bz2
   sha256: a7154f626c11f905afb0647379f1f56b6a84304a43b0ec6e18123b8de297978c
   md5: 6e793acbb30fa04299c06bbcb0d86809
   depends:
@@ -6315,7 +6315,7 @@ packages:
   license_family: MIT
   size: 88390
   timestamp: 1642117156794
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py310haa95532_0.tar.bz2
   sha256: 079bb5bd27170316f111209f6e034308fa6443102e62a2e29c58f73089356e37
   md5: 8eb51a59b8c2d264f072b9686f08554b
   depends:
@@ -6325,7 +6325,7 @@ packages:
   license_family: BSD
   size: 28442
   timestamp: 1642089401419
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.10.13-he1021f5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.10.13-he1021f5_0.tar.bz2
   sha256: 5027caf55d479d2bc69ce2cb05add913d693ca6eef29b98ed32a337b6f61c484
   md5: 06cf057afa5dfcd5c065f254327dadf8
   depends:
@@ -6346,7 +6346,7 @@ packages:
   license_family: PSF
   size: 16987973
   timestamp: 1694438940131
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py310haa95532_0.tar.bz2
   sha256: 352dbdde953be659f973fed0bf2753dbfc4a4412afaf8346b7cec231a2821bf7
   md5: 4b33d277fdc29fa891f48ed17aca03c1
   depends:
@@ -6355,7 +6355,7 @@ packages:
   license_family: BSD
   size: 270287
   timestamp: 1661376660131
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py310haa95532_0.tar.bz2
   sha256: 17d84f4d97cd7963a1f822c216b6bfe6e10d879a4e7ca38cbd6299215a661c06
   md5: dc045c7ebc22dbe30073071c3c3f926c
   depends:
@@ -6364,7 +6364,7 @@ packages:
   license_family: MIT
   size: 264945
   timestamp: 1695131888424
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py310haa95532_0.tar.bz2
   sha256: f0002cb60435d0c3acce4aca0b8793f2a5540502689185008091c7750d91f263
   md5: 155c58c52114dfdc2b9c212552ed4e29
   depends:
@@ -6374,7 +6374,7 @@ packages:
   license_family: BSD
   size: 40254
   timestamp: 1685031283281
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py310h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py310h2bbff1b_0.tar.bz2
   sha256: 9715738e6124de2510a3bf6ca945ba361fa27e3af60bcdf3a1bc25f9c0068b3b
   md5: b45930642e0ddbd43333c8a3ba4bc491
   depends:
@@ -6384,7 +6384,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13492611
   timestamp: 1669937046724
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py310h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py310h5da7b33_0.tar.bz2
   sha256: 5fca272384bcdd93c4caa9a753fc514b7e29d734498147c8fd26a52e3cadc2b8
   md5: 1992345047b4f1ed52e7f85b5a0e143e
   depends:
@@ -6396,7 +6396,7 @@ packages:
   license_family: MIT
   size: 234279
   timestamp: 1677610684013
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py310h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py310h2bbff1b_0.tar.bz2
   sha256: eb7e5c8ded28393c9c8db670f60c9e1a14d12bb017f8cc412c804af8afd1889b
   md5: 761bb45b296122ff2c2416e353007b50
   depends:
@@ -6408,7 +6408,7 @@ packages:
   license_family: MIT
   size: 153027
   timestamp: 1698096448626
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py310hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py310hd77b12b_0.tar.bz2
   sha256: 63366e304172ca8a18b170ef322cc51055b27b16390ab1bf05ba3ef20348ab0a
   md5: 3fd4cac25b4aa04c5ffec581fe8b8c19
   depends:
@@ -6420,7 +6420,7 @@ packages:
   license_family: BSD
   size: 452315
   timestamp: 1657616132820
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py310haa95532_0.tar.bz2
   sha256: 02701b8ad70d95006ccbee4601e527f84c5029b35738923ca93b0b040dc752a7
   md5: 0d1ce48ae3413d8328bb32ac3586b9a2
   depends:
@@ -6436,7 +6436,7 @@ packages:
   license_family: Apache
   size: 95410
   timestamp: 1690400388066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py310haa95532_0.tar.bz2
   sha256: 5dde38dba1af77afc49f44607ca9376503343abda2a413264b9ba49fc1532d9d
   md5: ff11aa4f430cf334bad62438098317f6
   depends:
@@ -6445,7 +6445,7 @@ packages:
   license_family: MIT
   size: 1107347
   timestamp: 1690291154228
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py310haa95532_1.tar.bz2
   sha256: 569af333ddf0153396422defcef42cb4b2d78a027312b59400d5285f410b918d
   md5: 0c1af441d87ed1e7eb60a5dea7fed5df
   depends:
@@ -6454,7 +6454,7 @@ packages:
   license_family: Apache
   size: 15818
   timestamp: 1642092199263
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py310haa95532_0.tar.bz2
   sha256: a23892e537aa5387f4a7e817dfdcc4b9c5fec6b40a1695f99ecb7e3896f8f1b3
   md5: 022293f076961b460cfe654421c3a69a
   depends:
@@ -6463,7 +6463,7 @@ packages:
   license_family: MIT
   size: 67725
   timestamp: 1696347732280
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
   sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
   md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
   depends:
@@ -6473,7 +6473,7 @@ packages:
   license_family: Other
   size: 1311308
   timestamp: 1681402905668
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -6483,7 +6483,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py310haa95532_0.tar.bz2
   sha256: d0d86ed6cd7ce216d8e9c014ccec1aca485f273a0390acd7fce88b999c5c07fc
   md5: 0c1eef070bdc583a5f13ae6d90df9ce5
   depends:
@@ -6494,7 +6494,7 @@ packages:
   license_family: BSD
   size: 30837
   timestamp: 1671752231574
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py310haa95532_0.tar.bz2
   sha256: bc1ddb7012553cfd0e0dfd59ac053f2c248ed6aa2f3f073535c2e3727b156081
   md5: bea69cca66bf89b57764689750ad19b0
   depends:
@@ -6504,7 +6504,7 @@ packages:
   license_family: BSD
   size: 39827
   timestamp: 1668168932332
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
   sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
   md5: 52cdcdb96383c010ca833a7c24b3935b
   depends:
@@ -6514,7 +6514,7 @@ packages:
   license_family: BSD
   size: 3690152
   timestamp: 1654036853710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py310h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py310h2bbff1b_0.tar.bz2
   sha256: e50a692e7a49da9e7f543b8f93d2ef6be0f0b814b0201ba3e03c11cdf6419a5a
   md5: 2557ded281fd319351c3d3c67d7332f5
   depends:
@@ -6525,7 +6525,7 @@ packages:
   license_family: Apache
   size: 690076
   timestamp: 1696937432926
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py310h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py310h9909e9c_0.tar.bz2
   sha256: 0a8e653e44eb35226386ce3796e602c8b62563c132e54b4949764f7385ee0b9f
   md5: c9a498cdb375d5e877d3fa823236f523
   depends:
@@ -6539,7 +6539,7 @@ packages:
   license_family: MOZILLA
   size: 144538
   timestamp: 1679561959497
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py310haa95532_0.tar.bz2
   sha256: 0ad5597762eaf2daae779e216aa12211a980a90272a38e0aab8c2def1b92163c
   md5: f97fb0e2c94c9c157c0761eb53ea36a1
   depends:
@@ -6548,7 +6548,7 @@ packages:
   license_family: BSD
   size: 194983
   timestamp: 1671144108028
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py310haa95532_0.tar.bz2
   sha256: 269fbb45f0a8a30aedda91e88758e8d88d552da0349e1f03ae2990f558615e96
   md5: 6798f519b46627f96159c290e41a1f9c
   depends:
@@ -6558,7 +6558,7 @@ packages:
   license_family: PSF
   size: 9275
   timestamp: 1690297966050
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py310haa95532_0.tar.bz2
   sha256: 61a4fa82d984385a15caedc47ea3cf6db4e92f5692eba76436e82ce003e8dae4
   md5: 5c78ae38dcb3715988dd4225e7c39c43
   depends:
@@ -6567,7 +6567,7 @@ packages:
   license_family: PSF
   size: 58380
   timestamp: 1690297951482
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py310haa95532_0.tar.bz2
   sha256: fb7d79c284177ec64a95e1786fae83070612ab4318a0cde9c4ed54fb4b95a031
   md5: c0297d13bebf64bb81c7d9ca9ebab5d1
   depends:
@@ -6576,7 +6576,7 @@ packages:
   license_family: MIT
   size: 11410
   timestamp: 1659769516199
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py310haa95532_0.tar.bz2
   sha256: f0682ed627aab2cfa804ea488eef5d1d9ccf186c5899b2c0a757c064272a734e
   md5: b972f371bef45c86f60b75d705b739de
   depends:
@@ -6591,7 +6591,7 @@ packages:
   license_family: MIT
   size: 190534
   timestamp: 1698257669737
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
   sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
   md5: 45ef24c486a484f079faf1dc90e4c7e9
   depends:
@@ -6600,12 +6600,12 @@ packages:
   license_family: BSD
   size: 8277
   timestamp: 1605602889180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
   sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
   md5: 4daaceb6cfc1af6274509081d8018ef1
   size: 2316783
   timestamp: 1605602872095
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py310haa95532_1.tar.bz2
   sha256: 5feccb42695e0a5f0d8e47806ec4a38d80812946bedff171a1b6bde5513843e7
   md5: 8719f9841803cf96f733f59aafbd147e
   depends:
@@ -6614,7 +6614,7 @@ packages:
   license_family: BSD
   size: 21579
   timestamp: 1642093965560
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py310haa95532_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py310haa95532_4.tar.bz2
   sha256: 817b30ed834a145aaff119991fd5a7a3314e84002d89bb41eb8c24cb3b5be00b
   md5: 8d197a8c69574b3efd963be618ac1138
   depends:
@@ -6624,7 +6624,7 @@ packages:
   license_family: BSD
   size: 73599
   timestamp: 1642093997435
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py310haa95532_0.tar.bz2
   sha256: cefd8ed6d60b0eee5f46993e5629240d255e18808415b1283d1ec7881bcc0b0a
   md5: 25769ac748c7674ec15eea828dee97dd
   depends:
@@ -6633,7 +6633,7 @@ packages:
   license_family: MIT
   size: 122045
   timestamp: 1695742066400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py310haa95532_0.tar.bz2
   sha256: 7c5b72bec25fabcb0a6644acee0a3f45c17d535780581a17ec6616ecd21b284d
   md5: 43afdf809d6ddf58af49fb1fc5230808
   depends:
@@ -6641,13 +6641,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 8531
   timestamp: 1642658494153
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py310haa95532_1.tar.bz2
   sha256: 67ae0c5a80eaa449ba31d96276218bb503b2a4b1cafe064376f26d5a227e98c7
   md5: 1cb14e0e9baf9ecb93a9268246620454
   depends:
@@ -6656,7 +6656,7 @@ packages:
   license_family: BSD
   size: 48944
   timestamp: 1675159282275
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
   sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
   md5: c3f7871e9a33adeccee1b1e8e216918e
   depends:
@@ -6666,7 +6666,7 @@ packages:
   license_family: GPL2
   size: 1332571
   timestamp: 1683113347814
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -6675,7 +6675,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
   sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
   md5: 1ab55f8c4b5292ec360c572120bf823e
   depends:
@@ -6685,7 +6685,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 9430705
   timestamp: 1616055773485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
   sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
   md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
   depends:
@@ -6695,7 +6695,7 @@ packages:
   license_family: Other
   size: 148931
   timestamp: 1666595229032
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
   sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
   md5: 8d6a1e767775fe0eb617cd6e22edc2ff
   depends:

--- a/euler/pixi.lock
+++ b/euler/pixi.lock
@@ -1,0 +1,6710 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py310h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py310h9102076_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py310h7f8727e_1002.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py310hd667e15_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py310h130f0dd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py310h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py310h2f386ee_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py310h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py310h1f438cf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py310h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py310ha18d171_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py310h7f8727e_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py310h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py310hd6ae3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py310h00e6091_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.7.3-py310hd732450_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py310hfa59a62_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py310h9585f30_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py310h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py310h22f2fdc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py310h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py310h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.10.4-h12debd9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py310h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py310h295c915_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py310h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py310h2f386ee_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py310h06a4308_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py310hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py310hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py310h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py310h4e76f89_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py310he9d5cce_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py310h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py310haf03e11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py310h30e54ef_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py310hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.17.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py310h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py310hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py310hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py310h946e0e5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py310hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py310hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py310hb47e01b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py310hca72f7f_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py310h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py310h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py310ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py310hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py310h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py310h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py310ha186be2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py310h3ea8b11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py310h7d39338_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py310hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py310hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py310hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.10.13-h5ee71fb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py310h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py310he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py310hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py310h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py310h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py310hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py310hecd8cb5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py310hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py310hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py310h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py310h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py310h96f19d2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py310hc377ac9_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py310h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py310h525c30c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py310hd4332d6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py310h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.17.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py310h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py310h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py310h50ffb84_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py310h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py310h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py310h1a28f6b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py310hecc3335_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py310h3b2db8e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py310ha9811e2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py310h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py310h3b245a6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py310h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py310h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.10.13-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py310h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py310hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py310h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py310h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py310hca03da5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py310h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py310h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py310h9128911_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py310hd77b12b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py310h2bbff1b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py310h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py310h89fc84f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py310hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.17.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py310h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py310hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py310h09808a7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py310h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py310h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py310h2bbff1b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py310h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py310h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py310h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py310h2cd9be0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py310h055cbcc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py310h65a83cf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py310h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py310h045eedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py310h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py310h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.10.13-he1021f5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py310h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py310h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py310h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py310hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py310h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py310h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py310haa95532_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py310h06a4308_0.tar.bz2
+  sha256: 1b165b1adae42121fc400da4825e3071cc8b257f4070aefe0bf4a5e8decf5932
+  md5: 113dcf34ca0d120a07b96997e221c3e2
+  depends:
+  - idna >=2.8
+  - python >=3.10,<3.11.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 165033
+  timestamp: 1644481743158
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py310h7f8727e_0.tar.bz2
+  sha256: f4d21ee48ca45cc62ae063f6de973c5599505d628e7675e512eb86f73f851410
+  md5: 96b990f76f2e61e914f5ad1958f6e7bd
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=7.5.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 85215
+  timestamp: 1644553401362
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py310h06a4308_0.tar.bz2
+  sha256: f60c5386ecc0cb0c21dd5bc93c5c30ca76ddf08270271298346c8caeadceb188
+  md5: 94e998805409e8ef3347727446f28c63
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 133035
+  timestamp: 1695718011394
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py310h06a4308_0.tar.bz2
+  sha256: d66cc22aa4d912b413bebff069c9b297bac6796a2b9943072906c30322f84330
+  md5: 6e1e2d8b3f95b30317cea5cc6ac9cf44
+  depends:
+  - python >=3.10,<3.11.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 209536
+  timestamp: 1681493093356
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py310h06a4308_0.tar.bz2
+  sha256: 7933a04f65cd54c879f49409b89fa55906f9ac3cf5919ce7ef9e216960e727dc
+  md5: 88353150bcecb679f62737785330e203
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3,<2.0a0
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14453101
+  timestamp: 1658136717996
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py310h9102076_0.tar.bz2
+  sha256: df2d57eb8f638e2dff6295dfdade084b9c2521d27cb0dcec5e0b1f69eb2a35b4
+  md5: 7321ee7373824f289d534d3a9635aeba
+  depends:
+  - libgcc-ng >=7.5.0
+  - numpy >=1.21.2,<2.0a0
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 345385
+  timestamp: 1648010842036
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+  sha256: 0bbcb6f78eac530c6a084459ffab3238647b266d0c74d695e6e6387dd119cc67
+  md5: bdc971e2a9affb5125b68ad708172dab
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 411301
+  timestamp: 1602517685375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py310h7f8727e_1002.tar.bz2
+  sha256: 1142d98a4a741c3a981a077792c898235662d7e0435219872ceadaf9914ea4f2
+  md5: 681b7a6c60515233e7940082b9983832
+  depends:
+  - cffi >=1.0.0
+  - libgcc-ng >=7.5.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 883596
+  timestamp: 1640803794269
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
+  sha256: 168c2fc4d5899ee70e85fadc998e00827e1b856a6fc4a402ed465cd7c320d19f
+  md5: f52e60deb7f4c82821be9a868e889348
+  depends:
+  - libgcc-ng >=7.3.0
+  license: bzip2
+  license_family: BSD
+  size: 107105
+  timestamp: 1563219611337
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+  sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
+  md5: 3ef00f4c5278b688552efc259c463dc8
+  license: MPL-2.0
+  license_family: Other
+  size: 132731
+  timestamp: 1694009767372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py310h06a4308_0.tar.bz2
+  sha256: 138d75d6dedc1e41d6111ac9cf021a4116119d1ee10b23037f031802d332c02f
+  md5: 4bfd5bc443cc66da42dacb9ecc7f8f34
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 158825
+  timestamp: 1690232282667
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py310hd667e15_1.tar.bz2
+  sha256: d94845e933aa2794857a2addef91366c0ef67a84433f1e1a26e7ff4fb0a938bd
+  md5: 5c83b10bcb81d4179f36368771f0d1fa
+  depends:
+  - libffi >=3.3
+  - libgcc-ng >=7.5.0
+  - pycparser
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 416321
+  timestamp: 1642753394042
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py310h06a4308_0.tar.bz2
+  sha256: 42a75e0216721a4a866e7edc3e81870c8cf8e9f8c3f2cace5318a1bc91d93328
+  md5: 2e415f3e186472953ca1abdd872ff076
+  depends:
+  - pyct >=0.4.4
+  - python >=3.10,<3.11.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1947957
+  timestamp: 1668084644133
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py310h06a4308_0.tar.bz2
+  sha256: 810d05cf52bfc487a64d6c664fc822e10ec307553fe6c0bbc85dbe39487e689f
+  md5: ccaf333120348af98f94afdfa8363aac
+  depends:
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12768
+  timestamp: 1671231151980
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py310h130f0dd_0.tar.bz2
+  sha256: d2a8f02d97dfaa1759c11ac815223a8c6a2e1108c91f0a0dcb031970040b55e9
+  md5: 105134bfa872c5a8617ffe18b361319b
+  depends:
+  - cffi >=1.12
+  - libgcc-ng
+  - openssl >=1.1.1v,<1.1.2a
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 2185827
+  timestamp: 1694445068014
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py310h295c915_0.tar.bz2
+  sha256: 8a4e935d3f3dbe68dd81d084f0ae09f6e1cf22b1ccb2ae7479ccba16307e1157
+  md5: aa967d228c67e44ca5c6142535b04c87
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 2108292
+  timestamp: 1640789547774
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py310h06a4308_0.tar.bz2
+  sha256: 413921f9bdd75ddbf9667fc35d4f7b8ac6ce751ab992297635e0cad2a8a9174e
+  md5: 57314b5e1702906d03bfcff4d7eab35a
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16500
+  timestamp: 1649908359372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py310h06a4308_0.tar.bz2
+  sha256: cfc573ac839d44c53498b07641283668461cf6d503913ea6eaf38e48b7f8c861
+  md5: a74f333ec7df6a6ec4793f890560fbdf
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26988
+  timestamp: 1668714404585
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+  sha256: 8a121233d0b2cbb2463b67e798739ad2946f38933430a6a7fd1197cc6eab1c99
+  md5: d2b24736491290a6c6d0138932111150
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: GPL-2.0-only and LicenseRef-FreeType
+  size: 965280
+  timestamp: 1635422707211
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+  sha256: 3c8ece1a7257b1d45f8fa25f46504bb709a1923d7175f2996e891366ec434b9d
+  md5: 299bf4271d710651a1d71d3795580c2d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 83592
+  timestamp: 1603192039050
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py310h06a4308_0.tar.bz2
+  sha256: 5998a5b93bd6d3be81b8cdd77e16f468de647f928d94412b974b8e10bf23e285
+  md5: 9b7c1a117126ce96c31467488ac559a1
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4521155
+  timestamp: 1693378240723
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+  sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
+  md5: 9213e0336e3a5216c989cfe52648412e
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 23805906
+  timestamp: 1588026213084
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py310h06a4308_0.tar.bz2
+  sha256: e71243f2719dce357ad12b215c23257a3ea353e8fabe954112ca4a204665a5b6
+  md5: aaedbfe2ce4396b9ae3598d8b1abb21d
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 115993
+  timestamp: 1666125633476
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+  sha256: 1b424413f28b840fc6d4bf467f37e9e405823b1e3b899005df80152d48936d64
+  md5: 4aa8bcf74c81cd3600978f791191692a
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 9246735
+  timestamp: 1634546760713
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py310h2f386ee_0.tar.bz2
+  sha256: 7dd3a2d36e69778e77cbb5bb53bd8cee420f6cef7e5b9e7db5d3eae5ab15e7f9
+  md5: c3310faa0f2fabb44a61384e8deee2f7
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.0
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=17
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 205933
+  timestamp: 1671488556575
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py310h06a4308_0.tar.bz2
+  sha256: e42ccdf6926cacfe67157d2f1eaf7bbb8f8db5976de6631e4bf95068c094a06b
+  md5: 9792abf6fa1ee2aafc8bc295f815eec4
+  depends:
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.10,<3.11.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1275466
+  timestamp: 1694181402009
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py310h06a4308_1.tar.bz2
+  sha256: 791097a544c793a7befc7778383c10e534c909adab9a446e38977d98a0fb0bb7
+  md5: 304ff041f756d6bac257f77c63a72aff
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1036683
+  timestamp: 1644315282525
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py310h06a4308_0.tar.bz2
+  sha256: b9e48b8c30ebc01e30a49ced6ee45bdd89d153f412936db53f80b0d53227861b
+  md5: 76227e72320c19ab16d6bda143f12096
+  depends:
+  - markupsafe >=2.0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 216531
+  timestamp: 1666908186956
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+  sha256: 85348bfb14db4fea84078d703e766a3c978c5a592a06e41266748826dd59d8ae
+  md5: 6e1c0fb5260c590f7ef5235cb3d05863
+  depends:
+  - libgcc-ng >=7.5.0
+  license: IJG
+  license_family: Other
+  size: 279884
+  timestamp: 1651065953960
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py310h06a4308_0.tar.bz2
+  sha256: 76a783faccefbbbfe6b408d2cb3ad4c364a058df6610080d858ef4f0a38f76af
+  md5: 871812adc9bb6e34d64620d7b539862b
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 133051
+  timestamp: 1676558776772
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py310h06a4308_0.tar.bz2
+  sha256: 1b898bebca729e6ef210e274706fb8a037baa10f61f3e0d51f970dcd44684e8d
+  md5: 9d97708df2ccb59b58082da5bc84c07f
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=22.3
+  - tornado >=6.0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193313
+  timestamp: 1650623162029
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py310h06a4308_0.tar.bz2
+  sha256: 0f122770cc027c9a69678db1067d949c6629e30116acb0b7a3a5b35e2b5d8b06
+  md5: b6ee7e9337a0ce9731b54c194ce72d73
+  depends:
+  - platformdirs >=2.5
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 91958
+  timestamp: 1679906681642
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py310h06a4308_0.tar.bz2
+  sha256: 8f74a19dd1efe33431c591688de139ef34c3c7cb7f397d67a835ea7ab71807c1
+  md5: ad34dede640c1068b2df718e9eb56e7a
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 413980
+  timestamp: 1671707770227
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py310h295c915_0.tar.bz2
+  sha256: 782f57a582753d54f0a92191a7dd7feeb2092b2b4b4c9d0f2a070cf36d2db676
+  md5: dd78f06c5539e774ae2d302f82961709
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1056439
+  timestamp: 1653292125501
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+  sha256: 3b4afe7665dcdb99bd4586a888b85b2e0325f8faecdd31c7780792080ee97872
+  md5: 822b5201dde61bc838072dc5b670c88c
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: Custom
+  size: 55183
+  timestamp: 1594054267890
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+  sha256: c6fafbe73d2f93b91b6f4b65829f925f52a8f84746a57abd216b39da9ce8c494
+  md5: 238f19c803a6ba7bd6dbd6989e03cbf1
+  depends:
+  - _libgcc_mutex * main
+  license: GPL
+  size: 8496776
+  timestamp: 1560112207081
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+  sha256: bc3e6e79c32ff0ecea601aa108ae9cf4068f69703580e40e266ad4bcc52cff54
+  md5: 9cb85601944ca7383b1769bff74b94e8
+  depends:
+  - libgcc-ng >=7.3.0
+  - zlib >=1.2.11,<2.0.0a0
+  license: zlib/libpng
+  size: 372914
+  timestamp: 1556041895170
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+  sha256: 43b0bd205f539583c088feb5b8d77b60c83d1df80c2a93dac9f2a1127001b2cf
+  md5: 53fa39fdae936e9d07c4b2f5ef361993
+  license: GPL3 with runtime exception
+  size: 4246257
+  timestamp: 1560112223556
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+  sha256: 711ea05b4c35bdafc762a172b01db896b17942f474c2b1a519f91370964bf9bc
+  md5: b25d56d33596623a6a4a9d9baaa4f602
+  depends:
+  - jpeg >=9e,<10a
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libwebp-base
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  size: 592974
+  timestamp: 1653047881023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
+  sha256: 4e1dce80f23551a69761ad48b2372e35f58292ec9cc0ce061312330366a1a223
+  md5: fda36b99463bad87974196da2d5bed08
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD 3-Clause
+  size: 18725
+  timestamp: 1633507857274
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+  sha256: 146dbb1e4dbccdd57819e5102a8ca00970b8e33d6c6180e8007db89b184da569
+  md5: c566a384259c1d2769852c3bddd81a67
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9d,<10a
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 90150
+  timestamp: 1645441199289
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+  sha256: cffb5a063111f7a99a99c74770b23db5dde52325e25a7a46d1903d5ff4a82c88
+  md5: eeb1bd66f28bed1956ab989d6eff7ae5
+  depends:
+  - libgcc-ng >=7.5.0
+  constrains:
+  - libwebp 1.2.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 889956
+  timestamp: 1645089138421
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+  sha256: 71f6c4a97014d745c58df52b4dd60ddd75a8508d54fe5b97f42bd1f31cb1c067
+  md5: 686e77514ec9f1ef0a6feed374f14d37
+  depends:
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.5.0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 789469
+  timestamp: 1653546418059
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+  sha256: ea3355a67c5173f3944f09861043ca66eb7dbeff8f385d13528b3aabc0801d0c
+  md5: 66e2aa12181bb2911485bdbe125d24c5
+  depends:
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.5.0
+  - libxml2 >=2.9.14,<2.10.0a0
+  license: MIT
+  size: 584199
+  timestamp: 1654075843119
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py310h1f438cf_0.tar.bz2
+  sha256: 4772edafba1c0cdc703ae02a3f2f37299b99fefe2dcd135e329df4ceeb2184e4
+  md5: 272fd5ca6590d8388145f32d1a3df749
+  depends:
+  - libgcc-ng >=7.5.0
+  - libxml2 >=2.9.12,<2.10.0a0
+  - libxslt >=1.1.28
+  - libxslt >=1.1.34,<2.0a0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  size: 5977342
+  timestamp: 1646642809299
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+  sha256: 2c6a5dda7c510a961bc78e31d4232be5e8e0760c93454f5fd200c379355e0f5e
+  md5: f35d4bf2fbb39e334992f6dd39f8721e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 220865
+  timestamp: 1627657046002
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py310h06a4308_0.tar.bz2
+  sha256: 93b9aa3ffe66b9ea121fcb1a32a2502006df7073fa29a00ccc00b185b00721ce
+  md5: 37edf1dc070689d9f64021285157aa25
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 122987
+  timestamp: 1671541964893
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py310h7f8727e_0.tar.bz2
+  sha256: efd169bd41fbc65ffd85725f6a76db92a343085108cc43b9e875c8d2783644b3
+  md5: d30b31c701efc1ab22fd8f7a1e489978
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37487
+  timestamp: 1654598030197
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py310ha18d171_1.tar.bz2
+  sha256: 27423a429435c9698361c0fad4e09a081e79a10b0dbee172b6694ff75e4bbd7c
+  md5: 06666f989a2eea665569e9d83774f6f7
+  depends:
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.11.0,<3.0a0
+  - freetype >=2.3
+  - kiwisolver >=1.0.1
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - numpy >=1.21.2,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.2.1
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.7
+  - tk
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7760687
+  timestamp: 1647441945703
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py310h06a4308_0.tar.bz2
+  sha256: be8075a8d70b0da67859d63016219e3dd1bc84a1b484abcbd8b95eff52884d88
+  md5: 6336be55da6cebfaf1cbbdc573524fc1
+  depends:
+  - python >=3.10,<3.11.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16451
+  timestamp: 1662014606193
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py310h7f8727e_1000.tar.bz2
+  sha256: 2074ac064fd4472eef8858d01cbf8475e775503f6b10803b2882c7d77fa394b9
+  md5: 33fe473ae7a1202e28c9143014029f62
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 55705
+  timestamp: 1640791663692
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+  sha256: 7c4ded8b2ef036839f988560848d2c32e1aa4627fd37a32710e42c39f5c61ac2
+  md5: bd20f4410b81f327e35ffa0657961146
+  depends:
+  - intel-openmp 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 229783051
+  timestamp: 1634547157986
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py310h7f8727e_0.tar.bz2
+  sha256: 6704d413c29ff9976ad9f08373806c21ef2444ce072a67663023a0d87d3de13f
+  md5: 83252b73851c784755a30c4932db6377
+  depends:
+  - libgcc-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - python >=3.10,<3.11.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217747
+  timestamp: 1641844379720
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py310hd6ae3a3_0.tar.bz2
+  sha256: 546faf25232afb3cf37280589e1f819a5aca6e1aeaed96d5eb9a3a1ddf369a45
+  md5: 899b76e4629a62b66a7fee96ca02a487
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21,<2.0a0
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  size: 713451
+  timestamp: 1641843696839
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py310h00e6091_0.tar.bz2
+  sha256: 8a0e862e81fd6dd43d5c4f683f50ba06d2a8a58686640b914104fe68dd84fc6b
+  md5: 4d23da9a63b3973bff5e8e9b9651c70d
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  size: 1269509
+  timestamp: 1641843589171
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py310h06a4308_0.tar.bz2
+  sha256: 5b9f37faeaf52cd23fc141e5f1a049cf3dcedf25c76dedf3532cde2f8cd25821
+  md5: 7a7a4eeed6ac4bc307b911271049b6ff
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8253050
+  timestamp: 1681756239192
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py310h06a4308_0.tar.bz2
+  sha256: e98c9c94fbc68a28dff1d259f5e5a12b181644ed0461dd8939076830d4caa87e
+  md5: dbb43e77b5e495a1bd256459f9dd2d76
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99326
+  timestamp: 1650290293630
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py310h06a4308_0.tar.bz2
+  sha256: 4ebad67463b41dfcde529483f1492a7e06c02bdee3157bc7e71060a8790ae5e0
+  md5: a6ccc2e18be71a21400c65170c469a08
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.10,<3.11.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 571994
+  timestamp: 1668450742267
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py310h06a4308_0.tar.bz2
+  sha256: 5c1ca15ce50d3a917f28b91b5c8269f5ef669eef183cd664c34e1a03644da6e9
+  md5: 3cf6f2cdd2bd9bc97c41407ca6db2db3
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.10,<3.11.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147752
+  timestamp: 1694616791091
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+  sha256: 0807371380965e421cb5f3f2a30d790fd5c41db11dbb6d318e14294c3b1741ed
+  md5: fca4bd4e3891aebf4fd7daf9b6d0ccfa
+  depends:
+  - libgcc-ng >=7.5.0
+  license: Free software (MIT-like)
+  size: 1083412
+  timestamp: 1636570020698
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py310h06a4308_0.tar.bz2
+  sha256: 284c8c75d3c557d80d81d7861582218d9822794f24aa3ffaa1a4b6b87e141cae
+  md5: 85a509faa4a3c9f1b3a3df32bab735e1
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13184
+  timestamp: 1672387223720
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py310h06a4308_1.tar.bz2
+  sha256: 812032fa5ade7c5eb9d0e44767949bbd2a1a42824c7aa084ed77e4852b73109c
+  md5: db64e78374173c35f054ce9c40c35a9e
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 598038
+  timestamp: 1690984876373
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py310h06a4308_0.tar.bz2
+  sha256: 048da58667248b6ccc7f4d9977466081e8bbf7f831abe9a922e2fe9740f8d1e3
+  md5: 133b837755ea8399962afb015afb561f
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21992
+  timestamp: 1668160675427
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.7.3-py310hd732450_1.tar.bz2
+  sha256: 9b1a3e57ea29f06538e8d284a398ef9b81b416ab84166e066256e77fbedd0c4e
+  md5: 15601802201565b422c212a6f1ee79e5
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.2,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - setuptools
+  license: MIT
+  size: 453854
+  timestamp: 1640792037686
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py310hfa59a62_0.tar.bz2
+  sha256: 0f0090d4b68693b026e33e1d32bb5dc12becf89093d6fc5089eae40e1f2797eb
+  md5: 7ca0065abe7f21dda202e48001dc97be
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.22.3 py310h9585f30_0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  size: 9998
+  timestamp: 1652802638914
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py310h9585f30_0.tar.bz2
+  sha256: 735d104050e9b2ca083c51a2fbbac025fd79cf1e0def76c73f9e90792a2ef8d4
+  md5: 9d47c84ae5205503a3b4b6c01dd8003f
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - numpy 1.22.3 py310hfa59a62_0
+  license: BSD-3-Clause
+  size: 16444261
+  timestamp: 1652802619412
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+  sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
+  md5: 5ad4571eba2479f77a9f849a6ae7724c
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: OpenSSL
+  license_family: Apache
+  size: 3998613
+  timestamp: 1694465071784
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py310h06a4308_0.tar.bz2
+  sha256: bf13f5c15c9ebba82cbc6dff583f8f87600e81bfebae36999aaf0d17a9b5bae9
+  md5: 6ec943237961f65bfe1678776460d76f
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73334
+  timestamp: 1693575207627
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py310h295c915_0.tar.bz2
+  sha256: 8b0a47627fdc2fd665e861a23ecd1b1f2abfde4fcfc17a0239c264e3da477946
+  md5: 721ffb229e89749055bb7e11df71f93a
+  depends:
+  - bottleneck >=1.3.1
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - numexpr >=2.7.1
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35190591
+  timestamp: 1650622912131
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py310h06a4308_0.tar.bz2
+  sha256: f0736d7b759129952e028fd791b9c662e37f034cfbfd321103197cf74bc771d4
+  md5: 38d315540dd820d0c5982c3491182d2e
+  depends:
+  - bleach
+  - bokeh >=2.4.0,<2.5.0
+  - markdown
+  - param >=1.12.0,<2.0.0a0
+  - pyct >=0.4.4
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - setuptools >=42
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >1.14.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14736179
+  timestamp: 1676380048816
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py310h06a4308_0.tar.bz2
+  sha256: 4f7b793253454afb7a0834872d2f47381172bc1d879c581a4d80c12427ee0883
+  md5: ba2287f1560613eeb38bcccccff8cc0c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 143006
+  timestamp: 1684915415304
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py310h22f2fdc_0.tar.bz2
+  sha256: ee09fb4a72b37685c9c4e16eda990f402e52878d54c24a6160d0c6a6ea8528ac
+  md5: d2c2bc0c866b0605b74f2a9977d0f70a
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp >=0.3.0
+  - libwebp >=1.2.0,<1.3.0a0
+  - python >=3.10,<3.11.0a0
+  - tk
+  - zlib >=1.2.11,<2.0.0a0
+  license: LicenseRef-PIL
+  license_family: Other
+  size: 1368886
+  timestamp: 1646325112795
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py310h06a4308_0.tar.bz2
+  sha256: 5f010145b4cba3c102d03ea4135abf773b4547f2a62d689d005498466e55d35c
+  md5: ff1a8e92055b4aa68ef2234c3677f6ea
+  depends:
+  - python >=3.10,<3.11.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2760212
+  timestamp: 1697548855340
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py310h06a4308_0.tar.bz2
+  sha256: 95ee7eb5dc731152d97631e2c59572b4838b5cf96f0c7fabb7eb0258590e8267
+  md5: 93b487d749f5b5c021ec09b98b7aa5ad
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 32180
+  timestamp: 1692205504671
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py310h06a4308_0.tar.bz2
+  sha256: acf569ca3e503deaaf44343cad7311d56554b3390cc695e1253c04059d50b023
+  md5: 02e7296fb89eadc1d5b8f6afcca292d1
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 92080
+  timestamp: 1659455234403
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py310h06a4308_0.tar.bz2
+  sha256: 07901e769b841cd002b264c4d12bbf3a052f31ed17dea6ac621af292b62948fe
+  md5: ef68e03bc5a6817d90d8a9517efd5f50
+  depends:
+  - python >=3.10,<3.11.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 600626
+  timestamp: 1672387422560
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py310h7f8727e_1.tar.bz2
+  sha256: 41f2a918ac201c093e4673d9bccbee6f53c540db25bd678961b1559372bd1507
+  md5: 0166f0d92de7dd688ea527168ca9dea4
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 402345
+  timestamp: 1640792653691
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py310h06a4308_0.tar.bz2
+  sha256: f28841b5157e89b26186c8e6f941e4f601a0bbb20807245d88a6af6dcca800cd
+  md5: 2b2a9be6bf17df2c01ceb1e622de6fab
+  depends:
+  - param >=1.7.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29492
+  timestamp: 1675441593109
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py310h06a4308_1.tar.bz2
+  sha256: eba38026b96d0b3543a2a529cde8a1d82654da5cbb3030ecfe67b4247f0c8f50
+  md5: a719d98f31e467f11ddf83a7e5893b49
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1887228
+  timestamp: 1684280033582
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py310h06a4308_0.tar.bz2
+  sha256: 39de2ecacca6f1a1e3cb00d90d9aa37eafd270b4dd73d34dd34b8f9ba3b39851
+  md5: 296f73e59bf7f4ab81960e2a1f03aed4
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94805
+  timestamp: 1690223492156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py310h06a4308_0.tar.bz2
+  sha256: 853b025e248d71d2f09ec9422b76c09cb46fdedd9a065295dd9305dac36aa286
+  md5: 683beb480351e058d66b538273fbfb8a
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 158193
+  timestamp: 1661452647484
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py310h7f8727e_0.tar.bz2
+  sha256: e5362c4925b888dc7ca4ca8378663c473b2279b2643b76e182b977f0f9363d2d
+  md5: fa93b46d0393c943b54aa9a01669b651
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 124226
+  timestamp: 1640807221148
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py310h06a4308_0.tar.bz2
+  sha256: d01fa02148ff1717b3c13b3afc1d9f7189fa7b15d1a612d79793f6c1534875d7
+  md5: 5ad7b13cb48fc3f12d94907489550019
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 28253
+  timestamp: 1640793693853
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.10.4-h12debd9_0.tar.bz2
+  sha256: 3ac2d9165dbc89e4b309a2fa192c01f7e65a2fd47fad588bad44c66c19ad9af8
+  md5: f931504bb2eeaf18f20388fd0ad44be4
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64
+  - libffi >=3.3,<3.4.0a0
+  - libgcc-ng >=7.5.0
+  - libuuid >=1.0.3,<2.0a0
+  - ncurses >=6.3,<7.0a0
+  - openssl >=1.1.1n,<1.1.2a
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.38.0,<4.0a0
+  - tk >=8.6.11,<8.7.0a0
+  - tzdata
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 25334822
+  timestamp: 1648716756622
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py310h06a4308_0.tar.bz2
+  sha256: 079d9c3369fc6dcd6fdb2b828167d29634783038fd9cc22b454115186ddbd928
+  md5: 7f9649b98bcdc1b5b0c4b22c5db5b9de
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 265085
+  timestamp: 1661371188626
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py310h06a4308_0.tar.bz2
+  sha256: 192ef817854e3b5084928ec7870179a2fdbecfd7329b8d653163cb720496889b
+  md5: b21c15ce377c91611d625e38bbad4ef3
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 260414
+  timestamp: 1695131699017
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py310h06a4308_0.tar.bz2
+  sha256: 6e119d30921348b2de45aa8379dba61fd10008d0badbf053e55f3ec33ffe6383
+  md5: 06008f770b5b8ecb4466f9fe2176388e
+  depends:
+  - param
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39891
+  timestamp: 1685030914537
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py310h7f8727e_0.tar.bz2
+  sha256: 2249185121c4179d5efac551a3ebeace1d5b63d5f4f08211a4fdf1536cd218f1
+  md5: 02982f901d86037ecc12cd93108d2c19
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.10,<3.11.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 496996
+  timestamp: 1640794093967
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py310h295c915_2.tar.bz2
+  sha256: 6e02808cda36e9049ffb1aa8848e34d79b433f0ec63da0760af2c6eabaee0b34
+  md5: 16950ca6a2533f8b599a6ecfe19b1a15
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.10,<3.11.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-clause
+  license_family: BSD
+  size: 1298077
+  timestamp: 1640794137148
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+  sha256: 8c950c69bee969e2c66f88f0dc247b3ab75a753672a88009779d5f5dba193532
+  md5: 150ac0eb929bab9dec912797bdfc7b95
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 433182
+  timestamp: 1642022402894
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py310h06a4308_0.tar.bz2
+  sha256: 6daaeba3024898ff16a157d7a2c13ad6f4fc8029403ae2e7433bec0ff7e5ae7c
+  md5: 702eb5472fbc61f44be857463101342e
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.10,<3.11.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95060
+  timestamp: 1690400239227
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py310h06a4308_0.tar.bz2
+  sha256: e8b2265971c9357df26399051465b044e9f55e702d297a1018ed029e424b0fbc
+  md5: 8eb5d51a70ed92bc2bfb96a7a65605c4
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1097106
+  timestamp: 1690290871845
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py310h06a4308_1.tar.bz2
+  sha256: e07c6ad52415ceac1405a370e644e4a36a4f0b0d220e495057cd222c12f85c91
+  md5: c15dcab2d9945d0997d49db7bbb2b12f
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15636
+  timestamp: 1640794815222
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py310h06a4308_0.tar.bz2
+  sha256: 7b2292b384f32587828c2c7a1a099bead9d2071a8969af87349f00fe9fcd98b2
+  md5: 5106026a40ffd8c8ea10c146563947cf
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 66920
+  timestamp: 1696347609464
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+  sha256: 87965b7b46d93866d31696a1045216d64f077a06b2900c356aba87e8559c6188
+  md5: fa334030245135b37027a882f3c468bf
+  depends:
+  - libgcc-ng >=7.5.0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: blessing
+  license_family: Other
+  size: 1561908
+  timestamp: 1655328608308
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py310h06a4308_0.tar.bz2
+  sha256: 0baaf2c1c9c5bdd29a149877e8cce8400fd190cb9d451b74af58adc91147984f
+  md5: 00362c34088a3a02bcca1ad72df5f58a
+  depends:
+  - ptyprocess
+  - python >=3.10,<3.11.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30045
+  timestamp: 1671752107828
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py310h06a4308_0.tar.bz2
+  sha256: c839dba354cb1f6b7bf7d7a0fda8c65c1fb1ec2d2165a37cd5abe8ee1ed2ecfc
+  md5: 12d717c4e3873e295865c1666ff125ef
+  depends:
+  - python >=3.10,<3.11.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39119
+  timestamp: 1668168931128
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+  sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
+  md5: 5b8375e2092012db69d2123dc0c68630
+  depends:
+  - libgcc-ng >=7.5.0
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3485432
+  timestamp: 1654088939579
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py310h7f8727e_0.tar.bz2
+  sha256: dcfeb70e565c04cfec6e5aee9c5c17fe4adc75fb8bbb6eb15d4a8b8cd65459cc
+  md5: 55bf10237c01dee421799c36a1330d29
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 681452
+  timestamp: 1640795414786
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py310h2f386ee_0.tar.bz2
+  sha256: a30a5199c6949d7bf07df14ac82f75eaada108f7d0b379442c538cf7fb660406
+  md5: 8db7239ae56fe0026c80a98aea04691b
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - ipywidgets >=6
+  - requests
+  - slack-sdk
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 124632
+  timestamp: 1679561970726
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py310h06a4308_0.tar.bz2
+  sha256: 82014300af56f45295fd7bbe0a21919ddae0a720f4725a40db456d8d74d8e2fd
+  md5: fc14d3692ef44fee5d3b267adbf97c74
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 194158
+  timestamp: 1671143967706
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py310h06a4308_0.tar.bz2
+  sha256: acc535e01009949fe351d05ffbcd491985953f775e525d57a4dcaf16fd5bb5ba
+  md5: c3464201dae5b16d65862ad1dd96bdf1
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing_extensions 4.7.1 py310h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8788
+  timestamp: 1690297549545
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py310h06a4308_0.tar.bz2
+  sha256: 72dee2f0c6a640cb1de55990730e48f94bc07638ef7dc35b009938ff8b59f278
+  md5: da05d1cae290b53411057861262f06bc
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57936
+  timestamp: 1690297542878
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py310h06a4308_0.tar.bz2
+  sha256: 314e95ee2129eb99b43f57cbf59bdedadf436ba256732720787ef10a830e1118
+  md5: ba5d23f2c9ed2f483c2d0228fd5b8b64
+  depends:
+  - brotlipy >=0.6.0
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 188260
+  timestamp: 1686163269682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py310h06a4308_1.tar.bz2
+  sha256: a375f3ad671266b27503b33f62ceaa7be112c0e47836e38a6c6a76225aff927d
+  md5: 49b82f30a2a45b2ce167a876cdc9e21c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21391
+  timestamp: 1640795864430
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py310h06a4308_4.tar.bz2
+  sha256: 7e971edc178e66023da0a1c6e35536806a3b77e50273392e2edf8ce0d0328064
+  md5: bcd8414adfe572fc3d04850d1fae2845
+  depends:
+  - python >=3.10,<3.11.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 71305
+  timestamp: 1640795883083
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py310h06a4308_0.tar.bz2
+  sha256: 386d7927763c6f2638f29ef11c05454c596c0046c46aa55a8348dc1e0b65bf52
+  md5: 17ad3bf81caf45682f2f905921246e84
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 102423
+  timestamp: 1695741985155
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+  sha256: 2ce360ff98c0ca4537d70c19266b5700810196c54ce2fbaff3b94a969846ee37
+  md5: 94cb94dc47405b24b1b5bd0a3275ab59
+  depends:
+  - libgcc-ng >=7.5.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 398058
+  timestamp: 1651602137803
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+  sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
+  md5: 567b68192c387b5fc88178425577a0fe
+  depends:
+  - libgcc-ng >=7.3.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=7.3.0
+  license: LGPL-3.0-or-later
+  size: 366479
+  timestamp: 1616055552392
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+  sha256: 513444d83ac2405e898531492ea59f3a95641e357cc39c1048d6fffc1791a16b
+  md5: 601d9449c280b9b145dc8c83b6f06119
+  depends:
+  - libgcc-ng >=7.5.0
+  license: Zlib
+  license_family: Other
+  size: 133595
+  timestamp: 1650637720646
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+  sha256: 1c049c23788a00b6f38bdc801245e0e60af98718d4db4c958658bcc67ff158c7
+  md5: b1737dfd2e06ad69ec5cfec341e207c6
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 827172
+  timestamp: 1650622223170
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
+  md5: b2aa5503875aba2f1d88cae9df9a96d5
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13636
+  timestamp: 1611930018941
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
+  md5: 544adf2677c47c9b9c891aea720678f1
+  depends:
+  - python >=3.5
+  license: MIT
+  size: 33999
+  timestamp: 1630003259346
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+  sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
+  md5: 9eff1a842dbda8d1bae9a2c008b599bc
+  depends:
+  - brotli >=1.0.1
+  - munkres
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 690443
+  timestamp: 1625743217109
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+  sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
+  md5: 33624a42ee387bf9918ea98b4e7b31fc
+  depends:
+  - pygments >=2.4.1,<3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8173
+  timestamp: 1601490751973
+- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+  sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
+  md5: 67857cc5e9044770d2b15f9d94a4521d
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12810
+  timestamp: 1600445183315
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+  sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
+  md5: e68a6f315f41a8d814d833652bf38b9b
+  depends:
+  - python >=3
+  license: MIT
+  size: 13374
+  timestamp: 1606932077143
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
+  md5: 2eb923cc014094f4acf7f849d67d73f8
+  depends:
+  - python
+  - six >=1.5
+  license: BSD-3-Clause and Apache
+  license_family: BSD
+  size: 246457
+  timestamp: 1626374695070
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
+  md5: 41db68b96e114e367c4f120a3b379e59
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19391
+  timestamp: 1632406728844
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+  sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
+  md5: a815d3bdb160bcc71687f2dda70d3ca4
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 122218
+  timestamp: 1680170368293
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py310hecd8cb5_0.tar.bz2
+  sha256: ab44806f981c5fd6a92e43ffd04aff3bf016de91628af7437fc74ef2b6043973
+  md5: ad7fce73167b8a72df4d1ae073542706
+  depends:
+  - idna >=2.8
+  - python >=3.10,<3.11.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 165345
+  timestamp: 1644481776414
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py310hecd8cb5_1001.tar.bz2
+  sha256: 09c3f6c4328480f28458ea1610756de82424aef128aa9cded81f8f0766a81485
+  md5: d6b76a162e56bfc828c021c67e0c68ac
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10049
+  timestamp: 1642500631813
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py310hca72f7f_0.tar.bz2
+  sha256: 4de7fc8c8f18ca65bf023bbc60d0e4bf7d17ea01323f264668df29b736cc6580
+  md5: 7f6d95177dc7630deefb205c1e2bdbab
+  depends:
+  - cffi >=1.0.1
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 36335
+  timestamp: 1644569785995
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py310hecd8cb5_0.tar.bz2
+  sha256: 19452fd77b0af5c1711d99cdf0d515bad131a173689e03d4bcdf287c49152563
+  md5: fdeae028483b25ed5cc0c1dbb106ed7f
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 134180
+  timestamp: 1695717928999
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py310hecd8cb5_0.tar.bz2
+  sha256: e32cef7941693f83b5c72e6a5c814ae79d358c529529d091464dee165d92d4c3
+  md5: 70b35ee64f157dbbc5adda90f9194bae
+  depends:
+  - python >=3.10,<3.11.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 209623
+  timestamp: 1681493122682
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py310h20db666_0.tar.bz2
+  sha256: 40d9035be55844db55fdfe31e85752d99c165d1355d792c08a91f9ccda834e10
+  md5: 3f953aa83d5a9ffd1393177be2ef719f
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6484731
+  timestamp: 1690546214635
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py310h4e76f89_0.tar.bz2
+  sha256: 1d0019c5cce0bdefaaf784c235036abf124ac8c3be5c3fc361fd3f4c8946e847
+  md5: ba6e64e3b27d07a725022a867307fa60
+  depends:
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 140869
+  timestamp: 1657175784357
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
+  md5: 31d6d04cd2388d8f19004501271b3545
+  depends:
+  - brotli-bin 1.0.9 hca72f7f_7
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18982
+  timestamp: 1659616229395
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
+  md5: caf1073dc2ca5aeb832a2877394eae12
+  depends:
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18233
+  timestamp: 1659616216769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py310he9d5cce_7.tar.bz2
+  sha256: f292b68dc123e7d16d2e6403360f7c4279b118a553771eefb8d69cb9ccdc55fa
+  md5: f8c7836d6d091f568645a7cf484604ab
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  size: 399745
+  timestamp: 1659616391600
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
+  sha256: 4574ffa241157e108d19ece60107a3a689cefaaca43578e6c4a6b344c7330278
+  md5: ab3b4e83407001e7f1603ca1fa0f4873
+  license: bzip2
+  license_family: BSD
+  size: 106284
+  timestamp: 1563219666100
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+  sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
+  md5: ce3588e31faa79f546e0fc6a36c5543c
+  license: MPL-2.0
+  license_family: Other
+  size: 133884
+  timestamp: 1694009771475
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py310hecd8cb5_0.tar.bz2
+  sha256: d9bec3e7e31f68d954604656a2326af62f08bcd687c05a142449d0d5c8cde1b3
+  md5: 5be325b9c245a807ebbacae214faf403
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159842
+  timestamp: 1690232263011
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py310h6c40b1e_3.tar.bz2
+  sha256: 0d8b97f3e71f6e4a475338f9c3f2fc9ea48cf38cdfe01a098dd55e55e8f98e41
+  md5: ea3b438028199e3d6bd7ae93786d2834
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 227222
+  timestamp: 1670423265293
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py310hecd8cb5_0.tar.bz2
+  sha256: 23a65cddc91ac3a24ca12a4b6cddf1d55997e9fdfba9456a7b68d2516b4233bd
+  md5: 31e701ceaf45deab0ea36be55a28c4b4
+  depends:
+  - pyct >=0.4.4
+  - python >=3.10,<3.11.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1921660
+  timestamp: 1668084532737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py310hecd8cb5_0.tar.bz2
+  sha256: eb9d8c1b21655250196a8fc27ea6713973a494ff4ea744344a28ab9cfa799dc8
+  md5: 0c9f7d21c1f8951251c85b92e684c8cb
+  depends:
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13815
+  timestamp: 1671231253863
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py310haf03e11_0.tar.bz2
+  sha256: 2a957b3fec7dfb81fd8281c5a50c794dd2ca2dee6c89a41d19220ebff0237765
+  md5: aeeea7b1bc519916c95da894e200d315
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 246640
+  timestamp: 1663827690536
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py310h30e54ef_0.tar.bz2
+  sha256: 037989d5057008a5f17d3d375e210cf2290bb6691dad6b9a34951fe57bf04b44
+  md5: cf5739b661e75d50538d7df9e8396666
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1312180
+  timestamp: 1694211808108
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py310hcec6c5f_0.tar.bz2
+  sha256: e2d11b07b8139917def31e4f4c1318396eae6762e18c771851cbebfe628cb157
+  md5: e3f9f6c8343ecf7dc8f311670be764fc
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 2068510
+  timestamp: 1690905208269
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py310hecd8cb5_0.tar.bz2
+  sha256: 670e9476a114ca61020f1a69803661de5cc6f01a26296a4c73bbbda94164dc4e
+  md5: 12f8f558c520d5a1e25ba2967edbee89
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16685
+  timestamp: 1649926502410
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py310hecd8cb5_0.tar.bz2
+  sha256: cf6ea491b82e836c5554fcb36224b22c987afa536a347d77fcef9ce60a762678
+  md5: dc1626b688c0694a85b2671bd78cab86
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27897
+  timestamp: 1668714443581
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+  sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
+  md5: e4a732941f74b8062c8bcbfe5c5c2b56
+  license: MIT
+  license_family: MIT
+  size: 80252
+  timestamp: 1676983220161
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.17.1-py310hecd8cb5_0.tar.bz2
+  sha256: 4d89c45e4f6ca1b63f69d7dcccbd5934b060e13c5d2711ecf25ea6022af473b8
+  md5: 9eabc7dbf073a8276ef1b5c40bf56982
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4626418
+  timestamp: 1693378265446
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+  sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
+  md5: f3ce6fe6eb760c236e5f7d04df5faa81
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28138484
+  timestamp: 1692293212596
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py310hecd8cb5_0.tar.bz2
+  sha256: dbeeaa099425216cbe0dad8e44951521772e71ee124ef3c30073751cc59aa957
+  md5: b9a7575212d1d752f9a9b917ba5c6685
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 117040
+  timestamp: 1666125702178
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+  sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
+  md5: 78baea934985ccd9514a366cc7e80ed4
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 727499
+  timestamp: 1681801225190
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py310h20db666_0.tar.bz2
+  sha256: b288ab7930ec37a7cb6f3558b82f67ac57b69ae561304f68d39d6b5663763096
+  md5: 69565782f10218ec53c3e7b50121388b
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 220460
+  timestamp: 1691121691261
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py310hecd8cb5_0.tar.bz2
+  sha256: 6308545b6b7a988e38a16159af2dac1d0b15f6cacade56cd571d6846275059d3
+  md5: ce8b3d8d7a177c5b0d6c8cb27369bfb0
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.10,<3.11.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1274856
+  timestamp: 1694181561315
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py310hecd8cb5_1.tar.bz2
+  sha256: e9462e4328da66b87f57311ba1a334cc4e6ee0e6fb6c617feadf54acec4ea14b
+  md5: 195c8c18c39ccb0f9673fd0aa8fdb365
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1034798
+  timestamp: 1644315303585
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py310hecd8cb5_0.tar.bz2
+  sha256: 76b44a192decbb67a6496d1501db38511944c3b53adc10ff7a59e104b587cf1b
+  md5: c362453df8790e78cfe5ef1d952ff6dd
+  depends:
+  - markupsafe >=2.0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217435
+  timestamp: 1666908206435
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
+  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
+  license: IJG
+  license_family: Other
+  size: 278924
+  timestamp: 1677849185191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py310hecd8cb5_0.tar.bz2
+  sha256: efe759e046a43f2570267f508af9a1fb7598c7d4e08d8f552d69be79cf411c78
+  md5: 05619f81c3e3b0fc7a156e320ec7111d
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 134344
+  timestamp: 1676558794739
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py310hecd8cb5_0.tar.bz2
+  sha256: 1b382008e5e5b7d7bbe5da1767d4d35021869c5ff1b7fdb17f10fa9634cd8e1e
+  md5: 32e23b69e39f05ec0c83b75738996fa2
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 200146
+  timestamp: 1676330021017
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py310hecd8cb5_0.tar.bz2
+  sha256: 1a18653cd4662d7930a527077bc2aa5e904e6e58ba60fca37b88316678b83174
+  md5: c8843d773865ac5e8d07d270f37f8b17
+  depends:
+  - platformdirs >=2.5
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 93428
+  timestamp: 1679906653176
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py310hecd8cb5_0.tar.bz2
+  sha256: db6767e015c939d2cfeb472adda2643ace0e3851d8a4fd83f4cc6e44cbe1221c
+  md5: 8e0febc4fb146683e2415f08b2e6d85b
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 405529
+  timestamp: 1671707749359
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py310hcec6c5f_0.tar.bz2
+  sha256: bde3b255886d59e9af9450489ba42e205865a223ec48c4bd3396405480715c97
+  md5: f4ed6fff2814558c3b717017465d8e2a
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65413
+  timestamp: 1672387282474
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
+  md5: 7dba7aa5b971febb55281659843586ba
+  license: MIT
+  size: 65470
+  timestamp: 1659616172703
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
+  md5: f78a158983f0bbaba56f34b976bc6dae
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 34189
+  timestamp: 1659616189313
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
+  md5: 36a1d885725d3ab4d1fadc5a29f978d2
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 327737
+  timestamp: 1659616202869
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+  sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
+  md5: 817848d0e2b2808acdc9b3fbbf581726
+  license: MIT
+  license_family: MIT
+  size: 133887
+  timestamp: 1683716590737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+  sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
+  md5: c90372428e1e4eed4fdcd790979d06b4
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1409377
+  timestamp: 1650983531933
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+  sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
+  md5: c0b99f8e1c7475f23b1c7b4250b06e1c
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88021
+  timestamp: 1694778290062
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+  sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
+  md5: 06866415ef22d5322f9bdc9956b59c4d
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 678174
+  timestamp: 1692970318885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+  sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
+  md5: 2edc6c894d6d0321304396e9bd40df94
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241774
+  timestamp: 1692973618934
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py310hecd8cb5_0.tar.bz2
+  sha256: 8e083eacdfa973821efce45fb1de838ccdab56cbee31a6ce70de0683ad2165f7
+  md5: 8f970cf73b7f71b2d2c624992e9cd6f7
+  depends:
+  - python >=3.10,<3.11.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 36179
+  timestamp: 1659783413376
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py310h946e0e5_0.tar.bz2
+  sha256: cceee8661c23a21fdbd31ebaf5f862f88dde52d3afcd7c26cc782209972a6ebe
+  md5: 16e6b7f845a0ae234cc7abf553857259
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1515705
+  timestamp: 1695058495195
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+  sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
+  md5: d5f58d056b4bfc67aec30c77035ba889
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 182491
+  timestamp: 1670944720979
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py310hecd8cb5_0.tar.bz2
+  sha256: bc2f8a9d82b05e7d2e9da576d86565f085b18ad824a61729c808a35d9aa899ae
+  md5: 2b5c8d5d297342184b21138a02a4cec1
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 124321
+  timestamp: 1671541949029
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py310hecd8cb5_1.tar.bz2
+  sha256: 444bec52a8b4f0e0169f69b0d2ee1409dc04a48509ea394d053e8fa3418e724b
+  md5: e95bbbc56e3c08f0018638c6ee82e567
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 108187
+  timestamp: 1684279943281
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py310hca72f7f_0.tar.bz2
+  sha256: a08565836c11f37e47a37bde257199924adc6b83fbf1c8d57a5a70e6b2151e03
+  md5: 783ab31d6fd7c0ec3450e9b687d60672
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22639
+  timestamp: 1654597944890
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py310hb47e01b_0.tar.bz2
+  sha256: 3371092d530ff8e27265385843474dbb6567b77df77ca44ffe9715b3bf337c1f
+  md5: 1a37eac45ba97a9133f9c04198bbb8e9
+  depends:
+  - __osx >=10.12
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8207820
+  timestamp: 1698692275293
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py310hecd8cb5_0.tar.bz2
+  sha256: b0b7bf33159ad955ac6503e0008bb4f6d42a431d39750d8748f1cfd437c33982
+  md5: 95dcb73cba7ccc8d9d54ded71c43f200
+  depends:
+  - python >=3.10,<3.11.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17405
+  timestamp: 1662014515076
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py310hecd8cb5_0.tar.bz2
+  sha256: 25de39c78f2dd34019fd7c7f46110a096abaf50fe8ed08ddbbdb905aa5fa4154
+  md5: 0a554b7362b3c3ee587f2486e58c9d4c
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 53950
+  timestamp: 1659721329388
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py310hecd8cb5_0.tar.bz2
+  sha256: f7319ca119de06ffc0efc159c00b0eb4aa1c8c95b0de062532590cb8da37be9e
+  md5: 3d14c228ee0ce206ba6889c36a0815c7
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 19643
+  timestamp: 1659716168738
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py310hca72f7f_1000.tar.bz2
+  sha256: b129a6779958bbb963454e068103a6f102d34864bc928b5f46fd19d122a745a6
+  md5: 7cfba0a36a59a4f70c4e9fcc39fa8d5c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 55621
+  timestamp: 1642534192191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+  sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
+  md5: 25051fe272624544652dc6d814c2943a
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224420228
+  timestamp: 1691503125614
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py310h6c40b1e_1.tar.bz2
+  sha256: 773d3474db4c2929410078d134b4990cbee452a432d78e2596d9dff19d086391
+  md5: 195f192460854e93de48e9680245b77e
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48109
+  timestamp: 1682969136581
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py310h6c40b1e_0.tar.bz2
+  sha256: 14ee8d02bebd80653a0d8a733074a333354b44a01facaab5c629b0a4929fcbfb
+  md5: 547d8d08cf840264effcef3064b00e9a
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 210701
+  timestamp: 1695058263687
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py310ha357a0b_0.tar.bz2
+  sha256: 20fc55fb2eb0e8c06c28e814cc8056f22b2e9e96ed7ff8b4be2d2e25222856d9
+  md5: 61bdf81fd58feec3a44e196398b1300f
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296201
+  timestamp: 1695060071873
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py310hecd8cb5_0.tar.bz2
+  sha256: f27a95f8b4c9ec17770b91fe707594651f7cb179f08d3b930be4b64b3682a833
+  md5: daf8c86dc56b8661a2480e9881fa7200
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8220896
+  timestamp: 1681756363497
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py310hecd8cb5_0.tar.bz2
+  sha256: 085d6403ec0ec4d4f0d95aae1cc1290ad30c256f13dca2eb40e9ba1303f9a062
+  md5: d57325e2862d4b24564d8349f6630e52
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99493
+  timestamp: 1650308474923
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py310hecd8cb5_0.tar.bz2
+  sha256: f77d94aaabd8c0402fd7423b081180d28f92a3ae1c8ef596a4a9fe0d7f58424b
+  md5: 713212d6bbc8c47f24ee3edb9ca7baee
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.10,<3.11.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 574237
+  timestamp: 1668450820509
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py310hecd8cb5_0.tar.bz2
+  sha256: 200687f529720b1a54320822026f40037a559a3eb3a59fd4025e0dd0ec3b9901
+  md5: 3035217993e7b73cb4a4919013344699
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.10,<3.11.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 149101
+  timestamp: 1694616785694
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py310hecd8cb5_0.tar.bz2
+  sha256: 77fcc055b810d404d839a214cbc06e8e234cce991e467983b3629df585c261e8
+  md5: 68d1f87ac6334f78182d0e27641d88d2
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14179
+  timestamp: 1672387168383
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py310hecd8cb5_1.tar.bz2
+  sha256: 218236846df8a0900c96fffe6f750ec0e231ae048b7483a85e6f5ae645b0c548
+  md5: 99fb68f5d037199fe8434f0efdc156fc
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 578675
+  timestamp: 1690985127411
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py310hecd8cb5_0.tar.bz2
+  sha256: a8774377f121ac341dde9dd8abb12bc66b4da190bffa1f174ccdcb0dfbab77a5
+  md5: bfd9bf83d0562607c255dbec00bbddb0
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22873
+  timestamp: 1668160738644
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py310h827a554_0.tar.bz2
+  sha256: b2634d72414fd2395f38dbca97b6f5ad6160e1bfac2f05a73de43bb60b690629
+  md5: 8fdb739c2f53afe8b38108439c1deea9
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 139299
+  timestamp: 1696515370721
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py310h827a554_0.tar.bz2
+  sha256: 6e4a3e3184090c941916975e48e1f2f157c5e4bd3473d867adb059b0147d39eb
+  md5: d573e7ba7699271b27ce831e01e5a753
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.0 py310ha186be2_0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10389
+  timestamp: 1695830676422
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py310ha186be2_0.tar.bz2
+  sha256: 7ae570d5e9669d4b69ea4ed7b49517afad8e657260a3fbc466155c71f9182887
+  md5: 1ed5fb43c01ff836a6f3e5e854cd1899
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - numpy 1.26.0 py310h827a554_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7610228
+  timestamp: 1695830639474
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
+  md5: 93f5d7b66976154adeda219bea02ba45
+  depends:
+  - libcxx >=10.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 484257
+  timestamp: 1630093862501
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+  sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
+  md5: 5e8713ef1215406254988163eaf34020
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4965606
+  timestamp: 1695323060401
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py310hecd8cb5_0.tar.bz2
+  sha256: 089feb98ce46c010cc25d3660d5bb16bcf7bd10a967bef18184fb15714fc0a32
+  md5: 43ef133d834ebf2f1dc2b7fba3d50ce6
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 74480
+  timestamp: 1693575260353
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py310h3ea8b11_0.tar.bz2
+  sha256: 254e46f19c0826956dbdf42b5f15028c4da8ef44141c42d008289ae98337e938
+  md5: 17a3e1285f42272d75ed890b655b041a
+  depends:
+  - bottleneck >=1.3.4
+  - libcxx >=14.0.6
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - tabulate >=0.8.10
+  - blosc >=1.21.0
+  - fsspec >=2022.05.0
+  - beautifulsoup4 >=4.11.1
+  - pyreadstat >=1.1.5
+  - pyqt >=5.15.6,<6
+  - s3fs >=2022.05.0
+  - numba >=0.55.2
+  - xlrd >=2.0.1
+  - qtpy >=2.2.0
+  - xarray >=2022.03.0
+  - psycopg2 >=2.9.3
+  - lxml >=4.8.0
+  - zstandard >=0.17.0
+  - pyarrow >=7.0.0
+  - pytables >=3.7.0
+  - xlsxwriter >=3.0.3
+  - gcsfs >=2022.05.0
+  - fastparquet >=0.8.1
+  - scipy >=1.8.1
+  - pymysql >=1.0.2
+  - odfpy>=1.4.1
+  - pandas-gbq >=0.17.5
+  - pyxlsb >=1.0.9
+  - matplotlib-base >=3.6.1
+  - openpyxl >=3.0.10
+  - jinja2 >=3.1.2
+  - html5lib >=1.1
+  - dataframe-api-compat >=0.1.7
+  - sqlalchemy >=1.4.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13608325
+  timestamp: 1697479408057
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py310hecd8cb5_0.tar.bz2
+  sha256: 4b2d5305590fbf66d22508e1b9ca7afbce87a25f6a1142d6de6b2815c9ba98d1
+  md5: dc07447e3ab88d2f1147ccec800be296
+  depends:
+  - bleach
+  - bokeh >=3.1.1,<3.3
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.16.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17078623
+  timestamp: 1695146541406
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py310hecd8cb5_0.tar.bz2
+  sha256: 08f766f3c49a9b1bd0addb34fb0ce0739d319003aa4d7580d25b8b344b3dac8d
+  md5: 7b31c764364be71df61cd206249ccae2
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 144060
+  timestamp: 1684915450654
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py310h7d39338_0.tar.bz2
+  sha256: d5e918ed8236a338d9f436a09eb46c30e5f9e347996994e5c90c473586227c24
+  md5: 857a827b9265d61c8ddc60a1ee07b439
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND
+  license_family: Other
+  size: 725546
+  timestamp: 1696580269946
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py310hecd8cb5_0.tar.bz2
+  sha256: eefa0d8918708629f5025ce521b9b15f7cddd0e87101bfdae3000bcfd2bf3da7
+  md5: 70535b7f63e00d50a7acc6bdd85586fd
+  depends:
+  - python >=3.10,<3.11.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2766709
+  timestamp: 1697548926659
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py310hecd8cb5_0.tar.bz2
+  sha256: dd5966a641fed108397a18417e59eca23b954459d8dfaf1c2b02006147bf803a
+  md5: 0ba5d202a0f8fa8addb28c3c5f411150
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 33266
+  timestamp: 1692205694975
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py310hecd8cb5_0.tar.bz2
+  sha256: c9dbcf730bb1f746db302a11fa5f42071e9d873f303f5dee75b239ede7bf3980
+  md5: 1327ba70c886ab04a2519bfed39bee65
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 92145
+  timestamp: 1659455228077
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py310hecd8cb5_0.tar.bz2
+  sha256: 0183e61dfefdba63f97fe57d2931e70094e050f823d8762878dc48e8d3dfb42e
+  md5: f188d7613b2cfb91b28004918aa19021
+  depends:
+  - python >=3.10,<3.11.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 601686
+  timestamp: 1672387406503
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py310hca72f7f_0.tar.bz2
+  sha256: 5a156c5d275cd9741ece740b8e0c73cf18ed8c6964fbbf8fe77c128477ee4e8d
+  md5: a13323d851b7c615fe3c85924773d118
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 370312
+  timestamp: 1656431483235
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py310hecd8cb5_0.tar.bz2
+  sha256: 6f28fc0782ff0a1f9f44be058392efcda61a916f4687f0e349c6a0b633154a31
+  md5: 89243bf420e88ab976e19b1a91228465
+  depends:
+  - param >=1.7.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30981
+  timestamp: 1675441597598
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py310hecd8cb5_1.tar.bz2
+  sha256: 864b005b3d12d53740f42f89e7d3468b43917f6054b2a27d49d6a072a7269aae
+  md5: 29606753a2e301fe9542067780a50ec1
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1889082
+  timestamp: 1684280018937
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py310hecd8cb5_0.tar.bz2
+  sha256: 487b805533d5b50277d9c89f51a3aa7e7b729c69da0405b226ba038d339bb8a5
+  md5: 61b06079b67e16ce1867a92c96d863b4
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95852
+  timestamp: 1690223503122
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py310hecd8cb5_0.tar.bz2
+  sha256: db519ef731035a089ea668c083e4808dd7cbcfe7e86888980bef6c27cac0a641
+  md5: 47485dc392cbae53021ae382b8dc08ae
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 159281
+  timestamp: 1661452701242
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py310hca72f7f_0.tar.bz2
+  sha256: dfd09b8d92159b9e9231af7e5918985449be9ff425a994a088356a67f2d0fb98
+  md5: 490a33ca92bfe105ba93c28b4c795ff8
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 92153
+  timestamp: 1642541595890
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py310hecd8cb5_0.tar.bz2
+  sha256: 7e7ad33a42ffc0cf30a64115bbf6a4fb77e6f4ff859b5cdc1c5af35e34a77a36
+  md5: 8b1372e62747adb48891711705ecf67c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 28205
+  timestamp: 1642536392594
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.10.13-h5ee71fb_0.tar.bz2
+  sha256: 5ba093f7f0e5088ce22ea87d6880a134bd0d1d67eed734cd7a339e8c0d688294
+  md5: 733726b31b54c2859abf39e515c391c1
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 14070954
+  timestamp: 1694439953107
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py310hecd8cb5_0.tar.bz2
+  sha256: 3d314468af451dbeb0ed8ac8388d85a0edb0dc4ff87e7679b0d8295e23b679ae
+  md5: 99de5095f6d8989cd8a0a60457a26e80
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 267017
+  timestamp: 1661368961839
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py310hecd8cb5_0.tar.bz2
+  sha256: 44eef36e967a2562a043a9db7f0fa137878b7adf7ff578d9378b9e020efa6bb0
+  md5: a36782f1fbc6a6d2e176522e3d5b79d0
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 263007
+  timestamp: 1695131673910
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py310hecd8cb5_0.tar.bz2
+  sha256: ccda239903a1c14577c76e9ec451630bd7dec7df91e7afcd2b4bc3ee111192ea
+  md5: cf498337272068feb029e4f873e400fe
+  depends:
+  - param
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41072
+  timestamp: 1685030909072
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py310h6c40b1e_0.tar.bz2
+  sha256: 59d597cc950bf5197924d433b42e72273f6dbbdaeeceb053f6050cad1fc1005e
+  md5: 2df629ea5b0b5e5e5327ab360e81f64a
+  depends:
+  - python >=3.10,<3.11.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 167875
+  timestamp: 1698096174693
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py310he9d5cce_0.tar.bz2
+  sha256: e56762c3fa93a7894e98e05e1b846e750a65687142687fc14b5f51acc09b6c94
+  md5: c597bda474adc66bd51ef3c45b5120ef
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.10,<3.11.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 496650
+  timestamp: 1657724393960
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py310hecd8cb5_0.tar.bz2
+  sha256: 39749df47bb595363c366aefa9724fb0251eae23ed1fd77b7e269a4f8a32c4c9
+  md5: b03a080689f8cfab8c86693d9816024a
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.10,<3.11.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 96142
+  timestamp: 1690400412604
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py310hecd8cb5_0.tar.bz2
+  sha256: 1824642ef4461a0a77d5e4e3d6af8a08d46252ed09f95d00f722b63ecb2a7b66
+  md5: 867cc0219069dcb5cd578910c58dda98
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1101438
+  timestamp: 1690291040658
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py310hecd8cb5_1.tar.bz2
+  sha256: 8b7cc3fd8e5f649e4d7d09cd47e0602839ee5735d8467aa16cab962a082ae3e8
+  md5: 5f805498c07279470db32b3e23387420
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15556
+  timestamp: 1642537667959
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py310hecd8cb5_0.tar.bz2
+  sha256: 97a6ef8790155b089dc6c1c7559cac226dc8966fb7189276d43e56361fef921b
+  md5: c5fe7f5450316dd0f7c407fc6d5c4590
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 67950
+  timestamp: 1696347655636
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+  sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
+  md5: 82e4db6a498480a75d53c55bd35b6478
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1801397
+  timestamp: 1681394807900
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py310hecd8cb5_0.tar.bz2
+  sha256: 92b0454b4739557af9a8f52f040828cb343935e874144e25eebf620be61cfb85
+  md5: 39fb00364e1ae13b9fc9af51c0540648
+  depends:
+  - ptyprocess
+  - python >=3.10,<3.11.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 31114
+  timestamp: 1671751965362
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py310hecd8cb5_0.tar.bz2
+  sha256: 47192486a825a7723642a5ff51a6e6e1951c2d32c7788da5de2485cc06b30211
+  md5: 857b3344cb9298976756ca71dc731d60
+  depends:
+  - python >=3.10,<3.11.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40085
+  timestamp: 1668168926166
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+  sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
+  md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
+  depends:
+  - zlib >=1.2.12,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3536231
+  timestamp: 1654088937695
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py310h6c40b1e_0.tar.bz2
+  sha256: 52fb9d05259365350eca75a97b42f8b9bcb7b090ebd6bd95d21f337f73c25e1c
+  md5: d2bfc5dd6b421d2a3f58d6255fdedcc6
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 689288
+  timestamp: 1696937228662
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py310h20db666_0.tar.bz2
+  sha256: 6876f55e026d8964844f80442aea51b2b5893c2f6e9afffc9a52b938de74a171
+  md5: 76f0e82559e0d2cb25cd00721d0ec899
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 126000
+  timestamp: 1679562147426
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py310hecd8cb5_0.tar.bz2
+  sha256: 87e0bd4e5178668a54ae6e6dcb3cd3ec495f5d67d63bfcda92c80c13b4c5818a
+  md5: 6fa79103a143c775db1fb39a353e3b57
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 194911
+  timestamp: 1671143953318
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py310hecd8cb5_0.tar.bz2
+  sha256: bd72de8e84b90728ea4b4e8388c4505bec7d09e29956c2432191a2db70206a34
+  md5: 28f471989dd29ca9c4dc30f062b20f76
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing_extensions 4.7.1 py310hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9682
+  timestamp: 1690297614212
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py310hecd8cb5_0.tar.bz2
+  sha256: 2f6971494a97a047be714d050b2abf622d39189e58a07033eba98372f7575c56
+  md5: aea017906d38d594a3efdea15d38ef95
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58932
+  timestamp: 1690297606654
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py310hecd8cb5_0.tar.bz2
+  sha256: 7669c43d362b42ed8c5d52c9660420df67f8f4ce59194d95c038b01b66f085d1
+  md5: 62dcb988e38541d7073093a64453dbb4
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 11601
+  timestamp: 1659769547734
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py310hecd8cb5_0.tar.bz2
+  sha256: 08d5f8a7db2a4e1708f75e8a87c977fbebcc2d936c2e52f246989cf80df44f94
+  md5: 03a75bef86c8f0bcf385b666513755d5
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 190398
+  timestamp: 1698257632441
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py310hecd8cb5_1.tar.bz2
+  sha256: aae85a1650806382831d1edd5b7e8912329c2d5859dd63258f2b422d0bee1761
+  md5: 7502e3b07c9f996017a9171d056b3865
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21319
+  timestamp: 1642539070002
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py310hecd8cb5_4.tar.bz2
+  sha256: bfcc4c35eae2d90abc18b87a0add0517e6ea10677cc2037d5378f9de0409003a
+  md5: ee812330edd951833ed8ba1ac49084d0
+  depends:
+  - python >=3.10,<3.11.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 71241
+  timestamp: 1642513589037
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py310hecd8cb5_0.tar.bz2
+  sha256: 05a3708b6a166574a7f062e6a8ae36052c291bfca26a9fc66f90ccd3f424f2a1
+  md5: a67133ecf7cdafd527c93a608369c20f
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 103558
+  timestamp: 1695741971042
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py310hecd8cb5_1.tar.bz2
+  sha256: b7c324c44d31162d3ae297d38d95157f1d8b27c8dd6de2ee369e2426eb1c7d67
+  md5: cb55c97b4ce01dec47958aefa7845582
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49600
+  timestamp: 1675159097509
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+  sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
+  md5: e243baa546432c8394a8059a44a5a3e4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 419227
+  timestamp: 1683113010463
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+  sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
+  md5: fe4ac85ee86d3a94ea3a4ebea3779763
+  depends:
+  - libcxx >=10.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 321797
+  timestamp: 1616055526986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+  sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
+  md5: 8e495591e369ac161857a72011c0a296
+  license: Zlib
+  license_family: Other
+  size: 120272
+  timestamp: 1666595024203
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+  sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
+  md5: f1465fbd810b3746c6de6babfd4fe28a
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1023573
+  timestamp: 1681304595869
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py310hca03da5_0.tar.bz2
+  sha256: b161c187c7a5303d7c39c503ae770312213b5ef48ea860e46a20e9356c7b027d
+  md5: 992ef1ea267b882a65a0a0174059a014
+  depends:
+  - idna >=2.8
+  - python >=3.10,<3.11.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 158997
+  timestamp: 1644482619945
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py310hca03da5_1001.tar.bz2
+  sha256: ab80767485355b86e85012079c6774f34b8a50cca22f6af691717dae8a6eecd3
+  md5: 313a6fb125023514957826391bd2bc9a
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10379
+  timestamp: 1643965069164
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py310h1a28f6b_0.tar.bz2
+  sha256: 88db781405798fc0a4bd4d2cfa4817d72a1717595814792b06baf438a74f971e
+  md5: 74f12ced47a5a18208005eb36438fb97
+  depends:
+  - cffi >=1.0.1
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 36148
+  timestamp: 1644845853887
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py310hca03da5_0.tar.bz2
+  sha256: fe75ee2d49ecc10cd6b9caaf2800e687c9dd7b9fed6bef30f3ed2c547f7d9135
+  md5: e38c094d6bb9e888c27e80421838f70b
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 134144
+  timestamp: 1695717859882
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py310hca03da5_0.tar.bz2
+  sha256: a9e8d204acd18d88e3d7bafdf4b186760aa70cbe05af7b772e2e89c0d622fcbe
+  md5: ba1e27ad80d1ea30735bc6d50ad8de7e
+  depends:
+  - python >=3.10,<3.11.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 210172
+  timestamp: 1681493083831
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py310h33ce5c2_0.tar.bz2
+  sha256: b0f9f35148a0c19833db161db41322512880a3fc7ea5853745864122650d0117
+  md5: d199b3fbf3bcf4b165bb779aca7ad26c
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6476634
+  timestamp: 1690546122888
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py310h96f19d2_0.tar.bz2
+  sha256: bb95775b0373a658338db915d396e3b15bfaa4638e3b1c871e93f403f175955a
+  md5: 89f546ea159e7f93abe4478b57de86c9
+  depends:
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 120152
+  timestamp: 1657175824776
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
+  md5: f860193e14afc7ef3f5b990a2ac003d2
+  depends:
+  - brotli-bin 1.0.9 h1a28f6b_7
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18936
+  timestamp: 1659616204016
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
+  md5: ad53130f3fd1f8d3c2fcbb7496e5585d
+  depends:
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18715
+  timestamp: 1659616188888
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py310hc377ac9_7.tar.bz2
+  sha256: a9ddfe62150d43572c17bacfc7fe21cca54ee0ec70257bdb3f46341b4f4e5811
+  md5: 447494f240be6ba630419e2e0d4da439
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  size: 372230
+  timestamp: 1659616285486
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
+  sha256: 019469288da4767fd021f488b907e2f4f3b34db686fa12055d52d9bb7bb4d872
+  md5: 9f63c782a4d20150ae9a664ee87cce16
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 150682
+  timestamp: 1624215191959
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+  sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
+  md5: 31ac2f5596cb7a44adf073c930641c54
+  license: MPL-2.0
+  license_family: Other
+  size: 133817
+  timestamp: 1694009762858
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py310hca03da5_0.tar.bz2
+  sha256: 5250d84793f93e22c917b89c6e0c0b3d679ab851e21f14961ac09140060b44ea
+  md5: 87f8474b08ef5467ece8b01444b3207f
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159793
+  timestamp: 1690232325493
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py310h80987f9_3.tar.bz2
+  sha256: 906fc6df2c6cf27d54fd51f7330fd5d5af8e30c435edf69957461a2d8411ba94
+  md5: dcbdc86631c5c07e3492c49d7084efcb
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 227157
+  timestamp: 1670423279818
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py310hca03da5_0.tar.bz2
+  sha256: f79e98ee1009bda17065a22a17ea14a839d436c5807a6044e0a300b10d93c8c9
+  md5: 69845f1299334fe1eee4ca3c6fd6cd77
+  depends:
+  - pyct >=0.4.4
+  - python >=3.10,<3.11.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1942655
+  timestamp: 1668084604892
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py310hca03da5_0.tar.bz2
+  sha256: 0d96460ec2d66be2d1dd8183c82e6ec69b1185d25553a560c2adf0bd9b200f91
+  md5: 8393a8d161630af4f51009518141f713
+  depends:
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13688
+  timestamp: 1671231144978
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py310h525c30c_0.tar.bz2
+  sha256: e3ff8b4c9b051ab09155a8065ce900c1a36b2d43eba37686245f697cc3388f63
+  md5: 4fe4492dce62492dfe12bc22541adc55
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 244141
+  timestamp: 1663827577910
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py310hd4332d6_0.tar.bz2
+  sha256: bae16cbe2ee81bedfeed997406503e120a92e3ba170da657d28633c5a588de6f
+  md5: 49bad9c3a61a06a888ae65cbee351ca6
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1404143
+  timestamp: 1694211691189
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py310h313beb8_0.tar.bz2
+  sha256: cac66c2a69e5bee96de7a9a5be0ecace698915c107c9fa9047e884ca671413fe
+  md5: 28e9929e5bb06bf8df0b540b2069ba33
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 2075348
+  timestamp: 1690905262055
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py310hca03da5_0.tar.bz2
+  sha256: 1d532b889e0e71fe68f59e0fd328fe4c42c11660de3a32a0e31fe149f02a3eb5
+  md5: f5ec34d95710f724fd4b4c064ed0abcd
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT License
+  license_family: MIT
+  size: 15257
+  timestamp: 1650293833649
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py310hca03da5_0.tar.bz2
+  sha256: e07e960cb79989d664cd2028560a3af63bddec35a1bf1b2443e97c007884c786
+  md5: 4be55fb58220d2ec53b7c7c2da96cb8e
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27899
+  timestamp: 1668714429621
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+  sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
+  md5: 1d0bd7e576c64c059ef781dd319ad82a
+  license: MIT
+  license_family: MIT
+  size: 77591
+  timestamp: 1676983230102
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.17.1-py310hca03da5_0.tar.bz2
+  sha256: 3f16f886fb136d2b57f708f5d0e04616f4dd4da5e2e8309d9c10d9c54c4babf9
+  md5: 1645f835fdbc218e042c4d7e9141d81c
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4501591
+  timestamp: 1693378202363
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+  sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
+  md5: 69eb3b03765627b6159ed23cdde78396
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28399065
+  timestamp: 1692293207812
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py310hca03da5_0.tar.bz2
+  sha256: 5017baf9a8738093eed8cb5aa3e0194c33c8d8f8fdf371a5d14a1954c9ff726a
+  md5: bbb580008f67de323af6c3ae9a74937c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 117075
+  timestamp: 1666125600066
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py310h33ce5c2_0.tar.bz2
+  sha256: dc9d40c2f7718f40ac7d9660f717d3dd5bb108470c1a3254b5d2bb68c83e71b8
+  md5: 4fbeb0ce7491c146ce1dba75fa9a37a0
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 222070
+  timestamp: 1691121668519
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py310hca03da5_0.tar.bz2
+  sha256: fdf971d7a35b30a12db7fdd122e193fe7bc3d00abb584cb0f0a328316e154011
+  md5: 1246d35ee1e4e48f0be379f9c71b2cad
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.10,<3.11.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1275330
+  timestamp: 1694181377825
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py310hca03da5_1.tar.bz2
+  sha256: bf77c0425ac78e734e7ad96610b53e8c6d79c8ba81e43157344f37f2fc2e53fb
+  md5: a29c97649beaa0409e53883280b57456
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1026561
+  timestamp: 1644316081070
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py310hca03da5_0.tar.bz2
+  sha256: 7c3cbf001d0a289e29ce708d973d5e780a36fd923f3fe02185a104ae5cb4cf53
+  md5: 62745f1b50b4627d478d87e45a82ca12
+  depends:
+  - markupsafe >=2.0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 218104
+  timestamp: 1666908165640
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
+  md5: 055e12390b844ea6c6e956ee08a618e8
+  license: IJG
+  license_family: Other
+  size: 273479
+  timestamp: 1677849171867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py310hca03da5_0.tar.bz2
+  sha256: 61cac8c3c495c9bd4929cd425d579e2af6cec549170f7d16cf6ddbc8f6622bd8
+  md5: 30956a5c5dab2c9358d6d27cb08bc489
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 134350
+  timestamp: 1676558790619
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py310hca03da5_0.tar.bz2
+  sha256: f723762f6638ac41a57cf16527d87ca94e3d1e60cd404fd58d694bf4b15c6267
+  md5: cc8524666e2ac097a9c54a077e3a776c
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 199244
+  timestamp: 1676329389846
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py310hca03da5_0.tar.bz2
+  sha256: a3001bf850c4eb6bd991e5755d384483003b0e6384e470a06d44d3049b643f90
+  md5: 83e9dbb1e2ee32a633c902d284fe1295
+  depends:
+  - platformdirs >=2.5
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 93396
+  timestamp: 1679906691116
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py310hca03da5_0.tar.bz2
+  sha256: cbc4401a0093ec9fd49e7dea062fd9b7a2d957243918169998bfbc935d4f9015
+  md5: b6039d2abd7aeb7095546c6cce193893
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 402719
+  timestamp: 1671707717154
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py310h313beb8_0.tar.bz2
+  sha256: 379b8b9c8e45b813e6d31a712c2d5c8ae5801570b4717626971fabe87938c51f
+  md5: 2ff257d592914060b35560de4fe1c83f
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64635
+  timestamp: 1672387310531
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
+  md5: a0f206782751dfffed0dd51302a1bf26
+  license: MIT
+  size: 68012
+  timestamp: 1659616138077
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
+  md5: 4c6667cdd061d28e9bc4e4300e4d115e
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 31173
+  timestamp: 1659616155596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
+  md5: 637e9430e258ddf050623ef2360184d8
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 298430
+  timestamp: 1659616172209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+  sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
+  md5: 55c615026c0869f8d3ba657f3bd38c43
+  license: MIT
+  license_family: MIT
+  size: 120389
+  timestamp: 1683716579036
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+  sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
+  md5: a41117710dafe569c9cc4e83f6f29fe3
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1411339
+  timestamp: 1650982753977
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+  sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
+  md5: 98d22e0124d55fae3c37c608dab1dcc9
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 89825
+  timestamp: 1694778225280
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+  sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
+  md5: 0ba499df6755eae5d2d23aa4ab004553
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 642657
+  timestamp: 1692970217410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+  sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
+  md5: c73101971e5ab6a8e8688239884eac81
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241607
+  timestamp: 1692973585084
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py310hca03da5_0.tar.bz2
+  sha256: 4e992da1d64efc2158c185b23883dee1e50ccc7a1ccb61d1b0546e6eb44bc536
+  md5: aad3f66e7d96961764d2b5d0ab08efb3
+  depends:
+  - python >=3.10,<3.11.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 36178
+  timestamp: 1659783445874
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py310h50ffb84_0.tar.bz2
+  sha256: 1d4faae7e0c5d9abb237903c0b2305c74c43487c61ae667d154ee7c58c3aedef
+  md5: 94d59d770946de5d7d08d46739d91aa3
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1490661
+  timestamp: 1695058336218
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+  sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
+  md5: c99006da802a97c9aae30da8c16b4820
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176131
+  timestamp: 1670944706815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py310hca03da5_0.tar.bz2
+  sha256: 8303fcbfcdf8ab390e505f34c5ac6fa057815139d8e6cf7380dc108eb772485c
+  md5: c769729b709fa4dd0a8da5be358de878
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 124217
+  timestamp: 1671541964591
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py310hca03da5_1.tar.bz2
+  sha256: b0e240d3ef06e292105f4e1b161426170e5897144c142d23df66935ab4108dc5
+  md5: 8c6193fc54f6c300530527f642efadf1
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 108119
+  timestamp: 1684279956548
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py310h1a28f6b_0.tar.bz2
+  sha256: 408f7c132e7feae166a93d69bb85dc663f67d9a9ebce63de72cc9711863a970a
+  md5: 7d61620437de9f62ee1d54ce53fee7d0
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23377
+  timestamp: 1654598111449
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py310h46d7db6_0.tar.bz2
+  sha256: 17ad3ab86fbd774cb1129c10d735c431867ca6ee8e86c848980c01d5518fd3c6
+  md5: 5f445a9b6e63e0e59991635fba7c34bc
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8157070
+  timestamp: 1698692208753
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py310hca03da5_0.tar.bz2
+  sha256: 9cfad1d0d85bf4079262292b47e62355c7c1847f641ca8dfc46c4226bce2d785
+  md5: b1a3a7ea89adee337db085727216abda
+  depends:
+  - python >=3.10,<3.11.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17383
+  timestamp: 1662014500374
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py310hca03da5_0.tar.bz2
+  sha256: 66e7f61e59f392a603639c284ce06bd2930a59270990089f602cdf2628467eb8
+  md5: cf0c798d425a37c0404fd04da7afb640
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 54195
+  timestamp: 1659721278389
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py310hca03da5_0.tar.bz2
+  sha256: 7f85b9bd603910fee4f7ecac3fbc3eb4b978ab16ad2acd88d3d5a03b89c6bace
+  md5: 984724161f039112bf536366c1332531
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 19648
+  timestamp: 1659716071039
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py310h1a28f6b_1000.tar.bz2
+  sha256: 6e5268ec49ec14a878619202872f376916e1f921ced05d95665e0161667c12de
+  md5: 15a84e69027161b6891ee3e2573f00b7
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 55998
+  timestamp: 1643966749532
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py310hca03da5_0.tar.bz2
+  sha256: ee416a11885d65898b2d8bd22c91515f7ca34fb617c49540218a0d1e646c8e99
+  md5: c6a3eb6ef4ccc860faa9f2e46f27787c
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8291033
+  timestamp: 1681756229533
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py310hca03da5_0.tar.bz2
+  sha256: aec5ec1774397f5621e5593b0dc108a4e327b07314ea39b2529ca7a02607e730
+  md5: 2699cbb6b7f2d98bf310172cec26ac11
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 97422
+  timestamp: 1650373598939
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py310hca03da5_0.tar.bz2
+  sha256: 298ce036c5bd3c96985385065a0a3970e6c015016a9b4605c8c9a85c5101f1ae
+  md5: 3e0f7d130ecce4d47961fc086b9c8241
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.10,<3.11.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 565126
+  timestamp: 1668450717170
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py310hca03da5_0.tar.bz2
+  sha256: 2ca888da7d4d25058cdf603b290ce3be700da9e7d6f48ab798077636318cee7c
+  md5: 3b5870300d3ad885ee18c9ab13d620f5
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.10,<3.11.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 149217
+  timestamp: 1694616882123
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py310hca03da5_0.tar.bz2
+  sha256: c60275ef60945a4be7a627d6f75aeda4d8845811ddef0ef8d9da5ff5e4313dd1
+  md5: d09b0cf5410d5cf474e0b53d733b70e0
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14207
+  timestamp: 1672387183579
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py310hca03da5_1.tar.bz2
+  sha256: 58ce1240d519353f46c912c05670e30a371a9a19678ed782178a90a2d8bbbb20
+  md5: f4546e01c9182b6d82a95c99a2fc3230
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 588419
+  timestamp: 1690984916773
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py310hca03da5_0.tar.bz2
+  sha256: 9e43edd9d03f5aab39d7897befc25be58d2248440acac582a82a8d2530d3bd46
+  md5: a2502e574a6a844b3276dfcf826a4b2e
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22925
+  timestamp: 1668160667137
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py310hecc3335_0.tar.bz2
+  sha256: a6a8b0d7b49057b07ebc0cc221674604d526bb7066afc62404b635e32ae8cf67
+  md5: 34dd4756c394fb45a284a7ae913df3e3
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 127427
+  timestamp: 1696515372844
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py310h3b2db8e_0.tar.bz2
+  sha256: 8e5f3e37e16e4f6d95513820d177c1ce51856bd3490248dc2cc5bad7243a440e
+  md5: 0d387b30c16c06ad842c0a74e2a79f15
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.26.0 py310ha9811e2_0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10380
+  timestamp: 1695831144544
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py310ha9811e2_0.tar.bz2
+  sha256: c0d375c130284bd551fd695b90ecdad52fd41fd2a21399d8158af8736e0217f9
+  md5: 912d2cc8df65d3e1083b6333b2c92fde
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - numpy 1.26.0 py310h3b2db8e_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6350032
+  timestamp: 1695831132292
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
+  md5: 371358a54bbdd307603888348d1a2c6f
+  depends:
+  - libcxx >=12.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD 2-Clause
+  size: 412248
+  timestamp: 1628861367714
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+  sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
+  md5: fa15d3b44ae1360ac9b640bbd5b6923c
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4746123
+  timestamp: 1695322833432
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py310hca03da5_0.tar.bz2
+  sha256: 93237eb96c47bb1d3af5a4df6da6604a45cd66c57793708afeef3878ae85e4eb
+  md5: e482a7583e0bf5b5f5671c4a1b658af8
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 74436
+  timestamp: 1693575224188
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py310h46d7db6_0.tar.bz2
+  sha256: 2f073b4803a981e2fc5b4e21b84a669a2e4c49c4f5233fe33a30c50a1cb11be5
+  md5: c75f1ef14f245572becd5761a5c551d5
+  depends:
+  - bottleneck >=1.3.4
+  - libcxx >=14.0.6
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - lxml >=4.8.0
+  - matplotlib-base >=3.6.1
+  - tabulate >=0.8.10
+  - pyqt >=5.15.6,<6
+  - openpyxl >=3.0.10
+  - s3fs >=2022.05.0
+  - pymysql >=1.0.2
+  - beautifulsoup4 >=4.11.1
+  - scipy >=1.8.1
+  - xlsxwriter >=3.0.3
+  - fastparquet >=0.8.1
+  - xlrd >=2.0.1
+  - blosc >=1.21.0
+  - zstandard >=0.17.0
+  - psycopg2 >=2.9.3
+  - pyarrow >=7.0.0
+  - pandas-gbq >=0.17.5
+  - pytables >=3.7.0
+  - sqlalchemy >=1.4.36
+  - odfpy>=1.4.1
+  - numba >=0.55.2
+  - jinja2 >=3.1.2
+  - pyreadstat >=1.1.5
+  - gcsfs >=2022.05.0
+  - qtpy >=2.2.0
+  - html5lib >=1.1
+  - xarray >=2022.03.0
+  - fsspec >=2022.05.0
+  - dataframe-api-compat >=0.1.7
+  - pyxlsb >=1.0.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13400109
+  timestamp: 1697477349034
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py310hca03da5_0.tar.bz2
+  sha256: 88811223659197b175b924057b7b5926c7093cded6f9a9aed5efb6452c2be8f1
+  md5: dfb4aca8097e63f3db61cad638723639
+  depends:
+  - bleach
+  - bokeh >=3.1.1,<3.3
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.16.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17074981
+  timestamp: 1695146365895
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py310hca03da5_0.tar.bz2
+  sha256: 958c77578e3569111c33fc9ddf8ec012f4d575818488d2704cf5d3a4c00a52c2
+  md5: b0818352d65dc7ea4998a5790de52397
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 144036
+  timestamp: 1684915352915
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py310h3b245a6_0.tar.bz2
+  sha256: a3d70106b4fd77ac519bf8bfcd141684874d0f0d4fea10d28e06319d388309de
+  md5: 133adf01151d7d098cdbe71a9b6c87e5
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 723566
+  timestamp: 1696580116818
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py310hca03da5_0.tar.bz2
+  sha256: 05c3517553b868e97fe5af7c168b896a4a5f4c948d9d96a9659eda79dfabda4a
+  md5: 2d67c116129367a525bd758831df8355
+  depends:
+  - python >=3.10,<3.11.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2757569
+  timestamp: 1697548846423
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py310hca03da5_0.tar.bz2
+  sha256: f90967e7b1263de747709a00d54c5c41ef7efe03ece8b480cd2f811ed6da7e68
+  md5: 68b0d1ba5f14b5296c2e880e3ce8e1cf
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 33194
+  timestamp: 1692205719500
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py310hca03da5_0.tar.bz2
+  sha256: cbcf62345c0121e1962743f0cde11b553c58338922df9b295b5f32e1e9160435
+  md5: e347b5b10b9679c069716037fc8114b5
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 92103
+  timestamp: 1659455169618
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py310hca03da5_0.tar.bz2
+  sha256: 5edeee8adcb94bd9394247e5ba36b9ab551e708026c9183a6b1dfc29f6223c83
+  md5: 77bb249fcdbd15c68965c3d8cbcfb007
+  depends:
+  - python >=3.10,<3.11.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 601509
+  timestamp: 1672387364356
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py310h1a28f6b_0.tar.bz2
+  sha256: ddcca2ed0751d233e1953dcd1a373b1d778bd6c303e4bae3713fa7d20a814ed7
+  md5: 2cb18e1233648dbd160770e5941bf588
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372012
+  timestamp: 1656431417953
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py310hca03da5_0.tar.bz2
+  sha256: 7cbbdf3a39c721a4c72adf205043864da01ea31af29835014e8379e7c368b1cc
+  md5: 0539e1b90082304925156fc822aad965
+  depends:
+  - param >=1.7.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30983
+  timestamp: 1675441560368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py310hca03da5_1.tar.bz2
+  sha256: 5a345e4a9a6f8ff0264bd5a8238e591192915b99f44c75aef66033aecea15ec7
+  md5: e2c9a794ff909ab32cc84c4fc6964a6d
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1882595
+  timestamp: 1684280055553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py310hca03da5_0.tar.bz2
+  sha256: 271d303a73878efe49bd997962fb5ba474fb118cd03d44958a3f61d446d87521
+  md5: bf861f951e567d14d903c7139c629d01
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95814
+  timestamp: 1690223518556
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py310hca03da5_0.tar.bz2
+  sha256: 952097983b02f9cb5b1679bb251bffcb4f3465ac8393a09b0f630571e2cb9367
+  md5: 16c9d43c3fbdfa9ff458e83ab1a2152f
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 159251
+  timestamp: 1661452569469
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py310h1a28f6b_0.tar.bz2
+  sha256: 80726e6021556bc2e26aca83b5959a45382273825f26013d15f9efd5720c93ba
+  md5: 31392a859bf368e1e89f58ab59c72aa2
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 93727
+  timestamp: 1643962200324
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py310hca03da5_0.tar.bz2
+  sha256: 70946f5858f17fec169e726e761cce1d1f3e6a99ef3a8e72007c1df51e09d5a3
+  md5: f9c6d792e5983df39d7dbb8389340e9a
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 28542
+  timestamp: 1643961550827
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.10.13-hb885b13_0.tar.bz2
+  sha256: b927da0c1d2fc87459dea7cd33221f7dfc3f1d9f552abebdcbb35437dea6c2cd
+  md5: 2058a138c3146791d7a04dc629716925
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13888559
+  timestamp: 1694438370078
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py310hca03da5_0.tar.bz2
+  sha256: 79a47f968466e21cf9b323b9704f5f6e317f8865b1d20e01e290ab2003662f33
+  md5: fac5645515e04c5ac0e47d80133671e2
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 267399
+  timestamp: 1661368747513
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py310hca03da5_0.tar.bz2
+  sha256: cb8650f9dbf55d92986b06947853974c670c58f549185b5ca2ec51df1f605532
+  md5: b947a5ed2ee1aec93707bdab5bd13c23
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 253158
+  timestamp: 1695131613841
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py310hca03da5_0.tar.bz2
+  sha256: 7a8c9f6dcf55a081acbbeae8c42cfaa8f8f64b080a594c655987118e6abf616b
+  md5: 7d17c4a9489fa213690b2c2976a763e7
+  depends:
+  - param
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41041
+  timestamp: 1685030908266
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py310h80987f9_0.tar.bz2
+  sha256: c3f5a9a25cdc410c00c59ea282ab308deb29f6ec08993e6a3eddf5134f399e62
+  md5: e16c05a8ef62c241107fd99c5da05086
+  depends:
+  - python >=3.10,<3.11.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 164816
+  timestamp: 1698096085371
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py310hc377ac9_0.tar.bz2
+  sha256: 2d8e1c3ebc2dd93e2276dfe3a819b7bc13b11847cd0b340ce15ae38e6133def7
+  md5: 200930199ebb3996d82d40e15a959d14
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.10,<3.11.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 491130
+  timestamp: 1657724255034
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py310hca03da5_0.tar.bz2
+  sha256: 8e63cb176caf9b27833a45bec02246794098c9af4e1aec1d64de575975d93369
+  md5: 8665a78622dbfca8b9cd1e449bcf14f3
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.10,<3.11.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 96229
+  timestamp: 1690400346206
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py310hca03da5_0.tar.bz2
+  sha256: b1c75800067d9c147f57b5652ca11b86c215b0d1f4f997a0f7308d64f2eb8fcc
+  md5: 5ac42342de04ece0c99e92baff7ea120
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1101462
+  timestamp: 1690290898451
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py310hca03da5_1.tar.bz2
+  sha256: 000195489823f3e343b2542cd1a867f0cc2cfb4b86335adaf470fd854c7ecfc6
+  md5: e62f5514aba294eb7ed6e791f5c1ca7a
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15853
+  timestamp: 1643964348442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py310hca03da5_0.tar.bz2
+  sha256: 83f37d7fdb2ae2499a0d56b0d8b73aaea225272a1133ec83b7cb5a0b76dcc038
+  md5: 4cf31645d894294b7542e108702346c3
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 67932
+  timestamp: 1696347608160
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+  sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
+  md5: 2302a79a045f152e183a52a81adfba62
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1674163
+  timestamp: 1681394762218
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py310hca03da5_0.tar.bz2
+  sha256: 683dfdcb2fa481064ecb68361103214c5c3f2734cceb055af3f93a2ae4863c01
+  md5: 88e05e239da5183806dbebb6ac49cddf
+  depends:
+  - ptyprocess
+  - python >=3.10,<3.11.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 31121
+  timestamp: 1671751855788
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py310hca03da5_0.tar.bz2
+  sha256: 1ff9b75217073a26f736b2fe32f9ccb77b145d7ff9099d5091b43276f92b1f12
+  md5: 11474a3502e9b8c16e301569b7f3d8db
+  depends:
+  - python >=3.10,<3.11.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40061
+  timestamp: 1668168847595
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+  sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
+  md5: 667e60c8b407d73cbba40f44901f4f00
+  depends:
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3412693
+  timestamp: 1654088929697
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py310h80987f9_0.tar.bz2
+  sha256: 48bf87c05fd656d65b64b12af2691d4c2f9fa9430f4b1b9b26a71a2264d442f3
+  md5: 8d14ebb07457c238388f473cd0e4c706
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 688875
+  timestamp: 1696937122724
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py310h33ce5c2_0.tar.bz2
+  sha256: 5cac533c8684214f579bfdf8d8d4653953a525d7ed46772589fc528ee7960da7
+  md5: 68442822b452de7cefb52492283a9306
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - ipywidgets >=6
+  - slack-sdk
+  - requests
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125939
+  timestamp: 1679561891996
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py310hca03da5_0.tar.bz2
+  sha256: 5d0e4a55ff115223ac5d160d461a1b6b9e2f238533c2209ca01fa09971da81c3
+  md5: f012387fad7bb86a0412e2b296a3abae
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 195245
+  timestamp: 1671143991865
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py310hca03da5_0.tar.bz2
+  sha256: 564936845bc19e1ab445cdbec6a88332b5b65d30a6a54618000c462d7728e1f7
+  md5: b92c68a3cd0f41c7168542112961df97
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing_extensions 4.7.1 py310hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9653
+  timestamp: 1690297564582
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py310hca03da5_0.tar.bz2
+  sha256: de2bc98656fe8401dc78d4f2b2cef4b109c1548643ad3a339f5c52489c7eb598
+  md5: 81f2601c88a0a620488e2f2ee345b644
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58886
+  timestamp: 1690297556078
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py310hca03da5_0.tar.bz2
+  sha256: 824583d1b434a796b37b52eed6e4356ee22fb743bbef86fb59d059d100d9bbbb
+  md5: d7f13af76ca65f6145c835983c1b42df
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 11622
+  timestamp: 1659769445368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py310hca03da5_0.tar.bz2
+  sha256: 24ede438e165023d63588e2450d925530c8d9b90686f24926c062129d34d5bea
+  md5: 834ed587e0ca438269b20130dda88ece
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 190320
+  timestamp: 1698257654517
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py310hca03da5_1.tar.bz2
+  sha256: 380724b46ae0ae1edb42bc668055aa2f27af3054d866b1e67e5acbb8481cd3a7
+  md5: 6bf29c754086a9d03490af7ef3f22e6d
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21597
+  timestamp: 1643962111312
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py310hca03da5_4.tar.bz2
+  sha256: 1af1e23c6dfdce91baa30e99db00d69fe7cfcc0aaf552be2edde3ed62008bf33
+  md5: d4ebbbf7f634114a203c3de7192e757a
+  depends:
+  - python >=3.10,<3.11.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 71591
+  timestamp: 1643972675082
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py310hca03da5_0.tar.bz2
+  sha256: 63ab5b0021036bc3301b65ae76a529d74396017a26374decfdff9a17d2c66b14
+  md5: acbbff48bc203d9111378db9dd1bbf31
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 103521
+  timestamp: 1695741952847
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py310hca03da5_1.tar.bz2
+  sha256: d1ff32f75206387e8ab53e1b2253668fb79d18f79811f4547fd204093a9d75f7
+  md5: 7083a0ee005b52138b63e2c3ef37df4b
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49594
+  timestamp: 1675159129875
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+  sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
+  md5: 2e75ad6a09c308268192efe03cc9ebf4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 411778
+  timestamp: 1683113019715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+  sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
+  md5: 30f666bf97c26587c5d2f68cc5f330ab
+  depends:
+  - libcxx >=12.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 316901
+  timestamp: 1629287855861
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+  sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
+  md5: 467ae28215d1aa1c5688bc0c8a184269
+  license: Zlib
+  license_family: Other
+  size: 103525
+  timestamp: 1666595022664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+  sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
+  md5: 7cfbed15f1feee1422810f7830075f53
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 779464
+  timestamp: 1681304594848
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py310haa95532_0.tar.bz2
+  sha256: 13fd982429e1737c4d19c8c886bf0ed3486217cf5c152006144c877deb332259
+  md5: 3820014684604f5d3252b882f8aaab33
+  depends:
+  - idna >=2.8
+  - python >=3.10,<3.11.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 165811
+  timestamp: 1644481936737
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py310h2bbff1b_0.tar.bz2
+  sha256: b1f650ded18f00b931bca2cfbe25d23234ebc094ceb1ff90ca0f9748773d77b0
+  md5: 2ab6af43f2a175c8cd55263ce03730e9
+  depends:
+  - cffi >=1.0.1
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 39303
+  timestamp: 1644569997665
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py310haa95532_0.tar.bz2
+  sha256: b52ffec0004d25c4678f19f9d9bf697dba0639d5efae5c4ce8cafea0a236a293
+  md5: ec8397c5b9126de5ac348175c3c8ea5a
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 133182
+  timestamp: 1695718150313
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py310haa95532_0.tar.bz2
+  sha256: c4c4c977a91a6cdf710bd55479d84fcbc3336a48d7029254030657b00d915ded
+  md5: 8ebad46690b1b1b28880d4ace9e21e8f
+  depends:
+  - python >=3.10,<3.11.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 203162
+  timestamp: 1681493178971
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py310h9909e9c_0.tar.bz2
+  sha256: 2ccaa7e04dde683da73d56723ef56400645fa1afd2d8e331928be62f7b7107c2
+  md5: 266b810907097ebc53c36a71a872f4e4
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6497005
+  timestamp: 1690546680130
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py310h9128911_0.tar.bz2
+  sha256: 42430813ea87898081645bafbbcb5b0c7d9bff4b740d3025e7e9de9aae82a0cb
+  md5: 853f10d144193bf07981313f3f45be2e
+  depends:
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 119901
+  timestamp: 1657176406189
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
+  md5: 507dfe693ef429f466d964b599f4af21
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_7
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 18650
+  timestamp: 1659616328001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
+  md5: d0bf43e8df60baae3b3105aa5c42a791
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 21153
+  timestamp: 1659616312367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py310hd77b12b_7.tar.bz2
+  sha256: d02d1373de2b868fa66dfdf2ec4297a5aec01725f0c76e64fef14db6e0f1b821
+  md5: 6fcc544ea32b1fcb4e2eb2b673e44fab
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 342821
+  timestamp: 1659616440229
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
+  sha256: 3a26c397d4e0d546b0c2f433074c20813c5f3ae98bcf07a165c648f369a850b9
+  md5: 8f8069ce8c9eff1b0f124de2c0a63b86
+  depends:
+  - vc >=14.1,<15.0a0
+  license: bzip2
+  license_family: BSD
+  size: 154105
+  timestamp: 1563219293348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+  sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
+  md5: 092b417c11edcbe6bb9b765ab4a55d23
+  license: MPL-2.0
+  license_family: Other
+  size: 164999
+  timestamp: 1694009822357
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py310haa95532_0.tar.bz2
+  sha256: 5ee23e62406d6e08785f0e4633df85e7ca014fee65fc7e8237793eaab630807d
+  md5: 9c41b340ab32284504915b516a9d66ff
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159587
+  timestamp: 1690232391364
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py310h2bbff1b_3.tar.bz2
+  sha256: e63d5278445148548991bd341db1602e30df6b543b00a5b08358e8387ad090e6
+  md5: 133c206236d294bb655c080030e57952
+  depends:
+  - pycparser
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 230624
+  timestamp: 1670423542690
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py310haa95532_0.tar.bz2
+  sha256: 9d1b2c34fa17a72e4e7b265cb5a421bb1a6dc893b35209739f1b710f79ebcc19
+  md5: 269703fa9499eb42cfd7b9fd349ecd22
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30646
+  timestamp: 1672387329696
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py310haa95532_0.tar.bz2
+  sha256: 5cdb9f54359011390717ffe4b5ea95190ded7f3f7efd2a6823e39e7f55f51cb7
+  md5: b52ec73e9b507f251db3e30c371805fc
+  depends:
+  - pyct >=0.4.4
+  - python >=3.10,<3.11.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1948637
+  timestamp: 1668085014506
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py310haa95532_0.tar.bz2
+  sha256: bae568885d7c36869fd0c51846178adb5c3708485481447d71a4b902c2711a85
+  md5: 737ebccb5ecc85d3dade710714f8987a
+  depends:
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13525
+  timestamp: 1671231256091
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py310h59b6b97_0.tar.bz2
+  sha256: 173e74e92fcd519d9e7a0770194f7d27b573f6bae4d506261ab1c743a1824295
+  md5: b9d7146c86ea3fc2eb35fc13cc3b9dc2
+  depends:
+  - numpy >=1.16,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184388
+  timestamp: 1663827960541
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py310h89fc84f_0.tar.bz2
+  sha256: d8f3f911996fae2cbbac0bbf36c6fcb219b56d6ecbc8f42eebbcf12d520e852c
+  md5: 04006c1bd5e2631d658c932f86d1466c
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1226697
+  timestamp: 1694445334623
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py310hd77b12b_0.tar.bz2
+  sha256: 847a1d4e079ce688c7e984cbf0c5c8a271c8e818c394433375b5a4f2b27beed1
+  md5: 3e4eb1dbd11005205430e157cc260dd6
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3304234
+  timestamp: 1690907391803
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py310haa95532_0.tar.bz2
+  sha256: 542db7e187d0a9fe16b6eacb6bb93e5d574d1956687553a85a33fd580ab6ab7c
+  md5: efac5662f2dbe0fabf392e1dd89eb105
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17084
+  timestamp: 1649926751338
+- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py310haa95532_0.tar.bz2
+  sha256: e39245b05e8e366255b4be0cb933d782e1878be9245df60170800b15f508442e
+  md5: 9b633859a365fd5f57ff3a516c1cb630
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27635
+  timestamp: 1668714412704
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+  sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
+  md5: 9f167d3e45441bc3633c1974b1b0ce8c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 88421
+  timestamp: 1676983264486
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.17.1-py310haa95532_0.tar.bz2
+  sha256: 86172e61afc03050a78493b413832f2387e7cfd68d9d32453536e62f4626f6b8
+  md5: b7311d1b87f5f363f4a4c6886d66525f
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4593112
+  timestamp: 1693379101528
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py310haa95532_0.tar.bz2
+  sha256: cd9a29cd845807b2a9697878823e6100893eec51edba1f621ffa32264fb0cb4d
+  md5: 407278e6cde931bab12b6b228233c12b
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116780
+  timestamp: 1666125624542
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+  sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
+  md5: 9834848bd7c7759acf12e78d09388563
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3891030
+  timestamp: 1681801474383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py310h9909e9c_0.tar.bz2
+  sha256: 15c175ea1869f4426dd50cb553e2a1e98aa6c0b47af072f99c6b06beb073b85d
+  md5: 2c8adfc1ab10d1322349e1f76709fdfb
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 218950
+  timestamp: 1691122141007
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py310haa95532_0.tar.bz2
+  sha256: 23a5271531047c5e32399f465811f9e33db997568934f5c9a81e0d30b8c414ef
+  md5: e3cdadcd40721ba52683bf56d526ec9d
+  depends:
+  - backcall
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.10,<3.11.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1294993
+  timestamp: 1694182107536
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py310haa95532_1.tar.bz2
+  sha256: 0afd0d4f99429141bc4d58779e6ef67a5e38df2847c8a063fc2bcfab15456c9f
+  md5: b7c6ad4ecb2e14de462b2e252beb9702
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1054863
+  timestamp: 1644315579242
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py310haa95532_0.tar.bz2
+  sha256: bacd57df0050f020aa5d1903e9b1ae68b31fec8b1e1de1e7d4fc1138e7a6b246
+  md5: e5c0ae2823b3401b98a266952536ef55
+  depends:
+  - markupsafe >=2.0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217598
+  timestamp: 1666908197686
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
+  md5: 81f2c343dc4c65eea39c45383272068f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 407861
+  timestamp: 1677849239400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py310haa95532_0.tar.bz2
+  sha256: 32526ef7954f7718c03b9d1f7ea55a542bb61918093df1a8b778557513b3c395
+  md5: 8fef9e2c122553e30b3a52af7051c2ed
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 153127
+  timestamp: 1676558962296
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py310haa95532_0.tar.bz2
+  sha256: ac6b6415f82a703882ba07242d9b7a3aa7241d75795c29838e1f136f48f8f228
+  md5: 9614757161de6dbd60002f047add9c65
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 231452
+  timestamp: 1676331217788
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py310haa95532_0.tar.bz2
+  sha256: e3d2d18e8e7598227bef203111240994ff26c6456306bef872abde12342abbd8
+  md5: f72fd5f0195fa76e3764fdef27bc5113
+  depends:
+  - platformdirs >=2.5
+  - python >=3.10,<3.11.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 117219
+  timestamp: 1679906755172
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py310haa95532_0.tar.bz2
+  sha256: 4495e6a31ba2f15bc110c1d2d04cf054a9be7732adea1de3670f6d816de7ebfe
+  md5: b3dc66383a9768cd7589eec50ae475d7
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.10,<3.11.0a0
+  - pywinpty
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 416122
+  timestamp: 1671707734329
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py310hd77b12b_0.tar.bz2
+  sha256: 10f79ef1927aca5f33da1e87a065bef0edd0e7bf1c346172d0f54b9b6472cbd0
+  md5: ffd45a996d8abf95243ca820e62e696a
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62337
+  timestamp: 1672388276172
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
+  md5: c345f51706eef530454f66b794e5e574
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 68189
+  timestamp: 1659616216976
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
+  md5: a7400cfb72042977bc047909ed504ce8
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 33743
+  timestamp: 1659616248209
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
+  md5: 6307f6854754ab5bd7c84e6998385bb1
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 733177
+  timestamp: 1659616279453
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_0.tar.bz2
+  sha256: 1b3b9be41dba504e468a336196de9fd09568ba42585e493888aaa3708f687d0a
+  md5: 5cdcd99f18d9dedb772d272088e72b4c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 116942
+  timestamp: 1683716620230
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+  sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
+  md5: b812bc5d9c76242e2bb2ac87afe7d39b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 730280
+  timestamp: 1650983734373
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+  sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
+  md5: ba9418df9288a2f031a02fa35b774ce0
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78524
+  timestamp: 1694778314659
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+  sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
+  md5: 6ece7f1a3248169837714d05d7f6ef0a
+  depends:
+  - libiconv >=1.16,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 3513910
+  timestamp: 1692971505729
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+  sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
+  md5: bd7ec244935e83e850a4ff34e8e2e64f
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 513971
+  timestamp: 1692973657152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py310haa95532_0.tar.bz2
+  sha256: b957593b060cc76d1e8376af052749f66268e81df18e7e8020b5d8fe5fe84690
+  md5: 4cea845047b0d40302f260127d1d02d9
+  depends:
+  - python >=3.10,<3.11.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 35946
+  timestamp: 1659783477621
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py310h09808a7_0.tar.bz2
+  sha256: ac823b3cb63c74d34df292cca72bd71c8576e84165ab0cfebfb973042711b7a3
+  md5: 34bb76c12bbfcfa7e0412be5dce83860
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1222879
+  timestamp: 1695058396030
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+  sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
+  md5: 6970c7f46b0164cad1d210e7a1419959
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143434
+  timestamp: 1670944902624
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py310haa95532_0.tar.bz2
+  sha256: 88e0ad9a62f0e385ed4a36fc1bbb088a49065fafa4f08daac7c846fce26b6540
+  md5: af908af5ac51eafcb7e6332cd02c0d21
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 143240
+  timestamp: 1671542001479
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py310haa95532_1.tar.bz2
+  sha256: ab424b8036257c53eb5110f8d8817ed959718c275e2dff88407332ce783519ed
+  md5: 24f0c3faa37da73027d950da5b6cd3d3
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 126331
+  timestamp: 1684280061614
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py310h2bbff1b_0.tar.bz2
+  sha256: cca6779dde2ebc8bb63aee472c86fc8d5996710be2a73b840dc76ef8e07e68cb
+  md5: 78c57d6739e4fa5af54a97b14571f861
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28649
+  timestamp: 1654508138547
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py310h4ed8f06_0.tar.bz2
+  sha256: 4d00cf08045a80ab68bd61865c2f5ced6cfc360341a67e93f198a7a4e5577f16
+  md5: 5bf45bd512276669b9f86860b52afa8d
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.0.1
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8123888
+  timestamp: 1698692488191
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py310haa95532_0.tar.bz2
+  sha256: cb2d90330a1c1bb4ae18110e7bc14f50287c6d603cf9c270cf98b72962ce3ea9
+  md5: 7e5b432f39238f991ea8e6c21fc7cc68
+  depends:
+  - python >=3.10,<3.11.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18107
+  timestamp: 1661934176570
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py310haa95532_0.tar.bz2
+  sha256: 8cac05d7cf61a8d4011fce8e0f3b109f8d94f06ea0dc9e0a7f0e8b208a054193
+  md5: 2cd828af0c9e8a8ecce14355b5619667
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 53824
+  timestamp: 1659721375084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py310haa95532_0.tar.bz2
+  sha256: 31152e14e45c00f079582bf2f32742b0ee2e23bd28904715092661fb7fd1d5b8
+  md5: 5205f987d201c5de2925956b8f9d8caa
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 19459
+  timestamp: 1659716154851
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py310h2bbff1b_1000.tar.bz2
+  sha256: 7b9b506f48183d7c27e0fbd96f67e4aaf666a2f0af31ab4e8c2a33db072f1ee9
+  md5: 4cb169fc0c073895a990bc57fd9250af
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 55776
+  timestamp: 1642084197341
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+  sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
+  md5: 5e763c995ff0c549f68a10bce70fede4
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187489950
+  timestamp: 1691503804820
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py310h2bbff1b_1.tar.bz2
+  sha256: 5f8249f157c4899b9c8339286067f77514e678ffa21aa03ab17812e8e96fb9d5
+  md5: a6d45a65a7468b522cb88a8f54a97b40
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49079
+  timestamp: 1682974931077
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py310h2bbff1b_0.tar.bz2
+  sha256: a9a69c26aebf41ea1b73fb1b93dc938c5b3fcc01a5b329924e01ffa3d3dca567
+  md5: 6f4bc20ffabe932e1203d21c88d534a3
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 185058
+  timestamp: 1695058617399
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py310h59b6b97_0.tar.bz2
+  sha256: 78df91f430b13e4fb883f56c8079c0333160cd932a0f78115676eb55bebae2e3
+  md5: cdbed1b6da0f67e2bf567d558e8df8ab
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 255283
+  timestamp: 1695060019544
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py310haa95532_0.tar.bz2
+  sha256: 0ecd16a20a7a7d0ccea061c7e0c7cfecfe9db556f86fd319cbcfe445e7f976ba
+  md5: 58fb8247372e5f24411d2cd24bdd849d
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8136529
+  timestamp: 1681757529551
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py310haa95532_0.tar.bz2
+  sha256: 8d0818da57652774f6bfa9656e68ada801d274bc53e33fa965b33cf1ffbf9b1d
+  md5: 58807f326752a62ecba3ecbddfa2ee27
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 118835
+  timestamp: 1650308692306
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py310haa95532_0.tar.bz2
+  sha256: 0b833ca97add638a8cee5cd359f10c03388cd3f52a17d916ea8a484316e72ee3
+  md5: 89416eb2988dd462bc1022d5fdea6ed8
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.10,<3.11.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 598189
+  timestamp: 1668450985682
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py310haa95532_0.tar.bz2
+  sha256: fc524bd0412e44df58c74a2fe1bcffd5144c8e6b02dabc85e37c6b10e25dbd6d
+  md5: 4721b97a4af2754a2931451abac90f66
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.10,<3.11.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 167757
+  timestamp: 1694616965307
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py310haa95532_0.tar.bz2
+  sha256: 3a6a1bbb486a2bb074afe240dd4e36788a06d555d6e608ec2c5ddabce7129718
+  md5: f2402bfc230f8ce5967ecc9106d02080
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13892
+  timestamp: 1672387381251
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py310haa95532_1.tar.bz2
+  sha256: e12ff0ea72619dc0ca38a03b11c6ab9f81f9e3c89c5f13c97b5d6cb5526265f9
+  md5: bd0c794050c1f8636a8dbc0e427d578f
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 612787
+  timestamp: 1690985469949
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py310haa95532_0.tar.bz2
+  sha256: 9b3509d9f413cb1e11bde8e46b8c3ade4803e76ae69cad2f103886ddd483f7d8
+  md5: bb52427ea8777cb067600a5bbd10d75e
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22564
+  timestamp: 1668160647721
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py310h2cd9be0_0.tar.bz2
+  sha256: fe4e6cd63421465b633b1dfbfe563f65cb98663aa7635c3faf3a91dc0efae606
+  md5: 46e661250fef8884a0d0299b35993ba4
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 136272
+  timestamp: 1696515576284
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py310h055cbcc_0.tar.bz2
+  sha256: 1a9e2b92f92fb8b93b3b60be5548bbd3d158a31abbaf35e4543490165078810f
+  md5: c88f44adc8655bbcc10800b0df493165
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.0 py310h65a83cf_0
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9907
+  timestamp: 1695833681433
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py310h65a83cf_0.tar.bz2
+  sha256: c4ce94f43e3af82b3903b2effc243533b98a1e0ef42c069fa0b24724bb6455b4
+  md5: 25d52b1b2ce9e6b0908a9c7106d1e323
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.26.0 py310h055cbcc_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6785892
+  timestamp: 1695833656818
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
+  md5: ab07e2a27ac08afe3d0b4c0890b8486a
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 2-Clause
+  size: 249316
+  timestamp: 1630094024143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+  sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
+  md5: 73b17037d87b5a58feb34dafc0538f7f
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8058396
+  timestamp: 1695324589828
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py310haa95532_0.tar.bz2
+  sha256: e928dff568c116cf8eab555dc97a0316adf7ac91f237ba74d766603700180b3f
+  md5: 5a70390791e717492016c3c2ea854a0e
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73714
+  timestamp: 1693575355290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py310h4ed8f06_0.tar.bz2
+  sha256: 4d40962b81389e06c1aa893ed74b72a831326d18379a9d90bb0214b07c42c9fb
+  md5: 12e0e47046bfdd743cc3f296ea7307f5
+  depends:
+  - bottleneck >=1.3.4
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - openpyxl >=3.0.10
+  - jinja2 >=3.1.2
+  - qtpy >=2.2.0
+  - numba >=0.55.2
+  - pyreadstat >=1.1.5
+  - zstandard >=0.17.0
+  - xlrd >=2.0.1
+  - tabulate >=0.8.10
+  - fsspec >=2022.05.0
+  - pyqt >=5.15.6,<6
+  - xarray >=2022.03.0
+  - xlsxwriter >=3.0.3
+  - beautifulsoup4 >=4.11.1
+  - html5lib >=1.1
+  - fastparquet >=0.8.1
+  - pyarrow >=7.0.0
+  - pyxlsb >=1.0.9
+  - matplotlib-base >=3.6.1
+  - odfpy>=1.4.1
+  - pytables >=3.7.0
+  - sqlalchemy >=1.4.36
+  - psycopg2 >=2.9.3
+  - blosc >=1.21.0
+  - lxml >=4.8.0
+  - pymysql >=1.0.2
+  - gcsfs >=2022.05.0
+  - pandas-gbq >=0.17.5
+  - dataframe-api-compat >=0.1.7
+  - s3fs >=2022.05.0
+  - scipy >=1.8.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12627118
+  timestamp: 1697477662723
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py310haa95532_0.tar.bz2
+  sha256: 2f62ba591aea27c6f15773bdfdc09558fcadd11559e48aadc3ea69960bf1e113
+  md5: ae943e3adf679487f8c691397d9fe533
+  depends:
+  - bleach
+  - bokeh >=3.1.1,<3.3
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.16.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17018899
+  timestamp: 1695146622867
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py310haa95532_0.tar.bz2
+  sha256: 7d8d0ef93307680696d575a445b442de32320fa3eb4b2fc090164ff0ac7e17a8
+  md5: 3eeea45a3f84b3b563e5990a36429dcb
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 143435
+  timestamp: 1684915381677
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py310h045eedc_0.tar.bz2
+  sha256: e14f0ffad04b6052df8d5c062d2c5f4aebc9c427575d9a3b94a1b8f4935851bd
+  md5: dcdcca0969f743b7c0afcb7bd32ce1af
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 813714
+  timestamp: 1696580634199
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py310haa95532_0.tar.bz2
+  sha256: 5cce15ad567bf7eb300af6c1ec94cb39db5b73143836089e755b0c8092f2a3fd
+  md5: dcf2b3a10dc331ceef151b651e07626e
+  depends:
+  - python >=3.10,<3.11.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3090037
+  timestamp: 1697549089299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py310haa95532_0.tar.bz2
+  sha256: e471553584e2ed5971404849a37358d13f08fabe18b0ef3ef33a3a0bc1a22fa3
+  md5: c5ebdddd493f77c393cc043a457a231b
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 32580
+  timestamp: 1692205629751
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py310haa95532_0.tar.bz2
+  sha256: c71476dc289e2c3e6711914cd2a8065b9b23b050d358f2edf1d6e7ce92c432ab
+  md5: e0882c5fb058a7242e98c9c390dccde2
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91989
+  timestamp: 1659455185228
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py310haa95532_0.tar.bz2
+  sha256: 4b35a6959ddc76b30270c6140878f38a8d144f916f2270455d876cc3fed5541a
+  md5: f2d689ceb3c687d5242da49928cc59c0
+  depends:
+  - python >=3.10,<3.11.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 600281
+  timestamp: 1672387969503
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py310h2bbff1b_0.tar.bz2
+  sha256: 8ba826d7c49fd587064175395cb0b4c956fff616b1866b4b8eaefa6baabc3415
+  md5: 8cfb596037d09d397df9bfddc7ea62a5
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 375863
+  timestamp: 1656431373274
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py310haa95532_0.tar.bz2
+  sha256: 9294dbfe51fbdba2a81b4fbf42f45cfd1e9a5ca8103e9835feecc026e72ab397
+  md5: 676088abc6448a356286bfb0cccf9d07
+  depends:
+  - param >=1.7.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48605
+  timestamp: 1675450476501
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py310haa95532_1.tar.bz2
+  sha256: 0425af15c734660310fd267c19aca5c8bac712f737e4b97d8fcefe38c0a9886d
+  md5: 3aa71810eb4ca6e3edd0398763f6f269
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1903399
+  timestamp: 1684280387582
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py310haa95532_0.tar.bz2
+  sha256: 48d4e140b012d95051d40ea19668b4660a5b35423233a4a86e09086e2803cdd8
+  md5: 3909ea700a127b6a649ea8b5859ebf2e
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95255
+  timestamp: 1690225526774
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py310haa95532_0.tar.bz2
+  sha256: 29adffad9359f41e32bddcd4e0202f88e1f82254f739a767d702fb7665163fda
+  md5: 70d08505015f3ab10c9d31c86441a1e1
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 158947
+  timestamp: 1661452750809
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py310h2bbff1b_0.tar.bz2
+  sha256: a7154f626c11f905afb0647379f1f56b6a84304a43b0ec6e18123b8de297978c
+  md5: 6e793acbb30fa04299c06bbcb0d86809
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 88390
+  timestamp: 1642117156794
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py310haa95532_0.tar.bz2
+  sha256: 079bb5bd27170316f111209f6e034308fa6443102e62a2e29c58f73089356e37
+  md5: 8eb51a59b8c2d264f072b9686f08554b
+  depends:
+  - python >=3.10,<3.11.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 28442
+  timestamp: 1642089401419
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.10.13-he1021f5_0.tar.bz2
+  sha256: 5027caf55d479d2bc69ce2cb05add913d693ca6eef29b98ed32a337b6f61c484
+  md5: 06cf057afa5dfcd5c065f254327dadf8
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - openssl >=3.0.10,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - openssl <3.5.7
+  license: PSF-2.0
+  license_family: PSF
+  size: 16987973
+  timestamp: 1694438940131
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py310haa95532_0.tar.bz2
+  sha256: 352dbdde953be659f973fed0bf2753dbfc4a4412afaf8346b7cec231a2821bf7
+  md5: 4b33d277fdc29fa891f48ed17aca03c1
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270287
+  timestamp: 1661376660131
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py310haa95532_0.tar.bz2
+  sha256: 17d84f4d97cd7963a1f822c216b6bfe6e10d879a4e7ca38cbd6299215a661c06
+  md5: dc045c7ebc22dbe30073071c3c3f926c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 264945
+  timestamp: 1695131888424
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py310haa95532_0.tar.bz2
+  sha256: f0002cb60435d0c3acce4aca0b8793f2a5540502689185008091c7750d91f263
+  md5: 155c58c52114dfdc2b9c212552ed4e29
+  depends:
+  - param
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40254
+  timestamp: 1685031283281
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py310h2bbff1b_0.tar.bz2
+  sha256: 9715738e6124de2510a3bf6ca945ba361fa27e3af60bcdf3a1bc25f9c0068b3b
+  md5: b45930642e0ddbd43333c8a3ba4bc491
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13492611
+  timestamp: 1669937046724
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py310h5da7b33_0.tar.bz2
+  sha256: 5fca272384bcdd93c4caa9a753fc514b7e29d734498147c8fd26a52e3cadc2b8
+  md5: 1992345047b4f1ed52e7f85b5a0e143e
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 234279
+  timestamp: 1677610684013
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py310h2bbff1b_0.tar.bz2
+  sha256: eb7e5c8ded28393c9c8db670f60c9e1a14d12bb017f8cc412c804af8afd1889b
+  md5: 761bb45b296122ff2c2416e353007b50
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 153027
+  timestamp: 1698096448626
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py310hd77b12b_0.tar.bz2
+  sha256: 63366e304172ca8a18b170ef322cc51055b27b16390ab1bf05ba3ef20348ab0a
+  md5: 3fd4cac25b4aa04c5ffec581fe8b8c19
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.4,<4.3.5.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 452315
+  timestamp: 1657616132820
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py310haa95532_0.tar.bz2
+  sha256: 02701b8ad70d95006ccbee4601e527f84c5029b35738923ca93b0b040dc752a7
+  md5: 0d1ce48ae3413d8328bb32ac3586b9a2
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.10,<3.11.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95410
+  timestamp: 1690400388066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py310haa95532_0.tar.bz2
+  sha256: 5dde38dba1af77afc49f44607ca9376503343abda2a413264b9ba49fc1532d9d
+  md5: ff11aa4f430cf334bad62438098317f6
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1107347
+  timestamp: 1690291154228
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py310haa95532_1.tar.bz2
+  sha256: 569af333ddf0153396422defcef42cb4b2d78a027312b59400d5285f410b918d
+  md5: 0c1af441d87ed1e7eb60a5dea7fed5df
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15818
+  timestamp: 1642092199263
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py310haa95532_0.tar.bz2
+  sha256: a23892e537aa5387f4a7e817dfdcc4b9c5fec6b40a1695f99ecb7e3896f8f1b3
+  md5: 022293f076961b460cfe654421c3a69a
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 67725
+  timestamp: 1696347732280
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+  sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
+  md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1311308
+  timestamp: 1681402905668
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py310haa95532_0.tar.bz2
+  sha256: d0d86ed6cd7ce216d8e9c014ccec1aca485f273a0390acd7fce88b999c5c07fc
+  md5: 0c1eef070bdc583a5f13ae6d90df9ce5
+  depends:
+  - python >=3.10,<3.11.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30837
+  timestamp: 1671752231574
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py310haa95532_0.tar.bz2
+  sha256: bc1ddb7012553cfd0e0dfd59ac053f2c248ed6aa2f3f073535c2e3727b156081
+  md5: bea69cca66bf89b57764689750ad19b0
+  depends:
+  - python >=3.10,<3.11.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39827
+  timestamp: 1668168932332
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+  sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
+  md5: 52cdcdb96383c010ca833a7c24b3935b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Tcl/Tk
+  license_family: BSD
+  size: 3690152
+  timestamp: 1654036853710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py310h2bbff1b_0.tar.bz2
+  sha256: e50a692e7a49da9e7f543b8f93d2ef6be0f0b814b0201ba3e03c11cdf6419a5a
+  md5: 2557ded281fd319351c3d3c67d7332f5
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 690076
+  timestamp: 1696937432926
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py310h9909e9c_0.tar.bz2
+  sha256: 0a8e653e44eb35226386ce3796e602c8b62563c132e54b4949764f7385ee0b9f
+  md5: c9a498cdb375d5e877d3fa823236f523
+  depends:
+  - colorama
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 144538
+  timestamp: 1679561959497
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py310haa95532_0.tar.bz2
+  sha256: 0ad5597762eaf2daae779e216aa12211a980a90272a38e0aab8c2def1b92163c
+  md5: f97fb0e2c94c9c157c0761eb53ea36a1
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 194983
+  timestamp: 1671144108028
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py310haa95532_0.tar.bz2
+  sha256: 269fbb45f0a8a30aedda91e88758e8d88d552da0349e1f03ae2990f558615e96
+  md5: 6798f519b46627f96159c290e41a1f9c
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing_extensions 4.7.1 py310haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9275
+  timestamp: 1690297966050
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py310haa95532_0.tar.bz2
+  sha256: 61a4fa82d984385a15caedc47ea3cf6db4e92f5692eba76436e82ce003e8dae4
+  md5: 5c78ae38dcb3715988dd4225e7c39c43
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58380
+  timestamp: 1690297951482
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py310haa95532_0.tar.bz2
+  sha256: fb7d79c284177ec64a95e1786fae83070612ab4318a0cde9c4ed54fb4b95a031
+  md5: c0297d13bebf64bb81c7d9ca9ebab5d1
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 11410
+  timestamp: 1659769516199
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py310haa95532_0.tar.bz2
+  sha256: f0682ed627aab2cfa804ea488eef5d1d9ccf186c5899b2c0a757c064272a734e
+  md5: b972f371bef45c86f60b75d705b739de
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 190534
+  timestamp: 1698257669737
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+  sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
+  md5: 45ef24c486a484f079faf1dc90e4c7e9
+  depends:
+  - vs2015_runtime >=14.27.29016
+  license: Modified BSD License (3-clause)
+  license_family: BSD
+  size: 8277
+  timestamp: 1605602889180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+  sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
+  md5: 4daaceb6cfc1af6274509081d8018ef1
+  size: 2316783
+  timestamp: 1605602872095
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py310haa95532_1.tar.bz2
+  sha256: 5feccb42695e0a5f0d8e47806ec4a38d80812946bedff171a1b6bde5513843e7
+  md5: 8719f9841803cf96f733f59aafbd147e
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21579
+  timestamp: 1642093965560
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py310haa95532_4.tar.bz2
+  sha256: 817b30ed834a145aaff119991fd5a7a3314e84002d89bb41eb8c24cb3b5be00b
+  md5: 8d197a8c69574b3efd963be618ac1138
+  depends:
+  - python >=3.10,<3.11.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73599
+  timestamp: 1642093997435
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py310haa95532_0.tar.bz2
+  sha256: cefd8ed6d60b0eee5f46993e5629240d255e18808415b1283d1ec7881bcc0b0a
+  md5: 25769ac748c7674ec15eea828dee97dd
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 122045
+  timestamp: 1695742066400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py310haa95532_0.tar.bz2
+  sha256: 7c5b72bec25fabcb0a6644acee0a3f45c17d535780581a17ec6616ecd21b284d
+  md5: 43afdf809d6ddf58af49fb1fc5230808
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: PUBLIC-DOMAIN
+  size: 8531
+  timestamp: 1642658494153
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py310haa95532_1.tar.bz2
+  sha256: 67ae0c5a80eaa449ba31d96276218bb503b2a4b1cafe064376f26d5a227e98c7
+  md5: 1cb14e0e9baf9ecb93a9268246620454
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48944
+  timestamp: 1675159282275
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+  sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
+  md5: c3f7871e9a33adeccee1b1e8e216918e
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 1332571
+  timestamp: 1683113347814
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+  sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
+  md5: 1ab55f8c4b5292ec360c572120bf823e
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-3.0-or-later
+  size: 9430705
+  timestamp: 1616055773485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+  sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
+  md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 148931
+  timestamp: 1666595229032
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+  sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
+  md5: 8d6a1e767775fe0eb617cd6e22edc2ff
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1871867
+  timestamp: 1681304638261

--- a/euler/pixi.toml
+++ b/euler/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "euler"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/euler/pixi.toml
+++ b/euler/pixi.toml
@@ -19,12 +19,12 @@ numpy = "*"
 pandas = "*"
 panel = "*"
 param = "*"
-pip = "*"
-setuptools = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+setuptools = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks]
 dashboard = "panel serve --rest-session-info --session-history -1 euler.ipynb --show"

--- a/euler/pixi.toml
+++ b/euler/pixi.toml
@@ -1,0 +1,31 @@
+[workspace]
+name = "euler"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2018-11-16"
+maintainers = ["jbednar"]
+categories = ["Mathematics"]
+labels = ["panel", "holoviews", "param", "bokeh"]
+description = "Panel dashboard illustrating Euler's Method"
+no_data_ingestion = true
+
+[dependencies]
+python = "3.10.*"
+notebook = "<7"
+holoviews = "*"
+numpy = "*"
+pandas = "*"
+panel = "*"
+param = "*"
+pip = "*"
+setuptools = "*"
+wheel = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks]
+dashboard = "panel serve --rest-session-info --session-history -1 euler.ipynb --show"
+notebook = "jupyter notebook euler.ipynb"

--- a/exoplanets/pixi.lock
+++ b/exoplanets/pixi.lock
@@ -1,0 +1,7756 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.9.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.1.0-h3826bc1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.21.5-py39he7a7128_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.21.5-py39hf524024_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.6.2-py39had2a1c9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.9.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.0.3-py39h3ea8b11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.9.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.0.3-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.17.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.9.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.0.3-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+  sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
+  md5: 613805add1c05b538ff06d217252feb7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 20810
+  timestamp: 1652859733309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+  sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
+  md5: 2cf39d906cc321896ffe3e5d33d80c5c
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162166
+  timestamp: 1644463608931
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+  sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
+  md5: 2972a84e0e22ae3244bbd2f1eebcf536
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 35352
+  timestamp: 1644569715988
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+  sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
+  md5: a68016b4b06460def24cb69d932986f3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132486
+  timestamp: 1695717963702
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+  sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
+  md5: 2f6356a2f530314b4059c08c79a3d8bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 205868
+  timestamp: 1681493113570
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+  sha256: 2d8e75f31f75ea5eb8b9021b4c21eb2846a254a097e06eb68e66fc36a82e1bed
+  md5: ae374a11c789a55555f70b29b9eff1f9
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3,<2.0a0
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14430294
+  timestamp: 1658136783940
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+  sha256: f84f9caa7eb9d489fd9634419fdf766d39293a5df1104b840fa0cdc5823a5c60
+  md5: 922555c0435d6b2537cf8ced534b048c
+  depends:
+  - libgcc-ng >=7.5.0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 141903
+  timestamp: 1648028958291
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+  sha256: 0bbcb6f78eac530c6a084459ffab3238647b266d0c74d695e6e6387dd119cc67
+  md5: bdc971e2a9affb5125b68ad708172dab
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 411301
+  timestamp: 1602517685375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+  sha256: 8c2071f706c2b445dabb781f7f8f008b23a29957468ec6894f050bfb3a2d5bf4
+  md5: c203ffc7bbba991c7089d4b383cfd92c
+  depends:
+  - cffi >=1.0.0
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 357797
+  timestamp: 1605539534667
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+  sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
+  md5: 3ef00f4c5278b688552efc259c463dc8
+  license: MPL-2.0
+  license_family: Other
+  size: 132731
+  timestamp: 1694009767372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+  sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
+  md5: d5cb3d97cf5e85ffe5e94037ed8a1169
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159077
+  timestamp: 1690232254640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+  sha256: 674707b9c42e65c903c9786ee5a56b4d42aa054f1e75b328db8a2c1bfa368739
+  md5: 76ae217198b014b89b267cf41b8251dd
+  depends:
+  - libffi >=3.3
+  - libgcc-ng >=7.5.0
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 231920
+  timestamp: 1642701209740
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
+  sha256: 762f4506c3e12b2332bd9abea3a2a1966f307b2673be7fd661dc6e316602d18b
+  md5: 4b8df5459d1762495428323753438641
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 151844
+  timestamp: 1698129872673
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
+  sha256: 4fd0207b930fbc936d4b8206117cfa9792aa19bfb320eb08aab6bba10002f9ee
+  md5: 7082a1ce8fa314cc2761d2f689c6bb9e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40456
+  timestamp: 1683040035572
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+  sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
+  md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1917831
+  timestamp: 1668084545510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+  sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
+  md5: 13702d3b4b744784e5bd559c7050dd6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12719
+  timestamp: 1671231205875
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+  sha256: 821af57c20a85b4e92268fbf65fbaec2f273da5bb21889d9643756ef6e473237
+  md5: f57e0f502500ffebdbec081ef61ad1d4
+  depends:
+  - cffi >=1.12
+  - libgcc-ng
+  - openssl >=1.1.1v,<1.1.2a
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 2179774
+  timestamp: 1694445209134
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
+  sha256: 2084ad037e4b67a158facc0d1b21d1de16df7fe758e2bf08f6e48c6b75626cb8
+  md5: 8bb8a915dda236f7a2cf790490983445
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2121644
+  timestamp: 1686782977519
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
+  sha256: 161644f5f183f5632806cb2cb31890d06a1a575bed7949fe11bc59d3d4344e9d
+  md5: 96baa11147a42b64dcaa233a1733b8ee
+  depends:
+  - colorcet
+  - dask-core
+  - datashape
+  - numba
+  - numpy <2.0a0
+  - pandas
+  - param <2.0.0a0
+  - pillow
+  - pyct
+  - python >=3.9,<3.10.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17667549
+  timestamp: 1692372404139
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
+  sha256: 80188a9729a26e36b027e673f5f30395798eb68f9fe4721f3f33b4d4d2e58285
+  md5: 686db307602cbbdc30ca7d62b765578b
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 103488
+  timestamp: 1613390248313
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+  sha256: 3a39a2d6f161080c706292e3bf480f62d2444b1d6d67b3d7db50458202ee31f1
+  md5: 0524ffca60f845eb392bbb56d56f0ce5
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2094615
+  timestamp: 1637091869922
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+  sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
+  md5: 2e6ec51066d825ef3c317abe78d6049e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16413
+  timestamp: 1649926472708
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+  sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
+  md5: b4d923222d45314856b5378cb115214d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26728
+  timestamp: 1668714462023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+  sha256: 8a121233d0b2cbb2463b67e798739ad2946f38933430a6a7fd1197cc6eab1c99
+  md5: d2b24736491290a6c6d0138932111150
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: GPL-2.0-only and LicenseRef-FreeType
+  size: 965280
+  timestamp: 1635422707211
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
+  sha256: cfef2f1f3f1aa159f87806b7fa2b65c02c0d6f9bd24ccda833b43246c5095be6
+  md5: 394ec1374a92c6fd5f772343934337e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 260575
+  timestamp: 1695734561396
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+  sha256: 3c8ece1a7257b1d45f8fa25f46504bb709a1923d7175f2996e891366ec434b9d
+  md5: 299bf4271d710651a1d71d3795580c2d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 83592
+  timestamp: 1603192039050
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+  sha256: 2d727f8335c59314b521b66d437ca4d51904134473ae503b7b097e239635f209
+  md5: 6991e520f353d995023404f6f524d192
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4507274
+  timestamp: 1693378095165
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.9.0-py39h06a4308_0.tar.bz2
+  sha256: ebe76b5a96add44b3befafb39e1b1946306cc0f1f98e8cf1fdfeb134a6fbd2fd
+  md5: 74ad1a52b081ba48af21ea48697c06aa
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.9.0,<3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3310817
+  timestamp: 1697560077151
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+  sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
+  md5: 9213e0336e3a5216c989cfe52648412e
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 23805906
+  timestamp: 1588026213084
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+  sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
+  md5: 1eb52f9f45cea2fb9ce27b19f990160e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110793
+  timestamp: 1666125606878
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+  sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
+  md5: 126b3c1933b7364ff03f67455b687e99
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 37588
+  timestamp: 1678997134023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+  sha256: 1b424413f28b840fc6d4bf467f37e9e405823b1e3b899005df80152d48936d64
+  md5: 4aa8bcf74c81cd3600978f791191692a
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 9246735
+  timestamp: 1634546760713
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+  sha256: b51b2e0dd37a74784ba19db22aded3f4c843b6fddb4a74399f65f36fc018aaa2
+  md5: 0d56ab1950f952284b895ac0f78284a7
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.0
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203541
+  timestamp: 1671488675347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+  sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
+  md5: ff47e0be879e817713ce2a9daa76e2b0
+  depends:
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1261116
+  timestamp: 1694181530670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+  sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
+  md5: 5ef6c6a0d1ac79143c7359d305155167
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1021637
+  timestamp: 1644297140650
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+  sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
+  md5: eaeb023688f781e7dd89e74310c38195
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 211775
+  timestamp: 1666908212136
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+  sha256: 85348bfb14db4fea84078d703e766a3c978c5a592a06e41266748826dd59d8ae
+  md5: 6e1c0fb5260c590f7ef5235cb3d05863
+  depends:
+  - libgcc-ng >=7.5.0
+  license: IJG
+  license_family: Other
+  size: 279884
+  timestamp: 1651065953960
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+  sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
+  md5: 0d2c3c5edf671b575532d5a3e8bf15fc
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 131510
+  timestamp: 1676558716852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+  sha256: 92bc012f9eb4ad71158cf4826fd3e125fcebff53b529276a81224acda48be547
+  md5: c5fd100e3062e831cbdf33331042f627
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=22.3
+  - tornado >=6.0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 190884
+  timestamp: 1650622553813
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+  sha256: 0192bd48cd96c60dc3054d5addd8cdb4a29a218843181318371f79daec8242f8
+  md5: d851b401dc13d04e6848bb36e12efc1c
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 91534
+  timestamp: 1679906652183
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+  sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
+  md5: a4beb461f0a60998a090d760b5c6c907
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411564
+  timestamp: 1671707702849
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+  sha256: 974df3dc76089be57b327acd6634384def84249003f58678ca1142bb274a75d9
+  md5: 81b969d1a00153759b30554a1f11ddfd
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92144
+  timestamp: 1653292217019
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+  sha256: 3b4afe7665dcdb99bd4586a888b85b2e0325f8faecdd31c7780792080ee97872
+  md5: 822b5201dde61bc838072dc5b670c88c
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: Custom
+  size: 55183
+  timestamp: 1594054267890
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+  sha256: c6fafbe73d2f93b91b6f4b65829f925f52a8f84746a57abd216b39da9ce8c494
+  md5: 238f19c803a6ba7bd6dbd6989e03cbf1
+  depends:
+  - _libgcc_mutex * main
+  license: GPL
+  size: 8496776
+  timestamp: 1560112207081
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
+  sha256: 83c6fdb30a240fbaa09f5d2e2ae8f092759cb710bc3fa628ccb18934fc237b7f
+  md5: 6003e09e8cef9aca91b954abfdd0f39c
+  license: GPL
+  size: 1336385
+  timestamp: 1534628456385
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+  sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
+  md5: 3080c2813e6e1d0f8a100a38b5b3456d
+  depends:
+  - _libgcc_mutex 0.1 main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 573231
+  timestamp: 1654090775721
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.1.0-h3826bc1_1.tar.bz2
+  sha256: effad2034f13cf7f1cdc51127e3a88123ae957c13f8c95f1817dfd79b5eba779
+  md5: c261302f1b58f6b2851f856d230dc947
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - zlib
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 29798461
+  timestamp: 1647523885063
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+  sha256: bc3e6e79c32ff0ecea601aa108ae9cf4068f69703580e40e266ad4bcc52cff54
+  md5: 9cb85601944ca7383b1769bff74b94e8
+  depends:
+  - libgcc-ng >=7.3.0
+  - zlib >=1.2.11,<2.0.0a0
+  license: zlib/libpng
+  size: 372914
+  timestamp: 1556041895170
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+  sha256: 43b0bd205f539583c088feb5b8d77b60c83d1df80c2a93dac9f2a1127001b2cf
+  md5: 53fa39fdae936e9d07c4b2f5ef361993
+  license: GPL3 with runtime exception
+  size: 4246257
+  timestamp: 1560112223556
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+  sha256: 711ea05b4c35bdafc762a172b01db896b17942f474c2b1a519f91370964bf9bc
+  md5: b25d56d33596623a6a4a9d9baaa4f602
+  depends:
+  - jpeg >=9e,<10a
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libwebp-base
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  size: 592974
+  timestamp: 1653047881023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+  sha256: 146dbb1e4dbccdd57819e5102a8ca00970b8e33d6c6180e8007db89b184da569
+  md5: c566a384259c1d2769852c3bddd81a67
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9d,<10a
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 90150
+  timestamp: 1645441199289
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+  sha256: cffb5a063111f7a99a99c74770b23db5dde52325e25a7a46d1903d5ff4a82c88
+  md5: eeb1bd66f28bed1956ab989d6eff7ae5
+  depends:
+  - libgcc-ng >=7.5.0
+  constrains:
+  - libwebp 1.2.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 889956
+  timestamp: 1645089138421
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+  sha256: 71f6c4a97014d745c58df52b4dd60ddd75a8508d54fe5b97f42bd1f31cb1c067
+  md5: 686e77514ec9f1ef0a6feed374f14d37
+  depends:
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.5.0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 789469
+  timestamp: 1653546418059
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+  sha256: ea3355a67c5173f3944f09861043ca66eb7dbeff8f385d13528b3aabc0801d0c
+  md5: 66e2aa12181bb2911485bdbe125d24c5
+  depends:
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.5.0
+  - libxml2 >=2.9.14,<2.10.0a0
+  license: MIT
+  size: 584199
+  timestamp: 1654075843119
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
+  sha256: 497e0a8e555539787dd237dea5d13a0a6061db2cb50ded20daddaf08bbf267cc
+  md5: ecc0c3c465bbf6988ebbc6a38e2eeb1c
+  depends:
+  - libgcc-ng >=7.5.0
+  - libllvm11 >=11.1.0,<11.2.0a0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  - zlib
+  license: BSD-2-Clause
+  size: 2826845
+  timestamp: 1647870510956
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
+  sha256: d8cd22ac7f033507549f6a0d078cd273607cb6e8246b0383375a33941969c12c
+  md5: 78c7a3a437536ae24d2d7ce15ec400d2
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11065
+  timestamp: 1652903210940
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+  sha256: 64b022d706b76c33965a250fdc8c6008443c41bff8ab27bb1df3cb70419576fd
+  md5: ec4f05846aacf634df15c389235725cc
+  depends:
+  - libgcc-ng >=7.5.0
+  - libxml2 >=2.9.12,<2.10.0a0
+  - libxslt >=1.1.28
+  - libxslt >=1.1.34,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  size: 1538261
+  timestamp: 1646624639995
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+  sha256: 2c6a5dda7c510a961bc78e31d4232be5e8e0760c93454f5fd200c379355e0f5e
+  md5: f35d4bf2fbb39e334992f6dd39f8721e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 220865
+  timestamp: 1627657046002
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+  sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
+  md5: 421f82c8274b44660dba629134faa6af
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 122221
+  timestamp: 1671541990505
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+  sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
+  md5: feb0e452205b44ac45d9b5e55c21a3b1
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22819
+  timestamp: 1654597913064
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+  sha256: dc51b316ef5dcfb82a9c0afdc40879146ae59516f6cea7db776077783dfd2d76
+  md5: b0b6b57c140f026b8806051107336576
+  depends:
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.11.0,<3.0a0
+  - freetype >=2.3
+  - kiwisolver >=1.0.1
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - numpy >=1.19.2,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.2.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  - tk
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7729454
+  timestamp: 1647442028622
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+  sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
+  md5: c04ef34af33da4c71bcc99b7ec24d210
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16391
+  timestamp: 1662014553452
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+  sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
+  md5: f6c734d73e6e3dbc1b62766cf18ff3e4
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58153
+  timestamp: 1607364912263
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+  sha256: 7c4ded8b2ef036839f988560848d2c32e1aa4627fd37a32710e42c39f5c61ac2
+  md5: bd20f4410b81f327e35ffa0657961146
+  depends:
+  - intel-openmp 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 229783051
+  timestamp: 1634547157986
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+  sha256: 5394f5efd53afb2c1b0abf571ce3d9cb684b6c7e255f140ba2acaa703d6113be
+  md5: d3cb2bfa63e30153f5527797dcc87280
+  depends:
+  - libgcc-ng >=7.5.0
+  - mkl >=2021.2.0,<2022.0a0
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 63551
+  timestamp: 1626176932911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+  sha256: c244d23da2749857a993f84969fd35ffd183ab8f462986df6d33ae0f705fe034
+  md5: 9b1f8ccc2488d0e04eb73211e2987483
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.3.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  size: 204136
+  timestamp: 1634566416657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+  sha256: f81f426f8ef306d636664bc49e7cdd70e2b4306d7c6bcb9c75fe35a45ab2087a
+  md5: 77aa1d7f958d36bf227e6ff4a34d2e3d
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.2.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  size: 365386
+  timestamp: 1626186165897
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
+  sha256: 305313d215116fbf13a38f8a321eb635b83294871801ac63e543a59ba7de642c
+  md5: e0db8ae050bd0db74f47edc370dbc287
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 24480
+  timestamp: 1607574279743
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+  sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
+  md5: 95c83d71814c504b5504df4f14548f1a
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8257558
+  timestamp: 1681756322140
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+  sha256: 1b92d72b083f3350359b8fb2e3b5dc846f49650c9e46a6a74354b1b7f0d42730
+  md5: 996babe4314515ddd41008a53cb5d47f
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 98791
+  timestamp: 1650290544347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+  sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
+  md5: 1710a25086c8098367eb36b9d441448b
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 569683
+  timestamp: 1668450704669
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+  sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
+  md5: 385cc9e53404776782502c0fdb08820f
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147046
+  timestamp: 1694616899309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+  sha256: 0807371380965e421cb5f3f2a30d790fd5c41db11dbb6d318e14294c3b1741ed
+  md5: fca4bd4e3891aebf4fd7daf9b6d0ccfa
+  depends:
+  - libgcc-ng >=7.5.0
+  license: Free software (MIT-like)
+  size: 1083412
+  timestamp: 1636570020698
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+  sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
+  md5: bbbcbebc20a4fdcadce398d0ca04f95e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13109
+  timestamp: 1672387143252
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+  sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
+  md5: 248ce515640465371927d46f389ed555
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 594054
+  timestamp: 1690985006481
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+  sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
+  md5: 70db71df4ee1cdd38090c0f7b80ba61f
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21944
+  timestamp: 1668160644514
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
+  sha256: 30f95c6c51ee7ca01801778b1773d8ecb57fcf06e864093f27148e1298517c20
+  md5: 1c1f0821f0dd2ece64844f39edcbd03f
+  depends:
+  - _openmp_mutex >=4.5
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - llvmlite >=0.38.0,<0.39.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - tbb >=2021.5.0
+  - libgomp
+  constrains:
+  - cudatoolkit >=9.2
+  - scipy >=1.0
+  - libopenblas !=0.3.6
+  - tbb  >=2021.0
+  - numpy >=1.18,<1.22
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3982289
+  timestamp: 1648045822890
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+  sha256: 15a12c8bebcda45c577e61cea412d9aafaa433e39f9e91fd61bbfab66fcee3ab
+  md5: 5239d8330e8bd34972fb80918dce79e7
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16.6,<2.0a0
+  - packaging
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 136437
+  timestamp: 1640689905588
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.21.5-py39he7a7128_2.tar.bz2
+  sha256: 9195828a286d79621f63766a1ac1143de7b862ae17ce5e95ca0c3a5c171868a1
+  md5: 2bd04a53d17b21af64f413dc810b3d94
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.21.5 py39hf524024_2
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  size: 9728
+  timestamp: 1651566346644
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.21.5-py39hf524024_2.tar.bz2
+  sha256: dbd1301d64a55552a01d74a1928d279646a97158cad3cce7e05548b6fa112338
+  md5: e5666032c7865b4977e740e6f069e540
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.21.5 py39he7a7128_2
+  license: BSD-3-Clause
+  size: 6385715
+  timestamp: 1651566332949
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+  sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
+  md5: 5ad4571eba2479f77a9f849a6ae7724c
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: OpenSSL
+  license_family: Apache
+  size: 3998613
+  timestamp: 1694465071784
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+  sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
+  md5: 77a22ed6d0d448c5288d0f695bc9ac49
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 72527
+  timestamp: 1693575234886
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+  sha256: e7a0abb0f00a94000876f2095f0cf531ad3803ffbd868a780b3f06816b54492c
+  md5: 97ef7e1fe923d22a8e2307f3f39a92d5
+  depends:
+  - bottleneck >=1.3.1
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - numexpr >=2.7.1
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13221005
+  timestamp: 1650622404234
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+  sha256: 49fdb57b2ed2ce4d6bb7a2c5adec36ba59522518a41fb941f9e39a9f43750cc5
+  md5: 871b65444733b7da5823ee0dc9826722
+  depends:
+  - bleach
+  - bokeh >=2.4.0,<2.5.0
+  - markdown
+  - param >=1.12.0,<2.0.0a0
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - setuptools >=42
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >1.14.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14712394
+  timestamp: 1676379803902
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+  sha256: 64a732ce2661cdb6bd8f9d1484ac10afeb73082b1c2b44728d212e0117d2860e
+  md5: ada303f0cf43a4e99cfa7f243b23b681
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141832
+  timestamp: 1684915385689
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.0-py39h06a4308_0.tar.bz2
+  sha256: f3e413ea4f7c8d69507bad538470e7edf7b53d1db742d3fd0599d331318560e0
+  md5: 325ccf5b485576d640add845a001501e
+  depends:
+  - locket
+  - python >=3.9,<3.10.0a0
+  - toolz
+  constrains:
+  - pandas >=0.19.0
+  - numpy >= 1.9.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35076
+  timestamp: 1693937956700
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+  sha256: 8bcb1c67693f42a3170eb77ef4cdbb81b605fdf40816953e69a33a065c101638
+  md5: b7689507fb5f879dc766aaa8a4c37351
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp >=0.3.0
+  - libwebp >=1.2.0,<1.3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk
+  - zlib >=1.2.11,<2.0.0a0
+  license: LicenseRef-PIL
+  license_family: Other
+  size: 734566
+  timestamp: 1646325095608
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+  sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
+  md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2674850
+  timestamp: 1697548887851
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+  sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
+  md5: fe56f0479dd414c846191116366262c3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 31999
+  timestamp: 1692205535111
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+  sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
+  md5: 44d2a857d13bdf9d99aaac039a249d47
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91137
+  timestamp: 1659455142164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+  sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
+  md5: eb899a739d9b58dd747f1f6bd52d4cf3
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 579771
+  timestamp: 1672387338600
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+  sha256: 6973cfe0565ba3b5ad6d1de9e34848fbbadd78b507b2e23e1c079636b8f8f317
+  md5: a924535045fb356e23e7a3cc8116b638
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 350026
+  timestamp: 1612298042840
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+  sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
+  md5: f36ecb722522cbe2e3737424edf1b5e1
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29312
+  timestamp: 1675441510984
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+  sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
+  md5: 6d03295e544251e608a28c8d7c48115e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1862058
+  timestamp: 1684280096752
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+  sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
+  md5: 1f09617aecd6f3c2f2e20692c0759f34
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94434
+  timestamp: 1690223520097
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+  sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
+  md5: ffceed627867508d73af1636ab5ebf42
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 156324
+  timestamp: 1661452578573
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+  sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
+  md5: 0e3341a4fe434167bf74b613eb6afd81
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 97194
+  timestamp: 1636110999719
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+  sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
+  md5: c5f3f7f10ad30f0945e75252615ab6e5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31331
+  timestamp: 1605305847037
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+  sha256: c4b9e332a6f2b7524e8c88e2b39a2568a48e556fd9a44c30759c43611d4d023d
+  md5: bb118745c9b08fc5028f45e77f371e68
+  depends:
+  - ld_impl_linux-64
+  - libffi >=3.3,<3.4.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - ncurses >=6.3,<7.0a0
+  - openssl >=1.1.1o,<1.1.2a
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.38.3,<4.0a0
+  - tk >=8.6.11,<8.7.0a0
+  - tzdata
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 24553777
+  timestamp: 1654084160832
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+  sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
+  md5: 0caa188a695319bdb13f53b0a2b3accc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264864
+  timestamp: 1661371117920
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+  sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
+  md5: bcb44ecbea441ee0d4659133d060d71f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257904
+  timestamp: 1695131670290
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+  sha256: e937081facacb141dc2c9cdcced92baa9a2662e4a56100b6041df0b6b7692570
+  md5: f3ac39b2349258198a9b3316636fe5d5
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39972
+  timestamp: 1685030752528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+  sha256: 3da9cbbd49fac566433748bd245d09d7d5fcd28b04c0397cbbf6d5bb92f5c4a5
+  md5: df73a5d2f6e089d51e71e91935a82c65
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 183753
+  timestamp: 1635775763162
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+  sha256: 26005d191bb15070aad70707ed6493f32678a67978bd3b83d4c9679cab44e717
+  md5: 2dc75d5a4ccb64310939c3a72d34ae20
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-clause
+  license_family: BSD
+  size: 521583
+  timestamp: 1638435042256
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+  sha256: 8c950c69bee969e2c66f88f0dc247b3ab75a753672a88009779d5f5dba193532
+  md5: 150ac0eb929bab9dec912797bdfc7b95
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 433182
+  timestamp: 1642022402894
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+  sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
+  md5: c7de00b4ac2778c4e5a7816320d75391
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94028
+  timestamp: 1690400356879
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.6.2-py39had2a1c9_1.tar.bz2
+  sha256: 2cf06019a66fbb0a9df571bac7f0460eb66f60d6b9c37f6a64a6dcddbe2c765f
+  md5: 5f18311a95358bb951f98a6d005a862d
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.3.0
+  - libgfortran-ng >=7,<8.0a0
+  - libstdcxx-ng >=7.3.0
+  - mkl >=2021.2.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  size: 21512828
+  timestamp: 1618856702227
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+  sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
+  md5: 1581cafc84708ed9aafaaee1cbbf6065
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1089416
+  timestamp: 1690290900608
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+  sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
+  md5: e19ffbfb24b990275d24fcea2bd1699b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15702
+  timestamp: 1614030498860
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+  sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
+  md5: ca061ce25c0f58628643abec8d6a8244
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 66330
+  timestamp: 1696347637947
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+  sha256: 87965b7b46d93866d31696a1045216d64f077a06b2900c356aba87e8559c6188
+  md5: fa334030245135b37027a882f3c468bf
+  depends:
+  - libgcc-ng >=7.5.0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: blessing
+  license_family: Other
+  size: 1561908
+  timestamp: 1655328608308
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
+  sha256: d4c0f3e57d8df6042151e65a706f8cd76c9325a47548f4ca3c3516e352dd8ca3
+  md5: 1decb9dd0e7bcee086d83b8b4ab8c8eb
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: Apache-2.0
+  size: 171277
+  timestamp: 1641830509786
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+  sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
+  md5: 0e76eab58fe488e91f0aee73f46de031
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29816
+  timestamp: 1671751864131
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+  sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
+  md5: b413a210eca82fe867e991eed085201b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38882
+  timestamp: 1668168876032
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+  sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
+  md5: 5b8375e2092012db69d2123dc0c68630
+  depends:
+  - libgcc-ng >=7.5.0
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3485432
+  timestamp: 1654088939579
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
+  sha256: 57983e3eb698a3b08b570d5f398d9550cf50b9bf54b2b4728c731ecbc0c89138
+  md5: 3ce956b1e1a7f77af6e6127dca987b95
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101246
+  timestamp: 1667464172523
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+  sha256: b746e39272888b9cc1a2a711b7b8836f2e26f4457850e43ad18bf0765e21dc3d
+  md5: 200e86f8d53aeebf4b7dcfc944fd7920
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 661662
+  timestamp: 1606942359431
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+  sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
+  md5: 67a8320961ff24e92eebb661536e5cf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - requests
+  - slack-sdk
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 123763
+  timestamp: 1679561904852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+  sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
+  md5: 0f0b91a158dd3692cbb7a7763b657bfe
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192032
+  timestamp: 1671143995098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
+  md5: 8515e64a3de7581360d713fe4c0a094e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8789
+  timestamp: 1690297588156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
+  md5: 60170012374b2a5007842fa5870d78c5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57479
+  timestamp: 1690297581658
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+  sha256: 870f20a3c006a74b291910f69c3469a409bd21437142864b29cfafeb89ca7c34
+  md5: 1b2f1589e3ebc3e0c6ecb38dba93e4ae
+  depends:
+  - brotlipy >=0.6.0
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 186761
+  timestamp: 1686163186447
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+  sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
+  md5: f8d03a15b974fc7810d9f54ae849fc8e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20781
+  timestamp: 1607365390528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+  sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
+  md5: d7db5d6ce1db80eade8a082ff78bf479
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 71044
+  timestamp: 1614804011510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+  sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
+  md5: b3899f8bda32734727bd5a73df1d7d17
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 101520
+  timestamp: 1695742037911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
+  sha256: d88bdc49a883a944cf1562ebb0a30d0451e28ab05521fc882615e357b105f414
+  md5: c150cf16071597fa3977fb81ebb83760
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1787638
+  timestamp: 1689041557651
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+  sha256: 2ce360ff98c0ca4537d70c19266b5700810196c54ce2fbaff3b94a969846ee37
+  md5: 94cb94dc47405b24b1b5bd0a3275ab59
+  depends:
+  - libgcc-ng >=7.5.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 398058
+  timestamp: 1651602137803
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+  sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
+  md5: 567b68192c387b5fc88178425577a0fe
+  depends:
+  - libgcc-ng >=7.3.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=7.3.0
+  license: LGPL-3.0-or-later
+  size: 366479
+  timestamp: 1616055552392
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+  sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
+  md5: 3818a9531fe74433c3b7d5144c9a58cc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18021
+  timestamp: 1672387231268
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+  sha256: 513444d83ac2405e898531492ea59f3a95641e357cc39c1048d6fffc1791a16b
+  md5: 601d9449c280b9b145dc8c83b6f06119
+  depends:
+  - libgcc-ng >=7.5.0
+  license: Zlib
+  license_family: Other
+  size: 133595
+  timestamp: 1650637720646
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+  sha256: 1c049c23788a00b6f38bdc801245e0e60af98718d4db4c958658bcc67ff158c7
+  md5: b1737dfd2e06ad69ec5cfec341e207c6
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 827172
+  timestamp: 1650622223170
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
+  md5: b2aa5503875aba2f1d88cae9df9a96d5
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13636
+  timestamp: 1611930018941
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
+  md5: 544adf2677c47c9b9c891aea720678f1
+  depends:
+  - python >=3.5
+  license: MIT
+  size: 33999
+  timestamp: 1630003259346
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+  sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
+  md5: 9eff1a842dbda8d1bae9a2c008b599bc
+  depends:
+  - brotli >=1.0.1
+  - munkres
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 690443
+  timestamp: 1625743217109
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+  sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
+  md5: 33624a42ee387bf9918ea98b4e7b31fc
+  depends:
+  - pygments >=2.4.1,<3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8173
+  timestamp: 1601490751973
+- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+  sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
+  md5: 67857cc5e9044770d2b15f9d94a4521d
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12810
+  timestamp: 1600445183315
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+  sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
+  md5: e68a6f315f41a8d814d833652bf38b9b
+  depends:
+  - python >=3
+  license: MIT
+  size: 13374
+  timestamp: 1606932077143
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
+  md5: 2eb923cc014094f4acf7f849d67d73f8
+  depends:
+  - python
+  - six >=1.5
+  license: BSD-3-Clause and Apache
+  license_family: BSD
+  size: 246457
+  timestamp: 1626374695070
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
+  md5: 41db68b96e114e367c4f120a3b379e59
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19391
+  timestamp: 1632406728844
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+  sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
+  md5: a815d3bdb160bcc71687f2dda70d3ca4
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 122218
+  timestamp: 1680170368293
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
+  md5: 447a49f7bad119faa80d7f14aa296c95
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162176
+  timestamp: 1644481750133
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+  sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
+  md5: 8810f48fe4a4792de0fd3520b502d08b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10019
+  timestamp: 1606859473259
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+  sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
+  md5: 00a446b6dfc61af223df4de29fe8ad94
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 34305
+  timestamp: 1644569782044
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
+  md5: bd92dd8bd5b9d24e632b62a075426e50
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133634
+  timestamp: 1695718025321
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+  sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
+  md5: f8ae051b591a9027adc16de1be9748f4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206198
+  timestamp: 1681493096349
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
+  sha256: 65ababd5e7812c35a97ac7d22b0ebe52c144121a3d49528b7d5c19e8453cce4a
+  md5: d85c13c017a37e406f6c1e00c1ea4f4f
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6480601
+  timestamp: 1690546287900
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+  sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
+  md5: 0d79760d544d0bd8acb4adc4ef813418
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 137075
+  timestamp: 1657175654487
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
+  md5: 31d6d04cd2388d8f19004501271b3545
+  depends:
+  - brotli-bin 1.0.9 hca72f7f_7
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18982
+  timestamp: 1659616229395
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
+  md5: caf1073dc2ca5aeb832a2877394eae12
+  depends:
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18233
+  timestamp: 1659616216769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+  sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
+  md5: aa1ed20c38af535c8d6a955314759d7b
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 394588
+  timestamp: 1659616312678
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+  sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
+  md5: ce3588e31faa79f546e0fc6a36c5543c
+  license: MPL-2.0
+  license_family: Other
+  size: 133884
+  timestamp: 1694009771475
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+  sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
+  md5: 21eb7f53076d0a69513cfd258f6ef63c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159756
+  timestamp: 1690232346868
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+  sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
+  md5: a40a04d9cda1e665565bc6c832d598b6
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225258
+  timestamp: 1670423337502
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
+  sha256: b860f45bce9fbb40d024dcd3306e66a52010641091ca8d1fcdde6c4238717c73
+  md5: 3c38f3af9c23b26efc2b11d82c95922a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 153013
+  timestamp: 1698129937688
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
+  sha256: c368e11dc241d1b79b4bb0d9333b353dc1b966b49d145163a0590d88ad88fef2
+  md5: 1e62044b8a32d1452e51773ba7a4319c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41392
+  timestamp: 1683040146991
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+  sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
+  md5: b2cc5f37f7bb069d061306e7eac2a011
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1913396
+  timestamp: 1668084575248
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
+  md5: 103d8c039e342115720a84d59c119d46
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13774
+  timestamp: 1671231190250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+  sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
+  md5: f69f09e0346172f225390d2b3b0d7873
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 246628
+  timestamp: 1663827484947
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+  sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
+  md5: cb80c7ac65b48a737654f371fe31c460
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1307228
+  timestamp: 1694212041712
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
+  sha256: e80ce32bc86af3e0b67d44bc2c774dde7490443bf6ae4bed7d9c666e3631965f
+  md5: ba47d3bdf582bf15e9250bff6b2f6dbd
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2125677
+  timestamp: 1686783049768
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
+  sha256: 7717c1f0af2af4b28b6d787b32c5e1740f391915c78707d8643e0d516088dbd0
+  md5: d7ae4c5cb253fa85c0ce268d2bf9a191
+  depends:
+  - colorcet
+  - dask-core
+  - datashape
+  - numba
+  - numpy <2.0a0
+  - pandas
+  - param <2.0.0a0
+  - pillow
+  - pyct
+  - python >=3.9,<3.10.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17679970
+  timestamp: 1692372465872
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
+  sha256: 40bbbe2ed223829f4a3f91024fa409f1a665ad94294bec2c9e930989bb2b8911
+  md5: 4add00dc619c12370af0ed18c76b71f6
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 103370
+  timestamp: 1613390236788
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+  sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
+  md5: 04cbe8f4bc62c34fac9d42d1124059bf
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2052734
+  timestamp: 1690905361158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
+  md5: ef0e825982f242085574f502dfff4f6b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16594
+  timestamp: 1649926538106
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
+  md5: 24747a300246c016b3a7f04dabd02d4a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27709
+  timestamp: 1668714497209
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
+  sha256: 95e9a45812b1b4059b973e5e6e131c7c1a8b2ce2dafc5117e7806b1c8f30de27
+  md5: bc889aaa846ed177fc5f495c24041acc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 262430
+  timestamp: 1695734574609
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+  sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
+  md5: e4a732941f74b8062c8bcbfe5c5c2b56
+  license: MIT
+  license_family: MIT
+  size: 80252
+  timestamp: 1676983220161
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.17.1-py39hecd8cb5_0.tar.bz2
+  sha256: a3c61a0d72aa6adca1967b894b190cf7d32fe78b0f8c57b855fb1e99c41aa3de
+  md5: ec60e644877f1e89c9ce00d487232396
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4610888
+  timestamp: 1693378182350
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.9.0-py39hecd8cb5_0.tar.bz2
+  sha256: 80f22084b7a306946e7bc7756d289703255d3760ff7c23f9b6193bf294feac10
+  md5: a6e68eab5b8d73a9048c89189f2a9f21
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.9.0,<3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3339771
+  timestamp: 1697559946138
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+  sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
+  md5: f3ce6fe6eb760c236e5f7d04df5faa81
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28138484
+  timestamp: 1692293212596
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+  sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
+  md5: 6dd72c43fea25b748ec7a9f6c0407e15
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111810
+  timestamp: 1666125671024
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
+  md5: 03cdb7e679924b329ecab8f12cb8fc67
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38813
+  timestamp: 1678997212422
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
+  md5: e113c4e6e758dd68faf196586bf5564d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51873
+  timestamp: 1698254765815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+  sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
+  md5: 78baea934985ccd9514a366cc7e80ed4
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 727499
+  timestamp: 1681801225190
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+  sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
+  md5: da9b63e42f281f7e77b289f4b654b83b
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 218436
+  timestamp: 1691121840155
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+  sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
+  md5: 6a7cb9b49593b29933fa2b503d533a08
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1257205
+  timestamp: 1694181720454
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+  sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
+  md5: d861ef66f5c0a282d60b65778a9de2f3
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1048450
+  timestamp: 1644315332508
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
+  md5: f7e603c965052deed8b789c35855a42f
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213537
+  timestamp: 1666908270815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
+  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
+  license: IJG
+  license_family: Other
+  size: 278924
+  timestamp: 1677849185191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+  sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
+  md5: a82a17e78f725dcbd71ff8dac6db05c7
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133134
+  timestamp: 1676558895333
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+  sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
+  md5: ee9270379a9ebdb6297e4b6849b3f7f0
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 195479
+  timestamp: 1676329410154
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 32b898a97dca7770858ab31294238fde11ab61a84831a52f320e5ee5405a147c
+  md5: 926e754b8fad288b583ef2933deae1a5
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92938
+  timestamp: 1679906616072
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+  sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
+  md5: 7e60995b3119417213e5faedda147499
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 403165
+  timestamp: 1671707664990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+  sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
+  md5: cd470bdb28bb0e8b3535c93a3a6dad07
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65431
+  timestamp: 1672387389172
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
+  md5: 7dba7aa5b971febb55281659843586ba
+  license: MIT
+  size: 65470
+  timestamp: 1659616172703
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
+  md5: f78a158983f0bbaba56f34b976bc6dae
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 34189
+  timestamp: 1659616189313
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
+  md5: 36a1d885725d3ab4d1fadc5a29f978d2
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 327737
+  timestamp: 1659616202869
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+  sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
+  md5: 817848d0e2b2808acdc9b3fbbf581726
+  license: MIT
+  license_family: MIT
+  size: 133887
+  timestamp: 1683716590737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+  sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
+  md5: e458587c87e3f2d20192f4e0738f2c63
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 149419
+  timestamp: 1665498987619
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+  sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
+  md5: 1058b661ec829b2ee3716ee2a5520641
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1917987
+  timestamp: 1665498925405
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+  sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
+  md5: c90372428e1e4eed4fdcd790979d06b4
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1409377
+  timestamp: 1650983531933
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+  sha256: 8176dd9a68815301a24ed51e72f3506f5f77c67a112efa0dd14971f2f3b3c8c1
+  md5: b5e470c224000a6bda6f655c155b53e7
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 27861431
+  timestamp: 1683292881730
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+  sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
+  md5: c0b99f8e1c7475f23b1c7b4250b06e1c
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88021
+  timestamp: 1694778290062
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+  sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
+  md5: 06866415ef22d5322f9bdc9956b59c4d
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 678174
+  timestamp: 1692970318885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+  sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
+  md5: 2edc6c894d6d0321304396e9bd40df94
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241774
+  timestamp: 1692973618934
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 0190d3b8d2939f28aa017711cf4147c51a1139da2922cc8420a71562dd99f844
+  md5: 454a7f2c4426453f17e995382a4235e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 36036
+  timestamp: 1659783508187
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+  sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
+  md5: 5c740b4a18a558de0ccfe601703c423c
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 338738
+  timestamp: 1662635677689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
+  sha256: fbf3c01a0834c151485b1b2ddf0c83d43703cbea051c6dbcb0d8d41946107670
+  md5: 12137025daee35f5c708ca10d0c96e3c
+  depends:
+  - libcxx >=14.0.6
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - python >=3.9,<3.10.0a0
+  - zlib
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 318622
+  timestamp: 1697031357874
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1dab4daa56408915de3ec270c8b887e7221d48633ea83b0afff61041fc197972
+  md5: 1519f9b766f9f894282db8353066e3b2
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11883
+  timestamp: 1652903144294
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+  sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
+  md5: 8bbd981ca0129d7beeacd3cd7623f714
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1491074
+  timestamp: 1695058597986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+  sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
+  md5: d5f58d056b4bfc67aec30c77035ba889
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 182491
+  timestamp: 1670944720979
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+  sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
+  md5: 1affd16b166571a91feae04baf5fd3da
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123431
+  timestamp: 1671542016019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+  sha256: e5fc51472fa0f36abd78baa5b3c9245d6627b0da11188e6a954d73f3f2bca210
+  md5: df7c519447affffb594f8c56b028ed33
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 107035
+  timestamp: 1684279974102
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+  sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
+  md5: 3681ebf029211ceab26af6f5d35abf39
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22254
+  timestamp: 1654598220251
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+  sha256: 2fd179efa024c92d0d71179a981a781d16c70f5d8c6305e0d678b0c7ae1275ab
+  md5: addda7f015d1673f794a23fdb18a3e09
+  depends:
+  - __osx >=10.12
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8182219
+  timestamp: 1698692361219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+  sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
+  md5: 6eb64ecfcd754502e271db0bb51d2cfd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17374
+  timestamp: 1662014643620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 2312ee5a6343e8495802698d7181f1b619aad7479d96ee253407b324ac884417
+  md5: 866960fa48a7ca335941786d4869802a
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53542
+  timestamp: 1659721365599
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: 37f455814ce242eb65ff80a0402f1bd231a388e6823e6c1e65f60b705c032a2d
+  md5: 4c9246c492a64729225aa5b04e12c2d1
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19573
+  timestamp: 1659716100178
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+  sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
+  md5: 2a4d604717a647ad21af766289cbbfc3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58057
+  timestamp: 1607364912348
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+  sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
+  md5: 25051fe272624544652dc6d814c2943a
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224420228
+  timestamp: 1691503125614
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+  sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
+  md5: 37d8cf85a63f7aa9af1624894a7d606d
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48590
+  timestamp: 1682969183093
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+  sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
+  md5: 0b2aee6666135bbd36b46d6ac66160f7
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 210705
+  timestamp: 1695058433223
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+  sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
+  md5: e22fb55ce380d0ebd44cce3f20d5349e
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296614
+  timestamp: 1695060155673
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
+  sha256: 5f60ca253f1fea0a1d765f535ff9ca2cf7efba90aea4c9a290d8f50ad11d4f6f
+  md5: 97d6ec94e2300030bddf0e5289cd2a84
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 24240
+  timestamp: 1607574265505
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+  sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
+  md5: 1a5d4004e64e3cfb7a2a297b9117c285
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8213832
+  timestamp: 1681756573646
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+  sha256: 2975bd1f98ca9ec7354ee378f86f8322ec90f568374776fd90e80c534fbee882
+  md5: 798627089e0ccba26695a26d9cb127ec
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99066
+  timestamp: 1650308465824
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+  sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
+  md5: e572c1264a7af20b486f64ac8c9e1f57
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 573356
+  timestamp: 1668450732828
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+  sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
+  md5: b67569a7c30af9ffa5cde6e4b52ac68b
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148342
+  timestamp: 1694616917184
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+  sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
+  md5: 97b81f34efbe86c5220fe82eb584fd62
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387288528
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+  sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
+  md5: d77862975a9a1cf50acb803be26e83a1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 575365
+  timestamp: 1690985052739
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+  sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
+  md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22858
+  timestamp: 1668160618784
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
+  sha256: 249efa747726ad61bc1093f33f155f0b7a0fa5b728cb1a6a6bd126458f279c96
+  md5: 1cced9a92d68307846cf59c238a42f13
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.41.0,<0.42.0a0
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.26
+  - python >=3.9,<3.10.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - libopenblas !=0.3.6
+  - tbb >=2021.6,<2022
+  - scipy >=1.0
+  - cuda-python >=11.6
+  - cudatoolkit >=10.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4431283
+  timestamp: 1697057424792
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+  sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
+  md5: 185e9c41abb88ee59b52ec0f5f65d506
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 138305
+  timestamp: 1696515469702
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
+  sha256: 361754aae186c6f4f8e5ceadf02b95ae74b47a97eaf1aa37538a7c410fb3ec88
+  md5: 02e4a556e3eb2375ec5a75795dd32372
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.25.2 py39ha186be2_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12847
+  timestamp: 1691166007881
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
+  sha256: 94d69c58f79dea6d155debef3237f02397ab6c3d042b519ad89fc64d204507d2
+  md5: 891a8850c69fd11971e58dfba0c40fcd
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.25.2 py39h827a554_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7529822
+  timestamp: 1691165972737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
+  md5: 93f5d7b66976154adeda219bea02ba45
+  depends:
+  - libcxx >=10.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 484257
+  timestamp: 1630093862501
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+  sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
+  md5: 5e8713ef1215406254988163eaf34020
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4965606
+  timestamp: 1695323060401
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+  sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
+  md5: 4154929ace2ad6ee16aea815635a6d1f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73598
+  timestamp: 1693575307570
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.0.3-py39h3ea8b11_0.tar.bz2
+  sha256: 5e8b15af733592f6f6bff1c6eee2b8b808e8252e8a1112dc5a1cafe74016bffd
+  md5: 814274b9cdcd2cebab38a7a4d3d6dc48
+  depends:
+  - bottleneck >=1.3.2
+  - libcxx >=14.0.6
+  - numexpr >=2.7.3
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - html5lib >=1.1
+  - sqlalchemy >=1.4.16
+  - xarray >=0.21.0
+  - pyqt >=5.15.1,<6
+  - lxml >=4.6.3
+  - tabulate >=0.8.9
+  - matplotlib-base >=3.6.1
+  - fastparquet >=0.6.3
+  - blosc >=1.21.0
+  - gcsfs >=2021.7.0
+  - jinja2 >=3.0.0
+  - scipy >=1.7.1
+  - fsspec >=2021.7.0
+  - pyreadstat >=1.1.2
+  - odfpy>=1.4.1
+  - psycopg2 >=2.8.6
+  - pyarrow >=7.0.0
+  - openpyxl >=3.0.7
+  - xlrd >=2.0.1
+  - pytables >=3.6.1
+  - zstandard >=0.15.2
+  - numba >=0.53.1
+  - beautifulsoup4 >=4.9.3
+  - pymysql >=1.0.2
+  - python-snappy >=0.6.0
+  - xlsxwriter >=1.4.3
+  - pandas-gbq >=0.15.0
+  - qtpy >=2.2.0
+  - pyxlsb >=1.0.8
+  - brotli >=0.7.0
+  - s3fs >=2021.08.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13333560
+  timestamp: 1692298689692
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
+  sha256: 1928d1f3aa777c6fe0b279f400fa417b293527531bbdd3d918cc8e987a680f86
+  md5: e8d7a163f2f9dd0f1972e126ee87b586
+  depends:
+  - bleach
+  - bokeh >=3.1.1,<3.3
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.16.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17076156
+  timestamp: 1695146369755
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+  sha256: 914f1ec8d911083c006c4c2d3b4c0c528e79abba3ae5f1dad825bd896870270d
+  md5: 949e0e4c0ce43c92eb52241892230873
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142949
+  timestamp: 1684915417020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.0-py39hecd8cb5_0.tar.bz2
+  sha256: 7d7a44349653b73746ec89c3e2ab12288404aaf260bdbdc0fd4f5774adf1f77e
+  md5: c541491d1fba2bfa195e6ba89167e9f2
+  depends:
+  - locket
+  - python >=3.9,<3.10.0a0
+  - toolz
+  constrains:
+  - pandas >=0.19.0
+  - numpy >= 1.9.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36127
+  timestamp: 1693937967627
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+  sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
+  md5: be0a90921f3bf4f0d6950fb786093de7
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND
+  license_family: Other
+  size: 719901
+  timestamp: 1696580194417
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+  sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
+  md5: 81ae9ec2d7fcf6934847bff558b619f5
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2672987
+  timestamp: 1697548890181
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+  sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
+  md5: 1a822c206e2abddc5d6d821721af227f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33013
+  timestamp: 1692205801265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+  sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
+  md5: 1604d33dbdb2446c642970f8b354bedb
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91266
+  timestamp: 1659455269141
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+  sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
+  md5: d1b3bcc35655a3123acb1fa2ad1a8511
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580828
+  timestamp: 1672387372015
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+  sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
+  md5: 7540555d1fb192236db9a7c5c9d3601c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365765
+  timestamp: 1656431373327
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
+  md5: 0a73533fb6e0dc717ab906a537bc747d
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30803
+  timestamp: 1675441638631
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+  sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
+  md5: 0a959fbad46ab38ade48dbd358002674
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1864757
+  timestamp: 1684280094736
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+  sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
+  md5: ea24b5076ef79e4567c5a3f0cb22b470
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95330
+  timestamp: 1690223465114
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+  sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
+  md5: bcaea6d4a47e9c874becaa700c78dcf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157216
+  timestamp: 1661452617825
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+  sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
+  md5: 707110d1b49cb1864acb0bbaa103591e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 95016
+  timestamp: 1636111184034
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
+  md5: 113a443b9c706f9f9c6187c0eaa3de27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31178
+  timestamp: 1605305861851
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+  sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
+  md5: 85a8d0001db70e52a479155228cb1fe0
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13324979
+  timestamp: 1694439878265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+  sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
+  md5: 47c5e22e31ec05a7bc0ce90065a53afd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 265348
+  timestamp: 1661368839620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+  sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
+  md5: ce9a69e1668aa1e133f2aa6d4e8d346f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 254958
+  timestamp: 1695131709704
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 9ee098c09f31fad7ff1856e5ce2619172eaf979997e7a427d1e05cce32c2af00
+  md5: cac1d1898b69ae9646dfbf082910635d
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40946
+  timestamp: 1685030787453
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+  sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
+  md5: 637f08b19dd8fd87347d8c44f9e3e202
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 170776
+  timestamp: 1698096100056
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+  sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
+  md5: 8ce3ac7d8a04e469b566f1b090d01140
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 470617
+  timestamp: 1657724324011
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
+  md5: 6f2d41dd76a03b7f85a1ed49af1763d6
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95100
+  timestamp: 1690400262627
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+  sha256: a9755ecbfd42c708945027facfa11a3dc3119778326a0ae5df79f80d7b72afa5
+  md5: 839ffa4e775fee9a8bdddabf4a14da43
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<1.28
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24331914
+  timestamp: 1696545397632
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
+  md5: b0321e6f14e139fc15b1f8b4acb35d2f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093966
+  timestamp: 1690290944588
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+  sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
+  md5: 62b64576a0aa5f6c3fb05f56650d25e1
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15535
+  timestamp: 1614030509324
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+  sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
+  md5: 15b5595b31e39f08eaacbe2e502d8fb3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67292
+  timestamp: 1696347733587
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+  sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
+  md5: 82e4db6a498480a75d53c55bd35b6478
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1801397
+  timestamp: 1681394807900
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+  sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
+  md5: 63b957927b9949ccb19da28ec4612706
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30902
+  timestamp: 1671751919031
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+  sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
+  md5: e346257a2fa8e2cb48c762138a5d009b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39915
+  timestamp: 1668168959656
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+  sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
+  md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
+  depends:
+  - zlib >=1.2.12,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3536231
+  timestamp: 1654088937695
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
+  sha256: 74fc3a9e308602b3710f8fa671f24f5492571d0c8f7c1b3071dac72671262d45
+  md5: e08ead92568f5bd72d5ac7f08f087fee
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102258
+  timestamp: 1667464155001
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+  sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
+  md5: a1bbf0abfb8c45541122c0eb2feee317
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680464
+  timestamp: 1696937112175
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+  sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
+  md5: d689f6203c0a9d04fb229c73d7e80a7a
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125145
+  timestamp: 1679561909274
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
+  md5: 8a292c1ee22489bef2e84bc3aaf4098e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193141
+  timestamp: 1671143985219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
+  md5: 8bf0bfffc11ad06a1c94e145941b0ad4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9651
+  timestamp: 1690297655669
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
+  md5: 343514a174b3485fde55a73f56398dd7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58456
+  timestamp: 1690297648002
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+  sha256: 11e7401cb6805db7ce22b1f9dd6ba5b7941c92225ce440bed1da0af284bfcad4
+  md5: 5c10d68fa5616cdd82ee93ef6e0f038c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11615
+  timestamp: 1659769478980
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+  sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
+  md5: c2242e8fd24003a74ddf37416661e06d
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188757
+  timestamp: 1698257668273
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+  sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
+  md5: 41f445e36b6b6722a9444508eef069f8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20583
+  timestamp: 1607365395045
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+  sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
+  md5: 409ee46ed24267b6da6fb32d13e1f21e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70730
+  timestamp: 1614804271285
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+  sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
+  md5: eb74e74d8e4fd533c55eb98b7b5e83bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102637
+  timestamp: 1695742077778
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
+  sha256: 9f5a34bef727052f97b1cc387c3a99a60754de99d6e4ab0b2de770d76b64dc0f
+  md5: b5ce0421037c626cfcec5b43d83ec420
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1787999
+  timestamp: 1689041573350
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+  sha256: cb007615819fd240ea4e343835dfbda3c508a92b5b7158219d30a22d0e67b57c
+  md5: bf215e781ac81e0fc433eedee330c54b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49462
+  timestamp: 1675159191191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+  sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
+  md5: e243baa546432c8394a8059a44a5a3e4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 419227
+  timestamp: 1683113010463
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+  sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
+  md5: fe4ac85ee86d3a94ea3a4ebea3779763
+  depends:
+  - libcxx >=10.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 321797
+  timestamp: 1616055526986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
+  md5: bc7073d9d4c0211cc4a1207c98fb765a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19091
+  timestamp: 1672387204865
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+  sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
+  md5: 8e495591e369ac161857a72011c0a296
+  license: Zlib
+  license_family: Other
+  size: 120272
+  timestamp: 1666595024203
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+  sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
+  md5: f1465fbd810b3746c6de6babfd4fe28a
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1023573
+  timestamp: 1681304595869
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+  sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
+  md5: cf55cb8d7031b30c70c56fc7c782b5c7
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 156104
+  timestamp: 1644482799136
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+  sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
+  md5: 84fce327d9f0d594e86f565e5c21962e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10183
+  timestamp: 1629146082730
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+  sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
+  md5: 84b8b998a741b37abf5312c1c03696ef
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33979
+  timestamp: 1644845817952
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+  sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
+  md5: 77b746931c8f31c3ae393ccb5819d43d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133628
+  timestamp: 1695717890677
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+  sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
+  md5: 3df6e8ba34208dea068890e5d5318cc0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206759
+  timestamp: 1681493095987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
+  sha256: 4edfceca9958378015a2d5ff705aecb977fa329fdd0caf51cf6a1b6b5506e5ab
+  md5: 7404ddc0add9157338d7d4822ac13cb3
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6462121
+  timestamp: 1690546176434
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+  sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
+  md5: bb55f81435cb6e11d264242274fccd1a
+  depends:
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 115947
+  timestamp: 1657175645380
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
+  md5: f860193e14afc7ef3f5b990a2ac003d2
+  depends:
+  - brotli-bin 1.0.9 h1a28f6b_7
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18936
+  timestamp: 1659616204016
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
+  md5: ad53130f3fd1f8d3c2fcbb7496e5585d
+  depends:
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18715
+  timestamp: 1659616188888
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+  sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
+  md5: 0982c046fb976e9f9fb19e7510187a18
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 366983
+  timestamp: 1659616245272
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+  sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
+  md5: 31ac2f5596cb7a44adf073c930641c54
+  license: MPL-2.0
+  license_family: Other
+  size: 133817
+  timestamp: 1694009762858
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+  sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
+  md5: cf1f6c3c34a1e1b9ab22b04233d860f6
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159783
+  timestamp: 1690232303987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+  sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
+  md5: 0eb268e38b5174d471a6e87d9d6102b1
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225355
+  timestamp: 1670423312966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
+  sha256: 41e76ba21b1279278a039245275eb4ee1f81b38b33cba00ca3575f06be5dc570
+  md5: c5170bf12e308fb7f2d1b4b9065f3df7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 153036
+  timestamp: 1698129857856
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
+  sha256: 36240dde0a1546469f35f3b5509b55384dfd894beb56b3ca929da4b96a2a5f24
+  md5: 844539636e4c20ee99e8ceeff5e902bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41376
+  timestamp: 1683040042906
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+  sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
+  md5: e68c94666cd60221b575c3814c89bac0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1946451
+  timestamp: 1668084573824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+  sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
+  md5: 1773ae2b080cdd55827e27673351551e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13646
+  timestamp: 1671231171682
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+  sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
+  md5: 53bfd99ad1b09164d537209cffd98161
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 244040
+  timestamp: 1663827469853
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+  sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
+  md5: b62455043c8eb2434466885b19fed2de
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1399573
+  timestamp: 1694211828228
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
+  sha256: fb7d12350372a70daa9f476647d04fc213ef9d8f73cbddaf30b40b1b45beef0f
+  md5: 34595eb00802934d092b3086d7b4344d
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2124926
+  timestamp: 1686783028732
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
+  sha256: d366da723fc8baf4d9de0d25688619efe4d1c7abe5407dfb28654c4c9e2ef019
+  md5: d4c923ceedacd8d5d18f994feed8dbb8
+  depends:
+  - colorcet
+  - dask-core
+  - datashape
+  - numba
+  - numpy <2.0a0
+  - pandas
+  - param <2.0.0a0
+  - pillow
+  - pyct
+  - python >=3.9,<3.10.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17708209
+  timestamp: 1692372524993
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
+  sha256: 83dbf9755ea887576e3f34adb1c26d418db9aaf3c77dc07f30b58c2221b81c72
+  md5: 36246697d07d6709de78abe36b6beae5
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 103201
+  timestamp: 1629793063728
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+  sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
+  md5: eb3cdc0fc210838b9271512a6a1b7c85
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2067708
+  timestamp: 1690905319109
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+  sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
+  md5: f44b80b9405410e5bde6bfe0b31d5b3f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 15135
+  timestamp: 1650293774207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+  sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
+  md5: f87027ccce1361d0f82c0edf1a10d53b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27677
+  timestamp: 1668714367519
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
+  sha256: 296371685a5dcd98f5128f11f413e63aa59c1eba60543faf3baaebd445964c5d
+  md5: 9817e8ffd3669484c9a7de99a8aceffb
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 257844
+  timestamp: 1695734566410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+  sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
+  md5: 1d0bd7e576c64c059ef781dd319ad82a
+  license: MIT
+  license_family: MIT
+  size: 77591
+  timestamp: 1676983230102
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.17.1-py39hca03da5_0.tar.bz2
+  sha256: 024023fcd6a34ff71b3b558f9db00506382edef02e7ae0cf8e49846840d7deb8
+  md5: 5598508e6b21861496a578c023958612
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4495882
+  timestamp: 1693378262537
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.9.0-py39hca03da5_0.tar.bz2
+  sha256: 519ed44b20355e914a87c6e6ecfcc6ac47b088b52223d64a052f73d98d5464a9
+  md5: 792b62dde64917556bdc4ba7b822c7ae
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.9.0,<3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3339433
+  timestamp: 1697560078781
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+  sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
+  md5: 69eb3b03765627b6159ed23cdde78396
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28399065
+  timestamp: 1692293207812
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+  sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
+  md5: 83366cbd3beb073112f4644a613b6bca
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111933
+  timestamp: 1666125627512
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+  sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
+  md5: 647c1a2f8460ffa8c670a1915bbdb494
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38790
+  timestamp: 1678997152549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+  sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
+  md5: 35e541905426c686ef2ff010a0e502fd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51860
+  timestamp: 1698254731870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+  sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
+  md5: 187d7720aedf38759d122cccb4576f2c
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 219976
+  timestamp: 1691121991680
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+  sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
+  md5: e8e7f10741f9cfa737b310b334940441
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1255894
+  timestamp: 1694181494549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+  sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
+  md5: ff209e75aee17af2e358b0008fbe8c88
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1022945
+  timestamp: 1644315931223
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+  sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
+  md5: d3e78ef296b3c74910d003bd10b475d6
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213972
+  timestamp: 1666908195870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
+  md5: 055e12390b844ea6c6e956ee08a618e8
+  license: IJG
+  license_family: Other
+  size: 273479
+  timestamp: 1677849171867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+  sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
+  md5: 783e2ad3d36472648c5ccc9f3051db3c
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133077
+  timestamp: 1676558732505
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+  sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
+  md5: 0677598f673f9729b5990316170a999d
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 197129
+  timestamp: 1676329661580
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+  sha256: 05f9ca0fdcfdc2e217438be27fead588c843a3aadf7d034467c83216d1e5c214
+  md5: 2d648b77d817ba38293c0728711ba8f5
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92852
+  timestamp: 1679906632236
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+  sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
+  md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 401319
+  timestamp: 1671707682572
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+  sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
+  md5: 247558a0aecf1ef7e77a4343761353d6
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64600
+  timestamp: 1672387273585
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
+  md5: a0f206782751dfffed0dd51302a1bf26
+  license: MIT
+  size: 68012
+  timestamp: 1659616138077
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
+  md5: 4c6667cdd061d28e9bc4e4300e4d115e
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 31173
+  timestamp: 1659616155596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
+  md5: 637e9430e258ddf050623ef2360184d8
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 298430
+  timestamp: 1659616172209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+  sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
+  md5: 55c615026c0869f8d3ba657f3bd38c43
+  license: MIT
+  license_family: MIT
+  size: 120389
+  timestamp: 1683716579036
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+  sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
+  md5: a41117710dafe569c9cc4e83f6f29fe3
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1411339
+  timestamp: 1650982753977
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+  sha256: d654027daea13ac9db36ab5fd5eff3ad398ec97c1777bf399f3ec680d2c145b9
+  md5: baabb1f905054bfea3af8f5768572a34
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 26579907
+  timestamp: 1683291669565
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+  sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
+  md5: 98d22e0124d55fae3c37c608dab1dcc9
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 89825
+  timestamp: 1694778225280
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+  sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
+  md5: 0ba499df6755eae5d2d23aa4ab004553
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 642657
+  timestamp: 1692970217410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+  sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
+  md5: c73101971e5ab6a8e8688239884eac81
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241607
+  timestamp: 1692973585084
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+  sha256: ac50f846e93e68d50bfdd5589ea8272b987243a64eba8e2e358ef311d7734001
+  md5: f19270ff954a41dabbfe36ff0656935b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 36040
+  timestamp: 1659783399073
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
+  sha256: 124d9d4f865f0f66c4e5e7f99dc1110330c9415cc51effc0a5aad4261880c2f0
+  md5: c08c14e55ba470513eb6c87206fb7b30
+  depends:
+  - libcxx >=14.0.6
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - python >=3.9,<3.10.0a0
+  - zlib
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 322413
+  timestamp: 1697031210019
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
+  sha256: 83e1c11fb14ec2767e833b540a6a0fdbd8641523b5673273914007008e6666da
+  md5: 64adbf70a0d4ab82aca039e972821537
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11877
+  timestamp: 1652903192510
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+  sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
+  md5: 353dff9d5d996c2a260f66381b2ce3e8
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1470815
+  timestamp: 1695058433965
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+  sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
+  md5: c99006da802a97c9aae30da8c16b4820
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176131
+  timestamp: 1670944706815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+  sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
+  md5: 60bd1e037cda86205526f77405d78129
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123361
+  timestamp: 1671541992772
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+  sha256: 2fd690fa3c54a40f0426874ea12e12aad2718263a75708ddd1fa6052a4ad7fb3
+  md5: 81388724babfe9c32ea5cdd93633c342
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 107072
+  timestamp: 1684280007887
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+  sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
+  md5: 34dfd76da78de2eae95bbda390d746d6
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23092
+  timestamp: 1654598007056
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+  sha256: bf0eeef3c3c713515766ab8b0dc7863413de5b4b227deede97e24d90ca342345
+  md5: a7bba1857eb84fb50caea377e60d2050
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8066509
+  timestamp: 1698692266161
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+  sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
+  md5: eb79dabbeedee7da85dfbfb145bb8a26
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17342
+  timestamp: 1662014601345
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+  sha256: f400ad75dd2890627dc948f3e2e6b19732d02c124723eaf22272026993a94d52
+  md5: 4a4ffc7365e30b18f4443281839e2718
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53505
+  timestamp: 1659721313693
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+  sha256: 20fb26a7ac748ce288cf8483a837b0c33f1348ae738bcdb69cdc2763c7bbf7e1
+  md5: a0aebbc6c170ebd8d4710fd70b3db503
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19562
+  timestamp: 1659716131839
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+  sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
+  md5: 56db7bd3ff511cd839bda081523b3edd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 55683
+  timestamp: 1629356128780
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
+  sha256: ee936ba5fd196c15c3cb538aef721e54bb4486110ae3ebbfcf78e95e8380efa4
+  md5: dde1d9e040e04cbfbc0138898240a660
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 23003
+  timestamp: 1629282780853
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+  sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
+  md5: 176e0dcaeb28393881bacf69941e3889
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8289638
+  timestamp: 1681756329011
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+  sha256: afc6f332c51a3defc69e4c4e641988c0556039b9cd42be22f3db5292c88ccf37
+  md5: 2bc409c7258160a9b739d08d5ffb5998
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 96942
+  timestamp: 1650373637069
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+  sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
+  md5: 150ea9fadddf21993d3328d3e48a18b7
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 557688
+  timestamp: 1668450759059
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+  sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
+  md5: 37163b32508f9f589b3e6462a3a47546
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148426
+  timestamp: 1694616771736
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+  sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
+  md5: 6cdf7cbc43bf40e92b056a5576bd0086
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387216468
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+  sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
+  md5: 0f05853a139b6cda9c73e9d2707a4976
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 590288
+  timestamp: 1690984971741
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+  sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
+  md5: 7de782e4fb34bfa95ef2fc79d27d727d
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22840
+  timestamp: 1668160634885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
+  sha256: 0a5a7295f055d2f175528cc895dcb07533df5f0b87f05ac7839ec1af15988218
+  md5: 3d8e6925b26ca29486d0b58b30f1f663
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.41.0,<0.42.0a0
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.26
+  - python >=3.9,<3.10.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - cuda-python >=11.6
+  - tbb >=2021.6,<2022
+  - libopenblas >=0.3.18, !=0.3.20
+  - scipy >=1.0
+  - cudatoolkit >=10.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4428704
+  timestamp: 1697061454581
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+  sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
+  md5: 1a7b23113372c5667dbfe45976b9cc5c
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 126357
+  timestamp: 1696515322390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
+  sha256: 5332b3635fbc1a800b0fe58db7a0e57bb5ef75cbc56a0512c76f01ac7fc7139f
+  md5: ab7fbf394a301d25d1bf8cfa76fd917b
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.25.2 py39ha9811e2_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12847
+  timestamp: 1691092401334
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
+  sha256: 114b5aa7ef0990a615e27116e05dba0e7e78df750e3592aa4b732438f391a394
+  md5: 3284c63e9251227322ef9fd9c997f2c7
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.25.2 py39h3b2db8e_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6338710
+  timestamp: 1691092386069
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
+  md5: 371358a54bbdd307603888348d1a2c6f
+  depends:
+  - libcxx >=12.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD 2-Clause
+  size: 412248
+  timestamp: 1628861367714
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+  sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
+  md5: fa15d3b44ae1360ac9b640bbd5b6923c
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4746123
+  timestamp: 1695322833432
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+  sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
+  md5: d73db95f07a282021efdf8bc09713261
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73620
+  timestamp: 1693575195999
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.0.3-py39h46d7db6_0.tar.bz2
+  sha256: 185a933dcaceb0fa378e214cd72ea89f9071f0699fa9fabab1535d674531611b
+  md5: 1730e1aecea062f0f6e8eb323c164d23
+  depends:
+  - bottleneck >=1.3.2
+  - libcxx >=14.0.6
+  - numexpr >=2.7.3
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - tabulate >=0.8.9
+  - lxml >=4.6.3
+  - psycopg2 >=2.8.6
+  - pyxlsb >=1.0.8
+  - python-snappy >=0.6.0
+  - pymysql >=1.0.2
+  - xlrd >=2.0.1
+  - qtpy >=2.2.0
+  - gcsfs >=2021.7.0
+  - openpyxl >=3.0.7
+  - html5lib >=1.1
+  - xarray >=0.21.0
+  - fsspec >=2021.7.0
+  - matplotlib-base >=3.6.1
+  - xlsxwriter >=1.4.3
+  - scipy >=1.7.1
+  - fastparquet >=0.6.3
+  - pandas-gbq >=0.15.0
+  - pyreadstat >=1.1.2
+  - sqlalchemy >=1.4.16
+  - blosc >=1.21.0
+  - pytables >=3.6.1
+  - beautifulsoup4 >=4.9.3
+  - pyqt >=5.15.1,<6
+  - pyarrow >=7.0.0
+  - brotli >=0.7.0
+  - jinja2 >=3.0.0
+  - s3fs >=2021.08.0
+  - zstandard >=0.15.2
+  - odfpy>=1.4.1
+  - numba >=0.53.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13122992
+  timestamp: 1692291303537
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
+  sha256: 4548d2a1bc58cd61e9c9f475a77bac68d9e49d4996c4c891d5ca8ba5ea7552b0
+  md5: b4ed079246a55ac8f91b8f8abb713b3b
+  depends:
+  - bleach
+  - bokeh >=3.1.1,<3.3
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.16.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17115516
+  timestamp: 1695146000246
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+  sha256: 0d64f2438be25524bbfeb8646e4fb3c18499d747398a03ed15d41b350b03e001
+  md5: 6a4908a5c9f7b3f17f09ebc34b1b691c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142857
+  timestamp: 1684915417403
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.0-py39hca03da5_0.tar.bz2
+  sha256: 17228498dd86fc52909ef03da734ae4334f704a52089ed629b739ed964a83062
+  md5: 308b356f70bb265a2c3898931401d8e2
+  depends:
+  - locket
+  - python >=3.9,<3.10.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36176
+  timestamp: 1693937934593
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+  sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
+  md5: 6e01c592ae3b8ff2d12cae76f2f4276b
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 715239
+  timestamp: 1696580071596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+  sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
+  md5: 9fb8f460c130d56caf33c6bbe46fbe8a
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2678841
+  timestamp: 1697548790931
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+  sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
+  md5: 390b8c3cd74281abecdbfd51476922f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33033
+  timestamp: 1692205747301
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+  sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
+  md5: 7896828fb3565fefad43f980d50c8723
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91190
+  timestamp: 1659455206354
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+  sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
+  md5: d934c74eb66d01af0f45f0881f4bab77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580588
+  timestamp: 1672387390426
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+  sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
+  md5: 9858166e5ffb624c8b9d281f4000d725
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 367167
+  timestamp: 1656431368885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+  sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
+  md5: 4d2b45c6be8221e6a3e44c2d5838426f
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30843
+  timestamp: 1675441531640
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+  sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
+  md5: 02521df4e2e79f75faa9cbb3560ab1dd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1861763
+  timestamp: 1684280026169
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+  sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
+  md5: bdebe59bffc7adbad83fdcd9d429a5f5
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95234
+  timestamp: 1690223494699
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+  sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
+  md5: d716e5c9b5eec45ce1df8eb52cab817a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157408
+  timestamp: 1661452601692
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+  sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
+  md5: 1907629863ed8e7c35ead232dae7693f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 91636
+  timestamp: 1628941083263
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+  sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
+  md5: 847b9bddf2a86e1609c0d53bbc23ea79
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 27378
+  timestamp: 1626781391140
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+  sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
+  md5: 18aa18bd0d260605923877921d26cc74
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13194025
+  timestamp: 1694438901368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+  sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
+  md5: 45642a99c83e7aed74d1ffab1f20145b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 266647
+  timestamp: 1661368655993
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+  sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
+  md5: fec748525144049a2fc7f52f9755232c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257235
+  timestamp: 1695131702047
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+  sha256: 960192a143672e9c1d6fe4027af448512d91eee7501e5c245c21b865cf8bf429
+  md5: 76d491244218505f071ba56a308673df
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40950
+  timestamp: 1685030774581
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+  sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
+  md5: 3445d25415998c807efbe64d3a7e03c8
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 167068
+  timestamp: 1698096118071
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+  sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
+  md5: e6e92da28e9b0e428ed4b7df417bec25
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 472418
+  timestamp: 1657724315435
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+  sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
+  md5: dba22515f36d3c266de5896350813ea2
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95103
+  timestamp: 1690400315537
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+  sha256: c35449c0ca64d0d6a23c019b6eba188f546e42379857cbc4240bbdddee1159d3
+  md5: 61cb82346e21710f3e0645096cda4e12
+  depends:
+  - blas * openblas
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.21.5,<1.28
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22859180
+  timestamp: 1696543469561
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+  sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
+  md5: 3cd7eb43e285faba76faf67667e26b00
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093916
+  timestamp: 1690290951258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+  sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
+  md5: c5e9aef0d6895de1c927e9d796cd7cd3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15691
+  timestamp: 1629145910454
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+  sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
+  md5: 0f7c229e774146ffc4e29dedf75372bf
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67279
+  timestamp: 1696347632563
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+  sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
+  md5: 2302a79a045f152e183a52a81adfba62
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1674163
+  timestamp: 1681394762218
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+  sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
+  md5: ae58720a18a2ed15eae214ad7a10d1b5
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 140125
+  timestamp: 1680167256603
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+  sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
+  md5: 4ae67163d55cf9df83d4027ebc38c501
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30894
+  timestamp: 1671751931536
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+  sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
+  md5: dbb5c0cddb6661a89afee647fd3dc01e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39875
+  timestamp: 1668168874870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+  sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
+  md5: 667e60c8b407d73cbba40f44901f4f00
+  depends:
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3412693
+  timestamp: 1654088929697
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
+  sha256: 065cf1b08faf1d28aa348d569f2266d8b33b22ba424312c7ec959be95f217646
+  md5: 20370dbc92a9262e6fc8c82208f74ff2
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102259
+  timestamp: 1667464137769
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+  sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
+  md5: 884f788a5f6a664c9b79f7a4a60362d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680561
+  timestamp: 1696937004165
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+  sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
+  md5: 639a4f489af172c866c18442948e5874
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - slack-sdk
+  - requests
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125170
+  timestamp: 1679561942932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+  sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
+  md5: e5b90eba83fddba6d7aa6072b5bf7c91
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193017
+  timestamp: 1671143921826
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
+  md5: 644ef8830437070f60efcfcd6a987198
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9670
+  timestamp: 1690297532002
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
+  md5: a902a833bb186a2f1a4b2b89b1195136
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58466
+  timestamp: 1690297524418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+  sha256: 536045a8a172c651fd306c285a6d7409775f018dac944f2124c538ccfb195e28
+  md5: d4dc6cdf0812191b9ec78b35b4fdf3e0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11593
+  timestamp: 1659769477205
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+  sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
+  md5: f3f1d2c1028dad2f11ff950a15c99dbf
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188640
+  timestamp: 1698257577209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+  sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
+  md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20091
+  timestamp: 1629144441130
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+  sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
+  md5: 3089c63bf8f4d0423e1a287da286d83e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70923
+  timestamp: 1629357115820
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+  sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
+  md5: 5886b30b312445471268444f41f39dc7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102583
+  timestamp: 1695741976083
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
+  sha256: 300b9e4cfc9d01fa4d537060b2867f3cb89f22f932992fc2427e00dda050d55b
+  md5: 768c174577b786b99f8b46c4789b36a2
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1800646
+  timestamp: 1689041569828
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+  sha256: 105e39d3eb51b47c7244b3379c0133ab7051966664f52835453b14509215b159
+  md5: ed20012c2cd99ffd04cca9929e0bc061
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49775
+  timestamp: 1675159079039
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+  sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
+  md5: 2e75ad6a09c308268192efe03cc9ebf4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 411778
+  timestamp: 1683113019715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+  sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
+  md5: 30f666bf97c26587c5d2f68cc5f330ab
+  depends:
+  - libcxx >=12.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 316901
+  timestamp: 1629287855861
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+  sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
+  md5: 584e591d36dcd5ba5c45404f0f7ebb2d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19076
+  timestamp: 1672387153578
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+  sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
+  md5: 467ae28215d1aa1c5688bc0c8a184269
+  license: Zlib
+  license_family: Other
+  size: 103525
+  timestamp: 1666595022664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+  sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
+  md5: 7cfbed15f1feee1422810f7830075f53
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 779464
+  timestamp: 1681304594848
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+  sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
+  md5: ed14f9bc6e55220483f1a5a388625a08
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162772
+  timestamp: 1644481986085
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+  sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
+  md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 39253
+  timestamp: 1644551767970
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+  sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
+  md5: b24d13c443a26f65a0778b475a5726bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132830
+  timestamp: 1695717959996
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+  sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
+  md5: 302c3c0696e17eaa62e140e3892644ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 199723
+  timestamp: 1681493196911
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
+  sha256: 29e914b68f261dd564de357888d32ec1511a6fcac9477fe68797289aba4d3e75
+  md5: 288585e412638a51e0288caf690d543b
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6485148
+  timestamp: 1690546982849
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+  sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
+  md5: bf930260f679bc74227bbb18bc36ae82
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 119700
+  timestamp: 1657176150595
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
+  md5: 507dfe693ef429f466d964b599f4af21
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_7
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 18650
+  timestamp: 1659616328001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
+  md5: d0bf43e8df60baae3b3105aa5c42a791
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 21153
+  timestamp: 1659616312367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+  sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
+  md5: 7bd24bf94c24e810aecaaf84a0978e6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 343204
+  timestamp: 1659616543542
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+  sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
+  md5: 092b417c11edcbe6bb9b765ab4a55d23
+  license: MPL-2.0
+  license_family: Other
+  size: 164999
+  timestamp: 1694009822357
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+  sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
+  md5: 708a750d370b9d6875651021e21c4446
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159322
+  timestamp: 1690232335307
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+  sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
+  md5: c35736da3ea26782425e78061268cf5e
+  depends:
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 228713
+  timestamp: 1670423312743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
+  sha256: 9577ff772035cd30e72323edff379dd3df877de00f7f690fd33c8720a5a4bbc9
+  md5: 1130fd979d4f97f511f10b36ff09513d
+  depends:
+  - colorama
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 152728
+  timestamp: 1698129962390
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
+  sha256: e5babe79f8132c4bd44bc05307976f2c5485014ae3129655dddbd3baa8e75e46
+  md5: 093223df00c6ef9db4e7e5aa7bfec00a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40844
+  timestamp: 1683040252786
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+  sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
+  md5: 457a4339a53c033d48ce0c72e5038d2e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30330
+  timestamp: 1672387265402
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+  sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
+  md5: 59ec65fd9e06b81a65cc12986c67d5da
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1939614
+  timestamp: 1668084794027
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+  sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
+  md5: 3489c1a2b73fc957b5a62cc59349e25b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13438
+  timestamp: 1671231196438
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+  sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
+  md5: 3492b96083c1e904cc32d26ea7f1e1d8
+  depends:
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184280
+  timestamp: 1663827558327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+  sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
+  md5: f46d904bc6f220327e70474971341f52
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1220835
+  timestamp: 1694445639066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
+  sha256: 78d66bcb1c979647e9c5473825d4a5e35afa2a0dfeef71cb0d9d9a72fea3c102
+  md5: f2875875bb22ab4704a77bc368a9dc00
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2180195
+  timestamp: 1686783294287
+- conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
+  sha256: 882a0fb257fb07bb47e8127b9ce1f556e319ce4941b74adc94f9849093e11d0d
+  md5: b6ef3c0b6e49ff3d497785c744ce44cc
+  depends:
+  - colorcet
+  - dask-core
+  - datashape
+  - numba
+  - numpy <2.0a0
+  - pandas
+  - param <2.0.0a0
+  - pillow
+  - pyct
+  - python >=3.9,<3.10.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17688679
+  timestamp: 1692373093225
+- conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
+  sha256: a6c8b5d32c52ce71d41c7702265e0bb064c960ab67b88ecbea967595c5e02bc3
+  md5: 112f2f9c7055656ec156fe287c97c0e9
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 104432
+  timestamp: 1613390539244
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+  sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
+  md5: 2ff4fb509788b0e47ac684ba151394d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3289966
+  timestamp: 1690907040646
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+  sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
+  md5: 0f166c3e70541d8bee6e9d0cb60fb66e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16979
+  timestamp: 1649926678161
+- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+  sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
+  md5: ea93d413944ca6a8677eb1b284b136ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27388
+  timestamp: 1668714577678
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
+  sha256: 6b724886465fea70d2ca843fea1d01bcc24d496601587b87c0cb8f2626b259c2
+  md5: 6c11d9242869d6c3b01698f728bd409b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 260567
+  timestamp: 1695734829130
+- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+  sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
+  md5: 9f167d3e45441bc3633c1974b1b0ce8c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 88421
+  timestamp: 1676983264486
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.17.1-py39haa95532_0.tar.bz2
+  sha256: e4e08cbe9311b78ab893105a8f34963b46fce74c67943176cf2309e355dceb80
+  md5: c68d9f0e4a10f15d15d5812093818900
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4580877
+  timestamp: 1693378576619
+- conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.9.0-py39haa95532_0.tar.bz2
+  sha256: fc1399ca859fa3cbb80f94869de2930299b9a4b72b88c29005d32d961738ad01
+  md5: bf03cceaecd14cb1b4c2955bddc1a2a9
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.9.0,<3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3358682
+  timestamp: 1697560035937
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+  sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
+  md5: 582d2c1135a89da757a038de831e7f39
+  license: Intel proprietary
+  size: 11086648
+  timestamp: 1664812389803
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+  sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
+  md5: 30fdefd1541c789c163751291a8faa88
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111448
+  timestamp: 1666125667599
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+  sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
+  md5: a10f07c7a3510272a296f9fed458a4ed
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38098
+  timestamp: 1678997241511
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+  sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
+  md5: fad9cf2023d807da8d44996e9d4399a0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51490
+  timestamp: 1698254721864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+  sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
+  md5: 9834848bd7c7759acf12e78d09388563
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3891030
+  timestamp: 1681801474383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+  sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
+  md5: 1285c8c628bc912c54d0968574c9f4c9
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217232
+  timestamp: 1691122695748
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+  sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
+  md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
+  depends:
+  - backcall
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1279433
+  timestamp: 1694181820978
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+  sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
+  md5: f5fcce35d3f21cdfc5893c5a7a86c651
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1035394
+  timestamp: 1644315567034
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+  sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
+  md5: f67fe3337528e2886f1ac3ab8ac37985
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213110
+  timestamp: 1666908350218
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
+  md5: 81f2c343dc4c65eea39c45383272068f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 407861
+  timestamp: 1677849239400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+  sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
+  md5: bd9526d38a145fe311a8aa36bc11e071
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 152006
+  timestamp: 1676558783570
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+  sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
+  md5: a00e6a62956fde3c4135464353ee8a53
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229158
+  timestamp: 1676330909084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+  sha256: db8335d6531b03c7bdfe789ebacc52631ac6ea4a37700bb3da1f6a53a1acd724
+  md5: ebeba61994cc225ea5f4f42caa511019
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116681
+  timestamp: 1679906658986
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+  sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
+  md5: 5efa1332f7c0a8d9638eda02170c4ce5
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pywinpty
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 413653
+  timestamp: 1671707957673
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+  sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
+  md5: 891fe66a24d8714737b2874985ee1303
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62298
+  timestamp: 1672388166096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
+  md5: c345f51706eef530454f66b794e5e574
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 68189
+  timestamp: 1659616216976
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
+  md5: a7400cfb72042977bc047909ed504ce8
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 33743
+  timestamp: 1659616248209
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
+  md5: 6307f6854754ab5bd7c84e6998385bb1
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 733177
+  timestamp: 1659616279453
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+  sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
+  md5: b812bc5d9c76242e2bb2ac87afe7d39b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 730280
+  timestamp: 1650983734373
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+  sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
+  md5: ba9418df9288a2f031a02fa35b774ce0
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78524
+  timestamp: 1694778314659
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+  sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
+  md5: 6ece7f1a3248169837714d05d7f6ef0a
+  depends:
+  - libiconv >=1.16,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 3513910
+  timestamp: 1692971505729
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+  sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
+  md5: bd7ec244935e83e850a4ff34e8e2e64f
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 513971
+  timestamp: 1692973657152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+  sha256: e1c0e745d9ba36a80773e841d96bf514ad1ceda419e4188aad3c22782af00234
+  md5: f226532e9bb308f20e874c56be6ceefb
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 35788
+  timestamp: 1659783414586
+- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
+  sha256: 2f610fc98b674e4eceeceaadbb94b4153759ee9249759dd27ca48bfdeeef82cf
+  md5: c24005244a08cbfb665f89d8858e0187
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 20824879
+  timestamp: 1697031479623
+- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
+  sha256: 5d4cf89313147e44530dbb3cc6a93247aaded0701bbf8ba3a382ef710abf4cfa
+  md5: 137deeca51202f6b4ac786472a00be55
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 12894
+  timestamp: 1652904101694
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+  sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
+  md5: fb7881e74b59262df0fa4ec981964efc
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1244887
+  timestamp: 1695058550693
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+  sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
+  md5: 6970c7f46b0164cad1d210e7a1419959
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143434
+  timestamp: 1670944902624
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+  sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
+  md5: 1015298551c040c6d5e26eebbae12ef5
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142316
+  timestamp: 1671542240512
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+  sha256: ab5c246c2b271acc1cdd0b9343989c0166681536e569cdbe71618f55d34c7292
+  md5: 7ce68d771cd94c9ff5efefe69d327c9a
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 125122
+  timestamp: 1684280210213
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+  sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
+  md5: 466da740fafef3d6bce114220f0be306
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28510
+  timestamp: 1654508162239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+  sha256: 1687ae122ee7d8b583141fc5014b76d494841dc8083b854449e3d6e0f6bb7019
+  md5: 3697ac26ee3c2d49338dd5b9c6551152
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8080067
+  timestamp: 1698692812610
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+  sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
+  md5: a9fa43e694b25cd49b8b08a9eefd696e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18054
+  timestamp: 1661915903969
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+  sha256: 8aa14047fac6ef8b326900c4bf1a960eaa7a1699c18fdf1e75a59101b610b6df
+  md5: 7e1d4d4700fbea6171d30f1d5ad24226
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53362
+  timestamp: 1659721308586
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+  sha256: 2017814a7cc93dd51c6b7c016e3cdf8fbc32fa20f985638aaff6a6377e9ee086
+  md5: a1a285c56b001c3b5c591bf21eec3149
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19326
+  timestamp: 1659716205153
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+  sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
+  md5: 248c468abced874f0231d3cc23177c77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58488
+  timestamp: 1607359497934
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+  sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
+  md5: 5e763c995ff0c549f68a10bce70fede4
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187489950
+  timestamp: 1691503804820
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+  sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
+  md5: dd0c2ece6a743c373c9b5a5919b4818f
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49744
+  timestamp: 1682975040154
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+  sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
+  md5: 57cea8df7ab85f2a98f64d23afcb1f90
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184956
+  timestamp: 1695058491736
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+  sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
+  md5: 8769cdd201d905069800488fe31574e5
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 256221
+  timestamp: 1695060152521
+- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
+  sha256: b75f28f29d60f2a8726fb0f036e5d01489942abbf77ff1e1cc8e12d7f372b8f3
+  md5: 7a1d29477873480809fd3860f2e69f01
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 24734
+  timestamp: 1607574381373
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+  sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
+  md5: d9781492332e6326f9fca87f3a8efacd
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8135792
+  timestamp: 1681756491399
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+  sha256: 2dd3178d3c570e30b9490ebabfd7bfac806afad8302d3dee0edc619805034397
+  md5: bef9da0f0694c45b6aaa4e6447479eaf
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 118324
+  timestamp: 1650290466135
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+  sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
+  md5: f1d8ce412e115986c403f223b3b47d0f
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 596314
+  timestamp: 1668451106600
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+  sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
+  md5: f96bbef0985d7e66ebf00c0d55e30e23
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 167045
+  timestamp: 1694617078743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+  sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
+  md5: 6e6ba64c8dc5025aeac606404a8df36a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13786
+  timestamp: 1672387480065
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+  sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
+  md5: 4a7a3286484766741f627696697c362c
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 609425
+  timestamp: 1690985686105
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+  sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
+  md5: 4269a1f93882205b90d4b2ae78fc82d5
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22417
+  timestamp: 1668160717305
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
+  sha256: 39b52f5a3e0f71a07358f2bd07a67b950170eabc3398ae968ef523cc0854141a
+  md5: 4baee3e5d96aed7d5d3e28051d6214e5
+  depends:
+  - llvmlite >=0.41.0,<0.42.0a0
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.26
+  - python >=3.9,<3.10.0a0
+  - tbb >=2021.8.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - tbb >=2021.6,<2022
+  - scipy >=1.0
+  - cudatoolkit >=10.2
+  - cuda-python >=11.6
+  - libopenblas !=0.3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4472762
+  timestamp: 1697063760024
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+  sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
+  md5: a18a576b7024cfd6f905c526a786a916
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 135285
+  timestamp: 1696515698492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
+  sha256: 410f3a13eaddcfcfc65cb077dd0b85b7c66853a2447161b9022eed7d9fe472f9
+  md5: c4aae7ab3842a3decd05c5c1d8b916d3
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.25.2 py39h65a83cf_0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12296
+  timestamp: 1691098390179
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
+  sha256: 5a81ff60cc876951905995ea52d3815e38a0d757c6c674acbef1144d8dc746fb
+  md5: 72413d41fe97de5da9b1ce325e544e05
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.25.2 py39h055cbcc_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6857794
+  timestamp: 1691098356763
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
+  md5: ab07e2a27ac08afe3d0b4c0890b8486a
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 2-Clause
+  size: 249316
+  timestamp: 1630094024143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+  sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
+  md5: 73b17037d87b5a58feb34dafc0538f7f
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8058396
+  timestamp: 1695324589828
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+  sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
+  md5: df1d746ba8d5d6ba01ac1373b9b71e1a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73016
+  timestamp: 1693575484990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.0.3-py39h4ed8f06_0.tar.bz2
+  sha256: ed91d8aecd0bceea2e5952d3e3054c80d9a37481ebfea1451cbeda6aed416ca3
+  md5: 915957bfbe46e521c9cafed0bf66c916
+  depends:
+  - bottleneck >=1.3.2
+  - numexpr >=2.7.3
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - pymysql >=1.0.2
+  - beautifulsoup4 >=4.9.3
+  - html5lib >=1.1
+  - fastparquet >=0.6.3
+  - brotli >=0.7.0
+  - blosc >=1.21.0
+  - numba >=0.53.1
+  - pyarrow >=7.0.0
+  - sqlalchemy >=1.4.16
+  - qtpy >=2.2.0
+  - odfpy>=1.4.1
+  - psycopg2 >=2.8.6
+  - pytables >=3.6.1
+  - jinja2 >=3.0.0
+  - pandas-gbq >=0.15.0
+  - gcsfs >=2021.7.0
+  - openpyxl >=3.0.7
+  - lxml >=4.6.3
+  - matplotlib-base >=3.6.1
+  - xarray >=0.21.0
+  - xlsxwriter >=1.4.3
+  - pyxlsb >=1.0.8
+  - tabulate >=0.8.9
+  - scipy >=1.7.1
+  - zstandard >=0.15.2
+  - python-snappy >=0.6.0
+  - pyreadstat >=1.1.2
+  - s3fs >=2021.08.0
+  - pyqt >=5.15.1,<6
+  - fsspec >=2021.7.0
+  - xlrd >=2.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12385096
+  timestamp: 1692216843654
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
+  sha256: 0044e1cc04f3cb7c48209276c35c59c05b87e852c0ac01be468b99f3656445fb
+  md5: ee81d2a2b2c558b43a48fd68c2de1dbf
+  depends:
+  - bleach
+  - bokeh >=3.1.1,<3.3
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.16.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17009718
+  timestamp: 1695148093102
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+  sha256: 2773f47b2d745ab483cf7fcbd5b5e2f7020d45462d32d2ccd5cf232ca13c6f67
+  md5: ca16cd208037bd58d2da267c338da4a4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142229
+  timestamp: 1684915524241
+- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.0-py39haa95532_0.tar.bz2
+  sha256: 7fa6e9e20cb7229eda9e5554fd3235ff11e30de6f87debfdb53181cdfca20817
+  md5: 9123ec9ccc86d35ed1ddec2aa3877968
+  depends:
+  - locket
+  - python >=3.9,<3.10.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35510
+  timestamp: 1693938142283
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+  sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
+  md5: 427c1450bebb632f43bbc8c83006e4cd
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 806931
+  timestamp: 1696580240310
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+  sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
+  md5: 21790cd3e2b8a45c4104aff0a68330d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3001751
+  timestamp: 1697549357662
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+  sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
+  md5: 56f44a1054da2d10777e375838191070
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 32355
+  timestamp: 1692205784293
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+  sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
+  md5: 8a35ad65651086575ce55371f22feda8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91045
+  timestamp: 1659455316472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+  sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
+  md5: 186eb95f816a2eff80c3c7f7d964c7b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 578514
+  timestamp: 1672388155359
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+  sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
+  md5: 47b6cbe6ce9289e47d16900b03596a91
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372807
+  timestamp: 1656431445633
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+  sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
+  md5: 07165c444adc7c7ccc8a345875adc5ef
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48408
+  timestamp: 1675450623287
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+  sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
+  md5: d58e76a31e2f6e7410ba4afd7f385b0d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1877445
+  timestamp: 1684280183367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+  sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
+  md5: 0e5b0fe7debbf558ce97090f6b67cdae
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94633
+  timestamp: 1690225630423
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+  sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
+  md5: 0fde797653e4ab589506121fb1e37555
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157119
+  timestamp: 1661452591647
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+  sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
+  md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 92679
+  timestamp: 1636093365041
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+  sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
+  md5: f870859d4dc7a8d82cf3546bd9035f33
+  depends:
+  - python >=3.9,<3.10.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 54520
+  timestamp: 1605307564142
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+  sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
+  md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
+  depends:
+  - openssl >=3.0.10,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 21172845
+  timestamp: 1694442462066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+  sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
+  md5: 9d99075052265ae3d718582d3b875038
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269964
+  timestamp: 1661376543480
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+  sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
+  md5: fa9074d94236c9b768bfd2c858875b27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 264836
+  timestamp: 1695131770282
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+  sha256: 97243a31c39f4990c0e9d4f2307f2f7fb9421553303923bc105067ec4340bdff
+  md5: 8078c5760f27398eaf1082226647d137
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40145
+  timestamp: 1685031143383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+  sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
+  md5: 3d2841085778006c2e79f9c7300f8b9d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13565975
+  timestamp: 1669937633869
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+  sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
+  md5: 54a4bc0724041dd173088419d6ede2af
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 239062
+  timestamp: 1677611495106
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+  sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
+  md5: f39f84115e228bad4bceaefdd637f022
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 158558
+  timestamp: 1698096358091
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+  sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
+  md5: df398a3a1668fd2a22061764e20ea91d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.4,<4.3.5.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 460913
+  timestamp: 1657616061604
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+  sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
+  md5: 38db77ece9dc76feffb9ef7638e38258
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94397
+  timestamp: 1690400496655
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+  sha256: 3a9a680173f731d515e0587d5b74583cc986b5c1ff62f4cf9e4f7ec268cbb62a
+  md5: 3387bf809e3d32dde3f5cbc3ef49bf47
+  depends:
+  - blas 1.0 mkl
+  - icc_rt >=2022.1.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<1.28
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22779707
+  timestamp: 1696550432358
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+  sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
+  md5: 3e284ae6b48ee30c364ffdc5601610b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1099842
+  timestamp: 1690291374842
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+  sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
+  md5: 993b3886b334bd1f49d34206f21997b4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15998
+  timestamp: 1614030572433
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+  sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
+  md5: 7ac9604ad7564ac0c71bff5db198656f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67012
+  timestamp: 1696347795139
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+  sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
+  md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1311308
+  timestamp: 1681402905668
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+  sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
+  md5: 28b9869d8d3a839918fac4a08f38cbc2
+  depends:
+  - python >=3.9,<3.10.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30546
+  timestamp: 1671752127904
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+  sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
+  md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39590
+  timestamp: 1668168880994
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+  sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
+  md5: 52cdcdb96383c010ca833a7c24b3935b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Tcl/Tk
+  license_family: BSD
+  size: 3690152
+  timestamp: 1654036853710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
+  sha256: 1ee791ecc17e11a31d6cf1553845e7279d9d9a2c7383a2a3e1ae131ddd024b6f
+  md5: b32030d310e0437dc631e5719369004c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102033
+  timestamp: 1667464306003
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+  sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
+  md5: 0e054ab29119cf4c1f778613acf972f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 681780
+  timestamp: 1696937326924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+  sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
+  md5: b6ad839ebba536ad1c3cc58d0e2123f0
+  depends:
+  - colorama
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 143681
+  timestamp: 1679562248929
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+  sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
+  md5: fe78de10019085146f1cc6c94fdc2620
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192822
+  timestamp: 1671143999327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
+  md5: ca5fc3fbdb09b6de068a8b7a8869369f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9208
+  timestamp: 1690298120549
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
+  md5: a86e87a10e5fdff486265e0c675fb99f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57922
+  timestamp: 1690298106990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+  sha256: 8057d3d2a0acd44496de33c5b222063c3f7d06b90c74fbbda45bd18b0b324219
+  md5: 398f8db5bd8cab84b3d85a9d85fa4889
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11362
+  timestamp: 1659769459206
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+  sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
+  md5: 0d31859e0a097aedbcc1627db33b3d92
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188367
+  timestamp: 1698257883295
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+  sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
+  md5: 45ef24c486a484f079faf1dc90e4c7e9
+  depends:
+  - vs2015_runtime >=14.27.29016
+  license: Modified BSD License (3-clause)
+  license_family: BSD
+  size: 8277
+  timestamp: 1605602889180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+  sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
+  md5: 4daaceb6cfc1af6274509081d8018ef1
+  size: 2316783
+  timestamp: 1605602872095
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+  sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
+  md5: 916c16904615c7af3b5d37cb6694f45e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21084
+  timestamp: 1607347371925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+  sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
+  md5: da69e6987fcc757e83a358ceaa13f62b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73391
+  timestamp: 1614804425587
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+  sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
+  md5: 23b9f4634b2e5450be617114f62c74f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 120873
+  timestamp: 1695742300539
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+  sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
+  md5: 120f0b088290fc17bd6618fc10a2f0c4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PUBLIC-DOMAIN
+  size: 34293
+  timestamp: 1605306211299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
+  sha256: 6bdb88cd45b22246e84b7400159ca90faf98ab4e8c1fa2d38d031cfc73c4dc13
+  md5: d6e10641ece06f67561c5f6a676a4b7e
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1794729
+  timestamp: 1689041580510
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+  sha256: a5d2a216d052105fdaad7256f23da3b29f95100d1dc0f29b6ab1f3bbc75e17a9
+  md5: a558f681ebc243f86cde2515c065b62e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48805
+  timestamp: 1675159123654
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+  sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
+  md5: c3f7871e9a33adeccee1b1e8e216918e
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 1332571
+  timestamp: 1683113347814
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+  sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
+  md5: 1ab55f8c4b5292ec360c572120bf823e
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-3.0-or-later
+  size: 9430705
+  timestamp: 1616055773485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+  sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
+  md5: 6875e0bf3828707dc9165d694c0d0a7d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18725
+  timestamp: 1672387612937
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+  sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
+  md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 148931
+  timestamp: 1666595229032
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+  sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
+  md5: 8d6a1e767775fe0eb617cd6e22edc2ff
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1871867
+  timestamp: 1681304638261

--- a/exoplanets/pixi.lock
+++ b/exoplanets/pixi.lock
@@ -7,708 +7,708 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.9.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.1.0-h3826bc1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.21.5-py39he7a7128_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.21.5-py39hf524024_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.6.2-py39had2a1c9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/hvplot-0.9.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libllvm11-11.1.0-h3826bc1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.21.5-py39he7a7128_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.21.5-py39hf524024_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/partd-1.4.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scipy-1.6.2-py39had2a1c9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.17.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.9.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.0.3-py39h3ea8b11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/hvplot-0.9.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-2.0.3-py39h3ea8b11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/partd-1.4.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.17.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.9.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.0.3-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/hvplot-0.9.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.0.3-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.17.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.9.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.0.3-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.17.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/hvplot-0.9.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-2.0.3-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/partd-1.4.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
   sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
   md5: 613805add1c05b538ff06d217252feb7
   depends:
@@ -719,7 +719,7 @@ packages:
   license: BSD-3-Clause
   size: 20810
   timestamp: 1652859733309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
   sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
   md5: 2cf39d906cc321896ffe3e5d33d80c5c
   depends:
@@ -732,7 +732,7 @@ packages:
   license_family: MIT
   size: 162166
   timestamp: 1644463608931
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
   sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
   md5: 2972a84e0e22ae3244bbd2f1eebcf536
   depends:
@@ -743,7 +743,7 @@ packages:
   license_family: MIT
   size: 35352
   timestamp: 1644569715988
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
   sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
   md5: a68016b4b06460def24cb69d932986f3
   depends:
@@ -752,7 +752,7 @@ packages:
   license_family: MIT
   size: 132486
   timestamp: 1695717963702
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
   sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
   md5: 2f6356a2f530314b4059c08c79a3d8bc
   depends:
@@ -762,12 +762,12 @@ packages:
   license_family: MIT
   size: 205868
   timestamp: 1681493113570
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
   sha256: 2d8e75f31f75ea5eb8b9021b4c21eb2846a254a097e06eb68e66fc36a82e1bed
   md5: ae374a11c789a55555f70b29b9eff1f9
   depends:
@@ -783,7 +783,7 @@ packages:
   license_family: BSD
   size: 14430294
   timestamp: 1658136783940
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
   sha256: f84f9caa7eb9d489fd9634419fdf766d39293a5df1104b840fa0cdc5823a5c60
   md5: 922555c0435d6b2537cf8ced534b048c
   depends:
@@ -794,7 +794,7 @@ packages:
   license_family: BSD
   size: 141903
   timestamp: 1648028958291
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
   sha256: 0bbcb6f78eac530c6a084459ffab3238647b266d0c74d695e6e6387dd119cc67
   md5: bdc971e2a9affb5125b68ad708172dab
   depends:
@@ -803,7 +803,7 @@ packages:
   license: MIT
   size: 411301
   timestamp: 1602517685375
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
   sha256: 8c2071f706c2b445dabb781f7f8f008b23a29957468ec6894f050bfb3a2d5bf4
   md5: c203ffc7bbba991c7089d4b383cfd92c
   depends:
@@ -814,14 +814,14 @@ packages:
   license_family: MIT
   size: 357797
   timestamp: 1605539534667
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
   sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
   md5: 3ef00f4c5278b688552efc259c463dc8
   license: MPL-2.0
   license_family: Other
   size: 132731
   timestamp: 1694009767372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
   sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
   md5: d5cb3d97cf5e85ffe5e94037ed8a1169
   depends:
@@ -830,7 +830,7 @@ packages:
   license_family: Other
   size: 159077
   timestamp: 1690232254640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
   sha256: 674707b9c42e65c903c9786ee5a56b4d42aa054f1e75b328db8a2c1bfa368739
   md5: 76ae217198b014b89b267cf41b8251dd
   depends:
@@ -842,7 +842,7 @@ packages:
   license_family: MIT
   size: 231920
   timestamp: 1642701209740
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
   sha256: 762f4506c3e12b2332bd9abea3a2a1966f307b2673be7fd661dc6e316602d18b
   md5: 4b8df5459d1762495428323753438641
   depends:
@@ -851,7 +851,7 @@ packages:
   license_family: BSD
   size: 151844
   timestamp: 1698129872673
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
   sha256: 4fd0207b930fbc936d4b8206117cfa9792aa19bfb320eb08aab6bba10002f9ee
   md5: 7082a1ce8fa314cc2761d2f689c6bb9e
   depends:
@@ -860,7 +860,7 @@ packages:
   license_family: BSD
   size: 40456
   timestamp: 1683040035572
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
   sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
   md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
   depends:
@@ -870,7 +870,7 @@ packages:
   license_family: CC
   size: 1917831
   timestamp: 1668084545510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
   sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
   md5: 13702d3b4b744784e5bd559c7050dd6f
   depends:
@@ -880,7 +880,7 @@ packages:
   license_family: BSD
   size: 12719
   timestamp: 1671231205875
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
   sha256: 821af57c20a85b4e92268fbf65fbaec2f273da5bb21889d9643756ef6e473237
   md5: f57e0f502500ffebdbec081ef61ad1d4
   depends:
@@ -894,7 +894,7 @@ packages:
   license_family: BSD
   size: 2179774
   timestamp: 1694445209134
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
   sha256: 2084ad037e4b67a158facc0d1b21d1de16df7fe758e2bf08f6e48c6b75626cb8
   md5: 8bb8a915dda236f7a2cf790490983445
   depends:
@@ -911,7 +911,7 @@ packages:
   license_family: BSD
   size: 2121644
   timestamp: 1686782977519
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
   sha256: 161644f5f183f5632806cb2cb31890d06a1a575bed7949fe11bc59d3d4344e9d
   md5: 96baa11147a42b64dcaa233a1733b8ee
   depends:
@@ -933,7 +933,7 @@ packages:
   license_family: BSD
   size: 17667549
   timestamp: 1692372404139
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
   sha256: 80188a9729a26e36b027e673f5f30395798eb68f9fe4721f3f33b4d4d2e58285
   md5: 686db307602cbbdc30ca7d62b765578b
   depends:
@@ -945,7 +945,7 @@ packages:
   license_family: BSD
   size: 103488
   timestamp: 1613390248313
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
   sha256: 3a39a2d6f161080c706292e3bf480f62d2444b1d6d67b3d7db50458202ee31f1
   md5: 0524ffca60f845eb392bbb56d56f0ce5
   depends:
@@ -956,7 +956,7 @@ packages:
   license_family: MIT
   size: 2094615
   timestamp: 1637091869922
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
   sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
   md5: 2e6ec51066d825ef3c317abe78d6049e
   depends:
@@ -965,7 +965,7 @@ packages:
   license_family: MIT
   size: 16413
   timestamp: 1649926472708
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
   sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
   md5: b4d923222d45314856b5378cb115214d
   depends:
@@ -974,7 +974,7 @@ packages:
   license_family: BSD
   size: 26728
   timestamp: 1668714462023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
   sha256: 8a121233d0b2cbb2463b67e798739ad2946f38933430a6a7fd1197cc6eab1c99
   md5: d2b24736491290a6c6d0138932111150
   depends:
@@ -984,7 +984,7 @@ packages:
   license: GPL-2.0-only and LicenseRef-FreeType
   size: 965280
   timestamp: 1635422707211
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
   sha256: cfef2f1f3f1aa159f87806b7fa2b65c02c0d6f9bd24ccda833b43246c5095be6
   md5: 394ec1374a92c6fd5f772343934337e4
   depends:
@@ -993,7 +993,7 @@ packages:
   license_family: BSD
   size: 260575
   timestamp: 1695734561396
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
   sha256: 3c8ece1a7257b1d45f8fa25f46504bb709a1923d7175f2996e891366ec434b9d
   md5: 299bf4271d710651a1d71d3795580c2d
   depends:
@@ -1001,7 +1001,7 @@ packages:
   license: MIT
   size: 83592
   timestamp: 1603192039050
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
   sha256: 2d727f8335c59314b521b66d437ca4d51904134473ae503b7b097e239635f209
   md5: 6991e520f353d995023404f6f524d192
   depends:
@@ -1018,7 +1018,7 @@ packages:
   license_family: BSD
   size: 4507274
   timestamp: 1693378095165
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.9.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/hvplot-0.9.0-py39h06a4308_0.tar.bz2
   sha256: ebe76b5a96add44b3befafb39e1b1946306cc0f1f98e8cf1fdfeb134a6fbd2fd
   md5: 74ad1a52b081ba48af21ea48697c06aa
   depends:
@@ -1035,7 +1035,7 @@ packages:
   license_family: BSD
   size: 3310817
   timestamp: 1697560077151
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
   sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
   md5: 9213e0336e3a5216c989cfe52648412e
   depends:
@@ -1044,7 +1044,7 @@ packages:
   license: MIT
   size: 23805906
   timestamp: 1588026213084
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
   sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
   md5: 1eb52f9f45cea2fb9ce27b19f990160e
   depends:
@@ -1053,7 +1053,7 @@ packages:
   license_family: BSD
   size: 110793
   timestamp: 1666125606878
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
   sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
   md5: 126b3c1933b7364ff03f67455b687e99
   depends:
@@ -1063,7 +1063,7 @@ packages:
   license_family: APACHE
   size: 37588
   timestamp: 1678997134023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
   sha256: 1b424413f28b840fc6d4bf467f37e9e405823b1e3b899005df80152d48936d64
   md5: 4aa8bcf74c81cd3600978f791191692a
   constrains:
@@ -1072,7 +1072,7 @@ packages:
   license_family: Proprietary
   size: 9246735
   timestamp: 1634546760713
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
   sha256: b51b2e0dd37a74784ba19db22aded3f4c843b6fddb4a74399f65f36fc018aaa2
   md5: 0d56ab1950f952284b895ac0f78284a7
   depends:
@@ -1092,7 +1092,7 @@ packages:
   license_family: BSD
   size: 203541
   timestamp: 1671488675347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
   sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
   md5: ff47e0be879e817713ce2a9daa76e2b0
   depends:
@@ -1113,7 +1113,7 @@ packages:
   license_family: BSD
   size: 1261116
   timestamp: 1694181530670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
   sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
   md5: 5ef6c6a0d1ac79143c7359d305155167
   depends:
@@ -1123,7 +1123,7 @@ packages:
   license_family: MIT
   size: 1021637
   timestamp: 1644297140650
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
   sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
   md5: eaeb023688f781e7dd89e74310c38195
   depends:
@@ -1133,7 +1133,7 @@ packages:
   license_family: BSD
   size: 211775
   timestamp: 1666908212136
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
   sha256: 85348bfb14db4fea84078d703e766a3c978c5a592a06e41266748826dd59d8ae
   md5: 6e1c0fb5260c590f7ef5235cb3d05863
   depends:
@@ -1142,7 +1142,7 @@ packages:
   license_family: Other
   size: 279884
   timestamp: 1651065953960
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
   sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
   md5: 0d2c3c5edf671b575532d5a3e8bf15fc
   depends:
@@ -1153,7 +1153,7 @@ packages:
   license_family: MIT
   size: 131510
   timestamp: 1676558716852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
   sha256: 92bc012f9eb4ad71158cf4826fd3e125fcebff53b529276a81224acda48be547
   md5: c5fd100e3062e831cbdf33331042f627
   depends:
@@ -1169,7 +1169,7 @@ packages:
   license_family: BSD
   size: 190884
   timestamp: 1650622553813
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
   sha256: 0192bd48cd96c60dc3054d5addd8cdb4a29a218843181318371f79daec8242f8
   md5: d851b401dc13d04e6848bb36e12efc1c
   depends:
@@ -1180,7 +1180,7 @@ packages:
   license_family: BSD
   size: 91534
   timestamp: 1679906652183
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
   sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
   md5: a4beb461f0a60998a090d760b5c6c907
   depends:
@@ -1204,7 +1204,7 @@ packages:
   license_family: BSD
   size: 411564
   timestamp: 1671707702849
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
   sha256: 974df3dc76089be57b327acd6634384def84249003f58678ca1142bb274a75d9
   md5: 81b969d1a00153759b30554a1f11ddfd
   depends:
@@ -1215,7 +1215,7 @@ packages:
   license_family: BSD
   size: 92144
   timestamp: 1653292217019
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -1226,7 +1226,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
   sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
   md5: 9508af80612e4fa1b5d1abb43ca7e63c
   constrains:
@@ -1234,7 +1234,7 @@ packages:
   license: GPL-3.0-only
   size: 749072
   timestamp: 1652971360657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
   sha256: 3b4afe7665dcdb99bd4586a888b85b2e0325f8faecdd31c7780792080ee97872
   md5: 822b5201dde61bc838072dc5b670c88c
   depends:
@@ -1243,7 +1243,7 @@ packages:
   license: Custom
   size: 55183
   timestamp: 1594054267890
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
   sha256: c6fafbe73d2f93b91b6f4b65829f925f52a8f84746a57abd216b39da9ce8c494
   md5: 238f19c803a6ba7bd6dbd6989e03cbf1
   depends:
@@ -1251,13 +1251,13 @@ packages:
   license: GPL
   size: 8496776
   timestamp: 1560112207081
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
   sha256: 83c6fdb30a240fbaa09f5d2e2ae8f092759cb710bc3fa628ccb18934fc237b7f
   md5: 6003e09e8cef9aca91b954abfdd0f39c
   license: GPL
   size: 1336385
   timestamp: 1534628456385
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
   sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
   md5: 3080c2813e6e1d0f8a100a38b5b3456d
   depends:
@@ -1265,7 +1265,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 573231
   timestamp: 1654090775721
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.1.0-h3826bc1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libllvm11-11.1.0-h3826bc1_1.tar.bz2
   sha256: effad2034f13cf7f1cdc51127e3a88123ae957c13f8c95f1817dfd79b5eba779
   md5: c261302f1b58f6b2851f856d230dc947
   depends:
@@ -1276,7 +1276,7 @@ packages:
   license_family: Apache
   size: 29798461
   timestamp: 1647523885063
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
   sha256: bc3e6e79c32ff0ecea601aa108ae9cf4068f69703580e40e266ad4bcc52cff54
   md5: 9cb85601944ca7383b1769bff74b94e8
   depends:
@@ -1285,7 +1285,7 @@ packages:
   license: zlib/libpng
   size: 372914
   timestamp: 1556041895170
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -1293,13 +1293,13 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
   sha256: 43b0bd205f539583c088feb5b8d77b60c83d1df80c2a93dac9f2a1127001b2cf
   md5: 53fa39fdae936e9d07c4b2f5ef361993
   license: GPL3 with runtime exception
   size: 4246257
   timestamp: 1560112223556
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
   sha256: 711ea05b4c35bdafc762a172b01db896b17942f474c2b1a519f91370964bf9bc
   md5: b25d56d33596623a6a4a9d9baaa4f602
   depends:
@@ -1313,7 +1313,7 @@ packages:
   license: HPND
   size: 592974
   timestamp: 1653047881023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
   sha256: 146dbb1e4dbccdd57819e5102a8ca00970b8e33d6c6180e8007db89b184da569
   md5: c566a384259c1d2769852c3bddd81a67
   depends:
@@ -1327,7 +1327,7 @@ packages:
   license_family: BSD
   size: 90150
   timestamp: 1645441199289
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
   sha256: cffb5a063111f7a99a99c74770b23db5dde52325e25a7a46d1903d5ff4a82c88
   md5: eeb1bd66f28bed1956ab989d6eff7ae5
   depends:
@@ -1338,7 +1338,7 @@ packages:
   license_family: BSD
   size: 889956
   timestamp: 1645089138421
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
   sha256: 71f6c4a97014d745c58df52b4dd60ddd75a8508d54fe5b97f42bd1f31cb1c067
   md5: 686e77514ec9f1ef0a6feed374f14d37
   depends:
@@ -1350,7 +1350,7 @@ packages:
   license_family: MIT
   size: 789469
   timestamp: 1653546418059
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
   sha256: ea3355a67c5173f3944f09861043ca66eb7dbeff8f385d13528b3aabc0801d0c
   md5: 66e2aa12181bb2911485bdbe125d24c5
   depends:
@@ -1360,7 +1360,7 @@ packages:
   license: MIT
   size: 584199
   timestamp: 1654075843119
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
   sha256: 497e0a8e555539787dd237dea5d13a0a6061db2cb50ded20daddaf08bbf267cc
   md5: ecc0c3c465bbf6988ebbc6a38e2eeb1c
   depends:
@@ -1372,7 +1372,7 @@ packages:
   license: BSD-2-Clause
   size: 2826845
   timestamp: 1647870510956
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
   sha256: d8cd22ac7f033507549f6a0d078cd273607cb6e8246b0383375a33941969c12c
   md5: 78c7a3a437536ae24d2d7ce15ec400d2
   depends:
@@ -1381,7 +1381,7 @@ packages:
   license_family: BSD
   size: 11065
   timestamp: 1652903210940
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
   sha256: 64b022d706b76c33965a250fdc8c6008443c41bff8ab27bb1df3cb70419576fd
   md5: ec4f05846aacf634df15c389235725cc
   depends:
@@ -1393,7 +1393,7 @@ packages:
   license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
   size: 1538261
   timestamp: 1646624639995
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
   sha256: 2c6a5dda7c510a961bc78e31d4232be5e8e0760c93454f5fd200c379355e0f5e
   md5: f35d4bf2fbb39e334992f6dd39f8721e
   depends:
@@ -1403,7 +1403,7 @@ packages:
   license_family: BSD
   size: 220865
   timestamp: 1627657046002
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
   sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
   md5: 421f82c8274b44660dba629134faa6af
   depends:
@@ -1413,7 +1413,7 @@ packages:
   license_family: BSD
   size: 122221
   timestamp: 1671541990505
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
   sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
   md5: feb0e452205b44ac45d9b5e55c21a3b1
   depends:
@@ -1425,7 +1425,7 @@ packages:
   license_family: BSD
   size: 22819
   timestamp: 1654597913064
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
   sha256: dc51b316ef5dcfb82a9c0afdc40879146ae59516f6cea7db776077783dfd2d76
   md5: b0b6b57c140f026b8806051107336576
   depends:
@@ -1447,7 +1447,7 @@ packages:
   license_family: PSF
   size: 7729454
   timestamp: 1647442028622
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
   sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
   md5: c04ef34af33da4c71bcc99b7ec24d210
   depends:
@@ -1457,7 +1457,7 @@ packages:
   license_family: BSD
   size: 16391
   timestamp: 1662014553452
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
   sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
   md5: f6c734d73e6e3dbc1b62766cf18ff3e4
   depends:
@@ -1467,7 +1467,7 @@ packages:
   license_family: BSD
   size: 58153
   timestamp: 1607364912263
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
   sha256: 7c4ded8b2ef036839f988560848d2c32e1aa4627fd37a32710e42c39f5c61ac2
   md5: bd20f4410b81f327e35ffa0657961146
   depends:
@@ -1478,7 +1478,7 @@ packages:
   license_family: Proprietary
   size: 229783051
   timestamp: 1634547157986
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
   sha256: 5394f5efd53afb2c1b0abf571ce3d9cb684b6c7e255f140ba2acaa703d6113be
   md5: d3cb2bfa63e30153f5527797dcc87280
   depends:
@@ -1490,7 +1490,7 @@ packages:
   license_family: BSD
   size: 63551
   timestamp: 1626176932911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
   sha256: c244d23da2749857a993f84969fd35ffd183ab8f462986df6d33ae0f705fe034
   md5: 9b1f8ccc2488d0e04eb73211e2987483
   depends:
@@ -1504,7 +1504,7 @@ packages:
   license: BSD 3-Clause
   size: 204136
   timestamp: 1634566416657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
   sha256: f81f426f8ef306d636664bc49e7cdd70e2b4306d7c6bcb9c75fe35a45ab2087a
   md5: 77aa1d7f958d36bf227e6ff4a34d2e3d
   depends:
@@ -1518,7 +1518,7 @@ packages:
   license: BSD-3-Clause
   size: 365386
   timestamp: 1626186165897
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
   sha256: 305313d215116fbf13a38f8a321eb635b83294871801ac63e543a59ba7de642c
   md5: e0db8ae050bd0db74f47edc370dbc287
   depends:
@@ -1528,7 +1528,7 @@ packages:
   license_family: BSD
   size: 24480
   timestamp: 1607574279743
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
   sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
   md5: 95c83d71814c504b5504df4f14548f1a
   depends:
@@ -1554,7 +1554,7 @@ packages:
   license_family: BSD
   size: 8257558
   timestamp: 1681756322140
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
   sha256: 1b92d72b083f3350359b8fb2e3b5dc846f49650c9e46a6a74354b1b7f0d42730
   md5: 996babe4314515ddd41008a53cb5d47f
   depends:
@@ -1567,7 +1567,7 @@ packages:
   license_family: BSD
   size: 98791
   timestamp: 1650290544347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
   sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
   md5: 1710a25086c8098367eb36b9d441448b
   depends:
@@ -1595,7 +1595,7 @@ packages:
   license_family: BSD
   size: 569683
   timestamp: 1668450704669
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
   sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
   md5: 385cc9e53404776782502c0fdb08820f
   depends:
@@ -1608,7 +1608,7 @@ packages:
   license_family: BSD
   size: 147046
   timestamp: 1694616899309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
   sha256: 0807371380965e421cb5f3f2a30d790fd5c41db11dbb6d318e14294c3b1741ed
   md5: fca4bd4e3891aebf4fd7daf9b6d0ccfa
   depends:
@@ -1616,7 +1616,7 @@ packages:
   license: Free software (MIT-like)
   size: 1083412
   timestamp: 1636570020698
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
   sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
   md5: bbbcbebc20a4fdcadce398d0ca04f95e
   depends:
@@ -1625,7 +1625,7 @@ packages:
   license_family: BSD
   size: 13109
   timestamp: 1672387143252
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
   sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
   md5: 248ce515640465371927d46f389ed555
   depends:
@@ -1650,7 +1650,7 @@ packages:
   license_family: BSD
   size: 594054
   timestamp: 1690985006481
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
   sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
   md5: 70db71df4ee1cdd38090c0f7b80ba61f
   depends:
@@ -1660,7 +1660,7 @@ packages:
   license_family: BSD
   size: 21944
   timestamp: 1668160644514
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
   sha256: 30f95c6c51ee7ca01801778b1773d8ecb57fcf06e864093f27148e1298517c20
   md5: 1c1f0821f0dd2ece64844f39edcbd03f
   depends:
@@ -1683,7 +1683,7 @@ packages:
   license_family: BSD
   size: 3982289
   timestamp: 1648045822890
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
   sha256: 15a12c8bebcda45c577e61cea412d9aafaa433e39f9e91fd61bbfab66fcee3ab
   md5: 5239d8330e8bd34972fb80918dce79e7
   depends:
@@ -1699,7 +1699,7 @@ packages:
   license_family: MIT
   size: 136437
   timestamp: 1640689905588
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.21.5-py39he7a7128_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.21.5-py39he7a7128_2.tar.bz2
   sha256: 9195828a286d79621f63766a1ac1143de7b862ae17ce5e95ca0c3a5c171868a1
   md5: 2bd04a53d17b21af64f413dc810b3d94
   depends:
@@ -1715,7 +1715,7 @@ packages:
   license: BSD-3-Clause
   size: 9728
   timestamp: 1651566346644
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.21.5-py39hf524024_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.21.5-py39hf524024_2.tar.bz2
   sha256: dbd1301d64a55552a01d74a1928d279646a97158cad3cce7e05548b6fa112338
   md5: e5666032c7865b4977e740e6f069e540
   depends:
@@ -1730,7 +1730,7 @@ packages:
   license: BSD-3-Clause
   size: 6385715
   timestamp: 1651566332949
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
   sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
   md5: 5ad4571eba2479f77a9f849a6ae7724c
   depends:
@@ -1740,7 +1740,7 @@ packages:
   license_family: Apache
   size: 3998613
   timestamp: 1694465071784
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
   sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
   md5: 77a22ed6d0d448c5288d0f695bc9ac49
   depends:
@@ -1749,7 +1749,7 @@ packages:
   license_family: Apache
   size: 72527
   timestamp: 1693575234886
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
   sha256: e7a0abb0f00a94000876f2095f0cf531ad3803ffbd868a780b3f06816b54492c
   md5: 97ef7e1fe923d22a8e2307f3f39a92d5
   depends:
@@ -1765,7 +1765,7 @@ packages:
   license_family: BSD
   size: 13221005
   timestamp: 1650622404234
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
   sha256: 49fdb57b2ed2ce4d6bb7a2c5adec36ba59522518a41fb941f9e39a9f43750cc5
   md5: 871b65444733b7da5823ee0dc9826722
   depends:
@@ -1786,7 +1786,7 @@ packages:
   license_family: BSD
   size: 14712394
   timestamp: 1676379803902
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
   sha256: 64a732ce2661cdb6bd8f9d1484ac10afeb73082b1c2b44728d212e0117d2860e
   md5: ada303f0cf43a4e99cfa7f243b23b681
   depends:
@@ -1795,7 +1795,7 @@ packages:
   license_family: BSD
   size: 141832
   timestamp: 1684915385689
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/partd-1.4.0-py39h06a4308_0.tar.bz2
   sha256: f3e413ea4f7c8d69507bad538470e7edf7b53d1db742d3fd0599d331318560e0
   md5: 325ccf5b485576d640add845a001501e
   depends:
@@ -1809,7 +1809,7 @@ packages:
   license_family: BSD
   size: 35076
   timestamp: 1693937956700
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
   sha256: 8bcb1c67693f42a3170eb77ef4cdbb81b605fdf40816953e69a33a065c101638
   md5: b7689507fb5f879dc766aaa8a4c37351
   depends:
@@ -1828,7 +1828,7 @@ packages:
   license_family: Other
   size: 734566
   timestamp: 1646325095608
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
   sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
   md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
   depends:
@@ -1839,7 +1839,7 @@ packages:
   license_family: MIT
   size: 2674850
   timestamp: 1697548887851
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
   sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
   md5: fe56f0479dd414c846191116366262c3
   depends:
@@ -1848,7 +1848,7 @@ packages:
   license_family: MIT
   size: 31999
   timestamp: 1692205535111
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
   sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
   md5: 44d2a857d13bdf9d99aaac039a249d47
   depends:
@@ -1857,7 +1857,7 @@ packages:
   license_family: Apache
   size: 91137
   timestamp: 1659455142164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
   sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
   md5: eb899a739d9b58dd747f1f6bd52d4cf3
   depends:
@@ -1869,7 +1869,7 @@ packages:
   license_family: BSD
   size: 579771
   timestamp: 1672387338600
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
   sha256: 6973cfe0565ba3b5ad6d1de9e34848fbbadd78b507b2e23e1c079636b8f8f317
   md5: a924535045fb356e23e7a3cc8116b638
   depends:
@@ -1879,7 +1879,7 @@ packages:
   license_family: BSD
   size: 350026
   timestamp: 1612298042840
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
   sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
   md5: f36ecb722522cbe2e3737424edf1b5e1
   depends:
@@ -1891,7 +1891,7 @@ packages:
   license_family: BSD
   size: 29312
   timestamp: 1675441510984
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
   sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
   md5: 6d03295e544251e608a28c8d7c48115e
   depends:
@@ -1900,7 +1900,7 @@ packages:
   license_family: BSD
   size: 1862058
   timestamp: 1684280096752
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
   sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
   md5: 1f09617aecd6f3c2f2e20692c0759f34
   depends:
@@ -1910,7 +1910,7 @@ packages:
   license_family: Apache
   size: 94434
   timestamp: 1690223520097
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
   sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
   md5: ffceed627867508d73af1636ab5ebf42
   depends:
@@ -1919,7 +1919,7 @@ packages:
   license_family: MIT
   size: 156324
   timestamp: 1661452578573
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
   sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
   md5: 0e3341a4fe434167bf74b613eb6afd81
   depends:
@@ -1929,7 +1929,7 @@ packages:
   license_family: MIT
   size: 97194
   timestamp: 1636110999719
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
   sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
   md5: c5f3f7f10ad30f0945e75252615ab6e5
   depends:
@@ -1938,7 +1938,7 @@ packages:
   license_family: BSD
   size: 31331
   timestamp: 1605305847037
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
   sha256: c4b9e332a6f2b7524e8c88e2b39a2568a48e556fd9a44c30759c43611d4d023d
   md5: bb118745c9b08fc5028f45e77f371e68
   depends:
@@ -1958,7 +1958,7 @@ packages:
   license_family: PSF
   size: 24553777
   timestamp: 1654084160832
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
   sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
   md5: 0caa188a695319bdb13f53b0a2b3accc
   depends:
@@ -1967,7 +1967,7 @@ packages:
   license_family: BSD
   size: 264864
   timestamp: 1661371117920
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
   sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
   md5: bcb44ecbea441ee0d4659133d060d71f
   depends:
@@ -1976,7 +1976,7 @@ packages:
   license_family: MIT
   size: 257904
   timestamp: 1695131670290
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
   sha256: e937081facacb141dc2c9cdcced92baa9a2662e4a56100b6041df0b6b7692570
   md5: f3ac39b2349258198a9b3316636fe5d5
   depends:
@@ -1986,7 +1986,7 @@ packages:
   license_family: BSD
   size: 39972
   timestamp: 1685030752528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
   sha256: 3da9cbbd49fac566433748bd245d09d7d5fcd28b04c0397cbbf6d5bb92f5c4a5
   md5: df73a5d2f6e089d51e71e91935a82c65
   depends:
@@ -1997,7 +1997,7 @@ packages:
   license_family: MIT
   size: 183753
   timestamp: 1635775763162
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
   sha256: 26005d191bb15070aad70707ed6493f32678a67978bd3b83d4c9679cab44e717
   md5: 2dc75d5a4ccb64310939c3a72d34ae20
   depends:
@@ -2008,7 +2008,7 @@ packages:
   license_family: BSD
   size: 521583
   timestamp: 1638435042256
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
   sha256: 8c950c69bee969e2c66f88f0dc247b3ab75a753672a88009779d5f5dba193532
   md5: 150ac0eb929bab9dec912797bdfc7b95
   depends:
@@ -2018,7 +2018,7 @@ packages:
   license_family: GPL
   size: 433182
   timestamp: 1642022402894
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
   sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
   md5: c7de00b4ac2778c4e5a7816320d75391
   depends:
@@ -2034,7 +2034,7 @@ packages:
   license_family: Apache
   size: 94028
   timestamp: 1690400356879
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.6.2-py39had2a1c9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/scipy-1.6.2-py39had2a1c9_1.tar.bz2
   sha256: 2cf06019a66fbb0a9df571bac7f0460eb66f60d6b9c37f6a64a6dcddbe2c765f
   md5: 5f18311a95358bb951f98a6d005a862d
   depends:
@@ -2049,7 +2049,7 @@ packages:
   license: BSD 3-Clause
   size: 21512828
   timestamp: 1618856702227
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
   sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
   md5: 1581cafc84708ed9aafaaee1cbbf6065
   depends:
@@ -2058,7 +2058,7 @@ packages:
   license_family: MIT
   size: 1089416
   timestamp: 1690290900608
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
   sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
   md5: e19ffbfb24b990275d24fcea2bd1699b
   depends:
@@ -2067,7 +2067,7 @@ packages:
   license_family: Apache
   size: 15702
   timestamp: 1614030498860
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
   sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
   md5: ca061ce25c0f58628643abec8d6a8244
   depends:
@@ -2076,7 +2076,7 @@ packages:
   license_family: MIT
   size: 66330
   timestamp: 1696347637947
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
   sha256: 87965b7b46d93866d31696a1045216d64f077a06b2900c356aba87e8559c6188
   md5: fa334030245135b37027a882f3c468bf
   depends:
@@ -2087,7 +2087,7 @@ packages:
   license_family: Other
   size: 1561908
   timestamp: 1655328608308
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
   sha256: d4c0f3e57d8df6042151e65a706f8cd76c9325a47548f4ca3c3516e352dd8ca3
   md5: 1decb9dd0e7bcee086d83b8b4ab8c8eb
   depends:
@@ -2096,7 +2096,7 @@ packages:
   license: Apache-2.0
   size: 171277
   timestamp: 1641830509786
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
   sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
   md5: 0e76eab58fe488e91f0aee73f46de031
   depends:
@@ -2107,7 +2107,7 @@ packages:
   license_family: BSD
   size: 29816
   timestamp: 1671751864131
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
   sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
   md5: b413a210eca82fe867e991eed085201b
   depends:
@@ -2117,7 +2117,7 @@ packages:
   license_family: BSD
   size: 38882
   timestamp: 1668168876032
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
   sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
   md5: 5b8375e2092012db69d2123dc0c68630
   depends:
@@ -2127,7 +2127,7 @@ packages:
   license_family: BSD
   size: 3485432
   timestamp: 1654088939579
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
   sha256: 57983e3eb698a3b08b570d5f398d9550cf50b9bf54b2b4728c731ecbc0c89138
   md5: 3ce956b1e1a7f77af6e6127dca987b95
   depends:
@@ -2136,7 +2136,7 @@ packages:
   license_family: BSD
   size: 101246
   timestamp: 1667464172523
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
   sha256: b746e39272888b9cc1a2a711b7b8836f2e26f4457850e43ad18bf0765e21dc3d
   md5: 200e86f8d53aeebf4b7dcfc944fd7920
   depends:
@@ -2146,7 +2146,7 @@ packages:
   license_family: Apache
   size: 661662
   timestamp: 1606942359431
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
   sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
   md5: 67a8320961ff24e92eebb661536e5cf7
   depends:
@@ -2159,7 +2159,7 @@ packages:
   license_family: MOZILLA
   size: 123763
   timestamp: 1679561904852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
   sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
   md5: 0f0b91a158dd3692cbb7a7763b657bfe
   depends:
@@ -2168,7 +2168,7 @@ packages:
   license_family: BSD
   size: 192032
   timestamp: 1671143995098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
   md5: 8515e64a3de7581360d713fe4c0a094e
   depends:
@@ -2178,7 +2178,7 @@ packages:
   license_family: PSF
   size: 8789
   timestamp: 1690297588156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
   md5: 60170012374b2a5007842fa5870d78c5
   depends:
@@ -2187,7 +2187,7 @@ packages:
   license_family: PSF
   size: 57479
   timestamp: 1690297581658
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
   sha256: 870f20a3c006a74b291910f69c3469a409bd21437142864b29cfafeb89ca7c34
   md5: 1b2f1589e3ebc3e0c6ecb38dba93e4ae
   depends:
@@ -2202,7 +2202,7 @@ packages:
   license_family: MIT
   size: 186761
   timestamp: 1686163186447
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
   sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
   md5: f8d03a15b974fc7810d9f54ae849fc8e
   depends:
@@ -2211,7 +2211,7 @@ packages:
   license_family: BSD
   size: 20781
   timestamp: 1607365390528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
   sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
   md5: d7db5d6ce1db80eade8a082ff78bf479
   depends:
@@ -2221,7 +2221,7 @@ packages:
   license_family: BSD
   size: 71044
   timestamp: 1614804011510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
   sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
   md5: b3899f8bda32734727bd5a73df1d7d17
   depends:
@@ -2230,7 +2230,7 @@ packages:
   license_family: MIT
   size: 101520
   timestamp: 1695742037911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
   sha256: d88bdc49a883a944cf1562ebb0a30d0451e28ab05521fc882615e357b105f414
   md5: c150cf16071597fa3977fb81ebb83760
   depends:
@@ -2242,7 +2242,7 @@ packages:
   license_family: Apache
   size: 1787638
   timestamp: 1689041557651
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
   sha256: 2ce360ff98c0ca4537d70c19266b5700810196c54ce2fbaff3b94a969846ee37
   md5: 94cb94dc47405b24b1b5bd0a3275ab59
   depends:
@@ -2251,7 +2251,7 @@ packages:
   license_family: GPL2
   size: 398058
   timestamp: 1651602137803
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -2259,7 +2259,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
   sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
   md5: 567b68192c387b5fc88178425577a0fe
   depends:
@@ -2269,7 +2269,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 366479
   timestamp: 1616055552392
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
   sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
   md5: 3818a9531fe74433c3b7d5144c9a58cc
   depends:
@@ -2278,7 +2278,7 @@ packages:
   license_family: MIT
   size: 18021
   timestamp: 1672387231268
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
   sha256: 513444d83ac2405e898531492ea59f3a95641e357cc39c1048d6fffc1791a16b
   md5: 601d9449c280b9b145dc8c83b6f06119
   depends:
@@ -2287,7 +2287,7 @@ packages:
   license_family: Other
   size: 133595
   timestamp: 1650637720646
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
   sha256: 1c049c23788a00b6f38bdc801245e0e60af98718d4db4c958658bcc67ff158c7
   md5: b1737dfd2e06ad69ec5cfec341e207c6
   depends:
@@ -2300,7 +2300,7 @@ packages:
   license_family: BSD
   size: 827172
   timestamp: 1650622223170
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -2313,7 +2313,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -2323,7 +2323,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
   md5: b2aa5503875aba2f1d88cae9df9a96d5
   depends:
@@ -2332,7 +2332,7 @@ packages:
   license_family: BSD
   size: 13636
   timestamp: 1611930018941
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -2344,7 +2344,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
   sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
   md5: 544adf2677c47c9b9c891aea720678f1
   depends:
@@ -2352,7 +2352,7 @@ packages:
   license: MIT
   size: 33999
   timestamp: 1630003259346
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -2361,7 +2361,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -2370,7 +2370,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -2379,7 +2379,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -2388,7 +2388,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
   sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
   md5: 9eff1a842dbda8d1bae9a2c008b599bc
   depends:
@@ -2399,7 +2399,7 @@ packages:
   license_family: MIT
   size: 690443
   timestamp: 1625743217109
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -2407,7 +2407,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
   sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
   md5: 33624a42ee387bf9918ea98b4e7b31fc
   depends:
@@ -2417,7 +2417,7 @@ packages:
   license_family: BSD
   size: 8173
   timestamp: 1601490751973
-- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
   sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
   md5: 67857cc5e9044770d2b15f9d94a4521d
   depends:
@@ -2426,7 +2426,7 @@ packages:
   license_family: Apache
   size: 12810
   timestamp: 1600445183315
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -2435,7 +2435,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -2444,7 +2444,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -2454,7 +2454,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
   sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
   md5: e68a6f315f41a8d814d833652bf38b9b
   depends:
@@ -2462,7 +2462,7 @@ packages:
   license: MIT
   size: 13374
   timestamp: 1606932077143
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -2470,7 +2470,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -2479,7 +2479,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -2488,7 +2488,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
   sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
   md5: 2eb923cc014094f4acf7f849d67d73f8
   depends:
@@ -2498,7 +2498,7 @@ packages:
   license_family: BSD
   size: 246457
   timestamp: 1626374695070
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
   sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
   md5: 02caf3f47f1d06256068053297355740
   depends:
@@ -2507,7 +2507,7 @@ packages:
   license_family: Apache
   size: 152292
   timestamp: 1690578151230
-- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
   sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
   md5: 41db68b96e114e367c4f120a3b379e59
   depends:
@@ -2516,7 +2516,7 @@ packages:
   license_family: BSD
   size: 19391
   timestamp: 1632406728844
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -2525,7 +2525,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -2537,14 +2537,14 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
   sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
   md5: a815d3bdb160bcc71687f2dda70d3ca4
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 122218
   timestamp: 1680170368293
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -2552,7 +2552,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
   sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
   md5: 447a49f7bad119faa80d7f14aa296c95
   depends:
@@ -2565,7 +2565,7 @@ packages:
   license_family: MIT
   size: 162176
   timestamp: 1644481750133
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
   sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
   md5: 8810f48fe4a4792de0fd3520b502d08b
   depends:
@@ -2574,7 +2574,7 @@ packages:
   license_family: BSD
   size: 10019
   timestamp: 1606859473259
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
   sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
   md5: 00a446b6dfc61af223df4de29fe8ad94
   depends:
@@ -2584,7 +2584,7 @@ packages:
   license_family: MIT
   size: 34305
   timestamp: 1644569782044
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
   sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
   md5: bd92dd8bd5b9d24e632b62a075426e50
   depends:
@@ -2593,7 +2593,7 @@ packages:
   license_family: MIT
   size: 133634
   timestamp: 1695718025321
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
   sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
   md5: f8ae051b591a9027adc16de1be9748f4
   depends:
@@ -2603,12 +2603,12 @@ packages:
   license_family: MIT
   size: 206198
   timestamp: 1681493096349
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
   sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
   md5: e2f3248e2a5009a02f7b8e54f83314ef
   size: 5620
   timestamp: 1528121955725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
   sha256: 65ababd5e7812c35a97ac7d22b0ebe52c144121a3d49528b7d5c19e8453cce4a
   md5: d85c13c017a37e406f6c1e00c1ea4f4f
   depends:
@@ -2626,7 +2626,7 @@ packages:
   license_family: BSD
   size: 6480601
   timestamp: 1690546287900
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
   sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
   md5: 0d79760d544d0bd8acb4adc4ef813418
   depends:
@@ -2636,7 +2636,7 @@ packages:
   license_family: BSD
   size: 137075
   timestamp: 1657175654487
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
   sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
   md5: 31d6d04cd2388d8f19004501271b3545
   depends:
@@ -2646,7 +2646,7 @@ packages:
   license: MIT
   size: 18982
   timestamp: 1659616229395
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
   sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
   md5: caf1073dc2ca5aeb832a2877394eae12
   depends:
@@ -2655,7 +2655,7 @@ packages:
   license: MIT
   size: 18233
   timestamp: 1659616216769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
   sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
   md5: aa1ed20c38af535c8d6a955314759d7b
   depends:
@@ -2664,14 +2664,14 @@ packages:
   license: MIT
   size: 394588
   timestamp: 1659616312678
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
   sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
   md5: ce3588e31faa79f546e0fc6a36c5543c
   license: MPL-2.0
   license_family: Other
   size: 133884
   timestamp: 1694009771475
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
   sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
   md5: 21eb7f53076d0a69513cfd258f6ef63c
   depends:
@@ -2680,7 +2680,7 @@ packages:
   license_family: Other
   size: 159756
   timestamp: 1690232346868
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
   sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
   md5: a40a04d9cda1e665565bc6c832d598b6
   depends:
@@ -2691,7 +2691,7 @@ packages:
   license_family: MIT
   size: 225258
   timestamp: 1670423337502
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
   sha256: b860f45bce9fbb40d024dcd3306e66a52010641091ca8d1fcdde6c4238717c73
   md5: 3c38f3af9c23b26efc2b11d82c95922a
   depends:
@@ -2700,7 +2700,7 @@ packages:
   license_family: BSD
   size: 153013
   timestamp: 1698129937688
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
   sha256: c368e11dc241d1b79b4bb0d9333b353dc1b966b49d145163a0590d88ad88fef2
   md5: 1e62044b8a32d1452e51773ba7a4319c
   depends:
@@ -2709,7 +2709,7 @@ packages:
   license_family: BSD
   size: 41392
   timestamp: 1683040146991
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
   sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
   md5: b2cc5f37f7bb069d061306e7eac2a011
   depends:
@@ -2719,7 +2719,7 @@ packages:
   license_family: CC
   size: 1913396
   timestamp: 1668084575248
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
   sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
   md5: 103d8c039e342115720a84d59c119d46
   depends:
@@ -2729,7 +2729,7 @@ packages:
   license_family: BSD
   size: 13774
   timestamp: 1671231190250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
   sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
   md5: f69f09e0346172f225390d2b3b0d7873
   depends:
@@ -2740,7 +2740,7 @@ packages:
   license_family: BSD
   size: 246628
   timestamp: 1663827484947
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
   sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
   md5: cb80c7ac65b48a737654f371fe31c460
   depends:
@@ -2753,7 +2753,7 @@ packages:
   license_family: BSD
   size: 1307228
   timestamp: 1694212041712
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
   sha256: e80ce32bc86af3e0b67d44bc2c774dde7490443bf6ae4bed7d9c666e3631965f
   md5: ba47d3bdf582bf15e9250bff6b2f6dbd
   depends:
@@ -2770,7 +2770,7 @@ packages:
   license_family: BSD
   size: 2125677
   timestamp: 1686783049768
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
   sha256: 7717c1f0af2af4b28b6d787b32c5e1740f391915c78707d8643e0d516088dbd0
   md5: d7ae4c5cb253fa85c0ce268d2bf9a191
   depends:
@@ -2792,7 +2792,7 @@ packages:
   license_family: BSD
   size: 17679970
   timestamp: 1692372465872
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
   sha256: 40bbbe2ed223829f4a3f91024fa409f1a665ad94294bec2c9e930989bb2b8911
   md5: 4add00dc619c12370af0ed18c76b71f6
   depends:
@@ -2804,7 +2804,7 @@ packages:
   license_family: BSD
   size: 103370
   timestamp: 1613390236788
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
   sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
   md5: 04cbe8f4bc62c34fac9d42d1124059bf
   depends:
@@ -2814,7 +2814,7 @@ packages:
   license_family: MIT
   size: 2052734
   timestamp: 1690905361158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
   sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
   md5: ef0e825982f242085574f502dfff4f6b
   depends:
@@ -2823,7 +2823,7 @@ packages:
   license_family: MIT
   size: 16594
   timestamp: 1649926538106
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
   sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
   md5: 24747a300246c016b3a7f04dabd02d4a
   depends:
@@ -2832,7 +2832,7 @@ packages:
   license_family: BSD
   size: 27709
   timestamp: 1668714497209
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -2842,7 +2842,7 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
   sha256: 95e9a45812b1b4059b973e5e6e131c7c1a8b2ce2dafc5117e7806b1c8f30de27
   md5: bc889aaa846ed177fc5f495c24041acc
   depends:
@@ -2851,14 +2851,14 @@ packages:
   license_family: BSD
   size: 262430
   timestamp: 1695734574609
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
   sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
   md5: e4a732941f74b8062c8bcbfe5c5c2b56
   license: MIT
   license_family: MIT
   size: 80252
   timestamp: 1676983220161
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.17.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.17.1-py39hecd8cb5_0.tar.bz2
   sha256: a3c61a0d72aa6adca1967b894b190cf7d32fe78b0f8c57b855fb1e99c41aa3de
   md5: ec60e644877f1e89c9ce00d487232396
   depends:
@@ -2875,7 +2875,7 @@ packages:
   license_family: BSD
   size: 4610888
   timestamp: 1693378182350
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.9.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/hvplot-0.9.0-py39hecd8cb5_0.tar.bz2
   sha256: 80f22084b7a306946e7bc7756d289703255d3760ff7c23f9b6193bf294feac10
   md5: a6e68eab5b8d73a9048c89189f2a9f21
   depends:
@@ -2892,7 +2892,7 @@ packages:
   license_family: BSD
   size: 3339771
   timestamp: 1697559946138
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
   sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
   md5: f3ce6fe6eb760c236e5f7d04df5faa81
   depends:
@@ -2901,7 +2901,7 @@ packages:
   license_family: MIT
   size: 28138484
   timestamp: 1692293212596
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
   sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
   md5: 6dd72c43fea25b748ec7a9f6c0407e15
   depends:
@@ -2910,7 +2910,7 @@ packages:
   license_family: BSD
   size: 111810
   timestamp: 1666125671024
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
   sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
   md5: 03cdb7e679924b329ecab8f12cb8fc67
   depends:
@@ -2920,7 +2920,7 @@ packages:
   license_family: APACHE
   size: 38813
   timestamp: 1678997212422
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
   sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
   md5: e113c4e6e758dd68faf196586bf5564d
   depends:
@@ -2930,7 +2930,7 @@ packages:
   license_family: Apache
   size: 51873
   timestamp: 1698254765815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
   sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
   md5: 78baea934985ccd9514a366cc7e80ed4
   depends:
@@ -2939,7 +2939,7 @@ packages:
   license_family: Proprietary
   size: 727499
   timestamp: 1681801225190
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
   sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
   md5: da9b63e42f281f7e77b289f4b654b83b
   depends:
@@ -2961,7 +2961,7 @@ packages:
   license_family: BSD
   size: 218436
   timestamp: 1691121840155
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
   sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
   md5: 6a7cb9b49593b29933fa2b503d533a08
   depends:
@@ -2983,7 +2983,7 @@ packages:
   license_family: BSD
   size: 1257205
   timestamp: 1694181720454
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
   sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
   md5: d861ef66f5c0a282d60b65778a9de2f3
   depends:
@@ -2993,7 +2993,7 @@ packages:
   license_family: MIT
   size: 1048450
   timestamp: 1644315332508
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
   sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
   md5: f7e603c965052deed8b789c35855a42f
   depends:
@@ -3003,14 +3003,14 @@ packages:
   license_family: BSD
   size: 213537
   timestamp: 1666908270815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
   sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
   md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
   license: IJG
   license_family: Other
   size: 278924
   timestamp: 1677849185191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
   sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
   md5: a82a17e78f725dcbd71ff8dac6db05c7
   depends:
@@ -3021,7 +3021,7 @@ packages:
   license_family: MIT
   size: 133134
   timestamp: 1676558895333
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
   sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
   md5: ee9270379a9ebdb6297e4b6849b3f7f0
   depends:
@@ -3037,7 +3037,7 @@ packages:
   license_family: BSD
   size: 195479
   timestamp: 1676329410154
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 32b898a97dca7770858ab31294238fde11ab61a84831a52f320e5ee5405a147c
   md5: 926e754b8fad288b583ef2933deae1a5
   depends:
@@ -3048,7 +3048,7 @@ packages:
   license_family: BSD
   size: 92938
   timestamp: 1679906616072
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
   sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
   md5: 7e60995b3119417213e5faedda147499
   depends:
@@ -3072,7 +3072,7 @@ packages:
   license_family: BSD
   size: 403165
   timestamp: 1671707664990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
   sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
   md5: cd470bdb28bb0e8b3535c93a3a6dad07
   depends:
@@ -3082,7 +3082,7 @@ packages:
   license_family: BSD
   size: 65431
   timestamp: 1672387389172
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -3092,7 +3092,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -3101,13 +3101,13 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
   sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
   md5: 7dba7aa5b971febb55281659843586ba
   license: MIT
   size: 65470
   timestamp: 1659616172703
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
   sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
   md5: f78a158983f0bbaba56f34b976bc6dae
   depends:
@@ -3115,7 +3115,7 @@ packages:
   license: MIT
   size: 34189
   timestamp: 1659616189313
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
   sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
   md5: 36a1d885725d3ab4d1fadc5a29f978d2
   depends:
@@ -3123,28 +3123,28 @@ packages:
   license: MIT
   size: 327737
   timestamp: 1659616202869
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
   sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
   md5: 817848d0e2b2808acdc9b3fbbf581726
   license: MIT
   license_family: MIT
   size: 133887
   timestamp: 1683716590737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
   sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
   md5: e458587c87e3f2d20192f4e0738f2c63
   depends:
@@ -3153,7 +3153,7 @@ packages:
   license_family: GPL
   size: 149419
   timestamp: 1665498987619
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
   sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
   md5: 1058b661ec829b2ee3716ee2a5520641
   depends:
@@ -3164,14 +3164,14 @@ packages:
   license_family: GPL
   size: 1917987
   timestamp: 1665498925405
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
   sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
   md5: c90372428e1e4eed4fdcd790979d06b4
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1409377
   timestamp: 1650983531933
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
   sha256: 8176dd9a68815301a24ed51e72f3506f5f77c67a112efa0dd14971f2f3b3c8c1
   md5: b5e470c224000a6bda6f655c155b53e7
   depends:
@@ -3183,7 +3183,7 @@ packages:
   license_family: Apache
   size: 27861431
   timestamp: 1683292881730
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -3192,13 +3192,13 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -3215,7 +3215,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
   sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
   md5: c0b99f8e1c7475f23b1c7b4250b06e1c
   depends:
@@ -3229,7 +3229,7 @@ packages:
   license_family: BSD
   size: 88021
   timestamp: 1694778290062
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
   sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
   md5: 46a65d1fc24013217e06aaf6d65ffcad
   constrains:
@@ -3238,7 +3238,7 @@ packages:
   license_family: BSD
   size: 425478
   timestamp: 1694776947990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
   sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
   md5: 06866415ef22d5322f9bdc9956b59c4d
   depends:
@@ -3250,7 +3250,7 @@ packages:
   license_family: MIT
   size: 678174
   timestamp: 1692970318885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
   sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
   md5: 2edc6c894d6d0321304396e9bd40df94
   depends:
@@ -3260,7 +3260,7 @@ packages:
   license_family: MIT
   size: 241774
   timestamp: 1692973618934
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 0190d3b8d2939f28aa017711cf4147c51a1139da2922cc8420a71562dd99f844
   md5: 454a7f2c4426453f17e995382a4235e4
   depends:
@@ -3270,7 +3270,7 @@ packages:
   license_family: MIT
   size: 36036
   timestamp: 1659783508187
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
   sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
   md5: 5c740b4a18a558de0ccfe601703c423c
   constrains:
@@ -3279,7 +3279,7 @@ packages:
   license_family: Apache
   size: 338738
   timestamp: 1662635677689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
   sha256: fbf3c01a0834c151485b1b2ddf0c83d43703cbea051c6dbcb0d8d41946107670
   md5: 12137025daee35f5c708ca10d0c96e3c
   depends:
@@ -3291,7 +3291,7 @@ packages:
   license_family: BSD
   size: 318622
   timestamp: 1697031357874
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 1dab4daa56408915de3ec270c8b887e7221d48633ea83b0afff61041fc197972
   md5: 1519f9b766f9f894282db8353066e3b2
   depends:
@@ -3300,7 +3300,7 @@ packages:
   license_family: BSD
   size: 11883
   timestamp: 1652903144294
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
   sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
   md5: 8bbd981ca0129d7beeacd3cd7623f714
   depends:
@@ -3311,7 +3311,7 @@ packages:
   license_family: Other
   size: 1491074
   timestamp: 1695058597986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
   sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
   md5: d5f58d056b4bfc67aec30c77035ba889
   depends:
@@ -3320,7 +3320,7 @@ packages:
   license_family: BSD
   size: 182491
   timestamp: 1670944720979
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
   sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
   md5: 1affd16b166571a91feae04baf5fd3da
   depends:
@@ -3330,7 +3330,7 @@ packages:
   license_family: BSD
   size: 123431
   timestamp: 1671542016019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
   sha256: e5fc51472fa0f36abd78baa5b3c9245d6627b0da11188e6a954d73f3f2bca210
   md5: df7c519447affffb594f8c56b028ed33
   depends:
@@ -3340,7 +3340,7 @@ packages:
   license_family: MIT
   size: 107035
   timestamp: 1684279974102
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
   sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
   md5: 3681ebf029211ceab26af6f5d35abf39
   depends:
@@ -3351,7 +3351,7 @@ packages:
   license_family: BSD
   size: 22254
   timestamp: 1654598220251
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
   sha256: 2fd179efa024c92d0d71179a981a781d16c70f5d8c6305e0d678b0c7ae1275ab
   md5: addda7f015d1673f794a23fdb18a3e09
   depends:
@@ -3374,7 +3374,7 @@ packages:
   license_family: PSF
   size: 8182219
   timestamp: 1698692361219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
   sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
   md5: 6eb64ecfcd754502e271db0bb51d2cfd
   depends:
@@ -3384,7 +3384,7 @@ packages:
   license_family: BSD
   size: 17374
   timestamp: 1662014643620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 2312ee5a6343e8495802698d7181f1b619aad7479d96ee253407b324ac884417
   md5: 866960fa48a7ca335941786d4869802a
   depends:
@@ -3394,7 +3394,7 @@ packages:
   license_family: MIT
   size: 53542
   timestamp: 1659721365599
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
   sha256: 37f455814ce242eb65ff80a0402f1bd231a388e6823e6c1e65f60b705c032a2d
   md5: 4c9246c492a64729225aa5b04e12c2d1
   depends:
@@ -3403,7 +3403,7 @@ packages:
   license_family: MIT
   size: 19573
   timestamp: 1659716100178
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
   sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
   md5: 2a4d604717a647ad21af766289cbbfc3
   depends:
@@ -3412,7 +3412,7 @@ packages:
   license_family: BSD
   size: 58057
   timestamp: 1607364912348
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
   sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
   md5: 25051fe272624544652dc6d814c2943a
   depends:
@@ -3425,7 +3425,7 @@ packages:
   license_family: Proprietary
   size: 224420228
   timestamp: 1691503125614
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
   sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
   md5: 37d8cf85a63f7aa9af1624894a7d606d
   depends:
@@ -3435,7 +3435,7 @@ packages:
   license_family: BSD
   size: 48590
   timestamp: 1682969183093
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
   sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
   md5: 0b2aee6666135bbd36b46d6ac66160f7
   depends:
@@ -3448,7 +3448,7 @@ packages:
   license_family: BSD
   size: 210705
   timestamp: 1695058433223
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
   sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
   md5: e22fb55ce380d0ebd44cce3f20d5349e
   depends:
@@ -3462,7 +3462,7 @@ packages:
   license_family: BSD
   size: 296614
   timestamp: 1695060155673
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
   sha256: 5f60ca253f1fea0a1d765f535ff9ca2cf7efba90aea4c9a290d8f50ad11d4f6f
   md5: 97d6ec94e2300030bddf0e5289cd2a84
   depends:
@@ -3472,7 +3472,7 @@ packages:
   license_family: BSD
   size: 24240
   timestamp: 1607574265505
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
   sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
   md5: 1a5d4004e64e3cfb7a2a297b9117c285
   depends:
@@ -3498,7 +3498,7 @@ packages:
   license_family: BSD
   size: 8213832
   timestamp: 1681756573646
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
   sha256: 2975bd1f98ca9ec7354ee378f86f8322ec90f568374776fd90e80c534fbee882
   md5: 798627089e0ccba26695a26d9cb127ec
   depends:
@@ -3511,7 +3511,7 @@ packages:
   license_family: BSD
   size: 99066
   timestamp: 1650308465824
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
   sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
   md5: e572c1264a7af20b486f64ac8c9e1f57
   depends:
@@ -3539,7 +3539,7 @@ packages:
   license_family: BSD
   size: 573356
   timestamp: 1668450732828
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
   sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
   md5: b67569a7c30af9ffa5cde6e4b52ac68b
   depends:
@@ -3552,14 +3552,14 @@ packages:
   license_family: BSD
   size: 148342
   timestamp: 1694616917184
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
   sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
   md5: 97b81f34efbe86c5220fe82eb584fd62
   depends:
@@ -3568,7 +3568,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387288528
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
   sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
   md5: d77862975a9a1cf50acb803be26e83a1
   depends:
@@ -3593,7 +3593,7 @@ packages:
   license_family: BSD
   size: 575365
   timestamp: 1690985052739
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
   sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
   md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
   depends:
@@ -3603,7 +3603,7 @@ packages:
   license_family: BSD
   size: 22858
   timestamp: 1668160618784
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
   sha256: 249efa747726ad61bc1093f33f155f0b7a0fa5b728cb1a6a6bd126458f279c96
   md5: 1cced9a92d68307846cf59c238a42f13
   depends:
@@ -3623,7 +3623,7 @@ packages:
   license_family: BSD
   size: 4431283
   timestamp: 1697057424792
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
   sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
   md5: 185e9c41abb88ee59b52ec0f5f65d506
   depends:
@@ -3637,7 +3637,7 @@ packages:
   license_family: MIT
   size: 138305
   timestamp: 1696515469702
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
   sha256: 361754aae186c6f4f8e5ceadf02b95ae74b47a97eaf1aa37538a7c410fb3ec88
   md5: 02e4a556e3eb2375ec5a75795dd32372
   depends:
@@ -3653,7 +3653,7 @@ packages:
   license_family: BSD
   size: 12847
   timestamp: 1691166007881
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
   sha256: 94d69c58f79dea6d155debef3237f02397ab6c3d042b519ad89fc64d204507d2
   md5: 891a8850c69fd11971e58dfba0c40fcd
   depends:
@@ -3668,7 +3668,7 @@ packages:
   license_family: BSD
   size: 7529822
   timestamp: 1691165972737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
   sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
   md5: 93f5d7b66976154adeda219bea02ba45
   depends:
@@ -3678,7 +3678,7 @@ packages:
   license: BSD 2-Clause
   size: 484257
   timestamp: 1630093862501
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
   sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
   md5: 5e8713ef1215406254988163eaf34020
   depends:
@@ -3687,7 +3687,7 @@ packages:
   license_family: Apache
   size: 4965606
   timestamp: 1695323060401
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
   sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
   md5: 4154929ace2ad6ee16aea815635a6d1f
   depends:
@@ -3696,7 +3696,7 @@ packages:
   license_family: Apache
   size: 73598
   timestamp: 1693575307570
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.0.3-py39h3ea8b11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-2.0.3-py39h3ea8b11_0.tar.bz2
   sha256: 5e8b15af733592f6f6bff1c6eee2b8b808e8252e8a1112dc5a1cafe74016bffd
   md5: 814274b9cdcd2cebab38a7a4d3d6dc48
   depends:
@@ -3744,7 +3744,7 @@ packages:
   license_family: BSD
   size: 13333560
   timestamp: 1692298689692
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
   sha256: 1928d1f3aa777c6fe0b279f400fa417b293527531bbdd3d918cc8e987a680f86
   md5: e8d7a163f2f9dd0f1972e126ee87b586
   depends:
@@ -3768,7 +3768,7 @@ packages:
   license_family: BSD
   size: 17076156
   timestamp: 1695146369755
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
   sha256: 914f1ec8d911083c006c4c2d3b4c0c528e79abba3ae5f1dad825bd896870270d
   md5: 949e0e4c0ce43c92eb52241892230873
   depends:
@@ -3777,7 +3777,7 @@ packages:
   license_family: BSD
   size: 142949
   timestamp: 1684915417020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/partd-1.4.0-py39hecd8cb5_0.tar.bz2
   sha256: 7d7a44349653b73746ec89c3e2ab12288404aaf260bdbdc0fd4f5774adf1f77e
   md5: c541491d1fba2bfa195e6ba89167e9f2
   depends:
@@ -3791,7 +3791,7 @@ packages:
   license_family: BSD
   size: 36127
   timestamp: 1693937967627
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
   sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
   md5: be0a90921f3bf4f0d6950fb786093de7
   depends:
@@ -3810,7 +3810,7 @@ packages:
   license_family: Other
   size: 719901
   timestamp: 1696580194417
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
   sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
   md5: 81ae9ec2d7fcf6934847bff558b619f5
   depends:
@@ -3821,7 +3821,7 @@ packages:
   license_family: MIT
   size: 2672987
   timestamp: 1697548890181
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
   sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
   md5: 1a822c206e2abddc5d6d821721af227f
   depends:
@@ -3830,7 +3830,7 @@ packages:
   license_family: MIT
   size: 33013
   timestamp: 1692205801265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
   sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
   md5: 1604d33dbdb2446c642970f8b354bedb
   depends:
@@ -3839,7 +3839,7 @@ packages:
   license_family: Apache
   size: 91266
   timestamp: 1659455269141
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
   sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
   md5: d1b3bcc35655a3123acb1fa2ad1a8511
   depends:
@@ -3851,7 +3851,7 @@ packages:
   license_family: BSD
   size: 580828
   timestamp: 1672387372015
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
   sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
   md5: 7540555d1fb192236db9a7c5c9d3601c
   depends:
@@ -3860,7 +3860,7 @@ packages:
   license_family: BSD
   size: 365765
   timestamp: 1656431373327
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
   sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
   md5: 0a73533fb6e0dc717ab906a537bc747d
   depends:
@@ -3872,7 +3872,7 @@ packages:
   license_family: BSD
   size: 30803
   timestamp: 1675441638631
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
   sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
   md5: 0a959fbad46ab38ade48dbd358002674
   depends:
@@ -3881,7 +3881,7 @@ packages:
   license_family: BSD
   size: 1864757
   timestamp: 1684280094736
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
   sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
   md5: ea24b5076ef79e4567c5a3f0cb22b470
   depends:
@@ -3891,7 +3891,7 @@ packages:
   license_family: Apache
   size: 95330
   timestamp: 1690223465114
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
   sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
   md5: bcaea6d4a47e9c874becaa700c78dcf7
   depends:
@@ -3900,7 +3900,7 @@ packages:
   license_family: MIT
   size: 157216
   timestamp: 1661452617825
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
   sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
   md5: 707110d1b49cb1864acb0bbaa103591e
   depends:
@@ -3909,7 +3909,7 @@ packages:
   license_family: MIT
   size: 95016
   timestamp: 1636111184034
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
   sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
   md5: 113a443b9c706f9f9c6187c0eaa3de27
   depends:
@@ -3918,7 +3918,7 @@ packages:
   license_family: BSD
   size: 31178
   timestamp: 1605305861851
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
   sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
   md5: 85a8d0001db70e52a479155228cb1fe0
   depends:
@@ -3937,7 +3937,7 @@ packages:
   license_family: PSF
   size: 13324979
   timestamp: 1694439878265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
   sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
   md5: 47c5e22e31ec05a7bc0ce90065a53afd
   depends:
@@ -3946,7 +3946,7 @@ packages:
   license_family: BSD
   size: 265348
   timestamp: 1661368839620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
   sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
   md5: ce9a69e1668aa1e133f2aa6d4e8d346f
   depends:
@@ -3955,7 +3955,7 @@ packages:
   license_family: MIT
   size: 254958
   timestamp: 1695131709704
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 9ee098c09f31fad7ff1856e5ce2619172eaf979997e7a427d1e05cce32c2af00
   md5: cac1d1898b69ae9646dfbf082910635d
   depends:
@@ -3965,7 +3965,7 @@ packages:
   license_family: BSD
   size: 40946
   timestamp: 1685030787453
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
   sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
   md5: 637f08b19dd8fd87347d8c44f9e3e202
   depends:
@@ -3975,7 +3975,7 @@ packages:
   license_family: MIT
   size: 170776
   timestamp: 1698096100056
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
   sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
   md5: 8ce3ac7d8a04e469b566f1b090d01140
   depends:
@@ -3986,7 +3986,7 @@ packages:
   license_family: BSD
   size: 470617
   timestamp: 1657724324011
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -3995,7 +3995,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
   sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
   md5: 6f2d41dd76a03b7f85a1ed49af1763d6
   depends:
@@ -4011,7 +4011,7 @@ packages:
   license_family: Apache
   size: 95100
   timestamp: 1690400262627
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
   sha256: a9755ecbfd42c708945027facfa11a3dc3119778326a0ae5df79f80d7b72afa5
   md5: 839ffa4e775fee9a8bdddabf4a14da43
   depends:
@@ -4028,7 +4028,7 @@ packages:
   license_family: BSD
   size: 24331914
   timestamp: 1696545397632
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
   md5: b0321e6f14e139fc15b1f8b4acb35d2f
   depends:
@@ -4037,7 +4037,7 @@ packages:
   license_family: MIT
   size: 1093966
   timestamp: 1690290944588
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
   sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
   md5: 62b64576a0aa5f6c3fb05f56650d25e1
   depends:
@@ -4046,7 +4046,7 @@ packages:
   license_family: Apache
   size: 15535
   timestamp: 1614030509324
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
   sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
   md5: 15b5595b31e39f08eaacbe2e502d8fb3
   depends:
@@ -4055,7 +4055,7 @@ packages:
   license_family: MIT
   size: 67292
   timestamp: 1696347733587
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
   sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
   md5: 82e4db6a498480a75d53c55bd35b6478
   depends:
@@ -4067,7 +4067,7 @@ packages:
   license_family: Other
   size: 1801397
   timestamp: 1681394807900
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -4076,7 +4076,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
   sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
   md5: 63b957927b9949ccb19da28ec4612706
   depends:
@@ -4087,7 +4087,7 @@ packages:
   license_family: BSD
   size: 30902
   timestamp: 1671751919031
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
   sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
   md5: e346257a2fa8e2cb48c762138a5d009b
   depends:
@@ -4097,7 +4097,7 @@ packages:
   license_family: BSD
   size: 39915
   timestamp: 1668168959656
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
   sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
   md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
   depends:
@@ -4106,7 +4106,7 @@ packages:
   license_family: BSD
   size: 3536231
   timestamp: 1654088937695
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
   sha256: 74fc3a9e308602b3710f8fa671f24f5492571d0c8f7c1b3071dac72671262d45
   md5: e08ead92568f5bd72d5ac7f08f087fee
   depends:
@@ -4115,7 +4115,7 @@ packages:
   license_family: BSD
   size: 102258
   timestamp: 1667464155001
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
   sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
   md5: a1bbf0abfb8c45541122c0eb2feee317
   depends:
@@ -4124,7 +4124,7 @@ packages:
   license_family: Apache
   size: 680464
   timestamp: 1696937112175
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
   sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
   md5: d689f6203c0a9d04fb229c73d7e80a7a
   depends:
@@ -4137,7 +4137,7 @@ packages:
   license_family: MOZILLA
   size: 125145
   timestamp: 1679561909274
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
   md5: 8a292c1ee22489bef2e84bc3aaf4098e
   depends:
@@ -4146,7 +4146,7 @@ packages:
   license_family: BSD
   size: 193141
   timestamp: 1671143985219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
   md5: 8bf0bfffc11ad06a1c94e145941b0ad4
   depends:
@@ -4156,7 +4156,7 @@ packages:
   license_family: PSF
   size: 9651
   timestamp: 1690297655669
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
   md5: 343514a174b3485fde55a73f56398dd7
   depends:
@@ -4165,7 +4165,7 @@ packages:
   license_family: PSF
   size: 58456
   timestamp: 1690297648002
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
   sha256: 11e7401cb6805db7ce22b1f9dd6ba5b7941c92225ce440bed1da0af284bfcad4
   md5: 5c10d68fa5616cdd82ee93ef6e0f038c
   depends:
@@ -4174,7 +4174,7 @@ packages:
   license_family: MIT
   size: 11615
   timestamp: 1659769478980
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
   sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
   md5: c2242e8fd24003a74ddf37416661e06d
   depends:
@@ -4189,7 +4189,7 @@ packages:
   license_family: MIT
   size: 188757
   timestamp: 1698257668273
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
   sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
   md5: 41f445e36b6b6722a9444508eef069f8
   depends:
@@ -4198,7 +4198,7 @@ packages:
   license_family: BSD
   size: 20583
   timestamp: 1607365395045
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
   sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
   md5: 409ee46ed24267b6da6fb32d13e1f21e
   depends:
@@ -4208,7 +4208,7 @@ packages:
   license_family: BSD
   size: 70730
   timestamp: 1614804271285
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
   sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
   md5: eb74e74d8e4fd533c55eb98b7b5e83bc
   depends:
@@ -4217,7 +4217,7 @@ packages:
   license_family: MIT
   size: 102637
   timestamp: 1695742077778
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
   sha256: 9f5a34bef727052f97b1cc387c3a99a60754de99d6e4ab0b2de770d76b64dc0f
   md5: b5ce0421037c626cfcec5b43d83ec420
   depends:
@@ -4229,7 +4229,7 @@ packages:
   license_family: Apache
   size: 1787999
   timestamp: 1689041573350
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
   sha256: cb007615819fd240ea4e343835dfbda3c508a92b5b7158219d30a22d0e67b57c
   md5: bf215e781ac81e0fc433eedee330c54b
   depends:
@@ -4238,20 +4238,20 @@ packages:
   license_family: BSD
   size: 49462
   timestamp: 1675159191191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
   sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
   md5: e243baa546432c8394a8059a44a5a3e4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 419227
   timestamp: 1683113010463
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
   sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
   md5: fe4ac85ee86d3a94ea3a4ebea3779763
   depends:
@@ -4260,7 +4260,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 321797
   timestamp: 1616055526986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
   sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
   md5: bc7073d9d4c0211cc4a1207c98fb765a
   depends:
@@ -4269,14 +4269,14 @@ packages:
   license_family: MIT
   size: 19091
   timestamp: 1672387204865
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
   sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
   md5: 8e495591e369ac161857a72011c0a296
   license: Zlib
   license_family: Other
   size: 120272
   timestamp: 1666595024203
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
   sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
   md5: f1465fbd810b3746c6de6babfd4fe28a
   depends:
@@ -4288,7 +4288,7 @@ packages:
   license_family: BSD
   size: 1023573
   timestamp: 1681304595869
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
   sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
   md5: cf55cb8d7031b30c70c56fc7c782b5c7
   depends:
@@ -4301,7 +4301,7 @@ packages:
   license_family: MIT
   size: 156104
   timestamp: 1644482799136
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
   sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
   md5: 84fce327d9f0d594e86f565e5c21962e
   depends:
@@ -4310,7 +4310,7 @@ packages:
   license_family: BSD
   size: 10183
   timestamp: 1629146082730
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
   sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
   md5: 84b8b998a741b37abf5312c1c03696ef
   depends:
@@ -4320,7 +4320,7 @@ packages:
   license_family: MIT
   size: 33979
   timestamp: 1644845817952
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
   sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
   md5: 77b746931c8f31c3ae393ccb5819d43d
   depends:
@@ -4329,7 +4329,7 @@ packages:
   license_family: MIT
   size: 133628
   timestamp: 1695717890677
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
   sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
   md5: 3df6e8ba34208dea068890e5d5318cc0
   depends:
@@ -4339,12 +4339,12 @@ packages:
   license_family: MIT
   size: 206759
   timestamp: 1681493095987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
   sha256: 4edfceca9958378015a2d5ff705aecb977fa329fdd0caf51cf6a1b6b5506e5ab
   md5: 7404ddc0add9157338d7d4822ac13cb3
   depends:
@@ -4362,7 +4362,7 @@ packages:
   license_family: BSD
   size: 6462121
   timestamp: 1690546176434
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
   sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
   md5: bb55f81435cb6e11d264242274fccd1a
   depends:
@@ -4372,7 +4372,7 @@ packages:
   license_family: BSD
   size: 115947
   timestamp: 1657175645380
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
   md5: f860193e14afc7ef3f5b990a2ac003d2
   depends:
@@ -4382,7 +4382,7 @@ packages:
   license: MIT
   size: 18936
   timestamp: 1659616204016
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
   sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
   md5: ad53130f3fd1f8d3c2fcbb7496e5585d
   depends:
@@ -4391,7 +4391,7 @@ packages:
   license: MIT
   size: 18715
   timestamp: 1659616188888
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
   sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
   md5: 0982c046fb976e9f9fb19e7510187a18
   depends:
@@ -4400,14 +4400,14 @@ packages:
   license: MIT
   size: 366983
   timestamp: 1659616245272
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
   sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
   md5: 31ac2f5596cb7a44adf073c930641c54
   license: MPL-2.0
   license_family: Other
   size: 133817
   timestamp: 1694009762858
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
   sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
   md5: cf1f6c3c34a1e1b9ab22b04233d860f6
   depends:
@@ -4416,7 +4416,7 @@ packages:
   license_family: Other
   size: 159783
   timestamp: 1690232303987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
   sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
   md5: 0eb268e38b5174d471a6e87d9d6102b1
   depends:
@@ -4427,7 +4427,7 @@ packages:
   license_family: MIT
   size: 225355
   timestamp: 1670423312966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
   sha256: 41e76ba21b1279278a039245275eb4ee1f81b38b33cba00ca3575f06be5dc570
   md5: c5170bf12e308fb7f2d1b4b9065f3df7
   depends:
@@ -4436,7 +4436,7 @@ packages:
   license_family: BSD
   size: 153036
   timestamp: 1698129857856
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
   sha256: 36240dde0a1546469f35f3b5509b55384dfd894beb56b3ca929da4b96a2a5f24
   md5: 844539636e4c20ee99e8ceeff5e902bc
   depends:
@@ -4445,7 +4445,7 @@ packages:
   license_family: BSD
   size: 41376
   timestamp: 1683040042906
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
   sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
   md5: e68c94666cd60221b575c3814c89bac0
   depends:
@@ -4455,7 +4455,7 @@ packages:
   license_family: CC
   size: 1946451
   timestamp: 1668084573824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
   sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
   md5: 1773ae2b080cdd55827e27673351551e
   depends:
@@ -4465,7 +4465,7 @@ packages:
   license_family: BSD
   size: 13646
   timestamp: 1671231171682
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
   sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
   md5: 53bfd99ad1b09164d537209cffd98161
   depends:
@@ -4476,7 +4476,7 @@ packages:
   license_family: BSD
   size: 244040
   timestamp: 1663827469853
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
   sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
   md5: b62455043c8eb2434466885b19fed2de
   depends:
@@ -4489,7 +4489,7 @@ packages:
   license_family: BSD
   size: 1399573
   timestamp: 1694211828228
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
   sha256: fb7d12350372a70daa9f476647d04fc213ef9d8f73cbddaf30b40b1b45beef0f
   md5: 34595eb00802934d092b3086d7b4344d
   depends:
@@ -4506,7 +4506,7 @@ packages:
   license_family: BSD
   size: 2124926
   timestamp: 1686783028732
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
   sha256: d366da723fc8baf4d9de0d25688619efe4d1c7abe5407dfb28654c4c9e2ef019
   md5: d4c923ceedacd8d5d18f994feed8dbb8
   depends:
@@ -4528,7 +4528,7 @@ packages:
   license_family: BSD
   size: 17708209
   timestamp: 1692372524993
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
   sha256: 83dbf9755ea887576e3f34adb1c26d418db9aaf3c77dc07f30b58c2221b81c72
   md5: 36246697d07d6709de78abe36b6beae5
   depends:
@@ -4540,7 +4540,7 @@ packages:
   license_family: BSD
   size: 103201
   timestamp: 1629793063728
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
   sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
   md5: eb3cdc0fc210838b9271512a6a1b7c85
   depends:
@@ -4550,7 +4550,7 @@ packages:
   license_family: MIT
   size: 2067708
   timestamp: 1690905319109
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
   sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
   md5: f44b80b9405410e5bde6bfe0b31d5b3f
   depends:
@@ -4559,7 +4559,7 @@ packages:
   license_family: MIT
   size: 15135
   timestamp: 1650293774207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
   sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
   md5: f87027ccce1361d0f82c0edf1a10d53b
   depends:
@@ -4568,7 +4568,7 @@ packages:
   license_family: BSD
   size: 27677
   timestamp: 1668714367519
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -4578,7 +4578,7 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
   sha256: 296371685a5dcd98f5128f11f413e63aa59c1eba60543faf3baaebd445964c5d
   md5: 9817e8ffd3669484c9a7de99a8aceffb
   depends:
@@ -4587,14 +4587,14 @@ packages:
   license_family: BSD
   size: 257844
   timestamp: 1695734566410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
   sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
   md5: 1d0bd7e576c64c059ef781dd319ad82a
   license: MIT
   license_family: MIT
   size: 77591
   timestamp: 1676983230102
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.17.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.17.1-py39hca03da5_0.tar.bz2
   sha256: 024023fcd6a34ff71b3b558f9db00506382edef02e7ae0cf8e49846840d7deb8
   md5: 5598508e6b21861496a578c023958612
   depends:
@@ -4611,7 +4611,7 @@ packages:
   license_family: BSD
   size: 4495882
   timestamp: 1693378262537
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.9.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/hvplot-0.9.0-py39hca03da5_0.tar.bz2
   sha256: 519ed44b20355e914a87c6e6ecfcc6ac47b088b52223d64a052f73d98d5464a9
   md5: 792b62dde64917556bdc4ba7b822c7ae
   depends:
@@ -4628,7 +4628,7 @@ packages:
   license_family: BSD
   size: 3339433
   timestamp: 1697560078781
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
   sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
   md5: 69eb3b03765627b6159ed23cdde78396
   depends:
@@ -4637,7 +4637,7 @@ packages:
   license_family: MIT
   size: 28399065
   timestamp: 1692293207812
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
   sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
   md5: 83366cbd3beb073112f4644a613b6bca
   depends:
@@ -4646,7 +4646,7 @@ packages:
   license_family: BSD
   size: 111933
   timestamp: 1666125627512
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
   sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
   md5: 647c1a2f8460ffa8c670a1915bbdb494
   depends:
@@ -4656,7 +4656,7 @@ packages:
   license_family: APACHE
   size: 38790
   timestamp: 1678997152549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
   sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
   md5: 35e541905426c686ef2ff010a0e502fd
   depends:
@@ -4666,7 +4666,7 @@ packages:
   license_family: Apache
   size: 51860
   timestamp: 1698254731870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
   sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
   md5: 187d7720aedf38759d122cccb4576f2c
   depends:
@@ -4688,7 +4688,7 @@ packages:
   license_family: BSD
   size: 219976
   timestamp: 1691121991680
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
   sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
   md5: e8e7f10741f9cfa737b310b334940441
   depends:
@@ -4710,7 +4710,7 @@ packages:
   license_family: BSD
   size: 1255894
   timestamp: 1694181494549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
   sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
   md5: ff209e75aee17af2e358b0008fbe8c88
   depends:
@@ -4720,7 +4720,7 @@ packages:
   license_family: MIT
   size: 1022945
   timestamp: 1644315931223
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
   sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
   md5: d3e78ef296b3c74910d003bd10b475d6
   depends:
@@ -4730,14 +4730,14 @@ packages:
   license_family: BSD
   size: 213972
   timestamp: 1666908195870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
   sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
   md5: 055e12390b844ea6c6e956ee08a618e8
   license: IJG
   license_family: Other
   size: 273479
   timestamp: 1677849171867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
   sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
   md5: 783e2ad3d36472648c5ccc9f3051db3c
   depends:
@@ -4748,7 +4748,7 @@ packages:
   license_family: MIT
   size: 133077
   timestamp: 1676558732505
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
   sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
   md5: 0677598f673f9729b5990316170a999d
   depends:
@@ -4764,7 +4764,7 @@ packages:
   license_family: BSD
   size: 197129
   timestamp: 1676329661580
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
   sha256: 05f9ca0fdcfdc2e217438be27fead588c843a3aadf7d034467c83216d1e5c214
   md5: 2d648b77d817ba38293c0728711ba8f5
   depends:
@@ -4775,7 +4775,7 @@ packages:
   license_family: BSD
   size: 92852
   timestamp: 1679906632236
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
   sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
   md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
   depends:
@@ -4799,7 +4799,7 @@ packages:
   license_family: BSD
   size: 401319
   timestamp: 1671707682572
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
   sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
   md5: 247558a0aecf1ef7e77a4343761353d6
   depends:
@@ -4809,7 +4809,7 @@ packages:
   license_family: BSD
   size: 64600
   timestamp: 1672387273585
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -4819,7 +4819,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -4828,13 +4828,13 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
   md5: a0f206782751dfffed0dd51302a1bf26
   license: MIT
   size: 68012
   timestamp: 1659616138077
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
   md5: 4c6667cdd061d28e9bc4e4300e4d115e
   depends:
@@ -4842,7 +4842,7 @@ packages:
   license: MIT
   size: 31173
   timestamp: 1659616155596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
   md5: 637e9430e258ddf050623ef2360184d8
   depends:
@@ -4850,28 +4850,28 @@ packages:
   license: MIT
   size: 298430
   timestamp: 1659616172209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
   sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
   md5: 55c615026c0869f8d3ba657f3bd38c43
   license: MIT
   license_family: MIT
   size: 120389
   timestamp: 1683716579036
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -4880,7 +4880,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -4891,14 +4891,14 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
   sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
   md5: a41117710dafe569c9cc4e83f6f29fe3
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1411339
   timestamp: 1650982753977
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
   sha256: d654027daea13ac9db36ab5fd5eff3ad398ec97c1777bf399f3ec680d2c145b9
   md5: baabb1f905054bfea3af8f5768572a34
   depends:
@@ -4910,7 +4910,7 @@ packages:
   license_family: Apache
   size: 26579907
   timestamp: 1683291669565
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -4921,7 +4921,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -4930,13 +4930,13 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -4953,7 +4953,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
   sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
   md5: 98d22e0124d55fae3c37c608dab1dcc9
   depends:
@@ -4967,7 +4967,7 @@ packages:
   license_family: BSD
   size: 89825
   timestamp: 1694778225280
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
   sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
   md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
   constrains:
@@ -4976,7 +4976,7 @@ packages:
   license_family: BSD
   size: 331675
   timestamp: 1694776939192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
   sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
   md5: 0ba499df6755eae5d2d23aa4ab004553
   depends:
@@ -4988,7 +4988,7 @@ packages:
   license_family: MIT
   size: 642657
   timestamp: 1692970217410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
   sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
   md5: c73101971e5ab6a8e8688239884eac81
   depends:
@@ -4998,7 +4998,7 @@ packages:
   license_family: MIT
   size: 241607
   timestamp: 1692973585084
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
   sha256: ac50f846e93e68d50bfdd5589ea8272b987243a64eba8e2e358ef311d7734001
   md5: f19270ff954a41dabbfe36ff0656935b
   depends:
@@ -5008,7 +5008,7 @@ packages:
   license_family: MIT
   size: 36040
   timestamp: 1659783399073
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -5017,7 +5017,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
   sha256: 124d9d4f865f0f66c4e5e7f99dc1110330c9415cc51effc0a5aad4261880c2f0
   md5: c08c14e55ba470513eb6c87206fb7b30
   depends:
@@ -5029,7 +5029,7 @@ packages:
   license_family: BSD
   size: 322413
   timestamp: 1697031210019
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
   sha256: 83e1c11fb14ec2767e833b540a6a0fdbd8641523b5673273914007008e6666da
   md5: 64adbf70a0d4ab82aca039e972821537
   depends:
@@ -5038,7 +5038,7 @@ packages:
   license_family: BSD
   size: 11877
   timestamp: 1652903192510
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
   sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
   md5: 353dff9d5d996c2a260f66381b2ce3e8
   depends:
@@ -5049,7 +5049,7 @@ packages:
   license_family: Other
   size: 1470815
   timestamp: 1695058433965
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
   sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
   md5: c99006da802a97c9aae30da8c16b4820
   depends:
@@ -5058,7 +5058,7 @@ packages:
   license_family: BSD
   size: 176131
   timestamp: 1670944706815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
   sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
   md5: 60bd1e037cda86205526f77405d78129
   depends:
@@ -5068,7 +5068,7 @@ packages:
   license_family: BSD
   size: 123361
   timestamp: 1671541992772
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
   sha256: 2fd690fa3c54a40f0426874ea12e12aad2718263a75708ddd1fa6052a4ad7fb3
   md5: 81388724babfe9c32ea5cdd93633c342
   depends:
@@ -5078,7 +5078,7 @@ packages:
   license_family: MIT
   size: 107072
   timestamp: 1684280007887
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
   sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
   md5: 34dfd76da78de2eae95bbda390d746d6
   depends:
@@ -5089,7 +5089,7 @@ packages:
   license_family: BSD
   size: 23092
   timestamp: 1654598007056
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
   sha256: bf0eeef3c3c713515766ab8b0dc7863413de5b4b227deede97e24d90ca342345
   md5: a7bba1857eb84fb50caea377e60d2050
   depends:
@@ -5111,7 +5111,7 @@ packages:
   license_family: PSF
   size: 8066509
   timestamp: 1698692266161
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
   sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
   md5: eb79dabbeedee7da85dfbfb145bb8a26
   depends:
@@ -5121,7 +5121,7 @@ packages:
   license_family: BSD
   size: 17342
   timestamp: 1662014601345
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
   sha256: f400ad75dd2890627dc948f3e2e6b19732d02c124723eaf22272026993a94d52
   md5: 4a4ffc7365e30b18f4443281839e2718
   depends:
@@ -5131,7 +5131,7 @@ packages:
   license_family: MIT
   size: 53505
   timestamp: 1659721313693
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
   sha256: 20fb26a7ac748ce288cf8483a837b0c33f1348ae738bcdb69cdc2763c7bbf7e1
   md5: a0aebbc6c170ebd8d4710fd70b3db503
   depends:
@@ -5140,7 +5140,7 @@ packages:
   license_family: MIT
   size: 19562
   timestamp: 1659716131839
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
   sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
   md5: 56db7bd3ff511cd839bda081523b3edd
   depends:
@@ -5149,7 +5149,7 @@ packages:
   license_family: BSD
   size: 55683
   timestamp: 1629356128780
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
   sha256: ee936ba5fd196c15c3cb538aef721e54bb4486110ae3ebbfcf78e95e8380efa4
   md5: dde1d9e040e04cbfbc0138898240a660
   depends:
@@ -5159,7 +5159,7 @@ packages:
   license_family: BSD
   size: 23003
   timestamp: 1629282780853
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
   sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
   md5: 176e0dcaeb28393881bacf69941e3889
   depends:
@@ -5185,7 +5185,7 @@ packages:
   license_family: BSD
   size: 8289638
   timestamp: 1681756329011
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
   sha256: afc6f332c51a3defc69e4c4e641988c0556039b9cd42be22f3db5292c88ccf37
   md5: 2bc409c7258160a9b739d08d5ffb5998
   depends:
@@ -5198,7 +5198,7 @@ packages:
   license_family: BSD
   size: 96942
   timestamp: 1650373637069
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
   sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
   md5: 150ea9fadddf21993d3328d3e48a18b7
   depends:
@@ -5226,7 +5226,7 @@ packages:
   license_family: BSD
   size: 557688
   timestamp: 1668450759059
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
   sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
   md5: 37163b32508f9f589b3e6462a3a47546
   depends:
@@ -5239,14 +5239,14 @@ packages:
   license_family: BSD
   size: 148426
   timestamp: 1694616771736
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
   sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
   md5: 6cdf7cbc43bf40e92b056a5576bd0086
   depends:
@@ -5255,7 +5255,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387216468
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
   sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
   md5: 0f05853a139b6cda9c73e9d2707a4976
   depends:
@@ -5280,7 +5280,7 @@ packages:
   license_family: BSD
   size: 590288
   timestamp: 1690984971741
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
   sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
   md5: 7de782e4fb34bfa95ef2fc79d27d727d
   depends:
@@ -5290,7 +5290,7 @@ packages:
   license_family: BSD
   size: 22840
   timestamp: 1668160634885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
   sha256: 0a5a7295f055d2f175528cc895dcb07533df5f0b87f05ac7839ec1af15988218
   md5: 3d8e6925b26ca29486d0b58b30f1f663
   depends:
@@ -5310,7 +5310,7 @@ packages:
   license_family: BSD
   size: 4428704
   timestamp: 1697061454581
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
   sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
   md5: 1a7b23113372c5667dbfe45976b9cc5c
   depends:
@@ -5321,7 +5321,7 @@ packages:
   license_family: MIT
   size: 126357
   timestamp: 1696515322390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
   sha256: 5332b3635fbc1a800b0fe58db7a0e57bb5ef75cbc56a0512c76f01ac7fc7139f
   md5: ab7fbf394a301d25d1bf8cfa76fd917b
   depends:
@@ -5334,7 +5334,7 @@ packages:
   license_family: BSD
   size: 12847
   timestamp: 1691092401334
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
   sha256: 114b5aa7ef0990a615e27116e05dba0e7e78df750e3592aa4b732438f391a394
   md5: 3284c63e9251227322ef9fd9c997f2c7
   depends:
@@ -5348,7 +5348,7 @@ packages:
   license_family: BSD
   size: 6338710
   timestamp: 1691092386069
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
   sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
   md5: 371358a54bbdd307603888348d1a2c6f
   depends:
@@ -5358,7 +5358,7 @@ packages:
   license: BSD 2-Clause
   size: 412248
   timestamp: 1628861367714
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
   sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
   md5: fa15d3b44ae1360ac9b640bbd5b6923c
   depends:
@@ -5367,7 +5367,7 @@ packages:
   license_family: Apache
   size: 4746123
   timestamp: 1695322833432
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
   sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
   md5: d73db95f07a282021efdf8bc09713261
   depends:
@@ -5376,7 +5376,7 @@ packages:
   license_family: Apache
   size: 73620
   timestamp: 1693575195999
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.0.3-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.0.3-py39h46d7db6_0.tar.bz2
   sha256: 185a933dcaceb0fa378e214cd72ea89f9071f0699fa9fabab1535d674531611b
   md5: 1730e1aecea062f0f6e8eb323c164d23
   depends:
@@ -5424,7 +5424,7 @@ packages:
   license_family: BSD
   size: 13122992
   timestamp: 1692291303537
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
   sha256: 4548d2a1bc58cd61e9c9f475a77bac68d9e49d4996c4c891d5ca8ba5ea7552b0
   md5: b4ed079246a55ac8f91b8f8abb713b3b
   depends:
@@ -5448,7 +5448,7 @@ packages:
   license_family: BSD
   size: 17115516
   timestamp: 1695146000246
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
   sha256: 0d64f2438be25524bbfeb8646e4fb3c18499d747398a03ed15d41b350b03e001
   md5: 6a4908a5c9f7b3f17f09ebc34b1b691c
   depends:
@@ -5457,7 +5457,7 @@ packages:
   license_family: BSD
   size: 142857
   timestamp: 1684915417403
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.0-py39hca03da5_0.tar.bz2
   sha256: 17228498dd86fc52909ef03da734ae4334f704a52089ed629b739ed964a83062
   md5: 308b356f70bb265a2c3898931401d8e2
   depends:
@@ -5471,7 +5471,7 @@ packages:
   license_family: BSD
   size: 36176
   timestamp: 1693937934593
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
   sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
   md5: 6e01c592ae3b8ff2d12cae76f2f4276b
   depends:
@@ -5490,7 +5490,7 @@ packages:
   license_family: Other
   size: 715239
   timestamp: 1696580071596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
   sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
   md5: 9fb8f460c130d56caf33c6bbe46fbe8a
   depends:
@@ -5501,7 +5501,7 @@ packages:
   license_family: MIT
   size: 2678841
   timestamp: 1697548790931
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
   sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
   md5: 390b8c3cd74281abecdbfd51476922f9
   depends:
@@ -5510,7 +5510,7 @@ packages:
   license_family: MIT
   size: 33033
   timestamp: 1692205747301
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
   sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
   md5: 7896828fb3565fefad43f980d50c8723
   depends:
@@ -5519,7 +5519,7 @@ packages:
   license_family: Apache
   size: 91190
   timestamp: 1659455206354
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
   sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
   md5: d934c74eb66d01af0f45f0881f4bab77
   depends:
@@ -5531,7 +5531,7 @@ packages:
   license_family: BSD
   size: 580588
   timestamp: 1672387390426
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
   sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
   md5: 9858166e5ffb624c8b9d281f4000d725
   depends:
@@ -5540,7 +5540,7 @@ packages:
   license_family: BSD
   size: 367167
   timestamp: 1656431368885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
   sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
   md5: 4d2b45c6be8221e6a3e44c2d5838426f
   depends:
@@ -5552,7 +5552,7 @@ packages:
   license_family: BSD
   size: 30843
   timestamp: 1675441531640
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
   sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
   md5: 02521df4e2e79f75faa9cbb3560ab1dd
   depends:
@@ -5561,7 +5561,7 @@ packages:
   license_family: BSD
   size: 1861763
   timestamp: 1684280026169
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
   sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
   md5: bdebe59bffc7adbad83fdcd9d429a5f5
   depends:
@@ -5571,7 +5571,7 @@ packages:
   license_family: Apache
   size: 95234
   timestamp: 1690223494699
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
   sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
   md5: d716e5c9b5eec45ce1df8eb52cab817a
   depends:
@@ -5580,7 +5580,7 @@ packages:
   license_family: MIT
   size: 157408
   timestamp: 1661452601692
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
   sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
   md5: 1907629863ed8e7c35ead232dae7693f
   depends:
@@ -5589,7 +5589,7 @@ packages:
   license_family: MIT
   size: 91636
   timestamp: 1628941083263
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
   sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
   md5: 847b9bddf2a86e1609c0d53bbc23ea79
   depends:
@@ -5598,7 +5598,7 @@ packages:
   license_family: BSD
   size: 27378
   timestamp: 1626781391140
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
   sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
   md5: 18aa18bd0d260605923877921d26cc74
   depends:
@@ -5617,7 +5617,7 @@ packages:
   license_family: PSF
   size: 13194025
   timestamp: 1694438901368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
   sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
   md5: 45642a99c83e7aed74d1ffab1f20145b
   depends:
@@ -5626,7 +5626,7 @@ packages:
   license_family: BSD
   size: 266647
   timestamp: 1661368655993
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
   sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
   md5: fec748525144049a2fc7f52f9755232c
   depends:
@@ -5635,7 +5635,7 @@ packages:
   license_family: MIT
   size: 257235
   timestamp: 1695131702047
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
   sha256: 960192a143672e9c1d6fe4027af448512d91eee7501e5c245c21b865cf8bf429
   md5: 76d491244218505f071ba56a308673df
   depends:
@@ -5645,7 +5645,7 @@ packages:
   license_family: BSD
   size: 40950
   timestamp: 1685030774581
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
   sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
   md5: 3445d25415998c807efbe64d3a7e03c8
   depends:
@@ -5655,7 +5655,7 @@ packages:
   license_family: MIT
   size: 167068
   timestamp: 1698096118071
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
   sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
   md5: e6e92da28e9b0e428ed4b7df417bec25
   depends:
@@ -5666,7 +5666,7 @@ packages:
   license_family: BSD
   size: 472418
   timestamp: 1657724315435
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -5675,7 +5675,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
   sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
   md5: dba22515f36d3c266de5896350813ea2
   depends:
@@ -5691,7 +5691,7 @@ packages:
   license_family: Apache
   size: 95103
   timestamp: 1690400315537
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
   sha256: c35449c0ca64d0d6a23c019b6eba188f546e42379857cbc4240bbdddee1159d3
   md5: 61cb82346e21710f3e0645096cda4e12
   depends:
@@ -5707,7 +5707,7 @@ packages:
   license_family: BSD
   size: 22859180
   timestamp: 1696543469561
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
   sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
   md5: 3cd7eb43e285faba76faf67667e26b00
   depends:
@@ -5716,7 +5716,7 @@ packages:
   license_family: MIT
   size: 1093916
   timestamp: 1690290951258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
   sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
   md5: c5e9aef0d6895de1c927e9d796cd7cd3
   depends:
@@ -5725,7 +5725,7 @@ packages:
   license_family: Apache
   size: 15691
   timestamp: 1629145910454
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
   sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
   md5: 0f7c229e774146ffc4e29dedf75372bf
   depends:
@@ -5734,7 +5734,7 @@ packages:
   license_family: MIT
   size: 67279
   timestamp: 1696347632563
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
   sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
   md5: 2302a79a045f152e183a52a81adfba62
   depends:
@@ -5746,7 +5746,7 @@ packages:
   license_family: Other
   size: 1674163
   timestamp: 1681394762218
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
   sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
   md5: ae58720a18a2ed15eae214ad7a10d1b5
   depends:
@@ -5755,7 +5755,7 @@ packages:
   license_family: Apache
   size: 140125
   timestamp: 1680167256603
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
   sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
   md5: 4ae67163d55cf9df83d4027ebc38c501
   depends:
@@ -5766,7 +5766,7 @@ packages:
   license_family: BSD
   size: 30894
   timestamp: 1671751931536
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
   sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
   md5: dbb5c0cddb6661a89afee647fd3dc01e
   depends:
@@ -5776,7 +5776,7 @@ packages:
   license_family: BSD
   size: 39875
   timestamp: 1668168874870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
   sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
   md5: 667e60c8b407d73cbba40f44901f4f00
   depends:
@@ -5785,7 +5785,7 @@ packages:
   license_family: BSD
   size: 3412693
   timestamp: 1654088929697
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
   sha256: 065cf1b08faf1d28aa348d569f2266d8b33b22ba424312c7ec959be95f217646
   md5: 20370dbc92a9262e6fc8c82208f74ff2
   depends:
@@ -5794,7 +5794,7 @@ packages:
   license_family: BSD
   size: 102259
   timestamp: 1667464137769
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
   sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
   md5: 884f788a5f6a664c9b79f7a4a60362d0
   depends:
@@ -5803,7 +5803,7 @@ packages:
   license_family: Apache
   size: 680561
   timestamp: 1696937004165
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
   sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
   md5: 639a4f489af172c866c18442948e5874
   depends:
@@ -5816,7 +5816,7 @@ packages:
   license_family: MOZILLA
   size: 125170
   timestamp: 1679561942932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
   sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
   md5: e5b90eba83fddba6d7aa6072b5bf7c91
   depends:
@@ -5825,7 +5825,7 @@ packages:
   license_family: BSD
   size: 193017
   timestamp: 1671143921826
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
   md5: 644ef8830437070f60efcfcd6a987198
   depends:
@@ -5835,7 +5835,7 @@ packages:
   license_family: PSF
   size: 9670
   timestamp: 1690297532002
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
   md5: a902a833bb186a2f1a4b2b89b1195136
   depends:
@@ -5844,7 +5844,7 @@ packages:
   license_family: PSF
   size: 58466
   timestamp: 1690297524418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
   sha256: 536045a8a172c651fd306c285a6d7409775f018dac944f2124c538ccfb195e28
   md5: d4dc6cdf0812191b9ec78b35b4fdf3e0
   depends:
@@ -5853,7 +5853,7 @@ packages:
   license_family: MIT
   size: 11593
   timestamp: 1659769477205
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
   sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
   md5: f3f1d2c1028dad2f11ff950a15c99dbf
   depends:
@@ -5868,7 +5868,7 @@ packages:
   license_family: MIT
   size: 188640
   timestamp: 1698257577209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
   sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
   md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
   depends:
@@ -5877,7 +5877,7 @@ packages:
   license_family: BSD
   size: 20091
   timestamp: 1629144441130
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
   sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
   md5: 3089c63bf8f4d0423e1a287da286d83e
   depends:
@@ -5887,7 +5887,7 @@ packages:
   license_family: BSD
   size: 70923
   timestamp: 1629357115820
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
   sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
   md5: 5886b30b312445471268444f41f39dc7
   depends:
@@ -5896,7 +5896,7 @@ packages:
   license_family: MIT
   size: 102583
   timestamp: 1695741976083
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
   sha256: 300b9e4cfc9d01fa4d537060b2867f3cb89f22f932992fc2427e00dda050d55b
   md5: 768c174577b786b99f8b46c4789b36a2
   depends:
@@ -5908,7 +5908,7 @@ packages:
   license_family: Apache
   size: 1800646
   timestamp: 1689041569828
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
   sha256: 105e39d3eb51b47c7244b3379c0133ab7051966664f52835453b14509215b159
   md5: ed20012c2cd99ffd04cca9929e0bc061
   depends:
@@ -5917,20 +5917,20 @@ packages:
   license_family: BSD
   size: 49775
   timestamp: 1675159079039
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
   sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
   md5: 2e75ad6a09c308268192efe03cc9ebf4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 411778
   timestamp: 1683113019715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
   sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
   md5: 30f666bf97c26587c5d2f68cc5f330ab
   depends:
@@ -5939,7 +5939,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 316901
   timestamp: 1629287855861
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
   sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
   md5: 584e591d36dcd5ba5c45404f0f7ebb2d
   depends:
@@ -5948,14 +5948,14 @@ packages:
   license_family: MIT
   size: 19076
   timestamp: 1672387153578
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
   sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
   md5: 467ae28215d1aa1c5688bc0c8a184269
   license: Zlib
   license_family: Other
   size: 103525
   timestamp: 1666595022664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
   sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
   md5: 7cfbed15f1feee1422810f7830075f53
   depends:
@@ -5967,7 +5967,7 @@ packages:
   license_family: BSD
   size: 779464
   timestamp: 1681304594848
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
   sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
   md5: ed14f9bc6e55220483f1a5a388625a08
   depends:
@@ -5980,7 +5980,7 @@ packages:
   license_family: MIT
   size: 162772
   timestamp: 1644481986085
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
   sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
   md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
   depends:
@@ -5992,7 +5992,7 @@ packages:
   license_family: MIT
   size: 39253
   timestamp: 1644551767970
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
   sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
   md5: b24d13c443a26f65a0778b475a5726bc
   depends:
@@ -6001,7 +6001,7 @@ packages:
   license_family: MIT
   size: 132830
   timestamp: 1695717959996
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
   sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
   md5: 302c3c0696e17eaa62e140e3892644ae
   depends:
@@ -6011,12 +6011,12 @@ packages:
   license_family: MIT
   size: 199723
   timestamp: 1681493196911
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
   sha256: 29e914b68f261dd564de357888d32ec1511a6fcac9477fe68797289aba4d3e75
   md5: 288585e412638a51e0288caf690d543b
   depends:
@@ -6034,7 +6034,7 @@ packages:
   license_family: BSD
   size: 6485148
   timestamp: 1690546982849
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
   sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
   md5: bf930260f679bc74227bbb18bc36ae82
   depends:
@@ -6046,7 +6046,7 @@ packages:
   license_family: BSD
   size: 119700
   timestamp: 1657176150595
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
   md5: 507dfe693ef429f466d964b599f4af21
   depends:
@@ -6058,7 +6058,7 @@ packages:
   license: MIT
   size: 18650
   timestamp: 1659616328001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
   md5: d0bf43e8df60baae3b3105aa5c42a791
   depends:
@@ -6069,7 +6069,7 @@ packages:
   license: MIT
   size: 21153
   timestamp: 1659616312367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
   sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
   md5: 7bd24bf94c24e810aecaaf84a0978e6f
   depends:
@@ -6079,14 +6079,14 @@ packages:
   license: MIT
   size: 343204
   timestamp: 1659616543542
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
   sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
   md5: 092b417c11edcbe6bb9b765ab4a55d23
   license: MPL-2.0
   license_family: Other
   size: 164999
   timestamp: 1694009822357
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
   sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
   md5: 708a750d370b9d6875651021e21c4446
   depends:
@@ -6095,7 +6095,7 @@ packages:
   license_family: Other
   size: 159322
   timestamp: 1690232335307
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
   sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
   md5: c35736da3ea26782425e78061268cf5e
   depends:
@@ -6107,7 +6107,7 @@ packages:
   license_family: MIT
   size: 228713
   timestamp: 1670423312743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
   sha256: 9577ff772035cd30e72323edff379dd3df877de00f7f690fd33c8720a5a4bbc9
   md5: 1130fd979d4f97f511f10b36ff09513d
   depends:
@@ -6117,7 +6117,7 @@ packages:
   license_family: BSD
   size: 152728
   timestamp: 1698129962390
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
   sha256: e5babe79f8132c4bd44bc05307976f2c5485014ae3129655dddbd3baa8e75e46
   md5: 093223df00c6ef9db4e7e5aa7bfec00a
   depends:
@@ -6126,7 +6126,7 @@ packages:
   license_family: BSD
   size: 40844
   timestamp: 1683040252786
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
   sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
   md5: 457a4339a53c033d48ce0c72e5038d2e
   depends:
@@ -6135,7 +6135,7 @@ packages:
   license_family: BSD
   size: 30330
   timestamp: 1672387265402
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
   sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
   md5: 59ec65fd9e06b81a65cc12986c67d5da
   depends:
@@ -6145,7 +6145,7 @@ packages:
   license_family: CC
   size: 1939614
   timestamp: 1668084794027
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
   sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
   md5: 3489c1a2b73fc957b5a62cc59349e25b
   depends:
@@ -6155,7 +6155,7 @@ packages:
   license_family: BSD
   size: 13438
   timestamp: 1671231196438
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
   sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
   md5: 3492b96083c1e904cc32d26ea7f1e1d8
   depends:
@@ -6167,7 +6167,7 @@ packages:
   license_family: BSD
   size: 184280
   timestamp: 1663827558327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
   sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
   md5: f46d904bc6f220327e70474971341f52
   depends:
@@ -6182,7 +6182,7 @@ packages:
   license_family: BSD
   size: 1220835
   timestamp: 1694445639066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
   sha256: 78d66bcb1c979647e9c5473825d4a5e35afa2a0dfeef71cb0d9d9a72fea3c102
   md5: f2875875bb22ab4704a77bc368a9dc00
   depends:
@@ -6199,7 +6199,7 @@ packages:
   license_family: BSD
   size: 2180195
   timestamp: 1686783294287
-- conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
   sha256: 882a0fb257fb07bb47e8127b9ce1f556e319ce4941b74adc94f9849093e11d0d
   md5: b6ef3c0b6e49ff3d497785c744ce44cc
   depends:
@@ -6221,7 +6221,7 @@ packages:
   license_family: BSD
   size: 17688679
   timestamp: 1692373093225
-- conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
   sha256: a6c8b5d32c52ce71d41c7702265e0bb064c960ab67b88ecbea967595c5e02bc3
   md5: 112f2f9c7055656ec156fe287c97c0e9
   depends:
@@ -6233,7 +6233,7 @@ packages:
   license_family: BSD
   size: 104432
   timestamp: 1613390539244
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
   sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
   md5: 2ff4fb509788b0e47ac684ba151394d0
   depends:
@@ -6244,7 +6244,7 @@ packages:
   license_family: MIT
   size: 3289966
   timestamp: 1690907040646
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
   sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
   md5: 0f166c3e70541d8bee6e9d0cb60fb66e
   depends:
@@ -6253,7 +6253,7 @@ packages:
   license_family: MIT
   size: 16979
   timestamp: 1649926678161
-- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
   sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
   md5: ea93d413944ca6a8677eb1b284b136ae
   depends:
@@ -6262,7 +6262,7 @@ packages:
   license_family: BSD
   size: 27388
   timestamp: 1668714577678
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -6274,7 +6274,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
   sha256: 6b724886465fea70d2ca843fea1d01bcc24d496601587b87c0cb8f2626b259c2
   md5: 6c11d9242869d6c3b01698f728bd409b
   depends:
@@ -6283,7 +6283,7 @@ packages:
   license_family: BSD
   size: 260567
   timestamp: 1695734829130
-- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
   sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
   md5: 9f167d3e45441bc3633c1974b1b0ce8c
   depends:
@@ -6293,7 +6293,7 @@ packages:
   license_family: MIT
   size: 88421
   timestamp: 1676983264486
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.17.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.17.1-py39haa95532_0.tar.bz2
   sha256: e4e08cbe9311b78ab893105a8f34963b46fce74c67943176cf2309e355dceb80
   md5: c68d9f0e4a10f15d15d5812093818900
   depends:
@@ -6310,7 +6310,7 @@ packages:
   license_family: BSD
   size: 4580877
   timestamp: 1693378576619
-- conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.9.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/hvplot-0.9.0-py39haa95532_0.tar.bz2
   sha256: fc1399ca859fa3cbb80f94869de2930299b9a4b72b88c29005d32d961738ad01
   md5: bf03cceaecd14cb1b4c2955bddc1a2a9
   depends:
@@ -6327,13 +6327,13 @@ packages:
   license_family: BSD
   size: 3358682
   timestamp: 1697560035937
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
   sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
   md5: 582d2c1135a89da757a038de831e7f39
   license: Intel proprietary
   size: 11086648
   timestamp: 1664812389803
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
   sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
   md5: 30fdefd1541c789c163751291a8faa88
   depends:
@@ -6342,7 +6342,7 @@ packages:
   license_family: BSD
   size: 111448
   timestamp: 1666125667599
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
   sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
   md5: a10f07c7a3510272a296f9fed458a4ed
   depends:
@@ -6352,7 +6352,7 @@ packages:
   license_family: APACHE
   size: 38098
   timestamp: 1678997241511
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
   sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
   md5: fad9cf2023d807da8d44996e9d4399a0
   depends:
@@ -6362,7 +6362,7 @@ packages:
   license_family: Apache
   size: 51490
   timestamp: 1698254721864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
   sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
   md5: 9834848bd7c7759acf12e78d09388563
   depends:
@@ -6372,7 +6372,7 @@ packages:
   license_family: Proprietary
   size: 3891030
   timestamp: 1681801474383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
   sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
   md5: 1285c8c628bc912c54d0968574c9f4c9
   depends:
@@ -6393,7 +6393,7 @@ packages:
   license_family: BSD
   size: 217232
   timestamp: 1691122695748
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
   sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
   md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
   depends:
@@ -6414,7 +6414,7 @@ packages:
   license_family: BSD
   size: 1279433
   timestamp: 1694181820978
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
   sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
   md5: f5fcce35d3f21cdfc5893c5a7a86c651
   depends:
@@ -6424,7 +6424,7 @@ packages:
   license_family: MIT
   size: 1035394
   timestamp: 1644315567034
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
   sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
   md5: f67fe3337528e2886f1ac3ab8ac37985
   depends:
@@ -6434,7 +6434,7 @@ packages:
   license_family: BSD
   size: 213110
   timestamp: 1666908350218
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
   sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
   md5: 81f2c343dc4c65eea39c45383272068f
   depends:
@@ -6444,7 +6444,7 @@ packages:
   license_family: Other
   size: 407861
   timestamp: 1677849239400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
   sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
   md5: bd9526d38a145fe311a8aa36bc11e071
   depends:
@@ -6455,7 +6455,7 @@ packages:
   license_family: MIT
   size: 152006
   timestamp: 1676558783570
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
   sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
   md5: a00e6a62956fde3c4135464353ee8a53
   depends:
@@ -6471,7 +6471,7 @@ packages:
   license_family: BSD
   size: 229158
   timestamp: 1676330909084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
   sha256: db8335d6531b03c7bdfe789ebacc52631ac6ea4a37700bb3da1f6a53a1acd724
   md5: ebeba61994cc225ea5f4f42caa511019
   depends:
@@ -6483,7 +6483,7 @@ packages:
   license_family: BSD
   size: 116681
   timestamp: 1679906658986
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
   sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
   md5: 5efa1332f7c0a8d9638eda02170c4ce5
   depends:
@@ -6508,7 +6508,7 @@ packages:
   license_family: BSD
   size: 413653
   timestamp: 1671707957673
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
   sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
   md5: 891fe66a24d8714737b2874985ee1303
   depends:
@@ -6519,7 +6519,7 @@ packages:
   license_family: BSD
   size: 62298
   timestamp: 1672388166096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -6529,7 +6529,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
   sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
   md5: c345f51706eef530454f66b794e5e574
   depends:
@@ -6538,7 +6538,7 @@ packages:
   license: MIT
   size: 68189
   timestamp: 1659616216976
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
   md5: a7400cfb72042977bc047909ed504ce8
   depends:
@@ -6548,7 +6548,7 @@ packages:
   license: MIT
   size: 33743
   timestamp: 1659616248209
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
   md5: 6307f6854754ab5bd7c84e6998385bb1
   depends:
@@ -6558,7 +6558,7 @@ packages:
   license: MIT
   size: 733177
   timestamp: 1659616279453
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -6568,7 +6568,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
   sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
   md5: b812bc5d9c76242e2bb2ac87afe7d39b
   depends:
@@ -6578,7 +6578,7 @@ packages:
   license_family: GPL3
   size: 730280
   timestamp: 1650983734373
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -6589,7 +6589,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -6598,7 +6598,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -6615,7 +6615,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
   sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
   md5: ba9418df9288a2f031a02fa35b774ce0
   depends:
@@ -6631,7 +6631,7 @@ packages:
   license_family: BSD
   size: 78524
   timestamp: 1694778314659
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
   sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
   md5: b1781519a200ccbfcb4a1194005aa3ef
   depends:
@@ -6643,7 +6643,7 @@ packages:
   license_family: BSD
   size: 338459
   timestamp: 1694777084290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
   sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
   md5: 6ece7f1a3248169837714d05d7f6ef0a
   depends:
@@ -6655,7 +6655,7 @@ packages:
   license_family: MIT
   size: 3513910
   timestamp: 1692971505729
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
   sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
   md5: bd7ec244935e83e850a4ff34e8e2e64f
   depends:
@@ -6666,7 +6666,7 @@ packages:
   license_family: MIT
   size: 513971
   timestamp: 1692973657152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
   sha256: e1c0e745d9ba36a80773e841d96bf514ad1ceda419e4188aad3c22782af00234
   md5: f226532e9bb308f20e874c56be6ceefb
   depends:
@@ -6676,7 +6676,7 @@ packages:
   license_family: MIT
   size: 35788
   timestamp: 1659783414586
-- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
   sha256: 2f610fc98b674e4eceeceaadbb94b4153759ee9249759dd27ca48bfdeeef82cf
   md5: c24005244a08cbfb665f89d8858e0187
   depends:
@@ -6688,7 +6688,7 @@ packages:
   license_family: BSD
   size: 20824879
   timestamp: 1697031479623
-- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
   sha256: 5d4cf89313147e44530dbb3cc6a93247aaded0701bbf8ba3a382ef710abf4cfa
   md5: 137deeca51202f6b4ac786472a00be55
   depends:
@@ -6697,7 +6697,7 @@ packages:
   license_family: BSD
   size: 12894
   timestamp: 1652904101694
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
   sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
   md5: fb7881e74b59262df0fa4ec981964efc
   depends:
@@ -6710,7 +6710,7 @@ packages:
   license_family: Other
   size: 1244887
   timestamp: 1695058550693
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
   sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
   md5: 6970c7f46b0164cad1d210e7a1419959
   depends:
@@ -6720,7 +6720,7 @@ packages:
   license_family: BSD
   size: 143434
   timestamp: 1670944902624
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
   sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
   md5: 1015298551c040c6d5e26eebbae12ef5
   depends:
@@ -6730,7 +6730,7 @@ packages:
   license_family: BSD
   size: 142316
   timestamp: 1671542240512
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
   sha256: ab5c246c2b271acc1cdd0b9343989c0166681536e569cdbe71618f55d34c7292
   md5: 7ce68d771cd94c9ff5efefe69d327c9a
   depends:
@@ -6740,7 +6740,7 @@ packages:
   license_family: MIT
   size: 125122
   timestamp: 1684280210213
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
   sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
   md5: 466da740fafef3d6bce114220f0be306
   depends:
@@ -6753,7 +6753,7 @@ packages:
   license_family: BSD
   size: 28510
   timestamp: 1654508162239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
   sha256: 1687ae122ee7d8b583141fc5014b76d494841dc8083b854449e3d6e0f6bb7019
   md5: 3697ac26ee3c2d49338dd5b9c6551152
   depends:
@@ -6776,7 +6776,7 @@ packages:
   license_family: PSF
   size: 8080067
   timestamp: 1698692812610
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
   sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
   md5: a9fa43e694b25cd49b8b08a9eefd696e
   depends:
@@ -6786,7 +6786,7 @@ packages:
   license_family: BSD
   size: 18054
   timestamp: 1661915903969
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
   sha256: 8aa14047fac6ef8b326900c4bf1a960eaa7a1699c18fdf1e75a59101b610b6df
   md5: 7e1d4d4700fbea6171d30f1d5ad24226
   depends:
@@ -6796,7 +6796,7 @@ packages:
   license_family: MIT
   size: 53362
   timestamp: 1659721308586
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
   sha256: 2017814a7cc93dd51c6b7c016e3cdf8fbc32fa20f985638aaff6a6377e9ee086
   md5: a1a285c56b001c3b5c591bf21eec3149
   depends:
@@ -6805,7 +6805,7 @@ packages:
   license_family: MIT
   size: 19326
   timestamp: 1659716205153
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
   sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
   md5: 248c468abced874f0231d3cc23177c77
   depends:
@@ -6816,7 +6816,7 @@ packages:
   license_family: BSD
   size: 58488
   timestamp: 1607359497934
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
   sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
   md5: 5e763c995ff0c549f68a10bce70fede4
   depends:
@@ -6828,7 +6828,7 @@ packages:
   license_family: Proprietary
   size: 187489950
   timestamp: 1691503804820
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
   sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
   md5: dd0c2ece6a743c373c9b5a5919b4818f
   depends:
@@ -6840,7 +6840,7 @@ packages:
   license_family: BSD
   size: 49744
   timestamp: 1682975040154
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
   sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
   md5: 57cea8df7ab85f2a98f64d23afcb1f90
   depends:
@@ -6855,7 +6855,7 @@ packages:
   license_family: BSD
   size: 184956
   timestamp: 1695058491736
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
   sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
   md5: 8769cdd201d905069800488fe31574e5
   depends:
@@ -6870,7 +6870,7 @@ packages:
   license_family: BSD
   size: 256221
   timestamp: 1695060152521
-- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
   sha256: b75f28f29d60f2a8726fb0f036e5d01489942abbf77ff1e1cc8e12d7f372b8f3
   md5: 7a1d29477873480809fd3860f2e69f01
   depends:
@@ -6880,7 +6880,7 @@ packages:
   license_family: BSD
   size: 24734
   timestamp: 1607574381373
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
   sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
   md5: d9781492332e6326f9fca87f3a8efacd
   depends:
@@ -6906,7 +6906,7 @@ packages:
   license_family: BSD
   size: 8135792
   timestamp: 1681756491399
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
   sha256: 2dd3178d3c570e30b9490ebabfd7bfac806afad8302d3dee0edc619805034397
   md5: bef9da0f0694c45b6aaa4e6447479eaf
   depends:
@@ -6919,7 +6919,7 @@ packages:
   license_family: BSD
   size: 118324
   timestamp: 1650290466135
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
   sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
   md5: f1d8ce412e115986c403f223b3b47d0f
   depends:
@@ -6947,7 +6947,7 @@ packages:
   license_family: BSD
   size: 596314
   timestamp: 1668451106600
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
   sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
   md5: f96bbef0985d7e66ebf00c0d55e30e23
   depends:
@@ -6960,7 +6960,7 @@ packages:
   license_family: BSD
   size: 167045
   timestamp: 1694617078743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
   sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
   md5: 6e6ba64c8dc5025aeac606404a8df36a
   depends:
@@ -6969,7 +6969,7 @@ packages:
   license_family: BSD
   size: 13786
   timestamp: 1672387480065
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
   sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
   md5: 4a7a3286484766741f627696697c362c
   depends:
@@ -6994,7 +6994,7 @@ packages:
   license_family: BSD
   size: 609425
   timestamp: 1690985686105
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
   sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
   md5: 4269a1f93882205b90d4b2ae78fc82d5
   depends:
@@ -7004,7 +7004,7 @@ packages:
   license_family: BSD
   size: 22417
   timestamp: 1668160717305
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
   sha256: 39b52f5a3e0f71a07358f2bd07a67b950170eabc3398ae968ef523cc0854141a
   md5: 4baee3e5d96aed7d5d3e28051d6214e5
   depends:
@@ -7024,7 +7024,7 @@ packages:
   license_family: BSD
   size: 4472762
   timestamp: 1697063760024
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
   sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
   md5: a18a576b7024cfd6f905c526a786a916
   depends:
@@ -7039,7 +7039,7 @@ packages:
   license_family: MIT
   size: 135285
   timestamp: 1696515698492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
   sha256: 410f3a13eaddcfcfc65cb077dd0b85b7c66853a2447161b9022eed7d9fe472f9
   md5: c4aae7ab3842a3decd05c5c1d8b916d3
   depends:
@@ -7056,7 +7056,7 @@ packages:
   license_family: BSD
   size: 12296
   timestamp: 1691098390179
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
   sha256: 5a81ff60cc876951905995ea52d3815e38a0d757c6c674acbef1144d8dc746fb
   md5: 72413d41fe97de5da9b1ce325e544e05
   depends:
@@ -7072,7 +7072,7 @@ packages:
   license_family: BSD
   size: 6857794
   timestamp: 1691098356763
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
   sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
   md5: ab07e2a27ac08afe3d0b4c0890b8486a
   depends:
@@ -7083,7 +7083,7 @@ packages:
   license: BSD 2-Clause
   size: 249316
   timestamp: 1630094024143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
   sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
   md5: 73b17037d87b5a58feb34dafc0538f7f
   depends:
@@ -7094,7 +7094,7 @@ packages:
   license_family: Apache
   size: 8058396
   timestamp: 1695324589828
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
   sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
   md5: df1d746ba8d5d6ba01ac1373b9b71e1a
   depends:
@@ -7103,7 +7103,7 @@ packages:
   license_family: Apache
   size: 73016
   timestamp: 1693575484990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.0.3-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-2.0.3-py39h4ed8f06_0.tar.bz2
   sha256: ed91d8aecd0bceea2e5952d3e3054c80d9a37481ebfea1451cbeda6aed416ca3
   md5: 915957bfbe46e521c9cafed0bf66c916
   depends:
@@ -7152,7 +7152,7 @@ packages:
   license_family: BSD
   size: 12385096
   timestamp: 1692216843654
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
   sha256: 0044e1cc04f3cb7c48209276c35c59c05b87e852c0ac01be468b99f3656445fb
   md5: ee81d2a2b2c558b43a48fd68c2de1dbf
   depends:
@@ -7176,7 +7176,7 @@ packages:
   license_family: BSD
   size: 17009718
   timestamp: 1695148093102
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
   sha256: 2773f47b2d745ab483cf7fcbd5b5e2f7020d45462d32d2ccd5cf232ca13c6f67
   md5: ca16cd208037bd58d2da267c338da4a4
   depends:
@@ -7185,7 +7185,7 @@ packages:
   license_family: BSD
   size: 142229
   timestamp: 1684915524241
-- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/partd-1.4.0-py39haa95532_0.tar.bz2
   sha256: 7fa6e9e20cb7229eda9e5554fd3235ff11e30de6f87debfdb53181cdfca20817
   md5: 9123ec9ccc86d35ed1ddec2aa3877968
   depends:
@@ -7199,7 +7199,7 @@ packages:
   license_family: BSD
   size: 35510
   timestamp: 1693938142283
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
   sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
   md5: 427c1450bebb632f43bbc8c83006e4cd
   depends:
@@ -7218,7 +7218,7 @@ packages:
   license_family: Other
   size: 806931
   timestamp: 1696580240310
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
   sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
   md5: 21790cd3e2b8a45c4104aff0a68330d0
   depends:
@@ -7229,7 +7229,7 @@ packages:
   license_family: MIT
   size: 3001751
   timestamp: 1697549357662
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
   sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
   md5: 56f44a1054da2d10777e375838191070
   depends:
@@ -7238,7 +7238,7 @@ packages:
   license_family: MIT
   size: 32355
   timestamp: 1692205784293
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
   sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
   md5: 8a35ad65651086575ce55371f22feda8
   depends:
@@ -7247,7 +7247,7 @@ packages:
   license_family: Apache
   size: 91045
   timestamp: 1659455316472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
   sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
   md5: 186eb95f816a2eff80c3c7f7d964c7b0
   depends:
@@ -7259,7 +7259,7 @@ packages:
   license_family: BSD
   size: 578514
   timestamp: 1672388155359
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
   sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
   md5: 47b6cbe6ce9289e47d16900b03596a91
   depends:
@@ -7270,7 +7270,7 @@ packages:
   license_family: BSD
   size: 372807
   timestamp: 1656431445633
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
   sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
   md5: 07165c444adc7c7ccc8a345875adc5ef
   depends:
@@ -7282,7 +7282,7 @@ packages:
   license_family: BSD
   size: 48408
   timestamp: 1675450623287
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
   sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
   md5: d58e76a31e2f6e7410ba4afd7f385b0d
   depends:
@@ -7291,7 +7291,7 @@ packages:
   license_family: BSD
   size: 1877445
   timestamp: 1684280183367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
   sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
   md5: 0e5b0fe7debbf558ce97090f6b67cdae
   depends:
@@ -7301,7 +7301,7 @@ packages:
   license_family: Apache
   size: 94633
   timestamp: 1690225630423
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
   sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
   md5: 0fde797653e4ab589506121fb1e37555
   depends:
@@ -7310,7 +7310,7 @@ packages:
   license_family: MIT
   size: 157119
   timestamp: 1661452591647
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
   sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
   md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
   depends:
@@ -7321,7 +7321,7 @@ packages:
   license_family: MIT
   size: 92679
   timestamp: 1636093365041
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
   sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
   md5: f870859d4dc7a8d82cf3546bd9035f33
   depends:
@@ -7331,7 +7331,7 @@ packages:
   license_family: BSD
   size: 54520
   timestamp: 1605307564142
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
   sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
   md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
   depends:
@@ -7344,7 +7344,7 @@ packages:
   license_family: PSF
   size: 21172845
   timestamp: 1694442462066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
   sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
   md5: 9d99075052265ae3d718582d3b875038
   depends:
@@ -7353,7 +7353,7 @@ packages:
   license_family: BSD
   size: 269964
   timestamp: 1661376543480
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
   sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
   md5: fa9074d94236c9b768bfd2c858875b27
   depends:
@@ -7362,7 +7362,7 @@ packages:
   license_family: MIT
   size: 264836
   timestamp: 1695131770282
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
   sha256: 97243a31c39f4990c0e9d4f2307f2f7fb9421553303923bc105067ec4340bdff
   md5: 8078c5760f27398eaf1082226647d137
   depends:
@@ -7372,7 +7372,7 @@ packages:
   license_family: BSD
   size: 40145
   timestamp: 1685031143383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
   sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
   md5: 3d2841085778006c2e79f9c7300f8b9d
   depends:
@@ -7382,7 +7382,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13565975
   timestamp: 1669937633869
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
   sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
   md5: 54a4bc0724041dd173088419d6ede2af
   depends:
@@ -7394,7 +7394,7 @@ packages:
   license_family: MIT
   size: 239062
   timestamp: 1677611495106
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
   sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
   md5: f39f84115e228bad4bceaefdd637f022
   depends:
@@ -7406,7 +7406,7 @@ packages:
   license_family: MIT
   size: 158558
   timestamp: 1698096358091
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
   sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
   md5: df398a3a1668fd2a22061764e20ea91d
   depends:
@@ -7418,7 +7418,7 @@ packages:
   license_family: BSD
   size: 460913
   timestamp: 1657616061604
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
   sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
   md5: 38db77ece9dc76feffb9ef7638e38258
   depends:
@@ -7434,7 +7434,7 @@ packages:
   license_family: Apache
   size: 94397
   timestamp: 1690400496655
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
   sha256: 3a9a680173f731d515e0587d5b74583cc986b5c1ff62f4cf9e4f7ec268cbb62a
   md5: 3387bf809e3d32dde3f5cbc3ef49bf47
   depends:
@@ -7452,7 +7452,7 @@ packages:
   license_family: BSD
   size: 22779707
   timestamp: 1696550432358
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
   sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
   md5: 3e284ae6b48ee30c364ffdc5601610b0
   depends:
@@ -7461,7 +7461,7 @@ packages:
   license_family: MIT
   size: 1099842
   timestamp: 1690291374842
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
   sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
   md5: 993b3886b334bd1f49d34206f21997b4
   depends:
@@ -7470,7 +7470,7 @@ packages:
   license_family: Apache
   size: 15998
   timestamp: 1614030572433
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
   sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
   md5: 7ac9604ad7564ac0c71bff5db198656f
   depends:
@@ -7479,7 +7479,7 @@ packages:
   license_family: MIT
   size: 67012
   timestamp: 1696347795139
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
   sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
   md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
   depends:
@@ -7489,7 +7489,7 @@ packages:
   license_family: Other
   size: 1311308
   timestamp: 1681402905668
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -7499,7 +7499,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
   sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
   md5: 28b9869d8d3a839918fac4a08f38cbc2
   depends:
@@ -7510,7 +7510,7 @@ packages:
   license_family: BSD
   size: 30546
   timestamp: 1671752127904
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
   sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
   md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
   depends:
@@ -7520,7 +7520,7 @@ packages:
   license_family: BSD
   size: 39590
   timestamp: 1668168880994
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
   sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
   md5: 52cdcdb96383c010ca833a7c24b3935b
   depends:
@@ -7530,7 +7530,7 @@ packages:
   license_family: BSD
   size: 3690152
   timestamp: 1654036853710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
   sha256: 1ee791ecc17e11a31d6cf1553845e7279d9d9a2c7383a2a3e1ae131ddd024b6f
   md5: b32030d310e0437dc631e5719369004c
   depends:
@@ -7539,7 +7539,7 @@ packages:
   license_family: BSD
   size: 102033
   timestamp: 1667464306003
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
   sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
   md5: 0e054ab29119cf4c1f778613acf972f9
   depends:
@@ -7550,7 +7550,7 @@ packages:
   license_family: Apache
   size: 681780
   timestamp: 1696937326924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
   sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
   md5: b6ad839ebba536ad1c3cc58d0e2123f0
   depends:
@@ -7564,7 +7564,7 @@ packages:
   license_family: MOZILLA
   size: 143681
   timestamp: 1679562248929
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
   sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
   md5: fe78de10019085146f1cc6c94fdc2620
   depends:
@@ -7573,7 +7573,7 @@ packages:
   license_family: BSD
   size: 192822
   timestamp: 1671143999327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
   md5: ca5fc3fbdb09b6de068a8b7a8869369f
   depends:
@@ -7583,7 +7583,7 @@ packages:
   license_family: PSF
   size: 9208
   timestamp: 1690298120549
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
   md5: a86e87a10e5fdff486265e0c675fb99f
   depends:
@@ -7592,7 +7592,7 @@ packages:
   license_family: PSF
   size: 57922
   timestamp: 1690298106990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
   sha256: 8057d3d2a0acd44496de33c5b222063c3f7d06b90c74fbbda45bd18b0b324219
   md5: 398f8db5bd8cab84b3d85a9d85fa4889
   depends:
@@ -7601,7 +7601,7 @@ packages:
   license_family: MIT
   size: 11362
   timestamp: 1659769459206
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
   sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
   md5: 0d31859e0a097aedbcc1627db33b3d92
   depends:
@@ -7616,7 +7616,7 @@ packages:
   license_family: MIT
   size: 188367
   timestamp: 1698257883295
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
   sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
   md5: 45ef24c486a484f079faf1dc90e4c7e9
   depends:
@@ -7625,12 +7625,12 @@ packages:
   license_family: BSD
   size: 8277
   timestamp: 1605602889180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
   sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
   md5: 4daaceb6cfc1af6274509081d8018ef1
   size: 2316783
   timestamp: 1605602872095
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
   sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
   md5: 916c16904615c7af3b5d37cb6694f45e
   depends:
@@ -7639,7 +7639,7 @@ packages:
   license_family: BSD
   size: 21084
   timestamp: 1607347371925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
   sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
   md5: da69e6987fcc757e83a358ceaa13f62b
   depends:
@@ -7649,7 +7649,7 @@ packages:
   license_family: BSD
   size: 73391
   timestamp: 1614804425587
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
   sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
   md5: 23b9f4634b2e5450be617114f62c74f9
   depends:
@@ -7658,7 +7658,7 @@ packages:
   license_family: MIT
   size: 120873
   timestamp: 1695742300539
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
   sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
   md5: 120f0b088290fc17bd6618fc10a2f0c4
   depends:
@@ -7666,13 +7666,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 34293
   timestamp: 1605306211299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
   sha256: 6bdb88cd45b22246e84b7400159ca90faf98ab4e8c1fa2d38d031cfc73c4dc13
   md5: d6e10641ece06f67561c5f6a676a4b7e
   depends:
@@ -7684,7 +7684,7 @@ packages:
   license_family: Apache
   size: 1794729
   timestamp: 1689041580510
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
   sha256: a5d2a216d052105fdaad7256f23da3b29f95100d1dc0f29b6ab1f3bbc75e17a9
   md5: a558f681ebc243f86cde2515c065b62e
   depends:
@@ -7693,7 +7693,7 @@ packages:
   license_family: BSD
   size: 48805
   timestamp: 1675159123654
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
   sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
   md5: c3f7871e9a33adeccee1b1e8e216918e
   depends:
@@ -7703,7 +7703,7 @@ packages:
   license_family: GPL2
   size: 1332571
   timestamp: 1683113347814
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -7712,7 +7712,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
   sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
   md5: 1ab55f8c4b5292ec360c572120bf823e
   depends:
@@ -7722,7 +7722,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 9430705
   timestamp: 1616055773485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
   sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
   md5: 6875e0bf3828707dc9165d694c0d0a7d
   depends:
@@ -7731,7 +7731,7 @@ packages:
   license_family: MIT
   size: 18725
   timestamp: 1672387612937
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
   sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
   md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
   depends:
@@ -7741,7 +7741,7 @@ packages:
   license_family: Other
   size: 148931
   timestamp: 1666595229032
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
   sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
   md5: 8d6a1e767775fe0eb617cd6e22edc2ff
   depends:

--- a/exoplanets/pixi.toml
+++ b/exoplanets/pixi.toml
@@ -20,15 +20,15 @@ hvplot = "*"
 holoviews = "*"
 datashader = "*"
 pandas = "<2.1"
-pip = "*"
-setuptools = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+setuptools = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks.dashboard]
 cmd = "panel serve --rest-session-info --session-history -1 exoplanets.ipynb --show"

--- a/exoplanets/pixi.toml
+++ b/exoplanets/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "exoplanets"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
 
 [tool.metadata]

--- a/exoplanets/pixi.toml
+++ b/exoplanets/pixi.toml
@@ -1,0 +1,57 @@
+[workspace]
+name = "exoplanets"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2021-06-17"
+maintainers = ["ablythed"]
+categories = ["Geospatial"]
+labels = ["hvplot", "holoviews", "panel", "bokeh"]
+description = "Map of confirmed and candidate exoplanets by discovery date"
+
+[dependencies]
+python = "3.9.*"
+notebook = "*"
+ipykernel = "*"
+panel = "*"
+bokeh = "*"
+hvplot = "*"
+holoviews = "*"
+datashader = "*"
+pandas = "<2.1"
+pip = "*"
+setuptools = "*"
+wheel = "*"
+
+[target.osx-64.dependencies]
+libgfortran = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks.dashboard]
+cmd = "panel serve --rest-session-info --session-history -1 exoplanets.ipynb --show"
+depends-on = ["download"]
+
+[tasks.notebook]
+cmd = "jupyter notebook exoplanets.ipynb"
+depends-on = ["download"]
+
+[tasks.download]
+depends-on = ["download-DATA_1", "download-DATA_2", "download-DATA_3"]
+
+[tasks.download-DATA_1]
+env = { FILENAME = "data/exoplanets.csv" }
+cmd = "mkdir -p data && curl -fsSL -o $FILENAME https://datashader-data.s3.amazonaws.com/exoplanets.csv"
+outputs = ["data/exoplanets.csv"]
+
+[tasks.download-DATA_2]
+env = { FILENAME = "data/stars.csv" }
+cmd = "mkdir -p data && curl -fsSL -o $FILENAME https://datashader-data.s3.amazonaws.com/stars.csv"
+outputs = ["data/stars.csv"]
+
+[tasks.download-DATA_3]
+env = { FILENAME = "data/candidates.csv" }
+cmd = "mkdir -p data && curl -fsSL -o $FILENAME https://datashader-data.s3.amazonaws.com/candidates.csv"
+outputs = ["data/candidates.csv"]

--- a/gapminders/pixi.lock
+++ b/gapminders/pixi.lock
@@ -7,656 +7,656 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/altair-5.0.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.1-py311h92b7b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.6.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.19.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.25.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.14-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.2-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/plotly-5.22.0-py311h92b7b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tenacity-8.2.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.1-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/altair-5.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-3.4.1-py311h92b7b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2024.6.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.19.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.25.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.14-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-2.2.2-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-1.4.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-2.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/plotly-5.22.0-py311h92b7b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.32.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tenacity-8.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.4.1-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-2.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/altair-5.0.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.1-py311h85bffb1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.6.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.19.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.25.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.14-h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.2-py311he327ffe_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/plotly-5.22.0-py311h85bffb1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tenacity-8.2.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.1-py311h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/altair-5.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-3.4.1-py311h85bffb1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2024.6.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.19.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.25.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.14-h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-2.2.2-py311he327ffe_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-1.4.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-2.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/plotly-5.22.0-py311h85bffb1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.32.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tenacity-8.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.4.1-py311h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-2.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/altair-5.0.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.1-py311hb6e6a13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.6.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.19.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.25.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.14-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.2-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/plotly-5.22.0-py311hb6e6a13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tenacity-8.2.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.1-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/altair-5.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.4.1-py311hb6e6a13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.6.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.19.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.25.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.14-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.2.2-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-1.4.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-2.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/plotly-5.22.0-py311hb6e6a13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.32.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tenacity-8.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.4.1-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/altair-5.0.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.1-py311h746a85d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.6.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.19.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.25.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.14-h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.2-py311hea22821_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/plotly-5.22.0-py311h746a85d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tenacity-8.2.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.1-py311h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/altair-5.0.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-3.4.1-py311h746a85d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2024.6.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.19.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.25.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.14-h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-2.2.2-py311hea22821_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-1.4.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-2.1.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/plotly-5.22.0-py311h746a85d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.32.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tenacity-8.2.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.4.1-py311h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-2.2.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
   sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
   md5: 613805add1c05b538ff06d217252feb7
   depends:
@@ -667,7 +667,7 @@ packages:
   license: BSD-3-Clause
   size: 20810
   timestamp: 1652859733309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/altair-5.0.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/altair-5.0.1-py311h06a4308_0.tar.bz2
   sha256: 182e66fccbb032294e781427a3cd8bab80cd5da25dc4aba9ad6af84c84cabd04
   md5: 1e25b33d589e2f1c465235a4302e1582
   depends:
@@ -681,7 +681,7 @@ packages:
   license_family: BSD
   size: 851870
   timestamp: 1687526078680
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
   sha256: 250f50edf43a786a32942e9ae67ce807e9b3ac4cb6b58b1170cb541fb24e391f
   md5: b48058294499d292ddf9a3b966dc9cc5
   depends:
@@ -695,7 +695,7 @@ packages:
   license_family: MIT
   size: 228473
   timestamp: 1706220559474
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
   sha256: 0d4f5274503916e1c683dcc16e8a7c4186557afa3f62399cd628e4eb535fe77a
   md5: 062acdb0f9ae976c25c2d15d589dc1d6
   depends:
@@ -706,7 +706,7 @@ packages:
   license_family: MIT
   size: 35809
   timestamp: 1676823571351
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
   sha256: 567dfdd5b986012421a736a5f1c1d5874d8d691dd483c838b55e1ab06c0b217d
   md5: 4e0aa1543f546b898523382ee8405e84
   depends:
@@ -715,7 +715,7 @@ packages:
   license_family: MIT
   size: 152577
   timestamp: 1695717917074
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
   sha256: 5bb9bfe025d9a49af272f194278f63cea7366e83bdf3f99d25f97b820d522089
   md5: 100d3161d97332fe38945afec8d36935
   depends:
@@ -725,12 +725,12 @@ packages:
   license_family: MIT
   size: 276381
   timestamp: 1718029864701
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.1-py311h92b7b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-3.4.1-py311h92b7b1e_0.tar.bz2
   sha256: 34d2dcc4885a03631c340e88ecb1002ac60c1f9573f34252e3ad8b87096c0040
   md5: 9b33d05f7b278ad9a9a3442da9d41f11
   depends:
@@ -748,7 +748,7 @@ packages:
   license_family: BSD
   size: 6054528
   timestamp: 1718119253989
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
   sha256: 8e2b2073ff5c61d35714e8a36ce657a8ac741b7bedc2852a238c7f1625142705
   md5: d951ab54a682b6328327fec53b1e5e72
   depends:
@@ -759,7 +759,7 @@ packages:
   license_family: BSD
   size: 147642
   timestamp: 1707864274452
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
   sha256: 5d15605858771290fdaaae41a43941623757a25cb1292080d69d6d3857807935
   md5: 7f517469aa5380c52e55db9f37df104f
   depends:
@@ -770,7 +770,7 @@ packages:
   license: MIT
   size: 18652
   timestamp: 1714483267080
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
   sha256: a5094f078584e27c7cced4a9564ae904a329f5c1702a7c1ba092d581ba1544f1
   md5: 6ddf45dd8a21a9512481de9bc0e5a03f
   depends:
@@ -780,7 +780,7 @@ packages:
   license: MIT
   size: 19711
   timestamp: 1714483255915
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
   sha256: 93180c973816246f068b742d0bf64840f0ea48e31d4f9b0747ea2ffc34d8855d
   md5: f3a00096965a5ba1eb41d2c99a4662a2
   depends:
@@ -790,7 +790,7 @@ packages:
   license: MIT
   size: 361574
   timestamp: 1714483400014
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
   sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
   md5: f5058c8d5b2994b7334f18e022105a14
   depends:
@@ -799,14 +799,14 @@ packages:
   license_family: BSD
   size: 427542
   timestamp: 1714510571510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
   sha256: 394f74202c2efc8fcfd02b8953f508eb6a2961d224a2f9d15091caf5cbe1be67
   md5: 1202b4ed32215c6405bb42fbff355316
   license: MPL-2.0
   license_family: Other
   size: 137411
   timestamp: 1710764808838
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.6.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2024.6.2-py311h06a4308_0.tar.bz2
   sha256: d30bad9397c44cec36475daa2aaa2460871ab3d76ac32b9f6df4601f2b0fb920
   md5: 92a88346f3e221bbc0549a16773bdb1e
   depends:
@@ -815,7 +815,7 @@ packages:
   license_family: Other
   size: 166124
   timestamp: 1717618114991
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
   sha256: d138cc3fde270eba783baf1e2ba17c89800b2cbbf20976d0eb425b3436a4a184
   md5: 1875e89c1a939e4e7c5e7b731c72b838
   depends:
@@ -827,7 +827,7 @@ packages:
   license_family: MIT
   size: 302401
   timestamp: 1714483186060
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
   sha256: d9c102b9ec7f3a635936b6f73d4db126d748a25f65407353bd76b260dc7d1cd6
   md5: eec48dbdf5dac0ea26750cc26b58c1d9
   depends:
@@ -836,7 +836,7 @@ packages:
   license_family: CC
   size: 554986
   timestamp: 1709758392744
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
   sha256: 882481e441b9b93cbdfb32fbe32a6ad9f26197472f186a08fddb921f61346c02
   md5: 443c79196064f57c98199e9990544b2f
   depends:
@@ -846,7 +846,7 @@ packages:
   license_family: BSD
   size: 16902
   timestamp: 1709322958614
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
   sha256: e4877b41553e31b9f9f090dffab77a654255c63776e8b30fc91ec1f60afadbf1
   md5: c34d3f1520f1e8c9957eb236710058c4
   depends:
@@ -858,7 +858,7 @@ packages:
   license_family: BSD
   size: 281162
   timestamp: 1700583651472
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
   sha256: 3b4cd8dc60572086f1a1cbb97e2712e0ffd55317ce8f0309d552eee7367855eb
   md5: 70a1263b6e19bf2d77c020a2e77277c9
   depends:
@@ -869,7 +869,7 @@ packages:
   license_family: MIT
   size: 2556575
   timestamp: 1690905285843
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
   sha256: 4b589e3265c74159130230c164ff2d8d381be65899a249def0b53f93ce83fd47
   md5: 245cb7173dcdba21cf368031cd87f706
   depends:
@@ -878,7 +878,7 @@ packages:
   license_family: MIT
   size: 17434
   timestamp: 1676823330845
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
   sha256: b75d12e85274660bb675a3e53d47a929872f2daa2ff5a76e98885ee3f2d19ad1
   md5: f2119d0885334060d0d7fe59e5220287
   depends:
@@ -897,7 +897,7 @@ packages:
   license_family: MIT
   size: 3237908
   timestamp: 1713551660998
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
   sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
   md5: a5dc8677d891dff2393b63189a3ad42f
   depends:
@@ -908,7 +908,7 @@ packages:
   license_family: Other
   size: 971975
   timestamp: 1666798278693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.19.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.19.0-py311h06a4308_0.tar.bz2
   sha256: 19943e427090f6ae2858ca276b1c928276d7429fc847c7fe769fb53d5124a936
   md5: 656272c262237114be93d53da3c25f86
   depends:
@@ -928,7 +928,7 @@ packages:
   license_family: BSD
   size: 6096391
   timestamp: 1718294765372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
   sha256: a0ae6c5a6b615d73d9a243331f3f7d749b4feafdf2f334337fda8abd6c8355ed
   md5: e61d8dcd4dfd6d165e6e480cee846bf5
   depends:
@@ -945,7 +945,7 @@ packages:
   license_family: BSD
   size: 357992
   timestamp: 1715090462763
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
   sha256: e08e27531775de40f46b6ac7bf71856963baa0c008bd2b4d112e6341cd3e8f4c
   md5: bfc7682613c861cbcb4ac01485c05657
   depends:
@@ -954,7 +954,7 @@ packages:
   license_family: BSD
   size: 147174
   timestamp: 1714398938840
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
   sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
   md5: 3add2ce56858a1b8f6a37342f82773d3
   depends:
@@ -970,7 +970,7 @@ packages:
   license_family: Proprietary
   size: 19310769
   timestamp: 1699647799237
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
   sha256: 0b670ab17ed2e1b592079bd64386dadc249ddc892e5ae1dd99f142a918ffc75d
   md5: 632575b9e442c1e5c146cf78424da610
   depends:
@@ -991,7 +991,7 @@ packages:
   license_family: BSD
   size: 227791
   timestamp: 1705934138566
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.25.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.25.0-py311h06a4308_0.tar.bz2
   sha256: 3bd99b00f61f427332fac1d1ba7e6e645ff21423c0c95323fdb55d3eae2d89fb
   md5: f59e3ad77589ccca38d734d6b2b8d653
   depends:
@@ -1009,7 +1009,7 @@ packages:
   license_family: BSD
   size: 1624438
   timestamp: 1718288016429
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
   sha256: a2918ea8a3e2c56fc6d91191e84b2f35500c392b16ab687a0c03ded2e2e51239
   md5: 84fadd6b7fef393cccc0d123dae6cae8
   depends:
@@ -1019,7 +1019,7 @@ packages:
   license_family: MIT
   size: 1162207
   timestamp: 1679336523618
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.4-py311h06a4308_0.tar.bz2
   sha256: f8c1f9c49e58fd9adfefbe99d055a8045643b620902c4758a07d689b21418900
   md5: 77918475e3a5511cd5a0f595a751b881
   depends:
@@ -1031,7 +1031,7 @@ packages:
   license_family: BSD
   size: 354911
   timestamp: 1716993527421
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
   sha256: c21f8f407266d039e819c27fe9eb4fb26587e974f3bd059b37cbaec5073722d0
   md5: ba1f47411e9e07876c7a3e9d3be6a98e
   depends:
@@ -1040,7 +1040,7 @@ packages:
   license_family: Other
   size: 281400
   timestamp: 1677849152168
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
   sha256: 06b729aee6dd2a1e545f3ad64179cc0d4ef8a15e33db3be2995dd3e0868465ca
   md5: 8bb3215912588e47e2eeb4e7a09ad64f
   depends:
@@ -1053,7 +1053,7 @@ packages:
   license_family: MIT
   size: 180858
   timestamp: 1699041715847
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
   sha256: 9e3bac2d41bd432b721b009e7de981766fba396e6f238e923f304112bd88655a
   md5: 84ae4cf3f2d01fbebdac374971192be9
   depends:
@@ -1063,7 +1063,7 @@ packages:
   license_family: MIT
   size: 15525
   timestamp: 1699032521315
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
   sha256: 79ce6dff3d93649a2555b1d2a4ae9eb77175a1c00664cb8eb0e6f848d5cdd1b9
   md5: db395b0efd7018fcf3a4af879170c2a8
   depends:
@@ -1079,7 +1079,7 @@ packages:
   license_family: BSD
   size: 276856
   timestamp: 1676823504812
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
   sha256: 91cca0ba49accdc9e97463bee087244a27ad107eb3af9ccb91634239f8b10f72
   md5: a185824bfc55bd90e1cf9330b417b74c
   depends:
@@ -1090,7 +1090,7 @@ packages:
   license_family: BSD
   size: 97359
   timestamp: 1718818381635
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
   sha256: 540f8dfb7cdc3877b4e24d6af65696d0bc7eae5de1c307229f86b3fe601a2286
   md5: f650f8c007471f6ef6c1a292918d2e1f
   depends:
@@ -1106,7 +1106,7 @@ packages:
   license_family: BSD
   size: 41920
   timestamp: 1718738122846
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
   sha256: 398387b6f1ee1691b04a31fedd1320225e5553aa921b06bc013f010a0008621e
   md5: bac66634a9133c633ddc879e14e83f23
   depends:
@@ -1133,7 +1133,7 @@ packages:
   license_family: BSD
   size: 610854
   timestamp: 1718827113534
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
   sha256: ddfee06ba9b149222c65d1d4270272840533aa63b56fe36363c84a891c71d328
   md5: ee128e5c0d8d9e1952e2387b66a5b8cb
   depends:
@@ -1143,7 +1143,7 @@ packages:
   license_family: BSD
   size: 27239
   timestamp: 1686870958829
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
   sha256: 0c6a074272ed58677ec17e4dbfceaffd2108841a61af92b32f156c5763108d1d
   md5: dd3d37841d0d20c70a60e8c939923894
   depends:
@@ -1155,7 +1155,7 @@ packages:
   license_family: BSD
   size: 19144
   timestamp: 1700168632051
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
   sha256: b040f0d0ee4588188ab6b83a93738b3ff6e6d1775424be97995bd0df0f4fb904
   md5: eae62735d710cf5ff6d51e6f59fcd999
   depends:
@@ -1166,7 +1166,7 @@ packages:
   license_family: BSD
   size: 78148
   timestamp: 1676827253282
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -1177,7 +1177,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
   sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
   md5: 9508af80612e4fa1b5d1abb43ca7e63c
   constrains:
@@ -1185,7 +1185,7 @@ packages:
   license: GPL-3.0-only
   size: 749072
   timestamp: 1652971360657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
   sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
   md5: 88199c75f2ac211728febced7785c24e
   depends:
@@ -1195,7 +1195,7 @@ packages:
   license_family: Apache
   size: 228278
   timestamp: 1635523146417
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
   sha256: bb990ea068c3b3dafd9c807e0e19570320cb2fe7d69cc326f1f0b5319b0654b2
   md5: 3ff70744e396b1af69656c574b05c3b9
   depends:
@@ -1203,7 +1203,7 @@ packages:
   license: MIT
   size: 66940
   timestamp: 1714483221853
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
   sha256: 3b87a816f72a00e1f0022a160e7eda70af89d3de2a2e08a72be1c17b31d759f3
   md5: 4f57d3a0a13ddaf1c06efb586b702f46
   depends:
@@ -1212,7 +1212,7 @@ packages:
   license: MIT
   size: 34446
   timestamp: 1714483232430
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
   sha256: 2cf15e89f910600f468edfde8d0f9b80a14fa2319ed89160dc7375dfd3764fdb
   md5: 463adc13f2feea3570d1eccac368d9e4
   depends:
@@ -1221,7 +1221,7 @@ packages:
   license: MIT
   size: 295090
   timestamp: 1714483244460
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
   sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
   md5: 55dde57e63a36b202e388a39dcee9a66
   depends:
@@ -1230,7 +1230,7 @@ packages:
   license_family: MIT
   size: 74096
   timestamp: 1695996494461
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
   sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
   md5: 1af9b4d62c708924417f2640ef22a68f
   depends:
@@ -1240,7 +1240,7 @@ packages:
   license_family: MIT
   size: 154016
   timestamp: 1714483282916
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
   sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
   md5: 641e72e5067bd6d5454405879e1cd2a7
   depends:
@@ -1255,7 +1255,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 8895144
   timestamp: 1654090827491
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
   sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
   md5: 3080c2813e6e1d0f8a100a38b5b3456d
   depends:
@@ -1263,7 +1263,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 573231
   timestamp: 1654090775721
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
   sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
   md5: 1bffe1481ed4f88827248fb9001f8923
   depends:
@@ -1273,7 +1273,7 @@ packages:
   license_family: Other
   size: 362561
   timestamp: 1677841789536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -1281,7 +1281,7 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
   sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
   md5: 8c195584a5f5471b600ee180e4052773
   depends:
@@ -1289,7 +1289,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 6410287
   timestamp: 1654090800863
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
   sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
   md5: ef78eebd98289aceacdfa29182426adf
   depends:
@@ -1307,7 +1307,7 @@ packages:
   license_family: Other
   size: 664034
   timestamp: 1693575237924
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
   sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
   md5: 292768ec77416ae257cfdd44ea2071c8
   depends:
@@ -1316,7 +1316,7 @@ packages:
   license_family: BSD
   size: 29197
   timestamp: 1668082729834
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
   sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
   md5: 9cdeef1d044c7e035c006890f11569d3
   depends:
@@ -1327,7 +1327,7 @@ packages:
   license_family: BSD
   size: 436056
   timestamp: 1694776944891
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
   sha256: fd8e30beb8c9442f16e6617fac92dd0c89ec823e98f06e60f712147380ead35f
   md5: 7ed7caf2816c8b85b67b6f4e8833cbd5
   depends:
@@ -1337,7 +1337,7 @@ packages:
   license_family: MIT
   size: 41155
   timestamp: 1676837080881
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
   sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
   md5: 76f089e76ec67583bb38428b51008097
   depends:
@@ -1347,7 +1347,7 @@ packages:
   license_family: BSD
   size: 164494
   timestamp: 1714510587156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
   sha256: 260e26dd509834c1b225ab7bdb97b9a86e00054fbdd5dfa49e68fa4dcf85a661
   md5: 8f5d7ddc69cc6f7d44c80d2251dea5d1
   depends:
@@ -1356,7 +1356,7 @@ packages:
   license_family: BSD
   size: 162339
   timestamp: 1676837095436
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
   sha256: 7f5b0804d0768619b7bd93b10488067d80bf42ec29f443f00b53ba11758a1241
   md5: 8afb45e45c0d93bfd142e682d4b021ef
   depends:
@@ -1366,7 +1366,7 @@ packages:
   license_family: MIT
   size: 134438
   timestamp: 1684280014220
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
   sha256: cb03570c99c983d7bfda94bc47d8eb00d4059b8548a171130775acc998004195
   md5: 5b1abbbf1e4f9b350b16fc9caf9e889b
   depends:
@@ -1378,7 +1378,7 @@ packages:
   license_family: BSD
   size: 26919
   timestamp: 1704206397615
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
   sha256: 85fea48bea278a77d102781a1cbb6bf69307207d741251e38a6515c5fd7e3523
   md5: d6ddba94f7c33c88c9825be8409991bf
   depends:
@@ -1400,7 +1400,7 @@ packages:
   license_family: PSF
   size: 9150942
   timestamp: 1713336680714
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
   sha256: 7ac07ea180b5928086075900afbc332fb1d3c81ddfacb54c891693c284056f14
   md5: fc83dd1b3d2ec3c0a297ead0c3405907
   depends:
@@ -1410,7 +1410,7 @@ packages:
   license_family: BSD
   size: 19573
   timestamp: 1676823852670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
   sha256: c9ba2f9c83820712dd97d6a1b54a1215b9820a0be02ac82380b4c50911b9400c
   md5: e5dc6b4a5b8e02733ce3bc9e9198a8d2
   depends:
@@ -1420,7 +1420,7 @@ packages:
   license_family: MIT
   size: 67750
   timestamp: 1676837123613
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
   sha256: 1a5141ef0de1cbff816f96bb4b212a40606e2fc11301a4c1358c8d63a6b2b027
   md5: 22ac3bc22b68fef4c1f3f6ab3c7bfe0b
   depends:
@@ -1429,7 +1429,7 @@ packages:
   license_family: MIT
   size: 23040
   timestamp: 1676827301164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
   sha256: 9aacfbbe6f638c58a4e8ff31374d1438d78b7db25d6ea6fd0c50ca2109f225d4
   md5: e602057e3b3d80da88c61d66e8851c5b
   depends:
@@ -1440,7 +1440,7 @@ packages:
   license_family: BSD
   size: 104681
   timestamp: 1676823696152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
   sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
   md5: ce77d0f05f846da4a6b9e23fe7f21d9b
   depends:
@@ -1454,7 +1454,7 @@ packages:
   license_family: Proprietary
   size: 206738176
   timestamp: 1699648006088
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
   sha256: 2aef0876d0df033f7fae8cddbd25d95fc1bfc067e60dd143bd8000fec0768b21
   md5: d6cdc670327bd1675bbea642849f04e1
   depends:
@@ -1465,7 +1465,7 @@ packages:
   license_family: BSD
   size: 59569
   timestamp: 1682948560323
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
   sha256: 691c4b2b47cf3fac55b4949d7c0f547246ef19cb3510749142cee4bd01ffb055
   md5: bbd69efa3f24ee747410f83118640d92
   depends:
@@ -1479,7 +1479,7 @@ packages:
   license_family: BSD
   size: 240723
   timestamp: 1695058405382
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
   sha256: 71f5c7beca4e81b465ecfc6ed51cb3d39f51dd88df0b29eff5def3d1f12969eb
   md5: 61d58663b7277cf4cc3cb8d9873d3ee8
   depends:
@@ -1494,7 +1494,7 @@ packages:
   license_family: BSD
   size: 331105
   timestamp: 1695059935112
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
   sha256: 6116c133fbed1e7ea0f5e69f900e93d7977cb715920d10b10642c191d00cc9a6
   md5: b842f7ebdc8b7b6a0dda4c5ebe12805b
   depends:
@@ -1507,7 +1507,7 @@ packages:
   license_family: BSD
   size: 8315206
   timestamp: 1717622768176
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
   sha256: bb45fb0a3973caa74fd8f845e0a519895f6a378807626e15ecf72c02f2eed794
   md5: 185f658ba8a74e326b7231c8fd0d62bf
   depends:
@@ -1520,7 +1520,7 @@ packages:
   license_family: BSD
   size: 121834
   timestamp: 1698934274227
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
   sha256: 8b2fc372a6655fd5b277d07b994ce43643553fbc37e63a60e9fe527a9026ec06
   md5: ed6ac14aed5a796b153d757862398997
   depends:
@@ -1547,7 +1547,7 @@ packages:
   license_family: BSD
   size: 523905
   timestamp: 1699022906468
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
   sha256: 7908ff6c516b15e8fb677be4071145e18adea7d4c13b8485a70a5ee2f573f8cb
   md5: 50c0e38207a131a5de6a14ef919ffcdc
   depends:
@@ -1560,7 +1560,7 @@ packages:
   license_family: BSD
   size: 169629
   timestamp: 1694616826002
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
   sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
   md5: 57ea097dc15f8d9f9eb90e1d919143b0
   depends:
@@ -1569,7 +1569,7 @@ packages:
   license_family: MIT
   size: 1157733
   timestamp: 1674734069410
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
   sha256: 266199dd4efde0ad342a9c500f4bc4299c5622219aea623b46315a9b4f6b8959
   md5: 2b21844d2b0024d0ffad0e6450cf0855
   depends:
@@ -1578,7 +1578,7 @@ packages:
   license_family: BSD
   size: 15860
   timestamp: 1708532713870
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
   sha256: 59e169e036db0f2b98ed19f867d8ac708970214599efa0d57d3413fc1dbe8e3c
   md5: d0faf375bfc33811456d43fe549cb939
   depends:
@@ -1603,7 +1603,7 @@ packages:
   license_family: BSD
   size: 710152
   timestamp: 1717630833268
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
   sha256: ef2857e6d3d7eb246b3abddfbd3aa2d124dd8565391ace3876b77339babc50bb
   md5: d276d1b1774107987963135c78ca7390
   depends:
@@ -1613,7 +1613,7 @@ packages:
   license_family: BSD
   size: 26607
   timestamp: 1699455972519
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
   sha256: 2f89f38a665ece47e8868b391fc70602fcee588e989bc1ca6f17f6094892a94e
   md5: b788c80b2d571531ea4f3f8335ae5423
   depends:
@@ -1628,7 +1628,7 @@ packages:
   license_family: MIT
   size: 168827
   timestamp: 1696515597877
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
   sha256: e09e1aff2c12d4ef3fec58fb627744e4b5c7d9eaede7175e293f77272d8b8bfd
   md5: fe8242cfd54d238507493612ae697ad4
   depends:
@@ -1645,7 +1645,7 @@ packages:
   license_family: BSD
   size: 10270
   timestamp: 1708639794640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
   sha256: a53ad723826651041a5057a1cf31bc8689b24d335ce61b196df5124974b05a8e
   md5: 7b29e7191c4170189d6080e61229f030
   depends:
@@ -1661,7 +1661,7 @@ packages:
   license_family: BSD
   size: 9163911
   timestamp: 1708639777712
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
   sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
   md5: b0afe23033c8c5344640bc25225fa579
   depends:
@@ -1672,7 +1672,7 @@ packages:
   license: BSD 2-Clause
   size: 516994
   timestamp: 1630084830020
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.14-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.14-h5eee18b_0.tar.bz2
   sha256: 9d2e19a18f4d7b5586b21fc618c6641460561afb734927994be07e3731df16d8
   md5: 24b027db9e86b7aefde7add4375a6245
   depends:
@@ -1682,7 +1682,7 @@ packages:
   license_family: Apache
   size: 5493210
   timestamp: 1718385220783
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
   sha256: 280225061aeba00d7b85f46e55d7d79cd92c92f662dc749d9c53187978e8d083
   md5: c51c21da68080d89300703ad818c824a
   depends:
@@ -1691,7 +1691,7 @@ packages:
   license_family: APACHE
   size: 38606
   timestamp: 1699371264464
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
   sha256: bd3eacd22e85f88bedd9c7e97a59eacfb3c8bb80eb59be244825d6895a0e7ac1
   md5: 08ceb294ba8a9ae13630da789884736e
   depends:
@@ -1700,7 +1700,7 @@ packages:
   license_family: Apache
   size: 157904
   timestamp: 1710807470578
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.2-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-2.2.2-py311ha02d727_0.tar.bz2
   sha256: b5979b0d4ef5c09f9795acb6b5e322b404f4eab7d73b6ed0aa59f03ef7acd25b
   md5: 1a353daeb78baa6b5bf8f47e1e74ca1c
   depends:
@@ -1751,7 +1751,7 @@ packages:
   license_family: BSD
   size: 17976832
   timestamp: 1718310942026
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-1.4.4-py311h06a4308_0.tar.bz2
   sha256: 998038e45884a19dc198675b2bedb22d871997c6cb1e6ebf0f46321c7f3b0cce
   md5: bbcbcf863dc2295acdab40895df5e7ce
   depends:
@@ -1775,7 +1775,7 @@ packages:
   license_family: BSD
   size: 21902532
   timestamp: 1718119233499
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-2.1.1-py311h06a4308_0.tar.bz2
   sha256: face211fc35bfa199b6d02f8ed25372d1f1a2093518a79a9eec9925bcf9e6d1d
   md5: 9cd12fbc855d97b19427e911262e3bee
   depends:
@@ -1784,7 +1784,7 @@ packages:
   license_family: BSD
   size: 263218
   timestamp: 1719348029519
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
   sha256: 28ed719669260a20bec78971edaffb91ec917d2a3f0fac1cf9a8ba21590baa43
   md5: 0481d078fcd64f7f981532a514d9d50d
   depends:
@@ -1801,7 +1801,7 @@ packages:
   license_family: Other
   size: 960727
   timestamp: 1714399060039
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
   sha256: d527189038b376a982c18613df808f25dc40314b0dc8fe5549f3ae9f4288e497
   md5: 68dad015e796cc26364b55f92f61faa7
   depends:
@@ -1812,7 +1812,7 @@ packages:
   license_family: MIT
   size: 3451714
   timestamp: 1715097126399
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
   sha256: d2bbab8bfc57c7f46ca8994bc87df7e744d3f036b867bc4be1145ba6d8d7e091
   md5: de41707272a8e3ccab764f0b7010a27d
   depends:
@@ -1821,7 +1821,7 @@ packages:
   license_family: MIT
   size: 37394
   timestamp: 1692205565974
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/plotly-5.22.0-py311h92b7b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/plotly-5.22.0-py311h92b7b1e_0.tar.bz2
   sha256: 96bba3ae7f93e3d9445b7ad732702fd85766fa6c365193c0362496f735c18540
   md5: aa8152ca2935f0127fc3b5ebc045fef8
   depends:
@@ -1835,7 +1835,7 @@ packages:
   license_family: MIT
   size: 10723879
   timestamp: 1718137102876
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
   sha256: e2a0e2a618aa33f0beff9583c7dc510b8d0737b023117346676aacbad33970d8
   md5: 66a6818307261b1a28ab12d1b7776fdf
   depends:
@@ -1844,7 +1844,7 @@ packages:
   license_family: Apache
   size: 121454
   timestamp: 1679340540306
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
   sha256: b7f591c19b10bf0daa7e6e3b45a9f4a0a0e83188e1f8a58037caea79e60f8d91
   md5: d945b4ccc135005839c504cc29df1745
   depends:
@@ -1856,7 +1856,7 @@ packages:
   license_family: BSD
   size: 749608
   timestamp: 1704404477511
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
   sha256: 96482b49191fdac59580a95e69508367083e1f7600145e11d7c2db634337eb26
   md5: 2d57bf8eacf3f291db845928241f724c
   depends:
@@ -1866,7 +1866,7 @@ packages:
   license_family: BSD
   size: 490805
   timestamp: 1679337420563
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
   sha256: ed927e4d058a8f4ea73edc7a43ed74877d93b88fdfa240b3b2777244386ced70
   md5: a1f0e05fc7e49712f81ad5478ec9d51e
   depends:
@@ -1875,7 +1875,7 @@ packages:
   license_family: BSD
   size: 2121496
   timestamp: 1684280065800
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
   sha256: ad219924e362ce7af458fa6547660181579e9a50e5aed1ffd9268cbe7c2650e3
   md5: 2b1ac40e0df3673d33b7f4c4f93ae1ef
   depends:
@@ -1884,7 +1884,7 @@ packages:
   license_family: MIT
   size: 207338
   timestamp: 1677811584327
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
   sha256: 114b55e00f4622c90fd2b404b21ad5f94a10283fcaaf86a42174b8d39b0a3e98
   md5: 2458e92683cc68671a6c8e1b86ce8817
   depends:
@@ -1893,7 +1893,7 @@ packages:
   license_family: BSD
   size: 35850
   timestamp: 1676822725516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
   sha256: ef622eb34669f3518d2f855cb333c56b106d02cdeac9d58e5a1a5a3097e4978d
   md5: 9d4f211d050d511b0b84c2e57e7fb1d7
   depends:
@@ -1915,7 +1915,7 @@ packages:
   license_family: PSF
   size: 36072860
   timestamp: 1713546307595
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
   sha256: a0f008717fab060ccd003dfebc09156d90b9afd14ac3626566aa1a8f3d3b7e2f
   md5: 357bf4fe94496cbae72ab4d780184b31
   depends:
@@ -1925,7 +1925,7 @@ packages:
   license_family: BSD
   size: 330924
   timestamp: 1716495762901
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
   sha256: aadc4078311c059265706a56265f0a57ceb538d36179d5203dd487d80d0e8f16
   md5: 59ec670fcd172447dbd9591b8fbfdd56
   depends:
@@ -1934,7 +1934,7 @@ packages:
   license_family: BSD
   size: 278741
   timestamp: 1679340144625
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
   sha256: d5058d0ecc3973316c1d5f1bfb03dd119e0dade85f4c2d21b412c8db4e1636f2
   md5: 93000e4d3603342779a2afda66fa91b8
   depends:
@@ -1943,7 +1943,7 @@ packages:
   license_family: BSD
   size: 17607
   timestamp: 1683823841946
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
   sha256: b85acb933fff864bfa89d034e8e3d85b1a9c2e69cbfc0d68c1d66ffd1443e67d
   md5: 0cdb92d2d684ee1095310f992ed0d9b2
   depends:
@@ -1952,7 +1952,7 @@ packages:
   license_family: MIT
   size: 266796
   timestamp: 1713974338678
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
   sha256: 511e8206a15445715b80be76493300930686b3fe1e512ae942d6ccca36df392a
   md5: 35a6e46ae970f8b71d78fb5a810f2e80
   depends:
@@ -1964,7 +1964,7 @@ packages:
   license_family: BSD
   size: 64013
   timestamp: 1711136926372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
   sha256: b2a1f649669f4336b74f6f20df711959bcd8024f8f8b94199dc0e040b06bd37a
   md5: f9e8e3f7068f717f75e555dc04545d8d
   depends:
@@ -1975,7 +1975,7 @@ packages:
   license_family: MIT
   size: 206433
   timestamp: 1698096204677
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
   sha256: 7c74db4292f31619606180f86f3c1e2d913495c2c9d1195c5d51681a6a841625
   md5: be1c05fae57d194924b9400f9b5ad3c6
   depends:
@@ -1986,7 +1986,7 @@ packages:
   license_family: Other
   size: 613277
   timestamp: 1709318516682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
   sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
   md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
   depends:
@@ -1996,7 +1996,7 @@ packages:
   license_family: GPL
   size: 467661
   timestamp: 1666648052561
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
   sha256: 89c2f4235277b9825cc805c5c44f0b1afcb683d7b5a3f513bc4bf243b643bb0c
   md5: db70eb57e33adf7b8bbdadd72214d48d
   depends:
@@ -2007,7 +2007,7 @@ packages:
   license_family: MIT
   size: 73679
   timestamp: 1699012111499
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.32.2-py311h06a4308_0.tar.bz2
   sha256: 12c831fad9b6e0acd3821819072a81c4ed7007e90f2daa9c711732b69c57548b
   md5: 0b9387d074f6714268bcc44c1f2634d9
   depends:
@@ -2023,7 +2023,7 @@ packages:
   license_family: Apache
   size: 121943
   timestamp: 1716902856135
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
   sha256: fdae3f68ea84b99561aee6c566ab1c287d8f2ae2668424e9283a8ed86af8f1d2
   md5: cde5b71ccbb3630053340b2c8c7dbf10
   depends:
@@ -2033,7 +2033,7 @@ packages:
   license_family: MIT
   size: 9333
   timestamp: 1683077183576
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
   sha256: 0bf859b06a07857099fd4f524fe5e0875fda70029e9485d95c7efa97134fbc14
   md5: fd5815cc592fdbd4c831901541eadaba
   depends:
@@ -2042,7 +2042,7 @@ packages:
   license_family: MIT
   size: 9735
   timestamp: 1683059096795
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
   sha256: 474553d01aea57214a54a7443f227da84a58e29c49eb7605ba0043c55b7d167a
   md5: f01333e9f0a908e435db650f42fbd2db
   depends:
@@ -2052,7 +2052,7 @@ packages:
   license_family: MIT
   size: 1096668
   timestamp: 1698946168635
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
   sha256: 51bcea0e575a626f6ffbd16d1153330fda93dbe3dd31dcd3a8f469ff61dd1e4e
   md5: 41d531c90be8c82bf79635ff3d409476
   depends:
@@ -2061,7 +2061,7 @@ packages:
   license_family: BSD
   size: 32295
   timestamp: 1699371262818
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
   sha256: 0a95988ea269c96354626dcab255b65b54bb5c503d24cdeb6ef2e1c42818bd59
   md5: 8bfb9f42492b3b53b8151d77e51c75d8
   depends:
@@ -2070,7 +2070,7 @@ packages:
   license_family: MIT
   size: 1594974
   timestamp: 1715024182643
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
   sha256: 1a84b00944bc5588e14a097460175f97df49acb4f1ff2498ffd9a1893068ed81
   md5: a456513471b2ecbed60430c21dd1ccc7
   depends:
@@ -2079,7 +2079,7 @@ packages:
   license_family: Other
   size: 17880
   timestamp: 1705431390054
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
   sha256: adcafd297d60af64107c113bb7b8b92160d0268a44ef9a3b79e56a88a0358ea7
   md5: 28ed704ed26b06d32662e3a6a87e59b0
   depends:
@@ -2088,7 +2088,7 @@ packages:
   license_family: MIT
   size: 88799
   timestamp: 1696347581401
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
   sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
   md5: f86119b3243fe3508160aa0406245738
   depends:
@@ -2101,7 +2101,7 @@ packages:
   license_family: Other
   size: 1723866
   timestamp: 1714488309729
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
   sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
   md5: 041a3caf09dc9ce8fc6c10925c4fe050
   depends:
@@ -2111,7 +2111,7 @@ packages:
   license_family: Apache
   size: 1888016
   timestamp: 1680167274961
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tenacity-8.2.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tenacity-8.2.2-py311h06a4308_0.tar.bz2
   sha256: 06b018d5bc7e446528070bb083cf5b9b679842a536925ae6d4596abb3af50ada
   md5: a3659c3a781d02a8133c3717880f8819
   depends:
@@ -2120,7 +2120,7 @@ packages:
   license_family: Apache
   size: 47169
   timestamp: 1682972395198
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
   sha256: 856a8ab8c350c50247b79966c6cb80fb6d4de36eef49ddf75aebbbcaf854c82d
   md5: 442dde204d14d171aab9ee40e8de4de8
   depends:
@@ -2131,7 +2131,7 @@ packages:
   license_family: BSD
   size: 37456
   timestamp: 1677696176157
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
   sha256: f0a026ddc0ed041bfc60c8a1ca0b70b7a69232775b3181bfb35a39fda42d6994
   md5: 2902d5a5854865baaaf58dc59cf06b3c
   depends:
@@ -2141,7 +2141,7 @@ packages:
   license_family: BSD
   size: 49185
   timestamp: 1676823769869
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
   sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
   md5: e2512d57c8a1e91e7b20e265c6906546
   depends:
@@ -2151,7 +2151,7 @@ packages:
   license_family: BSD
   size: 3588922
   timestamp: 1714770676475
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
   sha256: e58ff4a82819446f3c92e5b1aa2a784c4b06643e751fe67cf115858296dbfa50
   md5: 32ee4723173f1fad5563b8afb5f1c8f1
   depends:
@@ -2160,7 +2160,7 @@ packages:
   license_family: BSD
   size: 135634
   timestamp: 1676827536101
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.1-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.4.1-py311h5eee18b_0.tar.bz2
   sha256: 394fdf404ede3bc35d697b2e445c42590ddcae86a80f39642cc5366196fcbe54
   md5: a21cbca0664d8f34b0dca1f84998a31b
   depends:
@@ -2170,7 +2170,7 @@ packages:
   license_family: Apache
   size: 914199
   timestamp: 1718740165334
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
   sha256: 54f41afbea1c01a10e5703e64645de145f34ad6d89cf245fbc5cfaaff58a8743
   md5: 15b6c8bee4c28c6efb3e388178b37145
   depends:
@@ -2181,7 +2181,7 @@ packages:
   license_family: MOZILLA
   size: 154276
   timestamp: 1716395957568
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
   sha256: 2091b17ae4fa46ed98fd6bfe9ca1aff3b0b81d73045e0cc55774b6516b8704b3
   md5: 183ae7b837c1c68ec1a8011011fadea7
   depends:
@@ -2190,7 +2190,7 @@ packages:
   license_family: BSD
   size: 206924
   timestamp: 1718227183177
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
   sha256: 8c06c291c76e8c2022ffbb9fea4727a4bf1f9b03e498bafc56ba8ac4e7604ab9
   md5: 5adb7baf1091d09026a372cac930ce6c
   depends:
@@ -2200,7 +2200,7 @@ packages:
   license_family: PSF
   size: 8869
   timestamp: 1715268966416
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
   sha256: 118b0801167264c401e84bbf19175546092a5569cc098146f7362bbf890dc8d9
   md5: b3c2aa56d53b459f8365d8385f48d0c3
   depends:
@@ -2209,7 +2209,7 @@ packages:
   license_family: PSF
   size: 74489
   timestamp: 1715268960737
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
   sha256: 509b962773f0fe44a93a7f6196b254670a030eac8ea7f90727312e3ccd9294b2
   md5: 6c402d5bf4e01c8c3895c9ef41707b6e
   depends:
@@ -2218,7 +2218,7 @@ packages:
   license_family: MIT
   size: 11371
   timestamp: 1676828901104
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
   sha256: bbe7629e8ce52c82f13ed0d1fb919f3659ef466b274a7c74aa925a9bc7aee450
   md5: 7da527bbcf71270c1abed8ea52e7d44c
   depends:
@@ -2228,7 +2228,7 @@ packages:
   license_family: Apache
   size: 509031
   timestamp: 1713213062098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-2.2.2-py311h06a4308_0.tar.bz2
   sha256: 2de4e4586d3b1cbfa8ecfcfaaa148da3b005b303e0784be2d6c2e54a3a13d362
   md5: 3345015e0af00cc31acb88167a842381
   depends:
@@ -2244,7 +2244,7 @@ packages:
   license_family: MIT
   size: 209169
   timestamp: 1718912749915
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
   sha256: c3a5e0b855dc2de6c162708dfcf170a23eb9e7525d4252d8dce553369af4a330
   md5: a4c77e204b7787f820955166a1283168
   depends:
@@ -2253,7 +2253,7 @@ packages:
   license_family: BSD
   size: 25890
   timestamp: 1676823132898
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
   sha256: 42989f9970a8466cc4edb73463dfa194594dd1a5d42c9f820a1f86296d4af140
   md5: 655dfd4d2f17977cb81caa1c082d2b25
   depends:
@@ -2262,7 +2262,7 @@ packages:
   license_family: Apache
   size: 113505
   timestamp: 1715878346465
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
   sha256: eec0d2e0bce4b62278cacd7b0bee053160845e86507051a5434d2069bd290f36
   md5: a069e5aef64a6dac076cc9a3d28a17c9
   depends:
@@ -2271,7 +2271,7 @@ packages:
   license_family: MIT
   size: 136022
   timestamp: 1714717059748
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
   sha256: d18cdca154bf668826f869117ea996c4f9e8ef7d27b7c528332a7d17e5a8602c
   md5: 9f7353d72046b16dd6ef6b5689ac9bfd
   depends:
@@ -2280,7 +2280,7 @@ packages:
   license_family: BSD
   size: 54731
   timestamp: 1676828934954
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
   sha256: 9122d6e9dabb7a47f2bcb15d86b97c96c49a9048da3f8ae59675351710c14cc5
   md5: 660b2aead2ec87b751c86cd33934f44e
   depends:
@@ -2289,7 +2289,7 @@ packages:
   license_family: GPL2
   size: 716926
   timestamp: 1714510796277
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -2297,7 +2297,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
   sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
   md5: 943f1247a22b6b64171363bcee1eec27
   depends:
@@ -2308,7 +2308,7 @@ packages:
   license_family: Other
   size: 371663
   timestamp: 1705602144682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
   sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
   md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
   depends:
@@ -2317,7 +2317,7 @@ packages:
   license_family: Other
   size: 127143
   timestamp: 1714510716441
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
   sha256: af3c032f06352e87c450739cb8aafe1ff34ad28bf074b214ea98b3d29259a85d
   md5: 51fa34bd0e016ed7c5371cf6cb13ef6c
   depends:
@@ -2330,7 +2330,7 @@ packages:
   license_family: BSD
   size: 1044463
   timestamp: 1714678445052
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -2343,7 +2343,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -2353,7 +2353,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -2365,7 +2365,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
   sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
   md5: 544adf2677c47c9b9c891aea720678f1
   depends:
@@ -2373,7 +2373,7 @@ packages:
   license: MIT
   size: 33999
   timestamp: 1630003259346
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -2382,7 +2382,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -2391,7 +2391,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -2400,7 +2400,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -2409,7 +2409,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -2417,7 +2417,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -2426,7 +2426,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -2435,7 +2435,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -2445,7 +2445,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
   sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
   md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
   depends:
@@ -2454,7 +2454,7 @@ packages:
   license_family: BSD
   size: 5106
   timestamp: 1704404390460
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -2462,7 +2462,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -2471,7 +2471,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -2480,7 +2480,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
   sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
   md5: 02caf3f47f1d06256068053297355740
   depends:
@@ -2489,7 +2489,7 @@ packages:
   license_family: Apache
   size: 152292
   timestamp: 1690578151230
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -2498,7 +2498,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -2510,14 +2510,14 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
   sha256: dc9f709bacbaf08a0941d2622d82f91f18b355e82c55348ec29f1391215ca7e0
   md5: ece0f5837a4de2d4d5f1abf8347cd10a
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 124922
   timestamp: 1708711884650
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -2525,7 +2525,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/altair-5.0.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/altair-5.0.1-py311hecd8cb5_0.tar.bz2
   sha256: e6c4194bc4ac3c285b9d77d1e44689026dbe3b5b3c056576247bd04a532420e5
   md5: 74c44a80a2a1140dce26f799cc424a78
   depends:
@@ -2539,7 +2539,7 @@ packages:
   license_family: BSD
   size: 856738
   timestamp: 1687526271729
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
   sha256: 5800a2466734dd1ef372bec0dd3f0880c5072fa1e8b0668f5054f834285e991c
   md5: 18194e51d4420ac08f29f3f86581b52e
   depends:
@@ -2553,7 +2553,7 @@ packages:
   license_family: MIT
   size: 229003
   timestamp: 1706220302459
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
   sha256: ab7672364f1fa55ec5d8311d85d40e5b57cbd3517b17670557b6fb822bcf759c
   md5: 6e0159a5865cb7e96a748bd8560035ee
   depends:
@@ -2562,7 +2562,7 @@ packages:
   license_family: BSD
   size: 11579
   timestamp: 1678317458652
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
   sha256: 51556902e09436d46878ef772805d06416ca96ffaa66340b5565c0245574aaf5
   md5: 4cb1b20635cf5431d34cc96ca1e8a751
   depends:
@@ -2572,7 +2572,7 @@ packages:
   license_family: MIT
   size: 33355
   timestamp: 1678317111825
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
   sha256: 188b74f717e3ce3595da404c0e027b8ccafa9c186e88325e8f02c29d7b4c0744
   md5: 04ad90eead5812a0263b42321056ab33
   depends:
@@ -2581,7 +2581,7 @@ packages:
   license_family: MIT
   size: 153694
   timestamp: 1695717975427
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
   sha256: 365824e639808e52809f97b70b65da94a5eeb87e29dd97c8926aa72707a5a1c7
   md5: db7813418dfe42d59363fed4a68d5c36
   depends:
@@ -2591,12 +2591,12 @@ packages:
   license_family: MIT
   size: 278195
   timestamp: 1718029905185
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
   sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
   md5: e2f3248e2a5009a02f7b8e54f83314ef
   size: 5620
   timestamp: 1528121955725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.1-py311h85bffb1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-3.4.1-py311h85bffb1_0.tar.bz2
   sha256: ace9b81e898a3180d2fb07c75326414ec4cbaed62efff54e42feb6d59774ccab
   md5: 1aa0dfcb172854f56447096c70d6a005
   depends:
@@ -2614,7 +2614,7 @@ packages:
   license_family: BSD
   size: 6076891
   timestamp: 1718119694797
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
   sha256: 9acafafcaebd653c2372ddc864525722e1c55b884b5eba22e28e2b2d946b853c
   md5: 22375cc3c2edada31b85af56c8e6dee6
   depends:
@@ -2624,7 +2624,7 @@ packages:
   license_family: BSD
   size: 155829
   timestamp: 1707864406086
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
   sha256: d8b1ccb15297dcfb3f9ebb8139c3e28a13d6c2e73c37612cb214ab6cc58b15fa
   md5: e5dec9f13de061640ad2697562a99b54
   depends:
@@ -2634,7 +2634,7 @@ packages:
   license: MIT
   size: 19732
   timestamp: 1714483415038
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
   sha256: e9fda4393edd0234c88efc2b88e0edf42c94eb49ea5b189a80afd733058be8fb
   md5: 13ceed558eb174d6b77ed1b0035f1785
   depends:
@@ -2643,7 +2643,7 @@ packages:
   license: MIT
   size: 18400
   timestamp: 1714483395748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
   sha256: a323af3251e426962ad16edf8f46a696ef502731faf12aee32ca289c40b11342
   md5: 658ce49e9f07dba7a1afe70fa2666e0a
   depends:
@@ -2652,21 +2652,21 @@ packages:
   license: MIT
   size: 393858
   timestamp: 1714483549536
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
   sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
   md5: c5a600d81b1b48578863af2973c743ac
   license: bzip2-1.0.8
   license_family: BSD
   size: 187637
   timestamp: 1714510590009
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
   sha256: 0c5f9766aa2dcc08ae71b6c0102046a56b30297d0bedc3039b7f72d1658baa43
   md5: 34583b436e62a2ce55d6a7e8eb818e33
   license: MPL-2.0
   license_family: Other
   size: 138712
   timestamp: 1710764814844
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.6.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2024.6.2-py311hecd8cb5_0.tar.bz2
   sha256: 761b76b8878af5f46f978e343f8b5bb4e74f96b0efa4d0856dc191ca4191b20f
   md5: 7a636bdde91b0c3aa0815a4abff2c6d2
   depends:
@@ -2675,7 +2675,7 @@ packages:
   license_family: Other
   size: 167328
   timestamp: 1717618090475
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
   sha256: 6b5bebc13755b0a5ef423219eeecd1c25b97dbe83afad6e2552635387547d9f7
   md5: b7bc4192fcfed7fc7df1ce00bce97b02
   depends:
@@ -2686,7 +2686,7 @@ packages:
   license_family: MIT
   size: 291802
   timestamp: 1714483319125
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
   sha256: 9270668e34b00a2605584a2db5130c83826855cd05b896ce949f3156fa197429
   md5: 2586aa55677e822e8285d777f9039ca9
   depends:
@@ -2695,7 +2695,7 @@ packages:
   license_family: CC
   size: 543487
   timestamp: 1709758497949
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
   sha256: 389c63a84b92a6254c9d361ebe970d537d0b88733efd5ac5c3ee58196fd2c5a9
   md5: c7bc5b3cbe76be83a27f00b7e4740727
   depends:
@@ -2705,7 +2705,7 @@ packages:
   license_family: BSD
   size: 17974
   timestamp: 1709323004148
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
   sha256: bebfc5aa6be12e61a134b580b07b67f7d8c045d6b113fca5b21fa1e83a2f03ce
   md5: 239df72a3921c951059fa8afc09643f6
   depends:
@@ -2716,7 +2716,7 @@ packages:
   license_family: BSD
   size: 287736
   timestamp: 1700583644534
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
   sha256: e0e30590a78d99d51445ac4f668aefe1bf20025a35bdbac00f04647b95c9f152
   md5: bd0db635eefeea82a0c567b39c9a0e3d
   depends:
@@ -2726,7 +2726,7 @@ packages:
   license_family: MIT
   size: 2485698
   timestamp: 1690905283575
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
   sha256: d48b47b86b09dac1fa4542ec13e1bd4e23093638e684fa66ec3afdd9ce9337c1
   md5: 5a2d1828ab7c8eccd3c2610d13672977
   depends:
@@ -2735,7 +2735,7 @@ packages:
   license_family: MIT
   size: 17336
   timestamp: 1678316187749
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
   sha256: 54645c22fabc25b632114d1d3c403a6fad9149b51ab36719b2690a084f14a072
   md5: a8ad2f4abfb2e17ecf6e596342528156
   depends:
@@ -2753,7 +2753,7 @@ packages:
   license_family: MIT
   size: 3180691
   timestamp: 1713551771692
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -2763,7 +2763,7 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.19.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.19.0-py311hecd8cb5_0.tar.bz2
   sha256: b718db18f202153cd6625f0cea81b97f9b59830db03b1cdf7af0af798bcbd46d
   md5: 87cc8c19c172d322f93107dc619a4c89
   depends:
@@ -2783,7 +2783,7 @@ packages:
   license_family: BSD
   size: 6062014
   timestamp: 1718294749778
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 50dee40e4a9ea7a035baeecc85770c88d63d4e6b0c3c2519c1429e881171150c
   md5: 4d465f453dca5c65224dccbe953f600c
   depends:
@@ -2800,7 +2800,7 @@ packages:
   license_family: BSD
   size: 359293
   timestamp: 1715090716440
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
   sha256: 5c2458964157fe493ca18c513c693b70cb622087e5fa0c93e65fc45217edd811
   md5: 15629e52625221b51a443cefd9501d12
   depends:
@@ -2809,7 +2809,7 @@ packages:
   license_family: BSD
   size: 148522
   timestamp: 1714398885844
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
   sha256: e0127f50d444bf4474e8df07d602c7f6dd38690e8bb3fb28817c164940ffcde1
   md5: 583fcd7060cad6a77074d00d9ef62f44
   depends:
@@ -2818,7 +2818,7 @@ packages:
   license_family: Proprietary
   size: 731417
   timestamp: 1699647668990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
   sha256: eb58fa29b1ce9aa5fc774d4c466696457695dec3b206456614b4c9cac0a94e42
   md5: 3d3291ff58dff83dcd40ec54b435f4d2
   depends:
@@ -2840,7 +2840,7 @@ packages:
   license_family: BSD
   size: 229910
   timestamp: 1705934029588
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.25.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.25.0-py311hecd8cb5_0.tar.bz2
   sha256: b9d1a68433aed414dbdce4b9acc85b371503009926f516882c018331a56115d4
   md5: ba378a5e3c95af1eba43575438fa528e
   depends:
@@ -2858,7 +2858,7 @@ packages:
   license_family: BSD
   size: 1626808
   timestamp: 1718288248788
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
   sha256: e08cda2bcbdec124c63e951eb248c503bb1467c2a6000010c6bdc0726e0e00b7
   md5: 22c24f43b82da8b3920a913bbf452421
   depends:
@@ -2868,7 +2868,7 @@ packages:
   license_family: MIT
   size: 1168968
   timestamp: 1679336359851
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.4-py311hecd8cb5_0.tar.bz2
   sha256: b80384bec95335d8ad37895f5cfd2d8fdfaae7be05507f218344ddb5c6713d38
   md5: 8ac4f4807344f09b39c1b303cd2d1937
   depends:
@@ -2880,14 +2880,14 @@ packages:
   license_family: BSD
   size: 356777
   timestamp: 1716993516277
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
   sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
   md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
   license: IJG
   license_family: Other
   size: 278924
   timestamp: 1677849185191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
   sha256: 99fc6ac82c56eb2a580f96db24a5b887f8abc8c24af445d3313d5ebb48598478
   md5: 71892160908a6daedb5fb7c404079ae4
   depends:
@@ -2900,7 +2900,7 @@ packages:
   license_family: MIT
   size: 182073
   timestamp: 1699041732321
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 0ea44d0c8044e70ab0eaf4d6f5f3e4753838dee106b5cbd36561e21a65cbac77
   md5: 1d045016dca889d702f1caf3a16162fc
   depends:
@@ -2910,7 +2910,7 @@ packages:
   license_family: MIT
   size: 16528
   timestamp: 1699032525791
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
   sha256: 70442ec4b0b7ebbdcf150963f61f797b861001092124f4ea39a16eb92a4d176e
   md5: 63d1503915a15ae4f9ad1c46112ca374
   depends:
@@ -2926,7 +2926,7 @@ packages:
   license_family: BSD
   size: 272720
   timestamp: 1678316970740
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
   sha256: e657ec0667481d957827be1ce825b0a971aa3a211b07c1274d2c1099ded3129c
   md5: 5e317fd45011a0003c29331a8002cb75
   depends:
@@ -2937,7 +2937,7 @@ packages:
   license_family: BSD
   size: 98632
   timestamp: 1718818439542
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 2634d721123ea1e41b6e1cfe4a67552ec520ea9b5154c9e788ccb09d4745b732
   md5: e874eba19b493b7a68161429f24b8f51
   depends:
@@ -2953,7 +2953,7 @@ packages:
   license_family: BSD
   size: 43102
   timestamp: 1718738272613
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
   sha256: c353480ed4744c2a16aaccc1649bab38144436ad6d16ac2937e3e333d32fdccc
   md5: 7de25bdf4cfd3f5485d790d9cddf427f
   depends:
@@ -2980,7 +2980,7 @@ packages:
   license_family: BSD
   size: 619935
   timestamp: 1718828240904
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
   sha256: fd7964657f0a8fe8b167ba860b1f960e8b7b45309eb6c7c850d50ec283fe03b5
   md5: 2967bb345bc75f53182e263ff4743ca6
   depends:
@@ -2990,7 +2990,7 @@ packages:
   license_family: BSD
   size: 28223
   timestamp: 1686870845224
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
   sha256: 64cf59f0f74b0329b5069bc6135b4f40593f1dac52d85ad574d4b8e0a4b2cf16
   md5: 35e8b80eaa03a904fc7f1da39e7f654d
   depends:
@@ -3002,7 +3002,7 @@ packages:
   license_family: BSD
   size: 20234
   timestamp: 1700168776500
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
   sha256: a12382b50416803f559a03fb384ba492c1dafa351e1191a3f8dc361bee6c4f37
   md5: f2ae846b663bbb642f4b1e90eaad38a3
   depends:
@@ -3012,7 +3012,7 @@ packages:
   license_family: BSD
   size: 64817
   timestamp: 1678322501509
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -3022,7 +3022,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -3031,13 +3031,13 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 685c3bc9068bd485604b80bf03789e4dca95c410d33871bc1b882e47649fabed
   md5: 6cf8e55271e150ca0961d0ddedaa61bb
   license: MIT
   size: 66237
   timestamp: 1714483284541
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 69826cee54db9955f0120af21ec36d13f9211877fd67364f2068d0a54c6c97cd
   md5: 0851917257f490d35e1f73da8a1c723c
   depends:
@@ -3045,7 +3045,7 @@ packages:
   license: MIT
   size: 34042
   timestamp: 1714483343147
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 3f5a1f03b50b90b397a0ee432ad0cba13354abdaf7e5652c0fc60164b26a08b6
   md5: a50bdc871ef4bf14deb088d888b92b5e
   depends:
@@ -3053,28 +3053,28 @@ packages:
   license: MIT
   size: 311597
   timestamp: 1714483371586
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
   sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
   md5: 822a5b76117e56d3912f1f2153307528
   license: MIT
   license_family: MIT
   size: 136045
   timestamp: 1714483561919
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -3083,13 +3083,13 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -3106,7 +3106,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
   sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
   md5: 46a65d1fc24013217e06aaf6d65ffcad
   constrains:
@@ -3115,7 +3115,7 @@ packages:
   license_family: BSD
   size: 425478
   timestamp: 1694776947990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
   sha256: d28c465ec6d5f8d4962c597b249b58998300c8b4e3c937c578c3d15294ea863d
   md5: dcaed6ddd0723c7cce6bfad917be98b2
   depends:
@@ -3125,7 +3125,7 @@ packages:
   license_family: MIT
   size: 41176
   timestamp: 1678413498410
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
   sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
   md5: 8f57dc3a3327bb6f7e1cba908856ac7f
   depends:
@@ -3134,7 +3134,7 @@ packages:
   license_family: BSD
   size: 183138
   timestamp: 1714510756758
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
   sha256: 6fb2953e169ee1ae38f24d29752051501992f19b96b5ebcea9af75737bdbcb42
   md5: 7f410cdae838c5030108d1b98a8c78f6
   depends:
@@ -3143,7 +3143,7 @@ packages:
   license_family: BSD
   size: 162478
   timestamp: 1678377892595
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
   sha256: cd97e09a12ffb49b2a30a782fa8c7933b28f5ffdbfc5c73a9ebaa95fc9447370
   md5: d1fb6ebc1e5728aa6377cfc71da08942
   depends:
@@ -3153,7 +3153,7 @@ packages:
   license_family: MIT
   size: 135859
   timestamp: 1684280005320
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
   sha256: 30c3b189462a9d0f4794d229adadf34b5f5a5f56f95c30d5afc17ef524579290
   md5: d4e9421243129d1d57c472dab045f3dc
   depends:
@@ -3164,7 +3164,7 @@ packages:
   license_family: BSD
   size: 26639
   timestamp: 1704206159955
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
   sha256: 080000a28b3ceca54eec6de0748c690ea5a4c390e358283eac03fe7a6dd87065
   md5: 51344eca57d7940fb01eb5e8914509e3
   depends:
@@ -3186,7 +3186,7 @@ packages:
   license_family: PSF
   size: 9099909
   timestamp: 1713336790553
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
   sha256: 07e7fd5bd64e55328b4b99d92e2e2600d791f1095bf905daab4cfc59f0f0a45b
   md5: cf53321779f4ca7e986c1468719b93f1
   depends:
@@ -3196,7 +3196,7 @@ packages:
   license_family: BSD
   size: 19500
   timestamp: 1678317565001
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
   sha256: 0770e02be1ea1216af493cfc03d5b8a702e14606fa93b0692bcdab1fed1b898c
   md5: ca6f06ceaf66a32bbf5dfdb6e373a5cf
   depends:
@@ -3206,7 +3206,7 @@ packages:
   license_family: MIT
   size: 67892
   timestamp: 1678417734353
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
   sha256: fbe95ed0501bb0f137048476fe41bc718dd659e8ecb066bc67ac17d6a50f4318
   md5: ec162bde8d1c8a107b257df218b17035
   depends:
@@ -3215,7 +3215,7 @@ packages:
   license_family: MIT
   size: 23030
   timestamp: 1678381838497
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
   sha256: c20dd678655e582129a858a1c5162bdc254082d3a3c035b0f72629d9276e5b75
   md5: 800a0738c728796e02d0386ce7d457aa
   depends:
@@ -3226,7 +3226,7 @@ packages:
   license_family: BSD
   size: 104585
   timestamp: 1678317269407
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
   sha256: c825bc3070f73318ffff88a7a0b7fc6d1858b058ced735efd1789053f1583918
   md5: dea5f96459c9a6df6b026ca57d387936
   depends:
@@ -3239,7 +3239,7 @@ packages:
   license_family: Proprietary
   size: 224299920
   timestamp: 1699647835748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
   sha256: a76c134ec258612ff7d55cb2a19b9e3461cbbd375a744bd29390af9cfcd283b2
   md5: 1c736f58992009f53f014aef163bae31
   depends:
@@ -3249,7 +3249,7 @@ packages:
   license_family: BSD
   size: 48442
   timestamp: 1682969160267
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
   sha256: bcfb0d1e075d043bcf05fa1a7ce3c142bf222d29693366af49a5a346c770812f
   md5: 59e4820b34049cbc6619a8ac97290abc
   depends:
@@ -3262,7 +3262,7 @@ packages:
   license_family: BSD
   size: 222137
   timestamp: 1695058350477
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
   sha256: 114e408c40b332393cf2792393e4d1ede3465abcb3d345fe647ee519565346c8
   md5: 86b13271578e1fa5e664edcf6fcb3ce4
   depends:
@@ -3276,7 +3276,7 @@ packages:
   license_family: BSD
   size: 296860
   timestamp: 1695059990370
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
   sha256: f961b1322b6b02fee53ff9bd0f56bb73886eb59debd3f3666669593de7f48894
   md5: a1e74ccd2f341d1d672e33d79e60d200
   depends:
@@ -3289,7 +3289,7 @@ packages:
   license_family: BSD
   size: 8183400
   timestamp: 1717623127275
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
   sha256: e08cb3ee6df01f4c1e1ac8bc4ed1a06e549ffcc8774fe2e2842c644bb8f74a86
   md5: 6ba0ae0fb14cbea1e3197707701dc180
   depends:
@@ -3302,7 +3302,7 @@ packages:
   license_family: BSD
   size: 123077
   timestamp: 1698934356774
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 2f946b5042eaac97206b5217fb203f3604ab3a60aecd99bdfc684925e3136c18
   md5: b24026076c381ff2009e7acb9e0a6e87
   depends:
@@ -3329,7 +3329,7 @@ packages:
   license_family: BSD
   size: 534650
   timestamp: 1699022791300
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
   sha256: ba368605a0af6f1dcbdcb6fddab9ce63224a85dd11bfb2b1acace1dc17899411
   md5: 91f3ea3fe44d619ee95a6ed3773a0814
   depends:
@@ -3342,14 +3342,14 @@ packages:
   license_family: BSD
   size: 170926
   timestamp: 1694616830121
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
   sha256: 42d803e1d8b54748db5d989ecd503826f564132df7cddc20f520460f55e523a1
   md5: cd3fa71626ebc098da4625fc6be79752
   depends:
@@ -3358,7 +3358,7 @@ packages:
   license_family: BSD
   size: 16952
   timestamp: 1708532805951
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
   sha256: 09d88f1eb19a90dfe737f0e5b4dce7629f6076a2d91d572cbb0a41be5220a4e8
   md5: ac8c26d949a04f478b560b7d8a2358a4
   depends:
@@ -3383,7 +3383,7 @@ packages:
   license_family: BSD
   size: 707187
   timestamp: 1717630829258
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
   sha256: ed5608feb37a083d47b04203195260e801b64b5380f292cf18bb61e7ad827a2a
   md5: daa9c1c233673b727528548454aea664
   depends:
@@ -3393,7 +3393,7 @@ packages:
   license_family: BSD
   size: 27607
   timestamp: 1699456006797
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
   sha256: cacba45c1eebf7d86748737717883a98cf40664231460fa41391c79f98d06f45
   md5: 3dbfae0d5b90e77f9358564ad442ac9d
   depends:
@@ -3407,7 +3407,7 @@ packages:
   license_family: MIT
   size: 165572
   timestamp: 1696515553184
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
   sha256: 1466c3af380b949612c79940124e426eccd59e335c205da0c00383a69358d1c0
   md5: df6be53592d40ba7e03d6ffe349760bf
   depends:
@@ -3423,7 +3423,7 @@ packages:
   license_family: BSD
   size: 11330
   timestamp: 1708639985606
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
   sha256: ace67d704fa7eea1480eb463f2d91bfc161be2ee20263c5a9939805ae3c2a9da
   md5: ec124589478fa12fba4f35f31c3a0692
   depends:
@@ -3438,7 +3438,7 @@ packages:
   license_family: BSD
   size: 8783230
   timestamp: 1708639945646
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
   sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
   md5: 93f5d7b66976154adeda219bea02ba45
   depends:
@@ -3448,7 +3448,7 @@ packages:
   license: BSD 2-Clause
   size: 484257
   timestamp: 1630093862501
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.14-h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.14-h46256e1_0.tar.bz2
   sha256: fa7cff16e04414a72ead7fc787590e09d7b47401a296133b03664a0df266161b
   md5: 526bdcbb40402367e36003f076ba61d0
   depends:
@@ -3457,7 +3457,7 @@ packages:
   license_family: Apache
   size: 4948318
   timestamp: 1718385319448
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
   sha256: 8a0809f419065e014cb8e2c8a516cadca6088fb71fd1ef3ae2287d91e3360d59
   md5: 4dc0b9bc88476fcc5246d823ff1c289a
   depends:
@@ -3466,7 +3466,7 @@ packages:
   license_family: APACHE
   size: 39645
   timestamp: 1699371213055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
   sha256: 64fbbb03570788298d8b04d4ea6cb254fef5d5eec73265aeecd72cb565617f4d
   md5: 4b1195028bc26257df43fdd943638266
   depends:
@@ -3475,7 +3475,7 @@ packages:
   license_family: Apache
   size: 159450
   timestamp: 1710811009212
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.2-py311he327ffe_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-2.2.2-py311he327ffe_0.tar.bz2
   sha256: 878e8fbcca40ac0c3937780160c22b65633b32ac97a886a9e38d4453821fe8bb
   md5: ac61107a8dd7a5a51e19e57fcc3a7a5a
   depends:
@@ -3525,7 +3525,7 @@ packages:
   license_family: BSD
   size: 17291576
   timestamp: 1718309206876
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-1.4.4-py311hecd8cb5_0.tar.bz2
   sha256: 757d6789ddb8227afd02da27fb30d1339091c8bda8f9905011a591eaa3fc6147
   md5: 7445a0d4f67a8063b19c6372d1f8b02f
   depends:
@@ -3549,7 +3549,7 @@ packages:
   license_family: BSD
   size: 21789913
   timestamp: 1718119269606
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-2.1.1-py311hecd8cb5_0.tar.bz2
   sha256: a33f52ee58e7856ff19bd306a7c055950d669199981874a38c2bdb1896725c8f
   md5: 7aef330f65dd9dd63a06c89ddfb3b7bd
   depends:
@@ -3558,7 +3558,7 @@ packages:
   license_family: BSD
   size: 267605
   timestamp: 1719348049109
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
   sha256: 90efc71d35ab62d5b8d7b648e016444e1c4c8b83238b6dc9f2c6c3db4b14c599
   md5: 6b6eeb0a14c5479db1dd39aa8d338150
   depends:
@@ -3574,7 +3574,7 @@ packages:
   license_family: Other
   size: 939480
   timestamp: 1714399174883
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
   sha256: f6b0ded7010706431f2a6d9776aa6033dfd19d2264b3cebf28072629160090a8
   md5: 02de6d0d9cc23fafe2e3597ed0e52693
   depends:
@@ -3585,7 +3585,7 @@ packages:
   license_family: MIT
   size: 3444268
   timestamp: 1715097155645
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 81719c31101d6c019150cedcc7b08adb3bdb357e8b2952e428dadaabc4dc985d
   md5: 105825168e0a17fb007f60b5f314e311
   depends:
@@ -3594,7 +3594,7 @@ packages:
   license_family: MIT
   size: 38405
   timestamp: 1692205731769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/plotly-5.22.0-py311h85bffb1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/plotly-5.22.0-py311h85bffb1_0.tar.bz2
   sha256: 26709cb0a15c542c12e36b9a7c561737d3fa85465c4575a6f380ebaee4786497
   md5: caa14c99a2d9b493349baf43697983b7
   depends:
@@ -3608,7 +3608,7 @@ packages:
   license_family: MIT
   size: 10814266
   timestamp: 1718137191299
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
   sha256: c0982f688127129e026d2b4cdacdd5684d00796ea7bdadd7d26b1101b095d723
   md5: 0d6910c74729fede645c010110f1c89e
   depends:
@@ -3617,7 +3617,7 @@ packages:
   license_family: Apache
   size: 121796
   timestamp: 1679340253537
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
   sha256: e32843723b10ecd9badde28e1085419c0b59ed8a96c7cacce6395e39e3a874f9
   md5: 5af0280a817d2c273304cd22328124af
   depends:
@@ -3629,7 +3629,7 @@ packages:
   license_family: BSD
   size: 763044
   timestamp: 1704404460779
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
   sha256: 117a435c2473e2a20cc81eaacb2b45ea5e7fe3c946eec2915936d344913ede44
   md5: 0f459ee59fda20e2077fdc2c777edfc8
   depends:
@@ -3638,7 +3638,7 @@ packages:
   license_family: BSD
   size: 497470
   timestamp: 1679337286052
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
   sha256: dfb403f367c57327a4d080109df88383ecff18464de287a1ce936a7274e3656b
   md5: 997b674bad89963af875b93b06807f51
   depends:
@@ -3647,7 +3647,7 @@ packages:
   license_family: BSD
   size: 2120413
   timestamp: 1684280057020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
   sha256: 9d2c0f373ac1c5db329581793dd517092cdf9a59140f2516ed8c3a1f483c0bbd
   md5: ee10503a159e819abdc586666bdf0952
   depends:
@@ -3656,7 +3656,7 @@ packages:
   license_family: MIT
   size: 207552
   timestamp: 1678322848766
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 717e038567506ca58ce1cd4a3416892d02f4ebfdd332077cc3d110cfe3d36c58
   md5: 53bbfb400668f798eef6f8c7cf938e1f
   depends:
@@ -3665,7 +3665,7 @@ packages:
   license_family: BSD
   size: 35751
   timestamp: 1678315886516
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
   sha256: 092dea8d520acff3e64c71155e666b0b6074d37a71d5eb32f3cd485b0d185d0b
   md5: 9fbaf2d9534c26e76aa14b11b23de332
   depends:
@@ -3684,7 +3684,7 @@ packages:
   license_family: PSF
   size: 16852220
   timestamp: 1713545835789
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
   sha256: 04e100d0a1ea9722e24972657ec5935ad34c7c58957dabb821333e5eac80f717
   md5: 2b6de49ad07b26e1f7084f0fda958eb1
   depends:
@@ -3694,7 +3694,7 @@ packages:
   license_family: BSD
   size: 332276
   timestamp: 1716495830117
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
   sha256: 514249897265f66f6ecca0a4427eb02a43c33b3c24974db16d05db6bbe97881d
   md5: c9ea1437e5a3ba6a52ec2322505203e6
   depends:
@@ -3703,7 +3703,7 @@ packages:
   license_family: BSD
   size: 279116
   timestamp: 1679338758489
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
   sha256: 78b785b9b6ed46c86b0d3a32bdceea49f816672227fb63e726b2d46eadbdba0b
   md5: 79d783f74359141e0b06a848db33823b
   depends:
@@ -3712,7 +3712,7 @@ packages:
   license_family: BSD
   size: 18563
   timestamp: 1683823935261
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
   sha256: e358fe679e83ccdc8c433746ae6468e8e96d90d97d99530f8476ef5630b2c121
   md5: ce30a0a31d891e69dc9b7bf8b7f0c39c
   depends:
@@ -3721,7 +3721,7 @@ packages:
   license_family: MIT
   size: 268876
   timestamp: 1713974360942
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
   sha256: eeb5a5eed93b8e311ad4d3f4389e050f11bba2eaec9536e1c3ed2f849c6c999b
   md5: c18bd3e12de797d52a470c21a150dffe
   depends:
@@ -3733,7 +3733,7 @@ packages:
   license_family: BSD
   size: 65270
   timestamp: 1711136914884
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
   sha256: c3e11ed944da69c11b949bb918341a0d79ef603ee34a632d6a45fbf89ff924a1
   md5: fee7ff4d291f530b4cecb575f29807a0
   depends:
@@ -3743,7 +3743,7 @@ packages:
   license_family: MIT
   size: 197996
   timestamp: 1698096137432
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
   sha256: aa07b90a7ee65f76c8cba1ff99a5cdeb95cbe41881ae951f64ffff06674a1b2d
   md5: 58621e3d244137885f7dfbb35e50340a
   depends:
@@ -3753,7 +3753,7 @@ packages:
   license_family: Other
   size: 594801
   timestamp: 1709318510622
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -3762,7 +3762,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
   sha256: d784dc26c5de8e41845350a899e5779250b71f45d39e2aece62e739e9add7308
   md5: 7b077b7f46112bb31dc066396c51d3fa
   depends:
@@ -3773,7 +3773,7 @@ packages:
   license_family: MIT
   size: 74776
   timestamp: 1699012164201
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.32.2-py311hecd8cb5_0.tar.bz2
   sha256: e8c25fe5f26c25cc3cd5a744448a791c246610d3fa8690251f9e1fbc44188248
   md5: 28182e1a6b8c2c519dafc90093396a7a
   depends:
@@ -3789,7 +3789,7 @@ packages:
   license_family: Apache
   size: 123233
   timestamp: 1716902968357
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
   sha256: 727fb8d957e02d03b928d049ffbc712316f176a2c331391766d646621b45655a
   md5: 7e0e416c642f3ee4ddfb084a811fb4df
   depends:
@@ -3799,7 +3799,7 @@ packages:
   license_family: MIT
   size: 10236
   timestamp: 1683077214314
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
   sha256: a8a67143ccb65cfd6f50055176b6c26179a83130a45d0a12e79dd2de68d8db63
   md5: a2065790f41e3eeb6efe0ef6daa75377
   depends:
@@ -3808,7 +3808,7 @@ packages:
   license_family: MIT
   size: 10600
   timestamp: 1683059285216
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
   sha256: 6aba582338faa0c26fe336bdb10c65b8f7808a6e383bd8f80f3e6b612ca209ec
   md5: a7486349b5f7370f6902c2050a23d268
   depends:
@@ -3817,7 +3817,7 @@ packages:
   license_family: MIT
   size: 319197
   timestamp: 1698946203341
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
   sha256: beba0555707dac1e8484d73cee9e4128ac4b10e2a0d4209357481179022e8fdc
   md5: baa8b304607b3a9ae8a3d9acb354c31c
   depends:
@@ -3826,7 +3826,7 @@ packages:
   license_family: BSD
   size: 33343
   timestamp: 1699371216044
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
   sha256: c1df29188e321abe23651c73712a6d8ed3abdc89ad38a42c33f1835b3ab77abe
   md5: 6c984ea85326858942f7b635e0cc9ff8
   depends:
@@ -3835,7 +3835,7 @@ packages:
   license_family: MIT
   size: 1597325
   timestamp: 1715025837032
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
   sha256: 0eb44a16ef74a13ef7839209899d009cd94974fbc406a417d958c7bc8d955245
   md5: 41f239a5b67b1daf819849023aa5d12f
   depends:
@@ -3844,7 +3844,7 @@ packages:
   license_family: Other
   size: 19056
   timestamp: 1705431379885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
   sha256: 14775231982e1ea150189c956927ccfb1ad01a8c9395cdeea4d5a48b9b8ce664
   md5: 729badc4bf7ba8ccc70e0f9e58075c99
   depends:
@@ -3853,7 +3853,7 @@ packages:
   license_family: MIT
   size: 89812
   timestamp: 1696347694075
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
   sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
   md5: 6bef1694163a68ac4c37e5857b8da4f5
   depends:
@@ -3865,7 +3865,7 @@ packages:
   license_family: Other
   size: 1900191
   timestamp: 1714488351925
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -3874,7 +3874,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tenacity-8.2.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tenacity-8.2.2-py311hecd8cb5_0.tar.bz2
   sha256: d6ea04e7602bea3531f0ba35c83e37dceef1fabd687700a9e7632b38c642f03a
   md5: 29e9e157ef3d99b195eb65c039481c17
   depends:
@@ -3883,7 +3883,7 @@ packages:
   license_family: Apache
   size: 48156
   timestamp: 1682972384442
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
   sha256: 3d5c2968f581006437df3932cd5d3c1c4afa78f0e13757b958440245d3248856
   md5: 605ea221d225ad8e79284dbcfdab0715
   depends:
@@ -3894,7 +3894,7 @@ packages:
   license_family: BSD
   size: 37699
   timestamp: 1678317755913
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
   sha256: ed059e32ce5a1c0511575f29d2fb6da12c54a37000bfa80f9e5aa9dfd9e04101
   md5: 4d2261a92d25136a68b8d01d101119f5
   depends:
@@ -3904,7 +3904,7 @@ packages:
   license_family: BSD
   size: 49145
   timestamp: 1678317386284
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
   sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
   md5: 523c006cc67c011383678c762015479b
   depends:
@@ -3913,7 +3913,7 @@ packages:
   license_family: BSD
   size: 3594448
   timestamp: 1714770737885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
   sha256: 424b8284072266eb59d055c0b7b58241bfb00009d445743ea261d4eeee73ea19
   md5: f3a47898a55087edb9d65d29c24d9b88
   depends:
@@ -3922,7 +3922,7 @@ packages:
   license_family: BSD
   size: 135757
   timestamp: 1678323030858
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.1-py311h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.4.1-py311h46256e1_0.tar.bz2
   sha256: f46d29f5c4f5fceb7a39343da76f5c5ab89cbb0844e80a3a90457201c3fbc168
   md5: ee154208a17c1c4cd42d264b1a6f77c3
   depends:
@@ -3931,7 +3931,7 @@ packages:
   license_family: Apache
   size: 914461
   timestamp: 1718740220272
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
   sha256: 3df84b9897f05a104c99e297dc29ad8f718982fc64c61b5a2204c19c578f47e5
   md5: deab971930d242221ed86bfd768dde40
   depends:
@@ -3942,7 +3942,7 @@ packages:
   license_family: MOZILLA
   size: 155545
   timestamp: 1716396266697
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
   sha256: 5283f2b23a6e9d888b2834cba2bbf284f551e199d2c1b4add176b1cbafb19ee0
   md5: 58bf7871ca100fbda0492bb5a3363c80
   depends:
@@ -3951,7 +3951,7 @@ packages:
   license_family: BSD
   size: 208200
   timestamp: 1718227205760
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
   sha256: 17e5688d09ffbcb8b71b34b86edc7374fa0b04d60a4d729d405ffc22ef63726c
   md5: e4bf44ddbbcb136332ccb47ac2b879a0
   depends:
@@ -3961,7 +3961,7 @@ packages:
   license_family: PSF
   size: 9890
   timestamp: 1715269046804
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
   sha256: 7d369ec970d1d5411e457c79f94197756c7088deff8183806ea71e633b26edf9
   md5: 9ffa197b26373667f50b21876862398e
   depends:
@@ -3970,7 +3970,7 @@ packages:
   license_family: PSF
   size: 75595
   timestamp: 1715269030928
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
   sha256: a9960485ced319ac91afe69eaaf703c7e6b3049f1e06a4a8c2818b64155943f0
   md5: 0a9c8ea92a14330a07edabac249e32a9
   depends:
@@ -3979,7 +3979,7 @@ packages:
   license_family: MIT
   size: 11399
   timestamp: 1678394892923
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
   sha256: d42ae57366d05e12f10074583568355752436d66ad018ffbcfa24135f593810a
   md5: 1a98e48aa0bd8b3ec09e2cbdbb236575
   depends:
@@ -3988,7 +3988,7 @@ packages:
   license_family: Apache
   size: 498952
   timestamp: 1713213079520
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-2.2.2-py311hecd8cb5_0.tar.bz2
   sha256: f46959a5ebab808e8a3fb6036cee2f6a0f3bfe42c81d00158d4d2a88837d60d2
   md5: 7a554ae6cb2c33d09125ef897b39a4c5
   depends:
@@ -4004,7 +4004,7 @@ packages:
   license_family: MIT
   size: 210587
   timestamp: 1718912682770
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
   sha256: 597015e8a038a111f03ffbc9a217fcda549d75230c86ce53c1f23c53d6f1a0cb
   md5: 62e98aac883bccc1c87ca0d2ce2f08e0
   depends:
@@ -4013,7 +4013,7 @@ packages:
   license_family: BSD
   size: 25798
   timestamp: 1678317074170
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
   sha256: 1430e6f4b4dd9354b7bb88f7f7bc9cdbab26a034ad1ae5c278de0f5a99329372
   md5: be0832862b29bf5767a707ac6bd53b93
   depends:
@@ -4022,7 +4022,7 @@ packages:
   license_family: Apache
   size: 114834
   timestamp: 1715878445060
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
   sha256: 885a9b6046e76f7dc1a346b14c63b4083046137bfae036362c854458e20e4fc8
   md5: 3b279447ca282d065e681e567055b582
   depends:
@@ -4031,7 +4031,7 @@ packages:
   license_family: MIT
   size: 137340
   timestamp: 1714717062907
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
   sha256: 5b6d5246955b5f9480ff7027eb002442a7ade24f5c354da54ed513042f76cedc
   md5: f32aa8a37d5e65a8dc30f9a1f46bc63d
   depends:
@@ -4040,20 +4040,20 @@ packages:
   license_family: BSD
   size: 54719
   timestamp: 1678325412288
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
   sha256: ed0152ad6b87ffd9e01f4a62bc358e805ad59637f898a801b0a9cf903ae8e1fb
   md5: 8a92f8c663608f24e14d8a2068b9d83a
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 415323
   timestamp: 1714511993944
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
   sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
   md5: c25b6d40f834647d0bbe767f6c776031
   depends:
@@ -4063,14 +4063,14 @@ packages:
   license_family: Other
   size: 329449
   timestamp: 1705602140856
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
   sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
   md5: f2519b551f99765d9d98950c5e2b4713
   license: Zlib
   license_family: Other
   size: 119782
   timestamp: 1714511811597
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
   sha256: 7feb73e79bdbd45404ddc7a30c43bf4cc68eced8ce448ce7c31f5db134276fc5
   md5: 48313bc6570c705cadbba3c356e0dc8e
   depends:
@@ -4082,7 +4082,7 @@ packages:
   license_family: BSD
   size: 1014151
   timestamp: 1714678461080
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/altair-5.0.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/altair-5.0.1-py311hca03da5_0.tar.bz2
   sha256: 69ae1cf3113f620a23a84e91101bbd8242857c5a28380eeee922c5e9cbb00ebb
   md5: 4a438d84ca357b42f69abcc7032a5f73
   depends:
@@ -4096,7 +4096,7 @@ packages:
   license_family: BSD
   size: 855250
   timestamp: 1687526064968
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
   sha256: 9ca3f0dfc2bdbc109e359ba7ab246e6ae952a14819148ad069454b52f2bda802
   md5: 51fb05873a644cac52f0d1e10cb7969a
   depends:
@@ -4110,7 +4110,7 @@ packages:
   license_family: MIT
   size: 228856
   timestamp: 1706220385566
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
   sha256: 43405cc7341ce3efb2e24013ad62c64f26a69926635adceaa5459ccbcafb3776
   md5: effa6d22f497e164cc8455f7f329c304
   depends:
@@ -4119,7 +4119,7 @@ packages:
   license_family: BSD
   size: 12510
   timestamp: 1677917870614
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
   sha256: 947efe1c50b3280e9a67cbb18636bdade53a40960fff3056850ff81ab87acbe3
   md5: 7d2d384ee32ccc12dcb0dc099e421482
   depends:
@@ -4129,7 +4129,7 @@ packages:
   license_family: MIT
   size: 35091
   timestamp: 1677915945226
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
   sha256: 8259b4a0973c825ac81f581afcbe86640bd0a94b33caa996167309241877635a
   md5: 49b8ddacfd3927bcaae139eadfb72ce1
   depends:
@@ -4138,7 +4138,7 @@ packages:
   license_family: MIT
   size: 153557
   timestamp: 1695717951839
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
   sha256: ae3c6633ed84bac16592b3b756f96ffc577414971014ca9efa498a162588757f
   md5: ea600f99d012d734f831d1bc00a17661
   depends:
@@ -4148,12 +4148,12 @@ packages:
   license_family: MIT
   size: 281227
   timestamp: 1718029919645
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.1-py311hb6e6a13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.4.1-py311hb6e6a13_0.tar.bz2
   sha256: 4f861776f2954c67e690caba87d24de817fafe79964c1f6075a35c8bad2d2f2b
   md5: cd4dc5659854265ae73d6a9127746990
   depends:
@@ -4171,7 +4171,7 @@ packages:
   license_family: BSD
   size: 6089676
   timestamp: 1718119235085
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
   sha256: 688a071ba370f51b457cd32d70b7b38921ce9551203d06fa7fc2c30c4b79891d
   md5: b2353077a39ab997463768154dd58fec
   depends:
@@ -4181,7 +4181,7 @@ packages:
   license_family: BSD
   size: 134711
   timestamp: 1707864978809
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
   sha256: 048264434c33fdb53862cdd69b2e2bc4ce6f8a70b3211ad6d686d066eac2aa91
   md5: d55696ccaf6755931cd662dfb929aa0b
   depends:
@@ -4191,7 +4191,7 @@ packages:
   license: MIT
   size: 19737
   timestamp: 1714483270447
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
   sha256: 13627293296fcc231d8dc12d803dfc9621108c60df38b0e3c64e9e02ed55e564
   md5: 86efd4ad08cd80d3eab77873db84a255
   depends:
@@ -4200,7 +4200,7 @@ packages:
   license: MIT
   size: 19083
   timestamp: 1714483255364
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
   sha256: 2e542b2bb27f8379da3efcb83ef084cb26e6a9ab576c50487c2dd996afd5ccb1
   md5: e8cab9d1ef58a450f971690fcdb2ede2
   depends:
@@ -4209,21 +4209,21 @@ packages:
   license: MIT
   size: 380182
   timestamp: 1714483330655
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
   sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
   md5: 56d1386c7f1f338f0d18f82af6525273
   license: bzip2-1.0.8
   license_family: BSD
   size: 158748
   timestamp: 1714510571033
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
   sha256: bbfc668f445f3584936b326dcfe92bf71971ce16241f4f79db8aeb88d7aab41c
   md5: 10cc05ed51482e1dfcc31dbd13bb34c6
   license: MPL-2.0
   license_family: Other
   size: 138641
   timestamp: 1710764806818
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.6.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.6.2-py311hca03da5_0.tar.bz2
   sha256: 2a4db3202260845b4658285d2fca09de0e5afee9f5559b9195bf2c9e8fff1930
   md5: a56c6653ba51441b6e7db9bcef00880e
   depends:
@@ -4232,7 +4232,7 @@ packages:
   license_family: Other
   size: 167136
   timestamp: 1717618216897
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
   sha256: 8d26cd4d16545ad8afddd5521bc6894a50d5b8faff3abbe600bb9b062f3c3a0a
   md5: 66eb734b7d7008eb5fb537900767c7ae
   depends:
@@ -4243,7 +4243,7 @@ packages:
   license_family: MIT
   size: 286807
   timestamp: 1714483190838
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
   sha256: 808e56fb70f3d38599ee7a54c2a707b282ba9a401fa69a1f54cdc26425d9ce01
   md5: fc37321833175bda4fc5c21afe32db49
   depends:
@@ -4252,7 +4252,7 @@ packages:
   license_family: CC
   size: 539588
   timestamp: 1709758479776
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
   sha256: d9c126d8bcd1c89ea37186c172d6b1f73f45ada60e3ae1790a017b530baa0147
   md5: f0223aae3d622547f6accb212579c58e
   depends:
@@ -4262,7 +4262,7 @@ packages:
   license_family: BSD
   size: 17967
   timestamp: 1709322909223
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
   sha256: 1f908c688e47d03d92ac09d9541a1f1c773ac2ca485dd1d77441b1aaefc032db
   md5: 444c330471496a39a97e87f41ed70c96
   depends:
@@ -4273,7 +4273,7 @@ packages:
   license_family: BSD
   size: 281104
   timestamp: 1700583698464
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
   sha256: b9356e3ada4872c7c950d2ac7e0f107c4786775191efdfda3a469dffb18f2714
   md5: 07ddd96675caf30ea77cafb1ea5662a4
   depends:
@@ -4283,7 +4283,7 @@ packages:
   license_family: MIT
   size: 2490144
   timestamp: 1690905181398
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
   sha256: b1481ffa475c65200626f051d5dcbdb264730b533e928dde608a79ce7a5b4e48
   md5: aada2761547a291d68f4c016a1a9bc7b
   depends:
@@ -4292,7 +4292,7 @@ packages:
   license_family: MIT
   size: 18265
   timestamp: 1677911915719
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
   sha256: eb82a0e2ca36d0973b5f6642e27609554edad4b72696f989776d5db8cd4a6a42
   md5: fa8d9dd8a2fabba964c6bb75ace8c572
   depends:
@@ -4310,7 +4310,7 @@ packages:
   license_family: MIT
   size: 3201601
   timestamp: 1713551611540
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -4320,7 +4320,7 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.19.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.19.0-py311hca03da5_0.tar.bz2
   sha256: 428ad55601ca1f2e3828fbaf0388c58ec6ea2621822569bb5a465d3bb9ca4762
   md5: acb23eb80c417a2b0f390bb2120af479
   depends:
@@ -4340,7 +4340,7 @@ packages:
   license_family: BSD
   size: 6093873
   timestamp: 1718294669877
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
   sha256: 765d5b7ef75ed7f52a110504cd88e9b0c9977b841f1beaeeabb17e629b462908
   md5: 0af9cd26a7c9eb8b77d3cbacb93a118b
   depends:
@@ -4357,7 +4357,7 @@ packages:
   license_family: BSD
   size: 360105
   timestamp: 1715090588763
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
   sha256: 4d4ab70ae0ce008c1cc96a4edfbf3866d5e636acc4799a545ea93acee51635f7
   md5: 86a085a440729020d1d7b0b74d6a0c6c
   depends:
@@ -4366,7 +4366,7 @@ packages:
   license_family: BSD
   size: 148448
   timestamp: 1714398923507
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
   sha256: 63670c8f31770e1746016f645ca6b42b35f92d1c37e8025793d9490fed9998c0
   md5: 9cb417b9fdf02b4e007a5b5781e5a8cc
   depends:
@@ -4388,7 +4388,7 @@ packages:
   license_family: BSD
   size: 229932
   timestamp: 1705934202146
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.25.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.25.0-py311hca03da5_0.tar.bz2
   sha256: 84676342c0d1244d20aaff11b33bc8d661960b0ec09d911220e79c616e660343
   md5: 5f05461b6cb4cf1b2764a21b5d79b8f2
   depends:
@@ -4406,7 +4406,7 @@ packages:
   license_family: BSD
   size: 1632212
   timestamp: 1718288108323
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
   sha256: e57d10579b52a3cde45aa17e1bdd95dcb9d3346aa00eb02c51e38a42db83e18d
   md5: 05153120787fb09159b6e1ad902c6e10
   depends:
@@ -4416,7 +4416,7 @@ packages:
   license_family: MIT
   size: 1180481
   timestamp: 1678994989550
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.4-py311hca03da5_0.tar.bz2
   sha256: bdbc36a516717a24b40e2a4ac812c4d097b6733f4c6654602556969e5e0d4062
   md5: b31b2f2fd10d919c58c51fcbe54ef5c6
   depends:
@@ -4428,14 +4428,14 @@ packages:
   license_family: BSD
   size: 353970
   timestamp: 1716993463263
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
   sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
   md5: 055e12390b844ea6c6e956ee08a618e8
   license: IJG
   license_family: Other
   size: 273479
   timestamp: 1677849171867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
   sha256: 62025ce4a2b9244b9816c9e02487e0dda567600692b5f9ca71f425d084961c7e
   md5: d57b7063122e5bf25cdfc2a5ea7330a8
   depends:
@@ -4448,7 +4448,7 @@ packages:
   license_family: MIT
   size: 181872
   timestamp: 1699041739097
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
   sha256: 404b0847029f77bedd7902a170a046219e0dc5c0ec2be19ff45361cff25b2181
   md5: 3a02bbe8d45fdbcb2350f672be74c9f5
   depends:
@@ -4458,7 +4458,7 @@ packages:
   license_family: MIT
   size: 16524
   timestamp: 1699032463763
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
   sha256: 7deb8ad28c34c369573754304a03ea2acda8ee39102a56526ec689a4d9210109
   md5: 675ea1a746a78ff6bf8fc4b39139efff
   depends:
@@ -4474,7 +4474,7 @@ packages:
   license_family: BSD
   size: 277400
   timestamp: 1677914250715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
   sha256: ceec15c84f5c699b8055d01e046be04ccb7cfd7c8bd090fc18959f2a4d9f8cf8
   md5: f85c11f7068312e1e84505efef9d55e3
   depends:
@@ -4485,7 +4485,7 @@ packages:
   license_family: BSD
   size: 98520
   timestamp: 1718818476094
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
   sha256: b2f1ee2a297e001a2e70bc218f60deb08c50b9b727668913ed5a106640413d2e
   md5: fc4e797a17ff5dccadfb5d19346b7800
   depends:
@@ -4501,7 +4501,7 @@ packages:
   license_family: BSD
   size: 43099
   timestamp: 1718738212629
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
   sha256: 2d96618ab2e9b3de870a713d7e5b19f6cde936291f3c87972f945b6e27024e77
   md5: 534159d29d9aba9c7e70ee52c27b326b
   depends:
@@ -4528,7 +4528,7 @@ packages:
   license_family: BSD
   size: 614003
   timestamp: 1718827110867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
   sha256: 501e929d345aaa9079c965552b942b4e8bde35b87ae89faef003687a40bab3a4
   md5: 54c7b8554a405acd7c8326c41ba93e63
   depends:
@@ -4538,7 +4538,7 @@ packages:
   license_family: BSD
   size: 28237
   timestamp: 1686870817418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
   sha256: 773e7c4571f482a744dfb18ae26fb22635f5d3f51389c838bd97f9044ea55cc4
   md5: 5161546aba5597318cb5653390cdecd8
   depends:
@@ -4550,7 +4550,7 @@ packages:
   license_family: BSD
   size: 20235
   timestamp: 1700168681687
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
   sha256: 8c1c64d51be73aad381992a9df19d8336910bdfc40f19940231df86e177d17cc
   md5: b1f786f96684a143cf30d1f6b8aebdb3
   depends:
@@ -4560,7 +4560,7 @@ packages:
   license_family: BSD
   size: 65045
   timestamp: 1677925371836
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -4570,7 +4570,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -4579,13 +4579,13 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
   sha256: 199042b87451abaf14546af124ae3380194cddda928e0d30ccb341e93084854c
   md5: eaa0442887994a82486c65d87f6b71e6
   license: MIT
   size: 68806
   timestamp: 1714483212137
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
   sha256: bd9a8a17fb14086446b710fa029d238e69274b83ee2e7e09093496f190de82b5
   md5: 66615d6a0cb5dcca3e20c019cde0ed2d
   depends:
@@ -4593,7 +4593,7 @@ packages:
   license: MIT
   size: 32975
   timestamp: 1714483225840
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
   sha256: e1bf77e8b975c30a69b08a08410622e27c8cff6f592ccfa590466b83d9e6d104
   md5: 8af86bdac01fe303d693d9b76c071059
   depends:
@@ -4601,28 +4601,28 @@ packages:
   license: MIT
   size: 310266
   timestamp: 1714483239194
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
   sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
   md5: f31e4eb9cd6447cc2f5ef0243a76540c
   license: MIT
   license_family: MIT
   size: 120460
   timestamp: 1714483461787
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -4631,7 +4631,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -4642,7 +4642,7 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -4653,7 +4653,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -4662,13 +4662,13 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -4685,7 +4685,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
   sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
   md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
   constrains:
@@ -4694,7 +4694,7 @@ packages:
   license_family: BSD
   size: 331675
   timestamp: 1694776939192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
   sha256: 41c62a460bb81a1a272aa28b219fab9c26510adac177ff1528b1980eabc6e868
   md5: 8d312c5628dc7ea833e9b4dcb73e9c45
   depends:
@@ -4704,7 +4704,7 @@ packages:
   license_family: MIT
   size: 42346
   timestamp: 1677973051421
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -4713,7 +4713,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
   sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
   md5: f5f7e6e7541d8dc3d3df270d488d2e24
   depends:
@@ -4722,7 +4722,7 @@ packages:
   license_family: BSD
   size: 176990
   timestamp: 1714510588159
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
   sha256: d024f5142416961a5e66e424d4d14aec652f9e9dd738b41a97f45674c2ffc9d5
   md5: 0e2d94b125d802f7b006cf19c71655a1
   depends:
@@ -4731,7 +4731,7 @@ packages:
   license_family: BSD
   size: 163084
   timestamp: 1677932947966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
   sha256: acfd84e29ff4dc2d85543bb973a07f22b4ba53c5d00bca84608ee7f13b2a8676
   md5: 5ca161cd51e2db358e768453b3ee485e
   depends:
@@ -4741,7 +4741,7 @@ packages:
   license_family: MIT
   size: 135871
   timestamp: 1684279980293
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
   sha256: b1bed54c7bfb7304cde9e8e6f798543d08e808e81286a5a48296fc94d621f9da
   md5: 774358285c9e496c9f5c121cc546c823
   depends:
@@ -4752,7 +4752,7 @@ packages:
   license_family: BSD
   size: 27438
   timestamp: 1704206026910
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
   sha256: 9229a6e15abf3147cfcffad4ca389dad940e45779963b4fc3fd56dfdcfca3234
   md5: 4e1897f3cb4923de48c016468c01c051
   depends:
@@ -4773,7 +4773,7 @@ packages:
   license_family: PSF
   size: 9100733
   timestamp: 1713336457304
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
   sha256: 3276d61fc353c537bb09d4b7473d7abe12be38806f42c8cc383b62f40850a5cc
   md5: 6e9c9d47f264b77d9a8461f0899848a7
   depends:
@@ -4783,7 +4783,7 @@ packages:
   license_family: BSD
   size: 20446
   timestamp: 1677918370379
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
   sha256: 43c96d30775b61b4968422a47f9605049428120669f0742bbb9e5ba145c7d11e
   md5: a31ca0d9284860adf5463cf45a5e3145
   depends:
@@ -4793,7 +4793,7 @@ packages:
   license_family: MIT
   size: 69243
   timestamp: 1677995336989
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
   sha256: 96d8c9f42a38651b7bafe5f3cb132601db76cd1e28fa58e2eaf090e634292fff
   md5: 5ebc793a17b6aa84d13f19433545ffa5
   depends:
@@ -4802,7 +4802,7 @@ packages:
   license_family: MIT
   size: 23895
   timestamp: 1677942274932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
   sha256: db9bd659ada23f1ded443d2db00dd13b5d5c0b30f5062544b1ee2c2b88d63d29
   md5: 03c48121614cf12abfe30eced9b34717
   depends:
@@ -4813,7 +4813,7 @@ packages:
   license_family: BSD
   size: 105333
   timestamp: 1677916687032
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
   sha256: b6fa12e4bde747bf288bda31ce8ec5e24292dbf74fde67f18f9c9c100b845a38
   md5: 2eddc760c15171a1e8aa838d9d162e18
   depends:
@@ -4826,7 +4826,7 @@ packages:
   license_family: BSD
   size: 8291605
   timestamp: 1717622676584
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
   sha256: e8eee27fb667aa10b26f3bc4b93f449b7d991ded27b9cb457effee394ce05f6f
   md5: 6a3e5cd0e1141c01ffb91285bdccfe83
   depends:
@@ -4839,7 +4839,7 @@ packages:
   license_family: BSD
   size: 123043
   timestamp: 1698934328890
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
   sha256: 40230434aa2fbb33ece13632e8d4b7cd1ad68fdb8d1b00263af4a010795d25f8
   md5: f12ce7dad3620d6d53a442fa9d36a0b0
   depends:
@@ -4866,7 +4866,7 @@ packages:
   license_family: BSD
   size: 538067
   timestamp: 1699022954841
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
   sha256: a492acec8ceadc0911a75966ffa630a8eb15b2da8c7a8d544a645ba47771a2d1
   md5: 4002b1b88b2ecfdfc769036f43b0a895
   depends:
@@ -4879,14 +4879,14 @@ packages:
   license_family: BSD
   size: 170964
   timestamp: 1694616845237
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
   sha256: 417ace1ce51e81f3f92ddc26e0e3a83c1e19c9ebb7af7104452002a5573da534
   md5: 3e11de6cef096091bb733e07802f00b0
   depends:
@@ -4895,7 +4895,7 @@ packages:
   license_family: BSD
   size: 16979
   timestamp: 1708532698253
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
   sha256: 8ea1be4285e2e7d361cbcc1daf9c220f87ceaab2308bf7b339d2513d6ea22184
   md5: 774ce02efa90f212023541c0b24e92c1
   depends:
@@ -4920,7 +4920,7 @@ packages:
   license_family: BSD
   size: 726598
   timestamp: 1717630964815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
   sha256: b0cc542e2a6f42ba716e7e4ccf29eddcb155ad167fcdbc72d2db9c7873eb5639
   md5: 7acf81b17d2c4ceb3cd39dc9f173855c
   depends:
@@ -4930,7 +4930,7 @@ packages:
   license_family: BSD
   size: 27539
   timestamp: 1699455954000
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
   sha256: 151a3eb68d1189e69764ece1d8fb3544d31a22f5bbbc3e19d846de8dece304d2
   md5: eb6609e6bdc9c82d70df3f8c4c2de95b
   depends:
@@ -4941,7 +4941,7 @@ packages:
   license_family: MIT
   size: 153313
   timestamp: 1696515415712
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
   sha256: d3bb1d4be88320a5861cd3a0f086e9709f9b64c96c032cb9039cc4f17ec66a85
   md5: 0a7b97665c06fcd34a70e34abc177280
   depends:
@@ -4954,7 +4954,7 @@ packages:
   license_family: BSD
   size: 11288
   timestamp: 1708639168951
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
   sha256: 3e70248a7069ca12ccf56252869bfdb72211fd4e4c327e6994756496df786c79
   md5: ce4846006d98638cd86a532a72f8dfe4
   depends:
@@ -4968,7 +4968,7 @@ packages:
   license_family: BSD
   size: 7536860
   timestamp: 1708639153133
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
   sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
   md5: 371358a54bbdd307603888348d1a2c6f
   depends:
@@ -4978,7 +4978,7 @@ packages:
   license: BSD 2-Clause
   size: 412248
   timestamp: 1628861367714
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.14-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.14-h80987f9_0.tar.bz2
   sha256: 3bf30abbaf136d57fb89067f71ab22ca3777b537a13b3303acbb7b0f1da1eaa5
   md5: a4cf5fe0ec6c19fac1ff42127e430215
   depends:
@@ -4987,7 +4987,7 @@ packages:
   license_family: Apache
   size: 4766984
   timestamp: 1718385447449
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
   sha256: 77b0c0a0fb14d817390244ebd93c36d44a7867239963f211f7c0a72a3f98d382
   md5: b90336feb8a50d2eff880e89acb02f40
   depends:
@@ -4996,7 +4996,7 @@ packages:
   license_family: APACHE
   size: 39617
   timestamp: 1699371253760
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
   sha256: 4f6c3e8d8fc4c57975cab837ef109b9ee7af4f18aac72668334ac656e53c6edf
   md5: fbf1b507f9a80c5de3c957e8152124da
   depends:
@@ -5005,7 +5005,7 @@ packages:
   license_family: Apache
   size: 159289
   timestamp: 1710807498427
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.2-py311h7aedaa7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.2.2-py311h7aedaa7_0.tar.bz2
   sha256: 3ee48b8e32d5009fccbb8e0dbb00d905f827982adae9c9f799ad85ba6f13a077
   md5: 9e6f48d13a7911f6b5547e6a9c8dc5e1
   depends:
@@ -5055,7 +5055,7 @@ packages:
   license_family: BSD
   size: 17039081
   timestamp: 1718309063969
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-1.4.4-py311hca03da5_0.tar.bz2
   sha256: 30a99806e616ba4270fd3f517eff88728e50eaaa3a46dd811476eadc4744444a
   md5: 81c2a30ee5913e37fe552f51ab9b19be
   depends:
@@ -5079,7 +5079,7 @@ packages:
   license_family: BSD
   size: 21836599
   timestamp: 1718119512521
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-2.1.1-py311hca03da5_0.tar.bz2
   sha256: 7c4d34def227ba26cea176cd3d522aeb2584989e68052c387925536097cd1f63
   md5: 025e2c935f86e471a35d584c40bbed29
   depends:
@@ -5088,7 +5088,7 @@ packages:
   license_family: BSD
   size: 264597
   timestamp: 1719348054960
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
   sha256: 174b680f4bb041e8146aae80f92390122459e0ef8c911cab22d01e2e92d44ab1
   md5: cfffc94779cd26a349bd409b5590b098
   depends:
@@ -5104,7 +5104,7 @@ packages:
   license_family: Other
   size: 916496
   timestamp: 1714399019350
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
   sha256: 102c3c35a9dfa0f10ec8f4a040a24295f9c736443ccae2f685348a44f62a4d68
   md5: 027b347e79e252aa17b534e1a02bccd6
   depends:
@@ -5115,7 +5115,7 @@ packages:
   license_family: MIT
   size: 3447682
   timestamp: 1715097070362
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
   sha256: b6200816d65673aa1707c20a768c9cff87dd8dbe1335f9c1478e5931dfa08ee0
   md5: 14b1e0fa73eb33f9c83048482dcce57b
   depends:
@@ -5124,7 +5124,7 @@ packages:
   license_family: MIT
   size: 38423
   timestamp: 1692205689597
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/plotly-5.22.0-py311hb6e6a13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/plotly-5.22.0-py311hb6e6a13_0.tar.bz2
   sha256: e4c97496602c9de901fd64e48644f68f46253d1f70aa8910600664f075f7668b
   md5: d5775eadd788f5100fc6b02058539f42
   depends:
@@ -5138,7 +5138,7 @@ packages:
   license_family: MIT
   size: 10779565
   timestamp: 1718137635778
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
   sha256: ebdf211edd98d88a23778551c7a9702106edd0695d4fc48e87c21f77521c1ffe
   md5: d8c505081a468f1b99c62466e2309417
   depends:
@@ -5147,7 +5147,7 @@ packages:
   license_family: Apache
   size: 123084
   timestamp: 1678996822234
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
   sha256: 07cfba50d9e94364bde077731a824ca4f537138b35ee6b66d07aee16ac9850f1
   md5: 919bf486280a11e6acb3c2c3a82f7473
   depends:
@@ -5159,7 +5159,7 @@ packages:
   license_family: BSD
   size: 763225
   timestamp: 1704404463402
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
   sha256: 8094436b2c44e68e72569c704633802aad82e977b1e16026848218679c8becf4
   md5: 2360e46d3e598dd5e2abed781fe166c5
   depends:
@@ -5168,7 +5168,7 @@ packages:
   license_family: BSD
   size: 502115
   timestamp: 1678995719872
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
   sha256: 121b5b66721760c05f1d4eee91626229d1814663d3fb5f23126ef870aa496e26
   md5: 0c588c2ca790a05d422c06e8568201ad
   depends:
@@ -5177,7 +5177,7 @@ packages:
   license_family: BSD
   size: 2124200
   timestamp: 1684280082141
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
   sha256: 44b694db8e81d61960d28d60f9e9b573f03f7827881d302da334378881db4889
   md5: 6c94ba7caa599ff533e0ab55d898be8a
   depends:
@@ -5186,7 +5186,7 @@ packages:
   license_family: MIT
   size: 208454
   timestamp: 1677910948527
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
   sha256: 0bb3d2a57b332c5cf73ea40ea13c850ae24a1f9a3a41ed9267832d9e3c767572
   md5: 45a7fcf1641980d5114999736428502d
   depends:
@@ -5195,7 +5195,7 @@ packages:
   license_family: BSD
   size: 36755
   timestamp: 1677906514270
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
   sha256: 960c343b7b8569dfe4e71a395f7bede1e749da7b02c17506b590c9e1839e6fd7
   md5: 722c4b4386af73cf1562974a00c880a4
   depends:
@@ -5214,7 +5214,7 @@ packages:
   license_family: PSF
   size: 16494386
   timestamp: 1713545544909
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
   sha256: c3cbf5bd237b0a7458640191016b2701fe120c547df9afc835da76663a9c17f7
   md5: 843568c76b6b9384635b7fca74c79792
   depends:
@@ -5224,7 +5224,7 @@ packages:
   license_family: BSD
   size: 332222
   timestamp: 1716495881101
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
   sha256: f94b3cfea6f76ea9983e16d3c4c7e0a64f02c40cc2c3ad57189bca2e67030bd9
   md5: 0d100990ade57a02b60d1e8085db0bdf
   depends:
@@ -5233,7 +5233,7 @@ packages:
   license_family: BSD
   size: 280263
   timestamp: 1678996927464
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
   sha256: 252c86f5aef7f8dfce99a260c24cbb35a9adfea144a2acfabb224f516341544f
   md5: 745b888e19a644f48800799f82c01c21
   depends:
@@ -5242,7 +5242,7 @@ packages:
   license_family: BSD
   size: 18539
   timestamp: 1683823925189
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
   sha256: d945744eb133f19ca61325cac5128bdb053ae04de4a0ba6f69c061449cac8af7
   md5: 34baa81490d667381bc7021435b0e1f2
   depends:
@@ -5251,7 +5251,7 @@ packages:
   license_family: MIT
   size: 275858
   timestamp: 1713974457562
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
   sha256: 012585bdb5ae54c2cded50be703734e6dbf418b003635b6f6d7c1e36e7020c30
   md5: da7e99a707bd0cfa20db651b5c068bfd
   depends:
@@ -5263,7 +5263,7 @@ packages:
   license_family: BSD
   size: 65556
   timestamp: 1711136890180
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
   sha256: 4f04a43cbd612ab09cefbdc2e48ee61b51967dad59d859ce0502cc2c46c88fc5
   md5: c68bf65433b2151b51b2e699bc22c501
   depends:
@@ -5273,7 +5273,7 @@ packages:
   license_family: MIT
   size: 194632
   timestamp: 1698096151085
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
   sha256: ae8cdd5be5a7ad19ff82925a035859fafcc5942cd3899d127a508dbb9a235090
   md5: 252a7b997d08bf72f10b3bc2dc68333e
   depends:
@@ -5283,7 +5283,7 @@ packages:
   license_family: Other
   size: 580346
   timestamp: 1709318480624
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -5292,7 +5292,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
   sha256: 7a208abc002a2fc208ae25cb2cf932999a3e4980aa4c9edff315cb9ac62b12ce
   md5: bd22ebd3cff811577ea61f115ba7f4f2
   depends:
@@ -5303,7 +5303,7 @@ packages:
   license_family: MIT
   size: 74744
   timestamp: 1699012126255
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.32.2-py311hca03da5_0.tar.bz2
   sha256: c6eff6c175590d7fd2e500ff1673b160a4c2b67e1cb99370ec8b5a2c998e8025
   md5: a60c7eef247742967bca814d7f1d90ab
   depends:
@@ -5319,7 +5319,7 @@ packages:
   license_family: Apache
   size: 123308
   timestamp: 1716902854898
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
   sha256: 52368d9b557b8f54ef5ca4bf6cd5a3ec665171f2b2d2082cdd410bab88f4829c
   md5: ac76fb4d2eef3ecdd491cf5d3fb8620d
   depends:
@@ -5329,7 +5329,7 @@ packages:
   license_family: MIT
   size: 10204
   timestamp: 1683077239143
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
   sha256: 491d116c5f54ef340e3bce631835f7138cd1923d7b63e6ca9aa01b48110cb8f9
   md5: 9b81bd8ea808704f5433884b567f1f15
   depends:
@@ -5338,7 +5338,7 @@ packages:
   license_family: MIT
   size: 10557
   timestamp: 1683059079547
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
   sha256: b53a5f6119173d62e4e68a37ea8511c7fc87a00af72953e0048d075a799c7a7a
   md5: 76a16cf4edb9b12b2b96a2d323f060dc
   depends:
@@ -5347,7 +5347,7 @@ packages:
   license_family: MIT
   size: 342535
   timestamp: 1698945991201
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
   sha256: c80d52567084b1caaed2862b77b70065ca17afaf0b020733e9d6c273b4a63e78
   md5: ddf7d88c1967f3f7a4ce1c975fd47e0d
   depends:
@@ -5356,7 +5356,7 @@ packages:
   license_family: BSD
   size: 33321
   timestamp: 1699371225235
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
   sha256: 6d38d171ef87340cf0fbbf4c70217df4826c65400c9290774f5cb35e381e3315
   md5: b9529a812f9862fc89461b6b90f184ba
   depends:
@@ -5365,7 +5365,7 @@ packages:
   license_family: MIT
   size: 1599110
   timestamp: 1715024190898
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
   sha256: cd71091a234874d2826fa063ec5222b3191c9f47e1b5281c352d9df3f31a06bf
   md5: 0db8e29016c6bff026c083d9923a7566
   depends:
@@ -5374,7 +5374,7 @@ packages:
   license_family: Other
   size: 19073
   timestamp: 1705431415504
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
   sha256: 3e18cdafc607c6d7623b1c8f041cbfbb50a27e298f961abdcce7e36834ac39e1
   md5: 9ee0da74c55d0b8d83edf246fd717f20
   depends:
@@ -5383,7 +5383,7 @@ packages:
   license_family: MIT
   size: 89862
   timestamp: 1696347657368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
   sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
   md5: d8c1e9910392d0bcb22a173f9ce30fa6
   depends:
@@ -5395,7 +5395,7 @@ packages:
   license_family: Other
   size: 1758290
   timestamp: 1714488307689
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tenacity-8.2.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tenacity-8.2.2-py311hca03da5_0.tar.bz2
   sha256: 504a1cf35657ddf7d25c810d67b1aee3d37ca20181589a216c89309c719ee6b9
   md5: 0fa367bce619517b599b2046c1f7486d
   depends:
@@ -5404,7 +5404,7 @@ packages:
   license_family: Apache
   size: 48108
   timestamp: 1682972353529
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
   sha256: b5c265e9ed9a1ff2238a09b83bdc1826950faa87fd6b685debe60888de6e7a50
   md5: 5827c8a32317894ce18576e334daba47
   depends:
@@ -5415,7 +5415,7 @@ packages:
   license_family: BSD
   size: 38559
   timestamp: 1677918962258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
   sha256: cfefd86d0f4981d22b7611b3dc60359b8698bf39f2b743cb90b7005aaca88e1e
   md5: a04dbcd6095f6b8f3ad195a78d48b262
   depends:
@@ -5425,7 +5425,7 @@ packages:
   license_family: BSD
   size: 50058
   timestamp: 1677917499177
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
   sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
   md5: 3c25b4f4768ccda28b20a03ba27e7759
   depends:
@@ -5434,7 +5434,7 @@ packages:
   license_family: BSD
   size: 3484151
   timestamp: 1714770744982
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
   sha256: 0836468fafb1f5badbb573922e37200c6929bf2926ecf8d2259dff43811e0727
   md5: 5bc56dcb4bdb7cf623b7cea499feaddb
   depends:
@@ -5443,7 +5443,7 @@ packages:
   license_family: BSD
   size: 136409
   timestamp: 1677925889207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.1-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.4.1-py311h80987f9_0.tar.bz2
   sha256: 2fd655106e52bb73deea5a0af63708e75cf66e071f0f3f15c04a67413f721430
   md5: 324986c435dcfc101684907ce85c199e
   depends:
@@ -5452,7 +5452,7 @@ packages:
   license_family: Apache
   size: 915790
   timestamp: 1718740267109
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
   sha256: 81efb240a49cede5ece3a8ad48f1d9dfdeb56260bf1a20e25ec53cdb202f7c3e
   md5: 81a17d13c75596841b95340a34bbe929
   depends:
@@ -5463,7 +5463,7 @@ packages:
   license_family: MOZILLA
   size: 155516
   timestamp: 1716396017482
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
   sha256: 707e5dfdb9116f31bc1ad7f497f6e8416683add460258fdc2a4c16eec85226be
   md5: ffb602322a388ec8e1f385edaca3ce12
   depends:
@@ -5472,7 +5472,7 @@ packages:
   license_family: BSD
   size: 208171
   timestamp: 1718227091374
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
   sha256: 96071e07e807414b7ae5a2fe958ac171e5795576b3a4c2f5e8c643fba43d760f
   md5: a34f2b216e35a37f966883dacda229e2
   depends:
@@ -5482,7 +5482,7 @@ packages:
   license_family: PSF
   size: 9902
   timestamp: 1715268985387
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
   sha256: b20e48aff4c781a52b6be66d77418e768527a621f5fc272ecb34ea03475b2bd7
   md5: 707738432f16f5e63909fcaa6e65850d
   depends:
@@ -5491,7 +5491,7 @@ packages:
   license_family: PSF
   size: 75604
   timestamp: 1715268976065
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
   sha256: 2ea2d0520b330d381a2ab241bdb9ae146ef815ee7c96ee52a9773fb9ae85f4fd
   md5: 66f7f8979cfb2cccffac972d70482130
   depends:
@@ -5500,7 +5500,7 @@ packages:
   license_family: MIT
   size: 12614
   timestamp: 1677963554857
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
   sha256: df7fe7740bd853b641d624e2ec97f1aacb2b82691936a8c04ef18fa9768539c2
   md5: d5c7626d45fd03b22797c18e47812beb
   depends:
@@ -5509,7 +5509,7 @@ packages:
   license_family: Apache
   size: 518048
   timestamp: 1713213046424
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.2.2-py311hca03da5_0.tar.bz2
   sha256: bfdfb02fd3dd1c01fd36b0753e365bfe599153da178619d8b62814c89682ab8e
   md5: c30603849b5abe9935b0a58b2904a090
   depends:
@@ -5525,7 +5525,7 @@ packages:
   license_family: MIT
   size: 210621
   timestamp: 1718912666948
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
   sha256: 09738b7f9075386bf062b12ddb6fb72a06450d2481f6b5ca2026c811cd849569
   md5: 9afdec076c95746ac21235f971190e40
   depends:
@@ -5534,7 +5534,7 @@ packages:
   license_family: BSD
   size: 26727
   timestamp: 1677910175964
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
   sha256: b4ced7366de8eb7258f31d516616e70c62ed4a798780e57e208509d2b52ab435
   md5: 65a9a05a726734c1da667f9bd3c78c14
   depends:
@@ -5543,7 +5543,7 @@ packages:
   license_family: Apache
   size: 114733
   timestamp: 1715878377412
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
   sha256: aa301d9e42aadbe3dd5f301ccbf17fbadc347fd37d413c0cbcbd24403892a936
   md5: 77097d17d835a137af7950c628b66150
   depends:
@@ -5552,7 +5552,7 @@ packages:
   license_family: MIT
   size: 137260
   timestamp: 1714717037687
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
   sha256: 2cd108896df65636769e3804ecc2ca421ad9b54e64fa21922bbabe40c90c247a
   md5: b3a1e5077b28f71298d891fbfb5ff03e
   depends:
@@ -5561,20 +5561,20 @@ packages:
   license_family: BSD
   size: 55645
   timestamp: 1677927459979
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
   sha256: 5be8c968f2da5c4bf14f28d63e31b4c1b6993d980023769732c7f58f396c2e0b
   md5: 3f5f62d4e85e3bdd48d39189b01805a6
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 459197
   timestamp: 1714510992914
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
   sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
   md5: 3d57d1adadca9388aaaa1c529b65ba65
   depends:
@@ -5584,14 +5584,14 @@ packages:
   license_family: Other
   size: 322790
   timestamp: 1705602163804
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
   sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
   md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
   license: Zlib
   license_family: Other
   size: 104928
   timestamp: 1714510936868
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
   sha256: a3f3eaf240991b6bd7b0596a78d0abb3321cc79db52fa24f6f559189778871c6
   md5: 71f035b4716322539e2461cb6667e946
   depends:
@@ -5603,7 +5603,7 @@ packages:
   license_family: BSD
   size: 825339
   timestamp: 1714678419523
-- conda: https://repo.anaconda.com/pkgs/main/win-64/altair-5.0.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/altair-5.0.1-py311haa95532_0.tar.bz2
   sha256: 55d61cec328d4df122f92a21ffaa315f4b40bd78dfeeb4146d3a85eb121e351e
   md5: de1799404d5161a2fa6711688f5771eb
   depends:
@@ -5617,7 +5617,7 @@ packages:
   license_family: BSD
   size: 853339
   timestamp: 1687526136999
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
   sha256: 6e6787755de0cf2fd776c9681a7b0fd0fb23e35e679a463cc2005b991c413910
   md5: ccad42ec9a2ad48939f089c528abc8f0
   depends:
@@ -5631,7 +5631,7 @@ packages:
   license_family: MIT
   size: 229694
   timestamp: 1706220431719
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
   sha256: f715f7c2e06149bd6d43258e41479d3171efe5e9d56050a0a5f5652ed9d05fff
   md5: 11a8ca43d69881b88f95ae681478866d
   depends:
@@ -5643,7 +5643,7 @@ packages:
   license_family: MIT
   size: 36089
   timestamp: 1676424516042
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
   sha256: 9adabcdd2a10f73fa5ba56adc901eeea2e379991a0d4cb9737eec7aa6b9fc5d8
   md5: fc80b572be85601706d425b21a58d497
   depends:
@@ -5652,7 +5652,7 @@ packages:
   license_family: MIT
   size: 153102
   timestamp: 1695718054194
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
   sha256: f1eb2a5aeb25efa0b38fc1dd94a36d431bc80d654f11a052f67a899dcc471f57
   md5: 9db5a441c7cbcf4dc617f8c722e4310d
   depends:
@@ -5662,12 +5662,12 @@ packages:
   license_family: MIT
   size: 276663
   timestamp: 1718029990621
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.1-py311h746a85d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-3.4.1-py311h746a85d_0.tar.bz2
   sha256: 5e81c00b64a071a07c5ff5892fd48b94476c93121fdb2c28581dbf2e023480d8
   md5: fdd289f6664341f6b29f70804d322594
   depends:
@@ -5685,7 +5685,7 @@ packages:
   license_family: BSD
   size: 6101282
   timestamp: 1718119807269
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
   sha256: 5c12a5d7856d9977447360b3a99a5b99818707fe79781ba1779037f11b3fef53
   md5: 6a125ae352306a944aabc635a5fe13a3
   depends:
@@ -5697,7 +5697,7 @@ packages:
   license_family: BSD
   size: 139230
   timestamp: 1707864402762
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 751071782f597f87ed7f67437ef6cc669213902461b9795dd6eb0f4897eddc83
   md5: 5ad8fe62aad5e16cfdf2c5a7d1327fe7
   depends:
@@ -5709,7 +5709,7 @@ packages:
   license: MIT
   size: 19418
   timestamp: 1714483531456
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 9bd62d810867549b9c967c5915f3fa3f66cfbd6ede28b1cc152efd1261285c0a
   md5: 64cc76de3662b62bc8f0e42befd92c5d
   depends:
@@ -5720,7 +5720,7 @@ packages:
   license: MIT
   size: 32178
   timestamp: 1714483513837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
   sha256: 1547fa52134cf06b8d01bdf52114db7db60a89bf35c9c95be5b5a03b13dbd565
   md5: deb765cb7c4b7edc4d126f864f31747c
   depends:
@@ -5730,7 +5730,7 @@ packages:
   license: MIT
   size: 356401
   timestamp: 1714483740924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
   sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
   md5: 11e0af09a31e2d5df51c65a342032b85
   depends:
@@ -5740,14 +5740,14 @@ packages:
   license_family: BSD
   size: 112994
   timestamp: 1714511182837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
   sha256: 73391a74a5300ad3fb063ea0f0c3491d220128a0611a84036da2e23c1e93dc0e
   md5: 501ded4f9b5ed895077802defee912cf
   license: MPL-2.0
   license_family: Other
   size: 171644
   timestamp: 1710764856021
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.6.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2024.6.2-py311haa95532_0.tar.bz2
   sha256: ef70313240391cabaeb788bba56445c1d09e83bb3418708ce12d88caa02d948b
   md5: 3876257b995a2ff05fe3fa50e49a43fd
   depends:
@@ -5756,7 +5756,7 @@ packages:
   license_family: Other
   size: 167147
   timestamp: 1717618236343
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
   sha256: 5cb6ac90ad234248f3795945f69b0382397714a52712337b2f86339526b822d8
   md5: b90f3126f6315ea2e8ab242533062557
   depends:
@@ -5768,7 +5768,7 @@ packages:
   license_family: MIT
   size: 302693
   timestamp: 1714483562551
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
   sha256: 4099898f02e1f6119fcda65e747c3cbfef0bf563c8855b79a0245160709d5b45
   md5: ab9705c34e67fb8c8faec69d63ff4064
   depends:
@@ -5777,7 +5777,7 @@ packages:
   license_family: BSD
   size: 36410
   timestamp: 1676422341506
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
   sha256: c722f50980d7416ffb2cfc7bf72649307a0bb78c5a24eccefcd049cb61d6b355
   md5: c7c9ff0513ff3c99700919293b702410
   depends:
@@ -5786,7 +5786,7 @@ packages:
   license_family: CC
   size: 543258
   timestamp: 1709758602437
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
   sha256: 8fb3e816a5ad1da05125462dbc9e2a7e933b001a871aa65703802c0a894c6277
   md5: ee4b2fa9fce130496d5c7c86c35a1a05
   depends:
@@ -5796,7 +5796,7 @@ packages:
   license_family: BSD
   size: 17723
   timestamp: 1709323150229
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
   sha256: eeb49cd151ecdccd40062e8123a3b7a9a8a1eda6567dd33ce909ff8ee1a97c89
   md5: b7fe1f7ead1ec2ac642d022942282fc8
   depends:
@@ -5808,7 +5808,7 @@ packages:
   license_family: BSD
   size: 232451
   timestamp: 1700583772701
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
   sha256: 5c73f86e575f2ad683ee4a1c2df11020e270edd89d12f11199483d57b0b51826
   md5: e96a12895ce374476277b1b196ba24bd
   depends:
@@ -5819,7 +5819,7 @@ packages:
   license_family: MIT
   size: 3719519
   timestamp: 1690907216785
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
   sha256: 5d5fc8a24c804010b8cb5963227230352ea3ccf56bea9e8116e34f77223218f2
   md5: 8f989a72eed6293dfe0533c83057980d
   depends:
@@ -5828,7 +5828,7 @@ packages:
   license_family: MIT
   size: 17688
   timestamp: 1676423357100
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
   sha256: 27fb03eb57d25711a15e145f47a64320a9955b585efc9fd0a1a51cdd71b9fde3
   md5: eb3869e98f6f53dfec76e2eff4d6b61e
   depends:
@@ -5848,7 +5848,7 @@ packages:
   license_family: MIT
   size: 2732423
   timestamp: 1713552175344
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -5860,7 +5860,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.19.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.19.0-py311haa95532_0.tar.bz2
   sha256: 8bdfcbdc68524ef2222f4e4f39bdef9ebf4cdd046b8d3bc98e5baf1350f5fd4e
   md5: 21afc8a819b5d727107a701696f317e6
   depends:
@@ -5880,7 +5880,7 @@ packages:
   license_family: BSD
   size: 6118467
   timestamp: 1718295783978
-- conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
   sha256: dee3fc68ed81398d232b3afe9a032837bdbef98c1b2478604d6abd397e3e7d64
   md5: 3f75535ca6dfee0745b221922f21f6de
   depends:
@@ -5897,7 +5897,7 @@ packages:
   license_family: BSD
   size: 353312
   timestamp: 1715090519918
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
   sha256: 102c803186db6d62eaf41a906f6c563ff0d62b53c1eaede8a381e18c0d005ed9
   md5: 9d30dec03058758a428cf152e0ae28b5
   depends:
@@ -5906,7 +5906,7 @@ packages:
   license_family: BSD
   size: 148193
   timestamp: 1714399061601
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
   sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
   md5: d215cc8ee7ca2cc83cc250cc5d822fe0
   depends:
@@ -5916,7 +5916,7 @@ packages:
   license_family: Proprietary
   size: 3929136
   timestamp: 1699647939158
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
   sha256: 864e9598f64105769b4ec02cc404fb507bc59e217324daf1686c00cfd12c0055
   md5: 6bb1c3be1f85799a3988afc2c3c5a4f0
   depends:
@@ -5937,7 +5937,7 @@ packages:
   license_family: BSD
   size: 229621
   timestamp: 1705934494547
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.25.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.25.0-py311haa95532_0.tar.bz2
   sha256: 5bc6f0c2fcbf83879ec845c6d01c5f2509eb82033f97cf69f9efb04871f1c0ff
   md5: 0bd2c9f9e27b7527e9cc222955cf38f3
   depends:
@@ -5955,7 +5955,7 @@ packages:
   license_family: BSD
   size: 1664773
   timestamp: 1718288341111
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
   sha256: d81566367c79a28d4717157fc74293e846a47af99387ed479eb001a425dd398e
   md5: 28c76079c96ad7f8b1a5ed32b438c79a
   depends:
@@ -5965,7 +5965,7 @@ packages:
   license_family: MIT
   size: 1147434
   timestamp: 1679427525584
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.4-py311haa95532_0.tar.bz2
   sha256: 74c339ca0a20f4bc324974c2c28901c1f478ca7c8898483482883a7a82896d15
   md5: b3d3352c9d3bfe46f924b8e15fedf9be
   depends:
@@ -5977,7 +5977,7 @@ packages:
   license_family: BSD
   size: 353862
   timestamp: 1716993519832
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
   sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
   md5: 81f2c343dc4c65eea39c45383272068f
   depends:
@@ -5987,7 +5987,7 @@ packages:
   license_family: Other
   size: 407861
   timestamp: 1677849239400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
   sha256: 5e6698015a3b048093f5737f0e54bcbae415d0f9682dfdfeae3a8cfb4ea275e2
   md5: 0093a4214131046c4f68af0739dfbea4
   depends:
@@ -6000,7 +6000,7 @@ packages:
   license_family: MIT
   size: 201456
   timestamp: 1699041872445
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
   sha256: 9581be54128954080d7cef448b1728874c2ebbe5064f55adece422cf12eafa5a
   md5: 3adc105f87d5c7f0b1248bc3423f5b48
   depends:
@@ -6010,7 +6010,7 @@ packages:
   license_family: MIT
   size: 16187
   timestamp: 1699032556953
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
   sha256: ad8343bad7c8f0448cbcfbaf872cc94b56da81c52e5cdcee2a5d6b89f029eb75
   md5: addceff8d46c9d1d322618a9ce9e5b39
   depends:
@@ -6026,7 +6026,7 @@ packages:
   license_family: BSD
   size: 300354
   timestamp: 1676424060532
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
   sha256: fe0bf805dfa60d8b5d61670900442d0cda12523135176f60e1ebafb797e521d8
   md5: c8cf5ea3d4b0bc57dfe6b189b47e69e9
   depends:
@@ -6038,7 +6038,7 @@ packages:
   license_family: BSD
   size: 136783
   timestamp: 1718818384444
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
   sha256: 262c35a28d0af4d73ea1c010ce0c022005512a26d5c27064c8e009c0b7b789d9
   md5: 8367c61552aa274c0843201d88e461c8
   depends:
@@ -6054,7 +6054,7 @@ packages:
   license_family: BSD
   size: 72131
   timestamp: 1718738283200
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
   sha256: 00bf8449a37eb10c91ebfaa14b231905fde9493740cbda7ec89a8d3d8d9d1ff3
   md5: 1f3abe3cbf365249ebae7465a57e4cae
   depends:
@@ -6082,7 +6082,7 @@ packages:
   license_family: BSD
   size: 655133
   timestamp: 1718827724346
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
   sha256: 90420847230e72a648417f5f77cebcf7f17b89f70788652c276acc0c440e135f
   md5: ef3d8dee197aa37897bf6d39d2dd878f
   depends:
@@ -6093,7 +6093,7 @@ packages:
   license_family: BSD
   size: 27639
   timestamp: 1686871052174
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
   sha256: 97faaf26ce5254ec3649a8ee7f480b1556e4e8e6e4356d2fab1e6a5532631a0f
   md5: da23bd831c50c877f63038b7e16720ad
   depends:
@@ -6105,7 +6105,7 @@ packages:
   license_family: BSD
   size: 20163
   timestamp: 1700168785472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
   sha256: 8a2f0909fad0387e57cb0e9ee30db2b20761a9106e794381ffeac387a298fb07
   md5: 6058b2efc3284e27aacec2e6e6280433
   depends:
@@ -6116,7 +6116,7 @@ packages:
   license_family: BSD
   size: 62334
   timestamp: 1676432044242
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
   sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
   md5: f5f73266281ab12377d5d47bdf07500a
   depends:
@@ -6128,7 +6128,7 @@ packages:
   license_family: MIT
   size: 905072
   timestamp: 1617648814933
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -6138,7 +6138,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 7c906c94a4d46ea963080a6ba5bd12c1274da66159877a544fbc70291eeed98d
   md5: 45a3d52534fac8aa54a55ee92211a918
   depends:
@@ -6147,7 +6147,7 @@ packages:
   license: MIT
   size: 80216
   timestamp: 1714483371043
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
   sha256: daad7edc6d56abf3e176479e8628162dbf1c56b3d24db30d708aebae694a5214
   md5: e8ecf229f7fcb4c0b76d8613627948f5
   depends:
@@ -6157,7 +6157,7 @@ packages:
   license: MIT
   size: 45189
   timestamp: 1714483420152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 84320217abffa9386186ec8d03b4651bb4b1900d3871adc965a9a9e1d3799907
   md5: 651312fa22168f71f9aec5f9ee2c2fcf
   depends:
@@ -6167,7 +6167,7 @@ packages:
   license: MIT
   size: 756116
   timestamp: 1714483464368
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -6177,7 +6177,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
   sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
   md5: cf949d76148be1e2a534218d9c57df86
   depends:
@@ -6187,7 +6187,7 @@ packages:
   license_family: MIT
   size: 155435
   timestamp: 1714484319443
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -6198,7 +6198,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -6207,7 +6207,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -6224,7 +6224,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
   sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
   md5: b1781519a200ccbfcb4a1194005aa3ef
   depends:
@@ -6236,7 +6236,7 @@ packages:
   license_family: BSD
   size: 338459
   timestamp: 1694777084290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
   sha256: 4534c822511a052a72c2b070a05e5d8d6f3550f18ea00a33f9d8a9a92b4382cc
   md5: 82f24e7660831445a2183216e280a6a4
   depends:
@@ -6246,7 +6246,7 @@ packages:
   license_family: MIT
   size: 41464
   timestamp: 1676474474981
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
   sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
   md5: 320f40b75d93f3b96931c6d13c23946c
   depends:
@@ -6256,7 +6256,7 @@ packages:
   license_family: BSD
   size: 158902
   timestamp: 1714512129889
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
   sha256: e0dc6e119b224bb31ef34b6ba270ffadc181d38b698c5318de8df7a5d2c4ccbd
   md5: 992ccd756f09408f0b74dfb9852a8b7f
   depends:
@@ -6265,7 +6265,7 @@ packages:
   license_family: BSD
   size: 182381
   timestamp: 1676437963591
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
   sha256: 050b5fd4b28132d8102a7e6b40179894dc7f5e41f7ad9ee19211e67446c5740f
   md5: 3ae0b2f6baec708554648ddafa81b756
   depends:
@@ -6275,7 +6275,7 @@ packages:
   license_family: MIT
   size: 154386
   timestamp: 1684279992864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
   sha256: 8269c73b7a9c03b95a121e318d0468f35eecc016093620b0560f35238cc5df51
   md5: 2914bea0ae29315f998e1abac79ccaa8
   depends:
@@ -6288,7 +6288,7 @@ packages:
   license_family: BSD
   size: 30214
   timestamp: 1704206218108
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
   sha256: 68fb7d113dbf185b571343847e3dbefdbe7d0b9b5902f1f390bc2a6e33a3f8ee
   md5: a72ff718390a1fde0b208a43e6b9b655
   depends:
@@ -6310,7 +6310,7 @@ packages:
   license_family: PSF
   size: 11366001
   timestamp: 1713336740870
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
   sha256: 43279276850eb6e621812448cddc1093524cee0b7f8ed58b4600b68a4fb659f2
   md5: 5968b2b5c1f3cf5c8c8c9aaa4d8d66a2
   depends:
@@ -6320,7 +6320,7 @@ packages:
   license_family: BSD
   size: 19886
   timestamp: 1676425829787
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
   sha256: 3062a8254ca351b54f15bea85cc928a3ba4d879bb98ce97ece39a9f7eca215a5
   md5: 8f1565663abb34ad7fdd512e76da5532
   depends:
@@ -6330,7 +6330,7 @@ packages:
   license_family: MIT
   size: 68031
   timestamp: 1676481862508
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
   sha256: cdff5215c292fe59649ca40ca72f5d26da352760c1d6a56feba14eb13f7bbf61
   md5: e0f3f32b22135dfeaec277bc87183ca9
   depends:
@@ -6339,7 +6339,7 @@ packages:
   license_family: MIT
   size: 23328
   timestamp: 1676442709081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
   sha256: 3b173a25605d2aaacc57ec0e425f1d1c51327eb2521c8742a736e2c76069bc8d
   md5: 169f1c93a443f95a88665f3008623ce1
   depends:
@@ -6350,7 +6350,7 @@ packages:
   license_family: BSD
   size: 104882
   timestamp: 1676425142412
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
   sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
   md5: 527155127b9fada5e5c5c69a624674b9
   depends:
@@ -6362,7 +6362,7 @@ packages:
   license_family: Proprietary
   size: 187498166
   timestamp: 1699648376430
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
   sha256: cea59ae60da314caecf08edb9bcb03126c6dd35837c8184bceaa194decca3341
   md5: 30936b7263cf0171f7c86400f12ef184
   depends:
@@ -6374,7 +6374,7 @@ packages:
   license_family: BSD
   size: 49080
   timestamp: 1682975093455
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
   sha256: 5070ceb0a406b1b8b99e2ec58f5d224cbe16ec78109c46720bd182b509e05c6e
   md5: 34de1af5c639f2d06c6c8d99488e4226
   depends:
@@ -6389,7 +6389,7 @@ packages:
   license_family: BSD
   size: 196201
   timestamp: 1695058367111
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
   sha256: 6b4b27302e458fa527321c59be7c335d61f86da7501c4d141db20a72fad68b55
   md5: 7db9b12da1290bb2c2fc6ee52a945905
   depends:
@@ -6404,7 +6404,7 @@ packages:
   license_family: BSD
   size: 256371
   timestamp: 1695060425702
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
   sha256: 636f369607118a6ee3d0b63b7edb925d8081fd3fc829a7699136ce0dedbde067
   md5: b7e49c9cea50d8406cac81cd720dd80a
   depends:
@@ -6417,7 +6417,7 @@ packages:
   license_family: BSD
   size: 8323655
   timestamp: 1717622931223
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
   sha256: e940f9178ee2fa0a7c12873ae35ebea0074371653e5cfa1be8aa8d9271fd343b
   md5: 355d0835215911738a28010dfa6aa382
   depends:
@@ -6430,7 +6430,7 @@ packages:
   license_family: BSD
   size: 141785
   timestamp: 1698934346590
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
   sha256: 47dd00c0179f4eb29c70d0453d340f7f5332af326b3d51c64ca3bf6a14be8e7e
   md5: f66afe718bdb57667b03ebda4cb2ac7e
   depends:
@@ -6457,7 +6457,7 @@ packages:
   license_family: BSD
   size: 561655
   timestamp: 1699023338436
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
   sha256: 4ee863a1ff697274c642b3101f82b279a354e3f033a87505655039f89127bb41
   md5: bfaf19be6644ad2344e118aa0acccb13
   depends:
@@ -6470,7 +6470,7 @@ packages:
   license_family: BSD
   size: 189809
   timestamp: 1694617194065
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
   sha256: 90fb3f14c49da1397982eae21cd09e8d60d491d76f94c57590c56723fe6dc172
   md5: 46a523661fe5c1bce7b4213fd428c3de
   depends:
@@ -6479,7 +6479,7 @@ packages:
   license_family: BSD
   size: 16732
   timestamp: 1708532795328
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
   sha256: 62732e34b2cdcb73846cfdf53284067d32113aae0f6d736ca30ce2b0073bce27
   md5: ec7191b2ea4e65b5eed6f7fdd9271d28
   depends:
@@ -6504,7 +6504,7 @@ packages:
   license_family: BSD
   size: 769732
   timestamp: 1717630919732
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
   sha256: e040ebcab948325fbe17e4ab15be62e1fafa7bad225457e59764adb60eb40db5
   md5: 4d40a09df8cb74a9f044eab317436d67
   depends:
@@ -6514,7 +6514,7 @@ packages:
   license_family: BSD
   size: 27282
   timestamp: 1699456187703
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
   sha256: d3bd2a6614bb7e7f5ce3348d6674e71cce45cbde236beff32f0f08cd95a64ef0
   md5: e70f15643164f432d1df68635e7c322b
   depends:
@@ -6529,7 +6529,7 @@ packages:
   license_family: MIT
   size: 162691
   timestamp: 1696515822068
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
   sha256: 470fe9a0b3e196fa60d5550d8188f6074a207572fa0d353a4448d580872e7804
   md5: 6fdb8df0613fb2fb9f1732d335fa25f1
   depends:
@@ -6546,7 +6546,7 @@ packages:
   license_family: BSD
   size: 11053
   timestamp: 1708641901110
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
   sha256: 222c1711e7cf151e29077c7d4d86a865c9fd39615812d58a1daca6fd1b6bdfb5
   md5: 585bcd8bc3940a8a859f38ebafdcd77d
   depends:
@@ -6562,7 +6562,7 @@ packages:
   license_family: BSD
   size: 10723862
   timestamp: 1708641867155
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
   sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
   md5: ab07e2a27ac08afe3d0b4c0890b8486a
   depends:
@@ -6573,7 +6573,7 @@ packages:
   license: BSD 2-Clause
   size: 249316
   timestamp: 1630094024143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.14-h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.14-h827c3e9_0.tar.bz2
   sha256: e8db21d1d134a3881a8727bf8977c0ac1ac60a253bf9d6499d14907d1e25e4ad
   md5: 9dabd8629700e17dd0eaf4d4541783a5
   depends:
@@ -6584,7 +6584,7 @@ packages:
   license_family: Apache
   size: 8367632
   timestamp: 1718386877871
-- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
   sha256: b2f5f50a1ddf811102636f3acebd76716c88ebb628754b91eda7a3a962adf26c
   md5: 712527b4d84c350dca4b67f511c04414
   depends:
@@ -6593,7 +6593,7 @@ packages:
   license_family: APACHE
   size: 39421
   timestamp: 1699371341381
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
   sha256: 432b8b7c4671878cbbe361e518544203f97bd2e4f24fa08cf65e8be583f25529
   md5: e62e7c668b080e0f6ce09fd548f69f7f
   depends:
@@ -6602,7 +6602,7 @@ packages:
   license_family: Apache
   size: 159066
   timestamp: 1710809127954
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.2-py311hea22821_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-2.2.2-py311hea22821_0.tar.bz2
   sha256: 1b986a8752785cd01969e737952449f5f0f4284cab7690193fa1a602156881c2
   md5: ecfe5661d54e32e8533c02f5fd625dcb
   depends:
@@ -6653,7 +6653,7 @@ packages:
   license_family: BSD
   size: 17245139
   timestamp: 1718309568175
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-1.4.4-py311haa95532_0.tar.bz2
   sha256: 25474a636549a0686cae03bdbc694683021813bf9d59680e0599b7666444c755
   md5: 3c58f327cf194b62ab2f363e42598837
   depends:
@@ -6677,7 +6677,7 @@ packages:
   license_family: BSD
   size: 21849968
   timestamp: 1718120610637
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-2.1.1-py311haa95532_0.tar.bz2
   sha256: e6611058e26521784b6197418505acee343ca299b7fa3f57ec23621f869e1d57
   md5: ffd4cc05e70b156e44f242538d81ca99
   depends:
@@ -6686,7 +6686,7 @@ packages:
   license_family: BSD
   size: 264340
   timestamp: 1719348210484
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
   sha256: 6ca54ba8ce430caa8a1838b19869814d0b7fa3592a77f75298130983e635387b
   md5: e56c194e56d19dd8fd76f75a77f92c33
   depends:
@@ -6704,7 +6704,7 @@ packages:
   license_family: Other
   size: 1070844
   timestamp: 1714399290671
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
   sha256: 15001c7ee6cf6e0ef7afc2f313114f6103e7b6f641fac9a6899ee02d6537c822
   md5: 250ba95e77f5fcb3fe2aefa85157e859
   depends:
@@ -6715,7 +6715,7 @@ packages:
   license_family: MIT
   size: 3759346
   timestamp: 1715097175495
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
   sha256: e5f8cbfb5fc25d460a9117bfc5511959c5e86ccb193316033f87bd516e0c8881
   md5: 9f7e8b5eb651539386bb92c14e5c321b
   depends:
@@ -6724,7 +6724,7 @@ packages:
   license_family: MIT
   size: 37730
   timestamp: 1692205554840
-- conda: https://repo.anaconda.com/pkgs/main/win-64/plotly-5.22.0-py311h746a85d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/plotly-5.22.0-py311h746a85d_0.tar.bz2
   sha256: 68f4e222e47f1d9140322ee612f3518bdfbb13e9aeaa5ec9254b93bc8480af10
   md5: a87822d76184a133e2937b83e9ccd958
   depends:
@@ -6738,7 +6738,7 @@ packages:
   license_family: MIT
   size: 10783822
   timestamp: 1718151856544
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
   sha256: 6c5b53831273674361437fb546e08315fc11ca9275a174bca3887987e86ced5a
   md5: f8d91daf5173eb03157f484389adcdd4
   depends:
@@ -6747,7 +6747,7 @@ packages:
   license_family: Apache
   size: 122178
   timestamp: 1679591983138
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
   sha256: 546819d922b03f3a25ca9f98fd069d0588d481fc0603c6d74bd598fb6a93687f
   md5: 86c18e3e0b67ee099457475ed6caf2e6
   depends:
@@ -6759,7 +6759,7 @@ packages:
   license_family: BSD
   size: 751763
   timestamp: 1704404627180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
   sha256: ae06f0dfa2cfae51404afc6d6ad3a474a93015b5ba9a7d3ea24224b8e7547987
   md5: 3e19794c806cc3e84a3080a97c359b75
   depends:
@@ -6770,7 +6770,7 @@ packages:
   license_family: BSD
   size: 510466
   timestamp: 1679005998612
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
   sha256: d95c88d06f4f3f667bd9a39e5f18179e83b3cd4c115c06ce0fff390ff6d3a700
   md5: c6d00a8a4d89b1be99bfa3aff19d96b4
   depends:
@@ -6779,7 +6779,7 @@ packages:
   license_family: BSD
   size: 2134881
   timestamp: 1684280285492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
   sha256: 643a9a0eba1e2bd5980d21623d3b35188c24781ec251acc4d15714bd1ccb4c17
   md5: b3cda0394db05be6f0f6176abacb13f3
   depends:
@@ -6788,7 +6788,7 @@ packages:
   license_family: MIT
   size: 207985
   timestamp: 1678721438358
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
   sha256: 974c22de09078bf07c5db31fe12d8d89d6433508defc8237cbe52e08c69ed56b
   md5: 9cf10bfd49140a527cf4b1d912097e6d
   depends:
@@ -6798,7 +6798,7 @@ packages:
   license_family: BSD
   size: 36072
   timestamp: 1676426019064
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
   sha256: f43aca7a222c983c25c3e15f79c7e7e3c4909bb7839a1dd0ee327def81aa476e
   md5: 2b61f1cb7fec068c76ef0ff97c2c62b5
   depends:
@@ -6819,7 +6819,7 @@ packages:
   license_family: PSF
   size: 19811751
   timestamp: 1713545124922
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
   sha256: 2c61639b3bb56fc864c86558bceb7845b1731ac44bf1a94894172ea47a995bd4
   md5: 404805e547b4d50b5cd17e16bca87527
   depends:
@@ -6829,7 +6829,7 @@ packages:
   license_family: BSD
   size: 332043
   timestamp: 1716495838826
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
   sha256: 9acb33db60d9319595f52337cae3b88c2a2338cd66f1f9d8ae86d0a993c2067a
   md5: f4af8cf94d042b4dde487241bba1c457
   depends:
@@ -6838,7 +6838,7 @@ packages:
   license_family: BSD
   size: 279780
   timestamp: 1679500609851
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
   sha256: 48fe7373b012b51134b6b6ff67f18d2b4aae3a5c7700e4560ce002af7172f064
   md5: 0379cd17692152c12b662b0e4ea46b88
   depends:
@@ -6847,7 +6847,7 @@ packages:
   license_family: BSD
   size: 18008
   timestamp: 1683824373128
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
   sha256: 803274d986d0c4e3b5ec1018747ede86ef57137455b3e44a60e834717eafb92b
   md5: c9f134ddeff6fdf0373a45534ddb7079
   depends:
@@ -6856,7 +6856,7 @@ packages:
   license_family: MIT
   size: 273009
   timestamp: 1713974722039
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
   sha256: 6fbcba97c1dcb5157afd23f264c3cff069c7e4be5ea55980fc349eb8dc2cb49e
   md5: 8153e3f8b3283926bcf9403804a365f5
   depends:
@@ -6868,7 +6868,7 @@ packages:
   license_family: BSD
   size: 65050
   timestamp: 1711137009299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
   sha256: cd33dfee104dfbba4af38d06a09ccbae6a32e7c543afedab523303319ebb283d
   md5: 3dfc19af0306d80921e1403f1f551bba
   depends:
@@ -6878,7 +6878,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13679916
   timestamp: 1676423267293
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
   sha256: 102ff1d958209e3648bb49da3503cf752abab822011fdc4e12e88145c9e73772
   md5: 0553c2c381b6f5c836b23edc8c6db2ba
   depends:
@@ -6890,7 +6890,7 @@ packages:
   license_family: MIT
   size: 246689
   timestamp: 1677708371873
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
   sha256: bee5c4d0f41f06a9c0aac636885e36e8b81116aafde980f9ea48fdb64abb5567
   md5: 6c05a053240cb90765d6f8c2efdf905e
   depends:
@@ -6902,7 +6902,7 @@ packages:
   license_family: MIT
   size: 182228
   timestamp: 1698096268270
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
   sha256: ea39db411361d96545a04fb976940e9590147acb4ca9caacf7e8264780379347
   md5: b411b8be8e53e5059949dde02dd07faf
   depends:
@@ -6914,7 +6914,7 @@ packages:
   license_family: Other
   size: 565148
   timestamp: 1709319072176
-- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
   sha256: 47653b45a5f2d97b5bf0dbf0e620908880f9078da427eef69012effe3f19af67
   md5: 44e709ae67d89bccee2d4d46d358fee3
   depends:
@@ -6925,7 +6925,7 @@ packages:
   license_family: MIT
   size: 74493
   timestamp: 1699012356534
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.32.2-py311haa95532_0.tar.bz2
   sha256: 8b9586873f05e6ce14c4e067efc0a61effc8d163d5129447515234a4c43b5f43
   md5: 5fbd94c1f1e7c0a934eb8c9a00b34acb
   depends:
@@ -6941,7 +6941,7 @@ packages:
   license_family: Apache
   size: 122975
   timestamp: 1716903247759
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
   sha256: d6daaa6b45272819176e4aeb467ae00e3db43386548464a9993688f292709d40
   md5: 9fe721d7f7420c259df4f07d4503f654
   depends:
@@ -6951,7 +6951,7 @@ packages:
   license_family: MIT
   size: 9683
   timestamp: 1683077110211
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
   sha256: 6051860575f9448aea5799d74469c928cd7cdeeca1eb53657872262a77b1a7a8
   md5: 60e193eca497130034facd5fed168249
   depends:
@@ -6960,7 +6960,7 @@ packages:
   license_family: MIT
   size: 10094
   timestamp: 1683059114376
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
   sha256: ecd310461c1b45ab92ddf15539cea5a6e837860561c974d2d7393f9a7933f116
   md5: 1762fec2838763e904141167e18b0389
   depends:
@@ -6971,7 +6971,7 @@ packages:
   license_family: MIT
   size: 215600
   timestamp: 1698947891859
-- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
   sha256: 6fd52bae6360fbc8135d72e0c1e4fd407769fa4d0f4b59356e7aed3e000eb339
   md5: 49fd52885250da8aab17ed72e2e18b81
   depends:
@@ -6980,7 +6980,7 @@ packages:
   license_family: BSD
   size: 88901
   timestamp: 1699371435766
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
   sha256: a2ec4690bc07be9e7f3ad8e3003803eb4304a434d3f139633e2817318a9f7b20
   md5: dd2d225219924fc5c36598c919541271
   depends:
@@ -6989,7 +6989,7 @@ packages:
   license_family: MIT
   size: 1593050
   timestamp: 1715025622141
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
   sha256: 5d1b7e14dc04816692de0f8518ea8fcbefb26ab61cec83f96f2c44c1bee67fab
   md5: 505d2a70a875b5082dc857aa4dfab0d4
   depends:
@@ -6998,7 +6998,7 @@ packages:
   license_family: Other
   size: 18830
   timestamp: 1705431395254
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
   sha256: 5ff3b4ac3fbce4dd67a87856c04698d0397deb0ac288ff4e7eb02fbab57f1253
   md5: 0ca650a7001c6650809d3361de8cb005
   depends:
@@ -7007,7 +7007,7 @@ packages:
   license_family: MIT
   size: 89590
   timestamp: 1696347858925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
   sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
   md5: 833b93a2daade3407898f15588945d83
   depends:
@@ -7017,7 +7017,7 @@ packages:
   license_family: Other
   size: 1440481
   timestamp: 1714488344682
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -7027,7 +7027,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tenacity-8.2.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tenacity-8.2.2-py311haa95532_0.tar.bz2
   sha256: 2f689b3e7e3baab298c76332de10cdc3516ef2418618129235d507dffeb9e3f1
   md5: 2b7a7629993c8c6b6842dc86df45d3b0
   depends:
@@ -7036,7 +7036,7 @@ packages:
   license_family: Apache
   size: 47488
   timestamp: 1682972466477
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
   sha256: 78d89b50a29fbeb19a562f5dad95615e3f192bb4f3b86cd6ea75f2f825418232
   md5: 4a4040df560ea47704e0898c4c015808
   depends:
@@ -7047,7 +7047,7 @@ packages:
   license_family: BSD
   size: 38069
   timestamp: 1678228553220
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
   sha256: 70a3cc4a4e81a6421bc19cd410d1d6064aadb2b1cce38b020f85e5346716d8e7
   md5: 32a9a2539579a3d522dce3b5cb4f987b
   depends:
@@ -7057,7 +7057,7 @@ packages:
   license_family: BSD
   size: 49495
   timestamp: 1676425411739
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
   sha256: 0a95736cfd0bb25fc201cd6be4a2450ea8fc30eeb349d861812675b84c94fa74
   md5: a8a9fb30c6dd8e7a16d5dcd2333c3c49
   depends:
@@ -7068,7 +7068,7 @@ packages:
   license_family: BSD
   size: 3844176
   timestamp: 1714770894235
-- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
   sha256: ed5950ac0c12cc87f991a6f28112cf29057e2b7ad416ae4429a0b97c3efaf58c
   md5: b5e2a04879e6fd19f0eb5effded4dc61
   depends:
@@ -7077,7 +7077,7 @@ packages:
   license_family: BSD
   size: 135939
   timestamp: 1676431438808
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.1-py311h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.4.1-py311h827c3e9_0.tar.bz2
   sha256: 04340cd171ff970c405b4b955f825cb52deb71f4420346596744bf36214ce431
   md5: bbab95732695d5d4c759dfbd274a15ff
   depends:
@@ -7088,7 +7088,7 @@ packages:
   license_family: Apache
   size: 926984
   timestamp: 1718740216876
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
   sha256: 973dc7991dd5976ce2d27a94739712cac4d31f2d2958fbf23adb844f5ac999c8
   md5: ca74b36907b3f4f8a51bd5b2e4d8220b
   depends:
@@ -7100,7 +7100,7 @@ packages:
   license_family: MOZILLA
   size: 186541
   timestamp: 1716396206048
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
   sha256: a724711191ac1226bf228eab49718eed7b5c7394f539294eb0f88baf8e7bb24d
   md5: c78482e07d0aa6df9fcfa5b366dd87e3
   depends:
@@ -7109,7 +7109,7 @@ packages:
   license_family: BSD
   size: 207744
   timestamp: 1718227224929
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
   sha256: ab3cce654f1e94793fff0cb03b750d9b20cdbf099263b1906c3c5eaf8b347ab6
   md5: c68ffc771312afb6f88b94c24d2bb689
   depends:
@@ -7119,7 +7119,7 @@ packages:
   license_family: PSF
   size: 9706
   timestamp: 1715268972001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
   sha256: 4089efea1753ebe2f6617b46cc368738f285b1d816d4a4f01ba71524f46851b4
   md5: 7f610528ecd0b317180efa2058c32323
   depends:
@@ -7128,7 +7128,7 @@ packages:
   license_family: PSF
   size: 75414
   timestamp: 1715268958140
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
   sha256: d091897f05318c22ca31028370f25355065999078f7db6f88ab27bf4cb030ec8
   md5: 1776502c1cfb351554eeda6cddaf255f
   depends:
@@ -7137,7 +7137,7 @@ packages:
   license_family: MIT
   size: 11588
   timestamp: 1676457729096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
   sha256: c16498f8238cc331618720d078b87995eceb6bbf20268a7a4e8efbf7b5859a9a
   md5: 770432c0ca1ab9d99ffe95e51d3a3e74
   depends:
@@ -7148,7 +7148,7 @@ packages:
   license_family: Apache
   size: 517433
   timestamp: 1713213261710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-2.2.2-py311haa95532_0.tar.bz2
   sha256: e6b7f1cf269463c87bffbe808e88069c36ee0ff1d909e65d8986b914980ec0b9
   md5: b5852f18c3edfcc6147cdaf96a1ecc99
   depends:
@@ -7164,7 +7164,7 @@ packages:
   license_family: MIT
   size: 210228
   timestamp: 1718912759694
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
   sha256: 906048f3b1dc326b367a08edc91816ff523b5f06cd45d985b4dbb7cfe8017559
   md5: e509c495aaa92d767d554cd43a990ee5
   depends:
@@ -7173,12 +7173,12 @@ packages:
   license_family: BSD
   size: 8900
   timestamp: 1715797316229
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
   sha256: ab224d078734a23527716388ddffc034d18254843881d0fc068c2efa35bacfe1
   md5: 73f5831d017e5572330d2459844718f3
   size: 2246565
   timestamp: 1715797302913
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
   sha256: 24ea3d3e0cb98d0d246338dbb4562b67967bb32002e3704e495a5c863476e831
   md5: c7b9cdbe87b3c9720aeca1164a0fd6df
   depends:
@@ -7187,7 +7187,7 @@ packages:
   license_family: BSD
   size: 26181
   timestamp: 1676424437003
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
   sha256: 92d27e41ce34387e59acb47572fcb2e92c4defaeadafd11ce190226022023e69
   md5: f1bf142d852987acbe4b0bc94e87d958
   depends:
@@ -7196,7 +7196,7 @@ packages:
   license_family: Apache
   size: 145306
   timestamp: 1715878654770
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
   sha256: 1b086d1b079fdb2f148c7dd82658f2b7f283c88f286e1216c0f1237319039b0f
   md5: 299e87f151a549d86a48bf24df15c607
   depends:
@@ -7205,7 +7205,7 @@ packages:
   license_family: MIT
   size: 168041
   timestamp: 1714717238470
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
   sha256: 17fadf35aa8917c107e7b369e9364ac7c09537776e7943d37e225e14b7026c94
   md5: 0e67c3b9624540581b894b11267a837b
   depends:
@@ -7213,13 +7213,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 10197
   timestamp: 1676425485716
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
   sha256: b849b368e27920838fe40a512b102879693a55cb187dd1c8d3a83fa8c05a8054
   md5: 7b1f6e9c71906a93039b3446b99a5498
   depends:
@@ -7228,7 +7228,7 @@ packages:
   license_family: BSD
   size: 55114
   timestamp: 1676434863173
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
   sha256: 344a5276a9928638dcde054dfe4e87c8cb40bd2d4d356378b9ab2f863ca62e4b
   md5: fe471fd8b5a3d77be6fa5dbf9b99dafb
   depends:
@@ -7238,7 +7238,7 @@ packages:
   license_family: GPL2
   size: 1432281
   timestamp: 1714515119689
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -7247,7 +7247,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
   sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
   md5: e5aed81295b61b6d1eb62830799a0297
   depends:
@@ -7258,7 +7258,7 @@ packages:
   license_family: Other
   size: 9125184
   timestamp: 1705602328351
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
   sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
   md5: f295b54ab59f5b8658e2a322ac6aa721
   depends:
@@ -7268,7 +7268,7 @@ packages:
   license_family: Other
   size: 162161
   timestamp: 1714514792081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
   sha256: b2ff66b7f6efa0831f939e57e562c244332b690af08818a540d1a97fa07d8525
   md5: e548d528873d9a0006a36714cf36462a
   depends:

--- a/gapminders/pixi.lock
+++ b/gapminders/pixi.lock
@@ -1,0 +1,7283 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/altair-5.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.1-py311h92b7b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.6.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.19.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.25.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.14-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.2-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/plotly-5.22.0-py311h92b7b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tenacity-8.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.1-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/altair-5.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.1-py311h85bffb1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.6.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.19.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.25.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.14-h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.2-py311he327ffe_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/plotly-5.22.0-py311h85bffb1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tenacity-8.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.1-py311h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/altair-5.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.1-py311hb6e6a13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.6.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.19.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.25.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.14-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.2-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/plotly-5.22.0-py311hb6e6a13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tenacity-8.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.1-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/altair-5.0.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.1-py311h746a85d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.6.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.19.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.25.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.14-h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.2-py311hea22821_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/plotly-5.22.0-py311h746a85d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tenacity-8.2.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.1-py311h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+  sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
+  md5: 613805add1c05b538ff06d217252feb7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 20810
+  timestamp: 1652859733309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/altair-5.0.1-py311h06a4308_0.tar.bz2
+  sha256: 182e66fccbb032294e781427a3cd8bab80cd5da25dc4aba9ad6af84c84cabd04
+  md5: 1e25b33d589e2f1c465235a4302e1582
+  depends:
+  - jinja2
+  - jsonschema >=3.0
+  - numpy <2.0a0
+  - pandas >=0.18
+  - python >=3.11,<3.12.0a0
+  - toolz
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 851870
+  timestamp: 1687526078680
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+  sha256: 250f50edf43a786a32942e9ae67ce807e9b3ac4cb6b58b1170cb541fb24e391f
+  md5: b48058294499d292ddf9a3b966dc9cc5
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 228473
+  timestamp: 1706220559474
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+  sha256: 0d4f5274503916e1c683dcc16e8a7c4186557afa3f62399cd628e4eb535fe77a
+  md5: 062acdb0f9ae976c25c2d15d589dc1d6
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 35809
+  timestamp: 1676823571351
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+  sha256: 567dfdd5b986012421a736a5f1c1d5874d8d691dd483c838b55e1ab06c0b217d
+  md5: 4e0aa1543f546b898523382ee8405e84
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 152577
+  timestamp: 1695717917074
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
+  sha256: 5bb9bfe025d9a49af272f194278f63cea7366e83bdf3f99d25f97b820d522089
+  md5: 100d3161d97332fe38945afec8d36935
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 276381
+  timestamp: 1718029864701
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.1-py311h92b7b1e_0.tar.bz2
+  sha256: 34d2dcc4885a03631c340e88ecb1002ac60c1f9573f34252e3ad8b87096c0040
+  md5: 9b33d05f7b278ad9a9a3442da9d41f11
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6054528
+  timestamp: 1718119253989
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+  sha256: 8e2b2073ff5c61d35714e8a36ce657a8ac741b7bedc2852a238c7f1625142705
+  md5: d951ab54a682b6328327fec53b1e5e72
+  depends:
+  - libgcc-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 147642
+  timestamp: 1707864274452
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 5d15605858771290fdaaae41a43941623757a25cb1292080d69d6d3857807935
+  md5: 7f517469aa5380c52e55db9f37df104f
+  depends:
+  - brotli-bin 1.0.9 h5eee18b_8
+  - libbrotlidec 1.0.9 h5eee18b_8
+  - libbrotlienc 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 18652
+  timestamp: 1714483267080
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+  sha256: a5094f078584e27c7cced4a9564ae904a329f5c1702a7c1ba092d581ba1544f1
+  md5: 6ddf45dd8a21a9512481de9bc0e5a03f
+  depends:
+  - libbrotlidec 1.0.9 h5eee18b_8
+  - libbrotlienc 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 19711
+  timestamp: 1714483255915
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+  sha256: 93180c973816246f068b742d0bf64840f0ea48e31d4f9b0747ea2ffc34d8855d
+  md5: f3a00096965a5ba1eb41d2c99a4662a2
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 361574
+  timestamp: 1714483400014
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+  sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
+  md5: f5058c8d5b2994b7334f18e022105a14
+  depends:
+  - libgcc-ng >=11.2.0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 427542
+  timestamp: 1714510571510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+  sha256: 394f74202c2efc8fcfd02b8953f508eb6a2961d224a2f9d15091caf5cbe1be67
+  md5: 1202b4ed32215c6405bb42fbff355316
+  license: MPL-2.0
+  license_family: Other
+  size: 137411
+  timestamp: 1710764808838
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.6.2-py311h06a4308_0.tar.bz2
+  sha256: d30bad9397c44cec36475daa2aaa2460871ab3d76ac32b9f6df4601f2b0fb920
+  md5: 92a88346f3e221bbc0549a16773bdb1e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 166124
+  timestamp: 1717618114991
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+  sha256: d138cc3fde270eba783baf1e2ba17c89800b2cbbf20976d0eb425b3436a4a184
+  md5: 1875e89c1a939e4e7c5e7b731c72b838
+  depends:
+  - libffi >=3.4,<3.5
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 302401
+  timestamp: 1714483186060
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+  sha256: d9c102b9ec7f3a635936b6f73d4db126d748a25f65407353bd76b260dc7d1cd6
+  md5: eec48dbdf5dac0ea26750cc26b58c1d9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 554986
+  timestamp: 1709758392744
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+  sha256: 882481e441b9b93cbdfb32fbe32a6ad9f26197472f186a08fddb921f61346c02
+  md5: 443c79196064f57c98199e9990544b2f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16902
+  timestamp: 1709322958614
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+  sha256: e4877b41553e31b9f9f090dffab77a654255c63776e8b30fc91ec1f60afadbf1
+  md5: c34d3f1520f1e8c9957eb236710058c4
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281162
+  timestamp: 1700583651472
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+  sha256: 3b4cd8dc60572086f1a1cbb97e2712e0ffd55317ce8f0309d552eee7367855eb
+  md5: 70a1263b6e19bf2d77c020a2e77277c9
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2556575
+  timestamp: 1690905285843
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+  sha256: 4b589e3265c74159130230c164ff2d8d381be65899a249def0b53f93ce83fd47
+  md5: 245cb7173dcdba21cf368031cd87f706
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17434
+  timestamp: 1676823330845
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+  sha256: b75d12e85274660bb675a3e53d47a929872f2daa2ff5a76e98885ee3f2d19ad1
+  md5: f2119d0885334060d0d7fe59e5220287
+  depends:
+  - brotli >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - fs >=2.2.0,<3
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  - zopfli >=0.1.4
+  - lz4 >=1.7.4.2
+  license: MIT
+  license_family: MIT
+  size: 3237908
+  timestamp: 1713551660998
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+  sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
+  md5: a5dc8677d891dff2393b63189a3ad42f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 971975
+  timestamp: 1666798278693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.19.0-py311h06a4308_0.tar.bz2
+  sha256: 19943e427090f6ae2858ca276b1c928276d7429fc847c7fe769fb53d5124a936
+  md5: 656272c262237114be93d53da3c25f86
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21,<2.0a0
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.1
+  constrains:
+  - plotly >=4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6096391
+  timestamp: 1718294765372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+  sha256: a0ae6c5a6b615d73d9a243331f3f7d749b4feafdf2f334337fda8abd6c8355ed
+  md5: e61d8dcd4dfd6d165e6e480cee846bf5
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 357992
+  timestamp: 1715090462763
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+  sha256: e08e27531775de40f46b6ac7bf71856963baa0c008bd2b4d112e6341cd3e8f4c
+  md5: bfc7682613c861cbcb4ac01485c05657
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147174
+  timestamp: 1714398938840
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+  sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
+  md5: 3add2ce56858a1b8f6a37342f82773d3
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<1.2.14
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 19310769
+  timestamp: 1699647799237
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+  sha256: 0b670ab17ed2e1b592079bd64386dadc249ddc892e5ae1dd99f142a918ffc75d
+  md5: 632575b9e442c1e5c146cf78424da610
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 227791
+  timestamp: 1705934138566
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.25.0-py311h06a4308_0.tar.bz2
+  sha256: 3bd99b00f61f427332fac1d1ba7e6e645ff21423c0c95323fdb55d3eae2d89fb
+  md5: f59e3ad77589ccca38d734d6b2b8d653
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1624438
+  timestamp: 1718288016429
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+  sha256: a2918ea8a3e2c56fc6d91191e84b2f35500c392b16ab687a0c03ded2e2e51239
+  md5: 84fadd6b7fef393cccc0d123dae6cae8
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1162207
+  timestamp: 1679336523618
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py311h06a4308_0.tar.bz2
+  sha256: f8c1f9c49e58fd9adfefbe99d055a8045643b620902c4758a07d689b21418900
+  md5: 77918475e3a5511cd5a0f595a751b881
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 354911
+  timestamp: 1716993527421
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+  sha256: c21f8f407266d039e819c27fe9eb4fb26587e974f3bd059b37cbaec5073722d0
+  md5: ba1f47411e9e07876c7a3e9d3be6a98e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: IJG
+  license_family: Other
+  size: 281400
+  timestamp: 1677849152168
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+  sha256: 06b729aee6dd2a1e545f3ad64179cc0d4ef8a15e33db3be2995dd3e0868465ca
+  md5: 8bb3215912588e47e2eeb4e7a09ad64f
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 180858
+  timestamp: 1699041715847
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+  sha256: 9e3bac2d41bd432b721b009e7de981766fba396e6f238e923f304112bd88655a
+  md5: 84ae4cf3f2d01fbebdac374971192be9
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 15525
+  timestamp: 1699032521315
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+  sha256: 79ce6dff3d93649a2555b1d2a4ae9eb77175a1c00664cb8eb0e6f848d5cdd1b9
+  md5: db395b0efd7018fcf3a4af879170c2a8
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 276856
+  timestamp: 1676823504812
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
+  sha256: 91cca0ba49accdc9e97463bee087244a27ad107eb3af9ccb91634239f8b10f72
+  md5: a185824bfc55bd90e1cf9330b417b74c
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 97359
+  timestamp: 1718818381635
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
+  sha256: 540f8dfb7cdc3877b4e24d6af65696d0bc7eae5de1c307229f86b3fe601a2286
+  md5: f650f8c007471f6ef6c1a292918d2e1f
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41920
+  timestamp: 1718738122846
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
+  sha256: 398387b6f1ee1691b04a31fedd1320225e5553aa921b06bc013f010a0008621e
+  md5: bac66634a9133c633ddc879e14e83f23
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 610854
+  timestamp: 1718827113534
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+  sha256: ddfee06ba9b149222c65d1d4270272840533aa63b56fe36363c84a891c71d328
+  md5: ee128e5c0d8d9e1952e2387b66a5b8cb
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27239
+  timestamp: 1686870958829
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+  sha256: 0c6a074272ed58677ec17e4dbfceaffd2108841a61af92b32f156c5763108d1d
+  md5: dd3d37841d0d20c70a60e8c939923894
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19144
+  timestamp: 1700168632051
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+  sha256: b040f0d0ee4588188ab6b83a93738b3ff6e6d1775424be97995bd0df0f4fb904
+  md5: eae62735d710cf5ff6d51e6f59fcd999
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78148
+  timestamp: 1676827253282
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+  sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
+  md5: 88199c75f2ac211728febced7785c24e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 228278
+  timestamp: 1635523146417
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+  sha256: bb990ea068c3b3dafd9c807e0e19570320cb2fe7d69cc326f1f0b5319b0654b2
+  md5: 3ff70744e396b1af69656c574b05c3b9
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 66940
+  timestamp: 1714483221853
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 3b87a816f72a00e1f0022a160e7eda70af89d3de2a2e08a72be1c17b31d759f3
+  md5: 4f57d3a0a13ddaf1c06efb586b702f46
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 34446
+  timestamp: 1714483232430
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 2cf15e89f910600f468edfde8d0f9b80a14fa2319ed89160dc7375dfd3764fdb
+  md5: 463adc13f2feea3570d1eccac368d9e4
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 295090
+  timestamp: 1714483244460
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+  sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
+  md5: 55dde57e63a36b202e388a39dcee9a66
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 74096
+  timestamp: 1695996494461
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+  sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
+  md5: 1af9b4d62c708924417f2640ef22a68f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 154016
+  timestamp: 1714483282916
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
+  md5: 641e72e5067bd6d5454405879e1cd2a7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - _libgcc_mutex * main
+  - __glibc >=2.17
+  constrains:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - libgomp 11.2.0 h1234567_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 8895144
+  timestamp: 1654090827491
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+  sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
+  md5: 3080c2813e6e1d0f8a100a38b5b3456d
+  depends:
+  - _libgcc_mutex 0.1 main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 573231
+  timestamp: 1654090775721
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+  sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
+  md5: 1bffe1481ed4f88827248fb9001f8923
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 362561
+  timestamp: 1677841789536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
+  md5: 8c195584a5f5471b600ee180e4052773
+  depends:
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 6410287
+  timestamp: 1654090800863
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+  sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
+  md5: ef78eebd98289aceacdfa29182426adf
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 664034
+  timestamp: 1693575237924
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+  sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
+  md5: 292768ec77416ae257cfdd44ea2071c8
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29197
+  timestamp: 1668082729834
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+  sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
+  md5: 9cdeef1d044c7e035c006890f11569d3
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 436056
+  timestamp: 1694776944891
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+  sha256: fd8e30beb8c9442f16e6617fac92dd0c89ec823e98f06e60f712147380ead35f
+  md5: 7ed7caf2816c8b85b67b6f4e8833cbd5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41155
+  timestamp: 1676837080881
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+  sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
+  md5: 76f089e76ec67583bb38428b51008097
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 164494
+  timestamp: 1714510587156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+  sha256: 260e26dd509834c1b225ab7bdb97b9a86e00054fbdd5dfa49e68fa4dcf85a661
+  md5: 8f5d7ddc69cc6f7d44c80d2251dea5d1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162339
+  timestamp: 1676837095436
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+  sha256: 7f5b0804d0768619b7bd93b10488067d80bf42ec29f443f00b53ba11758a1241
+  md5: 8afb45e45c0d93bfd142e682d4b021ef
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 134438
+  timestamp: 1684280014220
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+  sha256: cb03570c99c983d7bfda94bc47d8eb00d4059b8548a171130775acc998004195
+  md5: 5b1abbbf1e4f9b350b16fc9caf9e889b
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26919
+  timestamp: 1704206397615
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+  sha256: 85fea48bea278a77d102781a1cbb6bf69307207d741251e38a6515c5fd7e3523
+  md5: d6ddba94f7c33c88c9825be8409991bf
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9150942
+  timestamp: 1713336680714
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+  sha256: 7ac07ea180b5928086075900afbc332fb1d3c81ddfacb54c891693c284056f14
+  md5: fc83dd1b3d2ec3c0a297ead0c3405907
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19573
+  timestamp: 1676823852670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+  sha256: c9ba2f9c83820712dd97d6a1b54a1215b9820a0be02ac82380b4c50911b9400c
+  md5: e5dc6b4a5b8e02733ce3bc9e9198a8d2
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67750
+  timestamp: 1676837123613
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+  sha256: 1a5141ef0de1cbff816f96bb4b212a40606e2fc11301a4c1358c8d63a6b2b027
+  md5: 22ac3bc22b68fef4c1f3f6ab3c7bfe0b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23040
+  timestamp: 1676827301164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+  sha256: 9aacfbbe6f638c58a4e8ff31374d1438d78b7db25d6ea6fd0c50ca2109f225d4
+  md5: e602057e3b3d80da88c61d66e8851c5b
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104681
+  timestamp: 1676823696152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+  sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
+  md5: ce77d0f05f846da4a6b9e23fe7f21d9b
+  depends:
+  - intel-openmp 2023.*
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - tbb 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 206738176
+  timestamp: 1699648006088
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+  sha256: 2aef0876d0df033f7fae8cddbd25d95fc1bfc067e60dd143bd8000fec0768b21
+  md5: d6cdc670327bd1675bbea642849f04e1
+  depends:
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59569
+  timestamp: 1682948560323
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+  sha256: 691c4b2b47cf3fac55b4949d7c0f547246ef19cb3510749142cee4bd01ffb055
+  md5: bbd69efa3f24ee747410f83118640d92
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 240723
+  timestamp: 1695058405382
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+  sha256: 71f5c7beca4e81b465ecfc6ed51cb3d39f51dd88df0b29eff5def3d1f12969eb
+  md5: 61d58663b7277cf4cc3cb8d9873d3ee8
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331105
+  timestamp: 1695059935112
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
+  sha256: 6116c133fbed1e7ea0f5e69f900e93d7977cb715920d10b10642c191d00cc9a6
+  md5: b842f7ebdc8b7b6a0dda4c5ebe12805b
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8315206
+  timestamp: 1717622768176
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+  sha256: bb45fb0a3973caa74fd8f845e0a519895f6a378807626e15ecf72c02f2eed794
+  md5: 185f658ba8a74e326b7231c8fd0d62bf
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 121834
+  timestamp: 1698934274227
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+  sha256: 8b2fc372a6655fd5b277d07b994ce43643553fbc37e63a60e9fe527a9026ec06
+  md5: ed6ac14aed5a796b153d757862398997
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 523905
+  timestamp: 1699022906468
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+  sha256: 7908ff6c516b15e8fb677be4071145e18adea7d4c13b8485a70a5ee2f573f8cb
+  md5: 50c0e38207a131a5de6a14ef919ffcdc
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 169629
+  timestamp: 1694616826002
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+  sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
+  md5: 57ea097dc15f8d9f9eb90e1d919143b0
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1157733
+  timestamp: 1674734069410
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+  sha256: 266199dd4efde0ad342a9c500f4bc4299c5622219aea623b46315a9b4f6b8959
+  md5: 2b21844d2b0024d0ffad0e6450cf0855
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 15860
+  timestamp: 1708532713870
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
+  sha256: 59e169e036db0f2b98ed19f867d8ac708970214599efa0d57d3413fc1dbe8e3c
+  md5: d0faf375bfc33811456d43fe549cb939
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 710152
+  timestamp: 1717630833268
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+  sha256: ef2857e6d3d7eb246b3abddfbd3aa2d124dd8565391ace3876b77339babc50bb
+  md5: d276d1b1774107987963135c78ca7390
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26607
+  timestamp: 1699455972519
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+  sha256: 2f89f38a665ece47e8868b391fc70602fcee588e989bc1ca6f17f6094892a94e
+  md5: b788c80b2d571531ea4f3f8335ae5423
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 168827
+  timestamp: 1696515597877
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+  sha256: e09e1aff2c12d4ef3fec58fb627744e4b5c7d9eaede7175e293f77272d8b8bfd
+  md5: fe8242cfd54d238507493612ae697ad4
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311hf175353_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10270
+  timestamp: 1708639794640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+  sha256: a53ad723826651041a5057a1cf31bc8689b24d335ce61b196df5124974b05a8e
+  md5: 7b29e7191c4170189d6080e61229f030
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311h08b1b3b_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9163911
+  timestamp: 1708639777712
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+  sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
+  md5: b0afe23033c8c5344640bc25225fa579
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 516994
+  timestamp: 1630084830020
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.14-h5eee18b_0.tar.bz2
+  sha256: 9d2e19a18f4d7b5586b21fc618c6641460561afb734927994be07e3731df16d8
+  md5: 24b027db9e86b7aefde7add4375a6245
+  depends:
+  - ca-certificates
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 5493210
+  timestamp: 1718385220783
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+  sha256: 280225061aeba00d7b85f46e55d7d79cd92c92f662dc749d9c53187978e8d083
+  md5: c51c21da68080d89300703ad818c824a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38606
+  timestamp: 1699371264464
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+  sha256: bd3eacd22e85f88bedd9c7e97a59eacfb3c8bb80eb59be244825d6895a0e7ac1
+  md5: 08ceb294ba8a9ae13630da789884736e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 157904
+  timestamp: 1710807470578
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.2-py311ha02d727_0.tar.bz2
+  sha256: b5979b0d4ef5c09f9795acb6b5e322b404f4eab7d73b6ed0aa59f03ef7acd25b
+  md5: 1a353daeb78baa6b5bf8f47e1e74ca1c
+  depends:
+  - bottleneck >=1.3.6
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - xlrd >=2.0.1
+  - xlsxwriter >=3.0.5
+  - python-calamine >=0.1.7
+  - gcsfs >=2022.11.0
+  - zstandard >=0.19.0
+  - s3fs >=2022.11.0
+  - psycopg2 >=2.9.6
+  - html5lib >=1.1
+  - tabulate >=0.9.0
+  - pytables >=3.8.0
+  - scipy >=1.10.0
+  - beautifulsoup4 >=4.11.2
+  - xarray >=2022.12.0
+  - pandas-gbq >=0.19.0
+  - jinja2 >=3.1.2
+  - odfpy>=1.4.1
+  - adbc-driver-postgresql >=0.8.0
+  - qtpy >=2.3.0
+  - sqlalchemy >=2.0.0
+  - pyqt >=5.15.9
+  - pyxlsb >=1.0.10
+  - adbc-driver-sqlite >=0.8.0
+  - fastparquet >=2022.12.0
+  - dataframe-api-compat >=0.1.7
+  - openpyxl >=3.1.0
+  - lxml >=4.9.2
+  - pyreadstat >=1.2.0
+  - blosc >=1.21.3
+  - matplotlib-base >=3.6.3
+  - pyarrow >=10.0.1
+  - pymysql >=1.0.2
+  - numba >=0.56.4
+  - fsspec >=2022.11.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17976832
+  timestamp: 1718310942026
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.4-py311h06a4308_0.tar.bz2
+  sha256: 998038e45884a19dc198675b2bedb22d871997c6cb1e6ebf0f46321c7f3b0cce
+  md5: bbcbcf863dc2295acdab40895df5e7ce
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.1.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21902532
+  timestamp: 1718119233499
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.1-py311h06a4308_0.tar.bz2
+  sha256: face211fc35bfa199b6d02f8ed25372d1f1a2093518a79a9eec9925bcf9e6d1d
+  md5: 9cd12fbc855d97b19427e911262e3bee
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 263218
+  timestamp: 1719348029519
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+  sha256: 28ed719669260a20bec78971edaffb91ec917d2a3f0fac1cf9a8ba21590baa43
+  md5: 0481d078fcd64f7f981532a514d9d50d
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 960727
+  timestamp: 1714399060039
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
+  sha256: d527189038b376a982c18613df808f25dc40314b0dc8fe5549f3ae9f4288e497
+  md5: 68dad015e796cc26364b55f92f61faa7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3451714
+  timestamp: 1715097126399
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+  sha256: d2bbab8bfc57c7f46ca8994bc87df7e744d3f036b867bc4be1145ba6d8d7e091
+  md5: de41707272a8e3ccab764f0b7010a27d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37394
+  timestamp: 1692205565974
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/plotly-5.22.0-py311h92b7b1e_0.tar.bz2
+  sha256: 96bba3ae7f93e3d9445b7ad732702fd85766fa6c365193c0362496f735c18540
+  md5: aa8152ca2935f0127fc3b5ebc045fef8
+  depends:
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - tenacity >=6.2.0
+  constrains:
+  - ipywidgets >=7.6
+  - jupyterlab >=3
+  license: MIT
+  license_family: MIT
+  size: 10723879
+  timestamp: 1718137102876
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+  sha256: e2a0e2a618aa33f0beff9583c7dc510b8d0737b023117346676aacbad33970d8
+  md5: 66a6818307261b1a28ab12d1b7776fdf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 121454
+  timestamp: 1679340540306
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+  sha256: b7f591c19b10bf0daa7e6e3b45a9f4a0a0e83188e1f8a58037caea79e60f8d91
+  md5: d945b4ccc135005839c504cc29df1745
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 749608
+  timestamp: 1704404477511
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+  sha256: 96482b49191fdac59580a95e69508367083e1f7600145e11d7c2db634337eb26
+  md5: 2d57bf8eacf3f291db845928241f724c
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 490805
+  timestamp: 1679337420563
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+  sha256: ed927e4d058a8f4ea73edc7a43ed74877d93b88fdfa240b3b2777244386ced70
+  md5: a1f0e05fc7e49712f81ad5478ec9d51e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2121496
+  timestamp: 1684280065800
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+  sha256: ad219924e362ce7af458fa6547660181579e9a50e5aed1ffd9268cbe7c2650e3
+  md5: 2b1ac40e0df3673d33b7f4c4f93ae1ef
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207338
+  timestamp: 1677811584327
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+  sha256: 114b55e00f4622c90fd2b404b21ad5f94a10283fcaaf86a42174b8d39b0a3e98
+  md5: 2458e92683cc68671a6c8e1b86ce8817
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35850
+  timestamp: 1676822725516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
+  sha256: ef622eb34669f3518d2f855cb333c56b106d02cdeac9d58e5a1a5a3097e4978d
+  md5: 9d4f211d050d511b0b84c2e57e7fb1d7
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.35.1
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 36072860
+  timestamp: 1713546307595
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+  sha256: a0f008717fab060ccd003dfebc09156d90b9afd14ac3626566aa1a8f3d3b7e2f
+  md5: 357bf4fe94496cbae72ab4d780184b31
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 330924
+  timestamp: 1716495762901
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+  sha256: aadc4078311c059265706a56265f0a57ceb538d36179d5203dd487d80d0e8f16
+  md5: 59ec670fcd172447dbd9591b8fbfdd56
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 278741
+  timestamp: 1679340144625
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+  sha256: d5058d0ecc3973316c1d5f1bfb03dd119e0dade85f4c2d21b412c8db4e1636f2
+  md5: 93000e4d3603342779a2afda66fa91b8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17607
+  timestamp: 1683823841946
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+  sha256: b85acb933fff864bfa89d034e8e3d85b1a9c2e69cbfc0d68c1d66ffd1443e67d
+  md5: 0cdb92d2d684ee1095310f992ed0d9b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 266796
+  timestamp: 1713974338678
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+  sha256: 511e8206a15445715b80be76493300930686b3fe1e512ae942d6ccca36df392a
+  md5: 35a6e46ae970f8b71d78fb5a810f2e80
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64013
+  timestamp: 1711136926372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+  sha256: b2a1f649669f4336b74f6f20df711959bcd8024f8f8b94199dc0e040b06bd37a
+  md5: f9e8e3f7068f717f75e555dc04545d8d
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 206433
+  timestamp: 1698096204677
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+  sha256: 7c74db4292f31619606180f86f3c1e2d913495c2c9d1195c5d51681a6a841625
+  md5: be1c05fae57d194924b9400f9b5ad3c6
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 613277
+  timestamp: 1709318516682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+  sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
+  md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 467661
+  timestamp: 1666648052561
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+  sha256: 89c2f4235277b9825cc805c5c44f0b1afcb683d7b5a3f513bc4bf243b643bb0c
+  md5: db70eb57e33adf7b8bbdadd72214d48d
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 73679
+  timestamp: 1699012111499
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.2-py311h06a4308_0.tar.bz2
+  sha256: 12c831fad9b6e0acd3821819072a81c4ed7007e90f2daa9c711732b69c57548b
+  md5: 0b9387d074f6714268bcc44c1f2634d9
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 121943
+  timestamp: 1716902856135
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+  sha256: fdae3f68ea84b99561aee6c566ab1c287d8f2ae2668424e9283a8ed86af8f1d2
+  md5: cde5b71ccbb3630053340b2c8c7dbf10
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9333
+  timestamp: 1683077183576
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+  sha256: 0bf859b06a07857099fd4f524fe5e0875fda70029e9485d95c7efa97134fbc14
+  md5: fd5815cc592fdbd4c831901541eadaba
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 9735
+  timestamp: 1683059096795
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+  sha256: 474553d01aea57214a54a7443f227da84a58e29c49eb7605ba0043c55b7d167a
+  md5: f01333e9f0a908e435db650f42fbd2db
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1096668
+  timestamp: 1698946168635
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+  sha256: 51bcea0e575a626f6ffbd16d1153330fda93dbe3dd31dcd3a8f469ff61dd1e4e
+  md5: 41d531c90be8c82bf79635ff3d409476
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 32295
+  timestamp: 1699371262818
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+  sha256: 0a95988ea269c96354626dcab255b65b54bb5c503d24cdeb6ef2e1c42818bd59
+  md5: 8bfb9f42492b3b53b8151d77e51c75d8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1594974
+  timestamp: 1715024182643
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+  sha256: 1a84b00944bc5588e14a097460175f97df49acb4f1ff2498ffd9a1893068ed81
+  md5: a456513471b2ecbed60430c21dd1ccc7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17880
+  timestamp: 1705431390054
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+  sha256: adcafd297d60af64107c113bb7b8b92160d0268a44ef9a3b79e56a88a0358ea7
+  md5: 28ed704ed26b06d32662e3a6a87e59b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 88799
+  timestamp: 1696347581401
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+  sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
+  md5: f86119b3243fe3508160aa0406245738
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1723866
+  timestamp: 1714488309729
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+  sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
+  md5: 041a3caf09dc9ce8fc6c10925c4fe050
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1888016
+  timestamp: 1680167274961
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tenacity-8.2.2-py311h06a4308_0.tar.bz2
+  sha256: 06b018d5bc7e446528070bb083cf5b9b679842a536925ae6d4596abb3af50ada
+  md5: a3659c3a781d02a8133c3717880f8819
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 47169
+  timestamp: 1682972395198
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+  sha256: 856a8ab8c350c50247b79966c6cb80fb6d4de36eef49ddf75aebbbcaf854c82d
+  md5: 442dde204d14d171aab9ee40e8de4de8
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37456
+  timestamp: 1677696176157
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+  sha256: f0a026ddc0ed041bfc60c8a1ca0b70b7a69232775b3181bfb35a39fda42d6994
+  md5: 2902d5a5854865baaaf58dc59cf06b3c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49185
+  timestamp: 1676823769869
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+  sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
+  md5: e2512d57c8a1e91e7b20e265c6906546
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3588922
+  timestamp: 1714770676475
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+  sha256: e58ff4a82819446f3c92e5b1aa2a784c4b06643e751fe67cf115858296dbfa50
+  md5: 32ee4723173f1fad5563b8afb5f1c8f1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135634
+  timestamp: 1676827536101
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.1-py311h5eee18b_0.tar.bz2
+  sha256: 394fdf404ede3bc35d697b2e445c42590ddcae86a80f39642cc5366196fcbe54
+  md5: a21cbca0664d8f34b0dca1f84998a31b
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 914199
+  timestamp: 1718740165334
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
+  sha256: 54f41afbea1c01a10e5703e64645de145f34ad6d89cf245fbc5cfaaff58a8743
+  md5: 15b6c8bee4c28c6efb3e388178b37145
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 154276
+  timestamp: 1716395957568
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
+  sha256: 2091b17ae4fa46ed98fd6bfe9ca1aff3b0b81d73045e0cc55774b6516b8704b3
+  md5: 183ae7b837c1c68ec1a8011011fadea7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 206924
+  timestamp: 1718227183177
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+  sha256: 8c06c291c76e8c2022ffbb9fea4727a4bf1f9b03e498bafc56ba8ac4e7604ab9
+  md5: 5adb7baf1091d09026a372cac930ce6c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8869
+  timestamp: 1715268966416
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+  sha256: 118b0801167264c401e84bbf19175546092a5569cc098146f7362bbf890dc8d9
+  md5: b3c2aa56d53b459f8365d8385f48d0c3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 74489
+  timestamp: 1715268960737
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+  sha256: 509b962773f0fe44a93a7f6196b254670a030eac8ea7f90727312e3ccd9294b2
+  md5: 6c402d5bf4e01c8c3895c9ef41707b6e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11371
+  timestamp: 1676828901104
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+  sha256: bbe7629e8ce52c82f13ed0d1fb919f3659ef466b274a7c74aa925a9bc7aee450
+  md5: 7da527bbcf71270c1abed8ea52e7d44c
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 509031
+  timestamp: 1713213062098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.2-py311h06a4308_0.tar.bz2
+  sha256: 2de4e4586d3b1cbfa8ecfcfaaa148da3b005b303e0784be2d6c2e54a3a13d362
+  md5: 3345015e0af00cc31acb88167a842381
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - zstandard >=0.18.0
+  - selenium >=4.4.3
+  - requests >=2.26.0
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 209169
+  timestamp: 1718912749915
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+  sha256: c3a5e0b855dc2de6c162708dfcf170a23eb9e7525d4252d8dce553369af4a330
+  md5: a4c77e204b7787f820955166a1283168
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25890
+  timestamp: 1676823132898
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+  sha256: 42989f9970a8466cc4edb73463dfa194594dd1a5d42c9f820a1f86296d4af140
+  md5: 655dfd4d2f17977cb81caa1c082d2b25
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 113505
+  timestamp: 1715878346465
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+  sha256: eec0d2e0bce4b62278cacd7b0bee053160845e86507051a5434d2069bd290f36
+  md5: a069e5aef64a6dac076cc9a3d28a17c9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 136022
+  timestamp: 1714717059748
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+  sha256: d18cdca154bf668826f869117ea996c4f9e8ef7d27b7c528332a7d17e5a8602c
+  md5: 9f7353d72046b16dd6ef6b5689ac9bfd
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54731
+  timestamp: 1676828934954
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+  sha256: 9122d6e9dabb7a47f2bcb15d86b97c96c49a9048da3f8ae59675351710c14cc5
+  md5: 660b2aead2ec87b751c86cd33934f44e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 716926
+  timestamp: 1714510796277
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+  sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
+  md5: 943f1247a22b6b64171363bcee1eec27
+  depends:
+  - libgcc-ng >=11.2.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=11.2.0
+  license: MPL-2.0
+  license_family: Other
+  size: 371663
+  timestamp: 1705602144682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+  sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
+  md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Zlib
+  license_family: Other
+  size: 127143
+  timestamp: 1714510716441
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+  sha256: af3c032f06352e87c450739cb8aafe1ff34ad28bf074b214ea98b3d29259a85d
+  md5: 51fa34bd0e016ed7c5371cf6cb13ef6c
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1044463
+  timestamp: 1714678445052
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
+  md5: 544adf2677c47c9b9c891aea720678f1
+  depends:
+  - python >=3.5
+  license: MIT
+  size: 33999
+  timestamp: 1630003259346
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+  sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
+  md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
+  depends:
+  - prompt-toolkit >=3.0.43,<3.0.44.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5106
+  timestamp: 1704404390460
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+  sha256: dc9f709bacbaf08a0941d2622d82f91f18b355e82c55348ec29f1391215ca7e0
+  md5: ece0f5837a4de2d4d5f1abf8347cd10a
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 124922
+  timestamp: 1708711884650
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/altair-5.0.1-py311hecd8cb5_0.tar.bz2
+  sha256: e6c4194bc4ac3c285b9d77d1e44689026dbe3b5b3c056576247bd04a532420e5
+  md5: 74c44a80a2a1140dce26f799cc424a78
+  depends:
+  - jinja2
+  - jsonschema >=3.0
+  - numpy <2.0a0
+  - pandas >=0.18
+  - python >=3.11,<3.12.0a0
+  - toolz
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 856738
+  timestamp: 1687526271729
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+  sha256: 5800a2466734dd1ef372bec0dd3f0880c5072fa1e8b0668f5054f834285e991c
+  md5: 18194e51d4420ac08f29f3f86581b52e
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 229003
+  timestamp: 1706220302459
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+  sha256: ab7672364f1fa55ec5d8311d85d40e5b57cbd3517b17670557b6fb822bcf759c
+  md5: 6e0159a5865cb7e96a748bd8560035ee
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 11579
+  timestamp: 1678317458652
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+  sha256: 51556902e09436d46878ef772805d06416ca96ffaa66340b5565c0245574aaf5
+  md5: 4cb1b20635cf5431d34cc96ca1e8a751
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 33355
+  timestamp: 1678317111825
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: 188b74f717e3ce3595da404c0e027b8ccafa9c186e88325e8f02c29d7b4c0744
+  md5: 04ad90eead5812a0263b42321056ab33
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153694
+  timestamp: 1695717975427
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
+  sha256: 365824e639808e52809f97b70b65da94a5eeb87e29dd97c8926aa72707a5a1c7
+  md5: db7813418dfe42d59363fed4a68d5c36
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 278195
+  timestamp: 1718029905185
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.1-py311h85bffb1_0.tar.bz2
+  sha256: ace9b81e898a3180d2fb07c75326414ec4cbaed62efff54e42feb6d59774ccab
+  md5: 1aa0dfcb172854f56447096c70d6a005
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6076891
+  timestamp: 1718119694797
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+  sha256: 9acafafcaebd653c2372ddc864525722e1c55b884b5eba22e28e2b2d946b853c
+  md5: 22375cc3c2edada31b85af56c8e6dee6
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 155829
+  timestamp: 1707864406086
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: d8b1ccb15297dcfb3f9ebb8139c3e28a13d6c2e73c37612cb214ab6cc58b15fa
+  md5: e5dec9f13de061640ad2697562a99b54
+  depends:
+  - brotli-bin 1.0.9 h6c40b1e_8
+  - libbrotlidec 1.0.9 h6c40b1e_8
+  - libbrotlienc 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 19732
+  timestamp: 1714483415038
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: e9fda4393edd0234c88efc2b88e0edf42c94eb49ea5b189a80afd733058be8fb
+  md5: 13ceed558eb174d6b77ed1b0035f1785
+  depends:
+  - libbrotlidec 1.0.9 h6c40b1e_8
+  - libbrotlienc 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 18400
+  timestamp: 1714483395748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+  sha256: a323af3251e426962ad16edf8f46a696ef502731faf12aee32ca289c40b11342
+  md5: 658ce49e9f07dba7a1afe70fa2666e0a
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 393858
+  timestamp: 1714483549536
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+  sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
+  md5: c5a600d81b1b48578863af2973c743ac
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 187637
+  timestamp: 1714510590009
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+  sha256: 0c5f9766aa2dcc08ae71b6c0102046a56b30297d0bedc3039b7f72d1658baa43
+  md5: 34583b436e62a2ce55d6a7e8eb818e33
+  license: MPL-2.0
+  license_family: Other
+  size: 138712
+  timestamp: 1710764814844
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.6.2-py311hecd8cb5_0.tar.bz2
+  sha256: 761b76b8878af5f46f978e343f8b5bb4e74f96b0efa4d0856dc191ca4191b20f
+  md5: 7a636bdde91b0c3aa0815a4abff2c6d2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 167328
+  timestamp: 1717618090475
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+  sha256: 6b5bebc13755b0a5ef423219eeecd1c25b97dbe83afad6e2552635387547d9f7
+  md5: b7bc4192fcfed7fc7df1ce00bce97b02
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 291802
+  timestamp: 1714483319125
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: 9270668e34b00a2605584a2db5130c83826855cd05b896ce949f3156fa197429
+  md5: 2586aa55677e822e8285d777f9039ca9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 543487
+  timestamp: 1709758497949
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: 389c63a84b92a6254c9d361ebe970d537d0b88733efd5ac5c3ee58196fd2c5a9
+  md5: c7bc5b3cbe76be83a27f00b7e4740727
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17974
+  timestamp: 1709323004148
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+  sha256: bebfc5aa6be12e61a134b580b07b67f7d8c045d6b113fca5b21fa1e83a2f03ce
+  md5: 239df72a3921c951059fa8afc09643f6
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 287736
+  timestamp: 1700583644534
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+  sha256: e0e30590a78d99d51445ac4f668aefe1bf20025a35bdbac00f04647b95c9f152
+  md5: bd0db635eefeea82a0c567b39c9a0e3d
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2485698
+  timestamp: 1690905283575
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+  sha256: d48b47b86b09dac1fa4542ec13e1bd4e23093638e684fa66ec3afdd9ce9337c1
+  md5: 5a2d1828ab7c8eccd3c2610d13672977
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17336
+  timestamp: 1678316187749
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+  sha256: 54645c22fabc25b632114d1d3c403a6fad9149b51ab36719b2690a084f14a072
+  md5: a8ad2f4abfb2e17ecf6e596342528156
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lz4 >=1.7.4.2
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  license: MIT
+  license_family: MIT
+  size: 3180691
+  timestamp: 1713551771692
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.19.0-py311hecd8cb5_0.tar.bz2
+  sha256: b718db18f202153cd6625f0cea81b97f9b59830db03b1cdf7af0af798bcbd46d
+  md5: 87cc8c19c172d322f93107dc619a4c89
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21,<2.0a0
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.1
+  constrains:
+  - plotly >=4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6062014
+  timestamp: 1718294749778
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 50dee40e4a9ea7a035baeecc85770c88d63d4e6b0c3c2519c1429e881171150c
+  md5: 4d465f453dca5c65224dccbe953f600c
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 359293
+  timestamp: 1715090716440
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+  sha256: 5c2458964157fe493ca18c513c693b70cb622087e5fa0c93e65fc45217edd811
+  md5: 15629e52625221b51a443cefd9501d12
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148522
+  timestamp: 1714398885844
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+  sha256: e0127f50d444bf4474e8df07d602c7f6dd38690e8bb3fb28817c164940ffcde1
+  md5: 583fcd7060cad6a77074d00d9ef62f44
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 731417
+  timestamp: 1699647668990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+  sha256: eb58fa29b1ce9aa5fc774d4c466696457695dec3b206456614b4c9cac0a94e42
+  md5: 3d3291ff58dff83dcd40ec54b435f4d2
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229910
+  timestamp: 1705934029588
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.25.0-py311hecd8cb5_0.tar.bz2
+  sha256: b9d1a68433aed414dbdce4b9acc85b371503009926f516882c018331a56115d4
+  md5: ba378a5e3c95af1eba43575438fa528e
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1626808
+  timestamp: 1718288248788
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+  sha256: e08cda2bcbdec124c63e951eb248c503bb1467c2a6000010c6bdc0726e0e00b7
+  md5: 22c24f43b82da8b3920a913bbf452421
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1168968
+  timestamp: 1679336359851
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py311hecd8cb5_0.tar.bz2
+  sha256: b80384bec95335d8ad37895f5cfd2d8fdfaae7be05507f218344ddb5c6713d38
+  md5: 8ac4f4807344f09b39c1b303cd2d1937
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 356777
+  timestamp: 1716993516277
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
+  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
+  license: IJG
+  license_family: Other
+  size: 278924
+  timestamp: 1677849185191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+  sha256: 99fc6ac82c56eb2a580f96db24a5b887f8abc8c24af445d3313d5ebb48598478
+  md5: 71892160908a6daedb5fb7c404079ae4
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 182073
+  timestamp: 1699041732321
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 0ea44d0c8044e70ab0eaf4d6f5f3e4753838dee106b5cbd36561e21a65cbac77
+  md5: 1d045016dca889d702f1caf3a16162fc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16528
+  timestamp: 1699032525791
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+  sha256: 70442ec4b0b7ebbdcf150963f61f797b861001092124f4ea39a16eb92a4d176e
+  md5: 63d1503915a15ae4f9ad1c46112ca374
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 272720
+  timestamp: 1678316970740
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
+  sha256: e657ec0667481d957827be1ce825b0a971aa3a211b07c1274d2c1099ded3129c
+  md5: 5e317fd45011a0003c29331a8002cb75
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 98632
+  timestamp: 1718818439542
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 2634d721123ea1e41b6e1cfe4a67552ec520ea9b5154c9e788ccb09d4745b732
+  md5: e874eba19b493b7a68161429f24b8f51
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43102
+  timestamp: 1718738272613
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
+  sha256: c353480ed4744c2a16aaccc1649bab38144436ad6d16ac2937e3e333d32fdccc
+  md5: 7de25bdf4cfd3f5485d790d9cddf427f
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 619935
+  timestamp: 1718828240904
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+  sha256: fd7964657f0a8fe8b167ba860b1f960e8b7b45309eb6c7c850d50ec283fe03b5
+  md5: 2967bb345bc75f53182e263ff4743ca6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28223
+  timestamp: 1686870845224
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+  sha256: 64cf59f0f74b0329b5069bc6135b4f40593f1dac52d85ad574d4b8e0a4b2cf16
+  md5: 35e8b80eaa03a904fc7f1da39e7f654d
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20234
+  timestamp: 1700168776500
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+  sha256: a12382b50416803f559a03fb384ba492c1dafa351e1191a3f8dc361bee6c4f37
+  md5: f2ae846b663bbb642f4b1e90eaad38a3
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64817
+  timestamp: 1678322501509
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 685c3bc9068bd485604b80bf03789e4dca95c410d33871bc1b882e47649fabed
+  md5: 6cf8e55271e150ca0961d0ddedaa61bb
+  license: MIT
+  size: 66237
+  timestamp: 1714483284541
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 69826cee54db9955f0120af21ec36d13f9211877fd67364f2068d0a54c6c97cd
+  md5: 0851917257f490d35e1f73da8a1c723c
+  depends:
+  - libbrotlicommon 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 34042
+  timestamp: 1714483343147
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 3f5a1f03b50b90b397a0ee432ad0cba13354abdaf7e5652c0fc60164b26a08b6
+  md5: a50bdc871ef4bf14deb088d888b92b5e
+  depends:
+  - libbrotlicommon 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 311597
+  timestamp: 1714483371586
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+  sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
+  md5: 822a5b76117e56d3912f1f2153307528
+  license: MIT
+  license_family: MIT
+  size: 136045
+  timestamp: 1714483561919
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: d28c465ec6d5f8d4962c597b249b58998300c8b4e3c937c578c3d15294ea863d
+  md5: dcaed6ddd0723c7cce6bfad917be98b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41176
+  timestamp: 1678413498410
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+  sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
+  md5: 8f57dc3a3327bb6f7e1cba908856ac7f
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 183138
+  timestamp: 1714510756758
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+  sha256: 6fb2953e169ee1ae38f24d29752051501992f19b96b5ebcea9af75737bdbcb42
+  md5: 7f410cdae838c5030108d1b98a8c78f6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162478
+  timestamp: 1678377892595
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+  sha256: cd97e09a12ffb49b2a30a782fa8c7933b28f5ffdbfc5c73a9ebaa95fc9447370
+  md5: d1fb6ebc1e5728aa6377cfc71da08942
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135859
+  timestamp: 1684280005320
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+  sha256: 30c3b189462a9d0f4794d229adadf34b5f5a5f56f95c30d5afc17ef524579290
+  md5: d4e9421243129d1d57c472dab045f3dc
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26639
+  timestamp: 1704206159955
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+  sha256: 080000a28b3ceca54eec6de0748c690ea5a4c390e358283eac03fe7a6dd87065
+  md5: 51344eca57d7940fb01eb5e8914509e3
+  depends:
+  - __osx >=10.12
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9099909
+  timestamp: 1713336790553
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+  sha256: 07e7fd5bd64e55328b4b99d92e2e2600d791f1095bf905daab4cfc59f0f0a45b
+  md5: cf53321779f4ca7e986c1468719b93f1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19500
+  timestamp: 1678317565001
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0770e02be1ea1216af493cfc03d5b8a702e14606fa93b0692bcdab1fed1b898c
+  md5: ca6f06ceaf66a32bbf5dfdb6e373a5cf
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67892
+  timestamp: 1678417734353
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: fbe95ed0501bb0f137048476fe41bc718dd659e8ecb066bc67ac17d6a50f4318
+  md5: ec162bde8d1c8a107b257df218b17035
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23030
+  timestamp: 1678381838497
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+  sha256: c20dd678655e582129a858a1c5162bdc254082d3a3c035b0f72629d9276e5b75
+  md5: 800a0738c728796e02d0386ce7d457aa
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104585
+  timestamp: 1678317269407
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+  sha256: c825bc3070f73318ffff88a7a0b7fc6d1858b058ced735efd1789053f1583918
+  md5: dea5f96459c9a6df6b026ca57d387936
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224299920
+  timestamp: 1699647835748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+  sha256: a76c134ec258612ff7d55cb2a19b9e3461cbbd375a744bd29390af9cfcd283b2
+  md5: 1c736f58992009f53f014aef163bae31
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48442
+  timestamp: 1682969160267
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+  sha256: bcfb0d1e075d043bcf05fa1a7ce3c142bf222d29693366af49a5a346c770812f
+  md5: 59e4820b34049cbc6619a8ac97290abc
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 222137
+  timestamp: 1695058350477
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+  sha256: 114e408c40b332393cf2792393e4d1ede3465abcb3d345fe647ee519565346c8
+  md5: 86b13271578e1fa5e664edcf6fcb3ce4
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296860
+  timestamp: 1695059990370
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: f961b1322b6b02fee53ff9bd0f56bb73886eb59debd3f3666669593de7f48894
+  md5: a1e74ccd2f341d1d672e33d79e60d200
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8183400
+  timestamp: 1717623127275
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: e08cb3ee6df01f4c1e1ac8bc4ed1a06e549ffcc8774fe2e2842c644bb8f74a86
+  md5: 6ba0ae0fb14cbea1e3197707701dc180
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123077
+  timestamp: 1698934356774
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 2f946b5042eaac97206b5217fb203f3604ab3a60aecd99bdfc684925e3136c18
+  md5: b24026076c381ff2009e7acb9e0a6e87
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 534650
+  timestamp: 1699022791300
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+  sha256: ba368605a0af6f1dcbdcb6fddab9ce63224a85dd11bfb2b1acace1dc17899411
+  md5: 91f3ea3fe44d619ee95a6ed3773a0814
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 170926
+  timestamp: 1694616830121
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 42d803e1d8b54748db5d989ecd503826f564132df7cddc20f520460f55e523a1
+  md5: cd3fa71626ebc098da4625fc6be79752
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16952
+  timestamp: 1708532805951
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
+  sha256: 09d88f1eb19a90dfe737f0e5b4dce7629f6076a2d91d572cbb0a41be5220a4e8
+  md5: ac8c26d949a04f478b560b7d8a2358a4
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 707187
+  timestamp: 1717630829258
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+  sha256: ed5608feb37a083d47b04203195260e801b64b5380f292cf18bb61e7ad827a2a
+  md5: daa9c1c233673b727528548454aea664
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27607
+  timestamp: 1699456006797
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+  sha256: cacba45c1eebf7d86748737717883a98cf40664231460fa41391c79f98d06f45
+  md5: 3dbfae0d5b90e77f9358564ad442ac9d
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 165572
+  timestamp: 1696515553184
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+  sha256: 1466c3af380b949612c79940124e426eccd59e335c205da0c00383a69358d1c0
+  md5: df6be53592d40ba7e03d6ffe349760bf
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311h53bf9ac_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11330
+  timestamp: 1708639985606
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+  sha256: ace67d704fa7eea1480eb463f2d91bfc161be2ee20263c5a9939805ae3c2a9da
+  md5: ec124589478fa12fba4f35f31c3a0692
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311h728a8a3_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8783230
+  timestamp: 1708639945646
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
+  md5: 93f5d7b66976154adeda219bea02ba45
+  depends:
+  - libcxx >=10.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 484257
+  timestamp: 1630093862501
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.14-h46256e1_0.tar.bz2
+  sha256: fa7cff16e04414a72ead7fc787590e09d7b47401a296133b03664a0df266161b
+  md5: 526bdcbb40402367e36003f076ba61d0
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4948318
+  timestamp: 1718385319448
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+  sha256: 8a0809f419065e014cb8e2c8a516cadca6088fb71fd1ef3ae2287d91e3360d59
+  md5: 4dc0b9bc88476fcc5246d823ff1c289a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39645
+  timestamp: 1699371213055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+  sha256: 64fbbb03570788298d8b04d4ea6cb254fef5d5eec73265aeecd72cb565617f4d
+  md5: 4b1195028bc26257df43fdd943638266
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 159450
+  timestamp: 1710811009212
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.2-py311he327ffe_0.tar.bz2
+  sha256: 878e8fbcca40ac0c3937780160c22b65633b32ac97a886a9e38d4453821fe8bb
+  md5: ac61107a8dd7a5a51e19e57fcc3a7a5a
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - pymysql >=1.0.2
+  - pandas-gbq >=0.19.0
+  - fsspec >=2022.11.0
+  - pyarrow >=10.0.1
+  - scipy >=1.10.0
+  - qtpy >=2.3.0
+  - lxml >=4.9.2
+  - numba >=0.56.4
+  - s3fs >=2022.11.0
+  - xlsxwriter >=3.0.5
+  - tabulate >=0.9.0
+  - adbc-driver-postgresql >=0.8.0
+  - sqlalchemy >=2.0.0
+  - python-calamine >=0.1.7
+  - adbc-driver-sqlite >=0.8.0
+  - html5lib >=1.1
+  - matplotlib-base >=3.6.3
+  - gcsfs >=2022.11.0
+  - blosc >=1.21.3
+  - xlrd >=2.0.1
+  - pyreadstat >=1.2.0
+  - fastparquet >=2022.12.0
+  - jinja2 >=3.1.2
+  - beautifulsoup4 >=4.11.2
+  - xarray >=2022.12.0
+  - pyqt >=5.15.9
+  - psycopg2 >=2.9.6
+  - pyxlsb >=1.0.10
+  - openpyxl >=3.1.0
+  - zstandard >=0.19.0
+  - odfpy>=1.4.1
+  - dataframe-api-compat >=0.1.7
+  - pytables >=3.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17291576
+  timestamp: 1718309206876
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.4-py311hecd8cb5_0.tar.bz2
+  sha256: 757d6789ddb8227afd02da27fb30d1339091c8bda8f9905011a591eaa3fc6147
+  md5: 7445a0d4f67a8063b19c6372d1f8b02f
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.1.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21789913
+  timestamp: 1718119269606
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.1-py311hecd8cb5_0.tar.bz2
+  sha256: a33f52ee58e7856ff19bd306a7c055950d669199981874a38c2bdb1896725c8f
+  md5: 7aef330f65dd9dd63a06c89ddfb3b7bd
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 267605
+  timestamp: 1719348049109
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+  sha256: 90efc71d35ab62d5b8d7b648e016444e1c4c8b83238b6dc9f2c6c3db4b14c599
+  md5: 6b6eeb0a14c5479db1dd39aa8d338150
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 939480
+  timestamp: 1714399174883
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
+  sha256: f6b0ded7010706431f2a6d9776aa6033dfd19d2264b3cebf28072629160090a8
+  md5: 02de6d0d9cc23fafe2e3597ed0e52693
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3444268
+  timestamp: 1715097155645
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 81719c31101d6c019150cedcc7b08adb3bdb357e8b2952e428dadaabc4dc985d
+  md5: 105825168e0a17fb007f60b5f314e311
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38405
+  timestamp: 1692205731769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/plotly-5.22.0-py311h85bffb1_0.tar.bz2
+  sha256: 26709cb0a15c542c12e36b9a7c561737d3fa85465c4575a6f380ebaee4786497
+  md5: caa14c99a2d9b493349baf43697983b7
+  depends:
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - tenacity >=6.2.0
+  constrains:
+  - jupyterlab >=3
+  - ipywidgets >=7.6
+  license: MIT
+  license_family: MIT
+  size: 10814266
+  timestamp: 1718137191299
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+  sha256: c0982f688127129e026d2b4cdacdd5684d00796ea7bdadd7d26b1101b095d723
+  md5: 0d6910c74729fede645c010110f1c89e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 121796
+  timestamp: 1679340253537
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+  sha256: e32843723b10ecd9badde28e1085419c0b59ed8a96c7cacce6395e39e3a874f9
+  md5: 5af0280a817d2c273304cd22328124af
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763044
+  timestamp: 1704404460779
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+  sha256: 117a435c2473e2a20cc81eaacb2b45ea5e7fe3c946eec2915936d344913ede44
+  md5: 0f459ee59fda20e2077fdc2c777edfc8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 497470
+  timestamp: 1679337286052
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+  sha256: dfb403f367c57327a4d080109df88383ecff18464de287a1ce936a7274e3656b
+  md5: 997b674bad89963af875b93b06807f51
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2120413
+  timestamp: 1684280057020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+  sha256: 9d2c0f373ac1c5db329581793dd517092cdf9a59140f2516ed8c3a1f483c0bbd
+  md5: ee10503a159e819abdc586666bdf0952
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207552
+  timestamp: 1678322848766
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 717e038567506ca58ce1cd4a3416892d02f4ebfdd332077cc3d110cfe3d36c58
+  md5: 53bbfb400668f798eef6f8c7cf938e1f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35751
+  timestamp: 1678315886516
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
+  sha256: 092dea8d520acff3e64c71155e666b0b6074d37a71d5eb32f3cd485b0d185d0b
+  md5: 9fbaf2d9534c26e76aa14b11b23de332
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16852220
+  timestamp: 1713545835789
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+  sha256: 04e100d0a1ea9722e24972657ec5935ad34c7c58957dabb821333e5eac80f717
+  md5: 2b6de49ad07b26e1f7084f0fda958eb1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332276
+  timestamp: 1716495830117
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+  sha256: 514249897265f66f6ecca0a4427eb02a43c33b3c24974db16d05db6bbe97881d
+  md5: c9ea1437e5a3ba6a52ec2322505203e6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279116
+  timestamp: 1679338758489
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+  sha256: 78b785b9b6ed46c86b0d3a32bdceea49f816672227fb63e726b2d46eadbdba0b
+  md5: 79d783f74359141e0b06a848db33823b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18563
+  timestamp: 1683823935261
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+  sha256: e358fe679e83ccdc8c433746ae6468e8e96d90d97d99530f8476ef5630b2c121
+  md5: ce30a0a31d891e69dc9b7bf8b7f0c39c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 268876
+  timestamp: 1713974360942
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+  sha256: eeb5a5eed93b8e311ad4d3f4389e050f11bba2eaec9536e1c3ed2f849c6c999b
+  md5: c18bd3e12de797d52a470c21a150dffe
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65270
+  timestamp: 1711136914884
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+  sha256: c3e11ed944da69c11b949bb918341a0d79ef603ee34a632d6a45fbf89ff924a1
+  md5: fee7ff4d291f530b4cecb575f29807a0
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 197996
+  timestamp: 1698096137432
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+  sha256: aa07b90a7ee65f76c8cba1ff99a5cdeb95cbe41881ae951f64ffff06674a1b2d
+  md5: 58621e3d244137885f7dfbb35e50340a
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 594801
+  timestamp: 1709318510622
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+  sha256: d784dc26c5de8e41845350a899e5779250b71f45d39e2aece62e739e9add7308
+  md5: 7b077b7f46112bb31dc066396c51d3fa
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74776
+  timestamp: 1699012164201
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.2-py311hecd8cb5_0.tar.bz2
+  sha256: e8c25fe5f26c25cc3cd5a744448a791c246610d3fa8690251f9e1fbc44188248
+  md5: 28182e1a6b8c2c519dafc90093396a7a
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 123233
+  timestamp: 1716902968357
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+  sha256: 727fb8d957e02d03b928d049ffbc712316f176a2c331391766d646621b45655a
+  md5: 7e0e416c642f3ee4ddfb084a811fb4df
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10236
+  timestamp: 1683077214314
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+  sha256: a8a67143ccb65cfd6f50055176b6c26179a83130a45d0a12e79dd2de68d8db63
+  md5: a2065790f41e3eeb6efe0ef6daa75377
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10600
+  timestamp: 1683059285216
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+  sha256: 6aba582338faa0c26fe336bdb10c65b8f7808a6e383bd8f80f3e6b612ca209ec
+  md5: a7486349b5f7370f6902c2050a23d268
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 319197
+  timestamp: 1698946203341
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+  sha256: beba0555707dac1e8484d73cee9e4128ac4b10e2a0d4209357481179022e8fdc
+  md5: baa8b304607b3a9ae8a3d9acb354c31c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33343
+  timestamp: 1699371216044
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+  sha256: c1df29188e321abe23651c73712a6d8ed3abdc89ad38a42c33f1835b3ab77abe
+  md5: 6c984ea85326858942f7b635e0cc9ff8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1597325
+  timestamp: 1715025837032
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0eb44a16ef74a13ef7839209899d009cd94974fbc406a417d958c7bc8d955245
+  md5: 41f239a5b67b1daf819849023aa5d12f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19056
+  timestamp: 1705431379885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+  sha256: 14775231982e1ea150189c956927ccfb1ad01a8c9395cdeea4d5a48b9b8ce664
+  md5: 729badc4bf7ba8ccc70e0f9e58075c99
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89812
+  timestamp: 1696347694075
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+  sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
+  md5: 6bef1694163a68ac4c37e5857b8da4f5
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1900191
+  timestamp: 1714488351925
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tenacity-8.2.2-py311hecd8cb5_0.tar.bz2
+  sha256: d6ea04e7602bea3531f0ba35c83e37dceef1fabd687700a9e7632b38c642f03a
+  md5: 29e9e157ef3d99b195eb65c039481c17
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 48156
+  timestamp: 1682972384442
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+  sha256: 3d5c2968f581006437df3932cd5d3c1c4afa78f0e13757b958440245d3248856
+  md5: 605ea221d225ad8e79284dbcfdab0715
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37699
+  timestamp: 1678317755913
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: ed059e32ce5a1c0511575f29d2fb6da12c54a37000bfa80f9e5aa9dfd9e04101
+  md5: 4d2261a92d25136a68b8d01d101119f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49145
+  timestamp: 1678317386284
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+  sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
+  md5: 523c006cc67c011383678c762015479b
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3594448
+  timestamp: 1714770737885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+  sha256: 424b8284072266eb59d055c0b7b58241bfb00009d445743ea261d4eeee73ea19
+  md5: f3a47898a55087edb9d65d29c24d9b88
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135757
+  timestamp: 1678323030858
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.1-py311h46256e1_0.tar.bz2
+  sha256: f46d29f5c4f5fceb7a39343da76f5c5ab89cbb0844e80a3a90457201c3fbc168
+  md5: ee154208a17c1c4cd42d264b1a6f77c3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 914461
+  timestamp: 1718740220272
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
+  sha256: 3df84b9897f05a104c99e297dc29ad8f718982fc64c61b5a2204c19c578f47e5
+  md5: deab971930d242221ed86bfd768dde40
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 155545
+  timestamp: 1716396266697
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
+  sha256: 5283f2b23a6e9d888b2834cba2bbf284f551e199d2c1b4add176b1cbafb19ee0
+  md5: 58bf7871ca100fbda0492bb5a3363c80
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 208200
+  timestamp: 1718227205760
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: 17e5688d09ffbcb8b71b34b86edc7374fa0b04d60a4d729d405ffc22ef63726c
+  md5: e4bf44ddbbcb136332ccb47ac2b879a0
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9890
+  timestamp: 1715269046804
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: 7d369ec970d1d5411e457c79f94197756c7088deff8183806ea71e633b26edf9
+  md5: 9ffa197b26373667f50b21876862398e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 75595
+  timestamp: 1715269030928
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+  sha256: a9960485ced319ac91afe69eaaf703c7e6b3049f1e06a4a8c2818b64155943f0
+  md5: 0a9c8ea92a14330a07edabac249e32a9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11399
+  timestamp: 1678394892923
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+  sha256: d42ae57366d05e12f10074583568355752436d66ad018ffbcfa24135f593810a
+  md5: 1a98e48aa0bd8b3ec09e2cbdbb236575
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 498952
+  timestamp: 1713213079520
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.2-py311hecd8cb5_0.tar.bz2
+  sha256: f46959a5ebab808e8a3fb6036cee2f6a0f3bfe42c81d00158d4d2a88837d60d2
+  md5: 7a554ae6cb2c33d09125ef897b39a4c5
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - h2 >=4,<5
+  - zstandard >=0.18.0
+  - selenium >=4.4.3
+  - requests >=2.26.0
+  license: MIT
+  license_family: MIT
+  size: 210587
+  timestamp: 1718912682770
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+  sha256: 597015e8a038a111f03ffbc9a217fcda549d75230c86ce53c1f23c53d6f1a0cb
+  md5: 62e98aac883bccc1c87ca0d2ce2f08e0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25798
+  timestamp: 1678317074170
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: 1430e6f4b4dd9354b7bb88f7f7bc9cdbab26a034ad1ae5c278de0f5a99329372
+  md5: be0832862b29bf5767a707ac6bd53b93
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 114834
+  timestamp: 1715878445060
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+  sha256: 885a9b6046e76f7dc1a346b14c63b4083046137bfae036362c854458e20e4fc8
+  md5: 3b279447ca282d065e681e567055b582
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 137340
+  timestamp: 1714717062907
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+  sha256: 5b6d5246955b5f9480ff7027eb002442a7ade24f5c354da54ed513042f76cedc
+  md5: f32aa8a37d5e65a8dc30f9a1f46bc63d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54719
+  timestamp: 1678325412288
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+  sha256: ed0152ad6b87ffd9e01f4a62bc358e805ad59637f898a801b0a9cf903ae8e1fb
+  md5: 8a92f8c663608f24e14d8a2068b9d83a
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 415323
+  timestamp: 1714511993944
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+  sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
+  md5: c25b6d40f834647d0bbe767f6c776031
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 329449
+  timestamp: 1705602140856
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+  sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
+  md5: f2519b551f99765d9d98950c5e2b4713
+  license: Zlib
+  license_family: Other
+  size: 119782
+  timestamp: 1714511811597
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+  sha256: 7feb73e79bdbd45404ddc7a30c43bf4cc68eced8ce448ce7c31f5db134276fc5
+  md5: 48313bc6570c705cadbba3c356e0dc8e
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1014151
+  timestamp: 1714678461080
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/altair-5.0.1-py311hca03da5_0.tar.bz2
+  sha256: 69ae1cf3113f620a23a84e91101bbd8242857c5a28380eeee922c5e9cbb00ebb
+  md5: 4a438d84ca357b42f69abcc7032a5f73
+  depends:
+  - jinja2
+  - jsonschema >=3.0
+  - numpy <2.0a0
+  - pandas >=0.18
+  - python >=3.11,<3.12.0a0
+  - toolz
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 855250
+  timestamp: 1687526064968
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+  sha256: 9ca3f0dfc2bdbc109e359ba7ab246e6ae952a14819148ad069454b52f2bda802
+  md5: 51fb05873a644cac52f0d1e10cb7969a
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.23
+  - uvloop >=0.17
+  license: MIT
+  license_family: MIT
+  size: 228856
+  timestamp: 1706220385566
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+  sha256: 43405cc7341ce3efb2e24013ad62c64f26a69926635adceaa5459ccbcafb3776
+  md5: effa6d22f497e164cc8455f7f329c304
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 12510
+  timestamp: 1677917870614
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+  sha256: 947efe1c50b3280e9a67cbb18636bdade53a40960fff3056850ff81ab87acbe3
+  md5: 7d2d384ee32ccc12dcb0dc099e421482
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 35091
+  timestamp: 1677915945226
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+  sha256: 8259b4a0973c825ac81f581afcbe86640bd0a94b33caa996167309241877635a
+  md5: 49b8ddacfd3927bcaae139eadfb72ce1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153557
+  timestamp: 1695717951839
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
+  sha256: ae3c6633ed84bac16592b3b756f96ffc577414971014ca9efa498a162588757f
+  md5: ea600f99d012d734f831d1bc00a17661
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 281227
+  timestamp: 1718029919645
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.1-py311hb6e6a13_0.tar.bz2
+  sha256: 4f861776f2954c67e690caba87d24de817fafe79964c1f6075a35c8bad2d2f2b
+  md5: cd4dc5659854265ae73d6a9127746990
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6089676
+  timestamp: 1718119235085
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+  sha256: 688a071ba370f51b457cd32d70b7b38921ce9551203d06fa7fc2c30c4b79891d
+  md5: b2353077a39ab997463768154dd58fec
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134711
+  timestamp: 1707864978809
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+  sha256: 048264434c33fdb53862cdd69b2e2bc4ce6f8a70b3211ad6d686d066eac2aa91
+  md5: d55696ccaf6755931cd662dfb929aa0b
+  depends:
+  - brotli-bin 1.0.9 h80987f9_8
+  - libbrotlidec 1.0.9 h80987f9_8
+  - libbrotlienc 1.0.9 h80987f9_8
+  license: MIT
+  size: 19737
+  timestamp: 1714483270447
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+  sha256: 13627293296fcc231d8dc12d803dfc9621108c60df38b0e3c64e9e02ed55e564
+  md5: 86efd4ad08cd80d3eab77873db84a255
+  depends:
+  - libbrotlidec 1.0.9 h80987f9_8
+  - libbrotlienc 1.0.9 h80987f9_8
+  license: MIT
+  size: 19083
+  timestamp: 1714483255364
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+  sha256: 2e542b2bb27f8379da3efcb83ef084cb26e6a9ab576c50487c2dd996afd5ccb1
+  md5: e8cab9d1ef58a450f971690fcdb2ede2
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 380182
+  timestamp: 1714483330655
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+  sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
+  md5: 56d1386c7f1f338f0d18f82af6525273
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 158748
+  timestamp: 1714510571033
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+  sha256: bbfc668f445f3584936b326dcfe92bf71971ce16241f4f79db8aeb88d7aab41c
+  md5: 10cc05ed51482e1dfcc31dbd13bb34c6
+  license: MPL-2.0
+  license_family: Other
+  size: 138641
+  timestamp: 1710764806818
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.6.2-py311hca03da5_0.tar.bz2
+  sha256: 2a4db3202260845b4658285d2fca09de0e5afee9f5559b9195bf2c9e8fff1930
+  md5: a56c6653ba51441b6e7db9bcef00880e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 167136
+  timestamp: 1717618216897
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+  sha256: 8d26cd4d16545ad8afddd5521bc6894a50d5b8faff3abbe600bb9b062f3c3a0a
+  md5: 66eb734b7d7008eb5fb537900767c7ae
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 286807
+  timestamp: 1714483190838
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+  sha256: 808e56fb70f3d38599ee7a54c2a707b282ba9a401fa69a1f54cdc26425d9ce01
+  md5: fc37321833175bda4fc5c21afe32db49
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 539588
+  timestamp: 1709758479776
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+  sha256: d9c126d8bcd1c89ea37186c172d6b1f73f45ada60e3ae1790a017b530baa0147
+  md5: f0223aae3d622547f6accb212579c58e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17967
+  timestamp: 1709322909223
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+  sha256: 1f908c688e47d03d92ac09d9541a1f1c773ac2ca485dd1d77441b1aaefc032db
+  md5: 444c330471496a39a97e87f41ed70c96
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281104
+  timestamp: 1700583698464
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+  sha256: b9356e3ada4872c7c950d2ac7e0f107c4786775191efdfda3a469dffb18f2714
+  md5: 07ddd96675caf30ea77cafb1ea5662a4
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2490144
+  timestamp: 1690905181398
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+  sha256: b1481ffa475c65200626f051d5dcbdb264730b533e928dde608a79ce7a5b4e48
+  md5: aada2761547a291d68f4c016a1a9bc7b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 18265
+  timestamp: 1677911915719
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+  sha256: eb82a0e2ca36d0973b5f6642e27609554edad4b72696f989776d5db8cd4a6a42
+  md5: fa8d9dd8a2fabba964c6bb75ace8c572
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 3201601
+  timestamp: 1713551611540
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.19.0-py311hca03da5_0.tar.bz2
+  sha256: 428ad55601ca1f2e3828fbaf0388c58ec6ea2621822569bb5a465d3bb9ca4762
+  md5: acb23eb80c417a2b0f390bb2120af479
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21,<2.0a0
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.1
+  constrains:
+  - plotly >=4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6093873
+  timestamp: 1718294669877
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+  sha256: 765d5b7ef75ed7f52a110504cd88e9b0c9977b841f1beaeeabb17e629b462908
+  md5: 0af9cd26a7c9eb8b77d3cbacb93a118b
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 360105
+  timestamp: 1715090588763
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+  sha256: 4d4ab70ae0ce008c1cc96a4edfbf3866d5e636acc4799a545ea93acee51635f7
+  md5: 86a085a440729020d1d7b0b74d6a0c6c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148448
+  timestamp: 1714398923507
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+  sha256: 63670c8f31770e1746016f645ca6b42b35f92d1c37e8025793d9490fed9998c0
+  md5: 9cb417b9fdf02b4e007a5b5781e5a8cc
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229932
+  timestamp: 1705934202146
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.25.0-py311hca03da5_0.tar.bz2
+  sha256: 84676342c0d1244d20aaff11b33bc8d661960b0ec09d911220e79c616e660343
+  md5: 5f05461b6cb4cf1b2764a21b5d79b8f2
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1632212
+  timestamp: 1718288108323
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+  sha256: e57d10579b52a3cde45aa17e1bdd95dcb9d3346aa00eb02c51e38a42db83e18d
+  md5: 05153120787fb09159b6e1ad902c6e10
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1180481
+  timestamp: 1678994989550
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py311hca03da5_0.tar.bz2
+  sha256: bdbc36a516717a24b40e2a4ac812c4d097b6733f4c6654602556969e5e0d4062
+  md5: b31b2f2fd10d919c58c51fcbe54ef5c6
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353970
+  timestamp: 1716993463263
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
+  md5: 055e12390b844ea6c6e956ee08a618e8
+  license: IJG
+  license_family: Other
+  size: 273479
+  timestamp: 1677849171867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+  sha256: 62025ce4a2b9244b9816c9e02487e0dda567600692b5f9ca71f425d084961c7e
+  md5: d57b7063122e5bf25cdfc2a5ea7330a8
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 181872
+  timestamp: 1699041739097
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+  sha256: 404b0847029f77bedd7902a170a046219e0dc5c0ec2be19ff45361cff25b2181
+  md5: 3a02bbe8d45fdbcb2350f672be74c9f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16524
+  timestamp: 1699032463763
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+  sha256: 7deb8ad28c34c369573754304a03ea2acda8ee39102a56526ec689a4d9210109
+  md5: 675ea1a746a78ff6bf8fc4b39139efff
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 277400
+  timestamp: 1677914250715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
+  sha256: ceec15c84f5c699b8055d01e046be04ccb7cfd7c8bd090fc18959f2a4d9f8cf8
+  md5: f85c11f7068312e1e84505efef9d55e3
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 98520
+  timestamp: 1718818476094
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
+  sha256: b2f1ee2a297e001a2e70bc218f60deb08c50b9b727668913ed5a106640413d2e
+  md5: fc4e797a17ff5dccadfb5d19346b7800
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43099
+  timestamp: 1718738212629
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
+  sha256: 2d96618ab2e9b3de870a713d7e5b19f6cde936291f3c87972f945b6e27024e77
+  md5: 534159d29d9aba9c7e70ee52c27b326b
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 614003
+  timestamp: 1718827110867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+  sha256: 501e929d345aaa9079c965552b942b4e8bde35b87ae89faef003687a40bab3a4
+  md5: 54c7b8554a405acd7c8326c41ba93e63
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28237
+  timestamp: 1686870817418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+  sha256: 773e7c4571f482a744dfb18ae26fb22635f5d3f51389c838bd97f9044ea55cc4
+  md5: 5161546aba5597318cb5653390cdecd8
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20235
+  timestamp: 1700168681687
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+  sha256: 8c1c64d51be73aad381992a9df19d8336910bdfc40f19940231df86e177d17cc
+  md5: b1f786f96684a143cf30d1f6b8aebdb3
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65045
+  timestamp: 1677925371836
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+  sha256: 199042b87451abaf14546af124ae3380194cddda928e0d30ccb341e93084854c
+  md5: eaa0442887994a82486c65d87f6b71e6
+  license: MIT
+  size: 68806
+  timestamp: 1714483212137
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+  sha256: bd9a8a17fb14086446b710fa029d238e69274b83ee2e7e09093496f190de82b5
+  md5: 66615d6a0cb5dcca3e20c019cde0ed2d
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_8
+  license: MIT
+  size: 32975
+  timestamp: 1714483225840
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+  sha256: e1bf77e8b975c30a69b08a08410622e27c8cff6f592ccfa590466b83d9e6d104
+  md5: 8af86bdac01fe303d693d9b76c071059
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_8
+  license: MIT
+  size: 310266
+  timestamp: 1714483239194
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+  sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
+  md5: f31e4eb9cd6447cc2f5ef0243a76540c
+  license: MIT
+  license_family: MIT
+  size: 120460
+  timestamp: 1714483461787
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+  sha256: 41c62a460bb81a1a272aa28b219fab9c26510adac177ff1528b1980eabc6e868
+  md5: 8d312c5628dc7ea833e9b4dcb73e9c45
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 42346
+  timestamp: 1677973051421
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+  sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
+  md5: f5f7e6e7541d8dc3d3df270d488d2e24
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176990
+  timestamp: 1714510588159
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+  sha256: d024f5142416961a5e66e424d4d14aec652f9e9dd738b41a97f45674c2ffc9d5
+  md5: 0e2d94b125d802f7b006cf19c71655a1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 163084
+  timestamp: 1677932947966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+  sha256: acfd84e29ff4dc2d85543bb973a07f22b4ba53c5d00bca84608ee7f13b2a8676
+  md5: 5ca161cd51e2db358e768453b3ee485e
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135871
+  timestamp: 1684279980293
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+  sha256: b1bed54c7bfb7304cde9e8e6f798543d08e808e81286a5a48296fc94d621f9da
+  md5: 774358285c9e496c9f5c121cc546c823
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27438
+  timestamp: 1704206026910
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+  sha256: 9229a6e15abf3147cfcffad4ca389dad940e45779963b4fc3fd56dfdcfca3234
+  md5: 4e1897f3cb4923de48c016468c01c051
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9100733
+  timestamp: 1713336457304
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+  sha256: 3276d61fc353c537bb09d4b7473d7abe12be38806f42c8cc383b62f40850a5cc
+  md5: 6e9c9d47f264b77d9a8461f0899848a7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20446
+  timestamp: 1677918370379
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+  sha256: 43c96d30775b61b4968422a47f9605049428120669f0742bbb9e5ba145c7d11e
+  md5: a31ca0d9284860adf5463cf45a5e3145
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 69243
+  timestamp: 1677995336989
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+  sha256: 96d8c9f42a38651b7bafe5f3cb132601db76cd1e28fa58e2eaf090e634292fff
+  md5: 5ebc793a17b6aa84d13f19433545ffa5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23895
+  timestamp: 1677942274932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+  sha256: db9bd659ada23f1ded443d2db00dd13b5d5c0b30f5062544b1ee2c2b88d63d29
+  md5: 03c48121614cf12abfe30eced9b34717
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105333
+  timestamp: 1677916687032
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
+  sha256: b6fa12e4bde747bf288bda31ce8ec5e24292dbf74fde67f18f9c9c100b845a38
+  md5: 2eddc760c15171a1e8aa838d9d162e18
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8291605
+  timestamp: 1717622676584
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+  sha256: e8eee27fb667aa10b26f3bc4b93f449b7d991ded27b9cb457effee394ce05f6f
+  md5: 6a3e5cd0e1141c01ffb91285bdccfe83
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123043
+  timestamp: 1698934328890
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+  sha256: 40230434aa2fbb33ece13632e8d4b7cd1ad68fdb8d1b00263af4a010795d25f8
+  md5: f12ce7dad3620d6d53a442fa9d36a0b0
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - pyqtwebengine >=5.15
+  - tornado >=6.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 538067
+  timestamp: 1699022954841
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+  sha256: a492acec8ceadc0911a75966ffa630a8eb15b2da8c7a8d544a645ba47771a2d1
+  md5: 4002b1b88b2ecfdfc769036f43b0a895
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 170964
+  timestamp: 1694616845237
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+  sha256: 417ace1ce51e81f3f92ddc26e0e3a83c1e19c9ebb7af7104452002a5573da534
+  md5: 3e11de6cef096091bb733e07802f00b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16979
+  timestamp: 1708532698253
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
+  sha256: 8ea1be4285e2e7d361cbcc1daf9c220f87ceaab2308bf7b339d2513d6ea22184
+  md5: 774ce02efa90f212023541c0b24e92c1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 726598
+  timestamp: 1717630964815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+  sha256: b0cc542e2a6f42ba716e7e4ccf29eddcb155ad167fcdbc72d2db9c7873eb5639
+  md5: 7acf81b17d2c4ceb3cd39dc9f173855c
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27539
+  timestamp: 1699455954000
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+  sha256: 151a3eb68d1189e69764ece1d8fb3544d31a22f5bbbc3e19d846de8dece304d2
+  md5: eb6609e6bdc9c82d70df3f8c4c2de95b
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153313
+  timestamp: 1696515415712
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+  sha256: d3bb1d4be88320a5861cd3a0f086e9709f9b64c96c032cb9039cc4f17ec66a85
+  md5: 0a7b97665c06fcd34a70e34abc177280
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.26.4 py311hfbfe69c_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11288
+  timestamp: 1708639168951
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+  sha256: 3e70248a7069ca12ccf56252869bfdb72211fd4e4c327e6994756496df786c79
+  md5: ce4846006d98638cd86a532a72f8dfe4
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311he598dae_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7536860
+  timestamp: 1708639153133
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
+  md5: 371358a54bbdd307603888348d1a2c6f
+  depends:
+  - libcxx >=12.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD 2-Clause
+  size: 412248
+  timestamp: 1628861367714
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.14-h80987f9_0.tar.bz2
+  sha256: 3bf30abbaf136d57fb89067f71ab22ca3777b537a13b3303acbb7b0f1da1eaa5
+  md5: a4cf5fe0ec6c19fac1ff42127e430215
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4766984
+  timestamp: 1718385447449
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+  sha256: 77b0c0a0fb14d817390244ebd93c36d44a7867239963f211f7c0a72a3f98d382
+  md5: b90336feb8a50d2eff880e89acb02f40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39617
+  timestamp: 1699371253760
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+  sha256: 4f6c3e8d8fc4c57975cab837ef109b9ee7af4f18aac72668334ac656e53c6edf
+  md5: fbf1b507f9a80c5de3c957e8152124da
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 159289
+  timestamp: 1710807498427
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.2-py311h7aedaa7_0.tar.bz2
+  sha256: 3ee48b8e32d5009fccbb8e0dbb00d905f827982adae9c9f799ad85ba6f13a077
+  md5: 9e6f48d13a7911f6b5547e6a9c8dc5e1
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - jinja2 >=3.1.2
+  - xlsxwriter >=3.0.5
+  - pandas-gbq >=0.19.0
+  - scipy >=1.10.0
+  - openpyxl >=3.1.0
+  - pymysql >=1.0.2
+  - s3fs >=2022.11.0
+  - dataframe-api-compat >=0.1.7
+  - pyarrow >=10.0.1
+  - xarray >=2022.12.0
+  - fsspec >=2022.11.0
+  - sqlalchemy >=2.0.0
+  - beautifulsoup4 >=4.11.2
+  - html5lib >=1.1
+  - lxml >=4.9.2
+  - gcsfs >=2022.11.0
+  - zstandard >=0.19.0
+  - qtpy >=2.3.0
+  - tabulate >=0.9.0
+  - blosc >=1.21.3
+  - matplotlib-base >=3.6.3
+  - adbc-driver-postgresql >=0.8.0
+  - numba >=0.56.4
+  - pyqt >=5.15.9
+  - odfpy>=1.4.1
+  - pyreadstat >=1.2.0
+  - python-calamine >=0.1.7
+  - fastparquet >=2022.12.0
+  - psycopg2 >=2.9.6
+  - adbc-driver-sqlite >=0.8.0
+  - pyxlsb >=1.0.10
+  - xlrd >=2.0.1
+  - pytables >=3.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17039081
+  timestamp: 1718309063969
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.4-py311hca03da5_0.tar.bz2
+  sha256: 30a99806e616ba4270fd3f517eff88728e50eaaa3a46dd811476eadc4744444a
+  md5: 81c2a30ee5913e37fe552f51ab9b19be
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.1.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21836599
+  timestamp: 1718119512521
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.1-py311hca03da5_0.tar.bz2
+  sha256: 7c4d34def227ba26cea176cd3d522aeb2584989e68052c387925536097cd1f63
+  md5: 025e2c935f86e471a35d584c40bbed29
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264597
+  timestamp: 1719348054960
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+  sha256: 174b680f4bb041e8146aae80f92390122459e0ef8c911cab22d01e2e92d44ab1
+  md5: cfffc94779cd26a349bd409b5590b098
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 916496
+  timestamp: 1714399019350
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
+  sha256: 102c3c35a9dfa0f10ec8f4a040a24295f9c736443ccae2f685348a44f62a4d68
+  md5: 027b347e79e252aa17b534e1a02bccd6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3447682
+  timestamp: 1715097070362
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+  sha256: b6200816d65673aa1707c20a768c9cff87dd8dbe1335f9c1478e5931dfa08ee0
+  md5: 14b1e0fa73eb33f9c83048482dcce57b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38423
+  timestamp: 1692205689597
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/plotly-5.22.0-py311hb6e6a13_0.tar.bz2
+  sha256: e4c97496602c9de901fd64e48644f68f46253d1f70aa8910600664f075f7668b
+  md5: d5775eadd788f5100fc6b02058539f42
+  depends:
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - tenacity >=6.2.0
+  constrains:
+  - ipywidgets >=7.6
+  - jupyterlab >=3
+  license: MIT
+  license_family: MIT
+  size: 10779565
+  timestamp: 1718137635778
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+  sha256: ebdf211edd98d88a23778551c7a9702106edd0695d4fc48e87c21f77521c1ffe
+  md5: d8c505081a468f1b99c62466e2309417
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 123084
+  timestamp: 1678996822234
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+  sha256: 07cfba50d9e94364bde077731a824ca4f537138b35ee6b66d07aee16ac9850f1
+  md5: 919bf486280a11e6acb3c2c3a82f7473
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763225
+  timestamp: 1704404463402
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+  sha256: 8094436b2c44e68e72569c704633802aad82e977b1e16026848218679c8becf4
+  md5: 2360e46d3e598dd5e2abed781fe166c5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 502115
+  timestamp: 1678995719872
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+  sha256: 121b5b66721760c05f1d4eee91626229d1814663d3fb5f23126ef870aa496e26
+  md5: 0c588c2ca790a05d422c06e8568201ad
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2124200
+  timestamp: 1684280082141
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+  sha256: 44b694db8e81d61960d28d60f9e9b573f03f7827881d302da334378881db4889
+  md5: 6c94ba7caa599ff533e0ab55d898be8a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 208454
+  timestamp: 1677910948527
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+  sha256: 0bb3d2a57b332c5cf73ea40ea13c850ae24a1f9a3a41ed9267832d9e3c767572
+  md5: 45a7fcf1641980d5114999736428502d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36755
+  timestamp: 1677906514270
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
+  sha256: 960c343b7b8569dfe4e71a395f7bede1e749da7b02c17506b590c9e1839e6fd7
+  md5: 722c4b4386af73cf1562974a00c880a4
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16494386
+  timestamp: 1713545544909
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+  sha256: c3cbf5bd237b0a7458640191016b2701fe120c547df9afc835da76663a9c17f7
+  md5: 843568c76b6b9384635b7fca74c79792
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332222
+  timestamp: 1716495881101
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+  sha256: f94b3cfea6f76ea9983e16d3c4c7e0a64f02c40cc2c3ad57189bca2e67030bd9
+  md5: 0d100990ade57a02b60d1e8085db0bdf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 280263
+  timestamp: 1678996927464
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+  sha256: 252c86f5aef7f8dfce99a260c24cbb35a9adfea144a2acfabb224f516341544f
+  md5: 745b888e19a644f48800799f82c01c21
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18539
+  timestamp: 1683823925189
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+  sha256: d945744eb133f19ca61325cac5128bdb053ae04de4a0ba6f69c061449cac8af7
+  md5: 34baa81490d667381bc7021435b0e1f2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 275858
+  timestamp: 1713974457562
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+  sha256: 012585bdb5ae54c2cded50be703734e6dbf418b003635b6f6d7c1e36e7020c30
+  md5: da7e99a707bd0cfa20db651b5c068bfd
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65556
+  timestamp: 1711136890180
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+  sha256: 4f04a43cbd612ab09cefbdc2e48ee61b51967dad59d859ce0502cc2c46c88fc5
+  md5: c68bf65433b2151b51b2e699bc22c501
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 194632
+  timestamp: 1698096151085
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+  sha256: ae8cdd5be5a7ad19ff82925a035859fafcc5942cd3899d127a508dbb9a235090
+  md5: 252a7b997d08bf72f10b3bc2dc68333e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 580346
+  timestamp: 1709318480624
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+  sha256: 7a208abc002a2fc208ae25cb2cf932999a3e4980aa4c9edff315cb9ac62b12ce
+  md5: bd22ebd3cff811577ea61f115ba7f4f2
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74744
+  timestamp: 1699012126255
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.2-py311hca03da5_0.tar.bz2
+  sha256: c6eff6c175590d7fd2e500ff1673b160a4c2b67e1cb99370ec8b5a2c998e8025
+  md5: a60c7eef247742967bca814d7f1d90ab
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 123308
+  timestamp: 1716902854898
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+  sha256: 52368d9b557b8f54ef5ca4bf6cd5a3ec665171f2b2d2082cdd410bab88f4829c
+  md5: ac76fb4d2eef3ecdd491cf5d3fb8620d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10204
+  timestamp: 1683077239143
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+  sha256: 491d116c5f54ef340e3bce631835f7138cd1923d7b63e6ca9aa01b48110cb8f9
+  md5: 9b81bd8ea808704f5433884b567f1f15
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10557
+  timestamp: 1683059079547
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+  sha256: b53a5f6119173d62e4e68a37ea8511c7fc87a00af72953e0048d075a799c7a7a
+  md5: 76a16cf4edb9b12b2b96a2d323f060dc
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 342535
+  timestamp: 1698945991201
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+  sha256: c80d52567084b1caaed2862b77b70065ca17afaf0b020733e9d6c273b4a63e78
+  md5: ddf7d88c1967f3f7a4ce1c975fd47e0d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33321
+  timestamp: 1699371225235
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+  sha256: 6d38d171ef87340cf0fbbf4c70217df4826c65400c9290774f5cb35e381e3315
+  md5: b9529a812f9862fc89461b6b90f184ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1599110
+  timestamp: 1715024190898
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+  sha256: cd71091a234874d2826fa063ec5222b3191c9f47e1b5281c352d9df3f31a06bf
+  md5: 0db8e29016c6bff026c083d9923a7566
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19073
+  timestamp: 1705431415504
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+  sha256: 3e18cdafc607c6d7623b1c8f041cbfbb50a27e298f961abdcce7e36834ac39e1
+  md5: 9ee0da74c55d0b8d83edf246fd717f20
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89862
+  timestamp: 1696347657368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+  sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
+  md5: d8c1e9910392d0bcb22a173f9ce30fa6
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1758290
+  timestamp: 1714488307689
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tenacity-8.2.2-py311hca03da5_0.tar.bz2
+  sha256: 504a1cf35657ddf7d25c810d67b1aee3d37ca20181589a216c89309c719ee6b9
+  md5: 0fa367bce619517b599b2046c1f7486d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 48108
+  timestamp: 1682972353529
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+  sha256: b5c265e9ed9a1ff2238a09b83bdc1826950faa87fd6b685debe60888de6e7a50
+  md5: 5827c8a32317894ce18576e334daba47
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38559
+  timestamp: 1677918962258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+  sha256: cfefd86d0f4981d22b7611b3dc60359b8698bf39f2b743cb90b7005aaca88e1e
+  md5: a04dbcd6095f6b8f3ad195a78d48b262
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50058
+  timestamp: 1677917499177
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+  sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
+  md5: 3c25b4f4768ccda28b20a03ba27e7759
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3484151
+  timestamp: 1714770744982
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+  sha256: 0836468fafb1f5badbb573922e37200c6929bf2926ecf8d2259dff43811e0727
+  md5: 5bc56dcb4bdb7cf623b7cea499feaddb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 136409
+  timestamp: 1677925889207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.1-py311h80987f9_0.tar.bz2
+  sha256: 2fd655106e52bb73deea5a0af63708e75cf66e071f0f3f15c04a67413f721430
+  md5: 324986c435dcfc101684907ce85c199e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 915790
+  timestamp: 1718740267109
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
+  sha256: 81efb240a49cede5ece3a8ad48f1d9dfdeb56260bf1a20e25ec53cdb202f7c3e
+  md5: 81a17d13c75596841b95340a34bbe929
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 155516
+  timestamp: 1716396017482
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
+  sha256: 707e5dfdb9116f31bc1ad7f497f6e8416683add460258fdc2a4c16eec85226be
+  md5: ffb602322a388ec8e1f385edaca3ce12
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 208171
+  timestamp: 1718227091374
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+  sha256: 96071e07e807414b7ae5a2fe958ac171e5795576b3a4c2f5e8c643fba43d760f
+  md5: a34f2b216e35a37f966883dacda229e2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9902
+  timestamp: 1715268985387
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+  sha256: b20e48aff4c781a52b6be66d77418e768527a621f5fc272ecb34ea03475b2bd7
+  md5: 707738432f16f5e63909fcaa6e65850d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 75604
+  timestamp: 1715268976065
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+  sha256: 2ea2d0520b330d381a2ab241bdb9ae146ef815ee7c96ee52a9773fb9ae85f4fd
+  md5: 66f7f8979cfb2cccffac972d70482130
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 12614
+  timestamp: 1677963554857
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+  sha256: df7fe7740bd853b641d624e2ec97f1aacb2b82691936a8c04ef18fa9768539c2
+  md5: d5c7626d45fd03b22797c18e47812beb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 518048
+  timestamp: 1713213046424
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.2-py311hca03da5_0.tar.bz2
+  sha256: bfdfb02fd3dd1c01fd36b0753e365bfe599153da178619d8b62814c89682ab8e
+  md5: c30603849b5abe9935b0a58b2904a090
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - zstandard >=0.18.0
+  - h2 >=4,<5
+  - selenium >=4.4.3
+  - requests >=2.26.0
+  license: MIT
+  license_family: MIT
+  size: 210621
+  timestamp: 1718912666948
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+  sha256: 09738b7f9075386bf062b12ddb6fb72a06450d2481f6b5ca2026c811cd849569
+  md5: 9afdec076c95746ac21235f971190e40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26727
+  timestamp: 1677910175964
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+  sha256: b4ced7366de8eb7258f31d516616e70c62ed4a798780e57e208509d2b52ab435
+  md5: 65a9a05a726734c1da667f9bd3c78c14
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 114733
+  timestamp: 1715878377412
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+  sha256: aa301d9e42aadbe3dd5f301ccbf17fbadc347fd37d413c0cbcbd24403892a936
+  md5: 77097d17d835a137af7950c628b66150
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 137260
+  timestamp: 1714717037687
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+  sha256: 2cd108896df65636769e3804ecc2ca421ad9b54e64fa21922bbabe40c90c247a
+  md5: b3a1e5077b28f71298d891fbfb5ff03e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55645
+  timestamp: 1677927459979
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+  sha256: 5be8c968f2da5c4bf14f28d63e31b4c1b6993d980023769732c7f58f396c2e0b
+  md5: 3f5f62d4e85e3bdd48d39189b01805a6
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 459197
+  timestamp: 1714510992914
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+  sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
+  md5: 3d57d1adadca9388aaaa1c529b65ba65
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 322790
+  timestamp: 1705602163804
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+  sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
+  md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
+  license: Zlib
+  license_family: Other
+  size: 104928
+  timestamp: 1714510936868
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+  sha256: a3f3eaf240991b6bd7b0596a78d0abb3321cc79db52fa24f6f559189778871c6
+  md5: 71f035b4716322539e2461cb6667e946
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 825339
+  timestamp: 1714678419523
+- conda: https://repo.anaconda.com/pkgs/main/win-64/altair-5.0.1-py311haa95532_0.tar.bz2
+  sha256: 55d61cec328d4df122f92a21ffaa315f4b40bd78dfeeb4146d3a85eb121e351e
+  md5: de1799404d5161a2fa6711688f5771eb
+  depends:
+  - jinja2
+  - jsonschema >=3.0
+  - numpy <2.0a0
+  - pandas >=0.18
+  - python >=3.11,<3.12.0a0
+  - toolz
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 853339
+  timestamp: 1687526136999
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+  sha256: 6e6787755de0cf2fd776c9681a7b0fd0fb23e35e679a463cc2005b991c413910
+  md5: ccad42ec9a2ad48939f089c528abc8f0
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 229694
+  timestamp: 1706220431719
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+  sha256: f715f7c2e06149bd6d43258e41479d3171efe5e9d56050a0a5f5652ed9d05fff
+  md5: 11a8ca43d69881b88f95ae681478866d
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 36089
+  timestamp: 1676424516042
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+  sha256: 9adabcdd2a10f73fa5ba56adc901eeea2e379991a0d4cb9737eec7aa6b9fc5d8
+  md5: fc80b572be85601706d425b21a58d497
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153102
+  timestamp: 1695718054194
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
+  sha256: f1eb2a5aeb25efa0b38fc1dd94a36d431bc80d654f11a052f67a899dcc471f57
+  md5: 9db5a441c7cbcf4dc617f8c722e4310d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 276663
+  timestamp: 1718029990621
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.1-py311h746a85d_0.tar.bz2
+  sha256: 5e81c00b64a071a07c5ff5892fd48b94476c93121fdb2c28581dbf2e023480d8
+  md5: fdd289f6664341f6b29f70804d322594
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6101282
+  timestamp: 1718119807269
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+  sha256: 5c12a5d7856d9977447360b3a99a5b99818707fe79781ba1779037f11b3fef53
+  md5: 6a125ae352306a944aabc635a5fe13a3
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 139230
+  timestamp: 1707864402762
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 751071782f597f87ed7f67437ef6cc669213902461b9795dd6eb0f4897eddc83
+  md5: 5ad8fe62aad5e16cfdf2c5a7d1327fe7
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_8
+  - libbrotlidec 1.0.9 h2bbff1b_8
+  - libbrotlienc 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 19418
+  timestamp: 1714483531456
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 9bd62d810867549b9c967c5915f3fa3f66cfbd6ede28b1cc152efd1261285c0a
+  md5: 64cc76de3662b62bc8f0e42befd92c5d
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_8
+  - libbrotlienc 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 32178
+  timestamp: 1714483513837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+  sha256: 1547fa52134cf06b8d01bdf52114db7db60a89bf35c9c95be5b5a03b13dbd565
+  md5: deb765cb7c4b7edc4d126f864f31747c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 356401
+  timestamp: 1714483740924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+  sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
+  md5: 11e0af09a31e2d5df51c65a342032b85
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 112994
+  timestamp: 1714511182837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+  sha256: 73391a74a5300ad3fb063ea0f0c3491d220128a0611a84036da2e23c1e93dc0e
+  md5: 501ded4f9b5ed895077802defee912cf
+  license: MPL-2.0
+  license_family: Other
+  size: 171644
+  timestamp: 1710764856021
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.6.2-py311haa95532_0.tar.bz2
+  sha256: ef70313240391cabaeb788bba56445c1d09e83bb3418708ce12d88caa02d948b
+  md5: 3876257b995a2ff05fe3fa50e49a43fd
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 167147
+  timestamp: 1717618236343
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+  sha256: 5cb6ac90ad234248f3795945f69b0382397714a52712337b2f86339526b822d8
+  md5: b90f3126f6315ea2e8ab242533062557
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 302693
+  timestamp: 1714483562551
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+  sha256: 4099898f02e1f6119fcda65e747c3cbfef0bf563c8855b79a0245160709d5b45
+  md5: ab9705c34e67fb8c8faec69d63ff4064
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36410
+  timestamp: 1676422341506
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+  sha256: c722f50980d7416ffb2cfc7bf72649307a0bb78c5a24eccefcd049cb61d6b355
+  md5: c7c9ff0513ff3c99700919293b702410
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 543258
+  timestamp: 1709758602437
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+  sha256: 8fb3e816a5ad1da05125462dbc9e2a7e933b001a871aa65703802c0a894c6277
+  md5: ee4b2fa9fce130496d5c7c86c35a1a05
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17723
+  timestamp: 1709323150229
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+  sha256: eeb49cd151ecdccd40062e8123a3b7a9a8a1eda6567dd33ce909ff8ee1a97c89
+  md5: b7fe1f7ead1ec2ac642d022942282fc8
+  depends:
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 232451
+  timestamp: 1700583772701
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+  sha256: 5c73f86e575f2ad683ee4a1c2df11020e270edd89d12f11199483d57b0b51826
+  md5: e96a12895ce374476277b1b196ba24bd
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3719519
+  timestamp: 1690907216785
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+  sha256: 5d5fc8a24c804010b8cb5963227230352ea3ccf56bea9e8116e34f77223218f2
+  md5: 8f989a72eed6293dfe0533c83057980d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17688
+  timestamp: 1676423357100
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+  sha256: 27fb03eb57d25711a15e145f47a64320a9955b585efc9fd0a1a51cdd71b9fde3
+  md5: eb3869e98f6f53dfec76e2eff4d6b61e
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 2732423
+  timestamp: 1713552175344
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.19.0-py311haa95532_0.tar.bz2
+  sha256: 8bdfcbdc68524ef2222f4e4f39bdef9ebf4cdd046b8d3bc98e5baf1350f5fd4e
+  md5: 21afc8a819b5d727107a701696f317e6
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21,<2.0a0
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.1
+  constrains:
+  - plotly >=4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6118467
+  timestamp: 1718295783978
+- conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+  sha256: dee3fc68ed81398d232b3afe9a032837bdbef98c1b2478604d6abd397e3e7d64
+  md5: 3f75535ca6dfee0745b221922f21f6de
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353312
+  timestamp: 1715090519918
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+  sha256: 102c803186db6d62eaf41a906f6c563ff0d62b53c1eaede8a381e18c0d005ed9
+  md5: 9d30dec03058758a428cf152e0ae28b5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148193
+  timestamp: 1714399061601
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+  sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
+  md5: d215cc8ee7ca2cc83cc250cc5d822fe0
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3929136
+  timestamp: 1699647939158
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+  sha256: 864e9598f64105769b4ec02cc404fb507bc59e217324daf1686c00cfd12c0055
+  md5: 6bb1c3be1f85799a3988afc2c3c5a4f0
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229621
+  timestamp: 1705934494547
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.25.0-py311haa95532_0.tar.bz2
+  sha256: 5bc6f0c2fcbf83879ec845c6d01c5f2509eb82033f97cf69f9efb04871f1c0ff
+  md5: 0bd2c9f9e27b7527e9cc222955cf38f3
+  depends:
+  - colorama
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1664773
+  timestamp: 1718288341111
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+  sha256: d81566367c79a28d4717157fc74293e846a47af99387ed479eb001a425dd398e
+  md5: 28c76079c96ad7f8b1a5ed32b438c79a
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1147434
+  timestamp: 1679427525584
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py311haa95532_0.tar.bz2
+  sha256: 74c339ca0a20f4bc324974c2c28901c1f478ca7c8898483482883a7a82896d15
+  md5: b3d3352c9d3bfe46f924b8e15fedf9be
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353862
+  timestamp: 1716993519832
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
+  md5: 81f2c343dc4c65eea39c45383272068f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 407861
+  timestamp: 1677849239400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+  sha256: 5e6698015a3b048093f5737f0e54bcbae415d0f9682dfdfeae3a8cfb4ea275e2
+  md5: 0093a4214131046c4f68af0739dfbea4
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 201456
+  timestamp: 1699041872445
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+  sha256: 9581be54128954080d7cef448b1728874c2ebbe5064f55adece422cf12eafa5a
+  md5: 3adc105f87d5c7f0b1248bc3423f5b48
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16187
+  timestamp: 1699032556953
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+  sha256: ad8343bad7c8f0448cbcfbaf872cc94b56da81c52e5cdcee2a5d6b89f029eb75
+  md5: addceff8d46c9d1d322618a9ce9e5b39
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 300354
+  timestamp: 1676424060532
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
+  sha256: fe0bf805dfa60d8b5d61670900442d0cda12523135176f60e1ebafb797e521d8
+  md5: c8cf5ea3d4b0bc57dfe6b189b47e69e9
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 136783
+  timestamp: 1718818384444
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
+  sha256: 262c35a28d0af4d73ea1c010ce0c022005512a26d5c27064c8e009c0b7b789d9
+  md5: 8367c61552aa274c0843201d88e461c8
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 72131
+  timestamp: 1718738283200
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
+  sha256: 00bf8449a37eb10c91ebfaa14b231905fde9493740cbda7ec89a8d3d8d9d1ff3
+  md5: 1f3abe3cbf365249ebae7465a57e4cae
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=2.0.1
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 655133
+  timestamp: 1718827724346
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+  sha256: 90420847230e72a648417f5f77cebcf7f17b89f70788652c276acc0c440e135f
+  md5: ef3d8dee197aa37897bf6d39d2dd878f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=2.0.10
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27639
+  timestamp: 1686871052174
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+  sha256: 97faaf26ce5254ec3649a8ee7f480b1556e4e8e6e4356d2fab1e6a5532631a0f
+  md5: da23bd831c50c877f63038b7e16720ad
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20163
+  timestamp: 1700168785472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+  sha256: 8a2f0909fad0387e57cb0e9ee30db2b20761a9106e794381ffeac387a298fb07
+  md5: 6058b2efc3284e27aacec2e6e6280433
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62334
+  timestamp: 1676432044242
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+  sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
+  md5: f5f73266281ab12377d5d47bdf07500a
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 905072
+  timestamp: 1617648814933
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 7c906c94a4d46ea963080a6ba5bd12c1274da66159877a544fbc70291eeed98d
+  md5: 45a3d52534fac8aa54a55ee92211a918
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 80216
+  timestamp: 1714483371043
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: daad7edc6d56abf3e176479e8628162dbf1c56b3d24db30d708aebae694a5214
+  md5: e8ecf229f7fcb4c0b76d8613627948f5
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 45189
+  timestamp: 1714483420152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 84320217abffa9386186ec8d03b4651bb4b1900d3871adc965a9a9e1d3799907
+  md5: 651312fa22168f71f9aec5f9ee2c2fcf
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 756116
+  timestamp: 1714483464368
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+  sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
+  md5: cf949d76148be1e2a534218d9c57df86
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 155435
+  timestamp: 1714484319443
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+  sha256: 4534c822511a052a72c2b070a05e5d8d6f3550f18ea00a33f9d8a9a92b4382cc
+  md5: 82f24e7660831445a2183216e280a6a4
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41464
+  timestamp: 1676474474981
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+  sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
+  md5: 320f40b75d93f3b96931c6d13c23946c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 158902
+  timestamp: 1714512129889
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+  sha256: e0dc6e119b224bb31ef34b6ba270ffadc181d38b698c5318de8df7a5d2c4ccbd
+  md5: 992ccd756f09408f0b74dfb9852a8b7f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 182381
+  timestamp: 1676437963591
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+  sha256: 050b5fd4b28132d8102a7e6b40179894dc7f5e41f7ad9ee19211e67446c5740f
+  md5: 3ae0b2f6baec708554648ddafa81b756
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 154386
+  timestamp: 1684279992864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+  sha256: 8269c73b7a9c03b95a121e318d0468f35eecc016093620b0560f35238cc5df51
+  md5: 2914bea0ae29315f998e1abac79ccaa8
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30214
+  timestamp: 1704206218108
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+  sha256: 68fb7d113dbf185b571343847e3dbefdbe7d0b9b5902f1f390bc2a6e33a3f8ee
+  md5: a72ff718390a1fde0b208a43e6b9b655
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 11366001
+  timestamp: 1713336740870
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+  sha256: 43279276850eb6e621812448cddc1093524cee0b7f8ed58b4600b68a4fb659f2
+  md5: 5968b2b5c1f3cf5c8c8c9aaa4d8d66a2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19886
+  timestamp: 1676425829787
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+  sha256: 3062a8254ca351b54f15bea85cc928a3ba4d879bb98ce97ece39a9f7eca215a5
+  md5: 8f1565663abb34ad7fdd512e76da5532
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 68031
+  timestamp: 1676481862508
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+  sha256: cdff5215c292fe59649ca40ca72f5d26da352760c1d6a56feba14eb13f7bbf61
+  md5: e0f3f32b22135dfeaec277bc87183ca9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23328
+  timestamp: 1676442709081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+  sha256: 3b173a25605d2aaacc57ec0e425f1d1c51327eb2521c8742a736e2c76069bc8d
+  md5: 169f1c93a443f95a88665f3008623ce1
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104882
+  timestamp: 1676425142412
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+  sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
+  md5: 527155127b9fada5e5c5c69a624674b9
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187498166
+  timestamp: 1699648376430
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+  sha256: cea59ae60da314caecf08edb9bcb03126c6dd35837c8184bceaa194decca3341
+  md5: 30936b7263cf0171f7c86400f12ef184
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49080
+  timestamp: 1682975093455
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+  sha256: 5070ceb0a406b1b8b99e2ec58f5d224cbe16ec78109c46720bd182b509e05c6e
+  md5: 34de1af5c639f2d06c6c8d99488e4226
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 196201
+  timestamp: 1695058367111
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+  sha256: 6b4b27302e458fa527321c59be7c335d61f86da7501c4d141db20a72fad68b55
+  md5: 7db9b12da1290bb2c2fc6ee52a945905
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 256371
+  timestamp: 1695060425702
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
+  sha256: 636f369607118a6ee3d0b63b7edb925d8081fd3fc829a7699136ce0dedbde067
+  md5: b7e49c9cea50d8406cac81cd720dd80a
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8323655
+  timestamp: 1717622931223
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+  sha256: e940f9178ee2fa0a7c12873ae35ebea0074371653e5cfa1be8aa8d9271fd343b
+  md5: 355d0835215911738a28010dfa6aa382
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141785
+  timestamp: 1698934346590
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+  sha256: 47dd00c0179f4eb29c70d0453d340f7f5332af326b3d51c64ca3bf6a14be8e7e
+  md5: f66afe718bdb57667b03ebda4cb2ac7e
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 561655
+  timestamp: 1699023338436
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+  sha256: 4ee863a1ff697274c642b3101f82b279a354e3f033a87505655039f89127bb41
+  md5: bfaf19be6644ad2344e118aa0acccb13
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189809
+  timestamp: 1694617194065
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+  sha256: 90fb3f14c49da1397982eae21cd09e8d60d491d76f94c57590c56723fe6dc172
+  md5: 46a523661fe5c1bce7b4213fd428c3de
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16732
+  timestamp: 1708532795328
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
+  sha256: 62732e34b2cdcb73846cfdf53284067d32113aae0f6d736ca30ce2b0073bce27
+  md5: ec7191b2ea4e65b5eed6f7fdd9271d28
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 769732
+  timestamp: 1717630919732
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+  sha256: e040ebcab948325fbe17e4ab15be62e1fafa7bad225457e59764adb60eb40db5
+  md5: 4d40a09df8cb74a9f044eab317436d67
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27282
+  timestamp: 1699456187703
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+  sha256: d3bd2a6614bb7e7f5ce3348d6674e71cce45cbde236beff32f0f08cd95a64ef0
+  md5: e70f15643164f432d1df68635e7c322b
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 162691
+  timestamp: 1696515822068
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+  sha256: 470fe9a0b3e196fa60d5550d8188f6074a207572fa0d353a4448d580872e7804
+  md5: 6fdb8df0613fb2fb9f1732d335fa25f1
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311hd01c5d8_0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11053
+  timestamp: 1708641901110
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+  sha256: 222c1711e7cf151e29077c7d4d86a865c9fd39615812d58a1daca6fd1b6bdfb5
+  md5: 585bcd8bc3940a8a859f38ebafdcd77d
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.26.4 py311hdab7c0b_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10723862
+  timestamp: 1708641867155
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
+  md5: ab07e2a27ac08afe3d0b4c0890b8486a
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 2-Clause
+  size: 249316
+  timestamp: 1630094024143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.14-h827c3e9_0.tar.bz2
+  sha256: e8db21d1d134a3881a8727bf8977c0ac1ac60a253bf9d6499d14907d1e25e4ad
+  md5: 9dabd8629700e17dd0eaf4d4541783a5
+  depends:
+  - ca-certificates
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8367632
+  timestamp: 1718386877871
+- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+  sha256: b2f5f50a1ddf811102636f3acebd76716c88ebb628754b91eda7a3a962adf26c
+  md5: 712527b4d84c350dca4b67f511c04414
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39421
+  timestamp: 1699371341381
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+  sha256: 432b8b7c4671878cbbe361e518544203f97bd2e4f24fa08cf65e8be583f25529
+  md5: e62e7c668b080e0f6ce09fd548f69f7f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 159066
+  timestamp: 1710809127954
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.2-py311hea22821_0.tar.bz2
+  sha256: 1b986a8752785cd01969e737952449f5f0f4284cab7690193fa1a602156881c2
+  md5: ecfe5661d54e32e8533c02f5fd625dcb
+  depends:
+  - bottleneck >=1.3.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - lxml >=4.9.2
+  - python-calamine >=0.1.7
+  - scipy >=1.10.0
+  - xlsxwriter >=3.0.5
+  - jinja2 >=3.1.2
+  - pyxlsb >=1.0.10
+  - pymysql >=1.0.2
+  - adbc-driver-sqlite >=0.8.0
+  - fastparquet >=2022.12.0
+  - zstandard >=0.19.0
+  - xarray >=2022.12.0
+  - blosc >=1.21.3
+  - gcsfs >=2022.11.0
+  - pytables >=3.8.0
+  - qtpy >=2.3.0
+  - sqlalchemy >=2.0.0
+  - xlrd >=2.0.1
+  - dataframe-api-compat >=0.1.7
+  - fsspec >=2022.11.0
+  - psycopg2 >=2.9.6
+  - pyreadstat >=1.2.0
+  - beautifulsoup4 >=4.11.2
+  - adbc-driver-postgresql >=0.8.0
+  - pyarrow >=10.0.1
+  - html5lib >=1.1
+  - numba >=0.56.4
+  - matplotlib-base >=3.6.3
+  - openpyxl >=3.1.0
+  - odfpy>=1.4.1
+  - s3fs >=2022.11.0
+  - pyqt >=5.15.9
+  - tabulate >=0.9.0
+  - pandas-gbq >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17245139
+  timestamp: 1718309568175
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.4-py311haa95532_0.tar.bz2
+  sha256: 25474a636549a0686cae03bdbc694683021813bf9d59680e0599b7666444c755
+  md5: 3c58f327cf194b62ab2f363e42598837
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.1.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21849968
+  timestamp: 1718120610637
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.1-py311haa95532_0.tar.bz2
+  sha256: e6611058e26521784b6197418505acee343ca299b7fa3f57ec23621f869e1d57
+  md5: ffd4cc05e70b156e44f242538d81ca99
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264340
+  timestamp: 1719348210484
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+  sha256: 6ca54ba8ce430caa8a1838b19869814d0b7fa3592a77f75298130983e635387b
+  md5: e56c194e56d19dd8fd76f75a77f92c33
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 1070844
+  timestamp: 1714399290671
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
+  sha256: 15001c7ee6cf6e0ef7afc2f313114f6103e7b6f641fac9a6899ee02d6537c822
+  md5: 250ba95e77f5fcb3fe2aefa85157e859
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3759346
+  timestamp: 1715097175495
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+  sha256: e5f8cbfb5fc25d460a9117bfc5511959c5e86ccb193316033f87bd516e0c8881
+  md5: 9f7e8b5eb651539386bb92c14e5c321b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37730
+  timestamp: 1692205554840
+- conda: https://repo.anaconda.com/pkgs/main/win-64/plotly-5.22.0-py311h746a85d_0.tar.bz2
+  sha256: 68f4e222e47f1d9140322ee612f3518bdfbb13e9aeaa5ec9254b93bc8480af10
+  md5: a87822d76184a133e2937b83e9ccd958
+  depends:
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - tenacity >=6.2.0
+  constrains:
+  - ipywidgets >=7.6
+  - jupyterlab >=3
+  license: MIT
+  license_family: MIT
+  size: 10783822
+  timestamp: 1718151856544
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+  sha256: 6c5b53831273674361437fb546e08315fc11ca9275a174bca3887987e86ced5a
+  md5: f8d91daf5173eb03157f484389adcdd4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 122178
+  timestamp: 1679591983138
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+  sha256: 546819d922b03f3a25ca9f98fd069d0588d481fc0603c6d74bd598fb6a93687f
+  md5: 86c18e3e0b67ee099457475ed6caf2e6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 751763
+  timestamp: 1704404627180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+  sha256: ae06f0dfa2cfae51404afc6d6ad3a474a93015b5ba9a7d3ea24224b8e7547987
+  md5: 3e19794c806cc3e84a3080a97c359b75
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 510466
+  timestamp: 1679005998612
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+  sha256: d95c88d06f4f3f667bd9a39e5f18179e83b3cd4c115c06ce0fff390ff6d3a700
+  md5: c6d00a8a4d89b1be99bfa3aff19d96b4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2134881
+  timestamp: 1684280285492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+  sha256: 643a9a0eba1e2bd5980d21623d3b35188c24781ec251acc4d15714bd1ccb4c17
+  md5: b3cda0394db05be6f0f6176abacb13f3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207985
+  timestamp: 1678721438358
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+  sha256: 974c22de09078bf07c5db31fe12d8d89d6433508defc8237cbe52e08c69ed56b
+  md5: 9cf10bfd49140a527cf4b1d912097e6d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36072
+  timestamp: 1676426019064
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
+  sha256: f43aca7a222c983c25c3e15f79c7e7e3c4909bb7839a1dd0ee327def81aa476e
+  md5: 2b61f1cb7fec068c76ef0ff97c2c62b5
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - openssl >=3.0.13,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - openssl <3.5.7
+  license: PSF-2.0
+  license_family: PSF
+  size: 19811751
+  timestamp: 1713545124922
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+  sha256: 2c61639b3bb56fc864c86558bceb7845b1731ac44bf1a94894172ea47a995bd4
+  md5: 404805e547b4d50b5cd17e16bca87527
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332043
+  timestamp: 1716495838826
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+  sha256: 9acb33db60d9319595f52337cae3b88c2a2338cd66f1f9d8ae86d0a993c2067a
+  md5: f4af8cf94d042b4dde487241bba1c457
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279780
+  timestamp: 1679500609851
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+  sha256: 48fe7373b012b51134b6b6ff67f18d2b4aae3a5c7700e4560ce002af7172f064
+  md5: 0379cd17692152c12b662b0e4ea46b88
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18008
+  timestamp: 1683824373128
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+  sha256: 803274d986d0c4e3b5ec1018747ede86ef57137455b3e44a60e834717eafb92b
+  md5: c9f134ddeff6fdf0373a45534ddb7079
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 273009
+  timestamp: 1713974722039
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+  sha256: 6fbcba97c1dcb5157afd23f264c3cff069c7e4be5ea55980fc349eb8dc2cb49e
+  md5: 8153e3f8b3283926bcf9403804a365f5
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65050
+  timestamp: 1711137009299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+  sha256: cd33dfee104dfbba4af38d06a09ccbae6a32e7c543afedab523303319ebb283d
+  md5: 3dfc19af0306d80921e1403f1f551bba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13679916
+  timestamp: 1676423267293
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+  sha256: 102ff1d958209e3648bb49da3503cf752abab822011fdc4e12e88145c9e73772
+  md5: 0553c2c381b6f5c836b23edc8c6db2ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 246689
+  timestamp: 1677708371873
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+  sha256: bee5c4d0f41f06a9c0aac636885e36e8b81116aafde980f9ea48fdb64abb5567
+  md5: 6c05a053240cb90765d6f8c2efdf905e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 182228
+  timestamp: 1698096268270
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+  sha256: ea39db411361d96545a04fb976940e9590147acb4ca9caacf7e8264780379347
+  md5: b411b8be8e53e5059949dde02dd07faf
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 565148
+  timestamp: 1709319072176
+- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+  sha256: 47653b45a5f2d97b5bf0dbf0e620908880f9078da427eef69012effe3f19af67
+  md5: 44e709ae67d89bccee2d4d46d358fee3
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74493
+  timestamp: 1699012356534
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.2-py311haa95532_0.tar.bz2
+  sha256: 8b9586873f05e6ce14c4e067efc0a61effc8d163d5129447515234a4c43b5f43
+  md5: 5fbd94c1f1e7c0a934eb8c9a00b34acb
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 122975
+  timestamp: 1716903247759
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+  sha256: d6daaa6b45272819176e4aeb467ae00e3db43386548464a9993688f292709d40
+  md5: 9fe721d7f7420c259df4f07d4503f654
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9683
+  timestamp: 1683077110211
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+  sha256: 6051860575f9448aea5799d74469c928cd7cdeeca1eb53657872262a77b1a7a8
+  md5: 60e193eca497130034facd5fed168249
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10094
+  timestamp: 1683059114376
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+  sha256: ecd310461c1b45ab92ddf15539cea5a6e837860561c974d2d7393f9a7933f116
+  md5: 1762fec2838763e904141167e18b0389
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 215600
+  timestamp: 1698947891859
+- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+  sha256: 6fd52bae6360fbc8135d72e0c1e4fd407769fa4d0f4b59356e7aed3e000eb339
+  md5: 49fd52885250da8aab17ed72e2e18b81
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88901
+  timestamp: 1699371435766
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+  sha256: a2ec4690bc07be9e7f3ad8e3003803eb4304a434d3f139633e2817318a9f7b20
+  md5: dd2d225219924fc5c36598c919541271
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1593050
+  timestamp: 1715025622141
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+  sha256: 5d1b7e14dc04816692de0f8518ea8fcbefb26ab61cec83f96f2c44c1bee67fab
+  md5: 505d2a70a875b5082dc857aa4dfab0d4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 18830
+  timestamp: 1705431395254
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+  sha256: 5ff3b4ac3fbce4dd67a87856c04698d0397deb0ac288ff4e7eb02fbab57f1253
+  md5: 0ca650a7001c6650809d3361de8cb005
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89590
+  timestamp: 1696347858925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+  sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
+  md5: 833b93a2daade3407898f15588945d83
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1440481
+  timestamp: 1714488344682
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tenacity-8.2.2-py311haa95532_0.tar.bz2
+  sha256: 2f689b3e7e3baab298c76332de10cdc3516ef2418618129235d507dffeb9e3f1
+  md5: 2b7a7629993c8c6b6842dc86df45d3b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 47488
+  timestamp: 1682972466477
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+  sha256: 78d89b50a29fbeb19a562f5dad95615e3f192bb4f3b86cd6ea75f2f825418232
+  md5: 4a4040df560ea47704e0898c4c015808
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38069
+  timestamp: 1678228553220
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+  sha256: 70a3cc4a4e81a6421bc19cd410d1d6064aadb2b1cce38b020f85e5346716d8e7
+  md5: 32a9a2539579a3d522dce3b5cb4f987b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49495
+  timestamp: 1676425411739
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+  sha256: 0a95736cfd0bb25fc201cd6be4a2450ea8fc30eeb349d861812675b84c94fa74
+  md5: a8a9fb30c6dd8e7a16d5dcd2333c3c49
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3844176
+  timestamp: 1714770894235
+- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+  sha256: ed5950ac0c12cc87f991a6f28112cf29057e2b7ad416ae4429a0b97c3efaf58c
+  md5: b5e2a04879e6fd19f0eb5effded4dc61
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135939
+  timestamp: 1676431438808
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.1-py311h827c3e9_0.tar.bz2
+  sha256: 04340cd171ff970c405b4b955f825cb52deb71f4420346596744bf36214ce431
+  md5: bbab95732695d5d4c759dfbd274a15ff
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 926984
+  timestamp: 1718740216876
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
+  sha256: 973dc7991dd5976ce2d27a94739712cac4d31f2d2958fbf23adb844f5ac999c8
+  md5: ca74b36907b3f4f8a51bd5b2e4d8220b
+  depends:
+  - colorama
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 186541
+  timestamp: 1716396206048
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
+  sha256: a724711191ac1226bf228eab49718eed7b5c7394f539294eb0f88baf8e7bb24d
+  md5: c78482e07d0aa6df9fcfa5b366dd87e3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 207744
+  timestamp: 1718227224929
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+  sha256: ab3cce654f1e94793fff0cb03b750d9b20cdbf099263b1906c3c5eaf8b347ab6
+  md5: c68ffc771312afb6f88b94c24d2bb689
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9706
+  timestamp: 1715268972001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+  sha256: 4089efea1753ebe2f6617b46cc368738f285b1d816d4a4f01ba71524f46851b4
+  md5: 7f610528ecd0b317180efa2058c32323
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 75414
+  timestamp: 1715268958140
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+  sha256: d091897f05318c22ca31028370f25355065999078f7db6f88ab27bf4cb030ec8
+  md5: 1776502c1cfb351554eeda6cddaf255f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11588
+  timestamp: 1676457729096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+  sha256: c16498f8238cc331618720d078b87995eceb6bbf20268a7a4e8efbf7b5859a9a
+  md5: 770432c0ca1ab9d99ffe95e51d3a3e74
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 517433
+  timestamp: 1713213261710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.2-py311haa95532_0.tar.bz2
+  sha256: e6b7f1cf269463c87bffbe808e88069c36ee0ff1d909e65d8986b914980ec0b9
+  md5: b5852f18c3edfcc6147cdaf96a1ecc99
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - zstandard >=0.18.0
+  - requests >=2.26.0
+  - selenium >=4.4.3
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 210228
+  timestamp: 1718912759694
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
+  sha256: 906048f3b1dc326b367a08edc91816ff523b5f06cd45d985b4dbb7cfe8017559
+  md5: e509c495aaa92d767d554cd43a990ee5
+  depends:
+  - vs2015_runtime >=14.29.30133
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8900
+  timestamp: 1715797316229
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
+  sha256: ab224d078734a23527716388ddffc034d18254843881d0fc068c2efa35bacfe1
+  md5: 73f5831d017e5572330d2459844718f3
+  size: 2246565
+  timestamp: 1715797302913
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+  sha256: 24ea3d3e0cb98d0d246338dbb4562b67967bb32002e3704e495a5c863476e831
+  md5: c7b9cdbe87b3c9720aeca1164a0fd6df
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26181
+  timestamp: 1676424437003
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+  sha256: 92d27e41ce34387e59acb47572fcb2e92c4defaeadafd11ce190226022023e69
+  md5: f1bf142d852987acbe4b0bc94e87d958
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145306
+  timestamp: 1715878654770
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+  sha256: 1b086d1b079fdb2f148c7dd82658f2b7f283c88f286e1216c0f1237319039b0f
+  md5: 299e87f151a549d86a48bf24df15c607
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 168041
+  timestamp: 1714717238470
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+  sha256: 17fadf35aa8917c107e7b369e9364ac7c09537776e7943d37e225e14b7026c94
+  md5: 0e67c3b9624540581b894b11267a837b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PUBLIC-DOMAIN
+  size: 10197
+  timestamp: 1676425485716
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+  sha256: b849b368e27920838fe40a512b102879693a55cb187dd1c8d3a83fa8c05a8054
+  md5: 7b1f6e9c71906a93039b3446b99a5498
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55114
+  timestamp: 1676434863173
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+  sha256: 344a5276a9928638dcde054dfe4e87c8cb40bd2d4d356378b9ab2f863ca62e4b
+  md5: fe471fd8b5a3d77be6fa5dbf9b99dafb
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 1432281
+  timestamp: 1714515119689
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+  sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
+  md5: e5aed81295b61b6d1eb62830799a0297
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 9125184
+  timestamp: 1705602328351
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+  sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
+  md5: f295b54ab59f5b8658e2a322ac6aa721
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 162161
+  timestamp: 1714514792081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+  sha256: b2ff66b7f6efa0831f939e57e562c244332b690af08818a540d1a97fa07d8525
+  md5: e548d528873d9a0006a36714cf36462a
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1933522
+  timestamp: 1714679197977

--- a/gapminders/pixi.toml
+++ b/gapminders/pixi.toml
@@ -21,12 +21,12 @@ param = ">=2.1.0"
 bokeh = ">=3.4.0"
 altair = ">=5.0.1"
 pandas = ">=2.2.1"
-pip = "*"
-setuptools = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+setuptools = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks.dashboard]
 cmd = "panel serve --rest-session-info --session-history -1 gapminders.ipynb --show"

--- a/gapminders/pixi.toml
+++ b/gapminders/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "gapminders"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/gapminders/pixi.toml
+++ b/gapminders/pixi.toml
@@ -1,0 +1,42 @@
+[workspace]
+name = "gapminders"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2018-01-01"
+maintainers = ["philippjfr"]
+categories = ["Economics", "Featured"]
+labels = ["panel", "altair", "hvplot", "bokeh", "plotly", "matplotlib"]
+description = "Using four different plotting libraries for the Hans Rosling gapminder example"
+
+[dependencies]
+python = "3.11.*"
+notebook = "<7"
+plotly = ">=5.19.0"
+holoviews = ">=1.18.3"
+hvplot = ">=0.9.2"
+panel = ">=1.4.2"
+param = ">=2.1.0"
+bokeh = ">=3.4.0"
+altair = ">=5.0.1"
+pandas = ">=2.2.1"
+pip = "*"
+setuptools = "*"
+wheel = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks.dashboard]
+cmd = "panel serve --rest-session-info --session-history -1 gapminders.ipynb --show"
+depends-on = ["download"]
+
+[tasks.notebook]
+cmd = "jupyter notebook gapminders.ipynb"
+depends-on = ["download"]
+
+[tasks.download]
+env = { FILENAME = "data/gapminders.csv" }
+cmd = "mkdir -p data && curl -fsSL -o $FILENAME https://raw.githubusercontent.com/plotly/datasets/5169d70627202f62d6ac983641541c76d26db861/gapminderDataFiveYear.csv"
+outputs = ["data/gapminders.csv"]

--- a/gene_profiling/pixi.lock
+++ b/gene_profiling/pixi.lock
@@ -1,0 +1,7811 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/nodefaults/
+    indexes:
+    - https://pypi.org/simple
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-25.1.0-py311h49ec1c0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb03c661_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb03c661_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311h1ddb823_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311h5b438cf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py311hdf67eae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/crc32c-2.7.1-py311haee01d2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.16-py311hc665b79_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.59.2-py311h3778330_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.1-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.14.0-nompi_py311h0b2f468_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h6e4c0c1_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.9-py311h724c32c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.17-h717163a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.44-h1423503_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.4-h3f801dc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-35_h4a7cf45_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb03c661_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb03c661_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb03c661_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-35_h0358290_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.14.1-h332b0f4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.24-h86f0d12_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.1-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.1-h73754d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.1.0-h69a702a_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.1.0-hcea5267_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.1-default_h7f8ec31_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.0-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-35_h47877c9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.67.0-had1ee68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.50-h421ea60_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.4-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-h8261f1e_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.1-he9a06e4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.0-ha9997c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.0-h26afc86_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.44.0-py311h1741904_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py311h2dc5d0c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.6-py311h0f3be63_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.1-py311hdf67eae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.61.2-py311h9806782_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.16.1-py311hed34c8f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.2.6-py311h5d046bc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.3-h55fea9a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.3-h26f9b46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.3.2-py311hed34c8f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.3.0-py311h3df08e7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.0.0-py311h49ec1c0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.13-h9e4cc4f_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h2dc5d0c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py311h2315fbb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.27.1-py311h902ca64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.7.2-py311hc3e1efb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.16.2-py311h1e13796_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.5-py311hb0beb2c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.2.0-hb60516a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.2-py311h49ec1c0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/umap-learn-0.5.9.post2-py311h38be061_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-16.0.0-py311h49ec1c0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py311h49ec1c0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h387f397_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py311haee01d2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anndata-0.12.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.10.0-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/array-api-compat-1.12.0-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.13.5-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyh29332c3_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.2.0-h82add2a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.8.3-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.8.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.18.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.2.18-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/donfig-0.8.1.post1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.5.0-pyhfa0c392_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.25.1-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.25.1-he01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.8.1-pyh31011fe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.0-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.17.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/legacy-api-wrap-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.1.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.5.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/natsort-8.4.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.3.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.5-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/patsy-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.22.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pynndescent-0.5.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.36.2-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/scanpy-1.11.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/session-info2-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20250822-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-3.1.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
+      - pypi: https://files.pythonhosted.org/packages/04/1e/b832de447dee8b582cac175871d2f6c3d5077cc56d5575cadba1fd1cccfa/linkify_it_py-2.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/31/fe563decfe3da71a97c9d8ff56bba6822f4ddb0b96feadbc8e579c337c15/panel_material_ui-0.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/13/5a/f8c0868199bbb231a02616286ce8a4ccb85f5387b9215510297dcfedd214/pyviz_comms-3.0.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/70/ae/44c4a6a4cbb496d93c6257954260fe3a6e91b7bed2240e5dad2a717f5111/markdown-3.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/8f/99214dc3d59d6aef171821dc8cc3dea34db8fafb962c98c34b1527a76e51/holoviews-1.22.0a0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8e/61/bc91751a2f7523279c881af11b8bda13f3cfba9f68a2b3a1e78961d92572/hv_anndata-0.0.3a2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e0/55/150c28bf3e50c7d65f763f7cc060740eada65817c40e6e5dead50fced228/panel-1.8.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anndata-0.12.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.10.0-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/array-api-compat-1.12.0-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.13.5-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyh29332c3_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.2.0-h82add2a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.8.3-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.8.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.18.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.2.18-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/donfig-0.8.1.post1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.5.0-pyhfa0c392_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.25.1-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.25.1-he01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.8.1-pyh31011fe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.0-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.17.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/legacy-api-wrap-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.1.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.5.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/natsort-8.4.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.3.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.5-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/patsy-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.22.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pynndescent-0.5.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.36.2-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/scanpy-1.11.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/session-info2-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20250822-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-3.1.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-25.1.0-py311h13e5629_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h1c43f85_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h1c43f85_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311h7b20566_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.5-hf13058a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.1-py311he66fa18_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.3-py311hd4d69bb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/crc32c-2.7.1-py311h179db11_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.16-py311hc651eee_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.59.2-py311hfbe4617_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.14.1-h694c41f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.14.0-nompi_py311h9f650d9_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.6-nompi_hc8237f9_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.9-py311ha94bed4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.17-h72f5680_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hcca01a6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.4-ha6bc127_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-35_he492b99_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h1c43f85_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h1c43f85_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h1c43f85_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-35_h9b27e0a_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.14.1-h5dec5d8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-21.1.1-h3d58e20_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.24-hcc1b750_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20250104-pl5321ha958ccf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.7.1-h21dd04a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.6-h281671d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libfreetype-2.14.1-h694c41f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libfreetype6-2.14.1-h6912278_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.1.0-h5f6db21_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.1.0-hfa3c126_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwloc-2.12.1-default_h094e1f9_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h57a12c2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.1.0-h6e16a3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-35_h859234e_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.1-hd471939_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.67.0-h3338091_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.30-openmp_h83c2472_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.50-h84aeda2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.50.4-h39a8b3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-hed3591d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-h59ddb5d_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.6.0-hb807250_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.0-ha1d9b0f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.0-h7b7ecba_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-21.1.0-hf4e0ed4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.44.0-py311hec21310_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.2-py311ha3cf9ac_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.10.6-py311h48d7e91_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.1.1-py311hd4d69bb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.61.2-py311hdda0fce_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numcodecs-0.16.1-py311hf4bc098_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.2.6-py311h27c81cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.3-h036ada5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.5.3-h230baf5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.3.2-py311hf4bc098_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.3.0-py311h0d39b4b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.0.0-py311h13e5629_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.1-py311h2f44256_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.1-py311hbc8e8a3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.13-h9ccd52b_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311ha3cf9ac_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-27.1.0-py311h0ab6910_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h7cca4af_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.27.1-py311hd3d88a1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.7.2-py311had5a2ce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.16.2-py311h32c7e5c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/statsmodels-0.14.5-py311ha2d3830_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tbb-2022.2.0-hc025b3e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hf689a15_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.5.2-py311h13e5629_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/umap-learn-0.5.9.post2-py311h6eed73b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-16.0.0-py311h13e5629_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.17.3-py311h13e5629_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.12-h6e16a3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h6c33b1e_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.25.0-py311h62e9434_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h8210216_2.conda
+      - pypi: https://files.pythonhosted.org/packages/04/1e/b832de447dee8b582cac175871d2f6c3d5077cc56d5575cadba1fd1cccfa/linkify_it_py-2.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/31/fe563decfe3da71a97c9d8ff56bba6822f4ddb0b96feadbc8e579c337c15/panel_material_ui-0.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/13/5a/f8c0868199bbb231a02616286ce8a4ccb85f5387b9215510297dcfedd214/pyviz_comms-3.0.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/70/ae/44c4a6a4cbb496d93c6257954260fe3a6e91b7bed2240e5dad2a717f5111/markdown-3.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/8f/99214dc3d59d6aef171821dc8cc3dea34db8fafb962c98c34b1527a76e51/holoviews-1.22.0a0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8e/61/bc91751a2f7523279c881af11b8bda13f3cfba9f68a2b3a1e78961d92572/hv_anndata-0.0.3a2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e0/55/150c28bf3e50c7d65f763f7cc060740eada65817c40e6e5dead50fced228/panel-1.8.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anndata-0.12.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.10.0-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/array-api-compat-1.12.0-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.13.5-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyh29332c3_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.2.0-h82add2a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.8.3-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.8.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.18.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.2.18-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/donfig-0.8.1.post1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.5.0-pyhfa0c392_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.25.1-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.25.1-he01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.8.1-pyh31011fe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.0-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.17.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/legacy-api-wrap-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.1.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.5.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/natsort-8.4.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.3.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.5-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/patsy-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.22.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pynndescent-0.5.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.36.2-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/scanpy-1.11.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/session-info2-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20250822-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-3.1.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-25.1.0-py311h3696347_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-h6caf38d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-h6caf38d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311hf719da1_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.5-h5505292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py311h146a0b8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.3-py311h57a9ea7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/crc32c-2.7.1-py311hb76fab6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.16-py311ha59bd64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.59.2-py311h2fe624c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.14.1-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.14.0-nompi_py311h1d03b57_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.6-nompi_he65715a_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py311h267d04e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.9-py311h63e5c0c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.17-h7eeda09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-hd64df32_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.4-h51d1e36_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-35_h51639a9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-h6caf38d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-h6caf38d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-h6caf38d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-35_hb0561ab_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.14.1-h73640d1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.1-hf598326_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.24-h5773f1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.1-hec049ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.1-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.14.1-h6da58f4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.1.0-hfdf1602_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.1.0-hb74de2c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.12.1-default_h48b22c3_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.1.0-h5505292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-35_hd9741b5_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.67.0-hc438710_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.30-openmp_h60d53f8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.50-h280e0eb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.50.4-h4237e3c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-h025e3ab_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.6.0-h07db88b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.0-h0ff4647_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.0-h9329255_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-21.1.0-hbb9b287_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.44.0-py311h674d19a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py311h4921393_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.10.6-py311h66dac5a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.1-py311h57a9ea7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.61.2-py311hdc76553_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numcodecs-0.16.1-py311hff7e5bb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.2.6-py311h762c074_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.3-h889cd5d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.5.3-h5503f6c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.3.2-py311hff7e5bb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.3.0-py311h3f9ac88_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.0.0-py311h3696347_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-11.1-py311hf0763de_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-11.1-py311hc5b188e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.13-hc22306f_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h4921393_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py311h13abfa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.27.1-py311h1c3fc1a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.7.2-py311h0f965f6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.16.2-py311h2734c94_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.5-py311h9dc9093_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2022.2.0-h5b2e6d4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.2-py311h3696347_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/umap-learn-0.5.9.post2-py311h267d04e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-16.0.0-py311h3696347_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.3-py311h3696347_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-h5505292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h888dc83_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py311h5bb9006_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_2.conda
+      - pypi: https://files.pythonhosted.org/packages/04/1e/b832de447dee8b582cac175871d2f6c3d5077cc56d5575cadba1fd1cccfa/linkify_it_py-2.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/31/fe563decfe3da71a97c9d8ff56bba6822f4ddb0b96feadbc8e579c337c15/panel_material_ui-0.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/13/5a/f8c0868199bbb231a02616286ce8a4ccb85f5387b9215510297dcfedd214/pyviz_comms-3.0.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/70/ae/44c4a6a4cbb496d93c6257954260fe3a6e91b7bed2240e5dad2a717f5111/markdown-3.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/8f/99214dc3d59d6aef171821dc8cc3dea34db8fafb962c98c34b1527a76e51/holoviews-1.22.0a0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8e/61/bc91751a2f7523279c881af11b8bda13f3cfba9f68a2b3a1e78961d92572/hv_anndata-0.0.3a2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e0/55/150c28bf3e50c7d65f763f7cc060740eada65817c40e6e5dead50fced228/panel-1.8.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anndata-0.12.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.10.0-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/array-api-compat-1.12.0-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.13.5-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyh29332c3_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.2.0-h82add2a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.8.3-h4c7d964_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.8.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.13-py311hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.18.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.2.18-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/donfig-0.8.1.post1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.5.0-pyh6be1c34_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.25.1-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.25.1-he01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.8.1-pyh5737063_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.0-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.17.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/legacy-api-wrap-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.1.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.5.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/natsort-8.4.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.3.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.5-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/patsy-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.22.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pynndescent-0.5.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.36.2-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/scanpy-1.11.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/session-info2-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20250822-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-3.1.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-25.1.0-py311h3485c13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-hfd05255_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-hfd05255_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311h3e6a449_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py311h3485c13_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.3-py311h3fd045d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/crc32c-2.7.1-py311hf893f09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.16-py311h5dfdfe8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.59.2-py311h3f79411_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.14.1-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.14.0-nompi_py311hc40ba4b_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.6-nompi_he30205f_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/icu-75.1-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.9-py311h275cad7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.17-hbcf6048_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h6470a55_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.4-h20038f6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-35_h5709861_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hfd05255_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hfd05255_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hfd05255_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-35_h2a3cdd5_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.14.1-h88aaa65_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.24-h76ddb4d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.1-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.6-h537db12_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libfreetype-2.14.1-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libfreetype6-2.14.1-hdbac1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-15.1.0-h1383e82_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-15.1.0-h1383e82_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.12.1-default_h64bd3f2_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.1.0-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-35_hf9ab0e9_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.50-h7351971_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.50.4-hf5d6505_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-h9aa295b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-h550210a_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.6.0-h4d5522a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-16-2.15.0-h06f855e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.15.0-ha29bfb0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/llvm-openmp-20.1.8-hfa2b4ca_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.44.0-py311h7c248df_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py311h5082efb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.10.6-py311h1675fdf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h57928b3_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.1-py311h3fd045d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.61.2-py311h7afb941_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numcodecs-0.16.1-py311h11fd7f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.2.6-py311h5e411d1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.3-h24db6dd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.5.3-h725018a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.3.2-py311h11fd7f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.3.0-py311h0f9b5fc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.0.0-py311h3485c13_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.13-h3f84c4b_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-311-py311hefeebc8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.15-py311hda3d55a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311h5082efb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-27.1.0-py311hb77b9c8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.27.1-py311hf51aa87_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.7.2-py311h8a15ebc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.16.2-py311h9a1c30b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/statsmodels-0.14.5-py311h17033d2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-h18a62a1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.5.2-py311h3485c13_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/umap-learn-0.5.9.post2-py311h1ea47a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-16.0.0-py311h3485c13_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_31.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_31.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_31.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.17.3-py311h3485c13_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.12-h0e40799_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.5-h0e40799_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-h5bddc39_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.25.0-py311hf893f09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-hbeecb71_2.conda
+      - pypi: https://files.pythonhosted.org/packages/04/1e/b832de447dee8b582cac175871d2f6c3d5077cc56d5575cadba1fd1cccfa/linkify_it_py-2.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/31/fe563decfe3da71a97c9d8ff56bba6822f4ddb0b96feadbc8e579c337c15/panel_material_ui-0.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/13/5a/f8c0868199bbb231a02616286ce8a4ccb85f5387b9215510297dcfedd214/pyviz_comms-3.0.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/70/ae/44c4a6a4cbb496d93c6257954260fe3a6e91b7bed2240e5dad2a717f5111/markdown-3.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/8f/99214dc3d59d6aef171821dc8cc3dea34db8fafb962c98c34b1527a76e51/holoviews-1.22.0a0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8e/61/bc91751a2f7523279c881af11b8bda13f3cfba9f68a2b3a1e78961d92572/hv_anndata-0.0.3a2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e0/55/150c28bf3e50c7d65f763f7cc060740eada65817c40e6e5dead50fced228/panel-1.8.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  license: None
+  size: 2562
+  timestamp: 1578324546067
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23621
+  timestamp: 1650670423406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-25.1.0-py311h49ec1c0_0.conda
+  sha256: d6d2f38ece253492a3e00800b5d4a5c2cc4b2de73b2c0fcc580c218f1cf58de6
+  md5: 112c5e2b7fe99e3678bbd64316d38f0c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.0.1
+  - libgcc >=14
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 35657
+  timestamp: 1753994819264
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb03c661_4.conda
+  sha256: 294526a54fa13635341729f250d0b1cf8f82cad1e6b83130304cbf3b6d8b74cc
+  md5: eaf3fbd2aa97c212336de38a51fe404e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli-bin 1.1.0 hb03c661_4
+  - libbrotlidec 1.1.0 hb03c661_4
+  - libbrotlienc 1.1.0 hb03c661_4
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 19883
+  timestamp: 1756599394934
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb03c661_4.conda
+  sha256: 444903c6e5c553175721a16b7c7de590ef754a15c28c99afbc8a963b35269517
+  md5: ca4ed8015764937c81b830f7f5b68543
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlidec 1.1.0 hb03c661_4
+  - libbrotlienc 1.1.0 hb03c661_4
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 19615
+  timestamp: 1756599385418
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311h1ddb823_4.conda
+  sha256: 318d4985acbf46457d254fbd6f0df80cc069890b5fc0013b3546d88eee1b1a1f
+  md5: 7138a06a7b0d11a23cfae323e6010a08
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 hb03c661_4
+  license: MIT
+  license_family: MIT
+  size: 354304
+  timestamp: 1756599521587
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
+  sha256: c30daba32ddebbb7ded490f0e371eae90f51e72db620554089103b4a6934b0d5
+  md5: 51a19bba1b8ebfb60df25cde030b7ebc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 260341
+  timestamp: 1757437258798
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.5-hb9d3cd8_0.conda
+  sha256: f8003bef369f57396593ccd03d08a8e21966157269426f71e943f96e4b579aeb
+  md5: f7f0d6cc2dc986d42ac2689ec88192be
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 206884
+  timestamp: 1744127994291
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311h5b438cf_1.conda
+  sha256: bbd04c8729e6400fa358536b1007c1376cc396d569b71de10f1df7669d44170e
+  md5: 82e0123a459d095ac99c76d150ccdacf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.4.6,<3.5.0a0
+  - libgcc >=14
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 303055
+  timestamp: 1756808613387
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py311hdf67eae_2.conda
+  sha256: cb35e53fc4fc2ae59c85303b0668d05fa3be9cd9f8b27a127882f47aa795895b
+  md5: bb6a0f88cf345f7e7a143d349dae6d9f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy >=1.25
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296784
+  timestamp: 1756544804579
+- conda: https://conda.anaconda.org/conda-forge/linux-64/crc32c-2.7.1-py311haee01d2_2.conda
+  sha256: 748dbb4c7a738e75ee5ac45dacc8ab670b63c5cc60a95f1dd6d3618d2cd7bb2a
+  md5: 9b04def27d786ab853536f133f909624
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  license: LGPL-2.1-or-later
+  size: 51845
+  timestamp: 1756602214713
+- conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.16-py311hc665b79_1.conda
+  sha256: 19b0d1d9b0459db1466ad5846f6a30408ca9bbe244dcbbf32708116b564ceb11
+  md5: 06e8c743932cc7788624128d08bc8806
+  depends:
+  - python
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2729957
+  timestamp: 1756742061937
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.59.2-py311h3778330_0.conda
+  sha256: f2685b212f3d84d2ba4fc89a03442724a94166ee8a9c1719efed0d7a07d474cb
+  md5: 5be2463c4d16a021dd571d7bf56ac799
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli
+  - libgcc >=14
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2934780
+  timestamp: 1756328826529
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.1-ha770c72_0.conda
+  sha256: bf8e4dffe46f7d25dc06f31038cacb01672c47b9f45201f065b0f4d00ab0a83e
+  md5: 4afc585cd97ba8a23809406cd8a9eda8
+  depends:
+  - libfreetype 2.14.1 ha770c72_0
+  - libfreetype6 2.14.1 h73754d4_0
+  license: GPL-2.0-only OR FTL
+  size: 173114
+  timestamp: 1757945422243
+- conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.14.0-nompi_py311h0b2f468_101.conda
+  sha256: f5d1955b90eb7060ee6f81bc39de0f4f8e28247b8fe810d70382b4fde9e0e1f9
+  md5: b3dd5deacc3147498b31366315fdc6cc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cached-property
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - libgcc >=14
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1358447
+  timestamp: 1756767156419
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h6e4c0c1_103.conda
+  sha256: 4f173af9e2299de7eee1af3d79e851bca28ee71e7426b377e841648b51d48614
+  md5: c74d83614aec66227ae5199d98852aaf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libaec >=1.1.4,<2.0a0
+  - libcurl >=8.14.1,<9.0a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3710057
+  timestamp: 1753357500665
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+  sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
+  md5: 8b189310083baabfb622af68fd9d3ae3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 12129203
+  timestamp: 1720853576813
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_2.conda
+  sha256: 4e744b30e3002b519c48868b3f5671328274d1d78cc8cbc0cda43057b570c508
+  md5: 5dd29601defbcc14ac6953d9504a80a7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18368
+  timestamp: 1756754243123
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+  sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
+  md5: b38117a3c920364aff79f870c984b4a3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  size: 134088
+  timestamp: 1754905959823
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.9-py311h724c32c_1.conda
+  sha256: 029a00a337e307256beab9cbaefc2c23cd28f040fff6f087703a63bc7487fc14
+  md5: 92720706b174926bc7238cc24f3b5956
+  depends:
+  - python
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78167
+  timestamp: 1756467524636
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+  sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
+  md5: 3f43953b7d3fb3aaa1d0d0723d91e368
+  depends:
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1370023
+  timestamp: 1719463201255
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.17-h717163a_0.conda
+  sha256: d6a61830a354da022eae93fa896d0991385a875c6bba53c82263a289deda9db8
+  md5: 000e85703f0fd9594c81710dd5066471
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 248046
+  timestamp: 1739160907615
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.44-h1423503_1.conda
+  sha256: 1a620f27d79217c1295049ba214c2f80372062fd251b569e9873d4a953d27554
+  md5: 0be7c6e070c19105f966d3758448d018
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - binutils_impl_linux-64 2.44
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 676044
+  timestamp: 1752032747103
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
+  sha256: 412381a43d5ff9bbed82cd52a0bbca5b90623f62e41007c9c42d3870c60945ff
+  md5: 9344155d33912347b37f0ae6c410a835
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 264243
+  timestamp: 1745264221534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.4-h3f801dc_0.conda
+  sha256: 410ab78fe89bc869d435de04c9ffa189598ac15bb0fe1ea8ace8fb1b860a2aa3
+  md5: 01ba04e414e47f95c03d6ddd81fd37be
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 36825
+  timestamp: 1749993532943
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-35_h4a7cf45_openblas.conda
+  sha256: 6cae2184069dd6527a405bc4a3de1290729f6f1c7a475fa4c937a6c02e05f058
+  md5: 6da7e852c812a84096b68158574398d0
+  depends:
+  - libopenblas >=0.3.30,<0.3.31.0a0
+  - libopenblas >=0.3.30,<1.0a0
+  constrains:
+  - blas 2.135   openblas
+  - liblapacke 3.9.0   35*_openblas
+  - mkl <2025
+  - liblapack  3.9.0   35*_openblas
+  - libcblas   3.9.0   35*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17153
+  timestamp: 1757446766752
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb03c661_4.conda
+  sha256: 2338a92d1de71f10c8cf70f7bb9775b0144a306d75c4812276749f54925612b6
+  md5: 1d29d2e33fe59954af82ef54a8af3fe1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 69333
+  timestamp: 1756599354727
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb03c661_4.conda
+  sha256: fcec0d26f67741b122f0d5eff32f0393d7ebd3ee6bb866ae2f17f3425a850936
+  md5: 5cb5a1c9a94a78f5b23684bcb845338d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.1.0 hb03c661_4
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 33406
+  timestamp: 1756599364386
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb03c661_4.conda
+  sha256: d42c7f0afce21d5279a0d54ee9e64a2279d35a07a90e0c9545caae57d6d7dc57
+  md5: 2e55011fa483edb8bfe3fd92e860cd79
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.1.0 hb03c661_4
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 289680
+  timestamp: 1756599375485
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-35_h0358290_openblas.conda
+  sha256: fb77db75b0bd50856a1d53edcfd70c3314cde7e7c7d87479ee9d6b7fdbe824f1
+  md5: 8aa3389d36791ecd31602a247b1f3641
+  depends:
+  - libblas 3.9.0 35_h4a7cf45_openblas
+  constrains:
+  - liblapacke 3.9.0   35*_openblas
+  - blas 2.135   openblas
+  - liblapack  3.9.0   35*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17149
+  timestamp: 1757446780072
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.14.1-h332b0f4_0.conda
+  sha256: b6c5cf340a4f80d70d64b3a29a7d9885a5918d16a5cb952022820e6d3e79dc8b
+  md5: 45f6713cb00f124af300342512219182
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libnghttp2 >=1.64.0,<2.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 449910
+  timestamp: 1749033146806
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.24-h86f0d12_0.conda
+  sha256: 8420748ea1cc5f18ecc5068b4f24c7a023cc9b20971c99c824ba10641fb95ddf
+  md5: 64f0c503da58ec25ebd359e4d990afa8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 72573
+  timestamp: 1747040452262
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+  sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
+  md5: c277e0a4d549b03ac1e9d6cbbe3d017b
+  depends:
+  - ncurses
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - ncurses >=6.5,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134676
+  timestamp: 1738479519902
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+  md5: 172bf1cd1ff8629f2b1179945ed45055
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 112766
+  timestamp: 1702146165126
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
+  sha256: da2080da8f0288b95dd86765c801c6e166c4619b910b11f9a8446fb852438dc2
+  md5: 4211416ecba1866fab0c6470986c22d6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - expat 2.7.1.*
+  license: MIT
+  license_family: MIT
+  size: 74811
+  timestamp: 1752719572741
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
+  sha256: 764432d32db45466e87f10621db5b74363a9f847d2b8b1f9743746cd160f06ab
+  md5: ede4673863426c0883c0063d853bbd85
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 57433
+  timestamp: 1743434498161
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.1-ha770c72_0.conda
+  sha256: 4641d37faeb97cf8a121efafd6afd040904d4bca8c46798122f417c31d5dfbec
+  md5: f4084e4e6577797150f9b04a4560ceb0
+  depends:
+  - libfreetype6 >=2.14.1
+  license: GPL-2.0-only OR FTL
+  size: 7664
+  timestamp: 1757945417134
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.1-h73754d4_0.conda
+  sha256: 4a7af818a3179fafb6c91111752954e29d3a2a950259c14a2fc7ba40a8b03652
+  md5: 8e7251989bca326a28f4a5ffbd74557a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libpng >=1.6.50,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - freetype >=2.14.1
+  license: GPL-2.0-only OR FTL
+  size: 386739
+  timestamp: 1757945416744
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_5.conda
+  sha256: 0caed73aac3966bfbf5710e06c728a24c6c138605121a3dacb2e03440e8baa6a
+  md5: 264fbfba7fb20acf3b29cde153e345ce
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 15.1.0 h767d61c_5
+  - libgcc-ng ==15.1.0=*_5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 824191
+  timestamp: 1757042543820
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_5.conda
+  sha256: f54bb9c3be12b24be327f4c1afccc2969712e0b091cdfbd1d763fb3e61cda03f
+  md5: 069afdf8ea72504e48d23ae1171d951c
+  depends:
+  - libgcc 15.1.0 h767d61c_5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 29187
+  timestamp: 1757042549554
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.1.0-h69a702a_5.conda
+  sha256: 4c1a526198d0d62441549fdfd668cc8e18e77609da1e545bdcc771dd8dc6a990
+  md5: 0c91408b3dec0b97e8a3c694845bd63b
+  depends:
+  - libgfortran5 15.1.0 hcea5267_5
+  constrains:
+  - libgfortran-ng ==15.1.0=*_5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 29169
+  timestamp: 1757042575979
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.1.0-hcea5267_5.conda
+  sha256: 9d06adc6d8e8187ddc1cad87525c690bc8202d8cb06c13b76ab2fc80a35ed565
+  md5: fbd4008644add05032b6764807ee2cba
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15.1.0
+  constrains:
+  - libgfortran 15.1.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1564589
+  timestamp: 1757042559498
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_5.conda
+  sha256: 125051d51a8c04694d0830f6343af78b556dd88cc249dfec5a97703ebfb1832d
+  md5: dcd5ff1940cd38f6df777cac86819d60
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 447215
+  timestamp: 1757042483384
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.1-default_h7f8ec31_1002.conda
+  sha256: f7fbc792dbcd04bf27219c765c10c239937b34c6c1a1f77a5827724753e02da1
+  md5: c01021ae525a76fe62720c7346212d74
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2450642
+  timestamp: 1757624375958
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+  sha256: c467851a7312765447155e071752d7bf9bf44d610a5687e32706f480aad2833f
+  md5: 915f5995e94f60e9a4826e0b0920ee88
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-only
+  size: 790176
+  timestamp: 1754908768807
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.0-hb9d3cd8_0.conda
+  sha256: 98b399287e27768bf79d48faba8a99a2289748c65cd342ca21033fab1860d4a4
+  md5: 9fa334557db9f63da6c9285fd2a48638
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 628947
+  timestamp: 1745268527144
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-35_h47877c9_openblas.conda
+  sha256: 5aceb67704af9185084ccdc8d841845df498a9af52783b858ceacd3e5b9e7dd8
+  md5: aa0b36b71d44f74686f13b9bfabec891
+  depends:
+  - libblas 3.9.0 35_h4a7cf45_openblas
+  constrains:
+  - liblapacke 3.9.0   35*_openblas
+  - blas 2.135   openblas
+  - libcblas   3.9.0   35*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17180
+  timestamp: 1757446792311
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
+  sha256: f2591c0069447bbe28d4d696b7fcb0c5bd0b4ac582769b89addbcf26fb3430d8
+  md5: 1a580f7796c7bf6393fddb8bbbde58dc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD
+  size: 112894
+  timestamp: 1749230047870
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.67.0-had1ee68_0.conda
+  sha256: a4a7dab8db4dc81c736e9a9b42bdfd97b087816e029e221380511960ac46c690
+  md5: b499ce4b026493a13774bcf0f4c33849
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - c-ares >=1.34.5,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 666600
+  timestamp: 1756834976695
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+  sha256: 927fe72b054277cde6cb82597d0fcf6baf127dcbce2e0a9d8925a68f1265eef5
+  md5: d864d34357c3b65a4b731f78c0801dc4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-only
+  license_family: GPL
+  size: 33731
+  timestamp: 1750274110928
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_2.conda
+  sha256: 1b51d1f96e751dc945cc06f79caa91833b0c3326efe24e9b506bd64ef49fc9b0
+  md5: dfc5aae7b043d9f56ba99514d5e60625
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  constrains:
+  - openblas >=0.3.30,<0.3.31.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5938936
+  timestamp: 1755474342204
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.50-h421ea60_1.conda
+  sha256: e75a2723000ce3a4b9fd9b9b9ce77553556c93e475a4657db6ed01abc02ea347
+  md5: 7af8e91b0deb5f8e25d1a595dea79614
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 317390
+  timestamp: 1753879899951
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
+  sha256: 0105bd108f19ea8e6a78d2d994a6d4a8db16d19a41212070d2d1d48a63c34161
+  md5: a587892d3c13b6621a6091be690dbca2
+  depends:
+  - libgcc-ng >=12
+  license: ISC
+  size: 205978
+  timestamp: 1716828628198
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.4-h0c1763c_0.conda
+  sha256: 6d9c32fc369af5a84875725f7ddfbfc2ace795c28f246dc70055a79f9b2003da
+  md5: 0b367fad34931cb79e0d6b7e5c06bb1c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: blessing
+  size: 932581
+  timestamp: 1753948484112
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+  sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
+  md5: eecce068c7e4eddeb169591baac20ac4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 304790
+  timestamp: 1745608545575
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_5.conda
+  sha256: 0f5f61cab229b6043541c13538d75ce11bd96fb2db76f94ecf81997b1fde6408
+  md5: 4e02a49aaa9d5190cb630fa43528fbe6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 15.1.0 h767d61c_5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3896432
+  timestamp: 1757042571458
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_5.conda
+  sha256: 7b8cabbf0ab4fe3581ca28fe8ca319f964078578a51dd2ca3f703c1d21ba23ff
+  md5: 8bba50c7f4679f08c861b597ad2bda6b
+  depends:
+  - libstdcxx 15.1.0 h8f9b012_5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 29233
+  timestamp: 1757042603319
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-h8261f1e_6.conda
+  sha256: c62694cd117548d810d2803da6d9063f78b1ffbf7367432c5388ce89474e9ebe
+  md5: b6093922931b535a7ba566b6f384fbe6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.24,<1.26.0a0
+  - libgcc >=14
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libstdcxx >=14
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: HPND
+  size: 433078
+  timestamp: 1755011934951
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.1-he9a06e4_0.conda
+  sha256: 776e28735cee84b97e4d05dd5d67b95221a3e2c09b8b13e3d6dbe6494337d527
+  md5: af930c65e9a79a3423d6d36e265cef65
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37087
+  timestamp: 1757334557450
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+  sha256: 3aed21ab28eddffdaf7f804f49be7a7d701e8f0e46c856d801270b470820a37b
+  md5: aea31d2e5b1091feca96fcfe945c3cf9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - libwebp 1.6.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 429011
+  timestamp: 1752159441324
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+  sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
+  md5: 92ed62436b625154323d40d5f2f11dd7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 395888
+  timestamp: 1727278577118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
+  md5: 5aa797f8787fe7a17d1b0821485b5adc
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 100393
+  timestamp: 1702724383534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.0-ha9997c6_0.conda
+  sha256: fba83a62276fb3d885e689afc7650b255a93d6e001ceacaccef4e36bbcb9d545
+  md5: 84bed2bfefc14e4878bd16979782e522
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - libxml2 2.15.0
+  license: MIT
+  license_family: MIT
+  size: 559002
+  timestamp: 1757953263066
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.0-h26afc86_0.conda
+  sha256: 09b6703783b2ac600794f7eb2bb5d9e8753a2de607735414e3dbd46d95b17a4c
+  md5: c52b54db4660b44ca75b6a61c533b9f5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libxml2-16 2.15.0 ha9997c6_0
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 45279
+  timestamp: 1757953270047
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
+  md5: edb0dca6bc32e4f4789199455a1dbeb8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 60963
+  timestamp: 1727963148474
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.44.0-py311h1741904_2.conda
+  sha256: d11b4d4591b870f0984d608559d0a38838d8d31537623fd5d8d26b8662941e4b
+  md5: 35932aa71ba077a5a162499488bc4dbf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30034949
+  timestamp: 1756303885481
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py311h2dc5d0c_1.conda
+  sha256: 0291d90706ac6d3eea73e66cd290ef6d805da3fad388d1d476b8536ec92ca9a8
+  md5: 6565a715337ae279e351d0abd8ffe88a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25354
+  timestamp: 1733219879408
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.6-py311h0f3be63_1.conda
+  sha256: 504ff6c8b4d5fba670b9b518d6e4ed7149a9c3682cb495fe9f87c79d387b2992
+  md5: 65ddf155ea43aa3bb366cb03ddf3436a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype
+  - kiwisolver >=1.3.1
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy >=1.23
+  - numpy >=1.23,<3
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  - tk >=8.6.13,<8.7.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8484360
+  timestamp: 1756869716686
+  purls:
+  - pkg:pypi/matplotlib?source=hash-mapping
+- conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.1-py311hdf67eae_1.conda
+  sha256: 8cbad527b1e5d5ed6c009661b692d3870e5cbf61c3accad28125c88b3636ab17
+  md5: d2494f7b8cbb0c6e9adb866c3d7a883f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 103624
+  timestamp: 1756678682315
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+  sha256: 3fde293232fa3fca98635e1167de6b7c7fda83caf24b9d6c91ec9eefb4f4d586
+  md5: 47e340acb35de30501a76c7c799c41d7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: X11 AND BSD-3-Clause
+  size: 891641
+  timestamp: 1738195959188
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.61.2-py311h9806782_1.conda
+  sha256: e822e0cb85a54d51d321897c5da3039788406f80d21e62a7bce01d1cade7c2f3
+  md5: 9b72f3bfefed2f5fa1cdb01e8110b571
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - libgcc >=13
+  - libstdcxx >=13
+  - llvmlite >=0.44.0,<0.45.0a0
+  - numpy >=1.21,<3
+  - numpy >=1.24,<2.3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libopenblas !=0.3.6
+  - tbb >=2021.6.0
+  - cudatoolkit >=11.2
+  - cuda-version >=11.2
+  - scipy >=1.0
+  - cuda-python >=11.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6033700
+  timestamp: 1749491483377
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.16.1-py311hed34c8f_1.conda
+  sha256: 394ba61aa08c0403d834ea28380fe3b58e9bd74da75012f21208a3b65db0119a
+  md5: 57479325cf442221eab67985b58f5fc6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - deprecated
+  - libgcc >=14
+  - libstdcxx >=14
+  - msgpack-python
+  - numpy >=1.23,<3
+  - numpy >=1.24
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - typing_extensions
+  license: MIT
+  license_family: MIT
+  size: 823259
+  timestamp: 1756542922354
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.2.6-py311h5d046bc_0.conda
+  sha256: f28273a72d25f4d7d62a9ba031d5271082afc498121bd0f6783d72b4103dbbc7
+  md5: babce4d9841ebfcee64249d98eb4e0d4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9068997
+  timestamp: 1747545091884
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.3-h55fea9a_1.conda
+  sha256: 0b7396dacf988f0b859798711b26b6bc9c6161dca21bacfd778473da58730afa
+  md5: 01243c4aaf71bde0297966125aea4706
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libpng >=1.6.50,<1.7.0a0
+  - libstdcxx >=14
+  - libtiff >=4.7.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 357828
+  timestamp: 1754297886899
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.3-h26f9b46_0.conda
+  sha256: 8c313f79fd9408f53922441fbb4e38f065e2251840f86862f05bdf613da7980f
+  md5: 72b3dd72e4f0b88cdacf3421313480f0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  size: 3136554
+  timestamp: 1758040407921
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.3.2-py311hed34c8f_0.conda
+  sha256: ac5372b55c12644ba4bab81270bb294fb70197f86c9b3ede57dfe367ecc6f198
+  md5: f98711aba4ad00ea3c286dcea5f57c1f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy >=1.22.4
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1
+  constrains:
+  - pyqt5 >=5.15.9
+  - pyarrow >=10.0.1
+  - s3fs >=2022.11.0
+  - xlrd >=2.0.1
+  - numexpr >=2.8.4
+  - openpyxl >=3.1.0
+  - pyreadstat >=1.2.0
+  - zstandard >=0.19.0
+  - bottleneck >=1.3.6
+  - python-calamine >=0.1.7
+  - fastparquet >=2022.12.0
+  - psycopg2 >=2.9.6
+  - html5lib >=1.1
+  - numba >=0.56.4
+  - lxml >=4.9.2
+  - odfpy >=1.4.1
+  - xlsxwriter >=3.0.5
+  - pytables >=3.8.0
+  - pandas-gbq >=0.19.0
+  - sqlalchemy >=2.0.0
+  - blosc >=1.21.3
+  - pyxlsb >=1.0.10
+  - tabulate >=0.9.0
+  - tzdata >=2022.7
+  - gcsfs >=2022.11.0
+  - fsspec >=2022.11.0
+  - scipy >=1.10.0
+  - beautifulsoup4 >=4.11.2
+  - qtpy >=2.3.0
+  - matplotlib >=3.6.3
+  - xarray >=2022.12.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15354460
+  timestamp: 1755779368955
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.3.0-py311h3df08e7_2.conda
+  sha256: a81a80f78fd4ee6d316165ce3e04b449b54c971b646ff461bd274b80ba2eb97f
+  md5: 54537a0323ab81bb3ec8f7d52a956556
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freetype
+  - lcms2 >=2.17,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libgcc >=14
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.3,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 993340
+  timestamp: 1758012793374
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.0.0-py311h49ec1c0_1.conda
+  sha256: 729720d777b14329af411220fd305f78e8914356f963af0053420e1cf5e58a53
+  md5: d30c3f3b089100634f93e97e5ee3aa85
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 483612
+  timestamp: 1755851438911
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+  sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
+  md5: b3c17d95b5a10c6e64a21fa17573e70e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 8252
+  timestamp: 1726802366959
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.13-h9e4cc4f_0_cpython.conda
+  sha256: 9979a7d4621049388892489267139f1aa629b10c26601ba5dce96afc2b1551d4
+  md5: 8c399445b6dc73eab839659e6c7b5ad1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.7.0,<3.0a0
+  - libffi >=3.4.6,<3.5.0a0
+  - libgcc >=13
+  - liblzma >=5.8.1,<6.0a0
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.50.0,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.5.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 30629559
+  timestamp: 1749050021812
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h2dc5d0c_2.conda
+  sha256: d107ad62ed5c62764fba9400f2c423d89adf917d687c7f2e56c3bfed605fb5b3
+  md5: 014417753f948da1f70d132b2de573be
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 213136
+  timestamp: 1737454846598
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py311h2315fbb_0.conda
+  sha256: 719104f31c414166a20281c973b6e29d1a2ab35e7930327368949895b8bc5629
+  md5: 6c87a0f4566469af3585b11d89163fd7
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - zeromq >=4.3.5,<4.4.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 386618
+  timestamp: 1757387012835
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+  sha256: 776363493bad83308ba30bcb88c2552632581b143e8ee25b1982c8c743e73abc
+  md5: 353823361b1d27eb3960efb076dfcaf6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-Qhull
+  size: 552937
+  timestamp: 1720813982144
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
+  sha256: 2d6d0c026902561ed77cd646b5021aef2d4db22e57a5b0178dfc669231e06d2c
+  md5: 283b96675859b20a825f8fa30f311446
+  depends:
+  - libgcc >=13
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 282480
+  timestamp: 1740379431762
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.27.1-py311h902ca64_1.conda
+  sha256: d9bc1564949ede4abd32aea34cf1997d704b6091e547f255dc0168996f5d5ec8
+  md5: 622c389c080689ba1575a0750eb0209d
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  size: 387057
+  timestamp: 1756737832651
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.7.2-py311hc3e1efb_0.conda
+  sha256: c10973e92f71d6a1277a29d3abffefc9ed4b27854b1e3144e505844d7e0a3fe7
+  md5: 3f5b4f552d1ef2a5fdc2a4e25db2ee9a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - joblib >=1.2.0
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy >=1.22.0
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scipy >=1.8.0
+  - threadpoolctl >=3.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9785405
+  timestamp: 1757406401803
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.16.2-py311h1e13796_0.conda
+  sha256: e87176da9a36babfb2f65ca1143050b07581efea67368999808378c1c96163fd
+  md5: 124834cd571d0174ad1c22701ab63199
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=14
+  - numpy <2.6
+  - numpy >=1.23,<3
+  - numpy >=1.25.2
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17289352
+  timestamp: 1757682174416
+- conda: https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.5-py311hb0beb2c_0.conda
+  sha256: 766186eb4ff37a69479ec0695df9d7b775a8fd79b8ded727a1963cc1bedcfc80
+  md5: 763f2b77d523c8662fa8a4fcabc4ef36
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy <3,>=1.22.3
+  - numpy >=1.23,<3
+  - packaging >=21.3
+  - pandas !=2.1.0,>=1.4
+  - patsy >=0.5.6
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scipy !=1.9.2,>=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12015823
+  timestamp: 1751917868394
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.2.0-hb60516a_1.conda
+  sha256: 105a12b00e407aaaf04d811d3e737d470fd9e9328bc9a6a57f0f3fea5a486e84
+  md5: 29ed2be4b47b5aa1b07689e12407fbfd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libhwloc >=2.12.1,<2.12.2.0a0
+  - libstdcxx >=14
+  license: Apache-2.0
+  license_family: APACHE
+  size: 183204
+  timestamp: 1755775909376
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
+  sha256: a84ff687119e6d8752346d1d408d5cf360dee0badd487a472aa8ddedfdc219e1
+  md5: a0116df4f4ed05c303811a837d5b39d8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: TCL
+  license_family: BSD
+  size: 3285204
+  timestamp: 1748387766691
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.2-py311h49ec1c0_1.conda
+  sha256: b1d686806d6b913e42aadb052b12d9cc91aae295640df3acfef645142fc33b3d
+  md5: 18a98f4444036100d78b230c94453ff4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 868049
+  timestamp: 1756855060036
+- conda: https://conda.anaconda.org/conda-forge/linux-64/umap-learn-0.5.9.post2-py311h38be061_0.conda
+  sha256: c00faf815359495beaeb2fdefc001c85076c8f5769c1301e09cf4632725589ae
+  md5: d024e9d8b8590f9366f5abab7038e697
+  depends:
+  - numba >=0.51.2
+  - numpy >=1.17
+  - pynndescent >=0.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scikit-learn >=0.22
+  - scipy >=1.3.1
+  - setuptools
+  - tbb >=2019.0
+  - tqdm
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 196112
+  timestamp: 1751544372477
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-16.0.0-py311h49ec1c0_1.conda
+  sha256: e2715a04632d75de539c1510238886ff1d6fc5b7e9e2ec240d8c11c175c1fffd
+  md5: 3457bd5c93b085bec51cdab58fbd1882
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 405256
+  timestamp: 1756494610217
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py311h49ec1c0_1.conda
+  sha256: efcb41a300b58624790d2ce1c6ac9c1da7d23dd91c3d329bd22853866f8f8533
+  md5: 47c1c27dee6c31bf8eefbdbdde817d83
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 65464
+  timestamp: 1756851731483
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb9d3cd8_0.conda
+  sha256: ed10c9283974d311855ae08a16dfd7e56241fac632aec3b92e3cfe73cff31038
+  md5: f6ebe2cb3f82ba6c057dde5d9debe4f7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 14780
+  timestamp: 1734229004433
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+  sha256: 6b250f3e59db07c2514057944a3ea2044d6a8cdde8a47b6497c254520fade1ee
+  md5: 8035c64cb77ed555e3f150b7b3972480
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 19901
+  timestamp: 1727794976192
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
+  sha256: 6d9ea2f731e284e9316d95fa61869fe7bbba33df7929f82693c121022810f4ad
+  md5: a77f85f77be52ff59391544bfe73390a
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  license_family: MIT
+  size: 85189
+  timestamp: 1753484064210
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h387f397_9.conda
+  sha256: 47cfe31255b91b4a6fa0e9dbaf26baa60ac97e033402dbc8b90ba5fee5ffe184
+  md5: 8035e5b54c08429354d5d64027041cad
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 310648
+  timestamp: 1757370847287
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py311haee01d2_0.conda
+  sha256: ed149760ea78e038e6424d8a327ea95da351727536c0e9abedccf5a61fc19932
+  md5: 0fd242142b0691eb9311dc32c1d4ab76
+  depends:
+  - python
+  - cffi >=1.11
+  - zstd >=1.5.7,<1.5.8.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 466651
+  timestamp: 1757930101225
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
+  sha256: a4166e3d8ff4e35932510aaff7aa90772f84b4d07e9f6f83c614cba7ceefe0eb
+  md5: 6432cb5d4ac0046c3ac0a8a0f95842f9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 567578
+  timestamp: 1742433379869
+- conda: https://conda.anaconda.org/conda-forge/noarch/anndata-0.12.2-pyhd8ed1ab_0.conda
+  sha256: 2cff0e6978b1216c0635c309b56f9d910684d0e072d0ef3b4728118f1b5c22c0
+  md5: fe01453b9202574809a0e6f68123751c
+  depends:
+  - array-api-compat >=1.7.1
+  - h5py >=3.8
+  - legacy-api-wrap
+  - natsort
+  - numpy >=1.26
+  - packaging >=24.2
+  - pandas >=2.1.0,!=2.1.2
+  - python >=3.11
+  - scipy >=1.12
+  - zarr >=2.18.7,!=3.0.*
+  constrains:
+  - awkward >=2.3.2
+  - xarray >=2025.06.1
+  - dask[array] >=2023.5.1,!=2024.8.*,!=2024.9.*,<2025.2.0
+  - pyarrow <21
+  - pandas<3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 131604
+  timestamp: 1754995412070
+- conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.10.0-pyhe01879c_0.conda
+  sha256: d1b50686672ebe7041e44811eda563e45b94a8354db67eca659040392ac74d63
+  md5: cc2613bfa71dec0eb2113ee21ac9ccbf
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.9
+  - sniffio >=1.1
+  - typing_extensions >=4.5
+  - python
+  constrains:
+  - trio >=0.26.1
+  - uvloop >=0.21
+  license: MIT
+  license_family: MIT
+  size: 134857
+  timestamp: 1754315087747
+- conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
+  sha256: 8f032b140ea4159806e4969a68b4a3c0a7cab1ad936eb958a2b5ffe5335e19bf
+  md5: 54898d0f524c9dee622d44bbb081a8ab
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 10076
+  timestamp: 1733332433806
+- conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
+  sha256: bea62005badcb98b1ae1796ec5d70ea0fc9539e7d59708ac4e7d41e2f4bb0bad
+  md5: 8ac12aff0860280ee0cff7fa2cf63f3b
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.9
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 18715
+  timestamp: 1749017288144
+- conda: https://conda.anaconda.org/conda-forge/noarch/array-api-compat-1.12.0-pyhe01879c_0.conda
+  sha256: 259b8e21ee0ce8f2cdcee9df7ba9b7e53d1b4aa2d252946acf5108e03d5d7b5e
+  md5: b656a1f58a53e7b6f5d4588d9b19e7b0
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 45821
+  timestamp: 1747403732947
+- conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_1.conda
+  sha256: c4b0bdb3d5dee50b60db92f99da3e4c524d5240aafc0a5fcc15e45ae2d1a3cd1
+  md5: 46b53236fdd990271b03c3978d4218a9
+  depends:
+  - python >=3.9
+  - python-dateutil >=2.7.0
+  - types-python-dateutil >=2.8.10
+  license: Apache-2.0
+  license_family: Apache
+  size: 99951
+  timestamp: 1733584345583
+- conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+  sha256: 93b14414b3b3ed91e286e1cbe4e7a60c4e1b1c730b0814d1e452a8ac4b9af593
+  md5: 8f587de4bcf981e26228f268df374a9b
+  depends:
+  - python >=3.9
+  constrains:
+  - astroid >=2,<4
+  license: Apache-2.0
+  license_family: Apache
+  size: 28206
+  timestamp: 1733250564754
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
+  sha256: 99c53ffbcb5dc58084faf18587b215f9ac8ced36bbfb55fa807c00967e419019
+  md5: a10d11958cadc13fdb43df75f8b1903f
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 57181
+  timestamp: 1741918625732
+- conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.13.5-pyha770c72_0.conda
+  sha256: d2124c0ea13527c7f54582269b3ae19541141a3740d6d779e7aa95aa82eaf561
+  md5: de0fd9702fd4c1186e930b8c35af6b6b
+  depends:
+  - python >=3.10
+  - soupsieve >=1.2
+  - typing-extensions
+  license: MIT
+  license_family: MIT
+  size: 88278
+  timestamp: 1756094375546
+- conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyh29332c3_4.conda
+  sha256: a05971bb80cca50ce9977aad3f7fc053e54ea7d5321523efc7b9a6e12901d3cd
+  md5: f0b4c8e370446ef89797608d60a564b3
+  depends:
+  - python >=3.9
+  - webencodings
+  - python
+  constrains:
+  - tinycss >=1.1.0,<1.5
+  license: Apache-2.0 AND MIT
+  size: 141405
+  timestamp: 1737382993425
+- conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.2.0-h82add2a_4.conda
+  sha256: 0aba699344275b3972bd751f9403316edea2ceb942db12f9f493b63c74774a46
+  md5: a30e9406c873940383555af4c873220d
+  depends:
+  - bleach ==6.2.0 pyh29332c3_4
+  - tinycss2
+  license: Apache-2.0 AND MIT
+  size: 4213
+  timestamp: 1737382993425
+- conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.8.0-pyhd8ed1ab_0.conda
+  sha256: 3a0af5b0c30d1e50cda6fea8c7783f3ea925e83f427b059fa81b2f36cde72e28
+  md5: 30698cfea774ec175babb8ff08dbc07a
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - narwhals >=1.13
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.10
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5020661
+  timestamp: 1756543232734
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.8.3-h4c7d964_0.conda
+  sha256: 3b82f62baad3fd33827b01b0426e8203a2786c8f452f633740868296bcbe8485
+  md5: c9e0c0f82f6e63323827db462b40ede8
+  depends:
+  - __win
+  license: ISC
+  size: 154489
+  timestamp: 1754210967212
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.8.3-hbd8a1cb_0.conda
+  sha256: 837b795a2bb39b75694ba910c13c15fa4998d4bb2a622c214a6a5174b2ae53d1
+  md5: 74784ee3d225fc3dca89edb635b4e5cc
+  depends:
+  - __unix
+  license: ISC
+  size: 154402
+  timestamp: 1754210968730
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+  sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
+  md5: 9b347a7ec10940d3f7941ff6c460b551
+  depends:
+  - cached_property >=1.5.2,<1.5.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4134
+  timestamp: 1615209571450
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+  sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+  md5: 576d629e47797577ab0f1b351297ef4a
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11065
+  timestamp: 1615209567874
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.8.3-pyhd8ed1ab_0.conda
+  sha256: a1ad5b0a2a242f439608f22a538d2175cac4444b7b3f4e2b8c090ac337aaea40
+  md5: 11f59985f49df4620890f3e746ed7102
+  depends:
+  - python >=3.9
+  license: ISC
+  size: 158692
+  timestamp: 1754231530168
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.3-pyhd8ed1ab_0.conda
+  sha256: 838d5a011f0e7422be6427becba3de743c78f3874ad2743c341accbba9bb2624
+  md5: 7e7d5ef1b9ed630e4a1c358d6bc62284
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 51033
+  timestamp: 1754767444665
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
+  md5: 962b9857ee8e7018c22f2776ffa0b2d7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27011
+  timestamp: 1733218222191
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_1.conda
+  sha256: 46055a0524ed3a48b23cd27a52246c89ac059ccce90a50b2eeb84d2f833ae827
+  md5: 91d7152c744dc0f18ef8beb3cbc9980a
+  depends:
+  - python >=3.9
+  license: CC-BY-4.0
+  size: 173950
+  timestamp: 1734007415513
+- conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
+  sha256: 576a44729314ad9e4e5ebe055fbf48beb8116b60e58f9070278985b2b634f212
+  md5: 2da13f2b299d8e1995bafbbe9689a2f7
+  depends:
+  - python >=3.9
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14690
+  timestamp: 1753453984907
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.13-py311hd8ed1ab_0.conda
+  sha256: ab70477f5cfb60961ba27d84a4c933a24705ac4b1736d8f3da14858e95bbfa7a
+  md5: 4666fd336f6d48d866a58490684704cd
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi * *_cp311
+  license: Python-2.0
+  size: 47495
+  timestamp: 1749048148121
+- conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+  sha256: 9827efa891e507a91a8a2acf64e210d2aff394e1cde432ad08e1f8c66b12293c
+  md5: 44600c4667a319d67dbe0681fc0bc833
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13399
+  timestamp: 1733332563512
+- conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.18.2-pyhd8ed1ab_0.conda
+  sha256: afa4c88adcd3242acb4a6e271c8af60df1e21262ff656bb8e8cbbf97b473c4c1
+  md5: 7202ca262fc28025443238271066d88b
+  depends:
+  - colorcet
+  - multipledispatch
+  - numba
+  - numpy
+  - packaging
+  - pandas
+  - param
+  - pyct
+  - python >=3.10
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17240471
+  timestamp: 1754389607986
+- conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
+  sha256: c17c6b9937c08ad63cb20a26f403a3234088e57d4455600974a0ce865cb14017
+  md5: 9ce473d1d1be1cc3810856a48b3fab32
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14129
+  timestamp: 1740385067843
+- conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
+  md5: 961b3a227b437d82ad7054484cfa71b2
+  depends:
+  - python >=3.6
+  license: PSF-2.0
+  license_family: PSF
+  size: 24062
+  timestamp: 1615232388757
+- conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.2.18-pyhd8ed1ab_0.conda
+  sha256: d614bcff10696f1efc714df07651b50bf3808401fcc03814309ecec242cc8870
+  md5: 0cef44b1754ae4d6924ac0eef6b9fdbe
+  depends:
+  - python >=3.9
+  - wrapt <2,>=1.10
+  license: MIT
+  license_family: MIT
+  size: 14382
+  timestamp: 1737987072859
+- conda: https://conda.anaconda.org/conda-forge/noarch/donfig-0.8.1.post1-pyhd8ed1ab_1.conda
+  sha256: d58e97d418f71703e822c422af5b9c431e3621a0ecdc8b0334c1ca33e076dfe7
+  md5: c56a7fa5597ad78b62e1f5d21f7f8b8f
+  depends:
+  - python >=3.9
+  - pyyaml
+  license: MIT
+  license_family: MIT
+  size: 22491
+  timestamp: 1734368817583
+- conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+  sha256: 80f579bfc71b3dab5bef74114b89e26c85cb0df8caf4c27ab5ffc16363d57ee7
+  md5: 3366592d3c219f2731721f11bc93755c
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 11259
+  timestamp: 1733327239578
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
+  sha256: ce61f4f99401a4bd455b89909153b40b9c823276aefcbb06f2044618696009ca
+  md5: 72e42d28960d875c7654614f8b50939a
+  depends:
+  - python >=3.9
+  - typing_extensions >=4.6.0
+  license: MIT and PSF-2.0
+  size: 21284
+  timestamp: 1746947398083
+- conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
+  sha256: 210c8165a58fdbf16e626aac93cc4c14dbd551a01d1516be5ecad795d2422cad
+  md5: ff9efb7f7469aed3c4a8106ffa29593c
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 30753
+  timestamp: 1756729456476
+- conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+  sha256: 2509992ec2fd38ab27c7cdb42cf6cadc566a1cc0d1021a2673475d9fa87c6276
+  md5: d3549fd50d450b6d9e7dddff25dd2110
+  depends:
+  - cached-property >=1.3.0
+  - python >=3.9,<4
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 16705
+  timestamp: 1733327494780
+- conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+  sha256: 84c64443368f84b600bfecc529a1194a3b14c3656ee2e832d15a20e0329b6da3
+  md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
+  depends:
+  - python >=3.10
+  - hyperframe >=6.1,<7
+  - hpack >=4.1,<5
+  - python
+  license: MIT
+  license_family: MIT
+  size: 95967
+  timestamp: 1756364871835
+- conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+  sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+  md5: 0a802cb9888dd14eeefc611f05c40b6e
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 30731
+  timestamp: 1737618390337
+- conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+  sha256: 77af6f5fe8b62ca07d09ac60127a30d9069fdc3c68d6b256754d0ffb1f7779f8
+  md5: 8e6923fc12f1fe8f8c4e5c9f343256ac
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 17397
+  timestamp: 1737618427549
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+  sha256: d7a472c9fd479e2e8dcb83fb8d433fce971ea369d704ece380e876f9c3494e87
+  md5: 39a4f67be3286c86d696df570b1201b7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49765
+  timestamp: 1733211921194
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+  sha256: c18ab120a0613ada4391b15981d86ff777b5690ca461ea7e9e49531e8f374745
+  md5: 63ccfdc3a3ce25b027b8767eb722fca8
+  depends:
+  - python >=3.9
+  - zipp >=3.20
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 34641
+  timestamp: 1747934053147
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+  sha256: 33cfd339bb4efac56edf93474b37ddc049e08b1b4930cf036c893cc1f5a1f32a
+  md5: b40131ab6a36ac2c09b7c57d4d3fbf99
+  depends:
+  - __linux
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119084
+  timestamp: 1719845605084
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+  sha256: dc569094125127c0078aa536f78733f383dd7e09507277ef8bcd1789786e7086
+  md5: 18df5fc4944a679e085e0e8f31775fc8
+  depends:
+  - __win
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119853
+  timestamp: 1719845858082
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+  sha256: 072534d4d379225b2c3a4e38bc7730b65ae171ac7f0c2d401141043336e97980
+  md5: 9eb15d654daa0ef5a98802f586bb4ffc
+  depends:
+  - __osx
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119568
+  timestamp: 1719845667420
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.5.0-pyh6be1c34_0.conda
+  sha256: 658c547dafb10cd0989f2cdf72f8ee9fe8f66240307b64555ee43f6908e9d0ad
+  md5: aec1868dd4cbe028b2c8cb11377895a6
+  depends:
+  - __win
+  - colorama
+  - decorator
+  - exceptiongroup
+  - ipython_pygments_lexers
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 630157
+  timestamp: 1756474536497
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.5.0-pyhfa0c392_0.conda
+  sha256: e9ca009d3aab9d8a85f0241d6ada2c7fbc84072008e95f803fa59da3294aa863
+  md5: c0916cc4b733577cd41df93884d857b0
+  depends:
+  - __unix
+  - pexpect >4.3
+  - decorator
+  - exceptiongroup
+  - ipython_pygments_lexers
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 630826
+  timestamp: 1756474504536
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_2.conda
+  sha256: 45821a8986b4cb2421f766b240dbe6998a3c3123f012dd566720c1322e9b6e18
+  md5: 2f0ba4bc12af346bc6c99bdc377e8944
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28153
+  timestamp: 1733399692864
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
+  sha256: 894682a42a7d659ae12878dbcb274516a7031bbea9104e92f8e88c1f2765a104
+  md5: bd80ba060603cc228d9d81c257093119
+  depends:
+  - pygments
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13993
+  timestamp: 1737123723464
+- conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+  sha256: 08e838d29c134a7684bca0468401d26840f41c92267c4126d7b43a6b533b0aed
+  md5: 0b0154421989637d424ccf0f104be51a
+  depends:
+  - arrow >=0.15.0
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 19832
+  timestamp: 1733493720346
+- conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+  sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+  md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.9
+  license: Apache-2.0 AND MIT
+  size: 843646
+  timestamp: 1733300981994
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+  sha256: f1ac18b11637ddadc05642e8185a851c7fab5998c6f5470d716812fae943b2af
+  md5: 446bd6c8cb26050d528881df495ce646
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 112714
+  timestamp: 1741263433881
+- conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.2-pyhd8ed1ab_0.conda
+  sha256: 6fc414c5ae7289739c2ba75ff569b79f72e38991d61eb67426a8a4b92f90462c
+  md5: 4e717929cfa0d49cef92d911e31d0e90
+  depends:
+  - python >=3.10
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 224671
+  timestamp: 1756321850584
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.25.1-pyhe01879c_0.conda
+  sha256: ac377ef7762e49cb9c4f985f1281eeff471e9adc3402526eea78e6ac6589cf1d
+  md5: 341fd940c242cf33e832c0402face56f
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.3.6
+  - python >=3.9
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  - python
+  license: MIT
+  license_family: MIT
+  size: 81688
+  timestamp: 1755595646123
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+  sha256: 0a4f3b132f0faca10c89fdf3b60e15abb62ded6fa80aebfc007d05965192aa04
+  md5: 439cd0f567d697b20a8f45cb70a1005a
+  depends:
+  - python >=3.10
+  - referencing >=0.31.0
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19236
+  timestamp: 1757335715225
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.25.1-he01879c_0.conda
+  sha256: aef6705fe1335e6472e1b6365fcdb586356b18dceff72d8d6a315fc90e900ccf
+  md5: 13e31c573c884962318a738405ca3487
+  depends:
+  - jsonschema >=4.25.1,<4.25.2.0a0
+  - fqdn
+  - idna
+  - isoduration
+  - jsonpointer >1.13
+  - rfc3339-validator
+  - rfc3986-validator >0.1.0
+  - rfc3987-syntax >=1.1.0
+  - uri-template
+  - webcolors >=24.6.0
+  license: MIT
+  license_family: MIT
+  size: 4744
+  timestamp: 1755595646123
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+  sha256: 38e67f3e0d631f4aeeab4bbd4062dcb6f4ae9dc35803053c995d02912a999b65
+  md5: 5cbf9a31a19d4ef9103adb7d71fd45fd
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.7
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99449
+  timestamp: 1673616104031
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.8.1-pyh31011fe_0.conda
+  sha256: 56a7a7e907f15cca8c4f9b0c99488276d4cb10821d2d15df9245662184872e81
+  md5: b7d89d860ebcda28a5303526cdee68ab
+  depends:
+  - __unix
+  - platformdirs >=2.5
+  - python >=3.8
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59562
+  timestamp: 1748333186063
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.8.1-pyh5737063_0.conda
+  sha256: 928c2514c2974fda78447903217f01ca89a77eefedd46bf6a2fe97072df57e8d
+  md5: 324e60a0d3f39f268e899709575ea3cd
+  depends:
+  - __win
+  - cpython
+  - platformdirs >=2.5
+  - python >=3.8
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59972
+  timestamp: 1748333368923
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.0-pyh29332c3_0.conda
+  sha256: 37e6ac3ccf7afcc730c3b93cb91a13b9ae827fd306f35dd28f958a74a14878b5
+  md5: f56000b36f09ab7533877e695e4e8cb0
+  depends:
+  - jsonschema-with-format-nongpl >=4.18.0
+  - packaging
+  - python >=3.9
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23647
+  timestamp: 1738765986736
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.17.0-pyhcf101f3_0.conda
+  sha256: 74c4e642be97c538dae1895f7052599dfd740d8bd251f727bce6453ce8d6cd9a
+  md5: d79a87dcfa726bcea8e61275feed6f83
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.11.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert-core >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.10
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 347094
+  timestamp: 1755870522134
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+  sha256: 0890fc79422191bc29edf17d7b42cff44ba254aa225d31eb30819f8772b775b8
+  md5: 2d983ff1b82a1ccb6f2e9d8784bdd6bd
+  depends:
+  - python >=3.9
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19711
+  timestamp: 1733428049134
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+  sha256: dc24b900742fdaf1e077d9a3458fd865711de80bca95fe3c6d46610c532c6ef0
+  md5: fd312693df06da3578383232528c468d
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.9
+  constrains:
+  - jupyterlab >=4.0.8,<5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18711
+  timestamp: 1733328194037
+- conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.2.2-pyhd8ed1ab_1.conda
+  sha256: 637a9c32e15a4333f1f9c91e0a506dbab4a6dab7ee83e126951159c916c81c99
+  md5: 3a8063b25e603999188ed4bbf3485404
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 92093
+  timestamp: 1734709450256
+- conda: https://conda.anaconda.org/conda-forge/noarch/legacy-api-wrap-1.4.1-pyhd8ed1ab_0.conda
+  sha256: 109ae0f20710a36cdd7f332e00117c49905f5f1e836a63b2f9930901fdcbc7f1
+  md5: 67a115a2ad8b264b815680f67fd6b7ec
+  depends:
+  - python >=3.10
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 15126
+  timestamp: 1732285081924
+- conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+  sha256: 69b7dc7131703d3d60da9b0faa6dd8acbf6f6c396224cf6aef3e855b8c0c41c6
+  md5: af6ab708897df59bd6e7283ceab1b56b
+  depends:
+  - python >=3.9
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14467
+  timestamp: 1733417051523
+- conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.1.4-pyhcf101f3_0.conda
+  sha256: 609ea628ace5c6cdbdce772704e6cb159ead26969bb2f386ca1757632b0f74c6
+  md5: f5a4d548d1d3bdd517260409fc21e205
+  depends:
+  - python >=3.10
+  - typing_extensions
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 72996
+  timestamp: 1756495311698
+- conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+  sha256: c6216a21154373b340c64f321f22fec51db4ee6156c2e642fa58368103ac5d09
+  md5: 121a57fce7fff0857ec70fa03200962f
+  depends:
+  - python >=3.6
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17254
+  timestamp: 1721907640382
+- conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+  sha256: d09c47c2cf456de5c09fa66d2c3c5035aa1fa228a1983a433c47b876aa16ce90
+  md5: 37293a85a0f4f77bbd9cf7aaefc62609
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  size: 15851
+  timestamp: 1749895533014
+- conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.5.0-pyhcf101f3_0.conda
+  sha256: a82b09ed2f505617f3743a5703ce25c0abc845afc58588572ea5f83bf08467c7
+  md5: c64dc3b3e0c804e0f1213abd46c1705d
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 253309
+  timestamp: 1757782706200
+- conda: https://conda.anaconda.org/conda-forge/noarch/natsort-8.4.0-pyh29332c3_1.conda
+  sha256: 594ae12c32f163f6d312e38de41311a89e476544613df0c1d048f699721621d7
+  md5: 0aa03903d33997f3886be58abc890aef
+  depends:
+  - python >=3.9
+  - python
+  license: MIT
+  license_family: MIT
+  size: 39002
+  timestamp: 1733880463101
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.3.2-pyhcf101f3_0.conda
+  sha256: e7860b5f31862fc93898d8e70d9f8be61fab0baf24314cf6a6f2dc45c72a5e9a
+  md5: 6155c934cc0fc5889c6414ebd667f9ab
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6761681
+  timestamp: 1757172242679
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
+  sha256: a20cff739d66c2f89f413e4ba4c6f6b59c50d5c30b5f0d840c13e8c9c2df9135
+  md5: 6bb0d77277061742744176ab555b723c
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.8
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28045
+  timestamp: 1734628936013
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
+  sha256: dcccb07c5a1acb7dc8be94330e62d54754c0e9c9cb2bb6865c8e3cfe44cf5a58
+  md5: d24beda1d30748afcc87c429454ece1b
+  depends:
+  - beautifulsoup4
+  - bleach-with-css !=5.0.0
+  - defusedxml
+  - importlib-metadata >=3.6
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9
+  - traitlets >=5.1
+  - python
+  constrains:
+  - pandoc >=2.9.2,<4.0.0
+  - nbconvert ==7.16.6 *_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 200601
+  timestamp: 1738067871724
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+  sha256: 7a5bd30a2e7ddd7b85031a5e2e14f290898098dc85bea5b3a5bf147c25122838
+  md5: bbe1963f1e47f594070ffe87cdf612ea
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.9
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100945
+  timestamp: 1733402844974
+- conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+  sha256: bb7b21d7fd0445ddc0631f64e66d91a179de4ba920b8381f29b9d006a42788c0
+  md5: 598fd7d4d0de2455fb74f56063969a97
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11543
+  timestamp: 1733325673691
+- conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
+  sha256: 02019191a2597865940394ff42418b37bc585a03a1c643d7cea9981774de2128
+  md5: 16bff3d37a4f99e3aa089c36c2b8d650
+  depends:
+  - python >=3.11
+  - python
+  constrains:
+  - numpy >=1.25
+  - scipy >=1.11.2
+  - matplotlib >=3.8
+  - pandas >=2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1564462
+  timestamp: 1749078300258
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+  sha256: e37db45223e432bcad809897177e05fff31828dfcfc3ef18f046ae44ec01286c
+  md5: f81a6fe643390df9347984644727d796
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert-core >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.7
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 308643
+  timestamp: 1715849037288
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+  sha256: 7b920e46b9f7a2d2aa6434222e5c8d739021dbc5cc75f32d124a8191d86f9056
+  md5: e7f89ea5f7ea9401642758ff50a2d9c1
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16817
+  timestamp: 1733408419340
+- conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+  sha256: 1840bd90d25d4930d60f57b4f38d4e0ae3f5b8db2819638709c36098c6ba770c
+  md5: e51f1e4089cad105b6cac64bd8166587
+  depends:
+  - python >=3.9
+  - typing_utils
+  license: Apache-2.0
+  license_family: APACHE
+  size: 30139
+  timestamp: 1734587755455
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+  sha256: 289861ed0c13a15d7bbb408796af4de72c2fe67e2bcb0de98f4c3fce259d7991
+  md5: 58335b26c38bf4a20f399384c33cbcf9
+  depends:
+  - python >=3.8
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 62477
+  timestamp: 1745345660407
+- conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
+  md5: 457c2c8c08e54905d6954e79cb5b5db9
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11627
+  timestamp: 1631603397334
+- conda: https://conda.anaconda.org/conda-forge/noarch/param-2.2.1-pyhd8ed1ab_0.conda
+  sha256: 2dc5b1f066e283d23678ef6484fa2fdaebe9db6a6d83905f7fc9233dc65ceba0
+  md5: b6f8a6ac73c7d5fdc5efc206ac8c98c4
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105120
+  timestamp: 1749664822292
+- conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.5-pyhcf101f3_0.conda
+  sha256: 30de7b4d15fbe53ffe052feccde31223a236dae0495bab54ab2479de30b2990f
+  md5: a110716cdb11cf51482ff4000dc253d7
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 81562
+  timestamp: 1755974222274
+- conda: https://conda.anaconda.org/conda-forge/noarch/patsy-1.0.1-pyhd8ed1ab_1.conda
+  sha256: ab52916f056b435757d46d4ce0a93fd73af47df9c11fd72b74cc4b7e1caca563
+  md5: ee23fabfd0a8c6b8d6f3729b47b2859d
+  depends:
+  - numpy >=1.4.0
+  - python >=3.9
+  license: BSD-2-Clause AND PSF-2.0
+  license_family: BSD
+  size: 186594
+  timestamp: 1733792482894
+- conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+  sha256: 202af1de83b585d36445dc1fda94266697341994d1a3328fabde4989e1b3d07a
+  md5: d0d408b1f18883a944376da5cf8101ea
+  depends:
+  - ptyprocess >=0.5
+  - python >=3.9
+  license: ISC
+  size: 53561
+  timestamp: 1733302019362
+- conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+  sha256: e2ac3d66c367dada209fc6da43e645672364b9fd5f9d28b9f016e24b81af475b
+  md5: 11a9d1d09a3615fc07c3faf79bc0b943
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 11748
+  timestamp: 1733327448200
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
+  sha256: ec9ed3cef137679f3e3a68e286c6efd52144684e1be0b05004d9699882dadcdd
+  md5: dfce4b2af4bfe90cdcaf56ca0b28ddf5
+  depends:
+  - python >=3.9,<3.13.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 1177168
+  timestamp: 1753924973872
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
+  sha256: dfe0fa6e351d2b0cef95ac1a1533d4f960d3992f9e0f82aeb5ec3623a699896b
+  md5: cc9d9a3929503785403dbfad9f707145
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 23653
+  timestamp: 1756227402815
+- conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.22.1-pyhd8ed1ab_0.conda
+  sha256: 454e2c0ef14accc888dd2cd2e8adb8c6a3a607d2d3c2f93962698b5718e6176d
+  md5: c64b77ccab10b822722904d889fa83b5
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  size: 52641
+  timestamp: 1748896836631
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+  sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae
+  md5: edb16f14d920fb3faf17f5ce582942d6
+  depends:
+  - python >=3.10
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.52
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 273927
+  timestamp: 1756321848365
+- conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+  sha256: a7713dfe30faf17508ec359e0bc7e0983f5d94682492469bd462cdaae9c64d83
+  md5: 7d9daffbb8d8e0af0f769dbbcd173a54
+  depends:
+  - python >=3.9
+  license: ISC
+  size: 19457
+  timestamp: 1733302371990
+- conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+  sha256: 71bd24600d14bb171a6321d523486f6a06f855e75e547fa0cb2a0953b02047f0
+  md5: 3bfdfb8dbcdc4af1ae3f9a8eb3948f04
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 16668
+  timestamp: 1733569518868
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+  sha256: 79db7928d13fab2d892592223d7570f5061c192f27b9febd1a418427b719acc6
+  md5: 12c566707c80111f9799308d9e265aef
+  depends:
+  - python >=3.9
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110100
+  timestamp: 1733195786147
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_1.conda
+  sha256: 456d1fb91e00ea0b55efa63c64d80b18489b0b71bffaa72c7a19bed0c637b9f4
+  md5: dcd4770a9dff3c3bb2e21cb0108af3d0
+  depends:
+  - param >=1.7.0
+  - python >=3.9
+  - pyyaml
+  - requests
+  - setuptools >=61.0
+  constrains:
+  - pyct-core <0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20171
+  timestamp: 1734342620392
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+  sha256: 5577623b9f6685ece2697c6eb7511b4c9ac5fb607c9babc2646c811b428fd46a
+  md5: 6b6ece66ebcae2d5f326c77ef2c5a066
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 889287
+  timestamp: 1750615908735
+- conda: https://conda.anaconda.org/conda-forge/noarch/pynndescent-0.5.13-pyhd8ed1ab_1.conda
+  sha256: fd7f81cfed1a04883261e2ebd73677066f5040c4ed7984e870c9c931069f9398
+  md5: 87b563f2388f452cedb6a878b738c7dc
+  depends:
+  - llvmlite >=0.30
+  - numba >=0.46
+  - numpy >=1.13
+  - python >=3.9
+  - scikit-learn >=0.19
+  - scipy >=1.0
+  - setuptools
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 49630
+  timestamp: 1734193646381
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.4-pyhcf101f3_0.conda
+  sha256: c3260cf948da6345770d75ae559d716e557580eddcd19623676931d172346969
+  md5: bf1f1292fc78307956289707e85cb1bf
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 104029
+  timestamp: 1757767060575
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
+  sha256: d016e04b0e12063fbee4a2d5fbb9b39a8d191b5a0042f0b8459188aedeabb0ca
+  md5: e2fd202833c4a981ce8a65974fe4abd1
+  depends:
+  - __win
+  - python >=3.9
+  - win_inet_pton
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21784
+  timestamp: 1733217448189
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+  sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
+  md5: 461219d1a5bd61342293efa2c0c90eac
+  depends:
+  - __unix
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21085
+  timestamp: 1733217331982
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+  md5: 5b8d21249ff20967101ffa321cab24e8
+  depends:
+  - python >=3.9
+  - six >=1.5
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 233310
+  timestamp: 1751104122689
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
+  sha256: df9aa74e9e28e8d1309274648aac08ec447a92512c33f61a8de0afa9ce32ebe8
+  md5: 23029aae904a2ba587daba708208012f
+  depends:
+  - python >=3.9
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 244628
+  timestamp: 1755304154927
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+  sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
+  md5: a61bf9ec79426938ff785eb69dbb1960
+  depends:
+  - python >=3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13383
+  timestamp: 1677079727691
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.2-pyhd8ed1ab_0.conda
+  sha256: e8392a8044d56ad017c08fec2b0eb10ae3d1235ac967d0aab8bd7b41c4a5eaf0
+  md5: 88476ae6ebd24f39261e0854ac244f33
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 144160
+  timestamp: 1742745254292
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
+  sha256: fddf123692aa4b1fc48f0471e346400d9852d96eeed77dbfdd746fa50a8ff894
+  md5: 8fcb6b0e2161850556231336dae58358
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7003
+  timestamp: 1752805919375
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
+  sha256: 8d2a8bf110cc1fc3df6904091dead158ba3e614d8402a83e51ed3a8aa93cdeb0
+  md5: bc8e3267d44011051f2eb14d22fb0960
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 189015
+  timestamp: 1742920947249
+- conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.36.2-pyh29332c3_0.conda
+  sha256: e20909f474a6cece176dfc0dc1addac265deb5fa92ea90e975fbca48085b20c3
+  md5: 9140f1c09dd5489549c6a33931b943c7
+  depends:
+  - attrs >=22.2.0
+  - python >=3.9
+  - rpds-py >=0.7.0
+  - typing_extensions >=4.4.0
+  - python
+  license: MIT
+  license_family: MIT
+  size: 51668
+  timestamp: 1737836872415
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
+  sha256: 8dc54e94721e9ab545d7234aa5192b74102263d3e704e6d0c8aa7008f2da2a7b
+  md5: db0c6b99149880c8ba515cf4abe93ee4
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 59263
+  timestamp: 1755614348400
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+  sha256: 2e4372f600490a6e0b3bac60717278448e323cab1c0fecd5f43f7c56535a99c5
+  md5: 36de09a8d3e5d5e6f4ee63af49e59706
+  depends:
+  - python >=3.9
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10209
+  timestamp: 1733600040800
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+  sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
+  md5: 912a71cc01012ee38e6b90ddd561e36f
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 7818
+  timestamp: 1598024297745
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
+  sha256: 70001ac24ee62058557783d9c5a7bbcfd97bd4911ef5440e3f7a576f9e43bc92
+  md5: 7234f99325263a5af6d4cd195035e8f2
+  depends:
+  - python >=3.9
+  - lark >=1.2.2
+  - python
+  license: MIT
+  license_family: MIT
+  size: 22913
+  timestamp: 1752876729969
+- conda: https://conda.anaconda.org/conda-forge/noarch/scanpy-1.11.4-pyhd8ed1ab_0.conda
+  sha256: 8d7be36901b4385b0b3da5c882ab509b4723a4d333cf046a0c1bc2044cce56f7
+  md5: 23d6ee85f416341db93463665899af6e
+  depends:
+  - anndata >=0.8
+  - h5py >=3.7.0
+  - joblib
+  - legacy-api-wrap >=1.4.1
+  - matplotlib-base >=3.7.5
+  - natsort
+  - networkx >=2.7.1
+  - numba >=0.57.1
+  - numpy >=1.24.1
+  - packaging >=21.3
+  - pandas >=1.5.3
+  - patsy !=1.0.0
+  - pynndescent >=0.5.13
+  - python >=3.10
+  - scikit-learn >=1.1.3
+  - scipy >=1.8.1
+  - seaborn >=0.13.2
+  - session-info2
+  - statsmodels >=0.14.5
+  - tqdm
+  - typing-extensions
+  - umap-learn >=0.5.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1962506
+  timestamp: 1753948476573
+- conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_3.conda
+  sha256: ea29a69b14dd6be5cdeeaa551bf50d78cafeaf0351e271e358f9b820fcab4cb0
+  md5: 62afb877ca2c2b4b6f9ecb37320085b6
+  depends:
+  - seaborn-base 0.13.2 pyhd8ed1ab_3
+  - statsmodels >=0.12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6876
+  timestamp: 1733730113224
+- conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_3.conda
+  sha256: f209c9c18187570b85ec06283c72d64b8738f825b1b82178f194f4866877f8aa
+  md5: fd96da444e81f9e6fcaac38590f3dd42
+  depends:
+  - matplotlib-base >=3.4,!=3.6.1
+  - numpy >=1.20,!=1.24.0
+  - pandas >=1.2
+  - python >=3.9
+  - scipy >=1.7
+  constrains:
+  - seaborn =0.13.2=*_3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 227843
+  timestamp: 1733730112409
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_1.conda
+  sha256: 00926652bbb8924e265caefdb1db100f86a479e8f1066efe395d5552dde54d02
+  md5: 938c8de6b9de091997145b3bf25cdbf9
+  depends:
+  - __linux
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22736
+  timestamp: 1733322148326
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_1.conda
+  sha256: 5282eb5b462502c38df8cb37cd1542c5bbe26af2453a18a0a0602d084ca39f53
+  md5: e67b1b1fa7a79ff9e8e326d0caf55854
+  depends:
+  - __osx
+  - pyobjc-framework-cocoa
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23100
+  timestamp: 1733322309409
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_1.conda
+  sha256: ba8b93df52e0d625177907852340d735026c81118ac197f61f1f5baea19071ad
+  md5: e6a4e906051565caf5fdae5b0415b654
+  depends:
+  - __win
+  - python >=3.9
+  - pywin32
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23359
+  timestamp: 1733322590167
+- conda: https://conda.anaconda.org/conda-forge/noarch/session-info2-0.2.2-pyhd8ed1ab_0.conda
+  sha256: 89753b10cc1ea763ab692931da152240af28f57fea878ea8dbd45f4f92c9343d
+  md5: b1592c08e769ea2e05b9a88f45bc275a
+  depends:
+  - python >=3.10
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 21065
+  timestamp: 1757704121818
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+  sha256: 972560fcf9657058e3e1f97186cc94389144b46dbdf58c807ce62e83f977e863
+  md5: 4de79c071274a53dcaf2a8c749d1499e
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 748788
+  timestamp: 1748804951958
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+  sha256: 458227f759d5e3fcec5d9b7acce54e10c9e1f4f4b7ec978f3bfd54ce4ee9853d
+  md5: 3339e3b65d58accf4ca4fb8748ab16b3
+  depends:
+  - python >=3.9
+  - python
+  license: MIT
+  license_family: MIT
+  size: 18455
+  timestamp: 1753199211006
+- conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+  sha256: c2248418c310bdd1719b186796ae50a8a77ce555228b6acd32768e2543a15012
+  md5: bf7a226e58dfb8346c70df36065d86c9
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  size: 15019
+  timestamp: 1733244175724
+- conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8-pyhd8ed1ab_0.conda
+  sha256: c978576cf9366ba576349b93be1cfd9311c00537622a2f9e14ba2b90c97cae9c
+  md5: 18c019ccf43769d211f2cf78e9ad46c2
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 37803
+  timestamp: 1756330614547
+- conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+  sha256: 570da295d421661af487f1595045760526964f41471021056e993e73089e9c41
+  md5: b1b505328da7a6b246787df4b5a49fbc
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 26988
+  timestamp: 1733569565672
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+  sha256: b300557c0382478cf661ddb520263508e4b3b5871b471410450ef2846e8c352c
+  md5: efba281bbdae5f6b0a1d53c6d4a97c93
+  depends:
+  - __linux
+  - ptyprocess
+  - python >=3.8
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22452
+  timestamp: 1710262728753
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+  sha256: 4daae56fc8da17784578fbdd064f17e3b3076b394730a14119e571707568dc8a
+  md5: 00b54981b923f5aefcd5e8547de056d5
+  depends:
+  - __osx
+  - ptyprocess
+  - python >=3.8
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22717
+  timestamp: 1710265922593
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
+  sha256: 8cb078291fd7882904e3de594d299c8de16dd3af7405787fce6919a385cfc238
+  md5: 4abd500577430a942a995fd0d09b76a2
+  depends:
+  - __win
+  - python >=3.8
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22883
+  timestamp: 1710262943966
+- conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
+  sha256: 6016672e0e72c4cf23c0cf7b1986283bd86a9c17e8d319212d78d8e9ae42fdfd
+  md5: 9d64911b31d57ca443e9f1e36b04385f
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23869
+  timestamp: 1741878358548
+- conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+  sha256: cad582d6f978276522f84bd209a5ddac824742fe2d452af6acf900f8650a73a2
+  md5: f1acf5fdefa8300de697982bcb1761c9
+  depends:
+  - python >=3.5
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28285
+  timestamp: 1729802975370
+- conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_1.conda
+  sha256: eda38f423c33c2eaeca49ed946a8d3bf466cc3364970e083a65eb2fd85258d87
+  md5: 40d0ed782a8aaa16ef248e68c06c168d
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 52475
+  timestamp: 1733736126261
+- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+  sha256: 11e2c85468ae9902d24a27137b6b39b4a78099806e551d390e394a8c34b48e40
+  md5: 9efbfdc37242619130ea42b1cc4ed861
+  depends:
+  - colorama
+  - python >=3.9
+  license: MPL-2.0 or MIT
+  size: 89498
+  timestamp: 1735661472632
+- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+  sha256: f39a5620c6e8e9e98357507262a7869de2ae8cc07da8b7f84e517c9fd6c2b959
+  md5: 019a7385be9af33791c989871317e1ed
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110051
+  timestamp: 1733367480074
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20250822-pyhd8ed1ab_0.conda
+  sha256: dfdf6e3dea87c873a86cfa47f7cba6ffb500bad576d083b3de6ad1b17e1a59c3
+  md5: 5e9220c892fe069da8de2b9c63663319
+  depends:
+  - python >=3.10
+  license: Apache-2.0 AND MIT
+  size: 24939
+  timestamp: 1755865615651
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+  sha256: 7c2df5721c742c2a47b2c8f960e718c930031663ac1174da67c1ed5999f7938c
+  md5: edd329d7d3a4ab45dcf905899a7a6115
+  depends:
+  - typing_extensions ==4.15.0 pyhcf101f3_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 91383
+  timestamp: 1756220668932
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+  sha256: 032271135bca55aeb156cee361c81350c6f3fb203f57d024d7e5a1fc9ef18731
+  md5: 0caa1af407ecff61170c9437a808404d
+  depends:
+  - python >=3.10
+  - python
+  license: PSF-2.0
+  license_family: PSF
+  size: 51692
+  timestamp: 1756220668932
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+  sha256: 3088d5d873411a56bf988eee774559335749aed6f6c28e07bf933256afb9eb6c
+  md5: f6d7aa696c67756a650e91e15e88223c
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 15183
+  timestamp: 1733331395943
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+  sha256: 5aaa366385d716557e365f0a4e9c3fca43ba196872abbbe3d56bb610d131e192
+  md5: 4222072737ccff51314b5ece9c7d6f5a
+  license: LicenseRef-Public-Domain
+  size: 122968
+  timestamp: 1742727099393
+- conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+  sha256: e0eb6c8daf892b3056f08416a96d68b0a358b7c46b99c8a50481b22631a4dfc0
+  md5: e7cb0f5745e4c5035a460248334af7eb
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 23990
+  timestamp: 1733323714454
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+  sha256: 4fb9789154bd666ca74e428d973df81087a697dbb987775bc3198d2215f240f8
+  md5: 436c165519e140cb08d246a4472a9d6a
+  depends:
+  - brotli-python >=1.0.9
+  - h2 >=4,<5
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 101735
+  timestamp: 1750271478254
+- conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+  sha256: f21e63e8f7346f9074fd00ca3b079bd3d2fa4d71f1f89d5b6934bf31446dc2a5
+  md5: b68980f2495d096e71c7fd9d7ccf63e6
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 32581
+  timestamp: 1733231433877
+- conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+  sha256: 08315dc2e61766a39219b2d82685fc25a56b2817acf84d5b390176080eaacf99
+  md5: b49f7b291e15494aafb0a7d74806f337
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18431
+  timestamp: 1733359823938
+- conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+  sha256: 19ff205e138bb056a46f9e3839935a2e60bd1cf01c8241a5e172a422fed4f9c6
+  md5: 2841eb5bfc75ce15e9a0054b98dcd64d
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15496
+  timestamp: 1733236131358
+- conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+  sha256: 1dd84764424ffc82030c19ad70607e6f9e3b9cb8e633970766d697185652053e
+  md5: 84f8f77f0a9c6ef401ee96611745da8f
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 46718
+  timestamp: 1733157432924
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+  sha256: 1b34021e815ff89a4d902d879c3bd2040bc1bd6169b32e9427497fa05c55f1ce
+  md5: 75cb7132eb58d97896e173ef12ac9986
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 62931
+  timestamp: 1733130309598
+- conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+  sha256: 93807369ab91f230cf9e6e2a237eaa812492fe00face5b38068735858fba954f
+  md5: 46e441ba871f524e2b067929da3051c2
+  depends:
+  - __win
+  - python >=3.9
+  license: LicenseRef-Public-Domain
+  size: 9555
+  timestamp: 1733130678956
+- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.9.0-pyhd8ed1ab_0.conda
+  sha256: ae5a7db3b457caacc5da3e47650ea2dc597b769787669b29bd68cb9d1822046c
+  md5: ebd60e8b77a2fc77a8d86892705ea245
+  depends:
+  - numpy >=1.26
+  - packaging >=24.1
+  - pandas >=2.2
+  - python >=3.11
+  constrains:
+  - iris >=3.9
+  - numba >=0.60
+  - nc-time-axis >=1.4
+  - hdf5 >=1.14
+  - zarr >=2.18
+  - seaborn-base >=0.13
+  - bottleneck >=1.4
+  - cartopy >=0.23
+  - cftime >=1.6
+  - dask-core >=2024.6
+  - toolz >=0.12
+  - distributed >=2024.6
+  - matplotlib-base >=3.8
+  - netcdf4 >=1.6.0
+  - flox >=0.9
+  - h5netcdf >=1.3
+  - pint >=0.24
+  - scipy >=1.13
+  - sparse >=0.15
+  - h5py >=3.11
+  license: Apache-2.0
+  license_family: APACHE
+  size: 898587
+  timestamp: 1756981236899
+- conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.4.0-pyhd8ed1ab_0.conda
+  sha256: ac6d4d4133b1e0f69075158cdf00fccad20e29fc6cc45faa480cec37a84af6ae
+  md5: 5663fa346821cd06dc1ece2c2600be2c
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49477
+  timestamp: 1745598150265
+- conda: https://conda.anaconda.org/conda-forge/noarch/zarr-3.1.2-pyhcf101f3_0.conda
+  sha256: 1f8d84067a6814961326dc444be037b2b4aacde55c3344c765d4b3460b9356ae
+  md5: 2bdb3950ea64a365bfe9e6414e748a9b
+  depends:
+  - python >=3.11
+  - packaging >=22.0
+  - numpy >=1.26
+  - numcodecs >=0.14
+  - typing_extensions >=4.9
+  - donfig >=0.8
+  - crc32c
+  - python
+  constrains:
+  - fsspec >=2023.10.0
+  - obstore >=0.5.1
+  license: MIT
+  license_family: MIT
+  size: 275145
+  timestamp: 1756217391401
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
+  sha256: 7560d21e1b021fd40b65bfb72f67945a3fcb83d78ad7ccf37b8b3165ec3b68ad
+  md5: df5e78d904988eb55042c0c97446079f
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 22963
+  timestamp: 1749421737203
+- conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-25.1.0-py311h13e5629_0.conda
+  sha256: cab14d6bdcaf64f0911dcd994b51ddb753650d041a74c87a2107041763605e66
+  md5: 8051f5bb22c95da482362f7a8c35fd68
+  depends:
+  - __osx >=10.13
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 33400
+  timestamp: 1753995045262
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h1c43f85_4.conda
+  sha256: 13847b7477bd66d0f718f337e7980c9a32f82ec4e4527c7e0a0983db2d798b8e
+  md5: 1a0a37da4466d45c00fc818bb6b446b3
+  depends:
+  - __osx >=10.13
+  - brotli-bin 1.1.0 h1c43f85_4
+  - libbrotlidec 1.1.0 h1c43f85_4
+  - libbrotlienc 1.1.0 h1c43f85_4
+  license: MIT
+  license_family: MIT
+  size: 20022
+  timestamp: 1756599872109
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h1c43f85_4.conda
+  sha256: 549ea0221019cfb4b370354f2c3ffbd4be1492740e1c73b2cdf9687ed6ad7364
+  md5: 718fb8aa4c8cb953982416db9a82b349
+  depends:
+  - __osx >=10.13
+  - libbrotlidec 1.1.0 h1c43f85_4
+  - libbrotlienc 1.1.0 h1c43f85_4
+  license: MIT
+  license_family: MIT
+  size: 17311
+  timestamp: 1756599830763
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311h7b20566_4.conda
+  sha256: 10afc3a0df8e7447c56b0753848336eeeeea04be9bf1817569c45755392de14b
+  md5: 13de3b969fd0ba12c4f6f9513f486f16
+  depends:
+  - __osx >=10.13
+  - libcxx >=19
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 h1c43f85_4
+  license: MIT
+  license_family: MIT
+  size: 368751
+  timestamp: 1756600247737
+- conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_8.conda
+  sha256: 8f50b58efb29c710f3cecf2027a8d7325ba769ab10c746eff75cea3ac050b10c
+  md5: 97c4b3bd8a90722104798175a1bdddbf
+  depends:
+  - __osx >=10.13
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 132607
+  timestamp: 1757437730085
+- conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.5-hf13058a_0.conda
+  sha256: b37f5dacfe1c59e0a207c1d65489b760dff9ddb97b8df7126ceda01692ba6e97
+  md5: eafe5d9f1a8c514afe41e6e833f66dfd
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 184824
+  timestamp: 1744128064511
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.1-py311he66fa18_1.conda
+  sha256: f5c6c73e0a389d2c89e10b36883e18cd3abd14756d9d01d53856aaae3131f219
+  md5: 70cd671f73c5c08899d5c43366d37787
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4.6,<3.5.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 294021
+  timestamp: 1756808523082
+- conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.3-py311hd4d69bb_2.conda
+  sha256: 69740b02124fd104b0c14494bc333cfc1bd64508d9dd0075a1493935866fbd64
+  md5: 7d3b5e08077a62b8f24737e54aa3fe81
+  depends:
+  - __osx >=10.13
+  - libcxx >=19
+  - numpy >=1.25
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269105
+  timestamp: 1756545009456
+- conda: https://conda.anaconda.org/conda-forge/osx-64/crc32c-2.7.1-py311h179db11_2.conda
+  sha256: 1fb331d5425ad730d2c9eb0b7055ea1ab7a5ba1049168a5a5231bb55c37a7e79
+  md5: 9a70e6717b9347cebfc8ce472fea2fe3
+  depends:
+  - python
+  - __osx >=10.13
+  - python_abi 3.11.* *_cp311
+  license: LGPL-2.1-or-later
+  size: 50983
+  timestamp: 1756602276112
+- conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.16-py311hc651eee_1.conda
+  sha256: 7f7300ee62b58658813e99a08f4a6f8daf585420cab6330f083ae697f569e66a
+  md5: 32c16e5c0e427989aff77ead02bf7f88
+  depends:
+  - python
+  - __osx >=10.13
+  - libcxx >=19
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2665552
+  timestamp: 1756742018979
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.59.2-py311hfbe4617_0.conda
+  sha256: 84dddca09970ecd2fe32f557faa1b9706bfeea6433e415e797c3313c9a5300a9
+  md5: d5648fdf64b8aa74dddd992740d6ccc5
+  depends:
+  - __osx >=10.13
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2841454
+  timestamp: 1756328929077
+- conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.14.1-h694c41f_0.conda
+  sha256: 9f8282510db291496e89618fc66a58a1124fe7a6276fbd57ed18c602ce2576e9
+  md5: ca641fdf8b7803f4b7212b6d66375930
+  depends:
+  - libfreetype 2.14.1 h694c41f_0
+  - libfreetype6 2.14.1 h6912278_0
+  license: GPL-2.0-only OR FTL
+  size: 173969
+  timestamp: 1757945973505
+- conda: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.14.0-nompi_py311h9f650d9_101.conda
+  sha256: 35bbb215c41a52ef69ba748c9d7e663acde1f17c5d838e0e933acf0d14c07ec5
+  md5: cd1012a17d3e6078ee6549a4289f1f74
+  depends:
+  - __osx >=10.13
+  - cached-property
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1166065
+  timestamp: 1756767313574
+- conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.6-nompi_hc8237f9_103.conda
+  sha256: e41d22f672b1fbe713d22cf69630abffaee68bdb38a500a708fc70e6f639357f
+  md5: 3f1df98f96e0c369d94232712c9b87d0
+  depends:
+  - __osx >=10.13
+  - libaec >=1.1.4,<2.0a0
+  - libcurl >=8.14.1,<9.0a0
+  - libcxx >=19
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - libgfortran5 >=15.1.0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3522832
+  timestamp: 1753358062940
+- conda: https://conda.anaconda.org/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
+  sha256: 2e64307532f482a0929412976c8450c719d558ba20c0962832132fd0d07ba7a7
+  md5: d68d48a3060eb5abdc1cdc8e2a3a5966
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 11761697
+  timestamp: 1720853679409
+- conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_2.conda
+  sha256: 8e0f5af4d5bd59f52d27926750416638e32a65d58a202593fa0e97f312ad78c3
+  md5: 9983b3959da3b695c8da48c93510cbdf
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18407
+  timestamp: 1756754411612
+- conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.9-py311ha94bed4_1.conda
+  sha256: 58391bf10f4450020c792b2dbd4f1b0aa0281dd008c121b36a9eae63a9d4322b
+  md5: a5e96ec3e24dd2fd9887ad284ee1a8c5
+  depends:
+  - python
+  - __osx >=10.13
+  - libcxx >=19
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 67533
+  timestamp: 1756467598070
+- conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+  sha256: 83b52685a4ce542772f0892a0f05764ac69d57187975579a0835ff255ae3ef9c
+  md5: d4765c524b1d91567886bde656fb514b
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1185323
+  timestamp: 1719463492984
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.17-h72f5680_0.conda
+  sha256: bcb81543e49ff23e18dea79ef322ab44b8189fb11141b1af99d058503233a5fc
+  md5: bf210d0c63f2afb9e414a858b79f0eaa
+  depends:
+  - __osx >=10.13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 226001
+  timestamp: 1739161050843
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hcca01a6_1.conda
+  sha256: cc1f1d7c30aa29da4474ec84026ec1032a8df1d7ec93f4af3b98bb793d01184e
+  md5: 21f765ced1a0ef4070df53cb425e1967
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 248882
+  timestamp: 1745264331196
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.4-ha6bc127_0.conda
+  sha256: f4fe00ef0df58b670696c62f2ec3f6484431acbf366ecfbcb71141c81439e331
+  md5: 1a768b826dfc68e07786788d98babfc3
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30034
+  timestamp: 1749993664561
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-35_he492b99_openblas.conda
+  sha256: e1958ed8252ce4e54558093c13bd8f6a61331a5ebf1bf088e64a8a118d14ba6f
+  md5: fa7588e7cdbe7718e90aea6c849e09ca
+  depends:
+  - libopenblas >=0.3.30,<0.3.31.0a0
+  - libopenblas >=0.3.30,<1.0a0
+  constrains:
+  - libcblas   3.9.0   35*_openblas
+  - liblapacke 3.9.0   35*_openblas
+  - blas 2.135   openblas
+  - liblapack  3.9.0   35*_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17314
+  timestamp: 1757447444160
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h1c43f85_4.conda
+  sha256: 28c1a5f7dbe68342b7341d9584961216bd16f81aa3c7f1af317680213c00b46a
+  md5: b8e1ee78815e0ba7835de4183304f96b
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 67948
+  timestamp: 1756599727911
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h1c43f85_4.conda
+  sha256: a287470602e8380c0bdb5e7a45ba3facac644432d7857f27b39d6ceb0dcbf8e9
+  md5: 9cc4be0cc163d793d5d4bcc405c81bf3
+  depends:
+  - __osx >=10.13
+  - libbrotlicommon 1.1.0 h1c43f85_4
+  license: MIT
+  license_family: MIT
+  size: 30743
+  timestamp: 1756599755474
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h1c43f85_4.conda
+  sha256: 820caf0a78770758830adbab97fe300104981a5327683830d162b37bc23399e9
+  md5: f2c000dc0185561b15de7f969f435e61
+  depends:
+  - __osx >=10.13
+  - libbrotlicommon 1.1.0 h1c43f85_4
+  license: MIT
+  license_family: MIT
+  size: 294904
+  timestamp: 1756599789206
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-35_h9b27e0a_openblas.conda
+  sha256: 1ef1234ac54075b1df1c8ed355ad807d8be97a49e61e3cc7f27fa0f7398936d3
+  md5: a16da81ce75921b71c512781fb2438ac
+  depends:
+  - libblas 3.9.0 35_he492b99_openblas
+  constrains:
+  - blas 2.135   openblas
+  - liblapack  3.9.0   35*_openblas
+  - liblapacke 3.9.0   35*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17303
+  timestamp: 1757447461918
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.14.1-h5dec5d8_0.conda
+  sha256: ca0d8d12056227d6b47122cfb6d68fc5a3a0c6ab75a0e908542954fc5f84506c
+  md5: 8738cd19972c3599400404882ddfbc24
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.64.0,<2.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 424040
+  timestamp: 1749033558114
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-21.1.1-h3d58e20_0.conda
+  sha256: dd207d8882854f22072b7fd4f03726e0e182e0666986ec880168f1753f7415dc
+  md5: 7f5b7dfca71a5c165ce57f46e9e48480
+  depends:
+  - __osx >=10.13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 571163
+  timestamp: 1757525814844
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.24-hcc1b750_0.conda
+  sha256: 2733a4adf53daca1aa4f41fe901f0f8ee9e4c509abd23ffcd7660013772d6f45
+  md5: f0a46c359722a3e84deb05cd4072d153
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 69751
+  timestamp: 1747040526774
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20250104-pl5321ha958ccf_0.conda
+  sha256: 6cc49785940a99e6a6b8c6edbb15f44c2dd6c789d9c283e5ee7bdfedd50b4cd6
+  md5: 1f4ed31220402fcddc083b4bff406868
+  depends:
+  - ncurses
+  - __osx >=10.13
+  - ncurses >=6.5,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 115563
+  timestamp: 1738479554273
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+  sha256: 0d238488564a7992942aa165ff994eca540f687753b4f0998b29b4e4d030ff43
+  md5: 899db79329439820b7e8f8de41bca902
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 106663
+  timestamp: 1702146352558
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.7.1-h21dd04a_0.conda
+  sha256: 689862313571b62ee77ee01729dc093f2bf25a2f99415fcfe51d3a6cd31cce7b
+  md5: 9fdeae0b7edda62e989557d645769515
+  depends:
+  - __osx >=10.13
+  constrains:
+  - expat 2.7.1.*
+  license: MIT
+  license_family: MIT
+  size: 72450
+  timestamp: 1752719744781
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.6-h281671d_1.conda
+  sha256: 6394b1bc67c64a21a5cc73d1736d1d4193a64515152e861785c44d2cfc49edf3
+  md5: 4ca9ea59839a9ca8df84170fab4ceb41
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 51216
+  timestamp: 1743434595269
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libfreetype-2.14.1-h694c41f_0.conda
+  sha256: 035e23ef87759a245d51890aedba0b494a26636784910c3730d76f3dc4482b1d
+  md5: e0e2edaf5e0c71b843e25a7ecc451cc9
+  depends:
+  - libfreetype6 >=2.14.1
+  license: GPL-2.0-only OR FTL
+  size: 7780
+  timestamp: 1757945952392
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libfreetype6-2.14.1-h6912278_0.conda
+  sha256: f5f28092e368efc773bcd1c381d123f8b211528385a9353e36f8808d00d11655
+  md5: dfbdc8fd781dc3111541e4234c19fdbd
+  depends:
+  - __osx >=10.13
+  - libpng >=1.6.50,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - freetype >=2.14.1
+  license: GPL-2.0-only OR FTL
+  size: 374993
+  timestamp: 1757945949585
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.1.0-h5f6db21_1.conda
+  sha256: 844500c9372d455f6ae538ffd3cdd7fda5f53d25a2a6b3ba33060a302c37bc3e
+  md5: 07cfad6b37da6e79349c6e3a0316a83b
+  depends:
+  - libgfortran5 15.1.0 hfa3c126_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 133973
+  timestamp: 1756239628906
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.1.0-hfa3c126_1.conda
+  sha256: c4bb79d9e9be3e3a335282b50d18a7965e2a972b95508ea47e4086f1fd699342
+  md5: 696e408f36a5a25afdb23e862053ca82
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 15.1.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1225193
+  timestamp: 1756238834726
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libhwloc-2.12.1-default_h094e1f9_1002.conda
+  sha256: 11e49fcf5c38aad4a78f4b74843eccd610c0e86c424b701e3e87cac072049fb7
+  md5: 4d9e9610b6a16291168144842cd9cae2
+  depends:
+  - __osx >=10.13
+  - libcxx >=19
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2381331
+  timestamp: 1757624131667
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h57a12c2_2.conda
+  sha256: a1c8cecdf9966921e13f0ae921309a1f415dfbd2b791f2117cf7e8f5e61a48b6
+  md5: 210a85a1119f97ea7887188d176db135
+  depends:
+  - __osx >=10.13
+  license: LGPL-2.1-only
+  size: 737846
+  timestamp: 1754908900138
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.1.0-h6e16a3a_0.conda
+  sha256: 9c0009389c1439ec96a08e3bf7731ac6f0eab794e0a133096556a9ae10be9c27
+  md5: 87537967e6de2f885a9fcebd42b7cb10
+  depends:
+  - __osx >=10.13
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 586456
+  timestamp: 1745268522731
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-35_h859234e_openblas.conda
+  sha256: 224b6a589afcd3b69fd6158a26b4400950742783e5d6e6bee74314e1f5f25e5c
+  md5: 340a8f781528d59abac136c0fa9f6a4c
+  depends:
+  - libblas 3.9.0 35_he492b99_openblas
+  constrains:
+  - liblapacke 3.9.0   35*_openblas
+  - blas 2.135   openblas
+  - libcblas   3.9.0   35*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17300
+  timestamp: 1757447490033
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.1-hd471939_2.conda
+  sha256: 7e22fd1bdb8bf4c2be93de2d4e718db5c548aa082af47a7430eb23192de6bb36
+  md5: 8468beea04b9065b9807fc8b9cdc5894
+  depends:
+  - __osx >=10.13
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD
+  size: 104826
+  timestamp: 1749230155443
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.67.0-h3338091_0.conda
+  sha256: c48d7e1cc927aef83ff9c48ae34dd1d7495c6ccc1edc4a3a6ba6aff1624be9ac
+  md5: e7630cef881b1174d40f3e69a883e55f
+  depends:
+  - __osx >=10.13
+  - c-ares >=1.34.5,<2.0a0
+  - libcxx >=19
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 605680
+  timestamp: 1756835898134
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.30-openmp_h83c2472_2.conda
+  sha256: 341dd45c2e88261f1f9ff76c3410355b4b0e894abe6ac89f7cbf64a3d10f0f01
+  md5: 89edf77977f520c4245567460d065821
+  depends:
+  - __osx >=10.13
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - llvm-openmp >=19.1.7
+  constrains:
+  - openblas >=0.3.30,<0.3.31.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6262457
+  timestamp: 1755473612572
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.50-h84aeda2_1.conda
+  sha256: 8d92c82bcb09908008d8cf5fab75e20733810d40081261d57ef8cd6495fc08b4
+  md5: 1fe32bb16991a24e112051cc0de89847
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 297609
+  timestamp: 1753879919854
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
+  sha256: d3975cfe60e81072666da8c76b993af018cf2e73fe55acba2b5ba0928efaccf5
+  md5: 6af4b059e26492da6013e79cbcb4d069
+  depends:
+  - __osx >=10.13
+  license: ISC
+  size: 210249
+  timestamp: 1716828641383
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.50.4-h39a8b3b_0.conda
+  sha256: 466366b094c3eb4b1d77320530cbf5400e7a10ab33e4824c200147488eebf7a6
+  md5: 156bfb239b6a67ab4a01110e6718cbc4
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: blessing
+  size: 980121
+  timestamp: 1753948554003
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-hed3591d_0.conda
+  sha256: 00654ba9e5f73aa1f75c1f69db34a19029e970a4aeb0fa8615934d8e9c369c3c
+  md5: a6cb15db1c2dc4d3a5f6cf3772e09e81
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 284216
+  timestamp: 1745608575796
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-h59ddb5d_6.conda
+  sha256: 656dc01238d4b766e35976319aba2a9b3ea707b467b7a5aad94ef49a150be7a8
+  md5: 1cb7b8054ffa9460ca3dd782062f3074
+  depends:
+  - __osx >=10.13
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=19
+  - libdeflate >=1.24,<1.26.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: HPND
+  size: 401676
+  timestamp: 1755012183336
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.6.0-hb807250_0.conda
+  sha256: 00dbfe574b5d9b9b2b519acb07545380a6bc98d1f76a02695be4995d4ec91391
+  md5: 7bb6608cf1f83578587297a158a6630b
+  depends:
+  - __osx >=10.13
+  constrains:
+  - libwebp 1.6.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365086
+  timestamp: 1752159528504
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+  sha256: 8896cd5deff6f57d102734f3e672bc17120613647288f9122bec69098e839af7
+  md5: bbeca862892e2898bdb45792a61c4afc
+  depends:
+  - __osx >=10.13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 323770
+  timestamp: 1727278927545
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.0-ha1d9b0f_0.conda
+  sha256: a3f8d7f884b81753398ebad9a82814274f3e914620e64931cb286644b7f672fd
+  md5: a9ff104c00d0dccf7f7ad049eb3a3a1f
+  depends:
+  - __osx >=10.13
+  - icu >=75.1,<76.0a0
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - libxml2 2.15.0
+  license: MIT
+  license_family: MIT
+  size: 494292
+  timestamp: 1757953804385
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.0-h7b7ecba_0.conda
+  sha256: 6ae3fa2e174e9d71a94755d0b82dccc60e73133464807bc3d6a892d28fe21837
+  md5: 3954b98e6a17c56263eab3f7d1f242e0
+  depends:
+  - __osx >=10.13
+  - icu >=75.1,<76.0a0
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libxml2-16 2.15.0 ha1d9b0f_0
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 39959
+  timestamp: 1757953828536
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+  sha256: 8412f96504fc5993a63edf1e211d042a1fd5b1d51dedec755d2058948fcced09
+  md5: 003a54a4e32b02f7355b50a837e699da
+  depends:
+  - __osx >=10.13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 57133
+  timestamp: 1727963183990
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-21.1.0-hf4e0ed4_0.conda
+  sha256: 78336131a08990390003ef05d14ecb49f3a47e4dac60b1bcebeccd87fa402925
+  md5: 5acc6c266fd33166fa3b33e48665ae0d
+  depends:
+  - __osx >=10.13
+  constrains:
+  - openmp 21.1.0|21.1.0.*
+  - intel-openmp <0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 311174
+  timestamp: 1756673275570
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.44.0-py311hec21310_2.conda
+  sha256: 30149864498ca3bcb2c306e32eab1d21ffb4c810c5ca800c5b0f5d27e54464d5
+  md5: 87cc806926e2c685a4eed8294b1b2cf9
+  depends:
+  - __osx >=10.13
+  - libcxx >=19
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 20377520
+  timestamp: 1756303960941
+- conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.2-py311ha3cf9ac_1.conda
+  sha256: e9965b5d4c29b17b1512035b24a7c126ed7bdb6b39103b52cae099d5bb4194a9
+  md5: 1d6596ca7c7b66215c5c0d58b3cb0dd3
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24688
+  timestamp: 1733219887972
+- conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.10.6-py311h48d7e91_1.conda
+  sha256: d808d67d497f77376139c98fa2b5d9bcfcf6c12c24fa57d55b29ad1f569de30f
+  md5: 0d9bcc9297c8e179ee7e43b7af3b543a
+  depends:
+  - __osx >=10.13
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype
+  - kiwisolver >=1.3.1
+  - libcxx >=19
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - numpy >=1.23
+  - numpy >=1.23,<3
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8271784
+  timestamp: 1756870011797
+  purls:
+  - pkg:pypi/matplotlib?source=hash-mapping
+- conda: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.1.1-py311hd4d69bb_1.conda
+  sha256: f6a6ef1fb34547b473e68b1698e11b54cd0caa3819217d2fd9807586f0f4e242
+  md5: 5a924ec08e77329384e9d196ebd432de
+  depends:
+  - __osx >=10.13
+  - libcxx >=19
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 91405
+  timestamp: 1756678753596
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
+  sha256: ea4a5d27ded18443749aefa49dc79f6356da8506d508b5296f60b8d51e0c4bd9
+  md5: ced34dd9929f491ca6dab6a2927aff25
+  depends:
+  - __osx >=10.13
+  license: X11 AND BSD-3-Clause
+  size: 822259
+  timestamp: 1738196181298
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.61.2-py311hdda0fce_1.conda
+  sha256: 26f9139ea5ad205301be937a0c23a485ada3151976e4cec192063038b1390299
+  md5: 7011fb414ba203728eda8eb28e14943e
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - llvm-openmp >=18.1.8
+  - llvm-openmp >=20.1.6
+  - llvmlite >=0.44.0,<0.45.0a0
+  - numpy >=1.21,<3
+  - numpy >=1.24,<2.3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - tbb >=2021.6.0
+  - scipy >=1.0
+  - cudatoolkit >=11.2
+  - cuda-version >=11.2
+  - libopenblas !=0.3.6
+  - cuda-python >=11.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5995296
+  timestamp: 1749491556176
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numcodecs-0.16.1-py311hf4bc098_1.conda
+  sha256: c604abfd23bf545940edd1834f82ad254ac3170663e4369a1622c7071f4238fc
+  md5: a662ebe85a933cba8cc4fdfc9cc91659
+  depends:
+  - __osx >=10.13
+  - deprecated
+  - libcxx >=19
+  - msgpack-python
+  - numpy >=1.23,<3
+  - numpy >=1.24
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - typing_extensions
+  license: MIT
+  license_family: MIT
+  size: 759045
+  timestamp: 1756543000407
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.2.6-py311h27c81cd_0.conda
+  sha256: bcb2c6fd701f3591fd4cd04580ec62ad88622c09671139a98d82ca80e2ae365f
+  md5: 8e850d1284fd8a90aeb4b5195a0116f3
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8182747
+  timestamp: 1747545065417
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.3-h036ada5_1.conda
+  sha256: fea2a79edb123fda31d73857e96b6cd24404a31d41693d8ef41235caed74b28e
+  md5: 38f264b121a043cf379980c959fb2d75
+  depends:
+  - __osx >=10.13
+  - libcxx >=19
+  - libpng >=1.6.50,<1.7.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 336370
+  timestamp: 1754297904811
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.5.3-h230baf5_0.conda
+  sha256: b38470dc57c365e40cea5968f393f3d5ddd36bc779623a17b843f437fd15ea06
+  md5: d51f5ce62794a19fa67da1ff101bae05
+  depends:
+  - __osx >=10.13
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2743344
+  timestamp: 1758041755497
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.3.2-py311hf4bc098_0.conda
+  sha256: b61681152840b4690d714ef1c4d2ef1dfd1985e0fc5d5d811bcb629c484d2466
+  md5: 8df328d2c2b8f76d94c87c848a7b49a6
+  depends:
+  - __osx >=10.13
+  - libcxx >=19
+  - numpy >=1.22.4
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1
+  constrains:
+  - numexpr >=2.8.4
+  - fastparquet >=2022.12.0
+  - qtpy >=2.3.0
+  - scipy >=1.10.0
+  - sqlalchemy >=2.0.0
+  - lxml >=4.9.2
+  - html5lib >=1.1
+  - matplotlib >=3.6.3
+  - odfpy >=1.4.1
+  - xlrd >=2.0.1
+  - beautifulsoup4 >=4.11.2
+  - fsspec >=2022.11.0
+  - numba >=0.56.4
+  - blosc >=1.21.3
+  - pyqt5 >=5.15.9
+  - gcsfs >=2022.11.0
+  - tzdata >=2022.7
+  - xarray >=2022.12.0
+  - tabulate >=0.9.0
+  - psycopg2 >=2.9.6
+  - pyxlsb >=1.0.10
+  - bottleneck >=1.3.6
+  - pytables >=3.8.0
+  - xlsxwriter >=3.0.5
+  - zstandard >=0.19.0
+  - openpyxl >=3.1.0
+  - python-calamine >=0.1.7
+  - pandas-gbq >=0.19.0
+  - pyreadstat >=1.2.0
+  - pyarrow >=10.0.1
+  - s3fs >=2022.11.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14631576
+  timestamp: 1755779827936
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.3.0-py311h0d39b4b_2.conda
+  sha256: 1940eb93219d31f52d4f98969c15ebf4a0fd288bb0156c5893ad528ce71d265e
+  md5: 0bdacf38e695b5443c32915a37f34514
+  depends:
+  - __osx >=10.13
+  - freetype
+  - lcms2 >=2.17,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.3,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 920030
+  timestamp: 1758013366508
+- conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.0.0-py311h13e5629_1.conda
+  sha256: ce1b788a4bae81bd2246c7284d620152832b899394259f2f938755e13f3afc6c
+  md5: d69888db150233f54b39919c12070de5
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 490770
+  timestamp: 1755851533700
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+  sha256: 05944ca3445f31614f8c674c560bca02ff05cb51637a96f665cb2bbe496099e5
+  md5: 8bcf980d2c6b17094961198284b8e862
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 8364
+  timestamp: 1726802331537
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.1-py311h2f44256_1.conda
+  sha256: d0800d251981e3d124bd960e799dd0c56e8b16cd1c6fb99a32990d62f492d754
+  md5: 840b246b6b86c37321e79ca56518273f
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4.6,<3.5.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 486295
+  timestamp: 1756813198835
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.1-py311hbc8e8a3_1.conda
+  sha256: 71394c6e3f77898e856dab863f283e92f65b03e02e12fcf228bd3715a3459431
+  md5: ab2c871073a077d149d6da6d03d10e44
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4.6,<3.5.0a0
+  - pyobjc-core 11.1.*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 385837
+  timestamp: 1756824131805
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.13-h9ccd52b_0_cpython.conda
+  sha256: d8e15db837c10242658979bc475298059bd6615524f2f71365ab8e54fbfea43c
+  md5: 6e28c31688c6f1fdea3dc3d48d33e1c0
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.7.0,<3.0a0
+  - libffi >=3.4.6,<3.5.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libsqlite >=3.50.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.5.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 15423460
+  timestamp: 1749049420299
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311ha3cf9ac_2.conda
+  sha256: 4855c51eedcde05f3d9666a0766050c7cbdff29b150d63c1adc4071637ba61d7
+  md5: f49b0da3b1e172263f4f1e2f261a490d
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 197287
+  timestamp: 1737454852180
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-27.1.0-py311h0ab6910_0.conda
+  sha256: a0200b5e781c22a5d7b64fd0edf5e9ab881772f7a15a6bc2359db8d0ac437bb3
+  md5: 840bdfbb93e35d650205af10883ff8a0
+  depends:
+  - python
+  - libcxx >=19
+  - __osx >=10.13
+  - zeromq >=4.3.5,<4.4.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 362304
+  timestamp: 1757387126324
+- conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+  sha256: 79d804fa6af9c750e8b09482559814ae18cd8df549ecb80a4873537a5a31e06e
+  md5: dd1ea9ff27c93db7c01a7b7656bd4ad4
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: LicenseRef-Qhull
+  size: 528122
+  timestamp: 1720814002588
+- conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h7cca4af_2.conda
+  sha256: 53017e80453c4c1d97aaf78369040418dea14cf8f46a2fa999f31bd70b36c877
+  md5: 342570f8e02f2f022147a7f841475784
+  depends:
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 256712
+  timestamp: 1740379577668
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.27.1-py311hd3d88a1_1.conda
+  sha256: 85357c87af076680c071a8ea843bea554d58694d011104b721cc13bbf9ad0e75
+  md5: 4b9839b15de18289ee5289a6dbcb8a45
+  depends:
+  - python
+  - __osx >=10.13
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 376118
+  timestamp: 1756737583772
+- conda: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.7.2-py311had5a2ce_0.conda
+  sha256: 7adab19ad8211ab267366046c199bda63b85a11833d73901cd8137cf555ddf51
+  md5: 35e84df764fb918f99c17602376d6a84
+  depends:
+  - __osx >=10.13
+  - joblib >=1.2.0
+  - libcxx >=19
+  - llvm-openmp >=19.1.7
+  - numpy >=1.22.0
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scipy >=1.8.0
+  - threadpoolctl >=3.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9157602
+  timestamp: 1757407090554
+- conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.16.2-py311h32c7e5c_0.conda
+  sha256: 8d8e69daa49c3c876fcacc31d31698d6d103e133c87c3d046fa67be4c0ad4a94
+  md5: 8bf3fee43462b21388d04251f37159e6
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=19
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - libgfortran5 >=15.1.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.6
+  - numpy >=1.23,<3
+  - numpy >=1.25.2
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15295538
+  timestamp: 1757683511655
+- conda: https://conda.anaconda.org/conda-forge/osx-64/statsmodels-0.14.5-py311ha2d3830_0.conda
+  sha256: 6dcc2a61a73de340317241d70f9f47499c69a62e508b8b251af738bff631f1de
+  md5: 2d429e456dd67796ed0e3114fb559f82
+  depends:
+  - __osx >=10.13
+  - numpy <3,>=1.22.3
+  - numpy >=1.23,<3
+  - packaging >=21.3
+  - pandas !=2.1.0,>=1.4
+  - patsy >=0.5.6
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scipy !=1.9.2,>=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11852156
+  timestamp: 1751918004113
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tbb-2022.2.0-hc025b3e_1.conda
+  sha256: 44d9b5795d8c72da1002ef504c16eadcb8615c9c8098c830c12ebacae31149ed
+  md5: 796b8d4a40afd4951d87ffd939c6a206
+  depends:
+  - __osx >=10.13
+  - libcxx >=19
+  - libhwloc >=2.12.1,<2.12.2.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 164273
+  timestamp: 1755776307318
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hf689a15_2.conda
+  sha256: b24468006a96b71a5f4372205ea7ec4b399b0f2a543541e86f883de54cd623fc
+  md5: 9864891a6946c2fe037c02fca7392ab4
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: TCL
+  license_family: BSD
+  size: 3259809
+  timestamp: 1748387843735
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.5.2-py311h13e5629_1.conda
+  sha256: 397226b6314aec2b076294816c941c1e9b7e3bbcf7a2e9dc9ba08f3ac10b0590
+  md5: 06fd6a712ee16b3e7998e8ee2e7fc8b1
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 869912
+  timestamp: 1756855230920
+- conda: https://conda.anaconda.org/conda-forge/osx-64/umap-learn-0.5.9.post2-py311h6eed73b_0.conda
+  sha256: 7ee998e66c77963170a53a80c47c8e568a527d5fc365335750f4f2021ce1b3bd
+  md5: 24e74513a8f65e2d772961ad0ab4c9be
+  depends:
+  - numba >=0.51.2
+  - numpy >=1.17
+  - pynndescent >=0.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scikit-learn >=0.22
+  - scipy >=1.3.1
+  - setuptools
+  - tbb >=2019.0
+  - tqdm
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 197095
+  timestamp: 1751544661566
+- conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-16.0.0-py311h13e5629_1.conda
+  sha256: cdd1276ff295078efb932f21305abda5392e8e43e7787050ea2d5ccbc04981ef
+  md5: 4199c0fe9c425eddb08f5741fcb772c5
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 400393
+  timestamp: 1756494700657
+- conda: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.17.3-py311h13e5629_1.conda
+  sha256: 69a040e11d6967e7a3b8a0a1730016e7668e7904686450fa8bc2ff74de68fe7a
+  md5: e61d11880c60001e858cc591ce35973f
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 61909
+  timestamp: 1756851726109
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.12-h6e16a3a_0.conda
+  sha256: b4d2225135aa44e551576c4f3cf999b3252da6ffe7b92f0ad45bb44b887976fc
+  md5: 4cf40e60b444d56512a64f39d12c20bd
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 13290
+  timestamp: 1734229077182
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
+  sha256: bb4d1ef9cafef535494adf9296130b6193b3a44375883185b5167de03eb1ac7f
+  md5: 9f438e1b6f4e73fd9e6d78bfe7c36743
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 18465
+  timestamp: 1727794980957
+- conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
+  sha256: a335161bfa57b64e6794c3c354e7d49449b28b8d8a7c4ed02bf04c3f009953f9
+  md5: a645bb90997d3fc2aea0adf6517059bd
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 79419
+  timestamp: 1753484072608
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h6c33b1e_9.conda
+  sha256: 30aa5a2e9c7b8dbf6659a2ccd8b74a9994cdf6f87591fcc592970daa6e7d3f3c
+  md5: d940d809c42fbf85b05814c3290660f5
+  depends:
+  - __osx >=10.13
+  - libcxx >=19
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 259628
+  timestamp: 1757371000392
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.25.0-py311h62e9434_0.conda
+  sha256: be241ea3ca603d68654beeab4c991c225c9361378a107f72c2433ddfdff88132
+  md5: 5425495af6b0b010230320d618022f20
+  depends:
+  - python
+  - cffi >=1.11
+  - zstd >=1.5.7,<1.5.8.0a0
+  - __osx >=10.13
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 462903
+  timestamp: 1757930157317
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h8210216_2.conda
+  sha256: c171c43d0c47eed45085112cb00c8c7d4f0caa5a32d47f2daca727e45fb98dca
+  md5: cd60a4a5a8d6a476b30d8aa4bb49251a
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 485754
+  timestamp: 1742433356230
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-25.1.0-py311h3696347_0.conda
+  sha256: f5b4102716a568877e212a9d4c677027b887f215d4735acfe4532efb2da59de1
+  md5: 3b4ba20f581ec2268df5a76c64232ae5
+  depends:
+  - __osx >=11.0
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 34325
+  timestamp: 1753995031680
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-h6caf38d_4.conda
+  sha256: 8aa8ee52b95fdc3ef09d476cbfa30df722809b16e6dca4a4f80e581012035b7b
+  md5: ce8659623cea44cc812bc0bfae4041c5
+  depends:
+  - __osx >=11.0
+  - brotli-bin 1.1.0 h6caf38d_4
+  - libbrotlidec 1.1.0 h6caf38d_4
+  - libbrotlienc 1.1.0 h6caf38d_4
+  license: MIT
+  license_family: MIT
+  size: 20003
+  timestamp: 1756599758165
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-h6caf38d_4.conda
+  sha256: e57d402b02c9287b7c02d9947d7b7b55a4f7d73341c210c233f6b388d4641e08
+  md5: ab57f389f304c4d2eb86d8ae46d219c3
+  depends:
+  - __osx >=11.0
+  - libbrotlidec 1.1.0 h6caf38d_4
+  - libbrotlienc 1.1.0 h6caf38d_4
+  license: MIT
+  license_family: MIT
+  size: 17373
+  timestamp: 1756599741779
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311hf719da1_4.conda
+  sha256: 64645da991de052f0e522486cf97f8457fb37ed5c30d67655d3a32d2b9f56167
+  md5: 4cd43bb7ba1a3cb4cd7a2e335f6d3c32
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 h6caf38d_4
+  license: MIT
+  license_family: MIT
+  size: 340889
+  timestamp: 1756599941690
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
+  sha256: b456200636bd5fecb2bec63f7e0985ad2097cf1b83d60ce0b6968dffa6d02aa1
+  md5: 58fd217444c2a5701a44244faf518206
+  depends:
+  - __osx >=11.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 125061
+  timestamp: 1757437486465
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.5-h5505292_0.conda
+  sha256: b4bb55d0806e41ffef94d0e3f3c97531f322b3cb0ca1f7cdf8e47f62538b7a2b
+  md5: f8cd1beb98240c7edb1a95883360ccfa
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 179696
+  timestamp: 1744128058734
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py311h146a0b8_1.conda
+  sha256: 97635f50d473eae17e11b954570efdc66b615dfa6321dd069742d6df4c14a8ba
+  md5: 1c72ccc307e7681c34e1c06c1711ee33
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4.6,<3.5.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 293204
+  timestamp: 1756808628759
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.3-py311h57a9ea7_2.conda
+  sha256: 3d85887270eb5f9f82025c93956cef6ff12a1aab49dbf7cba5ca4ee0544d4182
+  md5: 66103afd2e02f1a416930dc352ae327b
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - numpy >=1.25
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 259587
+  timestamp: 1756545016847
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/crc32c-2.7.1-py311hb76fab6_2.conda
+  sha256: 0a08956eb045084cc90dd981e10e99a973f839880fc18a35fe864731cd4c8efa
+  md5: 0b2957e663ab045966e2c787ac5cc285
+  depends:
+  - python
+  - python 3.11.* *_cpython
+  - __osx >=11.0
+  - python_abi 3.11.* *_cp311
+  license: LGPL-2.1-or-later
+  size: 52342
+  timestamp: 1756602289074
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.16-py311ha59bd64_1.conda
+  sha256: eea58c83203a96c1967574d495860bab109c52e10b41c5ac12daad7b66b81e70
+  md5: 9d7f1641fc7385ed8dfc337d35ad4008
+  depends:
+  - python
+  - libcxx >=19
+  - python 3.11.* *_cpython
+  - __osx >=11.0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2666633
+  timestamp: 1756742041729
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.59.2-py311h2fe624c_0.conda
+  sha256: 2d3dadff13a846513f81ece2ae356e4502f4edb5a5ebe58d21ecac7befed072a
+  md5: 70bc71c4717c3a4700988f96eeabf09a
+  depends:
+  - __osx >=11.0
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2866929
+  timestamp: 1756328916569
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.14.1-hce30654_0.conda
+  sha256: 14427aecd72e973a73d5f9dfd0e40b6bc3791d253de09b7bf233f6a9a190fd17
+  md5: 1ec9a1ee7a2c9339774ad9bb6fe6caec
+  depends:
+  - libfreetype 2.14.1 hce30654_0
+  - libfreetype6 2.14.1 h6da58f4_0
+  license: GPL-2.0-only OR FTL
+  size: 173399
+  timestamp: 1757947175403
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.14.0-nompi_py311h1d03b57_101.conda
+  sha256: d8f56e7ad233e37b0e91f204b63ec28e83c19285f7d62dedc201525f6cc0f12b
+  md5: 67a61d95d3be80013fbdac3afb260528
+  depends:
+  - __osx >=11.0
+  - cached-property
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1170719
+  timestamp: 1756767948292
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.6-nompi_he65715a_103.conda
+  sha256: 8948a63fc4a56536ce7b2716b781616c3909507300d26e9f265a3c13d59708a0
+  md5: fcc9aca330f13d071bfc4de3d0942d78
+  depends:
+  - __osx >=11.0
+  - libaec >=1.1.4,<2.0a0
+  - libcurl >=8.14.1,<9.0a0
+  - libcxx >=19
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - libgfortran5 >=15.1.0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3308443
+  timestamp: 1753356976982
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+  sha256: 9ba12c93406f3df5ab0a43db8a4b4ef67a5871dfd401010fbe29b218b2cbe620
+  md5: 5eb22c1d7b3fc4abb50d92d621583137
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 11857802
+  timestamp: 1720853997952
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py311h267d04e_2.conda
+  sha256: 92b998fa9e68b7793b5b15882932f7703cdc1cc6e1348d0a1799567ef6f04428
+  md5: 0edc5f25c32d86d5b4327e0f4de539f9
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18716
+  timestamp: 1756754690458
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.9-py311h63e5c0c_1.conda
+  sha256: ad672ae48e23e59a6adbff2b51fb47bfc1bf430f8e991dbf086b2506caf9eb31
+  md5: d5778729cfb3846a9d329c8740f13420
+  depends:
+  - python
+  - python 3.11.* *_cpython
+  - libcxx >=19
+  - __osx >=11.0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 66093
+  timestamp: 1756467632843
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+  sha256: 4442f957c3c77d69d9da3521268cad5d54c9033f1a73f99cde0a3658937b159b
+  md5: c6dc8a0fdec13a0565936655c33069a1
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1155530
+  timestamp: 1719463474401
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.17-h7eeda09_0.conda
+  sha256: 310a62c2f074ebd5aa43b3cd4b00d46385ce680fa2132ecee255a200e2d2f15f
+  md5: 92a61fd30b19ebd5c1621a5bfe6d8b5f
+  depends:
+  - __osx >=11.0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 212125
+  timestamp: 1739161108467
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-hd64df32_1.conda
+  sha256: 12361697f8ffc9968907d1a7b5830e34c670e4a59b638117a2cdfed8f63a38f8
+  md5: a74332d9b60b62905e3d30709df08bf1
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 188306
+  timestamp: 1745264362794
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.4-h51d1e36_0.conda
+  sha256: 0ea6b73b3fb1511615d9648186a7409e73b7a8d9b3d890d39df797730e3d1dbb
+  md5: 8ed0f86b7a5529b98ec73b43a53ce800
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30173
+  timestamp: 1749993648288
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-35_h51639a9_openblas.conda
+  sha256: 9eb9a0ba654824c10ae1246124a0ecaea9d6f8abd98d43ddfc5e36931191843d
+  md5: f6ff3c5ed6d55bdede368a8670c3ff99
+  depends:
+  - libopenblas >=0.3.30,<0.3.31.0a0
+  - libopenblas >=0.3.30,<1.0a0
+  constrains:
+  - liblapack  3.9.0   35*_openblas
+  - liblapacke 3.9.0   35*_openblas
+  - mkl <2025
+  - blas 2.135   openblas
+  - libcblas   3.9.0   35*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17354
+  timestamp: 1757447500683
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-h6caf38d_4.conda
+  sha256: 023b609ecc35bfee7935d65fcc5aba1a3ba6807cbba144a0730198c0914f7c79
+  md5: 231cffe69d41716afe4525c5c1cc5ddd
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 68938
+  timestamp: 1756599687687
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-h6caf38d_4.conda
+  sha256: 7f1cf83a00a494185fc087b00c355674a0f12e924b1b500d2c20519e98fdc064
+  md5: cb7e7fe96c9eee23a464afd57648d2cd
+  depends:
+  - __osx >=11.0
+  - libbrotlicommon 1.1.0 h6caf38d_4
+  license: MIT
+  license_family: MIT
+  size: 29015
+  timestamp: 1756599708339
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-h6caf38d_4.conda
+  sha256: a2f2c1c2369360147c46f48124a3a17f5122e78543275ff9788dc91a1d5819dc
+  md5: 4ce5651ae5cd6eebc5899f9bfe0eac3c
+  depends:
+  - __osx >=11.0
+  - libbrotlicommon 1.1.0 h6caf38d_4
+  license: MIT
+  license_family: MIT
+  size: 275791
+  timestamp: 1756599724058
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-35_hb0561ab_openblas.conda
+  sha256: 0697193d58b13ee71a2f43fb44654b3c07a07bbac8843bc5de3fa2996a49bd34
+  md5: 917dc7f4359ede7649d52a6d07a39902
+  depends:
+  - libblas 3.9.0 35_h51639a9_openblas
+  constrains:
+  - liblapack  3.9.0   35*_openblas
+  - liblapacke 3.9.0   35*_openblas
+  - blas 2.135   openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17338
+  timestamp: 1757447513089
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.14.1-h73640d1_0.conda
+  sha256: 0055b68137309db41ec34c938d95aec71d1f81bd9d998d5be18f32320c3ccba0
+  md5: 1af57c823803941dfc97305248a56d57
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.64.0,<2.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 403456
+  timestamp: 1749033320430
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.1-hf598326_0.conda
+  sha256: 6af03355967b7b097d5820dde05e0c709945fdb01f4bc56d11499d8bf7435239
+  md5: d5790f3769fedeea4e021483272bdc53
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 568291
+  timestamp: 1757525671408
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.24-h5773f1b_0.conda
+  sha256: 417d52b19c679e1881cce3f01cad3a2d542098fa2d6df5485aac40f01aede4d1
+  md5: 3baf58a5a87e7c2f4d243ce2f8f2fe5c
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 54790
+  timestamp: 1747040549847
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
+  sha256: 66aa216a403de0bb0c1340a88d1a06adaff66bae2cfd196731aa24db9859d631
+  md5: 44083d2d2c2025afca315c7a172eab2b
+  depends:
+  - ncurses
+  - __osx >=11.0
+  - ncurses >=6.5,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 107691
+  timestamp: 1738479560845
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+  sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
+  md5: 36d33e440c31857372a72137f78bacf5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 107458
+  timestamp: 1702146414478
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.1-hec049ff_0.conda
+  sha256: 8fbb17a56f51e7113ed511c5787e0dec0d4b10ef9df921c4fd1cccca0458f648
+  md5: b1ca5f21335782f71a8bd69bdc093f67
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.7.1.*
+  license: MIT
+  license_family: MIT
+  size: 65971
+  timestamp: 1752719657566
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
+  sha256: c6a530924a9b14e193ea9adfe92843de2a806d1b7dbfd341546ece9653129e60
+  md5: c215a60c2935b517dcda8cad4705734d
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 39839
+  timestamp: 1743434670405
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.1-hce30654_0.conda
+  sha256: 9de25a86066f078822d8dd95a83048d7dc2897d5d655c0e04a8a54fca13ef1ef
+  md5: f35fb38e89e2776994131fbf961fa44b
+  depends:
+  - libfreetype6 >=2.14.1
+  license: GPL-2.0-only OR FTL
+  size: 7810
+  timestamp: 1757947168537
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.14.1-h6da58f4_0.conda
+  sha256: cc4aec4c490123c0f248c1acd1aeab592afb6a44b1536734e20937cda748f7cd
+  md5: 6d4ede03e2a8e20eb51f7f681d2a2550
+  depends:
+  - __osx >=11.0
+  - libpng >=1.6.50,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - freetype >=2.14.1
+  license: GPL-2.0-only OR FTL
+  size: 346703
+  timestamp: 1757947166116
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.1.0-hfdf1602_1.conda
+  sha256: 981e3fac416e80b007a2798d6c1d4357ebebeb72a039aca1fb3a7effe9dcae86
+  md5: c98207b6e2b1a309abab696d229f163e
+  depends:
+  - libgfortran5 15.1.0 hb74de2c_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 134383
+  timestamp: 1756239485494
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.1.0-hb74de2c_1.conda
+  sha256: 1f8f5b2fdd0d2559d0f3bade8da8f57e9ee9b54685bd6081c6d6d9a2b0239b41
+  md5: 4281bd1c654cb4f5cab6392b3330451f
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 15.1.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 759679
+  timestamp: 1756238772083
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.12.1-default_h48b22c3_1002.conda
+  sha256: 90d3be72bfcb74541c6a8c48fdb3c903c2e7bf9ea66649d743c204a636e9e0bb
+  md5: 39a1c6805c7a3d2d5ad304ac015d5124
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2355866
+  timestamp: 1757624101657
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
+  sha256: de0336e800b2af9a40bdd694b03870ac4a848161b35c8a2325704f123f185f03
+  md5: 4d5a7445f0b25b6a3ddbb56e790f5251
+  depends:
+  - __osx >=11.0
+  license: LGPL-2.1-only
+  size: 750379
+  timestamp: 1754909073836
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.1.0-h5505292_0.conda
+  sha256: 78df2574fa6aa5b6f5fc367c03192f8ddf8e27dc23641468d54e031ff560b9d4
+  md5: 01caa4fbcaf0e6b08b3aef1151e91745
+  depends:
+  - __osx >=11.0
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 553624
+  timestamp: 1745268405713
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-35_hd9741b5_openblas.conda
+  sha256: dc7127de1aafcf77efc1b44b854bd648ba59113cd1f364e38b2fa868763913d0
+  md5: 270789394f52de7ae5e5328dfe7e26c1
+  depends:
+  - libblas 3.9.0 35_h51639a9_openblas
+  constrains:
+  - liblapacke 3.9.0   35*_openblas
+  - libcblas   3.9.0   35*_openblas
+  - blas 2.135   openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17374
+  timestamp: 1757447527491
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
+  sha256: 0cb92a9e026e7bd4842f410a5c5c665c89b2eb97794ffddba519a626b8ce7285
+  md5: d6df911d4564d77c4374b02552cb17d1
+  depends:
+  - __osx >=11.0
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD
+  size: 92286
+  timestamp: 1749230283517
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.67.0-hc438710_0.conda
+  sha256: a07cb53b5ffa2d5a18afc6fd5a526a5a53dd9523fbc022148bd2f9395697c46d
+  md5: a4b4dd73c67df470d091312ab87bf6ae
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.34.5,<2.0a0
+  - libcxx >=19
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 575454
+  timestamp: 1756835746393
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.30-openmp_h60d53f8_2.conda
+  sha256: 7b8551a4d21cf0b19f9a162f1f283a201b17f1bd5a6579abbd0d004788c511fa
+  md5: d004259fd8d3d2798b16299d6ad6c9e9
+  depends:
+  - __osx >=11.0
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - llvm-openmp >=19.1.7
+  constrains:
+  - openblas >=0.3.30,<0.3.31.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4284696
+  timestamp: 1755471861128
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.50-h280e0eb_1.conda
+  sha256: a2e0240fb0c79668047b528976872307ea80cb330baf8bf6624ac2c6443449df
+  md5: 4d0f5ce02033286551a32208a5519884
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 287056
+  timestamp: 1753879907258
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
+  sha256: fade8223e1e1004367d7101dd17261003b60aa576df6d7802191f8972f7470b1
+  md5: a7ce36e284c5faaf93c220dfc39e3abd
+  depends:
+  - __osx >=11.0
+  license: ISC
+  size: 164972
+  timestamp: 1716828607917
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.50.4-h4237e3c_0.conda
+  sha256: 802ebe62e6bc59fc26b26276b793e0542cfff2d03c086440aeaf72fb8bbcec44
+  md5: 1dcb0468f5146e38fae99aef9656034b
+  depends:
+  - __osx >=11.0
+  - icu >=75.1,<76.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: blessing
+  size: 902645
+  timestamp: 1753948599139
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
+  sha256: 8bfe837221390ffc6f111ecca24fa12d4a6325da0c8d131333d63d6c37f27e0a
+  md5: b68e8f66b94b44aaa8de4583d3d4cc40
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279193
+  timestamp: 1745608793272
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-h025e3ab_6.conda
+  sha256: d6ed4b307dde5d66b73aa3f155b3ed40ba9394947cfe148e2cd07605ef4b410b
+  md5: d0862034c2c563ef1f52a3237c133d8d
+  depends:
+  - __osx >=11.0
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=19
+  - libdeflate >=1.24,<1.26.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: HPND
+  size: 372136
+  timestamp: 1755012109767
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.6.0-h07db88b_0.conda
+  sha256: a4de3f371bb7ada325e1f27a4ef7bcc81b2b6a330e46fac9c2f78ac0755ea3dd
+  md5: e5e7d467f80da752be17796b87fe6385
+  depends:
+  - __osx >=11.0
+  constrains:
+  - libwebp 1.6.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 294974
+  timestamp: 1752159906788
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+  sha256: bd3816218924b1e43b275863e21a3e13a5db4a6da74cca8e60bc3c213eb62f71
+  md5: af523aae2eca6dfa1c8eec693f5b9a79
+  depends:
+  - __osx >=11.0
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 323658
+  timestamp: 1727278733917
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.0-h0ff4647_0.conda
+  sha256: db7bd5ce52c4dfd625e5669ac1ce91948aadbc64492687f4fa0adc535d2a1846
+  md5: a85dc9eaa4c77ddaecf8287a7a077981
+  depends:
+  - __osx >=11.0
+  - icu >=75.1,<76.0a0
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - libxml2 2.15.0
+  license: MIT
+  license_family: MIT
+  size: 464890
+  timestamp: 1757953505475
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.0-h9329255_0.conda
+  sha256: 927e45f9d36a38ef4e8cc84a86da20fc5a230b70d8f276b6dde75858b77777b2
+  md5: d553eb53ea3f6fc1c40dcfd139cf1d6b
+  depends:
+  - __osx >=11.0
+  - icu >=75.1,<76.0a0
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libxml2-16 2.15.0 h0ff4647_0
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 40345
+  timestamp: 1757953519097
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
+  md5: 369964e85dc26bfe78f41399b366c435
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 46438
+  timestamp: 1727963202283
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-21.1.0-hbb9b287_0.conda
+  sha256: c6750073a128376a14bedacfa90caab4c17025c9687fcf6f96e863b28d543af4
+  md5: e57d95fec6eaa747e583323cba6cfe5c
+  depends:
+  - __osx >=11.0
+  constrains:
+  - intel-openmp <0.0a0
+  - openmp 21.1.0|21.1.0.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 286039
+  timestamp: 1756673290280
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.44.0-py311h674d19a_2.conda
+  sha256: 19464d683b39de80f4c10a90ad122ce946b9c093ec42f79051a8ee0d100f2cb2
+  md5: cc38a7e6448eac18fa5f572f0070e0b1
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18896711
+  timestamp: 1756303991985
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py311h4921393_1.conda
+  sha256: 4f738a7c80e34e5e5d558e946b06d08e7c40e3cc4bdf08140bf782c359845501
+  md5: 249e2f6f5393bb6b36b3d3a3eebdcdf9
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24976
+  timestamp: 1733219849253
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.10.6-py311h66dac5a_0.conda
+  sha256: 198ddbc9aa2a86987b87ebbcee9db2a5a1716bdd31ffd96c118f403e003e0474
+  md5: 5f6150ef5ff86560f9b77c8d1aa20b96
+  depends:
+  - __osx >=11.0
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype
+  - kiwisolver >=1.3.1
+  - libcxx >=19
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - numpy >=1.23
+  - numpy >=1.23,<3
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8225464
+  timestamp: 1756835662332
+  purls:
+  - pkg:pypi/matplotlib?source=hash-mapping
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.1-py311h57a9ea7_1.conda
+  sha256: f4dc6a233cf14f3d1eb376e8611d2ec9d9cf47318cda27e6472efeeb9bfd7ed2
+  md5: ebe143e3d985c76b790a1bd79e24d3f1
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 90851
+  timestamp: 1756678775075
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
+  sha256: 2827ada40e8d9ca69a153a45f7fd14f32b2ead7045d3bbb5d10964898fe65733
+  md5: 068d497125e4bf8a66bf707254fff5ae
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  size: 797030
+  timestamp: 1738196177597
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.61.2-py311hdc76553_1.conda
+  sha256: 7da1684febe2617f5d78efe6e3ba3a94af6138bb6b3b28f76ca8e843e4933433
+  md5: 363d85d770ee8085e095d10dfc2e5432
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - llvm-openmp >=18.1.8
+  - llvm-openmp >=20.1.6
+  - llvmlite >=0.44.0,<0.45.0a0
+  - numpy >=1.21,<3
+  - numpy >=1.24,<2.3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - scipy >=1.0
+  - libopenblas >=0.3.18,!=0.3.20
+  - tbb >=2021.6.0
+  - cuda-python >=11.6
+  - cuda-version >=11.2
+  - cudatoolkit >=11.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5916594
+  timestamp: 1749491861087
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numcodecs-0.16.1-py311hff7e5bb_1.conda
+  sha256: 5b5a5dca97fc0cfb3166142dea735406611f5b4ac453feb0999918b81213bb40
+  md5: bd416067f5988dc7f9a6583e1e26e5cb
+  depends:
+  - __osx >=11.0
+  - deprecated
+  - libcxx >=19
+  - msgpack-python
+  - numpy >=1.23,<3
+  - numpy >=1.24
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - typing_extensions
+  license: MIT
+  license_family: MIT
+  size: 663579
+  timestamp: 1756543145516
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.2.6-py311h762c074_0.conda
+  sha256: c6cd42960418a2bd60cfbc293f08d85076f7d8aacf7a94f516195381241d4d93
+  md5: 9446d2629b529e92769dfb34c7c194bb
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7018728
+  timestamp: 1747545122995
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.3-h889cd5d_1.conda
+  sha256: 6013916893fcd9bc97c479279cfe4616de7735ec566bad0ee41bc729e14d31b2
+  md5: ab581998c77c512d455a13befcddaac3
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libpng >=1.6.50,<1.7.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 320198
+  timestamp: 1754297986425
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.5.3-h5503f6c_0.conda
+  sha256: c547508f11f214125fe5fc66da3d5a5dad6a9204315ee880b5ba65cdb32b6572
+  md5: 161d97c4c31b7851617119e6f851927f
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 3069340
+  timestamp: 1758040933817
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.3.2-py311hff7e5bb_0.conda
+  sha256: eb63f2d792b8eb69d1d53750fdde083f0bcf5b928cb069a1e557016a01ce4d71
+  md5: b28dbf599ee12914447e0b60530950d2
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - numpy >=1.22.4
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1
+  constrains:
+  - pandas-gbq >=0.19.0
+  - zstandard >=0.19.0
+  - pyarrow >=10.0.1
+  - lxml >=4.9.2
+  - xarray >=2022.12.0
+  - xlsxwriter >=3.0.5
+  - pytables >=3.8.0
+  - pyreadstat >=1.2.0
+  - psycopg2 >=2.9.6
+  - odfpy >=1.4.1
+  - qtpy >=2.3.0
+  - openpyxl >=3.1.0
+  - html5lib >=1.1
+  - fastparquet >=2022.12.0
+  - python-calamine >=0.1.7
+  - sqlalchemy >=2.0.0
+  - beautifulsoup4 >=4.11.2
+  - scipy >=1.10.0
+  - pyqt5 >=5.15.9
+  - gcsfs >=2022.11.0
+  - blosc >=1.21.3
+  - bottleneck >=1.3.6
+  - s3fs >=2022.11.0
+  - pyxlsb >=1.0.10
+  - xlrd >=2.0.1
+  - fsspec >=2022.11.0
+  - tabulate >=0.9.0
+  - matplotlib >=3.6.3
+  - numexpr >=2.8.4
+  - tzdata >=2022.7
+  - numba >=0.56.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14406952
+  timestamp: 1755779878619
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.3.0-py311h3f9ac88_2.conda
+  sha256: 71de25f7256b9f4d49d72abf51896c1ae4b8f5a48aafc5f067b4536f9fd66ccb
+  md5: 72a052035e0355cca5e24bb581d7340a
+  depends:
+  - __osx >=11.0
+  - freetype
+  - lcms2 >=2.17,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.3,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 910398
+  timestamp: 1758013095951
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.0.0-py311h3696347_1.conda
+  sha256: c21cd67c4037f232ba539f221839d1bcc7dbcc416d51f821fd319d91b5b61c3b
+  md5: c449b450f0c81bc09e6a59a07adf95a1
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 493127
+  timestamp: 1755851546773
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+  sha256: 8ed65e17fbb0ca944bfb8093b60086e3f9dd678c3448b5de212017394c247ee3
+  md5: 415816daf82e0b23a736a069a75e9da7
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 8381
+  timestamp: 1726802424786
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-11.1-py311hf0763de_1.conda
+  sha256: c5cbb88710d690ae2f571037708026abb8f15de1a4d764e4b825aaad6c4549c8
+  md5: 8c42827190081e9c29a1007454890067
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4.6,<3.5.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 477833
+  timestamp: 1756813465248
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-11.1-py311hc5b188e_1.conda
+  sha256: 62db0aa2d3a23ae2ca2c28f2c462e63c0911903169c72a139a9e659e3ed02b19
+  md5: ee9a511c6ffa04ac806bd2987b2b093d
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4.6,<3.5.0a0
+  - pyobjc-core 11.1.*
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 387176
+  timestamp: 1756824223349
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.13-hc22306f_0_cpython.conda
+  sha256: 2c966293ef9e97e66b55747c7a97bc95ba0311ac1cf0d04be4a51aafac60dcb1
+  md5: 95facc4683b7b3b9cf8ae0ed10f30dce
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.7.0,<3.0a0
+  - libffi >=3.4.6,<3.5.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libsqlite >=3.50.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.5.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 14573820
+  timestamp: 1749048947732
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h4921393_2.conda
+  sha256: 2af6006c9f692742181f4aa2e0656eb112981ccb0b420b899d3dd42c881bd72f
+  md5: 250b2ee8777221153fd2de9c279a7efa
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 196951
+  timestamp: 1737454935552
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py311h13abfa4_0.conda
+  sha256: 5a213744d267241e23f849c7671dc97eb98d7789fb559bf5d423ae1884294c7e
+  md5: 0d16883d4ab2d3fcb38460d018d6762f
+  depends:
+  - python
+  - __osx >=11.0
+  - libcxx >=19
+  - python 3.11.* *_cpython
+  - zeromq >=4.3.5,<4.4.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 359600
+  timestamp: 1757387159663
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+  sha256: 873ac689484262a51fd79bc6103c1a1bedbf524924d7f0088fb80703042805e4
+  md5: 6483b1f59526e05d7d894e466b5b6924
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: LicenseRef-Qhull
+  size: 516376
+  timestamp: 1720814307311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
+  sha256: 7db04684d3904f6151eff8673270922d31da1eea7fa73254d01c437f49702e34
+  md5: 63ef3f6e6d6d5c589e64f11263dc5676
+  depends:
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 252359
+  timestamp: 1740379663071
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.27.1-py311h1c3fc1a_1.conda
+  sha256: 95714a24265b6b4d4b218e303dcb075ba435826cb1d5927792ec94a8196c3e72
+  md5: 5236ffaff99e6421aa4431b4c00ca47a
+  depends:
+  - python
+  - python 3.11.* *_cpython
+  - __osx >=11.0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 362213
+  timestamp: 1756737586989
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.7.2-py311h0f965f6_0.conda
+  sha256: ef398e0e3e57680fe0422ba56245c54b3d7114c7a6e31ff0367bfbd7c553c05b
+  md5: 5d571c9769910a3377d13230be348f47
+  depends:
+  - __osx >=11.0
+  - joblib >=1.2.0
+  - libcxx >=19
+  - llvm-openmp >=19.1.7
+  - numpy >=1.22.0
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - scipy >=1.8.0
+  - threadpoolctl >=3.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9169335
+  timestamp: 1757407114262
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.16.2-py311h2734c94_0.conda
+  sha256: 972cd4e6379ad2ff96e36fd629c4dd0b2f32328f858848bfab8ad9a95c7f1d5e
+  md5: dfe66d7dfba5ee328467bc10c4df4718
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=19
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - libgfortran5 >=15.1.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.6
+  - numpy >=1.23,<3
+  - numpy >=1.25.2
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14047114
+  timestamp: 1757684291857
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.5-py311h9dc9093_0.conda
+  sha256: a12928c2ed682227bbae9962519fb3316a9162db3c73a3afbb97138fdc3a7173
+  md5: 0bb11b13609c9212051ea0c20a2acf2e
+  depends:
+  - __osx >=11.0
+  - numpy <3,>=1.22.3
+  - numpy >=1.23,<3
+  - packaging >=21.3
+  - pandas !=2.1.0,>=1.4
+  - patsy >=0.5.6
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - scipy !=1.9.2,>=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11795676
+  timestamp: 1751917879126
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2022.2.0-h5b2e6d4_1.conda
+  sha256: 561cc8c407880ff6f3965778f78c860d93d3b9c5bd206ba9aac7c437794d4155
+  md5: 1cdd70110585806da18f400d30d9b497
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libhwloc >=2.12.1,<2.12.2.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 119970
+  timestamp: 1755776161308
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
+  sha256: cb86c522576fa95c6db4c878849af0bccfd3264daf0cc40dd18e7f4a7bfced0e
+  md5: 7362396c170252e7b7b0c8fb37fe9c78
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: TCL
+  license_family: BSD
+  size: 3125538
+  timestamp: 1748388189063
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.2-py311h3696347_1.conda
+  sha256: 4941963a1f0046b2813bfbe4c2ded15cb0b0048436fe62237d69467e8c0e1692
+  md5: 25833dd6cb94341239aec42dd5370c33
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 870380
+  timestamp: 1756855179889
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/umap-learn-0.5.9.post2-py311h267d04e_0.conda
+  sha256: 7c2e38f5af59440ca29b670712edd3b829d45c6e590e6b20a42859c99c7b609e
+  md5: c160abdbcb62729bb3a2ddc732aa2bae
+  depends:
+  - numba >=0.51.2
+  - numpy >=1.17
+  - pynndescent >=0.5
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - scikit-learn >=0.22
+  - scipy >=1.3.1
+  - setuptools
+  - tbb >=2019.0
+  - tqdm
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 197175
+  timestamp: 1751544539720
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-16.0.0-py311h3696347_1.conda
+  sha256: 800e8ed94f2d771b006891b5af4c4b510c4cab49e8966ac08297b68d904f0e15
+  md5: 348a90d4b670542a7757e2415021bcf0
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 410696
+  timestamp: 1756494744297
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.3-py311h3696347_1.conda
+  sha256: db6de7e82c923f05807b4ec4413ab706ee3183f6ef89ad906277c60dea013e92
+  md5: a2f91e76263f4b55cca328110ef4d50b
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 62705
+  timestamp: 1756851806189
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-h5505292_0.conda
+  sha256: f33e6f013fc36ebc200f09ddead83468544cb5c353a3b50499b07b8c34e28a8d
+  md5: 50901e0764b7701d8ed7343496f4f301
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 13593
+  timestamp: 1734229104321
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+  sha256: 9939a166d780700d81023546759102b33fdc2c5f11ef09f5f66c77210fd334c8
+  md5: 77c447f48cab5d3a15ac224edb86a968
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 18487
+  timestamp: 1727795205022
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
+  sha256: b03433b13d89f5567e828ea9f1a7d5c5d697bf374c28a4168d71e9464f5dafac
+  md5: 78a0fe9e9c50d2c381e8ee47e3ea437d
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 83386
+  timestamp: 1753484079473
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h888dc83_9.conda
+  sha256: b6f9c130646e5971f6cad708e1eee278f5c7eea3ca97ec2fdd36e7abb764a7b8
+  md5: 26f39dfe38a2a65437c29d69906a0f68
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 244772
+  timestamp: 1757371008525
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py311h5bb9006_0.conda
+  sha256: fb1443a1479a6d709b4af7a2cdcea3ef2a5e859378de19814086fa86ca6f934e
+  md5: c7e0f1b714bd12d39899a4f0c296dd86
+  depends:
+  - python
+  - cffi >=1.11
+  - zstd >=1.5.7,<1.5.8.0a0
+  - __osx >=11.0
+  - python 3.11.* *_cpython
+  - zstd >=1.5.7,<1.6.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 390089
+  timestamp: 1757930124840
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_2.conda
+  sha256: 0d02046f57f7a1a3feae3e9d1aa2113788311f3cf37a3244c71e61a93177ba67
+  md5: e6f69c7bcccdefa417f056fa593b40f0
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 399979
+  timestamp: 1742433432699
+- conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
+  sha256: 1a62cd1f215fe0902e7004089693a78347a30ad687781dfda2289cab000e652d
+  md5: 37e16618af5c4851a3f3d66dd0e11141
+  depends:
+  - libgomp >=7.5.0
+  - libwinpthread >=12.0.0.r2.ggc561118da
+  constrains:
+  - openmp_impl 9999
+  - msys2-conda-epoch <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49468
+  timestamp: 1718213032772
+- conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-25.1.0-py311h3485c13_0.conda
+  sha256: 4bde4487abbca4c8834a582928a80692a32ebba67e906ce676e931035a13d004
+  md5: fdb37c9bd914e2a2c20f204f9cb15e6b
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 38615
+  timestamp: 1753995128176
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-hfd05255_4.conda
+  sha256: df2a43cc4a99bd184cb249e62106dfa9f55b3d06df9b5fc67072b0336852ff65
+  md5: 441706c019985cf109ced06458e6f742
+  depends:
+  - brotli-bin 1.1.0 hfd05255_4
+  - libbrotlidec 1.1.0 hfd05255_4
+  - libbrotlienc 1.1.0 hfd05255_4
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 20233
+  timestamp: 1756599828380
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-hfd05255_4.conda
+  sha256: e92c783502d95743b49b650c9276e9c56c7264da55429a5e45655150a6d1b0cf
+  md5: ef022c8941d7dcc420c8533b0e419733
+  depends:
+  - libbrotlidec 1.1.0 hfd05255_4
+  - libbrotlienc 1.1.0 hfd05255_4
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 21425
+  timestamp: 1756599802301
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311h3e6a449_4.conda
+  sha256: d524edc172239fec70ad946e3b2fa1b9d7eea145ad80e9e66da25a4d815770ea
+  md5: 21d3a7fa95d27938158009cd08e461f2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - libbrotlicommon 1.1.0 hfd05255_4
+  license: MIT
+  license_family: MIT
+  size: 323289
+  timestamp: 1756600106141
+- conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
+  sha256: d882712855624641f48aa9dc3f5feea2ed6b4e6004585d3616386a18186fe692
+  md5: 1077e9333c41ff0be8edd1a5ec0ddace
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 55977
+  timestamp: 1757437738856
+- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py311h3485c13_1.conda
+  sha256: 46baee342b50ce7fbf4c52267f73327cb0512b970332037c8911afee1e54f063
+  md5: 553a1836df919ca232b80ce1324fa5bb
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 296743
+  timestamp: 1756808544874
+- conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.3-py311h3fd045d_2.conda
+  sha256: 620d21eedddae5c2f8edb8c549c46a7204356ceff6b2d6c5560e4b5ce59a757d
+  md5: 327d9807b7aa0889a859070c550731d4
+  depends:
+  - numpy >=1.25
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 225470
+  timestamp: 1756544991146
+- conda: https://conda.anaconda.org/conda-forge/win-64/crc32c-2.7.1-py311hf893f09_2.conda
+  sha256: 71d113a32a8c208c4bd847dd3fe0000bb2ef5d05cbe321451cff724252cc37d7
+  md5: 4f1c566d5a21fcd3618de2f8416803a4
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.11.* *_cp311
+  license: LGPL-2.1-or-later
+  size: 53052
+  timestamp: 1756602254059
+- conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.16-py311h5dfdfe8_1.conda
+  sha256: 810fa69eca6adfbf707e2e31e26f24842ab313d2efbfdb8e73c15c164a8010d9
+  md5: 5996fd469da1e196fd42c72a7b7a65ca
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 3933261
+  timestamp: 1756742011482
+- conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.59.2-py311h3f79411_0.conda
+  sha256: e835c0f2d9070a9262820e9cf5177324c7df2148c4d85d756f02b38e443bd9eb
+  md5: 6c399663cab648a17883bf73f3057f04
+  depends:
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - unicodedata2 >=15.1.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 2523927
+  timestamp: 1756329034557
+- conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.14.1-h57928b3_0.conda
+  sha256: a9b3313edea0bf14ea6147ea43a1059d0bf78771a1336d2c8282891efc57709a
+  md5: d69c21967f35eb2ce7f1f85d6b6022d3
+  depends:
+  - libfreetype 2.14.1 h57928b3_0
+  - libfreetype6 2.14.1 hdbac1cb_0
+  license: GPL-2.0-only OR FTL
+  size: 184553
+  timestamp: 1757946164012
+- conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.14.0-nompi_py311hc40ba4b_101.conda
+  sha256: 34aae9b53e14cf62373a5bd1f475151430e4257cad6626a5d38469367b049da3
+  md5: 2ffcf6af42f0eadff1fa73417b848096
+  depends:
+  - cached-property
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1076133
+  timestamp: 1756767224174
+- conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.6-nompi_he30205f_103.conda
+  sha256: 0a90263b97e9860cec6c2540160ff1a1fff2a609b3d96452f8716ae63489dac5
+  md5: f1f7aaf642cefd2190582550eaca4658
+  depends:
+  - libaec >=1.1.4,<2.0a0
+  - libcurl >=8.14.1,<9.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2031491
+  timestamp: 1753357255237
+- conda: https://conda.anaconda.org/conda-forge/win-64/icu-75.1-he0c23c2_0.conda
+  sha256: 1d04369a1860a1e9e371b9fc82dd0092b616adcf057d6c88371856669280e920
+  md5: 8579b6bb8d18be7c0b27fb08adeeeb40
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 14544252
+  timestamp: 1720853966338
+- conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_2.conda
+  sha256: 64bcf78dbbda7ec523672c4b3f085527fd109732518e33907eac6b8049125113
+  md5: c8f80d7bee5c66371969936eba774c45
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43432
+  timestamp: 1756754355044
+- conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.9-py311h275cad7_1.conda
+  sha256: e5e759b61a71e16ba4637c9b08bb8e5c01ee678a47f3e980a7cacb8b0bee58b8
+  md5: 62b8b3f148d7f47db02304a7de177d13
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73589
+  timestamp: 1756467536839
+- conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+  sha256: 18e8b3430d7d232dad132f574268f56b3eb1a19431d6d5de8c53c29e6c18fa81
+  md5: 31aec030344e962fbd7dbbbbd68e60a9
+  depends:
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 712034
+  timestamp: 1719463874284
+- conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.17-hbcf6048_0.conda
+  sha256: 7712eab5f1a35ca3ea6db48ead49e0d6ac7f96f8560da8023e61b3dbe4f3b25d
+  md5: 3538827f77b82a837fa681a4579e37a1
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 510641
+  timestamp: 1739161381270
+- conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h6470a55_1.conda
+  sha256: 868a3dff758cc676fa1286d3f36c3e0101cca56730f7be531ab84dc91ec58e9d
+  md5: c1b81da6d29a14b542da14a36c9fbf3f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 164701
+  timestamp: 1745264384716
+- conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.4-h20038f6_0.conda
+  sha256: 0be89085effce9fdcbb6aea7acdb157b18793162f68266ee0a75acf615d4929b
+  md5: 85a2bed45827d77d5b308cb2b165404f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 33847
+  timestamp: 1749993666162
+- conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-35_h5709861_mkl.conda
+  sha256: 4180e7ab27ed03ddf01d7e599002fcba1b32dcb68214ee25da823bac371ed362
+  md5: 45d98af023f8b4a7640b1f713ce6b602
+  depends:
+  - mkl >=2024.2.2,<2025.0a0
+  constrains:
+  - blas 2.135   mkl
+  - liblapack  3.9.0   35*_mkl
+  - libcblas   3.9.0   35*_mkl
+  - liblapacke 3.9.0   35*_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 66044
+  timestamp: 1757003486248
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hfd05255_4.conda
+  sha256: 65d0aaf1176761291987f37c8481be132060cc3dbe44b1550797bc27d1a0c920
+  md5: 58aec7a295039d8614175eae3a4f8778
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 71243
+  timestamp: 1756599708777
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hfd05255_4.conda
+  sha256: aa03aff197ed503e38145d0d0f17c30382ac1c6d697535db24c98c272ef57194
+  md5: bf0ced5177fec8c18a7b51d568590b7c
+  depends:
+  - libbrotlicommon 1.1.0 hfd05255_4
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 33430
+  timestamp: 1756599740173
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hfd05255_4.conda
+  sha256: a593cde3e728a1e0486a19537846380e3ce90ae9d6c22c1412466a49474eeeed
+  md5: 37f4669f8ac2f04d826440a8f3f42300
+  depends:
+  - libbrotlicommon 1.1.0 hfd05255_4
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 245418
+  timestamp: 1756599770744
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-35_h2a3cdd5_mkl.conda
+  sha256: 88939f6c1b5da75bd26ce663aa437e1224b26ee0dab5e60cecc77600975f397e
+  md5: 9639091d266e92438582d0cc4cfc8350
+  depends:
+  - libblas 3.9.0 35_h5709861_mkl
+  constrains:
+  - blas 2.135   mkl
+  - liblapack  3.9.0   35*_mkl
+  - liblapacke 3.9.0   35*_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 66398
+  timestamp: 1757003514529
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.14.1-h88aaa65_0.conda
+  sha256: b2cface2cf35d8522289df7fffc14370596db6f6dc481cc1b6ca313faeac19d8
+  md5: 836b9c08f34d2017dbcaec907c6a1138
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: curl
+  license_family: MIT
+  size: 368346
+  timestamp: 1749033492826
+- conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.24-h76ddb4d_0.conda
+  sha256: 65347475c0009078887ede77efe60db679ea06f2b56f7853b9310787fe5ad035
+  md5: 08d988e266c6ae77e03d164b83786dc4
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 156292
+  timestamp: 1747040812624
+- conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.1-hac47afa_0.conda
+  sha256: 8432ca842bdf8073ccecf016ccc9140c41c7114dc4ec77ca754551c01f780845
+  md5: 3608ffde260281fa641e70d6e34b1b96
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - expat 2.7.1.*
+  license: MIT
+  license_family: MIT
+  size: 141322
+  timestamp: 1752719767870
+- conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.6-h537db12_1.conda
+  sha256: d3b0b8812eab553d3464bbd68204f007f1ebadf96ce30eb0cbc5159f72e353f5
+  md5: 85d8fa5e55ed8f93f874b3b23ed54ec6
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 44978
+  timestamp: 1743435053850
+- conda: https://conda.anaconda.org/conda-forge/win-64/libfreetype-2.14.1-h57928b3_0.conda
+  sha256: 2029702ec55e968ce18ec38cc8cf29f4c8c4989a0d51797164dab4f794349a64
+  md5: 3235024fe48d4087721797ebd6c9d28c
+  depends:
+  - libfreetype6 >=2.14.1
+  license: GPL-2.0-only OR FTL
+  size: 8109
+  timestamp: 1757946135015
+- conda: https://conda.anaconda.org/conda-forge/win-64/libfreetype6-2.14.1-hdbac1cb_0.conda
+  sha256: 223710600b1a5567163f7d66545817f2f144e4ef8f84e99e90f6b8a4e19cb7ad
+  md5: 6e7c5c5ab485057b5d07fd8188ba5c28
+  depends:
+  - libpng >=1.6.50,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - freetype >=2.14.1
+  license: GPL-2.0-only OR FTL
+  size: 340264
+  timestamp: 1757946133889
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-15.1.0-h1383e82_5.conda
+  sha256: 9b997baa85ba495c04e1b30f097b80420c02dcaca6441c4bf2c6bb4b2c5d2114
+  md5: c84381a01ede0e28d632fdbeea2debb2
+  depends:
+  - _openmp_mutex >=4.5
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - libgomp 15.1.0 h1383e82_5
+  - msys2-conda-epoch <0.0a0
+  - libgcc-ng ==15.1.0=*_5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 668284
+  timestamp: 1757042801517
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-15.1.0-h1383e82_5.conda
+  sha256: 65fd558d8f3296e364b8ae694932a64642fdd26d8eb4cf7adf08941e449be926
+  md5: eae9a32a85152da8e6928a703a514d35
+  depends:
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - msys2-conda-epoch <0.0a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 535560
+  timestamp: 1757042749206
+- conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.12.1-default_h64bd3f2_1002.conda
+  sha256: 266dfe151066c34695dbdc824ba1246b99f016115ef79339cbcf005ac50527c1
+  md5: b0cac6e5b06ca5eeb14b4f7cf908619f
+  depends:
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2414731
+  timestamp: 1757624335056
+- conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
+  sha256: 0dcdb1a5f01863ac4e8ba006a8b0dc1a02d2221ec3319b5915a1863254d7efa7
+  md5: 64571d1dd6cdcfa25d0664a5950fdaa2
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: LGPL-2.1-only
+  size: 696926
+  timestamp: 1754909290005
+- conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.1.0-h2466b09_0.conda
+  sha256: e61b0adef3028b51251124e43eb6edf724c67c0f6736f1628b02511480ac354e
+  md5: 7c51d27540389de84852daa1cdb9c63c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 838154
+  timestamp: 1745268437136
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-35_hf9ab0e9_mkl.conda
+  sha256: 56e0992fb58eed8f0d5fa165b8621fa150b84aa9af1467ea0a7a9bb7e2fced4f
+  md5: 0c6ed9d722cecda18f50f17fb3c30002
+  depends:
+  - libblas 3.9.0 35_h5709861_mkl
+  constrains:
+  - blas 2.135   mkl
+  - libcblas   3.9.0   35*_mkl
+  - liblapacke 3.9.0   35*_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78485
+  timestamp: 1757003541803
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
+  sha256: 55764956eb9179b98de7cc0e55696f2eff8f7b83fc3ebff5e696ca358bca28cc
+  md5: c15148b2e18da456f5108ccb5e411446
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD
+  size: 104935
+  timestamp: 1749230611612
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.50-h7351971_1.conda
+  sha256: e84b041f91c94841cb9b97952ab7f058d001d4a15ed4ce226ec5fdb267cc0fa5
+  md5: 3ae6e9f5c47c495ebeed95651518be61
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 382709
+  timestamp: 1753879944850
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+  sha256: 7bcb3edccea30f711b6be9601e083ecf4f435b9407d70fc48fbcf9e5d69a0fc6
+  md5: 198bb594f202b205c7d18b936fa4524f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: ISC
+  size: 202344
+  timestamp: 1716828757533
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.50.4-hf5d6505_0.conda
+  sha256: 5dc4f07b2d6270ac0c874caec53c6984caaaa84bc0d3eb593b0edf3dc8492efa
+  md5: ccb20d946040f86f0c05b644d5eadeca
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: blessing
+  size: 1288499
+  timestamp: 1753948889360
+- conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-h9aa295b_0.conda
+  sha256: cbdf93898f2e27cefca5f3fe46519335d1fab25c4ea2a11b11502ff63e602c09
+  md5: 9dce2f112bfd3400f4f432b3d0ac07b2
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 292785
+  timestamp: 1745608759342
+- conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-h550210a_6.conda
+  sha256: fd27821c8cfc425826f13760c3263d7b3b997c5372234cefa1586ff384dcc989
+  md5: 72d45aa52ebca91aedb0cfd9eac62655
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.24,<1.26.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - zstd >=1.5.7,<1.6.0a0
+  license: HPND
+  size: 983988
+  timestamp: 1755012056987
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.6.0-h4d5522a_0.conda
+  sha256: 7b6316abfea1007e100922760e9b8c820d6fc19df3f42fb5aca684cfacb31843
+  md5: f9bbae5e2537e3b06e0f7310ba76c893
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - libwebp 1.6.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279176
+  timestamp: 1752159543911
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_9.conda
+  sha256: 373f2973b8a358528b22be5e8d84322c165b4c5577d24d94fd67ad1bb0a0f261
+  md5: 08bfa5da6e242025304b206d152479ef
+  depends:
+  - ucrt
+  constrains:
+  - pthreads-win32 <0.0a0
+  - msys2-conda-epoch <0.0a0
+  license: MIT AND BSD-3-Clause-Clear
+  size: 35794
+  timestamp: 1737099561703
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
+  sha256: 08dec73df0e161c96765468847298a420933a36bc4f09b50e062df8793290737
+  md5: a69bbf778a462da324489976c84cfc8c
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - pthread-stubs
+  - ucrt >=10.0.20348.0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 1208687
+  timestamp: 1727279378819
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-16-2.15.0-h06f855e_0.conda
+  sha256: 15337581264464842ff28f616422b786161bee0169610ff292e0ea75fa78dba8
+  md5: a1071825a90769083fce8dbcefcccd65
+  depends:
+  - icu >=75.1,<76.0a0
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - libxml2 2.15.0
+  license: MIT
+  license_family: MIT
+  size: 512772
+  timestamp: 1757953703099
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.15.0-ha29bfb0_0.conda
+  sha256: c3c2c74bd917d83b26c102b18bde97759c23f24e0260beb962acf7385627fc38
+  md5: 5262552eb2f0d0b443adcfa265d97f0a
+  depends:
+  - icu >=75.1,<76.0a0
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libxml2-16 2.15.0 h06f855e_0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 42985
+  timestamp: 1757953736703
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+  sha256: ba945c6493449bed0e6e29883c4943817f7c79cbff52b83360f7b341277c6402
+  md5: 41fbfac52c601159df6c01f875de31b9
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 55476
+  timestamp: 1727963768015
+- conda: https://conda.anaconda.org/conda-forge/win-64/llvm-openmp-20.1.8-hfa2b4ca_2.conda
+  sha256: 8970b7f9057a1c2c18bfd743c6f5ce73b86197d7724423de4fa3d03911d5874b
+  md5: 2dc2edf349464c8b83a576175fc2ad42
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - intel-openmp <0.0a0
+  - openmp 20.1.8|20.1.8.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 344490
+  timestamp: 1756145011384
+- conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.44.0-py311h7c248df_2.conda
+  sha256: 6de812d5c747ee7d9c35377dda480e609b60a48cca06230481f550d7c64c225a
+  md5: 5a88a225dba32c6ae5f7a3b85fca9522
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18118948
+  timestamp: 1756303951134
+- conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py311h5082efb_1.conda
+  sha256: 6f756e13ccf1a521d3960bd3cadddf564e013e210eaeced411c5259f070da08e
+  md5: c1f2ddad665323278952a453912dc3bd
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28238
+  timestamp: 1733220208800
+- conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.10.6-py311h1675fdf_1.conda
+  sha256: ddf4dffdf128835c6feeb2e3c10e757802a4605adadafc15bed876dd6b75620a
+  md5: 076c701b94086fced31eef41e80927b0
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype
+  - kiwisolver >=1.3.1
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - numpy >=1.23
+  - numpy >=1.23,<3
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: PSF-2.0
+  license_family: PSF
+  size: 8049626
+  timestamp: 1756870061088
+  purls:
+  - pkg:pypi/matplotlib?source=hash-mapping
+- conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h57928b3_16.conda
+  sha256: ce841e7c3898764154a9293c0f92283c1eb28cdacf7a164c94b632a6af675d91
+  md5: 5cddc979c74b90cf5e5cda4f97d5d8bb
+  depends:
+  - llvm-openmp >=20.1.8
+  - tbb 2021.*
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 103088799
+  timestamp: 1753975600547
+- conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.1-py311h3fd045d_1.conda
+  sha256: 4da49f644d92f3e01fa1f2015d38e2571a20fe787cb294393c91952c2afe2986
+  md5: 108852c865da789f638275669e3f4a8e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: Apache
+  size: 88184
+  timestamp: 1756678810275
+- conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.61.2-py311h7afb941_1.conda
+  sha256: 4d8fdcd5ad4d9e26f31e114400439e2a1b59d8a1bd0f3d65e560e13f493eb8e6
+  md5: d908a5008f359e21d749f705da27c2cc
+  depends:
+  - llvmlite >=0.44.0,<0.45.0a0
+  - numpy >=1.21,<3
+  - numpy >=1.24,<2.3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - cuda-version >=11.2
+  - cuda-python >=11.6
+  - tbb >=2021.6.0
+  - scipy >=1.0
+  - cudatoolkit >=11.2
+  - libopenblas !=0.3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5976626
+  timestamp: 1749491978629
+- conda: https://conda.anaconda.org/conda-forge/win-64/numcodecs-0.16.1-py311h11fd7f3_1.conda
+  sha256: 4660c97fc32a7d85e51abde01a5fca420db3675acfc7fa68eb8fb879d2aea6de
+  md5: 5e2e82669917cd986be9ec7626e181a3
+  depends:
+  - deprecated
+  - msgpack-python
+  - numpy >=1.23,<3
+  - numpy >=1.24
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - typing_extensions
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 519763
+  timestamp: 1756542994834
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.2.6-py311h5e411d1_0.conda
+  sha256: f4ea606273089836e4b2b2355209142c1514d8bf103346ed435e85008df0804d
+  md5: 6612dfa4e68dd90c539f2e9f40a42514
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7800740
+  timestamp: 1747545419079
+- conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.3-h24db6dd_1.conda
+  sha256: c29cb1641bc5cfc2197e9b7b436f34142be4766dd2430a937b48b7474935aa55
+  md5: 25f45acb1a234ad1c9b9a20e1e6c559e
+  depends:
+  - libpng >=1.6.50,<1.7.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 245076
+  timestamp: 1754298075628
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.5.3-h725018a_0.conda
+  sha256: b8de982a72a9edc4bbfef52113f7dd8f224fb5dc1883aa7945dd48d3c37815d9
+  md5: 19b0ad594e05103080ad8c87fa782a35
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: Apache
+  size: 9218535
+  timestamp: 1758043741373
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.3.2-py311h11fd7f3_0.conda
+  sha256: 7eaadbdb9c58274daac8f5659ce448a570ea10e9bfc55c97a72a95a6e9b4d5aa
+  md5: 1528d744a31b20442ca7c1f365a28cc2
+  depends:
+  - numpy >=1.22.4
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - beautifulsoup4 >=4.11.2
+  - tzdata >=2022.7
+  - xlsxwriter >=3.0.5
+  - pytables >=3.8.0
+  - html5lib >=1.1
+  - s3fs >=2022.11.0
+  - matplotlib >=3.6.3
+  - pyarrow >=10.0.1
+  - lxml >=4.9.2
+  - python-calamine >=0.1.7
+  - pyxlsb >=1.0.10
+  - pandas-gbq >=0.19.0
+  - fastparquet >=2022.12.0
+  - bottleneck >=1.3.6
+  - xarray >=2022.12.0
+  - fsspec >=2022.11.0
+  - odfpy >=1.4.1
+  - pyqt5 >=5.15.9
+  - openpyxl >=3.1.0
+  - tabulate >=0.9.0
+  - psycopg2 >=2.9.6
+  - blosc >=1.21.3
+  - pyreadstat >=1.2.0
+  - qtpy >=2.3.0
+  - scipy >=1.10.0
+  - gcsfs >=2022.11.0
+  - numexpr >=2.8.4
+  - sqlalchemy >=2.0.0
+  - zstandard >=0.19.0
+  - xlrd >=2.0.1
+  - numba >=0.56.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14410335
+  timestamp: 1755779632554
+- conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.3.0-py311h0f9b5fc_2.conda
+  sha256: f0a07f46d28b11baa5b43e8e377aaa1032cf667a717b590c2c2a635d78624755
+  md5: 2391e23c0b5cf4c632029bc84b464821
+  depends:
+  - freetype
+  - lcms2 >=2.17,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.3,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: HPND
+  size: 903452
+  timestamp: 1758012998962
+- conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.0.0-py311h3485c13_1.conda
+  sha256: f48c2e47fda7259235f8abb55d219c419df3cc52e2e15ee9ee17da20b86393e5
+  md5: cd66a378835a5da422201faac2c114c7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 499413
+  timestamp: 1755851559633
+- conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
+  sha256: 7e446bafb4d692792310ed022fe284e848c6a868c861655a92435af7368bae7b
+  md5: 3c8f2573569bb816483e5cf57efbbe29
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 9389
+  timestamp: 1726802555076
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.13-h3f84c4b_0_cpython.conda
+  sha256: 723dbca1384f30bd2070f77dd83eefd0e8d7e4dda96ac3332fbf8fe5573a8abb
+  md5: bedbb6f7bb654839719cd528f9b298ad
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.7.0,<3.0a0
+  - libffi >=3.4.6,<3.5.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libsqlite >=3.50.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 18242669
+  timestamp: 1749048351218
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-311-py311hefeebc8_1.conda
+  sha256: e3ef7e0cc53111ab81b8a9dd3eabc1374d7420d4c9fce3c8631e73310203ad55
+  md5: c1cfe9f5d8e278cc4d2d4c7b0126634d
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.11.* *_cp311
+  license: PSF-2.0
+  license_family: PSF
+  size: 6729388
+  timestamp: 1756487145061
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.15-py311hda3d55a_0.conda
+  sha256: fbf3e3f2d5596e755bd4b83b5007fa629b184349781f46e137a4e80b6754c7c0
+  md5: 8a142e0fcd43513c2e876d97ba98c0fa
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 217009
+  timestamp: 1738661736085
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311h5082efb_2.conda
+  sha256: 6095e1d58c666f6a06c55338df09485eac34c76e43d92121d5786794e195aa4d
+  md5: e474ba674d780f0fa3b979ae9e81ba91
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 187430
+  timestamp: 1737454904007
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-27.1.0-py311hb77b9c8_0.conda
+  sha256: 1f146a62329093139fbe7fc109b595f19ca2b44beb921d0e1c6e61d2cb5ebef1
+  md5: 96460f14570e237d27b475ef8238fdf3
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - zeromq >=4.3.5,<4.3.6.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 363690
+  timestamp: 1757387035331
+- conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+  sha256: 887d53486a37bd870da62b8fa2ebe3993f912ad04bd755e7ed7c47ced97cbaa8
+  md5: 854fbdff64b572b5c0b470f334d34c11
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LicenseRef-Qhull
+  size: 1377020
+  timestamp: 1720814433486
+- conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.27.1-py311hf51aa87_1.conda
+  sha256: e61607627213b70e7be73570e7ef5e2d36b583512def108aaf78a6ab16f0cdd9
+  md5: 3c5b42969dae70e100154750d29d43cc
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 247101
+  timestamp: 1756737437304
+- conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.7.2-py311h8a15ebc_0.conda
+  sha256: 6b7db7a33e44b2ef36b77054f3f939a6bb7722e5a1e9a1b55bfe022eda0045a8
+  md5: f4ca4045c4da60540399bd67b4e1490f
+  depends:
+  - joblib >=1.2.0
+  - numpy >=1.22.0
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scipy >=1.8.0
+  - threadpoolctl >=3.1.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9040416
+  timestamp: 1757433538935
+- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.16.2-py311h9a1c30b_0.conda
+  sha256: 0bd54e04b152f4af55922b7ee792b42a1010c702d5b4d1ca47b062e67420e797
+  md5: a5b6b853ae5a10a0d6225659d5e6019c
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.6
+  - numpy >=1.23,<3
+  - numpy >=1.25.2
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15306714
+  timestamp: 1757683219896
+- conda: https://conda.anaconda.org/conda-forge/win-64/statsmodels-0.14.5-py311h17033d2_0.conda
+  sha256: e09d101d0044348e7a35f3a78f22bab0701a31059f02a63897cf87546e84e4f1
+  md5: 9cf4eebc1ad82ee44efc89bdde60a431
+  depends:
+  - numpy <3,>=1.22.3
+  - numpy >=1.23,<3
+  - packaging >=21.3
+  - pandas !=2.1.0,>=1.4
+  - patsy >=0.5.6
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scipy !=1.9.2,>=1.8
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11744906
+  timestamp: 1751917965278
+- conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-h18a62a1_3.conda
+  sha256: 30e82640a1ad9d9b5bee006da7e847566086f8fdb63d15b918794a7ef2df862c
+  md5: 72226638648e494aaafde8155d50dab2
+  depends:
+  - libhwloc >=2.12.1,<2.12.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: APACHE
+  size: 150266
+  timestamp: 1755776172092
+- conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
+  sha256: e3614b0eb4abcc70d98eae159db59d9b4059ed743ef402081151a948dce95896
+  md5: ebd0e761de9aa879a51d22cc721bd095
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: TCL
+  license_family: BSD
+  size: 3466348
+  timestamp: 1748388121356
+- conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.5.2-py311h3485c13_1.conda
+  sha256: 87527996d1297442bbc432369a5791af740762c1dda642d52cd55d32d5577937
+  md5: ec9179a7226659bd15d8085c8de15360
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: Apache
+  size: 871179
+  timestamp: 1756855104869
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+  sha256: 3005729dce6f3d3f5ec91dfc49fc75a0095f9cd23bab49efb899657297ac91a5
+  md5: 71b24316859acd00bdb8b38f5e2ce328
+  constrains:
+  - vc14_runtime >=14.29.30037
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-MicrosoftWindowsSDK10
+  size: 694692
+  timestamp: 1756385147981
+- conda: https://conda.anaconda.org/conda-forge/win-64/umap-learn-0.5.9.post2-py311h1ea47a8_0.conda
+  sha256: 32569facf3347208d6c29a5a510cbabd56c3180508445aa314b914a22c9eebe0
+  md5: 406406afb742e30518371835718efaba
+  depends:
+  - numba >=0.51.2
+  - numpy >=1.17
+  - pynndescent >=0.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scikit-learn >=0.22
+  - scipy >=1.3.1
+  - setuptools
+  - tbb >=2019.0
+  - tqdm
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 197502
+  timestamp: 1751544433219
+- conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-16.0.0-py311h3485c13_1.conda
+  sha256: d692506a8f0f9452c72d5b4b6d7d39bca7c383ab85749d82a77ad652ccbef940
+  md5: 969071f934c7c811f014688e5ec4178f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: Apache
+  size: 401855
+  timestamp: 1756494775091
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_31.conda
+  sha256: cb357591d069a1e6cb74199a8a43a7e3611f72a6caed9faa49dbb3d7a0a98e0b
+  md5: 28f4ca1e0337d0f27afb8602663c5723
+  depends:
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18249
+  timestamp: 1753739241465
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_31.conda
+  sha256: af4b4b354b87a9a8d05b8064ff1ea0b47083274f7c30b4eb96bc2312c9b5f08f
+  md5: 603e41da40a765fd47995faa021da946
+  depends:
+  - ucrt >=10.0.20348.0
+  - vcomp14 14.44.35208 h818238b_31
+  constrains:
+  - vs2015_runtime 14.44.35208.* *_31
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  size: 682424
+  timestamp: 1753739239305
+- conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_31.conda
+  sha256: 67b317b64f47635415776718d25170a9a6f9a1218c0f5a6202bfd687e07b6ea4
+  md5: a6b1d5c1fc3cb89f88f7179ee6a9afe3
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.44.35208.* *_31
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  size: 113963
+  timestamp: 1753739198723
+- conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: 9df10c5b607dd30e05ba08cbd940009305c75db242476f4e845ea06008b0a283
+  md5: 1cee351bf20b830d991dbe0bc8cd7dfe
+  license: MIT
+  license_family: MIT
+  size: 1176306
+- conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.17.3-py311h3485c13_1.conda
+  sha256: 96f1ea03084a6deeb0630372319a03d7774f982d24e9ad7394941efd5779591c
+  md5: fbf91bcdeeb11de218edce103104e353
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 64180
+  timestamp: 1756852365689
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.12-h0e40799_0.conda
+  sha256: 047836241b2712aab1e29474a6f728647bff3ab57de2806b0bb0a6cf9a2d2634
+  md5: 2ffbfae4548098297c033228256eb96e
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 108013
+  timestamp: 1734229474049
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.5-h0e40799_0.conda
+  sha256: 9075f98dcaa8e9957e4a3d9d30db05c7578a536950a31c200854c5c34e1edb2c
+  md5: 8393c0f7e7870b4eb45553326f81f0ff
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 69920
+  timestamp: 1727795651979
+- conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
+  sha256: 80ee68c1e7683a35295232ea79bcc87279d31ffeda04a1665efdb43cbd50a309
+  md5: 433699cba6602098ae8957a323da2664
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 63944
+  timestamp: 1753484092156
+- conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-h5bddc39_9.conda
+  sha256: 690cf749692c8ea556646d1a47b5824ad41b2f6dfd949e4cdb6c44a352fcb1aa
+  md5: a6c8f8ee856f7c3c1576e14b86cd8038
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 265212
+  timestamp: 1757370864284
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.25.0-py311hf893f09_0.conda
+  sha256: 3b66d3cb738a9993e8432d1a03402d207128166c4ef0c928e712958e51aff325
+  md5: d26077d20b4bba54f4c718ed1313805f
+  depends:
+  - python
+  - cffi >=1.11
+  - zstd >=1.5.7,<1.5.8.0a0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - zstd >=1.5.7,<1.6.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 375866
+  timestamp: 1757930134099
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-hbeecb71_2.conda
+  sha256: bc64864377d809b904e877a98d0584f43836c9f2ef27d3d2a1421fa6eae7ca04
+  md5: 21f56217d6125fb30c3c3f10c786d751
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 354697
+  timestamp: 1742433568506
+- pypi: https://files.pythonhosted.org/packages/04/1e/b832de447dee8b582cac175871d2f6c3d5077cc56d5575cadba1fd1cccfa/linkify_it_py-2.0.3-py3-none-any.whl
+  name: linkify-it-py
+  version: 2.0.3
+  sha256: 6bcbc417b0ac14323382aef5c5192c0075bf8a9d6b41820a2b66371eac6b6d79
+  requires_dist:
+  - uc-micro-py
+  - pytest ; extra == 'benchmark'
+  - pytest-benchmark ; extra == 'benchmark'
+  - pre-commit ; extra == 'dev'
+  - isort ; extra == 'dev'
+  - flake8 ; extra == 'dev'
+  - black ; extra == 'dev'
+  - pyproject-flake8 ; extra == 'dev'
+  - sphinx ; extra == 'doc'
+  - sphinx-book-theme ; extra == 'doc'
+  - myst-parser ; extra == 'doc'
+  - pytest ; extra == 'test'
+  - coverage ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/0c/31/fe563decfe3da71a97c9d8ff56bba6822f4ddb0b96feadbc8e579c337c15/panel_material_ui-0.5.0-py3-none-any.whl
+  name: panel-material-ui
+  version: 0.5.0
+  sha256: 072fbf20de2cb24464b8b9cf700a1cc13fd76f3701de28a48c9bf7fe733c7a08
+  requires_dist:
+  - bokeh>=3.8.0
+  - packaging
+  - panel>=1.8.0
+  - plotly; extra == "dev"
+  - pytest; extra == "dev"
+  - pytest-asyncio; extra == "dev"
+  - pytest-rerunfailures<16; extra == "dev"
+  - pytest-xdist; extra == "dev"
+  - watchfiles; extra == "dev"
+  - mypy; extra == "mypy"
+  - types-requests; extra == "mypy"
+  - typing-extensions; extra == "mypy"
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/13/5a/f8c0868199bbb231a02616286ce8a4ccb85f5387b9215510297dcfedd214/pyviz_comms-3.0.6-py3-none-any.whl
+  name: pyviz-comms
+  version: 3.0.6
+  sha256: 4eba6238cd4a7f4add2d11879ce55411785b7d38a7c5dba42c7a0826ca53e6c2
+  requires_dist:
+  - param
+  - flake8; extra == "all"
+  - jupyterlab~=4.0; extra == "all"
+  - keyring; extra == "all"
+  - pytest; extra == "all"
+  - rfc3986; extra == "all"
+  - setuptools>=40.8.0; extra == "all"
+  - twine; extra == "all"
+  - jupyterlab~=4.0; extra == "build"
+  - keyring; extra == "build"
+  - rfc3986; extra == "build"
+  - setuptools>=40.8.0; extra == "build"
+  - twine; extra == "build"
+  - flake8; extra == "tests"
+  - pytest; extra == "tests"
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl
+  name: uc-micro-py
+  version: 1.0.3
+  sha256: db1dffff340817673d7b466ec86114a9dc0e9d4d9b5ba229d9d60e5c12600cd5
+  requires_dist:
+  - pytest ; extra == 'test'
+  - coverage ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/70/ae/44c4a6a4cbb496d93c6257954260fe3a6e91b7bed2240e5dad2a717f5111/markdown-3.9-py3-none-any.whl
+  name: Markdown
+  version: '3.9'
+  sha256: 9f4d91ed810864ea88a6f32c07ba8bee1346c0cc1f6b1f9f6c822f2a9667d280
+  requires_dist:
+  - importlib-metadata>=4.4; python_version < "3.10"
+  - coverage; extra == "testing"
+  - pyyaml; extra == "testing"
+  - mkdocs>=1.6; extra == "docs"
+  - mkdocs-nature>=0.6; extra == "docs"
+  - mdx_gh_links>=0.2; extra == "docs"
+  - mkdocstrings[python]; extra == "docs"
+  - mkdocs-gen-files; extra == "docs"
+  - mkdocs-section-index; extra == "docs"
+  - mkdocs-literate-nav; extra == "docs"
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/7f/8f/99214dc3d59d6aef171821dc8cc3dea34db8fafb962c98c34b1527a76e51/holoviews-1.22.0a0-py3-none-any.whl
+  name: holoviews
+  version: 1.22.0a0
+  sha256: 31b0ef52e4f712eafbd96bad16edeed726d79b677c861100f76a0f380f01642e
+  requires_dist:
+  - bokeh>=3.1
+  - colorcet
+  - numpy>=1.21
+  - packaging
+  - pandas>=1.3
+  - panel>=1.0
+  - param<3.0,>=2.0
+  - pyviz-comms>=2.1
+  - matplotlib>=3; extra == "recommended"
+  - plotly>=4.0; extra == "recommended"
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/8e/61/bc91751a2f7523279c881af11b8bda13f3cfba9f68a2b3a1e78961d92572/hv_anndata-0.0.3a2-py3-none-any.whl
+  name: hv-anndata
+  version: 0.0.3a2
+  sha256: 8db1e9aa04fa272f4f8a60564f8f51ef1b0a47e6f2804657af0f1de5bed62a9e
+  requires_dist:
+  - anndata
+  - bokeh
+  - datashader
+  - holoviews>=1.21.0rc0
+  - numpy
+  - pandas
+  - panel
+  - panel-material-ui>=0.4.0rc1
+  - param
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
+  name: markdown-it-py
+  version: 4.0.0
+  sha256: 87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147
+  requires_dist:
+  - mdurl~=0.1
+  - psutil; extra == "benchmarking"
+  - pytest; extra == "benchmarking"
+  - pytest-benchmark; extra == "benchmarking"
+  - commonmark~=0.9; extra == "compare"
+  - markdown~=3.4; extra == "compare"
+  - mistletoe~=1.0; extra == "compare"
+  - mistune~=3.0; extra == "compare"
+  - panflute~=2.3; extra == "compare"
+  - markdown-it-pyrs; extra == "compare"
+  - linkify-it-py<3,>=1; extra == "linkify"
+  - mdit-py-plugins>=0.5.0; extra == "plugins"
+  - gprof2dot; extra == "profiling"
+  - mdit-py-plugins>=0.5.0; extra == "rtd"
+  - myst-parser; extra == "rtd"
+  - pyyaml; extra == "rtd"
+  - sphinx; extra == "rtd"
+  - sphinx-copybutton; extra == "rtd"
+  - sphinx-design; extra == "rtd"
+  - sphinx-book-theme~=1.0; extra == "rtd"
+  - jupyter_sphinx; extra == "rtd"
+  - ipykernel; extra == "rtd"
+  - coverage; extra == "testing"
+  - pytest; extra == "testing"
+  - pytest-cov; extra == "testing"
+  - pytest-regressions; extra == "testing"
+  - requests; extra == "testing"
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+  name: mdurl
+  version: 0.1.2
+  sha256: 84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/e0/55/150c28bf3e50c7d65f763f7cc060740eada65817c40e6e5dead50fced228/panel-1.8.1-py3-none-any.whl
+  name: panel
+  version: 1.8.1
+  sha256: c1e0f1fdfeba50702af95650c3b54bfaa68ebbff309147a2e1c25af8a67d9a2d
+  requires_dist:
+  - bleach
+  - bokeh<3.9.0,>=3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas>=1.2
+  - param<3.0,>=2.1.0
+  - pyviz-comms>=2.0.0
+  - requests
+  - tqdm
+  - typing-extensions
+  - watchfiles; extra == "dev"
+  - bokeh-fastapi<0.2.0,>=0.1.2; extra == "fastapi"
+  - fastapi[standard]; extra == "fastapi"
+  - mypy; extra == "mypy"
+  - pandas-stubs; extra == "mypy"
+  - types-bleach; extra == "mypy"
+  - types-croniter; extra == "mypy"
+  - types-markdown; extra == "mypy"
+  - types-psutil; extra == "mypy"
+  - types-requests; extra == "mypy"
+  - types-tqdm; extra == "mypy"
+  - typing-extensions; extra == "mypy"
+  - holoviews>=1.18.0; extra == "recommended"
+  - jupyterlab; extra == "recommended"
+  - matplotlib; extra == "recommended"
+  - pillow; extra == "recommended"
+  - plotly; extra == "recommended"
+  - psutil; extra == "tests"
+  - pytest; extra == "tests"
+  - pytest-asyncio; extra == "tests"
+  - pytest-rerunfailures<16.0; extra == "tests"
+  - pytest-xdist; extra == "tests"
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
+  name: mdit-py-plugins
+  version: 0.5.0
+  sha256: 07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f
+  requires_dist:
+  - markdown-it-py<5.0.0,>=2.0.0
+  - pre-commit; extra == "code-style"
+  - myst-parser; extra == "rtd"
+  - sphinx-book-theme; extra == "rtd"
+  - coverage; extra == "testing"
+  - pytest; extra == "testing"
+  - pytest-cov; extra == "testing"
+  - pytest-regressions; extra == "testing"
+  requires_python: '>=3.10'

--- a/gene_profiling/pixi.lock
+++ b/gene_profiling/pixi.lock
@@ -8,7 +8,6 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
-    - url: https://conda.anaconda.org/nodefaults/
     indexes:
     - https://pypi.org/simple
     packages:

--- a/gene_profiling/pixi.toml
+++ b/gene_profiling/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "gene_profiling"
-channels = ["conda-forge", "nodefaults"]
+channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/gene_profiling/pixi.toml
+++ b/gene_profiling/pixi.toml
@@ -1,0 +1,34 @@
+[workspace]
+name = "gene_profiling"
+channels = ["conda-forge", "nodefaults"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2025-09-12"
+maintainers = ["droumis"]
+categories = ["Other Sciences"]
+labels = ["panel", "holoviews", "bokeh", "datashader", "anndata", "scanpy"]
+title = "Gene Profiling of Cellular Subpopulations"
+description = "Explore single-cell populations by linking cluster visualization with marker gene expression analysis"
+no_data_ingestion = true
+
+[dependencies]
+notebook = ">=6.5.2,<7"
+python = "3.11.*"
+numpy = ">=2.2.6"
+datashader = ">=0.18.2"
+bokeh = ">=3.8.0"
+anndata = ">=0.12.2"
+scanpy = ">=1.11.4"
+pip = "*"
+wheel = "*"
+
+[pypi-dependencies]
+hv-anndata = ">=v0.0.3a2"
+holoviews = ">=v1.22.0a0"
+Markdown = "*"
+
+[tasks]
+lab = "jupyter lab gene_profiling.ipynb"
+notebook = "jupyter notebook gene_profiling.ipynb"
+dashboard = "panel serve --rest-session-info --session-history -1 gene_profiling.ipynb --show"

--- a/gene_profiling/pixi.toml
+++ b/gene_profiling/pixi.toml
@@ -20,13 +20,13 @@ datashader = ">=0.18.2"
 bokeh = ">=3.8.0"
 anndata = ">=0.12.2"
 scanpy = ">=1.11.4"
-pip = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [pypi-dependencies]
 hv-anndata = ">=v0.0.3a2"
 holoviews = ">=v1.22.0a0"
-Markdown = "*"
+Markdown = "*"  # promoted from anaconda-project lock
 
 [tasks]
 lab = "jupyter lab gene_profiling.ipynb"

--- a/genetic_algorithm/pixi.lock
+++ b/genetic_algorithm/pixi.lock
@@ -7,636 +7,636 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.17.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.0.3-py39h3ea8b11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-2.0.3-py39h3ea8b11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.17.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.0.3-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.0.3-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.17.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.0.3-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.17.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-2.0.3-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
   sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
   md5: 2cf39d906cc321896ffe3e5d33d80c5c
   depends:
@@ -649,7 +649,7 @@ packages:
   license_family: MIT
   size: 162166
   timestamp: 1644463608931
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
   sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
   md5: 2972a84e0e22ae3244bbd2f1eebcf536
   depends:
@@ -660,7 +660,7 @@ packages:
   license_family: MIT
   size: 35352
   timestamp: 1644569715988
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
   sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
   md5: a68016b4b06460def24cb69d932986f3
   depends:
@@ -669,7 +669,7 @@ packages:
   license_family: MIT
   size: 132486
   timestamp: 1695717963702
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
   sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
   md5: 2f6356a2f530314b4059c08c79a3d8bc
   depends:
@@ -679,12 +679,12 @@ packages:
   license_family: MIT
   size: 205868
   timestamp: 1681493113570
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
   sha256: 2d8e75f31f75ea5eb8b9021b4c21eb2846a254a097e06eb68e66fc36a82e1bed
   md5: ae374a11c789a55555f70b29b9eff1f9
   depends:
@@ -700,7 +700,7 @@ packages:
   license_family: BSD
   size: 14430294
   timestamp: 1658136783940
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
   sha256: f84f9caa7eb9d489fd9634419fdf766d39293a5df1104b840fa0cdc5823a5c60
   md5: 922555c0435d6b2537cf8ced534b048c
   depends:
@@ -711,7 +711,7 @@ packages:
   license_family: BSD
   size: 141903
   timestamp: 1648028958291
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
   sha256: 0bbcb6f78eac530c6a084459ffab3238647b266d0c74d695e6e6387dd119cc67
   md5: bdc971e2a9affb5125b68ad708172dab
   depends:
@@ -720,7 +720,7 @@ packages:
   license: MIT
   size: 411301
   timestamp: 1602517685375
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
   sha256: 8c2071f706c2b445dabb781f7f8f008b23a29957468ec6894f050bfb3a2d5bf4
   md5: c203ffc7bbba991c7089d4b383cfd92c
   depends:
@@ -731,14 +731,14 @@ packages:
   license_family: MIT
   size: 357797
   timestamp: 1605539534667
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
   sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
   md5: 3ef00f4c5278b688552efc259c463dc8
   license: MPL-2.0
   license_family: Other
   size: 132731
   timestamp: 1694009767372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
   sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
   md5: d5cb3d97cf5e85ffe5e94037ed8a1169
   depends:
@@ -747,7 +747,7 @@ packages:
   license_family: Other
   size: 159077
   timestamp: 1690232254640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
   sha256: 674707b9c42e65c903c9786ee5a56b4d42aa054f1e75b328db8a2c1bfa368739
   md5: 76ae217198b014b89b267cf41b8251dd
   depends:
@@ -759,7 +759,7 @@ packages:
   license_family: MIT
   size: 231920
   timestamp: 1642701209740
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
   sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
   md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
   depends:
@@ -769,7 +769,7 @@ packages:
   license_family: CC
   size: 1917831
   timestamp: 1668084545510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
   sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
   md5: 13702d3b4b744784e5bd559c7050dd6f
   depends:
@@ -779,7 +779,7 @@ packages:
   license_family: BSD
   size: 12719
   timestamp: 1671231205875
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
   sha256: 821af57c20a85b4e92268fbf65fbaec2f273da5bb21889d9643756ef6e473237
   md5: f57e0f502500ffebdbec081ef61ad1d4
   depends:
@@ -793,7 +793,7 @@ packages:
   license_family: BSD
   size: 2179774
   timestamp: 1694445209134
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
   sha256: 3a39a2d6f161080c706292e3bf480f62d2444b1d6d67b3d7db50458202ee31f1
   md5: 0524ffca60f845eb392bbb56d56f0ce5
   depends:
@@ -804,7 +804,7 @@ packages:
   license_family: MIT
   size: 2094615
   timestamp: 1637091869922
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
   sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
   md5: 2e6ec51066d825ef3c317abe78d6049e
   depends:
@@ -813,7 +813,7 @@ packages:
   license_family: MIT
   size: 16413
   timestamp: 1649926472708
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
   sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
   md5: b4d923222d45314856b5378cb115214d
   depends:
@@ -822,7 +822,7 @@ packages:
   license_family: BSD
   size: 26728
   timestamp: 1668714462023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
   sha256: 8a121233d0b2cbb2463b67e798739ad2946f38933430a6a7fd1197cc6eab1c99
   md5: d2b24736491290a6c6d0138932111150
   depends:
@@ -832,7 +832,7 @@ packages:
   license: GPL-2.0-only and LicenseRef-FreeType
   size: 965280
   timestamp: 1635422707211
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
   sha256: 3c8ece1a7257b1d45f8fa25f46504bb709a1923d7175f2996e891366ec434b9d
   md5: 299bf4271d710651a1d71d3795580c2d
   depends:
@@ -840,7 +840,7 @@ packages:
   license: MIT
   size: 83592
   timestamp: 1603192039050
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
   sha256: 2d727f8335c59314b521b66d437ca4d51904134473ae503b7b097e239635f209
   md5: 6991e520f353d995023404f6f524d192
   depends:
@@ -857,7 +857,7 @@ packages:
   license_family: BSD
   size: 4507274
   timestamp: 1693378095165
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
   sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
   md5: 9213e0336e3a5216c989cfe52648412e
   depends:
@@ -866,7 +866,7 @@ packages:
   license: MIT
   size: 23805906
   timestamp: 1588026213084
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
   sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
   md5: 1eb52f9f45cea2fb9ce27b19f990160e
   depends:
@@ -875,7 +875,7 @@ packages:
   license_family: BSD
   size: 110793
   timestamp: 1666125606878
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
   sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
   md5: 126b3c1933b7364ff03f67455b687e99
   depends:
@@ -885,7 +885,7 @@ packages:
   license_family: APACHE
   size: 37588
   timestamp: 1678997134023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
   sha256: 1b424413f28b840fc6d4bf467f37e9e405823b1e3b899005df80152d48936d64
   md5: 4aa8bcf74c81cd3600978f791191692a
   constrains:
@@ -894,7 +894,7 @@ packages:
   license_family: Proprietary
   size: 9246735
   timestamp: 1634546760713
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
   sha256: b51b2e0dd37a74784ba19db22aded3f4c843b6fddb4a74399f65f36fc018aaa2
   md5: 0d56ab1950f952284b895ac0f78284a7
   depends:
@@ -914,7 +914,7 @@ packages:
   license_family: BSD
   size: 203541
   timestamp: 1671488675347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
   sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
   md5: ff47e0be879e817713ce2a9daa76e2b0
   depends:
@@ -935,7 +935,7 @@ packages:
   license_family: BSD
   size: 1261116
   timestamp: 1694181530670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
   sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
   md5: 5ef6c6a0d1ac79143c7359d305155167
   depends:
@@ -945,7 +945,7 @@ packages:
   license_family: MIT
   size: 1021637
   timestamp: 1644297140650
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
   sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
   md5: eaeb023688f781e7dd89e74310c38195
   depends:
@@ -955,7 +955,7 @@ packages:
   license_family: BSD
   size: 211775
   timestamp: 1666908212136
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
   sha256: 85348bfb14db4fea84078d703e766a3c978c5a592a06e41266748826dd59d8ae
   md5: 6e1c0fb5260c590f7ef5235cb3d05863
   depends:
@@ -964,7 +964,7 @@ packages:
   license_family: Other
   size: 279884
   timestamp: 1651065953960
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
   sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
   md5: 0d2c3c5edf671b575532d5a3e8bf15fc
   depends:
@@ -975,7 +975,7 @@ packages:
   license_family: MIT
   size: 131510
   timestamp: 1676558716852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
   sha256: 92bc012f9eb4ad71158cf4826fd3e125fcebff53b529276a81224acda48be547
   md5: c5fd100e3062e831cbdf33331042f627
   depends:
@@ -991,7 +991,7 @@ packages:
   license_family: BSD
   size: 190884
   timestamp: 1650622553813
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
   sha256: 0192bd48cd96c60dc3054d5addd8cdb4a29a218843181318371f79daec8242f8
   md5: d851b401dc13d04e6848bb36e12efc1c
   depends:
@@ -1002,7 +1002,7 @@ packages:
   license_family: BSD
   size: 91534
   timestamp: 1679906652183
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
   sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
   md5: a4beb461f0a60998a090d760b5c6c907
   depends:
@@ -1026,7 +1026,7 @@ packages:
   license_family: BSD
   size: 411564
   timestamp: 1671707702849
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
   sha256: 974df3dc76089be57b327acd6634384def84249003f58678ca1142bb274a75d9
   md5: 81b969d1a00153759b30554a1f11ddfd
   depends:
@@ -1037,7 +1037,7 @@ packages:
   license_family: BSD
   size: 92144
   timestamp: 1653292217019
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -1048,7 +1048,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
   sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
   md5: 9508af80612e4fa1b5d1abb43ca7e63c
   constrains:
@@ -1056,7 +1056,7 @@ packages:
   license: GPL-3.0-only
   size: 749072
   timestamp: 1652971360657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
   sha256: 3b4afe7665dcdb99bd4586a888b85b2e0325f8faecdd31c7780792080ee97872
   md5: 822b5201dde61bc838072dc5b670c88c
   depends:
@@ -1065,7 +1065,7 @@ packages:
   license: Custom
   size: 55183
   timestamp: 1594054267890
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
   sha256: c6fafbe73d2f93b91b6f4b65829f925f52a8f84746a57abd216b39da9ce8c494
   md5: 238f19c803a6ba7bd6dbd6989e03cbf1
   depends:
@@ -1073,7 +1073,7 @@ packages:
   license: GPL
   size: 8496776
   timestamp: 1560112207081
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
   sha256: bc3e6e79c32ff0ecea601aa108ae9cf4068f69703580e40e266ad4bcc52cff54
   md5: 9cb85601944ca7383b1769bff74b94e8
   depends:
@@ -1082,7 +1082,7 @@ packages:
   license: zlib/libpng
   size: 372914
   timestamp: 1556041895170
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -1090,13 +1090,13 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
   sha256: 43b0bd205f539583c088feb5b8d77b60c83d1df80c2a93dac9f2a1127001b2cf
   md5: 53fa39fdae936e9d07c4b2f5ef361993
   license: GPL3 with runtime exception
   size: 4246257
   timestamp: 1560112223556
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
   sha256: 711ea05b4c35bdafc762a172b01db896b17942f474c2b1a519f91370964bf9bc
   md5: b25d56d33596623a6a4a9d9baaa4f602
   depends:
@@ -1110,7 +1110,7 @@ packages:
   license: HPND
   size: 592974
   timestamp: 1653047881023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
   sha256: 146dbb1e4dbccdd57819e5102a8ca00970b8e33d6c6180e8007db89b184da569
   md5: c566a384259c1d2769852c3bddd81a67
   depends:
@@ -1124,7 +1124,7 @@ packages:
   license_family: BSD
   size: 90150
   timestamp: 1645441199289
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
   sha256: cffb5a063111f7a99a99c74770b23db5dde52325e25a7a46d1903d5ff4a82c88
   md5: eeb1bd66f28bed1956ab989d6eff7ae5
   depends:
@@ -1135,7 +1135,7 @@ packages:
   license_family: BSD
   size: 889956
   timestamp: 1645089138421
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
   sha256: 71f6c4a97014d745c58df52b4dd60ddd75a8508d54fe5b97f42bd1f31cb1c067
   md5: 686e77514ec9f1ef0a6feed374f14d37
   depends:
@@ -1147,7 +1147,7 @@ packages:
   license_family: MIT
   size: 789469
   timestamp: 1653546418059
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
   sha256: ea3355a67c5173f3944f09861043ca66eb7dbeff8f385d13528b3aabc0801d0c
   md5: 66e2aa12181bb2911485bdbe125d24c5
   depends:
@@ -1157,7 +1157,7 @@ packages:
   license: MIT
   size: 584199
   timestamp: 1654075843119
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
   sha256: 64b022d706b76c33965a250fdc8c6008443c41bff8ab27bb1df3cb70419576fd
   md5: ec4f05846aacf634df15c389235725cc
   depends:
@@ -1169,7 +1169,7 @@ packages:
   license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
   size: 1538261
   timestamp: 1646624639995
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
   sha256: 2c6a5dda7c510a961bc78e31d4232be5e8e0760c93454f5fd200c379355e0f5e
   md5: f35d4bf2fbb39e334992f6dd39f8721e
   depends:
@@ -1179,7 +1179,7 @@ packages:
   license_family: BSD
   size: 220865
   timestamp: 1627657046002
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
   sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
   md5: 421f82c8274b44660dba629134faa6af
   depends:
@@ -1189,7 +1189,7 @@ packages:
   license_family: BSD
   size: 122221
   timestamp: 1671541990505
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
   sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
   md5: feb0e452205b44ac45d9b5e55c21a3b1
   depends:
@@ -1201,7 +1201,7 @@ packages:
   license_family: BSD
   size: 22819
   timestamp: 1654597913064
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
   sha256: dc51b316ef5dcfb82a9c0afdc40879146ae59516f6cea7db776077783dfd2d76
   md5: b0b6b57c140f026b8806051107336576
   depends:
@@ -1223,7 +1223,7 @@ packages:
   license_family: PSF
   size: 7729454
   timestamp: 1647442028622
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
   sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
   md5: c04ef34af33da4c71bcc99b7ec24d210
   depends:
@@ -1233,7 +1233,7 @@ packages:
   license_family: BSD
   size: 16391
   timestamp: 1662014553452
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
   sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
   md5: f6c734d73e6e3dbc1b62766cf18ff3e4
   depends:
@@ -1243,7 +1243,7 @@ packages:
   license_family: BSD
   size: 58153
   timestamp: 1607364912263
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
   sha256: 7c4ded8b2ef036839f988560848d2c32e1aa4627fd37a32710e42c39f5c61ac2
   md5: bd20f4410b81f327e35ffa0657961146
   depends:
@@ -1254,7 +1254,7 @@ packages:
   license_family: Proprietary
   size: 229783051
   timestamp: 1634547157986
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
   sha256: 5394f5efd53afb2c1b0abf571ce3d9cb684b6c7e255f140ba2acaa703d6113be
   md5: d3cb2bfa63e30153f5527797dcc87280
   depends:
@@ -1266,7 +1266,7 @@ packages:
   license_family: BSD
   size: 63551
   timestamp: 1626176932911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
   sha256: c244d23da2749857a993f84969fd35ffd183ab8f462986df6d33ae0f705fe034
   md5: 9b1f8ccc2488d0e04eb73211e2987483
   depends:
@@ -1280,7 +1280,7 @@ packages:
   license: BSD 3-Clause
   size: 204136
   timestamp: 1634566416657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
   sha256: f81f426f8ef306d636664bc49e7cdd70e2b4306d7c6bcb9c75fe35a45ab2087a
   md5: 77aa1d7f958d36bf227e6ff4a34d2e3d
   depends:
@@ -1294,7 +1294,7 @@ packages:
   license: BSD-3-Clause
   size: 365386
   timestamp: 1626186165897
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
   sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
   md5: 95c83d71814c504b5504df4f14548f1a
   depends:
@@ -1320,7 +1320,7 @@ packages:
   license_family: BSD
   size: 8257558
   timestamp: 1681756322140
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
   sha256: 1b92d72b083f3350359b8fb2e3b5dc846f49650c9e46a6a74354b1b7f0d42730
   md5: 996babe4314515ddd41008a53cb5d47f
   depends:
@@ -1333,7 +1333,7 @@ packages:
   license_family: BSD
   size: 98791
   timestamp: 1650290544347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
   sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
   md5: 1710a25086c8098367eb36b9d441448b
   depends:
@@ -1361,7 +1361,7 @@ packages:
   license_family: BSD
   size: 569683
   timestamp: 1668450704669
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
   sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
   md5: 385cc9e53404776782502c0fdb08820f
   depends:
@@ -1374,7 +1374,7 @@ packages:
   license_family: BSD
   size: 147046
   timestamp: 1694616899309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
   sha256: 0807371380965e421cb5f3f2a30d790fd5c41db11dbb6d318e14294c3b1741ed
   md5: fca4bd4e3891aebf4fd7daf9b6d0ccfa
   depends:
@@ -1382,7 +1382,7 @@ packages:
   license: Free software (MIT-like)
   size: 1083412
   timestamp: 1636570020698
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
   sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
   md5: bbbcbebc20a4fdcadce398d0ca04f95e
   depends:
@@ -1391,7 +1391,7 @@ packages:
   license_family: BSD
   size: 13109
   timestamp: 1672387143252
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
   sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
   md5: 248ce515640465371927d46f389ed555
   depends:
@@ -1416,7 +1416,7 @@ packages:
   license_family: BSD
   size: 594054
   timestamp: 1690985006481
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
   sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
   md5: 70db71df4ee1cdd38090c0f7b80ba61f
   depends:
@@ -1426,7 +1426,7 @@ packages:
   license_family: BSD
   size: 21944
   timestamp: 1668160644514
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
   sha256: 15a12c8bebcda45c577e61cea412d9aafaa433e39f9e91fd61bbfab66fcee3ab
   md5: 5239d8330e8bd34972fb80918dce79e7
   depends:
@@ -1442,7 +1442,7 @@ packages:
   license_family: MIT
   size: 136437
   timestamp: 1640689905588
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
   sha256: ff8d0426c7096e086db818265c3edf4a820accbfb15afae0407ca578de151fa9
   md5: d7bcf0b9ba2d85cf532059ec119d2750
   depends:
@@ -1458,7 +1458,7 @@ packages:
   license: BSD-3-Clause
   size: 9965
   timestamp: 1652801901707
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
   sha256: abfdeda143b6b667d50a82ea119043fc1469ee02f094a41a2402433ff408099e
   md5: e8dc29adc0282f4658e0e2f25ff207a2
   depends:
@@ -1473,7 +1473,7 @@ packages:
   license: BSD-3-Clause
   size: 7095882
   timestamp: 1652801886819
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
   sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
   md5: 5ad4571eba2479f77a9f849a6ae7724c
   depends:
@@ -1483,7 +1483,7 @@ packages:
   license_family: Apache
   size: 3998613
   timestamp: 1694465071784
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
   sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
   md5: 77a22ed6d0d448c5288d0f695bc9ac49
   depends:
@@ -1492,7 +1492,7 @@ packages:
   license_family: Apache
   size: 72527
   timestamp: 1693575234886
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
   sha256: e7a0abb0f00a94000876f2095f0cf531ad3803ffbd868a780b3f06816b54492c
   md5: 97ef7e1fe923d22a8e2307f3f39a92d5
   depends:
@@ -1508,7 +1508,7 @@ packages:
   license_family: BSD
   size: 13221005
   timestamp: 1650622404234
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
   sha256: 49fdb57b2ed2ce4d6bb7a2c5adec36ba59522518a41fb941f9e39a9f43750cc5
   md5: 871b65444733b7da5823ee0dc9826722
   depends:
@@ -1529,7 +1529,7 @@ packages:
   license_family: BSD
   size: 14712394
   timestamp: 1676379803902
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
   sha256: 64a732ce2661cdb6bd8f9d1484ac10afeb73082b1c2b44728d212e0117d2860e
   md5: ada303f0cf43a4e99cfa7f243b23b681
   depends:
@@ -1538,7 +1538,7 @@ packages:
   license_family: BSD
   size: 141832
   timestamp: 1684915385689
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
   sha256: 8bcb1c67693f42a3170eb77ef4cdbb81b605fdf40816953e69a33a065c101638
   md5: b7689507fb5f879dc766aaa8a4c37351
   depends:
@@ -1557,7 +1557,7 @@ packages:
   license_family: Other
   size: 734566
   timestamp: 1646325095608
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
   sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
   md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
   depends:
@@ -1568,7 +1568,7 @@ packages:
   license_family: MIT
   size: 2674850
   timestamp: 1697548887851
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
   sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
   md5: fe56f0479dd414c846191116366262c3
   depends:
@@ -1577,7 +1577,7 @@ packages:
   license_family: MIT
   size: 31999
   timestamp: 1692205535111
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
   sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
   md5: 44d2a857d13bdf9d99aaac039a249d47
   depends:
@@ -1586,7 +1586,7 @@ packages:
   license_family: Apache
   size: 91137
   timestamp: 1659455142164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
   sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
   md5: eb899a739d9b58dd747f1f6bd52d4cf3
   depends:
@@ -1598,7 +1598,7 @@ packages:
   license_family: BSD
   size: 579771
   timestamp: 1672387338600
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
   sha256: 6973cfe0565ba3b5ad6d1de9e34848fbbadd78b507b2e23e1c079636b8f8f317
   md5: a924535045fb356e23e7a3cc8116b638
   depends:
@@ -1608,7 +1608,7 @@ packages:
   license_family: BSD
   size: 350026
   timestamp: 1612298042840
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
   sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
   md5: f36ecb722522cbe2e3737424edf1b5e1
   depends:
@@ -1620,7 +1620,7 @@ packages:
   license_family: BSD
   size: 29312
   timestamp: 1675441510984
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
   sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
   md5: 6d03295e544251e608a28c8d7c48115e
   depends:
@@ -1629,7 +1629,7 @@ packages:
   license_family: BSD
   size: 1862058
   timestamp: 1684280096752
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
   sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
   md5: 1f09617aecd6f3c2f2e20692c0759f34
   depends:
@@ -1639,7 +1639,7 @@ packages:
   license_family: Apache
   size: 94434
   timestamp: 1690223520097
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
   sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
   md5: ffceed627867508d73af1636ab5ebf42
   depends:
@@ -1648,7 +1648,7 @@ packages:
   license_family: MIT
   size: 156324
   timestamp: 1661452578573
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
   sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
   md5: 0e3341a4fe434167bf74b613eb6afd81
   depends:
@@ -1658,7 +1658,7 @@ packages:
   license_family: MIT
   size: 97194
   timestamp: 1636110999719
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
   sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
   md5: c5f3f7f10ad30f0945e75252615ab6e5
   depends:
@@ -1667,7 +1667,7 @@ packages:
   license_family: BSD
   size: 31331
   timestamp: 1605305847037
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
   sha256: c4b9e332a6f2b7524e8c88e2b39a2568a48e556fd9a44c30759c43611d4d023d
   md5: bb118745c9b08fc5028f45e77f371e68
   depends:
@@ -1687,7 +1687,7 @@ packages:
   license_family: PSF
   size: 24553777
   timestamp: 1654084160832
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
   sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
   md5: 0caa188a695319bdb13f53b0a2b3accc
   depends:
@@ -1696,7 +1696,7 @@ packages:
   license_family: BSD
   size: 264864
   timestamp: 1661371117920
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
   sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
   md5: bcb44ecbea441ee0d4659133d060d71f
   depends:
@@ -1705,7 +1705,7 @@ packages:
   license_family: MIT
   size: 257904
   timestamp: 1695131670290
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
   sha256: e937081facacb141dc2c9cdcced92baa9a2662e4a56100b6041df0b6b7692570
   md5: f3ac39b2349258198a9b3316636fe5d5
   depends:
@@ -1715,7 +1715,7 @@ packages:
   license_family: BSD
   size: 39972
   timestamp: 1685030752528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
   sha256: 3da9cbbd49fac566433748bd245d09d7d5fcd28b04c0397cbbf6d5bb92f5c4a5
   md5: df73a5d2f6e089d51e71e91935a82c65
   depends:
@@ -1726,7 +1726,7 @@ packages:
   license_family: MIT
   size: 183753
   timestamp: 1635775763162
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
   sha256: 26005d191bb15070aad70707ed6493f32678a67978bd3b83d4c9679cab44e717
   md5: 2dc75d5a4ccb64310939c3a72d34ae20
   depends:
@@ -1737,7 +1737,7 @@ packages:
   license_family: BSD
   size: 521583
   timestamp: 1638435042256
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
   sha256: 8c950c69bee969e2c66f88f0dc247b3ab75a753672a88009779d5f5dba193532
   md5: 150ac0eb929bab9dec912797bdfc7b95
   depends:
@@ -1747,7 +1747,7 @@ packages:
   license_family: GPL
   size: 433182
   timestamp: 1642022402894
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
   sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
   md5: c7de00b4ac2778c4e5a7816320d75391
   depends:
@@ -1763,7 +1763,7 @@ packages:
   license_family: Apache
   size: 94028
   timestamp: 1690400356879
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
   sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
   md5: 1581cafc84708ed9aafaaee1cbbf6065
   depends:
@@ -1772,7 +1772,7 @@ packages:
   license_family: MIT
   size: 1089416
   timestamp: 1690290900608
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
   sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
   md5: e19ffbfb24b990275d24fcea2bd1699b
   depends:
@@ -1781,7 +1781,7 @@ packages:
   license_family: Apache
   size: 15702
   timestamp: 1614030498860
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
   sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
   md5: ca061ce25c0f58628643abec8d6a8244
   depends:
@@ -1790,7 +1790,7 @@ packages:
   license_family: MIT
   size: 66330
   timestamp: 1696347637947
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
   sha256: 87965b7b46d93866d31696a1045216d64f077a06b2900c356aba87e8559c6188
   md5: fa334030245135b37027a882f3c468bf
   depends:
@@ -1801,7 +1801,7 @@ packages:
   license_family: Other
   size: 1561908
   timestamp: 1655328608308
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
   sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
   md5: 0e76eab58fe488e91f0aee73f46de031
   depends:
@@ -1812,7 +1812,7 @@ packages:
   license_family: BSD
   size: 29816
   timestamp: 1671751864131
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
   sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
   md5: b413a210eca82fe867e991eed085201b
   depends:
@@ -1822,7 +1822,7 @@ packages:
   license_family: BSD
   size: 38882
   timestamp: 1668168876032
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
   sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
   md5: 5b8375e2092012db69d2123dc0c68630
   depends:
@@ -1832,7 +1832,7 @@ packages:
   license_family: BSD
   size: 3485432
   timestamp: 1654088939579
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
   sha256: b746e39272888b9cc1a2a711b7b8836f2e26f4457850e43ad18bf0765e21dc3d
   md5: 200e86f8d53aeebf4b7dcfc944fd7920
   depends:
@@ -1842,7 +1842,7 @@ packages:
   license_family: Apache
   size: 661662
   timestamp: 1606942359431
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
   sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
   md5: 67a8320961ff24e92eebb661536e5cf7
   depends:
@@ -1855,7 +1855,7 @@ packages:
   license_family: MOZILLA
   size: 123763
   timestamp: 1679561904852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
   sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
   md5: 0f0b91a158dd3692cbb7a7763b657bfe
   depends:
@@ -1864,7 +1864,7 @@ packages:
   license_family: BSD
   size: 192032
   timestamp: 1671143995098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
   md5: 8515e64a3de7581360d713fe4c0a094e
   depends:
@@ -1874,7 +1874,7 @@ packages:
   license_family: PSF
   size: 8789
   timestamp: 1690297588156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
   md5: 60170012374b2a5007842fa5870d78c5
   depends:
@@ -1883,7 +1883,7 @@ packages:
   license_family: PSF
   size: 57479
   timestamp: 1690297581658
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
   sha256: 870f20a3c006a74b291910f69c3469a409bd21437142864b29cfafeb89ca7c34
   md5: 1b2f1589e3ebc3e0c6ecb38dba93e4ae
   depends:
@@ -1898,7 +1898,7 @@ packages:
   license_family: MIT
   size: 186761
   timestamp: 1686163186447
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
   sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
   md5: f8d03a15b974fc7810d9f54ae849fc8e
   depends:
@@ -1907,7 +1907,7 @@ packages:
   license_family: BSD
   size: 20781
   timestamp: 1607365390528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
   sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
   md5: d7db5d6ce1db80eade8a082ff78bf479
   depends:
@@ -1917,7 +1917,7 @@ packages:
   license_family: BSD
   size: 71044
   timestamp: 1614804011510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
   sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
   md5: b3899f8bda32734727bd5a73df1d7d17
   depends:
@@ -1926,7 +1926,7 @@ packages:
   license_family: MIT
   size: 101520
   timestamp: 1695742037911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
   sha256: 2ce360ff98c0ca4537d70c19266b5700810196c54ce2fbaff3b94a969846ee37
   md5: 94cb94dc47405b24b1b5bd0a3275ab59
   depends:
@@ -1935,7 +1935,7 @@ packages:
   license_family: GPL2
   size: 398058
   timestamp: 1651602137803
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -1943,7 +1943,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
   sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
   md5: 567b68192c387b5fc88178425577a0fe
   depends:
@@ -1953,7 +1953,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 366479
   timestamp: 1616055552392
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
   sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
   md5: 3818a9531fe74433c3b7d5144c9a58cc
   depends:
@@ -1962,7 +1962,7 @@ packages:
   license_family: MIT
   size: 18021
   timestamp: 1672387231268
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
   sha256: 513444d83ac2405e898531492ea59f3a95641e357cc39c1048d6fffc1791a16b
   md5: 601d9449c280b9b145dc8c83b6f06119
   depends:
@@ -1971,7 +1971,7 @@ packages:
   license_family: Other
   size: 133595
   timestamp: 1650637720646
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
   sha256: 1c049c23788a00b6f38bdc801245e0e60af98718d4db4c958658bcc67ff158c7
   md5: b1737dfd2e06ad69ec5cfec341e207c6
   depends:
@@ -1984,7 +1984,7 @@ packages:
   license_family: BSD
   size: 827172
   timestamp: 1650622223170
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -1997,7 +1997,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -2007,7 +2007,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
   md5: b2aa5503875aba2f1d88cae9df9a96d5
   depends:
@@ -2016,7 +2016,7 @@ packages:
   license_family: BSD
   size: 13636
   timestamp: 1611930018941
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -2028,7 +2028,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
   sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
   md5: 544adf2677c47c9b9c891aea720678f1
   depends:
@@ -2036,7 +2036,7 @@ packages:
   license: MIT
   size: 33999
   timestamp: 1630003259346
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -2045,7 +2045,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -2054,7 +2054,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -2063,7 +2063,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -2072,7 +2072,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
   sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
   md5: 9eff1a842dbda8d1bae9a2c008b599bc
   depends:
@@ -2083,7 +2083,7 @@ packages:
   license_family: MIT
   size: 690443
   timestamp: 1625743217109
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -2091,7 +2091,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
   sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
   md5: 33624a42ee387bf9918ea98b4e7b31fc
   depends:
@@ -2101,7 +2101,7 @@ packages:
   license_family: BSD
   size: 8173
   timestamp: 1601490751973
-- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
   sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
   md5: 67857cc5e9044770d2b15f9d94a4521d
   depends:
@@ -2110,7 +2110,7 @@ packages:
   license_family: Apache
   size: 12810
   timestamp: 1600445183315
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -2119,7 +2119,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -2128,7 +2128,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -2138,7 +2138,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
   sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
   md5: e68a6f315f41a8d814d833652bf38b9b
   depends:
@@ -2146,7 +2146,7 @@ packages:
   license: MIT
   size: 13374
   timestamp: 1606932077143
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -2154,7 +2154,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -2163,7 +2163,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -2172,7 +2172,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
   sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
   md5: 2eb923cc014094f4acf7f849d67d73f8
   depends:
@@ -2182,7 +2182,7 @@ packages:
   license_family: BSD
   size: 246457
   timestamp: 1626374695070
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
   sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
   md5: 02caf3f47f1d06256068053297355740
   depends:
@@ -2191,7 +2191,7 @@ packages:
   license_family: Apache
   size: 152292
   timestamp: 1690578151230
-- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
   sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
   md5: 41db68b96e114e367c4f120a3b379e59
   depends:
@@ -2200,7 +2200,7 @@ packages:
   license_family: BSD
   size: 19391
   timestamp: 1632406728844
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -2209,7 +2209,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -2221,14 +2221,14 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
   sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
   md5: a815d3bdb160bcc71687f2dda70d3ca4
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 122218
   timestamp: 1680170368293
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -2236,7 +2236,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
   sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
   md5: 447a49f7bad119faa80d7f14aa296c95
   depends:
@@ -2249,7 +2249,7 @@ packages:
   license_family: MIT
   size: 162176
   timestamp: 1644481750133
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
   sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
   md5: 8810f48fe4a4792de0fd3520b502d08b
   depends:
@@ -2258,7 +2258,7 @@ packages:
   license_family: BSD
   size: 10019
   timestamp: 1606859473259
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
   sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
   md5: 00a446b6dfc61af223df4de29fe8ad94
   depends:
@@ -2268,7 +2268,7 @@ packages:
   license_family: MIT
   size: 34305
   timestamp: 1644569782044
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
   sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
   md5: bd92dd8bd5b9d24e632b62a075426e50
   depends:
@@ -2277,7 +2277,7 @@ packages:
   license_family: MIT
   size: 133634
   timestamp: 1695718025321
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
   sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
   md5: f8ae051b591a9027adc16de1be9748f4
   depends:
@@ -2287,12 +2287,12 @@ packages:
   license_family: MIT
   size: 206198
   timestamp: 1681493096349
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
   sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
   md5: e2f3248e2a5009a02f7b8e54f83314ef
   size: 5620
   timestamp: 1528121955725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
   sha256: 65ababd5e7812c35a97ac7d22b0ebe52c144121a3d49528b7d5c19e8453cce4a
   md5: d85c13c017a37e406f6c1e00c1ea4f4f
   depends:
@@ -2310,7 +2310,7 @@ packages:
   license_family: BSD
   size: 6480601
   timestamp: 1690546287900
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
   sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
   md5: 0d79760d544d0bd8acb4adc4ef813418
   depends:
@@ -2320,7 +2320,7 @@ packages:
   license_family: BSD
   size: 137075
   timestamp: 1657175654487
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
   sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
   md5: 31d6d04cd2388d8f19004501271b3545
   depends:
@@ -2330,7 +2330,7 @@ packages:
   license: MIT
   size: 18982
   timestamp: 1659616229395
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
   sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
   md5: caf1073dc2ca5aeb832a2877394eae12
   depends:
@@ -2339,7 +2339,7 @@ packages:
   license: MIT
   size: 18233
   timestamp: 1659616216769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
   sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
   md5: aa1ed20c38af535c8d6a955314759d7b
   depends:
@@ -2348,14 +2348,14 @@ packages:
   license: MIT
   size: 394588
   timestamp: 1659616312678
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
   sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
   md5: ce3588e31faa79f546e0fc6a36c5543c
   license: MPL-2.0
   license_family: Other
   size: 133884
   timestamp: 1694009771475
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
   sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
   md5: 21eb7f53076d0a69513cfd258f6ef63c
   depends:
@@ -2364,7 +2364,7 @@ packages:
   license_family: Other
   size: 159756
   timestamp: 1690232346868
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
   sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
   md5: a40a04d9cda1e665565bc6c832d598b6
   depends:
@@ -2375,7 +2375,7 @@ packages:
   license_family: MIT
   size: 225258
   timestamp: 1670423337502
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
   sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
   md5: b2cc5f37f7bb069d061306e7eac2a011
   depends:
@@ -2385,7 +2385,7 @@ packages:
   license_family: CC
   size: 1913396
   timestamp: 1668084575248
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
   sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
   md5: 103d8c039e342115720a84d59c119d46
   depends:
@@ -2395,7 +2395,7 @@ packages:
   license_family: BSD
   size: 13774
   timestamp: 1671231190250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
   sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
   md5: f69f09e0346172f225390d2b3b0d7873
   depends:
@@ -2406,7 +2406,7 @@ packages:
   license_family: BSD
   size: 246628
   timestamp: 1663827484947
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
   sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
   md5: cb80c7ac65b48a737654f371fe31c460
   depends:
@@ -2419,7 +2419,7 @@ packages:
   license_family: BSD
   size: 1307228
   timestamp: 1694212041712
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
   sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
   md5: 04cbe8f4bc62c34fac9d42d1124059bf
   depends:
@@ -2429,7 +2429,7 @@ packages:
   license_family: MIT
   size: 2052734
   timestamp: 1690905361158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
   sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
   md5: ef0e825982f242085574f502dfff4f6b
   depends:
@@ -2438,7 +2438,7 @@ packages:
   license_family: MIT
   size: 16594
   timestamp: 1649926538106
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
   sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
   md5: 24747a300246c016b3a7f04dabd02d4a
   depends:
@@ -2447,7 +2447,7 @@ packages:
   license_family: BSD
   size: 27709
   timestamp: 1668714497209
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -2457,14 +2457,14 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
   sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
   md5: e4a732941f74b8062c8bcbfe5c5c2b56
   license: MIT
   license_family: MIT
   size: 80252
   timestamp: 1676983220161
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.17.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.17.1-py39hecd8cb5_0.tar.bz2
   sha256: a3c61a0d72aa6adca1967b894b190cf7d32fe78b0f8c57b855fb1e99c41aa3de
   md5: ec60e644877f1e89c9ce00d487232396
   depends:
@@ -2481,7 +2481,7 @@ packages:
   license_family: BSD
   size: 4610888
   timestamp: 1693378182350
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
   sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
   md5: f3ce6fe6eb760c236e5f7d04df5faa81
   depends:
@@ -2490,7 +2490,7 @@ packages:
   license_family: MIT
   size: 28138484
   timestamp: 1692293212596
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
   sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
   md5: 6dd72c43fea25b748ec7a9f6c0407e15
   depends:
@@ -2499,7 +2499,7 @@ packages:
   license_family: BSD
   size: 111810
   timestamp: 1666125671024
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
   sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
   md5: 03cdb7e679924b329ecab8f12cb8fc67
   depends:
@@ -2509,7 +2509,7 @@ packages:
   license_family: APACHE
   size: 38813
   timestamp: 1678997212422
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
   sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
   md5: e113c4e6e758dd68faf196586bf5564d
   depends:
@@ -2519,7 +2519,7 @@ packages:
   license_family: Apache
   size: 51873
   timestamp: 1698254765815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
   sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
   md5: 78baea934985ccd9514a366cc7e80ed4
   depends:
@@ -2528,7 +2528,7 @@ packages:
   license_family: Proprietary
   size: 727499
   timestamp: 1681801225190
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
   sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
   md5: da9b63e42f281f7e77b289f4b654b83b
   depends:
@@ -2550,7 +2550,7 @@ packages:
   license_family: BSD
   size: 218436
   timestamp: 1691121840155
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
   sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
   md5: 6a7cb9b49593b29933fa2b503d533a08
   depends:
@@ -2572,7 +2572,7 @@ packages:
   license_family: BSD
   size: 1257205
   timestamp: 1694181720454
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
   sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
   md5: d861ef66f5c0a282d60b65778a9de2f3
   depends:
@@ -2582,7 +2582,7 @@ packages:
   license_family: MIT
   size: 1048450
   timestamp: 1644315332508
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
   sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
   md5: f7e603c965052deed8b789c35855a42f
   depends:
@@ -2592,14 +2592,14 @@ packages:
   license_family: BSD
   size: 213537
   timestamp: 1666908270815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
   sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
   md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
   license: IJG
   license_family: Other
   size: 278924
   timestamp: 1677849185191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
   sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
   md5: a82a17e78f725dcbd71ff8dac6db05c7
   depends:
@@ -2610,7 +2610,7 @@ packages:
   license_family: MIT
   size: 133134
   timestamp: 1676558895333
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
   sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
   md5: ee9270379a9ebdb6297e4b6849b3f7f0
   depends:
@@ -2626,7 +2626,7 @@ packages:
   license_family: BSD
   size: 195479
   timestamp: 1676329410154
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 32b898a97dca7770858ab31294238fde11ab61a84831a52f320e5ee5405a147c
   md5: 926e754b8fad288b583ef2933deae1a5
   depends:
@@ -2637,7 +2637,7 @@ packages:
   license_family: BSD
   size: 92938
   timestamp: 1679906616072
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
   sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
   md5: 7e60995b3119417213e5faedda147499
   depends:
@@ -2661,7 +2661,7 @@ packages:
   license_family: BSD
   size: 403165
   timestamp: 1671707664990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
   sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
   md5: cd470bdb28bb0e8b3535c93a3a6dad07
   depends:
@@ -2671,7 +2671,7 @@ packages:
   license_family: BSD
   size: 65431
   timestamp: 1672387389172
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -2681,7 +2681,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -2690,13 +2690,13 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
   sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
   md5: 7dba7aa5b971febb55281659843586ba
   license: MIT
   size: 65470
   timestamp: 1659616172703
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
   sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
   md5: f78a158983f0bbaba56f34b976bc6dae
   depends:
@@ -2704,7 +2704,7 @@ packages:
   license: MIT
   size: 34189
   timestamp: 1659616189313
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
   sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
   md5: 36a1d885725d3ab4d1fadc5a29f978d2
   depends:
@@ -2712,35 +2712,35 @@ packages:
   license: MIT
   size: 327737
   timestamp: 1659616202869
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
   sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
   md5: 817848d0e2b2808acdc9b3fbbf581726
   license: MIT
   license_family: MIT
   size: 133887
   timestamp: 1683716590737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
   sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
   md5: c90372428e1e4eed4fdcd790979d06b4
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1409377
   timestamp: 1650983531933
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -2749,13 +2749,13 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -2772,7 +2772,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
   sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
   md5: c0b99f8e1c7475f23b1c7b4250b06e1c
   depends:
@@ -2786,7 +2786,7 @@ packages:
   license_family: BSD
   size: 88021
   timestamp: 1694778290062
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
   sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
   md5: 46a65d1fc24013217e06aaf6d65ffcad
   constrains:
@@ -2795,7 +2795,7 @@ packages:
   license_family: BSD
   size: 425478
   timestamp: 1694776947990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
   sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
   md5: 06866415ef22d5322f9bdc9956b59c4d
   depends:
@@ -2807,7 +2807,7 @@ packages:
   license_family: MIT
   size: 678174
   timestamp: 1692970318885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
   sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
   md5: 2edc6c894d6d0321304396e9bd40df94
   depends:
@@ -2817,7 +2817,7 @@ packages:
   license_family: MIT
   size: 241774
   timestamp: 1692973618934
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 0190d3b8d2939f28aa017711cf4147c51a1139da2922cc8420a71562dd99f844
   md5: 454a7f2c4426453f17e995382a4235e4
   depends:
@@ -2827,7 +2827,7 @@ packages:
   license_family: MIT
   size: 36036
   timestamp: 1659783508187
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
   sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
   md5: 8bbd981ca0129d7beeacd3cd7623f714
   depends:
@@ -2838,7 +2838,7 @@ packages:
   license_family: Other
   size: 1491074
   timestamp: 1695058597986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
   sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
   md5: d5f58d056b4bfc67aec30c77035ba889
   depends:
@@ -2847,7 +2847,7 @@ packages:
   license_family: BSD
   size: 182491
   timestamp: 1670944720979
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
   sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
   md5: 1affd16b166571a91feae04baf5fd3da
   depends:
@@ -2857,7 +2857,7 @@ packages:
   license_family: BSD
   size: 123431
   timestamp: 1671542016019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
   sha256: e5fc51472fa0f36abd78baa5b3c9245d6627b0da11188e6a954d73f3f2bca210
   md5: df7c519447affffb594f8c56b028ed33
   depends:
@@ -2867,7 +2867,7 @@ packages:
   license_family: MIT
   size: 107035
   timestamp: 1684279974102
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
   sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
   md5: 3681ebf029211ceab26af6f5d35abf39
   depends:
@@ -2878,7 +2878,7 @@ packages:
   license_family: BSD
   size: 22254
   timestamp: 1654598220251
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
   sha256: 2fd179efa024c92d0d71179a981a781d16c70f5d8c6305e0d678b0c7ae1275ab
   md5: addda7f015d1673f794a23fdb18a3e09
   depends:
@@ -2901,7 +2901,7 @@ packages:
   license_family: PSF
   size: 8182219
   timestamp: 1698692361219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
   sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
   md5: 6eb64ecfcd754502e271db0bb51d2cfd
   depends:
@@ -2911,7 +2911,7 @@ packages:
   license_family: BSD
   size: 17374
   timestamp: 1662014643620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 2312ee5a6343e8495802698d7181f1b619aad7479d96ee253407b324ac884417
   md5: 866960fa48a7ca335941786d4869802a
   depends:
@@ -2921,7 +2921,7 @@ packages:
   license_family: MIT
   size: 53542
   timestamp: 1659721365599
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
   sha256: 37f455814ce242eb65ff80a0402f1bd231a388e6823e6c1e65f60b705c032a2d
   md5: 4c9246c492a64729225aa5b04e12c2d1
   depends:
@@ -2930,7 +2930,7 @@ packages:
   license_family: MIT
   size: 19573
   timestamp: 1659716100178
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
   sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
   md5: 2a4d604717a647ad21af766289cbbfc3
   depends:
@@ -2939,7 +2939,7 @@ packages:
   license_family: BSD
   size: 58057
   timestamp: 1607364912348
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
   sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
   md5: 25051fe272624544652dc6d814c2943a
   depends:
@@ -2952,7 +2952,7 @@ packages:
   license_family: Proprietary
   size: 224420228
   timestamp: 1691503125614
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
   sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
   md5: 37d8cf85a63f7aa9af1624894a7d606d
   depends:
@@ -2962,7 +2962,7 @@ packages:
   license_family: BSD
   size: 48590
   timestamp: 1682969183093
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
   sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
   md5: 0b2aee6666135bbd36b46d6ac66160f7
   depends:
@@ -2975,7 +2975,7 @@ packages:
   license_family: BSD
   size: 210705
   timestamp: 1695058433223
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
   sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
   md5: e22fb55ce380d0ebd44cce3f20d5349e
   depends:
@@ -2989,7 +2989,7 @@ packages:
   license_family: BSD
   size: 296614
   timestamp: 1695060155673
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
   sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
   md5: 1a5d4004e64e3cfb7a2a297b9117c285
   depends:
@@ -3015,7 +3015,7 @@ packages:
   license_family: BSD
   size: 8213832
   timestamp: 1681756573646
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
   sha256: 2975bd1f98ca9ec7354ee378f86f8322ec90f568374776fd90e80c534fbee882
   md5: 798627089e0ccba26695a26d9cb127ec
   depends:
@@ -3028,7 +3028,7 @@ packages:
   license_family: BSD
   size: 99066
   timestamp: 1650308465824
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
   sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
   md5: e572c1264a7af20b486f64ac8c9e1f57
   depends:
@@ -3056,7 +3056,7 @@ packages:
   license_family: BSD
   size: 573356
   timestamp: 1668450732828
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
   sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
   md5: b67569a7c30af9ffa5cde6e4b52ac68b
   depends:
@@ -3069,14 +3069,14 @@ packages:
   license_family: BSD
   size: 148342
   timestamp: 1694616917184
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
   sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
   md5: 97b81f34efbe86c5220fe82eb584fd62
   depends:
@@ -3085,7 +3085,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387288528
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
   sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
   md5: d77862975a9a1cf50acb803be26e83a1
   depends:
@@ -3110,7 +3110,7 @@ packages:
   license_family: BSD
   size: 575365
   timestamp: 1690985052739
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
   sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
   md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
   depends:
@@ -3120,7 +3120,7 @@ packages:
   license_family: BSD
   size: 22858
   timestamp: 1668160618784
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
   sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
   md5: 185e9c41abb88ee59b52ec0f5f65d506
   depends:
@@ -3134,7 +3134,7 @@ packages:
   license_family: MIT
   size: 138305
   timestamp: 1696515469702
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
   sha256: 82a2dd0c2ff6e20a275e5447dd03088f79694f7bfa5055a25c54bebf31aac4ca
   md5: c157e6ab469a95b06fa822ba075978b3
   depends:
@@ -3150,7 +3150,7 @@ packages:
   license_family: BSD
   size: 10376
   timestamp: 1695831243158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
   sha256: b3a003b41cec2751210e542911e99437db0321542f6812c1b88608ef720ba7ef
   md5: 56400dfe88c427cdf1854e47666b8a99
   depends:
@@ -3165,7 +3165,7 @@ packages:
   license_family: BSD
   size: 7570900
   timestamp: 1695831208653
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
   sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
   md5: 93f5d7b66976154adeda219bea02ba45
   depends:
@@ -3175,7 +3175,7 @@ packages:
   license: BSD 2-Clause
   size: 484257
   timestamp: 1630093862501
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
   sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
   md5: 5e8713ef1215406254988163eaf34020
   depends:
@@ -3184,7 +3184,7 @@ packages:
   license_family: Apache
   size: 4965606
   timestamp: 1695323060401
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
   sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
   md5: 4154929ace2ad6ee16aea815635a6d1f
   depends:
@@ -3193,7 +3193,7 @@ packages:
   license_family: Apache
   size: 73598
   timestamp: 1693575307570
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.0.3-py39h3ea8b11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-2.0.3-py39h3ea8b11_0.tar.bz2
   sha256: 5e8b15af733592f6f6bff1c6eee2b8b808e8252e8a1112dc5a1cafe74016bffd
   md5: 814274b9cdcd2cebab38a7a4d3d6dc48
   depends:
@@ -3241,7 +3241,7 @@ packages:
   license_family: BSD
   size: 13333560
   timestamp: 1692298689692
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
   sha256: 1928d1f3aa777c6fe0b279f400fa417b293527531bbdd3d918cc8e987a680f86
   md5: e8d7a163f2f9dd0f1972e126ee87b586
   depends:
@@ -3265,7 +3265,7 @@ packages:
   license_family: BSD
   size: 17076156
   timestamp: 1695146369755
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
   sha256: 914f1ec8d911083c006c4c2d3b4c0c528e79abba3ae5f1dad825bd896870270d
   md5: 949e0e4c0ce43c92eb52241892230873
   depends:
@@ -3274,7 +3274,7 @@ packages:
   license_family: BSD
   size: 142949
   timestamp: 1684915417020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
   sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
   md5: be0a90921f3bf4f0d6950fb786093de7
   depends:
@@ -3293,7 +3293,7 @@ packages:
   license_family: Other
   size: 719901
   timestamp: 1696580194417
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
   sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
   md5: 81ae9ec2d7fcf6934847bff558b619f5
   depends:
@@ -3304,7 +3304,7 @@ packages:
   license_family: MIT
   size: 2672987
   timestamp: 1697548890181
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
   sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
   md5: 1a822c206e2abddc5d6d821721af227f
   depends:
@@ -3313,7 +3313,7 @@ packages:
   license_family: MIT
   size: 33013
   timestamp: 1692205801265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
   sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
   md5: 1604d33dbdb2446c642970f8b354bedb
   depends:
@@ -3322,7 +3322,7 @@ packages:
   license_family: Apache
   size: 91266
   timestamp: 1659455269141
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
   sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
   md5: d1b3bcc35655a3123acb1fa2ad1a8511
   depends:
@@ -3334,7 +3334,7 @@ packages:
   license_family: BSD
   size: 580828
   timestamp: 1672387372015
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
   sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
   md5: 7540555d1fb192236db9a7c5c9d3601c
   depends:
@@ -3343,7 +3343,7 @@ packages:
   license_family: BSD
   size: 365765
   timestamp: 1656431373327
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
   sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
   md5: 0a73533fb6e0dc717ab906a537bc747d
   depends:
@@ -3355,7 +3355,7 @@ packages:
   license_family: BSD
   size: 30803
   timestamp: 1675441638631
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
   sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
   md5: 0a959fbad46ab38ade48dbd358002674
   depends:
@@ -3364,7 +3364,7 @@ packages:
   license_family: BSD
   size: 1864757
   timestamp: 1684280094736
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
   sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
   md5: ea24b5076ef79e4567c5a3f0cb22b470
   depends:
@@ -3374,7 +3374,7 @@ packages:
   license_family: Apache
   size: 95330
   timestamp: 1690223465114
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
   sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
   md5: bcaea6d4a47e9c874becaa700c78dcf7
   depends:
@@ -3383,7 +3383,7 @@ packages:
   license_family: MIT
   size: 157216
   timestamp: 1661452617825
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
   sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
   md5: 707110d1b49cb1864acb0bbaa103591e
   depends:
@@ -3392,7 +3392,7 @@ packages:
   license_family: MIT
   size: 95016
   timestamp: 1636111184034
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
   sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
   md5: 113a443b9c706f9f9c6187c0eaa3de27
   depends:
@@ -3401,7 +3401,7 @@ packages:
   license_family: BSD
   size: 31178
   timestamp: 1605305861851
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
   sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
   md5: 85a8d0001db70e52a479155228cb1fe0
   depends:
@@ -3420,7 +3420,7 @@ packages:
   license_family: PSF
   size: 13324979
   timestamp: 1694439878265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
   sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
   md5: 47c5e22e31ec05a7bc0ce90065a53afd
   depends:
@@ -3429,7 +3429,7 @@ packages:
   license_family: BSD
   size: 265348
   timestamp: 1661368839620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
   sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
   md5: ce9a69e1668aa1e133f2aa6d4e8d346f
   depends:
@@ -3438,7 +3438,7 @@ packages:
   license_family: MIT
   size: 254958
   timestamp: 1695131709704
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 9ee098c09f31fad7ff1856e5ce2619172eaf979997e7a427d1e05cce32c2af00
   md5: cac1d1898b69ae9646dfbf082910635d
   depends:
@@ -3448,7 +3448,7 @@ packages:
   license_family: BSD
   size: 40946
   timestamp: 1685030787453
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
   sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
   md5: 637f08b19dd8fd87347d8c44f9e3e202
   depends:
@@ -3458,7 +3458,7 @@ packages:
   license_family: MIT
   size: 170776
   timestamp: 1698096100056
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
   sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
   md5: 8ce3ac7d8a04e469b566f1b090d01140
   depends:
@@ -3469,7 +3469,7 @@ packages:
   license_family: BSD
   size: 470617
   timestamp: 1657724324011
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -3478,7 +3478,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
   sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
   md5: 6f2d41dd76a03b7f85a1ed49af1763d6
   depends:
@@ -3494,7 +3494,7 @@ packages:
   license_family: Apache
   size: 95100
   timestamp: 1690400262627
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
   md5: b0321e6f14e139fc15b1f8b4acb35d2f
   depends:
@@ -3503,7 +3503,7 @@ packages:
   license_family: MIT
   size: 1093966
   timestamp: 1690290944588
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
   sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
   md5: 62b64576a0aa5f6c3fb05f56650d25e1
   depends:
@@ -3512,7 +3512,7 @@ packages:
   license_family: Apache
   size: 15535
   timestamp: 1614030509324
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
   sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
   md5: 15b5595b31e39f08eaacbe2e502d8fb3
   depends:
@@ -3521,7 +3521,7 @@ packages:
   license_family: MIT
   size: 67292
   timestamp: 1696347733587
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
   sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
   md5: 82e4db6a498480a75d53c55bd35b6478
   depends:
@@ -3533,7 +3533,7 @@ packages:
   license_family: Other
   size: 1801397
   timestamp: 1681394807900
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -3542,7 +3542,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
   sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
   md5: 63b957927b9949ccb19da28ec4612706
   depends:
@@ -3553,7 +3553,7 @@ packages:
   license_family: BSD
   size: 30902
   timestamp: 1671751919031
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
   sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
   md5: e346257a2fa8e2cb48c762138a5d009b
   depends:
@@ -3563,7 +3563,7 @@ packages:
   license_family: BSD
   size: 39915
   timestamp: 1668168959656
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
   sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
   md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
   depends:
@@ -3572,7 +3572,7 @@ packages:
   license_family: BSD
   size: 3536231
   timestamp: 1654088937695
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
   sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
   md5: a1bbf0abfb8c45541122c0eb2feee317
   depends:
@@ -3581,7 +3581,7 @@ packages:
   license_family: Apache
   size: 680464
   timestamp: 1696937112175
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
   sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
   md5: d689f6203c0a9d04fb229c73d7e80a7a
   depends:
@@ -3594,7 +3594,7 @@ packages:
   license_family: MOZILLA
   size: 125145
   timestamp: 1679561909274
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
   md5: 8a292c1ee22489bef2e84bc3aaf4098e
   depends:
@@ -3603,7 +3603,7 @@ packages:
   license_family: BSD
   size: 193141
   timestamp: 1671143985219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
   md5: 8bf0bfffc11ad06a1c94e145941b0ad4
   depends:
@@ -3613,7 +3613,7 @@ packages:
   license_family: PSF
   size: 9651
   timestamp: 1690297655669
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
   md5: 343514a174b3485fde55a73f56398dd7
   depends:
@@ -3622,7 +3622,7 @@ packages:
   license_family: PSF
   size: 58456
   timestamp: 1690297648002
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
   sha256: 11e7401cb6805db7ce22b1f9dd6ba5b7941c92225ce440bed1da0af284bfcad4
   md5: 5c10d68fa5616cdd82ee93ef6e0f038c
   depends:
@@ -3631,7 +3631,7 @@ packages:
   license_family: MIT
   size: 11615
   timestamp: 1659769478980
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
   sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
   md5: c2242e8fd24003a74ddf37416661e06d
   depends:
@@ -3646,7 +3646,7 @@ packages:
   license_family: MIT
   size: 188757
   timestamp: 1698257668273
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
   sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
   md5: 41f445e36b6b6722a9444508eef069f8
   depends:
@@ -3655,7 +3655,7 @@ packages:
   license_family: BSD
   size: 20583
   timestamp: 1607365395045
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
   sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
   md5: 409ee46ed24267b6da6fb32d13e1f21e
   depends:
@@ -3665,7 +3665,7 @@ packages:
   license_family: BSD
   size: 70730
   timestamp: 1614804271285
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
   sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
   md5: eb74e74d8e4fd533c55eb98b7b5e83bc
   depends:
@@ -3674,7 +3674,7 @@ packages:
   license_family: MIT
   size: 102637
   timestamp: 1695742077778
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
   sha256: cb007615819fd240ea4e343835dfbda3c508a92b5b7158219d30a22d0e67b57c
   md5: bf215e781ac81e0fc433eedee330c54b
   depends:
@@ -3683,20 +3683,20 @@ packages:
   license_family: BSD
   size: 49462
   timestamp: 1675159191191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
   sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
   md5: e243baa546432c8394a8059a44a5a3e4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 419227
   timestamp: 1683113010463
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
   sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
   md5: fe4ac85ee86d3a94ea3a4ebea3779763
   depends:
@@ -3705,7 +3705,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 321797
   timestamp: 1616055526986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
   sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
   md5: bc7073d9d4c0211cc4a1207c98fb765a
   depends:
@@ -3714,14 +3714,14 @@ packages:
   license_family: MIT
   size: 19091
   timestamp: 1672387204865
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
   sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
   md5: 8e495591e369ac161857a72011c0a296
   license: Zlib
   license_family: Other
   size: 120272
   timestamp: 1666595024203
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
   sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
   md5: f1465fbd810b3746c6de6babfd4fe28a
   depends:
@@ -3733,7 +3733,7 @@ packages:
   license_family: BSD
   size: 1023573
   timestamp: 1681304595869
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
   sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
   md5: cf55cb8d7031b30c70c56fc7c782b5c7
   depends:
@@ -3746,7 +3746,7 @@ packages:
   license_family: MIT
   size: 156104
   timestamp: 1644482799136
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
   sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
   md5: 84fce327d9f0d594e86f565e5c21962e
   depends:
@@ -3755,7 +3755,7 @@ packages:
   license_family: BSD
   size: 10183
   timestamp: 1629146082730
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
   sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
   md5: 84b8b998a741b37abf5312c1c03696ef
   depends:
@@ -3765,7 +3765,7 @@ packages:
   license_family: MIT
   size: 33979
   timestamp: 1644845817952
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
   sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
   md5: 77b746931c8f31c3ae393ccb5819d43d
   depends:
@@ -3774,7 +3774,7 @@ packages:
   license_family: MIT
   size: 133628
   timestamp: 1695717890677
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
   sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
   md5: 3df6e8ba34208dea068890e5d5318cc0
   depends:
@@ -3784,12 +3784,12 @@ packages:
   license_family: MIT
   size: 206759
   timestamp: 1681493095987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
   sha256: 4edfceca9958378015a2d5ff705aecb977fa329fdd0caf51cf6a1b6b5506e5ab
   md5: 7404ddc0add9157338d7d4822ac13cb3
   depends:
@@ -3807,7 +3807,7 @@ packages:
   license_family: BSD
   size: 6462121
   timestamp: 1690546176434
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
   sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
   md5: bb55f81435cb6e11d264242274fccd1a
   depends:
@@ -3817,7 +3817,7 @@ packages:
   license_family: BSD
   size: 115947
   timestamp: 1657175645380
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
   md5: f860193e14afc7ef3f5b990a2ac003d2
   depends:
@@ -3827,7 +3827,7 @@ packages:
   license: MIT
   size: 18936
   timestamp: 1659616204016
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
   sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
   md5: ad53130f3fd1f8d3c2fcbb7496e5585d
   depends:
@@ -3836,7 +3836,7 @@ packages:
   license: MIT
   size: 18715
   timestamp: 1659616188888
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
   sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
   md5: 0982c046fb976e9f9fb19e7510187a18
   depends:
@@ -3845,14 +3845,14 @@ packages:
   license: MIT
   size: 366983
   timestamp: 1659616245272
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
   sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
   md5: 31ac2f5596cb7a44adf073c930641c54
   license: MPL-2.0
   license_family: Other
   size: 133817
   timestamp: 1694009762858
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
   sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
   md5: cf1f6c3c34a1e1b9ab22b04233d860f6
   depends:
@@ -3861,7 +3861,7 @@ packages:
   license_family: Other
   size: 159783
   timestamp: 1690232303987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
   sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
   md5: 0eb268e38b5174d471a6e87d9d6102b1
   depends:
@@ -3872,7 +3872,7 @@ packages:
   license_family: MIT
   size: 225355
   timestamp: 1670423312966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
   sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
   md5: e68c94666cd60221b575c3814c89bac0
   depends:
@@ -3882,7 +3882,7 @@ packages:
   license_family: CC
   size: 1946451
   timestamp: 1668084573824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
   sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
   md5: 1773ae2b080cdd55827e27673351551e
   depends:
@@ -3892,7 +3892,7 @@ packages:
   license_family: BSD
   size: 13646
   timestamp: 1671231171682
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
   sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
   md5: 53bfd99ad1b09164d537209cffd98161
   depends:
@@ -3903,7 +3903,7 @@ packages:
   license_family: BSD
   size: 244040
   timestamp: 1663827469853
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
   sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
   md5: b62455043c8eb2434466885b19fed2de
   depends:
@@ -3916,7 +3916,7 @@ packages:
   license_family: BSD
   size: 1399573
   timestamp: 1694211828228
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
   sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
   md5: eb3cdc0fc210838b9271512a6a1b7c85
   depends:
@@ -3926,7 +3926,7 @@ packages:
   license_family: MIT
   size: 2067708
   timestamp: 1690905319109
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
   sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
   md5: f44b80b9405410e5bde6bfe0b31d5b3f
   depends:
@@ -3935,7 +3935,7 @@ packages:
   license_family: MIT
   size: 15135
   timestamp: 1650293774207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
   sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
   md5: f87027ccce1361d0f82c0edf1a10d53b
   depends:
@@ -3944,7 +3944,7 @@ packages:
   license_family: BSD
   size: 27677
   timestamp: 1668714367519
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -3954,14 +3954,14 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
   sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
   md5: 1d0bd7e576c64c059ef781dd319ad82a
   license: MIT
   license_family: MIT
   size: 77591
   timestamp: 1676983230102
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.17.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.17.1-py39hca03da5_0.tar.bz2
   sha256: 024023fcd6a34ff71b3b558f9db00506382edef02e7ae0cf8e49846840d7deb8
   md5: 5598508e6b21861496a578c023958612
   depends:
@@ -3978,7 +3978,7 @@ packages:
   license_family: BSD
   size: 4495882
   timestamp: 1693378262537
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
   sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
   md5: 69eb3b03765627b6159ed23cdde78396
   depends:
@@ -3987,7 +3987,7 @@ packages:
   license_family: MIT
   size: 28399065
   timestamp: 1692293207812
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
   sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
   md5: 83366cbd3beb073112f4644a613b6bca
   depends:
@@ -3996,7 +3996,7 @@ packages:
   license_family: BSD
   size: 111933
   timestamp: 1666125627512
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
   sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
   md5: 647c1a2f8460ffa8c670a1915bbdb494
   depends:
@@ -4006,7 +4006,7 @@ packages:
   license_family: APACHE
   size: 38790
   timestamp: 1678997152549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
   sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
   md5: 35e541905426c686ef2ff010a0e502fd
   depends:
@@ -4016,7 +4016,7 @@ packages:
   license_family: Apache
   size: 51860
   timestamp: 1698254731870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
   sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
   md5: 187d7720aedf38759d122cccb4576f2c
   depends:
@@ -4038,7 +4038,7 @@ packages:
   license_family: BSD
   size: 219976
   timestamp: 1691121991680
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
   sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
   md5: e8e7f10741f9cfa737b310b334940441
   depends:
@@ -4060,7 +4060,7 @@ packages:
   license_family: BSD
   size: 1255894
   timestamp: 1694181494549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
   sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
   md5: ff209e75aee17af2e358b0008fbe8c88
   depends:
@@ -4070,7 +4070,7 @@ packages:
   license_family: MIT
   size: 1022945
   timestamp: 1644315931223
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
   sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
   md5: d3e78ef296b3c74910d003bd10b475d6
   depends:
@@ -4080,14 +4080,14 @@ packages:
   license_family: BSD
   size: 213972
   timestamp: 1666908195870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
   sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
   md5: 055e12390b844ea6c6e956ee08a618e8
   license: IJG
   license_family: Other
   size: 273479
   timestamp: 1677849171867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
   sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
   md5: 783e2ad3d36472648c5ccc9f3051db3c
   depends:
@@ -4098,7 +4098,7 @@ packages:
   license_family: MIT
   size: 133077
   timestamp: 1676558732505
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
   sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
   md5: 0677598f673f9729b5990316170a999d
   depends:
@@ -4114,7 +4114,7 @@ packages:
   license_family: BSD
   size: 197129
   timestamp: 1676329661580
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
   sha256: 05f9ca0fdcfdc2e217438be27fead588c843a3aadf7d034467c83216d1e5c214
   md5: 2d648b77d817ba38293c0728711ba8f5
   depends:
@@ -4125,7 +4125,7 @@ packages:
   license_family: BSD
   size: 92852
   timestamp: 1679906632236
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
   sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
   md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
   depends:
@@ -4149,7 +4149,7 @@ packages:
   license_family: BSD
   size: 401319
   timestamp: 1671707682572
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
   sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
   md5: 247558a0aecf1ef7e77a4343761353d6
   depends:
@@ -4159,7 +4159,7 @@ packages:
   license_family: BSD
   size: 64600
   timestamp: 1672387273585
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -4169,7 +4169,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -4178,13 +4178,13 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
   md5: a0f206782751dfffed0dd51302a1bf26
   license: MIT
   size: 68012
   timestamp: 1659616138077
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
   md5: 4c6667cdd061d28e9bc4e4300e4d115e
   depends:
@@ -4192,7 +4192,7 @@ packages:
   license: MIT
   size: 31173
   timestamp: 1659616155596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
   md5: 637e9430e258ddf050623ef2360184d8
   depends:
@@ -4200,28 +4200,28 @@ packages:
   license: MIT
   size: 298430
   timestamp: 1659616172209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
   sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
   md5: 55c615026c0869f8d3ba657f3bd38c43
   license: MIT
   license_family: MIT
   size: 120389
   timestamp: 1683716579036
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -4230,7 +4230,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -4241,14 +4241,14 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
   sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
   md5: a41117710dafe569c9cc4e83f6f29fe3
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1411339
   timestamp: 1650982753977
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -4259,7 +4259,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -4268,13 +4268,13 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -4291,7 +4291,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
   sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
   md5: 98d22e0124d55fae3c37c608dab1dcc9
   depends:
@@ -4305,7 +4305,7 @@ packages:
   license_family: BSD
   size: 89825
   timestamp: 1694778225280
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
   sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
   md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
   constrains:
@@ -4314,7 +4314,7 @@ packages:
   license_family: BSD
   size: 331675
   timestamp: 1694776939192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
   sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
   md5: 0ba499df6755eae5d2d23aa4ab004553
   depends:
@@ -4326,7 +4326,7 @@ packages:
   license_family: MIT
   size: 642657
   timestamp: 1692970217410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
   sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
   md5: c73101971e5ab6a8e8688239884eac81
   depends:
@@ -4336,7 +4336,7 @@ packages:
   license_family: MIT
   size: 241607
   timestamp: 1692973585084
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
   sha256: ac50f846e93e68d50bfdd5589ea8272b987243a64eba8e2e358ef311d7734001
   md5: f19270ff954a41dabbfe36ff0656935b
   depends:
@@ -4346,7 +4346,7 @@ packages:
   license_family: MIT
   size: 36040
   timestamp: 1659783399073
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -4355,7 +4355,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
   sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
   md5: 353dff9d5d996c2a260f66381b2ce3e8
   depends:
@@ -4366,7 +4366,7 @@ packages:
   license_family: Other
   size: 1470815
   timestamp: 1695058433965
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
   sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
   md5: c99006da802a97c9aae30da8c16b4820
   depends:
@@ -4375,7 +4375,7 @@ packages:
   license_family: BSD
   size: 176131
   timestamp: 1670944706815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
   sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
   md5: 60bd1e037cda86205526f77405d78129
   depends:
@@ -4385,7 +4385,7 @@ packages:
   license_family: BSD
   size: 123361
   timestamp: 1671541992772
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
   sha256: 2fd690fa3c54a40f0426874ea12e12aad2718263a75708ddd1fa6052a4ad7fb3
   md5: 81388724babfe9c32ea5cdd93633c342
   depends:
@@ -4395,7 +4395,7 @@ packages:
   license_family: MIT
   size: 107072
   timestamp: 1684280007887
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
   sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
   md5: 34dfd76da78de2eae95bbda390d746d6
   depends:
@@ -4406,7 +4406,7 @@ packages:
   license_family: BSD
   size: 23092
   timestamp: 1654598007056
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
   sha256: bf0eeef3c3c713515766ab8b0dc7863413de5b4b227deede97e24d90ca342345
   md5: a7bba1857eb84fb50caea377e60d2050
   depends:
@@ -4428,7 +4428,7 @@ packages:
   license_family: PSF
   size: 8066509
   timestamp: 1698692266161
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
   sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
   md5: eb79dabbeedee7da85dfbfb145bb8a26
   depends:
@@ -4438,7 +4438,7 @@ packages:
   license_family: BSD
   size: 17342
   timestamp: 1662014601345
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
   sha256: f400ad75dd2890627dc948f3e2e6b19732d02c124723eaf22272026993a94d52
   md5: 4a4ffc7365e30b18f4443281839e2718
   depends:
@@ -4448,7 +4448,7 @@ packages:
   license_family: MIT
   size: 53505
   timestamp: 1659721313693
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
   sha256: 20fb26a7ac748ce288cf8483a837b0c33f1348ae738bcdb69cdc2763c7bbf7e1
   md5: a0aebbc6c170ebd8d4710fd70b3db503
   depends:
@@ -4457,7 +4457,7 @@ packages:
   license_family: MIT
   size: 19562
   timestamp: 1659716131839
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
   sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
   md5: 56db7bd3ff511cd839bda081523b3edd
   depends:
@@ -4466,7 +4466,7 @@ packages:
   license_family: BSD
   size: 55683
   timestamp: 1629356128780
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
   sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
   md5: 176e0dcaeb28393881bacf69941e3889
   depends:
@@ -4492,7 +4492,7 @@ packages:
   license_family: BSD
   size: 8289638
   timestamp: 1681756329011
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
   sha256: afc6f332c51a3defc69e4c4e641988c0556039b9cd42be22f3db5292c88ccf37
   md5: 2bc409c7258160a9b739d08d5ffb5998
   depends:
@@ -4505,7 +4505,7 @@ packages:
   license_family: BSD
   size: 96942
   timestamp: 1650373637069
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
   sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
   md5: 150ea9fadddf21993d3328d3e48a18b7
   depends:
@@ -4533,7 +4533,7 @@ packages:
   license_family: BSD
   size: 557688
   timestamp: 1668450759059
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
   sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
   md5: 37163b32508f9f589b3e6462a3a47546
   depends:
@@ -4546,14 +4546,14 @@ packages:
   license_family: BSD
   size: 148426
   timestamp: 1694616771736
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
   sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
   md5: 6cdf7cbc43bf40e92b056a5576bd0086
   depends:
@@ -4562,7 +4562,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387216468
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
   sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
   md5: 0f05853a139b6cda9c73e9d2707a4976
   depends:
@@ -4587,7 +4587,7 @@ packages:
   license_family: BSD
   size: 590288
   timestamp: 1690984971741
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
   sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
   md5: 7de782e4fb34bfa95ef2fc79d27d727d
   depends:
@@ -4597,7 +4597,7 @@ packages:
   license_family: BSD
   size: 22840
   timestamp: 1668160634885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
   sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
   md5: 1a7b23113372c5667dbfe45976b9cc5c
   depends:
@@ -4608,7 +4608,7 @@ packages:
   license_family: MIT
   size: 126357
   timestamp: 1696515322390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
   sha256: 3cd1161558704176560843586b1b1f9b257fd68c0ca53a2fc09e61267f47514c
   md5: dd162b2716dc9daf732240a343862d4a
   depends:
@@ -4621,7 +4621,7 @@ packages:
   license_family: BSD
   size: 10388
   timestamp: 1695830584640
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
   sha256: 5f35d8c0e1768fa3a9d2e75659cd2096bea6b4e021afea114f573e95f4943fb2
   md5: 958f78b1e2299537996f98da7a930198
   depends:
@@ -4635,7 +4635,7 @@ packages:
   license_family: BSD
   size: 6313331
   timestamp: 1695830570878
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
   sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
   md5: 371358a54bbdd307603888348d1a2c6f
   depends:
@@ -4645,7 +4645,7 @@ packages:
   license: BSD 2-Clause
   size: 412248
   timestamp: 1628861367714
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
   sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
   md5: fa15d3b44ae1360ac9b640bbd5b6923c
   depends:
@@ -4654,7 +4654,7 @@ packages:
   license_family: Apache
   size: 4746123
   timestamp: 1695322833432
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
   sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
   md5: d73db95f07a282021efdf8bc09713261
   depends:
@@ -4663,7 +4663,7 @@ packages:
   license_family: Apache
   size: 73620
   timestamp: 1693575195999
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.0.3-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.0.3-py39h46d7db6_0.tar.bz2
   sha256: 185a933dcaceb0fa378e214cd72ea89f9071f0699fa9fabab1535d674531611b
   md5: 1730e1aecea062f0f6e8eb323c164d23
   depends:
@@ -4711,7 +4711,7 @@ packages:
   license_family: BSD
   size: 13122992
   timestamp: 1692291303537
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
   sha256: 4548d2a1bc58cd61e9c9f475a77bac68d9e49d4996c4c891d5ca8ba5ea7552b0
   md5: b4ed079246a55ac8f91b8f8abb713b3b
   depends:
@@ -4735,7 +4735,7 @@ packages:
   license_family: BSD
   size: 17115516
   timestamp: 1695146000246
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
   sha256: 0d64f2438be25524bbfeb8646e4fb3c18499d747398a03ed15d41b350b03e001
   md5: 6a4908a5c9f7b3f17f09ebc34b1b691c
   depends:
@@ -4744,7 +4744,7 @@ packages:
   license_family: BSD
   size: 142857
   timestamp: 1684915417403
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
   sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
   md5: 6e01c592ae3b8ff2d12cae76f2f4276b
   depends:
@@ -4763,7 +4763,7 @@ packages:
   license_family: Other
   size: 715239
   timestamp: 1696580071596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
   sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
   md5: 9fb8f460c130d56caf33c6bbe46fbe8a
   depends:
@@ -4774,7 +4774,7 @@ packages:
   license_family: MIT
   size: 2678841
   timestamp: 1697548790931
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
   sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
   md5: 390b8c3cd74281abecdbfd51476922f9
   depends:
@@ -4783,7 +4783,7 @@ packages:
   license_family: MIT
   size: 33033
   timestamp: 1692205747301
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
   sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
   md5: 7896828fb3565fefad43f980d50c8723
   depends:
@@ -4792,7 +4792,7 @@ packages:
   license_family: Apache
   size: 91190
   timestamp: 1659455206354
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
   sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
   md5: d934c74eb66d01af0f45f0881f4bab77
   depends:
@@ -4804,7 +4804,7 @@ packages:
   license_family: BSD
   size: 580588
   timestamp: 1672387390426
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
   sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
   md5: 9858166e5ffb624c8b9d281f4000d725
   depends:
@@ -4813,7 +4813,7 @@ packages:
   license_family: BSD
   size: 367167
   timestamp: 1656431368885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
   sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
   md5: 4d2b45c6be8221e6a3e44c2d5838426f
   depends:
@@ -4825,7 +4825,7 @@ packages:
   license_family: BSD
   size: 30843
   timestamp: 1675441531640
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
   sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
   md5: 02521df4e2e79f75faa9cbb3560ab1dd
   depends:
@@ -4834,7 +4834,7 @@ packages:
   license_family: BSD
   size: 1861763
   timestamp: 1684280026169
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
   sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
   md5: bdebe59bffc7adbad83fdcd9d429a5f5
   depends:
@@ -4844,7 +4844,7 @@ packages:
   license_family: Apache
   size: 95234
   timestamp: 1690223494699
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
   sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
   md5: d716e5c9b5eec45ce1df8eb52cab817a
   depends:
@@ -4853,7 +4853,7 @@ packages:
   license_family: MIT
   size: 157408
   timestamp: 1661452601692
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
   sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
   md5: 1907629863ed8e7c35ead232dae7693f
   depends:
@@ -4862,7 +4862,7 @@ packages:
   license_family: MIT
   size: 91636
   timestamp: 1628941083263
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
   sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
   md5: 847b9bddf2a86e1609c0d53bbc23ea79
   depends:
@@ -4871,7 +4871,7 @@ packages:
   license_family: BSD
   size: 27378
   timestamp: 1626781391140
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
   sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
   md5: 18aa18bd0d260605923877921d26cc74
   depends:
@@ -4890,7 +4890,7 @@ packages:
   license_family: PSF
   size: 13194025
   timestamp: 1694438901368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
   sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
   md5: 45642a99c83e7aed74d1ffab1f20145b
   depends:
@@ -4899,7 +4899,7 @@ packages:
   license_family: BSD
   size: 266647
   timestamp: 1661368655993
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
   sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
   md5: fec748525144049a2fc7f52f9755232c
   depends:
@@ -4908,7 +4908,7 @@ packages:
   license_family: MIT
   size: 257235
   timestamp: 1695131702047
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
   sha256: 960192a143672e9c1d6fe4027af448512d91eee7501e5c245c21b865cf8bf429
   md5: 76d491244218505f071ba56a308673df
   depends:
@@ -4918,7 +4918,7 @@ packages:
   license_family: BSD
   size: 40950
   timestamp: 1685030774581
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
   sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
   md5: 3445d25415998c807efbe64d3a7e03c8
   depends:
@@ -4928,7 +4928,7 @@ packages:
   license_family: MIT
   size: 167068
   timestamp: 1698096118071
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
   sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
   md5: e6e92da28e9b0e428ed4b7df417bec25
   depends:
@@ -4939,7 +4939,7 @@ packages:
   license_family: BSD
   size: 472418
   timestamp: 1657724315435
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -4948,7 +4948,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
   sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
   md5: dba22515f36d3c266de5896350813ea2
   depends:
@@ -4964,7 +4964,7 @@ packages:
   license_family: Apache
   size: 95103
   timestamp: 1690400315537
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
   sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
   md5: 3cd7eb43e285faba76faf67667e26b00
   depends:
@@ -4973,7 +4973,7 @@ packages:
   license_family: MIT
   size: 1093916
   timestamp: 1690290951258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
   sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
   md5: c5e9aef0d6895de1c927e9d796cd7cd3
   depends:
@@ -4982,7 +4982,7 @@ packages:
   license_family: Apache
   size: 15691
   timestamp: 1629145910454
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
   sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
   md5: 0f7c229e774146ffc4e29dedf75372bf
   depends:
@@ -4991,7 +4991,7 @@ packages:
   license_family: MIT
   size: 67279
   timestamp: 1696347632563
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
   sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
   md5: 2302a79a045f152e183a52a81adfba62
   depends:
@@ -5003,7 +5003,7 @@ packages:
   license_family: Other
   size: 1674163
   timestamp: 1681394762218
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
   sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
   md5: 4ae67163d55cf9df83d4027ebc38c501
   depends:
@@ -5014,7 +5014,7 @@ packages:
   license_family: BSD
   size: 30894
   timestamp: 1671751931536
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
   sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
   md5: dbb5c0cddb6661a89afee647fd3dc01e
   depends:
@@ -5024,7 +5024,7 @@ packages:
   license_family: BSD
   size: 39875
   timestamp: 1668168874870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
   sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
   md5: 667e60c8b407d73cbba40f44901f4f00
   depends:
@@ -5033,7 +5033,7 @@ packages:
   license_family: BSD
   size: 3412693
   timestamp: 1654088929697
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
   sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
   md5: 884f788a5f6a664c9b79f7a4a60362d0
   depends:
@@ -5042,7 +5042,7 @@ packages:
   license_family: Apache
   size: 680561
   timestamp: 1696937004165
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
   sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
   md5: 639a4f489af172c866c18442948e5874
   depends:
@@ -5055,7 +5055,7 @@ packages:
   license_family: MOZILLA
   size: 125170
   timestamp: 1679561942932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
   sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
   md5: e5b90eba83fddba6d7aa6072b5bf7c91
   depends:
@@ -5064,7 +5064,7 @@ packages:
   license_family: BSD
   size: 193017
   timestamp: 1671143921826
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
   md5: 644ef8830437070f60efcfcd6a987198
   depends:
@@ -5074,7 +5074,7 @@ packages:
   license_family: PSF
   size: 9670
   timestamp: 1690297532002
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
   md5: a902a833bb186a2f1a4b2b89b1195136
   depends:
@@ -5083,7 +5083,7 @@ packages:
   license_family: PSF
   size: 58466
   timestamp: 1690297524418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
   sha256: 536045a8a172c651fd306c285a6d7409775f018dac944f2124c538ccfb195e28
   md5: d4dc6cdf0812191b9ec78b35b4fdf3e0
   depends:
@@ -5092,7 +5092,7 @@ packages:
   license_family: MIT
   size: 11593
   timestamp: 1659769477205
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
   sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
   md5: f3f1d2c1028dad2f11ff950a15c99dbf
   depends:
@@ -5107,7 +5107,7 @@ packages:
   license_family: MIT
   size: 188640
   timestamp: 1698257577209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
   sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
   md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
   depends:
@@ -5116,7 +5116,7 @@ packages:
   license_family: BSD
   size: 20091
   timestamp: 1629144441130
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
   sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
   md5: 3089c63bf8f4d0423e1a287da286d83e
   depends:
@@ -5126,7 +5126,7 @@ packages:
   license_family: BSD
   size: 70923
   timestamp: 1629357115820
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
   sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
   md5: 5886b30b312445471268444f41f39dc7
   depends:
@@ -5135,7 +5135,7 @@ packages:
   license_family: MIT
   size: 102583
   timestamp: 1695741976083
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
   sha256: 105e39d3eb51b47c7244b3379c0133ab7051966664f52835453b14509215b159
   md5: ed20012c2cd99ffd04cca9929e0bc061
   depends:
@@ -5144,20 +5144,20 @@ packages:
   license_family: BSD
   size: 49775
   timestamp: 1675159079039
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
   sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
   md5: 2e75ad6a09c308268192efe03cc9ebf4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 411778
   timestamp: 1683113019715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
   sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
   md5: 30f666bf97c26587c5d2f68cc5f330ab
   depends:
@@ -5166,7 +5166,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 316901
   timestamp: 1629287855861
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
   sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
   md5: 584e591d36dcd5ba5c45404f0f7ebb2d
   depends:
@@ -5175,14 +5175,14 @@ packages:
   license_family: MIT
   size: 19076
   timestamp: 1672387153578
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
   sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
   md5: 467ae28215d1aa1c5688bc0c8a184269
   license: Zlib
   license_family: Other
   size: 103525
   timestamp: 1666595022664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
   sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
   md5: 7cfbed15f1feee1422810f7830075f53
   depends:
@@ -5194,7 +5194,7 @@ packages:
   license_family: BSD
   size: 779464
   timestamp: 1681304594848
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
   sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
   md5: ed14f9bc6e55220483f1a5a388625a08
   depends:
@@ -5207,7 +5207,7 @@ packages:
   license_family: MIT
   size: 162772
   timestamp: 1644481986085
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
   sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
   md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
   depends:
@@ -5219,7 +5219,7 @@ packages:
   license_family: MIT
   size: 39253
   timestamp: 1644551767970
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
   sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
   md5: b24d13c443a26f65a0778b475a5726bc
   depends:
@@ -5228,7 +5228,7 @@ packages:
   license_family: MIT
   size: 132830
   timestamp: 1695717959996
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
   sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
   md5: 302c3c0696e17eaa62e140e3892644ae
   depends:
@@ -5238,12 +5238,12 @@ packages:
   license_family: MIT
   size: 199723
   timestamp: 1681493196911
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
   sha256: 29e914b68f261dd564de357888d32ec1511a6fcac9477fe68797289aba4d3e75
   md5: 288585e412638a51e0288caf690d543b
   depends:
@@ -5261,7 +5261,7 @@ packages:
   license_family: BSD
   size: 6485148
   timestamp: 1690546982849
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
   sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
   md5: bf930260f679bc74227bbb18bc36ae82
   depends:
@@ -5273,7 +5273,7 @@ packages:
   license_family: BSD
   size: 119700
   timestamp: 1657176150595
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
   md5: 507dfe693ef429f466d964b599f4af21
   depends:
@@ -5285,7 +5285,7 @@ packages:
   license: MIT
   size: 18650
   timestamp: 1659616328001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
   md5: d0bf43e8df60baae3b3105aa5c42a791
   depends:
@@ -5296,7 +5296,7 @@ packages:
   license: MIT
   size: 21153
   timestamp: 1659616312367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
   sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
   md5: 7bd24bf94c24e810aecaaf84a0978e6f
   depends:
@@ -5306,14 +5306,14 @@ packages:
   license: MIT
   size: 343204
   timestamp: 1659616543542
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
   sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
   md5: 092b417c11edcbe6bb9b765ab4a55d23
   license: MPL-2.0
   license_family: Other
   size: 164999
   timestamp: 1694009822357
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
   sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
   md5: 708a750d370b9d6875651021e21c4446
   depends:
@@ -5322,7 +5322,7 @@ packages:
   license_family: Other
   size: 159322
   timestamp: 1690232335307
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
   sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
   md5: c35736da3ea26782425e78061268cf5e
   depends:
@@ -5334,7 +5334,7 @@ packages:
   license_family: MIT
   size: 228713
   timestamp: 1670423312743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
   sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
   md5: 457a4339a53c033d48ce0c72e5038d2e
   depends:
@@ -5343,7 +5343,7 @@ packages:
   license_family: BSD
   size: 30330
   timestamp: 1672387265402
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
   sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
   md5: 59ec65fd9e06b81a65cc12986c67d5da
   depends:
@@ -5353,7 +5353,7 @@ packages:
   license_family: CC
   size: 1939614
   timestamp: 1668084794027
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
   sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
   md5: 3489c1a2b73fc957b5a62cc59349e25b
   depends:
@@ -5363,7 +5363,7 @@ packages:
   license_family: BSD
   size: 13438
   timestamp: 1671231196438
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
   sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
   md5: 3492b96083c1e904cc32d26ea7f1e1d8
   depends:
@@ -5375,7 +5375,7 @@ packages:
   license_family: BSD
   size: 184280
   timestamp: 1663827558327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
   sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
   md5: f46d904bc6f220327e70474971341f52
   depends:
@@ -5390,7 +5390,7 @@ packages:
   license_family: BSD
   size: 1220835
   timestamp: 1694445639066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
   sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
   md5: 2ff4fb509788b0e47ac684ba151394d0
   depends:
@@ -5401,7 +5401,7 @@ packages:
   license_family: MIT
   size: 3289966
   timestamp: 1690907040646
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
   sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
   md5: 0f166c3e70541d8bee6e9d0cb60fb66e
   depends:
@@ -5410,7 +5410,7 @@ packages:
   license_family: MIT
   size: 16979
   timestamp: 1649926678161
-- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
   sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
   md5: ea93d413944ca6a8677eb1b284b136ae
   depends:
@@ -5419,7 +5419,7 @@ packages:
   license_family: BSD
   size: 27388
   timestamp: 1668714577678
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -5431,7 +5431,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
   sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
   md5: 9f167d3e45441bc3633c1974b1b0ce8c
   depends:
@@ -5441,7 +5441,7 @@ packages:
   license_family: MIT
   size: 88421
   timestamp: 1676983264486
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.17.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.17.1-py39haa95532_0.tar.bz2
   sha256: e4e08cbe9311b78ab893105a8f34963b46fce74c67943176cf2309e355dceb80
   md5: c68d9f0e4a10f15d15d5812093818900
   depends:
@@ -5458,7 +5458,7 @@ packages:
   license_family: BSD
   size: 4580877
   timestamp: 1693378576619
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
   sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
   md5: 30fdefd1541c789c163751291a8faa88
   depends:
@@ -5467,7 +5467,7 @@ packages:
   license_family: BSD
   size: 111448
   timestamp: 1666125667599
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
   sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
   md5: a10f07c7a3510272a296f9fed458a4ed
   depends:
@@ -5477,7 +5477,7 @@ packages:
   license_family: APACHE
   size: 38098
   timestamp: 1678997241511
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
   sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
   md5: fad9cf2023d807da8d44996e9d4399a0
   depends:
@@ -5487,7 +5487,7 @@ packages:
   license_family: Apache
   size: 51490
   timestamp: 1698254721864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
   sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
   md5: 9834848bd7c7759acf12e78d09388563
   depends:
@@ -5497,7 +5497,7 @@ packages:
   license_family: Proprietary
   size: 3891030
   timestamp: 1681801474383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
   sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
   md5: 1285c8c628bc912c54d0968574c9f4c9
   depends:
@@ -5518,7 +5518,7 @@ packages:
   license_family: BSD
   size: 217232
   timestamp: 1691122695748
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
   sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
   md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
   depends:
@@ -5539,7 +5539,7 @@ packages:
   license_family: BSD
   size: 1279433
   timestamp: 1694181820978
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
   sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
   md5: f5fcce35d3f21cdfc5893c5a7a86c651
   depends:
@@ -5549,7 +5549,7 @@ packages:
   license_family: MIT
   size: 1035394
   timestamp: 1644315567034
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
   sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
   md5: f67fe3337528e2886f1ac3ab8ac37985
   depends:
@@ -5559,7 +5559,7 @@ packages:
   license_family: BSD
   size: 213110
   timestamp: 1666908350218
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
   sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
   md5: 81f2c343dc4c65eea39c45383272068f
   depends:
@@ -5569,7 +5569,7 @@ packages:
   license_family: Other
   size: 407861
   timestamp: 1677849239400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
   sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
   md5: bd9526d38a145fe311a8aa36bc11e071
   depends:
@@ -5580,7 +5580,7 @@ packages:
   license_family: MIT
   size: 152006
   timestamp: 1676558783570
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
   sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
   md5: a00e6a62956fde3c4135464353ee8a53
   depends:
@@ -5596,7 +5596,7 @@ packages:
   license_family: BSD
   size: 229158
   timestamp: 1676330909084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
   sha256: db8335d6531b03c7bdfe789ebacc52631ac6ea4a37700bb3da1f6a53a1acd724
   md5: ebeba61994cc225ea5f4f42caa511019
   depends:
@@ -5608,7 +5608,7 @@ packages:
   license_family: BSD
   size: 116681
   timestamp: 1679906658986
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
   sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
   md5: 5efa1332f7c0a8d9638eda02170c4ce5
   depends:
@@ -5633,7 +5633,7 @@ packages:
   license_family: BSD
   size: 413653
   timestamp: 1671707957673
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
   sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
   md5: 891fe66a24d8714737b2874985ee1303
   depends:
@@ -5644,7 +5644,7 @@ packages:
   license_family: BSD
   size: 62298
   timestamp: 1672388166096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -5654,7 +5654,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
   sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
   md5: c345f51706eef530454f66b794e5e574
   depends:
@@ -5663,7 +5663,7 @@ packages:
   license: MIT
   size: 68189
   timestamp: 1659616216976
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
   md5: a7400cfb72042977bc047909ed504ce8
   depends:
@@ -5673,7 +5673,7 @@ packages:
   license: MIT
   size: 33743
   timestamp: 1659616248209
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
   md5: 6307f6854754ab5bd7c84e6998385bb1
   depends:
@@ -5683,7 +5683,7 @@ packages:
   license: MIT
   size: 733177
   timestamp: 1659616279453
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -5693,7 +5693,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
   sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
   md5: b812bc5d9c76242e2bb2ac87afe7d39b
   depends:
@@ -5703,7 +5703,7 @@ packages:
   license_family: GPL3
   size: 730280
   timestamp: 1650983734373
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -5714,7 +5714,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -5723,7 +5723,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -5740,7 +5740,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
   sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
   md5: ba9418df9288a2f031a02fa35b774ce0
   depends:
@@ -5756,7 +5756,7 @@ packages:
   license_family: BSD
   size: 78524
   timestamp: 1694778314659
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
   sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
   md5: b1781519a200ccbfcb4a1194005aa3ef
   depends:
@@ -5768,7 +5768,7 @@ packages:
   license_family: BSD
   size: 338459
   timestamp: 1694777084290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
   sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
   md5: 6ece7f1a3248169837714d05d7f6ef0a
   depends:
@@ -5780,7 +5780,7 @@ packages:
   license_family: MIT
   size: 3513910
   timestamp: 1692971505729
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
   sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
   md5: bd7ec244935e83e850a4ff34e8e2e64f
   depends:
@@ -5791,7 +5791,7 @@ packages:
   license_family: MIT
   size: 513971
   timestamp: 1692973657152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
   sha256: e1c0e745d9ba36a80773e841d96bf514ad1ceda419e4188aad3c22782af00234
   md5: f226532e9bb308f20e874c56be6ceefb
   depends:
@@ -5801,7 +5801,7 @@ packages:
   license_family: MIT
   size: 35788
   timestamp: 1659783414586
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
   sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
   md5: fb7881e74b59262df0fa4ec981964efc
   depends:
@@ -5814,7 +5814,7 @@ packages:
   license_family: Other
   size: 1244887
   timestamp: 1695058550693
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
   sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
   md5: 6970c7f46b0164cad1d210e7a1419959
   depends:
@@ -5824,7 +5824,7 @@ packages:
   license_family: BSD
   size: 143434
   timestamp: 1670944902624
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
   sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
   md5: 1015298551c040c6d5e26eebbae12ef5
   depends:
@@ -5834,7 +5834,7 @@ packages:
   license_family: BSD
   size: 142316
   timestamp: 1671542240512
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
   sha256: ab5c246c2b271acc1cdd0b9343989c0166681536e569cdbe71618f55d34c7292
   md5: 7ce68d771cd94c9ff5efefe69d327c9a
   depends:
@@ -5844,7 +5844,7 @@ packages:
   license_family: MIT
   size: 125122
   timestamp: 1684280210213
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
   sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
   md5: 466da740fafef3d6bce114220f0be306
   depends:
@@ -5857,7 +5857,7 @@ packages:
   license_family: BSD
   size: 28510
   timestamp: 1654508162239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
   sha256: 1687ae122ee7d8b583141fc5014b76d494841dc8083b854449e3d6e0f6bb7019
   md5: 3697ac26ee3c2d49338dd5b9c6551152
   depends:
@@ -5880,7 +5880,7 @@ packages:
   license_family: PSF
   size: 8080067
   timestamp: 1698692812610
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
   sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
   md5: a9fa43e694b25cd49b8b08a9eefd696e
   depends:
@@ -5890,7 +5890,7 @@ packages:
   license_family: BSD
   size: 18054
   timestamp: 1661915903969
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
   sha256: 8aa14047fac6ef8b326900c4bf1a960eaa7a1699c18fdf1e75a59101b610b6df
   md5: 7e1d4d4700fbea6171d30f1d5ad24226
   depends:
@@ -5900,7 +5900,7 @@ packages:
   license_family: MIT
   size: 53362
   timestamp: 1659721308586
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
   sha256: 2017814a7cc93dd51c6b7c016e3cdf8fbc32fa20f985638aaff6a6377e9ee086
   md5: a1a285c56b001c3b5c591bf21eec3149
   depends:
@@ -5909,7 +5909,7 @@ packages:
   license_family: MIT
   size: 19326
   timestamp: 1659716205153
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
   sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
   md5: 248c468abced874f0231d3cc23177c77
   depends:
@@ -5920,7 +5920,7 @@ packages:
   license_family: BSD
   size: 58488
   timestamp: 1607359497934
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
   sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
   md5: 5e763c995ff0c549f68a10bce70fede4
   depends:
@@ -5932,7 +5932,7 @@ packages:
   license_family: Proprietary
   size: 187489950
   timestamp: 1691503804820
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
   sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
   md5: dd0c2ece6a743c373c9b5a5919b4818f
   depends:
@@ -5944,7 +5944,7 @@ packages:
   license_family: BSD
   size: 49744
   timestamp: 1682975040154
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
   sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
   md5: 57cea8df7ab85f2a98f64d23afcb1f90
   depends:
@@ -5959,7 +5959,7 @@ packages:
   license_family: BSD
   size: 184956
   timestamp: 1695058491736
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
   sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
   md5: 8769cdd201d905069800488fe31574e5
   depends:
@@ -5974,7 +5974,7 @@ packages:
   license_family: BSD
   size: 256221
   timestamp: 1695060152521
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
   sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
   md5: d9781492332e6326f9fca87f3a8efacd
   depends:
@@ -6000,7 +6000,7 @@ packages:
   license_family: BSD
   size: 8135792
   timestamp: 1681756491399
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
   sha256: 2dd3178d3c570e30b9490ebabfd7bfac806afad8302d3dee0edc619805034397
   md5: bef9da0f0694c45b6aaa4e6447479eaf
   depends:
@@ -6013,7 +6013,7 @@ packages:
   license_family: BSD
   size: 118324
   timestamp: 1650290466135
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
   sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
   md5: f1d8ce412e115986c403f223b3b47d0f
   depends:
@@ -6041,7 +6041,7 @@ packages:
   license_family: BSD
   size: 596314
   timestamp: 1668451106600
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
   sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
   md5: f96bbef0985d7e66ebf00c0d55e30e23
   depends:
@@ -6054,7 +6054,7 @@ packages:
   license_family: BSD
   size: 167045
   timestamp: 1694617078743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
   sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
   md5: 6e6ba64c8dc5025aeac606404a8df36a
   depends:
@@ -6063,7 +6063,7 @@ packages:
   license_family: BSD
   size: 13786
   timestamp: 1672387480065
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
   sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
   md5: 4a7a3286484766741f627696697c362c
   depends:
@@ -6088,7 +6088,7 @@ packages:
   license_family: BSD
   size: 609425
   timestamp: 1690985686105
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
   sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
   md5: 4269a1f93882205b90d4b2ae78fc82d5
   depends:
@@ -6098,7 +6098,7 @@ packages:
   license_family: BSD
   size: 22417
   timestamp: 1668160717305
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
   sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
   md5: a18a576b7024cfd6f905c526a786a916
   depends:
@@ -6113,7 +6113,7 @@ packages:
   license_family: MIT
   size: 135285
   timestamp: 1696515698492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
   sha256: e5e11f9b42d770ee46ac24d1cdf7aa4e9c49a60a607c8c28e7729131a99eadd5
   md5: 4274d06db8a9a381c072d226d0322dc0
   depends:
@@ -6130,7 +6130,7 @@ packages:
   license_family: BSD
   size: 9835
   timestamp: 1695830845329
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
   sha256: dcaa1607ce40a0ed610dd5398e125c8e5b08e738e50b6037a8c72b49ca561ff2
   md5: d99d990a60644b97ba1ff9bb8da0e66f
   depends:
@@ -6146,7 +6146,7 @@ packages:
   license_family: BSD
   size: 6778113
   timestamp: 1695830816710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
   sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
   md5: ab07e2a27ac08afe3d0b4c0890b8486a
   depends:
@@ -6157,7 +6157,7 @@ packages:
   license: BSD 2-Clause
   size: 249316
   timestamp: 1630094024143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
   sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
   md5: 73b17037d87b5a58feb34dafc0538f7f
   depends:
@@ -6168,7 +6168,7 @@ packages:
   license_family: Apache
   size: 8058396
   timestamp: 1695324589828
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
   sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
   md5: df1d746ba8d5d6ba01ac1373b9b71e1a
   depends:
@@ -6177,7 +6177,7 @@ packages:
   license_family: Apache
   size: 73016
   timestamp: 1693575484990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.0.3-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-2.0.3-py39h4ed8f06_0.tar.bz2
   sha256: ed91d8aecd0bceea2e5952d3e3054c80d9a37481ebfea1451cbeda6aed416ca3
   md5: 915957bfbe46e521c9cafed0bf66c916
   depends:
@@ -6226,7 +6226,7 @@ packages:
   license_family: BSD
   size: 12385096
   timestamp: 1692216843654
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
   sha256: 0044e1cc04f3cb7c48209276c35c59c05b87e852c0ac01be468b99f3656445fb
   md5: ee81d2a2b2c558b43a48fd68c2de1dbf
   depends:
@@ -6250,7 +6250,7 @@ packages:
   license_family: BSD
   size: 17009718
   timestamp: 1695148093102
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
   sha256: 2773f47b2d745ab483cf7fcbd5b5e2f7020d45462d32d2ccd5cf232ca13c6f67
   md5: ca16cd208037bd58d2da267c338da4a4
   depends:
@@ -6259,7 +6259,7 @@ packages:
   license_family: BSD
   size: 142229
   timestamp: 1684915524241
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
   sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
   md5: 427c1450bebb632f43bbc8c83006e4cd
   depends:
@@ -6278,7 +6278,7 @@ packages:
   license_family: Other
   size: 806931
   timestamp: 1696580240310
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
   sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
   md5: 21790cd3e2b8a45c4104aff0a68330d0
   depends:
@@ -6289,7 +6289,7 @@ packages:
   license_family: MIT
   size: 3001751
   timestamp: 1697549357662
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
   sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
   md5: 56f44a1054da2d10777e375838191070
   depends:
@@ -6298,7 +6298,7 @@ packages:
   license_family: MIT
   size: 32355
   timestamp: 1692205784293
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
   sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
   md5: 8a35ad65651086575ce55371f22feda8
   depends:
@@ -6307,7 +6307,7 @@ packages:
   license_family: Apache
   size: 91045
   timestamp: 1659455316472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
   sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
   md5: 186eb95f816a2eff80c3c7f7d964c7b0
   depends:
@@ -6319,7 +6319,7 @@ packages:
   license_family: BSD
   size: 578514
   timestamp: 1672388155359
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
   sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
   md5: 47b6cbe6ce9289e47d16900b03596a91
   depends:
@@ -6330,7 +6330,7 @@ packages:
   license_family: BSD
   size: 372807
   timestamp: 1656431445633
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
   sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
   md5: 07165c444adc7c7ccc8a345875adc5ef
   depends:
@@ -6342,7 +6342,7 @@ packages:
   license_family: BSD
   size: 48408
   timestamp: 1675450623287
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
   sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
   md5: d58e76a31e2f6e7410ba4afd7f385b0d
   depends:
@@ -6351,7 +6351,7 @@ packages:
   license_family: BSD
   size: 1877445
   timestamp: 1684280183367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
   sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
   md5: 0e5b0fe7debbf558ce97090f6b67cdae
   depends:
@@ -6361,7 +6361,7 @@ packages:
   license_family: Apache
   size: 94633
   timestamp: 1690225630423
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
   sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
   md5: 0fde797653e4ab589506121fb1e37555
   depends:
@@ -6370,7 +6370,7 @@ packages:
   license_family: MIT
   size: 157119
   timestamp: 1661452591647
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
   sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
   md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
   depends:
@@ -6381,7 +6381,7 @@ packages:
   license_family: MIT
   size: 92679
   timestamp: 1636093365041
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
   sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
   md5: f870859d4dc7a8d82cf3546bd9035f33
   depends:
@@ -6391,7 +6391,7 @@ packages:
   license_family: BSD
   size: 54520
   timestamp: 1605307564142
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
   sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
   md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
   depends:
@@ -6404,7 +6404,7 @@ packages:
   license_family: PSF
   size: 21172845
   timestamp: 1694442462066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
   sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
   md5: 9d99075052265ae3d718582d3b875038
   depends:
@@ -6413,7 +6413,7 @@ packages:
   license_family: BSD
   size: 269964
   timestamp: 1661376543480
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
   sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
   md5: fa9074d94236c9b768bfd2c858875b27
   depends:
@@ -6422,7 +6422,7 @@ packages:
   license_family: MIT
   size: 264836
   timestamp: 1695131770282
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
   sha256: 97243a31c39f4990c0e9d4f2307f2f7fb9421553303923bc105067ec4340bdff
   md5: 8078c5760f27398eaf1082226647d137
   depends:
@@ -6432,7 +6432,7 @@ packages:
   license_family: BSD
   size: 40145
   timestamp: 1685031143383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
   sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
   md5: 3d2841085778006c2e79f9c7300f8b9d
   depends:
@@ -6442,7 +6442,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13565975
   timestamp: 1669937633869
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
   sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
   md5: 54a4bc0724041dd173088419d6ede2af
   depends:
@@ -6454,7 +6454,7 @@ packages:
   license_family: MIT
   size: 239062
   timestamp: 1677611495106
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
   sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
   md5: f39f84115e228bad4bceaefdd637f022
   depends:
@@ -6466,7 +6466,7 @@ packages:
   license_family: MIT
   size: 158558
   timestamp: 1698096358091
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
   sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
   md5: df398a3a1668fd2a22061764e20ea91d
   depends:
@@ -6478,7 +6478,7 @@ packages:
   license_family: BSD
   size: 460913
   timestamp: 1657616061604
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
   sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
   md5: 38db77ece9dc76feffb9ef7638e38258
   depends:
@@ -6494,7 +6494,7 @@ packages:
   license_family: Apache
   size: 94397
   timestamp: 1690400496655
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
   sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
   md5: 3e284ae6b48ee30c364ffdc5601610b0
   depends:
@@ -6503,7 +6503,7 @@ packages:
   license_family: MIT
   size: 1099842
   timestamp: 1690291374842
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
   sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
   md5: 993b3886b334bd1f49d34206f21997b4
   depends:
@@ -6512,7 +6512,7 @@ packages:
   license_family: Apache
   size: 15998
   timestamp: 1614030572433
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
   sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
   md5: 7ac9604ad7564ac0c71bff5db198656f
   depends:
@@ -6521,7 +6521,7 @@ packages:
   license_family: MIT
   size: 67012
   timestamp: 1696347795139
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
   sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
   md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
   depends:
@@ -6531,7 +6531,7 @@ packages:
   license_family: Other
   size: 1311308
   timestamp: 1681402905668
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -6541,7 +6541,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
   sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
   md5: 28b9869d8d3a839918fac4a08f38cbc2
   depends:
@@ -6552,7 +6552,7 @@ packages:
   license_family: BSD
   size: 30546
   timestamp: 1671752127904
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
   sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
   md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
   depends:
@@ -6562,7 +6562,7 @@ packages:
   license_family: BSD
   size: 39590
   timestamp: 1668168880994
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
   sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
   md5: 52cdcdb96383c010ca833a7c24b3935b
   depends:
@@ -6572,7 +6572,7 @@ packages:
   license_family: BSD
   size: 3690152
   timestamp: 1654036853710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
   sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
   md5: 0e054ab29119cf4c1f778613acf972f9
   depends:
@@ -6583,7 +6583,7 @@ packages:
   license_family: Apache
   size: 681780
   timestamp: 1696937326924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
   sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
   md5: b6ad839ebba536ad1c3cc58d0e2123f0
   depends:
@@ -6597,7 +6597,7 @@ packages:
   license_family: MOZILLA
   size: 143681
   timestamp: 1679562248929
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
   sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
   md5: fe78de10019085146f1cc6c94fdc2620
   depends:
@@ -6606,7 +6606,7 @@ packages:
   license_family: BSD
   size: 192822
   timestamp: 1671143999327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
   md5: ca5fc3fbdb09b6de068a8b7a8869369f
   depends:
@@ -6616,7 +6616,7 @@ packages:
   license_family: PSF
   size: 9208
   timestamp: 1690298120549
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
   md5: a86e87a10e5fdff486265e0c675fb99f
   depends:
@@ -6625,7 +6625,7 @@ packages:
   license_family: PSF
   size: 57922
   timestamp: 1690298106990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
   sha256: 8057d3d2a0acd44496de33c5b222063c3f7d06b90c74fbbda45bd18b0b324219
   md5: 398f8db5bd8cab84b3d85a9d85fa4889
   depends:
@@ -6634,7 +6634,7 @@ packages:
   license_family: MIT
   size: 11362
   timestamp: 1659769459206
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
   sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
   md5: 0d31859e0a097aedbcc1627db33b3d92
   depends:
@@ -6649,7 +6649,7 @@ packages:
   license_family: MIT
   size: 188367
   timestamp: 1698257883295
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
   sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
   md5: 45ef24c486a484f079faf1dc90e4c7e9
   depends:
@@ -6658,12 +6658,12 @@ packages:
   license_family: BSD
   size: 8277
   timestamp: 1605602889180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
   sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
   md5: 4daaceb6cfc1af6274509081d8018ef1
   size: 2316783
   timestamp: 1605602872095
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
   sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
   md5: 916c16904615c7af3b5d37cb6694f45e
   depends:
@@ -6672,7 +6672,7 @@ packages:
   license_family: BSD
   size: 21084
   timestamp: 1607347371925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
   sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
   md5: da69e6987fcc757e83a358ceaa13f62b
   depends:
@@ -6682,7 +6682,7 @@ packages:
   license_family: BSD
   size: 73391
   timestamp: 1614804425587
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
   sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
   md5: 23b9f4634b2e5450be617114f62c74f9
   depends:
@@ -6691,7 +6691,7 @@ packages:
   license_family: MIT
   size: 120873
   timestamp: 1695742300539
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
   sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
   md5: 120f0b088290fc17bd6618fc10a2f0c4
   depends:
@@ -6699,13 +6699,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 34293
   timestamp: 1605306211299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
   sha256: a5d2a216d052105fdaad7256f23da3b29f95100d1dc0f29b6ab1f3bbc75e17a9
   md5: a558f681ebc243f86cde2515c065b62e
   depends:
@@ -6714,7 +6714,7 @@ packages:
   license_family: BSD
   size: 48805
   timestamp: 1675159123654
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
   sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
   md5: c3f7871e9a33adeccee1b1e8e216918e
   depends:
@@ -6724,7 +6724,7 @@ packages:
   license_family: GPL2
   size: 1332571
   timestamp: 1683113347814
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -6733,7 +6733,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
   sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
   md5: 1ab55f8c4b5292ec360c572120bf823e
   depends:
@@ -6743,7 +6743,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 9430705
   timestamp: 1616055773485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
   sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
   md5: 6875e0bf3828707dc9165d694c0d0a7d
   depends:
@@ -6752,7 +6752,7 @@ packages:
   license_family: MIT
   size: 18725
   timestamp: 1672387612937
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
   sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
   md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
   depends:
@@ -6762,7 +6762,7 @@ packages:
   license_family: Other
   size: 148931
   timestamp: 1666595229032
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
   sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
   md5: 8d6a1e767775fe0eb617cd6e22edc2ff
   depends:

--- a/genetic_algorithm/pixi.lock
+++ b/genetic_algorithm/pixi.lock
@@ -1,0 +1,6777 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.0.3-py39h3ea8b11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.0.3-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.17.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.0.3-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+  sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
+  md5: 2cf39d906cc321896ffe3e5d33d80c5c
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162166
+  timestamp: 1644463608931
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+  sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
+  md5: 2972a84e0e22ae3244bbd2f1eebcf536
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 35352
+  timestamp: 1644569715988
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+  sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
+  md5: a68016b4b06460def24cb69d932986f3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132486
+  timestamp: 1695717963702
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+  sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
+  md5: 2f6356a2f530314b4059c08c79a3d8bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 205868
+  timestamp: 1681493113570
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+  sha256: 2d8e75f31f75ea5eb8b9021b4c21eb2846a254a097e06eb68e66fc36a82e1bed
+  md5: ae374a11c789a55555f70b29b9eff1f9
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3,<2.0a0
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14430294
+  timestamp: 1658136783940
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+  sha256: f84f9caa7eb9d489fd9634419fdf766d39293a5df1104b840fa0cdc5823a5c60
+  md5: 922555c0435d6b2537cf8ced534b048c
+  depends:
+  - libgcc-ng >=7.5.0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 141903
+  timestamp: 1648028958291
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+  sha256: 0bbcb6f78eac530c6a084459ffab3238647b266d0c74d695e6e6387dd119cc67
+  md5: bdc971e2a9affb5125b68ad708172dab
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 411301
+  timestamp: 1602517685375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+  sha256: 8c2071f706c2b445dabb781f7f8f008b23a29957468ec6894f050bfb3a2d5bf4
+  md5: c203ffc7bbba991c7089d4b383cfd92c
+  depends:
+  - cffi >=1.0.0
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 357797
+  timestamp: 1605539534667
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+  sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
+  md5: 3ef00f4c5278b688552efc259c463dc8
+  license: MPL-2.0
+  license_family: Other
+  size: 132731
+  timestamp: 1694009767372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+  sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
+  md5: d5cb3d97cf5e85ffe5e94037ed8a1169
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159077
+  timestamp: 1690232254640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+  sha256: 674707b9c42e65c903c9786ee5a56b4d42aa054f1e75b328db8a2c1bfa368739
+  md5: 76ae217198b014b89b267cf41b8251dd
+  depends:
+  - libffi >=3.3
+  - libgcc-ng >=7.5.0
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 231920
+  timestamp: 1642701209740
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+  sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
+  md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1917831
+  timestamp: 1668084545510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+  sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
+  md5: 13702d3b4b744784e5bd559c7050dd6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12719
+  timestamp: 1671231205875
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+  sha256: 821af57c20a85b4e92268fbf65fbaec2f273da5bb21889d9643756ef6e473237
+  md5: f57e0f502500ffebdbec081ef61ad1d4
+  depends:
+  - cffi >=1.12
+  - libgcc-ng
+  - openssl >=1.1.1v,<1.1.2a
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 2179774
+  timestamp: 1694445209134
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+  sha256: 3a39a2d6f161080c706292e3bf480f62d2444b1d6d67b3d7db50458202ee31f1
+  md5: 0524ffca60f845eb392bbb56d56f0ce5
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2094615
+  timestamp: 1637091869922
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+  sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
+  md5: 2e6ec51066d825ef3c317abe78d6049e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16413
+  timestamp: 1649926472708
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+  sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
+  md5: b4d923222d45314856b5378cb115214d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26728
+  timestamp: 1668714462023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+  sha256: 8a121233d0b2cbb2463b67e798739ad2946f38933430a6a7fd1197cc6eab1c99
+  md5: d2b24736491290a6c6d0138932111150
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: GPL-2.0-only and LicenseRef-FreeType
+  size: 965280
+  timestamp: 1635422707211
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+  sha256: 3c8ece1a7257b1d45f8fa25f46504bb709a1923d7175f2996e891366ec434b9d
+  md5: 299bf4271d710651a1d71d3795580c2d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 83592
+  timestamp: 1603192039050
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+  sha256: 2d727f8335c59314b521b66d437ca4d51904134473ae503b7b097e239635f209
+  md5: 6991e520f353d995023404f6f524d192
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4507274
+  timestamp: 1693378095165
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+  sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
+  md5: 9213e0336e3a5216c989cfe52648412e
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 23805906
+  timestamp: 1588026213084
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+  sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
+  md5: 1eb52f9f45cea2fb9ce27b19f990160e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110793
+  timestamp: 1666125606878
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+  sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
+  md5: 126b3c1933b7364ff03f67455b687e99
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 37588
+  timestamp: 1678997134023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+  sha256: 1b424413f28b840fc6d4bf467f37e9e405823b1e3b899005df80152d48936d64
+  md5: 4aa8bcf74c81cd3600978f791191692a
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 9246735
+  timestamp: 1634546760713
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+  sha256: b51b2e0dd37a74784ba19db22aded3f4c843b6fddb4a74399f65f36fc018aaa2
+  md5: 0d56ab1950f952284b895ac0f78284a7
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.0
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203541
+  timestamp: 1671488675347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+  sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
+  md5: ff47e0be879e817713ce2a9daa76e2b0
+  depends:
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1261116
+  timestamp: 1694181530670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+  sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
+  md5: 5ef6c6a0d1ac79143c7359d305155167
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1021637
+  timestamp: 1644297140650
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+  sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
+  md5: eaeb023688f781e7dd89e74310c38195
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 211775
+  timestamp: 1666908212136
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+  sha256: 85348bfb14db4fea84078d703e766a3c978c5a592a06e41266748826dd59d8ae
+  md5: 6e1c0fb5260c590f7ef5235cb3d05863
+  depends:
+  - libgcc-ng >=7.5.0
+  license: IJG
+  license_family: Other
+  size: 279884
+  timestamp: 1651065953960
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+  sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
+  md5: 0d2c3c5edf671b575532d5a3e8bf15fc
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 131510
+  timestamp: 1676558716852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+  sha256: 92bc012f9eb4ad71158cf4826fd3e125fcebff53b529276a81224acda48be547
+  md5: c5fd100e3062e831cbdf33331042f627
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=22.3
+  - tornado >=6.0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 190884
+  timestamp: 1650622553813
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+  sha256: 0192bd48cd96c60dc3054d5addd8cdb4a29a218843181318371f79daec8242f8
+  md5: d851b401dc13d04e6848bb36e12efc1c
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 91534
+  timestamp: 1679906652183
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+  sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
+  md5: a4beb461f0a60998a090d760b5c6c907
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411564
+  timestamp: 1671707702849
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+  sha256: 974df3dc76089be57b327acd6634384def84249003f58678ca1142bb274a75d9
+  md5: 81b969d1a00153759b30554a1f11ddfd
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92144
+  timestamp: 1653292217019
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+  sha256: 3b4afe7665dcdb99bd4586a888b85b2e0325f8faecdd31c7780792080ee97872
+  md5: 822b5201dde61bc838072dc5b670c88c
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: Custom
+  size: 55183
+  timestamp: 1594054267890
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+  sha256: c6fafbe73d2f93b91b6f4b65829f925f52a8f84746a57abd216b39da9ce8c494
+  md5: 238f19c803a6ba7bd6dbd6989e03cbf1
+  depends:
+  - _libgcc_mutex * main
+  license: GPL
+  size: 8496776
+  timestamp: 1560112207081
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+  sha256: bc3e6e79c32ff0ecea601aa108ae9cf4068f69703580e40e266ad4bcc52cff54
+  md5: 9cb85601944ca7383b1769bff74b94e8
+  depends:
+  - libgcc-ng >=7.3.0
+  - zlib >=1.2.11,<2.0.0a0
+  license: zlib/libpng
+  size: 372914
+  timestamp: 1556041895170
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+  sha256: 43b0bd205f539583c088feb5b8d77b60c83d1df80c2a93dac9f2a1127001b2cf
+  md5: 53fa39fdae936e9d07c4b2f5ef361993
+  license: GPL3 with runtime exception
+  size: 4246257
+  timestamp: 1560112223556
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+  sha256: 711ea05b4c35bdafc762a172b01db896b17942f474c2b1a519f91370964bf9bc
+  md5: b25d56d33596623a6a4a9d9baaa4f602
+  depends:
+  - jpeg >=9e,<10a
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libwebp-base
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  size: 592974
+  timestamp: 1653047881023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+  sha256: 146dbb1e4dbccdd57819e5102a8ca00970b8e33d6c6180e8007db89b184da569
+  md5: c566a384259c1d2769852c3bddd81a67
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9d,<10a
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 90150
+  timestamp: 1645441199289
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+  sha256: cffb5a063111f7a99a99c74770b23db5dde52325e25a7a46d1903d5ff4a82c88
+  md5: eeb1bd66f28bed1956ab989d6eff7ae5
+  depends:
+  - libgcc-ng >=7.5.0
+  constrains:
+  - libwebp 1.2.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 889956
+  timestamp: 1645089138421
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+  sha256: 71f6c4a97014d745c58df52b4dd60ddd75a8508d54fe5b97f42bd1f31cb1c067
+  md5: 686e77514ec9f1ef0a6feed374f14d37
+  depends:
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.5.0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 789469
+  timestamp: 1653546418059
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+  sha256: ea3355a67c5173f3944f09861043ca66eb7dbeff8f385d13528b3aabc0801d0c
+  md5: 66e2aa12181bb2911485bdbe125d24c5
+  depends:
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.5.0
+  - libxml2 >=2.9.14,<2.10.0a0
+  license: MIT
+  size: 584199
+  timestamp: 1654075843119
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+  sha256: 64b022d706b76c33965a250fdc8c6008443c41bff8ab27bb1df3cb70419576fd
+  md5: ec4f05846aacf634df15c389235725cc
+  depends:
+  - libgcc-ng >=7.5.0
+  - libxml2 >=2.9.12,<2.10.0a0
+  - libxslt >=1.1.28
+  - libxslt >=1.1.34,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  size: 1538261
+  timestamp: 1646624639995
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+  sha256: 2c6a5dda7c510a961bc78e31d4232be5e8e0760c93454f5fd200c379355e0f5e
+  md5: f35d4bf2fbb39e334992f6dd39f8721e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 220865
+  timestamp: 1627657046002
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+  sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
+  md5: 421f82c8274b44660dba629134faa6af
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 122221
+  timestamp: 1671541990505
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+  sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
+  md5: feb0e452205b44ac45d9b5e55c21a3b1
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22819
+  timestamp: 1654597913064
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+  sha256: dc51b316ef5dcfb82a9c0afdc40879146ae59516f6cea7db776077783dfd2d76
+  md5: b0b6b57c140f026b8806051107336576
+  depends:
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.11.0,<3.0a0
+  - freetype >=2.3
+  - kiwisolver >=1.0.1
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - numpy >=1.19.2,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.2.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  - tk
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7729454
+  timestamp: 1647442028622
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+  sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
+  md5: c04ef34af33da4c71bcc99b7ec24d210
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16391
+  timestamp: 1662014553452
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+  sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
+  md5: f6c734d73e6e3dbc1b62766cf18ff3e4
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58153
+  timestamp: 1607364912263
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+  sha256: 7c4ded8b2ef036839f988560848d2c32e1aa4627fd37a32710e42c39f5c61ac2
+  md5: bd20f4410b81f327e35ffa0657961146
+  depends:
+  - intel-openmp 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 229783051
+  timestamp: 1634547157986
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+  sha256: 5394f5efd53afb2c1b0abf571ce3d9cb684b6c7e255f140ba2acaa703d6113be
+  md5: d3cb2bfa63e30153f5527797dcc87280
+  depends:
+  - libgcc-ng >=7.5.0
+  - mkl >=2021.2.0,<2022.0a0
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 63551
+  timestamp: 1626176932911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+  sha256: c244d23da2749857a993f84969fd35ffd183ab8f462986df6d33ae0f705fe034
+  md5: 9b1f8ccc2488d0e04eb73211e2987483
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.3.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  size: 204136
+  timestamp: 1634566416657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+  sha256: f81f426f8ef306d636664bc49e7cdd70e2b4306d7c6bcb9c75fe35a45ab2087a
+  md5: 77aa1d7f958d36bf227e6ff4a34d2e3d
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.2.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  size: 365386
+  timestamp: 1626186165897
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+  sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
+  md5: 95c83d71814c504b5504df4f14548f1a
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8257558
+  timestamp: 1681756322140
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+  sha256: 1b92d72b083f3350359b8fb2e3b5dc846f49650c9e46a6a74354b1b7f0d42730
+  md5: 996babe4314515ddd41008a53cb5d47f
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 98791
+  timestamp: 1650290544347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+  sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
+  md5: 1710a25086c8098367eb36b9d441448b
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 569683
+  timestamp: 1668450704669
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+  sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
+  md5: 385cc9e53404776782502c0fdb08820f
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147046
+  timestamp: 1694616899309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+  sha256: 0807371380965e421cb5f3f2a30d790fd5c41db11dbb6d318e14294c3b1741ed
+  md5: fca4bd4e3891aebf4fd7daf9b6d0ccfa
+  depends:
+  - libgcc-ng >=7.5.0
+  license: Free software (MIT-like)
+  size: 1083412
+  timestamp: 1636570020698
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+  sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
+  md5: bbbcbebc20a4fdcadce398d0ca04f95e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13109
+  timestamp: 1672387143252
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+  sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
+  md5: 248ce515640465371927d46f389ed555
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 594054
+  timestamp: 1690985006481
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+  sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
+  md5: 70db71df4ee1cdd38090c0f7b80ba61f
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21944
+  timestamp: 1668160644514
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+  sha256: 15a12c8bebcda45c577e61cea412d9aafaa433e39f9e91fd61bbfab66fcee3ab
+  md5: 5239d8330e8bd34972fb80918dce79e7
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16.6,<2.0a0
+  - packaging
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 136437
+  timestamp: 1640689905588
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+  sha256: ff8d0426c7096e086db818265c3edf4a820accbfb15afae0407ca578de151fa9
+  md5: d7bcf0b9ba2d85cf532059ec119d2750
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.22.3 py39hf524024_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  size: 9965
+  timestamp: 1652801901707
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+  sha256: abfdeda143b6b667d50a82ea119043fc1469ee02f094a41a2402433ff408099e
+  md5: e8dc29adc0282f4658e0e2f25ff207a2
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.22.3 py39he7a7128_0
+  license: BSD-3-Clause
+  size: 7095882
+  timestamp: 1652801886819
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+  sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
+  md5: 5ad4571eba2479f77a9f849a6ae7724c
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: OpenSSL
+  license_family: Apache
+  size: 3998613
+  timestamp: 1694465071784
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+  sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
+  md5: 77a22ed6d0d448c5288d0f695bc9ac49
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 72527
+  timestamp: 1693575234886
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+  sha256: e7a0abb0f00a94000876f2095f0cf531ad3803ffbd868a780b3f06816b54492c
+  md5: 97ef7e1fe923d22a8e2307f3f39a92d5
+  depends:
+  - bottleneck >=1.3.1
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - numexpr >=2.7.1
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13221005
+  timestamp: 1650622404234
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+  sha256: 49fdb57b2ed2ce4d6bb7a2c5adec36ba59522518a41fb941f9e39a9f43750cc5
+  md5: 871b65444733b7da5823ee0dc9826722
+  depends:
+  - bleach
+  - bokeh >=2.4.0,<2.5.0
+  - markdown
+  - param >=1.12.0,<2.0.0a0
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - setuptools >=42
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >1.14.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14712394
+  timestamp: 1676379803902
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+  sha256: 64a732ce2661cdb6bd8f9d1484ac10afeb73082b1c2b44728d212e0117d2860e
+  md5: ada303f0cf43a4e99cfa7f243b23b681
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141832
+  timestamp: 1684915385689
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+  sha256: 8bcb1c67693f42a3170eb77ef4cdbb81b605fdf40816953e69a33a065c101638
+  md5: b7689507fb5f879dc766aaa8a4c37351
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp >=0.3.0
+  - libwebp >=1.2.0,<1.3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk
+  - zlib >=1.2.11,<2.0.0a0
+  license: LicenseRef-PIL
+  license_family: Other
+  size: 734566
+  timestamp: 1646325095608
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+  sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
+  md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2674850
+  timestamp: 1697548887851
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+  sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
+  md5: fe56f0479dd414c846191116366262c3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 31999
+  timestamp: 1692205535111
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+  sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
+  md5: 44d2a857d13bdf9d99aaac039a249d47
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91137
+  timestamp: 1659455142164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+  sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
+  md5: eb899a739d9b58dd747f1f6bd52d4cf3
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 579771
+  timestamp: 1672387338600
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+  sha256: 6973cfe0565ba3b5ad6d1de9e34848fbbadd78b507b2e23e1c079636b8f8f317
+  md5: a924535045fb356e23e7a3cc8116b638
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 350026
+  timestamp: 1612298042840
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+  sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
+  md5: f36ecb722522cbe2e3737424edf1b5e1
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29312
+  timestamp: 1675441510984
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+  sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
+  md5: 6d03295e544251e608a28c8d7c48115e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1862058
+  timestamp: 1684280096752
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+  sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
+  md5: 1f09617aecd6f3c2f2e20692c0759f34
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94434
+  timestamp: 1690223520097
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+  sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
+  md5: ffceed627867508d73af1636ab5ebf42
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 156324
+  timestamp: 1661452578573
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+  sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
+  md5: 0e3341a4fe434167bf74b613eb6afd81
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 97194
+  timestamp: 1636110999719
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+  sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
+  md5: c5f3f7f10ad30f0945e75252615ab6e5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31331
+  timestamp: 1605305847037
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+  sha256: c4b9e332a6f2b7524e8c88e2b39a2568a48e556fd9a44c30759c43611d4d023d
+  md5: bb118745c9b08fc5028f45e77f371e68
+  depends:
+  - ld_impl_linux-64
+  - libffi >=3.3,<3.4.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - ncurses >=6.3,<7.0a0
+  - openssl >=1.1.1o,<1.1.2a
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.38.3,<4.0a0
+  - tk >=8.6.11,<8.7.0a0
+  - tzdata
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 24553777
+  timestamp: 1654084160832
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+  sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
+  md5: 0caa188a695319bdb13f53b0a2b3accc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264864
+  timestamp: 1661371117920
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+  sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
+  md5: bcb44ecbea441ee0d4659133d060d71f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257904
+  timestamp: 1695131670290
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+  sha256: e937081facacb141dc2c9cdcced92baa9a2662e4a56100b6041df0b6b7692570
+  md5: f3ac39b2349258198a9b3316636fe5d5
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39972
+  timestamp: 1685030752528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+  sha256: 3da9cbbd49fac566433748bd245d09d7d5fcd28b04c0397cbbf6d5bb92f5c4a5
+  md5: df73a5d2f6e089d51e71e91935a82c65
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 183753
+  timestamp: 1635775763162
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+  sha256: 26005d191bb15070aad70707ed6493f32678a67978bd3b83d4c9679cab44e717
+  md5: 2dc75d5a4ccb64310939c3a72d34ae20
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-clause
+  license_family: BSD
+  size: 521583
+  timestamp: 1638435042256
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+  sha256: 8c950c69bee969e2c66f88f0dc247b3ab75a753672a88009779d5f5dba193532
+  md5: 150ac0eb929bab9dec912797bdfc7b95
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 433182
+  timestamp: 1642022402894
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+  sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
+  md5: c7de00b4ac2778c4e5a7816320d75391
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94028
+  timestamp: 1690400356879
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+  sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
+  md5: 1581cafc84708ed9aafaaee1cbbf6065
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1089416
+  timestamp: 1690290900608
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+  sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
+  md5: e19ffbfb24b990275d24fcea2bd1699b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15702
+  timestamp: 1614030498860
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+  sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
+  md5: ca061ce25c0f58628643abec8d6a8244
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 66330
+  timestamp: 1696347637947
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+  sha256: 87965b7b46d93866d31696a1045216d64f077a06b2900c356aba87e8559c6188
+  md5: fa334030245135b37027a882f3c468bf
+  depends:
+  - libgcc-ng >=7.5.0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: blessing
+  license_family: Other
+  size: 1561908
+  timestamp: 1655328608308
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+  sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
+  md5: 0e76eab58fe488e91f0aee73f46de031
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29816
+  timestamp: 1671751864131
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+  sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
+  md5: b413a210eca82fe867e991eed085201b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38882
+  timestamp: 1668168876032
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+  sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
+  md5: 5b8375e2092012db69d2123dc0c68630
+  depends:
+  - libgcc-ng >=7.5.0
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3485432
+  timestamp: 1654088939579
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+  sha256: b746e39272888b9cc1a2a711b7b8836f2e26f4457850e43ad18bf0765e21dc3d
+  md5: 200e86f8d53aeebf4b7dcfc944fd7920
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 661662
+  timestamp: 1606942359431
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+  sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
+  md5: 67a8320961ff24e92eebb661536e5cf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - requests
+  - slack-sdk
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 123763
+  timestamp: 1679561904852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+  sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
+  md5: 0f0b91a158dd3692cbb7a7763b657bfe
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192032
+  timestamp: 1671143995098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
+  md5: 8515e64a3de7581360d713fe4c0a094e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8789
+  timestamp: 1690297588156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
+  md5: 60170012374b2a5007842fa5870d78c5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57479
+  timestamp: 1690297581658
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+  sha256: 870f20a3c006a74b291910f69c3469a409bd21437142864b29cfafeb89ca7c34
+  md5: 1b2f1589e3ebc3e0c6ecb38dba93e4ae
+  depends:
+  - brotlipy >=0.6.0
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 186761
+  timestamp: 1686163186447
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+  sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
+  md5: f8d03a15b974fc7810d9f54ae849fc8e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20781
+  timestamp: 1607365390528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+  sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
+  md5: d7db5d6ce1db80eade8a082ff78bf479
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 71044
+  timestamp: 1614804011510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+  sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
+  md5: b3899f8bda32734727bd5a73df1d7d17
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 101520
+  timestamp: 1695742037911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+  sha256: 2ce360ff98c0ca4537d70c19266b5700810196c54ce2fbaff3b94a969846ee37
+  md5: 94cb94dc47405b24b1b5bd0a3275ab59
+  depends:
+  - libgcc-ng >=7.5.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 398058
+  timestamp: 1651602137803
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+  sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
+  md5: 567b68192c387b5fc88178425577a0fe
+  depends:
+  - libgcc-ng >=7.3.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=7.3.0
+  license: LGPL-3.0-or-later
+  size: 366479
+  timestamp: 1616055552392
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+  sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
+  md5: 3818a9531fe74433c3b7d5144c9a58cc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18021
+  timestamp: 1672387231268
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+  sha256: 513444d83ac2405e898531492ea59f3a95641e357cc39c1048d6fffc1791a16b
+  md5: 601d9449c280b9b145dc8c83b6f06119
+  depends:
+  - libgcc-ng >=7.5.0
+  license: Zlib
+  license_family: Other
+  size: 133595
+  timestamp: 1650637720646
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+  sha256: 1c049c23788a00b6f38bdc801245e0e60af98718d4db4c958658bcc67ff158c7
+  md5: b1737dfd2e06ad69ec5cfec341e207c6
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 827172
+  timestamp: 1650622223170
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
+  md5: b2aa5503875aba2f1d88cae9df9a96d5
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13636
+  timestamp: 1611930018941
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
+  md5: 544adf2677c47c9b9c891aea720678f1
+  depends:
+  - python >=3.5
+  license: MIT
+  size: 33999
+  timestamp: 1630003259346
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+  sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
+  md5: 9eff1a842dbda8d1bae9a2c008b599bc
+  depends:
+  - brotli >=1.0.1
+  - munkres
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 690443
+  timestamp: 1625743217109
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+  sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
+  md5: 33624a42ee387bf9918ea98b4e7b31fc
+  depends:
+  - pygments >=2.4.1,<3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8173
+  timestamp: 1601490751973
+- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+  sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
+  md5: 67857cc5e9044770d2b15f9d94a4521d
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12810
+  timestamp: 1600445183315
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+  sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
+  md5: e68a6f315f41a8d814d833652bf38b9b
+  depends:
+  - python >=3
+  license: MIT
+  size: 13374
+  timestamp: 1606932077143
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
+  md5: 2eb923cc014094f4acf7f849d67d73f8
+  depends:
+  - python
+  - six >=1.5
+  license: BSD-3-Clause and Apache
+  license_family: BSD
+  size: 246457
+  timestamp: 1626374695070
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
+  md5: 41db68b96e114e367c4f120a3b379e59
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19391
+  timestamp: 1632406728844
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+  sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
+  md5: a815d3bdb160bcc71687f2dda70d3ca4
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 122218
+  timestamp: 1680170368293
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
+  md5: 447a49f7bad119faa80d7f14aa296c95
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162176
+  timestamp: 1644481750133
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+  sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
+  md5: 8810f48fe4a4792de0fd3520b502d08b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10019
+  timestamp: 1606859473259
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+  sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
+  md5: 00a446b6dfc61af223df4de29fe8ad94
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 34305
+  timestamp: 1644569782044
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
+  md5: bd92dd8bd5b9d24e632b62a075426e50
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133634
+  timestamp: 1695718025321
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+  sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
+  md5: f8ae051b591a9027adc16de1be9748f4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206198
+  timestamp: 1681493096349
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
+  sha256: 65ababd5e7812c35a97ac7d22b0ebe52c144121a3d49528b7d5c19e8453cce4a
+  md5: d85c13c017a37e406f6c1e00c1ea4f4f
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6480601
+  timestamp: 1690546287900
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+  sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
+  md5: 0d79760d544d0bd8acb4adc4ef813418
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 137075
+  timestamp: 1657175654487
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
+  md5: 31d6d04cd2388d8f19004501271b3545
+  depends:
+  - brotli-bin 1.0.9 hca72f7f_7
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18982
+  timestamp: 1659616229395
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
+  md5: caf1073dc2ca5aeb832a2877394eae12
+  depends:
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18233
+  timestamp: 1659616216769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+  sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
+  md5: aa1ed20c38af535c8d6a955314759d7b
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 394588
+  timestamp: 1659616312678
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+  sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
+  md5: ce3588e31faa79f546e0fc6a36c5543c
+  license: MPL-2.0
+  license_family: Other
+  size: 133884
+  timestamp: 1694009771475
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+  sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
+  md5: 21eb7f53076d0a69513cfd258f6ef63c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159756
+  timestamp: 1690232346868
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+  sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
+  md5: a40a04d9cda1e665565bc6c832d598b6
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225258
+  timestamp: 1670423337502
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+  sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
+  md5: b2cc5f37f7bb069d061306e7eac2a011
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1913396
+  timestamp: 1668084575248
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
+  md5: 103d8c039e342115720a84d59c119d46
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13774
+  timestamp: 1671231190250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+  sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
+  md5: f69f09e0346172f225390d2b3b0d7873
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 246628
+  timestamp: 1663827484947
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+  sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
+  md5: cb80c7ac65b48a737654f371fe31c460
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1307228
+  timestamp: 1694212041712
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+  sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
+  md5: 04cbe8f4bc62c34fac9d42d1124059bf
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2052734
+  timestamp: 1690905361158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
+  md5: ef0e825982f242085574f502dfff4f6b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16594
+  timestamp: 1649926538106
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
+  md5: 24747a300246c016b3a7f04dabd02d4a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27709
+  timestamp: 1668714497209
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+  sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
+  md5: e4a732941f74b8062c8bcbfe5c5c2b56
+  license: MIT
+  license_family: MIT
+  size: 80252
+  timestamp: 1676983220161
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.17.1-py39hecd8cb5_0.tar.bz2
+  sha256: a3c61a0d72aa6adca1967b894b190cf7d32fe78b0f8c57b855fb1e99c41aa3de
+  md5: ec60e644877f1e89c9ce00d487232396
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4610888
+  timestamp: 1693378182350
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+  sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
+  md5: f3ce6fe6eb760c236e5f7d04df5faa81
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28138484
+  timestamp: 1692293212596
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+  sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
+  md5: 6dd72c43fea25b748ec7a9f6c0407e15
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111810
+  timestamp: 1666125671024
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
+  md5: 03cdb7e679924b329ecab8f12cb8fc67
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38813
+  timestamp: 1678997212422
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
+  md5: e113c4e6e758dd68faf196586bf5564d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51873
+  timestamp: 1698254765815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+  sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
+  md5: 78baea934985ccd9514a366cc7e80ed4
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 727499
+  timestamp: 1681801225190
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+  sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
+  md5: da9b63e42f281f7e77b289f4b654b83b
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 218436
+  timestamp: 1691121840155
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+  sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
+  md5: 6a7cb9b49593b29933fa2b503d533a08
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1257205
+  timestamp: 1694181720454
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+  sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
+  md5: d861ef66f5c0a282d60b65778a9de2f3
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1048450
+  timestamp: 1644315332508
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
+  md5: f7e603c965052deed8b789c35855a42f
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213537
+  timestamp: 1666908270815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
+  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
+  license: IJG
+  license_family: Other
+  size: 278924
+  timestamp: 1677849185191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+  sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
+  md5: a82a17e78f725dcbd71ff8dac6db05c7
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133134
+  timestamp: 1676558895333
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+  sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
+  md5: ee9270379a9ebdb6297e4b6849b3f7f0
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 195479
+  timestamp: 1676329410154
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 32b898a97dca7770858ab31294238fde11ab61a84831a52f320e5ee5405a147c
+  md5: 926e754b8fad288b583ef2933deae1a5
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92938
+  timestamp: 1679906616072
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+  sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
+  md5: 7e60995b3119417213e5faedda147499
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 403165
+  timestamp: 1671707664990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+  sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
+  md5: cd470bdb28bb0e8b3535c93a3a6dad07
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65431
+  timestamp: 1672387389172
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
+  md5: 7dba7aa5b971febb55281659843586ba
+  license: MIT
+  size: 65470
+  timestamp: 1659616172703
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
+  md5: f78a158983f0bbaba56f34b976bc6dae
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 34189
+  timestamp: 1659616189313
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
+  md5: 36a1d885725d3ab4d1fadc5a29f978d2
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 327737
+  timestamp: 1659616202869
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+  sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
+  md5: 817848d0e2b2808acdc9b3fbbf581726
+  license: MIT
+  license_family: MIT
+  size: 133887
+  timestamp: 1683716590737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+  sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
+  md5: c90372428e1e4eed4fdcd790979d06b4
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1409377
+  timestamp: 1650983531933
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+  sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
+  md5: c0b99f8e1c7475f23b1c7b4250b06e1c
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88021
+  timestamp: 1694778290062
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+  sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
+  md5: 06866415ef22d5322f9bdc9956b59c4d
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 678174
+  timestamp: 1692970318885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+  sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
+  md5: 2edc6c894d6d0321304396e9bd40df94
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241774
+  timestamp: 1692973618934
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 0190d3b8d2939f28aa017711cf4147c51a1139da2922cc8420a71562dd99f844
+  md5: 454a7f2c4426453f17e995382a4235e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 36036
+  timestamp: 1659783508187
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+  sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
+  md5: 8bbd981ca0129d7beeacd3cd7623f714
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1491074
+  timestamp: 1695058597986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+  sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
+  md5: d5f58d056b4bfc67aec30c77035ba889
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 182491
+  timestamp: 1670944720979
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+  sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
+  md5: 1affd16b166571a91feae04baf5fd3da
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123431
+  timestamp: 1671542016019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+  sha256: e5fc51472fa0f36abd78baa5b3c9245d6627b0da11188e6a954d73f3f2bca210
+  md5: df7c519447affffb594f8c56b028ed33
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 107035
+  timestamp: 1684279974102
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+  sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
+  md5: 3681ebf029211ceab26af6f5d35abf39
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22254
+  timestamp: 1654598220251
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+  sha256: 2fd179efa024c92d0d71179a981a781d16c70f5d8c6305e0d678b0c7ae1275ab
+  md5: addda7f015d1673f794a23fdb18a3e09
+  depends:
+  - __osx >=10.12
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8182219
+  timestamp: 1698692361219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+  sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
+  md5: 6eb64ecfcd754502e271db0bb51d2cfd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17374
+  timestamp: 1662014643620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 2312ee5a6343e8495802698d7181f1b619aad7479d96ee253407b324ac884417
+  md5: 866960fa48a7ca335941786d4869802a
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53542
+  timestamp: 1659721365599
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: 37f455814ce242eb65ff80a0402f1bd231a388e6823e6c1e65f60b705c032a2d
+  md5: 4c9246c492a64729225aa5b04e12c2d1
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19573
+  timestamp: 1659716100178
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+  sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
+  md5: 2a4d604717a647ad21af766289cbbfc3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58057
+  timestamp: 1607364912348
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+  sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
+  md5: 25051fe272624544652dc6d814c2943a
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224420228
+  timestamp: 1691503125614
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+  sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
+  md5: 37d8cf85a63f7aa9af1624894a7d606d
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48590
+  timestamp: 1682969183093
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+  sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
+  md5: 0b2aee6666135bbd36b46d6ac66160f7
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 210705
+  timestamp: 1695058433223
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+  sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
+  md5: e22fb55ce380d0ebd44cce3f20d5349e
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296614
+  timestamp: 1695060155673
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+  sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
+  md5: 1a5d4004e64e3cfb7a2a297b9117c285
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8213832
+  timestamp: 1681756573646
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+  sha256: 2975bd1f98ca9ec7354ee378f86f8322ec90f568374776fd90e80c534fbee882
+  md5: 798627089e0ccba26695a26d9cb127ec
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99066
+  timestamp: 1650308465824
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+  sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
+  md5: e572c1264a7af20b486f64ac8c9e1f57
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 573356
+  timestamp: 1668450732828
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+  sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
+  md5: b67569a7c30af9ffa5cde6e4b52ac68b
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148342
+  timestamp: 1694616917184
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+  sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
+  md5: 97b81f34efbe86c5220fe82eb584fd62
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387288528
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+  sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
+  md5: d77862975a9a1cf50acb803be26e83a1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 575365
+  timestamp: 1690985052739
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+  sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
+  md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22858
+  timestamp: 1668160618784
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+  sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
+  md5: 185e9c41abb88ee59b52ec0f5f65d506
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 138305
+  timestamp: 1696515469702
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+  sha256: 82a2dd0c2ff6e20a275e5447dd03088f79694f7bfa5055a25c54bebf31aac4ca
+  md5: c157e6ab469a95b06fa822ba075978b3
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.0 py39ha186be2_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10376
+  timestamp: 1695831243158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+  sha256: b3a003b41cec2751210e542911e99437db0321542f6812c1b88608ef720ba7ef
+  md5: 56400dfe88c427cdf1854e47666b8a99
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.26.0 py39h827a554_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7570900
+  timestamp: 1695831208653
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
+  md5: 93f5d7b66976154adeda219bea02ba45
+  depends:
+  - libcxx >=10.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 484257
+  timestamp: 1630093862501
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+  sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
+  md5: 5e8713ef1215406254988163eaf34020
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4965606
+  timestamp: 1695323060401
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+  sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
+  md5: 4154929ace2ad6ee16aea815635a6d1f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73598
+  timestamp: 1693575307570
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.0.3-py39h3ea8b11_0.tar.bz2
+  sha256: 5e8b15af733592f6f6bff1c6eee2b8b808e8252e8a1112dc5a1cafe74016bffd
+  md5: 814274b9cdcd2cebab38a7a4d3d6dc48
+  depends:
+  - bottleneck >=1.3.2
+  - libcxx >=14.0.6
+  - numexpr >=2.7.3
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - html5lib >=1.1
+  - sqlalchemy >=1.4.16
+  - xarray >=0.21.0
+  - pyqt >=5.15.1,<6
+  - lxml >=4.6.3
+  - tabulate >=0.8.9
+  - matplotlib-base >=3.6.1
+  - fastparquet >=0.6.3
+  - blosc >=1.21.0
+  - gcsfs >=2021.7.0
+  - jinja2 >=3.0.0
+  - scipy >=1.7.1
+  - fsspec >=2021.7.0
+  - pyreadstat >=1.1.2
+  - odfpy>=1.4.1
+  - psycopg2 >=2.8.6
+  - pyarrow >=7.0.0
+  - openpyxl >=3.0.7
+  - xlrd >=2.0.1
+  - pytables >=3.6.1
+  - zstandard >=0.15.2
+  - numba >=0.53.1
+  - beautifulsoup4 >=4.9.3
+  - pymysql >=1.0.2
+  - python-snappy >=0.6.0
+  - xlsxwriter >=1.4.3
+  - pandas-gbq >=0.15.0
+  - qtpy >=2.2.0
+  - pyxlsb >=1.0.8
+  - brotli >=0.7.0
+  - s3fs >=2021.08.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13333560
+  timestamp: 1692298689692
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
+  sha256: 1928d1f3aa777c6fe0b279f400fa417b293527531bbdd3d918cc8e987a680f86
+  md5: e8d7a163f2f9dd0f1972e126ee87b586
+  depends:
+  - bleach
+  - bokeh >=3.1.1,<3.3
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.16.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17076156
+  timestamp: 1695146369755
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+  sha256: 914f1ec8d911083c006c4c2d3b4c0c528e79abba3ae5f1dad825bd896870270d
+  md5: 949e0e4c0ce43c92eb52241892230873
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142949
+  timestamp: 1684915417020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+  sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
+  md5: be0a90921f3bf4f0d6950fb786093de7
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND
+  license_family: Other
+  size: 719901
+  timestamp: 1696580194417
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+  sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
+  md5: 81ae9ec2d7fcf6934847bff558b619f5
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2672987
+  timestamp: 1697548890181
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+  sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
+  md5: 1a822c206e2abddc5d6d821721af227f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33013
+  timestamp: 1692205801265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+  sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
+  md5: 1604d33dbdb2446c642970f8b354bedb
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91266
+  timestamp: 1659455269141
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+  sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
+  md5: d1b3bcc35655a3123acb1fa2ad1a8511
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580828
+  timestamp: 1672387372015
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+  sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
+  md5: 7540555d1fb192236db9a7c5c9d3601c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365765
+  timestamp: 1656431373327
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
+  md5: 0a73533fb6e0dc717ab906a537bc747d
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30803
+  timestamp: 1675441638631
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+  sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
+  md5: 0a959fbad46ab38ade48dbd358002674
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1864757
+  timestamp: 1684280094736
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+  sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
+  md5: ea24b5076ef79e4567c5a3f0cb22b470
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95330
+  timestamp: 1690223465114
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+  sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
+  md5: bcaea6d4a47e9c874becaa700c78dcf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157216
+  timestamp: 1661452617825
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+  sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
+  md5: 707110d1b49cb1864acb0bbaa103591e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 95016
+  timestamp: 1636111184034
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
+  md5: 113a443b9c706f9f9c6187c0eaa3de27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31178
+  timestamp: 1605305861851
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+  sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
+  md5: 85a8d0001db70e52a479155228cb1fe0
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13324979
+  timestamp: 1694439878265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+  sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
+  md5: 47c5e22e31ec05a7bc0ce90065a53afd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 265348
+  timestamp: 1661368839620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+  sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
+  md5: ce9a69e1668aa1e133f2aa6d4e8d346f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 254958
+  timestamp: 1695131709704
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 9ee098c09f31fad7ff1856e5ce2619172eaf979997e7a427d1e05cce32c2af00
+  md5: cac1d1898b69ae9646dfbf082910635d
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40946
+  timestamp: 1685030787453
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+  sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
+  md5: 637f08b19dd8fd87347d8c44f9e3e202
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 170776
+  timestamp: 1698096100056
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+  sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
+  md5: 8ce3ac7d8a04e469b566f1b090d01140
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 470617
+  timestamp: 1657724324011
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
+  md5: 6f2d41dd76a03b7f85a1ed49af1763d6
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95100
+  timestamp: 1690400262627
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
+  md5: b0321e6f14e139fc15b1f8b4acb35d2f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093966
+  timestamp: 1690290944588
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+  sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
+  md5: 62b64576a0aa5f6c3fb05f56650d25e1
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15535
+  timestamp: 1614030509324
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+  sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
+  md5: 15b5595b31e39f08eaacbe2e502d8fb3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67292
+  timestamp: 1696347733587
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+  sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
+  md5: 82e4db6a498480a75d53c55bd35b6478
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1801397
+  timestamp: 1681394807900
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+  sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
+  md5: 63b957927b9949ccb19da28ec4612706
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30902
+  timestamp: 1671751919031
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+  sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
+  md5: e346257a2fa8e2cb48c762138a5d009b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39915
+  timestamp: 1668168959656
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+  sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
+  md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
+  depends:
+  - zlib >=1.2.12,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3536231
+  timestamp: 1654088937695
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+  sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
+  md5: a1bbf0abfb8c45541122c0eb2feee317
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680464
+  timestamp: 1696937112175
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+  sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
+  md5: d689f6203c0a9d04fb229c73d7e80a7a
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125145
+  timestamp: 1679561909274
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
+  md5: 8a292c1ee22489bef2e84bc3aaf4098e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193141
+  timestamp: 1671143985219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
+  md5: 8bf0bfffc11ad06a1c94e145941b0ad4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9651
+  timestamp: 1690297655669
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
+  md5: 343514a174b3485fde55a73f56398dd7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58456
+  timestamp: 1690297648002
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+  sha256: 11e7401cb6805db7ce22b1f9dd6ba5b7941c92225ce440bed1da0af284bfcad4
+  md5: 5c10d68fa5616cdd82ee93ef6e0f038c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11615
+  timestamp: 1659769478980
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+  sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
+  md5: c2242e8fd24003a74ddf37416661e06d
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188757
+  timestamp: 1698257668273
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+  sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
+  md5: 41f445e36b6b6722a9444508eef069f8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20583
+  timestamp: 1607365395045
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+  sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
+  md5: 409ee46ed24267b6da6fb32d13e1f21e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70730
+  timestamp: 1614804271285
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+  sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
+  md5: eb74e74d8e4fd533c55eb98b7b5e83bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102637
+  timestamp: 1695742077778
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+  sha256: cb007615819fd240ea4e343835dfbda3c508a92b5b7158219d30a22d0e67b57c
+  md5: bf215e781ac81e0fc433eedee330c54b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49462
+  timestamp: 1675159191191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+  sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
+  md5: e243baa546432c8394a8059a44a5a3e4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 419227
+  timestamp: 1683113010463
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+  sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
+  md5: fe4ac85ee86d3a94ea3a4ebea3779763
+  depends:
+  - libcxx >=10.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 321797
+  timestamp: 1616055526986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
+  md5: bc7073d9d4c0211cc4a1207c98fb765a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19091
+  timestamp: 1672387204865
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+  sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
+  md5: 8e495591e369ac161857a72011c0a296
+  license: Zlib
+  license_family: Other
+  size: 120272
+  timestamp: 1666595024203
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+  sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
+  md5: f1465fbd810b3746c6de6babfd4fe28a
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1023573
+  timestamp: 1681304595869
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+  sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
+  md5: cf55cb8d7031b30c70c56fc7c782b5c7
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 156104
+  timestamp: 1644482799136
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+  sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
+  md5: 84fce327d9f0d594e86f565e5c21962e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10183
+  timestamp: 1629146082730
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+  sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
+  md5: 84b8b998a741b37abf5312c1c03696ef
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33979
+  timestamp: 1644845817952
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+  sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
+  md5: 77b746931c8f31c3ae393ccb5819d43d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133628
+  timestamp: 1695717890677
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+  sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
+  md5: 3df6e8ba34208dea068890e5d5318cc0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206759
+  timestamp: 1681493095987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
+  sha256: 4edfceca9958378015a2d5ff705aecb977fa329fdd0caf51cf6a1b6b5506e5ab
+  md5: 7404ddc0add9157338d7d4822ac13cb3
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6462121
+  timestamp: 1690546176434
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+  sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
+  md5: bb55f81435cb6e11d264242274fccd1a
+  depends:
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 115947
+  timestamp: 1657175645380
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
+  md5: f860193e14afc7ef3f5b990a2ac003d2
+  depends:
+  - brotli-bin 1.0.9 h1a28f6b_7
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18936
+  timestamp: 1659616204016
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
+  md5: ad53130f3fd1f8d3c2fcbb7496e5585d
+  depends:
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18715
+  timestamp: 1659616188888
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+  sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
+  md5: 0982c046fb976e9f9fb19e7510187a18
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 366983
+  timestamp: 1659616245272
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+  sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
+  md5: 31ac2f5596cb7a44adf073c930641c54
+  license: MPL-2.0
+  license_family: Other
+  size: 133817
+  timestamp: 1694009762858
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+  sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
+  md5: cf1f6c3c34a1e1b9ab22b04233d860f6
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159783
+  timestamp: 1690232303987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+  sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
+  md5: 0eb268e38b5174d471a6e87d9d6102b1
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225355
+  timestamp: 1670423312966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+  sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
+  md5: e68c94666cd60221b575c3814c89bac0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1946451
+  timestamp: 1668084573824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+  sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
+  md5: 1773ae2b080cdd55827e27673351551e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13646
+  timestamp: 1671231171682
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+  sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
+  md5: 53bfd99ad1b09164d537209cffd98161
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 244040
+  timestamp: 1663827469853
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+  sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
+  md5: b62455043c8eb2434466885b19fed2de
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1399573
+  timestamp: 1694211828228
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+  sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
+  md5: eb3cdc0fc210838b9271512a6a1b7c85
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2067708
+  timestamp: 1690905319109
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+  sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
+  md5: f44b80b9405410e5bde6bfe0b31d5b3f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 15135
+  timestamp: 1650293774207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+  sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
+  md5: f87027ccce1361d0f82c0edf1a10d53b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27677
+  timestamp: 1668714367519
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+  sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
+  md5: 1d0bd7e576c64c059ef781dd319ad82a
+  license: MIT
+  license_family: MIT
+  size: 77591
+  timestamp: 1676983230102
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.17.1-py39hca03da5_0.tar.bz2
+  sha256: 024023fcd6a34ff71b3b558f9db00506382edef02e7ae0cf8e49846840d7deb8
+  md5: 5598508e6b21861496a578c023958612
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4495882
+  timestamp: 1693378262537
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+  sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
+  md5: 69eb3b03765627b6159ed23cdde78396
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28399065
+  timestamp: 1692293207812
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+  sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
+  md5: 83366cbd3beb073112f4644a613b6bca
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111933
+  timestamp: 1666125627512
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+  sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
+  md5: 647c1a2f8460ffa8c670a1915bbdb494
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38790
+  timestamp: 1678997152549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+  sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
+  md5: 35e541905426c686ef2ff010a0e502fd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51860
+  timestamp: 1698254731870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+  sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
+  md5: 187d7720aedf38759d122cccb4576f2c
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 219976
+  timestamp: 1691121991680
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+  sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
+  md5: e8e7f10741f9cfa737b310b334940441
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1255894
+  timestamp: 1694181494549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+  sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
+  md5: ff209e75aee17af2e358b0008fbe8c88
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1022945
+  timestamp: 1644315931223
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+  sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
+  md5: d3e78ef296b3c74910d003bd10b475d6
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213972
+  timestamp: 1666908195870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
+  md5: 055e12390b844ea6c6e956ee08a618e8
+  license: IJG
+  license_family: Other
+  size: 273479
+  timestamp: 1677849171867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+  sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
+  md5: 783e2ad3d36472648c5ccc9f3051db3c
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133077
+  timestamp: 1676558732505
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+  sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
+  md5: 0677598f673f9729b5990316170a999d
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 197129
+  timestamp: 1676329661580
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+  sha256: 05f9ca0fdcfdc2e217438be27fead588c843a3aadf7d034467c83216d1e5c214
+  md5: 2d648b77d817ba38293c0728711ba8f5
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92852
+  timestamp: 1679906632236
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+  sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
+  md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 401319
+  timestamp: 1671707682572
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+  sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
+  md5: 247558a0aecf1ef7e77a4343761353d6
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64600
+  timestamp: 1672387273585
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
+  md5: a0f206782751dfffed0dd51302a1bf26
+  license: MIT
+  size: 68012
+  timestamp: 1659616138077
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
+  md5: 4c6667cdd061d28e9bc4e4300e4d115e
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 31173
+  timestamp: 1659616155596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
+  md5: 637e9430e258ddf050623ef2360184d8
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 298430
+  timestamp: 1659616172209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+  sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
+  md5: 55c615026c0869f8d3ba657f3bd38c43
+  license: MIT
+  license_family: MIT
+  size: 120389
+  timestamp: 1683716579036
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+  sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
+  md5: a41117710dafe569c9cc4e83f6f29fe3
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1411339
+  timestamp: 1650982753977
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+  sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
+  md5: 98d22e0124d55fae3c37c608dab1dcc9
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 89825
+  timestamp: 1694778225280
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+  sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
+  md5: 0ba499df6755eae5d2d23aa4ab004553
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 642657
+  timestamp: 1692970217410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+  sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
+  md5: c73101971e5ab6a8e8688239884eac81
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241607
+  timestamp: 1692973585084
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+  sha256: ac50f846e93e68d50bfdd5589ea8272b987243a64eba8e2e358ef311d7734001
+  md5: f19270ff954a41dabbfe36ff0656935b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 36040
+  timestamp: 1659783399073
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+  sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
+  md5: 353dff9d5d996c2a260f66381b2ce3e8
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1470815
+  timestamp: 1695058433965
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+  sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
+  md5: c99006da802a97c9aae30da8c16b4820
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176131
+  timestamp: 1670944706815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+  sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
+  md5: 60bd1e037cda86205526f77405d78129
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123361
+  timestamp: 1671541992772
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+  sha256: 2fd690fa3c54a40f0426874ea12e12aad2718263a75708ddd1fa6052a4ad7fb3
+  md5: 81388724babfe9c32ea5cdd93633c342
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 107072
+  timestamp: 1684280007887
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+  sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
+  md5: 34dfd76da78de2eae95bbda390d746d6
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23092
+  timestamp: 1654598007056
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+  sha256: bf0eeef3c3c713515766ab8b0dc7863413de5b4b227deede97e24d90ca342345
+  md5: a7bba1857eb84fb50caea377e60d2050
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8066509
+  timestamp: 1698692266161
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+  sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
+  md5: eb79dabbeedee7da85dfbfb145bb8a26
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17342
+  timestamp: 1662014601345
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+  sha256: f400ad75dd2890627dc948f3e2e6b19732d02c124723eaf22272026993a94d52
+  md5: 4a4ffc7365e30b18f4443281839e2718
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53505
+  timestamp: 1659721313693
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+  sha256: 20fb26a7ac748ce288cf8483a837b0c33f1348ae738bcdb69cdc2763c7bbf7e1
+  md5: a0aebbc6c170ebd8d4710fd70b3db503
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19562
+  timestamp: 1659716131839
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+  sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
+  md5: 56db7bd3ff511cd839bda081523b3edd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 55683
+  timestamp: 1629356128780
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+  sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
+  md5: 176e0dcaeb28393881bacf69941e3889
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8289638
+  timestamp: 1681756329011
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+  sha256: afc6f332c51a3defc69e4c4e641988c0556039b9cd42be22f3db5292c88ccf37
+  md5: 2bc409c7258160a9b739d08d5ffb5998
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 96942
+  timestamp: 1650373637069
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+  sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
+  md5: 150ea9fadddf21993d3328d3e48a18b7
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 557688
+  timestamp: 1668450759059
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+  sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
+  md5: 37163b32508f9f589b3e6462a3a47546
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148426
+  timestamp: 1694616771736
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+  sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
+  md5: 6cdf7cbc43bf40e92b056a5576bd0086
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387216468
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+  sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
+  md5: 0f05853a139b6cda9c73e9d2707a4976
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 590288
+  timestamp: 1690984971741
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+  sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
+  md5: 7de782e4fb34bfa95ef2fc79d27d727d
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22840
+  timestamp: 1668160634885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+  sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
+  md5: 1a7b23113372c5667dbfe45976b9cc5c
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 126357
+  timestamp: 1696515322390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+  sha256: 3cd1161558704176560843586b1b1f9b257fd68c0ca53a2fc09e61267f47514c
+  md5: dd162b2716dc9daf732240a343862d4a
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.26.0 py39ha9811e2_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10388
+  timestamp: 1695830584640
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+  sha256: 5f35d8c0e1768fa3a9d2e75659cd2096bea6b4e021afea114f573e95f4943fb2
+  md5: 958f78b1e2299537996f98da7a930198
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.26.0 py39h3b2db8e_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6313331
+  timestamp: 1695830570878
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
+  md5: 371358a54bbdd307603888348d1a2c6f
+  depends:
+  - libcxx >=12.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD 2-Clause
+  size: 412248
+  timestamp: 1628861367714
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+  sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
+  md5: fa15d3b44ae1360ac9b640bbd5b6923c
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4746123
+  timestamp: 1695322833432
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+  sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
+  md5: d73db95f07a282021efdf8bc09713261
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73620
+  timestamp: 1693575195999
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.0.3-py39h46d7db6_0.tar.bz2
+  sha256: 185a933dcaceb0fa378e214cd72ea89f9071f0699fa9fabab1535d674531611b
+  md5: 1730e1aecea062f0f6e8eb323c164d23
+  depends:
+  - bottleneck >=1.3.2
+  - libcxx >=14.0.6
+  - numexpr >=2.7.3
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - tabulate >=0.8.9
+  - lxml >=4.6.3
+  - psycopg2 >=2.8.6
+  - pyxlsb >=1.0.8
+  - python-snappy >=0.6.0
+  - pymysql >=1.0.2
+  - xlrd >=2.0.1
+  - qtpy >=2.2.0
+  - gcsfs >=2021.7.0
+  - openpyxl >=3.0.7
+  - html5lib >=1.1
+  - xarray >=0.21.0
+  - fsspec >=2021.7.0
+  - matplotlib-base >=3.6.1
+  - xlsxwriter >=1.4.3
+  - scipy >=1.7.1
+  - fastparquet >=0.6.3
+  - pandas-gbq >=0.15.0
+  - pyreadstat >=1.1.2
+  - sqlalchemy >=1.4.16
+  - blosc >=1.21.0
+  - pytables >=3.6.1
+  - beautifulsoup4 >=4.9.3
+  - pyqt >=5.15.1,<6
+  - pyarrow >=7.0.0
+  - brotli >=0.7.0
+  - jinja2 >=3.0.0
+  - s3fs >=2021.08.0
+  - zstandard >=0.15.2
+  - odfpy>=1.4.1
+  - numba >=0.53.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13122992
+  timestamp: 1692291303537
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
+  sha256: 4548d2a1bc58cd61e9c9f475a77bac68d9e49d4996c4c891d5ca8ba5ea7552b0
+  md5: b4ed079246a55ac8f91b8f8abb713b3b
+  depends:
+  - bleach
+  - bokeh >=3.1.1,<3.3
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.16.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17115516
+  timestamp: 1695146000246
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+  sha256: 0d64f2438be25524bbfeb8646e4fb3c18499d747398a03ed15d41b350b03e001
+  md5: 6a4908a5c9f7b3f17f09ebc34b1b691c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142857
+  timestamp: 1684915417403
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+  sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
+  md5: 6e01c592ae3b8ff2d12cae76f2f4276b
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 715239
+  timestamp: 1696580071596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+  sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
+  md5: 9fb8f460c130d56caf33c6bbe46fbe8a
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2678841
+  timestamp: 1697548790931
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+  sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
+  md5: 390b8c3cd74281abecdbfd51476922f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33033
+  timestamp: 1692205747301
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+  sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
+  md5: 7896828fb3565fefad43f980d50c8723
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91190
+  timestamp: 1659455206354
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+  sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
+  md5: d934c74eb66d01af0f45f0881f4bab77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580588
+  timestamp: 1672387390426
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+  sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
+  md5: 9858166e5ffb624c8b9d281f4000d725
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 367167
+  timestamp: 1656431368885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+  sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
+  md5: 4d2b45c6be8221e6a3e44c2d5838426f
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30843
+  timestamp: 1675441531640
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+  sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
+  md5: 02521df4e2e79f75faa9cbb3560ab1dd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1861763
+  timestamp: 1684280026169
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+  sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
+  md5: bdebe59bffc7adbad83fdcd9d429a5f5
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95234
+  timestamp: 1690223494699
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+  sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
+  md5: d716e5c9b5eec45ce1df8eb52cab817a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157408
+  timestamp: 1661452601692
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+  sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
+  md5: 1907629863ed8e7c35ead232dae7693f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 91636
+  timestamp: 1628941083263
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+  sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
+  md5: 847b9bddf2a86e1609c0d53bbc23ea79
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 27378
+  timestamp: 1626781391140
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+  sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
+  md5: 18aa18bd0d260605923877921d26cc74
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13194025
+  timestamp: 1694438901368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+  sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
+  md5: 45642a99c83e7aed74d1ffab1f20145b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 266647
+  timestamp: 1661368655993
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+  sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
+  md5: fec748525144049a2fc7f52f9755232c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257235
+  timestamp: 1695131702047
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+  sha256: 960192a143672e9c1d6fe4027af448512d91eee7501e5c245c21b865cf8bf429
+  md5: 76d491244218505f071ba56a308673df
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40950
+  timestamp: 1685030774581
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+  sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
+  md5: 3445d25415998c807efbe64d3a7e03c8
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 167068
+  timestamp: 1698096118071
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+  sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
+  md5: e6e92da28e9b0e428ed4b7df417bec25
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 472418
+  timestamp: 1657724315435
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+  sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
+  md5: dba22515f36d3c266de5896350813ea2
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95103
+  timestamp: 1690400315537
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+  sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
+  md5: 3cd7eb43e285faba76faf67667e26b00
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093916
+  timestamp: 1690290951258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+  sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
+  md5: c5e9aef0d6895de1c927e9d796cd7cd3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15691
+  timestamp: 1629145910454
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+  sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
+  md5: 0f7c229e774146ffc4e29dedf75372bf
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67279
+  timestamp: 1696347632563
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+  sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
+  md5: 2302a79a045f152e183a52a81adfba62
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1674163
+  timestamp: 1681394762218
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+  sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
+  md5: 4ae67163d55cf9df83d4027ebc38c501
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30894
+  timestamp: 1671751931536
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+  sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
+  md5: dbb5c0cddb6661a89afee647fd3dc01e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39875
+  timestamp: 1668168874870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+  sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
+  md5: 667e60c8b407d73cbba40f44901f4f00
+  depends:
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3412693
+  timestamp: 1654088929697
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+  sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
+  md5: 884f788a5f6a664c9b79f7a4a60362d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680561
+  timestamp: 1696937004165
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+  sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
+  md5: 639a4f489af172c866c18442948e5874
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - slack-sdk
+  - requests
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125170
+  timestamp: 1679561942932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+  sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
+  md5: e5b90eba83fddba6d7aa6072b5bf7c91
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193017
+  timestamp: 1671143921826
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
+  md5: 644ef8830437070f60efcfcd6a987198
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9670
+  timestamp: 1690297532002
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
+  md5: a902a833bb186a2f1a4b2b89b1195136
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58466
+  timestamp: 1690297524418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+  sha256: 536045a8a172c651fd306c285a6d7409775f018dac944f2124c538ccfb195e28
+  md5: d4dc6cdf0812191b9ec78b35b4fdf3e0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11593
+  timestamp: 1659769477205
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+  sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
+  md5: f3f1d2c1028dad2f11ff950a15c99dbf
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188640
+  timestamp: 1698257577209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+  sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
+  md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20091
+  timestamp: 1629144441130
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+  sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
+  md5: 3089c63bf8f4d0423e1a287da286d83e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70923
+  timestamp: 1629357115820
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+  sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
+  md5: 5886b30b312445471268444f41f39dc7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102583
+  timestamp: 1695741976083
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+  sha256: 105e39d3eb51b47c7244b3379c0133ab7051966664f52835453b14509215b159
+  md5: ed20012c2cd99ffd04cca9929e0bc061
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49775
+  timestamp: 1675159079039
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+  sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
+  md5: 2e75ad6a09c308268192efe03cc9ebf4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 411778
+  timestamp: 1683113019715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+  sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
+  md5: 30f666bf97c26587c5d2f68cc5f330ab
+  depends:
+  - libcxx >=12.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 316901
+  timestamp: 1629287855861
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+  sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
+  md5: 584e591d36dcd5ba5c45404f0f7ebb2d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19076
+  timestamp: 1672387153578
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+  sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
+  md5: 467ae28215d1aa1c5688bc0c8a184269
+  license: Zlib
+  license_family: Other
+  size: 103525
+  timestamp: 1666595022664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+  sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
+  md5: 7cfbed15f1feee1422810f7830075f53
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 779464
+  timestamp: 1681304594848
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+  sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
+  md5: ed14f9bc6e55220483f1a5a388625a08
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162772
+  timestamp: 1644481986085
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+  sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
+  md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 39253
+  timestamp: 1644551767970
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+  sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
+  md5: b24d13c443a26f65a0778b475a5726bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132830
+  timestamp: 1695717959996
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+  sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
+  md5: 302c3c0696e17eaa62e140e3892644ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 199723
+  timestamp: 1681493196911
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
+  sha256: 29e914b68f261dd564de357888d32ec1511a6fcac9477fe68797289aba4d3e75
+  md5: 288585e412638a51e0288caf690d543b
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6485148
+  timestamp: 1690546982849
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+  sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
+  md5: bf930260f679bc74227bbb18bc36ae82
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 119700
+  timestamp: 1657176150595
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
+  md5: 507dfe693ef429f466d964b599f4af21
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_7
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 18650
+  timestamp: 1659616328001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
+  md5: d0bf43e8df60baae3b3105aa5c42a791
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 21153
+  timestamp: 1659616312367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+  sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
+  md5: 7bd24bf94c24e810aecaaf84a0978e6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 343204
+  timestamp: 1659616543542
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+  sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
+  md5: 092b417c11edcbe6bb9b765ab4a55d23
+  license: MPL-2.0
+  license_family: Other
+  size: 164999
+  timestamp: 1694009822357
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+  sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
+  md5: 708a750d370b9d6875651021e21c4446
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159322
+  timestamp: 1690232335307
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+  sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
+  md5: c35736da3ea26782425e78061268cf5e
+  depends:
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 228713
+  timestamp: 1670423312743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+  sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
+  md5: 457a4339a53c033d48ce0c72e5038d2e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30330
+  timestamp: 1672387265402
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+  sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
+  md5: 59ec65fd9e06b81a65cc12986c67d5da
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1939614
+  timestamp: 1668084794027
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+  sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
+  md5: 3489c1a2b73fc957b5a62cc59349e25b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13438
+  timestamp: 1671231196438
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+  sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
+  md5: 3492b96083c1e904cc32d26ea7f1e1d8
+  depends:
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184280
+  timestamp: 1663827558327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+  sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
+  md5: f46d904bc6f220327e70474971341f52
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1220835
+  timestamp: 1694445639066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+  sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
+  md5: 2ff4fb509788b0e47ac684ba151394d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3289966
+  timestamp: 1690907040646
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+  sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
+  md5: 0f166c3e70541d8bee6e9d0cb60fb66e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16979
+  timestamp: 1649926678161
+- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+  sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
+  md5: ea93d413944ca6a8677eb1b284b136ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27388
+  timestamp: 1668714577678
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+  sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
+  md5: 9f167d3e45441bc3633c1974b1b0ce8c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 88421
+  timestamp: 1676983264486
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.17.1-py39haa95532_0.tar.bz2
+  sha256: e4e08cbe9311b78ab893105a8f34963b46fce74c67943176cf2309e355dceb80
+  md5: c68d9f0e4a10f15d15d5812093818900
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4580877
+  timestamp: 1693378576619
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+  sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
+  md5: 30fdefd1541c789c163751291a8faa88
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111448
+  timestamp: 1666125667599
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+  sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
+  md5: a10f07c7a3510272a296f9fed458a4ed
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38098
+  timestamp: 1678997241511
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+  sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
+  md5: fad9cf2023d807da8d44996e9d4399a0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51490
+  timestamp: 1698254721864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+  sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
+  md5: 9834848bd7c7759acf12e78d09388563
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3891030
+  timestamp: 1681801474383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+  sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
+  md5: 1285c8c628bc912c54d0968574c9f4c9
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217232
+  timestamp: 1691122695748
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+  sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
+  md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
+  depends:
+  - backcall
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1279433
+  timestamp: 1694181820978
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+  sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
+  md5: f5fcce35d3f21cdfc5893c5a7a86c651
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1035394
+  timestamp: 1644315567034
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+  sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
+  md5: f67fe3337528e2886f1ac3ab8ac37985
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213110
+  timestamp: 1666908350218
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
+  md5: 81f2c343dc4c65eea39c45383272068f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 407861
+  timestamp: 1677849239400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+  sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
+  md5: bd9526d38a145fe311a8aa36bc11e071
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 152006
+  timestamp: 1676558783570
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+  sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
+  md5: a00e6a62956fde3c4135464353ee8a53
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229158
+  timestamp: 1676330909084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+  sha256: db8335d6531b03c7bdfe789ebacc52631ac6ea4a37700bb3da1f6a53a1acd724
+  md5: ebeba61994cc225ea5f4f42caa511019
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116681
+  timestamp: 1679906658986
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+  sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
+  md5: 5efa1332f7c0a8d9638eda02170c4ce5
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pywinpty
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 413653
+  timestamp: 1671707957673
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+  sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
+  md5: 891fe66a24d8714737b2874985ee1303
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62298
+  timestamp: 1672388166096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
+  md5: c345f51706eef530454f66b794e5e574
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 68189
+  timestamp: 1659616216976
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
+  md5: a7400cfb72042977bc047909ed504ce8
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 33743
+  timestamp: 1659616248209
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
+  md5: 6307f6854754ab5bd7c84e6998385bb1
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 733177
+  timestamp: 1659616279453
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+  sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
+  md5: b812bc5d9c76242e2bb2ac87afe7d39b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 730280
+  timestamp: 1650983734373
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+  sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
+  md5: ba9418df9288a2f031a02fa35b774ce0
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78524
+  timestamp: 1694778314659
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+  sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
+  md5: 6ece7f1a3248169837714d05d7f6ef0a
+  depends:
+  - libiconv >=1.16,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 3513910
+  timestamp: 1692971505729
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+  sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
+  md5: bd7ec244935e83e850a4ff34e8e2e64f
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 513971
+  timestamp: 1692973657152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+  sha256: e1c0e745d9ba36a80773e841d96bf514ad1ceda419e4188aad3c22782af00234
+  md5: f226532e9bb308f20e874c56be6ceefb
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 35788
+  timestamp: 1659783414586
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+  sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
+  md5: fb7881e74b59262df0fa4ec981964efc
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1244887
+  timestamp: 1695058550693
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+  sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
+  md5: 6970c7f46b0164cad1d210e7a1419959
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143434
+  timestamp: 1670944902624
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+  sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
+  md5: 1015298551c040c6d5e26eebbae12ef5
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142316
+  timestamp: 1671542240512
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+  sha256: ab5c246c2b271acc1cdd0b9343989c0166681536e569cdbe71618f55d34c7292
+  md5: 7ce68d771cd94c9ff5efefe69d327c9a
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 125122
+  timestamp: 1684280210213
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+  sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
+  md5: 466da740fafef3d6bce114220f0be306
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28510
+  timestamp: 1654508162239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+  sha256: 1687ae122ee7d8b583141fc5014b76d494841dc8083b854449e3d6e0f6bb7019
+  md5: 3697ac26ee3c2d49338dd5b9c6551152
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8080067
+  timestamp: 1698692812610
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+  sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
+  md5: a9fa43e694b25cd49b8b08a9eefd696e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18054
+  timestamp: 1661915903969
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+  sha256: 8aa14047fac6ef8b326900c4bf1a960eaa7a1699c18fdf1e75a59101b610b6df
+  md5: 7e1d4d4700fbea6171d30f1d5ad24226
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53362
+  timestamp: 1659721308586
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+  sha256: 2017814a7cc93dd51c6b7c016e3cdf8fbc32fa20f985638aaff6a6377e9ee086
+  md5: a1a285c56b001c3b5c591bf21eec3149
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19326
+  timestamp: 1659716205153
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+  sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
+  md5: 248c468abced874f0231d3cc23177c77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58488
+  timestamp: 1607359497934
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+  sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
+  md5: 5e763c995ff0c549f68a10bce70fede4
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187489950
+  timestamp: 1691503804820
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+  sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
+  md5: dd0c2ece6a743c373c9b5a5919b4818f
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49744
+  timestamp: 1682975040154
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+  sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
+  md5: 57cea8df7ab85f2a98f64d23afcb1f90
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184956
+  timestamp: 1695058491736
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+  sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
+  md5: 8769cdd201d905069800488fe31574e5
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 256221
+  timestamp: 1695060152521
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+  sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
+  md5: d9781492332e6326f9fca87f3a8efacd
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8135792
+  timestamp: 1681756491399
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+  sha256: 2dd3178d3c570e30b9490ebabfd7bfac806afad8302d3dee0edc619805034397
+  md5: bef9da0f0694c45b6aaa4e6447479eaf
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 118324
+  timestamp: 1650290466135
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+  sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
+  md5: f1d8ce412e115986c403f223b3b47d0f
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 596314
+  timestamp: 1668451106600
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+  sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
+  md5: f96bbef0985d7e66ebf00c0d55e30e23
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 167045
+  timestamp: 1694617078743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+  sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
+  md5: 6e6ba64c8dc5025aeac606404a8df36a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13786
+  timestamp: 1672387480065
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+  sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
+  md5: 4a7a3286484766741f627696697c362c
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 609425
+  timestamp: 1690985686105
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+  sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
+  md5: 4269a1f93882205b90d4b2ae78fc82d5
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22417
+  timestamp: 1668160717305
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+  sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
+  md5: a18a576b7024cfd6f905c526a786a916
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 135285
+  timestamp: 1696515698492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+  sha256: e5e11f9b42d770ee46ac24d1cdf7aa4e9c49a60a607c8c28e7729131a99eadd5
+  md5: 4274d06db8a9a381c072d226d0322dc0
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.0 py39h65a83cf_0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9835
+  timestamp: 1695830845329
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+  sha256: dcaa1607ce40a0ed610dd5398e125c8e5b08e738e50b6037a8c72b49ca561ff2
+  md5: d99d990a60644b97ba1ff9bb8da0e66f
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.26.0 py39h055cbcc_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6778113
+  timestamp: 1695830816710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
+  md5: ab07e2a27ac08afe3d0b4c0890b8486a
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 2-Clause
+  size: 249316
+  timestamp: 1630094024143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+  sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
+  md5: 73b17037d87b5a58feb34dafc0538f7f
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8058396
+  timestamp: 1695324589828
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+  sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
+  md5: df1d746ba8d5d6ba01ac1373b9b71e1a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73016
+  timestamp: 1693575484990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.0.3-py39h4ed8f06_0.tar.bz2
+  sha256: ed91d8aecd0bceea2e5952d3e3054c80d9a37481ebfea1451cbeda6aed416ca3
+  md5: 915957bfbe46e521c9cafed0bf66c916
+  depends:
+  - bottleneck >=1.3.2
+  - numexpr >=2.7.3
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - pymysql >=1.0.2
+  - beautifulsoup4 >=4.9.3
+  - html5lib >=1.1
+  - fastparquet >=0.6.3
+  - brotli >=0.7.0
+  - blosc >=1.21.0
+  - numba >=0.53.1
+  - pyarrow >=7.0.0
+  - sqlalchemy >=1.4.16
+  - qtpy >=2.2.0
+  - odfpy>=1.4.1
+  - psycopg2 >=2.8.6
+  - pytables >=3.6.1
+  - jinja2 >=3.0.0
+  - pandas-gbq >=0.15.0
+  - gcsfs >=2021.7.0
+  - openpyxl >=3.0.7
+  - lxml >=4.6.3
+  - matplotlib-base >=3.6.1
+  - xarray >=0.21.0
+  - xlsxwriter >=1.4.3
+  - pyxlsb >=1.0.8
+  - tabulate >=0.8.9
+  - scipy >=1.7.1
+  - zstandard >=0.15.2
+  - python-snappy >=0.6.0
+  - pyreadstat >=1.1.2
+  - s3fs >=2021.08.0
+  - pyqt >=5.15.1,<6
+  - fsspec >=2021.7.0
+  - xlrd >=2.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12385096
+  timestamp: 1692216843654
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
+  sha256: 0044e1cc04f3cb7c48209276c35c59c05b87e852c0ac01be468b99f3656445fb
+  md5: ee81d2a2b2c558b43a48fd68c2de1dbf
+  depends:
+  - bleach
+  - bokeh >=3.1.1,<3.3
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.16.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17009718
+  timestamp: 1695148093102
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+  sha256: 2773f47b2d745ab483cf7fcbd5b5e2f7020d45462d32d2ccd5cf232ca13c6f67
+  md5: ca16cd208037bd58d2da267c338da4a4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142229
+  timestamp: 1684915524241
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+  sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
+  md5: 427c1450bebb632f43bbc8c83006e4cd
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 806931
+  timestamp: 1696580240310
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+  sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
+  md5: 21790cd3e2b8a45c4104aff0a68330d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3001751
+  timestamp: 1697549357662
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+  sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
+  md5: 56f44a1054da2d10777e375838191070
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 32355
+  timestamp: 1692205784293
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+  sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
+  md5: 8a35ad65651086575ce55371f22feda8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91045
+  timestamp: 1659455316472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+  sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
+  md5: 186eb95f816a2eff80c3c7f7d964c7b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 578514
+  timestamp: 1672388155359
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+  sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
+  md5: 47b6cbe6ce9289e47d16900b03596a91
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372807
+  timestamp: 1656431445633
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+  sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
+  md5: 07165c444adc7c7ccc8a345875adc5ef
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48408
+  timestamp: 1675450623287
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+  sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
+  md5: d58e76a31e2f6e7410ba4afd7f385b0d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1877445
+  timestamp: 1684280183367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+  sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
+  md5: 0e5b0fe7debbf558ce97090f6b67cdae
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94633
+  timestamp: 1690225630423
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+  sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
+  md5: 0fde797653e4ab589506121fb1e37555
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157119
+  timestamp: 1661452591647
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+  sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
+  md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 92679
+  timestamp: 1636093365041
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+  sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
+  md5: f870859d4dc7a8d82cf3546bd9035f33
+  depends:
+  - python >=3.9,<3.10.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 54520
+  timestamp: 1605307564142
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+  sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
+  md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
+  depends:
+  - openssl >=3.0.10,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 21172845
+  timestamp: 1694442462066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+  sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
+  md5: 9d99075052265ae3d718582d3b875038
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269964
+  timestamp: 1661376543480
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+  sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
+  md5: fa9074d94236c9b768bfd2c858875b27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 264836
+  timestamp: 1695131770282
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+  sha256: 97243a31c39f4990c0e9d4f2307f2f7fb9421553303923bc105067ec4340bdff
+  md5: 8078c5760f27398eaf1082226647d137
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40145
+  timestamp: 1685031143383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+  sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
+  md5: 3d2841085778006c2e79f9c7300f8b9d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13565975
+  timestamp: 1669937633869
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+  sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
+  md5: 54a4bc0724041dd173088419d6ede2af
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 239062
+  timestamp: 1677611495106
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+  sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
+  md5: f39f84115e228bad4bceaefdd637f022
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 158558
+  timestamp: 1698096358091
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+  sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
+  md5: df398a3a1668fd2a22061764e20ea91d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.4,<4.3.5.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 460913
+  timestamp: 1657616061604
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+  sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
+  md5: 38db77ece9dc76feffb9ef7638e38258
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94397
+  timestamp: 1690400496655
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+  sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
+  md5: 3e284ae6b48ee30c364ffdc5601610b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1099842
+  timestamp: 1690291374842
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+  sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
+  md5: 993b3886b334bd1f49d34206f21997b4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15998
+  timestamp: 1614030572433
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+  sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
+  md5: 7ac9604ad7564ac0c71bff5db198656f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67012
+  timestamp: 1696347795139
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+  sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
+  md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1311308
+  timestamp: 1681402905668
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+  sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
+  md5: 28b9869d8d3a839918fac4a08f38cbc2
+  depends:
+  - python >=3.9,<3.10.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30546
+  timestamp: 1671752127904
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+  sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
+  md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39590
+  timestamp: 1668168880994
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+  sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
+  md5: 52cdcdb96383c010ca833a7c24b3935b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Tcl/Tk
+  license_family: BSD
+  size: 3690152
+  timestamp: 1654036853710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+  sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
+  md5: 0e054ab29119cf4c1f778613acf972f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 681780
+  timestamp: 1696937326924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+  sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
+  md5: b6ad839ebba536ad1c3cc58d0e2123f0
+  depends:
+  - colorama
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 143681
+  timestamp: 1679562248929
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+  sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
+  md5: fe78de10019085146f1cc6c94fdc2620
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192822
+  timestamp: 1671143999327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
+  md5: ca5fc3fbdb09b6de068a8b7a8869369f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9208
+  timestamp: 1690298120549
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
+  md5: a86e87a10e5fdff486265e0c675fb99f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57922
+  timestamp: 1690298106990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+  sha256: 8057d3d2a0acd44496de33c5b222063c3f7d06b90c74fbbda45bd18b0b324219
+  md5: 398f8db5bd8cab84b3d85a9d85fa4889
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11362
+  timestamp: 1659769459206
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+  sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
+  md5: 0d31859e0a097aedbcc1627db33b3d92
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188367
+  timestamp: 1698257883295
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+  sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
+  md5: 45ef24c486a484f079faf1dc90e4c7e9
+  depends:
+  - vs2015_runtime >=14.27.29016
+  license: Modified BSD License (3-clause)
+  license_family: BSD
+  size: 8277
+  timestamp: 1605602889180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+  sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
+  md5: 4daaceb6cfc1af6274509081d8018ef1
+  size: 2316783
+  timestamp: 1605602872095
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+  sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
+  md5: 916c16904615c7af3b5d37cb6694f45e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21084
+  timestamp: 1607347371925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+  sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
+  md5: da69e6987fcc757e83a358ceaa13f62b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73391
+  timestamp: 1614804425587
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+  sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
+  md5: 23b9f4634b2e5450be617114f62c74f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 120873
+  timestamp: 1695742300539
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+  sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
+  md5: 120f0b088290fc17bd6618fc10a2f0c4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PUBLIC-DOMAIN
+  size: 34293
+  timestamp: 1605306211299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+  sha256: a5d2a216d052105fdaad7256f23da3b29f95100d1dc0f29b6ab1f3bbc75e17a9
+  md5: a558f681ebc243f86cde2515c065b62e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48805
+  timestamp: 1675159123654
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+  sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
+  md5: c3f7871e9a33adeccee1b1e8e216918e
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 1332571
+  timestamp: 1683113347814
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+  sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
+  md5: 1ab55f8c4b5292ec360c572120bf823e
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-3.0-or-later
+  size: 9430705
+  timestamp: 1616055773485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+  sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
+  md5: 6875e0bf3828707dc9165d694c0d0a7d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18725
+  timestamp: 1672387612937
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+  sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
+  md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 148931
+  timestamp: 1666595229032
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+  sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
+  md5: 8d6a1e767775fe0eb617cd6e22edc2ff
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1871867
+  timestamp: 1681304638261

--- a/genetic_algorithm/pixi.toml
+++ b/genetic_algorithm/pixi.toml
@@ -20,12 +20,12 @@ numpy = "*"
 pandas = "<2.1"
 bokeh = "*"
 param = "*"
-pip = "*"
-setuptools = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+setuptools = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks]
 dashboard = "panel serve --rest-session-info --session-history -1 genetic_algorithm.ipynb --show"

--- a/genetic_algorithm/pixi.toml
+++ b/genetic_algorithm/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "genetic_algorithm"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/genetic_algorithm/pixi.toml
+++ b/genetic_algorithm/pixi.toml
@@ -1,0 +1,32 @@
+[workspace]
+name = "genetic_algorithm"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2020-07-22"
+maintainers = ["scottire"]
+categories = ["Other Sciences", "Mathematics"]
+labels = ["holoviews", "panel", "bokeh"]
+description = "Interactive dashboard for Genetic Algorithm"
+no_data_ingestion = true
+
+[dependencies]
+python = "3.9.*"
+notebook = "*"
+holoviews = "*"
+panel = "*"
+numpy = "*"
+pandas = "<2.1"
+bokeh = "*"
+param = "*"
+pip = "*"
+setuptools = "*"
+wheel = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks]
+dashboard = "panel serve --rest-session-info --session-history -1 genetic_algorithm.ipynb --show"
+notebook = "jupyter notebook genetic_algorithm.ipynb"

--- a/gerrymandering/pixi.lock
+++ b/gerrymandering/pixi.lock
@@ -1,0 +1,13793 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-16.1.0-hc1eb8f0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.10.55-h721c034_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blosc-1.21.3-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.1-py311h92b7b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/branca-0.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.7.2-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cairo-1.16.0-hb05425b_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cartopy-0.22.0-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.8.30-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cfitsio-3.470-h5893167_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cftime-1.6.2-py311hbed6279_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.2-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-2024.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-expr-1.1.13-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.16.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2024.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.6.3-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fiona-1.9.5-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/folium-0.14.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.14.1-h55d465d_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freexl-2.0.0-hf309648_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.6.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gdal-3.6.2-py311ha0db937_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/geopandas-0.14.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/geopandas-base-0.14.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/geos-3.8.0-he6710b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/geotiff-1.7.0-h2a26cda_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/geoviews-1.12.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/geoviews-core-1.12.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.78.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-tools-2.78.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf4-4.2.13-h3ca952b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf5-1.12.1-h2b7332f_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.19.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.27.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/joblib-1.4.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/json-c-0.16-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kealib-1.5.0-hd940352_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libabseil-20240116.2-cxx17_h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.9.1-h251f7ec_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgdal-3.6.2-hd4d5da2_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libglib-2.78.4-hdc74915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgrpc-1.62.2-h2d74bed_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libkml-1.3.0-h096b73e_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hecde1de_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnetcdf-4.8.1-h14805e7_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpq-12.17-hdbd6064_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-4.25.3-he621ea3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libspatialindex-1.9.3-h2531618_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libspatialite-5.1.0-h040243e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.11.0-h251f7ec_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.13.1-hfdd30dd_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libzip-1.8.0-h6ac8c49_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.43.0-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mapclassify-2.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.9.2-py311h6fb44e5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/minizip-4.0.3-hf59b114_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.10-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.7-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py311hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/netcdf4-1.6.2-py311h0e679e6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nspr-4.35-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nss-3.89.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.60.0-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.15-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-2.0.1-h2d29ad5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.2-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.4.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pixman-0.40.0-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pooch-1.7.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/poppler-22.12.0-h9614445_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/poppler-data-0.4.11-h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/proj-9.3.1-he5811b7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-16.1.0-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.1.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyproj-3.6.1-py311h76fdc58_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyshp-2.3.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/qhull-2020.2-hdb19cb5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rtree-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scikit-learn-1.5.1-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.13.1-py311h08b1b3b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-75.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/shapely-2.0.5-py311h24a2a10_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/threadpoolctl-3.5.0-py311h92b7b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tiledb-2.3.3-h77177df_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.1-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.5-py311h92b7b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uriparser-0.9.7-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.44.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xerces-c-3.2.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-16.1.0-hc0a701b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.10.55-h61975a4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.1-py311h85bffb1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/branca-0.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.7.2-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cairo-1.16.0-h3ce6f7e_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cartopy-0.22.0-py311hdb55bb0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.8.30-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py311h9205ec4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cftime-1.6.2-py311hb9e55a9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.2-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-2024.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2024.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-expr-1.1.13-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.16.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2024.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/expat-2.6.3-h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fiona-1.9.5-py311hdb55bb0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/folium-0.14.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fontconfig-2.14.1-h269ac6a_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freexl-2.0.0-hce1ea5d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.6.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gdal-3.6.2-py311he4f215e_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/geopandas-0.14.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/geopandas-base-0.14.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/geos-3.8.0-hb1e8313_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/geotiff-1.7.0-hf6ff7a4_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/geoviews-1.12.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/geoviews-core-1.12.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gettext-0.21.0-h4e8c18a_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/glib-2.78.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/glib-tools-2.78.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf4-4.2.13-h39711bb_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf5-1.12.1-ha01d115_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.19.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.27.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/joblib-1.4.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/json-c-0.16-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kealib-1.5.0-h72c422f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libabseil-20240116.2-cxx17_h548131f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.9.1-h3a17b82_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgdal-3.6.2-hfaf651c_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libglib-2.78.4-h19e1a8f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgrpc-1.62.2-hf2926fd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libkml-1.3.0-h85bf17e_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h26321d7_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnetcdf-4.8.1-h9f5a9a2_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpq-12.17-h04015c4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-4.25.3-h34eed0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libspatialindex-1.9.3-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libspatialite-5.1.0-hd7ca590_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.11.0-hf20ceda_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.13.1-h6070cd6_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libzip-1.8.0-h29ab7a1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.43.0-py311h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-4.3.2-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mapclassify-2.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.9.2-py311hc25a08b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/minizip-4.0.3-h79ad51c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py311ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/netcdf4-1.6.2-py311h42ba51d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nspr-4.35-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nss-3.89.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.60.0-py311he327ffe_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h91b6869_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h91b6869_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311hb3ec012_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.15-h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-2.0.1-h5747287_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.2-py311he327ffe_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pcre2-10.42-h9b97e30_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.4.0-py311h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pixman-0.40.0-h9ed2024_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pooch-1.7.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/poppler-22.12.0-ha8a1649_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/poppler-data-0.4.11-hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/proj-9.3.1-h1972728_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-16.1.0-py311he327ffe_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.1.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyproj-3.6.1-py311h717f92e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyshp-2.3.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/qhull-2020.2-ha357a0b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rtree-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scikit-learn-1.5.1-py311he327ffe_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.13.1-py311hedc7b93_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-75.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/shapely-2.0.5-py311h41c673d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/threadpoolctl-3.5.0-py311h85bffb1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tiledb-2.3.3-h1b93210_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.1-py311h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.5-py311h85bffb1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uriparser-0.9.7-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.44.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xerces-c-3.2.4-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-16.1.0-hbc20fb2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.10.55-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.1-py311hb6e6a13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/branca-0.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.7.2-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cairo-1.16.0-h302bd0f_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cartopy-0.22.0-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.8.30-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cftime-1.6.2-py311ha0d4635_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.2-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-2024.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-expr-1.1.13-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.16.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2024.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/expat-2.6.3-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fiona-1.9.5-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/folium-0.14.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fontconfig-2.14.1-h6402c1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freexl-2.0.0-ha3de405_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.6.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gdal-3.6.2-py311h950983f_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geopandas-0.14.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geopandas-base-0.14.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geos-3.9.1-hc377ac9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geotiff-1.7.0-h41f0982_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geoviews-1.12.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geoviews-core-1.12.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-0.21.0-hbdbcc25_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glib-2.78.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glib-tools-2.78.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf4-4.2.13-h5e329fb_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf5-1.12.1-h05c076b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.19.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.27.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/joblib-1.4.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/json-c-0.16-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kealib-1.5.0-hba2eb73_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libabseil-20240116.2-cxx17_h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.9.1-h3e2b118_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgdal-3.6.2-h51eea9d_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libglib-2.78.4-h0a96307_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgrpc-1.62.2-h62f6fdd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libkml-1.3.0-hc4d7c42_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h19fdd8a_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnetcdf-4.8.1-h0fce390_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpq-12.17-h02f6b3c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-4.25.3-h514c7bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libspatialindex-1.9.3-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libspatialite-5.1.0-h3e2df84_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.11.0-h3e2b118_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.13.1-h0b34f26_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzip-1.8.0-h62fee54_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.43.0-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.3.2-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mapclassify-2.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.9.2-py311hecf7826_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/minizip-4.0.3-ha89c15f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py311h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/netcdf4-1.6.2-py311h55fefbe_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nspr-4.35-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nss-3.89.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.60.0-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.15-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-2.0.1-h937ddfc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.2-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre2-10.42-hb066dcc_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.4.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pixman-0.40.0-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pooch-1.7.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/poppler-22.12.0-h52f4003_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/poppler-data-0.4.11-hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/proj-9.3.1-h805f6d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-16.1.0-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.1.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyproj-3.6.1-py311h041c639_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyshp-2.3.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/qhull-2020.2-h48ca7d4_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rtree-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scikit-learn-1.5.1-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.13.1-py311hac8794a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-75.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/shapely-2.0.5-py311h3713c0e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/threadpoolctl-3.5.0-py311hb6e6a13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tiledb-2.3.3-hb4a6b97_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.1-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.5-py311hb6e6a13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uriparser-0.9.7-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.44.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xerces-c-3.2.4-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-16.1.0-h7cd61ee_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.10.55-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.1-py311h746a85d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/branca-0.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.7.2-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cairo-1.16.0-haedb8bc_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cartopy-0.22.0-py311h786e728_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.8.30-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py311h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cftime-1.6.2-py311h5bb9823_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.2-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-2024.8.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.8.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-expr-1.1.13-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.16.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2024.8.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/expat-2.6.3-h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fiona-1.9.5-py311hf62ec03_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/folium-0.14.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fontconfig-2.14.1-hb33846d_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freexl-2.0.0-hd7a5696_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.6.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/gdal-3.6.2-py311h4e7b5b2_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/geopandas-0.14.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/geopandas-base-0.14.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/geos-3.8.0-h33f27b4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/geotiff-1.7.0-h4545760_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/geoviews-1.12.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/geoviews-core-1.12.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/glib-2.78.4-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/glib-tools-2.78.4-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/hdf4-4.2.13-h712560f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/hdf5-1.12.1-h51c971a_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.19.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.27.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/joblib-1.4.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kealib-1.5.0-hde4a422_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libabseil-20240116.2-cxx17_h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.9.1-h0416ee5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libgdal-3.6.2-h0e70117_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libglib-2.78.4-ha17d25a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libgrpc-1.62.2-hf25190f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libkml-1.3.0-h63940dd_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libnetcdf-4.8.1-h6685c40_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.17-h906ac69_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-4.25.3-hf2fb9eb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libspatialindex-1.9.3-h6c2663c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libspatialite-5.1.0-h25d3e1c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.11.0-h291bd65_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.13.1-h24da03e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libzip-1.8.0-h289538f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.43.0-py311hf2fb9eb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.3.2-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mapclassify-2.5.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.9.2-py311h472561b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/minizip-4.0.3-hb68bac4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.10-py311h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.7-py311hea22821_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py311h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/netcdf4-1.6.2-py311hec71f40_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.60.0-py311hea22821_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.15-h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/orc-2.0.1-hd8d391b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.2-py311hea22821_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pcre2-10.42-h0ff8eda_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.4.0-py311h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pixman-0.40.0-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pooch-1.7.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/poppler-22.12.0-h0bf3bde_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/poppler-data-0.4.11-haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/proj-9.3.1-ha107b6e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-16.1.0-py311hea22821_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.1.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyproj-3.6.1-py311ha997c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyshp-2.3.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/qhull-2020.2-h59b6b97_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rtree-1.0.1-py311h2eaa2aa_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scikit-learn-1.5.1-py311hea22821_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.13.1-py311h9f229c6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-75.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/shapely-2.0.5-py311h82fc408_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/threadpoolctl-3.5.0-py311h746a85d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tiledb-2.3.3-hd8964de_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.1-py311h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.5-py311h746a85d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uriparser-0.9.7-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.40-h2eaa2aa_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.40.33807-h98bb1dd_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.44.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xerces-c-3.2.4-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+  sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
+  md5: 613805add1c05b538ff06d217252feb7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 20810
+  timestamp: 1652859733309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+  sha256: 250f50edf43a786a32942e9ae67ce807e9b3ac4cb6b58b1170cb541fb24e391f
+  md5: b48058294499d292ddf9a3b966dc9cc5
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 228473
+  timestamp: 1706220559474
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+  sha256: 0d4f5274503916e1c683dcc16e8a7c4186557afa3f62399cd628e4eb535fe77a
+  md5: 062acdb0f9ae976c25c2d15d589dc1d6
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 35809
+  timestamp: 1676823571351
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-16.1.0-hc1eb8f0_0.tar.bz2
+  sha256: 5d681d5cff12cd7e2e70cfcf9d80b5ea545dba909700fc84614738a3d2c964ce
+  md5: 3e952919ba8be71d29e9c547b3f8d4ed
+  depends:
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - aws-sdk-cpp >=1.10.55,<1.10.56.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.5.0,<0.6.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libgcc-ng >=11.2.0
+  - libgrpc >=1.62.2,<1.63.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx-ng >=11.2.0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.14,<4.0a0
+  - orc >=2.0.1,<2.0.2.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.10,<2.0a0
+  - utf8proc >=2.6.1,<2.9.0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 13867665
+  timestamp: 1721659616065
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+  sha256: 567dfdd5b986012421a736a5f1c1d5874d8d691dd483c838b55e1ab06c0b217d
+  md5: 4e0aa1543f546b898523382ee8405e84
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 152577
+  timestamp: 1695717917074
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
+  sha256: 432e4fb45ae24789afdaeca800862aad03f8ebed5af908f01eed2a09283915e5
+  md5: a88c0e111e1f47ee83f1b6f329a149ef
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 97643
+  timestamp: 1706746168671
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
+  sha256: edb54d1554aefb65ff5a3969085dd8695e1e3218a2987ac30a96901f0bbf887a
+  md5: 5f131e63f8d80f2b7ac505054204a9e3
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.12,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 44722
+  timestamp: 1706690912333
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
+  sha256: 2afbfb546992e5954748d039ea15405f99018f6de78ec2f32bc7ff9bfc428a9c
+  md5: 489017af35cf8bdb976e6fef020a4ac7
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 202658
+  timestamp: 1706189913451
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
+  sha256: 5f81f5a3ea27bd29bf32a6987290de8c7b2da6612676aa8e606a7003519cbf47
+  md5: c11e7ceff3ca45bf580d1c944d93bd1f
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 17839
+  timestamp: 1706690843204
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
+  sha256: 348ced323311d36344a0fa9e88d299b361bad1f628dfbdd34bcea8662b3ab44b
+  md5: 19a11cdc9727c5981d96983a29b93ce4
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52025
+  timestamp: 1706697274091
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
+  sha256: 14e2843a218cb01bfc499a22537eb345f6e222b8496cfda2050c73ad98f09cda
+  md5: 44cba75d1bb5122aeadcaf8bb7da5e2a
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-compression >=0.2.16,<0.2.17.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 192985
+  timestamp: 1706744140260
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
+  sha256: a0f6916d60c0e1bac6ba548bf05a491b8db048a94e13da2f1cfa51b4ca879fb8
+  md5: 1f010db4f5ef1b3d705ee04dd1d473c9
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  - s2n >=1.3.27,<1.3.28.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 143623
+  timestamp: 1706696185335
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
+  sha256: 596945a39d772056e57bb357202a17e02508f2594da9c00e00ad767b8213e998
+  md5: 98cccbcc56a28ec7339e393816f4bdf7
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 70139
+  timestamp: 1706746744249
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
+  sha256: 12bf86ab848e3311f4eed4e93734a84064dc84580ad6dd4bb823b4ab6ef09698
+  md5: 4a8c2dcf0ede655609a9fc5632a5227b
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.12,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 74700
+  timestamp: 1706747582638
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
+  sha256: f05ce64fee77518a6deb45f187fcee415328e90ea8f2bf6031bd5b8273a1028f
+  md5: b8ebb4b892d9b80d513b4ca62a8d6de2
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 53042
+  timestamp: 1706690818718
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
+  sha256: 52bb367fc367ee3923353927226299a2b8b1be6a1993c11e19b20cafe6c6db0f
+  md5: 4715508fd5f8b39e902cb2afebc13c93
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52138
+  timestamp: 1706192048702
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
+  sha256: 0d13fbdace8ab4fbfcc015cf83bead69560a3dfadc6e0ce8441001629d725834
+  md5: a02c72bff71848705e70cd6f075a28f3
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
+  - aws-c-s3 >=0.1.51,<0.1.52.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 211559
+  timestamp: 1706827608038
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.10.55-h721c034_0.tar.bz2
+  sha256: a489d946a0a70a4d31f5da9fdf38e2c0ba8122e1df4fc716961b5b02d7617dbe
+  md5: f29f551a4e61c4d8339710ba000c6da8
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.12,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2815192
+  timestamp: 1706890558504
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
+  sha256: 5bb9bfe025d9a49af272f194278f63cea7366e83bdf3f99d25f97b820d522089
+  md5: 100d3161d97332fe38945afec8d36935
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 276381
+  timestamp: 1718029864701
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blosc-1.21.3-h6a678d5_0.tar.bz2
+  sha256: 10b48986cb0e0c974477ac3a58aaae198270b01f19cbd3e900143c6558fa3424
+  md5: 202b4629c225257fc01a4a2180c4e2f7
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65491
+  timestamp: 1675247642609
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.1-py311h92b7b1e_0.tar.bz2
+  sha256: 34d2dcc4885a03631c340e88ecb1002ac60c1f9573f34252e3ad8b87096c0040
+  md5: 9b33d05f7b278ad9a9a3442da9d41f11
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6054528
+  timestamp: 1718119253989
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+  sha256: 3606c8607c29229222667f66421f79df167d33043fe9245cdd4e2c4520ecc721
+  md5: eca33dcef14fa044193e43492dca8585
+  depends:
+  - libboost 1.82.0 h109eef0_2
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 10768
+  timestamp: 1696762269985
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+  sha256: 8e2b2073ff5c61d35714e8a36ce657a8ac741b7bedc2852a238c7f1625142705
+  md5: d951ab54a682b6328327fec53b1e5e72
+  depends:
+  - libgcc-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 147642
+  timestamp: 1707864274452
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/branca-0.6.0-py311h06a4308_0.tar.bz2
+  sha256: 68972850391765ea3d78e6dfa5a9250ca3802581f4ac93d6e060c9c4d09087e9
+  md5: 8c9ea30811092c3176d88cbd8a3a2583
+  depends:
+  - jinja2
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 53547
+  timestamp: 1676843457111
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 5d15605858771290fdaaae41a43941623757a25cb1292080d69d6d3857807935
+  md5: 7f517469aa5380c52e55db9f37df104f
+  depends:
+  - brotli-bin 1.0.9 h5eee18b_8
+  - libbrotlidec 1.0.9 h5eee18b_8
+  - libbrotlienc 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 18652
+  timestamp: 1714483267080
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+  sha256: a5094f078584e27c7cced4a9564ae904a329f5c1702a7c1ba092d581ba1544f1
+  md5: 6ddf45dd8a21a9512481de9bc0e5a03f
+  depends:
+  - libbrotlidec 1.0.9 h5eee18b_8
+  - libbrotlienc 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 19711
+  timestamp: 1714483255915
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+  sha256: 93180c973816246f068b742d0bf64840f0ea48e31d4f9b0747ea2ffc34d8855d
+  md5: f3a00096965a5ba1eb41d2c99a4662a2
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 361574
+  timestamp: 1714483400014
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+  sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
+  md5: f5058c8d5b2994b7334f18e022105a14
+  depends:
+  - libgcc-ng >=11.2.0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 427542
+  timestamp: 1714510571510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+  sha256: 5b4c80587ae4ec915505469f79d866f27c80456156667c8548d31c67c2c1653e
+  md5: c3d6bfae757760082261779c406a880d
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 116270
+  timestamp: 1693902021950
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.7.2-h06a4308_0.tar.bz2
+  sha256: a2a50043dce163f30830357ecc6bb6971a2bf0b5d9630eea915a76c983908109
+  md5: aa5a2ac6c4251cef085589caa114348f
+  license: MPL-2.0
+  license_family: Other
+  size: 136398
+  timestamp: 1720622030294
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cairo-1.16.0-hb05425b_5.tar.bz2
+  sha256: c2bd44f53bdd95e6c638f604884af9080323ed7fa72e5e3968d79d0c381fc40b
+  md5: d80d0342ce4d61f119ceecfb678c205e
+  depends:
+  - fontconfig >=2.14.1,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - glib >=2.69.1,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.39,<1.7.0a0
+  - libxcb >=1.15,<2.0a0
+  - pixman >=0.40.0,<1.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: LGPL-2.1-or-later or MPL-1.1
+  license_family: LGPL
+  size: 1571007
+  timestamp: 1688495896158
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cartopy-0.22.0-py311ha02d727_0.tar.bz2
+  sha256: 389e2d88a8c60762bace0c200af8ac5cbef22c53906dcb4c36a5869bd6e7783c
+  md5: 01a63e18f09bb9f7eb25dd6d5bd47b28
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - matplotlib-base >=3.4
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20
+  - pyproj >=3.1.0
+  - pyshp >=2.1
+  - python >=3.11,<3.12.0a0
+  - shapely >=1.7
+  constrains:
+  - pillow >=6.1.0
+  - owslib >=0.20.0
+  - scipy >=1.3.1
+  license: LGPL-3.0-or-later AND (OGL-UK-1.0 OR OGL-UK-2.0)
+  license_family: LGPL
+  size: 2094915
+  timestamp: 1706196282018
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.8.30-py311h06a4308_0.tar.bz2
+  sha256: 6c769a7cae15ec611e2a3cc9ccfe646b6027f60c2822811b3f60f589a8c51d8f
+  md5: 6ffd4b4a690cad0ee056e659db868f56
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 169012
+  timestamp: 1725551779652
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+  sha256: d138cc3fde270eba783baf1e2ba17c89800b2cbbf20976d0eb425b3436a4a184
+  md5: 1875e89c1a939e4e7c5e7b731c72b838
+  depends:
+  - libffi >=3.4,<3.5
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 302401
+  timestamp: 1714483186060
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cfitsio-3.470-h5893167_7.tar.bz2
+  sha256: a4a855659e4a52515b940d1b9d8204b626c11395980e99539b24f52d658e1857
+  md5: 65a71d60ece0bd684f1be09b48de8d00
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=7.82.0,<9.0a0
+  - libgcc-ng >=11.2.0
+  - libgfortran-ng
+  - libgfortran5 >=11.2.0
+  - zlib >=1.2.12,<2.0.0a0
+  license: Other
+  license_family: Other
+  size: 1384722
+  timestamp: 1655814890848
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cftime-1.6.2-py311hbed6279_0.tar.bz2
+  sha256: c9ef620859a8501e4d098dd1454fd521395acc668ceb98a47cdf886132fbebc0
+  md5: a88a08c5a9bb08c528fd25e84eb8055b
+  depends:
+  - libgcc-ng >=11.2.0
+  - numpy >=1.22.3,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 252968
+  timestamp: 1679335541002
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+  sha256: 9ddbf05887c7d7926418520cc7848e57f6d2431bc4ec6d30e090b02dbf865041
+  md5: 57ae1141ad9a048fb2a75d7a3ef7430a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203190
+  timestamp: 1698129926216
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.0.0-py311h06a4308_0.tar.bz2
+  sha256: 017b35122f533e4ffc48bb3e0c6fd1f16e8cbb2a67d40b3f6572b77511ffe26d
+  md5: 75eb58b2cdb0ddf4e93293cf973a0829
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41983
+  timestamp: 1721657369906
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+  sha256: d9c102b9ec7f3a635936b6f73d4db126d748a25f65407353bd76b260dc7d1cd6
+  md5: eec48dbdf5dac0ea26750cc26b58c1d9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 554986
+  timestamp: 1709758392744
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+  sha256: 882481e441b9b93cbdfb32fbe32a6ad9f26197472f186a08fddb921f61346c02
+  md5: 443c79196064f57c98199e9990544b2f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16902
+  timestamp: 1709322958614
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+  sha256: e4877b41553e31b9f9f090dffab77a654255c63776e8b30fc91ec1f60afadbf1
+  md5: c34d3f1520f1e8c9957eb236710058c4
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281162
+  timestamp: 1700583651472
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.2-py311h5eee18b_0.tar.bz2
+  sha256: 01fa6e276a4e41ef2396c40c0993a54c2fa3f511b33424191e5af11936edba12
+  md5: d83fe12f3bf13f5171a19af502e6f4cf
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 444424
+  timestamp: 1701723706605
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-2024.8.2-py311h06a4308_0.tar.bz2
+  sha256: 8e6a08353c165d56c1f7b0b34fd5fc8c3f6dbbcaa23b84ac1464fed4e228ed78
+  md5: 53f5a1198efff2c28205dc615a2ce7f9
+  depends:
+  - bokeh >=2.4.2
+  - cytoolz >=0.12.0
+  - dask-core 2024.8.2
+  - dask-expr >=1.1,<1.2
+  - distributed 2024.8.2
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.24
+  - pandas >=2.0
+  - pyarrow >=14.0.1
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5341
+  timestamp: 1725525101958
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.8.2-py311h06a4308_0.tar.bz2
+  sha256: eeb6264edb355734090537f71628c795493e5848867c05fb5fd624b9c0899c64
+  md5: f2d72f1b4ba65ae83f861b1c1245a22c
+  depends:
+  - click >=8.1
+  - cloudpickle >=3.0.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.4.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3116663
+  timestamp: 1725461379792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-expr-1.1.13-py311h06a4308_0.tar.bz2
+  sha256: 2382306aaa5ccaa12416c585d7b5134b3851b6374fc4f9d0cccab8aefce6a678
+  md5: 22a0cfe6eb25d725e60defcd4956f9e1
+  depends:
+  - dask-core 2024.8.2
+  - pandas >=2
+  - pyarrow >=14.0.1
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 559943
+  timestamp: 1725523090728
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.16.3-py311h06a4308_0.tar.bz2
+  sha256: 0333d880caa9352ba4d49ecbd3c6282a362e574374c34c07e60f7dc3168a4e39
+  md5: 6bfb802c6e2297eca13453c609826efc
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy <2.0a0
+  - packaging
+  - pandas <3.0.0
+  - param
+  - pillow
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18020969
+  timestamp: 1720534125523
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+  sha256: 3b4cd8dc60572086f1a1cbb97e2712e0ffd55317ce8f0309d552eee7367855eb
+  md5: 70a1263b6e19bf2d77c020a2e77277c9
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2556575
+  timestamp: 1690905285843
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2024.8.2-py311h06a4308_0.tar.bz2
+  sha256: 6ee436c7fc7627b9ef3b64e146903ede1248566b124ef90835b3c8b9b8126de7
+  md5: be3a5a477ea79581ed8d2c004592d46e
+  depends:
+  - click >=8.0
+  - cloudpickle >=3.0.0
+  - dask-core 2024.8.2
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.2
+  - packaging >=20.0
+  - psutil >=5.8.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.4.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.11.2
+  - tornado >=6.2.0
+  - urllib3 >=1.26.5
+  - zict >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1809092
+  timestamp: 1725523030863
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+  sha256: 4b589e3265c74159130230c164ff2d8d381be65899a249def0b53f93ce83fd47
+  md5: 245cb7173dcdba21cf368031cd87f706
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17434
+  timestamp: 1676823330845
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.6.3-h6a678d5_0.tar.bz2
+  sha256: 4239a7e8973dadc127940fb25e63a07a7ec9627c39687ae4742ce561e4fd0d63
+  md5: 2a9b1536c3f7f922a2b63fa2981e447a
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 200780
+  timestamp: 1725543341127
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fiona-1.9.5-py311ha02d727_0.tar.bz2
+  sha256: bb0b24e6e5683b67ac67afed3cc3b038614b6b262896c3c572504036f643867e
+  md5: 9872767319bde0ac940064e25bea90b6
+  depends:
+  - attrs >=19.2.0
+  - certifi
+  - click >=8.0,<9.dev0
+  - click-plugins >=1.0
+  - cligj >=0.5
+  - gdal
+  - libgcc-ng >=11.2.0
+  - libgdal >=3.6.2,<3.7.0a0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - shapely
+  - six
+  constrains:
+  - boto3 >=1.3.1
+  license: BSD-3-Clause AND MIT
+  license_family: BSD
+  size: 1261206
+  timestamp: 1704921153226
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/folium-0.14.0-py311h06a4308_0.tar.bz2
+  sha256: a1ba73410e26bed5ac999e4d8187a51525d93170b9b0bb569980e266d6c9f3a0
+  md5: 11e63939b47a8f2f52311f739e40c2bb
+  depends:
+  - branca >=0.6.0
+  - jinja2 >=2.9
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  - requests
+  license: MIT
+  license_family: MIT
+  size: 135137
+  timestamp: 1676852488567
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.14.1-h55d465d_3.tar.bz2
+  sha256: dcb04f684a0182e8161eb607488cef61ad121b72eda8794b1072aad621663016
+  md5: 7fbedeb920dc384a9873983a4abf62a7
+  depends:
+  - expat >=2.6.2,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - libxml2 >=2.13.1,<2.14.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 343714
+  timestamp: 1722921016734
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+  sha256: b75d12e85274660bb675a3e53d47a929872f2daa2ff5a76e98885ee3f2d19ad1
+  md5: f2119d0885334060d0d7fe59e5220287
+  depends:
+  - brotli >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - fs >=2.2.0,<3
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  - zopfli >=0.1.4
+  - lz4 >=1.7.4.2
+  license: MIT
+  license_family: MIT
+  size: 3237908
+  timestamp: 1713551660998
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+  sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
+  md5: a5dc8677d891dff2393b63189a3ad42f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 971975
+  timestamp: 1666798278693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freexl-2.0.0-hf309648_0.tar.bz2
+  sha256: 491a87a5812c0541edeb8ad7b373b60f812e6721039871c8f01181365064453e
+  md5: 66fba742a11cdbb9293ea2ec9064182a
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libiconv >=1.16,<2.0a0
+  - minizip >=4.0.3,<5.0a0
+  license: MPL-1.1 OR GPL-2.0 OR LGPL-2.1
+  license_family: OTHER
+  size: 68357
+  timestamp: 1704742026807
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.6.1-py311h06a4308_0.tar.bz2
+  sha256: eb7d7646fbda149ab0291100cb5d5d964b93b04aae9423eddf7d9fae1e45f0ef
+  md5: cde515ecf78e4d4b9f6c2290eb00a952
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - pyarrow >=1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 382658
+  timestamp: 1724855656158
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gdal-3.6.2-py311ha0db937_5.tar.bz2
+  sha256: f2479b9cb4e3b11eccdf71fec824cf89e2c96ccd603955e6e669d7c9f80c4b25
+  md5: d14a13b87165ddd4d9c661a020d8cc6c
+  depends:
+  - libgcc-ng >=11.2.0
+  - libgdal 3.6.2 hd4d5da2_5
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2129775
+  timestamp: 1722934260007
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/geopandas-0.14.2-py311h06a4308_0.tar.bz2
+  sha256: 488c5e092687d69e02f6f2419bdfbe0dc0a0567bc31c08263bc1ef0e45aa16cf
+  md5: b8d18f774b3d15aedf425c270eed1866
+  depends:
+  - folium
+  - geopandas-base 0.14.2 py311h06a4308_0
+  - mapclassify >=2.4.0
+  - matplotlib-base >=3.5.0
+  - python >=3.11,<3.12.0a0
+  - rtree >=0.9
+  - xyzservices
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6670
+  timestamp: 1704929096836
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/geopandas-base-0.14.2-py311h06a4308_0.tar.bz2
+  sha256: 02f06748d52e7ceaf6c51c5284cb9c655ba424c582f795b182d4b59efc53012d
+  md5: 57a3a71a74a9d47e67b3b10759cc359a
+  depends:
+  - fiona >=1.8.21
+  - packaging
+  - pandas >=1.4.0
+  - pyproj >=3.3.0
+  - python >=3.11,<3.12.0a0
+  - shapely >=1.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1520212
+  timestamp: 1704929055070
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/geos-3.8.0-he6710b0_0.tar.bz2
+  sha256: 6d791f835f915ad4f34171399b7d3141e548446dcce384f7d11f28a04c002bb7
+  md5: 7f115aea55f4cffe8c6c937240697f06
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: LGPL-2.1
+  size: 1078422
+  timestamp: 1573215838521
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/geotiff-1.7.0-h2a26cda_3.tar.bz2
+  sha256: 8f95d6317f1f5ff58c20916eb940df5651f4bb1aa9c9c9047c4a5bee85530469
+  md5: 139f94650b50874dd00901442926141f
+  depends:
+  - jpeg >=9e,<10a
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libtiff >=4.1.0,<4.7.0
+  - proj >=9.3.1,<9.3.2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 303738
+  timestamp: 1704901294937
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/geoviews-1.12.0-py311h06a4308_0.tar.bz2
+  sha256: 08b1a0678ecfdb2cf0a147ee5cb8b8197901afe9729ee83be9b9fafe1c52178d
+  md5: 7cbe0e9318db0f8dc7b30d23e3663b17
+  depends:
+  - datashader
+  - geopandas-base
+  - geoviews-core 1.12.0 py311h06a4308_0
+  - netcdf4
+  - pandas <3.0.0
+  - pooch
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - scipy
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5757
+  timestamp: 1713972423984
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/geoviews-core-1.12.0-py311h06a4308_0.tar.bz2
+  sha256: 3cc4030dab44dbf7539c70bd29741a44039696c7393f429af9d410caa45403e5
+  md5: d215cfecad1dae06365de992c22ca460
+  depends:
+  - bokeh >=3.4.0,<3.5.0
+  - cartopy >=0.18.0
+  - holoviews >=1.16.0
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - panel >=1.0.0
+  - param >=1.9.0,<3.0
+  - pyproj
+  - python >=3.11,<3.12.0a0
+  - shapely
+  - xyzservices
+  constrains:
+  - geoviews 1.12.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 607708
+  timestamp: 1713972417175
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+  sha256: 2fc1136056f41fe92de719fb821550346704965dd12a5fa35069cdb4948d5c17
+  md5: fd089b0fba2b03aafe3adb6cdaa9ac3b
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203421
+  timestamp: 1706888218007
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
+  sha256: c323a9800a358c178f6f3b8860bbb77c373fbc3be981bb6420175fbb5431adf5
+  md5: 6485f51176cf651b3b28c3548cef10ad
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 78533
+  timestamp: 1676983203797
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.78.4-h6a678d5_0.tar.bz2
+  sha256: d9a486f0ac92b1365365c3e536040a552c2de633283f27129f16dadcbc6d2de8
+  md5: 32538e0c24874a85011a094217830bd4
+  depends:
+  - glib-tools 2.78.4 h6a678d5_0
+  - libgcc-ng >=11.2.0
+  - libglib 2.78.4 hdc74915_0
+  - libstdcxx-ng >=11.2.0
+  - python
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 499006
+  timestamp: 1708031707428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-tools-2.78.4-h6a678d5_0.tar.bz2
+  sha256: cc7d3a52acad1df08e3d4ec7eefb22f41320e7eada94e78bf4b051128cbe72d4
+  md5: d8dcbf2be12799cf7f333c21a0e91990
+  depends:
+  - libgcc-ng >=11.2.0
+  - libglib 2.78.4 hdc74915_0
+  - libstdcxx-ng >=11.2.0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 112595
+  timestamp: 1708031685927
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+  sha256: f1e190d4ee766add8131a2b011723c472284de2bbb5e07c8f895f30e3c591df7
+  md5: 82029e0758feac811afec2a6ef9e6155
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 108438
+  timestamp: 1706895276199
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf4-4.2.13-h3ca952b_2.tar.bz2
+  sha256: 70e1f9fdc6b123d8270bcd8cdd555519372924d39419ef8692b36bfa9d0b4653
+  md5: 35da658876a3e2a62dda54dcd5a7e5c2
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.2.0
+  - libstdcxx-ng >=7.2.0
+  - zlib >=1.2.11,<2.0.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 937548
+  timestamp: 1510862959026
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf5-1.12.1-h2b7332f_3.tar.bz2
+  sha256: 73266852d7a5b419020aff69fc1d21dc5447692d7cecc1e863f58a80712c308c
+  md5: e1cd70ce23bf9015a98db5b8d3771bad
+  depends:
+  - libcurl >=7.88.1,<9.0a0
+  - libgcc-ng >=11.2.0
+  - libgfortran-ng
+  - libgfortran5 >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: OTHER
+  license_family: BSD
+  size: 5778986
+  timestamp: 1686164924867
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.19.1-py311h06a4308_0.tar.bz2
+  sha256: ac845d3797a0b6cd8db67a966c7d7df23e5a8419387c6d01eaf40cf6f3c0e5bf
+  md5: 43ba3fab33c79788ebe98a58aa60a92f
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21,<2.0a0
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.1
+  constrains:
+  - plotly >=4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6109096
+  timestamp: 1720533991629
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+  sha256: a0ae6c5a6b615d73d9a243331f3f7d749b4feafdf2f334337fda8abd6c8355ed
+  md5: e61d8dcd4dfd6d165e6e480cee846bf5
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 357992
+  timestamp: 1715090462763
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+  sha256: b35b281dbf69b826c6ae04fcd7b6a2d1f098277a669a199906a1f23b4b0931a5
+  md5: 2a793fe24f85aa5819fe69c450cba6f7
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 29021241
+  timestamp: 1692293243228
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+  sha256: e08e27531775de40f46b6ac7bf71856963baa0c008bd2b4d112e6341cd3e8f4c
+  md5: bfc7682613c861cbcb4ac01485c05657
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147174
+  timestamp: 1714398938840
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+  sha256: c7ffa6006573483a05ef355770c3201f04dd04ab4b91ae01971a6cdc7fbdba35
+  md5: 23d7d38e93d930ea5e2cc5f4079d3816
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 49872
+  timestamp: 1704813633807
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+  sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
+  md5: 3add2ce56858a1b8f6a37342f82773d3
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<1.2.14
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 19310769
+  timestamp: 1699647799237
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+  sha256: 0b670ab17ed2e1b592079bd64386dadc249ddc892e5ae1dd99f142a918ffc75d
+  md5: 632575b9e442c1e5c146cf78424da610
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 227791
+  timestamp: 1705934138566
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.27.0-py311h06a4308_0.tar.bz2
+  sha256: 466a9ff4b27043bc48c6e619fe458a4d6390d7db1cc3096d971b6a6166212ee9
+  md5: e58614cdf643d299d1faf06bd2b92327
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1633729
+  timestamp: 1726064436441
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.1-py311h06a4308_0.tar.bz2
+  sha256: 527d00eacde56f9f8c391dacfca0f55c5c750c45c6400d6220b49e3ee36e5636
+  md5: a4b061aee54081589532e93572722769
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1175236
+  timestamp: 1721058517965
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py311h06a4308_0.tar.bz2
+  sha256: f8c1f9c49e58fd9adfefbe99d055a8045643b620902c4758a07d689b21418900
+  md5: 77918475e3a5511cd5a0f595a751b881
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 354911
+  timestamp: 1716993527421
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/joblib-1.4.2-py311h06a4308_0.tar.bz2
+  sha256: 8a7e666bf678937a4133e148bfb7d5624934696140076cc3ce3a7477348e751e
+  md5: 9fd2cf2c75e332b1a30806e9e47e6ba3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 542339
+  timestamp: 1718217284906
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+  sha256: 8316ae3abee25edab89788ee6e9eef79c398aba192559f514674a04ee1860bca
+  md5: 112209aed451545a622ab217c70f6972
+  depends:
+  - libgcc-ng >=11.2.0
+  license: IJG
+  license_family: Other
+  size: 283506
+  timestamp: 1722872662693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/json-c-0.16-h5eee18b_0.tar.bz2
+  sha256: eaf9ba80be45651a8e3c8598bd3b00e5671cd929359c06d7c9b668a3636ee04c
+  md5: 0594055417685a7b7a828c2647fb8fc3
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 84251
+  timestamp: 1659123696523
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+  sha256: 06b729aee6dd2a1e545f3ad64179cc0d4ef8a15e33db3be2995dd3e0868465ca
+  md5: 8bb3215912588e47e2eeb4e7a09ad64f
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 180858
+  timestamp: 1699041715847
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+  sha256: 9e3bac2d41bd432b721b009e7de981766fba396e6f238e923f304112bd88655a
+  md5: 84ae4cf3f2d01fbebdac374971192be9
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 15525
+  timestamp: 1699032521315
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+  sha256: 79ce6dff3d93649a2555b1d2a4ae9eb77175a1c00664cb8eb0e6f848d5cdd1b9
+  md5: db395b0efd7018fcf3a4af879170c2a8
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 276856
+  timestamp: 1676823504812
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
+  sha256: 91cca0ba49accdc9e97463bee087244a27ad107eb3af9ccb91634239f8b10f72
+  md5: a185824bfc55bd90e1cf9330b417b74c
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 97359
+  timestamp: 1718818381635
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
+  sha256: 540f8dfb7cdc3877b4e24d6af65696d0bc7eae5de1c307229f86b3fe601a2286
+  md5: f650f8c007471f6ef6c1a292918d2e1f
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41920
+  timestamp: 1718738122846
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
+  sha256: 398387b6f1ee1691b04a31fedd1320225e5553aa921b06bc013f010a0008621e
+  md5: bac66634a9133c633ddc879e14e83f23
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 610854
+  timestamp: 1718827113534
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+  sha256: ddfee06ba9b149222c65d1d4270272840533aa63b56fe36363c84a891c71d328
+  md5: ee128e5c0d8d9e1952e2387b66a5b8cb
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27239
+  timestamp: 1686870958829
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+  sha256: 0c6a074272ed58677ec17e4dbfceaffd2108841a61af92b32f156c5763108d1d
+  md5: dd3d37841d0d20c70a60e8c939923894
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19144
+  timestamp: 1700168632051
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kealib-1.5.0-hd940352_1.tar.bz2
+  sha256: 16579c84dc5fd0b6ed8e23fbd4c47d8d172a947bb306248e6e98bed6743f38d9
+  md5: 579d3d2360ae0d0a467960fec295d5e4
+  depends:
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 193532
+  timestamp: 1687966960572
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+  sha256: b040f0d0ee4588188ab6b83a93738b3ff6e6d1775424be97995bd0df0f4fb904
+  md5: eae62735d710cf5ff6d51e6f59fcd999
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78148
+  timestamp: 1676827253282
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+  sha256: 01bae3dd44469e34f043e0416f5f5e658429bf4031745399d9968d10b899e2c4
+  md5: 10171cca67e3d73c3646c6dc5a321460
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.8,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1427115
+  timestamp: 1686931095252
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+  sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
+  md5: 88199c75f2ac211728febced7785c24e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 228278
+  timestamp: 1635523146417
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libabseil-20240116.2-cxx17_h6a678d5_0.tar.bz2
+  sha256: 799f5e019772d5d774c07dbb8b8d633e0b559921c8ab16ab2276aca1ca4f2fa2
+  md5: fe4de116b00c2c7eb7d307a58eef7429
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  constrains:
+  - abseil-cpp =20240116.2
+  - libabseil-static =20240116.2=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1316915
+  timestamp: 1716563364037
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+  sha256: e2754627e8aeb98777318939e6773b9eadbdc219dd8961aca946354d9d30f481
+  md5: 4ed89646229bee3e594cd2cc8f6060f9
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 23778916
+  timestamp: 1696762223408
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+  sha256: bb990ea068c3b3dafd9c807e0e19570320cb2fe7d69cc326f1f0b5319b0654b2
+  md5: 3ff70744e396b1af69656c574b05c3b9
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 66940
+  timestamp: 1714483221853
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 3b87a816f72a00e1f0022a160e7eda70af89d3de2a2e08a72be1c17b31d759f3
+  md5: 4f57d3a0a13ddaf1c06efb586b702f46
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 34446
+  timestamp: 1714483232430
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 2cf15e89f910600f468edfde8d0f9b80a14fa2319ed89160dc7375dfd3764fdb
+  md5: 463adc13f2feea3570d1eccac368d9e4
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 295090
+  timestamp: 1714483244460
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.9.1-h251f7ec_0.tar.bz2
+  sha256: 5ed4a1b84f273bd7bcd1302c823f4fbd486567c5d7d1a1e78eff9e7188af2e36
+  md5: b1c706c4fa97ec653a40d7670f7b24a3
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libgcc-ng >=11.2.0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.57.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=3.0.14,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 426063
+  timestamp: 1725033936108
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+  sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
+  md5: 55dde57e63a36b202e388a39dcee9a66
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 74096
+  timestamp: 1695996494461
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+  sha256: 5bd3af246b6a93ea0912179ae66e0ad9157ca0142263010d84b65724e6db0bec
+  md5: 5cb0cc0e1783419cf8fc1c65fee0f62f
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 195807
+  timestamp: 1703006263489
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+  sha256: efdab884c85fda4461f7a393aa6d4e0e50d03cb59fb9c8a980b1307b8379ebe0
+  md5: eeca774c6154c49340dd403b1928d5e9
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 108906
+  timestamp: 1632891483341
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+  sha256: 4b2518a1aa3859031a531cd1077e8a60d5b3a0dc7c83210ef27ff9ce2c78c3e3
+  md5: 49f152ee4045544c10799d32bba85c07
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 480247
+  timestamp: 1685052130829
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+  sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
+  md5: 1af9b4d62c708924417f2640ef22a68f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 154016
+  timestamp: 1714483282916
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
+  md5: 641e72e5067bd6d5454405879e1cd2a7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - _libgcc_mutex * main
+  - __glibc >=2.17
+  constrains:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - libgomp 11.2.0 h1234567_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 8895144
+  timestamp: 1654090827491
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgdal-3.6.2-hd4d5da2_5.tar.bz2
+  sha256: 664d73bc76c16c7beca196c8771ad65efd9cb8e9cb4f4f38d10773de860ea210
+  md5: c6d6e277325ab84488480b397c441bc8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - blosc >=1.21.3,<2.0a0
+  - cfitsio >=3.470,<3.471.0a0
+  - expat >=2.6.2,<3.0a0
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.8.0,<3.8.1.0a0
+  - geotiff >=1.7.0,<1.8.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - hdf4 >=4.2.13,<4.2.14.0a0
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - jpeg >=9e,<10a
+  - json-c >=0.16,<0.17.0a0
+  - kealib >=1.5.0,<1.6.0a0
+  - lerc >=3.0,<4.0a0
+  - libcurl >=8.1.1,<9.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libgcc-ng >=11.2.0
+  - libiconv >=1.16,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libnetcdf >=4.8.1,<5.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=12.15,<13.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libstdcxx-ng >=11.2.0
+  - libtiff >=4.5.0,<4.7.0
+  - libuuid >=1.41.5,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxml2 >=2.13.1,<2.14.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - openssl >=3.0.14,<4.0a0
+  - pcre2 >=10.42,<10.43.0a0
+  - poppler <=22.12.0
+  - proj >=9.3.1,<9.3.2.0a0
+  - qhull
+  - sqlite >=3.45.3,<4.0a0
+  - tiledb >=2.3.3,<2.4.0a0
+  - xerces-c >=3.2.4,<3.3.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 11806172
+  timestamp: 1722934042808
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+  sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
+  md5: 27082517590f3b9fbffecc68513b461b
+  depends:
+  - libgfortran5 11.2.0.*
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 19860
+  timestamp: 1654090819660
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+  sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
+  md5: 0202c3c8ae4735cac6c7f3d1e1685964
+  constrains:
+  - libgfortran-ng 11.2.0 *_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 5228750
+  timestamp: 1654090762569
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libglib-2.78.4-hdc74915_0.tar.bz2
+  sha256: ddda848ae8594a9a28b14439b322763e4ffb0ff8d34e492c994e434fe3fbf934
+  md5: e35935cc3937ef52b2ef721dddc45738
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libiconv >=1.16,<2.0a0
+  - libstdcxx-ng >=11.2.0
+  - pcre2 >=10.42,<10.43.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - glib 2.78.4 *_0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 1583413
+  timestamp: 1708031663093
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+  sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
+  md5: 3080c2813e6e1d0f8a100a38b5b3456d
+  depends:
+  - _libgcc_mutex 0.1 main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 573231
+  timestamp: 1654090775721
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgrpc-1.62.2-h2d74bed_0.tar.bz2
+  sha256: 498fafb5df2311ce582cbdfd9262f060a484ad8577030298deed948a3c491cd7
+  md5: 3065951fe45c36bb91009a61776f5e9a
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libgcc-ng >=11.2.0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.13,<4.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - grpc-cpp =1.62.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 9018521
+  timestamp: 1716835817873
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
+  sha256: ed544d8aa7e77fc42c39c276b879955e6615b517c42fecd2624033a5050832eb
+  md5: 21ee76e09ab0a7315cbed14933d97773
+  depends:
+  - libgcc-ng >=11.2.0
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1436714
+  timestamp: 1714483320555
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libkml-1.3.0-h096b73e_7.tar.bz2
+  sha256: 4bb7365724e8b7bd55877fe27d7dcc61e52aad4d37720c4f9df7a74fd4194686
+  md5: b15d5383eae8842c69a4ce7690d933dc
+  depends:
+  - expat >=2.4.9,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - uriparser >=0.9.7,<1.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 576030
+  timestamp: 1693261870612
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hecde1de_4.tar.bz2
+  sha256: c50e6a07e8004849e1cf9f0a164e36a79ac9d14a14fa7d33dc5e370315800489
+  md5: 457cfe8b5e65d583e6797a1ba2b5fb4d
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 37206574
+  timestamp: 1726769447337
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnetcdf-4.8.1-h14805e7_4.tar.bz2
+  sha256: 4775eeae5aef46f0e44f5d6e3811fc8c87bacef4a7a7cb55c11a7f691f1d61df
+  md5: a3c3a438b69f45c2677164480da778ac
+  depends:
+  - hdf4 >=4.2.13,<4.2.14.0a0
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libzip
+  - openssl >=3.0.10,<4.0a0
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1575671
+  timestamp: 1691154789340
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+  sha256: 6c67d781d3c074ae46b18567f230bce4a4afa209e8b914dc2cb448502774886e
+  md5: c9627c386bbc8a1a1a0a2e736ea44501
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - c-ares >=1.7.5
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 722387
+  timestamp: 1697018420830
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+  sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
+  md5: 1bffe1481ed4f88827248fb9001f8923
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 362561
+  timestamp: 1677841789536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpq-12.17-hdbd6064_0.tar.bz2
+  sha256: 9fbd40a9bcf75d2f7aab558b3803175d419b1178ec2ece0d77c40a3e47cf0d9f
+  md5: ca25d5734b0361f78536d5e77b4b3e43
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.12,<4.0a0
+  size: 2973280
+  timestamp: 1706214551622
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-4.25.3-he621ea3_0.tar.bz2
+  sha256: c070317f268dfcf77d5ff50c286bf430419fa9267eeea67d622f85c25fc6de9d
+  md5: 1672198ffdc6aabb8750c51496719e19
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3242840
+  timestamp: 1716568319462
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libspatialindex-1.9.3-h2531618_0.tar.bz2
+  sha256: b0f60b4c32f917a9c1b1048520cdfb5937ff7a07befa8a71022dfafae6e29ca4
+  md5: 8365a8a1dd0aef199a1214831622a4ef
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 3283214
+  timestamp: 1616086764247
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libspatialite-5.1.0-h040243e_1.tar.bz2
+  sha256: 0e6af3c6b946ed1be3137aa1c44d838c6624fd52414a88a9444974fe3bcd1ee2
+  md5: d009c5fd5313b3b69bfb12e50f7a22a6
+  depends:
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.8.0,<3.8.1.0a0
+  - libgcc-ng >=11.2.0
+  - libiconv >=1.16,<2.0a0
+  - libstdcxx-ng >=11.2.0
+  - libxml2 >=2.13.1,<2.14.0a0
+  - minizip >=4.0.3,<5.0a0
+  - proj >=9.3.1,<9.3.2.0a0
+  - sqlite >=3.45.3,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later
+  license_family: OTHER
+  size: 4550399
+  timestamp: 1722878430832
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.11.0-h251f7ec_0.tar.bz2
+  sha256: 9ffb6bf8ac29a27a2faf800c0d9077f07e983a41c218f87a6013a6e1f95af2ab
+  md5: 5b81a682e40f4c00841445d130c90b20
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.13,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 276424
+  timestamp: 1715261489564
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
+  md5: 8c195584a5f5471b600ee180e4052773
+  depends:
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 6410287
+  timestamp: 1654090800863
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+  sha256: 974e4035c5d51cd41fa7a7f02fadc1980069c00526c1646fa18ea94e667fb137
+  md5: 188de945b4279a812953011e8c4580c2
+  depends:
+  - boost-cpp >=1.73
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.9,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4630795
+  timestamp: 1687975185557
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+  sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
+  md5: ef78eebd98289aceacdfa29182426adf
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 664034
+  timestamp: 1693575237924
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+  sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
+  md5: 292768ec77416ae257cfdd44ea2071c8
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29197
+  timestamp: 1668082729834
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+  sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
+  md5: 9cdeef1d044c7e035c006890f11569d3
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 436056
+  timestamp: 1694776944891
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+  sha256: 5d68e69709ae10bd6c4b58b6af447ad2f2bd24955994f3ec77103d1a6bf5e1f5
+  md5: 49e523de8d364b7fabc3850eccbe9bda
+  depends:
+  - libgcc-ng >=7.5.0
+  size: 623492
+  timestamp: 1652448233146
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.13.1-hfdd30dd_2.tar.bz2
+  sha256: 2f04d75b2175c95c328235b42f3669f1bb693be63d46e689bff878f806fa378e
+  md5: d424ae0c5ca1279f734a1c52a1740d3d
+  depends:
+  - icu >=73.1,<74.0a0
+  - libgcc-ng >=11.2.0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 738961
+  timestamp: 1722441092529
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libzip-1.8.0-h6ac8c49_1.tar.bz2
+  sha256: 6e37085dac10bad7a862609897cda91c3f0d7bdfe1352879ff1b97ea9a389a35
+  md5: 7258e512d546498dbb183a1d4da1c938
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=11.2.0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104828
+  timestamp: 1685378527586
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+  sha256: fd8e30beb8c9442f16e6617fac92dd0c89ec823e98f06e60f712147380ead35f
+  md5: 7ed7caf2816c8b85b67b6f4e8833cbd5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41155
+  timestamp: 1676837080881
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.43.0-py311h6a678d5_0.tar.bz2
+  sha256: ba4846b57918d712a2c9986a31ac24fc3105f7cb029d1bcd7972b4bcd7a15b1c
+  md5: 707e906a126ab3f69499704ab424b18e
+  depends:
+  - libgcc-ng >=11.2.0
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4446734
+  timestamp: 1720455383067
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+  sha256: 95fe76d2691feb13203b55ad2aba535bb848cae21ffd05b13ff51c7a45fa2332
+  md5: 6a04ec16e3abc1c7e2104be32cd6c418
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13458
+  timestamp: 1676827287432
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py311h5eee18b_0.tar.bz2
+  sha256: fc8fa25c9629d8b5362d14ca7c90792064492aef7765a60e3574948f4659b4f2
+  md5: ed09cfc6c49987d5af17585f5e5168cb
+  depends:
+  - libgcc-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40405
+  timestamp: 1686058019487
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+  sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
+  md5: 76f089e76ec67583bb38428b51008097
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 164494
+  timestamp: 1714510587156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mapclassify-2.5.0-py311h06a4308_0.tar.bz2
+  sha256: e4978f900634c42d71203b95c093062d05f068d381915f8173e5bc8e03d70748
+  md5: 2d15555f9810fbccd1cf3c8131a97f16
+  depends:
+  - networkx
+  - numpy >=1.3,<2.0a0
+  - pandas >=1.0
+  - python >=3.11,<3.12.0a0
+  - scikit-learn
+  - scipy >=1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 83254
+  timestamp: 1676858588658
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+  sha256: 260e26dd509834c1b225ab7bdb97b9a86e00054fbdd5dfa49e68fa4dcf85a661
+  md5: 8f5d7ddc69cc6f7d44c80d2251dea5d1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162339
+  timestamp: 1676837095436
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+  sha256: 7f5b0804d0768619b7bd93b10488067d80bf42ec29f443f00b53ba11758a1241
+  md5: 8afb45e45c0d93bfd142e682d4b021ef
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 134438
+  timestamp: 1684280014220
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+  sha256: cb03570c99c983d7bfda94bc47d8eb00d4059b8548a171130775acc998004195
+  md5: 5b1abbbf1e4f9b350b16fc9caf9e889b
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26919
+  timestamp: 1704206397615
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.9.2-py311h6fb44e5_0.tar.bz2
+  sha256: 3e5f475ba36d974005e6d3c4adbd1ba1874fba9d7db287eb74e7def409a5b478
+  md5: be51f267bf90790dcb7e1562ad5e4d42
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9468863
+  timestamp: 1725264212197
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+  sha256: 7ac07ea180b5928086075900afbc332fb1d3c81ddfacb54c891693c284056f14
+  md5: fc83dd1b3d2ec3c0a297ead0c3405907
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19573
+  timestamp: 1676823852670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+  sha256: c9ba2f9c83820712dd97d6a1b54a1215b9820a0be02ac82380b4c50911b9400c
+  md5: e5dc6b4a5b8e02733ce3bc9e9198a8d2
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67750
+  timestamp: 1676837123613
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+  sha256: 1a5141ef0de1cbff816f96bb4b212a40606e2fc11301a4c1358c8d63a6b2b027
+  md5: 22ac3bc22b68fef4c1f3f6ab3c7bfe0b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23040
+  timestamp: 1676827301164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/minizip-4.0.3-hf59b114_0.tar.bz2
+  sha256: 7a928b4375e97456db414de29942cd0b46d6337de41c327329a50382ad8db975
+  md5: c3de1cacc776d47a60a8ed29cb311a7f
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=11.2.0
+  - libiconv >=1.16,<2.0a0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.12,<4.0a0
+  - xz >=5.4.5,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 96540
+  timestamp: 1702658544366
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+  sha256: 9aacfbbe6f638c58a4e8ff31374d1438d78b7db25d6ea6fd0c50ca2109f225d4
+  md5: e602057e3b3d80da88c61d66e8851c5b
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104681
+  timestamp: 1676823696152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+  sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
+  md5: ce77d0f05f846da4a6b9e23fe7f21d9b
+  depends:
+  - intel-openmp 2023.*
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - tbb 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 206738176
+  timestamp: 1699648006088
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+  sha256: 2aef0876d0df033f7fae8cddbd25d95fc1bfc067e60dd143bd8000fec0768b21
+  md5: d6cdc670327bd1675bbea642849f04e1
+  depends:
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59569
+  timestamp: 1682948560323
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.10-py311h5eee18b_0.tar.bz2
+  sha256: 4bff1742ab031795ded9173ec2242e4db35dd09918a6cedd701b64240263fdfe
+  md5: c989fc726a5c71acfe87d09d135d0ce9
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 241044
+  timestamp: 1725370379952
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.7-py311ha02d727_0.tar.bz2
+  sha256: c30c46225564d1458bef94185eb97f0be93ed05da15a872d5ecb1a17d9e8f47a
+  md5: fcd712e3bc58078ec8524da8f773c6bc
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16
+  - python >=3.11,<3.12.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411983
+  timestamp: 1725370348238
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py311hdb19cb5_0.tar.bz2
+  sha256: ee4db7daf8d5e41a547e7790dd62aa98e203f4f857cf6018b850e7df8e613a3c
+  md5: 17145d1745996667614b52d2b27a1403
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 37588
+  timestamp: 1676823053826
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+  sha256: b558b3f6c144652b5e0d26497b3ce24c318a6b9ff8ea2079113c95e5553b3cf9
+  md5: 0b185969ac2b065c27cbcc9641d93678
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29568
+  timestamp: 1676841232463
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
+  sha256: 6116c133fbed1e7ea0f5e69f900e93d7977cb715920d10b10642c191d00cc9a6
+  md5: b842f7ebdc8b7b6a0dda4c5ebe12805b
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8315206
+  timestamp: 1717622768176
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+  sha256: bb45fb0a3973caa74fd8f845e0a519895f6a378807626e15ecf72c02f2eed794
+  md5: 185f658ba8a74e326b7231c8fd0d62bf
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 121834
+  timestamp: 1698934274227
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+  sha256: 8b2fc372a6655fd5b277d07b994ce43643553fbc37e63a60e9fe527a9026ec06
+  md5: ed6ac14aed5a796b153d757862398997
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 523905
+  timestamp: 1699022906468
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+  sha256: 7908ff6c516b15e8fb677be4071145e18adea7d4c13b8485a70a5ee2f573f8cb
+  md5: 50c0e38207a131a5de6a14ef919ffcdc
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 169629
+  timestamp: 1694616826002
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+  sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
+  md5: 57ea097dc15f8d9f9eb90e1d919143b0
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1157733
+  timestamp: 1674734069410
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+  sha256: 266199dd4efde0ad342a9c500f4bc4299c5622219aea623b46315a9b4f6b8959
+  md5: 2b21844d2b0024d0ffad0e6450cf0855
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 15860
+  timestamp: 1708532713870
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/netcdf4-1.6.2-py311h0e679e6_0.tar.bz2
+  sha256: b15fc9c240136e7365c01b584b0c91e471f58d5d0f974d36b478b2b21f1d91f9
+  md5: 29dfd4701640eba0d1ebf674d74d3b9d
+  depends:
+  - cftime
+  - hdf5
+  - libgcc-ng >=11.2.0
+  - libnetcdf >=4.8,<4.9.0a0
+  - libnetcdf >=4.8.1,<5.0a0
+  - numpy >=1.22.3,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 511133
+  timestamp: 1676841290599
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.3-py311h06a4308_0.tar.bz2
+  sha256: 95f608b1dd4383538cdd04a285f74d88b398e43f9b78f23a5f3cffe18cf438fe
+  md5: 232079919a9e1f2abf394f958d7dff44
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - scipy >=1.9,!=1.11.0,!=1.11.1
+  - pydot >=2.0
+  - matplotlib-base >=3.6
+  - lxml >=4.6
+  - numpy >=1.23,<2.0a0
+  - pandas >=1.4
+  - sympy >=1.10
+  - pygraphviz >=1.12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3340382
+  timestamp: 1720002512692
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
+  sha256: 59e169e036db0f2b98ed19f867d8ac708970214599efa0d57d3413fc1dbe8e3c
+  md5: d0faf375bfc33811456d43fe549cb939
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 710152
+  timestamp: 1717630833268
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+  sha256: ef2857e6d3d7eb246b3abddfbd3aa2d124dd8565391ace3876b77339babc50bb
+  md5: d276d1b1774107987963135c78ca7390
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26607
+  timestamp: 1699455972519
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nspr-4.35-h6a678d5_0.tar.bz2
+  sha256: ffa738460ef0c396c09265e08d626c08fb41e967affae28a3ca9c8d590bfb890
+  md5: 1168e3423b7869fdcbe350c10c7bf4b5
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MPL-2.0
+  license_family: OTHER
+  size: 240070
+  timestamp: 1685541755697
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nss-3.89.1-h6a678d5_0.tar.bz2
+  sha256: a1cd50c850d25fba4ca9ecd88bf9ce553ee4a2f8237e395ce5cc135feb56f3e1
+  md5: 7da60451dd1a36255b00240216616101
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - nspr >=4.35,<5.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MPL-2.0
+  license_family: OTHER
+  size: 2220153
+  timestamp: 1685543249020
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.60.0-py311ha02d727_0.tar.bz2
+  sha256: 08a8505d44d5a51141cf4bd895fb3925ee52160bd51e8c8147f11e7f48a65a1f
+  md5: 47699f658867be16614cddc1edd70731
+  depends:
+  - _openmp_mutex >=5.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  - libgomp
+  constrains:
+  - scipy >=1.0
+  - cudatoolkit >=11.2
+  - tbb >=2021.6,<2022
+  - cuda-python >=11.6
+  - cuda-version >=11.2
+  - numba-rvsdg 0.0.*
+  - libopenblas !=0.3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6188719
+  timestamp: 1720541020279
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+  sha256: 2f89f38a665ece47e8868b391fc70602fcee588e989bc1ca6f17f6094892a94e
+  md5: b788c80b2d571531ea4f3f8335ae5423
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 168827
+  timestamp: 1696515597877
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+  sha256: e09e1aff2c12d4ef3fec58fb627744e4b5c7d9eaede7175e293f77272d8b8bfd
+  md5: fe8242cfd54d238507493612ae697ad4
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311hf175353_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10270
+  timestamp: 1708639794640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+  sha256: a53ad723826651041a5057a1cf31bc8689b24d335ce61b196df5124974b05a8e
+  md5: 7b29e7191c4170189d6080e61229f030
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311h08b1b3b_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9163911
+  timestamp: 1708639777712
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
+  sha256: 1c9f6902907a3d4a7e5c3cb02236491ea4c4e66a1a0ce51fa506dffb24ba89f6
+  md5: 36d514eca3c87ab75a1d418607e26db2
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=11.2.0
+  - libtiff >=4.5.0,<4.7.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 528528
+  timestamp: 1722872671997
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.15-h5eee18b_0.tar.bz2
+  sha256: f8a3dbcdabfad712311fdbec1fd49d44340818d348df5d90f420de133a4daeb1
+  md5: 4084456e619e7c2ab269f3cf2ff831f2
+  depends:
+  - ca-certificates
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 5499760
+  timestamp: 1725545717819
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-2.0.1-h2d29ad5_0.tar.bz2
+  sha256: b29f46d834ef22a9cb4a05cb241cb6881a69be8eb96fb643fa7edc192b46669e
+  md5: 68b0e862640c31c5f82def14794015b5
+  depends:
+  - libgcc-ng >=11.2.0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.10,<2.0a0
+  - tzdata
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1341122
+  timestamp: 1717104644619
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+  sha256: 280225061aeba00d7b85f46e55d7d79cd92c92f662dc749d9c53187978e8d083
+  md5: c51c21da68080d89300703ad818c824a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38606
+  timestamp: 1699371264464
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.1-py311h06a4308_0.tar.bz2
+  sha256: 78b2ec7956f036125c4cd56bd8b13642b952b43a54850c778bf87a664b86d0ef
+  md5: db433aded6b3b43ee3cb5d1df0008d2e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 156677
+  timestamp: 1720101925844
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.2-py311ha02d727_0.tar.bz2
+  sha256: b5979b0d4ef5c09f9795acb6b5e322b404f4eab7d73b6ed0aa59f03ef7acd25b
+  md5: 1a353daeb78baa6b5bf8f47e1e74ca1c
+  depends:
+  - bottleneck >=1.3.6
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - xlrd >=2.0.1
+  - xlsxwriter >=3.0.5
+  - python-calamine >=0.1.7
+  - gcsfs >=2022.11.0
+  - zstandard >=0.19.0
+  - s3fs >=2022.11.0
+  - psycopg2 >=2.9.6
+  - html5lib >=1.1
+  - tabulate >=0.9.0
+  - pytables >=3.8.0
+  - scipy >=1.10.0
+  - beautifulsoup4 >=4.11.2
+  - xarray >=2022.12.0
+  - pandas-gbq >=0.19.0
+  - jinja2 >=3.1.2
+  - odfpy>=1.4.1
+  - adbc-driver-postgresql >=0.8.0
+  - qtpy >=2.3.0
+  - sqlalchemy >=2.0.0
+  - pyqt >=5.15.9
+  - pyxlsb >=1.0.10
+  - adbc-driver-sqlite >=0.8.0
+  - fastparquet >=2022.12.0
+  - dataframe-api-compat >=0.1.7
+  - openpyxl >=3.1.0
+  - lxml >=4.9.2
+  - pyreadstat >=1.2.0
+  - blosc >=1.21.3
+  - matplotlib-base >=3.6.3
+  - pyarrow >=10.0.1
+  - pymysql >=1.0.2
+  - numba >=0.56.4
+  - fsspec >=2022.11.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17976832
+  timestamp: 1718310942026
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.4-py311h06a4308_0.tar.bz2
+  sha256: 998038e45884a19dc198675b2bedb22d871997c6cb1e6ebf0f46321c7f3b0cce
+  md5: bbcbcf863dc2295acdab40895df5e7ce
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.1.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21902532
+  timestamp: 1718119233499
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.1-py311h06a4308_0.tar.bz2
+  sha256: face211fc35bfa199b6d02f8ed25372d1f1a2093518a79a9eec9925bcf9e6d1d
+  md5: 9cd12fbc855d97b19427e911262e3bee
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 263218
+  timestamp: 1719348029519
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+  sha256: a2e2beff710765f2e5135020121da4f227f5e1cbe142e17398a585f50a389d37
+  md5: eaf734d49b6e576e12be1398a295643a
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - pandas >=0.19.0
+  - numpy >= 1.9.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 47447
+  timestamp: 1698702703255
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
+  sha256: 71beb7373390a7c5e9bf8663d64e2b0a426755fe68adb26ed72b6570634f635e
+  md5: cd7c1793b37ba076f8515b49dbd850bd
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3346886
+  timestamp: 1714657706306
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.4.0-py311h5eee18b_0.tar.bz2
+  sha256: 404620647ed8ef6cfd5f4a3ea14a982ab1f87c9e9484b3202610e38a9c73613b
+  md5: 8953ff4147f4390dc84111f324ddb8ca
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 999277
+  timestamp: 1721059535410
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.2-py311h06a4308_0.tar.bz2
+  sha256: 87422d1d2592abe99ee9a6c06f6653030567e88571a21edca9f4c1f2cd22ae07
+  md5: 806984470b5328d7fdb721b37ec2d73f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2913778
+  timestamp: 1723484664306
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pixman-0.40.0-h7f8727e_1.tar.bz2
+  sha256: e0f6c86339e683ea9e3f7e4ce743df653103209aedf995b5e674c148cb349ed8
+  md5: c197093127a4cca3bb3227aab1a68573
+  depends:
+  - libgcc-ng >=7.5.0
+  license: MIT
+  size: 645031
+  timestamp: 1632711422664
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+  sha256: d2bbab8bfc57c7f46ca8994bc87df7e744d3f036b867bc4be1145ba6d8d7e091
+  md5: de41707272a8e3ccab764f0b7010a27d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37394
+  timestamp: 1692205565974
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pooch-1.7.0-py311h06a4308_0.tar.bz2
+  sha256: 552e2ce394d0f4d85a56f6faeddf6467ad77c2f3a59d9b6d60247f18d48b53ad
+  md5: e243eec6f01d39b9631983145f297563
+  depends:
+  - packaging >=20.0
+  - platformdirs >=2.5.0
+  - python >=3.11,<3.12.0a0
+  - requests >=2.19.0
+  constrains:
+  - paramiko >=2.7.0
+  - xxhash >=1.4.3
+  - tqdm >=4.41.0,<5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105365
+  timestamp: 1695850161588
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/poppler-22.12.0-h9614445_3.tar.bz2
+  sha256: 8f21d62af3a7e705ae24b9ded761059881628e12e6c01c74418e39a6807a2b5c
+  md5: e6372c38e428c74b336b5ebdf8c927f0
+  depends:
+  - boost-cpp >=1.73.0,<2.0a0
+  - cairo >=1.16.0,<2.0a0
+  - fontconfig >=2.14.1,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - glib >=2.69.1,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libgcc-ng >=11.2.0
+  - libiconv >=1.16,<2.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=11.2.0
+  - libtiff >=4.1.0,<4.7.0
+  - nspr >=4.35,<5.0a0
+  - nss >=3.89.1,<4.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - poppler-data
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 20506964
+  timestamp: 1696000977217
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/poppler-data-0.4.11-h06a4308_1.tar.bz2
+  sha256: cb8da35b87b1a486e8bb35a8978dcedc93a6d3cc9f9909665267d5fe5d1f93b2
+  md5: 3e4df7dd4cb1e7fc2415c39951ebf4a4
+  license: GPL-2.0-or-later and GPL-3.0-or-later and BSD-3-Clause
+  license_family: GPL
+  size: 3894636
+  timestamp: 1673863550016
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/proj-9.3.1-he5811b7_0.tar.bz2
+  sha256: 62d73836cb5b538f9c31764054b78cddccdf7722daa0548902b0374ec3e93404
+  md5: 8906cd915a63a288c79bbe1f2f4d3937
+  depends:
+  - libcurl >=7.88.1,<9.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libtiff >=4.1.0,<4.7.0
+  - sqlite >=3.41.2,<4.0a0
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 3393252
+  timestamp: 1704728725084
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+  sha256: e2a0e2a618aa33f0beff9583c7dc510b8d0737b023117346676aacbad33970d8
+  md5: 66a6818307261b1a28ab12d1b7776fdf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 121454
+  timestamp: 1679340540306
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+  sha256: b7f591c19b10bf0daa7e6e3b45a9f4a0a0e83188e1f8a58037caea79e60f8d91
+  md5: d945b4ccc135005839c504cc29df1745
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 749608
+  timestamp: 1704404477511
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+  sha256: 96482b49191fdac59580a95e69508367083e1f7600145e11d7c2db634337eb26
+  md5: 2d57bf8eacf3f291db845928241f724c
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 490805
+  timestamp: 1679337420563
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-16.1.0-py311ha02d727_0.tar.bz2
+  sha256: c03ea46d8d60ff2aa84ae4270aeaee4c000ac4b83096b967d79fbecdfb4e9042
+  md5: 799cccb8b55193647f4f97afb478df7b
+  depends:
+  - arrow-cpp >=16.1.0,<16.1.1.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 5332213
+  timestamp: 1721664638084
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+  sha256: eb75b4417565d25e2d1006db75aa8bd9da6b6c72a929954b01a31b9bf5f8b42e
+  md5: bb56c0358b65665f4dd509a4635f6f3c
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37802
+  timestamp: 1676838557935
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+  sha256: ed927e4d058a8f4ea73edc7a43ed74877d93b88fdfa240b3b2777244386ced70
+  md5: a1f0e05fc7e49712f81ad5478ec9d51e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2121496
+  timestamp: 1684280065800
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.1.2-py311h06a4308_0.tar.bz2
+  sha256: 9a1a3ae9707592f3a3ca830ec425b5f9dd82c467f66dc793cb73f43016e2166d
+  md5: c40a13571a56f0548f7b610e1734aee6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 459429
+  timestamp: 1725041741531
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyproj-3.6.1-py311h76fdc58_0.tar.bz2
+  sha256: 082852b55bcaa6f2c57262c9c3805f004dd9f83e28004186a177ec42af90829b
+  md5: 9e827c7b7763816e3d777d1680091ee0
+  depends:
+  - certifi
+  - libgcc-ng >=11.2.0
+  - proj >=9.3.1,<9.3.2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 643692
+  timestamp: 1704901597067
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyshp-2.3.1-py311h06a4308_0.tar.bz2
+  sha256: a2137cf7b9f2b4946913c31d2fb29ff40c05b5efb452111377493eb4c9d4beae
+  md5: 0da47478156b41225fbc4f2fe9fa7421
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 85675
+  timestamp: 1706101026788
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+  sha256: 114b55e00f4622c90fd2b404b21ad5f94a10283fcaaf86a42174b8d39b0a3e98
+  md5: 2458e92683cc68671a6c8e1b86ce8817
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35850
+  timestamp: 1676822725516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
+  sha256: ef622eb34669f3518d2f855cb333c56b106d02cdeac9d58e5a1a5a3097e4978d
+  md5: 9d4f211d050d511b0b84c2e57e7fb1d7
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.35.1
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 36072860
+  timestamp: 1713546307595
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+  sha256: a0f008717fab060ccd003dfebc09156d90b9afd14ac3626566aa1a8f3d3b7e2f
+  md5: 357bf4fe94496cbae72ab4d780184b31
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 330924
+  timestamp: 1716495762901
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+  sha256: aadc4078311c059265706a56265f0a57ceb538d36179d5203dd487d80d0e8f16
+  md5: 59ec670fcd172447dbd9591b8fbfdd56
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 278741
+  timestamp: 1679340144625
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+  sha256: d5058d0ecc3973316c1d5f1bfb03dd119e0dade85f4c2d21b412c8db4e1636f2
+  md5: 93000e4d3603342779a2afda66fa91b8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17607
+  timestamp: 1683823841946
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py311h6a678d5_0.tar.bz2
+  sha256: d9eff881e112d0b326d0c1ee0d42d6c2c4649b1c4edd168be1006f28f1f8962e
+  md5: d9d1f41dcee9b622cbfe048ab1632a47
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 154074
+  timestamp: 1682522389521
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+  sha256: b85acb933fff864bfa89d034e8e3d85b1a9c2e69cbfc0d68c1d66ffd1443e67d
+  md5: 0cdb92d2d684ee1095310f992ed0d9b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 266796
+  timestamp: 1713974338678
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+  sha256: 511e8206a15445715b80be76493300930686b3fe1e512ae942d6ccca36df392a
+  md5: 35a6e46ae970f8b71d78fb5a810f2e80
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64013
+  timestamp: 1711136926372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+  sha256: b2a1f649669f4336b74f6f20df711959bcd8024f8f8b94199dc0e040b06bd37a
+  md5: f9e8e3f7068f717f75e555dc04545d8d
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 206433
+  timestamp: 1698096204677
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+  sha256: 7c74db4292f31619606180f86f3c1e2d913495c2c9d1195c5d51681a6a841625
+  md5: be1c05fae57d194924b9400f9b5ad3c6
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 613277
+  timestamp: 1709318516682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/qhull-2020.2-hdb19cb5_2.tar.bz2
+  sha256: a9fce407d219dca8f61be8aab0837b5fb2642b8242965955fbdee7d880d00a82
+  md5: cb376ee332d02c7e7b10bca9ec74cff5
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Qhull
+  license_family: Other
+  size: 1990101
+  timestamp: 1670915839713
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+  sha256: 8a640736bef635346409582dbfe2b7d0ecc9da215c90173ff8a9a5fe22569107
+  md5: 6b583dce61c6feb352ef0f49f413af1e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-3-Clause
+  size: 235004
+  timestamp: 1652449537852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+  sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
+  md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 467661
+  timestamp: 1666648052561
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+  sha256: 89c2f4235277b9825cc805c5c44f0b1afcb683d7b5a3f513bc4bf243b643bb0c
+  md5: db70eb57e33adf7b8bbdadd72214d48d
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 73679
+  timestamp: 1699012111499
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py311h06a4308_0.tar.bz2
+  sha256: 77190094130d6db30f7422a6764d649b1be7e5e6c405a16fe83704d108ffdb02
+  md5: 293eada1e1224fe07130acf2f8786f96
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 123275
+  timestamp: 1721410959361
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+  sha256: fdae3f68ea84b99561aee6c566ab1c287d8f2ae2668424e9283a8ed86af8f1d2
+  md5: cde5b71ccbb3630053340b2c8c7dbf10
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9333
+  timestamp: 1683077183576
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+  sha256: 0bf859b06a07857099fd4f524fe5e0875fda70029e9485d95c7efa97134fbc14
+  md5: fd5815cc592fdbd4c831901541eadaba
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 9735
+  timestamp: 1683059096795
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+  sha256: 474553d01aea57214a54a7443f227da84a58e29c49eb7605ba0043c55b7d167a
+  md5: f01333e9f0a908e435db650f42fbd2db
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1096668
+  timestamp: 1698946168635
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rtree-1.0.1-py311h06a4308_0.tar.bz2
+  sha256: c7fe463fd96308054c7c01aea3fb92adcb226b161147e1ff8001b574fed6acb2
+  md5: f59a6905f6488c2e539954eff64ebac5
+  depends:
+  - libspatialindex >=1.8.5
+  - libspatialindex >=1.9.3,<1.9.4.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 63080
+  timestamp: 1676845705413
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
+  sha256: 8c8aa1eb7e215984f46c8e1c7cfa6e5e6b233993d92b835a9b1b5491a4b970ab
+  md5: 6e145b179adde03f8aa8a066c58d4e31
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.12,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 380702
+  timestamp: 1706563445897
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scikit-learn-1.5.1-py311ha02d727_0.tar.bz2
+  sha256: f753049fe5343e75a3a0bb323a2d375a2aa6fd4ae5e3b6536c5b9b8ad6a9fdeb
+  md5: 6fe5c19da4120d3a0c5333a22a21a863
+  depends:
+  - _openmp_mutex
+  - joblib >=1.2.0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - scipy >=1.6.0
+  - threadpoolctl >=3.1.0
+  - libgomp
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13381006
+  timestamp: 1721922162600
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.13.1-py311h08b1b3b_0.tar.bz2
+  sha256: be007cd7f5b114338573fe55aca47ea0e8c9e17e3a47a2df23619fa723c76b8d
+  md5: 13dbfb86ab689d288a7cf4c2d649c608
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libgfortran-ng
+  - libgfortran5 >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 4
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 27601481
+  timestamp: 1717530680610
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+  sha256: 51bcea0e575a626f6ffbd16d1153330fda93dbe3dd31dcd3a8f469ff61dd1e4e
+  md5: 41d531c90be8c82bf79635ff3d409476
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 32295
+  timestamp: 1699371262818
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-75.1.0-py311h06a4308_0.tar.bz2
+  sha256: 0012d33e169b495c9e289b185ff8d4192b93711c5dfc514b0c5efc536ea9600b
+  md5: 360f44ea616167b2c61cced23d0db311
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2311301
+  timestamp: 1726677958012
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/shapely-2.0.5-py311h24a2a10_0.tar.bz2
+  sha256: 76a2754449f40d4eae17b833dc1277fb1aec71dd3d823bcc247e796a713081ca
+  md5: 2e0ad2746f7361fab3b6d1d3b5adfdb5
+  depends:
+  - geos >=3.8.0,<3.8.1.0a0
+  - libgcc-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 616599
+  timestamp: 1722533261135
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
+  sha256: 8fd98235b37194986a5eb663c95a4a6db8c9e20a627f5c79ff8d9be3fd0e36f7
+  md5: 25ac00d957eda056675f8fa3eafdf6df
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 52749
+  timestamp: 1723557449203
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+  sha256: 1a84b00944bc5588e14a097460175f97df49acb4f1ff2498ffd9a1893068ed81
+  md5: a456513471b2ecbed60430c21dd1ccc7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17880
+  timestamp: 1705431390054
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+  sha256: adcafd297d60af64107c113bb7b8b92160d0268a44ef9a3b79e56a88a0358ea7
+  md5: 28ed704ed26b06d32662e3a6a87e59b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 88799
+  timestamp: 1696347581401
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+  sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
+  md5: f86119b3243fe3508160aa0406245738
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1723866
+  timestamp: 1714488309729
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+  sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
+  md5: 041a3caf09dc9ce8fc6c10925c4fe050
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1888016
+  timestamp: 1680167274961
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+  sha256: 856a8ab8c350c50247b79966c6cb80fb6d4de36eef49ddf75aebbbcaf854c82d
+  md5: 442dde204d14d171aab9ee40e8de4de8
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37456
+  timestamp: 1677696176157
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/threadpoolctl-3.5.0-py311h92b7b1e_0.tar.bz2
+  sha256: 77809e578fdb2dc8fd23d79fc0621fc21cd47744f2520840313ef932d2952186
+  md5: e49154b5b9fa725eccea9054f7ceeb33
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48858
+  timestamp: 1719407853019
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tiledb-2.3.3-h77177df_3.tar.bz2
+  sha256: 82c260e172d37e76f89069acf987900af72acfcf1c3332890db97bf8e443507f
+  md5: 705ac1e0f32ace2777ed7dfb03873197
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 2940076
+  timestamp: 1685656926819
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+  sha256: f0a026ddc0ed041bfc60c8a1ca0b70b7a69232775b3181bfb35a39fda42d6994
+  md5: 2902d5a5854865baaaf58dc59cf06b3c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49185
+  timestamp: 1676823769869
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+  sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
+  md5: e2512d57c8a1e91e7b20e265c6906546
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3588922
+  timestamp: 1714770676475
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+  sha256: e58ff4a82819446f3c92e5b1aa2a784c4b06643e751fe67cf115858296dbfa50
+  md5: 32ee4723173f1fad5563b8afb5f1c8f1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135634
+  timestamp: 1676827536101
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.1-py311h5eee18b_0.tar.bz2
+  sha256: 394fdf404ede3bc35d697b2e445c42590ddcae86a80f39642cc5366196fcbe54
+  md5: a21cbca0664d8f34b0dca1f84998a31b
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 914199
+  timestamp: 1718740165334
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.5-py311h92b7b1e_0.tar.bz2
+  sha256: dab820faa313d62b44014841409cef89a49dbda9a7697689ce37b3032ec3276e
+  md5: 1d6513a5b915465291fdb2041815bdc6
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 154437
+  timestamp: 1724854032868
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
+  sha256: 2091b17ae4fa46ed98fd6bfe9ca1aff3b0b81d73045e0cc55774b6516b8704b3
+  md5: 183ae7b837c1c68ec1a8011011fadea7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 206924
+  timestamp: 1718227183177
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+  sha256: 8c06c291c76e8c2022ffbb9fea4727a4bf1f9b03e498bafc56ba8ac4e7604ab9
+  md5: 5adb7baf1091d09026a372cac930ce6c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8869
+  timestamp: 1715268966416
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+  sha256: 118b0801167264c401e84bbf19175546092a5569cc098146f7362bbf890dc8d9
+  md5: b3c2aa56d53b459f8365d8385f48d0c3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 74489
+  timestamp: 1715268960737
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+  sha256: 509b962773f0fe44a93a7f6196b254670a030eac8ea7f90727312e3ccd9294b2
+  md5: 6c402d5bf4e01c8c3895c9ef41707b6e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11371
+  timestamp: 1676828901104
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+  sha256: bbe7629e8ce52c82f13ed0d1fb919f3659ef466b274a7c74aa925a9bc7aee450
+  md5: 7da527bbcf71270c1abed8ea52e7d44c
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 509031
+  timestamp: 1713213062098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uriparser-0.9.7-h5eee18b_0.tar.bz2
+  sha256: fa1281c13f5c8d18b36bb69705e4cd632ccc456b603f27ca63f68a787d03b0be
+  md5: 48e34041c9a0bd924018a6fab5d167b6
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48752
+  timestamp: 1692186947656
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.2-py311h06a4308_0.tar.bz2
+  sha256: 2de4e4586d3b1cbfa8ecfcfaaa148da3b005b303e0784be2d6c2e54a3a13d362
+  md5: 3345015e0af00cc31acb88167a842381
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - zstandard >=0.18.0
+  - selenium >=4.4.3
+  - requests >=2.26.0
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 209169
+  timestamp: 1718912749915
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+  sha256: a8d11b0f08217607b99ba560edf66423ca1e36f4ffbb6e2377e61670e2b5f36b
+  md5: 431e82b081b08aef0259df0437e04c75
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 97535
+  timestamp: 1706894675990
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+  sha256: c3a5e0b855dc2de6c162708dfcf170a23eb9e7525d4252d8dce553369af4a330
+  md5: a4c77e204b7787f820955166a1283168
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25890
+  timestamp: 1676823132898
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+  sha256: 42989f9970a8466cc4edb73463dfa194594dd1a5d42c9f820a1f86296d4af140
+  md5: 655dfd4d2f17977cb81caa1c082d2b25
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 113505
+  timestamp: 1715878346465
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.44.0-py311h06a4308_0.tar.bz2
+  sha256: 3b258ad0db82572157a72303bbd5c20399d0c7f3b48abc1435ef96e4517e59f7
+  md5: e11eb90c0ee1084a95cffe231196d98d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 138218
+  timestamp: 1726165052578
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+  sha256: 85248e503721da67797546cb8a22e303c1739100834b219c5621f216e3794e8d
+  md5: 2570956643f22d0f809b2467e02d3984
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2465865
+  timestamp: 1689041600364
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xerces-c-3.2.4-h6a678d5_1.tar.bz2
+  sha256: 02af202ca1131410fcf233d540a5875fe98a9c78c0af202e4258b50cb279379a
+  md5: f3f2648851cde3a44093a5788fa6b585
+  depends:
+  - icu >=73.1,<74.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3621933
+  timestamp: 1692994759691
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+  sha256: d18cdca154bf668826f869117ea996c4f9e8ef7d27b7c528332a7d17e5a8602c
+  md5: 9f7353d72046b16dd6ef6b5689ac9bfd
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54731
+  timestamp: 1676828934954
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+  sha256: 9122d6e9dabb7a47f2bcb15d86b97c96c49a9048da3f8ae59675351710c14cc5
+  md5: 660b2aead2ec87b751c86cd33934f44e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 716926
+  timestamp: 1714510796277
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+  sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
+  md5: 943f1247a22b6b64171363bcee1eec27
+  depends:
+  - libgcc-ng >=11.2.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=11.2.0
+  license: MPL-2.0
+  license_family: Other
+  size: 371663
+  timestamp: 1705602144682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py311h06a4308_0.tar.bz2
+  sha256: f33ed759a551e2cd64115a3b01af0fc9822b1a5a1a5c798aa0ee14292792d7c1
+  md5: 7feb38e587b3352efca77df1447858d2
+  depends:
+  - heapdict
+  - python >=3.11,<3.12.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102106
+  timestamp: 1695832995689
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
+  sha256: 7aa781d0850f97622755ed44772d2b215b253a8e211aede5f3f53e1b95b4143a
+  md5: b1d8823f50228d4efb7b7a6e267ed776
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 24333
+  timestamp: 1704207043644
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+  sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
+  md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Zlib
+  license_family: Other
+  size: 127143
+  timestamp: 1714510716441
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+  sha256: af3c032f06352e87c450739cb8aafe1ff34ad28bf074b214ea98b3d29259a85d
+  md5: 51fa34bd0e016ed7c5371cf6cb13ef6c
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1044463
+  timestamp: 1714678445052
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+  sha256: c0dd89ffac001588171152a285ddbbaea209ebe4116010f985f898b7e87c2f35
+  md5: 731ae7d446633bc729f3493a52d4365b
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 43502
+  timestamp: 1721748373551
+- conda: https://repo.anaconda.com/pkgs/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 159043b22b754bbfd41d70508ef60a42e3e0f74ebaccd4633726bcf944ab4249
+  md5: 86fd637d64a91d9e916f19f349d45a97
+  depends:
+  - click >=3.0,<8.2
+  - python
+  license: BSD-3-Clause
+  size: 10095
+  timestamp: 1630665910221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
+  sha256: bd00b5f84c5fee1a4f252c26d6575a93bcdc5e71832270685e002bf78b2f4eba
+  md5: 7c9691bb77e3f20cf12ded06388b4aad
+  depends:
+  - click >=4.0
+  - python >=3.6
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 10160
+  timestamp: 1622563293746
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 9de8666e5b70aa2437737128eaa14ffe80a7b5235c2a6b7d3f39ccefd7816ba0
+  md5: bb52e50c5ab1a5c7778c11376404dfdb
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 7933
+  timestamp: 1630598543551
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+  sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
+  md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
+  depends:
+  - prompt-toolkit >=3.0.43,<3.0.44.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5106
+  timestamp: 1704404390460
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+  sha256: 459f38609d854888998a8d76028019dbacdce2bfe401eab57b8eb8ff16da9c7f
+  md5: 2948a98ef4de5decb7e5eb888eae68ba
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13056
+  timestamp: 1682965564630
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
+  sha256: 305e5fd9993f3e5506f386f98794c7d53b6e6c68d4d411ada724de49a17945fa
+  md5: e1fbbd2d11d21aaec3c32f7d332c0e77
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13818
+  timestamp: 1712163766707
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 4e47f6c49ce84509f1466e8a4d728447bf4bcd9bce7b456431a789a262547067
+  md5: 4cad993b0f80bc23fb66a97592299cbb
+  depends:
+  - python >=2.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 26504
+  timestamp: 1623949147884
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+  sha256: ca2be6c7810a37cfc6db1f5383937b5d35c6d73c1fad8a9104de85f069b1df1c
+  md5: 9ccb2fb33edb152403d6ef32bf758a9d
+  depends:
+  - python
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 15614
+  timestamp: 1629402049497
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+  sha256: dc9f709bacbaf08a0941d2622d82f91f18b355e82c55348ec29f1391215ca7e0
+  md5: ece0f5837a4de2d4d5f1abf8347cd10a
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 124922
+  timestamp: 1708711884650
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+  sha256: 5800a2466734dd1ef372bec0dd3f0880c5072fa1e8b0668f5054f834285e991c
+  md5: 18194e51d4420ac08f29f3f86581b52e
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 229003
+  timestamp: 1706220302459
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+  sha256: ab7672364f1fa55ec5d8311d85d40e5b57cbd3517b17670557b6fb822bcf759c
+  md5: 6e0159a5865cb7e96a748bd8560035ee
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 11579
+  timestamp: 1678317458652
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+  sha256: 51556902e09436d46878ef772805d06416ca96ffaa66340b5565c0245574aaf5
+  md5: 4cb1b20635cf5431d34cc96ca1e8a751
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 33355
+  timestamp: 1678317111825
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-16.1.0-hc0a701b_0.tar.bz2
+  sha256: 27c6aab156b0419ea51b4c46361305d578e28ede4e0dea7134e5bcb059746ce3
+  md5: 3077e97632019a95156a6e2426a5d5eb
+  depends:
+  - __osx >=10.13
+  - __osx >=10.15
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - aws-sdk-cpp >=1.10.55,<1.10.56.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.5.0,<0.6.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libcxx >=14.0.6
+  - libgrpc >=1.62.2,<1.63.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.14,<4.0a0
+  - orc >=2.0.1,<2.0.2.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.10,<2.0a0
+  - utf8proc >=2.6.1,<2.9.0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 10676019
+  timestamp: 1721659474232
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: 188b74f717e3ce3595da404c0e027b8ccafa9c186e88325e8f02c29d7b4c0744
+  md5: 04ad90eead5812a0263b42321056ab33
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153694
+  timestamp: 1695717975427
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
+  sha256: a153eee37b30ca5c25c5c95463a8852f1cf62a8f45f73349e68f1e3b22eec6da
+  md5: 4bf760fad0e938618391f0db249d00e1
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 87236
+  timestamp: 1706746160841
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
+  sha256: 04ec5908b1dc2979ed50923af90d02da8a60434658efbc4f35fc61e7e9cafa0b
+  md5: 6ba283b7f902226f232fe8a32fa83ee4
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 37547
+  timestamp: 1706690917050
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
+  sha256: 08431c5ec5f0a9e95819b6a76c9cc870d2154e46b229431fd0b3dad25bb70b04
+  md5: 78b4b4225fdefef0b9b0d56b6e51e4a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 184146
+  timestamp: 1706189913777
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
+  sha256: 6a78705375d837a0eeeff9e914aae53a0d2cd44e9760075bdd8711a05f94ff3f
+  md5: 931b0654ae05bcd1acc760dc830b89d3
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 17410
+  timestamp: 1706690854689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
+  sha256: 1d468f7c085b73cc40f813885d77a74270f94dd973b4285546d8873030fcada7
+  md5: 3a61760bb61f85b3a0ffe7b14058801f
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 46197
+  timestamp: 1706697276616
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
+  sha256: b53432aadb2ffe2f1c584c6994b665f3620f29c51b200b03282065a480cf021e
+  md5: 9686f32b210a009048c0877ac39fe88c
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-compression >=0.2.16,<0.2.17.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 164397
+  timestamp: 1706744140750
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
+  sha256: 2ff9632eb2e2c7a70b8d64988e530d842fe5fa7fa529d34cda19f76fb40582e2
+  md5: ffbd1ff65fe9fb52d833af5d396b006d
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 125589
+  timestamp: 1706696187075
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
+  sha256: fa57f1d2b2eb56db72e4b54348452af67a1222bd4266b3d68c7b7ff00399743b
+  md5: ae9e78f6b1fef841fc0ffc7ef7c78d26
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 61379
+  timestamp: 1706746740037
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
+  sha256: 00834bd876756f1f13333c31623c2bdfa7d901b40aec161cf0343548fcd96187
+  md5: 4ef080b5a91e260d51d563218396d0f6
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 67408
+  timestamp: 1706747579372
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
+  sha256: fb3198a05c96030d8498a5c4873e56ae28a5b04fb904a5c696a2192e9ee6c45b
+  md5: 48efeda1471a50b9481c3943a0300e86
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 48055
+  timestamp: 1706690833951
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
+  sha256: f05fb72b1a5f25fab65ef416ff0d1966e3ff84f8a08c56bf809fb602028c66ec
+  md5: 86cda3f774047ff6b40eb14aab83215d
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51354
+  timestamp: 1706192066535
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
+  sha256: b8cb5f96e9eab47419622795fcdb42ad414481db9b84bbb50fcf8251a1314b59
+  md5: 335265dfe12cb6adcacf39b411cf9d7a
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
+  - aws-c-s3 >=0.1.51,<0.1.52.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 210312
+  timestamp: 1706827788950
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.10.55-h61975a4_0.tar.bz2
+  sha256: 40911c99dfa11ad32d451ab8cb5b24f0aecde231b5f8f4e9d8887bc4a720dc65
+  md5: 1078cfa7cb12f9a0d3fb4017cc9789b9
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 2322692
+  timestamp: 1706890560060
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
+  sha256: 365824e639808e52809f97b70b65da94a5eeb87e29dd97c8926aa72707a5a1c7
+  md5: db7813418dfe42d59363fed4a68d5c36
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 278195
+  timestamp: 1718029905185
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
+  sha256: 695ac69739e73351dfebfb01ea39c5e1dbfdcfb475590d6560ae318bfbad3a97
+  md5: 38fd73cba341639c45d8c747b08c9cc1
+  size: 49130
+  timestamp: 1528225884020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
+  sha256: 3699a260f422443de85b74084fe36f734be1a466eeebdfdf4195d52c9fdb5508
+  md5: 132d056e66b3ae9148f53819f8368c94
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - zlib >=1.2.12,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 66125
+  timestamp: 1675247668924
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.1-py311h85bffb1_0.tar.bz2
+  sha256: ace9b81e898a3180d2fb07c75326414ec4cbaed62efff54e42feb6d59774ccab
+  md5: 1aa0dfcb172854f56447096c70d6a005
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6076891
+  timestamp: 1718119694797
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+  sha256: 81102f2762d8eb2f07c69fbf7ca7dad879a257a053085492d4c1b4006eb35fb8
+  md5: 3c42777bc9330fe91177ea813b9ec252
+  depends:
+  - libboost 1.82.0 hf53b9f2_2
+  - libcxx >=14.0.6
+  license: BSL-1.0
+  license_family: OTHER
+  size: 11744
+  timestamp: 1696762233693
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+  sha256: 9acafafcaebd653c2372ddc864525722e1c55b884b5eba22e28e2b2d946b853c
+  md5: 22375cc3c2edada31b85af56c8e6dee6
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 155829
+  timestamp: 1707864406086
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/branca-0.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 054255ffd71363f6f36db8abfe2f56785c1bac9d9731e6d0942a7a0a4c89fb3e
+  md5: 8441be15714bfe4388f092e61ad3228e
+  depends:
+  - jinja2
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 53523
+  timestamp: 1678390549095
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: d8b1ccb15297dcfb3f9ebb8139c3e28a13d6c2e73c37612cb214ab6cc58b15fa
+  md5: e5dec9f13de061640ad2697562a99b54
+  depends:
+  - brotli-bin 1.0.9 h6c40b1e_8
+  - libbrotlidec 1.0.9 h6c40b1e_8
+  - libbrotlienc 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 19732
+  timestamp: 1714483415038
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: e9fda4393edd0234c88efc2b88e0edf42c94eb49ea5b189a80afd733058be8fb
+  md5: 13ceed558eb174d6b77ed1b0035f1785
+  depends:
+  - libbrotlidec 1.0.9 h6c40b1e_8
+  - libbrotlienc 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 18400
+  timestamp: 1714483395748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+  sha256: a323af3251e426962ad16edf8f46a696ef502731faf12aee32ca289c40b11342
+  md5: 658ce49e9f07dba7a1afe70fa2666e0a
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 393858
+  timestamp: 1714483549536
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+  sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
+  md5: c5a600d81b1b48578863af2973c743ac
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 187637
+  timestamp: 1714510590009
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+  sha256: f913b61ba3c1651b36688415cc163a5d575475f7573b543f48a80e7a5002e4bb
+  md5: f11d165eaa532ce04a35382841284298
+  license: MIT
+  license_family: MIT
+  size: 107047
+  timestamp: 1693902034820
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.7.2-hecd8cb5_0.tar.bz2
+  sha256: acc856860d2eb136b4a1a997634997b9b01929e6b22675eff544d13576b08a01
+  md5: 48b25ae3137cd9a822762c3f1c560881
+  license: MPL-2.0
+  license_family: Other
+  size: 137928
+  timestamp: 1720622036783
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cairo-1.16.0-h3ce6f7e_5.tar.bz2
+  sha256: 40610c1f84d17423e18948662190fab696d55b974b44c0e81efc8b4a18c74377
+  md5: a562993d973bb938743ff338502108d8
+  depends:
+  - fontconfig >=2.14.1,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - glib >=2.69.1,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - pixman >=0.40.0,<1.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: LGPL-2.1-or-later or MPL-1.1
+  license_family: LGPL
+  size: 1434523
+  timestamp: 1688495924565
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cartopy-0.22.0-py311hdb55bb0_0.tar.bz2
+  sha256: 42201ad67348e8d64bad9b17439c124058199fb5468dc6bb65ab736f91fbba8e
+  md5: 8aa3ca392fa7b61229467604c2732826
+  depends:
+  - libcxx >=14.0.6
+  - matplotlib-base >=3.4
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20
+  - pyproj >=3.1.0
+  - pyshp >=2.1
+  - python >=3.11,<3.12.0a0
+  - shapely >=1.7
+  constrains:
+  - pillow >=6.1.0
+  - owslib >=0.20.0
+  - scipy >=1.3.1
+  license: LGPL-3.0-or-later AND (OGL-UK-1.0 OR OGL-UK-2.0)
+  license_family: LGPL
+  size: 2088551
+  timestamp: 1706196555989
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.8.30-py311hecd8cb5_0.tar.bz2
+  sha256: acb2effe5ccd14a94eaf0dfe268f6b7f13165461ca60f24b8dab007259200b12
+  md5: 07e08081971e9f8255e5c4cbe19edf47
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 170244
+  timestamp: 1725551715047
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py311h9205ec4_0.tar.bz2
+  sha256: 8b66e37770f89a68ef4d7a70787720c300793e05822038379fa4068e7197fb2a
+  md5: e1f7832dcc299bc8f5069e90f7f8cc00
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 293031
+  timestamp: 1726856737247
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
+  sha256: 68a12eaeda90c9cdbce729f0d44d222c3f60ec4920bb781bf13fae3a89cb3dd1
+  md5: a0970a5c1c77125369aded2d4e25f870
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=7.82.0,<9.0a0
+  - libgfortran 5.*
+  - zlib >=1.2.12,<1.3.0a0
+  license: Other
+  license_family: Other
+  size: 1437665
+  timestamp: 1655814938182
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cftime-1.6.2-py311hb9e55a9_0.tar.bz2
+  sha256: 93f384d46e7938d7e971a4b556707f8beb2f1e62d5684e7cb893a6965aee4571
+  md5: a6e1483f1a8157e872dce8f5f4a213a3
+  depends:
+  - numpy >=1.22.3,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 223790
+  timestamp: 1679335421858
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+  sha256: aceaa74365b0d8e69c817639393df3a713a802f40645ac0bd2f39adc871acf54
+  md5: 52191c9d4f4fcaeea39574819ab2f14f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204365
+  timestamp: 1698129979494
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: 6289468ac6d509d11f928e80005c27fcc169be379c9714f839c305949fbc22af
+  md5: 851f577d81bce100ddf9c11ded38da06
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43158
+  timestamp: 1721657395305
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: 9270668e34b00a2605584a2db5130c83826855cd05b896ce949f3156fa197429
+  md5: 2586aa55677e822e8285d777f9039ca9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 543487
+  timestamp: 1709758497949
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: 389c63a84b92a6254c9d361ebe970d537d0b88733efd5ac5c3ee58196fd2c5a9
+  md5: c7bc5b3cbe76be83a27f00b7e4740727
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17974
+  timestamp: 1709323004148
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+  sha256: bebfc5aa6be12e61a134b580b07b67f7d8c045d6b113fca5b21fa1e83a2f03ce
+  md5: 239df72a3921c951059fa8afc09643f6
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 287736
+  timestamp: 1700583644534
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.2-py311h6c40b1e_0.tar.bz2
+  sha256: fd7bceb92f6c43c6b064a1258a33c441b3b39cd08883cb73204f8d0692b709fc
+  md5: 37f8b661d31327b8dff70a4cfa63cd5b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 390733
+  timestamp: 1701729666753
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-2024.8.2-py311hecd8cb5_0.tar.bz2
+  sha256: 0e4e4aa9b6d7b2a8781b98cf68d2754672eb6404fccca96cd43e2488448edfd5
+  md5: 14178f9fc5a4fea048d521b715f3f52f
+  depends:
+  - bokeh >=2.4.2
+  - cytoolz >=0.12.0
+  - dask-core 2024.8.2
+  - dask-expr >=1.1,<1.2
+  - distributed 2024.8.2
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.24
+  - pandas >=2.0
+  - pyarrow >=14.0.1
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6339
+  timestamp: 1725525026440
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2024.8.2-py311hecd8cb5_0.tar.bz2
+  sha256: 3ad77286d59361920bdfe9af6e71d7f31cada0e56b1c1ee0731a0b560bc16d92
+  md5: 31e739e79d93b568735a7db5cd201f52
+  depends:
+  - click >=8.1
+  - cloudpickle >=3.0.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.4.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3118893
+  timestamp: 1725461414545
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-expr-1.1.13-py311hecd8cb5_0.tar.bz2
+  sha256: 17d45edd99520c4f9ddfb8e97a2bb0833f2a939d4c158fd41b6f85b85dfe2284
+  md5: 56a7c77c19b3ad5ecd2c18f2a69f461c
+  depends:
+  - dask-core 2024.8.2
+  - pandas >=2
+  - pyarrow >=14.0.1
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 567529
+  timestamp: 1725523260810
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.16.3-py311hecd8cb5_0.tar.bz2
+  sha256: 9aaeb2715d1c3de8096c489b52ecb4c71d7341ee75bb5c3ace77c50c918ec5d4
+  md5: 05a98a96b9cccb007768b87c11e92b7e
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy <2.0a0
+  - packaging
+  - pandas <3.0.0
+  - param
+  - pillow
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18011437
+  timestamp: 1720534043633
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+  sha256: e0e30590a78d99d51445ac4f668aefe1bf20025a35bdbac00f04647b95c9f152
+  md5: bd0db635eefeea82a0c567b39c9a0e3d
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2485698
+  timestamp: 1690905283575
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2024.8.2-py311hecd8cb5_0.tar.bz2
+  sha256: 2b998b9a1e6adbf62b2fdac9c43ff01eb1a7ea419d5bf74e137aea2e8c9f4ef5
+  md5: 1b1cdc4f3aa302ebc27189d4d3e70878
+  depends:
+  - click >=8.0
+  - cloudpickle >=3.0.0
+  - dask-core 2024.8.2
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.2
+  - packaging >=20.0
+  - psutil >=5.8.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.4.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.11.2
+  - tornado >=6.2.0
+  - urllib3 >=1.26.5
+  - zict >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1821812
+  timestamp: 1725523177887
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+  sha256: d48b47b86b09dac1fa4542ec13e1bd4e23093638e684fa66ec3afdd9ce9337c1
+  md5: 5a2d1828ab7c8eccd3c2610d13672977
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17336
+  timestamp: 1678316187749
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/expat-2.6.3-h6d0c2b6_0.tar.bz2
+  sha256: e8786ba870f6f10e61b8314326799e0444f43b847bf048ef66c637d884043d54
+  md5: 1bee23775ed30c66271a6597f02496ac
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 161686
+  timestamp: 1725543368296
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fiona-1.9.5-py311hdb55bb0_0.tar.bz2
+  sha256: 2fffd781f3a809bfa4cc1c01b663d40188784681274f82e431bf775e33ce1e89
+  md5: d5686ab4bf4cb41246cdeb7cbbbe9662
+  depends:
+  - attrs >=19.2.0
+  - certifi
+  - click >=8.0,<9.dev0
+  - click-plugins >=1.0
+  - cligj >=0.5
+  - gdal
+  - libcxx >=14.0.6
+  - libgdal >=3.6.2,<3.7.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - shapely
+  - six
+  constrains:
+  - boto3 >=1.3.1
+  license: BSD-3-Clause AND MIT
+  license_family: BSD
+  size: 1174208
+  timestamp: 1704921471416
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/folium-0.14.0-py311hecd8cb5_0.tar.bz2
+  sha256: cf37efa8e371f0792d203309f571ab9c923ec10de4da2a4fb7163aa76e86fd0e
+  md5: d392fab032965fa4ea1fd599e9eaa3f3
+  depends:
+  - branca >=0.6.0
+  - jinja2 >=2.9
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  - requests
+  license: MIT
+  license_family: MIT
+  size: 135501
+  timestamp: 1678411970047
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fontconfig-2.14.1-h269ac6a_3.tar.bz2
+  sha256: c05a2895ae7758e77eb03ab269d3181461de6909dbf93426bb2e580245230cc6
+  md5: 1f34b1ef1a777b25daa69662f286b4bd
+  depends:
+  - expat >=2.6.2,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - libxml2 >=2.13.1,<2.14.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 281575
+  timestamp: 1722921216503
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+  sha256: 54645c22fabc25b632114d1d3c403a6fad9149b51ab36719b2690a084f14a072
+  md5: a8ad2f4abfb2e17ecf6e596342528156
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lz4 >=1.7.4.2
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  license: MIT
+  license_family: MIT
+  size: 3180691
+  timestamp: 1713551771692
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freexl-2.0.0-hce1ea5d_0.tar.bz2
+  sha256: 808936cc4ce749d1000a98a23d294b8c3f5acab0d729f2ea623103ea2231980f
+  md5: d7ef6a25e5a84f2e53545815074dce21
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - libiconv >=1.16,<2.0a0
+  - minizip >=4.0.3,<5.0a0
+  license: MPL-1.1 OR GPL-2.0 OR LGPL-2.1
+  license_family: OTHER
+  size: 62266
+  timestamp: 1704742027454
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.6.1-py311hecd8cb5_0.tar.bz2
+  sha256: 4316287b920b446149e5adf3519d12089b0c9ec49a8c1c802eee81c92d80132b
+  md5: b52775f876eba6074e08a4d65328fad0
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - pyarrow >=1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 383995
+  timestamp: 1724855682674
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/gdal-3.6.2-py311he4f215e_5.tar.bz2
+  sha256: 90644d91b92a8f6b27dc28735e0b6020997383761097d409e262057f29db5a8d
+  md5: 198ec689ebc32880f14617ff37b43c2d
+  depends:
+  - libcxx >=14.0.6
+  - libgdal 3.6.2 hfaf651c_5
+  - numpy >=1.23.5,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2174393
+  timestamp: 1722934875080
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/geopandas-0.14.2-py311hecd8cb5_0.tar.bz2
+  sha256: f0d5db2a531e1312187e8b5b7a6d253ad483cec5d71e599a13488b51e77f837d
+  md5: 20fde68bdcb32bda259d204656c8be62
+  depends:
+  - folium
+  - geopandas-base 0.14.2 py311hecd8cb5_0
+  - mapclassify >=2.4.0
+  - matplotlib-base >=3.5.0
+  - python >=3.11,<3.12.0a0
+  - rtree >=0.9
+  - xyzservices
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7728
+  timestamp: 1704929099800
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/geopandas-base-0.14.2-py311hecd8cb5_0.tar.bz2
+  sha256: 31686dc79fc428a9ba9a55830c30360c3701815599d08b9ffbcfad2f586d7fa8
+  md5: 90dafe9ab737e9bc186ef2ea808c627f
+  depends:
+  - fiona >=1.8.21
+  - packaging
+  - pandas >=1.4.0
+  - pyproj >=3.3.0
+  - python >=3.11,<3.12.0a0
+  - shapely >=1.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1513452
+  timestamp: 1704929062065
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/geos-3.8.0-hb1e8313_0.tar.bz2
+  sha256: ec1a020f11e34a94622a35fe338a640e688bd2a9959779e441496c575c1ebfd4
+  md5: d43b2e34536205c250f9a9a699d39b84
+  depends:
+  - libcxx >=10.0.0
+  license: LGPL-2.1
+  size: 916394
+  timestamp: 1592213531288
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/geotiff-1.7.0-hf6ff7a4_3.tar.bz2
+  sha256: 20ad07d0b90bb478a9043f514413bf9d9cdec1a1eace392b32b0e0ce27987722
+  md5: ff1f837d7dd22e46021db29c6d8460a5
+  depends:
+  - jpeg >=9e,<10a
+  - libcxx >=14.0.6
+  - libtiff >=4.1.0,<4.7.0
+  - proj >=9.3.1,<9.3.2.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 134716
+  timestamp: 1704901298585
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/geoviews-1.12.0-py311hecd8cb5_0.tar.bz2
+  sha256: 98838deb362872f4a9419c9be389d9b024e27ad017c4bb5c47bdef5d1181b8fe
+  md5: bfe351abb9640ee70b1a9a51f110eafc
+  depends:
+  - datashader
+  - geopandas-base
+  - geoviews-core 1.12.0 py311hecd8cb5_0
+  - netcdf4
+  - pandas <3.0.0
+  - pooch
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - scipy
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6722
+  timestamp: 1713972716714
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/geoviews-core-1.12.0-py311hecd8cb5_0.tar.bz2
+  sha256: 4a2b98cba460308370067dc6f8df380d7eda047caf8058506690858d5053aa9e
+  md5: 9fc251fa44cbe36ce7739e584b4f4af6
+  depends:
+  - bokeh >=3.4.0,<3.5.0
+  - cartopy >=0.18.0
+  - holoviews >=1.16.0
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - panel >=1.0.0
+  - param >=1.9.0,<3.0
+  - pyproj
+  - python >=3.11,<3.12.0a0
+  - shapely
+  - xyzservices
+  constrains:
+  - geoviews 1.12.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 625015
+  timestamp: 1713972701603
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/gettext-0.21.0-h4e8c18a_2.tar.bz2
+  sha256: 9f2052e2c2f4e1d48b4315c3976c53afc5ff69399166f24432bb8c02f868fc27
+  md5: eb9c4555f936f3998c0c5e462c44f0e9
+  depends:
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - libxml2 >=2.13.1,<2.14.0a0
+  - llvm-openmp >=14.0.6
+  - ncurses >=6.4,<7.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 3595681
+  timestamp: 1722923856325
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+  sha256: 3c7aa54548409f9343e891820ea43c195b5e4e4dce6b761bc3ae9f6c8be0fc86
+  md5: ed9629d6dc1612ec425eb8d27478b0f6
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 140316
+  timestamp: 1706888243476
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+  sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
+  md5: e4a732941f74b8062c8bcbfe5c5c2b56
+  license: MIT
+  license_family: MIT
+  size: 80252
+  timestamp: 1676983220161
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/glib-2.78.4-hcec6c5f_0.tar.bz2
+  sha256: 334df2c533e7dc057f37f8b736dc4d603f4619a4fb896cd931c9a784cc45d1ef
+  md5: fcfa37c8700f34b6faf9cd5bef32de4d
+  depends:
+  - gettext >=0.21.0,<1.0a0
+  - glib-tools 2.78.4 hcec6c5f_0
+  - libcxx >=14.0.6
+  - libglib 2.78.4 h19e1a8f_0
+  - python
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 505762
+  timestamp: 1708033264613
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/glib-tools-2.78.4-hcec6c5f_0.tar.bz2
+  sha256: bc7c13b0656fa2972a121b18a236ebb6a38f59ef42e603741585be176293b514
+  md5: 7d13cf328ebfdeb0f377f6da8c984a41
+  depends:
+  - gettext >=0.21.0,<1.0a0
+  - libcxx >=14.0.6
+  - libglib 2.78.4 h19e1a8f_0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 104298
+  timestamp: 1708033221652
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+  sha256: aed47f9ca4dd140b9c8a183e53d4b89eba84a20041d2038983cdfea8096104ef
+  md5: c0d981d7d43eaad55950ff5e57206e70
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 97828
+  timestamp: 1706895273858
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf4-4.2.13-h39711bb_2.tar.bz2
+  sha256: 85d7f9697d1243b5d088737a3f5c43610f01250f78e9a9fa9da6cca7830d73cf
+  md5: 637b7dadcfe411e14233764fd1d820a3
+  depends:
+  - jpeg >=9b,<10a
+  - libcxx >=4.0.1
+  - zlib >=1.2.11,<1.3.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 895428
+  timestamp: 1510863932515
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf5-1.12.1-ha01d115_3.tar.bz2
+  sha256: 4d93b05b1ae71c48560c7ca4088568388a5d13b7fbfa21cd7742a0f274ad0655
+  md5: 9a6277d2d9e1ced54bbae133f98b1fc3
+  depends:
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  - libgfortran 5.*
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: OTHER
+  license_family: BSD
+  size: 5830458
+  timestamp: 1686164224072
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.19.1-py311hecd8cb5_0.tar.bz2
+  sha256: d9dc05e6f02bcdb455cf0406270af8c94028b01b08d37c8dc5e3132d3c6856ca
+  md5: 74987b12edb2c87b1e86d105302788d5
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21,<2.0a0
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.1
+  constrains:
+  - plotly >=4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6083542
+  timestamp: 1720534072421
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 50dee40e4a9ea7a035baeecc85770c88d63d4e6b0c3c2519c1429e881171150c
+  md5: 4d465f453dca5c65224dccbe953f600c
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 359293
+  timestamp: 1715090716440
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+  sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
+  md5: f3ce6fe6eb760c236e5f7d04df5faa81
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28138484
+  timestamp: 1692293212596
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+  sha256: 5c2458964157fe493ca18c513c693b70cb622087e5fa0c93e65fc45217edd811
+  md5: 15629e52625221b51a443cefd9501d12
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148522
+  timestamp: 1714398885844
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+  sha256: 5a17849341e4d43fc6aff44486425852c16dee6e1cbcab1ed3f2167350f55359
+  md5: 445ac9df262ad2dcd86246a9ba5654b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 51118
+  timestamp: 1704813615186
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+  sha256: eb58fa29b1ce9aa5fc774d4c466696457695dec3b206456614b4c9cac0a94e42
+  md5: 3d3291ff58dff83dcd40ec54b435f4d2
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229910
+  timestamp: 1705934029588
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.27.0-py311hecd8cb5_0.tar.bz2
+  sha256: 901a391e792938d690a39cbe2551d7306bf85474bb0cff4e69088f78a9f5a26d
+  md5: 84fa63c5f6182b1f06c3ffa5e611507d
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1632976
+  timestamp: 1726064292193
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.1-py311hecd8cb5_0.tar.bz2
+  sha256: 9961222f1fb3a768e9c85a03761107809b321f4bc9af02d23289c59164bed7fe
+  md5: c671e7d14b22780a7b1fa8632b0bf8ba
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1178410
+  timestamp: 1721058471712
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py311hecd8cb5_0.tar.bz2
+  sha256: b80384bec95335d8ad37895f5cfd2d8fdfaae7be05507f218344ddb5c6713d38
+  md5: 8ac4f4807344f09b39c1b303cd2d1937
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 356777
+  timestamp: 1716993516277
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/joblib-1.4.2-py311hecd8cb5_0.tar.bz2
+  sha256: f6779df71ea45d589664943675ab424b3e9ee3dd649ede86b0d8c539c0f74aa8
+  md5: 105bdce440491e4e03aa018d5311b8b8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 545979
+  timestamp: 1718217257856
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+  sha256: 855982a798d9af8e70635a250528a5da3b2b0cf7095e2804858caf139c8a239b
+  md5: 112a5602fe42a84a5bafa038abeddf4f
+  license: IJG
+  license_family: Other
+  size: 279686
+  timestamp: 1722872676718
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/json-c-0.16-hca72f7f_0.tar.bz2
+  sha256: 2258f53c5f89d5ef8151aa775041c91de132ae5b467c0fb89c283c0fedc46836
+  md5: fc6b7ad3145ba86e7459b14fba98cd27
+  license: MIT
+  license_family: MIT
+  size: 73431
+  timestamp: 1659123708344
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+  sha256: 99fc6ac82c56eb2a580f96db24a5b887f8abc8c24af445d3313d5ebb48598478
+  md5: 71892160908a6daedb5fb7c404079ae4
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 182073
+  timestamp: 1699041732321
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 0ea44d0c8044e70ab0eaf4d6f5f3e4753838dee106b5cbd36561e21a65cbac77
+  md5: 1d045016dca889d702f1caf3a16162fc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16528
+  timestamp: 1699032525791
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+  sha256: 70442ec4b0b7ebbdcf150963f61f797b861001092124f4ea39a16eb92a4d176e
+  md5: 63d1503915a15ae4f9ad1c46112ca374
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 272720
+  timestamp: 1678316970740
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
+  sha256: e657ec0667481d957827be1ce825b0a971aa3a211b07c1274d2c1099ded3129c
+  md5: 5e317fd45011a0003c29331a8002cb75
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 98632
+  timestamp: 1718818439542
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 2634d721123ea1e41b6e1cfe4a67552ec520ea9b5154c9e788ccb09d4745b732
+  md5: e874eba19b493b7a68161429f24b8f51
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43102
+  timestamp: 1718738272613
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
+  sha256: c353480ed4744c2a16aaccc1649bab38144436ad6d16ac2937e3e333d32fdccc
+  md5: 7de25bdf4cfd3f5485d790d9cddf427f
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 619935
+  timestamp: 1718828240904
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+  sha256: fd7964657f0a8fe8b167ba860b1f960e8b7b45309eb6c7c850d50ec283fe03b5
+  md5: 2967bb345bc75f53182e263ff4743ca6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28223
+  timestamp: 1686870845224
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+  sha256: 64cf59f0f74b0329b5069bc6135b4f40593f1dac52d85ad574d4b8e0a4b2cf16
+  md5: 35e8b80eaa03a904fc7f1da39e7f654d
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20234
+  timestamp: 1700168776500
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kealib-1.5.0-h72c422f_1.tar.bz2
+  sha256: 9deac634ad1c9c3d3285637f09d16659dc7a36d53ac40c0403e53bafd338edee
+  md5: 652c4d08662f5de6049bb8d153c89218
+  depends:
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 170336
+  timestamp: 1687966990145
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+  sha256: a12382b50416803f559a03fb384ba492c1dafa351e1191a3f8dc361bee6c4f37
+  md5: f2ae846b663bbb642f4b1e90eaad38a3
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64817
+  timestamp: 1678322501509
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
+  sha256: a3a24cd84c291f7c9e28842ccfc2107d149f0aa8e676b85d9104eda77622e603
+  md5: 99ba4367783596d1bb0c7766ea6706ea
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - openssl >=3.0.8,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1290758
+  timestamp: 1686931137388
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libabseil-20240116.2-cxx17_h548131f_0.tar.bz2
+  sha256: 8973f292fbdc61fb9a0f97746e6e4d2ad7a777e54400e7800de9b14f229a7999
+  md5: 5524c45ff980ff65c2aa4bd106e7299a
+  depends:
+  - libcxx >=14.0.6
+  constrains:
+  - __osx >=10.15
+  - libabseil-static =20240116.2=cxx17*
+  - abseil-cpp =20240116.2
+  license: Apache-2.0
+  license_family: Apache
+  size: 1199721
+  timestamp: 1716563412628
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+  sha256: 127dbf93874f1bb3493b312fecb5ffedb8f2a41d2470e2cbeb889eb58d89ebf7
+  md5: 07502b61e43a2039e4312b40d53c1db1
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 22584954
+  timestamp: 1696762195023
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 685c3bc9068bd485604b80bf03789e4dca95c410d33871bc1b882e47649fabed
+  md5: 6cf8e55271e150ca0961d0ddedaa61bb
+  license: MIT
+  size: 66237
+  timestamp: 1714483284541
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 69826cee54db9955f0120af21ec36d13f9211877fd67364f2068d0a54c6c97cd
+  md5: 0851917257f490d35e1f73da8a1c723c
+  depends:
+  - libbrotlicommon 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 34042
+  timestamp: 1714483343147
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 3f5a1f03b50b90b397a0ee432ad0cba13354abdaf7e5652c0fc60164b26a08b6
+  md5: a50bdc871ef4bf14deb088d888b92b5e
+  depends:
+  - libbrotlicommon 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 311597
+  timestamp: 1714483371586
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.9.1-h3a17b82_0.tar.bz2
+  sha256: 9ddb2cb85d3248d0e6f1aae2583078f84006632040ae3e7596dd7fbd303c0d1f
+  md5: f983c731c77a28476bdded5141b2a942
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.57.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=3.0.14,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: curl
+  license_family: MIT
+  size: 394222
+  timestamp: 1725034051587
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+  sha256: e84e6cbacb12de6fe86955449502d3956696ae583060d0d4911ea6f503cfb9ad
+  md5: 1d200c536be4172db41c49e81a3e6350
+  depends:
+  - ncurses >=6.4,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 169586
+  timestamp: 1703006265367
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+  sha256: 4786264321edbff780633a5b752995eb3193ca4bce11b0fda179577f6cf1102c
+  md5: 849fdd014c201a9d2c2aa7c7db38a778
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 103993
+  timestamp: 1632891571494
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+  sha256: a60941a0365ee3e8b9ff721f75b0608c234b5652f53337a918b787839de4bb53
+  md5: 4d61f019594ebccfb3f4fb87ee778416
+  depends:
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 414942
+  timestamp: 1685052318462
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+  sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
+  md5: 822a5b76117e56d3912f1f2153307528
+  license: MIT
+  license_family: MIT
+  size: 136045
+  timestamp: 1714483561919
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgdal-3.6.2-hfaf651c_5.tar.bz2
+  sha256: 1a2ac5e7563c4590b37329d2f885723717ae8c2a97d24014e822b443d4fcb7d3
+  md5: abd853f43d551e28b514b574d81a1bd6
+  depends:
+  - blosc >=1.21.3,<2.0a0
+  - cfitsio >=3.470,<3.471.0a0
+  - expat >=2.6.2,<3.0a0
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.8.0,<3.8.1.0a0
+  - geotiff >=1.7.0,<1.8.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - hdf4 >=4.2.13,<4.2.14.0a0
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - jpeg >=9e,<10a
+  - json-c >=0.16,<0.17.0a0
+  - kealib >=1.5.0,<1.6.0a0
+  - lerc >=3.0,<4.0a0
+  - libcurl >=8.1.1,<9.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libiconv >=1.16,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libnetcdf >=4.8.1,<5.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=12.15,<13.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libtiff >=4.5.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxml2 >=2.13.1,<2.14.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - openssl >=3.0.14,<4.0a0
+  - pcre2 >=10.42,<10.43.0a0
+  - poppler <=22.12.0
+  - proj >=9.3.1,<9.3.2.0a0
+  - qhull
+  - sqlite >=3.45.3,<4.0a0
+  - tiledb >=2.3.3,<2.4.0a0
+  - xerces-c >=3.2.4,<3.3.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 10249856
+  timestamp: 1722934547022
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+  sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
+  md5: e458587c87e3f2d20192f4e0738f2c63
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 149419
+  timestamp: 1665498987619
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+  sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
+  md5: 1058b661ec829b2ee3716ee2a5520641
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1917987
+  timestamp: 1665498925405
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libglib-2.78.4-h19e1a8f_0.tar.bz2
+  sha256: 63167624a93a9482d7fa3a79fcf8f2e93fe587db2d5b9f8e73581c07dcf7f33b
+  md5: dd7eca3ab08ad18935ebdc7b4e4db2bc
+  depends:
+  - gettext >=0.21.0,<1.0a0
+  - libcxx >=14.0.6
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.16,<2.0a0
+  - pcre2 >=10.42,<10.43.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  constrains:
+  - glib 2.78.4 *_0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 3122562
+  timestamp: 1708033169400
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgrpc-1.62.2-hf2926fd_0.tar.bz2
+  sha256: 451a1bafa405093889dfcc3669f0a679d300bd8c8770901be300832f72e0d359
+  md5: b27400d99678fc64f10b5908ea05daed
+  depends:
+  - __osx >=10.13
+  - __osx >=10.15
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - openssl >=3.0.13,<4.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  constrains:
+  - grpc-cpp =1.62.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 6917286
+  timestamp: 1716835073567
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
+  sha256: 9ff6ed0f0b9f9f27f449e95d11aa1c4e9e80028fd9d2a8caca5a15d8df88f435
+  md5: 7b4b557afc66aba367da14d97d71934c
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1409885
+  timestamp: 1714483704680
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libkml-1.3.0-h85bf17e_7.tar.bz2
+  sha256: 45936f0f5c7e616f02e028fa75b2177af1ad16587190d350b0c54489dba96cb2
+  md5: 66ef0c8cf08472f25fba622bdc99921c
+  depends:
+  - expat >=2.4.9,<3.0a0
+  - libcxx >=14.0.6
+  - uriparser >=0.9.7,<1.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 435832
+  timestamp: 1693261846695
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h26321d7_4.tar.bz2
+  sha256: 3c62b303d658923dfd5ef7385a6560c97865e5ad22df05f2822575dc2f2f61f6
+  md5: 7a1ba247765a13e183f91bd5e857a0d6
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 27922606
+  timestamp: 1726769388473
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnetcdf-4.8.1-h9f5a9a2_4.tar.bz2
+  sha256: 80783306d885b715879e295d854a6586b5b03828885f218a0be80d5c68b8d87d
+  md5: dc1ead84c17a4758496bb51efe5d137d
+  depends:
+  - hdf4 >=4.2.13,<4.2.14.0a0
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  - libzip
+  - openssl >=3.0.10,<4.0a0
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1531548
+  timestamp: 1691155070635
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+  sha256: 7bfcf69c31a4eb15dfab661c93463ce8dfb7b3de4356945fa5c1ca50a5ae0cb0
+  md5: 4934bb34818fa3d99b32b9cb59fed205
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - c-ares >=1.7.5
+  - libcxx >=14.0.6
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 784918
+  timestamp: 1697018436251
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
+  sha256: 499ebc9000c8e810081b5d7f7524b45dc99f6914096ea9e145366033514938b4
+  md5: ce5c24f93932e1a53d7d89e502f28783
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10123989
+  timestamp: 1664896966769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpq-12.17-h04015c4_0.tar.bz2
+  sha256: a50cb971a1f7590aa43e1d3cce5d997ff7ce52026e0819aa3e2d6b9fd6703c3a
+  md5: 16c55d483601a4f5fcc0b0bdb59765c7
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - openssl >=3.0.12,<4.0a0
+  size: 2930205
+  timestamp: 1706214610342
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-4.25.3-h34eed0b_0.tar.bz2
+  sha256: 22fddb84e3f771ee2a550da0dbe4caa334ac53b8a633ea566ec5b2e4cbb261cf
+  md5: 1922ae6303e44e99aa04f54291240e1b
+  depends:
+  - __osx >=10.13
+  - __osx >=10.15
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libcxx >=14.0.6
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2688858
+  timestamp: 1716567854254
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libspatialindex-1.9.3-h23ab428_0.tar.bz2
+  sha256: aa1bca7ee910973ee9bb5b20d0f8c441aebf409983118a12e835edb65297ead5
+  md5: 10a339fb0866adb3eda36b776263dc99
+  depends:
+  - libcxx >=10.0.0
+  license: MIT
+  size: 415040
+  timestamp: 1616086763917
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libspatialite-5.1.0-hd7ca590_1.tar.bz2
+  sha256: f9034aa07ff8b221fbf027a7018d771e0b2911c6ae6e8c582247249f33a69bb4
+  md5: 11cb32d275d9b44be5ce352978f30d62
+  depends:
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.8.0,<3.8.1.0a0
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - libxml2 >=2.13.1,<2.14.0a0
+  - minizip >=4.0.3,<5.0a0
+  - proj >=9.3.1,<9.3.2.0a0
+  - sqlite >=3.45.3,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later
+  license_family: OTHER
+  size: 4233996
+  timestamp: 1722878959147
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.11.0-hf20ceda_0.tar.bz2
+  sha256: de5335a49a6eabc7b722fa68192f7f5bd3b3c8221fc8d8138d3ef9406a09e5b7
+  md5: 7112df7af035d166dc6fa941936355a0
+  depends:
+  - openssl >=3.0.13,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 260849
+  timestamp: 1715261514683
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+  sha256: 21ba71cdc65b56c6daefeeab55959e5a7edadfd697cfa8b2ed5c1b3e2a98586b
+  md5: cbbd369ee87aba597c942727bada4eee
+  depends:
+  - boost-cpp >=1.73
+  - libcxx >=14.0.6
+  - libevent >=2.1.12,<2.1.13.0a0
+  - openssl >=3.0.9,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 364326
+  timestamp: 1687975317748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.13.1-h6070cd6_2.tar.bz2
+  sha256: d32f24c3ee7f6be0b69b8b175d3cfa5a8b173447dfe34481ee2616f9bf974b0e
+  md5: 096ea9157e07c0e0f7fd213eb34cf615
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 632182
+  timestamp: 1722441134391
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libzip-1.8.0-h29ab7a1_1.tar.bz2
+  sha256: 2702cf5076d06c373f9198ae4c8a6e426f6c32b11e94bc9f2c911fe20426dd0a
+  md5: 5bd1fe81fac32de5a39a9bb9bc50d1e5
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 122019
+  timestamp: 1685378564524
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: d28c465ec6d5f8d4962c597b249b58998300c8b4e3c937c578c3d15294ea863d
+  md5: dcaed6ddd0723c7cce6bfad917be98b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41176
+  timestamp: 1678413498410
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+  sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
+  md5: 5c740b4a18a558de0ccfe601703c423c
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 338738
+  timestamp: 1662635677689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.43.0-py311h6d0c2b6_0.tar.bz2
+  sha256: 73052ee16f6d1df70d79c0258dc4e08af8840812e2d1c04a2edbb87c10ba5a34
+  md5: cd252d6bdabf736def933eb57332d0b5
+  depends:
+  - libcxx >=14.0.6
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 404923
+  timestamp: 1720455346980
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: 716a654df2e55052193150015bd5c9856b847893fc5a229fa8669725b1c56ff2
+  md5: 687ba6c11de38ad7cc597f7188b491e7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13357
+  timestamp: 1678322560230
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-4.3.2-py311h6c40b1e_0.tar.bz2
+  sha256: e05d6b661c088efc3f7f2fc99b8faad351f7660963ca66fbe63dfc9796821eb2
+  md5: d48a23f7e388334d5e39fc36ee84441b
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37947
+  timestamp: 1686058038545
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+  sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
+  md5: 8f57dc3a3327bb6f7e1cba908856ac7f
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 183138
+  timestamp: 1714510756758
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mapclassify-2.5.0-py311hecd8cb5_0.tar.bz2
+  sha256: bd2bb7d2150c5ee749287bcd09f8738d86c58689f252b64f78ad0cb6798696d9
+  md5: a0e839113d9bfb31e247e483158648f4
+  depends:
+  - networkx
+  - numpy >=1.3,<2.0a0
+  - pandas >=1.0
+  - python >=3.11,<3.12.0a0
+  - scikit-learn
+  - scipy >=1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 83276
+  timestamp: 1678417691421
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+  sha256: 6fb2953e169ee1ae38f24d29752051501992f19b96b5ebcea9af75737bdbcb42
+  md5: 7f410cdae838c5030108d1b98a8c78f6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162478
+  timestamp: 1678377892595
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+  sha256: cd97e09a12ffb49b2a30a782fa8c7933b28f5ffdbfc5c73a9ebaa95fc9447370
+  md5: d1fb6ebc1e5728aa6377cfc71da08942
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135859
+  timestamp: 1684280005320
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+  sha256: 30c3b189462a9d0f4794d229adadf34b5f5a5f56f95c30d5afc17ef524579290
+  md5: d4e9421243129d1d57c472dab045f3dc
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26639
+  timestamp: 1704206159955
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.9.2-py311hc25a08b_0.tar.bz2
+  sha256: 5fddd37bbe579892257bf574bc0b5199b97a3ba8addbf2ec73e5147609eae7cb
+  md5: 30837287c1590ec271189cb315be35d1
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9456494
+  timestamp: 1725264308019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+  sha256: 07e7fd5bd64e55328b4b99d92e2e2600d791f1095bf905daab4cfc59f0f0a45b
+  md5: cf53321779f4ca7e986c1468719b93f1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19500
+  timestamp: 1678317565001
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0770e02be1ea1216af493cfc03d5b8a702e14606fa93b0692bcdab1fed1b898c
+  md5: ca6f06ceaf66a32bbf5dfdb6e373a5cf
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67892
+  timestamp: 1678417734353
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: fbe95ed0501bb0f137048476fe41bc718dd659e8ecb066bc67ac17d6a50f4318
+  md5: ec162bde8d1c8a107b257df218b17035
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23030
+  timestamp: 1678381838497
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/minizip-4.0.3-h79ad51c_0.tar.bz2
+  sha256: 083706ad4e1c7cca21b8a7c2f98731f6d89c6f93027b0144a05dc2cf780b0104
+  md5: bad45529dbe30d5171372b53569c433a
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - openssl >=3.0.12,<4.0a0
+  - xz >=5.4.5,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 84756
+  timestamp: 1702658569259
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+  sha256: c20dd678655e582129a858a1c5162bdc254082d3a3c035b0f72629d9276e5b75
+  md5: 800a0738c728796e02d0386ce7d457aa
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104585
+  timestamp: 1678317269407
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py311ha357a0b_0.tar.bz2
+  sha256: 7517bb3a1337287e71ba182e23654f49275048389a1a3c6d750dc580caf4aaed
+  md5: 5466d265b312c4ff0ff4969ebf15c0ce
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 37529
+  timestamp: 1678318290205
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 638450a7ccb5f438ac65aa1c8d871fb5bb664e7261ec7e663d0302485c219a67
+  md5: 574875bbeabff85b5d9cfdb62066aece
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29473
+  timestamp: 1678392919304
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: f961b1322b6b02fee53ff9bd0f56bb73886eb59debd3f3666669593de7f48894
+  md5: a1e74ccd2f341d1d672e33d79e60d200
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8183400
+  timestamp: 1717623127275
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: e08cb3ee6df01f4c1e1ac8bc4ed1a06e549ffcc8774fe2e2842c644bb8f74a86
+  md5: 6ba0ae0fb14cbea1e3197707701dc180
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123077
+  timestamp: 1698934356774
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 2f946b5042eaac97206b5217fb203f3604ab3a60aecd99bdfc684925e3136c18
+  md5: b24026076c381ff2009e7acb9e0a6e87
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 534650
+  timestamp: 1699022791300
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+  sha256: ba368605a0af6f1dcbdcb6fddab9ce63224a85dd11bfb2b1acace1dc17899411
+  md5: 91f3ea3fe44d619ee95a6ed3773a0814
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 170926
+  timestamp: 1694616830121
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 42d803e1d8b54748db5d989ecd503826f564132df7cddc20f520460f55e523a1
+  md5: cd3fa71626ebc098da4625fc6be79752
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16952
+  timestamp: 1708532805951
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/netcdf4-1.6.2-py311h42ba51d_0.tar.bz2
+  sha256: 33a5c9bbe9945c87ab4e3b01cbd81f87fe01e135f4b17fcee672365b90181552
+  md5: bd6ad59e329f2f23ab865858336ba5ad
+  depends:
+  - cftime
+  - hdf5
+  - libnetcdf >=4.8,<4.9.0a0
+  - libnetcdf >=4.8.1,<5.0a0
+  - numpy >=1.22.3,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 461123
+  timestamp: 1678393009528
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.3-py311hecd8cb5_0.tar.bz2
+  sha256: e9e4b82191d34175fd8339d31322ca7a845e0fb577ec72f7dbd7cd5de8b35808
+  md5: 72e37904339e00f27f47843a0c6d0bce
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - matplotlib-base >=3.6
+  - numpy >=1.23,<2.0a0
+  - scipy >=1.9,!=1.11.0,!=1.11.1
+  - pandas >=1.4
+  - pydot >=2.0
+  - sympy >=1.10
+  - pygraphviz >=1.12
+  - lxml >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3343264
+  timestamp: 1720002820058
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
+  sha256: 09d88f1eb19a90dfe737f0e5b4dce7629f6076a2d91d572cbb0a41be5220a4e8
+  md5: ac8c26d949a04f478b560b7d8a2358a4
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 707187
+  timestamp: 1717630829258
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+  sha256: ed5608feb37a083d47b04203195260e801b64b5380f292cf18bb61e7ad827a2a
+  md5: daa9c1c233673b727528548454aea664
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27607
+  timestamp: 1699456006797
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nspr-4.35-hcec6c5f_0.tar.bz2
+  sha256: f006a4418ca8a5788d67fa836a89a236be9925b9dd7744a45cdec18d053a221d
+  md5: 4d90323cc76987c69a1c1d3996af71c0
+  depends:
+  - libcxx >=14.0.6
+  license: MPL-2.0
+  license_family: OTHER
+  size: 257208
+  timestamp: 1685541796770
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nss-3.89.1-hcec6c5f_0.tar.bz2
+  sha256: 0ee6d4545add1a4649506c1a69cb491a908ca5e47b386f9196485c3b5a9c371b
+  md5: 905b6e1c124eeba9dc9f338fd29932ec
+  depends:
+  - libcxx >=14.0.6
+  - nspr >=4.35,<5.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MPL-2.0
+  license_family: OTHER
+  size: 2130955
+  timestamp: 1685543311945
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.60.0-py311he327ffe_0.tar.bz2
+  sha256: 91c63f3ac3b610a957169b06171366da4cfd1f8eca7b484ee66c524de739e40c
+  md5: a1cc844a9046142569d89d3642ee460f
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - cuda-version >=11.2
+  - libopenblas !=0.3.6
+  - cuda-python >=11.6
+  - numba-rvsdg 0.0.*
+  - cudatoolkit >=11.2
+  - scipy >=1.0
+  - tbb >=2021.6,<2022
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6145701
+  timestamp: 1720541086329
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h91b6869_0.tar.bz2
+  sha256: b0c5c5239e83c629d77abc36d4de7e38c9d085c62e24197d3330b4b6e5de75d9
+  md5: 44fa81f89a7977c4f80cf3dc4cbf1d72
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 165510
+  timestamp: 1696515774706
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h91b6869_0.tar.bz2
+  sha256: 85aa18f7f372d263f1b9a6eed279e0fa048387520bf71b9c409e13801a0568d4
+  md5: c077c784069f04cc487620bcdc7707ea
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.26.4 py311hb3ec012_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11321
+  timestamp: 1708642350281
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311hb3ec012_0.tar.bz2
+  sha256: bc050bacb16826ee23329eed65b63c2625884e2af1853f901f7e09870c7dbd1f
+  md5: 96b8308a1bdb2f1e77698ea9fdf96bf3
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311h91b6869_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8784964
+  timestamp: 1708642301649
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
+  sha256: 401214a4763c79c2355b012b9f29e3cee097a598bb53e933acb6b98a2bb6614f
+  md5: 3216c5f433643ee62a8d0672c3500320
+  depends:
+  - libcxx >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.7.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 535252
+  timestamp: 1722872704730
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.15-h46256e1_0.tar.bz2
+  sha256: 8cc69ca3f77c9dc8bed662100046085536c6a95b77b2a964ba79fc81ba3f698a
+  md5: 270474613701d2371d5c5cc220a78825
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4961721
+  timestamp: 1725545867722
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-2.0.1-h5747287_0.tar.bz2
+  sha256: ca2972eb0d95b834238106df2b3bbb6efdb07ea2e9080a718669d8a1dc65f4cd
+  md5: 2fe36bccf7d2d86be813bda00878a7f0
+  depends:
+  - __osx >=10.13
+  - __osx >=10.15
+  - libcxx >=14.0.6
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.10,<2.0a0
+  - tzdata
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 526130
+  timestamp: 1717104747125
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+  sha256: 8a0809f419065e014cb8e2c8a516cadca6088fb71fd1ef3ae2287d91e3360d59
+  md5: 4dc0b9bc88476fcc5246d823ff1c289a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39645
+  timestamp: 1699371213055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.1-py311hecd8cb5_0.tar.bz2
+  sha256: dfeced2b57d53e4aaaf5e855c2f10b505ee74c486594bbe4b132843f12806ff3
+  md5: 05b50489c5ee7b2d5b5750f51cca96c1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 158201
+  timestamp: 1720101976586
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.2-py311he327ffe_0.tar.bz2
+  sha256: 878e8fbcca40ac0c3937780160c22b65633b32ac97a886a9e38d4453821fe8bb
+  md5: ac61107a8dd7a5a51e19e57fcc3a7a5a
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - pymysql >=1.0.2
+  - pandas-gbq >=0.19.0
+  - fsspec >=2022.11.0
+  - pyarrow >=10.0.1
+  - scipy >=1.10.0
+  - qtpy >=2.3.0
+  - lxml >=4.9.2
+  - numba >=0.56.4
+  - s3fs >=2022.11.0
+  - xlsxwriter >=3.0.5
+  - tabulate >=0.9.0
+  - adbc-driver-postgresql >=0.8.0
+  - sqlalchemy >=2.0.0
+  - python-calamine >=0.1.7
+  - adbc-driver-sqlite >=0.8.0
+  - html5lib >=1.1
+  - matplotlib-base >=3.6.3
+  - gcsfs >=2022.11.0
+  - blosc >=1.21.3
+  - xlrd >=2.0.1
+  - pyreadstat >=1.2.0
+  - fastparquet >=2022.12.0
+  - jinja2 >=3.1.2
+  - beautifulsoup4 >=4.11.2
+  - xarray >=2022.12.0
+  - pyqt >=5.15.9
+  - psycopg2 >=2.9.6
+  - pyxlsb >=1.0.10
+  - openpyxl >=3.1.0
+  - zstandard >=0.19.0
+  - odfpy>=1.4.1
+  - dataframe-api-compat >=0.1.7
+  - pytables >=3.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17291576
+  timestamp: 1718309206876
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.4-py311hecd8cb5_0.tar.bz2
+  sha256: 757d6789ddb8227afd02da27fb30d1339091c8bda8f9905011a591eaa3fc6147
+  md5: 7445a0d4f67a8063b19c6372d1f8b02f
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.1.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21789913
+  timestamp: 1718119269606
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.1-py311hecd8cb5_0.tar.bz2
+  sha256: a33f52ee58e7856ff19bd306a7c055950d669199981874a38c2bdb1896725c8f
+  md5: 7aef330f65dd9dd63a06c89ddfb3b7bd
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 267605
+  timestamp: 1719348049109
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+  sha256: 359b31da651ee35b9ca43974d26cd44e64f3cf412096c15dec7b720fa909a9b2
+  md5: 108e24227f8fdfc4d635bb4eedfa6cef
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48504
+  timestamp: 1698702608965
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pcre2-10.42-h9b97e30_1.tar.bz2
+  sha256: e18ec8727b8f74eb87a3c8945953c97de9b065aabcad272ece12972b854d964c
+  md5: 2a4a10038d1f8d6bb80609fdeb0ac324
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3403226
+  timestamp: 1714657724735
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.4.0-py311h46256e1_0.tar.bz2
+  sha256: cad086496c3ebc1d2a36932c49756595c89e1f2e1afe9fa8237a61136a9c49de
+  md5: 707e1417a63a43f98ab2da22d1f138ff
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 959109
+  timestamp: 1721059511981
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.2-py311hecd8cb5_0.tar.bz2
+  sha256: 492ea4d1c5a4f860f3312c7729f1e33b706007578c25c031241d7497a115dd79
+  md5: 835f4767cdb9d80338e0bba649c1ce3c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2923519
+  timestamp: 1723484652903
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pixman-0.40.0-h9ed2024_1.tar.bz2
+  sha256: 39981af6952de4e207cf6e5e769cb5b9c50f30cfd71a1fd97d6d3eef5feb5a6a
+  md5: ecb58f854cae469740631c23643c9c95
+  license: MIT
+  size: 617807
+  timestamp: 1632711594755
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 81719c31101d6c019150cedcc7b08adb3bdb357e8b2952e428dadaabc4dc985d
+  md5: 105825168e0a17fb007f60b5f314e311
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38405
+  timestamp: 1692205731769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pooch-1.7.0-py311hecd8cb5_0.tar.bz2
+  sha256: cd08f6e326bb6422407b242047b2528d1ec4e1127d764315859fd92b376c6abb
+  md5: 43dad20bf1b2e021c9079985acb21d5d
+  depends:
+  - packaging >=20.0
+  - platformdirs >=2.5.0
+  - python >=3.11,<3.12.0a0
+  - requests >=2.19.0
+  constrains:
+  - tqdm >=4.41.0,<5.0.0
+  - xxhash >=1.4.3
+  - paramiko >=2.7.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 106484
+  timestamp: 1695850216139
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/poppler-22.12.0-ha8a1649_3.tar.bz2
+  sha256: 36845a06f9abfb4ee06e24d1f9e57c2f8cded0c323491221862d45f929df6a34
+  md5: 8cb3c1e1fa4d3ed2f1589fdd2f686108
+  depends:
+  - boost-cpp >=1.73.0,<2.0a0
+  - cairo >=1.16.0,<2.0a0
+  - fontconfig >=2.14.1,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - gettext >=0.21.0,<1.0a0
+  - glib >=2.69.1,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - nspr >=4.35,<5.0a0
+  - nss >=3.89.1,<4.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - poppler-data
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 1833586
+  timestamp: 1696000908395
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/poppler-data-0.4.11-hecd8cb5_1.tar.bz2
+  sha256: 31fbd1899e753b454dc825d85e2cd9a0506107e772f5d5d307d4f234586c0059
+  md5: 54f685f65e667e076c4a7cb36f23f26e
+  license: GPL-2.0-or-later and GPL-3.0-or-later and BSD-3-Clause
+  license_family: GPL
+  size: 3839936
+  timestamp: 1673863552033
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/proj-9.3.1-h1972728_0.tar.bz2
+  sha256: 0db91133b64eae7b15583577af715638e73643704016e60b06c8ed675cd8029c
+  md5: e4d22e27045add53f9e03c4578052b0a
+  depends:
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.1.0,<4.7.0
+  - sqlite >=3.41.2,<4.0a0
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 3101265
+  timestamp: 1704728694567
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+  sha256: c0982f688127129e026d2b4cdacdd5684d00796ea7bdadd7d26b1101b095d723
+  md5: 0d6910c74729fede645c010110f1c89e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 121796
+  timestamp: 1679340253537
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+  sha256: e32843723b10ecd9badde28e1085419c0b59ed8a96c7cacce6395e39e3a874f9
+  md5: 5af0280a817d2c273304cd22328124af
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763044
+  timestamp: 1704404460779
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+  sha256: 117a435c2473e2a20cc81eaacb2b45ea5e7fe3c946eec2915936d344913ede44
+  md5: 0f459ee59fda20e2077fdc2c777edfc8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 497470
+  timestamp: 1679337286052
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-16.1.0-py311he327ffe_0.tar.bz2
+  sha256: e2b32bbc6715d76823cf6b4dfc1b3545002970cddbc91dca79b8778e6f86598d
+  md5: 06d164d039ad06fae027abb6ce8078ba
+  depends:
+  - arrow-cpp >=16.1.0,<16.1.1.0a0
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4943656
+  timestamp: 1721666101702
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+  sha256: 667b5cf00d31293dede2ddadcc30ab967103d585d40647f34d6d830af97ee51f
+  md5: 81d3876fa502fca91ba4136a5f3fc3d3
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37821
+  timestamp: 1678378977816
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+  sha256: dfb403f367c57327a4d080109df88383ecff18464de287a1ce936a7274e3656b
+  md5: 997b674bad89963af875b93b06807f51
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2120413
+  timestamp: 1684280057020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.1.2-py311hecd8cb5_0.tar.bz2
+  sha256: f9241d840cf4d8257796d1a5b8fb36155081165fa83f987e57afd4fbf93aaa9f
+  md5: 31b77244b3c1a71ea5299ce2297dced7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 459515
+  timestamp: 1725041684172
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyproj-3.6.1-py311h717f92e_0.tar.bz2
+  sha256: 64cc50f1f03f2fceee7e762683bc057a33645576bf950e524b999adfdd05c3a8
+  md5: bc7e6f8d55f35b35cf7204d50d713ea2
+  depends:
+  - certifi
+  - proj >=9.3.1,<9.3.2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 594660
+  timestamp: 1704904798330
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyshp-2.3.1-py311hecd8cb5_0.tar.bz2
+  sha256: c5da7585044b6530d15e60bc240c4461c978bfe7ab93d1bd8b65c09b2a56e7e4
+  md5: ff8fe62b78400d75cba37dfef852028a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 86946
+  timestamp: 1706101003087
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 717e038567506ca58ce1cd4a3416892d02f4ebfdd332077cc3d110cfe3d36c58
+  md5: 53bbfb400668f798eef6f8c7cf938e1f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35751
+  timestamp: 1678315886516
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
+  sha256: 092dea8d520acff3e64c71155e666b0b6074d37a71d5eb32f3cd485b0d185d0b
+  md5: 9fbaf2d9534c26e76aa14b11b23de332
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16852220
+  timestamp: 1713545835789
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+  sha256: 04e100d0a1ea9722e24972657ec5935ad34c7c58957dabb821333e5eac80f717
+  md5: 2b6de49ad07b26e1f7084f0fda958eb1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332276
+  timestamp: 1716495830117
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+  sha256: 514249897265f66f6ecca0a4427eb02a43c33b3c24974db16d05db6bbe97881d
+  md5: c9ea1437e5a3ba6a52ec2322505203e6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279116
+  timestamp: 1679338758489
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+  sha256: 78b785b9b6ed46c86b0d3a32bdceea49f816672227fb63e726b2d46eadbdba0b
+  md5: 79d783f74359141e0b06a848db33823b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18563
+  timestamp: 1683823935261
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py311hcec6c5f_0.tar.bz2
+  sha256: ceed2007dc80313fab055da9ad855aeff4178bfa03c16e78297fb77d058e6972
+  md5: 753c157b80f60f263e0fe6a2f8d4fc85
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 151925
+  timestamp: 1682522457855
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+  sha256: e358fe679e83ccdc8c433746ae6468e8e96d90d97d99530f8476ef5630b2c121
+  md5: ce30a0a31d891e69dc9b7bf8b7f0c39c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 268876
+  timestamp: 1713974360942
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+  sha256: eeb5a5eed93b8e311ad4d3f4389e050f11bba2eaec9536e1c3ed2f849c6c999b
+  md5: c18bd3e12de797d52a470c21a150dffe
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65270
+  timestamp: 1711136914884
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+  sha256: c3e11ed944da69c11b949bb918341a0d79ef603ee34a632d6a45fbf89ff924a1
+  md5: fee7ff4d291f530b4cecb575f29807a0
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 197996
+  timestamp: 1698096137432
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+  sha256: aa07b90a7ee65f76c8cba1ff99a5cdeb95cbe41881ae951f64ffff06674a1b2d
+  md5: 58621e3d244137885f7dfbb35e50340a
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 594801
+  timestamp: 1709318510622
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/qhull-2020.2-ha357a0b_2.tar.bz2
+  sha256: 35d47041555b4277b30abb836fbc815350a644ba3c4bd4f2e2ea73397c554f2f
+  md5: 5f3c1d74767029f19e9c2bd8172b557b
+  depends:
+  - libcxx >=14.0.6
+  license: Qhull
+  license_family: Other
+  size: 2019896
+  timestamp: 1670915867737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+  sha256: c69f556df9a27328c56943f3b5918cbb953cfbca987e20394d823a6174781202
+  md5: ab294ae71ecdfaa307a961cc71dd890d
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-3-Clause
+  size: 205638
+  timestamp: 1652449553607
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+  sha256: d784dc26c5de8e41845350a899e5779250b71f45d39e2aece62e739e9add7308
+  md5: 7b077b7f46112bb31dc066396c51d3fa
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74776
+  timestamp: 1699012164201
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py311hecd8cb5_0.tar.bz2
+  sha256: b1cfb76aa4576efad11927b3eea426d844c1676426d6cbea779070c51c4ab1c2
+  md5: 4bf97d09384f54359a8ba8c65b400331
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 124536
+  timestamp: 1721410924789
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+  sha256: 727fb8d957e02d03b928d049ffbc712316f176a2c331391766d646621b45655a
+  md5: 7e0e416c642f3ee4ddfb084a811fb4df
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10236
+  timestamp: 1683077214314
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+  sha256: a8a67143ccb65cfd6f50055176b6c26179a83130a45d0a12e79dd2de68d8db63
+  md5: a2065790f41e3eeb6efe0ef6daa75377
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10600
+  timestamp: 1683059285216
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+  sha256: 6aba582338faa0c26fe336bdb10c65b8f7808a6e383bd8f80f3e6b612ca209ec
+  md5: a7486349b5f7370f6902c2050a23d268
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 319197
+  timestamp: 1698946203341
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rtree-1.0.1-py311hecd8cb5_0.tar.bz2
+  sha256: 99624c139335e8bae5767a7bdd215d241e943ea392e297170a311bf46c52b412
+  md5: c617fa66cf6b725005202251b1d066bc
+  depends:
+  - libspatialindex >=1.8.5
+  - libspatialindex >=1.9.3,<1.9.4.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 63077
+  timestamp: 1678394121817
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scikit-learn-1.5.1-py311he327ffe_0.tar.bz2
+  sha256: 3260b532a642a5367b2ae8a82fd035269fde02b3a03c810dd6e7e383443da8bc
+  md5: 8f0399f0961818e462a35d6ca6c650d9
+  depends:
+  - blas * openblas
+  - joblib >=1.2.0
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - scipy >=1.13.0
+  - threadpoolctl >=3.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12471929
+  timestamp: 1721924399924
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.13.1-py311hedc7b93_0.tar.bz2
+  sha256: 34a7676f0206358af5382dde5277545feca8d14976a0de8f7c76bef2924fc48b
+  md5: bc42006faf0a94d5479e5836df7dc071
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 4
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 27740042
+  timestamp: 1717602667679
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+  sha256: beba0555707dac1e8484d73cee9e4128ac4b10e2a0d4209357481179022e8fdc
+  md5: baa8b304607b3a9ae8a3d9acb354c31c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33343
+  timestamp: 1699371216044
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-75.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: c6e56b4a14e883c7296b52673b4129e933d2bcfe45fafd8b504e62442aa290ba
+  md5: e658b6de04d59ad8fb45391c7e8dce54
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2318419
+  timestamp: 1726678116770
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/shapely-2.0.5-py311h41c673d_0.tar.bz2
+  sha256: 784dcfdfa8547eb6d59552b97d52cd4619999a66ca0028c8df262a6298d0175b
+  md5: 3a7efdb1fd39b9efcb325f9bf1fa3b56
+  depends:
+  - geos >=3.8.0,<3.8.1.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 596818
+  timestamp: 1722533782225
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
+  sha256: 9eaab5afd89c87ca139915589626785039fac30f05f8fb19e9eefe27eb935ce6
+  md5: babdcd3370f85ded3d313902dcebecfb
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 46224
+  timestamp: 1723557464934
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0eb44a16ef74a13ef7839209899d009cd94974fbc406a417d958c7bc8d955245
+  md5: 41f239a5b67b1daf819849023aa5d12f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19056
+  timestamp: 1705431379885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+  sha256: 14775231982e1ea150189c956927ccfb1ad01a8c9395cdeea4d5a48b9b8ce664
+  md5: 729badc4bf7ba8ccc70e0f9e58075c99
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89812
+  timestamp: 1696347694075
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+  sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
+  md5: 6bef1694163a68ac4c37e5857b8da4f5
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1900191
+  timestamp: 1714488351925
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+  sha256: 3d5c2968f581006437df3932cd5d3c1c4afa78f0e13757b958440245d3248856
+  md5: 605ea221d225ad8e79284dbcfdab0715
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37699
+  timestamp: 1678317755913
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/threadpoolctl-3.5.0-py311h85bffb1_0.tar.bz2
+  sha256: cb497652dc74d01957b3552dafed4b5a1002127403867409b72a8f6f1ce6d360
+  md5: c98fdcba2ed2a91a84ec80cf76af2660
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - blas=*=openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50030
+  timestamp: 1719407844996
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tiledb-2.3.3-h1b93210_3.tar.bz2
+  sha256: 7ff40023781ce8961c41886fd2a7c71aa5844c3135e80c20da14f05cb574a0bb
+  md5: 62681a61cd20436fe95391fbf801b53b
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 3039719
+  timestamp: 1685656939480
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: ed059e32ce5a1c0511575f29d2fb6da12c54a37000bfa80f9e5aa9dfd9e04101
+  md5: 4d2261a92d25136a68b8d01d101119f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49145
+  timestamp: 1678317386284
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+  sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
+  md5: 523c006cc67c011383678c762015479b
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3594448
+  timestamp: 1714770737885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+  sha256: 424b8284072266eb59d055c0b7b58241bfb00009d445743ea261d4eeee73ea19
+  md5: f3a47898a55087edb9d65d29c24d9b88
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135757
+  timestamp: 1678323030858
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.1-py311h46256e1_0.tar.bz2
+  sha256: f46d29f5c4f5fceb7a39343da76f5c5ab89cbb0844e80a3a90457201c3fbc168
+  md5: ee154208a17c1c4cd42d264b1a6f77c3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 914461
+  timestamp: 1718740220272
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.5-py311h85bffb1_0.tar.bz2
+  sha256: ec67885e979483932bf0ce9e720841d6f9d44bbc5a049f2e4a15232803f8362a
+  md5: 044460e02becd58190c03e794461acee
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 155741
+  timestamp: 1724854618448
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
+  sha256: 5283f2b23a6e9d888b2834cba2bbf284f551e199d2c1b4add176b1cbafb19ee0
+  md5: 58bf7871ca100fbda0492bb5a3363c80
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 208200
+  timestamp: 1718227205760
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: 17e5688d09ffbcb8b71b34b86edc7374fa0b04d60a4d729d405ffc22ef63726c
+  md5: e4bf44ddbbcb136332ccb47ac2b879a0
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9890
+  timestamp: 1715269046804
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: 7d369ec970d1d5411e457c79f94197756c7088deff8183806ea71e633b26edf9
+  md5: 9ffa197b26373667f50b21876862398e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 75595
+  timestamp: 1715269030928
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+  sha256: a9960485ced319ac91afe69eaaf703c7e6b3049f1e06a4a8c2818b64155943f0
+  md5: 0a9c8ea92a14330a07edabac249e32a9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11399
+  timestamp: 1678394892923
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+  sha256: d42ae57366d05e12f10074583568355752436d66ad018ffbcfa24135f593810a
+  md5: 1a98e48aa0bd8b3ec09e2cbdbb236575
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 498952
+  timestamp: 1713213079520
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uriparser-0.9.7-h6c40b1e_0.tar.bz2
+  sha256: 035b916c1eab3a6a27f0109d8e39fe37cbf8ebe0af948d88d7a3b96ab20dc999
+  md5: e697defd6c59ca6d98ab4bb5f951eb21
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 44105
+  timestamp: 1692186954114
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.2-py311hecd8cb5_0.tar.bz2
+  sha256: f46959a5ebab808e8a3fb6036cee2f6a0f3bfe42c81d00158d4d2a88837d60d2
+  md5: 7a554ae6cb2c33d09125ef897b39a4c5
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - h2 >=4,<5
+  - zstandard >=0.18.0
+  - selenium >=4.4.3
+  - requests >=2.26.0
+  license: MIT
+  license_family: MIT
+  size: 210587
+  timestamp: 1718912682770
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+  sha256: 0f8c3eb254be9c1957e748e385e20e62509d11052990c4755012be62434c9129
+  md5: 53229ba93f6e38308ae42ecfc6eaad9d
+  license: MIT
+  license_family: MIT
+  size: 96768
+  timestamp: 1706894705048
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+  sha256: 597015e8a038a111f03ffbc9a217fcda549d75230c86ce53c1f23c53d6f1a0cb
+  md5: 62e98aac883bccc1c87ca0d2ce2f08e0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25798
+  timestamp: 1678317074170
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: 1430e6f4b4dd9354b7bb88f7f7bc9cdbab26a034ad1ae5c278de0f5a99329372
+  md5: be0832862b29bf5767a707ac6bd53b93
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 114834
+  timestamp: 1715878445060
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.44.0-py311hecd8cb5_0.tar.bz2
+  sha256: 907fd39137318473d447c56d77f775c9d3fef5b4e840f8c43f50f8f9c016710f
+  md5: 2106db0f651f613ca1971e60afe3f5f2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 139423
+  timestamp: 1726165218455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: cc6995f677d1628f42ae80ed47ff08d8d1c8ed12580a326af6e307f5febc594a
+  md5: d01eb964863b95ef62061b77c9037ead
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2471632
+  timestamp: 1689041625741
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xerces-c-3.2.4-hcec6c5f_1.tar.bz2
+  sha256: 28cba861aa198f4f748010e8ea015a330e4f9403d89f70bcfbda003878a78fbc
+  md5: 44ff442e7aeb96a06f53d72aa76dd2ff
+  depends:
+  - icu >=73.1,<74.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 2832362
+  timestamp: 1692994769686
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+  sha256: 5b6d5246955b5f9480ff7027eb002442a7ade24f5c354da54ed513042f76cedc
+  md5: f32aa8a37d5e65a8dc30f9a1f46bc63d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54719
+  timestamp: 1678325412288
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+  sha256: ed0152ad6b87ffd9e01f4a62bc358e805ad59637f898a801b0a9cf903ae8e1fb
+  md5: 8a92f8c663608f24e14d8a2068b9d83a
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 415323
+  timestamp: 1714511993944
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+  sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
+  md5: c25b6d40f834647d0bbe767f6c776031
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 329449
+  timestamp: 1705602140856
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: e5fd1f8b8e5cc1221e85355ade7b69f0df640dbdc016b7f9ea0b0b6eda5bf9b6
+  md5: 11c4cb55382be5ab89b5c4085510db3b
+  depends:
+  - heapdict
+  - python >=3.11,<3.12.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 103266
+  timestamp: 1695833080541
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
+  sha256: 36fa7ad990aabf3607bda1f33e847888210974586363b6d69cf1ed092c192c35
+  md5: c981fe545122206cdeb647f2dc9e093d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 25496
+  timestamp: 1704207010227
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+  sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
+  md5: f2519b551f99765d9d98950c5e2b4713
+  license: Zlib
+  license_family: Other
+  size: 119782
+  timestamp: 1714511811597
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+  sha256: 7feb73e79bdbd45404ddc7a30c43bf4cc68eced8ce448ce7c31f5db134276fc5
+  md5: 48313bc6570c705cadbba3c356e0dc8e
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1014151
+  timestamp: 1714678461080
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+  sha256: 9ca3f0dfc2bdbc109e359ba7ab246e6ae952a14819148ad069454b52f2bda802
+  md5: 51fb05873a644cac52f0d1e10cb7969a
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.23
+  - uvloop >=0.17
+  license: MIT
+  license_family: MIT
+  size: 228856
+  timestamp: 1706220385566
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+  sha256: 43405cc7341ce3efb2e24013ad62c64f26a69926635adceaa5459ccbcafb3776
+  md5: effa6d22f497e164cc8455f7f329c304
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 12510
+  timestamp: 1677917870614
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+  sha256: 947efe1c50b3280e9a67cbb18636bdade53a40960fff3056850ff81ab87acbe3
+  md5: 7d2d384ee32ccc12dcb0dc099e421482
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 35091
+  timestamp: 1677915945226
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-16.1.0-hbc20fb2_0.tar.bz2
+  sha256: c88be5f2e95328d8ce44649753733633dafb646b727fa40c0392c151fa1b16ec
+  md5: 0b301ce50e318433007c6659b472ab1c
+  depends:
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - aws-sdk-cpp >=1.10.55,<1.10.56.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.5.0,<0.6.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libcxx >=14.0.6
+  - libgrpc >=1.62.2,<1.63.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.14,<4.0a0
+  - orc >=2.0.1,<2.0.2.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.10,<2.0a0
+  - utf8proc >=2.6.1,<2.9.0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 9859572
+  timestamp: 1721659135060
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+  sha256: 8259b4a0973c825ac81f581afcbe86640bd0a94b33caa996167309241877635a
+  md5: 49b8ddacfd3927bcaae139eadfb72ce1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153557
+  timestamp: 1695717951839
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
+  sha256: f536e8b60bdc895063ca0e0155d2041993caed5f932c232f2a0d8e52798da2f1
+  md5: daacfabaacebe1d1e53426ec3e385d14
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 86757
+  timestamp: 1706746162173
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
+  sha256: c356ce4cbd638a41fd3db59aa3559850e38c6b41188b8ffab32bdcbd9a55fe03
+  md5: e9dc8c248dda95e92533cae6815a0a8b
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 39456
+  timestamp: 1706690903374
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
+  sha256: 117825fcff2a68136a6e5183e05542c2654d73322e70daee3c50c0ecb3aec703
+  md5: b115d3f733fe8bae79b9d416754b260e
+  license: Apache-2.0
+  license_family: Apache
+  size: 182078
+  timestamp: 1706189905050
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
+  sha256: 241c19574abcaf91a47fc5c36f38e58c86732be5e06f5170063406098a58639f
+  md5: 3cfc3d38b8fdb25cc2e10e3e370d4106
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18039
+  timestamp: 1706690838125
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
+  sha256: d4c60f610e57b35a2962b8cea9911358d1642e0449468fa4967706af88bf5da9
+  md5: fc23856f141fe548afcfc4823881ee19
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 47155
+  timestamp: 1706697259456
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
+  sha256: c43ed35f4a64818ae39ca2c3c3652428c15da5e287f6e94254c3df4d6c759fb3
+  md5: 06366f5f8762447babf69804a04b1a69
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-compression >=0.2.16,<0.2.17.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 162746
+  timestamp: 1706744122437
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
+  sha256: 14e2ee7339c88089d1ff68f7144b3fb4f9e34fe538a9462f8de31dd6fdd1d42b
+  md5: 59ab0e7ffd73966ec6a2fa83a5df5c47
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 127084
+  timestamp: 1706696174505
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
+  sha256: 601baf006d0545ec65566701d99c601cba843e8ac03d80819d4b8bed23d1e5c4
+  md5: 2c98a19d57362cf1fbfec3dda3ea283b
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 61914
+  timestamp: 1706746732665
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
+  sha256: 16809db73ddc3c374ead2c2e9f2221894e2014d3e07ba62d79375cb4de4dfc9d
+  md5: c03f5e3b42bc59bd92db813522cce1aa
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 67560
+  timestamp: 1706747573116
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
+  sha256: 293cf6b9dfa727d0e65b383b0e434f8fb26480abd011516171b8652fd363c98e
+  md5: 2df2dd6c43a3b413b438a9ef834d78b0
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 48454
+  timestamp: 1706690816205
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
+  sha256: 773f7ff1a91af373d27f5c57833aff8912870108ddd94a5280bfdc608effe5e3
+  md5: fad8b095c03774c9d4901db7eda09002
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52142
+  timestamp: 1706192041205
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
+  sha256: 4efabe18fc312e65a5aac9b2ebe423296cfe702756891978244287ab47881927
+  md5: 5786a8ac037fd0e81e25f52dbc6dc72d
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
+  - aws-c-s3 >=0.1.51,<0.1.52.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 210683
+  timestamp: 1706827608490
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.10.55-h313beb8_0.tar.bz2
+  sha256: fe92c6408ee3ebf269b216d1c9576bc15e65a38bcf684f2a7b935e57dbf2e444
+  md5: 4c6b2dc15773f338a7f3299a753ab0af
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 2365300
+  timestamp: 1706890517127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
+  sha256: ae3c6633ed84bac16592b3b756f96ffc577414971014ca9efa498a162588757f
+  md5: ea600f99d012d734f831d1bc00a17661
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 281227
+  timestamp: 1718029919645
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
+  sha256: d51b7b5841be320209706d8e9caf669c0e0094f3a40e9eea51701a564ca7c2ed
+  md5: 61647f79e0ae70e914fee23c40c4caea
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43179
+  timestamp: 1675247655207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.1-py311hb6e6a13_0.tar.bz2
+  sha256: 4f861776f2954c67e690caba87d24de817fafe79964c1f6075a35c8bad2d2f2b
+  md5: cd4dc5659854265ae73d6a9127746990
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6089676
+  timestamp: 1718119235085
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
+  sha256: f1660ecfb8687d74e81a7b00699a8bb4677cbd791d14f50ba517de98e2f187ca
+  md5: 1636fc4b725da8c5e967952a55f3fd80
+  depends:
+  - libboost 1.82.0 h0bc93f9_2
+  - libcxx >=14.0.6
+  license: BSL-1.0
+  license_family: OTHER
+  size: 11780
+  timestamp: 1696762172661
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+  sha256: 688a071ba370f51b457cd32d70b7b38921ce9551203d06fa7fc2c30c4b79891d
+  md5: b2353077a39ab997463768154dd58fec
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134711
+  timestamp: 1707864978809
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/branca-0.6.0-py311hca03da5_0.tar.bz2
+  sha256: 0f5af59a0b198f514b57127ab7deeec9804d68d13a77e36c32341dd7ad0031e7
+  md5: 8c7e0f14f2ee41cb5791249210576946
+  depends:
+  - jinja2
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 54811
+  timestamp: 1677957274255
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+  sha256: 048264434c33fdb53862cdd69b2e2bc4ce6f8a70b3211ad6d686d066eac2aa91
+  md5: d55696ccaf6755931cd662dfb929aa0b
+  depends:
+  - brotli-bin 1.0.9 h80987f9_8
+  - libbrotlidec 1.0.9 h80987f9_8
+  - libbrotlienc 1.0.9 h80987f9_8
+  license: MIT
+  size: 19737
+  timestamp: 1714483270447
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+  sha256: 13627293296fcc231d8dc12d803dfc9621108c60df38b0e3c64e9e02ed55e564
+  md5: 86efd4ad08cd80d3eab77873db84a255
+  depends:
+  - libbrotlidec 1.0.9 h80987f9_8
+  - libbrotlienc 1.0.9 h80987f9_8
+  license: MIT
+  size: 19083
+  timestamp: 1714483255364
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+  sha256: 2e542b2bb27f8379da3efcb83ef084cb26e6a9ab576c50487c2dd996afd5ccb1
+  md5: e8cab9d1ef58a450f971690fcdb2ede2
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 380182
+  timestamp: 1714483330655
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+  sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
+  md5: 56d1386c7f1f338f0d18f82af6525273
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 158748
+  timestamp: 1714510571033
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+  sha256: b0be79290b1df1cf1d07a1a9c3f3a92ae262643a6df3dc10dfbac22a82874dd4
+  md5: 8fdcf1c08eee91fec7eefc22863c816a
+  license: MIT
+  license_family: MIT
+  size: 106550
+  timestamp: 1693902036526
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.7.2-hca03da5_0.tar.bz2
+  sha256: fe7a0afbef42d3a919d4017aab1aa5b975022b1a83175cca4ebde67bbf8c8bb6
+  md5: b1cc58c747f7ac1b6ef66ac3448f97db
+  license: MPL-2.0
+  license_family: Other
+  size: 137663
+  timestamp: 1720622028923
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cairo-1.16.0-h302bd0f_5.tar.bz2
+  sha256: c2f6508a6ede7d131884e906dbf409c781eb3cb04b6ebfa6a29a2310e1a8e0da
+  md5: 5febd95efbd8014e202562d7b0391869
+  depends:
+  - fontconfig >=2.14.1,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - glib >=2.69.1,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - pixman >=0.40.0,<1.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: LGPL-2.1-or-later or MPL-1.1
+  license_family: LGPL
+  size: 1403003
+  timestamp: 1688495951297
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cartopy-0.22.0-py311h7aedaa7_0.tar.bz2
+  sha256: 70bc64b33c059869de55a1629d18a85c81e9473e2e1f43578f38aa1ee3ff9605
+  md5: 9e47c054bbcc94755ecc856b53153363
+  depends:
+  - libcxx >=14.0.6
+  - matplotlib-base >=3.4
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20
+  - pyproj >=3.1.0
+  - pyshp >=2.1
+  - python >=3.11,<3.12.0a0
+  - shapely >=1.7
+  constrains:
+  - pillow >=6.1.0
+  - owslib >=0.20.0
+  - scipy >=1.3.1
+  license: LGPL-3.0-or-later AND (OGL-UK-1.0 OR OGL-UK-2.0)
+  license_family: LGPL
+  size: 2095879
+  timestamp: 1706196218316
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.8.30-py311hca03da5_0.tar.bz2
+  sha256: b5bf3208e126cb67926c2a36b5438d84eee9b8352ec007d6b143b0751ac6d8a8
+  md5: 07d0c4f8a1807db57b12a461f6142eb9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 170510
+  timestamp: 1725551796823
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_0.tar.bz2
+  sha256: 5b98c2dc6ebb5b3d5bf6e58ff3f495b4bf71b28de86ca299186554639de381c7
+  md5: a95cbad1b8d8cff239a8eb5d940c663f
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 292045
+  timestamp: 1726856478903
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
+  sha256: 3ba74ebffd6bc4bc451864f85048dec9b6ad085eb1904ce3e5450376e15f050e
+  md5: 289f238ac78b174f01c8a2b252b17735
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=7.82.0,<9.0a0
+  - libgfortran5
+  - zlib >=1.2.12,<2.0.0a0
+  license: Other
+  license_family: Other
+  size: 1243641
+  timestamp: 1655814869383
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cftime-1.6.2-py311ha0d4635_0.tar.bz2
+  sha256: e60fc249dd459f8794ca5b96367dfbfd876d4a8706ad2d200dea58f9905e7c64
+  md5: 092970bf83e050ce7b8646a1faac4a6c
+  depends:
+  - numpy >=1.22.3,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 223453
+  timestamp: 1678994382922
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+  sha256: df81a27f221d11af4a709f272dc8ba3fd3f6d5ab4ffd883c40567bcf04f0cfd3
+  md5: e49333e3ffe1fe2e701f50a6e6dccc52
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204179
+  timestamp: 1698129906257
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.0.0-py311hca03da5_0.tar.bz2
+  sha256: 340739a06e25afcd23ec4c5e5d45ac940feb16bee5122e1d14d261a2c80b5617
+  md5: bd85d021206472f6a6615575f126ed65
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43128
+  timestamp: 1721657439520
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+  sha256: 808e56fb70f3d38599ee7a54c2a707b282ba9a401fa69a1f54cdc26425d9ce01
+  md5: fc37321833175bda4fc5c21afe32db49
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 539588
+  timestamp: 1709758479776
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+  sha256: d9c126d8bcd1c89ea37186c172d6b1f73f45ada60e3ae1790a017b530baa0147
+  md5: f0223aae3d622547f6accb212579c58e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17967
+  timestamp: 1709322909223
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+  sha256: 1f908c688e47d03d92ac09d9541a1f1c773ac2ca485dd1d77441b1aaefc032db
+  md5: 444c330471496a39a97e87f41ed70c96
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281104
+  timestamp: 1700583698464
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.2-py311h80987f9_0.tar.bz2
+  sha256: 9e135f43ac703c578abe1b84761a1fb4ad75b63966f0b015fdcb939d3b05e7b3
+  md5: ab5b122dafc5b17f32b2ec8ce73d8adb
+  depends:
+  - python >=3.11,<3.12.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 403974
+  timestamp: 1701723703085
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-2024.8.2-py311hca03da5_0.tar.bz2
+  sha256: 4aacbf7dae263f81d1281b78e67f811982c977be4f3097f51de58ad0848d7351
+  md5: 73ff76a25b8b2144e11d28c833d31d56
+  depends:
+  - bokeh >=2.4.2
+  - cytoolz >=0.12.0
+  - dask-core 2024.8.2
+  - dask-expr >=1.1,<1.2
+  - distributed 2024.8.2
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.24
+  - pandas >=2.0
+  - pyarrow >=14.0.1
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6334
+  timestamp: 1725525201905
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.8.2-py311hca03da5_0.tar.bz2
+  sha256: 15839c0b76d580d62c4f06f834c6e2539a76034fdaf982911c389a017f7cced4
+  md5: 0c589d3d6f8d6ebe5996b2fff3620e1d
+  depends:
+  - click >=8.1
+  - cloudpickle >=3.0.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.4.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3119804
+  timestamp: 1725461423376
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-expr-1.1.13-py311hca03da5_0.tar.bz2
+  sha256: 9d41df91df3d0aa498f3de720a1e111ba8f6522ab7b109e87a64a0ff46eef7b4
+  md5: 4b8bb09acb791bdebb6da896a5a37e3e
+  depends:
+  - dask-core 2024.8.2
+  - pandas >=2
+  - pyarrow >=14.0.1
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 561561
+  timestamp: 1725523241610
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.16.3-py311hca03da5_0.tar.bz2
+  sha256: adf3ced9e94279c8700527309b650491a498e71cc9114caa517dd8beac136525
+  md5: de926408cadc24e8e062f5e686247c39
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy <2.0a0
+  - packaging
+  - pandas <3.0.0
+  - param
+  - pillow
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18017422
+  timestamp: 1720540529831
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+  sha256: b9356e3ada4872c7c950d2ac7e0f107c4786775191efdfda3a469dffb18f2714
+  md5: 07ddd96675caf30ea77cafb1ea5662a4
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2490144
+  timestamp: 1690905181398
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2024.8.2-py311hca03da5_0.tar.bz2
+  sha256: 71c057e91f66748e534adb341101df3644c2d3cbfa6b9a3d3ccb02dedd7df233
+  md5: d849272a6a043d96db4fb429e85ce9ec
+  depends:
+  - click >=8.0
+  - cloudpickle >=3.0.0
+  - dask-core 2024.8.2
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.2
+  - packaging >=20.0
+  - psutil >=5.8.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.4.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.11.2
+  - tornado >=6.2.0
+  - urllib3 >=1.26.5
+  - zict >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1825900
+  timestamp: 1725523100619
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+  sha256: b1481ffa475c65200626f051d5dcbdb264730b533e928dde608a79ce7a5b4e48
+  md5: aada2761547a291d68f4c016a1a9bc7b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 18265
+  timestamp: 1677911915719
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/expat-2.6.3-h313beb8_0.tar.bz2
+  sha256: 142b357054c77635d2a62f1a095b95a0d7c9adf3e06121f2b5f717d44c2111fe
+  md5: 43e2c7c99509cc831930aa1659c474bb
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 165907
+  timestamp: 1725543352377
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fiona-1.9.5-py311h7aedaa7_0.tar.bz2
+  sha256: f21e29d4281b14fe05478b92208ecd79a038998930d7435dc237fd47ffac78d4
+  md5: cee06f3915fd4e258b6e849187be8c71
+  depends:
+  - attrs >=19.2.0
+  - certifi
+  - click >=8.0,<9.dev0
+  - click-plugins >=1.0
+  - cligj >=0.5
+  - gdal
+  - libcxx >=14.0.6
+  - libgdal >=3.6.2,<3.7.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - shapely
+  - six
+  constrains:
+  - boto3 >=1.3.1
+  license: BSD-3-Clause AND MIT
+  license_family: BSD
+  size: 1162826
+  timestamp: 1704921012395
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/folium-0.14.0-py311hca03da5_0.tar.bz2
+  sha256: f7e6ee59efd1118f34a53b9b022511cb01d1e3fe2f2d8f3046f555f2a6eb33bb
+  md5: a2fb43de1f039d8e80cf3286ec0dba9b
+  depends:
+  - branca >=0.6.0
+  - jinja2 >=2.9
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  - requests
+  license: MIT
+  license_family: MIT
+  size: 136817
+  timestamp: 1677971749295
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fontconfig-2.14.1-h6402c1e_3.tar.bz2
+  sha256: 73c20700d3a1c761b0d2c3f7beec8ca45df571e9bba240e7be5bd667e26f5b3e
+  md5: 8171cb5f744dd4cbce6b1e63ee5d9285
+  depends:
+  - expat >=2.6.2,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - libxml2 >=2.13.1,<2.14.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 289660
+  timestamp: 1722921100495
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+  sha256: eb82a0e2ca36d0973b5f6642e27609554edad4b72696f989776d5db8cd4a6a42
+  md5: fa8d9dd8a2fabba964c6bb75ace8c572
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 3201601
+  timestamp: 1713551611540
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freexl-2.0.0-ha3de405_0.tar.bz2
+  sha256: 72c9da298576964ab1df878b31e78bd4d4dbe4a2cba3c5fa26c4c28cb1d73101
+  md5: 3655f44208f1ca8065195a43f9fefefe
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - libiconv >=1.16,<2.0a0
+  - minizip >=4.0.3,<5.0a0
+  license: MPL-1.1 OR GPL-2.0 OR LGPL-2.1
+  license_family: OTHER
+  size: 62175
+  timestamp: 1704742032594
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.6.1-py311hca03da5_0.tar.bz2
+  sha256: dea477d2b42cc015a051cc99d3c3ac0973df6c864088c8da0e77ab0713510b41
+  md5: d66f06e18672ef030741a74261313915
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - pyarrow >=1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 383596
+  timestamp: 1724855620851
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gdal-3.6.2-py311h950983f_5.tar.bz2
+  sha256: e7329e9ffe95eb88cec7533fbb567761967e91224d8564ab2467e989fc35f212
+  md5: f9ceb20cf40940ca146449ea24e5d3bb
+  depends:
+  - libcxx >=14.0.6
+  - libgdal 3.6.2 h51eea9d_5
+  - numpy >=1.23.5,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2168472
+  timestamp: 1722934125835
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geopandas-0.14.2-py311hca03da5_0.tar.bz2
+  sha256: d29e35f432d67d0d8af2bf69ea1570d7f90c0ece5bf4e06f1467e8397f759222
+  md5: a72181e7ca83308cd9fea8e5e49ba658
+  depends:
+  - folium
+  - geopandas-base 0.14.2 py311hca03da5_0
+  - mapclassify >=2.4.0
+  - matplotlib-base >=3.5.0
+  - python >=3.11,<3.12.0a0
+  - rtree >=0.9
+  - xyzservices
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7738
+  timestamp: 1704929067118
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geopandas-base-0.14.2-py311hca03da5_0.tar.bz2
+  sha256: 62a00facc1db52567eaec03014c6fd51e75592c1bd96f24ebd70c72db27b56fc
+  md5: 665415b1bed447a7b2cf6573e1fe050e
+  depends:
+  - fiona >=1.8.21
+  - packaging
+  - pandas >=1.4.0
+  - pyproj >=3.3.0
+  - python >=3.11,<3.12.0a0
+  - shapely >=1.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1532299
+  timestamp: 1704929023329
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geos-3.9.1-hc377ac9_1.tar.bz2
+  sha256: c901ff0682a8dcca5e77934a285af51dc7cfe5b0d2c22608d043d2940aecfb52
+  md5: 25182cc424f23f0544362ef982ce9138
+  depends:
+  - libcxx >=12.0.0
+  license: LGPL-2.1
+  size: 889806
+  timestamp: 1629009640131
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geotiff-1.7.0-h41f0982_3.tar.bz2
+  sha256: 77ff922ae1e5c060e14769b4ba274e384a7c9e611f7d3524acc1a16dd182f5c7
+  md5: 1945ea77a987535d3c7f483415aa7048
+  depends:
+  - jpeg >=9e,<10a
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - proj >=9.3.1,<9.3.2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 135163
+  timestamp: 1704901285550
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geoviews-1.12.0-py311hca03da5_0.tar.bz2
+  sha256: e2e7e8856e8f3619374b3de41e41fc22b95cf587fad5dbd9010ecbeb45cf6b80
+  md5: e3a3922c5157ec603ce4bf325c72183d
+  depends:
+  - datashader
+  - geopandas-base
+  - geoviews-core 1.12.0 py311hca03da5_0
+  - netcdf4
+  - pandas <3.0.0
+  - pooch
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - scipy
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6746
+  timestamp: 1713972561326
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geoviews-core-1.12.0-py311hca03da5_0.tar.bz2
+  sha256: 86c54e47c639149d480787b32ea1ae9d8e15fc46f885f5d304363aa6cd19988b
+  md5: cae539477289bce399216c36ae266b8a
+  depends:
+  - bokeh >=3.4.0,<3.5.0
+  - cartopy >=0.18.0
+  - holoviews >=1.16.0
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - panel >=1.0.0
+  - param >=1.9.0,<3.0
+  - pyproj
+  - python >=3.11,<3.12.0a0
+  - shapely
+  - xyzservices
+  constrains:
+  - geoviews 1.12.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 602983
+  timestamp: 1713972551007
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-0.21.0-hbdbcc25_2.tar.bz2
+  sha256: a9703c804e8377c081602e701536bb9ee3e45d73682ed991d4ab89b512f4dd6b
+  md5: f2541033cfec7a7244448619f81a5b0d
+  depends:
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - libxml2 >=2.13.1,<2.14.0a0
+  - llvm-openmp >=14.0.6
+  - ncurses >=6.4,<7.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 3546065
+  timestamp: 1722922815248
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+  sha256: 25e05b93a99914a5fd1a298a2c5b25479fbd571b0db9caa7c6ad4336f060f62c
+  md5: e213b68bb0274e0e54c610a041e059f5
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 150168
+  timestamp: 1706888198288
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+  sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
+  md5: 1d0bd7e576c64c059ef781dd319ad82a
+  license: MIT
+  license_family: MIT
+  size: 77591
+  timestamp: 1676983230102
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glib-2.78.4-h313beb8_0.tar.bz2
+  sha256: 3e9c434a66bffa098be94e78e27030da7ab2ff334d9f4281c4629fa77b1a90fb
+  md5: b3233037d5eaab7ccda0cfd2bfc0f68e
+  depends:
+  - gettext >=0.21.0,<1.0a0
+  - glib-tools 2.78.4 h313beb8_0
+  - libcxx >=14.0.6
+  - libglib 2.78.4 h0a96307_0
+  - python
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 508284
+  timestamp: 1708031704387
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glib-tools-2.78.4-h313beb8_0.tar.bz2
+  sha256: d911b7d543354da675d1538cd4f012d0709fd11ac67988120826725e70517745
+  md5: 3aa48599abab8066cfb3148ad90288ff
+  depends:
+  - gettext >=0.21.0,<1.0a0
+  - libcxx >=14.0.6
+  - libglib 2.78.4 h0a96307_0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 106508
+  timestamp: 1708031674414
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+  sha256: bbbcf47ef9249635b5199be1414b0b59687cc04ea9630d50ecc609dc200c095e
+  md5: 5820c373d6847a68551cadb8984a8277
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 95638
+  timestamp: 1706895270850
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf4-4.2.13-h5e329fb_3.tar.bz2
+  sha256: e9ccc7a4ec25606556785100e6ee1dd5d9b04ed1973978545a37bfe6be929ddc
+  md5: 2a40342fd2402a56d833312609fcf16b
+  depends:
+  - jpeg >=9b,<10a
+  - libcxx >=12.0.0
+  - zlib >=1.2.11,<2.0.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 913497
+  timestamp: 1629192094107
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf5-1.12.1-h05c076b_3.tar.bz2
+  sha256: 784ecf7eb9eee184a176cfc50498e041a353da3787f77fb96b18f9347ae8f954
+  md5: a5e4fb25fd69e50fb12d4a227b7048bf
+  depends:
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  - libgfortran5
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: OTHER
+  license_family: BSD
+  size: 6214795
+  timestamp: 1686167672819
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.19.1-py311hca03da5_0.tar.bz2
+  sha256: 456a62ed25e8801052a5fade2a30b245d1f3ce20163f9b4f8c6b6ab897db4797
+  md5: e4c7bea476dea67cd39bfa3be77b237f
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21,<2.0a0
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.1
+  constrains:
+  - plotly >=4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6098996
+  timestamp: 1720539818808
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+  sha256: 765d5b7ef75ed7f52a110504cd88e9b0c9977b841f1beaeeabb17e629b462908
+  md5: 0af9cd26a7c9eb8b77d3cbacb93a118b
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 360105
+  timestamp: 1715090588763
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+  sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
+  md5: 69eb3b03765627b6159ed23cdde78396
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28399065
+  timestamp: 1692293207812
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+  sha256: 4d4ab70ae0ce008c1cc96a4edfbf3866d5e636acc4799a545ea93acee51635f7
+  md5: 86a085a440729020d1d7b0b74d6a0c6c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148448
+  timestamp: 1714398923507
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+  sha256: ec139e4b87aadcacc0670ecbcc2a303d858d4ac38b9404458a4b676bce9d21d5
+  md5: bfcfed281f8df0f18726ec5f843b2b26
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 51053
+  timestamp: 1704813595720
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+  sha256: 63670c8f31770e1746016f645ca6b42b35f92d1c37e8025793d9490fed9998c0
+  md5: 9cb417b9fdf02b4e007a5b5781e5a8cc
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229932
+  timestamp: 1705934202146
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.27.0-py311hca03da5_0.tar.bz2
+  sha256: d2e3d351d5a509d9b384bba4684ff8ccd4fdc12a603f15a49e3d569d56ea413c
+  md5: c448971003786058866ba2239dc61986
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1636515
+  timestamp: 1726064271144
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.1-py311hca03da5_0.tar.bz2
+  sha256: 0dcfa64fca981f7c08f151bdb53b414e34c735184f1774ed9e0686f044488b9e
+  md5: 154a56110b37c8a84cc38e4f43d5ef5b
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1179602
+  timestamp: 1721058583397
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py311hca03da5_0.tar.bz2
+  sha256: bdbc36a516717a24b40e2a4ac812c4d097b6733f4c6654602556969e5e0d4062
+  md5: b31b2f2fd10d919c58c51fcbe54ef5c6
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353970
+  timestamp: 1716993463263
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/joblib-1.4.2-py311hca03da5_0.tar.bz2
+  sha256: cbf1f9070037d98cc2e729d3789d3ac76f01a7b36f302cd94bf2fb43528ab2e7
+  md5: afac24c80f4bc444a737c23393ad37e1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 547611
+  timestamp: 1718217291993
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+  sha256: 9d5cbffa98f3a4391f66b0c5ce1f411f0bfb0eb83137dc7146fb7bae23cb3570
+  md5: 95c92318023482e4e8c698ae6c4597fe
+  license: IJG
+  license_family: Other
+  size: 274078
+  timestamp: 1722872672311
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/json-c-0.16-h1a28f6b_0.tar.bz2
+  sha256: bb74124d37db18c31b4fef64d64f5809f50e9505ea5500437759b7fce8b2266c
+  md5: 0335d80562d5b6254f0d35791295241a
+  license: MIT
+  license_family: MIT
+  size: 75219
+  timestamp: 1659123705674
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+  sha256: 62025ce4a2b9244b9816c9e02487e0dda567600692b5f9ca71f425d084961c7e
+  md5: d57b7063122e5bf25cdfc2a5ea7330a8
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 181872
+  timestamp: 1699041739097
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+  sha256: 404b0847029f77bedd7902a170a046219e0dc5c0ec2be19ff45361cff25b2181
+  md5: 3a02bbe8d45fdbcb2350f672be74c9f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16524
+  timestamp: 1699032463763
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+  sha256: 7deb8ad28c34c369573754304a03ea2acda8ee39102a56526ec689a4d9210109
+  md5: 675ea1a746a78ff6bf8fc4b39139efff
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 277400
+  timestamp: 1677914250715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
+  sha256: ceec15c84f5c699b8055d01e046be04ccb7cfd7c8bd090fc18959f2a4d9f8cf8
+  md5: f85c11f7068312e1e84505efef9d55e3
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 98520
+  timestamp: 1718818476094
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
+  sha256: b2f1ee2a297e001a2e70bc218f60deb08c50b9b727668913ed5a106640413d2e
+  md5: fc4e797a17ff5dccadfb5d19346b7800
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43099
+  timestamp: 1718738212629
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
+  sha256: 2d96618ab2e9b3de870a713d7e5b19f6cde936291f3c87972f945b6e27024e77
+  md5: 534159d29d9aba9c7e70ee52c27b326b
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 614003
+  timestamp: 1718827110867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+  sha256: 501e929d345aaa9079c965552b942b4e8bde35b87ae89faef003687a40bab3a4
+  md5: 54c7b8554a405acd7c8326c41ba93e63
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28237
+  timestamp: 1686870817418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+  sha256: 773e7c4571f482a744dfb18ae26fb22635f5d3f51389c838bd97f9044ea55cc4
+  md5: 5161546aba5597318cb5653390cdecd8
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20235
+  timestamp: 1700168681687
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kealib-1.5.0-hba2eb73_1.tar.bz2
+  sha256: ebb886d4072bc12e08a90a8e14b61a2bbd4a17e69993f848982da2f7d60ed3d9
+  md5: 7da7333b8b4d51ab4408c66cd0bcd432
+  depends:
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 161523
+  timestamp: 1687966978773
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+  sha256: 8c1c64d51be73aad381992a9df19d8336910bdfc40f19940231df86e177d17cc
+  md5: b1f786f96684a143cf30d1f6b8aebdb3
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65045
+  timestamp: 1677925371836
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
+  sha256: 789402b67398d3d936ac4486df01869d59b0e1ba298cbd06407d059aced871e4
+  md5: a0f50a38705d0507bbf57ee49a1d9c29
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - openssl >=3.0.8,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1308175
+  timestamp: 1686931157327
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libabseil-20240116.2-cxx17_h313beb8_0.tar.bz2
+  sha256: 34390ba05b3d56366a2252f095f8bdf2527371854d981550db7485fc8290c10f
+  md5: c8055bc73af0ac231a8b507edc1ff116
+  depends:
+  - libcxx >=14.0.6
+  constrains:
+  - libabseil-static =20240116.2=cxx17*
+  - abseil-cpp =20240116.2
+  license: Apache-2.0
+  license_family: Apache
+  size: 1246977
+  timestamp: 1716563341094
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
+  sha256: c1f104bc84ee46a3d3beafb5e35236c64e6b4fd6cceabfb420e1838171b1d9c1
+  md5: 4f95903a1be48bbee1f9a818ec810b89
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 22243663
+  timestamp: 1696762144385
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+  sha256: 199042b87451abaf14546af124ae3380194cddda928e0d30ccb341e93084854c
+  md5: eaa0442887994a82486c65d87f6b71e6
+  license: MIT
+  size: 68806
+  timestamp: 1714483212137
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+  sha256: bd9a8a17fb14086446b710fa029d238e69274b83ee2e7e09093496f190de82b5
+  md5: 66615d6a0cb5dcca3e20c019cde0ed2d
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_8
+  license: MIT
+  size: 32975
+  timestamp: 1714483225840
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+  sha256: e1bf77e8b975c30a69b08a08410622e27c8cff6f592ccfa590466b83d9e6d104
+  md5: 8af86bdac01fe303d693d9b76c071059
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_8
+  license: MIT
+  size: 310266
+  timestamp: 1714483239194
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.9.1-h3e2b118_0.tar.bz2
+  sha256: 405b50a404f55b4cf4edcb17c89e1ca345dddc4cf6005a1a137048356eb2ccce
+  md5: 453584721c8f42a972fcace8ffeab37a
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.57.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=3.0.14,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 381982
+  timestamp: 1725034052027
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+  sha256: 9597df5344a718d37837966aa05091faf210260898fad5e7a64b87f17de9e90d
+  md5: 678a1f87940ef6cc421a092301b8c3fe
+  depends:
+  - ncurses >=6.4,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 167208
+  timestamp: 1703006281321
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+  sha256: 6fc572025852b210ecddcca3ab9ff3f1d5f6bd91f1933c6e296de6bb331f6b5d
+  md5: 6dd7d9c5737bbd2a27d18f15318dc3e6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 102059
+  timestamp: 1628961869728
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+  sha256: 9e7b9bb9367d8725a751cdfa0b2d270434d303ea196cfaacc605ee26be09874a
+  md5: 44d1843cc2f17eb2674f35b95468f551
+  depends:
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 415467
+  timestamp: 1685052299052
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+  sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
+  md5: f31e4eb9cd6447cc2f5ef0243a76540c
+  license: MIT
+  license_family: MIT
+  size: 120460
+  timestamp: 1714483461787
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgdal-3.6.2-h51eea9d_5.tar.bz2
+  sha256: e8f56a084dfd80a88e805742b19e618f821e2bbdc366cd60ff2fd7434a08d23b
+  md5: fedb5af05876b2088f1dd08585c0b48b
+  depends:
+  - blosc >=1.21.3,<2.0a0
+  - cfitsio >=3.470,<3.471.0a0
+  - expat >=2.6.2,<3.0a0
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.9.1,<3.9.2.0a0
+  - geotiff >=1.7.0,<1.8.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - hdf4 >=4.2.13,<4.2.14.0a0
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - jpeg >=9e,<10a
+  - json-c >=0.16,<0.17.0a0
+  - kealib >=1.5.0,<1.6.0a0
+  - lerc >=3.0,<4.0a0
+  - libcurl >=8.1.1,<9.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libiconv >=1.16,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libnetcdf >=4.8.1,<5.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=12.15,<13.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libtiff >=4.5.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxml2 >=2.13.1,<2.14.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - openssl >=3.0.14,<4.0a0
+  - pcre2 >=10.42,<10.43.0a0
+  - poppler <=22.12.0
+  - proj >=9.3.1,<9.3.2.0a0
+  - qhull
+  - sqlite >=3.45.3,<4.0a0
+  - tiledb >=2.3.3,<2.4.0a0
+  - xerces-c >=3.2.4,<3.3.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 9407485
+  timestamp: 1722933829430
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libglib-2.78.4-h0a96307_0.tar.bz2
+  sha256: 1646f1af879f87ac99b02cab3d93b94dd23c8a1ec53102de59689b8c33557861
+  md5: 38df07115736878de127de290cad1d75
+  depends:
+  - gettext >=0.21.0,<1.0a0
+  - libcxx >=14.0.6
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.16,<2.0a0
+  - pcre2 >=10.42,<10.43.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - glib 2.78.4 *_0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 3118001
+  timestamp: 1708031641409
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgrpc-1.62.2-h62f6fdd_0.tar.bz2
+  sha256: e6e4e402ba9350955e9472f33ae7ce4ed712b6ad38b9b5c532e68bfb02646390
+  md5: f5f2fdfe7750c7757efab6848e873b0c
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - openssl >=3.0.13,<4.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - grpc-cpp =1.62.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 6756803
+  timestamp: 1716834849823
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+  sha256: 72d242814b990900c9410d4738cc685f70ea71231742293cffbb475d8df100f8
+  md5: f9976688992b7ac4b56f5600ee15b5c4
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1407202
+  timestamp: 1714483550601
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libkml-1.3.0-hc4d7c42_7.tar.bz2
+  sha256: 3934364764ac9651132865f4bfaf3ae17f4bdbf2a96bd5ee7faec7995c556fb7
+  md5: 8012eb6fc2f5750fea616fe03b1be95e
+  depends:
+  - expat >=2.4.9,<3.0a0
+  - libcxx >=14.0.6
+  - uriparser >=0.9.7,<1.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 448001
+  timestamp: 1693261840201
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h19fdd8a_4.tar.bz2
+  sha256: fd3149d43dd971c2c1243a1f06a6b4e6ca1e405f058a8a6544267de4940c0622
+  md5: 53449788cfa51053aed142dcdc1143c4
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 26599780
+  timestamp: 1726766682927
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnetcdf-4.8.1-h0fce390_4.tar.bz2
+  sha256: 9b96c9b9ae04e51afd1eedb06140136aa2cac53445391631fc797b19cdb159c3
+  md5: 88d838a69640da6ba12b5074ad88c617
+  depends:
+  - hdf4 >=4.2.13,<4.2.14.0a0
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  - libzip
+  - openssl >=3.0.10,<4.0a0
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1459940
+  timestamp: 1691154694652
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
+  sha256: b7cd58ddb892ed9d3983bdde8fc2530f0653a58818c87e08659f3795f04d8aff
+  md5: cf519f7233951d00a30c3b969c4cd161
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - c-ares >=1.7.5
+  - libcxx >=14.0.6
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 728977
+  timestamp: 1697018415626
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpq-12.17-h02f6b3c_0.tar.bz2
+  sha256: 549664d70c08f95e101e43c7cdb44a3c7a4313c4b759133c4d97c473afab73d4
+  md5: 382a8ae341228d5e0d0de28992e9e412
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - openssl >=3.0.12,<4.0a0
+  size: 2946756
+  timestamp: 1706214474947
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-4.25.3-h514c7bf_0.tar.bz2
+  sha256: b628e7b726fc1d77b9b3f8d3078757de8cbc20399a4b0fbdaff6526ba82c4cec
+  md5: a92f039187d790f9d8d507549ef61914
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libcxx >=14.0.6
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2665938
+  timestamp: 1716567699253
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libspatialindex-1.9.3-hc377ac9_0.tar.bz2
+  sha256: 592a66a6145b5eee819a97caf509b996c84fe2c9ecd69c7e300f8b2a02050682
+  md5: 65682197af5a83e3ce46b5d04d44ef3b
+  depends:
+  - libcxx >=12.0.0
+  license: MIT
+  size: 386585
+  timestamp: 1629286650261
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libspatialite-5.1.0-h3e2df84_1.tar.bz2
+  sha256: 106668624ee0042c096a21d3b6ceaa92b6946bed44af1d9d18b4a80654be8b4f
+  md5: e94ec5458fc20edbc4d4053c256873ca
+  depends:
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.9.1,<3.9.2.0a0
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - libxml2 >=2.13.1,<2.14.0a0
+  - minizip >=4.0.3,<5.0a0
+  - proj >=9.3.1,<9.3.2.0a0
+  - sqlite >=3.45.3,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later
+  license_family: OTHER
+  size: 4009501
+  timestamp: 1722878455670
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.11.0-h3e2b118_0.tar.bz2
+  sha256: 8340de7b6d57959aba55785d3784acfbdf5cc61283b0daeab03804319f2663b2
+  md5: ee17e0c05e45b91f073113364ab0030f
+  depends:
+  - openssl >=3.0.13,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 262918
+  timestamp: 1715261490602
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
+  sha256: 82a73882a31e7a4f4edcdb0c21562e123da913d03b90b19396bd6dd4fcd9a7fc
+  md5: b5e5199892949d1e7e2db7bf0ee4dfe9
+  depends:
+  - boost-cpp >=1.73
+  - libcxx >=14.0.6
+  - libevent >=2.1.12,<2.1.13.0a0
+  - openssl >=3.0.9,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 361781
+  timestamp: 1687975246139
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.13.1-h0b34f26_2.tar.bz2
+  sha256: f84299f0fb53bb22cc8b735d7ad0cacf9daa54b58166934f2bcf1e47ec88c6e4
+  md5: 8686fc79ea861f1bf3f303e767403f72
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 628190
+  timestamp: 1722441197607
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzip-1.8.0-h62fee54_1.tar.bz2
+  sha256: f251f0003d6438118c386d0a86c51c74d1f5c64dfab630006703e98dedda6970
+  md5: c001b83d3596059c5536b73b17422797
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 121403
+  timestamp: 1685378612307
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+  sha256: 41c62a460bb81a1a272aa28b219fab9c26510adac177ff1528b1980eabc6e868
+  md5: 8d312c5628dc7ea833e9b4dcb73e9c45
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 42346
+  timestamp: 1677973051421
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.43.0-py311h313beb8_0.tar.bz2
+  sha256: e30d9731f52550ab97edacacf9bc11f53d64202e06fbc1747b263c18f26a924b
+  md5: 36e9863286c1022e2439cb56b83bc1ce
+  depends:
+  - libcxx >=14.0.6
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 409623
+  timestamp: 1720455480232
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+  sha256: 5777bbef827f72975a36f3da80ab4af718dc781264f74ad7e3864755d620c0f0
+  md5: 4240f1a79b812387919cc710a0469556
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14318
+  timestamp: 1677925438733
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.3.2-py311h80987f9_0.tar.bz2
+  sha256: 14582ae62269dca40493afba1649f929841f5d2bc5907bf0f6f01c6a551062c4
+  md5: c920d6dea31be5638d79a76026d523a0
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39941
+  timestamp: 1686063850483
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+  sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
+  md5: f5f7e6e7541d8dc3d3df270d488d2e24
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176990
+  timestamp: 1714510588159
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mapclassify-2.5.0-py311hca03da5_0.tar.bz2
+  sha256: 879edffd737b34f642fc6db56d9cea345d53d78f218eb7096683347e88cb81f3
+  md5: a9165e4af0562b7a1012b7e6d569710a
+  depends:
+  - networkx
+  - numpy >=1.3,<2.0a0
+  - pandas >=1.0
+  - python >=3.11,<3.12.0a0
+  - scikit-learn
+  - scipy >=1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84621
+  timestamp: 1677993482204
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+  sha256: d024f5142416961a5e66e424d4d14aec652f9e9dd738b41a97f45674c2ffc9d5
+  md5: 0e2d94b125d802f7b006cf19c71655a1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 163084
+  timestamp: 1677932947966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+  sha256: acfd84e29ff4dc2d85543bb973a07f22b4ba53c5d00bca84608ee7f13b2a8676
+  md5: 5ca161cd51e2db358e768453b3ee485e
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135871
+  timestamp: 1684279980293
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+  sha256: b1bed54c7bfb7304cde9e8e6f798543d08e808e81286a5a48296fc94d621f9da
+  md5: 774358285c9e496c9f5c121cc546c823
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27438
+  timestamp: 1704206026910
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.9.2-py311hecf7826_0.tar.bz2
+  sha256: 405da586a7522b94b0fadaf268e34a289aefaa7a1cc49da8702a13fcff1152f7
+  md5: 60d5ec1d897778a50874147ffb31e7db
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9423902
+  timestamp: 1725263975062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+  sha256: 3276d61fc353c537bb09d4b7473d7abe12be38806f42c8cc383b62f40850a5cc
+  md5: 6e9c9d47f264b77d9a8461f0899848a7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20446
+  timestamp: 1677918370379
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+  sha256: 43c96d30775b61b4968422a47f9605049428120669f0742bbb9e5ba145c7d11e
+  md5: a31ca0d9284860adf5463cf45a5e3145
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 69243
+  timestamp: 1677995336989
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+  sha256: 96d8c9f42a38651b7bafe5f3cb132601db76cd1e28fa58e2eaf090e634292fff
+  md5: 5ebc793a17b6aa84d13f19433545ffa5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23895
+  timestamp: 1677942274932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/minizip-4.0.3-ha89c15f_0.tar.bz2
+  sha256: ce004bae8d89b5f3205073c2ebfd2c5640983b3ce2764e3ab7eb6ee8b79622f1
+  md5: 13e620ec7fb353b7fe5da72085513509
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - openssl >=3.0.12,<4.0a0
+  - xz >=5.4.5,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 85926
+  timestamp: 1702658542217
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+  sha256: db9bd659ada23f1ded443d2db00dd13b5d5c0b30f5062544b1ee2c2b88d63d29
+  md5: 03c48121614cf12abfe30eced9b34717
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105333
+  timestamp: 1677916687032
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py311h48ca7d4_0.tar.bz2
+  sha256: 3e370e88a51671f87fa0c0e241569950f8c5a38d5e8743c33b0193f54d73d10d
+  md5: dd70eac354c92710ce4e2be9d4b02043
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 38448
+  timestamp: 1677909415759
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+  sha256: 8b05894fdcbe5cfcdee94812b043de4cd7b4fa51d3e2aad25fc7cff50c8f82ab
+  md5: c970d49137dce1c77f782ee5725950c1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 30745
+  timestamp: 1677960816849
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
+  sha256: b6fa12e4bde747bf288bda31ce8ec5e24292dbf74fde67f18f9c9c100b845a38
+  md5: 2eddc760c15171a1e8aa838d9d162e18
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8291605
+  timestamp: 1717622676584
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+  sha256: e8eee27fb667aa10b26f3bc4b93f449b7d991ded27b9cb457effee394ce05f6f
+  md5: 6a3e5cd0e1141c01ffb91285bdccfe83
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123043
+  timestamp: 1698934328890
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+  sha256: 40230434aa2fbb33ece13632e8d4b7cd1ad68fdb8d1b00263af4a010795d25f8
+  md5: f12ce7dad3620d6d53a442fa9d36a0b0
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - pyqtwebengine >=5.15
+  - tornado >=6.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 538067
+  timestamp: 1699022954841
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+  sha256: a492acec8ceadc0911a75966ffa630a8eb15b2da8c7a8d544a645ba47771a2d1
+  md5: 4002b1b88b2ecfdfc769036f43b0a895
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 170964
+  timestamp: 1694616845237
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+  sha256: 417ace1ce51e81f3f92ddc26e0e3a83c1e19c9ebb7af7104452002a5573da534
+  md5: 3e11de6cef096091bb733e07802f00b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16979
+  timestamp: 1708532698253
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/netcdf4-1.6.2-py311h55fefbe_0.tar.bz2
+  sha256: 2f9cf6038c9f3c986c66c926b5be0ff5a39b6e57647d77f90bdc5cbcc7761039
+  md5: 0b06a7960b828a49e7b58f2a312af1bc
+  depends:
+  - cftime
+  - hdf5
+  - libnetcdf >=4.8,<4.9.0a0
+  - libnetcdf >=4.8.1,<5.0a0
+  - numpy >=1.22.3,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 458619
+  timestamp: 1677960888123
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.3-py311hca03da5_0.tar.bz2
+  sha256: 9756a4aa4a76af06a19f0bf3efd3a27b46a0996d8fbbc5c2aebbb2facccb6165
+  md5: 6bb9e48cc0a0a0f96256cf19a67e34cc
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - pygraphviz >=1.12
+  - pydot >=2.0
+  - pandas >=1.4
+  - lxml >=4.6
+  - numpy >=1.23,<2.0a0
+  - sympy >=1.10
+  - scipy >=1.9,!=1.11.0,!=1.11.1
+  - matplotlib-base >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3354447
+  timestamp: 1720002587103
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
+  sha256: 8ea1be4285e2e7d361cbcc1daf9c220f87ceaab2308bf7b339d2513d6ea22184
+  md5: 774ce02efa90f212023541c0b24e92c1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 726598
+  timestamp: 1717630964815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+  sha256: b0cc542e2a6f42ba716e7e4ccf29eddcb155ad167fcdbc72d2db9c7873eb5639
+  md5: 7acf81b17d2c4ceb3cd39dc9f173855c
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27539
+  timestamp: 1699455954000
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nspr-4.35-h313beb8_0.tar.bz2
+  sha256: 49514dcfb22fb667890bebf464118e59f0c05b0574e39082cf06d4e171fc7f22
+  md5: e7808cc8e4a810fe3d9390192c44c619
+  depends:
+  - libcxx >=14.0.6
+  license: MPL-2.0
+  license_family: OTHER
+  size: 252418
+  timestamp: 1685541795239
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nss-3.89.1-h313beb8_0.tar.bz2
+  sha256: 01fe9808891853091be4aea4f05882ce1991d737e9f409dfc31ee4daa199019e
+  md5: 9c3977aa66fc7d91d83f63d79792ee1d
+  depends:
+  - libcxx >=14.0.6
+  - nspr >=4.35,<5.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MPL-2.0
+  license_family: OTHER
+  size: 2038812
+  timestamp: 1685543329548
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.60.0-py311h7aedaa7_0.tar.bz2
+  sha256: 00a7fab2dc788b2f4d748702d9eed2cca75d7486aeff0209f0c2979e2ec28a40
+  md5: dc8ceb8ae25109aa6c9face25605e269
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - cuda-version >=11.2
+  - cuda-python >=11.6
+  - numba-rvsdg 0.0.*
+  - scipy >=1.0
+  - libopenblas >=0.3.18, !=0.3.20
+  - cudatoolkit >=11.2
+  - tbb >=2021.6,<2022
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6146936
+  timestamp: 1720609337122
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+  sha256: 151a3eb68d1189e69764ece1d8fb3544d31a22f5bbbc3e19d846de8dece304d2
+  md5: eb6609e6bdc9c82d70df3f8c4c2de95b
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153313
+  timestamp: 1696515415712
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+  sha256: d3bb1d4be88320a5861cd3a0f086e9709f9b64c96c032cb9039cc4f17ec66a85
+  md5: 0a7b97665c06fcd34a70e34abc177280
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.26.4 py311hfbfe69c_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11288
+  timestamp: 1708639168951
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+  sha256: 3e70248a7069ca12ccf56252869bfdb72211fd4e4c327e6994756496df786c79
+  md5: ce4846006d98638cd86a532a72f8dfe4
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311he598dae_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7536860
+  timestamp: 1708639153133
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
+  sha256: b9f781280f49644ca05e18aacbdde1c57cc5107e7cc2471b843ea8461672aa7f
+  md5: 9125d30e4e105b45f7f7d9c20acafa10
+  depends:
+  - libcxx >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.7.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 450131
+  timestamp: 1722872679313
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.15-h80987f9_0.tar.bz2
+  sha256: 503def27e5229dc31eb3eea4c86ecabcd46a27b6711a968bafeaf7facfc8eeb1
+  md5: 2261823151398e7df6ee94c234f21f11
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4762637
+  timestamp: 1725545955868
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-2.0.1-h937ddfc_0.tar.bz2
+  sha256: 504f44b8b91a085a34fc2674ecfc8e617108cf1fa3484a2e24bed7e16e40679a
+  md5: 837ad487be774903686ba041dfad8795
+  depends:
+  - libcxx >=14.0.6
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.10,<2.0a0
+  - tzdata
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 505018
+  timestamp: 1717104635074
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+  sha256: 77b0c0a0fb14d817390244ebd93c36d44a7867239963f211f7c0a72a3f98d382
+  md5: b90336feb8a50d2eff880e89acb02f40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39617
+  timestamp: 1699371253760
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.1-py311hca03da5_0.tar.bz2
+  sha256: 077c5a53916492c8903911dc8f2661403a95488c937c44233401aaf1b4e513a9
+  md5: f996a0feb121848b1e43889b2c523328
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 158057
+  timestamp: 1720102085523
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.2-py311h7aedaa7_0.tar.bz2
+  sha256: 3ee48b8e32d5009fccbb8e0dbb00d905f827982adae9c9f799ad85ba6f13a077
+  md5: 9e6f48d13a7911f6b5547e6a9c8dc5e1
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - jinja2 >=3.1.2
+  - xlsxwriter >=3.0.5
+  - pandas-gbq >=0.19.0
+  - scipy >=1.10.0
+  - openpyxl >=3.1.0
+  - pymysql >=1.0.2
+  - s3fs >=2022.11.0
+  - dataframe-api-compat >=0.1.7
+  - pyarrow >=10.0.1
+  - xarray >=2022.12.0
+  - fsspec >=2022.11.0
+  - sqlalchemy >=2.0.0
+  - beautifulsoup4 >=4.11.2
+  - html5lib >=1.1
+  - lxml >=4.9.2
+  - gcsfs >=2022.11.0
+  - zstandard >=0.19.0
+  - qtpy >=2.3.0
+  - tabulate >=0.9.0
+  - blosc >=1.21.3
+  - matplotlib-base >=3.6.3
+  - adbc-driver-postgresql >=0.8.0
+  - numba >=0.56.4
+  - pyqt >=5.15.9
+  - odfpy>=1.4.1
+  - pyreadstat >=1.2.0
+  - python-calamine >=0.1.7
+  - fastparquet >=2022.12.0
+  - psycopg2 >=2.9.6
+  - adbc-driver-sqlite >=0.8.0
+  - pyxlsb >=1.0.10
+  - xlrd >=2.0.1
+  - pytables >=3.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17039081
+  timestamp: 1718309063969
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.4-py311hca03da5_0.tar.bz2
+  sha256: 30a99806e616ba4270fd3f517eff88728e50eaaa3a46dd811476eadc4744444a
+  md5: 81c2a30ee5913e37fe552f51ab9b19be
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.1.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21836599
+  timestamp: 1718119512521
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.1-py311hca03da5_0.tar.bz2
+  sha256: 7c4d34def227ba26cea176cd3d522aeb2584989e68052c387925536097cd1f63
+  md5: 025e2c935f86e471a35d584c40bbed29
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264597
+  timestamp: 1719348054960
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+  sha256: 088245becd055af4de74e4ed13cc752ab546423f204b170ba2dd8809af30a2c7
+  md5: 2eabea5ccc56ac088e0349626e59df06
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48517
+  timestamp: 1698702686783
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre2-10.42-hb066dcc_1.tar.bz2
+  sha256: 2e3e84ff33de1dfe5f51f04fee5966245629f55e08f5227f2c82e0cc96507ef6
+  md5: e3a0c4f02b456d965cdba237423b80c1
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1562789
+  timestamp: 1714657668464
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.4.0-py311h80987f9_0.tar.bz2
+  sha256: 4302dcc5c779ae3ceb65c9641bf7ffab447a113be8df1903b08329be8ebf0dda
+  md5: a0bcdedab49d87a75e069112dbae7d85
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 937161
+  timestamp: 1721059673573
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.2-py311hca03da5_0.tar.bz2
+  sha256: 4f82ab7dc13317069ec808da81c472668e6ab85f5d74d5b385b6d86b4ef32bad
+  md5: f9c03ed21097422236806938a7b7dd64
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2918476
+  timestamp: 1723484709578
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pixman-0.40.0-h1a28f6b_0.tar.bz2
+  sha256: a7b1a6ddba772080777ac65570dffa9ed08dd866e053fa98f3aa38835c9b010b
+  md5: a3abe939bd01b7f6fb4e4f3b6da91f7b
+  license: MIT
+  size: 269396
+  timestamp: 1628926728556
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+  sha256: b6200816d65673aa1707c20a768c9cff87dd8dbe1335f9c1478e5931dfa08ee0
+  md5: 14b1e0fa73eb33f9c83048482dcce57b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38423
+  timestamp: 1692205689597
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pooch-1.7.0-py311hca03da5_0.tar.bz2
+  sha256: 1571b209edc53736c9553ed18bcf571403c0a6068f59fbe9bb692e602aef3d77
+  md5: 86d822035dc65f8a0d6986e7c4e4c2e1
+  depends:
+  - packaging >=20.0
+  - platformdirs >=2.5.0
+  - python >=3.11,<3.12.0a0
+  - requests >=2.19.0
+  constrains:
+  - tqdm >=4.41.0,<5.0.0
+  - xxhash >=1.4.3
+  - paramiko >=2.7.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 106499
+  timestamp: 1695850196324
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/poppler-22.12.0-h52f4003_3.tar.bz2
+  sha256: 9f8cf7e763c5ce4cf0a5ebfc8db8b885b3c4e70c9b9433a96f5500b7fba4f3cc
+  md5: 40ae9e180cbf21de5afdfe4fd096849b
+  depends:
+  - boost-cpp >=1.73.0,<2.0a0
+  - cairo >=1.16.0,<2.0a0
+  - fontconfig >=2.14.1,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - gettext >=0.21.0,<1.0a0
+  - glib >=2.69.1,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - nspr >=4.35,<5.0a0
+  - nss >=3.89.1,<4.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - poppler-data
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 1749726
+  timestamp: 1696000773528
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/poppler-data-0.4.11-hca03da5_1.tar.bz2
+  sha256: 964a66d899c6c661baabf19c89dfeb71586ca495efb5dfe141c3d4d1447e87e6
+  md5: 2fd602e0516b7352f115305cba7708a9
+  license: GPL-2.0-or-later and GPL-3.0-or-later and BSD-3-Clause
+  license_family: GPL
+  size: 3918339
+  timestamp: 1673886276945
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/proj-9.3.1-h805f6d4_0.tar.bz2
+  sha256: 822ddf540e6702714be8691b449d570e8b086b6ba11c74dfcf956c8e4bc37d7a
+  md5: 20f3d6ee5166bf3a89175c703ffba3f1
+  depends:
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - sqlite >=3.41.2,<4.0a0
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 3037164
+  timestamp: 1704728708532
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+  sha256: ebdf211edd98d88a23778551c7a9702106edd0695d4fc48e87c21f77521c1ffe
+  md5: d8c505081a468f1b99c62466e2309417
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 123084
+  timestamp: 1678996822234
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+  sha256: 07cfba50d9e94364bde077731a824ca4f537138b35ee6b66d07aee16ac9850f1
+  md5: 919bf486280a11e6acb3c2c3a82f7473
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763225
+  timestamp: 1704404463402
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+  sha256: 8094436b2c44e68e72569c704633802aad82e977b1e16026848218679c8becf4
+  md5: 2360e46d3e598dd5e2abed781fe166c5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 502115
+  timestamp: 1678995719872
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-16.1.0-py311h7aedaa7_0.tar.bz2
+  sha256: 5f958c3434a27f1e95dc17918ea2bace13c95fda83d784449f63c53c9af4f13a
+  md5: e83cc83394ec825f5a1c95f5d276ff84
+  depends:
+  - arrow-cpp >=16.1.0,<16.1.1.0a0
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4857208
+  timestamp: 1721674203411
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+  sha256: 4f17f70658e32a9a86661184cace6be3bb7bd61f9b55b513092beddf44552679
+  md5: 0aa95279688b0433badea0b660ac8146
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38653
+  timestamp: 1677933613643
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+  sha256: 121b5b66721760c05f1d4eee91626229d1814663d3fb5f23126ef870aa496e26
+  md5: 0c588c2ca790a05d422c06e8568201ad
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2124200
+  timestamp: 1684280082141
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.1.2-py311hca03da5_0.tar.bz2
+  sha256: 4ab265ca91c0d88f68a7fee197dc9253aa6f5c4b1e3ae3469b7a042551faf59a
+  md5: 3225d4ec5e761e40f524727cafe781f9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 460107
+  timestamp: 1725041695293
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyproj-3.6.1-py311h041c639_0.tar.bz2
+  sha256: c8c55bae91000aa066ab44144ec20fc4704415e85ab3066952dccd7d5eb81176
+  md5: e030800d83b234505dc35b4eafc41004
+  depends:
+  - certifi
+  - proj >=9.3.1,<9.3.2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 599383
+  timestamp: 1704901394028
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyshp-2.3.1-py311hca03da5_0.tar.bz2
+  sha256: 6bdb5646ba3634799356b14377eb6ae3576bb7643da8bf6b47295864a3e1393e
+  md5: e330fead08da221c20ee1dec20e89935
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 86945
+  timestamp: 1706101072054
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+  sha256: 0bb3d2a57b332c5cf73ea40ea13c850ae24a1f9a3a41ed9267832d9e3c767572
+  md5: 45a7fcf1641980d5114999736428502d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36755
+  timestamp: 1677906514270
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
+  sha256: 960c343b7b8569dfe4e71a395f7bede1e749da7b02c17506b590c9e1839e6fd7
+  md5: 722c4b4386af73cf1562974a00c880a4
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16494386
+  timestamp: 1713545544909
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+  sha256: c3cbf5bd237b0a7458640191016b2701fe120c547df9afc835da76663a9c17f7
+  md5: 843568c76b6b9384635b7fca74c79792
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332222
+  timestamp: 1716495881101
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+  sha256: f94b3cfea6f76ea9983e16d3c4c7e0a64f02c40cc2c3ad57189bca2e67030bd9
+  md5: 0d100990ade57a02b60d1e8085db0bdf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 280263
+  timestamp: 1678996927464
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+  sha256: 252c86f5aef7f8dfce99a260c24cbb35a9adfea144a2acfabb224f516341544f
+  md5: 745b888e19a644f48800799f82c01c21
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18539
+  timestamp: 1683823925189
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py311h313beb8_0.tar.bz2
+  sha256: 5a40b7ba3aaff79b21020a5ba9df44202d9fa6152abd81f91ed1602cfa864ed7
+  md5: 95226a611d81daf647c0211ef2de31a7
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 148513
+  timestamp: 1682522467465
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+  sha256: d945744eb133f19ca61325cac5128bdb053ae04de4a0ba6f69c061449cac8af7
+  md5: 34baa81490d667381bc7021435b0e1f2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 275858
+  timestamp: 1713974457562
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+  sha256: 012585bdb5ae54c2cded50be703734e6dbf418b003635b6f6d7c1e36e7020c30
+  md5: da7e99a707bd0cfa20db651b5c068bfd
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65556
+  timestamp: 1711136890180
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+  sha256: 4f04a43cbd612ab09cefbdc2e48ee61b51967dad59d859ce0502cc2c46c88fc5
+  md5: c68bf65433b2151b51b2e699bc22c501
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 194632
+  timestamp: 1698096151085
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+  sha256: ae8cdd5be5a7ad19ff82925a035859fafcc5942cd3899d127a508dbb9a235090
+  md5: 252a7b997d08bf72f10b3bc2dc68333e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 580346
+  timestamp: 1709318480624
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/qhull-2020.2-h48ca7d4_2.tar.bz2
+  sha256: e033f2c9e52aa705d9c10d9a352bdad47a363299e42ad62bd7089ddf112ca355
+  md5: b7e91b270376c6d7281413dc8779cdea
+  depends:
+  - libcxx >=14.0.6
+  license: Qhull
+  license_family: Other
+  size: 1888397
+  timestamp: 1670915845902
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+  sha256: 089c6b9bebfa690f380710f219ab0fcc1acec9f2e187d4174a08222c45f58afc
+  md5: 11b832c6c10a6d2b0e687a20c3037c97
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-3-Clause
+  size: 194532
+  timestamp: 1652449531448
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+  sha256: 7a208abc002a2fc208ae25cb2cf932999a3e4980aa4c9edff315cb9ac62b12ce
+  md5: bd22ebd3cff811577ea61f115ba7f4f2
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74744
+  timestamp: 1699012126255
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py311hca03da5_0.tar.bz2
+  sha256: 5b63727e751cfb353b774b4324e1f5f959da5e689ee360214ed4d61b8848ecf9
+  md5: 94d4814a235f0aaadac2d8da53306e04
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 124591
+  timestamp: 1721414777485
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+  sha256: 52368d9b557b8f54ef5ca4bf6cd5a3ec665171f2b2d2082cdd410bab88f4829c
+  md5: ac76fb4d2eef3ecdd491cf5d3fb8620d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10204
+  timestamp: 1683077239143
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+  sha256: 491d116c5f54ef340e3bce631835f7138cd1923d7b63e6ca9aa01b48110cb8f9
+  md5: 9b81bd8ea808704f5433884b567f1f15
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10557
+  timestamp: 1683059079547
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+  sha256: b53a5f6119173d62e4e68a37ea8511c7fc87a00af72953e0048d075a799c7a7a
+  md5: 76a16cf4edb9b12b2b96a2d323f060dc
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 342535
+  timestamp: 1698945991201
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rtree-1.0.1-py311hca03da5_0.tar.bz2
+  sha256: 2f4457741d2274010be78d78bb81b50007e775d5cf80be40d37ea6cf330bef5f
+  md5: e22184f5affec782f7ad7be24e1a4d41
+  depends:
+  - libspatialindex >=1.8.5
+  - libspatialindex >=1.9.3,<1.9.4.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 64383
+  timestamp: 1677961908382
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scikit-learn-1.5.1-py311h7aedaa7_0.tar.bz2
+  sha256: 6e32d67ed188863eb571cb73e56810c4dadad1aa027edc126ed8162620d1477f
+  md5: 15480c79144ebf3ca7ae82e045e92785
+  depends:
+  - joblib >=1.2.0
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - scipy >=1.6.0
+  - threadpoolctl >=3.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12328951
+  timestamp: 1721924044788
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.13.1-py311hac8794a_0.tar.bz2
+  sha256: 670a9eb2b03627ded04a6a9c20636f3dadd6adc47dd8a091ff996a5ee22634e4
+  md5: d6bbfadefc4377ce93958944879a02ff
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 4
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 26137801
+  timestamp: 1717523015496
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+  sha256: c80d52567084b1caaed2862b77b70065ca17afaf0b020733e9d6c273b4a63e78
+  md5: ddf7d88c1967f3f7a4ce1c975fd47e0d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33321
+  timestamp: 1699371225235
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-75.1.0-py311hca03da5_0.tar.bz2
+  sha256: 70c84e0f41fa9eac5f35d447ebc6417279180694bddecdbba5d14e12124b56f2
+  md5: cdfbbc473d52a1334490dd81c7833ae7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2317457
+  timestamp: 1726677954270
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/shapely-2.0.5-py311h3713c0e_0.tar.bz2
+  sha256: 449896a8fdb7958ed9aece7ee58a5e651ac8dea9b87428e3ac79195b3591ff91
+  md5: f3df01e03a53bf47a3ea490e98f96520
+  depends:
+  - geos >=3.9.1,<3.9.2.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 593369
+  timestamp: 1722533349628
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
+  sha256: 499623019bea7cd167924f7fa841237b11b81a1e9cafe9b8ffde47d329275167
+  md5: 290d04cffc69bf26a4ed9f1aa9ad42e4
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 46038
+  timestamp: 1723557442909
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+  sha256: cd71091a234874d2826fa063ec5222b3191c9f47e1b5281c352d9df3f31a06bf
+  md5: 0db8e29016c6bff026c083d9923a7566
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19073
+  timestamp: 1705431415504
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+  sha256: 3e18cdafc607c6d7623b1c8f041cbfbb50a27e298f961abdcce7e36834ac39e1
+  md5: 9ee0da74c55d0b8d83edf246fd717f20
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89862
+  timestamp: 1696347657368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+  sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
+  md5: d8c1e9910392d0bcb22a173f9ce30fa6
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1758290
+  timestamp: 1714488307689
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+  sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
+  md5: ae58720a18a2ed15eae214ad7a10d1b5
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 140125
+  timestamp: 1680167256603
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+  sha256: b5c265e9ed9a1ff2238a09b83bdc1826950faa87fd6b685debe60888de6e7a50
+  md5: 5827c8a32317894ce18576e334daba47
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38559
+  timestamp: 1677918962258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/threadpoolctl-3.5.0-py311hb6e6a13_0.tar.bz2
+  sha256: 63378c3a92be71f9e8f573f4f793b1928567880d4d0cf1f780eeeedd29f62e6b
+  md5: 81e422eb374160f7b365d92fac5ad2b5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49989
+  timestamp: 1719407928127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tiledb-2.3.3-hb4a6b97_3.tar.bz2
+  sha256: b211874f0c31087994f3c23cc33bebcfce27233b9cd62cbe09bc801023943135
+  md5: ee2847a715600bc225b6014ac9af797a
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 2791548
+  timestamp: 1685656859713
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+  sha256: cfefd86d0f4981d22b7611b3dc60359b8698bf39f2b743cb90b7005aaca88e1e
+  md5: a04dbcd6095f6b8f3ad195a78d48b262
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50058
+  timestamp: 1677917499177
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+  sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
+  md5: 3c25b4f4768ccda28b20a03ba27e7759
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3484151
+  timestamp: 1714770744982
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+  sha256: 0836468fafb1f5badbb573922e37200c6929bf2926ecf8d2259dff43811e0727
+  md5: 5bc56dcb4bdb7cf623b7cea499feaddb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 136409
+  timestamp: 1677925889207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.1-py311h80987f9_0.tar.bz2
+  sha256: 2fd655106e52bb73deea5a0af63708e75cf66e071f0f3f15c04a67413f721430
+  md5: 324986c435dcfc101684907ce85c199e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 915790
+  timestamp: 1718740267109
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.5-py311hb6e6a13_0.tar.bz2
+  sha256: f6cda770cbe84b10f2d78d41bab43e1a1386e9722569c9b2b235083947fe90cc
+  md5: f5306a7b16da13a7258a20cecb62cdd5
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 155732
+  timestamp: 1724854273737
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
+  sha256: 707e5dfdb9116f31bc1ad7f497f6e8416683add460258fdc2a4c16eec85226be
+  md5: ffb602322a388ec8e1f385edaca3ce12
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 208171
+  timestamp: 1718227091374
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+  sha256: 96071e07e807414b7ae5a2fe958ac171e5795576b3a4c2f5e8c643fba43d760f
+  md5: a34f2b216e35a37f966883dacda229e2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9902
+  timestamp: 1715268985387
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+  sha256: b20e48aff4c781a52b6be66d77418e768527a621f5fc272ecb34ea03475b2bd7
+  md5: 707738432f16f5e63909fcaa6e65850d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 75604
+  timestamp: 1715268976065
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+  sha256: 2ea2d0520b330d381a2ab241bdb9ae146ef815ee7c96ee52a9773fb9ae85f4fd
+  md5: 66f7f8979cfb2cccffac972d70482130
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 12614
+  timestamp: 1677963554857
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+  sha256: df7fe7740bd853b641d624e2ec97f1aacb2b82691936a8c04ef18fa9768539c2
+  md5: d5c7626d45fd03b22797c18e47812beb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 518048
+  timestamp: 1713213046424
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uriparser-0.9.7-h80987f9_0.tar.bz2
+  sha256: c7402bdd16743bbd3350752e7009e40024b7ea2d280f54a6f74a4246f99e0edf
+  md5: 666f1bc2359d58c32ccbcbf4e9fcadd7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42998
+  timestamp: 1692186946914
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.2-py311hca03da5_0.tar.bz2
+  sha256: bfdfb02fd3dd1c01fd36b0753e365bfe599153da178619d8b62814c89682ab8e
+  md5: c30603849b5abe9935b0a58b2904a090
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - zstandard >=0.18.0
+  - h2 >=4,<5
+  - selenium >=4.4.3
+  - requests >=2.26.0
+  license: MIT
+  license_family: MIT
+  size: 210621
+  timestamp: 1718912666948
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+  sha256: 20ae100fd04de16356f26e7c9dab514015e57a9d54fb78767aa5ed97de7846fb
+  md5: f620d98b3d0072945948310c86f0f1c5
+  license: MIT
+  license_family: MIT
+  size: 157385
+  timestamp: 1706894678643
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+  sha256: 09738b7f9075386bf062b12ddb6fb72a06450d2481f6b5ca2026c811cd849569
+  md5: 9afdec076c95746ac21235f971190e40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26727
+  timestamp: 1677910175964
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+  sha256: b4ced7366de8eb7258f31d516616e70c62ed4a798780e57e208509d2b52ab435
+  md5: 65a9a05a726734c1da667f9bd3c78c14
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 114733
+  timestamp: 1715878377412
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.44.0-py311hca03da5_0.tar.bz2
+  sha256: 088f397ff8a4a7e178415dd7e2ff987c02b3674c7b6885972fb6c669978aff40
+  md5: a87f4be160e50ea022588aab7c7322bf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 139304
+  timestamp: 1726165038360
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+  sha256: cf030fc7020dc6d28530075468b8dc1edd843a1e393a2f81ca81c962e9af977b
+  md5: cae3fc90233f3af8f433a253d035b6e6
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2470844
+  timestamp: 1689041497962
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xerces-c-3.2.4-h313beb8_1.tar.bz2
+  sha256: 0f084440eba1b43120912f01cd0fff05d564b75d8a37ad1d9368b8c1fee757fa
+  md5: 45efffaf1c16790a7d418d53856a0fa3
+  depends:
+  - icu >=73.1,<74.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 2734029
+  timestamp: 1692994862695
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+  sha256: 2cd108896df65636769e3804ecc2ca421ad9b54e64fa21922bbabe40c90c247a
+  md5: b3a1e5077b28f71298d891fbfb5ff03e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55645
+  timestamp: 1677927459979
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+  sha256: 5be8c968f2da5c4bf14f28d63e31b4c1b6993d980023769732c7f58f396c2e0b
+  md5: 3f5f62d4e85e3bdd48d39189b01805a6
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 459197
+  timestamp: 1714510992914
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+  sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
+  md5: 3d57d1adadca9388aaaa1c529b65ba65
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 322790
+  timestamp: 1705602163804
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py311hca03da5_0.tar.bz2
+  sha256: db7fb95af4702cb2ce5281333fa769006f532bc39e8e5bd580a2eb9970a7a38d
+  md5: 2c13d5a0b62ff7a644a6957829dc54a6
+  depends:
+  - heapdict
+  - python >=3.11,<3.12.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 103248
+  timestamp: 1695832909752
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
+  sha256: cf38c69cf62d8f07b91b14bef8e0b6fc5ac220bd3a6cd2ab0378283f0f11494a
+  md5: 11660f745caf5eed1d03eafadb32678b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 25470
+  timestamp: 1704206932876
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+  sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
+  md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
+  license: Zlib
+  license_family: Other
+  size: 104928
+  timestamp: 1714510936868
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+  sha256: a3f3eaf240991b6bd7b0596a78d0abb3321cc79db52fa24f6f559189778871c6
+  md5: 71f035b4716322539e2461cb6667e946
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 825339
+  timestamp: 1714678419523
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+  sha256: 6e6787755de0cf2fd776c9681a7b0fd0fb23e35e679a463cc2005b991c413910
+  md5: ccad42ec9a2ad48939f089c528abc8f0
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 229694
+  timestamp: 1706220431719
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+  sha256: f715f7c2e06149bd6d43258e41479d3171efe5e9d56050a0a5f5652ed9d05fff
+  md5: 11a8ca43d69881b88f95ae681478866d
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 36089
+  timestamp: 1676424516042
+- conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-16.1.0-h7cd61ee_0.tar.bz2
+  sha256: df8114d6fe4c36f14e747ec009e37f8ef1c04639d366a5de71be565fda158c21
+  md5: 7af8c5f125b3edfd6c1d2c5767a4d64c
+  depends:
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - aws-sdk-cpp >=1.10.55,<1.10.56.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-ares >=1.19.1,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.5.0,<0.6.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libgrpc >=1.62.2,<1.63.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.14,<4.0a0
+  - orc >=2.0.1,<2.0.2.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.10,<2.0a0
+  - utf8proc >=2.6.1,<2.9.0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8713773
+  timestamp: 1721660803401
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+  sha256: 9adabcdd2a10f73fa5ba56adc901eeea2e379991a0d4cb9737eec7aa6b9fc5d8
+  md5: fc80b572be85601706d425b21a58d497
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153102
+  timestamp: 1695718054194
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
+  sha256: a11741c5aaa360b4772d0fb7eea606edb5266a4e2806b22f0b8b65b69b7a7273
+  md5: 9a54285c5e75ab5e6bfcb3b5590f9449
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 93395
+  timestamp: 1706746331576
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
+  sha256: 32b4da68dd0edbf0c8d7a8a18ba400b26775faabaccbc2cb3e9d2ab7c65e7714
+  md5: 48f0a7a7f739d8be4c9dd061be217619
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 45714
+  timestamp: 1706691182873
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
+  sha256: d2710c7f5b4bb8f94a964996387fbd6396f9881d163affeb7ffb050a39e58c1c
+  md5: 1a8a2f82798a94d1b272ec2d307cc5ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 195487
+  timestamp: 1706190077309
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
+  sha256: 0a5ea74ebcf9bdccfad972add8ff83a47992ab28370cebc34fc4594c1c7cf03a
+  md5: 2f90d407ca685c124ddb5fc4d79f4517
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 21804
+  timestamp: 1706690937014
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
+  sha256: 334d2d9c4181c9955256485f66bf4e48ae9b1dc03044aa0424bf1fda292b3151
+  md5: 9ab57953af3164d3d94001eeca0e6359
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52661
+  timestamp: 1706697357084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
+  sha256: 59155d1258b4e29c0046e5ab14b1e2cb3ccfca069982fe9dd4cd751b1ed67492
+  md5: 28bd7c351db93c3b8520cc1598eddf66
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-compression >=0.2.16,<0.2.17.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 177605
+  timestamp: 1706744253596
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
+  sha256: 3aa9b1c2c508a5dcfb482083cb986498f6df460e652cc7557d3c2d122d559ebe
+  md5: b8bf7ae26d234b6738fc37b7c172b3c5
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145865
+  timestamp: 1706696287610
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
+  sha256: 68564155186523ec8b97b892d0a6b62b3e6f75e4e2b80fac5684011e070295d6
+  md5: ba2fa531a69a5a7e4966eba6d7891c8b
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 69542
+  timestamp: 1706746839018
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
+  sha256: 9c0f2f18f8b7e10e940d2438d70a2a03893421f25fd50461b8b2979f3a310a15
+  md5: da0f3ce6d8f71a71e6cae01832d853f5
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 72614
+  timestamp: 1706747680710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
+  sha256: bcee1da236f6f5f88322979daddc89e8555648593f6282ad3073a68eb22a68d2
+  md5: bf4c19b0db5049930d8b2fcc3b9172fa
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51027
+  timestamp: 1706690972693
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
+  sha256: 32561df1e664cb320f79c26c5af23dd55953924e66824e2d6372a44687147bdc
+  md5: 05f4c6715180a992468035c0a86e734c
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 54300
+  timestamp: 1706192197648
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
+  sha256: 94d2fff3facfd248968d39a3fd7d3b1f7270df32a87dd567c33d60da1a5eb064
+  md5: 64fed6e7c73d88bfbfc39e838022f948
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
+  - aws-c-s3 >=0.1.51,<0.1.52.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 199877
+  timestamp: 1706827970924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.10.55-hd77b12b_0.tar.bz2
+  sha256: 813f252df10d2782fbb26e2c6348f55d44ef1618467e340224df44bcda4814ff
+  md5: 8efc1448ada827ddba894a07903808dc
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2519847
+  timestamp: 1706890866084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
+  sha256: f1eb2a5aeb25efa0b38fc1dd94a36d431bc80d654f11a052f67a899dcc471f57
+  md5: 9db5a441c7cbcf4dc617f8c722e4310d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 276663
+  timestamp: 1718029990621
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
+  sha256: cf9a8a0745c5fab48394d84a58fe2f06e5fa80c87d5cc8d6c8da2e1df52cc69f
+  md5: 462987773ecda8cbf1f80734e84f080f
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 93601
+  timestamp: 1675247818708
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.1-py311h746a85d_0.tar.bz2
+  sha256: 5e81c00b64a071a07c5ff5892fd48b94476c93121fdb2c28581dbf2e023480d8
+  md5: fdd289f6664341f6b29f70804d322594
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6101282
+  timestamp: 1718119807269
+- conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+  sha256: 68ef338b27c035add89c0812ad469dd8c9e94f27130f770345ea20deb049d50b
+  md5: 9ec19b145f655329532b608963cf32f4
+  depends:
+  - libboost 1.82.0 h3399ecb_2
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 11334
+  timestamp: 1696764270626
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+  sha256: 5c12a5d7856d9977447360b3a99a5b99818707fe79781ba1779037f11b3fef53
+  md5: 6a125ae352306a944aabc635a5fe13a3
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 139230
+  timestamp: 1707864402762
+- conda: https://repo.anaconda.com/pkgs/main/win-64/branca-0.6.0-py311haa95532_0.tar.bz2
+  sha256: 2778c36a218b44951d906c57b8d16cc46d9c9bfa4141da6413a31c0fd4103ffe
+  md5: 50d55880f75cbdba49c3f97efb7f65e9
+  depends:
+  - jinja2
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 53770
+  timestamp: 1678291335761
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 751071782f597f87ed7f67437ef6cc669213902461b9795dd6eb0f4897eddc83
+  md5: 5ad8fe62aad5e16cfdf2c5a7d1327fe7
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_8
+  - libbrotlidec 1.0.9 h2bbff1b_8
+  - libbrotlienc 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 19418
+  timestamp: 1714483531456
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 9bd62d810867549b9c967c5915f3fa3f66cfbd6ede28b1cc152efd1261285c0a
+  md5: 64cc76de3662b62bc8f0e42befd92c5d
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_8
+  - libbrotlienc 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 32178
+  timestamp: 1714483513837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+  sha256: 1547fa52134cf06b8d01bdf52114db7db60a89bf35c9c95be5b5a03b13dbd565
+  md5: deb765cb7c4b7edc4d126f864f31747c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 356401
+  timestamp: 1714483740924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+  sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
+  md5: 11e0af09a31e2d5df51c65a342032b85
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 112994
+  timestamp: 1714511182837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+  sha256: 41a6c5a90b88ec7010bb6dd89390754e476b52c3ab2d519bdab9556da8829479
+  md5: b047426a545e287f45e8abfbfcb0de55
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 118041
+  timestamp: 1693902191485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.7.2-haa95532_0.tar.bz2
+  sha256: e84389ae72c9f63990b605d03962b1c502c235fd4484497ee9b1deccb3b7e5f4
+  md5: 3dd1e7bf8c80bc5b45952beaab5a9fc8
+  license: MPL-2.0
+  license_family: Other
+  size: 170658
+  timestamp: 1720622045755
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cairo-1.16.0-haedb8bc_5.tar.bz2
+  sha256: 56af1f19db12dee9dbb177873726b3fdf6cbbd83736748c99ad7c536ff28ff28
+  md5: f2923f93791571dd8a664da18b5de5d0
+  depends:
+  - fontconfig >=2.14.1,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - glib >=2.69.1,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - pixman >=0.40.0,<1.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: LGPL-2.1-or-later or MPL-1.1
+  license_family: LGPL
+  size: 2351737
+  timestamp: 1688495984273
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cartopy-0.22.0-py311h786e728_0.tar.bz2
+  sha256: 02f3a82880a35d257467e517b1d233f2ffa720d46b96edbfc4aa72815c33adb2
+  md5: 4970ad0c66497ae3c67fe2c9e6fbb46c
+  depends:
+  - matplotlib-base >=3.4
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20
+  - pyproj >=3.1.0
+  - pyshp >=2.1
+  - python >=3.11,<3.12.0a0
+  - shapely >=1.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - owslib >=0.20.0
+  - scipy >=1.3.1
+  - pillow >=6.1.0
+  license: LGPL-3.0-or-later AND (OGL-UK-1.0 OR OGL-UK-2.0)
+  license_family: LGPL
+  size: 2148686
+  timestamp: 1706196267414
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.8.30-py311haa95532_0.tar.bz2
+  sha256: ddf997fd83ad3c39c91c80c97ffa35b76565c400a3993ff88ef3730c2cccb14b
+  md5: 5b933b0d173e2af3d30a74a74c9c3c69
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 169591
+  timestamp: 1725551908109
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py311h827c3e9_0.tar.bz2
+  sha256: 70eecd3e89d12624083a73c998d818dceb1505ab8e7be7d1f4814950b18c2fcf
+  md5: 1427fd9ad1be3e40e6dd5751d98fd96c
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 309709
+  timestamp: 1726856612505
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
+  sha256: a65386e70bdad9aa1e07ad430309c3ddc249b74bea69388dfbda99fd00069665
+  md5: e4174218de194962642b353f51a19d1e
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  license_family: Other
+  size: 617890
+  timestamp: 1655709069465
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cftime-1.6.2-py311h5bb9823_0.tar.bz2
+  sha256: 5226aec7c3544ec3358cef871868581ac6f530a6faa2bf35646ae0e422972039
+  md5: 02a762440b11ca414bcb91b382cbd35f
+  depends:
+  - numpy >=1.22.3,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 177428
+  timestamp: 1678830473247
+- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+  sha256: 7153817dd49ec317b519802c7c22c836602e00cbd96d68385e83eaf4c9f5ba6a
+  md5: cd829e5997611a602e29fa2fd5882635
+  depends:
+  - colorama
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204113
+  timestamp: 1698130080270
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.0.0-py311haa95532_0.tar.bz2
+  sha256: 364512f6fbda47a7683831e49d94cede5ea91ed57c0bcb27c4c1a95b067c7717
+  md5: c4c87a947b2f0594d0eda7d852140845
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42936
+  timestamp: 1721657516663
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+  sha256: 4099898f02e1f6119fcda65e747c3cbfef0bf563c8855b79a0245160709d5b45
+  md5: ab9705c34e67fb8c8faec69d63ff4064
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36410
+  timestamp: 1676422341506
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+  sha256: c722f50980d7416ffb2cfc7bf72649307a0bb78c5a24eccefcd049cb61d6b355
+  md5: c7c9ff0513ff3c99700919293b702410
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 543258
+  timestamp: 1709758602437
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+  sha256: 8fb3e816a5ad1da05125462dbc9e2a7e933b001a871aa65703802c0a894c6277
+  md5: ee4b2fa9fce130496d5c7c86c35a1a05
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17723
+  timestamp: 1709323150229
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+  sha256: eeb49cd151ecdccd40062e8123a3b7a9a8a1eda6567dd33ce909ff8ee1a97c89
+  md5: b7fe1f7ead1ec2ac642d022942282fc8
+  depends:
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 232451
+  timestamp: 1700583772701
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.2-py311h2bbff1b_0.tar.bz2
+  sha256: 037aab9c08cd8f7e78e65b602b3c2b61a7c812b270cbea15bef0e36d0305db6f
+  md5: b4e5dd983a62a7c27d73900400eab7ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - toolz >=0.10.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 369375
+  timestamp: 1701724118486
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-2024.8.2-py311haa95532_0.tar.bz2
+  sha256: 638524ff3e7423b6e5b3153997d239b4536e76c373c19000c4d74d39fe8759c6
+  md5: 154a27c109eca6a7977de0b22d1e6415
+  depends:
+  - bokeh >=2.4.2
+  - cytoolz >=0.12.0
+  - dask-core 2024.8.2
+  - dask-expr >=1.1,<1.2
+  - distributed 2024.8.2
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.24
+  - pandas >=2.0
+  - pyarrow >=14.0.1
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6170
+  timestamp: 1725525169281
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.8.2-py311haa95532_0.tar.bz2
+  sha256: c989952077ec0ea63cc766f6aaaf8f0ffebb12c7d2143a5cd111cc807dab253a
+  md5: 7628fc77d1af150ae6cceffcf154c990
+  depends:
+  - click >=8.1
+  - cloudpickle >=3.0.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.4.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3190714
+  timestamp: 1725464703740
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-expr-1.1.13-py311haa95532_0.tar.bz2
+  sha256: 843f2abd2cf40913c8d3376cd0965562cab66fa264299ac8775f58ed23a4ac88
+  md5: 16d4052ca9dfc0b7f4ca2d98b124f855
+  depends:
+  - dask-core 2024.8.2
+  - pandas >=2
+  - pyarrow >=14.0.1
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 566375
+  timestamp: 1725523069312
+- conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.16.3-py311haa95532_0.tar.bz2
+  sha256: 029f067d71a2825e4af1ba085c792ec96d93fde7ec0590d5f6414a051085cdb9
+  md5: f4c49a5695996b1146ca460058f4abe5
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy <2.0a0
+  - packaging
+  - pandas <3.0.0
+  - param
+  - pillow
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18066407
+  timestamp: 1720535030282
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+  sha256: 5c73f86e575f2ad683ee4a1c2df11020e270edd89d12f11199483d57b0b51826
+  md5: e96a12895ce374476277b1b196ba24bd
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3719519
+  timestamp: 1690907216785
+- conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2024.8.2-py311haa95532_0.tar.bz2
+  sha256: 5a8a41cec590e08b36b04fb1574cfa4f8d72da4d9696ca5629cc5031ba358b9c
+  md5: 4dd9ab14f278b8d90094d86e25d5d7bd
+  depends:
+  - click >=8.0
+  - cloudpickle >=3.0.0
+  - dask-core 2024.8.2
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.2
+  - packaging >=20.0
+  - psutil >=5.8.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.4.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.11.2
+  - tornado >=6.2.0
+  - urllib3 >=1.26.5
+  - zict >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1849988
+  timestamp: 1725523127698
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+  sha256: 5d5fc8a24c804010b8cb5963227230352ea3ccf56bea9e8116e34f77223218f2
+  md5: 8f989a72eed6293dfe0533c83057980d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17688
+  timestamp: 1676423357100
+- conda: https://repo.anaconda.com/pkgs/main/win-64/expat-2.6.3-h5da7b33_0.tar.bz2
+  sha256: b3c54b848c831db5e058f918b97ca08f9bfaacf0b1480272b393ac3c640e9233
+  md5: 1ead1075a3d07f112a4240b41331bea5
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 424897
+  timestamp: 1725543405738
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fiona-1.9.5-py311hf62ec03_0.tar.bz2
+  sha256: 06fbb41f1f1d4f6bf5892a23d442ef11f096146685999a6aa911841206ac02e9
+  md5: b5f6659dabb7383f976c8946396a8ed4
+  depends:
+  - attrs >=19.2.0
+  - certifi
+  - click >=8.0,<9.dev0
+  - click-plugins >=1.0
+  - cligj >=0.5
+  - gdal
+  - libgdal >=3.6.2,<3.7.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - shapely
+  - six
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - boto3 >=1.3.1
+  license: BSD-3-Clause AND MIT
+  license_family: BSD
+  size: 1135290
+  timestamp: 1704921300424
+- conda: https://repo.anaconda.com/pkgs/main/win-64/folium-0.14.0-py311haa95532_0.tar.bz2
+  sha256: cc762a994a3aa4bac82227157f52172c122064721f1bc2359221b1b1cd0ebfff
+  md5: 82adfdfd476c11198bf4429f3a6df57a
+  depends:
+  - branca >=0.6.0
+  - jinja2 >=2.9
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  - requests
+  license: MIT
+  license_family: MIT
+  size: 135350
+  timestamp: 1677743027073
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fontconfig-2.14.1-hb33846d_3.tar.bz2
+  sha256: 7e9db9a6a516769ff3f1623762ad4f07ad5e4e150497d605efab4b9c9db0ab2b
+  md5: 95a598df4ea56b9338948a3f8b7e16c6
+  depends:
+  - expat >=2.6.2,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - libiconv >=1.16,<2.0a0
+  - libxml2 >=2.13.1,<2.14.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 246846
+  timestamp: 1722921093124
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+  sha256: 27fb03eb57d25711a15e145f47a64320a9955b585efc9fd0a1a51cdd71b9fde3
+  md5: eb3869e98f6f53dfec76e2eff4d6b61e
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 2732423
+  timestamp: 1713552175344
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freexl-2.0.0-hd7a5696_0.tar.bz2
+  sha256: bbc5fd3e0525ea2987c00c9d5340a2f6156116b45506e6ff63152f0ffd371c65
+  md5: 4ee1c7ba72a00662bbf30c98d7c7f71f
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - libiconv >=1.16,<2.0a0
+  - minizip >=4.0.3,<5.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MPL-1.1 OR GPL-2.0 OR LGPL-2.1
+  license_family: OTHER
+  size: 90894
+  timestamp: 1704742083610
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.6.1-py311haa95532_0.tar.bz2
+  sha256: 20b5c643d8f2d2ca349435d8a762f1d42b7b9b4e86f154ce6722d30179f2d348
+  md5: 1db1c5f718e6a79a5f0117ec9957c6bc
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - pyarrow >=1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 383101
+  timestamp: 1724855844881
+- conda: https://repo.anaconda.com/pkgs/main/win-64/gdal-3.6.2-py311h4e7b5b2_5.tar.bz2
+  sha256: 0203fe50e59fbd981b51c72ee18a01fd75d7cc2b3fe612b43e2437f554427a53
+  md5: e842d2e703c69d4187dc6d6a3661ebcf
+  depends:
+  - libgdal 3.6.2 h0e70117_5
+  - numpy >=1.23.5,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 2532057
+  timestamp: 1722935226144
+- conda: https://repo.anaconda.com/pkgs/main/win-64/geopandas-0.14.2-py311haa95532_0.tar.bz2
+  sha256: b164ff61f7c91e4e183367e504a3db4ad72fb738e92579effb67b0bfe5fbe5a1
+  md5: 440b5443c96fe8968163dc40be94b514
+  depends:
+  - folium
+  - geopandas-base 0.14.2 py311haa95532_0
+  - mapclassify >=2.4.0
+  - matplotlib-base >=3.5.0
+  - python >=3.11,<3.12.0a0
+  - rtree >=0.9
+  - xyzservices
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7502
+  timestamp: 1704929217881
+- conda: https://repo.anaconda.com/pkgs/main/win-64/geopandas-base-0.14.2-py311haa95532_0.tar.bz2
+  sha256: 21ed1b795481b524738944b68ff92a60e8a0ef9c7c36b50b347f1cb60493edaa
+  md5: e1493ee5c24d8ad91d002cf3a85c8cce
+  depends:
+  - fiona >=1.8.21
+  - packaging
+  - pandas >=1.4.0
+  - pyproj >=3.3.0
+  - python >=3.11,<3.12.0a0
+  - shapely >=1.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1525805
+  timestamp: 1704929137513
+- conda: https://repo.anaconda.com/pkgs/main/win-64/geos-3.8.0-h33f27b4_0.tar.bz2
+  sha256: de43096c33bba4f0140d6954d74861f4338b4e610fbdd9b4651302eaacc5db93
+  md5: 46f610ec4be6b8e985048510341c9c42
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1
+  size: 1053138
+  timestamp: 1573216029043
+- conda: https://repo.anaconda.com/pkgs/main/win-64/geotiff-1.7.0-h4545760_3.tar.bz2
+  sha256: bbba369c615bf09d2926c3be6586b16f7125a9dcc78798ba380667e9b178cbc8
+  md5: d9cca68c18c2090110d351f614eb66c9
+  depends:
+  - jpeg >=9e,<10a
+  - libtiff >=4.1.0,<4.7.0
+  - proj >=9.3.1,<9.3.2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 140510
+  timestamp: 1704901404457
+- conda: https://repo.anaconda.com/pkgs/main/win-64/geoviews-1.12.0-py311haa95532_0.tar.bz2
+  sha256: 20f05b3256dc9a6287a361018813d6d3793b3ab4d509d2bf7dd7fd3ca861c6fa
+  md5: 5d90d3cadd1641ce3b68f708239ad546
+  depends:
+  - datashader
+  - geopandas-base
+  - geoviews-core 1.12.0 py311haa95532_0
+  - netcdf4
+  - pandas <3.0.0
+  - pooch
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - scipy
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6509
+  timestamp: 1713973058097
+- conda: https://repo.anaconda.com/pkgs/main/win-64/geoviews-core-1.12.0-py311haa95532_0.tar.bz2
+  sha256: c759a04c6517b45173b67ee5c835f15cc3ce816409b7760d3795555e78429802
+  md5: ac6fa23cdb5d5cb3ea3c42d14e11503e
+  depends:
+  - bokeh >=3.4.0,<3.5.0
+  - cartopy >=0.18.0
+  - holoviews >=1.16.0
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - panel >=1.0.0
+  - param >=1.9.0,<3.0
+  - pyproj
+  - python >=3.11,<3.12.0a0
+  - shapely
+  - xyzservices
+  constrains:
+  - geoviews 1.12.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 647354
+  timestamp: 1713973041380
+- conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+  sha256: 7cb0df7aa62796b0081e1708003529c02411aca6a540bae97beaec919aa64e74
+  md5: ea81fd813e10055553a8d7597c8be98f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 322778
+  timestamp: 1706888324269
+- conda: https://repo.anaconda.com/pkgs/main/win-64/glib-2.78.4-hd77b12b_0.tar.bz2
+  sha256: 5b0781144940dcf12887df93554bf297a14c7ccfac5f5fd2358c52d68e099872
+  md5: 2dc9a083084586cae235d8244aa8e701
+  depends:
+  - glib-tools 2.78.4 hd77b12b_0
+  - libglib 2.78.4 ha17d25a_0
+  - python
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 491679
+  timestamp: 1708032170326
+- conda: https://repo.anaconda.com/pkgs/main/win-64/glib-tools-2.78.4-hd77b12b_0.tar.bz2
+  sha256: 18d0ff7ef22898e8e3fa55072ce2a3e25a324166d3a8d0f8dadf070641dd3c90
+  md5: 74b78c84652c068703a7bff2ce4d6729
+  depends:
+  - libglib 2.78.4 ha17d25a_0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 100389
+  timestamp: 1708032103213
+- conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+  sha256: ed1fa1a40c6739b48ff3a2d51c3df20e4983b59684b04d93e1337c5f2e93a954
+  md5: 1797f64343a42395207cd452e6a6a751
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94476
+  timestamp: 1706895442146
+- conda: https://repo.anaconda.com/pkgs/main/win-64/hdf4-4.2.13-h712560f_2.tar.bz2
+  sha256: 8129c8aae5860d9975f3c88c2ef874d0a746a11074f922b6318446cc45f30768
+  md5: b3a727bf1c1df5b021aaf6cc7e81deb2
+  depends:
+  - jpeg >=9b,<10a
+  - vc 14.*
+  - zlib >=1.2.11,<2.0.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 2869081
+  timestamp: 1510864340539
+- conda: https://repo.anaconda.com/pkgs/main/win-64/hdf5-1.12.1-h51c971a_3.tar.bz2
+  sha256: d32219e535ae34e9d28f94306a38a0825030967c350f19d9a5502e8005acbd5d
+  md5: 0689c2ff6f4b9c15ee072694a8cd7467
+  depends:
+  - icc_rt >=2022.1.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: OTHER
+  license_family: BSD
+  size: 23765096
+  timestamp: 1686164892135
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.19.1-py311haa95532_0.tar.bz2
+  sha256: c284965bfb12ff5c525739b67825a8f93cc1f523c6c021b459c1b547121b9d48
+  md5: 6b8a81ad6dba8f4ff9c65cd62ca03a3c
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21,<2.0a0
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.1
+  constrains:
+  - plotly >=4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6118951
+  timestamp: 1720535043591
+- conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+  sha256: dee3fc68ed81398d232b3afe9a032837bdbef98c1b2478604d6abd397e3e7d64
+  md5: 3f75535ca6dfee0745b221922f21f6de
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353312
+  timestamp: 1715090519918
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+  sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
+  md5: 582d2c1135a89da757a038de831e7f39
+  license: Intel proprietary
+  size: 11086648
+  timestamp: 1664812389803
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+  sha256: 102c803186db6d62eaf41a906f6c563ff0d62b53c1eaede8a381e18c0d005ed9
+  md5: 9d30dec03058758a428cf152e0ae28b5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148193
+  timestamp: 1714399061601
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+  sha256: db30abacf919b3f68ae1e6a94c467fd1e69fbf47ba7a86e6b491d8bfe4776f92
+  md5: 9299876e7ddc3aea3487fd93340ceae7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 50842
+  timestamp: 1704813715071
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+  sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
+  md5: d215cc8ee7ca2cc83cc250cc5d822fe0
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3929136
+  timestamp: 1699647939158
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+  sha256: 864e9598f64105769b4ec02cc404fb507bc59e217324daf1686c00cfd12c0055
+  md5: 6bb1c3be1f85799a3988afc2c3c5a4f0
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229621
+  timestamp: 1705934494547
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.27.0-py311haa95532_0.tar.bz2
+  sha256: cdd0cdf851850a822f0757fd86c3492d98a5ab6a98bb3851bbec8b36a95b620f
+  md5: efc3d64ef763443d936e1a954fc9cc1f
+  depends:
+  - colorama
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1664842
+  timestamp: 1726064663198
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.1-py311haa95532_0.tar.bz2
+  sha256: 0b084d918d32ea80d965c141220384c348c9f13c5bf5dabdd49c8d2aa813c0b1
+  md5: e07d6312911028555a8d2434b60c15a8
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1168633
+  timestamp: 1721059057721
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py311haa95532_0.tar.bz2
+  sha256: 74c339ca0a20f4bc324974c2c28901c1f478ca7c8898483482883a7a82896d15
+  md5: b3d3352c9d3bfe46f924b8e15fedf9be
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353862
+  timestamp: 1716993519832
+- conda: https://repo.anaconda.com/pkgs/main/win-64/joblib-1.4.2-py311haa95532_0.tar.bz2
+  sha256: 43b9b601c7dbe74dbd4f0ca8ddeadb7043634b3d38472a6861f12d747cfd73a5
+  md5: 4290b995aa63a33c546a9f950d7eaf06
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 542763
+  timestamp: 1718217480002
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+  sha256: 0238fb10912d9345a9d327ff314a179de38369f8e1d0de0b5f4fab04defab0e4
+  md5: 16a420ea83811cfa0c7cadba8f9f0995
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 409932
+  timestamp: 1722872751697
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+  sha256: 5e6698015a3b048093f5737f0e54bcbae415d0f9682dfdfeae3a8cfb4ea275e2
+  md5: 0093a4214131046c4f68af0739dfbea4
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 201456
+  timestamp: 1699041872445
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+  sha256: 9581be54128954080d7cef448b1728874c2ebbe5064f55adece422cf12eafa5a
+  md5: 3adc105f87d5c7f0b1248bc3423f5b48
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16187
+  timestamp: 1699032556953
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+  sha256: ad8343bad7c8f0448cbcfbaf872cc94b56da81c52e5cdcee2a5d6b89f029eb75
+  md5: addceff8d46c9d1d322618a9ce9e5b39
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 300354
+  timestamp: 1676424060532
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
+  sha256: fe0bf805dfa60d8b5d61670900442d0cda12523135176f60e1ebafb797e521d8
+  md5: c8cf5ea3d4b0bc57dfe6b189b47e69e9
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 136783
+  timestamp: 1718818384444
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
+  sha256: 262c35a28d0af4d73ea1c010ce0c022005512a26d5c27064c8e009c0b7b789d9
+  md5: 8367c61552aa274c0843201d88e461c8
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 72131
+  timestamp: 1718738283200
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
+  sha256: 00bf8449a37eb10c91ebfaa14b231905fde9493740cbda7ec89a8d3d8d9d1ff3
+  md5: 1f3abe3cbf365249ebae7465a57e4cae
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=2.0.1
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 655133
+  timestamp: 1718827724346
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+  sha256: 90420847230e72a648417f5f77cebcf7f17b89f70788652c276acc0c440e135f
+  md5: ef3d8dee197aa37897bf6d39d2dd878f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=2.0.10
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27639
+  timestamp: 1686871052174
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+  sha256: 97faaf26ce5254ec3649a8ee7f480b1556e4e8e6e4356d2fab1e6a5532631a0f
+  md5: da23bd831c50c877f63038b7e16720ad
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20163
+  timestamp: 1700168785472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kealib-1.5.0-hde4a422_1.tar.bz2
+  sha256: 0d8750eb48746f1b33b771c80cb8572a01701f7c03775fb73bdc2e736efaf223
+  md5: 0218566fcda3f373f0c2af851a42ea7d
+  depends:
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 162316
+  timestamp: 1687967060759
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+  sha256: 8a2f0909fad0387e57cb0e9ee30db2b20761a9106e794381ffeac387a298fb07
+  md5: 6058b2efc3284e27aacec2e6e6280433
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62334
+  timestamp: 1676432044242
+- conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+  sha256: ef6b0347ae565dd648a2bb40bc8b0b30f2e4f8387778fefced1d581b7d5a3e16
+  md5: 8ef1d5919aa55fe56ef34d9a7969dca7
+  depends:
+  - openssl 3.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 861982
+  timestamp: 1684424430941
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+  sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
+  md5: f5f73266281ab12377d5d47bdf07500a
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 905072
+  timestamp: 1617648814933
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libabseil-20240116.2-cxx17_h5da7b33_0.tar.bz2
+  sha256: 0e20a85132c711cb36bc33f1c329eec57f9b8b5a52fe8b16e39ccf2181c3e585
+  md5: 2056c0ad87951b65e50a809d539a1903
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - abseil-cpp =20240116.2
+  - libabseil-static =20240116.2=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 2192360
+  timestamp: 1716563477680
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+  sha256: 4184dd040fc38cb123a98588a8344aa8d1ba1932df5fcc6c188f6b21f5a0c306
+  md5: da58cfa83f3d6c31ae12d8777cd1b64d
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 29803292
+  timestamp: 1696764164248
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 7c906c94a4d46ea963080a6ba5bd12c1274da66159877a544fbc70291eeed98d
+  md5: 45a3d52534fac8aa54a55ee92211a918
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 80216
+  timestamp: 1714483371043
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: daad7edc6d56abf3e176479e8628162dbf1c56b3d24db30d708aebae694a5214
+  md5: e8ecf229f7fcb4c0b76d8613627948f5
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 45189
+  timestamp: 1714483420152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 84320217abffa9386186ec8d03b4651bb4b1900d3871adc965a9a9e1d3799907
+  md5: 651312fa22168f71f9aec5f9ee2c2fcf
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 756116
+  timestamp: 1714483464368
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.9.1-h0416ee5_0.tar.bz2
+  sha256: 8823321b1f3a4dec2ba437b74f054b6188c4e86f15e9830a851c036f1000b116
+  md5: eb83a06e2e659553014b6ac66f379e09
+  depends:
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 371549
+  timestamp: 1725033449018
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
+  sha256: 6458c7a370c4e3366b3b208c5b2834a7acfb17981e47fe3fb861f225d7cefbc3
+  md5: ecabf4acab5b604856d8c7c4278c2c2c
+  depends:
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 446380
+  timestamp: 1685052520132
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+  sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
+  md5: cf949d76148be1e2a534218d9c57df86
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 155435
+  timestamp: 1714484319443
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libgdal-3.6.2-h0e70117_5.tar.bz2
+  sha256: fca3db3ff0375859740f9fbb7a749e0fbb5f929369e7753137c140304eb4f1ee
+  md5: 794f571fa5a295a31983efe8d40fdcd6
+  depends:
+  - blosc >=1.21.3,<2.0a0
+  - cfitsio >=3.470,<3.471.0a0
+  - expat >=2.6.2,<3.0a0
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.8.0,<3.8.1.0a0
+  - geotiff >=1.7.0,<1.8.0a0
+  - hdf4 >=4.2.13,<4.2.14.0a0
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - jpeg >=9e,<10a
+  - kealib >=1.5.0,<1.6.0a0
+  - lerc >=3.0,<4.0a0
+  - libcurl >=8.1.1,<9.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libiconv >=1.16,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libnetcdf >=4.8.1,<5.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=12.15,<13.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libtiff >=4.5.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxml2 >=2.13.1,<2.14.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - openssl >=3.0.14,<4.0a0
+  - pcre2 >=10.42,<10.43.0a0
+  - poppler <=22.12.0
+  - proj >=9.3.1,<9.3.2.0a0
+  - qhull
+  - sqlite >=3.45.3,<4.0a0
+  - tiledb >=2.3.3,<2.4.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - xerces-c >=3.2.4,<3.3.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 9788599
+  timestamp: 1722934726331
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libglib-2.78.4-ha17d25a_0.tar.bz2
+  sha256: da2f459c87a7174dc323db19a44f6240e018d8f6a4e0049ec6d81d668bedcb3c
+  md5: 1fd164cb1b7068353a2f026b13e23ecb
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.16,<2.0a0
+  - pcre2 >=10.42,<10.43.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - glib 2.78.4 *_0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 1455078
+  timestamp: 1708032035113
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libgrpc-1.62.2-hf25190f_0.tar.bz2
+  sha256: 1d933ff3c15bbd21e2463392eb8b84c19f5e7e8116757a5456d53edd182f8aa3
+  md5: eb54ebe53747695597188890f99c2aad
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - openssl >=3.0.13,<4.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - grpc-cpp =1.62.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 19177715
+  timestamp: 1716836854929
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_3.tar.bz2
+  sha256: 4085f304bede2d9d04dbff5ebd53b3f5fbfaee1cbc120018a9efc0e89d027877
+  md5: 7e6fe99f2af88b389cf7e371cad6f18f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 744054
+  timestamp: 1714484485224
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libkml-1.3.0-h63940dd_7.tar.bz2
+  sha256: d202eef643f39fbe4b24ff4240052d2b58d67a4ba5fcbd80d09106191b85bff6
+  md5: 6f63fe185daebe8da8c6b3dc941ad7b0
+  depends:
+  - expat >=2.4.9,<3.0a0
+  - uriparser >=0.9.7,<1.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3074807
+  timestamp: 1693262074974
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libnetcdf-4.8.1-h6685c40_4.tar.bz2
+  sha256: e846f05d6cdfd2850e5deb027b62e8d828fa9b12f61ae7ed6433155458032144
+  md5: 383bc5f062aafa9b714aa6204ab20daf
+  depends:
+  - hdf4 >=4.2.13,<4.2.14.0a0
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libzip
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 706142
+  timestamp: 1691155040631
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.17-h906ac69_0.tar.bz2
+  sha256: 54b46079c184c286b2f91575d3b5917bc3e6737f06885a50426e3263227c8a00
+  md5: e4d2859474935b4873e48b09ef30a95e
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - openssl >=3.0.12,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  size: 3763163
+  timestamp: 1706215177824
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-4.25.3-hf2fb9eb_0.tar.bz2
+  sha256: 189a48ba963858b5adf13f200a36ee566bcd823b8fbc1a0372d4605f465989ae
+  md5: 310f4bf562072517c58e700471d52999
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6407565
+  timestamp: 1716568643819
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libspatialindex-1.9.3-h6c2663c_0.tar.bz2
+  sha256: e3527de4b50ae741004bf5ddfd6c5c4fe4d778ffea475f858d2b29e76ced9796
+  md5: 91aa29bbc065cd3b53c7410ab683c9dd
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 455875
+  timestamp: 1616086916558
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libspatialite-5.1.0-h25d3e1c_1.tar.bz2
+  sha256: bdf5c51745cf1b34cb80ea32258a2adc22794decd9f629a09c736ab334fdd5d0
+  md5: 55d03f839232b495e65e9b0422bc452d
+  depends:
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.8.0,<3.8.1.0a0
+  - libiconv >=1.16,<2.0a0
+  - libxml2 >=2.13.1,<2.14.0a0
+  - minizip >=4.0.3,<5.0a0
+  - proj >=9.3.1,<9.3.2.0a0
+  - sqlite >=3.45.3,<4.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later
+  license_family: OTHER
+  size: 11259468
+  timestamp: 1722878479049
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.11.0-h291bd65_0.tar.bz2
+  sha256: dd96a8c3b6de33091ea6198afb7c9331750f9a0c46f870a2f3ff159f4a605976
+  md5: 7382641f6d0090d7112a2164bcf44bba
+  depends:
+  - openssl >=3.0.13,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 283220
+  timestamp: 1715261653579
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
+  sha256: 238e486a0d62264e7ab35098bdc0390fb9a4649921b18827228c811ae8252c88
+  md5: f1ebe453c5a955a25e4b00f73279fc42
+  depends:
+  - boost-cpp >=1.73
+  - libevent
+  - openssl >=3.0.9,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 894777
+  timestamp: 1687975823684
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.13.1-h24da03e_2.tar.bz2
+  sha256: 24d079d3358bb106c330c17312dfa6abdf9c12bce5d5790887f3cbdac49e7220
+  md5: c43739c31d4a9046d482f9382d6a671f
+  depends:
+  - libiconv >=1.16,<2.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 3558894
+  timestamp: 1722441155964
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libzip-1.8.0-h289538f_1.tar.bz2
+  sha256: 3e22e243bb7d519db4a017e867bbedd7b147d9383f96e76e45e9ecd21e457ff4
+  md5: 195764a402200698d64570dab3350bd5
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 132285
+  timestamp: 1685378734951
+- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+  sha256: 4534c822511a052a72c2b070a05e5d8d6f3550f18ea00a33f9d8a9a92b4382cc
+  md5: 82f24e7660831445a2183216e280a6a4
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41464
+  timestamp: 1676474474981
+- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.43.0-py311hf2fb9eb_0.tar.bz2
+  sha256: bc9012cb5609cecf8ac40ad23546d10744ce2a9760781b5503df66b1aa07d1c7
+  md5: 25112566aaca1c88c03db128f681354a
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 20924132
+  timestamp: 1720456466056
+- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+  sha256: 896b7a39bd4ad3621312130122b4fe84dcb67d7355166255c58ea9bc562eb0ae
+  md5: 640b852a56296f48cf073e61a59c5256
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13751
+  timestamp: 1676428354074
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.3.2-py311h2bbff1b_0.tar.bz2
+  sha256: 5d7d4142cd2c91d151d26b7b22f1e4bd2357bcc5ee6b56516552145b43a6d022
+  md5: 35b521ddf937dab77b7720d3640761d4
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 86304
+  timestamp: 1686058058871
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+  sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
+  md5: 320f40b75d93f3b96931c6d13c23946c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 158902
+  timestamp: 1714512129889
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mapclassify-2.5.0-py311haa95532_0.tar.bz2
+  sha256: b20da7a8916544c0c2996bb81e9c222cf03be28f50500854e18b8a6338e13d65
+  md5: ad01428f515e6d91bf0dd6ddbaae66b9
+  depends:
+  - networkx
+  - numpy >=1.3,<2.0a0
+  - pandas >=1.0
+  - python >=3.11,<3.12.0a0
+  - scikit-learn
+  - scipy >=1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 83669
+  timestamp: 1678299426555
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+  sha256: e0dc6e119b224bb31ef34b6ba270ffadc181d38b698c5318de8df7a5d2c4ccbd
+  md5: 992ccd756f09408f0b74dfb9852a8b7f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 182381
+  timestamp: 1676437963591
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+  sha256: 050b5fd4b28132d8102a7e6b40179894dc7f5e41f7ad9ee19211e67446c5740f
+  md5: 3ae0b2f6baec708554648ddafa81b756
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 154386
+  timestamp: 1684279992864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+  sha256: 8269c73b7a9c03b95a121e318d0468f35eecc016093620b0560f35238cc5df51
+  md5: 2914bea0ae29315f998e1abac79ccaa8
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30214
+  timestamp: 1704206218108
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.9.2-py311h472561b_0.tar.bz2
+  sha256: 8cbfc06d4c0bf20f4aef4e26a342f9c5abbb8411cdea98b36e9f6486657824b9
+  md5: cf7246a7ee382f69bef2143c6aa23f9d
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 11748171
+  timestamp: 1725264782314
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+  sha256: 43279276850eb6e621812448cddc1093524cee0b7f8ed58b4600b68a4fb659f2
+  md5: 5968b2b5c1f3cf5c8c8c9aaa4d8d66a2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19886
+  timestamp: 1676425829787
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+  sha256: 3062a8254ca351b54f15bea85cc928a3ba4d879bb98ce97ece39a9f7eca215a5
+  md5: 8f1565663abb34ad7fdd512e76da5532
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 68031
+  timestamp: 1676481862508
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+  sha256: cdff5215c292fe59649ca40ca72f5d26da352760c1d6a56feba14eb13f7bbf61
+  md5: e0f3f32b22135dfeaec277bc87183ca9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23328
+  timestamp: 1676442709081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/minizip-4.0.3-hb68bac4_0.tar.bz2
+  sha256: 3502f337214ce9758383ee66ca65d6df3bed8b7e0196b503191c82ccc5bfbda1
+  md5: 00fb9fd38e34b8c9c271663f9fc4037a
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.5,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 87133
+  timestamp: 1702658623971
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+  sha256: 3b173a25605d2aaacc57ec0e425f1d1c51327eb2521c8742a736e2c76069bc8d
+  md5: 169f1c93a443f95a88665f3008623ce1
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104882
+  timestamp: 1676425142412
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+  sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
+  md5: 527155127b9fada5e5c5c69a624674b9
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187498166
+  timestamp: 1699648376430
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+  sha256: cea59ae60da314caecf08edb9bcb03126c6dd35837c8184bceaa194decca3341
+  md5: 30936b7263cf0171f7c86400f12ef184
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49080
+  timestamp: 1682975093455
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.10-py311h827c3e9_0.tar.bz2
+  sha256: 3a4017ff342e7d12ad8ff76db494476992d627285244bd7a07a42f78c21549f0
+  md5: f92336ec1d8cd9abdfbeb63d377c8be3
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 212248
+  timestamp: 1725370696454
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.7-py311hea22821_0.tar.bz2
+  sha256: 5b0d1234978727c749e319f02847208c3ec17a428204d90f40909b775ffb1b19
+  md5: e06038d13d1449ef235986b9d9704c8f
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 343687
+  timestamp: 1725370790459
+- conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py311h59b6b97_0.tar.bz2
+  sha256: c09c5ed3f07731091958ea6ed06a1eaeaca1f7e1361d341fb06b344d51074ca2
+  md5: 520c04235cf0980e1ce908e893b4dc71
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 37775
+  timestamp: 1676427521514
+- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+  sha256: 39f09c1bc57b4800ebda331eddb462928435498705351b0432d51a4293294ad8
+  md5: 5565984a02f41e97cb9a4c9126ced14b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29808
+  timestamp: 1676442800892
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
+  sha256: 636f369607118a6ee3d0b63b7edb925d8081fd3fc829a7699136ce0dedbde067
+  md5: b7e49c9cea50d8406cac81cd720dd80a
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8323655
+  timestamp: 1717622931223
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+  sha256: e940f9178ee2fa0a7c12873ae35ebea0074371653e5cfa1be8aa8d9271fd343b
+  md5: 355d0835215911738a28010dfa6aa382
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141785
+  timestamp: 1698934346590
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+  sha256: 47dd00c0179f4eb29c70d0453d340f7f5332af326b3d51c64ca3bf6a14be8e7e
+  md5: f66afe718bdb57667b03ebda4cb2ac7e
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 561655
+  timestamp: 1699023338436
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+  sha256: 4ee863a1ff697274c642b3101f82b279a354e3f033a87505655039f89127bb41
+  md5: bfaf19be6644ad2344e118aa0acccb13
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189809
+  timestamp: 1694617194065
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+  sha256: 90fb3f14c49da1397982eae21cd09e8d60d491d76f94c57590c56723fe6dc172
+  md5: 46a523661fe5c1bce7b4213fd428c3de
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16732
+  timestamp: 1708532795328
+- conda: https://repo.anaconda.com/pkgs/main/win-64/netcdf4-1.6.2-py311hec71f40_0.tar.bz2
+  sha256: faeafcf13019b66a9d872ab583a202ddfc3379c1ddb60ceccf6169f5a3c8cd36
+  md5: 329b1d446951338d97ca3bc3c7811acf
+  depends:
+  - cftime
+  - hdf5
+  - libnetcdf >=4.8,<4.9.0a0
+  - libnetcdf >=4.8.1,<5.0a0
+  - numpy >=1.22.3,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 378318
+  timestamp: 1676504914982
+- conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.3-py311haa95532_0.tar.bz2
+  sha256: 581da15cfc0d588d67386e658b29fb73584fcb56ce1c6ca1f1b665884145c253
+  md5: f97b1af76352a41580d8b846a2546edf
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - lxml >=4.6
+  - numpy >=1.23,<2.0a0
+  - scipy >=1.9,!=1.11.0,!=1.11.1
+  - pydot >=2.0
+  - sympy >=1.10
+  - pandas >=1.4
+  - pygraphviz >=1.12
+  - matplotlib-base >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3348847
+  timestamp: 1720002931830
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
+  sha256: 62732e34b2cdcb73846cfdf53284067d32113aae0f6d736ca30ce2b0073bce27
+  md5: ec7191b2ea4e65b5eed6f7fdd9271d28
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 769732
+  timestamp: 1717630919732
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+  sha256: e040ebcab948325fbe17e4ab15be62e1fafa7bad225457e59764adb60eb40db5
+  md5: 4d40a09df8cb74a9f044eab317436d67
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27282
+  timestamp: 1699456187703
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.60.0-py311hea22821_0.tar.bz2
+  sha256: 3d252d3b5bb30fcacf291c414d308792cb35d528aead1ebc2255e25a3ddc13d2
+  md5: 1da6aae4b3e031c95051b21ca01fd279
+  depends:
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - cuda-python >=11.6
+  - libopenblas !=0.3.6
+  - numba-rvsdg 0.0.*
+  - tbb >=2021.6,<2022
+  - cudatoolkit >=11.2
+  - scipy >=1.0
+  - cuda-version >=11.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6230264
+  timestamp: 1720555663355
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+  sha256: d3bd2a6614bb7e7f5ce3348d6674e71cce45cbde236beff32f0f08cd95a64ef0
+  md5: e70f15643164f432d1df68635e7c322b
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 162691
+  timestamp: 1696515822068
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+  sha256: 470fe9a0b3e196fa60d5550d8188f6074a207572fa0d353a4448d580872e7804
+  md5: 6fdb8df0613fb2fb9f1732d335fa25f1
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311hd01c5d8_0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11053
+  timestamp: 1708641901110
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+  sha256: 222c1711e7cf151e29077c7d4d86a865c9fd39615812d58a1daca6fd1b6bdfb5
+  md5: 585bcd8bc3940a8a859f38ebafdcd77d
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.26.4 py311hdab7c0b_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10723862
+  timestamp: 1708641867155
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+  sha256: e2afce0548808d27293a03661ee5f7ac3e18f82a92c9fb23f420eb5e92126fc6
+  md5: 9dd921a785844abe0aa842c3800d405a
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.7.0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 286986
+  timestamp: 1722872761369
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.15-h827c3e9_0.tar.bz2
+  sha256: a72f51f69a6893797b51345f9fd6b6a3b12764b435bb50e247e9e05d75711bd0
+  md5: c05007cfd519c5097f50d9c830ad897f
+  depends:
+  - ca-certificates
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8396971
+  timestamp: 1725547066793
+- conda: https://repo.anaconda.com/pkgs/main/win-64/orc-2.0.1-hd8d391b_0.tar.bz2
+  sha256: af8a9ad457ebc4c4aa800676ffbfd5cf830e1da697672ea6412bf041fd61cedd
+  md5: 584d733dc81492d46a926660353b361a
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.10,<2.0a0
+  - tzdata
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1235996
+  timestamp: 1717104791454
+- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+  sha256: b2f5f50a1ddf811102636f3acebd76716c88ebb628754b91eda7a3a962adf26c
+  md5: 712527b4d84c350dca4b67f511c04414
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39421
+  timestamp: 1699371341381
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.1-py311haa95532_0.tar.bz2
+  sha256: 01e970843b748f4af6cb1600fd2736d546158c3d69584cb915a08eb6c6924fcf
+  md5: 59b0cc461ea2af7e3f344faadc91e6aa
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 157605
+  timestamp: 1720102973406
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.2-py311hea22821_0.tar.bz2
+  sha256: 1b986a8752785cd01969e737952449f5f0f4284cab7690193fa1a602156881c2
+  md5: ecfe5661d54e32e8533c02f5fd625dcb
+  depends:
+  - bottleneck >=1.3.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - lxml >=4.9.2
+  - python-calamine >=0.1.7
+  - scipy >=1.10.0
+  - xlsxwriter >=3.0.5
+  - jinja2 >=3.1.2
+  - pyxlsb >=1.0.10
+  - pymysql >=1.0.2
+  - adbc-driver-sqlite >=0.8.0
+  - fastparquet >=2022.12.0
+  - zstandard >=0.19.0
+  - xarray >=2022.12.0
+  - blosc >=1.21.3
+  - gcsfs >=2022.11.0
+  - pytables >=3.8.0
+  - qtpy >=2.3.0
+  - sqlalchemy >=2.0.0
+  - xlrd >=2.0.1
+  - dataframe-api-compat >=0.1.7
+  - fsspec >=2022.11.0
+  - psycopg2 >=2.9.6
+  - pyreadstat >=1.2.0
+  - beautifulsoup4 >=4.11.2
+  - adbc-driver-postgresql >=0.8.0
+  - pyarrow >=10.0.1
+  - html5lib >=1.1
+  - numba >=0.56.4
+  - matplotlib-base >=3.6.3
+  - openpyxl >=3.1.0
+  - odfpy>=1.4.1
+  - s3fs >=2022.11.0
+  - pyqt >=5.15.9
+  - tabulate >=0.9.0
+  - pandas-gbq >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17245139
+  timestamp: 1718309568175
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.4-py311haa95532_0.tar.bz2
+  sha256: 25474a636549a0686cae03bdbc694683021813bf9d59680e0599b7666444c755
+  md5: 3c58f327cf194b62ab2f363e42598837
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.1.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21849968
+  timestamp: 1718120610637
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.1-py311haa95532_0.tar.bz2
+  sha256: e6611058e26521784b6197418505acee343ca299b7fa3f57ec23621f869e1d57
+  md5: ffd4cc05e70b156e44f242538d81ca99
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264340
+  timestamp: 1719348210484
+- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+  sha256: b0d7fbfcf1c5c682ed9934eb6a33e00a2517941f2bcb9d677379f4bb73b2c45c
+  md5: 20c8f36595a48f5cda2f4f74c02a3ea2
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48206
+  timestamp: 1698702818841
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pcre2-10.42-h0ff8eda_1.tar.bz2
+  sha256: 226780b480fab9707a50e60f7aac8107753c120c8e32246bd11abb8b7bc28cd5
+  md5: 0872c5406994b3516b6d9ba76c86d5df
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1506213
+  timestamp: 1714657817313
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.4.0-py311h827c3e9_0.tar.bz2
+  sha256: f7fa1d4f22457546451aa9ab55a10130dc20119771e5e0556cfae2cec0460538
+  md5: a64d6539ac40ffb07ab02221c214362a
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 1081527
+  timestamp: 1721060065320
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.2-py311haa95532_0.tar.bz2
+  sha256: 9c0dc12161f77b43137dad2e520ed7a343c5d8d8fd545492336e84201d1bb74c
+  md5: 22cda044cb24e1db8fbaa5864feb4261
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3199019
+  timestamp: 1723485404416
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pixman-0.40.0-h2bbff1b_1.tar.bz2
+  sha256: 20923fa2937cde57e8d2f5d67391b37eef349a9e3f5ff589bc75fb3dd3e0074f
+  md5: c62f32977c25875ced94e930d942db6b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 497111
+  timestamp: 1632711499953
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+  sha256: e5f8cbfb5fc25d460a9117bfc5511959c5e86ccb193316033f87bd516e0c8881
+  md5: 9f7e8b5eb651539386bb92c14e5c321b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37730
+  timestamp: 1692205554840
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pooch-1.7.0-py311haa95532_0.tar.bz2
+  sha256: 81da48745a2df74dfc4e17cc4a5c980a2c344361a07ac4cb2346f9b11511dff9
+  md5: fa43caa0d4957148ae9f363fbe0c5419
+  depends:
+  - packaging >=20.0
+  - platformdirs >=2.5.0
+  - python >=3.11,<3.12.0a0
+  - requests >=2.19.0
+  constrains:
+  - paramiko >=2.7.0
+  - xxhash >=1.4.3
+  - tqdm >=4.41.0,<5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105871
+  timestamp: 1695850304789
+- conda: https://repo.anaconda.com/pkgs/main/win-64/poppler-22.12.0-h0bf3bde_3.tar.bz2
+  sha256: 03fa4c3b0fc491cfc4736272a8a07b111255aee8029359ecc315e3253b20b977
+  md5: deecd5672f83b496fddc7d797c491626
+  depends:
+  - boost-cpp >=1.73.0,<2.0a0
+  - cairo >=1.16.0,<2.0a0
+  - fontconfig >=2.14.1,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - glib >=2.69.1,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libiconv >=1.16,<2.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - openjpeg >=2.3.0,<3.0a0
+  - poppler-data
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 2826813
+  timestamp: 1696001451072
+- conda: https://repo.anaconda.com/pkgs/main/win-64/poppler-data-0.4.11-haa95532_1.tar.bz2
+  sha256: 48c7975e4777318317369fe480f75531534cb8933a3e4de97cddf778a12f96dd
+  md5: fc41b46e1055778a44677d2e0e97fe32
+  license: GPL-2.0-or-later and GPL-3.0-or-later and BSD-3-Clause
+  license_family: GPL
+  size: 478379
+  timestamp: 1673863618032
+- conda: https://repo.anaconda.com/pkgs/main/win-64/proj-9.3.1-ha107b6e_0.tar.bz2
+  sha256: d6889db09a27fabfc97957c2e2b71506e621d219a6821b8e76588aeeb4ea6678
+  md5: 2337a98f76b8e96b7e2e76475de4ee0e
+  depends:
+  - libcurl >=7.88.1,<9.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - sqlite >=3.41.2,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 3070698
+  timestamp: 1704729163554
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+  sha256: 6c5b53831273674361437fb546e08315fc11ca9275a174bca3887987e86ced5a
+  md5: f8d91daf5173eb03157f484389adcdd4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 122178
+  timestamp: 1679591983138
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+  sha256: 546819d922b03f3a25ca9f98fd069d0588d481fc0603c6d74bd598fb6a93687f
+  md5: 86c18e3e0b67ee099457475ed6caf2e6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 751763
+  timestamp: 1704404627180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+  sha256: ae06f0dfa2cfae51404afc6d6ad3a474a93015b5ba9a7d3ea24224b8e7547987
+  md5: 3e19794c806cc3e84a3080a97c359b75
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 510466
+  timestamp: 1679005998612
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-16.1.0-py311hea22821_0.tar.bz2
+  sha256: 11ce49f6257b950e12f9a3ff9051f9d68d3b91e2d993e7369654e43b0a0cbf7e
+  md5: f097ff39d6b087d13b434985c137689d
+  depends:
+  - arrow-cpp >=16.1.0,<16.1.1.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4559429
+  timestamp: 1721665324191
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+  sha256: e2af1efb1a5094a5962d93fa949ecab479a2ae7570e030f52eeac6761383c208
+  md5: 4cb1359e22ddf8f3996afddce5f6205c
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 56638
+  timestamp: 1676438592117
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+  sha256: d95c88d06f4f3f667bd9a39e5f18179e83b3cd4c115c06ce0fff390ff6d3a700
+  md5: c6d00a8a4d89b1be99bfa3aff19d96b4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2134881
+  timestamp: 1684280285492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.1.2-py311haa95532_0.tar.bz2
+  sha256: 0cb6e4748cba79e77b82fbb50b9a820631e4a40146ce3d36f37531b0ba3321e7
+  md5: 7970d23adb4bb63d41f004ceebd3e3d2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 458992
+  timestamp: 1725041937893
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyproj-3.6.1-py311ha997c60_0.tar.bz2
+  sha256: 3d9f5ea994fe7582b70cb191ad39ddac17c1a52f61dc27aeeba91b4daa1e24c0
+  md5: b6fdbea05872f8eba95ac7c5c91c301d
+  depends:
+  - certifi
+  - proj >=9.3.1,<9.3.2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 1114131
+  timestamp: 1704901663468
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyshp-2.3.1-py311haa95532_0.tar.bz2
+  sha256: 60c0a9b26c40d46015ea17b68da5ff7375568d11e17b92a9000d0b91166233b2
+  md5: a28cafa542d188f1c805c89f3226dd89
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 86645
+  timestamp: 1706101056895
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+  sha256: 974c22de09078bf07c5db31fe12d8d89d6433508defc8237cbe52e08c69ed56b
+  md5: 9cf10bfd49140a527cf4b1d912097e6d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36072
+  timestamp: 1676426019064
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
+  sha256: f43aca7a222c983c25c3e15f79c7e7e3c4909bb7839a1dd0ee327def81aa476e
+  md5: 2b61f1cb7fec068c76ef0ff97c2c62b5
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - openssl >=3.0.13,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - openssl <3.5.7
+  license: PSF-2.0
+  license_family: PSF
+  size: 19811751
+  timestamp: 1713545124922
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+  sha256: 2c61639b3bb56fc864c86558bceb7845b1731ac44bf1a94894172ea47a995bd4
+  md5: 404805e547b4d50b5cd17e16bca87527
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332043
+  timestamp: 1716495838826
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+  sha256: 9acb33db60d9319595f52337cae3b88c2a2338cd66f1f9d8ae86d0a993c2067a
+  md5: f4af8cf94d042b4dde487241bba1c457
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279780
+  timestamp: 1679500609851
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+  sha256: 48fe7373b012b51134b6b6ff67f18d2b4aae3a5c7700e4560ce002af7172f064
+  md5: 0379cd17692152c12b662b0e4ea46b88
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18008
+  timestamp: 1683824373128
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py311hd77b12b_0.tar.bz2
+  sha256: 40093db499547e192da8c52132ef1016bab65f2dfd2e4049739f2f8b574e3836
+  md5: a6b568626951b8a9070c30e043cb2603
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 150521
+  timestamp: 1682522716553
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+  sha256: 803274d986d0c4e3b5ec1018747ede86ef57137455b3e44a60e834717eafb92b
+  md5: c9f134ddeff6fdf0373a45534ddb7079
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 273009
+  timestamp: 1713974722039
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+  sha256: 6fbcba97c1dcb5157afd23f264c3cff069c7e4be5ea55980fc349eb8dc2cb49e
+  md5: 8153e3f8b3283926bcf9403804a365f5
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65050
+  timestamp: 1711137009299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+  sha256: cd33dfee104dfbba4af38d06a09ccbae6a32e7c543afedab523303319ebb283d
+  md5: 3dfc19af0306d80921e1403f1f551bba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13679916
+  timestamp: 1676423267293
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+  sha256: 102ff1d958209e3648bb49da3503cf752abab822011fdc4e12e88145c9e73772
+  md5: 0553c2c381b6f5c836b23edc8c6db2ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 246689
+  timestamp: 1677708371873
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+  sha256: bee5c4d0f41f06a9c0aac636885e36e8b81116aafde980f9ea48fdb64abb5567
+  md5: 6c05a053240cb90765d6f8c2efdf905e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 182228
+  timestamp: 1698096268270
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+  sha256: ea39db411361d96545a04fb976940e9590147acb4ca9caacf7e8264780379347
+  md5: b411b8be8e53e5059949dde02dd07faf
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 565148
+  timestamp: 1709319072176
+- conda: https://repo.anaconda.com/pkgs/main/win-64/qhull-2020.2-h59b6b97_2.tar.bz2
+  sha256: 5d677c17afe37f24eb30f143fccf45450d81929227869256a277a66dd9a36325
+  md5: 09ec672a48cc028863ef171fc8c5d418
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Qhull
+  license_family: Other
+  size: 2338798
+  timestamp: 1670915907181
+- conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+  sha256: 720f3dd1f933d035b1393951ffd1b6437fc5e19b1999e74096044514a46053fb
+  md5: add2dfb15b518144663fc3b897d66da7
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  size: 493391
+  timestamp: 1652432364793
+- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+  sha256: 47653b45a5f2d97b5bf0dbf0e620908880f9078da427eef69012effe3f19af67
+  md5: 44e709ae67d89bccee2d4d46d358fee3
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74493
+  timestamp: 1699012356534
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py311haa95532_0.tar.bz2
+  sha256: 4a18e8e023227dfb66668c5b1af421810be2db6d73d204a3f185f5460d747b1d
+  md5: fa65f36aabdaeb0c65be48d9e6a28952
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 124310
+  timestamp: 1721411219691
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+  sha256: d6daaa6b45272819176e4aeb467ae00e3db43386548464a9993688f292709d40
+  md5: 9fe721d7f7420c259df4f07d4503f654
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9683
+  timestamp: 1683077110211
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+  sha256: 6051860575f9448aea5799d74469c928cd7cdeeca1eb53657872262a77b1a7a8
+  md5: 60e193eca497130034facd5fed168249
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10094
+  timestamp: 1683059114376
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+  sha256: ecd310461c1b45ab92ddf15539cea5a6e837860561c974d2d7393f9a7933f116
+  md5: 1762fec2838763e904141167e18b0389
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 215600
+  timestamp: 1698947891859
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rtree-1.0.1-py311h2eaa2aa_0.tar.bz2
+  sha256: 3394280087bffa3fddc7937002ab9bc614b8b49a673d48da376de3856326ad6c
+  md5: c4090dd318aac6dc98afb35bcafb8a79
+  depends:
+  - libspatialindex >=1.8.5
+  - libspatialindex >=1.9.3,<1.9.4.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 63380
+  timestamp: 1676455791440
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scikit-learn-1.5.1-py311hea22821_0.tar.bz2
+  sha256: 2894460226abef75c8e5839637558a2d4def3ba7f854be3870620a36ef2bc818
+  md5: f2470395cb0f987b3aeda2b2e89b555e
+  depends:
+  - joblib >=1.2.0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - scipy >=1.6.0
+  - threadpoolctl >=3.1.0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12416315
+  timestamp: 1722070561815
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.13.1-py311h9f229c6_0.tar.bz2
+  sha256: bf3bfa0b2bbf800e38384bfee37854b0f22413a4b2f64b9a52135bd48ba5069b
+  md5: 7a7dd8a74d59ceba1963770bb2d85958
+  depends:
+  - blas 1.0 mkl
+  - icc_rt >=2022.1.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 5
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 32305235
+  timestamp: 1717522696972
+- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+  sha256: 6fd52bae6360fbc8135d72e0c1e4fd407769fa4d0f4b59356e7aed3e000eb339
+  md5: 49fd52885250da8aab17ed72e2e18b81
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88901
+  timestamp: 1699371435766
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-75.1.0-py311haa95532_0.tar.bz2
+  sha256: 229e6de8307d0463288427283e65479a1f2b8e0f4ec49edfd419bea6fb124b33
+  md5: 253b0897800b6c739dc3ee26546ddf7e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2308770
+  timestamp: 1726678611334
+- conda: https://repo.anaconda.com/pkgs/main/win-64/shapely-2.0.5-py311h82fc408_0.tar.bz2
+  sha256: 7890ce8c7136265f29c060c3364e04005f668ca704048556068bf3acc18a1f50
+  md5: 24fd48a77fd53b9d9440da592e080d51
+  depends:
+  - geos >=3.8.0,<3.8.1.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 611671
+  timestamp: 1722534074562
+- conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
+  sha256: 5e5f855a70cf4c9dc6f2ac8d9fa51a3f095bf4db8e2ee3ff213ef5432556d7cd
+  md5: 9c1f7331a4116e5c27d8af7453f8ee47
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 119274
+  timestamp: 1723557526373
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+  sha256: 5d1b7e14dc04816692de0f8518ea8fcbefb26ab61cec83f96f2c44c1bee67fab
+  md5: 505d2a70a875b5082dc857aa4dfab0d4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 18830
+  timestamp: 1705431395254
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+  sha256: 5ff3b4ac3fbce4dd67a87856c04698d0397deb0ac288ff4e7eb02fbab57f1253
+  md5: 0ca650a7001c6650809d3361de8cb005
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89590
+  timestamp: 1696347858925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+  sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
+  md5: 833b93a2daade3407898f15588945d83
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1440481
+  timestamp: 1714488344682
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+  sha256: 78d89b50a29fbeb19a562f5dad95615e3f192bb4f3b86cd6ea75f2f825418232
+  md5: 4a4040df560ea47704e0898c4c015808
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38069
+  timestamp: 1678228553220
+- conda: https://repo.anaconda.com/pkgs/main/win-64/threadpoolctl-3.5.0-py311h746a85d_0.tar.bz2
+  sha256: ca96d2a2b8dc02bea485ef1944ef7c8d6fb142db1dce83c2b2d4e14b0a89adc2
+  md5: ec1477c9c6e94c22522b11e109346f2f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49825
+  timestamp: 1719407929091
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tiledb-2.3.3-hd8964de_3.tar.bz2
+  sha256: cd56f532cf85dc3d3b13c170c8bdc22e9c4e4f943f92f400475f7edd864b56e2
+  md5: 2bb3534c127f29c03a059e11ac788343
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl 3.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 2544180
+  timestamp: 1685657756987
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+  sha256: 70a3cc4a4e81a6421bc19cd410d1d6064aadb2b1cce38b020f85e5346716d8e7
+  md5: 32a9a2539579a3d522dce3b5cb4f987b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49495
+  timestamp: 1676425411739
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+  sha256: 0a95736cfd0bb25fc201cd6be4a2450ea8fc30eeb349d861812675b84c94fa74
+  md5: a8a9fb30c6dd8e7a16d5dcd2333c3c49
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3844176
+  timestamp: 1714770894235
+- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+  sha256: ed5950ac0c12cc87f991a6f28112cf29057e2b7ad416ae4429a0b97c3efaf58c
+  md5: b5e2a04879e6fd19f0eb5effded4dc61
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135939
+  timestamp: 1676431438808
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.1-py311h827c3e9_0.tar.bz2
+  sha256: 04340cd171ff970c405b4b955f825cb52deb71f4420346596744bf36214ce431
+  md5: bbab95732695d5d4c759dfbd274a15ff
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 926984
+  timestamp: 1718740216876
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.5-py311h746a85d_0.tar.bz2
+  sha256: 283f31f5ef79657b27b9a6d82b5366b869744b553f90bad219714f2771b0088f
+  md5: cea2f913161c630749f8e8ac190c99f3
+  depends:
+  - colorama
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 186694
+  timestamp: 1724854118410
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
+  sha256: a724711191ac1226bf228eab49718eed7b5c7394f539294eb0f88baf8e7bb24d
+  md5: c78482e07d0aa6df9fcfa5b366dd87e3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 207744
+  timestamp: 1718227224929
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+  sha256: ab3cce654f1e94793fff0cb03b750d9b20cdbf099263b1906c3c5eaf8b347ab6
+  md5: c68ffc771312afb6f88b94c24d2bb689
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9706
+  timestamp: 1715268972001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+  sha256: 4089efea1753ebe2f6617b46cc368738f285b1d816d4a4f01ba71524f46851b4
+  md5: 7f610528ecd0b317180efa2058c32323
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 75414
+  timestamp: 1715268958140
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+  sha256: d091897f05318c22ca31028370f25355065999078f7db6f88ab27bf4cb030ec8
+  md5: 1776502c1cfb351554eeda6cddaf255f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11588
+  timestamp: 1676457729096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+  sha256: c16498f8238cc331618720d078b87995eceb6bbf20268a7a4e8efbf7b5859a9a
+  md5: 770432c0ca1ab9d99ffe95e51d3a3e74
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 517433
+  timestamp: 1713213261710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uriparser-0.9.7-h2bbff1b_0.tar.bz2
+  sha256: f88e04209064e9a72fccc9284271405d9548106c2bf302e24fa1e8e8bb36a127
+  md5: 8845191f3242c429e10220e3ed9ee73c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48486
+  timestamp: 1692187056029
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.2-py311haa95532_0.tar.bz2
+  sha256: e6b7f1cf269463c87bffbe808e88069c36ee0ff1d909e65d8986b914980ec0b9
+  md5: b5852f18c3edfcc6147cdaf96a1ecc99
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - zstandard >=0.18.0
+  - requests >=2.26.0
+  - selenium >=4.4.3
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 210228
+  timestamp: 1718912759694
+- conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+  sha256: 2ef16d0252e04063d44d0683831d55b485f713fe5af2c2efd61753fb4f27d7e4
+  md5: 256ab1d5dce70111a1f4807a5a9fc322
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 100982
+  timestamp: 1706894771410
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.40-h2eaa2aa_1.tar.bz2
+  sha256: 5bbfaacd95bb901683d6d2e7a1ee10f67172acc1e012f73f80bfef5237ae3ae4
+  md5: f37ef4381071123903074612dad356f4
+  depends:
+  - vs2015_runtime >=14.40.33807
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9122
+  timestamp: 1726064402583
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.40.33807-h98bb1dd_1.tar.bz2
+  sha256: d82b5b2b1a9a1b37da109039274c125355ce478a199c07c7826ac0fdc2178491
+  md5: a0f93c06400da31b9e6e0538eab91216
+  size: 2611238
+  timestamp: 1726064391949
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+  sha256: 24ea3d3e0cb98d0d246338dbb4562b67967bb32002e3704e495a5c863476e831
+  md5: c7b9cdbe87b3c9720aeca1164a0fd6df
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26181
+  timestamp: 1676424437003
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+  sha256: 92d27e41ce34387e59acb47572fcb2e92c4defaeadafd11ce190226022023e69
+  md5: f1bf142d852987acbe4b0bc94e87d958
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145306
+  timestamp: 1715878654770
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.44.0-py311haa95532_0.tar.bz2
+  sha256: 2eb16eafe8322ad10c73b19be8f2c8b6135561bead6f73f48c069417f5db8928
+  md5: b28ec461da7eac99523f146ae752529b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 170318
+  timestamp: 1726165294131
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+  sha256: 17fadf35aa8917c107e7b369e9364ac7c09537776e7943d37e225e14b7026c94
+  md5: 0e67c3b9624540581b894b11267a837b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PUBLIC-DOMAIN
+  size: 10197
+  timestamp: 1676425485716
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+  sha256: 25373efabba9a866849fe38a47c79e0fa323851b4bd4b5df357cc8d5617c2786
+  md5: a958e9d32c3b65c21e11e5d9e8491c43
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2467966
+  timestamp: 1689041676824
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xerces-c-3.2.4-hd77b12b_1.tar.bz2
+  sha256: 2160b68a45de4b20ce5e63ba06a0db91913e325e5b796ef9f40d38bd2bb8260d
+  md5: a6d582169295a9de869f242530796475
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4221569
+  timestamp: 1692995399482
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+  sha256: b849b368e27920838fe40a512b102879693a55cb187dd1c8d3a83fa8c05a8054
+  md5: 7b1f6e9c71906a93039b3446b99a5498
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55114
+  timestamp: 1676434863173
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+  sha256: 344a5276a9928638dcde054dfe4e87c8cb40bd2d4d356378b9ab2f863ca62e4b
+  md5: fe471fd8b5a3d77be6fa5dbf9b99dafb
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 1432281
+  timestamp: 1714515119689
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+  sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
+  md5: e5aed81295b61b6d1eb62830799a0297
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 9125184
+  timestamp: 1705602328351
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py311haa95532_0.tar.bz2
+  sha256: 478892109d9dc82c90f82d269d3796f4f812f6cba5d3d1f9178a20bd7f583a1f
+  md5: df02873bda6c5de6331b00fb1591abac
+  depends:
+  - heapdict
+  - python >=3.11,<3.12.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102456
+  timestamp: 1695833422458
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
+  sha256: d932439798665be388bbf68f3d68da5b42ed4753a43587d3f49848a85f58add4
+  md5: e2900345674e644e05540ffac6acca89
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 25247
+  timestamp: 1704207149955
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+  sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
+  md5: f295b54ab59f5b8658e2a322ac6aa721
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 162161
+  timestamp: 1714514792081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+  sha256: b2ff66b7f6efa0831f939e57e562c244332b690af08818a540d1a97fa07d8525
+  md5: e548d528873d9a0006a36714cf36462a
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1933522
+  timestamp: 1714679197977

--- a/gerrymandering/pixi.lock
+++ b/gerrymandering/pixi.lock
@@ -7,1138 +7,1138 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-16.1.0-hc1eb8f0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.10.55-h721c034_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blosc-1.21.3-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.1-py311h92b7b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/branca-0.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.7.2-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cairo-1.16.0-hb05425b_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cartopy-0.22.0-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.8.30-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cfitsio-3.470-h5893167_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cftime-1.6.2-py311hbed6279_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.2-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-2024.8.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.8.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-expr-1.1.13-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.16.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2024.8.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.6.3-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fiona-1.9.5-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/folium-0.14.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.14.1-h55d465d_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freexl-2.0.0-hf309648_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.6.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gdal-3.6.2-py311ha0db937_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/geopandas-0.14.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/geopandas-base-0.14.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/geos-3.8.0-he6710b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/geotiff-1.7.0-h2a26cda_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/geoviews-1.12.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/geoviews-core-1.12.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.78.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-tools-2.78.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf4-4.2.13-h3ca952b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf5-1.12.1-h2b7332f_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.19.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.27.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/joblib-1.4.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/json-c-0.16-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kealib-1.5.0-hd940352_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libabseil-20240116.2-cxx17_h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.9.1-h251f7ec_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgdal-3.6.2-hd4d5da2_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libglib-2.78.4-hdc74915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgrpc-1.62.2-h2d74bed_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libkml-1.3.0-h096b73e_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hecde1de_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnetcdf-4.8.1-h14805e7_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpq-12.17-hdbd6064_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-4.25.3-he621ea3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libspatialindex-1.9.3-h2531618_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libspatialite-5.1.0-h040243e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.11.0-h251f7ec_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.13.1-hfdd30dd_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libzip-1.8.0-h6ac8c49_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.43.0-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mapclassify-2.5.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.9.2-py311h6fb44e5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/minizip-4.0.3-hf59b114_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.10-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.7-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py311hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/netcdf4-1.6.2-py311h0e679e6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nspr-4.35-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nss-3.89.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.60.0-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.15-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-2.0.1-h2d29ad5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.2-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.4.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pixman-0.40.0-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pooch-1.7.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/poppler-22.12.0-h9614445_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/poppler-data-0.4.11-h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/proj-9.3.1-he5811b7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-16.1.0-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.1.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyproj-3.6.1-py311h76fdc58_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyshp-2.3.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/qhull-2020.2-hdb19cb5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rtree-1.0.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scikit-learn-1.5.1-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.13.1-py311h08b1b3b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-75.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/shapely-2.0.5-py311h24a2a10_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/threadpoolctl-3.5.0-py311h92b7b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tiledb-2.3.3-h77177df_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.1-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.5-py311h92b7b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uriparser-0.9.7-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.44.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xerces-c-3.2.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/arrow-cpp-16.1.0-hc1eb8f0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-sdk-cpp-1.10.55-h721c034_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blosc-1.21.3-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-3.4.1-py311h92b7b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/branca-0.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2024.7.2-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cairo-1.16.0-hb05425b_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cartopy-0.22.0-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2024.8.30-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cfitsio-3.470-h5893167_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cftime-1.6.2-py311hbed6279_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cloudpickle-3.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cytoolz-0.12.2-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dask-2024.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dask-core-2024.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dask-expr-1.1.13-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/datashader-0.16.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/distributed-2024.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/expat-2.6.3-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fiona-1.9.5-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/folium-0.14.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fontconfig-2.14.1-h55d465d_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freexl-2.0.0-hf309648_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fsspec-2024.6.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gdal-3.6.2-py311ha0db937_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/geopandas-0.14.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/geopandas-base-0.14.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/geos-3.8.0-he6710b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/geotiff-1.7.0-h2a26cda_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/geoviews-1.12.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/geoviews-core-1.12.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/glib-2.78.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/glib-tools-2.78.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/hdf4-4.2.13-h3ca952b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/hdf5-1.12.1-h2b7332f_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.19.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.27.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.19.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/joblib-1.4.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/json-c-0.16-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kealib-1.5.0-hd940352_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libabseil-20240116.2-cxx17_h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libcurl-8.9.1-h251f7ec_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgdal-3.6.2-hd4d5da2_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libglib-2.78.4-hdc74915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgrpc-1.62.2-h2d74bed_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libkml-1.3.0-h096b73e_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libllvm14-14.0.6-hecde1de_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libnetcdf-4.8.1-h14805e7_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpq-12.17-hdbd6064_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libprotobuf-4.25.3-he621ea3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libspatialindex-1.9.3-h2531618_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libspatialite-5.1.0-h040243e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libssh2-1.11.0-h251f7ec_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxml2-2.13.1-hfdd30dd_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libzip-1.8.0-h6ac8c49_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.43.0-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-4.3.2-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mapclassify-2.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.9.2-py311h6fb44e5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/minizip-4.0.3-hf59b114_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.10-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.7-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/msgpack-python-1.0.3-py311hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/netcdf4-1.6.2-py311h0e679e6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/networkx-3.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nspr-4.35-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nss-3.89.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numba-0.60.0-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.15-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/orc-2.0.1-h2d29ad5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-24.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-2.2.2-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-1.4.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-2.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-10.4.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-24.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pixman-0.40.0-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pooch-1.7.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/poppler-22.12.0-h9614445_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/poppler-data-0.4.11-h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/proj-9.3.1-he5811b7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyarrow-16.1.0-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.1.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyproj-3.6.1-py311h76fdc58_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyshp-2.3.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-lmdb-1.4.1-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/qhull-2020.2-hdb19cb5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.32.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rtree-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scikit-learn-1.5.1-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scipy-1.13.1-py311h08b1b3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-75.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/shapely-2.0.5-py311h24a2a10_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/threadpoolctl-3.5.0-py311h92b7b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tiledb-2.3.3-h77177df_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.4.1-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.66.5-py311h92b7b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/uriparser-0.9.7-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-2.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.44.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xerces-c-3.2.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zict-3.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-16.1.0-hc0a701b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.10.55-h61975a4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.1-py311h85bffb1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/branca-0.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.7.2-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cairo-1.16.0-h3ce6f7e_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cartopy-0.22.0-py311hdb55bb0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.8.30-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py311h9205ec4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cftime-1.6.2-py311hb9e55a9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.2-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-2024.8.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2024.8.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-expr-1.1.13-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.16.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2024.8.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/expat-2.6.3-h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fiona-1.9.5-py311hdb55bb0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/folium-0.14.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fontconfig-2.14.1-h269ac6a_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freexl-2.0.0-hce1ea5d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.6.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gdal-3.6.2-py311he4f215e_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/geopandas-0.14.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/geopandas-base-0.14.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/geos-3.8.0-hb1e8313_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/geotiff-1.7.0-hf6ff7a4_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/geoviews-1.12.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/geoviews-core-1.12.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gettext-0.21.0-h4e8c18a_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/glib-2.78.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/glib-tools-2.78.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf4-4.2.13-h39711bb_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf5-1.12.1-ha01d115_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.19.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.27.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/joblib-1.4.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/json-c-0.16-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kealib-1.5.0-h72c422f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libabseil-20240116.2-cxx17_h548131f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.9.1-h3a17b82_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgdal-3.6.2-hfaf651c_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libglib-2.78.4-h19e1a8f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgrpc-1.62.2-hf2926fd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libkml-1.3.0-h85bf17e_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h26321d7_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnetcdf-4.8.1-h9f5a9a2_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpq-12.17-h04015c4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-4.25.3-h34eed0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libspatialindex-1.9.3-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libspatialite-5.1.0-hd7ca590_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.11.0-hf20ceda_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.13.1-h6070cd6_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libzip-1.8.0-h29ab7a1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.43.0-py311h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-4.3.2-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mapclassify-2.5.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.9.2-py311hc25a08b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/minizip-4.0.3-h79ad51c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py311ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/netcdf4-1.6.2-py311h42ba51d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nspr-4.35-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nss-3.89.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.60.0-py311he327ffe_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h91b6869_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h91b6869_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311hb3ec012_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.15-h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-2.0.1-h5747287_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.2-py311he327ffe_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pcre2-10.42-h9b97e30_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.4.0-py311h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pixman-0.40.0-h9ed2024_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pooch-1.7.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/poppler-22.12.0-ha8a1649_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/poppler-data-0.4.11-hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/proj-9.3.1-h1972728_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-16.1.0-py311he327ffe_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.1.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyproj-3.6.1-py311h717f92e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyshp-2.3.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/qhull-2020.2-ha357a0b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rtree-1.0.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scikit-learn-1.5.1-py311he327ffe_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.13.1-py311hedc7b93_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-75.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/shapely-2.0.5-py311h41c673d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/threadpoolctl-3.5.0-py311h85bffb1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tiledb-2.3.3-h1b93210_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.1-py311h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.5-py311h85bffb1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uriparser-0.9.7-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.44.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xerces-c-3.2.4-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/arrow-cpp-16.1.0-hc0a701b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-sdk-cpp-1.10.55-h61975a4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-3.4.1-py311h85bffb1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/branca-0.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2024.7.2-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cairo-1.16.0-h3ce6f7e_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cartopy-0.22.0-py311hdb55bb0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2024.8.30-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.17.1-py311h9205ec4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cftime-1.6.2-py311hb9e55a9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cloudpickle-3.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cytoolz-0.12.2-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/dask-2024.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/dask-core-2024.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/dask-expr-1.1.13-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/datashader-0.16.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/distributed-2024.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/expat-2.6.3-h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fiona-1.9.5-py311hdb55bb0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/folium-0.14.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fontconfig-2.14.1-h269ac6a_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freexl-2.0.0-hce1ea5d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fsspec-2024.6.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/gdal-3.6.2-py311he4f215e_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/geopandas-0.14.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/geopandas-base-0.14.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/geos-3.8.0-hb1e8313_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/geotiff-1.7.0-hf6ff7a4_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/geoviews-1.12.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/geoviews-core-1.12.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/gettext-0.21.0-h4e8c18a_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/glib-2.78.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/glib-tools-2.78.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/hdf4-4.2.13-h39711bb_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/hdf5-1.12.1-ha01d115_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.19.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.27.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.19.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/joblib-1.4.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/json-c-0.16-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kealib-1.5.0-h72c422f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libabseil-20240116.2-cxx17_h548131f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcurl-8.9.1-h3a17b82_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgdal-3.6.2-hfaf651c_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libglib-2.78.4-h19e1a8f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgrpc-1.62.2-hf2926fd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libkml-1.3.0-h85bf17e_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libllvm14-14.0.6-h26321d7_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libnetcdf-4.8.1-h9f5a9a2_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpq-12.17-h04015c4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libprotobuf-4.25.3-h34eed0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libspatialindex-1.9.3-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libspatialite-5.1.0-hd7ca590_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libssh2-1.11.0-hf20ceda_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxml2-2.13.1-h6070cd6_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libzip-1.8.0-h29ab7a1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.43.0-py311h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-4.3.2-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mapclassify-2.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.9.2-py311hc25a08b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/minizip-4.0.3-h79ad51c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/msgpack-python-1.0.3-py311ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/netcdf4-1.6.2-py311h42ba51d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/networkx-3.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nspr-4.35-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nss-3.89.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numba-0.60.0-py311he327ffe_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py311h91b6869_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.4-py311h91b6869_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.4-py311hb3ec012_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.15-h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/orc-2.0.1-h5747287_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-24.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-2.2.2-py311he327ffe_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-1.4.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-2.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pcre2-10.42-h9b97e30_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.4.0-py311h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-24.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pixman-0.40.0-h9ed2024_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pooch-1.7.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/poppler-22.12.0-ha8a1649_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/poppler-data-0.4.11-hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/proj-9.3.1-h1972728_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyarrow-16.1.0-py311he327ffe_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.1.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyproj-3.6.1-py311h717f92e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyshp-2.3.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-lmdb-1.4.1-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/qhull-2020.2-ha357a0b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.32.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rtree-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scikit-learn-1.5.1-py311he327ffe_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scipy-1.13.1-py311hedc7b93_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-75.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/shapely-2.0.5-py311h41c673d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/threadpoolctl-3.5.0-py311h85bffb1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tiledb-2.3.3-h1b93210_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.4.1-py311h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.66.5-py311h85bffb1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uriparser-0.9.7-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-2.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.44.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xerces-c-3.2.4-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zict-3.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-16.1.0-hbc20fb2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.10.55-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.1-py311hb6e6a13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/branca-0.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.7.2-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cairo-1.16.0-h302bd0f_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cartopy-0.22.0-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.8.30-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cftime-1.6.2-py311ha0d4635_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.2-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-2024.8.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.8.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-expr-1.1.13-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.16.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2024.8.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/expat-2.6.3-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fiona-1.9.5-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/folium-0.14.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fontconfig-2.14.1-h6402c1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freexl-2.0.0-ha3de405_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.6.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gdal-3.6.2-py311h950983f_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geopandas-0.14.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geopandas-base-0.14.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geos-3.9.1-hc377ac9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geotiff-1.7.0-h41f0982_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geoviews-1.12.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geoviews-core-1.12.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-0.21.0-hbdbcc25_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glib-2.78.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glib-tools-2.78.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf4-4.2.13-h5e329fb_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf5-1.12.1-h05c076b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.19.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.27.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/joblib-1.4.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/json-c-0.16-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kealib-1.5.0-hba2eb73_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libabseil-20240116.2-cxx17_h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.9.1-h3e2b118_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgdal-3.6.2-h51eea9d_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libglib-2.78.4-h0a96307_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgrpc-1.62.2-h62f6fdd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libkml-1.3.0-hc4d7c42_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h19fdd8a_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnetcdf-4.8.1-h0fce390_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpq-12.17-h02f6b3c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-4.25.3-h514c7bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libspatialindex-1.9.3-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libspatialite-5.1.0-h3e2df84_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.11.0-h3e2b118_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.13.1-h0b34f26_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzip-1.8.0-h62fee54_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.43.0-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.3.2-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mapclassify-2.5.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.9.2-py311hecf7826_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/minizip-4.0.3-ha89c15f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py311h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/netcdf4-1.6.2-py311h55fefbe_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nspr-4.35-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nss-3.89.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.60.0-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.15-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-2.0.1-h937ddfc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.2-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre2-10.42-hb066dcc_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.4.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pixman-0.40.0-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pooch-1.7.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/poppler-22.12.0-h52f4003_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/poppler-data-0.4.11-hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/proj-9.3.1-h805f6d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-16.1.0-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.1.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyproj-3.6.1-py311h041c639_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyshp-2.3.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/qhull-2020.2-h48ca7d4_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rtree-1.0.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scikit-learn-1.5.1-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.13.1-py311hac8794a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-75.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/shapely-2.0.5-py311h3713c0e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/threadpoolctl-3.5.0-py311hb6e6a13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tiledb-2.3.3-hb4a6b97_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.1-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.5-py311hb6e6a13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uriparser-0.9.7-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.44.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xerces-c-3.2.4-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/arrow-cpp-16.1.0-hbc20fb2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-sdk-cpp-1.10.55-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.4.1-py311hb6e6a13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/branca-0.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2024.7.2-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cairo-1.16.0-h302bd0f_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cartopy-0.22.0-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.8.30-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cftime-1.6.2-py311ha0d4635_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-3.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cytoolz-0.12.2-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/dask-2024.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2024.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/dask-expr-1.1.13-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/datashader-0.16.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/distributed-2024.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/expat-2.6.3-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fiona-1.9.5-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/folium-0.14.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fontconfig-2.14.1-h6402c1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freexl-2.0.0-ha3de405_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2024.6.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/gdal-3.6.2-py311h950983f_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/geopandas-0.14.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/geopandas-base-0.14.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/geos-3.9.1-hc377ac9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/geotiff-1.7.0-h41f0982_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/geoviews-1.12.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/geoviews-core-1.12.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/gettext-0.21.0-hbdbcc25_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/glib-2.78.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/glib-tools-2.78.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/hdf4-4.2.13-h5e329fb_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/hdf5-1.12.1-h05c076b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.19.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.27.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.19.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/joblib-1.4.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/json-c-0.16-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kealib-1.5.0-hba2eb73_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libabseil-20240116.2-cxx17_h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcurl-8.9.1-h3e2b118_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgdal-3.6.2-h51eea9d_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libglib-2.78.4-h0a96307_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgrpc-1.62.2-h62f6fdd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libkml-1.3.0-hc4d7c42_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libllvm14-14.0.6-h19fdd8a_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libnetcdf-4.8.1-h0fce390_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpq-12.17-h02f6b3c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libprotobuf-4.25.3-h514c7bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libspatialindex-1.9.3-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libspatialite-5.1.0-h3e2df84_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libssh2-1.11.0-h3e2b118_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.13.1-h0b34f26_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libzip-1.8.0-h62fee54_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.43.0-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-4.3.2-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mapclassify-2.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.9.2-py311hecf7826_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/minizip-4.0.3-ha89c15f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/msgpack-python-1.0.3-py311h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/netcdf4-1.6.2-py311h55fefbe_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/networkx-3.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nspr-4.35-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nss-3.89.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numba-0.60.0-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.15-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/orc-2.0.1-h937ddfc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-24.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.2.2-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-1.4.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-2.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pcre2-10.42-hb066dcc_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.4.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-24.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pixman-0.40.0-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pooch-1.7.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/poppler-22.12.0-h52f4003_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/poppler-data-0.4.11-hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/proj-9.3.1-h805f6d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyarrow-16.1.0-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.1.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyproj-3.6.1-py311h041c639_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyshp-2.3.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-lmdb-1.4.1-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/qhull-2020.2-h48ca7d4_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.32.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rtree-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scikit-learn-1.5.1-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.13.1-py311hac8794a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-75.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/shapely-2.0.5-py311h3713c0e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/threadpoolctl-3.5.0-py311hb6e6a13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tiledb-2.3.3-hb4a6b97_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.4.1-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.66.5-py311hb6e6a13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uriparser-0.9.7-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.44.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xerces-c-3.2.4-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zict-3.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-16.1.0-h7cd61ee_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.10.55-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.1-py311h746a85d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/branca-0.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.7.2-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cairo-1.16.0-haedb8bc_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cartopy-0.22.0-py311h786e728_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.8.30-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py311h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cftime-1.6.2-py311h5bb9823_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.2-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-2024.8.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.8.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-expr-1.1.13-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.16.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2024.8.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/expat-2.6.3-h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fiona-1.9.5-py311hf62ec03_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/folium-0.14.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fontconfig-2.14.1-hb33846d_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freexl-2.0.0-hd7a5696_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.6.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/gdal-3.6.2-py311h4e7b5b2_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/geopandas-0.14.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/geopandas-base-0.14.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/geos-3.8.0-h33f27b4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/geotiff-1.7.0-h4545760_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/geoviews-1.12.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/geoviews-core-1.12.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/glib-2.78.4-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/glib-tools-2.78.4-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/hdf4-4.2.13-h712560f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/hdf5-1.12.1-h51c971a_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.19.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.27.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/joblib-1.4.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kealib-1.5.0-hde4a422_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libabseil-20240116.2-cxx17_h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.9.1-h0416ee5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libgdal-3.6.2-h0e70117_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libglib-2.78.4-ha17d25a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libgrpc-1.62.2-hf25190f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libkml-1.3.0-h63940dd_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libnetcdf-4.8.1-h6685c40_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.17-h906ac69_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-4.25.3-hf2fb9eb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libspatialindex-1.9.3-h6c2663c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libspatialite-5.1.0-h25d3e1c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.11.0-h291bd65_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.13.1-h24da03e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libzip-1.8.0-h289538f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.43.0-py311hf2fb9eb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.3.2-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mapclassify-2.5.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.9.2-py311h472561b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/minizip-4.0.3-hb68bac4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.10-py311h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.7-py311hea22821_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py311h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/netcdf4-1.6.2-py311hec71f40_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.60.0-py311hea22821_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.15-h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/orc-2.0.1-hd8d391b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.2-py311hea22821_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pcre2-10.42-h0ff8eda_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.4.0-py311h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pixman-0.40.0-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pooch-1.7.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/poppler-22.12.0-h0bf3bde_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/poppler-data-0.4.11-haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/proj-9.3.1-ha107b6e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-16.1.0-py311hea22821_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.1.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyproj-3.6.1-py311ha997c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyshp-2.3.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/qhull-2020.2-h59b6b97_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rtree-1.0.1-py311h2eaa2aa_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scikit-learn-1.5.1-py311hea22821_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.13.1-py311h9f229c6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-75.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/shapely-2.0.5-py311h82fc408_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/threadpoolctl-3.5.0-py311h746a85d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tiledb-2.3.3-hd8964de_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.1-py311h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.5-py311h746a85d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uriparser-0.9.7-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.40-h2eaa2aa_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.40.33807-h98bb1dd_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.44.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xerces-c-3.2.4-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/arrow-cpp-16.1.0-h7cd61ee_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-sdk-cpp-1.10.55-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-3.4.1-py311h746a85d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/branca-0.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2024.7.2-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cairo-1.16.0-haedb8bc_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cartopy-0.22.0-py311h786e728_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2024.8.30-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.17.1-py311h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cftime-1.6.2-py311h5bb9823_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cloudpickle-3.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cytoolz-0.12.2-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/dask-2024.8.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/dask-core-2024.8.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/dask-expr-1.1.13-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/datashader-0.16.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/distributed-2024.8.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/expat-2.6.3-h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fiona-1.9.5-py311hf62ec03_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/folium-0.14.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fontconfig-2.14.1-hb33846d_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freexl-2.0.0-hd7a5696_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fsspec-2024.6.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/gdal-3.6.2-py311h4e7b5b2_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/geopandas-0.14.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/geopandas-base-0.14.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/geos-3.8.0-h33f27b4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/geotiff-1.7.0-h4545760_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/geoviews-1.12.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/geoviews-core-1.12.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/glib-2.78.4-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/glib-tools-2.78.4-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/hdf4-4.2.13-h712560f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/hdf5-1.12.1-h51c971a_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.19.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.27.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.19.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/joblib-1.4.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kealib-1.5.0-hde4a422_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libabseil-20240116.2-cxx17_h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libcurl-8.9.1-h0416ee5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libgdal-3.6.2-h0e70117_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libglib-2.78.4-ha17d25a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libgrpc-1.62.2-hf25190f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libkml-1.3.0-h63940dd_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libnetcdf-4.8.1-h6685c40_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpq-12.17-h906ac69_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libprotobuf-4.25.3-hf2fb9eb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libspatialindex-1.9.3-h6c2663c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libspatialite-5.1.0-h25d3e1c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libssh2-1.11.0-h291bd65_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxml2-2.13.1-h24da03e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libzip-1.8.0-h289538f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/llvmlite-0.43.0-py311hf2fb9eb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-4.3.2-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mapclassify-2.5.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.9.2-py311h472561b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/minizip-4.0.3-hb68bac4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.10-py311h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.7-py311hea22821_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/msgpack-python-1.0.3-py311h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/netcdf4-1.6.2-py311hec71f40_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/networkx-3.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numba-0.60.0-py311hea22821_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.15-h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/orc-2.0.1-hd8d391b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-24.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-2.2.2-py311hea22821_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-1.4.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-2.1.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pcre2-10.42-h0ff8eda_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.4.0-py311h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-24.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pixman-0.40.0-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pooch-1.7.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/poppler-22.12.0-h0bf3bde_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/poppler-data-0.4.11-haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/proj-9.3.1-ha107b6e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyarrow-16.1.0-py311hea22821_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.1.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyproj-3.6.1-py311ha997c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyshp-2.3.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-lmdb-1.4.1-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/qhull-2020.2-h59b6b97_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.32.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rtree-1.0.1-py311h2eaa2aa_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scikit-learn-1.5.1-py311hea22821_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scipy-1.13.1-py311h9f229c6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-75.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/shapely-2.0.5-py311h82fc408_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/threadpoolctl-3.5.0-py311h746a85d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tiledb-2.3.3-hd8964de_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.4.1-py311h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.66.5-py311h746a85d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uriparser-0.9.7-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-2.2.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.40-h2eaa2aa_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.40.33807-h98bb1dd_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.44.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xerces-c-3.2.4-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zict-3.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
   sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
   md5: 613805add1c05b538ff06d217252feb7
   depends:
@@ -1149,7 +1149,7 @@ packages:
   license: BSD-3-Clause
   size: 20810
   timestamp: 1652859733309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
   sha256: 250f50edf43a786a32942e9ae67ce807e9b3ac4cb6b58b1170cb541fb24e391f
   md5: b48058294499d292ddf9a3b966dc9cc5
   depends:
@@ -1163,7 +1163,7 @@ packages:
   license_family: MIT
   size: 228473
   timestamp: 1706220559474
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
   sha256: 0d4f5274503916e1c683dcc16e8a7c4186557afa3f62399cd628e4eb535fe77a
   md5: 062acdb0f9ae976c25c2d15d589dc1d6
   depends:
@@ -1174,7 +1174,7 @@ packages:
   license_family: MIT
   size: 35809
   timestamp: 1676823571351
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-16.1.0-hc1eb8f0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/arrow-cpp-16.1.0-hc1eb8f0_0.tar.bz2
   sha256: 5d681d5cff12cd7e2e70cfcf9d80b5ea545dba909700fc84614738a3d2c964ce
   md5: 3e952919ba8be71d29e9c547b3f8d4ed
   depends:
@@ -1205,7 +1205,7 @@ packages:
   license_family: Apache
   size: 13867665
   timestamp: 1721659616065
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
   sha256: 567dfdd5b986012421a736a5f1c1d5874d8d691dd483c838b55e1ab06c0b217d
   md5: 4e0aa1543f546b898523382ee8405e84
   depends:
@@ -1214,7 +1214,7 @@ packages:
   license_family: MIT
   size: 152577
   timestamp: 1695717917074
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
   sha256: 432e4fb45ae24789afdaeca800862aad03f8ebed5af908f01eed2a09283915e5
   md5: a88c0e111e1f47ee83f1b6f329a149ef
   depends:
@@ -1228,7 +1228,7 @@ packages:
   license_family: Apache
   size: 97643
   timestamp: 1706746168671
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
   sha256: edb54d1554aefb65ff5a3969085dd8695e1e3218a2987ac30a96901f0bbf887a
   md5: 5f131e63f8d80f2b7ac505054204a9e3
   depends:
@@ -1239,7 +1239,7 @@ packages:
   license_family: Apache
   size: 44722
   timestamp: 1706690912333
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
   sha256: 2afbfb546992e5954748d039ea15405f99018f6de78ec2f32bc7ff9bfc428a9c
   md5: 489017af35cf8bdb976e6fef020a4ac7
   depends:
@@ -1248,7 +1248,7 @@ packages:
   license_family: Apache
   size: 202658
   timestamp: 1706189913451
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
   sha256: 5f81f5a3ea27bd29bf32a6987290de8c7b2da6612676aa8e606a7003519cbf47
   md5: c11e7ceff3ca45bf580d1c944d93bd1f
   depends:
@@ -1258,7 +1258,7 @@ packages:
   license_family: Apache
   size: 17839
   timestamp: 1706690843204
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
   sha256: 348ced323311d36344a0fa9e88d299b361bad1f628dfbdd34bcea8662b3ab44b
   md5: 19a11cdc9727c5981d96983a29b93ce4
   depends:
@@ -1271,7 +1271,7 @@ packages:
   license_family: Apache
   size: 52025
   timestamp: 1706697274091
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
   sha256: 14e2843a218cb01bfc499a22537eb345f6e222b8496cfda2050c73ad98f09cda
   md5: 44cba75d1bb5122aeadcaf8bb7da5e2a
   depends:
@@ -1284,7 +1284,7 @@ packages:
   license_family: Apache
   size: 192985
   timestamp: 1706744140260
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
   sha256: a0f6916d60c0e1bac6ba548bf05a491b8db048a94e13da2f1cfa51b4ca879fb8
   md5: 1f010db4f5ef1b3d705ee04dd1d473c9
   depends:
@@ -1296,7 +1296,7 @@ packages:
   license_family: Apache
   size: 143623
   timestamp: 1706696185335
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
   sha256: 596945a39d772056e57bb357202a17e02508f2594da9c00e00ad767b8213e998
   md5: 98cccbcc56a28ec7339e393816f4bdf7
   depends:
@@ -1308,7 +1308,7 @@ packages:
   license_family: Apache
   size: 70139
   timestamp: 1706746744249
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
   sha256: 12bf86ab848e3311f4eed4e93734a84064dc84580ad6dd4bb823b4ab6ef09698
   md5: 4a8c2dcf0ede655609a9fc5632a5227b
   depends:
@@ -1324,7 +1324,7 @@ packages:
   license_family: Apache
   size: 74700
   timestamp: 1706747582638
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
   sha256: f05ce64fee77518a6deb45f187fcee415328e90ea8f2bf6031bd5b8273a1028f
   md5: b8ebb4b892d9b80d513b4ca62a8d6de2
   depends:
@@ -1334,7 +1334,7 @@ packages:
   license_family: Apache
   size: 53042
   timestamp: 1706690818718
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
   sha256: 52bb367fc367ee3923353927226299a2b8b1be6a1993c11e19b20cafe6c6db0f
   md5: 4715508fd5f8b39e902cb2afebc13c93
   depends:
@@ -1344,7 +1344,7 @@ packages:
   license_family: Apache
   size: 52138
   timestamp: 1706192048702
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
   sha256: 0d13fbdace8ab4fbfcc015cf83bead69560a3dfadc6e0ce8441001629d725834
   md5: a02c72bff71848705e70cd6f075a28f3
   depends:
@@ -1363,7 +1363,7 @@ packages:
   license_family: Apache
   size: 211559
   timestamp: 1706827608038
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.10.55-h721c034_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-sdk-cpp-1.10.55-h721c034_0.tar.bz2
   sha256: a489d946a0a70a4d31f5da9fdf38e2c0ba8122e1df4fc716961b5b02d7617dbe
   md5: f29f551a4e61c4d8339710ba000c6da8
   depends:
@@ -1379,7 +1379,7 @@ packages:
   license_family: Apache
   size: 2815192
   timestamp: 1706890558504
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
   sha256: 5bb9bfe025d9a49af272f194278f63cea7366e83bdf3f99d25f97b820d522089
   md5: 100d3161d97332fe38945afec8d36935
   depends:
@@ -1389,12 +1389,12 @@ packages:
   license_family: MIT
   size: 276381
   timestamp: 1718029864701
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blosc-1.21.3-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blosc-1.21.3-h6a678d5_0.tar.bz2
   sha256: 10b48986cb0e0c974477ac3a58aaae198270b01f19cbd3e900143c6558fa3424
   md5: 202b4629c225257fc01a4a2180c4e2f7
   depends:
@@ -1407,7 +1407,7 @@ packages:
   license_family: BSD
   size: 65491
   timestamp: 1675247642609
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.1-py311h92b7b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-3.4.1-py311h92b7b1e_0.tar.bz2
   sha256: 34d2dcc4885a03631c340e88ecb1002ac60c1f9573f34252e3ad8b87096c0040
   md5: 9b33d05f7b278ad9a9a3442da9d41f11
   depends:
@@ -1425,7 +1425,7 @@ packages:
   license_family: BSD
   size: 6054528
   timestamp: 1718119253989
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
   sha256: 3606c8607c29229222667f66421f79df167d33043fe9245cdd4e2c4520ecc721
   md5: eca33dcef14fa044193e43492dca8585
   depends:
@@ -1436,7 +1436,7 @@ packages:
   license_family: OTHER
   size: 10768
   timestamp: 1696762269985
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
   sha256: 8e2b2073ff5c61d35714e8a36ce657a8ac741b7bedc2852a238c7f1625142705
   md5: d951ab54a682b6328327fec53b1e5e72
   depends:
@@ -1447,7 +1447,7 @@ packages:
   license_family: BSD
   size: 147642
   timestamp: 1707864274452
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/branca-0.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/branca-0.6.0-py311h06a4308_0.tar.bz2
   sha256: 68972850391765ea3d78e6dfa5a9250ca3802581f4ac93d6e060c9c4d09087e9
   md5: 8c9ea30811092c3176d88cbd8a3a2583
   depends:
@@ -1457,7 +1457,7 @@ packages:
   license_family: MIT
   size: 53547
   timestamp: 1676843457111
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
   sha256: 5d15605858771290fdaaae41a43941623757a25cb1292080d69d6d3857807935
   md5: 7f517469aa5380c52e55db9f37df104f
   depends:
@@ -1468,7 +1468,7 @@ packages:
   license: MIT
   size: 18652
   timestamp: 1714483267080
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
   sha256: a5094f078584e27c7cced4a9564ae904a329f5c1702a7c1ba092d581ba1544f1
   md5: 6ddf45dd8a21a9512481de9bc0e5a03f
   depends:
@@ -1478,7 +1478,7 @@ packages:
   license: MIT
   size: 19711
   timestamp: 1714483255915
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
   sha256: 93180c973816246f068b742d0bf64840f0ea48e31d4f9b0747ea2ffc34d8855d
   md5: f3a00096965a5ba1eb41d2c99a4662a2
   depends:
@@ -1488,7 +1488,7 @@ packages:
   license: MIT
   size: 361574
   timestamp: 1714483400014
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
   sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
   md5: f5058c8d5b2994b7334f18e022105a14
   depends:
@@ -1497,7 +1497,7 @@ packages:
   license_family: BSD
   size: 427542
   timestamp: 1714510571510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
   sha256: 5b4c80587ae4ec915505469f79d866f27c80456156667c8548d31c67c2c1653e
   md5: c3d6bfae757760082261779c406a880d
   depends:
@@ -1506,14 +1506,14 @@ packages:
   license_family: MIT
   size: 116270
   timestamp: 1693902021950
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.7.2-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2024.7.2-h06a4308_0.tar.bz2
   sha256: a2a50043dce163f30830357ecc6bb6971a2bf0b5d9630eea915a76c983908109
   md5: aa5a2ac6c4251cef085589caa114348f
   license: MPL-2.0
   license_family: Other
   size: 136398
   timestamp: 1720622030294
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cairo-1.16.0-hb05425b_5.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cairo-1.16.0-hb05425b_5.tar.bz2
   sha256: c2bd44f53bdd95e6c638f604884af9080323ed7fa72e5e3968d79d0c381fc40b
   md5: d80d0342ce4d61f119ceecfb678c205e
   depends:
@@ -1529,7 +1529,7 @@ packages:
   license_family: LGPL
   size: 1571007
   timestamp: 1688495896158
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cartopy-0.22.0-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cartopy-0.22.0-py311ha02d727_0.tar.bz2
   sha256: 389e2d88a8c60762bace0c200af8ac5cbef22c53906dcb4c36a5869bd6e7783c
   md5: 01a63e18f09bb9f7eb25dd6d5bd47b28
   depends:
@@ -1550,7 +1550,7 @@ packages:
   license_family: LGPL
   size: 2094915
   timestamp: 1706196282018
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.8.30-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2024.8.30-py311h06a4308_0.tar.bz2
   sha256: 6c769a7cae15ec611e2a3cc9ccfe646b6027f60c2822811b3f60f589a8c51d8f
   md5: 6ffd4b4a690cad0ee056e659db868f56
   depends:
@@ -1559,7 +1559,7 @@ packages:
   license_family: Other
   size: 169012
   timestamp: 1725551779652
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
   sha256: d138cc3fde270eba783baf1e2ba17c89800b2cbbf20976d0eb425b3436a4a184
   md5: 1875e89c1a939e4e7c5e7b731c72b838
   depends:
@@ -1571,7 +1571,7 @@ packages:
   license_family: MIT
   size: 302401
   timestamp: 1714483186060
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cfitsio-3.470-h5893167_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cfitsio-3.470-h5893167_7.tar.bz2
   sha256: a4a855659e4a52515b940d1b9d8204b626c11395980e99539b24f52d658e1857
   md5: 65a71d60ece0bd684f1be09b48de8d00
   depends:
@@ -1585,7 +1585,7 @@ packages:
   license_family: Other
   size: 1384722
   timestamp: 1655814890848
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cftime-1.6.2-py311hbed6279_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cftime-1.6.2-py311hbed6279_0.tar.bz2
   sha256: c9ef620859a8501e4d098dd1454fd521395acc668ceb98a47cdf886132fbebc0
   md5: a88a08c5a9bb08c528fd25e84eb8055b
   depends:
@@ -1596,7 +1596,7 @@ packages:
   license_family: MIT
   size: 252968
   timestamp: 1679335541002
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
   sha256: 9ddbf05887c7d7926418520cc7848e57f6d2431bc4ec6d30e090b02dbf865041
   md5: 57ae1141ad9a048fb2a75d7a3ef7430a
   depends:
@@ -1605,7 +1605,7 @@ packages:
   license_family: BSD
   size: 203190
   timestamp: 1698129926216
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cloudpickle-3.0.0-py311h06a4308_0.tar.bz2
   sha256: 017b35122f533e4ffc48bb3e0c6fd1f16e8cbb2a67d40b3f6572b77511ffe26d
   md5: 75eb58b2cdb0ddf4e93293cf973a0829
   depends:
@@ -1614,7 +1614,7 @@ packages:
   license_family: BSD
   size: 41983
   timestamp: 1721657369906
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
   sha256: d9c102b9ec7f3a635936b6f73d4db126d748a25f65407353bd76b260dc7d1cd6
   md5: eec48dbdf5dac0ea26750cc26b58c1d9
   depends:
@@ -1623,7 +1623,7 @@ packages:
   license_family: CC
   size: 554986
   timestamp: 1709758392744
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
   sha256: 882481e441b9b93cbdfb32fbe32a6ad9f26197472f186a08fddb921f61346c02
   md5: 443c79196064f57c98199e9990544b2f
   depends:
@@ -1633,7 +1633,7 @@ packages:
   license_family: BSD
   size: 16902
   timestamp: 1709322958614
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
   sha256: e4877b41553e31b9f9f090dffab77a654255c63776e8b30fc91ec1f60afadbf1
   md5: c34d3f1520f1e8c9957eb236710058c4
   depends:
@@ -1645,7 +1645,7 @@ packages:
   license_family: BSD
   size: 281162
   timestamp: 1700583651472
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.2-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cytoolz-0.12.2-py311h5eee18b_0.tar.bz2
   sha256: 01fa6e276a4e41ef2396c40c0993a54c2fa3f511b33424191e5af11936edba12
   md5: d83fe12f3bf13f5171a19af502e6f4cf
   depends:
@@ -1656,7 +1656,7 @@ packages:
   license_family: BSD
   size: 444424
   timestamp: 1701723706605
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-2024.8.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dask-2024.8.2-py311h06a4308_0.tar.bz2
   sha256: 8e6a08353c165d56c1f7b0b34fd5fc8c3f6dbbcaa23b84ac1464fed4e228ed78
   md5: 53f5a1198efff2c28205dc615a2ce7f9
   depends:
@@ -1675,7 +1675,7 @@ packages:
   license_family: BSD
   size: 5341
   timestamp: 1725525101958
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.8.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dask-core-2024.8.2-py311h06a4308_0.tar.bz2
   sha256: eeb6264edb355734090537f71628c795493e5848867c05fb5fd624b9c0899c64
   md5: f2d72f1b4ba65ae83f861b1c1245a22c
   depends:
@@ -1692,7 +1692,7 @@ packages:
   license_family: BSD
   size: 3116663
   timestamp: 1725461379792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-expr-1.1.13-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dask-expr-1.1.13-py311h06a4308_0.tar.bz2
   sha256: 2382306aaa5ccaa12416c585d7b5134b3851b6374fc4f9d0cccab8aefce6a678
   md5: 22a0cfe6eb25d725e60defcd4956f9e1
   depends:
@@ -1704,7 +1704,7 @@ packages:
   license_family: BSD
   size: 559943
   timestamp: 1725523090728
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.16.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/datashader-0.16.3-py311h06a4308_0.tar.bz2
   sha256: 0333d880caa9352ba4d49ecbd3c6282a362e574374c34c07e60f7dc3168a4e39
   md5: 6bfb802c6e2297eca13453c609826efc
   depends:
@@ -1727,7 +1727,7 @@ packages:
   license_family: BSD
   size: 18020969
   timestamp: 1720534125523
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
   sha256: 3b4cd8dc60572086f1a1cbb97e2712e0ffd55317ce8f0309d552eee7367855eb
   md5: 70a1263b6e19bf2d77c020a2e77277c9
   depends:
@@ -1738,7 +1738,7 @@ packages:
   license_family: MIT
   size: 2556575
   timestamp: 1690905285843
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2024.8.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/distributed-2024.8.2-py311h06a4308_0.tar.bz2
   sha256: 6ee436c7fc7627b9ef3b64e146903ede1248566b124ef90835b3c8b9b8126de7
   md5: be3a5a477ea79581ed8d2c004592d46e
   depends:
@@ -1762,7 +1762,7 @@ packages:
   license_family: BSD
   size: 1809092
   timestamp: 1725523030863
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
   sha256: 4b589e3265c74159130230c164ff2d8d381be65899a249def0b53f93ce83fd47
   md5: 245cb7173dcdba21cf368031cd87f706
   depends:
@@ -1771,7 +1771,7 @@ packages:
   license_family: MIT
   size: 17434
   timestamp: 1676823330845
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.6.3-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/expat-2.6.3-h6a678d5_0.tar.bz2
   sha256: 4239a7e8973dadc127940fb25e63a07a7ec9627c39687ae4742ce561e4fd0d63
   md5: 2a9b1536c3f7f922a2b63fa2981e447a
   depends:
@@ -1781,7 +1781,7 @@ packages:
   license_family: MIT
   size: 200780
   timestamp: 1725543341127
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fiona-1.9.5-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fiona-1.9.5-py311ha02d727_0.tar.bz2
   sha256: bb0b24e6e5683b67ac67afed3cc3b038614b6b262896c3c572504036f643867e
   md5: 9872767319bde0ac940064e25bea90b6
   depends:
@@ -1805,7 +1805,7 @@ packages:
   license_family: BSD
   size: 1261206
   timestamp: 1704921153226
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/folium-0.14.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/folium-0.14.0-py311h06a4308_0.tar.bz2
   sha256: a1ba73410e26bed5ac999e4d8187a51525d93170b9b0bb569980e266d6c9f3a0
   md5: 11e63939b47a8f2f52311f739e40c2bb
   depends:
@@ -1818,7 +1818,7 @@ packages:
   license_family: MIT
   size: 135137
   timestamp: 1676852488567
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.14.1-h55d465d_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fontconfig-2.14.1-h55d465d_3.tar.bz2
   sha256: dcb04f684a0182e8161eb607488cef61ad121b72eda8794b1072aad621663016
   md5: 7fbedeb920dc384a9873983a4abf62a7
   depends:
@@ -1832,7 +1832,7 @@ packages:
   license_family: MIT
   size: 343714
   timestamp: 1722921016734
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
   sha256: b75d12e85274660bb675a3e53d47a929872f2daa2ff5a76e98885ee3f2d19ad1
   md5: f2119d0885334060d0d7fe59e5220287
   depends:
@@ -1851,7 +1851,7 @@ packages:
   license_family: MIT
   size: 3237908
   timestamp: 1713551660998
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
   sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
   md5: a5dc8677d891dff2393b63189a3ad42f
   depends:
@@ -1862,7 +1862,7 @@ packages:
   license_family: Other
   size: 971975
   timestamp: 1666798278693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freexl-2.0.0-hf309648_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freexl-2.0.0-hf309648_0.tar.bz2
   sha256: 491a87a5812c0541edeb8ad7b373b60f812e6721039871c8f01181365064453e
   md5: 66fba742a11cdbb9293ea2ec9064182a
   depends:
@@ -1874,7 +1874,7 @@ packages:
   license_family: OTHER
   size: 68357
   timestamp: 1704742026807
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.6.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fsspec-2024.6.1-py311h06a4308_0.tar.bz2
   sha256: eb7d7646fbda149ab0291100cb5d5d964b93b04aae9423eddf7d9fae1e45f0ef
   md5: cde515ecf78e4d4b9f6c2290eb00a952
   depends:
@@ -1885,7 +1885,7 @@ packages:
   license_family: BSD
   size: 382658
   timestamp: 1724855656158
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gdal-3.6.2-py311ha0db937_5.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/gdal-3.6.2-py311ha0db937_5.tar.bz2
   sha256: f2479b9cb4e3b11eccdf71fec824cf89e2c96ccd603955e6e669d7c9f80c4b25
   md5: d14a13b87165ddd4d9c661a020d8cc6c
   depends:
@@ -1899,7 +1899,7 @@ packages:
   license_family: MIT
   size: 2129775
   timestamp: 1722934260007
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/geopandas-0.14.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/geopandas-0.14.2-py311h06a4308_0.tar.bz2
   sha256: 488c5e092687d69e02f6f2419bdfbe0dc0a0567bc31c08263bc1ef0e45aa16cf
   md5: b8d18f774b3d15aedf425c270eed1866
   depends:
@@ -1914,7 +1914,7 @@ packages:
   license_family: BSD
   size: 6670
   timestamp: 1704929096836
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/geopandas-base-0.14.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/geopandas-base-0.14.2-py311h06a4308_0.tar.bz2
   sha256: 02f06748d52e7ceaf6c51c5284cb9c655ba424c582f795b182d4b59efc53012d
   md5: 57a3a71a74a9d47e67b3b10759cc359a
   depends:
@@ -1928,7 +1928,7 @@ packages:
   license_family: BSD
   size: 1520212
   timestamp: 1704929055070
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/geos-3.8.0-he6710b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/geos-3.8.0-he6710b0_0.tar.bz2
   sha256: 6d791f835f915ad4f34171399b7d3141e548446dcce384f7d11f28a04c002bb7
   md5: 7f115aea55f4cffe8c6c937240697f06
   depends:
@@ -1937,7 +1937,7 @@ packages:
   license: LGPL-2.1
   size: 1078422
   timestamp: 1573215838521
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/geotiff-1.7.0-h2a26cda_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/geotiff-1.7.0-h2a26cda_3.tar.bz2
   sha256: 8f95d6317f1f5ff58c20916eb940df5651f4bb1aa9c9c9047c4a5bee85530469
   md5: 139f94650b50874dd00901442926141f
   depends:
@@ -1951,7 +1951,7 @@ packages:
   license_family: MIT
   size: 303738
   timestamp: 1704901294937
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/geoviews-1.12.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/geoviews-1.12.0-py311h06a4308_0.tar.bz2
   sha256: 08b1a0678ecfdb2cf0a147ee5cb8b8197901afe9729ee83be9b9fafe1c52178d
   md5: 7cbe0e9318db0f8dc7b30d23e3663b17
   depends:
@@ -1969,7 +1969,7 @@ packages:
   license_family: BSD
   size: 5757
   timestamp: 1713972423984
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/geoviews-core-1.12.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/geoviews-core-1.12.0-py311h06a4308_0.tar.bz2
   sha256: 3cc4030dab44dbf7539c70bd29741a44039696c7393f429af9d410caa45403e5
   md5: d215cfecad1dae06365de992c22ca460
   depends:
@@ -1990,7 +1990,7 @@ packages:
   license_family: BSD
   size: 607708
   timestamp: 1713972417175
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
   sha256: 2fc1136056f41fe92de719fb821550346704965dd12a5fa35069cdb4948d5c17
   md5: fd089b0fba2b03aafe3adb6cdaa9ac3b
   depends:
@@ -2000,7 +2000,7 @@ packages:
   license_family: BSD
   size: 203421
   timestamp: 1706888218007
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
   sha256: c323a9800a358c178f6f3b8860bbb77c373fbc3be981bb6420175fbb5431adf5
   md5: 6485f51176cf651b3b28c3548cef10ad
   depends:
@@ -2009,7 +2009,7 @@ packages:
   license_family: MIT
   size: 78533
   timestamp: 1676983203797
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.78.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/glib-2.78.4-h6a678d5_0.tar.bz2
   sha256: d9a486f0ac92b1365365c3e536040a552c2de633283f27129f16dadcbc6d2de8
   md5: 32538e0c24874a85011a094217830bd4
   depends:
@@ -2022,7 +2022,7 @@ packages:
   license_family: LGPL
   size: 499006
   timestamp: 1708031707428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-tools-2.78.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/glib-tools-2.78.4-h6a678d5_0.tar.bz2
   sha256: cc7d3a52acad1df08e3d4ec7eefb22f41320e7eada94e78bf4b051128cbe72d4
   md5: d8dcbf2be12799cf7f333c21a0e91990
   depends:
@@ -2033,7 +2033,7 @@ packages:
   license_family: LGPL
   size: 112595
   timestamp: 1708031685927
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
   sha256: f1e190d4ee766add8131a2b011723c472284de2bbb5e07c8f895f30e3c591df7
   md5: 82029e0758feac811afec2a6ef9e6155
   depends:
@@ -2044,7 +2044,7 @@ packages:
   license_family: BSD
   size: 108438
   timestamp: 1706895276199
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf4-4.2.13-h3ca952b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/hdf4-4.2.13-h3ca952b_2.tar.bz2
   sha256: 70e1f9fdc6b123d8270bcd8cdd555519372924d39419ef8692b36bfa9d0b4653
   md5: 35da658876a3e2a62dda54dcd5a7e5c2
   depends:
@@ -2056,7 +2056,7 @@ packages:
   license_family: BSD
   size: 937548
   timestamp: 1510862959026
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf5-1.12.1-h2b7332f_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/hdf5-1.12.1-h2b7332f_3.tar.bz2
   sha256: 73266852d7a5b419020aff69fc1d21dc5447692d7cecc1e863f58a80712c308c
   md5: e1cd70ce23bf9015a98db5b8d3771bad
   depends:
@@ -2072,7 +2072,7 @@ packages:
   license_family: BSD
   size: 5778986
   timestamp: 1686164924867
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.19.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.19.1-py311h06a4308_0.tar.bz2
   sha256: ac845d3797a0b6cd8db67a966c7d7df23e5a8419387c6d01eaf40cf6f3c0e5bf
   md5: 43ba3fab33c79788ebe98a58aa60a92f
   depends:
@@ -2092,7 +2092,7 @@ packages:
   license_family: BSD
   size: 6109096
   timestamp: 1720533991629
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
   sha256: a0ae6c5a6b615d73d9a243331f3f7d749b4feafdf2f334337fda8abd6c8355ed
   md5: e61d8dcd4dfd6d165e6e480cee846bf5
   depends:
@@ -2109,7 +2109,7 @@ packages:
   license_family: BSD
   size: 357992
   timestamp: 1715090462763
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
   sha256: b35b281dbf69b826c6ae04fcd7b6a2d1f098277a669a199906a1f23b4b0931a5
   md5: 2a793fe24f85aa5819fe69c450cba6f7
   depends:
@@ -2119,7 +2119,7 @@ packages:
   license_family: MIT
   size: 29021241
   timestamp: 1692293243228
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
   sha256: e08e27531775de40f46b6ac7bf71856963baa0c008bd2b4d112e6341cd3e8f4c
   md5: bfc7682613c861cbcb4ac01485c05657
   depends:
@@ -2128,7 +2128,7 @@ packages:
   license_family: BSD
   size: 147174
   timestamp: 1714398938840
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
   sha256: c7ffa6006573483a05ef355770c3201f04dd04ab4b91ae01971a6cdc7fbdba35
   md5: 23d7d38e93d930ea5e2cc5f4079d3816
   depends:
@@ -2138,7 +2138,7 @@ packages:
   license_family: APACHE
   size: 49872
   timestamp: 1704813633807
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
   sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
   md5: 3add2ce56858a1b8f6a37342f82773d3
   depends:
@@ -2154,7 +2154,7 @@ packages:
   license_family: Proprietary
   size: 19310769
   timestamp: 1699647799237
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
   sha256: 0b670ab17ed2e1b592079bd64386dadc249ddc892e5ae1dd99f142a918ffc75d
   md5: 632575b9e442c1e5c146cf78424da610
   depends:
@@ -2175,7 +2175,7 @@ packages:
   license_family: BSD
   size: 227791
   timestamp: 1705934138566
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.27.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.27.0-py311h06a4308_0.tar.bz2
   sha256: 466a9ff4b27043bc48c6e619fe458a4d6390d7db1cc3096d971b6a6166212ee9
   md5: e58614cdf643d299d1faf06bd2b92327
   depends:
@@ -2193,7 +2193,7 @@ packages:
   license_family: BSD
   size: 1633729
   timestamp: 1726064436441
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.19.1-py311h06a4308_0.tar.bz2
   sha256: 527d00eacde56f9f8c391dacfca0f55c5c750c45c6400d6220b49e3ee36e5636
   md5: a4b061aee54081589532e93572722769
   depends:
@@ -2203,7 +2203,7 @@ packages:
   license_family: MIT
   size: 1175236
   timestamp: 1721058517965
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.4-py311h06a4308_0.tar.bz2
   sha256: f8c1f9c49e58fd9adfefbe99d055a8045643b620902c4758a07d689b21418900
   md5: 77918475e3a5511cd5a0f595a751b881
   depends:
@@ -2215,7 +2215,7 @@ packages:
   license_family: BSD
   size: 354911
   timestamp: 1716993527421
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/joblib-1.4.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/joblib-1.4.2-py311h06a4308_0.tar.bz2
   sha256: 8a7e666bf678937a4133e148bfb7d5624934696140076cc3ce3a7477348e751e
   md5: 9fd2cf2c75e332b1a30806e9e47e6ba3
   depends:
@@ -2224,7 +2224,7 @@ packages:
   license_family: BSD
   size: 542339
   timestamp: 1718217284906
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
   sha256: 8316ae3abee25edab89788ee6e9eef79c398aba192559f514674a04ee1860bca
   md5: 112209aed451545a622ab217c70f6972
   depends:
@@ -2233,7 +2233,7 @@ packages:
   license_family: Other
   size: 283506
   timestamp: 1722872662693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/json-c-0.16-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/json-c-0.16-h5eee18b_0.tar.bz2
   sha256: eaf9ba80be45651a8e3c8598bd3b00e5671cd929359c06d7c9b668a3636ee04c
   md5: 0594055417685a7b7a828c2647fb8fc3
   depends:
@@ -2242,7 +2242,7 @@ packages:
   license_family: MIT
   size: 84251
   timestamp: 1659123696523
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
   sha256: 06b729aee6dd2a1e545f3ad64179cc0d4ef8a15e33db3be2995dd3e0868465ca
   md5: 8bb3215912588e47e2eeb4e7a09ad64f
   depends:
@@ -2255,7 +2255,7 @@ packages:
   license_family: MIT
   size: 180858
   timestamp: 1699041715847
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
   sha256: 9e3bac2d41bd432b721b009e7de981766fba396e6f238e923f304112bd88655a
   md5: 84ae4cf3f2d01fbebdac374971192be9
   depends:
@@ -2265,7 +2265,7 @@ packages:
   license_family: MIT
   size: 15525
   timestamp: 1699032521315
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
   sha256: 79ce6dff3d93649a2555b1d2a4ae9eb77175a1c00664cb8eb0e6f848d5cdd1b9
   md5: db395b0efd7018fcf3a4af879170c2a8
   depends:
@@ -2281,7 +2281,7 @@ packages:
   license_family: BSD
   size: 276856
   timestamp: 1676823504812
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
   sha256: 91cca0ba49accdc9e97463bee087244a27ad107eb3af9ccb91634239f8b10f72
   md5: a185824bfc55bd90e1cf9330b417b74c
   depends:
@@ -2292,7 +2292,7 @@ packages:
   license_family: BSD
   size: 97359
   timestamp: 1718818381635
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
   sha256: 540f8dfb7cdc3877b4e24d6af65696d0bc7eae5de1c307229f86b3fe601a2286
   md5: f650f8c007471f6ef6c1a292918d2e1f
   depends:
@@ -2308,7 +2308,7 @@ packages:
   license_family: BSD
   size: 41920
   timestamp: 1718738122846
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
   sha256: 398387b6f1ee1691b04a31fedd1320225e5553aa921b06bc013f010a0008621e
   md5: bac66634a9133c633ddc879e14e83f23
   depends:
@@ -2335,7 +2335,7 @@ packages:
   license_family: BSD
   size: 610854
   timestamp: 1718827113534
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
   sha256: ddfee06ba9b149222c65d1d4270272840533aa63b56fe36363c84a891c71d328
   md5: ee128e5c0d8d9e1952e2387b66a5b8cb
   depends:
@@ -2345,7 +2345,7 @@ packages:
   license_family: BSD
   size: 27239
   timestamp: 1686870958829
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
   sha256: 0c6a074272ed58677ec17e4dbfceaffd2108841a61af92b32f156c5763108d1d
   md5: dd3d37841d0d20c70a60e8c939923894
   depends:
@@ -2357,7 +2357,7 @@ packages:
   license_family: BSD
   size: 19144
   timestamp: 1700168632051
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kealib-1.5.0-hd940352_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kealib-1.5.0-hd940352_1.tar.bz2
   sha256: 16579c84dc5fd0b6ed8e23fbd4c47d8d172a947bb306248e6e98bed6743f38d9
   md5: 579d3d2360ae0d0a467960fec295d5e4
   depends:
@@ -2368,7 +2368,7 @@ packages:
   license_family: MIT
   size: 193532
   timestamp: 1687966960572
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
   sha256: b040f0d0ee4588188ab6b83a93738b3ff6e6d1775424be97995bd0df0f4fb904
   md5: eae62735d710cf5ff6d51e6f59fcd999
   depends:
@@ -2379,7 +2379,7 @@ packages:
   license_family: BSD
   size: 78148
   timestamp: 1676827253282
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
   sha256: 01bae3dd44469e34f043e0416f5f5e658429bf4031745399d9968d10b899e2c4
   md5: 10171cca67e3d73c3646c6dc5a321460
   depends:
@@ -2391,7 +2391,7 @@ packages:
   license_family: MIT
   size: 1427115
   timestamp: 1686931095252
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -2402,7 +2402,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
   sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
   md5: 9508af80612e4fa1b5d1abb43ca7e63c
   constrains:
@@ -2410,7 +2410,7 @@ packages:
   license: GPL-3.0-only
   size: 749072
   timestamp: 1652971360657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
   sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
   md5: 88199c75f2ac211728febced7785c24e
   depends:
@@ -2420,7 +2420,7 @@ packages:
   license_family: Apache
   size: 228278
   timestamp: 1635523146417
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libabseil-20240116.2-cxx17_h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libabseil-20240116.2-cxx17_h6a678d5_0.tar.bz2
   sha256: 799f5e019772d5d774c07dbb8b8d633e0b559921c8ab16ab2276aca1ca4f2fa2
   md5: fe4de116b00c2c7eb7d307a58eef7429
   depends:
@@ -2433,7 +2433,7 @@ packages:
   license_family: Apache
   size: 1316915
   timestamp: 1716563364037
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
   sha256: e2754627e8aeb98777318939e6773b9eadbdc219dd8961aca946354d9d30f481
   md5: 4ed89646229bee3e594cd2cc8f6060f9
   depends:
@@ -2448,7 +2448,7 @@ packages:
   license_family: OTHER
   size: 23778916
   timestamp: 1696762223408
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
   sha256: bb990ea068c3b3dafd9c807e0e19570320cb2fe7d69cc326f1f0b5319b0654b2
   md5: 3ff70744e396b1af69656c574b05c3b9
   depends:
@@ -2456,7 +2456,7 @@ packages:
   license: MIT
   size: 66940
   timestamp: 1714483221853
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
   sha256: 3b87a816f72a00e1f0022a160e7eda70af89d3de2a2e08a72be1c17b31d759f3
   md5: 4f57d3a0a13ddaf1c06efb586b702f46
   depends:
@@ -2465,7 +2465,7 @@ packages:
   license: MIT
   size: 34446
   timestamp: 1714483232430
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
   sha256: 2cf15e89f910600f468edfde8d0f9b80a14fa2319ed89160dc7375dfd3764fdb
   md5: 463adc13f2feea3570d1eccac368d9e4
   depends:
@@ -2474,7 +2474,7 @@ packages:
   license: MIT
   size: 295090
   timestamp: 1714483244460
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.9.1-h251f7ec_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libcurl-8.9.1-h251f7ec_0.tar.bz2
   sha256: 5ed4a1b84f273bd7bcd1302c823f4fbd486567c5d7d1a1e78eff9e7188af2e36
   md5: b1c706c4fa97ec653a40d7670f7b24a3
   depends:
@@ -2490,7 +2490,7 @@ packages:
   license_family: MIT
   size: 426063
   timestamp: 1725033936108
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
   sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
   md5: 55dde57e63a36b202e388a39dcee9a66
   depends:
@@ -2499,7 +2499,7 @@ packages:
   license_family: MIT
   size: 74096
   timestamp: 1695996494461
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
   sha256: 5bd3af246b6a93ea0912179ae66e0ad9157ca0142263010d84b65724e6db0bec
   md5: 5cb0cc0e1783419cf8fc1c65fee0f62f
   depends:
@@ -2509,7 +2509,7 @@ packages:
   license_family: BSD
   size: 195807
   timestamp: 1703006263489
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
   sha256: efdab884c85fda4461f7a393aa6d4e0e50d03cb59fb9c8a980b1307b8379ebe0
   md5: eeca774c6154c49340dd403b1928d5e9
   depends:
@@ -2518,7 +2518,7 @@ packages:
   license_family: BSD
   size: 108906
   timestamp: 1632891483341
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
   sha256: 4b2518a1aa3859031a531cd1077e8a60d5b3a0dc7c83210ef27ff9ce2c78c3e3
   md5: 49f152ee4045544c10799d32bba85c07
   depends:
@@ -2529,7 +2529,7 @@ packages:
   license_family: BSD
   size: 480247
   timestamp: 1685052130829
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
   sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
   md5: 1af9b4d62c708924417f2640ef22a68f
   depends:
@@ -2539,7 +2539,7 @@ packages:
   license_family: MIT
   size: 154016
   timestamp: 1714483282916
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
   sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
   md5: 641e72e5067bd6d5454405879e1cd2a7
   depends:
@@ -2554,7 +2554,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 8895144
   timestamp: 1654090827491
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgdal-3.6.2-hd4d5da2_5.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgdal-3.6.2-hd4d5da2_5.tar.bz2
   sha256: 664d73bc76c16c7beca196c8771ad65efd9cb8e9cb4f4f38d10773de860ea210
   md5: c6d6e277325ab84488480b397c441bc8
   depends:
@@ -2603,7 +2603,7 @@ packages:
   license_family: MIT
   size: 11806172
   timestamp: 1722934042808
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
   sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
   md5: 27082517590f3b9fbffecc68513b461b
   depends:
@@ -2612,7 +2612,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 19860
   timestamp: 1654090819660
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
   sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
   md5: 0202c3c8ae4735cac6c7f3d1e1685964
   constrains:
@@ -2620,7 +2620,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 5228750
   timestamp: 1654090762569
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libglib-2.78.4-hdc74915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libglib-2.78.4-hdc74915_0.tar.bz2
   sha256: ddda848ae8594a9a28b14439b322763e4ffb0ff8d34e492c994e434fe3fbf934
   md5: e35935cc3937ef52b2ef721dddc45738
   depends:
@@ -2636,7 +2636,7 @@ packages:
   license_family: LGPL
   size: 1583413
   timestamp: 1708031663093
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
   sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
   md5: 3080c2813e6e1d0f8a100a38b5b3456d
   depends:
@@ -2644,7 +2644,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 573231
   timestamp: 1654090775721
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgrpc-1.62.2-h2d74bed_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgrpc-1.62.2-h2d74bed_0.tar.bz2
   sha256: 498fafb5df2311ce582cbdfd9262f060a484ad8577030298deed948a3c491cd7
   md5: 3065951fe45c36bb91009a61776f5e9a
   depends:
@@ -2663,7 +2663,7 @@ packages:
   license_family: APACHE
   size: 9018521
   timestamp: 1716835817873
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
   sha256: ed544d8aa7e77fc42c39c276b879955e6615b517c42fecd2624033a5050832eb
   md5: 21ee76e09ab0a7315cbed14933d97773
   depends:
@@ -2672,7 +2672,7 @@ packages:
   license_family: GPL3
   size: 1436714
   timestamp: 1714483320555
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libkml-1.3.0-h096b73e_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libkml-1.3.0-h096b73e_7.tar.bz2
   sha256: 4bb7365724e8b7bd55877fe27d7dcc61e52aad4d37720c4f9df7a74fd4194686
   md5: b15d5383eae8842c69a4ce7690d933dc
   depends:
@@ -2685,7 +2685,7 @@ packages:
   license_family: BSD
   size: 576030
   timestamp: 1693261870612
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hecde1de_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libllvm14-14.0.6-hecde1de_4.tar.bz2
   sha256: c50e6a07e8004849e1cf9f0a164e36a79ac9d14a14fa7d33dc5e370315800489
   md5: 457cfe8b5e65d583e6797a1ba2b5fb4d
   depends:
@@ -2697,7 +2697,7 @@ packages:
   license_family: Apache
   size: 37206574
   timestamp: 1726769447337
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnetcdf-4.8.1-h14805e7_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libnetcdf-4.8.1-h14805e7_4.tar.bz2
   sha256: 4775eeae5aef46f0e44f5d6e3811fc8c87bacef4a7a7cb55c11a7f691f1d61df
   md5: a3c3a438b69f45c2677164480da778ac
   depends:
@@ -2713,7 +2713,7 @@ packages:
   license_family: BSD
   size: 1575671
   timestamp: 1691154789340
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
   sha256: 6c67d781d3c074ae46b18567f230bce4a4afa209e8b914dc2cb448502774886e
   md5: c9627c386bbc8a1a1a0a2e736ea44501
   depends:
@@ -2729,7 +2729,7 @@ packages:
   license_family: MIT
   size: 722387
   timestamp: 1697018420830
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
   sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
   md5: 1bffe1481ed4f88827248fb9001f8923
   depends:
@@ -2739,7 +2739,7 @@ packages:
   license_family: Other
   size: 362561
   timestamp: 1677841789536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpq-12.17-hdbd6064_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpq-12.17-hdbd6064_0.tar.bz2
   sha256: 9fbd40a9bcf75d2f7aab558b3803175d419b1178ec2ece0d77c40a3e47cf0d9f
   md5: ca25d5734b0361f78536d5e77b4b3e43
   depends:
@@ -2748,7 +2748,7 @@ packages:
   - openssl >=3.0.12,<4.0a0
   size: 2973280
   timestamp: 1706214551622
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-4.25.3-he621ea3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libprotobuf-4.25.3-he621ea3_0.tar.bz2
   sha256: c070317f268dfcf77d5ff50c286bf430419fa9267eeea67d622f85c25fc6de9d
   md5: 1672198ffdc6aabb8750c51496719e19
   depends:
@@ -2761,7 +2761,7 @@ packages:
   license_family: BSD
   size: 3242840
   timestamp: 1716568319462
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -2769,7 +2769,7 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libspatialindex-1.9.3-h2531618_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libspatialindex-1.9.3-h2531618_0.tar.bz2
   sha256: b0f60b4c32f917a9c1b1048520cdfb5937ff7a07befa8a71022dfafae6e29ca4
   md5: 8365a8a1dd0aef199a1214831622a4ef
   depends:
@@ -2778,7 +2778,7 @@ packages:
   license: MIT
   size: 3283214
   timestamp: 1616086764247
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libspatialite-5.1.0-h040243e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libspatialite-5.1.0-h040243e_1.tar.bz2
   sha256: 0e6af3c6b946ed1be3137aa1c44d838c6624fd52414a88a9444974fe3bcd1ee2
   md5: d009c5fd5313b3b69bfb12e50f7a22a6
   depends:
@@ -2796,7 +2796,7 @@ packages:
   license_family: OTHER
   size: 4550399
   timestamp: 1722878430832
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.11.0-h251f7ec_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libssh2-1.11.0-h251f7ec_0.tar.bz2
   sha256: 9ffb6bf8ac29a27a2faf800c0d9077f07e983a41c218f87a6013a6e1f95af2ab
   md5: 5b81a682e40f4c00841445d130c90b20
   depends:
@@ -2807,7 +2807,7 @@ packages:
   license_family: BSD
   size: 276424
   timestamp: 1715261489564
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
   sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
   md5: 8c195584a5f5471b600ee180e4052773
   depends:
@@ -2815,7 +2815,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 6410287
   timestamp: 1654090800863
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
   sha256: 974e4035c5d51cd41fa7a7f02fadc1980069c00526c1646fa18ea94e667fb137
   md5: 188de945b4279a812953011e8c4580c2
   depends:
@@ -2829,7 +2829,7 @@ packages:
   license_family: Apache
   size: 4630795
   timestamp: 1687975185557
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
   sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
   md5: ef78eebd98289aceacdfa29182426adf
   depends:
@@ -2847,7 +2847,7 @@ packages:
   license_family: Other
   size: 664034
   timestamp: 1693575237924
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
   sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
   md5: 292768ec77416ae257cfdd44ea2071c8
   depends:
@@ -2856,7 +2856,7 @@ packages:
   license_family: BSD
   size: 29197
   timestamp: 1668082729834
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
   sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
   md5: 9cdeef1d044c7e035c006890f11569d3
   depends:
@@ -2867,14 +2867,14 @@ packages:
   license_family: BSD
   size: 436056
   timestamp: 1694776944891
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
   sha256: 5d68e69709ae10bd6c4b58b6af447ad2f2bd24955994f3ec77103d1a6bf5e1f5
   md5: 49e523de8d364b7fabc3850eccbe9bda
   depends:
   - libgcc-ng >=7.5.0
   size: 623492
   timestamp: 1652448233146
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.13.1-hfdd30dd_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxml2-2.13.1-hfdd30dd_2.tar.bz2
   sha256: 2f04d75b2175c95c328235b42f3669f1bb693be63d46e689bff878f806fa378e
   md5: d424ae0c5ca1279f734a1c52a1740d3d
   depends:
@@ -2886,7 +2886,7 @@ packages:
   license_family: MIT
   size: 738961
   timestamp: 1722441092529
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libzip-1.8.0-h6ac8c49_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libzip-1.8.0-h6ac8c49_1.tar.bz2
   sha256: 6e37085dac10bad7a862609897cda91c3f0d7bdfe1352879ff1b97ea9a389a35
   md5: 7258e512d546498dbb183a1d4da1c938
   depends:
@@ -2901,7 +2901,7 @@ packages:
   license_family: BSD
   size: 104828
   timestamp: 1685378527586
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
   sha256: fd8e30beb8c9442f16e6617fac92dd0c89ec823e98f06e60f712147380ead35f
   md5: 7ed7caf2816c8b85b67b6f4e8833cbd5
   depends:
@@ -2911,7 +2911,7 @@ packages:
   license_family: MIT
   size: 41155
   timestamp: 1676837080881
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.43.0-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.43.0-py311h6a678d5_0.tar.bz2
   sha256: ba4846b57918d712a2c9986a31ac24fc3105f7cb029d1bcd7972b4bcd7a15b1c
   md5: 707e906a126ab3f69499704ab424b18e
   depends:
@@ -2923,7 +2923,7 @@ packages:
   license_family: BSD
   size: 4446734
   timestamp: 1720455383067
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
   sha256: 95fe76d2691feb13203b55ad2aba535bb848cae21ffd05b13ff51c7a45fa2332
   md5: 6a04ec16e3abc1c7e2104be32cd6c418
   depends:
@@ -2932,7 +2932,7 @@ packages:
   license_family: BSD
   size: 13458
   timestamp: 1676827287432
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-4.3.2-py311h5eee18b_0.tar.bz2
   sha256: fc8fa25c9629d8b5362d14ca7c90792064492aef7765a60e3574948f4659b4f2
   md5: ed09cfc6c49987d5af17585f5e5168cb
   depends:
@@ -2943,7 +2943,7 @@ packages:
   license_family: BSD
   size: 40405
   timestamp: 1686058019487
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
   sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
   md5: 76f089e76ec67583bb38428b51008097
   depends:
@@ -2953,7 +2953,7 @@ packages:
   license_family: BSD
   size: 164494
   timestamp: 1714510587156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mapclassify-2.5.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mapclassify-2.5.0-py311h06a4308_0.tar.bz2
   sha256: e4978f900634c42d71203b95c093062d05f068d381915f8173e5bc8e03d70748
   md5: 2d15555f9810fbccd1cf3c8131a97f16
   depends:
@@ -2967,7 +2967,7 @@ packages:
   license_family: BSD
   size: 83254
   timestamp: 1676858588658
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
   sha256: 260e26dd509834c1b225ab7bdb97b9a86e00054fbdd5dfa49e68fa4dcf85a661
   md5: 8f5d7ddc69cc6f7d44c80d2251dea5d1
   depends:
@@ -2976,7 +2976,7 @@ packages:
   license_family: BSD
   size: 162339
   timestamp: 1676837095436
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
   sha256: 7f5b0804d0768619b7bd93b10488067d80bf42ec29f443f00b53ba11758a1241
   md5: 8afb45e45c0d93bfd142e682d4b021ef
   depends:
@@ -2986,7 +2986,7 @@ packages:
   license_family: MIT
   size: 134438
   timestamp: 1684280014220
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
   sha256: cb03570c99c983d7bfda94bc47d8eb00d4059b8548a171130775acc998004195
   md5: 5b1abbbf1e4f9b350b16fc9caf9e889b
   depends:
@@ -2998,7 +2998,7 @@ packages:
   license_family: BSD
   size: 26919
   timestamp: 1704206397615
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.9.2-py311h6fb44e5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.9.2-py311h6fb44e5_0.tar.bz2
   sha256: 3e5f475ba36d974005e6d3c4adbd1ba1874fba9d7db287eb74e7def409a5b478
   md5: be51f267bf90790dcb7e1562ad5e4d42
   depends:
@@ -3019,7 +3019,7 @@ packages:
   license_family: PSF
   size: 9468863
   timestamp: 1725264212197
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
   sha256: 7ac07ea180b5928086075900afbc332fb1d3c81ddfacb54c891693c284056f14
   md5: fc83dd1b3d2ec3c0a297ead0c3405907
   depends:
@@ -3029,7 +3029,7 @@ packages:
   license_family: BSD
   size: 19573
   timestamp: 1676823852670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
   sha256: c9ba2f9c83820712dd97d6a1b54a1215b9820a0be02ac82380b4c50911b9400c
   md5: e5dc6b4a5b8e02733ce3bc9e9198a8d2
   depends:
@@ -3039,7 +3039,7 @@ packages:
   license_family: MIT
   size: 67750
   timestamp: 1676837123613
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
   sha256: 1a5141ef0de1cbff816f96bb4b212a40606e2fc11301a4c1358c8d63a6b2b027
   md5: 22ac3bc22b68fef4c1f3f6ab3c7bfe0b
   depends:
@@ -3048,7 +3048,7 @@ packages:
   license_family: MIT
   size: 23040
   timestamp: 1676827301164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/minizip-4.0.3-hf59b114_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/minizip-4.0.3-hf59b114_0.tar.bz2
   sha256: 7a928b4375e97456db414de29942cd0b46d6337de41c327329a50382ad8db975
   md5: c3de1cacc776d47a60a8ed29cb311a7f
   depends:
@@ -3064,7 +3064,7 @@ packages:
   license_family: Other
   size: 96540
   timestamp: 1702658544366
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
   sha256: 9aacfbbe6f638c58a4e8ff31374d1438d78b7db25d6ea6fd0c50ca2109f225d4
   md5: e602057e3b3d80da88c61d66e8851c5b
   depends:
@@ -3075,7 +3075,7 @@ packages:
   license_family: BSD
   size: 104681
   timestamp: 1676823696152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
   sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
   md5: ce77d0f05f846da4a6b9e23fe7f21d9b
   depends:
@@ -3089,7 +3089,7 @@ packages:
   license_family: Proprietary
   size: 206738176
   timestamp: 1699648006088
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
   sha256: 2aef0876d0df033f7fae8cddbd25d95fc1bfc067e60dd143bd8000fec0768b21
   md5: d6cdc670327bd1675bbea642849f04e1
   depends:
@@ -3100,7 +3100,7 @@ packages:
   license_family: BSD
   size: 59569
   timestamp: 1682948560323
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.10-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.10-py311h5eee18b_0.tar.bz2
   sha256: 4bff1742ab031795ded9173ec2242e4db35dd09918a6cedd701b64240263fdfe
   md5: c989fc726a5c71acfe87d09d135d0ce9
   depends:
@@ -3114,7 +3114,7 @@ packages:
   license_family: BSD
   size: 241044
   timestamp: 1725370379952
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.7-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.7-py311ha02d727_0.tar.bz2
   sha256: c30c46225564d1458bef94185eb97f0be93ed05da15a872d5ecb1a17d9e8f47a
   md5: fcd712e3bc58078ec8524da8f773c6bc
   depends:
@@ -3129,7 +3129,7 @@ packages:
   license_family: BSD
   size: 411983
   timestamp: 1725370348238
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py311hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/msgpack-python-1.0.3-py311hdb19cb5_0.tar.bz2
   sha256: ee4db7daf8d5e41a547e7790dd62aa98e203f4f857cf6018b850e7df8e613a3c
   md5: 17145d1745996667614b52d2b27a1403
   depends:
@@ -3140,7 +3140,7 @@ packages:
   license_family: Apache
   size: 37588
   timestamp: 1676823053826
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
   sha256: b558b3f6c144652b5e0d26497b3ce24c318a6b9ff8ea2079113c95e5553b3cf9
   md5: 0b185969ac2b065c27cbcc9641d93678
   depends:
@@ -3150,7 +3150,7 @@ packages:
   license_family: BSD
   size: 29568
   timestamp: 1676841232463
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
   sha256: 6116c133fbed1e7ea0f5e69f900e93d7977cb715920d10b10642c191d00cc9a6
   md5: b842f7ebdc8b7b6a0dda4c5ebe12805b
   depends:
@@ -3163,7 +3163,7 @@ packages:
   license_family: BSD
   size: 8315206
   timestamp: 1717622768176
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
   sha256: bb45fb0a3973caa74fd8f845e0a519895f6a378807626e15ecf72c02f2eed794
   md5: 185f658ba8a74e326b7231c8fd0d62bf
   depends:
@@ -3176,7 +3176,7 @@ packages:
   license_family: BSD
   size: 121834
   timestamp: 1698934274227
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
   sha256: 8b2fc372a6655fd5b277d07b994ce43643553fbc37e63a60e9fe527a9026ec06
   md5: ed6ac14aed5a796b153d757862398997
   depends:
@@ -3203,7 +3203,7 @@ packages:
   license_family: BSD
   size: 523905
   timestamp: 1699022906468
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
   sha256: 7908ff6c516b15e8fb677be4071145e18adea7d4c13b8485a70a5ee2f573f8cb
   md5: 50c0e38207a131a5de6a14ef919ffcdc
   depends:
@@ -3216,7 +3216,7 @@ packages:
   license_family: BSD
   size: 169629
   timestamp: 1694616826002
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
   sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
   md5: 57ea097dc15f8d9f9eb90e1d919143b0
   depends:
@@ -3225,7 +3225,7 @@ packages:
   license_family: MIT
   size: 1157733
   timestamp: 1674734069410
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
   sha256: 266199dd4efde0ad342a9c500f4bc4299c5622219aea623b46315a9b4f6b8959
   md5: 2b21844d2b0024d0ffad0e6450cf0855
   depends:
@@ -3234,7 +3234,7 @@ packages:
   license_family: BSD
   size: 15860
   timestamp: 1708532713870
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/netcdf4-1.6.2-py311h0e679e6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/netcdf4-1.6.2-py311h0e679e6_0.tar.bz2
   sha256: b15fc9c240136e7365c01b584b0c91e471f58d5d0f974d36b478b2b21f1d91f9
   md5: 29dfd4701640eba0d1ebf674d74d3b9d
   depends:
@@ -3249,7 +3249,7 @@ packages:
   license_family: MIT
   size: 511133
   timestamp: 1676841290599
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/networkx-3.3-py311h06a4308_0.tar.bz2
   sha256: 95f608b1dd4383538cdd04a285f74d88b398e43f9b78f23a5f3cffe18cf438fe
   md5: 232079919a9e1f2abf394f958d7dff44
   depends:
@@ -3267,7 +3267,7 @@ packages:
   license_family: BSD
   size: 3340382
   timestamp: 1720002512692
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
   sha256: 59e169e036db0f2b98ed19f867d8ac708970214599efa0d57d3413fc1dbe8e3c
   md5: d0faf375bfc33811456d43fe549cb939
   depends:
@@ -3292,7 +3292,7 @@ packages:
   license_family: BSD
   size: 710152
   timestamp: 1717630833268
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
   sha256: ef2857e6d3d7eb246b3abddfbd3aa2d124dd8565391ace3876b77339babc50bb
   md5: d276d1b1774107987963135c78ca7390
   depends:
@@ -3302,7 +3302,7 @@ packages:
   license_family: BSD
   size: 26607
   timestamp: 1699455972519
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nspr-4.35-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nspr-4.35-h6a678d5_0.tar.bz2
   sha256: ffa738460ef0c396c09265e08d626c08fb41e967affae28a3ca9c8d590bfb890
   md5: 1168e3423b7869fdcbe350c10c7bf4b5
   depends:
@@ -3312,7 +3312,7 @@ packages:
   license_family: OTHER
   size: 240070
   timestamp: 1685541755697
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nss-3.89.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nss-3.89.1-h6a678d5_0.tar.bz2
   sha256: a1cd50c850d25fba4ca9ecd88bf9ce553ee4a2f8237e395ce5cc135feb56f3e1
   md5: 7da60451dd1a36255b00240216616101
   depends:
@@ -3326,7 +3326,7 @@ packages:
   license_family: OTHER
   size: 2220153
   timestamp: 1685543249020
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.60.0-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numba-0.60.0-py311ha02d727_0.tar.bz2
   sha256: 08a8505d44d5a51141cf4bd895fb3925ee52160bd51e8c8147f11e7f48a65a1f
   md5: 47699f658867be16614cddc1edd70731
   depends:
@@ -3350,7 +3350,7 @@ packages:
   license_family: BSD
   size: 6188719
   timestamp: 1720541020279
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
   sha256: 2f89f38a665ece47e8868b391fc70602fcee588e989bc1ca6f17f6094892a94e
   md5: b788c80b2d571531ea4f3f8335ae5423
   depends:
@@ -3365,7 +3365,7 @@ packages:
   license_family: MIT
   size: 168827
   timestamp: 1696515597877
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
   sha256: e09e1aff2c12d4ef3fec58fb627744e4b5c7d9eaede7175e293f77272d8b8bfd
   md5: fe8242cfd54d238507493612ae697ad4
   depends:
@@ -3382,7 +3382,7 @@ packages:
   license_family: BSD
   size: 10270
   timestamp: 1708639794640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
   sha256: a53ad723826651041a5057a1cf31bc8689b24d335ce61b196df5124974b05a8e
   md5: 7b29e7191c4170189d6080e61229f030
   depends:
@@ -3398,7 +3398,7 @@ packages:
   license_family: BSD
   size: 9163911
   timestamp: 1708639777712
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
   sha256: 1c9f6902907a3d4a7e5c3cb02236491ea4c4e66a1a0ce51fa506dffb24ba89f6
   md5: 36d514eca3c87ab75a1d418607e26db2
   depends:
@@ -3410,7 +3410,7 @@ packages:
   license_family: BSD
   size: 528528
   timestamp: 1722872671997
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.15-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.15-h5eee18b_0.tar.bz2
   sha256: f8a3dbcdabfad712311fdbec1fd49d44340818d348df5d90f420de133a4daeb1
   md5: 4084456e619e7c2ab269f3cf2ff831f2
   depends:
@@ -3420,7 +3420,7 @@ packages:
   license_family: Apache
   size: 5499760
   timestamp: 1725545717819
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-2.0.1-h2d29ad5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/orc-2.0.1-h2d29ad5_0.tar.bz2
   sha256: b29f46d834ef22a9cb4a05cb241cb6881a69be8eb96fb643fa7edc192b46669e
   md5: 68b0e862640c31c5f82def14794015b5
   depends:
@@ -3436,7 +3436,7 @@ packages:
   license_family: Apache
   size: 1341122
   timestamp: 1717104644619
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
   sha256: 280225061aeba00d7b85f46e55d7d79cd92c92f662dc749d9c53187978e8d083
   md5: c51c21da68080d89300703ad818c824a
   depends:
@@ -3445,7 +3445,7 @@ packages:
   license_family: APACHE
   size: 38606
   timestamp: 1699371264464
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-24.1-py311h06a4308_0.tar.bz2
   sha256: 78b2ec7956f036125c4cd56bd8b13642b952b43a54850c778bf87a664b86d0ef
   md5: db433aded6b3b43ee3cb5d1df0008d2e
   depends:
@@ -3454,7 +3454,7 @@ packages:
   license_family: Apache
   size: 156677
   timestamp: 1720101925844
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.2-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-2.2.2-py311ha02d727_0.tar.bz2
   sha256: b5979b0d4ef5c09f9795acb6b5e322b404f4eab7d73b6ed0aa59f03ef7acd25b
   md5: 1a353daeb78baa6b5bf8f47e1e74ca1c
   depends:
@@ -3505,7 +3505,7 @@ packages:
   license_family: BSD
   size: 17976832
   timestamp: 1718310942026
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-1.4.4-py311h06a4308_0.tar.bz2
   sha256: 998038e45884a19dc198675b2bedb22d871997c6cb1e6ebf0f46321c7f3b0cce
   md5: bbcbcf863dc2295acdab40895df5e7ce
   depends:
@@ -3529,7 +3529,7 @@ packages:
   license_family: BSD
   size: 21902532
   timestamp: 1718119233499
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-2.1.1-py311h06a4308_0.tar.bz2
   sha256: face211fc35bfa199b6d02f8ed25372d1f1a2093518a79a9eec9925bcf9e6d1d
   md5: 9cd12fbc855d97b19427e911262e3bee
   depends:
@@ -3538,7 +3538,7 @@ packages:
   license_family: BSD
   size: 263218
   timestamp: 1719348029519
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
   sha256: a2e2beff710765f2e5135020121da4f227f5e1cbe142e17398a585f50a389d37
   md5: eaf734d49b6e576e12be1398a295643a
   depends:
@@ -3552,7 +3552,7 @@ packages:
   license_family: BSD
   size: 47447
   timestamp: 1698702703255
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
   sha256: 71beb7373390a7c5e9bf8663d64e2b0a426755fe68adb26ed72b6570634f635e
   md5: cd7c1793b37ba076f8515b49dbd850bd
   depends:
@@ -3563,7 +3563,7 @@ packages:
   license_family: BSD
   size: 3346886
   timestamp: 1714657706306
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.4.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-10.4.0-py311h5eee18b_0.tar.bz2
   sha256: 404620647ed8ef6cfd5f4a3ea14a982ab1f87c9e9484b3202610e38a9c73613b
   md5: 8953ff4147f4390dc84111f324ddb8ca
   depends:
@@ -3580,7 +3580,7 @@ packages:
   license_family: Other
   size: 999277
   timestamp: 1721059535410
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-24.2-py311h06a4308_0.tar.bz2
   sha256: 87422d1d2592abe99ee9a6c06f6653030567e88571a21edca9f4c1f2cd22ae07
   md5: 806984470b5328d7fdb721b37ec2d73f
   depends:
@@ -3591,7 +3591,7 @@ packages:
   license_family: MIT
   size: 2913778
   timestamp: 1723484664306
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pixman-0.40.0-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pixman-0.40.0-h7f8727e_1.tar.bz2
   sha256: e0f6c86339e683ea9e3f7e4ce743df653103209aedf995b5e674c148cb349ed8
   md5: c197093127a4cca3bb3227aab1a68573
   depends:
@@ -3599,7 +3599,7 @@ packages:
   license: MIT
   size: 645031
   timestamp: 1632711422664
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
   sha256: d2bbab8bfc57c7f46ca8994bc87df7e744d3f036b867bc4be1145ba6d8d7e091
   md5: de41707272a8e3ccab764f0b7010a27d
   depends:
@@ -3608,7 +3608,7 @@ packages:
   license_family: MIT
   size: 37394
   timestamp: 1692205565974
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pooch-1.7.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pooch-1.7.0-py311h06a4308_0.tar.bz2
   sha256: 552e2ce394d0f4d85a56f6faeddf6467ad77c2f3a59d9b6d60247f18d48b53ad
   md5: e243eec6f01d39b9631983145f297563
   depends:
@@ -3624,7 +3624,7 @@ packages:
   license_family: BSD
   size: 105365
   timestamp: 1695850161588
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/poppler-22.12.0-h9614445_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/poppler-22.12.0-h9614445_3.tar.bz2
   sha256: 8f21d62af3a7e705ae24b9ded761059881628e12e6c01c74418e39a6807a2b5c
   md5: e6372c38e428c74b336b5ebdf8c927f0
   depends:
@@ -3650,14 +3650,14 @@ packages:
   license_family: GPL
   size: 20506964
   timestamp: 1696000977217
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/poppler-data-0.4.11-h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/poppler-data-0.4.11-h06a4308_1.tar.bz2
   sha256: cb8da35b87b1a486e8bb35a8978dcedc93a6d3cc9f9909665267d5fe5d1f93b2
   md5: 3e4df7dd4cb1e7fc2415c39951ebf4a4
   license: GPL-2.0-or-later and GPL-3.0-or-later and BSD-3-Clause
   license_family: GPL
   size: 3894636
   timestamp: 1673863550016
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/proj-9.3.1-he5811b7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/proj-9.3.1-he5811b7_0.tar.bz2
   sha256: 62d73836cb5b538f9c31764054b78cddccdf7722daa0548902b0374ec3e93404
   md5: 8906cd915a63a288c79bbe1f2f4d3937
   depends:
@@ -3672,7 +3672,7 @@ packages:
   license_family: MIT
   size: 3393252
   timestamp: 1704728725084
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
   sha256: e2a0e2a618aa33f0beff9583c7dc510b8d0737b023117346676aacbad33970d8
   md5: 66a6818307261b1a28ab12d1b7776fdf
   depends:
@@ -3681,7 +3681,7 @@ packages:
   license_family: Apache
   size: 121454
   timestamp: 1679340540306
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
   sha256: b7f591c19b10bf0daa7e6e3b45a9f4a0a0e83188e1f8a58037caea79e60f8d91
   md5: d945b4ccc135005839c504cc29df1745
   depends:
@@ -3693,7 +3693,7 @@ packages:
   license_family: BSD
   size: 749608
   timestamp: 1704404477511
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
   sha256: 96482b49191fdac59580a95e69508367083e1f7600145e11d7c2db634337eb26
   md5: 2d57bf8eacf3f291db845928241f724c
   depends:
@@ -3703,7 +3703,7 @@ packages:
   license_family: BSD
   size: 490805
   timestamp: 1679337420563
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-16.1.0-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyarrow-16.1.0-py311ha02d727_0.tar.bz2
   sha256: c03ea46d8d60ff2aa84ae4270aeaee4c000ac4b83096b967d79fbecdfb4e9042
   md5: 799cccb8b55193647f4f97afb478df7b
   depends:
@@ -3716,7 +3716,7 @@ packages:
   license_family: Apache
   size: 5332213
   timestamp: 1721664638084
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
   sha256: eb75b4417565d25e2d1006db75aa8bd9da6b6c72a929954b01a31b9bf5f8b42e
   md5: bb56c0358b65665f4dd509a4635f6f3c
   depends:
@@ -3728,7 +3728,7 @@ packages:
   license_family: BSD
   size: 37802
   timestamp: 1676838557935
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
   sha256: ed927e4d058a8f4ea73edc7a43ed74877d93b88fdfa240b3b2777244386ced70
   md5: a1f0e05fc7e49712f81ad5478ec9d51e
   depends:
@@ -3737,7 +3737,7 @@ packages:
   license_family: BSD
   size: 2121496
   timestamp: 1684280065800
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.1.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.1.2-py311h06a4308_0.tar.bz2
   sha256: 9a1a3ae9707592f3a3ca830ec425b5f9dd82c467f66dc793cb73f43016e2166d
   md5: c40a13571a56f0548f7b610e1734aee6
   depends:
@@ -3746,7 +3746,7 @@ packages:
   license_family: MIT
   size: 459429
   timestamp: 1725041741531
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyproj-3.6.1-py311h76fdc58_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyproj-3.6.1-py311h76fdc58_0.tar.bz2
   sha256: 082852b55bcaa6f2c57262c9c3805f004dd9f83e28004186a177ec42af90829b
   md5: 9e827c7b7763816e3d777d1680091ee0
   depends:
@@ -3758,7 +3758,7 @@ packages:
   license_family: MIT
   size: 643692
   timestamp: 1704901597067
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyshp-2.3.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyshp-2.3.1-py311h06a4308_0.tar.bz2
   sha256: a2137cf7b9f2b4946913c31d2fb29ff40c05b5efb452111377493eb4c9d4beae
   md5: 0da47478156b41225fbc4f2fe9fa7421
   depends:
@@ -3767,7 +3767,7 @@ packages:
   license_family: MIT
   size: 85675
   timestamp: 1706101026788
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
   sha256: 114b55e00f4622c90fd2b404b21ad5f94a10283fcaaf86a42174b8d39b0a3e98
   md5: 2458e92683cc68671a6c8e1b86ce8817
   depends:
@@ -3776,7 +3776,7 @@ packages:
   license_family: BSD
   size: 35850
   timestamp: 1676822725516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
   sha256: ef622eb34669f3518d2f855cb333c56b106d02cdeac9d58e5a1a5a3097e4978d
   md5: 9d4f211d050d511b0b84c2e57e7fb1d7
   depends:
@@ -3798,7 +3798,7 @@ packages:
   license_family: PSF
   size: 36072860
   timestamp: 1713546307595
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
   sha256: a0f008717fab060ccd003dfebc09156d90b9afd14ac3626566aa1a8f3d3b7e2f
   md5: 357bf4fe94496cbae72ab4d780184b31
   depends:
@@ -3808,7 +3808,7 @@ packages:
   license_family: BSD
   size: 330924
   timestamp: 1716495762901
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
   sha256: aadc4078311c059265706a56265f0a57ceb538d36179d5203dd487d80d0e8f16
   md5: 59ec670fcd172447dbd9591b8fbfdd56
   depends:
@@ -3817,7 +3817,7 @@ packages:
   license_family: BSD
   size: 278741
   timestamp: 1679340144625
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
   sha256: d5058d0ecc3973316c1d5f1bfb03dd119e0dade85f4c2d21b412c8db4e1636f2
   md5: 93000e4d3603342779a2afda66fa91b8
   depends:
@@ -3826,7 +3826,7 @@ packages:
   license_family: BSD
   size: 17607
   timestamp: 1683823841946
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-lmdb-1.4.1-py311h6a678d5_0.tar.bz2
   sha256: d9eff881e112d0b326d0c1ee0d42d6c2c4649b1c4edd168be1006f28f1f8962e
   md5: d9d1f41dcee9b622cbfe048ab1632a47
   depends:
@@ -3837,7 +3837,7 @@ packages:
   license_family: Other
   size: 154074
   timestamp: 1682522389521
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
   sha256: b85acb933fff864bfa89d034e8e3d85b1a9c2e69cbfc0d68c1d66ffd1443e67d
   md5: 0cdb92d2d684ee1095310f992ed0d9b2
   depends:
@@ -3846,7 +3846,7 @@ packages:
   license_family: MIT
   size: 266796
   timestamp: 1713974338678
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
   sha256: 511e8206a15445715b80be76493300930686b3fe1e512ae942d6ccca36df392a
   md5: 35a6e46ae970f8b71d78fb5a810f2e80
   depends:
@@ -3858,7 +3858,7 @@ packages:
   license_family: BSD
   size: 64013
   timestamp: 1711136926372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
   sha256: b2a1f649669f4336b74f6f20df711959bcd8024f8f8b94199dc0e040b06bd37a
   md5: f9e8e3f7068f717f75e555dc04545d8d
   depends:
@@ -3869,7 +3869,7 @@ packages:
   license_family: MIT
   size: 206433
   timestamp: 1698096204677
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
   sha256: 7c74db4292f31619606180f86f3c1e2d913495c2c9d1195c5d51681a6a841625
   md5: be1c05fae57d194924b9400f9b5ad3c6
   depends:
@@ -3880,7 +3880,7 @@ packages:
   license_family: Other
   size: 613277
   timestamp: 1709318516682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/qhull-2020.2-hdb19cb5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/qhull-2020.2-hdb19cb5_2.tar.bz2
   sha256: a9fce407d219dca8f61be8aab0837b5fb2642b8242965955fbdee7d880d00a82
   md5: cb376ee332d02c7e7b10bca9ec74cff5
   depends:
@@ -3890,7 +3890,7 @@ packages:
   license_family: Other
   size: 1990101
   timestamp: 1670915839713
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
   sha256: 8a640736bef635346409582dbfe2b7d0ecc9da215c90173ff8a9a5fe22569107
   md5: 6b583dce61c6feb352ef0f49f413af1e
   depends:
@@ -3899,7 +3899,7 @@ packages:
   license: BSD-3-Clause
   size: 235004
   timestamp: 1652449537852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
   sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
   md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
   depends:
@@ -3909,7 +3909,7 @@ packages:
   license_family: GPL
   size: 467661
   timestamp: 1666648052561
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
   sha256: 89c2f4235277b9825cc805c5c44f0b1afcb683d7b5a3f513bc4bf243b643bb0c
   md5: db70eb57e33adf7b8bbdadd72214d48d
   depends:
@@ -3920,7 +3920,7 @@ packages:
   license_family: MIT
   size: 73679
   timestamp: 1699012111499
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.32.3-py311h06a4308_0.tar.bz2
   sha256: 77190094130d6db30f7422a6764d649b1be7e5e6c405a16fe83704d108ffdb02
   md5: 293eada1e1224fe07130acf2f8786f96
   depends:
@@ -3936,7 +3936,7 @@ packages:
   license_family: Apache
   size: 123275
   timestamp: 1721410959361
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
   sha256: fdae3f68ea84b99561aee6c566ab1c287d8f2ae2668424e9283a8ed86af8f1d2
   md5: cde5b71ccbb3630053340b2c8c7dbf10
   depends:
@@ -3946,7 +3946,7 @@ packages:
   license_family: MIT
   size: 9333
   timestamp: 1683077183576
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
   sha256: 0bf859b06a07857099fd4f524fe5e0875fda70029e9485d95c7efa97134fbc14
   md5: fd5815cc592fdbd4c831901541eadaba
   depends:
@@ -3955,7 +3955,7 @@ packages:
   license_family: MIT
   size: 9735
   timestamp: 1683059096795
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
   sha256: 474553d01aea57214a54a7443f227da84a58e29c49eb7605ba0043c55b7d167a
   md5: f01333e9f0a908e435db650f42fbd2db
   depends:
@@ -3965,7 +3965,7 @@ packages:
   license_family: MIT
   size: 1096668
   timestamp: 1698946168635
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rtree-1.0.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rtree-1.0.1-py311h06a4308_0.tar.bz2
   sha256: c7fe463fd96308054c7c01aea3fb92adcb226b161147e1ff8001b574fed6acb2
   md5: f59a6905f6488c2e539954eff64ebac5
   depends:
@@ -3976,7 +3976,7 @@ packages:
   license_family: MIT
   size: 63080
   timestamp: 1676845705413
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
   sha256: 8c8aa1eb7e215984f46c8e1c7cfa6e5e6b233993d92b835a9b1b5491a4b970ab
   md5: 6e145b179adde03f8aa8a066c58d4e31
   depends:
@@ -3986,7 +3986,7 @@ packages:
   license_family: Apache
   size: 380702
   timestamp: 1706563445897
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scikit-learn-1.5.1-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/scikit-learn-1.5.1-py311ha02d727_0.tar.bz2
   sha256: f753049fe5343e75a3a0bb323a2d375a2aa6fd4ae5e3b6536c5b9b8ad6a9fdeb
   md5: 6fe5c19da4120d3a0c5333a22a21a863
   depends:
@@ -4003,7 +4003,7 @@ packages:
   license_family: BSD
   size: 13381006
   timestamp: 1721922162600
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.13.1-py311h08b1b3b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/scipy-1.13.1-py311h08b1b3b_0.tar.bz2
   sha256: be007cd7f5b114338573fe55aca47ea0e8c9e17e3a47a2df23619fa723c76b8d
   md5: 13dbfb86ab689d288a7cf4c2d649c608
   depends:
@@ -4022,7 +4022,7 @@ packages:
   license_family: BSD
   size: 27601481
   timestamp: 1717530680610
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
   sha256: 51bcea0e575a626f6ffbd16d1153330fda93dbe3dd31dcd3a8f469ff61dd1e4e
   md5: 41d531c90be8c82bf79635ff3d409476
   depends:
@@ -4031,7 +4031,7 @@ packages:
   license_family: BSD
   size: 32295
   timestamp: 1699371262818
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-75.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-75.1.0-py311h06a4308_0.tar.bz2
   sha256: 0012d33e169b495c9e289b185ff8d4192b93711c5dfc514b0c5efc536ea9600b
   md5: 360f44ea616167b2c61cced23d0db311
   depends:
@@ -4040,7 +4040,7 @@ packages:
   license_family: MIT
   size: 2311301
   timestamp: 1726677958012
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/shapely-2.0.5-py311h24a2a10_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/shapely-2.0.5-py311h24a2a10_0.tar.bz2
   sha256: 76a2754449f40d4eae17b833dc1277fb1aec71dd3d823bcc247e796a713081ca
   md5: 2e0ad2746f7361fab3b6d1d3b5adfdb5
   depends:
@@ -4052,7 +4052,7 @@ packages:
   license_family: BSD
   size: 616599
   timestamp: 1722533261135
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
   sha256: 8fd98235b37194986a5eb663c95a4a6db8c9e20a627f5c79ff8d9be3fd0e36f7
   md5: 25ac00d957eda056675f8fa3eafdf6df
   depends:
@@ -4062,7 +4062,7 @@ packages:
   license_family: BSD
   size: 52749
   timestamp: 1723557449203
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
   sha256: 1a84b00944bc5588e14a097460175f97df49acb4f1ff2498ffd9a1893068ed81
   md5: a456513471b2ecbed60430c21dd1ccc7
   depends:
@@ -4071,7 +4071,7 @@ packages:
   license_family: Other
   size: 17880
   timestamp: 1705431390054
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
   sha256: adcafd297d60af64107c113bb7b8b92160d0268a44ef9a3b79e56a88a0358ea7
   md5: 28ed704ed26b06d32662e3a6a87e59b0
   depends:
@@ -4080,7 +4080,7 @@ packages:
   license_family: MIT
   size: 88799
   timestamp: 1696347581401
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
   sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
   md5: f86119b3243fe3508160aa0406245738
   depends:
@@ -4093,7 +4093,7 @@ packages:
   license_family: Other
   size: 1723866
   timestamp: 1714488309729
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
   sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
   md5: 041a3caf09dc9ce8fc6c10925c4fe050
   depends:
@@ -4103,7 +4103,7 @@ packages:
   license_family: Apache
   size: 1888016
   timestamp: 1680167274961
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
   sha256: 856a8ab8c350c50247b79966c6cb80fb6d4de36eef49ddf75aebbbcaf854c82d
   md5: 442dde204d14d171aab9ee40e8de4de8
   depends:
@@ -4114,7 +4114,7 @@ packages:
   license_family: BSD
   size: 37456
   timestamp: 1677696176157
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/threadpoolctl-3.5.0-py311h92b7b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/threadpoolctl-3.5.0-py311h92b7b1e_0.tar.bz2
   sha256: 77809e578fdb2dc8fd23d79fc0621fc21cd47744f2520840313ef932d2952186
   md5: e49154b5b9fa725eccea9054f7ceeb33
   depends:
@@ -4123,7 +4123,7 @@ packages:
   license_family: BSD
   size: 48858
   timestamp: 1719407853019
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tiledb-2.3.3-h77177df_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tiledb-2.3.3-h77177df_3.tar.bz2
   sha256: 82c260e172d37e76f89069acf987900af72acfcf1c3332890db97bf8e443507f
   md5: 705ac1e0f32ace2777ed7dfb03873197
   depends:
@@ -4140,7 +4140,7 @@ packages:
   license_family: MIT
   size: 2940076
   timestamp: 1685656926819
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
   sha256: f0a026ddc0ed041bfc60c8a1ca0b70b7a69232775b3181bfb35a39fda42d6994
   md5: 2902d5a5854865baaaf58dc59cf06b3c
   depends:
@@ -4150,7 +4150,7 @@ packages:
   license_family: BSD
   size: 49185
   timestamp: 1676823769869
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
   sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
   md5: e2512d57c8a1e91e7b20e265c6906546
   depends:
@@ -4160,7 +4160,7 @@ packages:
   license_family: BSD
   size: 3588922
   timestamp: 1714770676475
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
   sha256: e58ff4a82819446f3c92e5b1aa2a784c4b06643e751fe67cf115858296dbfa50
   md5: 32ee4723173f1fad5563b8afb5f1c8f1
   depends:
@@ -4169,7 +4169,7 @@ packages:
   license_family: BSD
   size: 135634
   timestamp: 1676827536101
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.1-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.4.1-py311h5eee18b_0.tar.bz2
   sha256: 394fdf404ede3bc35d697b2e445c42590ddcae86a80f39642cc5366196fcbe54
   md5: a21cbca0664d8f34b0dca1f84998a31b
   depends:
@@ -4179,7 +4179,7 @@ packages:
   license_family: Apache
   size: 914199
   timestamp: 1718740165334
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.5-py311h92b7b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.66.5-py311h92b7b1e_0.tar.bz2
   sha256: dab820faa313d62b44014841409cef89a49dbda9a7697689ce37b3032ec3276e
   md5: 1d6513a5b915465291fdb2041815bdc6
   depends:
@@ -4190,7 +4190,7 @@ packages:
   license_family: MOZILLA
   size: 154437
   timestamp: 1724854032868
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
   sha256: 2091b17ae4fa46ed98fd6bfe9ca1aff3b0b81d73045e0cc55774b6516b8704b3
   md5: 183ae7b837c1c68ec1a8011011fadea7
   depends:
@@ -4199,7 +4199,7 @@ packages:
   license_family: BSD
   size: 206924
   timestamp: 1718227183177
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
   sha256: 8c06c291c76e8c2022ffbb9fea4727a4bf1f9b03e498bafc56ba8ac4e7604ab9
   md5: 5adb7baf1091d09026a372cac930ce6c
   depends:
@@ -4209,7 +4209,7 @@ packages:
   license_family: PSF
   size: 8869
   timestamp: 1715268966416
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
   sha256: 118b0801167264c401e84bbf19175546092a5569cc098146f7362bbf890dc8d9
   md5: b3c2aa56d53b459f8365d8385f48d0c3
   depends:
@@ -4218,7 +4218,7 @@ packages:
   license_family: PSF
   size: 74489
   timestamp: 1715268960737
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
   sha256: 509b962773f0fe44a93a7f6196b254670a030eac8ea7f90727312e3ccd9294b2
   md5: 6c402d5bf4e01c8c3895c9ef41707b6e
   depends:
@@ -4227,7 +4227,7 @@ packages:
   license_family: MIT
   size: 11371
   timestamp: 1676828901104
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
   sha256: bbe7629e8ce52c82f13ed0d1fb919f3659ef466b274a7c74aa925a9bc7aee450
   md5: 7da527bbcf71270c1abed8ea52e7d44c
   depends:
@@ -4237,7 +4237,7 @@ packages:
   license_family: Apache
   size: 509031
   timestamp: 1713213062098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uriparser-0.9.7-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/uriparser-0.9.7-h5eee18b_0.tar.bz2
   sha256: fa1281c13f5c8d18b36bb69705e4cd632ccc456b603f27ca63f68a787d03b0be
   md5: 48e34041c9a0bd924018a6fab5d167b6
   depends:
@@ -4246,7 +4246,7 @@ packages:
   license_family: BSD
   size: 48752
   timestamp: 1692186947656
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-2.2.2-py311h06a4308_0.tar.bz2
   sha256: 2de4e4586d3b1cbfa8ecfcfaaa148da3b005b303e0784be2d6c2e54a3a13d362
   md5: 3345015e0af00cc31acb88167a842381
   depends:
@@ -4262,7 +4262,7 @@ packages:
   license_family: MIT
   size: 209169
   timestamp: 1718912749915
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
   sha256: a8d11b0f08217607b99ba560edf66423ca1e36f4ffbb6e2377e61670e2b5f36b
   md5: 431e82b081b08aef0259df0437e04c75
   depends:
@@ -4271,7 +4271,7 @@ packages:
   license_family: MIT
   size: 97535
   timestamp: 1706894675990
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
   sha256: c3a5e0b855dc2de6c162708dfcf170a23eb9e7525d4252d8dce553369af4a330
   md5: a4c77e204b7787f820955166a1283168
   depends:
@@ -4280,7 +4280,7 @@ packages:
   license_family: BSD
   size: 25890
   timestamp: 1676823132898
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
   sha256: 42989f9970a8466cc4edb73463dfa194594dd1a5d42c9f820a1f86296d4af140
   md5: 655dfd4d2f17977cb81caa1c082d2b25
   depends:
@@ -4289,7 +4289,7 @@ packages:
   license_family: Apache
   size: 113505
   timestamp: 1715878346465
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.44.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.44.0-py311h06a4308_0.tar.bz2
   sha256: 3b258ad0db82572157a72303bbd5c20399d0c7f3b48abc1435ef96e4517e59f7
   md5: e11eb90c0ee1084a95cffe231196d98d
   depends:
@@ -4298,7 +4298,7 @@ packages:
   license_family: MIT
   size: 138218
   timestamp: 1726165052578
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
   sha256: 85248e503721da67797546cb8a22e303c1739100834b219c5621f216e3794e8d
   md5: 2570956643f22d0f809b2467e02d3984
   depends:
@@ -4310,7 +4310,7 @@ packages:
   license_family: Apache
   size: 2465865
   timestamp: 1689041600364
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xerces-c-3.2.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xerces-c-3.2.4-h6a678d5_1.tar.bz2
   sha256: 02af202ca1131410fcf233d540a5875fe98a9c78c0af202e4258b50cb279379a
   md5: f3f2648851cde3a44093a5788fa6b585
   depends:
@@ -4321,7 +4321,7 @@ packages:
   license_family: Apache
   size: 3621933
   timestamp: 1692994759691
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
   sha256: d18cdca154bf668826f869117ea996c4f9e8ef7d27b7c528332a7d17e5a8602c
   md5: 9f7353d72046b16dd6ef6b5689ac9bfd
   depends:
@@ -4330,7 +4330,7 @@ packages:
   license_family: BSD
   size: 54731
   timestamp: 1676828934954
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
   sha256: 9122d6e9dabb7a47f2bcb15d86b97c96c49a9048da3f8ae59675351710c14cc5
   md5: 660b2aead2ec87b751c86cd33934f44e
   depends:
@@ -4339,7 +4339,7 @@ packages:
   license_family: GPL2
   size: 716926
   timestamp: 1714510796277
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -4347,7 +4347,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
   sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
   md5: 943f1247a22b6b64171363bcee1eec27
   depends:
@@ -4358,7 +4358,7 @@ packages:
   license_family: Other
   size: 371663
   timestamp: 1705602144682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zict-3.0.0-py311h06a4308_0.tar.bz2
   sha256: f33ed759a551e2cd64115a3b01af0fc9822b1a5a1a5c798aa0ee14292792d7c1
   md5: 7feb38e587b3352efca77df1447858d2
   depends:
@@ -4369,7 +4369,7 @@ packages:
   license_family: BSD
   size: 102106
   timestamp: 1695832995689
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
   sha256: 7aa781d0850f97622755ed44772d2b215b253a8e211aede5f3f53e1b95b4143a
   md5: b1d8823f50228d4efb7b7a6e267ed776
   depends:
@@ -4378,7 +4378,7 @@ packages:
   license_family: MIT
   size: 24333
   timestamp: 1704207043644
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
   sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
   md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
   depends:
@@ -4387,7 +4387,7 @@ packages:
   license_family: Other
   size: 127143
   timestamp: 1714510716441
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
   sha256: af3c032f06352e87c450739cb8aafe1ff34ad28bf074b214ea98b3d29259a85d
   md5: 51fa34bd0e016ed7c5371cf6cb13ef6c
   depends:
@@ -4400,7 +4400,7 @@ packages:
   license_family: BSD
   size: 1044463
   timestamp: 1714678445052
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -4413,7 +4413,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -4423,7 +4423,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -4435,7 +4435,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
   sha256: c0dd89ffac001588171152a285ddbbaea209ebe4116010f985f898b7e87c2f35
   md5: 731ae7d446633bc729f3493a52d4365b
   depends:
@@ -4444,7 +4444,7 @@ packages:
   license_family: MIT
   size: 43502
   timestamp: 1721748373551
-- conda: https://repo.anaconda.com/pkgs/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/click-plugins-1.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: 159043b22b754bbfd41d70508ef60a42e3e0f74ebaccd4633726bcf944ab4249
   md5: 86fd637d64a91d9e916f19f349d45a97
   depends:
@@ -4453,7 +4453,7 @@ packages:
   license: BSD-3-Clause
   size: 10095
   timestamp: 1630665910221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cligj-0.7.2-pyhd3eb1b0_0.tar.bz2
   sha256: bd00b5f84c5fee1a4f252c26d6575a93bcdc5e71832270685e002bf78b2f4eba
   md5: 7c9691bb77e3f20cf12ded06388b4aad
   depends:
@@ -4463,7 +4463,7 @@ packages:
   license_family: BSD
   size: 10160
   timestamp: 1622563293746
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -4472,7 +4472,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -4481,7 +4481,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -4490,7 +4490,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -4499,7 +4499,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
   sha256: 9de8666e5b70aa2437737128eaa14ffe80a7b5235c2a6b7d3f39ccefd7816ba0
   md5: bb52e50c5ab1a5c7778c11376404dfdb
   depends:
@@ -4507,7 +4507,7 @@ packages:
   license: BSD 3-Clause
   size: 7933
   timestamp: 1630598543551
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -4515,7 +4515,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -4524,7 +4524,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -4533,7 +4533,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -4543,7 +4543,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
   sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
   md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
   depends:
@@ -4552,7 +4552,7 @@ packages:
   license_family: BSD
   size: 5106
   timestamp: 1704404390460
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -4560,7 +4560,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -4569,21 +4569,21 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
   sha256: 459f38609d854888998a8d76028019dbacdce2bfe401eab57b8eb8ff16da9c7f
   md5: 2948a98ef4de5decb7e5eb888eae68ba
   license: BSD-3-Clause
   license_family: BSD
   size: 13056
   timestamp: 1682965564630
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
   sha256: 305e5fd9993f3e5506f386f98794c7d53b6e6c68d4d411ada724de49a17945fa
   md5: e1fbbd2d11d21aaec3c32f7d332c0e77
   license: BSD-3-Clause
   license_family: BSD
   size: 13818
   timestamp: 1712163766707
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -4592,7 +4592,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
   sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
   md5: 02caf3f47f1d06256068053297355740
   depends:
@@ -4601,7 +4601,7 @@ packages:
   license_family: Apache
   size: 152292
   timestamp: 1690578151230
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -4610,7 +4610,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
   sha256: 4e47f6c49ce84509f1466e8a4d728447bf4bcd9bce7b456431a789a262547067
   md5: 4cad993b0f80bc23fb66a97592299cbb
   depends:
@@ -4619,7 +4619,7 @@ packages:
   license_family: Apache
   size: 26504
   timestamp: 1623949147884
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -4631,7 +4631,7 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
   sha256: ca2be6c7810a37cfc6db1f5383937b5d35c6d73c1fad8a9104de85f069b1df1c
   md5: 9ccb2fb33edb152403d6ef32bf758a9d
   depends:
@@ -4640,14 +4640,14 @@ packages:
   license_family: BSD
   size: 15614
   timestamp: 1629402049497
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
   sha256: dc9f709bacbaf08a0941d2622d82f91f18b355e82c55348ec29f1391215ca7e0
   md5: ece0f5837a4de2d4d5f1abf8347cd10a
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 124922
   timestamp: 1708711884650
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -4655,7 +4655,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
   sha256: 5800a2466734dd1ef372bec0dd3f0880c5072fa1e8b0668f5054f834285e991c
   md5: 18194e51d4420ac08f29f3f86581b52e
   depends:
@@ -4669,7 +4669,7 @@ packages:
   license_family: MIT
   size: 229003
   timestamp: 1706220302459
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
   sha256: ab7672364f1fa55ec5d8311d85d40e5b57cbd3517b17670557b6fb822bcf759c
   md5: 6e0159a5865cb7e96a748bd8560035ee
   depends:
@@ -4678,7 +4678,7 @@ packages:
   license_family: BSD
   size: 11579
   timestamp: 1678317458652
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
   sha256: 51556902e09436d46878ef772805d06416ca96ffaa66340b5565c0245574aaf5
   md5: 4cb1b20635cf5431d34cc96ca1e8a751
   depends:
@@ -4688,7 +4688,7 @@ packages:
   license_family: MIT
   size: 33355
   timestamp: 1678317111825
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-16.1.0-hc0a701b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/arrow-cpp-16.1.0-hc0a701b_0.tar.bz2
   sha256: 27c6aab156b0419ea51b4c46361305d578e28ede4e0dea7134e5bcb059746ce3
   md5: 3077e97632019a95156a6e2426a5d5eb
   depends:
@@ -4720,7 +4720,7 @@ packages:
   license_family: Apache
   size: 10676019
   timestamp: 1721659474232
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
   sha256: 188b74f717e3ce3595da404c0e027b8ccafa9c186e88325e8f02c29d7b4c0744
   md5: 04ad90eead5812a0263b42321056ab33
   depends:
@@ -4729,7 +4729,7 @@ packages:
   license_family: MIT
   size: 153694
   timestamp: 1695717975427
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
   sha256: a153eee37b30ca5c25c5c95463a8852f1cf62a8f45f73349e68f1e3b22eec6da
   md5: 4bf760fad0e938618391f0db249d00e1
   depends:
@@ -4742,7 +4742,7 @@ packages:
   license_family: Apache
   size: 87236
   timestamp: 1706746160841
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
   sha256: 04ec5908b1dc2979ed50923af90d02da8a60434658efbc4f35fc61e7e9cafa0b
   md5: 6ba283b7f902226f232fe8a32fa83ee4
   depends:
@@ -4751,14 +4751,14 @@ packages:
   license_family: Apache
   size: 37547
   timestamp: 1706690917050
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
   sha256: 08431c5ec5f0a9e95819b6a76c9cc870d2154e46b229431fd0b3dad25bb70b04
   md5: 78b4b4225fdefef0b9b0d56b6e51e4a0
   license: Apache-2.0
   license_family: Apache
   size: 184146
   timestamp: 1706189913777
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
   sha256: 6a78705375d837a0eeeff9e914aae53a0d2cd44e9760075bdd8711a05f94ff3f
   md5: 931b0654ae05bcd1acc760dc830b89d3
   depends:
@@ -4767,7 +4767,7 @@ packages:
   license_family: Apache
   size: 17410
   timestamp: 1706690854689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
   sha256: 1d468f7c085b73cc40f813885d77a74270f94dd973b4285546d8873030fcada7
   md5: 3a61760bb61f85b3a0ffe7b14058801f
   depends:
@@ -4779,7 +4779,7 @@ packages:
   license_family: Apache
   size: 46197
   timestamp: 1706697276616
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
   sha256: b53432aadb2ffe2f1c584c6994b665f3620f29c51b200b03282065a480cf021e
   md5: 9686f32b210a009048c0877ac39fe88c
   depends:
@@ -4791,7 +4791,7 @@ packages:
   license_family: Apache
   size: 164397
   timestamp: 1706744140750
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
   sha256: 2ff9632eb2e2c7a70b8d64988e530d842fe5fa7fa529d34cda19f76fb40582e2
   md5: ffbd1ff65fe9fb52d833af5d396b006d
   depends:
@@ -4801,7 +4801,7 @@ packages:
   license_family: Apache
   size: 125589
   timestamp: 1706696187075
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
   sha256: fa57f1d2b2eb56db72e4b54348452af67a1222bd4266b3d68c7b7ff00399743b
   md5: ae9e78f6b1fef841fc0ffc7ef7c78d26
   depends:
@@ -4812,7 +4812,7 @@ packages:
   license_family: Apache
   size: 61379
   timestamp: 1706746740037
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
   sha256: 00834bd876756f1f13333c31623c2bdfa7d901b40aec161cf0343548fcd96187
   md5: 4ef080b5a91e260d51d563218396d0f6
   depends:
@@ -4826,7 +4826,7 @@ packages:
   license_family: Apache
   size: 67408
   timestamp: 1706747579372
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
   sha256: fb3198a05c96030d8498a5c4873e56ae28a5b04fb904a5c696a2192e9ee6c45b
   md5: 48efeda1471a50b9481c3943a0300e86
   depends:
@@ -4835,7 +4835,7 @@ packages:
   license_family: Apache
   size: 48055
   timestamp: 1706690833951
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
   sha256: f05fb72b1a5f25fab65ef416ff0d1966e3ff84f8a08c56bf809fb602028c66ec
   md5: 86cda3f774047ff6b40eb14aab83215d
   depends:
@@ -4844,7 +4844,7 @@ packages:
   license_family: Apache
   size: 51354
   timestamp: 1706192066535
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
   sha256: b8cb5f96e9eab47419622795fcdb42ad414481db9b84bbb50fcf8251a1314b59
   md5: 335265dfe12cb6adcacf39b411cf9d7a
   depends:
@@ -4862,7 +4862,7 @@ packages:
   license_family: Apache
   size: 210312
   timestamp: 1706827788950
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.10.55-h61975a4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-sdk-cpp-1.10.55-h61975a4_0.tar.bz2
   sha256: 40911c99dfa11ad32d451ab8cb5b24f0aecde231b5f8f4e9d8887bc4a720dc65
   md5: 1078cfa7cb12f9a0d3fb4017cc9789b9
   depends:
@@ -4876,7 +4876,7 @@ packages:
   license_family: Apache
   size: 2322692
   timestamp: 1706890560060
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
   sha256: 365824e639808e52809f97b70b65da94a5eeb87e29dd97c8926aa72707a5a1c7
   md5: db7813418dfe42d59363fed4a68d5c36
   depends:
@@ -4886,12 +4886,12 @@ packages:
   license_family: MIT
   size: 278195
   timestamp: 1718029905185
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-openblas.tar.bz2
   sha256: 695ac69739e73351dfebfb01ea39c5e1dbfdcfb475590d6560ae318bfbad3a97
   md5: 38fd73cba341639c45d8c747b08c9cc1
   size: 49130
   timestamp: 1528225884020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
   sha256: 3699a260f422443de85b74084fe36f734be1a466eeebdfdf4195d52c9fdb5508
   md5: 132d056e66b3ae9148f53819f8368c94
   depends:
@@ -4903,7 +4903,7 @@ packages:
   license_family: BSD
   size: 66125
   timestamp: 1675247668924
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.1-py311h85bffb1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-3.4.1-py311h85bffb1_0.tar.bz2
   sha256: ace9b81e898a3180d2fb07c75326414ec4cbaed62efff54e42feb6d59774ccab
   md5: 1aa0dfcb172854f56447096c70d6a005
   depends:
@@ -4921,7 +4921,7 @@ packages:
   license_family: BSD
   size: 6076891
   timestamp: 1718119694797
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
   sha256: 81102f2762d8eb2f07c69fbf7ca7dad879a257a053085492d4c1b4006eb35fb8
   md5: 3c42777bc9330fe91177ea813b9ec252
   depends:
@@ -4931,7 +4931,7 @@ packages:
   license_family: OTHER
   size: 11744
   timestamp: 1696762233693
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
   sha256: 9acafafcaebd653c2372ddc864525722e1c55b884b5eba22e28e2b2d946b853c
   md5: 22375cc3c2edada31b85af56c8e6dee6
   depends:
@@ -4941,7 +4941,7 @@ packages:
   license_family: BSD
   size: 155829
   timestamp: 1707864406086
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/branca-0.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/branca-0.6.0-py311hecd8cb5_0.tar.bz2
   sha256: 054255ffd71363f6f36db8abfe2f56785c1bac9d9731e6d0942a7a0a4c89fb3e
   md5: 8441be15714bfe4388f092e61ad3228e
   depends:
@@ -4951,7 +4951,7 @@ packages:
   license_family: MIT
   size: 53523
   timestamp: 1678390549095
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
   sha256: d8b1ccb15297dcfb3f9ebb8139c3e28a13d6c2e73c37612cb214ab6cc58b15fa
   md5: e5dec9f13de061640ad2697562a99b54
   depends:
@@ -4961,7 +4961,7 @@ packages:
   license: MIT
   size: 19732
   timestamp: 1714483415038
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
   sha256: e9fda4393edd0234c88efc2b88e0edf42c94eb49ea5b189a80afd733058be8fb
   md5: 13ceed558eb174d6b77ed1b0035f1785
   depends:
@@ -4970,7 +4970,7 @@ packages:
   license: MIT
   size: 18400
   timestamp: 1714483395748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
   sha256: a323af3251e426962ad16edf8f46a696ef502731faf12aee32ca289c40b11342
   md5: 658ce49e9f07dba7a1afe70fa2666e0a
   depends:
@@ -4979,28 +4979,28 @@ packages:
   license: MIT
   size: 393858
   timestamp: 1714483549536
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
   sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
   md5: c5a600d81b1b48578863af2973c743ac
   license: bzip2-1.0.8
   license_family: BSD
   size: 187637
   timestamp: 1714510590009
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
   sha256: f913b61ba3c1651b36688415cc163a5d575475f7573b543f48a80e7a5002e4bb
   md5: f11d165eaa532ce04a35382841284298
   license: MIT
   license_family: MIT
   size: 107047
   timestamp: 1693902034820
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.7.2-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2024.7.2-hecd8cb5_0.tar.bz2
   sha256: acc856860d2eb136b4a1a997634997b9b01929e6b22675eff544d13576b08a01
   md5: 48b25ae3137cd9a822762c3f1c560881
   license: MPL-2.0
   license_family: Other
   size: 137928
   timestamp: 1720622036783
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cairo-1.16.0-h3ce6f7e_5.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cairo-1.16.0-h3ce6f7e_5.tar.bz2
   sha256: 40610c1f84d17423e18948662190fab696d55b974b44c0e81efc8b4a18c74377
   md5: a562993d973bb938743ff338502108d8
   depends:
@@ -5014,7 +5014,7 @@ packages:
   license_family: LGPL
   size: 1434523
   timestamp: 1688495924565
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cartopy-0.22.0-py311hdb55bb0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cartopy-0.22.0-py311hdb55bb0_0.tar.bz2
   sha256: 42201ad67348e8d64bad9b17439c124058199fb5468dc6bb65ab736f91fbba8e
   md5: 8aa3ca392fa7b61229467604c2732826
   depends:
@@ -5034,7 +5034,7 @@ packages:
   license_family: LGPL
   size: 2088551
   timestamp: 1706196555989
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.8.30-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2024.8.30-py311hecd8cb5_0.tar.bz2
   sha256: acb2effe5ccd14a94eaf0dfe268f6b7f13165461ca60f24b8dab007259200b12
   md5: 07e08081971e9f8255e5c4cbe19edf47
   depends:
@@ -5043,7 +5043,7 @@ packages:
   license_family: Other
   size: 170244
   timestamp: 1725551715047
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py311h9205ec4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.17.1-py311h9205ec4_0.tar.bz2
   sha256: 8b66e37770f89a68ef4d7a70787720c300793e05822038379fa4068e7197fb2a
   md5: e1f7832dcc299bc8f5069e90f7f8cc00
   depends:
@@ -5054,7 +5054,7 @@ packages:
   license_family: MIT
   size: 293031
   timestamp: 1726856737247
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
   sha256: 68a12eaeda90c9cdbce729f0d44d222c3f60ec4920bb781bf13fae3a89cb3dd1
   md5: a0970a5c1c77125369aded2d4e25f870
   depends:
@@ -5066,7 +5066,7 @@ packages:
   license_family: Other
   size: 1437665
   timestamp: 1655814938182
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cftime-1.6.2-py311hb9e55a9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cftime-1.6.2-py311hb9e55a9_0.tar.bz2
   sha256: 93f384d46e7938d7e971a4b556707f8beb2f1e62d5684e7cb893a6965aee4571
   md5: a6e1483f1a8157e872dce8f5f4a213a3
   depends:
@@ -5076,7 +5076,7 @@ packages:
   license_family: MIT
   size: 223790
   timestamp: 1679335421858
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
   sha256: aceaa74365b0d8e69c817639393df3a713a802f40645ac0bd2f39adc871acf54
   md5: 52191c9d4f4fcaeea39574819ab2f14f
   depends:
@@ -5085,7 +5085,7 @@ packages:
   license_family: BSD
   size: 204365
   timestamp: 1698129979494
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cloudpickle-3.0.0-py311hecd8cb5_0.tar.bz2
   sha256: 6289468ac6d509d11f928e80005c27fcc169be379c9714f839c305949fbc22af
   md5: 851f577d81bce100ddf9c11ded38da06
   depends:
@@ -5094,7 +5094,7 @@ packages:
   license_family: BSD
   size: 43158
   timestamp: 1721657395305
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
   sha256: 9270668e34b00a2605584a2db5130c83826855cd05b896ce949f3156fa197429
   md5: 2586aa55677e822e8285d777f9039ca9
   depends:
@@ -5103,7 +5103,7 @@ packages:
   license_family: CC
   size: 543487
   timestamp: 1709758497949
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
   sha256: 389c63a84b92a6254c9d361ebe970d537d0b88733efd5ac5c3ee58196fd2c5a9
   md5: c7bc5b3cbe76be83a27f00b7e4740727
   depends:
@@ -5113,7 +5113,7 @@ packages:
   license_family: BSD
   size: 17974
   timestamp: 1709323004148
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
   sha256: bebfc5aa6be12e61a134b580b07b67f7d8c045d6b113fca5b21fa1e83a2f03ce
   md5: 239df72a3921c951059fa8afc09643f6
   depends:
@@ -5124,7 +5124,7 @@ packages:
   license_family: BSD
   size: 287736
   timestamp: 1700583644534
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.2-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cytoolz-0.12.2-py311h6c40b1e_0.tar.bz2
   sha256: fd7bceb92f6c43c6b064a1258a33c441b3b39cd08883cb73204f8d0692b709fc
   md5: 37f8b661d31327b8dff70a4cfa63cd5b
   depends:
@@ -5134,7 +5134,7 @@ packages:
   license_family: BSD
   size: 390733
   timestamp: 1701729666753
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-2024.8.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/dask-2024.8.2-py311hecd8cb5_0.tar.bz2
   sha256: 0e4e4aa9b6d7b2a8781b98cf68d2754672eb6404fccca96cd43e2488448edfd5
   md5: 14178f9fc5a4fea048d521b715f3f52f
   depends:
@@ -5153,7 +5153,7 @@ packages:
   license_family: BSD
   size: 6339
   timestamp: 1725525026440
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2024.8.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/dask-core-2024.8.2-py311hecd8cb5_0.tar.bz2
   sha256: 3ad77286d59361920bdfe9af6e71d7f31cada0e56b1c1ee0731a0b560bc16d92
   md5: 31e739e79d93b568735a7db5cd201f52
   depends:
@@ -5170,7 +5170,7 @@ packages:
   license_family: BSD
   size: 3118893
   timestamp: 1725461414545
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-expr-1.1.13-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/dask-expr-1.1.13-py311hecd8cb5_0.tar.bz2
   sha256: 17d45edd99520c4f9ddfb8e97a2bb0833f2a939d4c158fd41b6f85b85dfe2284
   md5: 56a7c77c19b3ad5ecd2c18f2a69f461c
   depends:
@@ -5182,7 +5182,7 @@ packages:
   license_family: BSD
   size: 567529
   timestamp: 1725523260810
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.16.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/datashader-0.16.3-py311hecd8cb5_0.tar.bz2
   sha256: 9aaeb2715d1c3de8096c489b52ecb4c71d7341ee75bb5c3ace77c50c918ec5d4
   md5: 05a98a96b9cccb007768b87c11e92b7e
   depends:
@@ -5205,7 +5205,7 @@ packages:
   license_family: BSD
   size: 18011437
   timestamp: 1720534043633
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
   sha256: e0e30590a78d99d51445ac4f668aefe1bf20025a35bdbac00f04647b95c9f152
   md5: bd0db635eefeea82a0c567b39c9a0e3d
   depends:
@@ -5215,7 +5215,7 @@ packages:
   license_family: MIT
   size: 2485698
   timestamp: 1690905283575
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2024.8.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/distributed-2024.8.2-py311hecd8cb5_0.tar.bz2
   sha256: 2b998b9a1e6adbf62b2fdac9c43ff01eb1a7ea419d5bf74e137aea2e8c9f4ef5
   md5: 1b1cdc4f3aa302ebc27189d4d3e70878
   depends:
@@ -5239,7 +5239,7 @@ packages:
   license_family: BSD
   size: 1821812
   timestamp: 1725523177887
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
   sha256: d48b47b86b09dac1fa4542ec13e1bd4e23093638e684fa66ec3afdd9ce9337c1
   md5: 5a2d1828ab7c8eccd3c2610d13672977
   depends:
@@ -5248,7 +5248,7 @@ packages:
   license_family: MIT
   size: 17336
   timestamp: 1678316187749
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/expat-2.6.3-h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/expat-2.6.3-h6d0c2b6_0.tar.bz2
   sha256: e8786ba870f6f10e61b8314326799e0444f43b847bf048ef66c637d884043d54
   md5: 1bee23775ed30c66271a6597f02496ac
   depends:
@@ -5257,7 +5257,7 @@ packages:
   license_family: MIT
   size: 161686
   timestamp: 1725543368296
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fiona-1.9.5-py311hdb55bb0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fiona-1.9.5-py311hdb55bb0_0.tar.bz2
   sha256: 2fffd781f3a809bfa4cc1c01b663d40188784681274f82e431bf775e33ce1e89
   md5: d5686ab4bf4cb41246cdeb7cbbbe9662
   depends:
@@ -5280,7 +5280,7 @@ packages:
   license_family: BSD
   size: 1174208
   timestamp: 1704921471416
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/folium-0.14.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/folium-0.14.0-py311hecd8cb5_0.tar.bz2
   sha256: cf37efa8e371f0792d203309f571ab9c923ec10de4da2a4fb7163aa76e86fd0e
   md5: d392fab032965fa4ea1fd599e9eaa3f3
   depends:
@@ -5293,7 +5293,7 @@ packages:
   license_family: MIT
   size: 135501
   timestamp: 1678411970047
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fontconfig-2.14.1-h269ac6a_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fontconfig-2.14.1-h269ac6a_3.tar.bz2
   sha256: c05a2895ae7758e77eb03ab269d3181461de6909dbf93426bb2e580245230cc6
   md5: 1f34b1ef1a777b25daa69662f286b4bd
   depends:
@@ -5305,7 +5305,7 @@ packages:
   license_family: MIT
   size: 281575
   timestamp: 1722921216503
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
   sha256: 54645c22fabc25b632114d1d3c403a6fad9149b51ab36719b2690a084f14a072
   md5: a8ad2f4abfb2e17ecf6e596342528156
   depends:
@@ -5323,7 +5323,7 @@ packages:
   license_family: MIT
   size: 3180691
   timestamp: 1713551771692
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -5333,7 +5333,7 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freexl-2.0.0-hce1ea5d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freexl-2.0.0-hce1ea5d_0.tar.bz2
   sha256: 808936cc4ce749d1000a98a23d294b8c3f5acab0d729f2ea623103ea2231980f
   md5: d7ef6a25e5a84f2e53545815074dce21
   depends:
@@ -5344,7 +5344,7 @@ packages:
   license_family: OTHER
   size: 62266
   timestamp: 1704742027454
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.6.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fsspec-2024.6.1-py311hecd8cb5_0.tar.bz2
   sha256: 4316287b920b446149e5adf3519d12089b0c9ec49a8c1c802eee81c92d80132b
   md5: b52775f876eba6074e08a4d65328fad0
   depends:
@@ -5355,7 +5355,7 @@ packages:
   license_family: BSD
   size: 383995
   timestamp: 1724855682674
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/gdal-3.6.2-py311he4f215e_5.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/gdal-3.6.2-py311he4f215e_5.tar.bz2
   sha256: 90644d91b92a8f6b27dc28735e0b6020997383761097d409e262057f29db5a8d
   md5: 198ec689ebc32880f14617ff37b43c2d
   depends:
@@ -5368,7 +5368,7 @@ packages:
   license_family: MIT
   size: 2174393
   timestamp: 1722934875080
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/geopandas-0.14.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/geopandas-0.14.2-py311hecd8cb5_0.tar.bz2
   sha256: f0d5db2a531e1312187e8b5b7a6d253ad483cec5d71e599a13488b51e77f837d
   md5: 20fde68bdcb32bda259d204656c8be62
   depends:
@@ -5383,7 +5383,7 @@ packages:
   license_family: BSD
   size: 7728
   timestamp: 1704929099800
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/geopandas-base-0.14.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/geopandas-base-0.14.2-py311hecd8cb5_0.tar.bz2
   sha256: 31686dc79fc428a9ba9a55830c30360c3701815599d08b9ffbcfad2f586d7fa8
   md5: 90dafe9ab737e9bc186ef2ea808c627f
   depends:
@@ -5397,7 +5397,7 @@ packages:
   license_family: BSD
   size: 1513452
   timestamp: 1704929062065
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/geos-3.8.0-hb1e8313_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/geos-3.8.0-hb1e8313_0.tar.bz2
   sha256: ec1a020f11e34a94622a35fe338a640e688bd2a9959779e441496c575c1ebfd4
   md5: d43b2e34536205c250f9a9a699d39b84
   depends:
@@ -5405,7 +5405,7 @@ packages:
   license: LGPL-2.1
   size: 916394
   timestamp: 1592213531288
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/geotiff-1.7.0-hf6ff7a4_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/geotiff-1.7.0-hf6ff7a4_3.tar.bz2
   sha256: 20ad07d0b90bb478a9043f514413bf9d9cdec1a1eace392b32b0e0ce27987722
   md5: ff1f837d7dd22e46021db29c6d8460a5
   depends:
@@ -5418,7 +5418,7 @@ packages:
   license_family: MIT
   size: 134716
   timestamp: 1704901298585
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/geoviews-1.12.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/geoviews-1.12.0-py311hecd8cb5_0.tar.bz2
   sha256: 98838deb362872f4a9419c9be389d9b024e27ad017c4bb5c47bdef5d1181b8fe
   md5: bfe351abb9640ee70b1a9a51f110eafc
   depends:
@@ -5436,7 +5436,7 @@ packages:
   license_family: BSD
   size: 6722
   timestamp: 1713972716714
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/geoviews-core-1.12.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/geoviews-core-1.12.0-py311hecd8cb5_0.tar.bz2
   sha256: 4a2b98cba460308370067dc6f8df380d7eda047caf8058506690858d5053aa9e
   md5: 9fc251fa44cbe36ce7739e584b4f4af6
   depends:
@@ -5457,7 +5457,7 @@ packages:
   license_family: BSD
   size: 625015
   timestamp: 1713972701603
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/gettext-0.21.0-h4e8c18a_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/gettext-0.21.0-h4e8c18a_2.tar.bz2
   sha256: 9f2052e2c2f4e1d48b4315c3976c53afc5ff69399166f24432bb8c02f868fc27
   md5: eb9c4555f936f3998c0c5e462c44f0e9
   depends:
@@ -5470,7 +5470,7 @@ packages:
   license_family: GPL
   size: 3595681
   timestamp: 1722923856325
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
   sha256: 3c7aa54548409f9343e891820ea43c195b5e4e4dce6b761bc3ae9f6c8be0fc86
   md5: ed9629d6dc1612ec425eb8d27478b0f6
   depends:
@@ -5479,14 +5479,14 @@ packages:
   license_family: BSD
   size: 140316
   timestamp: 1706888243476
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
   sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
   md5: e4a732941f74b8062c8bcbfe5c5c2b56
   license: MIT
   license_family: MIT
   size: 80252
   timestamp: 1676983220161
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/glib-2.78.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/glib-2.78.4-hcec6c5f_0.tar.bz2
   sha256: 334df2c533e7dc057f37f8b736dc4d603f4619a4fb896cd931c9a784cc45d1ef
   md5: fcfa37c8700f34b6faf9cd5bef32de4d
   depends:
@@ -5499,7 +5499,7 @@ packages:
   license_family: LGPL
   size: 505762
   timestamp: 1708033264613
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/glib-tools-2.78.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/glib-tools-2.78.4-hcec6c5f_0.tar.bz2
   sha256: bc7c13b0656fa2972a121b18a236ebb6a38f59ef42e603741585be176293b514
   md5: 7d13cf328ebfdeb0f377f6da8c984a41
   depends:
@@ -5510,7 +5510,7 @@ packages:
   license_family: LGPL
   size: 104298
   timestamp: 1708033221652
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
   sha256: aed47f9ca4dd140b9c8a183e53d4b89eba84a20041d2038983cdfea8096104ef
   md5: c0d981d7d43eaad55950ff5e57206e70
   depends:
@@ -5520,7 +5520,7 @@ packages:
   license_family: BSD
   size: 97828
   timestamp: 1706895273858
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf4-4.2.13-h39711bb_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/hdf4-4.2.13-h39711bb_2.tar.bz2
   sha256: 85d7f9697d1243b5d088737a3f5c43610f01250f78e9a9fa9da6cca7830d73cf
   md5: 637b7dadcfe411e14233764fd1d820a3
   depends:
@@ -5531,7 +5531,7 @@ packages:
   license_family: BSD
   size: 895428
   timestamp: 1510863932515
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf5-1.12.1-ha01d115_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/hdf5-1.12.1-ha01d115_3.tar.bz2
   sha256: 4d93b05b1ae71c48560c7ca4088568388a5d13b7fbfa21cd7742a0f274ad0655
   md5: 9a6277d2d9e1ced54bbae133f98b1fc3
   depends:
@@ -5545,7 +5545,7 @@ packages:
   license_family: BSD
   size: 5830458
   timestamp: 1686164224072
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.19.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.19.1-py311hecd8cb5_0.tar.bz2
   sha256: d9dc05e6f02bcdb455cf0406270af8c94028b01b08d37c8dc5e3132d3c6856ca
   md5: 74987b12edb2c87b1e86d105302788d5
   depends:
@@ -5565,7 +5565,7 @@ packages:
   license_family: BSD
   size: 6083542
   timestamp: 1720534072421
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 50dee40e4a9ea7a035baeecc85770c88d63d4e6b0c3c2519c1429e881171150c
   md5: 4d465f453dca5c65224dccbe953f600c
   depends:
@@ -5582,7 +5582,7 @@ packages:
   license_family: BSD
   size: 359293
   timestamp: 1715090716440
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
   sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
   md5: f3ce6fe6eb760c236e5f7d04df5faa81
   depends:
@@ -5591,7 +5591,7 @@ packages:
   license_family: MIT
   size: 28138484
   timestamp: 1692293212596
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
   sha256: 5c2458964157fe493ca18c513c693b70cb622087e5fa0c93e65fc45217edd811
   md5: 15629e52625221b51a443cefd9501d12
   depends:
@@ -5600,7 +5600,7 @@ packages:
   license_family: BSD
   size: 148522
   timestamp: 1714398885844
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
   sha256: 5a17849341e4d43fc6aff44486425852c16dee6e1cbcab1ed3f2167350f55359
   md5: 445ac9df262ad2dcd86246a9ba5654b2
   depends:
@@ -5610,7 +5610,7 @@ packages:
   license_family: APACHE
   size: 51118
   timestamp: 1704813615186
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
   sha256: eb58fa29b1ce9aa5fc774d4c466696457695dec3b206456614b4c9cac0a94e42
   md5: 3d3291ff58dff83dcd40ec54b435f4d2
   depends:
@@ -5632,7 +5632,7 @@ packages:
   license_family: BSD
   size: 229910
   timestamp: 1705934029588
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.27.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.27.0-py311hecd8cb5_0.tar.bz2
   sha256: 901a391e792938d690a39cbe2551d7306bf85474bb0cff4e69088f78a9f5a26d
   md5: 84fa63c5f6182b1f06c3ffa5e611507d
   depends:
@@ -5650,7 +5650,7 @@ packages:
   license_family: BSD
   size: 1632976
   timestamp: 1726064292193
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.19.1-py311hecd8cb5_0.tar.bz2
   sha256: 9961222f1fb3a768e9c85a03761107809b321f4bc9af02d23289c59164bed7fe
   md5: c671e7d14b22780a7b1fa8632b0bf8ba
   depends:
@@ -5660,7 +5660,7 @@ packages:
   license_family: MIT
   size: 1178410
   timestamp: 1721058471712
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.4-py311hecd8cb5_0.tar.bz2
   sha256: b80384bec95335d8ad37895f5cfd2d8fdfaae7be05507f218344ddb5c6713d38
   md5: 8ac4f4807344f09b39c1b303cd2d1937
   depends:
@@ -5672,7 +5672,7 @@ packages:
   license_family: BSD
   size: 356777
   timestamp: 1716993516277
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/joblib-1.4.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/joblib-1.4.2-py311hecd8cb5_0.tar.bz2
   sha256: f6779df71ea45d589664943675ab424b3e9ee3dd649ede86b0d8c539c0f74aa8
   md5: 105bdce440491e4e03aa018d5311b8b8
   depends:
@@ -5681,21 +5681,21 @@ packages:
   license_family: BSD
   size: 545979
   timestamp: 1718217257856
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
   sha256: 855982a798d9af8e70635a250528a5da3b2b0cf7095e2804858caf139c8a239b
   md5: 112a5602fe42a84a5bafa038abeddf4f
   license: IJG
   license_family: Other
   size: 279686
   timestamp: 1722872676718
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/json-c-0.16-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/json-c-0.16-hca72f7f_0.tar.bz2
   sha256: 2258f53c5f89d5ef8151aa775041c91de132ae5b467c0fb89c283c0fedc46836
   md5: fc6b7ad3145ba86e7459b14fba98cd27
   license: MIT
   license_family: MIT
   size: 73431
   timestamp: 1659123708344
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
   sha256: 99fc6ac82c56eb2a580f96db24a5b887f8abc8c24af445d3313d5ebb48598478
   md5: 71892160908a6daedb5fb7c404079ae4
   depends:
@@ -5708,7 +5708,7 @@ packages:
   license_family: MIT
   size: 182073
   timestamp: 1699041732321
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 0ea44d0c8044e70ab0eaf4d6f5f3e4753838dee106b5cbd36561e21a65cbac77
   md5: 1d045016dca889d702f1caf3a16162fc
   depends:
@@ -5718,7 +5718,7 @@ packages:
   license_family: MIT
   size: 16528
   timestamp: 1699032525791
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
   sha256: 70442ec4b0b7ebbdcf150963f61f797b861001092124f4ea39a16eb92a4d176e
   md5: 63d1503915a15ae4f9ad1c46112ca374
   depends:
@@ -5734,7 +5734,7 @@ packages:
   license_family: BSD
   size: 272720
   timestamp: 1678316970740
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
   sha256: e657ec0667481d957827be1ce825b0a971aa3a211b07c1274d2c1099ded3129c
   md5: 5e317fd45011a0003c29331a8002cb75
   depends:
@@ -5745,7 +5745,7 @@ packages:
   license_family: BSD
   size: 98632
   timestamp: 1718818439542
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 2634d721123ea1e41b6e1cfe4a67552ec520ea9b5154c9e788ccb09d4745b732
   md5: e874eba19b493b7a68161429f24b8f51
   depends:
@@ -5761,7 +5761,7 @@ packages:
   license_family: BSD
   size: 43102
   timestamp: 1718738272613
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
   sha256: c353480ed4744c2a16aaccc1649bab38144436ad6d16ac2937e3e333d32fdccc
   md5: 7de25bdf4cfd3f5485d790d9cddf427f
   depends:
@@ -5788,7 +5788,7 @@ packages:
   license_family: BSD
   size: 619935
   timestamp: 1718828240904
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
   sha256: fd7964657f0a8fe8b167ba860b1f960e8b7b45309eb6c7c850d50ec283fe03b5
   md5: 2967bb345bc75f53182e263ff4743ca6
   depends:
@@ -5798,7 +5798,7 @@ packages:
   license_family: BSD
   size: 28223
   timestamp: 1686870845224
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
   sha256: 64cf59f0f74b0329b5069bc6135b4f40593f1dac52d85ad574d4b8e0a4b2cf16
   md5: 35e8b80eaa03a904fc7f1da39e7f654d
   depends:
@@ -5810,7 +5810,7 @@ packages:
   license_family: BSD
   size: 20234
   timestamp: 1700168776500
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kealib-1.5.0-h72c422f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kealib-1.5.0-h72c422f_1.tar.bz2
   sha256: 9deac634ad1c9c3d3285637f09d16659dc7a36d53ac40c0403e53bafd338edee
   md5: 652c4d08662f5de6049bb8d153c89218
   depends:
@@ -5820,7 +5820,7 @@ packages:
   license_family: MIT
   size: 170336
   timestamp: 1687966990145
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
   sha256: a12382b50416803f559a03fb384ba492c1dafa351e1191a3f8dc361bee6c4f37
   md5: f2ae846b663bbb642f4b1e90eaad38a3
   depends:
@@ -5830,7 +5830,7 @@ packages:
   license_family: BSD
   size: 64817
   timestamp: 1678322501509
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
   sha256: a3a24cd84c291f7c9e28842ccfc2107d149f0aa8e676b85d9104eda77622e603
   md5: 99ba4367783596d1bb0c7766ea6706ea
   depends:
@@ -5841,7 +5841,7 @@ packages:
   license_family: MIT
   size: 1290758
   timestamp: 1686931137388
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -5851,7 +5851,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -5860,7 +5860,7 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libabseil-20240116.2-cxx17_h548131f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libabseil-20240116.2-cxx17_h548131f_0.tar.bz2
   sha256: 8973f292fbdc61fb9a0f97746e6e4d2ad7a777e54400e7800de9b14f229a7999
   md5: 5524c45ff980ff65c2aa4bd106e7299a
   depends:
@@ -5873,7 +5873,7 @@ packages:
   license_family: Apache
   size: 1199721
   timestamp: 1716563412628
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
   sha256: 127dbf93874f1bb3493b312fecb5ffedb8f2a41d2470e2cbeb889eb58d89ebf7
   md5: 07502b61e43a2039e4312b40d53c1db1
   depends:
@@ -5888,13 +5888,13 @@ packages:
   license_family: OTHER
   size: 22584954
   timestamp: 1696762195023
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 685c3bc9068bd485604b80bf03789e4dca95c410d33871bc1b882e47649fabed
   md5: 6cf8e55271e150ca0961d0ddedaa61bb
   license: MIT
   size: 66237
   timestamp: 1714483284541
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 69826cee54db9955f0120af21ec36d13f9211877fd67364f2068d0a54c6c97cd
   md5: 0851917257f490d35e1f73da8a1c723c
   depends:
@@ -5902,7 +5902,7 @@ packages:
   license: MIT
   size: 34042
   timestamp: 1714483343147
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 3f5a1f03b50b90b397a0ee432ad0cba13354abdaf7e5652c0fc60164b26a08b6
   md5: a50bdc871ef4bf14deb088d888b92b5e
   depends:
@@ -5910,7 +5910,7 @@ packages:
   license: MIT
   size: 311597
   timestamp: 1714483371586
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.9.1-h3a17b82_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcurl-8.9.1-h3a17b82_0.tar.bz2
   sha256: 9ddb2cb85d3248d0e6f1aae2583078f84006632040ae3e7596dd7fbd303c0d1f
   md5: f983c731c77a28476bdded5141b2a942
   depends:
@@ -5925,21 +5925,21 @@ packages:
   license_family: MIT
   size: 394222
   timestamp: 1725034051587
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
   sha256: e84e6cbacb12de6fe86955449502d3956696ae583060d0d4911ea6f503cfb9ad
   md5: 1d200c536be4172db41c49e81a3e6350
   depends:
@@ -5948,14 +5948,14 @@ packages:
   license_family: BSD
   size: 169586
   timestamp: 1703006265367
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
   sha256: 4786264321edbff780633a5b752995eb3193ca4bce11b0fda179577f6cf1102c
   md5: 849fdd014c201a9d2c2aa7c7db38a778
   license: BSD-2-Clause
   license_family: BSD
   size: 103993
   timestamp: 1632891571494
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
   sha256: a60941a0365ee3e8b9ff721f75b0608c234b5652f53337a918b787839de4bb53
   md5: 4d61f019594ebccfb3f4fb87ee778416
   depends:
@@ -5965,14 +5965,14 @@ packages:
   license_family: BSD
   size: 414942
   timestamp: 1685052318462
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
   sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
   md5: 822a5b76117e56d3912f1f2153307528
   license: MIT
   license_family: MIT
   size: 136045
   timestamp: 1714483561919
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgdal-3.6.2-hfaf651c_5.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgdal-3.6.2-hfaf651c_5.tar.bz2
   sha256: 1a2ac5e7563c4590b37329d2f885723717ae8c2a97d24014e822b443d4fcb7d3
   md5: abd853f43d551e28b514b574d81a1bd6
   depends:
@@ -6018,7 +6018,7 @@ packages:
   license_family: MIT
   size: 10249856
   timestamp: 1722934547022
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
   sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
   md5: e458587c87e3f2d20192f4e0738f2c63
   depends:
@@ -6027,7 +6027,7 @@ packages:
   license_family: GPL
   size: 149419
   timestamp: 1665498987619
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
   sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
   md5: 1058b661ec829b2ee3716ee2a5520641
   depends:
@@ -6038,7 +6038,7 @@ packages:
   license_family: GPL
   size: 1917987
   timestamp: 1665498925405
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libglib-2.78.4-h19e1a8f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libglib-2.78.4-h19e1a8f_0.tar.bz2
   sha256: 63167624a93a9482d7fa3a79fcf8f2e93fe587db2d5b9f8e73581c07dcf7f33b
   md5: dd7eca3ab08ad18935ebdc7b4e4db2bc
   depends:
@@ -6054,7 +6054,7 @@ packages:
   license_family: LGPL
   size: 3122562
   timestamp: 1708033169400
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgrpc-1.62.2-hf2926fd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgrpc-1.62.2-hf2926fd_0.tar.bz2
   sha256: 451a1bafa405093889dfcc3669f0a679d300bd8c8770901be300832f72e0d359
   md5: b27400d99678fc64f10b5908ea05daed
   depends:
@@ -6074,14 +6074,14 @@ packages:
   license_family: APACHE
   size: 6917286
   timestamp: 1716835073567
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
   sha256: 9ff6ed0f0b9f9f27f449e95d11aa1c4e9e80028fd9d2a8caca5a15d8df88f435
   md5: 7b4b557afc66aba367da14d97d71934c
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1409885
   timestamp: 1714483704680
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libkml-1.3.0-h85bf17e_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libkml-1.3.0-h85bf17e_7.tar.bz2
   sha256: 45936f0f5c7e616f02e028fa75b2177af1ad16587190d350b0c54489dba96cb2
   md5: 66ef0c8cf08472f25fba622bdc99921c
   depends:
@@ -6093,7 +6093,7 @@ packages:
   license_family: BSD
   size: 435832
   timestamp: 1693261846695
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h26321d7_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libllvm14-14.0.6-h26321d7_4.tar.bz2
   sha256: 3c62b303d658923dfd5ef7385a6560c97865e5ad22df05f2822575dc2f2f61f6
   md5: 7a1ba247765a13e183f91bd5e857a0d6
   depends:
@@ -6104,7 +6104,7 @@ packages:
   license_family: Apache
   size: 27922606
   timestamp: 1726769388473
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnetcdf-4.8.1-h9f5a9a2_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libnetcdf-4.8.1-h9f5a9a2_4.tar.bz2
   sha256: 80783306d885b715879e295d854a6586b5b03828885f218a0be80d5c68b8d87d
   md5: dc1ead84c17a4758496bb51efe5d137d
   depends:
@@ -6119,7 +6119,7 @@ packages:
   license_family: BSD
   size: 1531548
   timestamp: 1691155070635
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
   sha256: 7bfcf69c31a4eb15dfab661c93463ce8dfb7b3de4356945fa5c1ca50a5ae0cb0
   md5: 4934bb34818fa3d99b32b9cb59fed205
   depends:
@@ -6134,7 +6134,7 @@ packages:
   license_family: MIT
   size: 784918
   timestamp: 1697018436251
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
   sha256: 499ebc9000c8e810081b5d7f7524b45dc99f6914096ea9e145366033514938b4
   md5: ce5c24f93932e1a53d7d89e502f28783
   depends:
@@ -6145,7 +6145,7 @@ packages:
   license_family: BSD
   size: 10123989
   timestamp: 1664896966769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -6154,7 +6154,7 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpq-12.17-h04015c4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpq-12.17-h04015c4_0.tar.bz2
   sha256: a50cb971a1f7590aa43e1d3cce5d997ff7ce52026e0819aa3e2d6b9fd6703c3a
   md5: 16c55d483601a4f5fcc0b0bdb59765c7
   depends:
@@ -6162,7 +6162,7 @@ packages:
   - openssl >=3.0.12,<4.0a0
   size: 2930205
   timestamp: 1706214610342
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-4.25.3-h34eed0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libprotobuf-4.25.3-h34eed0b_0.tar.bz2
   sha256: 22fddb84e3f771ee2a550da0dbe4caa334ac53b8a633ea566ec5b2e4cbb261cf
   md5: 1922ae6303e44e99aa04f54291240e1b
   depends:
@@ -6176,13 +6176,13 @@ packages:
   license_family: BSD
   size: 2688858
   timestamp: 1716567854254
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libspatialindex-1.9.3-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libspatialindex-1.9.3-h23ab428_0.tar.bz2
   sha256: aa1bca7ee910973ee9bb5b20d0f8c441aebf409983118a12e835edb65297ead5
   md5: 10a339fb0866adb3eda36b776263dc99
   depends:
@@ -6190,7 +6190,7 @@ packages:
   license: MIT
   size: 415040
   timestamp: 1616086763917
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libspatialite-5.1.0-hd7ca590_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libspatialite-5.1.0-hd7ca590_1.tar.bz2
   sha256: f9034aa07ff8b221fbf027a7018d771e0b2911c6ae6e8c582247249f33a69bb4
   md5: 11cb32d275d9b44be5ce352978f30d62
   depends:
@@ -6207,7 +6207,7 @@ packages:
   license_family: OTHER
   size: 4233996
   timestamp: 1722878959147
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.11.0-hf20ceda_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libssh2-1.11.0-hf20ceda_0.tar.bz2
   sha256: de5335a49a6eabc7b722fa68192f7f5bd3b3c8221fc8d8138d3ef9406a09e5b7
   md5: 7112df7af035d166dc6fa941936355a0
   depends:
@@ -6217,7 +6217,7 @@ packages:
   license_family: BSD
   size: 260849
   timestamp: 1715261514683
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
   sha256: 21ba71cdc65b56c6daefeeab55959e5a7edadfd697cfa8b2ed5c1b3e2a98586b
   md5: cbbd369ee87aba597c942727bada4eee
   depends:
@@ -6230,7 +6230,7 @@ packages:
   license_family: Apache
   size: 364326
   timestamp: 1687975317748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -6247,7 +6247,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
   sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
   md5: 46a65d1fc24013217e06aaf6d65ffcad
   constrains:
@@ -6256,7 +6256,7 @@ packages:
   license_family: BSD
   size: 425478
   timestamp: 1694776947990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.13.1-h6070cd6_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxml2-2.13.1-h6070cd6_2.tar.bz2
   sha256: d32f24c3ee7f6be0b69b8b175d3cfa5a8b173447dfe34481ee2616f9bf974b0e
   md5: 096ea9157e07c0e0f7fd213eb34cf615
   depends:
@@ -6268,7 +6268,7 @@ packages:
   license_family: MIT
   size: 632182
   timestamp: 1722441134391
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libzip-1.8.0-h29ab7a1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libzip-1.8.0-h29ab7a1_1.tar.bz2
   sha256: 2702cf5076d06c373f9198ae4c8a6e426f6c32b11e94bc9f2c911fe20426dd0a
   md5: 5bd1fe81fac32de5a39a9bb9bc50d1e5
   depends:
@@ -6282,7 +6282,7 @@ packages:
   license_family: BSD
   size: 122019
   timestamp: 1685378564524
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
   sha256: d28c465ec6d5f8d4962c597b249b58998300c8b4e3c937c578c3d15294ea863d
   md5: dcaed6ddd0723c7cce6bfad917be98b2
   depends:
@@ -6292,7 +6292,7 @@ packages:
   license_family: MIT
   size: 41176
   timestamp: 1678413498410
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
   sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
   md5: 5c740b4a18a558de0ccfe601703c423c
   constrains:
@@ -6301,7 +6301,7 @@ packages:
   license_family: Apache
   size: 338738
   timestamp: 1662635677689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.43.0-py311h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.43.0-py311h6d0c2b6_0.tar.bz2
   sha256: 73052ee16f6d1df70d79c0258dc4e08af8840812e2d1c04a2edbb87c10ba5a34
   md5: cd252d6bdabf736def933eb57332d0b5
   depends:
@@ -6312,7 +6312,7 @@ packages:
   license_family: BSD
   size: 404923
   timestamp: 1720455346980
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
   sha256: 716a654df2e55052193150015bd5c9856b847893fc5a229fa8669725b1c56ff2
   md5: 687ba6c11de38ad7cc597f7188b491e7
   depends:
@@ -6321,7 +6321,7 @@ packages:
   license_family: BSD
   size: 13357
   timestamp: 1678322560230
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-4.3.2-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-4.3.2-py311h6c40b1e_0.tar.bz2
   sha256: e05d6b661c088efc3f7f2fc99b8faad351f7660963ca66fbe63dfc9796821eb2
   md5: d48a23f7e388334d5e39fc36ee84441b
   depends:
@@ -6331,7 +6331,7 @@ packages:
   license_family: BSD
   size: 37947
   timestamp: 1686058038545
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
   sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
   md5: 8f57dc3a3327bb6f7e1cba908856ac7f
   depends:
@@ -6340,7 +6340,7 @@ packages:
   license_family: BSD
   size: 183138
   timestamp: 1714510756758
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mapclassify-2.5.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mapclassify-2.5.0-py311hecd8cb5_0.tar.bz2
   sha256: bd2bb7d2150c5ee749287bcd09f8738d86c58689f252b64f78ad0cb6798696d9
   md5: a0e839113d9bfb31e247e483158648f4
   depends:
@@ -6354,7 +6354,7 @@ packages:
   license_family: BSD
   size: 83276
   timestamp: 1678417691421
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
   sha256: 6fb2953e169ee1ae38f24d29752051501992f19b96b5ebcea9af75737bdbcb42
   md5: 7f410cdae838c5030108d1b98a8c78f6
   depends:
@@ -6363,7 +6363,7 @@ packages:
   license_family: BSD
   size: 162478
   timestamp: 1678377892595
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
   sha256: cd97e09a12ffb49b2a30a782fa8c7933b28f5ffdbfc5c73a9ebaa95fc9447370
   md5: d1fb6ebc1e5728aa6377cfc71da08942
   depends:
@@ -6373,7 +6373,7 @@ packages:
   license_family: MIT
   size: 135859
   timestamp: 1684280005320
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
   sha256: 30c3b189462a9d0f4794d229adadf34b5f5a5f56f95c30d5afc17ef524579290
   md5: d4e9421243129d1d57c472dab045f3dc
   depends:
@@ -6384,7 +6384,7 @@ packages:
   license_family: BSD
   size: 26639
   timestamp: 1704206159955
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.9.2-py311hc25a08b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.9.2-py311hc25a08b_0.tar.bz2
   sha256: 5fddd37bbe579892257bf574bc0b5199b97a3ba8addbf2ec73e5147609eae7cb
   md5: 30837287c1590ec271189cb315be35d1
   depends:
@@ -6404,7 +6404,7 @@ packages:
   license_family: PSF
   size: 9456494
   timestamp: 1725264308019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
   sha256: 07e7fd5bd64e55328b4b99d92e2e2600d791f1095bf905daab4cfc59f0f0a45b
   md5: cf53321779f4ca7e986c1468719b93f1
   depends:
@@ -6414,7 +6414,7 @@ packages:
   license_family: BSD
   size: 19500
   timestamp: 1678317565001
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
   sha256: 0770e02be1ea1216af493cfc03d5b8a702e14606fa93b0692bcdab1fed1b898c
   md5: ca6f06ceaf66a32bbf5dfdb6e373a5cf
   depends:
@@ -6424,7 +6424,7 @@ packages:
   license_family: MIT
   size: 67892
   timestamp: 1678417734353
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
   sha256: fbe95ed0501bb0f137048476fe41bc718dd659e8ecb066bc67ac17d6a50f4318
   md5: ec162bde8d1c8a107b257df218b17035
   depends:
@@ -6433,7 +6433,7 @@ packages:
   license_family: MIT
   size: 23030
   timestamp: 1678381838497
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/minizip-4.0.3-h79ad51c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/minizip-4.0.3-h79ad51c_0.tar.bz2
   sha256: 083706ad4e1c7cca21b8a7c2f98731f6d89c6f93027b0144a05dc2cf780b0104
   md5: bad45529dbe30d5171372b53569c433a
   depends:
@@ -6448,7 +6448,7 @@ packages:
   license_family: Other
   size: 84756
   timestamp: 1702658569259
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
   sha256: c20dd678655e582129a858a1c5162bdc254082d3a3c035b0f72629d9276e5b75
   md5: 800a0738c728796e02d0386ce7d457aa
   depends:
@@ -6459,7 +6459,7 @@ packages:
   license_family: BSD
   size: 104585
   timestamp: 1678317269407
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py311ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/msgpack-python-1.0.3-py311ha357a0b_0.tar.bz2
   sha256: 7517bb3a1337287e71ba182e23654f49275048389a1a3c6d750dc580caf4aaed
   md5: 5466d265b312c4ff0ff4969ebf15c0ce
   depends:
@@ -6469,7 +6469,7 @@ packages:
   license_family: Apache
   size: 37529
   timestamp: 1678318290205
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
   sha256: 638450a7ccb5f438ac65aa1c8d871fb5bb664e7261ec7e663d0302485c219a67
   md5: 574875bbeabff85b5d9cfdb62066aece
   depends:
@@ -6479,7 +6479,7 @@ packages:
   license_family: BSD
   size: 29473
   timestamp: 1678392919304
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
   sha256: f961b1322b6b02fee53ff9bd0f56bb73886eb59debd3f3666669593de7f48894
   md5: a1e74ccd2f341d1d672e33d79e60d200
   depends:
@@ -6492,7 +6492,7 @@ packages:
   license_family: BSD
   size: 8183400
   timestamp: 1717623127275
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
   sha256: e08cb3ee6df01f4c1e1ac8bc4ed1a06e549ffcc8774fe2e2842c644bb8f74a86
   md5: 6ba0ae0fb14cbea1e3197707701dc180
   depends:
@@ -6505,7 +6505,7 @@ packages:
   license_family: BSD
   size: 123077
   timestamp: 1698934356774
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 2f946b5042eaac97206b5217fb203f3604ab3a60aecd99bdfc684925e3136c18
   md5: b24026076c381ff2009e7acb9e0a6e87
   depends:
@@ -6532,7 +6532,7 @@ packages:
   license_family: BSD
   size: 534650
   timestamp: 1699022791300
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
   sha256: ba368605a0af6f1dcbdcb6fddab9ce63224a85dd11bfb2b1acace1dc17899411
   md5: 91f3ea3fe44d619ee95a6ed3773a0814
   depends:
@@ -6545,14 +6545,14 @@ packages:
   license_family: BSD
   size: 170926
   timestamp: 1694616830121
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
   sha256: 42d803e1d8b54748db5d989ecd503826f564132df7cddc20f520460f55e523a1
   md5: cd3fa71626ebc098da4625fc6be79752
   depends:
@@ -6561,7 +6561,7 @@ packages:
   license_family: BSD
   size: 16952
   timestamp: 1708532805951
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/netcdf4-1.6.2-py311h42ba51d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/netcdf4-1.6.2-py311h42ba51d_0.tar.bz2
   sha256: 33a5c9bbe9945c87ab4e3b01cbd81f87fe01e135f4b17fcee672365b90181552
   md5: bd6ad59e329f2f23ab865858336ba5ad
   depends:
@@ -6575,7 +6575,7 @@ packages:
   license_family: MIT
   size: 461123
   timestamp: 1678393009528
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/networkx-3.3-py311hecd8cb5_0.tar.bz2
   sha256: e9e4b82191d34175fd8339d31322ca7a845e0fb577ec72f7dbd7cd5de8b35808
   md5: 72e37904339e00f27f47843a0c6d0bce
   depends:
@@ -6593,7 +6593,7 @@ packages:
   license_family: BSD
   size: 3343264
   timestamp: 1720002820058
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
   sha256: 09d88f1eb19a90dfe737f0e5b4dce7629f6076a2d91d572cbb0a41be5220a4e8
   md5: ac8c26d949a04f478b560b7d8a2358a4
   depends:
@@ -6618,7 +6618,7 @@ packages:
   license_family: BSD
   size: 707187
   timestamp: 1717630829258
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
   sha256: ed5608feb37a083d47b04203195260e801b64b5380f292cf18bb61e7ad827a2a
   md5: daa9c1c233673b727528548454aea664
   depends:
@@ -6628,7 +6628,7 @@ packages:
   license_family: BSD
   size: 27607
   timestamp: 1699456006797
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nspr-4.35-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nspr-4.35-hcec6c5f_0.tar.bz2
   sha256: f006a4418ca8a5788d67fa836a89a236be9925b9dd7744a45cdec18d053a221d
   md5: 4d90323cc76987c69a1c1d3996af71c0
   depends:
@@ -6637,7 +6637,7 @@ packages:
   license_family: OTHER
   size: 257208
   timestamp: 1685541796770
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nss-3.89.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nss-3.89.1-hcec6c5f_0.tar.bz2
   sha256: 0ee6d4545add1a4649506c1a69cb491a908ca5e47b386f9196485c3b5a9c371b
   md5: 905b6e1c124eeba9dc9f338fd29932ec
   depends:
@@ -6649,7 +6649,7 @@ packages:
   license_family: OTHER
   size: 2130955
   timestamp: 1685543311945
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.60.0-py311he327ffe_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numba-0.60.0-py311he327ffe_0.tar.bz2
   sha256: 91c63f3ac3b610a957169b06171366da4cfd1f8eca7b484ee66c524de739e40c
   md5: a1cc844a9046142569d89d3642ee460f
   depends:
@@ -6671,7 +6671,7 @@ packages:
   license_family: BSD
   size: 6145701
   timestamp: 1720541086329
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h91b6869_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py311h91b6869_0.tar.bz2
   sha256: b0c5c5239e83c629d77abc36d4de7e38c9d085c62e24197d3330b4b6e5de75d9
   md5: 44fa81f89a7977c4f80cf3dc4cbf1d72
   depends:
@@ -6684,7 +6684,7 @@ packages:
   license_family: MIT
   size: 165510
   timestamp: 1696515774706
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h91b6869_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.4-py311h91b6869_0.tar.bz2
   sha256: 85aa18f7f372d263f1b9a6eed279e0fa048387520bf71b9c409e13801a0568d4
   md5: c077c784069f04cc487620bcdc7707ea
   depends:
@@ -6697,7 +6697,7 @@ packages:
   license_family: BSD
   size: 11321
   timestamp: 1708642350281
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311hb3ec012_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.4-py311hb3ec012_0.tar.bz2
   sha256: bc050bacb16826ee23329eed65b63c2625884e2af1853f901f7e09870c7dbd1f
   md5: 96b8308a1bdb2f1e77698ea9fdf96bf3
   depends:
@@ -6711,7 +6711,7 @@ packages:
   license_family: BSD
   size: 8784964
   timestamp: 1708642301649
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
   sha256: 401214a4763c79c2355b012b9f29e3cee097a598bb53e933acb6b98a2bb6614f
   md5: 3216c5f433643ee62a8d0672c3500320
   depends:
@@ -6722,7 +6722,7 @@ packages:
   license_family: BSD
   size: 535252
   timestamp: 1722872704730
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.15-h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.15-h46256e1_0.tar.bz2
   sha256: 8cc69ca3f77c9dc8bed662100046085536c6a95b77b2a964ba79fc81ba3f698a
   md5: 270474613701d2371d5c5cc220a78825
   depends:
@@ -6731,7 +6731,7 @@ packages:
   license_family: Apache
   size: 4961721
   timestamp: 1725545867722
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-2.0.1-h5747287_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/orc-2.0.1-h5747287_0.tar.bz2
   sha256: ca2972eb0d95b834238106df2b3bbb6efdb07ea2e9080a718669d8a1dc65f4cd
   md5: 2fe36bccf7d2d86be813bda00878a7f0
   depends:
@@ -6748,7 +6748,7 @@ packages:
   license_family: Apache
   size: 526130
   timestamp: 1717104747125
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
   sha256: 8a0809f419065e014cb8e2c8a516cadca6088fb71fd1ef3ae2287d91e3360d59
   md5: 4dc0b9bc88476fcc5246d823ff1c289a
   depends:
@@ -6757,7 +6757,7 @@ packages:
   license_family: APACHE
   size: 39645
   timestamp: 1699371213055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-24.1-py311hecd8cb5_0.tar.bz2
   sha256: dfeced2b57d53e4aaaf5e855c2f10b505ee74c486594bbe4b132843f12806ff3
   md5: 05b50489c5ee7b2d5b5750f51cca96c1
   depends:
@@ -6766,7 +6766,7 @@ packages:
   license_family: Apache
   size: 158201
   timestamp: 1720101976586
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.2-py311he327ffe_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-2.2.2-py311he327ffe_0.tar.bz2
   sha256: 878e8fbcca40ac0c3937780160c22b65633b32ac97a886a9e38d4453821fe8bb
   md5: ac61107a8dd7a5a51e19e57fcc3a7a5a
   depends:
@@ -6816,7 +6816,7 @@ packages:
   license_family: BSD
   size: 17291576
   timestamp: 1718309206876
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-1.4.4-py311hecd8cb5_0.tar.bz2
   sha256: 757d6789ddb8227afd02da27fb30d1339091c8bda8f9905011a591eaa3fc6147
   md5: 7445a0d4f67a8063b19c6372d1f8b02f
   depends:
@@ -6840,7 +6840,7 @@ packages:
   license_family: BSD
   size: 21789913
   timestamp: 1718119269606
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-2.1.1-py311hecd8cb5_0.tar.bz2
   sha256: a33f52ee58e7856ff19bd306a7c055950d669199981874a38c2bdb1896725c8f
   md5: 7aef330f65dd9dd63a06c89ddfb3b7bd
   depends:
@@ -6849,7 +6849,7 @@ packages:
   license_family: BSD
   size: 267605
   timestamp: 1719348049109
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
   sha256: 359b31da651ee35b9ca43974d26cd44e64f3cf412096c15dec7b720fa909a9b2
   md5: 108e24227f8fdfc4d635bb4eedfa6cef
   depends:
@@ -6863,7 +6863,7 @@ packages:
   license_family: BSD
   size: 48504
   timestamp: 1698702608965
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pcre2-10.42-h9b97e30_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pcre2-10.42-h9b97e30_1.tar.bz2
   sha256: e18ec8727b8f74eb87a3c8945953c97de9b065aabcad272ece12972b854d964c
   md5: 2a4a10038d1f8d6bb80609fdeb0ac324
   depends:
@@ -6873,7 +6873,7 @@ packages:
   license_family: BSD
   size: 3403226
   timestamp: 1714657724735
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.4.0-py311h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.4.0-py311h46256e1_0.tar.bz2
   sha256: cad086496c3ebc1d2a36932c49756595c89e1f2e1afe9fa8237a61136a9c49de
   md5: 707e1417a63a43f98ab2da22d1f138ff
   depends:
@@ -6889,7 +6889,7 @@ packages:
   license_family: Other
   size: 959109
   timestamp: 1721059511981
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-24.2-py311hecd8cb5_0.tar.bz2
   sha256: 492ea4d1c5a4f860f3312c7729f1e33b706007578c25c031241d7497a115dd79
   md5: 835f4767cdb9d80338e0bba649c1ce3c
   depends:
@@ -6900,13 +6900,13 @@ packages:
   license_family: MIT
   size: 2923519
   timestamp: 1723484652903
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pixman-0.40.0-h9ed2024_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pixman-0.40.0-h9ed2024_1.tar.bz2
   sha256: 39981af6952de4e207cf6e5e769cb5b9c50f30cfd71a1fd97d6d3eef5feb5a6a
   md5: ecb58f854cae469740631c23643c9c95
   license: MIT
   size: 617807
   timestamp: 1632711594755
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 81719c31101d6c019150cedcc7b08adb3bdb357e8b2952e428dadaabc4dc985d
   md5: 105825168e0a17fb007f60b5f314e311
   depends:
@@ -6915,7 +6915,7 @@ packages:
   license_family: MIT
   size: 38405
   timestamp: 1692205731769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pooch-1.7.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pooch-1.7.0-py311hecd8cb5_0.tar.bz2
   sha256: cd08f6e326bb6422407b242047b2528d1ec4e1127d764315859fd92b376c6abb
   md5: 43dad20bf1b2e021c9079985acb21d5d
   depends:
@@ -6931,7 +6931,7 @@ packages:
   license_family: BSD
   size: 106484
   timestamp: 1695850216139
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/poppler-22.12.0-ha8a1649_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/poppler-22.12.0-ha8a1649_3.tar.bz2
   sha256: 36845a06f9abfb4ee06e24d1f9e57c2f8cded0c323491221862d45f929df6a34
   md5: 8cb3c1e1fa4d3ed2f1589fdd2f686108
   depends:
@@ -6957,14 +6957,14 @@ packages:
   license_family: GPL
   size: 1833586
   timestamp: 1696000908395
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/poppler-data-0.4.11-hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/poppler-data-0.4.11-hecd8cb5_1.tar.bz2
   sha256: 31fbd1899e753b454dc825d85e2cd9a0506107e772f5d5d307d4f234586c0059
   md5: 54f685f65e667e076c4a7cb36f23f26e
   license: GPL-2.0-or-later and GPL-3.0-or-later and BSD-3-Clause
   license_family: GPL
   size: 3839936
   timestamp: 1673863552033
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/proj-9.3.1-h1972728_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/proj-9.3.1-h1972728_0.tar.bz2
   sha256: 0db91133b64eae7b15583577af715638e73643704016e60b06c8ed675cd8029c
   md5: e4d22e27045add53f9e03c4578052b0a
   depends:
@@ -6978,7 +6978,7 @@ packages:
   license_family: MIT
   size: 3101265
   timestamp: 1704728694567
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
   sha256: c0982f688127129e026d2b4cdacdd5684d00796ea7bdadd7d26b1101b095d723
   md5: 0d6910c74729fede645c010110f1c89e
   depends:
@@ -6987,7 +6987,7 @@ packages:
   license_family: Apache
   size: 121796
   timestamp: 1679340253537
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
   sha256: e32843723b10ecd9badde28e1085419c0b59ed8a96c7cacce6395e39e3a874f9
   md5: 5af0280a817d2c273304cd22328124af
   depends:
@@ -6999,7 +6999,7 @@ packages:
   license_family: BSD
   size: 763044
   timestamp: 1704404460779
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
   sha256: 117a435c2473e2a20cc81eaacb2b45ea5e7fe3c946eec2915936d344913ede44
   md5: 0f459ee59fda20e2077fdc2c777edfc8
   depends:
@@ -7008,7 +7008,7 @@ packages:
   license_family: BSD
   size: 497470
   timestamp: 1679337286052
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-16.1.0-py311he327ffe_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyarrow-16.1.0-py311he327ffe_0.tar.bz2
   sha256: e2b32bbc6715d76823cf6b4dfc1b3545002970cddbc91dca79b8778e6f86598d
   md5: 06d164d039ad06fae027abb6ce8078ba
   depends:
@@ -7020,7 +7020,7 @@ packages:
   license_family: Apache
   size: 4943656
   timestamp: 1721666101702
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
   sha256: 667b5cf00d31293dede2ddadcc30ab967103d585d40647f34d6d830af97ee51f
   md5: 81d3876fa502fca91ba4136a5f3fc3d3
   depends:
@@ -7032,7 +7032,7 @@ packages:
   license_family: BSD
   size: 37821
   timestamp: 1678378977816
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
   sha256: dfb403f367c57327a4d080109df88383ecff18464de287a1ce936a7274e3656b
   md5: 997b674bad89963af875b93b06807f51
   depends:
@@ -7041,7 +7041,7 @@ packages:
   license_family: BSD
   size: 2120413
   timestamp: 1684280057020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.1.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.1.2-py311hecd8cb5_0.tar.bz2
   sha256: f9241d840cf4d8257796d1a5b8fb36155081165fa83f987e57afd4fbf93aaa9f
   md5: 31b77244b3c1a71ea5299ce2297dced7
   depends:
@@ -7050,7 +7050,7 @@ packages:
   license_family: MIT
   size: 459515
   timestamp: 1725041684172
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyproj-3.6.1-py311h717f92e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyproj-3.6.1-py311h717f92e_0.tar.bz2
   sha256: 64cc50f1f03f2fceee7e762683bc057a33645576bf950e524b999adfdd05c3a8
   md5: bc7e6f8d55f35b35cf7204d50d713ea2
   depends:
@@ -7061,7 +7061,7 @@ packages:
   license_family: MIT
   size: 594660
   timestamp: 1704904798330
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyshp-2.3.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyshp-2.3.1-py311hecd8cb5_0.tar.bz2
   sha256: c5da7585044b6530d15e60bc240c4461c978bfe7ab93d1bd8b65c09b2a56e7e4
   md5: ff8fe62b78400d75cba37dfef852028a
   depends:
@@ -7070,7 +7070,7 @@ packages:
   license_family: MIT
   size: 86946
   timestamp: 1706101003087
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 717e038567506ca58ce1cd4a3416892d02f4ebfdd332077cc3d110cfe3d36c58
   md5: 53bbfb400668f798eef6f8c7cf938e1f
   depends:
@@ -7079,7 +7079,7 @@ packages:
   license_family: BSD
   size: 35751
   timestamp: 1678315886516
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
   sha256: 092dea8d520acff3e64c71155e666b0b6074d37a71d5eb32f3cd485b0d185d0b
   md5: 9fbaf2d9534c26e76aa14b11b23de332
   depends:
@@ -7098,7 +7098,7 @@ packages:
   license_family: PSF
   size: 16852220
   timestamp: 1713545835789
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
   sha256: 04e100d0a1ea9722e24972657ec5935ad34c7c58957dabb821333e5eac80f717
   md5: 2b6de49ad07b26e1f7084f0fda958eb1
   depends:
@@ -7108,7 +7108,7 @@ packages:
   license_family: BSD
   size: 332276
   timestamp: 1716495830117
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
   sha256: 514249897265f66f6ecca0a4427eb02a43c33b3c24974db16d05db6bbe97881d
   md5: c9ea1437e5a3ba6a52ec2322505203e6
   depends:
@@ -7117,7 +7117,7 @@ packages:
   license_family: BSD
   size: 279116
   timestamp: 1679338758489
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
   sha256: 78b785b9b6ed46c86b0d3a32bdceea49f816672227fb63e726b2d46eadbdba0b
   md5: 79d783f74359141e0b06a848db33823b
   depends:
@@ -7126,7 +7126,7 @@ packages:
   license_family: BSD
   size: 18563
   timestamp: 1683823935261
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py311hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-lmdb-1.4.1-py311hcec6c5f_0.tar.bz2
   sha256: ceed2007dc80313fab055da9ad855aeff4178bfa03c16e78297fb77d058e6972
   md5: 753c157b80f60f263e0fe6a2f8d4fc85
   depends:
@@ -7136,7 +7136,7 @@ packages:
   license_family: Other
   size: 151925
   timestamp: 1682522457855
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
   sha256: e358fe679e83ccdc8c433746ae6468e8e96d90d97d99530f8476ef5630b2c121
   md5: ce30a0a31d891e69dc9b7bf8b7f0c39c
   depends:
@@ -7145,7 +7145,7 @@ packages:
   license_family: MIT
   size: 268876
   timestamp: 1713974360942
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
   sha256: eeb5a5eed93b8e311ad4d3f4389e050f11bba2eaec9536e1c3ed2f849c6c999b
   md5: c18bd3e12de797d52a470c21a150dffe
   depends:
@@ -7157,7 +7157,7 @@ packages:
   license_family: BSD
   size: 65270
   timestamp: 1711136914884
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
   sha256: c3e11ed944da69c11b949bb918341a0d79ef603ee34a632d6a45fbf89ff924a1
   md5: fee7ff4d291f530b4cecb575f29807a0
   depends:
@@ -7167,7 +7167,7 @@ packages:
   license_family: MIT
   size: 197996
   timestamp: 1698096137432
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
   sha256: aa07b90a7ee65f76c8cba1ff99a5cdeb95cbe41881ae951f64ffff06674a1b2d
   md5: 58621e3d244137885f7dfbb35e50340a
   depends:
@@ -7177,7 +7177,7 @@ packages:
   license_family: Other
   size: 594801
   timestamp: 1709318510622
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/qhull-2020.2-ha357a0b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/qhull-2020.2-ha357a0b_2.tar.bz2
   sha256: 35d47041555b4277b30abb836fbc815350a644ba3c4bd4f2e2ea73397c554f2f
   md5: 5f3c1d74767029f19e9c2bd8172b557b
   depends:
@@ -7186,7 +7186,7 @@ packages:
   license_family: Other
   size: 2019896
   timestamp: 1670915867737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
   sha256: c69f556df9a27328c56943f3b5918cbb953cfbca987e20394d823a6174781202
   md5: ab294ae71ecdfaa307a961cc71dd890d
   depends:
@@ -7194,7 +7194,7 @@ packages:
   license: BSD-3-Clause
   size: 205638
   timestamp: 1652449553607
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -7203,7 +7203,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
   sha256: d784dc26c5de8e41845350a899e5779250b71f45d39e2aece62e739e9add7308
   md5: 7b077b7f46112bb31dc066396c51d3fa
   depends:
@@ -7214,7 +7214,7 @@ packages:
   license_family: MIT
   size: 74776
   timestamp: 1699012164201
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.32.3-py311hecd8cb5_0.tar.bz2
   sha256: b1cfb76aa4576efad11927b3eea426d844c1676426d6cbea779070c51c4ab1c2
   md5: 4bf97d09384f54359a8ba8c65b400331
   depends:
@@ -7230,7 +7230,7 @@ packages:
   license_family: Apache
   size: 124536
   timestamp: 1721410924789
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
   sha256: 727fb8d957e02d03b928d049ffbc712316f176a2c331391766d646621b45655a
   md5: 7e0e416c642f3ee4ddfb084a811fb4df
   depends:
@@ -7240,7 +7240,7 @@ packages:
   license_family: MIT
   size: 10236
   timestamp: 1683077214314
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
   sha256: a8a67143ccb65cfd6f50055176b6c26179a83130a45d0a12e79dd2de68d8db63
   md5: a2065790f41e3eeb6efe0ef6daa75377
   depends:
@@ -7249,7 +7249,7 @@ packages:
   license_family: MIT
   size: 10600
   timestamp: 1683059285216
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
   sha256: 6aba582338faa0c26fe336bdb10c65b8f7808a6e383bd8f80f3e6b612ca209ec
   md5: a7486349b5f7370f6902c2050a23d268
   depends:
@@ -7258,7 +7258,7 @@ packages:
   license_family: MIT
   size: 319197
   timestamp: 1698946203341
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rtree-1.0.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rtree-1.0.1-py311hecd8cb5_0.tar.bz2
   sha256: 99624c139335e8bae5767a7bdd215d241e943ea392e297170a311bf46c52b412
   md5: c617fa66cf6b725005202251b1d066bc
   depends:
@@ -7269,7 +7269,7 @@ packages:
   license_family: MIT
   size: 63077
   timestamp: 1678394121817
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scikit-learn-1.5.1-py311he327ffe_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/scikit-learn-1.5.1-py311he327ffe_0.tar.bz2
   sha256: 3260b532a642a5367b2ae8a82fd035269fde02b3a03c810dd6e7e383443da8bc
   md5: 8f0399f0961818e462a35d6ca6c650d9
   depends:
@@ -7285,7 +7285,7 @@ packages:
   license_family: BSD
   size: 12471929
   timestamp: 1721924399924
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.13.1-py311hedc7b93_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/scipy-1.13.1-py311hedc7b93_0.tar.bz2
   sha256: 34a7676f0206358af5382dde5277545feca8d14976a0de8f7c76bef2924fc48b
   md5: bc42006faf0a94d5479e5836df7dc071
   depends:
@@ -7303,7 +7303,7 @@ packages:
   license_family: BSD
   size: 27740042
   timestamp: 1717602667679
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
   sha256: beba0555707dac1e8484d73cee9e4128ac4b10e2a0d4209357481179022e8fdc
   md5: baa8b304607b3a9ae8a3d9acb354c31c
   depends:
@@ -7312,7 +7312,7 @@ packages:
   license_family: BSD
   size: 33343
   timestamp: 1699371216044
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-75.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-75.1.0-py311hecd8cb5_0.tar.bz2
   sha256: c6e56b4a14e883c7296b52673b4129e933d2bcfe45fafd8b504e62442aa290ba
   md5: e658b6de04d59ad8fb45391c7e8dce54
   depends:
@@ -7321,7 +7321,7 @@ packages:
   license_family: MIT
   size: 2318419
   timestamp: 1726678116770
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/shapely-2.0.5-py311h41c673d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/shapely-2.0.5-py311h41c673d_0.tar.bz2
   sha256: 784dcfdfa8547eb6d59552b97d52cd4619999a66ca0028c8df262a6298d0175b
   md5: 3a7efdb1fd39b9efcb325f9bf1fa3b56
   depends:
@@ -7332,7 +7332,7 @@ packages:
   license_family: BSD
   size: 596818
   timestamp: 1722533782225
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
   sha256: 9eaab5afd89c87ca139915589626785039fac30f05f8fb19e9eefe27eb935ce6
   md5: babdcd3370f85ded3d313902dcebecfb
   depends:
@@ -7341,7 +7341,7 @@ packages:
   license_family: BSD
   size: 46224
   timestamp: 1723557464934
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
   sha256: 0eb44a16ef74a13ef7839209899d009cd94974fbc406a417d958c7bc8d955245
   md5: 41f239a5b67b1daf819849023aa5d12f
   depends:
@@ -7350,7 +7350,7 @@ packages:
   license_family: Other
   size: 19056
   timestamp: 1705431379885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
   sha256: 14775231982e1ea150189c956927ccfb1ad01a8c9395cdeea4d5a48b9b8ce664
   md5: 729badc4bf7ba8ccc70e0f9e58075c99
   depends:
@@ -7359,7 +7359,7 @@ packages:
   license_family: MIT
   size: 89812
   timestamp: 1696347694075
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
   sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
   md5: 6bef1694163a68ac4c37e5857b8da4f5
   depends:
@@ -7371,7 +7371,7 @@ packages:
   license_family: Other
   size: 1900191
   timestamp: 1714488351925
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -7380,7 +7380,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
   sha256: 3d5c2968f581006437df3932cd5d3c1c4afa78f0e13757b958440245d3248856
   md5: 605ea221d225ad8e79284dbcfdab0715
   depends:
@@ -7391,7 +7391,7 @@ packages:
   license_family: BSD
   size: 37699
   timestamp: 1678317755913
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/threadpoolctl-3.5.0-py311h85bffb1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/threadpoolctl-3.5.0-py311h85bffb1_0.tar.bz2
   sha256: cb497652dc74d01957b3552dafed4b5a1002127403867409b72a8f6f1ce6d360
   md5: c98fdcba2ed2a91a84ec80cf76af2660
   depends:
@@ -7402,7 +7402,7 @@ packages:
   license_family: BSD
   size: 50030
   timestamp: 1719407844996
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tiledb-2.3.3-h1b93210_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tiledb-2.3.3-h1b93210_3.tar.bz2
   sha256: 7ff40023781ce8961c41886fd2a7c71aa5844c3135e80c20da14f05cb574a0bb
   md5: 62681a61cd20436fe95391fbf801b53b
   depends:
@@ -7418,7 +7418,7 @@ packages:
   license_family: MIT
   size: 3039719
   timestamp: 1685656939480
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
   sha256: ed059e32ce5a1c0511575f29d2fb6da12c54a37000bfa80f9e5aa9dfd9e04101
   md5: 4d2261a92d25136a68b8d01d101119f5
   depends:
@@ -7428,7 +7428,7 @@ packages:
   license_family: BSD
   size: 49145
   timestamp: 1678317386284
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
   sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
   md5: 523c006cc67c011383678c762015479b
   depends:
@@ -7437,7 +7437,7 @@ packages:
   license_family: BSD
   size: 3594448
   timestamp: 1714770737885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
   sha256: 424b8284072266eb59d055c0b7b58241bfb00009d445743ea261d4eeee73ea19
   md5: f3a47898a55087edb9d65d29c24d9b88
   depends:
@@ -7446,7 +7446,7 @@ packages:
   license_family: BSD
   size: 135757
   timestamp: 1678323030858
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.1-py311h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.4.1-py311h46256e1_0.tar.bz2
   sha256: f46d29f5c4f5fceb7a39343da76f5c5ab89cbb0844e80a3a90457201c3fbc168
   md5: ee154208a17c1c4cd42d264b1a6f77c3
   depends:
@@ -7455,7 +7455,7 @@ packages:
   license_family: Apache
   size: 914461
   timestamp: 1718740220272
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.5-py311h85bffb1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.66.5-py311h85bffb1_0.tar.bz2
   sha256: ec67885e979483932bf0ce9e720841d6f9d44bbc5a049f2e4a15232803f8362a
   md5: 044460e02becd58190c03e794461acee
   depends:
@@ -7466,7 +7466,7 @@ packages:
   license_family: MOZILLA
   size: 155741
   timestamp: 1724854618448
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
   sha256: 5283f2b23a6e9d888b2834cba2bbf284f551e199d2c1b4add176b1cbafb19ee0
   md5: 58bf7871ca100fbda0492bb5a3363c80
   depends:
@@ -7475,7 +7475,7 @@ packages:
   license_family: BSD
   size: 208200
   timestamp: 1718227205760
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
   sha256: 17e5688d09ffbcb8b71b34b86edc7374fa0b04d60a4d729d405ffc22ef63726c
   md5: e4bf44ddbbcb136332ccb47ac2b879a0
   depends:
@@ -7485,7 +7485,7 @@ packages:
   license_family: PSF
   size: 9890
   timestamp: 1715269046804
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
   sha256: 7d369ec970d1d5411e457c79f94197756c7088deff8183806ea71e633b26edf9
   md5: 9ffa197b26373667f50b21876862398e
   depends:
@@ -7494,7 +7494,7 @@ packages:
   license_family: PSF
   size: 75595
   timestamp: 1715269030928
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
   sha256: a9960485ced319ac91afe69eaaf703c7e6b3049f1e06a4a8c2818b64155943f0
   md5: 0a9c8ea92a14330a07edabac249e32a9
   depends:
@@ -7503,7 +7503,7 @@ packages:
   license_family: MIT
   size: 11399
   timestamp: 1678394892923
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
   sha256: d42ae57366d05e12f10074583568355752436d66ad018ffbcfa24135f593810a
   md5: 1a98e48aa0bd8b3ec09e2cbdbb236575
   depends:
@@ -7512,14 +7512,14 @@ packages:
   license_family: Apache
   size: 498952
   timestamp: 1713213079520
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uriparser-0.9.7-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uriparser-0.9.7-h6c40b1e_0.tar.bz2
   sha256: 035b916c1eab3a6a27f0109d8e39fe37cbf8ebe0af948d88d7a3b96ab20dc999
   md5: e697defd6c59ca6d98ab4bb5f951eb21
   license: BSD-3-Clause
   license_family: BSD
   size: 44105
   timestamp: 1692186954114
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-2.2.2-py311hecd8cb5_0.tar.bz2
   sha256: f46959a5ebab808e8a3fb6036cee2f6a0f3bfe42c81d00158d4d2a88837d60d2
   md5: 7a554ae6cb2c33d09125ef897b39a4c5
   depends:
@@ -7535,14 +7535,14 @@ packages:
   license_family: MIT
   size: 210587
   timestamp: 1718912682770
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
   sha256: 0f8c3eb254be9c1957e748e385e20e62509d11052990c4755012be62434c9129
   md5: 53229ba93f6e38308ae42ecfc6eaad9d
   license: MIT
   license_family: MIT
   size: 96768
   timestamp: 1706894705048
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
   sha256: 597015e8a038a111f03ffbc9a217fcda549d75230c86ce53c1f23c53d6f1a0cb
   md5: 62e98aac883bccc1c87ca0d2ce2f08e0
   depends:
@@ -7551,7 +7551,7 @@ packages:
   license_family: BSD
   size: 25798
   timestamp: 1678317074170
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
   sha256: 1430e6f4b4dd9354b7bb88f7f7bc9cdbab26a034ad1ae5c278de0f5a99329372
   md5: be0832862b29bf5767a707ac6bd53b93
   depends:
@@ -7560,7 +7560,7 @@ packages:
   license_family: Apache
   size: 114834
   timestamp: 1715878445060
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.44.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.44.0-py311hecd8cb5_0.tar.bz2
   sha256: 907fd39137318473d447c56d77f775c9d3fef5b4e840f8c43f50f8f9c016710f
   md5: 2106db0f651f613ca1971e60afe3f5f2
   depends:
@@ -7569,7 +7569,7 @@ packages:
   license_family: MIT
   size: 139423
   timestamp: 1726165218455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
   sha256: cc6995f677d1628f42ae80ed47ff08d8d1c8ed12580a326af6e307f5febc594a
   md5: d01eb964863b95ef62061b77c9037ead
   depends:
@@ -7581,7 +7581,7 @@ packages:
   license_family: Apache
   size: 2471632
   timestamp: 1689041625741
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xerces-c-3.2.4-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xerces-c-3.2.4-hcec6c5f_1.tar.bz2
   sha256: 28cba861aa198f4f748010e8ea015a330e4f9403d89f70bcfbda003878a78fbc
   md5: 44ff442e7aeb96a06f53d72aa76dd2ff
   depends:
@@ -7591,7 +7591,7 @@ packages:
   license_family: Apache
   size: 2832362
   timestamp: 1692994769686
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
   sha256: 5b6d5246955b5f9480ff7027eb002442a7ade24f5c354da54ed513042f76cedc
   md5: f32aa8a37d5e65a8dc30f9a1f46bc63d
   depends:
@@ -7600,20 +7600,20 @@ packages:
   license_family: BSD
   size: 54719
   timestamp: 1678325412288
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
   sha256: ed0152ad6b87ffd9e01f4a62bc358e805ad59637f898a801b0a9cf903ae8e1fb
   md5: 8a92f8c663608f24e14d8a2068b9d83a
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 415323
   timestamp: 1714511993944
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
   sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
   md5: c25b6d40f834647d0bbe767f6c776031
   depends:
@@ -7623,7 +7623,7 @@ packages:
   license_family: Other
   size: 329449
   timestamp: 1705602140856
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zict-3.0.0-py311hecd8cb5_0.tar.bz2
   sha256: e5fd1f8b8e5cc1221e85355ade7b69f0df640dbdc016b7f9ea0b0b6eda5bf9b6
   md5: 11c4cb55382be5ab89b5c4085510db3b
   depends:
@@ -7634,7 +7634,7 @@ packages:
   license_family: BSD
   size: 103266
   timestamp: 1695833080541
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
   sha256: 36fa7ad990aabf3607bda1f33e847888210974586363b6d69cf1ed092c192c35
   md5: c981fe545122206cdeb647f2dc9e093d
   depends:
@@ -7643,14 +7643,14 @@ packages:
   license_family: MIT
   size: 25496
   timestamp: 1704207010227
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
   sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
   md5: f2519b551f99765d9d98950c5e2b4713
   license: Zlib
   license_family: Other
   size: 119782
   timestamp: 1714511811597
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
   sha256: 7feb73e79bdbd45404ddc7a30c43bf4cc68eced8ce448ce7c31f5db134276fc5
   md5: 48313bc6570c705cadbba3c356e0dc8e
   depends:
@@ -7662,7 +7662,7 @@ packages:
   license_family: BSD
   size: 1014151
   timestamp: 1714678461080
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
   sha256: 9ca3f0dfc2bdbc109e359ba7ab246e6ae952a14819148ad069454b52f2bda802
   md5: 51fb05873a644cac52f0d1e10cb7969a
   depends:
@@ -7676,7 +7676,7 @@ packages:
   license_family: MIT
   size: 228856
   timestamp: 1706220385566
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
   sha256: 43405cc7341ce3efb2e24013ad62c64f26a69926635adceaa5459ccbcafb3776
   md5: effa6d22f497e164cc8455f7f329c304
   depends:
@@ -7685,7 +7685,7 @@ packages:
   license_family: BSD
   size: 12510
   timestamp: 1677917870614
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
   sha256: 947efe1c50b3280e9a67cbb18636bdade53a40960fff3056850ff81ab87acbe3
   md5: 7d2d384ee32ccc12dcb0dc099e421482
   depends:
@@ -7695,7 +7695,7 @@ packages:
   license_family: MIT
   size: 35091
   timestamp: 1677915945226
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-16.1.0-hbc20fb2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/arrow-cpp-16.1.0-hbc20fb2_0.tar.bz2
   sha256: c88be5f2e95328d8ce44649753733633dafb646b727fa40c0392c151fa1b16ec
   md5: 0b301ce50e318433007c6659b472ab1c
   depends:
@@ -7725,7 +7725,7 @@ packages:
   license_family: Apache
   size: 9859572
   timestamp: 1721659135060
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
   sha256: 8259b4a0973c825ac81f581afcbe86640bd0a94b33caa996167309241877635a
   md5: 49b8ddacfd3927bcaae139eadfb72ce1
   depends:
@@ -7734,7 +7734,7 @@ packages:
   license_family: MIT
   size: 153557
   timestamp: 1695717951839
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
   sha256: f536e8b60bdc895063ca0e0155d2041993caed5f932c232f2a0d8e52798da2f1
   md5: daacfabaacebe1d1e53426ec3e385d14
   depends:
@@ -7747,7 +7747,7 @@ packages:
   license_family: Apache
   size: 86757
   timestamp: 1706746162173
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
   sha256: c356ce4cbd638a41fd3db59aa3559850e38c6b41188b8ffab32bdcbd9a55fe03
   md5: e9dc8c248dda95e92533cae6815a0a8b
   depends:
@@ -7756,14 +7756,14 @@ packages:
   license_family: Apache
   size: 39456
   timestamp: 1706690903374
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
   sha256: 117825fcff2a68136a6e5183e05542c2654d73322e70daee3c50c0ecb3aec703
   md5: b115d3f733fe8bae79b9d416754b260e
   license: Apache-2.0
   license_family: Apache
   size: 182078
   timestamp: 1706189905050
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
   sha256: 241c19574abcaf91a47fc5c36f38e58c86732be5e06f5170063406098a58639f
   md5: 3cfc3d38b8fdb25cc2e10e3e370d4106
   depends:
@@ -7772,7 +7772,7 @@ packages:
   license_family: Apache
   size: 18039
   timestamp: 1706690838125
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
   sha256: d4c60f610e57b35a2962b8cea9911358d1642e0449468fa4967706af88bf5da9
   md5: fc23856f141fe548afcfc4823881ee19
   depends:
@@ -7784,7 +7784,7 @@ packages:
   license_family: Apache
   size: 47155
   timestamp: 1706697259456
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
   sha256: c43ed35f4a64818ae39ca2c3c3652428c15da5e287f6e94254c3df4d6c759fb3
   md5: 06366f5f8762447babf69804a04b1a69
   depends:
@@ -7796,7 +7796,7 @@ packages:
   license_family: Apache
   size: 162746
   timestamp: 1706744122437
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
   sha256: 14e2ee7339c88089d1ff68f7144b3fb4f9e34fe538a9462f8de31dd6fdd1d42b
   md5: 59ab0e7ffd73966ec6a2fa83a5df5c47
   depends:
@@ -7806,7 +7806,7 @@ packages:
   license_family: Apache
   size: 127084
   timestamp: 1706696174505
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
   sha256: 601baf006d0545ec65566701d99c601cba843e8ac03d80819d4b8bed23d1e5c4
   md5: 2c98a19d57362cf1fbfec3dda3ea283b
   depends:
@@ -7817,7 +7817,7 @@ packages:
   license_family: Apache
   size: 61914
   timestamp: 1706746732665
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
   sha256: 16809db73ddc3c374ead2c2e9f2221894e2014d3e07ba62d79375cb4de4dfc9d
   md5: c03f5e3b42bc59bd92db813522cce1aa
   depends:
@@ -7831,7 +7831,7 @@ packages:
   license_family: Apache
   size: 67560
   timestamp: 1706747573116
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
   sha256: 293cf6b9dfa727d0e65b383b0e434f8fb26480abd011516171b8652fd363c98e
   md5: 2df2dd6c43a3b413b438a9ef834d78b0
   depends:
@@ -7840,7 +7840,7 @@ packages:
   license_family: Apache
   size: 48454
   timestamp: 1706690816205
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
   sha256: 773f7ff1a91af373d27f5c57833aff8912870108ddd94a5280bfdc608effe5e3
   md5: fad8b095c03774c9d4901db7eda09002
   depends:
@@ -7849,7 +7849,7 @@ packages:
   license_family: Apache
   size: 52142
   timestamp: 1706192041205
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
   sha256: 4efabe18fc312e65a5aac9b2ebe423296cfe702756891978244287ab47881927
   md5: 5786a8ac037fd0e81e25f52dbc6dc72d
   depends:
@@ -7867,7 +7867,7 @@ packages:
   license_family: Apache
   size: 210683
   timestamp: 1706827608490
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.10.55-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-sdk-cpp-1.10.55-h313beb8_0.tar.bz2
   sha256: fe92c6408ee3ebf269b216d1c9576bc15e65a38bcf684f2a7b935e57dbf2e444
   md5: 4c6b2dc15773f338a7f3299a753ab0af
   depends:
@@ -7881,7 +7881,7 @@ packages:
   license_family: Apache
   size: 2365300
   timestamp: 1706890517127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
   sha256: ae3c6633ed84bac16592b3b756f96ffc577414971014ca9efa498a162588757f
   md5: ea600f99d012d734f831d1bc00a17661
   depends:
@@ -7891,12 +7891,12 @@ packages:
   license_family: MIT
   size: 281227
   timestamp: 1718029919645
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
   sha256: d51b7b5841be320209706d8e9caf669c0e0094f3a40e9eea51701a564ca7c2ed
   md5: 61647f79e0ae70e914fee23c40c4caea
   depends:
@@ -7908,7 +7908,7 @@ packages:
   license_family: BSD
   size: 43179
   timestamp: 1675247655207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.1-py311hb6e6a13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.4.1-py311hb6e6a13_0.tar.bz2
   sha256: 4f861776f2954c67e690caba87d24de817fafe79964c1f6075a35c8bad2d2f2b
   md5: cd4dc5659854265ae73d6a9127746990
   depends:
@@ -7926,7 +7926,7 @@ packages:
   license_family: BSD
   size: 6089676
   timestamp: 1718119235085
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
   sha256: f1660ecfb8687d74e81a7b00699a8bb4677cbd791d14f50ba517de98e2f187ca
   md5: 1636fc4b725da8c5e967952a55f3fd80
   depends:
@@ -7936,7 +7936,7 @@ packages:
   license_family: OTHER
   size: 11780
   timestamp: 1696762172661
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
   sha256: 688a071ba370f51b457cd32d70b7b38921ce9551203d06fa7fc2c30c4b79891d
   md5: b2353077a39ab997463768154dd58fec
   depends:
@@ -7946,7 +7946,7 @@ packages:
   license_family: BSD
   size: 134711
   timestamp: 1707864978809
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/branca-0.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/branca-0.6.0-py311hca03da5_0.tar.bz2
   sha256: 0f5af59a0b198f514b57127ab7deeec9804d68d13a77e36c32341dd7ad0031e7
   md5: 8c7e0f14f2ee41cb5791249210576946
   depends:
@@ -7956,7 +7956,7 @@ packages:
   license_family: MIT
   size: 54811
   timestamp: 1677957274255
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
   sha256: 048264434c33fdb53862cdd69b2e2bc4ce6f8a70b3211ad6d686d066eac2aa91
   md5: d55696ccaf6755931cd662dfb929aa0b
   depends:
@@ -7966,7 +7966,7 @@ packages:
   license: MIT
   size: 19737
   timestamp: 1714483270447
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
   sha256: 13627293296fcc231d8dc12d803dfc9621108c60df38b0e3c64e9e02ed55e564
   md5: 86efd4ad08cd80d3eab77873db84a255
   depends:
@@ -7975,7 +7975,7 @@ packages:
   license: MIT
   size: 19083
   timestamp: 1714483255364
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
   sha256: 2e542b2bb27f8379da3efcb83ef084cb26e6a9ab576c50487c2dd996afd5ccb1
   md5: e8cab9d1ef58a450f971690fcdb2ede2
   depends:
@@ -7984,28 +7984,28 @@ packages:
   license: MIT
   size: 380182
   timestamp: 1714483330655
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
   sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
   md5: 56d1386c7f1f338f0d18f82af6525273
   license: bzip2-1.0.8
   license_family: BSD
   size: 158748
   timestamp: 1714510571033
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
   sha256: b0be79290b1df1cf1d07a1a9c3f3a92ae262643a6df3dc10dfbac22a82874dd4
   md5: 8fdcf1c08eee91fec7eefc22863c816a
   license: MIT
   license_family: MIT
   size: 106550
   timestamp: 1693902036526
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.7.2-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2024.7.2-hca03da5_0.tar.bz2
   sha256: fe7a0afbef42d3a919d4017aab1aa5b975022b1a83175cca4ebde67bbf8c8bb6
   md5: b1cc58c747f7ac1b6ef66ac3448f97db
   license: MPL-2.0
   license_family: Other
   size: 137663
   timestamp: 1720622028923
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cairo-1.16.0-h302bd0f_5.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cairo-1.16.0-h302bd0f_5.tar.bz2
   sha256: c2f6508a6ede7d131884e906dbf409c781eb3cb04b6ebfa6a29a2310e1a8e0da
   md5: 5febd95efbd8014e202562d7b0391869
   depends:
@@ -8019,7 +8019,7 @@ packages:
   license_family: LGPL
   size: 1403003
   timestamp: 1688495951297
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cartopy-0.22.0-py311h7aedaa7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cartopy-0.22.0-py311h7aedaa7_0.tar.bz2
   sha256: 70bc64b33c059869de55a1629d18a85c81e9473e2e1f43578f38aa1ee3ff9605
   md5: 9e47c054bbcc94755ecc856b53153363
   depends:
@@ -8039,7 +8039,7 @@ packages:
   license_family: LGPL
   size: 2095879
   timestamp: 1706196218316
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.8.30-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.8.30-py311hca03da5_0.tar.bz2
   sha256: b5bf3208e126cb67926c2a36b5438d84eee9b8352ec007d6b143b0751ac6d8a8
   md5: 07d0c4f8a1807db57b12a461f6142eb9
   depends:
@@ -8048,7 +8048,7 @@ packages:
   license_family: Other
   size: 170510
   timestamp: 1725551796823
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_0.tar.bz2
   sha256: 5b98c2dc6ebb5b3d5bf6e58ff3f495b4bf71b28de86ca299186554639de381c7
   md5: a95cbad1b8d8cff239a8eb5d940c663f
   depends:
@@ -8059,7 +8059,7 @@ packages:
   license_family: MIT
   size: 292045
   timestamp: 1726856478903
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
   sha256: 3ba74ebffd6bc4bc451864f85048dec9b6ad085eb1904ce3e5450376e15f050e
   md5: 289f238ac78b174f01c8a2b252b17735
   depends:
@@ -8071,7 +8071,7 @@ packages:
   license_family: Other
   size: 1243641
   timestamp: 1655814869383
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cftime-1.6.2-py311ha0d4635_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cftime-1.6.2-py311ha0d4635_0.tar.bz2
   sha256: e60fc249dd459f8794ca5b96367dfbfd876d4a8706ad2d200dea58f9905e7c64
   md5: 092970bf83e050ce7b8646a1faac4a6c
   depends:
@@ -8081,7 +8081,7 @@ packages:
   license_family: MIT
   size: 223453
   timestamp: 1678994382922
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
   sha256: df81a27f221d11af4a709f272dc8ba3fd3f6d5ab4ffd883c40567bcf04f0cfd3
   md5: e49333e3ffe1fe2e701f50a6e6dccc52
   depends:
@@ -8090,7 +8090,7 @@ packages:
   license_family: BSD
   size: 204179
   timestamp: 1698129906257
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-3.0.0-py311hca03da5_0.tar.bz2
   sha256: 340739a06e25afcd23ec4c5e5d45ac940feb16bee5122e1d14d261a2c80b5617
   md5: bd85d021206472f6a6615575f126ed65
   depends:
@@ -8099,7 +8099,7 @@ packages:
   license_family: BSD
   size: 43128
   timestamp: 1721657439520
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
   sha256: 808e56fb70f3d38599ee7a54c2a707b282ba9a401fa69a1f54cdc26425d9ce01
   md5: fc37321833175bda4fc5c21afe32db49
   depends:
@@ -8108,7 +8108,7 @@ packages:
   license_family: CC
   size: 539588
   timestamp: 1709758479776
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
   sha256: d9c126d8bcd1c89ea37186c172d6b1f73f45ada60e3ae1790a017b530baa0147
   md5: f0223aae3d622547f6accb212579c58e
   depends:
@@ -8118,7 +8118,7 @@ packages:
   license_family: BSD
   size: 17967
   timestamp: 1709322909223
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
   sha256: 1f908c688e47d03d92ac09d9541a1f1c773ac2ca485dd1d77441b1aaefc032db
   md5: 444c330471496a39a97e87f41ed70c96
   depends:
@@ -8129,7 +8129,7 @@ packages:
   license_family: BSD
   size: 281104
   timestamp: 1700583698464
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.2-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cytoolz-0.12.2-py311h80987f9_0.tar.bz2
   sha256: 9e135f43ac703c578abe1b84761a1fb4ad75b63966f0b015fdcb939d3b05e7b3
   md5: ab5b122dafc5b17f32b2ec8ce73d8adb
   depends:
@@ -8139,7 +8139,7 @@ packages:
   license_family: BSD
   size: 403974
   timestamp: 1701723703085
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-2024.8.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/dask-2024.8.2-py311hca03da5_0.tar.bz2
   sha256: 4aacbf7dae263f81d1281b78e67f811982c977be4f3097f51de58ad0848d7351
   md5: 73ff76a25b8b2144e11d28c833d31d56
   depends:
@@ -8158,7 +8158,7 @@ packages:
   license_family: BSD
   size: 6334
   timestamp: 1725525201905
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.8.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2024.8.2-py311hca03da5_0.tar.bz2
   sha256: 15839c0b76d580d62c4f06f834c6e2539a76034fdaf982911c389a017f7cced4
   md5: 0c589d3d6f8d6ebe5996b2fff3620e1d
   depends:
@@ -8175,7 +8175,7 @@ packages:
   license_family: BSD
   size: 3119804
   timestamp: 1725461423376
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-expr-1.1.13-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/dask-expr-1.1.13-py311hca03da5_0.tar.bz2
   sha256: 9d41df91df3d0aa498f3de720a1e111ba8f6522ab7b109e87a64a0ff46eef7b4
   md5: 4b8bb09acb791bdebb6da896a5a37e3e
   depends:
@@ -8187,7 +8187,7 @@ packages:
   license_family: BSD
   size: 561561
   timestamp: 1725523241610
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.16.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/datashader-0.16.3-py311hca03da5_0.tar.bz2
   sha256: adf3ced9e94279c8700527309b650491a498e71cc9114caa517dd8beac136525
   md5: de926408cadc24e8e062f5e686247c39
   depends:
@@ -8210,7 +8210,7 @@ packages:
   license_family: BSD
   size: 18017422
   timestamp: 1720540529831
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
   sha256: b9356e3ada4872c7c950d2ac7e0f107c4786775191efdfda3a469dffb18f2714
   md5: 07ddd96675caf30ea77cafb1ea5662a4
   depends:
@@ -8220,7 +8220,7 @@ packages:
   license_family: MIT
   size: 2490144
   timestamp: 1690905181398
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2024.8.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/distributed-2024.8.2-py311hca03da5_0.tar.bz2
   sha256: 71c057e91f66748e534adb341101df3644c2d3cbfa6b9a3d3ccb02dedd7df233
   md5: d849272a6a043d96db4fb429e85ce9ec
   depends:
@@ -8244,7 +8244,7 @@ packages:
   license_family: BSD
   size: 1825900
   timestamp: 1725523100619
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
   sha256: b1481ffa475c65200626f051d5dcbdb264730b533e928dde608a79ce7a5b4e48
   md5: aada2761547a291d68f4c016a1a9bc7b
   depends:
@@ -8253,7 +8253,7 @@ packages:
   license_family: MIT
   size: 18265
   timestamp: 1677911915719
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/expat-2.6.3-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/expat-2.6.3-h313beb8_0.tar.bz2
   sha256: 142b357054c77635d2a62f1a095b95a0d7c9adf3e06121f2b5f717d44c2111fe
   md5: 43e2c7c99509cc831930aa1659c474bb
   depends:
@@ -8262,7 +8262,7 @@ packages:
   license_family: MIT
   size: 165907
   timestamp: 1725543352377
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fiona-1.9.5-py311h7aedaa7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fiona-1.9.5-py311h7aedaa7_0.tar.bz2
   sha256: f21e29d4281b14fe05478b92208ecd79a038998930d7435dc237fd47ffac78d4
   md5: cee06f3915fd4e258b6e849187be8c71
   depends:
@@ -8285,7 +8285,7 @@ packages:
   license_family: BSD
   size: 1162826
   timestamp: 1704921012395
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/folium-0.14.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/folium-0.14.0-py311hca03da5_0.tar.bz2
   sha256: f7e6ee59efd1118f34a53b9b022511cb01d1e3fe2f2d8f3046f555f2a6eb33bb
   md5: a2fb43de1f039d8e80cf3286ec0dba9b
   depends:
@@ -8298,7 +8298,7 @@ packages:
   license_family: MIT
   size: 136817
   timestamp: 1677971749295
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fontconfig-2.14.1-h6402c1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fontconfig-2.14.1-h6402c1e_3.tar.bz2
   sha256: 73c20700d3a1c761b0d2c3f7beec8ca45df571e9bba240e7be5bd667e26f5b3e
   md5: 8171cb5f744dd4cbce6b1e63ee5d9285
   depends:
@@ -8310,7 +8310,7 @@ packages:
   license_family: MIT
   size: 289660
   timestamp: 1722921100495
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
   sha256: eb82a0e2ca36d0973b5f6642e27609554edad4b72696f989776d5db8cd4a6a42
   md5: fa8d9dd8a2fabba964c6bb75ace8c572
   depends:
@@ -8328,7 +8328,7 @@ packages:
   license_family: MIT
   size: 3201601
   timestamp: 1713551611540
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -8338,7 +8338,7 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freexl-2.0.0-ha3de405_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freexl-2.0.0-ha3de405_0.tar.bz2
   sha256: 72c9da298576964ab1df878b31e78bd4d4dbe4a2cba3c5fa26c4c28cb1d73101
   md5: 3655f44208f1ca8065195a43f9fefefe
   depends:
@@ -8349,7 +8349,7 @@ packages:
   license_family: OTHER
   size: 62175
   timestamp: 1704742032594
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.6.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2024.6.1-py311hca03da5_0.tar.bz2
   sha256: dea477d2b42cc015a051cc99d3c3ac0973df6c864088c8da0e77ab0713510b41
   md5: d66f06e18672ef030741a74261313915
   depends:
@@ -8360,7 +8360,7 @@ packages:
   license_family: BSD
   size: 383596
   timestamp: 1724855620851
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gdal-3.6.2-py311h950983f_5.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/gdal-3.6.2-py311h950983f_5.tar.bz2
   sha256: e7329e9ffe95eb88cec7533fbb567761967e91224d8564ab2467e989fc35f212
   md5: f9ceb20cf40940ca146449ea24e5d3bb
   depends:
@@ -8373,7 +8373,7 @@ packages:
   license_family: MIT
   size: 2168472
   timestamp: 1722934125835
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geopandas-0.14.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/geopandas-0.14.2-py311hca03da5_0.tar.bz2
   sha256: d29e35f432d67d0d8af2bf69ea1570d7f90c0ece5bf4e06f1467e8397f759222
   md5: a72181e7ca83308cd9fea8e5e49ba658
   depends:
@@ -8388,7 +8388,7 @@ packages:
   license_family: BSD
   size: 7738
   timestamp: 1704929067118
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geopandas-base-0.14.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/geopandas-base-0.14.2-py311hca03da5_0.tar.bz2
   sha256: 62a00facc1db52567eaec03014c6fd51e75592c1bd96f24ebd70c72db27b56fc
   md5: 665415b1bed447a7b2cf6573e1fe050e
   depends:
@@ -8402,7 +8402,7 @@ packages:
   license_family: BSD
   size: 1532299
   timestamp: 1704929023329
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geos-3.9.1-hc377ac9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/geos-3.9.1-hc377ac9_1.tar.bz2
   sha256: c901ff0682a8dcca5e77934a285af51dc7cfe5b0d2c22608d043d2940aecfb52
   md5: 25182cc424f23f0544362ef982ce9138
   depends:
@@ -8410,7 +8410,7 @@ packages:
   license: LGPL-2.1
   size: 889806
   timestamp: 1629009640131
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geotiff-1.7.0-h41f0982_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/geotiff-1.7.0-h41f0982_3.tar.bz2
   sha256: 77ff922ae1e5c060e14769b4ba274e384a7c9e611f7d3524acc1a16dd182f5c7
   md5: 1945ea77a987535d3c7f483415aa7048
   depends:
@@ -8423,7 +8423,7 @@ packages:
   license_family: MIT
   size: 135163
   timestamp: 1704901285550
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geoviews-1.12.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/geoviews-1.12.0-py311hca03da5_0.tar.bz2
   sha256: e2e7e8856e8f3619374b3de41e41fc22b95cf587fad5dbd9010ecbeb45cf6b80
   md5: e3a3922c5157ec603ce4bf325c72183d
   depends:
@@ -8441,7 +8441,7 @@ packages:
   license_family: BSD
   size: 6746
   timestamp: 1713972561326
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/geoviews-core-1.12.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/geoviews-core-1.12.0-py311hca03da5_0.tar.bz2
   sha256: 86c54e47c639149d480787b32ea1ae9d8e15fc46f885f5d304363aa6cd19988b
   md5: cae539477289bce399216c36ae266b8a
   depends:
@@ -8462,7 +8462,7 @@ packages:
   license_family: BSD
   size: 602983
   timestamp: 1713972551007
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gettext-0.21.0-hbdbcc25_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/gettext-0.21.0-hbdbcc25_2.tar.bz2
   sha256: a9703c804e8377c081602e701536bb9ee3e45d73682ed991d4ab89b512f4dd6b
   md5: f2541033cfec7a7244448619f81a5b0d
   depends:
@@ -8475,7 +8475,7 @@ packages:
   license_family: GPL
   size: 3546065
   timestamp: 1722922815248
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
   sha256: 25e05b93a99914a5fd1a298a2c5b25479fbd571b0db9caa7c6ad4336f060f62c
   md5: e213b68bb0274e0e54c610a041e059f5
   depends:
@@ -8484,14 +8484,14 @@ packages:
   license_family: BSD
   size: 150168
   timestamp: 1706888198288
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
   sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
   md5: 1d0bd7e576c64c059ef781dd319ad82a
   license: MIT
   license_family: MIT
   size: 77591
   timestamp: 1676983230102
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glib-2.78.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/glib-2.78.4-h313beb8_0.tar.bz2
   sha256: 3e9c434a66bffa098be94e78e27030da7ab2ff334d9f4281c4629fa77b1a90fb
   md5: b3233037d5eaab7ccda0cfd2bfc0f68e
   depends:
@@ -8504,7 +8504,7 @@ packages:
   license_family: LGPL
   size: 508284
   timestamp: 1708031704387
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glib-tools-2.78.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/glib-tools-2.78.4-h313beb8_0.tar.bz2
   sha256: d911b7d543354da675d1538cd4f012d0709fd11ac67988120826725e70517745
   md5: 3aa48599abab8066cfb3148ad90288ff
   depends:
@@ -8515,7 +8515,7 @@ packages:
   license_family: LGPL
   size: 106508
   timestamp: 1708031674414
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
   sha256: bbbcf47ef9249635b5199be1414b0b59687cc04ea9630d50ecc609dc200c095e
   md5: 5820c373d6847a68551cadb8984a8277
   depends:
@@ -8525,7 +8525,7 @@ packages:
   license_family: BSD
   size: 95638
   timestamp: 1706895270850
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf4-4.2.13-h5e329fb_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/hdf4-4.2.13-h5e329fb_3.tar.bz2
   sha256: e9ccc7a4ec25606556785100e6ee1dd5d9b04ed1973978545a37bfe6be929ddc
   md5: 2a40342fd2402a56d833312609fcf16b
   depends:
@@ -8536,7 +8536,7 @@ packages:
   license_family: BSD
   size: 913497
   timestamp: 1629192094107
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf5-1.12.1-h05c076b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/hdf5-1.12.1-h05c076b_3.tar.bz2
   sha256: 784ecf7eb9eee184a176cfc50498e041a353da3787f77fb96b18f9347ae8f954
   md5: a5e4fb25fd69e50fb12d4a227b7048bf
   depends:
@@ -8550,7 +8550,7 @@ packages:
   license_family: BSD
   size: 6214795
   timestamp: 1686167672819
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.19.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.19.1-py311hca03da5_0.tar.bz2
   sha256: 456a62ed25e8801052a5fade2a30b245d1f3ce20163f9b4f8c6b6ab897db4797
   md5: e4c7bea476dea67cd39bfa3be77b237f
   depends:
@@ -8570,7 +8570,7 @@ packages:
   license_family: BSD
   size: 6098996
   timestamp: 1720539818808
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
   sha256: 765d5b7ef75ed7f52a110504cd88e9b0c9977b841f1beaeeabb17e629b462908
   md5: 0af9cd26a7c9eb8b77d3cbacb93a118b
   depends:
@@ -8587,7 +8587,7 @@ packages:
   license_family: BSD
   size: 360105
   timestamp: 1715090588763
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
   sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
   md5: 69eb3b03765627b6159ed23cdde78396
   depends:
@@ -8596,7 +8596,7 @@ packages:
   license_family: MIT
   size: 28399065
   timestamp: 1692293207812
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
   sha256: 4d4ab70ae0ce008c1cc96a4edfbf3866d5e636acc4799a545ea93acee51635f7
   md5: 86a085a440729020d1d7b0b74d6a0c6c
   depends:
@@ -8605,7 +8605,7 @@ packages:
   license_family: BSD
   size: 148448
   timestamp: 1714398923507
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
   sha256: ec139e4b87aadcacc0670ecbcc2a303d858d4ac38b9404458a4b676bce9d21d5
   md5: bfcfed281f8df0f18726ec5f843b2b26
   depends:
@@ -8615,7 +8615,7 @@ packages:
   license_family: APACHE
   size: 51053
   timestamp: 1704813595720
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
   sha256: 63670c8f31770e1746016f645ca6b42b35f92d1c37e8025793d9490fed9998c0
   md5: 9cb417b9fdf02b4e007a5b5781e5a8cc
   depends:
@@ -8637,7 +8637,7 @@ packages:
   license_family: BSD
   size: 229932
   timestamp: 1705934202146
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.27.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.27.0-py311hca03da5_0.tar.bz2
   sha256: d2e3d351d5a509d9b384bba4684ff8ccd4fdc12a603f15a49e3d569d56ea413c
   md5: c448971003786058866ba2239dc61986
   depends:
@@ -8655,7 +8655,7 @@ packages:
   license_family: BSD
   size: 1636515
   timestamp: 1726064271144
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.19.1-py311hca03da5_0.tar.bz2
   sha256: 0dcfa64fca981f7c08f151bdb53b414e34c735184f1774ed9e0686f044488b9e
   md5: 154a56110b37c8a84cc38e4f43d5ef5b
   depends:
@@ -8665,7 +8665,7 @@ packages:
   license_family: MIT
   size: 1179602
   timestamp: 1721058583397
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.4-py311hca03da5_0.tar.bz2
   sha256: bdbc36a516717a24b40e2a4ac812c4d097b6733f4c6654602556969e5e0d4062
   md5: b31b2f2fd10d919c58c51fcbe54ef5c6
   depends:
@@ -8677,7 +8677,7 @@ packages:
   license_family: BSD
   size: 353970
   timestamp: 1716993463263
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/joblib-1.4.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/joblib-1.4.2-py311hca03da5_0.tar.bz2
   sha256: cbf1f9070037d98cc2e729d3789d3ac76f01a7b36f302cd94bf2fb43528ab2e7
   md5: afac24c80f4bc444a737c23393ad37e1
   depends:
@@ -8686,21 +8686,21 @@ packages:
   license_family: BSD
   size: 547611
   timestamp: 1718217291993
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
   sha256: 9d5cbffa98f3a4391f66b0c5ce1f411f0bfb0eb83137dc7146fb7bae23cb3570
   md5: 95c92318023482e4e8c698ae6c4597fe
   license: IJG
   license_family: Other
   size: 274078
   timestamp: 1722872672311
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/json-c-0.16-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/json-c-0.16-h1a28f6b_0.tar.bz2
   sha256: bb74124d37db18c31b4fef64d64f5809f50e9505ea5500437759b7fce8b2266c
   md5: 0335d80562d5b6254f0d35791295241a
   license: MIT
   license_family: MIT
   size: 75219
   timestamp: 1659123705674
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
   sha256: 62025ce4a2b9244b9816c9e02487e0dda567600692b5f9ca71f425d084961c7e
   md5: d57b7063122e5bf25cdfc2a5ea7330a8
   depends:
@@ -8713,7 +8713,7 @@ packages:
   license_family: MIT
   size: 181872
   timestamp: 1699041739097
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
   sha256: 404b0847029f77bedd7902a170a046219e0dc5c0ec2be19ff45361cff25b2181
   md5: 3a02bbe8d45fdbcb2350f672be74c9f5
   depends:
@@ -8723,7 +8723,7 @@ packages:
   license_family: MIT
   size: 16524
   timestamp: 1699032463763
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
   sha256: 7deb8ad28c34c369573754304a03ea2acda8ee39102a56526ec689a4d9210109
   md5: 675ea1a746a78ff6bf8fc4b39139efff
   depends:
@@ -8739,7 +8739,7 @@ packages:
   license_family: BSD
   size: 277400
   timestamp: 1677914250715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
   sha256: ceec15c84f5c699b8055d01e046be04ccb7cfd7c8bd090fc18959f2a4d9f8cf8
   md5: f85c11f7068312e1e84505efef9d55e3
   depends:
@@ -8750,7 +8750,7 @@ packages:
   license_family: BSD
   size: 98520
   timestamp: 1718818476094
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
   sha256: b2f1ee2a297e001a2e70bc218f60deb08c50b9b727668913ed5a106640413d2e
   md5: fc4e797a17ff5dccadfb5d19346b7800
   depends:
@@ -8766,7 +8766,7 @@ packages:
   license_family: BSD
   size: 43099
   timestamp: 1718738212629
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
   sha256: 2d96618ab2e9b3de870a713d7e5b19f6cde936291f3c87972f945b6e27024e77
   md5: 534159d29d9aba9c7e70ee52c27b326b
   depends:
@@ -8793,7 +8793,7 @@ packages:
   license_family: BSD
   size: 614003
   timestamp: 1718827110867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
   sha256: 501e929d345aaa9079c965552b942b4e8bde35b87ae89faef003687a40bab3a4
   md5: 54c7b8554a405acd7c8326c41ba93e63
   depends:
@@ -8803,7 +8803,7 @@ packages:
   license_family: BSD
   size: 28237
   timestamp: 1686870817418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
   sha256: 773e7c4571f482a744dfb18ae26fb22635f5d3f51389c838bd97f9044ea55cc4
   md5: 5161546aba5597318cb5653390cdecd8
   depends:
@@ -8815,7 +8815,7 @@ packages:
   license_family: BSD
   size: 20235
   timestamp: 1700168681687
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kealib-1.5.0-hba2eb73_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kealib-1.5.0-hba2eb73_1.tar.bz2
   sha256: ebb886d4072bc12e08a90a8e14b61a2bbd4a17e69993f848982da2f7d60ed3d9
   md5: 7da7333b8b4d51ab4408c66cd0bcd432
   depends:
@@ -8825,7 +8825,7 @@ packages:
   license_family: MIT
   size: 161523
   timestamp: 1687966978773
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
   sha256: 8c1c64d51be73aad381992a9df19d8336910bdfc40f19940231df86e177d17cc
   md5: b1f786f96684a143cf30d1f6b8aebdb3
   depends:
@@ -8835,7 +8835,7 @@ packages:
   license_family: BSD
   size: 65045
   timestamp: 1677925371836
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
   sha256: 789402b67398d3d936ac4486df01869d59b0e1ba298cbd06407d059aced871e4
   md5: a0f50a38705d0507bbf57ee49a1d9c29
   depends:
@@ -8846,7 +8846,7 @@ packages:
   license_family: MIT
   size: 1308175
   timestamp: 1686931157327
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -8856,7 +8856,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -8865,7 +8865,7 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libabseil-20240116.2-cxx17_h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libabseil-20240116.2-cxx17_h313beb8_0.tar.bz2
   sha256: 34390ba05b3d56366a2252f095f8bdf2527371854d981550db7485fc8290c10f
   md5: c8055bc73af0ac231a8b507edc1ff116
   depends:
@@ -8877,7 +8877,7 @@ packages:
   license_family: Apache
   size: 1246977
   timestamp: 1716563341094
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
   sha256: c1f104bc84ee46a3d3beafb5e35236c64e6b4fd6cceabfb420e1838171b1d9c1
   md5: 4f95903a1be48bbee1f9a818ec810b89
   depends:
@@ -8892,13 +8892,13 @@ packages:
   license_family: OTHER
   size: 22243663
   timestamp: 1696762144385
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
   sha256: 199042b87451abaf14546af124ae3380194cddda928e0d30ccb341e93084854c
   md5: eaa0442887994a82486c65d87f6b71e6
   license: MIT
   size: 68806
   timestamp: 1714483212137
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
   sha256: bd9a8a17fb14086446b710fa029d238e69274b83ee2e7e09093496f190de82b5
   md5: 66615d6a0cb5dcca3e20c019cde0ed2d
   depends:
@@ -8906,7 +8906,7 @@ packages:
   license: MIT
   size: 32975
   timestamp: 1714483225840
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
   sha256: e1bf77e8b975c30a69b08a08410622e27c8cff6f592ccfa590466b83d9e6d104
   md5: 8af86bdac01fe303d693d9b76c071059
   depends:
@@ -8914,7 +8914,7 @@ packages:
   license: MIT
   size: 310266
   timestamp: 1714483239194
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.9.1-h3e2b118_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcurl-8.9.1-h3e2b118_0.tar.bz2
   sha256: 405b50a404f55b4cf4edcb17c89e1ca345dddc4cf6005a1a137048356eb2ccce
   md5: 453584721c8f42a972fcace8ffeab37a
   depends:
@@ -8929,21 +8929,21 @@ packages:
   license_family: MIT
   size: 381982
   timestamp: 1725034052027
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
   sha256: 9597df5344a718d37837966aa05091faf210260898fad5e7a64b87f17de9e90d
   md5: 678a1f87940ef6cc421a092301b8c3fe
   depends:
@@ -8952,14 +8952,14 @@ packages:
   license_family: BSD
   size: 167208
   timestamp: 1703006281321
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
   sha256: 6fc572025852b210ecddcca3ab9ff3f1d5f6bd91f1933c6e296de6bb331f6b5d
   md5: 6dd7d9c5737bbd2a27d18f15318dc3e6
   license: BSD-2-Clause
   license_family: BSD
   size: 102059
   timestamp: 1628961869728
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
   sha256: 9e7b9bb9367d8725a751cdfa0b2d270434d303ea196cfaacc605ee26be09874a
   md5: 44d1843cc2f17eb2674f35b95468f551
   depends:
@@ -8969,14 +8969,14 @@ packages:
   license_family: BSD
   size: 415467
   timestamp: 1685052299052
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
   sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
   md5: f31e4eb9cd6447cc2f5ef0243a76540c
   license: MIT
   license_family: MIT
   size: 120460
   timestamp: 1714483461787
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgdal-3.6.2-h51eea9d_5.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgdal-3.6.2-h51eea9d_5.tar.bz2
   sha256: e8f56a084dfd80a88e805742b19e618f821e2bbdc366cd60ff2fd7434a08d23b
   md5: fedb5af05876b2088f1dd08585c0b48b
   depends:
@@ -9022,7 +9022,7 @@ packages:
   license_family: MIT
   size: 9407485
   timestamp: 1722933829430
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -9031,7 +9031,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -9042,7 +9042,7 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libglib-2.78.4-h0a96307_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libglib-2.78.4-h0a96307_0.tar.bz2
   sha256: 1646f1af879f87ac99b02cab3d93b94dd23c8a1ec53102de59689b8c33557861
   md5: 38df07115736878de127de290cad1d75
   depends:
@@ -9058,7 +9058,7 @@ packages:
   license_family: LGPL
   size: 3118001
   timestamp: 1708031641409
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgrpc-1.62.2-h62f6fdd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgrpc-1.62.2-h62f6fdd_0.tar.bz2
   sha256: e6e4e402ba9350955e9472f33ae7ce4ed712b6ad38b9b5c532e68bfb02646390
   md5: f5f2fdfe7750c7757efab6848e873b0c
   depends:
@@ -9076,14 +9076,14 @@ packages:
   license_family: APACHE
   size: 6756803
   timestamp: 1716834849823
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
   sha256: 72d242814b990900c9410d4738cc685f70ea71231742293cffbb475d8df100f8
   md5: f9976688992b7ac4b56f5600ee15b5c4
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1407202
   timestamp: 1714483550601
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libkml-1.3.0-hc4d7c42_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libkml-1.3.0-hc4d7c42_7.tar.bz2
   sha256: 3934364764ac9651132865f4bfaf3ae17f4bdbf2a96bd5ee7faec7995c556fb7
   md5: 8012eb6fc2f5750fea616fe03b1be95e
   depends:
@@ -9095,7 +9095,7 @@ packages:
   license_family: BSD
   size: 448001
   timestamp: 1693261840201
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h19fdd8a_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libllvm14-14.0.6-h19fdd8a_4.tar.bz2
   sha256: fd3149d43dd971c2c1243a1f06a6b4e6ca1e405f058a8a6544267de4940c0622
   md5: 53449788cfa51053aed142dcdc1143c4
   depends:
@@ -9106,7 +9106,7 @@ packages:
   license_family: Apache
   size: 26599780
   timestamp: 1726766682927
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnetcdf-4.8.1-h0fce390_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libnetcdf-4.8.1-h0fce390_4.tar.bz2
   sha256: 9b96c9b9ae04e51afd1eedb06140136aa2cac53445391631fc797b19cdb159c3
   md5: 88d838a69640da6ba12b5074ad88c617
   depends:
@@ -9121,7 +9121,7 @@ packages:
   license_family: BSD
   size: 1459940
   timestamp: 1691154694652
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
   sha256: b7cd58ddb892ed9d3983bdde8fc2530f0653a58818c87e08659f3795f04d8aff
   md5: cf519f7233951d00a30c3b969c4cd161
   depends:
@@ -9136,7 +9136,7 @@ packages:
   license_family: MIT
   size: 728977
   timestamp: 1697018415626
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -9147,7 +9147,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -9156,7 +9156,7 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpq-12.17-h02f6b3c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpq-12.17-h02f6b3c_0.tar.bz2
   sha256: 549664d70c08f95e101e43c7cdb44a3c7a4313c4b759133c4d97c473afab73d4
   md5: 382a8ae341228d5e0d0de28992e9e412
   depends:
@@ -9164,7 +9164,7 @@ packages:
   - openssl >=3.0.12,<4.0a0
   size: 2946756
   timestamp: 1706214474947
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-4.25.3-h514c7bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libprotobuf-4.25.3-h514c7bf_0.tar.bz2
   sha256: b628e7b726fc1d77b9b3f8d3078757de8cbc20399a4b0fbdaff6526ba82c4cec
   md5: a92f039187d790f9d8d507549ef61914
   depends:
@@ -9176,13 +9176,13 @@ packages:
   license_family: BSD
   size: 2665938
   timestamp: 1716567699253
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libspatialindex-1.9.3-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libspatialindex-1.9.3-hc377ac9_0.tar.bz2
   sha256: 592a66a6145b5eee819a97caf509b996c84fe2c9ecd69c7e300f8b2a02050682
   md5: 65682197af5a83e3ce46b5d04d44ef3b
   depends:
@@ -9190,7 +9190,7 @@ packages:
   license: MIT
   size: 386585
   timestamp: 1629286650261
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libspatialite-5.1.0-h3e2df84_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libspatialite-5.1.0-h3e2df84_1.tar.bz2
   sha256: 106668624ee0042c096a21d3b6ceaa92b6946bed44af1d9d18b4a80654be8b4f
   md5: e94ec5458fc20edbc4d4053c256873ca
   depends:
@@ -9207,7 +9207,7 @@ packages:
   license_family: OTHER
   size: 4009501
   timestamp: 1722878455670
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.11.0-h3e2b118_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libssh2-1.11.0-h3e2b118_0.tar.bz2
   sha256: 8340de7b6d57959aba55785d3784acfbdf5cc61283b0daeab03804319f2663b2
   md5: ee17e0c05e45b91f073113364ab0030f
   depends:
@@ -9217,7 +9217,7 @@ packages:
   license_family: BSD
   size: 262918
   timestamp: 1715261490602
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
   sha256: 82a73882a31e7a4f4edcdb0c21562e123da913d03b90b19396bd6dd4fcd9a7fc
   md5: b5e5199892949d1e7e2db7bf0ee4dfe9
   depends:
@@ -9230,7 +9230,7 @@ packages:
   license_family: Apache
   size: 361781
   timestamp: 1687975246139
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -9247,7 +9247,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
   sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
   md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
   constrains:
@@ -9256,7 +9256,7 @@ packages:
   license_family: BSD
   size: 331675
   timestamp: 1694776939192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.13.1-h0b34f26_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.13.1-h0b34f26_2.tar.bz2
   sha256: f84299f0fb53bb22cc8b735d7ad0cacf9daa54b58166934f2bcf1e47ec88c6e4
   md5: 8686fc79ea861f1bf3f303e767403f72
   depends:
@@ -9268,7 +9268,7 @@ packages:
   license_family: MIT
   size: 628190
   timestamp: 1722441197607
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzip-1.8.0-h62fee54_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libzip-1.8.0-h62fee54_1.tar.bz2
   sha256: f251f0003d6438118c386d0a86c51c74d1f5c64dfab630006703e98dedda6970
   md5: c001b83d3596059c5536b73b17422797
   depends:
@@ -9282,7 +9282,7 @@ packages:
   license_family: BSD
   size: 121403
   timestamp: 1685378612307
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
   sha256: 41c62a460bb81a1a272aa28b219fab9c26510adac177ff1528b1980eabc6e868
   md5: 8d312c5628dc7ea833e9b4dcb73e9c45
   depends:
@@ -9292,7 +9292,7 @@ packages:
   license_family: MIT
   size: 42346
   timestamp: 1677973051421
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -9301,7 +9301,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.43.0-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.43.0-py311h313beb8_0.tar.bz2
   sha256: e30d9731f52550ab97edacacf9bc11f53d64202e06fbc1747b263c18f26a924b
   md5: 36e9863286c1022e2439cb56b83bc1ce
   depends:
@@ -9312,7 +9312,7 @@ packages:
   license_family: BSD
   size: 409623
   timestamp: 1720455480232
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
   sha256: 5777bbef827f72975a36f3da80ab4af718dc781264f74ad7e3864755d620c0f0
   md5: 4240f1a79b812387919cc710a0469556
   depends:
@@ -9321,7 +9321,7 @@ packages:
   license_family: BSD
   size: 14318
   timestamp: 1677925438733
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.3.2-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-4.3.2-py311h80987f9_0.tar.bz2
   sha256: 14582ae62269dca40493afba1649f929841f5d2bc5907bf0f6f01c6a551062c4
   md5: c920d6dea31be5638d79a76026d523a0
   depends:
@@ -9331,7 +9331,7 @@ packages:
   license_family: BSD
   size: 39941
   timestamp: 1686063850483
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
   sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
   md5: f5f7e6e7541d8dc3d3df270d488d2e24
   depends:
@@ -9340,7 +9340,7 @@ packages:
   license_family: BSD
   size: 176990
   timestamp: 1714510588159
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mapclassify-2.5.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mapclassify-2.5.0-py311hca03da5_0.tar.bz2
   sha256: 879edffd737b34f642fc6db56d9cea345d53d78f218eb7096683347e88cb81f3
   md5: a9165e4af0562b7a1012b7e6d569710a
   depends:
@@ -9354,7 +9354,7 @@ packages:
   license_family: BSD
   size: 84621
   timestamp: 1677993482204
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
   sha256: d024f5142416961a5e66e424d4d14aec652f9e9dd738b41a97f45674c2ffc9d5
   md5: 0e2d94b125d802f7b006cf19c71655a1
   depends:
@@ -9363,7 +9363,7 @@ packages:
   license_family: BSD
   size: 163084
   timestamp: 1677932947966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
   sha256: acfd84e29ff4dc2d85543bb973a07f22b4ba53c5d00bca84608ee7f13b2a8676
   md5: 5ca161cd51e2db358e768453b3ee485e
   depends:
@@ -9373,7 +9373,7 @@ packages:
   license_family: MIT
   size: 135871
   timestamp: 1684279980293
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
   sha256: b1bed54c7bfb7304cde9e8e6f798543d08e808e81286a5a48296fc94d621f9da
   md5: 774358285c9e496c9f5c121cc546c823
   depends:
@@ -9384,7 +9384,7 @@ packages:
   license_family: BSD
   size: 27438
   timestamp: 1704206026910
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.9.2-py311hecf7826_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.9.2-py311hecf7826_0.tar.bz2
   sha256: 405da586a7522b94b0fadaf268e34a289aefaa7a1cc49da8702a13fcff1152f7
   md5: 60d5ec1d897778a50874147ffb31e7db
   depends:
@@ -9404,7 +9404,7 @@ packages:
   license_family: PSF
   size: 9423902
   timestamp: 1725263975062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
   sha256: 3276d61fc353c537bb09d4b7473d7abe12be38806f42c8cc383b62f40850a5cc
   md5: 6e9c9d47f264b77d9a8461f0899848a7
   depends:
@@ -9414,7 +9414,7 @@ packages:
   license_family: BSD
   size: 20446
   timestamp: 1677918370379
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
   sha256: 43c96d30775b61b4968422a47f9605049428120669f0742bbb9e5ba145c7d11e
   md5: a31ca0d9284860adf5463cf45a5e3145
   depends:
@@ -9424,7 +9424,7 @@ packages:
   license_family: MIT
   size: 69243
   timestamp: 1677995336989
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
   sha256: 96d8c9f42a38651b7bafe5f3cb132601db76cd1e28fa58e2eaf090e634292fff
   md5: 5ebc793a17b6aa84d13f19433545ffa5
   depends:
@@ -9433,7 +9433,7 @@ packages:
   license_family: MIT
   size: 23895
   timestamp: 1677942274932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/minizip-4.0.3-ha89c15f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/minizip-4.0.3-ha89c15f_0.tar.bz2
   sha256: ce004bae8d89b5f3205073c2ebfd2c5640983b3ce2764e3ab7eb6ee8b79622f1
   md5: 13e620ec7fb353b7fe5da72085513509
   depends:
@@ -9448,7 +9448,7 @@ packages:
   license_family: Other
   size: 85926
   timestamp: 1702658542217
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
   sha256: db9bd659ada23f1ded443d2db00dd13b5d5c0b30f5062544b1ee2c2b88d63d29
   md5: 03c48121614cf12abfe30eced9b34717
   depends:
@@ -9459,7 +9459,7 @@ packages:
   license_family: BSD
   size: 105333
   timestamp: 1677916687032
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py311h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/msgpack-python-1.0.3-py311h48ca7d4_0.tar.bz2
   sha256: 3e370e88a51671f87fa0c0e241569950f8c5a38d5e8743c33b0193f54d73d10d
   md5: dd70eac354c92710ce4e2be9d4b02043
   depends:
@@ -9469,7 +9469,7 @@ packages:
   license_family: Apache
   size: 38448
   timestamp: 1677909415759
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
   sha256: 8b05894fdcbe5cfcdee94812b043de4cd7b4fa51d3e2aad25fc7cff50c8f82ab
   md5: c970d49137dce1c77f782ee5725950c1
   depends:
@@ -9479,7 +9479,7 @@ packages:
   license_family: BSD
   size: 30745
   timestamp: 1677960816849
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
   sha256: b6fa12e4bde747bf288bda31ce8ec5e24292dbf74fde67f18f9c9c100b845a38
   md5: 2eddc760c15171a1e8aa838d9d162e18
   depends:
@@ -9492,7 +9492,7 @@ packages:
   license_family: BSD
   size: 8291605
   timestamp: 1717622676584
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
   sha256: e8eee27fb667aa10b26f3bc4b93f449b7d991ded27b9cb457effee394ce05f6f
   md5: 6a3e5cd0e1141c01ffb91285bdccfe83
   depends:
@@ -9505,7 +9505,7 @@ packages:
   license_family: BSD
   size: 123043
   timestamp: 1698934328890
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
   sha256: 40230434aa2fbb33ece13632e8d4b7cd1ad68fdb8d1b00263af4a010795d25f8
   md5: f12ce7dad3620d6d53a442fa9d36a0b0
   depends:
@@ -9532,7 +9532,7 @@ packages:
   license_family: BSD
   size: 538067
   timestamp: 1699022954841
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
   sha256: a492acec8ceadc0911a75966ffa630a8eb15b2da8c7a8d544a645ba47771a2d1
   md5: 4002b1b88b2ecfdfc769036f43b0a895
   depends:
@@ -9545,14 +9545,14 @@ packages:
   license_family: BSD
   size: 170964
   timestamp: 1694616845237
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
   sha256: 417ace1ce51e81f3f92ddc26e0e3a83c1e19c9ebb7af7104452002a5573da534
   md5: 3e11de6cef096091bb733e07802f00b0
   depends:
@@ -9561,7 +9561,7 @@ packages:
   license_family: BSD
   size: 16979
   timestamp: 1708532698253
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/netcdf4-1.6.2-py311h55fefbe_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/netcdf4-1.6.2-py311h55fefbe_0.tar.bz2
   sha256: 2f9cf6038c9f3c986c66c926b5be0ff5a39b6e57647d77f90bdc5cbcc7761039
   md5: 0b06a7960b828a49e7b58f2a312af1bc
   depends:
@@ -9575,7 +9575,7 @@ packages:
   license_family: MIT
   size: 458619
   timestamp: 1677960888123
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/networkx-3.3-py311hca03da5_0.tar.bz2
   sha256: 9756a4aa4a76af06a19f0bf3efd3a27b46a0996d8fbbc5c2aebbb2facccb6165
   md5: 6bb9e48cc0a0a0f96256cf19a67e34cc
   depends:
@@ -9593,7 +9593,7 @@ packages:
   license_family: BSD
   size: 3354447
   timestamp: 1720002587103
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
   sha256: 8ea1be4285e2e7d361cbcc1daf9c220f87ceaab2308bf7b339d2513d6ea22184
   md5: 774ce02efa90f212023541c0b24e92c1
   depends:
@@ -9618,7 +9618,7 @@ packages:
   license_family: BSD
   size: 726598
   timestamp: 1717630964815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
   sha256: b0cc542e2a6f42ba716e7e4ccf29eddcb155ad167fcdbc72d2db9c7873eb5639
   md5: 7acf81b17d2c4ceb3cd39dc9f173855c
   depends:
@@ -9628,7 +9628,7 @@ packages:
   license_family: BSD
   size: 27539
   timestamp: 1699455954000
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nspr-4.35-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nspr-4.35-h313beb8_0.tar.bz2
   sha256: 49514dcfb22fb667890bebf464118e59f0c05b0574e39082cf06d4e171fc7f22
   md5: e7808cc8e4a810fe3d9390192c44c619
   depends:
@@ -9637,7 +9637,7 @@ packages:
   license_family: OTHER
   size: 252418
   timestamp: 1685541795239
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nss-3.89.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nss-3.89.1-h313beb8_0.tar.bz2
   sha256: 01fe9808891853091be4aea4f05882ce1991d737e9f409dfc31ee4daa199019e
   md5: 9c3977aa66fc7d91d83f63d79792ee1d
   depends:
@@ -9649,7 +9649,7 @@ packages:
   license_family: OTHER
   size: 2038812
   timestamp: 1685543329548
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.60.0-py311h7aedaa7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numba-0.60.0-py311h7aedaa7_0.tar.bz2
   sha256: 00a7fab2dc788b2f4d748702d9eed2cca75d7486aeff0209f0c2979e2ec28a40
   md5: dc8ceb8ae25109aa6c9face25605e269
   depends:
@@ -9671,7 +9671,7 @@ packages:
   license_family: BSD
   size: 6146936
   timestamp: 1720609337122
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
   sha256: 151a3eb68d1189e69764ece1d8fb3544d31a22f5bbbc3e19d846de8dece304d2
   md5: eb6609e6bdc9c82d70df3f8c4c2de95b
   depends:
@@ -9682,7 +9682,7 @@ packages:
   license_family: MIT
   size: 153313
   timestamp: 1696515415712
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
   sha256: d3bb1d4be88320a5861cd3a0f086e9709f9b64c96c032cb9039cc4f17ec66a85
   md5: 0a7b97665c06fcd34a70e34abc177280
   depends:
@@ -9695,7 +9695,7 @@ packages:
   license_family: BSD
   size: 11288
   timestamp: 1708639168951
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
   sha256: 3e70248a7069ca12ccf56252869bfdb72211fd4e4c327e6994756496df786c79
   md5: ce4846006d98638cd86a532a72f8dfe4
   depends:
@@ -9709,7 +9709,7 @@ packages:
   license_family: BSD
   size: 7536860
   timestamp: 1708639153133
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
   sha256: b9f781280f49644ca05e18aacbdde1c57cc5107e7cc2471b843ea8461672aa7f
   md5: 9125d30e4e105b45f7f7d9c20acafa10
   depends:
@@ -9720,7 +9720,7 @@ packages:
   license_family: BSD
   size: 450131
   timestamp: 1722872679313
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.15-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.15-h80987f9_0.tar.bz2
   sha256: 503def27e5229dc31eb3eea4c86ecabcd46a27b6711a968bafeaf7facfc8eeb1
   md5: 2261823151398e7df6ee94c234f21f11
   depends:
@@ -9729,7 +9729,7 @@ packages:
   license_family: Apache
   size: 4762637
   timestamp: 1725545955868
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-2.0.1-h937ddfc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/orc-2.0.1-h937ddfc_0.tar.bz2
   sha256: 504f44b8b91a085a34fc2674ecfc8e617108cf1fa3484a2e24bed7e16e40679a
   md5: 837ad487be774903686ba041dfad8795
   depends:
@@ -9744,7 +9744,7 @@ packages:
   license_family: Apache
   size: 505018
   timestamp: 1717104635074
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
   sha256: 77b0c0a0fb14d817390244ebd93c36d44a7867239963f211f7c0a72a3f98d382
   md5: b90336feb8a50d2eff880e89acb02f40
   depends:
@@ -9753,7 +9753,7 @@ packages:
   license_family: APACHE
   size: 39617
   timestamp: 1699371253760
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-24.1-py311hca03da5_0.tar.bz2
   sha256: 077c5a53916492c8903911dc8f2661403a95488c937c44233401aaf1b4e513a9
   md5: f996a0feb121848b1e43889b2c523328
   depends:
@@ -9762,7 +9762,7 @@ packages:
   license_family: Apache
   size: 158057
   timestamp: 1720102085523
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.2-py311h7aedaa7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.2.2-py311h7aedaa7_0.tar.bz2
   sha256: 3ee48b8e32d5009fccbb8e0dbb00d905f827982adae9c9f799ad85ba6f13a077
   md5: 9e6f48d13a7911f6b5547e6a9c8dc5e1
   depends:
@@ -9812,7 +9812,7 @@ packages:
   license_family: BSD
   size: 17039081
   timestamp: 1718309063969
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-1.4.4-py311hca03da5_0.tar.bz2
   sha256: 30a99806e616ba4270fd3f517eff88728e50eaaa3a46dd811476eadc4744444a
   md5: 81c2a30ee5913e37fe552f51ab9b19be
   depends:
@@ -9836,7 +9836,7 @@ packages:
   license_family: BSD
   size: 21836599
   timestamp: 1718119512521
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-2.1.1-py311hca03da5_0.tar.bz2
   sha256: 7c4d34def227ba26cea176cd3d522aeb2584989e68052c387925536097cd1f63
   md5: 025e2c935f86e471a35d584c40bbed29
   depends:
@@ -9845,7 +9845,7 @@ packages:
   license_family: BSD
   size: 264597
   timestamp: 1719348054960
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
   sha256: 088245becd055af4de74e4ed13cc752ab546423f204b170ba2dd8809af30a2c7
   md5: 2eabea5ccc56ac088e0349626e59df06
   depends:
@@ -9859,7 +9859,7 @@ packages:
   license_family: BSD
   size: 48517
   timestamp: 1698702686783
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pcre2-10.42-hb066dcc_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pcre2-10.42-hb066dcc_1.tar.bz2
   sha256: 2e3e84ff33de1dfe5f51f04fee5966245629f55e08f5227f2c82e0cc96507ef6
   md5: e3a0c4f02b456d965cdba237423b80c1
   depends:
@@ -9869,7 +9869,7 @@ packages:
   license_family: BSD
   size: 1562789
   timestamp: 1714657668464
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.4.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.4.0-py311h80987f9_0.tar.bz2
   sha256: 4302dcc5c779ae3ceb65c9641bf7ffab447a113be8df1903b08329be8ebf0dda
   md5: a0bcdedab49d87a75e069112dbae7d85
   depends:
@@ -9885,7 +9885,7 @@ packages:
   license_family: Other
   size: 937161
   timestamp: 1721059673573
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-24.2-py311hca03da5_0.tar.bz2
   sha256: 4f82ab7dc13317069ec808da81c472668e6ab85f5d74d5b385b6d86b4ef32bad
   md5: f9c03ed21097422236806938a7b7dd64
   depends:
@@ -9896,13 +9896,13 @@ packages:
   license_family: MIT
   size: 2918476
   timestamp: 1723484709578
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pixman-0.40.0-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pixman-0.40.0-h1a28f6b_0.tar.bz2
   sha256: a7b1a6ddba772080777ac65570dffa9ed08dd866e053fa98f3aa38835c9b010b
   md5: a3abe939bd01b7f6fb4e4f3b6da91f7b
   license: MIT
   size: 269396
   timestamp: 1628926728556
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
   sha256: b6200816d65673aa1707c20a768c9cff87dd8dbe1335f9c1478e5931dfa08ee0
   md5: 14b1e0fa73eb33f9c83048482dcce57b
   depends:
@@ -9911,7 +9911,7 @@ packages:
   license_family: MIT
   size: 38423
   timestamp: 1692205689597
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pooch-1.7.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pooch-1.7.0-py311hca03da5_0.tar.bz2
   sha256: 1571b209edc53736c9553ed18bcf571403c0a6068f59fbe9bb692e602aef3d77
   md5: 86d822035dc65f8a0d6986e7c4e4c2e1
   depends:
@@ -9927,7 +9927,7 @@ packages:
   license_family: BSD
   size: 106499
   timestamp: 1695850196324
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/poppler-22.12.0-h52f4003_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/poppler-22.12.0-h52f4003_3.tar.bz2
   sha256: 9f8cf7e763c5ce4cf0a5ebfc8db8b885b3c4e70c9b9433a96f5500b7fba4f3cc
   md5: 40ae9e180cbf21de5afdfe4fd096849b
   depends:
@@ -9953,14 +9953,14 @@ packages:
   license_family: GPL
   size: 1749726
   timestamp: 1696000773528
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/poppler-data-0.4.11-hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/poppler-data-0.4.11-hca03da5_1.tar.bz2
   sha256: 964a66d899c6c661baabf19c89dfeb71586ca495efb5dfe141c3d4d1447e87e6
   md5: 2fd602e0516b7352f115305cba7708a9
   license: GPL-2.0-or-later and GPL-3.0-or-later and BSD-3-Clause
   license_family: GPL
   size: 3918339
   timestamp: 1673886276945
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/proj-9.3.1-h805f6d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/proj-9.3.1-h805f6d4_0.tar.bz2
   sha256: 822ddf540e6702714be8691b449d570e8b086b6ba11c74dfcf956c8e4bc37d7a
   md5: 20f3d6ee5166bf3a89175c703ffba3f1
   depends:
@@ -9974,7 +9974,7 @@ packages:
   license_family: MIT
   size: 3037164
   timestamp: 1704728708532
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
   sha256: ebdf211edd98d88a23778551c7a9702106edd0695d4fc48e87c21f77521c1ffe
   md5: d8c505081a468f1b99c62466e2309417
   depends:
@@ -9983,7 +9983,7 @@ packages:
   license_family: Apache
   size: 123084
   timestamp: 1678996822234
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
   sha256: 07cfba50d9e94364bde077731a824ca4f537138b35ee6b66d07aee16ac9850f1
   md5: 919bf486280a11e6acb3c2c3a82f7473
   depends:
@@ -9995,7 +9995,7 @@ packages:
   license_family: BSD
   size: 763225
   timestamp: 1704404463402
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
   sha256: 8094436b2c44e68e72569c704633802aad82e977b1e16026848218679c8becf4
   md5: 2360e46d3e598dd5e2abed781fe166c5
   depends:
@@ -10004,7 +10004,7 @@ packages:
   license_family: BSD
   size: 502115
   timestamp: 1678995719872
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-16.1.0-py311h7aedaa7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyarrow-16.1.0-py311h7aedaa7_0.tar.bz2
   sha256: 5f958c3434a27f1e95dc17918ea2bace13c95fda83d784449f63c53c9af4f13a
   md5: e83cc83394ec825f5a1c95f5d276ff84
   depends:
@@ -10016,7 +10016,7 @@ packages:
   license_family: Apache
   size: 4857208
   timestamp: 1721674203411
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
   sha256: 4f17f70658e32a9a86661184cace6be3bb7bd61f9b55b513092beddf44552679
   md5: 0aa95279688b0433badea0b660ac8146
   depends:
@@ -10028,7 +10028,7 @@ packages:
   license_family: BSD
   size: 38653
   timestamp: 1677933613643
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
   sha256: 121b5b66721760c05f1d4eee91626229d1814663d3fb5f23126ef870aa496e26
   md5: 0c588c2ca790a05d422c06e8568201ad
   depends:
@@ -10037,7 +10037,7 @@ packages:
   license_family: BSD
   size: 2124200
   timestamp: 1684280082141
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.1.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.1.2-py311hca03da5_0.tar.bz2
   sha256: 4ab265ca91c0d88f68a7fee197dc9253aa6f5c4b1e3ae3469b7a042551faf59a
   md5: 3225d4ec5e761e40f524727cafe781f9
   depends:
@@ -10046,7 +10046,7 @@ packages:
   license_family: MIT
   size: 460107
   timestamp: 1725041695293
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyproj-3.6.1-py311h041c639_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyproj-3.6.1-py311h041c639_0.tar.bz2
   sha256: c8c55bae91000aa066ab44144ec20fc4704415e85ab3066952dccd7d5eb81176
   md5: e030800d83b234505dc35b4eafc41004
   depends:
@@ -10057,7 +10057,7 @@ packages:
   license_family: MIT
   size: 599383
   timestamp: 1704901394028
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyshp-2.3.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyshp-2.3.1-py311hca03da5_0.tar.bz2
   sha256: 6bdb5646ba3634799356b14377eb6ae3576bb7643da8bf6b47295864a3e1393e
   md5: e330fead08da221c20ee1dec20e89935
   depends:
@@ -10066,7 +10066,7 @@ packages:
   license_family: MIT
   size: 86945
   timestamp: 1706101072054
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
   sha256: 0bb3d2a57b332c5cf73ea40ea13c850ae24a1f9a3a41ed9267832d9e3c767572
   md5: 45a7fcf1641980d5114999736428502d
   depends:
@@ -10075,7 +10075,7 @@ packages:
   license_family: BSD
   size: 36755
   timestamp: 1677906514270
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
   sha256: 960c343b7b8569dfe4e71a395f7bede1e749da7b02c17506b590c9e1839e6fd7
   md5: 722c4b4386af73cf1562974a00c880a4
   depends:
@@ -10094,7 +10094,7 @@ packages:
   license_family: PSF
   size: 16494386
   timestamp: 1713545544909
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
   sha256: c3cbf5bd237b0a7458640191016b2701fe120c547df9afc835da76663a9c17f7
   md5: 843568c76b6b9384635b7fca74c79792
   depends:
@@ -10104,7 +10104,7 @@ packages:
   license_family: BSD
   size: 332222
   timestamp: 1716495881101
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
   sha256: f94b3cfea6f76ea9983e16d3c4c7e0a64f02c40cc2c3ad57189bca2e67030bd9
   md5: 0d100990ade57a02b60d1e8085db0bdf
   depends:
@@ -10113,7 +10113,7 @@ packages:
   license_family: BSD
   size: 280263
   timestamp: 1678996927464
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
   sha256: 252c86f5aef7f8dfce99a260c24cbb35a9adfea144a2acfabb224f516341544f
   md5: 745b888e19a644f48800799f82c01c21
   depends:
@@ -10122,7 +10122,7 @@ packages:
   license_family: BSD
   size: 18539
   timestamp: 1683823925189
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-lmdb-1.4.1-py311h313beb8_0.tar.bz2
   sha256: 5a40b7ba3aaff79b21020a5ba9df44202d9fa6152abd81f91ed1602cfa864ed7
   md5: 95226a611d81daf647c0211ef2de31a7
   depends:
@@ -10132,7 +10132,7 @@ packages:
   license_family: Other
   size: 148513
   timestamp: 1682522467465
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
   sha256: d945744eb133f19ca61325cac5128bdb053ae04de4a0ba6f69c061449cac8af7
   md5: 34baa81490d667381bc7021435b0e1f2
   depends:
@@ -10141,7 +10141,7 @@ packages:
   license_family: MIT
   size: 275858
   timestamp: 1713974457562
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
   sha256: 012585bdb5ae54c2cded50be703734e6dbf418b003635b6f6d7c1e36e7020c30
   md5: da7e99a707bd0cfa20db651b5c068bfd
   depends:
@@ -10153,7 +10153,7 @@ packages:
   license_family: BSD
   size: 65556
   timestamp: 1711136890180
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
   sha256: 4f04a43cbd612ab09cefbdc2e48ee61b51967dad59d859ce0502cc2c46c88fc5
   md5: c68bf65433b2151b51b2e699bc22c501
   depends:
@@ -10163,7 +10163,7 @@ packages:
   license_family: MIT
   size: 194632
   timestamp: 1698096151085
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
   sha256: ae8cdd5be5a7ad19ff82925a035859fafcc5942cd3899d127a508dbb9a235090
   md5: 252a7b997d08bf72f10b3bc2dc68333e
   depends:
@@ -10173,7 +10173,7 @@ packages:
   license_family: Other
   size: 580346
   timestamp: 1709318480624
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/qhull-2020.2-h48ca7d4_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/qhull-2020.2-h48ca7d4_2.tar.bz2
   sha256: e033f2c9e52aa705d9c10d9a352bdad47a363299e42ad62bd7089ddf112ca355
   md5: b7e91b270376c6d7281413dc8779cdea
   depends:
@@ -10182,7 +10182,7 @@ packages:
   license_family: Other
   size: 1888397
   timestamp: 1670915845902
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
   sha256: 089c6b9bebfa690f380710f219ab0fcc1acec9f2e187d4174a08222c45f58afc
   md5: 11b832c6c10a6d2b0e687a20c3037c97
   depends:
@@ -10190,7 +10190,7 @@ packages:
   license: BSD-3-Clause
   size: 194532
   timestamp: 1652449531448
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -10199,7 +10199,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
   sha256: 7a208abc002a2fc208ae25cb2cf932999a3e4980aa4c9edff315cb9ac62b12ce
   md5: bd22ebd3cff811577ea61f115ba7f4f2
   depends:
@@ -10210,7 +10210,7 @@ packages:
   license_family: MIT
   size: 74744
   timestamp: 1699012126255
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.32.3-py311hca03da5_0.tar.bz2
   sha256: 5b63727e751cfb353b774b4324e1f5f959da5e689ee360214ed4d61b8848ecf9
   md5: 94d4814a235f0aaadac2d8da53306e04
   depends:
@@ -10226,7 +10226,7 @@ packages:
   license_family: Apache
   size: 124591
   timestamp: 1721414777485
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
   sha256: 52368d9b557b8f54ef5ca4bf6cd5a3ec665171f2b2d2082cdd410bab88f4829c
   md5: ac76fb4d2eef3ecdd491cf5d3fb8620d
   depends:
@@ -10236,7 +10236,7 @@ packages:
   license_family: MIT
   size: 10204
   timestamp: 1683077239143
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
   sha256: 491d116c5f54ef340e3bce631835f7138cd1923d7b63e6ca9aa01b48110cb8f9
   md5: 9b81bd8ea808704f5433884b567f1f15
   depends:
@@ -10245,7 +10245,7 @@ packages:
   license_family: MIT
   size: 10557
   timestamp: 1683059079547
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
   sha256: b53a5f6119173d62e4e68a37ea8511c7fc87a00af72953e0048d075a799c7a7a
   md5: 76a16cf4edb9b12b2b96a2d323f060dc
   depends:
@@ -10254,7 +10254,7 @@ packages:
   license_family: MIT
   size: 342535
   timestamp: 1698945991201
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rtree-1.0.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rtree-1.0.1-py311hca03da5_0.tar.bz2
   sha256: 2f4457741d2274010be78d78bb81b50007e775d5cf80be40d37ea6cf330bef5f
   md5: e22184f5affec782f7ad7be24e1a4d41
   depends:
@@ -10265,7 +10265,7 @@ packages:
   license_family: MIT
   size: 64383
   timestamp: 1677961908382
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scikit-learn-1.5.1-py311h7aedaa7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/scikit-learn-1.5.1-py311h7aedaa7_0.tar.bz2
   sha256: 6e32d67ed188863eb571cb73e56810c4dadad1aa027edc126ed8162620d1477f
   md5: 15480c79144ebf3ca7ae82e045e92785
   depends:
@@ -10280,7 +10280,7 @@ packages:
   license_family: BSD
   size: 12328951
   timestamp: 1721924044788
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.13.1-py311hac8794a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.13.1-py311hac8794a_0.tar.bz2
   sha256: 670a9eb2b03627ded04a6a9c20636f3dadd6adc47dd8a091ff996a5ee22634e4
   md5: d6bbfadefc4377ce93958944879a02ff
   depends:
@@ -10298,7 +10298,7 @@ packages:
   license_family: BSD
   size: 26137801
   timestamp: 1717523015496
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
   sha256: c80d52567084b1caaed2862b77b70065ca17afaf0b020733e9d6c273b4a63e78
   md5: ddf7d88c1967f3f7a4ce1c975fd47e0d
   depends:
@@ -10307,7 +10307,7 @@ packages:
   license_family: BSD
   size: 33321
   timestamp: 1699371225235
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-75.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-75.1.0-py311hca03da5_0.tar.bz2
   sha256: 70c84e0f41fa9eac5f35d447ebc6417279180694bddecdbba5d14e12124b56f2
   md5: cdfbbc473d52a1334490dd81c7833ae7
   depends:
@@ -10316,7 +10316,7 @@ packages:
   license_family: MIT
   size: 2317457
   timestamp: 1726677954270
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/shapely-2.0.5-py311h3713c0e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/shapely-2.0.5-py311h3713c0e_0.tar.bz2
   sha256: 449896a8fdb7958ed9aece7ee58a5e651ac8dea9b87428e3ac79195b3591ff91
   md5: f3df01e03a53bf47a3ea490e98f96520
   depends:
@@ -10327,7 +10327,7 @@ packages:
   license_family: BSD
   size: 593369
   timestamp: 1722533349628
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
   sha256: 499623019bea7cd167924f7fa841237b11b81a1e9cafe9b8ffde47d329275167
   md5: 290d04cffc69bf26a4ed9f1aa9ad42e4
   depends:
@@ -10336,7 +10336,7 @@ packages:
   license_family: BSD
   size: 46038
   timestamp: 1723557442909
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
   sha256: cd71091a234874d2826fa063ec5222b3191c9f47e1b5281c352d9df3f31a06bf
   md5: 0db8e29016c6bff026c083d9923a7566
   depends:
@@ -10345,7 +10345,7 @@ packages:
   license_family: Other
   size: 19073
   timestamp: 1705431415504
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
   sha256: 3e18cdafc607c6d7623b1c8f041cbfbb50a27e298f961abdcce7e36834ac39e1
   md5: 9ee0da74c55d0b8d83edf246fd717f20
   depends:
@@ -10354,7 +10354,7 @@ packages:
   license_family: MIT
   size: 89862
   timestamp: 1696347657368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
   sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
   md5: d8c1e9910392d0bcb22a173f9ce30fa6
   depends:
@@ -10366,7 +10366,7 @@ packages:
   license_family: Other
   size: 1758290
   timestamp: 1714488307689
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
   sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
   md5: ae58720a18a2ed15eae214ad7a10d1b5
   depends:
@@ -10375,7 +10375,7 @@ packages:
   license_family: Apache
   size: 140125
   timestamp: 1680167256603
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
   sha256: b5c265e9ed9a1ff2238a09b83bdc1826950faa87fd6b685debe60888de6e7a50
   md5: 5827c8a32317894ce18576e334daba47
   depends:
@@ -10386,7 +10386,7 @@ packages:
   license_family: BSD
   size: 38559
   timestamp: 1677918962258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/threadpoolctl-3.5.0-py311hb6e6a13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/threadpoolctl-3.5.0-py311hb6e6a13_0.tar.bz2
   sha256: 63378c3a92be71f9e8f573f4f793b1928567880d4d0cf1f780eeeedd29f62e6b
   md5: 81e422eb374160f7b365d92fac5ad2b5
   depends:
@@ -10395,7 +10395,7 @@ packages:
   license_family: BSD
   size: 49989
   timestamp: 1719407928127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tiledb-2.3.3-hb4a6b97_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tiledb-2.3.3-hb4a6b97_3.tar.bz2
   sha256: b211874f0c31087994f3c23cc33bebcfce27233b9cd62cbe09bc801023943135
   md5: ee2847a715600bc225b6014ac9af797a
   depends:
@@ -10411,7 +10411,7 @@ packages:
   license_family: MIT
   size: 2791548
   timestamp: 1685656859713
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
   sha256: cfefd86d0f4981d22b7611b3dc60359b8698bf39f2b743cb90b7005aaca88e1e
   md5: a04dbcd6095f6b8f3ad195a78d48b262
   depends:
@@ -10421,7 +10421,7 @@ packages:
   license_family: BSD
   size: 50058
   timestamp: 1677917499177
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
   sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
   md5: 3c25b4f4768ccda28b20a03ba27e7759
   depends:
@@ -10430,7 +10430,7 @@ packages:
   license_family: BSD
   size: 3484151
   timestamp: 1714770744982
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
   sha256: 0836468fafb1f5badbb573922e37200c6929bf2926ecf8d2259dff43811e0727
   md5: 5bc56dcb4bdb7cf623b7cea499feaddb
   depends:
@@ -10439,7 +10439,7 @@ packages:
   license_family: BSD
   size: 136409
   timestamp: 1677925889207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.1-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.4.1-py311h80987f9_0.tar.bz2
   sha256: 2fd655106e52bb73deea5a0af63708e75cf66e071f0f3f15c04a67413f721430
   md5: 324986c435dcfc101684907ce85c199e
   depends:
@@ -10448,7 +10448,7 @@ packages:
   license_family: Apache
   size: 915790
   timestamp: 1718740267109
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.5-py311hb6e6a13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.66.5-py311hb6e6a13_0.tar.bz2
   sha256: f6cda770cbe84b10f2d78d41bab43e1a1386e9722569c9b2b235083947fe90cc
   md5: f5306a7b16da13a7258a20cecb62cdd5
   depends:
@@ -10459,7 +10459,7 @@ packages:
   license_family: MOZILLA
   size: 155732
   timestamp: 1724854273737
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
   sha256: 707e5dfdb9116f31bc1ad7f497f6e8416683add460258fdc2a4c16eec85226be
   md5: ffb602322a388ec8e1f385edaca3ce12
   depends:
@@ -10468,7 +10468,7 @@ packages:
   license_family: BSD
   size: 208171
   timestamp: 1718227091374
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
   sha256: 96071e07e807414b7ae5a2fe958ac171e5795576b3a4c2f5e8c643fba43d760f
   md5: a34f2b216e35a37f966883dacda229e2
   depends:
@@ -10478,7 +10478,7 @@ packages:
   license_family: PSF
   size: 9902
   timestamp: 1715268985387
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
   sha256: b20e48aff4c781a52b6be66d77418e768527a621f5fc272ecb34ea03475b2bd7
   md5: 707738432f16f5e63909fcaa6e65850d
   depends:
@@ -10487,7 +10487,7 @@ packages:
   license_family: PSF
   size: 75604
   timestamp: 1715268976065
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
   sha256: 2ea2d0520b330d381a2ab241bdb9ae146ef815ee7c96ee52a9773fb9ae85f4fd
   md5: 66f7f8979cfb2cccffac972d70482130
   depends:
@@ -10496,7 +10496,7 @@ packages:
   license_family: MIT
   size: 12614
   timestamp: 1677963554857
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
   sha256: df7fe7740bd853b641d624e2ec97f1aacb2b82691936a8c04ef18fa9768539c2
   md5: d5c7626d45fd03b22797c18e47812beb
   depends:
@@ -10505,14 +10505,14 @@ packages:
   license_family: Apache
   size: 518048
   timestamp: 1713213046424
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uriparser-0.9.7-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uriparser-0.9.7-h80987f9_0.tar.bz2
   sha256: c7402bdd16743bbd3350752e7009e40024b7ea2d280f54a6f74a4246f99e0edf
   md5: 666f1bc2359d58c32ccbcbf4e9fcadd7
   license: BSD-3-Clause
   license_family: BSD
   size: 42998
   timestamp: 1692186946914
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.2.2-py311hca03da5_0.tar.bz2
   sha256: bfdfb02fd3dd1c01fd36b0753e365bfe599153da178619d8b62814c89682ab8e
   md5: c30603849b5abe9935b0a58b2904a090
   depends:
@@ -10528,14 +10528,14 @@ packages:
   license_family: MIT
   size: 210621
   timestamp: 1718912666948
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
   sha256: 20ae100fd04de16356f26e7c9dab514015e57a9d54fb78767aa5ed97de7846fb
   md5: f620d98b3d0072945948310c86f0f1c5
   license: MIT
   license_family: MIT
   size: 157385
   timestamp: 1706894678643
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
   sha256: 09738b7f9075386bf062b12ddb6fb72a06450d2481f6b5ca2026c811cd849569
   md5: 9afdec076c95746ac21235f971190e40
   depends:
@@ -10544,7 +10544,7 @@ packages:
   license_family: BSD
   size: 26727
   timestamp: 1677910175964
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
   sha256: b4ced7366de8eb7258f31d516616e70c62ed4a798780e57e208509d2b52ab435
   md5: 65a9a05a726734c1da667f9bd3c78c14
   depends:
@@ -10553,7 +10553,7 @@ packages:
   license_family: Apache
   size: 114733
   timestamp: 1715878377412
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.44.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.44.0-py311hca03da5_0.tar.bz2
   sha256: 088f397ff8a4a7e178415dd7e2ff987c02b3674c7b6885972fb6c669978aff40
   md5: a87f4be160e50ea022588aab7c7322bf
   depends:
@@ -10562,7 +10562,7 @@ packages:
   license_family: MIT
   size: 139304
   timestamp: 1726165038360
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
   sha256: cf030fc7020dc6d28530075468b8dc1edd843a1e393a2f81ca81c962e9af977b
   md5: cae3fc90233f3af8f433a253d035b6e6
   depends:
@@ -10574,7 +10574,7 @@ packages:
   license_family: Apache
   size: 2470844
   timestamp: 1689041497962
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xerces-c-3.2.4-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xerces-c-3.2.4-h313beb8_1.tar.bz2
   sha256: 0f084440eba1b43120912f01cd0fff05d564b75d8a37ad1d9368b8c1fee757fa
   md5: 45efffaf1c16790a7d418d53856a0fa3
   depends:
@@ -10584,7 +10584,7 @@ packages:
   license_family: Apache
   size: 2734029
   timestamp: 1692994862695
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
   sha256: 2cd108896df65636769e3804ecc2ca421ad9b54e64fa21922bbabe40c90c247a
   md5: b3a1e5077b28f71298d891fbfb5ff03e
   depends:
@@ -10593,20 +10593,20 @@ packages:
   license_family: BSD
   size: 55645
   timestamp: 1677927459979
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
   sha256: 5be8c968f2da5c4bf14f28d63e31b4c1b6993d980023769732c7f58f396c2e0b
   md5: 3f5f62d4e85e3bdd48d39189b01805a6
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 459197
   timestamp: 1714510992914
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
   sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
   md5: 3d57d1adadca9388aaaa1c529b65ba65
   depends:
@@ -10616,7 +10616,7 @@ packages:
   license_family: Other
   size: 322790
   timestamp: 1705602163804
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zict-3.0.0-py311hca03da5_0.tar.bz2
   sha256: db7fb95af4702cb2ce5281333fa769006f532bc39e8e5bd580a2eb9970a7a38d
   md5: 2c13d5a0b62ff7a644a6957829dc54a6
   depends:
@@ -10627,7 +10627,7 @@ packages:
   license_family: BSD
   size: 103248
   timestamp: 1695832909752
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
   sha256: cf38c69cf62d8f07b91b14bef8e0b6fc5ac220bd3a6cd2ab0378283f0f11494a
   md5: 11660f745caf5eed1d03eafadb32678b
   depends:
@@ -10636,14 +10636,14 @@ packages:
   license_family: MIT
   size: 25470
   timestamp: 1704206932876
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
   sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
   md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
   license: Zlib
   license_family: Other
   size: 104928
   timestamp: 1714510936868
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
   sha256: a3f3eaf240991b6bd7b0596a78d0abb3321cc79db52fa24f6f559189778871c6
   md5: 71f035b4716322539e2461cb6667e946
   depends:
@@ -10655,7 +10655,7 @@ packages:
   license_family: BSD
   size: 825339
   timestamp: 1714678419523
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
   sha256: 6e6787755de0cf2fd776c9681a7b0fd0fb23e35e679a463cc2005b991c413910
   md5: ccad42ec9a2ad48939f089c528abc8f0
   depends:
@@ -10669,7 +10669,7 @@ packages:
   license_family: MIT
   size: 229694
   timestamp: 1706220431719
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
   sha256: f715f7c2e06149bd6d43258e41479d3171efe5e9d56050a0a5f5652ed9d05fff
   md5: 11a8ca43d69881b88f95ae681478866d
   depends:
@@ -10681,7 +10681,7 @@ packages:
   license_family: MIT
   size: 36089
   timestamp: 1676424516042
-- conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-16.1.0-h7cd61ee_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/arrow-cpp-16.1.0-h7cd61ee_0.tar.bz2
   sha256: df8114d6fe4c36f14e747ec009e37f8ef1c04639d366a5de71be565fda158c21
   md5: 7af8c5f125b3edfd6c1d2c5767a4d64c
   depends:
@@ -10713,7 +10713,7 @@ packages:
   license_family: Apache
   size: 8713773
   timestamp: 1721660803401
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
   sha256: 9adabcdd2a10f73fa5ba56adc901eeea2e379991a0d4cb9737eec7aa6b9fc5d8
   md5: fc80b572be85601706d425b21a58d497
   depends:
@@ -10722,7 +10722,7 @@ packages:
   license_family: MIT
   size: 153102
   timestamp: 1695718054194
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
   sha256: a11741c5aaa360b4772d0fb7eea606edb5266a4e2806b22f0b8b65b69b7a7273
   md5: 9a54285c5e75ab5e6bfcb3b5590f9449
   depends:
@@ -10737,7 +10737,7 @@ packages:
   license_family: Apache
   size: 93395
   timestamp: 1706746331576
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
   sha256: 32b4da68dd0edbf0c8d7a8a18ba400b26775faabaccbc2cb3e9d2ab7c65e7714
   md5: 48f0a7a7f739d8be4c9dd061be217619
   depends:
@@ -10748,7 +10748,7 @@ packages:
   license_family: Apache
   size: 45714
   timestamp: 1706691182873
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
   sha256: d2710c7f5b4bb8f94a964996387fbd6396f9881d163affeb7ffb050a39e58c1c
   md5: 1a8a2f82798a94d1b272ec2d307cc5ef
   depends:
@@ -10758,7 +10758,7 @@ packages:
   license_family: Apache
   size: 195487
   timestamp: 1706190077309
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
   sha256: 0a5ea74ebcf9bdccfad972add8ff83a47992ab28370cebc34fc4594c1c7cf03a
   md5: 2f90d407ca685c124ddb5fc4d79f4517
   depends:
@@ -10769,7 +10769,7 @@ packages:
   license_family: Apache
   size: 21804
   timestamp: 1706690937014
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
   sha256: 334d2d9c4181c9955256485f66bf4e48ae9b1dc03044aa0424bf1fda292b3151
   md5: 9ab57953af3164d3d94001eeca0e6359
   depends:
@@ -10782,7 +10782,7 @@ packages:
   license_family: Apache
   size: 52661
   timestamp: 1706697357084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
   sha256: 59155d1258b4e29c0046e5ab14b1e2cb3ccfca069982fe9dd4cd751b1ed67492
   md5: 28bd7c351db93c3b8520cc1598eddf66
   depends:
@@ -10796,7 +10796,7 @@ packages:
   license_family: Apache
   size: 177605
   timestamp: 1706744253596
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
   sha256: 3aa9b1c2c508a5dcfb482083cb986498f6df460e652cc7557d3c2d122d559ebe
   md5: b8bf7ae26d234b6738fc37b7c172b3c5
   depends:
@@ -10808,7 +10808,7 @@ packages:
   license_family: Apache
   size: 145865
   timestamp: 1706696287610
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
   sha256: 68564155186523ec8b97b892d0a6b62b3e6f75e4e2b80fac5684011e070295d6
   md5: ba2fa531a69a5a7e4966eba6d7891c8b
   depends:
@@ -10821,7 +10821,7 @@ packages:
   license_family: Apache
   size: 69542
   timestamp: 1706746839018
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
   sha256: 9c0f2f18f8b7e10e940d2438d70a2a03893421f25fd50461b8b2979f3a310a15
   md5: da0f3ce6d8f71a71e6cae01832d853f5
   depends:
@@ -10837,7 +10837,7 @@ packages:
   license_family: Apache
   size: 72614
   timestamp: 1706747680710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
   sha256: bcee1da236f6f5f88322979daddc89e8555648593f6282ad3073a68eb22a68d2
   md5: bf4c19b0db5049930d8b2fcc3b9172fa
   depends:
@@ -10848,7 +10848,7 @@ packages:
   license_family: Apache
   size: 51027
   timestamp: 1706690972693
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
   sha256: 32561df1e664cb320f79c26c5af23dd55953924e66824e2d6372a44687147bdc
   md5: 05f4c6715180a992468035c0a86e734c
   depends:
@@ -10859,7 +10859,7 @@ packages:
   license_family: Apache
   size: 54300
   timestamp: 1706192197648
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
   sha256: 94d2fff3facfd248968d39a3fd7d3b1f7270df32a87dd567c33d60da1a5eb064
   md5: 64fed6e7c73d88bfbfc39e838022f948
   depends:
@@ -10878,7 +10878,7 @@ packages:
   license_family: Apache
   size: 199877
   timestamp: 1706827970924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.10.55-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-sdk-cpp-1.10.55-hd77b12b_0.tar.bz2
   sha256: 813f252df10d2782fbb26e2c6348f55d44ef1618467e340224df44bcda4814ff
   md5: 8efc1448ada827ddba894a07903808dc
   depends:
@@ -10893,7 +10893,7 @@ packages:
   license_family: Apache
   size: 2519847
   timestamp: 1706890866084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
   sha256: f1eb2a5aeb25efa0b38fc1dd94a36d431bc80d654f11a052f67a899dcc471f57
   md5: 9db5a441c7cbcf4dc617f8c722e4310d
   depends:
@@ -10903,12 +10903,12 @@ packages:
   license_family: MIT
   size: 276663
   timestamp: 1718029990621
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
   sha256: cf9a8a0745c5fab48394d84a58fe2f06e5fa80c87d5cc8d6c8da2e1df52cc69f
   md5: 462987773ecda8cbf1f80734e84f080f
   depends:
@@ -10921,7 +10921,7 @@ packages:
   license_family: BSD
   size: 93601
   timestamp: 1675247818708
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.1-py311h746a85d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-3.4.1-py311h746a85d_0.tar.bz2
   sha256: 5e81c00b64a071a07c5ff5892fd48b94476c93121fdb2c28581dbf2e023480d8
   md5: fdd289f6664341f6b29f70804d322594
   depends:
@@ -10939,7 +10939,7 @@ packages:
   license_family: BSD
   size: 6101282
   timestamp: 1718119807269
-- conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
   sha256: 68ef338b27c035add89c0812ad469dd8c9e94f27130f770345ea20deb049d50b
   md5: 9ec19b145f655329532b608963cf32f4
   depends:
@@ -10950,7 +10950,7 @@ packages:
   license_family: OTHER
   size: 11334
   timestamp: 1696764270626
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
   sha256: 5c12a5d7856d9977447360b3a99a5b99818707fe79781ba1779037f11b3fef53
   md5: 6a125ae352306a944aabc635a5fe13a3
   depends:
@@ -10962,7 +10962,7 @@ packages:
   license_family: BSD
   size: 139230
   timestamp: 1707864402762
-- conda: https://repo.anaconda.com/pkgs/main/win-64/branca-0.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/branca-0.6.0-py311haa95532_0.tar.bz2
   sha256: 2778c36a218b44951d906c57b8d16cc46d9c9bfa4141da6413a31c0fd4103ffe
   md5: 50d55880f75cbdba49c3f97efb7f65e9
   depends:
@@ -10972,7 +10972,7 @@ packages:
   license_family: MIT
   size: 53770
   timestamp: 1678291335761
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 751071782f597f87ed7f67437ef6cc669213902461b9795dd6eb0f4897eddc83
   md5: 5ad8fe62aad5e16cfdf2c5a7d1327fe7
   depends:
@@ -10984,7 +10984,7 @@ packages:
   license: MIT
   size: 19418
   timestamp: 1714483531456
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 9bd62d810867549b9c967c5915f3fa3f66cfbd6ede28b1cc152efd1261285c0a
   md5: 64cc76de3662b62bc8f0e42befd92c5d
   depends:
@@ -10995,7 +10995,7 @@ packages:
   license: MIT
   size: 32178
   timestamp: 1714483513837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
   sha256: 1547fa52134cf06b8d01bdf52114db7db60a89bf35c9c95be5b5a03b13dbd565
   md5: deb765cb7c4b7edc4d126f864f31747c
   depends:
@@ -11005,7 +11005,7 @@ packages:
   license: MIT
   size: 356401
   timestamp: 1714483740924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
   sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
   md5: 11e0af09a31e2d5df51c65a342032b85
   depends:
@@ -11015,7 +11015,7 @@ packages:
   license_family: BSD
   size: 112994
   timestamp: 1714511182837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
   sha256: 41a6c5a90b88ec7010bb6dd89390754e476b52c3ab2d519bdab9556da8829479
   md5: b047426a545e287f45e8abfbfcb0de55
   depends:
@@ -11025,14 +11025,14 @@ packages:
   license_family: MIT
   size: 118041
   timestamp: 1693902191485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.7.2-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2024.7.2-haa95532_0.tar.bz2
   sha256: e84389ae72c9f63990b605d03962b1c502c235fd4484497ee9b1deccb3b7e5f4
   md5: 3dd1e7bf8c80bc5b45952beaab5a9fc8
   license: MPL-2.0
   license_family: Other
   size: 170658
   timestamp: 1720622045755
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cairo-1.16.0-haedb8bc_5.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cairo-1.16.0-haedb8bc_5.tar.bz2
   sha256: 56af1f19db12dee9dbb177873726b3fdf6cbbd83736748c99ad7c536ff28ff28
   md5: f2923f93791571dd8a664da18b5de5d0
   depends:
@@ -11048,7 +11048,7 @@ packages:
   license_family: LGPL
   size: 2351737
   timestamp: 1688495984273
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cartopy-0.22.0-py311h786e728_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cartopy-0.22.0-py311h786e728_0.tar.bz2
   sha256: 02f3a82880a35d257467e517b1d233f2ffa720d46b96edbfc4aa72815c33adb2
   md5: 4970ad0c66497ae3c67fe2c9e6fbb46c
   depends:
@@ -11069,7 +11069,7 @@ packages:
   license_family: LGPL
   size: 2148686
   timestamp: 1706196267414
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.8.30-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2024.8.30-py311haa95532_0.tar.bz2
   sha256: ddf997fd83ad3c39c91c80c97ffa35b76565c400a3993ff88ef3730c2cccb14b
   md5: 5b933b0d173e2af3d30a74a74c9c3c69
   depends:
@@ -11078,7 +11078,7 @@ packages:
   license_family: Other
   size: 169591
   timestamp: 1725551908109
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py311h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.17.1-py311h827c3e9_0.tar.bz2
   sha256: 70eecd3e89d12624083a73c998d818dceb1505ab8e7be7d1f4814950b18c2fcf
   md5: 1427fd9ad1be3e40e6dd5751d98fd96c
   depends:
@@ -11090,7 +11090,7 @@ packages:
   license_family: MIT
   size: 309709
   timestamp: 1726856612505
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
   sha256: a65386e70bdad9aa1e07ad430309c3ddc249b74bea69388dfbda99fd00069665
   md5: e4174218de194962642b353f51a19d1e
   depends:
@@ -11100,7 +11100,7 @@ packages:
   license_family: Other
   size: 617890
   timestamp: 1655709069465
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cftime-1.6.2-py311h5bb9823_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cftime-1.6.2-py311h5bb9823_0.tar.bz2
   sha256: 5226aec7c3544ec3358cef871868581ac6f530a6faa2bf35646ae0e422972039
   md5: 02a762440b11ca414bcb91b382cbd35f
   depends:
@@ -11112,7 +11112,7 @@ packages:
   license_family: MIT
   size: 177428
   timestamp: 1678830473247
-- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
   sha256: 7153817dd49ec317b519802c7c22c836602e00cbd96d68385e83eaf4c9f5ba6a
   md5: cd829e5997611a602e29fa2fd5882635
   depends:
@@ -11122,7 +11122,7 @@ packages:
   license_family: BSD
   size: 204113
   timestamp: 1698130080270
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cloudpickle-3.0.0-py311haa95532_0.tar.bz2
   sha256: 364512f6fbda47a7683831e49d94cede5ea91ed57c0bcb27c4c1a95b067c7717
   md5: c4c87a947b2f0594d0eda7d852140845
   depends:
@@ -11131,7 +11131,7 @@ packages:
   license_family: BSD
   size: 42936
   timestamp: 1721657516663
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
   sha256: 4099898f02e1f6119fcda65e747c3cbfef0bf563c8855b79a0245160709d5b45
   md5: ab9705c34e67fb8c8faec69d63ff4064
   depends:
@@ -11140,7 +11140,7 @@ packages:
   license_family: BSD
   size: 36410
   timestamp: 1676422341506
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
   sha256: c722f50980d7416ffb2cfc7bf72649307a0bb78c5a24eccefcd049cb61d6b355
   md5: c7c9ff0513ff3c99700919293b702410
   depends:
@@ -11149,7 +11149,7 @@ packages:
   license_family: CC
   size: 543258
   timestamp: 1709758602437
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
   sha256: 8fb3e816a5ad1da05125462dbc9e2a7e933b001a871aa65703802c0a894c6277
   md5: ee4b2fa9fce130496d5c7c86c35a1a05
   depends:
@@ -11159,7 +11159,7 @@ packages:
   license_family: BSD
   size: 17723
   timestamp: 1709323150229
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
   sha256: eeb49cd151ecdccd40062e8123a3b7a9a8a1eda6567dd33ce909ff8ee1a97c89
   md5: b7fe1f7ead1ec2ac642d022942282fc8
   depends:
@@ -11171,7 +11171,7 @@ packages:
   license_family: BSD
   size: 232451
   timestamp: 1700583772701
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.2-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cytoolz-0.12.2-py311h2bbff1b_0.tar.bz2
   sha256: 037aab9c08cd8f7e78e65b602b3c2b61a7c812b270cbea15bef0e36d0305db6f
   md5: b4e5dd983a62a7c27d73900400eab7ba
   depends:
@@ -11183,7 +11183,7 @@ packages:
   license_family: BSD
   size: 369375
   timestamp: 1701724118486
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-2024.8.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/dask-2024.8.2-py311haa95532_0.tar.bz2
   sha256: 638524ff3e7423b6e5b3153997d239b4536e76c373c19000c4d74d39fe8759c6
   md5: 154a27c109eca6a7977de0b22d1e6415
   depends:
@@ -11202,7 +11202,7 @@ packages:
   license_family: BSD
   size: 6170
   timestamp: 1725525169281
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.8.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/dask-core-2024.8.2-py311haa95532_0.tar.bz2
   sha256: c989952077ec0ea63cc766f6aaaf8f0ffebb12c7d2143a5cd111cc807dab253a
   md5: 7628fc77d1af150ae6cceffcf154c990
   depends:
@@ -11219,7 +11219,7 @@ packages:
   license_family: BSD
   size: 3190714
   timestamp: 1725464703740
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-expr-1.1.13-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/dask-expr-1.1.13-py311haa95532_0.tar.bz2
   sha256: 843f2abd2cf40913c8d3376cd0965562cab66fa264299ac8775f58ed23a4ac88
   md5: 16d4052ca9dfc0b7f4ca2d98b124f855
   depends:
@@ -11231,7 +11231,7 @@ packages:
   license_family: BSD
   size: 566375
   timestamp: 1725523069312
-- conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.16.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/datashader-0.16.3-py311haa95532_0.tar.bz2
   sha256: 029f067d71a2825e4af1ba085c792ec96d93fde7ec0590d5f6414a051085cdb9
   md5: f4c49a5695996b1146ca460058f4abe5
   depends:
@@ -11254,7 +11254,7 @@ packages:
   license_family: BSD
   size: 18066407
   timestamp: 1720535030282
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
   sha256: 5c73f86e575f2ad683ee4a1c2df11020e270edd89d12f11199483d57b0b51826
   md5: e96a12895ce374476277b1b196ba24bd
   depends:
@@ -11265,7 +11265,7 @@ packages:
   license_family: MIT
   size: 3719519
   timestamp: 1690907216785
-- conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2024.8.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/distributed-2024.8.2-py311haa95532_0.tar.bz2
   sha256: 5a8a41cec590e08b36b04fb1574cfa4f8d72da4d9696ca5629cc5031ba358b9c
   md5: 4dd9ab14f278b8d90094d86e25d5d7bd
   depends:
@@ -11289,7 +11289,7 @@ packages:
   license_family: BSD
   size: 1849988
   timestamp: 1725523127698
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
   sha256: 5d5fc8a24c804010b8cb5963227230352ea3ccf56bea9e8116e34f77223218f2
   md5: 8f989a72eed6293dfe0533c83057980d
   depends:
@@ -11298,7 +11298,7 @@ packages:
   license_family: MIT
   size: 17688
   timestamp: 1676423357100
-- conda: https://repo.anaconda.com/pkgs/main/win-64/expat-2.6.3-h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/expat-2.6.3-h5da7b33_0.tar.bz2
   sha256: b3c54b848c831db5e058f918b97ca08f9bfaacf0b1480272b393ac3c640e9233
   md5: 1ead1075a3d07f112a4240b41331bea5
   depends:
@@ -11308,7 +11308,7 @@ packages:
   license_family: MIT
   size: 424897
   timestamp: 1725543405738
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fiona-1.9.5-py311hf62ec03_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fiona-1.9.5-py311hf62ec03_0.tar.bz2
   sha256: 06fbb41f1f1d4f6bf5892a23d442ef11f096146685999a6aa911841206ac02e9
   md5: b5f6659dabb7383f976c8946396a8ed4
   depends:
@@ -11332,7 +11332,7 @@ packages:
   license_family: BSD
   size: 1135290
   timestamp: 1704921300424
-- conda: https://repo.anaconda.com/pkgs/main/win-64/folium-0.14.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/folium-0.14.0-py311haa95532_0.tar.bz2
   sha256: cc762a994a3aa4bac82227157f52172c122064721f1bc2359221b1b1cd0ebfff
   md5: 82adfdfd476c11198bf4429f3a6df57a
   depends:
@@ -11345,7 +11345,7 @@ packages:
   license_family: MIT
   size: 135350
   timestamp: 1677743027073
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fontconfig-2.14.1-hb33846d_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fontconfig-2.14.1-hb33846d_3.tar.bz2
   sha256: 7e9db9a6a516769ff3f1623762ad4f07ad5e4e150497d605efab4b9c9db0ab2b
   md5: 95a598df4ea56b9338948a3f8b7e16c6
   depends:
@@ -11360,7 +11360,7 @@ packages:
   license_family: MIT
   size: 246846
   timestamp: 1722921093124
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
   sha256: 27fb03eb57d25711a15e145f47a64320a9955b585efc9fd0a1a51cdd71b9fde3
   md5: eb3869e98f6f53dfec76e2eff4d6b61e
   depends:
@@ -11380,7 +11380,7 @@ packages:
   license_family: MIT
   size: 2732423
   timestamp: 1713552175344
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -11392,7 +11392,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freexl-2.0.0-hd7a5696_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freexl-2.0.0-hd7a5696_0.tar.bz2
   sha256: bbc5fd3e0525ea2987c00c9d5340a2f6156116b45506e6ff63152f0ffd371c65
   md5: 4ee1c7ba72a00662bbf30c98d7c7f71f
   depends:
@@ -11405,7 +11405,7 @@ packages:
   license_family: OTHER
   size: 90894
   timestamp: 1704742083610
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.6.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fsspec-2024.6.1-py311haa95532_0.tar.bz2
   sha256: 20b5c643d8f2d2ca349435d8a762f1d42b7b9b4e86f154ce6722d30179f2d348
   md5: 1db1c5f718e6a79a5f0117ec9957c6bc
   depends:
@@ -11416,7 +11416,7 @@ packages:
   license_family: BSD
   size: 383101
   timestamp: 1724855844881
-- conda: https://repo.anaconda.com/pkgs/main/win-64/gdal-3.6.2-py311h4e7b5b2_5.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/gdal-3.6.2-py311h4e7b5b2_5.tar.bz2
   sha256: 0203fe50e59fbd981b51c72ee18a01fd75d7cc2b3fe612b43e2437f554427a53
   md5: e842d2e703c69d4187dc6d6a3661ebcf
   depends:
@@ -11430,7 +11430,7 @@ packages:
   license_family: MIT
   size: 2532057
   timestamp: 1722935226144
-- conda: https://repo.anaconda.com/pkgs/main/win-64/geopandas-0.14.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/geopandas-0.14.2-py311haa95532_0.tar.bz2
   sha256: b164ff61f7c91e4e183367e504a3db4ad72fb738e92579effb67b0bfe5fbe5a1
   md5: 440b5443c96fe8968163dc40be94b514
   depends:
@@ -11445,7 +11445,7 @@ packages:
   license_family: BSD
   size: 7502
   timestamp: 1704929217881
-- conda: https://repo.anaconda.com/pkgs/main/win-64/geopandas-base-0.14.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/geopandas-base-0.14.2-py311haa95532_0.tar.bz2
   sha256: 21ed1b795481b524738944b68ff92a60e8a0ef9c7c36b50b347f1cb60493edaa
   md5: e1493ee5c24d8ad91d002cf3a85c8cce
   depends:
@@ -11459,7 +11459,7 @@ packages:
   license_family: BSD
   size: 1525805
   timestamp: 1704929137513
-- conda: https://repo.anaconda.com/pkgs/main/win-64/geos-3.8.0-h33f27b4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/geos-3.8.0-h33f27b4_0.tar.bz2
   sha256: de43096c33bba4f0140d6954d74861f4338b4e610fbdd9b4651302eaacc5db93
   md5: 46f610ec4be6b8e985048510341c9c42
   depends:
@@ -11468,7 +11468,7 @@ packages:
   license: LGPL-2.1
   size: 1053138
   timestamp: 1573216029043
-- conda: https://repo.anaconda.com/pkgs/main/win-64/geotiff-1.7.0-h4545760_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/geotiff-1.7.0-h4545760_3.tar.bz2
   sha256: bbba369c615bf09d2926c3be6586b16f7125a9dcc78798ba380667e9b178cbc8
   md5: d9cca68c18c2090110d351f614eb66c9
   depends:
@@ -11482,7 +11482,7 @@ packages:
   license_family: MIT
   size: 140510
   timestamp: 1704901404457
-- conda: https://repo.anaconda.com/pkgs/main/win-64/geoviews-1.12.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/geoviews-1.12.0-py311haa95532_0.tar.bz2
   sha256: 20f05b3256dc9a6287a361018813d6d3793b3ab4d509d2bf7dd7fd3ca861c6fa
   md5: 5d90d3cadd1641ce3b68f708239ad546
   depends:
@@ -11500,7 +11500,7 @@ packages:
   license_family: BSD
   size: 6509
   timestamp: 1713973058097
-- conda: https://repo.anaconda.com/pkgs/main/win-64/geoviews-core-1.12.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/geoviews-core-1.12.0-py311haa95532_0.tar.bz2
   sha256: c759a04c6517b45173b67ee5c835f15cc3ce816409b7760d3795555e78429802
   md5: ac6fa23cdb5d5cb3ea3c42d14e11503e
   depends:
@@ -11521,7 +11521,7 @@ packages:
   license_family: BSD
   size: 647354
   timestamp: 1713973041380
-- conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
   sha256: 7cb0df7aa62796b0081e1708003529c02411aca6a540bae97beaec919aa64e74
   md5: ea81fd813e10055553a8d7597c8be98f
   depends:
@@ -11531,7 +11531,7 @@ packages:
   license_family: BSD
   size: 322778
   timestamp: 1706888324269
-- conda: https://repo.anaconda.com/pkgs/main/win-64/glib-2.78.4-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/glib-2.78.4-hd77b12b_0.tar.bz2
   sha256: 5b0781144940dcf12887df93554bf297a14c7ccfac5f5fd2358c52d68e099872
   md5: 2dc9a083084586cae235d8244aa8e701
   depends:
@@ -11544,7 +11544,7 @@ packages:
   license_family: LGPL
   size: 491679
   timestamp: 1708032170326
-- conda: https://repo.anaconda.com/pkgs/main/win-64/glib-tools-2.78.4-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/glib-tools-2.78.4-hd77b12b_0.tar.bz2
   sha256: 18d0ff7ef22898e8e3fa55072ce2a3e25a324166d3a8d0f8dadf070641dd3c90
   md5: 74b78c84652c068703a7bff2ce4d6729
   depends:
@@ -11555,7 +11555,7 @@ packages:
   license_family: LGPL
   size: 100389
   timestamp: 1708032103213
-- conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
   sha256: ed1fa1a40c6739b48ff3a2d51c3df20e4983b59684b04d93e1337c5f2e93a954
   md5: 1797f64343a42395207cd452e6a6a751
   depends:
@@ -11566,7 +11566,7 @@ packages:
   license_family: BSD
   size: 94476
   timestamp: 1706895442146
-- conda: https://repo.anaconda.com/pkgs/main/win-64/hdf4-4.2.13-h712560f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/hdf4-4.2.13-h712560f_2.tar.bz2
   sha256: 8129c8aae5860d9975f3c88c2ef874d0a746a11074f922b6318446cc45f30768
   md5: b3a727bf1c1df5b021aaf6cc7e81deb2
   depends:
@@ -11577,7 +11577,7 @@ packages:
   license_family: BSD
   size: 2869081
   timestamp: 1510864340539
-- conda: https://repo.anaconda.com/pkgs/main/win-64/hdf5-1.12.1-h51c971a_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/hdf5-1.12.1-h51c971a_3.tar.bz2
   sha256: d32219e535ae34e9d28f94306a38a0825030967c350f19d9a5502e8005acbd5d
   md5: 0689c2ff6f4b9c15ee072694a8cd7467
   depends:
@@ -11589,7 +11589,7 @@ packages:
   license_family: BSD
   size: 23765096
   timestamp: 1686164892135
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.19.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.19.1-py311haa95532_0.tar.bz2
   sha256: c284965bfb12ff5c525739b67825a8f93cc1f523c6c021b459c1b547121b9d48
   md5: 6b8a81ad6dba8f4ff9c65cd62ca03a3c
   depends:
@@ -11609,7 +11609,7 @@ packages:
   license_family: BSD
   size: 6118951
   timestamp: 1720535043591
-- conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
   sha256: dee3fc68ed81398d232b3afe9a032837bdbef98c1b2478604d6abd397e3e7d64
   md5: 3f75535ca6dfee0745b221922f21f6de
   depends:
@@ -11626,13 +11626,13 @@ packages:
   license_family: BSD
   size: 353312
   timestamp: 1715090519918
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
   sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
   md5: 582d2c1135a89da757a038de831e7f39
   license: Intel proprietary
   size: 11086648
   timestamp: 1664812389803
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
   sha256: 102c803186db6d62eaf41a906f6c563ff0d62b53c1eaede8a381e18c0d005ed9
   md5: 9d30dec03058758a428cf152e0ae28b5
   depends:
@@ -11641,7 +11641,7 @@ packages:
   license_family: BSD
   size: 148193
   timestamp: 1714399061601
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
   sha256: db30abacf919b3f68ae1e6a94c467fd1e69fbf47ba7a86e6b491d8bfe4776f92
   md5: 9299876e7ddc3aea3487fd93340ceae7
   depends:
@@ -11651,7 +11651,7 @@ packages:
   license_family: APACHE
   size: 50842
   timestamp: 1704813715071
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
   sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
   md5: d215cc8ee7ca2cc83cc250cc5d822fe0
   depends:
@@ -11661,7 +11661,7 @@ packages:
   license_family: Proprietary
   size: 3929136
   timestamp: 1699647939158
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
   sha256: 864e9598f64105769b4ec02cc404fb507bc59e217324daf1686c00cfd12c0055
   md5: 6bb1c3be1f85799a3988afc2c3c5a4f0
   depends:
@@ -11682,7 +11682,7 @@ packages:
   license_family: BSD
   size: 229621
   timestamp: 1705934494547
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.27.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.27.0-py311haa95532_0.tar.bz2
   sha256: cdd0cdf851850a822f0757fd86c3492d98a5ab6a98bb3851bbec8b36a95b620f
   md5: efc3d64ef763443d936e1a954fc9cc1f
   depends:
@@ -11700,7 +11700,7 @@ packages:
   license_family: BSD
   size: 1664842
   timestamp: 1726064663198
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.19.1-py311haa95532_0.tar.bz2
   sha256: 0b084d918d32ea80d965c141220384c348c9f13c5bf5dabdd49c8d2aa813c0b1
   md5: e07d6312911028555a8d2434b60c15a8
   depends:
@@ -11710,7 +11710,7 @@ packages:
   license_family: MIT
   size: 1168633
   timestamp: 1721059057721
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.4-py311haa95532_0.tar.bz2
   sha256: 74c339ca0a20f4bc324974c2c28901c1f478ca7c8898483482883a7a82896d15
   md5: b3d3352c9d3bfe46f924b8e15fedf9be
   depends:
@@ -11722,7 +11722,7 @@ packages:
   license_family: BSD
   size: 353862
   timestamp: 1716993519832
-- conda: https://repo.anaconda.com/pkgs/main/win-64/joblib-1.4.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/joblib-1.4.2-py311haa95532_0.tar.bz2
   sha256: 43b9b601c7dbe74dbd4f0ca8ddeadb7043634b3d38472a6861f12d747cfd73a5
   md5: 4290b995aa63a33c546a9f950d7eaf06
   depends:
@@ -11731,7 +11731,7 @@ packages:
   license_family: BSD
   size: 542763
   timestamp: 1718217480002
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
   sha256: 0238fb10912d9345a9d327ff314a179de38369f8e1d0de0b5f4fab04defab0e4
   md5: 16a420ea83811cfa0c7cadba8f9f0995
   depends:
@@ -11741,7 +11741,7 @@ packages:
   license_family: Other
   size: 409932
   timestamp: 1722872751697
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
   sha256: 5e6698015a3b048093f5737f0e54bcbae415d0f9682dfdfeae3a8cfb4ea275e2
   md5: 0093a4214131046c4f68af0739dfbea4
   depends:
@@ -11754,7 +11754,7 @@ packages:
   license_family: MIT
   size: 201456
   timestamp: 1699041872445
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
   sha256: 9581be54128954080d7cef448b1728874c2ebbe5064f55adece422cf12eafa5a
   md5: 3adc105f87d5c7f0b1248bc3423f5b48
   depends:
@@ -11764,7 +11764,7 @@ packages:
   license_family: MIT
   size: 16187
   timestamp: 1699032556953
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
   sha256: ad8343bad7c8f0448cbcfbaf872cc94b56da81c52e5cdcee2a5d6b89f029eb75
   md5: addceff8d46c9d1d322618a9ce9e5b39
   depends:
@@ -11780,7 +11780,7 @@ packages:
   license_family: BSD
   size: 300354
   timestamp: 1676424060532
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
   sha256: fe0bf805dfa60d8b5d61670900442d0cda12523135176f60e1ebafb797e521d8
   md5: c8cf5ea3d4b0bc57dfe6b189b47e69e9
   depends:
@@ -11792,7 +11792,7 @@ packages:
   license_family: BSD
   size: 136783
   timestamp: 1718818384444
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
   sha256: 262c35a28d0af4d73ea1c010ce0c022005512a26d5c27064c8e009c0b7b789d9
   md5: 8367c61552aa274c0843201d88e461c8
   depends:
@@ -11808,7 +11808,7 @@ packages:
   license_family: BSD
   size: 72131
   timestamp: 1718738283200
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
   sha256: 00bf8449a37eb10c91ebfaa14b231905fde9493740cbda7ec89a8d3d8d9d1ff3
   md5: 1f3abe3cbf365249ebae7465a57e4cae
   depends:
@@ -11836,7 +11836,7 @@ packages:
   license_family: BSD
   size: 655133
   timestamp: 1718827724346
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
   sha256: 90420847230e72a648417f5f77cebcf7f17b89f70788652c276acc0c440e135f
   md5: ef3d8dee197aa37897bf6d39d2dd878f
   depends:
@@ -11847,7 +11847,7 @@ packages:
   license_family: BSD
   size: 27639
   timestamp: 1686871052174
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
   sha256: 97faaf26ce5254ec3649a8ee7f480b1556e4e8e6e4356d2fab1e6a5532631a0f
   md5: da23bd831c50c877f63038b7e16720ad
   depends:
@@ -11859,7 +11859,7 @@ packages:
   license_family: BSD
   size: 20163
   timestamp: 1700168785472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kealib-1.5.0-hde4a422_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kealib-1.5.0-hde4a422_1.tar.bz2
   sha256: 0d8750eb48746f1b33b771c80cb8572a01701f7c03775fb73bdc2e736efaf223
   md5: 0218566fcda3f373f0c2af851a42ea7d
   depends:
@@ -11870,7 +11870,7 @@ packages:
   license_family: MIT
   size: 162316
   timestamp: 1687967060759
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
   sha256: 8a2f0909fad0387e57cb0e9ee30db2b20761a9106e794381ffeac387a298fb07
   md5: 6058b2efc3284e27aacec2e6e6280433
   depends:
@@ -11881,7 +11881,7 @@ packages:
   license_family: BSD
   size: 62334
   timestamp: 1676432044242
-- conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
   sha256: ef6b0347ae565dd648a2bb40bc8b0b30f2e4f8387778fefced1d581b7d5a3e16
   md5: 8ef1d5919aa55fe56ef34d9a7969dca7
   depends:
@@ -11892,7 +11892,7 @@ packages:
   license_family: MIT
   size: 861982
   timestamp: 1684424430941
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
   sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
   md5: f5f73266281ab12377d5d47bdf07500a
   depends:
@@ -11904,7 +11904,7 @@ packages:
   license_family: MIT
   size: 905072
   timestamp: 1617648814933
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -11914,7 +11914,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libabseil-20240116.2-cxx17_h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libabseil-20240116.2-cxx17_h5da7b33_0.tar.bz2
   sha256: 0e20a85132c711cb36bc33f1c329eec57f9b8b5a52fe8b16e39ccf2181c3e585
   md5: 2056c0ad87951b65e50a809d539a1903
   depends:
@@ -11927,7 +11927,7 @@ packages:
   license_family: Apache
   size: 2192360
   timestamp: 1716563477680
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
   sha256: 4184dd040fc38cb123a98588a8344aa8d1ba1932df5fcc6c188f6b21f5a0c306
   md5: da58cfa83f3d6c31ae12d8777cd1b64d
   depends:
@@ -11940,7 +11940,7 @@ packages:
   license_family: OTHER
   size: 29803292
   timestamp: 1696764164248
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 7c906c94a4d46ea963080a6ba5bd12c1274da66159877a544fbc70291eeed98d
   md5: 45a3d52534fac8aa54a55ee92211a918
   depends:
@@ -11949,7 +11949,7 @@ packages:
   license: MIT
   size: 80216
   timestamp: 1714483371043
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
   sha256: daad7edc6d56abf3e176479e8628162dbf1c56b3d24db30d708aebae694a5214
   md5: e8ecf229f7fcb4c0b76d8613627948f5
   depends:
@@ -11959,7 +11959,7 @@ packages:
   license: MIT
   size: 45189
   timestamp: 1714483420152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 84320217abffa9386186ec8d03b4651bb4b1900d3871adc965a9a9e1d3799907
   md5: 651312fa22168f71f9aec5f9ee2c2fcf
   depends:
@@ -11969,7 +11969,7 @@ packages:
   license: MIT
   size: 756116
   timestamp: 1714483464368
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.9.1-h0416ee5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libcurl-8.9.1-h0416ee5_0.tar.bz2
   sha256: 8823321b1f3a4dec2ba437b74f054b6188c4e86f15e9830a851c036f1000b116
   md5: eb83a06e2e659553014b6ac66f379e09
   depends:
@@ -11982,7 +11982,7 @@ packages:
   license_family: MIT
   size: 371549
   timestamp: 1725033449018
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -11992,7 +11992,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
   sha256: 6458c7a370c4e3366b3b208c5b2834a7acfb17981e47fe3fb861f225d7cefbc3
   md5: ecabf4acab5b604856d8c7c4278c2c2c
   depends:
@@ -12004,7 +12004,7 @@ packages:
   license_family: BSD
   size: 446380
   timestamp: 1685052520132
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
   sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
   md5: cf949d76148be1e2a534218d9c57df86
   depends:
@@ -12014,7 +12014,7 @@ packages:
   license_family: MIT
   size: 155435
   timestamp: 1714484319443
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libgdal-3.6.2-h0e70117_5.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libgdal-3.6.2-h0e70117_5.tar.bz2
   sha256: fca3db3ff0375859740f9fbb7a749e0fbb5f929369e7753137c140304eb4f1ee
   md5: 794f571fa5a295a31983efe8d40fdcd6
   depends:
@@ -12059,7 +12059,7 @@ packages:
   license_family: MIT
   size: 9788599
   timestamp: 1722934726331
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libglib-2.78.4-ha17d25a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libglib-2.78.4-ha17d25a_0.tar.bz2
   sha256: da2f459c87a7174dc323db19a44f6240e018d8f6a4e0049ec6d81d668bedcb3c
   md5: 1fd164cb1b7068353a2f026b13e23ecb
   depends:
@@ -12075,7 +12075,7 @@ packages:
   license_family: LGPL
   size: 1455078
   timestamp: 1708032035113
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libgrpc-1.62.2-hf25190f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libgrpc-1.62.2-hf25190f_0.tar.bz2
   sha256: 1d933ff3c15bbd21e2463392eb8b84c19f5e7e8116757a5456d53edd182f8aa3
   md5: eb54ebe53747695597188890f99c2aad
   depends:
@@ -12094,7 +12094,7 @@ packages:
   license_family: APACHE
   size: 19177715
   timestamp: 1716836854929
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_3.tar.bz2
   sha256: 4085f304bede2d9d04dbff5ebd53b3f5fbfaee1cbc120018a9efc0e89d027877
   md5: 7e6fe99f2af88b389cf7e371cad6f18f
   depends:
@@ -12104,7 +12104,7 @@ packages:
   license_family: GPL3
   size: 744054
   timestamp: 1714484485224
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libkml-1.3.0-h63940dd_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libkml-1.3.0-h63940dd_7.tar.bz2
   sha256: d202eef643f39fbe4b24ff4240052d2b58d67a4ba5fcbd80d09106191b85bff6
   md5: 6f63fe185daebe8da8c6b3dc941ad7b0
   depends:
@@ -12117,7 +12117,7 @@ packages:
   license_family: BSD
   size: 3074807
   timestamp: 1693262074974
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libnetcdf-4.8.1-h6685c40_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libnetcdf-4.8.1-h6685c40_4.tar.bz2
   sha256: e846f05d6cdfd2850e5deb027b62e8d828fa9b12f61ae7ed6433155458032144
   md5: 383bc5f062aafa9b714aa6204ab20daf
   depends:
@@ -12132,7 +12132,7 @@ packages:
   license_family: BSD
   size: 706142
   timestamp: 1691155040631
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -12143,7 +12143,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.17-h906ac69_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpq-12.17-h906ac69_0.tar.bz2
   sha256: 54b46079c184c286b2f91575d3b5917bc3e6737f06885a50426e3263227c8a00
   md5: e4d2859474935b4873e48b09ef30a95e
   depends:
@@ -12154,7 +12154,7 @@ packages:
   - zlib >=1.2.13,<2.0.0a0
   size: 3763163
   timestamp: 1706215177824
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-4.25.3-hf2fb9eb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libprotobuf-4.25.3-hf2fb9eb_0.tar.bz2
   sha256: 189a48ba963858b5adf13f200a36ee566bcd823b8fbc1a0372d4605f465989ae
   md5: 310f4bf562072517c58e700471d52999
   depends:
@@ -12167,7 +12167,7 @@ packages:
   license_family: BSD
   size: 6407565
   timestamp: 1716568643819
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -12176,7 +12176,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libspatialindex-1.9.3-h6c2663c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libspatialindex-1.9.3-h6c2663c_0.tar.bz2
   sha256: e3527de4b50ae741004bf5ddfd6c5c4fe4d778ffea475f858d2b29e76ced9796
   md5: 91aa29bbc065cd3b53c7410ab683c9dd
   depends:
@@ -12185,7 +12185,7 @@ packages:
   license: MIT
   size: 455875
   timestamp: 1616086916558
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libspatialite-5.1.0-h25d3e1c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libspatialite-5.1.0-h25d3e1c_1.tar.bz2
   sha256: bdf5c51745cf1b34cb80ea32258a2adc22794decd9f629a09c736ab334fdd5d0
   md5: 55d03f839232b495e65e9b0422bc452d
   depends:
@@ -12203,7 +12203,7 @@ packages:
   license_family: OTHER
   size: 11259468
   timestamp: 1722878479049
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.11.0-h291bd65_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libssh2-1.11.0-h291bd65_0.tar.bz2
   sha256: dd96a8c3b6de33091ea6198afb7c9331750f9a0c46f870a2f3ff159f4a605976
   md5: 7382641f6d0090d7112a2164bcf44bba
   depends:
@@ -12215,7 +12215,7 @@ packages:
   license_family: BSD
   size: 283220
   timestamp: 1715261653579
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
   sha256: 238e486a0d62264e7ab35098bdc0390fb9a4649921b18827228c811ae8252c88
   md5: f1ebe453c5a955a25e4b00f73279fc42
   depends:
@@ -12229,7 +12229,7 @@ packages:
   license_family: Apache
   size: 894777
   timestamp: 1687975823684
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -12246,7 +12246,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
   sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
   md5: b1781519a200ccbfcb4a1194005aa3ef
   depends:
@@ -12258,7 +12258,7 @@ packages:
   license_family: BSD
   size: 338459
   timestamp: 1694777084290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.13.1-h24da03e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxml2-2.13.1-h24da03e_2.tar.bz2
   sha256: 24d079d3358bb106c330c17312dfa6abdf9c12bce5d5790887f3cbdac49e7220
   md5: c43739c31d4a9046d482f9382d6a671f
   depends:
@@ -12270,7 +12270,7 @@ packages:
   license_family: MIT
   size: 3558894
   timestamp: 1722441155964
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libzip-1.8.0-h289538f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libzip-1.8.0-h289538f_1.tar.bz2
   sha256: 3e22e243bb7d519db4a017e867bbedd7b147d9383f96e76e45e9ecd21e457ff4
   md5: 195764a402200698d64570dab3350bd5
   depends:
@@ -12286,7 +12286,7 @@ packages:
   license_family: BSD
   size: 132285
   timestamp: 1685378734951
-- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
   sha256: 4534c822511a052a72c2b070a05e5d8d6f3550f18ea00a33f9d8a9a92b4382cc
   md5: 82f24e7660831445a2183216e280a6a4
   depends:
@@ -12296,7 +12296,7 @@ packages:
   license_family: MIT
   size: 41464
   timestamp: 1676474474981
-- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.43.0-py311hf2fb9eb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/llvmlite-0.43.0-py311hf2fb9eb_0.tar.bz2
   sha256: bc9012cb5609cecf8ac40ad23546d10744ce2a9760781b5503df66b1aa07d1c7
   md5: 25112566aaca1c88c03db128f681354a
   depends:
@@ -12308,7 +12308,7 @@ packages:
   license_family: BSD
   size: 20924132
   timestamp: 1720456466056
-- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
   sha256: 896b7a39bd4ad3621312130122b4fe84dcb67d7355166255c58ea9bc562eb0ae
   md5: 640b852a56296f48cf073e61a59c5256
   depends:
@@ -12317,7 +12317,7 @@ packages:
   license_family: BSD
   size: 13751
   timestamp: 1676428354074
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.3.2-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-4.3.2-py311h2bbff1b_0.tar.bz2
   sha256: 5d7d4142cd2c91d151d26b7b22f1e4bd2357bcc5ee6b56516552145b43a6d022
   md5: 35b521ddf937dab77b7720d3640761d4
   depends:
@@ -12329,7 +12329,7 @@ packages:
   license_family: BSD
   size: 86304
   timestamp: 1686058058871
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
   sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
   md5: 320f40b75d93f3b96931c6d13c23946c
   depends:
@@ -12339,7 +12339,7 @@ packages:
   license_family: BSD
   size: 158902
   timestamp: 1714512129889
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mapclassify-2.5.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mapclassify-2.5.0-py311haa95532_0.tar.bz2
   sha256: b20da7a8916544c0c2996bb81e9c222cf03be28f50500854e18b8a6338e13d65
   md5: ad01428f515e6d91bf0dd6ddbaae66b9
   depends:
@@ -12353,7 +12353,7 @@ packages:
   license_family: BSD
   size: 83669
   timestamp: 1678299426555
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
   sha256: e0dc6e119b224bb31ef34b6ba270ffadc181d38b698c5318de8df7a5d2c4ccbd
   md5: 992ccd756f09408f0b74dfb9852a8b7f
   depends:
@@ -12362,7 +12362,7 @@ packages:
   license_family: BSD
   size: 182381
   timestamp: 1676437963591
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
   sha256: 050b5fd4b28132d8102a7e6b40179894dc7f5e41f7ad9ee19211e67446c5740f
   md5: 3ae0b2f6baec708554648ddafa81b756
   depends:
@@ -12372,7 +12372,7 @@ packages:
   license_family: MIT
   size: 154386
   timestamp: 1684279992864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
   sha256: 8269c73b7a9c03b95a121e318d0468f35eecc016093620b0560f35238cc5df51
   md5: 2914bea0ae29315f998e1abac79ccaa8
   depends:
@@ -12385,7 +12385,7 @@ packages:
   license_family: BSD
   size: 30214
   timestamp: 1704206218108
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.9.2-py311h472561b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.9.2-py311h472561b_0.tar.bz2
   sha256: 8cbfc06d4c0bf20f4aef4e26a342f9c5abbb8411cdea98b36e9f6486657824b9
   md5: cf7246a7ee382f69bef2143c6aa23f9d
   depends:
@@ -12406,7 +12406,7 @@ packages:
   license_family: PSF
   size: 11748171
   timestamp: 1725264782314
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
   sha256: 43279276850eb6e621812448cddc1093524cee0b7f8ed58b4600b68a4fb659f2
   md5: 5968b2b5c1f3cf5c8c8c9aaa4d8d66a2
   depends:
@@ -12416,7 +12416,7 @@ packages:
   license_family: BSD
   size: 19886
   timestamp: 1676425829787
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
   sha256: 3062a8254ca351b54f15bea85cc928a3ba4d879bb98ce97ece39a9f7eca215a5
   md5: 8f1565663abb34ad7fdd512e76da5532
   depends:
@@ -12426,7 +12426,7 @@ packages:
   license_family: MIT
   size: 68031
   timestamp: 1676481862508
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
   sha256: cdff5215c292fe59649ca40ca72f5d26da352760c1d6a56feba14eb13f7bbf61
   md5: e0f3f32b22135dfeaec277bc87183ca9
   depends:
@@ -12435,7 +12435,7 @@ packages:
   license_family: MIT
   size: 23328
   timestamp: 1676442709081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/minizip-4.0.3-hb68bac4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/minizip-4.0.3-hb68bac4_0.tar.bz2
   sha256: 3502f337214ce9758383ee66ca65d6df3bed8b7e0196b503191c82ccc5bfbda1
   md5: 00fb9fd38e34b8c9c271663f9fc4037a
   depends:
@@ -12449,7 +12449,7 @@ packages:
   license_family: Other
   size: 87133
   timestamp: 1702658623971
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
   sha256: 3b173a25605d2aaacc57ec0e425f1d1c51327eb2521c8742a736e2c76069bc8d
   md5: 169f1c93a443f95a88665f3008623ce1
   depends:
@@ -12460,7 +12460,7 @@ packages:
   license_family: BSD
   size: 104882
   timestamp: 1676425142412
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
   sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
   md5: 527155127b9fada5e5c5c69a624674b9
   depends:
@@ -12472,7 +12472,7 @@ packages:
   license_family: Proprietary
   size: 187498166
   timestamp: 1699648376430
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
   sha256: cea59ae60da314caecf08edb9bcb03126c6dd35837c8184bceaa194decca3341
   md5: 30936b7263cf0171f7c86400f12ef184
   depends:
@@ -12484,7 +12484,7 @@ packages:
   license_family: BSD
   size: 49080
   timestamp: 1682975093455
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.10-py311h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.10-py311h827c3e9_0.tar.bz2
   sha256: 3a4017ff342e7d12ad8ff76db494476992d627285244bd7a07a42f78c21549f0
   md5: f92336ec1d8cd9abdfbeb63d377c8be3
   depends:
@@ -12499,7 +12499,7 @@ packages:
   license_family: BSD
   size: 212248
   timestamp: 1725370696454
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.7-py311hea22821_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.7-py311hea22821_0.tar.bz2
   sha256: 5b0d1234978727c749e319f02847208c3ec17a428204d90f40909b775ffb1b19
   md5: e06038d13d1449ef235986b9d9704c8f
   depends:
@@ -12514,7 +12514,7 @@ packages:
   license_family: BSD
   size: 343687
   timestamp: 1725370790459
-- conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py311h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/msgpack-python-1.0.3-py311h59b6b97_0.tar.bz2
   sha256: c09c5ed3f07731091958ea6ed06a1eaeaca1f7e1361d341fb06b344d51074ca2
   md5: 520c04235cf0980e1ce908e893b4dc71
   depends:
@@ -12525,7 +12525,7 @@ packages:
   license_family: Apache
   size: 37775
   timestamp: 1676427521514
-- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
   sha256: 39f09c1bc57b4800ebda331eddb462928435498705351b0432d51a4293294ad8
   md5: 5565984a02f41e97cb9a4c9126ced14b
   depends:
@@ -12535,7 +12535,7 @@ packages:
   license_family: BSD
   size: 29808
   timestamp: 1676442800892
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
   sha256: 636f369607118a6ee3d0b63b7edb925d8081fd3fc829a7699136ce0dedbde067
   md5: b7e49c9cea50d8406cac81cd720dd80a
   depends:
@@ -12548,7 +12548,7 @@ packages:
   license_family: BSD
   size: 8323655
   timestamp: 1717622931223
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
   sha256: e940f9178ee2fa0a7c12873ae35ebea0074371653e5cfa1be8aa8d9271fd343b
   md5: 355d0835215911738a28010dfa6aa382
   depends:
@@ -12561,7 +12561,7 @@ packages:
   license_family: BSD
   size: 141785
   timestamp: 1698934346590
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
   sha256: 47dd00c0179f4eb29c70d0453d340f7f5332af326b3d51c64ca3bf6a14be8e7e
   md5: f66afe718bdb57667b03ebda4cb2ac7e
   depends:
@@ -12588,7 +12588,7 @@ packages:
   license_family: BSD
   size: 561655
   timestamp: 1699023338436
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
   sha256: 4ee863a1ff697274c642b3101f82b279a354e3f033a87505655039f89127bb41
   md5: bfaf19be6644ad2344e118aa0acccb13
   depends:
@@ -12601,7 +12601,7 @@ packages:
   license_family: BSD
   size: 189809
   timestamp: 1694617194065
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
   sha256: 90fb3f14c49da1397982eae21cd09e8d60d491d76f94c57590c56723fe6dc172
   md5: 46a523661fe5c1bce7b4213fd428c3de
   depends:
@@ -12610,7 +12610,7 @@ packages:
   license_family: BSD
   size: 16732
   timestamp: 1708532795328
-- conda: https://repo.anaconda.com/pkgs/main/win-64/netcdf4-1.6.2-py311hec71f40_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/netcdf4-1.6.2-py311hec71f40_0.tar.bz2
   sha256: faeafcf13019b66a9d872ab583a202ddfc3379c1ddb60ceccf6169f5a3c8cd36
   md5: 329b1d446951338d97ca3bc3c7811acf
   depends:
@@ -12626,7 +12626,7 @@ packages:
   license_family: MIT
   size: 378318
   timestamp: 1676504914982
-- conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/networkx-3.3-py311haa95532_0.tar.bz2
   sha256: 581da15cfc0d588d67386e658b29fb73584fcb56ce1c6ca1f1b665884145c253
   md5: f97b1af76352a41580d8b846a2546edf
   depends:
@@ -12644,7 +12644,7 @@ packages:
   license_family: BSD
   size: 3348847
   timestamp: 1720002931830
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
   sha256: 62732e34b2cdcb73846cfdf53284067d32113aae0f6d736ca30ce2b0073bce27
   md5: ec7191b2ea4e65b5eed6f7fdd9271d28
   depends:
@@ -12669,7 +12669,7 @@ packages:
   license_family: BSD
   size: 769732
   timestamp: 1717630919732
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
   sha256: e040ebcab948325fbe17e4ab15be62e1fafa7bad225457e59764adb60eb40db5
   md5: 4d40a09df8cb74a9f044eab317436d67
   depends:
@@ -12679,7 +12679,7 @@ packages:
   license_family: BSD
   size: 27282
   timestamp: 1699456187703
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.60.0-py311hea22821_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numba-0.60.0-py311hea22821_0.tar.bz2
   sha256: 3d252d3b5bb30fcacf291c414d308792cb35d528aead1ebc2255e25a3ddc13d2
   md5: 1da6aae4b3e031c95051b21ca01fd279
   depends:
@@ -12701,7 +12701,7 @@ packages:
   license_family: BSD
   size: 6230264
   timestamp: 1720555663355
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
   sha256: d3bd2a6614bb7e7f5ce3348d6674e71cce45cbde236beff32f0f08cd95a64ef0
   md5: e70f15643164f432d1df68635e7c322b
   depends:
@@ -12716,7 +12716,7 @@ packages:
   license_family: MIT
   size: 162691
   timestamp: 1696515822068
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
   sha256: 470fe9a0b3e196fa60d5550d8188f6074a207572fa0d353a4448d580872e7804
   md5: 6fdb8df0613fb2fb9f1732d335fa25f1
   depends:
@@ -12733,7 +12733,7 @@ packages:
   license_family: BSD
   size: 11053
   timestamp: 1708641901110
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
   sha256: 222c1711e7cf151e29077c7d4d86a865c9fd39615812d58a1daca6fd1b6bdfb5
   md5: 585bcd8bc3940a8a859f38ebafdcd77d
   depends:
@@ -12749,7 +12749,7 @@ packages:
   license_family: BSD
   size: 10723862
   timestamp: 1708641867155
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
   sha256: e2afce0548808d27293a03661ee5f7ac3e18f82a92c9fb23f420eb5e92126fc6
   md5: 9dd921a785844abe0aa842c3800d405a
   depends:
@@ -12761,7 +12761,7 @@ packages:
   license_family: BSD
   size: 286986
   timestamp: 1722872761369
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.15-h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.15-h827c3e9_0.tar.bz2
   sha256: a72f51f69a6893797b51345f9fd6b6a3b12764b435bb50e247e9e05d75711bd0
   md5: c05007cfd519c5097f50d9c830ad897f
   depends:
@@ -12772,7 +12772,7 @@ packages:
   license_family: Apache
   size: 8396971
   timestamp: 1725547066793
-- conda: https://repo.anaconda.com/pkgs/main/win-64/orc-2.0.1-hd8d391b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/orc-2.0.1-hd8d391b_0.tar.bz2
   sha256: af8a9ad457ebc4c4aa800676ffbfd5cf830e1da697672ea6412bf041fd61cedd
   md5: 584d733dc81492d46a926660353b361a
   depends:
@@ -12790,7 +12790,7 @@ packages:
   license_family: Apache
   size: 1235996
   timestamp: 1717104791454
-- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
   sha256: b2f5f50a1ddf811102636f3acebd76716c88ebb628754b91eda7a3a962adf26c
   md5: 712527b4d84c350dca4b67f511c04414
   depends:
@@ -12799,7 +12799,7 @@ packages:
   license_family: APACHE
   size: 39421
   timestamp: 1699371341381
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-24.1-py311haa95532_0.tar.bz2
   sha256: 01e970843b748f4af6cb1600fd2736d546158c3d69584cb915a08eb6c6924fcf
   md5: 59b0cc461ea2af7e3f344faadc91e6aa
   depends:
@@ -12808,7 +12808,7 @@ packages:
   license_family: Apache
   size: 157605
   timestamp: 1720102973406
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.2-py311hea22821_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-2.2.2-py311hea22821_0.tar.bz2
   sha256: 1b986a8752785cd01969e737952449f5f0f4284cab7690193fa1a602156881c2
   md5: ecfe5661d54e32e8533c02f5fd625dcb
   depends:
@@ -12859,7 +12859,7 @@ packages:
   license_family: BSD
   size: 17245139
   timestamp: 1718309568175
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-1.4.4-py311haa95532_0.tar.bz2
   sha256: 25474a636549a0686cae03bdbc694683021813bf9d59680e0599b7666444c755
   md5: 3c58f327cf194b62ab2f363e42598837
   depends:
@@ -12883,7 +12883,7 @@ packages:
   license_family: BSD
   size: 21849968
   timestamp: 1718120610637
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-2.1.1-py311haa95532_0.tar.bz2
   sha256: e6611058e26521784b6197418505acee343ca299b7fa3f57ec23621f869e1d57
   md5: ffd4cc05e70b156e44f242538d81ca99
   depends:
@@ -12892,7 +12892,7 @@ packages:
   license_family: BSD
   size: 264340
   timestamp: 1719348210484
-- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
   sha256: b0d7fbfcf1c5c682ed9934eb6a33e00a2517941f2bcb9d677379f4bb73b2c45c
   md5: 20c8f36595a48f5cda2f4f74c02a3ea2
   depends:
@@ -12906,7 +12906,7 @@ packages:
   license_family: BSD
   size: 48206
   timestamp: 1698702818841
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pcre2-10.42-h0ff8eda_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pcre2-10.42-h0ff8eda_1.tar.bz2
   sha256: 226780b480fab9707a50e60f7aac8107753c120c8e32246bd11abb8b7bc28cd5
   md5: 0872c5406994b3516b6d9ba76c86d5df
   depends:
@@ -12918,7 +12918,7 @@ packages:
   license_family: BSD
   size: 1506213
   timestamp: 1714657817313
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.4.0-py311h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.4.0-py311h827c3e9_0.tar.bz2
   sha256: f7fa1d4f22457546451aa9ab55a10130dc20119771e5e0556cfae2cec0460538
   md5: a64d6539ac40ffb07ab02221c214362a
   depends:
@@ -12936,7 +12936,7 @@ packages:
   license_family: Other
   size: 1081527
   timestamp: 1721060065320
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-24.2-py311haa95532_0.tar.bz2
   sha256: 9c0dc12161f77b43137dad2e520ed7a343c5d8d8fd545492336e84201d1bb74c
   md5: 22cda044cb24e1db8fbaa5864feb4261
   depends:
@@ -12947,7 +12947,7 @@ packages:
   license_family: MIT
   size: 3199019
   timestamp: 1723485404416
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pixman-0.40.0-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pixman-0.40.0-h2bbff1b_1.tar.bz2
   sha256: 20923fa2937cde57e8d2f5d67391b37eef349a9e3f5ff589bc75fb3dd3e0074f
   md5: c62f32977c25875ced94e930d942db6b
   depends:
@@ -12956,7 +12956,7 @@ packages:
   license: MIT
   size: 497111
   timestamp: 1632711499953
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
   sha256: e5f8cbfb5fc25d460a9117bfc5511959c5e86ccb193316033f87bd516e0c8881
   md5: 9f7e8b5eb651539386bb92c14e5c321b
   depends:
@@ -12965,7 +12965,7 @@ packages:
   license_family: MIT
   size: 37730
   timestamp: 1692205554840
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pooch-1.7.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pooch-1.7.0-py311haa95532_0.tar.bz2
   sha256: 81da48745a2df74dfc4e17cc4a5c980a2c344361a07ac4cb2346f9b11511dff9
   md5: fa43caa0d4957148ae9f363fbe0c5419
   depends:
@@ -12981,7 +12981,7 @@ packages:
   license_family: BSD
   size: 105871
   timestamp: 1695850304789
-- conda: https://repo.anaconda.com/pkgs/main/win-64/poppler-22.12.0-h0bf3bde_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/poppler-22.12.0-h0bf3bde_3.tar.bz2
   sha256: 03fa4c3b0fc491cfc4736272a8a07b111255aee8029359ecc315e3253b20b977
   md5: deecd5672f83b496fddc7d797c491626
   depends:
@@ -13005,14 +13005,14 @@ packages:
   license_family: GPL
   size: 2826813
   timestamp: 1696001451072
-- conda: https://repo.anaconda.com/pkgs/main/win-64/poppler-data-0.4.11-haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/poppler-data-0.4.11-haa95532_1.tar.bz2
   sha256: 48c7975e4777318317369fe480f75531534cb8933a3e4de97cddf778a12f96dd
   md5: fc41b46e1055778a44677d2e0e97fe32
   license: GPL-2.0-or-later and GPL-3.0-or-later and BSD-3-Clause
   license_family: GPL
   size: 478379
   timestamp: 1673863618032
-- conda: https://repo.anaconda.com/pkgs/main/win-64/proj-9.3.1-ha107b6e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/proj-9.3.1-ha107b6e_0.tar.bz2
   sha256: d6889db09a27fabfc97957c2e2b71506e621d219a6821b8e76588aeeb4ea6678
   md5: 2337a98f76b8e96b7e2e76475de4ee0e
   depends:
@@ -13027,7 +13027,7 @@ packages:
   license_family: MIT
   size: 3070698
   timestamp: 1704729163554
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
   sha256: 6c5b53831273674361437fb546e08315fc11ca9275a174bca3887987e86ced5a
   md5: f8d91daf5173eb03157f484389adcdd4
   depends:
@@ -13036,7 +13036,7 @@ packages:
   license_family: Apache
   size: 122178
   timestamp: 1679591983138
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
   sha256: 546819d922b03f3a25ca9f98fd069d0588d481fc0603c6d74bd598fb6a93687f
   md5: 86c18e3e0b67ee099457475ed6caf2e6
   depends:
@@ -13048,7 +13048,7 @@ packages:
   license_family: BSD
   size: 751763
   timestamp: 1704404627180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
   sha256: ae06f0dfa2cfae51404afc6d6ad3a474a93015b5ba9a7d3ea24224b8e7547987
   md5: 3e19794c806cc3e84a3080a97c359b75
   depends:
@@ -13059,7 +13059,7 @@ packages:
   license_family: BSD
   size: 510466
   timestamp: 1679005998612
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-16.1.0-py311hea22821_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyarrow-16.1.0-py311hea22821_0.tar.bz2
   sha256: 11ce49f6257b950e12f9a3ff9051f9d68d3b91e2d993e7369654e43b0a0cbf7e
   md5: f097ff39d6b087d13b434985c137689d
   depends:
@@ -13072,7 +13072,7 @@ packages:
   license_family: Apache
   size: 4559429
   timestamp: 1721665324191
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
   sha256: e2af1efb1a5094a5962d93fa949ecab479a2ae7570e030f52eeac6761383c208
   md5: 4cb1359e22ddf8f3996afddce5f6205c
   depends:
@@ -13084,7 +13084,7 @@ packages:
   license_family: BSD
   size: 56638
   timestamp: 1676438592117
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
   sha256: d95c88d06f4f3f667bd9a39e5f18179e83b3cd4c115c06ce0fff390ff6d3a700
   md5: c6d00a8a4d89b1be99bfa3aff19d96b4
   depends:
@@ -13093,7 +13093,7 @@ packages:
   license_family: BSD
   size: 2134881
   timestamp: 1684280285492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.1.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.1.2-py311haa95532_0.tar.bz2
   sha256: 0cb6e4748cba79e77b82fbb50b9a820631e4a40146ce3d36f37531b0ba3321e7
   md5: 7970d23adb4bb63d41f004ceebd3e3d2
   depends:
@@ -13102,7 +13102,7 @@ packages:
   license_family: MIT
   size: 458992
   timestamp: 1725041937893
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyproj-3.6.1-py311ha997c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyproj-3.6.1-py311ha997c60_0.tar.bz2
   sha256: 3d9f5ea994fe7582b70cb191ad39ddac17c1a52f61dc27aeeba91b4daa1e24c0
   md5: b6fdbea05872f8eba95ac7c5c91c301d
   depends:
@@ -13115,7 +13115,7 @@ packages:
   license_family: MIT
   size: 1114131
   timestamp: 1704901663468
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyshp-2.3.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyshp-2.3.1-py311haa95532_0.tar.bz2
   sha256: 60c0a9b26c40d46015ea17b68da5ff7375568d11e17b92a9000d0b91166233b2
   md5: a28cafa542d188f1c805c89f3226dd89
   depends:
@@ -13124,7 +13124,7 @@ packages:
   license_family: MIT
   size: 86645
   timestamp: 1706101056895
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
   sha256: 974c22de09078bf07c5db31fe12d8d89d6433508defc8237cbe52e08c69ed56b
   md5: 9cf10bfd49140a527cf4b1d912097e6d
   depends:
@@ -13134,7 +13134,7 @@ packages:
   license_family: BSD
   size: 36072
   timestamp: 1676426019064
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
   sha256: f43aca7a222c983c25c3e15f79c7e7e3c4909bb7839a1dd0ee327def81aa476e
   md5: 2b61f1cb7fec068c76ef0ff97c2c62b5
   depends:
@@ -13155,7 +13155,7 @@ packages:
   license_family: PSF
   size: 19811751
   timestamp: 1713545124922
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
   sha256: 2c61639b3bb56fc864c86558bceb7845b1731ac44bf1a94894172ea47a995bd4
   md5: 404805e547b4d50b5cd17e16bca87527
   depends:
@@ -13165,7 +13165,7 @@ packages:
   license_family: BSD
   size: 332043
   timestamp: 1716495838826
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
   sha256: 9acb33db60d9319595f52337cae3b88c2a2338cd66f1f9d8ae86d0a993c2067a
   md5: f4af8cf94d042b4dde487241bba1c457
   depends:
@@ -13174,7 +13174,7 @@ packages:
   license_family: BSD
   size: 279780
   timestamp: 1679500609851
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
   sha256: 48fe7373b012b51134b6b6ff67f18d2b4aae3a5c7700e4560ce002af7172f064
   md5: 0379cd17692152c12b662b0e4ea46b88
   depends:
@@ -13183,7 +13183,7 @@ packages:
   license_family: BSD
   size: 18008
   timestamp: 1683824373128
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py311hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-lmdb-1.4.1-py311hd77b12b_0.tar.bz2
   sha256: 40093db499547e192da8c52132ef1016bab65f2dfd2e4049739f2f8b574e3836
   md5: a6b568626951b8a9070c30e043cb2603
   depends:
@@ -13194,7 +13194,7 @@ packages:
   license_family: Other
   size: 150521
   timestamp: 1682522716553
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
   sha256: 803274d986d0c4e3b5ec1018747ede86ef57137455b3e44a60e834717eafb92b
   md5: c9f134ddeff6fdf0373a45534ddb7079
   depends:
@@ -13203,7 +13203,7 @@ packages:
   license_family: MIT
   size: 273009
   timestamp: 1713974722039
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
   sha256: 6fbcba97c1dcb5157afd23f264c3cff069c7e4be5ea55980fc349eb8dc2cb49e
   md5: 8153e3f8b3283926bcf9403804a365f5
   depends:
@@ -13215,7 +13215,7 @@ packages:
   license_family: BSD
   size: 65050
   timestamp: 1711137009299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
   sha256: cd33dfee104dfbba4af38d06a09ccbae6a32e7c543afedab523303319ebb283d
   md5: 3dfc19af0306d80921e1403f1f551bba
   depends:
@@ -13225,7 +13225,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13679916
   timestamp: 1676423267293
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
   sha256: 102ff1d958209e3648bb49da3503cf752abab822011fdc4e12e88145c9e73772
   md5: 0553c2c381b6f5c836b23edc8c6db2ba
   depends:
@@ -13237,7 +13237,7 @@ packages:
   license_family: MIT
   size: 246689
   timestamp: 1677708371873
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
   sha256: bee5c4d0f41f06a9c0aac636885e36e8b81116aafde980f9ea48fdb64abb5567
   md5: 6c05a053240cb90765d6f8c2efdf905e
   depends:
@@ -13249,7 +13249,7 @@ packages:
   license_family: MIT
   size: 182228
   timestamp: 1698096268270
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
   sha256: ea39db411361d96545a04fb976940e9590147acb4ca9caacf7e8264780379347
   md5: b411b8be8e53e5059949dde02dd07faf
   depends:
@@ -13261,7 +13261,7 @@ packages:
   license_family: Other
   size: 565148
   timestamp: 1709319072176
-- conda: https://repo.anaconda.com/pkgs/main/win-64/qhull-2020.2-h59b6b97_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/qhull-2020.2-h59b6b97_2.tar.bz2
   sha256: 5d677c17afe37f24eb30f143fccf45450d81929227869256a277a66dd9a36325
   md5: 09ec672a48cc028863ef171fc8c5d418
   depends:
@@ -13271,7 +13271,7 @@ packages:
   license_family: Other
   size: 2338798
   timestamp: 1670915907181
-- conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
   sha256: 720f3dd1f933d035b1393951ffd1b6437fc5e19b1999e74096044514a46053fb
   md5: add2dfb15b518144663fc3b897d66da7
   depends:
@@ -13280,7 +13280,7 @@ packages:
   license: BSD-3-Clause
   size: 493391
   timestamp: 1652432364793
-- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
   sha256: 47653b45a5f2d97b5bf0dbf0e620908880f9078da427eef69012effe3f19af67
   md5: 44e709ae67d89bccee2d4d46d358fee3
   depends:
@@ -13291,7 +13291,7 @@ packages:
   license_family: MIT
   size: 74493
   timestamp: 1699012356534
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.32.3-py311haa95532_0.tar.bz2
   sha256: 4a18e8e023227dfb66668c5b1af421810be2db6d73d204a3f185f5460d747b1d
   md5: fa65f36aabdaeb0c65be48d9e6a28952
   depends:
@@ -13307,7 +13307,7 @@ packages:
   license_family: Apache
   size: 124310
   timestamp: 1721411219691
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
   sha256: d6daaa6b45272819176e4aeb467ae00e3db43386548464a9993688f292709d40
   md5: 9fe721d7f7420c259df4f07d4503f654
   depends:
@@ -13317,7 +13317,7 @@ packages:
   license_family: MIT
   size: 9683
   timestamp: 1683077110211
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
   sha256: 6051860575f9448aea5799d74469c928cd7cdeeca1eb53657872262a77b1a7a8
   md5: 60e193eca497130034facd5fed168249
   depends:
@@ -13326,7 +13326,7 @@ packages:
   license_family: MIT
   size: 10094
   timestamp: 1683059114376
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
   sha256: ecd310461c1b45ab92ddf15539cea5a6e837860561c974d2d7393f9a7933f116
   md5: 1762fec2838763e904141167e18b0389
   depends:
@@ -13337,7 +13337,7 @@ packages:
   license_family: MIT
   size: 215600
   timestamp: 1698947891859
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rtree-1.0.1-py311h2eaa2aa_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rtree-1.0.1-py311h2eaa2aa_0.tar.bz2
   sha256: 3394280087bffa3fddc7937002ab9bc614b8b49a673d48da376de3856326ad6c
   md5: c4090dd318aac6dc98afb35bcafb8a79
   depends:
@@ -13348,7 +13348,7 @@ packages:
   license_family: MIT
   size: 63380
   timestamp: 1676455791440
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scikit-learn-1.5.1-py311hea22821_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/scikit-learn-1.5.1-py311hea22821_0.tar.bz2
   sha256: 2894460226abef75c8e5839637558a2d4def3ba7f854be3870620a36ef2bc818
   md5: f2470395cb0f987b3aeda2b2e89b555e
   depends:
@@ -13363,7 +13363,7 @@ packages:
   license_family: BSD
   size: 12416315
   timestamp: 1722070561815
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.13.1-py311h9f229c6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/scipy-1.13.1-py311h9f229c6_0.tar.bz2
   sha256: bf3bfa0b2bbf800e38384bfee37854b0f22413a4b2f64b9a52135bd48ba5069b
   md5: 7a7dd8a74d59ceba1963770bb2d85958
   depends:
@@ -13381,7 +13381,7 @@ packages:
   license_family: BSD
   size: 32305235
   timestamp: 1717522696972
-- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
   sha256: 6fd52bae6360fbc8135d72e0c1e4fd407769fa4d0f4b59356e7aed3e000eb339
   md5: 49fd52885250da8aab17ed72e2e18b81
   depends:
@@ -13390,7 +13390,7 @@ packages:
   license_family: BSD
   size: 88901
   timestamp: 1699371435766
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-75.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-75.1.0-py311haa95532_0.tar.bz2
   sha256: 229e6de8307d0463288427283e65479a1f2b8e0f4ec49edfd419bea6fb124b33
   md5: 253b0897800b6c739dc3ee26546ddf7e
   depends:
@@ -13399,7 +13399,7 @@ packages:
   license_family: MIT
   size: 2308770
   timestamp: 1726678611334
-- conda: https://repo.anaconda.com/pkgs/main/win-64/shapely-2.0.5-py311h82fc408_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/shapely-2.0.5-py311h82fc408_0.tar.bz2
   sha256: 7890ce8c7136265f29c060c3364e04005f668ca704048556068bf3acc18a1f50
   md5: 24fd48a77fd53b9d9440da592e080d51
   depends:
@@ -13412,7 +13412,7 @@ packages:
   license_family: BSD
   size: 611671
   timestamp: 1722534074562
-- conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
   sha256: 5e5f855a70cf4c9dc6f2ac8d9fa51a3f095bf4db8e2ee3ff213ef5432556d7cd
   md5: 9c1f7331a4116e5c27d8af7453f8ee47
   depends:
@@ -13422,7 +13422,7 @@ packages:
   license_family: BSD
   size: 119274
   timestamp: 1723557526373
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
   sha256: 5d1b7e14dc04816692de0f8518ea8fcbefb26ab61cec83f96f2c44c1bee67fab
   md5: 505d2a70a875b5082dc857aa4dfab0d4
   depends:
@@ -13431,7 +13431,7 @@ packages:
   license_family: Other
   size: 18830
   timestamp: 1705431395254
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
   sha256: 5ff3b4ac3fbce4dd67a87856c04698d0397deb0ac288ff4e7eb02fbab57f1253
   md5: 0ca650a7001c6650809d3361de8cb005
   depends:
@@ -13440,7 +13440,7 @@ packages:
   license_family: MIT
   size: 89590
   timestamp: 1696347858925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
   sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
   md5: 833b93a2daade3407898f15588945d83
   depends:
@@ -13450,7 +13450,7 @@ packages:
   license_family: Other
   size: 1440481
   timestamp: 1714488344682
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -13460,7 +13460,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
   sha256: 78d89b50a29fbeb19a562f5dad95615e3f192bb4f3b86cd6ea75f2f825418232
   md5: 4a4040df560ea47704e0898c4c015808
   depends:
@@ -13471,7 +13471,7 @@ packages:
   license_family: BSD
   size: 38069
   timestamp: 1678228553220
-- conda: https://repo.anaconda.com/pkgs/main/win-64/threadpoolctl-3.5.0-py311h746a85d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/threadpoolctl-3.5.0-py311h746a85d_0.tar.bz2
   sha256: ca96d2a2b8dc02bea485ef1944ef7c8d6fb142db1dce83c2b2d4e14b0a89adc2
   md5: ec1477c9c6e94c22522b11e109346f2f
   depends:
@@ -13480,7 +13480,7 @@ packages:
   license_family: BSD
   size: 49825
   timestamp: 1719407929091
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tiledb-2.3.3-hd8964de_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tiledb-2.3.3-hd8964de_3.tar.bz2
   sha256: cd56f532cf85dc3d3b13c170c8bdc22e9c4e4f943f92f400475f7edd864b56e2
   md5: 2bb3534c127f29c03a059e11ac788343
   depends:
@@ -13495,7 +13495,7 @@ packages:
   license_family: MIT
   size: 2544180
   timestamp: 1685657756987
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
   sha256: 70a3cc4a4e81a6421bc19cd410d1d6064aadb2b1cce38b020f85e5346716d8e7
   md5: 32a9a2539579a3d522dce3b5cb4f987b
   depends:
@@ -13505,7 +13505,7 @@ packages:
   license_family: BSD
   size: 49495
   timestamp: 1676425411739
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
   sha256: 0a95736cfd0bb25fc201cd6be4a2450ea8fc30eeb349d861812675b84c94fa74
   md5: a8a9fb30c6dd8e7a16d5dcd2333c3c49
   depends:
@@ -13516,7 +13516,7 @@ packages:
   license_family: BSD
   size: 3844176
   timestamp: 1714770894235
-- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
   sha256: ed5950ac0c12cc87f991a6f28112cf29057e2b7ad416ae4429a0b97c3efaf58c
   md5: b5e2a04879e6fd19f0eb5effded4dc61
   depends:
@@ -13525,7 +13525,7 @@ packages:
   license_family: BSD
   size: 135939
   timestamp: 1676431438808
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.1-py311h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.4.1-py311h827c3e9_0.tar.bz2
   sha256: 04340cd171ff970c405b4b955f825cb52deb71f4420346596744bf36214ce431
   md5: bbab95732695d5d4c759dfbd274a15ff
   depends:
@@ -13536,7 +13536,7 @@ packages:
   license_family: Apache
   size: 926984
   timestamp: 1718740216876
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.5-py311h746a85d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.66.5-py311h746a85d_0.tar.bz2
   sha256: 283f31f5ef79657b27b9a6d82b5366b869744b553f90bad219714f2771b0088f
   md5: cea2f913161c630749f8e8ac190c99f3
   depends:
@@ -13548,7 +13548,7 @@ packages:
   license_family: MOZILLA
   size: 186694
   timestamp: 1724854118410
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
   sha256: a724711191ac1226bf228eab49718eed7b5c7394f539294eb0f88baf8e7bb24d
   md5: c78482e07d0aa6df9fcfa5b366dd87e3
   depends:
@@ -13557,7 +13557,7 @@ packages:
   license_family: BSD
   size: 207744
   timestamp: 1718227224929
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
   sha256: ab3cce654f1e94793fff0cb03b750d9b20cdbf099263b1906c3c5eaf8b347ab6
   md5: c68ffc771312afb6f88b94c24d2bb689
   depends:
@@ -13567,7 +13567,7 @@ packages:
   license_family: PSF
   size: 9706
   timestamp: 1715268972001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
   sha256: 4089efea1753ebe2f6617b46cc368738f285b1d816d4a4f01ba71524f46851b4
   md5: 7f610528ecd0b317180efa2058c32323
   depends:
@@ -13576,7 +13576,7 @@ packages:
   license_family: PSF
   size: 75414
   timestamp: 1715268958140
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
   sha256: d091897f05318c22ca31028370f25355065999078f7db6f88ab27bf4cb030ec8
   md5: 1776502c1cfb351554eeda6cddaf255f
   depends:
@@ -13585,7 +13585,7 @@ packages:
   license_family: MIT
   size: 11588
   timestamp: 1676457729096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
   sha256: c16498f8238cc331618720d078b87995eceb6bbf20268a7a4e8efbf7b5859a9a
   md5: 770432c0ca1ab9d99ffe95e51d3a3e74
   depends:
@@ -13596,7 +13596,7 @@ packages:
   license_family: Apache
   size: 517433
   timestamp: 1713213261710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uriparser-0.9.7-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uriparser-0.9.7-h2bbff1b_0.tar.bz2
   sha256: f88e04209064e9a72fccc9284271405d9548106c2bf302e24fa1e8e8bb36a127
   md5: 8845191f3242c429e10220e3ed9ee73c
   depends:
@@ -13606,7 +13606,7 @@ packages:
   license_family: BSD
   size: 48486
   timestamp: 1692187056029
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-2.2.2-py311haa95532_0.tar.bz2
   sha256: e6b7f1cf269463c87bffbe808e88069c36ee0ff1d909e65d8986b914980ec0b9
   md5: b5852f18c3edfcc6147cdaf96a1ecc99
   depends:
@@ -13622,7 +13622,7 @@ packages:
   license_family: MIT
   size: 210228
   timestamp: 1718912759694
-- conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
   sha256: 2ef16d0252e04063d44d0683831d55b485f713fe5af2c2efd61753fb4f27d7e4
   md5: 256ab1d5dce70111a1f4807a5a9fc322
   depends:
@@ -13632,7 +13632,7 @@ packages:
   license_family: MIT
   size: 100982
   timestamp: 1706894771410
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.40-h2eaa2aa_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.40-h2eaa2aa_1.tar.bz2
   sha256: 5bbfaacd95bb901683d6d2e7a1ee10f67172acc1e012f73f80bfef5237ae3ae4
   md5: f37ef4381071123903074612dad356f4
   depends:
@@ -13641,12 +13641,12 @@ packages:
   license_family: BSD
   size: 9122
   timestamp: 1726064402583
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.40.33807-h98bb1dd_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.40.33807-h98bb1dd_1.tar.bz2
   sha256: d82b5b2b1a9a1b37da109039274c125355ce478a199c07c7826ac0fdc2178491
   md5: a0f93c06400da31b9e6e0538eab91216
   size: 2611238
   timestamp: 1726064391949
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
   sha256: 24ea3d3e0cb98d0d246338dbb4562b67967bb32002e3704e495a5c863476e831
   md5: c7b9cdbe87b3c9720aeca1164a0fd6df
   depends:
@@ -13655,7 +13655,7 @@ packages:
   license_family: BSD
   size: 26181
   timestamp: 1676424437003
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
   sha256: 92d27e41ce34387e59acb47572fcb2e92c4defaeadafd11ce190226022023e69
   md5: f1bf142d852987acbe4b0bc94e87d958
   depends:
@@ -13664,7 +13664,7 @@ packages:
   license_family: Apache
   size: 145306
   timestamp: 1715878654770
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.44.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.44.0-py311haa95532_0.tar.bz2
   sha256: 2eb16eafe8322ad10c73b19be8f2c8b6135561bead6f73f48c069417f5db8928
   md5: b28ec461da7eac99523f146ae752529b
   depends:
@@ -13673,7 +13673,7 @@ packages:
   license_family: MIT
   size: 170318
   timestamp: 1726165294131
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
   sha256: 17fadf35aa8917c107e7b369e9364ac7c09537776e7943d37e225e14b7026c94
   md5: 0e67c3b9624540581b894b11267a837b
   depends:
@@ -13681,13 +13681,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 10197
   timestamp: 1676425485716
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
   sha256: 25373efabba9a866849fe38a47c79e0fa323851b4bd4b5df357cc8d5617c2786
   md5: a958e9d32c3b65c21e11e5d9e8491c43
   depends:
@@ -13699,7 +13699,7 @@ packages:
   license_family: Apache
   size: 2467966
   timestamp: 1689041676824
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xerces-c-3.2.4-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xerces-c-3.2.4-hd77b12b_1.tar.bz2
   sha256: 2160b68a45de4b20ce5e63ba06a0db91913e325e5b796ef9f40d38bd2bb8260d
   md5: a6d582169295a9de869f242530796475
   depends:
@@ -13709,7 +13709,7 @@ packages:
   license_family: Apache
   size: 4221569
   timestamp: 1692995399482
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
   sha256: b849b368e27920838fe40a512b102879693a55cb187dd1c8d3a83fa8c05a8054
   md5: 7b1f6e9c71906a93039b3446b99a5498
   depends:
@@ -13718,7 +13718,7 @@ packages:
   license_family: BSD
   size: 55114
   timestamp: 1676434863173
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
   sha256: 344a5276a9928638dcde054dfe4e87c8cb40bd2d4d356378b9ab2f863ca62e4b
   md5: fe471fd8b5a3d77be6fa5dbf9b99dafb
   depends:
@@ -13728,7 +13728,7 @@ packages:
   license_family: GPL2
   size: 1432281
   timestamp: 1714515119689
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -13737,7 +13737,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
   sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
   md5: e5aed81295b61b6d1eb62830799a0297
   depends:
@@ -13748,7 +13748,7 @@ packages:
   license_family: Other
   size: 9125184
   timestamp: 1705602328351
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zict-3.0.0-py311haa95532_0.tar.bz2
   sha256: 478892109d9dc82c90f82d269d3796f4f812f6cba5d3d1f9178a20bd7f583a1f
   md5: df02873bda6c5de6331b00fb1591abac
   depends:
@@ -13759,7 +13759,7 @@ packages:
   license_family: BSD
   size: 102456
   timestamp: 1695833422458
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
   sha256: d932439798665be388bbf68f3d68da5b42ed4753a43587d3f49848a85f58add4
   md5: e2900345674e644e05540ffac6acca89
   depends:
@@ -13768,7 +13768,7 @@ packages:
   license_family: MIT
   size: 25247
   timestamp: 1704207149955
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
   sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
   md5: f295b54ab59f5b8658e2a322ac6aa721
   depends:
@@ -13778,7 +13778,7 @@ packages:
   license_family: Other
   size: 162161
   timestamp: 1714514792081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
   sha256: b2ff66b7f6efa0831f939e57e562c244332b690af08818a540d1a97fa07d8525
   md5: e548d528873d9a0006a36714cf36462a
   depends:

--- a/gerrymandering/pixi.toml
+++ b/gerrymandering/pixi.toml
@@ -1,0 +1,49 @@
+[workspace]
+name = "gerrymandering"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2016-01-01"
+maintainers = ["philippjfr", "jbednar"]
+categories = ["Geospatial"]
+labels = ["datashader", "geoviews", "hvplot", "bokeh", "dask", "geopandas"]
+description = "Combine data of very different types to show gerrymandering"
+
+[dependencies]
+python = "3.11.*"
+notebook = ">=6.5.4,<7"
+cartopy = ">=0.21.1"
+dask = ">=2023.6.0"
+datashader = ">=0.16.0"
+geoviews = ">=1.11.1"
+holoviews = ">=1.18.3"
+pandas = ">=2.1.1"
+hvplot = ">=0.10.0"
+geopandas = ">=0.14.2"
+pyarrow = ">=14"
+pip = "*"
+wheel = "*"
+
+[target.osx-64.dependencies]
+libgfortran = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks.notebook]
+cmd = "jupyter notebook gerrymandering.ipynb"
+depends-on = ["download"]
+
+[tasks.download]
+depends-on = ["download-census_data", "download-congressional_district_data"]
+
+[tasks.download-census_data]
+env = { FILENAME = "data/census.snappy.parq" }
+cmd = "mkdir -p $FILENAME && curl -fsSL -o .census_data.zip http://s3.amazonaws.com/datashader-data/census.snappy.parq.zip && python -m zipfile -e .census_data.zip $FILENAME && rm .census_data.zip"
+outputs = ["data/census.snappy.parq"]
+
+[tasks.download-congressional_district_data]
+env = { FILENAME = "data/congressional_districts" }
+cmd = "mkdir -p $FILENAME && curl -fsSL -o .congressional_district_data.zip https://s3.amazonaws.com/datashader-data/cb_2015_us_cd114_5m.zip && python -m zipfile -e .congressional_district_data.zip $FILENAME && rm .congressional_district_data.zip"
+outputs = ["data/congressional_districts"]

--- a/gerrymandering/pixi.toml
+++ b/gerrymandering/pixi.toml
@@ -22,14 +22,14 @@ pandas = ">=2.1.1"
 hvplot = ">=0.10.0"
 geopandas = ">=0.14.2"
 pyarrow = ">=14"
-pip = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks.notebook]
 cmd = "jupyter notebook gerrymandering.ipynb"

--- a/gerrymandering/pixi.toml
+++ b/gerrymandering/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "gerrymandering"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/glaciers/pixi.lock
+++ b/glaciers/pixi.lock
@@ -7,877 +7,877 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-14.0.2-h374c478_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/async-lru-2.0.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.10.55-h721c034_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/babel-2.11.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.3.4-py311h92b7b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.12.12-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.11.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.16.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/grpc-cpp-1.48.2-he1ff14a_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.9.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter-lsp-2.2.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-8.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab-4.0.11-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_server-2.25.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.5.0-h251f7ec_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-hdbd6064_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.0-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-7.0.8-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.59.0-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.1.4-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.3.8-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.0.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.2.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-14.0.2-py311hb6e97c4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.8-h955ad1f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-25.1.2-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.11.4-py311h08b1b3b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.2.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.1.10-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/spatialpandas-0.4.10-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py311h92b7b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.9.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.9.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.1.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py311h06a4308_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/arrow-cpp-14.0.2-h374c478_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/async-lru-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-sdk-cpp-1.10.55-h721c034_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/babel-2.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-3.3.4-py311h92b7b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py311h6a678d5_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.12.12-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.16.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dask-core-2023.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/datashader-0.16.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fsspec-2023.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/grpc-cpp-1.48.2-he1ff14a_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/hvplot-0.9.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter-lsp-2.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-8.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyterlab-4.0.11-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyterlab_server-2.25.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libcurl-8.5.0-h251f7ec_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libssh2-1.10.0-hdbd6064_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.8.0-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-7.0.8-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numba-0.59.0-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.13-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-2.1.4-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-1.3.8-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-2.0.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-10.2.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-23.3.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyarrow-14.0.2-py311hb6e97c4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.11.8-h955ad1f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-25.1.2-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scipy-1.11.4-py311h08b1b3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-68.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/snappy-1.1.10-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/spatialpandas-0.4.10-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py311h92b7b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-2.1.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py311h06a4308_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/abseil-cpp-20230802.0-h61975a4_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-14.0.2-h3ade35f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/async-lru-2.0.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.10.55-h61975a4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/babel-2.11.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.4-py311h85bffb1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.12.12-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.11.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.16.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/grpc-cpp-1.48.2-hbe2b35a_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gtest-1.14.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.9.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter-lsp-2.2.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-8.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab-4.0.11-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_server-2.25.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.5.0-hf20ceda_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-h04015c4_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py311h41a4f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-7.0.8-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.59.0-py311hdb55bb0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-1.7.4-h995b336_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.4-py311hdb55bb0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.8-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.2.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-14.0.2-py311h2a249a5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.8-hf27a42d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-25.1.2-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.4-py311h224febf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.2.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.1.10-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/spatialpandas-0.4.10-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py311h85bffb1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.9.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.9.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.1.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py311hecd8cb5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/abseil-cpp-20230802.0-h61975a4_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/arrow-cpp-14.0.2-h3ade35f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/async-lru-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-sdk-cpp-1.10.55-h61975a4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/babel-2.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-3.3.4-py311h85bffb1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.12.12-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.16.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/dask-core-2023.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/datashader-0.16.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fsspec-2023.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/grpc-cpp-1.48.2-hbe2b35a_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/gtest-1.14.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/hvplot-0.9.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter-lsp-2.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-8.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyterlab-4.0.11-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyterlab_server-2.25.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcurl-8.5.0-hf20ceda_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libssh2-1.10.0-h04015c4_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py311h41a4f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-7.0.8-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numba-0.59.0-py311hdb55bb0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.13-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/orc-1.7.4-h995b336_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-2.1.4-py311hdb55bb0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-1.3.8-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-2.0.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.2.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-23.3.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyarrow-14.0.2-py311h2a249a5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.11.8-hf27a42d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-25.1.2-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scipy-1.11.4-py311h224febf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-68.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/snappy-1.1.10-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/spatialpandas-0.4.10-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py311h85bffb1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-2.1.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py311hecd8cb5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/abseil-cpp-20230802.0-h313beb8_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-14.0.2-hc7aafb3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/async-lru-2.0.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.10.55-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/babel-2.11.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.4-py311hb6e6a13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.12.12-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.11.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.16.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpc-cpp-1.48.2-hc60591f_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gtest-1.14.0-h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.9.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter-lsp-2.2.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-8.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab-4.0.11-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_server-2.25.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.5.0-h3e2b118_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h02f6b3c_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-7.0.8-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.59.0-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.4-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.8-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.2.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-14.0.2-py311ha07b5f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.8-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-25.1.2-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.4-py311hc76d9b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.2.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.1.10-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/spatialpandas-0.4.10-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py311hb6e6a13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.9.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.9.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.1.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py311hca03da5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/abseil-cpp-20230802.0-h313beb8_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/arrow-cpp-14.0.2-hc7aafb3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/async-lru-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-sdk-cpp-1.10.55-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/babel-2.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.3.4-py311hb6e6a13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.12.12-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.16.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2023.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/datashader-0.16.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2023.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/grpc-cpp-1.48.2-hc60591f_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/gtest-1.14.0-h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/hvplot-0.9.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter-lsp-2.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-8.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab-4.0.11-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_server-2.25.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcurl-8.5.0-h3e2b118_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libssh2-1.10.0-h02f6b3c_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-7.0.8-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numba-0.59.0-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.13-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.1.4-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-1.3.8-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-2.0.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.2.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyarrow-14.0.2-py311ha07b5f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.11.8-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-25.1.2-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.11.4-py311hc76d9b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/snappy-1.1.10-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/spatialpandas-0.4.10-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py311hb6e6a13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.1.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py311hca03da5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-14.0.2-ha81ea56_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/async-lru-2.0.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.10.55-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/babel-2.11.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.4-py311h746a85d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.12.12-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.11.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.16.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/grpc-cpp-1.48.2-hfe90ff0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.9.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter-lsp-2.2.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-8.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab-4.0.11-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_server-2.25.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.5.0-h86230a5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-he2ea4bf_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py311hf62ec03_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-7.0.8-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.59.0-py311hf62ec03_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.4-py311hf62ec03_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.8-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.2.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-14.0.2-py311h847bd2a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.8-he1021f5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-25.1.2-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.4-py311hc1ccb85_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.2.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.1.10-h6c2663c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/spatialpandas-0.4.10-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py311h746a85d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.9.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.9.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.1.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py311haa95532_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/arrow-cpp-14.0.2-ha81ea56_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/async-lru-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-sdk-cpp-1.10.55-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/babel-2.11.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-3.3.4-py311h746a85d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py311hd77b12b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.12.12-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.16.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/dask-core-2023.11.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/datashader-0.16.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fsspec-2023.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/grpc-cpp-1.48.2-hfe90ff0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/hvplot-0.9.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter-lsp-2.2.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-8.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyterlab-4.0.11-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyterlab_server-2.25.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libcurl-8.5.0-h86230a5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libssh2-1.10.0-he2ea4bf_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py311hf62ec03_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-7.0.8-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numba-0.59.0-py311hf62ec03_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.13-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-2.1.4-py311hf62ec03_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-1.3.8-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-2.0.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.2.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-23.3.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyarrow-14.0.2-py311h847bd2a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.11.8-he1021f5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-25.1.2-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scipy-1.11.4-py311hc1ccb85_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-68.2.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/snappy-1.1.10-h6c2663c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/spatialpandas-0.4.10-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py311h746a85d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.9.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.9.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-2.1.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py311haa95532_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
   sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
   md5: 613805add1c05b538ff06d217252feb7
   depends:
@@ -888,7 +888,7 @@ packages:
   license: BSD-3-Clause
   size: 20810
   timestamp: 1652859733309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
   sha256: 8762f481244fb151a200f01dd70e69c77171a3ee0f7f4c130e8e95b6a1626a68
   md5: c3707fcd2efa582afc5c7e1986c6ce48
   depends:
@@ -898,7 +898,7 @@ packages:
   license_family: Apache
   size: 1135866
   timestamp: 1652382888447
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
   sha256: 250f50edf43a786a32942e9ae67ce807e9b3ac4cb6b58b1170cb541fb24e391f
   md5: b48058294499d292ddf9a3b966dc9cc5
   depends:
@@ -912,7 +912,7 @@ packages:
   license_family: MIT
   size: 228473
   timestamp: 1706220559474
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
   sha256: 0d4f5274503916e1c683dcc16e8a7c4186557afa3f62399cd628e4eb535fe77a
   md5: 062acdb0f9ae976c25c2d15d589dc1d6
   depends:
@@ -923,7 +923,7 @@ packages:
   license_family: MIT
   size: 35809
   timestamp: 1676823571351
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-14.0.2-h374c478_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/arrow-cpp-14.0.2-h374c478_1.tar.bz2
   sha256: df890b7a4a677687ad7964182735e2eaf433d6066e346d9878ba90788e3d468f
   md5: 96e5995c1fe9e067faed3e61c416f54f
   depends:
@@ -953,7 +953,7 @@ packages:
   license_family: Apache
   size: 13402790
   timestamp: 1707254138477
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/async-lru-2.0.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/async-lru-2.0.4-py311h06a4308_0.tar.bz2
   sha256: f798d8239a172da4d1b2e5e6e43ee466f303f08d62f920f35cfdd4cbd5d4b171
   md5: 9721c4818b5eea1649443059b488209b
   depends:
@@ -962,7 +962,7 @@ packages:
   license_family: MIT
   size: 20540
   timestamp: 1699554588481
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
   sha256: 567dfdd5b986012421a736a5f1c1d5874d8d691dd483c838b55e1ab06c0b217d
   md5: 4e0aa1543f546b898523382ee8405e84
   depends:
@@ -971,7 +971,7 @@ packages:
   license_family: MIT
   size: 152577
   timestamp: 1695717917074
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
   sha256: 432e4fb45ae24789afdaeca800862aad03f8ebed5af908f01eed2a09283915e5
   md5: a88c0e111e1f47ee83f1b6f329a149ef
   depends:
@@ -985,7 +985,7 @@ packages:
   license_family: Apache
   size: 97643
   timestamp: 1706746168671
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
   sha256: edb54d1554aefb65ff5a3969085dd8695e1e3218a2987ac30a96901f0bbf887a
   md5: 5f131e63f8d80f2b7ac505054204a9e3
   depends:
@@ -996,7 +996,7 @@ packages:
   license_family: Apache
   size: 44722
   timestamp: 1706690912333
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
   sha256: 2afbfb546992e5954748d039ea15405f99018f6de78ec2f32bc7ff9bfc428a9c
   md5: 489017af35cf8bdb976e6fef020a4ac7
   depends:
@@ -1005,7 +1005,7 @@ packages:
   license_family: Apache
   size: 202658
   timestamp: 1706189913451
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
   sha256: 5f81f5a3ea27bd29bf32a6987290de8c7b2da6612676aa8e606a7003519cbf47
   md5: c11e7ceff3ca45bf580d1c944d93bd1f
   depends:
@@ -1015,7 +1015,7 @@ packages:
   license_family: Apache
   size: 17839
   timestamp: 1706690843204
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
   sha256: 348ced323311d36344a0fa9e88d299b361bad1f628dfbdd34bcea8662b3ab44b
   md5: 19a11cdc9727c5981d96983a29b93ce4
   depends:
@@ -1028,7 +1028,7 @@ packages:
   license_family: Apache
   size: 52025
   timestamp: 1706697274091
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
   sha256: 14e2843a218cb01bfc499a22537eb345f6e222b8496cfda2050c73ad98f09cda
   md5: 44cba75d1bb5122aeadcaf8bb7da5e2a
   depends:
@@ -1041,7 +1041,7 @@ packages:
   license_family: Apache
   size: 192985
   timestamp: 1706744140260
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
   sha256: a0f6916d60c0e1bac6ba548bf05a491b8db048a94e13da2f1cfa51b4ca879fb8
   md5: 1f010db4f5ef1b3d705ee04dd1d473c9
   depends:
@@ -1053,7 +1053,7 @@ packages:
   license_family: Apache
   size: 143623
   timestamp: 1706696185335
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
   sha256: 596945a39d772056e57bb357202a17e02508f2594da9c00e00ad767b8213e998
   md5: 98cccbcc56a28ec7339e393816f4bdf7
   depends:
@@ -1065,7 +1065,7 @@ packages:
   license_family: Apache
   size: 70139
   timestamp: 1706746744249
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
   sha256: 12bf86ab848e3311f4eed4e93734a84064dc84580ad6dd4bb823b4ab6ef09698
   md5: 4a8c2dcf0ede655609a9fc5632a5227b
   depends:
@@ -1081,7 +1081,7 @@ packages:
   license_family: Apache
   size: 74700
   timestamp: 1706747582638
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
   sha256: f05ce64fee77518a6deb45f187fcee415328e90ea8f2bf6031bd5b8273a1028f
   md5: b8ebb4b892d9b80d513b4ca62a8d6de2
   depends:
@@ -1091,7 +1091,7 @@ packages:
   license_family: Apache
   size: 53042
   timestamp: 1706690818718
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
   sha256: 52bb367fc367ee3923353927226299a2b8b1be6a1993c11e19b20cafe6c6db0f
   md5: 4715508fd5f8b39e902cb2afebc13c93
   depends:
@@ -1101,7 +1101,7 @@ packages:
   license_family: Apache
   size: 52138
   timestamp: 1706192048702
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
   sha256: 0d13fbdace8ab4fbfcc015cf83bead69560a3dfadc6e0ce8441001629d725834
   md5: a02c72bff71848705e70cd6f075a28f3
   depends:
@@ -1120,7 +1120,7 @@ packages:
   license_family: Apache
   size: 211559
   timestamp: 1706827608038
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.10.55-h721c034_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-sdk-cpp-1.10.55-h721c034_0.tar.bz2
   sha256: a489d946a0a70a4d31f5da9fdf38e2c0ba8122e1df4fc716961b5b02d7617dbe
   md5: f29f551a4e61c4d8339710ba000c6da8
   depends:
@@ -1136,7 +1136,7 @@ packages:
   license_family: Apache
   size: 2815192
   timestamp: 1706890558504
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/babel-2.11.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/babel-2.11.0-py311h06a4308_0.tar.bz2
   sha256: 8da2bfb50812660c69643386afa2a2d0ce9f2b0168e9b7a372349901d7d4b2f7
   md5: d0cde1ca577520a608da5ab86421f9aa
   depends:
@@ -1146,7 +1146,7 @@ packages:
   license_family: BSD
   size: 7241236
   timestamp: 1676825038806
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
   sha256: 894fceb5b4f8740bcd146de8bd0f6eabf14e2407b149b790b4983b8432681e6b
   md5: 2f0ef211bf628cd22bbfa44c3f9bc035
   depends:
@@ -1156,12 +1156,12 @@ packages:
   license_family: MIT
   size: 271600
   timestamp: 1681493103694
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.3.4-py311h92b7b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-3.3.4-py311h92b7b1e_0.tar.bz2
   sha256: 4a2cc7df4d70b7210617c937d5ff70118118c358ebfe8a1556b3760797fee677
   md5: f8afc99a3bda5d35a807958a571d9314
   depends:
@@ -1179,7 +1179,7 @@ packages:
   license_family: BSD
   size: 5947827
   timestamp: 1706912367637
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
   sha256: 3606c8607c29229222667f66421f79df167d33043fe9245cdd4e2c4520ecc721
   md5: eca33dcef14fa044193e43492dca8585
   depends:
@@ -1190,7 +1190,7 @@ packages:
   license_family: OTHER
   size: 10768
   timestamp: 1696762269985
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
   sha256: 8e2b2073ff5c61d35714e8a36ce657a8ac741b7bedc2852a238c7f1625142705
   md5: d951ab54a682b6328327fec53b1e5e72
   depends:
@@ -1201,7 +1201,7 @@ packages:
   license_family: BSD
   size: 147642
   timestamp: 1707864274452
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
   sha256: 11df9b719339bb40e4af8eb124a094def217f64e2440af973d7342da19c030b0
   md5: 712827b1699cc71e6240626c413408f3
   depends:
@@ -1212,7 +1212,7 @@ packages:
   license: MIT
   size: 18907
   timestamp: 1659616178155
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
   sha256: 6408b6849347ef01f5ed170f4b35fb4bdfed2d9cf9da4912a4b104a810518a80
   md5: d9d570587ccfd7158b66feb823c990c6
   depends:
@@ -1222,7 +1222,7 @@ packages:
   license: MIT
   size: 19933
   timestamp: 1659616170430
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py311h6a678d5_7.tar.bz2
   sha256: 571346f89ad34b632322adfa4ed159bbf8977ad7308ccd0956c1bdf2c92a4c41
   md5: c64bed33690b27399c697e2f0aaae8dc
   depends:
@@ -1232,7 +1232,7 @@ packages:
   license: MIT
   size: 360843
   timestamp: 1676830217115
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_5.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_5.tar.bz2
   sha256: f8b8221aa41ef3a18177a44ec397d6fea5ba4d5fc6586f2d1a685bb7eb2c4196
   md5: b02d65d19a697e8a84045027f1808b31
   depends:
@@ -1241,7 +1241,7 @@ packages:
   license_family: BSD
   size: 427268
   timestamp: 1709103505611
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
   sha256: 5b4c80587ae4ec915505469f79d866f27c80456156667c8548d31c67c2c1653e
   md5: c3d6bfae757760082261779c406a880d
   depends:
@@ -1250,14 +1250,14 @@ packages:
   license_family: MIT
   size: 116270
   timestamp: 1693902021950
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.12.12-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.12.12-h06a4308_0.tar.bz2
   sha256: 2f7e8c1f5acc49d1008e13d2dbf66d5462877471ba1020fe78e8323bcbee308d
   md5: 78b3ba713700dac5e7ea2617e6d165d2
   license: MPL-2.0
   license_family: Other
   size: 135757
   timestamp: 1702903808756
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
   sha256: 6dc29d20180f6e002f37b251efa639716d3444e129a754dabf751f816aada7ef
   md5: 5dbfa083e6ab6318fac58fe0e0c94445
   depends:
@@ -1266,7 +1266,7 @@ packages:
   license_family: Other
   size: 165152
   timestamp: 1707229213375
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.16.0-py311h5eee18b_0.tar.bz2
   sha256: 03df3de5da8600074ef873a312a6a55acf4d95bcefa9639300e2a810422d52e3
   md5: b4449b087c14709979812e47b3f9e8d8
   depends:
@@ -1278,7 +1278,7 @@ packages:
   license_family: MIT
   size: 302422
   timestamp: 1700254453506
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
   sha256: 9ddbf05887c7d7926418520cc7848e57f6d2431bc4ec6d30e090b02dbf865041
   md5: 57ae1141ad9a048fb2a75d7a3ef7430a
   depends:
@@ -1287,7 +1287,7 @@ packages:
   license_family: BSD
   size: 203190
   timestamp: 1698129926216
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
   sha256: a5beda842876d0d71598cd2a50ced5fb2731539bc4172fe501b93b60e0c6cd3f
   md5: d5293e5fe74a4e0d71bbf14c9a57f900
   depends:
@@ -1296,7 +1296,7 @@ packages:
   license_family: BSD
   size: 49509
   timestamp: 1683040113536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py311h06a4308_0.tar.bz2
   sha256: 6ec0e7033905bcb379a798486abd1962fca23c31f6a07db206ddc5aa78095573
   md5: b276060ab29889c1055c68be83a31f66
   depends:
@@ -1306,7 +1306,7 @@ packages:
   license_family: CC
   size: 1982585
   timestamp: 1676839188918
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py311h06a4308_0.tar.bz2
   sha256: fcd93d0f515f326a67a4967fbf35b3cd916716f4022851c166101c8ba3277a54
   md5: e0631ec02ad9afd01a077509fde68b1b
   depends:
@@ -1316,7 +1316,7 @@ packages:
   license_family: BSD
   size: 14821
   timestamp: 1677709155428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
   sha256: e4877b41553e31b9f9f090dffab77a654255c63776e8b30fc91ec1f60afadbf1
   md5: c34d3f1520f1e8c9957eb236710058c4
   depends:
@@ -1328,7 +1328,7 @@ packages:
   license_family: BSD
   size: 281162
   timestamp: 1700583651472
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.11.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dask-core-2023.11.0-py311h06a4308_0.tar.bz2
   sha256: edc245960b92d491dc5bb03992ac344e206f094928dde23f814f6436b5781ac1
   md5: 043e5bb51e65e9a64ce9d3e56b10de63
   depends:
@@ -1345,7 +1345,7 @@ packages:
   license_family: BSD
   size: 3024310
   timestamp: 1701396195636
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.16.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/datashader-0.16.0-py311h06a4308_0.tar.bz2
   sha256: 309e8323cc5e7506a2be851649d36be0b6a0e157194baf6ee4fc900a1b43fddd
   md5: c938e7730d42d87dba1658a8893d6338
   depends:
@@ -1367,7 +1367,7 @@ packages:
   license_family: BSD
   size: 18004747
   timestamp: 1699543167034
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
   sha256: 3b4cd8dc60572086f1a1cbb97e2712e0ffd55317ce8f0309d552eee7367855eb
   md5: 70a1263b6e19bf2d77c020a2e77277c9
   depends:
@@ -1378,7 +1378,7 @@ packages:
   license_family: MIT
   size: 2556575
   timestamp: 1690905285843
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
   sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
   md5: a5dc8677d891dff2393b63189a3ad42f
   depends:
@@ -1389,7 +1389,7 @@ packages:
   license_family: Other
   size: 971975
   timestamp: 1666798278693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fsspec-2023.10.0-py311h06a4308_0.tar.bz2
   sha256: d5ed98698d800033bc70eb3633f77327fbdf112fc75ba68b1b90693b8f376575
   md5: a145e4f64de83d744d152fc1d921801b
   depends:
@@ -1398,7 +1398,7 @@ packages:
   license_family: BSD
   size: 351684
   timestamp: 1701286605635
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
   sha256: 2fc1136056f41fe92de719fb821550346704965dd12a5fa35069cdb4948d5c17
   md5: fd089b0fba2b03aafe3adb6cdaa9ac3b
   depends:
@@ -1408,7 +1408,7 @@ packages:
   license_family: BSD
   size: 203421
   timestamp: 1706888218007
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
   sha256: f1e190d4ee766add8131a2b011723c472284de2bbb5e07c8f895f30e3c591df7
   md5: 82029e0758feac811afec2a6ef9e6155
   depends:
@@ -1419,7 +1419,7 @@ packages:
   license_family: BSD
   size: 108438
   timestamp: 1706895276199
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/grpc-cpp-1.48.2-he1ff14a_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/grpc-cpp-1.48.2-he1ff14a_1.tar.bz2
   sha256: 32657e2d11dd813e5649f714c7f58115cff3387f27cf0904cee873bd0d82d2a4
   md5: bdfb8214247977e4ededa4aeb3291ea3
   depends:
@@ -1437,7 +1437,7 @@ packages:
   license_family: APACHE
   size: 5391101
   timestamp: 1685747457305
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
   sha256: f48ccfb4214e2af41e73a3904e343ecd1eb1ae06578c26f55a5dd247771b2c86
   md5: d58e9eb09817935eb7342ceff889f481
   depends:
@@ -1454,7 +1454,7 @@ packages:
   license_family: BSD
   size: 5335524
   timestamp: 1707836581350
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.9.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/hvplot-0.9.2-py311h06a4308_0.tar.bz2
   sha256: c57aadceaadbc1e6e93500577f9c9f6a5bc0cbb63cb769f5dbd20459f8bd9784
   md5: ec35a1d07f175727de6679fdf32ff454
   depends:
@@ -1471,7 +1471,7 @@ packages:
   license_family: BSD
   size: 1978054
   timestamp: 1706712503802
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
   sha256: b35b281dbf69b826c6ae04fcd7b6a2d1f098277a669a199906a1f23b4b0931a5
   md5: 2a793fe24f85aa5819fe69c450cba6f7
   depends:
@@ -1481,7 +1481,7 @@ packages:
   license_family: MIT
   size: 29021241
   timestamp: 1692293243228
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py311h06a4308_0.tar.bz2
   sha256: 1b65cda7fbe1e9300a5aa96c6098788f61d4389fc5bdc2beab12d27ac62102a9
   md5: c4aa1c5005412821f81fa13e4cd78514
   depends:
@@ -1490,7 +1490,7 @@ packages:
   license_family: BSD
   size: 123676
   timestamp: 1676822710633
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
   sha256: c7ffa6006573483a05ef355770c3201f04dd04ab4b91ae01971a6cdc7fbdba35
   md5: 23d7d38e93d930ea5e2cc5f4079d3816
   depends:
@@ -1500,7 +1500,7 @@ packages:
   license_family: APACHE
   size: 49872
   timestamp: 1704813633807
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
   sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
   md5: 3add2ce56858a1b8f6a37342f82773d3
   depends:
@@ -1516,7 +1516,7 @@ packages:
   license_family: Proprietary
   size: 19310769
   timestamp: 1699647799237
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
   sha256: 0b670ab17ed2e1b592079bd64386dadc249ddc892e5ae1dd99f142a918ffc75d
   md5: 632575b9e442c1e5c146cf78424da610
   depends:
@@ -1537,7 +1537,7 @@ packages:
   license_family: BSD
   size: 227791
   timestamp: 1705934138566
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
   sha256: 65228eb868c3ec8aa71f958e60a675a919f016c2057392e02fd422fc841858f9
   md5: 68e23f14cd222c233e6b37262bc61c23
   depends:
@@ -1554,7 +1554,7 @@ packages:
   license_family: BSD
   size: 1612840
   timestamp: 1704833066871
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
   sha256: a2918ea8a3e2c56fc6d91191e84b2f35500c392b16ab687a0c03ded2e2e51239
   md5: 84fadd6b7fef393cccc0d123dae6cae8
   depends:
@@ -1564,7 +1564,7 @@ packages:
   license_family: MIT
   size: 1162207
   timestamp: 1679336523618
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
   sha256: 4520b83e425883981f97191986a08122fbaebc3f16b898368796314136779028
   md5: 42a8f32c4d842d3e5410b2bc1cc2fb57
   depends:
@@ -1574,7 +1574,7 @@ packages:
   license_family: BSD
   size: 352284
   timestamp: 1706733655761
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
   sha256: c21f8f407266d039e819c27fe9eb4fb26587e974f3bd059b37cbaec5073722d0
   md5: ba1f47411e9e07876c7a3e9d3be6a98e
   depends:
@@ -1583,7 +1583,7 @@ packages:
   license_family: Other
   size: 281400
   timestamp: 1677849152168
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
   sha256: 06b729aee6dd2a1e545f3ad64179cc0d4ef8a15e33db3be2995dd3e0868465ca
   md5: 8bb3215912588e47e2eeb4e7a09ad64f
   depends:
@@ -1596,7 +1596,7 @@ packages:
   license_family: MIT
   size: 180858
   timestamp: 1699041715847
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
   sha256: 9e3bac2d41bd432b721b009e7de981766fba396e6f238e923f304112bd88655a
   md5: 84ae4cf3f2d01fbebdac374971192be9
   depends:
@@ -1606,7 +1606,7 @@ packages:
   license_family: MIT
   size: 15525
   timestamp: 1699032521315
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter-lsp-2.2.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter-lsp-2.2.0-py311h06a4308_0.tar.bz2
   sha256: c4b1dcb8ba34bfb2c7fc6ccf1399dd0bd2a324e792eac722561607f2bff68d72
   md5: d82f26a5c414b519c7737240fb7f342e
   depends:
@@ -1616,7 +1616,7 @@ packages:
   license_family: BSD
   size: 100413
   timestamp: 1699978354251
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-8.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-8.6.0-py311h06a4308_0.tar.bz2
   sha256: d215948faad1eff39b5bec3da793d6d185b85793a1d839c3d1c196b85fd6c9b1
   md5: 555ea509581f49256e7aae2ff5dce460
   depends:
@@ -1630,7 +1630,7 @@ packages:
   license_family: BSD
   size: 221658
   timestamp: 1699456577818
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
   sha256: fedc7e5560252af44b0dfbe6f7acfe20ab17a6a08e758f670a1cd820551afc7a
   md5: bd28d36963087f53a79b23fee697d665
   depends:
@@ -1641,7 +1641,7 @@ packages:
   license_family: BSD
   size: 93898
   timestamp: 1698937453304
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
   sha256: 2b896fe8b2187b7df824041826e14379476eb2e61d607d8cb38ac2b3df40aaa4
   md5: 8fc7e517da96c2c482331f6b08d07a17
   depends:
@@ -1657,7 +1657,7 @@ packages:
   license_family: BSD
   size: 41459
   timestamp: 1699282616532
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
   sha256: 87d372f5b23bcc2410e43b40b4ad059ea1625178b8a2b484fc63805ce517e594
   md5: 50204f372b1672871d6ab3db6a876374
   depends:
@@ -1684,7 +1684,7 @@ packages:
   license_family: BSD
   size: 594177
   timestamp: 1699467208489
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
   sha256: ddfee06ba9b149222c65d1d4270272840533aa63b56fe36363c84a891c71d328
   md5: ee128e5c0d8d9e1952e2387b66a5b8cb
   depends:
@@ -1694,7 +1694,7 @@ packages:
   license_family: BSD
   size: 27239
   timestamp: 1686870958829
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab-4.0.11-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyterlab-4.0.11-py311h06a4308_0.tar.bz2
   sha256: a2bc9b312a31e5abaedf230659ecb31f9483a1a3c0f4cd1adae7f5ea2045f9d6
   md5: 728bdb3c057e57cd963f304d2c8a48a9
   depends:
@@ -1716,7 +1716,7 @@ packages:
   license_family: BSD
   size: 6665313
   timestamp: 1706803269767
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_server-2.25.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyterlab_server-2.25.1-py311h06a4308_0.tar.bz2
   sha256: b8c434bad4499fc41d0e18986b7ab1fbcf5e2aabadc2658430ee1f5cd16c4cbc
   md5: 59a08c840ebfa765cfe5d4dc764804c7
   depends:
@@ -1732,7 +1732,7 @@ packages:
   license_family: BSD
   size: 106168
   timestamp: 1699555585974
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
   sha256: b040f0d0ee4588188ab6b83a93738b3ff6e6d1775424be97995bd0df0f4fb904
   md5: eae62735d710cf5ff6d51e6f59fcd999
   depends:
@@ -1743,7 +1743,7 @@ packages:
   license_family: BSD
   size: 78148
   timestamp: 1676827253282
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
   sha256: 01bae3dd44469e34f043e0416f5f5e658429bf4031745399d9968d10b899e2c4
   md5: 10171cca67e3d73c3646c6dc5a321460
   depends:
@@ -1755,7 +1755,7 @@ packages:
   license_family: MIT
   size: 1427115
   timestamp: 1686931095252
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -1766,7 +1766,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
   sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
   md5: 9508af80612e4fa1b5d1abb43ca7e63c
   constrains:
@@ -1774,7 +1774,7 @@ packages:
   license: GPL-3.0-only
   size: 749072
   timestamp: 1652971360657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
   sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
   md5: 88199c75f2ac211728febced7785c24e
   depends:
@@ -1784,7 +1784,7 @@ packages:
   license_family: Apache
   size: 228278
   timestamp: 1635523146417
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
   sha256: e2754627e8aeb98777318939e6773b9eadbdc219dd8961aca946354d9d30f481
   md5: 4ed89646229bee3e594cd2cc8f6060f9
   depends:
@@ -1799,7 +1799,7 @@ packages:
   license_family: OTHER
   size: 23778916
   timestamp: 1696762223408
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
   sha256: 472cf888db65d00451fcd5fccd5244d55c061e8d7efe43f70220414ef64521a5
   md5: 787927eff72e62c270f614cbcba9479c
   depends:
@@ -1807,7 +1807,7 @@ packages:
   license: MIT
   size: 67109
   timestamp: 1659616145972
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
   sha256: 19a43182ca343510ba51baa0fce91d64c840a19cdf13c6dde4e03e819c70897e
   md5: c0608d376a30b5aa4d2f2c22978135db
   depends:
@@ -1816,7 +1816,7 @@ packages:
   license: MIT
   size: 34691
   timestamp: 1659616154057
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
   sha256: 158c401aa0bab05aa5f4134aea798085e4e3849209946f896cca352930d2225d
   md5: cc6a6d362912a2d112310bd3f8acd44e
   depends:
@@ -1825,7 +1825,7 @@ packages:
   license: MIT
   size: 295287
   timestamp: 1659616162282
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.5.0-h251f7ec_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libcurl-8.5.0-h251f7ec_0.tar.bz2
   sha256: 22628e28b6df8298b761c4524b086a02b0e9fe208cf37ec86090497c4db50583
   md5: 7d328929de28a113f3e5b8e0d70ce709
   depends:
@@ -1841,7 +1841,7 @@ packages:
   license_family: MIT
   size: 403919
   timestamp: 1704383721246
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
   sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
   md5: 55dde57e63a36b202e388a39dcee9a66
   depends:
@@ -1850,7 +1850,7 @@ packages:
   license_family: MIT
   size: 74096
   timestamp: 1695996494461
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
   sha256: 5bd3af246b6a93ea0912179ae66e0ad9157ca0142263010d84b65724e6db0bec
   md5: 5cb0cc0e1783419cf8fc1c65fee0f62f
   depends:
@@ -1860,7 +1860,7 @@ packages:
   license_family: BSD
   size: 195807
   timestamp: 1703006263489
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
   sha256: efdab884c85fda4461f7a393aa6d4e0e50d03cb59fb9c8a980b1307b8379ebe0
   md5: eeca774c6154c49340dd403b1928d5e9
   depends:
@@ -1869,7 +1869,7 @@ packages:
   license_family: BSD
   size: 108906
   timestamp: 1632891483341
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
   sha256: 4b2518a1aa3859031a531cd1077e8a60d5b3a0dc7c83210ef27ff9ce2c78c3e3
   md5: 49f152ee4045544c10799d32bba85c07
   depends:
@@ -1880,7 +1880,7 @@ packages:
   license_family: BSD
   size: 480247
   timestamp: 1685052130829
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
   sha256: ec1c6341cf0091b55be05285037cb3fbba90573e00257f383ab274d8b8e6d46f
   md5: 32ac65d639d6c155ea7276cadf1fd2b6
   depends:
@@ -1890,7 +1890,7 @@ packages:
   license_family: MIT
   size: 147907
   timestamp: 1683716564178
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
   sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
   md5: 641e72e5067bd6d5454405879e1cd2a7
   depends:
@@ -1905,7 +1905,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 8895144
   timestamp: 1654090827491
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
   sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
   md5: 27082517590f3b9fbffecc68513b461b
   depends:
@@ -1914,7 +1914,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 19860
   timestamp: 1654090819660
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
   sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
   md5: 0202c3c8ae4735cac6c7f3d1e1685964
   constrains:
@@ -1922,7 +1922,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 5228750
   timestamp: 1654090762569
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
   sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
   md5: 3080c2813e6e1d0f8a100a38b5b3456d
   depends:
@@ -1930,7 +1930,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 573231
   timestamp: 1654090775721
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
   sha256: 512fac06ddd97b4383503d4fbd8145102966055b29ccf86841a930dbb4ef3ab8
   md5: 833c0e514ff9c8ae0511630b024d60e0
   depends:
@@ -1943,7 +1943,7 @@ packages:
   license_family: Apache
   size: 37179832
   timestamp: 1683292829131
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
   sha256: 6c67d781d3c074ae46b18567f230bce4a4afa209e8b914dc2cb448502774886e
   md5: c9627c386bbc8a1a1a0a2e736ea44501
   depends:
@@ -1959,7 +1959,7 @@ packages:
   license_family: MIT
   size: 722387
   timestamp: 1697018420830
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
   sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
   md5: 1bffe1481ed4f88827248fb9001f8923
   depends:
@@ -1969,7 +1969,7 @@ packages:
   license_family: Other
   size: 362561
   timestamp: 1677841789536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
   sha256: a24f7d1cdb5e18466a61860a5a66baffd608e212bbfed2935350e83d4d8659c0
   md5: b32a43de76bc9be9c71f9a12edec8a1e
   depends:
@@ -1980,7 +1980,7 @@ packages:
   license_family: BSD
   size: 2706964
   timestamp: 1675278653314
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -1988,7 +1988,7 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-hdbd6064_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libssh2-1.10.0-hdbd6064_2.tar.bz2
   sha256: d011fe14e4b5752feb7f1d6b7c1a7913cb153f8759b4befdf53ed7a5d846cd52
   md5: c29b0f58de6585e5220e10eb5ac2f9e2
   depends:
@@ -1998,7 +1998,7 @@ packages:
   license_family: BSD
   size: 311498
   timestamp: 1686931236351
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
   sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
   md5: 8c195584a5f5471b600ee180e4052773
   depends:
@@ -2006,7 +2006,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 6410287
   timestamp: 1654090800863
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
   sha256: 974e4035c5d51cd41fa7a7f02fadc1980069c00526c1646fa18ea94e667fb137
   md5: 188de945b4279a812953011e8c4580c2
   depends:
@@ -2020,7 +2020,7 @@ packages:
   license_family: Apache
   size: 4630795
   timestamp: 1687975185557
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
   sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
   md5: ef78eebd98289aceacdfa29182426adf
   depends:
@@ -2038,7 +2038,7 @@ packages:
   license_family: Other
   size: 664034
   timestamp: 1693575237924
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
   sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
   md5: 292768ec77416ae257cfdd44ea2071c8
   depends:
@@ -2047,7 +2047,7 @@ packages:
   license_family: BSD
   size: 29197
   timestamp: 1668082729834
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
   sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
   md5: 9cdeef1d044c7e035c006890f11569d3
   depends:
@@ -2058,7 +2058,7 @@ packages:
   license_family: BSD
   size: 436056
   timestamp: 1694776944891
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
   sha256: fd8e30beb8c9442f16e6617fac92dd0c89ec823e98f06e60f712147380ead35f
   md5: 7ed7caf2816c8b85b67b6f4e8833cbd5
   depends:
@@ -2068,7 +2068,7 @@ packages:
   license_family: MIT
   size: 41155
   timestamp: 1676837080881
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
   sha256: 05e355127db0d3ed67c4c383fd929ef1c3d7d3f19472f6e5433a866e94378bed
   md5: b7897895622e5ab6e62279f07fa1f587
   depends:
@@ -2080,7 +2080,7 @@ packages:
   license_family: BSD
   size: 4367002
   timestamp: 1706910875807
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
   sha256: 95fe76d2691feb13203b55ad2aba535bb848cae21ffd05b13ff51c7a45fa2332
   md5: 6a04ec16e3abc1c7e2104be32cd6c418
   depends:
@@ -2089,7 +2089,7 @@ packages:
   license_family: BSD
   size: 13458
   timestamp: 1676827287432
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
   sha256: 36b23ab8d8aa22d70a2f733462cabe95e5b27ca919ec7a75a5592bc39c5f7d16
   md5: f24adbfdfe16b0bac0d14640bb5ce616
   depends:
@@ -2099,7 +2099,7 @@ packages:
   license_family: BSD
   size: 163649
   timestamp: 1670944701605
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
   sha256: 260e26dd509834c1b225ab7bdb97b9a86e00054fbdd5dfa49e68fa4dcf85a661
   md5: 8f5d7ddc69cc6f7d44c80d2251dea5d1
   depends:
@@ -2108,7 +2108,7 @@ packages:
   license_family: BSD
   size: 162339
   timestamp: 1676837095436
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
   sha256: 7f5b0804d0768619b7bd93b10488067d80bf42ec29f443f00b53ba11758a1241
   md5: 8afb45e45c0d93bfd142e682d4b021ef
   depends:
@@ -2118,7 +2118,7 @@ packages:
   license_family: MIT
   size: 134438
   timestamp: 1684280014220
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
   sha256: cb03570c99c983d7bfda94bc47d8eb00d4059b8548a171130775acc998004195
   md5: 5b1abbbf1e4f9b350b16fc9caf9e889b
   depends:
@@ -2130,7 +2130,7 @@ packages:
   license_family: BSD
   size: 26919
   timestamp: 1704206397615
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.0-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.8.0-py311ha02d727_0.tar.bz2
   sha256: 9efe8bfd1544ca9b3a42a7c5f287c6c23ad0d0211643a4a4ad43fbd6bb6473a0
   md5: a3e9d32a5a23d979490d0ce20b8ef228
   depends:
@@ -2152,7 +2152,7 @@ packages:
   license_family: PSF
   size: 9104983
   timestamp: 1698692396617
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
   sha256: 7ac07ea180b5928086075900afbc332fb1d3c81ddfacb54c891693c284056f14
   md5: fc83dd1b3d2ec3c0a297ead0c3405907
   depends:
@@ -2162,7 +2162,7 @@ packages:
   license_family: BSD
   size: 19573
   timestamp: 1676823852670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
   sha256: c9ba2f9c83820712dd97d6a1b54a1215b9820a0be02ac82380b4c50911b9400c
   md5: e5dc6b4a5b8e02733ce3bc9e9198a8d2
   depends:
@@ -2172,7 +2172,7 @@ packages:
   license_family: MIT
   size: 67750
   timestamp: 1676837123613
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
   sha256: 1a5141ef0de1cbff816f96bb4b212a40606e2fc11301a4c1358c8d63a6b2b027
   md5: 22ac3bc22b68fef4c1f3f6ab3c7bfe0b
   depends:
@@ -2181,7 +2181,7 @@ packages:
   license_family: MIT
   size: 23040
   timestamp: 1676827301164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
   sha256: 9aacfbbe6f638c58a4e8ff31374d1438d78b7db25d6ea6fd0c50ca2109f225d4
   md5: e602057e3b3d80da88c61d66e8851c5b
   depends:
@@ -2192,7 +2192,7 @@ packages:
   license_family: BSD
   size: 104681
   timestamp: 1676823696152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
   sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
   md5: ce77d0f05f846da4a6b9e23fe7f21d9b
   depends:
@@ -2206,7 +2206,7 @@ packages:
   license_family: Proprietary
   size: 206738176
   timestamp: 1699648006088
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
   sha256: 2aef0876d0df033f7fae8cddbd25d95fc1bfc067e60dd143bd8000fec0768b21
   md5: d6cdc670327bd1675bbea642849f04e1
   depends:
@@ -2217,7 +2217,7 @@ packages:
   license_family: BSD
   size: 59569
   timestamp: 1682948560323
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
   sha256: 691c4b2b47cf3fac55b4949d7c0f547246ef19cb3510749142cee4bd01ffb055
   md5: bbd69efa3f24ee747410f83118640d92
   depends:
@@ -2231,7 +2231,7 @@ packages:
   license_family: BSD
   size: 240723
   timestamp: 1695058405382
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
   sha256: 71f5c7beca4e81b465ecfc6ed51cb3d39f51dd88df0b29eff5def3d1f12969eb
   md5: 61d58663b7277cf4cc3cb8d9873d3ee8
   depends:
@@ -2246,7 +2246,7 @@ packages:
   license_family: BSD
   size: 331105
   timestamp: 1695059935112
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
   sha256: b558b3f6c144652b5e0d26497b3ce24c318a6b9ff8ea2079113c95e5553b3cf9
   md5: 0b185969ac2b065c27cbcc9641d93678
   depends:
@@ -2256,7 +2256,7 @@ packages:
   license_family: BSD
   size: 29568
   timestamp: 1676841232463
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
   sha256: bb45fb0a3973caa74fd8f845e0a519895f6a378807626e15ecf72c02f2eed794
   md5: 185f658ba8a74e326b7231c8fd0d62bf
   depends:
@@ -2269,7 +2269,7 @@ packages:
   license_family: BSD
   size: 121834
   timestamp: 1698934274227
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
   sha256: 8b2fc372a6655fd5b277d07b994ce43643553fbc37e63a60e9fe527a9026ec06
   md5: ed6ac14aed5a796b153d757862398997
   depends:
@@ -2296,7 +2296,7 @@ packages:
   license_family: BSD
   size: 523905
   timestamp: 1699022906468
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
   sha256: 7908ff6c516b15e8fb677be4071145e18adea7d4c13b8485a70a5ee2f573f8cb
   md5: 50c0e38207a131a5de6a14ef919ffcdc
   depends:
@@ -2309,7 +2309,7 @@ packages:
   license_family: BSD
   size: 169629
   timestamp: 1694616826002
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
   sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
   md5: 57ea097dc15f8d9f9eb90e1d919143b0
   depends:
@@ -2318,7 +2318,7 @@ packages:
   license_family: MIT
   size: 1157733
   timestamp: 1674734069410
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
   sha256: 266199dd4efde0ad342a9c500f4bc4299c5622219aea623b46315a9b4f6b8959
   md5: 2b21844d2b0024d0ffad0e6450cf0855
   depends:
@@ -2327,7 +2327,7 @@ packages:
   license_family: BSD
   size: 15860
   timestamp: 1708532713870
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-7.0.8-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-7.0.8-py311h06a4308_0.tar.bz2
   sha256: 59e17fc80ec01ffef983431d36b41013d1da575e03f5bc1ff36fc3b7e496e7be
   md5: b4e5249538db1bc282ac0d0d8c4f307c
   depends:
@@ -2341,7 +2341,7 @@ packages:
   license_family: BSD
   size: 3650043
   timestamp: 1708029938702
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
   sha256: ef2857e6d3d7eb246b3abddfbd3aa2d124dd8565391ace3876b77339babc50bb
   md5: d276d1b1774107987963135c78ca7390
   depends:
@@ -2351,7 +2351,7 @@ packages:
   license_family: BSD
   size: 26607
   timestamp: 1699455972519
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.59.0-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numba-0.59.0-py311ha02d727_0.tar.bz2
   sha256: 72d8bcdf6f7ef6019a65d19501e25e5240ceda3730393ca3a21a868cc65e6043
   md5: 06bfdf47b0437d89981058907f297b89
   depends:
@@ -2374,7 +2374,7 @@ packages:
   license_family: BSD
   size: 6076268
   timestamp: 1707087452201
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
   sha256: 2f89f38a665ece47e8868b391fc70602fcee588e989bc1ca6f17f6094892a94e
   md5: b788c80b2d571531ea4f3f8335ae5423
   depends:
@@ -2389,7 +2389,7 @@ packages:
   license_family: MIT
   size: 168827
   timestamp: 1696515597877
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
   sha256: e09e1aff2c12d4ef3fec58fb627744e4b5c7d9eaede7175e293f77272d8b8bfd
   md5: fe8242cfd54d238507493612ae697ad4
   depends:
@@ -2406,7 +2406,7 @@ packages:
   license_family: BSD
   size: 10270
   timestamp: 1708639794640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
   sha256: a53ad723826651041a5057a1cf31bc8689b24d335ce61b196df5124974b05a8e
   md5: 7b29e7191c4170189d6080e61229f030
   depends:
@@ -2422,7 +2422,7 @@ packages:
   license_family: BSD
   size: 9163911
   timestamp: 1708639777712
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
   sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
   md5: b0afe23033c8c5344640bc25225fa579
   depends:
@@ -2433,7 +2433,7 @@ packages:
   license: BSD 2-Clause
   size: 516994
   timestamp: 1630084830020
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.13-h7f8727e_0.tar.bz2
   sha256: 71f97234bc7d69c59e4a3dd2eb7c0f983e2c21547695c42fa00579362372d528
   md5: 40a571ff3839c015f034b51da60a69a1
   depends:
@@ -2443,7 +2443,7 @@ packages:
   license_family: Apache
   size: 5498847
   timestamp: 1706908984217
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
   sha256: 9618addfc1b940c048372ffb2c8500d4b44d02455a9bd1f411e530ed5e09b8d5
   md5: 56057ed323f733bdcf262468682d0358
   depends:
@@ -2458,7 +2458,7 @@ packages:
   license_family: Apache
   size: 1132661
   timestamp: 1676482768554
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
   sha256: 280225061aeba00d7b85f46e55d7d79cd92c92f662dc749d9c53187978e8d083
   md5: c51c21da68080d89300703ad818c824a
   depends:
@@ -2467,7 +2467,7 @@ packages:
   license_family: APACHE
   size: 38606
   timestamp: 1699371264464
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py311h06a4308_0.tar.bz2
   sha256: 8ea36ca391d340cb8e2a71674e192e25ad23d9b9b5c74270f626a4a3f56a1aef
   md5: 1cdfac1a7c76d71d2a6830e4a84df79a
   depends:
@@ -2476,7 +2476,7 @@ packages:
   license_family: Apache
   size: 93525
   timestamp: 1693575262009
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.1.4-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-2.1.4-py311ha02d727_0.tar.bz2
   sha256: 2af8bf52c2eff731ebee633ec5da325b58e113077098a3103a4223ff1bb162e9
   md5: d46d81f25227a2a9e030a5e777d98d36
   depends:
@@ -2524,7 +2524,7 @@ packages:
   license_family: BSD
   size: 16961688
   timestamp: 1702321029603
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.3.8-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-1.3.8-py311h06a4308_0.tar.bz2
   sha256: 9833c4d4247c8c320febb944aa1c42ea63479fb3c0334cbcc3f09718251c97b7
   md5: 52c4ac82d18fc6c46136085443495071
   depends:
@@ -2548,7 +2548,7 @@ packages:
   license_family: BSD
   size: 18067488
   timestamp: 1706540032944
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.0.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-2.0.2-py311h06a4308_0.tar.bz2
   sha256: 3a7e48b56598b47e2da15be3d282b0360bcdf41ce022c15bb761b275426c9b0f
   md5: 566774cbb1fad5e3131f337708d1c7c3
   depends:
@@ -2557,7 +2557,7 @@ packages:
   license_family: BSD
   size: 254603
   timestamp: 1705937840407
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
   sha256: a2e2beff710765f2e5135020121da4f227f5e1cbe142e17398a585f50a389d37
   md5: eaf734d49b6e576e12be1398a295643a
   depends:
@@ -2571,7 +2571,7 @@ packages:
   license_family: BSD
   size: 47447
   timestamp: 1698702703255
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.2.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-10.2.0-py311h5eee18b_0.tar.bz2
   sha256: 32af5aaf90e864d7714e85a9eb0c84d4ebb863e595351664d7e7560cfe7a7fd9
   md5: 83e90196712d58d9fd5f8b69843e5873
   depends:
@@ -2588,7 +2588,7 @@ packages:
   license_family: Other
   size: 954430
   timestamp: 1707233291841
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-23.3.1-py311h06a4308_0.tar.bz2
   sha256: 0bedd7decde6751a3efbb2367dd22d916b61391e334833d548b285fdd3420080
   md5: aebee46c2eadf95ea8633847612f0f15
   depends:
@@ -2599,7 +2599,7 @@ packages:
   license_family: MIT
   size: 3443056
   timestamp: 1700667782149
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
   sha256: d2bbab8bfc57c7f46ca8994bc87df7e744d3f036b867bc4be1145ba6d8d7e091
   md5: de41707272a8e3ccab764f0b7010a27d
   depends:
@@ -2608,7 +2608,7 @@ packages:
   license_family: MIT
   size: 37394
   timestamp: 1692205565974
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
   sha256: e2a0e2a618aa33f0beff9583c7dc510b8d0737b023117346676aacbad33970d8
   md5: 66a6818307261b1a28ab12d1b7776fdf
   depends:
@@ -2617,7 +2617,7 @@ packages:
   license_family: Apache
   size: 121454
   timestamp: 1679340540306
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
   sha256: b7f591c19b10bf0daa7e6e3b45a9f4a0a0e83188e1f8a58037caea79e60f8d91
   md5: d945b4ccc135005839c504cc29df1745
   depends:
@@ -2629,7 +2629,7 @@ packages:
   license_family: BSD
   size: 749608
   timestamp: 1704404477511
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
   sha256: 96482b49191fdac59580a95e69508367083e1f7600145e11d7c2db634337eb26
   md5: 2d57bf8eacf3f291db845928241f724c
   depends:
@@ -2639,7 +2639,7 @@ packages:
   license_family: BSD
   size: 490805
   timestamp: 1679337420563
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-14.0.2-py311hb6e97c4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyarrow-14.0.2-py311hb6e97c4_0.tar.bz2
   sha256: 252204d5e65480b83b9e31c63cecfaff95725ef5fc302714f92c344b7fdbafe3
   md5: f2b86ab94d7af6c10b9586263b1b45df
   depends:
@@ -2653,7 +2653,7 @@ packages:
   license_family: Apache
   size: 5423490
   timestamp: 1707331892286
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
   sha256: eb75b4417565d25e2d1006db75aa8bd9da6b6c72a929954b01a31b9bf5f8b42e
   md5: bb56c0358b65665f4dd509a4635f6f3c
   depends:
@@ -2665,7 +2665,7 @@ packages:
   license_family: BSD
   size: 37802
   timestamp: 1676838557935
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
   sha256: ed927e4d058a8f4ea73edc7a43ed74877d93b88fdfa240b3b2777244386ced70
   md5: a1f0e05fc7e49712f81ad5478ec9d51e
   depends:
@@ -2674,7 +2674,7 @@ packages:
   license_family: BSD
   size: 2121496
   timestamp: 1684280065800
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
   sha256: ad219924e362ce7af458fa6547660181579e9a50e5aed1ffd9268cbe7c2650e3
   md5: 2b1ac40e0df3673d33b7f4c4f93ae1ef
   depends:
@@ -2683,7 +2683,7 @@ packages:
   license_family: MIT
   size: 207338
   timestamp: 1677811584327
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
   sha256: 114b55e00f4622c90fd2b404b21ad5f94a10283fcaaf86a42174b8d39b0a3e98
   md5: 2458e92683cc68671a6c8e1b86ce8817
   depends:
@@ -2692,7 +2692,7 @@ packages:
   license_family: BSD
   size: 35850
   timestamp: 1676822725516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.8-h955ad1f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.11.8-h955ad1f_0.tar.bz2
   sha256: 8bae0856b2f337f43cb5cbbf71ebf684ef47438210465b8733304d7d7f258559
   md5: 7fa94ac6e31488660ca09b2896b9d96d
   depends:
@@ -2714,7 +2714,7 @@ packages:
   license_family: PSF
   size: 36090392
   timestamp: 1708984519285
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
   sha256: aadc4078311c059265706a56265f0a57ceb538d36179d5203dd487d80d0e8f16
   md5: 59ec670fcd172447dbd9591b8fbfdd56
   depends:
@@ -2723,7 +2723,7 @@ packages:
   license_family: BSD
   size: 278741
   timestamp: 1679340144625
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
   sha256: d5058d0ecc3973316c1d5f1bfb03dd119e0dade85f4c2d21b412c8db4e1636f2
   md5: 93000e4d3603342779a2afda66fa91b8
   depends:
@@ -2732,7 +2732,7 @@ packages:
   license_family: BSD
   size: 17607
   timestamp: 1683823841946
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py311h06a4308_0.tar.bz2
   sha256: b5f08fc0a119fc4bedef13130efb40f2d2af8cfb069b8eeaaaa97c99c7070cd7
   md5: 765c02a2485efe5e6307e2d424d0eba0
   depends:
@@ -2741,7 +2741,7 @@ packages:
   license_family: MIT
   size: 269196
   timestamp: 1695131641771
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.0-py311h06a4308_0.tar.bz2
   sha256: b3c50415b604cd6c4ac81a8d2f3ebb2b59cce09b2a4d2d83a6016e7d3fea169d
   md5: cdf2f9462252bfa0137b7f1090dc5129
   depends:
@@ -2753,7 +2753,7 @@ packages:
   license_family: BSD
   size: 63656
   timestamp: 1701728055800
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
   sha256: b2a1f649669f4336b74f6f20df711959bcd8024f8f8b94199dc0e040b06bd37a
   md5: f9e8e3f7068f717f75e555dc04545d8d
   depends:
@@ -2764,7 +2764,7 @@ packages:
   license_family: MIT
   size: 206433
   timestamp: 1698096204677
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-25.1.2-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-25.1.2-py311h6a678d5_0.tar.bz2
   sha256: 787979e7e36b0eaf06c65f8840f3af969b6efa6ba2a7e2736b1bb52e96588242
   md5: eb62cbfdbe25aaebbafad6166ec66903
   depends:
@@ -2776,7 +2776,7 @@ packages:
   license_family: BSD
   size: 583036
   timestamp: 1705605396341
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
   sha256: 8a640736bef635346409582dbfe2b7d0ecc9da215c90173ff8a9a5fe22569107
   md5: 6b583dce61c6feb352ef0f49f413af1e
   depends:
@@ -2785,7 +2785,7 @@ packages:
   license: BSD-3-Clause
   size: 235004
   timestamp: 1652449537852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
   sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
   md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
   depends:
@@ -2795,7 +2795,7 @@ packages:
   license_family: GPL
   size: 467661
   timestamp: 1666648052561
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
   sha256: 89c2f4235277b9825cc805c5c44f0b1afcb683d7b5a3f513bc4bf243b643bb0c
   md5: db70eb57e33adf7b8bbdadd72214d48d
   depends:
@@ -2806,7 +2806,7 @@ packages:
   license_family: MIT
   size: 73679
   timestamp: 1699012111499
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
   sha256: 684037527327839d734e7eac2ee09ef5ddb4f77df22daf40c79e51db29d09543
   md5: 57c5bcb9eae9f1d93ccfd38025660de2
   depends:
@@ -2822,7 +2822,7 @@ packages:
   license_family: Apache
   size: 119414
   timestamp: 1707355661872
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
   sha256: fdae3f68ea84b99561aee6c566ab1c287d8f2ae2668424e9283a8ed86af8f1d2
   md5: cde5b71ccbb3630053340b2c8c7dbf10
   depends:
@@ -2832,7 +2832,7 @@ packages:
   license_family: MIT
   size: 9333
   timestamp: 1683077183576
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
   sha256: 0bf859b06a07857099fd4f524fe5e0875fda70029e9485d95c7efa97134fbc14
   md5: fd5815cc592fdbd4c831901541eadaba
   depends:
@@ -2841,7 +2841,7 @@ packages:
   license_family: MIT
   size: 9735
   timestamp: 1683059096795
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
   sha256: 474553d01aea57214a54a7443f227da84a58e29c49eb7605ba0043c55b7d167a
   md5: f01333e9f0a908e435db650f42fbd2db
   depends:
@@ -2851,7 +2851,7 @@ packages:
   license_family: MIT
   size: 1096668
   timestamp: 1698946168635
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
   sha256: 8c8aa1eb7e215984f46c8e1c7cfa6e5e6b233993d92b835a9b1b5491a4b970ab
   md5: 6e145b179adde03f8aa8a066c58d4e31
   depends:
@@ -2861,7 +2861,7 @@ packages:
   license_family: Apache
   size: 380702
   timestamp: 1706563445897
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.11.4-py311h08b1b3b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/scipy-1.11.4-py311h08b1b3b_0.tar.bz2
   sha256: 98d0cd31403b1cab3e4557619ef7aa7affa12e44e377f1f900f8edf10720a776
   md5: a6b09c764e9edd584e434fe404943d98
   depends:
@@ -2878,7 +2878,7 @@ packages:
   license_family: BSD
   size: 25430724
   timestamp: 1701296824601
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
   sha256: 51bcea0e575a626f6ffbd16d1153330fda93dbe3dd31dcd3a8f469ff61dd1e4e
   md5: 41d531c90be8c82bf79635ff3d409476
   depends:
@@ -2887,7 +2887,7 @@ packages:
   license_family: BSD
   size: 32295
   timestamp: 1699371262818
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.2.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-68.2.2-py311h06a4308_0.tar.bz2
   sha256: 6b87a3d61effa58d79a2da505767a14b407a20ede434d23959351af267e7a2e8
   md5: 86f5c1e109c9b35531a693b9c6f025b9
   depends:
@@ -2896,7 +2896,7 @@ packages:
   license_family: MIT
   size: 1450811
   timestamp: 1702327568944
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.1.10-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/snappy-1.1.10-h6a678d5_1.tar.bz2
   sha256: 15045902c5957ae0c8196ad7f1cecdadc7e6f5545f24f143339f488f063775f0
   md5: 0b92bda0f6031b4f8fe9b4f1c0e55c06
   depends:
@@ -2906,7 +2906,7 @@ packages:
   license_family: BSD
   size: 48768
   timestamp: 1702909413687
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
   sha256: 1a84b00944bc5588e14a097460175f97df49acb4f1ff2498ffd9a1893068ed81
   md5: a456513471b2ecbed60430c21dd1ccc7
   depends:
@@ -2915,7 +2915,7 @@ packages:
   license_family: Other
   size: 17880
   timestamp: 1705431390054
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
   sha256: adcafd297d60af64107c113bb7b8b92160d0268a44ef9a3b79e56a88a0358ea7
   md5: 28ed704ed26b06d32662e3a6a87e59b0
   depends:
@@ -2924,7 +2924,7 @@ packages:
   license_family: MIT
   size: 88799
   timestamp: 1696347581401
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/spatialpandas-0.4.10-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/spatialpandas-0.4.10-py311h06a4308_0.tar.bz2
   sha256: 6088de9e451b3792c1697b8d70d12084f210749788e3469024942662e9bbc134
   md5: 0c9f08bcbb2835cb43d240748b61f76c
   depends:
@@ -2940,7 +2940,7 @@ packages:
   license_family: BSD
   size: 199479
   timestamp: 1705085105567
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
   sha256: 8b45ba506984fe9c061b4acde6f5243d52dda8c1eae4992f8d80c03f425214fe
   md5: 68c24a824d36a16bbb28d80d70cee8d2
   depends:
@@ -2953,7 +2953,7 @@ packages:
   license_family: Other
   size: 1640317
   timestamp: 1681394746811
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
   sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
   md5: 041a3caf09dc9ce8fc6c10925c4fe050
   depends:
@@ -2963,7 +2963,7 @@ packages:
   license_family: Apache
   size: 1888016
   timestamp: 1680167274961
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
   sha256: 856a8ab8c350c50247b79966c6cb80fb6d4de36eef49ddf75aebbbcaf854c82d
   md5: 442dde204d14d171aab9ee40e8de4de8
   depends:
@@ -2974,7 +2974,7 @@ packages:
   license_family: BSD
   size: 37456
   timestamp: 1677696176157
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
   sha256: f0a026ddc0ed041bfc60c8a1ca0b70b7a69232775b3181bfb35a39fda42d6994
   md5: 2902d5a5854865baaaf58dc59cf06b3c
   depends:
@@ -2984,7 +2984,7 @@ packages:
   license_family: BSD
   size: 49185
   timestamp: 1676823769869
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
   sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
   md5: 5b8375e2092012db69d2123dc0c68630
   depends:
@@ -2994,7 +2994,7 @@ packages:
   license_family: BSD
   size: 3485432
   timestamp: 1654088939579
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
   sha256: e58ff4a82819446f3c92e5b1aa2a784c4b06643e751fe67cf115858296dbfa50
   md5: 32ee4723173f1fad5563b8afb5f1c8f1
   depends:
@@ -3003,7 +3003,7 @@ packages:
   license_family: BSD
   size: 135634
   timestamp: 1676827536101
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
   sha256: 1bf522ade750cf0b70d61e71916ff00569e2908db1e9dedb223fda2608ed8bde
   md5: 6793c74fe94211c0bfe6766c6dd490af
   depends:
@@ -3013,7 +3013,7 @@ packages:
   license_family: Apache
   size: 893808
   timestamp: 1696937055591
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py311h92b7b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py311h92b7b1e_0.tar.bz2
   sha256: 948846e5f3f49dba2e5d33b73deb0dc6db17656ffd3d5a55d35c3dcefea248d0
   md5: a94778a1fa3ad0ce3774751f4786fe55
   depends:
@@ -3026,7 +3026,7 @@ packages:
   license_family: MOZILLA
   size: 152015
   timestamp: 1679562095911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
   sha256: 0575785f6553e61cc6138abfd5de52305fac6f85971642fa1f056a76c66a52b2
   md5: f2c25e5dfdd23f70b83776a8832893cf
   depends:
@@ -3035,7 +3035,7 @@ packages:
   license_family: BSD
   size: 270865
   timestamp: 1676823316868
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.9.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.9.0-py311h06a4308_1.tar.bz2
   sha256: e0dbca6707368472ef0adfe498c024de7c9a56d9c6ff25ffe1449e8e95da89aa
   md5: 570cf697aaefcaee710444daef8a11d1
   depends:
@@ -3045,7 +3045,7 @@ packages:
   license_family: PSF
   size: 8792
   timestamp: 1705599472930
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.9.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.9.0-py311h06a4308_1.tar.bz2
   sha256: da18ffdb0ef53142aeb5d964b8db1542c290eb328ae9fbdf96690750272bd8bc
   md5: c6d716b2a8ae08f6e4039ea74d13b79f
   depends:
@@ -3054,7 +3054,7 @@ packages:
   license_family: PSF
   size: 70729
   timestamp: 1705599465726
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
   sha256: 509b962773f0fe44a93a7f6196b254670a030eac8ea7f90727312e3ccd9294b2
   md5: 6c402d5bf4e01c8c3895c9ef41707b6e
   depends:
@@ -3063,7 +3063,7 @@ packages:
   license_family: MIT
   size: 11371
   timestamp: 1676828901104
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.1.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-2.1.0-py311h06a4308_1.tar.bz2
   sha256: a0b300e422e89ca84cd1ece98b796af3133c56279871fbf0198871c9edd3585e
   md5: 5cdea1fde6548c3a82add475b39e60c2
   depends:
@@ -3078,7 +3078,7 @@ packages:
   license_family: MIT
   size: 183475
   timestamp: 1707770592436
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
   sha256: a8d11b0f08217607b99ba560edf66423ca1e36f4ffbb6e2377e61670e2b5f36b
   md5: 431e82b081b08aef0259df0437e04c75
   depends:
@@ -3087,7 +3087,7 @@ packages:
   license_family: MIT
   size: 97535
   timestamp: 1706894675990
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
   sha256: c3a5e0b855dc2de6c162708dfcf170a23eb9e7525d4252d8dce553369af4a330
   md5: a4c77e204b7787f820955166a1283168
   depends:
@@ -3096,7 +3096,7 @@ packages:
   license_family: BSD
   size: 25890
   timestamp: 1676823132898
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py311h06a4308_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py311h06a4308_4.tar.bz2
   sha256: 7b505fdb5d801adfb3032e2541bf9bf17ed2238764b7a53cb845e33e7f835faf
   md5: 07dc61e2e59fe57a9bfe8efcbb23ffe6
   depends:
@@ -3106,7 +3106,7 @@ packages:
   license_family: BSD
   size: 90518
   timestamp: 1676824901641
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py311h06a4308_0.tar.bz2
   sha256: 0384032ae4756c7ebcb0e52b9dbc21f4ef8a5d19fcc75909380ffe68bbecb46f
   md5: 9a75092954c0c7c5cc61b9a6ff27cbc8
   depends:
@@ -3115,7 +3115,7 @@ packages:
   license_family: MIT
   size: 134611
   timestamp: 1695742011767
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
   sha256: 85248e503721da67797546cb8a22e303c1739100834b219c5621f216e3794e8d
   md5: 2570956643f22d0f809b2467e02d3984
   depends:
@@ -3127,7 +3127,7 @@ packages:
   license_family: Apache
   size: 2465865
   timestamp: 1689041600364
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
   sha256: d18cdca154bf668826f869117ea996c4f9e8ef7d27b7c528332a7d17e5a8602c
   md5: 9f7353d72046b16dd6ef6b5689ac9bfd
   depends:
@@ -3136,7 +3136,7 @@ packages:
   license_family: BSD
   size: 54731
   timestamp: 1676828934954
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_0.tar.bz2
   sha256: 27f1a89843c5fb9306168df51c7b8114423ea5b8161334e01bb23feec56eb0cc
   md5: 456c2ad05120ad4756f690c1144aa999
   depends:
@@ -3145,7 +3145,7 @@ packages:
   license_family: GPL2
   size: 777889
   timestamp: 1709046225704
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -3153,7 +3153,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
   sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
   md5: 943f1247a22b6b64171363bcee1eec27
   depends:
@@ -3164,7 +3164,7 @@ packages:
   license_family: Other
   size: 371663
   timestamp: 1705602144682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
   sha256: 7aa781d0850f97622755ed44772d2b215b253a8e211aede5f3f53e1b95b4143a
   md5: b1d8823f50228d4efb7b7a6e267ed776
   depends:
@@ -3173,7 +3173,7 @@ packages:
   license_family: MIT
   size: 24333
   timestamp: 1704207043644
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
   sha256: 2dc9150a95704d83efd39bb9dfb44bdf8419022f4fb0fc416380a922a27c130d
   md5: 4f315d7551f4bbeb06b6fc28342a9aa5
   depends:
@@ -3182,7 +3182,7 @@ packages:
   license_family: Other
   size: 127528
   timestamp: 1666595012798
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
   sha256: aa6aa291bec6aa66e1f063cfa75a9e0fc6bd459fcb45c372aacac9006a073900
   md5: 4e99328768f538f33aecebdae9472744
   depends:
@@ -3195,7 +3195,7 @@ packages:
   license_family: BSD
   size: 1055426
   timestamp: 1681304602537
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -3208,7 +3208,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -3218,7 +3218,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -3230,7 +3230,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
   sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
   md5: 544adf2677c47c9b9c891aea720678f1
   depends:
@@ -3238,7 +3238,7 @@ packages:
   license: MIT
   size: 33999
   timestamp: 1630003259346
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -3247,7 +3247,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -3256,7 +3256,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -3265,7 +3265,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -3274,7 +3274,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
   sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
   md5: 9eff1a842dbda8d1bae9a2c008b599bc
   depends:
@@ -3285,7 +3285,7 @@ packages:
   license_family: MIT
   size: 690443
   timestamp: 1625743217109
-- conda: https://repo.anaconda.com/pkgs/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
   sha256: 6db7265c2238c6e5b4c98906498c47af341238b5d5a9baee383777181f421366
   md5: 91e3336204a0ea3951957d7d5e8f3e26
   depends:
@@ -3294,7 +3294,7 @@ packages:
   license_family: Apache
   size: 21503
   timestamp: 1624432813739
-- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
   sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
   md5: 33624a42ee387bf9918ea98b4e7b31fc
   depends:
@@ -3304,7 +3304,7 @@ packages:
   license_family: BSD
   size: 8173
   timestamp: 1601490751973
-- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
   sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
   md5: 67857cc5e9044770d2b15f9d94a4521d
   depends:
@@ -3313,7 +3313,7 @@ packages:
   license_family: Apache
   size: 12810
   timestamp: 1600445183315
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -3322,7 +3322,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -3331,7 +3331,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -3341,7 +3341,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
   sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
   md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
   depends:
@@ -3350,7 +3350,7 @@ packages:
   license_family: BSD
   size: 5106
   timestamp: 1704404390460
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -3358,7 +3358,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -3367,7 +3367,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -3376,7 +3376,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
   sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
   md5: 2eb923cc014094f4acf7f849d67d73f8
   depends:
@@ -3386,7 +3386,7 @@ packages:
   license_family: BSD
   size: 246457
   timestamp: 1626374695070
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
   sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
   md5: 02caf3f47f1d06256068053297355740
   depends:
@@ -3395,7 +3395,7 @@ packages:
   license_family: Apache
   size: 152292
   timestamp: 1690578151230
-- conda: https://repo.anaconda.com/pkgs/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
   sha256: 2b09b3a4920393833a5963dd702757152b425d2712acfc3fe0b59ceec6e315bd
   md5: f00776a58646c5ae1644fc52029a5b66
   depends:
@@ -3405,7 +3405,7 @@ packages:
   license_family: Apache
   size: 14955
   timestamp: 1629465474976
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -3414,7 +3414,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -3426,14 +3426,14 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
   sha256: dc9f709bacbaf08a0941d2622d82f91f18b355e82c55348ec29f1391215ca7e0
   md5: ece0f5837a4de2d4d5f1abf8347cd10a
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 124922
   timestamp: 1708711884650
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -3441,7 +3441,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/abseil-cpp-20230802.0-h61975a4_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/abseil-cpp-20230802.0-h61975a4_2.tar.bz2
   sha256: dc40cfc393c2acdb97ce54289d3124bdff35ffd4a6c203abb6f3f5598f49c115
   md5: 64a761d3c1af045bf01d84d3fc4302a2
   depends:
@@ -3451,7 +3451,7 @@ packages:
   license_family: Apache
   size: 1336618
   timestamp: 1698327954026
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
   sha256: 5800a2466734dd1ef372bec0dd3f0880c5072fa1e8b0668f5054f834285e991c
   md5: 18194e51d4420ac08f29f3f86581b52e
   depends:
@@ -3465,7 +3465,7 @@ packages:
   license_family: MIT
   size: 229003
   timestamp: 1706220302459
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
   sha256: ab7672364f1fa55ec5d8311d85d40e5b57cbd3517b17670557b6fb822bcf759c
   md5: 6e0159a5865cb7e96a748bd8560035ee
   depends:
@@ -3474,7 +3474,7 @@ packages:
   license_family: BSD
   size: 11579
   timestamp: 1678317458652
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
   sha256: 51556902e09436d46878ef772805d06416ca96ffaa66340b5565c0245574aaf5
   md5: 4cb1b20635cf5431d34cc96ca1e8a751
   depends:
@@ -3484,7 +3484,7 @@ packages:
   license_family: MIT
   size: 33355
   timestamp: 1678317111825
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-14.0.2-h3ade35f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/arrow-cpp-14.0.2-h3ade35f_1.tar.bz2
   sha256: f5480f3e450648a37debe91d0218007a976e4b046fafc8956a7351c2a20f83ec
   md5: 2079b1125e4344044941008a444ff201
   depends:
@@ -3513,7 +3513,7 @@ packages:
   license_family: Apache
   size: 10268727
   timestamp: 1707253751856
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/async-lru-2.0.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/async-lru-2.0.4-py311hecd8cb5_0.tar.bz2
   sha256: e6fb3357ab4e25e2e839a28def6450035a291c094ff91d4129fcdbb58f2bbe48
   md5: d1d0d5703fa8c45784265d8dccf01334
   depends:
@@ -3522,7 +3522,7 @@ packages:
   license_family: MIT
   size: 21499
   timestamp: 1699554645746
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
   sha256: 188b74f717e3ce3595da404c0e027b8ccafa9c186e88325e8f02c29d7b4c0744
   md5: 04ad90eead5812a0263b42321056ab33
   depends:
@@ -3531,7 +3531,7 @@ packages:
   license_family: MIT
   size: 153694
   timestamp: 1695717975427
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
   sha256: a153eee37b30ca5c25c5c95463a8852f1cf62a8f45f73349e68f1e3b22eec6da
   md5: 4bf760fad0e938618391f0db249d00e1
   depends:
@@ -3544,7 +3544,7 @@ packages:
   license_family: Apache
   size: 87236
   timestamp: 1706746160841
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
   sha256: 04ec5908b1dc2979ed50923af90d02da8a60434658efbc4f35fc61e7e9cafa0b
   md5: 6ba283b7f902226f232fe8a32fa83ee4
   depends:
@@ -3553,14 +3553,14 @@ packages:
   license_family: Apache
   size: 37547
   timestamp: 1706690917050
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
   sha256: 08431c5ec5f0a9e95819b6a76c9cc870d2154e46b229431fd0b3dad25bb70b04
   md5: 78b4b4225fdefef0b9b0d56b6e51e4a0
   license: Apache-2.0
   license_family: Apache
   size: 184146
   timestamp: 1706189913777
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
   sha256: 6a78705375d837a0eeeff9e914aae53a0d2cd44e9760075bdd8711a05f94ff3f
   md5: 931b0654ae05bcd1acc760dc830b89d3
   depends:
@@ -3569,7 +3569,7 @@ packages:
   license_family: Apache
   size: 17410
   timestamp: 1706690854689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
   sha256: 1d468f7c085b73cc40f813885d77a74270f94dd973b4285546d8873030fcada7
   md5: 3a61760bb61f85b3a0ffe7b14058801f
   depends:
@@ -3581,7 +3581,7 @@ packages:
   license_family: Apache
   size: 46197
   timestamp: 1706697276616
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
   sha256: b53432aadb2ffe2f1c584c6994b665f3620f29c51b200b03282065a480cf021e
   md5: 9686f32b210a009048c0877ac39fe88c
   depends:
@@ -3593,7 +3593,7 @@ packages:
   license_family: Apache
   size: 164397
   timestamp: 1706744140750
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
   sha256: 2ff9632eb2e2c7a70b8d64988e530d842fe5fa7fa529d34cda19f76fb40582e2
   md5: ffbd1ff65fe9fb52d833af5d396b006d
   depends:
@@ -3603,7 +3603,7 @@ packages:
   license_family: Apache
   size: 125589
   timestamp: 1706696187075
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
   sha256: fa57f1d2b2eb56db72e4b54348452af67a1222bd4266b3d68c7b7ff00399743b
   md5: ae9e78f6b1fef841fc0ffc7ef7c78d26
   depends:
@@ -3614,7 +3614,7 @@ packages:
   license_family: Apache
   size: 61379
   timestamp: 1706746740037
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
   sha256: 00834bd876756f1f13333c31623c2bdfa7d901b40aec161cf0343548fcd96187
   md5: 4ef080b5a91e260d51d563218396d0f6
   depends:
@@ -3628,7 +3628,7 @@ packages:
   license_family: Apache
   size: 67408
   timestamp: 1706747579372
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
   sha256: fb3198a05c96030d8498a5c4873e56ae28a5b04fb904a5c696a2192e9ee6c45b
   md5: 48efeda1471a50b9481c3943a0300e86
   depends:
@@ -3637,7 +3637,7 @@ packages:
   license_family: Apache
   size: 48055
   timestamp: 1706690833951
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
   sha256: f05fb72b1a5f25fab65ef416ff0d1966e3ff84f8a08c56bf809fb602028c66ec
   md5: 86cda3f774047ff6b40eb14aab83215d
   depends:
@@ -3646,7 +3646,7 @@ packages:
   license_family: Apache
   size: 51354
   timestamp: 1706192066535
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
   sha256: b8cb5f96e9eab47419622795fcdb42ad414481db9b84bbb50fcf8251a1314b59
   md5: 335265dfe12cb6adcacf39b411cf9d7a
   depends:
@@ -3664,7 +3664,7 @@ packages:
   license_family: Apache
   size: 210312
   timestamp: 1706827788950
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.10.55-h61975a4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-sdk-cpp-1.10.55-h61975a4_0.tar.bz2
   sha256: 40911c99dfa11ad32d451ab8cb5b24f0aecde231b5f8f4e9d8887bc4a720dc65
   md5: 1078cfa7cb12f9a0d3fb4017cc9789b9
   depends:
@@ -3678,7 +3678,7 @@ packages:
   license_family: Apache
   size: 2322692
   timestamp: 1706890560060
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/babel-2.11.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/babel-2.11.0-py311hecd8cb5_0.tar.bz2
   sha256: aed8823dbb096851f6eddc345f02c23fba42decce2c584f0fe09440002c37996
   md5: fc567742fccd3b08593b1dcca16522f7
   depends:
@@ -3688,7 +3688,7 @@ packages:
   license_family: BSD
   size: 7215195
   timestamp: 1678318116416
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
   sha256: bf3c60386619f08cf5105b4b903bbc109b3252c3b923fe055aa445908a01969c
   md5: 3f84a301921ec6400b7f1f1c4ba3260d
   depends:
@@ -3698,12 +3698,12 @@ packages:
   license_family: MIT
   size: 270017
   timestamp: 1681493109562
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
   sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
   md5: e2f3248e2a5009a02f7b8e54f83314ef
   size: 5620
   timestamp: 1528121955725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.4-py311h85bffb1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-3.3.4-py311h85bffb1_0.tar.bz2
   sha256: f15cd24d07af9f487c57041513d46bede83ece5b46571d8bbb2898f12784b270
   md5: f7d3cece4f39b37c62a1dd51d8864926
   depends:
@@ -3721,7 +3721,7 @@ packages:
   license_family: BSD
   size: 5968984
   timestamp: 1706912422498
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
   sha256: 81102f2762d8eb2f07c69fbf7ca7dad879a257a053085492d4c1b4006eb35fb8
   md5: 3c42777bc9330fe91177ea813b9ec252
   depends:
@@ -3731,7 +3731,7 @@ packages:
   license_family: OTHER
   size: 11744
   timestamp: 1696762233693
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
   sha256: 9acafafcaebd653c2372ddc864525722e1c55b884b5eba22e28e2b2d946b853c
   md5: 22375cc3c2edada31b85af56c8e6dee6
   depends:
@@ -3741,7 +3741,7 @@ packages:
   license_family: BSD
   size: 155829
   timestamp: 1707864406086
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
   sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
   md5: 31d6d04cd2388d8f19004501271b3545
   depends:
@@ -3751,7 +3751,7 @@ packages:
   license: MIT
   size: 18982
   timestamp: 1659616229395
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
   sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
   md5: caf1073dc2ca5aeb832a2877394eae12
   depends:
@@ -3760,7 +3760,7 @@ packages:
   license: MIT
   size: 18233
   timestamp: 1659616216769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_7.tar.bz2
   sha256: c2d2a7102d7bb658f36fda7addf7c760d43a1c8cdae43cf8a18b3afb6203ef1a
   md5: 8c76190ec95110ec2fa8693e8afd2f43
   depends:
@@ -3769,28 +3769,28 @@ packages:
   license: MIT
   size: 392066
   timestamp: 1678380073106
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_5.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_5.tar.bz2
   sha256: 7e2172cff3b4ea31c574f23faa57cf6fd1317c12b597f9be429d4ea13ab7fb93
   md5: 12dea79e2208f1eb08fb0fa2c83caa78
   license: bzip2-1.0.8
   license_family: BSD
   size: 187662
   timestamp: 1709103518672
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
   sha256: f913b61ba3c1651b36688415cc163a5d575475f7573b543f48a80e7a5002e4bb
   md5: f11d165eaa532ce04a35382841284298
   license: MIT
   license_family: MIT
   size: 107047
   timestamp: 1693902034820
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.12.12-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.12.12-hecd8cb5_0.tar.bz2
   sha256: 163ca64270d7851b9bb178e868b436147ef6d572f9be7c01a9cd4721ce7817ea
   md5: 7c5f25b8f4ea6c3b44506c6953ba3d7f
   license: MPL-2.0
   license_family: Other
   size: 136869
   timestamp: 1702903808021
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
   sha256: 20b1fc398e925e6c8cea6a06d3bb614e2c0de886e3f14f85b0ba26e57ff40b7e
   md5: ac95cfe373c7fef7820e93189041b0cc
   depends:
@@ -3799,7 +3799,7 @@ packages:
   license_family: Other
   size: 166856
   timestamp: 1707229213510
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.16.0-py311h6c40b1e_0.tar.bz2
   sha256: 13a3c5586dc1dde131ad47d9a204311c1203e9264b6eb3e2a7b4afd1aef264f4
   md5: 6c7425a58845106e2490bbd355759525
   depends:
@@ -3810,7 +3810,7 @@ packages:
   license_family: MIT
   size: 291181
   timestamp: 1700254523543
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
   sha256: aceaa74365b0d8e69c817639393df3a713a802f40645ac0bd2f39adc871acf54
   md5: 52191c9d4f4fcaeea39574819ab2f14f
   depends:
@@ -3819,7 +3819,7 @@ packages:
   license_family: BSD
   size: 204365
   timestamp: 1698129979494
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
   sha256: 53099bea1cdfeac00bf4bf48e7c3321424af31b9726a7f67033ed06e5d924f04
   md5: 0302e97edbd24e02df7609a6072dc569
   depends:
@@ -3828,7 +3828,7 @@ packages:
   license_family: BSD
   size: 50495
   timestamp: 1683040190091
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py311hecd8cb5_0.tar.bz2
   sha256: 684e2fa3140eb2f2935c19215b7aa4b0a5cc004c35a3b6e53a5604645f804c69
   md5: 9c13d4db519875cab33a32edc7e184a2
   depends:
@@ -3838,7 +3838,7 @@ packages:
   license_family: CC
   size: 1993446
   timestamp: 1678380167657
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py311hecd8cb5_0.tar.bz2
   sha256: c524feeeba84eb0aa8c9ab59982bb5bb4cabe3525eb6ceebea33124d3e67f9d9
   md5: a38d2386a4b96dc9613a00e0c82c82e5
   depends:
@@ -3848,7 +3848,7 @@ packages:
   license_family: BSD
   size: 15010
   timestamp: 1678317798586
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
   sha256: bebfc5aa6be12e61a134b580b07b67f7d8c045d6b113fca5b21fa1e83a2f03ce
   md5: 239df72a3921c951059fa8afc09643f6
   depends:
@@ -3859,7 +3859,7 @@ packages:
   license_family: BSD
   size: 287736
   timestamp: 1700583644534
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.11.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/dask-core-2023.11.0-py311hecd8cb5_0.tar.bz2
   sha256: 45a9f823c8e031b1bc78639206ff4e235ce7de67da9b991724316d00075393b0
   md5: 9d10bc7c171e384a536f9f121d964fe7
   depends:
@@ -3876,7 +3876,7 @@ packages:
   license_family: BSD
   size: 3027866
   timestamp: 1701396257640
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.16.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/datashader-0.16.0-py311hecd8cb5_0.tar.bz2
   sha256: 973b7d6f902d0021116a94004a4abc43b623a516033cd650360db52b7a5900da
   md5: 3d602a55412745fd7dc1f5fcfdc2fca6
   depends:
@@ -3898,7 +3898,7 @@ packages:
   license_family: BSD
   size: 18008805
   timestamp: 1699543215294
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
   sha256: e0e30590a78d99d51445ac4f668aefe1bf20025a35bdbac00f04647b95c9f152
   md5: bd0db635eefeea82a0c567b39c9a0e3d
   depends:
@@ -3908,7 +3908,7 @@ packages:
   license_family: MIT
   size: 2485698
   timestamp: 1690905283575
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -3918,7 +3918,7 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fsspec-2023.10.0-py311hecd8cb5_0.tar.bz2
   sha256: cc000c524197eaa2eecce2a45492566926dab255ae74cb5672aa41036d4f5b0b
   md5: bbb399dd044b1b338fc05c6769f1f1ab
   depends:
@@ -3927,7 +3927,7 @@ packages:
   license_family: BSD
   size: 353105
   timestamp: 1701286652549
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
   sha256: 3c7aa54548409f9343e891820ea43c195b5e4e4dce6b761bc3ae9f6c8be0fc86
   md5: ed9629d6dc1612ec425eb8d27478b0f6
   depends:
@@ -3936,7 +3936,7 @@ packages:
   license_family: BSD
   size: 140316
   timestamp: 1706888243476
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
   sha256: aed47f9ca4dd140b9c8a183e53d4b89eba84a20041d2038983cdfea8096104ef
   md5: c0d981d7d43eaad55950ff5e57206e70
   depends:
@@ -3946,7 +3946,7 @@ packages:
   license_family: BSD
   size: 97828
   timestamp: 1706895273858
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/grpc-cpp-1.48.2-hbe2b35a_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/grpc-cpp-1.48.2-hbe2b35a_4.tar.bz2
   sha256: 5d69cd8a1582c5062ed6753ee9ba403cee89d89f6e1628bcaba823a33a92a186
   md5: c37d24f6749355412dabe28bd64ce229
   depends:
@@ -3963,7 +3963,7 @@ packages:
   license_family: APACHE
   size: 3994389
   timestamp: 1701983483827
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/gtest-1.14.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/gtest-1.14.0-ha357a0b_0.tar.bz2
   sha256: edfb65219af41d5037b6371c6b074c8372db90b17d25f85f55e36523c01949ec
   md5: f21a88869091d6d4d88b9b5f064a3157
   depends:
@@ -3974,7 +3974,7 @@ packages:
   license_family: BSD
   size: 400287
   timestamp: 1692633607623
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
   sha256: 4120472ee1c5d31efffeb045892bece27b9a15a30d77c35212f6508221635918
   md5: 9561a225b5171285250c9071f8cab074
   depends:
@@ -3991,7 +3991,7 @@ packages:
   license_family: BSD
   size: 5368257
   timestamp: 1707836808668
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.9.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/hvplot-0.9.2-py311hecd8cb5_0.tar.bz2
   sha256: b40f02edd3bb9d3387a64b7eb737f5c0b03a41cb7914008fbf471480e4d9171f
   md5: 3314bdd2404310154e886c927615b70e
   depends:
@@ -4008,7 +4008,7 @@ packages:
   license_family: BSD
   size: 1991989
   timestamp: 1706712702324
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
   sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
   md5: f3ce6fe6eb760c236e5f7d04df5faa81
   depends:
@@ -4017,7 +4017,7 @@ packages:
   license_family: MIT
   size: 28138484
   timestamp: 1692293212596
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py311hecd8cb5_0.tar.bz2
   sha256: 26d87f25d75af1d60c81d793c93584fd86795a4c0335988957b22ad56cc549f6
   md5: 35e263cc9e4e1742438d5f55036a4209
   depends:
@@ -4026,7 +4026,7 @@ packages:
   license_family: BSD
   size: 123716
   timestamp: 1678315837792
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
   sha256: 5a17849341e4d43fc6aff44486425852c16dee6e1cbcab1ed3f2167350f55359
   md5: 445ac9df262ad2dcd86246a9ba5654b2
   depends:
@@ -4036,7 +4036,7 @@ packages:
   license_family: APACHE
   size: 51118
   timestamp: 1704813615186
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
   sha256: e0127f50d444bf4474e8df07d602c7f6dd38690e8bb3fb28817c164940ffcde1
   md5: 583fcd7060cad6a77074d00d9ef62f44
   depends:
@@ -4045,7 +4045,7 @@ packages:
   license_family: Proprietary
   size: 731417
   timestamp: 1699647668990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
   sha256: eb58fa29b1ce9aa5fc774d4c466696457695dec3b206456614b4c9cac0a94e42
   md5: 3d3291ff58dff83dcd40ec54b435f4d2
   depends:
@@ -4067,7 +4067,7 @@ packages:
   license_family: BSD
   size: 229910
   timestamp: 1705934029588
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
   sha256: 73aa7662c00c73bab2dafefefc87a1b524961d2687410af624ecbd6703e483f3
   md5: 7e71e99766107a553752ed8f22b61cf0
   depends:
@@ -4084,7 +4084,7 @@ packages:
   license_family: BSD
   size: 1611976
   timestamp: 1704833049616
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
   sha256: e08cda2bcbdec124c63e951eb248c503bb1467c2a6000010c6bdc0726e0e00b7
   md5: 22c24f43b82da8b3920a913bbf452421
   depends:
@@ -4094,7 +4094,7 @@ packages:
   license_family: MIT
   size: 1168968
   timestamp: 1679336359851
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
   sha256: 3b262312f1fc76e490c067408771da0a12c7691379cddc3c86121255cda7a41d
   md5: cbf00a1bc151243cb6a33524b62f3663
   depends:
@@ -4104,14 +4104,14 @@ packages:
   license_family: BSD
   size: 353280
   timestamp: 1706733664000
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
   sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
   md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
   license: IJG
   license_family: Other
   size: 278924
   timestamp: 1677849185191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
   sha256: 99fc6ac82c56eb2a580f96db24a5b887f8abc8c24af445d3313d5ebb48598478
   md5: 71892160908a6daedb5fb7c404079ae4
   depends:
@@ -4124,7 +4124,7 @@ packages:
   license_family: MIT
   size: 182073
   timestamp: 1699041732321
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 0ea44d0c8044e70ab0eaf4d6f5f3e4753838dee106b5cbd36561e21a65cbac77
   md5: 1d045016dca889d702f1caf3a16162fc
   depends:
@@ -4134,7 +4134,7 @@ packages:
   license_family: MIT
   size: 16528
   timestamp: 1699032525791
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter-lsp-2.2.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter-lsp-2.2.0-py311hecd8cb5_0.tar.bz2
   sha256: 9f7e13e4b84794cc99f78e0513157be30b9c9b039c413a90c03583304b7edeba
   md5: a76eeb3f746de2b0282bbf9872ac1e8d
   depends:
@@ -4144,7 +4144,7 @@ packages:
   license_family: BSD
   size: 101678
   timestamp: 1699978325870
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-8.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-8.6.0-py311hecd8cb5_0.tar.bz2
   sha256: 7e100bfb19e640dd312cdb921155f67c52675cf128d1aef2f3e975d30f3171a8
   md5: 08bbf3e56f89bc800fda1eeb998a0d1d
   depends:
@@ -4158,7 +4158,7 @@ packages:
   license_family: BSD
   size: 222285
   timestamp: 1699456395712
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
   sha256: 8601c674f4779900f6a949e47b814be68b722b0b3d394433bec9d197924ebd69
   md5: b8423f8caff3041a251fc3681f43496a
   depends:
@@ -4169,7 +4169,7 @@ packages:
   license_family: BSD
   size: 94990
   timestamp: 1698937583196
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
   sha256: 6a430c812ce0415a04d9cfe6c66d9012eced2d91c04960c88bc8ec1e9f1b5d6d
   md5: 30b3d5d6a8cf5d1604e5f5fb177917b5
   depends:
@@ -4185,7 +4185,7 @@ packages:
   license_family: BSD
   size: 42513
   timestamp: 1699282637015
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
   sha256: c2d206db117f7161e77236ebd6b0051fc73e1731c242d1e08597d736a0376c92
   md5: bdb61de2e20e02c93423d9de091c74ad
   depends:
@@ -4212,7 +4212,7 @@ packages:
   license_family: BSD
   size: 601837
   timestamp: 1699466514455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
   sha256: fd7964657f0a8fe8b167ba860b1f960e8b7b45309eb6c7c850d50ec283fe03b5
   md5: 2967bb345bc75f53182e263ff4743ca6
   depends:
@@ -4222,7 +4222,7 @@ packages:
   license_family: BSD
   size: 28223
   timestamp: 1686870845224
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab-4.0.11-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyterlab-4.0.11-py311hecd8cb5_0.tar.bz2
   sha256: ad199926171ef67c2e96e7c603c7dc6c96e25a23deb9979f1c910616df8e8b48
   md5: d749db644752070354a015015fd1a102
   depends:
@@ -4244,7 +4244,7 @@ packages:
   license_family: BSD
   size: 6618991
   timestamp: 1706803097395
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_server-2.25.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyterlab_server-2.25.1-py311hecd8cb5_0.tar.bz2
   sha256: 557bd1a8ff0502191adb3ff3af74b54ee2ec4800d281492bd8e588ddcf095bfb
   md5: 14c8a1959a83eff470adc09cc65bdb57
   depends:
@@ -4260,7 +4260,7 @@ packages:
   license_family: BSD
   size: 107281
   timestamp: 1699555527525
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
   sha256: a12382b50416803f559a03fb384ba492c1dafa351e1191a3f8dc361bee6c4f37
   md5: f2ae846b663bbb642f4b1e90eaad38a3
   depends:
@@ -4270,7 +4270,7 @@ packages:
   license_family: BSD
   size: 64817
   timestamp: 1678322501509
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
   sha256: a3a24cd84c291f7c9e28842ccfc2107d149f0aa8e676b85d9104eda77622e603
   md5: 99ba4367783596d1bb0c7766ea6706ea
   depends:
@@ -4281,7 +4281,7 @@ packages:
   license_family: MIT
   size: 1290758
   timestamp: 1686931137388
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -4291,7 +4291,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -4300,7 +4300,7 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
   sha256: 127dbf93874f1bb3493b312fecb5ffedb8f2a41d2470e2cbeb889eb58d89ebf7
   md5: 07502b61e43a2039e4312b40d53c1db1
   depends:
@@ -4315,13 +4315,13 @@ packages:
   license_family: OTHER
   size: 22584954
   timestamp: 1696762195023
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
   sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
   md5: 7dba7aa5b971febb55281659843586ba
   license: MIT
   size: 65470
   timestamp: 1659616172703
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
   sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
   md5: f78a158983f0bbaba56f34b976bc6dae
   depends:
@@ -4329,7 +4329,7 @@ packages:
   license: MIT
   size: 34189
   timestamp: 1659616189313
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
   sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
   md5: 36a1d885725d3ab4d1fadc5a29f978d2
   depends:
@@ -4337,7 +4337,7 @@ packages:
   license: MIT
   size: 327737
   timestamp: 1659616202869
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.5.0-hf20ceda_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcurl-8.5.0-hf20ceda_0.tar.bz2
   sha256: b34c59c148f100cfabc8a55470cc0d46f4ba2d1f90dedf516b151ca1374d2e54
   md5: 14f3b4d1790efbf8e35a9a9259cb6e8a
   depends:
@@ -4352,21 +4352,21 @@ packages:
   license_family: MIT
   size: 373198
   timestamp: 1704383716512
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
   sha256: e84e6cbacb12de6fe86955449502d3956696ae583060d0d4911ea6f503cfb9ad
   md5: 1d200c536be4172db41c49e81a3e6350
   depends:
@@ -4375,14 +4375,14 @@ packages:
   license_family: BSD
   size: 169586
   timestamp: 1703006265367
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
   sha256: 4786264321edbff780633a5b752995eb3193ca4bce11b0fda179577f6cf1102c
   md5: 849fdd014c201a9d2c2aa7c7db38a778
   license: BSD-2-Clause
   license_family: BSD
   size: 103993
   timestamp: 1632891571494
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
   sha256: a60941a0365ee3e8b9ff721f75b0608c234b5652f53337a918b787839de4bb53
   md5: 4d61f019594ebccfb3f4fb87ee778416
   depends:
@@ -4392,14 +4392,14 @@ packages:
   license_family: BSD
   size: 414942
   timestamp: 1685052318462
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
   sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
   md5: 817848d0e2b2808acdc9b3fbbf581726
   license: MIT
   license_family: MIT
   size: 133887
   timestamp: 1683716590737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
   sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
   md5: e458587c87e3f2d20192f4e0738f2c63
   depends:
@@ -4408,7 +4408,7 @@ packages:
   license_family: GPL
   size: 149419
   timestamp: 1665498987619
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
   sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
   md5: 1058b661ec829b2ee3716ee2a5520641
   depends:
@@ -4419,14 +4419,14 @@ packages:
   license_family: GPL
   size: 1917987
   timestamp: 1665498925405
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
   sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
   md5: c90372428e1e4eed4fdcd790979d06b4
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1409377
   timestamp: 1650983531933
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
   sha256: 8176dd9a68815301a24ed51e72f3506f5f77c67a112efa0dd14971f2f3b3c8c1
   md5: b5e470c224000a6bda6f655c155b53e7
   depends:
@@ -4438,7 +4438,7 @@ packages:
   license_family: Apache
   size: 27861431
   timestamp: 1683292881730
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
   sha256: 7bfcf69c31a4eb15dfab661c93463ce8dfb7b3de4356945fa5c1ca50a5ae0cb0
   md5: 4934bb34818fa3d99b32b9cb59fed205
   depends:
@@ -4453,7 +4453,7 @@ packages:
   license_family: MIT
   size: 784918
   timestamp: 1697018436251
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -4462,7 +4462,7 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
   sha256: 1884de5207f5a1210217d7132348b4944ec4b09a91085b7b47a19dfdd9b6dbba
   md5: aa960ea0133deec4637a8d05700cc3c4
   depends:
@@ -4472,13 +4472,13 @@ packages:
   license_family: BSD
   size: 2412437
   timestamp: 1675278748544
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-h04015c4_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libssh2-1.10.0-h04015c4_2.tar.bz2
   sha256: ea67e176a2142813dc19481cd83fd7c17fda32a96cbdd72c78e29b59030eb5fa
   md5: 13a0cba33faf8074613ca460a6ddae19
   depends:
@@ -4487,7 +4487,7 @@ packages:
   license_family: BSD
   size: 338575
   timestamp: 1686931283039
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
   sha256: 21ba71cdc65b56c6daefeeab55959e5a7edadfd697cfa8b2ed5c1b3e2a98586b
   md5: cbbd369ee87aba597c942727bada4eee
   depends:
@@ -4500,7 +4500,7 @@ packages:
   license_family: Apache
   size: 364326
   timestamp: 1687975317748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -4517,7 +4517,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
   sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
   md5: 46a65d1fc24013217e06aaf6d65ffcad
   constrains:
@@ -4526,7 +4526,7 @@ packages:
   license_family: BSD
   size: 425478
   timestamp: 1694776947990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
   sha256: d28c465ec6d5f8d4962c597b249b58998300c8b4e3c937c578c3d15294ea863d
   md5: dcaed6ddd0723c7cce6bfad917be98b2
   depends:
@@ -4536,7 +4536,7 @@ packages:
   license_family: MIT
   size: 41176
   timestamp: 1678413498410
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
   sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
   md5: 5c740b4a18a558de0ccfe601703c423c
   constrains:
@@ -4545,7 +4545,7 @@ packages:
   license_family: Apache
   size: 338738
   timestamp: 1662635677689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
   sha256: 53808184421c81e661f9927ff564a0d0ecdf3b816c8aba8e2368434e055529d4
   md5: bee10bfbe90767fcb8f8f6ab3a05d85a
   depends:
@@ -4556,7 +4556,7 @@ packages:
   license_family: BSD
   size: 407784
   timestamp: 1706911015242
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
   sha256: 716a654df2e55052193150015bd5c9856b847893fc5a229fa8669725b1c56ff2
   md5: 687ba6c11de38ad7cc597f7188b491e7
   depends:
@@ -4565,7 +4565,7 @@ packages:
   license_family: BSD
   size: 13357
   timestamp: 1678322560230
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
   sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
   md5: d5f58d056b4bfc67aec30c77035ba889
   depends:
@@ -4574,7 +4574,7 @@ packages:
   license_family: BSD
   size: 182491
   timestamp: 1670944720979
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
   sha256: 6fb2953e169ee1ae38f24d29752051501992f19b96b5ebcea9af75737bdbcb42
   md5: 7f410cdae838c5030108d1b98a8c78f6
   depends:
@@ -4583,7 +4583,7 @@ packages:
   license_family: BSD
   size: 162478
   timestamp: 1678377892595
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
   sha256: cd97e09a12ffb49b2a30a782fa8c7933b28f5ffdbfc5c73a9ebaa95fc9447370
   md5: d1fb6ebc1e5728aa6377cfc71da08942
   depends:
@@ -4593,7 +4593,7 @@ packages:
   license_family: MIT
   size: 135859
   timestamp: 1684280005320
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
   sha256: 30c3b189462a9d0f4794d229adadf34b5f5a5f56f95c30d5afc17ef524579290
   md5: d4e9421243129d1d57c472dab045f3dc
   depends:
@@ -4604,7 +4604,7 @@ packages:
   license_family: BSD
   size: 26639
   timestamp: 1704206159955
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py311h41a4f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py311h41a4f6b_0.tar.bz2
   sha256: 9587aa978de993d5090d7dc9e17269202b995e65f8aa57e53386d8c246ef6d08
   md5: ce68e30c505d14cf8dceaf49fbea83ae
   depends:
@@ -4626,7 +4626,7 @@ packages:
   license_family: PSF
   size: 9157187
   timestamp: 1698692447834
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
   sha256: 07e7fd5bd64e55328b4b99d92e2e2600d791f1095bf905daab4cfc59f0f0a45b
   md5: cf53321779f4ca7e986c1468719b93f1
   depends:
@@ -4636,7 +4636,7 @@ packages:
   license_family: BSD
   size: 19500
   timestamp: 1678317565001
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
   sha256: 0770e02be1ea1216af493cfc03d5b8a702e14606fa93b0692bcdab1fed1b898c
   md5: ca6f06ceaf66a32bbf5dfdb6e373a5cf
   depends:
@@ -4646,7 +4646,7 @@ packages:
   license_family: MIT
   size: 67892
   timestamp: 1678417734353
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
   sha256: fbe95ed0501bb0f137048476fe41bc718dd659e8ecb066bc67ac17d6a50f4318
   md5: ec162bde8d1c8a107b257df218b17035
   depends:
@@ -4655,7 +4655,7 @@ packages:
   license_family: MIT
   size: 23030
   timestamp: 1678381838497
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
   sha256: c20dd678655e582129a858a1c5162bdc254082d3a3c035b0f72629d9276e5b75
   md5: 800a0738c728796e02d0386ce7d457aa
   depends:
@@ -4666,7 +4666,7 @@ packages:
   license_family: BSD
   size: 104585
   timestamp: 1678317269407
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
   sha256: c825bc3070f73318ffff88a7a0b7fc6d1858b058ced735efd1789053f1583918
   md5: dea5f96459c9a6df6b026ca57d387936
   depends:
@@ -4679,7 +4679,7 @@ packages:
   license_family: Proprietary
   size: 224299920
   timestamp: 1699647835748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
   sha256: a76c134ec258612ff7d55cb2a19b9e3461cbbd375a744bd29390af9cfcd283b2
   md5: 1c736f58992009f53f014aef163bae31
   depends:
@@ -4689,7 +4689,7 @@ packages:
   license_family: BSD
   size: 48442
   timestamp: 1682969160267
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
   sha256: bcfb0d1e075d043bcf05fa1a7ce3c142bf222d29693366af49a5a346c770812f
   md5: 59e4820b34049cbc6619a8ac97290abc
   depends:
@@ -4702,7 +4702,7 @@ packages:
   license_family: BSD
   size: 222137
   timestamp: 1695058350477
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
   sha256: 114e408c40b332393cf2792393e4d1ede3465abcb3d345fe647ee519565346c8
   md5: 86b13271578e1fa5e664edcf6fcb3ce4
   depends:
@@ -4716,7 +4716,7 @@ packages:
   license_family: BSD
   size: 296860
   timestamp: 1695059990370
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
   sha256: 638450a7ccb5f438ac65aa1c8d871fb5bb664e7261ec7e663d0302485c219a67
   md5: 574875bbeabff85b5d9cfdb62066aece
   depends:
@@ -4726,7 +4726,7 @@ packages:
   license_family: BSD
   size: 29473
   timestamp: 1678392919304
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
   sha256: e08cb3ee6df01f4c1e1ac8bc4ed1a06e549ffcc8774fe2e2842c644bb8f74a86
   md5: 6ba0ae0fb14cbea1e3197707701dc180
   depends:
@@ -4739,7 +4739,7 @@ packages:
   license_family: BSD
   size: 123077
   timestamp: 1698934356774
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 2f946b5042eaac97206b5217fb203f3604ab3a60aecd99bdfc684925e3136c18
   md5: b24026076c381ff2009e7acb9e0a6e87
   depends:
@@ -4766,7 +4766,7 @@ packages:
   license_family: BSD
   size: 534650
   timestamp: 1699022791300
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
   sha256: ba368605a0af6f1dcbdcb6fddab9ce63224a85dd11bfb2b1acace1dc17899411
   md5: 91f3ea3fe44d619ee95a6ed3773a0814
   depends:
@@ -4779,14 +4779,14 @@ packages:
   license_family: BSD
   size: 170926
   timestamp: 1694616830121
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
   sha256: 42d803e1d8b54748db5d989ecd503826f564132df7cddc20f520460f55e523a1
   md5: cd3fa71626ebc098da4625fc6be79752
   depends:
@@ -4795,7 +4795,7 @@ packages:
   license_family: BSD
   size: 16952
   timestamp: 1708532805951
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-7.0.8-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-7.0.8-py311hecd8cb5_0.tar.bz2
   sha256: 08457eb26f6e84a25bbf413be70cd91274819e526f90ecdc859ee84af0b3491f
   md5: a424f09e1db7fc2c399ce807e01c3713
   depends:
@@ -4809,7 +4809,7 @@ packages:
   license_family: BSD
   size: 3655911
   timestamp: 1708029925977
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
   sha256: ed5608feb37a083d47b04203195260e801b64b5380f292cf18bb61e7ad827a2a
   md5: daa9c1c233673b727528548454aea664
   depends:
@@ -4819,7 +4819,7 @@ packages:
   license_family: BSD
   size: 27607
   timestamp: 1699456006797
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.59.0-py311hdb55bb0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numba-0.59.0-py311hdb55bb0_0.tar.bz2
   sha256: 69970b4fc56036ba54b11e2112d710a1572797f934f01b6e748f887fbbc02e05
   md5: b144edd077f656bd6f3d3d822a404757
   depends:
@@ -4840,7 +4840,7 @@ packages:
   license_family: BSD
   size: 6068490
   timestamp: 1707088668480
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
   sha256: cacba45c1eebf7d86748737717883a98cf40664231460fa41391c79f98d06f45
   md5: 3dbfae0d5b90e77f9358564ad442ac9d
   depends:
@@ -4854,7 +4854,7 @@ packages:
   license_family: MIT
   size: 165572
   timestamp: 1696515553184
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
   sha256: 1466c3af380b949612c79940124e426eccd59e335c205da0c00383a69358d1c0
   md5: df6be53592d40ba7e03d6ffe349760bf
   depends:
@@ -4870,7 +4870,7 @@ packages:
   license_family: BSD
   size: 11330
   timestamp: 1708639985606
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
   sha256: ace67d704fa7eea1480eb463f2d91bfc161be2ee20263c5a9939805ae3c2a9da
   md5: ec124589478fa12fba4f35f31c3a0692
   depends:
@@ -4885,7 +4885,7 @@ packages:
   license_family: BSD
   size: 8783230
   timestamp: 1708639945646
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
   sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
   md5: 93f5d7b66976154adeda219bea02ba45
   depends:
@@ -4895,7 +4895,7 @@ packages:
   license: BSD 2-Clause
   size: 484257
   timestamp: 1630093862501
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.13-hca72f7f_0.tar.bz2
   sha256: a2436a86c232a907fb262e2fb08a3548f94270e5920414cabcc11d64f7c3a951
   md5: 978612352a91a0d147af8ef7b6f1abff
   depends:
@@ -4904,7 +4904,7 @@ packages:
   license_family: Apache
   size: 4973118
   timestamp: 1706909367755
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-1.7.4-h995b336_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/orc-1.7.4-h995b336_1.tar.bz2
   sha256: 281d5a10e7a0a25bd6ee20d1d0f03530dd90fe5b4e3490ad3f33f0367df36f7c
   md5: 062f9bba1d43123d02c60d23a29831a1
   depends:
@@ -4918,7 +4918,7 @@ packages:
   license_family: Apache
   size: 425422
   timestamp: 1676482778334
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
   sha256: 8a0809f419065e014cb8e2c8a516cadca6088fb71fd1ef3ae2287d91e3360d59
   md5: 4dc0b9bc88476fcc5246d823ff1c289a
   depends:
@@ -4927,7 +4927,7 @@ packages:
   license_family: APACHE
   size: 39645
   timestamp: 1699371213055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py311hecd8cb5_0.tar.bz2
   sha256: a3d14ada61d37cd7b72521ed4b5e1ddf636a404ed58dd86a8741c330b4fb9641
   md5: c3e67df9325059e25dc5ba737a42b85e
   depends:
@@ -4936,7 +4936,7 @@ packages:
   license_family: Apache
   size: 94687
   timestamp: 1693575215769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.4-py311hdb55bb0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-2.1.4-py311hdb55bb0_0.tar.bz2
   sha256: 21b84d1ce163e08f513cf522b72dafcae785ca18584bed8844ec2553a9c3377a
   md5: 0afbb24816dbaf0619522a3e92f8ca6f
   depends:
@@ -4983,7 +4983,7 @@ packages:
   license_family: BSD
   size: 16389779
   timestamp: 1702320012708
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.8-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-1.3.8-py311hecd8cb5_0.tar.bz2
   sha256: 5050103ac0fcd3b29a1ab8669b4cb31805af7f299b2c62bb4c50aea4d1fd5f65
   md5: 9eb4f152098b195653d1faa0bf3eb0bd
   depends:
@@ -5007,7 +5007,7 @@ packages:
   license_family: BSD
   size: 18231647
   timestamp: 1706539715358
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-2.0.2-py311hecd8cb5_0.tar.bz2
   sha256: 93a4b6935afddd0d930338ec2c51ade4d6bbe34124fbbc8a5e95ec2dddc1a351
   md5: 15335a6edc2ec59e46c87530151d153e
   depends:
@@ -5016,7 +5016,7 @@ packages:
   license_family: BSD
   size: 257173
   timestamp: 1705937867682
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
   sha256: 359b31da651ee35b9ca43974d26cd44e64f3cf412096c15dec7b720fa909a9b2
   md5: 108e24227f8fdfc4d635bb4eedfa6cef
   depends:
@@ -5030,7 +5030,7 @@ packages:
   license_family: BSD
   size: 48504
   timestamp: 1698702608965
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.2.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.2.0-py311h6c40b1e_0.tar.bz2
   sha256: b780f0b40809fb2f2fa3d17978285271bfcf90146cf2eeaa1b73fef12f5b89bf
   md5: 3f12e40a25334141a1824d39974a9397
   depends:
@@ -5046,7 +5046,7 @@ packages:
   license_family: Other
   size: 920074
   timestamp: 1707233139159
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-23.3.1-py311hecd8cb5_0.tar.bz2
   sha256: 62866ff6b1a021bde2758b97004ed1903fe34744be4ae8f2a0f7cd3113a45d72
   md5: 1b9b2e51a171bc752955f3592e596184
   depends:
@@ -5057,7 +5057,7 @@ packages:
   license_family: MIT
   size: 3454892
   timestamp: 1700667869320
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 81719c31101d6c019150cedcc7b08adb3bdb357e8b2952e428dadaabc4dc985d
   md5: 105825168e0a17fb007f60b5f314e311
   depends:
@@ -5066,7 +5066,7 @@ packages:
   license_family: MIT
   size: 38405
   timestamp: 1692205731769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
   sha256: c0982f688127129e026d2b4cdacdd5684d00796ea7bdadd7d26b1101b095d723
   md5: 0d6910c74729fede645c010110f1c89e
   depends:
@@ -5075,7 +5075,7 @@ packages:
   license_family: Apache
   size: 121796
   timestamp: 1679340253537
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
   sha256: e32843723b10ecd9badde28e1085419c0b59ed8a96c7cacce6395e39e3a874f9
   md5: 5af0280a817d2c273304cd22328124af
   depends:
@@ -5087,7 +5087,7 @@ packages:
   license_family: BSD
   size: 763044
   timestamp: 1704404460779
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
   sha256: 117a435c2473e2a20cc81eaacb2b45ea5e7fe3c946eec2915936d344913ede44
   md5: 0f459ee59fda20e2077fdc2c777edfc8
   depends:
@@ -5096,7 +5096,7 @@ packages:
   license_family: BSD
   size: 497470
   timestamp: 1679337286052
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-14.0.2-py311h2a249a5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyarrow-14.0.2-py311h2a249a5_0.tar.bz2
   sha256: 7ed49e248ab0fbfaea3a170c8f795e7de8ba372bfad16f53e60500b10d5ca648
   md5: 9917697f50ec91d18d43cd9670ec8130
   depends:
@@ -5109,7 +5109,7 @@ packages:
   license_family: Apache
   size: 5054065
   timestamp: 1707331316454
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
   sha256: 667b5cf00d31293dede2ddadcc30ab967103d585d40647f34d6d830af97ee51f
   md5: 81d3876fa502fca91ba4136a5f3fc3d3
   depends:
@@ -5121,7 +5121,7 @@ packages:
   license_family: BSD
   size: 37821
   timestamp: 1678378977816
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
   sha256: dfb403f367c57327a4d080109df88383ecff18464de287a1ce936a7274e3656b
   md5: 997b674bad89963af875b93b06807f51
   depends:
@@ -5130,7 +5130,7 @@ packages:
   license_family: BSD
   size: 2120413
   timestamp: 1684280057020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
   sha256: 9d2c0f373ac1c5db329581793dd517092cdf9a59140f2516ed8c3a1f483c0bbd
   md5: ee10503a159e819abdc586666bdf0952
   depends:
@@ -5139,7 +5139,7 @@ packages:
   license_family: MIT
   size: 207552
   timestamp: 1678322848766
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 717e038567506ca58ce1cd4a3416892d02f4ebfdd332077cc3d110cfe3d36c58
   md5: 53bbfb400668f798eef6f8c7cf938e1f
   depends:
@@ -5148,7 +5148,7 @@ packages:
   license_family: BSD
   size: 35751
   timestamp: 1678315886516
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.8-hf27a42d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.11.8-hf27a42d_0.tar.bz2
   sha256: dea2e1371f27376636d240d98eb9d2d1f383df0264b354c2d97c90b60358f9ab
   md5: ff3603a0ff4f66a66856b3f09e29fec9
   depends:
@@ -5167,7 +5167,7 @@ packages:
   license_family: PSF
   size: 16812245
   timestamp: 1708984581993
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
   sha256: 514249897265f66f6ecca0a4427eb02a43c33b3c24974db16d05db6bbe97881d
   md5: c9ea1437e5a3ba6a52ec2322505203e6
   depends:
@@ -5176,7 +5176,7 @@ packages:
   license_family: BSD
   size: 279116
   timestamp: 1679338758489
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
   sha256: 78b785b9b6ed46c86b0d3a32bdceea49f816672227fb63e726b2d46eadbdba0b
   md5: 79d783f74359141e0b06a848db33823b
   depends:
@@ -5185,7 +5185,7 @@ packages:
   license_family: BSD
   size: 18563
   timestamp: 1683823935261
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py311hecd8cb5_0.tar.bz2
   sha256: eed664215f9a8effb182ed051cb022bd0a071a76fdf360cf05466c0ce4d772ae
   md5: 897822a1e234eea0b95a9fd59341d741
   depends:
@@ -5194,7 +5194,7 @@ packages:
   license_family: MIT
   size: 273158
   timestamp: 1695131639050
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.0-py311hecd8cb5_0.tar.bz2
   sha256: 724125528ecb35777bdbaa47d9b7a9b7ae9dbd9c8448ed90179661f0574ede8f
   md5: 9e84d66d6f1ec1799c133f805d01a313
   depends:
@@ -5206,7 +5206,7 @@ packages:
   license_family: BSD
   size: 65001
   timestamp: 1701728146986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
   sha256: c3e11ed944da69c11b949bb918341a0d79ef603ee34a632d6a45fbf89ff924a1
   md5: fee7ff4d291f530b4cecb575f29807a0
   depends:
@@ -5216,7 +5216,7 @@ packages:
   license_family: MIT
   size: 197996
   timestamp: 1698096137432
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-25.1.2-py311hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-25.1.2-py311hcec6c5f_0.tar.bz2
   sha256: 9996c79c554086df5bb4e39afa822c9f71da32a461c268829a3e849c9b4f105f
   md5: de5b99be21f6203d7577f11140c13534
   depends:
@@ -5227,7 +5227,7 @@ packages:
   license_family: BSD
   size: 528098
   timestamp: 1705605165873
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
   sha256: c69f556df9a27328c56943f3b5918cbb953cfbca987e20394d823a6174781202
   md5: ab294ae71ecdfaa307a961cc71dd890d
   depends:
@@ -5235,7 +5235,7 @@ packages:
   license: BSD-3-Clause
   size: 205638
   timestamp: 1652449553607
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -5244,7 +5244,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
   sha256: d784dc26c5de8e41845350a899e5779250b71f45d39e2aece62e739e9add7308
   md5: 7b077b7f46112bb31dc066396c51d3fa
   depends:
@@ -5255,7 +5255,7 @@ packages:
   license_family: MIT
   size: 74776
   timestamp: 1699012164201
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
   sha256: 3357b6b327b3d0a2cc0f02934a60bbd6df38f4ea7bbb3f50cb8e21332c9f5786
   md5: bf5e48b646e36ef2b788be9665c0e5ae
   depends:
@@ -5271,7 +5271,7 @@ packages:
   license_family: Apache
   size: 120768
   timestamp: 1707355762747
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
   sha256: 727fb8d957e02d03b928d049ffbc712316f176a2c331391766d646621b45655a
   md5: 7e0e416c642f3ee4ddfb084a811fb4df
   depends:
@@ -5281,7 +5281,7 @@ packages:
   license_family: MIT
   size: 10236
   timestamp: 1683077214314
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
   sha256: a8a67143ccb65cfd6f50055176b6c26179a83130a45d0a12e79dd2de68d8db63
   md5: a2065790f41e3eeb6efe0ef6daa75377
   depends:
@@ -5290,7 +5290,7 @@ packages:
   license_family: MIT
   size: 10600
   timestamp: 1683059285216
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
   sha256: 6aba582338faa0c26fe336bdb10c65b8f7808a6e383bd8f80f3e6b612ca209ec
   md5: a7486349b5f7370f6902c2050a23d268
   depends:
@@ -5299,7 +5299,7 @@ packages:
   license_family: MIT
   size: 319197
   timestamp: 1698946203341
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.4-py311h224febf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/scipy-1.11.4-py311h224febf_0.tar.bz2
   sha256: 6eb508cf1ddf070b86077ee851d0098cd0832ecc5dc1bbbf98f5db4eda6f0622
   md5: 427298abca5174c12a54cbc7a883e25e
   depends:
@@ -5316,7 +5316,7 @@ packages:
   license_family: BSD
   size: 26151054
   timestamp: 1701295650624
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
   sha256: beba0555707dac1e8484d73cee9e4128ac4b10e2a0d4209357481179022e8fdc
   md5: baa8b304607b3a9ae8a3d9acb354c31c
   depends:
@@ -5325,7 +5325,7 @@ packages:
   license_family: BSD
   size: 33343
   timestamp: 1699371216044
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.2.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-68.2.2-py311hecd8cb5_0.tar.bz2
   sha256: 1fd0e6f89a7e31c6382f667c8e17c15e024e69c518e159502959ce80eeb6ad08
   md5: 6b87c7058c345f2193df22edc652d8b1
   depends:
@@ -5334,7 +5334,7 @@ packages:
   license_family: MIT
   size: 1449619
   timestamp: 1702505160918
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.1.10-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/snappy-1.1.10-hcec6c5f_1.tar.bz2
   sha256: 9e61e80cb7cc715a3d688a660249da591e20550716a245684ffca317df9a19df
   md5: 62a52eef7c69e9be38fa0313aa49b4be
   depends:
@@ -5343,7 +5343,7 @@ packages:
   license_family: BSD
   size: 42438
   timestamp: 1702909424521
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
   sha256: 0eb44a16ef74a13ef7839209899d009cd94974fbc406a417d958c7bc8d955245
   md5: 41f239a5b67b1daf819849023aa5d12f
   depends:
@@ -5352,7 +5352,7 @@ packages:
   license_family: Other
   size: 19056
   timestamp: 1705431379885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
   sha256: 14775231982e1ea150189c956927ccfb1ad01a8c9395cdeea4d5a48b9b8ce664
   md5: 729badc4bf7ba8ccc70e0f9e58075c99
   depends:
@@ -5361,7 +5361,7 @@ packages:
   license_family: MIT
   size: 89812
   timestamp: 1696347694075
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/spatialpandas-0.4.10-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/spatialpandas-0.4.10-py311hecd8cb5_0.tar.bz2
   sha256: 25fc234a8966287e369835e71b7160b865aa8b8c76efefb8b5a65e2374d25795
   md5: f01d2f259587e702a84ed20c780549ca
   depends:
@@ -5377,7 +5377,7 @@ packages:
   license_family: BSD
   size: 201132
   timestamp: 1705085097451
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
   sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
   md5: 82e4db6a498480a75d53c55bd35b6478
   depends:
@@ -5389,7 +5389,7 @@ packages:
   license_family: Other
   size: 1801397
   timestamp: 1681394807900
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -5398,7 +5398,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
   sha256: 3d5c2968f581006437df3932cd5d3c1c4afa78f0e13757b958440245d3248856
   md5: 605ea221d225ad8e79284dbcfdab0715
   depends:
@@ -5409,7 +5409,7 @@ packages:
   license_family: BSD
   size: 37699
   timestamp: 1678317755913
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
   sha256: ed059e32ce5a1c0511575f29d2fb6da12c54a37000bfa80f9e5aa9dfd9e04101
   md5: 4d2261a92d25136a68b8d01d101119f5
   depends:
@@ -5419,7 +5419,7 @@ packages:
   license_family: BSD
   size: 49145
   timestamp: 1678317386284
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
   sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
   md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
   depends:
@@ -5428,7 +5428,7 @@ packages:
   license_family: BSD
   size: 3536231
   timestamp: 1654088937695
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
   sha256: 424b8284072266eb59d055c0b7b58241bfb00009d445743ea261d4eeee73ea19
   md5: f3a47898a55087edb9d65d29c24d9b88
   depends:
@@ -5437,7 +5437,7 @@ packages:
   license_family: BSD
   size: 135757
   timestamp: 1678323030858
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
   sha256: 6ab71b48d145c69007cfb5b4a21def2cc83bba972b7cc91c7d52d0d7eeb055bf
   md5: f8970b0ad5c8b452b8722ceb4e5c17f7
   depends:
@@ -5446,7 +5446,7 @@ packages:
   license_family: Apache
   size: 895379
   timestamp: 1696937269468
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py311h85bffb1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py311h85bffb1_0.tar.bz2
   sha256: 5d060a98ba771ff867611e5f2d8504bbf40c2013c34cbf69c8aca70f0b70034d
   md5: 3c678c9776759d2fc963072e007d9887
   depends:
@@ -5459,7 +5459,7 @@ packages:
   license_family: MOZILLA
   size: 153033
   timestamp: 1679561985939
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 9e8dbede0bc54c77b974210be66503e7e8e45e0f1c71dc5c16cc9a9674d54259
   md5: b4fcab9e63bd7b3cdf458c953904807c
   depends:
@@ -5468,7 +5468,7 @@ packages:
   license_family: BSD
   size: 270874
   timestamp: 1678316116954
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.9.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.9.0-py311hecd8cb5_1.tar.bz2
   sha256: c92c53f476c8157965a9637a4fd5ae7311c724396669d55fbe6b1b16c4c678c4
   md5: 1d97af42c34da5f616ceee31e3a56d46
   depends:
@@ -5478,7 +5478,7 @@ packages:
   license_family: PSF
   size: 9879
   timestamp: 1705599378858
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.9.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.9.0-py311hecd8cb5_1.tar.bz2
   sha256: 00a423edcfd3cc351068c09cf89ecacebd44425dc589aa5e2778e9b8552b521d
   md5: 0926a658fe3590254e368b5b23a0cf3e
   depends:
@@ -5487,7 +5487,7 @@ packages:
   license_family: PSF
   size: 71954
   timestamp: 1705599373108
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
   sha256: a9960485ced319ac91afe69eaaf703c7e6b3049f1e06a4a8c2818b64155943f0
   md5: 0a9c8ea92a14330a07edabac249e32a9
   depends:
@@ -5496,7 +5496,7 @@ packages:
   license_family: MIT
   size: 11399
   timestamp: 1678394892923
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.1.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-2.1.0-py311hecd8cb5_1.tar.bz2
   sha256: 33caa82e1fec2ce6b468392257f3556e5e6ae91654c01393b36bc340fe78f9b7
   md5: 08b9cfb7943aadbfee616be6064cee7c
   depends:
@@ -5511,14 +5511,14 @@ packages:
   license_family: MIT
   size: 184811
   timestamp: 1707770784530
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
   sha256: 0f8c3eb254be9c1957e748e385e20e62509d11052990c4755012be62434c9129
   md5: 53229ba93f6e38308ae42ecfc6eaad9d
   license: MIT
   license_family: MIT
   size: 96768
   timestamp: 1706894705048
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
   sha256: 597015e8a038a111f03ffbc9a217fcda549d75230c86ce53c1f23c53d6f1a0cb
   md5: 62e98aac883bccc1c87ca0d2ce2f08e0
   depends:
@@ -5527,7 +5527,7 @@ packages:
   license_family: BSD
   size: 25798
   timestamp: 1678317074170
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py311hecd8cb5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py311hecd8cb5_4.tar.bz2
   sha256: f60e6da6f08bf1bdcec59ed71fb53bbd3d2e3c487dba59523e956bfea6ba9ef6
   md5: 6acead6f585f1bae0447298d4fec340c
   depends:
@@ -5537,7 +5537,7 @@ packages:
   license_family: BSD
   size: 90538
   timestamp: 1678317776793
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py311hecd8cb5_0.tar.bz2
   sha256: 6a3b28cbb393389bae4c9797915aef07f6249246c2bf47ab9423033f56e2981a
   md5: 6b3dc26d34618284dbcc5aeef192a8c5
   depends:
@@ -5546,7 +5546,7 @@ packages:
   license_family: MIT
   size: 135700
   timestamp: 1695742005524
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
   sha256: cc6995f677d1628f42ae80ed47ff08d8d1c8ed12580a326af6e307f5febc594a
   md5: d01eb964863b95ef62061b77c9037ead
   depends:
@@ -5558,7 +5558,7 @@ packages:
   license_family: Apache
   size: 2471632
   timestamp: 1689041625741
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
   sha256: 5b6d5246955b5f9480ff7027eb002442a7ade24f5c354da54ed513042f76cedc
   md5: f32aa8a37d5e65a8dc30f9a1f46bc63d
   depends:
@@ -5567,20 +5567,20 @@ packages:
   license_family: BSD
   size: 54719
   timestamp: 1678325412288
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_0.tar.bz2
   sha256: 1534a1e1364db8c8c39d84e48a9210d86913403e5fcccbf352eb08d05ce27742
   md5: 4b947ef4c6c62f0248b01a557b05f08b
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 490044
   timestamp: 1709046329183
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
   sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
   md5: c25b6d40f834647d0bbe767f6c776031
   depends:
@@ -5590,7 +5590,7 @@ packages:
   license_family: Other
   size: 329449
   timestamp: 1705602140856
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
   sha256: 36fa7ad990aabf3607bda1f33e847888210974586363b6d69cf1ed092c192c35
   md5: c981fe545122206cdeb647f2dc9e093d
   depends:
@@ -5599,14 +5599,14 @@ packages:
   license_family: MIT
   size: 25496
   timestamp: 1704207010227
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
   sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
   md5: 8e495591e369ac161857a72011c0a296
   license: Zlib
   license_family: Other
   size: 120272
   timestamp: 1666595024203
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
   sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
   md5: f1465fbd810b3746c6de6babfd4fe28a
   depends:
@@ -5618,7 +5618,7 @@ packages:
   license_family: BSD
   size: 1023573
   timestamp: 1681304595869
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/abseil-cpp-20230802.0-h313beb8_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/abseil-cpp-20230802.0-h313beb8_2.tar.bz2
   sha256: d42422c15e115f76aec2f71e25887104359d5140af3cc6f19e358af011dc7ba9
   md5: 9996619edfa02accc1fb7912d5ecc5fb
   depends:
@@ -5628,7 +5628,7 @@ packages:
   license_family: Apache
   size: 1372151
   timestamp: 1698327835928
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
   sha256: 9ca3f0dfc2bdbc109e359ba7ab246e6ae952a14819148ad069454b52f2bda802
   md5: 51fb05873a644cac52f0d1e10cb7969a
   depends:
@@ -5642,7 +5642,7 @@ packages:
   license_family: MIT
   size: 228856
   timestamp: 1706220385566
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
   sha256: 43405cc7341ce3efb2e24013ad62c64f26a69926635adceaa5459ccbcafb3776
   md5: effa6d22f497e164cc8455f7f329c304
   depends:
@@ -5651,7 +5651,7 @@ packages:
   license_family: BSD
   size: 12510
   timestamp: 1677917870614
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
   sha256: 947efe1c50b3280e9a67cbb18636bdade53a40960fff3056850ff81ab87acbe3
   md5: 7d2d384ee32ccc12dcb0dc099e421482
   depends:
@@ -5661,7 +5661,7 @@ packages:
   license_family: MIT
   size: 35091
   timestamp: 1677915945226
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-14.0.2-hc7aafb3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/arrow-cpp-14.0.2-hc7aafb3_1.tar.bz2
   sha256: 86bab32d1e41090bc20f55a7e337565aa8085b6fbafe9bab11886ccf7d938bcd
   md5: 26f4f94a10d3fb85cfdb2ef11894d3d3
   depends:
@@ -5690,7 +5690,7 @@ packages:
   license_family: Apache
   size: 9537543
   timestamp: 1707253459914
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/async-lru-2.0.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/async-lru-2.0.4-py311hca03da5_0.tar.bz2
   sha256: 9c64b8d25d87c43834c3f98c331598f9353b063af9456da0be91252a4433e01e
   md5: 46c58da7041280e5ac6f5c9ce4b8b7a6
   depends:
@@ -5699,7 +5699,7 @@ packages:
   license_family: MIT
   size: 21474
   timestamp: 1699554635961
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
   sha256: 8259b4a0973c825ac81f581afcbe86640bd0a94b33caa996167309241877635a
   md5: 49b8ddacfd3927bcaae139eadfb72ce1
   depends:
@@ -5708,7 +5708,7 @@ packages:
   license_family: MIT
   size: 153557
   timestamp: 1695717951839
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
   sha256: f536e8b60bdc895063ca0e0155d2041993caed5f932c232f2a0d8e52798da2f1
   md5: daacfabaacebe1d1e53426ec3e385d14
   depends:
@@ -5721,7 +5721,7 @@ packages:
   license_family: Apache
   size: 86757
   timestamp: 1706746162173
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
   sha256: c356ce4cbd638a41fd3db59aa3559850e38c6b41188b8ffab32bdcbd9a55fe03
   md5: e9dc8c248dda95e92533cae6815a0a8b
   depends:
@@ -5730,14 +5730,14 @@ packages:
   license_family: Apache
   size: 39456
   timestamp: 1706690903374
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
   sha256: 117825fcff2a68136a6e5183e05542c2654d73322e70daee3c50c0ecb3aec703
   md5: b115d3f733fe8bae79b9d416754b260e
   license: Apache-2.0
   license_family: Apache
   size: 182078
   timestamp: 1706189905050
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
   sha256: 241c19574abcaf91a47fc5c36f38e58c86732be5e06f5170063406098a58639f
   md5: 3cfc3d38b8fdb25cc2e10e3e370d4106
   depends:
@@ -5746,7 +5746,7 @@ packages:
   license_family: Apache
   size: 18039
   timestamp: 1706690838125
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
   sha256: d4c60f610e57b35a2962b8cea9911358d1642e0449468fa4967706af88bf5da9
   md5: fc23856f141fe548afcfc4823881ee19
   depends:
@@ -5758,7 +5758,7 @@ packages:
   license_family: Apache
   size: 47155
   timestamp: 1706697259456
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
   sha256: c43ed35f4a64818ae39ca2c3c3652428c15da5e287f6e94254c3df4d6c759fb3
   md5: 06366f5f8762447babf69804a04b1a69
   depends:
@@ -5770,7 +5770,7 @@ packages:
   license_family: Apache
   size: 162746
   timestamp: 1706744122437
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
   sha256: 14e2ee7339c88089d1ff68f7144b3fb4f9e34fe538a9462f8de31dd6fdd1d42b
   md5: 59ab0e7ffd73966ec6a2fa83a5df5c47
   depends:
@@ -5780,7 +5780,7 @@ packages:
   license_family: Apache
   size: 127084
   timestamp: 1706696174505
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
   sha256: 601baf006d0545ec65566701d99c601cba843e8ac03d80819d4b8bed23d1e5c4
   md5: 2c98a19d57362cf1fbfec3dda3ea283b
   depends:
@@ -5791,7 +5791,7 @@ packages:
   license_family: Apache
   size: 61914
   timestamp: 1706746732665
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
   sha256: 16809db73ddc3c374ead2c2e9f2221894e2014d3e07ba62d79375cb4de4dfc9d
   md5: c03f5e3b42bc59bd92db813522cce1aa
   depends:
@@ -5805,7 +5805,7 @@ packages:
   license_family: Apache
   size: 67560
   timestamp: 1706747573116
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
   sha256: 293cf6b9dfa727d0e65b383b0e434f8fb26480abd011516171b8652fd363c98e
   md5: 2df2dd6c43a3b413b438a9ef834d78b0
   depends:
@@ -5814,7 +5814,7 @@ packages:
   license_family: Apache
   size: 48454
   timestamp: 1706690816205
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
   sha256: 773f7ff1a91af373d27f5c57833aff8912870108ddd94a5280bfdc608effe5e3
   md5: fad8b095c03774c9d4901db7eda09002
   depends:
@@ -5823,7 +5823,7 @@ packages:
   license_family: Apache
   size: 52142
   timestamp: 1706192041205
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
   sha256: 4efabe18fc312e65a5aac9b2ebe423296cfe702756891978244287ab47881927
   md5: 5786a8ac037fd0e81e25f52dbc6dc72d
   depends:
@@ -5841,7 +5841,7 @@ packages:
   license_family: Apache
   size: 210683
   timestamp: 1706827608490
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.10.55-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-sdk-cpp-1.10.55-h313beb8_0.tar.bz2
   sha256: fe92c6408ee3ebf269b216d1c9576bc15e65a38bcf684f2a7b935e57dbf2e444
   md5: 4c6b2dc15773f338a7f3299a753ab0af
   depends:
@@ -5855,7 +5855,7 @@ packages:
   license_family: Apache
   size: 2365300
   timestamp: 1706890517127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/babel-2.11.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/babel-2.11.0-py311hca03da5_0.tar.bz2
   sha256: cbca68c98946526eb9a24c01717a0c850d1736f7530196ce627bcc33d8337a18
   md5: 57ee914212070a75e071674d97480bd5
   depends:
@@ -5865,7 +5865,7 @@ packages:
   license_family: BSD
   size: 7177152
   timestamp: 1677920828584
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
   sha256: 11159a30daae77cfc1abe5e60c19261f65c005e6fbc460aecf72318514d737ad
   md5: 0c5002654a9cb21db1fdf8c1d2017df5
   depends:
@@ -5875,12 +5875,12 @@ packages:
   license_family: MIT
   size: 269772
   timestamp: 1681493072129
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.4-py311hb6e6a13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.3.4-py311hb6e6a13_0.tar.bz2
   sha256: 6b377e6f2fe4de6fca0c7c4391d08c9deda4796e27e5bd788f1e923ad1fe0a24
   md5: 415e7bf52d5561124e9844bfb1b5a5a3
   depends:
@@ -5898,7 +5898,7 @@ packages:
   license_family: BSD
   size: 5963938
   timestamp: 1706912283449
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
   sha256: f1660ecfb8687d74e81a7b00699a8bb4677cbd791d14f50ba517de98e2f187ca
   md5: 1636fc4b725da8c5e967952a55f3fd80
   depends:
@@ -5908,7 +5908,7 @@ packages:
   license_family: OTHER
   size: 11780
   timestamp: 1696762172661
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
   sha256: 688a071ba370f51b457cd32d70b7b38921ce9551203d06fa7fc2c30c4b79891d
   md5: b2353077a39ab997463768154dd58fec
   depends:
@@ -5918,7 +5918,7 @@ packages:
   license_family: BSD
   size: 134711
   timestamp: 1707864978809
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
   md5: f860193e14afc7ef3f5b990a2ac003d2
   depends:
@@ -5928,7 +5928,7 @@ packages:
   license: MIT
   size: 18936
   timestamp: 1659616204016
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
   sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
   md5: ad53130f3fd1f8d3c2fcbb7496e5585d
   depends:
@@ -5937,7 +5937,7 @@ packages:
   license: MIT
   size: 18715
   timestamp: 1659616188888
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_7.tar.bz2
   sha256: 878977be9f40a4133e5ebf46445792951807e968ac2cbb6fe213895be5b08792
   md5: 8d6e62d7b368eb8f472feafe25727cf1
   depends:
@@ -5946,28 +5946,28 @@ packages:
   license: MIT
   size: 378567
   timestamp: 1677936496352
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_5.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_5.tar.bz2
   sha256: 61999c6665d4a479663fcec455c697d7ee25f77d3379c22674c09d195d5b5415
   md5: 783ed8e4e14fd3c67c2b2990eae6d2d0
   license: bzip2-1.0.8
   license_family: BSD
   size: 158591
   timestamp: 1709108082151
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
   sha256: b0be79290b1df1cf1d07a1a9c3f3a92ae262643a6df3dc10dfbac22a82874dd4
   md5: 8fdcf1c08eee91fec7eefc22863c816a
   license: MIT
   license_family: MIT
   size: 106550
   timestamp: 1693902036526
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.12.12-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.12.12-hca03da5_0.tar.bz2
   sha256: ca38fcb75cd86450c0d44d625bd3d9bb0fd76fd38e1419ac46b9728e5dd39cee
   md5: a9be49b86aa6166ae15edcbec97c9a64
   license: MPL-2.0
   license_family: Other
   size: 136725
   timestamp: 1702903798678
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
   sha256: 512969f339a9a7b347cdb7b88f439819168089867f04732279f02759d8caf24e
   md5: 2009c2ee465fdd74dbd046de73726234
   depends:
@@ -5976,7 +5976,7 @@ packages:
   license_family: Other
   size: 166501
   timestamp: 1707229221324
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.16.0-py311h80987f9_0.tar.bz2
   sha256: 18fcf8e1b8c1e60e900de74a5b92da8b2a35994e516633e25a44e2a999d87c55
   md5: 5f71bbf181a1ef20bfd9f109d601be55
   depends:
@@ -5987,7 +5987,7 @@ packages:
   license_family: MIT
   size: 293162
   timestamp: 1700254333982
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
   sha256: df81a27f221d11af4a709f272dc8ba3fd3f6d5ab4ffd883c40567bcf04f0cfd3
   md5: e49333e3ffe1fe2e701f50a6e6dccc52
   depends:
@@ -5996,7 +5996,7 @@ packages:
   license_family: BSD
   size: 204179
   timestamp: 1698129906257
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
   sha256: 53edaca56d853083d44cef6234fe4b3d076d107e915781ce54ec135c25e09f0e
   md5: 5d1d51e53c11bcb56cf863d58e37c077
   depends:
@@ -6005,7 +6005,7 @@ packages:
   license_family: BSD
   size: 50433
   timestamp: 1683040076511
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py311hca03da5_0.tar.bz2
   sha256: 78900105b8ca2c9ce2891de6f8338dd2af8c6b0a63beab5b75ccd99ee39492fe
   md5: a756c63489618f8253181b875caa2671
   depends:
@@ -6015,7 +6015,7 @@ packages:
   license_family: CC
   size: 1980149
   timestamp: 1677936576606
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py311hca03da5_0.tar.bz2
   sha256: 1f0182e1752be7793ba6c8838ba6ef02fe14e53fc6416e2a5e269938e4835c09
   md5: b739c2dfaec3151c90fb7581380c731c
   depends:
@@ -6025,7 +6025,7 @@ packages:
   license_family: BSD
   size: 15977
   timestamp: 1677919288315
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
   sha256: 1f908c688e47d03d92ac09d9541a1f1c773ac2ca485dd1d77441b1aaefc032db
   md5: 444c330471496a39a97e87f41ed70c96
   depends:
@@ -6036,7 +6036,7 @@ packages:
   license_family: BSD
   size: 281104
   timestamp: 1700583698464
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.11.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2023.11.0-py311hca03da5_0.tar.bz2
   sha256: 66b75168a7eb1fa16c9ddd7004339dab4d4bd3557f60abfcfb9de706f27cfd42
   md5: 4c482f6b591b73d95c21f967bd69b471
   depends:
@@ -6053,7 +6053,7 @@ packages:
   license_family: BSD
   size: 3028051
   timestamp: 1701396155471
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.16.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/datashader-0.16.0-py311hca03da5_0.tar.bz2
   sha256: 2b7fcd83146c02c4d4b2e2adb2512172536118cb0f630c47a43b11c5005734bf
   md5: 6687cac2611e1868f6ad781167a671c1
   depends:
@@ -6075,7 +6075,7 @@ packages:
   license_family: BSD
   size: 17988386
   timestamp: 1699548972355
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
   sha256: b9356e3ada4872c7c950d2ac7e0f107c4786775191efdfda3a469dffb18f2714
   md5: 07ddd96675caf30ea77cafb1ea5662a4
   depends:
@@ -6085,7 +6085,7 @@ packages:
   license_family: MIT
   size: 2490144
   timestamp: 1690905181398
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -6095,7 +6095,7 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2023.10.0-py311hca03da5_0.tar.bz2
   sha256: 45b19b02debde95c5d041fdc56142d2bd9f73ae6b3886330a155e3f30e0bf184
   md5: 851b0bdc5ef05a991187ebffb031b644
   depends:
@@ -6104,7 +6104,7 @@ packages:
   license_family: BSD
   size: 354094
   timestamp: 1701286511713
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
   sha256: 25e05b93a99914a5fd1a298a2c5b25479fbd571b0db9caa7c6ad4336f060f62c
   md5: e213b68bb0274e0e54c610a041e059f5
   depends:
@@ -6113,7 +6113,7 @@ packages:
   license_family: BSD
   size: 150168
   timestamp: 1706888198288
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
   sha256: bbbcf47ef9249635b5199be1414b0b59687cc04ea9630d50ecc609dc200c095e
   md5: 5820c373d6847a68551cadb8984a8277
   depends:
@@ -6123,7 +6123,7 @@ packages:
   license_family: BSD
   size: 95638
   timestamp: 1706895270850
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpc-cpp-1.48.2-hc60591f_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/grpc-cpp-1.48.2-hc60591f_4.tar.bz2
   sha256: 4787d6730eae9c37b11f76db852a2c0a070b4dabc9abb9e423fa3ad68944ed19
   md5: 8dff6fefff4eabeeedc5a67b15d91aff
   depends:
@@ -6140,7 +6140,7 @@ packages:
   license_family: APACHE
   size: 3884646
   timestamp: 1701982736145
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gtest-1.14.0-h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/gtest-1.14.0-h48ca7d4_0.tar.bz2
   sha256: 064fc752345ef3973d3ebf2145029eaa308c17e12abe72a732255db9cdea6a40
   md5: 37ace38cf07143b39ae9b89feb204d3d
   depends:
@@ -6151,7 +6151,7 @@ packages:
   license_family: BSD
   size: 399378
   timestamp: 1692633568295
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
   sha256: 898d10bc1ededb43b7339ccf57fef404d96184de8ebaa788dba0b36a8c8a282d
   md5: a1925e4ff9f6124ca7d439430bc110fb
   depends:
@@ -6168,7 +6168,7 @@ packages:
   license_family: BSD
   size: 5399311
   timestamp: 1707836657705
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.9.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/hvplot-0.9.2-py311hca03da5_0.tar.bz2
   sha256: 38744dc9d106d062336ecb9b881f729f77639a45b629f55370b635c32115180e
   md5: 8293ebf287cf3fe7573cbf50ed50824a
   depends:
@@ -6185,7 +6185,7 @@ packages:
   license_family: BSD
   size: 1990277
   timestamp: 1706712464594
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
   sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
   md5: 69eb3b03765627b6159ed23cdde78396
   depends:
@@ -6194,7 +6194,7 @@ packages:
   license_family: MIT
   size: 28399065
   timestamp: 1692293207812
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py311hca03da5_0.tar.bz2
   sha256: 91535ae79966681095aa2d1463e0480d577ffb4874369d0e96d5fb1994829ef3
   md5: ac3a53e1831ef6e75223125737f3a69a
   depends:
@@ -6203,7 +6203,7 @@ packages:
   license_family: BSD
   size: 124616
   timestamp: 1677906184652
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
   sha256: ec139e4b87aadcacc0670ecbcc2a303d858d4ac38b9404458a4b676bce9d21d5
   md5: bfcfed281f8df0f18726ec5f843b2b26
   depends:
@@ -6213,7 +6213,7 @@ packages:
   license_family: APACHE
   size: 51053
   timestamp: 1704813595720
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
   sha256: 63670c8f31770e1746016f645ca6b42b35f92d1c37e8025793d9490fed9998c0
   md5: 9cb417b9fdf02b4e007a5b5781e5a8cc
   depends:
@@ -6235,7 +6235,7 @@ packages:
   license_family: BSD
   size: 229932
   timestamp: 1705934202146
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
   sha256: a40c76c412ec793ca26b97a9b5c496d253768438e1f7d4a0ee5f63ea79eed355
   md5: f609e4fe044318211cf0e37e289beebd
   depends:
@@ -6252,7 +6252,7 @@ packages:
   license_family: BSD
   size: 1614299
   timestamp: 1704833142734
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
   sha256: e57d10579b52a3cde45aa17e1bdd95dcb9d3346aa00eb02c51e38a42db83e18d
   md5: 05153120787fb09159b6e1ad902c6e10
   depends:
@@ -6262,7 +6262,7 @@ packages:
   license_family: MIT
   size: 1180481
   timestamp: 1678994989550
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
   sha256: 06512ef9a910fa72bf5697fe89e88c605d61f8478a9d8dd233c13f40e30f8446
   md5: cfa00c9ffd3407e29507525c020e5526
   depends:
@@ -6272,14 +6272,14 @@ packages:
   license_family: BSD
   size: 355730
   timestamp: 1706733720706
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
   sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
   md5: 055e12390b844ea6c6e956ee08a618e8
   license: IJG
   license_family: Other
   size: 273479
   timestamp: 1677849171867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
   sha256: 62025ce4a2b9244b9816c9e02487e0dda567600692b5f9ca71f425d084961c7e
   md5: d57b7063122e5bf25cdfc2a5ea7330a8
   depends:
@@ -6292,7 +6292,7 @@ packages:
   license_family: MIT
   size: 181872
   timestamp: 1699041739097
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
   sha256: 404b0847029f77bedd7902a170a046219e0dc5c0ec2be19ff45361cff25b2181
   md5: 3a02bbe8d45fdbcb2350f672be74c9f5
   depends:
@@ -6302,7 +6302,7 @@ packages:
   license_family: MIT
   size: 16524
   timestamp: 1699032463763
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter-lsp-2.2.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter-lsp-2.2.0-py311hca03da5_0.tar.bz2
   sha256: 8d8eb94257336543a0c6a2168a68195ee1258af47f4b5b58d8797ac483744a63
   md5: 191fecf4322e1348caac6337955a9e5a
   depends:
@@ -6312,7 +6312,7 @@ packages:
   license_family: BSD
   size: 101675
   timestamp: 1699978313832
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-8.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-8.6.0-py311hca03da5_0.tar.bz2
   sha256: bb525ddbadaeb7090eb5bf8aaf2d4d01765c5e2e93136a47fbb1f5b663bab567
   md5: df7c907e1d274521660c4e2030c5b6ef
   depends:
@@ -6326,7 +6326,7 @@ packages:
   license_family: BSD
   size: 225157
   timestamp: 1699455930116
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
   sha256: 8220b1bbdde5e800810f7bf183a992af1a95825a837edf975fa8c4b51c5d806f
   md5: 3a06ddad06e04d5f0211c22cd81ca75a
   depends:
@@ -6337,7 +6337,7 @@ packages:
   license_family: BSD
   size: 94950
   timestamp: 1698937436979
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
   sha256: 8a9a9f9ddbf1b7744ef04a8c862438499a41d81a4beb4a49860156c273bb7497
   md5: 051355801f09eefe850ee8145151f934
   depends:
@@ -6353,7 +6353,7 @@ packages:
   license_family: BSD
   size: 42497
   timestamp: 1699282590553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
   sha256: 65c703cc996a705d0ee350070e313b1cae865f9d6e6490ebf1164c0f3ce22d93
   md5: 305ad8bcaad3e352d61b1e594093b467
   depends:
@@ -6380,7 +6380,7 @@ packages:
   license_family: BSD
   size: 596801
   timestamp: 1699466743685
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
   sha256: 501e929d345aaa9079c965552b942b4e8bde35b87ae89faef003687a40bab3a4
   md5: 54c7b8554a405acd7c8326c41ba93e63
   depends:
@@ -6390,7 +6390,7 @@ packages:
   license_family: BSD
   size: 28237
   timestamp: 1686870817418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab-4.0.11-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab-4.0.11-py311hca03da5_0.tar.bz2
   sha256: 7c07921656d5a8f8fdc8e5edb0b18ffdfbde22a1938258cf29e78b5b66c93928
   md5: b152aceb76578939f6aced4bf328dee9
   depends:
@@ -6412,7 +6412,7 @@ packages:
   license_family: BSD
   size: 6667686
   timestamp: 1706803531409
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_server-2.25.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_server-2.25.1-py311hca03da5_0.tar.bz2
   sha256: e28c8ba9c667ba5a276d3302005b990874c6de77e4fc785f87224a2dc2ca5394
   md5: 3873f22212fb841a76c5348f5f6acf98
   depends:
@@ -6428,7 +6428,7 @@ packages:
   license_family: BSD
   size: 107252
   timestamp: 1699555538493
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
   sha256: 8c1c64d51be73aad381992a9df19d8336910bdfc40f19940231df86e177d17cc
   md5: b1f786f96684a143cf30d1f6b8aebdb3
   depends:
@@ -6438,7 +6438,7 @@ packages:
   license_family: BSD
   size: 65045
   timestamp: 1677925371836
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
   sha256: 789402b67398d3d936ac4486df01869d59b0e1ba298cbd06407d059aced871e4
   md5: a0f50a38705d0507bbf57ee49a1d9c29
   depends:
@@ -6449,7 +6449,7 @@ packages:
   license_family: MIT
   size: 1308175
   timestamp: 1686931157327
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -6459,7 +6459,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -6468,7 +6468,7 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
   sha256: c1f104bc84ee46a3d3beafb5e35236c64e6b4fd6cceabfb420e1838171b1d9c1
   md5: 4f95903a1be48bbee1f9a818ec810b89
   depends:
@@ -6483,13 +6483,13 @@ packages:
   license_family: OTHER
   size: 22243663
   timestamp: 1696762144385
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
   md5: a0f206782751dfffed0dd51302a1bf26
   license: MIT
   size: 68012
   timestamp: 1659616138077
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
   md5: 4c6667cdd061d28e9bc4e4300e4d115e
   depends:
@@ -6497,7 +6497,7 @@ packages:
   license: MIT
   size: 31173
   timestamp: 1659616155596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
   md5: 637e9430e258ddf050623ef2360184d8
   depends:
@@ -6505,7 +6505,7 @@ packages:
   license: MIT
   size: 298430
   timestamp: 1659616172209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.5.0-h3e2b118_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcurl-8.5.0-h3e2b118_0.tar.bz2
   sha256: 5f11db2220b728d4e13e1d0069aeb0215719a7bdfce88ecfc7be68778986eb54
   md5: 131c9519f6e616b3295735ac1a7f9c2e
   depends:
@@ -6520,21 +6520,21 @@ packages:
   license_family: MIT
   size: 357001
   timestamp: 1704383770648
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
   sha256: 9597df5344a718d37837966aa05091faf210260898fad5e7a64b87f17de9e90d
   md5: 678a1f87940ef6cc421a092301b8c3fe
   depends:
@@ -6543,14 +6543,14 @@ packages:
   license_family: BSD
   size: 167208
   timestamp: 1703006281321
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
   sha256: 6fc572025852b210ecddcca3ab9ff3f1d5f6bd91f1933c6e296de6bb331f6b5d
   md5: 6dd7d9c5737bbd2a27d18f15318dc3e6
   license: BSD-2-Clause
   license_family: BSD
   size: 102059
   timestamp: 1628961869728
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
   sha256: 9e7b9bb9367d8725a751cdfa0b2d270434d303ea196cfaacc605ee26be09874a
   md5: 44d1843cc2f17eb2674f35b95468f551
   depends:
@@ -6560,14 +6560,14 @@ packages:
   license_family: BSD
   size: 415467
   timestamp: 1685052299052
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
   sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
   md5: 55c615026c0869f8d3ba657f3bd38c43
   license: MIT
   license_family: MIT
   size: 120389
   timestamp: 1683716579036
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -6576,7 +6576,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -6587,14 +6587,14 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
   sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
   md5: a41117710dafe569c9cc4e83f6f29fe3
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1411339
   timestamp: 1650982753977
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
   sha256: d654027daea13ac9db36ab5fd5eff3ad398ec97c1777bf399f3ec680d2c145b9
   md5: baabb1f905054bfea3af8f5768572a34
   depends:
@@ -6606,7 +6606,7 @@ packages:
   license_family: Apache
   size: 26579907
   timestamp: 1683291669565
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
   sha256: b7cd58ddb892ed9d3983bdde8fc2530f0653a58818c87e08659f3795f04d8aff
   md5: cf519f7233951d00a30c3b969c4cd161
   depends:
@@ -6621,7 +6621,7 @@ packages:
   license_family: MIT
   size: 728977
   timestamp: 1697018415626
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -6632,7 +6632,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -6641,7 +6641,7 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
   sha256: 239ec46c06c477e722230159971bac8d9eb14793a2e75f6e3d3a7a04ed5d5ebd
   md5: 50e9c501f39bb262703c764789099f24
   depends:
@@ -6651,13 +6651,13 @@ packages:
   license_family: BSD
   size: 2338901
   timestamp: 1675278555141
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h02f6b3c_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libssh2-1.10.0-h02f6b3c_2.tar.bz2
   sha256: c16b9310ccbfef25d8cc35d53acaf40af838170f7fdb87df5178baaf096a9045
   md5: 41dce58413afe3226a5c8c66fea6db05
   depends:
@@ -6666,7 +6666,7 @@ packages:
   license_family: BSD
   size: 334603
   timestamp: 1686931243969
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
   sha256: 82a73882a31e7a4f4edcdb0c21562e123da913d03b90b19396bd6dd4fcd9a7fc
   md5: b5e5199892949d1e7e2db7bf0ee4dfe9
   depends:
@@ -6679,7 +6679,7 @@ packages:
   license_family: Apache
   size: 361781
   timestamp: 1687975246139
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -6696,7 +6696,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
   sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
   md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
   constrains:
@@ -6705,7 +6705,7 @@ packages:
   license_family: BSD
   size: 331675
   timestamp: 1694776939192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
   sha256: 41c62a460bb81a1a272aa28b219fab9c26510adac177ff1528b1980eabc6e868
   md5: 8d312c5628dc7ea833e9b4dcb73e9c45
   depends:
@@ -6715,7 +6715,7 @@ packages:
   license_family: MIT
   size: 42346
   timestamp: 1677973051421
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -6724,7 +6724,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
   sha256: 911c7577f591311bfb000121831234e7bc6332bff62fd00c2245371e67f473c0
   md5: 419681f23f179ba08e5fdf9884ea238d
   depends:
@@ -6735,7 +6735,7 @@ packages:
   license_family: BSD
   size: 410616
   timestamp: 1706910762686
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
   sha256: 5777bbef827f72975a36f3da80ab4af718dc781264f74ad7e3864755d620c0f0
   md5: 4240f1a79b812387919cc710a0469556
   depends:
@@ -6744,7 +6744,7 @@ packages:
   license_family: BSD
   size: 14318
   timestamp: 1677925438733
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
   sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
   md5: c99006da802a97c9aae30da8c16b4820
   depends:
@@ -6753,7 +6753,7 @@ packages:
   license_family: BSD
   size: 176131
   timestamp: 1670944706815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
   sha256: d024f5142416961a5e66e424d4d14aec652f9e9dd738b41a97f45674c2ffc9d5
   md5: 0e2d94b125d802f7b006cf19c71655a1
   depends:
@@ -6762,7 +6762,7 @@ packages:
   license_family: BSD
   size: 163084
   timestamp: 1677932947966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
   sha256: acfd84e29ff4dc2d85543bb973a07f22b4ba53c5d00bca84608ee7f13b2a8676
   md5: 5ca161cd51e2db358e768453b3ee485e
   depends:
@@ -6772,7 +6772,7 @@ packages:
   license_family: MIT
   size: 135871
   timestamp: 1684279980293
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
   sha256: b1bed54c7bfb7304cde9e8e6f798543d08e808e81286a5a48296fc94d621f9da
   md5: 774358285c9e496c9f5c121cc546c823
   depends:
@@ -6783,7 +6783,7 @@ packages:
   license_family: BSD
   size: 27438
   timestamp: 1704206026910
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py311h7aedaa7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py311h7aedaa7_0.tar.bz2
   sha256: 3da52ef1129befc15f1a7085ac48de8800d41c110c3283813541c6447a4f59ab
   md5: 8a032bf4688298c856578ef7717f51e9
   depends:
@@ -6804,7 +6804,7 @@ packages:
   license_family: PSF
   size: 9087688
   timestamp: 1698692324263
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
   sha256: 3276d61fc353c537bb09d4b7473d7abe12be38806f42c8cc383b62f40850a5cc
   md5: 6e9c9d47f264b77d9a8461f0899848a7
   depends:
@@ -6814,7 +6814,7 @@ packages:
   license_family: BSD
   size: 20446
   timestamp: 1677918370379
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
   sha256: 43c96d30775b61b4968422a47f9605049428120669f0742bbb9e5ba145c7d11e
   md5: a31ca0d9284860adf5463cf45a5e3145
   depends:
@@ -6824,7 +6824,7 @@ packages:
   license_family: MIT
   size: 69243
   timestamp: 1677995336989
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
   sha256: 96d8c9f42a38651b7bafe5f3cb132601db76cd1e28fa58e2eaf090e634292fff
   md5: 5ebc793a17b6aa84d13f19433545ffa5
   depends:
@@ -6833,7 +6833,7 @@ packages:
   license_family: MIT
   size: 23895
   timestamp: 1677942274932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
   sha256: db9bd659ada23f1ded443d2db00dd13b5d5c0b30f5062544b1ee2c2b88d63d29
   md5: 03c48121614cf12abfe30eced9b34717
   depends:
@@ -6844,7 +6844,7 @@ packages:
   license_family: BSD
   size: 105333
   timestamp: 1677916687032
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
   sha256: 8b05894fdcbe5cfcdee94812b043de4cd7b4fa51d3e2aad25fc7cff50c8f82ab
   md5: c970d49137dce1c77f782ee5725950c1
   depends:
@@ -6854,7 +6854,7 @@ packages:
   license_family: BSD
   size: 30745
   timestamp: 1677960816849
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
   sha256: e8eee27fb667aa10b26f3bc4b93f449b7d991ded27b9cb457effee394ce05f6f
   md5: 6a3e5cd0e1141c01ffb91285bdccfe83
   depends:
@@ -6867,7 +6867,7 @@ packages:
   license_family: BSD
   size: 123043
   timestamp: 1698934328890
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
   sha256: 40230434aa2fbb33ece13632e8d4b7cd1ad68fdb8d1b00263af4a010795d25f8
   md5: f12ce7dad3620d6d53a442fa9d36a0b0
   depends:
@@ -6894,7 +6894,7 @@ packages:
   license_family: BSD
   size: 538067
   timestamp: 1699022954841
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
   sha256: a492acec8ceadc0911a75966ffa630a8eb15b2da8c7a8d544a645ba47771a2d1
   md5: 4002b1b88b2ecfdfc769036f43b0a895
   depends:
@@ -6907,14 +6907,14 @@ packages:
   license_family: BSD
   size: 170964
   timestamp: 1694616845237
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
   sha256: 417ace1ce51e81f3f92ddc26e0e3a83c1e19c9ebb7af7104452002a5573da534
   md5: 3e11de6cef096091bb733e07802f00b0
   depends:
@@ -6923,7 +6923,7 @@ packages:
   license_family: BSD
   size: 16979
   timestamp: 1708532698253
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-7.0.8-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-7.0.8-py311hca03da5_0.tar.bz2
   sha256: 0aab440b27d9cab7a31c41d0198be602a88c41a95efb9e7b5be99a96ee2fc6cb
   md5: 959445d700f0266e95d1bdf5809d34bf
   depends:
@@ -6937,7 +6937,7 @@ packages:
   license_family: BSD
   size: 3671288
   timestamp: 1708030081801
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
   sha256: b0cc542e2a6f42ba716e7e4ccf29eddcb155ad167fcdbc72d2db9c7873eb5639
   md5: 7acf81b17d2c4ceb3cd39dc9f173855c
   depends:
@@ -6947,7 +6947,7 @@ packages:
   license_family: BSD
   size: 27539
   timestamp: 1699455954000
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.59.0-py311h7aedaa7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numba-0.59.0-py311h7aedaa7_0.tar.bz2
   sha256: 58644d56d161e63cdf56e15b8af2a5746b2f0b3566de267585c49d604708fbdb
   md5: 3563748843fceaf6a4a5c46df45e6233
   depends:
@@ -6968,7 +6968,7 @@ packages:
   license_family: BSD
   size: 6058828
   timestamp: 1707086185656
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
   sha256: 151a3eb68d1189e69764ece1d8fb3544d31a22f5bbbc3e19d846de8dece304d2
   md5: eb6609e6bdc9c82d70df3f8c4c2de95b
   depends:
@@ -6979,7 +6979,7 @@ packages:
   license_family: MIT
   size: 153313
   timestamp: 1696515415712
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
   sha256: d3bb1d4be88320a5861cd3a0f086e9709f9b64c96c032cb9039cc4f17ec66a85
   md5: 0a7b97665c06fcd34a70e34abc177280
   depends:
@@ -6992,7 +6992,7 @@ packages:
   license_family: BSD
   size: 11288
   timestamp: 1708639168951
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
   sha256: 3e70248a7069ca12ccf56252869bfdb72211fd4e4c327e6994756496df786c79
   md5: ce4846006d98638cd86a532a72f8dfe4
   depends:
@@ -7006,7 +7006,7 @@ packages:
   license_family: BSD
   size: 7536860
   timestamp: 1708639153133
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
   sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
   md5: 371358a54bbdd307603888348d1a2c6f
   depends:
@@ -7016,7 +7016,7 @@ packages:
   license: BSD 2-Clause
   size: 412248
   timestamp: 1628861367714
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.13-h1a28f6b_0.tar.bz2
   sha256: facd0cf76309dc1b1ee0c7ac6b09cf66579014e41465eddeaf65faf5f886866d
   md5: 81ee9a235e1ea8e7575c3c73495fee73
   depends:
@@ -7025,7 +7025,7 @@ packages:
   license_family: Apache
   size: 6343688
   timestamp: 1706909118317
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
   sha256: c4135710b5536fb859a6672c055bbc2cff0426e0655e75c7fdf808f7f3344ada
   md5: 483605a01fccba850b7f0cbdeff29858
   depends:
@@ -7039,7 +7039,7 @@ packages:
   license_family: Apache
   size: 421604
   timestamp: 1676482754496
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
   sha256: 77b0c0a0fb14d817390244ebd93c36d44a7867239963f211f7c0a72a3f98d382
   md5: b90336feb8a50d2eff880e89acb02f40
   depends:
@@ -7048,7 +7048,7 @@ packages:
   license_family: APACHE
   size: 39617
   timestamp: 1699371253760
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py311hca03da5_0.tar.bz2
   sha256: ce5eb462d7fb1524d353faf2096260ed65ccbbc20fcb8132813524736e402206
   md5: d086ecc9233b5cbd62ab53cc59d638dc
   depends:
@@ -7057,7 +7057,7 @@ packages:
   license_family: Apache
   size: 94576
   timestamp: 1693575249609
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.4-py311h7aedaa7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.1.4-py311h7aedaa7_0.tar.bz2
   sha256: ad73567d6bf389563175f497502ed44997c53f789278baf156cd495a198090a0
   md5: 7eb05ca2fff7a8c6db506af74ea80329
   depends:
@@ -7104,7 +7104,7 @@ packages:
   license_family: BSD
   size: 16231013
   timestamp: 1702319217107
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.8-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-1.3.8-py311hca03da5_0.tar.bz2
   sha256: 2232daa3075c0c344684268ed4aaf922894787928efa1acd51ebdd939365837a
   md5: 6c986a04b608c9b13280f84290442ed4
   depends:
@@ -7128,7 +7128,7 @@ packages:
   license_family: BSD
   size: 18187036
   timestamp: 1706539764590
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-2.0.2-py311hca03da5_0.tar.bz2
   sha256: bf72807672308638cfe45b7779f9284305cb99cd7caff9fb1c1319ad98494e2f
   md5: 6408b94b5ca53fc26b1e1997bcc34382
   depends:
@@ -7137,7 +7137,7 @@ packages:
   license_family: BSD
   size: 257144
   timestamp: 1705937843381
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
   sha256: 088245becd055af4de74e4ed13cc752ab546423f204b170ba2dd8809af30a2c7
   md5: 2eabea5ccc56ac088e0349626e59df06
   depends:
@@ -7151,7 +7151,7 @@ packages:
   license_family: BSD
   size: 48517
   timestamp: 1698702686783
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.2.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.2.0-py311h80987f9_0.tar.bz2
   sha256: 9b723b1be321340764f3e7941266445575c6bd33a120f9a99eb419c36db8f750
   md5: aba11ac677d0312fc4694fcd9b4f1b5a
   depends:
@@ -7167,7 +7167,7 @@ packages:
   license_family: Other
   size: 900885
   timestamp: 1707233080957
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3.1-py311hca03da5_0.tar.bz2
   sha256: f6298f1b93b2c4f62e11be8f5cb1c184b9774492626f3c93a004cf5d7e4e84f6
   md5: 92d6c6c6a869b6d1449ddc614f622c42
   depends:
@@ -7178,7 +7178,7 @@ packages:
   license_family: MIT
   size: 3445195
   timestamp: 1700667693168
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
   sha256: b6200816d65673aa1707c20a768c9cff87dd8dbe1335f9c1478e5931dfa08ee0
   md5: 14b1e0fa73eb33f9c83048482dcce57b
   depends:
@@ -7187,7 +7187,7 @@ packages:
   license_family: MIT
   size: 38423
   timestamp: 1692205689597
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
   sha256: ebdf211edd98d88a23778551c7a9702106edd0695d4fc48e87c21f77521c1ffe
   md5: d8c505081a468f1b99c62466e2309417
   depends:
@@ -7196,7 +7196,7 @@ packages:
   license_family: Apache
   size: 123084
   timestamp: 1678996822234
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
   sha256: 07cfba50d9e94364bde077731a824ca4f537138b35ee6b66d07aee16ac9850f1
   md5: 919bf486280a11e6acb3c2c3a82f7473
   depends:
@@ -7208,7 +7208,7 @@ packages:
   license_family: BSD
   size: 763225
   timestamp: 1704404463402
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
   sha256: 8094436b2c44e68e72569c704633802aad82e977b1e16026848218679c8becf4
   md5: 2360e46d3e598dd5e2abed781fe166c5
   depends:
@@ -7217,7 +7217,7 @@ packages:
   license_family: BSD
   size: 502115
   timestamp: 1678995719872
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-14.0.2-py311ha07b5f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyarrow-14.0.2-py311ha07b5f9_0.tar.bz2
   sha256: 4ef0edee30559d99ce74a3207b5e594420549d743b6a6942f4910909f0bf7f15
   md5: ee7f74b498c265a06b470b7f853612e0
   depends:
@@ -7230,7 +7230,7 @@ packages:
   license_family: Apache
   size: 4965174
   timestamp: 1707331530109
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
   sha256: 4f17f70658e32a9a86661184cace6be3bb7bd61f9b55b513092beddf44552679
   md5: 0aa95279688b0433badea0b660ac8146
   depends:
@@ -7242,7 +7242,7 @@ packages:
   license_family: BSD
   size: 38653
   timestamp: 1677933613643
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
   sha256: 121b5b66721760c05f1d4eee91626229d1814663d3fb5f23126ef870aa496e26
   md5: 0c588c2ca790a05d422c06e8568201ad
   depends:
@@ -7251,7 +7251,7 @@ packages:
   license_family: BSD
   size: 2124200
   timestamp: 1684280082141
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
   sha256: 44b694db8e81d61960d28d60f9e9b573f03f7827881d302da334378881db4889
   md5: 6c94ba7caa599ff533e0ab55d898be8a
   depends:
@@ -7260,7 +7260,7 @@ packages:
   license_family: MIT
   size: 208454
   timestamp: 1677910948527
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
   sha256: 0bb3d2a57b332c5cf73ea40ea13c850ae24a1f9a3a41ed9267832d9e3c767572
   md5: 45a7fcf1641980d5114999736428502d
   depends:
@@ -7269,7 +7269,7 @@ packages:
   license_family: BSD
   size: 36755
   timestamp: 1677906514270
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.8-hb885b13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.11.8-hb885b13_0.tar.bz2
   sha256: 7db8bda1ad368413284ee399322d421feb385863426f8ce3167c0eee6788b8d6
   md5: b1b70eac1af7d86cc231d9b695ff1d3e
   depends:
@@ -7288,7 +7288,7 @@ packages:
   license_family: PSF
   size: 16417657
   timestamp: 1708983786954
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
   sha256: f94b3cfea6f76ea9983e16d3c4c7e0a64f02c40cc2c3ad57189bca2e67030bd9
   md5: 0d100990ade57a02b60d1e8085db0bdf
   depends:
@@ -7297,7 +7297,7 @@ packages:
   license_family: BSD
   size: 280263
   timestamp: 1678996927464
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
   sha256: 252c86f5aef7f8dfce99a260c24cbb35a9adfea144a2acfabb224f516341544f
   md5: 745b888e19a644f48800799f82c01c21
   depends:
@@ -7306,7 +7306,7 @@ packages:
   license_family: BSD
   size: 18539
   timestamp: 1683823925189
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py311hca03da5_0.tar.bz2
   sha256: f8cc25e0bc49acf0af5cdf745f34f7d35a877ef06139e32ca5106eef7697051d
   md5: 4b486ff581b914b8276656a84479f214
   depends:
@@ -7315,7 +7315,7 @@ packages:
   license_family: MIT
   size: 267956
   timestamp: 1695131641887
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.0-py311hca03da5_0.tar.bz2
   sha256: a0c6c59c5626b13a70938bf3ab7e5884059e0100b8d9cc3d16a9f4fcf04e336d
   md5: 3e170ed828445a213e568c666aaa5c7c
   depends:
@@ -7327,7 +7327,7 @@ packages:
   license_family: BSD
   size: 64735
   timestamp: 1701728050405
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
   sha256: 4f04a43cbd612ab09cefbdc2e48ee61b51967dad59d859ce0502cc2c46c88fc5
   md5: c68bf65433b2151b51b2e699bc22c501
   depends:
@@ -7337,7 +7337,7 @@ packages:
   license_family: MIT
   size: 194632
   timestamp: 1698096151085
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-25.1.2-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-25.1.2-py311h313beb8_0.tar.bz2
   sha256: 66d6bcf8e67799c60b41ed3c14d352cc065abee1afe41fab710eac41ddb27809
   md5: 488d9d295388699484bd2d1226157163
   depends:
@@ -7348,7 +7348,7 @@ packages:
   license_family: BSD
   size: 543785
   timestamp: 1705605339487
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
   sha256: 089c6b9bebfa690f380710f219ab0fcc1acec9f2e187d4174a08222c45f58afc
   md5: 11b832c6c10a6d2b0e687a20c3037c97
   depends:
@@ -7356,7 +7356,7 @@ packages:
   license: BSD-3-Clause
   size: 194532
   timestamp: 1652449531448
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -7365,7 +7365,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
   sha256: 7a208abc002a2fc208ae25cb2cf932999a3e4980aa4c9edff315cb9ac62b12ce
   md5: bd22ebd3cff811577ea61f115ba7f4f2
   depends:
@@ -7376,7 +7376,7 @@ packages:
   license_family: MIT
   size: 74744
   timestamp: 1699012126255
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
   sha256: cc8d055a068fe5a7484284c3360d81db61656dd6118c743c740fcc47cd3da379
   md5: e5fad71ef3b99077b79052576e51bf9f
   depends:
@@ -7392,7 +7392,7 @@ packages:
   license_family: Apache
   size: 120672
   timestamp: 1707355664440
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
   sha256: 52368d9b557b8f54ef5ca4bf6cd5a3ec665171f2b2d2082cdd410bab88f4829c
   md5: ac76fb4d2eef3ecdd491cf5d3fb8620d
   depends:
@@ -7402,7 +7402,7 @@ packages:
   license_family: MIT
   size: 10204
   timestamp: 1683077239143
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
   sha256: 491d116c5f54ef340e3bce631835f7138cd1923d7b63e6ca9aa01b48110cb8f9
   md5: 9b81bd8ea808704f5433884b567f1f15
   depends:
@@ -7411,7 +7411,7 @@ packages:
   license_family: MIT
   size: 10557
   timestamp: 1683059079547
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
   sha256: b53a5f6119173d62e4e68a37ea8511c7fc87a00af72953e0048d075a799c7a7a
   md5: 76a16cf4edb9b12b2b96a2d323f060dc
   depends:
@@ -7420,7 +7420,7 @@ packages:
   license_family: MIT
   size: 342535
   timestamp: 1698945991201
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.4-py311hc76d9b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.11.4-py311hc76d9b0_0.tar.bz2
   sha256: 3550487285cafe22b3bac9eb60439600c27d6a77906efbc377949819267bdd34
   md5: b20e6556db358f62dc816548d376e078
   depends:
@@ -7436,7 +7436,7 @@ packages:
   license_family: BSD
   size: 24658627
   timestamp: 1701296201411
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
   sha256: c80d52567084b1caaed2862b77b70065ca17afaf0b020733e9d6c273b4a63e78
   md5: ddf7d88c1967f3f7a4ce1c975fd47e0d
   depends:
@@ -7445,7 +7445,7 @@ packages:
   license_family: BSD
   size: 33321
   timestamp: 1699371225235
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.2.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.2.2-py311hca03da5_0.tar.bz2
   sha256: bba54d36884cbbc17c6a9d7084829e43591b6d93b24ac95ec96da59166c97c04
   md5: 8cc3f395928902a35730a8090ba44e99
   depends:
@@ -7454,7 +7454,7 @@ packages:
   license_family: MIT
   size: 1464983
   timestamp: 1702505333484
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.1.10-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/snappy-1.1.10-h313beb8_1.tar.bz2
   sha256: f340be28c71abb0b785dd78f742e12befb08e37b77087924364e01a7b1d25bda
   md5: 4f553ef7b00e79fb67318e680da9fdaa
   depends:
@@ -7463,7 +7463,7 @@ packages:
   license_family: BSD
   size: 42517
   timestamp: 1702909400491
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
   sha256: cd71091a234874d2826fa063ec5222b3191c9f47e1b5281c352d9df3f31a06bf
   md5: 0db8e29016c6bff026c083d9923a7566
   depends:
@@ -7472,7 +7472,7 @@ packages:
   license_family: Other
   size: 19073
   timestamp: 1705431415504
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
   sha256: 3e18cdafc607c6d7623b1c8f041cbfbb50a27e298f961abdcce7e36834ac39e1
   md5: 9ee0da74c55d0b8d83edf246fd717f20
   depends:
@@ -7481,7 +7481,7 @@ packages:
   license_family: MIT
   size: 89862
   timestamp: 1696347657368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/spatialpandas-0.4.10-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/spatialpandas-0.4.10-py311hca03da5_0.tar.bz2
   sha256: 826cbb85537b6da88a90b75f26e119b3a090dc0619b78985237ec18dd0cda0c8
   md5: 4b8f39c5bb27448d160de0dd9b10cd11
   depends:
@@ -7497,7 +7497,7 @@ packages:
   license_family: BSD
   size: 201118
   timestamp: 1705085077616
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
   sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
   md5: 2302a79a045f152e183a52a81adfba62
   depends:
@@ -7509,7 +7509,7 @@ packages:
   license_family: Other
   size: 1674163
   timestamp: 1681394762218
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
   sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
   md5: ae58720a18a2ed15eae214ad7a10d1b5
   depends:
@@ -7518,7 +7518,7 @@ packages:
   license_family: Apache
   size: 140125
   timestamp: 1680167256603
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
   sha256: b5c265e9ed9a1ff2238a09b83bdc1826950faa87fd6b685debe60888de6e7a50
   md5: 5827c8a32317894ce18576e334daba47
   depends:
@@ -7529,7 +7529,7 @@ packages:
   license_family: BSD
   size: 38559
   timestamp: 1677918962258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
   sha256: cfefd86d0f4981d22b7611b3dc60359b8698bf39f2b743cb90b7005aaca88e1e
   md5: a04dbcd6095f6b8f3ad195a78d48b262
   depends:
@@ -7539,7 +7539,7 @@ packages:
   license_family: BSD
   size: 50058
   timestamp: 1677917499177
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
   sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
   md5: 667e60c8b407d73cbba40f44901f4f00
   depends:
@@ -7548,7 +7548,7 @@ packages:
   license_family: BSD
   size: 3412693
   timestamp: 1654088929697
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
   sha256: 0836468fafb1f5badbb573922e37200c6929bf2926ecf8d2259dff43811e0727
   md5: 5bc56dcb4bdb7cf623b7cea499feaddb
   depends:
@@ -7557,7 +7557,7 @@ packages:
   license_family: BSD
   size: 136409
   timestamp: 1677925889207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
   sha256: 177246487449f87567fe56c8f20011a4350a132d1556c9f87474d7b2e8c1374f
   md5: d465118217b9f27d47dceff89c2e9f95
   depends:
@@ -7566,7 +7566,7 @@ packages:
   license_family: Apache
   size: 896655
   timestamp: 1696937042980
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py311hb6e6a13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py311hb6e6a13_0.tar.bz2
   sha256: 5a1fa09dad8becc420220686970bbaa80d6cc11c0db0a50b82eea7916da8da9e
   md5: 3a32fec6b7aad634be22db2c2ca01b4d
   depends:
@@ -7579,7 +7579,7 @@ packages:
   license_family: MOZILLA
   size: 152999
   timestamp: 1679562052353
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
   sha256: 65e760119352cd85c63d365d2576c09a9ddb060e5b029a265d50bc268eed9290
   md5: 14c241871b12dc3be52e6cd681267caf
   depends:
@@ -7588,7 +7588,7 @@ packages:
   license_family: BSD
   size: 271445
   timestamp: 1677911758960
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.9.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.9.0-py311hca03da5_1.tar.bz2
   sha256: eb3608b1f32c4a791ca19a69cf611e470ec7bb722e40f27d3e5f6dbc76c69ecc
   md5: e4ada62e242b4702435995090405d693
   depends:
@@ -7598,7 +7598,7 @@ packages:
   license_family: PSF
   size: 9874
   timestamp: 1705599390176
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.9.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.9.0-py311hca03da5_1.tar.bz2
   sha256: 0899503a82d0e0a765a7e9d1a0480c3b1c389f4d6e68b633400271380172118e
   md5: 224636c70a8945f989ebf39b8cfcf52a
   depends:
@@ -7607,7 +7607,7 @@ packages:
   license_family: PSF
   size: 71941
   timestamp: 1705599383532
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
   sha256: 2ea2d0520b330d381a2ab241bdb9ae146ef815ee7c96ee52a9773fb9ae85f4fd
   md5: 66f7f8979cfb2cccffac972d70482130
   depends:
@@ -7616,7 +7616,7 @@ packages:
   license_family: MIT
   size: 12614
   timestamp: 1677963554857
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.1.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.1.0-py311hca03da5_1.tar.bz2
   sha256: ec56a4893344adc6712b9915267bb5faca7203496f8ad924cba7ebf2cec302b9
   md5: 7dd5b6728562eaa24668abd062985f4d
   depends:
@@ -7631,14 +7631,14 @@ packages:
   license_family: MIT
   size: 184702
   timestamp: 1707770626151
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
   sha256: 20ae100fd04de16356f26e7c9dab514015e57a9d54fb78767aa5ed97de7846fb
   md5: f620d98b3d0072945948310c86f0f1c5
   license: MIT
   license_family: MIT
   size: 157385
   timestamp: 1706894678643
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
   sha256: 09738b7f9075386bf062b12ddb6fb72a06450d2481f6b5ca2026c811cd849569
   md5: 9afdec076c95746ac21235f971190e40
   depends:
@@ -7647,7 +7647,7 @@ packages:
   license_family: BSD
   size: 26727
   timestamp: 1677910175964
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py311hca03da5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py311hca03da5_4.tar.bz2
   sha256: e7e149717c2a2f69f4e80a97aaeff1e929309abeaacf856020e709a9663df561
   md5: 2ea9e4e91d48d4e0697990e52d1c2b96
   depends:
@@ -7657,7 +7657,7 @@ packages:
   license_family: BSD
   size: 91423
   timestamp: 1677919120338
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py311hca03da5_0.tar.bz2
   sha256: d84b9b0d2e1b8c23f2a12c466c37df43b3a6c55bcf2ec7feead52a5ce4fc4652
   md5: 258d088b822011748130c24d4a205e0c
   depends:
@@ -7666,7 +7666,7 @@ packages:
   license_family: MIT
   size: 135718
   timestamp: 1695741999838
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
   sha256: cf030fc7020dc6d28530075468b8dc1edd843a1e393a2f81ca81c962e9af977b
   md5: cae3fc90233f3af8f433a253d035b6e6
   depends:
@@ -7678,7 +7678,7 @@ packages:
   license_family: Apache
   size: 2470844
   timestamp: 1689041497962
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
   sha256: 2cd108896df65636769e3804ecc2ca421ad9b54e64fa21922bbabe40c90c247a
   md5: b3a1e5077b28f71298d891fbfb5ff03e
   depends:
@@ -7687,20 +7687,20 @@ packages:
   license_family: BSD
   size: 55645
   timestamp: 1677927459979
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_0.tar.bz2
   sha256: 85c9b1e0bce1cd413fca9b3488682812a4e232fe0661a2679c3d88a0c10552ca
   md5: 704baf12587c18a04d0c66394b1890e8
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 475787
   timestamp: 1709048675809
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
   sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
   md5: 3d57d1adadca9388aaaa1c529b65ba65
   depends:
@@ -7710,7 +7710,7 @@ packages:
   license_family: Other
   size: 322790
   timestamp: 1705602163804
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
   sha256: cf38c69cf62d8f07b91b14bef8e0b6fc5ac220bd3a6cd2ab0378283f0f11494a
   md5: 11660f745caf5eed1d03eafadb32678b
   depends:
@@ -7719,14 +7719,14 @@ packages:
   license_family: MIT
   size: 25470
   timestamp: 1704206932876
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
   sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
   md5: 467ae28215d1aa1c5688bc0c8a184269
   license: Zlib
   license_family: Other
   size: 103525
   timestamp: 1666595022664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
   sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
   md5: 7cfbed15f1feee1422810f7830075f53
   depends:
@@ -7738,7 +7738,7 @@ packages:
   license_family: BSD
   size: 779464
   timestamp: 1681304594848
-- conda: https://repo.anaconda.com/pkgs/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
   sha256: c5a4f98a90713f799a73195cc159571c4bd373bfa43640dc0c1707608e582945
   md5: 537f198da93942d8ef7008606edae551
   depends:
@@ -7748,7 +7748,7 @@ packages:
   license_family: Apache
   size: 2363136
   timestamp: 1652426285158
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
   sha256: 6e6787755de0cf2fd776c9681a7b0fd0fb23e35e679a463cc2005b991c413910
   md5: ccad42ec9a2ad48939f089c528abc8f0
   depends:
@@ -7762,7 +7762,7 @@ packages:
   license_family: MIT
   size: 229694
   timestamp: 1706220431719
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
   sha256: f715f7c2e06149bd6d43258e41479d3171efe5e9d56050a0a5f5652ed9d05fff
   md5: 11a8ca43d69881b88f95ae681478866d
   depends:
@@ -7774,7 +7774,7 @@ packages:
   license_family: MIT
   size: 36089
   timestamp: 1676424516042
-- conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-14.0.2-ha81ea56_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/arrow-cpp-14.0.2-ha81ea56_1.tar.bz2
   sha256: 5d0903878b06d0a444fa43444390f3b662f6338750e23ee2817c784246ff7098
   md5: e0fda639825394bcb3a87b639c0d7a11
   depends:
@@ -7804,7 +7804,7 @@ packages:
   license_family: Apache
   size: 9794512
   timestamp: 1707254932864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/async-lru-2.0.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/async-lru-2.0.4-py311haa95532_0.tar.bz2
   sha256: 6acc4dc697147467d128382439a1648f2dc6c498d0a97aa9c44ef5de2962cdc6
   md5: 8baa05a5d81f5f0dd92cdd60fd509486
   depends:
@@ -7813,7 +7813,7 @@ packages:
   license_family: MIT
   size: 21308
   timestamp: 1699554782283
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
   sha256: 9adabcdd2a10f73fa5ba56adc901eeea2e379991a0d4cb9737eec7aa6b9fc5d8
   md5: fc80b572be85601706d425b21a58d497
   depends:
@@ -7822,7 +7822,7 @@ packages:
   license_family: MIT
   size: 153102
   timestamp: 1695718054194
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
   sha256: a11741c5aaa360b4772d0fb7eea606edb5266a4e2806b22f0b8b65b69b7a7273
   md5: 9a54285c5e75ab5e6bfcb3b5590f9449
   depends:
@@ -7837,7 +7837,7 @@ packages:
   license_family: Apache
   size: 93395
   timestamp: 1706746331576
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
   sha256: 32b4da68dd0edbf0c8d7a8a18ba400b26775faabaccbc2cb3e9d2ab7c65e7714
   md5: 48f0a7a7f739d8be4c9dd061be217619
   depends:
@@ -7848,7 +7848,7 @@ packages:
   license_family: Apache
   size: 45714
   timestamp: 1706691182873
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
   sha256: d2710c7f5b4bb8f94a964996387fbd6396f9881d163affeb7ffb050a39e58c1c
   md5: 1a8a2f82798a94d1b272ec2d307cc5ef
   depends:
@@ -7858,7 +7858,7 @@ packages:
   license_family: Apache
   size: 195487
   timestamp: 1706190077309
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
   sha256: 0a5ea74ebcf9bdccfad972add8ff83a47992ab28370cebc34fc4594c1c7cf03a
   md5: 2f90d407ca685c124ddb5fc4d79f4517
   depends:
@@ -7869,7 +7869,7 @@ packages:
   license_family: Apache
   size: 21804
   timestamp: 1706690937014
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
   sha256: 334d2d9c4181c9955256485f66bf4e48ae9b1dc03044aa0424bf1fda292b3151
   md5: 9ab57953af3164d3d94001eeca0e6359
   depends:
@@ -7882,7 +7882,7 @@ packages:
   license_family: Apache
   size: 52661
   timestamp: 1706697357084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
   sha256: 59155d1258b4e29c0046e5ab14b1e2cb3ccfca069982fe9dd4cd751b1ed67492
   md5: 28bd7c351db93c3b8520cc1598eddf66
   depends:
@@ -7896,7 +7896,7 @@ packages:
   license_family: Apache
   size: 177605
   timestamp: 1706744253596
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
   sha256: 3aa9b1c2c508a5dcfb482083cb986498f6df460e652cc7557d3c2d122d559ebe
   md5: b8bf7ae26d234b6738fc37b7c172b3c5
   depends:
@@ -7908,7 +7908,7 @@ packages:
   license_family: Apache
   size: 145865
   timestamp: 1706696287610
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
   sha256: 68564155186523ec8b97b892d0a6b62b3e6f75e4e2b80fac5684011e070295d6
   md5: ba2fa531a69a5a7e4966eba6d7891c8b
   depends:
@@ -7921,7 +7921,7 @@ packages:
   license_family: Apache
   size: 69542
   timestamp: 1706746839018
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
   sha256: 9c0f2f18f8b7e10e940d2438d70a2a03893421f25fd50461b8b2979f3a310a15
   md5: da0f3ce6d8f71a71e6cae01832d853f5
   depends:
@@ -7937,7 +7937,7 @@ packages:
   license_family: Apache
   size: 72614
   timestamp: 1706747680710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
   sha256: bcee1da236f6f5f88322979daddc89e8555648593f6282ad3073a68eb22a68d2
   md5: bf4c19b0db5049930d8b2fcc3b9172fa
   depends:
@@ -7948,7 +7948,7 @@ packages:
   license_family: Apache
   size: 51027
   timestamp: 1706690972693
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
   sha256: 32561df1e664cb320f79c26c5af23dd55953924e66824e2d6372a44687147bdc
   md5: 05f4c6715180a992468035c0a86e734c
   depends:
@@ -7959,7 +7959,7 @@ packages:
   license_family: Apache
   size: 54300
   timestamp: 1706192197648
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
   sha256: 94d2fff3facfd248968d39a3fd7d3b1f7270df32a87dd567c33d60da1a5eb064
   md5: 64fed6e7c73d88bfbfc39e838022f948
   depends:
@@ -7978,7 +7978,7 @@ packages:
   license_family: Apache
   size: 199877
   timestamp: 1706827970924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.10.55-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-sdk-cpp-1.10.55-hd77b12b_0.tar.bz2
   sha256: 813f252df10d2782fbb26e2c6348f55d44ef1618467e340224df44bcda4814ff
   md5: 8efc1448ada827ddba894a07903808dc
   depends:
@@ -7993,7 +7993,7 @@ packages:
   license_family: Apache
   size: 2519847
   timestamp: 1706890866084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/babel-2.11.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/babel-2.11.0-py311haa95532_0.tar.bz2
   sha256: b94e6065a6fec9259eef85dc952c59bf20e854682cbf934f04a0c2f1ac2417f0
   md5: 50cfce72575fcdf3757c27bc6ba5d0e9
   depends:
@@ -8003,7 +8003,7 @@ packages:
   license_family: BSD
   size: 7218701
   timestamp: 1676427266094
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
   sha256: 38ccda1553733326d99a75436b4b0f7640bafbbfcdbc33838b0e59cf017de687
   md5: 3f6812578c5e0b3ba0d2a651cc766c15
   depends:
@@ -8013,12 +8013,12 @@ packages:
   license_family: MIT
   size: 266405
   timestamp: 1681493141116
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.4-py311h746a85d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-3.3.4-py311h746a85d_0.tar.bz2
   sha256: 8450618c2bd233e851007daf1e022cd8fdc660a07b04c24da6484d2bc8757851
   md5: fa1651f65858b6f42a8259d8ec788675
   depends:
@@ -8036,7 +8036,7 @@ packages:
   license_family: BSD
   size: 5957046
   timestamp: 1706912402593
-- conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
   sha256: 68ef338b27c035add89c0812ad469dd8c9e94f27130f770345ea20deb049d50b
   md5: 9ec19b145f655329532b608963cf32f4
   depends:
@@ -8047,7 +8047,7 @@ packages:
   license_family: OTHER
   size: 11334
   timestamp: 1696764270626
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
   sha256: 5c12a5d7856d9977447360b3a99a5b99818707fe79781ba1779037f11b3fef53
   md5: 6a125ae352306a944aabc635a5fe13a3
   depends:
@@ -8059,7 +8059,7 @@ packages:
   license_family: BSD
   size: 139230
   timestamp: 1707864402762
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
   md5: 507dfe693ef429f466d964b599f4af21
   depends:
@@ -8071,7 +8071,7 @@ packages:
   license: MIT
   size: 18650
   timestamp: 1659616328001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
   md5: d0bf43e8df60baae3b3105aa5c42a791
   depends:
@@ -8082,7 +8082,7 @@ packages:
   license: MIT
   size: 21153
   timestamp: 1659616312367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py311hd77b12b_7.tar.bz2
   sha256: a210ef4e1570b7220c9a7a30dce3e598b46585531951906fd4e8e996357842a6
   md5: 0ef1d798410f6494cec4943a48743e4b
   depends:
@@ -8092,7 +8092,7 @@ packages:
   license: MIT
   size: 343107
   timestamp: 1676436053216
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_5.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_5.tar.bz2
   sha256: 8845552a84555d4adb13a5f16e2b5d55040a732b7df9319e00f9fc713e0f896f
   md5: 08085c8a9c0fa1a1a404a973695b2af3
   depends:
@@ -8102,7 +8102,7 @@ packages:
   license_family: BSD
   size: 95525
   timestamp: 1709103616461
-- conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
   sha256: 41a6c5a90b88ec7010bb6dd89390754e476b52c3ab2d519bdab9556da8829479
   md5: b047426a545e287f45e8abfbfcb0de55
   depends:
@@ -8112,14 +8112,14 @@ packages:
   license_family: MIT
   size: 118041
   timestamp: 1693902191485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.12.12-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.12.12-haa95532_0.tar.bz2
   sha256: 80273bf1f2ba732b7244a27c855a15a8a2595d5b1e97b5c53a6931f5455eca58
   md5: d713a3ca49bde113fd1b2b2f9e33d604
   license: MPL-2.0
   license_family: Other
   size: 169663
   timestamp: 1702903842577
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
   sha256: cd6545642e380b13700f2f2a7a1fb54a273365047bd23108dbd03b197f5c0c9c
   md5: 929edc1c553d2da4d6c6c0745b033cc3
   depends:
@@ -8128,7 +8128,7 @@ packages:
   license_family: Other
   size: 166377
   timestamp: 1707229328635
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.16.0-py311h2bbff1b_0.tar.bz2
   sha256: bea4047e8e2fc864a26fdf1015a0c3564096ed5147a84dcf7e47d666f3df2caf
   md5: 630e8a46b4a26d3fe7daa159efa5ceaf
   depends:
@@ -8140,7 +8140,7 @@ packages:
   license_family: MIT
   size: 290350
   timestamp: 1700254613419
-- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
   sha256: 7153817dd49ec317b519802c7c22c836602e00cbd96d68385e83eaf4c9f5ba6a
   md5: cd829e5997611a602e29fa2fd5882635
   depends:
@@ -8150,7 +8150,7 @@ packages:
   license_family: BSD
   size: 204113
   timestamp: 1698130080270
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
   sha256: 03f00c22b6d92ee55b727b369e8dbdd9a4d590f2655b62b7c45ecd046741858e
   md5: 116f67c13bb0b3caee6cbde334ff6abb
   depends:
@@ -8159,7 +8159,7 @@ packages:
   license_family: BSD
   size: 49934
   timestamp: 1683040303796
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
   sha256: 4099898f02e1f6119fcda65e747c3cbfef0bf563c8855b79a0245160709d5b45
   md5: ab9705c34e67fb8c8faec69d63ff4064
   depends:
@@ -8168,7 +8168,7 @@ packages:
   license_family: BSD
   size: 36410
   timestamp: 1676422341506
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py311haa95532_0.tar.bz2
   sha256: ab4d331ec5eafcc152d9fbe857761cdab2f44d440b9f272bfa50dd036a784484
   md5: 0b34f1694f1f9be13e7f4497874b4fb5
   depends:
@@ -8178,7 +8178,7 @@ packages:
   license_family: CC
   size: 2010331
   timestamp: 1676440450100
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py311haa95532_0.tar.bz2
   sha256: b0a027b85028b7d3c61a4fb73c4004e93b4f0b49bbdc46473fb3ca3eea9e236a
   md5: 18dc1ad965a886263bb9ff902bcc3b14
   depends:
@@ -8188,7 +8188,7 @@ packages:
   license_family: BSD
   size: 15370
   timestamp: 1678376609334
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
   sha256: eeb49cd151ecdccd40062e8123a3b7a9a8a1eda6567dd33ce909ff8ee1a97c89
   md5: b7fe1f7ead1ec2ac642d022942282fc8
   depends:
@@ -8200,7 +8200,7 @@ packages:
   license_family: BSD
   size: 232451
   timestamp: 1700583772701
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.11.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/dask-core-2023.11.0-py311haa95532_0.tar.bz2
   sha256: 132d5f66fb9c6b2093c5c066d3fa6ac1468d1bd3fb3b26816556f3c4c8e4be08
   md5: aace1519be879e46f0cbc9e62bd5a4ba
   depends:
@@ -8217,7 +8217,7 @@ packages:
   license_family: BSD
   size: 3086382
   timestamp: 1701396440772
-- conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.16.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/datashader-0.16.0-py311haa95532_0.tar.bz2
   sha256: 7c57396f00b4d63b1b597ccad75548f6e81f4e2b831c660fe14c6764d62148e8
   md5: 0d1d476cfdb705f2ed6cfe2f6a092ef4
   depends:
@@ -8239,7 +8239,7 @@ packages:
   license_family: BSD
   size: 18023517
   timestamp: 1699544725067
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
   sha256: 5c73f86e575f2ad683ee4a1c2df11020e270edd89d12f11199483d57b0b51826
   md5: e96a12895ce374476277b1b196ba24bd
   depends:
@@ -8250,7 +8250,7 @@ packages:
   license_family: MIT
   size: 3719519
   timestamp: 1690907216785
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -8262,7 +8262,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fsspec-2023.10.0-py311haa95532_0.tar.bz2
   sha256: c028a882df2015945eb0d46ac4eb1cade6ab581d148853cd230f42ce799201d1
   md5: 5eae68cf18620dfc9610394ebefcf301
   depends:
@@ -8271,7 +8271,7 @@ packages:
   license_family: BSD
   size: 359005
   timestamp: 1701286643781
-- conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
   sha256: 7cb0df7aa62796b0081e1708003529c02411aca6a540bae97beaec919aa64e74
   md5: ea81fd813e10055553a8d7597c8be98f
   depends:
@@ -8281,7 +8281,7 @@ packages:
   license_family: BSD
   size: 322778
   timestamp: 1706888324269
-- conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
   sha256: ed1fa1a40c6739b48ff3a2d51c3df20e4983b59684b04d93e1337c5f2e93a954
   md5: 1797f64343a42395207cd452e6a6a751
   depends:
@@ -8292,7 +8292,7 @@ packages:
   license_family: BSD
   size: 94476
   timestamp: 1706895442146
-- conda: https://repo.anaconda.com/pkgs/main/win-64/grpc-cpp-1.48.2-hfe90ff0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/grpc-cpp-1.48.2-hfe90ff0_1.tar.bz2
   sha256: 0c6223208742064a2829f8dd658e04b72f5176e357a1320c0b0398b91abfd292
   md5: 19c77d6709407253582fae939434016c
   depends:
@@ -8306,7 +8306,7 @@ packages:
   license_family: APACHE
   size: 31002375
   timestamp: 1685747992041
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
   sha256: 68d59a361a93a5ae36542f667138b4ab072e1abff15b3aa2dc55575baf86a3e9
   md5: 383239566d9506b743c7bc65d709b7e1
   depends:
@@ -8323,7 +8323,7 @@ packages:
   license_family: BSD
   size: 5374020
   timestamp: 1707836834797
-- conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.9.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/hvplot-0.9.2-py311haa95532_0.tar.bz2
   sha256: fa30e4a64279a12bc084a7e5a1f038fd31af17207a27133e2eff3807a72e011b
   md5: ef78998ab4439e42d7a0fe14d2f35751
   depends:
@@ -8340,13 +8340,13 @@ packages:
   license_family: BSD
   size: 1990475
   timestamp: 1706712786427
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
   sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
   md5: 582d2c1135a89da757a038de831e7f39
   license: Intel proprietary
   size: 11086648
   timestamp: 1664812389803
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.4-py311haa95532_0.tar.bz2
   sha256: 762f3a14fb7ffb445311ba2098e543de33ed6ab035c57ac4b63976a9c894eebb
   md5: 88e19c2afbc6a264c37f9f92e223caa0
   depends:
@@ -8355,7 +8355,7 @@ packages:
   license_family: BSD
   size: 124063
   timestamp: 1676424962314
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
   sha256: db30abacf919b3f68ae1e6a94c467fd1e69fbf47ba7a86e6b491d8bfe4776f92
   md5: 9299876e7ddc3aea3487fd93340ceae7
   depends:
@@ -8365,7 +8365,7 @@ packages:
   license_family: APACHE
   size: 50842
   timestamp: 1704813715071
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
   sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
   md5: d215cc8ee7ca2cc83cc250cc5d822fe0
   depends:
@@ -8375,7 +8375,7 @@ packages:
   license_family: Proprietary
   size: 3929136
   timestamp: 1699647939158
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
   sha256: 864e9598f64105769b4ec02cc404fb507bc59e217324daf1686c00cfd12c0055
   md5: 6bb1c3be1f85799a3988afc2c3c5a4f0
   depends:
@@ -8396,7 +8396,7 @@ packages:
   license_family: BSD
   size: 229621
   timestamp: 1705934494547
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
   sha256: e0b44f0c3a4ead0fb8e58033c0be25524ee9ecf7f4cc632f03e9f6fac3484baa
   md5: 50cbc18d0c7b42a4553b52d0cef2c857
   depends:
@@ -8413,7 +8413,7 @@ packages:
   license_family: BSD
   size: 1637367
   timestamp: 1704834149957
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
   sha256: d81566367c79a28d4717157fc74293e846a47af99387ed479eb001a425dd398e
   md5: 28c76079c96ad7f8b1a5ed32b438c79a
   depends:
@@ -8423,7 +8423,7 @@ packages:
   license_family: MIT
   size: 1147434
   timestamp: 1679427525584
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
   sha256: f766a445df8e81447f27c830e162566b221fa1bfc41296a6c5e0789586ca1fbf
   md5: 55bc50633414fc8616ccbf4140a42d5f
   depends:
@@ -8433,7 +8433,7 @@ packages:
   license_family: BSD
   size: 353715
   timestamp: 1706733949898
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
   sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
   md5: 81f2c343dc4c65eea39c45383272068f
   depends:
@@ -8443,7 +8443,7 @@ packages:
   license_family: Other
   size: 407861
   timestamp: 1677849239400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
   sha256: 5e6698015a3b048093f5737f0e54bcbae415d0f9682dfdfeae3a8cfb4ea275e2
   md5: 0093a4214131046c4f68af0739dfbea4
   depends:
@@ -8456,7 +8456,7 @@ packages:
   license_family: MIT
   size: 201456
   timestamp: 1699041872445
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
   sha256: 9581be54128954080d7cef448b1728874c2ebbe5064f55adece422cf12eafa5a
   md5: 3adc105f87d5c7f0b1248bc3423f5b48
   depends:
@@ -8466,7 +8466,7 @@ packages:
   license_family: MIT
   size: 16187
   timestamp: 1699032556953
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter-lsp-2.2.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter-lsp-2.2.0-py311haa95532_0.tar.bz2
   sha256: 2fd9671118852dc700897fdb980a323287f40880f2ef19864e78039049f84563
   md5: c3ab03d0742e6ca173838fae93247b04
   depends:
@@ -8476,7 +8476,7 @@ packages:
   license_family: BSD
   size: 101303
   timestamp: 1699978449116
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-8.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-8.6.0-py311haa95532_0.tar.bz2
   sha256: 4772d37293b0350a3fbfa9b16d0b279544c753f78371b352013daa1d4769a78d
   md5: 5cd7415248e27a289f9d6dff9b600a73
   depends:
@@ -8490,7 +8490,7 @@ packages:
   license_family: BSD
   size: 258542
   timestamp: 1699456032957
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
   sha256: 851ae576c2b72bf3172cd460feec4f5577dc06476a043e185279071b67549fab
   md5: fae4d214d00de6604738f39acbbb197e
   depends:
@@ -8502,7 +8502,7 @@ packages:
   license_family: BSD
   size: 119710
   timestamp: 1698937651636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
   sha256: d97ad90f9121ecf7f8d3af773b222c0bd244204ee73a3e44185491fa16d83104
   md5: 73ac0fa3c67e5eb283173d74a2771752
   depends:
@@ -8518,7 +8518,7 @@ packages:
   license_family: BSD
   size: 60625
   timestamp: 1699282918176
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
   sha256: 257e1102d2dc3f8b0c1708585c819e86f41abd101084cd0569e8e31652480875
   md5: 2128c6806bba6953e1a275f37e7a295b
   depends:
@@ -8546,7 +8546,7 @@ packages:
   license_family: BSD
   size: 614705
   timestamp: 1699467242943
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
   sha256: 90420847230e72a648417f5f77cebcf7f17b89f70788652c276acc0c440e135f
   md5: ef3d8dee197aa37897bf6d39d2dd878f
   depends:
@@ -8557,7 +8557,7 @@ packages:
   license_family: BSD
   size: 27639
   timestamp: 1686871052174
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab-4.0.11-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyterlab-4.0.11-py311haa95532_0.tar.bz2
   sha256: cc3eb5e2c513fab04e2740a093f9c44f0355f746ba4cbfeacc2ecbbd08d7096f
   md5: 729d6b5a3d58c98e8ec73afcb59e0d0b
   depends:
@@ -8580,7 +8580,7 @@ packages:
   license_family: BSD
   size: 6714941
   timestamp: 1706809027799
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_server-2.25.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyterlab_server-2.25.1-py311haa95532_0.tar.bz2
   sha256: 066d78020fbe62fa9401979852ddbeff05f8e9faeec861487cb2662b9b5d39f9
   md5: 2f7340345dee00a18c766c1c1472fca3
   depends:
@@ -8596,7 +8596,7 @@ packages:
   license_family: BSD
   size: 106966
   timestamp: 1699555552806
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
   sha256: 8a2f0909fad0387e57cb0e9ee30db2b20761a9106e794381ffeac387a298fb07
   md5: 6058b2efc3284e27aacec2e6e6280433
   depends:
@@ -8607,7 +8607,7 @@ packages:
   license_family: BSD
   size: 62334
   timestamp: 1676432044242
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -8617,7 +8617,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
   sha256: 4184dd040fc38cb123a98588a8344aa8d1ba1932df5fcc6c188f6b21f5a0c306
   md5: da58cfa83f3d6c31ae12d8777cd1b64d
   depends:
@@ -8630,7 +8630,7 @@ packages:
   license_family: OTHER
   size: 29803292
   timestamp: 1696764164248
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
   sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
   md5: c345f51706eef530454f66b794e5e574
   depends:
@@ -8639,7 +8639,7 @@ packages:
   license: MIT
   size: 68189
   timestamp: 1659616216976
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
   md5: a7400cfb72042977bc047909ed504ce8
   depends:
@@ -8649,7 +8649,7 @@ packages:
   license: MIT
   size: 33743
   timestamp: 1659616248209
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
   md5: 6307f6854754ab5bd7c84e6998385bb1
   depends:
@@ -8659,7 +8659,7 @@ packages:
   license: MIT
   size: 733177
   timestamp: 1659616279453
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.5.0-h86230a5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libcurl-8.5.0-h86230a5_0.tar.bz2
   sha256: d505283d2d3a94a530b341933d3047662d3481d88826ddf68bd78935c0fb94c3
   md5: 1e9446c8a7f39247834fe0bd16d3edb0
   depends:
@@ -8672,7 +8672,7 @@ packages:
   license_family: MIT
   size: 338561
   timestamp: 1704383910302
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -8682,7 +8682,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
   sha256: 6458c7a370c4e3366b3b208c5b2834a7acfb17981e47fe3fb861f225d7cefbc3
   md5: ecabf4acab5b604856d8c7c4278c2c2c
   depends:
@@ -8694,7 +8694,7 @@ packages:
   license_family: BSD
   size: 446380
   timestamp: 1685052520132
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_0.tar.bz2
   sha256: 1b3b9be41dba504e468a336196de9fd09568ba42585e493888aaa3708f687d0a
   md5: 5cdcd99f18d9dedb772d272088e72b4c
   depends:
@@ -8704,7 +8704,7 @@ packages:
   license_family: MIT
   size: 116942
   timestamp: 1683716620230
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -8715,7 +8715,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
   sha256: f7368e611e349b91315ce4ba4dbf9116d996a48f98eed425f4d5c3d5b9fcfa5e
   md5: 77eb9daff9052f1fbf24d91c5bba1d74
   depends:
@@ -8726,7 +8726,7 @@ packages:
   license_family: BSD
   size: 2543079
   timestamp: 1675278760037
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -8735,7 +8735,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-he2ea4bf_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libssh2-1.10.0-he2ea4bf_2.tar.bz2
   sha256: 07e45cd4e2e791528d099791f1664983b880566c836e73925211e45c9e28096b
   md5: 5f67893563dfc1dd0e45d3b2abf2e3f4
   depends:
@@ -8746,7 +8746,7 @@ packages:
   license_family: BSD
   size: 230596
   timestamp: 1686933095919
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
   sha256: 238e486a0d62264e7ab35098bdc0390fb9a4649921b18827228c811ae8252c88
   md5: f1ebe453c5a955a25e4b00f73279fc42
   depends:
@@ -8760,7 +8760,7 @@ packages:
   license_family: Apache
   size: 894777
   timestamp: 1687975823684
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -8777,7 +8777,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
   sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
   md5: b1781519a200ccbfcb4a1194005aa3ef
   depends:
@@ -8789,7 +8789,7 @@ packages:
   license_family: BSD
   size: 338459
   timestamp: 1694777084290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
   sha256: 4534c822511a052a72c2b070a05e5d8d6f3550f18ea00a33f9d8a9a92b4382cc
   md5: 82f24e7660831445a2183216e280a6a4
   depends:
@@ -8799,7 +8799,7 @@ packages:
   license_family: MIT
   size: 41464
   timestamp: 1676474474981
-- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
   sha256: b2b50fb4e43e4c4da8db26cf362671e03774384732e1925d82e12dfce45c5ac3
   md5: 44ff317b1ff9bd2b1fbf39da56965b16
   depends:
@@ -8811,7 +8811,7 @@ packages:
   license_family: BSD
   size: 20842990
   timestamp: 1706911120234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
   sha256: 896b7a39bd4ad3621312130122b4fe84dcb67d7355166255c58ea9bc562eb0ae
   md5: 640b852a56296f48cf073e61a59c5256
   depends:
@@ -8820,7 +8820,7 @@ packages:
   license_family: BSD
   size: 13751
   timestamp: 1676428354074
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
   sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
   md5: 6970c7f46b0164cad1d210e7a1419959
   depends:
@@ -8830,7 +8830,7 @@ packages:
   license_family: BSD
   size: 143434
   timestamp: 1670944902624
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
   sha256: e0dc6e119b224bb31ef34b6ba270ffadc181d38b698c5318de8df7a5d2c4ccbd
   md5: 992ccd756f09408f0b74dfb9852a8b7f
   depends:
@@ -8839,7 +8839,7 @@ packages:
   license_family: BSD
   size: 182381
   timestamp: 1676437963591
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
   sha256: 050b5fd4b28132d8102a7e6b40179894dc7f5e41f7ad9ee19211e67446c5740f
   md5: 3ae0b2f6baec708554648ddafa81b756
   depends:
@@ -8849,7 +8849,7 @@ packages:
   license_family: MIT
   size: 154386
   timestamp: 1684279992864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
   sha256: 8269c73b7a9c03b95a121e318d0468f35eecc016093620b0560f35238cc5df51
   md5: 2914bea0ae29315f998e1abac79ccaa8
   depends:
@@ -8862,7 +8862,7 @@ packages:
   license_family: BSD
   size: 30214
   timestamp: 1704206218108
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py311hf62ec03_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py311hf62ec03_0.tar.bz2
   sha256: 0d2464ab9dcb0605a6b7ebf336d2f941f24f4eca7b6795992547dc2b8608ca9c
   md5: 25f356b0b2b6bfb61e05d9c35598b8c6
   depends:
@@ -8884,7 +8884,7 @@ packages:
   license_family: PSF
   size: 9029291
   timestamp: 1698692645569
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
   sha256: 43279276850eb6e621812448cddc1093524cee0b7f8ed58b4600b68a4fb659f2
   md5: 5968b2b5c1f3cf5c8c8c9aaa4d8d66a2
   depends:
@@ -8894,7 +8894,7 @@ packages:
   license_family: BSD
   size: 19886
   timestamp: 1676425829787
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
   sha256: 3062a8254ca351b54f15bea85cc928a3ba4d879bb98ce97ece39a9f7eca215a5
   md5: 8f1565663abb34ad7fdd512e76da5532
   depends:
@@ -8904,7 +8904,7 @@ packages:
   license_family: MIT
   size: 68031
   timestamp: 1676481862508
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
   sha256: cdff5215c292fe59649ca40ca72f5d26da352760c1d6a56feba14eb13f7bbf61
   md5: e0f3f32b22135dfeaec277bc87183ca9
   depends:
@@ -8913,7 +8913,7 @@ packages:
   license_family: MIT
   size: 23328
   timestamp: 1676442709081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
   sha256: 3b173a25605d2aaacc57ec0e425f1d1c51327eb2521c8742a736e2c76069bc8d
   md5: 169f1c93a443f95a88665f3008623ce1
   depends:
@@ -8924,7 +8924,7 @@ packages:
   license_family: BSD
   size: 104882
   timestamp: 1676425142412
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
   sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
   md5: 527155127b9fada5e5c5c69a624674b9
   depends:
@@ -8936,7 +8936,7 @@ packages:
   license_family: Proprietary
   size: 187498166
   timestamp: 1699648376430
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
   sha256: cea59ae60da314caecf08edb9bcb03126c6dd35837c8184bceaa194decca3341
   md5: 30936b7263cf0171f7c86400f12ef184
   depends:
@@ -8948,7 +8948,7 @@ packages:
   license_family: BSD
   size: 49080
   timestamp: 1682975093455
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
   sha256: 5070ceb0a406b1b8b99e2ec58f5d224cbe16ec78109c46720bd182b509e05c6e
   md5: 34de1af5c639f2d06c6c8d99488e4226
   depends:
@@ -8963,7 +8963,7 @@ packages:
   license_family: BSD
   size: 196201
   timestamp: 1695058367111
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
   sha256: 6b4b27302e458fa527321c59be7c335d61f86da7501c4d141db20a72fad68b55
   md5: 7db9b12da1290bb2c2fc6ee52a945905
   depends:
@@ -8978,7 +8978,7 @@ packages:
   license_family: BSD
   size: 256371
   timestamp: 1695060425702
-- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
   sha256: 39f09c1bc57b4800ebda331eddb462928435498705351b0432d51a4293294ad8
   md5: 5565984a02f41e97cb9a4c9126ced14b
   depends:
@@ -8988,7 +8988,7 @@ packages:
   license_family: BSD
   size: 29808
   timestamp: 1676442800892
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
   sha256: e940f9178ee2fa0a7c12873ae35ebea0074371653e5cfa1be8aa8d9271fd343b
   md5: 355d0835215911738a28010dfa6aa382
   depends:
@@ -9001,7 +9001,7 @@ packages:
   license_family: BSD
   size: 141785
   timestamp: 1698934346590
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
   sha256: 47dd00c0179f4eb29c70d0453d340f7f5332af326b3d51c64ca3bf6a14be8e7e
   md5: f66afe718bdb57667b03ebda4cb2ac7e
   depends:
@@ -9028,7 +9028,7 @@ packages:
   license_family: BSD
   size: 561655
   timestamp: 1699023338436
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
   sha256: 4ee863a1ff697274c642b3101f82b279a354e3f033a87505655039f89127bb41
   md5: bfaf19be6644ad2344e118aa0acccb13
   depends:
@@ -9041,7 +9041,7 @@ packages:
   license_family: BSD
   size: 189809
   timestamp: 1694617194065
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
   sha256: 90fb3f14c49da1397982eae21cd09e8d60d491d76f94c57590c56723fe6dc172
   md5: 46a523661fe5c1bce7b4213fd428c3de
   depends:
@@ -9050,7 +9050,7 @@ packages:
   license_family: BSD
   size: 16732
   timestamp: 1708532795328
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-7.0.8-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-7.0.8-py311haa95532_0.tar.bz2
   sha256: aa72c6e127bc394de0b570413912e0625759ba10248fbf884928c9ec3ed6fa70
   md5: 1cdaa20793e8f70874ade8136e1dd5c2
   depends:
@@ -9064,7 +9064,7 @@ packages:
   license_family: BSD
   size: 3681116
   timestamp: 1708030716052
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
   sha256: e040ebcab948325fbe17e4ab15be62e1fafa7bad225457e59764adb60eb40db5
   md5: 4d40a09df8cb74a9f044eab317436d67
   depends:
@@ -9074,7 +9074,7 @@ packages:
   license_family: BSD
   size: 27282
   timestamp: 1699456187703
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.59.0-py311hf62ec03_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numba-0.59.0-py311hf62ec03_0.tar.bz2
   sha256: 9e6d63bc596cb6aca8abd565c448807da8278d9e40489bcc6de4bc190d4bacdb
   md5: b75de367d02c1eb056d5594680cb3d26
   depends:
@@ -9095,7 +9095,7 @@ packages:
   license_family: BSD
   size: 6092876
   timestamp: 1707085479626
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
   sha256: d3bd2a6614bb7e7f5ce3348d6674e71cce45cbde236beff32f0f08cd95a64ef0
   md5: e70f15643164f432d1df68635e7c322b
   depends:
@@ -9110,7 +9110,7 @@ packages:
   license_family: MIT
   size: 162691
   timestamp: 1696515822068
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
   sha256: 470fe9a0b3e196fa60d5550d8188f6074a207572fa0d353a4448d580872e7804
   md5: 6fdb8df0613fb2fb9f1732d335fa25f1
   depends:
@@ -9127,7 +9127,7 @@ packages:
   license_family: BSD
   size: 11053
   timestamp: 1708641901110
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
   sha256: 222c1711e7cf151e29077c7d4d86a865c9fd39615812d58a1daca6fd1b6bdfb5
   md5: 585bcd8bc3940a8a859f38ebafdcd77d
   depends:
@@ -9143,7 +9143,7 @@ packages:
   license_family: BSD
   size: 10723862
   timestamp: 1708641867155
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
   sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
   md5: ab07e2a27ac08afe3d0b4c0890b8486a
   depends:
@@ -9154,7 +9154,7 @@ packages:
   license: BSD 2-Clause
   size: 249316
   timestamp: 1630094024143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.13-h2bbff1b_0.tar.bz2
   sha256: d7065fb018761770402c537b7010faac29e72078f0a956dfb719cd03ed8e8eca
   md5: 39fdacf2d8eaeca0aac16629c415b5b7
   depends:
@@ -9165,7 +9165,7 @@ packages:
   license_family: Apache
   size: 8043758
   timestamp: 1706911036188
-- conda: https://repo.anaconda.com/pkgs/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
   sha256: 417cf23716f17b6daf2b717bbd69240aa9440845dfa415f59a97961794632ce5
   md5: 36d709d47c43a3e9b43f23cf4edb6438
   depends:
@@ -9180,7 +9180,7 @@ packages:
   license_family: Apache
   size: 877890
   timestamp: 1676482911485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
   sha256: b2f5f50a1ddf811102636f3acebd76716c88ebb628754b91eda7a3a962adf26c
   md5: 712527b4d84c350dca4b67f511c04414
   depends:
@@ -9189,7 +9189,7 @@ packages:
   license_family: APACHE
   size: 39421
   timestamp: 1699371341381
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py311haa95532_0.tar.bz2
   sha256: a9d2bf21f7a458e90f0c6ebf72ad591d5a1b891542d4c401e487661f25f0f693
   md5: 58e3da20b3e08b819b3d1e5ffcaf5cdb
   depends:
@@ -9198,7 +9198,7 @@ packages:
   license_family: Apache
   size: 93982
   timestamp: 1693575296514
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.4-py311hf62ec03_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-2.1.4-py311hf62ec03_0.tar.bz2
   sha256: 4eab648cd85b8a663a9b8d1d682879aa5ca7dafe1d86a413da718873614eff12
   md5: 05b234e5e53cc9027e3e410957dd763a
   depends:
@@ -9246,7 +9246,7 @@ packages:
   license_family: BSD
   size: 15488930
   timestamp: 1702324598982
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.8-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-1.3.8-py311haa95532_0.tar.bz2
   sha256: 0848859520e789dc9977e6ea4aaf8848addbe1a8282cf5c8453b916dc529ccb1
   md5: 544ef9511ce79469e60c32a951ca60fc
   depends:
@@ -9270,7 +9270,7 @@ packages:
   license_family: BSD
   size: 18091432
   timestamp: 1706540215140
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-2.0.2-py311haa95532_0.tar.bz2
   sha256: 7fce288045b1aa3d9fd77db303459df57c96801a0cb35c207aa0171592ed102f
   md5: 6fbe82754fe5f691d0f5d08957209b10
   depends:
@@ -9279,7 +9279,7 @@ packages:
   license_family: BSD
   size: 256371
   timestamp: 1705937896560
-- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
   sha256: b0d7fbfcf1c5c682ed9934eb6a33e00a2517941f2bcb9d677379f4bb73b2c45c
   md5: 20c8f36595a48f5cda2f4f74c02a3ea2
   depends:
@@ -9293,7 +9293,7 @@ packages:
   license_family: BSD
   size: 48206
   timestamp: 1698702818841
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.2.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.2.0-py311h2bbff1b_0.tar.bz2
   sha256: 432d176d749e044690d3763be771717aa20ef91897602214bca56994b49a6e76
   md5: 3e09be8412e98a656951ed1f76525c57
   depends:
@@ -9310,7 +9310,7 @@ packages:
   license_family: Other
   size: 1005722
   timestamp: 1707233792036
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-23.3.1-py311haa95532_0.tar.bz2
   sha256: 5d612af287cad7d0fc1b8e2e01d7f49b5466f2e17338b03a13cd60111f2513aa
   md5: 1b0f29aa3fc57cc8d5a48ae392aa8567
   depends:
@@ -9321,7 +9321,7 @@ packages:
   license_family: MIT
   size: 3752545
   timestamp: 1700667933959
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
   sha256: e5f8cbfb5fc25d460a9117bfc5511959c5e86ccb193316033f87bd516e0c8881
   md5: 9f7e8b5eb651539386bb92c14e5c321b
   depends:
@@ -9330,7 +9330,7 @@ packages:
   license_family: MIT
   size: 37730
   timestamp: 1692205554840
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
   sha256: 6c5b53831273674361437fb546e08315fc11ca9275a174bca3887987e86ced5a
   md5: f8d91daf5173eb03157f484389adcdd4
   depends:
@@ -9339,7 +9339,7 @@ packages:
   license_family: Apache
   size: 122178
   timestamp: 1679591983138
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
   sha256: 546819d922b03f3a25ca9f98fd069d0588d481fc0603c6d74bd598fb6a93687f
   md5: 86c18e3e0b67ee099457475ed6caf2e6
   depends:
@@ -9351,7 +9351,7 @@ packages:
   license_family: BSD
   size: 751763
   timestamp: 1704404627180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
   sha256: ae06f0dfa2cfae51404afc6d6ad3a474a93015b5ba9a7d3ea24224b8e7547987
   md5: 3e19794c806cc3e84a3080a97c359b75
   depends:
@@ -9362,7 +9362,7 @@ packages:
   license_family: BSD
   size: 510466
   timestamp: 1679005998612
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-14.0.2-py311h847bd2a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyarrow-14.0.2-py311h847bd2a_0.tar.bz2
   sha256: a33dd77a94c79ab95caaa02fbdcb399d4041806a52a82411529cf1454f031536
   md5: 01f56e64de4eed195d72a61301444fa7
   depends:
@@ -9376,7 +9376,7 @@ packages:
   license_family: Apache
   size: 4504341
   timestamp: 1707332113670
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
   sha256: e2af1efb1a5094a5962d93fa949ecab479a2ae7570e030f52eeac6761383c208
   md5: 4cb1359e22ddf8f3996afddce5f6205c
   depends:
@@ -9388,7 +9388,7 @@ packages:
   license_family: BSD
   size: 56638
   timestamp: 1676438592117
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
   sha256: d95c88d06f4f3f667bd9a39e5f18179e83b3cd4c115c06ce0fff390ff6d3a700
   md5: c6d00a8a4d89b1be99bfa3aff19d96b4
   depends:
@@ -9397,7 +9397,7 @@ packages:
   license_family: BSD
   size: 2134881
   timestamp: 1684280285492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
   sha256: 643a9a0eba1e2bd5980d21623d3b35188c24781ec251acc4d15714bd1ccb4c17
   md5: b3cda0394db05be6f0f6176abacb13f3
   depends:
@@ -9406,7 +9406,7 @@ packages:
   license_family: MIT
   size: 207985
   timestamp: 1678721438358
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
   sha256: 974c22de09078bf07c5db31fe12d8d89d6433508defc8237cbe52e08c69ed56b
   md5: 9cf10bfd49140a527cf4b1d912097e6d
   depends:
@@ -9416,7 +9416,7 @@ packages:
   license_family: BSD
   size: 36072
   timestamp: 1676426019064
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.8-he1021f5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.11.8-he1021f5_0.tar.bz2
   sha256: 1c557d91837e0205cd08180b604da06f28d7679df1ea1026e7954add3eb4d468
   md5: 3901bef86daffeb6ff2317543b292766
   depends:
@@ -9437,7 +9437,7 @@ packages:
   license_family: PSF
   size: 19539055
   timestamp: 1708983524626
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
   sha256: 9acb33db60d9319595f52337cae3b88c2a2338cd66f1f9d8ae86d0a993c2067a
   md5: f4af8cf94d042b4dde487241bba1c457
   depends:
@@ -9446,7 +9446,7 @@ packages:
   license_family: BSD
   size: 279780
   timestamp: 1679500609851
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
   sha256: 48fe7373b012b51134b6b6ff67f18d2b4aae3a5c7700e4560ce002af7172f064
   md5: 0379cd17692152c12b662b0e4ea46b88
   depends:
@@ -9455,7 +9455,7 @@ packages:
   license_family: BSD
   size: 18008
   timestamp: 1683824373128
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py311haa95532_0.tar.bz2
   sha256: d9c9e5d09c2ca723a22fcd0b934f7f9f31e97d5587b2c231527c1f6de5753e1c
   md5: 81204aa731cc509770267cd8695dc5e0
   depends:
@@ -9464,7 +9464,7 @@ packages:
   license_family: MIT
   size: 276494
   timestamp: 1695132123472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.0-py311haa95532_0.tar.bz2
   sha256: 0c43947eb37620d36cf57860c6008e0cda5f29c22dd55931b5efcb0bcb8fb671
   md5: 37f7545c68cfed4547e4fae53db71efc
   depends:
@@ -9476,7 +9476,7 @@ packages:
   license_family: BSD
   size: 64373
   timestamp: 1701728120219
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
   sha256: cd33dfee104dfbba4af38d06a09ccbae6a32e7c543afedab523303319ebb283d
   md5: 3dfc19af0306d80921e1403f1f551bba
   depends:
@@ -9486,7 +9486,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13679916
   timestamp: 1676423267293
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
   sha256: 102ff1d958209e3648bb49da3503cf752abab822011fdc4e12e88145c9e73772
   md5: 0553c2c381b6f5c836b23edc8c6db2ba
   depends:
@@ -9498,7 +9498,7 @@ packages:
   license_family: MIT
   size: 246689
   timestamp: 1677708371873
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
   sha256: bee5c4d0f41f06a9c0aac636885e36e8b81116aafde980f9ea48fdb64abb5567
   md5: 6c05a053240cb90765d6f8c2efdf905e
   depends:
@@ -9510,7 +9510,7 @@ packages:
   license_family: MIT
   size: 182228
   timestamp: 1698096268270
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-25.1.2-py311hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-25.1.2-py311hd77b12b_0.tar.bz2
   sha256: d08d1b2bc1859011d6d8c8e0afff0cad680c598e5ad59bb7beab9317b3bdece4
   md5: 5e36645629336f3732b14604bb666442
   depends:
@@ -9522,7 +9522,7 @@ packages:
   license_family: BSD
   size: 552293
   timestamp: 1705606206058
-- conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
   sha256: 720f3dd1f933d035b1393951ffd1b6437fc5e19b1999e74096044514a46053fb
   md5: add2dfb15b518144663fc3b897d66da7
   depends:
@@ -9531,7 +9531,7 @@ packages:
   license: BSD-3-Clause
   size: 493391
   timestamp: 1652432364793
-- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
   sha256: 47653b45a5f2d97b5bf0dbf0e620908880f9078da427eef69012effe3f19af67
   md5: 44e709ae67d89bccee2d4d46d358fee3
   depends:
@@ -9542,7 +9542,7 @@ packages:
   license_family: MIT
   size: 74493
   timestamp: 1699012356534
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
   sha256: d7bcba5262df162756885a773c3bf2dace27311bbbb1830a0f97aa60ac7c1239
   md5: daeb99ccfe39f725278203412aac0873
   depends:
@@ -9558,7 +9558,7 @@ packages:
   license_family: Apache
   size: 120468
   timestamp: 1707355917958
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
   sha256: d6daaa6b45272819176e4aeb467ae00e3db43386548464a9993688f292709d40
   md5: 9fe721d7f7420c259df4f07d4503f654
   depends:
@@ -9568,7 +9568,7 @@ packages:
   license_family: MIT
   size: 9683
   timestamp: 1683077110211
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
   sha256: 6051860575f9448aea5799d74469c928cd7cdeeca1eb53657872262a77b1a7a8
   md5: 60e193eca497130034facd5fed168249
   depends:
@@ -9577,7 +9577,7 @@ packages:
   license_family: MIT
   size: 10094
   timestamp: 1683059114376
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
   sha256: ecd310461c1b45ab92ddf15539cea5a6e837860561c974d2d7393f9a7933f116
   md5: 1762fec2838763e904141167e18b0389
   depends:
@@ -9588,7 +9588,7 @@ packages:
   license_family: MIT
   size: 215600
   timestamp: 1698947891859
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.4-py311hc1ccb85_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/scipy-1.11.4-py311hc1ccb85_0.tar.bz2
   sha256: 70535bcdff9735b337047dfa90f6217c3bac195d7540943a5ce52585dd397687
   md5: 2fb9d23bf1492486d8fe8ad2edf50a3a
   depends:
@@ -9606,7 +9606,7 @@ packages:
   license_family: BSD
   size: 24536956
   timestamp: 1701301327353
-- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
   sha256: 6fd52bae6360fbc8135d72e0c1e4fd407769fa4d0f4b59356e7aed3e000eb339
   md5: 49fd52885250da8aab17ed72e2e18b81
   depends:
@@ -9615,7 +9615,7 @@ packages:
   license_family: BSD
   size: 88901
   timestamp: 1699371435766
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.2.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-68.2.2-py311haa95532_0.tar.bz2
   sha256: dd535d42d7acccdbb7047b82c7cdfa2ea1570198ab691d93f5959ab80d1dcf40
   md5: 9d5ff220ecf2631d397d9ffda8f12e40
   depends:
@@ -9624,7 +9624,7 @@ packages:
   license_family: MIT
   size: 1457756
   timestamp: 1702328037082
-- conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.1.10-h6c2663c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/snappy-1.1.10-h6c2663c_1.tar.bz2
   sha256: 7555e0d33dc29191da0f311d9e6112ddf0c200bbafe5cde89015d524dce84a72
   md5: 54bc73a36ca51e06733d9d42f23e2ea4
   depends:
@@ -9634,7 +9634,7 @@ packages:
   license_family: BSD
   size: 100857
   timestamp: 1702909533553
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
   sha256: 5d1b7e14dc04816692de0f8518ea8fcbefb26ab61cec83f96f2c44c1bee67fab
   md5: 505d2a70a875b5082dc857aa4dfab0d4
   depends:
@@ -9643,7 +9643,7 @@ packages:
   license_family: Other
   size: 18830
   timestamp: 1705431395254
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
   sha256: 5ff3b4ac3fbce4dd67a87856c04698d0397deb0ac288ff4e7eb02fbab57f1253
   md5: 0ca650a7001c6650809d3361de8cb005
   depends:
@@ -9652,7 +9652,7 @@ packages:
   license_family: MIT
   size: 89590
   timestamp: 1696347858925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/spatialpandas-0.4.10-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/spatialpandas-0.4.10-py311haa95532_0.tar.bz2
   sha256: 631471c767af7d400cc8ce11aa4f24d2fd3212ffe543f36465c0821854470649
   md5: 2ed16fdda5f786936c3cc8fdc2cc412a
   depends:
@@ -9668,7 +9668,7 @@ packages:
   license_family: BSD
   size: 200448
   timestamp: 1705085489563
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
   sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
   md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
   depends:
@@ -9678,7 +9678,7 @@ packages:
   license_family: Other
   size: 1311308
   timestamp: 1681402905668
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -9688,7 +9688,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
   sha256: 78d89b50a29fbeb19a562f5dad95615e3f192bb4f3b86cd6ea75f2f825418232
   md5: 4a4040df560ea47704e0898c4c015808
   depends:
@@ -9699,7 +9699,7 @@ packages:
   license_family: BSD
   size: 38069
   timestamp: 1678228553220
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
   sha256: 70a3cc4a4e81a6421bc19cd410d1d6064aadb2b1cce38b020f85e5346716d8e7
   md5: 32a9a2539579a3d522dce3b5cb4f987b
   depends:
@@ -9709,7 +9709,7 @@ packages:
   license_family: BSD
   size: 49495
   timestamp: 1676425411739
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
   sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
   md5: 52cdcdb96383c010ca833a7c24b3935b
   depends:
@@ -9719,7 +9719,7 @@ packages:
   license_family: BSD
   size: 3690152
   timestamp: 1654036853710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
   sha256: ed5950ac0c12cc87f991a6f28112cf29057e2b7ad416ae4429a0b97c3efaf58c
   md5: b5e2a04879e6fd19f0eb5effded4dc61
   depends:
@@ -9728,7 +9728,7 @@ packages:
   license_family: BSD
   size: 135939
   timestamp: 1676431438808
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
   sha256: 4febf30c11674711b86c8c10da46a5e1613071388da999210912a31508864add
   md5: 1c109fc1112ea1f5f377bdf0d18ba75f
   depends:
@@ -9739,7 +9739,7 @@ packages:
   license_family: Apache
   size: 895633
   timestamp: 1696937216859
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py311h746a85d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py311h746a85d_0.tar.bz2
   sha256: 2020add9f7607ecefd9628c1c1fa2e7349c0498e4926da842e662dba5fb99e1e
   md5: af51b3b92896b4fa3bf89df021009eda
   depends:
@@ -9753,7 +9753,7 @@ packages:
   license_family: MOZILLA
   size: 171971
   timestamp: 1679562109474
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
   sha256: e8c77efe880546252f244f995cbed5967809555127b4f818b97455d434b23415
   md5: 7397ac07045115960ebd8dec95326a7a
   depends:
@@ -9762,7 +9762,7 @@ packages:
   license_family: BSD
   size: 270819
   timestamp: 1676423321499
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.9.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.9.0-py311haa95532_1.tar.bz2
   sha256: ae7b4d80613eee90d2a9d86a099327c81606cde33700e476402407f1a206362c
   md5: d7326551a9f54853015af81861222d5f
   depends:
@@ -9772,7 +9772,7 @@ packages:
   license_family: PSF
   size: 9651
   timestamp: 1705599444849
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.9.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.9.0-py311haa95532_1.tar.bz2
   sha256: 1900ee02288c0abdaa44f34bccafc34691a59069330b0fc0c0922b4b4621b786
   md5: 0b94ee0b1e2488c3840a348d7d97aca2
   depends:
@@ -9781,7 +9781,7 @@ packages:
   license_family: PSF
   size: 71708
   timestamp: 1705599429360
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
   sha256: d091897f05318c22ca31028370f25355065999078f7db6f88ab27bf4cb030ec8
   md5: 1776502c1cfb351554eeda6cddaf255f
   depends:
@@ -9790,7 +9790,7 @@ packages:
   license_family: MIT
   size: 11588
   timestamp: 1676457729096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.1.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-2.1.0-py311haa95532_1.tar.bz2
   sha256: 75e984e5015c5fee121159768fc92653d58303e983450308f8efee40382cc6f7
   md5: bcaf27d1ba712299ee395d7cb0d4852b
   depends:
@@ -9805,7 +9805,7 @@ packages:
   license_family: MIT
   size: 184432
   timestamp: 1707770951801
-- conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
   sha256: 2ef16d0252e04063d44d0683831d55b485f713fe5af2c2efd61753fb4f27d7e4
   md5: 256ab1d5dce70111a1f4807a5a9fc322
   depends:
@@ -9815,7 +9815,7 @@ packages:
   license_family: MIT
   size: 100982
   timestamp: 1706894771410
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
   sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
   md5: 45ef24c486a484f079faf1dc90e4c7e9
   depends:
@@ -9824,12 +9824,12 @@ packages:
   license_family: BSD
   size: 8277
   timestamp: 1605602889180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
   sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
   md5: 4daaceb6cfc1af6274509081d8018ef1
   size: 2316783
   timestamp: 1605602872095
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
   sha256: 24ea3d3e0cb98d0d246338dbb4562b67967bb32002e3704e495a5c863476e831
   md5: c7b9cdbe87b3c9720aeca1164a0fd6df
   depends:
@@ -9838,7 +9838,7 @@ packages:
   license_family: BSD
   size: 26181
   timestamp: 1676424437003
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py311haa95532_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py311haa95532_4.tar.bz2
   sha256: 4008652f05783c7c1ac31fb5b8cf36899c3380b24e82996c6fd44f7b6aca1278
   md5: dd85600927df8322040c4998a114b567
   depends:
@@ -9848,7 +9848,7 @@ packages:
   license_family: BSD
   size: 94482
   timestamp: 1676426093953
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py311haa95532_0.tar.bz2
   sha256: 0c4a64027b1bc400a86a51b048f097c33080d7a35f898c1ae8753799d505f4cf
   md5: e65f8ba947e678d66a8a9bd18e332e04
   depends:
@@ -9857,7 +9857,7 @@ packages:
   license_family: MIT
   size: 154572
   timestamp: 1695742144881
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
   sha256: 17fadf35aa8917c107e7b369e9364ac7c09537776e7943d37e225e14b7026c94
   md5: 0e67c3b9624540581b894b11267a837b
   depends:
@@ -9865,13 +9865,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 10197
   timestamp: 1676425485716
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
   sha256: 25373efabba9a866849fe38a47c79e0fa323851b4bd4b5df357cc8d5617c2786
   md5: a958e9d32c3b65c21e11e5d9e8491c43
   depends:
@@ -9883,7 +9883,7 @@ packages:
   license_family: Apache
   size: 2467966
   timestamp: 1689041676824
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
   sha256: b849b368e27920838fe40a512b102879693a55cb187dd1c8d3a83fa8c05a8054
   md5: 7b1f6e9c71906a93039b3446b99a5498
   depends:
@@ -9892,7 +9892,7 @@ packages:
   license_family: BSD
   size: 55114
   timestamp: 1676434863173
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_0.tar.bz2
   sha256: 74c3575a7b72b952797c7c775522d8cf329fe06ec6b6949f45253e40c3f188cf
   md5: 76e728c35d284bfce7867c48d7046cc9
   depends:
@@ -9902,7 +9902,7 @@ packages:
   license_family: GPL2
   size: 1380439
   timestamp: 1709046669590
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -9911,7 +9911,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
   sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
   md5: e5aed81295b61b6d1eb62830799a0297
   depends:
@@ -9922,7 +9922,7 @@ packages:
   license_family: Other
   size: 9125184
   timestamp: 1705602328351
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
   sha256: d932439798665be388bbf68f3d68da5b42ed4753a43587d3f49848a85f58add4
   md5: e2900345674e644e05540ffac6acca89
   depends:
@@ -9931,7 +9931,7 @@ packages:
   license_family: MIT
   size: 25247
   timestamp: 1704207149955
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
   sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
   md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
   depends:
@@ -9941,7 +9941,7 @@ packages:
   license_family: Other
   size: 148931
   timestamp: 1666595229032
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
   sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
   md5: 8d6a1e767775fe0eb617cd6e22edc2ff
   depends:

--- a/glaciers/pixi.lock
+++ b/glaciers/pixi.lock
@@ -1,0 +1,9956 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-14.0.2-h374c478_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/async-lru-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.10.55-h721c034_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/babel-2.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.3.4-py311h92b7b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.12.12-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.16.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/grpc-cpp-1.48.2-he1ff14a_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.9.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter-lsp-2.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-8.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab-4.0.11-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_server-2.25.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.5.0-h251f7ec_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-hdbd6064_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.0-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-7.0.8-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.59.0-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.1.4-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.3.8-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.0.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.2.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-14.0.2-py311hb6e97c4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.8-h955ad1f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-25.1.2-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.11.4-py311h08b1b3b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.1.10-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/spatialpandas-0.4.10-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py311h92b7b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.1.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py311h06a4308_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/abseil-cpp-20230802.0-h61975a4_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-14.0.2-h3ade35f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/async-lru-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.10.55-h61975a4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/babel-2.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.4-py311h85bffb1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.12.12-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.16.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/grpc-cpp-1.48.2-hbe2b35a_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gtest-1.14.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.9.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter-lsp-2.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-8.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab-4.0.11-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_server-2.25.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.5.0-hf20ceda_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-h04015c4_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py311h41a4f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-7.0.8-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.59.0-py311hdb55bb0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-1.7.4-h995b336_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.4-py311hdb55bb0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.8-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.2.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-14.0.2-py311h2a249a5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.8-hf27a42d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-25.1.2-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.4-py311h224febf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.1.10-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/spatialpandas-0.4.10-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py311h85bffb1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.1.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py311hecd8cb5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/abseil-cpp-20230802.0-h313beb8_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-14.0.2-hc7aafb3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/async-lru-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.10.55-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/babel-2.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.4-py311hb6e6a13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.12.12-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.16.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpc-cpp-1.48.2-hc60591f_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gtest-1.14.0-h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.9.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter-lsp-2.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-8.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab-4.0.11-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_server-2.25.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.5.0-h3e2b118_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h02f6b3c_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-7.0.8-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.59.0-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.4-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.8-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.2.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-14.0.2-py311ha07b5f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.8-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-25.1.2-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.4-py311hc76d9b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.1.10-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/spatialpandas-0.4.10-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py311hb6e6a13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.1.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py311hca03da5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-14.0.2-ha81ea56_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/async-lru-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.10.55-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/babel-2.11.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.4-py311h746a85d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.12.12-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.11.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.16.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/grpc-cpp-1.48.2-hfe90ff0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.9.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter-lsp-2.2.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-8.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab-4.0.11-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_server-2.25.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.5.0-h86230a5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-he2ea4bf_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py311hf62ec03_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-7.0.8-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.59.0-py311hf62ec03_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.4-py311hf62ec03_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.8-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.2.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-14.0.2-py311h847bd2a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.8-he1021f5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-25.1.2-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.4-py311hc1ccb85_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.2.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.1.10-h6c2663c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/spatialpandas-0.4.10-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py311h746a85d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.9.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.9.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.1.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py311haa95532_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+  sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
+  md5: 613805add1c05b538ff06d217252feb7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 20810
+  timestamp: 1652859733309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
+  sha256: 8762f481244fb151a200f01dd70e69c77171a3ee0f7f4c130e8e95b6a1626a68
+  md5: c3707fcd2efa582afc5c7e1986c6ce48
+  depends:
+  - libgcc-ng >=8.4.0
+  - libstdcxx-ng >=8.4.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1135866
+  timestamp: 1652382888447
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+  sha256: 250f50edf43a786a32942e9ae67ce807e9b3ac4cb6b58b1170cb541fb24e391f
+  md5: b48058294499d292ddf9a3b966dc9cc5
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 228473
+  timestamp: 1706220559474
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+  sha256: 0d4f5274503916e1c683dcc16e8a7c4186557afa3f62399cd628e4eb535fe77a
+  md5: 062acdb0f9ae976c25c2d15d589dc1d6
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 35809
+  timestamp: 1676823571351
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-14.0.2-h374c478_1.tar.bz2
+  sha256: df890b7a4a677687ad7964182735e2eaf433d6066e346d9878ba90788e3d468f
+  md5: 96e5995c1fe9e067faed3e61c416f54f
+  depends:
+  - abseil-cpp >=20211102.0,<20211102.1.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - aws-sdk-cpp >=1.10.55,<1.10.56.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags
+  - glog >=0.5.0,<0.6.0a0
+  - grpc-cpp >=1.48.2,<1.49.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libgcc-ng >=11.2.0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libstdcxx-ng >=11.2.0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.13,<4.0a0
+  - orc >=1.7.4,<1.7.5.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.9,<2.0a0
+  - utf8proc >=2.6.1,<2.9.0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 13402790
+  timestamp: 1707254138477
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/async-lru-2.0.4-py311h06a4308_0.tar.bz2
+  sha256: f798d8239a172da4d1b2e5e6e43ee466f303f08d62f920f35cfdd4cbd5d4b171
+  md5: 9721c4818b5eea1649443059b488209b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 20540
+  timestamp: 1699554588481
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+  sha256: 567dfdd5b986012421a736a5f1c1d5874d8d691dd483c838b55e1ab06c0b217d
+  md5: 4e0aa1543f546b898523382ee8405e84
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 152577
+  timestamp: 1695717917074
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
+  sha256: 432e4fb45ae24789afdaeca800862aad03f8ebed5af908f01eed2a09283915e5
+  md5: a88c0e111e1f47ee83f1b6f329a149ef
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 97643
+  timestamp: 1706746168671
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
+  sha256: edb54d1554aefb65ff5a3969085dd8695e1e3218a2987ac30a96901f0bbf887a
+  md5: 5f131e63f8d80f2b7ac505054204a9e3
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.12,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 44722
+  timestamp: 1706690912333
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
+  sha256: 2afbfb546992e5954748d039ea15405f99018f6de78ec2f32bc7ff9bfc428a9c
+  md5: 489017af35cf8bdb976e6fef020a4ac7
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 202658
+  timestamp: 1706189913451
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
+  sha256: 5f81f5a3ea27bd29bf32a6987290de8c7b2da6612676aa8e606a7003519cbf47
+  md5: c11e7ceff3ca45bf580d1c944d93bd1f
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 17839
+  timestamp: 1706690843204
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
+  sha256: 348ced323311d36344a0fa9e88d299b361bad1f628dfbdd34bcea8662b3ab44b
+  md5: 19a11cdc9727c5981d96983a29b93ce4
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52025
+  timestamp: 1706697274091
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
+  sha256: 14e2843a218cb01bfc499a22537eb345f6e222b8496cfda2050c73ad98f09cda
+  md5: 44cba75d1bb5122aeadcaf8bb7da5e2a
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-compression >=0.2.16,<0.2.17.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 192985
+  timestamp: 1706744140260
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
+  sha256: a0f6916d60c0e1bac6ba548bf05a491b8db048a94e13da2f1cfa51b4ca879fb8
+  md5: 1f010db4f5ef1b3d705ee04dd1d473c9
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  - s2n >=1.3.27,<1.3.28.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 143623
+  timestamp: 1706696185335
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
+  sha256: 596945a39d772056e57bb357202a17e02508f2594da9c00e00ad767b8213e998
+  md5: 98cccbcc56a28ec7339e393816f4bdf7
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 70139
+  timestamp: 1706746744249
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
+  sha256: 12bf86ab848e3311f4eed4e93734a84064dc84580ad6dd4bb823b4ab6ef09698
+  md5: 4a8c2dcf0ede655609a9fc5632a5227b
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.12,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 74700
+  timestamp: 1706747582638
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
+  sha256: f05ce64fee77518a6deb45f187fcee415328e90ea8f2bf6031bd5b8273a1028f
+  md5: b8ebb4b892d9b80d513b4ca62a8d6de2
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 53042
+  timestamp: 1706690818718
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
+  sha256: 52bb367fc367ee3923353927226299a2b8b1be6a1993c11e19b20cafe6c6db0f
+  md5: 4715508fd5f8b39e902cb2afebc13c93
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52138
+  timestamp: 1706192048702
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
+  sha256: 0d13fbdace8ab4fbfcc015cf83bead69560a3dfadc6e0ce8441001629d725834
+  md5: a02c72bff71848705e70cd6f075a28f3
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
+  - aws-c-s3 >=0.1.51,<0.1.52.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 211559
+  timestamp: 1706827608038
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.10.55-h721c034_0.tar.bz2
+  sha256: a489d946a0a70a4d31f5da9fdf38e2c0ba8122e1df4fc716961b5b02d7617dbe
+  md5: f29f551a4e61c4d8339710ba000c6da8
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.12,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2815192
+  timestamp: 1706890558504
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/babel-2.11.0-py311h06a4308_0.tar.bz2
+  sha256: 8da2bfb50812660c69643386afa2a2d0ce9f2b0168e9b7a372349901d7d4b2f7
+  md5: d0cde1ca577520a608da5ab86421f9aa
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pytz >=2015.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7241236
+  timestamp: 1676825038806
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+  sha256: 894fceb5b4f8740bcd146de8bd0f6eabf14e2407b149b790b4983b8432681e6b
+  md5: 2f0ef211bf628cd22bbfa44c3f9bc035
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 271600
+  timestamp: 1681493103694
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.3.4-py311h92b7b1e_0.tar.bz2
+  sha256: 4a2cc7df4d70b7210617c937d5ff70118118c358ebfe8a1556b3760797fee677
+  md5: f8afc99a3bda5d35a807958a571d9314
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5947827
+  timestamp: 1706912367637
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+  sha256: 3606c8607c29229222667f66421f79df167d33043fe9245cdd4e2c4520ecc721
+  md5: eca33dcef14fa044193e43492dca8585
+  depends:
+  - libboost 1.82.0 h109eef0_2
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 10768
+  timestamp: 1696762269985
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+  sha256: 8e2b2073ff5c61d35714e8a36ce657a8ac741b7bedc2852a238c7f1625142705
+  md5: d951ab54a682b6328327fec53b1e5e72
+  depends:
+  - libgcc-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 147642
+  timestamp: 1707864274452
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 11df9b719339bb40e4af8eb124a094def217f64e2440af973d7342da19c030b0
+  md5: 712827b1699cc71e6240626c413408f3
+  depends:
+  - brotli-bin 1.0.9 h5eee18b_7
+  - libbrotlidec 1.0.9 h5eee18b_7
+  - libbrotlienc 1.0.9 h5eee18b_7
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 18907
+  timestamp: 1659616178155
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 6408b6849347ef01f5ed170f4b35fb4bdfed2d9cf9da4912a4b104a810518a80
+  md5: d9d570587ccfd7158b66feb823c990c6
+  depends:
+  - libbrotlidec 1.0.9 h5eee18b_7
+  - libbrotlienc 1.0.9 h5eee18b_7
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 19933
+  timestamp: 1659616170430
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_7.tar.bz2
+  sha256: 571346f89ad34b632322adfa4ed159bbf8977ad7308ccd0956c1bdf2c92a4c41
+  md5: c64bed33690b27399c697e2f0aaae8dc
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 360843
+  timestamp: 1676830217115
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_5.tar.bz2
+  sha256: f8b8221aa41ef3a18177a44ec397d6fea5ba4d5fc6586f2d1a685bb7eb2c4196
+  md5: b02d65d19a697e8a84045027f1808b31
+  depends:
+  - libgcc-ng >=11.2.0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 427268
+  timestamp: 1709103505611
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+  sha256: 5b4c80587ae4ec915505469f79d866f27c80456156667c8548d31c67c2c1653e
+  md5: c3d6bfae757760082261779c406a880d
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 116270
+  timestamp: 1693902021950
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.12.12-h06a4308_0.tar.bz2
+  sha256: 2f7e8c1f5acc49d1008e13d2dbf66d5462877471ba1020fe78e8323bcbee308d
+  md5: 78b3ba713700dac5e7ea2617e6d165d2
+  license: MPL-2.0
+  license_family: Other
+  size: 135757
+  timestamp: 1702903808756
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+  sha256: 6dc29d20180f6e002f37b251efa639716d3444e129a754dabf751f816aada7ef
+  md5: 5dbfa083e6ab6318fac58fe0e0c94445
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 165152
+  timestamp: 1707229213375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_0.tar.bz2
+  sha256: 03df3de5da8600074ef873a312a6a55acf4d95bcefa9639300e2a810422d52e3
+  md5: b4449b087c14709979812e47b3f9e8d8
+  depends:
+  - libffi >=3.4,<3.5
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 302422
+  timestamp: 1700254453506
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+  sha256: 9ddbf05887c7d7926418520cc7848e57f6d2431bc4ec6d30e090b02dbf865041
+  md5: 57ae1141ad9a048fb2a75d7a3ef7430a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203190
+  timestamp: 1698129926216
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
+  sha256: a5beda842876d0d71598cd2a50ced5fb2731539bc4172fe501b93b60e0c6cd3f
+  md5: d5293e5fe74a4e0d71bbf14c9a57f900
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49509
+  timestamp: 1683040113536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py311h06a4308_0.tar.bz2
+  sha256: 6ec0e7033905bcb379a798486abd1962fca23c31f6a07db206ddc5aa78095573
+  md5: b276060ab29889c1055c68be83a31f66
+  depends:
+  - pyct >=0.4.4
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1982585
+  timestamp: 1676839188918
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py311h06a4308_0.tar.bz2
+  sha256: fcd93d0f515f326a67a4967fbf35b3cd916716f4022851c166101c8ba3277a54
+  md5: e0631ec02ad9afd01a077509fde68b1b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14821
+  timestamp: 1677709155428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+  sha256: e4877b41553e31b9f9f090dffab77a654255c63776e8b30fc91ec1f60afadbf1
+  md5: c34d3f1520f1e8c9957eb236710058c4
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281162
+  timestamp: 1700583651472
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.11.0-py311h06a4308_0.tar.bz2
+  sha256: edc245960b92d491dc5bb03992ac344e206f094928dde23f814f6436b5781ac1
+  md5: 043e5bb51e65e9a64ce9d3e56b10de63
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3024310
+  timestamp: 1701396195636
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.16.0-py311h06a4308_0.tar.bz2
+  sha256: 309e8323cc5e7506a2be851649d36be0b6a0e157194baf6ee4fc900a1b43fddd
+  md5: c938e7730d42d87dba1658a8893d6338
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy <2.0a0
+  - pandas <3.0.0
+  - param
+  - pillow
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18004747
+  timestamp: 1699543167034
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+  sha256: 3b4cd8dc60572086f1a1cbb97e2712e0ffd55317ce8f0309d552eee7367855eb
+  md5: 70a1263b6e19bf2d77c020a2e77277c9
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2556575
+  timestamp: 1690905285843
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+  sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
+  md5: a5dc8677d891dff2393b63189a3ad42f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 971975
+  timestamp: 1666798278693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.10.0-py311h06a4308_0.tar.bz2
+  sha256: d5ed98698d800033bc70eb3633f77327fbdf112fc75ba68b1b90693b8f376575
+  md5: a145e4f64de83d744d152fc1d921801b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 351684
+  timestamp: 1701286605635
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+  sha256: 2fc1136056f41fe92de719fb821550346704965dd12a5fa35069cdb4948d5c17
+  md5: fd089b0fba2b03aafe3adb6cdaa9ac3b
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203421
+  timestamp: 1706888218007
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+  sha256: f1e190d4ee766add8131a2b011723c472284de2bbb5e07c8f895f30e3c591df7
+  md5: 82029e0758feac811afec2a6ef9e6155
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 108438
+  timestamp: 1706895276199
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/grpc-cpp-1.48.2-he1ff14a_1.tar.bz2
+  sha256: 32657e2d11dd813e5649f714c7f58115cff3387f27cf0904cee873bd0d82d2a4
+  md5: bdfb8214247977e4ededa4aeb3291ea3
+  depends:
+  - abseil-cpp >=20211102.0,<20211102.1.0a0
+  - c-ares >=1.19.0,<2.0a0
+  - libgcc-ng >=11.2.0
+  - libprotobuf >=3.20.3,<3.20.4.0a0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libstdcxx-ng >=11.2.0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5391101
+  timestamp: 1685747457305
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
+  sha256: f48ccfb4214e2af41e73a3904e343ecd1eb1ae06578c26f55a5dd247771b2c86
+  md5: d58e9eb09817935eb7342ceff889f481
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5335524
+  timestamp: 1707836581350
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.9.2-py311h06a4308_0.tar.bz2
+  sha256: c57aadceaadbc1e6e93500577f9c9f6a5bc0cbb63cb769f5dbd20459f8bd9784
+  md5: ec35a1d07f175727de6679fdf32ff454
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1978054
+  timestamp: 1706712503802
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+  sha256: b35b281dbf69b826c6ae04fcd7b6a2d1f098277a669a199906a1f23b4b0931a5
+  md5: 2a793fe24f85aa5819fe69c450cba6f7
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 29021241
+  timestamp: 1692293243228
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py311h06a4308_0.tar.bz2
+  sha256: 1b65cda7fbe1e9300a5aa96c6098788f61d4389fc5bdc2beab12d27ac62102a9
+  md5: c4aa1c5005412821f81fa13e4cd78514
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123676
+  timestamp: 1676822710633
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+  sha256: c7ffa6006573483a05ef355770c3201f04dd04ab4b91ae01971a6cdc7fbdba35
+  md5: 23d7d38e93d930ea5e2cc5f4079d3816
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 49872
+  timestamp: 1704813633807
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+  sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
+  md5: 3add2ce56858a1b8f6a37342f82773d3
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<1.2.14
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 19310769
+  timestamp: 1699647799237
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+  sha256: 0b670ab17ed2e1b592079bd64386dadc249ddc892e5ae1dd99f142a918ffc75d
+  md5: 632575b9e442c1e5c146cf78424da610
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 227791
+  timestamp: 1705934138566
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+  sha256: 65228eb868c3ec8aa71f958e60a675a919f016c2057392e02fd422fc841858f9
+  md5: 68e23f14cd222c233e6b37262bc61c23
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1612840
+  timestamp: 1704833066871
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+  sha256: a2918ea8a3e2c56fc6d91191e84b2f35500c392b16ab687a0c03ded2e2e51239
+  md5: 84fadd6b7fef393cccc0d123dae6cae8
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1162207
+  timestamp: 1679336523618
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
+  sha256: 4520b83e425883981f97191986a08122fbaebc3f16b898368796314136779028
+  md5: 42a8f32c4d842d3e5410b2bc1cc2fb57
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 352284
+  timestamp: 1706733655761
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+  sha256: c21f8f407266d039e819c27fe9eb4fb26587e974f3bd059b37cbaec5073722d0
+  md5: ba1f47411e9e07876c7a3e9d3be6a98e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: IJG
+  license_family: Other
+  size: 281400
+  timestamp: 1677849152168
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+  sha256: 06b729aee6dd2a1e545f3ad64179cc0d4ef8a15e33db3be2995dd3e0868465ca
+  md5: 8bb3215912588e47e2eeb4e7a09ad64f
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 180858
+  timestamp: 1699041715847
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+  sha256: 9e3bac2d41bd432b721b009e7de981766fba396e6f238e923f304112bd88655a
+  md5: 84ae4cf3f2d01fbebdac374971192be9
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 15525
+  timestamp: 1699032521315
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter-lsp-2.2.0-py311h06a4308_0.tar.bz2
+  sha256: c4b1dcb8ba34bfb2c7fc6ccf1399dd0bd2a324e792eac722561607f2bff68d72
+  md5: d82f26a5c414b519c7737240fb7f342e
+  depends:
+  - jupyter_server >=1.1.2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100413
+  timestamp: 1699978354251
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-8.6.0-py311h06a4308_0.tar.bz2
+  sha256: d215948faad1eff39b5bec3da793d6d185b85793a1d839c3d1c196b85fd6c9b1
+  md5: 555ea509581f49256e7aae2ff5dce460
+  depends:
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 221658
+  timestamp: 1699456577818
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+  sha256: fedc7e5560252af44b0dfbe6f7acfe20ab17a6a08e758f670a1cd820551afc7a
+  md5: bd28d36963087f53a79b23fee697d665
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 93898
+  timestamp: 1698937453304
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+  sha256: 2b896fe8b2187b7df824041826e14379476eb2e61d607d8cb38ac2b3df40aaa4
+  md5: 8fc7e517da96c2c482331f6b08d07a17
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41459
+  timestamp: 1699282616532
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+  sha256: 87d372f5b23bcc2410e43b40b4ad059ea1625178b8a2b484fc63805ce517e594
+  md5: 50204f372b1672871d6ab3db6a876374
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 594177
+  timestamp: 1699467208489
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+  sha256: ddfee06ba9b149222c65d1d4270272840533aa63b56fe36363c84a891c71d328
+  md5: ee128e5c0d8d9e1952e2387b66a5b8cb
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27239
+  timestamp: 1686870958829
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab-4.0.11-py311h06a4308_0.tar.bz2
+  sha256: a2bc9b312a31e5abaedf230659ecb31f9483a1a3c0f4cd1adae7f5ea2045f9d6
+  md5: 728bdb3c057e57cd963f304d2c8a48a9
+  depends:
+  - async-lru >=1.0.0
+  - ipykernel
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.19.0,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  - traitlets
+  constrains:
+  - nodejs >=18.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6665313
+  timestamp: 1706803269767
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_server-2.25.1-py311h06a4308_0.tar.bz2
+  sha256: b8c434bad4499fc41d0e18986b7ab1fbcf5e2aabadc2658430ee1f5cd16c4cbc
+  md5: 59a08c840ebfa765cfe5d4dc764804c7
+  depends:
+  - babel >=2.10
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18.0
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.11,<3.12.0a0
+  - requests >=2.31
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 106168
+  timestamp: 1699555585974
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+  sha256: b040f0d0ee4588188ab6b83a93738b3ff6e6d1775424be97995bd0df0f4fb904
+  md5: eae62735d710cf5ff6d51e6f59fcd999
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78148
+  timestamp: 1676827253282
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+  sha256: 01bae3dd44469e34f043e0416f5f5e658429bf4031745399d9968d10b899e2c4
+  md5: 10171cca67e3d73c3646c6dc5a321460
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.8,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1427115
+  timestamp: 1686931095252
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+  sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
+  md5: 88199c75f2ac211728febced7785c24e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 228278
+  timestamp: 1635523146417
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+  sha256: e2754627e8aeb98777318939e6773b9eadbdc219dd8961aca946354d9d30f481
+  md5: 4ed89646229bee3e594cd2cc8f6060f9
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 23778916
+  timestamp: 1696762223408
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 472cf888db65d00451fcd5fccd5244d55c061e8d7efe43f70220414ef64521a5
+  md5: 787927eff72e62c270f614cbcba9479c
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 67109
+  timestamp: 1659616145972
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 19a43182ca343510ba51baa0fce91d64c840a19cdf13c6dde4e03e819c70897e
+  md5: c0608d376a30b5aa4d2f2c22978135db
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_7
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 34691
+  timestamp: 1659616154057
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 158c401aa0bab05aa5f4134aea798085e4e3849209946f896cca352930d2225d
+  md5: cc6a6d362912a2d112310bd3f8acd44e
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_7
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 295287
+  timestamp: 1659616162282
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.5.0-h251f7ec_0.tar.bz2
+  sha256: 22628e28b6df8298b761c4524b086a02b0e9fe208cf37ec86090497c4db50583
+  md5: 7d328929de28a113f3e5b8e0d70ce709
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libgcc-ng >=11.2.0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.57.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=3.0.12,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 403919
+  timestamp: 1704383721246
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+  sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
+  md5: 55dde57e63a36b202e388a39dcee9a66
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 74096
+  timestamp: 1695996494461
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+  sha256: 5bd3af246b6a93ea0912179ae66e0ad9157ca0142263010d84b65724e6db0bec
+  md5: 5cb0cc0e1783419cf8fc1c65fee0f62f
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 195807
+  timestamp: 1703006263489
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+  sha256: efdab884c85fda4461f7a393aa6d4e0e50d03cb59fb9c8a980b1307b8379ebe0
+  md5: eeca774c6154c49340dd403b1928d5e9
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 108906
+  timestamp: 1632891483341
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+  sha256: 4b2518a1aa3859031a531cd1077e8a60d5b3a0dc7c83210ef27ff9ce2c78c3e3
+  md5: 49f152ee4045544c10799d32bba85c07
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 480247
+  timestamp: 1685052130829
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
+  sha256: ec1c6341cf0091b55be05285037cb3fbba90573e00257f383ab274d8b8e6d46f
+  md5: 32ac65d639d6c155ea7276cadf1fd2b6
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 147907
+  timestamp: 1683716564178
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
+  md5: 641e72e5067bd6d5454405879e1cd2a7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - _libgcc_mutex * main
+  - __glibc >=2.17
+  constrains:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - libgomp 11.2.0 h1234567_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 8895144
+  timestamp: 1654090827491
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+  sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
+  md5: 27082517590f3b9fbffecc68513b461b
+  depends:
+  - libgfortran5 11.2.0.*
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 19860
+  timestamp: 1654090819660
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+  sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
+  md5: 0202c3c8ae4735cac6c7f3d1e1685964
+  constrains:
+  - libgfortran-ng 11.2.0 *_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 5228750
+  timestamp: 1654090762569
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+  sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
+  md5: 3080c2813e6e1d0f8a100a38b5b3456d
+  depends:
+  - _libgcc_mutex 0.1 main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 573231
+  timestamp: 1654090775721
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+  sha256: 512fac06ddd97b4383503d4fbd8145102966055b29ccf86841a930dbb4ef3ab8
+  md5: 833c0e514ff9c8ae0511630b024d60e0
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 37179832
+  timestamp: 1683292829131
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+  sha256: 6c67d781d3c074ae46b18567f230bce4a4afa209e8b914dc2cb448502774886e
+  md5: c9627c386bbc8a1a1a0a2e736ea44501
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - c-ares >=1.7.5
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 722387
+  timestamp: 1697018420830
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+  sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
+  md5: 1bffe1481ed4f88827248fb9001f8923
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 362561
+  timestamp: 1677841789536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
+  sha256: a24f7d1cdb5e18466a61860a5a66baffd608e212bbfed2935350e83d4d8659c0
+  md5: b32a43de76bc9be9c71f9a12edec8a1e
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2706964
+  timestamp: 1675278653314
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-hdbd6064_2.tar.bz2
+  sha256: d011fe14e4b5752feb7f1d6b7c1a7913cb153f8759b4befdf53ed7a5d846cd52
+  md5: c29b0f58de6585e5220e10eb5ac2f9e2
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 311498
+  timestamp: 1686931236351
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
+  md5: 8c195584a5f5471b600ee180e4052773
+  depends:
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 6410287
+  timestamp: 1654090800863
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+  sha256: 974e4035c5d51cd41fa7a7f02fadc1980069c00526c1646fa18ea94e667fb137
+  md5: 188de945b4279a812953011e8c4580c2
+  depends:
+  - boost-cpp >=1.73
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.9,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4630795
+  timestamp: 1687975185557
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+  sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
+  md5: ef78eebd98289aceacdfa29182426adf
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 664034
+  timestamp: 1693575237924
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+  sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
+  md5: 292768ec77416ae257cfdd44ea2071c8
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29197
+  timestamp: 1668082729834
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+  sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
+  md5: 9cdeef1d044c7e035c006890f11569d3
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 436056
+  timestamp: 1694776944891
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+  sha256: fd8e30beb8c9442f16e6617fac92dd0c89ec823e98f06e60f712147380ead35f
+  md5: 7ed7caf2816c8b85b67b6f4e8833cbd5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41155
+  timestamp: 1676837080881
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
+  sha256: 05e355127db0d3ed67c4c383fd929ef1c3d7d3f19472f6e5433a866e94378bed
+  md5: b7897895622e5ab6e62279f07fa1f587
+  depends:
+  - libgcc-ng >=11.2.0
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4367002
+  timestamp: 1706910875807
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+  sha256: 95fe76d2691feb13203b55ad2aba535bb848cae21ffd05b13ff51c7a45fa2332
+  md5: 6a04ec16e3abc1c7e2104be32cd6c418
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13458
+  timestamp: 1676827287432
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
+  sha256: 36b23ab8d8aa22d70a2f733462cabe95e5b27ca919ec7a75a5592bc39c5f7d16
+  md5: f24adbfdfe16b0bac0d14640bb5ce616
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 163649
+  timestamp: 1670944701605
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+  sha256: 260e26dd509834c1b225ab7bdb97b9a86e00054fbdd5dfa49e68fa4dcf85a661
+  md5: 8f5d7ddc69cc6f7d44c80d2251dea5d1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162339
+  timestamp: 1676837095436
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+  sha256: 7f5b0804d0768619b7bd93b10488067d80bf42ec29f443f00b53ba11758a1241
+  md5: 8afb45e45c0d93bfd142e682d4b021ef
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 134438
+  timestamp: 1684280014220
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+  sha256: cb03570c99c983d7bfda94bc47d8eb00d4059b8548a171130775acc998004195
+  md5: 5b1abbbf1e4f9b350b16fc9caf9e889b
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26919
+  timestamp: 1704206397615
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.0-py311ha02d727_0.tar.bz2
+  sha256: 9efe8bfd1544ca9b3a42a7c5f287c6c23ad0d0211643a4a4ad43fbd6bb6473a0
+  md5: a3e9d32a5a23d979490d0ce20b8ef228
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.0.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9104983
+  timestamp: 1698692396617
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+  sha256: 7ac07ea180b5928086075900afbc332fb1d3c81ddfacb54c891693c284056f14
+  md5: fc83dd1b3d2ec3c0a297ead0c3405907
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19573
+  timestamp: 1676823852670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+  sha256: c9ba2f9c83820712dd97d6a1b54a1215b9820a0be02ac82380b4c50911b9400c
+  md5: e5dc6b4a5b8e02733ce3bc9e9198a8d2
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67750
+  timestamp: 1676837123613
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+  sha256: 1a5141ef0de1cbff816f96bb4b212a40606e2fc11301a4c1358c8d63a6b2b027
+  md5: 22ac3bc22b68fef4c1f3f6ab3c7bfe0b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23040
+  timestamp: 1676827301164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+  sha256: 9aacfbbe6f638c58a4e8ff31374d1438d78b7db25d6ea6fd0c50ca2109f225d4
+  md5: e602057e3b3d80da88c61d66e8851c5b
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104681
+  timestamp: 1676823696152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+  sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
+  md5: ce77d0f05f846da4a6b9e23fe7f21d9b
+  depends:
+  - intel-openmp 2023.*
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - tbb 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 206738176
+  timestamp: 1699648006088
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+  sha256: 2aef0876d0df033f7fae8cddbd25d95fc1bfc067e60dd143bd8000fec0768b21
+  md5: d6cdc670327bd1675bbea642849f04e1
+  depends:
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59569
+  timestamp: 1682948560323
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+  sha256: 691c4b2b47cf3fac55b4949d7c0f547246ef19cb3510749142cee4bd01ffb055
+  md5: bbd69efa3f24ee747410f83118640d92
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 240723
+  timestamp: 1695058405382
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+  sha256: 71f5c7beca4e81b465ecfc6ed51cb3d39f51dd88df0b29eff5def3d1f12969eb
+  md5: 61d58663b7277cf4cc3cb8d9873d3ee8
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331105
+  timestamp: 1695059935112
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+  sha256: b558b3f6c144652b5e0d26497b3ce24c318a6b9ff8ea2079113c95e5553b3cf9
+  md5: 0b185969ac2b065c27cbcc9641d93678
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29568
+  timestamp: 1676841232463
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+  sha256: bb45fb0a3973caa74fd8f845e0a519895f6a378807626e15ecf72c02f2eed794
+  md5: 185f658ba8a74e326b7231c8fd0d62bf
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 121834
+  timestamp: 1698934274227
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+  sha256: 8b2fc372a6655fd5b277d07b994ce43643553fbc37e63a60e9fe527a9026ec06
+  md5: ed6ac14aed5a796b153d757862398997
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 523905
+  timestamp: 1699022906468
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+  sha256: 7908ff6c516b15e8fb677be4071145e18adea7d4c13b8485a70a5ee2f573f8cb
+  md5: 50c0e38207a131a5de6a14ef919ffcdc
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 169629
+  timestamp: 1694616826002
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+  sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
+  md5: 57ea097dc15f8d9f9eb90e1d919143b0
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1157733
+  timestamp: 1674734069410
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+  sha256: 266199dd4efde0ad342a9c500f4bc4299c5622219aea623b46315a9b4f6b8959
+  md5: 2b21844d2b0024d0ffad0e6450cf0855
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 15860
+  timestamp: 1708532713870
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-7.0.8-py311h06a4308_0.tar.bz2
+  sha256: 59e17fc80ec01ffef983431d36b41013d1da575e03f5bc1ff36fc3b7e496e7be
+  md5: b4e5249538db1bc282ac0d0d8c4f307c
+  depends:
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab >=4.0.2,<4.1
+  - jupyterlab_server >=2.22.1,<3
+  - notebook-shim >=0.2,<0.3
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3650043
+  timestamp: 1708029938702
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+  sha256: ef2857e6d3d7eb246b3abddfbd3aa2d124dd8565391ace3876b77339babc50bb
+  md5: d276d1b1774107987963135c78ca7390
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26607
+  timestamp: 1699455972519
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.59.0-py311ha02d727_0.tar.bz2
+  sha256: 72d8bcdf6f7ef6019a65d19501e25e5240ceda3730393ca3a21a868cc65e6043
+  md5: 06bfdf47b0437d89981058907f297b89
+  depends:
+  - _openmp_mutex >=5.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - llvmlite >=0.42.0,<0.43.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  - libgomp
+  constrains:
+  - cuda-python >=11.6
+  - scipy >=1.0
+  - tbb >=2021.6,<2022
+  - numba-rvsdg 0.0.*
+  - libopenblas !=0.3.6
+  - cudatoolkit >=10.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6076268
+  timestamp: 1707087452201
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+  sha256: 2f89f38a665ece47e8868b391fc70602fcee588e989bc1ca6f17f6094892a94e
+  md5: b788c80b2d571531ea4f3f8335ae5423
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 168827
+  timestamp: 1696515597877
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+  sha256: e09e1aff2c12d4ef3fec58fb627744e4b5c7d9eaede7175e293f77272d8b8bfd
+  md5: fe8242cfd54d238507493612ae697ad4
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311hf175353_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10270
+  timestamp: 1708639794640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+  sha256: a53ad723826651041a5057a1cf31bc8689b24d335ce61b196df5124974b05a8e
+  md5: 7b29e7191c4170189d6080e61229f030
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311h08b1b3b_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9163911
+  timestamp: 1708639777712
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+  sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
+  md5: b0afe23033c8c5344640bc25225fa579
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 516994
+  timestamp: 1630084830020
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_0.tar.bz2
+  sha256: 71f97234bc7d69c59e4a3dd2eb7c0f983e2c21547695c42fa00579362372d528
+  md5: 40a571ff3839c015f034b51da60a69a1
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 5498847
+  timestamp: 1706908984217
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
+  sha256: 9618addfc1b940c048372ffb2c8500d4b44d02455a9bd1f411e530ed5e09b8d5
+  md5: 56057ed323f733bdcf262468682d0358
+  depends:
+  - libgcc-ng >=11.2.0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.9,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1132661
+  timestamp: 1676482768554
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+  sha256: 280225061aeba00d7b85f46e55d7d79cd92c92f662dc749d9c53187978e8d083
+  md5: c51c21da68080d89300703ad818c824a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38606
+  timestamp: 1699371264464
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py311h06a4308_0.tar.bz2
+  sha256: 8ea36ca391d340cb8e2a71674e192e25ad23d9b9b5c74270f626a4a3f56a1aef
+  md5: 1cdfac1a7c76d71d2a6830e4a84df79a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 93525
+  timestamp: 1693575262009
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.1.4-py311ha02d727_0.tar.bz2
+  sha256: 2af8bf52c2eff731ebee633ec5da325b58e113077098a3103a4223ff1bb162e9
+  md5: d46d81f25227a2a9e030a5e777d98d36
+  depends:
+  - bottleneck >=1.3.4
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numexpr >=2.8.0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - psycopg2 >=2.9.3
+  - pyqt >=5.15.6,<6
+  - zstandard >=0.17.0
+  - pyarrow >=7.0.0
+  - lxml >=4.8.0
+  - numba >=0.55.2
+  - openpyxl >=3.0.10
+  - jinja2 >=3.1.2
+  - pyreadstat >=1.1.5
+  - pyxlsb >=1.0.9
+  - matplotlib-base >=3.6.1
+  - fsspec >=2022.05.0
+  - qtpy >=2.2.0
+  - tabulate >=0.8.10
+  - xarray >=2022.03.0
+  - fastparquet >=0.8.1
+  - pytables >=3.7.0
+  - gcsfs >=2022.05.0
+  - dataframe-api-compat >=0.1.7
+  - blosc >=1.21.0
+  - pandas-gbq >=0.17.5
+  - scipy >=1.8.1
+  - odfpy>=1.4.1
+  - xlsxwriter >=3.0.3
+  - beautifulsoup4 >=4.11.1
+  - xlrd >=2.0.1
+  - sqlalchemy >=1.4.36
+  - pymysql >=1.0.2
+  - html5lib >=1.1
+  - s3fs >=2022.05.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16961688
+  timestamp: 1702321029603
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.3.8-py311h06a4308_0.tar.bz2
+  sha256: 9833c4d4247c8c320febb944aa1c42ea63479fb3c0334cbcc3f09718251c97b7
+  md5: 52c4ac82d18fc6c46136085443495071
+  depends:
+  - bleach
+  - bokeh >=3.2.0,<3.4
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.0.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.17.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18067488
+  timestamp: 1706540032944
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.0.2-py311h06a4308_0.tar.bz2
+  sha256: 3a7e48b56598b47e2da15be3d282b0360bcdf41ce022c15bb761b275426c9b0f
+  md5: 566774cbb1fad5e3131f337708d1c7c3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 254603
+  timestamp: 1705937840407
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+  sha256: a2e2beff710765f2e5135020121da4f227f5e1cbe142e17398a585f50a389d37
+  md5: eaf734d49b6e576e12be1398a295643a
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - pandas >=0.19.0
+  - numpy >= 1.9.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 47447
+  timestamp: 1698702703255
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.2.0-py311h5eee18b_0.tar.bz2
+  sha256: 32af5aaf90e864d7714e85a9eb0c84d4ebb863e595351664d7e7560cfe7a7fd9
+  md5: 83e90196712d58d9fd5f8b69843e5873
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 954430
+  timestamp: 1707233291841
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3.1-py311h06a4308_0.tar.bz2
+  sha256: 0bedd7decde6751a3efbb2367dd22d916b61391e334833d548b285fdd3420080
+  md5: aebee46c2eadf95ea8633847612f0f15
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3443056
+  timestamp: 1700667782149
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+  sha256: d2bbab8bfc57c7f46ca8994bc87df7e744d3f036b867bc4be1145ba6d8d7e091
+  md5: de41707272a8e3ccab764f0b7010a27d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37394
+  timestamp: 1692205565974
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+  sha256: e2a0e2a618aa33f0beff9583c7dc510b8d0737b023117346676aacbad33970d8
+  md5: 66a6818307261b1a28ab12d1b7776fdf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 121454
+  timestamp: 1679340540306
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+  sha256: b7f591c19b10bf0daa7e6e3b45a9f4a0a0e83188e1f8a58037caea79e60f8d91
+  md5: d945b4ccc135005839c504cc29df1745
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 749608
+  timestamp: 1704404477511
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+  sha256: 96482b49191fdac59580a95e69508367083e1f7600145e11d7c2db634337eb26
+  md5: 2d57bf8eacf3f291db845928241f724c
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 490805
+  timestamp: 1679337420563
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-14.0.2-py311hb6e97c4_0.tar.bz2
+  sha256: 252204d5e65480b83b9e31c63cecfaff95725ef5fc302714f92c344b7fdbafe3
+  md5: f2b86ab94d7af6c10b9586263b1b45df
+  depends:
+  - arrow-cpp >=14.0.2,<14.0.3.0a0
+  - boost-cpp
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 5423490
+  timestamp: 1707331892286
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+  sha256: eb75b4417565d25e2d1006db75aa8bd9da6b6c72a929954b01a31b9bf5f8b42e
+  md5: bb56c0358b65665f4dd509a4635f6f3c
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37802
+  timestamp: 1676838557935
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+  sha256: ed927e4d058a8f4ea73edc7a43ed74877d93b88fdfa240b3b2777244386ced70
+  md5: a1f0e05fc7e49712f81ad5478ec9d51e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2121496
+  timestamp: 1684280065800
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+  sha256: ad219924e362ce7af458fa6547660181579e9a50e5aed1ffd9268cbe7c2650e3
+  md5: 2b1ac40e0df3673d33b7f4c4f93ae1ef
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207338
+  timestamp: 1677811584327
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+  sha256: 114b55e00f4622c90fd2b404b21ad5f94a10283fcaaf86a42174b8d39b0a3e98
+  md5: 2458e92683cc68671a6c8e1b86ce8817
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35850
+  timestamp: 1676822725516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.8-h955ad1f_0.tar.bz2
+  sha256: 8bae0856b2f337f43cb5cbbf71ebf684ef47438210465b8733304d7d7f258559
+  md5: 7fa94ac6e31488660ca09b2896b9d96d
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.35.1
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.5,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 36090392
+  timestamp: 1708984519285
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+  sha256: aadc4078311c059265706a56265f0a57ceb538d36179d5203dd487d80d0e8f16
+  md5: 59ec670fcd172447dbd9591b8fbfdd56
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 278741
+  timestamp: 1679340144625
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+  sha256: d5058d0ecc3973316c1d5f1bfb03dd119e0dade85f4c2d21b412c8db4e1636f2
+  md5: 93000e4d3603342779a2afda66fa91b8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17607
+  timestamp: 1683823841946
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py311h06a4308_0.tar.bz2
+  sha256: b5f08fc0a119fc4bedef13130efb40f2d2af8cfb069b8eeaaaa97c99c7070cd7
+  md5: 765c02a2485efe5e6307e2d424d0eba0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 269196
+  timestamp: 1695131641771
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.0-py311h06a4308_0.tar.bz2
+  sha256: b3c50415b604cd6c4ac81a8d2f3ebb2b59cce09b2a4d2d83a6016e7d3fea169d
+  md5: cdf2f9462252bfa0137b7f1090dc5129
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 63656
+  timestamp: 1701728055800
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+  sha256: b2a1f649669f4336b74f6f20df711959bcd8024f8f8b94199dc0e040b06bd37a
+  md5: f9e8e3f7068f717f75e555dc04545d8d
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 206433
+  timestamp: 1698096204677
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-25.1.2-py311h6a678d5_0.tar.bz2
+  sha256: 787979e7e36b0eaf06c65f8840f3af969b6efa6ba2a7e2736b1bb52e96588242
+  md5: eb62cbfdbe25aaebbafad6166ec66903
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 583036
+  timestamp: 1705605396341
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+  sha256: 8a640736bef635346409582dbfe2b7d0ecc9da215c90173ff8a9a5fe22569107
+  md5: 6b583dce61c6feb352ef0f49f413af1e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-3-Clause
+  size: 235004
+  timestamp: 1652449537852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+  sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
+  md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 467661
+  timestamp: 1666648052561
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+  sha256: 89c2f4235277b9825cc805c5c44f0b1afcb683d7b5a3f513bc4bf243b643bb0c
+  md5: db70eb57e33adf7b8bbdadd72214d48d
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 73679
+  timestamp: 1699012111499
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
+  sha256: 684037527327839d734e7eac2ee09ef5ddb4f77df22daf40c79e51db29d09543
+  md5: 57c5bcb9eae9f1d93ccfd38025660de2
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 119414
+  timestamp: 1707355661872
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+  sha256: fdae3f68ea84b99561aee6c566ab1c287d8f2ae2668424e9283a8ed86af8f1d2
+  md5: cde5b71ccbb3630053340b2c8c7dbf10
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9333
+  timestamp: 1683077183576
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+  sha256: 0bf859b06a07857099fd4f524fe5e0875fda70029e9485d95c7efa97134fbc14
+  md5: fd5815cc592fdbd4c831901541eadaba
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 9735
+  timestamp: 1683059096795
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+  sha256: 474553d01aea57214a54a7443f227da84a58e29c49eb7605ba0043c55b7d167a
+  md5: f01333e9f0a908e435db650f42fbd2db
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1096668
+  timestamp: 1698946168635
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
+  sha256: 8c8aa1eb7e215984f46c8e1c7cfa6e5e6b233993d92b835a9b1b5491a4b970ab
+  md5: 6e145b179adde03f8aa8a066c58d4e31
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.12,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 380702
+  timestamp: 1706563445897
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.11.4-py311h08b1b3b_0.tar.bz2
+  sha256: 98d0cd31403b1cab3e4557619ef7aa7affa12e44e377f1f900f8edf10720a776
+  md5: a6b09c764e9edd584e434fe404943d98
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libgfortran-ng
+  - libgfortran5 >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<1.28
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25430724
+  timestamp: 1701296824601
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+  sha256: 51bcea0e575a626f6ffbd16d1153330fda93dbe3dd31dcd3a8f469ff61dd1e4e
+  md5: 41d531c90be8c82bf79635ff3d409476
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 32295
+  timestamp: 1699371262818
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.2.2-py311h06a4308_0.tar.bz2
+  sha256: 6b87a3d61effa58d79a2da505767a14b407a20ede434d23959351af267e7a2e8
+  md5: 86f5c1e109c9b35531a693b9c6f025b9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1450811
+  timestamp: 1702327568944
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.1.10-h6a678d5_1.tar.bz2
+  sha256: 15045902c5957ae0c8196ad7f1cecdadc7e6f5545f24f143339f488f063775f0
+  md5: 0b92bda0f6031b4f8fe9b4f1c0e55c06
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 48768
+  timestamp: 1702909413687
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+  sha256: 1a84b00944bc5588e14a097460175f97df49acb4f1ff2498ffd9a1893068ed81
+  md5: a456513471b2ecbed60430c21dd1ccc7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17880
+  timestamp: 1705431390054
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+  sha256: adcafd297d60af64107c113bb7b8b92160d0268a44ef9a3b79e56a88a0358ea7
+  md5: 28ed704ed26b06d32662e3a6a87e59b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 88799
+  timestamp: 1696347581401
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/spatialpandas-0.4.10-py311h06a4308_0.tar.bz2
+  sha256: 6088de9e451b3792c1697b8d70d12084f210749788e3469024942662e9bbc134
+  md5: 0c9f08bcbb2835cb43d240748b61f76c
+  depends:
+  - dask-core
+  - fsspec
+  - numba
+  - pandas
+  - param
+  - pyarrow >=1.0
+  - python >=3.11,<3.12.0a0
+  - retrying
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 199479
+  timestamp: 1705085105567
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
+  sha256: 8b45ba506984fe9c061b4acde6f5243d52dda8c1eae4992f8d80c03f425214fe
+  md5: 68c24a824d36a16bbb28d80d70cee8d2
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1640317
+  timestamp: 1681394746811
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+  sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
+  md5: 041a3caf09dc9ce8fc6c10925c4fe050
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1888016
+  timestamp: 1680167274961
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+  sha256: 856a8ab8c350c50247b79966c6cb80fb6d4de36eef49ddf75aebbbcaf854c82d
+  md5: 442dde204d14d171aab9ee40e8de4de8
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37456
+  timestamp: 1677696176157
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+  sha256: f0a026ddc0ed041bfc60c8a1ca0b70b7a69232775b3181bfb35a39fda42d6994
+  md5: 2902d5a5854865baaaf58dc59cf06b3c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49185
+  timestamp: 1676823769869
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+  sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
+  md5: 5b8375e2092012db69d2123dc0c68630
+  depends:
+  - libgcc-ng >=7.5.0
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3485432
+  timestamp: 1654088939579
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+  sha256: e58ff4a82819446f3c92e5b1aa2a784c4b06643e751fe67cf115858296dbfa50
+  md5: 32ee4723173f1fad5563b8afb5f1c8f1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135634
+  timestamp: 1676827536101
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+  sha256: 1bf522ade750cf0b70d61e71916ff00569e2908db1e9dedb223fda2608ed8bde
+  md5: 6793c74fe94211c0bfe6766c6dd490af
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 893808
+  timestamp: 1696937055591
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py311h92b7b1e_0.tar.bz2
+  sha256: 948846e5f3f49dba2e5d33b73deb0dc6db17656ffd3d5a55d35c3dcefea248d0
+  md5: a94778a1fa3ad0ce3774751f4786fe55
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  - requests
+  - slack-sdk
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 152015
+  timestamp: 1679562095911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+  sha256: 0575785f6553e61cc6138abfd5de52305fac6f85971642fa1f056a76c66a52b2
+  md5: f2c25e5dfdd23f70b83776a8832893cf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270865
+  timestamp: 1676823316868
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.9.0-py311h06a4308_1.tar.bz2
+  sha256: e0dbca6707368472ef0adfe498c024de7c9a56d9c6ff25ffe1449e8e95da89aa
+  md5: 570cf697aaefcaee710444daef8a11d1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.9.0 py311h06a4308_1
+  license: PSF-2.0
+  license_family: PSF
+  size: 8792
+  timestamp: 1705599472930
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.9.0-py311h06a4308_1.tar.bz2
+  sha256: da18ffdb0ef53142aeb5d964b8db1542c290eb328ae9fbdf96690750272bd8bc
+  md5: c6d716b2a8ae08f6e4039ea74d13b79f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 70729
+  timestamp: 1705599465726
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+  sha256: 509b962773f0fe44a93a7f6196b254670a030eac8ea7f90727312e3ccd9294b2
+  md5: 6c402d5bf4e01c8c3895c9ef41707b6e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11371
+  timestamp: 1676828901104
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.1.0-py311h06a4308_1.tar.bz2
+  sha256: a0b300e422e89ca84cd1ece98b796af3133c56279871fbf0198871c9edd3585e
+  md5: 5cdea1fde6548c3a82add475b39e60c2
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - zstandard >=0.18.0
+  - selenium >=4.4.3
+  - requests >=2.26.0
+  license: MIT
+  license_family: MIT
+  size: 183475
+  timestamp: 1707770592436
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+  sha256: a8d11b0f08217607b99ba560edf66423ca1e36f4ffbb6e2377e61670e2b5f36b
+  md5: 431e82b081b08aef0259df0437e04c75
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 97535
+  timestamp: 1706894675990
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+  sha256: c3a5e0b855dc2de6c162708dfcf170a23eb9e7525d4252d8dce553369af4a330
+  md5: a4c77e204b7787f820955166a1283168
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25890
+  timestamp: 1676823132898
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py311h06a4308_4.tar.bz2
+  sha256: 7b505fdb5d801adfb3032e2541bf9bf17ed2238764b7a53cb845e33e7f835faf
+  md5: 07dc61e2e59fe57a9bfe8efcbb23ffe6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 90518
+  timestamp: 1676824901641
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py311h06a4308_0.tar.bz2
+  sha256: 0384032ae4756c7ebcb0e52b9dbc21f4ef8a5d19fcc75909380ffe68bbecb46f
+  md5: 9a75092954c0c7c5cc61b9a6ff27cbc8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 134611
+  timestamp: 1695742011767
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+  sha256: 85248e503721da67797546cb8a22e303c1739100834b219c5621f216e3794e8d
+  md5: 2570956643f22d0f809b2467e02d3984
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2465865
+  timestamp: 1689041600364
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+  sha256: d18cdca154bf668826f869117ea996c4f9e8ef7d27b7c528332a7d17e5a8602c
+  md5: 9f7353d72046b16dd6ef6b5689ac9bfd
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54731
+  timestamp: 1676828934954
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_0.tar.bz2
+  sha256: 27f1a89843c5fb9306168df51c7b8114423ea5b8161334e01bb23feec56eb0cc
+  md5: 456c2ad05120ad4756f690c1144aa999
+  depends:
+  - libgcc-ng >=11.2.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 777889
+  timestamp: 1709046225704
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+  sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
+  md5: 943f1247a22b6b64171363bcee1eec27
+  depends:
+  - libgcc-ng >=11.2.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=11.2.0
+  license: MPL-2.0
+  license_family: Other
+  size: 371663
+  timestamp: 1705602144682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
+  sha256: 7aa781d0850f97622755ed44772d2b215b253a8e211aede5f3f53e1b95b4143a
+  md5: b1d8823f50228d4efb7b7a6e267ed776
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 24333
+  timestamp: 1704207043644
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
+  sha256: 2dc9150a95704d83efd39bb9dfb44bdf8419022f4fb0fc416380a922a27c130d
+  md5: 4f315d7551f4bbeb06b6fc28342a9aa5
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Zlib
+  license_family: Other
+  size: 127528
+  timestamp: 1666595012798
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
+  sha256: aa6aa291bec6aa66e1f063cfa75a9e0fc6bd459fcb45c372aacac9006a073900
+  md5: 4e99328768f538f33aecebdae9472744
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1055426
+  timestamp: 1681304602537
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
+  md5: 544adf2677c47c9b9c891aea720678f1
+  depends:
+  - python >=3.5
+  license: MIT
+  size: 33999
+  timestamp: 1630003259346
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+  sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
+  md5: 9eff1a842dbda8d1bae9a2c008b599bc
+  depends:
+  - brotli >=1.0.1
+  - munkres
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 690443
+  timestamp: 1625743217109
+- conda: https://repo.anaconda.com/pkgs/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
+  sha256: 6db7265c2238c6e5b4c98906498c47af341238b5d5a9baee383777181f421366
+  md5: 91e3336204a0ea3951957d7d5e8f3e26
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 21503
+  timestamp: 1624432813739
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+  sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
+  md5: 33624a42ee387bf9918ea98b4e7b31fc
+  depends:
+  - pygments >=2.4.1,<3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8173
+  timestamp: 1601490751973
+- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+  sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
+  md5: 67857cc5e9044770d2b15f9d94a4521d
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12810
+  timestamp: 1600445183315
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+  sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
+  md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
+  depends:
+  - prompt-toolkit >=3.0.43,<3.0.44.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5106
+  timestamp: 1704404390460
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
+  md5: 2eb923cc014094f4acf7f849d67d73f8
+  depends:
+  - python
+  - six >=1.5
+  license: BSD-3-Clause and Apache
+  license_family: BSD
+  size: 246457
+  timestamp: 1626374695070
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://repo.anaconda.com/pkgs/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
+  sha256: 2b09b3a4920393833a5963dd702757152b425d2712acfc3fe0b59ceec6e315bd
+  md5: f00776a58646c5ae1644fc52029a5b66
+  depends:
+  - python
+  - six >=1.7.0
+  license: Apache 2.0
+  license_family: Apache
+  size: 14955
+  timestamp: 1629465474976
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+  sha256: dc9f709bacbaf08a0941d2622d82f91f18b355e82c55348ec29f1391215ca7e0
+  md5: ece0f5837a4de2d4d5f1abf8347cd10a
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 124922
+  timestamp: 1708711884650
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/abseil-cpp-20230802.0-h61975a4_2.tar.bz2
+  sha256: dc40cfc393c2acdb97ce54289d3124bdff35ffd4a6c203abb6f3f5598f49c115
+  md5: 64a761d3c1af045bf01d84d3fc4302a2
+  depends:
+  - gtest >=1.14.0,<1.14.1.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 1336618
+  timestamp: 1698327954026
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+  sha256: 5800a2466734dd1ef372bec0dd3f0880c5072fa1e8b0668f5054f834285e991c
+  md5: 18194e51d4420ac08f29f3f86581b52e
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 229003
+  timestamp: 1706220302459
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+  sha256: ab7672364f1fa55ec5d8311d85d40e5b57cbd3517b17670557b6fb822bcf759c
+  md5: 6e0159a5865cb7e96a748bd8560035ee
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 11579
+  timestamp: 1678317458652
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+  sha256: 51556902e09436d46878ef772805d06416ca96ffaa66340b5565c0245574aaf5
+  md5: 4cb1b20635cf5431d34cc96ca1e8a751
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 33355
+  timestamp: 1678317111825
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-14.0.2-h3ade35f_1.tar.bz2
+  sha256: f5480f3e450648a37debe91d0218007a976e4b046fafc8956a7351c2a20f83ec
+  md5: 2079b1125e4344044941008a444ff201
+  depends:
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - aws-sdk-cpp >=1.10.55,<1.10.56.0a0
+  - brotli
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags
+  - glog >=0.5.0,<0.6.0a0
+  - grpc-cpp >=1.48.2,<1.49.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.13,<4.0a0
+  - orc >=1.7.4,<1.7.5.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.9,<2.0a0
+  - utf8proc >=2.6.1,<2.9.0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 10268727
+  timestamp: 1707253751856
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/async-lru-2.0.4-py311hecd8cb5_0.tar.bz2
+  sha256: e6fb3357ab4e25e2e839a28def6450035a291c094ff91d4129fcdbb58f2bbe48
+  md5: d1d0d5703fa8c45784265d8dccf01334
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 21499
+  timestamp: 1699554645746
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: 188b74f717e3ce3595da404c0e027b8ccafa9c186e88325e8f02c29d7b4c0744
+  md5: 04ad90eead5812a0263b42321056ab33
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153694
+  timestamp: 1695717975427
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
+  sha256: a153eee37b30ca5c25c5c95463a8852f1cf62a8f45f73349e68f1e3b22eec6da
+  md5: 4bf760fad0e938618391f0db249d00e1
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 87236
+  timestamp: 1706746160841
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
+  sha256: 04ec5908b1dc2979ed50923af90d02da8a60434658efbc4f35fc61e7e9cafa0b
+  md5: 6ba283b7f902226f232fe8a32fa83ee4
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 37547
+  timestamp: 1706690917050
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
+  sha256: 08431c5ec5f0a9e95819b6a76c9cc870d2154e46b229431fd0b3dad25bb70b04
+  md5: 78b4b4225fdefef0b9b0d56b6e51e4a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 184146
+  timestamp: 1706189913777
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
+  sha256: 6a78705375d837a0eeeff9e914aae53a0d2cd44e9760075bdd8711a05f94ff3f
+  md5: 931b0654ae05bcd1acc760dc830b89d3
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 17410
+  timestamp: 1706690854689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
+  sha256: 1d468f7c085b73cc40f813885d77a74270f94dd973b4285546d8873030fcada7
+  md5: 3a61760bb61f85b3a0ffe7b14058801f
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 46197
+  timestamp: 1706697276616
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
+  sha256: b53432aadb2ffe2f1c584c6994b665f3620f29c51b200b03282065a480cf021e
+  md5: 9686f32b210a009048c0877ac39fe88c
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-compression >=0.2.16,<0.2.17.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 164397
+  timestamp: 1706744140750
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
+  sha256: 2ff9632eb2e2c7a70b8d64988e530d842fe5fa7fa529d34cda19f76fb40582e2
+  md5: ffbd1ff65fe9fb52d833af5d396b006d
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 125589
+  timestamp: 1706696187075
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
+  sha256: fa57f1d2b2eb56db72e4b54348452af67a1222bd4266b3d68c7b7ff00399743b
+  md5: ae9e78f6b1fef841fc0ffc7ef7c78d26
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 61379
+  timestamp: 1706746740037
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
+  sha256: 00834bd876756f1f13333c31623c2bdfa7d901b40aec161cf0343548fcd96187
+  md5: 4ef080b5a91e260d51d563218396d0f6
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 67408
+  timestamp: 1706747579372
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
+  sha256: fb3198a05c96030d8498a5c4873e56ae28a5b04fb904a5c696a2192e9ee6c45b
+  md5: 48efeda1471a50b9481c3943a0300e86
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 48055
+  timestamp: 1706690833951
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
+  sha256: f05fb72b1a5f25fab65ef416ff0d1966e3ff84f8a08c56bf809fb602028c66ec
+  md5: 86cda3f774047ff6b40eb14aab83215d
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51354
+  timestamp: 1706192066535
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
+  sha256: b8cb5f96e9eab47419622795fcdb42ad414481db9b84bbb50fcf8251a1314b59
+  md5: 335265dfe12cb6adcacf39b411cf9d7a
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
+  - aws-c-s3 >=0.1.51,<0.1.52.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 210312
+  timestamp: 1706827788950
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.10.55-h61975a4_0.tar.bz2
+  sha256: 40911c99dfa11ad32d451ab8cb5b24f0aecde231b5f8f4e9d8887bc4a720dc65
+  md5: 1078cfa7cb12f9a0d3fb4017cc9789b9
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 2322692
+  timestamp: 1706890560060
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/babel-2.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: aed8823dbb096851f6eddc345f02c23fba42decce2c584f0fe09440002c37996
+  md5: fc567742fccd3b08593b1dcca16522f7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pytz >=2015.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7215195
+  timestamp: 1678318116416
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+  sha256: bf3c60386619f08cf5105b4b903bbc109b3252c3b923fe055aa445908a01969c
+  md5: 3f84a301921ec6400b7f1f1c4ba3260d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 270017
+  timestamp: 1681493109562
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.4-py311h85bffb1_0.tar.bz2
+  sha256: f15cd24d07af9f487c57041513d46bede83ece5b46571d8bbb2898f12784b270
+  md5: f7d3cece4f39b37c62a1dd51d8864926
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5968984
+  timestamp: 1706912422498
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+  sha256: 81102f2762d8eb2f07c69fbf7ca7dad879a257a053085492d4c1b4006eb35fb8
+  md5: 3c42777bc9330fe91177ea813b9ec252
+  depends:
+  - libboost 1.82.0 hf53b9f2_2
+  - libcxx >=14.0.6
+  license: BSL-1.0
+  license_family: OTHER
+  size: 11744
+  timestamp: 1696762233693
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+  sha256: 9acafafcaebd653c2372ddc864525722e1c55b884b5eba22e28e2b2d946b853c
+  md5: 22375cc3c2edada31b85af56c8e6dee6
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 155829
+  timestamp: 1707864406086
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
+  md5: 31d6d04cd2388d8f19004501271b3545
+  depends:
+  - brotli-bin 1.0.9 hca72f7f_7
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18982
+  timestamp: 1659616229395
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
+  md5: caf1073dc2ca5aeb832a2877394eae12
+  depends:
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18233
+  timestamp: 1659616216769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_7.tar.bz2
+  sha256: c2d2a7102d7bb658f36fda7addf7c760d43a1c8cdae43cf8a18b3afb6203ef1a
+  md5: 8c76190ec95110ec2fa8693e8afd2f43
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 392066
+  timestamp: 1678380073106
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_5.tar.bz2
+  sha256: 7e2172cff3b4ea31c574f23faa57cf6fd1317c12b597f9be429d4ea13ab7fb93
+  md5: 12dea79e2208f1eb08fb0fa2c83caa78
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 187662
+  timestamp: 1709103518672
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+  sha256: f913b61ba3c1651b36688415cc163a5d575475f7573b543f48a80e7a5002e4bb
+  md5: f11d165eaa532ce04a35382841284298
+  license: MIT
+  license_family: MIT
+  size: 107047
+  timestamp: 1693902034820
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.12.12-hecd8cb5_0.tar.bz2
+  sha256: 163ca64270d7851b9bb178e868b436147ef6d572f9be7c01a9cd4721ce7817ea
+  md5: 7c5f25b8f4ea6c3b44506c6953ba3d7f
+  license: MPL-2.0
+  license_family: Other
+  size: 136869
+  timestamp: 1702903808021
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+  sha256: 20b1fc398e925e6c8cea6a06d3bb614e2c0de886e3f14f85b0ba26e57ff40b7e
+  md5: ac95cfe373c7fef7820e93189041b0cc
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 166856
+  timestamp: 1707229213510
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_0.tar.bz2
+  sha256: 13a3c5586dc1dde131ad47d9a204311c1203e9264b6eb3e2a7b4afd1aef264f4
+  md5: 6c7425a58845106e2490bbd355759525
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 291181
+  timestamp: 1700254523543
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+  sha256: aceaa74365b0d8e69c817639393df3a713a802f40645ac0bd2f39adc871acf54
+  md5: 52191c9d4f4fcaeea39574819ab2f14f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204365
+  timestamp: 1698129979494
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: 53099bea1cdfeac00bf4bf48e7c3321424af31b9726a7f67033ed06e5d924f04
+  md5: 0302e97edbd24e02df7609a6072dc569
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50495
+  timestamp: 1683040190091
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py311hecd8cb5_0.tar.bz2
+  sha256: 684e2fa3140eb2f2935c19215b7aa4b0a5cc004c35a3b6e53a5604645f804c69
+  md5: 9c13d4db519875cab33a32edc7e184a2
+  depends:
+  - pyct >=0.4.4
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1993446
+  timestamp: 1678380167657
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py311hecd8cb5_0.tar.bz2
+  sha256: c524feeeba84eb0aa8c9ab59982bb5bb4cabe3525eb6ceebea33124d3e67f9d9
+  md5: a38d2386a4b96dc9613a00e0c82c82e5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15010
+  timestamp: 1678317798586
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+  sha256: bebfc5aa6be12e61a134b580b07b67f7d8c045d6b113fca5b21fa1e83a2f03ce
+  md5: 239df72a3921c951059fa8afc09643f6
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 287736
+  timestamp: 1700583644534
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: 45a9f823c8e031b1bc78639206ff4e235ce7de67da9b991724316d00075393b0
+  md5: 9d10bc7c171e384a536f9f121d964fe7
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3027866
+  timestamp: 1701396257640
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.16.0-py311hecd8cb5_0.tar.bz2
+  sha256: 973b7d6f902d0021116a94004a4abc43b623a516033cd650360db52b7a5900da
+  md5: 3d602a55412745fd7dc1f5fcfdc2fca6
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy <2.0a0
+  - pandas <3.0.0
+  - param
+  - pillow
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18008805
+  timestamp: 1699543215294
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+  sha256: e0e30590a78d99d51445ac4f668aefe1bf20025a35bdbac00f04647b95c9f152
+  md5: bd0db635eefeea82a0c567b39c9a0e3d
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2485698
+  timestamp: 1690905283575
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: cc000c524197eaa2eecce2a45492566926dab255ae74cb5672aa41036d4f5b0b
+  md5: bbb399dd044b1b338fc05c6769f1f1ab
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353105
+  timestamp: 1701286652549
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+  sha256: 3c7aa54548409f9343e891820ea43c195b5e4e4dce6b761bc3ae9f6c8be0fc86
+  md5: ed9629d6dc1612ec425eb8d27478b0f6
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 140316
+  timestamp: 1706888243476
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+  sha256: aed47f9ca4dd140b9c8a183e53d4b89eba84a20041d2038983cdfea8096104ef
+  md5: c0d981d7d43eaad55950ff5e57206e70
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 97828
+  timestamp: 1706895273858
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/grpc-cpp-1.48.2-hbe2b35a_4.tar.bz2
+  sha256: 5d69cd8a1582c5062ed6753ee9ba403cee89d89f6e1628bcaba823a33a92a186
+  md5: c37d24f6749355412dabe28bd64ce229
+  depends:
+  - abseil-cpp >=20230802.0,<20230802.1.0a0
+  - c-ares >=1.19.1,<2.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.20.4.0a0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - openssl 3.*
+  - openssl >=3.0.12,<4.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3994389
+  timestamp: 1701983483827
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/gtest-1.14.0-ha357a0b_0.tar.bz2
+  sha256: edfb65219af41d5037b6371c6b074c8372db90b17d25f85f55e36523c01949ec
+  md5: f21a88869091d6d4d88b9b5f064a3157
+  depends:
+  - libcxx >=14.0.6
+  constrains:
+  - gmock 1.14.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 400287
+  timestamp: 1692633607623
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
+  sha256: 4120472ee1c5d31efffeb045892bece27b9a15a30d77c35212f6508221635918
+  md5: 9561a225b5171285250c9071f8cab074
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5368257
+  timestamp: 1707836808668
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.9.2-py311hecd8cb5_0.tar.bz2
+  sha256: b40f02edd3bb9d3387a64b7eb737f5c0b03a41cb7914008fbf471480e4d9171f
+  md5: 3314bdd2404310154e886c927615b70e
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1991989
+  timestamp: 1706712702324
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+  sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
+  md5: f3ce6fe6eb760c236e5f7d04df5faa81
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28138484
+  timestamp: 1692293212596
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py311hecd8cb5_0.tar.bz2
+  sha256: 26d87f25d75af1d60c81d793c93584fd86795a4c0335988957b22ad56cc549f6
+  md5: 35e263cc9e4e1742438d5f55036a4209
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123716
+  timestamp: 1678315837792
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+  sha256: 5a17849341e4d43fc6aff44486425852c16dee6e1cbcab1ed3f2167350f55359
+  md5: 445ac9df262ad2dcd86246a9ba5654b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 51118
+  timestamp: 1704813615186
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+  sha256: e0127f50d444bf4474e8df07d602c7f6dd38690e8bb3fb28817c164940ffcde1
+  md5: 583fcd7060cad6a77074d00d9ef62f44
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 731417
+  timestamp: 1699647668990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+  sha256: eb58fa29b1ce9aa5fc774d4c466696457695dec3b206456614b4c9cac0a94e42
+  md5: 3d3291ff58dff83dcd40ec54b435f4d2
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229910
+  timestamp: 1705934029588
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+  sha256: 73aa7662c00c73bab2dafefefc87a1b524961d2687410af624ecbd6703e483f3
+  md5: 7e71e99766107a553752ed8f22b61cf0
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1611976
+  timestamp: 1704833049616
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+  sha256: e08cda2bcbdec124c63e951eb248c503bb1467c2a6000010c6bdc0726e0e00b7
+  md5: 22c24f43b82da8b3920a913bbf452421
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1168968
+  timestamp: 1679336359851
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
+  sha256: 3b262312f1fc76e490c067408771da0a12c7691379cddc3c86121255cda7a41d
+  md5: cbf00a1bc151243cb6a33524b62f3663
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353280
+  timestamp: 1706733664000
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
+  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
+  license: IJG
+  license_family: Other
+  size: 278924
+  timestamp: 1677849185191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+  sha256: 99fc6ac82c56eb2a580f96db24a5b887f8abc8c24af445d3313d5ebb48598478
+  md5: 71892160908a6daedb5fb7c404079ae4
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 182073
+  timestamp: 1699041732321
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 0ea44d0c8044e70ab0eaf4d6f5f3e4753838dee106b5cbd36561e21a65cbac77
+  md5: 1d045016dca889d702f1caf3a16162fc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16528
+  timestamp: 1699032525791
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter-lsp-2.2.0-py311hecd8cb5_0.tar.bz2
+  sha256: 9f7e13e4b84794cc99f78e0513157be30b9c9b039c413a90c03583304b7edeba
+  md5: a76eeb3f746de2b0282bbf9872ac1e8d
+  depends:
+  - jupyter_server >=1.1.2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101678
+  timestamp: 1699978325870
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-8.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 7e100bfb19e640dd312cdb921155f67c52675cf128d1aef2f3e975d30f3171a8
+  md5: 08bbf3e56f89bc800fda1eeb998a0d1d
+  depends:
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 222285
+  timestamp: 1699456395712
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+  sha256: 8601c674f4779900f6a949e47b814be68b722b0b3d394433bec9d197924ebd69
+  md5: b8423f8caff3041a251fc3681f43496a
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94990
+  timestamp: 1698937583196
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: 6a430c812ce0415a04d9cfe6c66d9012eced2d91c04960c88bc8ec1e9f1b5d6d
+  md5: 30b3d5d6a8cf5d1604e5f5fb177917b5
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42513
+  timestamp: 1699282637015
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: c2d206db117f7161e77236ebd6b0051fc73e1731c242d1e08597d736a0376c92
+  md5: bdb61de2e20e02c93423d9de091c74ad
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 601837
+  timestamp: 1699466514455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+  sha256: fd7964657f0a8fe8b167ba860b1f960e8b7b45309eb6c7c850d50ec283fe03b5
+  md5: 2967bb345bc75f53182e263ff4743ca6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28223
+  timestamp: 1686870845224
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab-4.0.11-py311hecd8cb5_0.tar.bz2
+  sha256: ad199926171ef67c2e96e7c603c7dc6c96e25a23deb9979f1c910616df8e8b48
+  md5: d749db644752070354a015015fd1a102
+  depends:
+  - async-lru >=1.0.0
+  - ipykernel
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.19.0,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  - traitlets
+  constrains:
+  - nodejs >=18.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6618991
+  timestamp: 1706803097395
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_server-2.25.1-py311hecd8cb5_0.tar.bz2
+  sha256: 557bd1a8ff0502191adb3ff3af74b54ee2ec4800d281492bd8e588ddcf095bfb
+  md5: 14c8a1959a83eff470adc09cc65bdb57
+  depends:
+  - babel >=2.10
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18.0
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.11,<3.12.0a0
+  - requests >=2.31
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 107281
+  timestamp: 1699555527525
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+  sha256: a12382b50416803f559a03fb384ba492c1dafa351e1191a3f8dc361bee6c4f37
+  md5: f2ae846b663bbb642f4b1e90eaad38a3
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64817
+  timestamp: 1678322501509
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
+  sha256: a3a24cd84c291f7c9e28842ccfc2107d149f0aa8e676b85d9104eda77622e603
+  md5: 99ba4367783596d1bb0c7766ea6706ea
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - openssl >=3.0.8,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1290758
+  timestamp: 1686931137388
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+  sha256: 127dbf93874f1bb3493b312fecb5ffedb8f2a41d2470e2cbeb889eb58d89ebf7
+  md5: 07502b61e43a2039e4312b40d53c1db1
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 22584954
+  timestamp: 1696762195023
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
+  md5: 7dba7aa5b971febb55281659843586ba
+  license: MIT
+  size: 65470
+  timestamp: 1659616172703
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
+  md5: f78a158983f0bbaba56f34b976bc6dae
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 34189
+  timestamp: 1659616189313
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
+  md5: 36a1d885725d3ab4d1fadc5a29f978d2
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 327737
+  timestamp: 1659616202869
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.5.0-hf20ceda_0.tar.bz2
+  sha256: b34c59c148f100cfabc8a55470cc0d46f4ba2d1f90dedf516b151ca1374d2e54
+  md5: 14f3b4d1790efbf8e35a9a9259cb6e8a
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.57.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=3.0.12,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: curl
+  license_family: MIT
+  size: 373198
+  timestamp: 1704383716512
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+  sha256: e84e6cbacb12de6fe86955449502d3956696ae583060d0d4911ea6f503cfb9ad
+  md5: 1d200c536be4172db41c49e81a3e6350
+  depends:
+  - ncurses >=6.4,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 169586
+  timestamp: 1703006265367
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+  sha256: 4786264321edbff780633a5b752995eb3193ca4bce11b0fda179577f6cf1102c
+  md5: 849fdd014c201a9d2c2aa7c7db38a778
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 103993
+  timestamp: 1632891571494
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+  sha256: a60941a0365ee3e8b9ff721f75b0608c234b5652f53337a918b787839de4bb53
+  md5: 4d61f019594ebccfb3f4fb87ee778416
+  depends:
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 414942
+  timestamp: 1685052318462
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+  sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
+  md5: 817848d0e2b2808acdc9b3fbbf581726
+  license: MIT
+  license_family: MIT
+  size: 133887
+  timestamp: 1683716590737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+  sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
+  md5: e458587c87e3f2d20192f4e0738f2c63
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 149419
+  timestamp: 1665498987619
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+  sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
+  md5: 1058b661ec829b2ee3716ee2a5520641
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1917987
+  timestamp: 1665498925405
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+  sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
+  md5: c90372428e1e4eed4fdcd790979d06b4
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1409377
+  timestamp: 1650983531933
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+  sha256: 8176dd9a68815301a24ed51e72f3506f5f77c67a112efa0dd14971f2f3b3c8c1
+  md5: b5e470c224000a6bda6f655c155b53e7
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 27861431
+  timestamp: 1683292881730
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+  sha256: 7bfcf69c31a4eb15dfab661c93463ce8dfb7b3de4356945fa5c1ca50a5ae0cb0
+  md5: 4934bb34818fa3d99b32b9cb59fed205
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - c-ares >=1.7.5
+  - libcxx >=14.0.6
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 784918
+  timestamp: 1697018436251
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
+  sha256: 1884de5207f5a1210217d7132348b4944ec4b09a91085b7b47a19dfdd9b6dbba
+  md5: aa960ea0133deec4637a8d05700cc3c4
+  depends:
+  - libcxx >=14.0.6
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2412437
+  timestamp: 1675278748544
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-h04015c4_2.tar.bz2
+  sha256: ea67e176a2142813dc19481cd83fd7c17fda32a96cbdd72c78e29b59030eb5fa
+  md5: 13a0cba33faf8074613ca460a6ddae19
+  depends:
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338575
+  timestamp: 1686931283039
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+  sha256: 21ba71cdc65b56c6daefeeab55959e5a7edadfd697cfa8b2ed5c1b3e2a98586b
+  md5: cbbd369ee87aba597c942727bada4eee
+  depends:
+  - boost-cpp >=1.73
+  - libcxx >=14.0.6
+  - libevent >=2.1.12,<2.1.13.0a0
+  - openssl >=3.0.9,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 364326
+  timestamp: 1687975317748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: d28c465ec6d5f8d4962c597b249b58998300c8b4e3c937c578c3d15294ea863d
+  md5: dcaed6ddd0723c7cce6bfad917be98b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41176
+  timestamp: 1678413498410
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+  sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
+  md5: 5c740b4a18a558de0ccfe601703c423c
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 338738
+  timestamp: 1662635677689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
+  sha256: 53808184421c81e661f9927ff564a0d0ecdf3b816c8aba8e2368434e055529d4
+  md5: bee10bfbe90767fcb8f8f6ab3a05d85a
+  depends:
+  - libcxx >=14.0.6
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 407784
+  timestamp: 1706911015242
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: 716a654df2e55052193150015bd5c9856b847893fc5a229fa8669725b1c56ff2
+  md5: 687ba6c11de38ad7cc597f7188b491e7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13357
+  timestamp: 1678322560230
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+  sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
+  md5: d5f58d056b4bfc67aec30c77035ba889
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 182491
+  timestamp: 1670944720979
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+  sha256: 6fb2953e169ee1ae38f24d29752051501992f19b96b5ebcea9af75737bdbcb42
+  md5: 7f410cdae838c5030108d1b98a8c78f6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162478
+  timestamp: 1678377892595
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+  sha256: cd97e09a12ffb49b2a30a782fa8c7933b28f5ffdbfc5c73a9ebaa95fc9447370
+  md5: d1fb6ebc1e5728aa6377cfc71da08942
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135859
+  timestamp: 1684280005320
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+  sha256: 30c3b189462a9d0f4794d229adadf34b5f5a5f56f95c30d5afc17ef524579290
+  md5: d4e9421243129d1d57c472dab045f3dc
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26639
+  timestamp: 1704206159955
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py311h41a4f6b_0.tar.bz2
+  sha256: 9587aa978de993d5090d7dc9e17269202b995e65f8aa57e53386d8c246ef6d08
+  md5: ce68e30c505d14cf8dceaf49fbea83ae
+  depends:
+  - __osx >=10.12
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9157187
+  timestamp: 1698692447834
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+  sha256: 07e7fd5bd64e55328b4b99d92e2e2600d791f1095bf905daab4cfc59f0f0a45b
+  md5: cf53321779f4ca7e986c1468719b93f1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19500
+  timestamp: 1678317565001
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0770e02be1ea1216af493cfc03d5b8a702e14606fa93b0692bcdab1fed1b898c
+  md5: ca6f06ceaf66a32bbf5dfdb6e373a5cf
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67892
+  timestamp: 1678417734353
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: fbe95ed0501bb0f137048476fe41bc718dd659e8ecb066bc67ac17d6a50f4318
+  md5: ec162bde8d1c8a107b257df218b17035
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23030
+  timestamp: 1678381838497
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+  sha256: c20dd678655e582129a858a1c5162bdc254082d3a3c035b0f72629d9276e5b75
+  md5: 800a0738c728796e02d0386ce7d457aa
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104585
+  timestamp: 1678317269407
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+  sha256: c825bc3070f73318ffff88a7a0b7fc6d1858b058ced735efd1789053f1583918
+  md5: dea5f96459c9a6df6b026ca57d387936
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224299920
+  timestamp: 1699647835748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+  sha256: a76c134ec258612ff7d55cb2a19b9e3461cbbd375a744bd29390af9cfcd283b2
+  md5: 1c736f58992009f53f014aef163bae31
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48442
+  timestamp: 1682969160267
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+  sha256: bcfb0d1e075d043bcf05fa1a7ce3c142bf222d29693366af49a5a346c770812f
+  md5: 59e4820b34049cbc6619a8ac97290abc
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 222137
+  timestamp: 1695058350477
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+  sha256: 114e408c40b332393cf2792393e4d1ede3465abcb3d345fe647ee519565346c8
+  md5: 86b13271578e1fa5e664edcf6fcb3ce4
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296860
+  timestamp: 1695059990370
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 638450a7ccb5f438ac65aa1c8d871fb5bb664e7261ec7e663d0302485c219a67
+  md5: 574875bbeabff85b5d9cfdb62066aece
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29473
+  timestamp: 1678392919304
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: e08cb3ee6df01f4c1e1ac8bc4ed1a06e549ffcc8774fe2e2842c644bb8f74a86
+  md5: 6ba0ae0fb14cbea1e3197707701dc180
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123077
+  timestamp: 1698934356774
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 2f946b5042eaac97206b5217fb203f3604ab3a60aecd99bdfc684925e3136c18
+  md5: b24026076c381ff2009e7acb9e0a6e87
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 534650
+  timestamp: 1699022791300
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+  sha256: ba368605a0af6f1dcbdcb6fddab9ce63224a85dd11bfb2b1acace1dc17899411
+  md5: 91f3ea3fe44d619ee95a6ed3773a0814
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 170926
+  timestamp: 1694616830121
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 42d803e1d8b54748db5d989ecd503826f564132df7cddc20f520460f55e523a1
+  md5: cd3fa71626ebc098da4625fc6be79752
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16952
+  timestamp: 1708532805951
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-7.0.8-py311hecd8cb5_0.tar.bz2
+  sha256: 08457eb26f6e84a25bbf413be70cd91274819e526f90ecdc859ee84af0b3491f
+  md5: a424f09e1db7fc2c399ce807e01c3713
+  depends:
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab >=4.0.2,<4.1
+  - jupyterlab_server >=2.22.1,<3
+  - notebook-shim >=0.2,<0.3
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3655911
+  timestamp: 1708029925977
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+  sha256: ed5608feb37a083d47b04203195260e801b64b5380f292cf18bb61e7ad827a2a
+  md5: daa9c1c233673b727528548454aea664
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27607
+  timestamp: 1699456006797
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.59.0-py311hdb55bb0_0.tar.bz2
+  sha256: 69970b4fc56036ba54b11e2112d710a1572797f934f01b6e748f887fbbc02e05
+  md5: b144edd077f656bd6f3d3d822a404757
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.42.0,<0.43.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - tbb >=2021.6,<2022
+  - libopenblas !=0.3.6
+  - numba-rvsdg 0.0.*
+  - scipy >=1.0
+  - cudatoolkit >=10.2
+  - cuda-python >=11.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6068490
+  timestamp: 1707088668480
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+  sha256: cacba45c1eebf7d86748737717883a98cf40664231460fa41391c79f98d06f45
+  md5: 3dbfae0d5b90e77f9358564ad442ac9d
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 165572
+  timestamp: 1696515553184
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+  sha256: 1466c3af380b949612c79940124e426eccd59e335c205da0c00383a69358d1c0
+  md5: df6be53592d40ba7e03d6ffe349760bf
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311h53bf9ac_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11330
+  timestamp: 1708639985606
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+  sha256: ace67d704fa7eea1480eb463f2d91bfc161be2ee20263c5a9939805ae3c2a9da
+  md5: ec124589478fa12fba4f35f31c3a0692
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311h728a8a3_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8783230
+  timestamp: 1708639945646
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
+  md5: 93f5d7b66976154adeda219bea02ba45
+  depends:
+  - libcxx >=10.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 484257
+  timestamp: 1630093862501
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_0.tar.bz2
+  sha256: a2436a86c232a907fb262e2fb08a3548f94270e5920414cabcc11d64f7c3a951
+  md5: 978612352a91a0d147af8ef7b6f1abff
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4973118
+  timestamp: 1706909367755
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-1.7.4-h995b336_1.tar.bz2
+  sha256: 281d5a10e7a0a25bd6ee20d1d0f03530dd90fe5b4e3490ad3f33f0367df36f7c
+  md5: 062f9bba1d43123d02c60d23a29831a1
+  depends:
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.9,<2.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 425422
+  timestamp: 1676482778334
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+  sha256: 8a0809f419065e014cb8e2c8a516cadca6088fb71fd1ef3ae2287d91e3360d59
+  md5: 4dc0b9bc88476fcc5246d823ff1c289a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39645
+  timestamp: 1699371213055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py311hecd8cb5_0.tar.bz2
+  sha256: a3d14ada61d37cd7b72521ed4b5e1ddf636a404ed58dd86a8741c330b4fb9641
+  md5: c3e67df9325059e25dc5ba737a42b85e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 94687
+  timestamp: 1693575215769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.4-py311hdb55bb0_0.tar.bz2
+  sha256: 21b84d1ce163e08f513cf522b72dafcae785ca18584bed8844ec2553a9c3377a
+  md5: 0afbb24816dbaf0619522a3e92f8ca6f
+  depends:
+  - bottleneck >=1.3.4
+  - libcxx >=14.0.6
+  - numexpr >=2.8.0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - fsspec >=2022.05.0
+  - qtpy >=2.2.0
+  - pytables >=3.7.0
+  - xarray >=2022.03.0
+  - gcsfs >=2022.05.0
+  - xlsxwriter >=3.0.3
+  - s3fs >=2022.05.0
+  - pyreadstat >=1.1.5
+  - pyxlsb >=1.0.9
+  - odfpy>=1.4.1
+  - pyarrow >=7.0.0
+  - sqlalchemy >=1.4.36
+  - pymysql >=1.0.2
+  - openpyxl >=3.0.10
+  - lxml >=4.8.0
+  - xlrd >=2.0.1
+  - numba >=0.55.2
+  - psycopg2 >=2.9.3
+  - pyqt >=5.15.6,<6
+  - dataframe-api-compat >=0.1.7
+  - html5lib >=1.1
+  - matplotlib-base >=3.6.1
+  - beautifulsoup4 >=4.11.1
+  - blosc >=1.21.0
+  - fastparquet >=0.8.1
+  - tabulate >=0.8.10
+  - scipy >=1.8.1
+  - zstandard >=0.17.0
+  - pandas-gbq >=0.17.5
+  - jinja2 >=3.1.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16389779
+  timestamp: 1702320012708
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.8-py311hecd8cb5_0.tar.bz2
+  sha256: 5050103ac0fcd3b29a1ab8669b4cb31805af7f299b2c62bb4c50aea4d1fd5f65
+  md5: 9eb4f152098b195653d1faa0bf3eb0bd
+  depends:
+  - bleach
+  - bokeh >=3.2.0,<3.4
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.0.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.17.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18231647
+  timestamp: 1706539715358
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.2-py311hecd8cb5_0.tar.bz2
+  sha256: 93a4b6935afddd0d930338ec2c51ade4d6bbe34124fbbc8a5e95ec2dddc1a351
+  md5: 15335a6edc2ec59e46c87530151d153e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 257173
+  timestamp: 1705937867682
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+  sha256: 359b31da651ee35b9ca43974d26cd44e64f3cf412096c15dec7b720fa909a9b2
+  md5: 108e24227f8fdfc4d635bb4eedfa6cef
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48504
+  timestamp: 1698702608965
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.2.0-py311h6c40b1e_0.tar.bz2
+  sha256: b780f0b40809fb2f2fa3d17978285271bfcf90146cf2eeaa1b73fef12f5b89bf
+  md5: 3f12e40a25334141a1824d39974a9397
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 920074
+  timestamp: 1707233139159
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3.1-py311hecd8cb5_0.tar.bz2
+  sha256: 62866ff6b1a021bde2758b97004ed1903fe34744be4ae8f2a0f7cd3113a45d72
+  md5: 1b9b2e51a171bc752955f3592e596184
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3454892
+  timestamp: 1700667869320
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 81719c31101d6c019150cedcc7b08adb3bdb357e8b2952e428dadaabc4dc985d
+  md5: 105825168e0a17fb007f60b5f314e311
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38405
+  timestamp: 1692205731769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+  sha256: c0982f688127129e026d2b4cdacdd5684d00796ea7bdadd7d26b1101b095d723
+  md5: 0d6910c74729fede645c010110f1c89e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 121796
+  timestamp: 1679340253537
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+  sha256: e32843723b10ecd9badde28e1085419c0b59ed8a96c7cacce6395e39e3a874f9
+  md5: 5af0280a817d2c273304cd22328124af
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763044
+  timestamp: 1704404460779
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+  sha256: 117a435c2473e2a20cc81eaacb2b45ea5e7fe3c946eec2915936d344913ede44
+  md5: 0f459ee59fda20e2077fdc2c777edfc8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 497470
+  timestamp: 1679337286052
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-14.0.2-py311h2a249a5_0.tar.bz2
+  sha256: 7ed49e248ab0fbfaea3a170c8f795e7de8ba372bfad16f53e60500b10d5ca648
+  md5: 9917697f50ec91d18d43cd9670ec8130
+  depends:
+  - arrow-cpp >=14.0.2,<14.0.3.0a0
+  - boost-cpp
+  - libcxx >=14.0.6
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 5054065
+  timestamp: 1707331316454
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+  sha256: 667b5cf00d31293dede2ddadcc30ab967103d585d40647f34d6d830af97ee51f
+  md5: 81d3876fa502fca91ba4136a5f3fc3d3
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37821
+  timestamp: 1678378977816
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+  sha256: dfb403f367c57327a4d080109df88383ecff18464de287a1ce936a7274e3656b
+  md5: 997b674bad89963af875b93b06807f51
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2120413
+  timestamp: 1684280057020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+  sha256: 9d2c0f373ac1c5db329581793dd517092cdf9a59140f2516ed8c3a1f483c0bbd
+  md5: ee10503a159e819abdc586666bdf0952
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207552
+  timestamp: 1678322848766
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 717e038567506ca58ce1cd4a3416892d02f4ebfdd332077cc3d110cfe3d36c58
+  md5: 53bbfb400668f798eef6f8c7cf938e1f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35751
+  timestamp: 1678315886516
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.8-hf27a42d_0.tar.bz2
+  sha256: dea2e1371f27376636d240d98eb9d2d1f383df0264b354c2d97c90b60358f9ab
+  md5: ff3603a0ff4f66a66856b3f09e29fec9
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.5,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16812245
+  timestamp: 1708984581993
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+  sha256: 514249897265f66f6ecca0a4427eb02a43c33b3c24974db16d05db6bbe97881d
+  md5: c9ea1437e5a3ba6a52ec2322505203e6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279116
+  timestamp: 1679338758489
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+  sha256: 78b785b9b6ed46c86b0d3a32bdceea49f816672227fb63e726b2d46eadbdba0b
+  md5: 79d783f74359141e0b06a848db33823b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18563
+  timestamp: 1683823935261
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py311hecd8cb5_0.tar.bz2
+  sha256: eed664215f9a8effb182ed051cb022bd0a071a76fdf360cf05466c0ce4d772ae
+  md5: 897822a1e234eea0b95a9fd59341d741
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 273158
+  timestamp: 1695131639050
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: 724125528ecb35777bdbaa47d9b7a9b7ae9dbd9c8448ed90179661f0574ede8f
+  md5: 9e84d66d6f1ec1799c133f805d01a313
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65001
+  timestamp: 1701728146986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+  sha256: c3e11ed944da69c11b949bb918341a0d79ef603ee34a632d6a45fbf89ff924a1
+  md5: fee7ff4d291f530b4cecb575f29807a0
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 197996
+  timestamp: 1698096137432
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-25.1.2-py311hcec6c5f_0.tar.bz2
+  sha256: 9996c79c554086df5bb4e39afa822c9f71da32a461c268829a3e849c9b4f105f
+  md5: de5b99be21f6203d7577f11140c13534
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 528098
+  timestamp: 1705605165873
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+  sha256: c69f556df9a27328c56943f3b5918cbb953cfbca987e20394d823a6174781202
+  md5: ab294ae71ecdfaa307a961cc71dd890d
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-3-Clause
+  size: 205638
+  timestamp: 1652449553607
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+  sha256: d784dc26c5de8e41845350a899e5779250b71f45d39e2aece62e739e9add7308
+  md5: 7b077b7f46112bb31dc066396c51d3fa
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74776
+  timestamp: 1699012164201
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
+  sha256: 3357b6b327b3d0a2cc0f02934a60bbd6df38f4ea7bbb3f50cb8e21332c9f5786
+  md5: bf5e48b646e36ef2b788be9665c0e5ae
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 120768
+  timestamp: 1707355762747
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+  sha256: 727fb8d957e02d03b928d049ffbc712316f176a2c331391766d646621b45655a
+  md5: 7e0e416c642f3ee4ddfb084a811fb4df
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10236
+  timestamp: 1683077214314
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+  sha256: a8a67143ccb65cfd6f50055176b6c26179a83130a45d0a12e79dd2de68d8db63
+  md5: a2065790f41e3eeb6efe0ef6daa75377
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10600
+  timestamp: 1683059285216
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+  sha256: 6aba582338faa0c26fe336bdb10c65b8f7808a6e383bd8f80f3e6b612ca209ec
+  md5: a7486349b5f7370f6902c2050a23d268
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 319197
+  timestamp: 1698946203341
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.4-py311h224febf_0.tar.bz2
+  sha256: 6eb508cf1ddf070b86077ee851d0098cd0832ecc5dc1bbbf98f5db4eda6f0622
+  md5: 427298abca5174c12a54cbc7a883e25e
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<1.28
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26151054
+  timestamp: 1701295650624
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+  sha256: beba0555707dac1e8484d73cee9e4128ac4b10e2a0d4209357481179022e8fdc
+  md5: baa8b304607b3a9ae8a3d9acb354c31c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33343
+  timestamp: 1699371216044
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.2.2-py311hecd8cb5_0.tar.bz2
+  sha256: 1fd0e6f89a7e31c6382f667c8e17c15e024e69c518e159502959ce80eeb6ad08
+  md5: 6b87c7058c345f2193df22edc652d8b1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1449619
+  timestamp: 1702505160918
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.1.10-hcec6c5f_1.tar.bz2
+  sha256: 9e61e80cb7cc715a3d688a660249da591e20550716a245684ffca317df9a19df
+  md5: 62a52eef7c69e9be38fa0313aa49b4be
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 42438
+  timestamp: 1702909424521
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0eb44a16ef74a13ef7839209899d009cd94974fbc406a417d958c7bc8d955245
+  md5: 41f239a5b67b1daf819849023aa5d12f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19056
+  timestamp: 1705431379885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+  sha256: 14775231982e1ea150189c956927ccfb1ad01a8c9395cdeea4d5a48b9b8ce664
+  md5: 729badc4bf7ba8ccc70e0f9e58075c99
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89812
+  timestamp: 1696347694075
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/spatialpandas-0.4.10-py311hecd8cb5_0.tar.bz2
+  sha256: 25fc234a8966287e369835e71b7160b865aa8b8c76efefb8b5a65e2374d25795
+  md5: f01d2f259587e702a84ed20c780549ca
+  depends:
+  - dask-core
+  - fsspec
+  - numba
+  - pandas
+  - param
+  - pyarrow >=1.0
+  - python >=3.11,<3.12.0a0
+  - retrying
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 201132
+  timestamp: 1705085097451
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+  sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
+  md5: 82e4db6a498480a75d53c55bd35b6478
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1801397
+  timestamp: 1681394807900
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+  sha256: 3d5c2968f581006437df3932cd5d3c1c4afa78f0e13757b958440245d3248856
+  md5: 605ea221d225ad8e79284dbcfdab0715
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37699
+  timestamp: 1678317755913
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: ed059e32ce5a1c0511575f29d2fb6da12c54a37000bfa80f9e5aa9dfd9e04101
+  md5: 4d2261a92d25136a68b8d01d101119f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49145
+  timestamp: 1678317386284
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+  sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
+  md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
+  depends:
+  - zlib >=1.2.12,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3536231
+  timestamp: 1654088937695
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+  sha256: 424b8284072266eb59d055c0b7b58241bfb00009d445743ea261d4eeee73ea19
+  md5: f3a47898a55087edb9d65d29c24d9b88
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135757
+  timestamp: 1678323030858
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+  sha256: 6ab71b48d145c69007cfb5b4a21def2cc83bba972b7cc91c7d52d0d7eeb055bf
+  md5: f8970b0ad5c8b452b8722ceb4e5c17f7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 895379
+  timestamp: 1696937269468
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py311h85bffb1_0.tar.bz2
+  sha256: 5d060a98ba771ff867611e5f2d8504bbf40c2013c34cbf69c8aca70f0b70034d
+  md5: 3c678c9776759d2fc963072e007d9887
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 153033
+  timestamp: 1679561985939
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 9e8dbede0bc54c77b974210be66503e7e8e45e0f1c71dc5c16cc9a9674d54259
+  md5: b4fcab9e63bd7b3cdf458c953904807c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270874
+  timestamp: 1678316116954
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.9.0-py311hecd8cb5_1.tar.bz2
+  sha256: c92c53f476c8157965a9637a4fd5ae7311c724396669d55fbe6b1b16c4c678c4
+  md5: 1d97af42c34da5f616ceee31e3a56d46
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.9.0 py311hecd8cb5_1
+  license: PSF-2.0
+  license_family: PSF
+  size: 9879
+  timestamp: 1705599378858
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.9.0-py311hecd8cb5_1.tar.bz2
+  sha256: 00a423edcfd3cc351068c09cf89ecacebd44425dc589aa5e2778e9b8552b521d
+  md5: 0926a658fe3590254e368b5b23a0cf3e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 71954
+  timestamp: 1705599373108
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+  sha256: a9960485ced319ac91afe69eaaf703c7e6b3049f1e06a4a8c2818b64155943f0
+  md5: 0a9c8ea92a14330a07edabac249e32a9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11399
+  timestamp: 1678394892923
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.1.0-py311hecd8cb5_1.tar.bz2
+  sha256: 33caa82e1fec2ce6b468392257f3556e5e6ae91654c01393b36bc340fe78f9b7
+  md5: 08b9cfb7943aadbfee616be6064cee7c
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - selenium >=4.4.3
+  - zstandard >=0.18.0
+  - requests >=2.26.0
+  license: MIT
+  license_family: MIT
+  size: 184811
+  timestamp: 1707770784530
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+  sha256: 0f8c3eb254be9c1957e748e385e20e62509d11052990c4755012be62434c9129
+  md5: 53229ba93f6e38308ae42ecfc6eaad9d
+  license: MIT
+  license_family: MIT
+  size: 96768
+  timestamp: 1706894705048
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+  sha256: 597015e8a038a111f03ffbc9a217fcda549d75230c86ce53c1f23c53d6f1a0cb
+  md5: 62e98aac883bccc1c87ca0d2ce2f08e0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25798
+  timestamp: 1678317074170
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py311hecd8cb5_4.tar.bz2
+  sha256: f60e6da6f08bf1bdcec59ed71fb53bbd3d2e3c487dba59523e956bfea6ba9ef6
+  md5: 6acead6f585f1bae0447298d4fec340c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 90538
+  timestamp: 1678317776793
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py311hecd8cb5_0.tar.bz2
+  sha256: 6a3b28cbb393389bae4c9797915aef07f6249246c2bf47ab9423033f56e2981a
+  md5: 6b3dc26d34618284dbcc5aeef192a8c5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135700
+  timestamp: 1695742005524
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: cc6995f677d1628f42ae80ed47ff08d8d1c8ed12580a326af6e307f5febc594a
+  md5: d01eb964863b95ef62061b77c9037ead
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2471632
+  timestamp: 1689041625741
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+  sha256: 5b6d5246955b5f9480ff7027eb002442a7ade24f5c354da54ed513042f76cedc
+  md5: f32aa8a37d5e65a8dc30f9a1f46bc63d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54719
+  timestamp: 1678325412288
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_0.tar.bz2
+  sha256: 1534a1e1364db8c8c39d84e48a9210d86913403e5fcccbf352eb08d05ce27742
+  md5: 4b947ef4c6c62f0248b01a557b05f08b
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 490044
+  timestamp: 1709046329183
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+  sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
+  md5: c25b6d40f834647d0bbe767f6c776031
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 329449
+  timestamp: 1705602140856
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
+  sha256: 36fa7ad990aabf3607bda1f33e847888210974586363b6d69cf1ed092c192c35
+  md5: c981fe545122206cdeb647f2dc9e093d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 25496
+  timestamp: 1704207010227
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+  sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
+  md5: 8e495591e369ac161857a72011c0a296
+  license: Zlib
+  license_family: Other
+  size: 120272
+  timestamp: 1666595024203
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+  sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
+  md5: f1465fbd810b3746c6de6babfd4fe28a
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1023573
+  timestamp: 1681304595869
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/abseil-cpp-20230802.0-h313beb8_2.tar.bz2
+  sha256: d42422c15e115f76aec2f71e25887104359d5140af3cc6f19e358af011dc7ba9
+  md5: 9996619edfa02accc1fb7912d5ecc5fb
+  depends:
+  - gtest >=1.14.0,<1.14.1.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 1372151
+  timestamp: 1698327835928
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+  sha256: 9ca3f0dfc2bdbc109e359ba7ab246e6ae952a14819148ad069454b52f2bda802
+  md5: 51fb05873a644cac52f0d1e10cb7969a
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.23
+  - uvloop >=0.17
+  license: MIT
+  license_family: MIT
+  size: 228856
+  timestamp: 1706220385566
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+  sha256: 43405cc7341ce3efb2e24013ad62c64f26a69926635adceaa5459ccbcafb3776
+  md5: effa6d22f497e164cc8455f7f329c304
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 12510
+  timestamp: 1677917870614
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+  sha256: 947efe1c50b3280e9a67cbb18636bdade53a40960fff3056850ff81ab87acbe3
+  md5: 7d2d384ee32ccc12dcb0dc099e421482
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 35091
+  timestamp: 1677915945226
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-14.0.2-hc7aafb3_1.tar.bz2
+  sha256: 86bab32d1e41090bc20f55a7e337565aa8085b6fbafe9bab11886ccf7d938bcd
+  md5: 26f4f94a10d3fb85cfdb2ef11894d3d3
+  depends:
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - aws-sdk-cpp >=1.10.55,<1.10.56.0a0
+  - brotli
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags
+  - glog >=0.5.0,<0.6.0a0
+  - grpc-cpp >=1.48.2,<1.49.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.13,<4.0a0
+  - orc >=1.7.4,<1.7.5.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.9,<2.0a0
+  - utf8proc >=2.6.1,<2.9.0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 9537543
+  timestamp: 1707253459914
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/async-lru-2.0.4-py311hca03da5_0.tar.bz2
+  sha256: 9c64b8d25d87c43834c3f98c331598f9353b063af9456da0be91252a4433e01e
+  md5: 46c58da7041280e5ac6f5c9ce4b8b7a6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 21474
+  timestamp: 1699554635961
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+  sha256: 8259b4a0973c825ac81f581afcbe86640bd0a94b33caa996167309241877635a
+  md5: 49b8ddacfd3927bcaae139eadfb72ce1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153557
+  timestamp: 1695717951839
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
+  sha256: f536e8b60bdc895063ca0e0155d2041993caed5f932c232f2a0d8e52798da2f1
+  md5: daacfabaacebe1d1e53426ec3e385d14
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 86757
+  timestamp: 1706746162173
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
+  sha256: c356ce4cbd638a41fd3db59aa3559850e38c6b41188b8ffab32bdcbd9a55fe03
+  md5: e9dc8c248dda95e92533cae6815a0a8b
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 39456
+  timestamp: 1706690903374
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
+  sha256: 117825fcff2a68136a6e5183e05542c2654d73322e70daee3c50c0ecb3aec703
+  md5: b115d3f733fe8bae79b9d416754b260e
+  license: Apache-2.0
+  license_family: Apache
+  size: 182078
+  timestamp: 1706189905050
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
+  sha256: 241c19574abcaf91a47fc5c36f38e58c86732be5e06f5170063406098a58639f
+  md5: 3cfc3d38b8fdb25cc2e10e3e370d4106
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18039
+  timestamp: 1706690838125
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
+  sha256: d4c60f610e57b35a2962b8cea9911358d1642e0449468fa4967706af88bf5da9
+  md5: fc23856f141fe548afcfc4823881ee19
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 47155
+  timestamp: 1706697259456
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
+  sha256: c43ed35f4a64818ae39ca2c3c3652428c15da5e287f6e94254c3df4d6c759fb3
+  md5: 06366f5f8762447babf69804a04b1a69
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-compression >=0.2.16,<0.2.17.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 162746
+  timestamp: 1706744122437
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
+  sha256: 14e2ee7339c88089d1ff68f7144b3fb4f9e34fe538a9462f8de31dd6fdd1d42b
+  md5: 59ab0e7ffd73966ec6a2fa83a5df5c47
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 127084
+  timestamp: 1706696174505
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
+  sha256: 601baf006d0545ec65566701d99c601cba843e8ac03d80819d4b8bed23d1e5c4
+  md5: 2c98a19d57362cf1fbfec3dda3ea283b
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 61914
+  timestamp: 1706746732665
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
+  sha256: 16809db73ddc3c374ead2c2e9f2221894e2014d3e07ba62d79375cb4de4dfc9d
+  md5: c03f5e3b42bc59bd92db813522cce1aa
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 67560
+  timestamp: 1706747573116
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
+  sha256: 293cf6b9dfa727d0e65b383b0e434f8fb26480abd011516171b8652fd363c98e
+  md5: 2df2dd6c43a3b413b438a9ef834d78b0
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 48454
+  timestamp: 1706690816205
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
+  sha256: 773f7ff1a91af373d27f5c57833aff8912870108ddd94a5280bfdc608effe5e3
+  md5: fad8b095c03774c9d4901db7eda09002
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52142
+  timestamp: 1706192041205
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
+  sha256: 4efabe18fc312e65a5aac9b2ebe423296cfe702756891978244287ab47881927
+  md5: 5786a8ac037fd0e81e25f52dbc6dc72d
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
+  - aws-c-s3 >=0.1.51,<0.1.52.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 210683
+  timestamp: 1706827608490
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.10.55-h313beb8_0.tar.bz2
+  sha256: fe92c6408ee3ebf269b216d1c9576bc15e65a38bcf684f2a7b935e57dbf2e444
+  md5: 4c6b2dc15773f338a7f3299a753ab0af
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 2365300
+  timestamp: 1706890517127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/babel-2.11.0-py311hca03da5_0.tar.bz2
+  sha256: cbca68c98946526eb9a24c01717a0c850d1736f7530196ce627bcc33d8337a18
+  md5: 57ee914212070a75e071674d97480bd5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pytz >=2015.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7177152
+  timestamp: 1677920828584
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+  sha256: 11159a30daae77cfc1abe5e60c19261f65c005e6fbc460aecf72318514d737ad
+  md5: 0c5002654a9cb21db1fdf8c1d2017df5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 269772
+  timestamp: 1681493072129
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.4-py311hb6e6a13_0.tar.bz2
+  sha256: 6b377e6f2fe4de6fca0c7c4391d08c9deda4796e27e5bd788f1e923ad1fe0a24
+  md5: 415e7bf52d5561124e9844bfb1b5a5a3
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5963938
+  timestamp: 1706912283449
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
+  sha256: f1660ecfb8687d74e81a7b00699a8bb4677cbd791d14f50ba517de98e2f187ca
+  md5: 1636fc4b725da8c5e967952a55f3fd80
+  depends:
+  - libboost 1.82.0 h0bc93f9_2
+  - libcxx >=14.0.6
+  license: BSL-1.0
+  license_family: OTHER
+  size: 11780
+  timestamp: 1696762172661
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+  sha256: 688a071ba370f51b457cd32d70b7b38921ce9551203d06fa7fc2c30c4b79891d
+  md5: b2353077a39ab997463768154dd58fec
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134711
+  timestamp: 1707864978809
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
+  md5: f860193e14afc7ef3f5b990a2ac003d2
+  depends:
+  - brotli-bin 1.0.9 h1a28f6b_7
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18936
+  timestamp: 1659616204016
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
+  md5: ad53130f3fd1f8d3c2fcbb7496e5585d
+  depends:
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18715
+  timestamp: 1659616188888
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_7.tar.bz2
+  sha256: 878977be9f40a4133e5ebf46445792951807e968ac2cbb6fe213895be5b08792
+  md5: 8d6e62d7b368eb8f472feafe25727cf1
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 378567
+  timestamp: 1677936496352
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_5.tar.bz2
+  sha256: 61999c6665d4a479663fcec455c697d7ee25f77d3379c22674c09d195d5b5415
+  md5: 783ed8e4e14fd3c67c2b2990eae6d2d0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 158591
+  timestamp: 1709108082151
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+  sha256: b0be79290b1df1cf1d07a1a9c3f3a92ae262643a6df3dc10dfbac22a82874dd4
+  md5: 8fdcf1c08eee91fec7eefc22863c816a
+  license: MIT
+  license_family: MIT
+  size: 106550
+  timestamp: 1693902036526
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.12.12-hca03da5_0.tar.bz2
+  sha256: ca38fcb75cd86450c0d44d625bd3d9bb0fd76fd38e1419ac46b9728e5dd39cee
+  md5: a9be49b86aa6166ae15edcbec97c9a64
+  license: MPL-2.0
+  license_family: Other
+  size: 136725
+  timestamp: 1702903798678
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+  sha256: 512969f339a9a7b347cdb7b88f439819168089867f04732279f02759d8caf24e
+  md5: 2009c2ee465fdd74dbd046de73726234
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 166501
+  timestamp: 1707229221324
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_0.tar.bz2
+  sha256: 18fcf8e1b8c1e60e900de74a5b92da8b2a35994e516633e25a44e2a999d87c55
+  md5: 5f71bbf181a1ef20bfd9f109d601be55
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 293162
+  timestamp: 1700254333982
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+  sha256: df81a27f221d11af4a709f272dc8ba3fd3f6d5ab4ffd883c40567bcf04f0cfd3
+  md5: e49333e3ffe1fe2e701f50a6e6dccc52
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204179
+  timestamp: 1698129906257
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
+  sha256: 53edaca56d853083d44cef6234fe4b3d076d107e915781ce54ec135c25e09f0e
+  md5: 5d1d51e53c11bcb56cf863d58e37c077
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50433
+  timestamp: 1683040076511
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py311hca03da5_0.tar.bz2
+  sha256: 78900105b8ca2c9ce2891de6f8338dd2af8c6b0a63beab5b75ccd99ee39492fe
+  md5: a756c63489618f8253181b875caa2671
+  depends:
+  - pyct >=0.4.4
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1980149
+  timestamp: 1677936576606
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py311hca03da5_0.tar.bz2
+  sha256: 1f0182e1752be7793ba6c8838ba6ef02fe14e53fc6416e2a5e269938e4835c09
+  md5: b739c2dfaec3151c90fb7581380c731c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15977
+  timestamp: 1677919288315
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+  sha256: 1f908c688e47d03d92ac09d9541a1f1c773ac2ca485dd1d77441b1aaefc032db
+  md5: 444c330471496a39a97e87f41ed70c96
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281104
+  timestamp: 1700583698464
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.11.0-py311hca03da5_0.tar.bz2
+  sha256: 66b75168a7eb1fa16c9ddd7004339dab4d4bd3557f60abfcfb9de706f27cfd42
+  md5: 4c482f6b591b73d95c21f967bd69b471
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3028051
+  timestamp: 1701396155471
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.16.0-py311hca03da5_0.tar.bz2
+  sha256: 2b7fcd83146c02c4d4b2e2adb2512172536118cb0f630c47a43b11c5005734bf
+  md5: 6687cac2611e1868f6ad781167a671c1
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy <2.0a0
+  - pandas <3.0.0
+  - param
+  - pillow
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17988386
+  timestamp: 1699548972355
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+  sha256: b9356e3ada4872c7c950d2ac7e0f107c4786775191efdfda3a469dffb18f2714
+  md5: 07ddd96675caf30ea77cafb1ea5662a4
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2490144
+  timestamp: 1690905181398
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.10.0-py311hca03da5_0.tar.bz2
+  sha256: 45b19b02debde95c5d041fdc56142d2bd9f73ae6b3886330a155e3f30e0bf184
+  md5: 851b0bdc5ef05a991187ebffb031b644
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 354094
+  timestamp: 1701286511713
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+  sha256: 25e05b93a99914a5fd1a298a2c5b25479fbd571b0db9caa7c6ad4336f060f62c
+  md5: e213b68bb0274e0e54c610a041e059f5
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 150168
+  timestamp: 1706888198288
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+  sha256: bbbcf47ef9249635b5199be1414b0b59687cc04ea9630d50ecc609dc200c095e
+  md5: 5820c373d6847a68551cadb8984a8277
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 95638
+  timestamp: 1706895270850
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpc-cpp-1.48.2-hc60591f_4.tar.bz2
+  sha256: 4787d6730eae9c37b11f76db852a2c0a070b4dabc9abb9e423fa3ad68944ed19
+  md5: 8dff6fefff4eabeeedc5a67b15d91aff
+  depends:
+  - abseil-cpp >=20230802.0,<20230802.1.0a0
+  - c-ares >=1.19.1,<2.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.20.4.0a0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - openssl 3.*
+  - openssl >=3.0.12,<4.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3884646
+  timestamp: 1701982736145
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gtest-1.14.0-h48ca7d4_0.tar.bz2
+  sha256: 064fc752345ef3973d3ebf2145029eaa308c17e12abe72a732255db9cdea6a40
+  md5: 37ace38cf07143b39ae9b89feb204d3d
+  depends:
+  - libcxx >=14.0.6
+  constrains:
+  - gmock 1.14.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 399378
+  timestamp: 1692633568295
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
+  sha256: 898d10bc1ededb43b7339ccf57fef404d96184de8ebaa788dba0b36a8c8a282d
+  md5: a1925e4ff9f6124ca7d439430bc110fb
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5399311
+  timestamp: 1707836657705
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.9.2-py311hca03da5_0.tar.bz2
+  sha256: 38744dc9d106d062336ecb9b881f729f77639a45b629f55370b635c32115180e
+  md5: 8293ebf287cf3fe7573cbf50ed50824a
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1990277
+  timestamp: 1706712464594
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+  sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
+  md5: 69eb3b03765627b6159ed23cdde78396
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28399065
+  timestamp: 1692293207812
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py311hca03da5_0.tar.bz2
+  sha256: 91535ae79966681095aa2d1463e0480d577ffb4874369d0e96d5fb1994829ef3
+  md5: ac3a53e1831ef6e75223125737f3a69a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 124616
+  timestamp: 1677906184652
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+  sha256: ec139e4b87aadcacc0670ecbcc2a303d858d4ac38b9404458a4b676bce9d21d5
+  md5: bfcfed281f8df0f18726ec5f843b2b26
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 51053
+  timestamp: 1704813595720
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+  sha256: 63670c8f31770e1746016f645ca6b42b35f92d1c37e8025793d9490fed9998c0
+  md5: 9cb417b9fdf02b4e007a5b5781e5a8cc
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229932
+  timestamp: 1705934202146
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+  sha256: a40c76c412ec793ca26b97a9b5c496d253768438e1f7d4a0ee5f63ea79eed355
+  md5: f609e4fe044318211cf0e37e289beebd
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1614299
+  timestamp: 1704833142734
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+  sha256: e57d10579b52a3cde45aa17e1bdd95dcb9d3346aa00eb02c51e38a42db83e18d
+  md5: 05153120787fb09159b6e1ad902c6e10
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1180481
+  timestamp: 1678994989550
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
+  sha256: 06512ef9a910fa72bf5697fe89e88c605d61f8478a9d8dd233c13f40e30f8446
+  md5: cfa00c9ffd3407e29507525c020e5526
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 355730
+  timestamp: 1706733720706
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
+  md5: 055e12390b844ea6c6e956ee08a618e8
+  license: IJG
+  license_family: Other
+  size: 273479
+  timestamp: 1677849171867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+  sha256: 62025ce4a2b9244b9816c9e02487e0dda567600692b5f9ca71f425d084961c7e
+  md5: d57b7063122e5bf25cdfc2a5ea7330a8
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 181872
+  timestamp: 1699041739097
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+  sha256: 404b0847029f77bedd7902a170a046219e0dc5c0ec2be19ff45361cff25b2181
+  md5: 3a02bbe8d45fdbcb2350f672be74c9f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16524
+  timestamp: 1699032463763
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter-lsp-2.2.0-py311hca03da5_0.tar.bz2
+  sha256: 8d8eb94257336543a0c6a2168a68195ee1258af47f4b5b58d8797ac483744a63
+  md5: 191fecf4322e1348caac6337955a9e5a
+  depends:
+  - jupyter_server >=1.1.2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101675
+  timestamp: 1699978313832
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-8.6.0-py311hca03da5_0.tar.bz2
+  sha256: bb525ddbadaeb7090eb5bf8aaf2d4d01765c5e2e93136a47fbb1f5b663bab567
+  md5: df7c907e1d274521660c4e2030c5b6ef
+  depends:
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 225157
+  timestamp: 1699455930116
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+  sha256: 8220b1bbdde5e800810f7bf183a992af1a95825a837edf975fa8c4b51c5d806f
+  md5: 3a06ddad06e04d5f0211c22cd81ca75a
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94950
+  timestamp: 1698937436979
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+  sha256: 8a9a9f9ddbf1b7744ef04a8c862438499a41d81a4beb4a49860156c273bb7497
+  md5: 051355801f09eefe850ee8145151f934
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42497
+  timestamp: 1699282590553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+  sha256: 65c703cc996a705d0ee350070e313b1cae865f9d6e6490ebf1164c0f3ce22d93
+  md5: 305ad8bcaad3e352d61b1e594093b467
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 596801
+  timestamp: 1699466743685
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+  sha256: 501e929d345aaa9079c965552b942b4e8bde35b87ae89faef003687a40bab3a4
+  md5: 54c7b8554a405acd7c8326c41ba93e63
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28237
+  timestamp: 1686870817418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab-4.0.11-py311hca03da5_0.tar.bz2
+  sha256: 7c07921656d5a8f8fdc8e5edb0b18ffdfbde22a1938258cf29e78b5b66c93928
+  md5: b152aceb76578939f6aced4bf328dee9
+  depends:
+  - async-lru >=1.0.0
+  - ipykernel
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.19.0,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  - traitlets
+  constrains:
+  - nodejs >=18.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6667686
+  timestamp: 1706803531409
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_server-2.25.1-py311hca03da5_0.tar.bz2
+  sha256: e28c8ba9c667ba5a276d3302005b990874c6de77e4fc785f87224a2dc2ca5394
+  md5: 3873f22212fb841a76c5348f5f6acf98
+  depends:
+  - babel >=2.10
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18.0
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.11,<3.12.0a0
+  - requests >=2.31
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 107252
+  timestamp: 1699555538493
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+  sha256: 8c1c64d51be73aad381992a9df19d8336910bdfc40f19940231df86e177d17cc
+  md5: b1f786f96684a143cf30d1f6b8aebdb3
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65045
+  timestamp: 1677925371836
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
+  sha256: 789402b67398d3d936ac4486df01869d59b0e1ba298cbd06407d059aced871e4
+  md5: a0f50a38705d0507bbf57ee49a1d9c29
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - openssl >=3.0.8,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1308175
+  timestamp: 1686931157327
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
+  sha256: c1f104bc84ee46a3d3beafb5e35236c64e6b4fd6cceabfb420e1838171b1d9c1
+  md5: 4f95903a1be48bbee1f9a818ec810b89
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 22243663
+  timestamp: 1696762144385
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
+  md5: a0f206782751dfffed0dd51302a1bf26
+  license: MIT
+  size: 68012
+  timestamp: 1659616138077
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
+  md5: 4c6667cdd061d28e9bc4e4300e4d115e
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 31173
+  timestamp: 1659616155596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
+  md5: 637e9430e258ddf050623ef2360184d8
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 298430
+  timestamp: 1659616172209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.5.0-h3e2b118_0.tar.bz2
+  sha256: 5f11db2220b728d4e13e1d0069aeb0215719a7bdfce88ecfc7be68778986eb54
+  md5: 131c9519f6e616b3295735ac1a7f9c2e
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.57.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=3.0.12,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 357001
+  timestamp: 1704383770648
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+  sha256: 9597df5344a718d37837966aa05091faf210260898fad5e7a64b87f17de9e90d
+  md5: 678a1f87940ef6cc421a092301b8c3fe
+  depends:
+  - ncurses >=6.4,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 167208
+  timestamp: 1703006281321
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+  sha256: 6fc572025852b210ecddcca3ab9ff3f1d5f6bd91f1933c6e296de6bb331f6b5d
+  md5: 6dd7d9c5737bbd2a27d18f15318dc3e6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 102059
+  timestamp: 1628961869728
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+  sha256: 9e7b9bb9367d8725a751cdfa0b2d270434d303ea196cfaacc605ee26be09874a
+  md5: 44d1843cc2f17eb2674f35b95468f551
+  depends:
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 415467
+  timestamp: 1685052299052
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+  sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
+  md5: 55c615026c0869f8d3ba657f3bd38c43
+  license: MIT
+  license_family: MIT
+  size: 120389
+  timestamp: 1683716579036
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+  sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
+  md5: a41117710dafe569c9cc4e83f6f29fe3
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1411339
+  timestamp: 1650982753977
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+  sha256: d654027daea13ac9db36ab5fd5eff3ad398ec97c1777bf399f3ec680d2c145b9
+  md5: baabb1f905054bfea3af8f5768572a34
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 26579907
+  timestamp: 1683291669565
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
+  sha256: b7cd58ddb892ed9d3983bdde8fc2530f0653a58818c87e08659f3795f04d8aff
+  md5: cf519f7233951d00a30c3b969c4cd161
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - c-ares >=1.7.5
+  - libcxx >=14.0.6
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 728977
+  timestamp: 1697018415626
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
+  sha256: 239ec46c06c477e722230159971bac8d9eb14793a2e75f6e3d3a7a04ed5d5ebd
+  md5: 50e9c501f39bb262703c764789099f24
+  depends:
+  - libcxx >=14.0.6
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2338901
+  timestamp: 1675278555141
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h02f6b3c_2.tar.bz2
+  sha256: c16b9310ccbfef25d8cc35d53acaf40af838170f7fdb87df5178baaf096a9045
+  md5: 41dce58413afe3226a5c8c66fea6db05
+  depends:
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 334603
+  timestamp: 1686931243969
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
+  sha256: 82a73882a31e7a4f4edcdb0c21562e123da913d03b90b19396bd6dd4fcd9a7fc
+  md5: b5e5199892949d1e7e2db7bf0ee4dfe9
+  depends:
+  - boost-cpp >=1.73
+  - libcxx >=14.0.6
+  - libevent >=2.1.12,<2.1.13.0a0
+  - openssl >=3.0.9,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 361781
+  timestamp: 1687975246139
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+  sha256: 41c62a460bb81a1a272aa28b219fab9c26510adac177ff1528b1980eabc6e868
+  md5: 8d312c5628dc7ea833e9b4dcb73e9c45
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 42346
+  timestamp: 1677973051421
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
+  sha256: 911c7577f591311bfb000121831234e7bc6332bff62fd00c2245371e67f473c0
+  md5: 419681f23f179ba08e5fdf9884ea238d
+  depends:
+  - libcxx >=14.0.6
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 410616
+  timestamp: 1706910762686
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+  sha256: 5777bbef827f72975a36f3da80ab4af718dc781264f74ad7e3864755d620c0f0
+  md5: 4240f1a79b812387919cc710a0469556
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14318
+  timestamp: 1677925438733
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+  sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
+  md5: c99006da802a97c9aae30da8c16b4820
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176131
+  timestamp: 1670944706815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+  sha256: d024f5142416961a5e66e424d4d14aec652f9e9dd738b41a97f45674c2ffc9d5
+  md5: 0e2d94b125d802f7b006cf19c71655a1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 163084
+  timestamp: 1677932947966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+  sha256: acfd84e29ff4dc2d85543bb973a07f22b4ba53c5d00bca84608ee7f13b2a8676
+  md5: 5ca161cd51e2db358e768453b3ee485e
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135871
+  timestamp: 1684279980293
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+  sha256: b1bed54c7bfb7304cde9e8e6f798543d08e808e81286a5a48296fc94d621f9da
+  md5: 774358285c9e496c9f5c121cc546c823
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27438
+  timestamp: 1704206026910
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py311h7aedaa7_0.tar.bz2
+  sha256: 3da52ef1129befc15f1a7085ac48de8800d41c110c3283813541c6447a4f59ab
+  md5: 8a032bf4688298c856578ef7717f51e9
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9087688
+  timestamp: 1698692324263
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+  sha256: 3276d61fc353c537bb09d4b7473d7abe12be38806f42c8cc383b62f40850a5cc
+  md5: 6e9c9d47f264b77d9a8461f0899848a7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20446
+  timestamp: 1677918370379
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+  sha256: 43c96d30775b61b4968422a47f9605049428120669f0742bbb9e5ba145c7d11e
+  md5: a31ca0d9284860adf5463cf45a5e3145
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 69243
+  timestamp: 1677995336989
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+  sha256: 96d8c9f42a38651b7bafe5f3cb132601db76cd1e28fa58e2eaf090e634292fff
+  md5: 5ebc793a17b6aa84d13f19433545ffa5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23895
+  timestamp: 1677942274932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+  sha256: db9bd659ada23f1ded443d2db00dd13b5d5c0b30f5062544b1ee2c2b88d63d29
+  md5: 03c48121614cf12abfe30eced9b34717
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105333
+  timestamp: 1677916687032
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+  sha256: 8b05894fdcbe5cfcdee94812b043de4cd7b4fa51d3e2aad25fc7cff50c8f82ab
+  md5: c970d49137dce1c77f782ee5725950c1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 30745
+  timestamp: 1677960816849
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+  sha256: e8eee27fb667aa10b26f3bc4b93f449b7d991ded27b9cb457effee394ce05f6f
+  md5: 6a3e5cd0e1141c01ffb91285bdccfe83
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123043
+  timestamp: 1698934328890
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+  sha256: 40230434aa2fbb33ece13632e8d4b7cd1ad68fdb8d1b00263af4a010795d25f8
+  md5: f12ce7dad3620d6d53a442fa9d36a0b0
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - pyqtwebengine >=5.15
+  - tornado >=6.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 538067
+  timestamp: 1699022954841
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+  sha256: a492acec8ceadc0911a75966ffa630a8eb15b2da8c7a8d544a645ba47771a2d1
+  md5: 4002b1b88b2ecfdfc769036f43b0a895
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 170964
+  timestamp: 1694616845237
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+  sha256: 417ace1ce51e81f3f92ddc26e0e3a83c1e19c9ebb7af7104452002a5573da534
+  md5: 3e11de6cef096091bb733e07802f00b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16979
+  timestamp: 1708532698253
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-7.0.8-py311hca03da5_0.tar.bz2
+  sha256: 0aab440b27d9cab7a31c41d0198be602a88c41a95efb9e7b5be99a96ee2fc6cb
+  md5: 959445d700f0266e95d1bdf5809d34bf
+  depends:
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab >=4.0.2,<4.1
+  - jupyterlab_server >=2.22.1,<3
+  - notebook-shim >=0.2,<0.3
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3671288
+  timestamp: 1708030081801
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+  sha256: b0cc542e2a6f42ba716e7e4ccf29eddcb155ad167fcdbc72d2db9c7873eb5639
+  md5: 7acf81b17d2c4ceb3cd39dc9f173855c
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27539
+  timestamp: 1699455954000
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.59.0-py311h7aedaa7_0.tar.bz2
+  sha256: 58644d56d161e63cdf56e15b8af2a5746b2f0b3566de267585c49d604708fbdb
+  md5: 3563748843fceaf6a4a5c46df45e6233
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.42.0,<0.43.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - cudatoolkit >=10.2
+  - numba-rvsdg 0.0.*
+  - libopenblas >=0.3.18, !=0.3.20
+  - cuda-python >=11.6
+  - scipy >=1.0
+  - tbb >=2021.6,<2022
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6058828
+  timestamp: 1707086185656
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+  sha256: 151a3eb68d1189e69764ece1d8fb3544d31a22f5bbbc3e19d846de8dece304d2
+  md5: eb6609e6bdc9c82d70df3f8c4c2de95b
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153313
+  timestamp: 1696515415712
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+  sha256: d3bb1d4be88320a5861cd3a0f086e9709f9b64c96c032cb9039cc4f17ec66a85
+  md5: 0a7b97665c06fcd34a70e34abc177280
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.26.4 py311hfbfe69c_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11288
+  timestamp: 1708639168951
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+  sha256: 3e70248a7069ca12ccf56252869bfdb72211fd4e4c327e6994756496df786c79
+  md5: ce4846006d98638cd86a532a72f8dfe4
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311he598dae_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7536860
+  timestamp: 1708639153133
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
+  md5: 371358a54bbdd307603888348d1a2c6f
+  depends:
+  - libcxx >=12.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD 2-Clause
+  size: 412248
+  timestamp: 1628861367714
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_0.tar.bz2
+  sha256: facd0cf76309dc1b1ee0c7ac6b09cf66579014e41465eddeaf65faf5f886866d
+  md5: 81ee9a235e1ea8e7575c3c73495fee73
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 6343688
+  timestamp: 1706909118317
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
+  sha256: c4135710b5536fb859a6672c055bbc2cff0426e0655e75c7fdf808f7f3344ada
+  md5: 483605a01fccba850b7f0cbdeff29858
+  depends:
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.9,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 421604
+  timestamp: 1676482754496
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+  sha256: 77b0c0a0fb14d817390244ebd93c36d44a7867239963f211f7c0a72a3f98d382
+  md5: b90336feb8a50d2eff880e89acb02f40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39617
+  timestamp: 1699371253760
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py311hca03da5_0.tar.bz2
+  sha256: ce5eb462d7fb1524d353faf2096260ed65ccbbc20fcb8132813524736e402206
+  md5: d086ecc9233b5cbd62ab53cc59d638dc
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 94576
+  timestamp: 1693575249609
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.4-py311h7aedaa7_0.tar.bz2
+  sha256: ad73567d6bf389563175f497502ed44997c53f789278baf156cd495a198090a0
+  md5: 7eb05ca2fff7a8c6db506af74ea80329
+  depends:
+  - bottleneck >=1.3.4
+  - libcxx >=14.0.6
+  - numexpr >=2.8.0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - sqlalchemy >=1.4.36
+  - pyarrow >=7.0.0
+  - pyreadstat >=1.1.5
+  - pyxlsb >=1.0.9
+  - blosc >=1.21.0
+  - fastparquet >=0.8.1
+  - s3fs >=2022.05.0
+  - pymysql >=1.0.2
+  - beautifulsoup4 >=4.11.1
+  - gcsfs >=2022.05.0
+  - dataframe-api-compat >=0.1.7
+  - xlsxwriter >=3.0.3
+  - pyqt >=5.15.6,<6
+  - xlrd >=2.0.1
+  - matplotlib-base >=3.6.1
+  - jinja2 >=3.1.2
+  - tabulate >=0.8.10
+  - psycopg2 >=2.9.3
+  - zstandard >=0.17.0
+  - pytables >=3.7.0
+  - xarray >=2022.03.0
+  - fsspec >=2022.05.0
+  - openpyxl >=3.0.10
+  - qtpy >=2.2.0
+  - numba >=0.55.2
+  - lxml >=4.8.0
+  - odfpy>=1.4.1
+  - html5lib >=1.1
+  - pandas-gbq >=0.17.5
+  - scipy >=1.8.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16231013
+  timestamp: 1702319217107
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.8-py311hca03da5_0.tar.bz2
+  sha256: 2232daa3075c0c344684268ed4aaf922894787928efa1acd51ebdd939365837a
+  md5: 6c986a04b608c9b13280f84290442ed4
+  depends:
+  - bleach
+  - bokeh >=3.2.0,<3.4
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.0.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.17.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18187036
+  timestamp: 1706539764590
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.2-py311hca03da5_0.tar.bz2
+  sha256: bf72807672308638cfe45b7779f9284305cb99cd7caff9fb1c1319ad98494e2f
+  md5: 6408b94b5ca53fc26b1e1997bcc34382
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 257144
+  timestamp: 1705937843381
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+  sha256: 088245becd055af4de74e4ed13cc752ab546423f204b170ba2dd8809af30a2c7
+  md5: 2eabea5ccc56ac088e0349626e59df06
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48517
+  timestamp: 1698702686783
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.2.0-py311h80987f9_0.tar.bz2
+  sha256: 9b723b1be321340764f3e7941266445575c6bd33a120f9a99eb419c36db8f750
+  md5: aba11ac677d0312fc4694fcd9b4f1b5a
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 900885
+  timestamp: 1707233080957
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3.1-py311hca03da5_0.tar.bz2
+  sha256: f6298f1b93b2c4f62e11be8f5cb1c184b9774492626f3c93a004cf5d7e4e84f6
+  md5: 92d6c6c6a869b6d1449ddc614f622c42
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3445195
+  timestamp: 1700667693168
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+  sha256: b6200816d65673aa1707c20a768c9cff87dd8dbe1335f9c1478e5931dfa08ee0
+  md5: 14b1e0fa73eb33f9c83048482dcce57b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38423
+  timestamp: 1692205689597
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+  sha256: ebdf211edd98d88a23778551c7a9702106edd0695d4fc48e87c21f77521c1ffe
+  md5: d8c505081a468f1b99c62466e2309417
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 123084
+  timestamp: 1678996822234
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+  sha256: 07cfba50d9e94364bde077731a824ca4f537138b35ee6b66d07aee16ac9850f1
+  md5: 919bf486280a11e6acb3c2c3a82f7473
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763225
+  timestamp: 1704404463402
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+  sha256: 8094436b2c44e68e72569c704633802aad82e977b1e16026848218679c8becf4
+  md5: 2360e46d3e598dd5e2abed781fe166c5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 502115
+  timestamp: 1678995719872
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-14.0.2-py311ha07b5f9_0.tar.bz2
+  sha256: 4ef0edee30559d99ce74a3207b5e594420549d743b6a6942f4910909f0bf7f15
+  md5: ee7f74b498c265a06b470b7f853612e0
+  depends:
+  - arrow-cpp >=14.0.2,<14.0.3.0a0
+  - boost-cpp
+  - libcxx >=14.0.6
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4965174
+  timestamp: 1707331530109
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+  sha256: 4f17f70658e32a9a86661184cace6be3bb7bd61f9b55b513092beddf44552679
+  md5: 0aa95279688b0433badea0b660ac8146
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38653
+  timestamp: 1677933613643
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+  sha256: 121b5b66721760c05f1d4eee91626229d1814663d3fb5f23126ef870aa496e26
+  md5: 0c588c2ca790a05d422c06e8568201ad
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2124200
+  timestamp: 1684280082141
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+  sha256: 44b694db8e81d61960d28d60f9e9b573f03f7827881d302da334378881db4889
+  md5: 6c94ba7caa599ff533e0ab55d898be8a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 208454
+  timestamp: 1677910948527
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+  sha256: 0bb3d2a57b332c5cf73ea40ea13c850ae24a1f9a3a41ed9267832d9e3c767572
+  md5: 45a7fcf1641980d5114999736428502d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36755
+  timestamp: 1677906514270
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.8-hb885b13_0.tar.bz2
+  sha256: 7db8bda1ad368413284ee399322d421feb385863426f8ce3167c0eee6788b8d6
+  md5: b1b70eac1af7d86cc231d9b695ff1d3e
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.5,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16417657
+  timestamp: 1708983786954
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+  sha256: f94b3cfea6f76ea9983e16d3c4c7e0a64f02c40cc2c3ad57189bca2e67030bd9
+  md5: 0d100990ade57a02b60d1e8085db0bdf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 280263
+  timestamp: 1678996927464
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+  sha256: 252c86f5aef7f8dfce99a260c24cbb35a9adfea144a2acfabb224f516341544f
+  md5: 745b888e19a644f48800799f82c01c21
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18539
+  timestamp: 1683823925189
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py311hca03da5_0.tar.bz2
+  sha256: f8cc25e0bc49acf0af5cdf745f34f7d35a877ef06139e32ca5106eef7697051d
+  md5: 4b486ff581b914b8276656a84479f214
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 267956
+  timestamp: 1695131641887
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.0-py311hca03da5_0.tar.bz2
+  sha256: a0c6c59c5626b13a70938bf3ab7e5884059e0100b8d9cc3d16a9f4fcf04e336d
+  md5: 3e170ed828445a213e568c666aaa5c7c
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64735
+  timestamp: 1701728050405
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+  sha256: 4f04a43cbd612ab09cefbdc2e48ee61b51967dad59d859ce0502cc2c46c88fc5
+  md5: c68bf65433b2151b51b2e699bc22c501
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 194632
+  timestamp: 1698096151085
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-25.1.2-py311h313beb8_0.tar.bz2
+  sha256: 66d6bcf8e67799c60b41ed3c14d352cc065abee1afe41fab710eac41ddb27809
+  md5: 488d9d295388699484bd2d1226157163
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 543785
+  timestamp: 1705605339487
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+  sha256: 089c6b9bebfa690f380710f219ab0fcc1acec9f2e187d4174a08222c45f58afc
+  md5: 11b832c6c10a6d2b0e687a20c3037c97
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-3-Clause
+  size: 194532
+  timestamp: 1652449531448
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+  sha256: 7a208abc002a2fc208ae25cb2cf932999a3e4980aa4c9edff315cb9ac62b12ce
+  md5: bd22ebd3cff811577ea61f115ba7f4f2
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74744
+  timestamp: 1699012126255
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
+  sha256: cc8d055a068fe5a7484284c3360d81db61656dd6118c743c740fcc47cd3da379
+  md5: e5fad71ef3b99077b79052576e51bf9f
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 120672
+  timestamp: 1707355664440
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+  sha256: 52368d9b557b8f54ef5ca4bf6cd5a3ec665171f2b2d2082cdd410bab88f4829c
+  md5: ac76fb4d2eef3ecdd491cf5d3fb8620d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10204
+  timestamp: 1683077239143
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+  sha256: 491d116c5f54ef340e3bce631835f7138cd1923d7b63e6ca9aa01b48110cb8f9
+  md5: 9b81bd8ea808704f5433884b567f1f15
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10557
+  timestamp: 1683059079547
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+  sha256: b53a5f6119173d62e4e68a37ea8511c7fc87a00af72953e0048d075a799c7a7a
+  md5: 76a16cf4edb9b12b2b96a2d323f060dc
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 342535
+  timestamp: 1698945991201
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.4-py311hc76d9b0_0.tar.bz2
+  sha256: 3550487285cafe22b3bac9eb60439600c27d6a77906efbc377949819267bdd34
+  md5: b20e6556db358f62dc816548d376e078
+  depends:
+  - blas * openblas
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.23.5,<1.28
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24658627
+  timestamp: 1701296201411
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+  sha256: c80d52567084b1caaed2862b77b70065ca17afaf0b020733e9d6c273b4a63e78
+  md5: ddf7d88c1967f3f7a4ce1c975fd47e0d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33321
+  timestamp: 1699371225235
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.2.2-py311hca03da5_0.tar.bz2
+  sha256: bba54d36884cbbc17c6a9d7084829e43591b6d93b24ac95ec96da59166c97c04
+  md5: 8cc3f395928902a35730a8090ba44e99
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1464983
+  timestamp: 1702505333484
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.1.10-h313beb8_1.tar.bz2
+  sha256: f340be28c71abb0b785dd78f742e12befb08e37b77087924364e01a7b1d25bda
+  md5: 4f553ef7b00e79fb67318e680da9fdaa
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 42517
+  timestamp: 1702909400491
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+  sha256: cd71091a234874d2826fa063ec5222b3191c9f47e1b5281c352d9df3f31a06bf
+  md5: 0db8e29016c6bff026c083d9923a7566
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19073
+  timestamp: 1705431415504
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+  sha256: 3e18cdafc607c6d7623b1c8f041cbfbb50a27e298f961abdcce7e36834ac39e1
+  md5: 9ee0da74c55d0b8d83edf246fd717f20
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89862
+  timestamp: 1696347657368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/spatialpandas-0.4.10-py311hca03da5_0.tar.bz2
+  sha256: 826cbb85537b6da88a90b75f26e119b3a090dc0619b78985237ec18dd0cda0c8
+  md5: 4b8f39c5bb27448d160de0dd9b10cd11
+  depends:
+  - dask-core
+  - fsspec
+  - numba
+  - pandas
+  - param
+  - pyarrow >=1.0
+  - python >=3.11,<3.12.0a0
+  - retrying
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 201118
+  timestamp: 1705085077616
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+  sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
+  md5: 2302a79a045f152e183a52a81adfba62
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1674163
+  timestamp: 1681394762218
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+  sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
+  md5: ae58720a18a2ed15eae214ad7a10d1b5
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 140125
+  timestamp: 1680167256603
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+  sha256: b5c265e9ed9a1ff2238a09b83bdc1826950faa87fd6b685debe60888de6e7a50
+  md5: 5827c8a32317894ce18576e334daba47
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38559
+  timestamp: 1677918962258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+  sha256: cfefd86d0f4981d22b7611b3dc60359b8698bf39f2b743cb90b7005aaca88e1e
+  md5: a04dbcd6095f6b8f3ad195a78d48b262
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50058
+  timestamp: 1677917499177
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+  sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
+  md5: 667e60c8b407d73cbba40f44901f4f00
+  depends:
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3412693
+  timestamp: 1654088929697
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+  sha256: 0836468fafb1f5badbb573922e37200c6929bf2926ecf8d2259dff43811e0727
+  md5: 5bc56dcb4bdb7cf623b7cea499feaddb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 136409
+  timestamp: 1677925889207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+  sha256: 177246487449f87567fe56c8f20011a4350a132d1556c9f87474d7b2e8c1374f
+  md5: d465118217b9f27d47dceff89c2e9f95
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 896655
+  timestamp: 1696937042980
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py311hb6e6a13_0.tar.bz2
+  sha256: 5a1fa09dad8becc420220686970bbaa80d6cc11c0db0a50b82eea7916da8da9e
+  md5: 3a32fec6b7aad634be22db2c2ca01b4d
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  - slack-sdk
+  - requests
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 152999
+  timestamp: 1679562052353
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+  sha256: 65e760119352cd85c63d365d2576c09a9ddb060e5b029a265d50bc268eed9290
+  md5: 14c241871b12dc3be52e6cd681267caf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 271445
+  timestamp: 1677911758960
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.9.0-py311hca03da5_1.tar.bz2
+  sha256: eb3608b1f32c4a791ca19a69cf611e470ec7bb722e40f27d3e5f6dbc76c69ecc
+  md5: e4ada62e242b4702435995090405d693
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.9.0 py311hca03da5_1
+  license: PSF-2.0
+  license_family: PSF
+  size: 9874
+  timestamp: 1705599390176
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.9.0-py311hca03da5_1.tar.bz2
+  sha256: 0899503a82d0e0a765a7e9d1a0480c3b1c389f4d6e68b633400271380172118e
+  md5: 224636c70a8945f989ebf39b8cfcf52a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 71941
+  timestamp: 1705599383532
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+  sha256: 2ea2d0520b330d381a2ab241bdb9ae146ef815ee7c96ee52a9773fb9ae85f4fd
+  md5: 66f7f8979cfb2cccffac972d70482130
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 12614
+  timestamp: 1677963554857
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.1.0-py311hca03da5_1.tar.bz2
+  sha256: ec56a4893344adc6712b9915267bb5faca7203496f8ad924cba7ebf2cec302b9
+  md5: 7dd5b6728562eaa24668abd062985f4d
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - zstandard >=0.18.0
+  - requests >=2.26.0
+  - selenium >=4.4.3
+  license: MIT
+  license_family: MIT
+  size: 184702
+  timestamp: 1707770626151
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+  sha256: 20ae100fd04de16356f26e7c9dab514015e57a9d54fb78767aa5ed97de7846fb
+  md5: f620d98b3d0072945948310c86f0f1c5
+  license: MIT
+  license_family: MIT
+  size: 157385
+  timestamp: 1706894678643
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+  sha256: 09738b7f9075386bf062b12ddb6fb72a06450d2481f6b5ca2026c811cd849569
+  md5: 9afdec076c95746ac21235f971190e40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26727
+  timestamp: 1677910175964
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py311hca03da5_4.tar.bz2
+  sha256: e7e149717c2a2f69f4e80a97aaeff1e929309abeaacf856020e709a9663df561
+  md5: 2ea9e4e91d48d4e0697990e52d1c2b96
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 91423
+  timestamp: 1677919120338
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py311hca03da5_0.tar.bz2
+  sha256: d84b9b0d2e1b8c23f2a12c466c37df43b3a6c55bcf2ec7feead52a5ce4fc4652
+  md5: 258d088b822011748130c24d4a205e0c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135718
+  timestamp: 1695741999838
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+  sha256: cf030fc7020dc6d28530075468b8dc1edd843a1e393a2f81ca81c962e9af977b
+  md5: cae3fc90233f3af8f433a253d035b6e6
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2470844
+  timestamp: 1689041497962
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+  sha256: 2cd108896df65636769e3804ecc2ca421ad9b54e64fa21922bbabe40c90c247a
+  md5: b3a1e5077b28f71298d891fbfb5ff03e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55645
+  timestamp: 1677927459979
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_0.tar.bz2
+  sha256: 85c9b1e0bce1cd413fca9b3488682812a4e232fe0661a2679c3d88a0c10552ca
+  md5: 704baf12587c18a04d0c66394b1890e8
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 475787
+  timestamp: 1709048675809
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+  sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
+  md5: 3d57d1adadca9388aaaa1c529b65ba65
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 322790
+  timestamp: 1705602163804
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
+  sha256: cf38c69cf62d8f07b91b14bef8e0b6fc5ac220bd3a6cd2ab0378283f0f11494a
+  md5: 11660f745caf5eed1d03eafadb32678b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 25470
+  timestamp: 1704206932876
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+  sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
+  md5: 467ae28215d1aa1c5688bc0c8a184269
+  license: Zlib
+  license_family: Other
+  size: 103525
+  timestamp: 1666595022664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+  sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
+  md5: 7cfbed15f1feee1422810f7830075f53
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 779464
+  timestamp: 1681304594848
+- conda: https://repo.anaconda.com/pkgs/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
+  sha256: c5a4f98a90713f799a73195cc159571c4bd373bfa43640dc0c1707608e582945
+  md5: 537f198da93942d8ef7008606edae551
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2363136
+  timestamp: 1652426285158
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+  sha256: 6e6787755de0cf2fd776c9681a7b0fd0fb23e35e679a463cc2005b991c413910
+  md5: ccad42ec9a2ad48939f089c528abc8f0
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 229694
+  timestamp: 1706220431719
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+  sha256: f715f7c2e06149bd6d43258e41479d3171efe5e9d56050a0a5f5652ed9d05fff
+  md5: 11a8ca43d69881b88f95ae681478866d
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 36089
+  timestamp: 1676424516042
+- conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-14.0.2-ha81ea56_1.tar.bz2
+  sha256: 5d0903878b06d0a444fa43444390f3b662f6338750e23ee2817c784246ff7098
+  md5: e0fda639825394bcb3a87b639c0d7a11
+  depends:
+  - abseil-cpp >=20211102.0,<20211102.1.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - aws-sdk-cpp >=1.10.55,<1.10.56.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-ares >=1.18.1,<2.0a0
+  - glog >=0.5.0,<0.6.0a0
+  - grpc-cpp >=1.48.2,<1.49.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.13,<4.0a0
+  - orc >=1.7.4,<1.7.5.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.9,<2.0a0
+  - utf8proc >=2.6.1,<2.9.0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 9794512
+  timestamp: 1707254932864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/async-lru-2.0.4-py311haa95532_0.tar.bz2
+  sha256: 6acc4dc697147467d128382439a1648f2dc6c498d0a97aa9c44ef5de2962cdc6
+  md5: 8baa05a5d81f5f0dd92cdd60fd509486
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 21308
+  timestamp: 1699554782283
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+  sha256: 9adabcdd2a10f73fa5ba56adc901eeea2e379991a0d4cb9737eec7aa6b9fc5d8
+  md5: fc80b572be85601706d425b21a58d497
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153102
+  timestamp: 1695718054194
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
+  sha256: a11741c5aaa360b4772d0fb7eea606edb5266a4e2806b22f0b8b65b69b7a7273
+  md5: 9a54285c5e75ab5e6bfcb3b5590f9449
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 93395
+  timestamp: 1706746331576
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
+  sha256: 32b4da68dd0edbf0c8d7a8a18ba400b26775faabaccbc2cb3e9d2ab7c65e7714
+  md5: 48f0a7a7f739d8be4c9dd061be217619
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 45714
+  timestamp: 1706691182873
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
+  sha256: d2710c7f5b4bb8f94a964996387fbd6396f9881d163affeb7ffb050a39e58c1c
+  md5: 1a8a2f82798a94d1b272ec2d307cc5ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 195487
+  timestamp: 1706190077309
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
+  sha256: 0a5ea74ebcf9bdccfad972add8ff83a47992ab28370cebc34fc4594c1c7cf03a
+  md5: 2f90d407ca685c124ddb5fc4d79f4517
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 21804
+  timestamp: 1706690937014
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
+  sha256: 334d2d9c4181c9955256485f66bf4e48ae9b1dc03044aa0424bf1fda292b3151
+  md5: 9ab57953af3164d3d94001eeca0e6359
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52661
+  timestamp: 1706697357084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
+  sha256: 59155d1258b4e29c0046e5ab14b1e2cb3ccfca069982fe9dd4cd751b1ed67492
+  md5: 28bd7c351db93c3b8520cc1598eddf66
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-compression >=0.2.16,<0.2.17.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 177605
+  timestamp: 1706744253596
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
+  sha256: 3aa9b1c2c508a5dcfb482083cb986498f6df460e652cc7557d3c2d122d559ebe
+  md5: b8bf7ae26d234b6738fc37b7c172b3c5
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145865
+  timestamp: 1706696287610
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
+  sha256: 68564155186523ec8b97b892d0a6b62b3e6f75e4e2b80fac5684011e070295d6
+  md5: ba2fa531a69a5a7e4966eba6d7891c8b
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 69542
+  timestamp: 1706746839018
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
+  sha256: 9c0f2f18f8b7e10e940d2438d70a2a03893421f25fd50461b8b2979f3a310a15
+  md5: da0f3ce6d8f71a71e6cae01832d853f5
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 72614
+  timestamp: 1706747680710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
+  sha256: bcee1da236f6f5f88322979daddc89e8555648593f6282ad3073a68eb22a68d2
+  md5: bf4c19b0db5049930d8b2fcc3b9172fa
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51027
+  timestamp: 1706690972693
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
+  sha256: 32561df1e664cb320f79c26c5af23dd55953924e66824e2d6372a44687147bdc
+  md5: 05f4c6715180a992468035c0a86e734c
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 54300
+  timestamp: 1706192197648
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
+  sha256: 94d2fff3facfd248968d39a3fd7d3b1f7270df32a87dd567c33d60da1a5eb064
+  md5: 64fed6e7c73d88bfbfc39e838022f948
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
+  - aws-c-s3 >=0.1.51,<0.1.52.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 199877
+  timestamp: 1706827970924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.10.55-hd77b12b_0.tar.bz2
+  sha256: 813f252df10d2782fbb26e2c6348f55d44ef1618467e340224df44bcda4814ff
+  md5: 8efc1448ada827ddba894a07903808dc
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2519847
+  timestamp: 1706890866084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/babel-2.11.0-py311haa95532_0.tar.bz2
+  sha256: b94e6065a6fec9259eef85dc952c59bf20e854682cbf934f04a0c2f1ac2417f0
+  md5: 50cfce72575fcdf3757c27bc6ba5d0e9
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pytz >=2015.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7218701
+  timestamp: 1676427266094
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+  sha256: 38ccda1553733326d99a75436b4b0f7640bafbbfcdbc33838b0e59cf017de687
+  md5: 3f6812578c5e0b3ba0d2a651cc766c15
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 266405
+  timestamp: 1681493141116
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.4-py311h746a85d_0.tar.bz2
+  sha256: 8450618c2bd233e851007daf1e022cd8fdc660a07b04c24da6484d2bc8757851
+  md5: fa1651f65858b6f42a8259d8ec788675
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5957046
+  timestamp: 1706912402593
+- conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+  sha256: 68ef338b27c035add89c0812ad469dd8c9e94f27130f770345ea20deb049d50b
+  md5: 9ec19b145f655329532b608963cf32f4
+  depends:
+  - libboost 1.82.0 h3399ecb_2
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 11334
+  timestamp: 1696764270626
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+  sha256: 5c12a5d7856d9977447360b3a99a5b99818707fe79781ba1779037f11b3fef53
+  md5: 6a125ae352306a944aabc635a5fe13a3
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 139230
+  timestamp: 1707864402762
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
+  md5: 507dfe693ef429f466d964b599f4af21
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_7
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 18650
+  timestamp: 1659616328001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
+  md5: d0bf43e8df60baae3b3105aa5c42a791
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 21153
+  timestamp: 1659616312367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_7.tar.bz2
+  sha256: a210ef4e1570b7220c9a7a30dce3e598b46585531951906fd4e8e996357842a6
+  md5: 0ef1d798410f6494cec4943a48743e4b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 343107
+  timestamp: 1676436053216
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_5.tar.bz2
+  sha256: 8845552a84555d4adb13a5f16e2b5d55040a732b7df9319e00f9fc713e0f896f
+  md5: 08085c8a9c0fa1a1a404a973695b2af3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 95525
+  timestamp: 1709103616461
+- conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+  sha256: 41a6c5a90b88ec7010bb6dd89390754e476b52c3ab2d519bdab9556da8829479
+  md5: b047426a545e287f45e8abfbfcb0de55
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 118041
+  timestamp: 1693902191485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.12.12-haa95532_0.tar.bz2
+  sha256: 80273bf1f2ba732b7244a27c855a15a8a2595d5b1e97b5c53a6931f5455eca58
+  md5: d713a3ca49bde113fd1b2b2f9e33d604
+  license: MPL-2.0
+  license_family: Other
+  size: 169663
+  timestamp: 1702903842577
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+  sha256: cd6545642e380b13700f2f2a7a1fb54a273365047bd23108dbd03b197f5c0c9c
+  md5: 929edc1c553d2da4d6c6c0745b033cc3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 166377
+  timestamp: 1707229328635
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_0.tar.bz2
+  sha256: bea4047e8e2fc864a26fdf1015a0c3564096ed5147a84dcf7e47d666f3df2caf
+  md5: 630e8a46b4a26d3fe7daa159efa5ceaf
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 290350
+  timestamp: 1700254613419
+- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+  sha256: 7153817dd49ec317b519802c7c22c836602e00cbd96d68385e83eaf4c9f5ba6a
+  md5: cd829e5997611a602e29fa2fd5882635
+  depends:
+  - colorama
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204113
+  timestamp: 1698130080270
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
+  sha256: 03f00c22b6d92ee55b727b369e8dbdd9a4d590f2655b62b7c45ecd046741858e
+  md5: 116f67c13bb0b3caee6cbde334ff6abb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49934
+  timestamp: 1683040303796
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+  sha256: 4099898f02e1f6119fcda65e747c3cbfef0bf563c8855b79a0245160709d5b45
+  md5: ab9705c34e67fb8c8faec69d63ff4064
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36410
+  timestamp: 1676422341506
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py311haa95532_0.tar.bz2
+  sha256: ab4d331ec5eafcc152d9fbe857761cdab2f44d440b9f272bfa50dd036a784484
+  md5: 0b34f1694f1f9be13e7f4497874b4fb5
+  depends:
+  - pyct >=0.4.4
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 2010331
+  timestamp: 1676440450100
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py311haa95532_0.tar.bz2
+  sha256: b0a027b85028b7d3c61a4fb73c4004e93b4f0b49bbdc46473fb3ca3eea9e236a
+  md5: 18dc1ad965a886263bb9ff902bcc3b14
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15370
+  timestamp: 1678376609334
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+  sha256: eeb49cd151ecdccd40062e8123a3b7a9a8a1eda6567dd33ce909ff8ee1a97c89
+  md5: b7fe1f7ead1ec2ac642d022942282fc8
+  depends:
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 232451
+  timestamp: 1700583772701
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.11.0-py311haa95532_0.tar.bz2
+  sha256: 132d5f66fb9c6b2093c5c066d3fa6ac1468d1bd3fb3b26816556f3c4c8e4be08
+  md5: aace1519be879e46f0cbc9e62bd5a4ba
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3086382
+  timestamp: 1701396440772
+- conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.16.0-py311haa95532_0.tar.bz2
+  sha256: 7c57396f00b4d63b1b597ccad75548f6e81f4e2b831c660fe14c6764d62148e8
+  md5: 0d1d476cfdb705f2ed6cfe2f6a092ef4
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy <2.0a0
+  - pandas <3.0.0
+  - param
+  - pillow
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18023517
+  timestamp: 1699544725067
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+  sha256: 5c73f86e575f2ad683ee4a1c2df11020e270edd89d12f11199483d57b0b51826
+  md5: e96a12895ce374476277b1b196ba24bd
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3719519
+  timestamp: 1690907216785
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.10.0-py311haa95532_0.tar.bz2
+  sha256: c028a882df2015945eb0d46ac4eb1cade6ab581d148853cd230f42ce799201d1
+  md5: 5eae68cf18620dfc9610394ebefcf301
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 359005
+  timestamp: 1701286643781
+- conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+  sha256: 7cb0df7aa62796b0081e1708003529c02411aca6a540bae97beaec919aa64e74
+  md5: ea81fd813e10055553a8d7597c8be98f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 322778
+  timestamp: 1706888324269
+- conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+  sha256: ed1fa1a40c6739b48ff3a2d51c3df20e4983b59684b04d93e1337c5f2e93a954
+  md5: 1797f64343a42395207cd452e6a6a751
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94476
+  timestamp: 1706895442146
+- conda: https://repo.anaconda.com/pkgs/main/win-64/grpc-cpp-1.48.2-hfe90ff0_1.tar.bz2
+  sha256: 0c6223208742064a2829f8dd658e04b72f5176e357a1320c0b0398b91abfd292
+  md5: 19c77d6709407253582fae939434016c
+  depends:
+  - libprotobuf >=3.20.3,<3.20.4.0a0
+  - openssl 3.*
+  - re2
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 31002375
+  timestamp: 1685747992041
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
+  sha256: 68d59a361a93a5ae36542f667138b4ab072e1abff15b3aa2dc55575baf86a3e9
+  md5: 383239566d9506b743c7bc65d709b7e1
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5374020
+  timestamp: 1707836834797
+- conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.9.2-py311haa95532_0.tar.bz2
+  sha256: fa30e4a64279a12bc084a7e5a1f038fd31af17207a27133e2eff3807a72e011b
+  md5: ef78998ab4439e42d7a0fe14d2f35751
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1990475
+  timestamp: 1706712786427
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+  sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
+  md5: 582d2c1135a89da757a038de831e7f39
+  license: Intel proprietary
+  size: 11086648
+  timestamp: 1664812389803
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py311haa95532_0.tar.bz2
+  sha256: 762f3a14fb7ffb445311ba2098e543de33ed6ab035c57ac4b63976a9c894eebb
+  md5: 88e19c2afbc6a264c37f9f92e223caa0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 124063
+  timestamp: 1676424962314
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+  sha256: db30abacf919b3f68ae1e6a94c467fd1e69fbf47ba7a86e6b491d8bfe4776f92
+  md5: 9299876e7ddc3aea3487fd93340ceae7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 50842
+  timestamp: 1704813715071
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+  sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
+  md5: d215cc8ee7ca2cc83cc250cc5d822fe0
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3929136
+  timestamp: 1699647939158
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+  sha256: 864e9598f64105769b4ec02cc404fb507bc59e217324daf1686c00cfd12c0055
+  md5: 6bb1c3be1f85799a3988afc2c3c5a4f0
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229621
+  timestamp: 1705934494547
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+  sha256: e0b44f0c3a4ead0fb8e58033c0be25524ee9ecf7f4cc632f03e9f6fac3484baa
+  md5: 50cbc18d0c7b42a4553b52d0cef2c857
+  depends:
+  - colorama
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1637367
+  timestamp: 1704834149957
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+  sha256: d81566367c79a28d4717157fc74293e846a47af99387ed479eb001a425dd398e
+  md5: 28c76079c96ad7f8b1a5ed32b438c79a
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1147434
+  timestamp: 1679427525584
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
+  sha256: f766a445df8e81447f27c830e162566b221fa1bfc41296a6c5e0789586ca1fbf
+  md5: 55bc50633414fc8616ccbf4140a42d5f
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353715
+  timestamp: 1706733949898
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
+  md5: 81f2c343dc4c65eea39c45383272068f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 407861
+  timestamp: 1677849239400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+  sha256: 5e6698015a3b048093f5737f0e54bcbae415d0f9682dfdfeae3a8cfb4ea275e2
+  md5: 0093a4214131046c4f68af0739dfbea4
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 201456
+  timestamp: 1699041872445
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+  sha256: 9581be54128954080d7cef448b1728874c2ebbe5064f55adece422cf12eafa5a
+  md5: 3adc105f87d5c7f0b1248bc3423f5b48
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16187
+  timestamp: 1699032556953
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter-lsp-2.2.0-py311haa95532_0.tar.bz2
+  sha256: 2fd9671118852dc700897fdb980a323287f40880f2ef19864e78039049f84563
+  md5: c3ab03d0742e6ca173838fae93247b04
+  depends:
+  - jupyter_server >=1.1.2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101303
+  timestamp: 1699978449116
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-8.6.0-py311haa95532_0.tar.bz2
+  sha256: 4772d37293b0350a3fbfa9b16d0b279544c753f78371b352013daa1d4769a78d
+  md5: 5cd7415248e27a289f9d6dff9b600a73
+  depends:
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 258542
+  timestamp: 1699456032957
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+  sha256: 851ae576c2b72bf3172cd460feec4f5577dc06476a043e185279071b67549fab
+  md5: fae4d214d00de6604738f39acbbb197e
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119710
+  timestamp: 1698937651636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+  sha256: d97ad90f9121ecf7f8d3af773b222c0bd244204ee73a3e44185491fa16d83104
+  md5: 73ac0fa3c67e5eb283173d74a2771752
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 60625
+  timestamp: 1699282918176
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+  sha256: 257e1102d2dc3f8b0c1708585c819e86f41abd101084cd0569e8e31652480875
+  md5: 2128c6806bba6953e1a275f37e7a295b
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pywinpty
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 614705
+  timestamp: 1699467242943
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+  sha256: 90420847230e72a648417f5f77cebcf7f17b89f70788652c276acc0c440e135f
+  md5: ef3d8dee197aa37897bf6d39d2dd878f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=2.0.10
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27639
+  timestamp: 1686871052174
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab-4.0.11-py311haa95532_0.tar.bz2
+  sha256: cc3eb5e2c513fab04e2740a093f9c44f0355f746ba4cbfeacc2ecbbd08d7096f
+  md5: 729d6b5a3d58c98e8ec73afcb59e0d0b
+  depends:
+  - async-lru >=1.0.0
+  - ipykernel
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.19.0,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  - traitlets
+  - pywin32
+  constrains:
+  - nodejs >=18.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6714941
+  timestamp: 1706809027799
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_server-2.25.1-py311haa95532_0.tar.bz2
+  sha256: 066d78020fbe62fa9401979852ddbeff05f8e9faeec861487cb2662b9b5d39f9
+  md5: 2f7340345dee00a18c766c1c1472fca3
+  depends:
+  - babel >=2.10
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18.0
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.11,<3.12.0a0
+  - requests >=2.31
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 106966
+  timestamp: 1699555552806
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+  sha256: 8a2f0909fad0387e57cb0e9ee30db2b20761a9106e794381ffeac387a298fb07
+  md5: 6058b2efc3284e27aacec2e6e6280433
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62334
+  timestamp: 1676432044242
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+  sha256: 4184dd040fc38cb123a98588a8344aa8d1ba1932df5fcc6c188f6b21f5a0c306
+  md5: da58cfa83f3d6c31ae12d8777cd1b64d
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 29803292
+  timestamp: 1696764164248
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
+  md5: c345f51706eef530454f66b794e5e574
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 68189
+  timestamp: 1659616216976
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
+  md5: a7400cfb72042977bc047909ed504ce8
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 33743
+  timestamp: 1659616248209
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
+  md5: 6307f6854754ab5bd7c84e6998385bb1
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 733177
+  timestamp: 1659616279453
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.5.0-h86230a5_0.tar.bz2
+  sha256: d505283d2d3a94a530b341933d3047662d3481d88826ddf68bd78935c0fb94c3
+  md5: 1e9446c8a7f39247834fe0bd16d3edb0
+  depends:
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 338561
+  timestamp: 1704383910302
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
+  sha256: 6458c7a370c4e3366b3b208c5b2834a7acfb17981e47fe3fb861f225d7cefbc3
+  md5: ecabf4acab5b604856d8c7c4278c2c2c
+  depends:
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 446380
+  timestamp: 1685052520132
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_0.tar.bz2
+  sha256: 1b3b9be41dba504e468a336196de9fd09568ba42585e493888aaa3708f687d0a
+  md5: 5cdcd99f18d9dedb772d272088e72b4c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 116942
+  timestamp: 1683716620230
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
+  sha256: f7368e611e349b91315ce4ba4dbf9116d996a48f98eed425f4d5c3d5b9fcfa5e
+  md5: 77eb9daff9052f1fbf24d91c5bba1d74
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2543079
+  timestamp: 1675278760037
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-he2ea4bf_2.tar.bz2
+  sha256: 07e45cd4e2e791528d099791f1664983b880566c836e73925211e45c9e28096b
+  md5: 5f67893563dfc1dd0e45d3b2abf2e3f4
+  depends:
+  - openssl >=3.0.8,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 230596
+  timestamp: 1686933095919
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
+  sha256: 238e486a0d62264e7ab35098bdc0390fb9a4649921b18827228c811ae8252c88
+  md5: f1ebe453c5a955a25e4b00f73279fc42
+  depends:
+  - boost-cpp >=1.73
+  - libevent
+  - openssl >=3.0.9,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 894777
+  timestamp: 1687975823684
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+  sha256: 4534c822511a052a72c2b070a05e5d8d6f3550f18ea00a33f9d8a9a92b4382cc
+  md5: 82f24e7660831445a2183216e280a6a4
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41464
+  timestamp: 1676474474981
+- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
+  sha256: b2b50fb4e43e4c4da8db26cf362671e03774384732e1925d82e12dfce45c5ac3
+  md5: 44ff317b1ff9bd2b1fbf39da56965b16
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 20842990
+  timestamp: 1706911120234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+  sha256: 896b7a39bd4ad3621312130122b4fe84dcb67d7355166255c58ea9bc562eb0ae
+  md5: 640b852a56296f48cf073e61a59c5256
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13751
+  timestamp: 1676428354074
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+  sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
+  md5: 6970c7f46b0164cad1d210e7a1419959
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143434
+  timestamp: 1670944902624
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+  sha256: e0dc6e119b224bb31ef34b6ba270ffadc181d38b698c5318de8df7a5d2c4ccbd
+  md5: 992ccd756f09408f0b74dfb9852a8b7f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 182381
+  timestamp: 1676437963591
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+  sha256: 050b5fd4b28132d8102a7e6b40179894dc7f5e41f7ad9ee19211e67446c5740f
+  md5: 3ae0b2f6baec708554648ddafa81b756
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 154386
+  timestamp: 1684279992864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+  sha256: 8269c73b7a9c03b95a121e318d0468f35eecc016093620b0560f35238cc5df51
+  md5: 2914bea0ae29315f998e1abac79ccaa8
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30214
+  timestamp: 1704206218108
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py311hf62ec03_0.tar.bz2
+  sha256: 0d2464ab9dcb0605a6b7ebf336d2f941f24f4eca7b6795992547dc2b8608ca9c
+  md5: 25f356b0b2b6bfb61e05d9c35598b8c6
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.0.1
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9029291
+  timestamp: 1698692645569
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+  sha256: 43279276850eb6e621812448cddc1093524cee0b7f8ed58b4600b68a4fb659f2
+  md5: 5968b2b5c1f3cf5c8c8c9aaa4d8d66a2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19886
+  timestamp: 1676425829787
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+  sha256: 3062a8254ca351b54f15bea85cc928a3ba4d879bb98ce97ece39a9f7eca215a5
+  md5: 8f1565663abb34ad7fdd512e76da5532
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 68031
+  timestamp: 1676481862508
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+  sha256: cdff5215c292fe59649ca40ca72f5d26da352760c1d6a56feba14eb13f7bbf61
+  md5: e0f3f32b22135dfeaec277bc87183ca9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23328
+  timestamp: 1676442709081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+  sha256: 3b173a25605d2aaacc57ec0e425f1d1c51327eb2521c8742a736e2c76069bc8d
+  md5: 169f1c93a443f95a88665f3008623ce1
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104882
+  timestamp: 1676425142412
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+  sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
+  md5: 527155127b9fada5e5c5c69a624674b9
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187498166
+  timestamp: 1699648376430
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+  sha256: cea59ae60da314caecf08edb9bcb03126c6dd35837c8184bceaa194decca3341
+  md5: 30936b7263cf0171f7c86400f12ef184
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49080
+  timestamp: 1682975093455
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+  sha256: 5070ceb0a406b1b8b99e2ec58f5d224cbe16ec78109c46720bd182b509e05c6e
+  md5: 34de1af5c639f2d06c6c8d99488e4226
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 196201
+  timestamp: 1695058367111
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+  sha256: 6b4b27302e458fa527321c59be7c335d61f86da7501c4d141db20a72fad68b55
+  md5: 7db9b12da1290bb2c2fc6ee52a945905
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 256371
+  timestamp: 1695060425702
+- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+  sha256: 39f09c1bc57b4800ebda331eddb462928435498705351b0432d51a4293294ad8
+  md5: 5565984a02f41e97cb9a4c9126ced14b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29808
+  timestamp: 1676442800892
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+  sha256: e940f9178ee2fa0a7c12873ae35ebea0074371653e5cfa1be8aa8d9271fd343b
+  md5: 355d0835215911738a28010dfa6aa382
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141785
+  timestamp: 1698934346590
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+  sha256: 47dd00c0179f4eb29c70d0453d340f7f5332af326b3d51c64ca3bf6a14be8e7e
+  md5: f66afe718bdb57667b03ebda4cb2ac7e
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 561655
+  timestamp: 1699023338436
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+  sha256: 4ee863a1ff697274c642b3101f82b279a354e3f033a87505655039f89127bb41
+  md5: bfaf19be6644ad2344e118aa0acccb13
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189809
+  timestamp: 1694617194065
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+  sha256: 90fb3f14c49da1397982eae21cd09e8d60d491d76f94c57590c56723fe6dc172
+  md5: 46a523661fe5c1bce7b4213fd428c3de
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16732
+  timestamp: 1708532795328
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-7.0.8-py311haa95532_0.tar.bz2
+  sha256: aa72c6e127bc394de0b570413912e0625759ba10248fbf884928c9ec3ed6fa70
+  md5: 1cdaa20793e8f70874ade8136e1dd5c2
+  depends:
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab >=4.0.2,<4.1
+  - jupyterlab_server >=2.22.1,<3
+  - notebook-shim >=0.2,<0.3
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3681116
+  timestamp: 1708030716052
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+  sha256: e040ebcab948325fbe17e4ab15be62e1fafa7bad225457e59764adb60eb40db5
+  md5: 4d40a09df8cb74a9f044eab317436d67
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27282
+  timestamp: 1699456187703
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.59.0-py311hf62ec03_0.tar.bz2
+  sha256: 9e6d63bc596cb6aca8abd565c448807da8278d9e40489bcc6de4bc190d4bacdb
+  md5: b75de367d02c1eb056d5594680cb3d26
+  depends:
+  - llvmlite >=0.42.0,<0.43.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - numba-rvsdg 0.0.*
+  - scipy >=1.0
+  - cuda-python >=11.6
+  - libopenblas !=0.3.6
+  - cudatoolkit >=10.2
+  - tbb >=2021.6,<2022
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6092876
+  timestamp: 1707085479626
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+  sha256: d3bd2a6614bb7e7f5ce3348d6674e71cce45cbde236beff32f0f08cd95a64ef0
+  md5: e70f15643164f432d1df68635e7c322b
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 162691
+  timestamp: 1696515822068
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+  sha256: 470fe9a0b3e196fa60d5550d8188f6074a207572fa0d353a4448d580872e7804
+  md5: 6fdb8df0613fb2fb9f1732d335fa25f1
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311hd01c5d8_0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11053
+  timestamp: 1708641901110
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+  sha256: 222c1711e7cf151e29077c7d4d86a865c9fd39615812d58a1daca6fd1b6bdfb5
+  md5: 585bcd8bc3940a8a859f38ebafdcd77d
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.26.4 py311hdab7c0b_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10723862
+  timestamp: 1708641867155
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
+  md5: ab07e2a27ac08afe3d0b4c0890b8486a
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 2-Clause
+  size: 249316
+  timestamp: 1630094024143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_0.tar.bz2
+  sha256: d7065fb018761770402c537b7010faac29e72078f0a956dfb719cd03ed8e8eca
+  md5: 39fdacf2d8eaeca0aac16629c415b5b7
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8043758
+  timestamp: 1706911036188
+- conda: https://repo.anaconda.com/pkgs/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
+  sha256: 417cf23716f17b6daf2b717bbd69240aa9440845dfa415f59a97961794632ce5
+  md5: 36d709d47c43a3e9b43f23cf4edb6438
+  depends:
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.9,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 877890
+  timestamp: 1676482911485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+  sha256: b2f5f50a1ddf811102636f3acebd76716c88ebb628754b91eda7a3a962adf26c
+  md5: 712527b4d84c350dca4b67f511c04414
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39421
+  timestamp: 1699371341381
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py311haa95532_0.tar.bz2
+  sha256: a9d2bf21f7a458e90f0c6ebf72ad591d5a1b891542d4c401e487661f25f0f693
+  md5: 58e3da20b3e08b819b3d1e5ffcaf5cdb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 93982
+  timestamp: 1693575296514
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.4-py311hf62ec03_0.tar.bz2
+  sha256: 4eab648cd85b8a663a9b8d1d682879aa5ca7dafe1d86a413da718873614eff12
+  md5: 05b234e5e53cc9027e3e410957dd763a
+  depends:
+  - bottleneck >=1.3.4
+  - numexpr >=2.8.0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - pytables >=3.7.0
+  - html5lib >=1.1
+  - xlsxwriter >=3.0.3
+  - gcsfs >=2022.05.0
+  - qtpy >=2.2.0
+  - jinja2 >=3.1.2
+  - openpyxl >=3.0.10
+  - numba >=0.55.2
+  - pyqt >=5.15.6,<6
+  - fsspec >=2022.05.0
+  - s3fs >=2022.05.0
+  - blosc >=1.21.0
+  - tabulate >=0.8.10
+  - pymysql >=1.0.2
+  - psycopg2 >=2.9.3
+  - pandas-gbq >=0.17.5
+  - beautifulsoup4 >=4.11.1
+  - xarray >=2022.03.0
+  - lxml >=4.8.0
+  - pyxlsb >=1.0.9
+  - pyarrow >=7.0.0
+  - pyreadstat >=1.1.5
+  - zstandard >=0.17.0
+  - xlrd >=2.0.1
+  - scipy >=1.8.1
+  - dataframe-api-compat >=0.1.7
+  - fastparquet >=0.8.1
+  - odfpy>=1.4.1
+  - matplotlib-base >=3.6.1
+  - sqlalchemy >=1.4.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15488930
+  timestamp: 1702324598982
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.8-py311haa95532_0.tar.bz2
+  sha256: 0848859520e789dc9977e6ea4aaf8848addbe1a8282cf5c8453b916dc529ccb1
+  md5: 544ef9511ce79469e60c32a951ca60fc
+  depends:
+  - bleach
+  - bokeh >=3.2.0,<3.4
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.0.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.17.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18091432
+  timestamp: 1706540215140
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.2-py311haa95532_0.tar.bz2
+  sha256: 7fce288045b1aa3d9fd77db303459df57c96801a0cb35c207aa0171592ed102f
+  md5: 6fbe82754fe5f691d0f5d08957209b10
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 256371
+  timestamp: 1705937896560
+- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+  sha256: b0d7fbfcf1c5c682ed9934eb6a33e00a2517941f2bcb9d677379f4bb73b2c45c
+  md5: 20c8f36595a48f5cda2f4f74c02a3ea2
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48206
+  timestamp: 1698702818841
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.2.0-py311h2bbff1b_0.tar.bz2
+  sha256: 432d176d749e044690d3763be771717aa20ef91897602214bca56994b49a6e76
+  md5: 3e09be8412e98a656951ed1f76525c57
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 1005722
+  timestamp: 1707233792036
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3.1-py311haa95532_0.tar.bz2
+  sha256: 5d612af287cad7d0fc1b8e2e01d7f49b5466f2e17338b03a13cd60111f2513aa
+  md5: 1b0f29aa3fc57cc8d5a48ae392aa8567
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3752545
+  timestamp: 1700667933959
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+  sha256: e5f8cbfb5fc25d460a9117bfc5511959c5e86ccb193316033f87bd516e0c8881
+  md5: 9f7e8b5eb651539386bb92c14e5c321b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37730
+  timestamp: 1692205554840
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+  sha256: 6c5b53831273674361437fb546e08315fc11ca9275a174bca3887987e86ced5a
+  md5: f8d91daf5173eb03157f484389adcdd4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 122178
+  timestamp: 1679591983138
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+  sha256: 546819d922b03f3a25ca9f98fd069d0588d481fc0603c6d74bd598fb6a93687f
+  md5: 86c18e3e0b67ee099457475ed6caf2e6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 751763
+  timestamp: 1704404627180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+  sha256: ae06f0dfa2cfae51404afc6d6ad3a474a93015b5ba9a7d3ea24224b8e7547987
+  md5: 3e19794c806cc3e84a3080a97c359b75
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 510466
+  timestamp: 1679005998612
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-14.0.2-py311h847bd2a_0.tar.bz2
+  sha256: a33dd77a94c79ab95caaa02fbdcb399d4041806a52a82411529cf1454f031536
+  md5: 01f56e64de4eed195d72a61301444fa7
+  depends:
+  - arrow-cpp >=14.0.2,<14.0.3.0a0
+  - boost-cpp
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4504341
+  timestamp: 1707332113670
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+  sha256: e2af1efb1a5094a5962d93fa949ecab479a2ae7570e030f52eeac6761383c208
+  md5: 4cb1359e22ddf8f3996afddce5f6205c
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 56638
+  timestamp: 1676438592117
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+  sha256: d95c88d06f4f3f667bd9a39e5f18179e83b3cd4c115c06ce0fff390ff6d3a700
+  md5: c6d00a8a4d89b1be99bfa3aff19d96b4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2134881
+  timestamp: 1684280285492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+  sha256: 643a9a0eba1e2bd5980d21623d3b35188c24781ec251acc4d15714bd1ccb4c17
+  md5: b3cda0394db05be6f0f6176abacb13f3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207985
+  timestamp: 1678721438358
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+  sha256: 974c22de09078bf07c5db31fe12d8d89d6433508defc8237cbe52e08c69ed56b
+  md5: 9cf10bfd49140a527cf4b1d912097e6d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36072
+  timestamp: 1676426019064
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.8-he1021f5_0.tar.bz2
+  sha256: 1c557d91837e0205cd08180b604da06f28d7679df1ea1026e7954add3eb4d468
+  md5: 3901bef86daffeb6ff2317543b292766
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - openssl >=3.0.13,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.5,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - openssl <3.5.7
+  license: PSF-2.0
+  license_family: PSF
+  size: 19539055
+  timestamp: 1708983524626
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+  sha256: 9acb33db60d9319595f52337cae3b88c2a2338cd66f1f9d8ae86d0a993c2067a
+  md5: f4af8cf94d042b4dde487241bba1c457
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279780
+  timestamp: 1679500609851
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+  sha256: 48fe7373b012b51134b6b6ff67f18d2b4aae3a5c7700e4560ce002af7172f064
+  md5: 0379cd17692152c12b662b0e4ea46b88
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18008
+  timestamp: 1683824373128
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py311haa95532_0.tar.bz2
+  sha256: d9c9e5d09c2ca723a22fcd0b934f7f9f31e97d5587b2c231527c1f6de5753e1c
+  md5: 81204aa731cc509770267cd8695dc5e0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 276494
+  timestamp: 1695132123472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.0-py311haa95532_0.tar.bz2
+  sha256: 0c43947eb37620d36cf57860c6008e0cda5f29c22dd55931b5efcb0bcb8fb671
+  md5: 37f7545c68cfed4547e4fae53db71efc
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64373
+  timestamp: 1701728120219
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+  sha256: cd33dfee104dfbba4af38d06a09ccbae6a32e7c543afedab523303319ebb283d
+  md5: 3dfc19af0306d80921e1403f1f551bba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13679916
+  timestamp: 1676423267293
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+  sha256: 102ff1d958209e3648bb49da3503cf752abab822011fdc4e12e88145c9e73772
+  md5: 0553c2c381b6f5c836b23edc8c6db2ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 246689
+  timestamp: 1677708371873
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+  sha256: bee5c4d0f41f06a9c0aac636885e36e8b81116aafde980f9ea48fdb64abb5567
+  md5: 6c05a053240cb90765d6f8c2efdf905e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 182228
+  timestamp: 1698096268270
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-25.1.2-py311hd77b12b_0.tar.bz2
+  sha256: d08d1b2bc1859011d6d8c8e0afff0cad680c598e5ad59bb7beab9317b3bdece4
+  md5: 5e36645629336f3732b14604bb666442
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 552293
+  timestamp: 1705606206058
+- conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+  sha256: 720f3dd1f933d035b1393951ffd1b6437fc5e19b1999e74096044514a46053fb
+  md5: add2dfb15b518144663fc3b897d66da7
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  size: 493391
+  timestamp: 1652432364793
+- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+  sha256: 47653b45a5f2d97b5bf0dbf0e620908880f9078da427eef69012effe3f19af67
+  md5: 44e709ae67d89bccee2d4d46d358fee3
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74493
+  timestamp: 1699012356534
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
+  sha256: d7bcba5262df162756885a773c3bf2dace27311bbbb1830a0f97aa60ac7c1239
+  md5: daeb99ccfe39f725278203412aac0873
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 120468
+  timestamp: 1707355917958
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+  sha256: d6daaa6b45272819176e4aeb467ae00e3db43386548464a9993688f292709d40
+  md5: 9fe721d7f7420c259df4f07d4503f654
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9683
+  timestamp: 1683077110211
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+  sha256: 6051860575f9448aea5799d74469c928cd7cdeeca1eb53657872262a77b1a7a8
+  md5: 60e193eca497130034facd5fed168249
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10094
+  timestamp: 1683059114376
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+  sha256: ecd310461c1b45ab92ddf15539cea5a6e837860561c974d2d7393f9a7933f116
+  md5: 1762fec2838763e904141167e18b0389
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 215600
+  timestamp: 1698947891859
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.4-py311hc1ccb85_0.tar.bz2
+  sha256: 70535bcdff9735b337047dfa90f6217c3bac195d7540943a5ce52585dd397687
+  md5: 2fb9d23bf1492486d8fe8ad2edf50a3a
+  depends:
+  - blas 1.0 mkl
+  - icc_rt >=2022.1.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<1.28
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24536956
+  timestamp: 1701301327353
+- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+  sha256: 6fd52bae6360fbc8135d72e0c1e4fd407769fa4d0f4b59356e7aed3e000eb339
+  md5: 49fd52885250da8aab17ed72e2e18b81
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88901
+  timestamp: 1699371435766
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.2.2-py311haa95532_0.tar.bz2
+  sha256: dd535d42d7acccdbb7047b82c7cdfa2ea1570198ab691d93f5959ab80d1dcf40
+  md5: 9d5ff220ecf2631d397d9ffda8f12e40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1457756
+  timestamp: 1702328037082
+- conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.1.10-h6c2663c_1.tar.bz2
+  sha256: 7555e0d33dc29191da0f311d9e6112ddf0c200bbafe5cde89015d524dce84a72
+  md5: 54bc73a36ca51e06733d9d42f23e2ea4
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 100857
+  timestamp: 1702909533553
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+  sha256: 5d1b7e14dc04816692de0f8518ea8fcbefb26ab61cec83f96f2c44c1bee67fab
+  md5: 505d2a70a875b5082dc857aa4dfab0d4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 18830
+  timestamp: 1705431395254
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+  sha256: 5ff3b4ac3fbce4dd67a87856c04698d0397deb0ac288ff4e7eb02fbab57f1253
+  md5: 0ca650a7001c6650809d3361de8cb005
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89590
+  timestamp: 1696347858925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/spatialpandas-0.4.10-py311haa95532_0.tar.bz2
+  sha256: 631471c767af7d400cc8ce11aa4f24d2fd3212ffe543f36465c0821854470649
+  md5: 2ed16fdda5f786936c3cc8fdc2cc412a
+  depends:
+  - dask-core
+  - fsspec
+  - numba
+  - pandas
+  - param
+  - pyarrow >=1.0
+  - python >=3.11,<3.12.0a0
+  - retrying
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 200448
+  timestamp: 1705085489563
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+  sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
+  md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1311308
+  timestamp: 1681402905668
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+  sha256: 78d89b50a29fbeb19a562f5dad95615e3f192bb4f3b86cd6ea75f2f825418232
+  md5: 4a4040df560ea47704e0898c4c015808
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38069
+  timestamp: 1678228553220
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+  sha256: 70a3cc4a4e81a6421bc19cd410d1d6064aadb2b1cce38b020f85e5346716d8e7
+  md5: 32a9a2539579a3d522dce3b5cb4f987b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49495
+  timestamp: 1676425411739
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+  sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
+  md5: 52cdcdb96383c010ca833a7c24b3935b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Tcl/Tk
+  license_family: BSD
+  size: 3690152
+  timestamp: 1654036853710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+  sha256: ed5950ac0c12cc87f991a6f28112cf29057e2b7ad416ae4429a0b97c3efaf58c
+  md5: b5e2a04879e6fd19f0eb5effded4dc61
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135939
+  timestamp: 1676431438808
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+  sha256: 4febf30c11674711b86c8c10da46a5e1613071388da999210912a31508864add
+  md5: 1c109fc1112ea1f5f377bdf0d18ba75f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 895633
+  timestamp: 1696937216859
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py311h746a85d_0.tar.bz2
+  sha256: 2020add9f7607ecefd9628c1c1fa2e7349c0498e4926da842e662dba5fb99e1e
+  md5: af51b3b92896b4fa3bf89df021009eda
+  depends:
+  - colorama
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 171971
+  timestamp: 1679562109474
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+  sha256: e8c77efe880546252f244f995cbed5967809555127b4f818b97455d434b23415
+  md5: 7397ac07045115960ebd8dec95326a7a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270819
+  timestamp: 1676423321499
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.9.0-py311haa95532_1.tar.bz2
+  sha256: ae7b4d80613eee90d2a9d86a099327c81606cde33700e476402407f1a206362c
+  md5: d7326551a9f54853015af81861222d5f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.9.0 py311haa95532_1
+  license: PSF-2.0
+  license_family: PSF
+  size: 9651
+  timestamp: 1705599444849
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.9.0-py311haa95532_1.tar.bz2
+  sha256: 1900ee02288c0abdaa44f34bccafc34691a59069330b0fc0c0922b4b4621b786
+  md5: 0b94ee0b1e2488c3840a348d7d97aca2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 71708
+  timestamp: 1705599429360
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+  sha256: d091897f05318c22ca31028370f25355065999078f7db6f88ab27bf4cb030ec8
+  md5: 1776502c1cfb351554eeda6cddaf255f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11588
+  timestamp: 1676457729096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.1.0-py311haa95532_1.tar.bz2
+  sha256: 75e984e5015c5fee121159768fc92653d58303e983450308f8efee40382cc6f7
+  md5: bcaf27d1ba712299ee395d7cb0d4852b
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - requests >=2.26.0
+  - zstandard >=0.18.0
+  - selenium >=4.4.3
+  license: MIT
+  license_family: MIT
+  size: 184432
+  timestamp: 1707770951801
+- conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+  sha256: 2ef16d0252e04063d44d0683831d55b485f713fe5af2c2efd61753fb4f27d7e4
+  md5: 256ab1d5dce70111a1f4807a5a9fc322
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 100982
+  timestamp: 1706894771410
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+  sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
+  md5: 45ef24c486a484f079faf1dc90e4c7e9
+  depends:
+  - vs2015_runtime >=14.27.29016
+  license: Modified BSD License (3-clause)
+  license_family: BSD
+  size: 8277
+  timestamp: 1605602889180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+  sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
+  md5: 4daaceb6cfc1af6274509081d8018ef1
+  size: 2316783
+  timestamp: 1605602872095
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+  sha256: 24ea3d3e0cb98d0d246338dbb4562b67967bb32002e3704e495a5c863476e831
+  md5: c7b9cdbe87b3c9720aeca1164a0fd6df
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26181
+  timestamp: 1676424437003
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py311haa95532_4.tar.bz2
+  sha256: 4008652f05783c7c1ac31fb5b8cf36899c3380b24e82996c6fd44f7b6aca1278
+  md5: dd85600927df8322040c4998a114b567
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94482
+  timestamp: 1676426093953
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py311haa95532_0.tar.bz2
+  sha256: 0c4a64027b1bc400a86a51b048f097c33080d7a35f898c1ae8753799d505f4cf
+  md5: e65f8ba947e678d66a8a9bd18e332e04
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 154572
+  timestamp: 1695742144881
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+  sha256: 17fadf35aa8917c107e7b369e9364ac7c09537776e7943d37e225e14b7026c94
+  md5: 0e67c3b9624540581b894b11267a837b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PUBLIC-DOMAIN
+  size: 10197
+  timestamp: 1676425485716
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+  sha256: 25373efabba9a866849fe38a47c79e0fa323851b4bd4b5df357cc8d5617c2786
+  md5: a958e9d32c3b65c21e11e5d9e8491c43
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2467966
+  timestamp: 1689041676824
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+  sha256: b849b368e27920838fe40a512b102879693a55cb187dd1c8d3a83fa8c05a8054
+  md5: 7b1f6e9c71906a93039b3446b99a5498
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55114
+  timestamp: 1676434863173
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_0.tar.bz2
+  sha256: 74c3575a7b72b952797c7c775522d8cf329fe06ec6b6949f45253e40c3f188cf
+  md5: 76e728c35d284bfce7867c48d7046cc9
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 1380439
+  timestamp: 1709046669590
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+  sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
+  md5: e5aed81295b61b6d1eb62830799a0297
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 9125184
+  timestamp: 1705602328351
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
+  sha256: d932439798665be388bbf68f3d68da5b42ed4753a43587d3f49848a85f58add4
+  md5: e2900345674e644e05540ffac6acca89
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 25247
+  timestamp: 1704207149955
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+  sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
+  md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 148931
+  timestamp: 1666595229032
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+  sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
+  md5: 8d6a1e767775fe0eb617cd6e22edc2ff
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1871867
+  timestamp: 1681304638261

--- a/glaciers/pixi.toml
+++ b/glaciers/pixi.toml
@@ -21,15 +21,15 @@ panel = ">=1"
 spatialpandas = "*"
 param = "*"
 pandas = "*"
-pip = "*"
-setuptools = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+setuptools = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks]
 dashboard = "panel serve --rest-session-info --session-history -1 glaciers.ipynb --show"

--- a/glaciers/pixi.toml
+++ b/glaciers/pixi.toml
@@ -1,0 +1,36 @@
+[workspace]
+name = "glaciers"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2018-01-01"
+maintainers = ["philippjfr"]
+categories = ["Geospatial", "Featured"]
+labels = ["panel", "hvplot", "holoviews", "datashader", "bokeh"]
+description = "Glaciers explorer using Datashader and Panel"
+
+[dependencies]
+python = "3.11.*"
+bokeh = ">=3.3.4"
+notebook = "*"
+datashader = "*"
+holoviews = "*"
+hvplot = "*"
+panel = ">=1"
+spatialpandas = "*"
+param = "*"
+pandas = "*"
+pip = "*"
+setuptools = "*"
+wheel = "*"
+
+[target.osx-64.dependencies]
+libgfortran = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks]
+dashboard = "panel serve --rest-session-info --session-history -1 glaciers.ipynb --show"
+notebook = "jupyter notebook glaciers.ipynb"

--- a/glaciers/pixi.toml
+++ b/glaciers/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "glaciers"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/goldbach_comet/pixi.lock
+++ b/goldbach_comet/pixi.lock
@@ -7,700 +7,700 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gmp-6.2.1-h295c915_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gmpy2-2.1.2-py39heeb90bb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.0-h8213a91_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.0-h28cd5cc_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.1.0-h3826bc1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.5.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mpc-1.1.0-h10f8cd9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mpfr-4.0.2-hb69a4c5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mpmath-1.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.21.5-py39he7a7128_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.21.5-py39hf524024_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.9.2-py39h2531618_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-5.9.7-h5867ecd_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.6.2-py39had2a1c9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-4.19.13-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sympy-1.11.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gmp-6.2.1-h295c915_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gmpy2-2.1.2-py39heeb90bb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gst-plugins-base-1.14.0-h8213a91_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gstreamer-1.14.0-h28cd5cc_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libllvm11-11.1.0-h3826bc1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-3.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mpc-1.1.0-h10f8cd9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mpfr-4.0.2-hb69a4c5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mpmath-1.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.21.5-py39he7a7128_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.21.5-py39hf524024_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyqt-5.9.2-py39h2531618_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/qt-5.9.7-h5867ecd_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scipy-1.6.2-py39had2a1c9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sip-4.19.13-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sympy-1.11.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gmp-6.2.1-he9d5cce_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gmpy2-2.1.2-py39hd5de756_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.5.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.5.3-py39hfb0c5b7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mpc-1.1.0-h6ef4df4_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mpfr-4.0.2-h9066e36_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mpmath-1.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-1.5.3-py39h07fba90_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sympy-1.11.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/gmp-6.2.1-he9d5cce_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/gmpy2-2.1.2-py39hd5de756_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-3.5.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.5.3-py39hfb0c5b7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mpc-1.1.0-h6ef4df4_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mpfr-4.0.2-h9066e36_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mpmath-1.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-1.5.3-py39h07fba90_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sympy-1.11.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gmp-6.2.1-hc377ac9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gmpy2-2.1.2-py39h8c48613_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.5.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.5.3-py39hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mpc-1.1.0-h8c48613_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mpfr-4.0.2-h695f6f0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mpmath-1.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-1.5.3-py39h78102c4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sympy-1.11.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/gmp-6.2.1-hc377ac9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/gmpy2-2.1.2-py39h8c48613_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-3.5.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.5.3-py39hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mpc-1.1.0-h8c48613_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mpfr-4.0.2-h695f6f0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mpmath-1.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-1.5.3-py39h78102c4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sympy-1.11.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.5.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.5.3-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mpmath-1.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-1.5.3-py39hf11a4ad_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sympy-1.11.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-3.5.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.5.3-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mpmath-1.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-1.5.3-py39hf11a4ad_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sympy-1.11.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
   sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
   md5: 613805add1c05b538ff06d217252feb7
   depends:
@@ -711,7 +711,7 @@ packages:
   license: BSD-3-Clause
   size: 20810
   timestamp: 1652859733309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
   sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
   md5: 2cf39d906cc321896ffe3e5d33d80c5c
   depends:
@@ -724,7 +724,7 @@ packages:
   license_family: MIT
   size: 162166
   timestamp: 1644463608931
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
   sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
   md5: 2972a84e0e22ae3244bbd2f1eebcf536
   depends:
@@ -735,7 +735,7 @@ packages:
   license_family: MIT
   size: 35352
   timestamp: 1644569715988
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
   sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
   md5: a68016b4b06460def24cb69d932986f3
   depends:
@@ -744,7 +744,7 @@ packages:
   license_family: MIT
   size: 132486
   timestamp: 1695717963702
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
   sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
   md5: 2f6356a2f530314b4059c08c79a3d8bc
   depends:
@@ -754,12 +754,12 @@ packages:
   license_family: MIT
   size: 205868
   timestamp: 1681493113570
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
   sha256: f84f9caa7eb9d489fd9634419fdf766d39293a5df1104b840fa0cdc5823a5c60
   md5: 922555c0435d6b2537cf8ced534b048c
   depends:
@@ -770,7 +770,7 @@ packages:
   license_family: BSD
   size: 141903
   timestamp: 1648028958291
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
   sha256: 0bbcb6f78eac530c6a084459ffab3238647b266d0c74d695e6e6387dd119cc67
   md5: bdc971e2a9affb5125b68ad708172dab
   depends:
@@ -779,7 +779,7 @@ packages:
   license: MIT
   size: 411301
   timestamp: 1602517685375
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
   sha256: 8c2071f706c2b445dabb781f7f8f008b23a29957468ec6894f050bfb3a2d5bf4
   md5: c203ffc7bbba991c7089d4b383cfd92c
   depends:
@@ -790,14 +790,14 @@ packages:
   license_family: MIT
   size: 357797
   timestamp: 1605539534667
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
   sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
   md5: 3ef00f4c5278b688552efc259c463dc8
   license: MPL-2.0
   license_family: Other
   size: 132731
   timestamp: 1694009767372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
   sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
   md5: d5cb3d97cf5e85ffe5e94037ed8a1169
   depends:
@@ -806,7 +806,7 @@ packages:
   license_family: Other
   size: 159077
   timestamp: 1690232254640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
   sha256: 674707b9c42e65c903c9786ee5a56b4d42aa054f1e75b328db8a2c1bfa368739
   md5: 76ae217198b014b89b267cf41b8251dd
   depends:
@@ -818,7 +818,7 @@ packages:
   license_family: MIT
   size: 231920
   timestamp: 1642701209740
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
   sha256: 762f4506c3e12b2332bd9abea3a2a1966f307b2673be7fd661dc6e316602d18b
   md5: 4b8df5459d1762495428323753438641
   depends:
@@ -827,7 +827,7 @@ packages:
   license_family: BSD
   size: 151844
   timestamp: 1698129872673
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
   sha256: 4fd0207b930fbc936d4b8206117cfa9792aa19bfb320eb08aab6bba10002f9ee
   md5: 7082a1ce8fa314cc2761d2f689c6bb9e
   depends:
@@ -836,7 +836,7 @@ packages:
   license_family: BSD
   size: 40456
   timestamp: 1683040035572
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
   sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
   md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
   depends:
@@ -846,7 +846,7 @@ packages:
   license_family: CC
   size: 1917831
   timestamp: 1668084545510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
   sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
   md5: 13702d3b4b744784e5bd559c7050dd6f
   depends:
@@ -856,7 +856,7 @@ packages:
   license_family: BSD
   size: 12719
   timestamp: 1671231205875
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
   sha256: 821af57c20a85b4e92268fbf65fbaec2f273da5bb21889d9643756ef6e473237
   md5: f57e0f502500ffebdbec081ef61ad1d4
   depends:
@@ -870,7 +870,7 @@ packages:
   license_family: BSD
   size: 2179774
   timestamp: 1694445209134
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
   sha256: 2084ad037e4b67a158facc0d1b21d1de16df7fe758e2bf08f6e48c6b75626cb8
   md5: 8bb8a915dda236f7a2cf790490983445
   depends:
@@ -887,7 +887,7 @@ packages:
   license_family: BSD
   size: 2121644
   timestamp: 1686782977519
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
   sha256: 161644f5f183f5632806cb2cb31890d06a1a575bed7949fe11bc59d3d4344e9d
   md5: 96baa11147a42b64dcaa233a1733b8ee
   depends:
@@ -909,7 +909,7 @@ packages:
   license_family: BSD
   size: 17667549
   timestamp: 1692372404139
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
   sha256: 80188a9729a26e36b027e673f5f30395798eb68f9fe4721f3f33b4d4d2e58285
   md5: 686db307602cbbdc30ca7d62b765578b
   depends:
@@ -921,7 +921,7 @@ packages:
   license_family: BSD
   size: 103488
   timestamp: 1613390248313
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
   sha256: 469debfa966d24b8372aaf909ecbe27dc6fde186f6f0d5b9e0a8427e38053364
   md5: 498d0788982ec4c5d13a44359b9c7afb
   depends:
@@ -931,7 +931,7 @@ packages:
   license: GPL2
   size: 600218
   timestamp: 1602701107852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
   sha256: 3a39a2d6f161080c706292e3bf480f62d2444b1d6d67b3d7db50458202ee31f1
   md5: 0524ffca60f845eb392bbb56d56f0ce5
   depends:
@@ -942,7 +942,7 @@ packages:
   license_family: MIT
   size: 2094615
   timestamp: 1637091869922
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
   sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
   md5: 2e6ec51066d825ef3c317abe78d6049e
   depends:
@@ -951,7 +951,7 @@ packages:
   license_family: MIT
   size: 16413
   timestamp: 1649926472708
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
   sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
   md5: b4d923222d45314856b5378cb115214d
   depends:
@@ -960,7 +960,7 @@ packages:
   license_family: BSD
   size: 26728
   timestamp: 1668714462023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
   sha256: 27cde2cf0b1e10c2315bc1384fcb56537b424f6c2c872ca4662bc971e41910da
   md5: c12e8c75f3c7c4f5867827c5dc02dc2c
   depends:
@@ -970,7 +970,7 @@ packages:
   license_family: MIT
   size: 216001
   timestamp: 1644418571578
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
   sha256: f80526def98864c9560dd3f6754d1c905edc001d18279f6e169913ee8f26a6a2
   md5: e2fda4383ff9a690a6ac174553e10414
   depends:
@@ -981,7 +981,7 @@ packages:
   license: MIT
   size: 306671
   timestamp: 1612452969808
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
   sha256: 8a121233d0b2cbb2463b67e798739ad2946f38933430a6a7fd1197cc6eab1c99
   md5: d2b24736491290a6c6d0138932111150
   depends:
@@ -991,7 +991,7 @@ packages:
   license: GPL-2.0-only and LicenseRef-FreeType
   size: 965280
   timestamp: 1635422707211
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
   sha256: cfef2f1f3f1aa159f87806b7fa2b65c02c0d6f9bd24ccda833b43246c5095be6
   md5: 394ec1374a92c6fd5f772343934337e4
   depends:
@@ -1000,7 +1000,7 @@ packages:
   license_family: BSD
   size: 260575
   timestamp: 1695734561396
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
   sha256: 3c8ece1a7257b1d45f8fa25f46504bb709a1923d7175f2996e891366ec434b9d
   md5: 299bf4271d710651a1d71d3795580c2d
   depends:
@@ -1008,7 +1008,7 @@ packages:
   license: MIT
   size: 83592
   timestamp: 1603192039050
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
   sha256: bb98f022743e5df14d73db0edae49eb95a11abcc41c973fe2f30c3810bc5021e
   md5: 858d4f13f1b0e54ee8cc3dd7c67cf0de
   depends:
@@ -1022,7 +1022,7 @@ packages:
   license_family: LGPL
   size: 2021087
   timestamp: 1642701448286
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gmp-6.2.1-h295c915_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/gmp-6.2.1-h295c915_3.tar.bz2
   sha256: 670ae61b47df07aa53dd2a75b31d023213321ba9d5037b18be0c17a6e79f28f7
   md5: 4f4570f23a92244101431ec46a235436
   depends:
@@ -1031,7 +1031,7 @@ packages:
   license: GPL-2.0-or-later AND LGPL-3.0-or-later
   size: 822432
   timestamp: 1653996358530
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gmpy2-2.1.2-py39heeb90bb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/gmpy2-2.1.2-py39heeb90bb_0.tar.bz2
   sha256: e0b2501055bc7b93d1d63e634ef7305916950ce4b838d4ed0353e1d700bbaa70
   md5: ae2924a47ff1c78b01088a248f76e673
   depends:
@@ -1044,7 +1044,7 @@ packages:
   license_family: LGPL
   size: 217855
   timestamp: 1645438799445
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.0-h8213a91_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/gst-plugins-base-1.14.0-h8213a91_2.tar.bz2
   sha256: c85c664066c685b606df768d23eac08e1b824e391eb59f61a9ef608f4f46c5b6
   md5: df2e0695e2edbd91b719da5b15249c5a
   depends:
@@ -1056,7 +1056,7 @@ packages:
   - zlib >=1.2.11,<2.0.0a0
   size: 6651032
   timestamp: 1609866747525
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.0-h28cd5cc_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/gstreamer-1.14.0-h28cd5cc_2.tar.bz2
   sha256: dc1af8ae3b38b8d81c00b54dac851618dba87ea8d4083af84dcb60c3070039ad
   md5: 83453eb716b94c66fb64391760c0eeb1
   depends:
@@ -1064,7 +1064,7 @@ packages:
   - libgcc-ng >=7.3.0
   size: 4178090
   timestamp: 1609866593800
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
   sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
   md5: 9213e0336e3a5216c989cfe52648412e
   depends:
@@ -1073,7 +1073,7 @@ packages:
   license: MIT
   size: 23805906
   timestamp: 1588026213084
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
   sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
   md5: 1eb52f9f45cea2fb9ce27b19f990160e
   depends:
@@ -1082,7 +1082,7 @@ packages:
   license_family: BSD
   size: 110793
   timestamp: 1666125606878
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
   sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
   md5: 126b3c1933b7364ff03f67455b687e99
   depends:
@@ -1092,7 +1092,7 @@ packages:
   license_family: APACHE
   size: 37588
   timestamp: 1678997134023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
   sha256: 1b424413f28b840fc6d4bf467f37e9e405823b1e3b899005df80152d48936d64
   md5: 4aa8bcf74c81cd3600978f791191692a
   constrains:
@@ -1101,7 +1101,7 @@ packages:
   license_family: Proprietary
   size: 9246735
   timestamp: 1634546760713
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
   sha256: b51b2e0dd37a74784ba19db22aded3f4c843b6fddb4a74399f65f36fc018aaa2
   md5: 0d56ab1950f952284b895ac0f78284a7
   depends:
@@ -1121,7 +1121,7 @@ packages:
   license_family: BSD
   size: 203541
   timestamp: 1671488675347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
   sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
   md5: ff47e0be879e817713ce2a9daa76e2b0
   depends:
@@ -1142,7 +1142,7 @@ packages:
   license_family: BSD
   size: 1261116
   timestamp: 1694181530670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
   sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
   md5: 5ef6c6a0d1ac79143c7359d305155167
   depends:
@@ -1152,7 +1152,7 @@ packages:
   license_family: MIT
   size: 1021637
   timestamp: 1644297140650
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
   sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
   md5: eaeb023688f781e7dd89e74310c38195
   depends:
@@ -1162,7 +1162,7 @@ packages:
   license_family: BSD
   size: 211775
   timestamp: 1666908212136
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
   sha256: 85348bfb14db4fea84078d703e766a3c978c5a592a06e41266748826dd59d8ae
   md5: 6e1c0fb5260c590f7ef5235cb3d05863
   depends:
@@ -1171,7 +1171,7 @@ packages:
   license_family: Other
   size: 279884
   timestamp: 1651065953960
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
   sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
   md5: 0d2c3c5edf671b575532d5a3e8bf15fc
   depends:
@@ -1182,7 +1182,7 @@ packages:
   license_family: MIT
   size: 131510
   timestamp: 1676558716852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
   sha256: 92bc012f9eb4ad71158cf4826fd3e125fcebff53b529276a81224acda48be547
   md5: c5fd100e3062e831cbdf33331042f627
   depends:
@@ -1198,7 +1198,7 @@ packages:
   license_family: BSD
   size: 190884
   timestamp: 1650622553813
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
   sha256: 0192bd48cd96c60dc3054d5addd8cdb4a29a218843181318371f79daec8242f8
   md5: d851b401dc13d04e6848bb36e12efc1c
   depends:
@@ -1209,7 +1209,7 @@ packages:
   license_family: BSD
   size: 91534
   timestamp: 1679906652183
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
   sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
   md5: a4beb461f0a60998a090d760b5c6c907
   depends:
@@ -1233,7 +1233,7 @@ packages:
   license_family: BSD
   size: 411564
   timestamp: 1671707702849
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
   sha256: 974df3dc76089be57b327acd6634384def84249003f58678ca1142bb274a75d9
   md5: 81b969d1a00153759b30554a1f11ddfd
   depends:
@@ -1244,7 +1244,7 @@ packages:
   license_family: BSD
   size: 92144
   timestamp: 1653292217019
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -1255,7 +1255,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
   sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
   md5: 9508af80612e4fa1b5d1abb43ca7e63c
   constrains:
@@ -1263,7 +1263,7 @@ packages:
   license: GPL-3.0-only
   size: 749072
   timestamp: 1652971360657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
   sha256: 3b4afe7665dcdb99bd4586a888b85b2e0325f8faecdd31c7780792080ee97872
   md5: 822b5201dde61bc838072dc5b670c88c
   depends:
@@ -1272,7 +1272,7 @@ packages:
   license: Custom
   size: 55183
   timestamp: 1594054267890
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
   sha256: c6fafbe73d2f93b91b6f4b65829f925f52a8f84746a57abd216b39da9ce8c494
   md5: 238f19c803a6ba7bd6dbd6989e03cbf1
   depends:
@@ -1280,13 +1280,13 @@ packages:
   license: GPL
   size: 8496776
   timestamp: 1560112207081
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
   sha256: 83c6fdb30a240fbaa09f5d2e2ae8f092759cb710bc3fa628ccb18934fc237b7f
   md5: 6003e09e8cef9aca91b954abfdd0f39c
   license: GPL
   size: 1336385
   timestamp: 1534628456385
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
   sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
   md5: 3080c2813e6e1d0f8a100a38b5b3456d
   depends:
@@ -1294,7 +1294,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 573231
   timestamp: 1654090775721
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.1.0-h3826bc1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libllvm11-11.1.0-h3826bc1_1.tar.bz2
   sha256: effad2034f13cf7f1cdc51127e3a88123ae957c13f8c95f1817dfd79b5eba779
   md5: c261302f1b58f6b2851f856d230dc947
   depends:
@@ -1305,7 +1305,7 @@ packages:
   license_family: Apache
   size: 29798461
   timestamp: 1647523885063
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
   sha256: bc3e6e79c32ff0ecea601aa108ae9cf4068f69703580e40e266ad4bcc52cff54
   md5: 9cb85601944ca7383b1769bff74b94e8
   depends:
@@ -1314,7 +1314,7 @@ packages:
   license: zlib/libpng
   size: 372914
   timestamp: 1556041895170
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -1322,13 +1322,13 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
   sha256: 43b0bd205f539583c088feb5b8d77b60c83d1df80c2a93dac9f2a1127001b2cf
   md5: 53fa39fdae936e9d07c4b2f5ef361993
   license: GPL3 with runtime exception
   size: 4246257
   timestamp: 1560112223556
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
   sha256: 711ea05b4c35bdafc762a172b01db896b17942f474c2b1a519f91370964bf9bc
   md5: b25d56d33596623a6a4a9d9baaa4f602
   depends:
@@ -1342,7 +1342,7 @@ packages:
   license: HPND
   size: 592974
   timestamp: 1653047881023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
   sha256: 4e1dce80f23551a69761ad48b2372e35f58292ec9cc0ce061312330366a1a223
   md5: fda36b99463bad87974196da2d5bed08
   depends:
@@ -1350,7 +1350,7 @@ packages:
   license: BSD 3-Clause
   size: 18725
   timestamp: 1633507857274
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
   sha256: 146dbb1e4dbccdd57819e5102a8ca00970b8e33d6c6180e8007db89b184da569
   md5: c566a384259c1d2769852c3bddd81a67
   depends:
@@ -1364,7 +1364,7 @@ packages:
   license_family: BSD
   size: 90150
   timestamp: 1645441199289
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
   sha256: cffb5a063111f7a99a99c74770b23db5dde52325e25a7a46d1903d5ff4a82c88
   md5: eeb1bd66f28bed1956ab989d6eff7ae5
   depends:
@@ -1375,14 +1375,14 @@ packages:
   license_family: BSD
   size: 889956
   timestamp: 1645089138421
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
   sha256: 5d68e69709ae10bd6c4b58b6af447ad2f2bd24955994f3ec77103d1a6bf5e1f5
   md5: 49e523de8d364b7fabc3850eccbe9bda
   depends:
   - libgcc-ng >=7.5.0
   size: 623492
   timestamp: 1652448233146
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
   sha256: 71f6c4a97014d745c58df52b4dd60ddd75a8508d54fe5b97f42bd1f31cb1c067
   md5: 686e77514ec9f1ef0a6feed374f14d37
   depends:
@@ -1394,7 +1394,7 @@ packages:
   license_family: MIT
   size: 789469
   timestamp: 1653546418059
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
   sha256: ea3355a67c5173f3944f09861043ca66eb7dbeff8f385d13528b3aabc0801d0c
   md5: 66e2aa12181bb2911485bdbe125d24c5
   depends:
@@ -1404,7 +1404,7 @@ packages:
   license: MIT
   size: 584199
   timestamp: 1654075843119
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
   sha256: 497e0a8e555539787dd237dea5d13a0a6061db2cb50ded20daddaf08bbf267cc
   md5: ecc0c3c465bbf6988ebbc6a38e2eeb1c
   depends:
@@ -1416,7 +1416,7 @@ packages:
   license: BSD-2-Clause
   size: 2826845
   timestamp: 1647870510956
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
   sha256: d8cd22ac7f033507549f6a0d078cd273607cb6e8246b0383375a33941969c12c
   md5: 78c7a3a437536ae24d2d7ce15ec400d2
   depends:
@@ -1425,7 +1425,7 @@ packages:
   license_family: BSD
   size: 11065
   timestamp: 1652903210940
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
   sha256: 64b022d706b76c33965a250fdc8c6008443c41bff8ab27bb1df3cb70419576fd
   md5: ec4f05846aacf634df15c389235725cc
   depends:
@@ -1437,7 +1437,7 @@ packages:
   license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
   size: 1538261
   timestamp: 1646624639995
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
   sha256: 2c6a5dda7c510a961bc78e31d4232be5e8e0760c93454f5fd200c379355e0f5e
   md5: f35d4bf2fbb39e334992f6dd39f8721e
   depends:
@@ -1447,7 +1447,7 @@ packages:
   license_family: BSD
   size: 220865
   timestamp: 1627657046002
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
   sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
   md5: feb0e452205b44ac45d9b5e55c21a3b1
   depends:
@@ -1459,7 +1459,7 @@ packages:
   license_family: BSD
   size: 22819
   timestamp: 1654597913064
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.5.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-3.5.1-py39h06a4308_1.tar.bz2
   sha256: 62fb0d06224e15528540718debebeaebbfdbd7f03106fad52a7002fb96c6b8bd
   md5: 364c1e3dddefa27741e540496c38b694
   depends:
@@ -1471,7 +1471,7 @@ packages:
   license_family: PSF
   size: 28294
   timestamp: 1647442129989
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
   sha256: dc51b316ef5dcfb82a9c0afdc40879146ae59516f6cea7db776077783dfd2d76
   md5: b0b6b57c140f026b8806051107336576
   depends:
@@ -1493,7 +1493,7 @@ packages:
   license_family: PSF
   size: 7729454
   timestamp: 1647442028622
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
   sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
   md5: c04ef34af33da4c71bcc99b7ec24d210
   depends:
@@ -1503,7 +1503,7 @@ packages:
   license_family: BSD
   size: 16391
   timestamp: 1662014553452
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
   sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
   md5: f6c734d73e6e3dbc1b62766cf18ff3e4
   depends:
@@ -1513,7 +1513,7 @@ packages:
   license_family: BSD
   size: 58153
   timestamp: 1607364912263
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
   sha256: 7c4ded8b2ef036839f988560848d2c32e1aa4627fd37a32710e42c39f5c61ac2
   md5: bd20f4410b81f327e35ffa0657961146
   depends:
@@ -1524,7 +1524,7 @@ packages:
   license_family: Proprietary
   size: 229783051
   timestamp: 1634547157986
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
   sha256: 5394f5efd53afb2c1b0abf571ce3d9cb684b6c7e255f140ba2acaa703d6113be
   md5: d3cb2bfa63e30153f5527797dcc87280
   depends:
@@ -1536,7 +1536,7 @@ packages:
   license_family: BSD
   size: 63551
   timestamp: 1626176932911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
   sha256: c244d23da2749857a993f84969fd35ffd183ab8f462986df6d33ae0f705fe034
   md5: 9b1f8ccc2488d0e04eb73211e2987483
   depends:
@@ -1550,7 +1550,7 @@ packages:
   license: BSD 3-Clause
   size: 204136
   timestamp: 1634566416657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
   sha256: f81f426f8ef306d636664bc49e7cdd70e2b4306d7c6bcb9c75fe35a45ab2087a
   md5: 77aa1d7f958d36bf227e6ff4a34d2e3d
   depends:
@@ -1564,7 +1564,7 @@ packages:
   license: BSD-3-Clause
   size: 365386
   timestamp: 1626186165897
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mpc-1.1.0-h10f8cd9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mpc-1.1.0-h10f8cd9_1.tar.bz2
   sha256: 2d95fe186309a0ee27df3a9af16aed4135d13e504844807b39d2c8e0b79a7ea0
   md5: c3e5119d578d2418331013ba024ba0bc
   depends:
@@ -1574,7 +1574,7 @@ packages:
   license: LGPL 3
   size: 96138
   timestamp: 1527612531645
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mpfr-4.0.2-hb69a4c5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mpfr-4.0.2-hb69a4c5_1.tar.bz2
   sha256: 45797c64e087386ef4a31738858fd43ed3c035a4e01f391fac8aa4fc6e6a8b40
   md5: 207e53f498d2efe14423a980e4d74816
   depends:
@@ -1583,7 +1583,7 @@ packages:
   license: LGPL-3.0-only
   size: 668948
   timestamp: 1593116348009
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mpmath-1.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mpmath-1.3.0-py39h06a4308_0.tar.bz2
   sha256: a4f00021c787949ff03a7f880484aff486b97aab80c6f5b6e0e738796559cf1f
   md5: ec29864ca787fa2e4ae66c4f91e9ed08
   depends:
@@ -1592,7 +1592,7 @@ packages:
   license_family: BSD
   size: 990665
   timestamp: 1690848387419
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
   sha256: 305313d215116fbf13a38f8a321eb635b83294871801ac63e543a59ba7de642c
   md5: e0db8ae050bd0db74f47edc370dbc287
   depends:
@@ -1602,7 +1602,7 @@ packages:
   license_family: BSD
   size: 24480
   timestamp: 1607574279743
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
   sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
   md5: 95c83d71814c504b5504df4f14548f1a
   depends:
@@ -1628,7 +1628,7 @@ packages:
   license_family: BSD
   size: 8257558
   timestamp: 1681756322140
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
   sha256: 1b92d72b083f3350359b8fb2e3b5dc846f49650c9e46a6a74354b1b7f0d42730
   md5: 996babe4314515ddd41008a53cb5d47f
   depends:
@@ -1641,7 +1641,7 @@ packages:
   license_family: BSD
   size: 98791
   timestamp: 1650290544347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
   sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
   md5: 1710a25086c8098367eb36b9d441448b
   depends:
@@ -1669,7 +1669,7 @@ packages:
   license_family: BSD
   size: 569683
   timestamp: 1668450704669
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
   sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
   md5: 385cc9e53404776782502c0fdb08820f
   depends:
@@ -1682,7 +1682,7 @@ packages:
   license_family: BSD
   size: 147046
   timestamp: 1694616899309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
   sha256: 0807371380965e421cb5f3f2a30d790fd5c41db11dbb6d318e14294c3b1741ed
   md5: fca4bd4e3891aebf4fd7daf9b6d0ccfa
   depends:
@@ -1690,7 +1690,7 @@ packages:
   license: Free software (MIT-like)
   size: 1083412
   timestamp: 1636570020698
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
   sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
   md5: bbbcbebc20a4fdcadce398d0ca04f95e
   depends:
@@ -1699,7 +1699,7 @@ packages:
   license_family: BSD
   size: 13109
   timestamp: 1672387143252
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
   sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
   md5: 248ce515640465371927d46f389ed555
   depends:
@@ -1724,7 +1724,7 @@ packages:
   license_family: BSD
   size: 594054
   timestamp: 1690985006481
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
   sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
   md5: 70db71df4ee1cdd38090c0f7b80ba61f
   depends:
@@ -1734,7 +1734,7 @@ packages:
   license_family: BSD
   size: 21944
   timestamp: 1668160644514
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
   sha256: 30f95c6c51ee7ca01801778b1773d8ecb57fcf06e864093f27148e1298517c20
   md5: 1c1f0821f0dd2ece64844f39edcbd03f
   depends:
@@ -1757,7 +1757,7 @@ packages:
   license_family: BSD
   size: 3982289
   timestamp: 1648045822890
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
   sha256: 15a12c8bebcda45c577e61cea412d9aafaa433e39f9e91fd61bbfab66fcee3ab
   md5: 5239d8330e8bd34972fb80918dce79e7
   depends:
@@ -1773,7 +1773,7 @@ packages:
   license_family: MIT
   size: 136437
   timestamp: 1640689905588
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.21.5-py39he7a7128_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.21.5-py39he7a7128_2.tar.bz2
   sha256: 9195828a286d79621f63766a1ac1143de7b862ae17ce5e95ca0c3a5c171868a1
   md5: 2bd04a53d17b21af64f413dc810b3d94
   depends:
@@ -1789,7 +1789,7 @@ packages:
   license: BSD-3-Clause
   size: 9728
   timestamp: 1651566346644
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.21.5-py39hf524024_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.21.5-py39hf524024_2.tar.bz2
   sha256: dbd1301d64a55552a01d74a1928d279646a97158cad3cce7e05548b6fa112338
   md5: e5666032c7865b4977e740e6f069e540
   depends:
@@ -1804,7 +1804,7 @@ packages:
   license: BSD-3-Clause
   size: 6385715
   timestamp: 1651566332949
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
   sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
   md5: 5ad4571eba2479f77a9f849a6ae7724c
   depends:
@@ -1814,7 +1814,7 @@ packages:
   license_family: Apache
   size: 3998613
   timestamp: 1694465071784
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
   sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
   md5: 77a22ed6d0d448c5288d0f695bc9ac49
   depends:
@@ -1823,7 +1823,7 @@ packages:
   license_family: Apache
   size: 72527
   timestamp: 1693575234886
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
   sha256: e7a0abb0f00a94000876f2095f0cf531ad3803ffbd868a780b3f06816b54492c
   md5: 97ef7e1fe923d22a8e2307f3f39a92d5
   depends:
@@ -1839,7 +1839,7 @@ packages:
   license_family: BSD
   size: 13221005
   timestamp: 1650622404234
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
   sha256: 64a732ce2661cdb6bd8f9d1484ac10afeb73082b1c2b44728d212e0117d2860e
   md5: ada303f0cf43a4e99cfa7f243b23b681
   depends:
@@ -1848,7 +1848,7 @@ packages:
   license_family: BSD
   size: 141832
   timestamp: 1684915385689
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
   sha256: 9c699bd495cbf23db7dea986deeb75183571b83adc14b3e4a36cc6cfd2a198a8
   md5: 39ed6f683307cca54ac666b2d1f849ff
   depends:
@@ -1862,7 +1862,7 @@ packages:
   license_family: BSD
   size: 35706
   timestamp: 1698702632637
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
   sha256: 4881cc5e0d5b20335bcfba4eaf29fdc95dedf2607903aabecdacffb64d3407d4
   md5: 4bac8a874e62f41ebab8345ca6076eb6
   depends:
@@ -1872,7 +1872,7 @@ packages:
   license_family: BSD
   size: 263308
   timestamp: 1624477853289
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
   sha256: 8bcb1c67693f42a3170eb77ef4cdbb81b605fdf40816953e69a33a065c101638
   md5: b7689507fb5f879dc766aaa8a4c37351
   depends:
@@ -1891,7 +1891,7 @@ packages:
   license_family: Other
   size: 734566
   timestamp: 1646325095608
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
   sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
   md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
   depends:
@@ -1902,7 +1902,7 @@ packages:
   license_family: MIT
   size: 2674850
   timestamp: 1697548887851
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
   sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
   md5: fe56f0479dd414c846191116366262c3
   depends:
@@ -1911,7 +1911,7 @@ packages:
   license_family: MIT
   size: 31999
   timestamp: 1692205535111
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
   sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
   md5: 44d2a857d13bdf9d99aaac039a249d47
   depends:
@@ -1920,7 +1920,7 @@ packages:
   license_family: Apache
   size: 91137
   timestamp: 1659455142164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
   sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
   md5: eb899a739d9b58dd747f1f6bd52d4cf3
   depends:
@@ -1932,7 +1932,7 @@ packages:
   license_family: BSD
   size: 579771
   timestamp: 1672387338600
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
   sha256: 6973cfe0565ba3b5ad6d1de9e34848fbbadd78b507b2e23e1c079636b8f8f317
   md5: a924535045fb356e23e7a3cc8116b638
   depends:
@@ -1942,7 +1942,7 @@ packages:
   license_family: BSD
   size: 350026
   timestamp: 1612298042840
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
   sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
   md5: f36ecb722522cbe2e3737424edf1b5e1
   depends:
@@ -1954,7 +1954,7 @@ packages:
   license_family: BSD
   size: 29312
   timestamp: 1675441510984
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
   sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
   md5: 6d03295e544251e608a28c8d7c48115e
   depends:
@@ -1963,7 +1963,7 @@ packages:
   license_family: BSD
   size: 1862058
   timestamp: 1684280096752
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
   sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
   md5: 1f09617aecd6f3c2f2e20692c0759f34
   depends:
@@ -1973,7 +1973,7 @@ packages:
   license_family: Apache
   size: 94434
   timestamp: 1690223520097
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
   sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
   md5: ffceed627867508d73af1636ab5ebf42
   depends:
@@ -1982,7 +1982,7 @@ packages:
   license_family: MIT
   size: 156324
   timestamp: 1661452578573
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.9.2-py39h2531618_6.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyqt-5.9.2-py39h2531618_6.tar.bz2
   sha256: c96502aca0df082c457f31d9e6202419aa86f24e1c699c3a34d02602f7a42812
   md5: 3eda4bcc31b66fd5002817def97cd129
   depends:
@@ -1996,7 +1996,7 @@ packages:
   license_family: GPL
   size: 6010734
   timestamp: 1607697278482
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
   sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
   md5: 0e3341a4fe434167bf74b613eb6afd81
   depends:
@@ -2006,7 +2006,7 @@ packages:
   license_family: MIT
   size: 97194
   timestamp: 1636110999719
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
   sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
   md5: c5f3f7f10ad30f0945e75252615ab6e5
   depends:
@@ -2015,7 +2015,7 @@ packages:
   license_family: BSD
   size: 31331
   timestamp: 1605305847037
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
   sha256: c4b9e332a6f2b7524e8c88e2b39a2568a48e556fd9a44c30759c43611d4d023d
   md5: bb118745c9b08fc5028f45e77f371e68
   depends:
@@ -2035,7 +2035,7 @@ packages:
   license_family: PSF
   size: 24553777
   timestamp: 1654084160832
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
   sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
   md5: 0caa188a695319bdb13f53b0a2b3accc
   depends:
@@ -2044,7 +2044,7 @@ packages:
   license_family: BSD
   size: 264864
   timestamp: 1661371117920
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
   sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
   md5: bcb44ecbea441ee0d4659133d060d71f
   depends:
@@ -2053,7 +2053,7 @@ packages:
   license_family: MIT
   size: 257904
   timestamp: 1695131670290
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
   sha256: 3da9cbbd49fac566433748bd245d09d7d5fcd28b04c0397cbbf6d5bb92f5c4a5
   md5: df73a5d2f6e089d51e71e91935a82c65
   depends:
@@ -2064,7 +2064,7 @@ packages:
   license_family: MIT
   size: 183753
   timestamp: 1635775763162
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
   sha256: 26005d191bb15070aad70707ed6493f32678a67978bd3b83d4c9679cab44e717
   md5: 2dc75d5a4ccb64310939c3a72d34ae20
   depends:
@@ -2075,7 +2075,7 @@ packages:
   license_family: BSD
   size: 521583
   timestamp: 1638435042256
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-5.9.7-h5867ecd_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/qt-5.9.7-h5867ecd_1.tar.bz2
   sha256: 5881ffba2ab8ed28112e80dd3f17ced0832b75615b9f8aab6bf171575c812b88
   md5: 50da300935a335f7605d3f96fa045111
   depends:
@@ -2099,7 +2099,7 @@ packages:
   license: LGPL-3.0
   size: 90037659
   timestamp: 1544604609235
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
   sha256: 8c950c69bee969e2c66f88f0dc247b3ab75a753672a88009779d5f5dba193532
   md5: 150ac0eb929bab9dec912797bdfc7b95
   depends:
@@ -2109,7 +2109,7 @@ packages:
   license_family: GPL
   size: 433182
   timestamp: 1642022402894
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
   sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
   md5: c7de00b4ac2778c4e5a7816320d75391
   depends:
@@ -2125,7 +2125,7 @@ packages:
   license_family: Apache
   size: 94028
   timestamp: 1690400356879
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.6.2-py39had2a1c9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/scipy-1.6.2-py39had2a1c9_1.tar.bz2
   sha256: 2cf06019a66fbb0a9df571bac7f0460eb66f60d6b9c37f6a64a6dcddbe2c765f
   md5: 5f18311a95358bb951f98a6d005a862d
   depends:
@@ -2140,7 +2140,7 @@ packages:
   license: BSD 3-Clause
   size: 21512828
   timestamp: 1618856702227
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
   sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
   md5: 1581cafc84708ed9aafaaee1cbbf6065
   depends:
@@ -2149,7 +2149,7 @@ packages:
   license_family: MIT
   size: 1089416
   timestamp: 1690290900608
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-4.19.13-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sip-4.19.13-py39h295c915_0.tar.bz2
   sha256: 9f2d68b41365097a380979014b3cabf5f1f9f07e5554eb215eef4801f640922e
   md5: 3ec6ce8f2eae0969b341e5702fb029c6
   depends:
@@ -2159,7 +2159,7 @@ packages:
   license: GPL-3.0
   size: 302624
   timestamp: 1643114723175
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
   sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
   md5: e19ffbfb24b990275d24fcea2bd1699b
   depends:
@@ -2168,7 +2168,7 @@ packages:
   license_family: Apache
   size: 15702
   timestamp: 1614030498860
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
   sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
   md5: ca061ce25c0f58628643abec8d6a8244
   depends:
@@ -2177,7 +2177,7 @@ packages:
   license_family: MIT
   size: 66330
   timestamp: 1696347637947
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
   sha256: 87965b7b46d93866d31696a1045216d64f077a06b2900c356aba87e8559c6188
   md5: fa334030245135b37027a882f3c468bf
   depends:
@@ -2188,7 +2188,7 @@ packages:
   license_family: Other
   size: 1561908
   timestamp: 1655328608308
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sympy-1.11.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sympy-1.11.1-py39h06a4308_0.tar.bz2
   sha256: d0a6c03dbe0b345752dee89659b33bbeb03457d7f370492daa8bc86f3d4841e1
   md5: 610a90128fe91c0402b3907b14c43542
   depends:
@@ -2201,7 +2201,7 @@ packages:
   license_family: BSD
   size: 12358373
   timestamp: 1668204388050
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
   sha256: d4c0f3e57d8df6042151e65a706f8cd76c9325a47548f4ca3c3516e352dd8ca3
   md5: 1decb9dd0e7bcee086d83b8b4ab8c8eb
   depends:
@@ -2210,7 +2210,7 @@ packages:
   license: Apache-2.0
   size: 171277
   timestamp: 1641830509786
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
   sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
   md5: 0e76eab58fe488e91f0aee73f46de031
   depends:
@@ -2221,7 +2221,7 @@ packages:
   license_family: BSD
   size: 29816
   timestamp: 1671751864131
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
   sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
   md5: b413a210eca82fe867e991eed085201b
   depends:
@@ -2231,7 +2231,7 @@ packages:
   license_family: BSD
   size: 38882
   timestamp: 1668168876032
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
   sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
   md5: 5b8375e2092012db69d2123dc0c68630
   depends:
@@ -2241,7 +2241,7 @@ packages:
   license_family: BSD
   size: 3485432
   timestamp: 1654088939579
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
   sha256: 57983e3eb698a3b08b570d5f398d9550cf50b9bf54b2b4728c731ecbc0c89138
   md5: 3ce956b1e1a7f77af6e6127dca987b95
   depends:
@@ -2250,7 +2250,7 @@ packages:
   license_family: BSD
   size: 101246
   timestamp: 1667464172523
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
   sha256: b746e39272888b9cc1a2a711b7b8836f2e26f4457850e43ad18bf0765e21dc3d
   md5: 200e86f8d53aeebf4b7dcfc944fd7920
   depends:
@@ -2260,7 +2260,7 @@ packages:
   license_family: Apache
   size: 661662
   timestamp: 1606942359431
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
   sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
   md5: 0f0b91a158dd3692cbb7a7763b657bfe
   depends:
@@ -2269,7 +2269,7 @@ packages:
   license_family: BSD
   size: 192032
   timestamp: 1671143995098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
   md5: 8515e64a3de7581360d713fe4c0a094e
   depends:
@@ -2279,7 +2279,7 @@ packages:
   license_family: PSF
   size: 8789
   timestamp: 1690297588156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
   md5: 60170012374b2a5007842fa5870d78c5
   depends:
@@ -2288,7 +2288,7 @@ packages:
   license_family: PSF
   size: 57479
   timestamp: 1690297581658
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
   sha256: 870f20a3c006a74b291910f69c3469a409bd21437142864b29cfafeb89ca7c34
   md5: 1b2f1589e3ebc3e0c6ecb38dba93e4ae
   depends:
@@ -2303,7 +2303,7 @@ packages:
   license_family: MIT
   size: 186761
   timestamp: 1686163186447
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
   sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
   md5: f8d03a15b974fc7810d9f54ae849fc8e
   depends:
@@ -2312,7 +2312,7 @@ packages:
   license_family: BSD
   size: 20781
   timestamp: 1607365390528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
   sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
   md5: d7db5d6ce1db80eade8a082ff78bf479
   depends:
@@ -2322,7 +2322,7 @@ packages:
   license_family: BSD
   size: 71044
   timestamp: 1614804011510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
   sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
   md5: b3899f8bda32734727bd5a73df1d7d17
   depends:
@@ -2331,7 +2331,7 @@ packages:
   license_family: MIT
   size: 101520
   timestamp: 1695742037911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
   sha256: d88bdc49a883a944cf1562ebb0a30d0451e28ab05521fc882615e357b105f414
   md5: c150cf16071597fa3977fb81ebb83760
   depends:
@@ -2343,7 +2343,7 @@ packages:
   license_family: Apache
   size: 1787638
   timestamp: 1689041557651
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
   sha256: 2ce360ff98c0ca4537d70c19266b5700810196c54ce2fbaff3b94a969846ee37
   md5: 94cb94dc47405b24b1b5bd0a3275ab59
   depends:
@@ -2352,7 +2352,7 @@ packages:
   license_family: GPL2
   size: 398058
   timestamp: 1651602137803
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -2360,7 +2360,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
   sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
   md5: 567b68192c387b5fc88178425577a0fe
   depends:
@@ -2370,7 +2370,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 366479
   timestamp: 1616055552392
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
   sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
   md5: 3818a9531fe74433c3b7d5144c9a58cc
   depends:
@@ -2379,7 +2379,7 @@ packages:
   license_family: MIT
   size: 18021
   timestamp: 1672387231268
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
   sha256: 513444d83ac2405e898531492ea59f3a95641e357cc39c1048d6fffc1791a16b
   md5: 601d9449c280b9b145dc8c83b6f06119
   depends:
@@ -2388,7 +2388,7 @@ packages:
   license_family: Other
   size: 133595
   timestamp: 1650637720646
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
   sha256: 1c049c23788a00b6f38bdc801245e0e60af98718d4db4c958658bcc67ff158c7
   md5: b1737dfd2e06ad69ec5cfec341e207c6
   depends:
@@ -2401,7 +2401,7 @@ packages:
   license_family: BSD
   size: 827172
   timestamp: 1650622223170
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -2414,7 +2414,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -2424,7 +2424,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
   md5: b2aa5503875aba2f1d88cae9df9a96d5
   depends:
@@ -2433,7 +2433,7 @@ packages:
   license_family: BSD
   size: 13636
   timestamp: 1611930018941
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -2445,7 +2445,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
   sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
   md5: 544adf2677c47c9b9c891aea720678f1
   depends:
@@ -2453,7 +2453,7 @@ packages:
   license: MIT
   size: 33999
   timestamp: 1630003259346
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -2462,7 +2462,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -2471,7 +2471,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -2480,7 +2480,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -2489,7 +2489,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
   sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
   md5: 9eff1a842dbda8d1bae9a2c008b599bc
   depends:
@@ -2500,7 +2500,7 @@ packages:
   license_family: MIT
   size: 690443
   timestamp: 1625743217109
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -2508,7 +2508,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
   sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
   md5: 33624a42ee387bf9918ea98b4e7b31fc
   depends:
@@ -2518,7 +2518,7 @@ packages:
   license_family: BSD
   size: 8173
   timestamp: 1601490751973
-- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
   sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
   md5: 67857cc5e9044770d2b15f9d94a4521d
   depends:
@@ -2527,7 +2527,7 @@ packages:
   license_family: Apache
   size: 12810
   timestamp: 1600445183315
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -2536,7 +2536,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -2545,7 +2545,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -2555,7 +2555,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
   sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
   md5: e68a6f315f41a8d814d833652bf38b9b
   depends:
@@ -2563,7 +2563,7 @@ packages:
   license: MIT
   size: 13374
   timestamp: 1606932077143
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -2571,7 +2571,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -2580,7 +2580,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -2589,7 +2589,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
   sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
   md5: 2eb923cc014094f4acf7f849d67d73f8
   depends:
@@ -2599,7 +2599,7 @@ packages:
   license_family: BSD
   size: 246457
   timestamp: 1626374695070
-- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
   sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
   md5: 41db68b96e114e367c4f120a3b379e59
   depends:
@@ -2608,7 +2608,7 @@ packages:
   license_family: BSD
   size: 19391
   timestamp: 1632406728844
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -2617,7 +2617,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -2629,14 +2629,14 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
   sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
   md5: a815d3bdb160bcc71687f2dda70d3ca4
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 122218
   timestamp: 1680170368293
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -2644,7 +2644,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
   sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
   md5: 447a49f7bad119faa80d7f14aa296c95
   depends:
@@ -2657,7 +2657,7 @@ packages:
   license_family: MIT
   size: 162176
   timestamp: 1644481750133
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
   sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
   md5: 8810f48fe4a4792de0fd3520b502d08b
   depends:
@@ -2666,7 +2666,7 @@ packages:
   license_family: BSD
   size: 10019
   timestamp: 1606859473259
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
   sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
   md5: 00a446b6dfc61af223df4de29fe8ad94
   depends:
@@ -2676,7 +2676,7 @@ packages:
   license_family: MIT
   size: 34305
   timestamp: 1644569782044
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
   sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
   md5: bd92dd8bd5b9d24e632b62a075426e50
   depends:
@@ -2685,7 +2685,7 @@ packages:
   license_family: MIT
   size: 133634
   timestamp: 1695718025321
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
   sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
   md5: f8ae051b591a9027adc16de1be9748f4
   depends:
@@ -2695,12 +2695,12 @@ packages:
   license_family: MIT
   size: 206198
   timestamp: 1681493096349
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
   sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
   md5: e2f3248e2a5009a02f7b8e54f83314ef
   size: 5620
   timestamp: 1528121955725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
   sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
   md5: 0d79760d544d0bd8acb4adc4ef813418
   depends:
@@ -2710,7 +2710,7 @@ packages:
   license_family: BSD
   size: 137075
   timestamp: 1657175654487
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
   sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
   md5: 31d6d04cd2388d8f19004501271b3545
   depends:
@@ -2720,7 +2720,7 @@ packages:
   license: MIT
   size: 18982
   timestamp: 1659616229395
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
   sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
   md5: caf1073dc2ca5aeb832a2877394eae12
   depends:
@@ -2729,7 +2729,7 @@ packages:
   license: MIT
   size: 18233
   timestamp: 1659616216769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
   sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
   md5: aa1ed20c38af535c8d6a955314759d7b
   depends:
@@ -2738,14 +2738,14 @@ packages:
   license: MIT
   size: 394588
   timestamp: 1659616312678
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
   sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
   md5: ce3588e31faa79f546e0fc6a36c5543c
   license: MPL-2.0
   license_family: Other
   size: 133884
   timestamp: 1694009771475
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
   sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
   md5: 21eb7f53076d0a69513cfd258f6ef63c
   depends:
@@ -2754,7 +2754,7 @@ packages:
   license_family: Other
   size: 159756
   timestamp: 1690232346868
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
   sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
   md5: a40a04d9cda1e665565bc6c832d598b6
   depends:
@@ -2765,7 +2765,7 @@ packages:
   license_family: MIT
   size: 225258
   timestamp: 1670423337502
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
   sha256: b860f45bce9fbb40d024dcd3306e66a52010641091ca8d1fcdde6c4238717c73
   md5: 3c38f3af9c23b26efc2b11d82c95922a
   depends:
@@ -2774,7 +2774,7 @@ packages:
   license_family: BSD
   size: 153013
   timestamp: 1698129937688
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
   sha256: c368e11dc241d1b79b4bb0d9333b353dc1b966b49d145163a0590d88ad88fef2
   md5: 1e62044b8a32d1452e51773ba7a4319c
   depends:
@@ -2783,7 +2783,7 @@ packages:
   license_family: BSD
   size: 41392
   timestamp: 1683040146991
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
   sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
   md5: b2cc5f37f7bb069d061306e7eac2a011
   depends:
@@ -2793,7 +2793,7 @@ packages:
   license_family: CC
   size: 1913396
   timestamp: 1668084575248
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
   sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
   md5: 103d8c039e342115720a84d59c119d46
   depends:
@@ -2803,7 +2803,7 @@ packages:
   license_family: BSD
   size: 13774
   timestamp: 1671231190250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
   sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
   md5: cb80c7ac65b48a737654f371fe31c460
   depends:
@@ -2816,7 +2816,7 @@ packages:
   license_family: BSD
   size: 1307228
   timestamp: 1694212041712
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
   sha256: e80ce32bc86af3e0b67d44bc2c774dde7490443bf6ae4bed7d9c666e3631965f
   md5: ba47d3bdf582bf15e9250bff6b2f6dbd
   depends:
@@ -2833,7 +2833,7 @@ packages:
   license_family: BSD
   size: 2125677
   timestamp: 1686783049768
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
   sha256: 7717c1f0af2af4b28b6d787b32c5e1740f391915c78707d8643e0d516088dbd0
   md5: d7ae4c5cb253fa85c0ce268d2bf9a191
   depends:
@@ -2855,7 +2855,7 @@ packages:
   license_family: BSD
   size: 17679970
   timestamp: 1692372465872
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
   sha256: 40bbbe2ed223829f4a3f91024fa409f1a665ad94294bec2c9e930989bb2b8911
   md5: 4add00dc619c12370af0ed18c76b71f6
   depends:
@@ -2867,7 +2867,7 @@ packages:
   license_family: BSD
   size: 103370
   timestamp: 1613390236788
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
   sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
   md5: 04cbe8f4bc62c34fac9d42d1124059bf
   depends:
@@ -2877,7 +2877,7 @@ packages:
   license_family: MIT
   size: 2052734
   timestamp: 1690905361158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
   sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
   md5: ef0e825982f242085574f502dfff4f6b
   depends:
@@ -2886,7 +2886,7 @@ packages:
   license_family: MIT
   size: 16594
   timestamp: 1649926538106
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
   sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
   md5: 24747a300246c016b3a7f04dabd02d4a
   depends:
@@ -2895,7 +2895,7 @@ packages:
   license_family: BSD
   size: 27709
   timestamp: 1668714497209
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -2905,7 +2905,7 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
   sha256: 95e9a45812b1b4059b973e5e6e131c7c1a8b2ce2dafc5117e7806b1c8f30de27
   md5: bc889aaa846ed177fc5f495c24041acc
   depends:
@@ -2914,14 +2914,14 @@ packages:
   license_family: BSD
   size: 262430
   timestamp: 1695734574609
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
   sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
   md5: e4a732941f74b8062c8bcbfe5c5c2b56
   license: MIT
   license_family: MIT
   size: 80252
   timestamp: 1676983220161
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/gmp-6.2.1-he9d5cce_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/gmp-6.2.1-he9d5cce_3.tar.bz2
   sha256: 4ad52b3117e5a73afae7b257439d7ddda39032dacbb097645756f71fe688c952
   md5: e0c3ff3de3d5896b080f777be9badbbc
   depends:
@@ -2929,7 +2929,7 @@ packages:
   license: GPL-2.0-or-later AND LGPL-3.0-or-later
   size: 817742
   timestamp: 1653996454448
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/gmpy2-2.1.2-py39hd5de756_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/gmpy2-2.1.2-py39hd5de756_0.tar.bz2
   sha256: 21504857bd37aa0a2f7abc08de83e5f94ae65460499616b1b5f00ea200998eb9
   md5: 7a69b7671ec6be17706d87af701c9cec
   depends:
@@ -2941,7 +2941,7 @@ packages:
   license_family: LGPL
   size: 170636
   timestamp: 1645455604074
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
   sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
   md5: f3ce6fe6eb760c236e5f7d04df5faa81
   depends:
@@ -2950,7 +2950,7 @@ packages:
   license_family: MIT
   size: 28138484
   timestamp: 1692293212596
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
   sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
   md5: 6dd72c43fea25b748ec7a9f6c0407e15
   depends:
@@ -2959,7 +2959,7 @@ packages:
   license_family: BSD
   size: 111810
   timestamp: 1666125671024
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
   sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
   md5: 03cdb7e679924b329ecab8f12cb8fc67
   depends:
@@ -2969,7 +2969,7 @@ packages:
   license_family: APACHE
   size: 38813
   timestamp: 1678997212422
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
   sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
   md5: 78baea934985ccd9514a366cc7e80ed4
   depends:
@@ -2978,7 +2978,7 @@ packages:
   license_family: Proprietary
   size: 727499
   timestamp: 1681801225190
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
   sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
   md5: da9b63e42f281f7e77b289f4b654b83b
   depends:
@@ -3000,7 +3000,7 @@ packages:
   license_family: BSD
   size: 218436
   timestamp: 1691121840155
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
   sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
   md5: 6a7cb9b49593b29933fa2b503d533a08
   depends:
@@ -3022,7 +3022,7 @@ packages:
   license_family: BSD
   size: 1257205
   timestamp: 1694181720454
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
   sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
   md5: d861ef66f5c0a282d60b65778a9de2f3
   depends:
@@ -3032,7 +3032,7 @@ packages:
   license_family: MIT
   size: 1048450
   timestamp: 1644315332508
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
   sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
   md5: f7e603c965052deed8b789c35855a42f
   depends:
@@ -3042,14 +3042,14 @@ packages:
   license_family: BSD
   size: 213537
   timestamp: 1666908270815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
   sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
   md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
   license: IJG
   license_family: Other
   size: 278924
   timestamp: 1677849185191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
   sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
   md5: a82a17e78f725dcbd71ff8dac6db05c7
   depends:
@@ -3060,7 +3060,7 @@ packages:
   license_family: MIT
   size: 133134
   timestamp: 1676558895333
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
   sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
   md5: ee9270379a9ebdb6297e4b6849b3f7f0
   depends:
@@ -3076,7 +3076,7 @@ packages:
   license_family: BSD
   size: 195479
   timestamp: 1676329410154
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 32b898a97dca7770858ab31294238fde11ab61a84831a52f320e5ee5405a147c
   md5: 926e754b8fad288b583ef2933deae1a5
   depends:
@@ -3087,7 +3087,7 @@ packages:
   license_family: BSD
   size: 92938
   timestamp: 1679906616072
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
   sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
   md5: 7e60995b3119417213e5faedda147499
   depends:
@@ -3111,7 +3111,7 @@ packages:
   license_family: BSD
   size: 403165
   timestamp: 1671707664990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
   sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
   md5: cd470bdb28bb0e8b3535c93a3a6dad07
   depends:
@@ -3121,7 +3121,7 @@ packages:
   license_family: BSD
   size: 65431
   timestamp: 1672387389172
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -3131,7 +3131,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -3140,13 +3140,13 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
   sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
   md5: 7dba7aa5b971febb55281659843586ba
   license: MIT
   size: 65470
   timestamp: 1659616172703
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
   sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
   md5: f78a158983f0bbaba56f34b976bc6dae
   depends:
@@ -3154,7 +3154,7 @@ packages:
   license: MIT
   size: 34189
   timestamp: 1659616189313
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
   sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
   md5: 36a1d885725d3ab4d1fadc5a29f978d2
   depends:
@@ -3162,28 +3162,28 @@ packages:
   license: MIT
   size: 327737
   timestamp: 1659616202869
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
   sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
   md5: 817848d0e2b2808acdc9b3fbbf581726
   license: MIT
   license_family: MIT
   size: 133887
   timestamp: 1683716590737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
   sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
   md5: e458587c87e3f2d20192f4e0738f2c63
   depends:
@@ -3192,7 +3192,7 @@ packages:
   license_family: GPL
   size: 149419
   timestamp: 1665498987619
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
   sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
   md5: 1058b661ec829b2ee3716ee2a5520641
   depends:
@@ -3203,14 +3203,14 @@ packages:
   license_family: GPL
   size: 1917987
   timestamp: 1665498925405
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
   sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
   md5: c90372428e1e4eed4fdcd790979d06b4
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1409377
   timestamp: 1650983531933
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
   sha256: 8176dd9a68815301a24ed51e72f3506f5f77c67a112efa0dd14971f2f3b3c8c1
   md5: b5e470c224000a6bda6f655c155b53e7
   depends:
@@ -3222,7 +3222,7 @@ packages:
   license_family: Apache
   size: 27861431
   timestamp: 1683292881730
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -3231,13 +3231,13 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -3254,7 +3254,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
   sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
   md5: c0b99f8e1c7475f23b1c7b4250b06e1c
   depends:
@@ -3268,7 +3268,7 @@ packages:
   license_family: BSD
   size: 88021
   timestamp: 1694778290062
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
   sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
   md5: 46a65d1fc24013217e06aaf6d65ffcad
   constrains:
@@ -3277,7 +3277,7 @@ packages:
   license_family: BSD
   size: 425478
   timestamp: 1694776947990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
   sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
   md5: 06866415ef22d5322f9bdc9956b59c4d
   depends:
@@ -3289,7 +3289,7 @@ packages:
   license_family: MIT
   size: 678174
   timestamp: 1692970318885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
   sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
   md5: 2edc6c894d6d0321304396e9bd40df94
   depends:
@@ -3299,7 +3299,7 @@ packages:
   license_family: MIT
   size: 241774
   timestamp: 1692973618934
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
   sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
   md5: 5c740b4a18a558de0ccfe601703c423c
   constrains:
@@ -3308,7 +3308,7 @@ packages:
   license_family: Apache
   size: 338738
   timestamp: 1662635677689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
   sha256: fbf3c01a0834c151485b1b2ddf0c83d43703cbea051c6dbcb0d8d41946107670
   md5: 12137025daee35f5c708ca10d0c96e3c
   depends:
@@ -3320,7 +3320,7 @@ packages:
   license_family: BSD
   size: 318622
   timestamp: 1697031357874
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 1dab4daa56408915de3ec270c8b887e7221d48633ea83b0afff61041fc197972
   md5: 1519f9b766f9f894282db8353066e3b2
   depends:
@@ -3329,7 +3329,7 @@ packages:
   license_family: BSD
   size: 11883
   timestamp: 1652903144294
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
   sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
   md5: 8bbd981ca0129d7beeacd3cd7623f714
   depends:
@@ -3340,7 +3340,7 @@ packages:
   license_family: Other
   size: 1491074
   timestamp: 1695058597986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
   sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
   md5: d5f58d056b4bfc67aec30c77035ba889
   depends:
@@ -3349,7 +3349,7 @@ packages:
   license_family: BSD
   size: 182491
   timestamp: 1670944720979
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
   sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
   md5: 3681ebf029211ceab26af6f5d35abf39
   depends:
@@ -3360,7 +3360,7 @@ packages:
   license_family: BSD
   size: 22254
   timestamp: 1654598220251
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.5.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-3.5.3-py39hecd8cb5_0.tar.bz2
   sha256: eb50c8eed3f9cc7a082b51c6d8fa2e298e497af1c6daedcf9f9b2d010eff0194
   md5: 7780a1de869415ba3f30d778b97a8897
   depends:
@@ -3371,7 +3371,7 @@ packages:
   license_family: PSF
   size: 7564
   timestamp: 1667357137796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.5.3-py39hfb0c5b7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.5.3-py39hfb0c5b7_0.tar.bz2
   sha256: 4e47d48d968afb1b6eb6f3498a70989570970b14721a8eba6165e0ba5fb901b7
   md5: 6d5fc756d08aca1d7efb452d38a94c5e
   depends:
@@ -3391,7 +3391,7 @@ packages:
   license_family: PSF
   size: 7750190
   timestamp: 1667356965102
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
   sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
   md5: 6eb64ecfcd754502e271db0bb51d2cfd
   depends:
@@ -3401,7 +3401,7 @@ packages:
   license_family: BSD
   size: 17374
   timestamp: 1662014643620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
   sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
   md5: 2a4d604717a647ad21af766289cbbfc3
   depends:
@@ -3410,7 +3410,7 @@ packages:
   license_family: BSD
   size: 58057
   timestamp: 1607364912348
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
   sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
   md5: 25051fe272624544652dc6d814c2943a
   depends:
@@ -3423,7 +3423,7 @@ packages:
   license_family: Proprietary
   size: 224420228
   timestamp: 1691503125614
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
   sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
   md5: 37d8cf85a63f7aa9af1624894a7d606d
   depends:
@@ -3433,7 +3433,7 @@ packages:
   license_family: BSD
   size: 48590
   timestamp: 1682969183093
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
   sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
   md5: 0b2aee6666135bbd36b46d6ac66160f7
   depends:
@@ -3446,7 +3446,7 @@ packages:
   license_family: BSD
   size: 210705
   timestamp: 1695058433223
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
   sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
   md5: e22fb55ce380d0ebd44cce3f20d5349e
   depends:
@@ -3460,7 +3460,7 @@ packages:
   license_family: BSD
   size: 296614
   timestamp: 1695060155673
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mpc-1.1.0-h6ef4df4_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mpc-1.1.0-h6ef4df4_1.tar.bz2
   sha256: 7592d8bdd91939479ce242511fa530cf488d69765e3f1a1d1ca87292c78ed696
   md5: e3f4e5825d7495329009da2529626af2
   depends:
@@ -3469,7 +3469,7 @@ packages:
   license: LGPL 3
   size: 92037
   timestamp: 1527612755603
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mpfr-4.0.2-h9066e36_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mpfr-4.0.2-h9066e36_1.tar.bz2
   sha256: 288afa0093b87d1d486cb2c837ee4d66e6976f7cd19242653ccc0c9a01af37cd
   md5: 083ab8a04e706f95d97e79de976540fb
   depends:
@@ -3477,7 +3477,7 @@ packages:
   license: LGPL-3.0-only
   size: 607328
   timestamp: 1593117609730
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mpmath-1.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mpmath-1.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 9550dfc6bdeaf7d964155aa2e6545269af8dac5080a04c7a0404336d737fd98e
   md5: 2cf92437be655244199383de117395d4
   depends:
@@ -3486,7 +3486,7 @@ packages:
   license_family: BSD
   size: 992149
   timestamp: 1690848362952
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
   sha256: 5f60ca253f1fea0a1d765f535ff9ca2cf7efba90aea4c9a290d8f50ad11d4f6f
   md5: 97d6ec94e2300030bddf0e5289cd2a84
   depends:
@@ -3496,7 +3496,7 @@ packages:
   license_family: BSD
   size: 24240
   timestamp: 1607574265505
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
   sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
   md5: 1a5d4004e64e3cfb7a2a297b9117c285
   depends:
@@ -3522,7 +3522,7 @@ packages:
   license_family: BSD
   size: 8213832
   timestamp: 1681756573646
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
   sha256: 2975bd1f98ca9ec7354ee378f86f8322ec90f568374776fd90e80c534fbee882
   md5: 798627089e0ccba26695a26d9cb127ec
   depends:
@@ -3535,7 +3535,7 @@ packages:
   license_family: BSD
   size: 99066
   timestamp: 1650308465824
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
   sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
   md5: e572c1264a7af20b486f64ac8c9e1f57
   depends:
@@ -3563,7 +3563,7 @@ packages:
   license_family: BSD
   size: 573356
   timestamp: 1668450732828
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
   sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
   md5: b67569a7c30af9ffa5cde6e4b52ac68b
   depends:
@@ -3576,14 +3576,14 @@ packages:
   license_family: BSD
   size: 148342
   timestamp: 1694616917184
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
   sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
   md5: 97b81f34efbe86c5220fe82eb584fd62
   depends:
@@ -3592,7 +3592,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387288528
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
   sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
   md5: d77862975a9a1cf50acb803be26e83a1
   depends:
@@ -3617,7 +3617,7 @@ packages:
   license_family: BSD
   size: 575365
   timestamp: 1690985052739
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
   sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
   md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
   depends:
@@ -3627,7 +3627,7 @@ packages:
   license_family: BSD
   size: 22858
   timestamp: 1668160618784
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
   sha256: 249efa747726ad61bc1093f33f155f0b7a0fa5b728cb1a6a6bd126458f279c96
   md5: 1cced9a92d68307846cf59c238a42f13
   depends:
@@ -3647,7 +3647,7 @@ packages:
   license_family: BSD
   size: 4431283
   timestamp: 1697057424792
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
   sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
   md5: 185e9c41abb88ee59b52ec0f5f65d506
   depends:
@@ -3661,7 +3661,7 @@ packages:
   license_family: MIT
   size: 138305
   timestamp: 1696515469702
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
   sha256: 361754aae186c6f4f8e5ceadf02b95ae74b47a97eaf1aa37538a7c410fb3ec88
   md5: 02e4a556e3eb2375ec5a75795dd32372
   depends:
@@ -3677,7 +3677,7 @@ packages:
   license_family: BSD
   size: 12847
   timestamp: 1691166007881
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
   sha256: 94d69c58f79dea6d155debef3237f02397ab6c3d042b519ad89fc64d204507d2
   md5: 891a8850c69fd11971e58dfba0c40fcd
   depends:
@@ -3692,7 +3692,7 @@ packages:
   license_family: BSD
   size: 7529822
   timestamp: 1691165972737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
   sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
   md5: 93f5d7b66976154adeda219bea02ba45
   depends:
@@ -3702,7 +3702,7 @@ packages:
   license: BSD 2-Clause
   size: 484257
   timestamp: 1630093862501
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
   sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
   md5: 5e8713ef1215406254988163eaf34020
   depends:
@@ -3711,7 +3711,7 @@ packages:
   license_family: Apache
   size: 4965606
   timestamp: 1695323060401
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
   sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
   md5: 4154929ace2ad6ee16aea815635a6d1f
   depends:
@@ -3720,7 +3720,7 @@ packages:
   license_family: Apache
   size: 73598
   timestamp: 1693575307570
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-1.5.3-py39h07fba90_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-1.5.3-py39h07fba90_0.tar.bz2
   sha256: e9cb7e5f160ca30db363e54a07ebe4c0a3bb18615995403b926c973d21fc05ba
   md5: 32c41a3c0aafd5440f887a4a72b00193
   depends:
@@ -3766,7 +3766,7 @@ packages:
   license_family: BSD
   size: 13059606
   timestamp: 1677853236606
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
   sha256: 914f1ec8d911083c006c4c2d3b4c0c528e79abba3ae5f1dad825bd896870270d
   md5: 949e0e4c0ce43c92eb52241892230873
   depends:
@@ -3775,7 +3775,7 @@ packages:
   license_family: BSD
   size: 142949
   timestamp: 1684915417020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
   sha256: ddcb56e35d537f7a748b242c7c44368f112471973a52ae022945f597b7a83c7c
   md5: 94bac4f8fbfaf821ace161b9f1f58716
   depends:
@@ -3789,7 +3789,7 @@ packages:
   license_family: BSD
   size: 36756
   timestamp: 1698702713944
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
   sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
   md5: be0a90921f3bf4f0d6950fb786093de7
   depends:
@@ -3808,7 +3808,7 @@ packages:
   license_family: Other
   size: 719901
   timestamp: 1696580194417
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
   sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
   md5: 81ae9ec2d7fcf6934847bff558b619f5
   depends:
@@ -3819,7 +3819,7 @@ packages:
   license_family: MIT
   size: 2672987
   timestamp: 1697548890181
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
   sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
   md5: 1a822c206e2abddc5d6d821721af227f
   depends:
@@ -3828,7 +3828,7 @@ packages:
   license_family: MIT
   size: 33013
   timestamp: 1692205801265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
   sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
   md5: 1604d33dbdb2446c642970f8b354bedb
   depends:
@@ -3837,7 +3837,7 @@ packages:
   license_family: Apache
   size: 91266
   timestamp: 1659455269141
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
   sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
   md5: d1b3bcc35655a3123acb1fa2ad1a8511
   depends:
@@ -3849,7 +3849,7 @@ packages:
   license_family: BSD
   size: 580828
   timestamp: 1672387372015
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
   sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
   md5: 7540555d1fb192236db9a7c5c9d3601c
   depends:
@@ -3858,7 +3858,7 @@ packages:
   license_family: BSD
   size: 365765
   timestamp: 1656431373327
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
   sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
   md5: 0a73533fb6e0dc717ab906a537bc747d
   depends:
@@ -3870,7 +3870,7 @@ packages:
   license_family: BSD
   size: 30803
   timestamp: 1675441638631
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
   sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
   md5: 0a959fbad46ab38ade48dbd358002674
   depends:
@@ -3879,7 +3879,7 @@ packages:
   license_family: BSD
   size: 1864757
   timestamp: 1684280094736
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
   sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
   md5: ea24b5076ef79e4567c5a3f0cb22b470
   depends:
@@ -3889,7 +3889,7 @@ packages:
   license_family: Apache
   size: 95330
   timestamp: 1690223465114
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
   sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
   md5: bcaea6d4a47e9c874becaa700c78dcf7
   depends:
@@ -3898,7 +3898,7 @@ packages:
   license_family: MIT
   size: 157216
   timestamp: 1661452617825
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
   sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
   md5: 707110d1b49cb1864acb0bbaa103591e
   depends:
@@ -3907,7 +3907,7 @@ packages:
   license_family: MIT
   size: 95016
   timestamp: 1636111184034
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
   sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
   md5: 113a443b9c706f9f9c6187c0eaa3de27
   depends:
@@ -3916,7 +3916,7 @@ packages:
   license_family: BSD
   size: 31178
   timestamp: 1605305861851
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
   sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
   md5: 85a8d0001db70e52a479155228cb1fe0
   depends:
@@ -3935,7 +3935,7 @@ packages:
   license_family: PSF
   size: 13324979
   timestamp: 1694439878265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
   sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
   md5: 47c5e22e31ec05a7bc0ce90065a53afd
   depends:
@@ -3944,7 +3944,7 @@ packages:
   license_family: BSD
   size: 265348
   timestamp: 1661368839620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
   sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
   md5: ce9a69e1668aa1e133f2aa6d4e8d346f
   depends:
@@ -3953,7 +3953,7 @@ packages:
   license_family: MIT
   size: 254958
   timestamp: 1695131709704
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
   sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
   md5: 637f08b19dd8fd87347d8c44f9e3e202
   depends:
@@ -3963,7 +3963,7 @@ packages:
   license_family: MIT
   size: 170776
   timestamp: 1698096100056
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
   sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
   md5: 8ce3ac7d8a04e469b566f1b090d01140
   depends:
@@ -3974,7 +3974,7 @@ packages:
   license_family: BSD
   size: 470617
   timestamp: 1657724324011
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -3983,7 +3983,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
   sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
   md5: 6f2d41dd76a03b7f85a1ed49af1763d6
   depends:
@@ -3999,7 +3999,7 @@ packages:
   license_family: Apache
   size: 95100
   timestamp: 1690400262627
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
   sha256: a9755ecbfd42c708945027facfa11a3dc3119778326a0ae5df79f80d7b72afa5
   md5: 839ffa4e775fee9a8bdddabf4a14da43
   depends:
@@ -4016,7 +4016,7 @@ packages:
   license_family: BSD
   size: 24331914
   timestamp: 1696545397632
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
   md5: b0321e6f14e139fc15b1f8b4acb35d2f
   depends:
@@ -4025,7 +4025,7 @@ packages:
   license_family: MIT
   size: 1093966
   timestamp: 1690290944588
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
   sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
   md5: 62b64576a0aa5f6c3fb05f56650d25e1
   depends:
@@ -4034,7 +4034,7 @@ packages:
   license_family: Apache
   size: 15535
   timestamp: 1614030509324
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
   sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
   md5: 15b5595b31e39f08eaacbe2e502d8fb3
   depends:
@@ -4043,7 +4043,7 @@ packages:
   license_family: MIT
   size: 67292
   timestamp: 1696347733587
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
   sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
   md5: 82e4db6a498480a75d53c55bd35b6478
   depends:
@@ -4055,7 +4055,7 @@ packages:
   license_family: Other
   size: 1801397
   timestamp: 1681394807900
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sympy-1.11.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sympy-1.11.1-py39hecd8cb5_0.tar.bz2
   sha256: c8ca26b224982f834434ed8be60a54c7c1f07523a0ed67db6a5f4b9b51022ac5
   md5: cc3bdf03364df0db20134e08a6b00cf8
   depends:
@@ -4068,7 +4068,7 @@ packages:
   license_family: BSD
   size: 12376249
   timestamp: 1668204225577
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -4077,7 +4077,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
   sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
   md5: 63b957927b9949ccb19da28ec4612706
   depends:
@@ -4088,7 +4088,7 @@ packages:
   license_family: BSD
   size: 30902
   timestamp: 1671751919031
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
   sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
   md5: e346257a2fa8e2cb48c762138a5d009b
   depends:
@@ -4098,7 +4098,7 @@ packages:
   license_family: BSD
   size: 39915
   timestamp: 1668168959656
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
   sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
   md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
   depends:
@@ -4107,7 +4107,7 @@ packages:
   license_family: BSD
   size: 3536231
   timestamp: 1654088937695
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
   sha256: 74fc3a9e308602b3710f8fa671f24f5492571d0c8f7c1b3071dac72671262d45
   md5: e08ead92568f5bd72d5ac7f08f087fee
   depends:
@@ -4116,7 +4116,7 @@ packages:
   license_family: BSD
   size: 102258
   timestamp: 1667464155001
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
   sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
   md5: a1bbf0abfb8c45541122c0eb2feee317
   depends:
@@ -4125,7 +4125,7 @@ packages:
   license_family: Apache
   size: 680464
   timestamp: 1696937112175
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
   md5: 8a292c1ee22489bef2e84bc3aaf4098e
   depends:
@@ -4134,7 +4134,7 @@ packages:
   license_family: BSD
   size: 193141
   timestamp: 1671143985219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
   md5: 8bf0bfffc11ad06a1c94e145941b0ad4
   depends:
@@ -4144,7 +4144,7 @@ packages:
   license_family: PSF
   size: 9651
   timestamp: 1690297655669
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
   md5: 343514a174b3485fde55a73f56398dd7
   depends:
@@ -4153,7 +4153,7 @@ packages:
   license_family: PSF
   size: 58456
   timestamp: 1690297648002
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
   sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
   md5: c2242e8fd24003a74ddf37416661e06d
   depends:
@@ -4168,7 +4168,7 @@ packages:
   license_family: MIT
   size: 188757
   timestamp: 1698257668273
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
   sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
   md5: 41f445e36b6b6722a9444508eef069f8
   depends:
@@ -4177,7 +4177,7 @@ packages:
   license_family: BSD
   size: 20583
   timestamp: 1607365395045
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
   sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
   md5: 409ee46ed24267b6da6fb32d13e1f21e
   depends:
@@ -4187,7 +4187,7 @@ packages:
   license_family: BSD
   size: 70730
   timestamp: 1614804271285
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
   sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
   md5: eb74e74d8e4fd533c55eb98b7b5e83bc
   depends:
@@ -4196,7 +4196,7 @@ packages:
   license_family: MIT
   size: 102637
   timestamp: 1695742077778
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
   sha256: 9f5a34bef727052f97b1cc387c3a99a60754de99d6e4ab0b2de770d76b64dc0f
   md5: b5ce0421037c626cfcec5b43d83ec420
   depends:
@@ -4208,20 +4208,20 @@ packages:
   license_family: Apache
   size: 1787999
   timestamp: 1689041573350
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
   sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
   md5: e243baa546432c8394a8059a44a5a3e4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 419227
   timestamp: 1683113010463
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
   sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
   md5: fe4ac85ee86d3a94ea3a4ebea3779763
   depends:
@@ -4230,7 +4230,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 321797
   timestamp: 1616055526986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
   sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
   md5: bc7073d9d4c0211cc4a1207c98fb765a
   depends:
@@ -4239,14 +4239,14 @@ packages:
   license_family: MIT
   size: 19091
   timestamp: 1672387204865
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
   sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
   md5: 8e495591e369ac161857a72011c0a296
   license: Zlib
   license_family: Other
   size: 120272
   timestamp: 1666595024203
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
   sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
   md5: f1465fbd810b3746c6de6babfd4fe28a
   depends:
@@ -4258,7 +4258,7 @@ packages:
   license_family: BSD
   size: 1023573
   timestamp: 1681304595869
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
   sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
   md5: cf55cb8d7031b30c70c56fc7c782b5c7
   depends:
@@ -4271,7 +4271,7 @@ packages:
   license_family: MIT
   size: 156104
   timestamp: 1644482799136
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
   sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
   md5: 84fce327d9f0d594e86f565e5c21962e
   depends:
@@ -4280,7 +4280,7 @@ packages:
   license_family: BSD
   size: 10183
   timestamp: 1629146082730
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
   sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
   md5: 84b8b998a741b37abf5312c1c03696ef
   depends:
@@ -4290,7 +4290,7 @@ packages:
   license_family: MIT
   size: 33979
   timestamp: 1644845817952
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
   sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
   md5: 77b746931c8f31c3ae393ccb5819d43d
   depends:
@@ -4299,7 +4299,7 @@ packages:
   license_family: MIT
   size: 133628
   timestamp: 1695717890677
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
   sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
   md5: 3df6e8ba34208dea068890e5d5318cc0
   depends:
@@ -4309,12 +4309,12 @@ packages:
   license_family: MIT
   size: 206759
   timestamp: 1681493095987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
   sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
   md5: bb55f81435cb6e11d264242274fccd1a
   depends:
@@ -4324,7 +4324,7 @@ packages:
   license_family: BSD
   size: 115947
   timestamp: 1657175645380
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
   md5: f860193e14afc7ef3f5b990a2ac003d2
   depends:
@@ -4334,7 +4334,7 @@ packages:
   license: MIT
   size: 18936
   timestamp: 1659616204016
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
   sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
   md5: ad53130f3fd1f8d3c2fcbb7496e5585d
   depends:
@@ -4343,7 +4343,7 @@ packages:
   license: MIT
   size: 18715
   timestamp: 1659616188888
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
   sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
   md5: 0982c046fb976e9f9fb19e7510187a18
   depends:
@@ -4352,14 +4352,14 @@ packages:
   license: MIT
   size: 366983
   timestamp: 1659616245272
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
   sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
   md5: 31ac2f5596cb7a44adf073c930641c54
   license: MPL-2.0
   license_family: Other
   size: 133817
   timestamp: 1694009762858
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
   sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
   md5: cf1f6c3c34a1e1b9ab22b04233d860f6
   depends:
@@ -4368,7 +4368,7 @@ packages:
   license_family: Other
   size: 159783
   timestamp: 1690232303987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
   sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
   md5: 0eb268e38b5174d471a6e87d9d6102b1
   depends:
@@ -4379,7 +4379,7 @@ packages:
   license_family: MIT
   size: 225355
   timestamp: 1670423312966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
   sha256: 41e76ba21b1279278a039245275eb4ee1f81b38b33cba00ca3575f06be5dc570
   md5: c5170bf12e308fb7f2d1b4b9065f3df7
   depends:
@@ -4388,7 +4388,7 @@ packages:
   license_family: BSD
   size: 153036
   timestamp: 1698129857856
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
   sha256: 36240dde0a1546469f35f3b5509b55384dfd894beb56b3ca929da4b96a2a5f24
   md5: 844539636e4c20ee99e8ceeff5e902bc
   depends:
@@ -4397,7 +4397,7 @@ packages:
   license_family: BSD
   size: 41376
   timestamp: 1683040042906
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
   sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
   md5: e68c94666cd60221b575c3814c89bac0
   depends:
@@ -4407,7 +4407,7 @@ packages:
   license_family: CC
   size: 1946451
   timestamp: 1668084573824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
   sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
   md5: 1773ae2b080cdd55827e27673351551e
   depends:
@@ -4417,7 +4417,7 @@ packages:
   license_family: BSD
   size: 13646
   timestamp: 1671231171682
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
   sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
   md5: b62455043c8eb2434466885b19fed2de
   depends:
@@ -4430,7 +4430,7 @@ packages:
   license_family: BSD
   size: 1399573
   timestamp: 1694211828228
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
   sha256: fb7d12350372a70daa9f476647d04fc213ef9d8f73cbddaf30b40b1b45beef0f
   md5: 34595eb00802934d092b3086d7b4344d
   depends:
@@ -4447,7 +4447,7 @@ packages:
   license_family: BSD
   size: 2124926
   timestamp: 1686783028732
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
   sha256: d366da723fc8baf4d9de0d25688619efe4d1c7abe5407dfb28654c4c9e2ef019
   md5: d4c923ceedacd8d5d18f994feed8dbb8
   depends:
@@ -4469,7 +4469,7 @@ packages:
   license_family: BSD
   size: 17708209
   timestamp: 1692372524993
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
   sha256: 83dbf9755ea887576e3f34adb1c26d418db9aaf3c77dc07f30b58c2221b81c72
   md5: 36246697d07d6709de78abe36b6beae5
   depends:
@@ -4481,7 +4481,7 @@ packages:
   license_family: BSD
   size: 103201
   timestamp: 1629793063728
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
   sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
   md5: eb3cdc0fc210838b9271512a6a1b7c85
   depends:
@@ -4491,7 +4491,7 @@ packages:
   license_family: MIT
   size: 2067708
   timestamp: 1690905319109
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
   sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
   md5: f44b80b9405410e5bde6bfe0b31d5b3f
   depends:
@@ -4500,7 +4500,7 @@ packages:
   license_family: MIT
   size: 15135
   timestamp: 1650293774207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
   sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
   md5: f87027ccce1361d0f82c0edf1a10d53b
   depends:
@@ -4509,7 +4509,7 @@ packages:
   license_family: BSD
   size: 27677
   timestamp: 1668714367519
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -4519,7 +4519,7 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
   sha256: 296371685a5dcd98f5128f11f413e63aa59c1eba60543faf3baaebd445964c5d
   md5: 9817e8ffd3669484c9a7de99a8aceffb
   depends:
@@ -4528,14 +4528,14 @@ packages:
   license_family: BSD
   size: 257844
   timestamp: 1695734566410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
   sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
   md5: 1d0bd7e576c64c059ef781dd319ad82a
   license: MIT
   license_family: MIT
   size: 77591
   timestamp: 1676983230102
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gmp-6.2.1-hc377ac9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/gmp-6.2.1-hc377ac9_3.tar.bz2
   sha256: d4e13c27a19390f5e0737e47cc55bcd8d0399679affea7701a0129d902665030
   md5: d875d1f8cda3e280dafdb38350477b15
   depends:
@@ -4543,7 +4543,7 @@ packages:
   license: GPL-2.0-or-later AND LGPL-3.0-or-later
   size: 643155
   timestamp: 1653996450241
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gmpy2-2.1.2-py39h8c48613_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/gmpy2-2.1.2-py39h8c48613_0.tar.bz2
   sha256: f99e81c82245e80be9bf260fec5f71345edc64ac64d425168e43466ae1d55e37
   md5: 5ff8378b91647681350f9cabfced006e
   depends:
@@ -4555,7 +4555,7 @@ packages:
   license_family: LGPL
   size: 166804
   timestamp: 1645462713827
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
   sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
   md5: 69eb3b03765627b6159ed23cdde78396
   depends:
@@ -4564,7 +4564,7 @@ packages:
   license_family: MIT
   size: 28399065
   timestamp: 1692293207812
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
   sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
   md5: 83366cbd3beb073112f4644a613b6bca
   depends:
@@ -4573,7 +4573,7 @@ packages:
   license_family: BSD
   size: 111933
   timestamp: 1666125627512
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
   sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
   md5: 647c1a2f8460ffa8c670a1915bbdb494
   depends:
@@ -4583,7 +4583,7 @@ packages:
   license_family: APACHE
   size: 38790
   timestamp: 1678997152549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
   sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
   md5: 187d7720aedf38759d122cccb4576f2c
   depends:
@@ -4605,7 +4605,7 @@ packages:
   license_family: BSD
   size: 219976
   timestamp: 1691121991680
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
   sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
   md5: e8e7f10741f9cfa737b310b334940441
   depends:
@@ -4627,7 +4627,7 @@ packages:
   license_family: BSD
   size: 1255894
   timestamp: 1694181494549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
   sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
   md5: ff209e75aee17af2e358b0008fbe8c88
   depends:
@@ -4637,7 +4637,7 @@ packages:
   license_family: MIT
   size: 1022945
   timestamp: 1644315931223
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
   sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
   md5: d3e78ef296b3c74910d003bd10b475d6
   depends:
@@ -4647,14 +4647,14 @@ packages:
   license_family: BSD
   size: 213972
   timestamp: 1666908195870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
   sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
   md5: 055e12390b844ea6c6e956ee08a618e8
   license: IJG
   license_family: Other
   size: 273479
   timestamp: 1677849171867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
   sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
   md5: 783e2ad3d36472648c5ccc9f3051db3c
   depends:
@@ -4665,7 +4665,7 @@ packages:
   license_family: MIT
   size: 133077
   timestamp: 1676558732505
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
   sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
   md5: 0677598f673f9729b5990316170a999d
   depends:
@@ -4681,7 +4681,7 @@ packages:
   license_family: BSD
   size: 197129
   timestamp: 1676329661580
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
   sha256: 05f9ca0fdcfdc2e217438be27fead588c843a3aadf7d034467c83216d1e5c214
   md5: 2d648b77d817ba38293c0728711ba8f5
   depends:
@@ -4692,7 +4692,7 @@ packages:
   license_family: BSD
   size: 92852
   timestamp: 1679906632236
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
   sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
   md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
   depends:
@@ -4716,7 +4716,7 @@ packages:
   license_family: BSD
   size: 401319
   timestamp: 1671707682572
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
   sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
   md5: 247558a0aecf1ef7e77a4343761353d6
   depends:
@@ -4726,7 +4726,7 @@ packages:
   license_family: BSD
   size: 64600
   timestamp: 1672387273585
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -4736,7 +4736,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -4745,13 +4745,13 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
   md5: a0f206782751dfffed0dd51302a1bf26
   license: MIT
   size: 68012
   timestamp: 1659616138077
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
   md5: 4c6667cdd061d28e9bc4e4300e4d115e
   depends:
@@ -4759,7 +4759,7 @@ packages:
   license: MIT
   size: 31173
   timestamp: 1659616155596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
   md5: 637e9430e258ddf050623ef2360184d8
   depends:
@@ -4767,28 +4767,28 @@ packages:
   license: MIT
   size: 298430
   timestamp: 1659616172209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
   sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
   md5: 55c615026c0869f8d3ba657f3bd38c43
   license: MIT
   license_family: MIT
   size: 120389
   timestamp: 1683716579036
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -4797,7 +4797,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -4808,14 +4808,14 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
   sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
   md5: a41117710dafe569c9cc4e83f6f29fe3
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1411339
   timestamp: 1650982753977
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
   sha256: d654027daea13ac9db36ab5fd5eff3ad398ec97c1777bf399f3ec680d2c145b9
   md5: baabb1f905054bfea3af8f5768572a34
   depends:
@@ -4827,7 +4827,7 @@ packages:
   license_family: Apache
   size: 26579907
   timestamp: 1683291669565
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -4838,7 +4838,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -4847,13 +4847,13 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -4870,7 +4870,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
   sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
   md5: 98d22e0124d55fae3c37c608dab1dcc9
   depends:
@@ -4884,7 +4884,7 @@ packages:
   license_family: BSD
   size: 89825
   timestamp: 1694778225280
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
   sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
   md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
   constrains:
@@ -4893,7 +4893,7 @@ packages:
   license_family: BSD
   size: 331675
   timestamp: 1694776939192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
   sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
   md5: 0ba499df6755eae5d2d23aa4ab004553
   depends:
@@ -4905,7 +4905,7 @@ packages:
   license_family: MIT
   size: 642657
   timestamp: 1692970217410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
   sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
   md5: c73101971e5ab6a8e8688239884eac81
   depends:
@@ -4915,7 +4915,7 @@ packages:
   license_family: MIT
   size: 241607
   timestamp: 1692973585084
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -4924,7 +4924,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
   sha256: 124d9d4f865f0f66c4e5e7f99dc1110330c9415cc51effc0a5aad4261880c2f0
   md5: c08c14e55ba470513eb6c87206fb7b30
   depends:
@@ -4936,7 +4936,7 @@ packages:
   license_family: BSD
   size: 322413
   timestamp: 1697031210019
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
   sha256: 83e1c11fb14ec2767e833b540a6a0fdbd8641523b5673273914007008e6666da
   md5: 64adbf70a0d4ab82aca039e972821537
   depends:
@@ -4945,7 +4945,7 @@ packages:
   license_family: BSD
   size: 11877
   timestamp: 1652903192510
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
   sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
   md5: 353dff9d5d996c2a260f66381b2ce3e8
   depends:
@@ -4956,7 +4956,7 @@ packages:
   license_family: Other
   size: 1470815
   timestamp: 1695058433965
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
   sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
   md5: c99006da802a97c9aae30da8c16b4820
   depends:
@@ -4965,7 +4965,7 @@ packages:
   license_family: BSD
   size: 176131
   timestamp: 1670944706815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
   sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
   md5: 34dfd76da78de2eae95bbda390d746d6
   depends:
@@ -4976,7 +4976,7 @@ packages:
   license_family: BSD
   size: 23092
   timestamp: 1654598007056
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.5.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-3.5.3-py39hca03da5_0.tar.bz2
   sha256: 457f9bffd4cdd69022f23a2674bcf4e0ad5a10489d5ad3040eee92abf0b36247
   md5: d529ca5317c79ac2c4263accaf9ffe94
   depends:
@@ -4987,7 +4987,7 @@ packages:
   license_family: PSF
   size: 7557
   timestamp: 1667356944439
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.5.3-py39hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.5.3-py39hc377ac9_0.tar.bz2
   sha256: f618e537364de52e01c5ea00da9e929cbd69f6fb2b44b33438ec6ca86e6d20d3
   md5: 44e021749203eb346116b909afbc177d
   depends:
@@ -5007,7 +5007,7 @@ packages:
   license_family: PSF
   size: 7700383
   timestamp: 1667356814530
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
   sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
   md5: eb79dabbeedee7da85dfbfb145bb8a26
   depends:
@@ -5017,7 +5017,7 @@ packages:
   license_family: BSD
   size: 17342
   timestamp: 1662014601345
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
   sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
   md5: 56db7bd3ff511cd839bda081523b3edd
   depends:
@@ -5026,7 +5026,7 @@ packages:
   license_family: BSD
   size: 55683
   timestamp: 1629356128780
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mpc-1.1.0-h8c48613_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mpc-1.1.0-h8c48613_1.tar.bz2
   sha256: 61fcc5f4d95d412156111870e23d691ce8a0264ace3404f6e139786b1a8041c5
   md5: 493853604367a8158e507a82e0f39115
   depends:
@@ -5035,7 +5035,7 @@ packages:
   license: LGPL-3-or-later
   size: 129349
   timestamp: 1628353319507
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mpfr-4.0.2-h695f6f0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mpfr-4.0.2-h695f6f0_1.tar.bz2
   sha256: b933d173664ccdd85acdc80beaeb3e4d098622fc9379161308b1aa66a38a0e64
   md5: 0930875aa2bcd9ddd2cdb6b5b37f3770
   depends:
@@ -5043,7 +5043,7 @@ packages:
   license: LGPL-3.0-only
   size: 585142
   timestamp: 1628351993556
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mpmath-1.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mpmath-1.3.0-py39hca03da5_0.tar.bz2
   sha256: 83195356bfcb13fa023df6a811587e218c1508520f9ca164a317f986a432f545
   md5: 2c559997f16b72a30172693cccaaed12
   depends:
@@ -5052,7 +5052,7 @@ packages:
   license_family: BSD
   size: 990288
   timestamp: 1690848313585
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
   sha256: ee936ba5fd196c15c3cb538aef721e54bb4486110ae3ebbfcf78e95e8380efa4
   md5: dde1d9e040e04cbfbc0138898240a660
   depends:
@@ -5062,7 +5062,7 @@ packages:
   license_family: BSD
   size: 23003
   timestamp: 1629282780853
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
   sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
   md5: 176e0dcaeb28393881bacf69941e3889
   depends:
@@ -5088,7 +5088,7 @@ packages:
   license_family: BSD
   size: 8289638
   timestamp: 1681756329011
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
   sha256: afc6f332c51a3defc69e4c4e641988c0556039b9cd42be22f3db5292c88ccf37
   md5: 2bc409c7258160a9b739d08d5ffb5998
   depends:
@@ -5101,7 +5101,7 @@ packages:
   license_family: BSD
   size: 96942
   timestamp: 1650373637069
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
   sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
   md5: 150ea9fadddf21993d3328d3e48a18b7
   depends:
@@ -5129,7 +5129,7 @@ packages:
   license_family: BSD
   size: 557688
   timestamp: 1668450759059
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
   sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
   md5: 37163b32508f9f589b3e6462a3a47546
   depends:
@@ -5142,14 +5142,14 @@ packages:
   license_family: BSD
   size: 148426
   timestamp: 1694616771736
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
   sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
   md5: 6cdf7cbc43bf40e92b056a5576bd0086
   depends:
@@ -5158,7 +5158,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387216468
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
   sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
   md5: 0f05853a139b6cda9c73e9d2707a4976
   depends:
@@ -5183,7 +5183,7 @@ packages:
   license_family: BSD
   size: 590288
   timestamp: 1690984971741
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
   sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
   md5: 7de782e4fb34bfa95ef2fc79d27d727d
   depends:
@@ -5193,7 +5193,7 @@ packages:
   license_family: BSD
   size: 22840
   timestamp: 1668160634885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
   sha256: 0a5a7295f055d2f175528cc895dcb07533df5f0b87f05ac7839ec1af15988218
   md5: 3d8e6925b26ca29486d0b58b30f1f663
   depends:
@@ -5213,7 +5213,7 @@ packages:
   license_family: BSD
   size: 4428704
   timestamp: 1697061454581
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
   sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
   md5: 1a7b23113372c5667dbfe45976b9cc5c
   depends:
@@ -5224,7 +5224,7 @@ packages:
   license_family: MIT
   size: 126357
   timestamp: 1696515322390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
   sha256: 5332b3635fbc1a800b0fe58db7a0e57bb5ef75cbc56a0512c76f01ac7fc7139f
   md5: ab7fbf394a301d25d1bf8cfa76fd917b
   depends:
@@ -5237,7 +5237,7 @@ packages:
   license_family: BSD
   size: 12847
   timestamp: 1691092401334
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
   sha256: 114b5aa7ef0990a615e27116e05dba0e7e78df750e3592aa4b732438f391a394
   md5: 3284c63e9251227322ef9fd9c997f2c7
   depends:
@@ -5251,7 +5251,7 @@ packages:
   license_family: BSD
   size: 6338710
   timestamp: 1691092386069
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
   sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
   md5: 371358a54bbdd307603888348d1a2c6f
   depends:
@@ -5261,7 +5261,7 @@ packages:
   license: BSD 2-Clause
   size: 412248
   timestamp: 1628861367714
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
   sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
   md5: fa15d3b44ae1360ac9b640bbd5b6923c
   depends:
@@ -5270,7 +5270,7 @@ packages:
   license_family: Apache
   size: 4746123
   timestamp: 1695322833432
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
   sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
   md5: d73db95f07a282021efdf8bc09713261
   depends:
@@ -5279,7 +5279,7 @@ packages:
   license_family: Apache
   size: 73620
   timestamp: 1693575195999
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-1.5.3-py39h78102c4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-1.5.3-py39h78102c4_0.tar.bz2
   sha256: e094ee730427e220e2b6e7fd54a1b34d4d16bfa9818b4472d2608fb7db9ce1c1
   md5: c72f88467f474447f0fbee8013a750fc
   depends:
@@ -5325,7 +5325,7 @@ packages:
   license_family: BSD
   size: 12828607
   timestamp: 1677852272349
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
   sha256: 0d64f2438be25524bbfeb8646e4fb3c18499d747398a03ed15d41b350b03e001
   md5: 6a4908a5c9f7b3f17f09ebc34b1b691c
   depends:
@@ -5334,7 +5334,7 @@ packages:
   license_family: BSD
   size: 142857
   timestamp: 1684915417403
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
   sha256: 3a6450282f56265e800500b62cd1bbe39cd5a6a09c4747c6dc3e8aab10bfa8a0
   md5: 9b01b16f9c5a033ee8b92683d66b184e
   depends:
@@ -5348,7 +5348,7 @@ packages:
   license_family: BSD
   size: 36731
   timestamp: 1698702611592
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
   sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
   md5: 6e01c592ae3b8ff2d12cae76f2f4276b
   depends:
@@ -5367,7 +5367,7 @@ packages:
   license_family: Other
   size: 715239
   timestamp: 1696580071596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
   sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
   md5: 9fb8f460c130d56caf33c6bbe46fbe8a
   depends:
@@ -5378,7 +5378,7 @@ packages:
   license_family: MIT
   size: 2678841
   timestamp: 1697548790931
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
   sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
   md5: 390b8c3cd74281abecdbfd51476922f9
   depends:
@@ -5387,7 +5387,7 @@ packages:
   license_family: MIT
   size: 33033
   timestamp: 1692205747301
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
   sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
   md5: 7896828fb3565fefad43f980d50c8723
   depends:
@@ -5396,7 +5396,7 @@ packages:
   license_family: Apache
   size: 91190
   timestamp: 1659455206354
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
   sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
   md5: d934c74eb66d01af0f45f0881f4bab77
   depends:
@@ -5408,7 +5408,7 @@ packages:
   license_family: BSD
   size: 580588
   timestamp: 1672387390426
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
   sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
   md5: 9858166e5ffb624c8b9d281f4000d725
   depends:
@@ -5417,7 +5417,7 @@ packages:
   license_family: BSD
   size: 367167
   timestamp: 1656431368885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
   sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
   md5: 4d2b45c6be8221e6a3e44c2d5838426f
   depends:
@@ -5429,7 +5429,7 @@ packages:
   license_family: BSD
   size: 30843
   timestamp: 1675441531640
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
   sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
   md5: 02521df4e2e79f75faa9cbb3560ab1dd
   depends:
@@ -5438,7 +5438,7 @@ packages:
   license_family: BSD
   size: 1861763
   timestamp: 1684280026169
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
   sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
   md5: bdebe59bffc7adbad83fdcd9d429a5f5
   depends:
@@ -5448,7 +5448,7 @@ packages:
   license_family: Apache
   size: 95234
   timestamp: 1690223494699
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
   sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
   md5: d716e5c9b5eec45ce1df8eb52cab817a
   depends:
@@ -5457,7 +5457,7 @@ packages:
   license_family: MIT
   size: 157408
   timestamp: 1661452601692
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
   sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
   md5: 1907629863ed8e7c35ead232dae7693f
   depends:
@@ -5466,7 +5466,7 @@ packages:
   license_family: MIT
   size: 91636
   timestamp: 1628941083263
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
   sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
   md5: 847b9bddf2a86e1609c0d53bbc23ea79
   depends:
@@ -5475,7 +5475,7 @@ packages:
   license_family: BSD
   size: 27378
   timestamp: 1626781391140
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
   sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
   md5: 18aa18bd0d260605923877921d26cc74
   depends:
@@ -5494,7 +5494,7 @@ packages:
   license_family: PSF
   size: 13194025
   timestamp: 1694438901368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
   sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
   md5: 45642a99c83e7aed74d1ffab1f20145b
   depends:
@@ -5503,7 +5503,7 @@ packages:
   license_family: BSD
   size: 266647
   timestamp: 1661368655993
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
   sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
   md5: fec748525144049a2fc7f52f9755232c
   depends:
@@ -5512,7 +5512,7 @@ packages:
   license_family: MIT
   size: 257235
   timestamp: 1695131702047
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
   sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
   md5: 3445d25415998c807efbe64d3a7e03c8
   depends:
@@ -5522,7 +5522,7 @@ packages:
   license_family: MIT
   size: 167068
   timestamp: 1698096118071
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
   sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
   md5: e6e92da28e9b0e428ed4b7df417bec25
   depends:
@@ -5533,7 +5533,7 @@ packages:
   license_family: BSD
   size: 472418
   timestamp: 1657724315435
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -5542,7 +5542,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
   sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
   md5: dba22515f36d3c266de5896350813ea2
   depends:
@@ -5558,7 +5558,7 @@ packages:
   license_family: Apache
   size: 95103
   timestamp: 1690400315537
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
   sha256: c35449c0ca64d0d6a23c019b6eba188f546e42379857cbc4240bbdddee1159d3
   md5: 61cb82346e21710f3e0645096cda4e12
   depends:
@@ -5574,7 +5574,7 @@ packages:
   license_family: BSD
   size: 22859180
   timestamp: 1696543469561
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
   sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
   md5: 3cd7eb43e285faba76faf67667e26b00
   depends:
@@ -5583,7 +5583,7 @@ packages:
   license_family: MIT
   size: 1093916
   timestamp: 1690290951258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
   sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
   md5: c5e9aef0d6895de1c927e9d796cd7cd3
   depends:
@@ -5592,7 +5592,7 @@ packages:
   license_family: Apache
   size: 15691
   timestamp: 1629145910454
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
   sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
   md5: 0f7c229e774146ffc4e29dedf75372bf
   depends:
@@ -5601,7 +5601,7 @@ packages:
   license_family: MIT
   size: 67279
   timestamp: 1696347632563
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
   sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
   md5: 2302a79a045f152e183a52a81adfba62
   depends:
@@ -5613,7 +5613,7 @@ packages:
   license_family: Other
   size: 1674163
   timestamp: 1681394762218
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sympy-1.11.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sympy-1.11.1-py39hca03da5_0.tar.bz2
   sha256: dbe2022bb90ff178c4c336c3edf7e04a0d5bbedc9b9f2ffde94201b3f96a5e13
   md5: 3af171911eca8754aa316ceccb8c1a0d
   depends:
@@ -5626,7 +5626,7 @@ packages:
   license_family: BSD
   size: 12362938
   timestamp: 1668203400757
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
   sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
   md5: ae58720a18a2ed15eae214ad7a10d1b5
   depends:
@@ -5635,7 +5635,7 @@ packages:
   license_family: Apache
   size: 140125
   timestamp: 1680167256603
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
   sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
   md5: 4ae67163d55cf9df83d4027ebc38c501
   depends:
@@ -5646,7 +5646,7 @@ packages:
   license_family: BSD
   size: 30894
   timestamp: 1671751931536
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
   sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
   md5: dbb5c0cddb6661a89afee647fd3dc01e
   depends:
@@ -5656,7 +5656,7 @@ packages:
   license_family: BSD
   size: 39875
   timestamp: 1668168874870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
   sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
   md5: 667e60c8b407d73cbba40f44901f4f00
   depends:
@@ -5665,7 +5665,7 @@ packages:
   license_family: BSD
   size: 3412693
   timestamp: 1654088929697
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
   sha256: 065cf1b08faf1d28aa348d569f2266d8b33b22ba424312c7ec959be95f217646
   md5: 20370dbc92a9262e6fc8c82208f74ff2
   depends:
@@ -5674,7 +5674,7 @@ packages:
   license_family: BSD
   size: 102259
   timestamp: 1667464137769
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
   sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
   md5: 884f788a5f6a664c9b79f7a4a60362d0
   depends:
@@ -5683,7 +5683,7 @@ packages:
   license_family: Apache
   size: 680561
   timestamp: 1696937004165
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
   sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
   md5: e5b90eba83fddba6d7aa6072b5bf7c91
   depends:
@@ -5692,7 +5692,7 @@ packages:
   license_family: BSD
   size: 193017
   timestamp: 1671143921826
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
   md5: 644ef8830437070f60efcfcd6a987198
   depends:
@@ -5702,7 +5702,7 @@ packages:
   license_family: PSF
   size: 9670
   timestamp: 1690297532002
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
   md5: a902a833bb186a2f1a4b2b89b1195136
   depends:
@@ -5711,7 +5711,7 @@ packages:
   license_family: PSF
   size: 58466
   timestamp: 1690297524418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
   sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
   md5: f3f1d2c1028dad2f11ff950a15c99dbf
   depends:
@@ -5726,7 +5726,7 @@ packages:
   license_family: MIT
   size: 188640
   timestamp: 1698257577209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
   sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
   md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
   depends:
@@ -5735,7 +5735,7 @@ packages:
   license_family: BSD
   size: 20091
   timestamp: 1629144441130
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
   sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
   md5: 3089c63bf8f4d0423e1a287da286d83e
   depends:
@@ -5745,7 +5745,7 @@ packages:
   license_family: BSD
   size: 70923
   timestamp: 1629357115820
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
   sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
   md5: 5886b30b312445471268444f41f39dc7
   depends:
@@ -5754,7 +5754,7 @@ packages:
   license_family: MIT
   size: 102583
   timestamp: 1695741976083
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
   sha256: 300b9e4cfc9d01fa4d537060b2867f3cb89f22f932992fc2427e00dda050d55b
   md5: 768c174577b786b99f8b46c4789b36a2
   depends:
@@ -5766,20 +5766,20 @@ packages:
   license_family: Apache
   size: 1800646
   timestamp: 1689041569828
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
   sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
   md5: 2e75ad6a09c308268192efe03cc9ebf4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 411778
   timestamp: 1683113019715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
   sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
   md5: 30f666bf97c26587c5d2f68cc5f330ab
   depends:
@@ -5788,7 +5788,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 316901
   timestamp: 1629287855861
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
   sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
   md5: 584e591d36dcd5ba5c45404f0f7ebb2d
   depends:
@@ -5797,14 +5797,14 @@ packages:
   license_family: MIT
   size: 19076
   timestamp: 1672387153578
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
   sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
   md5: 467ae28215d1aa1c5688bc0c8a184269
   license: Zlib
   license_family: Other
   size: 103525
   timestamp: 1666595022664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
   sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
   md5: 7cfbed15f1feee1422810f7830075f53
   depends:
@@ -5816,7 +5816,7 @@ packages:
   license_family: BSD
   size: 779464
   timestamp: 1681304594848
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
   sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
   md5: ed14f9bc6e55220483f1a5a388625a08
   depends:
@@ -5829,7 +5829,7 @@ packages:
   license_family: MIT
   size: 162772
   timestamp: 1644481986085
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
   sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
   md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
   depends:
@@ -5841,7 +5841,7 @@ packages:
   license_family: MIT
   size: 39253
   timestamp: 1644551767970
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
   sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
   md5: b24d13c443a26f65a0778b475a5726bc
   depends:
@@ -5850,7 +5850,7 @@ packages:
   license_family: MIT
   size: 132830
   timestamp: 1695717959996
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
   sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
   md5: 302c3c0696e17eaa62e140e3892644ae
   depends:
@@ -5860,12 +5860,12 @@ packages:
   license_family: MIT
   size: 199723
   timestamp: 1681493196911
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
   sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
   md5: bf930260f679bc74227bbb18bc36ae82
   depends:
@@ -5877,7 +5877,7 @@ packages:
   license_family: BSD
   size: 119700
   timestamp: 1657176150595
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
   md5: 507dfe693ef429f466d964b599f4af21
   depends:
@@ -5889,7 +5889,7 @@ packages:
   license: MIT
   size: 18650
   timestamp: 1659616328001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
   md5: d0bf43e8df60baae3b3105aa5c42a791
   depends:
@@ -5900,7 +5900,7 @@ packages:
   license: MIT
   size: 21153
   timestamp: 1659616312367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
   sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
   md5: 7bd24bf94c24e810aecaaf84a0978e6f
   depends:
@@ -5910,14 +5910,14 @@ packages:
   license: MIT
   size: 343204
   timestamp: 1659616543542
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
   sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
   md5: 092b417c11edcbe6bb9b765ab4a55d23
   license: MPL-2.0
   license_family: Other
   size: 164999
   timestamp: 1694009822357
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
   sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
   md5: 708a750d370b9d6875651021e21c4446
   depends:
@@ -5926,7 +5926,7 @@ packages:
   license_family: Other
   size: 159322
   timestamp: 1690232335307
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
   sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
   md5: c35736da3ea26782425e78061268cf5e
   depends:
@@ -5938,7 +5938,7 @@ packages:
   license_family: MIT
   size: 228713
   timestamp: 1670423312743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
   sha256: 9577ff772035cd30e72323edff379dd3df877de00f7f690fd33c8720a5a4bbc9
   md5: 1130fd979d4f97f511f10b36ff09513d
   depends:
@@ -5948,7 +5948,7 @@ packages:
   license_family: BSD
   size: 152728
   timestamp: 1698129962390
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
   sha256: e5babe79f8132c4bd44bc05307976f2c5485014ae3129655dddbd3baa8e75e46
   md5: 093223df00c6ef9db4e7e5aa7bfec00a
   depends:
@@ -5957,7 +5957,7 @@ packages:
   license_family: BSD
   size: 40844
   timestamp: 1683040252786
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
   sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
   md5: 457a4339a53c033d48ce0c72e5038d2e
   depends:
@@ -5966,7 +5966,7 @@ packages:
   license_family: BSD
   size: 30330
   timestamp: 1672387265402
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
   sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
   md5: 59ec65fd9e06b81a65cc12986c67d5da
   depends:
@@ -5976,7 +5976,7 @@ packages:
   license_family: CC
   size: 1939614
   timestamp: 1668084794027
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
   sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
   md5: 3489c1a2b73fc957b5a62cc59349e25b
   depends:
@@ -5986,7 +5986,7 @@ packages:
   license_family: BSD
   size: 13438
   timestamp: 1671231196438
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
   sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
   md5: f46d904bc6f220327e70474971341f52
   depends:
@@ -6001,7 +6001,7 @@ packages:
   license_family: BSD
   size: 1220835
   timestamp: 1694445639066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
   sha256: 78d66bcb1c979647e9c5473825d4a5e35afa2a0dfeef71cb0d9d9a72fea3c102
   md5: f2875875bb22ab4704a77bc368a9dc00
   depends:
@@ -6018,7 +6018,7 @@ packages:
   license_family: BSD
   size: 2180195
   timestamp: 1686783294287
-- conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
   sha256: 882a0fb257fb07bb47e8127b9ce1f556e319ce4941b74adc94f9849093e11d0d
   md5: b6ef3c0b6e49ff3d497785c744ce44cc
   depends:
@@ -6040,7 +6040,7 @@ packages:
   license_family: BSD
   size: 17688679
   timestamp: 1692373093225
-- conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
   sha256: a6c8b5d32c52ce71d41c7702265e0bb064c960ab67b88ecbea967595c5e02bc3
   md5: 112f2f9c7055656ec156fe287c97c0e9
   depends:
@@ -6052,7 +6052,7 @@ packages:
   license_family: BSD
   size: 104432
   timestamp: 1613390539244
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
   sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
   md5: 2ff4fb509788b0e47ac684ba151394d0
   depends:
@@ -6063,7 +6063,7 @@ packages:
   license_family: MIT
   size: 3289966
   timestamp: 1690907040646
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
   sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
   md5: 0f166c3e70541d8bee6e9d0cb60fb66e
   depends:
@@ -6072,7 +6072,7 @@ packages:
   license_family: MIT
   size: 16979
   timestamp: 1649926678161
-- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
   sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
   md5: ea93d413944ca6a8677eb1b284b136ae
   depends:
@@ -6081,7 +6081,7 @@ packages:
   license_family: BSD
   size: 27388
   timestamp: 1668714577678
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -6093,7 +6093,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
   sha256: 6b724886465fea70d2ca843fea1d01bcc24d496601587b87c0cb8f2626b259c2
   md5: 6c11d9242869d6c3b01698f728bd409b
   depends:
@@ -6102,7 +6102,7 @@ packages:
   license_family: BSD
   size: 260567
   timestamp: 1695734829130
-- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
   sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
   md5: 9f167d3e45441bc3633c1974b1b0ce8c
   depends:
@@ -6112,13 +6112,13 @@ packages:
   license_family: MIT
   size: 88421
   timestamp: 1676983264486
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
   sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
   md5: 582d2c1135a89da757a038de831e7f39
   license: Intel proprietary
   size: 11086648
   timestamp: 1664812389803
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
   sha256: 945f4521793d7d279532d1ccd5157201c5cbf64f846bfe60249d01e1b4edf295
   md5: 0accae23d095c165ac731f4a1f3ca497
   depends:
@@ -6128,7 +6128,7 @@ packages:
   license_family: MIT
   size: 37021132
   timestamp: 1692294548916
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
   sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
   md5: 30fdefd1541c789c163751291a8faa88
   depends:
@@ -6137,7 +6137,7 @@ packages:
   license_family: BSD
   size: 111448
   timestamp: 1666125667599
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
   sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
   md5: a10f07c7a3510272a296f9fed458a4ed
   depends:
@@ -6147,7 +6147,7 @@ packages:
   license_family: APACHE
   size: 38098
   timestamp: 1678997241511
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
   sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
   md5: 9834848bd7c7759acf12e78d09388563
   depends:
@@ -6157,7 +6157,7 @@ packages:
   license_family: Proprietary
   size: 3891030
   timestamp: 1681801474383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
   sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
   md5: 1285c8c628bc912c54d0968574c9f4c9
   depends:
@@ -6178,7 +6178,7 @@ packages:
   license_family: BSD
   size: 217232
   timestamp: 1691122695748
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
   sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
   md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
   depends:
@@ -6199,7 +6199,7 @@ packages:
   license_family: BSD
   size: 1279433
   timestamp: 1694181820978
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
   sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
   md5: f5fcce35d3f21cdfc5893c5a7a86c651
   depends:
@@ -6209,7 +6209,7 @@ packages:
   license_family: MIT
   size: 1035394
   timestamp: 1644315567034
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
   sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
   md5: f67fe3337528e2886f1ac3ab8ac37985
   depends:
@@ -6219,7 +6219,7 @@ packages:
   license_family: BSD
   size: 213110
   timestamp: 1666908350218
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
   sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
   md5: 81f2c343dc4c65eea39c45383272068f
   depends:
@@ -6229,7 +6229,7 @@ packages:
   license_family: Other
   size: 407861
   timestamp: 1677849239400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
   sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
   md5: bd9526d38a145fe311a8aa36bc11e071
   depends:
@@ -6240,7 +6240,7 @@ packages:
   license_family: MIT
   size: 152006
   timestamp: 1676558783570
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
   sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
   md5: a00e6a62956fde3c4135464353ee8a53
   depends:
@@ -6256,7 +6256,7 @@ packages:
   license_family: BSD
   size: 229158
   timestamp: 1676330909084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
   sha256: db8335d6531b03c7bdfe789ebacc52631ac6ea4a37700bb3da1f6a53a1acd724
   md5: ebeba61994cc225ea5f4f42caa511019
   depends:
@@ -6268,7 +6268,7 @@ packages:
   license_family: BSD
   size: 116681
   timestamp: 1679906658986
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
   sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
   md5: 5efa1332f7c0a8d9638eda02170c4ce5
   depends:
@@ -6293,7 +6293,7 @@ packages:
   license_family: BSD
   size: 413653
   timestamp: 1671707957673
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
   sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
   md5: 891fe66a24d8714737b2874985ee1303
   depends:
@@ -6304,7 +6304,7 @@ packages:
   license_family: BSD
   size: 62298
   timestamp: 1672388166096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
   sha256: ef6b0347ae565dd648a2bb40bc8b0b30f2e4f8387778fefced1d581b7d5a3e16
   md5: 8ef1d5919aa55fe56ef34d9a7969dca7
   depends:
@@ -6315,7 +6315,7 @@ packages:
   license_family: MIT
   size: 861982
   timestamp: 1684424430941
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -6325,7 +6325,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
   sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
   md5: c345f51706eef530454f66b794e5e574
   depends:
@@ -6334,7 +6334,7 @@ packages:
   license: MIT
   size: 68189
   timestamp: 1659616216976
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
   md5: a7400cfb72042977bc047909ed504ce8
   depends:
@@ -6344,7 +6344,7 @@ packages:
   license: MIT
   size: 33743
   timestamp: 1659616248209
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
   md5: 6307f6854754ab5bd7c84e6998385bb1
   depends:
@@ -6354,7 +6354,7 @@ packages:
   license: MIT
   size: 733177
   timestamp: 1659616279453
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
   sha256: bb17beae8860a83d081d57273825b46bf8fe9903f3b4182ab41a7ae2c7274859
   md5: 94182f4ab8beb4eddfd8167b2e2b0380
   depends:
@@ -6366,7 +6366,7 @@ packages:
   license_family: Apache
   size: 147804
   timestamp: 1681225547009
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
   sha256: 01b84a38c9069e7b8e6fa2a07707e785df7d40b8f01d76a504e98e5a5cd58539
   md5: 22c9f7e59174c49f06e3c5c9384401ce
   depends:
@@ -6377,7 +6377,7 @@ packages:
   license_family: Apache
   size: 25699299
   timestamp: 1681225463612
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -6387,7 +6387,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
   sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
   md5: b812bc5d9c76242e2bb2ac87afe7d39b
   depends:
@@ -6397,7 +6397,7 @@ packages:
   license_family: GPL3
   size: 730280
   timestamp: 1650983734373
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -6408,7 +6408,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
   sha256: a36ea5c77075e90f47d3f5c1e2081c0c1c78c5c0a5135bf9a6448fca67bbc79d
   md5: a0a02817a7def0563d1635035c26451b
   depends:
@@ -6419,7 +6419,7 @@ packages:
   - zlib >=1.2.13,<2.0.0a0
   size: 3827890
   timestamp: 1687382140999
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -6428,7 +6428,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -6445,7 +6445,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
   sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
   md5: ba9418df9288a2f031a02fa35b774ce0
   depends:
@@ -6461,7 +6461,7 @@ packages:
   license_family: BSD
   size: 78524
   timestamp: 1694778314659
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
   sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
   md5: b1781519a200ccbfcb4a1194005aa3ef
   depends:
@@ -6473,7 +6473,7 @@ packages:
   license_family: BSD
   size: 338459
   timestamp: 1694777084290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
   sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
   md5: 6ece7f1a3248169837714d05d7f6ef0a
   depends:
@@ -6485,7 +6485,7 @@ packages:
   license_family: MIT
   size: 3513910
   timestamp: 1692971505729
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
   sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
   md5: bd7ec244935e83e850a4ff34e8e2e64f
   depends:
@@ -6496,7 +6496,7 @@ packages:
   license_family: MIT
   size: 513971
   timestamp: 1692973657152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
   sha256: 2f610fc98b674e4eceeceaadbb94b4153759ee9249759dd27ca48bfdeeef82cf
   md5: c24005244a08cbfb665f89d8858e0187
   depends:
@@ -6508,7 +6508,7 @@ packages:
   license_family: BSD
   size: 20824879
   timestamp: 1697031479623
-- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
   sha256: 5d4cf89313147e44530dbb3cc6a93247aaded0701bbf8ba3a382ef710abf4cfa
   md5: 137deeca51202f6b4ac786472a00be55
   depends:
@@ -6517,7 +6517,7 @@ packages:
   license_family: BSD
   size: 12894
   timestamp: 1652904101694
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
   sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
   md5: fb7881e74b59262df0fa4ec981964efc
   depends:
@@ -6530,7 +6530,7 @@ packages:
   license_family: Other
   size: 1244887
   timestamp: 1695058550693
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
   sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
   md5: 6970c7f46b0164cad1d210e7a1419959
   depends:
@@ -6540,7 +6540,7 @@ packages:
   license_family: BSD
   size: 143434
   timestamp: 1670944902624
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
   sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
   md5: 466da740fafef3d6bce114220f0be306
   depends:
@@ -6553,7 +6553,7 @@ packages:
   license_family: BSD
   size: 28510
   timestamp: 1654508162239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.5.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-3.5.3-py39haa95532_0.tar.bz2
   sha256: 105e3de6be2aa03ae066f4b24abbf0b7658cdc4197ebcfdb65063e6ad8002783
   md5: a734c9b1f9d2ed092f9e1b26e889e527
   depends:
@@ -6565,7 +6565,7 @@ packages:
   license_family: PSF
   size: 7297
   timestamp: 1667357382033
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.5.3-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.5.3-py39hd77b12b_0.tar.bz2
   sha256: 8b27ecc6b6efbf276e4ce82aef23a81c334957b937e7395ab33a0ce68e6336ba
   md5: 1f1b068723f4cf163fe5fe3d8e3535f9
   depends:
@@ -6586,7 +6586,7 @@ packages:
   license_family: PSF
   size: 7680416
   timestamp: 1667357230289
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
   sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
   md5: a9fa43e694b25cd49b8b08a9eefd696e
   depends:
@@ -6596,7 +6596,7 @@ packages:
   license_family: BSD
   size: 18054
   timestamp: 1661915903969
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
   sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
   md5: 248c468abced874f0231d3cc23177c77
   depends:
@@ -6607,7 +6607,7 @@ packages:
   license_family: BSD
   size: 58488
   timestamp: 1607359497934
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
   sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
   md5: 5e763c995ff0c549f68a10bce70fede4
   depends:
@@ -6619,7 +6619,7 @@ packages:
   license_family: Proprietary
   size: 187489950
   timestamp: 1691503804820
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
   sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
   md5: dd0c2ece6a743c373c9b5a5919b4818f
   depends:
@@ -6631,7 +6631,7 @@ packages:
   license_family: BSD
   size: 49744
   timestamp: 1682975040154
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
   sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
   md5: 57cea8df7ab85f2a98f64d23afcb1f90
   depends:
@@ -6646,7 +6646,7 @@ packages:
   license_family: BSD
   size: 184956
   timestamp: 1695058491736
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
   sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
   md5: 8769cdd201d905069800488fe31574e5
   depends:
@@ -6661,7 +6661,7 @@ packages:
   license_family: BSD
   size: 256221
   timestamp: 1695060152521
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mpmath-1.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mpmath-1.3.0-py39haa95532_0.tar.bz2
   sha256: 463964fde7a829a3e2c5a61918086ee6b4352122923f221c53180a27801ff2c7
   md5: 661e228c104a96594f7f85d9e6a13916
   depends:
@@ -6670,7 +6670,7 @@ packages:
   license_family: BSD
   size: 989044
   timestamp: 1690848602295
-- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
   sha256: b75f28f29d60f2a8726fb0f036e5d01489942abbf77ff1e1cc8e12d7f372b8f3
   md5: 7a1d29477873480809fd3860f2e69f01
   depends:
@@ -6680,7 +6680,7 @@ packages:
   license_family: BSD
   size: 24734
   timestamp: 1607574381373
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
   sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
   md5: d9781492332e6326f9fca87f3a8efacd
   depends:
@@ -6706,7 +6706,7 @@ packages:
   license_family: BSD
   size: 8135792
   timestamp: 1681756491399
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
   sha256: 2dd3178d3c570e30b9490ebabfd7bfac806afad8302d3dee0edc619805034397
   md5: bef9da0f0694c45b6aaa4e6447479eaf
   depends:
@@ -6719,7 +6719,7 @@ packages:
   license_family: BSD
   size: 118324
   timestamp: 1650290466135
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
   sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
   md5: f1d8ce412e115986c403f223b3b47d0f
   depends:
@@ -6747,7 +6747,7 @@ packages:
   license_family: BSD
   size: 596314
   timestamp: 1668451106600
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
   sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
   md5: f96bbef0985d7e66ebf00c0d55e30e23
   depends:
@@ -6760,7 +6760,7 @@ packages:
   license_family: BSD
   size: 167045
   timestamp: 1694617078743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
   sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
   md5: 6e6ba64c8dc5025aeac606404a8df36a
   depends:
@@ -6769,7 +6769,7 @@ packages:
   license_family: BSD
   size: 13786
   timestamp: 1672387480065
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
   sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
   md5: 4a7a3286484766741f627696697c362c
   depends:
@@ -6794,7 +6794,7 @@ packages:
   license_family: BSD
   size: 609425
   timestamp: 1690985686105
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
   sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
   md5: 4269a1f93882205b90d4b2ae78fc82d5
   depends:
@@ -6804,7 +6804,7 @@ packages:
   license_family: BSD
   size: 22417
   timestamp: 1668160717305
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
   sha256: 39b52f5a3e0f71a07358f2bd07a67b950170eabc3398ae968ef523cc0854141a
   md5: 4baee3e5d96aed7d5d3e28051d6214e5
   depends:
@@ -6824,7 +6824,7 @@ packages:
   license_family: BSD
   size: 4472762
   timestamp: 1697063760024
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
   sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
   md5: a18a576b7024cfd6f905c526a786a916
   depends:
@@ -6839,7 +6839,7 @@ packages:
   license_family: MIT
   size: 135285
   timestamp: 1696515698492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
   sha256: 410f3a13eaddcfcfc65cb077dd0b85b7c66853a2447161b9022eed7d9fe472f9
   md5: c4aae7ab3842a3decd05c5c1d8b916d3
   depends:
@@ -6856,7 +6856,7 @@ packages:
   license_family: BSD
   size: 12296
   timestamp: 1691098390179
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
   sha256: 5a81ff60cc876951905995ea52d3815e38a0d757c6c674acbef1144d8dc746fb
   md5: 72413d41fe97de5da9b1ce325e544e05
   depends:
@@ -6872,7 +6872,7 @@ packages:
   license_family: BSD
   size: 6857794
   timestamp: 1691098356763
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
   sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
   md5: ab07e2a27ac08afe3d0b4c0890b8486a
   depends:
@@ -6883,7 +6883,7 @@ packages:
   license: BSD 2-Clause
   size: 249316
   timestamp: 1630094024143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
   sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
   md5: 73b17037d87b5a58feb34dafc0538f7f
   depends:
@@ -6894,7 +6894,7 @@ packages:
   license_family: Apache
   size: 8058396
   timestamp: 1695324589828
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
   sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
   md5: df1d746ba8d5d6ba01ac1373b9b71e1a
   depends:
@@ -6903,7 +6903,7 @@ packages:
   license_family: Apache
   size: 73016
   timestamp: 1693575484990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-1.5.3-py39hf11a4ad_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-1.5.3-py39hf11a4ad_0.tar.bz2
   sha256: f6e50ae841f87d086a2e132e1d526003b538711ce50b69329ab0c7fd692a6fa2
   md5: b1c36236dfcdaa9db886e6bbb2046b9e
   depends:
@@ -6950,7 +6950,7 @@ packages:
   license_family: BSD
   size: 12136904
   timestamp: 1677836569898
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
   sha256: 2773f47b2d745ab483cf7fcbd5b5e2f7020d45462d32d2ccd5cf232ca13c6f67
   md5: ca16cd208037bd58d2da267c338da4a4
   depends:
@@ -6959,7 +6959,7 @@ packages:
   license_family: BSD
   size: 142229
   timestamp: 1684915524241
-- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
   sha256: 5738f61dae392c171b4f699a6973e736198e4d4a63fa22dcf957afaf1de150af
   md5: cba721e73156d62fc4ff23159e96ad41
   depends:
@@ -6973,7 +6973,7 @@ packages:
   license_family: BSD
   size: 36452
   timestamp: 1698702686971
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
   sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
   md5: 427c1450bebb632f43bbc8c83006e4cd
   depends:
@@ -6992,7 +6992,7 @@ packages:
   license_family: Other
   size: 806931
   timestamp: 1696580240310
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
   sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
   md5: 21790cd3e2b8a45c4104aff0a68330d0
   depends:
@@ -7003,7 +7003,7 @@ packages:
   license_family: MIT
   size: 3001751
   timestamp: 1697549357662
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
   sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
   md5: 56f44a1054da2d10777e375838191070
   depends:
@@ -7012,7 +7012,7 @@ packages:
   license_family: MIT
   size: 32355
   timestamp: 1692205784293
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
   sha256: bbcef9bbf4ccd051becaa7d8aa88cb5f46ff64570cc395b6a471332d8b900e11
   md5: 0daf62b71923d157544576122b0fa79d
   depends:
@@ -7021,7 +7021,7 @@ packages:
   license_family: BSD
   size: 82560
   timestamp: 1607021261834
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
   sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
   md5: 8a35ad65651086575ce55371f22feda8
   depends:
@@ -7030,7 +7030,7 @@ packages:
   license_family: Apache
   size: 91045
   timestamp: 1659455316472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
   sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
   md5: 186eb95f816a2eff80c3c7f7d964c7b0
   depends:
@@ -7042,7 +7042,7 @@ packages:
   license_family: BSD
   size: 578514
   timestamp: 1672388155359
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
   sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
   md5: 47b6cbe6ce9289e47d16900b03596a91
   depends:
@@ -7053,7 +7053,7 @@ packages:
   license_family: BSD
   size: 372807
   timestamp: 1656431445633
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
   sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
   md5: 07165c444adc7c7ccc8a345875adc5ef
   depends:
@@ -7065,7 +7065,7 @@ packages:
   license_family: BSD
   size: 48408
   timestamp: 1675450623287
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
   sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
   md5: d58e76a31e2f6e7410ba4afd7f385b0d
   depends:
@@ -7074,7 +7074,7 @@ packages:
   license_family: BSD
   size: 1877445
   timestamp: 1684280183367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
   sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
   md5: 0e5b0fe7debbf558ce97090f6b67cdae
   depends:
@@ -7084,7 +7084,7 @@ packages:
   license_family: Apache
   size: 94633
   timestamp: 1690225630423
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
   sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
   md5: 0fde797653e4ab589506121fb1e37555
   depends:
@@ -7093,7 +7093,7 @@ packages:
   license_family: MIT
   size: 157119
   timestamp: 1661452591647
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
   sha256: e70028d0250602c01feac17e60fafd371daee5d731917732b7eced4ab47b3243
   md5: 72a51c0d49711d22a39aefc04fa0c328
   depends:
@@ -7108,7 +7108,7 @@ packages:
   license_family: GPL
   size: 5007361
   timestamp: 1698781683371
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
   sha256: 6eb0c4f2e8acaa6dfaf1fb5b4b34f13d366ebf11d77e14a674a26d7fabbc7981
   md5: 9354d98a97abd4715cdf63d4a28f7645
   depends:
@@ -7119,7 +7119,7 @@ packages:
   license_family: GPL
   size: 84071
   timestamp: 1698769559444
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
   sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
   md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
   depends:
@@ -7130,7 +7130,7 @@ packages:
   license_family: MIT
   size: 92679
   timestamp: 1636093365041
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
   sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
   md5: f870859d4dc7a8d82cf3546bd9035f33
   depends:
@@ -7140,7 +7140,7 @@ packages:
   license_family: BSD
   size: 54520
   timestamp: 1605307564142
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
   sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
   md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
   depends:
@@ -7153,7 +7153,7 @@ packages:
   license_family: PSF
   size: 21172845
   timestamp: 1694442462066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
   sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
   md5: 9d99075052265ae3d718582d3b875038
   depends:
@@ -7162,7 +7162,7 @@ packages:
   license_family: BSD
   size: 269964
   timestamp: 1661376543480
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
   sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
   md5: fa9074d94236c9b768bfd2c858875b27
   depends:
@@ -7171,7 +7171,7 @@ packages:
   license_family: MIT
   size: 264836
   timestamp: 1695131770282
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
   sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
   md5: 3d2841085778006c2e79f9c7300f8b9d
   depends:
@@ -7181,7 +7181,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13565975
   timestamp: 1669937633869
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
   sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
   md5: 54a4bc0724041dd173088419d6ede2af
   depends:
@@ -7193,7 +7193,7 @@ packages:
   license_family: MIT
   size: 239062
   timestamp: 1677611495106
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
   sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
   md5: f39f84115e228bad4bceaefdd637f022
   depends:
@@ -7205,7 +7205,7 @@ packages:
   license_family: MIT
   size: 158558
   timestamp: 1698096358091
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
   sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
   md5: df398a3a1668fd2a22061764e20ea91d
   depends:
@@ -7217,7 +7217,7 @@ packages:
   license_family: BSD
   size: 460913
   timestamp: 1657616061604
-- conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
   sha256: 409f9fad42cbae8d915d1703d87db6af9f951b150517daa4e1c0220cc5eb7b0f
   md5: 2b17abf94b02a6c5ba6b7623dba97ff9
   depends:
@@ -7240,7 +7240,7 @@ packages:
   license_family: LGPL
   size: 69829482
   timestamp: 1693228189080
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
   sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
   md5: 38db77ece9dc76feffb9ef7638e38258
   depends:
@@ -7256,7 +7256,7 @@ packages:
   license_family: Apache
   size: 94397
   timestamp: 1690400496655
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
   sha256: 3a9a680173f731d515e0587d5b74583cc986b5c1ff62f4cf9e4f7ec268cbb62a
   md5: 3387bf809e3d32dde3f5cbc3ef49bf47
   depends:
@@ -7274,7 +7274,7 @@ packages:
   license_family: BSD
   size: 22779707
   timestamp: 1696550432358
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
   sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
   md5: 3e284ae6b48ee30c364ffdc5601610b0
   depends:
@@ -7283,7 +7283,7 @@ packages:
   license_family: MIT
   size: 1099842
   timestamp: 1690291374842
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
   sha256: ed2b75ca1bb075901550bf892aa18a46a563e512e28ad5fe1b36e7ed3c6708d0
   md5: 22779fae19f454e13656af8b737f8bd3
   depends:
@@ -7298,7 +7298,7 @@ packages:
   license_family: GPL
   size: 602624
   timestamp: 1698676202396
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
   sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
   md5: 993b3886b334bd1f49d34206f21997b4
   depends:
@@ -7307,7 +7307,7 @@ packages:
   license_family: Apache
   size: 15998
   timestamp: 1614030572433
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
   sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
   md5: 7ac9604ad7564ac0c71bff5db198656f
   depends:
@@ -7316,7 +7316,7 @@ packages:
   license_family: MIT
   size: 67012
   timestamp: 1696347795139
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
   sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
   md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
   depends:
@@ -7326,7 +7326,7 @@ packages:
   license_family: Other
   size: 1311308
   timestamp: 1681402905668
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sympy-1.11.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sympy-1.11.1-py39haa95532_0.tar.bz2
   sha256: 4a20950353298ff8cbdb3f43abeeda4a5cc1853c3707e74fd39a1e5bfcd9d0a1
   md5: 6abb1c631939885d181f058e98607737
   depends:
@@ -7338,7 +7338,7 @@ packages:
   license_family: BSD
   size: 12382333
   timestamp: 1668206099862
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -7348,7 +7348,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
   sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
   md5: 28b9869d8d3a839918fac4a08f38cbc2
   depends:
@@ -7359,7 +7359,7 @@ packages:
   license_family: BSD
   size: 30546
   timestamp: 1671752127904
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
   sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
   md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
   depends:
@@ -7369,7 +7369,7 @@ packages:
   license_family: BSD
   size: 39590
   timestamp: 1668168880994
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
   sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
   md5: 52cdcdb96383c010ca833a7c24b3935b
   depends:
@@ -7379,7 +7379,7 @@ packages:
   license_family: BSD
   size: 3690152
   timestamp: 1654036853710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
   sha256: 86a1b449d27205327a5de0f81d18d9ad768e68d915b91b1d5b82be2d8f524e94
   md5: 78a8a9f8c638df9a2db80964c97ff43f
   depends:
@@ -7388,7 +7388,7 @@ packages:
   license_family: MIT
   size: 25476
   timestamp: 1657175730463
-- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
   sha256: 1ee791ecc17e11a31d6cf1553845e7279d9d9a2c7383a2a3e1ae131ddd024b6f
   md5: b32030d310e0437dc631e5719369004c
   depends:
@@ -7397,7 +7397,7 @@ packages:
   license_family: BSD
   size: 102033
   timestamp: 1667464306003
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
   sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
   md5: 0e054ab29119cf4c1f778613acf972f9
   depends:
@@ -7408,7 +7408,7 @@ packages:
   license_family: Apache
   size: 681780
   timestamp: 1696937326924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
   sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
   md5: fe78de10019085146f1cc6c94fdc2620
   depends:
@@ -7417,7 +7417,7 @@ packages:
   license_family: BSD
   size: 192822
   timestamp: 1671143999327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
   md5: ca5fc3fbdb09b6de068a8b7a8869369f
   depends:
@@ -7427,7 +7427,7 @@ packages:
   license_family: PSF
   size: 9208
   timestamp: 1690298120549
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
   md5: a86e87a10e5fdff486265e0c675fb99f
   depends:
@@ -7436,7 +7436,7 @@ packages:
   license_family: PSF
   size: 57922
   timestamp: 1690298106990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
   sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
   md5: 0d31859e0a097aedbcc1627db33b3d92
   depends:
@@ -7451,7 +7451,7 @@ packages:
   license_family: MIT
   size: 188367
   timestamp: 1698257883295
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
   sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
   md5: 45ef24c486a484f079faf1dc90e4c7e9
   depends:
@@ -7460,12 +7460,12 @@ packages:
   license_family: BSD
   size: 8277
   timestamp: 1605602889180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
   sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
   md5: 4daaceb6cfc1af6274509081d8018ef1
   size: 2316783
   timestamp: 1605602872095
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
   sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
   md5: 916c16904615c7af3b5d37cb6694f45e
   depends:
@@ -7474,7 +7474,7 @@ packages:
   license_family: BSD
   size: 21084
   timestamp: 1607347371925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
   sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
   md5: da69e6987fcc757e83a358ceaa13f62b
   depends:
@@ -7484,7 +7484,7 @@ packages:
   license_family: BSD
   size: 73391
   timestamp: 1614804425587
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
   sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
   md5: 23b9f4634b2e5450be617114f62c74f9
   depends:
@@ -7493,7 +7493,7 @@ packages:
   license_family: MIT
   size: 120873
   timestamp: 1695742300539
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
   sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
   md5: 120f0b088290fc17bd6618fc10a2f0c4
   depends:
@@ -7501,13 +7501,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 34293
   timestamp: 1605306211299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
   sha256: 6bdb88cd45b22246e84b7400159ca90faf98ab4e8c1fa2d38d031cfc73c4dc13
   md5: d6e10641ece06f67561c5f6a676a4b7e
   depends:
@@ -7519,7 +7519,7 @@ packages:
   license_family: Apache
   size: 1794729
   timestamp: 1689041580510
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
   sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
   md5: c3f7871e9a33adeccee1b1e8e216918e
   depends:
@@ -7529,7 +7529,7 @@ packages:
   license_family: GPL2
   size: 1332571
   timestamp: 1683113347814
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -7538,7 +7538,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
   sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
   md5: 1ab55f8c4b5292ec360c572120bf823e
   depends:
@@ -7548,7 +7548,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 9430705
   timestamp: 1616055773485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
   sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
   md5: 6875e0bf3828707dc9165d694c0d0a7d
   depends:
@@ -7557,7 +7557,7 @@ packages:
   license_family: MIT
   size: 18725
   timestamp: 1672387612937
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
   sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
   md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
   depends:
@@ -7567,7 +7567,7 @@ packages:
   license_family: Other
   size: 148931
   timestamp: 1666595229032
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
   sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
   md5: 8d6a1e767775fe0eb617cd6e22edc2ff
   depends:

--- a/goldbach_comet/pixi.lock
+++ b/goldbach_comet/pixi.lock
@@ -1,0 +1,7582 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gmp-6.2.1-h295c915_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gmpy2-2.1.2-py39heeb90bb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.0-h8213a91_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.0-h28cd5cc_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.1.0-h3826bc1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mpc-1.1.0-h10f8cd9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mpfr-4.0.2-hb69a4c5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mpmath-1.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.21.5-py39he7a7128_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.21.5-py39hf524024_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.9.2-py39h2531618_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-5.9.7-h5867ecd_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.6.2-py39had2a1c9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-4.19.13-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sympy-1.11.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gmp-6.2.1-he9d5cce_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gmpy2-2.1.2-py39hd5de756_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.5.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.5.3-py39hfb0c5b7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mpc-1.1.0-h6ef4df4_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mpfr-4.0.2-h9066e36_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mpmath-1.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-1.5.3-py39h07fba90_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sympy-1.11.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gmp-6.2.1-hc377ac9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gmpy2-2.1.2-py39h8c48613_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.5.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.5.3-py39hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mpc-1.1.0-h8c48613_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mpfr-4.0.2-h695f6f0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mpmath-1.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-1.5.3-py39h78102c4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sympy-1.11.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.5.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.5.3-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mpmath-1.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-1.5.3-py39hf11a4ad_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sympy-1.11.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+  sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
+  md5: 613805add1c05b538ff06d217252feb7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 20810
+  timestamp: 1652859733309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+  sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
+  md5: 2cf39d906cc321896ffe3e5d33d80c5c
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162166
+  timestamp: 1644463608931
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+  sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
+  md5: 2972a84e0e22ae3244bbd2f1eebcf536
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 35352
+  timestamp: 1644569715988
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+  sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
+  md5: a68016b4b06460def24cb69d932986f3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132486
+  timestamp: 1695717963702
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+  sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
+  md5: 2f6356a2f530314b4059c08c79a3d8bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 205868
+  timestamp: 1681493113570
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+  sha256: f84f9caa7eb9d489fd9634419fdf766d39293a5df1104b840fa0cdc5823a5c60
+  md5: 922555c0435d6b2537cf8ced534b048c
+  depends:
+  - libgcc-ng >=7.5.0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 141903
+  timestamp: 1648028958291
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+  sha256: 0bbcb6f78eac530c6a084459ffab3238647b266d0c74d695e6e6387dd119cc67
+  md5: bdc971e2a9affb5125b68ad708172dab
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 411301
+  timestamp: 1602517685375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+  sha256: 8c2071f706c2b445dabb781f7f8f008b23a29957468ec6894f050bfb3a2d5bf4
+  md5: c203ffc7bbba991c7089d4b383cfd92c
+  depends:
+  - cffi >=1.0.0
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 357797
+  timestamp: 1605539534667
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+  sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
+  md5: 3ef00f4c5278b688552efc259c463dc8
+  license: MPL-2.0
+  license_family: Other
+  size: 132731
+  timestamp: 1694009767372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+  sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
+  md5: d5cb3d97cf5e85ffe5e94037ed8a1169
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159077
+  timestamp: 1690232254640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+  sha256: 674707b9c42e65c903c9786ee5a56b4d42aa054f1e75b328db8a2c1bfa368739
+  md5: 76ae217198b014b89b267cf41b8251dd
+  depends:
+  - libffi >=3.3
+  - libgcc-ng >=7.5.0
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 231920
+  timestamp: 1642701209740
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
+  sha256: 762f4506c3e12b2332bd9abea3a2a1966f307b2673be7fd661dc6e316602d18b
+  md5: 4b8df5459d1762495428323753438641
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 151844
+  timestamp: 1698129872673
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
+  sha256: 4fd0207b930fbc936d4b8206117cfa9792aa19bfb320eb08aab6bba10002f9ee
+  md5: 7082a1ce8fa314cc2761d2f689c6bb9e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40456
+  timestamp: 1683040035572
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+  sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
+  md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1917831
+  timestamp: 1668084545510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+  sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
+  md5: 13702d3b4b744784e5bd559c7050dd6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12719
+  timestamp: 1671231205875
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+  sha256: 821af57c20a85b4e92268fbf65fbaec2f273da5bb21889d9643756ef6e473237
+  md5: f57e0f502500ffebdbec081ef61ad1d4
+  depends:
+  - cffi >=1.12
+  - libgcc-ng
+  - openssl >=1.1.1v,<1.1.2a
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 2179774
+  timestamp: 1694445209134
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
+  sha256: 2084ad037e4b67a158facc0d1b21d1de16df7fe758e2bf08f6e48c6b75626cb8
+  md5: 8bb8a915dda236f7a2cf790490983445
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2121644
+  timestamp: 1686782977519
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
+  sha256: 161644f5f183f5632806cb2cb31890d06a1a575bed7949fe11bc59d3d4344e9d
+  md5: 96baa11147a42b64dcaa233a1733b8ee
+  depends:
+  - colorcet
+  - dask-core
+  - datashape
+  - numba
+  - numpy <2.0a0
+  - pandas
+  - param <2.0.0a0
+  - pillow
+  - pyct
+  - python >=3.9,<3.10.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17667549
+  timestamp: 1692372404139
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
+  sha256: 80188a9729a26e36b027e673f5f30395798eb68f9fe4721f3f33b4d4d2e58285
+  md5: 686db307602cbbdc30ca7d62b765578b
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 103488
+  timestamp: 1613390248313
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+  sha256: 469debfa966d24b8372aaf909ecbe27dc6fde186f6f0d5b9e0a8427e38053364
+  md5: 498d0788982ec4c5d13a44359b9c7afb
+  depends:
+  - expat >=2.2.10,<3.0a0
+  - glib
+  - libgcc-ng >=7.3.0
+  license: GPL2
+  size: 600218
+  timestamp: 1602701107852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+  sha256: 3a39a2d6f161080c706292e3bf480f62d2444b1d6d67b3d7db50458202ee31f1
+  md5: 0524ffca60f845eb392bbb56d56f0ce5
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2094615
+  timestamp: 1637091869922
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+  sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
+  md5: 2e6ec51066d825ef3c317abe78d6049e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16413
+  timestamp: 1649926472708
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+  sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
+  md5: b4d923222d45314856b5378cb115214d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26728
+  timestamp: 1668714462023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
+  sha256: 27cde2cf0b1e10c2315bc1384fcb56537b424f6c2c872ca4662bc971e41910da
+  md5: c12e8c75f3c7c4f5867827c5dc02dc2c
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: MIT
+  license_family: MIT
+  size: 216001
+  timestamp: 1644418571578
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
+  sha256: f80526def98864c9560dd3f6754d1c905edc001d18279f6e169913ee8f26a6a2
+  md5: e2fda4383ff9a690a6ac174553e10414
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - libgcc-ng >=7.3.0
+  - libuuid >=1.0.3,<2.0a0
+  - libxml2 >=2.9.10,<2.10.0a0
+  license: MIT
+  size: 306671
+  timestamp: 1612452969808
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+  sha256: 8a121233d0b2cbb2463b67e798739ad2946f38933430a6a7fd1197cc6eab1c99
+  md5: d2b24736491290a6c6d0138932111150
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: GPL-2.0-only and LicenseRef-FreeType
+  size: 965280
+  timestamp: 1635422707211
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
+  sha256: cfef2f1f3f1aa159f87806b7fa2b65c02c0d6f9bd24ccda833b43246c5095be6
+  md5: 394ec1374a92c6fd5f772343934337e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 260575
+  timestamp: 1695734561396
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+  sha256: 3c8ece1a7257b1d45f8fa25f46504bb709a1923d7175f2996e891366ec434b9d
+  md5: 299bf4271d710651a1d71d3795580c2d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 83592
+  timestamp: 1603192039050
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
+  sha256: bb98f022743e5df14d73db0edae49eb95a11abcc41c973fe2f30c3810bc5021e
+  md5: 858d4f13f1b0e54ee8cc3dd7c67cf0de
+  depends:
+  - libffi >=3.3
+  - libffi >=3.3,<3.4.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - pcre >=8.45,<9.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 2021087
+  timestamp: 1642701448286
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gmp-6.2.1-h295c915_3.tar.bz2
+  sha256: 670ae61b47df07aa53dd2a75b31d023213321ba9d5037b18be0c17a6e79f28f7
+  md5: 4f4570f23a92244101431ec46a235436
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: GPL-2.0-or-later AND LGPL-3.0-or-later
+  size: 822432
+  timestamp: 1653996358530
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gmpy2-2.1.2-py39heeb90bb_0.tar.bz2
+  sha256: e0b2501055bc7b93d1d63e634ef7305916950ce4b838d4ed0353e1d700bbaa70
+  md5: ae2924a47ff1c78b01088a248f76e673
+  depends:
+  - gmp >=6.1.2
+  - libgcc-ng >=7.5.0
+  - mpc
+  - mpfr >=4.0.2,<5.0a0
+  - python >=3.9,<3.10.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 217855
+  timestamp: 1645438799445
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.0-h8213a91_2.tar.bz2
+  sha256: c85c664066c685b606df768d23eac08e1b824e391eb59f61a9ef608f4f46c5b6
+  md5: df2e0695e2edbd91b719da5b15249c5a
+  depends:
+  - glib >=2.66.1,<3.0a0
+  - gstreamer >=1.14.0,<2.0a0
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - libxcb >=1.14,<2.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  size: 6651032
+  timestamp: 1609866747525
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.0-h28cd5cc_2.tar.bz2
+  sha256: dc1af8ae3b38b8d81c00b54dac851618dba87ea8d4083af84dcb60c3070039ad
+  md5: 83453eb716b94c66fb64391760c0eeb1
+  depends:
+  - glib >=2.66.1,<3.0a0
+  - libgcc-ng >=7.3.0
+  size: 4178090
+  timestamp: 1609866593800
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+  sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
+  md5: 9213e0336e3a5216c989cfe52648412e
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 23805906
+  timestamp: 1588026213084
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+  sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
+  md5: 1eb52f9f45cea2fb9ce27b19f990160e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110793
+  timestamp: 1666125606878
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+  sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
+  md5: 126b3c1933b7364ff03f67455b687e99
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 37588
+  timestamp: 1678997134023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+  sha256: 1b424413f28b840fc6d4bf467f37e9e405823b1e3b899005df80152d48936d64
+  md5: 4aa8bcf74c81cd3600978f791191692a
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 9246735
+  timestamp: 1634546760713
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+  sha256: b51b2e0dd37a74784ba19db22aded3f4c843b6fddb4a74399f65f36fc018aaa2
+  md5: 0d56ab1950f952284b895ac0f78284a7
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.0
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203541
+  timestamp: 1671488675347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+  sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
+  md5: ff47e0be879e817713ce2a9daa76e2b0
+  depends:
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1261116
+  timestamp: 1694181530670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+  sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
+  md5: 5ef6c6a0d1ac79143c7359d305155167
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1021637
+  timestamp: 1644297140650
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+  sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
+  md5: eaeb023688f781e7dd89e74310c38195
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 211775
+  timestamp: 1666908212136
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+  sha256: 85348bfb14db4fea84078d703e766a3c978c5a592a06e41266748826dd59d8ae
+  md5: 6e1c0fb5260c590f7ef5235cb3d05863
+  depends:
+  - libgcc-ng >=7.5.0
+  license: IJG
+  license_family: Other
+  size: 279884
+  timestamp: 1651065953960
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+  sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
+  md5: 0d2c3c5edf671b575532d5a3e8bf15fc
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 131510
+  timestamp: 1676558716852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+  sha256: 92bc012f9eb4ad71158cf4826fd3e125fcebff53b529276a81224acda48be547
+  md5: c5fd100e3062e831cbdf33331042f627
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=22.3
+  - tornado >=6.0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 190884
+  timestamp: 1650622553813
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+  sha256: 0192bd48cd96c60dc3054d5addd8cdb4a29a218843181318371f79daec8242f8
+  md5: d851b401dc13d04e6848bb36e12efc1c
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 91534
+  timestamp: 1679906652183
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+  sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
+  md5: a4beb461f0a60998a090d760b5c6c907
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411564
+  timestamp: 1671707702849
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+  sha256: 974df3dc76089be57b327acd6634384def84249003f58678ca1142bb274a75d9
+  md5: 81b969d1a00153759b30554a1f11ddfd
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92144
+  timestamp: 1653292217019
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+  sha256: 3b4afe7665dcdb99bd4586a888b85b2e0325f8faecdd31c7780792080ee97872
+  md5: 822b5201dde61bc838072dc5b670c88c
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: Custom
+  size: 55183
+  timestamp: 1594054267890
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+  sha256: c6fafbe73d2f93b91b6f4b65829f925f52a8f84746a57abd216b39da9ce8c494
+  md5: 238f19c803a6ba7bd6dbd6989e03cbf1
+  depends:
+  - _libgcc_mutex * main
+  license: GPL
+  size: 8496776
+  timestamp: 1560112207081
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
+  sha256: 83c6fdb30a240fbaa09f5d2e2ae8f092759cb710bc3fa628ccb18934fc237b7f
+  md5: 6003e09e8cef9aca91b954abfdd0f39c
+  license: GPL
+  size: 1336385
+  timestamp: 1534628456385
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+  sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
+  md5: 3080c2813e6e1d0f8a100a38b5b3456d
+  depends:
+  - _libgcc_mutex 0.1 main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 573231
+  timestamp: 1654090775721
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.1.0-h3826bc1_1.tar.bz2
+  sha256: effad2034f13cf7f1cdc51127e3a88123ae957c13f8c95f1817dfd79b5eba779
+  md5: c261302f1b58f6b2851f856d230dc947
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - zlib
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 29798461
+  timestamp: 1647523885063
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+  sha256: bc3e6e79c32ff0ecea601aa108ae9cf4068f69703580e40e266ad4bcc52cff54
+  md5: 9cb85601944ca7383b1769bff74b94e8
+  depends:
+  - libgcc-ng >=7.3.0
+  - zlib >=1.2.11,<2.0.0a0
+  license: zlib/libpng
+  size: 372914
+  timestamp: 1556041895170
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+  sha256: 43b0bd205f539583c088feb5b8d77b60c83d1df80c2a93dac9f2a1127001b2cf
+  md5: 53fa39fdae936e9d07c4b2f5ef361993
+  license: GPL3 with runtime exception
+  size: 4246257
+  timestamp: 1560112223556
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+  sha256: 711ea05b4c35bdafc762a172b01db896b17942f474c2b1a519f91370964bf9bc
+  md5: b25d56d33596623a6a4a9d9baaa4f602
+  depends:
+  - jpeg >=9e,<10a
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libwebp-base
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  size: 592974
+  timestamp: 1653047881023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
+  sha256: 4e1dce80f23551a69761ad48b2372e35f58292ec9cc0ce061312330366a1a223
+  md5: fda36b99463bad87974196da2d5bed08
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD 3-Clause
+  size: 18725
+  timestamp: 1633507857274
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+  sha256: 146dbb1e4dbccdd57819e5102a8ca00970b8e33d6c6180e8007db89b184da569
+  md5: c566a384259c1d2769852c3bddd81a67
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9d,<10a
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 90150
+  timestamp: 1645441199289
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+  sha256: cffb5a063111f7a99a99c74770b23db5dde52325e25a7a46d1903d5ff4a82c88
+  md5: eeb1bd66f28bed1956ab989d6eff7ae5
+  depends:
+  - libgcc-ng >=7.5.0
+  constrains:
+  - libwebp 1.2.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 889956
+  timestamp: 1645089138421
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+  sha256: 5d68e69709ae10bd6c4b58b6af447ad2f2bd24955994f3ec77103d1a6bf5e1f5
+  md5: 49e523de8d364b7fabc3850eccbe9bda
+  depends:
+  - libgcc-ng >=7.5.0
+  size: 623492
+  timestamp: 1652448233146
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+  sha256: 71f6c4a97014d745c58df52b4dd60ddd75a8508d54fe5b97f42bd1f31cb1c067
+  md5: 686e77514ec9f1ef0a6feed374f14d37
+  depends:
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.5.0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 789469
+  timestamp: 1653546418059
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+  sha256: ea3355a67c5173f3944f09861043ca66eb7dbeff8f385d13528b3aabc0801d0c
+  md5: 66e2aa12181bb2911485bdbe125d24c5
+  depends:
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.5.0
+  - libxml2 >=2.9.14,<2.10.0a0
+  license: MIT
+  size: 584199
+  timestamp: 1654075843119
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
+  sha256: 497e0a8e555539787dd237dea5d13a0a6061db2cb50ded20daddaf08bbf267cc
+  md5: ecc0c3c465bbf6988ebbc6a38e2eeb1c
+  depends:
+  - libgcc-ng >=7.5.0
+  - libllvm11 >=11.1.0,<11.2.0a0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  - zlib
+  license: BSD-2-Clause
+  size: 2826845
+  timestamp: 1647870510956
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
+  sha256: d8cd22ac7f033507549f6a0d078cd273607cb6e8246b0383375a33941969c12c
+  md5: 78c7a3a437536ae24d2d7ce15ec400d2
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11065
+  timestamp: 1652903210940
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+  sha256: 64b022d706b76c33965a250fdc8c6008443c41bff8ab27bb1df3cb70419576fd
+  md5: ec4f05846aacf634df15c389235725cc
+  depends:
+  - libgcc-ng >=7.5.0
+  - libxml2 >=2.9.12,<2.10.0a0
+  - libxslt >=1.1.28
+  - libxslt >=1.1.34,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  size: 1538261
+  timestamp: 1646624639995
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+  sha256: 2c6a5dda7c510a961bc78e31d4232be5e8e0760c93454f5fd200c379355e0f5e
+  md5: f35d4bf2fbb39e334992f6dd39f8721e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 220865
+  timestamp: 1627657046002
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+  sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
+  md5: feb0e452205b44ac45d9b5e55c21a3b1
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22819
+  timestamp: 1654597913064
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.5.1-py39h06a4308_1.tar.bz2
+  sha256: 62fb0d06224e15528540718debebeaebbfdbd7f03106fad52a7002fb96c6b8bd
+  md5: 364c1e3dddefa27741e540496c38b694
+  depends:
+  - matplotlib-base >=3.5.1,<3.5.2.0a0
+  - pyqt
+  - python >=3.9,<3.10.0a0
+  - tornado
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 28294
+  timestamp: 1647442129989
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+  sha256: dc51b316ef5dcfb82a9c0afdc40879146ae59516f6cea7db776077783dfd2d76
+  md5: b0b6b57c140f026b8806051107336576
+  depends:
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.11.0,<3.0a0
+  - freetype >=2.3
+  - kiwisolver >=1.0.1
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - numpy >=1.19.2,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.2.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  - tk
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7729454
+  timestamp: 1647442028622
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+  sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
+  md5: c04ef34af33da4c71bcc99b7ec24d210
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16391
+  timestamp: 1662014553452
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+  sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
+  md5: f6c734d73e6e3dbc1b62766cf18ff3e4
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58153
+  timestamp: 1607364912263
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+  sha256: 7c4ded8b2ef036839f988560848d2c32e1aa4627fd37a32710e42c39f5c61ac2
+  md5: bd20f4410b81f327e35ffa0657961146
+  depends:
+  - intel-openmp 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 229783051
+  timestamp: 1634547157986
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+  sha256: 5394f5efd53afb2c1b0abf571ce3d9cb684b6c7e255f140ba2acaa703d6113be
+  md5: d3cb2bfa63e30153f5527797dcc87280
+  depends:
+  - libgcc-ng >=7.5.0
+  - mkl >=2021.2.0,<2022.0a0
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 63551
+  timestamp: 1626176932911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+  sha256: c244d23da2749857a993f84969fd35ffd183ab8f462986df6d33ae0f705fe034
+  md5: 9b1f8ccc2488d0e04eb73211e2987483
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.3.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  size: 204136
+  timestamp: 1634566416657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+  sha256: f81f426f8ef306d636664bc49e7cdd70e2b4306d7c6bcb9c75fe35a45ab2087a
+  md5: 77aa1d7f958d36bf227e6ff4a34d2e3d
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.2.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  size: 365386
+  timestamp: 1626186165897
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mpc-1.1.0-h10f8cd9_1.tar.bz2
+  sha256: 2d95fe186309a0ee27df3a9af16aed4135d13e504844807b39d2c8e0b79a7ea0
+  md5: c3e5119d578d2418331013ba024ba0bc
+  depends:
+  - gmp >=6.1.2
+  - libgcc-ng >=7.2.0
+  - mpfr >=4.0.1,<5.0a0
+  license: LGPL 3
+  size: 96138
+  timestamp: 1527612531645
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mpfr-4.0.2-hb69a4c5_1.tar.bz2
+  sha256: 45797c64e087386ef4a31738858fd43ed3c035a4e01f391fac8aa4fc6e6a8b40
+  md5: 207e53f498d2efe14423a980e4d74816
+  depends:
+  - gmp >=6.1.2
+  - libgcc-ng >=7.3.0
+  license: LGPL-3.0-only
+  size: 668948
+  timestamp: 1593116348009
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mpmath-1.3.0-py39h06a4308_0.tar.bz2
+  sha256: a4f00021c787949ff03a7f880484aff486b97aab80c6f5b6e0e738796559cf1f
+  md5: ec29864ca787fa2e4ae66c4f91e9ed08
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 990665
+  timestamp: 1690848387419
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
+  sha256: 305313d215116fbf13a38f8a321eb635b83294871801ac63e543a59ba7de642c
+  md5: e0db8ae050bd0db74f47edc370dbc287
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 24480
+  timestamp: 1607574279743
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+  sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
+  md5: 95c83d71814c504b5504df4f14548f1a
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8257558
+  timestamp: 1681756322140
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+  sha256: 1b92d72b083f3350359b8fb2e3b5dc846f49650c9e46a6a74354b1b7f0d42730
+  md5: 996babe4314515ddd41008a53cb5d47f
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 98791
+  timestamp: 1650290544347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+  sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
+  md5: 1710a25086c8098367eb36b9d441448b
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 569683
+  timestamp: 1668450704669
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+  sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
+  md5: 385cc9e53404776782502c0fdb08820f
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147046
+  timestamp: 1694616899309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+  sha256: 0807371380965e421cb5f3f2a30d790fd5c41db11dbb6d318e14294c3b1741ed
+  md5: fca4bd4e3891aebf4fd7daf9b6d0ccfa
+  depends:
+  - libgcc-ng >=7.5.0
+  license: Free software (MIT-like)
+  size: 1083412
+  timestamp: 1636570020698
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+  sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
+  md5: bbbcbebc20a4fdcadce398d0ca04f95e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13109
+  timestamp: 1672387143252
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+  sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
+  md5: 248ce515640465371927d46f389ed555
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 594054
+  timestamp: 1690985006481
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+  sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
+  md5: 70db71df4ee1cdd38090c0f7b80ba61f
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21944
+  timestamp: 1668160644514
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
+  sha256: 30f95c6c51ee7ca01801778b1773d8ecb57fcf06e864093f27148e1298517c20
+  md5: 1c1f0821f0dd2ece64844f39edcbd03f
+  depends:
+  - _openmp_mutex >=4.5
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - llvmlite >=0.38.0,<0.39.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - tbb >=2021.5.0
+  - libgomp
+  constrains:
+  - cudatoolkit >=9.2
+  - scipy >=1.0
+  - libopenblas !=0.3.6
+  - tbb  >=2021.0
+  - numpy >=1.18,<1.22
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3982289
+  timestamp: 1648045822890
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+  sha256: 15a12c8bebcda45c577e61cea412d9aafaa433e39f9e91fd61bbfab66fcee3ab
+  md5: 5239d8330e8bd34972fb80918dce79e7
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16.6,<2.0a0
+  - packaging
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 136437
+  timestamp: 1640689905588
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.21.5-py39he7a7128_2.tar.bz2
+  sha256: 9195828a286d79621f63766a1ac1143de7b862ae17ce5e95ca0c3a5c171868a1
+  md5: 2bd04a53d17b21af64f413dc810b3d94
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.21.5 py39hf524024_2
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  size: 9728
+  timestamp: 1651566346644
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.21.5-py39hf524024_2.tar.bz2
+  sha256: dbd1301d64a55552a01d74a1928d279646a97158cad3cce7e05548b6fa112338
+  md5: e5666032c7865b4977e740e6f069e540
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.21.5 py39he7a7128_2
+  license: BSD-3-Clause
+  size: 6385715
+  timestamp: 1651566332949
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+  sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
+  md5: 5ad4571eba2479f77a9f849a6ae7724c
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: OpenSSL
+  license_family: Apache
+  size: 3998613
+  timestamp: 1694465071784
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+  sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
+  md5: 77a22ed6d0d448c5288d0f695bc9ac49
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 72527
+  timestamp: 1693575234886
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+  sha256: e7a0abb0f00a94000876f2095f0cf531ad3803ffbd868a780b3f06816b54492c
+  md5: 97ef7e1fe923d22a8e2307f3f39a92d5
+  depends:
+  - bottleneck >=1.3.1
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - numexpr >=2.7.1
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13221005
+  timestamp: 1650622404234
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+  sha256: 64a732ce2661cdb6bd8f9d1484ac10afeb73082b1c2b44728d212e0117d2860e
+  md5: ada303f0cf43a4e99cfa7f243b23b681
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141832
+  timestamp: 1684915385689
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
+  sha256: 9c699bd495cbf23db7dea986deeb75183571b83adc14b3e4a36cc6cfd2a198a8
+  md5: 39ed6f683307cca54ac666b2d1f849ff
+  depends:
+  - locket
+  - python >=3.9,<3.10.0a0
+  - toolz
+  constrains:
+  - pandas >=0.19.0
+  - numpy >= 1.9.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35706
+  timestamp: 1698702632637
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
+  sha256: 4881cc5e0d5b20335bcfba4eaf29fdc95dedf2607903aabecdacffb64d3407d4
+  md5: 4bac8a874e62f41ebab8345ca6076eb6
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 263308
+  timestamp: 1624477853289
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+  sha256: 8bcb1c67693f42a3170eb77ef4cdbb81b605fdf40816953e69a33a065c101638
+  md5: b7689507fb5f879dc766aaa8a4c37351
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp >=0.3.0
+  - libwebp >=1.2.0,<1.3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk
+  - zlib >=1.2.11,<2.0.0a0
+  license: LicenseRef-PIL
+  license_family: Other
+  size: 734566
+  timestamp: 1646325095608
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+  sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
+  md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2674850
+  timestamp: 1697548887851
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+  sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
+  md5: fe56f0479dd414c846191116366262c3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 31999
+  timestamp: 1692205535111
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+  sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
+  md5: 44d2a857d13bdf9d99aaac039a249d47
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91137
+  timestamp: 1659455142164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+  sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
+  md5: eb899a739d9b58dd747f1f6bd52d4cf3
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 579771
+  timestamp: 1672387338600
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+  sha256: 6973cfe0565ba3b5ad6d1de9e34848fbbadd78b507b2e23e1c079636b8f8f317
+  md5: a924535045fb356e23e7a3cc8116b638
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 350026
+  timestamp: 1612298042840
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+  sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
+  md5: f36ecb722522cbe2e3737424edf1b5e1
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29312
+  timestamp: 1675441510984
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+  sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
+  md5: 6d03295e544251e608a28c8d7c48115e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1862058
+  timestamp: 1684280096752
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+  sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
+  md5: 1f09617aecd6f3c2f2e20692c0759f34
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94434
+  timestamp: 1690223520097
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+  sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
+  md5: ffceed627867508d73af1636ab5ebf42
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 156324
+  timestamp: 1661452578573
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.9.2-py39h2531618_6.tar.bz2
+  sha256: c96502aca0df082c457f31d9e6202419aa86f24e1c699c3a34d02602f7a42812
+  md5: 3eda4bcc31b66fd5002817def97cd129
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  - qt 5.9.*
+  - qt >=5.9.7,<5.10.0a0
+  - sip 4.19.13.*
+  license: Commercial, GPL-2.0, GPL-3.0
+  license_family: GPL
+  size: 6010734
+  timestamp: 1607697278482
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+  sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
+  md5: 0e3341a4fe434167bf74b613eb6afd81
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 97194
+  timestamp: 1636110999719
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+  sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
+  md5: c5f3f7f10ad30f0945e75252615ab6e5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31331
+  timestamp: 1605305847037
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+  sha256: c4b9e332a6f2b7524e8c88e2b39a2568a48e556fd9a44c30759c43611d4d023d
+  md5: bb118745c9b08fc5028f45e77f371e68
+  depends:
+  - ld_impl_linux-64
+  - libffi >=3.3,<3.4.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - ncurses >=6.3,<7.0a0
+  - openssl >=1.1.1o,<1.1.2a
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.38.3,<4.0a0
+  - tk >=8.6.11,<8.7.0a0
+  - tzdata
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 24553777
+  timestamp: 1654084160832
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+  sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
+  md5: 0caa188a695319bdb13f53b0a2b3accc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264864
+  timestamp: 1661371117920
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+  sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
+  md5: bcb44ecbea441ee0d4659133d060d71f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257904
+  timestamp: 1695131670290
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+  sha256: 3da9cbbd49fac566433748bd245d09d7d5fcd28b04c0397cbbf6d5bb92f5c4a5
+  md5: df73a5d2f6e089d51e71e91935a82c65
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 183753
+  timestamp: 1635775763162
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+  sha256: 26005d191bb15070aad70707ed6493f32678a67978bd3b83d4c9679cab44e717
+  md5: 2dc75d5a4ccb64310939c3a72d34ae20
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-clause
+  license_family: BSD
+  size: 521583
+  timestamp: 1638435042256
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-5.9.7-h5867ecd_1.tar.bz2
+  sha256: 5881ffba2ab8ed28112e80dd3f17ced0832b75615b9f8aab6bf171575c812b88
+  md5: 50da300935a335f7605d3f96fa045111
+  depends:
+  - dbus >=1.13.2,<2.0a0
+  - expat >=2.2.6,<3.0a0
+  - fontconfig >=2.13.0,<3.0a0
+  - freetype >=2.9.1,<3.0a0
+  - glib >=2.56.2,<3.0a0
+  - gst-plugins-base >=1.14.0,<1.15.0a0
+  - gstreamer >=1.14.0,<1.15.0a0
+  - icu >=58.2,<59.0a0
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libpng >=1.6.35,<1.7.0a0
+  - libstdcxx-ng >=7.3.0
+  - libxcb >=1.13,<2.0a0
+  - libxml2 >=2.9.8,<2.10.0a0
+  - openssl 1.1.*
+  - sqlite >=3.25.3,<4.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: LGPL-3.0
+  size: 90037659
+  timestamp: 1544604609235
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+  sha256: 8c950c69bee969e2c66f88f0dc247b3ab75a753672a88009779d5f5dba193532
+  md5: 150ac0eb929bab9dec912797bdfc7b95
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 433182
+  timestamp: 1642022402894
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+  sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
+  md5: c7de00b4ac2778c4e5a7816320d75391
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94028
+  timestamp: 1690400356879
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.6.2-py39had2a1c9_1.tar.bz2
+  sha256: 2cf06019a66fbb0a9df571bac7f0460eb66f60d6b9c37f6a64a6dcddbe2c765f
+  md5: 5f18311a95358bb951f98a6d005a862d
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.3.0
+  - libgfortran-ng >=7,<8.0a0
+  - libstdcxx-ng >=7.3.0
+  - mkl >=2021.2.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  size: 21512828
+  timestamp: 1618856702227
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+  sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
+  md5: 1581cafc84708ed9aafaaee1cbbf6065
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1089416
+  timestamp: 1690290900608
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-4.19.13-py39h295c915_0.tar.bz2
+  sha256: 9f2d68b41365097a380979014b3cabf5f1f9f07e5554eb215eef4801f640922e
+  md5: 3ec6ce8f2eae0969b341e5702fb029c6
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: GPL-3.0
+  size: 302624
+  timestamp: 1643114723175
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+  sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
+  md5: e19ffbfb24b990275d24fcea2bd1699b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15702
+  timestamp: 1614030498860
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+  sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
+  md5: ca061ce25c0f58628643abec8d6a8244
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 66330
+  timestamp: 1696347637947
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+  sha256: 87965b7b46d93866d31696a1045216d64f077a06b2900c356aba87e8559c6188
+  md5: fa334030245135b37027a882f3c468bf
+  depends:
+  - libgcc-ng >=7.5.0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: blessing
+  license_family: Other
+  size: 1561908
+  timestamp: 1655328608308
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sympy-1.11.1-py39h06a4308_0.tar.bz2
+  sha256: d0a6c03dbe0b345752dee89659b33bbeb03457d7f370492daa8bc86f3d4841e1
+  md5: 610a90128fe91c0402b3907b14c43542
+  depends:
+  - gmpy2 >=2.0.8
+  - mpmath >=0.19
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - antlr-python-runtime >=4.7,<4.8
+  license: BSD-3-Clause AND MIT
+  license_family: BSD
+  size: 12358373
+  timestamp: 1668204388050
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
+  sha256: d4c0f3e57d8df6042151e65a706f8cd76c9325a47548f4ca3c3516e352dd8ca3
+  md5: 1decb9dd0e7bcee086d83b8b4ab8c8eb
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: Apache-2.0
+  size: 171277
+  timestamp: 1641830509786
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+  sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
+  md5: 0e76eab58fe488e91f0aee73f46de031
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29816
+  timestamp: 1671751864131
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+  sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
+  md5: b413a210eca82fe867e991eed085201b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38882
+  timestamp: 1668168876032
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+  sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
+  md5: 5b8375e2092012db69d2123dc0c68630
+  depends:
+  - libgcc-ng >=7.5.0
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3485432
+  timestamp: 1654088939579
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
+  sha256: 57983e3eb698a3b08b570d5f398d9550cf50b9bf54b2b4728c731ecbc0c89138
+  md5: 3ce956b1e1a7f77af6e6127dca987b95
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101246
+  timestamp: 1667464172523
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+  sha256: b746e39272888b9cc1a2a711b7b8836f2e26f4457850e43ad18bf0765e21dc3d
+  md5: 200e86f8d53aeebf4b7dcfc944fd7920
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 661662
+  timestamp: 1606942359431
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+  sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
+  md5: 0f0b91a158dd3692cbb7a7763b657bfe
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192032
+  timestamp: 1671143995098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
+  md5: 8515e64a3de7581360d713fe4c0a094e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8789
+  timestamp: 1690297588156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
+  md5: 60170012374b2a5007842fa5870d78c5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57479
+  timestamp: 1690297581658
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+  sha256: 870f20a3c006a74b291910f69c3469a409bd21437142864b29cfafeb89ca7c34
+  md5: 1b2f1589e3ebc3e0c6ecb38dba93e4ae
+  depends:
+  - brotlipy >=0.6.0
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 186761
+  timestamp: 1686163186447
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+  sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
+  md5: f8d03a15b974fc7810d9f54ae849fc8e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20781
+  timestamp: 1607365390528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+  sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
+  md5: d7db5d6ce1db80eade8a082ff78bf479
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 71044
+  timestamp: 1614804011510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+  sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
+  md5: b3899f8bda32734727bd5a73df1d7d17
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 101520
+  timestamp: 1695742037911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
+  sha256: d88bdc49a883a944cf1562ebb0a30d0451e28ab05521fc882615e357b105f414
+  md5: c150cf16071597fa3977fb81ebb83760
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1787638
+  timestamp: 1689041557651
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+  sha256: 2ce360ff98c0ca4537d70c19266b5700810196c54ce2fbaff3b94a969846ee37
+  md5: 94cb94dc47405b24b1b5bd0a3275ab59
+  depends:
+  - libgcc-ng >=7.5.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 398058
+  timestamp: 1651602137803
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+  sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
+  md5: 567b68192c387b5fc88178425577a0fe
+  depends:
+  - libgcc-ng >=7.3.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=7.3.0
+  license: LGPL-3.0-or-later
+  size: 366479
+  timestamp: 1616055552392
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+  sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
+  md5: 3818a9531fe74433c3b7d5144c9a58cc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18021
+  timestamp: 1672387231268
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+  sha256: 513444d83ac2405e898531492ea59f3a95641e357cc39c1048d6fffc1791a16b
+  md5: 601d9449c280b9b145dc8c83b6f06119
+  depends:
+  - libgcc-ng >=7.5.0
+  license: Zlib
+  license_family: Other
+  size: 133595
+  timestamp: 1650637720646
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+  sha256: 1c049c23788a00b6f38bdc801245e0e60af98718d4db4c958658bcc67ff158c7
+  md5: b1737dfd2e06ad69ec5cfec341e207c6
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 827172
+  timestamp: 1650622223170
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
+  md5: b2aa5503875aba2f1d88cae9df9a96d5
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13636
+  timestamp: 1611930018941
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
+  md5: 544adf2677c47c9b9c891aea720678f1
+  depends:
+  - python >=3.5
+  license: MIT
+  size: 33999
+  timestamp: 1630003259346
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+  sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
+  md5: 9eff1a842dbda8d1bae9a2c008b599bc
+  depends:
+  - brotli >=1.0.1
+  - munkres
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 690443
+  timestamp: 1625743217109
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+  sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
+  md5: 33624a42ee387bf9918ea98b4e7b31fc
+  depends:
+  - pygments >=2.4.1,<3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8173
+  timestamp: 1601490751973
+- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+  sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
+  md5: 67857cc5e9044770d2b15f9d94a4521d
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12810
+  timestamp: 1600445183315
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+  sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
+  md5: e68a6f315f41a8d814d833652bf38b9b
+  depends:
+  - python >=3
+  license: MIT
+  size: 13374
+  timestamp: 1606932077143
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
+  md5: 2eb923cc014094f4acf7f849d67d73f8
+  depends:
+  - python
+  - six >=1.5
+  license: BSD-3-Clause and Apache
+  license_family: BSD
+  size: 246457
+  timestamp: 1626374695070
+- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
+  md5: 41db68b96e114e367c4f120a3b379e59
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19391
+  timestamp: 1632406728844
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+  sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
+  md5: a815d3bdb160bcc71687f2dda70d3ca4
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 122218
+  timestamp: 1680170368293
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
+  md5: 447a49f7bad119faa80d7f14aa296c95
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162176
+  timestamp: 1644481750133
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+  sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
+  md5: 8810f48fe4a4792de0fd3520b502d08b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10019
+  timestamp: 1606859473259
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+  sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
+  md5: 00a446b6dfc61af223df4de29fe8ad94
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 34305
+  timestamp: 1644569782044
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
+  md5: bd92dd8bd5b9d24e632b62a075426e50
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133634
+  timestamp: 1695718025321
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+  sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
+  md5: f8ae051b591a9027adc16de1be9748f4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206198
+  timestamp: 1681493096349
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+  sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
+  md5: 0d79760d544d0bd8acb4adc4ef813418
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 137075
+  timestamp: 1657175654487
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
+  md5: 31d6d04cd2388d8f19004501271b3545
+  depends:
+  - brotli-bin 1.0.9 hca72f7f_7
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18982
+  timestamp: 1659616229395
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
+  md5: caf1073dc2ca5aeb832a2877394eae12
+  depends:
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18233
+  timestamp: 1659616216769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+  sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
+  md5: aa1ed20c38af535c8d6a955314759d7b
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 394588
+  timestamp: 1659616312678
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+  sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
+  md5: ce3588e31faa79f546e0fc6a36c5543c
+  license: MPL-2.0
+  license_family: Other
+  size: 133884
+  timestamp: 1694009771475
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+  sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
+  md5: 21eb7f53076d0a69513cfd258f6ef63c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159756
+  timestamp: 1690232346868
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+  sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
+  md5: a40a04d9cda1e665565bc6c832d598b6
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225258
+  timestamp: 1670423337502
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
+  sha256: b860f45bce9fbb40d024dcd3306e66a52010641091ca8d1fcdde6c4238717c73
+  md5: 3c38f3af9c23b26efc2b11d82c95922a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 153013
+  timestamp: 1698129937688
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
+  sha256: c368e11dc241d1b79b4bb0d9333b353dc1b966b49d145163a0590d88ad88fef2
+  md5: 1e62044b8a32d1452e51773ba7a4319c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41392
+  timestamp: 1683040146991
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+  sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
+  md5: b2cc5f37f7bb069d061306e7eac2a011
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1913396
+  timestamp: 1668084575248
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
+  md5: 103d8c039e342115720a84d59c119d46
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13774
+  timestamp: 1671231190250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+  sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
+  md5: cb80c7ac65b48a737654f371fe31c460
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1307228
+  timestamp: 1694212041712
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
+  sha256: e80ce32bc86af3e0b67d44bc2c774dde7490443bf6ae4bed7d9c666e3631965f
+  md5: ba47d3bdf582bf15e9250bff6b2f6dbd
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2125677
+  timestamp: 1686783049768
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
+  sha256: 7717c1f0af2af4b28b6d787b32c5e1740f391915c78707d8643e0d516088dbd0
+  md5: d7ae4c5cb253fa85c0ce268d2bf9a191
+  depends:
+  - colorcet
+  - dask-core
+  - datashape
+  - numba
+  - numpy <2.0a0
+  - pandas
+  - param <2.0.0a0
+  - pillow
+  - pyct
+  - python >=3.9,<3.10.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17679970
+  timestamp: 1692372465872
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
+  sha256: 40bbbe2ed223829f4a3f91024fa409f1a665ad94294bec2c9e930989bb2b8911
+  md5: 4add00dc619c12370af0ed18c76b71f6
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 103370
+  timestamp: 1613390236788
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+  sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
+  md5: 04cbe8f4bc62c34fac9d42d1124059bf
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2052734
+  timestamp: 1690905361158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
+  md5: ef0e825982f242085574f502dfff4f6b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16594
+  timestamp: 1649926538106
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
+  md5: 24747a300246c016b3a7f04dabd02d4a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27709
+  timestamp: 1668714497209
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
+  sha256: 95e9a45812b1b4059b973e5e6e131c7c1a8b2ce2dafc5117e7806b1c8f30de27
+  md5: bc889aaa846ed177fc5f495c24041acc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 262430
+  timestamp: 1695734574609
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+  sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
+  md5: e4a732941f74b8062c8bcbfe5c5c2b56
+  license: MIT
+  license_family: MIT
+  size: 80252
+  timestamp: 1676983220161
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/gmp-6.2.1-he9d5cce_3.tar.bz2
+  sha256: 4ad52b3117e5a73afae7b257439d7ddda39032dacbb097645756f71fe688c952
+  md5: e0c3ff3de3d5896b080f777be9badbbc
+  depends:
+  - libcxx >=12.0.0
+  license: GPL-2.0-or-later AND LGPL-3.0-or-later
+  size: 817742
+  timestamp: 1653996454448
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/gmpy2-2.1.2-py39hd5de756_0.tar.bz2
+  sha256: 21504857bd37aa0a2f7abc08de83e5f94ae65460499616b1b5f00ea200998eb9
+  md5: 7a69b7671ec6be17706d87af701c9cec
+  depends:
+  - gmp >=6.1.2
+  - mpc
+  - mpfr >=4.0.2,<5.0a0
+  - python >=3.9,<3.10.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 170636
+  timestamp: 1645455604074
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+  sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
+  md5: f3ce6fe6eb760c236e5f7d04df5faa81
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28138484
+  timestamp: 1692293212596
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+  sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
+  md5: 6dd72c43fea25b748ec7a9f6c0407e15
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111810
+  timestamp: 1666125671024
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
+  md5: 03cdb7e679924b329ecab8f12cb8fc67
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38813
+  timestamp: 1678997212422
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+  sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
+  md5: 78baea934985ccd9514a366cc7e80ed4
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 727499
+  timestamp: 1681801225190
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+  sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
+  md5: da9b63e42f281f7e77b289f4b654b83b
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 218436
+  timestamp: 1691121840155
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+  sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
+  md5: 6a7cb9b49593b29933fa2b503d533a08
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1257205
+  timestamp: 1694181720454
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+  sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
+  md5: d861ef66f5c0a282d60b65778a9de2f3
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1048450
+  timestamp: 1644315332508
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
+  md5: f7e603c965052deed8b789c35855a42f
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213537
+  timestamp: 1666908270815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
+  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
+  license: IJG
+  license_family: Other
+  size: 278924
+  timestamp: 1677849185191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+  sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
+  md5: a82a17e78f725dcbd71ff8dac6db05c7
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133134
+  timestamp: 1676558895333
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+  sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
+  md5: ee9270379a9ebdb6297e4b6849b3f7f0
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 195479
+  timestamp: 1676329410154
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 32b898a97dca7770858ab31294238fde11ab61a84831a52f320e5ee5405a147c
+  md5: 926e754b8fad288b583ef2933deae1a5
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92938
+  timestamp: 1679906616072
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+  sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
+  md5: 7e60995b3119417213e5faedda147499
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 403165
+  timestamp: 1671707664990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+  sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
+  md5: cd470bdb28bb0e8b3535c93a3a6dad07
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65431
+  timestamp: 1672387389172
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
+  md5: 7dba7aa5b971febb55281659843586ba
+  license: MIT
+  size: 65470
+  timestamp: 1659616172703
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
+  md5: f78a158983f0bbaba56f34b976bc6dae
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 34189
+  timestamp: 1659616189313
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
+  md5: 36a1d885725d3ab4d1fadc5a29f978d2
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 327737
+  timestamp: 1659616202869
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+  sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
+  md5: 817848d0e2b2808acdc9b3fbbf581726
+  license: MIT
+  license_family: MIT
+  size: 133887
+  timestamp: 1683716590737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+  sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
+  md5: e458587c87e3f2d20192f4e0738f2c63
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 149419
+  timestamp: 1665498987619
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+  sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
+  md5: 1058b661ec829b2ee3716ee2a5520641
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1917987
+  timestamp: 1665498925405
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+  sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
+  md5: c90372428e1e4eed4fdcd790979d06b4
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1409377
+  timestamp: 1650983531933
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+  sha256: 8176dd9a68815301a24ed51e72f3506f5f77c67a112efa0dd14971f2f3b3c8c1
+  md5: b5e470c224000a6bda6f655c155b53e7
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 27861431
+  timestamp: 1683292881730
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+  sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
+  md5: c0b99f8e1c7475f23b1c7b4250b06e1c
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88021
+  timestamp: 1694778290062
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+  sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
+  md5: 06866415ef22d5322f9bdc9956b59c4d
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 678174
+  timestamp: 1692970318885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+  sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
+  md5: 2edc6c894d6d0321304396e9bd40df94
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241774
+  timestamp: 1692973618934
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+  sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
+  md5: 5c740b4a18a558de0ccfe601703c423c
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 338738
+  timestamp: 1662635677689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
+  sha256: fbf3c01a0834c151485b1b2ddf0c83d43703cbea051c6dbcb0d8d41946107670
+  md5: 12137025daee35f5c708ca10d0c96e3c
+  depends:
+  - libcxx >=14.0.6
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - python >=3.9,<3.10.0a0
+  - zlib
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 318622
+  timestamp: 1697031357874
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1dab4daa56408915de3ec270c8b887e7221d48633ea83b0afff61041fc197972
+  md5: 1519f9b766f9f894282db8353066e3b2
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11883
+  timestamp: 1652903144294
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+  sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
+  md5: 8bbd981ca0129d7beeacd3cd7623f714
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1491074
+  timestamp: 1695058597986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+  sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
+  md5: d5f58d056b4bfc67aec30c77035ba889
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 182491
+  timestamp: 1670944720979
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+  sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
+  md5: 3681ebf029211ceab26af6f5d35abf39
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22254
+  timestamp: 1654598220251
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.5.3-py39hecd8cb5_0.tar.bz2
+  sha256: eb50c8eed3f9cc7a082b51c6d8fa2e298e497af1c6daedcf9f9b2d010eff0194
+  md5: 7780a1de869415ba3f30d778b97a8897
+  depends:
+  - matplotlib-base >=3.5.3,<3.5.4.0a0
+  - python >=3.9,<3.10.0a0
+  - tornado
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7564
+  timestamp: 1667357137796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.5.3-py39hfb0c5b7_0.tar.bz2
+  sha256: 4e47d48d968afb1b6eb6f3498a70989570970b14721a8eba6165e0ba5fb901b7
+  md5: 6d5fc756d08aca1d7efb452d38a94c5e
+  depends:
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - freetype >=2.3
+  - kiwisolver >=1.0.1
+  - libcxx >=12.0.0
+  - numpy >=1.19.2,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.2.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7750190
+  timestamp: 1667356965102
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+  sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
+  md5: 6eb64ecfcd754502e271db0bb51d2cfd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17374
+  timestamp: 1662014643620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+  sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
+  md5: 2a4d604717a647ad21af766289cbbfc3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58057
+  timestamp: 1607364912348
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+  sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
+  md5: 25051fe272624544652dc6d814c2943a
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224420228
+  timestamp: 1691503125614
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+  sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
+  md5: 37d8cf85a63f7aa9af1624894a7d606d
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48590
+  timestamp: 1682969183093
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+  sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
+  md5: 0b2aee6666135bbd36b46d6ac66160f7
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 210705
+  timestamp: 1695058433223
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+  sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
+  md5: e22fb55ce380d0ebd44cce3f20d5349e
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296614
+  timestamp: 1695060155673
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mpc-1.1.0-h6ef4df4_1.tar.bz2
+  sha256: 7592d8bdd91939479ce242511fa530cf488d69765e3f1a1d1ca87292c78ed696
+  md5: e3f4e5825d7495329009da2529626af2
+  depends:
+  - gmp >=6.1.2
+  - mpfr >=4.0.1,<5.0a0
+  license: LGPL 3
+  size: 92037
+  timestamp: 1527612755603
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mpfr-4.0.2-h9066e36_1.tar.bz2
+  sha256: 288afa0093b87d1d486cb2c837ee4d66e6976f7cd19242653ccc0c9a01af37cd
+  md5: 083ab8a04e706f95d97e79de976540fb
+  depends:
+  - gmp >=6.1.2
+  license: LGPL-3.0-only
+  size: 607328
+  timestamp: 1593117609730
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mpmath-1.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 9550dfc6bdeaf7d964155aa2e6545269af8dac5080a04c7a0404336d737fd98e
+  md5: 2cf92437be655244199383de117395d4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 992149
+  timestamp: 1690848362952
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
+  sha256: 5f60ca253f1fea0a1d765f535ff9ca2cf7efba90aea4c9a290d8f50ad11d4f6f
+  md5: 97d6ec94e2300030bddf0e5289cd2a84
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 24240
+  timestamp: 1607574265505
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+  sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
+  md5: 1a5d4004e64e3cfb7a2a297b9117c285
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8213832
+  timestamp: 1681756573646
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+  sha256: 2975bd1f98ca9ec7354ee378f86f8322ec90f568374776fd90e80c534fbee882
+  md5: 798627089e0ccba26695a26d9cb127ec
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99066
+  timestamp: 1650308465824
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+  sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
+  md5: e572c1264a7af20b486f64ac8c9e1f57
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 573356
+  timestamp: 1668450732828
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+  sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
+  md5: b67569a7c30af9ffa5cde6e4b52ac68b
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148342
+  timestamp: 1694616917184
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+  sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
+  md5: 97b81f34efbe86c5220fe82eb584fd62
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387288528
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+  sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
+  md5: d77862975a9a1cf50acb803be26e83a1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 575365
+  timestamp: 1690985052739
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+  sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
+  md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22858
+  timestamp: 1668160618784
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
+  sha256: 249efa747726ad61bc1093f33f155f0b7a0fa5b728cb1a6a6bd126458f279c96
+  md5: 1cced9a92d68307846cf59c238a42f13
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.41.0,<0.42.0a0
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.26
+  - python >=3.9,<3.10.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - libopenblas !=0.3.6
+  - tbb >=2021.6,<2022
+  - scipy >=1.0
+  - cuda-python >=11.6
+  - cudatoolkit >=10.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4431283
+  timestamp: 1697057424792
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+  sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
+  md5: 185e9c41abb88ee59b52ec0f5f65d506
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 138305
+  timestamp: 1696515469702
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
+  sha256: 361754aae186c6f4f8e5ceadf02b95ae74b47a97eaf1aa37538a7c410fb3ec88
+  md5: 02e4a556e3eb2375ec5a75795dd32372
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.25.2 py39ha186be2_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12847
+  timestamp: 1691166007881
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
+  sha256: 94d69c58f79dea6d155debef3237f02397ab6c3d042b519ad89fc64d204507d2
+  md5: 891a8850c69fd11971e58dfba0c40fcd
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.25.2 py39h827a554_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7529822
+  timestamp: 1691165972737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
+  md5: 93f5d7b66976154adeda219bea02ba45
+  depends:
+  - libcxx >=10.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 484257
+  timestamp: 1630093862501
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+  sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
+  md5: 5e8713ef1215406254988163eaf34020
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4965606
+  timestamp: 1695323060401
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+  sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
+  md5: 4154929ace2ad6ee16aea815635a6d1f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73598
+  timestamp: 1693575307570
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-1.5.3-py39h07fba90_0.tar.bz2
+  sha256: e9cb7e5f160ca30db363e54a07ebe4c0a3bb18615995403b926c973d21fc05ba
+  md5: 32c41a3c0aafd5440f887a4a72b00193
+  depends:
+  - bottleneck >=1.3.2
+  - libcxx >=14.0.6
+  - numexpr >=2.7.3
+  - numpy >=1.20.3,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  constrains:
+  - tabulate >=0.8.9
+  - pymysql >=1.0.2
+  - s3fs >=2021.08.0
+  - pyreadstat >=1.1.2
+  - zstandard >=0.15.2
+  - html5lib >=1.1
+  - fastparquet >=0.4.0
+  - gcsfs >=2021.7.0
+  - tzdata >=2022a
+  - openpyxl >=3.0.7
+  - xarray >=0.19.0
+  - pytables >=3.6.1
+  - python-snappy >=0.6.0
+  - brotli >=0.7.0
+  - xlsxwriter >=1.4.3
+  - xlwt >=1.3.0
+  - sqlalchemy >=1.4.16
+  - beautifulsoup4 >=4.9.3
+  - blosc >=1.21.0
+  - jinja2 >=3.0.0
+  - scipy >=1.7.1
+  - psycopg2 >=2.8.6
+  - xlrd >=2.0.1
+  - pandas-gbq >=0.15.0
+  - numba >=0.53.1
+  - pyarrow >=1.0.1
+  - lxml >=4.6.3
+  - matplotlib-base >=3.3.2
+  - fsspec >=2021.7.0
+  - pyxlsb >=1.0.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13059606
+  timestamp: 1677853236606
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+  sha256: 914f1ec8d911083c006c4c2d3b4c0c528e79abba3ae5f1dad825bd896870270d
+  md5: 949e0e4c0ce43c92eb52241892230873
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142949
+  timestamp: 1684915417020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
+  sha256: ddcb56e35d537f7a748b242c7c44368f112471973a52ae022945f597b7a83c7c
+  md5: 94bac4f8fbfaf821ace161b9f1f58716
+  depends:
+  - locket
+  - python >=3.9,<3.10.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36756
+  timestamp: 1698702713944
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+  sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
+  md5: be0a90921f3bf4f0d6950fb786093de7
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND
+  license_family: Other
+  size: 719901
+  timestamp: 1696580194417
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+  sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
+  md5: 81ae9ec2d7fcf6934847bff558b619f5
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2672987
+  timestamp: 1697548890181
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+  sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
+  md5: 1a822c206e2abddc5d6d821721af227f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33013
+  timestamp: 1692205801265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+  sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
+  md5: 1604d33dbdb2446c642970f8b354bedb
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91266
+  timestamp: 1659455269141
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+  sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
+  md5: d1b3bcc35655a3123acb1fa2ad1a8511
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580828
+  timestamp: 1672387372015
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+  sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
+  md5: 7540555d1fb192236db9a7c5c9d3601c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365765
+  timestamp: 1656431373327
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
+  md5: 0a73533fb6e0dc717ab906a537bc747d
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30803
+  timestamp: 1675441638631
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+  sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
+  md5: 0a959fbad46ab38ade48dbd358002674
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1864757
+  timestamp: 1684280094736
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+  sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
+  md5: ea24b5076ef79e4567c5a3f0cb22b470
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95330
+  timestamp: 1690223465114
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+  sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
+  md5: bcaea6d4a47e9c874becaa700c78dcf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157216
+  timestamp: 1661452617825
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+  sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
+  md5: 707110d1b49cb1864acb0bbaa103591e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 95016
+  timestamp: 1636111184034
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
+  md5: 113a443b9c706f9f9c6187c0eaa3de27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31178
+  timestamp: 1605305861851
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+  sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
+  md5: 85a8d0001db70e52a479155228cb1fe0
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13324979
+  timestamp: 1694439878265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+  sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
+  md5: 47c5e22e31ec05a7bc0ce90065a53afd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 265348
+  timestamp: 1661368839620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+  sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
+  md5: ce9a69e1668aa1e133f2aa6d4e8d346f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 254958
+  timestamp: 1695131709704
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+  sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
+  md5: 637f08b19dd8fd87347d8c44f9e3e202
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 170776
+  timestamp: 1698096100056
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+  sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
+  md5: 8ce3ac7d8a04e469b566f1b090d01140
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 470617
+  timestamp: 1657724324011
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
+  md5: 6f2d41dd76a03b7f85a1ed49af1763d6
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95100
+  timestamp: 1690400262627
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+  sha256: a9755ecbfd42c708945027facfa11a3dc3119778326a0ae5df79f80d7b72afa5
+  md5: 839ffa4e775fee9a8bdddabf4a14da43
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<1.28
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24331914
+  timestamp: 1696545397632
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
+  md5: b0321e6f14e139fc15b1f8b4acb35d2f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093966
+  timestamp: 1690290944588
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+  sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
+  md5: 62b64576a0aa5f6c3fb05f56650d25e1
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15535
+  timestamp: 1614030509324
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+  sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
+  md5: 15b5595b31e39f08eaacbe2e502d8fb3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67292
+  timestamp: 1696347733587
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+  sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
+  md5: 82e4db6a498480a75d53c55bd35b6478
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1801397
+  timestamp: 1681394807900
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sympy-1.11.1-py39hecd8cb5_0.tar.bz2
+  sha256: c8ca26b224982f834434ed8be60a54c7c1f07523a0ed67db6a5f4b9b51022ac5
+  md5: cc3bdf03364df0db20134e08a6b00cf8
+  depends:
+  - gmpy2 >=2.0.8
+  - mpmath >=0.19
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - antlr-python-runtime >=4.7,<4.8
+  license: BSD-3-Clause AND MIT
+  license_family: BSD
+  size: 12376249
+  timestamp: 1668204225577
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+  sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
+  md5: 63b957927b9949ccb19da28ec4612706
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30902
+  timestamp: 1671751919031
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+  sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
+  md5: e346257a2fa8e2cb48c762138a5d009b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39915
+  timestamp: 1668168959656
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+  sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
+  md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
+  depends:
+  - zlib >=1.2.12,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3536231
+  timestamp: 1654088937695
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
+  sha256: 74fc3a9e308602b3710f8fa671f24f5492571d0c8f7c1b3071dac72671262d45
+  md5: e08ead92568f5bd72d5ac7f08f087fee
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102258
+  timestamp: 1667464155001
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+  sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
+  md5: a1bbf0abfb8c45541122c0eb2feee317
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680464
+  timestamp: 1696937112175
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
+  md5: 8a292c1ee22489bef2e84bc3aaf4098e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193141
+  timestamp: 1671143985219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
+  md5: 8bf0bfffc11ad06a1c94e145941b0ad4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9651
+  timestamp: 1690297655669
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
+  md5: 343514a174b3485fde55a73f56398dd7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58456
+  timestamp: 1690297648002
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+  sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
+  md5: c2242e8fd24003a74ddf37416661e06d
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188757
+  timestamp: 1698257668273
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+  sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
+  md5: 41f445e36b6b6722a9444508eef069f8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20583
+  timestamp: 1607365395045
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+  sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
+  md5: 409ee46ed24267b6da6fb32d13e1f21e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70730
+  timestamp: 1614804271285
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+  sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
+  md5: eb74e74d8e4fd533c55eb98b7b5e83bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102637
+  timestamp: 1695742077778
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
+  sha256: 9f5a34bef727052f97b1cc387c3a99a60754de99d6e4ab0b2de770d76b64dc0f
+  md5: b5ce0421037c626cfcec5b43d83ec420
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1787999
+  timestamp: 1689041573350
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+  sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
+  md5: e243baa546432c8394a8059a44a5a3e4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 419227
+  timestamp: 1683113010463
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+  sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
+  md5: fe4ac85ee86d3a94ea3a4ebea3779763
+  depends:
+  - libcxx >=10.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 321797
+  timestamp: 1616055526986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
+  md5: bc7073d9d4c0211cc4a1207c98fb765a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19091
+  timestamp: 1672387204865
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+  sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
+  md5: 8e495591e369ac161857a72011c0a296
+  license: Zlib
+  license_family: Other
+  size: 120272
+  timestamp: 1666595024203
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+  sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
+  md5: f1465fbd810b3746c6de6babfd4fe28a
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1023573
+  timestamp: 1681304595869
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+  sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
+  md5: cf55cb8d7031b30c70c56fc7c782b5c7
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 156104
+  timestamp: 1644482799136
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+  sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
+  md5: 84fce327d9f0d594e86f565e5c21962e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10183
+  timestamp: 1629146082730
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+  sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
+  md5: 84b8b998a741b37abf5312c1c03696ef
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33979
+  timestamp: 1644845817952
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+  sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
+  md5: 77b746931c8f31c3ae393ccb5819d43d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133628
+  timestamp: 1695717890677
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+  sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
+  md5: 3df6e8ba34208dea068890e5d5318cc0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206759
+  timestamp: 1681493095987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+  sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
+  md5: bb55f81435cb6e11d264242274fccd1a
+  depends:
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 115947
+  timestamp: 1657175645380
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
+  md5: f860193e14afc7ef3f5b990a2ac003d2
+  depends:
+  - brotli-bin 1.0.9 h1a28f6b_7
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18936
+  timestamp: 1659616204016
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
+  md5: ad53130f3fd1f8d3c2fcbb7496e5585d
+  depends:
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18715
+  timestamp: 1659616188888
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+  sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
+  md5: 0982c046fb976e9f9fb19e7510187a18
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 366983
+  timestamp: 1659616245272
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+  sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
+  md5: 31ac2f5596cb7a44adf073c930641c54
+  license: MPL-2.0
+  license_family: Other
+  size: 133817
+  timestamp: 1694009762858
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+  sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
+  md5: cf1f6c3c34a1e1b9ab22b04233d860f6
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159783
+  timestamp: 1690232303987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+  sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
+  md5: 0eb268e38b5174d471a6e87d9d6102b1
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225355
+  timestamp: 1670423312966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
+  sha256: 41e76ba21b1279278a039245275eb4ee1f81b38b33cba00ca3575f06be5dc570
+  md5: c5170bf12e308fb7f2d1b4b9065f3df7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 153036
+  timestamp: 1698129857856
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
+  sha256: 36240dde0a1546469f35f3b5509b55384dfd894beb56b3ca929da4b96a2a5f24
+  md5: 844539636e4c20ee99e8ceeff5e902bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41376
+  timestamp: 1683040042906
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+  sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
+  md5: e68c94666cd60221b575c3814c89bac0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1946451
+  timestamp: 1668084573824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+  sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
+  md5: 1773ae2b080cdd55827e27673351551e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13646
+  timestamp: 1671231171682
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+  sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
+  md5: b62455043c8eb2434466885b19fed2de
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1399573
+  timestamp: 1694211828228
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
+  sha256: fb7d12350372a70daa9f476647d04fc213ef9d8f73cbddaf30b40b1b45beef0f
+  md5: 34595eb00802934d092b3086d7b4344d
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2124926
+  timestamp: 1686783028732
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
+  sha256: d366da723fc8baf4d9de0d25688619efe4d1c7abe5407dfb28654c4c9e2ef019
+  md5: d4c923ceedacd8d5d18f994feed8dbb8
+  depends:
+  - colorcet
+  - dask-core
+  - datashape
+  - numba
+  - numpy <2.0a0
+  - pandas
+  - param <2.0.0a0
+  - pillow
+  - pyct
+  - python >=3.9,<3.10.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17708209
+  timestamp: 1692372524993
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
+  sha256: 83dbf9755ea887576e3f34adb1c26d418db9aaf3c77dc07f30b58c2221b81c72
+  md5: 36246697d07d6709de78abe36b6beae5
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 103201
+  timestamp: 1629793063728
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+  sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
+  md5: eb3cdc0fc210838b9271512a6a1b7c85
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2067708
+  timestamp: 1690905319109
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+  sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
+  md5: f44b80b9405410e5bde6bfe0b31d5b3f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 15135
+  timestamp: 1650293774207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+  sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
+  md5: f87027ccce1361d0f82c0edf1a10d53b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27677
+  timestamp: 1668714367519
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
+  sha256: 296371685a5dcd98f5128f11f413e63aa59c1eba60543faf3baaebd445964c5d
+  md5: 9817e8ffd3669484c9a7de99a8aceffb
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 257844
+  timestamp: 1695734566410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+  sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
+  md5: 1d0bd7e576c64c059ef781dd319ad82a
+  license: MIT
+  license_family: MIT
+  size: 77591
+  timestamp: 1676983230102
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gmp-6.2.1-hc377ac9_3.tar.bz2
+  sha256: d4e13c27a19390f5e0737e47cc55bcd8d0399679affea7701a0129d902665030
+  md5: d875d1f8cda3e280dafdb38350477b15
+  depends:
+  - libcxx >=12.0.0
+  license: GPL-2.0-or-later AND LGPL-3.0-or-later
+  size: 643155
+  timestamp: 1653996450241
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gmpy2-2.1.2-py39h8c48613_0.tar.bz2
+  sha256: f99e81c82245e80be9bf260fec5f71345edc64ac64d425168e43466ae1d55e37
+  md5: 5ff8378b91647681350f9cabfced006e
+  depends:
+  - gmp >=6.2.1,<7.0a0
+  - mpc >=1.1.0,<2.0a0
+  - mpfr >=4.0.2,<5.0a0
+  - python >=3.9,<3.10.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 166804
+  timestamp: 1645462713827
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+  sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
+  md5: 69eb3b03765627b6159ed23cdde78396
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28399065
+  timestamp: 1692293207812
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+  sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
+  md5: 83366cbd3beb073112f4644a613b6bca
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111933
+  timestamp: 1666125627512
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+  sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
+  md5: 647c1a2f8460ffa8c670a1915bbdb494
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38790
+  timestamp: 1678997152549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+  sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
+  md5: 187d7720aedf38759d122cccb4576f2c
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 219976
+  timestamp: 1691121991680
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+  sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
+  md5: e8e7f10741f9cfa737b310b334940441
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1255894
+  timestamp: 1694181494549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+  sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
+  md5: ff209e75aee17af2e358b0008fbe8c88
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1022945
+  timestamp: 1644315931223
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+  sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
+  md5: d3e78ef296b3c74910d003bd10b475d6
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213972
+  timestamp: 1666908195870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
+  md5: 055e12390b844ea6c6e956ee08a618e8
+  license: IJG
+  license_family: Other
+  size: 273479
+  timestamp: 1677849171867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+  sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
+  md5: 783e2ad3d36472648c5ccc9f3051db3c
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133077
+  timestamp: 1676558732505
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+  sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
+  md5: 0677598f673f9729b5990316170a999d
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 197129
+  timestamp: 1676329661580
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+  sha256: 05f9ca0fdcfdc2e217438be27fead588c843a3aadf7d034467c83216d1e5c214
+  md5: 2d648b77d817ba38293c0728711ba8f5
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92852
+  timestamp: 1679906632236
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+  sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
+  md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 401319
+  timestamp: 1671707682572
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+  sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
+  md5: 247558a0aecf1ef7e77a4343761353d6
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64600
+  timestamp: 1672387273585
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
+  md5: a0f206782751dfffed0dd51302a1bf26
+  license: MIT
+  size: 68012
+  timestamp: 1659616138077
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
+  md5: 4c6667cdd061d28e9bc4e4300e4d115e
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 31173
+  timestamp: 1659616155596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
+  md5: 637e9430e258ddf050623ef2360184d8
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 298430
+  timestamp: 1659616172209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+  sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
+  md5: 55c615026c0869f8d3ba657f3bd38c43
+  license: MIT
+  license_family: MIT
+  size: 120389
+  timestamp: 1683716579036
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+  sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
+  md5: a41117710dafe569c9cc4e83f6f29fe3
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1411339
+  timestamp: 1650982753977
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+  sha256: d654027daea13ac9db36ab5fd5eff3ad398ec97c1777bf399f3ec680d2c145b9
+  md5: baabb1f905054bfea3af8f5768572a34
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 26579907
+  timestamp: 1683291669565
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+  sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
+  md5: 98d22e0124d55fae3c37c608dab1dcc9
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 89825
+  timestamp: 1694778225280
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+  sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
+  md5: 0ba499df6755eae5d2d23aa4ab004553
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 642657
+  timestamp: 1692970217410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+  sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
+  md5: c73101971e5ab6a8e8688239884eac81
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241607
+  timestamp: 1692973585084
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
+  sha256: 124d9d4f865f0f66c4e5e7f99dc1110330c9415cc51effc0a5aad4261880c2f0
+  md5: c08c14e55ba470513eb6c87206fb7b30
+  depends:
+  - libcxx >=14.0.6
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - python >=3.9,<3.10.0a0
+  - zlib
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 322413
+  timestamp: 1697031210019
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
+  sha256: 83e1c11fb14ec2767e833b540a6a0fdbd8641523b5673273914007008e6666da
+  md5: 64adbf70a0d4ab82aca039e972821537
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11877
+  timestamp: 1652903192510
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+  sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
+  md5: 353dff9d5d996c2a260f66381b2ce3e8
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1470815
+  timestamp: 1695058433965
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+  sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
+  md5: c99006da802a97c9aae30da8c16b4820
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176131
+  timestamp: 1670944706815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+  sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
+  md5: 34dfd76da78de2eae95bbda390d746d6
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23092
+  timestamp: 1654598007056
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.5.3-py39hca03da5_0.tar.bz2
+  sha256: 457f9bffd4cdd69022f23a2674bcf4e0ad5a10489d5ad3040eee92abf0b36247
+  md5: d529ca5317c79ac2c4263accaf9ffe94
+  depends:
+  - matplotlib-base >=3.5.3,<3.5.4.0a0
+  - python >=3.9,<3.10.0a0
+  - tornado
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7557
+  timestamp: 1667356944439
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.5.3-py39hc377ac9_0.tar.bz2
+  sha256: f618e537364de52e01c5ea00da9e929cbd69f6fb2b44b33438ec6ca86e6d20d3
+  md5: 44e021749203eb346116b909afbc177d
+  depends:
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - freetype >=2.3
+  - kiwisolver >=1.0.1
+  - libcxx >=12.0.0
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.2.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7700383
+  timestamp: 1667356814530
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+  sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
+  md5: eb79dabbeedee7da85dfbfb145bb8a26
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17342
+  timestamp: 1662014601345
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+  sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
+  md5: 56db7bd3ff511cd839bda081523b3edd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 55683
+  timestamp: 1629356128780
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mpc-1.1.0-h8c48613_1.tar.bz2
+  sha256: 61fcc5f4d95d412156111870e23d691ce8a0264ace3404f6e139786b1a8041c5
+  md5: 493853604367a8158e507a82e0f39115
+  depends:
+  - gmp >=6.2.1,<7.0a0
+  - mpfr >=4.0.2,<5.0a0
+  license: LGPL-3-or-later
+  size: 129349
+  timestamp: 1628353319507
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mpfr-4.0.2-h695f6f0_1.tar.bz2
+  sha256: b933d173664ccdd85acdc80beaeb3e4d098622fc9379161308b1aa66a38a0e64
+  md5: 0930875aa2bcd9ddd2cdb6b5b37f3770
+  depends:
+  - gmp >=6.2.1,<7.0a0
+  license: LGPL-3.0-only
+  size: 585142
+  timestamp: 1628351993556
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mpmath-1.3.0-py39hca03da5_0.tar.bz2
+  sha256: 83195356bfcb13fa023df6a811587e218c1508520f9ca164a317f986a432f545
+  md5: 2c559997f16b72a30172693cccaaed12
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 990288
+  timestamp: 1690848313585
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
+  sha256: ee936ba5fd196c15c3cb538aef721e54bb4486110ae3ebbfcf78e95e8380efa4
+  md5: dde1d9e040e04cbfbc0138898240a660
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 23003
+  timestamp: 1629282780853
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+  sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
+  md5: 176e0dcaeb28393881bacf69941e3889
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8289638
+  timestamp: 1681756329011
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+  sha256: afc6f332c51a3defc69e4c4e641988c0556039b9cd42be22f3db5292c88ccf37
+  md5: 2bc409c7258160a9b739d08d5ffb5998
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 96942
+  timestamp: 1650373637069
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+  sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
+  md5: 150ea9fadddf21993d3328d3e48a18b7
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 557688
+  timestamp: 1668450759059
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+  sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
+  md5: 37163b32508f9f589b3e6462a3a47546
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148426
+  timestamp: 1694616771736
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+  sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
+  md5: 6cdf7cbc43bf40e92b056a5576bd0086
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387216468
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+  sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
+  md5: 0f05853a139b6cda9c73e9d2707a4976
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 590288
+  timestamp: 1690984971741
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+  sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
+  md5: 7de782e4fb34bfa95ef2fc79d27d727d
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22840
+  timestamp: 1668160634885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
+  sha256: 0a5a7295f055d2f175528cc895dcb07533df5f0b87f05ac7839ec1af15988218
+  md5: 3d8e6925b26ca29486d0b58b30f1f663
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.41.0,<0.42.0a0
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.26
+  - python >=3.9,<3.10.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - cuda-python >=11.6
+  - tbb >=2021.6,<2022
+  - libopenblas >=0.3.18, !=0.3.20
+  - scipy >=1.0
+  - cudatoolkit >=10.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4428704
+  timestamp: 1697061454581
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+  sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
+  md5: 1a7b23113372c5667dbfe45976b9cc5c
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 126357
+  timestamp: 1696515322390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
+  sha256: 5332b3635fbc1a800b0fe58db7a0e57bb5ef75cbc56a0512c76f01ac7fc7139f
+  md5: ab7fbf394a301d25d1bf8cfa76fd917b
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.25.2 py39ha9811e2_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12847
+  timestamp: 1691092401334
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
+  sha256: 114b5aa7ef0990a615e27116e05dba0e7e78df750e3592aa4b732438f391a394
+  md5: 3284c63e9251227322ef9fd9c997f2c7
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.25.2 py39h3b2db8e_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6338710
+  timestamp: 1691092386069
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
+  md5: 371358a54bbdd307603888348d1a2c6f
+  depends:
+  - libcxx >=12.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD 2-Clause
+  size: 412248
+  timestamp: 1628861367714
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+  sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
+  md5: fa15d3b44ae1360ac9b640bbd5b6923c
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4746123
+  timestamp: 1695322833432
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+  sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
+  md5: d73db95f07a282021efdf8bc09713261
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73620
+  timestamp: 1693575195999
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-1.5.3-py39h78102c4_0.tar.bz2
+  sha256: e094ee730427e220e2b6e7fd54a1b34d4d16bfa9818b4472d2608fb7db9ce1c1
+  md5: c72f88467f474447f0fbee8013a750fc
+  depends:
+  - bottleneck >=1.3.2
+  - libcxx >=14.0.6
+  - numexpr >=2.7.3
+  - numpy >=1.21,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  constrains:
+  - pyxlsb >=1.0.8
+  - pandas-gbq >=0.15.0
+  - fsspec >=2021.7.0
+  - xlsxwriter >=1.4.3
+  - lxml >=4.6.3
+  - xarray >=0.19.0
+  - tzdata >=2022a
+  - xlwt >=1.3.0
+  - beautifulsoup4 >=4.9.3
+  - fastparquet >=0.4.0
+  - jinja2 >=3.0.0
+  - brotli >=0.7.0
+  - pyarrow >=1.0.1
+  - matplotlib-base >=3.3.2
+  - pyreadstat >=1.1.2
+  - gcsfs >=2021.7.0
+  - pytables >=3.6.1
+  - sqlalchemy >=1.4.16
+  - html5lib >=1.1
+  - tabulate >=0.8.9
+  - python-snappy >=0.6.0
+  - scipy >=1.7.1
+  - blosc >=1.21.0
+  - numba >=0.53.1
+  - openpyxl >=3.0.7
+  - xlrd >=2.0.1
+  - zstandard >=0.15.2
+  - s3fs >=2021.08.0
+  - pymysql >=1.0.2
+  - psycopg2 >=2.8.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12828607
+  timestamp: 1677852272349
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+  sha256: 0d64f2438be25524bbfeb8646e4fb3c18499d747398a03ed15d41b350b03e001
+  md5: 6a4908a5c9f7b3f17f09ebc34b1b691c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142857
+  timestamp: 1684915417403
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
+  sha256: 3a6450282f56265e800500b62cd1bbe39cd5a6a09c4747c6dc3e8aab10bfa8a0
+  md5: 9b01b16f9c5a033ee8b92683d66b184e
+  depends:
+  - locket
+  - python >=3.9,<3.10.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36731
+  timestamp: 1698702611592
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+  sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
+  md5: 6e01c592ae3b8ff2d12cae76f2f4276b
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 715239
+  timestamp: 1696580071596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+  sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
+  md5: 9fb8f460c130d56caf33c6bbe46fbe8a
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2678841
+  timestamp: 1697548790931
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+  sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
+  md5: 390b8c3cd74281abecdbfd51476922f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33033
+  timestamp: 1692205747301
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+  sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
+  md5: 7896828fb3565fefad43f980d50c8723
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91190
+  timestamp: 1659455206354
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+  sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
+  md5: d934c74eb66d01af0f45f0881f4bab77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580588
+  timestamp: 1672387390426
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+  sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
+  md5: 9858166e5ffb624c8b9d281f4000d725
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 367167
+  timestamp: 1656431368885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+  sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
+  md5: 4d2b45c6be8221e6a3e44c2d5838426f
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30843
+  timestamp: 1675441531640
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+  sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
+  md5: 02521df4e2e79f75faa9cbb3560ab1dd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1861763
+  timestamp: 1684280026169
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+  sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
+  md5: bdebe59bffc7adbad83fdcd9d429a5f5
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95234
+  timestamp: 1690223494699
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+  sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
+  md5: d716e5c9b5eec45ce1df8eb52cab817a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157408
+  timestamp: 1661452601692
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+  sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
+  md5: 1907629863ed8e7c35ead232dae7693f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 91636
+  timestamp: 1628941083263
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+  sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
+  md5: 847b9bddf2a86e1609c0d53bbc23ea79
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 27378
+  timestamp: 1626781391140
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+  sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
+  md5: 18aa18bd0d260605923877921d26cc74
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13194025
+  timestamp: 1694438901368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+  sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
+  md5: 45642a99c83e7aed74d1ffab1f20145b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 266647
+  timestamp: 1661368655993
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+  sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
+  md5: fec748525144049a2fc7f52f9755232c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257235
+  timestamp: 1695131702047
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+  sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
+  md5: 3445d25415998c807efbe64d3a7e03c8
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 167068
+  timestamp: 1698096118071
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+  sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
+  md5: e6e92da28e9b0e428ed4b7df417bec25
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 472418
+  timestamp: 1657724315435
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+  sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
+  md5: dba22515f36d3c266de5896350813ea2
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95103
+  timestamp: 1690400315537
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+  sha256: c35449c0ca64d0d6a23c019b6eba188f546e42379857cbc4240bbdddee1159d3
+  md5: 61cb82346e21710f3e0645096cda4e12
+  depends:
+  - blas * openblas
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.21.5,<1.28
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22859180
+  timestamp: 1696543469561
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+  sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
+  md5: 3cd7eb43e285faba76faf67667e26b00
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093916
+  timestamp: 1690290951258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+  sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
+  md5: c5e9aef0d6895de1c927e9d796cd7cd3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15691
+  timestamp: 1629145910454
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+  sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
+  md5: 0f7c229e774146ffc4e29dedf75372bf
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67279
+  timestamp: 1696347632563
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+  sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
+  md5: 2302a79a045f152e183a52a81adfba62
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1674163
+  timestamp: 1681394762218
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sympy-1.11.1-py39hca03da5_0.tar.bz2
+  sha256: dbe2022bb90ff178c4c336c3edf7e04a0d5bbedc9b9f2ffde94201b3f96a5e13
+  md5: 3af171911eca8754aa316ceccb8c1a0d
+  depends:
+  - gmpy2 >=2.0.8
+  - mpmath >=0.19
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - antlr-python-runtime >=4.7,<4.8
+  license: BSD-3-Clause AND MIT
+  license_family: BSD
+  size: 12362938
+  timestamp: 1668203400757
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+  sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
+  md5: ae58720a18a2ed15eae214ad7a10d1b5
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 140125
+  timestamp: 1680167256603
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+  sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
+  md5: 4ae67163d55cf9df83d4027ebc38c501
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30894
+  timestamp: 1671751931536
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+  sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
+  md5: dbb5c0cddb6661a89afee647fd3dc01e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39875
+  timestamp: 1668168874870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+  sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
+  md5: 667e60c8b407d73cbba40f44901f4f00
+  depends:
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3412693
+  timestamp: 1654088929697
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
+  sha256: 065cf1b08faf1d28aa348d569f2266d8b33b22ba424312c7ec959be95f217646
+  md5: 20370dbc92a9262e6fc8c82208f74ff2
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102259
+  timestamp: 1667464137769
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+  sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
+  md5: 884f788a5f6a664c9b79f7a4a60362d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680561
+  timestamp: 1696937004165
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+  sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
+  md5: e5b90eba83fddba6d7aa6072b5bf7c91
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193017
+  timestamp: 1671143921826
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
+  md5: 644ef8830437070f60efcfcd6a987198
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9670
+  timestamp: 1690297532002
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
+  md5: a902a833bb186a2f1a4b2b89b1195136
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58466
+  timestamp: 1690297524418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+  sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
+  md5: f3f1d2c1028dad2f11ff950a15c99dbf
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188640
+  timestamp: 1698257577209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+  sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
+  md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20091
+  timestamp: 1629144441130
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+  sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
+  md5: 3089c63bf8f4d0423e1a287da286d83e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70923
+  timestamp: 1629357115820
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+  sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
+  md5: 5886b30b312445471268444f41f39dc7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102583
+  timestamp: 1695741976083
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
+  sha256: 300b9e4cfc9d01fa4d537060b2867f3cb89f22f932992fc2427e00dda050d55b
+  md5: 768c174577b786b99f8b46c4789b36a2
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1800646
+  timestamp: 1689041569828
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+  sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
+  md5: 2e75ad6a09c308268192efe03cc9ebf4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 411778
+  timestamp: 1683113019715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+  sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
+  md5: 30f666bf97c26587c5d2f68cc5f330ab
+  depends:
+  - libcxx >=12.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 316901
+  timestamp: 1629287855861
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+  sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
+  md5: 584e591d36dcd5ba5c45404f0f7ebb2d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19076
+  timestamp: 1672387153578
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+  sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
+  md5: 467ae28215d1aa1c5688bc0c8a184269
+  license: Zlib
+  license_family: Other
+  size: 103525
+  timestamp: 1666595022664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+  sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
+  md5: 7cfbed15f1feee1422810f7830075f53
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 779464
+  timestamp: 1681304594848
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+  sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
+  md5: ed14f9bc6e55220483f1a5a388625a08
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162772
+  timestamp: 1644481986085
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+  sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
+  md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 39253
+  timestamp: 1644551767970
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+  sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
+  md5: b24d13c443a26f65a0778b475a5726bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132830
+  timestamp: 1695717959996
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+  sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
+  md5: 302c3c0696e17eaa62e140e3892644ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 199723
+  timestamp: 1681493196911
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+  sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
+  md5: bf930260f679bc74227bbb18bc36ae82
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 119700
+  timestamp: 1657176150595
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
+  md5: 507dfe693ef429f466d964b599f4af21
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_7
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 18650
+  timestamp: 1659616328001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
+  md5: d0bf43e8df60baae3b3105aa5c42a791
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 21153
+  timestamp: 1659616312367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+  sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
+  md5: 7bd24bf94c24e810aecaaf84a0978e6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 343204
+  timestamp: 1659616543542
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+  sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
+  md5: 092b417c11edcbe6bb9b765ab4a55d23
+  license: MPL-2.0
+  license_family: Other
+  size: 164999
+  timestamp: 1694009822357
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+  sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
+  md5: 708a750d370b9d6875651021e21c4446
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159322
+  timestamp: 1690232335307
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+  sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
+  md5: c35736da3ea26782425e78061268cf5e
+  depends:
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 228713
+  timestamp: 1670423312743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
+  sha256: 9577ff772035cd30e72323edff379dd3df877de00f7f690fd33c8720a5a4bbc9
+  md5: 1130fd979d4f97f511f10b36ff09513d
+  depends:
+  - colorama
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 152728
+  timestamp: 1698129962390
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
+  sha256: e5babe79f8132c4bd44bc05307976f2c5485014ae3129655dddbd3baa8e75e46
+  md5: 093223df00c6ef9db4e7e5aa7bfec00a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40844
+  timestamp: 1683040252786
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+  sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
+  md5: 457a4339a53c033d48ce0c72e5038d2e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30330
+  timestamp: 1672387265402
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+  sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
+  md5: 59ec65fd9e06b81a65cc12986c67d5da
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1939614
+  timestamp: 1668084794027
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+  sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
+  md5: 3489c1a2b73fc957b5a62cc59349e25b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13438
+  timestamp: 1671231196438
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+  sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
+  md5: f46d904bc6f220327e70474971341f52
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1220835
+  timestamp: 1694445639066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
+  sha256: 78d66bcb1c979647e9c5473825d4a5e35afa2a0dfeef71cb0d9d9a72fea3c102
+  md5: f2875875bb22ab4704a77bc368a9dc00
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2180195
+  timestamp: 1686783294287
+- conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
+  sha256: 882a0fb257fb07bb47e8127b9ce1f556e319ce4941b74adc94f9849093e11d0d
+  md5: b6ef3c0b6e49ff3d497785c744ce44cc
+  depends:
+  - colorcet
+  - dask-core
+  - datashape
+  - numba
+  - numpy <2.0a0
+  - pandas
+  - param <2.0.0a0
+  - pillow
+  - pyct
+  - python >=3.9,<3.10.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17688679
+  timestamp: 1692373093225
+- conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
+  sha256: a6c8b5d32c52ce71d41c7702265e0bb064c960ab67b88ecbea967595c5e02bc3
+  md5: 112f2f9c7055656ec156fe287c97c0e9
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 104432
+  timestamp: 1613390539244
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+  sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
+  md5: 2ff4fb509788b0e47ac684ba151394d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3289966
+  timestamp: 1690907040646
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+  sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
+  md5: 0f166c3e70541d8bee6e9d0cb60fb66e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16979
+  timestamp: 1649926678161
+- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+  sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
+  md5: ea93d413944ca6a8677eb1b284b136ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27388
+  timestamp: 1668714577678
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
+  sha256: 6b724886465fea70d2ca843fea1d01bcc24d496601587b87c0cb8f2626b259c2
+  md5: 6c11d9242869d6c3b01698f728bd409b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 260567
+  timestamp: 1695734829130
+- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+  sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
+  md5: 9f167d3e45441bc3633c1974b1b0ce8c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 88421
+  timestamp: 1676983264486
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+  sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
+  md5: 582d2c1135a89da757a038de831e7f39
+  license: Intel proprietary
+  size: 11086648
+  timestamp: 1664812389803
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+  sha256: 945f4521793d7d279532d1ccd5157201c5cbf64f846bfe60249d01e1b4edf295
+  md5: 0accae23d095c165ac731f4a1f3ca497
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 37021132
+  timestamp: 1692294548916
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+  sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
+  md5: 30fdefd1541c789c163751291a8faa88
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111448
+  timestamp: 1666125667599
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+  sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
+  md5: a10f07c7a3510272a296f9fed458a4ed
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38098
+  timestamp: 1678997241511
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+  sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
+  md5: 9834848bd7c7759acf12e78d09388563
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3891030
+  timestamp: 1681801474383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+  sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
+  md5: 1285c8c628bc912c54d0968574c9f4c9
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217232
+  timestamp: 1691122695748
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+  sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
+  md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
+  depends:
+  - backcall
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1279433
+  timestamp: 1694181820978
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+  sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
+  md5: f5fcce35d3f21cdfc5893c5a7a86c651
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1035394
+  timestamp: 1644315567034
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+  sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
+  md5: f67fe3337528e2886f1ac3ab8ac37985
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213110
+  timestamp: 1666908350218
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
+  md5: 81f2c343dc4c65eea39c45383272068f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 407861
+  timestamp: 1677849239400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+  sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
+  md5: bd9526d38a145fe311a8aa36bc11e071
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 152006
+  timestamp: 1676558783570
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+  sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
+  md5: a00e6a62956fde3c4135464353ee8a53
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229158
+  timestamp: 1676330909084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+  sha256: db8335d6531b03c7bdfe789ebacc52631ac6ea4a37700bb3da1f6a53a1acd724
+  md5: ebeba61994cc225ea5f4f42caa511019
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116681
+  timestamp: 1679906658986
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+  sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
+  md5: 5efa1332f7c0a8d9638eda02170c4ce5
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pywinpty
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 413653
+  timestamp: 1671707957673
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+  sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
+  md5: 891fe66a24d8714737b2874985ee1303
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62298
+  timestamp: 1672388166096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+  sha256: ef6b0347ae565dd648a2bb40bc8b0b30f2e4f8387778fefced1d581b7d5a3e16
+  md5: 8ef1d5919aa55fe56ef34d9a7969dca7
+  depends:
+  - openssl 3.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 861982
+  timestamp: 1684424430941
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
+  md5: c345f51706eef530454f66b794e5e574
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 68189
+  timestamp: 1659616216976
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
+  md5: a7400cfb72042977bc047909ed504ce8
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 33743
+  timestamp: 1659616248209
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
+  md5: 6307f6854754ab5bd7c84e6998385bb1
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 733177
+  timestamp: 1659616279453
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+  sha256: bb17beae8860a83d081d57273825b46bf8fe9903f3b4182ab41a7ae2c7274859
+  md5: 94182f4ab8beb4eddfd8167b2e2b0380
+  depends:
+  - libclang13 14.0.6 default_h8e68704_1
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 147804
+  timestamp: 1681225547009
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+  sha256: 01b84a38c9069e7b8e6fa2a07707e785df7d40b8f01d76a504e98e5a5cd58539
+  md5: 22c9f7e59174c49f06e3c5c9384401ce
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 25699299
+  timestamp: 1681225463612
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+  sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
+  md5: b812bc5d9c76242e2bb2ac87afe7d39b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 730280
+  timestamp: 1650983734373
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
+  sha256: a36ea5c77075e90f47d3f5c1e2081c0c1c78c5c0a5135bf9a6448fca67bbc79d
+  md5: a0a02817a7def0563d1635035c26451b
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - openssl >=3.0.8,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  size: 3827890
+  timestamp: 1687382140999
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+  sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
+  md5: ba9418df9288a2f031a02fa35b774ce0
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78524
+  timestamp: 1694778314659
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+  sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
+  md5: 6ece7f1a3248169837714d05d7f6ef0a
+  depends:
+  - libiconv >=1.16,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 3513910
+  timestamp: 1692971505729
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+  sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
+  md5: bd7ec244935e83e850a4ff34e8e2e64f
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 513971
+  timestamp: 1692973657152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
+  sha256: 2f610fc98b674e4eceeceaadbb94b4153759ee9249759dd27ca48bfdeeef82cf
+  md5: c24005244a08cbfb665f89d8858e0187
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 20824879
+  timestamp: 1697031479623
+- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
+  sha256: 5d4cf89313147e44530dbb3cc6a93247aaded0701bbf8ba3a382ef710abf4cfa
+  md5: 137deeca51202f6b4ac786472a00be55
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 12894
+  timestamp: 1652904101694
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+  sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
+  md5: fb7881e74b59262df0fa4ec981964efc
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1244887
+  timestamp: 1695058550693
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+  sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
+  md5: 6970c7f46b0164cad1d210e7a1419959
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143434
+  timestamp: 1670944902624
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+  sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
+  md5: 466da740fafef3d6bce114220f0be306
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28510
+  timestamp: 1654508162239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.5.3-py39haa95532_0.tar.bz2
+  sha256: 105e3de6be2aa03ae066f4b24abbf0b7658cdc4197ebcfdb65063e6ad8002783
+  md5: a734c9b1f9d2ed092f9e1b26e889e527
+  depends:
+  - matplotlib-base >=3.5.3,<3.5.4.0a0
+  - pyqt
+  - python >=3.9,<3.10.0a0
+  - tornado
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7297
+  timestamp: 1667357382033
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.5.3-py39hd77b12b_0.tar.bz2
+  sha256: 8b27ecc6b6efbf276e4ce82aef23a81c334957b937e7395ab33a0ce68e6336ba
+  md5: 1f1b068723f4cf163fe5fe3d8e3535f9
+  depends:
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - freetype >=2.3
+  - kiwisolver >=1.0.1
+  - numpy >=1.19.2,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.2.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7680416
+  timestamp: 1667357230289
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+  sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
+  md5: a9fa43e694b25cd49b8b08a9eefd696e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18054
+  timestamp: 1661915903969
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+  sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
+  md5: 248c468abced874f0231d3cc23177c77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58488
+  timestamp: 1607359497934
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+  sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
+  md5: 5e763c995ff0c549f68a10bce70fede4
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187489950
+  timestamp: 1691503804820
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+  sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
+  md5: dd0c2ece6a743c373c9b5a5919b4818f
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49744
+  timestamp: 1682975040154
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+  sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
+  md5: 57cea8df7ab85f2a98f64d23afcb1f90
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184956
+  timestamp: 1695058491736
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+  sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
+  md5: 8769cdd201d905069800488fe31574e5
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 256221
+  timestamp: 1695060152521
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mpmath-1.3.0-py39haa95532_0.tar.bz2
+  sha256: 463964fde7a829a3e2c5a61918086ee6b4352122923f221c53180a27801ff2c7
+  md5: 661e228c104a96594f7f85d9e6a13916
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 989044
+  timestamp: 1690848602295
+- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
+  sha256: b75f28f29d60f2a8726fb0f036e5d01489942abbf77ff1e1cc8e12d7f372b8f3
+  md5: 7a1d29477873480809fd3860f2e69f01
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 24734
+  timestamp: 1607574381373
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+  sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
+  md5: d9781492332e6326f9fca87f3a8efacd
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8135792
+  timestamp: 1681756491399
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+  sha256: 2dd3178d3c570e30b9490ebabfd7bfac806afad8302d3dee0edc619805034397
+  md5: bef9da0f0694c45b6aaa4e6447479eaf
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 118324
+  timestamp: 1650290466135
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+  sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
+  md5: f1d8ce412e115986c403f223b3b47d0f
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 596314
+  timestamp: 1668451106600
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+  sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
+  md5: f96bbef0985d7e66ebf00c0d55e30e23
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 167045
+  timestamp: 1694617078743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+  sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
+  md5: 6e6ba64c8dc5025aeac606404a8df36a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13786
+  timestamp: 1672387480065
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+  sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
+  md5: 4a7a3286484766741f627696697c362c
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 609425
+  timestamp: 1690985686105
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+  sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
+  md5: 4269a1f93882205b90d4b2ae78fc82d5
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22417
+  timestamp: 1668160717305
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
+  sha256: 39b52f5a3e0f71a07358f2bd07a67b950170eabc3398ae968ef523cc0854141a
+  md5: 4baee3e5d96aed7d5d3e28051d6214e5
+  depends:
+  - llvmlite >=0.41.0,<0.42.0a0
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.26
+  - python >=3.9,<3.10.0a0
+  - tbb >=2021.8.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - tbb >=2021.6,<2022
+  - scipy >=1.0
+  - cudatoolkit >=10.2
+  - cuda-python >=11.6
+  - libopenblas !=0.3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4472762
+  timestamp: 1697063760024
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+  sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
+  md5: a18a576b7024cfd6f905c526a786a916
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 135285
+  timestamp: 1696515698492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
+  sha256: 410f3a13eaddcfcfc65cb077dd0b85b7c66853a2447161b9022eed7d9fe472f9
+  md5: c4aae7ab3842a3decd05c5c1d8b916d3
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.25.2 py39h65a83cf_0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12296
+  timestamp: 1691098390179
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
+  sha256: 5a81ff60cc876951905995ea52d3815e38a0d757c6c674acbef1144d8dc746fb
+  md5: 72413d41fe97de5da9b1ce325e544e05
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.25.2 py39h055cbcc_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6857794
+  timestamp: 1691098356763
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
+  md5: ab07e2a27ac08afe3d0b4c0890b8486a
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 2-Clause
+  size: 249316
+  timestamp: 1630094024143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+  sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
+  md5: 73b17037d87b5a58feb34dafc0538f7f
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8058396
+  timestamp: 1695324589828
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+  sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
+  md5: df1d746ba8d5d6ba01ac1373b9b71e1a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73016
+  timestamp: 1693575484990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-1.5.3-py39hf11a4ad_0.tar.bz2
+  sha256: f6e50ae841f87d086a2e132e1d526003b538711ce50b69329ab0c7fd692a6fa2
+  md5: b1c36236dfcdaa9db886e6bbb2046b9e
+  depends:
+  - bottleneck >=1.3.2
+  - numexpr >=2.7.3
+  - numpy >=1.20.3,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - python-snappy >=0.6.0
+  - tzdata >=2022a
+  - gcsfs >=2021.7.0
+  - html5lib >=1.1
+  - openpyxl >=3.0.7
+  - psycopg2 >=2.8.6
+  - pyarrow >=1.0.1
+  - brotli >=0.7.0
+  - scipy >=1.7.1
+  - xarray >=0.19.0
+  - beautifulsoup4 >=4.9.3
+  - fastparquet >=0.4.0
+  - jinja2 >=3.0.0
+  - zstandard >=0.15.2
+  - tabulate >=0.8.9
+  - pyxlsb >=1.0.8
+  - sqlalchemy >=1.4.16
+  - xlrd >=2.0.1
+  - xlsxwriter >=1.4.3
+  - fsspec >=2021.7.0
+  - pymysql >=1.0.2
+  - blosc >=1.21.0
+  - pandas-gbq >=0.15.0
+  - numba >=0.53.1
+  - lxml >=4.6.3
+  - pytables >=3.6.1
+  - matplotlib-base >=3.3.2
+  - pyreadstat >=1.1.2
+  - xlwt >=1.3.0
+  - s3fs >=2021.08.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12136904
+  timestamp: 1677836569898
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+  sha256: 2773f47b2d745ab483cf7fcbd5b5e2f7020d45462d32d2ccd5cf232ca13c6f67
+  md5: ca16cd208037bd58d2da267c338da4a4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142229
+  timestamp: 1684915524241
+- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
+  sha256: 5738f61dae392c171b4f699a6973e736198e4d4a63fa22dcf957afaf1de150af
+  md5: cba721e73156d62fc4ff23159e96ad41
+  depends:
+  - locket
+  - python >=3.9,<3.10.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36452
+  timestamp: 1698702686971
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+  sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
+  md5: 427c1450bebb632f43bbc8c83006e4cd
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 806931
+  timestamp: 1696580240310
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+  sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
+  md5: 21790cd3e2b8a45c4104aff0a68330d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3001751
+  timestamp: 1697549357662
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+  sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
+  md5: 56f44a1054da2d10777e375838191070
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 32355
+  timestamp: 1692205784293
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
+  sha256: bbcef9bbf4ccd051becaa7d8aa88cb5f46ff64570cc395b6a471332d8b900e11
+  md5: 0daf62b71923d157544576122b0fa79d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-clause
+  license_family: BSD
+  size: 82560
+  timestamp: 1607021261834
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+  sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
+  md5: 8a35ad65651086575ce55371f22feda8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91045
+  timestamp: 1659455316472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+  sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
+  md5: 186eb95f816a2eff80c3c7f7d964c7b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 578514
+  timestamp: 1672388155359
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+  sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
+  md5: 47b6cbe6ce9289e47d16900b03596a91
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372807
+  timestamp: 1656431445633
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+  sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
+  md5: 07165c444adc7c7ccc8a345875adc5ef
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48408
+  timestamp: 1675450623287
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+  sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
+  md5: d58e76a31e2f6e7410ba4afd7f385b0d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1877445
+  timestamp: 1684280183367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+  sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
+  md5: 0e5b0fe7debbf558ce97090f6b67cdae
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94633
+  timestamp: 1690225630423
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+  sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
+  md5: 0fde797653e4ab589506121fb1e37555
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157119
+  timestamp: 1661452591647
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
+  sha256: e70028d0250602c01feac17e60fafd371daee5d731917732b7eced4ab47b3243
+  md5: 72a51c0d49711d22a39aefc04fa0c328
+  depends:
+  - pyqt5-sip 12.13.0 py39h2bbff1b_0
+  - python >=3.9,<3.10.0a0
+  - qt-main 5.15.*
+  - qt-main >=5.15.2,<5.16.0a0
+  - sip >=6.7.12,<6.8.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 5007361
+  timestamp: 1698781683371
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
+  sha256: 6eb0c4f2e8acaa6dfaf1fb5b4b34f13d366ebf11d77e14a674a26d7fabbc7981
+  md5: 9354d98a97abd4715cdf63d4a28f7645
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 84071
+  timestamp: 1698769559444
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+  sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
+  md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 92679
+  timestamp: 1636093365041
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+  sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
+  md5: f870859d4dc7a8d82cf3546bd9035f33
+  depends:
+  - python >=3.9,<3.10.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 54520
+  timestamp: 1605307564142
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+  sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
+  md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
+  depends:
+  - openssl >=3.0.10,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 21172845
+  timestamp: 1694442462066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+  sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
+  md5: 9d99075052265ae3d718582d3b875038
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269964
+  timestamp: 1661376543480
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+  sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
+  md5: fa9074d94236c9b768bfd2c858875b27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 264836
+  timestamp: 1695131770282
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+  sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
+  md5: 3d2841085778006c2e79f9c7300f8b9d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13565975
+  timestamp: 1669937633869
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+  sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
+  md5: 54a4bc0724041dd173088419d6ede2af
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 239062
+  timestamp: 1677611495106
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+  sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
+  md5: f39f84115e228bad4bceaefdd637f022
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 158558
+  timestamp: 1698096358091
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+  sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
+  md5: df398a3a1668fd2a22061764e20ea91d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.4,<4.3.5.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 460913
+  timestamp: 1657616061604
+- conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
+  sha256: 409f9fad42cbae8d915d1703d87db6af9f951b150517daa4e1c0220cc5eb7b0f
+  md5: 2b17abf94b02a6c5ba6b7623dba97ff9
+  depends:
+  - icu >=73.1,<74.0a0
+  - jpeg >=9e,<10a
+  - krb5 >=1.20.1,<1.21.0a0
+  - libclang >=14.0.6,<15.0a0
+  - libclang13 >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=12.15,<13.0a0
+  - openssl >=3.0.10,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  constrains:
+  - qt >=5.15.2,<6
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 69829482
+  timestamp: 1693228189080
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+  sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
+  md5: 38db77ece9dc76feffb9ef7638e38258
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94397
+  timestamp: 1690400496655
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+  sha256: 3a9a680173f731d515e0587d5b74583cc986b5c1ff62f4cf9e4f7ec268cbb62a
+  md5: 3387bf809e3d32dde3f5cbc3ef49bf47
+  depends:
+  - blas 1.0 mkl
+  - icc_rt >=2022.1.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<1.28
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22779707
+  timestamp: 1696550432358
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+  sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
+  md5: 3e284ae6b48ee30c364ffdc5601610b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1099842
+  timestamp: 1690291374842
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
+  sha256: ed2b75ca1bb075901550bf892aa18a46a563e512e28ad5fe1b36e7ed3c6708d0
+  md5: 22779fae19f454e13656af8b737f8bd3
+  depends:
+  - packaging
+  - ply
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - tomli
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-SIP_License OR GPL-2.0-or-later OR GPL-3.0-or-later
+  license_family: GPL
+  size: 602624
+  timestamp: 1698676202396
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+  sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
+  md5: 993b3886b334bd1f49d34206f21997b4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15998
+  timestamp: 1614030572433
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+  sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
+  md5: 7ac9604ad7564ac0c71bff5db198656f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67012
+  timestamp: 1696347795139
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+  sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
+  md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1311308
+  timestamp: 1681402905668
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sympy-1.11.1-py39haa95532_0.tar.bz2
+  sha256: 4a20950353298ff8cbdb3f43abeeda4a5cc1853c3707e74fd39a1e5bfcd9d0a1
+  md5: 6abb1c631939885d181f058e98607737
+  depends:
+  - mpmath >=0.19
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - antlr-python-runtime >=4.7,<4.8
+  license: BSD-3-Clause AND MIT
+  license_family: BSD
+  size: 12382333
+  timestamp: 1668206099862
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+  sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
+  md5: 28b9869d8d3a839918fac4a08f38cbc2
+  depends:
+  - python >=3.9,<3.10.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30546
+  timestamp: 1671752127904
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+  sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
+  md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39590
+  timestamp: 1668168880994
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+  sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
+  md5: 52cdcdb96383c010ca833a7c24b3935b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Tcl/Tk
+  license_family: BSD
+  size: 3690152
+  timestamp: 1654036853710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
+  sha256: 86a1b449d27205327a5de0f81d18d9ad768e68d915b91b1d5b82be2d8f524e94
+  md5: 78a8a9f8c638df9a2db80964c97ff43f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 25476
+  timestamp: 1657175730463
+- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
+  sha256: 1ee791ecc17e11a31d6cf1553845e7279d9d9a2c7383a2a3e1ae131ddd024b6f
+  md5: b32030d310e0437dc631e5719369004c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102033
+  timestamp: 1667464306003
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+  sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
+  md5: 0e054ab29119cf4c1f778613acf972f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 681780
+  timestamp: 1696937326924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+  sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
+  md5: fe78de10019085146f1cc6c94fdc2620
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192822
+  timestamp: 1671143999327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
+  md5: ca5fc3fbdb09b6de068a8b7a8869369f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9208
+  timestamp: 1690298120549
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
+  md5: a86e87a10e5fdff486265e0c675fb99f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57922
+  timestamp: 1690298106990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+  sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
+  md5: 0d31859e0a097aedbcc1627db33b3d92
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188367
+  timestamp: 1698257883295
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+  sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
+  md5: 45ef24c486a484f079faf1dc90e4c7e9
+  depends:
+  - vs2015_runtime >=14.27.29016
+  license: Modified BSD License (3-clause)
+  license_family: BSD
+  size: 8277
+  timestamp: 1605602889180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+  sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
+  md5: 4daaceb6cfc1af6274509081d8018ef1
+  size: 2316783
+  timestamp: 1605602872095
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+  sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
+  md5: 916c16904615c7af3b5d37cb6694f45e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21084
+  timestamp: 1607347371925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+  sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
+  md5: da69e6987fcc757e83a358ceaa13f62b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73391
+  timestamp: 1614804425587
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+  sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
+  md5: 23b9f4634b2e5450be617114f62c74f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 120873
+  timestamp: 1695742300539
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+  sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
+  md5: 120f0b088290fc17bd6618fc10a2f0c4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PUBLIC-DOMAIN
+  size: 34293
+  timestamp: 1605306211299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
+  sha256: 6bdb88cd45b22246e84b7400159ca90faf98ab4e8c1fa2d38d031cfc73c4dc13
+  md5: d6e10641ece06f67561c5f6a676a4b7e
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1794729
+  timestamp: 1689041580510
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+  sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
+  md5: c3f7871e9a33adeccee1b1e8e216918e
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 1332571
+  timestamp: 1683113347814
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+  sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
+  md5: 1ab55f8c4b5292ec360c572120bf823e
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-3.0-or-later
+  size: 9430705
+  timestamp: 1616055773485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+  sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
+  md5: 6875e0bf3828707dc9165d694c0d0a7d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18725
+  timestamp: 1672387612937
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+  sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
+  md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 148931
+  timestamp: 1666595229032
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+  sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
+  md5: 8d6a1e767775fe0eb617cd6e22edc2ff
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1871867
+  timestamp: 1681304638261

--- a/goldbach_comet/pixi.toml
+++ b/goldbach_comet/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "goldbach_comet"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
 
 [tool.metadata]

--- a/goldbach_comet/pixi.toml
+++ b/goldbach_comet/pixi.toml
@@ -22,15 +22,15 @@ numba = "*"
 numpy = "*"
 pandas = "*"
 sympy = "*"
-pip = "*"
-setuptools = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+setuptools = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks]
 notebook = "jupyter notebook goldbach_comet.ipynb"

--- a/goldbach_comet/pixi.toml
+++ b/goldbach_comet/pixi.toml
@@ -1,0 +1,36 @@
+[workspace]
+name = "goldbach_comet"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2021-08-24"
+maintainers = ["djfrancesco"]
+categories = ["Mathematics"]
+labels = ["datashader", "matplotlib", "numba"]
+title = "Goldbach's comet"
+description = "Evaluating Goldbach function with Numba and plotting it with Datashader"
+no_data_ingestion = true
+
+[dependencies]
+python = "3.9.*"
+notebook = "*"
+colorcet = "*"
+datashader = ">=0.12"
+matplotlib = "3.5.*"
+numba = "*"
+numpy = "*"
+pandas = "*"
+sympy = "*"
+pip = "*"
+setuptools = "*"
+wheel = "*"
+
+[target.osx-64.dependencies]
+libgfortran = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks]
+notebook = "jupyter notebook goldbach_comet.ipynb"

--- a/gull_tracking/pixi.lock
+++ b/gull_tracking/pixi.lock
@@ -1,0 +1,8112 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.16.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.3.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.59.1-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2024.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.16.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.3.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.59.1-py311hdb55bb0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.16.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.3.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.59.1-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.5.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.16.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.3.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.59.1-py311hf62ec03_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+  sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
+  md5: 613805add1c05b538ff06d217252feb7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 20810
+  timestamp: 1652859733309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+  sha256: 250f50edf43a786a32942e9ae67ce807e9b3ac4cb6b58b1170cb541fb24e391f
+  md5: b48058294499d292ddf9a3b966dc9cc5
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 228473
+  timestamp: 1706220559474
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+  sha256: 0d4f5274503916e1c683dcc16e8a7c4186557afa3f62399cd628e4eb535fe77a
+  md5: 062acdb0f9ae976c25c2d15d589dc1d6
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 35809
+  timestamp: 1676823571351
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+  sha256: 567dfdd5b986012421a736a5f1c1d5874d8d691dd483c838b55e1ab06c0b217d
+  md5: 4e0aa1543f546b898523382ee8405e84
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 152577
+  timestamp: 1695717917074
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+  sha256: 894fceb5b4f8740bcd146de8bd0f6eabf14e2407b149b790b4983b8432681e6b
+  md5: 2f0ef211bf628cd22bbfa44c3f9bc035
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 271600
+  timestamp: 1681493103694
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
+  sha256: 9f027f156744dcbf28945aad6e422ef030c84c2a5d40116d3e40407c66853bf8
+  md5: 7b52489e04f9a5585643d5578835fc68
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6059952
+  timestamp: 1712084450899
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+  sha256: 8e2b2073ff5c61d35714e8a36ce657a8ac741b7bedc2852a238c7f1625142705
+  md5: d951ab54a682b6328327fec53b1e5e72
+  depends:
+  - libgcc-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 147642
+  timestamp: 1707864274452
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 5d15605858771290fdaaae41a43941623757a25cb1292080d69d6d3857807935
+  md5: 7f517469aa5380c52e55db9f37df104f
+  depends:
+  - brotli-bin 1.0.9 h5eee18b_8
+  - libbrotlidec 1.0.9 h5eee18b_8
+  - libbrotlienc 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 18652
+  timestamp: 1714483267080
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+  sha256: a5094f078584e27c7cced4a9564ae904a329f5c1702a7c1ba092d581ba1544f1
+  md5: 6ddf45dd8a21a9512481de9bc0e5a03f
+  depends:
+  - libbrotlidec 1.0.9 h5eee18b_8
+  - libbrotlienc 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 19711
+  timestamp: 1714483255915
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+  sha256: 93180c973816246f068b742d0bf64840f0ea48e31d4f9b0747ea2ffc34d8855d
+  md5: f3a00096965a5ba1eb41d2c99a4662a2
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 361574
+  timestamp: 1714483400014
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+  sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
+  md5: f5058c8d5b2994b7334f18e022105a14
+  depends:
+  - libgcc-ng >=11.2.0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 427542
+  timestamp: 1714510571510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+  sha256: 394f74202c2efc8fcfd02b8953f508eb6a2961d224a2f9d15091caf5cbe1be67
+  md5: 1202b4ed32215c6405bb42fbff355316
+  license: MPL-2.0
+  license_family: Other
+  size: 137411
+  timestamp: 1710764808838
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+  sha256: 6dc29d20180f6e002f37b251efa639716d3444e129a754dabf751f816aada7ef
+  md5: 5dbfa083e6ab6318fac58fe0e0c94445
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 165152
+  timestamp: 1707229213375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+  sha256: d138cc3fde270eba783baf1e2ba17c89800b2cbbf20976d0eb425b3436a4a184
+  md5: 1875e89c1a939e4e7c5e7b731c72b838
+  depends:
+  - libffi >=3.4,<3.5
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 302401
+  timestamp: 1714483186060
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+  sha256: 9ddbf05887c7d7926418520cc7848e57f6d2431bc4ec6d30e090b02dbf865041
+  md5: 57ae1141ad9a048fb2a75d7a3ef7430a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203190
+  timestamp: 1698129926216
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
+  sha256: a5beda842876d0d71598cd2a50ced5fb2731539bc4172fe501b93b60e0c6cd3f
+  md5: d5293e5fe74a4e0d71bbf14c9a57f900
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49509
+  timestamp: 1683040113536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+  sha256: d9c102b9ec7f3a635936b6f73d4db126d748a25f65407353bd76b260dc7d1cd6
+  md5: eec48dbdf5dac0ea26750cc26b58c1d9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 554986
+  timestamp: 1709758392744
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+  sha256: 882481e441b9b93cbdfb32fbe32a6ad9f26197472f186a08fddb921f61346c02
+  md5: 443c79196064f57c98199e9990544b2f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16902
+  timestamp: 1709322958614
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+  sha256: e4877b41553e31b9f9f090dffab77a654255c63776e8b30fc91ec1f60afadbf1
+  md5: c34d3f1520f1e8c9957eb236710058c4
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281162
+  timestamp: 1700583651472
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.5.0-py311h06a4308_0.tar.bz2
+  sha256: d7c1822466ff522e14771be1a4234a7e80da0a70fbae0b56422c419eb74fea2d
+  md5: 4ac1601f900babedf8edf35bd98d2ec7
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3104830
+  timestamp: 1715838694654
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.16.0-py311h06a4308_0.tar.bz2
+  sha256: 309e8323cc5e7506a2be851649d36be0b6a0e157194baf6ee4fc900a1b43fddd
+  md5: c938e7730d42d87dba1658a8893d6338
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy <2.0a0
+  - pandas <3.0.0
+  - param
+  - pillow
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18004747
+  timestamp: 1699543167034
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+  sha256: 3b4cd8dc60572086f1a1cbb97e2712e0ffd55317ce8f0309d552eee7367855eb
+  md5: 70a1263b6e19bf2d77c020a2e77277c9
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2556575
+  timestamp: 1690905285843
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+  sha256: 4b589e3265c74159130230c164ff2d8d381be65899a249def0b53f93ce83fd47
+  md5: 245cb7173dcdba21cf368031cd87f706
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17434
+  timestamp: 1676823330845
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+  sha256: b75d12e85274660bb675a3e53d47a929872f2daa2ff5a76e98885ee3f2d19ad1
+  md5: f2119d0885334060d0d7fe59e5220287
+  depends:
+  - brotli >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - fs >=2.2.0,<3
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  - zopfli >=0.1.4
+  - lz4 >=1.7.4.2
+  license: MIT
+  license_family: MIT
+  size: 3237908
+  timestamp: 1713551660998
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+  sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
+  md5: a5dc8677d891dff2393b63189a3ad42f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 971975
+  timestamp: 1666798278693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.3.1-py311h06a4308_0.tar.bz2
+  sha256: a78f34d0b919c5fce722d33afc278cd48f5eec2bf186c35dd18d59d85d45909b
+  md5: 199586a3dcad8985bc4cb0e4262e06d1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 364478
+  timestamp: 1714461584790
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
+  sha256: f48ccfb4214e2af41e73a3904e343ecd1eb1ae06578c26f55a5dd247771b2c86
+  md5: d58e9eb09817935eb7342ceff889f481
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5335524
+  timestamp: 1707836581350
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+  sha256: a0ae6c5a6b615d73d9a243331f3f7d749b4feafdf2f334337fda8abd6c8355ed
+  md5: e61d8dcd4dfd6d165e6e480cee846bf5
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 357992
+  timestamp: 1715090462763
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+  sha256: e08e27531775de40f46b6ac7bf71856963baa0c008bd2b4d112e6341cd3e8f4c
+  md5: bfc7682613c861cbcb4ac01485c05657
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147174
+  timestamp: 1714398938840
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+  sha256: c7ffa6006573483a05ef355770c3201f04dd04ab4b91ae01971a6cdc7fbdba35
+  md5: 23d7d38e93d930ea5e2cc5f4079d3816
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 49872
+  timestamp: 1704813633807
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+  sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
+  md5: 3add2ce56858a1b8f6a37342f82773d3
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<1.2.14
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 19310769
+  timestamp: 1699647799237
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+  sha256: 0b670ab17ed2e1b592079bd64386dadc249ddc892e5ae1dd99f142a918ffc75d
+  md5: 632575b9e442c1e5c146cf78424da610
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 227791
+  timestamp: 1705934138566
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+  sha256: 65228eb868c3ec8aa71f958e60a675a919f016c2057392e02fd422fc841858f9
+  md5: 68e23f14cd222c233e6b37262bc61c23
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1612840
+  timestamp: 1704833066871
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+  sha256: a2918ea8a3e2c56fc6d91191e84b2f35500c392b16ab687a0c03ded2e2e51239
+  md5: 84fadd6b7fef393cccc0d123dae6cae8
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1162207
+  timestamp: 1679336523618
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
+  sha256: 4520b83e425883981f97191986a08122fbaebc3f16b898368796314136779028
+  md5: 42a8f32c4d842d3e5410b2bc1cc2fb57
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 352284
+  timestamp: 1706733655761
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+  sha256: c21f8f407266d039e819c27fe9eb4fb26587e974f3bd059b37cbaec5073722d0
+  md5: ba1f47411e9e07876c7a3e9d3be6a98e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: IJG
+  license_family: Other
+  size: 281400
+  timestamp: 1677849152168
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+  sha256: 06b729aee6dd2a1e545f3ad64179cc0d4ef8a15e33db3be2995dd3e0868465ca
+  md5: 8bb3215912588e47e2eeb4e7a09ad64f
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 180858
+  timestamp: 1699041715847
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+  sha256: 9e3bac2d41bd432b721b009e7de981766fba396e6f238e923f304112bd88655a
+  md5: 84ae4cf3f2d01fbebdac374971192be9
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 15525
+  timestamp: 1699032521315
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+  sha256: 79ce6dff3d93649a2555b1d2a4ae9eb77175a1c00664cb8eb0e6f848d5cdd1b9
+  md5: db395b0efd7018fcf3a4af879170c2a8
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 276856
+  timestamp: 1676823504812
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+  sha256: fedc7e5560252af44b0dfbe6f7acfe20ab17a6a08e758f670a1cd820551afc7a
+  md5: bd28d36963087f53a79b23fee697d665
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 93898
+  timestamp: 1698937453304
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+  sha256: 2b896fe8b2187b7df824041826e14379476eb2e61d607d8cb38ac2b3df40aaa4
+  md5: 8fc7e517da96c2c482331f6b08d07a17
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41459
+  timestamp: 1699282616532
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+  sha256: 87d372f5b23bcc2410e43b40b4ad059ea1625178b8a2b484fc63805ce517e594
+  md5: 50204f372b1672871d6ab3db6a876374
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 594177
+  timestamp: 1699467208489
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+  sha256: ddfee06ba9b149222c65d1d4270272840533aa63b56fe36363c84a891c71d328
+  md5: ee128e5c0d8d9e1952e2387b66a5b8cb
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27239
+  timestamp: 1686870958829
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+  sha256: 0c6a074272ed58677ec17e4dbfceaffd2108841a61af92b32f156c5763108d1d
+  md5: dd3d37841d0d20c70a60e8c939923894
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19144
+  timestamp: 1700168632051
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+  sha256: b040f0d0ee4588188ab6b83a93738b3ff6e6d1775424be97995bd0df0f4fb904
+  md5: eae62735d710cf5ff6d51e6f59fcd999
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78148
+  timestamp: 1676827253282
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+  sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
+  md5: 88199c75f2ac211728febced7785c24e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 228278
+  timestamp: 1635523146417
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+  sha256: bb990ea068c3b3dafd9c807e0e19570320cb2fe7d69cc326f1f0b5319b0654b2
+  md5: 3ff70744e396b1af69656c574b05c3b9
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 66940
+  timestamp: 1714483221853
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 3b87a816f72a00e1f0022a160e7eda70af89d3de2a2e08a72be1c17b31d759f3
+  md5: 4f57d3a0a13ddaf1c06efb586b702f46
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 34446
+  timestamp: 1714483232430
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 2cf15e89f910600f468edfde8d0f9b80a14fa2319ed89160dc7375dfd3764fdb
+  md5: 463adc13f2feea3570d1eccac368d9e4
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 295090
+  timestamp: 1714483244460
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+  sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
+  md5: 55dde57e63a36b202e388a39dcee9a66
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 74096
+  timestamp: 1695996494461
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+  sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
+  md5: 1af9b4d62c708924417f2640ef22a68f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 154016
+  timestamp: 1714483282916
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
+  md5: 641e72e5067bd6d5454405879e1cd2a7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - _libgcc_mutex * main
+  - __glibc >=2.17
+  constrains:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - libgomp 11.2.0 h1234567_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 8895144
+  timestamp: 1654090827491
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+  sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
+  md5: 27082517590f3b9fbffecc68513b461b
+  depends:
+  - libgfortran5 11.2.0.*
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 19860
+  timestamp: 1654090819660
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+  sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
+  md5: 0202c3c8ae4735cac6c7f3d1e1685964
+  constrains:
+  - libgfortran-ng 11.2.0 *_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 5228750
+  timestamp: 1654090762569
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+  sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
+  md5: 3080c2813e6e1d0f8a100a38b5b3456d
+  depends:
+  - _libgcc_mutex 0.1 main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 573231
+  timestamp: 1654090775721
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+  sha256: 512fac06ddd97b4383503d4fbd8145102966055b29ccf86841a930dbb4ef3ab8
+  md5: 833c0e514ff9c8ae0511630b024d60e0
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 37179832
+  timestamp: 1683292829131
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+  sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
+  md5: 1bffe1481ed4f88827248fb9001f8923
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 362561
+  timestamp: 1677841789536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
+  md5: 8c195584a5f5471b600ee180e4052773
+  depends:
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 6410287
+  timestamp: 1654090800863
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+  sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
+  md5: ef78eebd98289aceacdfa29182426adf
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 664034
+  timestamp: 1693575237924
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+  sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
+  md5: 292768ec77416ae257cfdd44ea2071c8
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29197
+  timestamp: 1668082729834
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+  sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
+  md5: 9cdeef1d044c7e035c006890f11569d3
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 436056
+  timestamp: 1694776944891
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+  sha256: fd8e30beb8c9442f16e6617fac92dd0c89ec823e98f06e60f712147380ead35f
+  md5: 7ed7caf2816c8b85b67b6f4e8833cbd5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41155
+  timestamp: 1676837080881
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
+  sha256: 05e355127db0d3ed67c4c383fd929ef1c3d7d3f19472f6e5433a866e94378bed
+  md5: b7897895622e5ab6e62279f07fa1f587
+  depends:
+  - libgcc-ng >=11.2.0
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4367002
+  timestamp: 1706910875807
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+  sha256: 95fe76d2691feb13203b55ad2aba535bb848cae21ffd05b13ff51c7a45fa2332
+  md5: 6a04ec16e3abc1c7e2104be32cd6c418
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13458
+  timestamp: 1676827287432
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+  sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
+  md5: 76f089e76ec67583bb38428b51008097
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 164494
+  timestamp: 1714510587156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+  sha256: 260e26dd509834c1b225ab7bdb97b9a86e00054fbdd5dfa49e68fa4dcf85a661
+  md5: 8f5d7ddc69cc6f7d44c80d2251dea5d1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162339
+  timestamp: 1676837095436
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+  sha256: 7f5b0804d0768619b7bd93b10488067d80bf42ec29f443f00b53ba11758a1241
+  md5: 8afb45e45c0d93bfd142e682d4b021ef
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 134438
+  timestamp: 1684280014220
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+  sha256: cb03570c99c983d7bfda94bc47d8eb00d4059b8548a171130775acc998004195
+  md5: 5b1abbbf1e4f9b350b16fc9caf9e889b
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26919
+  timestamp: 1704206397615
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+  sha256: 85fea48bea278a77d102781a1cbb6bf69307207d741251e38a6515c5fd7e3523
+  md5: d6ddba94f7c33c88c9825be8409991bf
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9150942
+  timestamp: 1713336680714
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+  sha256: 7ac07ea180b5928086075900afbc332fb1d3c81ddfacb54c891693c284056f14
+  md5: fc83dd1b3d2ec3c0a297ead0c3405907
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19573
+  timestamp: 1676823852670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+  sha256: c9ba2f9c83820712dd97d6a1b54a1215b9820a0be02ac82380b4c50911b9400c
+  md5: e5dc6b4a5b8e02733ce3bc9e9198a8d2
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67750
+  timestamp: 1676837123613
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+  sha256: 1a5141ef0de1cbff816f96bb4b212a40606e2fc11301a4c1358c8d63a6b2b027
+  md5: 22ac3bc22b68fef4c1f3f6ab3c7bfe0b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23040
+  timestamp: 1676827301164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+  sha256: 9aacfbbe6f638c58a4e8ff31374d1438d78b7db25d6ea6fd0c50ca2109f225d4
+  md5: e602057e3b3d80da88c61d66e8851c5b
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104681
+  timestamp: 1676823696152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+  sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
+  md5: ce77d0f05f846da4a6b9e23fe7f21d9b
+  depends:
+  - intel-openmp 2023.*
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - tbb 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 206738176
+  timestamp: 1699648006088
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+  sha256: 2aef0876d0df033f7fae8cddbd25d95fc1bfc067e60dd143bd8000fec0768b21
+  md5: d6cdc670327bd1675bbea642849f04e1
+  depends:
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59569
+  timestamp: 1682948560323
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+  sha256: 691c4b2b47cf3fac55b4949d7c0f547246ef19cb3510749142cee4bd01ffb055
+  md5: bbd69efa3f24ee747410f83118640d92
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 240723
+  timestamp: 1695058405382
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+  sha256: 71f5c7beca4e81b465ecfc6ed51cb3d39f51dd88df0b29eff5def3d1f12969eb
+  md5: 61d58663b7277cf4cc3cb8d9873d3ee8
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331105
+  timestamp: 1695059935112
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+  sha256: b558b3f6c144652b5e0d26497b3ce24c318a6b9ff8ea2079113c95e5553b3cf9
+  md5: 0b185969ac2b065c27cbcc9641d93678
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29568
+  timestamp: 1676841232463
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
+  sha256: 20d832ce714465ae1685d29e2f913fd105d385d003fe1bef71ef472e6f3489e6
+  md5: ad76299b0c33b7a5c0d45905271165c1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8303422
+  timestamp: 1699542957307
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+  sha256: bb45fb0a3973caa74fd8f845e0a519895f6a378807626e15ecf72c02f2eed794
+  md5: 185f658ba8a74e326b7231c8fd0d62bf
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 121834
+  timestamp: 1698934274227
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+  sha256: 8b2fc372a6655fd5b277d07b994ce43643553fbc37e63a60e9fe527a9026ec06
+  md5: ed6ac14aed5a796b153d757862398997
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 523905
+  timestamp: 1699022906468
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+  sha256: 7908ff6c516b15e8fb677be4071145e18adea7d4c13b8485a70a5ee2f573f8cb
+  md5: 50c0e38207a131a5de6a14ef919ffcdc
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 169629
+  timestamp: 1694616826002
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+  sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
+  md5: 57ea097dc15f8d9f9eb90e1d919143b0
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1157733
+  timestamp: 1674734069410
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+  sha256: 266199dd4efde0ad342a9c500f4bc4299c5622219aea623b46315a9b4f6b8959
+  md5: 2b21844d2b0024d0ffad0e6450cf0855
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 15860
+  timestamp: 1708532713870
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
+  sha256: 13d6c640710895e9732225cdedbe47fcd756887fffeb0cf9bc149ee7234dfc27
+  md5: a87d55e3d071f2c435b10db49a9911af
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 730963
+  timestamp: 1690984942516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+  sha256: ef2857e6d3d7eb246b3abddfbd3aa2d124dd8565391ace3876b77339babc50bb
+  md5: d276d1b1774107987963135c78ca7390
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26607
+  timestamp: 1699455972519
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.59.1-py311ha02d727_0.tar.bz2
+  sha256: 1b830d1d091462cff92de55f24339365a9d2c23b27d19799833b4780efe99c15
+  md5: 06367b04f8f04c0dc4e356a2ca9dc854
+  depends:
+  - _openmp_mutex >=5.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - llvmlite >=0.42.0,<0.43.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  - libgomp
+  constrains:
+  - scipy >=1.0
+  - cudatoolkit >=10.2
+  - cuda-python >=11.6
+  - tbb >=2021.6,<2022
+  - libopenblas !=0.3.6
+  - numba-rvsdg 0.0.*
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6084284
+  timestamp: 1711988494237
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+  sha256: 2f89f38a665ece47e8868b391fc70602fcee588e989bc1ca6f17f6094892a94e
+  md5: b788c80b2d571531ea4f3f8335ae5423
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 168827
+  timestamp: 1696515597877
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+  sha256: e09e1aff2c12d4ef3fec58fb627744e4b5c7d9eaede7175e293f77272d8b8bfd
+  md5: fe8242cfd54d238507493612ae697ad4
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311hf175353_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10270
+  timestamp: 1708639794640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+  sha256: a53ad723826651041a5057a1cf31bc8689b24d335ce61b196df5124974b05a8e
+  md5: 7b29e7191c4170189d6080e61229f030
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311h08b1b3b_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9163911
+  timestamp: 1708639777712
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+  sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
+  md5: b0afe23033c8c5344640bc25225fa579
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 516994
+  timestamp: 1630084830020
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
+  sha256: 6c7cb4097e4f3655b54a119304e50f0edbc4bd52f36c84629b64674cf8d468b8
+  md5: f1e48c973646ded3c2e1a189a9d8b8c9
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 5498991
+  timestamp: 1716318104769
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+  sha256: 280225061aeba00d7b85f46e55d7d79cd92c92f662dc749d9c53187978e8d083
+  md5: c51c21da68080d89300703ad818c824a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38606
+  timestamp: 1699371264464
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+  sha256: bd3eacd22e85f88bedd9c7e97a59eacfb3c8bb80eb59be244825d6895a0e7ac1
+  md5: 08ceb294ba8a9ae13630da789884736e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 157904
+  timestamp: 1710807470578
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
+  sha256: a2ee3a6aaf54929b82b851b2eb5436e14e5a294303ef429d6dccd33bcdfc8002
+  md5: b467a5c7ad672ccc2d498a67b9eeeaaa
+  depends:
+  - bottleneck >=1.3.6
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - fsspec >=2022.11.0
+  - matplotlib-base >=3.6.3
+  - tabulate >=0.9.0
+  - odfpy>=1.4.1
+  - pyreadstat >=1.2.0
+  - pyarrow >=10.0.1
+  - python-calamine >=0.1.7
+  - s3fs >=2022.11.0
+  - beautifulsoup4 >=4.11.2
+  - gcsfs >=2022.11.0
+  - xlrd >=2.0.1
+  - dataframe-api-compat >=0.1.7
+  - pyqt >=5.15.9
+  - adbc-driver-postgresql >=0.8.0
+  - fastparquet >=2022.12.0
+  - psycopg2 >=2.9.6
+  - qtpy >=2.3.0
+  - openpyxl >=3.1.0
+  - xarray >=2022.12.0
+  - html5lib >=1.1
+  - jinja2 >=3.1.2
+  - pyxlsb >=1.0.10
+  - sqlalchemy >=2.0.0
+  - zstandard >=0.19.0
+  - pymysql >=1.0.2
+  - pandas-gbq >=0.19.0
+  - lxml >=4.9.2
+  - numba >=0.56.4
+  - xlsxwriter >=3.0.5
+  - blosc >=1.21.3
+  - adbc-driver-sqlite >=0.8.0
+  - pytables >=3.8.0
+  - scipy >=1.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17970687
+  timestamp: 1709593080388
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
+  sha256: aa05415302a27a82105e9d0800151f09fd1bb896b90854dc23989f9aecd9200b
+  md5: 4974b1ae5f1a3b6d9fb26e7eb2c26733
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.0.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21869200
+  timestamp: 1714071532259
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
+  sha256: c6c782537b96ab9caf3e25f5a33799c727e84664cdbab37a8d3359a221e2d2e3
+  md5: 8f56d0f63e0589dd7e4a004678307813
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 263438
+  timestamp: 1711136934516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+  sha256: a2e2beff710765f2e5135020121da4f227f5e1cbe142e17398a585f50a389d37
+  md5: eaf734d49b6e576e12be1398a295643a
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - pandas >=0.19.0
+  - numpy >= 1.9.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 47447
+  timestamp: 1698702703255
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+  sha256: 28ed719669260a20bec78971edaffb91ec917d2a3f0fac1cf9a8ba21590baa43
+  md5: 0481d078fcd64f7f981532a514d9d50d
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 960727
+  timestamp: 1714399060039
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
+  sha256: d527189038b376a982c18613df808f25dc40314b0dc8fe5549f3ae9f4288e497
+  md5: 68dad015e796cc26364b55f92f61faa7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3451714
+  timestamp: 1715097126399
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+  sha256: d2bbab8bfc57c7f46ca8994bc87df7e744d3f036b867bc4be1145ba6d8d7e091
+  md5: de41707272a8e3ccab764f0b7010a27d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37394
+  timestamp: 1692205565974
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+  sha256: e2a0e2a618aa33f0beff9583c7dc510b8d0737b023117346676aacbad33970d8
+  md5: 66a6818307261b1a28ab12d1b7776fdf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 121454
+  timestamp: 1679340540306
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+  sha256: b7f591c19b10bf0daa7e6e3b45a9f4a0a0e83188e1f8a58037caea79e60f8d91
+  md5: d945b4ccc135005839c504cc29df1745
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 749608
+  timestamp: 1704404477511
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+  sha256: 96482b49191fdac59580a95e69508367083e1f7600145e11d7c2db634337eb26
+  md5: 2d57bf8eacf3f291db845928241f724c
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 490805
+  timestamp: 1679337420563
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+  sha256: eb75b4417565d25e2d1006db75aa8bd9da6b6c72a929954b01a31b9bf5f8b42e
+  md5: bb56c0358b65665f4dd509a4635f6f3c
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37802
+  timestamp: 1676838557935
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+  sha256: ed927e4d058a8f4ea73edc7a43ed74877d93b88fdfa240b3b2777244386ced70
+  md5: a1f0e05fc7e49712f81ad5478ec9d51e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2121496
+  timestamp: 1684280065800
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+  sha256: ad219924e362ce7af458fa6547660181579e9a50e5aed1ffd9268cbe7c2650e3
+  md5: 2b1ac40e0df3673d33b7f4c4f93ae1ef
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207338
+  timestamp: 1677811584327
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+  sha256: 114b55e00f4622c90fd2b404b21ad5f94a10283fcaaf86a42174b8d39b0a3e98
+  md5: 2458e92683cc68671a6c8e1b86ce8817
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35850
+  timestamp: 1676822725516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
+  sha256: ef622eb34669f3518d2f855cb333c56b106d02cdeac9d58e5a1a5a3097e4978d
+  md5: 9d4f211d050d511b0b84c2e57e7fb1d7
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.35.1
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 36072860
+  timestamp: 1713546307595
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+  sha256: a0f008717fab060ccd003dfebc09156d90b9afd14ac3626566aa1a8f3d3b7e2f
+  md5: 357bf4fe94496cbae72ab4d780184b31
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 330924
+  timestamp: 1716495762901
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+  sha256: aadc4078311c059265706a56265f0a57ceb538d36179d5203dd487d80d0e8f16
+  md5: 59ec670fcd172447dbd9591b8fbfdd56
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 278741
+  timestamp: 1679340144625
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+  sha256: d5058d0ecc3973316c1d5f1bfb03dd119e0dade85f4c2d21b412c8db4e1636f2
+  md5: 93000e4d3603342779a2afda66fa91b8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17607
+  timestamp: 1683823841946
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+  sha256: b85acb933fff864bfa89d034e8e3d85b1a9c2e69cbfc0d68c1d66ffd1443e67d
+  md5: 0cdb92d2d684ee1095310f992ed0d9b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 266796
+  timestamp: 1713974338678
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+  sha256: 511e8206a15445715b80be76493300930686b3fe1e512ae942d6ccca36df392a
+  md5: 35a6e46ae970f8b71d78fb5a810f2e80
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64013
+  timestamp: 1711136926372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+  sha256: b2a1f649669f4336b74f6f20df711959bcd8024f8f8b94199dc0e040b06bd37a
+  md5: f9e8e3f7068f717f75e555dc04545d8d
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 206433
+  timestamp: 1698096204677
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+  sha256: 7c74db4292f31619606180f86f3c1e2d913495c2c9d1195c5d51681a6a841625
+  md5: be1c05fae57d194924b9400f9b5ad3c6
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 613277
+  timestamp: 1709318516682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+  sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
+  md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 467661
+  timestamp: 1666648052561
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+  sha256: 89c2f4235277b9825cc805c5c44f0b1afcb683d7b5a3f513bc4bf243b643bb0c
+  md5: db70eb57e33adf7b8bbdadd72214d48d
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 73679
+  timestamp: 1699012111499
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
+  sha256: 684037527327839d734e7eac2ee09ef5ddb4f77df22daf40c79e51db29d09543
+  md5: 57c5bcb9eae9f1d93ccfd38025660de2
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 119414
+  timestamp: 1707355661872
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+  sha256: fdae3f68ea84b99561aee6c566ab1c287d8f2ae2668424e9283a8ed86af8f1d2
+  md5: cde5b71ccbb3630053340b2c8c7dbf10
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9333
+  timestamp: 1683077183576
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+  sha256: 0bf859b06a07857099fd4f524fe5e0875fda70029e9485d95c7efa97134fbc14
+  md5: fd5815cc592fdbd4c831901541eadaba
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 9735
+  timestamp: 1683059096795
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+  sha256: 474553d01aea57214a54a7443f227da84a58e29c49eb7605ba0043c55b7d167a
+  md5: f01333e9f0a908e435db650f42fbd2db
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1096668
+  timestamp: 1698946168635
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
+  sha256: b06b45da61807f76b6d800047f123fee2cc95eb84da508550e0908951c8d9f6f
+  md5: 9b100efb9ba2fc7f9bcfaa8fd2ab6f9f
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libgfortran-ng
+  - libgfortran5 >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 4
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 27615256
+  timestamp: 1714076660659
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+  sha256: 51bcea0e575a626f6ffbd16d1153330fda93dbe3dd31dcd3a8f469ff61dd1e4e
+  md5: 41d531c90be8c82bf79635ff3d409476
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 32295
+  timestamp: 1699371262818
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+  sha256: 0a95988ea269c96354626dcab255b65b54bb5c503d24cdeb6ef2e1c42818bd59
+  md5: 8bfb9f42492b3b53b8151d77e51c75d8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1594974
+  timestamp: 1715024182643
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+  sha256: 1a84b00944bc5588e14a097460175f97df49acb4f1ff2498ffd9a1893068ed81
+  md5: a456513471b2ecbed60430c21dd1ccc7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17880
+  timestamp: 1705431390054
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+  sha256: adcafd297d60af64107c113bb7b8b92160d0268a44ef9a3b79e56a88a0358ea7
+  md5: 28ed704ed26b06d32662e3a6a87e59b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 88799
+  timestamp: 1696347581401
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+  sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
+  md5: f86119b3243fe3508160aa0406245738
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1723866
+  timestamp: 1714488309729
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+  sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
+  md5: 041a3caf09dc9ce8fc6c10925c4fe050
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1888016
+  timestamp: 1680167274961
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+  sha256: 856a8ab8c350c50247b79966c6cb80fb6d4de36eef49ddf75aebbbcaf854c82d
+  md5: 442dde204d14d171aab9ee40e8de4de8
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37456
+  timestamp: 1677696176157
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+  sha256: f0a026ddc0ed041bfc60c8a1ca0b70b7a69232775b3181bfb35a39fda42d6994
+  md5: 2902d5a5854865baaaf58dc59cf06b3c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49185
+  timestamp: 1676823769869
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+  sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
+  md5: e2512d57c8a1e91e7b20e265c6906546
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3588922
+  timestamp: 1714770676475
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+  sha256: e58ff4a82819446f3c92e5b1aa2a784c4b06643e751fe67cf115858296dbfa50
+  md5: 32ee4723173f1fad5563b8afb5f1c8f1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135634
+  timestamp: 1676827536101
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+  sha256: 1bf522ade750cf0b70d61e71916ff00569e2908db1e9dedb223fda2608ed8bde
+  md5: 6793c74fe94211c0bfe6766c6dd490af
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 893808
+  timestamp: 1696937055591
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
+  sha256: 54f41afbea1c01a10e5703e64645de145f34ad6d89cf245fbc5cfaaff58a8743
+  md5: 15b6c8bee4c28c6efb3e388178b37145
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 154276
+  timestamp: 1716395957568
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+  sha256: 0575785f6553e61cc6138abfd5de52305fac6f85971642fa1f056a76c66a52b2
+  md5: f2c25e5dfdd23f70b83776a8832893cf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270865
+  timestamp: 1676823316868
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+  sha256: 8c06c291c76e8c2022ffbb9fea4727a4bf1f9b03e498bafc56ba8ac4e7604ab9
+  md5: 5adb7baf1091d09026a372cac930ce6c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8869
+  timestamp: 1715268966416
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+  sha256: 118b0801167264c401e84bbf19175546092a5569cc098146f7362bbf890dc8d9
+  md5: b3c2aa56d53b459f8365d8385f48d0c3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 74489
+  timestamp: 1715268960737
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+  sha256: 509b962773f0fe44a93a7f6196b254670a030eac8ea7f90727312e3ccd9294b2
+  md5: 6c402d5bf4e01c8c3895c9ef41707b6e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11371
+  timestamp: 1676828901104
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+  sha256: bbe7629e8ce52c82f13ed0d1fb919f3659ef466b274a7c74aa925a9bc7aee450
+  md5: 7da527bbcf71270c1abed8ea52e7d44c
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 509031
+  timestamp: 1713213062098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
+  sha256: 5c6afad310db12b3658a652efc5de45c182164a0b537cb2cdae5885428b30d22
+  md5: 89ea2fed160a633e0a6d152b61cb0dd2
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - zstandard >=0.18.0
+  - requests >=2.26.0
+  - selenium >=4.4.3
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 209068
+  timestamp: 1715635972793
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+  sha256: c3a5e0b855dc2de6c162708dfcf170a23eb9e7525d4252d8dce553369af4a330
+  md5: a4c77e204b7787f820955166a1283168
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25890
+  timestamp: 1676823132898
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+  sha256: 42989f9970a8466cc4edb73463dfa194594dd1a5d42c9f820a1f86296d4af140
+  md5: 655dfd4d2f17977cb81caa1c082d2b25
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 113505
+  timestamp: 1715878346465
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+  sha256: eec0d2e0bce4b62278cacd7b0bee053160845e86507051a5434d2069bd290f36
+  md5: a069e5aef64a6dac076cc9a3d28a17c9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 136022
+  timestamp: 1714717059748
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+  sha256: 85248e503721da67797546cb8a22e303c1739100834b219c5621f216e3794e8d
+  md5: 2570956643f22d0f809b2467e02d3984
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2465865
+  timestamp: 1689041600364
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+  sha256: d18cdca154bf668826f869117ea996c4f9e8ef7d27b7c528332a7d17e5a8602c
+  md5: 9f7353d72046b16dd6ef6b5689ac9bfd
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54731
+  timestamp: 1676828934954
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+  sha256: 9122d6e9dabb7a47f2bcb15d86b97c96c49a9048da3f8ae59675351710c14cc5
+  md5: 660b2aead2ec87b751c86cd33934f44e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 716926
+  timestamp: 1714510796277
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+  sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
+  md5: 943f1247a22b6b64171363bcee1eec27
+  depends:
+  - libgcc-ng >=11.2.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=11.2.0
+  license: MPL-2.0
+  license_family: Other
+  size: 371663
+  timestamp: 1705602144682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
+  sha256: 7aa781d0850f97622755ed44772d2b215b253a8e211aede5f3f53e1b95b4143a
+  md5: b1d8823f50228d4efb7b7a6e267ed776
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 24333
+  timestamp: 1704207043644
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+  sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
+  md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Zlib
+  license_family: Other
+  size: 127143
+  timestamp: 1714510716441
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+  sha256: af3c032f06352e87c450739cb8aafe1ff34ad28bf074b214ea98b3d29259a85d
+  md5: 51fa34bd0e016ed7c5371cf6cb13ef6c
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1044463
+  timestamp: 1714678445052
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
+  md5: 544adf2677c47c9b9c891aea720678f1
+  depends:
+  - python >=3.5
+  license: MIT
+  size: 33999
+  timestamp: 1630003259346
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+  sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
+  md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
+  depends:
+  - prompt-toolkit >=3.0.43,<3.0.44.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5106
+  timestamp: 1704404390460
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+  sha256: 459f38609d854888998a8d76028019dbacdce2bfe401eab57b8eb8ff16da9c7f
+  md5: 2948a98ef4de5decb7e5eb888eae68ba
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13056
+  timestamp: 1682965564630
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
+  sha256: 305e5fd9993f3e5506f386f98794c7d53b6e6c68d4d411ada724de49a17945fa
+  md5: e1fbbd2d11d21aaec3c32f7d332c0e77
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13818
+  timestamp: 1712163766707
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+  sha256: dc9f709bacbaf08a0941d2622d82f91f18b355e82c55348ec29f1391215ca7e0
+  md5: ece0f5837a4de2d4d5f1abf8347cd10a
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 124922
+  timestamp: 1708711884650
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+  sha256: 5800a2466734dd1ef372bec0dd3f0880c5072fa1e8b0668f5054f834285e991c
+  md5: 18194e51d4420ac08f29f3f86581b52e
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 229003
+  timestamp: 1706220302459
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+  sha256: ab7672364f1fa55ec5d8311d85d40e5b57cbd3517b17670557b6fb822bcf759c
+  md5: 6e0159a5865cb7e96a748bd8560035ee
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 11579
+  timestamp: 1678317458652
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+  sha256: 51556902e09436d46878ef772805d06416ca96ffaa66340b5565c0245574aaf5
+  md5: 4cb1b20635cf5431d34cc96ca1e8a751
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 33355
+  timestamp: 1678317111825
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: 188b74f717e3ce3595da404c0e027b8ccafa9c186e88325e8f02c29d7b4c0744
+  md5: 04ad90eead5812a0263b42321056ab33
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153694
+  timestamp: 1695717975427
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+  sha256: bf3c60386619f08cf5105b4b903bbc109b3252c3b923fe055aa445908a01969c
+  md5: 3f84a301921ec6400b7f1f1c4ba3260d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 270017
+  timestamp: 1681493109562
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
+  sha256: 126ae8e30b8464fb2dc94ce9163dcb2d5482f7214c7d8a48340c3f09f1409d5e
+  md5: d5e0c054042910b4394a14c7eb4d8131
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6080356
+  timestamp: 1712084675745
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+  sha256: 9acafafcaebd653c2372ddc864525722e1c55b884b5eba22e28e2b2d946b853c
+  md5: 22375cc3c2edada31b85af56c8e6dee6
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 155829
+  timestamp: 1707864406086
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: d8b1ccb15297dcfb3f9ebb8139c3e28a13d6c2e73c37612cb214ab6cc58b15fa
+  md5: e5dec9f13de061640ad2697562a99b54
+  depends:
+  - brotli-bin 1.0.9 h6c40b1e_8
+  - libbrotlidec 1.0.9 h6c40b1e_8
+  - libbrotlienc 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 19732
+  timestamp: 1714483415038
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: e9fda4393edd0234c88efc2b88e0edf42c94eb49ea5b189a80afd733058be8fb
+  md5: 13ceed558eb174d6b77ed1b0035f1785
+  depends:
+  - libbrotlidec 1.0.9 h6c40b1e_8
+  - libbrotlienc 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 18400
+  timestamp: 1714483395748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+  sha256: a323af3251e426962ad16edf8f46a696ef502731faf12aee32ca289c40b11342
+  md5: 658ce49e9f07dba7a1afe70fa2666e0a
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 393858
+  timestamp: 1714483549536
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+  sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
+  md5: c5a600d81b1b48578863af2973c743ac
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 187637
+  timestamp: 1714510590009
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+  sha256: 0c5f9766aa2dcc08ae71b6c0102046a56b30297d0bedc3039b7f72d1658baa43
+  md5: 34583b436e62a2ce55d6a7e8eb818e33
+  license: MPL-2.0
+  license_family: Other
+  size: 138712
+  timestamp: 1710764814844
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+  sha256: 20b1fc398e925e6c8cea6a06d3bb614e2c0de886e3f14f85b0ba26e57ff40b7e
+  md5: ac95cfe373c7fef7820e93189041b0cc
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 166856
+  timestamp: 1707229213510
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+  sha256: 6b5bebc13755b0a5ef423219eeecd1c25b97dbe83afad6e2552635387547d9f7
+  md5: b7bc4192fcfed7fc7df1ce00bce97b02
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 291802
+  timestamp: 1714483319125
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+  sha256: aceaa74365b0d8e69c817639393df3a713a802f40645ac0bd2f39adc871acf54
+  md5: 52191c9d4f4fcaeea39574819ab2f14f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204365
+  timestamp: 1698129979494
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: 53099bea1cdfeac00bf4bf48e7c3321424af31b9726a7f67033ed06e5d924f04
+  md5: 0302e97edbd24e02df7609a6072dc569
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50495
+  timestamp: 1683040190091
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: 9270668e34b00a2605584a2db5130c83826855cd05b896ce949f3156fa197429
+  md5: 2586aa55677e822e8285d777f9039ca9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 543487
+  timestamp: 1709758497949
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: 389c63a84b92a6254c9d361ebe970d537d0b88733efd5ac5c3ee58196fd2c5a9
+  md5: c7bc5b3cbe76be83a27f00b7e4740727
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17974
+  timestamp: 1709323004148
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+  sha256: bebfc5aa6be12e61a134b580b07b67f7d8c045d6b113fca5b21fa1e83a2f03ce
+  md5: 239df72a3921c951059fa8afc09643f6
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 287736
+  timestamp: 1700583644534
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2024.5.0-py311hecd8cb5_0.tar.bz2
+  sha256: 5e6d053acad4139e50c724bb862204097c82f5d9c00dc3c4dd280ec4e2e50f94
+  md5: ebd1df3504dc6c94b7c587bba659be54
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3107521
+  timestamp: 1715838704477
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.16.0-py311hecd8cb5_0.tar.bz2
+  sha256: 973b7d6f902d0021116a94004a4abc43b623a516033cd650360db52b7a5900da
+  md5: 3d602a55412745fd7dc1f5fcfdc2fca6
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy <2.0a0
+  - pandas <3.0.0
+  - param
+  - pillow
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18008805
+  timestamp: 1699543215294
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+  sha256: e0e30590a78d99d51445ac4f668aefe1bf20025a35bdbac00f04647b95c9f152
+  md5: bd0db635eefeea82a0c567b39c9a0e3d
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2485698
+  timestamp: 1690905283575
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+  sha256: d48b47b86b09dac1fa4542ec13e1bd4e23093638e684fa66ec3afdd9ce9337c1
+  md5: 5a2d1828ab7c8eccd3c2610d13672977
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17336
+  timestamp: 1678316187749
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+  sha256: 54645c22fabc25b632114d1d3c403a6fad9149b51ab36719b2690a084f14a072
+  md5: a8ad2f4abfb2e17ecf6e596342528156
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lz4 >=1.7.4.2
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  license: MIT
+  license_family: MIT
+  size: 3180691
+  timestamp: 1713551771692
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.3.1-py311hecd8cb5_0.tar.bz2
+  sha256: 296e72c622f7014041055d8c7b602385ad10893aa1c0b600248c95e7d116dfa9
+  md5: 93d5cc02fe01e3b396f02df0ca682a79
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365534
+  timestamp: 1714461741656
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
+  sha256: 4120472ee1c5d31efffeb045892bece27b9a15a30d77c35212f6508221635918
+  md5: 9561a225b5171285250c9071f8cab074
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5368257
+  timestamp: 1707836808668
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 50dee40e4a9ea7a035baeecc85770c88d63d4e6b0c3c2519c1429e881171150c
+  md5: 4d465f453dca5c65224dccbe953f600c
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 359293
+  timestamp: 1715090716440
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+  sha256: 5c2458964157fe493ca18c513c693b70cb622087e5fa0c93e65fc45217edd811
+  md5: 15629e52625221b51a443cefd9501d12
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148522
+  timestamp: 1714398885844
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+  sha256: 5a17849341e4d43fc6aff44486425852c16dee6e1cbcab1ed3f2167350f55359
+  md5: 445ac9df262ad2dcd86246a9ba5654b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 51118
+  timestamp: 1704813615186
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+  sha256: e0127f50d444bf4474e8df07d602c7f6dd38690e8bb3fb28817c164940ffcde1
+  md5: 583fcd7060cad6a77074d00d9ef62f44
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 731417
+  timestamp: 1699647668990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+  sha256: eb58fa29b1ce9aa5fc774d4c466696457695dec3b206456614b4c9cac0a94e42
+  md5: 3d3291ff58dff83dcd40ec54b435f4d2
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229910
+  timestamp: 1705934029588
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+  sha256: 73aa7662c00c73bab2dafefefc87a1b524961d2687410af624ecbd6703e483f3
+  md5: 7e71e99766107a553752ed8f22b61cf0
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1611976
+  timestamp: 1704833049616
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+  sha256: e08cda2bcbdec124c63e951eb248c503bb1467c2a6000010c6bdc0726e0e00b7
+  md5: 22c24f43b82da8b3920a913bbf452421
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1168968
+  timestamp: 1679336359851
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
+  sha256: 3b262312f1fc76e490c067408771da0a12c7691379cddc3c86121255cda7a41d
+  md5: cbf00a1bc151243cb6a33524b62f3663
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353280
+  timestamp: 1706733664000
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
+  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
+  license: IJG
+  license_family: Other
+  size: 278924
+  timestamp: 1677849185191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+  sha256: 99fc6ac82c56eb2a580f96db24a5b887f8abc8c24af445d3313d5ebb48598478
+  md5: 71892160908a6daedb5fb7c404079ae4
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 182073
+  timestamp: 1699041732321
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 0ea44d0c8044e70ab0eaf4d6f5f3e4753838dee106b5cbd36561e21a65cbac77
+  md5: 1d045016dca889d702f1caf3a16162fc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16528
+  timestamp: 1699032525791
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+  sha256: 70442ec4b0b7ebbdcf150963f61f797b861001092124f4ea39a16eb92a4d176e
+  md5: 63d1503915a15ae4f9ad1c46112ca374
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 272720
+  timestamp: 1678316970740
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+  sha256: 8601c674f4779900f6a949e47b814be68b722b0b3d394433bec9d197924ebd69
+  md5: b8423f8caff3041a251fc3681f43496a
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94990
+  timestamp: 1698937583196
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: 6a430c812ce0415a04d9cfe6c66d9012eced2d91c04960c88bc8ec1e9f1b5d6d
+  md5: 30b3d5d6a8cf5d1604e5f5fb177917b5
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42513
+  timestamp: 1699282637015
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: c2d206db117f7161e77236ebd6b0051fc73e1731c242d1e08597d736a0376c92
+  md5: bdb61de2e20e02c93423d9de091c74ad
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 601837
+  timestamp: 1699466514455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+  sha256: fd7964657f0a8fe8b167ba860b1f960e8b7b45309eb6c7c850d50ec283fe03b5
+  md5: 2967bb345bc75f53182e263ff4743ca6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28223
+  timestamp: 1686870845224
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+  sha256: 64cf59f0f74b0329b5069bc6135b4f40593f1dac52d85ad574d4b8e0a4b2cf16
+  md5: 35e8b80eaa03a904fc7f1da39e7f654d
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20234
+  timestamp: 1700168776500
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+  sha256: a12382b50416803f559a03fb384ba492c1dafa351e1191a3f8dc361bee6c4f37
+  md5: f2ae846b663bbb642f4b1e90eaad38a3
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64817
+  timestamp: 1678322501509
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 685c3bc9068bd485604b80bf03789e4dca95c410d33871bc1b882e47649fabed
+  md5: 6cf8e55271e150ca0961d0ddedaa61bb
+  license: MIT
+  size: 66237
+  timestamp: 1714483284541
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 69826cee54db9955f0120af21ec36d13f9211877fd67364f2068d0a54c6c97cd
+  md5: 0851917257f490d35e1f73da8a1c723c
+  depends:
+  - libbrotlicommon 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 34042
+  timestamp: 1714483343147
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 3f5a1f03b50b90b397a0ee432ad0cba13354abdaf7e5652c0fc60164b26a08b6
+  md5: a50bdc871ef4bf14deb088d888b92b5e
+  depends:
+  - libbrotlicommon 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 311597
+  timestamp: 1714483371586
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+  sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
+  md5: 822a5b76117e56d3912f1f2153307528
+  license: MIT
+  license_family: MIT
+  size: 136045
+  timestamp: 1714483561919
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+  sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
+  md5: e458587c87e3f2d20192f4e0738f2c63
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 149419
+  timestamp: 1665498987619
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+  sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
+  md5: 1058b661ec829b2ee3716ee2a5520641
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1917987
+  timestamp: 1665498925405
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+  sha256: 8176dd9a68815301a24ed51e72f3506f5f77c67a112efa0dd14971f2f3b3c8c1
+  md5: b5e470c224000a6bda6f655c155b53e7
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 27861431
+  timestamp: 1683292881730
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: d28c465ec6d5f8d4962c597b249b58998300c8b4e3c937c578c3d15294ea863d
+  md5: dcaed6ddd0723c7cce6bfad917be98b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41176
+  timestamp: 1678413498410
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+  sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
+  md5: 5c740b4a18a558de0ccfe601703c423c
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 338738
+  timestamp: 1662635677689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
+  sha256: 53808184421c81e661f9927ff564a0d0ecdf3b816c8aba8e2368434e055529d4
+  md5: bee10bfbe90767fcb8f8f6ab3a05d85a
+  depends:
+  - libcxx >=14.0.6
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 407784
+  timestamp: 1706911015242
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: 716a654df2e55052193150015bd5c9856b847893fc5a229fa8669725b1c56ff2
+  md5: 687ba6c11de38ad7cc597f7188b491e7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13357
+  timestamp: 1678322560230
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+  sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
+  md5: 8f57dc3a3327bb6f7e1cba908856ac7f
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 183138
+  timestamp: 1714510756758
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+  sha256: 6fb2953e169ee1ae38f24d29752051501992f19b96b5ebcea9af75737bdbcb42
+  md5: 7f410cdae838c5030108d1b98a8c78f6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162478
+  timestamp: 1678377892595
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+  sha256: cd97e09a12ffb49b2a30a782fa8c7933b28f5ffdbfc5c73a9ebaa95fc9447370
+  md5: d1fb6ebc1e5728aa6377cfc71da08942
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135859
+  timestamp: 1684280005320
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+  sha256: 30c3b189462a9d0f4794d229adadf34b5f5a5f56f95c30d5afc17ef524579290
+  md5: d4e9421243129d1d57c472dab045f3dc
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26639
+  timestamp: 1704206159955
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+  sha256: 080000a28b3ceca54eec6de0748c690ea5a4c390e358283eac03fe7a6dd87065
+  md5: 51344eca57d7940fb01eb5e8914509e3
+  depends:
+  - __osx >=10.12
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9099909
+  timestamp: 1713336790553
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+  sha256: 07e7fd5bd64e55328b4b99d92e2e2600d791f1095bf905daab4cfc59f0f0a45b
+  md5: cf53321779f4ca7e986c1468719b93f1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19500
+  timestamp: 1678317565001
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0770e02be1ea1216af493cfc03d5b8a702e14606fa93b0692bcdab1fed1b898c
+  md5: ca6f06ceaf66a32bbf5dfdb6e373a5cf
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67892
+  timestamp: 1678417734353
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: fbe95ed0501bb0f137048476fe41bc718dd659e8ecb066bc67ac17d6a50f4318
+  md5: ec162bde8d1c8a107b257df218b17035
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23030
+  timestamp: 1678381838497
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+  sha256: c20dd678655e582129a858a1c5162bdc254082d3a3c035b0f72629d9276e5b75
+  md5: 800a0738c728796e02d0386ce7d457aa
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104585
+  timestamp: 1678317269407
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+  sha256: c825bc3070f73318ffff88a7a0b7fc6d1858b058ced735efd1789053f1583918
+  md5: dea5f96459c9a6df6b026ca57d387936
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224299920
+  timestamp: 1699647835748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+  sha256: a76c134ec258612ff7d55cb2a19b9e3461cbbd375a744bd29390af9cfcd283b2
+  md5: 1c736f58992009f53f014aef163bae31
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48442
+  timestamp: 1682969160267
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+  sha256: bcfb0d1e075d043bcf05fa1a7ce3c142bf222d29693366af49a5a346c770812f
+  md5: 59e4820b34049cbc6619a8ac97290abc
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 222137
+  timestamp: 1695058350477
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+  sha256: 114e408c40b332393cf2792393e4d1ede3465abcb3d345fe647ee519565346c8
+  md5: 86b13271578e1fa5e664edcf6fcb3ce4
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296860
+  timestamp: 1695059990370
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 638450a7ccb5f438ac65aa1c8d871fb5bb664e7261ec7e663d0302485c219a67
+  md5: 574875bbeabff85b5d9cfdb62066aece
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29473
+  timestamp: 1678392919304
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: a58960e88525a202ba193b4dd8227c4d9c3dd98b8b43edea34b05a9a9fd1121c
+  md5: 71a37f987c3df6657548d098bd2a58e7
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8286383
+  timestamp: 1699543227340
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: e08cb3ee6df01f4c1e1ac8bc4ed1a06e549ffcc8774fe2e2842c644bb8f74a86
+  md5: 6ba0ae0fb14cbea1e3197707701dc180
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123077
+  timestamp: 1698934356774
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 2f946b5042eaac97206b5217fb203f3604ab3a60aecd99bdfc684925e3136c18
+  md5: b24026076c381ff2009e7acb9e0a6e87
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 534650
+  timestamp: 1699022791300
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+  sha256: ba368605a0af6f1dcbdcb6fddab9ce63224a85dd11bfb2b1acace1dc17899411
+  md5: 91f3ea3fe44d619ee95a6ed3773a0814
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 170926
+  timestamp: 1694616830121
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 42d803e1d8b54748db5d989ecd503826f564132df7cddc20f520460f55e523a1
+  md5: cd3fa71626ebc098da4625fc6be79752
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16952
+  timestamp: 1708532805951
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
+  sha256: 92d50872fad0d1fecfea42cbfdb69887def80927c169a88204d163c2d3c7d035
+  md5: fe6780b8659ff5d6061268708a7b2032
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 716120
+  timestamp: 1690984968401
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+  sha256: ed5608feb37a083d47b04203195260e801b64b5380f292cf18bb61e7ad827a2a
+  md5: daa9c1c233673b727528548454aea664
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27607
+  timestamp: 1699456006797
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.59.1-py311hdb55bb0_0.tar.bz2
+  sha256: 733ece9d325b4baeaea505bd82be98ffe9e5f15669bf079ee4f2f15225bc70cb
+  md5: c426b5fb76b3d219a2fbfa2792684ae2
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.42.0,<0.43.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - cudatoolkit >=10.2
+  - numba-rvsdg 0.0.*
+  - cuda-python >=11.6
+  - scipy >=1.0
+  - tbb >=2021.6,<2022
+  - libopenblas !=0.3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6049873
+  timestamp: 1711992424576
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+  sha256: cacba45c1eebf7d86748737717883a98cf40664231460fa41391c79f98d06f45
+  md5: 3dbfae0d5b90e77f9358564ad442ac9d
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 165572
+  timestamp: 1696515553184
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+  sha256: 1466c3af380b949612c79940124e426eccd59e335c205da0c00383a69358d1c0
+  md5: df6be53592d40ba7e03d6ffe349760bf
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311h53bf9ac_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11330
+  timestamp: 1708639985606
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+  sha256: ace67d704fa7eea1480eb463f2d91bfc161be2ee20263c5a9939805ae3c2a9da
+  md5: ec124589478fa12fba4f35f31c3a0692
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311h728a8a3_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8783230
+  timestamp: 1708639945646
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
+  md5: 93f5d7b66976154adeda219bea02ba45
+  depends:
+  - libcxx >=10.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 484257
+  timestamp: 1630093862501
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
+  sha256: 891ffe9826f6f9ec9a4fc5d1bbb9a64f9de23f27705c2202f7d475b7cd14dd83
+  md5: ab0d447c9eb4fcada05d853bd13a24ac
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4970613
+  timestamp: 1716319014066
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+  sha256: 8a0809f419065e014cb8e2c8a516cadca6088fb71fd1ef3ae2287d91e3360d59
+  md5: 4dc0b9bc88476fcc5246d823ff1c289a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39645
+  timestamp: 1699371213055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+  sha256: 64fbbb03570788298d8b04d4ea6cb254fef5d5eec73265aeecd72cb565617f4d
+  md5: 4b1195028bc26257df43fdd943638266
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 159450
+  timestamp: 1710811009212
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
+  sha256: 6abb7e0aeda0130f54925421900772e1bc46d1f04ae69ce1376524457686d49f
+  md5: 232a6370c3fab0c41c6d4c7339e778ca
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - xarray >=2022.12.0
+  - xlrd >=2.0.1
+  - pytables >=3.8.0
+  - qtpy >=2.3.0
+  - scipy >=1.10.0
+  - adbc-driver-sqlite >=0.8.0
+  - pyqt >=5.15.9
+  - fastparquet >=2022.12.0
+  - pyxlsb >=1.0.10
+  - gcsfs >=2022.11.0
+  - matplotlib-base >=3.6.3
+  - tabulate >=0.9.0
+  - xlsxwriter >=3.0.5
+  - html5lib >=1.1
+  - python-calamine >=0.1.7
+  - pandas-gbq >=0.19.0
+  - odfpy>=1.4.1
+  - pyreadstat >=1.2.0
+  - dataframe-api-compat >=0.1.7
+  - beautifulsoup4 >=4.11.2
+  - lxml >=4.9.2
+  - sqlalchemy >=2.0.0
+  - jinja2 >=3.1.2
+  - s3fs >=2022.11.0
+  - psycopg2 >=2.9.6
+  - openpyxl >=3.1.0
+  - fsspec >=2022.11.0
+  - adbc-driver-postgresql >=0.8.0
+  - numba >=0.56.4
+  - blosc >=1.21.3
+  - pymysql >=1.0.2
+  - zstandard >=0.19.0
+  - pyarrow >=10.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17296294
+  timestamp: 1709591285369
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
+  sha256: 10a5eb185aa5dcfecfa854c2e66b3779cb6d2dee85f1b2236f43234a1c1ba9e0
+  md5: 2200abcb857e6bb8cb46b861cb4d2fd7
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.0.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22071486
+  timestamp: 1714072093679
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: daf01c56a3c44555ecb61e9a0e899a7b58872c6b7631f00a04ee8d3199e9e568
+  md5: 2163ed8005a14ecda15efe5586582cce
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 267508
+  timestamp: 1711137004592
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+  sha256: 359b31da651ee35b9ca43974d26cd44e64f3cf412096c15dec7b720fa909a9b2
+  md5: 108e24227f8fdfc4d635bb4eedfa6cef
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48504
+  timestamp: 1698702608965
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+  sha256: 90efc71d35ab62d5b8d7b648e016444e1c4c8b83238b6dc9f2c6c3db4b14c599
+  md5: 6b6eeb0a14c5479db1dd39aa8d338150
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 939480
+  timestamp: 1714399174883
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
+  sha256: f6b0ded7010706431f2a6d9776aa6033dfd19d2264b3cebf28072629160090a8
+  md5: 02de6d0d9cc23fafe2e3597ed0e52693
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3444268
+  timestamp: 1715097155645
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 81719c31101d6c019150cedcc7b08adb3bdb357e8b2952e428dadaabc4dc985d
+  md5: 105825168e0a17fb007f60b5f314e311
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38405
+  timestamp: 1692205731769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+  sha256: c0982f688127129e026d2b4cdacdd5684d00796ea7bdadd7d26b1101b095d723
+  md5: 0d6910c74729fede645c010110f1c89e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 121796
+  timestamp: 1679340253537
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+  sha256: e32843723b10ecd9badde28e1085419c0b59ed8a96c7cacce6395e39e3a874f9
+  md5: 5af0280a817d2c273304cd22328124af
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763044
+  timestamp: 1704404460779
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+  sha256: 117a435c2473e2a20cc81eaacb2b45ea5e7fe3c946eec2915936d344913ede44
+  md5: 0f459ee59fda20e2077fdc2c777edfc8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 497470
+  timestamp: 1679337286052
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+  sha256: 667b5cf00d31293dede2ddadcc30ab967103d585d40647f34d6d830af97ee51f
+  md5: 81d3876fa502fca91ba4136a5f3fc3d3
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37821
+  timestamp: 1678378977816
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+  sha256: dfb403f367c57327a4d080109df88383ecff18464de287a1ce936a7274e3656b
+  md5: 997b674bad89963af875b93b06807f51
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2120413
+  timestamp: 1684280057020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+  sha256: 9d2c0f373ac1c5db329581793dd517092cdf9a59140f2516ed8c3a1f483c0bbd
+  md5: ee10503a159e819abdc586666bdf0952
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207552
+  timestamp: 1678322848766
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 717e038567506ca58ce1cd4a3416892d02f4ebfdd332077cc3d110cfe3d36c58
+  md5: 53bbfb400668f798eef6f8c7cf938e1f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35751
+  timestamp: 1678315886516
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
+  sha256: 092dea8d520acff3e64c71155e666b0b6074d37a71d5eb32f3cd485b0d185d0b
+  md5: 9fbaf2d9534c26e76aa14b11b23de332
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16852220
+  timestamp: 1713545835789
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+  sha256: 04e100d0a1ea9722e24972657ec5935ad34c7c58957dabb821333e5eac80f717
+  md5: 2b6de49ad07b26e1f7084f0fda958eb1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332276
+  timestamp: 1716495830117
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+  sha256: 514249897265f66f6ecca0a4427eb02a43c33b3c24974db16d05db6bbe97881d
+  md5: c9ea1437e5a3ba6a52ec2322505203e6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279116
+  timestamp: 1679338758489
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+  sha256: 78b785b9b6ed46c86b0d3a32bdceea49f816672227fb63e726b2d46eadbdba0b
+  md5: 79d783f74359141e0b06a848db33823b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18563
+  timestamp: 1683823935261
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+  sha256: e358fe679e83ccdc8c433746ae6468e8e96d90d97d99530f8476ef5630b2c121
+  md5: ce30a0a31d891e69dc9b7bf8b7f0c39c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 268876
+  timestamp: 1713974360942
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+  sha256: eeb5a5eed93b8e311ad4d3f4389e050f11bba2eaec9536e1c3ed2f849c6c999b
+  md5: c18bd3e12de797d52a470c21a150dffe
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65270
+  timestamp: 1711136914884
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+  sha256: c3e11ed944da69c11b949bb918341a0d79ef603ee34a632d6a45fbf89ff924a1
+  md5: fee7ff4d291f530b4cecb575f29807a0
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 197996
+  timestamp: 1698096137432
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+  sha256: aa07b90a7ee65f76c8cba1ff99a5cdeb95cbe41881ae951f64ffff06674a1b2d
+  md5: 58621e3d244137885f7dfbb35e50340a
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 594801
+  timestamp: 1709318510622
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+  sha256: d784dc26c5de8e41845350a899e5779250b71f45d39e2aece62e739e9add7308
+  md5: 7b077b7f46112bb31dc066396c51d3fa
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74776
+  timestamp: 1699012164201
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
+  sha256: 3357b6b327b3d0a2cc0f02934a60bbd6df38f4ea7bbb3f50cb8e21332c9f5786
+  md5: bf5e48b646e36ef2b788be9665c0e5ae
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 120768
+  timestamp: 1707355762747
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+  sha256: 727fb8d957e02d03b928d049ffbc712316f176a2c331391766d646621b45655a
+  md5: 7e0e416c642f3ee4ddfb084a811fb4df
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10236
+  timestamp: 1683077214314
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+  sha256: a8a67143ccb65cfd6f50055176b6c26179a83130a45d0a12e79dd2de68d8db63
+  md5: a2065790f41e3eeb6efe0ef6daa75377
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10600
+  timestamp: 1683059285216
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+  sha256: 6aba582338faa0c26fe336bdb10c65b8f7808a6e383bd8f80f3e6b612ca209ec
+  md5: a7486349b5f7370f6902c2050a23d268
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 319197
+  timestamp: 1698946203341
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
+  sha256: 86bda04163628ef7b35528fbb4fe1d56fef50d10570a859e5ae8a7fbb60f577c
+  md5: 05e397dddd20d91460e3cedea0b3686f
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 4
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 27745043
+  timestamp: 1714075585637
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+  sha256: beba0555707dac1e8484d73cee9e4128ac4b10e2a0d4209357481179022e8fdc
+  md5: baa8b304607b3a9ae8a3d9acb354c31c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33343
+  timestamp: 1699371216044
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+  sha256: c1df29188e321abe23651c73712a6d8ed3abdc89ad38a42c33f1835b3ab77abe
+  md5: 6c984ea85326858942f7b635e0cc9ff8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1597325
+  timestamp: 1715025837032
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0eb44a16ef74a13ef7839209899d009cd94974fbc406a417d958c7bc8d955245
+  md5: 41f239a5b67b1daf819849023aa5d12f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19056
+  timestamp: 1705431379885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+  sha256: 14775231982e1ea150189c956927ccfb1ad01a8c9395cdeea4d5a48b9b8ce664
+  md5: 729badc4bf7ba8ccc70e0f9e58075c99
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89812
+  timestamp: 1696347694075
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+  sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
+  md5: 6bef1694163a68ac4c37e5857b8da4f5
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1900191
+  timestamp: 1714488351925
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+  sha256: 3d5c2968f581006437df3932cd5d3c1c4afa78f0e13757b958440245d3248856
+  md5: 605ea221d225ad8e79284dbcfdab0715
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37699
+  timestamp: 1678317755913
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: ed059e32ce5a1c0511575f29d2fb6da12c54a37000bfa80f9e5aa9dfd9e04101
+  md5: 4d2261a92d25136a68b8d01d101119f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49145
+  timestamp: 1678317386284
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+  sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
+  md5: 523c006cc67c011383678c762015479b
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3594448
+  timestamp: 1714770737885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+  sha256: 424b8284072266eb59d055c0b7b58241bfb00009d445743ea261d4eeee73ea19
+  md5: f3a47898a55087edb9d65d29c24d9b88
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135757
+  timestamp: 1678323030858
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+  sha256: 6ab71b48d145c69007cfb5b4a21def2cc83bba972b7cc91c7d52d0d7eeb055bf
+  md5: f8970b0ad5c8b452b8722ceb4e5c17f7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 895379
+  timestamp: 1696937269468
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
+  sha256: 3df84b9897f05a104c99e297dc29ad8f718982fc64c61b5a2204c19c578f47e5
+  md5: deab971930d242221ed86bfd768dde40
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 155545
+  timestamp: 1716396266697
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 9e8dbede0bc54c77b974210be66503e7e8e45e0f1c71dc5c16cc9a9674d54259
+  md5: b4fcab9e63bd7b3cdf458c953904807c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270874
+  timestamp: 1678316116954
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: 17e5688d09ffbcb8b71b34b86edc7374fa0b04d60a4d729d405ffc22ef63726c
+  md5: e4bf44ddbbcb136332ccb47ac2b879a0
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9890
+  timestamp: 1715269046804
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: 7d369ec970d1d5411e457c79f94197756c7088deff8183806ea71e633b26edf9
+  md5: 9ffa197b26373667f50b21876862398e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 75595
+  timestamp: 1715269030928
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+  sha256: a9960485ced319ac91afe69eaaf703c7e6b3049f1e06a4a8c2818b64155943f0
+  md5: 0a9c8ea92a14330a07edabac249e32a9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11399
+  timestamp: 1678394892923
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+  sha256: d42ae57366d05e12f10074583568355752436d66ad018ffbcfa24135f593810a
+  md5: 1a98e48aa0bd8b3ec09e2cbdbb236575
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 498952
+  timestamp: 1713213079520
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: 5dc693f0e0aeb30cb6033015b13e75c8a21c56b1262d9652788c3e73a5c5c4a5
+  md5: 6b5cc9b43aa34431f8c30b5cdc22004b
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - selenium >=4.4.3
+  - h2 >=4,<5
+  - requests >=2.26.0
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 210522
+  timestamp: 1715636148762
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+  sha256: 597015e8a038a111f03ffbc9a217fcda549d75230c86ce53c1f23c53d6f1a0cb
+  md5: 62e98aac883bccc1c87ca0d2ce2f08e0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25798
+  timestamp: 1678317074170
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: 1430e6f4b4dd9354b7bb88f7f7bc9cdbab26a034ad1ae5c278de0f5a99329372
+  md5: be0832862b29bf5767a707ac6bd53b93
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 114834
+  timestamp: 1715878445060
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+  sha256: 885a9b6046e76f7dc1a346b14c63b4083046137bfae036362c854458e20e4fc8
+  md5: 3b279447ca282d065e681e567055b582
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 137340
+  timestamp: 1714717062907
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: cc6995f677d1628f42ae80ed47ff08d8d1c8ed12580a326af6e307f5febc594a
+  md5: d01eb964863b95ef62061b77c9037ead
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2471632
+  timestamp: 1689041625741
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+  sha256: 5b6d5246955b5f9480ff7027eb002442a7ade24f5c354da54ed513042f76cedc
+  md5: f32aa8a37d5e65a8dc30f9a1f46bc63d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54719
+  timestamp: 1678325412288
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+  sha256: ed0152ad6b87ffd9e01f4a62bc358e805ad59637f898a801b0a9cf903ae8e1fb
+  md5: 8a92f8c663608f24e14d8a2068b9d83a
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 415323
+  timestamp: 1714511993944
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+  sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
+  md5: c25b6d40f834647d0bbe767f6c776031
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 329449
+  timestamp: 1705602140856
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
+  sha256: 36fa7ad990aabf3607bda1f33e847888210974586363b6d69cf1ed092c192c35
+  md5: c981fe545122206cdeb647f2dc9e093d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 25496
+  timestamp: 1704207010227
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+  sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
+  md5: f2519b551f99765d9d98950c5e2b4713
+  license: Zlib
+  license_family: Other
+  size: 119782
+  timestamp: 1714511811597
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+  sha256: 7feb73e79bdbd45404ddc7a30c43bf4cc68eced8ce448ce7c31f5db134276fc5
+  md5: 48313bc6570c705cadbba3c356e0dc8e
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1014151
+  timestamp: 1714678461080
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+  sha256: 9ca3f0dfc2bdbc109e359ba7ab246e6ae952a14819148ad069454b52f2bda802
+  md5: 51fb05873a644cac52f0d1e10cb7969a
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.23
+  - uvloop >=0.17
+  license: MIT
+  license_family: MIT
+  size: 228856
+  timestamp: 1706220385566
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+  sha256: 43405cc7341ce3efb2e24013ad62c64f26a69926635adceaa5459ccbcafb3776
+  md5: effa6d22f497e164cc8455f7f329c304
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 12510
+  timestamp: 1677917870614
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+  sha256: 947efe1c50b3280e9a67cbb18636bdade53a40960fff3056850ff81ab87acbe3
+  md5: 7d2d384ee32ccc12dcb0dc099e421482
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 35091
+  timestamp: 1677915945226
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+  sha256: 8259b4a0973c825ac81f581afcbe86640bd0a94b33caa996167309241877635a
+  md5: 49b8ddacfd3927bcaae139eadfb72ce1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153557
+  timestamp: 1695717951839
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+  sha256: 11159a30daae77cfc1abe5e60c19261f65c005e6fbc460aecf72318514d737ad
+  md5: 0c5002654a9cb21db1fdf8c1d2017df5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 269772
+  timestamp: 1681493072129
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
+  sha256: 90439f37ede74ef464e76093e173a8e94a20ee4ad79c68c9e7570fbc67fc13cc
+  md5: bb3b906307dd679fc3276be7581494f9
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6073834
+  timestamp: 1712084392983
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+  sha256: 688a071ba370f51b457cd32d70b7b38921ce9551203d06fa7fc2c30c4b79891d
+  md5: b2353077a39ab997463768154dd58fec
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134711
+  timestamp: 1707864978809
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+  sha256: 048264434c33fdb53862cdd69b2e2bc4ce6f8a70b3211ad6d686d066eac2aa91
+  md5: d55696ccaf6755931cd662dfb929aa0b
+  depends:
+  - brotli-bin 1.0.9 h80987f9_8
+  - libbrotlidec 1.0.9 h80987f9_8
+  - libbrotlienc 1.0.9 h80987f9_8
+  license: MIT
+  size: 19737
+  timestamp: 1714483270447
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+  sha256: 13627293296fcc231d8dc12d803dfc9621108c60df38b0e3c64e9e02ed55e564
+  md5: 86efd4ad08cd80d3eab77873db84a255
+  depends:
+  - libbrotlidec 1.0.9 h80987f9_8
+  - libbrotlienc 1.0.9 h80987f9_8
+  license: MIT
+  size: 19083
+  timestamp: 1714483255364
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+  sha256: 2e542b2bb27f8379da3efcb83ef084cb26e6a9ab576c50487c2dd996afd5ccb1
+  md5: e8cab9d1ef58a450f971690fcdb2ede2
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 380182
+  timestamp: 1714483330655
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+  sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
+  md5: 56d1386c7f1f338f0d18f82af6525273
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 158748
+  timestamp: 1714510571033
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+  sha256: bbfc668f445f3584936b326dcfe92bf71971ce16241f4f79db8aeb88d7aab41c
+  md5: 10cc05ed51482e1dfcc31dbd13bb34c6
+  license: MPL-2.0
+  license_family: Other
+  size: 138641
+  timestamp: 1710764806818
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+  sha256: 512969f339a9a7b347cdb7b88f439819168089867f04732279f02759d8caf24e
+  md5: 2009c2ee465fdd74dbd046de73726234
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 166501
+  timestamp: 1707229221324
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+  sha256: 8d26cd4d16545ad8afddd5521bc6894a50d5b8faff3abbe600bb9b062f3c3a0a
+  md5: 66eb734b7d7008eb5fb537900767c7ae
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 286807
+  timestamp: 1714483190838
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+  sha256: df81a27f221d11af4a709f272dc8ba3fd3f6d5ab4ffd883c40567bcf04f0cfd3
+  md5: e49333e3ffe1fe2e701f50a6e6dccc52
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204179
+  timestamp: 1698129906257
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
+  sha256: 53edaca56d853083d44cef6234fe4b3d076d107e915781ce54ec135c25e09f0e
+  md5: 5d1d51e53c11bcb56cf863d58e37c077
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50433
+  timestamp: 1683040076511
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+  sha256: 808e56fb70f3d38599ee7a54c2a707b282ba9a401fa69a1f54cdc26425d9ce01
+  md5: fc37321833175bda4fc5c21afe32db49
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 539588
+  timestamp: 1709758479776
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+  sha256: d9c126d8bcd1c89ea37186c172d6b1f73f45ada60e3ae1790a017b530baa0147
+  md5: f0223aae3d622547f6accb212579c58e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17967
+  timestamp: 1709322909223
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+  sha256: 1f908c688e47d03d92ac09d9541a1f1c773ac2ca485dd1d77441b1aaefc032db
+  md5: 444c330471496a39a97e87f41ed70c96
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281104
+  timestamp: 1700583698464
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.5.0-py311hca03da5_0.tar.bz2
+  sha256: 71c289b48cfb6e957d879c3150963cd80654f408e274a9bc816ee6b72d69e912
+  md5: fd38d206222a32b3c71718acaf205013
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3103523
+  timestamp: 1715838626586
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.16.0-py311hca03da5_0.tar.bz2
+  sha256: 2b7fcd83146c02c4d4b2e2adb2512172536118cb0f630c47a43b11c5005734bf
+  md5: 6687cac2611e1868f6ad781167a671c1
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy <2.0a0
+  - pandas <3.0.0
+  - param
+  - pillow
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17988386
+  timestamp: 1699548972355
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+  sha256: b9356e3ada4872c7c950d2ac7e0f107c4786775191efdfda3a469dffb18f2714
+  md5: 07ddd96675caf30ea77cafb1ea5662a4
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2490144
+  timestamp: 1690905181398
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+  sha256: b1481ffa475c65200626f051d5dcbdb264730b533e928dde608a79ce7a5b4e48
+  md5: aada2761547a291d68f4c016a1a9bc7b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 18265
+  timestamp: 1677911915719
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+  sha256: eb82a0e2ca36d0973b5f6642e27609554edad4b72696f989776d5db8cd4a6a42
+  md5: fa8d9dd8a2fabba964c6bb75ace8c572
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 3201601
+  timestamp: 1713551611540
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.3.1-py311hca03da5_0.tar.bz2
+  sha256: aa53d9f23e86ac3398f6b935cea01dcd8a1b1821d9b1d37b16a5ba68a2dbe569
+  md5: 2d5841b96988498045c28e3b3951d5ac
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 373029
+  timestamp: 1714461571346
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
+  sha256: 898d10bc1ededb43b7339ccf57fef404d96184de8ebaa788dba0b36a8c8a282d
+  md5: a1925e4ff9f6124ca7d439430bc110fb
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5399311
+  timestamp: 1707836657705
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+  sha256: 765d5b7ef75ed7f52a110504cd88e9b0c9977b841f1beaeeabb17e629b462908
+  md5: 0af9cd26a7c9eb8b77d3cbacb93a118b
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 360105
+  timestamp: 1715090588763
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+  sha256: 4d4ab70ae0ce008c1cc96a4edfbf3866d5e636acc4799a545ea93acee51635f7
+  md5: 86a085a440729020d1d7b0b74d6a0c6c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148448
+  timestamp: 1714398923507
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+  sha256: ec139e4b87aadcacc0670ecbcc2a303d858d4ac38b9404458a4b676bce9d21d5
+  md5: bfcfed281f8df0f18726ec5f843b2b26
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 51053
+  timestamp: 1704813595720
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+  sha256: 63670c8f31770e1746016f645ca6b42b35f92d1c37e8025793d9490fed9998c0
+  md5: 9cb417b9fdf02b4e007a5b5781e5a8cc
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229932
+  timestamp: 1705934202146
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+  sha256: a40c76c412ec793ca26b97a9b5c496d253768438e1f7d4a0ee5f63ea79eed355
+  md5: f609e4fe044318211cf0e37e289beebd
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1614299
+  timestamp: 1704833142734
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+  sha256: e57d10579b52a3cde45aa17e1bdd95dcb9d3346aa00eb02c51e38a42db83e18d
+  md5: 05153120787fb09159b6e1ad902c6e10
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1180481
+  timestamp: 1678994989550
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
+  sha256: 06512ef9a910fa72bf5697fe89e88c605d61f8478a9d8dd233c13f40e30f8446
+  md5: cfa00c9ffd3407e29507525c020e5526
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 355730
+  timestamp: 1706733720706
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
+  md5: 055e12390b844ea6c6e956ee08a618e8
+  license: IJG
+  license_family: Other
+  size: 273479
+  timestamp: 1677849171867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+  sha256: 62025ce4a2b9244b9816c9e02487e0dda567600692b5f9ca71f425d084961c7e
+  md5: d57b7063122e5bf25cdfc2a5ea7330a8
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 181872
+  timestamp: 1699041739097
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+  sha256: 404b0847029f77bedd7902a170a046219e0dc5c0ec2be19ff45361cff25b2181
+  md5: 3a02bbe8d45fdbcb2350f672be74c9f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16524
+  timestamp: 1699032463763
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+  sha256: 7deb8ad28c34c369573754304a03ea2acda8ee39102a56526ec689a4d9210109
+  md5: 675ea1a746a78ff6bf8fc4b39139efff
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 277400
+  timestamp: 1677914250715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+  sha256: 8220b1bbdde5e800810f7bf183a992af1a95825a837edf975fa8c4b51c5d806f
+  md5: 3a06ddad06e04d5f0211c22cd81ca75a
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94950
+  timestamp: 1698937436979
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+  sha256: 8a9a9f9ddbf1b7744ef04a8c862438499a41d81a4beb4a49860156c273bb7497
+  md5: 051355801f09eefe850ee8145151f934
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42497
+  timestamp: 1699282590553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+  sha256: 65c703cc996a705d0ee350070e313b1cae865f9d6e6490ebf1164c0f3ce22d93
+  md5: 305ad8bcaad3e352d61b1e594093b467
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 596801
+  timestamp: 1699466743685
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+  sha256: 501e929d345aaa9079c965552b942b4e8bde35b87ae89faef003687a40bab3a4
+  md5: 54c7b8554a405acd7c8326c41ba93e63
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28237
+  timestamp: 1686870817418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+  sha256: 773e7c4571f482a744dfb18ae26fb22635f5d3f51389c838bd97f9044ea55cc4
+  md5: 5161546aba5597318cb5653390cdecd8
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20235
+  timestamp: 1700168681687
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+  sha256: 8c1c64d51be73aad381992a9df19d8336910bdfc40f19940231df86e177d17cc
+  md5: b1f786f96684a143cf30d1f6b8aebdb3
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65045
+  timestamp: 1677925371836
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+  sha256: 199042b87451abaf14546af124ae3380194cddda928e0d30ccb341e93084854c
+  md5: eaa0442887994a82486c65d87f6b71e6
+  license: MIT
+  size: 68806
+  timestamp: 1714483212137
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+  sha256: bd9a8a17fb14086446b710fa029d238e69274b83ee2e7e09093496f190de82b5
+  md5: 66615d6a0cb5dcca3e20c019cde0ed2d
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_8
+  license: MIT
+  size: 32975
+  timestamp: 1714483225840
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+  sha256: e1bf77e8b975c30a69b08a08410622e27c8cff6f592ccfa590466b83d9e6d104
+  md5: 8af86bdac01fe303d693d9b76c071059
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_8
+  license: MIT
+  size: 310266
+  timestamp: 1714483239194
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+  sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
+  md5: f31e4eb9cd6447cc2f5ef0243a76540c
+  license: MIT
+  license_family: MIT
+  size: 120460
+  timestamp: 1714483461787
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+  sha256: d654027daea13ac9db36ab5fd5eff3ad398ec97c1777bf399f3ec680d2c145b9
+  md5: baabb1f905054bfea3af8f5768572a34
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 26579907
+  timestamp: 1683291669565
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+  sha256: 41c62a460bb81a1a272aa28b219fab9c26510adac177ff1528b1980eabc6e868
+  md5: 8d312c5628dc7ea833e9b4dcb73e9c45
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 42346
+  timestamp: 1677973051421
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
+  sha256: 911c7577f591311bfb000121831234e7bc6332bff62fd00c2245371e67f473c0
+  md5: 419681f23f179ba08e5fdf9884ea238d
+  depends:
+  - libcxx >=14.0.6
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 410616
+  timestamp: 1706910762686
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+  sha256: 5777bbef827f72975a36f3da80ab4af718dc781264f74ad7e3864755d620c0f0
+  md5: 4240f1a79b812387919cc710a0469556
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14318
+  timestamp: 1677925438733
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+  sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
+  md5: f5f7e6e7541d8dc3d3df270d488d2e24
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176990
+  timestamp: 1714510588159
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+  sha256: d024f5142416961a5e66e424d4d14aec652f9e9dd738b41a97f45674c2ffc9d5
+  md5: 0e2d94b125d802f7b006cf19c71655a1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 163084
+  timestamp: 1677932947966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+  sha256: acfd84e29ff4dc2d85543bb973a07f22b4ba53c5d00bca84608ee7f13b2a8676
+  md5: 5ca161cd51e2db358e768453b3ee485e
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135871
+  timestamp: 1684279980293
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+  sha256: b1bed54c7bfb7304cde9e8e6f798543d08e808e81286a5a48296fc94d621f9da
+  md5: 774358285c9e496c9f5c121cc546c823
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27438
+  timestamp: 1704206026910
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+  sha256: 9229a6e15abf3147cfcffad4ca389dad940e45779963b4fc3fd56dfdcfca3234
+  md5: 4e1897f3cb4923de48c016468c01c051
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9100733
+  timestamp: 1713336457304
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+  sha256: 3276d61fc353c537bb09d4b7473d7abe12be38806f42c8cc383b62f40850a5cc
+  md5: 6e9c9d47f264b77d9a8461f0899848a7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20446
+  timestamp: 1677918370379
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+  sha256: 43c96d30775b61b4968422a47f9605049428120669f0742bbb9e5ba145c7d11e
+  md5: a31ca0d9284860adf5463cf45a5e3145
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 69243
+  timestamp: 1677995336989
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+  sha256: 96d8c9f42a38651b7bafe5f3cb132601db76cd1e28fa58e2eaf090e634292fff
+  md5: 5ebc793a17b6aa84d13f19433545ffa5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23895
+  timestamp: 1677942274932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+  sha256: db9bd659ada23f1ded443d2db00dd13b5d5c0b30f5062544b1ee2c2b88d63d29
+  md5: 03c48121614cf12abfe30eced9b34717
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105333
+  timestamp: 1677916687032
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+  sha256: 8b05894fdcbe5cfcdee94812b043de4cd7b4fa51d3e2aad25fc7cff50c8f82ab
+  md5: c970d49137dce1c77f782ee5725950c1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 30745
+  timestamp: 1677960816849
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
+  sha256: a8b3d349481dc694eb9a507f55c91e8981e2a3bc41743023ca01248c8a6d779a
+  md5: 71e6e29ec3b98fb282c01b012a5df236
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8294656
+  timestamp: 1699543119360
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+  sha256: e8eee27fb667aa10b26f3bc4b93f449b7d991ded27b9cb457effee394ce05f6f
+  md5: 6a3e5cd0e1141c01ffb91285bdccfe83
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123043
+  timestamp: 1698934328890
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+  sha256: 40230434aa2fbb33ece13632e8d4b7cd1ad68fdb8d1b00263af4a010795d25f8
+  md5: f12ce7dad3620d6d53a442fa9d36a0b0
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - pyqtwebengine >=5.15
+  - tornado >=6.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 538067
+  timestamp: 1699022954841
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+  sha256: a492acec8ceadc0911a75966ffa630a8eb15b2da8c7a8d544a645ba47771a2d1
+  md5: 4002b1b88b2ecfdfc769036f43b0a895
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 170964
+  timestamp: 1694616845237
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+  sha256: 417ace1ce51e81f3f92ddc26e0e3a83c1e19c9ebb7af7104452002a5573da534
+  md5: 3e11de6cef096091bb733e07802f00b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16979
+  timestamp: 1708532698253
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
+  sha256: 2e09ae8d10d7e5651727aab66a1e89b59e716295267a8295eaa53760c4c38533
+  md5: 8d52be8699bf030546811bb69fbeb2b1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 728383
+  timestamp: 1690985022565
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+  sha256: b0cc542e2a6f42ba716e7e4ccf29eddcb155ad167fcdbc72d2db9c7873eb5639
+  md5: 7acf81b17d2c4ceb3cd39dc9f173855c
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27539
+  timestamp: 1699455954000
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.59.1-py311h7aedaa7_0.tar.bz2
+  sha256: 4e0fb594095ce53c58f97eafc1c113e150929a6935e8ee54d86359cc7a9afd14
+  md5: df6c4ead6e4bed95d012bdd5e79f10db
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.42.0,<0.43.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - libopenblas >=0.3.18, !=0.3.20
+  - numba-rvsdg 0.0.*
+  - cudatoolkit >=10.2
+  - tbb >=2021.6,<2022
+  - scipy >=1.0
+  - cuda-python >=11.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6062719
+  timestamp: 1711988782214
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+  sha256: 151a3eb68d1189e69764ece1d8fb3544d31a22f5bbbc3e19d846de8dece304d2
+  md5: eb6609e6bdc9c82d70df3f8c4c2de95b
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153313
+  timestamp: 1696515415712
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+  sha256: d3bb1d4be88320a5861cd3a0f086e9709f9b64c96c032cb9039cc4f17ec66a85
+  md5: 0a7b97665c06fcd34a70e34abc177280
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.26.4 py311hfbfe69c_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11288
+  timestamp: 1708639168951
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+  sha256: 3e70248a7069ca12ccf56252869bfdb72211fd4e4c327e6994756496df786c79
+  md5: ce4846006d98638cd86a532a72f8dfe4
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311he598dae_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7536860
+  timestamp: 1708639153133
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
+  md5: 371358a54bbdd307603888348d1a2c6f
+  depends:
+  - libcxx >=12.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD 2-Clause
+  size: 412248
+  timestamp: 1628861367714
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
+  sha256: da78bd65c91881856baadf977534832f68db3938c1b5b713c8797be70b83c98c
+  md5: f728656890f860eec5ad2899e657df3a
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4763426
+  timestamp: 1716318333548
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+  sha256: 77b0c0a0fb14d817390244ebd93c36d44a7867239963f211f7c0a72a3f98d382
+  md5: b90336feb8a50d2eff880e89acb02f40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39617
+  timestamp: 1699371253760
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+  sha256: 4f6c3e8d8fc4c57975cab837ef109b9ee7af4f18aac72668334ac656e53c6edf
+  md5: fbf1b507f9a80c5de3c957e8152124da
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 159289
+  timestamp: 1710807498427
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
+  sha256: 3af823879c340838c1040e99f653c3438ccce8dc559bd91c3f4ab2579282a002
+  md5: 5b3df01fda0281dab4196bc36d1ca367
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - odfpy>=1.4.1
+  - adbc-driver-postgresql >=0.8.0
+  - scipy >=1.10.0
+  - fastparquet >=2022.12.0
+  - pyxlsb >=1.0.10
+  - pymysql >=1.0.2
+  - sqlalchemy >=2.0.0
+  - pyreadstat >=1.2.0
+  - beautifulsoup4 >=4.11.2
+  - fsspec >=2022.11.0
+  - openpyxl >=3.1.0
+  - xlsxwriter >=3.0.5
+  - jinja2 >=3.1.2
+  - zstandard >=0.19.0
+  - numba >=0.56.4
+  - matplotlib-base >=3.6.3
+  - psycopg2 >=2.9.6
+  - xlrd >=2.0.1
+  - pyarrow >=10.0.1
+  - pytables >=3.8.0
+  - html5lib >=1.1
+  - blosc >=1.21.3
+  - gcsfs >=2022.11.0
+  - dataframe-api-compat >=0.1.7
+  - qtpy >=2.3.0
+  - adbc-driver-sqlite >=0.8.0
+  - lxml >=4.9.2
+  - xarray >=2022.12.0
+  - s3fs >=2022.11.0
+  - pandas-gbq >=0.19.0
+  - pyqt >=5.15.9
+  - tabulate >=0.9.0
+  - python-calamine >=0.1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17082645
+  timestamp: 1709591689205
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
+  sha256: 8bf772501cf4b49a939de17bf378d3e395f452d3070d05871354bd2bc915d012
+  md5: 753d2070a2aea47934ecf6ac1ea0bc04
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.0.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21901817
+  timestamp: 1714071405089
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
+  sha256: 67feb8232961ad9d7672a49f6f86f0b86764f62a97d86d58b90ca7e8345bab76
+  md5: 3afb6e6747bd29e9483d35dbf8b24f74
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264413
+  timestamp: 1711136882294
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+  sha256: 088245becd055af4de74e4ed13cc752ab546423f204b170ba2dd8809af30a2c7
+  md5: 2eabea5ccc56ac088e0349626e59df06
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48517
+  timestamp: 1698702686783
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+  sha256: 174b680f4bb041e8146aae80f92390122459e0ef8c911cab22d01e2e92d44ab1
+  md5: cfffc94779cd26a349bd409b5590b098
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 916496
+  timestamp: 1714399019350
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
+  sha256: 102c3c35a9dfa0f10ec8f4a040a24295f9c736443ccae2f685348a44f62a4d68
+  md5: 027b347e79e252aa17b534e1a02bccd6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3447682
+  timestamp: 1715097070362
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+  sha256: b6200816d65673aa1707c20a768c9cff87dd8dbe1335f9c1478e5931dfa08ee0
+  md5: 14b1e0fa73eb33f9c83048482dcce57b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38423
+  timestamp: 1692205689597
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+  sha256: ebdf211edd98d88a23778551c7a9702106edd0695d4fc48e87c21f77521c1ffe
+  md5: d8c505081a468f1b99c62466e2309417
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 123084
+  timestamp: 1678996822234
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+  sha256: 07cfba50d9e94364bde077731a824ca4f537138b35ee6b66d07aee16ac9850f1
+  md5: 919bf486280a11e6acb3c2c3a82f7473
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763225
+  timestamp: 1704404463402
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+  sha256: 8094436b2c44e68e72569c704633802aad82e977b1e16026848218679c8becf4
+  md5: 2360e46d3e598dd5e2abed781fe166c5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 502115
+  timestamp: 1678995719872
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+  sha256: 4f17f70658e32a9a86661184cace6be3bb7bd61f9b55b513092beddf44552679
+  md5: 0aa95279688b0433badea0b660ac8146
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38653
+  timestamp: 1677933613643
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+  sha256: 121b5b66721760c05f1d4eee91626229d1814663d3fb5f23126ef870aa496e26
+  md5: 0c588c2ca790a05d422c06e8568201ad
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2124200
+  timestamp: 1684280082141
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+  sha256: 44b694db8e81d61960d28d60f9e9b573f03f7827881d302da334378881db4889
+  md5: 6c94ba7caa599ff533e0ab55d898be8a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 208454
+  timestamp: 1677910948527
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+  sha256: 0bb3d2a57b332c5cf73ea40ea13c850ae24a1f9a3a41ed9267832d9e3c767572
+  md5: 45a7fcf1641980d5114999736428502d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36755
+  timestamp: 1677906514270
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
+  sha256: 960c343b7b8569dfe4e71a395f7bede1e749da7b02c17506b590c9e1839e6fd7
+  md5: 722c4b4386af73cf1562974a00c880a4
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16494386
+  timestamp: 1713545544909
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+  sha256: c3cbf5bd237b0a7458640191016b2701fe120c547df9afc835da76663a9c17f7
+  md5: 843568c76b6b9384635b7fca74c79792
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332222
+  timestamp: 1716495881101
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+  sha256: f94b3cfea6f76ea9983e16d3c4c7e0a64f02c40cc2c3ad57189bca2e67030bd9
+  md5: 0d100990ade57a02b60d1e8085db0bdf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 280263
+  timestamp: 1678996927464
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+  sha256: 252c86f5aef7f8dfce99a260c24cbb35a9adfea144a2acfabb224f516341544f
+  md5: 745b888e19a644f48800799f82c01c21
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18539
+  timestamp: 1683823925189
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+  sha256: d945744eb133f19ca61325cac5128bdb053ae04de4a0ba6f69c061449cac8af7
+  md5: 34baa81490d667381bc7021435b0e1f2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 275858
+  timestamp: 1713974457562
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+  sha256: 012585bdb5ae54c2cded50be703734e6dbf418b003635b6f6d7c1e36e7020c30
+  md5: da7e99a707bd0cfa20db651b5c068bfd
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65556
+  timestamp: 1711136890180
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+  sha256: 4f04a43cbd612ab09cefbdc2e48ee61b51967dad59d859ce0502cc2c46c88fc5
+  md5: c68bf65433b2151b51b2e699bc22c501
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 194632
+  timestamp: 1698096151085
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+  sha256: ae8cdd5be5a7ad19ff82925a035859fafcc5942cd3899d127a508dbb9a235090
+  md5: 252a7b997d08bf72f10b3bc2dc68333e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 580346
+  timestamp: 1709318480624
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+  sha256: 7a208abc002a2fc208ae25cb2cf932999a3e4980aa4c9edff315cb9ac62b12ce
+  md5: bd22ebd3cff811577ea61f115ba7f4f2
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74744
+  timestamp: 1699012126255
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
+  sha256: cc8d055a068fe5a7484284c3360d81db61656dd6118c743c740fcc47cd3da379
+  md5: e5fad71ef3b99077b79052576e51bf9f
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 120672
+  timestamp: 1707355664440
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+  sha256: 52368d9b557b8f54ef5ca4bf6cd5a3ec665171f2b2d2082cdd410bab88f4829c
+  md5: ac76fb4d2eef3ecdd491cf5d3fb8620d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10204
+  timestamp: 1683077239143
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+  sha256: 491d116c5f54ef340e3bce631835f7138cd1923d7b63e6ca9aa01b48110cb8f9
+  md5: 9b81bd8ea808704f5433884b567f1f15
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10557
+  timestamp: 1683059079547
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+  sha256: b53a5f6119173d62e4e68a37ea8511c7fc87a00af72953e0048d075a799c7a7a
+  md5: 76a16cf4edb9b12b2b96a2d323f060dc
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 342535
+  timestamp: 1698945991201
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
+  sha256: 9e8312f9452357202813aa289430c939302617f562dae9e90fdc3fb5e9be49d0
+  md5: def02b749d0c0a3675d96aeb508a2306
+  depends:
+  - blas * openblas
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 4
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 26383719
+  timestamp: 1714070280353
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+  sha256: c80d52567084b1caaed2862b77b70065ca17afaf0b020733e9d6c273b4a63e78
+  md5: ddf7d88c1967f3f7a4ce1c975fd47e0d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33321
+  timestamp: 1699371225235
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+  sha256: 6d38d171ef87340cf0fbbf4c70217df4826c65400c9290774f5cb35e381e3315
+  md5: b9529a812f9862fc89461b6b90f184ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1599110
+  timestamp: 1715024190898
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+  sha256: cd71091a234874d2826fa063ec5222b3191c9f47e1b5281c352d9df3f31a06bf
+  md5: 0db8e29016c6bff026c083d9923a7566
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19073
+  timestamp: 1705431415504
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+  sha256: 3e18cdafc607c6d7623b1c8f041cbfbb50a27e298f961abdcce7e36834ac39e1
+  md5: 9ee0da74c55d0b8d83edf246fd717f20
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89862
+  timestamp: 1696347657368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+  sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
+  md5: d8c1e9910392d0bcb22a173f9ce30fa6
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1758290
+  timestamp: 1714488307689
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+  sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
+  md5: ae58720a18a2ed15eae214ad7a10d1b5
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 140125
+  timestamp: 1680167256603
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+  sha256: b5c265e9ed9a1ff2238a09b83bdc1826950faa87fd6b685debe60888de6e7a50
+  md5: 5827c8a32317894ce18576e334daba47
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38559
+  timestamp: 1677918962258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+  sha256: cfefd86d0f4981d22b7611b3dc60359b8698bf39f2b743cb90b7005aaca88e1e
+  md5: a04dbcd6095f6b8f3ad195a78d48b262
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50058
+  timestamp: 1677917499177
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+  sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
+  md5: 3c25b4f4768ccda28b20a03ba27e7759
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3484151
+  timestamp: 1714770744982
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+  sha256: 0836468fafb1f5badbb573922e37200c6929bf2926ecf8d2259dff43811e0727
+  md5: 5bc56dcb4bdb7cf623b7cea499feaddb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 136409
+  timestamp: 1677925889207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+  sha256: 177246487449f87567fe56c8f20011a4350a132d1556c9f87474d7b2e8c1374f
+  md5: d465118217b9f27d47dceff89c2e9f95
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 896655
+  timestamp: 1696937042980
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
+  sha256: 81efb240a49cede5ece3a8ad48f1d9dfdeb56260bf1a20e25ec53cdb202f7c3e
+  md5: 81a17d13c75596841b95340a34bbe929
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 155516
+  timestamp: 1716396017482
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+  sha256: 65e760119352cd85c63d365d2576c09a9ddb060e5b029a265d50bc268eed9290
+  md5: 14c241871b12dc3be52e6cd681267caf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 271445
+  timestamp: 1677911758960
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+  sha256: 96071e07e807414b7ae5a2fe958ac171e5795576b3a4c2f5e8c643fba43d760f
+  md5: a34f2b216e35a37f966883dacda229e2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9902
+  timestamp: 1715268985387
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+  sha256: b20e48aff4c781a52b6be66d77418e768527a621f5fc272ecb34ea03475b2bd7
+  md5: 707738432f16f5e63909fcaa6e65850d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 75604
+  timestamp: 1715268976065
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+  sha256: 2ea2d0520b330d381a2ab241bdb9ae146ef815ee7c96ee52a9773fb9ae85f4fd
+  md5: 66f7f8979cfb2cccffac972d70482130
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 12614
+  timestamp: 1677963554857
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+  sha256: df7fe7740bd853b641d624e2ec97f1aacb2b82691936a8c04ef18fa9768539c2
+  md5: d5c7626d45fd03b22797c18e47812beb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 518048
+  timestamp: 1713213046424
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
+  sha256: 3fbcccceb4d7d99f60a6e6e013ab84c4532244c42ab9d65b6fdaab6bd30f7269
+  md5: 6a7e05872852d4bcde959f7cc8407672
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - requests >=2.26.0
+  - selenium >=4.4.3
+  - zstandard >=0.18.0
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 210307
+  timestamp: 1715635933070
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+  sha256: 09738b7f9075386bf062b12ddb6fb72a06450d2481f6b5ca2026c811cd849569
+  md5: 9afdec076c95746ac21235f971190e40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26727
+  timestamp: 1677910175964
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+  sha256: b4ced7366de8eb7258f31d516616e70c62ed4a798780e57e208509d2b52ab435
+  md5: 65a9a05a726734c1da667f9bd3c78c14
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 114733
+  timestamp: 1715878377412
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+  sha256: aa301d9e42aadbe3dd5f301ccbf17fbadc347fd37d413c0cbcbd24403892a936
+  md5: 77097d17d835a137af7950c628b66150
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 137260
+  timestamp: 1714717037687
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+  sha256: cf030fc7020dc6d28530075468b8dc1edd843a1e393a2f81ca81c962e9af977b
+  md5: cae3fc90233f3af8f433a253d035b6e6
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2470844
+  timestamp: 1689041497962
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+  sha256: 2cd108896df65636769e3804ecc2ca421ad9b54e64fa21922bbabe40c90c247a
+  md5: b3a1e5077b28f71298d891fbfb5ff03e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55645
+  timestamp: 1677927459979
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+  sha256: 5be8c968f2da5c4bf14f28d63e31b4c1b6993d980023769732c7f58f396c2e0b
+  md5: 3f5f62d4e85e3bdd48d39189b01805a6
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 459197
+  timestamp: 1714510992914
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+  sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
+  md5: 3d57d1adadca9388aaaa1c529b65ba65
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 322790
+  timestamp: 1705602163804
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
+  sha256: cf38c69cf62d8f07b91b14bef8e0b6fc5ac220bd3a6cd2ab0378283f0f11494a
+  md5: 11660f745caf5eed1d03eafadb32678b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 25470
+  timestamp: 1704206932876
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+  sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
+  md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
+  license: Zlib
+  license_family: Other
+  size: 104928
+  timestamp: 1714510936868
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+  sha256: a3f3eaf240991b6bd7b0596a78d0abb3321cc79db52fa24f6f559189778871c6
+  md5: 71f035b4716322539e2461cb6667e946
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 825339
+  timestamp: 1714678419523
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+  sha256: 6e6787755de0cf2fd776c9681a7b0fd0fb23e35e679a463cc2005b991c413910
+  md5: ccad42ec9a2ad48939f089c528abc8f0
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 229694
+  timestamp: 1706220431719
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+  sha256: f715f7c2e06149bd6d43258e41479d3171efe5e9d56050a0a5f5652ed9d05fff
+  md5: 11a8ca43d69881b88f95ae681478866d
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 36089
+  timestamp: 1676424516042
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+  sha256: 9adabcdd2a10f73fa5ba56adc901eeea2e379991a0d4cb9737eec7aa6b9fc5d8
+  md5: fc80b572be85601706d425b21a58d497
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153102
+  timestamp: 1695718054194
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+  sha256: 38ccda1553733326d99a75436b4b0f7640bafbbfcdbc33838b0e59cf017de687
+  md5: 3f6812578c5e0b3ba0d2a651cc766c15
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 266405
+  timestamp: 1681493141116
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
+  sha256: fe765d810e1612af7a42f34223077f0adc05dbd386b257be24661913d067fe30
+  md5: 82e988aba03c8afa03fce78f7442806e
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6086137
+  timestamp: 1712084583317
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+  sha256: 5c12a5d7856d9977447360b3a99a5b99818707fe79781ba1779037f11b3fef53
+  md5: 6a125ae352306a944aabc635a5fe13a3
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 139230
+  timestamp: 1707864402762
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 751071782f597f87ed7f67437ef6cc669213902461b9795dd6eb0f4897eddc83
+  md5: 5ad8fe62aad5e16cfdf2c5a7d1327fe7
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_8
+  - libbrotlidec 1.0.9 h2bbff1b_8
+  - libbrotlienc 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 19418
+  timestamp: 1714483531456
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 9bd62d810867549b9c967c5915f3fa3f66cfbd6ede28b1cc152efd1261285c0a
+  md5: 64cc76de3662b62bc8f0e42befd92c5d
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_8
+  - libbrotlienc 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 32178
+  timestamp: 1714483513837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+  sha256: 1547fa52134cf06b8d01bdf52114db7db60a89bf35c9c95be5b5a03b13dbd565
+  md5: deb765cb7c4b7edc4d126f864f31747c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 356401
+  timestamp: 1714483740924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+  sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
+  md5: 11e0af09a31e2d5df51c65a342032b85
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 112994
+  timestamp: 1714511182837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+  sha256: 73391a74a5300ad3fb063ea0f0c3491d220128a0611a84036da2e23c1e93dc0e
+  md5: 501ded4f9b5ed895077802defee912cf
+  license: MPL-2.0
+  license_family: Other
+  size: 171644
+  timestamp: 1710764856021
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+  sha256: cd6545642e380b13700f2f2a7a1fb54a273365047bd23108dbd03b197f5c0c9c
+  md5: 929edc1c553d2da4d6c6c0745b033cc3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 166377
+  timestamp: 1707229328635
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+  sha256: 5cb6ac90ad234248f3795945f69b0382397714a52712337b2f86339526b822d8
+  md5: b90f3126f6315ea2e8ab242533062557
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 302693
+  timestamp: 1714483562551
+- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+  sha256: 7153817dd49ec317b519802c7c22c836602e00cbd96d68385e83eaf4c9f5ba6a
+  md5: cd829e5997611a602e29fa2fd5882635
+  depends:
+  - colorama
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204113
+  timestamp: 1698130080270
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
+  sha256: 03f00c22b6d92ee55b727b369e8dbdd9a4d590f2655b62b7c45ecd046741858e
+  md5: 116f67c13bb0b3caee6cbde334ff6abb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49934
+  timestamp: 1683040303796
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+  sha256: 4099898f02e1f6119fcda65e747c3cbfef0bf563c8855b79a0245160709d5b45
+  md5: ab9705c34e67fb8c8faec69d63ff4064
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36410
+  timestamp: 1676422341506
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+  sha256: c722f50980d7416ffb2cfc7bf72649307a0bb78c5a24eccefcd049cb61d6b355
+  md5: c7c9ff0513ff3c99700919293b702410
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 543258
+  timestamp: 1709758602437
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+  sha256: 8fb3e816a5ad1da05125462dbc9e2a7e933b001a871aa65703802c0a894c6277
+  md5: ee4b2fa9fce130496d5c7c86c35a1a05
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17723
+  timestamp: 1709323150229
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+  sha256: eeb49cd151ecdccd40062e8123a3b7a9a8a1eda6567dd33ce909ff8ee1a97c89
+  md5: b7fe1f7ead1ec2ac642d022942282fc8
+  depends:
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 232451
+  timestamp: 1700583772701
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.5.0-py311haa95532_0.tar.bz2
+  sha256: d4875dbaa16d83af1fc9a05d4d14dfd917f3840fa4d751160f070a7cbaa20230
+  md5: e1d44a630a3508b624fcd37e1d7684d1
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3173632
+  timestamp: 1715838851049
+- conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.16.0-py311haa95532_0.tar.bz2
+  sha256: 7c57396f00b4d63b1b597ccad75548f6e81f4e2b831c660fe14c6764d62148e8
+  md5: 0d1d476cfdb705f2ed6cfe2f6a092ef4
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy <2.0a0
+  - pandas <3.0.0
+  - param
+  - pillow
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18023517
+  timestamp: 1699544725067
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+  sha256: 5c73f86e575f2ad683ee4a1c2df11020e270edd89d12f11199483d57b0b51826
+  md5: e96a12895ce374476277b1b196ba24bd
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3719519
+  timestamp: 1690907216785
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+  sha256: 5d5fc8a24c804010b8cb5963227230352ea3ccf56bea9e8116e34f77223218f2
+  md5: 8f989a72eed6293dfe0533c83057980d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17688
+  timestamp: 1676423357100
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+  sha256: 27fb03eb57d25711a15e145f47a64320a9955b585efc9fd0a1a51cdd71b9fde3
+  md5: eb3869e98f6f53dfec76e2eff4d6b61e
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 2732423
+  timestamp: 1713552175344
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.3.1-py311haa95532_0.tar.bz2
+  sha256: c906de92968266d481957c5776467523da53b7f4d6daadb63255bd5cefd252c3
+  md5: 2710581e3de1c90426c77e4b73185262
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372660
+  timestamp: 1714461880258
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
+  sha256: 68d59a361a93a5ae36542f667138b4ab072e1abff15b3aa2dc55575baf86a3e9
+  md5: 383239566d9506b743c7bc65d709b7e1
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5374020
+  timestamp: 1707836834797
+- conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+  sha256: dee3fc68ed81398d232b3afe9a032837bdbef98c1b2478604d6abd397e3e7d64
+  md5: 3f75535ca6dfee0745b221922f21f6de
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353312
+  timestamp: 1715090519918
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+  sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
+  md5: 582d2c1135a89da757a038de831e7f39
+  license: Intel proprietary
+  size: 11086648
+  timestamp: 1664812389803
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+  sha256: 102c803186db6d62eaf41a906f6c563ff0d62b53c1eaede8a381e18c0d005ed9
+  md5: 9d30dec03058758a428cf152e0ae28b5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148193
+  timestamp: 1714399061601
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+  sha256: db30abacf919b3f68ae1e6a94c467fd1e69fbf47ba7a86e6b491d8bfe4776f92
+  md5: 9299876e7ddc3aea3487fd93340ceae7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 50842
+  timestamp: 1704813715071
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+  sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
+  md5: d215cc8ee7ca2cc83cc250cc5d822fe0
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3929136
+  timestamp: 1699647939158
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+  sha256: 864e9598f64105769b4ec02cc404fb507bc59e217324daf1686c00cfd12c0055
+  md5: 6bb1c3be1f85799a3988afc2c3c5a4f0
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229621
+  timestamp: 1705934494547
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+  sha256: e0b44f0c3a4ead0fb8e58033c0be25524ee9ecf7f4cc632f03e9f6fac3484baa
+  md5: 50cbc18d0c7b42a4553b52d0cef2c857
+  depends:
+  - colorama
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1637367
+  timestamp: 1704834149957
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+  sha256: d81566367c79a28d4717157fc74293e846a47af99387ed479eb001a425dd398e
+  md5: 28c76079c96ad7f8b1a5ed32b438c79a
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1147434
+  timestamp: 1679427525584
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
+  sha256: f766a445df8e81447f27c830e162566b221fa1bfc41296a6c5e0789586ca1fbf
+  md5: 55bc50633414fc8616ccbf4140a42d5f
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353715
+  timestamp: 1706733949898
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
+  md5: 81f2c343dc4c65eea39c45383272068f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 407861
+  timestamp: 1677849239400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+  sha256: 5e6698015a3b048093f5737f0e54bcbae415d0f9682dfdfeae3a8cfb4ea275e2
+  md5: 0093a4214131046c4f68af0739dfbea4
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 201456
+  timestamp: 1699041872445
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+  sha256: 9581be54128954080d7cef448b1728874c2ebbe5064f55adece422cf12eafa5a
+  md5: 3adc105f87d5c7f0b1248bc3423f5b48
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16187
+  timestamp: 1699032556953
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+  sha256: ad8343bad7c8f0448cbcfbaf872cc94b56da81c52e5cdcee2a5d6b89f029eb75
+  md5: addceff8d46c9d1d322618a9ce9e5b39
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 300354
+  timestamp: 1676424060532
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+  sha256: 851ae576c2b72bf3172cd460feec4f5577dc06476a043e185279071b67549fab
+  md5: fae4d214d00de6604738f39acbbb197e
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119710
+  timestamp: 1698937651636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+  sha256: d97ad90f9121ecf7f8d3af773b222c0bd244204ee73a3e44185491fa16d83104
+  md5: 73ac0fa3c67e5eb283173d74a2771752
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 60625
+  timestamp: 1699282918176
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+  sha256: 257e1102d2dc3f8b0c1708585c819e86f41abd101084cd0569e8e31652480875
+  md5: 2128c6806bba6953e1a275f37e7a295b
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pywinpty
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 614705
+  timestamp: 1699467242943
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+  sha256: 90420847230e72a648417f5f77cebcf7f17b89f70788652c276acc0c440e135f
+  md5: ef3d8dee197aa37897bf6d39d2dd878f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=2.0.10
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27639
+  timestamp: 1686871052174
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+  sha256: 97faaf26ce5254ec3649a8ee7f480b1556e4e8e6e4356d2fab1e6a5532631a0f
+  md5: da23bd831c50c877f63038b7e16720ad
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20163
+  timestamp: 1700168785472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+  sha256: 8a2f0909fad0387e57cb0e9ee30db2b20761a9106e794381ffeac387a298fb07
+  md5: 6058b2efc3284e27aacec2e6e6280433
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62334
+  timestamp: 1676432044242
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+  sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
+  md5: f5f73266281ab12377d5d47bdf07500a
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 905072
+  timestamp: 1617648814933
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 7c906c94a4d46ea963080a6ba5bd12c1274da66159877a544fbc70291eeed98d
+  md5: 45a3d52534fac8aa54a55ee92211a918
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 80216
+  timestamp: 1714483371043
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: daad7edc6d56abf3e176479e8628162dbf1c56b3d24db30d708aebae694a5214
+  md5: e8ecf229f7fcb4c0b76d8613627948f5
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 45189
+  timestamp: 1714483420152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 84320217abffa9386186ec8d03b4651bb4b1900d3871adc965a9a9e1d3799907
+  md5: 651312fa22168f71f9aec5f9ee2c2fcf
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 756116
+  timestamp: 1714483464368
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+  sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
+  md5: cf949d76148be1e2a534218d9c57df86
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 155435
+  timestamp: 1714484319443
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+  sha256: 4534c822511a052a72c2b070a05e5d8d6f3550f18ea00a33f9d8a9a92b4382cc
+  md5: 82f24e7660831445a2183216e280a6a4
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41464
+  timestamp: 1676474474981
+- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
+  sha256: b2b50fb4e43e4c4da8db26cf362671e03774384732e1925d82e12dfce45c5ac3
+  md5: 44ff317b1ff9bd2b1fbf39da56965b16
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 20842990
+  timestamp: 1706911120234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+  sha256: 896b7a39bd4ad3621312130122b4fe84dcb67d7355166255c58ea9bc562eb0ae
+  md5: 640b852a56296f48cf073e61a59c5256
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13751
+  timestamp: 1676428354074
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+  sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
+  md5: 320f40b75d93f3b96931c6d13c23946c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 158902
+  timestamp: 1714512129889
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+  sha256: e0dc6e119b224bb31ef34b6ba270ffadc181d38b698c5318de8df7a5d2c4ccbd
+  md5: 992ccd756f09408f0b74dfb9852a8b7f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 182381
+  timestamp: 1676437963591
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+  sha256: 050b5fd4b28132d8102a7e6b40179894dc7f5e41f7ad9ee19211e67446c5740f
+  md5: 3ae0b2f6baec708554648ddafa81b756
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 154386
+  timestamp: 1684279992864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+  sha256: 8269c73b7a9c03b95a121e318d0468f35eecc016093620b0560f35238cc5df51
+  md5: 2914bea0ae29315f998e1abac79ccaa8
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30214
+  timestamp: 1704206218108
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+  sha256: 68fb7d113dbf185b571343847e3dbefdbe7d0b9b5902f1f390bc2a6e33a3f8ee
+  md5: a72ff718390a1fde0b208a43e6b9b655
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 11366001
+  timestamp: 1713336740870
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+  sha256: 43279276850eb6e621812448cddc1093524cee0b7f8ed58b4600b68a4fb659f2
+  md5: 5968b2b5c1f3cf5c8c8c9aaa4d8d66a2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19886
+  timestamp: 1676425829787
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+  sha256: 3062a8254ca351b54f15bea85cc928a3ba4d879bb98ce97ece39a9f7eca215a5
+  md5: 8f1565663abb34ad7fdd512e76da5532
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 68031
+  timestamp: 1676481862508
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+  sha256: cdff5215c292fe59649ca40ca72f5d26da352760c1d6a56feba14eb13f7bbf61
+  md5: e0f3f32b22135dfeaec277bc87183ca9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23328
+  timestamp: 1676442709081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+  sha256: 3b173a25605d2aaacc57ec0e425f1d1c51327eb2521c8742a736e2c76069bc8d
+  md5: 169f1c93a443f95a88665f3008623ce1
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104882
+  timestamp: 1676425142412
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+  sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
+  md5: 527155127b9fada5e5c5c69a624674b9
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187498166
+  timestamp: 1699648376430
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+  sha256: cea59ae60da314caecf08edb9bcb03126c6dd35837c8184bceaa194decca3341
+  md5: 30936b7263cf0171f7c86400f12ef184
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49080
+  timestamp: 1682975093455
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+  sha256: 5070ceb0a406b1b8b99e2ec58f5d224cbe16ec78109c46720bd182b509e05c6e
+  md5: 34de1af5c639f2d06c6c8d99488e4226
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 196201
+  timestamp: 1695058367111
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+  sha256: 6b4b27302e458fa527321c59be7c335d61f86da7501c4d141db20a72fad68b55
+  md5: 7db9b12da1290bb2c2fc6ee52a945905
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 256371
+  timestamp: 1695060425702
+- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+  sha256: 39f09c1bc57b4800ebda331eddb462928435498705351b0432d51a4293294ad8
+  md5: 5565984a02f41e97cb9a4c9126ced14b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29808
+  timestamp: 1676442800892
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
+  sha256: 5422fc4dc6708279223027e45dd1ccffe4dc2feb93c60c8a683946a398c60a1c
+  md5: 62d16437707dd382c21a9ed1d8b375dc
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8304222
+  timestamp: 1699543942441
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+  sha256: e940f9178ee2fa0a7c12873ae35ebea0074371653e5cfa1be8aa8d9271fd343b
+  md5: 355d0835215911738a28010dfa6aa382
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141785
+  timestamp: 1698934346590
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+  sha256: 47dd00c0179f4eb29c70d0453d340f7f5332af326b3d51c64ca3bf6a14be8e7e
+  md5: f66afe718bdb57667b03ebda4cb2ac7e
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 561655
+  timestamp: 1699023338436
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+  sha256: 4ee863a1ff697274c642b3101f82b279a354e3f033a87505655039f89127bb41
+  md5: bfaf19be6644ad2344e118aa0acccb13
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189809
+  timestamp: 1694617194065
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+  sha256: 90fb3f14c49da1397982eae21cd09e8d60d491d76f94c57590c56723fe6dc172
+  md5: 46a523661fe5c1bce7b4213fd428c3de
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16732
+  timestamp: 1708532795328
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
+  sha256: 5db3fd8b4d97e2a6232e2f7c62f1ce82ae3876326aed9f8c3ea656eda83e55da
+  md5: 39c36df9dac13398e8a54497dcc14611
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 755697
+  timestamp: 1690986137327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+  sha256: e040ebcab948325fbe17e4ab15be62e1fafa7bad225457e59764adb60eb40db5
+  md5: 4d40a09df8cb74a9f044eab317436d67
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27282
+  timestamp: 1699456187703
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.59.1-py311hf62ec03_0.tar.bz2
+  sha256: a20cb730d87b945125202c7f4e81490c24db708f373d1214e6b04f5d2b4177b3
+  md5: a235c61c1928d09080158ffd42ffbccc
+  depends:
+  - llvmlite >=0.42.0,<0.43.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - cuda-python >=11.6
+  - tbb >=2021.6,<2022
+  - scipy >=1.0
+  - libopenblas !=0.3.6
+  - numba-rvsdg 0.0.*
+  - cudatoolkit >=10.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6100005
+  timestamp: 1712021687877
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+  sha256: d3bd2a6614bb7e7f5ce3348d6674e71cce45cbde236beff32f0f08cd95a64ef0
+  md5: e70f15643164f432d1df68635e7c322b
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 162691
+  timestamp: 1696515822068
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+  sha256: 470fe9a0b3e196fa60d5550d8188f6074a207572fa0d353a4448d580872e7804
+  md5: 6fdb8df0613fb2fb9f1732d335fa25f1
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311hd01c5d8_0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11053
+  timestamp: 1708641901110
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+  sha256: 222c1711e7cf151e29077c7d4d86a865c9fd39615812d58a1daca6fd1b6bdfb5
+  md5: 585bcd8bc3940a8a859f38ebafdcd77d
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.26.4 py311hdab7c0b_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10723862
+  timestamp: 1708641867155
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
+  md5: ab07e2a27ac08afe3d0b4c0890b8486a
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 2-Clause
+  size: 249316
+  timestamp: 1630094024143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
+  sha256: c8e066c2cb547914401ec29b7356914ca3cdf6ac37eead248fe0c41236a7838c
+  md5: 5879739cc77497a518b2ebd55857183b
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8118619
+  timestamp: 1716319803768
+- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+  sha256: b2f5f50a1ddf811102636f3acebd76716c88ebb628754b91eda7a3a962adf26c
+  md5: 712527b4d84c350dca4b67f511c04414
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39421
+  timestamp: 1699371341381
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+  sha256: 432b8b7c4671878cbbe361e518544203f97bd2e4f24fa08cf65e8be583f25529
+  md5: e62e7c668b080e0f6ce09fd548f69f7f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 159066
+  timestamp: 1710809127954
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
+  sha256: 3ae55d8148580fc3f171c0fcc420488fbba05517cefd358fe013b45ec3594371
+  md5: bfb42ed6826a1c8cded9539fc6e07029
+  depends:
+  - bottleneck >=1.3.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - python-calamine >=0.1.7
+  - xarray >=2022.12.0
+  - lxml >=4.9.2
+  - dataframe-api-compat >=0.1.7
+  - jinja2 >=3.1.2
+  - zstandard >=0.19.0
+  - blosc >=1.21.3
+  - matplotlib-base >=3.6.3
+  - adbc-driver-postgresql >=0.8.0
+  - xlrd >=2.0.1
+  - fastparquet >=2022.12.0
+  - pymysql >=1.0.2
+  - gcsfs >=2022.11.0
+  - pandas-gbq >=0.19.0
+  - xlsxwriter >=3.0.5
+  - pyarrow >=10.0.1
+  - html5lib >=1.1
+  - pyqt >=5.15.9
+  - psycopg2 >=2.9.6
+  - scipy >=1.10.0
+  - numba >=0.56.4
+  - qtpy >=2.3.0
+  - openpyxl >=3.1.0
+  - adbc-driver-sqlite >=0.8.0
+  - tabulate >=0.9.0
+  - pyreadstat >=1.2.0
+  - pytables >=3.8.0
+  - beautifulsoup4 >=4.11.2
+  - pyxlsb >=1.0.10
+  - sqlalchemy >=2.0.0
+  - s3fs >=2022.11.0
+  - fsspec >=2022.11.0
+  - odfpy>=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16924671
+  timestamp: 1709591125871
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
+  sha256: b529eac4abff05f13760c51ad37adf24e744109a6fb30471b26dc1f6a1c23847
+  md5: b690cc140a7866280131762a26c05f39
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.0.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21902721
+  timestamp: 1714073654508
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
+  sha256: e77795e1af9bc27d45841d6b9c51e0e7da31e0eabaaffa99162245adc55d13a3
+  md5: 14046398ac44f496bc9df300285ec586
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 267222
+  timestamp: 1711137058994
+- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+  sha256: b0d7fbfcf1c5c682ed9934eb6a33e00a2517941f2bcb9d677379f4bb73b2c45c
+  md5: 20c8f36595a48f5cda2f4f74c02a3ea2
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48206
+  timestamp: 1698702818841
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+  sha256: 6ca54ba8ce430caa8a1838b19869814d0b7fa3592a77f75298130983e635387b
+  md5: e56c194e56d19dd8fd76f75a77f92c33
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 1070844
+  timestamp: 1714399290671
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
+  sha256: 15001c7ee6cf6e0ef7afc2f313114f6103e7b6f641fac9a6899ee02d6537c822
+  md5: 250ba95e77f5fcb3fe2aefa85157e859
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3759346
+  timestamp: 1715097175495
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+  sha256: e5f8cbfb5fc25d460a9117bfc5511959c5e86ccb193316033f87bd516e0c8881
+  md5: 9f7e8b5eb651539386bb92c14e5c321b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37730
+  timestamp: 1692205554840
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+  sha256: 6c5b53831273674361437fb546e08315fc11ca9275a174bca3887987e86ced5a
+  md5: f8d91daf5173eb03157f484389adcdd4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 122178
+  timestamp: 1679591983138
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+  sha256: 546819d922b03f3a25ca9f98fd069d0588d481fc0603c6d74bd598fb6a93687f
+  md5: 86c18e3e0b67ee099457475ed6caf2e6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 751763
+  timestamp: 1704404627180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+  sha256: ae06f0dfa2cfae51404afc6d6ad3a474a93015b5ba9a7d3ea24224b8e7547987
+  md5: 3e19794c806cc3e84a3080a97c359b75
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 510466
+  timestamp: 1679005998612
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+  sha256: e2af1efb1a5094a5962d93fa949ecab479a2ae7570e030f52eeac6761383c208
+  md5: 4cb1359e22ddf8f3996afddce5f6205c
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 56638
+  timestamp: 1676438592117
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+  sha256: d95c88d06f4f3f667bd9a39e5f18179e83b3cd4c115c06ce0fff390ff6d3a700
+  md5: c6d00a8a4d89b1be99bfa3aff19d96b4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2134881
+  timestamp: 1684280285492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+  sha256: 643a9a0eba1e2bd5980d21623d3b35188c24781ec251acc4d15714bd1ccb4c17
+  md5: b3cda0394db05be6f0f6176abacb13f3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207985
+  timestamp: 1678721438358
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+  sha256: 974c22de09078bf07c5db31fe12d8d89d6433508defc8237cbe52e08c69ed56b
+  md5: 9cf10bfd49140a527cf4b1d912097e6d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36072
+  timestamp: 1676426019064
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
+  sha256: f43aca7a222c983c25c3e15f79c7e7e3c4909bb7839a1dd0ee327def81aa476e
+  md5: 2b61f1cb7fec068c76ef0ff97c2c62b5
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - openssl >=3.0.13,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - openssl <3.5.7
+  license: PSF-2.0
+  license_family: PSF
+  size: 19811751
+  timestamp: 1713545124922
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+  sha256: 2c61639b3bb56fc864c86558bceb7845b1731ac44bf1a94894172ea47a995bd4
+  md5: 404805e547b4d50b5cd17e16bca87527
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332043
+  timestamp: 1716495838826
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+  sha256: 9acb33db60d9319595f52337cae3b88c2a2338cd66f1f9d8ae86d0a993c2067a
+  md5: f4af8cf94d042b4dde487241bba1c457
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279780
+  timestamp: 1679500609851
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+  sha256: 48fe7373b012b51134b6b6ff67f18d2b4aae3a5c7700e4560ce002af7172f064
+  md5: 0379cd17692152c12b662b0e4ea46b88
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18008
+  timestamp: 1683824373128
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+  sha256: 803274d986d0c4e3b5ec1018747ede86ef57137455b3e44a60e834717eafb92b
+  md5: c9f134ddeff6fdf0373a45534ddb7079
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 273009
+  timestamp: 1713974722039
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+  sha256: 6fbcba97c1dcb5157afd23f264c3cff069c7e4be5ea55980fc349eb8dc2cb49e
+  md5: 8153e3f8b3283926bcf9403804a365f5
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65050
+  timestamp: 1711137009299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+  sha256: cd33dfee104dfbba4af38d06a09ccbae6a32e7c543afedab523303319ebb283d
+  md5: 3dfc19af0306d80921e1403f1f551bba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13679916
+  timestamp: 1676423267293
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+  sha256: 102ff1d958209e3648bb49da3503cf752abab822011fdc4e12e88145c9e73772
+  md5: 0553c2c381b6f5c836b23edc8c6db2ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 246689
+  timestamp: 1677708371873
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+  sha256: bee5c4d0f41f06a9c0aac636885e36e8b81116aafde980f9ea48fdb64abb5567
+  md5: 6c05a053240cb90765d6f8c2efdf905e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 182228
+  timestamp: 1698096268270
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+  sha256: ea39db411361d96545a04fb976940e9590147acb4ca9caacf7e8264780379347
+  md5: b411b8be8e53e5059949dde02dd07faf
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 565148
+  timestamp: 1709319072176
+- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+  sha256: 47653b45a5f2d97b5bf0dbf0e620908880f9078da427eef69012effe3f19af67
+  md5: 44e709ae67d89bccee2d4d46d358fee3
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74493
+  timestamp: 1699012356534
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
+  sha256: d7bcba5262df162756885a773c3bf2dace27311bbbb1830a0f97aa60ac7c1239
+  md5: daeb99ccfe39f725278203412aac0873
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 120468
+  timestamp: 1707355917958
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+  sha256: d6daaa6b45272819176e4aeb467ae00e3db43386548464a9993688f292709d40
+  md5: 9fe721d7f7420c259df4f07d4503f654
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9683
+  timestamp: 1683077110211
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+  sha256: 6051860575f9448aea5799d74469c928cd7cdeeca1eb53657872262a77b1a7a8
+  md5: 60e193eca497130034facd5fed168249
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10094
+  timestamp: 1683059114376
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+  sha256: ecd310461c1b45ab92ddf15539cea5a6e837860561c974d2d7393f9a7933f116
+  md5: 1762fec2838763e904141167e18b0389
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 215600
+  timestamp: 1698947891859
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
+  sha256: 0042fa2dc2ec8c2181f28f5ee4f45087ea58dca7acc6b89c48f3ce6eac8f9bdd
+  md5: 755c9767608b233b94ec3a67c8e0da4b
+  depends:
+  - blas 1.0 mkl
+  - icc_rt >=2022.1.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 5
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 32418527
+  timestamp: 1714081783418
+- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+  sha256: 6fd52bae6360fbc8135d72e0c1e4fd407769fa4d0f4b59356e7aed3e000eb339
+  md5: 49fd52885250da8aab17ed72e2e18b81
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88901
+  timestamp: 1699371435766
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+  sha256: a2ec4690bc07be9e7f3ad8e3003803eb4304a434d3f139633e2817318a9f7b20
+  md5: dd2d225219924fc5c36598c919541271
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1593050
+  timestamp: 1715025622141
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+  sha256: 5d1b7e14dc04816692de0f8518ea8fcbefb26ab61cec83f96f2c44c1bee67fab
+  md5: 505d2a70a875b5082dc857aa4dfab0d4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 18830
+  timestamp: 1705431395254
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+  sha256: 5ff3b4ac3fbce4dd67a87856c04698d0397deb0ac288ff4e7eb02fbab57f1253
+  md5: 0ca650a7001c6650809d3361de8cb005
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89590
+  timestamp: 1696347858925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+  sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
+  md5: 833b93a2daade3407898f15588945d83
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1440481
+  timestamp: 1714488344682
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+  sha256: 78d89b50a29fbeb19a562f5dad95615e3f192bb4f3b86cd6ea75f2f825418232
+  md5: 4a4040df560ea47704e0898c4c015808
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38069
+  timestamp: 1678228553220
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+  sha256: 70a3cc4a4e81a6421bc19cd410d1d6064aadb2b1cce38b020f85e5346716d8e7
+  md5: 32a9a2539579a3d522dce3b5cb4f987b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49495
+  timestamp: 1676425411739
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+  sha256: 0a95736cfd0bb25fc201cd6be4a2450ea8fc30eeb349d861812675b84c94fa74
+  md5: a8a9fb30c6dd8e7a16d5dcd2333c3c49
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3844176
+  timestamp: 1714770894235
+- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+  sha256: ed5950ac0c12cc87f991a6f28112cf29057e2b7ad416ae4429a0b97c3efaf58c
+  md5: b5e2a04879e6fd19f0eb5effded4dc61
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135939
+  timestamp: 1676431438808
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+  sha256: 4febf30c11674711b86c8c10da46a5e1613071388da999210912a31508864add
+  md5: 1c109fc1112ea1f5f377bdf0d18ba75f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 895633
+  timestamp: 1696937216859
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
+  sha256: 973dc7991dd5976ce2d27a94739712cac4d31f2d2958fbf23adb844f5ac999c8
+  md5: ca74b36907b3f4f8a51bd5b2e4d8220b
+  depends:
+  - colorama
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 186541
+  timestamp: 1716396206048
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+  sha256: e8c77efe880546252f244f995cbed5967809555127b4f818b97455d434b23415
+  md5: 7397ac07045115960ebd8dec95326a7a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270819
+  timestamp: 1676423321499
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+  sha256: ab3cce654f1e94793fff0cb03b750d9b20cdbf099263b1906c3c5eaf8b347ab6
+  md5: c68ffc771312afb6f88b94c24d2bb689
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9706
+  timestamp: 1715268972001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+  sha256: 4089efea1753ebe2f6617b46cc368738f285b1d816d4a4f01ba71524f46851b4
+  md5: 7f610528ecd0b317180efa2058c32323
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 75414
+  timestamp: 1715268958140
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+  sha256: d091897f05318c22ca31028370f25355065999078f7db6f88ab27bf4cb030ec8
+  md5: 1776502c1cfb351554eeda6cddaf255f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11588
+  timestamp: 1676457729096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+  sha256: c16498f8238cc331618720d078b87995eceb6bbf20268a7a4e8efbf7b5859a9a
+  md5: 770432c0ca1ab9d99ffe95e51d3a3e74
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 517433
+  timestamp: 1713213261710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
+  sha256: 3009bd4e7e8126309e606c81cb75d4b8d4fbb2bceac10ec43f7eb6eaaf717ac2
+  md5: ee6e87af42008a762d3531771c1a2b18
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - selenium >=4.4.3
+  - requests >=2.26.0
+  - h2 >=4,<5
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 210034
+  timestamp: 1715636431813
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
+  sha256: 906048f3b1dc326b367a08edc91816ff523b5f06cd45d985b4dbb7cfe8017559
+  md5: e509c495aaa92d767d554cd43a990ee5
+  depends:
+  - vs2015_runtime >=14.29.30133
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8900
+  timestamp: 1715797316229
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
+  sha256: ab224d078734a23527716388ddffc034d18254843881d0fc068c2efa35bacfe1
+  md5: 73f5831d017e5572330d2459844718f3
+  size: 2246565
+  timestamp: 1715797302913
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+  sha256: 24ea3d3e0cb98d0d246338dbb4562b67967bb32002e3704e495a5c863476e831
+  md5: c7b9cdbe87b3c9720aeca1164a0fd6df
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26181
+  timestamp: 1676424437003
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+  sha256: 92d27e41ce34387e59acb47572fcb2e92c4defaeadafd11ce190226022023e69
+  md5: f1bf142d852987acbe4b0bc94e87d958
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145306
+  timestamp: 1715878654770
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+  sha256: 1b086d1b079fdb2f148c7dd82658f2b7f283c88f286e1216c0f1237319039b0f
+  md5: 299e87f151a549d86a48bf24df15c607
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 168041
+  timestamp: 1714717238470
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+  sha256: 17fadf35aa8917c107e7b369e9364ac7c09537776e7943d37e225e14b7026c94
+  md5: 0e67c3b9624540581b894b11267a837b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PUBLIC-DOMAIN
+  size: 10197
+  timestamp: 1676425485716
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+  sha256: 25373efabba9a866849fe38a47c79e0fa323851b4bd4b5df357cc8d5617c2786
+  md5: a958e9d32c3b65c21e11e5d9e8491c43
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2467966
+  timestamp: 1689041676824
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+  sha256: b849b368e27920838fe40a512b102879693a55cb187dd1c8d3a83fa8c05a8054
+  md5: 7b1f6e9c71906a93039b3446b99a5498
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55114
+  timestamp: 1676434863173
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+  sha256: 344a5276a9928638dcde054dfe4e87c8cb40bd2d4d356378b9ab2f863ca62e4b
+  md5: fe471fd8b5a3d77be6fa5dbf9b99dafb
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 1432281
+  timestamp: 1714515119689
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+  sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
+  md5: e5aed81295b61b6d1eb62830799a0297
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 9125184
+  timestamp: 1705602328351
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
+  sha256: d932439798665be388bbf68f3d68da5b42ed4753a43587d3f49848a85f58add4
+  md5: e2900345674e644e05540ffac6acca89
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 25247
+  timestamp: 1704207149955
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+  sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
+  md5: f295b54ab59f5b8658e2a322ac6aa721
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 162161
+  timestamp: 1714514792081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+  sha256: b2ff66b7f6efa0831f939e57e562c244332b690af08818a540d1a97fa07d8525
+  md5: e548d528873d9a0006a36714cf36462a
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1933522
+  timestamp: 1714679197977

--- a/gull_tracking/pixi.lock
+++ b/gull_tracking/pixi.lock
@@ -7,718 +7,718 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.5.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.16.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.3.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.59.1-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dask-core-2024.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/datashader-0.16.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fsspec-2024.3.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numba-0.59.1-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2024.5.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.16.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.3.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.59.1-py311hdb55bb0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/dask-core-2024.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/datashader-0.16.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fsspec-2024.3.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numba-0.59.1-py311hdb55bb0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.5.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.16.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.3.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.59.1-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2024.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/datashader-0.16.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2024.3.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numba-0.59.1-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.5.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.16.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.3.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.59.1-py311hf62ec03_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/dask-core-2024.5.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/datashader-0.16.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fsspec-2024.3.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numba-0.59.1-py311hf62ec03_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
   sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
   md5: 613805add1c05b538ff06d217252feb7
   depends:
@@ -729,7 +729,7 @@ packages:
   license: BSD-3-Clause
   size: 20810
   timestamp: 1652859733309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
   sha256: 250f50edf43a786a32942e9ae67ce807e9b3ac4cb6b58b1170cb541fb24e391f
   md5: b48058294499d292ddf9a3b966dc9cc5
   depends:
@@ -743,7 +743,7 @@ packages:
   license_family: MIT
   size: 228473
   timestamp: 1706220559474
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
   sha256: 0d4f5274503916e1c683dcc16e8a7c4186557afa3f62399cd628e4eb535fe77a
   md5: 062acdb0f9ae976c25c2d15d589dc1d6
   depends:
@@ -754,7 +754,7 @@ packages:
   license_family: MIT
   size: 35809
   timestamp: 1676823571351
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
   sha256: 567dfdd5b986012421a736a5f1c1d5874d8d691dd483c838b55e1ab06c0b217d
   md5: 4e0aa1543f546b898523382ee8405e84
   depends:
@@ -763,7 +763,7 @@ packages:
   license_family: MIT
   size: 152577
   timestamp: 1695717917074
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
   sha256: 894fceb5b4f8740bcd146de8bd0f6eabf14e2407b149b790b4983b8432681e6b
   md5: 2f0ef211bf628cd22bbfa44c3f9bc035
   depends:
@@ -773,12 +773,12 @@ packages:
   license_family: MIT
   size: 271600
   timestamp: 1681493103694
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
   sha256: 9f027f156744dcbf28945aad6e422ef030c84c2a5d40116d3e40407c66853bf8
   md5: 7b52489e04f9a5585643d5578835fc68
   depends:
@@ -796,7 +796,7 @@ packages:
   license_family: BSD
   size: 6059952
   timestamp: 1712084450899
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
   sha256: 8e2b2073ff5c61d35714e8a36ce657a8ac741b7bedc2852a238c7f1625142705
   md5: d951ab54a682b6328327fec53b1e5e72
   depends:
@@ -807,7 +807,7 @@ packages:
   license_family: BSD
   size: 147642
   timestamp: 1707864274452
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
   sha256: 5d15605858771290fdaaae41a43941623757a25cb1292080d69d6d3857807935
   md5: 7f517469aa5380c52e55db9f37df104f
   depends:
@@ -818,7 +818,7 @@ packages:
   license: MIT
   size: 18652
   timestamp: 1714483267080
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
   sha256: a5094f078584e27c7cced4a9564ae904a329f5c1702a7c1ba092d581ba1544f1
   md5: 6ddf45dd8a21a9512481de9bc0e5a03f
   depends:
@@ -828,7 +828,7 @@ packages:
   license: MIT
   size: 19711
   timestamp: 1714483255915
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
   sha256: 93180c973816246f068b742d0bf64840f0ea48e31d4f9b0747ea2ffc34d8855d
   md5: f3a00096965a5ba1eb41d2c99a4662a2
   depends:
@@ -838,7 +838,7 @@ packages:
   license: MIT
   size: 361574
   timestamp: 1714483400014
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
   sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
   md5: f5058c8d5b2994b7334f18e022105a14
   depends:
@@ -847,14 +847,14 @@ packages:
   license_family: BSD
   size: 427542
   timestamp: 1714510571510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
   sha256: 394f74202c2efc8fcfd02b8953f508eb6a2961d224a2f9d15091caf5cbe1be67
   md5: 1202b4ed32215c6405bb42fbff355316
   license: MPL-2.0
   license_family: Other
   size: 137411
   timestamp: 1710764808838
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
   sha256: 6dc29d20180f6e002f37b251efa639716d3444e129a754dabf751f816aada7ef
   md5: 5dbfa083e6ab6318fac58fe0e0c94445
   depends:
@@ -863,7 +863,7 @@ packages:
   license_family: Other
   size: 165152
   timestamp: 1707229213375
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
   sha256: d138cc3fde270eba783baf1e2ba17c89800b2cbbf20976d0eb425b3436a4a184
   md5: 1875e89c1a939e4e7c5e7b731c72b838
   depends:
@@ -875,7 +875,7 @@ packages:
   license_family: MIT
   size: 302401
   timestamp: 1714483186060
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
   sha256: 9ddbf05887c7d7926418520cc7848e57f6d2431bc4ec6d30e090b02dbf865041
   md5: 57ae1141ad9a048fb2a75d7a3ef7430a
   depends:
@@ -884,7 +884,7 @@ packages:
   license_family: BSD
   size: 203190
   timestamp: 1698129926216
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
   sha256: a5beda842876d0d71598cd2a50ced5fb2731539bc4172fe501b93b60e0c6cd3f
   md5: d5293e5fe74a4e0d71bbf14c9a57f900
   depends:
@@ -893,7 +893,7 @@ packages:
   license_family: BSD
   size: 49509
   timestamp: 1683040113536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
   sha256: d9c102b9ec7f3a635936b6f73d4db126d748a25f65407353bd76b260dc7d1cd6
   md5: eec48dbdf5dac0ea26750cc26b58c1d9
   depends:
@@ -902,7 +902,7 @@ packages:
   license_family: CC
   size: 554986
   timestamp: 1709758392744
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
   sha256: 882481e441b9b93cbdfb32fbe32a6ad9f26197472f186a08fddb921f61346c02
   md5: 443c79196064f57c98199e9990544b2f
   depends:
@@ -912,7 +912,7 @@ packages:
   license_family: BSD
   size: 16902
   timestamp: 1709322958614
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
   sha256: e4877b41553e31b9f9f090dffab77a654255c63776e8b30fc91ec1f60afadbf1
   md5: c34d3f1520f1e8c9957eb236710058c4
   depends:
@@ -924,7 +924,7 @@ packages:
   license_family: BSD
   size: 281162
   timestamp: 1700583651472
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.5.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dask-core-2024.5.0-py311h06a4308_0.tar.bz2
   sha256: d7c1822466ff522e14771be1a4234a7e80da0a70fbae0b56422c419eb74fea2d
   md5: 4ac1601f900babedf8edf35bd98d2ec7
   depends:
@@ -941,7 +941,7 @@ packages:
   license_family: BSD
   size: 3104830
   timestamp: 1715838694654
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.16.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/datashader-0.16.0-py311h06a4308_0.tar.bz2
   sha256: 309e8323cc5e7506a2be851649d36be0b6a0e157194baf6ee4fc900a1b43fddd
   md5: c938e7730d42d87dba1658a8893d6338
   depends:
@@ -963,7 +963,7 @@ packages:
   license_family: BSD
   size: 18004747
   timestamp: 1699543167034
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
   sha256: 3b4cd8dc60572086f1a1cbb97e2712e0ffd55317ce8f0309d552eee7367855eb
   md5: 70a1263b6e19bf2d77c020a2e77277c9
   depends:
@@ -974,7 +974,7 @@ packages:
   license_family: MIT
   size: 2556575
   timestamp: 1690905285843
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
   sha256: 4b589e3265c74159130230c164ff2d8d381be65899a249def0b53f93ce83fd47
   md5: 245cb7173dcdba21cf368031cd87f706
   depends:
@@ -983,7 +983,7 @@ packages:
   license_family: MIT
   size: 17434
   timestamp: 1676823330845
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
   sha256: b75d12e85274660bb675a3e53d47a929872f2daa2ff5a76e98885ee3f2d19ad1
   md5: f2119d0885334060d0d7fe59e5220287
   depends:
@@ -1002,7 +1002,7 @@ packages:
   license_family: MIT
   size: 3237908
   timestamp: 1713551660998
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
   sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
   md5: a5dc8677d891dff2393b63189a3ad42f
   depends:
@@ -1013,7 +1013,7 @@ packages:
   license_family: Other
   size: 971975
   timestamp: 1666798278693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.3.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fsspec-2024.3.1-py311h06a4308_0.tar.bz2
   sha256: a78f34d0b919c5fce722d33afc278cd48f5eec2bf186c35dd18d59d85d45909b
   md5: 199586a3dcad8985bc4cb0e4262e06d1
   depends:
@@ -1022,7 +1022,7 @@ packages:
   license_family: BSD
   size: 364478
   timestamp: 1714461584790
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
   sha256: f48ccfb4214e2af41e73a3904e343ecd1eb1ae06578c26f55a5dd247771b2c86
   md5: d58e9eb09817935eb7342ceff889f481
   depends:
@@ -1039,7 +1039,7 @@ packages:
   license_family: BSD
   size: 5335524
   timestamp: 1707836581350
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
   sha256: a0ae6c5a6b615d73d9a243331f3f7d749b4feafdf2f334337fda8abd6c8355ed
   md5: e61d8dcd4dfd6d165e6e480cee846bf5
   depends:
@@ -1056,7 +1056,7 @@ packages:
   license_family: BSD
   size: 357992
   timestamp: 1715090462763
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
   sha256: e08e27531775de40f46b6ac7bf71856963baa0c008bd2b4d112e6341cd3e8f4c
   md5: bfc7682613c861cbcb4ac01485c05657
   depends:
@@ -1065,7 +1065,7 @@ packages:
   license_family: BSD
   size: 147174
   timestamp: 1714398938840
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
   sha256: c7ffa6006573483a05ef355770c3201f04dd04ab4b91ae01971a6cdc7fbdba35
   md5: 23d7d38e93d930ea5e2cc5f4079d3816
   depends:
@@ -1075,7 +1075,7 @@ packages:
   license_family: APACHE
   size: 49872
   timestamp: 1704813633807
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
   sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
   md5: 3add2ce56858a1b8f6a37342f82773d3
   depends:
@@ -1091,7 +1091,7 @@ packages:
   license_family: Proprietary
   size: 19310769
   timestamp: 1699647799237
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
   sha256: 0b670ab17ed2e1b592079bd64386dadc249ddc892e5ae1dd99f142a918ffc75d
   md5: 632575b9e442c1e5c146cf78424da610
   depends:
@@ -1112,7 +1112,7 @@ packages:
   license_family: BSD
   size: 227791
   timestamp: 1705934138566
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
   sha256: 65228eb868c3ec8aa71f958e60a675a919f016c2057392e02fd422fc841858f9
   md5: 68e23f14cd222c233e6b37262bc61c23
   depends:
@@ -1129,7 +1129,7 @@ packages:
   license_family: BSD
   size: 1612840
   timestamp: 1704833066871
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
   sha256: a2918ea8a3e2c56fc6d91191e84b2f35500c392b16ab687a0c03ded2e2e51239
   md5: 84fadd6b7fef393cccc0d123dae6cae8
   depends:
@@ -1139,7 +1139,7 @@ packages:
   license_family: MIT
   size: 1162207
   timestamp: 1679336523618
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
   sha256: 4520b83e425883981f97191986a08122fbaebc3f16b898368796314136779028
   md5: 42a8f32c4d842d3e5410b2bc1cc2fb57
   depends:
@@ -1149,7 +1149,7 @@ packages:
   license_family: BSD
   size: 352284
   timestamp: 1706733655761
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
   sha256: c21f8f407266d039e819c27fe9eb4fb26587e974f3bd059b37cbaec5073722d0
   md5: ba1f47411e9e07876c7a3e9d3be6a98e
   depends:
@@ -1158,7 +1158,7 @@ packages:
   license_family: Other
   size: 281400
   timestamp: 1677849152168
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
   sha256: 06b729aee6dd2a1e545f3ad64179cc0d4ef8a15e33db3be2995dd3e0868465ca
   md5: 8bb3215912588e47e2eeb4e7a09ad64f
   depends:
@@ -1171,7 +1171,7 @@ packages:
   license_family: MIT
   size: 180858
   timestamp: 1699041715847
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
   sha256: 9e3bac2d41bd432b721b009e7de981766fba396e6f238e923f304112bd88655a
   md5: 84ae4cf3f2d01fbebdac374971192be9
   depends:
@@ -1181,7 +1181,7 @@ packages:
   license_family: MIT
   size: 15525
   timestamp: 1699032521315
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
   sha256: 79ce6dff3d93649a2555b1d2a4ae9eb77175a1c00664cb8eb0e6f848d5cdd1b9
   md5: db395b0efd7018fcf3a4af879170c2a8
   depends:
@@ -1197,7 +1197,7 @@ packages:
   license_family: BSD
   size: 276856
   timestamp: 1676823504812
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
   sha256: fedc7e5560252af44b0dfbe6f7acfe20ab17a6a08e758f670a1cd820551afc7a
   md5: bd28d36963087f53a79b23fee697d665
   depends:
@@ -1208,7 +1208,7 @@ packages:
   license_family: BSD
   size: 93898
   timestamp: 1698937453304
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
   sha256: 2b896fe8b2187b7df824041826e14379476eb2e61d607d8cb38ac2b3df40aaa4
   md5: 8fc7e517da96c2c482331f6b08d07a17
   depends:
@@ -1224,7 +1224,7 @@ packages:
   license_family: BSD
   size: 41459
   timestamp: 1699282616532
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
   sha256: 87d372f5b23bcc2410e43b40b4ad059ea1625178b8a2b484fc63805ce517e594
   md5: 50204f372b1672871d6ab3db6a876374
   depends:
@@ -1251,7 +1251,7 @@ packages:
   license_family: BSD
   size: 594177
   timestamp: 1699467208489
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
   sha256: ddfee06ba9b149222c65d1d4270272840533aa63b56fe36363c84a891c71d328
   md5: ee128e5c0d8d9e1952e2387b66a5b8cb
   depends:
@@ -1261,7 +1261,7 @@ packages:
   license_family: BSD
   size: 27239
   timestamp: 1686870958829
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
   sha256: 0c6a074272ed58677ec17e4dbfceaffd2108841a61af92b32f156c5763108d1d
   md5: dd3d37841d0d20c70a60e8c939923894
   depends:
@@ -1273,7 +1273,7 @@ packages:
   license_family: BSD
   size: 19144
   timestamp: 1700168632051
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
   sha256: b040f0d0ee4588188ab6b83a93738b3ff6e6d1775424be97995bd0df0f4fb904
   md5: eae62735d710cf5ff6d51e6f59fcd999
   depends:
@@ -1284,7 +1284,7 @@ packages:
   license_family: BSD
   size: 78148
   timestamp: 1676827253282
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -1295,7 +1295,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
   sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
   md5: 9508af80612e4fa1b5d1abb43ca7e63c
   constrains:
@@ -1303,7 +1303,7 @@ packages:
   license: GPL-3.0-only
   size: 749072
   timestamp: 1652971360657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
   sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
   md5: 88199c75f2ac211728febced7785c24e
   depends:
@@ -1313,7 +1313,7 @@ packages:
   license_family: Apache
   size: 228278
   timestamp: 1635523146417
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
   sha256: bb990ea068c3b3dafd9c807e0e19570320cb2fe7d69cc326f1f0b5319b0654b2
   md5: 3ff70744e396b1af69656c574b05c3b9
   depends:
@@ -1321,7 +1321,7 @@ packages:
   license: MIT
   size: 66940
   timestamp: 1714483221853
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
   sha256: 3b87a816f72a00e1f0022a160e7eda70af89d3de2a2e08a72be1c17b31d759f3
   md5: 4f57d3a0a13ddaf1c06efb586b702f46
   depends:
@@ -1330,7 +1330,7 @@ packages:
   license: MIT
   size: 34446
   timestamp: 1714483232430
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
   sha256: 2cf15e89f910600f468edfde8d0f9b80a14fa2319ed89160dc7375dfd3764fdb
   md5: 463adc13f2feea3570d1eccac368d9e4
   depends:
@@ -1339,7 +1339,7 @@ packages:
   license: MIT
   size: 295090
   timestamp: 1714483244460
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
   sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
   md5: 55dde57e63a36b202e388a39dcee9a66
   depends:
@@ -1348,7 +1348,7 @@ packages:
   license_family: MIT
   size: 74096
   timestamp: 1695996494461
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
   sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
   md5: 1af9b4d62c708924417f2640ef22a68f
   depends:
@@ -1358,7 +1358,7 @@ packages:
   license_family: MIT
   size: 154016
   timestamp: 1714483282916
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
   sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
   md5: 641e72e5067bd6d5454405879e1cd2a7
   depends:
@@ -1373,7 +1373,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 8895144
   timestamp: 1654090827491
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
   sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
   md5: 27082517590f3b9fbffecc68513b461b
   depends:
@@ -1382,7 +1382,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 19860
   timestamp: 1654090819660
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
   sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
   md5: 0202c3c8ae4735cac6c7f3d1e1685964
   constrains:
@@ -1390,7 +1390,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 5228750
   timestamp: 1654090762569
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
   sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
   md5: 3080c2813e6e1d0f8a100a38b5b3456d
   depends:
@@ -1398,7 +1398,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 573231
   timestamp: 1654090775721
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
   sha256: 512fac06ddd97b4383503d4fbd8145102966055b29ccf86841a930dbb4ef3ab8
   md5: 833c0e514ff9c8ae0511630b024d60e0
   depends:
@@ -1411,7 +1411,7 @@ packages:
   license_family: Apache
   size: 37179832
   timestamp: 1683292829131
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
   sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
   md5: 1bffe1481ed4f88827248fb9001f8923
   depends:
@@ -1421,7 +1421,7 @@ packages:
   license_family: Other
   size: 362561
   timestamp: 1677841789536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -1429,7 +1429,7 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
   sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
   md5: 8c195584a5f5471b600ee180e4052773
   depends:
@@ -1437,7 +1437,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 6410287
   timestamp: 1654090800863
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
   sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
   md5: ef78eebd98289aceacdfa29182426adf
   depends:
@@ -1455,7 +1455,7 @@ packages:
   license_family: Other
   size: 664034
   timestamp: 1693575237924
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
   sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
   md5: 292768ec77416ae257cfdd44ea2071c8
   depends:
@@ -1464,7 +1464,7 @@ packages:
   license_family: BSD
   size: 29197
   timestamp: 1668082729834
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
   sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
   md5: 9cdeef1d044c7e035c006890f11569d3
   depends:
@@ -1475,7 +1475,7 @@ packages:
   license_family: BSD
   size: 436056
   timestamp: 1694776944891
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
   sha256: fd8e30beb8c9442f16e6617fac92dd0c89ec823e98f06e60f712147380ead35f
   md5: 7ed7caf2816c8b85b67b6f4e8833cbd5
   depends:
@@ -1485,7 +1485,7 @@ packages:
   license_family: MIT
   size: 41155
   timestamp: 1676837080881
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
   sha256: 05e355127db0d3ed67c4c383fd929ef1c3d7d3f19472f6e5433a866e94378bed
   md5: b7897895622e5ab6e62279f07fa1f587
   depends:
@@ -1497,7 +1497,7 @@ packages:
   license_family: BSD
   size: 4367002
   timestamp: 1706910875807
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
   sha256: 95fe76d2691feb13203b55ad2aba535bb848cae21ffd05b13ff51c7a45fa2332
   md5: 6a04ec16e3abc1c7e2104be32cd6c418
   depends:
@@ -1506,7 +1506,7 @@ packages:
   license_family: BSD
   size: 13458
   timestamp: 1676827287432
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
   sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
   md5: 76f089e76ec67583bb38428b51008097
   depends:
@@ -1516,7 +1516,7 @@ packages:
   license_family: BSD
   size: 164494
   timestamp: 1714510587156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
   sha256: 260e26dd509834c1b225ab7bdb97b9a86e00054fbdd5dfa49e68fa4dcf85a661
   md5: 8f5d7ddc69cc6f7d44c80d2251dea5d1
   depends:
@@ -1525,7 +1525,7 @@ packages:
   license_family: BSD
   size: 162339
   timestamp: 1676837095436
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
   sha256: 7f5b0804d0768619b7bd93b10488067d80bf42ec29f443f00b53ba11758a1241
   md5: 8afb45e45c0d93bfd142e682d4b021ef
   depends:
@@ -1535,7 +1535,7 @@ packages:
   license_family: MIT
   size: 134438
   timestamp: 1684280014220
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
   sha256: cb03570c99c983d7bfda94bc47d8eb00d4059b8548a171130775acc998004195
   md5: 5b1abbbf1e4f9b350b16fc9caf9e889b
   depends:
@@ -1547,7 +1547,7 @@ packages:
   license_family: BSD
   size: 26919
   timestamp: 1704206397615
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
   sha256: 85fea48bea278a77d102781a1cbb6bf69307207d741251e38a6515c5fd7e3523
   md5: d6ddba94f7c33c88c9825be8409991bf
   depends:
@@ -1569,7 +1569,7 @@ packages:
   license_family: PSF
   size: 9150942
   timestamp: 1713336680714
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
   sha256: 7ac07ea180b5928086075900afbc332fb1d3c81ddfacb54c891693c284056f14
   md5: fc83dd1b3d2ec3c0a297ead0c3405907
   depends:
@@ -1579,7 +1579,7 @@ packages:
   license_family: BSD
   size: 19573
   timestamp: 1676823852670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
   sha256: c9ba2f9c83820712dd97d6a1b54a1215b9820a0be02ac82380b4c50911b9400c
   md5: e5dc6b4a5b8e02733ce3bc9e9198a8d2
   depends:
@@ -1589,7 +1589,7 @@ packages:
   license_family: MIT
   size: 67750
   timestamp: 1676837123613
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
   sha256: 1a5141ef0de1cbff816f96bb4b212a40606e2fc11301a4c1358c8d63a6b2b027
   md5: 22ac3bc22b68fef4c1f3f6ab3c7bfe0b
   depends:
@@ -1598,7 +1598,7 @@ packages:
   license_family: MIT
   size: 23040
   timestamp: 1676827301164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
   sha256: 9aacfbbe6f638c58a4e8ff31374d1438d78b7db25d6ea6fd0c50ca2109f225d4
   md5: e602057e3b3d80da88c61d66e8851c5b
   depends:
@@ -1609,7 +1609,7 @@ packages:
   license_family: BSD
   size: 104681
   timestamp: 1676823696152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
   sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
   md5: ce77d0f05f846da4a6b9e23fe7f21d9b
   depends:
@@ -1623,7 +1623,7 @@ packages:
   license_family: Proprietary
   size: 206738176
   timestamp: 1699648006088
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
   sha256: 2aef0876d0df033f7fae8cddbd25d95fc1bfc067e60dd143bd8000fec0768b21
   md5: d6cdc670327bd1675bbea642849f04e1
   depends:
@@ -1634,7 +1634,7 @@ packages:
   license_family: BSD
   size: 59569
   timestamp: 1682948560323
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
   sha256: 691c4b2b47cf3fac55b4949d7c0f547246ef19cb3510749142cee4bd01ffb055
   md5: bbd69efa3f24ee747410f83118640d92
   depends:
@@ -1648,7 +1648,7 @@ packages:
   license_family: BSD
   size: 240723
   timestamp: 1695058405382
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
   sha256: 71f5c7beca4e81b465ecfc6ed51cb3d39f51dd88df0b29eff5def3d1f12969eb
   md5: 61d58663b7277cf4cc3cb8d9873d3ee8
   depends:
@@ -1663,7 +1663,7 @@ packages:
   license_family: BSD
   size: 331105
   timestamp: 1695059935112
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
   sha256: b558b3f6c144652b5e0d26497b3ce24c318a6b9ff8ea2079113c95e5553b3cf9
   md5: 0b185969ac2b065c27cbcc9641d93678
   depends:
@@ -1673,7 +1673,7 @@ packages:
   license_family: BSD
   size: 29568
   timestamp: 1676841232463
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
   sha256: 20d832ce714465ae1685d29e2f913fd105d385d003fe1bef71ef472e6f3489e6
   md5: ad76299b0c33b7a5c0d45905271165c1
   depends:
@@ -1699,7 +1699,7 @@ packages:
   license_family: BSD
   size: 8303422
   timestamp: 1699542957307
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
   sha256: bb45fb0a3973caa74fd8f845e0a519895f6a378807626e15ecf72c02f2eed794
   md5: 185f658ba8a74e326b7231c8fd0d62bf
   depends:
@@ -1712,7 +1712,7 @@ packages:
   license_family: BSD
   size: 121834
   timestamp: 1698934274227
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
   sha256: 8b2fc372a6655fd5b277d07b994ce43643553fbc37e63a60e9fe527a9026ec06
   md5: ed6ac14aed5a796b153d757862398997
   depends:
@@ -1739,7 +1739,7 @@ packages:
   license_family: BSD
   size: 523905
   timestamp: 1699022906468
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
   sha256: 7908ff6c516b15e8fb677be4071145e18adea7d4c13b8485a70a5ee2f573f8cb
   md5: 50c0e38207a131a5de6a14ef919ffcdc
   depends:
@@ -1752,7 +1752,7 @@ packages:
   license_family: BSD
   size: 169629
   timestamp: 1694616826002
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
   sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
   md5: 57ea097dc15f8d9f9eb90e1d919143b0
   depends:
@@ -1761,7 +1761,7 @@ packages:
   license_family: MIT
   size: 1157733
   timestamp: 1674734069410
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
   sha256: 266199dd4efde0ad342a9c500f4bc4299c5622219aea623b46315a9b4f6b8959
   md5: 2b21844d2b0024d0ffad0e6450cf0855
   depends:
@@ -1770,7 +1770,7 @@ packages:
   license_family: BSD
   size: 15860
   timestamp: 1708532713870
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
   sha256: 13d6c640710895e9732225cdedbe47fcd756887fffeb0cf9bc149ee7234dfc27
   md5: a87d55e3d071f2c435b10db49a9911af
   depends:
@@ -1795,7 +1795,7 @@ packages:
   license_family: BSD
   size: 730963
   timestamp: 1690984942516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
   sha256: ef2857e6d3d7eb246b3abddfbd3aa2d124dd8565391ace3876b77339babc50bb
   md5: d276d1b1774107987963135c78ca7390
   depends:
@@ -1805,7 +1805,7 @@ packages:
   license_family: BSD
   size: 26607
   timestamp: 1699455972519
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.59.1-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numba-0.59.1-py311ha02d727_0.tar.bz2
   sha256: 1b830d1d091462cff92de55f24339365a9d2c23b27d19799833b4780efe99c15
   md5: 06367b04f8f04c0dc4e356a2ca9dc854
   depends:
@@ -1828,7 +1828,7 @@ packages:
   license_family: BSD
   size: 6084284
   timestamp: 1711988494237
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
   sha256: 2f89f38a665ece47e8868b391fc70602fcee588e989bc1ca6f17f6094892a94e
   md5: b788c80b2d571531ea4f3f8335ae5423
   depends:
@@ -1843,7 +1843,7 @@ packages:
   license_family: MIT
   size: 168827
   timestamp: 1696515597877
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
   sha256: e09e1aff2c12d4ef3fec58fb627744e4b5c7d9eaede7175e293f77272d8b8bfd
   md5: fe8242cfd54d238507493612ae697ad4
   depends:
@@ -1860,7 +1860,7 @@ packages:
   license_family: BSD
   size: 10270
   timestamp: 1708639794640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
   sha256: a53ad723826651041a5057a1cf31bc8689b24d335ce61b196df5124974b05a8e
   md5: 7b29e7191c4170189d6080e61229f030
   depends:
@@ -1876,7 +1876,7 @@ packages:
   license_family: BSD
   size: 9163911
   timestamp: 1708639777712
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
   sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
   md5: b0afe23033c8c5344640bc25225fa579
   depends:
@@ -1887,7 +1887,7 @@ packages:
   license: BSD 2-Clause
   size: 516994
   timestamp: 1630084830020
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
   sha256: 6c7cb4097e4f3655b54a119304e50f0edbc4bd52f36c84629b64674cf8d468b8
   md5: f1e48c973646ded3c2e1a189a9d8b8c9
   depends:
@@ -1897,7 +1897,7 @@ packages:
   license_family: Apache
   size: 5498991
   timestamp: 1716318104769
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
   sha256: 280225061aeba00d7b85f46e55d7d79cd92c92f662dc749d9c53187978e8d083
   md5: c51c21da68080d89300703ad818c824a
   depends:
@@ -1906,7 +1906,7 @@ packages:
   license_family: APACHE
   size: 38606
   timestamp: 1699371264464
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
   sha256: bd3eacd22e85f88bedd9c7e97a59eacfb3c8bb80eb59be244825d6895a0e7ac1
   md5: 08ceb294ba8a9ae13630da789884736e
   depends:
@@ -1915,7 +1915,7 @@ packages:
   license_family: Apache
   size: 157904
   timestamp: 1710807470578
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
   sha256: a2ee3a6aaf54929b82b851b2eb5436e14e5a294303ef429d6dccd33bcdfc8002
   md5: b467a5c7ad672ccc2d498a67b9eeeaaa
   depends:
@@ -1966,7 +1966,7 @@ packages:
   license_family: BSD
   size: 17970687
   timestamp: 1709593080388
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
   sha256: aa05415302a27a82105e9d0800151f09fd1bb896b90854dc23989f9aecd9200b
   md5: 4974b1ae5f1a3b6d9fb26e7eb2c26733
   depends:
@@ -1990,7 +1990,7 @@ packages:
   license_family: BSD
   size: 21869200
   timestamp: 1714071532259
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
   sha256: c6c782537b96ab9caf3e25f5a33799c727e84664cdbab37a8d3359a221e2d2e3
   md5: 8f56d0f63e0589dd7e4a004678307813
   depends:
@@ -1999,7 +1999,7 @@ packages:
   license_family: BSD
   size: 263438
   timestamp: 1711136934516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
   sha256: a2e2beff710765f2e5135020121da4f227f5e1cbe142e17398a585f50a389d37
   md5: eaf734d49b6e576e12be1398a295643a
   depends:
@@ -2013,7 +2013,7 @@ packages:
   license_family: BSD
   size: 47447
   timestamp: 1698702703255
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
   sha256: 28ed719669260a20bec78971edaffb91ec917d2a3f0fac1cf9a8ba21590baa43
   md5: 0481d078fcd64f7f981532a514d9d50d
   depends:
@@ -2030,7 +2030,7 @@ packages:
   license_family: Other
   size: 960727
   timestamp: 1714399060039
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
   sha256: d527189038b376a982c18613df808f25dc40314b0dc8fe5549f3ae9f4288e497
   md5: 68dad015e796cc26364b55f92f61faa7
   depends:
@@ -2041,7 +2041,7 @@ packages:
   license_family: MIT
   size: 3451714
   timestamp: 1715097126399
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
   sha256: d2bbab8bfc57c7f46ca8994bc87df7e744d3f036b867bc4be1145ba6d8d7e091
   md5: de41707272a8e3ccab764f0b7010a27d
   depends:
@@ -2050,7 +2050,7 @@ packages:
   license_family: MIT
   size: 37394
   timestamp: 1692205565974
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
   sha256: e2a0e2a618aa33f0beff9583c7dc510b8d0737b023117346676aacbad33970d8
   md5: 66a6818307261b1a28ab12d1b7776fdf
   depends:
@@ -2059,7 +2059,7 @@ packages:
   license_family: Apache
   size: 121454
   timestamp: 1679340540306
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
   sha256: b7f591c19b10bf0daa7e6e3b45a9f4a0a0e83188e1f8a58037caea79e60f8d91
   md5: d945b4ccc135005839c504cc29df1745
   depends:
@@ -2071,7 +2071,7 @@ packages:
   license_family: BSD
   size: 749608
   timestamp: 1704404477511
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
   sha256: 96482b49191fdac59580a95e69508367083e1f7600145e11d7c2db634337eb26
   md5: 2d57bf8eacf3f291db845928241f724c
   depends:
@@ -2081,7 +2081,7 @@ packages:
   license_family: BSD
   size: 490805
   timestamp: 1679337420563
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
   sha256: eb75b4417565d25e2d1006db75aa8bd9da6b6c72a929954b01a31b9bf5f8b42e
   md5: bb56c0358b65665f4dd509a4635f6f3c
   depends:
@@ -2093,7 +2093,7 @@ packages:
   license_family: BSD
   size: 37802
   timestamp: 1676838557935
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
   sha256: ed927e4d058a8f4ea73edc7a43ed74877d93b88fdfa240b3b2777244386ced70
   md5: a1f0e05fc7e49712f81ad5478ec9d51e
   depends:
@@ -2102,7 +2102,7 @@ packages:
   license_family: BSD
   size: 2121496
   timestamp: 1684280065800
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
   sha256: ad219924e362ce7af458fa6547660181579e9a50e5aed1ffd9268cbe7c2650e3
   md5: 2b1ac40e0df3673d33b7f4c4f93ae1ef
   depends:
@@ -2111,7 +2111,7 @@ packages:
   license_family: MIT
   size: 207338
   timestamp: 1677811584327
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
   sha256: 114b55e00f4622c90fd2b404b21ad5f94a10283fcaaf86a42174b8d39b0a3e98
   md5: 2458e92683cc68671a6c8e1b86ce8817
   depends:
@@ -2120,7 +2120,7 @@ packages:
   license_family: BSD
   size: 35850
   timestamp: 1676822725516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
   sha256: ef622eb34669f3518d2f855cb333c56b106d02cdeac9d58e5a1a5a3097e4978d
   md5: 9d4f211d050d511b0b84c2e57e7fb1d7
   depends:
@@ -2142,7 +2142,7 @@ packages:
   license_family: PSF
   size: 36072860
   timestamp: 1713546307595
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
   sha256: a0f008717fab060ccd003dfebc09156d90b9afd14ac3626566aa1a8f3d3b7e2f
   md5: 357bf4fe94496cbae72ab4d780184b31
   depends:
@@ -2152,7 +2152,7 @@ packages:
   license_family: BSD
   size: 330924
   timestamp: 1716495762901
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
   sha256: aadc4078311c059265706a56265f0a57ceb538d36179d5203dd487d80d0e8f16
   md5: 59ec670fcd172447dbd9591b8fbfdd56
   depends:
@@ -2161,7 +2161,7 @@ packages:
   license_family: BSD
   size: 278741
   timestamp: 1679340144625
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
   sha256: d5058d0ecc3973316c1d5f1bfb03dd119e0dade85f4c2d21b412c8db4e1636f2
   md5: 93000e4d3603342779a2afda66fa91b8
   depends:
@@ -2170,7 +2170,7 @@ packages:
   license_family: BSD
   size: 17607
   timestamp: 1683823841946
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
   sha256: b85acb933fff864bfa89d034e8e3d85b1a9c2e69cbfc0d68c1d66ffd1443e67d
   md5: 0cdb92d2d684ee1095310f992ed0d9b2
   depends:
@@ -2179,7 +2179,7 @@ packages:
   license_family: MIT
   size: 266796
   timestamp: 1713974338678
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
   sha256: 511e8206a15445715b80be76493300930686b3fe1e512ae942d6ccca36df392a
   md5: 35a6e46ae970f8b71d78fb5a810f2e80
   depends:
@@ -2191,7 +2191,7 @@ packages:
   license_family: BSD
   size: 64013
   timestamp: 1711136926372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
   sha256: b2a1f649669f4336b74f6f20df711959bcd8024f8f8b94199dc0e040b06bd37a
   md5: f9e8e3f7068f717f75e555dc04545d8d
   depends:
@@ -2202,7 +2202,7 @@ packages:
   license_family: MIT
   size: 206433
   timestamp: 1698096204677
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
   sha256: 7c74db4292f31619606180f86f3c1e2d913495c2c9d1195c5d51681a6a841625
   md5: be1c05fae57d194924b9400f9b5ad3c6
   depends:
@@ -2213,7 +2213,7 @@ packages:
   license_family: Other
   size: 613277
   timestamp: 1709318516682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
   sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
   md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
   depends:
@@ -2223,7 +2223,7 @@ packages:
   license_family: GPL
   size: 467661
   timestamp: 1666648052561
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
   sha256: 89c2f4235277b9825cc805c5c44f0b1afcb683d7b5a3f513bc4bf243b643bb0c
   md5: db70eb57e33adf7b8bbdadd72214d48d
   depends:
@@ -2234,7 +2234,7 @@ packages:
   license_family: MIT
   size: 73679
   timestamp: 1699012111499
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
   sha256: 684037527327839d734e7eac2ee09ef5ddb4f77df22daf40c79e51db29d09543
   md5: 57c5bcb9eae9f1d93ccfd38025660de2
   depends:
@@ -2250,7 +2250,7 @@ packages:
   license_family: Apache
   size: 119414
   timestamp: 1707355661872
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
   sha256: fdae3f68ea84b99561aee6c566ab1c287d8f2ae2668424e9283a8ed86af8f1d2
   md5: cde5b71ccbb3630053340b2c8c7dbf10
   depends:
@@ -2260,7 +2260,7 @@ packages:
   license_family: MIT
   size: 9333
   timestamp: 1683077183576
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
   sha256: 0bf859b06a07857099fd4f524fe5e0875fda70029e9485d95c7efa97134fbc14
   md5: fd5815cc592fdbd4c831901541eadaba
   depends:
@@ -2269,7 +2269,7 @@ packages:
   license_family: MIT
   size: 9735
   timestamp: 1683059096795
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
   sha256: 474553d01aea57214a54a7443f227da84a58e29c49eb7605ba0043c55b7d167a
   md5: f01333e9f0a908e435db650f42fbd2db
   depends:
@@ -2279,7 +2279,7 @@ packages:
   license_family: MIT
   size: 1096668
   timestamp: 1698946168635
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
   sha256: b06b45da61807f76b6d800047f123fee2cc95eb84da508550e0908951c8d9f6f
   md5: 9b100efb9ba2fc7f9bcfaa8fd2ab6f9f
   depends:
@@ -2298,7 +2298,7 @@ packages:
   license_family: BSD
   size: 27615256
   timestamp: 1714076660659
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
   sha256: 51bcea0e575a626f6ffbd16d1153330fda93dbe3dd31dcd3a8f469ff61dd1e4e
   md5: 41d531c90be8c82bf79635ff3d409476
   depends:
@@ -2307,7 +2307,7 @@ packages:
   license_family: BSD
   size: 32295
   timestamp: 1699371262818
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
   sha256: 0a95988ea269c96354626dcab255b65b54bb5c503d24cdeb6ef2e1c42818bd59
   md5: 8bfb9f42492b3b53b8151d77e51c75d8
   depends:
@@ -2316,7 +2316,7 @@ packages:
   license_family: MIT
   size: 1594974
   timestamp: 1715024182643
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
   sha256: 1a84b00944bc5588e14a097460175f97df49acb4f1ff2498ffd9a1893068ed81
   md5: a456513471b2ecbed60430c21dd1ccc7
   depends:
@@ -2325,7 +2325,7 @@ packages:
   license_family: Other
   size: 17880
   timestamp: 1705431390054
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
   sha256: adcafd297d60af64107c113bb7b8b92160d0268a44ef9a3b79e56a88a0358ea7
   md5: 28ed704ed26b06d32662e3a6a87e59b0
   depends:
@@ -2334,7 +2334,7 @@ packages:
   license_family: MIT
   size: 88799
   timestamp: 1696347581401
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
   sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
   md5: f86119b3243fe3508160aa0406245738
   depends:
@@ -2347,7 +2347,7 @@ packages:
   license_family: Other
   size: 1723866
   timestamp: 1714488309729
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
   sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
   md5: 041a3caf09dc9ce8fc6c10925c4fe050
   depends:
@@ -2357,7 +2357,7 @@ packages:
   license_family: Apache
   size: 1888016
   timestamp: 1680167274961
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
   sha256: 856a8ab8c350c50247b79966c6cb80fb6d4de36eef49ddf75aebbbcaf854c82d
   md5: 442dde204d14d171aab9ee40e8de4de8
   depends:
@@ -2368,7 +2368,7 @@ packages:
   license_family: BSD
   size: 37456
   timestamp: 1677696176157
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
   sha256: f0a026ddc0ed041bfc60c8a1ca0b70b7a69232775b3181bfb35a39fda42d6994
   md5: 2902d5a5854865baaaf58dc59cf06b3c
   depends:
@@ -2378,7 +2378,7 @@ packages:
   license_family: BSD
   size: 49185
   timestamp: 1676823769869
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
   sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
   md5: e2512d57c8a1e91e7b20e265c6906546
   depends:
@@ -2388,7 +2388,7 @@ packages:
   license_family: BSD
   size: 3588922
   timestamp: 1714770676475
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
   sha256: e58ff4a82819446f3c92e5b1aa2a784c4b06643e751fe67cf115858296dbfa50
   md5: 32ee4723173f1fad5563b8afb5f1c8f1
   depends:
@@ -2397,7 +2397,7 @@ packages:
   license_family: BSD
   size: 135634
   timestamp: 1676827536101
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
   sha256: 1bf522ade750cf0b70d61e71916ff00569e2908db1e9dedb223fda2608ed8bde
   md5: 6793c74fe94211c0bfe6766c6dd490af
   depends:
@@ -2407,7 +2407,7 @@ packages:
   license_family: Apache
   size: 893808
   timestamp: 1696937055591
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
   sha256: 54f41afbea1c01a10e5703e64645de145f34ad6d89cf245fbc5cfaaff58a8743
   md5: 15b6c8bee4c28c6efb3e388178b37145
   depends:
@@ -2418,7 +2418,7 @@ packages:
   license_family: MOZILLA
   size: 154276
   timestamp: 1716395957568
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
   sha256: 0575785f6553e61cc6138abfd5de52305fac6f85971642fa1f056a76c66a52b2
   md5: f2c25e5dfdd23f70b83776a8832893cf
   depends:
@@ -2427,7 +2427,7 @@ packages:
   license_family: BSD
   size: 270865
   timestamp: 1676823316868
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
   sha256: 8c06c291c76e8c2022ffbb9fea4727a4bf1f9b03e498bafc56ba8ac4e7604ab9
   md5: 5adb7baf1091d09026a372cac930ce6c
   depends:
@@ -2437,7 +2437,7 @@ packages:
   license_family: PSF
   size: 8869
   timestamp: 1715268966416
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
   sha256: 118b0801167264c401e84bbf19175546092a5569cc098146f7362bbf890dc8d9
   md5: b3c2aa56d53b459f8365d8385f48d0c3
   depends:
@@ -2446,7 +2446,7 @@ packages:
   license_family: PSF
   size: 74489
   timestamp: 1715268960737
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
   sha256: 509b962773f0fe44a93a7f6196b254670a030eac8ea7f90727312e3ccd9294b2
   md5: 6c402d5bf4e01c8c3895c9ef41707b6e
   depends:
@@ -2455,7 +2455,7 @@ packages:
   license_family: MIT
   size: 11371
   timestamp: 1676828901104
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
   sha256: bbe7629e8ce52c82f13ed0d1fb919f3659ef466b274a7c74aa925a9bc7aee450
   md5: 7da527bbcf71270c1abed8ea52e7d44c
   depends:
@@ -2465,7 +2465,7 @@ packages:
   license_family: Apache
   size: 509031
   timestamp: 1713213062098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
   sha256: 5c6afad310db12b3658a652efc5de45c182164a0b537cb2cdae5885428b30d22
   md5: 89ea2fed160a633e0a6d152b61cb0dd2
   depends:
@@ -2481,7 +2481,7 @@ packages:
   license_family: MIT
   size: 209068
   timestamp: 1715635972793
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
   sha256: c3a5e0b855dc2de6c162708dfcf170a23eb9e7525d4252d8dce553369af4a330
   md5: a4c77e204b7787f820955166a1283168
   depends:
@@ -2490,7 +2490,7 @@ packages:
   license_family: BSD
   size: 25890
   timestamp: 1676823132898
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
   sha256: 42989f9970a8466cc4edb73463dfa194594dd1a5d42c9f820a1f86296d4af140
   md5: 655dfd4d2f17977cb81caa1c082d2b25
   depends:
@@ -2499,7 +2499,7 @@ packages:
   license_family: Apache
   size: 113505
   timestamp: 1715878346465
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
   sha256: eec0d2e0bce4b62278cacd7b0bee053160845e86507051a5434d2069bd290f36
   md5: a069e5aef64a6dac076cc9a3d28a17c9
   depends:
@@ -2508,7 +2508,7 @@ packages:
   license_family: MIT
   size: 136022
   timestamp: 1714717059748
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
   sha256: 85248e503721da67797546cb8a22e303c1739100834b219c5621f216e3794e8d
   md5: 2570956643f22d0f809b2467e02d3984
   depends:
@@ -2520,7 +2520,7 @@ packages:
   license_family: Apache
   size: 2465865
   timestamp: 1689041600364
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
   sha256: d18cdca154bf668826f869117ea996c4f9e8ef7d27b7c528332a7d17e5a8602c
   md5: 9f7353d72046b16dd6ef6b5689ac9bfd
   depends:
@@ -2529,7 +2529,7 @@ packages:
   license_family: BSD
   size: 54731
   timestamp: 1676828934954
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
   sha256: 9122d6e9dabb7a47f2bcb15d86b97c96c49a9048da3f8ae59675351710c14cc5
   md5: 660b2aead2ec87b751c86cd33934f44e
   depends:
@@ -2538,7 +2538,7 @@ packages:
   license_family: GPL2
   size: 716926
   timestamp: 1714510796277
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -2546,7 +2546,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
   sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
   md5: 943f1247a22b6b64171363bcee1eec27
   depends:
@@ -2557,7 +2557,7 @@ packages:
   license_family: Other
   size: 371663
   timestamp: 1705602144682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
   sha256: 7aa781d0850f97622755ed44772d2b215b253a8e211aede5f3f53e1b95b4143a
   md5: b1d8823f50228d4efb7b7a6e267ed776
   depends:
@@ -2566,7 +2566,7 @@ packages:
   license_family: MIT
   size: 24333
   timestamp: 1704207043644
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
   sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
   md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
   depends:
@@ -2575,7 +2575,7 @@ packages:
   license_family: Other
   size: 127143
   timestamp: 1714510716441
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
   sha256: af3c032f06352e87c450739cb8aafe1ff34ad28bf074b214ea98b3d29259a85d
   md5: 51fa34bd0e016ed7c5371cf6cb13ef6c
   depends:
@@ -2588,7 +2588,7 @@ packages:
   license_family: BSD
   size: 1044463
   timestamp: 1714678445052
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -2601,7 +2601,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -2611,7 +2611,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -2623,7 +2623,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
   sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
   md5: 544adf2677c47c9b9c891aea720678f1
   depends:
@@ -2631,7 +2631,7 @@ packages:
   license: MIT
   size: 33999
   timestamp: 1630003259346
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -2640,7 +2640,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -2649,7 +2649,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -2658,7 +2658,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -2667,7 +2667,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -2675,7 +2675,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -2684,7 +2684,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -2693,7 +2693,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -2703,7 +2703,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
   sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
   md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
   depends:
@@ -2712,7 +2712,7 @@ packages:
   license_family: BSD
   size: 5106
   timestamp: 1704404390460
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -2720,7 +2720,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -2729,21 +2729,21 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
   sha256: 459f38609d854888998a8d76028019dbacdce2bfe401eab57b8eb8ff16da9c7f
   md5: 2948a98ef4de5decb7e5eb888eae68ba
   license: BSD-3-Clause
   license_family: BSD
   size: 13056
   timestamp: 1682965564630
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
   sha256: 305e5fd9993f3e5506f386f98794c7d53b6e6c68d4d411ada724de49a17945fa
   md5: e1fbbd2d11d21aaec3c32f7d332c0e77
   license: BSD-3-Clause
   license_family: BSD
   size: 13818
   timestamp: 1712163766707
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -2752,7 +2752,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
   sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
   md5: 02caf3f47f1d06256068053297355740
   depends:
@@ -2761,7 +2761,7 @@ packages:
   license_family: Apache
   size: 152292
   timestamp: 1690578151230
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -2770,7 +2770,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -2782,14 +2782,14 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
   sha256: dc9f709bacbaf08a0941d2622d82f91f18b355e82c55348ec29f1391215ca7e0
   md5: ece0f5837a4de2d4d5f1abf8347cd10a
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 124922
   timestamp: 1708711884650
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -2797,7 +2797,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
   sha256: 5800a2466734dd1ef372bec0dd3f0880c5072fa1e8b0668f5054f834285e991c
   md5: 18194e51d4420ac08f29f3f86581b52e
   depends:
@@ -2811,7 +2811,7 @@ packages:
   license_family: MIT
   size: 229003
   timestamp: 1706220302459
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
   sha256: ab7672364f1fa55ec5d8311d85d40e5b57cbd3517b17670557b6fb822bcf759c
   md5: 6e0159a5865cb7e96a748bd8560035ee
   depends:
@@ -2820,7 +2820,7 @@ packages:
   license_family: BSD
   size: 11579
   timestamp: 1678317458652
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
   sha256: 51556902e09436d46878ef772805d06416ca96ffaa66340b5565c0245574aaf5
   md5: 4cb1b20635cf5431d34cc96ca1e8a751
   depends:
@@ -2830,7 +2830,7 @@ packages:
   license_family: MIT
   size: 33355
   timestamp: 1678317111825
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
   sha256: 188b74f717e3ce3595da404c0e027b8ccafa9c186e88325e8f02c29d7b4c0744
   md5: 04ad90eead5812a0263b42321056ab33
   depends:
@@ -2839,7 +2839,7 @@ packages:
   license_family: MIT
   size: 153694
   timestamp: 1695717975427
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
   sha256: bf3c60386619f08cf5105b4b903bbc109b3252c3b923fe055aa445908a01969c
   md5: 3f84a301921ec6400b7f1f1c4ba3260d
   depends:
@@ -2849,12 +2849,12 @@ packages:
   license_family: MIT
   size: 270017
   timestamp: 1681493109562
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
   sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
   md5: e2f3248e2a5009a02f7b8e54f83314ef
   size: 5620
   timestamp: 1528121955725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
   sha256: 126ae8e30b8464fb2dc94ce9163dcb2d5482f7214c7d8a48340c3f09f1409d5e
   md5: d5e0c054042910b4394a14c7eb4d8131
   depends:
@@ -2872,7 +2872,7 @@ packages:
   license_family: BSD
   size: 6080356
   timestamp: 1712084675745
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
   sha256: 9acafafcaebd653c2372ddc864525722e1c55b884b5eba22e28e2b2d946b853c
   md5: 22375cc3c2edada31b85af56c8e6dee6
   depends:
@@ -2882,7 +2882,7 @@ packages:
   license_family: BSD
   size: 155829
   timestamp: 1707864406086
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
   sha256: d8b1ccb15297dcfb3f9ebb8139c3e28a13d6c2e73c37612cb214ab6cc58b15fa
   md5: e5dec9f13de061640ad2697562a99b54
   depends:
@@ -2892,7 +2892,7 @@ packages:
   license: MIT
   size: 19732
   timestamp: 1714483415038
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
   sha256: e9fda4393edd0234c88efc2b88e0edf42c94eb49ea5b189a80afd733058be8fb
   md5: 13ceed558eb174d6b77ed1b0035f1785
   depends:
@@ -2901,7 +2901,7 @@ packages:
   license: MIT
   size: 18400
   timestamp: 1714483395748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
   sha256: a323af3251e426962ad16edf8f46a696ef502731faf12aee32ca289c40b11342
   md5: 658ce49e9f07dba7a1afe70fa2666e0a
   depends:
@@ -2910,21 +2910,21 @@ packages:
   license: MIT
   size: 393858
   timestamp: 1714483549536
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
   sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
   md5: c5a600d81b1b48578863af2973c743ac
   license: bzip2-1.0.8
   license_family: BSD
   size: 187637
   timestamp: 1714510590009
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
   sha256: 0c5f9766aa2dcc08ae71b6c0102046a56b30297d0bedc3039b7f72d1658baa43
   md5: 34583b436e62a2ce55d6a7e8eb818e33
   license: MPL-2.0
   license_family: Other
   size: 138712
   timestamp: 1710764814844
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
   sha256: 20b1fc398e925e6c8cea6a06d3bb614e2c0de886e3f14f85b0ba26e57ff40b7e
   md5: ac95cfe373c7fef7820e93189041b0cc
   depends:
@@ -2933,7 +2933,7 @@ packages:
   license_family: Other
   size: 166856
   timestamp: 1707229213510
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
   sha256: 6b5bebc13755b0a5ef423219eeecd1c25b97dbe83afad6e2552635387547d9f7
   md5: b7bc4192fcfed7fc7df1ce00bce97b02
   depends:
@@ -2944,7 +2944,7 @@ packages:
   license_family: MIT
   size: 291802
   timestamp: 1714483319125
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
   sha256: aceaa74365b0d8e69c817639393df3a713a802f40645ac0bd2f39adc871acf54
   md5: 52191c9d4f4fcaeea39574819ab2f14f
   depends:
@@ -2953,7 +2953,7 @@ packages:
   license_family: BSD
   size: 204365
   timestamp: 1698129979494
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
   sha256: 53099bea1cdfeac00bf4bf48e7c3321424af31b9726a7f67033ed06e5d924f04
   md5: 0302e97edbd24e02df7609a6072dc569
   depends:
@@ -2962,7 +2962,7 @@ packages:
   license_family: BSD
   size: 50495
   timestamp: 1683040190091
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
   sha256: 9270668e34b00a2605584a2db5130c83826855cd05b896ce949f3156fa197429
   md5: 2586aa55677e822e8285d777f9039ca9
   depends:
@@ -2971,7 +2971,7 @@ packages:
   license_family: CC
   size: 543487
   timestamp: 1709758497949
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
   sha256: 389c63a84b92a6254c9d361ebe970d537d0b88733efd5ac5c3ee58196fd2c5a9
   md5: c7bc5b3cbe76be83a27f00b7e4740727
   depends:
@@ -2981,7 +2981,7 @@ packages:
   license_family: BSD
   size: 17974
   timestamp: 1709323004148
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
   sha256: bebfc5aa6be12e61a134b580b07b67f7d8c045d6b113fca5b21fa1e83a2f03ce
   md5: 239df72a3921c951059fa8afc09643f6
   depends:
@@ -2992,7 +2992,7 @@ packages:
   license_family: BSD
   size: 287736
   timestamp: 1700583644534
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2024.5.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/dask-core-2024.5.0-py311hecd8cb5_0.tar.bz2
   sha256: 5e6d053acad4139e50c724bb862204097c82f5d9c00dc3c4dd280ec4e2e50f94
   md5: ebd1df3504dc6c94b7c587bba659be54
   depends:
@@ -3009,7 +3009,7 @@ packages:
   license_family: BSD
   size: 3107521
   timestamp: 1715838704477
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.16.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/datashader-0.16.0-py311hecd8cb5_0.tar.bz2
   sha256: 973b7d6f902d0021116a94004a4abc43b623a516033cd650360db52b7a5900da
   md5: 3d602a55412745fd7dc1f5fcfdc2fca6
   depends:
@@ -3031,7 +3031,7 @@ packages:
   license_family: BSD
   size: 18008805
   timestamp: 1699543215294
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
   sha256: e0e30590a78d99d51445ac4f668aefe1bf20025a35bdbac00f04647b95c9f152
   md5: bd0db635eefeea82a0c567b39c9a0e3d
   depends:
@@ -3041,7 +3041,7 @@ packages:
   license_family: MIT
   size: 2485698
   timestamp: 1690905283575
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
   sha256: d48b47b86b09dac1fa4542ec13e1bd4e23093638e684fa66ec3afdd9ce9337c1
   md5: 5a2d1828ab7c8eccd3c2610d13672977
   depends:
@@ -3050,7 +3050,7 @@ packages:
   license_family: MIT
   size: 17336
   timestamp: 1678316187749
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
   sha256: 54645c22fabc25b632114d1d3c403a6fad9149b51ab36719b2690a084f14a072
   md5: a8ad2f4abfb2e17ecf6e596342528156
   depends:
@@ -3068,7 +3068,7 @@ packages:
   license_family: MIT
   size: 3180691
   timestamp: 1713551771692
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -3078,7 +3078,7 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.3.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fsspec-2024.3.1-py311hecd8cb5_0.tar.bz2
   sha256: 296e72c622f7014041055d8c7b602385ad10893aa1c0b600248c95e7d116dfa9
   md5: 93d5cc02fe01e3b396f02df0ca682a79
   depends:
@@ -3087,7 +3087,7 @@ packages:
   license_family: BSD
   size: 365534
   timestamp: 1714461741656
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
   sha256: 4120472ee1c5d31efffeb045892bece27b9a15a30d77c35212f6508221635918
   md5: 9561a225b5171285250c9071f8cab074
   depends:
@@ -3104,7 +3104,7 @@ packages:
   license_family: BSD
   size: 5368257
   timestamp: 1707836808668
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 50dee40e4a9ea7a035baeecc85770c88d63d4e6b0c3c2519c1429e881171150c
   md5: 4d465f453dca5c65224dccbe953f600c
   depends:
@@ -3121,7 +3121,7 @@ packages:
   license_family: BSD
   size: 359293
   timestamp: 1715090716440
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
   sha256: 5c2458964157fe493ca18c513c693b70cb622087e5fa0c93e65fc45217edd811
   md5: 15629e52625221b51a443cefd9501d12
   depends:
@@ -3130,7 +3130,7 @@ packages:
   license_family: BSD
   size: 148522
   timestamp: 1714398885844
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
   sha256: 5a17849341e4d43fc6aff44486425852c16dee6e1cbcab1ed3f2167350f55359
   md5: 445ac9df262ad2dcd86246a9ba5654b2
   depends:
@@ -3140,7 +3140,7 @@ packages:
   license_family: APACHE
   size: 51118
   timestamp: 1704813615186
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
   sha256: e0127f50d444bf4474e8df07d602c7f6dd38690e8bb3fb28817c164940ffcde1
   md5: 583fcd7060cad6a77074d00d9ef62f44
   depends:
@@ -3149,7 +3149,7 @@ packages:
   license_family: Proprietary
   size: 731417
   timestamp: 1699647668990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
   sha256: eb58fa29b1ce9aa5fc774d4c466696457695dec3b206456614b4c9cac0a94e42
   md5: 3d3291ff58dff83dcd40ec54b435f4d2
   depends:
@@ -3171,7 +3171,7 @@ packages:
   license_family: BSD
   size: 229910
   timestamp: 1705934029588
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
   sha256: 73aa7662c00c73bab2dafefefc87a1b524961d2687410af624ecbd6703e483f3
   md5: 7e71e99766107a553752ed8f22b61cf0
   depends:
@@ -3188,7 +3188,7 @@ packages:
   license_family: BSD
   size: 1611976
   timestamp: 1704833049616
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
   sha256: e08cda2bcbdec124c63e951eb248c503bb1467c2a6000010c6bdc0726e0e00b7
   md5: 22c24f43b82da8b3920a913bbf452421
   depends:
@@ -3198,7 +3198,7 @@ packages:
   license_family: MIT
   size: 1168968
   timestamp: 1679336359851
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
   sha256: 3b262312f1fc76e490c067408771da0a12c7691379cddc3c86121255cda7a41d
   md5: cbf00a1bc151243cb6a33524b62f3663
   depends:
@@ -3208,14 +3208,14 @@ packages:
   license_family: BSD
   size: 353280
   timestamp: 1706733664000
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
   sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
   md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
   license: IJG
   license_family: Other
   size: 278924
   timestamp: 1677849185191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
   sha256: 99fc6ac82c56eb2a580f96db24a5b887f8abc8c24af445d3313d5ebb48598478
   md5: 71892160908a6daedb5fb7c404079ae4
   depends:
@@ -3228,7 +3228,7 @@ packages:
   license_family: MIT
   size: 182073
   timestamp: 1699041732321
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 0ea44d0c8044e70ab0eaf4d6f5f3e4753838dee106b5cbd36561e21a65cbac77
   md5: 1d045016dca889d702f1caf3a16162fc
   depends:
@@ -3238,7 +3238,7 @@ packages:
   license_family: MIT
   size: 16528
   timestamp: 1699032525791
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
   sha256: 70442ec4b0b7ebbdcf150963f61f797b861001092124f4ea39a16eb92a4d176e
   md5: 63d1503915a15ae4f9ad1c46112ca374
   depends:
@@ -3254,7 +3254,7 @@ packages:
   license_family: BSD
   size: 272720
   timestamp: 1678316970740
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
   sha256: 8601c674f4779900f6a949e47b814be68b722b0b3d394433bec9d197924ebd69
   md5: b8423f8caff3041a251fc3681f43496a
   depends:
@@ -3265,7 +3265,7 @@ packages:
   license_family: BSD
   size: 94990
   timestamp: 1698937583196
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
   sha256: 6a430c812ce0415a04d9cfe6c66d9012eced2d91c04960c88bc8ec1e9f1b5d6d
   md5: 30b3d5d6a8cf5d1604e5f5fb177917b5
   depends:
@@ -3281,7 +3281,7 @@ packages:
   license_family: BSD
   size: 42513
   timestamp: 1699282637015
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
   sha256: c2d206db117f7161e77236ebd6b0051fc73e1731c242d1e08597d736a0376c92
   md5: bdb61de2e20e02c93423d9de091c74ad
   depends:
@@ -3308,7 +3308,7 @@ packages:
   license_family: BSD
   size: 601837
   timestamp: 1699466514455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
   sha256: fd7964657f0a8fe8b167ba860b1f960e8b7b45309eb6c7c850d50ec283fe03b5
   md5: 2967bb345bc75f53182e263ff4743ca6
   depends:
@@ -3318,7 +3318,7 @@ packages:
   license_family: BSD
   size: 28223
   timestamp: 1686870845224
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
   sha256: 64cf59f0f74b0329b5069bc6135b4f40593f1dac52d85ad574d4b8e0a4b2cf16
   md5: 35e8b80eaa03a904fc7f1da39e7f654d
   depends:
@@ -3330,7 +3330,7 @@ packages:
   license_family: BSD
   size: 20234
   timestamp: 1700168776500
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
   sha256: a12382b50416803f559a03fb384ba492c1dafa351e1191a3f8dc361bee6c4f37
   md5: f2ae846b663bbb642f4b1e90eaad38a3
   depends:
@@ -3340,7 +3340,7 @@ packages:
   license_family: BSD
   size: 64817
   timestamp: 1678322501509
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -3350,7 +3350,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -3359,13 +3359,13 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 685c3bc9068bd485604b80bf03789e4dca95c410d33871bc1b882e47649fabed
   md5: 6cf8e55271e150ca0961d0ddedaa61bb
   license: MIT
   size: 66237
   timestamp: 1714483284541
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 69826cee54db9955f0120af21ec36d13f9211877fd67364f2068d0a54c6c97cd
   md5: 0851917257f490d35e1f73da8a1c723c
   depends:
@@ -3373,7 +3373,7 @@ packages:
   license: MIT
   size: 34042
   timestamp: 1714483343147
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 3f5a1f03b50b90b397a0ee432ad0cba13354abdaf7e5652c0fc60164b26a08b6
   md5: a50bdc871ef4bf14deb088d888b92b5e
   depends:
@@ -3381,28 +3381,28 @@ packages:
   license: MIT
   size: 311597
   timestamp: 1714483371586
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
   sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
   md5: 822a5b76117e56d3912f1f2153307528
   license: MIT
   license_family: MIT
   size: 136045
   timestamp: 1714483561919
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
   sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
   md5: e458587c87e3f2d20192f4e0738f2c63
   depends:
@@ -3411,7 +3411,7 @@ packages:
   license_family: GPL
   size: 149419
   timestamp: 1665498987619
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
   sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
   md5: 1058b661ec829b2ee3716ee2a5520641
   depends:
@@ -3422,7 +3422,7 @@ packages:
   license_family: GPL
   size: 1917987
   timestamp: 1665498925405
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
   sha256: 8176dd9a68815301a24ed51e72f3506f5f77c67a112efa0dd14971f2f3b3c8c1
   md5: b5e470c224000a6bda6f655c155b53e7
   depends:
@@ -3434,7 +3434,7 @@ packages:
   license_family: Apache
   size: 27861431
   timestamp: 1683292881730
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -3443,13 +3443,13 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -3466,7 +3466,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
   sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
   md5: 46a65d1fc24013217e06aaf6d65ffcad
   constrains:
@@ -3475,7 +3475,7 @@ packages:
   license_family: BSD
   size: 425478
   timestamp: 1694776947990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
   sha256: d28c465ec6d5f8d4962c597b249b58998300c8b4e3c937c578c3d15294ea863d
   md5: dcaed6ddd0723c7cce6bfad917be98b2
   depends:
@@ -3485,7 +3485,7 @@ packages:
   license_family: MIT
   size: 41176
   timestamp: 1678413498410
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
   sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
   md5: 5c740b4a18a558de0ccfe601703c423c
   constrains:
@@ -3494,7 +3494,7 @@ packages:
   license_family: Apache
   size: 338738
   timestamp: 1662635677689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
   sha256: 53808184421c81e661f9927ff564a0d0ecdf3b816c8aba8e2368434e055529d4
   md5: bee10bfbe90767fcb8f8f6ab3a05d85a
   depends:
@@ -3505,7 +3505,7 @@ packages:
   license_family: BSD
   size: 407784
   timestamp: 1706911015242
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
   sha256: 716a654df2e55052193150015bd5c9856b847893fc5a229fa8669725b1c56ff2
   md5: 687ba6c11de38ad7cc597f7188b491e7
   depends:
@@ -3514,7 +3514,7 @@ packages:
   license_family: BSD
   size: 13357
   timestamp: 1678322560230
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
   sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
   md5: 8f57dc3a3327bb6f7e1cba908856ac7f
   depends:
@@ -3523,7 +3523,7 @@ packages:
   license_family: BSD
   size: 183138
   timestamp: 1714510756758
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
   sha256: 6fb2953e169ee1ae38f24d29752051501992f19b96b5ebcea9af75737bdbcb42
   md5: 7f410cdae838c5030108d1b98a8c78f6
   depends:
@@ -3532,7 +3532,7 @@ packages:
   license_family: BSD
   size: 162478
   timestamp: 1678377892595
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
   sha256: cd97e09a12ffb49b2a30a782fa8c7933b28f5ffdbfc5c73a9ebaa95fc9447370
   md5: d1fb6ebc1e5728aa6377cfc71da08942
   depends:
@@ -3542,7 +3542,7 @@ packages:
   license_family: MIT
   size: 135859
   timestamp: 1684280005320
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
   sha256: 30c3b189462a9d0f4794d229adadf34b5f5a5f56f95c30d5afc17ef524579290
   md5: d4e9421243129d1d57c472dab045f3dc
   depends:
@@ -3553,7 +3553,7 @@ packages:
   license_family: BSD
   size: 26639
   timestamp: 1704206159955
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
   sha256: 080000a28b3ceca54eec6de0748c690ea5a4c390e358283eac03fe7a6dd87065
   md5: 51344eca57d7940fb01eb5e8914509e3
   depends:
@@ -3575,7 +3575,7 @@ packages:
   license_family: PSF
   size: 9099909
   timestamp: 1713336790553
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
   sha256: 07e7fd5bd64e55328b4b99d92e2e2600d791f1095bf905daab4cfc59f0f0a45b
   md5: cf53321779f4ca7e986c1468719b93f1
   depends:
@@ -3585,7 +3585,7 @@ packages:
   license_family: BSD
   size: 19500
   timestamp: 1678317565001
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
   sha256: 0770e02be1ea1216af493cfc03d5b8a702e14606fa93b0692bcdab1fed1b898c
   md5: ca6f06ceaf66a32bbf5dfdb6e373a5cf
   depends:
@@ -3595,7 +3595,7 @@ packages:
   license_family: MIT
   size: 67892
   timestamp: 1678417734353
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
   sha256: fbe95ed0501bb0f137048476fe41bc718dd659e8ecb066bc67ac17d6a50f4318
   md5: ec162bde8d1c8a107b257df218b17035
   depends:
@@ -3604,7 +3604,7 @@ packages:
   license_family: MIT
   size: 23030
   timestamp: 1678381838497
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
   sha256: c20dd678655e582129a858a1c5162bdc254082d3a3c035b0f72629d9276e5b75
   md5: 800a0738c728796e02d0386ce7d457aa
   depends:
@@ -3615,7 +3615,7 @@ packages:
   license_family: BSD
   size: 104585
   timestamp: 1678317269407
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
   sha256: c825bc3070f73318ffff88a7a0b7fc6d1858b058ced735efd1789053f1583918
   md5: dea5f96459c9a6df6b026ca57d387936
   depends:
@@ -3628,7 +3628,7 @@ packages:
   license_family: Proprietary
   size: 224299920
   timestamp: 1699647835748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
   sha256: a76c134ec258612ff7d55cb2a19b9e3461cbbd375a744bd29390af9cfcd283b2
   md5: 1c736f58992009f53f014aef163bae31
   depends:
@@ -3638,7 +3638,7 @@ packages:
   license_family: BSD
   size: 48442
   timestamp: 1682969160267
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
   sha256: bcfb0d1e075d043bcf05fa1a7ce3c142bf222d29693366af49a5a346c770812f
   md5: 59e4820b34049cbc6619a8ac97290abc
   depends:
@@ -3651,7 +3651,7 @@ packages:
   license_family: BSD
   size: 222137
   timestamp: 1695058350477
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
   sha256: 114e408c40b332393cf2792393e4d1ede3465abcb3d345fe647ee519565346c8
   md5: 86b13271578e1fa5e664edcf6fcb3ce4
   depends:
@@ -3665,7 +3665,7 @@ packages:
   license_family: BSD
   size: 296860
   timestamp: 1695059990370
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
   sha256: 638450a7ccb5f438ac65aa1c8d871fb5bb664e7261ec7e663d0302485c219a67
   md5: 574875bbeabff85b5d9cfdb62066aece
   depends:
@@ -3675,7 +3675,7 @@ packages:
   license_family: BSD
   size: 29473
   timestamp: 1678392919304
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
   sha256: a58960e88525a202ba193b4dd8227c4d9c3dd98b8b43edea34b05a9a9fd1121c
   md5: 71a37f987c3df6657548d098bd2a58e7
   depends:
@@ -3701,7 +3701,7 @@ packages:
   license_family: BSD
   size: 8286383
   timestamp: 1699543227340
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
   sha256: e08cb3ee6df01f4c1e1ac8bc4ed1a06e549ffcc8774fe2e2842c644bb8f74a86
   md5: 6ba0ae0fb14cbea1e3197707701dc180
   depends:
@@ -3714,7 +3714,7 @@ packages:
   license_family: BSD
   size: 123077
   timestamp: 1698934356774
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 2f946b5042eaac97206b5217fb203f3604ab3a60aecd99bdfc684925e3136c18
   md5: b24026076c381ff2009e7acb9e0a6e87
   depends:
@@ -3741,7 +3741,7 @@ packages:
   license_family: BSD
   size: 534650
   timestamp: 1699022791300
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
   sha256: ba368605a0af6f1dcbdcb6fddab9ce63224a85dd11bfb2b1acace1dc17899411
   md5: 91f3ea3fe44d619ee95a6ed3773a0814
   depends:
@@ -3754,14 +3754,14 @@ packages:
   license_family: BSD
   size: 170926
   timestamp: 1694616830121
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
   sha256: 42d803e1d8b54748db5d989ecd503826f564132df7cddc20f520460f55e523a1
   md5: cd3fa71626ebc098da4625fc6be79752
   depends:
@@ -3770,7 +3770,7 @@ packages:
   license_family: BSD
   size: 16952
   timestamp: 1708532805951
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
   sha256: 92d50872fad0d1fecfea42cbfdb69887def80927c169a88204d163c2d3c7d035
   md5: fe6780b8659ff5d6061268708a7b2032
   depends:
@@ -3795,7 +3795,7 @@ packages:
   license_family: BSD
   size: 716120
   timestamp: 1690984968401
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
   sha256: ed5608feb37a083d47b04203195260e801b64b5380f292cf18bb61e7ad827a2a
   md5: daa9c1c233673b727528548454aea664
   depends:
@@ -3805,7 +3805,7 @@ packages:
   license_family: BSD
   size: 27607
   timestamp: 1699456006797
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.59.1-py311hdb55bb0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numba-0.59.1-py311hdb55bb0_0.tar.bz2
   sha256: 733ece9d325b4baeaea505bd82be98ffe9e5f15669bf079ee4f2f15225bc70cb
   md5: c426b5fb76b3d219a2fbfa2792684ae2
   depends:
@@ -3826,7 +3826,7 @@ packages:
   license_family: BSD
   size: 6049873
   timestamp: 1711992424576
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
   sha256: cacba45c1eebf7d86748737717883a98cf40664231460fa41391c79f98d06f45
   md5: 3dbfae0d5b90e77f9358564ad442ac9d
   depends:
@@ -3840,7 +3840,7 @@ packages:
   license_family: MIT
   size: 165572
   timestamp: 1696515553184
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
   sha256: 1466c3af380b949612c79940124e426eccd59e335c205da0c00383a69358d1c0
   md5: df6be53592d40ba7e03d6ffe349760bf
   depends:
@@ -3856,7 +3856,7 @@ packages:
   license_family: BSD
   size: 11330
   timestamp: 1708639985606
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
   sha256: ace67d704fa7eea1480eb463f2d91bfc161be2ee20263c5a9939805ae3c2a9da
   md5: ec124589478fa12fba4f35f31c3a0692
   depends:
@@ -3871,7 +3871,7 @@ packages:
   license_family: BSD
   size: 8783230
   timestamp: 1708639945646
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
   sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
   md5: 93f5d7b66976154adeda219bea02ba45
   depends:
@@ -3881,7 +3881,7 @@ packages:
   license: BSD 2-Clause
   size: 484257
   timestamp: 1630093862501
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
   sha256: 891ffe9826f6f9ec9a4fc5d1bbb9a64f9de23f27705c2202f7d475b7cd14dd83
   md5: ab0d447c9eb4fcada05d853bd13a24ac
   depends:
@@ -3890,7 +3890,7 @@ packages:
   license_family: Apache
   size: 4970613
   timestamp: 1716319014066
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
   sha256: 8a0809f419065e014cb8e2c8a516cadca6088fb71fd1ef3ae2287d91e3360d59
   md5: 4dc0b9bc88476fcc5246d823ff1c289a
   depends:
@@ -3899,7 +3899,7 @@ packages:
   license_family: APACHE
   size: 39645
   timestamp: 1699371213055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
   sha256: 64fbbb03570788298d8b04d4ea6cb254fef5d5eec73265aeecd72cb565617f4d
   md5: 4b1195028bc26257df43fdd943638266
   depends:
@@ -3908,7 +3908,7 @@ packages:
   license_family: Apache
   size: 159450
   timestamp: 1710811009212
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
   sha256: 6abb7e0aeda0130f54925421900772e1bc46d1f04ae69ce1376524457686d49f
   md5: 232a6370c3fab0c41c6d4c7339e778ca
   depends:
@@ -3958,7 +3958,7 @@ packages:
   license_family: BSD
   size: 17296294
   timestamp: 1709591285369
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
   sha256: 10a5eb185aa5dcfecfa854c2e66b3779cb6d2dee85f1b2236f43234a1c1ba9e0
   md5: 2200abcb857e6bb8cb46b861cb4d2fd7
   depends:
@@ -3982,7 +3982,7 @@ packages:
   license_family: BSD
   size: 22071486
   timestamp: 1714072093679
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
   sha256: daf01c56a3c44555ecb61e9a0e899a7b58872c6b7631f00a04ee8d3199e9e568
   md5: 2163ed8005a14ecda15efe5586582cce
   depends:
@@ -3991,7 +3991,7 @@ packages:
   license_family: BSD
   size: 267508
   timestamp: 1711137004592
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
   sha256: 359b31da651ee35b9ca43974d26cd44e64f3cf412096c15dec7b720fa909a9b2
   md5: 108e24227f8fdfc4d635bb4eedfa6cef
   depends:
@@ -4005,7 +4005,7 @@ packages:
   license_family: BSD
   size: 48504
   timestamp: 1698702608965
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
   sha256: 90efc71d35ab62d5b8d7b648e016444e1c4c8b83238b6dc9f2c6c3db4b14c599
   md5: 6b6eeb0a14c5479db1dd39aa8d338150
   depends:
@@ -4021,7 +4021,7 @@ packages:
   license_family: Other
   size: 939480
   timestamp: 1714399174883
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
   sha256: f6b0ded7010706431f2a6d9776aa6033dfd19d2264b3cebf28072629160090a8
   md5: 02de6d0d9cc23fafe2e3597ed0e52693
   depends:
@@ -4032,7 +4032,7 @@ packages:
   license_family: MIT
   size: 3444268
   timestamp: 1715097155645
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 81719c31101d6c019150cedcc7b08adb3bdb357e8b2952e428dadaabc4dc985d
   md5: 105825168e0a17fb007f60b5f314e311
   depends:
@@ -4041,7 +4041,7 @@ packages:
   license_family: MIT
   size: 38405
   timestamp: 1692205731769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
   sha256: c0982f688127129e026d2b4cdacdd5684d00796ea7bdadd7d26b1101b095d723
   md5: 0d6910c74729fede645c010110f1c89e
   depends:
@@ -4050,7 +4050,7 @@ packages:
   license_family: Apache
   size: 121796
   timestamp: 1679340253537
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
   sha256: e32843723b10ecd9badde28e1085419c0b59ed8a96c7cacce6395e39e3a874f9
   md5: 5af0280a817d2c273304cd22328124af
   depends:
@@ -4062,7 +4062,7 @@ packages:
   license_family: BSD
   size: 763044
   timestamp: 1704404460779
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
   sha256: 117a435c2473e2a20cc81eaacb2b45ea5e7fe3c946eec2915936d344913ede44
   md5: 0f459ee59fda20e2077fdc2c777edfc8
   depends:
@@ -4071,7 +4071,7 @@ packages:
   license_family: BSD
   size: 497470
   timestamp: 1679337286052
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
   sha256: 667b5cf00d31293dede2ddadcc30ab967103d585d40647f34d6d830af97ee51f
   md5: 81d3876fa502fca91ba4136a5f3fc3d3
   depends:
@@ -4083,7 +4083,7 @@ packages:
   license_family: BSD
   size: 37821
   timestamp: 1678378977816
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
   sha256: dfb403f367c57327a4d080109df88383ecff18464de287a1ce936a7274e3656b
   md5: 997b674bad89963af875b93b06807f51
   depends:
@@ -4092,7 +4092,7 @@ packages:
   license_family: BSD
   size: 2120413
   timestamp: 1684280057020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
   sha256: 9d2c0f373ac1c5db329581793dd517092cdf9a59140f2516ed8c3a1f483c0bbd
   md5: ee10503a159e819abdc586666bdf0952
   depends:
@@ -4101,7 +4101,7 @@ packages:
   license_family: MIT
   size: 207552
   timestamp: 1678322848766
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 717e038567506ca58ce1cd4a3416892d02f4ebfdd332077cc3d110cfe3d36c58
   md5: 53bbfb400668f798eef6f8c7cf938e1f
   depends:
@@ -4110,7 +4110,7 @@ packages:
   license_family: BSD
   size: 35751
   timestamp: 1678315886516
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
   sha256: 092dea8d520acff3e64c71155e666b0b6074d37a71d5eb32f3cd485b0d185d0b
   md5: 9fbaf2d9534c26e76aa14b11b23de332
   depends:
@@ -4129,7 +4129,7 @@ packages:
   license_family: PSF
   size: 16852220
   timestamp: 1713545835789
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
   sha256: 04e100d0a1ea9722e24972657ec5935ad34c7c58957dabb821333e5eac80f717
   md5: 2b6de49ad07b26e1f7084f0fda958eb1
   depends:
@@ -4139,7 +4139,7 @@ packages:
   license_family: BSD
   size: 332276
   timestamp: 1716495830117
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
   sha256: 514249897265f66f6ecca0a4427eb02a43c33b3c24974db16d05db6bbe97881d
   md5: c9ea1437e5a3ba6a52ec2322505203e6
   depends:
@@ -4148,7 +4148,7 @@ packages:
   license_family: BSD
   size: 279116
   timestamp: 1679338758489
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
   sha256: 78b785b9b6ed46c86b0d3a32bdceea49f816672227fb63e726b2d46eadbdba0b
   md5: 79d783f74359141e0b06a848db33823b
   depends:
@@ -4157,7 +4157,7 @@ packages:
   license_family: BSD
   size: 18563
   timestamp: 1683823935261
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
   sha256: e358fe679e83ccdc8c433746ae6468e8e96d90d97d99530f8476ef5630b2c121
   md5: ce30a0a31d891e69dc9b7bf8b7f0c39c
   depends:
@@ -4166,7 +4166,7 @@ packages:
   license_family: MIT
   size: 268876
   timestamp: 1713974360942
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
   sha256: eeb5a5eed93b8e311ad4d3f4389e050f11bba2eaec9536e1c3ed2f849c6c999b
   md5: c18bd3e12de797d52a470c21a150dffe
   depends:
@@ -4178,7 +4178,7 @@ packages:
   license_family: BSD
   size: 65270
   timestamp: 1711136914884
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
   sha256: c3e11ed944da69c11b949bb918341a0d79ef603ee34a632d6a45fbf89ff924a1
   md5: fee7ff4d291f530b4cecb575f29807a0
   depends:
@@ -4188,7 +4188,7 @@ packages:
   license_family: MIT
   size: 197996
   timestamp: 1698096137432
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
   sha256: aa07b90a7ee65f76c8cba1ff99a5cdeb95cbe41881ae951f64ffff06674a1b2d
   md5: 58621e3d244137885f7dfbb35e50340a
   depends:
@@ -4198,7 +4198,7 @@ packages:
   license_family: Other
   size: 594801
   timestamp: 1709318510622
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -4207,7 +4207,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
   sha256: d784dc26c5de8e41845350a899e5779250b71f45d39e2aece62e739e9add7308
   md5: 7b077b7f46112bb31dc066396c51d3fa
   depends:
@@ -4218,7 +4218,7 @@ packages:
   license_family: MIT
   size: 74776
   timestamp: 1699012164201
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
   sha256: 3357b6b327b3d0a2cc0f02934a60bbd6df38f4ea7bbb3f50cb8e21332c9f5786
   md5: bf5e48b646e36ef2b788be9665c0e5ae
   depends:
@@ -4234,7 +4234,7 @@ packages:
   license_family: Apache
   size: 120768
   timestamp: 1707355762747
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
   sha256: 727fb8d957e02d03b928d049ffbc712316f176a2c331391766d646621b45655a
   md5: 7e0e416c642f3ee4ddfb084a811fb4df
   depends:
@@ -4244,7 +4244,7 @@ packages:
   license_family: MIT
   size: 10236
   timestamp: 1683077214314
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
   sha256: a8a67143ccb65cfd6f50055176b6c26179a83130a45d0a12e79dd2de68d8db63
   md5: a2065790f41e3eeb6efe0ef6daa75377
   depends:
@@ -4253,7 +4253,7 @@ packages:
   license_family: MIT
   size: 10600
   timestamp: 1683059285216
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
   sha256: 6aba582338faa0c26fe336bdb10c65b8f7808a6e383bd8f80f3e6b612ca209ec
   md5: a7486349b5f7370f6902c2050a23d268
   depends:
@@ -4262,7 +4262,7 @@ packages:
   license_family: MIT
   size: 319197
   timestamp: 1698946203341
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
   sha256: 86bda04163628ef7b35528fbb4fe1d56fef50d10570a859e5ae8a7fbb60f577c
   md5: 05e397dddd20d91460e3cedea0b3686f
   depends:
@@ -4281,7 +4281,7 @@ packages:
   license_family: BSD
   size: 27745043
   timestamp: 1714075585637
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
   sha256: beba0555707dac1e8484d73cee9e4128ac4b10e2a0d4209357481179022e8fdc
   md5: baa8b304607b3a9ae8a3d9acb354c31c
   depends:
@@ -4290,7 +4290,7 @@ packages:
   license_family: BSD
   size: 33343
   timestamp: 1699371216044
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
   sha256: c1df29188e321abe23651c73712a6d8ed3abdc89ad38a42c33f1835b3ab77abe
   md5: 6c984ea85326858942f7b635e0cc9ff8
   depends:
@@ -4299,7 +4299,7 @@ packages:
   license_family: MIT
   size: 1597325
   timestamp: 1715025837032
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
   sha256: 0eb44a16ef74a13ef7839209899d009cd94974fbc406a417d958c7bc8d955245
   md5: 41f239a5b67b1daf819849023aa5d12f
   depends:
@@ -4308,7 +4308,7 @@ packages:
   license_family: Other
   size: 19056
   timestamp: 1705431379885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
   sha256: 14775231982e1ea150189c956927ccfb1ad01a8c9395cdeea4d5a48b9b8ce664
   md5: 729badc4bf7ba8ccc70e0f9e58075c99
   depends:
@@ -4317,7 +4317,7 @@ packages:
   license_family: MIT
   size: 89812
   timestamp: 1696347694075
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
   sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
   md5: 6bef1694163a68ac4c37e5857b8da4f5
   depends:
@@ -4329,7 +4329,7 @@ packages:
   license_family: Other
   size: 1900191
   timestamp: 1714488351925
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -4338,7 +4338,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
   sha256: 3d5c2968f581006437df3932cd5d3c1c4afa78f0e13757b958440245d3248856
   md5: 605ea221d225ad8e79284dbcfdab0715
   depends:
@@ -4349,7 +4349,7 @@ packages:
   license_family: BSD
   size: 37699
   timestamp: 1678317755913
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
   sha256: ed059e32ce5a1c0511575f29d2fb6da12c54a37000bfa80f9e5aa9dfd9e04101
   md5: 4d2261a92d25136a68b8d01d101119f5
   depends:
@@ -4359,7 +4359,7 @@ packages:
   license_family: BSD
   size: 49145
   timestamp: 1678317386284
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
   sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
   md5: 523c006cc67c011383678c762015479b
   depends:
@@ -4368,7 +4368,7 @@ packages:
   license_family: BSD
   size: 3594448
   timestamp: 1714770737885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
   sha256: 424b8284072266eb59d055c0b7b58241bfb00009d445743ea261d4eeee73ea19
   md5: f3a47898a55087edb9d65d29c24d9b88
   depends:
@@ -4377,7 +4377,7 @@ packages:
   license_family: BSD
   size: 135757
   timestamp: 1678323030858
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
   sha256: 6ab71b48d145c69007cfb5b4a21def2cc83bba972b7cc91c7d52d0d7eeb055bf
   md5: f8970b0ad5c8b452b8722ceb4e5c17f7
   depends:
@@ -4386,7 +4386,7 @@ packages:
   license_family: Apache
   size: 895379
   timestamp: 1696937269468
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
   sha256: 3df84b9897f05a104c99e297dc29ad8f718982fc64c61b5a2204c19c578f47e5
   md5: deab971930d242221ed86bfd768dde40
   depends:
@@ -4397,7 +4397,7 @@ packages:
   license_family: MOZILLA
   size: 155545
   timestamp: 1716396266697
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 9e8dbede0bc54c77b974210be66503e7e8e45e0f1c71dc5c16cc9a9674d54259
   md5: b4fcab9e63bd7b3cdf458c953904807c
   depends:
@@ -4406,7 +4406,7 @@ packages:
   license_family: BSD
   size: 270874
   timestamp: 1678316116954
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
   sha256: 17e5688d09ffbcb8b71b34b86edc7374fa0b04d60a4d729d405ffc22ef63726c
   md5: e4bf44ddbbcb136332ccb47ac2b879a0
   depends:
@@ -4416,7 +4416,7 @@ packages:
   license_family: PSF
   size: 9890
   timestamp: 1715269046804
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
   sha256: 7d369ec970d1d5411e457c79f94197756c7088deff8183806ea71e633b26edf9
   md5: 9ffa197b26373667f50b21876862398e
   depends:
@@ -4425,7 +4425,7 @@ packages:
   license_family: PSF
   size: 75595
   timestamp: 1715269030928
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
   sha256: a9960485ced319ac91afe69eaaf703c7e6b3049f1e06a4a8c2818b64155943f0
   md5: 0a9c8ea92a14330a07edabac249e32a9
   depends:
@@ -4434,7 +4434,7 @@ packages:
   license_family: MIT
   size: 11399
   timestamp: 1678394892923
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
   sha256: d42ae57366d05e12f10074583568355752436d66ad018ffbcfa24135f593810a
   md5: 1a98e48aa0bd8b3ec09e2cbdbb236575
   depends:
@@ -4443,7 +4443,7 @@ packages:
   license_family: Apache
   size: 498952
   timestamp: 1713213079520
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
   sha256: 5dc693f0e0aeb30cb6033015b13e75c8a21c56b1262d9652788c3e73a5c5c4a5
   md5: 6b5cc9b43aa34431f8c30b5cdc22004b
   depends:
@@ -4459,7 +4459,7 @@ packages:
   license_family: MIT
   size: 210522
   timestamp: 1715636148762
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
   sha256: 597015e8a038a111f03ffbc9a217fcda549d75230c86ce53c1f23c53d6f1a0cb
   md5: 62e98aac883bccc1c87ca0d2ce2f08e0
   depends:
@@ -4468,7 +4468,7 @@ packages:
   license_family: BSD
   size: 25798
   timestamp: 1678317074170
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
   sha256: 1430e6f4b4dd9354b7bb88f7f7bc9cdbab26a034ad1ae5c278de0f5a99329372
   md5: be0832862b29bf5767a707ac6bd53b93
   depends:
@@ -4477,7 +4477,7 @@ packages:
   license_family: Apache
   size: 114834
   timestamp: 1715878445060
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
   sha256: 885a9b6046e76f7dc1a346b14c63b4083046137bfae036362c854458e20e4fc8
   md5: 3b279447ca282d065e681e567055b582
   depends:
@@ -4486,7 +4486,7 @@ packages:
   license_family: MIT
   size: 137340
   timestamp: 1714717062907
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
   sha256: cc6995f677d1628f42ae80ed47ff08d8d1c8ed12580a326af6e307f5febc594a
   md5: d01eb964863b95ef62061b77c9037ead
   depends:
@@ -4498,7 +4498,7 @@ packages:
   license_family: Apache
   size: 2471632
   timestamp: 1689041625741
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
   sha256: 5b6d5246955b5f9480ff7027eb002442a7ade24f5c354da54ed513042f76cedc
   md5: f32aa8a37d5e65a8dc30f9a1f46bc63d
   depends:
@@ -4507,20 +4507,20 @@ packages:
   license_family: BSD
   size: 54719
   timestamp: 1678325412288
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
   sha256: ed0152ad6b87ffd9e01f4a62bc358e805ad59637f898a801b0a9cf903ae8e1fb
   md5: 8a92f8c663608f24e14d8a2068b9d83a
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 415323
   timestamp: 1714511993944
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
   sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
   md5: c25b6d40f834647d0bbe767f6c776031
   depends:
@@ -4530,7 +4530,7 @@ packages:
   license_family: Other
   size: 329449
   timestamp: 1705602140856
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
   sha256: 36fa7ad990aabf3607bda1f33e847888210974586363b6d69cf1ed092c192c35
   md5: c981fe545122206cdeb647f2dc9e093d
   depends:
@@ -4539,14 +4539,14 @@ packages:
   license_family: MIT
   size: 25496
   timestamp: 1704207010227
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
   sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
   md5: f2519b551f99765d9d98950c5e2b4713
   license: Zlib
   license_family: Other
   size: 119782
   timestamp: 1714511811597
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
   sha256: 7feb73e79bdbd45404ddc7a30c43bf4cc68eced8ce448ce7c31f5db134276fc5
   md5: 48313bc6570c705cadbba3c356e0dc8e
   depends:
@@ -4558,7 +4558,7 @@ packages:
   license_family: BSD
   size: 1014151
   timestamp: 1714678461080
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
   sha256: 9ca3f0dfc2bdbc109e359ba7ab246e6ae952a14819148ad069454b52f2bda802
   md5: 51fb05873a644cac52f0d1e10cb7969a
   depends:
@@ -4572,7 +4572,7 @@ packages:
   license_family: MIT
   size: 228856
   timestamp: 1706220385566
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
   sha256: 43405cc7341ce3efb2e24013ad62c64f26a69926635adceaa5459ccbcafb3776
   md5: effa6d22f497e164cc8455f7f329c304
   depends:
@@ -4581,7 +4581,7 @@ packages:
   license_family: BSD
   size: 12510
   timestamp: 1677917870614
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
   sha256: 947efe1c50b3280e9a67cbb18636bdade53a40960fff3056850ff81ab87acbe3
   md5: 7d2d384ee32ccc12dcb0dc099e421482
   depends:
@@ -4591,7 +4591,7 @@ packages:
   license_family: MIT
   size: 35091
   timestamp: 1677915945226
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
   sha256: 8259b4a0973c825ac81f581afcbe86640bd0a94b33caa996167309241877635a
   md5: 49b8ddacfd3927bcaae139eadfb72ce1
   depends:
@@ -4600,7 +4600,7 @@ packages:
   license_family: MIT
   size: 153557
   timestamp: 1695717951839
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
   sha256: 11159a30daae77cfc1abe5e60c19261f65c005e6fbc460aecf72318514d737ad
   md5: 0c5002654a9cb21db1fdf8c1d2017df5
   depends:
@@ -4610,12 +4610,12 @@ packages:
   license_family: MIT
   size: 269772
   timestamp: 1681493072129
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
   sha256: 90439f37ede74ef464e76093e173a8e94a20ee4ad79c68c9e7570fbc67fc13cc
   md5: bb3b906307dd679fc3276be7581494f9
   depends:
@@ -4633,7 +4633,7 @@ packages:
   license_family: BSD
   size: 6073834
   timestamp: 1712084392983
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
   sha256: 688a071ba370f51b457cd32d70b7b38921ce9551203d06fa7fc2c30c4b79891d
   md5: b2353077a39ab997463768154dd58fec
   depends:
@@ -4643,7 +4643,7 @@ packages:
   license_family: BSD
   size: 134711
   timestamp: 1707864978809
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
   sha256: 048264434c33fdb53862cdd69b2e2bc4ce6f8a70b3211ad6d686d066eac2aa91
   md5: d55696ccaf6755931cd662dfb929aa0b
   depends:
@@ -4653,7 +4653,7 @@ packages:
   license: MIT
   size: 19737
   timestamp: 1714483270447
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
   sha256: 13627293296fcc231d8dc12d803dfc9621108c60df38b0e3c64e9e02ed55e564
   md5: 86efd4ad08cd80d3eab77873db84a255
   depends:
@@ -4662,7 +4662,7 @@ packages:
   license: MIT
   size: 19083
   timestamp: 1714483255364
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
   sha256: 2e542b2bb27f8379da3efcb83ef084cb26e6a9ab576c50487c2dd996afd5ccb1
   md5: e8cab9d1ef58a450f971690fcdb2ede2
   depends:
@@ -4671,21 +4671,21 @@ packages:
   license: MIT
   size: 380182
   timestamp: 1714483330655
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
   sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
   md5: 56d1386c7f1f338f0d18f82af6525273
   license: bzip2-1.0.8
   license_family: BSD
   size: 158748
   timestamp: 1714510571033
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
   sha256: bbfc668f445f3584936b326dcfe92bf71971ce16241f4f79db8aeb88d7aab41c
   md5: 10cc05ed51482e1dfcc31dbd13bb34c6
   license: MPL-2.0
   license_family: Other
   size: 138641
   timestamp: 1710764806818
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
   sha256: 512969f339a9a7b347cdb7b88f439819168089867f04732279f02759d8caf24e
   md5: 2009c2ee465fdd74dbd046de73726234
   depends:
@@ -4694,7 +4694,7 @@ packages:
   license_family: Other
   size: 166501
   timestamp: 1707229221324
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
   sha256: 8d26cd4d16545ad8afddd5521bc6894a50d5b8faff3abbe600bb9b062f3c3a0a
   md5: 66eb734b7d7008eb5fb537900767c7ae
   depends:
@@ -4705,7 +4705,7 @@ packages:
   license_family: MIT
   size: 286807
   timestamp: 1714483190838
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
   sha256: df81a27f221d11af4a709f272dc8ba3fd3f6d5ab4ffd883c40567bcf04f0cfd3
   md5: e49333e3ffe1fe2e701f50a6e6dccc52
   depends:
@@ -4714,7 +4714,7 @@ packages:
   license_family: BSD
   size: 204179
   timestamp: 1698129906257
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
   sha256: 53edaca56d853083d44cef6234fe4b3d076d107e915781ce54ec135c25e09f0e
   md5: 5d1d51e53c11bcb56cf863d58e37c077
   depends:
@@ -4723,7 +4723,7 @@ packages:
   license_family: BSD
   size: 50433
   timestamp: 1683040076511
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
   sha256: 808e56fb70f3d38599ee7a54c2a707b282ba9a401fa69a1f54cdc26425d9ce01
   md5: fc37321833175bda4fc5c21afe32db49
   depends:
@@ -4732,7 +4732,7 @@ packages:
   license_family: CC
   size: 539588
   timestamp: 1709758479776
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
   sha256: d9c126d8bcd1c89ea37186c172d6b1f73f45ada60e3ae1790a017b530baa0147
   md5: f0223aae3d622547f6accb212579c58e
   depends:
@@ -4742,7 +4742,7 @@ packages:
   license_family: BSD
   size: 17967
   timestamp: 1709322909223
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
   sha256: 1f908c688e47d03d92ac09d9541a1f1c773ac2ca485dd1d77441b1aaefc032db
   md5: 444c330471496a39a97e87f41ed70c96
   depends:
@@ -4753,7 +4753,7 @@ packages:
   license_family: BSD
   size: 281104
   timestamp: 1700583698464
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.5.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2024.5.0-py311hca03da5_0.tar.bz2
   sha256: 71c289b48cfb6e957d879c3150963cd80654f408e274a9bc816ee6b72d69e912
   md5: fd38d206222a32b3c71718acaf205013
   depends:
@@ -4770,7 +4770,7 @@ packages:
   license_family: BSD
   size: 3103523
   timestamp: 1715838626586
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.16.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/datashader-0.16.0-py311hca03da5_0.tar.bz2
   sha256: 2b7fcd83146c02c4d4b2e2adb2512172536118cb0f630c47a43b11c5005734bf
   md5: 6687cac2611e1868f6ad781167a671c1
   depends:
@@ -4792,7 +4792,7 @@ packages:
   license_family: BSD
   size: 17988386
   timestamp: 1699548972355
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
   sha256: b9356e3ada4872c7c950d2ac7e0f107c4786775191efdfda3a469dffb18f2714
   md5: 07ddd96675caf30ea77cafb1ea5662a4
   depends:
@@ -4802,7 +4802,7 @@ packages:
   license_family: MIT
   size: 2490144
   timestamp: 1690905181398
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
   sha256: b1481ffa475c65200626f051d5dcbdb264730b533e928dde608a79ce7a5b4e48
   md5: aada2761547a291d68f4c016a1a9bc7b
   depends:
@@ -4811,7 +4811,7 @@ packages:
   license_family: MIT
   size: 18265
   timestamp: 1677911915719
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
   sha256: eb82a0e2ca36d0973b5f6642e27609554edad4b72696f989776d5db8cd4a6a42
   md5: fa8d9dd8a2fabba964c6bb75ace8c572
   depends:
@@ -4829,7 +4829,7 @@ packages:
   license_family: MIT
   size: 3201601
   timestamp: 1713551611540
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -4839,7 +4839,7 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.3.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2024.3.1-py311hca03da5_0.tar.bz2
   sha256: aa53d9f23e86ac3398f6b935cea01dcd8a1b1821d9b1d37b16a5ba68a2dbe569
   md5: 2d5841b96988498045c28e3b3951d5ac
   depends:
@@ -4848,7 +4848,7 @@ packages:
   license_family: BSD
   size: 373029
   timestamp: 1714461571346
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
   sha256: 898d10bc1ededb43b7339ccf57fef404d96184de8ebaa788dba0b36a8c8a282d
   md5: a1925e4ff9f6124ca7d439430bc110fb
   depends:
@@ -4865,7 +4865,7 @@ packages:
   license_family: BSD
   size: 5399311
   timestamp: 1707836657705
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
   sha256: 765d5b7ef75ed7f52a110504cd88e9b0c9977b841f1beaeeabb17e629b462908
   md5: 0af9cd26a7c9eb8b77d3cbacb93a118b
   depends:
@@ -4882,7 +4882,7 @@ packages:
   license_family: BSD
   size: 360105
   timestamp: 1715090588763
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
   sha256: 4d4ab70ae0ce008c1cc96a4edfbf3866d5e636acc4799a545ea93acee51635f7
   md5: 86a085a440729020d1d7b0b74d6a0c6c
   depends:
@@ -4891,7 +4891,7 @@ packages:
   license_family: BSD
   size: 148448
   timestamp: 1714398923507
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
   sha256: ec139e4b87aadcacc0670ecbcc2a303d858d4ac38b9404458a4b676bce9d21d5
   md5: bfcfed281f8df0f18726ec5f843b2b26
   depends:
@@ -4901,7 +4901,7 @@ packages:
   license_family: APACHE
   size: 51053
   timestamp: 1704813595720
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
   sha256: 63670c8f31770e1746016f645ca6b42b35f92d1c37e8025793d9490fed9998c0
   md5: 9cb417b9fdf02b4e007a5b5781e5a8cc
   depends:
@@ -4923,7 +4923,7 @@ packages:
   license_family: BSD
   size: 229932
   timestamp: 1705934202146
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
   sha256: a40c76c412ec793ca26b97a9b5c496d253768438e1f7d4a0ee5f63ea79eed355
   md5: f609e4fe044318211cf0e37e289beebd
   depends:
@@ -4940,7 +4940,7 @@ packages:
   license_family: BSD
   size: 1614299
   timestamp: 1704833142734
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
   sha256: e57d10579b52a3cde45aa17e1bdd95dcb9d3346aa00eb02c51e38a42db83e18d
   md5: 05153120787fb09159b6e1ad902c6e10
   depends:
@@ -4950,7 +4950,7 @@ packages:
   license_family: MIT
   size: 1180481
   timestamp: 1678994989550
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
   sha256: 06512ef9a910fa72bf5697fe89e88c605d61f8478a9d8dd233c13f40e30f8446
   md5: cfa00c9ffd3407e29507525c020e5526
   depends:
@@ -4960,14 +4960,14 @@ packages:
   license_family: BSD
   size: 355730
   timestamp: 1706733720706
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
   sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
   md5: 055e12390b844ea6c6e956ee08a618e8
   license: IJG
   license_family: Other
   size: 273479
   timestamp: 1677849171867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
   sha256: 62025ce4a2b9244b9816c9e02487e0dda567600692b5f9ca71f425d084961c7e
   md5: d57b7063122e5bf25cdfc2a5ea7330a8
   depends:
@@ -4980,7 +4980,7 @@ packages:
   license_family: MIT
   size: 181872
   timestamp: 1699041739097
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
   sha256: 404b0847029f77bedd7902a170a046219e0dc5c0ec2be19ff45361cff25b2181
   md5: 3a02bbe8d45fdbcb2350f672be74c9f5
   depends:
@@ -4990,7 +4990,7 @@ packages:
   license_family: MIT
   size: 16524
   timestamp: 1699032463763
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
   sha256: 7deb8ad28c34c369573754304a03ea2acda8ee39102a56526ec689a4d9210109
   md5: 675ea1a746a78ff6bf8fc4b39139efff
   depends:
@@ -5006,7 +5006,7 @@ packages:
   license_family: BSD
   size: 277400
   timestamp: 1677914250715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
   sha256: 8220b1bbdde5e800810f7bf183a992af1a95825a837edf975fa8c4b51c5d806f
   md5: 3a06ddad06e04d5f0211c22cd81ca75a
   depends:
@@ -5017,7 +5017,7 @@ packages:
   license_family: BSD
   size: 94950
   timestamp: 1698937436979
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
   sha256: 8a9a9f9ddbf1b7744ef04a8c862438499a41d81a4beb4a49860156c273bb7497
   md5: 051355801f09eefe850ee8145151f934
   depends:
@@ -5033,7 +5033,7 @@ packages:
   license_family: BSD
   size: 42497
   timestamp: 1699282590553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
   sha256: 65c703cc996a705d0ee350070e313b1cae865f9d6e6490ebf1164c0f3ce22d93
   md5: 305ad8bcaad3e352d61b1e594093b467
   depends:
@@ -5060,7 +5060,7 @@ packages:
   license_family: BSD
   size: 596801
   timestamp: 1699466743685
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
   sha256: 501e929d345aaa9079c965552b942b4e8bde35b87ae89faef003687a40bab3a4
   md5: 54c7b8554a405acd7c8326c41ba93e63
   depends:
@@ -5070,7 +5070,7 @@ packages:
   license_family: BSD
   size: 28237
   timestamp: 1686870817418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
   sha256: 773e7c4571f482a744dfb18ae26fb22635f5d3f51389c838bd97f9044ea55cc4
   md5: 5161546aba5597318cb5653390cdecd8
   depends:
@@ -5082,7 +5082,7 @@ packages:
   license_family: BSD
   size: 20235
   timestamp: 1700168681687
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
   sha256: 8c1c64d51be73aad381992a9df19d8336910bdfc40f19940231df86e177d17cc
   md5: b1f786f96684a143cf30d1f6b8aebdb3
   depends:
@@ -5092,7 +5092,7 @@ packages:
   license_family: BSD
   size: 65045
   timestamp: 1677925371836
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -5102,7 +5102,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -5111,13 +5111,13 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
   sha256: 199042b87451abaf14546af124ae3380194cddda928e0d30ccb341e93084854c
   md5: eaa0442887994a82486c65d87f6b71e6
   license: MIT
   size: 68806
   timestamp: 1714483212137
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
   sha256: bd9a8a17fb14086446b710fa029d238e69274b83ee2e7e09093496f190de82b5
   md5: 66615d6a0cb5dcca3e20c019cde0ed2d
   depends:
@@ -5125,7 +5125,7 @@ packages:
   license: MIT
   size: 32975
   timestamp: 1714483225840
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
   sha256: e1bf77e8b975c30a69b08a08410622e27c8cff6f592ccfa590466b83d9e6d104
   md5: 8af86bdac01fe303d693d9b76c071059
   depends:
@@ -5133,28 +5133,28 @@ packages:
   license: MIT
   size: 310266
   timestamp: 1714483239194
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
   sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
   md5: f31e4eb9cd6447cc2f5ef0243a76540c
   license: MIT
   license_family: MIT
   size: 120460
   timestamp: 1714483461787
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -5163,7 +5163,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -5174,7 +5174,7 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
   sha256: d654027daea13ac9db36ab5fd5eff3ad398ec97c1777bf399f3ec680d2c145b9
   md5: baabb1f905054bfea3af8f5768572a34
   depends:
@@ -5186,7 +5186,7 @@ packages:
   license_family: Apache
   size: 26579907
   timestamp: 1683291669565
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -5197,7 +5197,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -5206,13 +5206,13 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -5229,7 +5229,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
   sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
   md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
   constrains:
@@ -5238,7 +5238,7 @@ packages:
   license_family: BSD
   size: 331675
   timestamp: 1694776939192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
   sha256: 41c62a460bb81a1a272aa28b219fab9c26510adac177ff1528b1980eabc6e868
   md5: 8d312c5628dc7ea833e9b4dcb73e9c45
   depends:
@@ -5248,7 +5248,7 @@ packages:
   license_family: MIT
   size: 42346
   timestamp: 1677973051421
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -5257,7 +5257,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
   sha256: 911c7577f591311bfb000121831234e7bc6332bff62fd00c2245371e67f473c0
   md5: 419681f23f179ba08e5fdf9884ea238d
   depends:
@@ -5268,7 +5268,7 @@ packages:
   license_family: BSD
   size: 410616
   timestamp: 1706910762686
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
   sha256: 5777bbef827f72975a36f3da80ab4af718dc781264f74ad7e3864755d620c0f0
   md5: 4240f1a79b812387919cc710a0469556
   depends:
@@ -5277,7 +5277,7 @@ packages:
   license_family: BSD
   size: 14318
   timestamp: 1677925438733
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
   sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
   md5: f5f7e6e7541d8dc3d3df270d488d2e24
   depends:
@@ -5286,7 +5286,7 @@ packages:
   license_family: BSD
   size: 176990
   timestamp: 1714510588159
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
   sha256: d024f5142416961a5e66e424d4d14aec652f9e9dd738b41a97f45674c2ffc9d5
   md5: 0e2d94b125d802f7b006cf19c71655a1
   depends:
@@ -5295,7 +5295,7 @@ packages:
   license_family: BSD
   size: 163084
   timestamp: 1677932947966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
   sha256: acfd84e29ff4dc2d85543bb973a07f22b4ba53c5d00bca84608ee7f13b2a8676
   md5: 5ca161cd51e2db358e768453b3ee485e
   depends:
@@ -5305,7 +5305,7 @@ packages:
   license_family: MIT
   size: 135871
   timestamp: 1684279980293
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
   sha256: b1bed54c7bfb7304cde9e8e6f798543d08e808e81286a5a48296fc94d621f9da
   md5: 774358285c9e496c9f5c121cc546c823
   depends:
@@ -5316,7 +5316,7 @@ packages:
   license_family: BSD
   size: 27438
   timestamp: 1704206026910
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
   sha256: 9229a6e15abf3147cfcffad4ca389dad940e45779963b4fc3fd56dfdcfca3234
   md5: 4e1897f3cb4923de48c016468c01c051
   depends:
@@ -5337,7 +5337,7 @@ packages:
   license_family: PSF
   size: 9100733
   timestamp: 1713336457304
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
   sha256: 3276d61fc353c537bb09d4b7473d7abe12be38806f42c8cc383b62f40850a5cc
   md5: 6e9c9d47f264b77d9a8461f0899848a7
   depends:
@@ -5347,7 +5347,7 @@ packages:
   license_family: BSD
   size: 20446
   timestamp: 1677918370379
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
   sha256: 43c96d30775b61b4968422a47f9605049428120669f0742bbb9e5ba145c7d11e
   md5: a31ca0d9284860adf5463cf45a5e3145
   depends:
@@ -5357,7 +5357,7 @@ packages:
   license_family: MIT
   size: 69243
   timestamp: 1677995336989
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
   sha256: 96d8c9f42a38651b7bafe5f3cb132601db76cd1e28fa58e2eaf090e634292fff
   md5: 5ebc793a17b6aa84d13f19433545ffa5
   depends:
@@ -5366,7 +5366,7 @@ packages:
   license_family: MIT
   size: 23895
   timestamp: 1677942274932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
   sha256: db9bd659ada23f1ded443d2db00dd13b5d5c0b30f5062544b1ee2c2b88d63d29
   md5: 03c48121614cf12abfe30eced9b34717
   depends:
@@ -5377,7 +5377,7 @@ packages:
   license_family: BSD
   size: 105333
   timestamp: 1677916687032
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
   sha256: 8b05894fdcbe5cfcdee94812b043de4cd7b4fa51d3e2aad25fc7cff50c8f82ab
   md5: c970d49137dce1c77f782ee5725950c1
   depends:
@@ -5387,7 +5387,7 @@ packages:
   license_family: BSD
   size: 30745
   timestamp: 1677960816849
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
   sha256: a8b3d349481dc694eb9a507f55c91e8981e2a3bc41743023ca01248c8a6d779a
   md5: 71e6e29ec3b98fb282c01b012a5df236
   depends:
@@ -5413,7 +5413,7 @@ packages:
   license_family: BSD
   size: 8294656
   timestamp: 1699543119360
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
   sha256: e8eee27fb667aa10b26f3bc4b93f449b7d991ded27b9cb457effee394ce05f6f
   md5: 6a3e5cd0e1141c01ffb91285bdccfe83
   depends:
@@ -5426,7 +5426,7 @@ packages:
   license_family: BSD
   size: 123043
   timestamp: 1698934328890
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
   sha256: 40230434aa2fbb33ece13632e8d4b7cd1ad68fdb8d1b00263af4a010795d25f8
   md5: f12ce7dad3620d6d53a442fa9d36a0b0
   depends:
@@ -5453,7 +5453,7 @@ packages:
   license_family: BSD
   size: 538067
   timestamp: 1699022954841
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
   sha256: a492acec8ceadc0911a75966ffa630a8eb15b2da8c7a8d544a645ba47771a2d1
   md5: 4002b1b88b2ecfdfc769036f43b0a895
   depends:
@@ -5466,14 +5466,14 @@ packages:
   license_family: BSD
   size: 170964
   timestamp: 1694616845237
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
   sha256: 417ace1ce51e81f3f92ddc26e0e3a83c1e19c9ebb7af7104452002a5573da534
   md5: 3e11de6cef096091bb733e07802f00b0
   depends:
@@ -5482,7 +5482,7 @@ packages:
   license_family: BSD
   size: 16979
   timestamp: 1708532698253
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
   sha256: 2e09ae8d10d7e5651727aab66a1e89b59e716295267a8295eaa53760c4c38533
   md5: 8d52be8699bf030546811bb69fbeb2b1
   depends:
@@ -5507,7 +5507,7 @@ packages:
   license_family: BSD
   size: 728383
   timestamp: 1690985022565
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
   sha256: b0cc542e2a6f42ba716e7e4ccf29eddcb155ad167fcdbc72d2db9c7873eb5639
   md5: 7acf81b17d2c4ceb3cd39dc9f173855c
   depends:
@@ -5517,7 +5517,7 @@ packages:
   license_family: BSD
   size: 27539
   timestamp: 1699455954000
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.59.1-py311h7aedaa7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numba-0.59.1-py311h7aedaa7_0.tar.bz2
   sha256: 4e0fb594095ce53c58f97eafc1c113e150929a6935e8ee54d86359cc7a9afd14
   md5: df6c4ead6e4bed95d012bdd5e79f10db
   depends:
@@ -5538,7 +5538,7 @@ packages:
   license_family: BSD
   size: 6062719
   timestamp: 1711988782214
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
   sha256: 151a3eb68d1189e69764ece1d8fb3544d31a22f5bbbc3e19d846de8dece304d2
   md5: eb6609e6bdc9c82d70df3f8c4c2de95b
   depends:
@@ -5549,7 +5549,7 @@ packages:
   license_family: MIT
   size: 153313
   timestamp: 1696515415712
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
   sha256: d3bb1d4be88320a5861cd3a0f086e9709f9b64c96c032cb9039cc4f17ec66a85
   md5: 0a7b97665c06fcd34a70e34abc177280
   depends:
@@ -5562,7 +5562,7 @@ packages:
   license_family: BSD
   size: 11288
   timestamp: 1708639168951
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
   sha256: 3e70248a7069ca12ccf56252869bfdb72211fd4e4c327e6994756496df786c79
   md5: ce4846006d98638cd86a532a72f8dfe4
   depends:
@@ -5576,7 +5576,7 @@ packages:
   license_family: BSD
   size: 7536860
   timestamp: 1708639153133
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
   sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
   md5: 371358a54bbdd307603888348d1a2c6f
   depends:
@@ -5586,7 +5586,7 @@ packages:
   license: BSD 2-Clause
   size: 412248
   timestamp: 1628861367714
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
   sha256: da78bd65c91881856baadf977534832f68db3938c1b5b713c8797be70b83c98c
   md5: f728656890f860eec5ad2899e657df3a
   depends:
@@ -5595,7 +5595,7 @@ packages:
   license_family: Apache
   size: 4763426
   timestamp: 1716318333548
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
   sha256: 77b0c0a0fb14d817390244ebd93c36d44a7867239963f211f7c0a72a3f98d382
   md5: b90336feb8a50d2eff880e89acb02f40
   depends:
@@ -5604,7 +5604,7 @@ packages:
   license_family: APACHE
   size: 39617
   timestamp: 1699371253760
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
   sha256: 4f6c3e8d8fc4c57975cab837ef109b9ee7af4f18aac72668334ac656e53c6edf
   md5: fbf1b507f9a80c5de3c957e8152124da
   depends:
@@ -5613,7 +5613,7 @@ packages:
   license_family: Apache
   size: 159289
   timestamp: 1710807498427
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
   sha256: 3af823879c340838c1040e99f653c3438ccce8dc559bd91c3f4ab2579282a002
   md5: 5b3df01fda0281dab4196bc36d1ca367
   depends:
@@ -5663,7 +5663,7 @@ packages:
   license_family: BSD
   size: 17082645
   timestamp: 1709591689205
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
   sha256: 8bf772501cf4b49a939de17bf378d3e395f452d3070d05871354bd2bc915d012
   md5: 753d2070a2aea47934ecf6ac1ea0bc04
   depends:
@@ -5687,7 +5687,7 @@ packages:
   license_family: BSD
   size: 21901817
   timestamp: 1714071405089
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
   sha256: 67feb8232961ad9d7672a49f6f86f0b86764f62a97d86d58b90ca7e8345bab76
   md5: 3afb6e6747bd29e9483d35dbf8b24f74
   depends:
@@ -5696,7 +5696,7 @@ packages:
   license_family: BSD
   size: 264413
   timestamp: 1711136882294
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
   sha256: 088245becd055af4de74e4ed13cc752ab546423f204b170ba2dd8809af30a2c7
   md5: 2eabea5ccc56ac088e0349626e59df06
   depends:
@@ -5710,7 +5710,7 @@ packages:
   license_family: BSD
   size: 48517
   timestamp: 1698702686783
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
   sha256: 174b680f4bb041e8146aae80f92390122459e0ef8c911cab22d01e2e92d44ab1
   md5: cfffc94779cd26a349bd409b5590b098
   depends:
@@ -5726,7 +5726,7 @@ packages:
   license_family: Other
   size: 916496
   timestamp: 1714399019350
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
   sha256: 102c3c35a9dfa0f10ec8f4a040a24295f9c736443ccae2f685348a44f62a4d68
   md5: 027b347e79e252aa17b534e1a02bccd6
   depends:
@@ -5737,7 +5737,7 @@ packages:
   license_family: MIT
   size: 3447682
   timestamp: 1715097070362
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
   sha256: b6200816d65673aa1707c20a768c9cff87dd8dbe1335f9c1478e5931dfa08ee0
   md5: 14b1e0fa73eb33f9c83048482dcce57b
   depends:
@@ -5746,7 +5746,7 @@ packages:
   license_family: MIT
   size: 38423
   timestamp: 1692205689597
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
   sha256: ebdf211edd98d88a23778551c7a9702106edd0695d4fc48e87c21f77521c1ffe
   md5: d8c505081a468f1b99c62466e2309417
   depends:
@@ -5755,7 +5755,7 @@ packages:
   license_family: Apache
   size: 123084
   timestamp: 1678996822234
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
   sha256: 07cfba50d9e94364bde077731a824ca4f537138b35ee6b66d07aee16ac9850f1
   md5: 919bf486280a11e6acb3c2c3a82f7473
   depends:
@@ -5767,7 +5767,7 @@ packages:
   license_family: BSD
   size: 763225
   timestamp: 1704404463402
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
   sha256: 8094436b2c44e68e72569c704633802aad82e977b1e16026848218679c8becf4
   md5: 2360e46d3e598dd5e2abed781fe166c5
   depends:
@@ -5776,7 +5776,7 @@ packages:
   license_family: BSD
   size: 502115
   timestamp: 1678995719872
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
   sha256: 4f17f70658e32a9a86661184cace6be3bb7bd61f9b55b513092beddf44552679
   md5: 0aa95279688b0433badea0b660ac8146
   depends:
@@ -5788,7 +5788,7 @@ packages:
   license_family: BSD
   size: 38653
   timestamp: 1677933613643
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
   sha256: 121b5b66721760c05f1d4eee91626229d1814663d3fb5f23126ef870aa496e26
   md5: 0c588c2ca790a05d422c06e8568201ad
   depends:
@@ -5797,7 +5797,7 @@ packages:
   license_family: BSD
   size: 2124200
   timestamp: 1684280082141
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
   sha256: 44b694db8e81d61960d28d60f9e9b573f03f7827881d302da334378881db4889
   md5: 6c94ba7caa599ff533e0ab55d898be8a
   depends:
@@ -5806,7 +5806,7 @@ packages:
   license_family: MIT
   size: 208454
   timestamp: 1677910948527
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
   sha256: 0bb3d2a57b332c5cf73ea40ea13c850ae24a1f9a3a41ed9267832d9e3c767572
   md5: 45a7fcf1641980d5114999736428502d
   depends:
@@ -5815,7 +5815,7 @@ packages:
   license_family: BSD
   size: 36755
   timestamp: 1677906514270
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
   sha256: 960c343b7b8569dfe4e71a395f7bede1e749da7b02c17506b590c9e1839e6fd7
   md5: 722c4b4386af73cf1562974a00c880a4
   depends:
@@ -5834,7 +5834,7 @@ packages:
   license_family: PSF
   size: 16494386
   timestamp: 1713545544909
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
   sha256: c3cbf5bd237b0a7458640191016b2701fe120c547df9afc835da76663a9c17f7
   md5: 843568c76b6b9384635b7fca74c79792
   depends:
@@ -5844,7 +5844,7 @@ packages:
   license_family: BSD
   size: 332222
   timestamp: 1716495881101
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
   sha256: f94b3cfea6f76ea9983e16d3c4c7e0a64f02c40cc2c3ad57189bca2e67030bd9
   md5: 0d100990ade57a02b60d1e8085db0bdf
   depends:
@@ -5853,7 +5853,7 @@ packages:
   license_family: BSD
   size: 280263
   timestamp: 1678996927464
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
   sha256: 252c86f5aef7f8dfce99a260c24cbb35a9adfea144a2acfabb224f516341544f
   md5: 745b888e19a644f48800799f82c01c21
   depends:
@@ -5862,7 +5862,7 @@ packages:
   license_family: BSD
   size: 18539
   timestamp: 1683823925189
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
   sha256: d945744eb133f19ca61325cac5128bdb053ae04de4a0ba6f69c061449cac8af7
   md5: 34baa81490d667381bc7021435b0e1f2
   depends:
@@ -5871,7 +5871,7 @@ packages:
   license_family: MIT
   size: 275858
   timestamp: 1713974457562
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
   sha256: 012585bdb5ae54c2cded50be703734e6dbf418b003635b6f6d7c1e36e7020c30
   md5: da7e99a707bd0cfa20db651b5c068bfd
   depends:
@@ -5883,7 +5883,7 @@ packages:
   license_family: BSD
   size: 65556
   timestamp: 1711136890180
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
   sha256: 4f04a43cbd612ab09cefbdc2e48ee61b51967dad59d859ce0502cc2c46c88fc5
   md5: c68bf65433b2151b51b2e699bc22c501
   depends:
@@ -5893,7 +5893,7 @@ packages:
   license_family: MIT
   size: 194632
   timestamp: 1698096151085
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
   sha256: ae8cdd5be5a7ad19ff82925a035859fafcc5942cd3899d127a508dbb9a235090
   md5: 252a7b997d08bf72f10b3bc2dc68333e
   depends:
@@ -5903,7 +5903,7 @@ packages:
   license_family: Other
   size: 580346
   timestamp: 1709318480624
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -5912,7 +5912,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
   sha256: 7a208abc002a2fc208ae25cb2cf932999a3e4980aa4c9edff315cb9ac62b12ce
   md5: bd22ebd3cff811577ea61f115ba7f4f2
   depends:
@@ -5923,7 +5923,7 @@ packages:
   license_family: MIT
   size: 74744
   timestamp: 1699012126255
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
   sha256: cc8d055a068fe5a7484284c3360d81db61656dd6118c743c740fcc47cd3da379
   md5: e5fad71ef3b99077b79052576e51bf9f
   depends:
@@ -5939,7 +5939,7 @@ packages:
   license_family: Apache
   size: 120672
   timestamp: 1707355664440
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
   sha256: 52368d9b557b8f54ef5ca4bf6cd5a3ec665171f2b2d2082cdd410bab88f4829c
   md5: ac76fb4d2eef3ecdd491cf5d3fb8620d
   depends:
@@ -5949,7 +5949,7 @@ packages:
   license_family: MIT
   size: 10204
   timestamp: 1683077239143
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
   sha256: 491d116c5f54ef340e3bce631835f7138cd1923d7b63e6ca9aa01b48110cb8f9
   md5: 9b81bd8ea808704f5433884b567f1f15
   depends:
@@ -5958,7 +5958,7 @@ packages:
   license_family: MIT
   size: 10557
   timestamp: 1683059079547
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
   sha256: b53a5f6119173d62e4e68a37ea8511c7fc87a00af72953e0048d075a799c7a7a
   md5: 76a16cf4edb9b12b2b96a2d323f060dc
   depends:
@@ -5967,7 +5967,7 @@ packages:
   license_family: MIT
   size: 342535
   timestamp: 1698945991201
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
   sha256: 9e8312f9452357202813aa289430c939302617f562dae9e90fdc3fb5e9be49d0
   md5: def02b749d0c0a3675d96aeb508a2306
   depends:
@@ -5985,7 +5985,7 @@ packages:
   license_family: BSD
   size: 26383719
   timestamp: 1714070280353
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
   sha256: c80d52567084b1caaed2862b77b70065ca17afaf0b020733e9d6c273b4a63e78
   md5: ddf7d88c1967f3f7a4ce1c975fd47e0d
   depends:
@@ -5994,7 +5994,7 @@ packages:
   license_family: BSD
   size: 33321
   timestamp: 1699371225235
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
   sha256: 6d38d171ef87340cf0fbbf4c70217df4826c65400c9290774f5cb35e381e3315
   md5: b9529a812f9862fc89461b6b90f184ba
   depends:
@@ -6003,7 +6003,7 @@ packages:
   license_family: MIT
   size: 1599110
   timestamp: 1715024190898
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
   sha256: cd71091a234874d2826fa063ec5222b3191c9f47e1b5281c352d9df3f31a06bf
   md5: 0db8e29016c6bff026c083d9923a7566
   depends:
@@ -6012,7 +6012,7 @@ packages:
   license_family: Other
   size: 19073
   timestamp: 1705431415504
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
   sha256: 3e18cdafc607c6d7623b1c8f041cbfbb50a27e298f961abdcce7e36834ac39e1
   md5: 9ee0da74c55d0b8d83edf246fd717f20
   depends:
@@ -6021,7 +6021,7 @@ packages:
   license_family: MIT
   size: 89862
   timestamp: 1696347657368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
   sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
   md5: d8c1e9910392d0bcb22a173f9ce30fa6
   depends:
@@ -6033,7 +6033,7 @@ packages:
   license_family: Other
   size: 1758290
   timestamp: 1714488307689
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
   sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
   md5: ae58720a18a2ed15eae214ad7a10d1b5
   depends:
@@ -6042,7 +6042,7 @@ packages:
   license_family: Apache
   size: 140125
   timestamp: 1680167256603
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
   sha256: b5c265e9ed9a1ff2238a09b83bdc1826950faa87fd6b685debe60888de6e7a50
   md5: 5827c8a32317894ce18576e334daba47
   depends:
@@ -6053,7 +6053,7 @@ packages:
   license_family: BSD
   size: 38559
   timestamp: 1677918962258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
   sha256: cfefd86d0f4981d22b7611b3dc60359b8698bf39f2b743cb90b7005aaca88e1e
   md5: a04dbcd6095f6b8f3ad195a78d48b262
   depends:
@@ -6063,7 +6063,7 @@ packages:
   license_family: BSD
   size: 50058
   timestamp: 1677917499177
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
   sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
   md5: 3c25b4f4768ccda28b20a03ba27e7759
   depends:
@@ -6072,7 +6072,7 @@ packages:
   license_family: BSD
   size: 3484151
   timestamp: 1714770744982
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
   sha256: 0836468fafb1f5badbb573922e37200c6929bf2926ecf8d2259dff43811e0727
   md5: 5bc56dcb4bdb7cf623b7cea499feaddb
   depends:
@@ -6081,7 +6081,7 @@ packages:
   license_family: BSD
   size: 136409
   timestamp: 1677925889207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
   sha256: 177246487449f87567fe56c8f20011a4350a132d1556c9f87474d7b2e8c1374f
   md5: d465118217b9f27d47dceff89c2e9f95
   depends:
@@ -6090,7 +6090,7 @@ packages:
   license_family: Apache
   size: 896655
   timestamp: 1696937042980
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
   sha256: 81efb240a49cede5ece3a8ad48f1d9dfdeb56260bf1a20e25ec53cdb202f7c3e
   md5: 81a17d13c75596841b95340a34bbe929
   depends:
@@ -6101,7 +6101,7 @@ packages:
   license_family: MOZILLA
   size: 155516
   timestamp: 1716396017482
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
   sha256: 65e760119352cd85c63d365d2576c09a9ddb060e5b029a265d50bc268eed9290
   md5: 14c241871b12dc3be52e6cd681267caf
   depends:
@@ -6110,7 +6110,7 @@ packages:
   license_family: BSD
   size: 271445
   timestamp: 1677911758960
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
   sha256: 96071e07e807414b7ae5a2fe958ac171e5795576b3a4c2f5e8c643fba43d760f
   md5: a34f2b216e35a37f966883dacda229e2
   depends:
@@ -6120,7 +6120,7 @@ packages:
   license_family: PSF
   size: 9902
   timestamp: 1715268985387
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
   sha256: b20e48aff4c781a52b6be66d77418e768527a621f5fc272ecb34ea03475b2bd7
   md5: 707738432f16f5e63909fcaa6e65850d
   depends:
@@ -6129,7 +6129,7 @@ packages:
   license_family: PSF
   size: 75604
   timestamp: 1715268976065
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
   sha256: 2ea2d0520b330d381a2ab241bdb9ae146ef815ee7c96ee52a9773fb9ae85f4fd
   md5: 66f7f8979cfb2cccffac972d70482130
   depends:
@@ -6138,7 +6138,7 @@ packages:
   license_family: MIT
   size: 12614
   timestamp: 1677963554857
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
   sha256: df7fe7740bd853b641d624e2ec97f1aacb2b82691936a8c04ef18fa9768539c2
   md5: d5c7626d45fd03b22797c18e47812beb
   depends:
@@ -6147,7 +6147,7 @@ packages:
   license_family: Apache
   size: 518048
   timestamp: 1713213046424
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
   sha256: 3fbcccceb4d7d99f60a6e6e013ab84c4532244c42ab9d65b6fdaab6bd30f7269
   md5: 6a7e05872852d4bcde959f7cc8407672
   depends:
@@ -6163,7 +6163,7 @@ packages:
   license_family: MIT
   size: 210307
   timestamp: 1715635933070
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
   sha256: 09738b7f9075386bf062b12ddb6fb72a06450d2481f6b5ca2026c811cd849569
   md5: 9afdec076c95746ac21235f971190e40
   depends:
@@ -6172,7 +6172,7 @@ packages:
   license_family: BSD
   size: 26727
   timestamp: 1677910175964
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
   sha256: b4ced7366de8eb7258f31d516616e70c62ed4a798780e57e208509d2b52ab435
   md5: 65a9a05a726734c1da667f9bd3c78c14
   depends:
@@ -6181,7 +6181,7 @@ packages:
   license_family: Apache
   size: 114733
   timestamp: 1715878377412
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
   sha256: aa301d9e42aadbe3dd5f301ccbf17fbadc347fd37d413c0cbcbd24403892a936
   md5: 77097d17d835a137af7950c628b66150
   depends:
@@ -6190,7 +6190,7 @@ packages:
   license_family: MIT
   size: 137260
   timestamp: 1714717037687
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
   sha256: cf030fc7020dc6d28530075468b8dc1edd843a1e393a2f81ca81c962e9af977b
   md5: cae3fc90233f3af8f433a253d035b6e6
   depends:
@@ -6202,7 +6202,7 @@ packages:
   license_family: Apache
   size: 2470844
   timestamp: 1689041497962
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
   sha256: 2cd108896df65636769e3804ecc2ca421ad9b54e64fa21922bbabe40c90c247a
   md5: b3a1e5077b28f71298d891fbfb5ff03e
   depends:
@@ -6211,20 +6211,20 @@ packages:
   license_family: BSD
   size: 55645
   timestamp: 1677927459979
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
   sha256: 5be8c968f2da5c4bf14f28d63e31b4c1b6993d980023769732c7f58f396c2e0b
   md5: 3f5f62d4e85e3bdd48d39189b01805a6
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 459197
   timestamp: 1714510992914
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
   sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
   md5: 3d57d1adadca9388aaaa1c529b65ba65
   depends:
@@ -6234,7 +6234,7 @@ packages:
   license_family: Other
   size: 322790
   timestamp: 1705602163804
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
   sha256: cf38c69cf62d8f07b91b14bef8e0b6fc5ac220bd3a6cd2ab0378283f0f11494a
   md5: 11660f745caf5eed1d03eafadb32678b
   depends:
@@ -6243,14 +6243,14 @@ packages:
   license_family: MIT
   size: 25470
   timestamp: 1704206932876
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
   sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
   md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
   license: Zlib
   license_family: Other
   size: 104928
   timestamp: 1714510936868
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
   sha256: a3f3eaf240991b6bd7b0596a78d0abb3321cc79db52fa24f6f559189778871c6
   md5: 71f035b4716322539e2461cb6667e946
   depends:
@@ -6262,7 +6262,7 @@ packages:
   license_family: BSD
   size: 825339
   timestamp: 1714678419523
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
   sha256: 6e6787755de0cf2fd776c9681a7b0fd0fb23e35e679a463cc2005b991c413910
   md5: ccad42ec9a2ad48939f089c528abc8f0
   depends:
@@ -6276,7 +6276,7 @@ packages:
   license_family: MIT
   size: 229694
   timestamp: 1706220431719
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
   sha256: f715f7c2e06149bd6d43258e41479d3171efe5e9d56050a0a5f5652ed9d05fff
   md5: 11a8ca43d69881b88f95ae681478866d
   depends:
@@ -6288,7 +6288,7 @@ packages:
   license_family: MIT
   size: 36089
   timestamp: 1676424516042
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
   sha256: 9adabcdd2a10f73fa5ba56adc901eeea2e379991a0d4cb9737eec7aa6b9fc5d8
   md5: fc80b572be85601706d425b21a58d497
   depends:
@@ -6297,7 +6297,7 @@ packages:
   license_family: MIT
   size: 153102
   timestamp: 1695718054194
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
   sha256: 38ccda1553733326d99a75436b4b0f7640bafbbfcdbc33838b0e59cf017de687
   md5: 3f6812578c5e0b3ba0d2a651cc766c15
   depends:
@@ -6307,12 +6307,12 @@ packages:
   license_family: MIT
   size: 266405
   timestamp: 1681493141116
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
   sha256: fe765d810e1612af7a42f34223077f0adc05dbd386b257be24661913d067fe30
   md5: 82e988aba03c8afa03fce78f7442806e
   depends:
@@ -6330,7 +6330,7 @@ packages:
   license_family: BSD
   size: 6086137
   timestamp: 1712084583317
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
   sha256: 5c12a5d7856d9977447360b3a99a5b99818707fe79781ba1779037f11b3fef53
   md5: 6a125ae352306a944aabc635a5fe13a3
   depends:
@@ -6342,7 +6342,7 @@ packages:
   license_family: BSD
   size: 139230
   timestamp: 1707864402762
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 751071782f597f87ed7f67437ef6cc669213902461b9795dd6eb0f4897eddc83
   md5: 5ad8fe62aad5e16cfdf2c5a7d1327fe7
   depends:
@@ -6354,7 +6354,7 @@ packages:
   license: MIT
   size: 19418
   timestamp: 1714483531456
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 9bd62d810867549b9c967c5915f3fa3f66cfbd6ede28b1cc152efd1261285c0a
   md5: 64cc76de3662b62bc8f0e42befd92c5d
   depends:
@@ -6365,7 +6365,7 @@ packages:
   license: MIT
   size: 32178
   timestamp: 1714483513837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
   sha256: 1547fa52134cf06b8d01bdf52114db7db60a89bf35c9c95be5b5a03b13dbd565
   md5: deb765cb7c4b7edc4d126f864f31747c
   depends:
@@ -6375,7 +6375,7 @@ packages:
   license: MIT
   size: 356401
   timestamp: 1714483740924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
   sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
   md5: 11e0af09a31e2d5df51c65a342032b85
   depends:
@@ -6385,14 +6385,14 @@ packages:
   license_family: BSD
   size: 112994
   timestamp: 1714511182837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
   sha256: 73391a74a5300ad3fb063ea0f0c3491d220128a0611a84036da2e23c1e93dc0e
   md5: 501ded4f9b5ed895077802defee912cf
   license: MPL-2.0
   license_family: Other
   size: 171644
   timestamp: 1710764856021
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
   sha256: cd6545642e380b13700f2f2a7a1fb54a273365047bd23108dbd03b197f5c0c9c
   md5: 929edc1c553d2da4d6c6c0745b033cc3
   depends:
@@ -6401,7 +6401,7 @@ packages:
   license_family: Other
   size: 166377
   timestamp: 1707229328635
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
   sha256: 5cb6ac90ad234248f3795945f69b0382397714a52712337b2f86339526b822d8
   md5: b90f3126f6315ea2e8ab242533062557
   depends:
@@ -6413,7 +6413,7 @@ packages:
   license_family: MIT
   size: 302693
   timestamp: 1714483562551
-- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
   sha256: 7153817dd49ec317b519802c7c22c836602e00cbd96d68385e83eaf4c9f5ba6a
   md5: cd829e5997611a602e29fa2fd5882635
   depends:
@@ -6423,7 +6423,7 @@ packages:
   license_family: BSD
   size: 204113
   timestamp: 1698130080270
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
   sha256: 03f00c22b6d92ee55b727b369e8dbdd9a4d590f2655b62b7c45ecd046741858e
   md5: 116f67c13bb0b3caee6cbde334ff6abb
   depends:
@@ -6432,7 +6432,7 @@ packages:
   license_family: BSD
   size: 49934
   timestamp: 1683040303796
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
   sha256: 4099898f02e1f6119fcda65e747c3cbfef0bf563c8855b79a0245160709d5b45
   md5: ab9705c34e67fb8c8faec69d63ff4064
   depends:
@@ -6441,7 +6441,7 @@ packages:
   license_family: BSD
   size: 36410
   timestamp: 1676422341506
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
   sha256: c722f50980d7416ffb2cfc7bf72649307a0bb78c5a24eccefcd049cb61d6b355
   md5: c7c9ff0513ff3c99700919293b702410
   depends:
@@ -6450,7 +6450,7 @@ packages:
   license_family: CC
   size: 543258
   timestamp: 1709758602437
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
   sha256: 8fb3e816a5ad1da05125462dbc9e2a7e933b001a871aa65703802c0a894c6277
   md5: ee4b2fa9fce130496d5c7c86c35a1a05
   depends:
@@ -6460,7 +6460,7 @@ packages:
   license_family: BSD
   size: 17723
   timestamp: 1709323150229
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
   sha256: eeb49cd151ecdccd40062e8123a3b7a9a8a1eda6567dd33ce909ff8ee1a97c89
   md5: b7fe1f7ead1ec2ac642d022942282fc8
   depends:
@@ -6472,7 +6472,7 @@ packages:
   license_family: BSD
   size: 232451
   timestamp: 1700583772701
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.5.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/dask-core-2024.5.0-py311haa95532_0.tar.bz2
   sha256: d4875dbaa16d83af1fc9a05d4d14dfd917f3840fa4d751160f070a7cbaa20230
   md5: e1d44a630a3508b624fcd37e1d7684d1
   depends:
@@ -6489,7 +6489,7 @@ packages:
   license_family: BSD
   size: 3173632
   timestamp: 1715838851049
-- conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.16.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/datashader-0.16.0-py311haa95532_0.tar.bz2
   sha256: 7c57396f00b4d63b1b597ccad75548f6e81f4e2b831c660fe14c6764d62148e8
   md5: 0d1d476cfdb705f2ed6cfe2f6a092ef4
   depends:
@@ -6511,7 +6511,7 @@ packages:
   license_family: BSD
   size: 18023517
   timestamp: 1699544725067
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
   sha256: 5c73f86e575f2ad683ee4a1c2df11020e270edd89d12f11199483d57b0b51826
   md5: e96a12895ce374476277b1b196ba24bd
   depends:
@@ -6522,7 +6522,7 @@ packages:
   license_family: MIT
   size: 3719519
   timestamp: 1690907216785
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
   sha256: 5d5fc8a24c804010b8cb5963227230352ea3ccf56bea9e8116e34f77223218f2
   md5: 8f989a72eed6293dfe0533c83057980d
   depends:
@@ -6531,7 +6531,7 @@ packages:
   license_family: MIT
   size: 17688
   timestamp: 1676423357100
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
   sha256: 27fb03eb57d25711a15e145f47a64320a9955b585efc9fd0a1a51cdd71b9fde3
   md5: eb3869e98f6f53dfec76e2eff4d6b61e
   depends:
@@ -6551,7 +6551,7 @@ packages:
   license_family: MIT
   size: 2732423
   timestamp: 1713552175344
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -6563,7 +6563,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.3.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fsspec-2024.3.1-py311haa95532_0.tar.bz2
   sha256: c906de92968266d481957c5776467523da53b7f4d6daadb63255bd5cefd252c3
   md5: 2710581e3de1c90426c77e4b73185262
   depends:
@@ -6572,7 +6572,7 @@ packages:
   license_family: BSD
   size: 372660
   timestamp: 1714461880258
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
   sha256: 68d59a361a93a5ae36542f667138b4ab072e1abff15b3aa2dc55575baf86a3e9
   md5: 383239566d9506b743c7bc65d709b7e1
   depends:
@@ -6589,7 +6589,7 @@ packages:
   license_family: BSD
   size: 5374020
   timestamp: 1707836834797
-- conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
   sha256: dee3fc68ed81398d232b3afe9a032837bdbef98c1b2478604d6abd397e3e7d64
   md5: 3f75535ca6dfee0745b221922f21f6de
   depends:
@@ -6606,13 +6606,13 @@ packages:
   license_family: BSD
   size: 353312
   timestamp: 1715090519918
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
   sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
   md5: 582d2c1135a89da757a038de831e7f39
   license: Intel proprietary
   size: 11086648
   timestamp: 1664812389803
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
   sha256: 102c803186db6d62eaf41a906f6c563ff0d62b53c1eaede8a381e18c0d005ed9
   md5: 9d30dec03058758a428cf152e0ae28b5
   depends:
@@ -6621,7 +6621,7 @@ packages:
   license_family: BSD
   size: 148193
   timestamp: 1714399061601
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
   sha256: db30abacf919b3f68ae1e6a94c467fd1e69fbf47ba7a86e6b491d8bfe4776f92
   md5: 9299876e7ddc3aea3487fd93340ceae7
   depends:
@@ -6631,7 +6631,7 @@ packages:
   license_family: APACHE
   size: 50842
   timestamp: 1704813715071
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
   sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
   md5: d215cc8ee7ca2cc83cc250cc5d822fe0
   depends:
@@ -6641,7 +6641,7 @@ packages:
   license_family: Proprietary
   size: 3929136
   timestamp: 1699647939158
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
   sha256: 864e9598f64105769b4ec02cc404fb507bc59e217324daf1686c00cfd12c0055
   md5: 6bb1c3be1f85799a3988afc2c3c5a4f0
   depends:
@@ -6662,7 +6662,7 @@ packages:
   license_family: BSD
   size: 229621
   timestamp: 1705934494547
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
   sha256: e0b44f0c3a4ead0fb8e58033c0be25524ee9ecf7f4cc632f03e9f6fac3484baa
   md5: 50cbc18d0c7b42a4553b52d0cef2c857
   depends:
@@ -6679,7 +6679,7 @@ packages:
   license_family: BSD
   size: 1637367
   timestamp: 1704834149957
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
   sha256: d81566367c79a28d4717157fc74293e846a47af99387ed479eb001a425dd398e
   md5: 28c76079c96ad7f8b1a5ed32b438c79a
   depends:
@@ -6689,7 +6689,7 @@ packages:
   license_family: MIT
   size: 1147434
   timestamp: 1679427525584
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
   sha256: f766a445df8e81447f27c830e162566b221fa1bfc41296a6c5e0789586ca1fbf
   md5: 55bc50633414fc8616ccbf4140a42d5f
   depends:
@@ -6699,7 +6699,7 @@ packages:
   license_family: BSD
   size: 353715
   timestamp: 1706733949898
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
   sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
   md5: 81f2c343dc4c65eea39c45383272068f
   depends:
@@ -6709,7 +6709,7 @@ packages:
   license_family: Other
   size: 407861
   timestamp: 1677849239400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
   sha256: 5e6698015a3b048093f5737f0e54bcbae415d0f9682dfdfeae3a8cfb4ea275e2
   md5: 0093a4214131046c4f68af0739dfbea4
   depends:
@@ -6722,7 +6722,7 @@ packages:
   license_family: MIT
   size: 201456
   timestamp: 1699041872445
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
   sha256: 9581be54128954080d7cef448b1728874c2ebbe5064f55adece422cf12eafa5a
   md5: 3adc105f87d5c7f0b1248bc3423f5b48
   depends:
@@ -6732,7 +6732,7 @@ packages:
   license_family: MIT
   size: 16187
   timestamp: 1699032556953
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
   sha256: ad8343bad7c8f0448cbcfbaf872cc94b56da81c52e5cdcee2a5d6b89f029eb75
   md5: addceff8d46c9d1d322618a9ce9e5b39
   depends:
@@ -6748,7 +6748,7 @@ packages:
   license_family: BSD
   size: 300354
   timestamp: 1676424060532
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
   sha256: 851ae576c2b72bf3172cd460feec4f5577dc06476a043e185279071b67549fab
   md5: fae4d214d00de6604738f39acbbb197e
   depends:
@@ -6760,7 +6760,7 @@ packages:
   license_family: BSD
   size: 119710
   timestamp: 1698937651636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
   sha256: d97ad90f9121ecf7f8d3af773b222c0bd244204ee73a3e44185491fa16d83104
   md5: 73ac0fa3c67e5eb283173d74a2771752
   depends:
@@ -6776,7 +6776,7 @@ packages:
   license_family: BSD
   size: 60625
   timestamp: 1699282918176
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
   sha256: 257e1102d2dc3f8b0c1708585c819e86f41abd101084cd0569e8e31652480875
   md5: 2128c6806bba6953e1a275f37e7a295b
   depends:
@@ -6804,7 +6804,7 @@ packages:
   license_family: BSD
   size: 614705
   timestamp: 1699467242943
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
   sha256: 90420847230e72a648417f5f77cebcf7f17b89f70788652c276acc0c440e135f
   md5: ef3d8dee197aa37897bf6d39d2dd878f
   depends:
@@ -6815,7 +6815,7 @@ packages:
   license_family: BSD
   size: 27639
   timestamp: 1686871052174
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
   sha256: 97faaf26ce5254ec3649a8ee7f480b1556e4e8e6e4356d2fab1e6a5532631a0f
   md5: da23bd831c50c877f63038b7e16720ad
   depends:
@@ -6827,7 +6827,7 @@ packages:
   license_family: BSD
   size: 20163
   timestamp: 1700168785472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
   sha256: 8a2f0909fad0387e57cb0e9ee30db2b20761a9106e794381ffeac387a298fb07
   md5: 6058b2efc3284e27aacec2e6e6280433
   depends:
@@ -6838,7 +6838,7 @@ packages:
   license_family: BSD
   size: 62334
   timestamp: 1676432044242
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
   sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
   md5: f5f73266281ab12377d5d47bdf07500a
   depends:
@@ -6850,7 +6850,7 @@ packages:
   license_family: MIT
   size: 905072
   timestamp: 1617648814933
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -6860,7 +6860,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 7c906c94a4d46ea963080a6ba5bd12c1274da66159877a544fbc70291eeed98d
   md5: 45a3d52534fac8aa54a55ee92211a918
   depends:
@@ -6869,7 +6869,7 @@ packages:
   license: MIT
   size: 80216
   timestamp: 1714483371043
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
   sha256: daad7edc6d56abf3e176479e8628162dbf1c56b3d24db30d708aebae694a5214
   md5: e8ecf229f7fcb4c0b76d8613627948f5
   depends:
@@ -6879,7 +6879,7 @@ packages:
   license: MIT
   size: 45189
   timestamp: 1714483420152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 84320217abffa9386186ec8d03b4651bb4b1900d3871adc965a9a9e1d3799907
   md5: 651312fa22168f71f9aec5f9ee2c2fcf
   depends:
@@ -6889,7 +6889,7 @@ packages:
   license: MIT
   size: 756116
   timestamp: 1714483464368
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -6899,7 +6899,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
   sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
   md5: cf949d76148be1e2a534218d9c57df86
   depends:
@@ -6909,7 +6909,7 @@ packages:
   license_family: MIT
   size: 155435
   timestamp: 1714484319443
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -6920,7 +6920,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -6929,7 +6929,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -6946,7 +6946,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
   sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
   md5: b1781519a200ccbfcb4a1194005aa3ef
   depends:
@@ -6958,7 +6958,7 @@ packages:
   license_family: BSD
   size: 338459
   timestamp: 1694777084290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
   sha256: 4534c822511a052a72c2b070a05e5d8d6f3550f18ea00a33f9d8a9a92b4382cc
   md5: 82f24e7660831445a2183216e280a6a4
   depends:
@@ -6968,7 +6968,7 @@ packages:
   license_family: MIT
   size: 41464
   timestamp: 1676474474981
-- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
   sha256: b2b50fb4e43e4c4da8db26cf362671e03774384732e1925d82e12dfce45c5ac3
   md5: 44ff317b1ff9bd2b1fbf39da56965b16
   depends:
@@ -6980,7 +6980,7 @@ packages:
   license_family: BSD
   size: 20842990
   timestamp: 1706911120234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
   sha256: 896b7a39bd4ad3621312130122b4fe84dcb67d7355166255c58ea9bc562eb0ae
   md5: 640b852a56296f48cf073e61a59c5256
   depends:
@@ -6989,7 +6989,7 @@ packages:
   license_family: BSD
   size: 13751
   timestamp: 1676428354074
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
   sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
   md5: 320f40b75d93f3b96931c6d13c23946c
   depends:
@@ -6999,7 +6999,7 @@ packages:
   license_family: BSD
   size: 158902
   timestamp: 1714512129889
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
   sha256: e0dc6e119b224bb31ef34b6ba270ffadc181d38b698c5318de8df7a5d2c4ccbd
   md5: 992ccd756f09408f0b74dfb9852a8b7f
   depends:
@@ -7008,7 +7008,7 @@ packages:
   license_family: BSD
   size: 182381
   timestamp: 1676437963591
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
   sha256: 050b5fd4b28132d8102a7e6b40179894dc7f5e41f7ad9ee19211e67446c5740f
   md5: 3ae0b2f6baec708554648ddafa81b756
   depends:
@@ -7018,7 +7018,7 @@ packages:
   license_family: MIT
   size: 154386
   timestamp: 1684279992864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
   sha256: 8269c73b7a9c03b95a121e318d0468f35eecc016093620b0560f35238cc5df51
   md5: 2914bea0ae29315f998e1abac79ccaa8
   depends:
@@ -7031,7 +7031,7 @@ packages:
   license_family: BSD
   size: 30214
   timestamp: 1704206218108
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
   sha256: 68fb7d113dbf185b571343847e3dbefdbe7d0b9b5902f1f390bc2a6e33a3f8ee
   md5: a72ff718390a1fde0b208a43e6b9b655
   depends:
@@ -7053,7 +7053,7 @@ packages:
   license_family: PSF
   size: 11366001
   timestamp: 1713336740870
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
   sha256: 43279276850eb6e621812448cddc1093524cee0b7f8ed58b4600b68a4fb659f2
   md5: 5968b2b5c1f3cf5c8c8c9aaa4d8d66a2
   depends:
@@ -7063,7 +7063,7 @@ packages:
   license_family: BSD
   size: 19886
   timestamp: 1676425829787
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
   sha256: 3062a8254ca351b54f15bea85cc928a3ba4d879bb98ce97ece39a9f7eca215a5
   md5: 8f1565663abb34ad7fdd512e76da5532
   depends:
@@ -7073,7 +7073,7 @@ packages:
   license_family: MIT
   size: 68031
   timestamp: 1676481862508
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
   sha256: cdff5215c292fe59649ca40ca72f5d26da352760c1d6a56feba14eb13f7bbf61
   md5: e0f3f32b22135dfeaec277bc87183ca9
   depends:
@@ -7082,7 +7082,7 @@ packages:
   license_family: MIT
   size: 23328
   timestamp: 1676442709081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
   sha256: 3b173a25605d2aaacc57ec0e425f1d1c51327eb2521c8742a736e2c76069bc8d
   md5: 169f1c93a443f95a88665f3008623ce1
   depends:
@@ -7093,7 +7093,7 @@ packages:
   license_family: BSD
   size: 104882
   timestamp: 1676425142412
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
   sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
   md5: 527155127b9fada5e5c5c69a624674b9
   depends:
@@ -7105,7 +7105,7 @@ packages:
   license_family: Proprietary
   size: 187498166
   timestamp: 1699648376430
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
   sha256: cea59ae60da314caecf08edb9bcb03126c6dd35837c8184bceaa194decca3341
   md5: 30936b7263cf0171f7c86400f12ef184
   depends:
@@ -7117,7 +7117,7 @@ packages:
   license_family: BSD
   size: 49080
   timestamp: 1682975093455
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
   sha256: 5070ceb0a406b1b8b99e2ec58f5d224cbe16ec78109c46720bd182b509e05c6e
   md5: 34de1af5c639f2d06c6c8d99488e4226
   depends:
@@ -7132,7 +7132,7 @@ packages:
   license_family: BSD
   size: 196201
   timestamp: 1695058367111
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
   sha256: 6b4b27302e458fa527321c59be7c335d61f86da7501c4d141db20a72fad68b55
   md5: 7db9b12da1290bb2c2fc6ee52a945905
   depends:
@@ -7147,7 +7147,7 @@ packages:
   license_family: BSD
   size: 256371
   timestamp: 1695060425702
-- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
   sha256: 39f09c1bc57b4800ebda331eddb462928435498705351b0432d51a4293294ad8
   md5: 5565984a02f41e97cb9a4c9126ced14b
   depends:
@@ -7157,7 +7157,7 @@ packages:
   license_family: BSD
   size: 29808
   timestamp: 1676442800892
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
   sha256: 5422fc4dc6708279223027e45dd1ccffe4dc2feb93c60c8a683946a398c60a1c
   md5: 62d16437707dd382c21a9ed1d8b375dc
   depends:
@@ -7183,7 +7183,7 @@ packages:
   license_family: BSD
   size: 8304222
   timestamp: 1699543942441
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
   sha256: e940f9178ee2fa0a7c12873ae35ebea0074371653e5cfa1be8aa8d9271fd343b
   md5: 355d0835215911738a28010dfa6aa382
   depends:
@@ -7196,7 +7196,7 @@ packages:
   license_family: BSD
   size: 141785
   timestamp: 1698934346590
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
   sha256: 47dd00c0179f4eb29c70d0453d340f7f5332af326b3d51c64ca3bf6a14be8e7e
   md5: f66afe718bdb57667b03ebda4cb2ac7e
   depends:
@@ -7223,7 +7223,7 @@ packages:
   license_family: BSD
   size: 561655
   timestamp: 1699023338436
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
   sha256: 4ee863a1ff697274c642b3101f82b279a354e3f033a87505655039f89127bb41
   md5: bfaf19be6644ad2344e118aa0acccb13
   depends:
@@ -7236,7 +7236,7 @@ packages:
   license_family: BSD
   size: 189809
   timestamp: 1694617194065
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
   sha256: 90fb3f14c49da1397982eae21cd09e8d60d491d76f94c57590c56723fe6dc172
   md5: 46a523661fe5c1bce7b4213fd428c3de
   depends:
@@ -7245,7 +7245,7 @@ packages:
   license_family: BSD
   size: 16732
   timestamp: 1708532795328
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
   sha256: 5db3fd8b4d97e2a6232e2f7c62f1ce82ae3876326aed9f8c3ea656eda83e55da
   md5: 39c36df9dac13398e8a54497dcc14611
   depends:
@@ -7270,7 +7270,7 @@ packages:
   license_family: BSD
   size: 755697
   timestamp: 1690986137327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
   sha256: e040ebcab948325fbe17e4ab15be62e1fafa7bad225457e59764adb60eb40db5
   md5: 4d40a09df8cb74a9f044eab317436d67
   depends:
@@ -7280,7 +7280,7 @@ packages:
   license_family: BSD
   size: 27282
   timestamp: 1699456187703
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.59.1-py311hf62ec03_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numba-0.59.1-py311hf62ec03_0.tar.bz2
   sha256: a20cb730d87b945125202c7f4e81490c24db708f373d1214e6b04f5d2b4177b3
   md5: a235c61c1928d09080158ffd42ffbccc
   depends:
@@ -7301,7 +7301,7 @@ packages:
   license_family: BSD
   size: 6100005
   timestamp: 1712021687877
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
   sha256: d3bd2a6614bb7e7f5ce3348d6674e71cce45cbde236beff32f0f08cd95a64ef0
   md5: e70f15643164f432d1df68635e7c322b
   depends:
@@ -7316,7 +7316,7 @@ packages:
   license_family: MIT
   size: 162691
   timestamp: 1696515822068
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
   sha256: 470fe9a0b3e196fa60d5550d8188f6074a207572fa0d353a4448d580872e7804
   md5: 6fdb8df0613fb2fb9f1732d335fa25f1
   depends:
@@ -7333,7 +7333,7 @@ packages:
   license_family: BSD
   size: 11053
   timestamp: 1708641901110
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
   sha256: 222c1711e7cf151e29077c7d4d86a865c9fd39615812d58a1daca6fd1b6bdfb5
   md5: 585bcd8bc3940a8a859f38ebafdcd77d
   depends:
@@ -7349,7 +7349,7 @@ packages:
   license_family: BSD
   size: 10723862
   timestamp: 1708641867155
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
   sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
   md5: ab07e2a27ac08afe3d0b4c0890b8486a
   depends:
@@ -7360,7 +7360,7 @@ packages:
   license: BSD 2-Clause
   size: 249316
   timestamp: 1630094024143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
   sha256: c8e066c2cb547914401ec29b7356914ca3cdf6ac37eead248fe0c41236a7838c
   md5: 5879739cc77497a518b2ebd55857183b
   depends:
@@ -7371,7 +7371,7 @@ packages:
   license_family: Apache
   size: 8118619
   timestamp: 1716319803768
-- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
   sha256: b2f5f50a1ddf811102636f3acebd76716c88ebb628754b91eda7a3a962adf26c
   md5: 712527b4d84c350dca4b67f511c04414
   depends:
@@ -7380,7 +7380,7 @@ packages:
   license_family: APACHE
   size: 39421
   timestamp: 1699371341381
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
   sha256: 432b8b7c4671878cbbe361e518544203f97bd2e4f24fa08cf65e8be583f25529
   md5: e62e7c668b080e0f6ce09fd548f69f7f
   depends:
@@ -7389,7 +7389,7 @@ packages:
   license_family: Apache
   size: 159066
   timestamp: 1710809127954
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
   sha256: 3ae55d8148580fc3f171c0fcc420488fbba05517cefd358fe013b45ec3594371
   md5: bfb42ed6826a1c8cded9539fc6e07029
   depends:
@@ -7440,7 +7440,7 @@ packages:
   license_family: BSD
   size: 16924671
   timestamp: 1709591125871
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
   sha256: b529eac4abff05f13760c51ad37adf24e744109a6fb30471b26dc1f6a1c23847
   md5: b690cc140a7866280131762a26c05f39
   depends:
@@ -7464,7 +7464,7 @@ packages:
   license_family: BSD
   size: 21902721
   timestamp: 1714073654508
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
   sha256: e77795e1af9bc27d45841d6b9c51e0e7da31e0eabaaffa99162245adc55d13a3
   md5: 14046398ac44f496bc9df300285ec586
   depends:
@@ -7473,7 +7473,7 @@ packages:
   license_family: BSD
   size: 267222
   timestamp: 1711137058994
-- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
   sha256: b0d7fbfcf1c5c682ed9934eb6a33e00a2517941f2bcb9d677379f4bb73b2c45c
   md5: 20c8f36595a48f5cda2f4f74c02a3ea2
   depends:
@@ -7487,7 +7487,7 @@ packages:
   license_family: BSD
   size: 48206
   timestamp: 1698702818841
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
   sha256: 6ca54ba8ce430caa8a1838b19869814d0b7fa3592a77f75298130983e635387b
   md5: e56c194e56d19dd8fd76f75a77f92c33
   depends:
@@ -7505,7 +7505,7 @@ packages:
   license_family: Other
   size: 1070844
   timestamp: 1714399290671
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
   sha256: 15001c7ee6cf6e0ef7afc2f313114f6103e7b6f641fac9a6899ee02d6537c822
   md5: 250ba95e77f5fcb3fe2aefa85157e859
   depends:
@@ -7516,7 +7516,7 @@ packages:
   license_family: MIT
   size: 3759346
   timestamp: 1715097175495
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
   sha256: e5f8cbfb5fc25d460a9117bfc5511959c5e86ccb193316033f87bd516e0c8881
   md5: 9f7e8b5eb651539386bb92c14e5c321b
   depends:
@@ -7525,7 +7525,7 @@ packages:
   license_family: MIT
   size: 37730
   timestamp: 1692205554840
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
   sha256: 6c5b53831273674361437fb546e08315fc11ca9275a174bca3887987e86ced5a
   md5: f8d91daf5173eb03157f484389adcdd4
   depends:
@@ -7534,7 +7534,7 @@ packages:
   license_family: Apache
   size: 122178
   timestamp: 1679591983138
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
   sha256: 546819d922b03f3a25ca9f98fd069d0588d481fc0603c6d74bd598fb6a93687f
   md5: 86c18e3e0b67ee099457475ed6caf2e6
   depends:
@@ -7546,7 +7546,7 @@ packages:
   license_family: BSD
   size: 751763
   timestamp: 1704404627180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
   sha256: ae06f0dfa2cfae51404afc6d6ad3a474a93015b5ba9a7d3ea24224b8e7547987
   md5: 3e19794c806cc3e84a3080a97c359b75
   depends:
@@ -7557,7 +7557,7 @@ packages:
   license_family: BSD
   size: 510466
   timestamp: 1679005998612
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
   sha256: e2af1efb1a5094a5962d93fa949ecab479a2ae7570e030f52eeac6761383c208
   md5: 4cb1359e22ddf8f3996afddce5f6205c
   depends:
@@ -7569,7 +7569,7 @@ packages:
   license_family: BSD
   size: 56638
   timestamp: 1676438592117
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
   sha256: d95c88d06f4f3f667bd9a39e5f18179e83b3cd4c115c06ce0fff390ff6d3a700
   md5: c6d00a8a4d89b1be99bfa3aff19d96b4
   depends:
@@ -7578,7 +7578,7 @@ packages:
   license_family: BSD
   size: 2134881
   timestamp: 1684280285492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
   sha256: 643a9a0eba1e2bd5980d21623d3b35188c24781ec251acc4d15714bd1ccb4c17
   md5: b3cda0394db05be6f0f6176abacb13f3
   depends:
@@ -7587,7 +7587,7 @@ packages:
   license_family: MIT
   size: 207985
   timestamp: 1678721438358
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
   sha256: 974c22de09078bf07c5db31fe12d8d89d6433508defc8237cbe52e08c69ed56b
   md5: 9cf10bfd49140a527cf4b1d912097e6d
   depends:
@@ -7597,7 +7597,7 @@ packages:
   license_family: BSD
   size: 36072
   timestamp: 1676426019064
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
   sha256: f43aca7a222c983c25c3e15f79c7e7e3c4909bb7839a1dd0ee327def81aa476e
   md5: 2b61f1cb7fec068c76ef0ff97c2c62b5
   depends:
@@ -7618,7 +7618,7 @@ packages:
   license_family: PSF
   size: 19811751
   timestamp: 1713545124922
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
   sha256: 2c61639b3bb56fc864c86558bceb7845b1731ac44bf1a94894172ea47a995bd4
   md5: 404805e547b4d50b5cd17e16bca87527
   depends:
@@ -7628,7 +7628,7 @@ packages:
   license_family: BSD
   size: 332043
   timestamp: 1716495838826
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
   sha256: 9acb33db60d9319595f52337cae3b88c2a2338cd66f1f9d8ae86d0a993c2067a
   md5: f4af8cf94d042b4dde487241bba1c457
   depends:
@@ -7637,7 +7637,7 @@ packages:
   license_family: BSD
   size: 279780
   timestamp: 1679500609851
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
   sha256: 48fe7373b012b51134b6b6ff67f18d2b4aae3a5c7700e4560ce002af7172f064
   md5: 0379cd17692152c12b662b0e4ea46b88
   depends:
@@ -7646,7 +7646,7 @@ packages:
   license_family: BSD
   size: 18008
   timestamp: 1683824373128
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
   sha256: 803274d986d0c4e3b5ec1018747ede86ef57137455b3e44a60e834717eafb92b
   md5: c9f134ddeff6fdf0373a45534ddb7079
   depends:
@@ -7655,7 +7655,7 @@ packages:
   license_family: MIT
   size: 273009
   timestamp: 1713974722039
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
   sha256: 6fbcba97c1dcb5157afd23f264c3cff069c7e4be5ea55980fc349eb8dc2cb49e
   md5: 8153e3f8b3283926bcf9403804a365f5
   depends:
@@ -7667,7 +7667,7 @@ packages:
   license_family: BSD
   size: 65050
   timestamp: 1711137009299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
   sha256: cd33dfee104dfbba4af38d06a09ccbae6a32e7c543afedab523303319ebb283d
   md5: 3dfc19af0306d80921e1403f1f551bba
   depends:
@@ -7677,7 +7677,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13679916
   timestamp: 1676423267293
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
   sha256: 102ff1d958209e3648bb49da3503cf752abab822011fdc4e12e88145c9e73772
   md5: 0553c2c381b6f5c836b23edc8c6db2ba
   depends:
@@ -7689,7 +7689,7 @@ packages:
   license_family: MIT
   size: 246689
   timestamp: 1677708371873
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
   sha256: bee5c4d0f41f06a9c0aac636885e36e8b81116aafde980f9ea48fdb64abb5567
   md5: 6c05a053240cb90765d6f8c2efdf905e
   depends:
@@ -7701,7 +7701,7 @@ packages:
   license_family: MIT
   size: 182228
   timestamp: 1698096268270
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
   sha256: ea39db411361d96545a04fb976940e9590147acb4ca9caacf7e8264780379347
   md5: b411b8be8e53e5059949dde02dd07faf
   depends:
@@ -7713,7 +7713,7 @@ packages:
   license_family: Other
   size: 565148
   timestamp: 1709319072176
-- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
   sha256: 47653b45a5f2d97b5bf0dbf0e620908880f9078da427eef69012effe3f19af67
   md5: 44e709ae67d89bccee2d4d46d358fee3
   depends:
@@ -7724,7 +7724,7 @@ packages:
   license_family: MIT
   size: 74493
   timestamp: 1699012356534
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
   sha256: d7bcba5262df162756885a773c3bf2dace27311bbbb1830a0f97aa60ac7c1239
   md5: daeb99ccfe39f725278203412aac0873
   depends:
@@ -7740,7 +7740,7 @@ packages:
   license_family: Apache
   size: 120468
   timestamp: 1707355917958
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
   sha256: d6daaa6b45272819176e4aeb467ae00e3db43386548464a9993688f292709d40
   md5: 9fe721d7f7420c259df4f07d4503f654
   depends:
@@ -7750,7 +7750,7 @@ packages:
   license_family: MIT
   size: 9683
   timestamp: 1683077110211
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
   sha256: 6051860575f9448aea5799d74469c928cd7cdeeca1eb53657872262a77b1a7a8
   md5: 60e193eca497130034facd5fed168249
   depends:
@@ -7759,7 +7759,7 @@ packages:
   license_family: MIT
   size: 10094
   timestamp: 1683059114376
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
   sha256: ecd310461c1b45ab92ddf15539cea5a6e837860561c974d2d7393f9a7933f116
   md5: 1762fec2838763e904141167e18b0389
   depends:
@@ -7770,7 +7770,7 @@ packages:
   license_family: MIT
   size: 215600
   timestamp: 1698947891859
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
   sha256: 0042fa2dc2ec8c2181f28f5ee4f45087ea58dca7acc6b89c48f3ce6eac8f9bdd
   md5: 755c9767608b233b94ec3a67c8e0da4b
   depends:
@@ -7788,7 +7788,7 @@ packages:
   license_family: BSD
   size: 32418527
   timestamp: 1714081783418
-- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
   sha256: 6fd52bae6360fbc8135d72e0c1e4fd407769fa4d0f4b59356e7aed3e000eb339
   md5: 49fd52885250da8aab17ed72e2e18b81
   depends:
@@ -7797,7 +7797,7 @@ packages:
   license_family: BSD
   size: 88901
   timestamp: 1699371435766
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
   sha256: a2ec4690bc07be9e7f3ad8e3003803eb4304a434d3f139633e2817318a9f7b20
   md5: dd2d225219924fc5c36598c919541271
   depends:
@@ -7806,7 +7806,7 @@ packages:
   license_family: MIT
   size: 1593050
   timestamp: 1715025622141
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
   sha256: 5d1b7e14dc04816692de0f8518ea8fcbefb26ab61cec83f96f2c44c1bee67fab
   md5: 505d2a70a875b5082dc857aa4dfab0d4
   depends:
@@ -7815,7 +7815,7 @@ packages:
   license_family: Other
   size: 18830
   timestamp: 1705431395254
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
   sha256: 5ff3b4ac3fbce4dd67a87856c04698d0397deb0ac288ff4e7eb02fbab57f1253
   md5: 0ca650a7001c6650809d3361de8cb005
   depends:
@@ -7824,7 +7824,7 @@ packages:
   license_family: MIT
   size: 89590
   timestamp: 1696347858925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
   sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
   md5: 833b93a2daade3407898f15588945d83
   depends:
@@ -7834,7 +7834,7 @@ packages:
   license_family: Other
   size: 1440481
   timestamp: 1714488344682
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -7844,7 +7844,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
   sha256: 78d89b50a29fbeb19a562f5dad95615e3f192bb4f3b86cd6ea75f2f825418232
   md5: 4a4040df560ea47704e0898c4c015808
   depends:
@@ -7855,7 +7855,7 @@ packages:
   license_family: BSD
   size: 38069
   timestamp: 1678228553220
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
   sha256: 70a3cc4a4e81a6421bc19cd410d1d6064aadb2b1cce38b020f85e5346716d8e7
   md5: 32a9a2539579a3d522dce3b5cb4f987b
   depends:
@@ -7865,7 +7865,7 @@ packages:
   license_family: BSD
   size: 49495
   timestamp: 1676425411739
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
   sha256: 0a95736cfd0bb25fc201cd6be4a2450ea8fc30eeb349d861812675b84c94fa74
   md5: a8a9fb30c6dd8e7a16d5dcd2333c3c49
   depends:
@@ -7876,7 +7876,7 @@ packages:
   license_family: BSD
   size: 3844176
   timestamp: 1714770894235
-- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
   sha256: ed5950ac0c12cc87f991a6f28112cf29057e2b7ad416ae4429a0b97c3efaf58c
   md5: b5e2a04879e6fd19f0eb5effded4dc61
   depends:
@@ -7885,7 +7885,7 @@ packages:
   license_family: BSD
   size: 135939
   timestamp: 1676431438808
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
   sha256: 4febf30c11674711b86c8c10da46a5e1613071388da999210912a31508864add
   md5: 1c109fc1112ea1f5f377bdf0d18ba75f
   depends:
@@ -7896,7 +7896,7 @@ packages:
   license_family: Apache
   size: 895633
   timestamp: 1696937216859
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
   sha256: 973dc7991dd5976ce2d27a94739712cac4d31f2d2958fbf23adb844f5ac999c8
   md5: ca74b36907b3f4f8a51bd5b2e4d8220b
   depends:
@@ -7908,7 +7908,7 @@ packages:
   license_family: MOZILLA
   size: 186541
   timestamp: 1716396206048
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
   sha256: e8c77efe880546252f244f995cbed5967809555127b4f818b97455d434b23415
   md5: 7397ac07045115960ebd8dec95326a7a
   depends:
@@ -7917,7 +7917,7 @@ packages:
   license_family: BSD
   size: 270819
   timestamp: 1676423321499
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
   sha256: ab3cce654f1e94793fff0cb03b750d9b20cdbf099263b1906c3c5eaf8b347ab6
   md5: c68ffc771312afb6f88b94c24d2bb689
   depends:
@@ -7927,7 +7927,7 @@ packages:
   license_family: PSF
   size: 9706
   timestamp: 1715268972001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
   sha256: 4089efea1753ebe2f6617b46cc368738f285b1d816d4a4f01ba71524f46851b4
   md5: 7f610528ecd0b317180efa2058c32323
   depends:
@@ -7936,7 +7936,7 @@ packages:
   license_family: PSF
   size: 75414
   timestamp: 1715268958140
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
   sha256: d091897f05318c22ca31028370f25355065999078f7db6f88ab27bf4cb030ec8
   md5: 1776502c1cfb351554eeda6cddaf255f
   depends:
@@ -7945,7 +7945,7 @@ packages:
   license_family: MIT
   size: 11588
   timestamp: 1676457729096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
   sha256: c16498f8238cc331618720d078b87995eceb6bbf20268a7a4e8efbf7b5859a9a
   md5: 770432c0ca1ab9d99ffe95e51d3a3e74
   depends:
@@ -7956,7 +7956,7 @@ packages:
   license_family: Apache
   size: 517433
   timestamp: 1713213261710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
   sha256: 3009bd4e7e8126309e606c81cb75d4b8d4fbb2bceac10ec43f7eb6eaaf717ac2
   md5: ee6e87af42008a762d3531771c1a2b18
   depends:
@@ -7972,7 +7972,7 @@ packages:
   license_family: MIT
   size: 210034
   timestamp: 1715636431813
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
   sha256: 906048f3b1dc326b367a08edc91816ff523b5f06cd45d985b4dbb7cfe8017559
   md5: e509c495aaa92d767d554cd43a990ee5
   depends:
@@ -7981,12 +7981,12 @@ packages:
   license_family: BSD
   size: 8900
   timestamp: 1715797316229
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
   sha256: ab224d078734a23527716388ddffc034d18254843881d0fc068c2efa35bacfe1
   md5: 73f5831d017e5572330d2459844718f3
   size: 2246565
   timestamp: 1715797302913
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
   sha256: 24ea3d3e0cb98d0d246338dbb4562b67967bb32002e3704e495a5c863476e831
   md5: c7b9cdbe87b3c9720aeca1164a0fd6df
   depends:
@@ -7995,7 +7995,7 @@ packages:
   license_family: BSD
   size: 26181
   timestamp: 1676424437003
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
   sha256: 92d27e41ce34387e59acb47572fcb2e92c4defaeadafd11ce190226022023e69
   md5: f1bf142d852987acbe4b0bc94e87d958
   depends:
@@ -8004,7 +8004,7 @@ packages:
   license_family: Apache
   size: 145306
   timestamp: 1715878654770
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
   sha256: 1b086d1b079fdb2f148c7dd82658f2b7f283c88f286e1216c0f1237319039b0f
   md5: 299e87f151a549d86a48bf24df15c607
   depends:
@@ -8013,7 +8013,7 @@ packages:
   license_family: MIT
   size: 168041
   timestamp: 1714717238470
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
   sha256: 17fadf35aa8917c107e7b369e9364ac7c09537776e7943d37e225e14b7026c94
   md5: 0e67c3b9624540581b894b11267a837b
   depends:
@@ -8021,13 +8021,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 10197
   timestamp: 1676425485716
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
   sha256: 25373efabba9a866849fe38a47c79e0fa323851b4bd4b5df357cc8d5617c2786
   md5: a958e9d32c3b65c21e11e5d9e8491c43
   depends:
@@ -8039,7 +8039,7 @@ packages:
   license_family: Apache
   size: 2467966
   timestamp: 1689041676824
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
   sha256: b849b368e27920838fe40a512b102879693a55cb187dd1c8d3a83fa8c05a8054
   md5: 7b1f6e9c71906a93039b3446b99a5498
   depends:
@@ -8048,7 +8048,7 @@ packages:
   license_family: BSD
   size: 55114
   timestamp: 1676434863173
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
   sha256: 344a5276a9928638dcde054dfe4e87c8cb40bd2d4d356378b9ab2f863ca62e4b
   md5: fe471fd8b5a3d77be6fa5dbf9b99dafb
   depends:
@@ -8058,7 +8058,7 @@ packages:
   license_family: GPL2
   size: 1432281
   timestamp: 1714515119689
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -8067,7 +8067,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
   sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
   md5: e5aed81295b61b6d1eb62830799a0297
   depends:
@@ -8078,7 +8078,7 @@ packages:
   license_family: Other
   size: 9125184
   timestamp: 1705602328351
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
   sha256: d932439798665be388bbf68f3d68da5b42ed4753a43587d3f49848a85f58add4
   md5: e2900345674e644e05540ffac6acca89
   depends:
@@ -8087,7 +8087,7 @@ packages:
   license_family: MIT
   size: 25247
   timestamp: 1704207149955
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
   sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
   md5: f295b54ab59f5b8658e2a322ac6aa721
   depends:
@@ -8097,7 +8097,7 @@ packages:
   license_family: Other
   size: 162161
   timestamp: 1714514792081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
   sha256: b2ff66b7f6efa0831f939e57e562c244332b690af08818a540d1a97fa07d8525
   md5: e548d528873d9a0006a36714cf36462a
   depends:

--- a/gull_tracking/pixi.toml
+++ b/gull_tracking/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "gull_tracking"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/gull_tracking/pixi.toml
+++ b/gull_tracking/pixi.toml
@@ -1,0 +1,38 @@
+[workspace]
+name = "gull_tracking"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2019-12-12"
+maintainers = ["jbednar"]
+categories = ["Other Sciences", "Geospatial"]
+labels = ["datashader", "hvplot", "bokeh"]
+description = "Visualizing GPS tracking for herring gulls in Belgium"
+
+[dependencies]
+python = "3.11.*"
+bokeh = ">=3.3.4"
+notebook = ">=6.5.4,<7"
+colorcet = ">=3.1.0"
+datashader = ">=0.16.0"
+hvplot = ">=0.10.0"
+pandas = ">=2.2.1"
+pip = "*"
+setuptools = "*"
+wheel = "*"
+
+[target.osx-64.dependencies]
+libgfortran = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks.notebook]
+cmd = "jupyter notebook gull_tracking.ipynb"
+depends-on = ["download"]
+
+[tasks.download]
+env = { FILENAME = "data/HG_OOSTENDE-gps-2018.csv" }
+cmd = "mkdir -p data && curl -fsSL -o $FILENAME https://s3.eu-west-1.amazonaws.com/datasets.holoviz.org/HG_OOSTENDE/v1/HG_OOSTENDE-gps-2018.csv"
+outputs = ["data/HG_OOSTENDE-gps-2018.csv"]

--- a/gull_tracking/pixi.toml
+++ b/gull_tracking/pixi.toml
@@ -18,15 +18,15 @@ colorcet = ">=3.1.0"
 datashader = ">=0.16.0"
 hvplot = ">=0.10.0"
 pandas = ">=2.2.1"
-pip = "*"
-setuptools = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+setuptools = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks.notebook]
 cmd = "jupyter notebook gull_tracking.ipynb"

--- a/heat_and_trees/pixi.lock
+++ b/heat_and_trees/pixi.lock
@@ -1,0 +1,13477 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/nodefaults/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.9.5-py311h459d7ec_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311h459d7ec_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.22-hbd3ac97_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.7.1-h87b94db_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.23-h4ab18f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.18-he027950_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.2-h7671281_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.2-he17ee6b_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.10-h826b7d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.4-hcd6a914_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.6.0-h365ddd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.16-he027950_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.18-he027950_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.27.3-hda66527_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.329-h46c3b66_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.12.0-h830ed8b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.8.0-hdb0d106_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.11.0-ha67cba7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.6.0-he3f277c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.10.0-h29b5301_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-hef167b5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hb755f60_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.32.2-h4bc722e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.7.4-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hbb29018_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.23.0-py311h14de704_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py311hb3a22ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.4.1-hf8ad068_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.4-py311h18e1886_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.2.1-py311h9547e67_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-0.12.3-py311h459d7ec_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.2-py311h4332511_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-10.2.1-h00ab1b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.53.1-py311h61187de_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h743c826_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.4.1-py311h459d7ec_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.9.1-py311h4a2bcd2_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.12.2-hac33072_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.3-hf7fa9e8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-he1b5a44_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_hdf9ad27_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.17-h1220068_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-5.7.2-py311h38be061_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kealib-1.5.3-hee9dde6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.5-py311h9547e67_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-hf3520f5_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240116.2-cxx17_he02047a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.4-hfca40fe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-16.1.0-h34456a7_14_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-16.1.0-he02047a_14_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-16.1.0-he02047a_14_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-16.1.0-hc9a23c6_14_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-22_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-22_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.8.0-hca28451_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.20-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.1.0-h77fa898_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.9.1-ha770c72_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.9.1-h1d1841c_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-fits-3.9.1-hdd6600c_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.9.1-h5f34788_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.9.1-ha39a594_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.9.1-ha2ed5f0_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.9.1-h2ebfdf0_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-kea-3.9.1-h2b45729_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.9.1-h94e7027_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pdf-3.9.1-h562c687_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pg-3.9.1-he047751_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-postgisraster-3.9.1-he047751_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-tiledb-3.9.1-hfcb00c0_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-xls-3.9.1-h062f1c4_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.1.0-h69a702a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.1.0-hc5f4f2c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.3-h8a4344b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.1.0-h77fa898_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.26.0-h26d7fe4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.26.0-ha262f82_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.62.2-h15f2491_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-hbbc8833_1020.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-22_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h135f659_114.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.27-pthreads_hac2b453_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-16.1.0-h9e5060d_14_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.3-ha72fbe1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.3-h08a7969_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.09.01-h5a48ba9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-hc670b87_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h15fa968_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.0-hde9e2c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.1.0-hc0a3c3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.19.0-hb90f79a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-h1dd3fc0_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.16-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.7-h4c95cb1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.10.1-h2629f0a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-h4ab18f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.43.0-py311hbde99c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.3-py311h38e4bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hd590300_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.5-py311h459d7ec_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.1-py311hffb96ce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.7-h401b404_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.0.8-py311h52f7536_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.0.5-py311h459d7ec_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.1-nompi_py311h25b3b55_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.102-h593d115_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.60.0-py311h4bc866e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.12.1-py311h4332511_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.0.0-py311h1461c94_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-h4ab18f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.1-h17fec99_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.2-py311h14de704_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-h0f59acf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.4.0-py311h82a398c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/poppler-24.07.0-hb0d391f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/postgresql-16.3-h8e811e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.4.1-hb784bbd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.0.0-py311h331c9d8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-16.1.0-py311hbd00459_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-16.1.0-py311h8c3dac4_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.9.0-py311hfc743a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.6.1-py311hc21b84f_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.9-hb806964_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-4_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py311h459d7ec_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.0.3-py311h08a0b41_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.3.10-py311h539dff6_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.09.01-h7f4b329_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.19.0-py311hb3a8bbb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.17-he19d79f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.5.1-py311hd632256_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.0-py311h517d4fd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.5-py311h5925939_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.13.0-hd2e6256_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.46.0-h6d4b2fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.24.2-hc55ee95_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.1-py311h331c9d8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tzcode-2024a-h3f72095_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.5-hac6953d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-h7391055_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.9-hb711507_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-h7f98852_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.9.4-py311h459d7ec_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h75354e8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-h4ab18f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py311h5cd10c7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.7.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.6.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.12.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.12.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.0.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.0.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-xarray-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyarrow-hotfix-0.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-70.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20240316-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.18.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.19.2-pyhd8ed1ab_0.conda
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.7.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.6.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.12.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.12.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.0.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.0.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-xarray-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyarrow-hotfix-0.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-70.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20240316-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.18.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.9.5-py311he705e18_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h2725bcf_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.22-hb04b931_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.7.1-hd73d8db_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.23-hfdf4475_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.18-hd73d8db_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.2-h2713d70_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.2-he29c2fd_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.10-h4406d91_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.4-hf6997d9_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.6.0-h13137a3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.16-hd73d8db_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.18-hd73d8db_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.27.3-h0a15bd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.329-h554caeb_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.12.0-hf8dbe3c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.8.0-h906f3f0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.11.0-h5f32033_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.6.0-h0dc8e96_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-files-datalake-cpp-12.10.0-hc1cec4e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.6-h7d75f6d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hdf8f085_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.32.2-h51dda26_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.7.4-h8857fd0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h9f650ed_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cartopy-0.23.0-py311hfdcbad3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.16.0-py311hc0b63fd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cfitsio-4.4.1-ha105788_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cftime-1.6.4-py311hce3442d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.2.1-py311h1d816ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-0.12.3-py311he705e18_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.2-py311hbafa61a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/expat-2.6.2-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-10.2.1-h7728843_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.14.2-h5bb23bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.53.1-py311h72ae277_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3ec172f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/frozenlist-1.4.1-py311he705e18_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.9.1-py311h055bc3f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.12.1-h93d8f39_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/geotiff-1.7.3-h4bbec01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hb1e8313_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h2790a97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.3-nompi_h687a608_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/json-c-0.17-h6253ea5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jupyter_core-5.7.2-py311h6eed73b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/kealib-1.5.3-hb2b617a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.5-py311h5fe6e05_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240116.2-cxx17_hf036a51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.7.4-h20e244c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-16.1.0-had6961a_14_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-16.1.0-hf036a51_14_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-16.1.0-hf036a51_14_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-16.1.0-h85bc590_14_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-22_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-22_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.8.0-hf9fcc65_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-18.1.8-hef8daea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.20-h49d49c5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.2-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.9.1-hc21aedb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.80.3-h736d271_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.26.0-h721cda5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.26.0-h9e84e37_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.62.2-h384b2fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-h5ff76d1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libkml-1.3.0-hfcbc525_1020.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-22_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-hc8e404f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.2-nompi_h7334405_114.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.58.0-h64cf6d3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.27-openmp_h8869122_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-16.1.0-h904a336_14_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.43-h92b6c6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.3-h4501773_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.25.3-h4e4d658_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2023.09.01-h81f5012_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/librttopo-1.1.0-hf05f67e_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.18-hbcb3906_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libspatialite-5.1.0-h5579707_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.46.0-h1b8f9f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.19.0-h064b379_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h129831d_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.16-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.7-hc603aa4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzip-1.10.1-hc158999_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-h87427d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.8-h15ab845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.43.0-py311h6cc91e7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-4.3.3-py311hdfabcfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lzo-2.10-h10d778d_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.5-py311he705e18_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.1-py311hf31e254_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.0.7-h62b0c8d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.0.8-py311h46c8309_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/multidict-6.0.5-py311h5547dcb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h5846eda_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/netcdf4-1.7.1-nompi_py311ha7361b2_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/nspr-4.35-hea0b92c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/nss-3.102-he7eb89d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.60.0-py311h0e5bd6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numcodecs-0.12.1-py311hbafa61a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.0.0-py311hc11d9cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.1-h87427d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.1-hf43e91b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.2-py311hfdcbad3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.44-h7634a1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.4.0-py311h2755ac0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.4-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/poppler-24.04.0-h0face88_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/postgresql-16.3-h1d90168_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.4.0-hf92c781_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.0.0-py311h72ae277_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-16.1.0-py311he764780_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-16.1.0-py311h4d2d057_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.3.1-py311h9d23797_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.3.1-py311h9d23797_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.9.0-py311h4afbaa0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.6.1-py311hc55c11a_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.9-h657bba9_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-4_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.1-py311h2725bcf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.0.3-py311h89e2aaa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rasterio-1.3.10-py311h6fa6b3e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2023.09.01-hb168e87_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.19.0-py311h295b1db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.5.1-py311h3c3ac6d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.0-py311h40a1ab3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.4-py311h2a2259d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-he1e6707_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.13.0-h1a4aec9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.46.0-h28673e1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tiledb-2.24.2-h86b3714_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.1-py311h72ae277_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tzcode-2024a-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/uriparser-0.9.8-h6aefe2f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xerces-c-3.2.5-hbbe9ea5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yarl-1.9.4-py311he705e18_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-hde137ed_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-h87427d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py311h51fa951_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.7.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.6.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.12.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.12.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.0.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.0.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-xarray-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyarrow-hotfix-0.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-70.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20240316-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.18.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.9.5-py311h05b510d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311heffc1b2_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.22-h8a62e84_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.7.1-h94d0942_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.23-h99b78c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.18-h94d0942_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.4.2-hb74cd8f_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.8.2-had1507a_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.14.10-hcdb10ff_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.10.4-h856d8ab_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.6.0-ha9fd6de_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.16-h94d0942_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.18-h94d0942_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.27.3-h9d3339c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.329-he6360a2_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.12.0-hd01fc5c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.8.0-h0a11218_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.11.0-h77cc766_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.6.0-h7024f69_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.10.0-h64d02d0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h5499902_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311ha891d26_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.32.2-h99b78c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.7.4-hf0a4a13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hc6c324b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cartopy-0.23.0-py311h4b4568b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.16.0-py311h4a08483_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cfitsio-4.4.1-h793ed5c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.4-py311h5d790af_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.2.1-py311hcc98501_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-0.12.3-py311h05b510d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.2-py311hb9542d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.6.2-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-10.2.1-h2ffa867_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.14.2-h82840c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.53.1-py311hd3f4193_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-hfbad9fb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.4.1-py311h05b510d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.9.1-py311hac07d20_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.12.2-h00cdb27_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geotiff-1.7.3-h7e5fb84_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hc88da5d_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.3-nompi_hec07895_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/json-c-0.17-he54c16a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py311h267d04e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jupyter_core-5.7.2-py311h267d04e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kealib-1.5.3-h848a2d4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.5-py311he4fd1f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240116.2-cxx17_h00cdb27_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.7.4-h83d404f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-16.1.0-h2a00445_14_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-16.1.0-h00cdb27_14_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-16.1.0-h00cdb27_14_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-16.1.0-hc68f6b8_14_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-22_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-22_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.8.0-h7b6f9a7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-18.1.8-h167917d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.20-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.2-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-3.9.1-hce30654_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.9.1-hf00468f_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-fits-3.9.1-h7a7a030_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.9.1-hdd4b840_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.9.1-h94124bd_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.9.1-hf90b89a_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.9.1-h54bcb16_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-kea-3.9.1-hacb1b3e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.9.1-h1723b65_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-pdf-3.9.1-h4cf08c4_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-pg-3.9.1-h7d28298_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-postgisraster-3.9.1-h7d28298_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-tiledb-3.9.1-hbb20944_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-xls-3.9.1-hb39617b_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.80.3-h59d46d9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.26.0-hfe08963_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.26.0-h1466eeb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.62.2-h9c18a4f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.22.5-h8fbad5d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libkml-1.3.0-h00ed6cc_1020.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-22_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnetcdf-4.9.2-nompi_he469be0_114.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.58.0-ha4dd798_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.27-openmp_h517c56d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-16.1.0-hcf52c46_14_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.43-h091b4b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.3-h7afe498_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.25.3-hbfab5d5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2023.09.01-h7b2c953_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/librttopo-1.1.0-h31fb324_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.18-h27ca646_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libspatialite-5.1.0-hf7a34df_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.46.0-hfb93653_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.19.0-h026a170_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.6.0-h07db509_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-h1a8c8d9_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.16-hf2054a2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.7-h9a80f22_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzip-1.10.1-ha0bc3c6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-hfb2fe0b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.8-hde57baf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.43.0-py311h02e79e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-4.3.3-py311hd44b8e9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h93a5062_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.5-py311h05b510d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.9.1-py311hba6b155_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/minizip-4.0.7-h27ee973_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.0.8-py311h6bde47b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.0.5-py311he2be06e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-hb89a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/netcdf4-1.7.1-nompi_py311h42682c7_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.35-hb7217d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.102-hc42bcbf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.60.0-py311h9506ed5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numcodecs-0.12.1-py311hb9542d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.0.0-py311h4268184_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.1-hfb2fe0b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.1-h47ade37_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.2-py311h4b4568b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-h297a79d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.4.0-py311hd7951ec_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.4-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/poppler-24.07.0-h9787579_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/postgresql-16.3-hdfa2ec6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.4.1-hfb94cee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.0.0-py311hd3f4193_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-16.1.0-py311h35c05fe_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-16.1.0-py311hf5072a7_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.3.1-py311h5f135c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.3.1-py311h5f135c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.8.0-py311he661659_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.6.1-py311h5e0e26b_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.9-h932a869_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-4_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.1-py311heffc1b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.0.3-py311h9bed540_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rasterio-1.3.10-py311he66545a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2023.09.01-h4cba328_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.19.0-py311h98c6a39_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.5.1-py311hbfb48bc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.0-py311hceeca8c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.5-py311h0f19114_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/spdlog-1.13.0-h5fcca99_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.46.0-h5838104_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tiledb-2.24.2-h5def871_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.1-py311hd3f4193_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tzcode-2024a-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uriparser-0.9.8-h00cdb27_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xerces-c-3.2.5-hf393695_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.9.4-py311h05b510d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-hcc0f68c_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-hfb2fe0b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py311h4a6b76e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.7.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.6.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.12.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.12.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.0.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.0.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-xarray-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyarrow-hotfix-0.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-70.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20240316-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyhd8ed1ab_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.18.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.9.5-py311ha68e1ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311ha68e1ae_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.22-h8c86ca4_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.7.1-hea5f451_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.23-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.18-hea5f451_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.2-h4b8288a_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.2-h269d64e_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.10-hfca834b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.4-h519d897_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.6.0-hb746b11_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.16-hea5f451_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.18-hea5f451_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.27.3-h8c89294_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.329-he0aa860_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/azure-core-cpp-1.12.0-haf5610f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/azure-identity-cpp-1.8.0-h8578521_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/azure-storage-blobs-cpp-12.11.0-h39eb5e7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/azure-storage-common-cpp-12.6.0-h8578521_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.6-h85f69ea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311h12c1d0e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.32.2-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.7.4-h56e8100_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h91e5215_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cartopy-0.23.0-py311hcf9f919_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.16.0-py311ha68e1ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cfitsio-4.4.1-hc2ea260_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cftime-1.6.4-py311h0a17f05_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.2.1-py311h005e61a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-0.12.3-py311ha68e1ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.2-py311hda3d55a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/expat-2.6.2-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-10.2.1-h181d51b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.14.2-hbde0cde_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.53.1-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-h8276f4a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.4.1-py311ha68e1ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.9.1-py311h2711c7e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.12.2-h5a68840_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.3-hd7df778_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_h2b43c12_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/icu-73.2-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.0-h57928b3_980.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jupyter_core-5.7.2-py311h1ea47a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kealib-1.5.3-h6c43f9b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.5-py311h005e61a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240116.2-cxx17_he0c23c2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.7.4-haf234dc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-16.1.0-h11e6a32_14_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-16.1.0-he0c23c2_14_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-16.1.0-he0c23c2_14_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-16.1.0-h1f0e801_14_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-22_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-22_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.8.0-hd5e4a3a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.20-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.2-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.9.1-h57928b3_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.9.1-h7e31c53_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-fits-3.9.1-h0a0b71e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.9.1-hd2a089b_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.9.1-h430f241_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.9.1-had131a1_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.9.1-hed4c6cb_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-kea-3.9.1-h95b1a77_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.9.1-h55e78d3_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pdf-3.9.1-h261eb30_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pg-3.9.1-ha693a0f_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-postgisraster-3.9.1-ha693a0f_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-tiledb-3.9.1-h0c63b6b_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-xls-3.9.1-hd0e23a6_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.80.3-h7025463_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.26.0-h5e7cea3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.26.0-he5eb982_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.62.2-h5273850_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.1-default_h8125262_1000.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-h538826c_1020.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-22_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_h92078aa_114.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-16.1.0-h178134c_14_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.43-h19919ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpq-16.3-hab9416b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.25.3-h503648d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2023.09.01-hf8d8778_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-h6c42fcb_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.18-h8d14728_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-hcb35769_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.46.0-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.19.0-ha2b3283_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-hddb2be6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-h82a8f57_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.16-hcd874cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.7-h0f24e4e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzip-1.10.1-h1d365fa_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.43.0-py311h7deaa30_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-4.3.3-py311haddf500_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lzo-2.10-hcfcfb64_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.5-py311ha68e1ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.1-py311h8f1b1e4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/minizip-4.0.6-hb638d1e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.1.0-h66d3029_692.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.0.8-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.0.5-py311ha68e1ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/netcdf4-1.7.1-nompi_py311hbdc12eb_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.60.0-py311h0673bce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numcodecs-0.12.1-py311hda3d55a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.0.0-py311h35ffc71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.1-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.1-h7e885a9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.2-py311hcf9f919_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-10.4.0-py311h5592be9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/poppler-24.07.0-h686f694_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/postgresql-16.3-h7f155c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.4.1-hd9569ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.0.0-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-hcd874cb_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-16.1.0-py311h06a5be4_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-16.1.0-py311hf9a78b3_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.9.0-py311h2494c99_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.6.1-py311h93f6e28_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.9-h631f459_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-4_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-306-py311h12c1d0e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.13-py311h12c1d0e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.1-py311ha68e1ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.0.3-py311h484c95c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rasterio-1.3.10-py311hb019220_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2023.09.01-hd3b24a8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.19.0-py311h533ab2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.5.1-py311hdcb8d17_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.0-py311hd4686c6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.5-py311hf837ac7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.13.0-h64d2f7d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.46.0-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.12.0-hc790b64_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.24.2-h297c385_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.1-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h8a93ad2_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-ha82c5b3_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.2.5-he0c23c2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-hcd874cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.3-hcd874cb_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yarl-1.9.4-py311ha68e1ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-he1f189c_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py311h53056dc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  license: None
+  size: 2562
+  timestamp: 1578324546067
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23621
+  timestamp: 1650670423406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.9.5-py311h459d7ec_0.conda
+  sha256: 2eb99d920ef0dcd608e195bb852a64634ecf13f74680796959f1b9d9a9650a7b
+  md5: 0175d2636cc41dc019b51462c13ce225
+  depends:
+  - aiosignal >=1.1.2
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - libgcc-ng >=12
+  - multidict >=4.5,<7.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yarl >=1.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  size: 810945
+  timestamp: 1713965013081
+- conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311h459d7ec_4.conda
+  sha256: 104194af519b4e667aa5341068b94b521a791aaaa05ec0091f8f0bdba43a60ac
+  md5: de5b16869a430949b02161b04b844a30
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 34955
+  timestamp: 1695386703660
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.22-hbd3ac97_10.conda
+  sha256: c8bf9f9901a56a56b18ab044d67ecde69ee1289881267924dd81670ac34591fe
+  md5: 7ca4abcc98c7521c02f4e8809bbe40df
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-c-sdkutils >=0.1.16,<0.1.17.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 105990
+  timestamp: 1720943253516
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.7.1-h87b94db_1.conda
+  sha256: f445f38a4170f0ae02cdf13e1bc23cbb826a4b45f39402f02fe5737b0a8ed3a9
+  md5: 2d76d2cfdcfe2d5c3883d33d8be919e7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - libgcc-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 47092
+  timestamp: 1720901538926
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.23-h4ab18f5_0.conda
+  sha256: f3eab0ec3f01ddc3ebdc235d4ae1b3b803d83e40f2cd2389bf8c65ab96e90f02
+  md5: 94d61ae2b2b701008a9d52ce6bbead27
+  depends:
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 235612
+  timestamp: 1718918062664
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.18-he027950_7.conda
+  sha256: d4c70b8716e19fe56a563ab858ab7440f41c2dd927687357a44e69f23001126d
+  md5: 11e5cb0b426772974f6416545baee0ce
+  depends:
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 19271
+  timestamp: 1718967071890
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.2-h7671281_15.conda
+  sha256: b9546f0637c66d4086a169f4210bf0d569140f41c13f0c1c6826355f51f82494
+  md5: 3b45b0da170f515de8be68155e14955a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-checksums >=0.1.18,<0.1.19.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 54007
+  timestamp: 1720743896466
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.2-he17ee6b_6.conda
+  sha256: c2a9501d5e361051457b0afc3ce77496a73c2cf90ad859010812130d512e9271
+  md5: 4e3d1bb2ade85619ac2163e695c2cc1b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-compression >=0.2.18,<0.2.19.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 194638
+  timestamp: 1720753051593
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.10-h826b7d6_1.conda
+  sha256: 68cb6f708e5e1cf50d98f3c896c7a72ab68e71ce9a69be4eea5dbde5c04bebdc
+  md5: 6961646dded770513a781de4cd5c1fe1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - libgcc-ng >=12
+  - s2n >=1.4.17,<1.4.18.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 157925
+  timestamp: 1720718674802
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.4-hcd6a914_8.conda
+  sha256: aa6100ed16b1b6eabccca1ee5e36039862e37a7ee91c852de8d4ca0082dcd54e
+  md5: b81c45867558446640306507498b2c6b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 164233
+  timestamp: 1720751408585
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.6.0-h365ddd8_2.conda
+  sha256: 5f82835411b3db3ae9d5db575386d83a8cc6f5f61b414afa6155879b2071c2f6
+  md5: 22339cf124753bafda336167f80e7860
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-auth >=0.7.22,<0.7.23.0a0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-checksums >=0.1.18,<0.1.19.0a0
+  - libgcc-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 110393
+  timestamp: 1720949912044
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.16-he027950_3.conda
+  sha256: 0f957d8cebe9c9b4041c858ca9a20619eb3fa866c71b21478a02d51f219d59cb
+  md5: adbf0c44ca88a3cded175cd809a106b6
+  depends:
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 54943
+  timestamp: 1718973317061
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.18-he027950_7.conda
+  sha256: 094cff556dbf8fdd60505c8285b0a873de101374f568200275d8fd7fb77ad5e9
+  md5: 95611b325a9728ed68b8f7eef2dd3feb
+  depends:
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 50220
+  timestamp: 1718973002363
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.27.3-hda66527_2.conda
+  sha256: 3149277f03a55d7dcffdbe489863cacc36a831dbf38b9725bdc653a8c5de134f
+  md5: 734875312c8196feecc91f89856da612
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-auth >=0.7.22,<0.7.23.0a0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-event-stream >=0.4.2,<0.4.3.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-c-mqtt >=0.10.4,<0.10.5.0a0
+  - aws-c-s3 >=0.6.0,<0.6.1.0a0
+  - aws-c-sdkutils >=0.1.16,<0.1.17.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 345359
+  timestamp: 1720963443140
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.329-h46c3b66_9.conda
+  sha256: 983f6977cc6b25c8bc785b20859970009242b3812e6b4de592ceb17caf93acb6
+  md5: c840f07ec58dc0b06041e7f36550a539
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-event-stream >=0.4.2,<0.4.3.0a0
+  - aws-checksums >=0.1.18,<0.1.19.0a0
+  - aws-crt-cpp >=0.27.3,<0.27.4.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3619739
+  timestamp: 1720816476436
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.12.0-h830ed8b_0.conda
+  sha256: f76438c1f2a2c6142b344652c9fb93304cf1bb1534521f94c9c30fb9b238f0f5
+  md5: 320d066f9cad598854f4af32c7c82931
+  depends:
+  - libcurl >=8.7.1,<9.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.3.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 343309
+  timestamp: 1715352349052
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.8.0-hdb0d106_1.conda
+  sha256: 87420c137ae4d3e139cace9d9da8d63e6888d206f4eea0082975352d4ee65b14
+  md5: a297ffb4b505f51d0f58352c5c13971b
+  depends:
+  - azure-core-cpp >=1.12.0,<1.12.1.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 197711
+  timestamp: 1718986423496
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.11.0-ha67cba7_1.conda
+  sha256: 1dc694bcecdead2dbd871bb3abe5470c4473a7e46cfa39885aec70c230d3c16e
+  md5: f03bba57b85a5b3ac443a871787fc429
+  depends:
+  - azure-core-cpp >=1.12.0,<1.12.1.0a0
+  - azure-storage-common-cpp >=12.6.0,<12.6.1.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 522085
+  timestamp: 1718993907705
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.6.0-he3f277c_1.conda
+  sha256: 464c687ed110befb4099be88ea69d2d2fd039a428ab6d9575ac9bf88e932dd55
+  md5: 8a10bb068b138dd473300b5fe34a1865
+  depends:
+  - azure-core-cpp >=1.12.0,<1.12.1.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.12.7,<2.14.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 136709
+  timestamp: 1718986773861
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.10.0-h29b5301_1.conda
+  sha256: ef222289612266a7e60a968b16921ecf22845e6a8354133f61b6e9c376659c19
+  md5: bb35c23b178fc17b9e4458766f91da7f
+  depends:
+  - azure-core-cpp >=1.12.0,<1.12.1.0a0
+  - azure-storage-blobs-cpp >=12.11.0,<12.11.1.0a0
+  - azure-storage-common-cpp >=12.6.0,<12.6.1.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 275723
+  timestamp: 1719000071367
+- conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-hef167b5_0.conda
+  sha256: 6cc260f9c6d32c5e728a2099a52fdd7ee69a782fff7b400d0606fcd32e0f5fd1
+  md5: 54fe76ab3d0189acaef95156874db7f9
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48842
+  timestamp: 1719266029046
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hd590300_1.conda
+  sha256: f2d918d351edd06c55a6c2d84b488fe392f85ea018ff227daac07db22b408f6b
+  md5: f27a24d46e3ea7b70a1f98e50c62508f
+  depends:
+  - brotli-bin 1.1.0 hd590300_1
+  - libbrotlidec 1.1.0 hd590300_1
+  - libbrotlienc 1.1.0 hd590300_1
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 19383
+  timestamp: 1695990069230
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hd590300_1.conda
+  sha256: a641abfbaec54f454c8434061fffa7fdaa9c695e8a5a400ed96b4f07c0c00677
+  md5: 39f910d205726805a958da408ca194ba
+  depends:
+  - libbrotlidec 1.1.0 hd590300_1
+  - libbrotlienc 1.1.0 hd590300_1
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 18980
+  timestamp: 1695990054140
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hb755f60_1.conda
+  sha256: 559093679e9fdb6061b7b80ca0f9a31fe6ffc213f1dae65bc5c82e2cd1a94107
+  md5: cce9e7c3f1c307f2a5fb08a2922d6164
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 hd590300_1
+  license: MIT
+  license_family: MIT
+  size: 351340
+  timestamp: 1695990160360
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+  sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
+  md5: 62ee74e96c5ebb0af99386de58cf9553
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 252783
+  timestamp: 1720974456583
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.32.2-h4bc722e_0.conda
+  sha256: d1b01f9e3d10b97fd09e19fda0caf9bfad3c884a6b19fb3f654a9aed02a70b58
+  md5: 8024af1ee7078e37fa3101c0a0296af2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 179740
+  timestamp: 1721065841233
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.7.4-hbcca054_0.conda
+  sha256: c1548a3235376f464f9931850b64b02492f379b2f2bb98bc786055329b080446
+  md5: 23ab7665c5f63cfb9f1f6195256daac6
+  license: ISC
+  size: 154853
+  timestamp: 1720077432978
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hbb29018_2.conda
+  sha256: 51cfaf4669ad83499b3da215b915c503d36faf6edf6db4681a70b5710842a86c
+  md5: b6d90276c5aee9b4407dd94eb0cd40a8
+  depends:
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=73.2,<74.0a0
+  - libgcc-ng >=12
+  - libglib >=2.80.2,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.2,<1.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 984224
+  timestamp: 1718985592664
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.23.0-py311h14de704_1.conda
+  sha256: 22d1ea507cfa9e0b0314bd11b1a2bee1565a47005e254816358532e22a48626b
+  md5: 27e5956e552c6e71f56cb1ec042617a8
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - matplotlib-base >=3.5
+  - numpy >=1.19,<3
+  - packaging >=20
+  - pyproj >=3.3.1
+  - pyshp >=2.3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - shapely >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1531526
+  timestamp: 1715897588328
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py311hb3a22ac_0.conda
+  sha256: b71c94528ca0c35133da4b7ef69b51a0b55eeee570376057f3d2ad60c3ab1444
+  md5: b3469563ac5e808b0cd92810d0697043
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 300207
+  timestamp: 1696001873452
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.4.1-hf8ad068_0.conda
+  sha256: 74ed4d8b327fa775d9c87e476a7221b74fb913aadcef207622596a99683c8faf
+  md5: 1b7a01fd02d11efe0eb5a676842a7b7d
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  - libzlib >=1.3.1,<2.0a0
+  license: LicenseRef-fitsio
+  size: 924198
+  timestamp: 1718906379286
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.4-py311h18e1886_0.conda
+  sha256: bc3784d8622bab058c2a76ded90559e8acf19cea2768bc2bcac5e525890647b0
+  md5: 0eb1e6c7d10285ec12e01f73d1896d93
+  depends:
+  - libgcc-ng >=12
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 250491
+  timestamp: 1718096595206
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.2.1-py311h9547e67_0.conda
+  sha256: 82cec326aa81b9b6b40d9f4dab5045f0553092405efd0de9d2daf71179f20607
+  md5: 74ad0ae64f1ef565e27eda87fa749e84
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.20
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 258932
+  timestamp: 1712430087609
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-0.12.3-py311h459d7ec_0.conda
+  sha256: 1c05863330af1c1af9fcd721170fe50a42757b60e32f35933edd96e97bc188bd
+  md5: 13d385f635d7fbe9acc93600f67a6cb4
+  depends:
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 395711
+  timestamp: 1706897222426
+- conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.2-py311h4332511_0.conda
+  sha256: e2db26eab0c42553287acdb1e34d88f144e14fa04be6b0e986e05e7b4deb8bd6
+  md5: 22beed609083cfd67ea057020117894f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2303586
+  timestamp: 1719378778171
+- conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.2-h59595ed_0.conda
+  sha256: 89916c536ae5b85bb8bf0cfa27d751e274ea0911f04e4a928744735c14ef5155
+  md5: 53fb86322bdb89496d7579fe3f02fd61
+  depends:
+  - libexpat 2.6.2 h59595ed_0
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 137627
+  timestamp: 1710362144873
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-10.2.1-h00ab1b0_0.conda
+  sha256: 7b9ba098a3661e023c3555e01554354ac4891af8f8998e85f0fcbfdac79fc0d4
+  md5: 35ef8bc24bd34074ebae3c943d551728
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 193853
+  timestamp: 1704454679950
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
+  sha256: 155d534c9037347ea7439a2c6da7c24ffec8e5dd278889b4c57274a1d91e0a83
+  md5: 0f69b688f52ff6da70bccb7ff7001d1d
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libgcc-ng >=12
+  - libuuid >=2.32.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 272010
+  timestamp: 1674828850194
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.53.1-py311h61187de_0.conda
+  sha256: 4d12e34631e2a883fdf723617fd338b35b0a5cc901fe110c6642cdd03524abb6
+  md5: bcbe6c9db1c25900c3808b8974e1bb90
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli
+  - libgcc-ng >=12
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2906675
+  timestamp: 1720359181737
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+  sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
+  md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 634972
+  timestamp: 1694615932610
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h743c826_0.conda
+  sha256: 9213f60ba710ecfd3632ce47e036775c9f15ce80a6682ff63cbf12d9dddd5382
+  md5: 12e6988845706b2cfbc3bc35c9a61a95
+  depends:
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - minizip >=4.0.1,<5.0a0
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 59769
+  timestamp: 1694952692595
+- conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.4.1-py311h459d7ec_0.conda
+  sha256: 56917dda8da109d51a3b25d30256365e1676f7b2fbaf793a3f003e51548bf794
+  md5: b267e553a337e1878512621e374845c5
+  depends:
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 60669
+  timestamp: 1702645612671
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.9.1-py311h4a2bcd2_7.conda
+  sha256: cda3e838773fc1498df67f676626f72193691f23f2d5d115c19403db01dbb14f
+  md5: 7d19ea8cc5af0c87610762aaba932e3a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libgdal-core 3.9.1.*
+  - libkml >=1.3.0,<1.4.0a0
+  - libstdcxx-ng >=12
+  - libxml2 >=2.12.7,<2.14.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 1716143
+  timestamp: 1720823188942
+- conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.12.2-hac33072_0.conda
+  sha256: 8ccddcf6263f972122d2ea7388b881194dcd9bc8e1092b4440b7a7572c65b226
+  md5: 621d814955342209dc8e7f87c41f1ba0
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LGPL-2.1-only
+  size: 1737620
+  timestamp: 1717689194737
+- conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.3-hf7fa9e8_1.conda
+  sha256: df00139c22b1b2ab1e1e48bb94c68febcc40a7ca812bd4f228a3e09ac9d2cdf2
+  md5: 8ff4fa3ab0b63dc5b214a68839499e41
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.4.0,<9.5.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 131934
+  timestamp: 1717777012441
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-he1b5a44_1004.tar.bz2
+  sha256: a853c0cacf53cfc59e1bca8d6e5cdfe9f38fce836f08c2a69e35429c2a492e77
+  md5: cddaf2c63ea4a5901cf09524c490ecdc
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116549
+  timestamp: 1594303828933
+- conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+  sha256: aac402a8298f0c0cc528664249170372ef6b37ac39fdc92b40601a6aed1e32ff
+  md5: 3bf7b9fd5a7136126e0234db4b87c8b6
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 77248
+  timestamp: 1712692454246
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
+  sha256: dc824dc1d0aa358e28da2ecbbb9f03d932d976c8dca11214aa1dcdfcbd054ba2
+  md5: ff862eebdfeb2fd048ae9dc92510baca
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 143452
+  timestamp: 1718284177264
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
+  sha256: 0d09b6dc1ce5c4005ae1c6a19dc10767932ef9a5e9c755cfdbb5189ac8fb0684
+  md5: bd77f8da987968ec3927990495dc22e4
+  depends:
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 756742
+  timestamp: 1695661547874
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_hdf9ad27_105.conda
+  sha256: 2278fa07da6f96e807d402cd55480624d67d2dee202191aaaf278ce5ab23605a
+  md5: 7e1729554e209627636a0f6fabcdd115
+  depends:
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3911675
+  timestamp: 1717587866574
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
+  sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
+  md5: cc47e1facc155f91abd89b11e48e72ff
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 12089150
+  timestamp: 1692900650789
+- conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.17-h1220068_1.conda
+  sha256: 0caf06ccfbd6f9a7b3a1e09fa83e318c9e84f2d1c1003a9e486f2600f4096720
+  md5: f8f0f0c4338bad5c34a4e9e11460481d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 83682
+  timestamp: 1720812978049
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_0.conda
+  sha256: 30a3947da86b74e09b1013d232f40b4b960c192b7dce35407e89b10e3e28cdc7
+  md5: 01a505ab9b4e3af12baa98b82f5fcafa
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17919
+  timestamp: 1718283458583
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-5.7.2-py311h38be061_0.conda
+  sha256: 49834d76e70d6461e19c265296b0f492578f63360d0e4799b06bbe2c0d018a7a
+  md5: f85e78497dfed6f6a4b865191f42de2e
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 95226
+  timestamp: 1710257482063
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kealib-1.5.3-hee9dde6_1.conda
+  sha256: d607ddb5906a335cb3665dd81f3adec4af248cf398147693b470b65d887408e7
+  md5: c5b7b29e2b66107553d0366538257a51
+  depends:
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 170709
+  timestamp: 1716158265533
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+  sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
+  md5: 30186d27e2c9fa62b45fb1476b7200e3
+  depends:
+  - libgcc-ng >=10.3.0
+  license: LGPL-2.1-or-later
+  size: 117831
+  timestamp: 1646151697040
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.5-py311h9547e67_1.conda
+  sha256: 723b0894d2d2b05a38f9c5a285d5a0a5baa27235ceab6531dbf262ba7c6955c1
+  md5: 2c65bdf442b0d37aad080c8a4e0d452f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73273
+  timestamp: 1695380140676
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+  sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
+  md5: 3f43953b7d3fb3aaa1d0d0723d91e368
+  depends:
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1370023
+  timestamp: 1719463201255
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+  sha256: 5c878d104b461b7ef922abe6320711c0d01772f4cd55de18b674f88547870041
+  md5: 51bb7010fc86f70eee639b4bb7a894f5
+  depends:
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 245247
+  timestamp: 1701647787198
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-hf3520f5_7.conda
+  sha256: 764b6950aceaaad0c67ef925417594dd14cd2e22fff864aeef455ac259263d15
+  md5: b80f2f396ca2c28b8c14c437a4ed1e74
+  constrains:
+  - binutils_impl_linux-64 2.40
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 707602
+  timestamp: 1718625640445
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+  sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
+  md5: 76bbff344f0134279f225174e9064c8f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 281798
+  timestamp: 1657977462600
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240116.2-cxx17_he02047a_1.conda
+  sha256: 945396726cadae174a661ce006e3f74d71dbd719219faf7cc74696b267f7b0b5
+  md5: c48fc56ec03229f294176923c3265c05
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  constrains:
+  - abseil-cpp =20240116.2
+  - libabseil-static =20240116.2=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1264712
+  timestamp: 1720857377573
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
+  sha256: 2ef420a655528bca9d269086cf33b7e90d2f54ad941b437fb1ed5eca87cee017
+  md5: 5e97e271911b8b2001a8b71860c32faa
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 35446
+  timestamp: 1711021212685
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.4-hfca40fe_0.conda
+  sha256: c30970e5e6515c662d00bb74e7c1b09ebe0c8c92c772b952a41a5725e2dcc936
+  md5: 32ddb97f897740641d8d46a829ce1704
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - lzo >=2.10,<3.0a0
+  - openssl >=3.3.0,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 871853
+  timestamp: 1716394516418
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-16.1.0-h34456a7_14_cpu.conda
+  sha256: 9cf9fd5430432fe5f3cc15081c1d9edbdbf1d086c83803c6735d7b57b4ca07a9
+  md5: 9f76c33cbcbacc87a9555da65713681c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-crt-cpp >=0.27.3,<0.27.4.0a0
+  - aws-sdk-cpp >=1.11.329,<1.11.330.0a0
+  - azure-core-cpp >=1.12.0,<1.12.1.0a0
+  - azure-identity-cpp >=1.8.0,<1.8.1.0a0
+  - azure-storage-blobs-cpp >=12.11.0,<12.11.1.0a0
+  - azure-storage-files-datalake-cpp >=12.10.0,<12.10.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libgcc-ng >=12
+  - libgoogle-cloud >=2.26.0,<2.27.0a0
+  - libgoogle-cloud-storage >=2.26.0,<2.27.0a0
+  - libre2-11 >=2023.9.1
+  - libstdcxx-ng >=12
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.1,<2.0.2.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  - libutf8proc <2.9
+  constrains:
+  - arrow-cpp <0.0a0
+  - parquet-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 8354505
+  timestamp: 1720852882382
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-16.1.0-he02047a_14_cpu.conda
+  sha256: b848ee86f1b952cb0d9c18d50e794ea0e5de27ef4201e1faa439e35152cdb401
+  md5: 491c2677e91ada55bfe283dbd14d1aac
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 16.1.0 h34456a7_14_cpu
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: APACHE
+  size: 599314
+  timestamp: 1720852925695
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-16.1.0-he02047a_14_cpu.conda
+  sha256: d170ef3cb2c339efd2385018703e41af924b4d6584e200b83f01c4e486c721dc
+  md5: 4381fff40c7bcf7ca0142ed4b0120dbc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 16.1.0 h34456a7_14_cpu
+  - libarrow-acero 16.1.0 he02047a_14_cpu
+  - libgcc-ng >=12
+  - libparquet 16.1.0 h9e5060d_14_cpu
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: APACHE
+  size: 579282
+  timestamp: 1720853013890
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-16.1.0-hc9a23c6_14_cpu.conda
+  sha256: 8fedad37852c554148f4b93d63bf982d21c9bae397e64d5a30e7cdb886740fa0
+  md5: c35b4b76394d7414888fd4d66d7ae96a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libarrow 16.1.0 h34456a7_14_cpu
+  - libarrow-acero 16.1.0 he02047a_14_cpu
+  - libarrow-dataset 16.1.0 he02047a_14_cpu
+  - libgcc-ng >=12
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: APACHE
+  size: 548600
+  timestamp: 1720853055532
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-22_linux64_openblas.conda
+  sha256: 082b8ac20d43a7bbcdc28b3b1cd40e4df3a8b5daf0a2d23d68953a44d2d12c1b
+  md5: 1a2a0cd3153464fee6646f3dd6dad9b8
+  depends:
+  - libopenblas >=0.3.27,<0.3.28.0a0
+  - libopenblas >=0.3.27,<1.0a0
+  constrains:
+  - libcblas 3.9.0 22_linux64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 22_linux64_openblas
+  - liblapack 3.9.0 22_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14537
+  timestamp: 1712542250081
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
+  sha256: 40f29d1fab92c847b083739af86ad2f36d8154008cf99b64194e4705a1725d78
+  md5: aec6c91c7371c26392a06708a73c70e5
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 69403
+  timestamp: 1695990007212
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
+  sha256: 86fc861246fbe5ad85c1b6b3882aaffc89590a48b42d794d3d5c8e6d99e5f926
+  md5: f07002e225d7a60a694d42a7bf5ff53f
+  depends:
+  - libbrotlicommon 1.1.0 hd590300_1
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 32775
+  timestamp: 1695990022788
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
+  sha256: f751b8b1c4754a2a8dfdc3b4040fa7818f35bbf6b10e905a47d3a194b746b071
+  md5: 5fc11c6020d421960607d821310fcd4d
+  depends:
+  - libbrotlicommon 1.1.0 hd590300_1
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 282523
+  timestamp: 1695990038302
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-22_linux64_openblas.conda
+  sha256: da1b2faa017663c8f5555c1c5518e96ac4cd8e0be2a673c1c9e2cb8507c8fe46
+  md5: 4b31699e0ec5de64d5896e580389c9a1
+  depends:
+  - libblas 3.9.0 22_linux64_openblas
+  constrains:
+  - liblapack 3.9.0 22_linux64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 22_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14438
+  timestamp: 1712542270166
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+  sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
+  md5: c965a5aa0d5c1c37ffc62dff36e28400
+  depends:
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20440
+  timestamp: 1633683576494
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.8.0-hca28451_1.conda
+  sha256: 6b5b64cdcdb643368ebe236de07eedee99b025bb95129bbe317c46e5bdc693f3
+  md5: b8afb3e3cb3423cc445cf611ab95fdb0
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc-ng >=12
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 410158
+  timestamp: 1719602718702
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.20-hd590300_0.conda
+  sha256: f8e0f25c382b1d0b87a9b03887a34dbd91485453f1ea991fef726dba57373612
+  md5: 8e88f9389f1165d7c0936fe40d9a9a79
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 71500
+  timestamp: 1711196523408
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+  sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
+  md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 123878
+  timestamp: 1597616541093
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+  md5: 172bf1cd1ff8629f2b1179945ed45055
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 112766
+  timestamp: 1702146165126
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+  sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
+  md5: a1cfcc585f0c42bf8d5546bb1dfb668d
+  depends:
+  - libgcc-ng >=12
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 427426
+  timestamp: 1685725977222
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
+  sha256: 331bb7c7c05025343ebd79f86ae612b9e1e74d2687b8f3179faec234f986ce19
+  md5: e7ba12deb7020dd080c6c70e7b6f6a3d
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - expat 2.6.2.*
+  license: MIT
+  license_family: MIT
+  size: 73730
+  timestamp: 1710362120304
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+  sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+  md5: d645c6d2ac96843a2bfaccd2d62b3ac3
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 58292
+  timestamp: 1636488182923
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.1.0-h77fa898_0.conda
+  sha256: b8e869ac96591cda2704bf7e77a301025e405227791a0bddf14a3dac65125538
+  md5: ca0fad6a41ddaef54a153b78eccb5037
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 14.1.0 h77fa898_0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 842109
+  timestamp: 1719538896937
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.9.1-ha770c72_7.conda
+  sha256: 07b842ebcb5278dad849d964a855b2f05b0393d702109b3cc90af0f6b8c0dca8
+  md5: d077b243089f0bf40ce8d81981349cda
+  depends:
+  - libgdal-core 3.9.1.*
+  - libgdal-fits 3.9.1.*
+  - libgdal-grib 3.9.1.*
+  - libgdal-hdf4 3.9.1.*
+  - libgdal-hdf5 3.9.1.*
+  - libgdal-jp2openjpeg 3.9.1.*
+  - libgdal-kea 3.9.1.*
+  - libgdal-netcdf 3.9.1.*
+  - libgdal-pdf 3.9.1.*
+  - libgdal-pg 3.9.1.*
+  - libgdal-postgisraster 3.9.1.*
+  - libgdal-tiledb 3.9.1.*
+  - libgdal-xls 3.9.1.*
+  license: MIT
+  license_family: MIT
+  size: 421636
+  timestamp: 1720824592243
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.9.1-h1d1841c_7.conda
+  sha256: 62296ded701499cf64c72c7bb1ab690754a50464cc3cd8124d57f9012c6b2d34
+  md5: 85fcff96b59d3e3a812601d713931d4f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.12.2,<3.12.3.0a0
+  - geotiff >=1.7.3,<1.8.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - json-c >=0.17,<0.18.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libarchive >=3.7.4,<3.8.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libdeflate >=1.20,<1.26.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.46.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.8.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.3.1,<4.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - proj >=9.4.1,<9.5.0a0
+  - xerces-c >=3.2.5,<3.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - libgdal 3.9.1.*
+  license: MIT
+  license_family: MIT
+  size: 10211065
+  timestamp: 1720823013713
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-fits-3.9.1-hdd6600c_7.conda
+  sha256: 577f3c4a8d2ff54a3b220da75f05f387251c85de6e15e28f293fe7429987619f
+  md5: 114cd0cf835b0b396ff90a7e428ec832
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cfitsio >=4.4.1,<4.4.2.0a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 475780
+  timestamp: 1720823927868
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.9.1-h5f34788_7.conda
+  sha256: 0f5787081cca5eab3cb12aef4f1f65ebebb1194a3abcc21b9f2195057ce006d9
+  md5: 7a40a828cc1a4a24050b0ad76c603c21
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libaec >=1.1.3,<2.0a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 720178
+  timestamp: 1720823986482
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.9.1-ha39a594_7.conda
+  sha256: 1798533ccb4fef5945ac3373453d38aba3ab10cd042f77ca735aee39a5370d73
+  md5: 1e84b86bbbcc9ba7bf978cd941fc96f1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 576128
+  timestamp: 1720824041701
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.9.1-ha2ed5f0_7.conda
+  sha256: ff6a4e04a2b2c2ab124a9aecba48b5fa44912e96676c66a020195b352fbecc71
+  md5: ffd276b53ef7fb95e0f391b1e21b7918
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 638985
+  timestamp: 1720824107188
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.9.1-h2ebfdf0_7.conda
+  sha256: ef56a9bef1377da99addf10deb4517bfebf432cc86609aa94c6d13de8222d270
+  md5: 59a91c96e5036c64413da8bacbd7537a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libstdcxx-ng >=12
+  - openjpeg >=2.5.2,<3.0a0
+  license: MIT
+  license_family: MIT
+  size: 467567
+  timestamp: 1720824155262
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-kea-3.9.1-h2b45729_7.conda
+  sha256: ed626007b5a5e8f4f3a85c1aaacdb5f32d85f5d2c95fafd8192ad8c9e8363e8c
+  md5: ee8bf923231d382e59270912fe27c719
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - kealib >=1.5.3,<1.6.0a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libgdal-hdf5 3.9.1.*
+  - libkml >=1.3.0,<1.4.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 479580
+  timestamp: 1720824514873
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.9.1-h94e7027_7.conda
+  sha256: 0416d377b17656aed0a47356f93d99305e1c24cdfc8f06935b8079f7d3a141db
+  md5: 1cfe8f3c7942f8054995b9071d8508b5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libgdal-hdf4 3.9.1.*
+  - libgdal-hdf5 3.9.1.*
+  - libkml >=1.3.0,<1.4.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 731425
+  timestamp: 1720824586425
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pdf-3.9.1-h562c687_7.conda
+  sha256: f2bf28e626c4c1d4b9810670f08534fce8e1a0aa7d452539fb3202361a45f49a
+  md5: 75b565ed397359019a106a51e6ad909e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libstdcxx-ng >=12
+  - poppler >=24.7.0,<24.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 663531
+  timestamp: 1720824226937
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pg-3.9.1-he047751_7.conda
+  sha256: 2648c011d8247b46a86f75a48281c9863a9080301105b1c832a584c906f887da
+  md5: 1cd7a1b13dabf9cc8a6911679938345f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libpq >=16.3,<17.0a0
+  - libstdcxx-ng >=12
+  - postgresql
+  license: MIT
+  license_family: MIT
+  size: 524494
+  timestamp: 1720824282866
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-postgisraster-3.9.1-he047751_7.conda
+  sha256: 8ef3ff24194d7ed5d6bfb1079f5e62e6b5e0d9845dcb06f6b604f8a358e51f1c
+  md5: 8e7addc813d9499ed2b554925bcb655a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libpq >=16.3,<17.0a0
+  - libstdcxx-ng >=12
+  - postgresql
+  license: MIT
+  license_family: MIT
+  size: 478442
+  timestamp: 1720824334321
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-tiledb-3.9.1-hfcb00c0_7.conda
+  sha256: aa269ce0bef56bf5baf07bca73fda069c512b2f950c1c14b0b038ff209cab082
+  md5: d8f858536ce539f884b7eeff249a13b2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libstdcxx-ng >=12
+  - tiledb >=2.24.2,<2.25.0a0
+  license: MIT
+  license_family: MIT
+  size: 670916
+  timestamp: 1720824412046
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-xls-3.9.1-h062f1c4_7.conda
+  sha256: a9f213030b907c87910b2d0f3641c67feced05fa19a0c922e8f89f1870732786
+  md5: 443029b63038425649158dfa3678b54d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freexl >=2.0.0,<3.0a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 433730
+  timestamp: 1720824460026
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.1.0-h69a702a_0.conda
+  sha256: ef624dacacf97b2b0af39110b36e2fd3e39e358a1a6b7b21b85c9ac22d8ffed9
+  md5: f4ca84fbd6d06b0a052fb2d5b96dde41
+  depends:
+  - libgfortran5 14.1.0 hc5f4f2c_0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 49893
+  timestamp: 1719538933879
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.1.0-hc5f4f2c_0.conda
+  sha256: a67d66b1e60a8a9a9e4440cee627c959acb4810cb182e089a4b0729bfdfbdf90
+  md5: 6456c2620c990cd8dde2428a27ba0bc5
+  depends:
+  - libgcc-ng >=14.1.0
+  constrains:
+  - libgfortran-ng 14.1.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1457561
+  timestamp: 1719538909168
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.3-h8a4344b_1.conda
+  sha256: 5f5854a7cee117d115009d8f22a70d5f9e28f09cb6e453e8f1dd712e354ecec9
+  md5: 6ea440297aacee4893f02ad759e6ffbc
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  constrains:
+  - glib 2.80.3 *_1
+  license: LGPL-2.1-or-later
+  size: 3886207
+  timestamp: 1720334852370
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.1.0-h77fa898_0.conda
+  sha256: 7699df61a1f6c644b3576a40f54791561f2845983120477a16116b951c9cdb05
+  md5: ae061a5ed5f05818acdf9adab72c146d
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 456925
+  timestamp: 1719538796073
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.26.0-h26d7fe4_0.conda
+  sha256: c6caa2d4c375c6c5718e6223bb20ccf6305313c0fef2a66499b4f6cdaa299635
+  md5: 7b9d4c93870fb2d644168071d4d76afb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libgcc-ng >=12
+  - libgrpc >=1.62.2,<1.63.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  constrains:
+  - libgoogle-cloud 2.26.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1223584
+  timestamp: 1719889637602
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.26.0-ha262f82_0.conda
+  sha256: 7c16bf2e5aa6b5e42450c218fdfa7d5ff1da952c5a5c821c001ab3fd940c2aed
+  md5: 89b53708fd67762b26c38c8ecc5d323d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libgcc-ng >=12
+  - libgoogle-cloud 2.26.0 h26d7fe4_0
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  size: 764005
+  timestamp: 1719889827732
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.62.2-h15f2491_0.conda
+  sha256: 28241ed89335871db33cb6010e9ccb2d9e9b6bb444ddf6884f02f0857363c06a
+  md5: 8dabe607748cb3d7002ad73cd06f1325
+  depends:
+  - c-ares >=1.28.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.1,<20240117.0a0
+  - libgcc-ng >=12
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libre2-11 >=2023.9.1
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.2.1,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.62.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 7316832
+  timestamp: 1713390645548
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+  sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
+  md5: d66573916ffcf376178462f1b61c941e
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  size: 705775
+  timestamp: 1702682170569
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+  sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
+  md5: ea25936bb4080d843790b586850f82b8
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 618575
+  timestamp: 1694474974816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-hbbc8833_1020.conda
+  sha256: 5bd19933cb3790ec8632c11fa67c25d82654bea6c2bc4f51f8bcd8b122ae96c8
+  md5: 6d76c5822cb38bc1ab5a06565c6cf626
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libexpat >=2.6.2,<3.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  - uriparser >=0.9.8,<1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 395723
+  timestamp: 1720690222714
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-22_linux64_openblas.conda
+  sha256: db246341d42f9100d45adeb1a7ba8b1ef5b51ceb9056fd643e98046a3259fde6
+  md5: b083767b6c877e24ee597d93b87ab838
+  depends:
+  - libblas 3.9.0 22_linux64_openblas
+  constrains:
+  - libcblas 3.9.0 22_linux64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 22_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14471
+  timestamp: 1712542277696
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
+  sha256: 225cc7c3b20ac1db1bdb37fa18c95bf8aecef4388e984ab2f7540a9f4382106a
+  md5: 73301c133ded2bf71906aa2104edae8b
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 31484415
+  timestamp: 1690557554081
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h135f659_114.conda
+  sha256: 055572a4c8a1c3f9ac60071ee678f5ea49cfd7ac60a636d817988a6f9d6de6ae
+  md5: a908e463c710bd6b10a9eaa89fdf003c
+  depends:
+  - blosc >=1.21.5,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzip >=1.10.1,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - zlib
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 849172
+  timestamp: 1717671645362
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
+  sha256: 1910c5306c6aa5bcbd623c3c930c440e9c77a5a019008e1487810e3c1d3716cb
+  md5: 700ac6ea6d53d5510591c4344d5c989a
+  depends:
+  - c-ares >=1.23.0,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.2.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 631936
+  timestamp: 1702130036271
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+  sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+  md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  license_family: GPL
+  size: 33408
+  timestamp: 1697359010159
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.27-pthreads_hac2b453_1.conda
+  sha256: 714cb82d7c4620ea2635a92d3df263ab841676c9b183d0c01992767bb2451c39
+  md5: ae05ece66d3924ac3d48b4aa3fa96cec
+  depends:
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  constrains:
+  - openblas >=0.3.27,<0.3.28.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5563053
+  timestamp: 1720426334043
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-16.1.0-h9e5060d_14_cpu.conda
+  sha256: a9d5f1fb34dca50c4786c36083db86b87ddaf6c3fde0285f78bddc84f924fb8e
+  md5: 9fc891cd8f6bd24ba3db2c12fd1528e9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 16.1.0 h34456a7_14_cpu
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libthrift >=0.19.0,<0.19.1.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 1182840
+  timestamp: 1720852992449
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
+  sha256: 502f6ff148ac2777cc55ae4ade01a8fc3543b4ffab25c4e0eaa15f94e90dd997
+  md5: 009981dd9cfcaa4dbfa25ffaed86bcae
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: zlib-acknowledgement
+  size: 288221
+  timestamp: 1708780443939
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.3-ha72fbe1_0.conda
+  sha256: 117ba1e11f07b1ca0671641bd6d1f2e7fc6e27db1c317a0cdb4799ffa69f47db
+  md5: bac737ae28b79cfbafd515258d97d29e
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libgcc-ng >=12
+  - openssl >=3.3.0,<4.0a0
+  license: PostgreSQL
+  size: 2500439
+  timestamp: 1715266400833
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.3-h08a7969_0.conda
+  sha256: 70e0eef046033af2e8d21251a785563ad738ed5281c74e21c31c457780845dcd
+  md5: 6945825cebd2aeb16af4c69d97c32c13
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.1,<20240117.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2811207
+  timestamp: 1709514552541
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.09.01-h5a48ba9_2.conda
+  sha256: 3f3c65fe0e9e328b4c1ebc2b622727cef3e5b81b18228cfa6cf0955bc1ed8eff
+  md5: 41c69fba59d495e8cf5ffda48a607e35
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.1,<20240117.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  constrains:
+  - re2 2023.09.01.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 232603
+  timestamp: 1708946763521
+- conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-hc670b87_16.conda
+  sha256: 65bfd9f8915b1fc2523c58bf556dc2b9ed6127b7c6877ed2841c67b717f6f924
+  md5: 3d9f3a2e5d7213c34997e4464d2f938c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - geos >=3.12.2,<3.12.3.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 231637
+  timestamp: 1720347750456
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
+  sha256: 53da0c8b79659df7b53eebdb80783503ce72fb4b10ed6e9e05cc0e9e4207a130
+  md5: c3788462a6fbddafdb413a9f9053e58d
+  depends:
+  - libgcc-ng >=7.5.0
+  license: ISC
+  size: 374999
+  timestamp: 1605135674116
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h15fa968_8.conda
+  sha256: ba7a298eb6e101ad4c3769c84f0d635c34e677a1879064f41e82598f0a0f5696
+  md5: 48502f34f5ba86c1ce192cb30f959dc9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freexl >=2
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.12.2,<3.12.3.0a0
+  - libgcc-ng >=12
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.46.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.4.1,<9.5.0a0
+  - sqlite
+  - zlib
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 3494258
+  timestamp: 1720363665050
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.0-hde9e2c9_0.conda
+  sha256: daee3f68786231dad457d0dfde3f7f1f9a7f2018adabdbb864226775101341a8
+  md5: 18aa975d2094c34aef978060ae7da7d8
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0a0
+  license: Unlicense
+  size: 865346
+  timestamp: 1718050628718
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+  sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
+  md5: 1f5a58e686b13bcfde88b93f547d23fe
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 271133
+  timestamp: 1685837707056
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.1.0-hc0a3c3a_0.conda
+  sha256: 88c42b388202ffe16adaa337e36cf5022c63cf09b0405cf06fc6aeacccbe6146
+  md5: 1cb187a157136398ddbaae90713e2498
+  depends:
+  - libgcc-ng 14.1.0 h77fa898_0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3881307
+  timestamp: 1719538923443
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.19.0-hb90f79a_1.conda
+  sha256: 719add2cf20d144ef9962c57cd0f77178259bdb3aae1cded2e2b2b7c646092f5
+  md5: 8cdb7d41faa0260875ba92414c487e2d
+  depends:
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 409409
+  timestamp: 1695958011498
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-h1dd3fc0_3.conda
+  sha256: fc3b210f9584a92793c07396cb93e72265ff3f1fa7ca629128bf0a50d5cb15e4
+  md5: 66f03896ffbe1a110ffda05c7a856504
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.20,<1.26.0a0
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: HPND
+  size: 282688
+  timestamp: 1711217970425
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
+  sha256: 49082ee8d01339b225f7f8c60f32a2a2c05fe3b16f31b554b4fb2c1dea237d1c
+  md5: ede4266dc02e875fe1ea77b25dd43747
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 101070
+  timestamp: 1667316029302
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33601
+  timestamp: 1680112270483
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+  sha256: 49bc5f6b1e11cb2babf2a2a731d1a680a5e08a858280876a779dbda06c78c35f
+  md5: b26e8aa824079e1be0294e7152ca4559
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 438953
+  timestamp: 1713199854503
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.16-hd590300_0.conda
+  sha256: 7180375f37fd264bb50672a63da94536d4abd81ccec059e932728ae056324b3a
+  md5: 151cba22b85a989c2d6ef9633ffee1e4
+  depends:
+  - libgcc-ng >=12
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 394932
+  timestamp: 1693088990429
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
+  md5: 5aa797f8787fe7a17d1b0821485b5adc
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 100393
+  timestamp: 1702724383534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.7-h4c95cb1_3.conda
+  sha256: 11a346aed187405a7d3710a79b815fd66ff80fec3b9b7f840a24531324742acf
+  md5: 0ac9aff6010a7751961c8e4b863a40e7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=73.2,<74.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 705701
+  timestamp: 1720772684071
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.10.1-h2629f0a_3.conda
+  sha256: 84e93f189072dcfcbe77744f19c7e4171523fbecfaba7352e5a23bbe014574c7
+  md5: ac79812548e7e8cf61f7b0abdef01d3b
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 107198
+  timestamp: 1694416433629
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-h4ab18f5_1.conda
+  sha256: adf6096f98b537a11ae3729eaa642b0811478f0ea0402ca67b5108fe2cb0010d
+  md5: 57d7dc60e9325e3de37ff8dffd18e814
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - zlib 1.3.1 *_1
+  license: Zlib
+  license_family: Other
+  size: 61574
+  timestamp: 1716874187109
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.43.0-py311hbde99c3_0.conda
+  sha256: f19013fd10871fb6e6e9e75ea7067b50683f6335b8f1d1893a80d731d5ce3825
+  md5: 4c60dfcba06b363be954401addee8800
+  depends:
+  - libgcc-ng >=12
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3465538
+  timestamp: 1718324420735
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.3-py311h38e4bf4_0.conda
+  sha256: 61d20694cf17fd621fc07859ccdd810be9de702fd0fa5c8f60f0ef4602b8bcde
+  md5: 3910c815fc788621f88b2bdc0fa9f0a6
+  depends:
+  - libgcc-ng >=12
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39927
+  timestamp: 1704831250044
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+  sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
+  md5: 318b08df404f9c9be5712aaa5a6f0bb0
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143402
+  timestamp: 1674727076728
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hd590300_1001.conda
+  sha256: 88433b98a9dd9da315400e7fb9cd5f70804cb17dca8b1c85163a64f90f584126
+  md5: ec7398d21e2651e0dcb0044d03b9a339
+  depends:
+  - libgcc-ng >=12
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  size: 171416
+  timestamp: 1713515738503
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.5-py311h459d7ec_0.conda
+  sha256: 14912e557a6576e03f65991be89e9d289c6e301921b6ecfb4e7186ba974f453d
+  md5: a322b4185121935c871d201ae00ac143
+  depends:
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27502
+  timestamp: 1706900084436
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.1-py311hffb96ce_0.conda
+  sha256: 790a297a441dbe7e58225ed9c47e5efb747c7d76574529b0fc0209271da4e470
+  md5: 990bc73fa802e6387f683d0fbc6b7bd4
+  depends:
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  - tk >=8.6.13,<8.7.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 7880789
+  timestamp: 1720648511765
+- conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.7-h401b404_0.conda
+  sha256: 6315ea87d094418e744deb79a22331718b36a0e6e107cd7fc3c52c7922bc8133
+  md5: 4474532a312b2245c5c77f1176989b46
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 91409
+  timestamp: 1718483022284
+- conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.0.8-py311h52f7536_0.conda
+  sha256: 8b0b4def742cebde399fd3244248e6db5b6843e7db64a94a10d6b649a3f20144
+  md5: f33f59b8130753174992f409a41e112e
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 103577
+  timestamp: 1715670788972
+- conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.0.5-py311h459d7ec_0.conda
+  sha256: aa20fb2d8ecb16099126ec5607fc12082de4111b5e4882e944f4b6cd846178d9
+  md5: 4288ea5cbe686d1b18fc3efb36c009a5
+  depends:
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 61944
+  timestamp: 1707040860316
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h59595ed_0.conda
+  sha256: 4fc3b384f4072b68853a0013ea83bdfd3d66b0126e2238e1d6e1560747aa7586
+  md5: fcea371545eda051b6deafb24889fc69
+  depends:
+  - libgcc-ng >=12
+  license: X11 AND BSD-3-Clause
+  size: 887465
+  timestamp: 1715194722503
+- conda: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.1-nompi_py311h25b3b55_101.conda
+  sha256: 225cdb356a51baeb0937e801292c6c16000777be1013f226d799e515edf4c2c1
+  md5: 936afeddfa3704eb834d0887b0838826
+  depends:
+  - certifi
+  - cftime
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libgcc-ng >=12
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 1140531
+  timestamp: 1718724259724
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda
+  sha256: 8fadeebb2b7369a4f3b2c039a980d419f65c7b18267ba0c62588f9f894396d0c
+  md5: da0ec11a6454ae19bff5b02ed881a2b1
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 226848
+  timestamp: 1669784948267
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.102-h593d115_0.conda
+  sha256: 5e5dbae2f5bc55646a9d70601432ea71b867ce06bccd174e479ac36abf5d0807
+  md5: 40e5e48c55a45621c4399ca9236406b7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libsqlite >=3.46.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.35,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1974313
+  timestamp: 1720064644368
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.60.0-py311h4bc866e_0.conda
+  sha256: b48178613ba637b647c5738772d3efabfca502ea579b5ec10784a33d5acb0789
+  md5: e32a210e9caf97383c35685fd2343512
+  depends:
+  - _openmp_mutex >=4.5
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libopenblas !=0.3.6
+  - cuda-version >=11.2
+  - cuda-python >=11.6
+  - tbb >=2021.6.0
+  - scipy >=1.0
+  - cudatoolkit >=11.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5801568
+  timestamp: 1718888179690
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.12.1-py311h4332511_1.conda
+  sha256: 40683eac07dc08ff26d64434cbd594b124791d6dd80c7e3c84664382ed6a1095
+  md5: 887aa6096851eab5c34fe95ed1641591
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - msgpack-python
+  - numpy >=1.7
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 779950
+  timestamp: 1715219045731
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.0.0-py311h1461c94_0.conda
+  sha256: f5c8070a623a216f999aec9b60b181f0624b7b074cc08189bdb4da6376c01a5d
+  md5: 4998996a22ef05d2f486216075a3037f
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8955242
+  timestamp: 1718615418098
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
+  sha256: 5600a0b82df042bd27d01e4e687187411561dfc11cc05143a08ce29b64bf2af2
+  md5: 7f2e286780f072ed750df46dc2631138
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.43,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 341592
+  timestamp: 1709159244431
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-h4ab18f5_1.conda
+  sha256: ff3faf8d4c1c9aa4bd3263b596a68fcc6ac910297f354b2ce28718a3509db6d9
+  md5: b1e9d076f14e8d776213fd5047b4c3d9
+  depends:
+  - ca-certificates
+  - libgcc-ng >=12
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2896610
+  timestamp: 1719363957188
+- conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.1-h17fec99_1.conda
+  sha256: d340c67b23fb0e1ef7e13574dd4a428f360bfce93b2a588b3b63625926b038d6
+  md5: 3bf65f0d8e7322a1cfe8b670fa35ec81
+  depends:
+  - libgcc-ng >=12
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1029691
+  timestamp: 1716789702707
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.2-py311h14de704_1.conda
+  sha256: d600c0cc42fca1ad36d969758b2495062ad83124ecfcf5673c98b11093af7055
+  md5: 84e2dd379d4edec4dd6382861486104d
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.22.4,<3
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15682728
+  timestamp: 1715898175468
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-h0f59acf_0.conda
+  sha256: 90646ad0d8f9d0fd896170c4f3d754e88c4ba0eaf856c24d00842016f644baab
+  md5: 3914f7ac1761dce57102c72ca7c35d01
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 955778
+  timestamp: 1718466128333
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.4.0-py311h82a398c_0.conda
+  sha256: baad77ac48dab88863c072bb47697161bc213c926cb184f4053b8aa5b467f39b
+  md5: b9e0ac1f5564b6572a6d702c04207be8
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.16,<2.0.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 42107472
+  timestamp: 1719903721717
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
+  sha256: 366d28e2a0a191d6c535e234741e0cd1d94d713f76073d8af4a5ccb2a266121e
+  md5: 71004cbf7924e19c02746ccde9fd7123
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 386826
+  timestamp: 1706549500138
+- conda: https://conda.anaconda.org/conda-forge/linux-64/poppler-24.07.0-hb0d391f_0.conda
+  sha256: 20ddd62419f3ddf779dfaae7d12001b0e63e365f781b1137f6db0b428193a3cb
+  md5: 561842bc59112340fa1f5f1ed06ae4a2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.0,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libgcc-ng >=12
+  - libglib >=2.80.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.35,<5.0a0
+  - nss >=3.102,<4.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - poppler-data
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 1906317
+  timestamp: 1720373278987
+- conda: https://conda.anaconda.org/conda-forge/linux-64/postgresql-16.3-h8e811e2_0.conda
+  sha256: 4cd39edd84011657978e35abdc880cf3e49785e8a86f1c99a34029a3e4998abe
+  md5: e4d52462da124ed3792472f95a36fc2a
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libgcc-ng >=12
+  - libpq 16.3 ha72fbe1_0
+  - libxml2 >=2.12.6,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.3.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tzcode
+  - tzdata
+  license: PostgreSQL
+  size: 5332852
+  timestamp: 1715266435060
+- conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.4.1-hb784bbd_0.conda
+  sha256: ec9d16725925c62a7974faa396ca61878cb4cc7398c6c0e76d3ae28cffafc7db
+  md5: c38c5246d064ef16eba065d93c46f1c6
+  depends:
+  - libcurl >=8.8.0,<9.0a0
+  - libgcc-ng >=12
+  - libsqlite >=3.46.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 3048862
+  timestamp: 1718272927953
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.0.0-py311h331c9d8_0.conda
+  sha256: 33fea160c284e588f4ff534567e84c8d3679556787708b9bab89a99e5008ac76
+  md5: f1cbef9236edde98a811ba5a98975f2e
+  depends:
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 508965
+  timestamp: 1719274724588
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+  sha256: 67c84822f87b641d89df09758da498b2d4558d47b920fd1d3fe6d3a871e000ff
+  md5: 22dad4df6e8630e8dff2428f6f6a7036
+  depends:
+  - libgcc-ng >=7.5.0
+  license: MIT
+  license_family: MIT
+  size: 5625
+  timestamp: 1606147468727
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-16.1.0-py311hbd00459_4.conda
+  sha256: ffc890c57deb9a86523f8702c6440701a5d95b304f390400f510819743b92920
+  md5: 79ebadb39164c2861d6a6819c772434a
+  depends:
+  - libarrow-acero 16.1.0.*
+  - libarrow-dataset 16.1.0.*
+  - libarrow-substrait 16.1.0.*
+  - libparquet 16.1.0.*
+  - numpy >=1.19,<3
+  - pyarrow-core 16.1.0 *_4_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 28218
+  timestamp: 1719450778701
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-16.1.0-py311h8c3dac4_4_cpu.conda
+  sha256: 18a02eea4073607e6e193e791970acd3d12fe4feadaf45590a380fa6f3102998
+  md5: 61e946fb87536002a3d17cf5a7e70655
+  depends:
+  - libarrow 16.1.0.* *cpu
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - orc >=2.0.1
+  - aws-crt-cpp >=0.26.12
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4472932
+  timestamp: 1719450556539
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.9.0-py311hfc743a8_0.conda
+  sha256: bf2c1b7831d9f95ecdd47f8c54113147e8fa82163e251e93f523c1e4302948c6
+  md5: 8a02cc6044fd91d6171949978cd15a30
+  depends:
+  - gdal
+  - libgcc-ng >=12
+  - libgdal >=3.9.0,<3.10.0a0
+  - libstdcxx-ng >=12
+  - numpy
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 743966
+  timestamp: 1718695983053
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.6.1-py311hc21b84f_7.conda
+  sha256: 8f4083b1d24f25ece69a674c56d40b4385ce7b340c9dca043e46e986cd61aadb
+  md5: 0d55a70a8c2160a7f3cbe9fcfd87f82a
+  depends:
+  - certifi
+  - libgcc-ng >=12
+  - proj >=9.4.0,<9.5.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 554158
+  timestamp: 1717792714450
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.9-hb806964_0_cpython.conda
+  sha256: 177f33a1fb8d3476b38f73c37b42f01c0b014fa0e039a701fd9f83d83aae6d40
+  md5: ac68acfa8b558ed406c75e98d3428d7b
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.6.2,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.45.3,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4.20240210,<7.0a0
+  - openssl >=3.2.1,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 30884494
+  timestamp: 1713553104915
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-4_cp311.conda
+  sha256: 0be3ac1bf852d64f553220c7e6457e9c047dfb7412da9d22fbaa67e60858b3cf
+  md5: d786502c97404c94d7d58d258a445a65
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6385
+  timestamp: 1695147338551
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py311h459d7ec_1.conda
+  sha256: 28729ef1ffa7f6f9dfd54345a47c7faac5d34296d66a2b9891fb147f4efe1348
+  md5: 52719a74ad130de8fb5d047dc91f247a
+  depends:
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 200626
+  timestamp: 1695373818537
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.0.3-py311h08a0b41_0.conda
+  sha256: 1b488c4600682702e10c296d77f4497b1ef3fdf37847861e4e1269f2718b8842
+  md5: 8bef21c0a0160e7369fc2f494acf85d0
+  depends:
+  - libgcc-ng >=12
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 475189
+  timestamp: 1715024515323
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+  sha256: 776363493bad83308ba30bcb88c2552632581b143e8ee25b1982c8c743e73abc
+  md5: 353823361b1d27eb3960efb076dfcaf6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-Qhull
+  size: 552937
+  timestamp: 1720813982144
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.3.10-py311h539dff6_4.conda
+  sha256: f9087a7f46694f68626b2111fd00cc1f45f23a3bbbf840def85e5c8120deb75d
+  md5: 016c46d34a1dedc423263c3899cb1391
+  depends:
+  - affine
+  - attrs
+  - certifi
+  - click >=4
+  - click-plugins
+  - cligj >=0.5
+  - libgcc-ng >=12
+  - libgdal >=3.9.0,<3.10.0a0
+  - libstdcxx-ng >=12
+  - numpy >=1.19,<3
+  - proj >=9.4.0,<9.5.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7906333
+  timestamp: 1717805837476
+- conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.09.01-h7f4b329_2.conda
+  sha256: f0f520f57e6b58313e8c41abc7dfa48742a05f1681f05654558127b667c769a8
+  md5: 8f70e36268dea8eb666ef14c29bd3cda
+  depends:
+  - libre2-11 2023.09.01 h5a48ba9_2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26617
+  timestamp: 1708946796423
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+  sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
+  md5: 47d31b792659ce70f470b5c82fdfb7a4
+  depends:
+  - libgcc-ng >=12
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 281456
+  timestamp: 1679532220005
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.19.0-py311hb3a8bbb_0.conda
+  sha256: 59cdf20e780485cf5d44a6d1170addd32f3a831bda2fedb9bf9464880cb756bb
+  md5: c724ab184763ae3168331e1c467d887e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  size: 331396
+  timestamp: 1720476807230
+- conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.17-he19d79f_0.conda
+  sha256: 6d1aa582964771a6cf47d120e2c5cdc700fe3744101cd5660af1eb81d47d689a
+  md5: e25ac9bf10f8e6aa67727b1cdbe762ef
+  depends:
+  - libgcc-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 349926
+  timestamp: 1719619139334
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.5.1-py311hd632256_0.conda
+  sha256: 855a322daff2d64c9a75b1fea560d2f6f4dd02685220519c9a3ce25bbdd92f7d
+  md5: f3928b428ad924ecb8f0e9b71124ed7f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - joblib >=1.2.0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scipy
+  - threadpoolctl >=3.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10548981
+  timestamp: 1719998745552
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.0-py311h517d4fd_1.conda
+  sha256: 55bb5502a4795b5b271bd3879846665ad9ac7ffeeea418ba6334accd8d5c71f4
+  md5: 481fd009b2d863f526f60ca19cb7880b
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - numpy >=1.23.5,<2.3
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17709552
+  timestamp: 1720323995099
+- conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.5-py311h5925939_0.conda
+  sha256: 801d2bf817f33d66b4dac1c959424f4b9e546ffa87df1d018a723fd11e9fd936
+  md5: 105ce0d9e7aa0324031a3abaf9ec71f7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - geos >=3.12.2,<3.12.3.0a0
+  - libgcc-ng >=12
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 579137
+  timestamp: 1720886322048
+- conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
+  sha256: dc7c8e0e8c3e8702aae81c52d940bfaabe756953ee51b1f1757e891bab62cf7f
+  md5: 6b7dcc7349efd123d493d2dbe85a045f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42465
+  timestamp: 1720003704360
+- conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.13.0-hd2e6256_0.conda
+  sha256: 2027b971e83a9c9d292c12880269fe08e782fe9b15b93b5a3ddc8697116e6750
+  md5: 18f9348f064632785d54dbd1db9344bb
+  depends:
+  - fmt >=10.2.1,<11.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 188328
+  timestamp: 1713902039030
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.46.0-h6d4b2fc_0.conda
+  sha256: e849d576e52bf3e6fc5786f89b7d76978f2e2438587826c95570324cb572e52b
+  md5: 77ea8dff5cf8550cc8f5629a6af56323
+  depends:
+  - libgcc-ng >=12
+  - libsqlite 3.46.0 hde9e2c9_0
+  - libzlib >=1.2.13,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 860352
+  timestamp: 1718050658212
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.24.2-hc55ee95_2.conda
+  sha256: 9a84b39d158d72ff96143b6b532fe93001f1b1171ddbbf9b42ac12a22252d739
+  md5: bc6b3a6693d53e33dea28c89e02745dd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-crt-cpp >=0.27.3,<0.27.4.0a0
+  - aws-sdk-cpp >=1.11.329,<1.11.330.0a0
+  - azure-core-cpp >=1.12.0,<1.12.1.0a0
+  - azure-identity-cpp >=1.8.0,<1.8.1.0a0
+  - azure-storage-blobs-cpp >=12.11.0,<12.11.1.0a0
+  - azure-storage-common-cpp >=12.6.0,<12.6.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - fmt >=10.2.1,<11.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libgcc-ng >=12
+  - libgoogle-cloud >=2.26.0,<2.27.0a0
+  - libgoogle-cloud-storage >=2.26.0,<2.27.0a0
+  - libstdcxx-ng >=12
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.3.1,<4.0a0
+  - spdlog >=1.13.0,<1.14.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 4352150
+  timestamp: 1720847834461
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+  sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
+  md5: d453b98d9c83e71da0741bb0ff4d76bc
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3318875
+  timestamp: 1699202167581
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.1-py311h331c9d8_0.conda
+  sha256: 753f5496ba6a69fc52bd58e55296d789b964d1ba1539420bfc10bcd0e1d016fb
+  md5: e29e451c96bf8e81a5760b7565c6ed2c
+  depends:
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 856038
+  timestamp: 1717722984124
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tzcode-2024a-h3f72095_0.conda
+  sha256: d3ea2927cabd6c9f27ee0cb498f893ac0133687d6a9e65e0bce4861c732a18df
+  md5: 32146e34aaec3745a08b6f49af3f41b0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 69821
+  timestamp: 1706868851630
+- conda: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda
+  sha256: 2aad2aeff7c69a2d7eecd7b662eef756b27d6a6b96f3e2c2a7071340ce14543e
+  md5: d71d3a66528853c0a1ac2c02d79a0284
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48270
+  timestamp: 1715010035325
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.5-hac6953d_0.conda
+  sha256: 75d06ca406f03f653d7a3183f2a1ccfdb3a3c6c830493933ec4c3c98e06a32bb
+  md5: 63b80ca78d29380fe69e69412dcbe4ac
+  depends:
+  - icu >=73.2,<74.0a0
+  - libcurl >=8.5.0,<9.0a0
+  - libgcc-ng >=12
+  - libnsl >=2.0.1,<2.1.0a0
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 1636164
+  timestamp: 1703092965257
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
+  sha256: e90b0a6a5d41776f11add74aa030f789faf4efd3875c31964d6f9cfa63a10dd1
+  md5: 4b230e8381279d76131116660f5a241a
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 27338
+  timestamp: 1610027759842
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hd590300_0.conda
+  sha256: 5aa9b3682285bb2bf1a8adc064cb63aff76ef9178769740d855abb42b0d24236
+  md5: b462a33c0be1421532f28bfe8f4a7514
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 58469
+  timestamp: 1685307573114
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-h7391055_0.conda
+  sha256: 089ad5f0453c604e18985480218a84b27009e9e6de9a0fa5f4a20b8778ede1f1
+  md5: 93ee23f12bc2e684548181256edd2cf6
+  depends:
+  - libgcc-ng >=12
+  - libuuid >=2.38.1,<3.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 27433
+  timestamp: 1685453649160
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.9-hb711507_1.conda
+  sha256: 66eabe62b66c1597c4a755dcd3f4ce2c78adaf7b32e25dfee45504d67d7735c1
+  md5: 4a6d410296d7e39f00bacdee7df046e9
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  - xorg-kbproto
+  - xorg-xextproto >=7.3.0,<8.0a0
+  - xorg-xproto
+  license: MIT
+  license_family: MIT
+  size: 832198
+  timestamp: 1718846846409
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+  sha256: 309751371d525ce50af7c87811b435c176915239fc9e132b99a25d5e1703f2d4
+  md5: 2c80dc38fface310c9bd81b17037fee5
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 14468
+  timestamp: 1684637984591
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+  sha256: 4df7c5ee11b8686d3453e7f3f4aa20ceef441262b49860733066c52cfd0e4a77
+  md5: be93aabceefa2fac576e971aef407908
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 19126
+  timestamp: 1610071769228
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
+  sha256: 73e5cfbdff41ef8a844441f884412aa5a585a0f0632ec901da035a03e1fe1249
+  md5: 82b6df12252e6f32402b96dacc656fec
+  depends:
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.7.2,<2.0a0
+  - xorg-xextproto
+  license: MIT
+  license_family: MIT
+  size: 50143
+  timestamp: 1677036907815
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hd590300_0.conda
+  sha256: 26da4d1911473c965c32ce2b4ff7572349719eaacb88a066db8d968a4132c3f7
+  md5: ed67c36f215b310412b2af935bf3e530
+  depends:
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-renderproto
+  license: MIT
+  license_family: MIT
+  size: 37770
+  timestamp: 1688300707994
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-h7f98852_1002.tar.bz2
+  sha256: 38942930f233d1898594dd9edf4b0c0786f3dbc12065a0c308634c37fd936034
+  md5: 06feff3d2634e3097ce2fe681474b534
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 9621
+  timestamp: 1614866326326
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
+  sha256: b8dda3b560e8a7830fe23be1c58cc41f407b2e20ae2f3b6901eb5842ba62b743
+  md5: bce9f945da8ad2ae9b1d7165a64d0f87
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 30270
+  timestamp: 1677036833037
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
+  sha256: f197bb742a17c78234c24605ad1fe2d88b1d25f332b75d73e5ba8cf8fbc2a10d
+  md5: b4a4381d54784606820704f7b5f05a15
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 74922
+  timestamp: 1607291557628
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+  sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+  md5: 2161070d867d1b1204ea749c8eec4ef0
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1 and GPL-2.0
+  size: 418368
+  timestamp: 1660346797927
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+  sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
+  md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 89141
+  timestamp: 1641346969816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.9.4-py311h459d7ec_0.conda
+  sha256: 673e4a626e9e7d661154e5609f696c0c8a9247087f5c8b7744cfbb4fe0872713
+  md5: fff0f2058e9d86c8bf5848ee93917a8d
+  depends:
+  - idna >=2.0
+  - libgcc-ng >=12
+  - multidict >=4.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 122372
+  timestamp: 1705508480013
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h75354e8_4.conda
+  sha256: bc9aaee39e7be107d7daff237435dfd8f791aca460a98583a36a263615205262
+  md5: 03cc8d9838ad9dd0060ab532e81ccb21
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libgcc-ng >=12
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=12
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 353229
+  timestamp: 1715607188837
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-h4ab18f5_1.conda
+  sha256: cee16ab07a11303de721915f0a269e8c7a54a5c834aa52f74b1cc3a59000ade8
+  md5: 9653f1bf3766164d0e65fa723cabbc54
+  depends:
+  - libgcc-ng >=12
+  - libzlib 1.3.1 h4ab18f5_1
+  license: Zlib
+  license_family: Other
+  size: 93004
+  timestamp: 1716874213487
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py311h5cd10c7_0.conda
+  sha256: ee4e7202ed6d6027eabb9669252b4dfd8144d4fde644435ebe39ab608086e7af
+  md5: 8efe4fe2396281627b3450af8357b190
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.11
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 416323
+  timestamp: 1721044178290
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+  sha256: c558b9cc01d9c1444031bd1ce4b9cff86f9085765f17627a6cd85fc623c8a02b
+  md5: 4d056880988120e29d75bfff282e0f45
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 554846
+  timestamp: 1714722996770
+- conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+  sha256: fbf0288cae7c6e5005280436ff73c95a36c5a4c978ba50175cc8e3eb22abc5f9
+  md5: ae5f4ad87126c55ba3f690ef07f81d64
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18726
+  timestamp: 1674245215155
+- conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 575c742e14c86575986dc867463582a970463da50b77264cdf54df74f5563783
+  md5: d1e1eb7e21a9e2c74279d87dafb68156
+  depends:
+  - frozenlist >=1.1.0
+  - python >=3.7
+  license: Apache-2.0
+  license_family: APACHE
+  size: 12730
+  timestamp: 1667935912504
+- conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
+  sha256: 84ac9429812495f12939ab4994f2634f7cacd254f6234a0c2c0243daed15a7ee
+  md5: 1fa97c6e8db1f82c64ff17a5efc4ae8e
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.8
+  - sniffio >=1.1
+  - typing_extensions >=4.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 104255
+  timestamp: 1717693144467
+- conda: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+  sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
+  md5: 5f095bc6454094e96f146491fd03633b
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 12840
+  timestamp: 1603108499239
+- conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
+  sha256: 45ae2d41f4a4dcf8707633d3d7ae376fc62f0c09b1d063c3049c3f6f8c911670
+  md5: cc4834a9ee7cc49ce8d25177c47b10d8
+  depends:
+  - python >=3.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 10241
+  timestamp: 1707233195627
+- conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+  sha256: 130766446f5507bd44df957b6b5c898a8bd98f024bb426ed6cb9ff1ad67fc677
+  md5: 3afef1f55a1366b4d3b6a0d92e2235e4
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.7
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 18602
+  timestamp: 1692818472638
+- conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+  sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
+  md5: b77d8c2313158e6e461ca0efb1c2c508
+  depends:
+  - python >=3.8
+  - python-dateutil >=2.7.0
+  - types-python-dateutil >=2.8.10
+  license: Apache-2.0
+  license_family: Apache
+  size: 100096
+  timestamp: 1696129131844
+- conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+  sha256: b3e9369529fe7d721b66f18680ff4b561e20dbf6507e209e1f60eac277c97560
+  md5: c0481c9de49f040272556e2cedf42816
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 6164
+  timestamp: 1531050741142
+- conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+  sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
+  md5: 5f25798dcefd8252ce5f9dc494d5f571
+  depends:
+  - python >=3.5
+  - six >=1.12.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 28922
+  timestamp: 1698341257884
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
+  sha256: 77c7d03bdb243a048fff398cedc74327b7dc79169ebe3b4c8448b0331ea55fea
+  md5: 5e4c0743c70186509d1412e03c2d8dfa
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 54582
+  timestamp: 1704011393776
+- conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+  sha256: 7b05b2d0669029326c623b9df7a29fa49d1982a9e7e31b2fea34b4c9a4a72317
+  md5: 332493000404d8411859539a5a630865
+  depends:
+  - python >=3.6
+  - soupsieve >=1.2
+  license: MIT
+  license_family: MIT
+  size: 118200
+  timestamp: 1705564819537
+- conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+  sha256: 845e77ef495376c5c3c328ccfd746ca0ef1978150cae8eae61a300fe7755fb08
+  md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
+  depends:
+  - packaging
+  - python >=3.6
+  - setuptools
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 131220
+  timestamp: 1696630354218
+- conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.4.2-pyhd8ed1ab_0.conda
+  sha256: 33f7fdb46804da0930346ab2b7b1fab1225752b0977f5bf8f4763c4e2c1a824e
+  md5: e704d0474c0155db9632bd740b6c9d17
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4745611
+  timestamp: 1719324760487
+- conda: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.2-pyhd8ed1ab_0.conda
+  sha256: 9f7df349cb5a8852804d5bb1f5f49e3076a55ac7229b9c114bb5f7461f497ba7
+  md5: 5f1c719f1cac0aee5e6bd6ca7d54a7fa
+  depends:
+  - jinja2 >=3
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 28923
+  timestamp: 1714071906758
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+  sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
+  md5: 9b347a7ec10940d3f7941ff6c460b551
+  depends:
+  - cached_property >=1.5.2,<1.5.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4134
+  timestamp: 1615209571450
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+  sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+  md5: 576d629e47797577ab0f1b351297ef4a
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11065
+  timestamp: 1615209567874
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.7.4-pyhd8ed1ab_0.conda
+  sha256: dd3577bb5275062c388c46b075dcb795f47f8dac561da7dd35fe504b936934e5
+  md5: 24e7fd6ca65997938fff9e5ab6f653e4
+  depends:
+  - python >=3.7
+  license: ISC
+  size: 159308
+  timestamp: 1720458053074
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+  sha256: 20cae47d31fdd58d99c4d2e65fbdcefa0b0de0c84e455ba9d6356a4bdbc4b5b9
+  md5: 7f4a9e3fcff3f6356ae99244a014da6a
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 46597
+  timestamp: 1698833765762
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+  sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
+  md5: f3ad426304898027fc619827ff428eca
+  depends:
+  - __unix
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84437
+  timestamp: 1692311973840
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
+  sha256: 90236b113b9a20041736e80b80ee965167f9aac0468315c55e2bad902d673fb0
+  md5: 3549ecbceb6cd77b91a105511b7d0786
+  depends:
+  - __win
+  - colorama
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 85051
+  timestamp: 1692312207348
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+  sha256: ddef6e559dde6673ee504b0e29dd814d36e22b6b9b1f519fa856ee268905bf92
+  md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
+  depends:
+  - click >=3.0
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8992
+  timestamp: 1554588104889
+- conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+  sha256: 97bd58f0cfcff56a0bcda101e26f7d936625599325beba3e3a1fa512dd7fc174
+  md5: a29b7c141d6b2de4bb67788a5f107734
+  depends:
+  - click >=4.0
+  - python <4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10255
+  timestamp: 1633637895378
+- conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+  sha256: 0dfbc1ffa72e7a0882f486c9b1e4e9cccb68cf5c576fe53a89d076c9f1d43754
+  md5: 753d29fe41bb881e4b9c004f0abf973f
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24746
+  timestamp: 1697464875382
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+  sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+  md5: 3faab06a954c2a04039983f2c4a50d99
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25170
+  timestamp: 1666700778190
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+  sha256: 79a6b4fff545e0b18f86ad93276a1797eb6ac3f7e1851e03f02d63b19655731b
+  md5: 4d155b600b63bc6ba89d91fab74238f8
+  depends:
+  - python >=3.7
+  license: CC-BY-4.0
+  size: 173517
+  timestamp: 1709713413736
+- conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+  sha256: e923acf02708a8a0b591f3bce4bdc11c8e63b73198b99b35fe6cd96bfb6a0dbe
+  md5: 948d84721b578d426294e17a02e24cbb
+  depends:
+  - python >=3.6
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12134
+  timestamp: 1710320435158
+- conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+  sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
+  md5: 5cd86562580f274031ede6aa6aa24441
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13458
+  timestamp: 1696677888423
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.7.0-pyhd8ed1ab_0.conda
+  sha256: 8c4c05e42b34fb0c5eec1ce2fd542ee756333659e056ac34fab20e12376f4d21
+  md5: f0647685bcd2c8d78b6e8177d6735edb
+  depends:
+  - bokeh >=2.4.2,!=3.0.*
+  - cytoolz >=0.11.0
+  - dask-core >=2024.7.0,<2024.7.1.0a0
+  - dask-expr >=1.1,<1.2
+  - distributed >=2024.7.0,<2024.7.1.0a0
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.21
+  - pandas >=2.0
+  - pyarrow >=7.0
+  - pyarrow-hotfix
+  - python >=3.9
+  constrains:
+  - openssl !=1.1.1e
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7434
+  timestamp: 1720318437409
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.7.0-pyhd8ed1ab_0.conda
+  sha256: 9c0f6ef94a1967fa553b1b26db032f9a61881c92f9ff0dbee572d2df5d173c53
+  md5: 755e47653ae38f5c50f1435af756e844
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib_metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.4.0
+  - python >=3.9
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 878090
+  timestamp: 1720290443126
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.7-pyhd8ed1ab_0.conda
+  sha256: bdcb6a1a26cb5c61711e4bfdb99565ce4aba4e292faab6ca595bceca76ff9d13
+  md5: 412b700b5a88f167078cd7b839881086
+  depends:
+  - dask-core 2024.7.0
+  - pandas >=2
+  - pyarrow
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 183907
+  timestamp: 1720300457390
+- conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+  sha256: 8f35e2d76173d300f5e5f504d67238097c16457267d421a8ab10d1e5bd9b734d
+  md5: 1316959270592fbf8e2278a336de3ab9
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy
+  - packaging
+  - pandas
+  - param
+  - pillow
+  - pyct
+  - python >=3.9
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17230062
+  timestamp: 1720435590279
+- conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+  md5: 43afe5ab04e35e17ba28649471dd7364
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 12072
+  timestamp: 1641555714315
+- conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
+  md5: 961b3a227b437d82ad7054484cfa71b2
+  depends:
+  - python >=3.6
+  license: PSF-2.0
+  license_family: PSF
+  size: 24062
+  timestamp: 1615232388757
+- conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.7.0-pyhd8ed1ab_0.conda
+  sha256: 69f9a962a122b4fdd36f1aa59a8780299d8e0b9ec3e11c757ce77dadb63a1231
+  md5: 2ae917b0098f286f63f69ec9365fb0b1
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - cytoolz >=0.10.1
+  - dask-core >=2024.7.0,<2024.7.1.0a0
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.0
+  - packaging >=20.0
+  - psutil >=5.7.2
+  - python >=3.9
+  - pyyaml >=5.3.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.10.0
+  - tornado >=6.0.4
+  - urllib3 >=1.24.3
+  - zict >=3.0.0
+  constrains:
+  - openssl !=1.1.1e
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 795925
+  timestamp: 1720300404413
+- conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
+  md5: 3cf04868fee0a029769bd41f4b2fbf2d
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 9199
+  timestamp: 1643888357950
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+  sha256: e0edd30c4b7144406bb4da975e6bb97d6bc9c0e999aa4efe66ae108cada5d5b5
+  md5: d02ae936e42063ca46af6cdad2dbd1e0
+  depends:
+  - python >=3.7
+  license: MIT and PSF-2.0
+  size: 20418
+  timestamp: 1720869435725
+- conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+  sha256: c738804ab1e6376f8ea63372229a04c8d658dc90fd5a218c6273a2eaf02f4057
+  md5: e16be50e378d8a4533b989035b196ab8
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 27689
+  timestamp: 1698580072627
+- conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+  sha256: 42be6ac8478051b26751d778490d6a71de12e5c6443e145ff3eddbc577d9bcda
+  md5: 348e27e78a5e39090031448c72f66d5e
+  depends:
+  - python >=3.6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 19975
+  timestamp: 1643971626978
+- conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.17.0-pyhd8ed1ab_0.conda
+  sha256: d5c4153cad0154112daf0db648afe82ad7930523e2cb9f7379bb2d148fac0537
+  md5: 9b96a3e6e0473b5722fa4fbefcefcded
+  depends:
+  - branca >=0.6.0
+  - jinja2 >=2.9
+  - numpy
+  - python >=3.8
+  - requests
+  - xyzservices
+  license: MIT
+  license_family: MIT
+  size: 78894
+  timestamp: 1718606077008
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+  sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+  md5: 0c96522c6bdaed4b1566d11387caaf45
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 397370
+  timestamp: 1566932522327
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+  sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+  md5: 34893075a5c9e55cdafac56607368fc6
+  license: OFL-1.1
+  license_family: Other
+  size: 96530
+  timestamp: 1620479909603
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+  sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+  md5: 4d59c254e01d9cde7957100457e2d5fb
+  license: OFL-1.1
+  license_family: Other
+  size: 700814
+  timestamp: 1620479612257
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_2.conda
+  sha256: c940f6e969143e13a3a9660abb3c7e7e23b8319efb29dbdd5dee0b9939236e13
+  md5: cbbe59391138ea5ad3658c76912e147f
+  license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
+  license_family: Other
+  size: 1622566
+  timestamp: 1714483134319
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+  sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+  md5: fee5683a3f04bd15cbd8318b096a27ab
+  depends:
+  - fonts-conda-forge
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3667
+  timestamp: 1566974674465
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+  sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
+  md5: f766549260d6815b0c52253f1fb1bb29
+  depends:
+  - font-ttf-dejavu-sans-mono
+  - font-ttf-inconsolata
+  - font-ttf-source-code-pro
+  - font-ttf-ubuntu
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4102
+  timestamp: 1566932280397
+- conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 6cfd1f9bcd2358a69fb571f4b3af049b630d52647d906822dbedac03e84e4f63
+  md5: 642d35437078749ef23a5dca2c9bb1f3
+  depends:
+  - cached-property >=1.3.0
+  - python >=2.7,<4
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 14395
+  timestamp: 1638810388635
+- conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.6.1-pyhff2d567_0.conda
+  sha256: 2b8e98294c70d9a33ee0ef27539a8a8752a26efeafa0225e85dc876ef5bb49f4
+  md5: 996bf792cdb8c0ac38ff54b9fde56841
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 133141
+  timestamp: 1719515065535
+- conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_0.conda
+  sha256: 6d3f8148d88b1f2c100e03fce441f19577f6a4b69e3a2c57d522b48010d84f5f
+  md5: efef4ce75a678216d510d08222845c7f
+  depends:
+  - folium
+  - geopandas-base 1.0.1 pyha770c72_0
+  - mapclassify >=2.4.0
+  - matplotlib-base
+  - pyogrio >=0.7.2
+  - pyproj >=3.3.0
+  - python >=3.9
+  - xyzservices
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7438
+  timestamp: 1719933423912
+- conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_0.conda
+  sha256: b07d76f79cc3b1dc7f5a73aeeb0f7c9977526d73237df7e200582fdff48045d1
+  md5: 1b7d46173c29e14dde41f97cf5aa61df
+  depends:
+  - numpy >=1.22
+  - packaging
+  - pandas >=1.4.0
+  - python >=3.9
+  - shapely >=2.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 239347
+  timestamp: 1719933418796
+- conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.12.0-pyhd8ed1ab_0.conda
+  sha256: 69bb3170580b0ec9575aa6852cd9833eac53fc8e0580ac38763592e063931d8a
+  md5: 593c5b1cdd8c89d8146b108b29fc48c4
+  depends:
+  - bokeh >=3.4.0,<3.5.0
+  - cartopy >=0.18.0
+  - datashader
+  - geopandas-base
+  - geoviews-core 1.12.0 pyha770c72_0
+  - holoviews >=1.16.0
+  - netcdf4
+  - numpy >=1.0
+  - packaging
+  - pandas
+  - panel >=1.0.0
+  - param >=1.9.3
+  - pyct
+  - pyproj
+  - python >=3.9
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8258
+  timestamp: 1712332911278
+- conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.12.0-pyha770c72_0.conda
+  sha256: 7c9ff712a7060cab5cbabd40ab1d8efc8bb41c363c7f6c87ae86b6cc0200735e
+  md5: 6883b457008f3af5a9bee634e7c4f331
+  depends:
+  - bokeh >=3.4.0,<3.5.0
+  - cartopy >=0.18.0
+  - holoviews >=1.16.0
+  - numpy >=1.0
+  - packaging
+  - panel >=1.0.0
+  - param >=1.9.3
+  - pyproj
+  - python >=3.9
+  constrains:
+  - geoviews 1.12.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 398649
+  timestamp: 1712332845477
+- conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+  sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
+  md5: b748fbf7060927a6e82df7cb5ee8f097
+  depends:
+  - hpack >=4.0,<5
+  - hyperframe >=6.0,<7
+  - python >=3.6.1
+  license: MIT
+  license_family: MIT
+  size: 46754
+  timestamp: 1634280590080
+- conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.19.1-pyhd8ed1ab_0.conda
+  sha256: f1ac92cf18b339b387f71150cfd5ebd05292a4edf002f42ddeb1997ecbdc8d34
+  md5: 7ab8cd2286271685ab4dc40a8997faa8
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.9
+  - pyviz_comms >=2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3969880
+  timestamp: 1720336844750
+- conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+  sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
+  md5: 914d6646c4dbb1fd3ff539830a12fd71
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 25341
+  timestamp: 1598856368685
+- conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.10.0-pyhd8ed1ab_0.conda
+  sha256: 03199ab176e282edb19adaaed15242da8dfab9038abd0691d109b062b2f2ae1d
+  md5: 62e8362edc9bb3380e63186d4ad3e735
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 239351
+  timestamp: 1715056489256
+- conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
+  md5: 9f765cbfab6870c8435b9eefecd7a1f4
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 14646
+  timestamp: 1619110249723
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.7-pyhd8ed1ab_0.conda
+  sha256: 9687ee909ed46169395d4f99a0ee94b80a52f87bed69cd454bb6d37ffeb0ec7b
+  md5: c0cc1420498b17414d8617d0b9f506ca
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 52718
+  timestamp: 1713279497047
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.0.0-pyha770c72_0.conda
+  sha256: e40d7e71c37ec95df9a19d39f5bb7a567c325be3ccde06290a71400aab719cac
+  md5: 3286556cdd99048d198f72c3f6f69103
+  depends:
+  - python >=3.8
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 27367
+  timestamp: 1719361971438
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.0.0-hd8ed1ab_0.conda
+  sha256: f786f67bcdd6debb6edc2bc496e2899a560bbcc970e66727d42a805a1a5bf9a3
+  md5: 5f8c8ebbe6413a7838cf6ecf14d5d31b
+  depends:
+  - importlib-metadata >=8.0.0,<8.0.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 9511
+  timestamp: 1719361975786
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
+  sha256: c6ae80c0beaeabb342c5b041f19669992ae6e937dbec56ced766cb035900f9de
+  md5: c5d3907ad8bd7bf557521a1833cf7e6d
+  depends:
+  - python >=3.8
+  - zipp >=3.1.0
+  constrains:
+  - importlib-resources >=6.4.0,<6.4.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 33056
+  timestamp: 1711041009039
+- conda: https://conda.anaconda.org/conda-forge/noarch/intake-0.7.0-pyhd8ed1ab_0.conda
+  sha256: 8dba632e81a11347d959bb11367f6b0184e2dcc9aeab550de156beac5fa6091b
+  md5: 310f0fdaec6eecd9cc7833a788bafb1f
+  depends:
+  - appdirs
+  - cloudpickle >=0.2.2
+  - dask >=1.0
+  - entrypoints
+  - fsspec >=0.7.4
+  - jinja2
+  - msgpack-python
+  - numpy
+  - partd >=0.3.10
+  - python >=3.6
+  - pyyaml
+  - requests
+  - toolz >=0.8.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 193092
+  timestamp: 1685391772164
+- conda: https://conda.anaconda.org/conda-forge/noarch/intake-xarray-0.7.0-pyhd8ed1ab_0.conda
+  sha256: ceb8cf5761c29467684cb860f1c73fce396ed412a3b54f69cdd314b96ef736b6
+  md5: d6471673fac9fa8f13a2517315ffcf6b
+  depends:
+  - dask >=2.2
+  - fsspec >=2022
+  - intake >=0.6.6
+  - msgpack-python
+  - netcdf4
+  - python >=3.5
+  - requests
+  - xarray >=2022
+  - zarr
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 27517
+  timestamp: 1685414168477
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+  sha256: 33cfd339bb4efac56edf93474b37ddc049e08b1b4930cf036c893cc1f5a1f32a
+  md5: b40131ab6a36ac2c09b7c57d4d3fbf99
+  depends:
+  - __linux
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119084
+  timestamp: 1719845605084
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+  sha256: dc569094125127c0078aa536f78733f383dd7e09507277ef8bcd1789786e7086
+  md5: 18df5fc4944a679e085e0e8f31775fc8
+  depends:
+  - __win
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119853
+  timestamp: 1719845858082
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+  sha256: 072534d4d379225b2c3a4e38bc7730b65ae171ac7f0c2d401141043336e97980
+  md5: 9eb15d654daa0ef5a98802f586bb4ffc
+  depends:
+  - __osx
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119568
+  timestamp: 1719845667420
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh707e725_0.conda
+  sha256: a40c2859a055d98ba234d67b233fb1ba55d86cbe632ec96eecb7c5019c16478b
+  md5: f64d3520d5d00321c10f4dabb5b903f3
+  depends:
+  - __unix
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.10
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 599279
+  timestamp: 1719582627972
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh7428d3b_0.conda
+  sha256: b0fd9f89ef87c4b968ae8aae01c4ff8969eb4463f1fb28c77ff0b33b444d9cef
+  md5: f5047e2bc6a82dcdf2f169fdb0bbed99
+  depends:
+  - __win
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.10
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 600345
+  timestamp: 1719583103556
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_1.conda
+  sha256: 72fbbe8bc511f20268d347c1a06e279128237e096c4c174b2f9164a661c6b13e
+  md5: f8ed9f18dce81e4ee55c858cc2f8548a
+  depends:
+  - python >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28064
+  timestamp: 1716278507729
+- conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
+  md5: 4cb68948e0b8429534380243d063a27a
+  depends:
+  - arrow >=0.15.0
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 17189
+  timestamp: 1638811664194
+- conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+  sha256: 362f0936ef37dfd1eaa860190e42a6ebf8faa094eaa3be6aa4d9ace95f40047a
+  md5: 81a3be0b2023e1ea8555781f0ad904a2
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 841312
+  timestamp: 1696326218364
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+  sha256: 27380d870d42d00350d2d52598cddaf02f9505fb24be09488da0c9b8d1428f2d
+  md5: 7b86ecb7d3557821c649b3c31e3eb9f2
+  depends:
+  - markupsafe >=2.0
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111565
+  timestamp: 1715127275924
+- conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
+  sha256: 8ad719524b1039510fcbd75eb776123189d75e2c09228189257ddbcab86f5b64
+  md5: 25df261d4523d9f9783bcdb7208d872f
+  depends:
+  - python >=3.8
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 219731
+  timestamp: 1714665585214
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+  sha256: 7d0c4c0346b26be9f220682b7c5c0d84606d48c6dbc36fc238e4452dda733aff
+  md5: da304c192ad59975202859b367d0f6a2
+  depends:
+  - attrs >=22.2.0
+  - importlib_resources >=1.4.0
+  - jsonschema-specifications >=2023.03.6
+  - pkgutil-resolve-name >=1.3.10
+  - python >=3.8
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 74323
+  timestamp: 1720529611305
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
+  sha256: a9630556ddc3121c0be32f4cbf792dd9102bd380d5cd81d57759d172cf0c2da2
+  md5: a0e4efb5f35786a05af4809a2fb1f855
+  depends:
+  - importlib_resources >=1.4.0
+  - python >=3.8
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 16431
+  timestamp: 1703778502971
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+  sha256: 007a0a506a0d1805b099629cb0ee743ad0afe7d9749e57339f32c168119e0139
+  md5: 16b37612b3a2fd77f409329e213b530c
+  depends:
+  - fqdn
+  - idna
+  - isoduration
+  - jsonpointer >1.13
+  - jsonschema >=4.23.0,<4.23.1.0a0
+  - rfc3339-validator
+  - rfc3986-validator >0.1.0
+  - uri-template
+  - webcolors >=24.6.0
+  license: MIT
+  license_family: MIT
+  size: 7143
+  timestamp: 1720529619500
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+  sha256: 38e67f3e0d631f4aeeab4bbd4062dcb6f4ae9dc35803053c995d02912a999b65
+  md5: 5cbf9a31a19d4ef9103adb7d71fd45fd
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.7
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99449
+  timestamp: 1673616104031
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+  sha256: cd3f41dc093162a41d4bae171e40a1b9b115c4d488e9bb837a8fa9d084931fb9
+  md5: ed45423c41b3da15ea1df39b1f80c2ca
+  depends:
+  - jsonschema-with-format-nongpl >=4.18.0
+  - python >=3.8
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21475
+  timestamp: 1710805759187
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+  sha256: edab71a05feceac54bdb90e755a257545af7832b9911607c1a70f09be44ba985
+  md5: ca23c71f70a7c7935b3d03f0f1a5801d
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert-core >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.8
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 323978
+  timestamp: 1720816754998
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+  sha256: 038efbc7e4b2e72d49ed193cfb2bbbe9fbab2459786ce9350301f466a32567db
+  md5: 219b3833aa8ed91d47d1be6ca03f30be
+  depends:
+  - python >=3.8
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19818
+  timestamp: 1710262791393
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+  sha256: 4aa622bbcf97e44cd1adf0100b7ff71b7e20268f043bdf6feae4d16152f1f242
+  md5: afcd1b53bcac8844540358e33f33d28f
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.7
+  constrains:
+  - jupyterlab >=4.0.8,<5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18776
+  timestamp: 1707149279640
+- conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+  sha256: aa99d44e8c83865026575a8af253141c53e0b3ab05f053befaa7757c8525064f
+  md5: f1b64ca4faf563605cf6f6ca93f9ff3f
+  depends:
+  - python >=3.7
+  - uc-micro-py
+  license: MIT
+  license_family: MIT
+  size: 24035
+  timestamp: 1707129321841
+- conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
+  md5: 91e27ef3d05cc772ce627e51cff111c4
+  depends:
+  - python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 8250
+  timestamp: 1650660473123
+- conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.6.1-pyhd8ed1ab_0.conda
+  sha256: 204ab8b242229d422b33cfec07ea61cefa8bd22375a16658afbabaafce031d64
+  md5: 6aceae1ad4f16cf7b73ee04189947f98
+  depends:
+  - networkx >=2.7
+  - numpy >=1.23
+  - pandas >=1.4,!=1.5.0
+  - python >=3.9
+  - scikit-learn >=1.0
+  - scipy >=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38684
+  timestamp: 1696563711967
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+  sha256: fce1fde00359696983989699c00f9891194c4ebafea647a8d21b7e2e3329b56e
+  md5: 06e9bebf748a0dea03ecbe1f0e27e909
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78331
+  timestamp: 1710435316163
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+  sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
+  md5: 93a8e71256479c62074356ef6ebf501b
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 64356
+  timestamp: 1686175179621
+- conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+  sha256: 7ea68676ea35fbb095420bbcc1c82c4767b8be7bb56abb6989b7f89d957a3bab
+  md5: 779345c95648be40d22aaa89de7d4254
+  depends:
+  - python >=3.6
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14599
+  timestamp: 1713250613726
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.1-pyhd8ed1ab_0.conda
+  sha256: 3525b8e4598ccaab913a2bcb8a63998c6e5cc1870d0c5a5b4e867aa69c720aa1
+  md5: eb90dd178bcdd0260dfaa6e1cbccf042
+  depends:
+  - markdown-it-py >=1.0.0,<4.0.0
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 41972
+  timestamp: 1715570303416
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+  sha256: 64073dfb6bb429d52fff30891877b48c7ec0f89625b1bf844905b66a81cce6e1
+  md5: 776a8dd9e824f77abac30e6ef43a8f7a
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 14680
+  timestamp: 1704317789138
+- conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+  sha256: f95cb70007e3cc2ba44e17c29a056b499e6dadf08746706d0c817c8e2f47e05c
+  md5: 5cbee699846772cc939bef23a0d524ed
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 66022
+  timestamp: 1698947249750
+- conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+  sha256: 6d5839f75780475ad4dffe018026d493e26076f95862550a48424b4d7f6689d8
+  md5: 1073dc92c8f247d94ac14dd79ca0bbec
+  depends:
+  - python
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 12299
+  timestamp: 1534825527617
+- conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+  sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
+  md5: 2ba8498c1018c1e9c61eb99b973dfe19
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12452
+  timestamp: 1600387789153
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_0.conda
+  sha256: da3330a8ffff1f5b15b558543fbec69e05a48750ed50b53369b93da788abedc5
+  md5: 6275b55edf34cfa1f01ba40b699dd915
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5493243
+  timestamp: 1716838925077
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
+  sha256: 589d72d36d61a23b39d6fff2c488f93e29e20de4fc6f5d315b5f2c16e81028bf
+  md5: 15b51397e0fe8ea7d7da60d83eb76ebc
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.8
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27851
+  timestamp: 1710317767117
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+  sha256: 074d858c5808e0a832acc0da37cd70de1565e8d6e17a62d5a11b3902b5e78319
+  md5: e2d2abb421c13456a9a9f80272fdf543
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<3.1
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.8
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - nbconvert =7.16.4=*_1
+  - pandoc >=2.9.2,<4.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189599
+  timestamp: 1718135529468
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+  sha256: 36fe73da4d37bc7ac2d1540526ecd294fbd09acda04e096181ab8f1ccd2b464c
+  md5: 0b57b5368ab7fc7cdc9e3511fa867214
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.8
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101232
+  timestamp: 1712239122969
+- conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+  sha256: 30db21d1f7e59b3408b831a7e0417b83b53ee6223afae56482c5f26da3ceb49a
+  md5: 6598c056f64dc8800d40add25e4e2c34
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11638
+  timestamp: 1705850780510
+- conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.3-pyhd8ed1ab_1.conda
+  sha256: cbd8a6de87ad842e7665df38dcec719873fe74698bc761de5431047b8fada41a
+  md5: d335fd5704b46f4efb89a6774e81aef0
+  depends:
+  - python >=3.10
+  constrains:
+  - pandas >=1.4
+  - numpy >=1.22
+  - matplotlib >=3.5
+  - scipy >=1.9,!=1.11.0,!=1.11.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1185670
+  timestamp: 1712540499262
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+  sha256: e37db45223e432bcad809897177e05fff31828dfcfc3ef18f046ae44ec01286c
+  md5: f81a6fe643390df9347984644727d796
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert-core >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.7
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 308643
+  timestamp: 1715849037288
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+  sha256: 9b5fdef9ebe89222baa9da2796ebe7bc02ec6c5a1f61327b651d6b92cf9a0230
+  md5: 3d85618e2c97ab896b5b5e298d32b5b3
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16880
+  timestamp: 1707957948029
+- conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+  sha256: 5e238e5e646414d517a13f6786c7227206ace58271e3ef63f6adca4d6a4c2839
+  md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
+  depends:
+  - python >=3.6
+  - typing_utils
+  license: Apache-2.0
+  license_family: APACHE
+  size: 30232
+  timestamp: 1706394723472
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+  sha256: 36aca948219e2c9fdd6d80728bcc657519e02f06c2703d8db3446aec67f51d81
+  md5: cbe1bb1f21567018ce595d9c2be0f0db
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: APACHE
+  size: 50290
+  timestamp: 1718189540074
+- conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
+  md5: 457c2c8c08e54905d6954e79cb5b5db9
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11627
+  timestamp: 1631603397334
+- conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.4.4-pyhd8ed1ab_0.conda
+  sha256: 2580dc1cded2da8c4bb3cb457acaaf32fed7740b6ae1dbd47ef887a450107972
+  md5: 4502ea799cb1ccc772b9ac88ed96eb63
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - param >=2.1.0,<3
+  - python >=3.9
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18902842
+  timestamp: 1717330379870
+- conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+  sha256: db644c81c1f47e1fa8134d5de935ec4269d765fbef8d44bd454eb187c7524472
+  md5: bd991333d5bc659bb82bfb5a5d4c1576
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 103339
+  timestamp: 1719325288387
+- conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+  sha256: bfe404eebb930cc41782d34f8fc04c0388ea692eeebe2c5fc28df8ec8d4d61ae
+  md5: 81534b420deb77da8833f2289b8d47ac
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 75191
+  timestamp: 1712320447201
+- conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+  sha256: 472fc587c63ec4f6eba0cc0b06008a6371e0a08a5986de3cf4e8024a47b4fe6c
+  md5: 0badf9c54e24cecfb0ad2f99d680c163
+  depends:
+  - locket
+  - python >=3.9
+  - toolz
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20884
+  timestamp: 1715026639309
+- conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+  sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
+  md5: 629f3203c99b32e0988910c93e77f3b6
+  depends:
+  - ptyprocess >=0.5
+  - python >=3.7
+  license: ISC
+  size: 53600
+  timestamp: 1706113273252
+- conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+  sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
+  md5: 415f0ebb6198cc2801c73438a9fb5761
+  depends:
+  - python >=3
+  license: MIT
+  license_family: MIT
+  size: 9332
+  timestamp: 1602536313357
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+  sha256: b7c1c5d8f13e8cb491c4bd1d0d1896a4cf80fc47de01059ad77509112b664a4a
+  md5: f586ac1e56c8638b64f9c8122a7b8a67
+  depends:
+  - python >=3.7
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 1398245
+  timestamp: 1706960660581
+- conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+  sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
+  md5: 405678b942f2481cecdb3e010f4925d9
+  depends:
+  - python >=3.6
+  license: MIT AND PSF-2.0
+  size: 10778
+  timestamp: 1694617398467
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.2-pyhd8ed1ab_0.conda
+  sha256: adc59384cf0b2fc6dc7362840151e8cb076349197a38f7230278252698a88442
+  md5: 6f6cf28bf8e021933869bae3f84b8fc9
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 20572
+  timestamp: 1715777739019
+- conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+  sha256: 2f227e17b3c0346112815faa605502b66c1c4511a856127f2899abf15a98a2cf
+  md5: d8d7293c5b37f39b2ac32940621c6592
+  license: BSD-3-Clause AND (GPL-2.0-only OR GPL-3.0-only)
+  license_family: OTHER
+  size: 2348171
+  timestamp: 1675353652214
+- conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.20.0-pyhd8ed1ab_0.conda
+  sha256: 757cd91d01c2e0b64fadf6bc9a11f558cf7638d897dfbaf7415ddf324d5405c9
+  md5: 9a19b94034dd3abb2b348c8b93388035
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: Apache
+  size: 48913
+  timestamp: 1707932844383
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
+  sha256: d93ac5853e398aaa10f0dd7addd64b411f94ace1f9104d619cd250e19a5ac5b4
+  md5: 1247c861065d227781231950e14fe817
+  depends:
+  - python >=3.7
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.47
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270710
+  timestamp: 1718048095491
+- conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+  sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+  md5: 359eeb6536da0e687af562ed265ec263
+  depends:
+  - python
+  license: ISC
+  size: 16546
+  timestamp: 1609419417991
+- conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+  sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
+  md5: 6784285c7e55cb7212efabc79e4c2883
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14551
+  timestamp: 1642876055775
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyarrow-hotfix-0.6-pyhd8ed1ab_0.conda
+  sha256: 9b767969d059c106aac6596438a7e7ebd3aa1e2ff6553d4b7e05126dfebf4bd6
+  md5: ccc06e6ef2064ae129fab3286299abda
+  depends:
+  - pyarrow >=0.14
+  - python >=3.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 13567
+  timestamp: 1700596511761
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+  sha256: 406001ebf017688b1a1554b49127ca3a4ac4626ec0fd51dc75ffa4415b720b64
+  md5: 844d9eb3b43095b031874477f7d70088
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105098
+  timestamp: 1711811634025
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+  sha256: 0e1e17a37d53be84c33b88218f10afb5f8137f19a727fdc56e45ae0b8b439a57
+  md5: 24c245c82396be3297c0aa26b69e18d8
+  depends:
+  - param >=1.7.0
+  - python >=3.7
+  - pyyaml
+  - requests
+  - setuptools >=61.0
+  constrains:
+  - pyct-core <0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20096
+  timestamp: 1701103924264
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+  sha256: 78267adf4e76d0d64ea2ffab008c501156c108bb08fecb703816fb63e279780b
+  md5: b7f5c092b8f9800150d998a71b76d5a1
+  depends:
+  - python >=3.8
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 879295
+  timestamp: 1714846885370
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
+  sha256: 06c77cb03e5dde2d939b216c99dd2db52ea93a4c7c599f3882f136005c359c7b
+  md5: b9a4dacf97241704529131a0dfc0494f
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 89455
+  timestamp: 1709721146886
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 41eced0d5e855bc52018f200b239d627daa38ad78a655ffa2f1efd95b07b6bce
+  md5: 92a889dc236a5197612bc85bee6d7174
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 964060
+  timestamp: 1659003065197
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
+  sha256: b3a612bc887f3dd0fb7c4199ad8e342bd148cf69a9b74fd9468a18cf2bef07b7
+  md5: 56cd9fe388baac0e90c7149cfac95b60
+  depends:
+  - __win
+  - python >=3.8
+  - win_inet_pton
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19348
+  timestamp: 1661605138291
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+  sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+  md5: 2a7de29fb590ca14b5243c4c812c8025
+  depends:
+  - __unix
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18981
+  timestamp: 1661604969727
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+  sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
+  md5: 2cf4264fffb9e6eff6031c5b6884d61c
+  depends:
+  - python >=3.7
+  - six >=1.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 222742
+  timestamp: 1709299922152
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
+  sha256: 7d8c931b89c9980434986b4deb22c2917b58d9936c3974139b9c10ae86fdfe60
+  md5: b98d2018c01ce9980c03ee2850690fab
+  depends:
+  - python >=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 226165
+  timestamp: 1718477110630
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+  sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
+  md5: a61bf9ec79426938ff785eb69dbb1960
+  depends:
+  - python >=3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13383
+  timestamp: 1677079727691
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
+  sha256: 9da9a849d53705dee450b83507df1ca8ffea5f83bd21a215202221f1c492f8ad
+  md5: 98206ea9954216ee7540f0c773f2104d
+  depends:
+  - python >=3.6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 144024
+  timestamp: 1707747742930
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+  sha256: 1a7d6b233f7e6e3bbcbad054c8fd51e690a67b129a899a056a5e45dd9f00cb41
+  md5: 3eeeeb9e4827ace8c0c1419c85d590ad
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 188538
+  timestamp: 1706886944988
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.2-pyhd8ed1ab_1.conda
+  sha256: 11ed55e8df7526aacf06bd16854a17ff98d0100f032507932380d172dbaceca4
+  md5: 7dbdded7e27acfe3f29fa47daa5ac5ac
+  depends:
+  - param
+  - python >=3.6
+  constrains:
+  - jupyterlab >=4.0,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48296
+  timestamp: 1715168431327
+- conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+  sha256: be8d6d9e86b1a3fef5424127ff81782f8ca63d3058980859609f6f1ecdd34cb3
+  md5: 0fc8b52192a8898627c3efae1003e9f6
+  depends:
+  - attrs >=22.2.0
+  - python >=3.8
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 42210
+  timestamp: 1714619625532
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+  sha256: 5845ffe82a6fa4d437a2eae1e32a1ad308d7ad349f61e337c0a890fe04c513cc
+  md5: 5ede4753180c7a550a443c430dc8ab52
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.8
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 58810
+  timestamp: 1717057174842
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
+  md5: fed45fc5ea0813240707998abe49f520
+  depends:
+  - python >=3.5
+  - six
+  license: MIT
+  license_family: MIT
+  size: 8064
+  timestamp: 1638811838081
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+  sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
+  md5: 912a71cc01012ee38e6b90ddd561e36f
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 7818
+  timestamp: 1598024297745
+- conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.16.0-pyhd8ed1ab_0.conda
+  sha256: b63b43fac200261b2667666f45894fbe068101e4a57926b72f4d82fe2e5b78c1
+  md5: e651425fab6f281a049b785d1d630b1a
+  depends:
+  - numpy >=1.23
+  - packaging
+  - pyproj >=3.3
+  - python >=3.10
+  - rasterio >=1.3
+  - scipy
+  - xarray >=2022.3.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51117
+  timestamp: 1720478614024
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_0.conda
+  sha256: c4401b071e86ddfa0ea4f34b85308db2516b6aeca50053535996864cfdee7b3f
+  md5: 778594b20097b5a948c59e50ae42482a
+  depends:
+  - __linux
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22868
+  timestamp: 1712585140895
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
+  sha256: f911307db932c92510da6c3c15b461aef935720776643a1fbf3683f61001068b
+  md5: c3cb67fc72fb38020fe7923dbbcf69b0
+  depends:
+  - __osx
+  - pyobjc-framework-cocoa
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23165
+  timestamp: 1712585504123
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_0.conda
+  sha256: d8aa230501a33250af2deee03006a2579f0335e7240a9c7286834788dcdcfaa8
+  md5: 5a86a21050ca3831ec7f77fb302f1132
+  depends:
+  - __win
+  - python >=3.7
+  - pywin32
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23319
+  timestamp: 1712585816346
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-70.3.0-pyhd8ed1ab_0.conda
+  sha256: 869ea7688c040911ac1050d5765fa1f3d8ea1858c9f9cecb0df136a2f5e44f46
+  md5: 693bb57e8f92120caa956898065f3627
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 496453
+  timestamp: 1720782643725
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+  sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
+  md5: e5f25f8dbc060e9a8d912e432202afc2
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 14259
+  timestamp: 1620240338595
+- conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+  sha256: bc12100b2d8836b93c55068b463190505b8064d0fc7d025e89f20ebf22fe6c2b
+  md5: 490730480d76cf9c8f8f2849719c6e2b
+  depends:
+  - python >=3.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 15064
+  timestamp: 1708953086199
+- conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2
+  sha256: ebb8f5f9e362f186fb7d732e656f85c969b86309494436eba51cc3b8b96683f7
+  md5: cb83a3d6ecf73f50117635192414426a
+  depends:
+  - numpy
+  - pyparsing >=2.1.6
+  - python
+  license: MIT
+  license_family: MIT
+  size: 8136
+  timestamp: 1568905295860
+- conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
+  md5: 6d6552722448103793743dabfbda532d
+  depends:
+  - python >=2.7
+  license: Apache-2.0
+  license_family: APACHE
+  size: 26314
+  timestamp: 1621217159824
+- conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+  sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
+  md5: 3f144b2c34f8cb5a9abd9ed23a39c561
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 36754
+  timestamp: 1693929424267
+- conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+  sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
+  md5: e7df0fdd404616638df5ece6e69ba7af
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 26205
+  timestamp: 1669632203115
+- conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+  sha256: 2e2c255b6f24a6d75b9938cb184520e27db697db2c24f04e18342443ae847c0a
+  md5: 04eedddeb68ad39871c8127dd1c21f4f
+  depends:
+  - python >=3.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17386
+  timestamp: 1702066480361
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+  sha256: b300557c0382478cf661ddb520263508e4b3b5871b471410450ef2846e8c352c
+  md5: efba281bbdae5f6b0a1d53c6d4a97c93
+  depends:
+  - __linux
+  - ptyprocess
+  - python >=3.8
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22452
+  timestamp: 1710262728753
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+  sha256: 4daae56fc8da17784578fbdd064f17e3b3076b394730a14119e571707568dc8a
+  md5: 00b54981b923f5aefcd5e8547de056d5
+  depends:
+  - __osx
+  - ptyprocess
+  - python >=3.8
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22717
+  timestamp: 1710265922593
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
+  sha256: 8cb078291fd7882904e3de594d299c8de16dd3af7405787fce6919a385cfc238
+  md5: 4abd500577430a942a995fd0d09b76a2
+  depends:
+  - __win
+  - python >=3.8
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22883
+  timestamp: 1710262943966
+- conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
+  sha256: 45e402941f6bed094022c5726a2ca494e6224b85180d2367fb6ddd9aea68079d
+  md5: df68d78237980a159bd7149f33c0e8fd
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23548
+  timestamp: 1714400228771
+- conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.3.0-pyhd8ed1ab_0.conda
+  sha256: bc55e5899e66805589c02061e315bfc23ae6cc2f2811f5cc13fb189a5ed9d90f
+  md5: 8662629d9a05f9cff364e31ca106c1ac
+  depends:
+  - python >=3.5
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25405
+  timestamp: 1713975078735
+- conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.1-pyhd8ed1ab_0.conda
+  sha256: 22b0a9790317526e08609d5dfdd828210ae89e6d444a9e954855fc29012e90c6
+  md5: 2fcb582444635e2c402e8569bb94e039
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 52358
+  timestamp: 1706112720607
+- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.4-pyhd8ed1ab_0.conda
+  sha256: 75342f40a69e434a1a23003c3e254a95dca695fb14955bc32f1819cd503964b2
+  md5: e74cd796e70a4261f86699ee0a3a7a24
+  depends:
+  - colorama
+  - python >=3.7
+  license: MPL-2.0 or MIT
+  size: 89452
+  timestamp: 1714855008479
+- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+  sha256: 8a64fa0f19022828513667c2c7176cfd125001f3f4b9bc00d33732e627dd2592
+  md5: 3df84416a021220d8b5700c613af2dc5
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110187
+  timestamp: 1713535244513
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20240316-pyhd8ed1ab_0.conda
+  sha256: 6630bbc43dfb72339fadafc521db56c9d17af72bfce459af195eecb01163de20
+  md5: 7831efa91d57475373ee52fb92e8d137
+  depends:
+  - python >=3.6
+  license: Apache-2.0 AND MIT
+  size: 21769
+  timestamp: 1710590028155
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+  sha256: d3b9a8ed6da7c9f9553c5fd8a4fca9c3e0ab712fa5f497859f82337d67533b73
+  md5: 52d648bd608f5737b123f510bb5514b5
+  depends:
+  - typing_extensions 4.12.2 pyha770c72_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 10097
+  timestamp: 1717802659025
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+  sha256: 0fce54f8ec3e59f5ef3bb7641863be4e1bf1279623e5af3d3fa726e8f7628ddb
+  md5: ebe6952715e1d5eb567eeebf25250fa7
+  depends:
+  - python >=3.8
+  license: PSF-2.0
+  license_family: PSF
+  size: 39888
+  timestamp: 1717802653893
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 9e3758b620397f56fb709f796969de436d63b7117897159619b87938e1f78739
+  md5: eb67e3cace64c66233e2d35949e20f92
+  depends:
+  - python >=3.6.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 13829
+  timestamp: 1622899345711
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+  sha256: 7b2b69c54ec62a243eb6fba2391b5e443421608c3ae5dbff938ad33ca8db5122
+  md5: 161081fc7cec0bfda0d86d7cb595f8d8
+  license: LicenseRef-Public-Domain
+  size: 119815
+  timestamp: 1706886945727
+- conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+  sha256: 54293cd94da3a6b978b353eb7897555055d925ad0008bc73e85cca19e2587ed0
+  md5: 3b7fc78d7be7b450952aaa916fb78877
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 11162
+  timestamp: 1707507514699
+- conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+  sha256: b76904b53721dc88a46352324c79d2b077c2f74a9f7208ad2c4249892669ae94
+  md5: 0944dc65cb4a9b5b68522c3bb585d41c
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 23999
+  timestamp: 1688655976471
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
+  sha256: 00c47c602c03137e7396f904eccede8cc64cc6bad63ce1fc355125df8882a748
+  md5: e804c43f58255e977093a2298e442bb8
+  depends:
+  - brotli-python >=1.0.9
+  - h2 >=4,<5
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.8
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 95048
+  timestamp: 1719391384778
+- conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+  sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
+  md5: 68f0738df502a14213624b288c60c9ad
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 32709
+  timestamp: 1704731373922
+- conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.6.0-pyhd8ed1ab_0.conda
+  sha256: 6377de3bc05b80f25c5fe75f180a81fc8a6aa601d4b228161f75f78862d00a0f
+  md5: 419f2f6cf90fc7a6feee657752cd0f7b
+  depends:
+  - python >=3.5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18291
+  timestamp: 1717667379821
+- conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+  sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
+  md5: daf5160ff9cde3a468556965329085b9
+  depends:
+  - python >=2.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15600
+  timestamp: 1694681458271
+- conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+  sha256: 44a5e3b97feef24cd719f7851cca9af9799dc9c17d3e0298d5856baab2d682f5
+  md5: f372c576b8774922da83cda2b12f9d29
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: APACHE
+  size: 47066
+  timestamp: 1713923494501
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
+  sha256: cb318f066afd6fd64619f14c030569faf3f53e6f50abf743b4c865e7d95b96bc
+  md5: 0b5293a157c2b5cd513dd1b03d8d3aae
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 57963
+  timestamp: 1711546009410
+- conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyhd8ed1ab_6.tar.bz2
+  sha256: a11ae693a0645bf6c7b8a47bac030be9c0967d0b1924537b9ff7458e832c0511
+  md5: 30878ecc4bd36e8deeea1e3c151b2e0b
+  depends:
+  - __win
+  - python >=3.6
+  license: PUBLIC-DOMAIN
+  size: 8191
+  timestamp: 1667051294134
+- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.6.0-pyhd8ed1ab_1.conda
+  sha256: 782aaa095b246f18c2486826d2a71d886b2b4b99c08378f2bfda5d61877e509b
+  md5: a6775bba72ade3fd777ccac04902202c
+  depends:
+  - numpy >=1.23
+  - packaging >=23.1
+  - pandas >=2.0
+  - python >=3.9
+  constrains:
+  - sparse >=0.14
+  - nc-time-axis >=1.4
+  - netcdf4 >=1.6.0
+  - pint >=0.22
+  - dask-core >=2023.4
+  - toolz >=0.12
+  - cartopy >=0.21
+  - bottleneck >=1.3
+  - iris >=3.4
+  - zarr >=2.14
+  - matplotlib-base >=3.7
+  - h5py >=3.8
+  - hdf5 >=1.12
+  - cftime >=1.6
+  - h5netcdf >=1.1
+  - flox >=0.7
+  - distributed >=2023.4
+  - seaborn-base >=0.12
+  - numba >=0.56
+  - scipy >=1.10
+  license: Apache-2.0
+  license_family: APACHE
+  size: 788402
+  timestamp: 1718302275503
+- conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.6.0-pyhd8ed1ab_0.conda
+  sha256: da2e54cb68776e62a708cb6d5f026229d8405ff4cfd8a2446f7d386f07ebc5c1
+  md5: de631703d59e40af41c56c4b4e2928ab
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 46663
+  timestamp: 1717752234053
+- conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.18.2-pyhd8ed1ab_0.conda
+  sha256: 16685f7412d79345732e889595a881ee320b85abd44f7244c0f7e628d9d976ec
+  md5: 02f53038910b6fbc9d36bd5f663318e8
+  depends:
+  - asciitree
+  - fasteners
+  - numcodecs >=0.10.0,<0.16.0a0
+  - numpy >=1.23
+  - python >=3.9
+  constrains:
+  - notebook
+  - ipywidgets >=8.0.0
+  - ipytree >=0.2.2
+  license: MIT
+  license_family: MIT
+  size: 160260
+  timestamp: 1716779819794
+- conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+  sha256: 3d65c081514569ab3642ba7e6c2a6b4615778b596db6b1c82ee30a2d912539e5
+  md5: cf30c2c15b82aacb07f9c09e28ff2275
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36325
+  timestamp: 1681770298596
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.19.2-pyhd8ed1ab_0.conda
+  sha256: e3e9c8501f581bfdc4700b83ea283395e237ec6b9b5cbfbedb556e1da6f4fdc9
+  md5: 49808e59df5535116f6878b2a820d6f4
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 20917
+  timestamp: 1718013395428
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.9.5-py311he705e18_0.conda
+  sha256: 6e1c28d255830f350ccc135db4932153a978956d480e7bcd26c1663e19db4f9d
+  md5: a955769e6187495614f719668695e28f
+  depends:
+  - aiosignal >=1.1.2
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - multidict >=4.5,<7.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yarl >=1.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  size: 779497
+  timestamp: 1713965157234
+- conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h2725bcf_4.conda
+  sha256: be27659496bcb660fc9c3f5f74128a7bb090336897e9c7cfbcc55ae66f13b8d8
+  md5: e2aba0ad0f533ee73f9d4330d2e32549
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 32542
+  timestamp: 1695386887016
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.22-hb04b931_10.conda
+  sha256: b95a2f9adc0b77c88b10c6001eb101d6b76bb0efdf80a8fa7e99c510e8236ed2
+  md5: 58e7453d9442ec10c3bfbe3466502baf
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-c-sdkutils >=0.1.16,<0.1.17.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 92326
+  timestamp: 1720943225649
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.7.1-hd73d8db_1.conda
+  sha256: 40d2903b718bd4ddf4706ff4e86831c11a012e1a662f73e30073b4f7f364fcca
+  md5: a8735aa1de30e27dc87bde25dd3201d8
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 39142
+  timestamp: 1720901553777
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.23-hfdf4475_0.conda
+  sha256: 63680a7e163a947eb97f68cf1d5dd26fe0fef9443196de4fc31615b28d6095a7
+  md5: 35083fa12de9dc9918de60c112ceab27
+  depends:
+  - __osx >=10.13
+  license: Apache-2.0
+  license_family: Apache
+  size: 225527
+  timestamp: 1718918230587
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.18-hd73d8db_7.conda
+  sha256: c8fabda8233f979f9c5173a5ba5f6482c26e8ac8af55e78550fff27e997e0dbd
+  md5: b082d6b9a40e41fd27f48786d318e910
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18245
+  timestamp: 1718967218275
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.2-h2713d70_15.conda
+  sha256: 410497c0175beb16b9564ce43f44ed284f19ee1b42b968ad1bd69f4d3c49296a
+  md5: 21aeef6fb90f64d3625f06501c4d023c
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-checksums >=0.1.18,<0.1.19.0a0
+  - libcxx >=16
+  license: Apache-2.0
+  license_family: Apache
+  size: 46353
+  timestamp: 1720743940835
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.2-he29c2fd_6.conda
+  sha256: 8acfcfb37640b3482ddb7b8f43ca72a698c60ac3208e7f54edf47354cb21a382
+  md5: 9b1b61150532b6c5eda36700a408209d
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-compression >=0.2.18,<0.2.19.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 162753
+  timestamp: 1720753184386
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.10-h4406d91_1.conda
+  sha256: 928f7fdffec3c8c3ee8cb5c2bcc6f23f404d89a9b260e4dac96eb8e12d959d31
+  md5: 975be62a8eb5e601ff6f888420dab870
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 137548
+  timestamp: 1720718795509
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.4-hf6997d9_8.conda
+  sha256: 5b25821cd94e77459c7b0011df094d4ed67d04092639f84b79bf57e506eecd2e
+  md5: dfa33f1d17f9e18b54411bf2eeff0b55
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 138716
+  timestamp: 1720751463402
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.6.0-h13137a3_2.conda
+  sha256: f4bd86c0fa2e779ee01a8fa870177617d51467ea1cffa00a32e1e8abed2e0a5d
+  md5: 7564d61ed7073be23ca8fbce2fc5806a
+  depends:
+  - __osx >=10.13
+  - aws-c-auth >=0.7.22,<0.7.23.0a0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-checksums >=0.1.18,<0.1.19.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95794
+  timestamp: 1720949972170
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.16-hd73d8db_3.conda
+  sha256: b944db69a4bf7481362378d81ff634b5eeed88f0b85c6609f195cd68ab3a8948
+  md5: 7932c9b2420f0a809ab1b08e2ea53896
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 49533
+  timestamp: 1718973334715
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.18-hd73d8db_7.conda
+  sha256: a4e2dc37e4bbb2d64d1fac29c1d9fbc7c50ad3b5e15ff52e05ae63e8052e54d3
+  md5: c3f25d79d4a36a89b3c638a6e3614f28
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 49210
+  timestamp: 1718973197891
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.27.3-h0a15bd7_2.conda
+  sha256: 718d350e8a0cf3bb09373da2e11820f3cb7e453fd95ad5ab14c104e4701b26bc
+  md5: 58f9e6e6e0848a4dda31c123c577107a
+  depends:
+  - __osx >=10.13
+  - aws-c-auth >=0.7.22,<0.7.23.0a0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-event-stream >=0.4.2,<0.4.3.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-c-mqtt >=0.10.4,<0.10.5.0a0
+  - aws-c-s3 >=0.6.0,<0.6.1.0a0
+  - aws-c-sdkutils >=0.1.16,<0.1.17.0a0
+  - libcxx >=16
+  license: Apache-2.0
+  license_family: Apache
+  size: 291354
+  timestamp: 1720963559899
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.329-h554caeb_9.conda
+  sha256: a9b6751a5a80f8713e55256afccdd96efd3442b9791ce8bd2e40c49ac0dc95f6
+  md5: a875dc66bc06f0bf49dc9739e6e2fbab
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-event-stream >=0.4.2,<0.4.3.0a0
+  - aws-checksums >=0.1.18,<0.1.19.0a0
+  - aws-crt-cpp >=0.27.3,<0.27.4.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libcxx >=16
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3417533
+  timestamp: 1720817049208
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.12.0-hf8dbe3c_0.conda
+  sha256: c6ea0cec8d2a6d1cb6c30105f7e99fb8bf3de6cbd8c36dafb972517998725448
+  md5: bbe2fcdfbdd6bb570691ea3c814bf0ea
+  depends:
+  - __osx >=10.13
+  - libcurl >=8.7.1,<9.0a0
+  - libcxx >=16
+  - openssl >=3.3.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 305101
+  timestamp: 1715352440366
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.8.0-h906f3f0_1.conda
+  sha256: d6656ddfd349b546105f9b47944f2fe3200601d5fa31e13236b3a248e85faa47
+  md5: 710118f53411ec0f8b8832cb52374d72
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.12.0,<1.12.1.0a0
+  - libcxx >=16
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 152268
+  timestamp: 1718986617037
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.11.0-h5f32033_1.conda
+  sha256: b77b800ff43ed3ef54c78a66e280905244086d8cb5188ba2c04c3b0fb4708528
+  md5: ac9d444eda34370acdf088291aeeaf5b
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.12.0,<1.12.1.0a0
+  - azure-storage-common-cpp >=12.6.0,<12.6.1.0a0
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  size: 427452
+  timestamp: 1718994110504
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.6.0-h0dc8e96_1.conda
+  sha256: 8ca1fa9c687825bb8fc6578e6d29569d1a0158361e1f9217e018ab1c0743e9c4
+  md5: 91bbe2122324a2044d5d174b493d4670
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.12.0,<1.12.1.0a0
+  - libcxx >=16
+  - libxml2 >=2.12.7,<2.14.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 116244
+  timestamp: 1718986878532
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-files-datalake-cpp-12.10.0-hc1cec4e_1.conda
+  sha256: e632fb435a08ca7d44e7adf5f45aa7128587b36e96bdd6771a051782e6124079
+  md5: 9a035eab2cbda7b3e2d2ccc5013e8604
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.12.0,<1.12.1.0a0
+  - azure-storage-blobs-cpp >=12.11.0,<12.11.1.0a0
+  - azure-storage-common-cpp >=12.6.0,<12.6.1.0a0
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  size: 190030
+  timestamp: 1719000148151
+- conda: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.6-h7d75f6d_0.conda
+  sha256: 65e5f5dd3d68ed0d9d35e79d64f8141283cad2b55dcd9a04480ceea0e436aca8
+  md5: 3e5669e51737d04f4806dd3e8c424663
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 47051
+  timestamp: 1719266142315
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h0dc2134_1.conda
+  sha256: 4bf66d450be5d3f9ebe029b50f818d088b1ef9666b1f19e90c85479c77bbdcde
+  md5: 9272dd3b19c4e8212f8542cefd5c3d67
+  depends:
+  - brotli-bin 1.1.0 h0dc2134_1
+  - libbrotlidec 1.1.0 h0dc2134_1
+  - libbrotlienc 1.1.0 h0dc2134_1
+  license: MIT
+  license_family: MIT
+  size: 19530
+  timestamp: 1695990310168
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h0dc2134_1.conda
+  sha256: 7ca3cfb4c5df314ed481301335387ab2b2ee651e2c74fbb15bacc795c664a5f1
+  md5: ece565c215adcc47fc1db4e651ee094b
+  depends:
+  - libbrotlidec 1.1.0 h0dc2134_1
+  - libbrotlienc 1.1.0 h0dc2134_1
+  license: MIT
+  license_family: MIT
+  size: 16660
+  timestamp: 1695990286737
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hdf8f085_1.conda
+  sha256: 0f5e0a7de58006f349220365e32db521a1fe494c37ee455e5ecf05b8fe567dcc
+  md5: 546fdccabb90492fbaf2da4ffb78f352
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 h0dc2134_1
+  license: MIT
+  license_family: MIT
+  size: 366864
+  timestamp: 1695990449997
+- conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+  sha256: cad153608b81fb24fc8c509357daa9ae4e49dfc535b2cb49b91e23dbd68fc3c5
+  md5: 7ed4301d437b59045be7e051a0308211
+  depends:
+  - __osx >=10.13
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 134188
+  timestamp: 1720974491916
+- conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.32.2-h51dda26_0.conda
+  sha256: b900aed0d474caed6735ba9936f372eb45df4f43c893fcc0e7b434372fa3c5c8
+  md5: be4a9b58fcf1374aeb79e873c1166e19
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 160929
+  timestamp: 1721066014296
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.7.4-h8857fd0_0.conda
+  sha256: d16f46c489cb3192305c7d25b795333c5fc17bb0986de20598ed519f8c9cc9e4
+  md5: 7df874a4b05b2d2b82826190170eaa0f
+  license: ISC
+  size: 154473
+  timestamp: 1720077510541
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h9f650ed_2.conda
+  sha256: 1d2480538838cf5009df0285a73aa405798bc49de0c689ab270f543f5ae961aa
+  md5: d264e5b9759cab8d203cdfe43eabd8b5
+  depends:
+  - __osx >=10.13
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=73.2,<74.0a0
+  - libcxx >=16
+  - libglib >=2.80.2,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.4,<1.0a0
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 886028
+  timestamp: 1718985776278
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cartopy-0.23.0-py311hfdcbad3_1.conda
+  sha256: b00d69422714f4d6c6de829cfcc4159321f9889748855d17e99fb52ad685fad6
+  md5: ef200bd6d71024725c18237a8012fd7f
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - matplotlib-base >=3.5
+  - numpy >=1.19,<3
+  - packaging >=20
+  - pyproj >=3.3.1
+  - pyshp >=2.3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - shapely >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1511877
+  timestamp: 1715897639389
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.16.0-py311hc0b63fd_0.conda
+  sha256: 1f13a5fa7f310fdbd27f5eddceb9e62cfb10012c58a58c923dd6f51fa979748a
+  md5: 15d07b82223cac96af629e5e747ba27a
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 289932
+  timestamp: 1696002096156
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cfitsio-4.4.1-ha105788_0.conda
+  sha256: 6b54b24abd3122d33d80a59a901cd51b26b6d47fbb9f84c2bf1f87606e9899c6
+  md5: 99445be39aaea44a05046c479f8c6dc9
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.3.1,<2.0a0
+  license: LicenseRef-fitsio
+  size: 849075
+  timestamp: 1718906514228
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cftime-1.6.4-py311hce3442d_0.conda
+  sha256: 2df629f269bb8c82a5c9310f37ea278ee62987a6745110b794562f21f8708956
+  md5: d7d27c26b91d3ebb7efdae3e0afa619a
+  depends:
+  - __osx >=10.13
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 213388
+  timestamp: 1718096811666
+- conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.2.1-py311h1d816ee_0.conda
+  sha256: b33d5801564943bbbbe939a9ec4d460b2e0ced624089bdfe0bfa2a5e5d8fa1f3
+  md5: 4f7502f4d2cddbea5feba4e82d99c6c4
+  depends:
+  - libcxx >=16
+  - numpy >=1.20
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 249875
+  timestamp: 1712430222440
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-0.12.3-py311he705e18_0.conda
+  sha256: ef0ce284ca238ab279d7c0ffc7710e0e797855d07f1be3d5ae6cf17389311f15
+  md5: e5d928a48ce4a515ac69d5f65fda1a60
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 343617
+  timestamp: 1706897348938
+- conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.2-py311hbafa61a_0.conda
+  sha256: ebf44cc0eaa650f9cdb85045cbef1c2ebb4ef74fabb8394a1e5cd5f4ae06bb8e
+  md5: 404cbe80fc0990a9965bdb8622c6f5a4
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2264268
+  timestamp: 1719378841584
+- conda: https://conda.anaconda.org/conda-forge/osx-64/expat-2.6.2-h73e2aa4_0.conda
+  sha256: 0fd1befb18d9d937358a90d5b8f97ac2402761e9d4295779cbad9d7adfb47976
+  md5: dc0882915da2ec74696ad87aa2350f27
+  depends:
+  - libexpat 2.6.2 h73e2aa4_0
+  license: MIT
+  license_family: MIT
+  size: 126612
+  timestamp: 1710362607162
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-10.2.1-h7728843_0.conda
+  sha256: 2faeccfe2b9f7c028cf271f66757365fe43b15a1234084c16f159646a646ccbc
+  md5: ab205d53bda43d03f5c5b993ccb406b3
+  depends:
+  - libcxx >=15
+  license: MIT
+  license_family: MIT
+  size: 181468
+  timestamp: 1704454938658
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.14.2-h5bb23bf_0.conda
+  sha256: f63e6d1d6aef8ba6de4fc54d3d7898a153479888d40ffdf2e4cfad6f92679d34
+  md5: 86cc5867dfbee4178118392bae4a3c89
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 237068
+  timestamp: 1674829100063
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.53.1-py311h72ae277_0.conda
+  sha256: a7f9b44870386c7fbb67ede9a2e7736e612e0b72c08a12353abd528c80e1adbf
+  md5: 8fced2d56f0b77c803cf31d9cd06e7a5
+  depends:
+  - __osx >=10.13
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2826047
+  timestamp: 1720359212068
+- conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+  sha256: b292cf5a25f094eeb4b66e37d99a97894aafd04a5683980852a8cbddccdc8e4e
+  md5: 25152fce119320c980e5470e64834b50
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 599300
+  timestamp: 1694616137838
+- conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3ec172f_0.conda
+  sha256: 9d59f1894c3b526e6806e376e979b81d0df23a836415122b86458aef72cda24a
+  md5: 640c34a8084e2a812bcee5b804597fc9
+  depends:
+  - libexpat >=2.5.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - minizip >=4.0.1,<5.0a0
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 54007
+  timestamp: 1694952882265
+- conda: https://conda.anaconda.org/conda-forge/osx-64/frozenlist-1.4.1-py311he705e18_0.conda
+  sha256: 6c496e4a740f191d7ab23744d39bd6d415789f9d5dcf74ed043a16a3f8968ef4
+  md5: 6b64f053b1a2e3bfe1f93c2714844ef0
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 53105
+  timestamp: 1702645839241
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.9.1-py311h055bc3f_2.conda
+  sha256: b539d1b7636bc8ee7929da2b6a8015cb3b25397d3e1bf2ceb689eab2e3a202f3
+  md5: 4eb16798fae5264d73cca13cf324f1ac
+  depends:
+  - __osx >=10.13
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libcxx >=16
+  - libgdal 3.9.1 hc21aedb_2
+  - libxml2 >=2.12.7,<2.14.0a0
+  - numpy >=1.19,<3
+  - openssl >=3.3.1,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 1694108
+  timestamp: 1719487432882
+- conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.12.1-h93d8f39_0.conda
+  sha256: 6feffb0d1999a22c5f94d2168b1af9c5fbdd25c9a963a6825ee32cf05e5c07f5
+  md5: d13f05ed3985f57456b610bab66366db
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  license: LGPL-2.1-only
+  size: 1462098
+  timestamp: 1699778844758
+- conda: https://conda.anaconda.org/conda-forge/osx-64/geotiff-1.7.3-h4bbec01_1.conda
+  sha256: 7f5c0d021822e12cd64848caa77d43398cea90381f420d6f973877f3eccc2188
+  md5: 94b592c68bb826b1ffee62524b117aa2
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.4.0,<9.5.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 116364
+  timestamp: 1717777078423
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hb1e8313_1004.tar.bz2
+  sha256: 39540f879057ae529cad131644af111a8c3c48b384ec6212de6a5381e0863948
+  md5: 3f59cc77a929537e42120faf104e0d16
+  depends:
+  - libcxx >=10.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94612
+  timestamp: 1599590973213
+- conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h10d778d_0.conda
+  sha256: 2c825df829097536314a195ae5cacaa8695209da6b4400135a65d8e23c008ff8
+  md5: 03e8c9b4d3da5f3d6eabdd020c2d63ac
+  license: MIT
+  license_family: MIT
+  size: 74516
+  timestamp: 1712692686914
+- conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h2790a97_0.conda
+  sha256: dd56547db8625eb5c91bb0a9fbe8bd6f5c7fbf5b6059d46365e94472c46b24f9
+  md5: 06cf91665775b0da395229cd4331b27d
+  depends:
+  - __osx >=10.13
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 117017
+  timestamp: 1718284325443
+- conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
+  sha256: 8c767cc71226e9eb62649c903c68ba73c5f5e7e3696ec0319d1f90586cebec7d
+  md5: 7ce543bf38dbfae0de9af112ee178af2
+  depends:
+  - libcxx >=15.0.7
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 724103
+  timestamp: 1695661907511
+- conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.3-nompi_h687a608_105.conda
+  sha256: 98f8350730d09e8ad7b62ca6d6be38ee2324b11bbcd1a5fe2cac619b12cd68d7
+  md5: 98544299f6bb2ef4d7362506a3dde886
+  depends:
+  - __osx >=10.13
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libcxx >=16
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3733954
+  timestamp: 1717588360008
+- conda: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
+  sha256: f66362dc36178ac9b7c7a9b012948a9d2d050b3debec24bbd94aadbc44854185
+  md5: 5cc301d759ec03f28328428e28f65591
+  license: MIT
+  license_family: MIT
+  size: 11787527
+  timestamp: 1692901622519
+- conda: https://conda.anaconda.org/conda-forge/osx-64/json-c-0.17-h6253ea5_1.conda
+  sha256: 66ddd1a4d643c7c800a1bb8e61f5f4198ec102be37db9a6d2e037004442eff8d
+  md5: fb72a2ef514c2df4ba035187945a6dcf
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 72163
+  timestamp: 1720813111542
+- conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_0.conda
+  sha256: b98237f5071161a30b711062b1c9306a2f7abea0b97fabfeff662919f40d1f00
+  md5: e6239ae1b58ab3e7f6863ee46dba46b5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18107
+  timestamp: 1718283517513
+- conda: https://conda.anaconda.org/conda-forge/osx-64/jupyter_core-5.7.2-py311h6eed73b_0.conda
+  sha256: 3078f27009ce1f3cdd46dc97bd4f3f51277aa5957f6a90e300c613bd848767b7
+  md5: 582fe977a5a6b9f37a72ff34a753381e
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 95661
+  timestamp: 1710257750738
+- conda: https://conda.anaconda.org/conda-forge/osx-64/kealib-1.5.3-hb2b617a_1.conda
+  sha256: 3150dedf047284e8b808a169dfe630d818d8513b79d08a5404b90973c61c6914
+  md5: e24e1fa559fd29c34593d6a47b459443
+  depends:
+  - __osx >=10.13
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  size: 152270
+  timestamp: 1716158359765
+- conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.5-py311h5fe6e05_1.conda
+  sha256: 586a4d0a17e6cfd9f8fdee56106d263ee40ca156832774d6e899f82ad68ac8d0
+  md5: 24305b23f7995de72bbd53b7c01242a2
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 60694
+  timestamp: 1695380246398
+- conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+  sha256: 83b52685a4ce542772f0892a0f05764ac69d57187975579a0835ff255ae3ef9c
+  md5: d4765c524b1d91567886bde656fb514b
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1185323
+  timestamp: 1719463492984
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
+  sha256: 222ebc0a55544b9922f61e75015d02861e65b48f12113af41d48ba0814e14e4e
+  md5: 1442db8f03517834843666c422238c9b
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 224432
+  timestamp: 1701648089496
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+  sha256: e41790fc0f4089726369b3c7f813117bbc14b533e0ed8b94cf75aba252e82497
+  md5: f9d6a4c82889d5ecedec1d90eb673c55
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 290319
+  timestamp: 1657977526749
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240116.2-cxx17_hf036a51_1.conda
+  sha256: 396d18f39d5207ecae06fddcbc6e5f20865718939bc4e0ea9729e13952833aac
+  md5: d6c78ca84abed3fea5f308ac83b8f54e
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  constrains:
+  - abseil-cpp =20240116.2
+  - libabseil-static =20240116.2=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1124364
+  timestamp: 1720857589333
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
+  sha256: dae5921339c5d89f4bf58a95fd4e9c76270dbf7f6a94f3c5081b574905fcccf8
+  md5: 66d3c1f6dd4636216b4fca7a748d50eb
+  depends:
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 28602
+  timestamp: 1711021419744
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.7.4-h20e244c_0.conda
+  sha256: 9e46db25e976630e6738b351d76d9b79047ae232638b82f9f45eba774caaef8a
+  md5: 82a85fa38e83366009b7f4b2cef4deb8
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libiconv >=1.17,<2.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - lzo >=2.10,<3.0a0
+  - openssl >=3.3.0,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 742682
+  timestamp: 1716394747351
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-16.1.0-had6961a_14_cpu.conda
+  sha256: 8084e95cbc334ed5f5a1066a941a8017416fa94f7950b99a69086778f8541ef4
+  md5: 908186519a7a25b1b42d9cc521325e96
+  depends:
+  - __osx >=10.13
+  - aws-crt-cpp >=0.27.3,<0.27.4.0a0
+  - aws-sdk-cpp >=1.11.329,<1.11.330.0a0
+  - azure-core-cpp >=1.12.0,<1.12.1.0a0
+  - azure-identity-cpp >=1.8.0,<1.8.1.0a0
+  - azure-storage-blobs-cpp >=12.11.0,<12.11.1.0a0
+  - azure-storage-files-datalake-cpp >=12.10.0,<12.10.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=16
+  - libgoogle-cloud >=2.26.0,<2.27.0a0
+  - libgoogle-cloud-storage >=2.26.0,<2.27.0a0
+  - libre2-11 >=2023.9.1
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.1,<2.0.2.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  - libutf8proc <2.9
+  constrains:
+  - arrow-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  - parquet-cpp <0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5886068
+  timestamp: 1720851968932
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-16.1.0-hf036a51_14_cpu.conda
+  sha256: c66700bca8a4273a471b5d133991d5c851352489b678779bcc72854850b3a441
+  md5: 5d9f85c29ceee96786bff23589053260
+  depends:
+  - __osx >=10.13
+  - libarrow 16.1.0 had6961a_14_cpu
+  - libcxx >=16
+  license: Apache-2.0
+  license_family: APACHE
+  size: 523225
+  timestamp: 1720852083451
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-16.1.0-hf036a51_14_cpu.conda
+  sha256: 7b969084d6e49ab673e2b79252bb927548e78b6be5bc47171a86fcb6f4338ec0
+  md5: c82c68c2da4e31396c0b3fc81d3cf26e
+  depends:
+  - __osx >=10.13
+  - libarrow 16.1.0 had6961a_14_cpu
+  - libarrow-acero 16.1.0 hf036a51_14_cpu
+  - libcxx >=16
+  - libparquet 16.1.0 h904a336_14_cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 510141
+  timestamp: 1720852710561
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-16.1.0-h85bc590_14_cpu.conda
+  sha256: 45df7257ce514a9af7a8dad820dd0b056a2067278cb23b85e6ea84d5b1c0c0da
+  md5: c60b86c6c1e3c9ae5d0d815e58e59c4d
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libarrow 16.1.0 had6961a_14_cpu
+  - libarrow-acero 16.1.0 hf036a51_14_cpu
+  - libarrow-dataset 16.1.0 hf036a51_14_cpu
+  - libcxx >=16
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 481234
+  timestamp: 1720852863783
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-22_osx64_openblas.conda
+  sha256: d72060239f904b3a81d2329efcf84dc62c2dfd66dbc4efc8dcae1afdf8f02b59
+  md5: b80966a8c8dd0b531f8e65f709d732e8
+  depends:
+  - libopenblas >=0.3.27,<0.3.28.0a0
+  - libopenblas >=0.3.27,<1.0a0
+  constrains:
+  - liblapacke 3.9.0 22_osx64_openblas
+  - blas * openblas
+  - libcblas 3.9.0 22_osx64_openblas
+  - liblapack 3.9.0 22_osx64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14749
+  timestamp: 1712542279018
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h0dc2134_1.conda
+  sha256: f57c57c442ef371982619f82af8735f93a4f50293022cfd1ffaf2ff89c2e0b2a
+  md5: 9e6c31441c9aa24e41ace40d6151aab6
+  license: MIT
+  license_family: MIT
+  size: 67476
+  timestamp: 1695990207321
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h0dc2134_1.conda
+  sha256: b11939c4c93c29448660ab5f63273216969d1f2f315dd9be60f3c43c4e61a50c
+  md5: 9ee0bab91b2ca579e10353738be36063
+  depends:
+  - libbrotlicommon 1.1.0 h0dc2134_1
+  license: MIT
+  license_family: MIT
+  size: 30327
+  timestamp: 1695990232422
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h0dc2134_1.conda
+  sha256: bc964c23e1a60ca1afe7bac38a9c1f2af3db4a8072c9f2eac4e4de537a844ac7
+  md5: 8a421fe09c6187f0eb5e2338a8a8be6d
+  depends:
+  - libbrotlicommon 1.1.0 h0dc2134_1
+  license: MIT
+  license_family: MIT
+  size: 299092
+  timestamp: 1695990259225
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-22_osx64_openblas.conda
+  sha256: 6a2ba9198e2320c3e22fe3d121310cf8a8ac663e94100c5693b34523fcb3cc04
+  md5: b9fef82772330f61b2b0201c72d2c29b
+  depends:
+  - libblas 3.9.0 22_osx64_openblas
+  constrains:
+  - liblapacke 3.9.0 22_osx64_openblas
+  - blas * openblas
+  - liblapack 3.9.0 22_osx64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14636
+  timestamp: 1712542311437
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+  sha256: 3043869ac1ee84554f177695e92f2f3c2c507b260edad38a0bf3981fce1632ff
+  md5: 23d6d5a69918a438355d7cbc4c3d54c9
+  depends:
+  - libcxx >=11.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20128
+  timestamp: 1633683906221
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.8.0-hf9fcc65_1.conda
+  sha256: 25e2b044e6978f1714a4b2844f34a45fc8a0c60185db8d332906989d70b65927
+  md5: 11711bab5306a6534797a68b3c4c2bed
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 390707
+  timestamp: 1719602983754
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-18.1.8-hef8daea_0.conda
+  sha256: d5e7755fe7175e6632179801f2e71c67eec033f1610a48e14510df679c038aa3
+  md5: 4101cde4241c92aeac310d65e6791579
+  depends:
+  - __osx >=10.13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1396919
+  timestamp: 1720589431855
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.20-h49d49c5_0.conda
+  sha256: 8c2087952db55c4118dd2e29381176a54606da47033fd61ebb1b0f4391fcd28d
+  md5: d46104f6a896a0bc6a1d37b88b2edf5c
+  license: MIT
+  license_family: MIT
+  size: 70364
+  timestamp: 1711196727346
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+  sha256: dbd3c3f2eca1d21c52e4c03b21930bbce414c4592f8ce805801575b9e9256095
+  md5: 6016a8a1d0e63cac3de2c352cd40208b
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 105382
+  timestamp: 1597616576726
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+  sha256: 0d238488564a7992942aa165ff994eca540f687753b4f0998b29b4e4d030ff43
+  md5: 899db79329439820b7e8f8de41bca902
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 106663
+  timestamp: 1702146352558
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+  sha256: e0bd9af2a29f8dd74309c0ae4f17a7c2b8c4b89f875ff1d6540c941eefbd07fb
+  md5: e38e467e577bd193a7d5de7c2c540b04
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372661
+  timestamp: 1685726378869
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.2-h73e2aa4_0.conda
+  sha256: a188a77b275d61159a32ab547f7d17892226e7dac4518d2c6ac3ac8fc8dfde92
+  md5: 3d1d51c8f716d97c864d12f7af329526
+  constrains:
+  - expat 2.6.2.*
+  license: MIT
+  license_family: MIT
+  size: 69246
+  timestamp: 1710362566073
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+  sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
+  md5: ccb34fb14960ad8b125962d3d79b31a9
+  license: MIT
+  license_family: MIT
+  size: 51348
+  timestamp: 1636488394370
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.9.1-hc21aedb_2.conda
+  sha256: 8b37c6d23a9102b2124054cdd63bc90eea13bd11945a35fdd339637acf291a99
+  md5: c518689f5b66ee82a751fa43d093d0d2
+  depends:
+  - __osx >=10.13
+  - blosc >=1.21.6,<2.0a0
+  - cfitsio >=4.4.1,<4.4.2.0a0
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.12.1,<3.12.2.0a0
+  - geotiff >=1.7.1,<1.8.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - json-c >=0.17,<0.18.0a0
+  - kealib >=1.5.3,<1.6.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libarchive >=3.7.4,<3.8.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libcxx >=16
+  - libdeflate >=1.20,<1.26.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libpq >=16.3,<17.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.46.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - openssl >=3.3.1,<4.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - poppler >=24.4.0,<24.5.0a0
+  - postgresql
+  - proj >=9.4.0,<9.5.0a0
+  - tiledb >=2.24.1,<2.25.0a0
+  - xerces-c >=3.2.5,<3.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - libgdal-core <0.0a0
+  license: MIT
+  license_family: MIT
+  size: 10212976
+  timestamp: 1719487296333
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+  sha256: 4874422e567b68334705c135c17e5acdca1404de8255673ce30ad3510e00be0d
+  md5: 0b6e23a012ee7a9a5f6b244f5a92c1d5
+  depends:
+  - libgfortran5 13.2.0 h2873a65_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110106
+  timestamp: 1707328956438
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+  sha256: da3db4b947e30aec7596a3ef92200d17e774cccbbf7efc47802529a4ca5ca31b
+  md5: e4fb4d23ec2870ff3c40d10afe305aec
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1571379
+  timestamp: 1707328880361
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.80.3-h736d271_1.conda
+  sha256: bfd5a28140d31f9310efcdfd1136f36d7ca718a297690a1a8869b3a1966675ae
+  md5: 0919d467624606fbc05c38c458f3f42a
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  constrains:
+  - glib 2.80.3 *_1
+  license: LGPL-2.1-or-later
+  size: 3655643
+  timestamp: 1720335043559
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.26.0-h721cda5_0.conda
+  sha256: f514519dc7a48cfd81e5c2dd436223b221f80c03f224253739e22d60d896f632
+  md5: 7f7f4537746da4470385ec3a496730a4
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libcxx >=16
+  - libgrpc >=1.62.2,<1.63.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - openssl >=3.3.1,<4.0a0
+  constrains:
+  - libgoogle-cloud 2.26.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 875432
+  timestamp: 1719889038115
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.26.0-h9e84e37_0.conda
+  sha256: d2081318e2962225c7b00fee355f66737553828eac42ddfbab968f59b039213a
+  md5: b1e5017003917b69d5c046fc7ac0dcc3
+  depends:
+  - __osx >=10.13
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libcxx >=16
+  - libgoogle-cloud 2.26.0 h721cda5_0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  size: 549363
+  timestamp: 1719890135847
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.62.2-h384b2fc_0.conda
+  sha256: 7c228040e7dac4e5e7e6935a4decf6bc2155cc05fcfb0811d25ccb242d0036ba
+  md5: 9421f67cf8b4bc976fe5d0c3ab42de18
+  depends:
+  - __osx >=10.13
+  - c-ares >=1.28.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.1,<20240117.0a0
+  - libcxx >=16
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libre2-11 >=2023.9.1
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.2.1,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.62.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5189573
+  timestamp: 1713392887258
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
+  sha256: 23d4923baeca359423a7347c2ed7aaf48c68603df0cf8b87cc94a10b0d4e9a23
+  md5: 6c3628d047e151efba7cf08c5e54d1ca
+  license: LGPL-2.1-only
+  size: 666538
+  timestamp: 1702682713201
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-h5ff76d1_2.conda
+  sha256: 280aaef0ed84637ee869012ad9ad9ed208e068dd9b8cf010dafeea717dad7203
+  md5: 3fb6774cb8cdbb93a6013b67bcf9716d
+  depends:
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 74307
+  timestamp: 1712512790983
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+  sha256: d9572fd1024adc374aae7c247d0f29fdf4b122f1e3586fe62acc18067f40d02f
+  md5: 72507f8e3961bc968af17435060b6dd6
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 579748
+  timestamp: 1694475265912
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libkml-1.3.0-hfcbc525_1020.conda
+  sha256: 20dec455f668ab2527d6a20204599253ac0b2d4d0325e4a1ce2316850128cc3e
+  md5: 055d429f351b79c0a7b7d7e39ff45b28
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libexpat >=2.6.2,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - uriparser >=0.9.8,<1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 285823
+  timestamp: 1720690426491
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-22_osx64_openblas.conda
+  sha256: e36744f3e780564d6748b5dd05e15ad6a1af9184cf32ab9d1304c13a6bc3e16b
+  md5: f21b282ff7ba14df6134a0fe6ab42b1b
+  depends:
+  - libblas 3.9.0 22_osx64_openblas
+  constrains:
+  - liblapacke 3.9.0 22_osx64_openblas
+  - blas * openblas
+  - libcblas 3.9.0 22_osx64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14657
+  timestamp: 1712542322711
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-hc8e404f_4.conda
+  sha256: 0df3902a300cfe092425f86144d5e00ef67be3cd1cc89fd63084d45262a772ad
+  md5: ed06753e2ba7c66ed0ca7f19578fcb68
+  depends:
+  - libcxx >=15
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 22467131
+  timestamp: 1690563140552
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.2-nompi_h7334405_114.conda
+  sha256: a4af96274a6c72d97e84dfc728ecc765af300de805d962a835c0841bb6a8f331
+  md5: 32ffbe5b0b0134e49f6347f4de8c5dcc
+  depends:
+  - __osx >=10.13
+  - blosc >=1.21.5,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libcxx >=16
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzip >=1.10.1,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - zlib
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 726205
+  timestamp: 1717671847032
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.58.0-h64cf6d3_1.conda
+  sha256: 412fd768e787e586602f8e9ea52bf089f3460fc630f6987f0cbd89b70e9a4380
+  md5: faecc55c2a8155d9ff1c0ff9a0fef64f
+  depends:
+  - __osx >=10.9
+  - c-ares >=1.23.0,<2.0a0
+  - libcxx >=16.0.6
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.2.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 599736
+  timestamp: 1702130398536
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.27-openmp_h8869122_1.conda
+  sha256: 83b0b9d3d09889b3648a81d2c18a2d78c405b03b115107941f0496a8b358ce6d
+  md5: c0798ad76ddd730dade6ff4dff66e0b5
+  depends:
+  - __osx >=10.13
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - llvm-openmp >=16.0.6
+  constrains:
+  - openblas >=0.3.27,<0.3.28.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6047513
+  timestamp: 1720426759731
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-16.1.0-h904a336_14_cpu.conda
+  sha256: eb2217015b46783afb7e0b246a1ccfc0a1d6094e615963adb0d937bbf0227fe1
+  md5: 32c0b7e2be719131a46d9392a3bb0e50
+  depends:
+  - __osx >=10.13
+  - libarrow 16.1.0 had6961a_14_cpu
+  - libcxx >=16
+  - libthrift >=0.19.0,<0.19.1.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 931837
+  timestamp: 1720852631235
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.43-h92b6c6a_0.conda
+  sha256: 13e646d24b5179e6b0a5ece4451a587d759f55d9a360b7015f8f96eff4524b8f
+  md5: 65dcddb15965c9de2c0365cb14910532
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: zlib-acknowledgement
+  size: 268524
+  timestamp: 1708780496420
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.3-h4501773_0.conda
+  sha256: 039da003586fdcdb40b8c8ffa25d5ded33316ba3a32ec79afde098a68b8a3acc
+  md5: 74f18d32d7cc71584c8b05fd1ee555a0
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.2,<1.22.0a0
+  - openssl >=3.3.0,<4.0a0
+  license: PostgreSQL
+  size: 2398885
+  timestamp: 1715267344306
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.25.3-h4e4d658_0.conda
+  sha256: 3f126769fb5820387d436370ad48600e05d038a28689fdf9988b64e1059947a8
+  md5: 57b7ee4f1fd8573781cfdabaec4a7782
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240116.1,<20240117.0a0
+  - libcxx >=16
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2216001
+  timestamp: 1709514908146
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2023.09.01-h81f5012_2.conda
+  sha256: 384b72a09bd4bb29c1aa085110b2f940dba431587ffb4e2c1a28f605887a1867
+  md5: c5c36ec64e3c86504728c38b79011d08
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240116.1,<20240117.0a0
+  - libcxx >=16
+  constrains:
+  - re2 2023.09.01.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184017
+  timestamp: 1708947106275
+- conda: https://conda.anaconda.org/conda-forge/osx-64/librttopo-1.1.0-hf05f67e_15.conda
+  sha256: 10c46efefda5cc77143832a186f517e401098907cf9c3ec7406a5c242bb34e33
+  md5: e65bedc9d9779a161cf26b6d12305246
+  depends:
+  - __osx >=10.9
+  - geos >=3.12.1,<3.12.2.0a0
+  - libcxx >=16.0.6
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 213839
+  timestamp: 1700766697471
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.18-hbcb3906_1.tar.bz2
+  sha256: 2da45f14e3d383b4b9e3a8bacc95cd2832aac2dbf9fbc70d255d384a310c5660
+  md5: 24632c09ed931af617fe6d5292919cab
+  license: ISC
+  size: 528765
+  timestamp: 1605135849110
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libspatialite-5.1.0-h5579707_7.conda
+  sha256: 39f91448573cb8f1b016b3deb28138ddfd4945789caa6fa6d53bf73b6c00b2aa
+  md5: 3c644ddec526be45f1c16a04306f57a5
+  depends:
+  - __osx >=10.13
+  - freexl >=2
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.12.1,<3.12.2.0a0
+  - libcxx >=16
+  - libiconv >=1.17,<2.0a0
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.45.3,<4.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.4.0,<9.5.0a0
+  - sqlite
+  - zlib
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 3146197
+  timestamp: 1717778409091
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.46.0-h1b8f9f3_0.conda
+  sha256: 63af1a9e3284c7e4952364bafe7267e41e2d9d8bcc0e85a4ea4b0ec02d3693f6
+  md5: 5dadfbc1a567fe6e475df4ce3148be09
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.2.13,<2.0a0
+  license: Unlicense
+  size: 908643
+  timestamp: 1718050720117
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+  sha256: f3886763b88f4b24265db6036535ef77b7b77ce91b1cbe588c0fbdd861eec515
+  md5: ca3a72efba692c59a90d4b9fc0dfe774
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 259556
+  timestamp: 1685837820566
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.19.0-h064b379_1.conda
+  sha256: 4346c25ef6e2ff3d0fc93074238508531188ecd0dbea6414f6cb93a7775072c4
+  md5: b152655bfad7c2374ff03be0596052b6
+  depends:
+  - libcxx >=15.0.7
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 325415
+  timestamp: 1695958330036
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h129831d_3.conda
+  sha256: f9b35c5ec1aea9a2cc20e9275a0bb8f056482faa8c5a62feb243ed780755ea30
+  md5: 568593071d2e6cea7b5fc1f75bfa10ca
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=16
+  - libdeflate >=1.20,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: HPND
+  size: 257489
+  timestamp: 1711218113053
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
+  sha256: 55a7f96b2802e94def207fdfe92bc52c24d705d139bb6cdb3d936cbe85e1c505
+  md5: db98dc3e58cbc11583180609c429c17d
+  license: MIT
+  license_family: MIT
+  size: 98942
+  timestamp: 1667316472080
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
+  sha256: 7bafd8f4c637778cd0aa390bf3a894feef0e1fcf6ea6000c7ffc25c4c5a65538
+  md5: b2c0047ea73819d992484faacbbe1c24
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 355099
+  timestamp: 1713200298965
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.16-h0dc2134_0.conda
+  sha256: c64277f586b716d5c34947e7f2783ef0d24f239a136bc6a024e854bede0389a9
+  md5: 07e80289d4ba724f37b4b6f001f88fbe
+  depends:
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 322676
+  timestamp: 1693089168477
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.7-hc603aa4_3.conda
+  sha256: b0cf4a1d3e628876613665ea957a4c0adc30460be859fa859a1eed7eac87330b
+  md5: c188d96aea8eaa16efec573fe36a9a13
+  depends:
+  - __osx >=10.13
+  - icu >=73.2,<74.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 620129
+  timestamp: 1720772795289
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzip-1.10.1-hc158999_3.conda
+  sha256: 0689e4a6e67e80027e43eefb8a365273405a01f5ab2ece97319155b8be5d64f6
+  md5: 6112b3173f3aa2f12a8f40d07a77cc35
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 127599
+  timestamp: 1694416738467
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-h87427d6_1.conda
+  sha256: 80a62db652b1da0ccc100812a1d86e94f75028968991bfb17f9536f3aa72d91d
+  md5: b7575b5aa92108dcc9aaab0f05f2dbce
+  depends:
+  - __osx >=10.13
+  constrains:
+  - zlib 1.3.1 *_1
+  license: Zlib
+  license_family: Other
+  size: 57372
+  timestamp: 1716874211519
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.8-h15ab845_0.conda
+  sha256: 0fd74128806bd839c7a9aa343faf265b94aece84f75f67f14b6246936138e61e
+  md5: 2c3c6c8aaf8728f87326964a82fdc7d8
+  depends:
+  - __osx >=10.13
+  constrains:
+  - openmp 18.1.8|18.1.8.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 300682
+  timestamp: 1718887195436
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.43.0-py311h6cc91e7_0.conda
+  sha256: ff810afc712c74cea7a54e6577a5483f26d128efc1da24f94b8789251e012a3d
+  md5: 4ed50735a4863cfa81e558f0415da343
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 382723
+  timestamp: 1718324593783
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-4.3.3-py311hdfabcfc_0.conda
+  sha256: 213229b2b04df7bcf77966aef5bef0b628b8801feebd2d11e19e88113f01b896
+  md5: 23c26f7a049deecd3aa1d2ac4fe3b732
+  depends:
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36864
+  timestamp: 1704831579795
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+  sha256: 39aa0c01696e4e202bf5e337413de09dfeec061d89acd5f28e9968b4e93c3f48
+  md5: aa04f7143228308662696ac24023f991
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 156415
+  timestamp: 1674727335352
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lzo-2.10-h10d778d_1001.conda
+  sha256: 4006c57f805ca6aec72ee0eb7166b2fd648dd1bf3721b9de4b909cd374196643
+  md5: bfecd73e4a2dc18ffd5288acf8a212ab
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  size: 146405
+  timestamp: 1713516112292
+- conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.5-py311he705e18_0.conda
+  sha256: 83a2b764a4946a04e693a4dd8fe5a35bf093a378da9ce18bf0689cd5dcb3c3fe
+  md5: 75abe7e2e3a0874a49d7c175115f443f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26155
+  timestamp: 1706900211496
+- conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.1-py311hf31e254_0.conda
+  sha256: 5a0a36703aaa51d439c60b3934850acb533b3957b6360707cdb413c488e2ac0e
+  md5: f7ed5d9fc0a0a43ca289608e4ff30aab
+  depends:
+  - __osx >=10.13
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=16
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 7794488
+  timestamp: 1720648759880
+- conda: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.0.7-h62b0c8d_0.conda
+  sha256: e02a6e1a43b0ff44bb9460d46d3f7687a1876d435fb3c2c6cf9e19bab60901f6
+  md5: 9cb19284d7d835918241acf8180099db
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libcxx >=16
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 78595
+  timestamp: 1718483214061
+- conda: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.0.8-py311h46c8309_0.conda
+  sha256: 3d575b0c8e6dcbbdc7c27f3f93b68c72adf2cfac3c88b792b12b35fd4b9ba4ac
+  md5: e451ed01f83544c6029f8fe29d0e9fe3
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 92344
+  timestamp: 1715670916175
+- conda: https://conda.anaconda.org/conda-forge/osx-64/multidict-6.0.5-py311h5547dcb_0.conda
+  sha256: 6bb2acb8f4c1c25e4bb61421f654559c044af98d409c794cd84ae9fbac031ded
+  md5: 163d2cb37b054606283917075809c5be
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 55414
+  timestamp: 1707040997198
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h5846eda_0.conda
+  sha256: 6ecc73db0e49143092c0934355ac41583a5d5a48c6914c5f6ca48e562d3a4b79
+  md5: 02a888433d165c99bf09784a7b14d900
+  license: X11 AND BSD-3-Clause
+  size: 823601
+  timestamp: 1715195267791
+- conda: https://conda.anaconda.org/conda-forge/osx-64/netcdf4-1.7.1-nompi_py311ha7361b2_101.conda
+  sha256: eed3d2ae67abbad83cde3a7748042d0e24d7a98780ab6215a131b14204874bd6
+  md5: d798c51d8df3a8a54936fef2ed77f8cf
+  depends:
+  - __osx >=10.13
+  - certifi
+  - cftime
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 1046878
+  timestamp: 1718724394281
+- conda: https://conda.anaconda.org/conda-forge/osx-64/nspr-4.35-hea0b92c_0.conda
+  sha256: da6e19bd0ff31e219760e647cfe1cc499a8cdfaff305f06c56d495ca062b86de
+  md5: a9e56c98d13d8b7ce72bf4357317c29b
+  depends:
+  - libcxx >=14.0.6
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 230071
+  timestamp: 1669785313586
+- conda: https://conda.anaconda.org/conda-forge/osx-64/nss-3.102-he7eb89d_0.conda
+  sha256: 205386081d59f541784594628d542996b0bcfac1fe32d42010221706bcaf88a4
+  md5: 95e32708bfbae8cd9936c0ad006439a1
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libsqlite >=3.46.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.35,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1853247
+  timestamp: 1720064737210
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.60.0-py311h0e5bd6a_0.conda
+  sha256: 47fbc7925d5ee5ba9d841e542752288fc7059f44c0b95c34e11c609f4754e517
+  md5: 8bd1ff28924ea52b539528d85f70a1ac
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - llvm-openmp >=16.0.6
+  - llvm-openmp >=18.1.8
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libopenblas !=0.3.6
+  - cuda-python >=11.6
+  - scipy >=1.0
+  - tbb >=2021.6.0
+  - cudatoolkit >=11.2
+  - cuda-version >=11.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5773011
+  timestamp: 1718888442395
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numcodecs-0.12.1-py311hbafa61a_1.conda
+  sha256: e6d42d8af368df97d38ca455684502259d6ddf951bff593f6d1f05068ebb1aad
+  md5: a9591354aae6c160509f9bb3ae071a29
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - msgpack-python
+  - numpy >=1.7
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 737461
+  timestamp: 1715219198186
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.0.0-py311hc11d9cb_0.conda
+  sha256: 0e82d37aa474ce84302775f02d31fe0c762844ec472f5ed8f0db8190d5fd1db9
+  md5: f3e2a534964152fca3ba80bea594f673
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=16
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8016515
+  timestamp: 1718615633162
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
+  sha256: dc9c405119b9b54f8ca5984da27ba498bd848ab4f0f580da6f293009ca5adc13
+  md5: 05a14cc9d725dd74995927968d6547e3
+  depends:
+  - libcxx >=16
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 331273
+  timestamp: 1709159538792
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.1-h87427d6_1.conda
+  sha256: 60eed5d771207bcef05e0547c8f93a61d0ad1dcf75e19f8f8d9ded8094d78477
+  md5: d838ffe9ec3c6d971f110e04487466ff
+  depends:
+  - __osx >=10.13
+  - ca-certificates
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2551950
+  timestamp: 1719364820943
+- conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.1-hf43e91b_1.conda
+  sha256: 718010a056ef084a12bfd6b4d7908c8817a0093ecc395c270857134e002d5857
+  md5: 15d11d156ad646e69176df6af6ef0826
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 438785
+  timestamp: 1716789731333
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.2-py311hfdcbad3_1.conda
+  sha256: 070c97918f2ea3384120a87ca3681803242b48875d9269ed73542bacfa14fd03
+  md5: 8dbecc860148500512e768571c59fbe0
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - numpy >=1.22.4,<3
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14887900
+  timestamp: 1715898095186
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.44-h7634a1b_0.conda
+  sha256: b397f92ef7d561f817c5336295d6696c72d2576328baceb9dc51bfc772bcb48e
+  md5: b8f63aec37f31ffddac6dfdc0b31a73e
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 858178
+  timestamp: 1718466163292
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.4.0-py311h2755ac0_0.conda
+  sha256: 933016d8409d4b9e336a2eadb78fcb568ad1133650202c708b7530e4c7da4e6a
+  md5: d42d761fa1af8a6480fcdfd6ed74e432
+  depends:
+  - __osx >=10.13
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.16,<2.0.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 42271065
+  timestamp: 1719903842670
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.4-h73e2aa4_0.conda
+  sha256: 3ab44e12e566c67a6e9fd831f557ab195456aa996b8dd9af19787ca80caa5cd1
+  md5: cb134c1e03fd32f4e6bea3f6de2614fd
+  depends:
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  size: 323904
+  timestamp: 1709239931160
+- conda: https://conda.anaconda.org/conda-forge/osx-64/poppler-24.04.0-h0face88_0.conda
+  sha256: 8f83bd2c60f2f961ff90aa10797d7962d229a94bc4ecbea9896e8a5c9fa0d5a8
+  md5: 2263d7ca58e513ef1172dd12ac67b43c
+  depends:
+  - cairo >=1.18.0,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libcurl >=8.7.1,<9.0a0
+  - libcxx >=16
+  - libglib >=2.80.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - nspr >=4.35,<5.0a0
+  - nss >=3.98,<4.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - poppler-data
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 1584834
+  timestamp: 1713361448761
+- conda: https://conda.anaconda.org/conda-forge/osx-64/postgresql-16.3-h1d90168_0.conda
+  sha256: 69a0887d23f51bc7e35097bf03f88d2ff14e88cc578c3f8296a178c8378950ec
+  md5: a7ccb9b98d8e3ef61c0ca6d470e8e66d
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.2,<1.22.0a0
+  - libpq 16.3 h4501773_0
+  - libxml2 >=2.12.6,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.3.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tzcode
+  - tzdata
+  license: PostgreSQL
+  size: 4612922
+  timestamp: 1715267536439
+- conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.4.0-hf92c781_2.conda
+  sha256: 3f53c59d844de2f791a514ba6817f9f1e12958b545d3f00bc1c01bdec775682f
+  md5: 7b1acaebf44e94af2906000b50e6bae6
+  depends:
+  - __osx >=10.13
+  - libcurl >=8.8.0,<9.0a0
+  - libcxx >=16
+  - libsqlite >=3.45.3,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2824994
+  timestamp: 1717746545087
+- conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.0.0-py311h72ae277_0.conda
+  sha256: fa9ddabbf1a7f0e360dcdd9dfb6fd93742e211211c821693843e946655163dbf
+  md5: a31301b30c5844e74944b88ff3e6a98c
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 517243
+  timestamp: 1719274745686
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
+  sha256: 6e3900bb241bcdec513d4e7180fe9a19186c1a38f0b4080ed619d26014222c53
+  md5: addd19059de62181cd11ae8f4ef26084
+  license: MIT
+  license_family: MIT
+  size: 5653
+  timestamp: 1606147699844
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-16.1.0-py311he764780_4.conda
+  sha256: 3a74ff7b664d7f1b1a29cce288397042cc8d5b52de1c0e7204fe07cd8a43c102
+  md5: 5f4356c4a9b2a2f5939acbc343c3c4a7
+  depends:
+  - libarrow-acero 16.1.0.*
+  - libarrow-dataset 16.1.0.*
+  - libarrow-substrait 16.1.0.*
+  - libparquet 16.1.0.*
+  - numpy >=1.19,<3
+  - pyarrow-core 16.1.0 *_4_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 28400
+  timestamp: 1719450668450
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-16.1.0-py311h4d2d057_4_cpu.conda
+  sha256: 74fdab5c1bbec1be1714b380f86e1ae8db9157ca7909ab0b7d6839d8763149b7
+  md5: fde59faa82da742385924f115d66b8cf
+  depends:
+  - __osx >=10.13
+  - libarrow 16.1.0.* *cpu
+  - libcxx >=16
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - orc >=2.0.1
+  - aws-crt-cpp >=0.26.12
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3962733
+  timestamp: 1719450626229
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.3.1-py311h9d23797_0.conda
+  sha256: 00321f83e0079164e3c220b0b8311c1397dac34e8a209c3300c1cae04b1796ed
+  md5: 5bce9e98557971559e7c2e672c6772fe
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 489019
+  timestamp: 1718171770466
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.3.1-py311h9d23797_0.conda
+  sha256: 8cc6a36d71affa4354ed5184ebafe1144f5a0a4add37f4410ff4ea422695f47c
+  md5: 557ec4f240ee3f8944ae1b3015ef36dd
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 10.3.1.*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 382713
+  timestamp: 1718645767182
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.9.0-py311h4afbaa0_0.conda
+  sha256: 5aa1fa1e9db21f4d1312429a00c41f60d0fcc6b895c7012f0ede5ddf810835fc
+  md5: 1202fca68f1c38642e3f7c1059c276cb
+  depends:
+  - __osx >=10.13
+  - gdal
+  - libcxx >=16
+  - libgdal >=3.9.0,<3.10.0a0
+  - numpy
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 671171
+  timestamp: 1718696245065
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.6.1-py311hc55c11a_7.conda
+  sha256: b68c237df4bc353e949e0c36e932f63f6b00e914e7e8588acb7f9217557cc5a2
+  md5: bdd31b8ef0e43a46f0e18ccb1b529bb8
+  depends:
+  - __osx >=10.13
+  - certifi
+  - proj >=9.4.0,<9.5.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 489116
+  timestamp: 1717792930782
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.9-h657bba9_0_cpython.conda
+  sha256: 3b50a5abb3b812875beaa9ab792dbd1bf44f335c64e9f9fedcf92d953995651c
+  md5: 612763bc5ede9552e4233ec518b9c9fb
+  depends:
+  - __osx >=10.9
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.45.3,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4.20240210,<7.0a0
+  - openssl >=3.2.1,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 15503226
+  timestamp: 1713553747073
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-4_cp311.conda
+  sha256: f56dfe2a57b3b27bad3f9527f943548e8b2526e949d9d6fc0a383020d9359afe
+  md5: fef7a52f0eca6bae9e8e2e255bc86394
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6478
+  timestamp: 1695147518012
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.1-py311h2725bcf_1.conda
+  sha256: 8ce2ba443414170a2570514d0ce6d03625a847e91af9763d48dc58c338e6f7f3
+  md5: 9283f991b5e5856a99f8aabba9927df5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 188606
+  timestamp: 1695373840022
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.0.3-py311h89e2aaa_0.conda
+  sha256: 54e3e8a723ee2fff0e9317417684d5237453f935c0c971fb9808b9acb4fe15fa
+  md5: 91ec96c7ebdeb80c1d0d32777bfe76fa
+  depends:
+  - __osx >=10.9
+  - libcxx >=16
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 453164
+  timestamp: 1715024606404
+- conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+  sha256: 79d804fa6af9c750e8b09482559814ae18cd8df549ecb80a4873537a5a31e06e
+  md5: dd1ea9ff27c93db7c01a7b7656bd4ad4
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: LicenseRef-Qhull
+  size: 528122
+  timestamp: 1720814002588
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rasterio-1.3.10-py311h6fa6b3e_3.conda
+  sha256: b511ce6fc0c13842312fc9d9fff180abd02139944e76e86400a6c7cc93167182
+  md5: dba0f78020af6abd36f48e2a55aec057
+  depends:
+  - __osx >=10.13
+  - affine
+  - attrs
+  - certifi
+  - click >=4
+  - click-plugins
+  - cligj >=0.5
+  - libcxx >=16
+  - libgdal >=3.9.0,<3.10.0a0
+  - numpy >=1.19,<3
+  - proj >=9.4.0,<9.4.1.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7240415
+  timestamp: 1717673394680
+- conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2023.09.01-hb168e87_2.conda
+  sha256: 5739ed2cfa62ed7f828eb4b9e6e69ff1df56cb9a9aacdc296451a3cb647034eb
+  md5: 266f8ca8528fc7e0fa31066c309ad864
+  depends:
+  - libre2-11 2023.09.01 h81f5012_2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26814
+  timestamp: 1708947195067
+- conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+  sha256: 41e7d30a097d9b060037f0c6a2b1d4c4ae7e942c06c943d23f9d481548478568
+  md5: f17f77f2acf4d344734bda76829ce14e
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 255870
+  timestamp: 1679532707590
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.19.0-py311h295b1db_0.conda
+  sha256: 2fd1b7f0191cdf0b933c1e593fe05fc5ad62f12ba0ea6166b71dccf274731d2a
+  md5: d8535fdf90c6f305bc305fed0fb1e24a
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 294306
+  timestamp: 1720476815878
+- conda: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.5.1-py311h3c3ac6d_0.conda
+  sha256: 9484c7f5c686252e7dd5e180537f35bf7518bae2ba0f5970f849313a427b4a4f
+  md5: 209cc9f21aced058dfe783848c7a13d9
+  depends:
+  - __osx >=10.13
+  - joblib >=1.2.0
+  - libcxx >=16
+  - llvm-openmp >=16.0.6
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scipy
+  - threadpoolctl >=3.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9691054
+  timestamp: 1719998770348
+- conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.0-py311h40a1ab3_1.conda
+  sha256: b68a52c33bedbbdafa783d31b3f504386a517308675ed21e76479d75f304efa7
+  md5: b47b90ee6bfd9bcd9cbff7be3610a732
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=16
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy >=1.23.5,<2.3
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16227492
+  timestamp: 1720323954067
+- conda: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.4-py311h2a2259d_1.conda
+  sha256: 1558a50e9396b96de2c4cadeac8e6e1634361c262f993c46de2c7bdf53c344d2
+  md5: 8fecc952952ffd37fc83089b295b94a3
+  depends:
+  - __osx >=10.13
+  - geos >=3.12.1,<3.12.2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 545132
+  timestamp: 1715876727680
+- conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-he1e6707_0.conda
+  sha256: a979319cd4916f0e7450aa92bb3cf4c2518afa80be50de99f31d075e693a6dd9
+  md5: ddceef5df973c8ff7d6b32353c0cb358
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37036
+  timestamp: 1720003862906
+- conda: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.13.0-h1a4aec9_0.conda
+  sha256: 2f1a981d8d1e06511081ef10068c083965bf1ea0fe7546f8a5f1e37a2982110a
+  md5: 2288eabc17f9fec9b64dac2cfe07b8ac
+  depends:
+  - fmt >=10.2.1,<11.0a0
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  size: 162075
+  timestamp: 1713902597770
+- conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.46.0-h28673e1_0.conda
+  sha256: 7d868d34348615450c43cb4737b44987a0e45fdf4759502b323494dc8c931409
+  md5: b76e50276ebb3131cb84aac8123ca75d
+  depends:
+  - __osx >=10.13
+  - libsqlite 3.46.0 h1b8f9f3_0
+  - libzlib >=1.2.13,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 912413
+  timestamp: 1718050767696
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tiledb-2.24.2-h86b3714_2.conda
+  sha256: c3ab3d43e3a4d8ebe7cdc318893ee3b0600a137dc394d0d36f9e10edb90ad941
+  md5: d48129ada13ea9c8a8a2b0ab007c1125
+  depends:
+  - __osx >=10.13
+  - aws-crt-cpp >=0.27.3,<0.27.4.0a0
+  - aws-sdk-cpp >=1.11.329,<1.11.330.0a0
+  - azure-core-cpp >=1.12.0,<1.12.1.0a0
+  - azure-identity-cpp >=1.8.0,<1.8.1.0a0
+  - azure-storage-blobs-cpp >=12.11.0,<12.11.1.0a0
+  - azure-storage-common-cpp >=12.6.0,<12.6.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - fmt >=10.2.1,<11.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libcxx >=16
+  - libgoogle-cloud >=2.26.0,<2.27.0a0
+  - libgoogle-cloud-storage >=2.26.0,<2.27.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.3.1,<4.0a0
+  - spdlog >=1.13.0,<1.14.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 3842000
+  timestamp: 1720847948135
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+  sha256: 30412b2e9de4ff82d8c2a7e5d06a15f4f4fef1809a72138b6ccb53a33b26faf5
+  md5: bf830ba5afc507c6232d4ef0fb1a882d
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3270220
+  timestamp: 1699202389792
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.1-py311h72ae277_0.conda
+  sha256: 0182804d203f702736883fd5b8a6df0ae7ef427ac0609d172b4c8e3bca8a30bd
+  md5: eefa3eeb81da03b9f46a2bb2a01dfef4
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 859395
+  timestamp: 1717722909139
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tzcode-2024a-h10d778d_0.conda
+  sha256: e3ee34b2711500f3b1d38309d47cfd7e4d05c0144f0b2b2bdfbc271a28cfdd76
+  md5: 8d50ba6668dbd193cd42ccd9099fa2ae
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 63341
+  timestamp: 1706869081062
+- conda: https://conda.anaconda.org/conda-forge/osx-64/uriparser-0.9.8-h6aefe2f_0.conda
+  sha256: fec8e52955fc314580a93dee665349bf430ce6df19019cea3fae7ec60f732bdd
+  md5: 649890a63cc818b24fbbf0572db221a5
+  depends:
+  - __osx >=10.9
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43396
+  timestamp: 1715010079800
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xerces-c-3.2.5-hbbe9ea5_0.conda
+  sha256: 10487c0b28ee2303570c6d0867000587a8c36836fffd4d634d8778c494d16965
+  md5: ade166000a13c81d9a75f65281e302b0
+  depends:
+  - icu >=73.2,<74.0a0
+  - libcurl >=8.5.0,<9.0a0
+  - libcxx >=15
+  license: Apache-2.0
+  license_family: Apache
+  size: 1346161
+  timestamp: 1703093374769
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
+  sha256: 8a2e398c4f06f10c64e69f56bcf3ddfa30b432201446a0893505e735b346619a
+  md5: 9566b4c29274125b0266d0177b5eb97b
+  license: MIT
+  license_family: MIT
+  size: 13071
+  timestamp: 1684638167647
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2
+  sha256: 485421c16f03a01b8ed09984e0b2ababdbb3527e1abf354ff7646f8329be905f
+  md5: 86ac76d6bf1cbb9621943eb3bd9ae36e
+  license: MIT
+  license_family: MIT
+  size: 17225
+  timestamp: 1610071995461
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+  sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
+  md5: a72f9d4ea13d55d745ff1ed594747f10
+  license: LGPL-2.1 and GPL-2.0
+  size: 238119
+  timestamp: 1660346964847
+- conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+  sha256: 5301417e2c8dea45b401ffee8df3957d2447d4ce80c83c5ff151fc6bfe1c4148
+  md5: d7e08fcf8259d742156188e8762b4d20
+  license: MIT
+  license_family: MIT
+  size: 84237
+  timestamp: 1641347062780
+- conda: https://conda.anaconda.org/conda-forge/osx-64/yarl-1.9.4-py311he705e18_0.conda
+  sha256: 668ea9d1e0c7b4eaa769cc79de1ea4e8da22a61d4112e660ecbaca140f097109
+  md5: 6b7f34fc151c338cdaca4d4d6fb92d55
+  depends:
+  - idna >=2.0
+  - multidict >=4.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 112887
+  timestamp: 1705508591601
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-hde137ed_4.conda
+  sha256: 871625ce993e6c61649b14659a3d1d6011fbb242b7d6a25cadbc6300b2356f32
+  md5: e56609055da6c658aa329d42a6c6b9f2
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.2,<1.22.0a0
+  - libcxx >=16
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 304498
+  timestamp: 1715607961981
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-h87427d6_1.conda
+  sha256: 41bd5fef28b2755d637e3a8ea5c84010628392fbcf80c7e3d7370aaced7ee4fe
+  md5: 3ac9ef8975965f9698dbedd2a4cc5894
+  depends:
+  - __osx >=10.13
+  - libzlib 1.3.1 h87427d6_1
+  license: Zlib
+  license_family: Other
+  size: 88782
+  timestamp: 1716874245467
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py311h51fa951_0.conda
+  sha256: 5cbac17776b5c8bd27f08f6db4b05a7dc886966370626132654e1418a828931f
+  md5: 9e5d830263cca953b20bb760ca4b6a0d
+  depends:
+  - __osx >=10.13
+  - cffi >=1.11
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 412173
+  timestamp: 1721044344005
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
+  sha256: efa04a98cb149643fa54c4dad5a0179e36a5fbc88427ea0eec88ceed87fd0f96
+  md5: 4cb2cd56f039b129bb0e491c1164167e
+  depends:
+  - __osx >=10.9
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 498900
+  timestamp: 1714723303098
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.9.5-py311h05b510d_0.conda
+  sha256: 63ee70099b66bfa62751d1eb82831438426e3cfc9671a0b836dd9b9d94c92bd6
+  md5: 69eee7117ab7f3ef9eb59a600a9079a3
+  depends:
+  - aiosignal >=1.1.2
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - multidict >=4.5,<7.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - yarl >=1.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  size: 782527
+  timestamp: 1713965372169
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311heffc1b2_4.conda
+  sha256: b9ab23e4f0d615432949d4b93723bd04b3c4aef725aa03b1e993903265c1b975
+  md5: e9a56c22ca1215ed3a7b6a9e8c4e6f07
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 34126
+  timestamp: 1695386994453
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.22-h8a62e84_10.conda
+  sha256: 933c77d0c6eb77bc99b2184f3332b8254f3d82624627bdce9885aa7a32186b48
+  md5: 7a43a23a02f7c952f48d154454336c8c
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-c-sdkutils >=0.1.16,<0.1.17.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91193
+  timestamp: 1720943290434
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.7.1-h94d0942_1.conda
+  sha256: b36692df6896084ecbf370c5a58590ebd0c7e1b9e0a0f27f2de2b81c8e1dca11
+  md5: d70f882eefb9cabf3e18a2f3957936de
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 40129
+  timestamp: 1720901602965
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.23-h99b78c6_0.conda
+  sha256: 15e965a0d1c37927e23d46691e632cf8b39afee5c9ba735f2d535fdb7b58b19e
+  md5: d9f2adf47d2078d44a23480140e76550
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 220102
+  timestamp: 1718918149063
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.18-h94d0942_7.conda
+  sha256: d0244c7638853f8f8feb4a3107844fc6be23c6e29312fc5eda9221df5817b8a7
+  md5: c9a37f68bef48f48782746404f4050a2
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18226
+  timestamp: 1718967294106
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.4.2-hb74cd8f_15.conda
+  sha256: a28581c0fa33d5bf8f71ca18dc632b997ba83d4442a3c2955e40927708ce8b0b
+  md5: e12aae765ef60c989a43f042a4141ab7
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-checksums >=0.1.18,<0.1.19.0a0
+  - libcxx >=16
+  license: Apache-2.0
+  license_family: Apache
+  size: 47055
+  timestamp: 1720743983413
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.8.2-had1507a_6.conda
+  sha256: 42a85dee175d2a8a832157ab3fd8c052955f90f65d40f1076d066b486c64d1ed
+  md5: d6a478f39b7ee977690d7dfc4115adfc
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-compression >=0.2.18,<0.2.19.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 151282
+  timestamp: 1720753122319
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.14.10-hcdb10ff_1.conda
+  sha256: 3b5fcdb83ab4af4b669c753f5ee167502e821180347f2d624bbaf77f9b082eb1
+  md5: e7d85effc69338579c0b928eabe27d67
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 137117
+  timestamp: 1720718690476
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.10.4-h856d8ab_8.conda
+  sha256: c2096334214c00905c71a527e330757e9a419c1e290ba515c6a54531f2b975b9
+  md5: 7a49b5ed4c1676b6aefbd6d7c92d976f
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 117815
+  timestamp: 1720751330215
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.6.0-ha9fd6de_2.conda
+  sha256: 1c3c682ec25a3b3842f9dc14bcdb01705acf828e37c291cf244032299ae22416
+  md5: a326f688d66aa81fc403a2227e93a327
+  depends:
+  - __osx >=11.0
+  - aws-c-auth >=0.7.22,<0.7.23.0a0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-checksums >=0.1.18,<0.1.19.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94615
+  timestamp: 1720949958165
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.16-h94d0942_3.conda
+  sha256: 4303f310b156abeca86ea8a4b4c8be5cfb96dd4214c2ebcfeef1bec3fa1dc793
+  md5: 1f9dd57e79cf2191ed139491aa460e24
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 49180
+  timestamp: 1718973550277
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.18-h94d0942_7.conda
+  sha256: cdd08a5b6b4ebadf05087238987681dc370bd0336ed410d0047171020f160187
+  md5: fbd0be30bdd84b6735dfa3d6c5916b2e
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 49160
+  timestamp: 1718973261942
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.27.3-h9d3339c_2.conda
+  sha256: d863e05f421e23a7a7dc1bf545b409857bddac99231290af442a448d26143eb3
+  md5: bca678a227f7083dffc3d4c0dbd9f2de
+  depends:
+  - __osx >=11.0
+  - aws-c-auth >=0.7.22,<0.7.23.0a0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-event-stream >=0.4.2,<0.4.3.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-c-mqtt >=0.10.4,<0.10.5.0a0
+  - aws-c-s3 >=0.6.0,<0.6.1.0a0
+  - aws-c-sdkutils >=0.1.16,<0.1.17.0a0
+  - libcxx >=16
+  license: Apache-2.0
+  license_family: Apache
+  size: 227663
+  timestamp: 1720963606175
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.329-he6360a2_9.conda
+  sha256: 46e6e18df4c9a8f8cd34ef0a1952dd2d96bf5fe78a1237d4bdeac212de2eb97d
+  md5: df8458d1bc6ec9616f8e88a0eadb05c7
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-event-stream >=0.4.2,<0.4.3.0a0
+  - aws-checksums >=0.1.18,<0.1.19.0a0
+  - aws-crt-cpp >=0.27.3,<0.27.4.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libcxx >=16
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3353366
+  timestamp: 1720817128688
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.12.0-hd01fc5c_0.conda
+  sha256: 046435d3502da0f13c13ee6d92d57684624bf18aefc0d84b99d3ed39d034b078
+  md5: 2accb43f3af2ebf2dbd127978242c10a
+  depends:
+  - __osx >=11.0
+  - libcurl >=8.7.1,<9.0a0
+  - libcxx >=16
+  - openssl >=3.3.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 295160
+  timestamp: 1715352604782
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.8.0-h0a11218_1.conda
+  sha256: 2e54b5d0bd189f43d93e5d3f93534d360c071a4fa4c9f1c9e17301cb29943d43
+  md5: ed8853eaa0ea62cee06025902a46ff17
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.12.0,<1.12.1.0a0
+  - libcxx >=16
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 145294
+  timestamp: 1718986610816
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.11.0-h77cc766_1.conda
+  sha256: 390ada2bad5c76b33ef3d2e9e03ee54f7245060a34d6b199117e956301101449
+  md5: 817fa040e0458866a658a471abc74c64
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.12.0,<1.12.1.0a0
+  - azure-storage-common-cpp >=12.6.0,<12.6.1.0a0
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  size: 420145
+  timestamp: 1718994123570
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.6.0-h7024f69_1.conda
+  sha256: fbf126aad4d98627a32334cdff8e8f0626120a641f424e08d741595d8b6dc8de
+  md5: e796ec0c1c7486270353910f0683de86
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.12.0,<1.12.1.0a0
+  - libcxx >=16
+  - libxml2 >=2.12.7,<2.14.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 112303
+  timestamp: 1718986939585
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.10.0-h64d02d0_1.conda
+  sha256: 593d9d1343ff5ff012264002b9190bc0a7a2a51fb94f54e23b0c54f45153a59b
+  md5: ddbd1d97fa5a420f5a68384be1079e42
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.12.0,<1.12.1.0a0
+  - azure-storage-blobs-cpp >=12.11.0,<12.11.1.0a0
+  - azure-storage-common-cpp >=12.6.0,<12.6.1.0a0
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  size: 184592
+  timestamp: 1719000309622
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h5499902_0.conda
+  sha256: 5a1e635a371449a750b776cab64ad83f5218b58b3f137ebd33ad3ec17f1ce92e
+  md5: e94ca7aec8544f700d45b24aff2dd4d7
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33201
+  timestamp: 1719266149627
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hb547adb_1.conda
+  sha256: 62d1587deab752fcee07adc371eb20fcadc09f72c0c85399c22b637ca858020f
+  md5: a33aa58d448cbc054f887e39dd1dfaea
+  depends:
+  - brotli-bin 1.1.0 hb547adb_1
+  - libbrotlidec 1.1.0 hb547adb_1
+  - libbrotlienc 1.1.0 hb547adb_1
+  license: MIT
+  license_family: MIT
+  size: 19506
+  timestamp: 1695990588610
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hb547adb_1.conda
+  sha256: 8fbfc2834606292016f2faffac67deea4c5cdbc21a61169f0b355e1600105a24
+  md5: 990d04f8c017b1b77103f9a7730a5f12
+  depends:
+  - libbrotlidec 1.1.0 hb547adb_1
+  - libbrotlienc 1.1.0 hb547adb_1
+  license: MIT
+  license_family: MIT
+  size: 17001
+  timestamp: 1695990551239
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311ha891d26_1.conda
+  sha256: 2d78c79ccf2c17236c52ef217a4c34b762eb7908a6903d94439f787aac1c8f4b
+  md5: 5e802b015e33447d1283d599d21f052b
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 hb547adb_1
+  license: MIT
+  license_family: MIT
+  size: 343332
+  timestamp: 1695991223439
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+  sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
+  md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
+  depends:
+  - __osx >=11.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 122909
+  timestamp: 1720974522888
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.32.2-h99b78c6_0.conda
+  sha256: c9cb861e4cc5458df7e9277dd16623efc69491d1d74a85d826c121e2d831415c
+  md5: b0bcd3b8a19fb530d6106467dc681bb4
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 157768
+  timestamp: 1721065989990
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.7.4-hf0a4a13_0.conda
+  sha256: 33a61116dae7f369b6ce92a7f2a1ff361ae737c675a493b11feb5570b89e0e3b
+  md5: 21f9a33e5fe996189e470c19c5354dbe
+  license: ISC
+  size: 154517
+  timestamp: 1720077468981
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hc6c324b_2.conda
+  sha256: 7cb330f41fd5abd3d2444a62c0439af8b11c96497aa2f87d76a5b580edf6d35c
+  md5: 6efeefcad878c15377f49f64e2cbf232
+  depends:
+  - __osx >=11.0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=73.2,<74.0a0
+  - libcxx >=16
+  - libglib >=2.80.2,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.4,<1.0a0
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 898820
+  timestamp: 1718985829269
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cartopy-0.23.0-py311h4b4568b_1.conda
+  sha256: b37a68637aa8f68d47e1403f76b7f1f1f2dd26e79578f6b8e1ee3610049ba5e2
+  md5: eea8b62d33c57bb0fd222292442a19da
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - matplotlib-base >=3.5
+  - numpy >=1.19,<3
+  - packaging >=20
+  - pyproj >=3.3.1
+  - pyshp >=2.3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - shapely >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1506233
+  timestamp: 1715897762892
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.16.0-py311h4a08483_0.conda
+  sha256: 9430416328fe2a28e206e703de771817064c8613a79a6a21fe7107f6a783104c
+  md5: cbdde0484a47b40e6ce2a4e5aaeb48d7
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 292511
+  timestamp: 1696002194472
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cfitsio-4.4.1-h793ed5c_0.conda
+  sha256: cad6c9f86f98f1ac980e8229ef76a9bb8f62d167a52d29770e0548c7f9a80eb1
+  md5: c2a9a79b58d2de021ad9295f53e1f40a
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.3.1,<2.0a0
+  license: LicenseRef-fitsio
+  size: 802060
+  timestamp: 1718906517515
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.4-py311h5d790af_0.conda
+  sha256: a3548d9f89fa41144a55dd5f2b696d4212bdfa24eef2e0e866be34b23ca47b4c
+  md5: ac42ae0d4cb643c229313a9dc2857449
+  depends:
+  - __osx >=11.0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 206929
+  timestamp: 1718096847756
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.2.1-py311hcc98501_0.conda
+  sha256: 9045fa8a05a102d4cd484fec327511386db759b4241bbacd2c5ac34a238f9379
+  md5: 3f5b59b9e9b329527f1af3ee98b3d750
+  depends:
+  - libcxx >=16
+  - numpy >=1.20
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 242204
+  timestamp: 1712430316704
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-0.12.3-py311h05b510d_0.conda
+  sha256: 260980644b0ed686518437f9e86346b0798d7cab6a368a7ab61f085526ae5920
+  md5: d880c8585f9f1dc7057efd5bf7a212e2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 342071
+  timestamp: 1706897488336
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.2-py311hb9542d7_0.conda
+  sha256: 785e8e4147c0f13bdeff92e6812f0a6f7345c5bc984f3e39c94bfc3ee8b7c14b
+  md5: 04a6fbf1020eaae55565eea41378a2fb
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2249814
+  timestamp: 1719378977314
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.6.2-hebf3989_0.conda
+  sha256: 9ac22553a4d595d7e4c9ca9aa09a0b38da65314529a7a7008edc73d3f9e7904a
+  md5: de0cff0ec74f273c4b6aa281479906c3
+  depends:
+  - libexpat 2.6.2 hebf3989_0
+  license: MIT
+  license_family: MIT
+  size: 124594
+  timestamp: 1710362455984
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-10.2.1-h2ffa867_0.conda
+  sha256: 8570ae6fb7cd1179c646e2c48105e91b3ed8ba15855f12965cc5c9719753c06f
+  md5: 8cccde6755bdd787f9840f38a34b4e7d
+  depends:
+  - libcxx >=15
+  license: MIT
+  license_family: MIT
+  size: 174209
+  timestamp: 1704454873305
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.14.2-h82840c6_0.conda
+  sha256: 7094917fc6758186e17c61d8ee8fd2bbbe9f303b4addac61d918fa415c497e2b
+  md5: f77d47ddb6d3cc5b39b9bdf65635afbb
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 237668
+  timestamp: 1674829263740
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.53.1-py311hd3f4193_0.conda
+  sha256: 3b72a418e742b6440ad6591b3f249a0ec3db85143bdb80dfe468525e927b412f
+  md5: 23c938d8d8c598d230f3f6658ee4ec56
+  depends:
+  - __osx >=11.0
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2771834
+  timestamp: 1720359359538
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+  sha256: 791673127e037a2dc0eebe122dc4f904cb3f6e635bb888f42cbe1a76b48748d9
+  md5: e6085e516a3e304ce41a8ee08b9b89ad
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 596430
+  timestamp: 1694616332835
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-hfbad9fb_0.conda
+  sha256: 9cb4957d1431bc57bc95b1e99a50669d91ac3441226a78f69fa030d52f2bda77
+  md5: 40722e5f48287567cda6fb2ec1f7891b
+  depends:
+  - libexpat >=2.5.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - minizip >=4.0.1,<5.0a0
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 55132
+  timestamp: 1694952828719
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.4.1-py311h05b510d_0.conda
+  sha256: 57a0b0677fbf065ae150e5a874f08d6263646acaa808ad44d01149b8abe7c739
+  md5: 9dfb057a46648eb850a8a7b400ae0ae4
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 53365
+  timestamp: 1702645980217
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.9.1-py311hac07d20_7.conda
+  sha256: 0c920225a242b1720273ba7123ca861fa303385e057008cb9279601b69aeac20
+  md5: b30dfafacb2b50b6b6161a3f4bd55c36
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libgdal-core 3.9.1.*
+  - libkml >=1.3.0,<1.4.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 1685920
+  timestamp: 1720823906071
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.12.2-h00cdb27_0.conda
+  sha256: dd763dbafab15d06dbb0995dd2d3f72a49539b00f4325cebb31dd8c89bc5bfdf
+  md5: 9fbc852def80f2d9861be720920e9706
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: LGPL-2.1-only
+  size: 1393461
+  timestamp: 1717689921980
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/geotiff-1.7.3-h7e5fb84_1.conda
+  sha256: d25259c84a706a2bf9568c96b68e198a1155c8761b6788fe00d4b15ca21f12f7
+  md5: 5e689f0ec059ec6fa91deb388f4d9510
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.4.0,<9.5.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 114637
+  timestamp: 1717777096013
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hc88da5d_1004.tar.bz2
+  sha256: 25d4a20af2e5ace95fdec88970f6d190e77e20074d2f6d3cef766198b76a4289
+  md5: aab9ddfad863e9ef81229a1f8852211b
+  depends:
+  - libcxx >=11.0.0.rc1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 86690
+  timestamp: 1599590990520
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-h93a5062_0.conda
+  sha256: 843b3f364ff844137e37d5c0a181f11f6d51adcedd216f019d074e5aa5d7e09c
+  md5: 95fa1486c77505330c20f7202492b913
+  license: MIT
+  license_family: MIT
+  size: 71613
+  timestamp: 1712692611426
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
+  sha256: 9fc77de416953aa959039db72bc41bfa4600ae3ff84acad04a7d0c1ab9552602
+  md5: fef68d0a95aa5b84b5c1a4f6f3bf40e1
+  depends:
+  - __osx >=11.0
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 112215
+  timestamp: 1718284365403
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
+  sha256: c3b01e3c3fe4ca1c4d28c287eaa5168a4f2fd3ffd76690082ac919244c22fa90
+  md5: ff5d749fd711dc7759e127db38005924
+  depends:
+  - libcxx >=15.0.7
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 762257
+  timestamp: 1695661864625
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.3-nompi_hec07895_105.conda
+  sha256: 5d87a1b63862e7da78c7bd9c17dea3526c0462c11df9004943cfa4569cc25dd3
+  md5: f9c8c7304d52c8846eab5d6c34219812
+  depends:
+  - __osx >=11.0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libcxx >=16
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3445248
+  timestamp: 1717587775787
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
+  sha256: ff9cd0c6cd1349954c801fb443c94192b637e1b414514539f3c49c56a39f51b1
+  md5: 8521bd47c0e11c5902535bb1a17c565f
+  license: MIT
+  license_family: MIT
+  size: 11997841
+  timestamp: 1692902104771
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/json-c-0.17-he54c16a_1.conda
+  sha256: b12b280c0179628b2aa355286331d48b136104cf96179c355971f2e7c5b226ac
+  md5: 4831302cd6badbdb87c0334163fb7d68
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 74409
+  timestamp: 1720813255190
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py311h267d04e_0.conda
+  sha256: 05ead39da575f7e25ad1e07755cf24e4b389bb2de945a14049b93e51034b47f9
+  md5: d962e72d8c1d0efb22f0e54e8e97cd71
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18410
+  timestamp: 1718283680472
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jupyter_core-5.7.2-py311h267d04e_0.conda
+  sha256: 0606c9f5a0a9de1e3d8348df4639b7f9dc493a7cf641fd4e9c956af5a33d2b7a
+  md5: f9e296ff8724469af7117f453824a6de
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 96069
+  timestamp: 1710257757802
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/kealib-1.5.3-h848a2d4_1.conda
+  sha256: f17ee2e89bce1923222148956c3b3ab2e859b60f82568a3241593239a8412546
+  md5: dafdda3213a216870027af0c76f204c7
+  depends:
+  - __osx >=11.0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  size: 142911
+  timestamp: 1716158475936
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.5-py311he4fd1f5_1.conda
+  sha256: 907af50734789d47b3e8b2148dde763699dc746c64e5849baf6bd720c8cd0235
+  md5: 4c871d65040b8c7bbb914df7f8f11492
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 61946
+  timestamp: 1695380538042
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+  sha256: 4442f957c3c77d69d9da3521268cad5d54c9033f1a73f99cde0a3658937b159b
+  md5: c6dc8a0fdec13a0565936655c33069a1
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1155530
+  timestamp: 1719463474401
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
+  sha256: 151e0c84feb7e0747fabcc85006b8973b22f5abbc3af76a9add0b0ef0320ebe4
+  md5: 66f6c134e76fe13cce8a9ea5814b5dd5
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 211959
+  timestamp: 1701647962657
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+  sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
+  md5: de462d5aacda3b30721b512c5da4e742
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 215721
+  timestamp: 1657977558796
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240116.2-cxx17_h00cdb27_1.conda
+  sha256: a9517c8683924f4b3b9380cdaa50fdd2009cd8d5f3918c92f64394238189d3cb
+  md5: f16963d88aed907af8b90878b8d8a05c
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  constrains:
+  - abseil-cpp =20240116.2
+  - libabseil-static =20240116.2=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1136123
+  timestamp: 1720857649214
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
+  sha256: 896189b7b48a194c46a3556ea04943ef81cbe0498521231f8eb25816a68bc8ed
+  md5: 6f0b8e56d2e7bae12a18fc5b2cd9f310
+  depends:
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 28451
+  timestamp: 1711021498493
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.7.4-h83d404f_0.conda
+  sha256: 5301d7dc52c2e1f87b229606033c475caf87cd94ef5a5efb3af565a62b88127e
+  md5: 8b604ee634caafd92f2ff2fab6a1f75a
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libiconv >=1.17,<2.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - lzo >=2.10,<3.0a0
+  - openssl >=3.3.0,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 775700
+  timestamp: 1716394811506
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-16.1.0-h2a00445_14_cpu.conda
+  sha256: e2372ca6cc1fbcc84f3ecfeb0a7969ce21016616c29154b214ee369ebda584ff
+  md5: b898a31c17b0ddcb8d2802c2fe0807ce
+  depends:
+  - __osx >=11.0
+  - aws-crt-cpp >=0.27.3,<0.27.4.0a0
+  - aws-sdk-cpp >=1.11.329,<1.11.330.0a0
+  - azure-core-cpp >=1.12.0,<1.12.1.0a0
+  - azure-identity-cpp >=1.8.0,<1.8.1.0a0
+  - azure-storage-blobs-cpp >=12.11.0,<12.11.1.0a0
+  - azure-storage-files-datalake-cpp >=12.10.0,<12.10.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=16
+  - libgoogle-cloud >=2.26.0,<2.27.0a0
+  - libgoogle-cloud-storage >=2.26.0,<2.27.0a0
+  - libre2-11 >=2023.9.1
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.1,<2.0.2.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  - libutf8proc <2.9
+  constrains:
+  - arrow-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  - parquet-cpp <0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5259152
+  timestamp: 1720852251128
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-16.1.0-h00cdb27_14_cpu.conda
+  sha256: c373c35f11b4a7c911ab831fbc2d3abcb4e29d1b7b075d2aad23bd0bc3ec170d
+  md5: b7e1c1689a73c63d2ce2e016e5350779
+  depends:
+  - __osx >=11.0
+  - libarrow 16.1.0 h2a00445_14_cpu
+  - libcxx >=16
+  license: Apache-2.0
+  license_family: APACHE
+  size: 487622
+  timestamp: 1720852349738
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-16.1.0-h00cdb27_14_cpu.conda
+  sha256: 1a72f86887c46436cd28d2509d1cc3c9340d34dd2f713f2fb5e5a649d59af4d8
+  md5: a152a98059b80d43463ee2e4fc0dee09
+  depends:
+  - __osx >=11.0
+  - libarrow 16.1.0 h2a00445_14_cpu
+  - libarrow-acero 16.1.0 h00cdb27_14_cpu
+  - libcxx >=16
+  - libparquet 16.1.0 hcf52c46_14_cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 487091
+  timestamp: 1720853246431
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-16.1.0-hc68f6b8_14_cpu.conda
+  sha256: 71a3e8cf8a85a6e9d6368c7d3c7abb632c538e8e737f4fcb546d0f045e3a4a34
+  md5: 091d891aa3c6ed65c4cd1e2b43127510
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libarrow 16.1.0 h2a00445_14_cpu
+  - libarrow-acero 16.1.0 h00cdb27_14_cpu
+  - libarrow-dataset 16.1.0 h00cdb27_14_cpu
+  - libcxx >=16
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 469321
+  timestamp: 1720853491596
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-22_osxarm64_openblas.conda
+  sha256: 8620e13366076011cfcc6b2565c7a2d362c5d3f0423f54b9ef9bfc17b1a012a4
+  md5: aeaf35355ef0f37c7c1ba35b7b7db55f
+  depends:
+  - libopenblas >=0.3.27,<0.3.28.0a0
+  - libopenblas >=0.3.27,<1.0a0
+  constrains:
+  - blas * openblas
+  - liblapack 3.9.0 22_osxarm64_openblas
+  - liblapacke 3.9.0 22_osxarm64_openblas
+  - libcblas 3.9.0 22_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14824
+  timestamp: 1712542396471
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hb547adb_1.conda
+  sha256: 556f0fddf4bd4d35febab404d98cb6862ce3b7ca843e393da0451bfc4654cf07
+  md5: cd68f024df0304be41d29a9088162b02
+  license: MIT
+  license_family: MIT
+  size: 68579
+  timestamp: 1695990426128
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hb547adb_1.conda
+  sha256: c1c85937828ad3bc434ac60b7bcbde376f4d2ea4ee42d15d369bf2a591775b4a
+  md5: ee1a519335cc10d0ec7e097602058c0a
+  depends:
+  - libbrotlicommon 1.1.0 hb547adb_1
+  license: MIT
+  license_family: MIT
+  size: 28928
+  timestamp: 1695990463780
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hb547adb_1.conda
+  sha256: 690dfc98e891ee1871c54166d30f6e22edfc2d7d6b29e7988dde5f1ce271c81a
+  md5: d7e077f326a98b2cc60087eaff7c730b
+  depends:
+  - libbrotlicommon 1.1.0 hb547adb_1
+  license: MIT
+  license_family: MIT
+  size: 280943
+  timestamp: 1695990509392
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-22_osxarm64_openblas.conda
+  sha256: 2c7902985dc77db1d7252b4e838d92a34b1729799ae402988d62d077868f6cca
+  md5: 37b3682240a69874a22658dedbca37d9
+  depends:
+  - libblas 3.9.0 22_osxarm64_openblas
+  constrains:
+  - blas * openblas
+  - liblapack 3.9.0 22_osxarm64_openblas
+  - liblapacke 3.9.0 22_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14741
+  timestamp: 1712542420590
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+  sha256: 58477b67cc719060b5b069ba57161e20ba69b8695d154a719cb4b60caf577929
+  md5: 32bd82a6a625ea6ce090a81c3d34edeb
+  depends:
+  - libcxx >=11.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18765
+  timestamp: 1633683992603
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.8.0-h7b6f9a7_1.conda
+  sha256: 9da82a9bd72e9872941da32be54543076c92dbeb2aba688a1c24adbc1c699e64
+  md5: e9580b0bb247a2ccf937b16161478f19
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 370070
+  timestamp: 1719603062088
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-18.1.8-h167917d_0.conda
+  sha256: a598062f2d1522fc3727c16620fbc2bc913c1069342671428a92fcf4eb02ec12
+  md5: c891c2eeabd7d67fbc38e012cc6045d6
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1219441
+  timestamp: 1720589623297
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.20-h93a5062_0.conda
+  sha256: 6d16cccb141b6bb05c38107b335089046664ea1d6611601d3f6e7e4227a99925
+  md5: 97efeaeba2a9a82bdf46fc6d025e3a57
+  license: MIT
+  license_family: MIT
+  size: 54481
+  timestamp: 1711196723486
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+  sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
+  md5: 30e4362988a2623e9eb34337b83e01f9
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 96607
+  timestamp: 1597616630749
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+  sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
+  md5: 36d33e440c31857372a72137f78bacf5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 107458
+  timestamp: 1702146414478
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+  sha256: 8c136d7586259bb5c0d2b913aaadc5b9737787ae4f40e3ad1beaf96c80b919b7
+  md5: 1a109764bff3bdc7bdd84088347d71dc
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 368167
+  timestamp: 1685726248899
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.2-hebf3989_0.conda
+  sha256: ba7173ac30064ea901a4c9fb5a51846dcc25512ceb565759be7d18cbf3e5415e
+  md5: e3cde7cfa87f82f7cb13d482d5e0ad09
+  constrains:
+  - expat 2.6.2.*
+  license: MIT
+  license_family: MIT
+  size: 63655
+  timestamp: 1710362424980
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+  md5: 086914b672be056eb70fd4285b6783b6
+  license: MIT
+  license_family: MIT
+  size: 39020
+  timestamp: 1636488587153
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-3.9.1-hce30654_7.conda
+  sha256: 6d1fdde673bacab9f6be6b9a97e64477b13a83268c1dd4e75efd3782398350b7
+  md5: d74d513cc225e46f5a880b9aa0412c97
+  depends:
+  - libgdal-core 3.9.1.*
+  - libgdal-fits 3.9.1.*
+  - libgdal-grib 3.9.1.*
+  - libgdal-hdf4 3.9.1.*
+  - libgdal-hdf5 3.9.1.*
+  - libgdal-jp2openjpeg 3.9.1.*
+  - libgdal-kea 3.9.1.*
+  - libgdal-netcdf 3.9.1.*
+  - libgdal-pdf 3.9.1.*
+  - libgdal-pg 3.9.1.*
+  - libgdal-postgisraster 3.9.1.*
+  - libgdal-tiledb 3.9.1.*
+  - libgdal-xls 3.9.1.*
+  license: MIT
+  license_family: MIT
+  size: 421988
+  timestamp: 1720827156384
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.9.1-hf00468f_7.conda
+  sha256: bc1b34c0c504e35de2a4701fd7638d18585ca6b6c3cefbf14ab5fd48c2a79836
+  md5: ff9fc17efd84272c5d7e6043e40e401b
+  depends:
+  - __osx >=11.0
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.12.2,<3.12.3.0a0
+  - geotiff >=1.7.3,<1.8.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - json-c >=0.17,<0.18.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libarchive >=3.7.4,<3.8.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libcxx >=16
+  - libdeflate >=1.20,<1.26.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.46.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.3.1,<4.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - proj >=9.4.1,<9.5.0a0
+  - xerces-c >=3.2.5,<3.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - libgdal 3.9.1.*
+  license: MIT
+  license_family: MIT
+  size: 8219774
+  timestamp: 1720823728172
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-fits-3.9.1-h7a7a030_7.conda
+  sha256: 2fa6e2e69453cf5c90ad0e06b536d27bc0fb22ea5cc6cae1522a6c3e1cfbacc2
+  md5: 8dc6a2ab3d0dc0fab88fdba56464bdc6
+  depends:
+  - __osx >=11.0
+  - cfitsio >=4.4.1,<4.4.2.0a0
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  license: MIT
+  license_family: MIT
+  size: 465168
+  timestamp: 1720825526452
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.9.1-hdd4b840_7.conda
+  sha256: e54e89a8f583c1bbf6e68652feb2ffd7998271193c30c07e206f123cb71e248e
+  md5: bf29145ee72fec59a8a506600fa22e8a
+  depends:
+  - __osx >=11.0
+  - libaec >=1.1.3,<2.0a0
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  license: MIT
+  license_family: MIT
+  size: 650605
+  timestamp: 1720825667828
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.9.1-h94124bd_7.conda
+  sha256: 2822fad2887e7d71ae5dd12174d3308d85060da5e9bc5ecf6f3f8123b3307066
+  md5: 67699c765888af43fbbad0414ee1bb54
+  depends:
+  - __osx >=11.0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  license: MIT
+  license_family: MIT
+  size: 577668
+  timestamp: 1720825809075
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.9.1-hf90b89a_7.conda
+  sha256: 3c6ba7fd4cd4f68a21862e581d86a31005f66eee13e5cb6bedb3c30b908bd1e3
+  md5: 603d2e65f5dfdca270c9a5b2bc5f65d2
+  depends:
+  - __osx >=11.0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  license: MIT
+  license_family: MIT
+  size: 592204
+  timestamp: 1720825962555
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.9.1-h54bcb16_7.conda
+  sha256: fca9b55904973d22f2eb3536ef88f0decc1a76766314e5fd86c82dc7df98a335
+  md5: a659dc980a3c6ac922c08307d5ece9bc
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  license: MIT
+  license_family: MIT
+  size: 461939
+  timestamp: 1720826097136
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-kea-3.9.1-hacb1b3e_7.conda
+  sha256: fbfd7b9879bc43dce94f7860e3c9992ad3b4b2413e3caf6bb5a48778cfc16966
+  md5: 4b38c04d47134bfbde804c00d218e210
+  depends:
+  - __osx >=11.0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - kealib >=1.5.3,<1.6.0a0
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libgdal-hdf5 3.9.1.*
+  - libkml >=1.3.0,<1.4.0a0
+  license: MIT
+  license_family: MIT
+  size: 469036
+  timestamp: 1720826995914
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.9.1-h1723b65_7.conda
+  sha256: ac23953fd45c58ccbd4b65e3c8d4ad4310bf4f8a8c94b330a0ac43a7593e4ab1
+  md5: 6309cd0e1fb60357750ef2932a2adbd1
+  depends:
+  - __osx >=11.0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libgdal-hdf4 3.9.1.*
+  - libgdal-hdf5 3.9.1.*
+  - libkml >=1.3.0,<1.4.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 665234
+  timestamp: 1720827146318
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-pdf-3.9.1-h4cf08c4_7.conda
+  sha256: bfaa19bcff87fa9e8e8f6feacf30b6968a96bc09e936babb95fd9ec7ca09efee
+  md5: 6495f483d1455e5b8ca1cfc76b083b2d
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - poppler >=24.7.0,<24.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 598494
+  timestamp: 1720826256398
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-pg-3.9.1-h7d28298_7.conda
+  sha256: a03505cc395cbaf1ca66782e6dce4782c6d3a04bd4632a8c249de86d019482f5
+  md5: 91053ea747131c8c12aa7a13898503a5
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libpq >=16.3,<17.0a0
+  - postgresql
+  license: MIT
+  license_family: MIT
+  size: 502772
+  timestamp: 1720826400041
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-postgisraster-3.9.1-h7d28298_7.conda
+  sha256: 10e722199282e0db259d49d1a0f091fe44943ebe2ea0dd855bfb0fda77ffa9da
+  md5: 4066be470db56c40ddd5dc119b98e044
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libpq >=16.3,<17.0a0
+  - postgresql
+  license: MIT
+  license_family: MIT
+  size: 467478
+  timestamp: 1720826540255
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-tiledb-3.9.1-hbb20944_7.conda
+  sha256: 634787fe6861a60d22f43f3af11fa0c424efbb250c7a21a8f70fab5ec70e05c6
+  md5: d6254e327607ee9a241fc95934c617ee
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - tiledb >=2.24.2,<2.25.0a0
+  license: MIT
+  license_family: MIT
+  size: 615326
+  timestamp: 1720826713397
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-xls-3.9.1-hb39617b_7.conda
+  sha256: c212176d469f8dd16d0a7f6ba6126cc21db59e79e6a552d5b34c32fec4849ded
+  md5: 03fb902977e492773646c8b4a1e27c6c
+  depends:
+  - __osx >=11.0
+  - freexl >=2.0.0,<3.0a0
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  license: MIT
+  license_family: MIT
+  size: 431546
+  timestamp: 1720826842355
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+  sha256: 44e541b4821c96b28b27fef5630883a60ce4fee91fd9c79f25a199f8f73f337b
+  md5: 4a55d9e169114b2b90d3ec4604cd7bbf
+  depends:
+  - libgfortran5 13.2.0 hf226fd6_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110233
+  timestamp: 1707330749033
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+  sha256: bafc679eedb468a86aa4636061c55966186399ee0a04b605920d208d97ac579a
+  md5: 66ac81d54e95c534ae488726c1f698ea
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 997381
+  timestamp: 1707330687590
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.80.3-h59d46d9_1.conda
+  sha256: 92f9ca586a0d8070ae2c8924cbc7cc4fd79d47ff9cce58336984c86a197ab181
+  md5: 2fd194003b4e69ab690f18994a71fd70
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  constrains:
+  - glib 2.80.3 *_1
+  license: LGPL-2.1-or-later
+  size: 3655117
+  timestamp: 1720335093245
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.26.0-hfe08963_0.conda
+  sha256: 6753beade8465987399e85ca47c94814e8e24c58cf0ff5591545e6cbe7172ec5
+  md5: db7ab92239aeb06c3c52de90cc1e6f7a
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libcxx >=16
+  - libgrpc >=1.62.2,<1.63.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - openssl >=3.3.1,<4.0a0
+  constrains:
+  - libgoogle-cloud 2.26.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 860834
+  timestamp: 1719889280878
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.26.0-h1466eeb_0.conda
+  sha256: b4c37ebd74a1453ee1cf561e40354544866d1816fa12637b7076377d0ef205ae
+  md5: 385940a9a022e911e88f4e9ea45e47b3
+  depends:
+  - __osx >=11.0
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libcxx >=16
+  - libgoogle-cloud 2.26.0 hfe08963_0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  size: 531614
+  timestamp: 1719890205153
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.62.2-h9c18a4f_0.conda
+  sha256: d2c5b5a828f6f1242c11e8c91968f48f64446f7dd5cbfa1197545e465eb7d47a
+  md5: e624fc11026dbb84c549435eccd08623
+  depends:
+  - c-ares >=1.28.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.1,<20240117.0a0
+  - libcxx >=16
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libre2-11 >=2023.9.1
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.2.1,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.62.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5016525
+  timestamp: 1713392846329
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
+  sha256: bc7de5097b97bcafcf7deaaed505f7ce02f648aac8eccc0d5a47cc599a1d0304
+  md5: 69bda57310071cf6d2b86caf11573d2d
+  license: LGPL-2.1-only
+  size: 676469
+  timestamp: 1702682458114
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.22.5-h8fbad5d_2.conda
+  sha256: 21bc79bdf34ffd20cb84d2a8bd82d7d0e2a1b94b9e72773f0fb207e5b4f1ff63
+  md5: 3d216d0add050129007de3342be7b8c5
+  depends:
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 81206
+  timestamp: 1712512755390
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+  sha256: a42054eaa38e84fc1e5ab443facac4bbc9d1b6b6f23f54b7bf4f1eb687e1d993
+  md5: 3ff1e053dc3a2b8e36b9bfa4256a58d1
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 547541
+  timestamp: 1694475104253
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libkml-1.3.0-h00ed6cc_1020.conda
+  sha256: 254156e86db817d7f312441837ebf3835b01d83e939e1ce54664dd160b6ad716
+  md5: 628dcff1d0a6bb93fc114bf09dd65470
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libexpat >=2.6.2,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - uriparser >=0.9.8,<1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 280157
+  timestamp: 1720690334214
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-22_osxarm64_openblas.conda
+  sha256: 2b1b24c98d15a6a3ad54cf7c8fef1ddccf84b7c557cde08235aaeffd1ff50ee8
+  md5: f2794950bc005e123b2c21f7fa3d7a6e
+  depends:
+  - libblas 3.9.0 22_osxarm64_openblas
+  constrains:
+  - blas * openblas
+  - liblapacke 3.9.0 22_osxarm64_openblas
+  - libcblas 3.9.0 22_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14730
+  timestamp: 1712542435551
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_4.conda
+  sha256: 6f603914fe8633a615f0d2f1383978eb279eeb552079a78449c9fbb43f22a349
+  md5: 9f3dce5d26ea56a9000cd74c034582bd
+  depends:
+  - libcxx >=15
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 20571387
+  timestamp: 1690559110016
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnetcdf-4.9.2-nompi_he469be0_114.conda
+  sha256: aeac591ba859f9cf775993e8b7f21e50803405d41ef363dc4981d114e8df88a8
+  md5: 8fd3ce6d910ed831c130c391c4364d3f
+  depends:
+  - __osx >=11.0
+  - blosc >=1.21.5,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libcxx >=16
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzip >=1.10.1,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - zlib
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 681051
+  timestamp: 1717671966211
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.58.0-ha4dd798_1.conda
+  sha256: fc97aaaf0c6d0f508be313d86c2705b490998d382560df24be918b8e977802cd
+  md5: 1813e066bfcef82de579a0be8a766df4
+  depends:
+  - __osx >=10.9
+  - c-ares >=1.23.0,<2.0a0
+  - libcxx >=16.0.6
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.2.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 565451
+  timestamp: 1702130473930
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.27-openmp_h517c56d_1.conda
+  sha256: 46cfcc592b5255262f567cd098be3c61da6bca6c24d640e878dc8342b0f6d069
+  md5: 71b8a34d70aa567a990162f327e81505
+  depends:
+  - __osx >=11.0
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - llvm-openmp >=16.0.6
+  constrains:
+  - openblas >=0.3.27,<0.3.28.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2925328
+  timestamp: 1720425811743
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-16.1.0-hcf52c46_14_cpu.conda
+  sha256: ff5dfb7bf5b4697d9c7dca5e0caa4d9b0b995a0765ac6cde2f8da8f96e75f3c0
+  md5: b80d93f6639450fa83b459b3f4e9860d
+  depends:
+  - __osx >=11.0
+  - libarrow 16.1.0 h2a00445_14_cpu
+  - libcxx >=16
+  - libthrift >=0.19.0,<0.19.1.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 871343
+  timestamp: 1720853160720
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.43-h091b4b1_0.conda
+  sha256: 66c4713b07408398f2221229a1c1d5df57d65dc0902258113f2d9ecac4772495
+  md5: 77e684ca58d82cae9deebafb95b1a2b8
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: zlib-acknowledgement
+  size: 264177
+  timestamp: 1708780447187
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.3-h7afe498_0.conda
+  sha256: ef7c3bca8ee224e7bb282d85fa573180a8ef4eab943c313cb5b799ce506651bf
+  md5: b0f5315a3f630ade192cb9b569ce54ba
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.2,<1.22.0a0
+  - openssl >=3.3.0,<4.0a0
+  license: PostgreSQL
+  size: 2365596
+  timestamp: 1715266849220
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.25.3-hbfab5d5_0.conda
+  sha256: d754519abc3ddbdedab2a38d0639170f5347c1573eef80c707f3a8dc5dff706a
+  md5: 5f70b2b945a9741cba7e6dfe735a02a7
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.1,<20240117.0a0
+  - libcxx >=16
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2154402
+  timestamp: 1709514097574
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2023.09.01-h7b2c953_2.conda
+  sha256: c8a0a6e7a627dc9c66ffb8858f8f6d499f67fd269b6636b25dc5169760610f05
+  md5: 0b7b2ced046d6b5fe6e9d46b1ee0324c
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.1,<20240117.0a0
+  - libcxx >=16
+  constrains:
+  - re2 2023.09.01.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 171443
+  timestamp: 1708947163461
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/librttopo-1.1.0-h31fb324_16.conda
+  sha256: bf022fa3a85bc38c200c5f97d2e19ac5aa4e97908a6a542e8c13b7d3ff869224
+  md5: 1a8e3f8e886499916b8942628e6b6880
+  depends:
+  - __osx >=11.0
+  - geos >=3.12.2,<3.12.3.0a0
+  - libcxx >=16
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 191683
+  timestamp: 1720347975066
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.18-h27ca646_1.tar.bz2
+  sha256: 1d95fe5e5e6a0700669aab454b2a32f97289c9ed8d1f7667c2ba98327a6f05bc
+  md5: 90859688dbca4735b74c02af14c4c793
+  license: ISC
+  size: 324912
+  timestamp: 1605135878892
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libspatialite-5.1.0-hf7a34df_8.conda
+  sha256: 95353aabfb7e632ca093fed17a9949ef736e8199a542dd0e6a55725d9e245188
+  md5: a7ded74ba9c89174f15aa61d0c9b4ef8
+  depends:
+  - __osx >=11.0
+  - freexl >=2
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.12.2,<3.12.3.0a0
+  - libcxx >=16
+  - libiconv >=1.17,<2.0a0
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.46.0,<4.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.4.1,<9.5.0a0
+  - sqlite
+  - zlib
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 3001587
+  timestamp: 1720363359540
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.46.0-hfb93653_0.conda
+  sha256: 73048f9cb8647d3d3bfe6021c0b7d663e12cffbe9b4f31bd081e713b0a9ad8f9
+  md5: 12300188028c9bc02da965128b91b517
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.2.13,<2.0a0
+  license: Unlicense
+  size: 830198
+  timestamp: 1718050644825
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
+  sha256: bb57d0c53289721fff1eeb3103a1c6a988178e88d8a8f4345b0b91a35f0e0015
+  md5: 029f7dc931a3b626b94823bc77830b01
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 255610
+  timestamp: 1685837894256
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.19.0-h026a170_1.conda
+  sha256: b2c1b30d36f0412c0c0313db76a0236d736f3a9b887b8ed16182f531e4b7cb80
+  md5: 4b8b21eb00d9019e9fa351141da2a6ac
+  depends:
+  - libcxx >=15.0.7
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 331154
+  timestamp: 1695958512679
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.6.0-h07db509_3.conda
+  sha256: 6df3e129682f6dc43826e5028e1807624b2a7634c4becbb50e56be9f77167f25
+  md5: 28c9f8c6dd75666dfb296aea06c49cb8
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=16
+  - libdeflate >=1.20,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: HPND
+  size: 238349
+  timestamp: 1711218119201
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-h1a8c8d9_0.tar.bz2
+  sha256: a3faddac08efd930fa3a1cc254b5053b4ed9428c49a888d437bf084d403c931a
+  md5: f8c9c41a122ab3abdf8943b13f4957ee
+  license: MIT
+  license_family: MIT
+  size: 103492
+  timestamp: 1667316405233
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+  sha256: 0d4bad713a512d79bfeb4d61821f447afab8b0792aca823f505ce6b195e9fde5
+  md5: c0af0edfebe780b19940e94871f1a765
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 287750
+  timestamp: 1713200194013
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.16-hf2054a2_0.conda
+  sha256: ebf4b797f18de4280548520c97ca1528bcb5a8bc721e3bb133a4e3c930a5320f
+  md5: 55b5ed79062edde70459943d2d430d99
+  depends:
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 359805
+  timestamp: 1693089356642
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.7-h9a80f22_3.conda
+  sha256: 760d05981dd32d55ee820a0f35f714a7af32c1c4cc209bf705a0ede93d5bd683
+  md5: 705829a78a7ce3dff19a967f0f0f5ed3
+  depends:
+  - __osx >=11.0
+  - icu >=73.2,<74.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 588441
+  timestamp: 1720772863811
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzip-1.10.1-ha0bc3c6_3.conda
+  sha256: fb42f34c2275523a06bc8464454fa57f2417203524cabb7aacca4e5de6cfeb69
+  md5: e37c0da207079e488709043634d6a711
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 128244
+  timestamp: 1694416824668
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-hfb2fe0b_1.conda
+  sha256: c34365dd37b0eab27b9693af32a1f7f284955517c2cc91f1b88a7ef4738ff03e
+  md5: 636077128927cf79fd933276dc3aed47
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.1 *_1
+  license: Zlib
+  license_family: Other
+  size: 46921
+  timestamp: 1716874262512
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.8-hde57baf_0.conda
+  sha256: 42bc913b3c91934a1ce7ff635e87ee48e2e252632f0cbf607c5a3e4409d9f9dd
+  md5: 82393fdbe38448d878a8848b6fcbcefb
+  depends:
+  - __osx >=11.0
+  constrains:
+  - openmp 18.1.8|18.1.8.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 276438
+  timestamp: 1718911793488
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.43.0-py311h02e79e2_0.conda
+  sha256: a6bb6294a5e5c0a8250acaf3b817e7b009e9c656c767f762b1d85bd436d23f13
+  md5: 70b19f96b4f02d092495ebc40f871172
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 381993
+  timestamp: 1718324755906
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-4.3.3-py311hd44b8e9_0.conda
+  sha256: 94e21299626e9910d9a42de2d28e8ffc018af2dc0ecd247905d06b2a418f313a
+  md5: 55e5496cc171c496f2f1930de465b863
+  depends:
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110848
+  timestamp: 1704831784856
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+  sha256: fc343b8c82efe40819b986e29ba748366514e5ab94a1e1138df195af5f45fa24
+  md5: 45505bec548634f7d05e02fb25262cb9
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 141188
+  timestamp: 1674727268278
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h93a5062_1001.conda
+  sha256: b68160b0a8ec374cea12de7afb954ca47419cdc300358232e19cec666d60b929
+  md5: 915996063a7380c652f83609e970c2a7
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  size: 131447
+  timestamp: 1713516009610
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.5-py311h05b510d_0.conda
+  sha256: 3f2127bd8788dc4b7c3d6d65ae4b7d2f8c7d02a246fc17b819390edeca53fd93
+  md5: a27177455a9d29f4ac9d687a489e5d52
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26578
+  timestamp: 1706900556332
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.9.1-py311hba6b155_0.conda
+  sha256: bbef4f95fb877ac2b2c5766d61c35ddb1e52ce8ac0713aee75f7f976d55a1ea1
+  md5: 6955e64798e21412833d1c308ec76dd3
+  depends:
+  - __osx >=11.0
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=16
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 7814280
+  timestamp: 1720648685909
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/minizip-4.0.7-h27ee973_0.conda
+  sha256: 8216190bed8462758d1fea34964f4f46e6314e92696d8b6607bde588895663ad
+  md5: 73dcdab1f21da49048a4f26d648c87a9
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libcxx >=16
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 77944
+  timestamp: 1718483144234
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.0.8-py311h6bde47b_0.conda
+  sha256: d7f42bb89e656b70c4be5e85dd409aab2bf11aa4638589cfd030306c9d682e6d
+  md5: 649b2c1744a0ef73cc7a78cc6a453a9a
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 92556
+  timestamp: 1715670922825
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.0.5-py311he2be06e_0.conda
+  sha256: 4cec39a59647f2ed4c43e3ce67367bf9114782cbc6c6901c17aa9f9fa2c18174
+  md5: da67ca4f3cc3f0bf140643d5e03cabe5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 56038
+  timestamp: 1707041092018
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-hb89a1cb_0.conda
+  sha256: 87d7cf716d9d930dab682cb57b3b8d3a61940b47d6703f3529a155c938a6990a
+  md5: b13ad5724ac9ae98b6b4fd87e4500ba4
+  license: X11 AND BSD-3-Clause
+  size: 795131
+  timestamp: 1715194898402
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/netcdf4-1.7.1-nompi_py311h42682c7_101.conda
+  sha256: 29a2eb92a5e88d698bc947b92bf27bc6f244e89e97a71de0ad7493a6078c7c12
+  md5: 87559315bbe21d9a322012772b854eb4
+  depends:
+  - __osx >=11.0
+  - certifi
+  - cftime
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 1038191
+  timestamp: 1718724874931
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.35-hb7217d7_0.conda
+  sha256: 35959d36ea9e8a2c422db9f113ee0ac91a9b0c19c51b05f75d0793c3827cfa3a
+  md5: f81b5ec944dbbcff3dd08375eb036efa
+  depends:
+  - libcxx >=14.0.6
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 220745
+  timestamp: 1669785182058
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.102-hc42bcbf_0.conda
+  sha256: 15f521cae90a27ff42b5de3f40cf76f574e0e703c51aa4c882a3590eef284edf
+  md5: 8e6786925188583c0c18920545bb0d72
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libsqlite >=3.46.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.35,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1772423
+  timestamp: 1720064875294
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.60.0-py311h9506ed5_0.conda
+  sha256: 70435f94de8b5328b039ffff9dfdd00c8c0a503cb1a86f4b70ae9cbdd7e4ec1f
+  md5: 5e14ce0b9976d6d0370c9f5032c81bb7
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - llvm-openmp >=16.0.6
+  - llvm-openmp >=18.1.7
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - cuda-version >=11.2
+  - cudatoolkit >=11.2
+  - scipy >=1.0
+  - cuda-python >=11.6
+  - libopenblas >=0.3.18, !=0.3.20
+  - tbb >=2021.6.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5778831
+  timestamp: 1718888718616
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numcodecs-0.12.1-py311hb9542d7_1.conda
+  sha256: a600002fbe6eade8613fc8aa43d41bb72d7fb070b70ffef07e36a7f4ab7b9a26
+  md5: a2dd6003034a0a0c708a5917e9b4b532
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - msgpack-python
+  - numpy >=1.7
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 657088
+  timestamp: 1715219244502
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.0.0-py311h4268184_0.conda
+  sha256: 078b4b7acab19b7314f7dae436805bcf1c231faedde9c393153234a2bcabf9e4
+  md5: 5c316e8847d997ad1b271be52ee06189
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=16
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6878925
+  timestamp: 1718615710207
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
+  sha256: 472d6eaffc1996e6af35ec8e91c967f472a536a470079bfa56383cc0dbf4d463
+  md5: 5029846003f0bc14414b9128a1f7c84b
+  depends:
+  - libcxx >=16
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 316603
+  timestamp: 1709159627299
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.1-hfb2fe0b_1.conda
+  sha256: 3ab411856c3bef88595473f0dd86e82de4f913f88319548acf262d5b1175b050
+  md5: c665dec48e08311096823956642a501c
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2897767
+  timestamp: 1719363723462
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.1-h47ade37_1.conda
+  sha256: 567a9677258cdd03484e3045255bf10a9d8f1031c5030ef83f1fdc1a1ad6f401
+  md5: cd1013678ccef9b552335004f20a2d26
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 417136
+  timestamp: 1716789821766
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.2-py311h4b4568b_1.conda
+  sha256: b08f214593af94dd9bb50d7bf432d1defde66312bd1a2476f27a5fdd9f45ef66
+  md5: b1790dadc62d0af23378d5a79b263893
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - numpy >=1.22.4,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14742444
+  timestamp: 1715898315491
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-h297a79d_0.conda
+  sha256: 23ddc5022a1025027ac1957dc1947c70d93a78414fbb183026457a537e8b3770
+  md5: 62f8d7e2ef03b0aae64185b0f38316eb
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 615298
+  timestamp: 1718466168866
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.4.0-py311hd7951ec_0.conda
+  sha256: 45cfa14f79c75bc6c3cc32e72728777f985ac79787eac6f560774375321deeed
+  md5: 4e46815e20c996cc2ecf3b79d21411b3
+  depends:
+  - __osx >=11.0
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.16,<2.0.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 41840053
+  timestamp: 1719903975499
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.4-hebf3989_0.conda
+  sha256: df0ba2710ccdea5c909b63635529797f6eb3635b6fb77ae9cb2f183d08818409
+  md5: 0308c68e711cd295aaa026a4f8c4b1e5
+  depends:
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  size: 198755
+  timestamp: 1709239846651
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/poppler-24.07.0-h9787579_0.conda
+  sha256: 52aaad25569bc5e3ba867ae01be90d01e0701683d16820888cb6a6c45402f6d6
+  md5: be71ad375a07cf6e2266c1f388c093a9
+  depends:
+  - __osx >=11.0
+  - cairo >=1.18.0,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libcxx >=16
+  - libglib >=2.80.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.35,<5.0a0
+  - nss >=3.102,<4.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - poppler-data
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 1504924
+  timestamp: 1720373679696
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/postgresql-16.3-hdfa2ec6_0.conda
+  sha256: 50bb32b3c8f827a07b29cec09df578fa4f4f7b41770ca6686cccdb5e3bf91431
+  md5: caaf4b5ea6b6abebcbf6ac18522b5875
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.2,<1.22.0a0
+  - libpq 16.3 h7afe498_0
+  - libxml2 >=2.12.6,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.3.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tzcode
+  - tzdata
+  license: PostgreSQL
+  size: 4330650
+  timestamp: 1715267000628
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.4.1-hfb94cee_0.conda
+  sha256: b50cf5ce599ec37b64b5508df1ccd9ad291656d432aa4b6aea887217e9b55690
+  md5: 090b6e9b16cf8d539c689c04e237a252
+  depends:
+  - __osx >=11.0
+  - libcurl >=8.8.0,<9.0a0
+  - libcxx >=16
+  - libsqlite >=3.46.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2712012
+  timestamp: 1718273063314
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.0.0-py311hd3f4193_0.conda
+  sha256: 984318469265162206090199a756db2f327dada39b050c9878534663b3eb6268
+  md5: 3cfef0112ab97269edb8fd98afc78288
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 517029
+  timestamp: 1719274800839
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
+  sha256: 9da9e6f5d51dff6ad2e4ee0874791437ba952e0a6249942273f0fedfd07ea826
+  md5: d3f26c6494d4105d4ecb85203d687102
+  license: MIT
+  license_family: MIT
+  size: 5696
+  timestamp: 1606147608402
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-16.1.0-py311h35c05fe_4.conda
+  sha256: 470e6fc6dc10f5694876156564c7d1e130af47723f50fe715cfe9de05980d70a
+  md5: 75d41ec86da137a75aec215ef4417ccb
+  depends:
+  - libarrow-acero 16.1.0.*
+  - libarrow-dataset 16.1.0.*
+  - libarrow-substrait 16.1.0.*
+  - libparquet 16.1.0.*
+  - numpy >=1.19,<3
+  - pyarrow-core 16.1.0 *_4_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 28483
+  timestamp: 1719450916556
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-16.1.0-py311hf5072a7_4_cpu.conda
+  sha256: 69070d76ac497a8853b4b9ae2ca9adf12f0c82dc199072276540f06c4f3e653d
+  md5: 20c55afa6ee597464fb47e7c45a60e03
+  depends:
+  - __osx >=11.0
+  - libarrow 16.1.0.* *cpu
+  - libcxx >=16
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - orc >=2.0.1
+  - aws-crt-cpp >=0.26.12
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3875344
+  timestamp: 1719450851916
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.3.1-py311h5f135c3_0.conda
+  sha256: 7d52a7ee1fa28ed97acd33ad29407aca29e652c4588e15a98360b729a4155ec7
+  md5: 03b8f7f2cd5efcebac78a17f8ae8c0d2
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 481686
+  timestamp: 1718171961717
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.3.1-py311h5f135c3_0.conda
+  sha256: 80c5cc1941af44446ee007a6c7c98c642307ae968fd70f7f5bf6ebd0ec311fd5
+  md5: a0541fa0e67858765b21be323626f5b0
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 10.3.1.*
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 384567
+  timestamp: 1718645692999
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.8.0-py311he661659_2.conda
+  sha256: dc23f072661188c01bdf993ef29b4913cb70854febc8a02e12e0d304ab05078e
+  md5: eadd540cba719d30c75658c0432701b3
+  depends:
+  - __osx >=11.0
+  - gdal
+  - libcxx >=16
+  - libgdal >=3.9.0,<3.10.0a0
+  - numpy
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 668628
+  timestamp: 1716285222123
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.6.1-py311h5e0e26b_7.conda
+  sha256: 8deb5b31c570240df56b32126b525a1aa68256a4538ca79b152c6892074061ac
+  md5: 8c2b8330b7d788920b3a9802829d4200
+  depends:
+  - __osx >=11.0
+  - certifi
+  - proj >=9.4.0,<9.5.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 493907
+  timestamp: 1717792936954
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.9-h932a869_0_cpython.conda
+  sha256: a436ceabde1f056a0ac3e347dadc780ee2a135a421ddb6e9a469370769829e3c
+  md5: 293e0713ae804b5527a673e7605c04fc
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.45.3,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4.20240210,<7.0a0
+  - openssl >=3.2.1,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 14644189
+  timestamp: 1713552154779
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-4_cp311.conda
+  sha256: 4837089c477b9b84fa38a17f453e6634e68237267211b27a8a2f5ccd847f4e55
+  md5: 8d3751bc73d3bbb66f216fa2331d5649
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6492
+  timestamp: 1695147509940
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.1-py311heffc1b2_1.conda
+  sha256: b155f5c27f0e2951256774628c4b91fdeee3267018eef29897a74e3d1316c8b0
+  md5: d310bfbb8230b9175c0cbc10189ad804
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 187795
+  timestamp: 1695373829282
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.0.3-py311h9bed540_0.conda
+  sha256: 03b787e5d09ebd7c8e5a359d21ed264c4f0c473e7421be48d339fabddd43ffea
+  md5: 140d0704f24e0bad258d4e7ef567d797
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 451293
+  timestamp: 1715024663451
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+  sha256: 873ac689484262a51fd79bc6103c1a1bedbf524924d7f0088fb80703042805e4
+  md5: 6483b1f59526e05d7d894e466b5b6924
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: LicenseRef-Qhull
+  size: 516376
+  timestamp: 1720814307311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rasterio-1.3.10-py311he66545a_4.conda
+  sha256: 912e3579028e7dae6c7cf7be499f59a0b63d16d2a889573d8019c54270bf7a48
+  md5: 5b6ac0520f22c224807db33944050370
+  depends:
+  - __osx >=11.0
+  - affine
+  - attrs
+  - certifi
+  - click >=4
+  - click-plugins
+  - cligj >=0.5
+  - libcxx >=16
+  - libgdal >=3.9.0,<3.10.0a0
+  - numpy >=1.19,<3
+  - proj >=9.4.0,<9.5.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7352133
+  timestamp: 1717806141383
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2023.09.01-h4cba328_2.conda
+  sha256: 0e0d44414381c39a7e6f3da442cb41c637df0dcb383a07425f19c19ccffa0118
+  md5: 0342882197116478a42fa4ea35af79c1
+  depends:
+  - libre2-11 2023.09.01 h7b2c953_2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26770
+  timestamp: 1708947220914
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+  sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
+  md5: 8cbb776a2f641b943d413b3e19df71f4
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 250351
+  timestamp: 1679532511311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.19.0-py311h98c6a39_0.conda
+  sha256: f176d657a1e36740354568b8a8ac2a133445dbb8a83706a31eaf00fb143b9f5c
+  md5: f6b7b80530db28eb61fb3cc41fecb58d
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 288343
+  timestamp: 1720476944005
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.5.1-py311hbfb48bc_0.conda
+  sha256: 750975969130d3cf01d211a1efc8455aaab747040bc1bea48f3da767e5b1fd0a
+  md5: c0859c6e5ce3b8f341fca34a52433925
+  depends:
+  - __osx >=11.0
+  - joblib >=1.2.0
+  - libcxx >=16
+  - llvm-openmp >=16.0.6
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - scipy
+  - threadpoolctl >=3.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9746058
+  timestamp: 1719998814101
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.0-py311hceeca8c_1.conda
+  sha256: 1fe291622b76be350589fd806ed51e0915e5d7be678332c7bacef36347bf1480
+  md5: d5884accd1a71796a6f9a59b60f814b3
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=16
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy >=1.23.5,<2.3
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15225466
+  timestamp: 1720324237608
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.5-py311h0f19114_0.conda
+  sha256: 3ff72d1ad10f472539b69e28bb791f0119a257b48073ed87c9927e341566cf53
+  md5: 9b2359934179fb7c8292a53b8d7eab44
+  depends:
+  - __osx >=11.0
+  - geos >=3.12.2,<3.12.3.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 543970
+  timestamp: 1720886461593
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
+  sha256: cb7a9440241c6092e0f1c795fdca149c4767023e783eaf9cfebc501f906b4897
+  md5: 69d0f9694f3294418ee935da3d5f7272
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35708
+  timestamp: 1720003794374
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/spdlog-1.13.0-h5fcca99_0.conda
+  sha256: 161ad4bb6de140ca00024dd5004b4ab99189767df7f83362d6c252c03213e29a
+  md5: 1907a70a6494b95f3961417e7a9564d2
+  depends:
+  - fmt >=10.2.1,<11.0a0
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  size: 156731
+  timestamp: 1713902551224
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.46.0-h5838104_0.conda
+  sha256: e13b719f70b3a20f40b59f814d32483ae8cd95fef83224127b10091828026f7d
+  md5: 05c5dc8cd793dcfc5849d0569da9b175
+  depends:
+  - __osx >=11.0
+  - libsqlite 3.46.0 hfb93653_0
+  - libzlib >=1.2.13,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 822635
+  timestamp: 1718050678797
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tiledb-2.24.2-h5def871_2.conda
+  sha256: 66c9f8d45ff614af969ded3dc271354bc1885c97fae946bad361a471ae0d629e
+  md5: 324ed9291d2eba902557876197cec529
+  depends:
+  - __osx >=11.0
+  - aws-crt-cpp >=0.27.3,<0.27.4.0a0
+  - aws-sdk-cpp >=1.11.329,<1.11.330.0a0
+  - azure-core-cpp >=1.12.0,<1.12.1.0a0
+  - azure-identity-cpp >=1.8.0,<1.8.1.0a0
+  - azure-storage-blobs-cpp >=12.11.0,<12.11.1.0a0
+  - azure-storage-common-cpp >=12.6.0,<12.6.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - fmt >=10.2.1,<11.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libcxx >=16
+  - libgoogle-cloud >=2.26.0,<2.27.0a0
+  - libgoogle-cloud-storage >=2.26.0,<2.27.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.3.1,<4.0a0
+  - spdlog >=1.13.0,<1.14.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 3531392
+  timestamp: 1720847638756
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+  sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
+  md5: b50a57ba89c32b62428b71a875291c9b
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3145523
+  timestamp: 1699202432999
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.1-py311hd3f4193_0.conda
+  sha256: 4924c617390d88a6f85879b2892a42b3feeea4d1e5fb2f23b2175eeb2b41c7f2
+  md5: 180f7d621916cb04e655d4eda068f4bc
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 857353
+  timestamp: 1717722957594
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tzcode-2024a-h93a5062_0.conda
+  sha256: 70bce0410d77b6ba3c32079aa87a98877ea970d8e96f2e4503e9b81198ece1f4
+  md5: 33ebc94eb6420500a4aeb0fc45112bba
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 63845
+  timestamp: 1706869030258
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/uriparser-0.9.8-h00cdb27_0.conda
+  sha256: fa0bcbfb20a508ca9bf482236fe799581cbd0eab016e47a865e9fa44dbe3c512
+  md5: e8ff9e11babbc8cd77af5a4258dc2802
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40625
+  timestamp: 1715010029254
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xerces-c-3.2.5-hf393695_0.conda
+  sha256: 8ad901a5fe535ebd16b469cf8e46cf174f7e6e4d9b432cc8cc02666a87e7e2ee
+  md5: 5e4741a1e687aee5fc9c409a0476bef2
+  depends:
+  - icu >=73.2,<74.0a0
+  - libcurl >=8.5.0,<9.0a0
+  - libcxx >=15
+  license: Apache-2.0
+  license_family: Apache
+  size: 1270959
+  timestamp: 1703093076013
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
+  sha256: 02c313a1cada46912e5b9bdb355cfb4534bfe22143b4ea4ecc419690e793023b
+  md5: ca73dc4f01ea91e44e3ed76602c5ea61
+  license: MIT
+  license_family: MIT
+  size: 13667
+  timestamp: 1684638272445
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
+  sha256: d9a2fb4762779994718832f05a7d62ab2dcf6103a312235267628b5187ce88f7
+  md5: 6738b13f7fadc18725965abdd4129c36
+  license: MIT
+  license_family: MIT
+  size: 18164
+  timestamp: 1610071737668
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+  sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
+  md5: 39c6b54e94014701dd157f4f576ed211
+  license: LGPL-2.1 and GPL-2.0
+  size: 235693
+  timestamp: 1660346961024
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+  sha256: 93181a04ba8cfecfdfb162fc958436d868cc37db504c58078eab4c1a3e57fbb7
+  md5: 4bb3f014845110883a3c5ee811fd84b4
+  license: MIT
+  license_family: MIT
+  size: 88016
+  timestamp: 1641347076660
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.9.4-py311h05b510d_0.conda
+  sha256: 1da2a08c44e284d17156838d8207fde58dececde3c07626114df4d9a64ae9213
+  md5: 510eded0989b4ef17f3adeca6cb21b22
+  depends:
+  - idna >=2.0
+  - multidict >=4.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 113463
+  timestamp: 1705508875443
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-hcc0f68c_4.conda
+  sha256: c22520d6d66a80f17c5f2b3719ad4a6ee809b210b8ac87d6f05ab98b94b3abda
+  md5: 39fb79e7a7a880a03f82c1f2eb7f7c73
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.2,<1.22.0a0
+  - libcxx >=16
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 298555
+  timestamp: 1715607628741
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-hfb2fe0b_1.conda
+  sha256: 87360c2dc662916aac37cf01e53324b4f4f78db6f399220818076752b093ede5
+  md5: f27e021db7862b6ddbc1d3578f10d883
+  depends:
+  - __osx >=11.0
+  - libzlib 1.3.1 hfb2fe0b_1
+  license: Zlib
+  license_family: Other
+  size: 78260
+  timestamp: 1716874280334
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py311h4a6b76e_0.conda
+  sha256: c372898778c58816cf8ad0031504ffb9a451d92c8547e2e524e6e61c1df5d9a3
+  md5: 0571c2ddfd8f08fbf08f3333ac826b2d
+  depends:
+  - __osx >=11.0
+  - cffi >=1.11
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 332378
+  timestamp: 1721044254516
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+  sha256: 2d4fd1ff7ee79cd954ca8e81abf11d9d49954dd1fef80f27289e2402ae9c2e09
+  md5: d96942c06c3e84bfcc5efb038724a7fd
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 405089
+  timestamp: 1714723101397
+- conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.9.5-py311ha68e1ae_0.conda
+  sha256: 03e161ef1e710089630276964921bb6de9c9852d0b04a59e3fe528c608327767
+  md5: 9c350d73bdc0e3c68fd1d20afa9466a1
+  depends:
+  - aiosignal >=1.1.2
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - multidict >=4.5,<7.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yarl >=1.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  size: 769123
+  timestamp: 1713965512225
+- conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311ha68e1ae_4.conda
+  sha256: 0b8eb99e7ac6b409abbb5f3b9733f883865ff4314e85146380f072f6f6234929
+  md5: e95c947541bf1cb821ea4a6bf7d5794c
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 34687
+  timestamp: 1695387285415
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.22-h8c86ca4_10.conda
+  sha256: 76fb4adb653407b4c514fba7b08e0940869989d660c4b11dedb183c01f7bb77a
+  md5: 94493124319f290e7ad45228d54db509
+  depends:
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-c-sdkutils >=0.1.16,<0.1.17.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 101513
+  timestamp: 1720943471630
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.7.1-hea5f451_1.conda
+  sha256: 24813fbc554c89a6fe26e319b773a4b977bdfbdd356fbc63aa28d5c3df9567c5
+  md5: 72dff54470c6fc809b845fac58d39aad
+  depends:
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 46905
+  timestamp: 1720901876108
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.23-h2466b09_0.conda
+  sha256: 728f9689bea381beebd8c94e333976eec5970bfe5a6a3bf981ee14f5a9229140
+  md5: df475c2b12da4aa32d4946a1453681f5
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 234194
+  timestamp: 1718918578757
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.18-hea5f451_7.conda
+  sha256: 76899d3e3c482fdbd49d7844dc03a4ead7b727e8978f79c5e2a569ef80d815e0
+  md5: 3834f2ba3431fe21692de035a7b992c1
+  depends:
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 22658
+  timestamp: 1718967658946
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.2-h4b8288a_15.conda
+  sha256: b7d65c7cd46ae34608e296e7d642b0e8291eb3517a176138a3daa088c2495136
+  md5: 270c3f0f23c48f3ac0074c3e81bdabac
+  depends:
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-checksums >=0.1.18,<0.1.19.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 54326
+  timestamp: 1720744311520
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.2-h269d64e_6.conda
+  sha256: 7195e70551e3adea16e632b706e8beebfc1d494115942a5839b6edd689108bbc
+  md5: 1603ce5ebacad267b5b5d2c484c73679
+  depends:
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-compression >=0.2.18,<0.2.19.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 180156
+  timestamp: 1720753340047
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.10-hfca834b_1.conda
+  sha256: e487ef1ca72ca609e245184259f6a06d2304997fc1fe7e399ab7efcabc1337da
+  md5: edbdbf574dccbab97002d7408f42d334
+  depends:
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 159625
+  timestamp: 1720719292787
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.4-h519d897_8.conda
+  sha256: 487c9db3d181b802fd56431bd5cbc79e6624b50f1b8fa1f2988adf4509155797
+  md5: b6a0c6760077bb28547ba3ce5ed04cd1
+  depends:
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 158054
+  timestamp: 1720751730919
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.6.0-hb746b11_2.conda
+  sha256: 55a9c0de5feee48492905b3bc8c33b530b79621fff5ab47989221e286f987635
+  md5: f2a22db8c6fa50b13b45e5b8f7d18f11
+  depends:
+  - aws-c-auth >=0.7.22,<0.7.23.0a0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-checksums >=0.1.18,<0.1.19.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 106792
+  timestamp: 1720950156987
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.16-hea5f451_3.conda
+  sha256: f7f80b7650ce03ca9700b8138df625ad4b2a1c49a20ff555cf0fbd4f4b6faa1b
+  md5: 367b3cc3a418fca38f7afc47e753c993
+  depends:
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 54072
+  timestamp: 1718973704299
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.18-hea5f451_7.conda
+  sha256: dfb5d5311ca15516739acd30a7cbfc9077a6164ded265a7247fbf52ea774aea2
+  md5: 1f9a89bde3856fe9feb32eb05f59f231
+  depends:
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 52585
+  timestamp: 1718973550940
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.27.3-h8c89294_2.conda
+  sha256: b9cec3aff15f0890d173813cb570d3bb7b7bf5df85ac6e08296d7134cc6e9c1c
+  md5: 0e2b0e8c97696f1584304ca9fe1e601e
+  depends:
+  - aws-c-auth >=0.7.22,<0.7.23.0a0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-event-stream >=0.4.2,<0.4.3.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-c-mqtt >=0.10.4,<0.10.5.0a0
+  - aws-c-s3 >=0.6.0,<0.6.1.0a0
+  - aws-c-sdkutils >=0.1.16,<0.1.17.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 255271
+  timestamp: 1720963842160
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.329-he0aa860_9.conda
+  sha256: 293cb078bb0d85d480a9bb07e4baeaa88992932961f533a6ceff484f0ec71a48
+  md5: 4fe9877157ca105fce0608c339c2f5b1
+  depends:
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-event-stream >=0.4.2,<0.4.3.0a0
+  - aws-checksums >=0.1.18,<0.1.19.0a0
+  - aws-crt-cpp >=0.27.3,<0.27.4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 3443586
+  timestamp: 1720817600288
+- conda: https://conda.anaconda.org/conda-forge/win-64/azure-core-cpp-1.12.0-haf5610f_0.conda
+  sha256: 7cf6406f5cfa4d63b1c44909fd4c03fed50142db5a8ac0599524df8efa01169e
+  md5: 67994861f2ad1b37d1e10f158b7c928f
+  depends:
+  - libcurl >=8.7.1,<9.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 484815
+  timestamp: 1715352771226
+- conda: https://conda.anaconda.org/conda-forge/win-64/azure-identity-cpp-1.8.0-h8578521_1.conda
+  sha256: 1afbff8a53b288fe2f5f7421f8c851e717622c4153cfd19c6315bc8e512157d9
+  md5: 94d553e22aecb59b2634bc3182a7a462
+  depends:
+  - azure-core-cpp >=1.12.0,<1.12.1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 372333
+  timestamp: 1718986947131
+- conda: https://conda.anaconda.org/conda-forge/win-64/azure-storage-blobs-cpp-12.11.0-h39eb5e7_1.conda
+  sha256: a2b14afb4ecbcc3479f972290c06a476cbe9894c8654d87ac11e18cd4bf8e5c8
+  md5: 78712b83caedfcadb6c620d7bf7def86
+  depends:
+  - azure-core-cpp >=1.12.0,<1.12.1.0a0
+  - azure-storage-common-cpp >=12.6.0,<12.6.1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 957365
+  timestamp: 1718994459694
+- conda: https://conda.anaconda.org/conda-forge/win-64/azure-storage-common-cpp-12.6.0-h8578521_1.conda
+  sha256: 3687f5d8d80c5c9cd6eb96e93c91f808381c2e2455257dfacccd87a74649353c
+  md5: d8a540d0d6447d27aa04c7e3155cd775
+  depends:
+  - azure-core-cpp >=1.12.0,<1.12.1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 227586
+  timestamp: 1718987377230
+- conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.6-h85f69ea_0.conda
+  sha256: 1289853b41df5355f45664f1cb015c868df1f570cf743e9e4a5bda8efe8c42fa
+  md5: 2390269374fded230fcbca8332a4adc0
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50135
+  timestamp: 1719266616208
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-hcfcfb64_1.conda
+  sha256: b927c95121c5f3d82fe084730281739fb04621afebf2d9f05711a0f42d27e326
+  md5: f47f6db2528e38321fb00ae31674c133
+  depends:
+  - brotli-bin 1.1.0 hcfcfb64_1
+  - libbrotlidec 1.1.0 hcfcfb64_1
+  - libbrotlienc 1.1.0 hcfcfb64_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 19772
+  timestamp: 1695990547936
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-hcfcfb64_1.conda
+  sha256: 4fbcb8f94acc97b2b04adbc64e304acd7c06fa0cf01953527bddae46091cc942
+  md5: 0105229d7c5fabaa840043a86c10ec64
+  depends:
+  - libbrotlidec 1.1.0 hcfcfb64_1
+  - libbrotlienc 1.1.0 hcfcfb64_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 20885
+  timestamp: 1695990517506
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311h12c1d0e_1.conda
+  sha256: 5390e1e5e8e159d4893ecbfd2c08ca75ef51bdce1a4a44ff4ee9e2d596004aac
+  md5: 42fbf4e947c17ea605e6a4d7f526669a
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libbrotlicommon 1.1.0 hcfcfb64_1
+  license: MIT
+  license_family: MIT
+  size: 322086
+  timestamp: 1695990976742
+- conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+  sha256: 35a5dad92e88fdd7fc405e864ec239486f4f31eec229e31686e61a140a8e573b
+  md5: 276e7ffe9ffe39688abc665ef0f45596
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 54927
+  timestamp: 1720974860185
+- conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.32.2-h2466b09_0.conda
+  sha256: fccd2071e12ffd71fe7d7e3756fe485fa9d6db6eea69dfe5c236ab6c1d852fda
+  md5: 7e157b8146e5b50a85f7f48446247fff
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 165644
+  timestamp: 1721066677779
+- conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.7.4-h56e8100_0.conda
+  sha256: 7f37bb33c7954de1b4d19ad622859feb4f6c58f751c38b895524cad4e44af72e
+  md5: 9caa97c9504072cd060cf0a3142cc0ed
+  license: ISC
+  size: 154943
+  timestamp: 1720077592592
+- conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h91e5215_2.conda
+  sha256: 89568f4f6844c8c195457fbb2ce39acd9a727be4daadebc2464455db2fda143c
+  md5: 7a0b2818b003bd79106c29f55126d2c3
+  depends:
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=73.2,<74.0a0
+  - libglib >=2.80.2,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.4,<1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 1519852
+  timestamp: 1718986279087
+- conda: https://conda.anaconda.org/conda-forge/win-64/cartopy-0.23.0-py311hcf9f919_1.conda
+  sha256: f8041e836b80b7d1fc1fe817108288c8b7a8ea04d484862a3353be7cd0103967
+  md5: 2caa2c4a69d67e93cba547f159f7b0cb
+  depends:
+  - matplotlib-base >=3.5
+  - numpy >=1.19,<3
+  - packaging >=20
+  - pyproj >=3.3.1
+  - pyshp >=2.3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - shapely >=1.7
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1577423
+  timestamp: 1715898143057
+- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.16.0-py311ha68e1ae_0.conda
+  sha256: eb7463fe3785dd9ac0b3b1e5fea3b721d20eb082e194cab0af8d9ff28c28934f
+  md5: d109d6e767c4890ea32880b8bfa4a3b6
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 297043
+  timestamp: 1696002186279
+- conda: https://conda.anaconda.org/conda-forge/win-64/cfitsio-4.4.1-hc2ea260_0.conda
+  sha256: 97249ec67f115c05a2a452e62f6aed2e3f3a244ba1f33b0e9395a05f9d7f6fee
+  md5: b3263858e6a924d05dc2e9ce335593ba
+  depends:
+  - libcurl >=8.8.0,<9.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LicenseRef-fitsio
+  size: 601046
+  timestamp: 1718906922426
+- conda: https://conda.anaconda.org/conda-forge/win-64/cftime-1.6.4-py311h0a17f05_0.conda
+  sha256: 795d5127d34f78d62e42ac184f0c75d4687a032726e9784374839d99156f6355
+  md5: be0158556407bb5e8e78ec665812634d
+  depends:
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 187708
+  timestamp: 1718097030515
+- conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.2.1-py311h005e61a_0.conda
+  sha256: f9c392ae4c746ac32c55b20d8c487cbc06a91d5dd650261089d90fb55cfcb8c2
+  md5: 050075a7a22e39222595b9191bc082e3
+  depends:
+  - numpy >=1.20
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 206670
+  timestamp: 1712430308615
+- conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-0.12.3-py311ha68e1ae_0.conda
+  sha256: 41a67dd265e30f79fcbc5a9ecba50fc6dbe69fd66b7b12fe07ccb61ae75303ef
+  md5: cac7a698148d6f4c5818ef6edc0a1e58
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 322488
+  timestamp: 1706897983176
+- conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.2-py311hda3d55a_0.conda
+  sha256: 334cc1ad70e050c0dfbab8fc132a5fe41504247189443945723403e3e645c14f
+  md5: e9e8facb47c1afe755daf256c4781124
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 3238916
+  timestamp: 1719379343465
+- conda: https://conda.anaconda.org/conda-forge/win-64/expat-2.6.2-h63175ca_0.conda
+  sha256: f5a13d4bc591a4dc210954f492dd59a0ecf9b9d2ab28bf2ece755ca8f69ec1b4
+  md5: 52f9dec6758ceb8ce0ea8af9fa13eb1a
+  depends:
+  - libexpat 2.6.2 h63175ca_0
+  license: MIT
+  license_family: MIT
+  size: 229627
+  timestamp: 1710362661692
+- conda: https://conda.anaconda.org/conda-forge/win-64/fmt-10.2.1-h181d51b_0.conda
+  sha256: 4593d75b6a1e0b5b43fdcba6b968537638a6e469521fb4c3073929f973891828
+  md5: 4253b572559cc775cae49def5c97b3c0
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 185170
+  timestamp: 1704455079451
+- conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.14.2-hbde0cde_0.conda
+  sha256: 643f2b95be68abeb130c53d543dcd0c1244bebabd58c774a21b31e4b51ac3c96
+  md5: 08767992f1a4f1336a257af1241034bd
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 190111
+  timestamp: 1674829354122
+- conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.53.1-py311he736701_0.conda
+  sha256: bc3770f12525e47778bcd80e95a60f7b6f26ba7b037909dfca232867e6b0900c
+  md5: ff5f337c093df4d814ae6de175113610
+  depends:
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 2466222
+  timestamp: 1720359708882
+- conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+  sha256: 2c53ee8879e05e149a9e525481d36adfd660a6abda26fd731376fa64ff03e728
+  md5: 3761b23693f768dc75a8fd0a73ca053f
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-only OR FTL
+  size: 510306
+  timestamp: 1694616398888
+- conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-h8276f4a_0.conda
+  sha256: 9ef2fcf3b35703bf61a8359038c4b707382f3d5f0c4020f3f8ffb2f665daabae
+  md5: 8e02e06229c677cbc9f5dc69ba49052c
+  depends:
+  - libexpat >=2.5.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - minizip >=4.0.1,<5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 77439
+  timestamp: 1694953013560
+- conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.4.1-py311ha68e1ae_0.conda
+  sha256: a30775ce649c48dd00c5e68a675a29e521802694a73d728a4d418ab847d80412
+  md5: 60608857f155a14154a95182e56b09a7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 54239
+  timestamp: 1702646200957
+- conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.9.1-py311h2711c7e_7.conda
+  sha256: 2dd19258a999f4c1be3e71b98daab354d4fdc41cd9d7c3bc7420540a1b641654
+  md5: df7907f926118ae7475678ebc03d8a5f
+  depends:
+  - libgdal-core 3.9.1.*
+  - libkml >=1.3.0,<1.4.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1645242
+  timestamp: 1720824680437
+- conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.12.2-h5a68840_0.conda
+  sha256: 9b56fa160cd15891636fa050ecc0f0b4bdaffbcb31de626aae7468e7110df969
+  md5: 002724d477c22c106ad05ad90ecce1b8
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-only
+  size: 1569073
+  timestamp: 1717690066933
+- conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.3-hd7df778_1.conda
+  sha256: 6e1d97f71644fe2e8c1b69c37c1967aed0b4a545605b7f9d540f1e62c06166cc
+  md5: ebc0058bce6824048891fe3c58bf6acd
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.4.0,<9.5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 123487
+  timestamp: 1717777636505
+- conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
+  sha256: 52fa5dde69758c19c69ab68a3d7ebfb2c9042e3a55d405c29a59d3b0584fd790
+  md5: 84344a916a73727c1326841007b52ca8
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 779637
+  timestamp: 1695662145568
+- conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_h2b43c12_105.conda
+  sha256: 56c803607a64b5117a8b4bcfdde722e4fa40970ddc4c61224b0981cbb70fb005
+  md5: 5788de34381caf624b78c4981618dc0a
+  depends:
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2039111
+  timestamp: 1717587493910
+- conda: https://conda.anaconda.org/conda-forge/win-64/icu-73.2-h63175ca_0.conda
+  sha256: 423aaa2b69d713520712f55c7c71994b7e6f967824bb39b59ad968e7b209ce8c
+  md5: 0f47d9e3192d9e09ae300da0d28e0f56
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 13422193
+  timestamp: 1692901469029
+- conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.0-h57928b3_980.conda
+  sha256: e3ddfb67e0a922868e68f83d0b56755ff1c280ffa959a0c5ee6a922aaf7022b0
+  md5: 9c28c39e64871a0adef7d1195bd58655
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 1860328
+  timestamp: 1721088141110
+- conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_0.conda
+  sha256: 50cda289c46d043cbfd0f4fd0b6ec6793e6bfc6b4e307baa40486a391d501215
+  md5: fb9c38edbc17bbaa549a8fdc933ada68
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42767
+  timestamp: 1718283925914
+- conda: https://conda.anaconda.org/conda-forge/win-64/jupyter_core-5.7.2-py311h1ea47a8_0.conda
+  sha256: 59a353a47826a4bf136dec1100c90604a6a9fd06f3c203da73d4ea8bbe359aab
+  md5: 191bcd5e85d4f305510e46893de9ae08
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111749
+  timestamp: 1710257755792
+- conda: https://conda.anaconda.org/conda-forge/win-64/kealib-1.5.3-h6c43f9b_1.conda
+  sha256: b4b2cee0ad62ae1f8e4a541d34074c575df935682c023fdf1c21c9c5c9995fa9
+  md5: a20c9e3598a55ca3e61cad90ef33ada3
+  depends:
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 133355
+  timestamp: 1716158947179
+- conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.5-py311h005e61a_1.conda
+  sha256: 8fdd1bff75c24ac6a2a13be4db1c9abcfa39ab50b81539e8bd01131141df271a
+  md5: de0b3f37405f8386ac8be18fdc06ff92
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55822
+  timestamp: 1695380386563
+- conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+  sha256: 18e8b3430d7d232dad132f574268f56b3eb1a19431d6d5de8c53c29e6c18fa81
+  md5: 31aec030344e962fbd7dbbbbd68e60a9
+  depends:
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 712034
+  timestamp: 1719463874284
+- conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
+  sha256: f9fd9e80e46358a57d9bb97b1e37a03da4022143b019aa3c4476d8a7795de290
+  md5: d3592435917b62a8becff3a60db674f6
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 507632
+  timestamp: 1701648249706
+- conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+  sha256: f4f39d7f6a2f9b407f8fb567a6c25755270421731d70f0ff331f5de4fa367488
+  md5: 1900cb3cab5055833cfddb0ba233b074
+  depends:
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30037
+  license: Apache-2.0
+  license_family: Apache
+  size: 194365
+  timestamp: 1657977692274
+- conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240116.2-cxx17_he0c23c2_1.conda
+  sha256: aafa7993698420ef786c145f660e6822139c02cf9230fbad43efff6d4828defc
+  md5: 19725e54b7f996e0a5748ec5e9e37ae9
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libabseil-static =20240116.2=cxx17*
+  - abseil-cpp =20240116.2
+  license: Apache-2.0
+  license_family: Apache
+  size: 1802886
+  timestamp: 1720857653184
+- conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
+  sha256: f5c293d3cfc00f71dfdb64bd65ab53625565f8778fc2d5790575bef238976ebf
+  md5: 8723000f6ffdbdaef16025f0a01b64c5
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 32567
+  timestamp: 1711021603471
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.7.4-haf234dc_0.conda
+  sha256: 3ab13c269949874c4538b22eeb83a36d2c55b4a4ea6628bef1bab4c724ee5a1b
+  md5: 86de12ebf8d7fffeba4ca9dbf13e9733
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - lzo >=2.10,<3.0a0
+  - openssl >=3.3.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 957632
+  timestamp: 1716395481752
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-16.1.0-h11e6a32_14_cpu.conda
+  sha256: 621a0d2e4b1572a8d0292dc81d8b65897d36d15a1ebe2314701d6abab0aba18d
+  md5: 4a99497931ff52b28cdf0da17167498f
+  depends:
+  - aws-crt-cpp >=0.27.3,<0.27.4.0a0
+  - aws-sdk-cpp >=1.11.329,<1.11.330.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libgoogle-cloud >=2.26.0,<2.27.0a0
+  - libgoogle-cloud-storage >=2.26.0,<2.27.0a0
+  - libre2-11 >=2023.9.1
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.1,<2.0.2.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
+  - libutf8proc <2.9
+  constrains:
+  - arrow-cpp <0.0a0
+  - parquet-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5116155
+  timestamp: 1720853379313
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-16.1.0-he0c23c2_14_cpu.conda
+  sha256: d23addb34459136ff85b261af4079a0bd3f9feb2e8ea203d4502bba4d5d9e014
+  md5: 5befc967c3de6dc7eb33c876e6f9f1ae
+  depends:
+  - libarrow 16.1.0 h11e6a32_14_cpu
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 446589
+  timestamp: 1720853462778
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-16.1.0-he0c23c2_14_cpu.conda
+  sha256: 05bf65f73d59bef0fac3d5572d3b09f2292f55b065ed2bb4a21ec15137dcb7b1
+  md5: cf56162cda531d484a10870437d8f9ba
+  depends:
+  - libarrow 16.1.0 h11e6a32_14_cpu
+  - libarrow-acero 16.1.0 he0c23c2_14_cpu
+  - libparquet 16.1.0 h178134c_14_cpu
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 427061
+  timestamp: 1720853724637
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-16.1.0-h1f0e801_14_cpu.conda
+  sha256: 2b84739380fc3a090b7ae2e873768fdc531750bed6fa9c738b345a289a949b29
+  md5: cbca4d5062a1efbce98d4998db2dde1b
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libarrow 16.1.0 h11e6a32_14_cpu
+  - libarrow-acero 16.1.0 he0c23c2_14_cpu
+  - libarrow-dataset 16.1.0 he0c23c2_14_cpu
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 383645
+  timestamp: 1720853835576
+- conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-22_win64_mkl.conda
+  sha256: 4faab445cbd9a13736a206b98fde962d0a9fa80dcbd38300951a8b2863e7c35c
+  md5: 65c56ecdeceffd6c32d3d54db7e02c6e
+  depends:
+  - mkl 2024.1.0 h66d3029_692
+  constrains:
+  - liblapacke 3.9.0 22_win64_mkl
+  - blas * mkl
+  - libcblas 3.9.0 22_win64_mkl
+  - liblapack 3.9.0 22_win64_mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5182602
+  timestamp: 1712542984136
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hcfcfb64_1.conda
+  sha256: f75fed29b0cc503d1b149a4945eaa32df56e19da5e2933de29e8f03947203709
+  md5: f77f319fb82980166569e1280d5b2864
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 70598
+  timestamp: 1695990405143
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hcfcfb64_1.conda
+  sha256: 1b352ee05931ea24c11cd4a994d673890fd1cc690c21e023e736bdaac2632e93
+  md5: 19ce3e1dacc7912b3d6ff40690ba9ae0
+  depends:
+  - libbrotlicommon 1.1.0 hcfcfb64_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 32788
+  timestamp: 1695990443165
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hcfcfb64_1.conda
+  sha256: eae6b76154e594c6d211160c6d1aeed848672618152a562e0eabdfa641d34aca
+  md5: 71e890a0b361fd58743a13f77e1506b7
+  depends:
+  - libbrotlicommon 1.1.0 hcfcfb64_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 246515
+  timestamp: 1695990479484
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-22_win64_mkl.conda
+  sha256: 5503273924650330dc03edd1eb01ec4020b9967b5a4cafc377ba20b976d15590
+  md5: 336c93ab102846c6131cf68e722a68f1
+  depends:
+  - libblas 3.9.0 22_win64_mkl
+  constrains:
+  - liblapacke 3.9.0 22_win64_mkl
+  - blas * mkl
+  - liblapack 3.9.0 22_win64_mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5191513
+  timestamp: 1712543043641
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+  sha256: 75e60fbe436ba8a11c170c89af5213e8bec0418f88b7771ab7e3d9710b70c54e
+  md5: cd4cc2d0c610c8cb5419ccc979f2d6ce
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25694
+  timestamp: 1633684287072
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.8.0-hd5e4a3a_1.conda
+  sha256: ebe665ec226672e7e6e37f2b1fe554db83f9fea5267cbc5a849ab34d8546b2c3
+  md5: 88fbd2ea44690c6dfad8737659936461
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: curl
+  license_family: MIT
+  size: 334189
+  timestamp: 1719603160758
+- conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.20-hcfcfb64_0.conda
+  sha256: 6628a5b76ad70c1a0909563c637ddc446ee824739ba7c348d4da2f0aa6ac9527
+  md5: b12b5bde5eb201a1df75e49320cc938a
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 155358
+  timestamp: 1711197066985
+- conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+  sha256: af03882afb7a7135288becf340c2f0cf8aa8221138a9a7b108aaeb308a486da1
+  md5: 25efbd786caceef438be46da78a7b5ef
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 410555
+  timestamp: 1685726568668
+- conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.2-h63175ca_0.conda
+  sha256: 79f612f75108f3e16bbdc127d4885bb74729cf66a8702fca0373dad89d40c4b7
+  md5: bc592d03f62779511d392c175dcece64
+  constrains:
+  - expat 2.6.2.*
+  license: MIT
+  license_family: MIT
+  size: 139224
+  timestamp: 1710362609641
+- conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+  sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
+  md5: 2c96d1b6915b408893f9472569dee135
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 42063
+  timestamp: 1636489106777
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.9.1-h57928b3_7.conda
+  sha256: 65c6a7284e6b85786ca59288a3af49b79949ec035bf45cd0327080d7d7917586
+  md5: 239b68a175a9eb17d49c7b190fff03ba
+  depends:
+  - libgdal-core 3.9.1.*
+  - libgdal-fits 3.9.1.*
+  - libgdal-grib 3.9.1.*
+  - libgdal-hdf4 3.9.1.*
+  - libgdal-hdf5 3.9.1.*
+  - libgdal-jp2openjpeg 3.9.1.*
+  - libgdal-kea 3.9.1.*
+  - libgdal-netcdf 3.9.1.*
+  - libgdal-pdf 3.9.1.*
+  - libgdal-pg 3.9.1.*
+  - libgdal-postgisraster 3.9.1.*
+  - libgdal-tiledb 3.9.1.*
+  - libgdal-xls 3.9.1.*
+  license: MIT
+  license_family: MIT
+  size: 422620
+  timestamp: 1720827833144
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.9.1-h7e31c53_7.conda
+  sha256: 97f8465de180b8f78282ef609d5c16d103946d2db38b1abb6bb014b2dcd6aa64
+  md5: ca177f91a08b4417d73bbece957f7bc5
+  depends:
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.12.2,<3.12.3.0a0
+  - geotiff >=1.7.3,<1.8.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libarchive >=3.7.4,<3.8.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libdeflate >=1.20,<1.26.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.46.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.3.1,<4.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - proj >=9.4.1,<9.5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xerces-c >=3.2.5,<3.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - libgdal 3.9.1.*
+  license: MIT
+  license_family: MIT
+  size: 8055070
+  timestamp: 1720824000220
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-fits-3.9.1-h0a0b71e_7.conda
+  sha256: b9c13cded1735c3226f1c3faae3286ec6671ac6f3e85dc87bb12a5cbef35dd09
+  md5: 88d6413eb4f2d3e727aa4f11fce5cc5c
+  depends:
+  - cfitsio >=4.4.1,<4.4.2.0a0
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 496107
+  timestamp: 1720826118739
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.9.1-hd2a089b_7.conda
+  sha256: b332e57d952a867b4414e63f9cd8a083d7fc5585d3f91b3673df8faae6c4f401
+  md5: e9c05bc941ee9e50f6b8ff7ffe5c09fd
+  depends:
+  - libaec >=1.1.3,<2.0a0
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 677265
+  timestamp: 1720826267006
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.9.1-h430f241_7.conda
+  sha256: 8df935a2fb314c80ee935a4f3d4d4b3c16db2002f796fcbc90d9cc1a242a73d2
+  md5: a92d1a848de57a10b77885e6d9138aa6
+  depends:
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 561286
+  timestamp: 1720826410786
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.9.1-had131a1_7.conda
+  sha256: fa421fcc941c4bc11e1c13d7fe7247a0d2b9cac36fef56ad50cc3db5c683ae8a
+  md5: cd6349de6a265020ce34a6b5f4e592d6
+  depends:
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 612327
+  timestamp: 1720826569399
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.9.1-hed4c6cb_7.conda
+  sha256: 5d49941b33f0b4815b897b4d0a8e8c2d9acade0cf4c602dec6dcd25960ac7932
+  md5: abafd7ff5c30204ac654590adc9d20f8
+  depends:
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 496499
+  timestamp: 1720826703230
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-kea-3.9.1-h95b1a77_7.conda
+  sha256: e05c219d1095cb9152f5e59fee9243fec361ac364633a09b88660d7b6fafceb3
+  md5: dd327fa14b543a0508bcef08b50d6ec8
+  depends:
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - kealib >=1.5.3,<1.6.0a0
+  - libgdal-core >=3.9
+  - libgdal-hdf5 3.9.1.*
+  - libkml >=1.3.0,<1.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 517991
+  timestamp: 1720827673411
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.9.1-h55e78d3_7.conda
+  sha256: b59867ef5f3f8f868a0d4d33a7093e73fe51d83e05007e05587b1b293288174f
+  md5: 39b9ac3417bf29a2ced3af4ff07a8626
+  depends:
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libgdal-core >=3.9
+  - libgdal-hdf4 3.9.1.*
+  - libgdal-hdf5 3.9.1.*
+  - libkml >=1.3.0,<1.4.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 665791
+  timestamp: 1720827826278
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pdf-3.9.1-h261eb30_7.conda
+  sha256: e3948fe8d131548517fbc95f45969f1bd18a70204f93792c770553f400d6471f
+  md5: 8ef273448de0e3e59250effa5dd5b319
+  depends:
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - poppler >=24.7.0,<24.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 625052
+  timestamp: 1720826886713
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pg-3.9.1-ha693a0f_7.conda
+  sha256: 96ef1dd5ca34e2327805a37bccb64cdf34998ab61781ced0d1edcc29b9c1afb0
+  md5: 00eada45f3379eec3f0eb09943763a28
+  depends:
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libpq >=16.3,<17.0a0
+  - postgresql
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 531697
+  timestamp: 1720827037659
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-postgisraster-3.9.1-ha693a0f_7.conda
+  sha256: 13a3d78cfeca337ec6453777e912855792553be934e318a0a6d9595c6d9949b5
+  md5: 2a180e29e55a314dc68ee93270905c68
+  depends:
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libpq >=16.3,<17.0a0
+  - postgresql
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 503769
+  timestamp: 1720827201780
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-tiledb-3.9.1-h0c63b6b_7.conda
+  sha256: 2bd8fac2af9c0465bbeb042ff8f14c0b8fc84c5250bbd9e642b0e6a59b9e6354
+  md5: d57f92f46b6f9d63baabbcb7c34f3011
+  depends:
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - tiledb >=2.24.2,<2.25.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 627135
+  timestamp: 1720827395369
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-xls-3.9.1-hd0e23a6_7.conda
+  sha256: 031edf8d4868e92a6423b848327132b03fb0f434d536b7e81f8e41dcc9965a8a
+  md5: 986f33ccc00f1a835db635e0c8f804d5
+  depends:
+  - freexl >=2.0.0,<3.0a0
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 465093
+  timestamp: 1720827527441
+- conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.80.3-h7025463_1.conda
+  sha256: cae4f5ab6c64512aa6ae9f5c808f9b0aaea19496ddeab3720c118ad0809f7733
+  md5: 53c80e0ed9a3905ca7047c03756a5caa
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - glib 2.80.3 *_1
+  license: LGPL-2.1-or-later
+  size: 3743922
+  timestamp: 1720334986136
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.26.0-h5e7cea3_0.conda
+  sha256: 31e0abd909dce9b0223471383e5f561c802da0abfe7d6f28eb0317c806879c41
+  md5: 641d850ed6a3d2bffb546868eb7cb4db
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libgrpc >=1.62.2,<1.63.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libgoogle-cloud 2.26.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 14356
+  timestamp: 1719889580338
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.26.0-he5eb982_0.conda
+  sha256: cfe666f4e205148661249a87587335a1dae58f7bf530fb08dcc2ffcd1bc6adb9
+  md5: 31d875f47c82afb1c9bbe3beb3bd8d6e
+  depends:
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libgoogle-cloud 2.26.0 h5e7cea3_0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 14267
+  timestamp: 1719889928831
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.62.2-h5273850_0.conda
+  sha256: 08794bf5ea0e19ac23ed47d0f8699b5c05c46f14334b41f075e53bac9bbf97d8
+  md5: 2939e4b5baecfeac1e8dee5c4f579f1a
+  depends:
+  - c-ares >=1.28.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.1,<20240117.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libre2-11 >=2023.9.1
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.2.1,<4.0a0
+  - re2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - grpc-cpp =1.62.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 16097674
+  timestamp: 1713392821679
+- conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.1-default_h8125262_1000.conda
+  sha256: 92728e292640186759d6dddae3334a1bc0b139740b736ffaeccb825fb8c07a2e
+  md5: 933bad6e4658157f1aec9b171374fde2
+  depends:
+  - libxml2 >=2.12.7,<2.14.0a0
+  - pthreads-win32
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2379689
+  timestamp: 1720461835526
+- conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+  sha256: 5f844dd19b046d43174ad80c6ea75b5d504020e3b63cfbc4ace97b8730d35c7b
+  md5: e1eb10b1cca179f2baa3601e4efc8712
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-only
+  size: 636146
+  timestamp: 1702682547199
+- conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_2.conda
+  sha256: 1b95335af0a3e278b31e16667fa4e51d1c3f5e22d394d982539dfd5d34c5ae19
+  md5: aa622c938af057adc119f8b8eecada01
+  depends:
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 95745
+  timestamp: 1712516102666
+- conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+  sha256: 4e7808e3098b4b4ed7e287f63bb24f9045cc4d95bfd39f0db870fc2837d74dff
+  md5: 3f1b948619c45b1ca714d60c7389092c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 822966
+  timestamp: 1694475223854
+- conda: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-h538826c_1020.conda
+  sha256: 2f20949d50302bddfd4b6c9bb2cd91a02c97ce5a36fab552f2eacad53a71c113
+  md5: fddbd8a22ee5700bc07e978e25c10ef1
+  depends:
+  - libexpat >=2.6.2,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - uriparser >=0.9.8,<1.0a0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1655764
+  timestamp: 1720690303546
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-22_win64_mkl.conda
+  sha256: 8b28b361a13819ed83a67d3bfdde750a13bc8b50b9af26d94fd61616d0f2d703
+  md5: c752cc2af9f3d8d7b2fdebb915a33ef7
+  depends:
+  - libblas 3.9.0 22_win64_mkl
+  constrains:
+  - liblapacke 3.9.0 22_win64_mkl
+  - blas * mkl
+  - libcblas 3.9.0 22_win64_mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5182500
+  timestamp: 1712543085027
+- conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_h92078aa_114.conda
+  sha256: 111fb98bf02e717c69eb78388a5b03dc7af05bfa840ac51c2b31beb70bf42318
+  md5: 819507db3802d9a179de4d161285c22f
+  depends:
+  - blosc >=1.21.5,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzip >=1.10.1,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 624793
+  timestamp: 1717672198533
+- conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-16.1.0-h178134c_14_cpu.conda
+  sha256: ab17da6957c351cad8d8aafa0cea63da780f452855ff4dc8450644e66f8d88b7
+  md5: 9598f17e88626331cfabb1134f4b2e37
+  depends:
+  - libarrow 16.1.0 h11e6a32_14_cpu
+  - libthrift >=0.19.0,<0.19.1.0a0
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 794669
+  timestamp: 1720853663470
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.43-h19919ed_0.conda
+  sha256: 6ad31bf262a114de5bbe0c6ba73b29ed25239d0f46f9d59700310d2ea0b3c142
+  md5: 77e398acc32617a0384553aea29e866b
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: zlib-acknowledgement
+  size: 347514
+  timestamp: 1708780763195
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpq-16.3-hab9416b_0.conda
+  sha256: 5cb998386c86fcbf5c3b929c0ec252e80b56d3f2ef4bc857496f5d06d3b28af1
+  md5: 84d2332f3110845bbafbfd7d5311354f
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - openssl >=3.3.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PostgreSQL
+  size: 3456937
+  timestamp: 1715267132646
+- conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.25.3-h503648d_0.conda
+  sha256: 5d4c5592be3994657ebf47e52f26b734cc50b0ea9db007d920e2e31762aac216
+  md5: 4da7de0ba35777742edf67bf7a1075df
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.1,<20240117.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5650604
+  timestamp: 1709514804631
+- conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2023.09.01-hf8d8778_2.conda
+  sha256: 04331dad30a076ebb24c683197a5feabf4fd9be0fa0e06f416767096f287f900
+  md5: cf54cb5077a60797d53a132d37af25fc
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.1,<20240117.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - re2 2023.09.01.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 256561
+  timestamp: 1708947458481
+- conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-h6c42fcb_16.conda
+  sha256: 417d468a42860bee6d487a39603740c3650fb7eae03b694a9bddada9ef5d1017
+  md5: 4476d717f460b45f5033206bbb84f3f5
+  depends:
+  - geos >=3.12.2,<3.12.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 407420
+  timestamp: 1720347953921
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.18-h8d14728_1.tar.bz2
+  sha256: ecc463f0ab6eaf6bc5bd6ff9c17f65595de6c7a38db812222ab8ffde0d3f4bc2
+  md5: 5c1fb45b5e2912c19098750ae8a32604
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: ISC
+  size: 713431
+  timestamp: 1605135918736
+- conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-hcb35769_8.conda
+  sha256: 98ab122b2a48b70b0845d81cda0f96df11bb89240b17583091b9f39022ad9dab
+  md5: 68253306f07e185a8420488465cc1c32
+  depends:
+  - freexl >=2
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.12.2,<3.12.3.0a0
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.46.0,<4.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.4.1,<9.5.0a0
+  - sqlite
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 8799088
+  timestamp: 1720363415346
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.46.0-h2466b09_0.conda
+  sha256: 662bd7e0d63c5b8c31cca19b91649e798319b93568a2ba8d1375efb91eeb251b
+  md5: 951b0a3a463932e17414cd9f047fa03d
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 876677
+  timestamp: 1718051113874
+- conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+  sha256: 813fd04eed2a2d5d9c36e53c554f9c1f08e9324e2922bd60c9c52dbbed2dbcec
+  md5: dc262d03aae04fe26825062879141a41
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 266806
+  timestamp: 1685838242099
+- conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.19.0-ha2b3283_1.conda
+  sha256: 89bbc59898c827429a52315c9c0dd888ea73ab1157a8c86098aeae7d13454ac4
+  md5: d3432b9d4950e91d2fdf3bed91248ee0
+  depends:
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 612342
+  timestamp: 1695958519927
+- conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-hddb2be6_3.conda
+  sha256: 2e04844865cfe0286d70482c129f159542b325f4e45774aaff5fbe5027b30b0a
+  md5: 6d1828c9039929e2f185c5fa9d133018
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.20,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: HPND
+  size: 787198
+  timestamp: 1711218639912
+- conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-h82a8f57_0.tar.bz2
+  sha256: 6efa83e3f2fb9acaf096a18d21d0f679d110934798348c5defc780d4b759a76c
+  md5: 076894846fe9f068f91c57d158c90cba
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 104389
+  timestamp: 1667316359211
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+  sha256: d0ca51cb1de9192be9a3238e71fbcca5a535619c499c4f4c9b2ed41c14d36770
+  md5: abd61d0ab127ec5cd68f62c2969e6f34
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 274359
+  timestamp: 1713200524021
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.16-hcd874cb_0.conda
+  sha256: 3b1f3b04baa370cfb1c350cfa829e6236519df5f03e3f57ea2cb2eb044eb8616
+  md5: 7c1217d3b075f195ab17370f2d550f5d
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 989932
+  timestamp: 1693089470750
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.7-h0f24e4e_4.conda
+  sha256: ae78197961b09b0eef4ee194a44e4adc4555c0f2f20c348086b0cd8aaf2f7731
+  md5: ed4d301f0d2149b34deb9c4fecafd836
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1682090
+  timestamp: 1721031296951
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzip-1.10.1-h1d365fa_3.conda
+  sha256: 221698b52dd7a3dcfc67ff9460e9c8649fc6c86506a2a2ab6f57b97e7489bb9f
+  md5: 5c629cd12d89e2856c17b1dc5fcf44a4
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 146434
+  timestamp: 1694417117772
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_1.conda
+  sha256: b13846a54a15243e15f96fec06b526d8155adc6a1ac2b6ed47a88f6a71a94b68
+  md5: d4483ca8afc57ddf1f6dded53b36c17f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - zlib 1.3.1 *_1
+  license: Zlib
+  license_family: Other
+  size: 56186
+  timestamp: 1716874730539
+- conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.43.0-py311h7deaa30_0.conda
+  sha256: a574886526737e1c3c3188115862fac5b5600a6394c3d6adee60443be98023ee
+  md5: 3e7e4560830194638b6f0ee64c71b06b
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - vs2015_runtime
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17130729
+  timestamp: 1718324901462
+- conda: https://conda.anaconda.org/conda-forge/win-64/lz4-4.3.3-py311haddf500_0.conda
+  sha256: 1f826e3a559eed39113d4d3b8131b937abf9d3139e63786ff0c8c295f0a5a652
+  md5: 5e0fceb00bc784481e1ac2aa44b1e844
+  depends:
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 77111
+  timestamp: 1704831874474
+- conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+  sha256: a0954b4b1590735ea5f3d0f4579c3883f8ac837387afd5b398b241fda85124ab
+  md5: e34720eb20a33fc3bfb8451dd837ab7a
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134235
+  timestamp: 1674728465431
+- conda: https://conda.anaconda.org/conda-forge/win-64/lzo-2.10-hcfcfb64_1001.conda
+  sha256: 39e176b8cc8fe878d87594fae0504c649d1c2c6d5476dd7238237d19eb825751
+  md5: 629f4f4e874cf096eb93a23240910cee
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  size: 142771
+  timestamp: 1713516312465
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+  sha256: 9de95a7996d5366ae0808eef2acbc63f9b11b874aa42375f55379e6715845dc6
+  md5: 066552ac6b907ec6d72c0ddab29050dc
+  depends:
+  - m2w64-gcc-libs-core
+  - msys2-conda-epoch ==20160418
+  license: GPL, LGPL, FDL, custom
+  size: 350687
+  timestamp: 1608163451316
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+  sha256: 3bd1ab02b7c89a5b153a17be03b36d833f1517ff2a6a77ead7c4a808b88196aa
+  md5: fe759119b8b3bfa720b8762c6fdc35de
+  depends:
+  - m2w64-gcc-libgfortran
+  - m2w64-gcc-libs-core
+  - m2w64-gmp
+  - m2w64-libwinpthread-git
+  - msys2-conda-epoch ==20160418
+  license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  size: 532390
+  timestamp: 1608163512830
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+  sha256: 58afdfe859ed2e9a9b1cc06bc408720cb2c3a6a132e59d4805b090d7574f4ee0
+  md5: 4289d80fb4d272f1f3b56cfe87ac90bd
+  depends:
+  - m2w64-gmp
+  - m2w64-libwinpthread-git
+  - msys2-conda-epoch ==20160418
+  license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  size: 219240
+  timestamp: 1608163481341
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+  sha256: 7e3cd95f554660de45f8323fca359e904e8d203efaf07a4d311e46d611481ed1
+  md5: 53a1c73e1e3d185516d7e3af177596d9
+  depends:
+  - msys2-conda-epoch ==20160418
+  license: LGPL3
+  size: 743501
+  timestamp: 1608163782057
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+  sha256: f63a09b2cae7defae0480f1740015d6235f1861afa6fe2e2d3e10bd0d1314ee0
+  md5: 774130a326dee16f1ceb05cc687ee4f0
+  depends:
+  - msys2-conda-epoch ==20160418
+  license: MIT, BSD
+  size: 31928
+  timestamp: 1608166099896
+- conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.5-py311ha68e1ae_0.conda
+  sha256: c629f79fe78b5df7f08daa6b7f125f7a67f789bf734949c6d68aa063d7296208
+  md5: 07da1326e2837e055ef6f44ef3334b0a
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30011
+  timestamp: 1706900632904
+- conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.1-py311h8f1b1e4_0.conda
+  sha256: c4c2e1448ecfe4a9df4541f2c7aefa8763bc5ed8076aaef60625063de82a81f6
+  md5: b8ddf387d6506d6840a4c3d34c5f1b4b
+  depends:
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 7945306
+  timestamp: 1720649281635
+- conda: https://conda.anaconda.org/conda-forge/win-64/minizip-4.0.6-hb638d1e_0.conda
+  sha256: b334446aa40fe368ea816f5ee47145aea4408812a5a8d016db51923d7c465835
+  md5: 43e2b972e258a25a1e01790ad0e3287a
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 85324
+  timestamp: 1717296997985
+- conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.1.0-h66d3029_692.conda
+  sha256: abfdb5eb3a17af59a827ea49fcb4d2bf18e70b62498bf3720351962e636cb5b7
+  md5: b43ec7ed045323edeff31e348eea8652
+  depends:
+  - intel-openmp 2024.*
+  - tbb 2021.*
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 109491063
+  timestamp: 1712153746272
+- conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.0.8-py311h3257749_0.conda
+  sha256: 5917104a6e00f51a28fd217709818d1b765eef3de898601e23b2fb364d824186
+  md5: 25ab436993969840e7c521197c044300
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 89483
+  timestamp: 1715671288024
+- conda: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+  sha256: 99358d58d778abee4dca82ad29fb58058571f19b0f86138363c260049d4ac7f1
+  md5: b0309b72560df66f71a9d5e34a5efdfa
+  size: 3227
+  timestamp: 1608166968312
+- conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.0.5-py311ha68e1ae_0.conda
+  sha256: 2c293ae0eea6a117f307ac19cc2f3a8ffa0489f91e836bc5e573112e8e24915a
+  md5: 524a0b4313bfc6986a9ab28d5aed5d1e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 56996
+  timestamp: 1707041405260
+- conda: https://conda.anaconda.org/conda-forge/win-64/netcdf4-1.7.1-nompi_py311hbdc12eb_101.conda
+  sha256: ea9a820b60a21b07edc2ed6e7f1b89377d293ed25b13eaf915b9262449465437
+  md5: 5befdc14ec7dcbd30640682812e899d6
+  depends:
+  - certifi
+  - cftime
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1003846
+  timestamp: 1718724836540
+- conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.60.0-py311h0673bce_0.conda
+  sha256: b3359607051ec34c3eeb90447ece326822b6883882cf0e425cb1108dbcaebdc9
+  md5: 5d6eb2107dd921d651e46d059a82ab95
+  depends:
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - cudatoolkit >=11.2
+  - libopenblas !=0.3.6
+  - cuda-version >=11.2
+  - tbb >=2021.6.0
+  - scipy >=1.0
+  - cuda-python >=11.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5807308
+  timestamp: 1718888792863
+- conda: https://conda.anaconda.org/conda-forge/win-64/numcodecs-0.12.1-py311hda3d55a_1.conda
+  sha256: 95dca18d0e9339f8a8f5e061e470bfb9074c4f8d1fff9ebe0ccb5ff4489f80f9
+  md5: 1ef4d26104201076053465f1346d0915
+  depends:
+  - msgpack-python
+  - numpy >=1.7
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 486207
+  timestamp: 1715219518168
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.0.0-py311h35ffc71_0.conda
+  sha256: 5906dfbddd7ce315ceaebf56140e00ec12f981e9ccebdfe52a31826a9adf12f2
+  md5: 21ec404be139a6b20fde4f73c6ec484c
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7584309
+  timestamp: 1718616050139
+- conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
+  sha256: dda71cbe094234ab208f3552dec1f4ca6f2e614175d010808d6cb66ecf0bc753
+  md5: 7e7099ad94ac3b599808950cec30ad4e
+  depends:
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 237974
+  timestamp: 1709159764160
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.1-h2466b09_1.conda
+  sha256: e45ee071d45fcfaa59beb31def800cdb9d81b17bbb74c4a7e400102cb22ca35e
+  md5: aa36aca82d1ffd26bee88ac7dc9e1ee3
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 8355633
+  timestamp: 1719366975403
+- conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.1-h7e885a9_1.conda
+  sha256: 8aca1dcb6e9b3e71ffbec26c2b84f45fa682d9075b78cd30acc48044b64149ec
+  md5: 97012c0aeee0bf55c05b5ec42cac0864
+  depends:
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 925642
+  timestamp: 1716789911582
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.2-py311hcf9f919_1.conda
+  sha256: 351b4f7211fc755ea1af8b218d2515418df3af08170197011934faf06bb5d98e
+  md5: ec3ed8d602148625469dc13c481f23b5
+  depends:
+  - numpy >=1.22.4,<3
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14600290
+  timestamp: 1715898888392
+- conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_0.conda
+  sha256: 44351611091ed72c4682ad23e53d7874334757298ff0ebb2acd769359ae82ab3
+  md5: 007d07ab5027e0bf49f6fa660a9f89a0
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 816867
+  timestamp: 1718466930248
+- conda: https://conda.anaconda.org/conda-forge/win-64/pillow-10.4.0-py311h5592be9_0.conda
+  sha256: 6c29b557ee62bdd0e387b2fd62bee51e0c2486e5d9c32015ecca8bb9a901b2ce
+  md5: f6c7ffe64dfb84c7081ea09747ec0450
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.16,<2.0.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: HPND
+  size: 42332084
+  timestamp: 1719904289800
+- conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
+  sha256: 51de4d7fb41597b06d60f1b82e269dafcb55e994e08fdcca8e4d6f7d42bedd07
+  md5: b98135614135d5f458b75ab9ebb9558c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 461854
+  timestamp: 1709239971654
+- conda: https://conda.anaconda.org/conda-forge/win-64/poppler-24.07.0-h686f694_0.conda
+  sha256: c22de4784acad150c56c0064ba383abd80b097eeb0c192461efec8e572599a2c
+  md5: 4e21d8257375ae401877013416ebc12b
+  depends:
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libglib >=2.80.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - poppler-data
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 2374174
+  timestamp: 1720374177748
+- conda: https://conda.anaconda.org/conda-forge/win-64/postgresql-16.3-h7f155c9_0.conda
+  sha256: 7cd34a8803a3687f6fbed5908dd9b2ecb0ff923a1ac7c4d602d0f06a5804edbd
+  md5: a253c97c94a2c2886e1cb79e34a5b641
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libpq 16.3 hab9416b_0
+  - libxml2 >=2.12.6,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.3.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PostgreSQL
+  size: 18697452
+  timestamp: 1715267263356
+- conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.4.1-hd9569ee_0.conda
+  sha256: 6ebc0dc14e3057c859c09702149ddc0d301cbfb0e1c7553b617b194e0b0cabfb
+  md5: 123d005359753b6f1f7cae5dab367826
+  depends:
+  - libcurl >=8.8.0,<9.0a0
+  - libsqlite >=3.46.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2700952
+  timestamp: 1718273646988
+- conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.0.0-py311he736701_0.conda
+  sha256: 9a9900e87f48a04ea597a987105dd978f4d62312f334f2a0f58f3a749b42e226
+  md5: 325e47d267a6db408c1d61bde22c2d9c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 527926
+  timestamp: 1719275196844
+- conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-hcd874cb_1001.tar.bz2
+  sha256: bb5a6ddf1a609a63addd6d7b488b0f58d05092ea84e9203283409bff539e202a
+  md5: a1f820480193ea83582b13249a7e7bd9
+  depends:
+  - m2w64-gcc-libs
+  license: MIT
+  license_family: MIT
+  size: 6417
+  timestamp: 1606147814351
+- conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
+  sha256: 576a228630a72f25d255a5e345e5f10878e153221a96560f2498040cd6f54005
+  md5: e2da8758d7d51ff6aa78a14dfb9dbed4
+  depends:
+  - vc 14.*
+  license: LGPL 2
+  size: 144301
+  timestamp: 1537755684331
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-16.1.0-py311h06a5be4_4.conda
+  sha256: 4056152beb601a18f48fdf95897fbdd15d67719936f08dcdf7ec2a049d0c298c
+  md5: 2563e5b5e7f13e3c8b30c249bc8f6729
+  depends:
+  - libarrow-acero 16.1.0.*
+  - libarrow-dataset 16.1.0.*
+  - libarrow-substrait 16.1.0.*
+  - libparquet 16.1.0.*
+  - numpy >=1.19,<3
+  - pyarrow-core 16.1.0 *_4_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 28790
+  timestamp: 1719452033245
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-16.1.0-py311hf9a78b3_4_cpu.conda
+  sha256: a479b9bec9114339c7572d4f2aa33f5fa94409bce63301b36b0c478b7d6afc89
+  md5: e55e213574bc88ee83efb3edf1e41f38
+  depends:
+  - libarrow 16.1.0.* *cpu
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - orc >=2.0.1
+  - apache-arrow-proc =*=cpu
+  - aws-crt-cpp >=0.26.12
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3404211
+  timestamp: 1719451135030
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.9.0-py311h2494c99_0.conda
+  sha256: 4d404d0d0a6fd384a2c94ad3eeee8d30d47b44ff1a3baf9fa254c75ec647864c
+  md5: 5749157f37ded7ae4639f35dbb4de3a7
+  depends:
+  - gdal
+  - libgdal >=3.9.0,<3.10.0a0
+  - numpy
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 902559
+  timestamp: 1718696645786
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.6.1-py311h93f6e28_7.conda
+  sha256: 018b84fdecf2ee3d9613f4ae70d5f54a784431a685601066e7e6224b7d49e738
+  md5: 6cd57e74500464383dc5cf0947a4c159
+  depends:
+  - certifi
+  - proj >=9.4.0,<9.5.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 747836
+  timestamp: 1717793027916
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.9-h631f459_0_cpython.conda
+  sha256: 23698d4eb24970f74911d120204318d48384fabbb25e1e57773ad74fcd38fb12
+  md5: d7ed1e7c4e2dcdfd4599bd42c0613e6c
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.45.3,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.2.1,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 18232422
+  timestamp: 1713551717924
+- conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-4_cp311.conda
+  sha256: 67c2aade3e2160642eec0742384e766b20c766055e3d99335681e3e05d88ed7b
+  md5: 70513332c71b56eace4ee6441e66c012
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6755
+  timestamp: 1695147711935
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-306-py311h12c1d0e_2.conda
+  sha256: 79d942817bdaf384602113e5fcb9158dc45cae4044bed308918a5db97f141fdb
+  md5: 25df0fc55722ea1a94494f41302e2d1c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 6124285
+  timestamp: 1695974706892
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.13-py311h12c1d0e_0.conda
+  sha256: 07ee90dfcc15982f282ddf82cf4bbbcf0c9ecfabb51daad9341022a7405fb4c8
+  md5: 8cec3af6f3eed98cc6edf8f7fb26a7d4
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 212234
+  timestamp: 1708995766138
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.1-py311ha68e1ae_1.conda
+  sha256: 4fb0770fc70381a8ab3ced33413ad9dc5e82d4c535b593edd580113ce8760298
+  md5: 2b4128962cd665153e946f2a88667a3b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 175469
+  timestamp: 1695374086205
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.0.3-py311h484c95c_0.conda
+  sha256: 9c5c301d6bbb041d8728dfde015be7bc3ca5159b8193013581c5aa2de7bb9e89
+  md5: f32e37cabb3bc68396d2bc7939ac333c
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 453691
+  timestamp: 1715025354726
+- conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+  sha256: 887d53486a37bd870da62b8fa2ebe3993f912ad04bd755e7ed7c47ced97cbaa8
+  md5: 854fbdff64b572b5c0b470f334d34c11
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LicenseRef-Qhull
+  size: 1377020
+  timestamp: 1720814433486
+- conda: https://conda.anaconda.org/conda-forge/win-64/rasterio-1.3.10-py311hb019220_4.conda
+  sha256: 0cdcab881baba2c3ace0d3a6c62fad2454ee66f0e8fd22b6ccfbcea43f9ef134
+  md5: afda2244b08b75a76464d23fa56319a6
+  depends:
+  - affine
+  - attrs
+  - certifi
+  - click >=4
+  - click-plugins
+  - cligj >=0.5
+  - libgdal >=3.9.0,<3.10.0a0
+  - numpy >=1.19,<3
+  - proj >=9.4.0,<9.5.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7171348
+  timestamp: 1717806970067
+- conda: https://conda.anaconda.org/conda-forge/win-64/re2-2023.09.01-hd3b24a8_2.conda
+  sha256: 929744a982215ea19f6f9a9d00c782969cd690bfddeeb650a39df1536af577fe
+  md5: ffeb985810bc7d103662e1465c758847
+  depends:
+  - libre2-11 2023.09.01 hf8d8778_2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 207315
+  timestamp: 1708947529390
+- conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.19.0-py311h533ab2d_0.conda
+  sha256: 414afb9b15b8e3dc78445730e9e710470990b2b3a8ddd62a9874a9dbd9a80b07
+  md5: a596b3c3f1ba36b3668765b79cbf7e81
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 205907
+  timestamp: 1720477189899
+- conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.5.1-py311hdcb8d17_0.conda
+  sha256: 8bc7ca0c72326f49c1dba67ab2863839a16b095eb8a5726779c0b44288e46e55
+  md5: b31a7361a5b0560c48f7451e666cb11d
+  depends:
+  - joblib >=1.2.0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scipy
+  - threadpoolctl >=3.1.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9490152
+  timestamp: 1719999020340
+- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.0-py311hd4686c6_1.conda
+  sha256: 60f67658fe153e37da2bda1847eb8b5142d4ff721308f5bf80e4548fa2425b0f
+  md5: 46e7cf04c2a67603ff58a2d9b8ca128a
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy >=1.23.5,<2.3
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16062838
+  timestamp: 1720324583000
+- conda: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.5-py311hf837ac7_0.conda
+  sha256: 5f3b37beee2f06a5ea2c7f4c472a2d390a3a589329f63c43582b140ff0503680
+  md5: 39beb8aa55c1e4f2d665e8d05cf5f118
+  depends:
+  - geos >=3.12.2,<3.12.3.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 547401
+  timestamp: 1720886589061
+- conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
+  sha256: 5b9450f619aabcfbf3d284a272964250b2e1971ab0f7a7ef9143dda0ecc537b8
+  md5: 7635a408509e20dcfc7653ca305ad799
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59350
+  timestamp: 1720004197144
+- conda: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.13.0-h64d2f7d_0.conda
+  sha256: 7c5c8d6e2df300f7887e5488a21b11d854ffbc51a1b149af4164d6cbd225fd7a
+  md5: e21d3d1aef3973f78ee161bb053c5922
+  depends:
+  - fmt >=10.2.1,<11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 161230
+  timestamp: 1713902489730
+- conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.46.0-h2466b09_0.conda
+  sha256: 204edea00bb813d1e3da31dcd8caf1cb355ded08be3065ca53dea066bf75b827
+  md5: f60e557d64002fe9955b929226adf81d
+  depends:
+  - libsqlite 3.46.0 h2466b09_0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 885699
+  timestamp: 1718051144579
+- conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.12.0-hc790b64_3.conda
+  sha256: 721a88d702e31efd9437d387774ef9157846743e66648f5f863b29ae322e8479
+  md5: a16e2a639e87c554abee5192ce6ee308
+  depends:
+  - libhwloc >=2.11.1,<2.11.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 161213
+  timestamp: 1720768916898
+- conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.24.2-h297c385_2.conda
+  sha256: 58dea3bd8e8f56870e5b05dc096b467ed60229085af562ac7e64c0a18fa2c7fc
+  md5: b789d377848e690e72cdacc3f17db8d2
+  depends:
+  - aws-crt-cpp >=0.27.3,<0.27.4.0a0
+  - aws-sdk-cpp >=1.11.329,<1.11.330.0a0
+  - azure-core-cpp >=1.12.0,<1.12.1.0a0
+  - azure-identity-cpp >=1.8.0,<1.8.1.0a0
+  - azure-storage-blobs-cpp >=12.11.0,<12.11.1.0a0
+  - azure-storage-common-cpp >=12.6.0,<12.6.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - fmt >=10.2.1,<11.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libgoogle-cloud >=2.26.0,<2.27.0a0
+  - libgoogle-cloud-storage >=2.26.0,<2.27.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.3.1,<4.0a0
+  - spdlog >=1.13.0,<1.14.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.40.33810
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 3123009
+  timestamp: 1720848265809
+- conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+  sha256: 2c4e914f521ccb2718946645108c9bd3fc3216ba69aea20c2c3cedbd8db32bb1
+  md5: fc048363eb8f03cd1737600a5d08aafe
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: TCL
+  license_family: BSD
+  size: 3503410
+  timestamp: 1699202577803
+- conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.1-py311he736701_0.conda
+  sha256: 6efb2b0eaf5063c76288d1bf1a55488e9035d86bd63380de5ed4990499ca6859
+  md5: d6b9b155b10baf4ee79602a0e6b8265f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 860084
+  timestamp: 1717723311673
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+  sha256: f29cdaf8712008f6b419b8b1a403923b00ab2504bfe0fb2ba8eb60e72d4f14c6
+  md5: 72608f6cd3e5898229c3ea16deb1ac43
+  constrains:
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-Proprietary
+  license_family: PROPRIETARY
+  size: 1283972
+  timestamp: 1666630199266
+- conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
+  sha256: ed0eed8ed0343d29cdbfaeb1bfd141f090af696547d69f91c18f46350299f00d
+  md5: 28b4cf9065681f43cc567410edf8243d
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49181
+  timestamp: 1715010467661
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h8a93ad2_20.conda
+  sha256: 23ac5feb15a9adf3ab2b8c4dcd63650f8b7ae860c5ceb073e49cf71d203eddef
+  md5: 8558f367e1d7700554f7cdb823c46faf
+  depends:
+  - vc14_runtime >=14.40.33810
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17391
+  timestamp: 1717709040616
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-ha82c5b3_20.conda
+  sha256: af3cfa347e3d7c1277e9b964b0849a9a9f095bff61836cb3c3a89862fbc32e17
+  md5: e39cc4c34c53654ec939558993d9dc5b
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.40.33810.* *_20
+  license: LicenseRef-ProprietaryMicrosoft
+  license_family: Proprietary
+  size: 751934
+  timestamp: 1717709031266
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_20.conda
+  sha256: 0c2803f7a788c51f28235a7228dc2ab3f107b4b16ab0845a3e595c8c51e50a7a
+  md5: c21f1b4a3a30bbc3ef35a50957578e0e
+  depends:
+  - vc14_runtime >=14.40.33810
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17395
+  timestamp: 1717709043353
+- conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: 9df10c5b607dd30e05ba08cbd940009305c75db242476f4e845ea06008b0a283
+  md5: 1cee351bf20b830d991dbe0bc8cd7dfe
+  license: MIT
+  license_family: MIT
+  size: 1176306
+- conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.2.5-he0c23c2_1.conda
+  sha256: d90517c4ea257096a021ccb42742607e9ee034492aba697db1095321a871a638
+  md5: 0a0d85bb98ea8ffb9948afe5bcbd63f7
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 3547000
+  timestamp: 1721032032254
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-hcd874cb_0.conda
+  sha256: 8c5b976e3b36001bdefdb41fb70415f9c07eff631f1f0155f3225a7649320e77
+  md5: c46ba8712093cb0114404ae8a7582e1a
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  license: MIT
+  license_family: MIT
+  size: 51297
+  timestamp: 1684638355740
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.3-hcd874cb_0.tar.bz2
+  sha256: f51205d33c07d744ec177243e5d9b874002910c731954f2c8da82459be462b93
+  md5: 46878ebb6b9cbd8afcf8088d7ef00ece
+  depends:
+  - m2w64-gcc-libs
+  license: MIT
+  license_family: MIT
+  size: 67908
+  timestamp: 1610072296570
+- conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+  sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
+  md5: 515d77642eaa3639413c6b1bc3f94219
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: LGPL-2.1 and GPL-2.0
+  size: 217804
+  timestamp: 1660346976440
+- conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+  sha256: 4e2246383003acbad9682c7c63178e2e715ad0eb84f03a8df1fbfba455dfedc5
+  md5: adbfb9f45d1004a26763652246a33764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 63274
+  timestamp: 1641347623319
+- conda: https://conda.anaconda.org/conda-forge/win-64/yarl-1.9.4-py311ha68e1ae_0.conda
+  sha256: 647a7f6395be44b82a3dd4ad58d02fd1ce56cca19083061cbb118f788c0f31e5
+  md5: 522f873d68d2557056d6cfed8335fe96
+  depends:
+  - idna >=2.0
+  - multidict >=4.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 113426
+  timestamp: 1705509198913
+- conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-he1f189c_4.conda
+  sha256: 0f375034a88659f764ce837f324698a883da227fcb517561ffaf6a89474211b4
+  md5: b755eb545c2728b9a53729f02e627834
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 2707065
+  timestamp: 1715607874610
+- conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_1.conda
+  sha256: 76409556e6c7cb91991cd94d7fc853c9272c2872bd7e3573ff35eb33d6fca5be
+  md5: f8e0a35bf6df768ad87ed7bbbc36ab04
+  depends:
+  - libzlib 1.3.1 h2466b09_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Zlib
+  license_family: Other
+  size: 108081
+  timestamp: 1716874767420
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py311h53056dc_0.conda
+  sha256: 3bd0e287215152d6e3a17090c015368b7632f907cecfb363e7a3391f8ee04f8e
+  md5: a2663051856bfd6ac673a93a0baa7aba
+  depends:
+  - cffi >=1.11
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 322403
+  timestamp: 1721044645946
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+  sha256: 768e30dc513568491818fb068ee867c57c514b553915536da09e5d10b4ebf3c3
+  md5: 9a17230f95733c04dc40a2b1e5491d74
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 349143
+  timestamp: 1714723445995

--- a/heat_and_trees/pixi.lock
+++ b/heat_and_trees/pixi.lock
@@ -8,7 +8,6 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
-    - url: https://conda.anaconda.org/nodefaults/
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2

--- a/heat_and_trees/pixi.toml
+++ b/heat_and_trees/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "heat_and_trees"
-channels = ["conda-forge", "nodefaults"]
+channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/heat_and_trees/pixi.toml
+++ b/heat_and_trees/pixi.toml
@@ -29,8 +29,8 @@ pyarrow = ">=16.1.0"
 rasterio = ">=1.2.10"
 rioxarray = ">=0.15.0"
 xarray = ">=2024.5.0"
-pip = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [activation.env]
 INTAKE_CACHE_DIR = "data"

--- a/heat_and_trees/pixi.toml
+++ b/heat_and_trees/pixi.toml
@@ -1,0 +1,39 @@
+[workspace]
+name = "heat_and_trees"
+channels = ["conda-forge", "nodefaults"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2018-10-01"
+maintainers = ["jsignell"]
+categories = ["Geospatial", "Featured"]
+labels = ["hvplot", "geoviews", "datashader", "bokeh", "dask", "geopandas", "xarray"]
+description = "Analysis of how trees affect heat distribution in urban areas. Based on\n`a blog post <https://urbanspatialanalysis.com/urban-heat-islands-street-trees-in-philadelphia/>`_\nby Ken Steif.\n"
+
+[dependencies]
+python = "3.11.*"
+notebook = "<7"
+bokeh = ">=3.4.1"
+cartopy = ">=0.23.0"
+colorcet = ">=3.1.0"
+datashader = ">=0.16.1"
+geopandas = ">=0.14.4"
+geoviews = ">=1.12.0"
+hvplot = ">=0.10.0"
+intake = "<2"
+aiohttp = ">=3.9.5"
+intake-xarray = ">=0.7.0"
+numpy = ">=1.26.4"
+pandas = ">=2.2.2"
+pyarrow = ">=16.1.0"
+rasterio = ">=1.2.10"
+rioxarray = ">=0.15.0"
+xarray = ">=2024.5.0"
+pip = "*"
+wheel = "*"
+
+[activation.env]
+INTAKE_CACHE_DIR = "data"
+
+[tasks]
+notebook = "jupyter notebook heat_and_trees.ipynb"

--- a/hipster_dynamics/pixi.lock
+++ b/hipster_dynamics/pixi.lock
@@ -1,0 +1,7122 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.0-h8213a91_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.0-h28cd5cc_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.9.2-py39h2531618_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-5.9.7-h5867ecd_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-4.19.13-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.8.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.8.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.17.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.8.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+  sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
+  md5: 2cf39d906cc321896ffe3e5d33d80c5c
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162166
+  timestamp: 1644463608931
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+  sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
+  md5: 2972a84e0e22ae3244bbd2f1eebcf536
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 35352
+  timestamp: 1644569715988
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+  sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
+  md5: a68016b4b06460def24cb69d932986f3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132486
+  timestamp: 1695717963702
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+  sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
+  md5: 2f6356a2f530314b4059c08c79a3d8bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 205868
+  timestamp: 1681493113570
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+  sha256: 2d8e75f31f75ea5eb8b9021b4c21eb2846a254a097e06eb68e66fc36a82e1bed
+  md5: ae374a11c789a55555f70b29b9eff1f9
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3,<2.0a0
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14430294
+  timestamp: 1658136783940
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+  sha256: f84f9caa7eb9d489fd9634419fdf766d39293a5df1104b840fa0cdc5823a5c60
+  md5: 922555c0435d6b2537cf8ced534b048c
+  depends:
+  - libgcc-ng >=7.5.0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 141903
+  timestamp: 1648028958291
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+  sha256: 0bbcb6f78eac530c6a084459ffab3238647b266d0c74d695e6e6387dd119cc67
+  md5: bdc971e2a9affb5125b68ad708172dab
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 411301
+  timestamp: 1602517685375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+  sha256: 8c2071f706c2b445dabb781f7f8f008b23a29957468ec6894f050bfb3a2d5bf4
+  md5: c203ffc7bbba991c7089d4b383cfd92c
+  depends:
+  - cffi >=1.0.0
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 357797
+  timestamp: 1605539534667
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+  sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
+  md5: 3ef00f4c5278b688552efc259c463dc8
+  license: MPL-2.0
+  license_family: Other
+  size: 132731
+  timestamp: 1694009767372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+  sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
+  md5: d5cb3d97cf5e85ffe5e94037ed8a1169
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159077
+  timestamp: 1690232254640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+  sha256: 674707b9c42e65c903c9786ee5a56b4d42aa054f1e75b328db8a2c1bfa368739
+  md5: 76ae217198b014b89b267cf41b8251dd
+  depends:
+  - libffi >=3.3
+  - libgcc-ng >=7.5.0
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 231920
+  timestamp: 1642701209740
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+  sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
+  md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1917831
+  timestamp: 1668084545510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+  sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
+  md5: 13702d3b4b744784e5bd559c7050dd6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12719
+  timestamp: 1671231205875
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+  sha256: 821af57c20a85b4e92268fbf65fbaec2f273da5bb21889d9643756ef6e473237
+  md5: f57e0f502500ffebdbec081ef61ad1d4
+  depends:
+  - cffi >=1.12
+  - libgcc-ng
+  - openssl >=1.1.1v,<1.1.2a
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 2179774
+  timestamp: 1694445209134
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+  sha256: 469debfa966d24b8372aaf909ecbe27dc6fde186f6f0d5b9e0a8427e38053364
+  md5: 498d0788982ec4c5d13a44359b9c7afb
+  depends:
+  - expat >=2.2.10,<3.0a0
+  - glib
+  - libgcc-ng >=7.3.0
+  license: GPL2
+  size: 600218
+  timestamp: 1602701107852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+  sha256: 3a39a2d6f161080c706292e3bf480f62d2444b1d6d67b3d7db50458202ee31f1
+  md5: 0524ffca60f845eb392bbb56d56f0ce5
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2094615
+  timestamp: 1637091869922
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+  sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
+  md5: 2e6ec51066d825ef3c317abe78d6049e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16413
+  timestamp: 1649926472708
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+  sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
+  md5: b4d923222d45314856b5378cb115214d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26728
+  timestamp: 1668714462023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
+  sha256: 27cde2cf0b1e10c2315bc1384fcb56537b424f6c2c872ca4662bc971e41910da
+  md5: c12e8c75f3c7c4f5867827c5dc02dc2c
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: MIT
+  license_family: MIT
+  size: 216001
+  timestamp: 1644418571578
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
+  sha256: f80526def98864c9560dd3f6754d1c905edc001d18279f6e169913ee8f26a6a2
+  md5: e2fda4383ff9a690a6ac174553e10414
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - libgcc-ng >=7.3.0
+  - libuuid >=1.0.3,<2.0a0
+  - libxml2 >=2.9.10,<2.10.0a0
+  license: MIT
+  size: 306671
+  timestamp: 1612452969808
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+  sha256: 8a121233d0b2cbb2463b67e798739ad2946f38933430a6a7fd1197cc6eab1c99
+  md5: d2b24736491290a6c6d0138932111150
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: GPL-2.0-only and LicenseRef-FreeType
+  size: 965280
+  timestamp: 1635422707211
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+  sha256: 3c8ece1a7257b1d45f8fa25f46504bb709a1923d7175f2996e891366ec434b9d
+  md5: 299bf4271d710651a1d71d3795580c2d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 83592
+  timestamp: 1603192039050
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
+  sha256: bb98f022743e5df14d73db0edae49eb95a11abcc41c973fe2f30c3810bc5021e
+  md5: 858d4f13f1b0e54ee8cc3dd7c67cf0de
+  depends:
+  - libffi >=3.3
+  - libffi >=3.3,<3.4.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - pcre >=8.45,<9.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 2021087
+  timestamp: 1642701448286
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.0-h8213a91_2.tar.bz2
+  sha256: c85c664066c685b606df768d23eac08e1b824e391eb59f61a9ef608f4f46c5b6
+  md5: df2e0695e2edbd91b719da5b15249c5a
+  depends:
+  - glib >=2.66.1,<3.0a0
+  - gstreamer >=1.14.0,<2.0a0
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - libxcb >=1.14,<2.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  size: 6651032
+  timestamp: 1609866747525
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.0-h28cd5cc_2.tar.bz2
+  sha256: dc1af8ae3b38b8d81c00b54dac851618dba87ea8d4083af84dcb60c3070039ad
+  md5: 83453eb716b94c66fb64391760c0eeb1
+  depends:
+  - glib >=2.66.1,<3.0a0
+  - libgcc-ng >=7.3.0
+  size: 4178090
+  timestamp: 1609866593800
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+  sha256: 2d727f8335c59314b521b66d437ca4d51904134473ae503b7b097e239635f209
+  md5: 6991e520f353d995023404f6f524d192
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4507274
+  timestamp: 1693378095165
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+  sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
+  md5: 9213e0336e3a5216c989cfe52648412e
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 23805906
+  timestamp: 1588026213084
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+  sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
+  md5: 1eb52f9f45cea2fb9ce27b19f990160e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110793
+  timestamp: 1666125606878
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+  sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
+  md5: 126b3c1933b7364ff03f67455b687e99
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 37588
+  timestamp: 1678997134023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+  sha256: 1b424413f28b840fc6d4bf467f37e9e405823b1e3b899005df80152d48936d64
+  md5: 4aa8bcf74c81cd3600978f791191692a
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 9246735
+  timestamp: 1634546760713
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+  sha256: b51b2e0dd37a74784ba19db22aded3f4c843b6fddb4a74399f65f36fc018aaa2
+  md5: 0d56ab1950f952284b895ac0f78284a7
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.0
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203541
+  timestamp: 1671488675347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+  sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
+  md5: ff47e0be879e817713ce2a9daa76e2b0
+  depends:
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1261116
+  timestamp: 1694181530670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+  sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
+  md5: 5ef6c6a0d1ac79143c7359d305155167
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1021637
+  timestamp: 1644297140650
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+  sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
+  md5: eaeb023688f781e7dd89e74310c38195
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 211775
+  timestamp: 1666908212136
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+  sha256: 85348bfb14db4fea84078d703e766a3c978c5a592a06e41266748826dd59d8ae
+  md5: 6e1c0fb5260c590f7ef5235cb3d05863
+  depends:
+  - libgcc-ng >=7.5.0
+  license: IJG
+  license_family: Other
+  size: 279884
+  timestamp: 1651065953960
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+  sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
+  md5: 0d2c3c5edf671b575532d5a3e8bf15fc
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 131510
+  timestamp: 1676558716852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+  sha256: 92bc012f9eb4ad71158cf4826fd3e125fcebff53b529276a81224acda48be547
+  md5: c5fd100e3062e831cbdf33331042f627
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=22.3
+  - tornado >=6.0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 190884
+  timestamp: 1650622553813
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+  sha256: 0192bd48cd96c60dc3054d5addd8cdb4a29a218843181318371f79daec8242f8
+  md5: d851b401dc13d04e6848bb36e12efc1c
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 91534
+  timestamp: 1679906652183
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+  sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
+  md5: a4beb461f0a60998a090d760b5c6c907
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411564
+  timestamp: 1671707702849
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+  sha256: 974df3dc76089be57b327acd6634384def84249003f58678ca1142bb274a75d9
+  md5: 81b969d1a00153759b30554a1f11ddfd
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92144
+  timestamp: 1653292217019
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+  sha256: 3b4afe7665dcdb99bd4586a888b85b2e0325f8faecdd31c7780792080ee97872
+  md5: 822b5201dde61bc838072dc5b670c88c
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: Custom
+  size: 55183
+  timestamp: 1594054267890
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+  sha256: c6fafbe73d2f93b91b6f4b65829f925f52a8f84746a57abd216b39da9ce8c494
+  md5: 238f19c803a6ba7bd6dbd6989e03cbf1
+  depends:
+  - _libgcc_mutex * main
+  license: GPL
+  size: 8496776
+  timestamp: 1560112207081
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+  sha256: bc3e6e79c32ff0ecea601aa108ae9cf4068f69703580e40e266ad4bcc52cff54
+  md5: 9cb85601944ca7383b1769bff74b94e8
+  depends:
+  - libgcc-ng >=7.3.0
+  - zlib >=1.2.11,<2.0.0a0
+  license: zlib/libpng
+  size: 372914
+  timestamp: 1556041895170
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+  sha256: 43b0bd205f539583c088feb5b8d77b60c83d1df80c2a93dac9f2a1127001b2cf
+  md5: 53fa39fdae936e9d07c4b2f5ef361993
+  license: GPL3 with runtime exception
+  size: 4246257
+  timestamp: 1560112223556
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+  sha256: 711ea05b4c35bdafc762a172b01db896b17942f474c2b1a519f91370964bf9bc
+  md5: b25d56d33596623a6a4a9d9baaa4f602
+  depends:
+  - jpeg >=9e,<10a
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libwebp-base
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  size: 592974
+  timestamp: 1653047881023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
+  sha256: 4e1dce80f23551a69761ad48b2372e35f58292ec9cc0ce061312330366a1a223
+  md5: fda36b99463bad87974196da2d5bed08
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD 3-Clause
+  size: 18725
+  timestamp: 1633507857274
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+  sha256: 146dbb1e4dbccdd57819e5102a8ca00970b8e33d6c6180e8007db89b184da569
+  md5: c566a384259c1d2769852c3bddd81a67
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9d,<10a
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 90150
+  timestamp: 1645441199289
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+  sha256: cffb5a063111f7a99a99c74770b23db5dde52325e25a7a46d1903d5ff4a82c88
+  md5: eeb1bd66f28bed1956ab989d6eff7ae5
+  depends:
+  - libgcc-ng >=7.5.0
+  constrains:
+  - libwebp 1.2.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 889956
+  timestamp: 1645089138421
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+  sha256: 5d68e69709ae10bd6c4b58b6af447ad2f2bd24955994f3ec77103d1a6bf5e1f5
+  md5: 49e523de8d364b7fabc3850eccbe9bda
+  depends:
+  - libgcc-ng >=7.5.0
+  size: 623492
+  timestamp: 1652448233146
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+  sha256: 71f6c4a97014d745c58df52b4dd60ddd75a8508d54fe5b97f42bd1f31cb1c067
+  md5: 686e77514ec9f1ef0a6feed374f14d37
+  depends:
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.5.0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 789469
+  timestamp: 1653546418059
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+  sha256: ea3355a67c5173f3944f09861043ca66eb7dbeff8f385d13528b3aabc0801d0c
+  md5: 66e2aa12181bb2911485bdbe125d24c5
+  depends:
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.5.0
+  - libxml2 >=2.9.14,<2.10.0a0
+  license: MIT
+  size: 584199
+  timestamp: 1654075843119
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+  sha256: 64b022d706b76c33965a250fdc8c6008443c41bff8ab27bb1df3cb70419576fd
+  md5: ec4f05846aacf634df15c389235725cc
+  depends:
+  - libgcc-ng >=7.5.0
+  - libxml2 >=2.9.12,<2.10.0a0
+  - libxslt >=1.1.28
+  - libxslt >=1.1.34,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  size: 1538261
+  timestamp: 1646624639995
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+  sha256: 2c6a5dda7c510a961bc78e31d4232be5e8e0760c93454f5fd200c379355e0f5e
+  md5: f35d4bf2fbb39e334992f6dd39f8721e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 220865
+  timestamp: 1627657046002
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+  sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
+  md5: 421f82c8274b44660dba629134faa6af
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 122221
+  timestamp: 1671541990505
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+  sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
+  md5: feb0e452205b44ac45d9b5e55c21a3b1
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22819
+  timestamp: 1654597913064
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.5.1-py39h06a4308_1.tar.bz2
+  sha256: 62fb0d06224e15528540718debebeaebbfdbd7f03106fad52a7002fb96c6b8bd
+  md5: 364c1e3dddefa27741e540496c38b694
+  depends:
+  - matplotlib-base >=3.5.1,<3.5.2.0a0
+  - pyqt
+  - python >=3.9,<3.10.0a0
+  - tornado
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 28294
+  timestamp: 1647442129989
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+  sha256: dc51b316ef5dcfb82a9c0afdc40879146ae59516f6cea7db776077783dfd2d76
+  md5: b0b6b57c140f026b8806051107336576
+  depends:
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.11.0,<3.0a0
+  - freetype >=2.3
+  - kiwisolver >=1.0.1
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - numpy >=1.19.2,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.2.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  - tk
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7729454
+  timestamp: 1647442028622
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+  sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
+  md5: c04ef34af33da4c71bcc99b7ec24d210
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16391
+  timestamp: 1662014553452
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+  sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
+  md5: f6c734d73e6e3dbc1b62766cf18ff3e4
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58153
+  timestamp: 1607364912263
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+  sha256: 7c4ded8b2ef036839f988560848d2c32e1aa4627fd37a32710e42c39f5c61ac2
+  md5: bd20f4410b81f327e35ffa0657961146
+  depends:
+  - intel-openmp 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 229783051
+  timestamp: 1634547157986
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+  sha256: 5394f5efd53afb2c1b0abf571ce3d9cb684b6c7e255f140ba2acaa703d6113be
+  md5: d3cb2bfa63e30153f5527797dcc87280
+  depends:
+  - libgcc-ng >=7.5.0
+  - mkl >=2021.2.0,<2022.0a0
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 63551
+  timestamp: 1626176932911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+  sha256: c244d23da2749857a993f84969fd35ffd183ab8f462986df6d33ae0f705fe034
+  md5: 9b1f8ccc2488d0e04eb73211e2987483
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.3.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  size: 204136
+  timestamp: 1634566416657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+  sha256: f81f426f8ef306d636664bc49e7cdd70e2b4306d7c6bcb9c75fe35a45ab2087a
+  md5: 77aa1d7f958d36bf227e6ff4a34d2e3d
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.2.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  size: 365386
+  timestamp: 1626186165897
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+  sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
+  md5: 95c83d71814c504b5504df4f14548f1a
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8257558
+  timestamp: 1681756322140
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+  sha256: 1b92d72b083f3350359b8fb2e3b5dc846f49650c9e46a6a74354b1b7f0d42730
+  md5: 996babe4314515ddd41008a53cb5d47f
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 98791
+  timestamp: 1650290544347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+  sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
+  md5: 1710a25086c8098367eb36b9d441448b
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 569683
+  timestamp: 1668450704669
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+  sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
+  md5: 385cc9e53404776782502c0fdb08820f
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147046
+  timestamp: 1694616899309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+  sha256: 0807371380965e421cb5f3f2a30d790fd5c41db11dbb6d318e14294c3b1741ed
+  md5: fca4bd4e3891aebf4fd7daf9b6d0ccfa
+  depends:
+  - libgcc-ng >=7.5.0
+  license: Free software (MIT-like)
+  size: 1083412
+  timestamp: 1636570020698
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+  sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
+  md5: bbbcbebc20a4fdcadce398d0ca04f95e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13109
+  timestamp: 1672387143252
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+  sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
+  md5: 248ce515640465371927d46f389ed555
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 594054
+  timestamp: 1690985006481
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+  sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
+  md5: 70db71df4ee1cdd38090c0f7b80ba61f
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21944
+  timestamp: 1668160644514
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+  sha256: 15a12c8bebcda45c577e61cea412d9aafaa433e39f9e91fd61bbfab66fcee3ab
+  md5: 5239d8330e8bd34972fb80918dce79e7
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16.6,<2.0a0
+  - packaging
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 136437
+  timestamp: 1640689905588
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+  sha256: ff8d0426c7096e086db818265c3edf4a820accbfb15afae0407ca578de151fa9
+  md5: d7bcf0b9ba2d85cf532059ec119d2750
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.22.3 py39hf524024_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  size: 9965
+  timestamp: 1652801901707
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+  sha256: abfdeda143b6b667d50a82ea119043fc1469ee02f094a41a2402433ff408099e
+  md5: e8dc29adc0282f4658e0e2f25ff207a2
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.22.3 py39he7a7128_0
+  license: BSD-3-Clause
+  size: 7095882
+  timestamp: 1652801886819
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+  sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
+  md5: 5ad4571eba2479f77a9f849a6ae7724c
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: OpenSSL
+  license_family: Apache
+  size: 3998613
+  timestamp: 1694465071784
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+  sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
+  md5: 77a22ed6d0d448c5288d0f695bc9ac49
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 72527
+  timestamp: 1693575234886
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+  sha256: e7a0abb0f00a94000876f2095f0cf531ad3803ffbd868a780b3f06816b54492c
+  md5: 97ef7e1fe923d22a8e2307f3f39a92d5
+  depends:
+  - bottleneck >=1.3.1
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - numexpr >=2.7.1
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13221005
+  timestamp: 1650622404234
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+  sha256: 49fdb57b2ed2ce4d6bb7a2c5adec36ba59522518a41fb941f9e39a9f43750cc5
+  md5: 871b65444733b7da5823ee0dc9826722
+  depends:
+  - bleach
+  - bokeh >=2.4.0,<2.5.0
+  - markdown
+  - param >=1.12.0,<2.0.0a0
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - setuptools >=42
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >1.14.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14712394
+  timestamp: 1676379803902
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+  sha256: 64a732ce2661cdb6bd8f9d1484ac10afeb73082b1c2b44728d212e0117d2860e
+  md5: ada303f0cf43a4e99cfa7f243b23b681
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141832
+  timestamp: 1684915385689
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
+  sha256: 4881cc5e0d5b20335bcfba4eaf29fdc95dedf2607903aabecdacffb64d3407d4
+  md5: 4bac8a874e62f41ebab8345ca6076eb6
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 263308
+  timestamp: 1624477853289
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+  sha256: 8bcb1c67693f42a3170eb77ef4cdbb81b605fdf40816953e69a33a065c101638
+  md5: b7689507fb5f879dc766aaa8a4c37351
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp >=0.3.0
+  - libwebp >=1.2.0,<1.3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk
+  - zlib >=1.2.11,<2.0.0a0
+  license: LicenseRef-PIL
+  license_family: Other
+  size: 734566
+  timestamp: 1646325095608
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+  sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
+  md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2674850
+  timestamp: 1697548887851
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+  sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
+  md5: fe56f0479dd414c846191116366262c3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 31999
+  timestamp: 1692205535111
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+  sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
+  md5: 44d2a857d13bdf9d99aaac039a249d47
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91137
+  timestamp: 1659455142164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+  sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
+  md5: eb899a739d9b58dd747f1f6bd52d4cf3
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 579771
+  timestamp: 1672387338600
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+  sha256: 6973cfe0565ba3b5ad6d1de9e34848fbbadd78b507b2e23e1c079636b8f8f317
+  md5: a924535045fb356e23e7a3cc8116b638
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 350026
+  timestamp: 1612298042840
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+  sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
+  md5: f36ecb722522cbe2e3737424edf1b5e1
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29312
+  timestamp: 1675441510984
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+  sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
+  md5: 6d03295e544251e608a28c8d7c48115e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1862058
+  timestamp: 1684280096752
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+  sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
+  md5: 1f09617aecd6f3c2f2e20692c0759f34
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94434
+  timestamp: 1690223520097
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+  sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
+  md5: ffceed627867508d73af1636ab5ebf42
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 156324
+  timestamp: 1661452578573
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.9.2-py39h2531618_6.tar.bz2
+  sha256: c96502aca0df082c457f31d9e6202419aa86f24e1c699c3a34d02602f7a42812
+  md5: 3eda4bcc31b66fd5002817def97cd129
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  - qt 5.9.*
+  - qt >=5.9.7,<5.10.0a0
+  - sip 4.19.13.*
+  license: Commercial, GPL-2.0, GPL-3.0
+  license_family: GPL
+  size: 6010734
+  timestamp: 1607697278482
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+  sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
+  md5: 0e3341a4fe434167bf74b613eb6afd81
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 97194
+  timestamp: 1636110999719
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+  sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
+  md5: c5f3f7f10ad30f0945e75252615ab6e5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31331
+  timestamp: 1605305847037
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+  sha256: c4b9e332a6f2b7524e8c88e2b39a2568a48e556fd9a44c30759c43611d4d023d
+  md5: bb118745c9b08fc5028f45e77f371e68
+  depends:
+  - ld_impl_linux-64
+  - libffi >=3.3,<3.4.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - ncurses >=6.3,<7.0a0
+  - openssl >=1.1.1o,<1.1.2a
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.38.3,<4.0a0
+  - tk >=8.6.11,<8.7.0a0
+  - tzdata
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 24553777
+  timestamp: 1654084160832
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+  sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
+  md5: 0caa188a695319bdb13f53b0a2b3accc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264864
+  timestamp: 1661371117920
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+  sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
+  md5: bcb44ecbea441ee0d4659133d060d71f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257904
+  timestamp: 1695131670290
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+  sha256: e937081facacb141dc2c9cdcced92baa9a2662e4a56100b6041df0b6b7692570
+  md5: f3ac39b2349258198a9b3316636fe5d5
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39972
+  timestamp: 1685030752528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+  sha256: 3da9cbbd49fac566433748bd245d09d7d5fcd28b04c0397cbbf6d5bb92f5c4a5
+  md5: df73a5d2f6e089d51e71e91935a82c65
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 183753
+  timestamp: 1635775763162
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+  sha256: 26005d191bb15070aad70707ed6493f32678a67978bd3b83d4c9679cab44e717
+  md5: 2dc75d5a4ccb64310939c3a72d34ae20
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-clause
+  license_family: BSD
+  size: 521583
+  timestamp: 1638435042256
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-5.9.7-h5867ecd_1.tar.bz2
+  sha256: 5881ffba2ab8ed28112e80dd3f17ced0832b75615b9f8aab6bf171575c812b88
+  md5: 50da300935a335f7605d3f96fa045111
+  depends:
+  - dbus >=1.13.2,<2.0a0
+  - expat >=2.2.6,<3.0a0
+  - fontconfig >=2.13.0,<3.0a0
+  - freetype >=2.9.1,<3.0a0
+  - glib >=2.56.2,<3.0a0
+  - gst-plugins-base >=1.14.0,<1.15.0a0
+  - gstreamer >=1.14.0,<1.15.0a0
+  - icu >=58.2,<59.0a0
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libpng >=1.6.35,<1.7.0a0
+  - libstdcxx-ng >=7.3.0
+  - libxcb >=1.13,<2.0a0
+  - libxml2 >=2.9.8,<2.10.0a0
+  - openssl 1.1.*
+  - sqlite >=3.25.3,<4.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: LGPL-3.0
+  size: 90037659
+  timestamp: 1544604609235
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+  sha256: 8c950c69bee969e2c66f88f0dc247b3ab75a753672a88009779d5f5dba193532
+  md5: 150ac0eb929bab9dec912797bdfc7b95
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 433182
+  timestamp: 1642022402894
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+  sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
+  md5: c7de00b4ac2778c4e5a7816320d75391
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94028
+  timestamp: 1690400356879
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+  sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
+  md5: 1581cafc84708ed9aafaaee1cbbf6065
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1089416
+  timestamp: 1690290900608
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-4.19.13-py39h295c915_0.tar.bz2
+  sha256: 9f2d68b41365097a380979014b3cabf5f1f9f07e5554eb215eef4801f640922e
+  md5: 3ec6ce8f2eae0969b341e5702fb029c6
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: GPL-3.0
+  size: 302624
+  timestamp: 1643114723175
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+  sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
+  md5: e19ffbfb24b990275d24fcea2bd1699b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15702
+  timestamp: 1614030498860
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+  sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
+  md5: ca061ce25c0f58628643abec8d6a8244
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 66330
+  timestamp: 1696347637947
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+  sha256: 87965b7b46d93866d31696a1045216d64f077a06b2900c356aba87e8559c6188
+  md5: fa334030245135b37027a882f3c468bf
+  depends:
+  - libgcc-ng >=7.5.0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: blessing
+  license_family: Other
+  size: 1561908
+  timestamp: 1655328608308
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+  sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
+  md5: 0e76eab58fe488e91f0aee73f46de031
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29816
+  timestamp: 1671751864131
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+  sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
+  md5: b413a210eca82fe867e991eed085201b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38882
+  timestamp: 1668168876032
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+  sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
+  md5: 5b8375e2092012db69d2123dc0c68630
+  depends:
+  - libgcc-ng >=7.5.0
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3485432
+  timestamp: 1654088939579
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+  sha256: b746e39272888b9cc1a2a711b7b8836f2e26f4457850e43ad18bf0765e21dc3d
+  md5: 200e86f8d53aeebf4b7dcfc944fd7920
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 661662
+  timestamp: 1606942359431
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+  sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
+  md5: 67a8320961ff24e92eebb661536e5cf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - requests
+  - slack-sdk
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 123763
+  timestamp: 1679561904852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+  sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
+  md5: 0f0b91a158dd3692cbb7a7763b657bfe
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192032
+  timestamp: 1671143995098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
+  md5: 8515e64a3de7581360d713fe4c0a094e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8789
+  timestamp: 1690297588156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
+  md5: 60170012374b2a5007842fa5870d78c5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57479
+  timestamp: 1690297581658
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+  sha256: 870f20a3c006a74b291910f69c3469a409bd21437142864b29cfafeb89ca7c34
+  md5: 1b2f1589e3ebc3e0c6ecb38dba93e4ae
+  depends:
+  - brotlipy >=0.6.0
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 186761
+  timestamp: 1686163186447
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+  sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
+  md5: f8d03a15b974fc7810d9f54ae849fc8e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20781
+  timestamp: 1607365390528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+  sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
+  md5: d7db5d6ce1db80eade8a082ff78bf479
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 71044
+  timestamp: 1614804011510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+  sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
+  md5: b3899f8bda32734727bd5a73df1d7d17
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 101520
+  timestamp: 1695742037911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+  sha256: 2ce360ff98c0ca4537d70c19266b5700810196c54ce2fbaff3b94a969846ee37
+  md5: 94cb94dc47405b24b1b5bd0a3275ab59
+  depends:
+  - libgcc-ng >=7.5.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 398058
+  timestamp: 1651602137803
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+  sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
+  md5: 567b68192c387b5fc88178425577a0fe
+  depends:
+  - libgcc-ng >=7.3.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=7.3.0
+  license: LGPL-3.0-or-later
+  size: 366479
+  timestamp: 1616055552392
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+  sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
+  md5: 3818a9531fe74433c3b7d5144c9a58cc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18021
+  timestamp: 1672387231268
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+  sha256: 513444d83ac2405e898531492ea59f3a95641e357cc39c1048d6fffc1791a16b
+  md5: 601d9449c280b9b145dc8c83b6f06119
+  depends:
+  - libgcc-ng >=7.5.0
+  license: Zlib
+  license_family: Other
+  size: 133595
+  timestamp: 1650637720646
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+  sha256: 1c049c23788a00b6f38bdc801245e0e60af98718d4db4c958658bcc67ff158c7
+  md5: b1737dfd2e06ad69ec5cfec341e207c6
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 827172
+  timestamp: 1650622223170
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
+  md5: b2aa5503875aba2f1d88cae9df9a96d5
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13636
+  timestamp: 1611930018941
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
+  md5: 544adf2677c47c9b9c891aea720678f1
+  depends:
+  - python >=3.5
+  license: MIT
+  size: 33999
+  timestamp: 1630003259346
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+  sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
+  md5: 9eff1a842dbda8d1bae9a2c008b599bc
+  depends:
+  - brotli >=1.0.1
+  - munkres
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 690443
+  timestamp: 1625743217109
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+  sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
+  md5: 33624a42ee387bf9918ea98b4e7b31fc
+  depends:
+  - pygments >=2.4.1,<3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8173
+  timestamp: 1601490751973
+- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+  sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
+  md5: 67857cc5e9044770d2b15f9d94a4521d
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12810
+  timestamp: 1600445183315
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+  sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
+  md5: e68a6f315f41a8d814d833652bf38b9b
+  depends:
+  - python >=3
+  license: MIT
+  size: 13374
+  timestamp: 1606932077143
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
+  md5: 2eb923cc014094f4acf7f849d67d73f8
+  depends:
+  - python
+  - six >=1.5
+  license: BSD-3-Clause and Apache
+  license_family: BSD
+  size: 246457
+  timestamp: 1626374695070
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
+  md5: 41db68b96e114e367c4f120a3b379e59
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19391
+  timestamp: 1632406728844
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+  sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
+  md5: a815d3bdb160bcc71687f2dda70d3ca4
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 122218
+  timestamp: 1680170368293
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
+  md5: 447a49f7bad119faa80d7f14aa296c95
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162176
+  timestamp: 1644481750133
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+  sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
+  md5: 8810f48fe4a4792de0fd3520b502d08b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10019
+  timestamp: 1606859473259
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+  sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
+  md5: 00a446b6dfc61af223df4de29fe8ad94
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 34305
+  timestamp: 1644569782044
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
+  md5: bd92dd8bd5b9d24e632b62a075426e50
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133634
+  timestamp: 1695718025321
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+  sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
+  md5: f8ae051b591a9027adc16de1be9748f4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206198
+  timestamp: 1681493096349
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
+  sha256: 65ababd5e7812c35a97ac7d22b0ebe52c144121a3d49528b7d5c19e8453cce4a
+  md5: d85c13c017a37e406f6c1e00c1ea4f4f
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6480601
+  timestamp: 1690546287900
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+  sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
+  md5: 0d79760d544d0bd8acb4adc4ef813418
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 137075
+  timestamp: 1657175654487
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
+  md5: 31d6d04cd2388d8f19004501271b3545
+  depends:
+  - brotli-bin 1.0.9 hca72f7f_7
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18982
+  timestamp: 1659616229395
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
+  md5: caf1073dc2ca5aeb832a2877394eae12
+  depends:
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18233
+  timestamp: 1659616216769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+  sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
+  md5: aa1ed20c38af535c8d6a955314759d7b
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 394588
+  timestamp: 1659616312678
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+  sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
+  md5: ce3588e31faa79f546e0fc6a36c5543c
+  license: MPL-2.0
+  license_family: Other
+  size: 133884
+  timestamp: 1694009771475
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+  sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
+  md5: 21eb7f53076d0a69513cfd258f6ef63c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159756
+  timestamp: 1690232346868
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+  sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
+  md5: a40a04d9cda1e665565bc6c832d598b6
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225258
+  timestamp: 1670423337502
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+  sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
+  md5: b2cc5f37f7bb069d061306e7eac2a011
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1913396
+  timestamp: 1668084575248
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
+  md5: 103d8c039e342115720a84d59c119d46
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13774
+  timestamp: 1671231190250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+  sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
+  md5: f69f09e0346172f225390d2b3b0d7873
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 246628
+  timestamp: 1663827484947
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+  sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
+  md5: cb80c7ac65b48a737654f371fe31c460
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1307228
+  timestamp: 1694212041712
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+  sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
+  md5: 04cbe8f4bc62c34fac9d42d1124059bf
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2052734
+  timestamp: 1690905361158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
+  md5: ef0e825982f242085574f502dfff4f6b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16594
+  timestamp: 1649926538106
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
+  md5: 24747a300246c016b3a7f04dabd02d4a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27709
+  timestamp: 1668714497209
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+  sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
+  md5: e4a732941f74b8062c8bcbfe5c5c2b56
+  license: MIT
+  license_family: MIT
+  size: 80252
+  timestamp: 1676983220161
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.17.1-py39hecd8cb5_0.tar.bz2
+  sha256: a3c61a0d72aa6adca1967b894b190cf7d32fe78b0f8c57b855fb1e99c41aa3de
+  md5: ec60e644877f1e89c9ce00d487232396
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4610888
+  timestamp: 1693378182350
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+  sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
+  md5: f3ce6fe6eb760c236e5f7d04df5faa81
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28138484
+  timestamp: 1692293212596
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+  sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
+  md5: 6dd72c43fea25b748ec7a9f6c0407e15
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111810
+  timestamp: 1666125671024
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
+  md5: 03cdb7e679924b329ecab8f12cb8fc67
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38813
+  timestamp: 1678997212422
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
+  md5: e113c4e6e758dd68faf196586bf5564d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51873
+  timestamp: 1698254765815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+  sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
+  md5: 78baea934985ccd9514a366cc7e80ed4
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 727499
+  timestamp: 1681801225190
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+  sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
+  md5: da9b63e42f281f7e77b289f4b654b83b
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 218436
+  timestamp: 1691121840155
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+  sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
+  md5: 6a7cb9b49593b29933fa2b503d533a08
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1257205
+  timestamp: 1694181720454
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+  sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
+  md5: d861ef66f5c0a282d60b65778a9de2f3
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1048450
+  timestamp: 1644315332508
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
+  md5: f7e603c965052deed8b789c35855a42f
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213537
+  timestamp: 1666908270815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
+  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
+  license: IJG
+  license_family: Other
+  size: 278924
+  timestamp: 1677849185191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+  sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
+  md5: a82a17e78f725dcbd71ff8dac6db05c7
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133134
+  timestamp: 1676558895333
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+  sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
+  md5: ee9270379a9ebdb6297e4b6849b3f7f0
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 195479
+  timestamp: 1676329410154
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 32b898a97dca7770858ab31294238fde11ab61a84831a52f320e5ee5405a147c
+  md5: 926e754b8fad288b583ef2933deae1a5
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92938
+  timestamp: 1679906616072
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+  sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
+  md5: 7e60995b3119417213e5faedda147499
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 403165
+  timestamp: 1671707664990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+  sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
+  md5: cd470bdb28bb0e8b3535c93a3a6dad07
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65431
+  timestamp: 1672387389172
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
+  md5: 7dba7aa5b971febb55281659843586ba
+  license: MIT
+  size: 65470
+  timestamp: 1659616172703
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
+  md5: f78a158983f0bbaba56f34b976bc6dae
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 34189
+  timestamp: 1659616189313
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
+  md5: 36a1d885725d3ab4d1fadc5a29f978d2
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 327737
+  timestamp: 1659616202869
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+  sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
+  md5: 817848d0e2b2808acdc9b3fbbf581726
+  license: MIT
+  license_family: MIT
+  size: 133887
+  timestamp: 1683716590737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+  sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
+  md5: c90372428e1e4eed4fdcd790979d06b4
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1409377
+  timestamp: 1650983531933
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+  sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
+  md5: c0b99f8e1c7475f23b1c7b4250b06e1c
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88021
+  timestamp: 1694778290062
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+  sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
+  md5: 06866415ef22d5322f9bdc9956b59c4d
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 678174
+  timestamp: 1692970318885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+  sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
+  md5: 2edc6c894d6d0321304396e9bd40df94
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241774
+  timestamp: 1692973618934
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 0190d3b8d2939f28aa017711cf4147c51a1139da2922cc8420a71562dd99f844
+  md5: 454a7f2c4426453f17e995382a4235e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 36036
+  timestamp: 1659783508187
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+  sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
+  md5: 8bbd981ca0129d7beeacd3cd7623f714
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1491074
+  timestamp: 1695058597986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+  sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
+  md5: d5f58d056b4bfc67aec30c77035ba889
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 182491
+  timestamp: 1670944720979
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+  sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
+  md5: 1affd16b166571a91feae04baf5fd3da
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123431
+  timestamp: 1671542016019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+  sha256: e5fc51472fa0f36abd78baa5b3c9245d6627b0da11188e6a954d73f3f2bca210
+  md5: df7c519447affffb594f8c56b028ed33
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 107035
+  timestamp: 1684279974102
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+  sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
+  md5: 3681ebf029211ceab26af6f5d35abf39
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22254
+  timestamp: 1654598220251
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.8.0-py39hecd8cb5_0.tar.bz2
+  sha256: 40aa972e605bdc8305ebdc4b8e891ae8b65382be12d221e002ec31cfe830ac22
+  md5: 07b2a24fd3dcb5cb0af22e137cd43408
+  depends:
+  - matplotlib-base >=3.8.0,<3.8.1.0a0
+  - python >=3.9,<3.10.0a0
+  - tornado >=5
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8754
+  timestamp: 1698692468088
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+  sha256: 2fd179efa024c92d0d71179a981a781d16c70f5d8c6305e0d678b0c7ae1275ab
+  md5: addda7f015d1673f794a23fdb18a3e09
+  depends:
+  - __osx >=10.12
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8182219
+  timestamp: 1698692361219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+  sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
+  md5: 6eb64ecfcd754502e271db0bb51d2cfd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17374
+  timestamp: 1662014643620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 2312ee5a6343e8495802698d7181f1b619aad7479d96ee253407b324ac884417
+  md5: 866960fa48a7ca335941786d4869802a
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53542
+  timestamp: 1659721365599
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: 37f455814ce242eb65ff80a0402f1bd231a388e6823e6c1e65f60b705c032a2d
+  md5: 4c9246c492a64729225aa5b04e12c2d1
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19573
+  timestamp: 1659716100178
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+  sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
+  md5: 2a4d604717a647ad21af766289cbbfc3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58057
+  timestamp: 1607364912348
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+  sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
+  md5: 25051fe272624544652dc6d814c2943a
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224420228
+  timestamp: 1691503125614
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+  sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
+  md5: 37d8cf85a63f7aa9af1624894a7d606d
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48590
+  timestamp: 1682969183093
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+  sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
+  md5: 0b2aee6666135bbd36b46d6ac66160f7
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 210705
+  timestamp: 1695058433223
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+  sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
+  md5: e22fb55ce380d0ebd44cce3f20d5349e
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296614
+  timestamp: 1695060155673
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+  sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
+  md5: 1a5d4004e64e3cfb7a2a297b9117c285
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8213832
+  timestamp: 1681756573646
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+  sha256: 2975bd1f98ca9ec7354ee378f86f8322ec90f568374776fd90e80c534fbee882
+  md5: 798627089e0ccba26695a26d9cb127ec
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99066
+  timestamp: 1650308465824
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+  sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
+  md5: e572c1264a7af20b486f64ac8c9e1f57
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 573356
+  timestamp: 1668450732828
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+  sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
+  md5: b67569a7c30af9ffa5cde6e4b52ac68b
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148342
+  timestamp: 1694616917184
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+  sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
+  md5: 97b81f34efbe86c5220fe82eb584fd62
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387288528
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+  sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
+  md5: d77862975a9a1cf50acb803be26e83a1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 575365
+  timestamp: 1690985052739
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+  sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
+  md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22858
+  timestamp: 1668160618784
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+  sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
+  md5: 185e9c41abb88ee59b52ec0f5f65d506
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 138305
+  timestamp: 1696515469702
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+  sha256: 82a2dd0c2ff6e20a275e5447dd03088f79694f7bfa5055a25c54bebf31aac4ca
+  md5: c157e6ab469a95b06fa822ba075978b3
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.0 py39ha186be2_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10376
+  timestamp: 1695831243158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+  sha256: b3a003b41cec2751210e542911e99437db0321542f6812c1b88608ef720ba7ef
+  md5: 56400dfe88c427cdf1854e47666b8a99
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.26.0 py39h827a554_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7570900
+  timestamp: 1695831208653
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
+  md5: 93f5d7b66976154adeda219bea02ba45
+  depends:
+  - libcxx >=10.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 484257
+  timestamp: 1630093862501
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+  sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
+  md5: 5e8713ef1215406254988163eaf34020
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4965606
+  timestamp: 1695323060401
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+  sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
+  md5: 4154929ace2ad6ee16aea815635a6d1f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73598
+  timestamp: 1693575307570
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+  sha256: aff5acedef9da91b77851e1a163b8319d72bc4152c98ac87703a2eac1e5d575b
+  md5: 7df4c76aa8c52fedce5346748d56459e
+  depends:
+  - bottleneck >=1.3.4
+  - libcxx >=14.0.6
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - tabulate >=0.8.10
+  - blosc >=1.21.0
+  - fsspec >=2022.05.0
+  - beautifulsoup4 >=4.11.1
+  - pyreadstat >=1.1.5
+  - pyqt >=5.15.6,<6
+  - s3fs >=2022.05.0
+  - numba >=0.55.2
+  - xlrd >=2.0.1
+  - qtpy >=2.2.0
+  - xarray >=2022.03.0
+  - psycopg2 >=2.9.3
+  - lxml >=4.8.0
+  - zstandard >=0.17.0
+  - pyarrow >=7.0.0
+  - pytables >=3.7.0
+  - xlsxwriter >=3.0.3
+  - gcsfs >=2022.05.0
+  - fastparquet >=0.8.1
+  - scipy >=1.8.1
+  - pymysql >=1.0.2
+  - odfpy>=1.4.1
+  - pandas-gbq >=0.17.5
+  - pyxlsb >=1.0.9
+  - matplotlib-base >=3.6.1
+  - openpyxl >=3.0.10
+  - jinja2 >=3.1.2
+  - html5lib >=1.1
+  - dataframe-api-compat >=0.1.7
+  - sqlalchemy >=1.4.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13388063
+  timestamp: 1697477404222
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
+  sha256: 1928d1f3aa777c6fe0b279f400fa417b293527531bbdd3d918cc8e987a680f86
+  md5: e8d7a163f2f9dd0f1972e126ee87b586
+  depends:
+  - bleach
+  - bokeh >=3.1.1,<3.3
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.16.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17076156
+  timestamp: 1695146369755
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+  sha256: 914f1ec8d911083c006c4c2d3b4c0c528e79abba3ae5f1dad825bd896870270d
+  md5: 949e0e4c0ce43c92eb52241892230873
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142949
+  timestamp: 1684915417020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+  sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
+  md5: be0a90921f3bf4f0d6950fb786093de7
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND
+  license_family: Other
+  size: 719901
+  timestamp: 1696580194417
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+  sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
+  md5: 81ae9ec2d7fcf6934847bff558b619f5
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2672987
+  timestamp: 1697548890181
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+  sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
+  md5: 1a822c206e2abddc5d6d821721af227f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33013
+  timestamp: 1692205801265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+  sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
+  md5: 1604d33dbdb2446c642970f8b354bedb
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91266
+  timestamp: 1659455269141
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+  sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
+  md5: d1b3bcc35655a3123acb1fa2ad1a8511
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580828
+  timestamp: 1672387372015
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+  sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
+  md5: 7540555d1fb192236db9a7c5c9d3601c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365765
+  timestamp: 1656431373327
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
+  md5: 0a73533fb6e0dc717ab906a537bc747d
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30803
+  timestamp: 1675441638631
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+  sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
+  md5: 0a959fbad46ab38ade48dbd358002674
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1864757
+  timestamp: 1684280094736
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+  sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
+  md5: ea24b5076ef79e4567c5a3f0cb22b470
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95330
+  timestamp: 1690223465114
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+  sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
+  md5: bcaea6d4a47e9c874becaa700c78dcf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157216
+  timestamp: 1661452617825
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+  sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
+  md5: 707110d1b49cb1864acb0bbaa103591e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 95016
+  timestamp: 1636111184034
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
+  md5: 113a443b9c706f9f9c6187c0eaa3de27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31178
+  timestamp: 1605305861851
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+  sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
+  md5: 85a8d0001db70e52a479155228cb1fe0
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13324979
+  timestamp: 1694439878265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+  sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
+  md5: 47c5e22e31ec05a7bc0ce90065a53afd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 265348
+  timestamp: 1661368839620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+  sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
+  md5: ce9a69e1668aa1e133f2aa6d4e8d346f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 254958
+  timestamp: 1695131709704
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 9ee098c09f31fad7ff1856e5ce2619172eaf979997e7a427d1e05cce32c2af00
+  md5: cac1d1898b69ae9646dfbf082910635d
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40946
+  timestamp: 1685030787453
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+  sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
+  md5: 637f08b19dd8fd87347d8c44f9e3e202
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 170776
+  timestamp: 1698096100056
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+  sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
+  md5: 8ce3ac7d8a04e469b566f1b090d01140
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 470617
+  timestamp: 1657724324011
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
+  md5: 6f2d41dd76a03b7f85a1ed49af1763d6
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95100
+  timestamp: 1690400262627
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
+  md5: b0321e6f14e139fc15b1f8b4acb35d2f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093966
+  timestamp: 1690290944588
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+  sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
+  md5: 62b64576a0aa5f6c3fb05f56650d25e1
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15535
+  timestamp: 1614030509324
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+  sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
+  md5: 15b5595b31e39f08eaacbe2e502d8fb3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67292
+  timestamp: 1696347733587
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+  sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
+  md5: 82e4db6a498480a75d53c55bd35b6478
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1801397
+  timestamp: 1681394807900
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+  sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
+  md5: 63b957927b9949ccb19da28ec4612706
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30902
+  timestamp: 1671751919031
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+  sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
+  md5: e346257a2fa8e2cb48c762138a5d009b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39915
+  timestamp: 1668168959656
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+  sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
+  md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
+  depends:
+  - zlib >=1.2.12,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3536231
+  timestamp: 1654088937695
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+  sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
+  md5: a1bbf0abfb8c45541122c0eb2feee317
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680464
+  timestamp: 1696937112175
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+  sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
+  md5: d689f6203c0a9d04fb229c73d7e80a7a
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125145
+  timestamp: 1679561909274
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
+  md5: 8a292c1ee22489bef2e84bc3aaf4098e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193141
+  timestamp: 1671143985219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
+  md5: 8bf0bfffc11ad06a1c94e145941b0ad4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9651
+  timestamp: 1690297655669
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
+  md5: 343514a174b3485fde55a73f56398dd7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58456
+  timestamp: 1690297648002
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+  sha256: 11e7401cb6805db7ce22b1f9dd6ba5b7941c92225ce440bed1da0af284bfcad4
+  md5: 5c10d68fa5616cdd82ee93ef6e0f038c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11615
+  timestamp: 1659769478980
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+  sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
+  md5: c2242e8fd24003a74ddf37416661e06d
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188757
+  timestamp: 1698257668273
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+  sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
+  md5: 41f445e36b6b6722a9444508eef069f8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20583
+  timestamp: 1607365395045
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+  sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
+  md5: 409ee46ed24267b6da6fb32d13e1f21e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70730
+  timestamp: 1614804271285
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+  sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
+  md5: eb74e74d8e4fd533c55eb98b7b5e83bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102637
+  timestamp: 1695742077778
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+  sha256: cb007615819fd240ea4e343835dfbda3c508a92b5b7158219d30a22d0e67b57c
+  md5: bf215e781ac81e0fc433eedee330c54b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49462
+  timestamp: 1675159191191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+  sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
+  md5: e243baa546432c8394a8059a44a5a3e4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 419227
+  timestamp: 1683113010463
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+  sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
+  md5: fe4ac85ee86d3a94ea3a4ebea3779763
+  depends:
+  - libcxx >=10.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 321797
+  timestamp: 1616055526986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
+  md5: bc7073d9d4c0211cc4a1207c98fb765a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19091
+  timestamp: 1672387204865
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+  sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
+  md5: 8e495591e369ac161857a72011c0a296
+  license: Zlib
+  license_family: Other
+  size: 120272
+  timestamp: 1666595024203
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+  sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
+  md5: f1465fbd810b3746c6de6babfd4fe28a
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1023573
+  timestamp: 1681304595869
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+  sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
+  md5: cf55cb8d7031b30c70c56fc7c782b5c7
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 156104
+  timestamp: 1644482799136
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+  sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
+  md5: 84fce327d9f0d594e86f565e5c21962e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10183
+  timestamp: 1629146082730
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+  sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
+  md5: 84b8b998a741b37abf5312c1c03696ef
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33979
+  timestamp: 1644845817952
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+  sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
+  md5: 77b746931c8f31c3ae393ccb5819d43d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133628
+  timestamp: 1695717890677
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+  sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
+  md5: 3df6e8ba34208dea068890e5d5318cc0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206759
+  timestamp: 1681493095987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
+  sha256: 4edfceca9958378015a2d5ff705aecb977fa329fdd0caf51cf6a1b6b5506e5ab
+  md5: 7404ddc0add9157338d7d4822ac13cb3
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6462121
+  timestamp: 1690546176434
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+  sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
+  md5: bb55f81435cb6e11d264242274fccd1a
+  depends:
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 115947
+  timestamp: 1657175645380
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
+  md5: f860193e14afc7ef3f5b990a2ac003d2
+  depends:
+  - brotli-bin 1.0.9 h1a28f6b_7
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18936
+  timestamp: 1659616204016
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
+  md5: ad53130f3fd1f8d3c2fcbb7496e5585d
+  depends:
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18715
+  timestamp: 1659616188888
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+  sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
+  md5: 0982c046fb976e9f9fb19e7510187a18
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 366983
+  timestamp: 1659616245272
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+  sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
+  md5: 31ac2f5596cb7a44adf073c930641c54
+  license: MPL-2.0
+  license_family: Other
+  size: 133817
+  timestamp: 1694009762858
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+  sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
+  md5: cf1f6c3c34a1e1b9ab22b04233d860f6
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159783
+  timestamp: 1690232303987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+  sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
+  md5: 0eb268e38b5174d471a6e87d9d6102b1
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225355
+  timestamp: 1670423312966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+  sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
+  md5: e68c94666cd60221b575c3814c89bac0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1946451
+  timestamp: 1668084573824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+  sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
+  md5: 1773ae2b080cdd55827e27673351551e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13646
+  timestamp: 1671231171682
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+  sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
+  md5: 53bfd99ad1b09164d537209cffd98161
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 244040
+  timestamp: 1663827469853
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+  sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
+  md5: b62455043c8eb2434466885b19fed2de
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1399573
+  timestamp: 1694211828228
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+  sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
+  md5: eb3cdc0fc210838b9271512a6a1b7c85
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2067708
+  timestamp: 1690905319109
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+  sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
+  md5: f44b80b9405410e5bde6bfe0b31d5b3f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 15135
+  timestamp: 1650293774207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+  sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
+  md5: f87027ccce1361d0f82c0edf1a10d53b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27677
+  timestamp: 1668714367519
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+  sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
+  md5: 1d0bd7e576c64c059ef781dd319ad82a
+  license: MIT
+  license_family: MIT
+  size: 77591
+  timestamp: 1676983230102
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.17.1-py39hca03da5_0.tar.bz2
+  sha256: 024023fcd6a34ff71b3b558f9db00506382edef02e7ae0cf8e49846840d7deb8
+  md5: 5598508e6b21861496a578c023958612
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4495882
+  timestamp: 1693378262537
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+  sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
+  md5: 69eb3b03765627b6159ed23cdde78396
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28399065
+  timestamp: 1692293207812
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+  sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
+  md5: 83366cbd3beb073112f4644a613b6bca
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111933
+  timestamp: 1666125627512
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+  sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
+  md5: 647c1a2f8460ffa8c670a1915bbdb494
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38790
+  timestamp: 1678997152549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+  sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
+  md5: 35e541905426c686ef2ff010a0e502fd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51860
+  timestamp: 1698254731870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+  sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
+  md5: 187d7720aedf38759d122cccb4576f2c
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 219976
+  timestamp: 1691121991680
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+  sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
+  md5: e8e7f10741f9cfa737b310b334940441
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1255894
+  timestamp: 1694181494549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+  sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
+  md5: ff209e75aee17af2e358b0008fbe8c88
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1022945
+  timestamp: 1644315931223
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+  sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
+  md5: d3e78ef296b3c74910d003bd10b475d6
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213972
+  timestamp: 1666908195870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
+  md5: 055e12390b844ea6c6e956ee08a618e8
+  license: IJG
+  license_family: Other
+  size: 273479
+  timestamp: 1677849171867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+  sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
+  md5: 783e2ad3d36472648c5ccc9f3051db3c
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133077
+  timestamp: 1676558732505
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+  sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
+  md5: 0677598f673f9729b5990316170a999d
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 197129
+  timestamp: 1676329661580
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+  sha256: 05f9ca0fdcfdc2e217438be27fead588c843a3aadf7d034467c83216d1e5c214
+  md5: 2d648b77d817ba38293c0728711ba8f5
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92852
+  timestamp: 1679906632236
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+  sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
+  md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 401319
+  timestamp: 1671707682572
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+  sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
+  md5: 247558a0aecf1ef7e77a4343761353d6
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64600
+  timestamp: 1672387273585
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
+  md5: a0f206782751dfffed0dd51302a1bf26
+  license: MIT
+  size: 68012
+  timestamp: 1659616138077
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
+  md5: 4c6667cdd061d28e9bc4e4300e4d115e
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 31173
+  timestamp: 1659616155596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
+  md5: 637e9430e258ddf050623ef2360184d8
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 298430
+  timestamp: 1659616172209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+  sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
+  md5: 55c615026c0869f8d3ba657f3bd38c43
+  license: MIT
+  license_family: MIT
+  size: 120389
+  timestamp: 1683716579036
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+  sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
+  md5: a41117710dafe569c9cc4e83f6f29fe3
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1411339
+  timestamp: 1650982753977
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+  sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
+  md5: 98d22e0124d55fae3c37c608dab1dcc9
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 89825
+  timestamp: 1694778225280
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+  sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
+  md5: 0ba499df6755eae5d2d23aa4ab004553
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 642657
+  timestamp: 1692970217410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+  sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
+  md5: c73101971e5ab6a8e8688239884eac81
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241607
+  timestamp: 1692973585084
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+  sha256: ac50f846e93e68d50bfdd5589ea8272b987243a64eba8e2e358ef311d7734001
+  md5: f19270ff954a41dabbfe36ff0656935b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 36040
+  timestamp: 1659783399073
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+  sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
+  md5: 353dff9d5d996c2a260f66381b2ce3e8
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1470815
+  timestamp: 1695058433965
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+  sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
+  md5: c99006da802a97c9aae30da8c16b4820
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176131
+  timestamp: 1670944706815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+  sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
+  md5: 60bd1e037cda86205526f77405d78129
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123361
+  timestamp: 1671541992772
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+  sha256: 2fd690fa3c54a40f0426874ea12e12aad2718263a75708ddd1fa6052a4ad7fb3
+  md5: 81388724babfe9c32ea5cdd93633c342
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 107072
+  timestamp: 1684280007887
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+  sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
+  md5: 34dfd76da78de2eae95bbda390d746d6
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23092
+  timestamp: 1654598007056
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.8.0-py39hca03da5_0.tar.bz2
+  sha256: f6d7d0f791face4d911f5907df48e093cebcd1da188ba3d3267bf858d6dcacaf
+  md5: 6a55e97ce33cd40a280f538dd5437eff
+  depends:
+  - matplotlib-base >=3.8.0,<3.8.1.0a0
+  - python >=3.9,<3.10.0a0
+  - tornado >=5
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8725
+  timestamp: 1698692342704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+  sha256: bf0eeef3c3c713515766ab8b0dc7863413de5b4b227deede97e24d90ca342345
+  md5: a7bba1857eb84fb50caea377e60d2050
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8066509
+  timestamp: 1698692266161
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+  sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
+  md5: eb79dabbeedee7da85dfbfb145bb8a26
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17342
+  timestamp: 1662014601345
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+  sha256: f400ad75dd2890627dc948f3e2e6b19732d02c124723eaf22272026993a94d52
+  md5: 4a4ffc7365e30b18f4443281839e2718
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53505
+  timestamp: 1659721313693
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+  sha256: 20fb26a7ac748ce288cf8483a837b0c33f1348ae738bcdb69cdc2763c7bbf7e1
+  md5: a0aebbc6c170ebd8d4710fd70b3db503
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19562
+  timestamp: 1659716131839
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+  sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
+  md5: 56db7bd3ff511cd839bda081523b3edd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 55683
+  timestamp: 1629356128780
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+  sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
+  md5: 176e0dcaeb28393881bacf69941e3889
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8289638
+  timestamp: 1681756329011
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+  sha256: afc6f332c51a3defc69e4c4e641988c0556039b9cd42be22f3db5292c88ccf37
+  md5: 2bc409c7258160a9b739d08d5ffb5998
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 96942
+  timestamp: 1650373637069
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+  sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
+  md5: 150ea9fadddf21993d3328d3e48a18b7
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 557688
+  timestamp: 1668450759059
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+  sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
+  md5: 37163b32508f9f589b3e6462a3a47546
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148426
+  timestamp: 1694616771736
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+  sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
+  md5: 6cdf7cbc43bf40e92b056a5576bd0086
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387216468
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+  sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
+  md5: 0f05853a139b6cda9c73e9d2707a4976
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 590288
+  timestamp: 1690984971741
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+  sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
+  md5: 7de782e4fb34bfa95ef2fc79d27d727d
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22840
+  timestamp: 1668160634885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+  sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
+  md5: 1a7b23113372c5667dbfe45976b9cc5c
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 126357
+  timestamp: 1696515322390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+  sha256: 3cd1161558704176560843586b1b1f9b257fd68c0ca53a2fc09e61267f47514c
+  md5: dd162b2716dc9daf732240a343862d4a
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.26.0 py39ha9811e2_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10388
+  timestamp: 1695830584640
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+  sha256: 5f35d8c0e1768fa3a9d2e75659cd2096bea6b4e021afea114f573e95f4943fb2
+  md5: 958f78b1e2299537996f98da7a930198
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.26.0 py39h3b2db8e_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6313331
+  timestamp: 1695830570878
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
+  md5: 371358a54bbdd307603888348d1a2c6f
+  depends:
+  - libcxx >=12.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD 2-Clause
+  size: 412248
+  timestamp: 1628861367714
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+  sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
+  md5: fa15d3b44ae1360ac9b640bbd5b6923c
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4746123
+  timestamp: 1695322833432
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+  sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
+  md5: d73db95f07a282021efdf8bc09713261
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73620
+  timestamp: 1693575195999
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+  sha256: 247b5e4d81b6d5d013a9c27e1f30c41fff896fed98a68ebda26b19b4062a6828
+  md5: 354a1d65300b4309d53dfa648014e8fe
+  depends:
+  - bottleneck >=1.3.4
+  - libcxx >=14.0.6
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - lxml >=4.8.0
+  - matplotlib-base >=3.6.1
+  - tabulate >=0.8.10
+  - pyqt >=5.15.6,<6
+  - openpyxl >=3.0.10
+  - s3fs >=2022.05.0
+  - pymysql >=1.0.2
+  - beautifulsoup4 >=4.11.1
+  - scipy >=1.8.1
+  - xlsxwriter >=3.0.3
+  - fastparquet >=0.8.1
+  - xlrd >=2.0.1
+  - blosc >=1.21.0
+  - zstandard >=0.17.0
+  - psycopg2 >=2.9.3
+  - pyarrow >=7.0.0
+  - pandas-gbq >=0.17.5
+  - pytables >=3.7.0
+  - sqlalchemy >=1.4.36
+  - odfpy>=1.4.1
+  - numba >=0.55.2
+  - jinja2 >=3.1.2
+  - pyreadstat >=1.1.5
+  - gcsfs >=2022.05.0
+  - qtpy >=2.2.0
+  - html5lib >=1.1
+  - xarray >=2022.03.0
+  - fsspec >=2022.05.0
+  - dataframe-api-compat >=0.1.7
+  - pyxlsb >=1.0.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13257999
+  timestamp: 1697478739906
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
+  sha256: 4548d2a1bc58cd61e9c9f475a77bac68d9e49d4996c4c891d5ca8ba5ea7552b0
+  md5: b4ed079246a55ac8f91b8f8abb713b3b
+  depends:
+  - bleach
+  - bokeh >=3.1.1,<3.3
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.16.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17115516
+  timestamp: 1695146000246
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+  sha256: 0d64f2438be25524bbfeb8646e4fb3c18499d747398a03ed15d41b350b03e001
+  md5: 6a4908a5c9f7b3f17f09ebc34b1b691c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142857
+  timestamp: 1684915417403
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+  sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
+  md5: 6e01c592ae3b8ff2d12cae76f2f4276b
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 715239
+  timestamp: 1696580071596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+  sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
+  md5: 9fb8f460c130d56caf33c6bbe46fbe8a
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2678841
+  timestamp: 1697548790931
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+  sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
+  md5: 390b8c3cd74281abecdbfd51476922f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33033
+  timestamp: 1692205747301
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+  sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
+  md5: 7896828fb3565fefad43f980d50c8723
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91190
+  timestamp: 1659455206354
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+  sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
+  md5: d934c74eb66d01af0f45f0881f4bab77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580588
+  timestamp: 1672387390426
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+  sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
+  md5: 9858166e5ffb624c8b9d281f4000d725
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 367167
+  timestamp: 1656431368885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+  sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
+  md5: 4d2b45c6be8221e6a3e44c2d5838426f
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30843
+  timestamp: 1675441531640
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+  sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
+  md5: 02521df4e2e79f75faa9cbb3560ab1dd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1861763
+  timestamp: 1684280026169
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+  sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
+  md5: bdebe59bffc7adbad83fdcd9d429a5f5
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95234
+  timestamp: 1690223494699
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+  sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
+  md5: d716e5c9b5eec45ce1df8eb52cab817a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157408
+  timestamp: 1661452601692
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+  sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
+  md5: 1907629863ed8e7c35ead232dae7693f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 91636
+  timestamp: 1628941083263
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+  sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
+  md5: 847b9bddf2a86e1609c0d53bbc23ea79
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 27378
+  timestamp: 1626781391140
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+  sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
+  md5: 18aa18bd0d260605923877921d26cc74
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13194025
+  timestamp: 1694438901368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+  sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
+  md5: 45642a99c83e7aed74d1ffab1f20145b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 266647
+  timestamp: 1661368655993
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+  sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
+  md5: fec748525144049a2fc7f52f9755232c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257235
+  timestamp: 1695131702047
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+  sha256: 960192a143672e9c1d6fe4027af448512d91eee7501e5c245c21b865cf8bf429
+  md5: 76d491244218505f071ba56a308673df
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40950
+  timestamp: 1685030774581
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+  sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
+  md5: 3445d25415998c807efbe64d3a7e03c8
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 167068
+  timestamp: 1698096118071
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+  sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
+  md5: e6e92da28e9b0e428ed4b7df417bec25
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 472418
+  timestamp: 1657724315435
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+  sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
+  md5: dba22515f36d3c266de5896350813ea2
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95103
+  timestamp: 1690400315537
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+  sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
+  md5: 3cd7eb43e285faba76faf67667e26b00
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093916
+  timestamp: 1690290951258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+  sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
+  md5: c5e9aef0d6895de1c927e9d796cd7cd3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15691
+  timestamp: 1629145910454
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+  sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
+  md5: 0f7c229e774146ffc4e29dedf75372bf
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67279
+  timestamp: 1696347632563
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+  sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
+  md5: 2302a79a045f152e183a52a81adfba62
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1674163
+  timestamp: 1681394762218
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+  sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
+  md5: 4ae67163d55cf9df83d4027ebc38c501
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30894
+  timestamp: 1671751931536
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+  sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
+  md5: dbb5c0cddb6661a89afee647fd3dc01e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39875
+  timestamp: 1668168874870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+  sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
+  md5: 667e60c8b407d73cbba40f44901f4f00
+  depends:
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3412693
+  timestamp: 1654088929697
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+  sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
+  md5: 884f788a5f6a664c9b79f7a4a60362d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680561
+  timestamp: 1696937004165
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+  sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
+  md5: 639a4f489af172c866c18442948e5874
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - slack-sdk
+  - requests
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125170
+  timestamp: 1679561942932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+  sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
+  md5: e5b90eba83fddba6d7aa6072b5bf7c91
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193017
+  timestamp: 1671143921826
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
+  md5: 644ef8830437070f60efcfcd6a987198
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9670
+  timestamp: 1690297532002
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
+  md5: a902a833bb186a2f1a4b2b89b1195136
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58466
+  timestamp: 1690297524418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+  sha256: 536045a8a172c651fd306c285a6d7409775f018dac944f2124c538ccfb195e28
+  md5: d4dc6cdf0812191b9ec78b35b4fdf3e0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11593
+  timestamp: 1659769477205
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+  sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
+  md5: f3f1d2c1028dad2f11ff950a15c99dbf
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188640
+  timestamp: 1698257577209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+  sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
+  md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20091
+  timestamp: 1629144441130
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+  sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
+  md5: 3089c63bf8f4d0423e1a287da286d83e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70923
+  timestamp: 1629357115820
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+  sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
+  md5: 5886b30b312445471268444f41f39dc7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102583
+  timestamp: 1695741976083
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+  sha256: 105e39d3eb51b47c7244b3379c0133ab7051966664f52835453b14509215b159
+  md5: ed20012c2cd99ffd04cca9929e0bc061
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49775
+  timestamp: 1675159079039
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+  sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
+  md5: 2e75ad6a09c308268192efe03cc9ebf4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 411778
+  timestamp: 1683113019715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+  sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
+  md5: 30f666bf97c26587c5d2f68cc5f330ab
+  depends:
+  - libcxx >=12.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 316901
+  timestamp: 1629287855861
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+  sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
+  md5: 584e591d36dcd5ba5c45404f0f7ebb2d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19076
+  timestamp: 1672387153578
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+  sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
+  md5: 467ae28215d1aa1c5688bc0c8a184269
+  license: Zlib
+  license_family: Other
+  size: 103525
+  timestamp: 1666595022664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+  sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
+  md5: 7cfbed15f1feee1422810f7830075f53
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 779464
+  timestamp: 1681304594848
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+  sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
+  md5: ed14f9bc6e55220483f1a5a388625a08
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162772
+  timestamp: 1644481986085
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+  sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
+  md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 39253
+  timestamp: 1644551767970
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+  sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
+  md5: b24d13c443a26f65a0778b475a5726bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132830
+  timestamp: 1695717959996
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+  sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
+  md5: 302c3c0696e17eaa62e140e3892644ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 199723
+  timestamp: 1681493196911
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
+  sha256: 29e914b68f261dd564de357888d32ec1511a6fcac9477fe68797289aba4d3e75
+  md5: 288585e412638a51e0288caf690d543b
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6485148
+  timestamp: 1690546982849
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+  sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
+  md5: bf930260f679bc74227bbb18bc36ae82
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 119700
+  timestamp: 1657176150595
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
+  md5: 507dfe693ef429f466d964b599f4af21
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_7
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 18650
+  timestamp: 1659616328001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
+  md5: d0bf43e8df60baae3b3105aa5c42a791
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 21153
+  timestamp: 1659616312367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+  sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
+  md5: 7bd24bf94c24e810aecaaf84a0978e6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 343204
+  timestamp: 1659616543542
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+  sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
+  md5: 092b417c11edcbe6bb9b765ab4a55d23
+  license: MPL-2.0
+  license_family: Other
+  size: 164999
+  timestamp: 1694009822357
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+  sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
+  md5: 708a750d370b9d6875651021e21c4446
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159322
+  timestamp: 1690232335307
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+  sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
+  md5: c35736da3ea26782425e78061268cf5e
+  depends:
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 228713
+  timestamp: 1670423312743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+  sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
+  md5: 457a4339a53c033d48ce0c72e5038d2e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30330
+  timestamp: 1672387265402
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+  sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
+  md5: 59ec65fd9e06b81a65cc12986c67d5da
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1939614
+  timestamp: 1668084794027
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+  sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
+  md5: 3489c1a2b73fc957b5a62cc59349e25b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13438
+  timestamp: 1671231196438
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+  sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
+  md5: 3492b96083c1e904cc32d26ea7f1e1d8
+  depends:
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184280
+  timestamp: 1663827558327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+  sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
+  md5: f46d904bc6f220327e70474971341f52
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1220835
+  timestamp: 1694445639066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+  sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
+  md5: 2ff4fb509788b0e47ac684ba151394d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3289966
+  timestamp: 1690907040646
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+  sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
+  md5: 0f166c3e70541d8bee6e9d0cb60fb66e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16979
+  timestamp: 1649926678161
+- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+  sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
+  md5: ea93d413944ca6a8677eb1b284b136ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27388
+  timestamp: 1668714577678
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+  sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
+  md5: 9f167d3e45441bc3633c1974b1b0ce8c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 88421
+  timestamp: 1676983264486
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.17.1-py39haa95532_0.tar.bz2
+  sha256: e4e08cbe9311b78ab893105a8f34963b46fce74c67943176cf2309e355dceb80
+  md5: c68d9f0e4a10f15d15d5812093818900
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4580877
+  timestamp: 1693378576619
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+  sha256: 945f4521793d7d279532d1ccd5157201c5cbf64f846bfe60249d01e1b4edf295
+  md5: 0accae23d095c165ac731f4a1f3ca497
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 37021132
+  timestamp: 1692294548916
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+  sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
+  md5: 30fdefd1541c789c163751291a8faa88
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111448
+  timestamp: 1666125667599
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+  sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
+  md5: a10f07c7a3510272a296f9fed458a4ed
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38098
+  timestamp: 1678997241511
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+  sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
+  md5: fad9cf2023d807da8d44996e9d4399a0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51490
+  timestamp: 1698254721864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+  sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
+  md5: 9834848bd7c7759acf12e78d09388563
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3891030
+  timestamp: 1681801474383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+  sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
+  md5: 1285c8c628bc912c54d0968574c9f4c9
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217232
+  timestamp: 1691122695748
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+  sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
+  md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
+  depends:
+  - backcall
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1279433
+  timestamp: 1694181820978
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+  sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
+  md5: f5fcce35d3f21cdfc5893c5a7a86c651
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1035394
+  timestamp: 1644315567034
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+  sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
+  md5: f67fe3337528e2886f1ac3ab8ac37985
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213110
+  timestamp: 1666908350218
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
+  md5: 81f2c343dc4c65eea39c45383272068f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 407861
+  timestamp: 1677849239400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+  sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
+  md5: bd9526d38a145fe311a8aa36bc11e071
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 152006
+  timestamp: 1676558783570
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+  sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
+  md5: a00e6a62956fde3c4135464353ee8a53
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229158
+  timestamp: 1676330909084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+  sha256: db8335d6531b03c7bdfe789ebacc52631ac6ea4a37700bb3da1f6a53a1acd724
+  md5: ebeba61994cc225ea5f4f42caa511019
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116681
+  timestamp: 1679906658986
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+  sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
+  md5: 5efa1332f7c0a8d9638eda02170c4ce5
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pywinpty
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 413653
+  timestamp: 1671707957673
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+  sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
+  md5: 891fe66a24d8714737b2874985ee1303
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62298
+  timestamp: 1672388166096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+  sha256: ef6b0347ae565dd648a2bb40bc8b0b30f2e4f8387778fefced1d581b7d5a3e16
+  md5: 8ef1d5919aa55fe56ef34d9a7969dca7
+  depends:
+  - openssl 3.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 861982
+  timestamp: 1684424430941
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
+  md5: c345f51706eef530454f66b794e5e574
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 68189
+  timestamp: 1659616216976
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
+  md5: a7400cfb72042977bc047909ed504ce8
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 33743
+  timestamp: 1659616248209
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
+  md5: 6307f6854754ab5bd7c84e6998385bb1
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 733177
+  timestamp: 1659616279453
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+  sha256: bb17beae8860a83d081d57273825b46bf8fe9903f3b4182ab41a7ae2c7274859
+  md5: 94182f4ab8beb4eddfd8167b2e2b0380
+  depends:
+  - libclang13 14.0.6 default_h8e68704_1
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 147804
+  timestamp: 1681225547009
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+  sha256: 01b84a38c9069e7b8e6fa2a07707e785df7d40b8f01d76a504e98e5a5cd58539
+  md5: 22c9f7e59174c49f06e3c5c9384401ce
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 25699299
+  timestamp: 1681225463612
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+  sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
+  md5: b812bc5d9c76242e2bb2ac87afe7d39b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 730280
+  timestamp: 1650983734373
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
+  sha256: a36ea5c77075e90f47d3f5c1e2081c0c1c78c5c0a5135bf9a6448fca67bbc79d
+  md5: a0a02817a7def0563d1635035c26451b
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - openssl >=3.0.8,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  size: 3827890
+  timestamp: 1687382140999
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+  sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
+  md5: ba9418df9288a2f031a02fa35b774ce0
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78524
+  timestamp: 1694778314659
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+  sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
+  md5: 6ece7f1a3248169837714d05d7f6ef0a
+  depends:
+  - libiconv >=1.16,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 3513910
+  timestamp: 1692971505729
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+  sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
+  md5: bd7ec244935e83e850a4ff34e8e2e64f
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 513971
+  timestamp: 1692973657152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+  sha256: e1c0e745d9ba36a80773e841d96bf514ad1ceda419e4188aad3c22782af00234
+  md5: f226532e9bb308f20e874c56be6ceefb
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 35788
+  timestamp: 1659783414586
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+  sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
+  md5: fb7881e74b59262df0fa4ec981964efc
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1244887
+  timestamp: 1695058550693
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+  sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
+  md5: 6970c7f46b0164cad1d210e7a1419959
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143434
+  timestamp: 1670944902624
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+  sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
+  md5: 1015298551c040c6d5e26eebbae12ef5
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142316
+  timestamp: 1671542240512
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+  sha256: ab5c246c2b271acc1cdd0b9343989c0166681536e569cdbe71618f55d34c7292
+  md5: 7ce68d771cd94c9ff5efefe69d327c9a
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 125122
+  timestamp: 1684280210213
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+  sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
+  md5: 466da740fafef3d6bce114220f0be306
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28510
+  timestamp: 1654508162239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.8.0-py39haa95532_0.tar.bz2
+  sha256: 3ee1e0b89c9a16ed21af80d9883d7638227028cac76ab24b5dcb4aa25dcd5536
+  md5: 0ec5d4cee9f74324b4bf0a653e53681b
+  depends:
+  - matplotlib-base >=3.8.0,<3.8.1.0a0
+  - pyqt >=5
+  - python >=3.9,<3.10.0a0
+  - tornado >=5
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8485
+  timestamp: 1698692858409
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+  sha256: 1687ae122ee7d8b583141fc5014b76d494841dc8083b854449e3d6e0f6bb7019
+  md5: 3697ac26ee3c2d49338dd5b9c6551152
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8080067
+  timestamp: 1698692812610
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+  sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
+  md5: a9fa43e694b25cd49b8b08a9eefd696e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18054
+  timestamp: 1661915903969
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+  sha256: 8aa14047fac6ef8b326900c4bf1a960eaa7a1699c18fdf1e75a59101b610b6df
+  md5: 7e1d4d4700fbea6171d30f1d5ad24226
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53362
+  timestamp: 1659721308586
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+  sha256: 2017814a7cc93dd51c6b7c016e3cdf8fbc32fa20f985638aaff6a6377e9ee086
+  md5: a1a285c56b001c3b5c591bf21eec3149
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19326
+  timestamp: 1659716205153
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+  sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
+  md5: 248c468abced874f0231d3cc23177c77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58488
+  timestamp: 1607359497934
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+  sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
+  md5: 5e763c995ff0c549f68a10bce70fede4
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187489950
+  timestamp: 1691503804820
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+  sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
+  md5: dd0c2ece6a743c373c9b5a5919b4818f
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49744
+  timestamp: 1682975040154
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+  sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
+  md5: 57cea8df7ab85f2a98f64d23afcb1f90
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184956
+  timestamp: 1695058491736
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+  sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
+  md5: 8769cdd201d905069800488fe31574e5
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 256221
+  timestamp: 1695060152521
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+  sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
+  md5: d9781492332e6326f9fca87f3a8efacd
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8135792
+  timestamp: 1681756491399
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+  sha256: 2dd3178d3c570e30b9490ebabfd7bfac806afad8302d3dee0edc619805034397
+  md5: bef9da0f0694c45b6aaa4e6447479eaf
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 118324
+  timestamp: 1650290466135
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+  sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
+  md5: f1d8ce412e115986c403f223b3b47d0f
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 596314
+  timestamp: 1668451106600
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+  sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
+  md5: f96bbef0985d7e66ebf00c0d55e30e23
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 167045
+  timestamp: 1694617078743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+  sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
+  md5: 6e6ba64c8dc5025aeac606404a8df36a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13786
+  timestamp: 1672387480065
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+  sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
+  md5: 4a7a3286484766741f627696697c362c
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 609425
+  timestamp: 1690985686105
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+  sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
+  md5: 4269a1f93882205b90d4b2ae78fc82d5
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22417
+  timestamp: 1668160717305
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+  sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
+  md5: a18a576b7024cfd6f905c526a786a916
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 135285
+  timestamp: 1696515698492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+  sha256: e5e11f9b42d770ee46ac24d1cdf7aa4e9c49a60a607c8c28e7729131a99eadd5
+  md5: 4274d06db8a9a381c072d226d0322dc0
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.0 py39h65a83cf_0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9835
+  timestamp: 1695830845329
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+  sha256: dcaa1607ce40a0ed610dd5398e125c8e5b08e738e50b6037a8c72b49ca561ff2
+  md5: d99d990a60644b97ba1ff9bb8da0e66f
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.26.0 py39h055cbcc_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6778113
+  timestamp: 1695830816710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
+  md5: ab07e2a27ac08afe3d0b4c0890b8486a
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 2-Clause
+  size: 249316
+  timestamp: 1630094024143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+  sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
+  md5: 73b17037d87b5a58feb34dafc0538f7f
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8058396
+  timestamp: 1695324589828
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+  sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
+  md5: df1d746ba8d5d6ba01ac1373b9b71e1a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73016
+  timestamp: 1693575484990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+  sha256: 1994e5831fd421bd6cf85916073d4012dec53e673b672b3985efaf771f0a7bf8
+  md5: c486a5b51e3227f6ea564a9dd3125e45
+  depends:
+  - bottleneck >=1.3.4
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - openpyxl >=3.0.10
+  - jinja2 >=3.1.2
+  - qtpy >=2.2.0
+  - numba >=0.55.2
+  - pyreadstat >=1.1.5
+  - zstandard >=0.17.0
+  - xlrd >=2.0.1
+  - tabulate >=0.8.10
+  - fsspec >=2022.05.0
+  - pyqt >=5.15.6,<6
+  - xarray >=2022.03.0
+  - xlsxwriter >=3.0.3
+  - beautifulsoup4 >=4.11.1
+  - html5lib >=1.1
+  - fastparquet >=0.8.1
+  - pyarrow >=7.0.0
+  - pyxlsb >=1.0.9
+  - matplotlib-base >=3.6.1
+  - odfpy>=1.4.1
+  - pytables >=3.7.0
+  - sqlalchemy >=1.4.36
+  - psycopg2 >=2.9.3
+  - blosc >=1.21.0
+  - lxml >=4.8.0
+  - pymysql >=1.0.2
+  - gcsfs >=2022.05.0
+  - pandas-gbq >=0.17.5
+  - dataframe-api-compat >=0.1.7
+  - s3fs >=2022.05.0
+  - scipy >=1.8.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12629931
+  timestamp: 1697479885371
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
+  sha256: 0044e1cc04f3cb7c48209276c35c59c05b87e852c0ac01be468b99f3656445fb
+  md5: ee81d2a2b2c558b43a48fd68c2de1dbf
+  depends:
+  - bleach
+  - bokeh >=3.1.1,<3.3
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.16.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17009718
+  timestamp: 1695148093102
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+  sha256: 2773f47b2d745ab483cf7fcbd5b5e2f7020d45462d32d2ccd5cf232ca13c6f67
+  md5: ca16cd208037bd58d2da267c338da4a4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142229
+  timestamp: 1684915524241
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+  sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
+  md5: 427c1450bebb632f43bbc8c83006e4cd
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 806931
+  timestamp: 1696580240310
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+  sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
+  md5: 21790cd3e2b8a45c4104aff0a68330d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3001751
+  timestamp: 1697549357662
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+  sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
+  md5: 56f44a1054da2d10777e375838191070
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 32355
+  timestamp: 1692205784293
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
+  sha256: bbcef9bbf4ccd051becaa7d8aa88cb5f46ff64570cc395b6a471332d8b900e11
+  md5: 0daf62b71923d157544576122b0fa79d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-clause
+  license_family: BSD
+  size: 82560
+  timestamp: 1607021261834
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+  sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
+  md5: 8a35ad65651086575ce55371f22feda8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91045
+  timestamp: 1659455316472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+  sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
+  md5: 186eb95f816a2eff80c3c7f7d964c7b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 578514
+  timestamp: 1672388155359
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+  sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
+  md5: 47b6cbe6ce9289e47d16900b03596a91
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372807
+  timestamp: 1656431445633
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+  sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
+  md5: 07165c444adc7c7ccc8a345875adc5ef
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48408
+  timestamp: 1675450623287
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+  sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
+  md5: d58e76a31e2f6e7410ba4afd7f385b0d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1877445
+  timestamp: 1684280183367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+  sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
+  md5: 0e5b0fe7debbf558ce97090f6b67cdae
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94633
+  timestamp: 1690225630423
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+  sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
+  md5: 0fde797653e4ab589506121fb1e37555
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157119
+  timestamp: 1661452591647
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
+  sha256: e70028d0250602c01feac17e60fafd371daee5d731917732b7eced4ab47b3243
+  md5: 72a51c0d49711d22a39aefc04fa0c328
+  depends:
+  - pyqt5-sip 12.13.0 py39h2bbff1b_0
+  - python >=3.9,<3.10.0a0
+  - qt-main 5.15.*
+  - qt-main >=5.15.2,<5.16.0a0
+  - sip >=6.7.12,<6.8.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 5007361
+  timestamp: 1698781683371
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
+  sha256: 6eb0c4f2e8acaa6dfaf1fb5b4b34f13d366ebf11d77e14a674a26d7fabbc7981
+  md5: 9354d98a97abd4715cdf63d4a28f7645
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 84071
+  timestamp: 1698769559444
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+  sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
+  md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 92679
+  timestamp: 1636093365041
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+  sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
+  md5: f870859d4dc7a8d82cf3546bd9035f33
+  depends:
+  - python >=3.9,<3.10.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 54520
+  timestamp: 1605307564142
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+  sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
+  md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
+  depends:
+  - openssl >=3.0.10,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 21172845
+  timestamp: 1694442462066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+  sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
+  md5: 9d99075052265ae3d718582d3b875038
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269964
+  timestamp: 1661376543480
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+  sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
+  md5: fa9074d94236c9b768bfd2c858875b27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 264836
+  timestamp: 1695131770282
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+  sha256: 97243a31c39f4990c0e9d4f2307f2f7fb9421553303923bc105067ec4340bdff
+  md5: 8078c5760f27398eaf1082226647d137
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40145
+  timestamp: 1685031143383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+  sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
+  md5: 3d2841085778006c2e79f9c7300f8b9d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13565975
+  timestamp: 1669937633869
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+  sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
+  md5: 54a4bc0724041dd173088419d6ede2af
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 239062
+  timestamp: 1677611495106
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+  sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
+  md5: f39f84115e228bad4bceaefdd637f022
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 158558
+  timestamp: 1698096358091
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+  sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
+  md5: df398a3a1668fd2a22061764e20ea91d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.4,<4.3.5.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 460913
+  timestamp: 1657616061604
+- conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
+  sha256: 409f9fad42cbae8d915d1703d87db6af9f951b150517daa4e1c0220cc5eb7b0f
+  md5: 2b17abf94b02a6c5ba6b7623dba97ff9
+  depends:
+  - icu >=73.1,<74.0a0
+  - jpeg >=9e,<10a
+  - krb5 >=1.20.1,<1.21.0a0
+  - libclang >=14.0.6,<15.0a0
+  - libclang13 >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=12.15,<13.0a0
+  - openssl >=3.0.10,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  constrains:
+  - qt >=5.15.2,<6
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 69829482
+  timestamp: 1693228189080
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+  sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
+  md5: 38db77ece9dc76feffb9ef7638e38258
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94397
+  timestamp: 1690400496655
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+  sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
+  md5: 3e284ae6b48ee30c364ffdc5601610b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1099842
+  timestamp: 1690291374842
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
+  sha256: ed2b75ca1bb075901550bf892aa18a46a563e512e28ad5fe1b36e7ed3c6708d0
+  md5: 22779fae19f454e13656af8b737f8bd3
+  depends:
+  - packaging
+  - ply
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - tomli
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-SIP_License OR GPL-2.0-or-later OR GPL-3.0-or-later
+  license_family: GPL
+  size: 602624
+  timestamp: 1698676202396
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+  sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
+  md5: 993b3886b334bd1f49d34206f21997b4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15998
+  timestamp: 1614030572433
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+  sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
+  md5: 7ac9604ad7564ac0c71bff5db198656f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67012
+  timestamp: 1696347795139
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+  sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
+  md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1311308
+  timestamp: 1681402905668
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+  sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
+  md5: 28b9869d8d3a839918fac4a08f38cbc2
+  depends:
+  - python >=3.9,<3.10.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30546
+  timestamp: 1671752127904
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+  sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
+  md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39590
+  timestamp: 1668168880994
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+  sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
+  md5: 52cdcdb96383c010ca833a7c24b3935b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Tcl/Tk
+  license_family: BSD
+  size: 3690152
+  timestamp: 1654036853710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
+  sha256: 86a1b449d27205327a5de0f81d18d9ad768e68d915b91b1d5b82be2d8f524e94
+  md5: 78a8a9f8c638df9a2db80964c97ff43f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 25476
+  timestamp: 1657175730463
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+  sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
+  md5: 0e054ab29119cf4c1f778613acf972f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 681780
+  timestamp: 1696937326924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+  sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
+  md5: b6ad839ebba536ad1c3cc58d0e2123f0
+  depends:
+  - colorama
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 143681
+  timestamp: 1679562248929
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+  sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
+  md5: fe78de10019085146f1cc6c94fdc2620
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192822
+  timestamp: 1671143999327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
+  md5: ca5fc3fbdb09b6de068a8b7a8869369f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9208
+  timestamp: 1690298120549
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
+  md5: a86e87a10e5fdff486265e0c675fb99f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57922
+  timestamp: 1690298106990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+  sha256: 8057d3d2a0acd44496de33c5b222063c3f7d06b90c74fbbda45bd18b0b324219
+  md5: 398f8db5bd8cab84b3d85a9d85fa4889
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11362
+  timestamp: 1659769459206
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+  sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
+  md5: 0d31859e0a097aedbcc1627db33b3d92
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188367
+  timestamp: 1698257883295
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+  sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
+  md5: 45ef24c486a484f079faf1dc90e4c7e9
+  depends:
+  - vs2015_runtime >=14.27.29016
+  license: Modified BSD License (3-clause)
+  license_family: BSD
+  size: 8277
+  timestamp: 1605602889180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+  sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
+  md5: 4daaceb6cfc1af6274509081d8018ef1
+  size: 2316783
+  timestamp: 1605602872095
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+  sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
+  md5: 916c16904615c7af3b5d37cb6694f45e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21084
+  timestamp: 1607347371925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+  sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
+  md5: da69e6987fcc757e83a358ceaa13f62b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73391
+  timestamp: 1614804425587
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+  sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
+  md5: 23b9f4634b2e5450be617114f62c74f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 120873
+  timestamp: 1695742300539
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+  sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
+  md5: 120f0b088290fc17bd6618fc10a2f0c4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PUBLIC-DOMAIN
+  size: 34293
+  timestamp: 1605306211299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+  sha256: a5d2a216d052105fdaad7256f23da3b29f95100d1dc0f29b6ab1f3bbc75e17a9
+  md5: a558f681ebc243f86cde2515c065b62e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48805
+  timestamp: 1675159123654
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+  sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
+  md5: c3f7871e9a33adeccee1b1e8e216918e
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 1332571
+  timestamp: 1683113347814
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+  sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
+  md5: 1ab55f8c4b5292ec360c572120bf823e
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-3.0-or-later
+  size: 9430705
+  timestamp: 1616055773485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+  sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
+  md5: 6875e0bf3828707dc9165d694c0d0a7d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18725
+  timestamp: 1672387612937
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+  sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
+  md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 148931
+  timestamp: 1666595229032
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+  sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
+  md5: 8d6a1e767775fe0eb617cd6e22edc2ff
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1871867
+  timestamp: 1681304638261

--- a/hipster_dynamics/pixi.lock
+++ b/hipster_dynamics/pixi.lock
@@ -7,663 +7,663 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.0-h8213a91_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.0-h28cd5cc_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.5.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.9.2-py39h2531618_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-5.9.7-h5867ecd_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-4.19.13-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gst-plugins-base-1.14.0-h8213a91_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gstreamer-1.14.0-h28cd5cc_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-3.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyqt-5.9.2-py39h2531618_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/qt-5.9.7-h5867ecd_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sip-4.19.13-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.17.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.8.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-3.8.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.17.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.8.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-3.8.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.17.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.8.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.17.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-3.8.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
   sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
   md5: 2cf39d906cc321896ffe3e5d33d80c5c
   depends:
@@ -676,7 +676,7 @@ packages:
   license_family: MIT
   size: 162166
   timestamp: 1644463608931
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
   sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
   md5: 2972a84e0e22ae3244bbd2f1eebcf536
   depends:
@@ -687,7 +687,7 @@ packages:
   license_family: MIT
   size: 35352
   timestamp: 1644569715988
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
   sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
   md5: a68016b4b06460def24cb69d932986f3
   depends:
@@ -696,7 +696,7 @@ packages:
   license_family: MIT
   size: 132486
   timestamp: 1695717963702
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
   sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
   md5: 2f6356a2f530314b4059c08c79a3d8bc
   depends:
@@ -706,12 +706,12 @@ packages:
   license_family: MIT
   size: 205868
   timestamp: 1681493113570
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
   sha256: 2d8e75f31f75ea5eb8b9021b4c21eb2846a254a097e06eb68e66fc36a82e1bed
   md5: ae374a11c789a55555f70b29b9eff1f9
   depends:
@@ -727,7 +727,7 @@ packages:
   license_family: BSD
   size: 14430294
   timestamp: 1658136783940
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
   sha256: f84f9caa7eb9d489fd9634419fdf766d39293a5df1104b840fa0cdc5823a5c60
   md5: 922555c0435d6b2537cf8ced534b048c
   depends:
@@ -738,7 +738,7 @@ packages:
   license_family: BSD
   size: 141903
   timestamp: 1648028958291
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
   sha256: 0bbcb6f78eac530c6a084459ffab3238647b266d0c74d695e6e6387dd119cc67
   md5: bdc971e2a9affb5125b68ad708172dab
   depends:
@@ -747,7 +747,7 @@ packages:
   license: MIT
   size: 411301
   timestamp: 1602517685375
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
   sha256: 8c2071f706c2b445dabb781f7f8f008b23a29957468ec6894f050bfb3a2d5bf4
   md5: c203ffc7bbba991c7089d4b383cfd92c
   depends:
@@ -758,14 +758,14 @@ packages:
   license_family: MIT
   size: 357797
   timestamp: 1605539534667
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
   sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
   md5: 3ef00f4c5278b688552efc259c463dc8
   license: MPL-2.0
   license_family: Other
   size: 132731
   timestamp: 1694009767372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
   sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
   md5: d5cb3d97cf5e85ffe5e94037ed8a1169
   depends:
@@ -774,7 +774,7 @@ packages:
   license_family: Other
   size: 159077
   timestamp: 1690232254640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
   sha256: 674707b9c42e65c903c9786ee5a56b4d42aa054f1e75b328db8a2c1bfa368739
   md5: 76ae217198b014b89b267cf41b8251dd
   depends:
@@ -786,7 +786,7 @@ packages:
   license_family: MIT
   size: 231920
   timestamp: 1642701209740
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
   sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
   md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
   depends:
@@ -796,7 +796,7 @@ packages:
   license_family: CC
   size: 1917831
   timestamp: 1668084545510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
   sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
   md5: 13702d3b4b744784e5bd559c7050dd6f
   depends:
@@ -806,7 +806,7 @@ packages:
   license_family: BSD
   size: 12719
   timestamp: 1671231205875
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
   sha256: 821af57c20a85b4e92268fbf65fbaec2f273da5bb21889d9643756ef6e473237
   md5: f57e0f502500ffebdbec081ef61ad1d4
   depends:
@@ -820,7 +820,7 @@ packages:
   license_family: BSD
   size: 2179774
   timestamp: 1694445209134
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
   sha256: 469debfa966d24b8372aaf909ecbe27dc6fde186f6f0d5b9e0a8427e38053364
   md5: 498d0788982ec4c5d13a44359b9c7afb
   depends:
@@ -830,7 +830,7 @@ packages:
   license: GPL2
   size: 600218
   timestamp: 1602701107852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
   sha256: 3a39a2d6f161080c706292e3bf480f62d2444b1d6d67b3d7db50458202ee31f1
   md5: 0524ffca60f845eb392bbb56d56f0ce5
   depends:
@@ -841,7 +841,7 @@ packages:
   license_family: MIT
   size: 2094615
   timestamp: 1637091869922
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
   sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
   md5: 2e6ec51066d825ef3c317abe78d6049e
   depends:
@@ -850,7 +850,7 @@ packages:
   license_family: MIT
   size: 16413
   timestamp: 1649926472708
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
   sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
   md5: b4d923222d45314856b5378cb115214d
   depends:
@@ -859,7 +859,7 @@ packages:
   license_family: BSD
   size: 26728
   timestamp: 1668714462023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
   sha256: 27cde2cf0b1e10c2315bc1384fcb56537b424f6c2c872ca4662bc971e41910da
   md5: c12e8c75f3c7c4f5867827c5dc02dc2c
   depends:
@@ -869,7 +869,7 @@ packages:
   license_family: MIT
   size: 216001
   timestamp: 1644418571578
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
   sha256: f80526def98864c9560dd3f6754d1c905edc001d18279f6e169913ee8f26a6a2
   md5: e2fda4383ff9a690a6ac174553e10414
   depends:
@@ -880,7 +880,7 @@ packages:
   license: MIT
   size: 306671
   timestamp: 1612452969808
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
   sha256: 8a121233d0b2cbb2463b67e798739ad2946f38933430a6a7fd1197cc6eab1c99
   md5: d2b24736491290a6c6d0138932111150
   depends:
@@ -890,7 +890,7 @@ packages:
   license: GPL-2.0-only and LicenseRef-FreeType
   size: 965280
   timestamp: 1635422707211
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
   sha256: 3c8ece1a7257b1d45f8fa25f46504bb709a1923d7175f2996e891366ec434b9d
   md5: 299bf4271d710651a1d71d3795580c2d
   depends:
@@ -898,7 +898,7 @@ packages:
   license: MIT
   size: 83592
   timestamp: 1603192039050
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
   sha256: bb98f022743e5df14d73db0edae49eb95a11abcc41c973fe2f30c3810bc5021e
   md5: 858d4f13f1b0e54ee8cc3dd7c67cf0de
   depends:
@@ -912,7 +912,7 @@ packages:
   license_family: LGPL
   size: 2021087
   timestamp: 1642701448286
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.0-h8213a91_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/gst-plugins-base-1.14.0-h8213a91_2.tar.bz2
   sha256: c85c664066c685b606df768d23eac08e1b824e391eb59f61a9ef608f4f46c5b6
   md5: df2e0695e2edbd91b719da5b15249c5a
   depends:
@@ -924,7 +924,7 @@ packages:
   - zlib >=1.2.11,<2.0.0a0
   size: 6651032
   timestamp: 1609866747525
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.0-h28cd5cc_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/gstreamer-1.14.0-h28cd5cc_2.tar.bz2
   sha256: dc1af8ae3b38b8d81c00b54dac851618dba87ea8d4083af84dcb60c3070039ad
   md5: 83453eb716b94c66fb64391760c0eeb1
   depends:
@@ -932,7 +932,7 @@ packages:
   - libgcc-ng >=7.3.0
   size: 4178090
   timestamp: 1609866593800
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
   sha256: 2d727f8335c59314b521b66d437ca4d51904134473ae503b7b097e239635f209
   md5: 6991e520f353d995023404f6f524d192
   depends:
@@ -949,7 +949,7 @@ packages:
   license_family: BSD
   size: 4507274
   timestamp: 1693378095165
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
   sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
   md5: 9213e0336e3a5216c989cfe52648412e
   depends:
@@ -958,7 +958,7 @@ packages:
   license: MIT
   size: 23805906
   timestamp: 1588026213084
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
   sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
   md5: 1eb52f9f45cea2fb9ce27b19f990160e
   depends:
@@ -967,7 +967,7 @@ packages:
   license_family: BSD
   size: 110793
   timestamp: 1666125606878
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
   sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
   md5: 126b3c1933b7364ff03f67455b687e99
   depends:
@@ -977,7 +977,7 @@ packages:
   license_family: APACHE
   size: 37588
   timestamp: 1678997134023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
   sha256: 1b424413f28b840fc6d4bf467f37e9e405823b1e3b899005df80152d48936d64
   md5: 4aa8bcf74c81cd3600978f791191692a
   constrains:
@@ -986,7 +986,7 @@ packages:
   license_family: Proprietary
   size: 9246735
   timestamp: 1634546760713
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
   sha256: b51b2e0dd37a74784ba19db22aded3f4c843b6fddb4a74399f65f36fc018aaa2
   md5: 0d56ab1950f952284b895ac0f78284a7
   depends:
@@ -1006,7 +1006,7 @@ packages:
   license_family: BSD
   size: 203541
   timestamp: 1671488675347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
   sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
   md5: ff47e0be879e817713ce2a9daa76e2b0
   depends:
@@ -1027,7 +1027,7 @@ packages:
   license_family: BSD
   size: 1261116
   timestamp: 1694181530670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
   sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
   md5: 5ef6c6a0d1ac79143c7359d305155167
   depends:
@@ -1037,7 +1037,7 @@ packages:
   license_family: MIT
   size: 1021637
   timestamp: 1644297140650
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
   sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
   md5: eaeb023688f781e7dd89e74310c38195
   depends:
@@ -1047,7 +1047,7 @@ packages:
   license_family: BSD
   size: 211775
   timestamp: 1666908212136
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
   sha256: 85348bfb14db4fea84078d703e766a3c978c5a592a06e41266748826dd59d8ae
   md5: 6e1c0fb5260c590f7ef5235cb3d05863
   depends:
@@ -1056,7 +1056,7 @@ packages:
   license_family: Other
   size: 279884
   timestamp: 1651065953960
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
   sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
   md5: 0d2c3c5edf671b575532d5a3e8bf15fc
   depends:
@@ -1067,7 +1067,7 @@ packages:
   license_family: MIT
   size: 131510
   timestamp: 1676558716852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
   sha256: 92bc012f9eb4ad71158cf4826fd3e125fcebff53b529276a81224acda48be547
   md5: c5fd100e3062e831cbdf33331042f627
   depends:
@@ -1083,7 +1083,7 @@ packages:
   license_family: BSD
   size: 190884
   timestamp: 1650622553813
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
   sha256: 0192bd48cd96c60dc3054d5addd8cdb4a29a218843181318371f79daec8242f8
   md5: d851b401dc13d04e6848bb36e12efc1c
   depends:
@@ -1094,7 +1094,7 @@ packages:
   license_family: BSD
   size: 91534
   timestamp: 1679906652183
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
   sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
   md5: a4beb461f0a60998a090d760b5c6c907
   depends:
@@ -1118,7 +1118,7 @@ packages:
   license_family: BSD
   size: 411564
   timestamp: 1671707702849
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
   sha256: 974df3dc76089be57b327acd6634384def84249003f58678ca1142bb274a75d9
   md5: 81b969d1a00153759b30554a1f11ddfd
   depends:
@@ -1129,7 +1129,7 @@ packages:
   license_family: BSD
   size: 92144
   timestamp: 1653292217019
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -1140,7 +1140,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
   sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
   md5: 9508af80612e4fa1b5d1abb43ca7e63c
   constrains:
@@ -1148,7 +1148,7 @@ packages:
   license: GPL-3.0-only
   size: 749072
   timestamp: 1652971360657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
   sha256: 3b4afe7665dcdb99bd4586a888b85b2e0325f8faecdd31c7780792080ee97872
   md5: 822b5201dde61bc838072dc5b670c88c
   depends:
@@ -1157,7 +1157,7 @@ packages:
   license: Custom
   size: 55183
   timestamp: 1594054267890
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
   sha256: c6fafbe73d2f93b91b6f4b65829f925f52a8f84746a57abd216b39da9ce8c494
   md5: 238f19c803a6ba7bd6dbd6989e03cbf1
   depends:
@@ -1165,7 +1165,7 @@ packages:
   license: GPL
   size: 8496776
   timestamp: 1560112207081
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
   sha256: bc3e6e79c32ff0ecea601aa108ae9cf4068f69703580e40e266ad4bcc52cff54
   md5: 9cb85601944ca7383b1769bff74b94e8
   depends:
@@ -1174,7 +1174,7 @@ packages:
   license: zlib/libpng
   size: 372914
   timestamp: 1556041895170
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -1182,13 +1182,13 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
   sha256: 43b0bd205f539583c088feb5b8d77b60c83d1df80c2a93dac9f2a1127001b2cf
   md5: 53fa39fdae936e9d07c4b2f5ef361993
   license: GPL3 with runtime exception
   size: 4246257
   timestamp: 1560112223556
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
   sha256: 711ea05b4c35bdafc762a172b01db896b17942f474c2b1a519f91370964bf9bc
   md5: b25d56d33596623a6a4a9d9baaa4f602
   depends:
@@ -1202,7 +1202,7 @@ packages:
   license: HPND
   size: 592974
   timestamp: 1653047881023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
   sha256: 4e1dce80f23551a69761ad48b2372e35f58292ec9cc0ce061312330366a1a223
   md5: fda36b99463bad87974196da2d5bed08
   depends:
@@ -1210,7 +1210,7 @@ packages:
   license: BSD 3-Clause
   size: 18725
   timestamp: 1633507857274
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
   sha256: 146dbb1e4dbccdd57819e5102a8ca00970b8e33d6c6180e8007db89b184da569
   md5: c566a384259c1d2769852c3bddd81a67
   depends:
@@ -1224,7 +1224,7 @@ packages:
   license_family: BSD
   size: 90150
   timestamp: 1645441199289
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
   sha256: cffb5a063111f7a99a99c74770b23db5dde52325e25a7a46d1903d5ff4a82c88
   md5: eeb1bd66f28bed1956ab989d6eff7ae5
   depends:
@@ -1235,14 +1235,14 @@ packages:
   license_family: BSD
   size: 889956
   timestamp: 1645089138421
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
   sha256: 5d68e69709ae10bd6c4b58b6af447ad2f2bd24955994f3ec77103d1a6bf5e1f5
   md5: 49e523de8d364b7fabc3850eccbe9bda
   depends:
   - libgcc-ng >=7.5.0
   size: 623492
   timestamp: 1652448233146
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
   sha256: 71f6c4a97014d745c58df52b4dd60ddd75a8508d54fe5b97f42bd1f31cb1c067
   md5: 686e77514ec9f1ef0a6feed374f14d37
   depends:
@@ -1254,7 +1254,7 @@ packages:
   license_family: MIT
   size: 789469
   timestamp: 1653546418059
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
   sha256: ea3355a67c5173f3944f09861043ca66eb7dbeff8f385d13528b3aabc0801d0c
   md5: 66e2aa12181bb2911485bdbe125d24c5
   depends:
@@ -1264,7 +1264,7 @@ packages:
   license: MIT
   size: 584199
   timestamp: 1654075843119
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
   sha256: 64b022d706b76c33965a250fdc8c6008443c41bff8ab27bb1df3cb70419576fd
   md5: ec4f05846aacf634df15c389235725cc
   depends:
@@ -1276,7 +1276,7 @@ packages:
   license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
   size: 1538261
   timestamp: 1646624639995
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
   sha256: 2c6a5dda7c510a961bc78e31d4232be5e8e0760c93454f5fd200c379355e0f5e
   md5: f35d4bf2fbb39e334992f6dd39f8721e
   depends:
@@ -1286,7 +1286,7 @@ packages:
   license_family: BSD
   size: 220865
   timestamp: 1627657046002
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
   sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
   md5: 421f82c8274b44660dba629134faa6af
   depends:
@@ -1296,7 +1296,7 @@ packages:
   license_family: BSD
   size: 122221
   timestamp: 1671541990505
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
   sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
   md5: feb0e452205b44ac45d9b5e55c21a3b1
   depends:
@@ -1308,7 +1308,7 @@ packages:
   license_family: BSD
   size: 22819
   timestamp: 1654597913064
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.5.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-3.5.1-py39h06a4308_1.tar.bz2
   sha256: 62fb0d06224e15528540718debebeaebbfdbd7f03106fad52a7002fb96c6b8bd
   md5: 364c1e3dddefa27741e540496c38b694
   depends:
@@ -1320,7 +1320,7 @@ packages:
   license_family: PSF
   size: 28294
   timestamp: 1647442129989
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
   sha256: dc51b316ef5dcfb82a9c0afdc40879146ae59516f6cea7db776077783dfd2d76
   md5: b0b6b57c140f026b8806051107336576
   depends:
@@ -1342,7 +1342,7 @@ packages:
   license_family: PSF
   size: 7729454
   timestamp: 1647442028622
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
   sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
   md5: c04ef34af33da4c71bcc99b7ec24d210
   depends:
@@ -1352,7 +1352,7 @@ packages:
   license_family: BSD
   size: 16391
   timestamp: 1662014553452
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
   sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
   md5: f6c734d73e6e3dbc1b62766cf18ff3e4
   depends:
@@ -1362,7 +1362,7 @@ packages:
   license_family: BSD
   size: 58153
   timestamp: 1607364912263
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
   sha256: 7c4ded8b2ef036839f988560848d2c32e1aa4627fd37a32710e42c39f5c61ac2
   md5: bd20f4410b81f327e35ffa0657961146
   depends:
@@ -1373,7 +1373,7 @@ packages:
   license_family: Proprietary
   size: 229783051
   timestamp: 1634547157986
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
   sha256: 5394f5efd53afb2c1b0abf571ce3d9cb684b6c7e255f140ba2acaa703d6113be
   md5: d3cb2bfa63e30153f5527797dcc87280
   depends:
@@ -1385,7 +1385,7 @@ packages:
   license_family: BSD
   size: 63551
   timestamp: 1626176932911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
   sha256: c244d23da2749857a993f84969fd35ffd183ab8f462986df6d33ae0f705fe034
   md5: 9b1f8ccc2488d0e04eb73211e2987483
   depends:
@@ -1399,7 +1399,7 @@ packages:
   license: BSD 3-Clause
   size: 204136
   timestamp: 1634566416657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
   sha256: f81f426f8ef306d636664bc49e7cdd70e2b4306d7c6bcb9c75fe35a45ab2087a
   md5: 77aa1d7f958d36bf227e6ff4a34d2e3d
   depends:
@@ -1413,7 +1413,7 @@ packages:
   license: BSD-3-Clause
   size: 365386
   timestamp: 1626186165897
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
   sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
   md5: 95c83d71814c504b5504df4f14548f1a
   depends:
@@ -1439,7 +1439,7 @@ packages:
   license_family: BSD
   size: 8257558
   timestamp: 1681756322140
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
   sha256: 1b92d72b083f3350359b8fb2e3b5dc846f49650c9e46a6a74354b1b7f0d42730
   md5: 996babe4314515ddd41008a53cb5d47f
   depends:
@@ -1452,7 +1452,7 @@ packages:
   license_family: BSD
   size: 98791
   timestamp: 1650290544347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
   sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
   md5: 1710a25086c8098367eb36b9d441448b
   depends:
@@ -1480,7 +1480,7 @@ packages:
   license_family: BSD
   size: 569683
   timestamp: 1668450704669
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
   sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
   md5: 385cc9e53404776782502c0fdb08820f
   depends:
@@ -1493,7 +1493,7 @@ packages:
   license_family: BSD
   size: 147046
   timestamp: 1694616899309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
   sha256: 0807371380965e421cb5f3f2a30d790fd5c41db11dbb6d318e14294c3b1741ed
   md5: fca4bd4e3891aebf4fd7daf9b6d0ccfa
   depends:
@@ -1501,7 +1501,7 @@ packages:
   license: Free software (MIT-like)
   size: 1083412
   timestamp: 1636570020698
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
   sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
   md5: bbbcbebc20a4fdcadce398d0ca04f95e
   depends:
@@ -1510,7 +1510,7 @@ packages:
   license_family: BSD
   size: 13109
   timestamp: 1672387143252
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
   sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
   md5: 248ce515640465371927d46f389ed555
   depends:
@@ -1535,7 +1535,7 @@ packages:
   license_family: BSD
   size: 594054
   timestamp: 1690985006481
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
   sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
   md5: 70db71df4ee1cdd38090c0f7b80ba61f
   depends:
@@ -1545,7 +1545,7 @@ packages:
   license_family: BSD
   size: 21944
   timestamp: 1668160644514
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
   sha256: 15a12c8bebcda45c577e61cea412d9aafaa433e39f9e91fd61bbfab66fcee3ab
   md5: 5239d8330e8bd34972fb80918dce79e7
   depends:
@@ -1561,7 +1561,7 @@ packages:
   license_family: MIT
   size: 136437
   timestamp: 1640689905588
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
   sha256: ff8d0426c7096e086db818265c3edf4a820accbfb15afae0407ca578de151fa9
   md5: d7bcf0b9ba2d85cf532059ec119d2750
   depends:
@@ -1577,7 +1577,7 @@ packages:
   license: BSD-3-Clause
   size: 9965
   timestamp: 1652801901707
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
   sha256: abfdeda143b6b667d50a82ea119043fc1469ee02f094a41a2402433ff408099e
   md5: e8dc29adc0282f4658e0e2f25ff207a2
   depends:
@@ -1592,7 +1592,7 @@ packages:
   license: BSD-3-Clause
   size: 7095882
   timestamp: 1652801886819
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
   sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
   md5: 5ad4571eba2479f77a9f849a6ae7724c
   depends:
@@ -1602,7 +1602,7 @@ packages:
   license_family: Apache
   size: 3998613
   timestamp: 1694465071784
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
   sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
   md5: 77a22ed6d0d448c5288d0f695bc9ac49
   depends:
@@ -1611,7 +1611,7 @@ packages:
   license_family: Apache
   size: 72527
   timestamp: 1693575234886
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
   sha256: e7a0abb0f00a94000876f2095f0cf531ad3803ffbd868a780b3f06816b54492c
   md5: 97ef7e1fe923d22a8e2307f3f39a92d5
   depends:
@@ -1627,7 +1627,7 @@ packages:
   license_family: BSD
   size: 13221005
   timestamp: 1650622404234
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
   sha256: 49fdb57b2ed2ce4d6bb7a2c5adec36ba59522518a41fb941f9e39a9f43750cc5
   md5: 871b65444733b7da5823ee0dc9826722
   depends:
@@ -1648,7 +1648,7 @@ packages:
   license_family: BSD
   size: 14712394
   timestamp: 1676379803902
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
   sha256: 64a732ce2661cdb6bd8f9d1484ac10afeb73082b1c2b44728d212e0117d2860e
   md5: ada303f0cf43a4e99cfa7f243b23b681
   depends:
@@ -1657,7 +1657,7 @@ packages:
   license_family: BSD
   size: 141832
   timestamp: 1684915385689
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
   sha256: 4881cc5e0d5b20335bcfba4eaf29fdc95dedf2607903aabecdacffb64d3407d4
   md5: 4bac8a874e62f41ebab8345ca6076eb6
   depends:
@@ -1667,7 +1667,7 @@ packages:
   license_family: BSD
   size: 263308
   timestamp: 1624477853289
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
   sha256: 8bcb1c67693f42a3170eb77ef4cdbb81b605fdf40816953e69a33a065c101638
   md5: b7689507fb5f879dc766aaa8a4c37351
   depends:
@@ -1686,7 +1686,7 @@ packages:
   license_family: Other
   size: 734566
   timestamp: 1646325095608
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
   sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
   md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
   depends:
@@ -1697,7 +1697,7 @@ packages:
   license_family: MIT
   size: 2674850
   timestamp: 1697548887851
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
   sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
   md5: fe56f0479dd414c846191116366262c3
   depends:
@@ -1706,7 +1706,7 @@ packages:
   license_family: MIT
   size: 31999
   timestamp: 1692205535111
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
   sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
   md5: 44d2a857d13bdf9d99aaac039a249d47
   depends:
@@ -1715,7 +1715,7 @@ packages:
   license_family: Apache
   size: 91137
   timestamp: 1659455142164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
   sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
   md5: eb899a739d9b58dd747f1f6bd52d4cf3
   depends:
@@ -1727,7 +1727,7 @@ packages:
   license_family: BSD
   size: 579771
   timestamp: 1672387338600
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
   sha256: 6973cfe0565ba3b5ad6d1de9e34848fbbadd78b507b2e23e1c079636b8f8f317
   md5: a924535045fb356e23e7a3cc8116b638
   depends:
@@ -1737,7 +1737,7 @@ packages:
   license_family: BSD
   size: 350026
   timestamp: 1612298042840
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
   sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
   md5: f36ecb722522cbe2e3737424edf1b5e1
   depends:
@@ -1749,7 +1749,7 @@ packages:
   license_family: BSD
   size: 29312
   timestamp: 1675441510984
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
   sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
   md5: 6d03295e544251e608a28c8d7c48115e
   depends:
@@ -1758,7 +1758,7 @@ packages:
   license_family: BSD
   size: 1862058
   timestamp: 1684280096752
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
   sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
   md5: 1f09617aecd6f3c2f2e20692c0759f34
   depends:
@@ -1768,7 +1768,7 @@ packages:
   license_family: Apache
   size: 94434
   timestamp: 1690223520097
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
   sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
   md5: ffceed627867508d73af1636ab5ebf42
   depends:
@@ -1777,7 +1777,7 @@ packages:
   license_family: MIT
   size: 156324
   timestamp: 1661452578573
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.9.2-py39h2531618_6.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyqt-5.9.2-py39h2531618_6.tar.bz2
   sha256: c96502aca0df082c457f31d9e6202419aa86f24e1c699c3a34d02602f7a42812
   md5: 3eda4bcc31b66fd5002817def97cd129
   depends:
@@ -1791,7 +1791,7 @@ packages:
   license_family: GPL
   size: 6010734
   timestamp: 1607697278482
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
   sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
   md5: 0e3341a4fe434167bf74b613eb6afd81
   depends:
@@ -1801,7 +1801,7 @@ packages:
   license_family: MIT
   size: 97194
   timestamp: 1636110999719
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
   sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
   md5: c5f3f7f10ad30f0945e75252615ab6e5
   depends:
@@ -1810,7 +1810,7 @@ packages:
   license_family: BSD
   size: 31331
   timestamp: 1605305847037
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
   sha256: c4b9e332a6f2b7524e8c88e2b39a2568a48e556fd9a44c30759c43611d4d023d
   md5: bb118745c9b08fc5028f45e77f371e68
   depends:
@@ -1830,7 +1830,7 @@ packages:
   license_family: PSF
   size: 24553777
   timestamp: 1654084160832
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
   sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
   md5: 0caa188a695319bdb13f53b0a2b3accc
   depends:
@@ -1839,7 +1839,7 @@ packages:
   license_family: BSD
   size: 264864
   timestamp: 1661371117920
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
   sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
   md5: bcb44ecbea441ee0d4659133d060d71f
   depends:
@@ -1848,7 +1848,7 @@ packages:
   license_family: MIT
   size: 257904
   timestamp: 1695131670290
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
   sha256: e937081facacb141dc2c9cdcced92baa9a2662e4a56100b6041df0b6b7692570
   md5: f3ac39b2349258198a9b3316636fe5d5
   depends:
@@ -1858,7 +1858,7 @@ packages:
   license_family: BSD
   size: 39972
   timestamp: 1685030752528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
   sha256: 3da9cbbd49fac566433748bd245d09d7d5fcd28b04c0397cbbf6d5bb92f5c4a5
   md5: df73a5d2f6e089d51e71e91935a82c65
   depends:
@@ -1869,7 +1869,7 @@ packages:
   license_family: MIT
   size: 183753
   timestamp: 1635775763162
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
   sha256: 26005d191bb15070aad70707ed6493f32678a67978bd3b83d4c9679cab44e717
   md5: 2dc75d5a4ccb64310939c3a72d34ae20
   depends:
@@ -1880,7 +1880,7 @@ packages:
   license_family: BSD
   size: 521583
   timestamp: 1638435042256
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-5.9.7-h5867ecd_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/qt-5.9.7-h5867ecd_1.tar.bz2
   sha256: 5881ffba2ab8ed28112e80dd3f17ced0832b75615b9f8aab6bf171575c812b88
   md5: 50da300935a335f7605d3f96fa045111
   depends:
@@ -1904,7 +1904,7 @@ packages:
   license: LGPL-3.0
   size: 90037659
   timestamp: 1544604609235
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
   sha256: 8c950c69bee969e2c66f88f0dc247b3ab75a753672a88009779d5f5dba193532
   md5: 150ac0eb929bab9dec912797bdfc7b95
   depends:
@@ -1914,7 +1914,7 @@ packages:
   license_family: GPL
   size: 433182
   timestamp: 1642022402894
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
   sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
   md5: c7de00b4ac2778c4e5a7816320d75391
   depends:
@@ -1930,7 +1930,7 @@ packages:
   license_family: Apache
   size: 94028
   timestamp: 1690400356879
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
   sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
   md5: 1581cafc84708ed9aafaaee1cbbf6065
   depends:
@@ -1939,7 +1939,7 @@ packages:
   license_family: MIT
   size: 1089416
   timestamp: 1690290900608
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-4.19.13-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sip-4.19.13-py39h295c915_0.tar.bz2
   sha256: 9f2d68b41365097a380979014b3cabf5f1f9f07e5554eb215eef4801f640922e
   md5: 3ec6ce8f2eae0969b341e5702fb029c6
   depends:
@@ -1949,7 +1949,7 @@ packages:
   license: GPL-3.0
   size: 302624
   timestamp: 1643114723175
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
   sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
   md5: e19ffbfb24b990275d24fcea2bd1699b
   depends:
@@ -1958,7 +1958,7 @@ packages:
   license_family: Apache
   size: 15702
   timestamp: 1614030498860
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
   sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
   md5: ca061ce25c0f58628643abec8d6a8244
   depends:
@@ -1967,7 +1967,7 @@ packages:
   license_family: MIT
   size: 66330
   timestamp: 1696347637947
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
   sha256: 87965b7b46d93866d31696a1045216d64f077a06b2900c356aba87e8559c6188
   md5: fa334030245135b37027a882f3c468bf
   depends:
@@ -1978,7 +1978,7 @@ packages:
   license_family: Other
   size: 1561908
   timestamp: 1655328608308
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
   sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
   md5: 0e76eab58fe488e91f0aee73f46de031
   depends:
@@ -1989,7 +1989,7 @@ packages:
   license_family: BSD
   size: 29816
   timestamp: 1671751864131
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
   sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
   md5: b413a210eca82fe867e991eed085201b
   depends:
@@ -1999,7 +1999,7 @@ packages:
   license_family: BSD
   size: 38882
   timestamp: 1668168876032
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
   sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
   md5: 5b8375e2092012db69d2123dc0c68630
   depends:
@@ -2009,7 +2009,7 @@ packages:
   license_family: BSD
   size: 3485432
   timestamp: 1654088939579
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
   sha256: b746e39272888b9cc1a2a711b7b8836f2e26f4457850e43ad18bf0765e21dc3d
   md5: 200e86f8d53aeebf4b7dcfc944fd7920
   depends:
@@ -2019,7 +2019,7 @@ packages:
   license_family: Apache
   size: 661662
   timestamp: 1606942359431
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
   sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
   md5: 67a8320961ff24e92eebb661536e5cf7
   depends:
@@ -2032,7 +2032,7 @@ packages:
   license_family: MOZILLA
   size: 123763
   timestamp: 1679561904852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
   sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
   md5: 0f0b91a158dd3692cbb7a7763b657bfe
   depends:
@@ -2041,7 +2041,7 @@ packages:
   license_family: BSD
   size: 192032
   timestamp: 1671143995098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
   md5: 8515e64a3de7581360d713fe4c0a094e
   depends:
@@ -2051,7 +2051,7 @@ packages:
   license_family: PSF
   size: 8789
   timestamp: 1690297588156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
   md5: 60170012374b2a5007842fa5870d78c5
   depends:
@@ -2060,7 +2060,7 @@ packages:
   license_family: PSF
   size: 57479
   timestamp: 1690297581658
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
   sha256: 870f20a3c006a74b291910f69c3469a409bd21437142864b29cfafeb89ca7c34
   md5: 1b2f1589e3ebc3e0c6ecb38dba93e4ae
   depends:
@@ -2075,7 +2075,7 @@ packages:
   license_family: MIT
   size: 186761
   timestamp: 1686163186447
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
   sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
   md5: f8d03a15b974fc7810d9f54ae849fc8e
   depends:
@@ -2084,7 +2084,7 @@ packages:
   license_family: BSD
   size: 20781
   timestamp: 1607365390528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
   sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
   md5: d7db5d6ce1db80eade8a082ff78bf479
   depends:
@@ -2094,7 +2094,7 @@ packages:
   license_family: BSD
   size: 71044
   timestamp: 1614804011510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
   sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
   md5: b3899f8bda32734727bd5a73df1d7d17
   depends:
@@ -2103,7 +2103,7 @@ packages:
   license_family: MIT
   size: 101520
   timestamp: 1695742037911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
   sha256: 2ce360ff98c0ca4537d70c19266b5700810196c54ce2fbaff3b94a969846ee37
   md5: 94cb94dc47405b24b1b5bd0a3275ab59
   depends:
@@ -2112,7 +2112,7 @@ packages:
   license_family: GPL2
   size: 398058
   timestamp: 1651602137803
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -2120,7 +2120,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
   sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
   md5: 567b68192c387b5fc88178425577a0fe
   depends:
@@ -2130,7 +2130,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 366479
   timestamp: 1616055552392
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
   sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
   md5: 3818a9531fe74433c3b7d5144c9a58cc
   depends:
@@ -2139,7 +2139,7 @@ packages:
   license_family: MIT
   size: 18021
   timestamp: 1672387231268
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
   sha256: 513444d83ac2405e898531492ea59f3a95641e357cc39c1048d6fffc1791a16b
   md5: 601d9449c280b9b145dc8c83b6f06119
   depends:
@@ -2148,7 +2148,7 @@ packages:
   license_family: Other
   size: 133595
   timestamp: 1650637720646
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
   sha256: 1c049c23788a00b6f38bdc801245e0e60af98718d4db4c958658bcc67ff158c7
   md5: b1737dfd2e06ad69ec5cfec341e207c6
   depends:
@@ -2161,7 +2161,7 @@ packages:
   license_family: BSD
   size: 827172
   timestamp: 1650622223170
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -2174,7 +2174,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -2184,7 +2184,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
   md5: b2aa5503875aba2f1d88cae9df9a96d5
   depends:
@@ -2193,7 +2193,7 @@ packages:
   license_family: BSD
   size: 13636
   timestamp: 1611930018941
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -2205,7 +2205,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
   sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
   md5: 544adf2677c47c9b9c891aea720678f1
   depends:
@@ -2213,7 +2213,7 @@ packages:
   license: MIT
   size: 33999
   timestamp: 1630003259346
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -2222,7 +2222,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -2231,7 +2231,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -2240,7 +2240,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -2249,7 +2249,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
   sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
   md5: 9eff1a842dbda8d1bae9a2c008b599bc
   depends:
@@ -2260,7 +2260,7 @@ packages:
   license_family: MIT
   size: 690443
   timestamp: 1625743217109
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -2268,7 +2268,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
   sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
   md5: 33624a42ee387bf9918ea98b4e7b31fc
   depends:
@@ -2278,7 +2278,7 @@ packages:
   license_family: BSD
   size: 8173
   timestamp: 1601490751973
-- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
   sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
   md5: 67857cc5e9044770d2b15f9d94a4521d
   depends:
@@ -2287,7 +2287,7 @@ packages:
   license_family: Apache
   size: 12810
   timestamp: 1600445183315
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -2296,7 +2296,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -2305,7 +2305,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -2315,7 +2315,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
   sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
   md5: e68a6f315f41a8d814d833652bf38b9b
   depends:
@@ -2323,7 +2323,7 @@ packages:
   license: MIT
   size: 13374
   timestamp: 1606932077143
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -2331,7 +2331,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -2340,7 +2340,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -2349,7 +2349,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
   sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
   md5: 2eb923cc014094f4acf7f849d67d73f8
   depends:
@@ -2359,7 +2359,7 @@ packages:
   license_family: BSD
   size: 246457
   timestamp: 1626374695070
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
   sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
   md5: 02caf3f47f1d06256068053297355740
   depends:
@@ -2368,7 +2368,7 @@ packages:
   license_family: Apache
   size: 152292
   timestamp: 1690578151230
-- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
   sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
   md5: 41db68b96e114e367c4f120a3b379e59
   depends:
@@ -2377,7 +2377,7 @@ packages:
   license_family: BSD
   size: 19391
   timestamp: 1632406728844
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -2386,7 +2386,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -2398,14 +2398,14 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
   sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
   md5: a815d3bdb160bcc71687f2dda70d3ca4
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 122218
   timestamp: 1680170368293
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -2413,7 +2413,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
   sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
   md5: 447a49f7bad119faa80d7f14aa296c95
   depends:
@@ -2426,7 +2426,7 @@ packages:
   license_family: MIT
   size: 162176
   timestamp: 1644481750133
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
   sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
   md5: 8810f48fe4a4792de0fd3520b502d08b
   depends:
@@ -2435,7 +2435,7 @@ packages:
   license_family: BSD
   size: 10019
   timestamp: 1606859473259
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
   sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
   md5: 00a446b6dfc61af223df4de29fe8ad94
   depends:
@@ -2445,7 +2445,7 @@ packages:
   license_family: MIT
   size: 34305
   timestamp: 1644569782044
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
   sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
   md5: bd92dd8bd5b9d24e632b62a075426e50
   depends:
@@ -2454,7 +2454,7 @@ packages:
   license_family: MIT
   size: 133634
   timestamp: 1695718025321
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
   sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
   md5: f8ae051b591a9027adc16de1be9748f4
   depends:
@@ -2464,12 +2464,12 @@ packages:
   license_family: MIT
   size: 206198
   timestamp: 1681493096349
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
   sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
   md5: e2f3248e2a5009a02f7b8e54f83314ef
   size: 5620
   timestamp: 1528121955725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
   sha256: 65ababd5e7812c35a97ac7d22b0ebe52c144121a3d49528b7d5c19e8453cce4a
   md5: d85c13c017a37e406f6c1e00c1ea4f4f
   depends:
@@ -2487,7 +2487,7 @@ packages:
   license_family: BSD
   size: 6480601
   timestamp: 1690546287900
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
   sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
   md5: 0d79760d544d0bd8acb4adc4ef813418
   depends:
@@ -2497,7 +2497,7 @@ packages:
   license_family: BSD
   size: 137075
   timestamp: 1657175654487
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
   sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
   md5: 31d6d04cd2388d8f19004501271b3545
   depends:
@@ -2507,7 +2507,7 @@ packages:
   license: MIT
   size: 18982
   timestamp: 1659616229395
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
   sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
   md5: caf1073dc2ca5aeb832a2877394eae12
   depends:
@@ -2516,7 +2516,7 @@ packages:
   license: MIT
   size: 18233
   timestamp: 1659616216769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
   sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
   md5: aa1ed20c38af535c8d6a955314759d7b
   depends:
@@ -2525,14 +2525,14 @@ packages:
   license: MIT
   size: 394588
   timestamp: 1659616312678
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
   sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
   md5: ce3588e31faa79f546e0fc6a36c5543c
   license: MPL-2.0
   license_family: Other
   size: 133884
   timestamp: 1694009771475
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
   sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
   md5: 21eb7f53076d0a69513cfd258f6ef63c
   depends:
@@ -2541,7 +2541,7 @@ packages:
   license_family: Other
   size: 159756
   timestamp: 1690232346868
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
   sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
   md5: a40a04d9cda1e665565bc6c832d598b6
   depends:
@@ -2552,7 +2552,7 @@ packages:
   license_family: MIT
   size: 225258
   timestamp: 1670423337502
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
   sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
   md5: b2cc5f37f7bb069d061306e7eac2a011
   depends:
@@ -2562,7 +2562,7 @@ packages:
   license_family: CC
   size: 1913396
   timestamp: 1668084575248
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
   sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
   md5: 103d8c039e342115720a84d59c119d46
   depends:
@@ -2572,7 +2572,7 @@ packages:
   license_family: BSD
   size: 13774
   timestamp: 1671231190250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
   sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
   md5: f69f09e0346172f225390d2b3b0d7873
   depends:
@@ -2583,7 +2583,7 @@ packages:
   license_family: BSD
   size: 246628
   timestamp: 1663827484947
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
   sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
   md5: cb80c7ac65b48a737654f371fe31c460
   depends:
@@ -2596,7 +2596,7 @@ packages:
   license_family: BSD
   size: 1307228
   timestamp: 1694212041712
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
   sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
   md5: 04cbe8f4bc62c34fac9d42d1124059bf
   depends:
@@ -2606,7 +2606,7 @@ packages:
   license_family: MIT
   size: 2052734
   timestamp: 1690905361158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
   sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
   md5: ef0e825982f242085574f502dfff4f6b
   depends:
@@ -2615,7 +2615,7 @@ packages:
   license_family: MIT
   size: 16594
   timestamp: 1649926538106
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
   sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
   md5: 24747a300246c016b3a7f04dabd02d4a
   depends:
@@ -2624,7 +2624,7 @@ packages:
   license_family: BSD
   size: 27709
   timestamp: 1668714497209
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -2634,14 +2634,14 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
   sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
   md5: e4a732941f74b8062c8bcbfe5c5c2b56
   license: MIT
   license_family: MIT
   size: 80252
   timestamp: 1676983220161
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.17.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.17.1-py39hecd8cb5_0.tar.bz2
   sha256: a3c61a0d72aa6adca1967b894b190cf7d32fe78b0f8c57b855fb1e99c41aa3de
   md5: ec60e644877f1e89c9ce00d487232396
   depends:
@@ -2658,7 +2658,7 @@ packages:
   license_family: BSD
   size: 4610888
   timestamp: 1693378182350
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
   sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
   md5: f3ce6fe6eb760c236e5f7d04df5faa81
   depends:
@@ -2667,7 +2667,7 @@ packages:
   license_family: MIT
   size: 28138484
   timestamp: 1692293212596
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
   sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
   md5: 6dd72c43fea25b748ec7a9f6c0407e15
   depends:
@@ -2676,7 +2676,7 @@ packages:
   license_family: BSD
   size: 111810
   timestamp: 1666125671024
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
   sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
   md5: 03cdb7e679924b329ecab8f12cb8fc67
   depends:
@@ -2686,7 +2686,7 @@ packages:
   license_family: APACHE
   size: 38813
   timestamp: 1678997212422
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
   sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
   md5: e113c4e6e758dd68faf196586bf5564d
   depends:
@@ -2696,7 +2696,7 @@ packages:
   license_family: Apache
   size: 51873
   timestamp: 1698254765815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
   sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
   md5: 78baea934985ccd9514a366cc7e80ed4
   depends:
@@ -2705,7 +2705,7 @@ packages:
   license_family: Proprietary
   size: 727499
   timestamp: 1681801225190
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
   sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
   md5: da9b63e42f281f7e77b289f4b654b83b
   depends:
@@ -2727,7 +2727,7 @@ packages:
   license_family: BSD
   size: 218436
   timestamp: 1691121840155
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
   sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
   md5: 6a7cb9b49593b29933fa2b503d533a08
   depends:
@@ -2749,7 +2749,7 @@ packages:
   license_family: BSD
   size: 1257205
   timestamp: 1694181720454
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
   sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
   md5: d861ef66f5c0a282d60b65778a9de2f3
   depends:
@@ -2759,7 +2759,7 @@ packages:
   license_family: MIT
   size: 1048450
   timestamp: 1644315332508
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
   sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
   md5: f7e603c965052deed8b789c35855a42f
   depends:
@@ -2769,14 +2769,14 @@ packages:
   license_family: BSD
   size: 213537
   timestamp: 1666908270815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
   sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
   md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
   license: IJG
   license_family: Other
   size: 278924
   timestamp: 1677849185191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
   sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
   md5: a82a17e78f725dcbd71ff8dac6db05c7
   depends:
@@ -2787,7 +2787,7 @@ packages:
   license_family: MIT
   size: 133134
   timestamp: 1676558895333
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
   sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
   md5: ee9270379a9ebdb6297e4b6849b3f7f0
   depends:
@@ -2803,7 +2803,7 @@ packages:
   license_family: BSD
   size: 195479
   timestamp: 1676329410154
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 32b898a97dca7770858ab31294238fde11ab61a84831a52f320e5ee5405a147c
   md5: 926e754b8fad288b583ef2933deae1a5
   depends:
@@ -2814,7 +2814,7 @@ packages:
   license_family: BSD
   size: 92938
   timestamp: 1679906616072
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
   sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
   md5: 7e60995b3119417213e5faedda147499
   depends:
@@ -2838,7 +2838,7 @@ packages:
   license_family: BSD
   size: 403165
   timestamp: 1671707664990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
   sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
   md5: cd470bdb28bb0e8b3535c93a3a6dad07
   depends:
@@ -2848,7 +2848,7 @@ packages:
   license_family: BSD
   size: 65431
   timestamp: 1672387389172
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -2858,7 +2858,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -2867,13 +2867,13 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
   sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
   md5: 7dba7aa5b971febb55281659843586ba
   license: MIT
   size: 65470
   timestamp: 1659616172703
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
   sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
   md5: f78a158983f0bbaba56f34b976bc6dae
   depends:
@@ -2881,7 +2881,7 @@ packages:
   license: MIT
   size: 34189
   timestamp: 1659616189313
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
   sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
   md5: 36a1d885725d3ab4d1fadc5a29f978d2
   depends:
@@ -2889,35 +2889,35 @@ packages:
   license: MIT
   size: 327737
   timestamp: 1659616202869
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
   sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
   md5: 817848d0e2b2808acdc9b3fbbf581726
   license: MIT
   license_family: MIT
   size: 133887
   timestamp: 1683716590737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
   sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
   md5: c90372428e1e4eed4fdcd790979d06b4
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1409377
   timestamp: 1650983531933
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -2926,13 +2926,13 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -2949,7 +2949,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
   sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
   md5: c0b99f8e1c7475f23b1c7b4250b06e1c
   depends:
@@ -2963,7 +2963,7 @@ packages:
   license_family: BSD
   size: 88021
   timestamp: 1694778290062
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
   sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
   md5: 46a65d1fc24013217e06aaf6d65ffcad
   constrains:
@@ -2972,7 +2972,7 @@ packages:
   license_family: BSD
   size: 425478
   timestamp: 1694776947990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
   sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
   md5: 06866415ef22d5322f9bdc9956b59c4d
   depends:
@@ -2984,7 +2984,7 @@ packages:
   license_family: MIT
   size: 678174
   timestamp: 1692970318885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
   sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
   md5: 2edc6c894d6d0321304396e9bd40df94
   depends:
@@ -2994,7 +2994,7 @@ packages:
   license_family: MIT
   size: 241774
   timestamp: 1692973618934
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 0190d3b8d2939f28aa017711cf4147c51a1139da2922cc8420a71562dd99f844
   md5: 454a7f2c4426453f17e995382a4235e4
   depends:
@@ -3004,7 +3004,7 @@ packages:
   license_family: MIT
   size: 36036
   timestamp: 1659783508187
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
   sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
   md5: 8bbd981ca0129d7beeacd3cd7623f714
   depends:
@@ -3015,7 +3015,7 @@ packages:
   license_family: Other
   size: 1491074
   timestamp: 1695058597986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
   sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
   md5: d5f58d056b4bfc67aec30c77035ba889
   depends:
@@ -3024,7 +3024,7 @@ packages:
   license_family: BSD
   size: 182491
   timestamp: 1670944720979
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
   sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
   md5: 1affd16b166571a91feae04baf5fd3da
   depends:
@@ -3034,7 +3034,7 @@ packages:
   license_family: BSD
   size: 123431
   timestamp: 1671542016019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
   sha256: e5fc51472fa0f36abd78baa5b3c9245d6627b0da11188e6a954d73f3f2bca210
   md5: df7c519447affffb594f8c56b028ed33
   depends:
@@ -3044,7 +3044,7 @@ packages:
   license_family: MIT
   size: 107035
   timestamp: 1684279974102
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
   sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
   md5: 3681ebf029211ceab26af6f5d35abf39
   depends:
@@ -3055,7 +3055,7 @@ packages:
   license_family: BSD
   size: 22254
   timestamp: 1654598220251
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.8.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-3.8.0-py39hecd8cb5_0.tar.bz2
   sha256: 40aa972e605bdc8305ebdc4b8e891ae8b65382be12d221e002ec31cfe830ac22
   md5: 07b2a24fd3dcb5cb0af22e137cd43408
   depends:
@@ -3066,7 +3066,7 @@ packages:
   license_family: PSF
   size: 8754
   timestamp: 1698692468088
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
   sha256: 2fd179efa024c92d0d71179a981a781d16c70f5d8c6305e0d678b0c7ae1275ab
   md5: addda7f015d1673f794a23fdb18a3e09
   depends:
@@ -3089,7 +3089,7 @@ packages:
   license_family: PSF
   size: 8182219
   timestamp: 1698692361219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
   sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
   md5: 6eb64ecfcd754502e271db0bb51d2cfd
   depends:
@@ -3099,7 +3099,7 @@ packages:
   license_family: BSD
   size: 17374
   timestamp: 1662014643620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 2312ee5a6343e8495802698d7181f1b619aad7479d96ee253407b324ac884417
   md5: 866960fa48a7ca335941786d4869802a
   depends:
@@ -3109,7 +3109,7 @@ packages:
   license_family: MIT
   size: 53542
   timestamp: 1659721365599
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
   sha256: 37f455814ce242eb65ff80a0402f1bd231a388e6823e6c1e65f60b705c032a2d
   md5: 4c9246c492a64729225aa5b04e12c2d1
   depends:
@@ -3118,7 +3118,7 @@ packages:
   license_family: MIT
   size: 19573
   timestamp: 1659716100178
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
   sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
   md5: 2a4d604717a647ad21af766289cbbfc3
   depends:
@@ -3127,7 +3127,7 @@ packages:
   license_family: BSD
   size: 58057
   timestamp: 1607364912348
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
   sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
   md5: 25051fe272624544652dc6d814c2943a
   depends:
@@ -3140,7 +3140,7 @@ packages:
   license_family: Proprietary
   size: 224420228
   timestamp: 1691503125614
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
   sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
   md5: 37d8cf85a63f7aa9af1624894a7d606d
   depends:
@@ -3150,7 +3150,7 @@ packages:
   license_family: BSD
   size: 48590
   timestamp: 1682969183093
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
   sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
   md5: 0b2aee6666135bbd36b46d6ac66160f7
   depends:
@@ -3163,7 +3163,7 @@ packages:
   license_family: BSD
   size: 210705
   timestamp: 1695058433223
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
   sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
   md5: e22fb55ce380d0ebd44cce3f20d5349e
   depends:
@@ -3177,7 +3177,7 @@ packages:
   license_family: BSD
   size: 296614
   timestamp: 1695060155673
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
   sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
   md5: 1a5d4004e64e3cfb7a2a297b9117c285
   depends:
@@ -3203,7 +3203,7 @@ packages:
   license_family: BSD
   size: 8213832
   timestamp: 1681756573646
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
   sha256: 2975bd1f98ca9ec7354ee378f86f8322ec90f568374776fd90e80c534fbee882
   md5: 798627089e0ccba26695a26d9cb127ec
   depends:
@@ -3216,7 +3216,7 @@ packages:
   license_family: BSD
   size: 99066
   timestamp: 1650308465824
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
   sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
   md5: e572c1264a7af20b486f64ac8c9e1f57
   depends:
@@ -3244,7 +3244,7 @@ packages:
   license_family: BSD
   size: 573356
   timestamp: 1668450732828
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
   sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
   md5: b67569a7c30af9ffa5cde6e4b52ac68b
   depends:
@@ -3257,14 +3257,14 @@ packages:
   license_family: BSD
   size: 148342
   timestamp: 1694616917184
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
   sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
   md5: 97b81f34efbe86c5220fe82eb584fd62
   depends:
@@ -3273,7 +3273,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387288528
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
   sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
   md5: d77862975a9a1cf50acb803be26e83a1
   depends:
@@ -3298,7 +3298,7 @@ packages:
   license_family: BSD
   size: 575365
   timestamp: 1690985052739
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
   sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
   md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
   depends:
@@ -3308,7 +3308,7 @@ packages:
   license_family: BSD
   size: 22858
   timestamp: 1668160618784
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
   sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
   md5: 185e9c41abb88ee59b52ec0f5f65d506
   depends:
@@ -3322,7 +3322,7 @@ packages:
   license_family: MIT
   size: 138305
   timestamp: 1696515469702
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
   sha256: 82a2dd0c2ff6e20a275e5447dd03088f79694f7bfa5055a25c54bebf31aac4ca
   md5: c157e6ab469a95b06fa822ba075978b3
   depends:
@@ -3338,7 +3338,7 @@ packages:
   license_family: BSD
   size: 10376
   timestamp: 1695831243158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
   sha256: b3a003b41cec2751210e542911e99437db0321542f6812c1b88608ef720ba7ef
   md5: 56400dfe88c427cdf1854e47666b8a99
   depends:
@@ -3353,7 +3353,7 @@ packages:
   license_family: BSD
   size: 7570900
   timestamp: 1695831208653
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
   sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
   md5: 93f5d7b66976154adeda219bea02ba45
   depends:
@@ -3363,7 +3363,7 @@ packages:
   license: BSD 2-Clause
   size: 484257
   timestamp: 1630093862501
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
   sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
   md5: 5e8713ef1215406254988163eaf34020
   depends:
@@ -3372,7 +3372,7 @@ packages:
   license_family: Apache
   size: 4965606
   timestamp: 1695323060401
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
   sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
   md5: 4154929ace2ad6ee16aea815635a6d1f
   depends:
@@ -3381,7 +3381,7 @@ packages:
   license_family: Apache
   size: 73598
   timestamp: 1693575307570
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
   sha256: aff5acedef9da91b77851e1a163b8319d72bc4152c98ac87703a2eac1e5d575b
   md5: 7df4c76aa8c52fedce5346748d56459e
   depends:
@@ -3428,7 +3428,7 @@ packages:
   license_family: BSD
   size: 13388063
   timestamp: 1697477404222
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
   sha256: 1928d1f3aa777c6fe0b279f400fa417b293527531bbdd3d918cc8e987a680f86
   md5: e8d7a163f2f9dd0f1972e126ee87b586
   depends:
@@ -3452,7 +3452,7 @@ packages:
   license_family: BSD
   size: 17076156
   timestamp: 1695146369755
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
   sha256: 914f1ec8d911083c006c4c2d3b4c0c528e79abba3ae5f1dad825bd896870270d
   md5: 949e0e4c0ce43c92eb52241892230873
   depends:
@@ -3461,7 +3461,7 @@ packages:
   license_family: BSD
   size: 142949
   timestamp: 1684915417020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
   sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
   md5: be0a90921f3bf4f0d6950fb786093de7
   depends:
@@ -3480,7 +3480,7 @@ packages:
   license_family: Other
   size: 719901
   timestamp: 1696580194417
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
   sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
   md5: 81ae9ec2d7fcf6934847bff558b619f5
   depends:
@@ -3491,7 +3491,7 @@ packages:
   license_family: MIT
   size: 2672987
   timestamp: 1697548890181
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
   sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
   md5: 1a822c206e2abddc5d6d821721af227f
   depends:
@@ -3500,7 +3500,7 @@ packages:
   license_family: MIT
   size: 33013
   timestamp: 1692205801265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
   sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
   md5: 1604d33dbdb2446c642970f8b354bedb
   depends:
@@ -3509,7 +3509,7 @@ packages:
   license_family: Apache
   size: 91266
   timestamp: 1659455269141
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
   sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
   md5: d1b3bcc35655a3123acb1fa2ad1a8511
   depends:
@@ -3521,7 +3521,7 @@ packages:
   license_family: BSD
   size: 580828
   timestamp: 1672387372015
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
   sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
   md5: 7540555d1fb192236db9a7c5c9d3601c
   depends:
@@ -3530,7 +3530,7 @@ packages:
   license_family: BSD
   size: 365765
   timestamp: 1656431373327
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
   sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
   md5: 0a73533fb6e0dc717ab906a537bc747d
   depends:
@@ -3542,7 +3542,7 @@ packages:
   license_family: BSD
   size: 30803
   timestamp: 1675441638631
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
   sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
   md5: 0a959fbad46ab38ade48dbd358002674
   depends:
@@ -3551,7 +3551,7 @@ packages:
   license_family: BSD
   size: 1864757
   timestamp: 1684280094736
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
   sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
   md5: ea24b5076ef79e4567c5a3f0cb22b470
   depends:
@@ -3561,7 +3561,7 @@ packages:
   license_family: Apache
   size: 95330
   timestamp: 1690223465114
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
   sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
   md5: bcaea6d4a47e9c874becaa700c78dcf7
   depends:
@@ -3570,7 +3570,7 @@ packages:
   license_family: MIT
   size: 157216
   timestamp: 1661452617825
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
   sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
   md5: 707110d1b49cb1864acb0bbaa103591e
   depends:
@@ -3579,7 +3579,7 @@ packages:
   license_family: MIT
   size: 95016
   timestamp: 1636111184034
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
   sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
   md5: 113a443b9c706f9f9c6187c0eaa3de27
   depends:
@@ -3588,7 +3588,7 @@ packages:
   license_family: BSD
   size: 31178
   timestamp: 1605305861851
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
   sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
   md5: 85a8d0001db70e52a479155228cb1fe0
   depends:
@@ -3607,7 +3607,7 @@ packages:
   license_family: PSF
   size: 13324979
   timestamp: 1694439878265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
   sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
   md5: 47c5e22e31ec05a7bc0ce90065a53afd
   depends:
@@ -3616,7 +3616,7 @@ packages:
   license_family: BSD
   size: 265348
   timestamp: 1661368839620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
   sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
   md5: ce9a69e1668aa1e133f2aa6d4e8d346f
   depends:
@@ -3625,7 +3625,7 @@ packages:
   license_family: MIT
   size: 254958
   timestamp: 1695131709704
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 9ee098c09f31fad7ff1856e5ce2619172eaf979997e7a427d1e05cce32c2af00
   md5: cac1d1898b69ae9646dfbf082910635d
   depends:
@@ -3635,7 +3635,7 @@ packages:
   license_family: BSD
   size: 40946
   timestamp: 1685030787453
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
   sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
   md5: 637f08b19dd8fd87347d8c44f9e3e202
   depends:
@@ -3645,7 +3645,7 @@ packages:
   license_family: MIT
   size: 170776
   timestamp: 1698096100056
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
   sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
   md5: 8ce3ac7d8a04e469b566f1b090d01140
   depends:
@@ -3656,7 +3656,7 @@ packages:
   license_family: BSD
   size: 470617
   timestamp: 1657724324011
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -3665,7 +3665,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
   sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
   md5: 6f2d41dd76a03b7f85a1ed49af1763d6
   depends:
@@ -3681,7 +3681,7 @@ packages:
   license_family: Apache
   size: 95100
   timestamp: 1690400262627
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
   md5: b0321e6f14e139fc15b1f8b4acb35d2f
   depends:
@@ -3690,7 +3690,7 @@ packages:
   license_family: MIT
   size: 1093966
   timestamp: 1690290944588
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
   sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
   md5: 62b64576a0aa5f6c3fb05f56650d25e1
   depends:
@@ -3699,7 +3699,7 @@ packages:
   license_family: Apache
   size: 15535
   timestamp: 1614030509324
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
   sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
   md5: 15b5595b31e39f08eaacbe2e502d8fb3
   depends:
@@ -3708,7 +3708,7 @@ packages:
   license_family: MIT
   size: 67292
   timestamp: 1696347733587
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
   sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
   md5: 82e4db6a498480a75d53c55bd35b6478
   depends:
@@ -3720,7 +3720,7 @@ packages:
   license_family: Other
   size: 1801397
   timestamp: 1681394807900
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -3729,7 +3729,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
   sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
   md5: 63b957927b9949ccb19da28ec4612706
   depends:
@@ -3740,7 +3740,7 @@ packages:
   license_family: BSD
   size: 30902
   timestamp: 1671751919031
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
   sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
   md5: e346257a2fa8e2cb48c762138a5d009b
   depends:
@@ -3750,7 +3750,7 @@ packages:
   license_family: BSD
   size: 39915
   timestamp: 1668168959656
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
   sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
   md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
   depends:
@@ -3759,7 +3759,7 @@ packages:
   license_family: BSD
   size: 3536231
   timestamp: 1654088937695
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
   sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
   md5: a1bbf0abfb8c45541122c0eb2feee317
   depends:
@@ -3768,7 +3768,7 @@ packages:
   license_family: Apache
   size: 680464
   timestamp: 1696937112175
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
   sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
   md5: d689f6203c0a9d04fb229c73d7e80a7a
   depends:
@@ -3781,7 +3781,7 @@ packages:
   license_family: MOZILLA
   size: 125145
   timestamp: 1679561909274
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
   md5: 8a292c1ee22489bef2e84bc3aaf4098e
   depends:
@@ -3790,7 +3790,7 @@ packages:
   license_family: BSD
   size: 193141
   timestamp: 1671143985219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
   md5: 8bf0bfffc11ad06a1c94e145941b0ad4
   depends:
@@ -3800,7 +3800,7 @@ packages:
   license_family: PSF
   size: 9651
   timestamp: 1690297655669
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
   md5: 343514a174b3485fde55a73f56398dd7
   depends:
@@ -3809,7 +3809,7 @@ packages:
   license_family: PSF
   size: 58456
   timestamp: 1690297648002
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
   sha256: 11e7401cb6805db7ce22b1f9dd6ba5b7941c92225ce440bed1da0af284bfcad4
   md5: 5c10d68fa5616cdd82ee93ef6e0f038c
   depends:
@@ -3818,7 +3818,7 @@ packages:
   license_family: MIT
   size: 11615
   timestamp: 1659769478980
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
   sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
   md5: c2242e8fd24003a74ddf37416661e06d
   depends:
@@ -3833,7 +3833,7 @@ packages:
   license_family: MIT
   size: 188757
   timestamp: 1698257668273
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
   sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
   md5: 41f445e36b6b6722a9444508eef069f8
   depends:
@@ -3842,7 +3842,7 @@ packages:
   license_family: BSD
   size: 20583
   timestamp: 1607365395045
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
   sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
   md5: 409ee46ed24267b6da6fb32d13e1f21e
   depends:
@@ -3852,7 +3852,7 @@ packages:
   license_family: BSD
   size: 70730
   timestamp: 1614804271285
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
   sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
   md5: eb74e74d8e4fd533c55eb98b7b5e83bc
   depends:
@@ -3861,7 +3861,7 @@ packages:
   license_family: MIT
   size: 102637
   timestamp: 1695742077778
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
   sha256: cb007615819fd240ea4e343835dfbda3c508a92b5b7158219d30a22d0e67b57c
   md5: bf215e781ac81e0fc433eedee330c54b
   depends:
@@ -3870,20 +3870,20 @@ packages:
   license_family: BSD
   size: 49462
   timestamp: 1675159191191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
   sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
   md5: e243baa546432c8394a8059a44a5a3e4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 419227
   timestamp: 1683113010463
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
   sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
   md5: fe4ac85ee86d3a94ea3a4ebea3779763
   depends:
@@ -3892,7 +3892,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 321797
   timestamp: 1616055526986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
   sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
   md5: bc7073d9d4c0211cc4a1207c98fb765a
   depends:
@@ -3901,14 +3901,14 @@ packages:
   license_family: MIT
   size: 19091
   timestamp: 1672387204865
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
   sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
   md5: 8e495591e369ac161857a72011c0a296
   license: Zlib
   license_family: Other
   size: 120272
   timestamp: 1666595024203
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
   sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
   md5: f1465fbd810b3746c6de6babfd4fe28a
   depends:
@@ -3920,7 +3920,7 @@ packages:
   license_family: BSD
   size: 1023573
   timestamp: 1681304595869
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
   sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
   md5: cf55cb8d7031b30c70c56fc7c782b5c7
   depends:
@@ -3933,7 +3933,7 @@ packages:
   license_family: MIT
   size: 156104
   timestamp: 1644482799136
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
   sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
   md5: 84fce327d9f0d594e86f565e5c21962e
   depends:
@@ -3942,7 +3942,7 @@ packages:
   license_family: BSD
   size: 10183
   timestamp: 1629146082730
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
   sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
   md5: 84b8b998a741b37abf5312c1c03696ef
   depends:
@@ -3952,7 +3952,7 @@ packages:
   license_family: MIT
   size: 33979
   timestamp: 1644845817952
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
   sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
   md5: 77b746931c8f31c3ae393ccb5819d43d
   depends:
@@ -3961,7 +3961,7 @@ packages:
   license_family: MIT
   size: 133628
   timestamp: 1695717890677
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
   sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
   md5: 3df6e8ba34208dea068890e5d5318cc0
   depends:
@@ -3971,12 +3971,12 @@ packages:
   license_family: MIT
   size: 206759
   timestamp: 1681493095987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
   sha256: 4edfceca9958378015a2d5ff705aecb977fa329fdd0caf51cf6a1b6b5506e5ab
   md5: 7404ddc0add9157338d7d4822ac13cb3
   depends:
@@ -3994,7 +3994,7 @@ packages:
   license_family: BSD
   size: 6462121
   timestamp: 1690546176434
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
   sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
   md5: bb55f81435cb6e11d264242274fccd1a
   depends:
@@ -4004,7 +4004,7 @@ packages:
   license_family: BSD
   size: 115947
   timestamp: 1657175645380
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
   md5: f860193e14afc7ef3f5b990a2ac003d2
   depends:
@@ -4014,7 +4014,7 @@ packages:
   license: MIT
   size: 18936
   timestamp: 1659616204016
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
   sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
   md5: ad53130f3fd1f8d3c2fcbb7496e5585d
   depends:
@@ -4023,7 +4023,7 @@ packages:
   license: MIT
   size: 18715
   timestamp: 1659616188888
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
   sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
   md5: 0982c046fb976e9f9fb19e7510187a18
   depends:
@@ -4032,14 +4032,14 @@ packages:
   license: MIT
   size: 366983
   timestamp: 1659616245272
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
   sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
   md5: 31ac2f5596cb7a44adf073c930641c54
   license: MPL-2.0
   license_family: Other
   size: 133817
   timestamp: 1694009762858
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
   sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
   md5: cf1f6c3c34a1e1b9ab22b04233d860f6
   depends:
@@ -4048,7 +4048,7 @@ packages:
   license_family: Other
   size: 159783
   timestamp: 1690232303987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
   sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
   md5: 0eb268e38b5174d471a6e87d9d6102b1
   depends:
@@ -4059,7 +4059,7 @@ packages:
   license_family: MIT
   size: 225355
   timestamp: 1670423312966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
   sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
   md5: e68c94666cd60221b575c3814c89bac0
   depends:
@@ -4069,7 +4069,7 @@ packages:
   license_family: CC
   size: 1946451
   timestamp: 1668084573824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
   sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
   md5: 1773ae2b080cdd55827e27673351551e
   depends:
@@ -4079,7 +4079,7 @@ packages:
   license_family: BSD
   size: 13646
   timestamp: 1671231171682
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
   sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
   md5: 53bfd99ad1b09164d537209cffd98161
   depends:
@@ -4090,7 +4090,7 @@ packages:
   license_family: BSD
   size: 244040
   timestamp: 1663827469853
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
   sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
   md5: b62455043c8eb2434466885b19fed2de
   depends:
@@ -4103,7 +4103,7 @@ packages:
   license_family: BSD
   size: 1399573
   timestamp: 1694211828228
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
   sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
   md5: eb3cdc0fc210838b9271512a6a1b7c85
   depends:
@@ -4113,7 +4113,7 @@ packages:
   license_family: MIT
   size: 2067708
   timestamp: 1690905319109
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
   sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
   md5: f44b80b9405410e5bde6bfe0b31d5b3f
   depends:
@@ -4122,7 +4122,7 @@ packages:
   license_family: MIT
   size: 15135
   timestamp: 1650293774207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
   sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
   md5: f87027ccce1361d0f82c0edf1a10d53b
   depends:
@@ -4131,7 +4131,7 @@ packages:
   license_family: BSD
   size: 27677
   timestamp: 1668714367519
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -4141,14 +4141,14 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
   sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
   md5: 1d0bd7e576c64c059ef781dd319ad82a
   license: MIT
   license_family: MIT
   size: 77591
   timestamp: 1676983230102
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.17.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.17.1-py39hca03da5_0.tar.bz2
   sha256: 024023fcd6a34ff71b3b558f9db00506382edef02e7ae0cf8e49846840d7deb8
   md5: 5598508e6b21861496a578c023958612
   depends:
@@ -4165,7 +4165,7 @@ packages:
   license_family: BSD
   size: 4495882
   timestamp: 1693378262537
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
   sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
   md5: 69eb3b03765627b6159ed23cdde78396
   depends:
@@ -4174,7 +4174,7 @@ packages:
   license_family: MIT
   size: 28399065
   timestamp: 1692293207812
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
   sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
   md5: 83366cbd3beb073112f4644a613b6bca
   depends:
@@ -4183,7 +4183,7 @@ packages:
   license_family: BSD
   size: 111933
   timestamp: 1666125627512
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
   sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
   md5: 647c1a2f8460ffa8c670a1915bbdb494
   depends:
@@ -4193,7 +4193,7 @@ packages:
   license_family: APACHE
   size: 38790
   timestamp: 1678997152549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
   sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
   md5: 35e541905426c686ef2ff010a0e502fd
   depends:
@@ -4203,7 +4203,7 @@ packages:
   license_family: Apache
   size: 51860
   timestamp: 1698254731870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
   sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
   md5: 187d7720aedf38759d122cccb4576f2c
   depends:
@@ -4225,7 +4225,7 @@ packages:
   license_family: BSD
   size: 219976
   timestamp: 1691121991680
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
   sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
   md5: e8e7f10741f9cfa737b310b334940441
   depends:
@@ -4247,7 +4247,7 @@ packages:
   license_family: BSD
   size: 1255894
   timestamp: 1694181494549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
   sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
   md5: ff209e75aee17af2e358b0008fbe8c88
   depends:
@@ -4257,7 +4257,7 @@ packages:
   license_family: MIT
   size: 1022945
   timestamp: 1644315931223
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
   sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
   md5: d3e78ef296b3c74910d003bd10b475d6
   depends:
@@ -4267,14 +4267,14 @@ packages:
   license_family: BSD
   size: 213972
   timestamp: 1666908195870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
   sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
   md5: 055e12390b844ea6c6e956ee08a618e8
   license: IJG
   license_family: Other
   size: 273479
   timestamp: 1677849171867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
   sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
   md5: 783e2ad3d36472648c5ccc9f3051db3c
   depends:
@@ -4285,7 +4285,7 @@ packages:
   license_family: MIT
   size: 133077
   timestamp: 1676558732505
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
   sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
   md5: 0677598f673f9729b5990316170a999d
   depends:
@@ -4301,7 +4301,7 @@ packages:
   license_family: BSD
   size: 197129
   timestamp: 1676329661580
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
   sha256: 05f9ca0fdcfdc2e217438be27fead588c843a3aadf7d034467c83216d1e5c214
   md5: 2d648b77d817ba38293c0728711ba8f5
   depends:
@@ -4312,7 +4312,7 @@ packages:
   license_family: BSD
   size: 92852
   timestamp: 1679906632236
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
   sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
   md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
   depends:
@@ -4336,7 +4336,7 @@ packages:
   license_family: BSD
   size: 401319
   timestamp: 1671707682572
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
   sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
   md5: 247558a0aecf1ef7e77a4343761353d6
   depends:
@@ -4346,7 +4346,7 @@ packages:
   license_family: BSD
   size: 64600
   timestamp: 1672387273585
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -4356,7 +4356,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -4365,13 +4365,13 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
   md5: a0f206782751dfffed0dd51302a1bf26
   license: MIT
   size: 68012
   timestamp: 1659616138077
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
   md5: 4c6667cdd061d28e9bc4e4300e4d115e
   depends:
@@ -4379,7 +4379,7 @@ packages:
   license: MIT
   size: 31173
   timestamp: 1659616155596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
   md5: 637e9430e258ddf050623ef2360184d8
   depends:
@@ -4387,28 +4387,28 @@ packages:
   license: MIT
   size: 298430
   timestamp: 1659616172209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
   sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
   md5: 55c615026c0869f8d3ba657f3bd38c43
   license: MIT
   license_family: MIT
   size: 120389
   timestamp: 1683716579036
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -4417,7 +4417,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -4428,14 +4428,14 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
   sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
   md5: a41117710dafe569c9cc4e83f6f29fe3
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1411339
   timestamp: 1650982753977
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -4446,7 +4446,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -4455,13 +4455,13 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -4478,7 +4478,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
   sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
   md5: 98d22e0124d55fae3c37c608dab1dcc9
   depends:
@@ -4492,7 +4492,7 @@ packages:
   license_family: BSD
   size: 89825
   timestamp: 1694778225280
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
   sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
   md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
   constrains:
@@ -4501,7 +4501,7 @@ packages:
   license_family: BSD
   size: 331675
   timestamp: 1694776939192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
   sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
   md5: 0ba499df6755eae5d2d23aa4ab004553
   depends:
@@ -4513,7 +4513,7 @@ packages:
   license_family: MIT
   size: 642657
   timestamp: 1692970217410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
   sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
   md5: c73101971e5ab6a8e8688239884eac81
   depends:
@@ -4523,7 +4523,7 @@ packages:
   license_family: MIT
   size: 241607
   timestamp: 1692973585084
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
   sha256: ac50f846e93e68d50bfdd5589ea8272b987243a64eba8e2e358ef311d7734001
   md5: f19270ff954a41dabbfe36ff0656935b
   depends:
@@ -4533,7 +4533,7 @@ packages:
   license_family: MIT
   size: 36040
   timestamp: 1659783399073
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -4542,7 +4542,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
   sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
   md5: 353dff9d5d996c2a260f66381b2ce3e8
   depends:
@@ -4553,7 +4553,7 @@ packages:
   license_family: Other
   size: 1470815
   timestamp: 1695058433965
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
   sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
   md5: c99006da802a97c9aae30da8c16b4820
   depends:
@@ -4562,7 +4562,7 @@ packages:
   license_family: BSD
   size: 176131
   timestamp: 1670944706815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
   sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
   md5: 60bd1e037cda86205526f77405d78129
   depends:
@@ -4572,7 +4572,7 @@ packages:
   license_family: BSD
   size: 123361
   timestamp: 1671541992772
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
   sha256: 2fd690fa3c54a40f0426874ea12e12aad2718263a75708ddd1fa6052a4ad7fb3
   md5: 81388724babfe9c32ea5cdd93633c342
   depends:
@@ -4582,7 +4582,7 @@ packages:
   license_family: MIT
   size: 107072
   timestamp: 1684280007887
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
   sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
   md5: 34dfd76da78de2eae95bbda390d746d6
   depends:
@@ -4593,7 +4593,7 @@ packages:
   license_family: BSD
   size: 23092
   timestamp: 1654598007056
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.8.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-3.8.0-py39hca03da5_0.tar.bz2
   sha256: f6d7d0f791face4d911f5907df48e093cebcd1da188ba3d3267bf858d6dcacaf
   md5: 6a55e97ce33cd40a280f538dd5437eff
   depends:
@@ -4604,7 +4604,7 @@ packages:
   license_family: PSF
   size: 8725
   timestamp: 1698692342704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
   sha256: bf0eeef3c3c713515766ab8b0dc7863413de5b4b227deede97e24d90ca342345
   md5: a7bba1857eb84fb50caea377e60d2050
   depends:
@@ -4626,7 +4626,7 @@ packages:
   license_family: PSF
   size: 8066509
   timestamp: 1698692266161
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
   sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
   md5: eb79dabbeedee7da85dfbfb145bb8a26
   depends:
@@ -4636,7 +4636,7 @@ packages:
   license_family: BSD
   size: 17342
   timestamp: 1662014601345
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
   sha256: f400ad75dd2890627dc948f3e2e6b19732d02c124723eaf22272026993a94d52
   md5: 4a4ffc7365e30b18f4443281839e2718
   depends:
@@ -4646,7 +4646,7 @@ packages:
   license_family: MIT
   size: 53505
   timestamp: 1659721313693
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
   sha256: 20fb26a7ac748ce288cf8483a837b0c33f1348ae738bcdb69cdc2763c7bbf7e1
   md5: a0aebbc6c170ebd8d4710fd70b3db503
   depends:
@@ -4655,7 +4655,7 @@ packages:
   license_family: MIT
   size: 19562
   timestamp: 1659716131839
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
   sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
   md5: 56db7bd3ff511cd839bda081523b3edd
   depends:
@@ -4664,7 +4664,7 @@ packages:
   license_family: BSD
   size: 55683
   timestamp: 1629356128780
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
   sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
   md5: 176e0dcaeb28393881bacf69941e3889
   depends:
@@ -4690,7 +4690,7 @@ packages:
   license_family: BSD
   size: 8289638
   timestamp: 1681756329011
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
   sha256: afc6f332c51a3defc69e4c4e641988c0556039b9cd42be22f3db5292c88ccf37
   md5: 2bc409c7258160a9b739d08d5ffb5998
   depends:
@@ -4703,7 +4703,7 @@ packages:
   license_family: BSD
   size: 96942
   timestamp: 1650373637069
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
   sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
   md5: 150ea9fadddf21993d3328d3e48a18b7
   depends:
@@ -4731,7 +4731,7 @@ packages:
   license_family: BSD
   size: 557688
   timestamp: 1668450759059
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
   sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
   md5: 37163b32508f9f589b3e6462a3a47546
   depends:
@@ -4744,14 +4744,14 @@ packages:
   license_family: BSD
   size: 148426
   timestamp: 1694616771736
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
   sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
   md5: 6cdf7cbc43bf40e92b056a5576bd0086
   depends:
@@ -4760,7 +4760,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387216468
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
   sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
   md5: 0f05853a139b6cda9c73e9d2707a4976
   depends:
@@ -4785,7 +4785,7 @@ packages:
   license_family: BSD
   size: 590288
   timestamp: 1690984971741
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
   sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
   md5: 7de782e4fb34bfa95ef2fc79d27d727d
   depends:
@@ -4795,7 +4795,7 @@ packages:
   license_family: BSD
   size: 22840
   timestamp: 1668160634885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
   sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
   md5: 1a7b23113372c5667dbfe45976b9cc5c
   depends:
@@ -4806,7 +4806,7 @@ packages:
   license_family: MIT
   size: 126357
   timestamp: 1696515322390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
   sha256: 3cd1161558704176560843586b1b1f9b257fd68c0ca53a2fc09e61267f47514c
   md5: dd162b2716dc9daf732240a343862d4a
   depends:
@@ -4819,7 +4819,7 @@ packages:
   license_family: BSD
   size: 10388
   timestamp: 1695830584640
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
   sha256: 5f35d8c0e1768fa3a9d2e75659cd2096bea6b4e021afea114f573e95f4943fb2
   md5: 958f78b1e2299537996f98da7a930198
   depends:
@@ -4833,7 +4833,7 @@ packages:
   license_family: BSD
   size: 6313331
   timestamp: 1695830570878
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
   sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
   md5: 371358a54bbdd307603888348d1a2c6f
   depends:
@@ -4843,7 +4843,7 @@ packages:
   license: BSD 2-Clause
   size: 412248
   timestamp: 1628861367714
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
   sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
   md5: fa15d3b44ae1360ac9b640bbd5b6923c
   depends:
@@ -4852,7 +4852,7 @@ packages:
   license_family: Apache
   size: 4746123
   timestamp: 1695322833432
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
   sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
   md5: d73db95f07a282021efdf8bc09713261
   depends:
@@ -4861,7 +4861,7 @@ packages:
   license_family: Apache
   size: 73620
   timestamp: 1693575195999
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
   sha256: 247b5e4d81b6d5d013a9c27e1f30c41fff896fed98a68ebda26b19b4062a6828
   md5: 354a1d65300b4309d53dfa648014e8fe
   depends:
@@ -4908,7 +4908,7 @@ packages:
   license_family: BSD
   size: 13257999
   timestamp: 1697478739906
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
   sha256: 4548d2a1bc58cd61e9c9f475a77bac68d9e49d4996c4c891d5ca8ba5ea7552b0
   md5: b4ed079246a55ac8f91b8f8abb713b3b
   depends:
@@ -4932,7 +4932,7 @@ packages:
   license_family: BSD
   size: 17115516
   timestamp: 1695146000246
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
   sha256: 0d64f2438be25524bbfeb8646e4fb3c18499d747398a03ed15d41b350b03e001
   md5: 6a4908a5c9f7b3f17f09ebc34b1b691c
   depends:
@@ -4941,7 +4941,7 @@ packages:
   license_family: BSD
   size: 142857
   timestamp: 1684915417403
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
   sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
   md5: 6e01c592ae3b8ff2d12cae76f2f4276b
   depends:
@@ -4960,7 +4960,7 @@ packages:
   license_family: Other
   size: 715239
   timestamp: 1696580071596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
   sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
   md5: 9fb8f460c130d56caf33c6bbe46fbe8a
   depends:
@@ -4971,7 +4971,7 @@ packages:
   license_family: MIT
   size: 2678841
   timestamp: 1697548790931
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
   sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
   md5: 390b8c3cd74281abecdbfd51476922f9
   depends:
@@ -4980,7 +4980,7 @@ packages:
   license_family: MIT
   size: 33033
   timestamp: 1692205747301
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
   sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
   md5: 7896828fb3565fefad43f980d50c8723
   depends:
@@ -4989,7 +4989,7 @@ packages:
   license_family: Apache
   size: 91190
   timestamp: 1659455206354
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
   sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
   md5: d934c74eb66d01af0f45f0881f4bab77
   depends:
@@ -5001,7 +5001,7 @@ packages:
   license_family: BSD
   size: 580588
   timestamp: 1672387390426
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
   sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
   md5: 9858166e5ffb624c8b9d281f4000d725
   depends:
@@ -5010,7 +5010,7 @@ packages:
   license_family: BSD
   size: 367167
   timestamp: 1656431368885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
   sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
   md5: 4d2b45c6be8221e6a3e44c2d5838426f
   depends:
@@ -5022,7 +5022,7 @@ packages:
   license_family: BSD
   size: 30843
   timestamp: 1675441531640
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
   sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
   md5: 02521df4e2e79f75faa9cbb3560ab1dd
   depends:
@@ -5031,7 +5031,7 @@ packages:
   license_family: BSD
   size: 1861763
   timestamp: 1684280026169
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
   sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
   md5: bdebe59bffc7adbad83fdcd9d429a5f5
   depends:
@@ -5041,7 +5041,7 @@ packages:
   license_family: Apache
   size: 95234
   timestamp: 1690223494699
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
   sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
   md5: d716e5c9b5eec45ce1df8eb52cab817a
   depends:
@@ -5050,7 +5050,7 @@ packages:
   license_family: MIT
   size: 157408
   timestamp: 1661452601692
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
   sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
   md5: 1907629863ed8e7c35ead232dae7693f
   depends:
@@ -5059,7 +5059,7 @@ packages:
   license_family: MIT
   size: 91636
   timestamp: 1628941083263
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
   sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
   md5: 847b9bddf2a86e1609c0d53bbc23ea79
   depends:
@@ -5068,7 +5068,7 @@ packages:
   license_family: BSD
   size: 27378
   timestamp: 1626781391140
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
   sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
   md5: 18aa18bd0d260605923877921d26cc74
   depends:
@@ -5087,7 +5087,7 @@ packages:
   license_family: PSF
   size: 13194025
   timestamp: 1694438901368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
   sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
   md5: 45642a99c83e7aed74d1ffab1f20145b
   depends:
@@ -5096,7 +5096,7 @@ packages:
   license_family: BSD
   size: 266647
   timestamp: 1661368655993
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
   sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
   md5: fec748525144049a2fc7f52f9755232c
   depends:
@@ -5105,7 +5105,7 @@ packages:
   license_family: MIT
   size: 257235
   timestamp: 1695131702047
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
   sha256: 960192a143672e9c1d6fe4027af448512d91eee7501e5c245c21b865cf8bf429
   md5: 76d491244218505f071ba56a308673df
   depends:
@@ -5115,7 +5115,7 @@ packages:
   license_family: BSD
   size: 40950
   timestamp: 1685030774581
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
   sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
   md5: 3445d25415998c807efbe64d3a7e03c8
   depends:
@@ -5125,7 +5125,7 @@ packages:
   license_family: MIT
   size: 167068
   timestamp: 1698096118071
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
   sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
   md5: e6e92da28e9b0e428ed4b7df417bec25
   depends:
@@ -5136,7 +5136,7 @@ packages:
   license_family: BSD
   size: 472418
   timestamp: 1657724315435
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -5145,7 +5145,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
   sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
   md5: dba22515f36d3c266de5896350813ea2
   depends:
@@ -5161,7 +5161,7 @@ packages:
   license_family: Apache
   size: 95103
   timestamp: 1690400315537
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
   sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
   md5: 3cd7eb43e285faba76faf67667e26b00
   depends:
@@ -5170,7 +5170,7 @@ packages:
   license_family: MIT
   size: 1093916
   timestamp: 1690290951258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
   sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
   md5: c5e9aef0d6895de1c927e9d796cd7cd3
   depends:
@@ -5179,7 +5179,7 @@ packages:
   license_family: Apache
   size: 15691
   timestamp: 1629145910454
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
   sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
   md5: 0f7c229e774146ffc4e29dedf75372bf
   depends:
@@ -5188,7 +5188,7 @@ packages:
   license_family: MIT
   size: 67279
   timestamp: 1696347632563
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
   sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
   md5: 2302a79a045f152e183a52a81adfba62
   depends:
@@ -5200,7 +5200,7 @@ packages:
   license_family: Other
   size: 1674163
   timestamp: 1681394762218
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
   sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
   md5: 4ae67163d55cf9df83d4027ebc38c501
   depends:
@@ -5211,7 +5211,7 @@ packages:
   license_family: BSD
   size: 30894
   timestamp: 1671751931536
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
   sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
   md5: dbb5c0cddb6661a89afee647fd3dc01e
   depends:
@@ -5221,7 +5221,7 @@ packages:
   license_family: BSD
   size: 39875
   timestamp: 1668168874870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
   sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
   md5: 667e60c8b407d73cbba40f44901f4f00
   depends:
@@ -5230,7 +5230,7 @@ packages:
   license_family: BSD
   size: 3412693
   timestamp: 1654088929697
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
   sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
   md5: 884f788a5f6a664c9b79f7a4a60362d0
   depends:
@@ -5239,7 +5239,7 @@ packages:
   license_family: Apache
   size: 680561
   timestamp: 1696937004165
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
   sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
   md5: 639a4f489af172c866c18442948e5874
   depends:
@@ -5252,7 +5252,7 @@ packages:
   license_family: MOZILLA
   size: 125170
   timestamp: 1679561942932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
   sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
   md5: e5b90eba83fddba6d7aa6072b5bf7c91
   depends:
@@ -5261,7 +5261,7 @@ packages:
   license_family: BSD
   size: 193017
   timestamp: 1671143921826
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
   md5: 644ef8830437070f60efcfcd6a987198
   depends:
@@ -5271,7 +5271,7 @@ packages:
   license_family: PSF
   size: 9670
   timestamp: 1690297532002
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
   md5: a902a833bb186a2f1a4b2b89b1195136
   depends:
@@ -5280,7 +5280,7 @@ packages:
   license_family: PSF
   size: 58466
   timestamp: 1690297524418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
   sha256: 536045a8a172c651fd306c285a6d7409775f018dac944f2124c538ccfb195e28
   md5: d4dc6cdf0812191b9ec78b35b4fdf3e0
   depends:
@@ -5289,7 +5289,7 @@ packages:
   license_family: MIT
   size: 11593
   timestamp: 1659769477205
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
   sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
   md5: f3f1d2c1028dad2f11ff950a15c99dbf
   depends:
@@ -5304,7 +5304,7 @@ packages:
   license_family: MIT
   size: 188640
   timestamp: 1698257577209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
   sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
   md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
   depends:
@@ -5313,7 +5313,7 @@ packages:
   license_family: BSD
   size: 20091
   timestamp: 1629144441130
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
   sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
   md5: 3089c63bf8f4d0423e1a287da286d83e
   depends:
@@ -5323,7 +5323,7 @@ packages:
   license_family: BSD
   size: 70923
   timestamp: 1629357115820
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
   sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
   md5: 5886b30b312445471268444f41f39dc7
   depends:
@@ -5332,7 +5332,7 @@ packages:
   license_family: MIT
   size: 102583
   timestamp: 1695741976083
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
   sha256: 105e39d3eb51b47c7244b3379c0133ab7051966664f52835453b14509215b159
   md5: ed20012c2cd99ffd04cca9929e0bc061
   depends:
@@ -5341,20 +5341,20 @@ packages:
   license_family: BSD
   size: 49775
   timestamp: 1675159079039
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
   sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
   md5: 2e75ad6a09c308268192efe03cc9ebf4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 411778
   timestamp: 1683113019715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
   sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
   md5: 30f666bf97c26587c5d2f68cc5f330ab
   depends:
@@ -5363,7 +5363,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 316901
   timestamp: 1629287855861
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
   sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
   md5: 584e591d36dcd5ba5c45404f0f7ebb2d
   depends:
@@ -5372,14 +5372,14 @@ packages:
   license_family: MIT
   size: 19076
   timestamp: 1672387153578
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
   sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
   md5: 467ae28215d1aa1c5688bc0c8a184269
   license: Zlib
   license_family: Other
   size: 103525
   timestamp: 1666595022664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
   sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
   md5: 7cfbed15f1feee1422810f7830075f53
   depends:
@@ -5391,7 +5391,7 @@ packages:
   license_family: BSD
   size: 779464
   timestamp: 1681304594848
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
   sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
   md5: ed14f9bc6e55220483f1a5a388625a08
   depends:
@@ -5404,7 +5404,7 @@ packages:
   license_family: MIT
   size: 162772
   timestamp: 1644481986085
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
   sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
   md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
   depends:
@@ -5416,7 +5416,7 @@ packages:
   license_family: MIT
   size: 39253
   timestamp: 1644551767970
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
   sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
   md5: b24d13c443a26f65a0778b475a5726bc
   depends:
@@ -5425,7 +5425,7 @@ packages:
   license_family: MIT
   size: 132830
   timestamp: 1695717959996
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
   sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
   md5: 302c3c0696e17eaa62e140e3892644ae
   depends:
@@ -5435,12 +5435,12 @@ packages:
   license_family: MIT
   size: 199723
   timestamp: 1681493196911
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
   sha256: 29e914b68f261dd564de357888d32ec1511a6fcac9477fe68797289aba4d3e75
   md5: 288585e412638a51e0288caf690d543b
   depends:
@@ -5458,7 +5458,7 @@ packages:
   license_family: BSD
   size: 6485148
   timestamp: 1690546982849
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
   sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
   md5: bf930260f679bc74227bbb18bc36ae82
   depends:
@@ -5470,7 +5470,7 @@ packages:
   license_family: BSD
   size: 119700
   timestamp: 1657176150595
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
   md5: 507dfe693ef429f466d964b599f4af21
   depends:
@@ -5482,7 +5482,7 @@ packages:
   license: MIT
   size: 18650
   timestamp: 1659616328001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
   md5: d0bf43e8df60baae3b3105aa5c42a791
   depends:
@@ -5493,7 +5493,7 @@ packages:
   license: MIT
   size: 21153
   timestamp: 1659616312367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
   sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
   md5: 7bd24bf94c24e810aecaaf84a0978e6f
   depends:
@@ -5503,14 +5503,14 @@ packages:
   license: MIT
   size: 343204
   timestamp: 1659616543542
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
   sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
   md5: 092b417c11edcbe6bb9b765ab4a55d23
   license: MPL-2.0
   license_family: Other
   size: 164999
   timestamp: 1694009822357
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
   sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
   md5: 708a750d370b9d6875651021e21c4446
   depends:
@@ -5519,7 +5519,7 @@ packages:
   license_family: Other
   size: 159322
   timestamp: 1690232335307
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
   sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
   md5: c35736da3ea26782425e78061268cf5e
   depends:
@@ -5531,7 +5531,7 @@ packages:
   license_family: MIT
   size: 228713
   timestamp: 1670423312743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
   sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
   md5: 457a4339a53c033d48ce0c72e5038d2e
   depends:
@@ -5540,7 +5540,7 @@ packages:
   license_family: BSD
   size: 30330
   timestamp: 1672387265402
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
   sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
   md5: 59ec65fd9e06b81a65cc12986c67d5da
   depends:
@@ -5550,7 +5550,7 @@ packages:
   license_family: CC
   size: 1939614
   timestamp: 1668084794027
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
   sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
   md5: 3489c1a2b73fc957b5a62cc59349e25b
   depends:
@@ -5560,7 +5560,7 @@ packages:
   license_family: BSD
   size: 13438
   timestamp: 1671231196438
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
   sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
   md5: 3492b96083c1e904cc32d26ea7f1e1d8
   depends:
@@ -5572,7 +5572,7 @@ packages:
   license_family: BSD
   size: 184280
   timestamp: 1663827558327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
   sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
   md5: f46d904bc6f220327e70474971341f52
   depends:
@@ -5587,7 +5587,7 @@ packages:
   license_family: BSD
   size: 1220835
   timestamp: 1694445639066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
   sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
   md5: 2ff4fb509788b0e47ac684ba151394d0
   depends:
@@ -5598,7 +5598,7 @@ packages:
   license_family: MIT
   size: 3289966
   timestamp: 1690907040646
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
   sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
   md5: 0f166c3e70541d8bee6e9d0cb60fb66e
   depends:
@@ -5607,7 +5607,7 @@ packages:
   license_family: MIT
   size: 16979
   timestamp: 1649926678161
-- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
   sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
   md5: ea93d413944ca6a8677eb1b284b136ae
   depends:
@@ -5616,7 +5616,7 @@ packages:
   license_family: BSD
   size: 27388
   timestamp: 1668714577678
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -5628,7 +5628,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
   sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
   md5: 9f167d3e45441bc3633c1974b1b0ce8c
   depends:
@@ -5638,7 +5638,7 @@ packages:
   license_family: MIT
   size: 88421
   timestamp: 1676983264486
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.17.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.17.1-py39haa95532_0.tar.bz2
   sha256: e4e08cbe9311b78ab893105a8f34963b46fce74c67943176cf2309e355dceb80
   md5: c68d9f0e4a10f15d15d5812093818900
   depends:
@@ -5655,7 +5655,7 @@ packages:
   license_family: BSD
   size: 4580877
   timestamp: 1693378576619
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
   sha256: 945f4521793d7d279532d1ccd5157201c5cbf64f846bfe60249d01e1b4edf295
   md5: 0accae23d095c165ac731f4a1f3ca497
   depends:
@@ -5665,7 +5665,7 @@ packages:
   license_family: MIT
   size: 37021132
   timestamp: 1692294548916
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
   sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
   md5: 30fdefd1541c789c163751291a8faa88
   depends:
@@ -5674,7 +5674,7 @@ packages:
   license_family: BSD
   size: 111448
   timestamp: 1666125667599
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
   sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
   md5: a10f07c7a3510272a296f9fed458a4ed
   depends:
@@ -5684,7 +5684,7 @@ packages:
   license_family: APACHE
   size: 38098
   timestamp: 1678997241511
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
   sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
   md5: fad9cf2023d807da8d44996e9d4399a0
   depends:
@@ -5694,7 +5694,7 @@ packages:
   license_family: Apache
   size: 51490
   timestamp: 1698254721864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
   sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
   md5: 9834848bd7c7759acf12e78d09388563
   depends:
@@ -5704,7 +5704,7 @@ packages:
   license_family: Proprietary
   size: 3891030
   timestamp: 1681801474383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
   sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
   md5: 1285c8c628bc912c54d0968574c9f4c9
   depends:
@@ -5725,7 +5725,7 @@ packages:
   license_family: BSD
   size: 217232
   timestamp: 1691122695748
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
   sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
   md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
   depends:
@@ -5746,7 +5746,7 @@ packages:
   license_family: BSD
   size: 1279433
   timestamp: 1694181820978
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
   sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
   md5: f5fcce35d3f21cdfc5893c5a7a86c651
   depends:
@@ -5756,7 +5756,7 @@ packages:
   license_family: MIT
   size: 1035394
   timestamp: 1644315567034
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
   sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
   md5: f67fe3337528e2886f1ac3ab8ac37985
   depends:
@@ -5766,7 +5766,7 @@ packages:
   license_family: BSD
   size: 213110
   timestamp: 1666908350218
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
   sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
   md5: 81f2c343dc4c65eea39c45383272068f
   depends:
@@ -5776,7 +5776,7 @@ packages:
   license_family: Other
   size: 407861
   timestamp: 1677849239400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
   sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
   md5: bd9526d38a145fe311a8aa36bc11e071
   depends:
@@ -5787,7 +5787,7 @@ packages:
   license_family: MIT
   size: 152006
   timestamp: 1676558783570
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
   sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
   md5: a00e6a62956fde3c4135464353ee8a53
   depends:
@@ -5803,7 +5803,7 @@ packages:
   license_family: BSD
   size: 229158
   timestamp: 1676330909084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
   sha256: db8335d6531b03c7bdfe789ebacc52631ac6ea4a37700bb3da1f6a53a1acd724
   md5: ebeba61994cc225ea5f4f42caa511019
   depends:
@@ -5815,7 +5815,7 @@ packages:
   license_family: BSD
   size: 116681
   timestamp: 1679906658986
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
   sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
   md5: 5efa1332f7c0a8d9638eda02170c4ce5
   depends:
@@ -5840,7 +5840,7 @@ packages:
   license_family: BSD
   size: 413653
   timestamp: 1671707957673
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
   sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
   md5: 891fe66a24d8714737b2874985ee1303
   depends:
@@ -5851,7 +5851,7 @@ packages:
   license_family: BSD
   size: 62298
   timestamp: 1672388166096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
   sha256: ef6b0347ae565dd648a2bb40bc8b0b30f2e4f8387778fefced1d581b7d5a3e16
   md5: 8ef1d5919aa55fe56ef34d9a7969dca7
   depends:
@@ -5862,7 +5862,7 @@ packages:
   license_family: MIT
   size: 861982
   timestamp: 1684424430941
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -5872,7 +5872,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
   sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
   md5: c345f51706eef530454f66b794e5e574
   depends:
@@ -5881,7 +5881,7 @@ packages:
   license: MIT
   size: 68189
   timestamp: 1659616216976
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
   md5: a7400cfb72042977bc047909ed504ce8
   depends:
@@ -5891,7 +5891,7 @@ packages:
   license: MIT
   size: 33743
   timestamp: 1659616248209
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
   md5: 6307f6854754ab5bd7c84e6998385bb1
   depends:
@@ -5901,7 +5901,7 @@ packages:
   license: MIT
   size: 733177
   timestamp: 1659616279453
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
   sha256: bb17beae8860a83d081d57273825b46bf8fe9903f3b4182ab41a7ae2c7274859
   md5: 94182f4ab8beb4eddfd8167b2e2b0380
   depends:
@@ -5913,7 +5913,7 @@ packages:
   license_family: Apache
   size: 147804
   timestamp: 1681225547009
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
   sha256: 01b84a38c9069e7b8e6fa2a07707e785df7d40b8f01d76a504e98e5a5cd58539
   md5: 22c9f7e59174c49f06e3c5c9384401ce
   depends:
@@ -5924,7 +5924,7 @@ packages:
   license_family: Apache
   size: 25699299
   timestamp: 1681225463612
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -5934,7 +5934,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
   sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
   md5: b812bc5d9c76242e2bb2ac87afe7d39b
   depends:
@@ -5944,7 +5944,7 @@ packages:
   license_family: GPL3
   size: 730280
   timestamp: 1650983734373
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -5955,7 +5955,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
   sha256: a36ea5c77075e90f47d3f5c1e2081c0c1c78c5c0a5135bf9a6448fca67bbc79d
   md5: a0a02817a7def0563d1635035c26451b
   depends:
@@ -5966,7 +5966,7 @@ packages:
   - zlib >=1.2.13,<2.0.0a0
   size: 3827890
   timestamp: 1687382140999
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -5975,7 +5975,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -5992,7 +5992,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
   sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
   md5: ba9418df9288a2f031a02fa35b774ce0
   depends:
@@ -6008,7 +6008,7 @@ packages:
   license_family: BSD
   size: 78524
   timestamp: 1694778314659
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
   sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
   md5: b1781519a200ccbfcb4a1194005aa3ef
   depends:
@@ -6020,7 +6020,7 @@ packages:
   license_family: BSD
   size: 338459
   timestamp: 1694777084290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
   sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
   md5: 6ece7f1a3248169837714d05d7f6ef0a
   depends:
@@ -6032,7 +6032,7 @@ packages:
   license_family: MIT
   size: 3513910
   timestamp: 1692971505729
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
   sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
   md5: bd7ec244935e83e850a4ff34e8e2e64f
   depends:
@@ -6043,7 +6043,7 @@ packages:
   license_family: MIT
   size: 513971
   timestamp: 1692973657152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
   sha256: e1c0e745d9ba36a80773e841d96bf514ad1ceda419e4188aad3c22782af00234
   md5: f226532e9bb308f20e874c56be6ceefb
   depends:
@@ -6053,7 +6053,7 @@ packages:
   license_family: MIT
   size: 35788
   timestamp: 1659783414586
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
   sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
   md5: fb7881e74b59262df0fa4ec981964efc
   depends:
@@ -6066,7 +6066,7 @@ packages:
   license_family: Other
   size: 1244887
   timestamp: 1695058550693
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
   sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
   md5: 6970c7f46b0164cad1d210e7a1419959
   depends:
@@ -6076,7 +6076,7 @@ packages:
   license_family: BSD
   size: 143434
   timestamp: 1670944902624
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
   sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
   md5: 1015298551c040c6d5e26eebbae12ef5
   depends:
@@ -6086,7 +6086,7 @@ packages:
   license_family: BSD
   size: 142316
   timestamp: 1671542240512
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
   sha256: ab5c246c2b271acc1cdd0b9343989c0166681536e569cdbe71618f55d34c7292
   md5: 7ce68d771cd94c9ff5efefe69d327c9a
   depends:
@@ -6096,7 +6096,7 @@ packages:
   license_family: MIT
   size: 125122
   timestamp: 1684280210213
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
   sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
   md5: 466da740fafef3d6bce114220f0be306
   depends:
@@ -6109,7 +6109,7 @@ packages:
   license_family: BSD
   size: 28510
   timestamp: 1654508162239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.8.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-3.8.0-py39haa95532_0.tar.bz2
   sha256: 3ee1e0b89c9a16ed21af80d9883d7638227028cac76ab24b5dcb4aa25dcd5536
   md5: 0ec5d4cee9f74324b4bf0a653e53681b
   depends:
@@ -6121,7 +6121,7 @@ packages:
   license_family: PSF
   size: 8485
   timestamp: 1698692858409
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
   sha256: 1687ae122ee7d8b583141fc5014b76d494841dc8083b854449e3d6e0f6bb7019
   md5: 3697ac26ee3c2d49338dd5b9c6551152
   depends:
@@ -6144,7 +6144,7 @@ packages:
   license_family: PSF
   size: 8080067
   timestamp: 1698692812610
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
   sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
   md5: a9fa43e694b25cd49b8b08a9eefd696e
   depends:
@@ -6154,7 +6154,7 @@ packages:
   license_family: BSD
   size: 18054
   timestamp: 1661915903969
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
   sha256: 8aa14047fac6ef8b326900c4bf1a960eaa7a1699c18fdf1e75a59101b610b6df
   md5: 7e1d4d4700fbea6171d30f1d5ad24226
   depends:
@@ -6164,7 +6164,7 @@ packages:
   license_family: MIT
   size: 53362
   timestamp: 1659721308586
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
   sha256: 2017814a7cc93dd51c6b7c016e3cdf8fbc32fa20f985638aaff6a6377e9ee086
   md5: a1a285c56b001c3b5c591bf21eec3149
   depends:
@@ -6173,7 +6173,7 @@ packages:
   license_family: MIT
   size: 19326
   timestamp: 1659716205153
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
   sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
   md5: 248c468abced874f0231d3cc23177c77
   depends:
@@ -6184,7 +6184,7 @@ packages:
   license_family: BSD
   size: 58488
   timestamp: 1607359497934
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
   sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
   md5: 5e763c995ff0c549f68a10bce70fede4
   depends:
@@ -6196,7 +6196,7 @@ packages:
   license_family: Proprietary
   size: 187489950
   timestamp: 1691503804820
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
   sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
   md5: dd0c2ece6a743c373c9b5a5919b4818f
   depends:
@@ -6208,7 +6208,7 @@ packages:
   license_family: BSD
   size: 49744
   timestamp: 1682975040154
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
   sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
   md5: 57cea8df7ab85f2a98f64d23afcb1f90
   depends:
@@ -6223,7 +6223,7 @@ packages:
   license_family: BSD
   size: 184956
   timestamp: 1695058491736
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
   sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
   md5: 8769cdd201d905069800488fe31574e5
   depends:
@@ -6238,7 +6238,7 @@ packages:
   license_family: BSD
   size: 256221
   timestamp: 1695060152521
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
   sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
   md5: d9781492332e6326f9fca87f3a8efacd
   depends:
@@ -6264,7 +6264,7 @@ packages:
   license_family: BSD
   size: 8135792
   timestamp: 1681756491399
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
   sha256: 2dd3178d3c570e30b9490ebabfd7bfac806afad8302d3dee0edc619805034397
   md5: bef9da0f0694c45b6aaa4e6447479eaf
   depends:
@@ -6277,7 +6277,7 @@ packages:
   license_family: BSD
   size: 118324
   timestamp: 1650290466135
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
   sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
   md5: f1d8ce412e115986c403f223b3b47d0f
   depends:
@@ -6305,7 +6305,7 @@ packages:
   license_family: BSD
   size: 596314
   timestamp: 1668451106600
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
   sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
   md5: f96bbef0985d7e66ebf00c0d55e30e23
   depends:
@@ -6318,7 +6318,7 @@ packages:
   license_family: BSD
   size: 167045
   timestamp: 1694617078743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
   sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
   md5: 6e6ba64c8dc5025aeac606404a8df36a
   depends:
@@ -6327,7 +6327,7 @@ packages:
   license_family: BSD
   size: 13786
   timestamp: 1672387480065
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
   sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
   md5: 4a7a3286484766741f627696697c362c
   depends:
@@ -6352,7 +6352,7 @@ packages:
   license_family: BSD
   size: 609425
   timestamp: 1690985686105
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
   sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
   md5: 4269a1f93882205b90d4b2ae78fc82d5
   depends:
@@ -6362,7 +6362,7 @@ packages:
   license_family: BSD
   size: 22417
   timestamp: 1668160717305
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
   sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
   md5: a18a576b7024cfd6f905c526a786a916
   depends:
@@ -6377,7 +6377,7 @@ packages:
   license_family: MIT
   size: 135285
   timestamp: 1696515698492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
   sha256: e5e11f9b42d770ee46ac24d1cdf7aa4e9c49a60a607c8c28e7729131a99eadd5
   md5: 4274d06db8a9a381c072d226d0322dc0
   depends:
@@ -6394,7 +6394,7 @@ packages:
   license_family: BSD
   size: 9835
   timestamp: 1695830845329
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
   sha256: dcaa1607ce40a0ed610dd5398e125c8e5b08e738e50b6037a8c72b49ca561ff2
   md5: d99d990a60644b97ba1ff9bb8da0e66f
   depends:
@@ -6410,7 +6410,7 @@ packages:
   license_family: BSD
   size: 6778113
   timestamp: 1695830816710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
   sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
   md5: ab07e2a27ac08afe3d0b4c0890b8486a
   depends:
@@ -6421,7 +6421,7 @@ packages:
   license: BSD 2-Clause
   size: 249316
   timestamp: 1630094024143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
   sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
   md5: 73b17037d87b5a58feb34dafc0538f7f
   depends:
@@ -6432,7 +6432,7 @@ packages:
   license_family: Apache
   size: 8058396
   timestamp: 1695324589828
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
   sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
   md5: df1d746ba8d5d6ba01ac1373b9b71e1a
   depends:
@@ -6441,7 +6441,7 @@ packages:
   license_family: Apache
   size: 73016
   timestamp: 1693575484990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
   sha256: 1994e5831fd421bd6cf85916073d4012dec53e673b672b3985efaf771f0a7bf8
   md5: c486a5b51e3227f6ea564a9dd3125e45
   depends:
@@ -6489,7 +6489,7 @@ packages:
   license_family: BSD
   size: 12629931
   timestamp: 1697479885371
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
   sha256: 0044e1cc04f3cb7c48209276c35c59c05b87e852c0ac01be468b99f3656445fb
   md5: ee81d2a2b2c558b43a48fd68c2de1dbf
   depends:
@@ -6513,7 +6513,7 @@ packages:
   license_family: BSD
   size: 17009718
   timestamp: 1695148093102
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
   sha256: 2773f47b2d745ab483cf7fcbd5b5e2f7020d45462d32d2ccd5cf232ca13c6f67
   md5: ca16cd208037bd58d2da267c338da4a4
   depends:
@@ -6522,7 +6522,7 @@ packages:
   license_family: BSD
   size: 142229
   timestamp: 1684915524241
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
   sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
   md5: 427c1450bebb632f43bbc8c83006e4cd
   depends:
@@ -6541,7 +6541,7 @@ packages:
   license_family: Other
   size: 806931
   timestamp: 1696580240310
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
   sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
   md5: 21790cd3e2b8a45c4104aff0a68330d0
   depends:
@@ -6552,7 +6552,7 @@ packages:
   license_family: MIT
   size: 3001751
   timestamp: 1697549357662
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
   sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
   md5: 56f44a1054da2d10777e375838191070
   depends:
@@ -6561,7 +6561,7 @@ packages:
   license_family: MIT
   size: 32355
   timestamp: 1692205784293
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
   sha256: bbcef9bbf4ccd051becaa7d8aa88cb5f46ff64570cc395b6a471332d8b900e11
   md5: 0daf62b71923d157544576122b0fa79d
   depends:
@@ -6570,7 +6570,7 @@ packages:
   license_family: BSD
   size: 82560
   timestamp: 1607021261834
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
   sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
   md5: 8a35ad65651086575ce55371f22feda8
   depends:
@@ -6579,7 +6579,7 @@ packages:
   license_family: Apache
   size: 91045
   timestamp: 1659455316472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
   sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
   md5: 186eb95f816a2eff80c3c7f7d964c7b0
   depends:
@@ -6591,7 +6591,7 @@ packages:
   license_family: BSD
   size: 578514
   timestamp: 1672388155359
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
   sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
   md5: 47b6cbe6ce9289e47d16900b03596a91
   depends:
@@ -6602,7 +6602,7 @@ packages:
   license_family: BSD
   size: 372807
   timestamp: 1656431445633
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
   sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
   md5: 07165c444adc7c7ccc8a345875adc5ef
   depends:
@@ -6614,7 +6614,7 @@ packages:
   license_family: BSD
   size: 48408
   timestamp: 1675450623287
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
   sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
   md5: d58e76a31e2f6e7410ba4afd7f385b0d
   depends:
@@ -6623,7 +6623,7 @@ packages:
   license_family: BSD
   size: 1877445
   timestamp: 1684280183367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
   sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
   md5: 0e5b0fe7debbf558ce97090f6b67cdae
   depends:
@@ -6633,7 +6633,7 @@ packages:
   license_family: Apache
   size: 94633
   timestamp: 1690225630423
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
   sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
   md5: 0fde797653e4ab589506121fb1e37555
   depends:
@@ -6642,7 +6642,7 @@ packages:
   license_family: MIT
   size: 157119
   timestamp: 1661452591647
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
   sha256: e70028d0250602c01feac17e60fafd371daee5d731917732b7eced4ab47b3243
   md5: 72a51c0d49711d22a39aefc04fa0c328
   depends:
@@ -6657,7 +6657,7 @@ packages:
   license_family: GPL
   size: 5007361
   timestamp: 1698781683371
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
   sha256: 6eb0c4f2e8acaa6dfaf1fb5b4b34f13d366ebf11d77e14a674a26d7fabbc7981
   md5: 9354d98a97abd4715cdf63d4a28f7645
   depends:
@@ -6668,7 +6668,7 @@ packages:
   license_family: GPL
   size: 84071
   timestamp: 1698769559444
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
   sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
   md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
   depends:
@@ -6679,7 +6679,7 @@ packages:
   license_family: MIT
   size: 92679
   timestamp: 1636093365041
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
   sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
   md5: f870859d4dc7a8d82cf3546bd9035f33
   depends:
@@ -6689,7 +6689,7 @@ packages:
   license_family: BSD
   size: 54520
   timestamp: 1605307564142
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
   sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
   md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
   depends:
@@ -6702,7 +6702,7 @@ packages:
   license_family: PSF
   size: 21172845
   timestamp: 1694442462066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
   sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
   md5: 9d99075052265ae3d718582d3b875038
   depends:
@@ -6711,7 +6711,7 @@ packages:
   license_family: BSD
   size: 269964
   timestamp: 1661376543480
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
   sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
   md5: fa9074d94236c9b768bfd2c858875b27
   depends:
@@ -6720,7 +6720,7 @@ packages:
   license_family: MIT
   size: 264836
   timestamp: 1695131770282
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
   sha256: 97243a31c39f4990c0e9d4f2307f2f7fb9421553303923bc105067ec4340bdff
   md5: 8078c5760f27398eaf1082226647d137
   depends:
@@ -6730,7 +6730,7 @@ packages:
   license_family: BSD
   size: 40145
   timestamp: 1685031143383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
   sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
   md5: 3d2841085778006c2e79f9c7300f8b9d
   depends:
@@ -6740,7 +6740,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13565975
   timestamp: 1669937633869
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
   sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
   md5: 54a4bc0724041dd173088419d6ede2af
   depends:
@@ -6752,7 +6752,7 @@ packages:
   license_family: MIT
   size: 239062
   timestamp: 1677611495106
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
   sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
   md5: f39f84115e228bad4bceaefdd637f022
   depends:
@@ -6764,7 +6764,7 @@ packages:
   license_family: MIT
   size: 158558
   timestamp: 1698096358091
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
   sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
   md5: df398a3a1668fd2a22061764e20ea91d
   depends:
@@ -6776,7 +6776,7 @@ packages:
   license_family: BSD
   size: 460913
   timestamp: 1657616061604
-- conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
   sha256: 409f9fad42cbae8d915d1703d87db6af9f951b150517daa4e1c0220cc5eb7b0f
   md5: 2b17abf94b02a6c5ba6b7623dba97ff9
   depends:
@@ -6799,7 +6799,7 @@ packages:
   license_family: LGPL
   size: 69829482
   timestamp: 1693228189080
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
   sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
   md5: 38db77ece9dc76feffb9ef7638e38258
   depends:
@@ -6815,7 +6815,7 @@ packages:
   license_family: Apache
   size: 94397
   timestamp: 1690400496655
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
   sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
   md5: 3e284ae6b48ee30c364ffdc5601610b0
   depends:
@@ -6824,7 +6824,7 @@ packages:
   license_family: MIT
   size: 1099842
   timestamp: 1690291374842
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
   sha256: ed2b75ca1bb075901550bf892aa18a46a563e512e28ad5fe1b36e7ed3c6708d0
   md5: 22779fae19f454e13656af8b737f8bd3
   depends:
@@ -6839,7 +6839,7 @@ packages:
   license_family: GPL
   size: 602624
   timestamp: 1698676202396
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
   sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
   md5: 993b3886b334bd1f49d34206f21997b4
   depends:
@@ -6848,7 +6848,7 @@ packages:
   license_family: Apache
   size: 15998
   timestamp: 1614030572433
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
   sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
   md5: 7ac9604ad7564ac0c71bff5db198656f
   depends:
@@ -6857,7 +6857,7 @@ packages:
   license_family: MIT
   size: 67012
   timestamp: 1696347795139
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
   sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
   md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
   depends:
@@ -6867,7 +6867,7 @@ packages:
   license_family: Other
   size: 1311308
   timestamp: 1681402905668
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -6877,7 +6877,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
   sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
   md5: 28b9869d8d3a839918fac4a08f38cbc2
   depends:
@@ -6888,7 +6888,7 @@ packages:
   license_family: BSD
   size: 30546
   timestamp: 1671752127904
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
   sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
   md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
   depends:
@@ -6898,7 +6898,7 @@ packages:
   license_family: BSD
   size: 39590
   timestamp: 1668168880994
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
   sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
   md5: 52cdcdb96383c010ca833a7c24b3935b
   depends:
@@ -6908,7 +6908,7 @@ packages:
   license_family: BSD
   size: 3690152
   timestamp: 1654036853710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
   sha256: 86a1b449d27205327a5de0f81d18d9ad768e68d915b91b1d5b82be2d8f524e94
   md5: 78a8a9f8c638df9a2db80964c97ff43f
   depends:
@@ -6917,7 +6917,7 @@ packages:
   license_family: MIT
   size: 25476
   timestamp: 1657175730463
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
   sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
   md5: 0e054ab29119cf4c1f778613acf972f9
   depends:
@@ -6928,7 +6928,7 @@ packages:
   license_family: Apache
   size: 681780
   timestamp: 1696937326924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
   sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
   md5: b6ad839ebba536ad1c3cc58d0e2123f0
   depends:
@@ -6942,7 +6942,7 @@ packages:
   license_family: MOZILLA
   size: 143681
   timestamp: 1679562248929
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
   sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
   md5: fe78de10019085146f1cc6c94fdc2620
   depends:
@@ -6951,7 +6951,7 @@ packages:
   license_family: BSD
   size: 192822
   timestamp: 1671143999327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
   md5: ca5fc3fbdb09b6de068a8b7a8869369f
   depends:
@@ -6961,7 +6961,7 @@ packages:
   license_family: PSF
   size: 9208
   timestamp: 1690298120549
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
   md5: a86e87a10e5fdff486265e0c675fb99f
   depends:
@@ -6970,7 +6970,7 @@ packages:
   license_family: PSF
   size: 57922
   timestamp: 1690298106990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
   sha256: 8057d3d2a0acd44496de33c5b222063c3f7d06b90c74fbbda45bd18b0b324219
   md5: 398f8db5bd8cab84b3d85a9d85fa4889
   depends:
@@ -6979,7 +6979,7 @@ packages:
   license_family: MIT
   size: 11362
   timestamp: 1659769459206
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
   sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
   md5: 0d31859e0a097aedbcc1627db33b3d92
   depends:
@@ -6994,7 +6994,7 @@ packages:
   license_family: MIT
   size: 188367
   timestamp: 1698257883295
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
   sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
   md5: 45ef24c486a484f079faf1dc90e4c7e9
   depends:
@@ -7003,12 +7003,12 @@ packages:
   license_family: BSD
   size: 8277
   timestamp: 1605602889180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
   sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
   md5: 4daaceb6cfc1af6274509081d8018ef1
   size: 2316783
   timestamp: 1605602872095
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
   sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
   md5: 916c16904615c7af3b5d37cb6694f45e
   depends:
@@ -7017,7 +7017,7 @@ packages:
   license_family: BSD
   size: 21084
   timestamp: 1607347371925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
   sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
   md5: da69e6987fcc757e83a358ceaa13f62b
   depends:
@@ -7027,7 +7027,7 @@ packages:
   license_family: BSD
   size: 73391
   timestamp: 1614804425587
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
   sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
   md5: 23b9f4634b2e5450be617114f62c74f9
   depends:
@@ -7036,7 +7036,7 @@ packages:
   license_family: MIT
   size: 120873
   timestamp: 1695742300539
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
   sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
   md5: 120f0b088290fc17bd6618fc10a2f0c4
   depends:
@@ -7044,13 +7044,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 34293
   timestamp: 1605306211299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
   sha256: a5d2a216d052105fdaad7256f23da3b29f95100d1dc0f29b6ab1f3bbc75e17a9
   md5: a558f681ebc243f86cde2515c065b62e
   depends:
@@ -7059,7 +7059,7 @@ packages:
   license_family: BSD
   size: 48805
   timestamp: 1675159123654
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
   sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
   md5: c3f7871e9a33adeccee1b1e8e216918e
   depends:
@@ -7069,7 +7069,7 @@ packages:
   license_family: GPL2
   size: 1332571
   timestamp: 1683113347814
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -7078,7 +7078,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
   sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
   md5: 1ab55f8c4b5292ec360c572120bf823e
   depends:
@@ -7088,7 +7088,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 9430705
   timestamp: 1616055773485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
   sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
   md5: 6875e0bf3828707dc9165d694c0d0a7d
   depends:
@@ -7097,7 +7097,7 @@ packages:
   license_family: MIT
   size: 18725
   timestamp: 1672387612937
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
   sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
   md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
   depends:
@@ -7107,7 +7107,7 @@ packages:
   license_family: Other
   size: 148931
   timestamp: 1666595229032
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
   sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
   md5: 8d6a1e767775fe0eb617cd6e22edc2ff
   depends:

--- a/hipster_dynamics/pixi.toml
+++ b/hipster_dynamics/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "hipster_dynamics"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/hipster_dynamics/pixi.toml
+++ b/hipster_dynamics/pixi.toml
@@ -1,0 +1,31 @@
+[workspace]
+name = "hipster_dynamics"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2017-06-28"
+maintainers = ["philippjfr"]
+categories = ["Mathematics", "Economics"]
+labels = ["holoviews", "bokeh", "matplotlib"]
+description = "The Hipster Effect - An IPython Interactive Exploration. Adapted from\nthe `original notebook <http://jakevdp.github.io/blog/2014/11/11/the-hipster-effect-interactive/>`_\nto use HoloViews by Philipp Rudiger.\n"
+no_data_ingestion = true
+
+[dependencies]
+python = "3.9.*"
+notebook = "*"
+bokeh = "<3.3"
+holoviews = "*"
+matplotlib = "*"
+numpy = "*"
+pandas = "*"
+param = "*"
+pip = "*"
+setuptools = "*"
+wheel = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks]
+notebook = "jupyter notebook hipster_dynamics.ipynb"

--- a/hipster_dynamics/pixi.toml
+++ b/hipster_dynamics/pixi.toml
@@ -20,12 +20,12 @@ matplotlib = "*"
 numpy = "*"
 pandas = "*"
 param = "*"
-pip = "*"
-setuptools = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+setuptools = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks]
 notebook = "jupyter notebook hipster_dynamics.ipynb"

--- a/iex_trading/pixi.lock
+++ b/iex_trading/pixi.lock
@@ -1,0 +1,7477 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.1.0-h3826bc1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.21.5-py39he7a7128_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.21.5-py39hf524024_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.6.2-py39had2a1c9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.4.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-0.14.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-2.4.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-0.14.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-2.4.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.16.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-0.14.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+  sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
+  md5: 613805add1c05b538ff06d217252feb7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 20810
+  timestamp: 1652859733309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+  sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
+  md5: 2cf39d906cc321896ffe3e5d33d80c5c
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162166
+  timestamp: 1644463608931
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+  sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
+  md5: 2972a84e0e22ae3244bbd2f1eebcf536
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 35352
+  timestamp: 1644569715988
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+  sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
+  md5: a68016b4b06460def24cb69d932986f3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132486
+  timestamp: 1695717963702
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+  sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
+  md5: 2f6356a2f530314b4059c08c79a3d8bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 205868
+  timestamp: 1681493113570
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+  sha256: 2d8e75f31f75ea5eb8b9021b4c21eb2846a254a097e06eb68e66fc36a82e1bed
+  md5: ae374a11c789a55555f70b29b9eff1f9
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3,<2.0a0
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14430294
+  timestamp: 1658136783940
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+  sha256: f84f9caa7eb9d489fd9634419fdf766d39293a5df1104b840fa0cdc5823a5c60
+  md5: 922555c0435d6b2537cf8ced534b048c
+  depends:
+  - libgcc-ng >=7.5.0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 141903
+  timestamp: 1648028958291
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+  sha256: 0bbcb6f78eac530c6a084459ffab3238647b266d0c74d695e6e6387dd119cc67
+  md5: bdc971e2a9affb5125b68ad708172dab
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 411301
+  timestamp: 1602517685375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+  sha256: 8c2071f706c2b445dabb781f7f8f008b23a29957468ec6894f050bfb3a2d5bf4
+  md5: c203ffc7bbba991c7089d4b383cfd92c
+  depends:
+  - cffi >=1.0.0
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 357797
+  timestamp: 1605539534667
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+  sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
+  md5: 3ef00f4c5278b688552efc259c463dc8
+  license: MPL-2.0
+  license_family: Other
+  size: 132731
+  timestamp: 1694009767372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+  sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
+  md5: d5cb3d97cf5e85ffe5e94037ed8a1169
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159077
+  timestamp: 1690232254640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+  sha256: 674707b9c42e65c903c9786ee5a56b4d42aa054f1e75b328db8a2c1bfa368739
+  md5: 76ae217198b014b89b267cf41b8251dd
+  depends:
+  - libffi >=3.3
+  - libgcc-ng >=7.5.0
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 231920
+  timestamp: 1642701209740
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
+  sha256: 762f4506c3e12b2332bd9abea3a2a1966f307b2673be7fd661dc6e316602d18b
+  md5: 4b8df5459d1762495428323753438641
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 151844
+  timestamp: 1698129872673
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
+  sha256: 4fd0207b930fbc936d4b8206117cfa9792aa19bfb320eb08aab6bba10002f9ee
+  md5: 7082a1ce8fa314cc2761d2f689c6bb9e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40456
+  timestamp: 1683040035572
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+  sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
+  md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1917831
+  timestamp: 1668084545510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+  sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
+  md5: 13702d3b4b744784e5bd559c7050dd6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12719
+  timestamp: 1671231205875
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+  sha256: 821af57c20a85b4e92268fbf65fbaec2f273da5bb21889d9643756ef6e473237
+  md5: f57e0f502500ffebdbec081ef61ad1d4
+  depends:
+  - cffi >=1.12
+  - libgcc-ng
+  - openssl >=1.1.1v,<1.1.2a
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 2179774
+  timestamp: 1694445209134
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
+  sha256: 2084ad037e4b67a158facc0d1b21d1de16df7fe758e2bf08f6e48c6b75626cb8
+  md5: 8bb8a915dda236f7a2cf790490983445
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2121644
+  timestamp: 1686782977519
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
+  sha256: 161644f5f183f5632806cb2cb31890d06a1a575bed7949fe11bc59d3d4344e9d
+  md5: 96baa11147a42b64dcaa233a1733b8ee
+  depends:
+  - colorcet
+  - dask-core
+  - datashape
+  - numba
+  - numpy <2.0a0
+  - pandas
+  - param <2.0.0a0
+  - pillow
+  - pyct
+  - python >=3.9,<3.10.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17667549
+  timestamp: 1692372404139
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
+  sha256: 80188a9729a26e36b027e673f5f30395798eb68f9fe4721f3f33b4d4d2e58285
+  md5: 686db307602cbbdc30ca7d62b765578b
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 103488
+  timestamp: 1613390248313
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+  sha256: 3a39a2d6f161080c706292e3bf480f62d2444b1d6d67b3d7db50458202ee31f1
+  md5: 0524ffca60f845eb392bbb56d56f0ce5
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2094615
+  timestamp: 1637091869922
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+  sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
+  md5: 2e6ec51066d825ef3c317abe78d6049e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16413
+  timestamp: 1649926472708
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+  sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
+  md5: b4d923222d45314856b5378cb115214d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26728
+  timestamp: 1668714462023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+  sha256: 8a121233d0b2cbb2463b67e798739ad2946f38933430a6a7fd1197cc6eab1c99
+  md5: d2b24736491290a6c6d0138932111150
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: GPL-2.0-only and LicenseRef-FreeType
+  size: 965280
+  timestamp: 1635422707211
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
+  sha256: cfef2f1f3f1aa159f87806b7fa2b65c02c0d6f9bd24ccda833b43246c5095be6
+  md5: 394ec1374a92c6fd5f772343934337e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 260575
+  timestamp: 1695734561396
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+  sha256: 3c8ece1a7257b1d45f8fa25f46504bb709a1923d7175f2996e891366ec434b9d
+  md5: 299bf4271d710651a1d71d3795580c2d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 83592
+  timestamp: 1603192039050
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.16.2-py39h06a4308_0.tar.bz2
+  sha256: 2e5fb1c82cc47f1ad7183ff2fefc18d220e83bd33f040c84d4fb041c7f7ba382
+  md5: 8d76398418d08803d4584117fc3f4260
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4477427
+  timestamp: 1686339582413
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+  sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
+  md5: 9213e0336e3a5216c989cfe52648412e
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 23805906
+  timestamp: 1588026213084
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+  sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
+  md5: 1eb52f9f45cea2fb9ce27b19f990160e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110793
+  timestamp: 1666125606878
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+  sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
+  md5: 126b3c1933b7364ff03f67455b687e99
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 37588
+  timestamp: 1678997134023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+  sha256: 1b424413f28b840fc6d4bf467f37e9e405823b1e3b899005df80152d48936d64
+  md5: 4aa8bcf74c81cd3600978f791191692a
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 9246735
+  timestamp: 1634546760713
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+  sha256: b51b2e0dd37a74784ba19db22aded3f4c843b6fddb4a74399f65f36fc018aaa2
+  md5: 0d56ab1950f952284b895ac0f78284a7
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.0
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203541
+  timestamp: 1671488675347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+  sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
+  md5: ff47e0be879e817713ce2a9daa76e2b0
+  depends:
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1261116
+  timestamp: 1694181530670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+  sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
+  md5: 5ef6c6a0d1ac79143c7359d305155167
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1021637
+  timestamp: 1644297140650
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+  sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
+  md5: eaeb023688f781e7dd89e74310c38195
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 211775
+  timestamp: 1666908212136
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+  sha256: 85348bfb14db4fea84078d703e766a3c978c5a592a06e41266748826dd59d8ae
+  md5: 6e1c0fb5260c590f7ef5235cb3d05863
+  depends:
+  - libgcc-ng >=7.5.0
+  license: IJG
+  license_family: Other
+  size: 279884
+  timestamp: 1651065953960
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+  sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
+  md5: 0d2c3c5edf671b575532d5a3e8bf15fc
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 131510
+  timestamp: 1676558716852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+  sha256: 92bc012f9eb4ad71158cf4826fd3e125fcebff53b529276a81224acda48be547
+  md5: c5fd100e3062e831cbdf33331042f627
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=22.3
+  - tornado >=6.0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 190884
+  timestamp: 1650622553813
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+  sha256: 0192bd48cd96c60dc3054d5addd8cdb4a29a218843181318371f79daec8242f8
+  md5: d851b401dc13d04e6848bb36e12efc1c
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 91534
+  timestamp: 1679906652183
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+  sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
+  md5: a4beb461f0a60998a090d760b5c6c907
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411564
+  timestamp: 1671707702849
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+  sha256: 974df3dc76089be57b327acd6634384def84249003f58678ca1142bb274a75d9
+  md5: 81b969d1a00153759b30554a1f11ddfd
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92144
+  timestamp: 1653292217019
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+  sha256: 3b4afe7665dcdb99bd4586a888b85b2e0325f8faecdd31c7780792080ee97872
+  md5: 822b5201dde61bc838072dc5b670c88c
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: Custom
+  size: 55183
+  timestamp: 1594054267890
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+  sha256: c6fafbe73d2f93b91b6f4b65829f925f52a8f84746a57abd216b39da9ce8c494
+  md5: 238f19c803a6ba7bd6dbd6989e03cbf1
+  depends:
+  - _libgcc_mutex * main
+  license: GPL
+  size: 8496776
+  timestamp: 1560112207081
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
+  sha256: 83c6fdb30a240fbaa09f5d2e2ae8f092759cb710bc3fa628ccb18934fc237b7f
+  md5: 6003e09e8cef9aca91b954abfdd0f39c
+  license: GPL
+  size: 1336385
+  timestamp: 1534628456385
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+  sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
+  md5: 3080c2813e6e1d0f8a100a38b5b3456d
+  depends:
+  - _libgcc_mutex 0.1 main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 573231
+  timestamp: 1654090775721
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.1.0-h3826bc1_1.tar.bz2
+  sha256: effad2034f13cf7f1cdc51127e3a88123ae957c13f8c95f1817dfd79b5eba779
+  md5: c261302f1b58f6b2851f856d230dc947
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - zlib
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 29798461
+  timestamp: 1647523885063
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+  sha256: bc3e6e79c32ff0ecea601aa108ae9cf4068f69703580e40e266ad4bcc52cff54
+  md5: 9cb85601944ca7383b1769bff74b94e8
+  depends:
+  - libgcc-ng >=7.3.0
+  - zlib >=1.2.11,<2.0.0a0
+  license: zlib/libpng
+  size: 372914
+  timestamp: 1556041895170
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+  sha256: 43b0bd205f539583c088feb5b8d77b60c83d1df80c2a93dac9f2a1127001b2cf
+  md5: 53fa39fdae936e9d07c4b2f5ef361993
+  license: GPL3 with runtime exception
+  size: 4246257
+  timestamp: 1560112223556
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+  sha256: 711ea05b4c35bdafc762a172b01db896b17942f474c2b1a519f91370964bf9bc
+  md5: b25d56d33596623a6a4a9d9baaa4f602
+  depends:
+  - jpeg >=9e,<10a
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libwebp-base
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  size: 592974
+  timestamp: 1653047881023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+  sha256: 146dbb1e4dbccdd57819e5102a8ca00970b8e33d6c6180e8007db89b184da569
+  md5: c566a384259c1d2769852c3bddd81a67
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9d,<10a
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 90150
+  timestamp: 1645441199289
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+  sha256: cffb5a063111f7a99a99c74770b23db5dde52325e25a7a46d1903d5ff4a82c88
+  md5: eeb1bd66f28bed1956ab989d6eff7ae5
+  depends:
+  - libgcc-ng >=7.5.0
+  constrains:
+  - libwebp 1.2.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 889956
+  timestamp: 1645089138421
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+  sha256: 71f6c4a97014d745c58df52b4dd60ddd75a8508d54fe5b97f42bd1f31cb1c067
+  md5: 686e77514ec9f1ef0a6feed374f14d37
+  depends:
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.5.0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 789469
+  timestamp: 1653546418059
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+  sha256: ea3355a67c5173f3944f09861043ca66eb7dbeff8f385d13528b3aabc0801d0c
+  md5: 66e2aa12181bb2911485bdbe125d24c5
+  depends:
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.5.0
+  - libxml2 >=2.9.14,<2.10.0a0
+  license: MIT
+  size: 584199
+  timestamp: 1654075843119
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
+  sha256: 497e0a8e555539787dd237dea5d13a0a6061db2cb50ded20daddaf08bbf267cc
+  md5: ecc0c3c465bbf6988ebbc6a38e2eeb1c
+  depends:
+  - libgcc-ng >=7.5.0
+  - libllvm11 >=11.1.0,<11.2.0a0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  - zlib
+  license: BSD-2-Clause
+  size: 2826845
+  timestamp: 1647870510956
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
+  sha256: d8cd22ac7f033507549f6a0d078cd273607cb6e8246b0383375a33941969c12c
+  md5: 78c7a3a437536ae24d2d7ce15ec400d2
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11065
+  timestamp: 1652903210940
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+  sha256: 64b022d706b76c33965a250fdc8c6008443c41bff8ab27bb1df3cb70419576fd
+  md5: ec4f05846aacf634df15c389235725cc
+  depends:
+  - libgcc-ng >=7.5.0
+  - libxml2 >=2.9.12,<2.10.0a0
+  - libxslt >=1.1.28
+  - libxslt >=1.1.34,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  size: 1538261
+  timestamp: 1646624639995
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+  sha256: 2c6a5dda7c510a961bc78e31d4232be5e8e0760c93454f5fd200c379355e0f5e
+  md5: f35d4bf2fbb39e334992f6dd39f8721e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 220865
+  timestamp: 1627657046002
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+  sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
+  md5: 421f82c8274b44660dba629134faa6af
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 122221
+  timestamp: 1671541990505
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+  sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
+  md5: feb0e452205b44ac45d9b5e55c21a3b1
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22819
+  timestamp: 1654597913064
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+  sha256: dc51b316ef5dcfb82a9c0afdc40879146ae59516f6cea7db776077783dfd2d76
+  md5: b0b6b57c140f026b8806051107336576
+  depends:
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.11.0,<3.0a0
+  - freetype >=2.3
+  - kiwisolver >=1.0.1
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - numpy >=1.19.2,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.2.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  - tk
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7729454
+  timestamp: 1647442028622
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+  sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
+  md5: c04ef34af33da4c71bcc99b7ec24d210
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16391
+  timestamp: 1662014553452
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+  sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
+  md5: f6c734d73e6e3dbc1b62766cf18ff3e4
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58153
+  timestamp: 1607364912263
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+  sha256: 7c4ded8b2ef036839f988560848d2c32e1aa4627fd37a32710e42c39f5c61ac2
+  md5: bd20f4410b81f327e35ffa0657961146
+  depends:
+  - intel-openmp 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 229783051
+  timestamp: 1634547157986
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+  sha256: 5394f5efd53afb2c1b0abf571ce3d9cb684b6c7e255f140ba2acaa703d6113be
+  md5: d3cb2bfa63e30153f5527797dcc87280
+  depends:
+  - libgcc-ng >=7.5.0
+  - mkl >=2021.2.0,<2022.0a0
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 63551
+  timestamp: 1626176932911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+  sha256: c244d23da2749857a993f84969fd35ffd183ab8f462986df6d33ae0f705fe034
+  md5: 9b1f8ccc2488d0e04eb73211e2987483
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.3.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  size: 204136
+  timestamp: 1634566416657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+  sha256: f81f426f8ef306d636664bc49e7cdd70e2b4306d7c6bcb9c75fe35a45ab2087a
+  md5: 77aa1d7f958d36bf227e6ff4a34d2e3d
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.2.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  size: 365386
+  timestamp: 1626186165897
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
+  sha256: 305313d215116fbf13a38f8a321eb635b83294871801ac63e543a59ba7de642c
+  md5: e0db8ae050bd0db74f47edc370dbc287
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 24480
+  timestamp: 1607574279743
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+  sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
+  md5: 95c83d71814c504b5504df4f14548f1a
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8257558
+  timestamp: 1681756322140
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+  sha256: 1b92d72b083f3350359b8fb2e3b5dc846f49650c9e46a6a74354b1b7f0d42730
+  md5: 996babe4314515ddd41008a53cb5d47f
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 98791
+  timestamp: 1650290544347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+  sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
+  md5: 1710a25086c8098367eb36b9d441448b
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 569683
+  timestamp: 1668450704669
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+  sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
+  md5: 385cc9e53404776782502c0fdb08820f
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147046
+  timestamp: 1694616899309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+  sha256: 0807371380965e421cb5f3f2a30d790fd5c41db11dbb6d318e14294c3b1741ed
+  md5: fca4bd4e3891aebf4fd7daf9b6d0ccfa
+  depends:
+  - libgcc-ng >=7.5.0
+  license: Free software (MIT-like)
+  size: 1083412
+  timestamp: 1636570020698
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+  sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
+  md5: bbbcbebc20a4fdcadce398d0ca04f95e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13109
+  timestamp: 1672387143252
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+  sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
+  md5: 248ce515640465371927d46f389ed555
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 594054
+  timestamp: 1690985006481
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+  sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
+  md5: 70db71df4ee1cdd38090c0f7b80ba61f
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21944
+  timestamp: 1668160644514
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
+  sha256: 30f95c6c51ee7ca01801778b1773d8ecb57fcf06e864093f27148e1298517c20
+  md5: 1c1f0821f0dd2ece64844f39edcbd03f
+  depends:
+  - _openmp_mutex >=4.5
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - llvmlite >=0.38.0,<0.39.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - tbb >=2021.5.0
+  - libgomp
+  constrains:
+  - cudatoolkit >=9.2
+  - scipy >=1.0
+  - libopenblas !=0.3.6
+  - tbb  >=2021.0
+  - numpy >=1.18,<1.22
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3982289
+  timestamp: 1648045822890
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+  sha256: 15a12c8bebcda45c577e61cea412d9aafaa433e39f9e91fd61bbfab66fcee3ab
+  md5: 5239d8330e8bd34972fb80918dce79e7
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16.6,<2.0a0
+  - packaging
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 136437
+  timestamp: 1640689905588
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.21.5-py39he7a7128_2.tar.bz2
+  sha256: 9195828a286d79621f63766a1ac1143de7b862ae17ce5e95ca0c3a5c171868a1
+  md5: 2bd04a53d17b21af64f413dc810b3d94
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.21.5 py39hf524024_2
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  size: 9728
+  timestamp: 1651566346644
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.21.5-py39hf524024_2.tar.bz2
+  sha256: dbd1301d64a55552a01d74a1928d279646a97158cad3cce7e05548b6fa112338
+  md5: e5666032c7865b4977e740e6f069e540
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.21.5 py39he7a7128_2
+  license: BSD-3-Clause
+  size: 6385715
+  timestamp: 1651566332949
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+  sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
+  md5: 5ad4571eba2479f77a9f849a6ae7724c
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: OpenSSL
+  license_family: Apache
+  size: 3998613
+  timestamp: 1694465071784
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+  sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
+  md5: 77a22ed6d0d448c5288d0f695bc9ac49
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 72527
+  timestamp: 1693575234886
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+  sha256: e7a0abb0f00a94000876f2095f0cf531ad3803ffbd868a780b3f06816b54492c
+  md5: 97ef7e1fe923d22a8e2307f3f39a92d5
+  depends:
+  - bottleneck >=1.3.1
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - numexpr >=2.7.1
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13221005
+  timestamp: 1650622404234
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+  sha256: 49fdb57b2ed2ce4d6bb7a2c5adec36ba59522518a41fb941f9e39a9f43750cc5
+  md5: 871b65444733b7da5823ee0dc9826722
+  depends:
+  - bleach
+  - bokeh >=2.4.0,<2.5.0
+  - markdown
+  - param >=1.12.0,<2.0.0a0
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - setuptools >=42
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >1.14.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14712394
+  timestamp: 1676379803902
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+  sha256: 64a732ce2661cdb6bd8f9d1484ac10afeb73082b1c2b44728d212e0117d2860e
+  md5: ada303f0cf43a4e99cfa7f243b23b681
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141832
+  timestamp: 1684915385689
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
+  sha256: 9c699bd495cbf23db7dea986deeb75183571b83adc14b3e4a36cc6cfd2a198a8
+  md5: 39ed6f683307cca54ac666b2d1f849ff
+  depends:
+  - locket
+  - python >=3.9,<3.10.0a0
+  - toolz
+  constrains:
+  - pandas >=0.19.0
+  - numpy >= 1.9.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35706
+  timestamp: 1698702632637
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+  sha256: 8bcb1c67693f42a3170eb77ef4cdbb81b605fdf40816953e69a33a065c101638
+  md5: b7689507fb5f879dc766aaa8a4c37351
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp >=0.3.0
+  - libwebp >=1.2.0,<1.3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk
+  - zlib >=1.2.11,<2.0.0a0
+  license: LicenseRef-PIL
+  license_family: Other
+  size: 734566
+  timestamp: 1646325095608
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+  sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
+  md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2674850
+  timestamp: 1697548887851
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+  sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
+  md5: fe56f0479dd414c846191116366262c3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 31999
+  timestamp: 1692205535111
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+  sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
+  md5: 44d2a857d13bdf9d99aaac039a249d47
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91137
+  timestamp: 1659455142164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+  sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
+  md5: eb899a739d9b58dd747f1f6bd52d4cf3
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 579771
+  timestamp: 1672387338600
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+  sha256: 6973cfe0565ba3b5ad6d1de9e34848fbbadd78b507b2e23e1c079636b8f8f317
+  md5: a924535045fb356e23e7a3cc8116b638
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 350026
+  timestamp: 1612298042840
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+  sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
+  md5: f36ecb722522cbe2e3737424edf1b5e1
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29312
+  timestamp: 1675441510984
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+  sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
+  md5: 6d03295e544251e608a28c8d7c48115e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1862058
+  timestamp: 1684280096752
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+  sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
+  md5: 1f09617aecd6f3c2f2e20692c0759f34
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94434
+  timestamp: 1690223520097
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+  sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
+  md5: ffceed627867508d73af1636ab5ebf42
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 156324
+  timestamp: 1661452578573
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+  sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
+  md5: 0e3341a4fe434167bf74b613eb6afd81
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 97194
+  timestamp: 1636110999719
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+  sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
+  md5: c5f3f7f10ad30f0945e75252615ab6e5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31331
+  timestamp: 1605305847037
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+  sha256: c4b9e332a6f2b7524e8c88e2b39a2568a48e556fd9a44c30759c43611d4d023d
+  md5: bb118745c9b08fc5028f45e77f371e68
+  depends:
+  - ld_impl_linux-64
+  - libffi >=3.3,<3.4.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - ncurses >=6.3,<7.0a0
+  - openssl >=1.1.1o,<1.1.2a
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.38.3,<4.0a0
+  - tk >=8.6.11,<8.7.0a0
+  - tzdata
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 24553777
+  timestamp: 1654084160832
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+  sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
+  md5: 0caa188a695319bdb13f53b0a2b3accc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264864
+  timestamp: 1661371117920
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+  sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
+  md5: bcb44ecbea441ee0d4659133d060d71f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257904
+  timestamp: 1695131670290
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+  sha256: e937081facacb141dc2c9cdcced92baa9a2662e4a56100b6041df0b6b7692570
+  md5: f3ac39b2349258198a9b3316636fe5d5
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39972
+  timestamp: 1685030752528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+  sha256: 3da9cbbd49fac566433748bd245d09d7d5fcd28b04c0397cbbf6d5bb92f5c4a5
+  md5: df73a5d2f6e089d51e71e91935a82c65
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 183753
+  timestamp: 1635775763162
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+  sha256: 26005d191bb15070aad70707ed6493f32678a67978bd3b83d4c9679cab44e717
+  md5: 2dc75d5a4ccb64310939c3a72d34ae20
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-clause
+  license_family: BSD
+  size: 521583
+  timestamp: 1638435042256
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+  sha256: 8c950c69bee969e2c66f88f0dc247b3ab75a753672a88009779d5f5dba193532
+  md5: 150ac0eb929bab9dec912797bdfc7b95
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 433182
+  timestamp: 1642022402894
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+  sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
+  md5: c7de00b4ac2778c4e5a7816320d75391
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94028
+  timestamp: 1690400356879
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.6.2-py39had2a1c9_1.tar.bz2
+  sha256: 2cf06019a66fbb0a9df571bac7f0460eb66f60d6b9c37f6a64a6dcddbe2c765f
+  md5: 5f18311a95358bb951f98a6d005a862d
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.3.0
+  - libgfortran-ng >=7,<8.0a0
+  - libstdcxx-ng >=7.3.0
+  - mkl >=2021.2.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  size: 21512828
+  timestamp: 1618856702227
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+  sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
+  md5: 1581cafc84708ed9aafaaee1cbbf6065
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1089416
+  timestamp: 1690290900608
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+  sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
+  md5: e19ffbfb24b990275d24fcea2bd1699b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15702
+  timestamp: 1614030498860
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+  sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
+  md5: ca061ce25c0f58628643abec8d6a8244
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 66330
+  timestamp: 1696347637947
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+  sha256: 87965b7b46d93866d31696a1045216d64f077a06b2900c356aba87e8559c6188
+  md5: fa334030245135b37027a882f3c468bf
+  depends:
+  - libgcc-ng >=7.5.0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: blessing
+  license_family: Other
+  size: 1561908
+  timestamp: 1655328608308
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
+  sha256: d4c0f3e57d8df6042151e65a706f8cd76c9325a47548f4ca3c3516e352dd8ca3
+  md5: 1decb9dd0e7bcee086d83b8b4ab8c8eb
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: Apache-2.0
+  size: 171277
+  timestamp: 1641830509786
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+  sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
+  md5: 0e76eab58fe488e91f0aee73f46de031
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29816
+  timestamp: 1671751864131
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+  sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
+  md5: b413a210eca82fe867e991eed085201b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38882
+  timestamp: 1668168876032
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+  sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
+  md5: 5b8375e2092012db69d2123dc0c68630
+  depends:
+  - libgcc-ng >=7.5.0
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3485432
+  timestamp: 1654088939579
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
+  sha256: 57983e3eb698a3b08b570d5f398d9550cf50b9bf54b2b4728c731ecbc0c89138
+  md5: 3ce956b1e1a7f77af6e6127dca987b95
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101246
+  timestamp: 1667464172523
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+  sha256: b746e39272888b9cc1a2a711b7b8836f2e26f4457850e43ad18bf0765e21dc3d
+  md5: 200e86f8d53aeebf4b7dcfc944fd7920
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 661662
+  timestamp: 1606942359431
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+  sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
+  md5: 67a8320961ff24e92eebb661536e5cf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - requests
+  - slack-sdk
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 123763
+  timestamp: 1679561904852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+  sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
+  md5: 0f0b91a158dd3692cbb7a7763b657bfe
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192032
+  timestamp: 1671143995098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
+  md5: 8515e64a3de7581360d713fe4c0a094e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8789
+  timestamp: 1690297588156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
+  md5: 60170012374b2a5007842fa5870d78c5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57479
+  timestamp: 1690297581658
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+  sha256: 870f20a3c006a74b291910f69c3469a409bd21437142864b29cfafeb89ca7c34
+  md5: 1b2f1589e3ebc3e0c6ecb38dba93e4ae
+  depends:
+  - brotlipy >=0.6.0
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 186761
+  timestamp: 1686163186447
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+  sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
+  md5: f8d03a15b974fc7810d9f54ae849fc8e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20781
+  timestamp: 1607365390528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+  sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
+  md5: d7db5d6ce1db80eade8a082ff78bf479
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 71044
+  timestamp: 1614804011510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+  sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
+  md5: b3899f8bda32734727bd5a73df1d7d17
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 101520
+  timestamp: 1695742037911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
+  sha256: d88bdc49a883a944cf1562ebb0a30d0451e28ab05521fc882615e357b105f414
+  md5: c150cf16071597fa3977fb81ebb83760
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1787638
+  timestamp: 1689041557651
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+  sha256: 2ce360ff98c0ca4537d70c19266b5700810196c54ce2fbaff3b94a969846ee37
+  md5: 94cb94dc47405b24b1b5bd0a3275ab59
+  depends:
+  - libgcc-ng >=7.5.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 398058
+  timestamp: 1651602137803
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+  sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
+  md5: 567b68192c387b5fc88178425577a0fe
+  depends:
+  - libgcc-ng >=7.3.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=7.3.0
+  license: LGPL-3.0-or-later
+  size: 366479
+  timestamp: 1616055552392
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+  sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
+  md5: 3818a9531fe74433c3b7d5144c9a58cc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18021
+  timestamp: 1672387231268
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+  sha256: 513444d83ac2405e898531492ea59f3a95641e357cc39c1048d6fffc1791a16b
+  md5: 601d9449c280b9b145dc8c83b6f06119
+  depends:
+  - libgcc-ng >=7.5.0
+  license: Zlib
+  license_family: Other
+  size: 133595
+  timestamp: 1650637720646
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+  sha256: 1c049c23788a00b6f38bdc801245e0e60af98718d4db4c958658bcc67ff158c7
+  md5: b1737dfd2e06ad69ec5cfec341e207c6
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 827172
+  timestamp: 1650622223170
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
+  md5: b2aa5503875aba2f1d88cae9df9a96d5
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13636
+  timestamp: 1611930018941
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
+  md5: 544adf2677c47c9b9c891aea720678f1
+  depends:
+  - python >=3.5
+  license: MIT
+  size: 33999
+  timestamp: 1630003259346
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+  sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
+  md5: 9eff1a842dbda8d1bae9a2c008b599bc
+  depends:
+  - brotli >=1.0.1
+  - munkres
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 690443
+  timestamp: 1625743217109
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+  sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
+  md5: 33624a42ee387bf9918ea98b4e7b31fc
+  depends:
+  - pygments >=2.4.1,<3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8173
+  timestamp: 1601490751973
+- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+  sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
+  md5: 67857cc5e9044770d2b15f9d94a4521d
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12810
+  timestamp: 1600445183315
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+  sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
+  md5: e68a6f315f41a8d814d833652bf38b9b
+  depends:
+  - python >=3
+  license: MIT
+  size: 13374
+  timestamp: 1606932077143
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
+  md5: 2eb923cc014094f4acf7f849d67d73f8
+  depends:
+  - python
+  - six >=1.5
+  license: BSD-3-Clause and Apache
+  license_family: BSD
+  size: 246457
+  timestamp: 1626374695070
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
+  md5: 41db68b96e114e367c4f120a3b379e59
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19391
+  timestamp: 1632406728844
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+  sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
+  md5: a815d3bdb160bcc71687f2dda70d3ca4
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 122218
+  timestamp: 1680170368293
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
+  md5: 447a49f7bad119faa80d7f14aa296c95
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162176
+  timestamp: 1644481750133
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+  sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
+  md5: 8810f48fe4a4792de0fd3520b502d08b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10019
+  timestamp: 1606859473259
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+  sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
+  md5: 00a446b6dfc61af223df4de29fe8ad94
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 34305
+  timestamp: 1644569782044
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
+  md5: bd92dd8bd5b9d24e632b62a075426e50
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133634
+  timestamp: 1695718025321
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+  sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
+  md5: f8ae051b591a9027adc16de1be9748f4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206198
+  timestamp: 1681493096349
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.4.3-py39hecd8cb5_0.tar.bz2
+  sha256: 1f5dcdfd5854f527041cc8ad99de5b1e9de2cf89fc07d6ceebe773d0311a92b7
+  md5: 6188865467aabac07a36811fc37b0982
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3,<2.0a0
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14356265
+  timestamp: 1658136884702
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+  sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
+  md5: 0d79760d544d0bd8acb4adc4ef813418
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 137075
+  timestamp: 1657175654487
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
+  md5: 31d6d04cd2388d8f19004501271b3545
+  depends:
+  - brotli-bin 1.0.9 hca72f7f_7
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18982
+  timestamp: 1659616229395
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
+  md5: caf1073dc2ca5aeb832a2877394eae12
+  depends:
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18233
+  timestamp: 1659616216769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+  sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
+  md5: aa1ed20c38af535c8d6a955314759d7b
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 394588
+  timestamp: 1659616312678
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+  sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
+  md5: ce3588e31faa79f546e0fc6a36c5543c
+  license: MPL-2.0
+  license_family: Other
+  size: 133884
+  timestamp: 1694009771475
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+  sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
+  md5: 21eb7f53076d0a69513cfd258f6ef63c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159756
+  timestamp: 1690232346868
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+  sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
+  md5: a40a04d9cda1e665565bc6c832d598b6
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225258
+  timestamp: 1670423337502
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
+  sha256: b860f45bce9fbb40d024dcd3306e66a52010641091ca8d1fcdde6c4238717c73
+  md5: 3c38f3af9c23b26efc2b11d82c95922a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 153013
+  timestamp: 1698129937688
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
+  sha256: c368e11dc241d1b79b4bb0d9333b353dc1b966b49d145163a0590d88ad88fef2
+  md5: 1e62044b8a32d1452e51773ba7a4319c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41392
+  timestamp: 1683040146991
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+  sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
+  md5: b2cc5f37f7bb069d061306e7eac2a011
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1913396
+  timestamp: 1668084575248
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
+  md5: 103d8c039e342115720a84d59c119d46
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13774
+  timestamp: 1671231190250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+  sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
+  md5: f69f09e0346172f225390d2b3b0d7873
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 246628
+  timestamp: 1663827484947
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+  sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
+  md5: cb80c7ac65b48a737654f371fe31c460
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1307228
+  timestamp: 1694212041712
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
+  sha256: e80ce32bc86af3e0b67d44bc2c774dde7490443bf6ae4bed7d9c666e3631965f
+  md5: ba47d3bdf582bf15e9250bff6b2f6dbd
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2125677
+  timestamp: 1686783049768
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
+  sha256: 7717c1f0af2af4b28b6d787b32c5e1740f391915c78707d8643e0d516088dbd0
+  md5: d7ae4c5cb253fa85c0ce268d2bf9a191
+  depends:
+  - colorcet
+  - dask-core
+  - datashape
+  - numba
+  - numpy <2.0a0
+  - pandas
+  - param <2.0.0a0
+  - pillow
+  - pyct
+  - python >=3.9,<3.10.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17679970
+  timestamp: 1692372465872
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
+  sha256: 40bbbe2ed223829f4a3f91024fa409f1a665ad94294bec2c9e930989bb2b8911
+  md5: 4add00dc619c12370af0ed18c76b71f6
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 103370
+  timestamp: 1613390236788
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+  sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
+  md5: 04cbe8f4bc62c34fac9d42d1124059bf
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2052734
+  timestamp: 1690905361158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
+  md5: ef0e825982f242085574f502dfff4f6b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16594
+  timestamp: 1649926538106
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
+  md5: 24747a300246c016b3a7f04dabd02d4a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27709
+  timestamp: 1668714497209
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
+  sha256: 95e9a45812b1b4059b973e5e6e131c7c1a8b2ce2dafc5117e7806b1c8f30de27
+  md5: bc889aaa846ed177fc5f495c24041acc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 262430
+  timestamp: 1695734574609
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+  sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
+  md5: e4a732941f74b8062c8bcbfe5c5c2b56
+  license: MIT
+  license_family: MIT
+  size: 80252
+  timestamp: 1676983220161
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.16.2-py39hecd8cb5_0.tar.bz2
+  sha256: 00e402347930096d412390391e5d113dac1c28a19dcb94b7df3f68c3a38e4ed9
+  md5: 33827cf9fc2386dbcc81c4376e29eca4
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4528196
+  timestamp: 1686339564809
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+  sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
+  md5: f3ce6fe6eb760c236e5f7d04df5faa81
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28138484
+  timestamp: 1692293212596
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+  sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
+  md5: 6dd72c43fea25b748ec7a9f6c0407e15
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111810
+  timestamp: 1666125671024
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
+  md5: 03cdb7e679924b329ecab8f12cb8fc67
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38813
+  timestamp: 1678997212422
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
+  md5: e113c4e6e758dd68faf196586bf5564d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51873
+  timestamp: 1698254765815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+  sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
+  md5: 78baea934985ccd9514a366cc7e80ed4
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 727499
+  timestamp: 1681801225190
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+  sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
+  md5: da9b63e42f281f7e77b289f4b654b83b
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 218436
+  timestamp: 1691121840155
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+  sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
+  md5: 6a7cb9b49593b29933fa2b503d533a08
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1257205
+  timestamp: 1694181720454
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+  sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
+  md5: d861ef66f5c0a282d60b65778a9de2f3
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1048450
+  timestamp: 1644315332508
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
+  md5: f7e603c965052deed8b789c35855a42f
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213537
+  timestamp: 1666908270815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
+  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
+  license: IJG
+  license_family: Other
+  size: 278924
+  timestamp: 1677849185191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+  sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
+  md5: a82a17e78f725dcbd71ff8dac6db05c7
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133134
+  timestamp: 1676558895333
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+  sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
+  md5: ee9270379a9ebdb6297e4b6849b3f7f0
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 195479
+  timestamp: 1676329410154
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 32b898a97dca7770858ab31294238fde11ab61a84831a52f320e5ee5405a147c
+  md5: 926e754b8fad288b583ef2933deae1a5
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92938
+  timestamp: 1679906616072
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+  sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
+  md5: 7e60995b3119417213e5faedda147499
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 403165
+  timestamp: 1671707664990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+  sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
+  md5: cd470bdb28bb0e8b3535c93a3a6dad07
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65431
+  timestamp: 1672387389172
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
+  md5: 7dba7aa5b971febb55281659843586ba
+  license: MIT
+  size: 65470
+  timestamp: 1659616172703
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
+  md5: f78a158983f0bbaba56f34b976bc6dae
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 34189
+  timestamp: 1659616189313
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
+  md5: 36a1d885725d3ab4d1fadc5a29f978d2
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 327737
+  timestamp: 1659616202869
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+  sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
+  md5: 817848d0e2b2808acdc9b3fbbf581726
+  license: MIT
+  license_family: MIT
+  size: 133887
+  timestamp: 1683716590737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+  sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
+  md5: e458587c87e3f2d20192f4e0738f2c63
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 149419
+  timestamp: 1665498987619
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+  sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
+  md5: 1058b661ec829b2ee3716ee2a5520641
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1917987
+  timestamp: 1665498925405
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+  sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
+  md5: c90372428e1e4eed4fdcd790979d06b4
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1409377
+  timestamp: 1650983531933
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+  sha256: 8176dd9a68815301a24ed51e72f3506f5f77c67a112efa0dd14971f2f3b3c8c1
+  md5: b5e470c224000a6bda6f655c155b53e7
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 27861431
+  timestamp: 1683292881730
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+  sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
+  md5: c0b99f8e1c7475f23b1c7b4250b06e1c
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88021
+  timestamp: 1694778290062
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+  sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
+  md5: 06866415ef22d5322f9bdc9956b59c4d
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 678174
+  timestamp: 1692970318885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+  sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
+  md5: 2edc6c894d6d0321304396e9bd40df94
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241774
+  timestamp: 1692973618934
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+  sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
+  md5: 5c740b4a18a558de0ccfe601703c423c
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 338738
+  timestamp: 1662635677689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
+  sha256: fbf3c01a0834c151485b1b2ddf0c83d43703cbea051c6dbcb0d8d41946107670
+  md5: 12137025daee35f5c708ca10d0c96e3c
+  depends:
+  - libcxx >=14.0.6
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - python >=3.9,<3.10.0a0
+  - zlib
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 318622
+  timestamp: 1697031357874
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1dab4daa56408915de3ec270c8b887e7221d48633ea83b0afff61041fc197972
+  md5: 1519f9b766f9f894282db8353066e3b2
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11883
+  timestamp: 1652903144294
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+  sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
+  md5: 8bbd981ca0129d7beeacd3cd7623f714
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1491074
+  timestamp: 1695058597986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+  sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
+  md5: d5f58d056b4bfc67aec30c77035ba889
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 182491
+  timestamp: 1670944720979
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+  sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
+  md5: 1affd16b166571a91feae04baf5fd3da
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123431
+  timestamp: 1671542016019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+  sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
+  md5: 3681ebf029211ceab26af6f5d35abf39
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22254
+  timestamp: 1654598220251
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+  sha256: 2fd179efa024c92d0d71179a981a781d16c70f5d8c6305e0d678b0c7ae1275ab
+  md5: addda7f015d1673f794a23fdb18a3e09
+  depends:
+  - __osx >=10.12
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8182219
+  timestamp: 1698692361219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+  sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
+  md5: 6eb64ecfcd754502e271db0bb51d2cfd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17374
+  timestamp: 1662014643620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+  sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
+  md5: 2a4d604717a647ad21af766289cbbfc3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58057
+  timestamp: 1607364912348
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+  sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
+  md5: 25051fe272624544652dc6d814c2943a
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224420228
+  timestamp: 1691503125614
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+  sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
+  md5: 37d8cf85a63f7aa9af1624894a7d606d
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48590
+  timestamp: 1682969183093
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+  sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
+  md5: 0b2aee6666135bbd36b46d6ac66160f7
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 210705
+  timestamp: 1695058433223
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+  sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
+  md5: e22fb55ce380d0ebd44cce3f20d5349e
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296614
+  timestamp: 1695060155673
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
+  sha256: 5f60ca253f1fea0a1d765f535ff9ca2cf7efba90aea4c9a290d8f50ad11d4f6f
+  md5: 97d6ec94e2300030bddf0e5289cd2a84
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 24240
+  timestamp: 1607574265505
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+  sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
+  md5: 1a5d4004e64e3cfb7a2a297b9117c285
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8213832
+  timestamp: 1681756573646
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+  sha256: 2975bd1f98ca9ec7354ee378f86f8322ec90f568374776fd90e80c534fbee882
+  md5: 798627089e0ccba26695a26d9cb127ec
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99066
+  timestamp: 1650308465824
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+  sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
+  md5: e572c1264a7af20b486f64ac8c9e1f57
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 573356
+  timestamp: 1668450732828
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+  sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
+  md5: b67569a7c30af9ffa5cde6e4b52ac68b
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148342
+  timestamp: 1694616917184
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+  sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
+  md5: 97b81f34efbe86c5220fe82eb584fd62
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387288528
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+  sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
+  md5: d77862975a9a1cf50acb803be26e83a1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 575365
+  timestamp: 1690985052739
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+  sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
+  md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22858
+  timestamp: 1668160618784
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
+  sha256: 249efa747726ad61bc1093f33f155f0b7a0fa5b728cb1a6a6bd126458f279c96
+  md5: 1cced9a92d68307846cf59c238a42f13
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.41.0,<0.42.0a0
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.26
+  - python >=3.9,<3.10.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - libopenblas !=0.3.6
+  - tbb >=2021.6,<2022
+  - scipy >=1.0
+  - cuda-python >=11.6
+  - cudatoolkit >=10.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4431283
+  timestamp: 1697057424792
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+  sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
+  md5: 185e9c41abb88ee59b52ec0f5f65d506
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 138305
+  timestamp: 1696515469702
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
+  sha256: 361754aae186c6f4f8e5ceadf02b95ae74b47a97eaf1aa37538a7c410fb3ec88
+  md5: 02e4a556e3eb2375ec5a75795dd32372
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.25.2 py39ha186be2_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12847
+  timestamp: 1691166007881
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
+  sha256: 94d69c58f79dea6d155debef3237f02397ab6c3d042b519ad89fc64d204507d2
+  md5: 891a8850c69fd11971e58dfba0c40fcd
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.25.2 py39h827a554_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7529822
+  timestamp: 1691165972737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
+  md5: 93f5d7b66976154adeda219bea02ba45
+  depends:
+  - libcxx >=10.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 484257
+  timestamp: 1630093862501
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+  sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
+  md5: 5e8713ef1215406254988163eaf34020
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4965606
+  timestamp: 1695323060401
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+  sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
+  md5: 4154929ace2ad6ee16aea815635a6d1f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73598
+  timestamp: 1693575307570
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+  sha256: aff5acedef9da91b77851e1a163b8319d72bc4152c98ac87703a2eac1e5d575b
+  md5: 7df4c76aa8c52fedce5346748d56459e
+  depends:
+  - bottleneck >=1.3.4
+  - libcxx >=14.0.6
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - tabulate >=0.8.10
+  - blosc >=1.21.0
+  - fsspec >=2022.05.0
+  - beautifulsoup4 >=4.11.1
+  - pyreadstat >=1.1.5
+  - pyqt >=5.15.6,<6
+  - s3fs >=2022.05.0
+  - numba >=0.55.2
+  - xlrd >=2.0.1
+  - qtpy >=2.2.0
+  - xarray >=2022.03.0
+  - psycopg2 >=2.9.3
+  - lxml >=4.8.0
+  - zstandard >=0.17.0
+  - pyarrow >=7.0.0
+  - pytables >=3.7.0
+  - xlsxwriter >=3.0.3
+  - gcsfs >=2022.05.0
+  - fastparquet >=0.8.1
+  - scipy >=1.8.1
+  - pymysql >=1.0.2
+  - odfpy>=1.4.1
+  - pandas-gbq >=0.17.5
+  - pyxlsb >=1.0.9
+  - matplotlib-base >=3.6.1
+  - openpyxl >=3.0.10
+  - jinja2 >=3.1.2
+  - html5lib >=1.1
+  - dataframe-api-compat >=0.1.7
+  - sqlalchemy >=1.4.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13388063
+  timestamp: 1697477404222
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-0.14.3-py39hecd8cb5_0.tar.bz2
+  sha256: c63341d41ad75c475a793800d229886be5aba866e1885f23778f23093b15f891
+  md5: 1eaea439a84cf758cbaab861a140f67f
+  depends:
+  - bleach
+  - bokeh >=2.4.0,<2.5.0
+  - markdown
+  - param >=1.12.0,<2.0.0a0
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - setuptools >=42
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >1.14.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14708005
+  timestamp: 1676380263675
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+  sha256: 914f1ec8d911083c006c4c2d3b4c0c528e79abba3ae5f1dad825bd896870270d
+  md5: 949e0e4c0ce43c92eb52241892230873
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142949
+  timestamp: 1684915417020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
+  sha256: ddcb56e35d537f7a748b242c7c44368f112471973a52ae022945f597b7a83c7c
+  md5: 94bac4f8fbfaf821ace161b9f1f58716
+  depends:
+  - locket
+  - python >=3.9,<3.10.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36756
+  timestamp: 1698702713944
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+  sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
+  md5: be0a90921f3bf4f0d6950fb786093de7
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND
+  license_family: Other
+  size: 719901
+  timestamp: 1696580194417
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+  sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
+  md5: 81ae9ec2d7fcf6934847bff558b619f5
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2672987
+  timestamp: 1697548890181
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+  sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
+  md5: 1a822c206e2abddc5d6d821721af227f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33013
+  timestamp: 1692205801265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+  sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
+  md5: 1604d33dbdb2446c642970f8b354bedb
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91266
+  timestamp: 1659455269141
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+  sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
+  md5: d1b3bcc35655a3123acb1fa2ad1a8511
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580828
+  timestamp: 1672387372015
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+  sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
+  md5: 7540555d1fb192236db9a7c5c9d3601c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365765
+  timestamp: 1656431373327
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
+  md5: 0a73533fb6e0dc717ab906a537bc747d
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30803
+  timestamp: 1675441638631
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+  sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
+  md5: 0a959fbad46ab38ade48dbd358002674
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1864757
+  timestamp: 1684280094736
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+  sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
+  md5: ea24b5076ef79e4567c5a3f0cb22b470
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95330
+  timestamp: 1690223465114
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+  sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
+  md5: bcaea6d4a47e9c874becaa700c78dcf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157216
+  timestamp: 1661452617825
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+  sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
+  md5: 707110d1b49cb1864acb0bbaa103591e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 95016
+  timestamp: 1636111184034
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
+  md5: 113a443b9c706f9f9c6187c0eaa3de27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31178
+  timestamp: 1605305861851
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+  sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
+  md5: 85a8d0001db70e52a479155228cb1fe0
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13324979
+  timestamp: 1694439878265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+  sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
+  md5: 47c5e22e31ec05a7bc0ce90065a53afd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 265348
+  timestamp: 1661368839620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+  sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
+  md5: ce9a69e1668aa1e133f2aa6d4e8d346f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 254958
+  timestamp: 1695131709704
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 9ee098c09f31fad7ff1856e5ce2619172eaf979997e7a427d1e05cce32c2af00
+  md5: cac1d1898b69ae9646dfbf082910635d
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40946
+  timestamp: 1685030787453
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+  sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
+  md5: 637f08b19dd8fd87347d8c44f9e3e202
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 170776
+  timestamp: 1698096100056
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+  sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
+  md5: 8ce3ac7d8a04e469b566f1b090d01140
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 470617
+  timestamp: 1657724324011
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
+  md5: 6f2d41dd76a03b7f85a1ed49af1763d6
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95100
+  timestamp: 1690400262627
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+  sha256: a9755ecbfd42c708945027facfa11a3dc3119778326a0ae5df79f80d7b72afa5
+  md5: 839ffa4e775fee9a8bdddabf4a14da43
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<1.28
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24331914
+  timestamp: 1696545397632
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
+  md5: b0321e6f14e139fc15b1f8b4acb35d2f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093966
+  timestamp: 1690290944588
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+  sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
+  md5: 62b64576a0aa5f6c3fb05f56650d25e1
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15535
+  timestamp: 1614030509324
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+  sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
+  md5: 15b5595b31e39f08eaacbe2e502d8fb3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67292
+  timestamp: 1696347733587
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+  sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
+  md5: 82e4db6a498480a75d53c55bd35b6478
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1801397
+  timestamp: 1681394807900
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+  sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
+  md5: 63b957927b9949ccb19da28ec4612706
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30902
+  timestamp: 1671751919031
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+  sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
+  md5: e346257a2fa8e2cb48c762138a5d009b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39915
+  timestamp: 1668168959656
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+  sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
+  md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
+  depends:
+  - zlib >=1.2.12,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3536231
+  timestamp: 1654088937695
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
+  sha256: 74fc3a9e308602b3710f8fa671f24f5492571d0c8f7c1b3071dac72671262d45
+  md5: e08ead92568f5bd72d5ac7f08f087fee
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102258
+  timestamp: 1667464155001
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+  sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
+  md5: a1bbf0abfb8c45541122c0eb2feee317
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680464
+  timestamp: 1696937112175
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+  sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
+  md5: d689f6203c0a9d04fb229c73d7e80a7a
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125145
+  timestamp: 1679561909274
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
+  md5: 8a292c1ee22489bef2e84bc3aaf4098e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193141
+  timestamp: 1671143985219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
+  md5: 8bf0bfffc11ad06a1c94e145941b0ad4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9651
+  timestamp: 1690297655669
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
+  md5: 343514a174b3485fde55a73f56398dd7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58456
+  timestamp: 1690297648002
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+  sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
+  md5: c2242e8fd24003a74ddf37416661e06d
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188757
+  timestamp: 1698257668273
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+  sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
+  md5: 41f445e36b6b6722a9444508eef069f8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20583
+  timestamp: 1607365395045
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+  sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
+  md5: 409ee46ed24267b6da6fb32d13e1f21e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70730
+  timestamp: 1614804271285
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+  sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
+  md5: eb74e74d8e4fd533c55eb98b7b5e83bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102637
+  timestamp: 1695742077778
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
+  sha256: 9f5a34bef727052f97b1cc387c3a99a60754de99d6e4ab0b2de770d76b64dc0f
+  md5: b5ce0421037c626cfcec5b43d83ec420
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1787999
+  timestamp: 1689041573350
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+  sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
+  md5: e243baa546432c8394a8059a44a5a3e4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 419227
+  timestamp: 1683113010463
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+  sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
+  md5: fe4ac85ee86d3a94ea3a4ebea3779763
+  depends:
+  - libcxx >=10.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 321797
+  timestamp: 1616055526986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
+  md5: bc7073d9d4c0211cc4a1207c98fb765a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19091
+  timestamp: 1672387204865
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+  sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
+  md5: 8e495591e369ac161857a72011c0a296
+  license: Zlib
+  license_family: Other
+  size: 120272
+  timestamp: 1666595024203
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+  sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
+  md5: f1465fbd810b3746c6de6babfd4fe28a
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1023573
+  timestamp: 1681304595869
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+  sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
+  md5: cf55cb8d7031b30c70c56fc7c782b5c7
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 156104
+  timestamp: 1644482799136
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+  sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
+  md5: 84fce327d9f0d594e86f565e5c21962e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10183
+  timestamp: 1629146082730
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+  sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
+  md5: 84b8b998a741b37abf5312c1c03696ef
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33979
+  timestamp: 1644845817952
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+  sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
+  md5: 77b746931c8f31c3ae393ccb5819d43d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133628
+  timestamp: 1695717890677
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+  sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
+  md5: 3df6e8ba34208dea068890e5d5318cc0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206759
+  timestamp: 1681493095987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-2.4.3-py39hca03da5_0.tar.bz2
+  sha256: 7926e4d65d56b72cbce30732a5e24b075c4a9893ddb0160b90d6d08104636e49
+  md5: db35093fddb91beafe2274068cebee9f
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3,<2.0a0
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14425917
+  timestamp: 1658136781676
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+  sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
+  md5: bb55f81435cb6e11d264242274fccd1a
+  depends:
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 115947
+  timestamp: 1657175645380
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
+  md5: f860193e14afc7ef3f5b990a2ac003d2
+  depends:
+  - brotli-bin 1.0.9 h1a28f6b_7
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18936
+  timestamp: 1659616204016
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
+  md5: ad53130f3fd1f8d3c2fcbb7496e5585d
+  depends:
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18715
+  timestamp: 1659616188888
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+  sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
+  md5: 0982c046fb976e9f9fb19e7510187a18
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 366983
+  timestamp: 1659616245272
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+  sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
+  md5: 31ac2f5596cb7a44adf073c930641c54
+  license: MPL-2.0
+  license_family: Other
+  size: 133817
+  timestamp: 1694009762858
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+  sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
+  md5: cf1f6c3c34a1e1b9ab22b04233d860f6
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159783
+  timestamp: 1690232303987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+  sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
+  md5: 0eb268e38b5174d471a6e87d9d6102b1
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225355
+  timestamp: 1670423312966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
+  sha256: 41e76ba21b1279278a039245275eb4ee1f81b38b33cba00ca3575f06be5dc570
+  md5: c5170bf12e308fb7f2d1b4b9065f3df7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 153036
+  timestamp: 1698129857856
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
+  sha256: 36240dde0a1546469f35f3b5509b55384dfd894beb56b3ca929da4b96a2a5f24
+  md5: 844539636e4c20ee99e8ceeff5e902bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41376
+  timestamp: 1683040042906
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+  sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
+  md5: e68c94666cd60221b575c3814c89bac0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1946451
+  timestamp: 1668084573824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+  sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
+  md5: 1773ae2b080cdd55827e27673351551e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13646
+  timestamp: 1671231171682
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+  sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
+  md5: 53bfd99ad1b09164d537209cffd98161
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 244040
+  timestamp: 1663827469853
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+  sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
+  md5: b62455043c8eb2434466885b19fed2de
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1399573
+  timestamp: 1694211828228
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
+  sha256: fb7d12350372a70daa9f476647d04fc213ef9d8f73cbddaf30b40b1b45beef0f
+  md5: 34595eb00802934d092b3086d7b4344d
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2124926
+  timestamp: 1686783028732
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
+  sha256: d366da723fc8baf4d9de0d25688619efe4d1c7abe5407dfb28654c4c9e2ef019
+  md5: d4c923ceedacd8d5d18f994feed8dbb8
+  depends:
+  - colorcet
+  - dask-core
+  - datashape
+  - numba
+  - numpy <2.0a0
+  - pandas
+  - param <2.0.0a0
+  - pillow
+  - pyct
+  - python >=3.9,<3.10.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17708209
+  timestamp: 1692372524993
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
+  sha256: 83dbf9755ea887576e3f34adb1c26d418db9aaf3c77dc07f30b58c2221b81c72
+  md5: 36246697d07d6709de78abe36b6beae5
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 103201
+  timestamp: 1629793063728
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+  sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
+  md5: eb3cdc0fc210838b9271512a6a1b7c85
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2067708
+  timestamp: 1690905319109
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+  sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
+  md5: f44b80b9405410e5bde6bfe0b31d5b3f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 15135
+  timestamp: 1650293774207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+  sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
+  md5: f87027ccce1361d0f82c0edf1a10d53b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27677
+  timestamp: 1668714367519
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
+  sha256: 296371685a5dcd98f5128f11f413e63aa59c1eba60543faf3baaebd445964c5d
+  md5: 9817e8ffd3669484c9a7de99a8aceffb
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 257844
+  timestamp: 1695734566410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+  sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
+  md5: 1d0bd7e576c64c059ef781dd319ad82a
+  license: MIT
+  license_family: MIT
+  size: 77591
+  timestamp: 1676983230102
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.16.2-py39hca03da5_0.tar.bz2
+  sha256: f3338a8df94863e3bc66b3b0682d6e0097168937da735452dbecb229952d7ecd
+  md5: 21ca98bf948c366e8c596eea731a5e76
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4456018
+  timestamp: 1686339534531
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+  sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
+  md5: 69eb3b03765627b6159ed23cdde78396
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28399065
+  timestamp: 1692293207812
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+  sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
+  md5: 83366cbd3beb073112f4644a613b6bca
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111933
+  timestamp: 1666125627512
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+  sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
+  md5: 647c1a2f8460ffa8c670a1915bbdb494
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38790
+  timestamp: 1678997152549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+  sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
+  md5: 35e541905426c686ef2ff010a0e502fd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51860
+  timestamp: 1698254731870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+  sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
+  md5: 187d7720aedf38759d122cccb4576f2c
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 219976
+  timestamp: 1691121991680
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+  sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
+  md5: e8e7f10741f9cfa737b310b334940441
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1255894
+  timestamp: 1694181494549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+  sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
+  md5: ff209e75aee17af2e358b0008fbe8c88
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1022945
+  timestamp: 1644315931223
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+  sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
+  md5: d3e78ef296b3c74910d003bd10b475d6
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213972
+  timestamp: 1666908195870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
+  md5: 055e12390b844ea6c6e956ee08a618e8
+  license: IJG
+  license_family: Other
+  size: 273479
+  timestamp: 1677849171867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+  sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
+  md5: 783e2ad3d36472648c5ccc9f3051db3c
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133077
+  timestamp: 1676558732505
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+  sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
+  md5: 0677598f673f9729b5990316170a999d
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 197129
+  timestamp: 1676329661580
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+  sha256: 05f9ca0fdcfdc2e217438be27fead588c843a3aadf7d034467c83216d1e5c214
+  md5: 2d648b77d817ba38293c0728711ba8f5
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92852
+  timestamp: 1679906632236
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+  sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
+  md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 401319
+  timestamp: 1671707682572
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+  sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
+  md5: 247558a0aecf1ef7e77a4343761353d6
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64600
+  timestamp: 1672387273585
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
+  md5: a0f206782751dfffed0dd51302a1bf26
+  license: MIT
+  size: 68012
+  timestamp: 1659616138077
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
+  md5: 4c6667cdd061d28e9bc4e4300e4d115e
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 31173
+  timestamp: 1659616155596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
+  md5: 637e9430e258ddf050623ef2360184d8
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 298430
+  timestamp: 1659616172209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+  sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
+  md5: 55c615026c0869f8d3ba657f3bd38c43
+  license: MIT
+  license_family: MIT
+  size: 120389
+  timestamp: 1683716579036
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+  sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
+  md5: a41117710dafe569c9cc4e83f6f29fe3
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1411339
+  timestamp: 1650982753977
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+  sha256: d654027daea13ac9db36ab5fd5eff3ad398ec97c1777bf399f3ec680d2c145b9
+  md5: baabb1f905054bfea3af8f5768572a34
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 26579907
+  timestamp: 1683291669565
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+  sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
+  md5: 98d22e0124d55fae3c37c608dab1dcc9
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 89825
+  timestamp: 1694778225280
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+  sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
+  md5: 0ba499df6755eae5d2d23aa4ab004553
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 642657
+  timestamp: 1692970217410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+  sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
+  md5: c73101971e5ab6a8e8688239884eac81
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241607
+  timestamp: 1692973585084
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
+  sha256: 124d9d4f865f0f66c4e5e7f99dc1110330c9415cc51effc0a5aad4261880c2f0
+  md5: c08c14e55ba470513eb6c87206fb7b30
+  depends:
+  - libcxx >=14.0.6
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - python >=3.9,<3.10.0a0
+  - zlib
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 322413
+  timestamp: 1697031210019
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
+  sha256: 83e1c11fb14ec2767e833b540a6a0fdbd8641523b5673273914007008e6666da
+  md5: 64adbf70a0d4ab82aca039e972821537
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11877
+  timestamp: 1652903192510
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+  sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
+  md5: 353dff9d5d996c2a260f66381b2ce3e8
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1470815
+  timestamp: 1695058433965
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+  sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
+  md5: c99006da802a97c9aae30da8c16b4820
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176131
+  timestamp: 1670944706815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+  sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
+  md5: 60bd1e037cda86205526f77405d78129
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123361
+  timestamp: 1671541992772
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+  sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
+  md5: 34dfd76da78de2eae95bbda390d746d6
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23092
+  timestamp: 1654598007056
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+  sha256: bf0eeef3c3c713515766ab8b0dc7863413de5b4b227deede97e24d90ca342345
+  md5: a7bba1857eb84fb50caea377e60d2050
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8066509
+  timestamp: 1698692266161
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+  sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
+  md5: eb79dabbeedee7da85dfbfb145bb8a26
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17342
+  timestamp: 1662014601345
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+  sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
+  md5: 56db7bd3ff511cd839bda081523b3edd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 55683
+  timestamp: 1629356128780
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
+  sha256: ee936ba5fd196c15c3cb538aef721e54bb4486110ae3ebbfcf78e95e8380efa4
+  md5: dde1d9e040e04cbfbc0138898240a660
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 23003
+  timestamp: 1629282780853
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+  sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
+  md5: 176e0dcaeb28393881bacf69941e3889
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8289638
+  timestamp: 1681756329011
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+  sha256: afc6f332c51a3defc69e4c4e641988c0556039b9cd42be22f3db5292c88ccf37
+  md5: 2bc409c7258160a9b739d08d5ffb5998
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 96942
+  timestamp: 1650373637069
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+  sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
+  md5: 150ea9fadddf21993d3328d3e48a18b7
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 557688
+  timestamp: 1668450759059
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+  sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
+  md5: 37163b32508f9f589b3e6462a3a47546
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148426
+  timestamp: 1694616771736
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+  sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
+  md5: 6cdf7cbc43bf40e92b056a5576bd0086
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387216468
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+  sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
+  md5: 0f05853a139b6cda9c73e9d2707a4976
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 590288
+  timestamp: 1690984971741
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+  sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
+  md5: 7de782e4fb34bfa95ef2fc79d27d727d
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22840
+  timestamp: 1668160634885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
+  sha256: 0a5a7295f055d2f175528cc895dcb07533df5f0b87f05ac7839ec1af15988218
+  md5: 3d8e6925b26ca29486d0b58b30f1f663
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.41.0,<0.42.0a0
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.26
+  - python >=3.9,<3.10.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - cuda-python >=11.6
+  - tbb >=2021.6,<2022
+  - libopenblas >=0.3.18, !=0.3.20
+  - scipy >=1.0
+  - cudatoolkit >=10.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4428704
+  timestamp: 1697061454581
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+  sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
+  md5: 1a7b23113372c5667dbfe45976b9cc5c
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 126357
+  timestamp: 1696515322390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
+  sha256: 5332b3635fbc1a800b0fe58db7a0e57bb5ef75cbc56a0512c76f01ac7fc7139f
+  md5: ab7fbf394a301d25d1bf8cfa76fd917b
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.25.2 py39ha9811e2_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12847
+  timestamp: 1691092401334
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
+  sha256: 114b5aa7ef0990a615e27116e05dba0e7e78df750e3592aa4b732438f391a394
+  md5: 3284c63e9251227322ef9fd9c997f2c7
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.25.2 py39h3b2db8e_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6338710
+  timestamp: 1691092386069
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
+  md5: 371358a54bbdd307603888348d1a2c6f
+  depends:
+  - libcxx >=12.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD 2-Clause
+  size: 412248
+  timestamp: 1628861367714
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+  sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
+  md5: fa15d3b44ae1360ac9b640bbd5b6923c
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4746123
+  timestamp: 1695322833432
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+  sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
+  md5: d73db95f07a282021efdf8bc09713261
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73620
+  timestamp: 1693575195999
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+  sha256: 247b5e4d81b6d5d013a9c27e1f30c41fff896fed98a68ebda26b19b4062a6828
+  md5: 354a1d65300b4309d53dfa648014e8fe
+  depends:
+  - bottleneck >=1.3.4
+  - libcxx >=14.0.6
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - lxml >=4.8.0
+  - matplotlib-base >=3.6.1
+  - tabulate >=0.8.10
+  - pyqt >=5.15.6,<6
+  - openpyxl >=3.0.10
+  - s3fs >=2022.05.0
+  - pymysql >=1.0.2
+  - beautifulsoup4 >=4.11.1
+  - scipy >=1.8.1
+  - xlsxwriter >=3.0.3
+  - fastparquet >=0.8.1
+  - xlrd >=2.0.1
+  - blosc >=1.21.0
+  - zstandard >=0.17.0
+  - psycopg2 >=2.9.3
+  - pyarrow >=7.0.0
+  - pandas-gbq >=0.17.5
+  - pytables >=3.7.0
+  - sqlalchemy >=1.4.36
+  - odfpy>=1.4.1
+  - numba >=0.55.2
+  - jinja2 >=3.1.2
+  - pyreadstat >=1.1.5
+  - gcsfs >=2022.05.0
+  - qtpy >=2.2.0
+  - html5lib >=1.1
+  - xarray >=2022.03.0
+  - fsspec >=2022.05.0
+  - dataframe-api-compat >=0.1.7
+  - pyxlsb >=1.0.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13257999
+  timestamp: 1697478739906
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-0.14.3-py39hca03da5_0.tar.bz2
+  sha256: cb0fd0d862204d53fcd866cbe971602c3e7be58d5cc8f9dde2fd3cdf9376439e
+  md5: 274366470779c9c9a91141a769c8457f
+  depends:
+  - bleach
+  - bokeh >=2.4.0,<2.5.0
+  - markdown
+  - param >=1.12.0,<2.0.0a0
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - setuptools >=42
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >1.14.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14650720
+  timestamp: 1676379977310
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+  sha256: 0d64f2438be25524bbfeb8646e4fb3c18499d747398a03ed15d41b350b03e001
+  md5: 6a4908a5c9f7b3f17f09ebc34b1b691c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142857
+  timestamp: 1684915417403
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
+  sha256: 3a6450282f56265e800500b62cd1bbe39cd5a6a09c4747c6dc3e8aab10bfa8a0
+  md5: 9b01b16f9c5a033ee8b92683d66b184e
+  depends:
+  - locket
+  - python >=3.9,<3.10.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36731
+  timestamp: 1698702611592
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+  sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
+  md5: 6e01c592ae3b8ff2d12cae76f2f4276b
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 715239
+  timestamp: 1696580071596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+  sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
+  md5: 9fb8f460c130d56caf33c6bbe46fbe8a
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2678841
+  timestamp: 1697548790931
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+  sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
+  md5: 390b8c3cd74281abecdbfd51476922f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33033
+  timestamp: 1692205747301
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+  sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
+  md5: 7896828fb3565fefad43f980d50c8723
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91190
+  timestamp: 1659455206354
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+  sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
+  md5: d934c74eb66d01af0f45f0881f4bab77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580588
+  timestamp: 1672387390426
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+  sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
+  md5: 9858166e5ffb624c8b9d281f4000d725
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 367167
+  timestamp: 1656431368885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+  sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
+  md5: 4d2b45c6be8221e6a3e44c2d5838426f
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30843
+  timestamp: 1675441531640
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+  sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
+  md5: 02521df4e2e79f75faa9cbb3560ab1dd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1861763
+  timestamp: 1684280026169
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+  sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
+  md5: bdebe59bffc7adbad83fdcd9d429a5f5
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95234
+  timestamp: 1690223494699
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+  sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
+  md5: d716e5c9b5eec45ce1df8eb52cab817a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157408
+  timestamp: 1661452601692
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+  sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
+  md5: 1907629863ed8e7c35ead232dae7693f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 91636
+  timestamp: 1628941083263
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+  sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
+  md5: 847b9bddf2a86e1609c0d53bbc23ea79
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 27378
+  timestamp: 1626781391140
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+  sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
+  md5: 18aa18bd0d260605923877921d26cc74
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13194025
+  timestamp: 1694438901368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+  sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
+  md5: 45642a99c83e7aed74d1ffab1f20145b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 266647
+  timestamp: 1661368655993
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+  sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
+  md5: fec748525144049a2fc7f52f9755232c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257235
+  timestamp: 1695131702047
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+  sha256: 960192a143672e9c1d6fe4027af448512d91eee7501e5c245c21b865cf8bf429
+  md5: 76d491244218505f071ba56a308673df
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40950
+  timestamp: 1685030774581
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+  sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
+  md5: 3445d25415998c807efbe64d3a7e03c8
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 167068
+  timestamp: 1698096118071
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+  sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
+  md5: e6e92da28e9b0e428ed4b7df417bec25
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 472418
+  timestamp: 1657724315435
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+  sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
+  md5: dba22515f36d3c266de5896350813ea2
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95103
+  timestamp: 1690400315537
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+  sha256: c35449c0ca64d0d6a23c019b6eba188f546e42379857cbc4240bbdddee1159d3
+  md5: 61cb82346e21710f3e0645096cda4e12
+  depends:
+  - blas * openblas
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.21.5,<1.28
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22859180
+  timestamp: 1696543469561
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+  sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
+  md5: 3cd7eb43e285faba76faf67667e26b00
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093916
+  timestamp: 1690290951258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+  sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
+  md5: c5e9aef0d6895de1c927e9d796cd7cd3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15691
+  timestamp: 1629145910454
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+  sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
+  md5: 0f7c229e774146ffc4e29dedf75372bf
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67279
+  timestamp: 1696347632563
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+  sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
+  md5: 2302a79a045f152e183a52a81adfba62
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1674163
+  timestamp: 1681394762218
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+  sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
+  md5: ae58720a18a2ed15eae214ad7a10d1b5
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 140125
+  timestamp: 1680167256603
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+  sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
+  md5: 4ae67163d55cf9df83d4027ebc38c501
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30894
+  timestamp: 1671751931536
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+  sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
+  md5: dbb5c0cddb6661a89afee647fd3dc01e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39875
+  timestamp: 1668168874870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+  sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
+  md5: 667e60c8b407d73cbba40f44901f4f00
+  depends:
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3412693
+  timestamp: 1654088929697
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
+  sha256: 065cf1b08faf1d28aa348d569f2266d8b33b22ba424312c7ec959be95f217646
+  md5: 20370dbc92a9262e6fc8c82208f74ff2
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102259
+  timestamp: 1667464137769
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+  sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
+  md5: 884f788a5f6a664c9b79f7a4a60362d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680561
+  timestamp: 1696937004165
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+  sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
+  md5: 639a4f489af172c866c18442948e5874
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - slack-sdk
+  - requests
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125170
+  timestamp: 1679561942932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+  sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
+  md5: e5b90eba83fddba6d7aa6072b5bf7c91
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193017
+  timestamp: 1671143921826
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
+  md5: 644ef8830437070f60efcfcd6a987198
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9670
+  timestamp: 1690297532002
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
+  md5: a902a833bb186a2f1a4b2b89b1195136
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58466
+  timestamp: 1690297524418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+  sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
+  md5: f3f1d2c1028dad2f11ff950a15c99dbf
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188640
+  timestamp: 1698257577209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+  sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
+  md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20091
+  timestamp: 1629144441130
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+  sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
+  md5: 3089c63bf8f4d0423e1a287da286d83e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70923
+  timestamp: 1629357115820
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+  sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
+  md5: 5886b30b312445471268444f41f39dc7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102583
+  timestamp: 1695741976083
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
+  sha256: 300b9e4cfc9d01fa4d537060b2867f3cb89f22f932992fc2427e00dda050d55b
+  md5: 768c174577b786b99f8b46c4789b36a2
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1800646
+  timestamp: 1689041569828
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+  sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
+  md5: 2e75ad6a09c308268192efe03cc9ebf4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 411778
+  timestamp: 1683113019715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+  sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
+  md5: 30f666bf97c26587c5d2f68cc5f330ab
+  depends:
+  - libcxx >=12.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 316901
+  timestamp: 1629287855861
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+  sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
+  md5: 584e591d36dcd5ba5c45404f0f7ebb2d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19076
+  timestamp: 1672387153578
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+  sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
+  md5: 467ae28215d1aa1c5688bc0c8a184269
+  license: Zlib
+  license_family: Other
+  size: 103525
+  timestamp: 1666595022664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+  sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
+  md5: 7cfbed15f1feee1422810f7830075f53
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 779464
+  timestamp: 1681304594848
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+  sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
+  md5: ed14f9bc6e55220483f1a5a388625a08
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162772
+  timestamp: 1644481986085
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+  sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
+  md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 39253
+  timestamp: 1644551767970
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+  sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
+  md5: b24d13c443a26f65a0778b475a5726bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132830
+  timestamp: 1695717959996
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+  sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
+  md5: 302c3c0696e17eaa62e140e3892644ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 199723
+  timestamp: 1681493196911
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-2.4.3-py39haa95532_0.tar.bz2
+  sha256: a8150eba2526f695999bf260643c51779153bece456d86bb5ceaf2320dc28436
+  md5: af8143c21529c930f9d54b9fa12df1f9
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3,<2.0a0
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14460067
+  timestamp: 1658137245730
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+  sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
+  md5: bf930260f679bc74227bbb18bc36ae82
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 119700
+  timestamp: 1657176150595
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
+  md5: 507dfe693ef429f466d964b599f4af21
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_7
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 18650
+  timestamp: 1659616328001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
+  md5: d0bf43e8df60baae3b3105aa5c42a791
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 21153
+  timestamp: 1659616312367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+  sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
+  md5: 7bd24bf94c24e810aecaaf84a0978e6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 343204
+  timestamp: 1659616543542
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+  sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
+  md5: 092b417c11edcbe6bb9b765ab4a55d23
+  license: MPL-2.0
+  license_family: Other
+  size: 164999
+  timestamp: 1694009822357
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+  sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
+  md5: 708a750d370b9d6875651021e21c4446
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159322
+  timestamp: 1690232335307
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+  sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
+  md5: c35736da3ea26782425e78061268cf5e
+  depends:
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 228713
+  timestamp: 1670423312743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
+  sha256: 9577ff772035cd30e72323edff379dd3df877de00f7f690fd33c8720a5a4bbc9
+  md5: 1130fd979d4f97f511f10b36ff09513d
+  depends:
+  - colorama
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 152728
+  timestamp: 1698129962390
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
+  sha256: e5babe79f8132c4bd44bc05307976f2c5485014ae3129655dddbd3baa8e75e46
+  md5: 093223df00c6ef9db4e7e5aa7bfec00a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40844
+  timestamp: 1683040252786
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+  sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
+  md5: 457a4339a53c033d48ce0c72e5038d2e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30330
+  timestamp: 1672387265402
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+  sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
+  md5: 59ec65fd9e06b81a65cc12986c67d5da
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1939614
+  timestamp: 1668084794027
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+  sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
+  md5: 3489c1a2b73fc957b5a62cc59349e25b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13438
+  timestamp: 1671231196438
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+  sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
+  md5: 3492b96083c1e904cc32d26ea7f1e1d8
+  depends:
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184280
+  timestamp: 1663827558327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+  sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
+  md5: f46d904bc6f220327e70474971341f52
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1220835
+  timestamp: 1694445639066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
+  sha256: 78d66bcb1c979647e9c5473825d4a5e35afa2a0dfeef71cb0d9d9a72fea3c102
+  md5: f2875875bb22ab4704a77bc368a9dc00
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2180195
+  timestamp: 1686783294287
+- conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
+  sha256: 882a0fb257fb07bb47e8127b9ce1f556e319ce4941b74adc94f9849093e11d0d
+  md5: b6ef3c0b6e49ff3d497785c744ce44cc
+  depends:
+  - colorcet
+  - dask-core
+  - datashape
+  - numba
+  - numpy <2.0a0
+  - pandas
+  - param <2.0.0a0
+  - pillow
+  - pyct
+  - python >=3.9,<3.10.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17688679
+  timestamp: 1692373093225
+- conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
+  sha256: a6c8b5d32c52ce71d41c7702265e0bb064c960ab67b88ecbea967595c5e02bc3
+  md5: 112f2f9c7055656ec156fe287c97c0e9
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 104432
+  timestamp: 1613390539244
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+  sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
+  md5: 2ff4fb509788b0e47ac684ba151394d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3289966
+  timestamp: 1690907040646
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+  sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
+  md5: 0f166c3e70541d8bee6e9d0cb60fb66e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16979
+  timestamp: 1649926678161
+- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+  sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
+  md5: ea93d413944ca6a8677eb1b284b136ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27388
+  timestamp: 1668714577678
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
+  sha256: 6b724886465fea70d2ca843fea1d01bcc24d496601587b87c0cb8f2626b259c2
+  md5: 6c11d9242869d6c3b01698f728bd409b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 260567
+  timestamp: 1695734829130
+- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+  sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
+  md5: 9f167d3e45441bc3633c1974b1b0ce8c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 88421
+  timestamp: 1676983264486
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.16.2-py39haa95532_0.tar.bz2
+  sha256: 22697eed11ebd3285a5c95a03473bc49b8e6870df4351399ac881157d147b6c0
+  md5: f4ee7531c4b389eb2c5a940edcde3580
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4563678
+  timestamp: 1686339525300
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+  sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
+  md5: 582d2c1135a89da757a038de831e7f39
+  license: Intel proprietary
+  size: 11086648
+  timestamp: 1664812389803
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+  sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
+  md5: 30fdefd1541c789c163751291a8faa88
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111448
+  timestamp: 1666125667599
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+  sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
+  md5: a10f07c7a3510272a296f9fed458a4ed
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38098
+  timestamp: 1678997241511
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+  sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
+  md5: fad9cf2023d807da8d44996e9d4399a0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51490
+  timestamp: 1698254721864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+  sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
+  md5: 9834848bd7c7759acf12e78d09388563
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3891030
+  timestamp: 1681801474383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+  sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
+  md5: 1285c8c628bc912c54d0968574c9f4c9
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217232
+  timestamp: 1691122695748
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+  sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
+  md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
+  depends:
+  - backcall
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1279433
+  timestamp: 1694181820978
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+  sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
+  md5: f5fcce35d3f21cdfc5893c5a7a86c651
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1035394
+  timestamp: 1644315567034
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+  sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
+  md5: f67fe3337528e2886f1ac3ab8ac37985
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213110
+  timestamp: 1666908350218
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
+  md5: 81f2c343dc4c65eea39c45383272068f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 407861
+  timestamp: 1677849239400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+  sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
+  md5: bd9526d38a145fe311a8aa36bc11e071
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 152006
+  timestamp: 1676558783570
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+  sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
+  md5: a00e6a62956fde3c4135464353ee8a53
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229158
+  timestamp: 1676330909084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+  sha256: db8335d6531b03c7bdfe789ebacc52631ac6ea4a37700bb3da1f6a53a1acd724
+  md5: ebeba61994cc225ea5f4f42caa511019
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116681
+  timestamp: 1679906658986
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+  sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
+  md5: 5efa1332f7c0a8d9638eda02170c4ce5
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pywinpty
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 413653
+  timestamp: 1671707957673
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+  sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
+  md5: 891fe66a24d8714737b2874985ee1303
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62298
+  timestamp: 1672388166096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
+  md5: c345f51706eef530454f66b794e5e574
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 68189
+  timestamp: 1659616216976
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
+  md5: a7400cfb72042977bc047909ed504ce8
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 33743
+  timestamp: 1659616248209
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
+  md5: 6307f6854754ab5bd7c84e6998385bb1
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 733177
+  timestamp: 1659616279453
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+  sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
+  md5: b812bc5d9c76242e2bb2ac87afe7d39b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 730280
+  timestamp: 1650983734373
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+  sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
+  md5: ba9418df9288a2f031a02fa35b774ce0
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78524
+  timestamp: 1694778314659
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+  sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
+  md5: 6ece7f1a3248169837714d05d7f6ef0a
+  depends:
+  - libiconv >=1.16,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 3513910
+  timestamp: 1692971505729
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+  sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
+  md5: bd7ec244935e83e850a4ff34e8e2e64f
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 513971
+  timestamp: 1692973657152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
+  sha256: 2f610fc98b674e4eceeceaadbb94b4153759ee9249759dd27ca48bfdeeef82cf
+  md5: c24005244a08cbfb665f89d8858e0187
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 20824879
+  timestamp: 1697031479623
+- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
+  sha256: 5d4cf89313147e44530dbb3cc6a93247aaded0701bbf8ba3a382ef710abf4cfa
+  md5: 137deeca51202f6b4ac786472a00be55
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 12894
+  timestamp: 1652904101694
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+  sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
+  md5: fb7881e74b59262df0fa4ec981964efc
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1244887
+  timestamp: 1695058550693
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+  sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
+  md5: 6970c7f46b0164cad1d210e7a1419959
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143434
+  timestamp: 1670944902624
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+  sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
+  md5: 1015298551c040c6d5e26eebbae12ef5
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142316
+  timestamp: 1671542240512
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+  sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
+  md5: 466da740fafef3d6bce114220f0be306
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28510
+  timestamp: 1654508162239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+  sha256: 1687ae122ee7d8b583141fc5014b76d494841dc8083b854449e3d6e0f6bb7019
+  md5: 3697ac26ee3c2d49338dd5b9c6551152
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8080067
+  timestamp: 1698692812610
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+  sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
+  md5: a9fa43e694b25cd49b8b08a9eefd696e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18054
+  timestamp: 1661915903969
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+  sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
+  md5: 248c468abced874f0231d3cc23177c77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58488
+  timestamp: 1607359497934
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+  sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
+  md5: 5e763c995ff0c549f68a10bce70fede4
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187489950
+  timestamp: 1691503804820
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+  sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
+  md5: dd0c2ece6a743c373c9b5a5919b4818f
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49744
+  timestamp: 1682975040154
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+  sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
+  md5: 57cea8df7ab85f2a98f64d23afcb1f90
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184956
+  timestamp: 1695058491736
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+  sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
+  md5: 8769cdd201d905069800488fe31574e5
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 256221
+  timestamp: 1695060152521
+- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
+  sha256: b75f28f29d60f2a8726fb0f036e5d01489942abbf77ff1e1cc8e12d7f372b8f3
+  md5: 7a1d29477873480809fd3860f2e69f01
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 24734
+  timestamp: 1607574381373
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+  sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
+  md5: d9781492332e6326f9fca87f3a8efacd
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8135792
+  timestamp: 1681756491399
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+  sha256: 2dd3178d3c570e30b9490ebabfd7bfac806afad8302d3dee0edc619805034397
+  md5: bef9da0f0694c45b6aaa4e6447479eaf
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 118324
+  timestamp: 1650290466135
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+  sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
+  md5: f1d8ce412e115986c403f223b3b47d0f
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 596314
+  timestamp: 1668451106600
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+  sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
+  md5: f96bbef0985d7e66ebf00c0d55e30e23
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 167045
+  timestamp: 1694617078743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+  sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
+  md5: 6e6ba64c8dc5025aeac606404a8df36a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13786
+  timestamp: 1672387480065
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+  sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
+  md5: 4a7a3286484766741f627696697c362c
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 609425
+  timestamp: 1690985686105
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+  sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
+  md5: 4269a1f93882205b90d4b2ae78fc82d5
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22417
+  timestamp: 1668160717305
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
+  sha256: 39b52f5a3e0f71a07358f2bd07a67b950170eabc3398ae968ef523cc0854141a
+  md5: 4baee3e5d96aed7d5d3e28051d6214e5
+  depends:
+  - llvmlite >=0.41.0,<0.42.0a0
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.26
+  - python >=3.9,<3.10.0a0
+  - tbb >=2021.8.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - tbb >=2021.6,<2022
+  - scipy >=1.0
+  - cudatoolkit >=10.2
+  - cuda-python >=11.6
+  - libopenblas !=0.3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4472762
+  timestamp: 1697063760024
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+  sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
+  md5: a18a576b7024cfd6f905c526a786a916
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 135285
+  timestamp: 1696515698492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
+  sha256: 410f3a13eaddcfcfc65cb077dd0b85b7c66853a2447161b9022eed7d9fe472f9
+  md5: c4aae7ab3842a3decd05c5c1d8b916d3
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.25.2 py39h65a83cf_0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12296
+  timestamp: 1691098390179
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
+  sha256: 5a81ff60cc876951905995ea52d3815e38a0d757c6c674acbef1144d8dc746fb
+  md5: 72413d41fe97de5da9b1ce325e544e05
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.25.2 py39h055cbcc_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6857794
+  timestamp: 1691098356763
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
+  md5: ab07e2a27ac08afe3d0b4c0890b8486a
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 2-Clause
+  size: 249316
+  timestamp: 1630094024143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+  sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
+  md5: 73b17037d87b5a58feb34dafc0538f7f
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8058396
+  timestamp: 1695324589828
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+  sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
+  md5: df1d746ba8d5d6ba01ac1373b9b71e1a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73016
+  timestamp: 1693575484990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+  sha256: 1994e5831fd421bd6cf85916073d4012dec53e673b672b3985efaf771f0a7bf8
+  md5: c486a5b51e3227f6ea564a9dd3125e45
+  depends:
+  - bottleneck >=1.3.4
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - openpyxl >=3.0.10
+  - jinja2 >=3.1.2
+  - qtpy >=2.2.0
+  - numba >=0.55.2
+  - pyreadstat >=1.1.5
+  - zstandard >=0.17.0
+  - xlrd >=2.0.1
+  - tabulate >=0.8.10
+  - fsspec >=2022.05.0
+  - pyqt >=5.15.6,<6
+  - xarray >=2022.03.0
+  - xlsxwriter >=3.0.3
+  - beautifulsoup4 >=4.11.1
+  - html5lib >=1.1
+  - fastparquet >=0.8.1
+  - pyarrow >=7.0.0
+  - pyxlsb >=1.0.9
+  - matplotlib-base >=3.6.1
+  - odfpy>=1.4.1
+  - pytables >=3.7.0
+  - sqlalchemy >=1.4.36
+  - psycopg2 >=2.9.3
+  - blosc >=1.21.0
+  - lxml >=4.8.0
+  - pymysql >=1.0.2
+  - gcsfs >=2022.05.0
+  - pandas-gbq >=0.17.5
+  - dataframe-api-compat >=0.1.7
+  - s3fs >=2022.05.0
+  - scipy >=1.8.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12629931
+  timestamp: 1697479885371
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-0.14.3-py39haa95532_0.tar.bz2
+  sha256: 00a343d88532d207ef3f8387af638b82608a8904ef11c9a1495693bb4658c49a
+  md5: 0f761c1e7e55d96c6504348291a2d7c4
+  depends:
+  - bleach
+  - bokeh >=2.4.0,<2.5.0
+  - markdown
+  - param >=1.12.0,<2.0.0a0
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - setuptools >=42
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >1.14.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14717609
+  timestamp: 1676380051970
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+  sha256: 2773f47b2d745ab483cf7fcbd5b5e2f7020d45462d32d2ccd5cf232ca13c6f67
+  md5: ca16cd208037bd58d2da267c338da4a4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142229
+  timestamp: 1684915524241
+- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
+  sha256: 5738f61dae392c171b4f699a6973e736198e4d4a63fa22dcf957afaf1de150af
+  md5: cba721e73156d62fc4ff23159e96ad41
+  depends:
+  - locket
+  - python >=3.9,<3.10.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36452
+  timestamp: 1698702686971
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+  sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
+  md5: 427c1450bebb632f43bbc8c83006e4cd
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 806931
+  timestamp: 1696580240310
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+  sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
+  md5: 21790cd3e2b8a45c4104aff0a68330d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3001751
+  timestamp: 1697549357662
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+  sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
+  md5: 56f44a1054da2d10777e375838191070
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 32355
+  timestamp: 1692205784293
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+  sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
+  md5: 8a35ad65651086575ce55371f22feda8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91045
+  timestamp: 1659455316472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+  sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
+  md5: 186eb95f816a2eff80c3c7f7d964c7b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 578514
+  timestamp: 1672388155359
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+  sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
+  md5: 47b6cbe6ce9289e47d16900b03596a91
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372807
+  timestamp: 1656431445633
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+  sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
+  md5: 07165c444adc7c7ccc8a345875adc5ef
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48408
+  timestamp: 1675450623287
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+  sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
+  md5: d58e76a31e2f6e7410ba4afd7f385b0d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1877445
+  timestamp: 1684280183367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+  sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
+  md5: 0e5b0fe7debbf558ce97090f6b67cdae
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94633
+  timestamp: 1690225630423
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+  sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
+  md5: 0fde797653e4ab589506121fb1e37555
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157119
+  timestamp: 1661452591647
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+  sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
+  md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 92679
+  timestamp: 1636093365041
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+  sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
+  md5: f870859d4dc7a8d82cf3546bd9035f33
+  depends:
+  - python >=3.9,<3.10.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 54520
+  timestamp: 1605307564142
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+  sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
+  md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
+  depends:
+  - openssl >=3.0.10,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 21172845
+  timestamp: 1694442462066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+  sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
+  md5: 9d99075052265ae3d718582d3b875038
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269964
+  timestamp: 1661376543480
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+  sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
+  md5: fa9074d94236c9b768bfd2c858875b27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 264836
+  timestamp: 1695131770282
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+  sha256: 97243a31c39f4990c0e9d4f2307f2f7fb9421553303923bc105067ec4340bdff
+  md5: 8078c5760f27398eaf1082226647d137
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40145
+  timestamp: 1685031143383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+  sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
+  md5: 3d2841085778006c2e79f9c7300f8b9d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13565975
+  timestamp: 1669937633869
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+  sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
+  md5: 54a4bc0724041dd173088419d6ede2af
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 239062
+  timestamp: 1677611495106
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+  sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
+  md5: f39f84115e228bad4bceaefdd637f022
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 158558
+  timestamp: 1698096358091
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+  sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
+  md5: df398a3a1668fd2a22061764e20ea91d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.4,<4.3.5.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 460913
+  timestamp: 1657616061604
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+  sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
+  md5: 38db77ece9dc76feffb9ef7638e38258
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94397
+  timestamp: 1690400496655
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+  sha256: 3a9a680173f731d515e0587d5b74583cc986b5c1ff62f4cf9e4f7ec268cbb62a
+  md5: 3387bf809e3d32dde3f5cbc3ef49bf47
+  depends:
+  - blas 1.0 mkl
+  - icc_rt >=2022.1.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<1.28
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22779707
+  timestamp: 1696550432358
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+  sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
+  md5: 3e284ae6b48ee30c364ffdc5601610b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1099842
+  timestamp: 1690291374842
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+  sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
+  md5: 993b3886b334bd1f49d34206f21997b4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15998
+  timestamp: 1614030572433
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+  sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
+  md5: 7ac9604ad7564ac0c71bff5db198656f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67012
+  timestamp: 1696347795139
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+  sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
+  md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1311308
+  timestamp: 1681402905668
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+  sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
+  md5: 28b9869d8d3a839918fac4a08f38cbc2
+  depends:
+  - python >=3.9,<3.10.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30546
+  timestamp: 1671752127904
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+  sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
+  md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39590
+  timestamp: 1668168880994
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+  sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
+  md5: 52cdcdb96383c010ca833a7c24b3935b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Tcl/Tk
+  license_family: BSD
+  size: 3690152
+  timestamp: 1654036853710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
+  sha256: 1ee791ecc17e11a31d6cf1553845e7279d9d9a2c7383a2a3e1ae131ddd024b6f
+  md5: b32030d310e0437dc631e5719369004c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102033
+  timestamp: 1667464306003
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+  sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
+  md5: 0e054ab29119cf4c1f778613acf972f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 681780
+  timestamp: 1696937326924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+  sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
+  md5: b6ad839ebba536ad1c3cc58d0e2123f0
+  depends:
+  - colorama
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 143681
+  timestamp: 1679562248929
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+  sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
+  md5: fe78de10019085146f1cc6c94fdc2620
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192822
+  timestamp: 1671143999327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
+  md5: ca5fc3fbdb09b6de068a8b7a8869369f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9208
+  timestamp: 1690298120549
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
+  md5: a86e87a10e5fdff486265e0c675fb99f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57922
+  timestamp: 1690298106990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+  sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
+  md5: 0d31859e0a097aedbcc1627db33b3d92
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188367
+  timestamp: 1698257883295
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+  sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
+  md5: 45ef24c486a484f079faf1dc90e4c7e9
+  depends:
+  - vs2015_runtime >=14.27.29016
+  license: Modified BSD License (3-clause)
+  license_family: BSD
+  size: 8277
+  timestamp: 1605602889180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+  sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
+  md5: 4daaceb6cfc1af6274509081d8018ef1
+  size: 2316783
+  timestamp: 1605602872095
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+  sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
+  md5: 916c16904615c7af3b5d37cb6694f45e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21084
+  timestamp: 1607347371925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+  sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
+  md5: da69e6987fcc757e83a358ceaa13f62b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73391
+  timestamp: 1614804425587
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+  sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
+  md5: 23b9f4634b2e5450be617114f62c74f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 120873
+  timestamp: 1695742300539
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+  sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
+  md5: 120f0b088290fc17bd6618fc10a2f0c4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PUBLIC-DOMAIN
+  size: 34293
+  timestamp: 1605306211299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
+  sha256: 6bdb88cd45b22246e84b7400159ca90faf98ab4e8c1fa2d38d031cfc73c4dc13
+  md5: d6e10641ece06f67561c5f6a676a4b7e
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1794729
+  timestamp: 1689041580510
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+  sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
+  md5: c3f7871e9a33adeccee1b1e8e216918e
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 1332571
+  timestamp: 1683113347814
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+  sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
+  md5: 1ab55f8c4b5292ec360c572120bf823e
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-3.0-or-later
+  size: 9430705
+  timestamp: 1616055773485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+  sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
+  md5: 6875e0bf3828707dc9165d694c0d0a7d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18725
+  timestamp: 1672387612937
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+  sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
+  md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 148931
+  timestamp: 1666595229032
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+  sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
+  md5: 8d6a1e767775fe0eb617cd6e22edc2ff
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1871867
+  timestamp: 1681304638261

--- a/iex_trading/pixi.lock
+++ b/iex_trading/pixi.lock
@@ -7,686 +7,686 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.16.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.1.0-h3826bc1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.21.5-py39he7a7128_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.21.5-py39hf524024_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.6.2-py39had2a1c9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libllvm11-11.1.0-h3826bc1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.21.5-py39he7a7128_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.21.5-py39hf524024_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scipy-1.6.2-py39had2a1c9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.4.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.16.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-0.14.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-2.4.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-0.14.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-2.4.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.16.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-0.14.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-2.4.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-0.14.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-2.4.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.16.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-0.14.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-2.4.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.16.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-0.14.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
   sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
   md5: 613805add1c05b538ff06d217252feb7
   depends:
@@ -697,7 +697,7 @@ packages:
   license: BSD-3-Clause
   size: 20810
   timestamp: 1652859733309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
   sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
   md5: 2cf39d906cc321896ffe3e5d33d80c5c
   depends:
@@ -710,7 +710,7 @@ packages:
   license_family: MIT
   size: 162166
   timestamp: 1644463608931
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
   sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
   md5: 2972a84e0e22ae3244bbd2f1eebcf536
   depends:
@@ -721,7 +721,7 @@ packages:
   license_family: MIT
   size: 35352
   timestamp: 1644569715988
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
   sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
   md5: a68016b4b06460def24cb69d932986f3
   depends:
@@ -730,7 +730,7 @@ packages:
   license_family: MIT
   size: 132486
   timestamp: 1695717963702
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
   sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
   md5: 2f6356a2f530314b4059c08c79a3d8bc
   depends:
@@ -740,12 +740,12 @@ packages:
   license_family: MIT
   size: 205868
   timestamp: 1681493113570
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
   sha256: 2d8e75f31f75ea5eb8b9021b4c21eb2846a254a097e06eb68e66fc36a82e1bed
   md5: ae374a11c789a55555f70b29b9eff1f9
   depends:
@@ -761,7 +761,7 @@ packages:
   license_family: BSD
   size: 14430294
   timestamp: 1658136783940
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
   sha256: f84f9caa7eb9d489fd9634419fdf766d39293a5df1104b840fa0cdc5823a5c60
   md5: 922555c0435d6b2537cf8ced534b048c
   depends:
@@ -772,7 +772,7 @@ packages:
   license_family: BSD
   size: 141903
   timestamp: 1648028958291
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
   sha256: 0bbcb6f78eac530c6a084459ffab3238647b266d0c74d695e6e6387dd119cc67
   md5: bdc971e2a9affb5125b68ad708172dab
   depends:
@@ -781,7 +781,7 @@ packages:
   license: MIT
   size: 411301
   timestamp: 1602517685375
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
   sha256: 8c2071f706c2b445dabb781f7f8f008b23a29957468ec6894f050bfb3a2d5bf4
   md5: c203ffc7bbba991c7089d4b383cfd92c
   depends:
@@ -792,14 +792,14 @@ packages:
   license_family: MIT
   size: 357797
   timestamp: 1605539534667
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
   sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
   md5: 3ef00f4c5278b688552efc259c463dc8
   license: MPL-2.0
   license_family: Other
   size: 132731
   timestamp: 1694009767372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
   sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
   md5: d5cb3d97cf5e85ffe5e94037ed8a1169
   depends:
@@ -808,7 +808,7 @@ packages:
   license_family: Other
   size: 159077
   timestamp: 1690232254640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
   sha256: 674707b9c42e65c903c9786ee5a56b4d42aa054f1e75b328db8a2c1bfa368739
   md5: 76ae217198b014b89b267cf41b8251dd
   depends:
@@ -820,7 +820,7 @@ packages:
   license_family: MIT
   size: 231920
   timestamp: 1642701209740
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
   sha256: 762f4506c3e12b2332bd9abea3a2a1966f307b2673be7fd661dc6e316602d18b
   md5: 4b8df5459d1762495428323753438641
   depends:
@@ -829,7 +829,7 @@ packages:
   license_family: BSD
   size: 151844
   timestamp: 1698129872673
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
   sha256: 4fd0207b930fbc936d4b8206117cfa9792aa19bfb320eb08aab6bba10002f9ee
   md5: 7082a1ce8fa314cc2761d2f689c6bb9e
   depends:
@@ -838,7 +838,7 @@ packages:
   license_family: BSD
   size: 40456
   timestamp: 1683040035572
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
   sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
   md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
   depends:
@@ -848,7 +848,7 @@ packages:
   license_family: CC
   size: 1917831
   timestamp: 1668084545510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
   sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
   md5: 13702d3b4b744784e5bd559c7050dd6f
   depends:
@@ -858,7 +858,7 @@ packages:
   license_family: BSD
   size: 12719
   timestamp: 1671231205875
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
   sha256: 821af57c20a85b4e92268fbf65fbaec2f273da5bb21889d9643756ef6e473237
   md5: f57e0f502500ffebdbec081ef61ad1d4
   depends:
@@ -872,7 +872,7 @@ packages:
   license_family: BSD
   size: 2179774
   timestamp: 1694445209134
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
   sha256: 2084ad037e4b67a158facc0d1b21d1de16df7fe758e2bf08f6e48c6b75626cb8
   md5: 8bb8a915dda236f7a2cf790490983445
   depends:
@@ -889,7 +889,7 @@ packages:
   license_family: BSD
   size: 2121644
   timestamp: 1686782977519
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
   sha256: 161644f5f183f5632806cb2cb31890d06a1a575bed7949fe11bc59d3d4344e9d
   md5: 96baa11147a42b64dcaa233a1733b8ee
   depends:
@@ -911,7 +911,7 @@ packages:
   license_family: BSD
   size: 17667549
   timestamp: 1692372404139
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
   sha256: 80188a9729a26e36b027e673f5f30395798eb68f9fe4721f3f33b4d4d2e58285
   md5: 686db307602cbbdc30ca7d62b765578b
   depends:
@@ -923,7 +923,7 @@ packages:
   license_family: BSD
   size: 103488
   timestamp: 1613390248313
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
   sha256: 3a39a2d6f161080c706292e3bf480f62d2444b1d6d67b3d7db50458202ee31f1
   md5: 0524ffca60f845eb392bbb56d56f0ce5
   depends:
@@ -934,7 +934,7 @@ packages:
   license_family: MIT
   size: 2094615
   timestamp: 1637091869922
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
   sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
   md5: 2e6ec51066d825ef3c317abe78d6049e
   depends:
@@ -943,7 +943,7 @@ packages:
   license_family: MIT
   size: 16413
   timestamp: 1649926472708
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
   sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
   md5: b4d923222d45314856b5378cb115214d
   depends:
@@ -952,7 +952,7 @@ packages:
   license_family: BSD
   size: 26728
   timestamp: 1668714462023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
   sha256: 8a121233d0b2cbb2463b67e798739ad2946f38933430a6a7fd1197cc6eab1c99
   md5: d2b24736491290a6c6d0138932111150
   depends:
@@ -962,7 +962,7 @@ packages:
   license: GPL-2.0-only and LicenseRef-FreeType
   size: 965280
   timestamp: 1635422707211
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
   sha256: cfef2f1f3f1aa159f87806b7fa2b65c02c0d6f9bd24ccda833b43246c5095be6
   md5: 394ec1374a92c6fd5f772343934337e4
   depends:
@@ -971,7 +971,7 @@ packages:
   license_family: BSD
   size: 260575
   timestamp: 1695734561396
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
   sha256: 3c8ece1a7257b1d45f8fa25f46504bb709a1923d7175f2996e891366ec434b9d
   md5: 299bf4271d710651a1d71d3795580c2d
   depends:
@@ -979,7 +979,7 @@ packages:
   license: MIT
   size: 83592
   timestamp: 1603192039050
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.16.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.16.2-py39h06a4308_0.tar.bz2
   sha256: 2e5fb1c82cc47f1ad7183ff2fefc18d220e83bd33f040c84d4fb041c7f7ba382
   md5: 8d76398418d08803d4584117fc3f4260
   depends:
@@ -996,7 +996,7 @@ packages:
   license_family: BSD
   size: 4477427
   timestamp: 1686339582413
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
   sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
   md5: 9213e0336e3a5216c989cfe52648412e
   depends:
@@ -1005,7 +1005,7 @@ packages:
   license: MIT
   size: 23805906
   timestamp: 1588026213084
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
   sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
   md5: 1eb52f9f45cea2fb9ce27b19f990160e
   depends:
@@ -1014,7 +1014,7 @@ packages:
   license_family: BSD
   size: 110793
   timestamp: 1666125606878
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
   sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
   md5: 126b3c1933b7364ff03f67455b687e99
   depends:
@@ -1024,7 +1024,7 @@ packages:
   license_family: APACHE
   size: 37588
   timestamp: 1678997134023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
   sha256: 1b424413f28b840fc6d4bf467f37e9e405823b1e3b899005df80152d48936d64
   md5: 4aa8bcf74c81cd3600978f791191692a
   constrains:
@@ -1033,7 +1033,7 @@ packages:
   license_family: Proprietary
   size: 9246735
   timestamp: 1634546760713
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
   sha256: b51b2e0dd37a74784ba19db22aded3f4c843b6fddb4a74399f65f36fc018aaa2
   md5: 0d56ab1950f952284b895ac0f78284a7
   depends:
@@ -1053,7 +1053,7 @@ packages:
   license_family: BSD
   size: 203541
   timestamp: 1671488675347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
   sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
   md5: ff47e0be879e817713ce2a9daa76e2b0
   depends:
@@ -1074,7 +1074,7 @@ packages:
   license_family: BSD
   size: 1261116
   timestamp: 1694181530670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
   sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
   md5: 5ef6c6a0d1ac79143c7359d305155167
   depends:
@@ -1084,7 +1084,7 @@ packages:
   license_family: MIT
   size: 1021637
   timestamp: 1644297140650
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
   sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
   md5: eaeb023688f781e7dd89e74310c38195
   depends:
@@ -1094,7 +1094,7 @@ packages:
   license_family: BSD
   size: 211775
   timestamp: 1666908212136
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
   sha256: 85348bfb14db4fea84078d703e766a3c978c5a592a06e41266748826dd59d8ae
   md5: 6e1c0fb5260c590f7ef5235cb3d05863
   depends:
@@ -1103,7 +1103,7 @@ packages:
   license_family: Other
   size: 279884
   timestamp: 1651065953960
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
   sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
   md5: 0d2c3c5edf671b575532d5a3e8bf15fc
   depends:
@@ -1114,7 +1114,7 @@ packages:
   license_family: MIT
   size: 131510
   timestamp: 1676558716852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
   sha256: 92bc012f9eb4ad71158cf4826fd3e125fcebff53b529276a81224acda48be547
   md5: c5fd100e3062e831cbdf33331042f627
   depends:
@@ -1130,7 +1130,7 @@ packages:
   license_family: BSD
   size: 190884
   timestamp: 1650622553813
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
   sha256: 0192bd48cd96c60dc3054d5addd8cdb4a29a218843181318371f79daec8242f8
   md5: d851b401dc13d04e6848bb36e12efc1c
   depends:
@@ -1141,7 +1141,7 @@ packages:
   license_family: BSD
   size: 91534
   timestamp: 1679906652183
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
   sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
   md5: a4beb461f0a60998a090d760b5c6c907
   depends:
@@ -1165,7 +1165,7 @@ packages:
   license_family: BSD
   size: 411564
   timestamp: 1671707702849
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
   sha256: 974df3dc76089be57b327acd6634384def84249003f58678ca1142bb274a75d9
   md5: 81b969d1a00153759b30554a1f11ddfd
   depends:
@@ -1176,7 +1176,7 @@ packages:
   license_family: BSD
   size: 92144
   timestamp: 1653292217019
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -1187,7 +1187,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
   sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
   md5: 9508af80612e4fa1b5d1abb43ca7e63c
   constrains:
@@ -1195,7 +1195,7 @@ packages:
   license: GPL-3.0-only
   size: 749072
   timestamp: 1652971360657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
   sha256: 3b4afe7665dcdb99bd4586a888b85b2e0325f8faecdd31c7780792080ee97872
   md5: 822b5201dde61bc838072dc5b670c88c
   depends:
@@ -1204,7 +1204,7 @@ packages:
   license: Custom
   size: 55183
   timestamp: 1594054267890
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
   sha256: c6fafbe73d2f93b91b6f4b65829f925f52a8f84746a57abd216b39da9ce8c494
   md5: 238f19c803a6ba7bd6dbd6989e03cbf1
   depends:
@@ -1212,13 +1212,13 @@ packages:
   license: GPL
   size: 8496776
   timestamp: 1560112207081
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-7.3.0-hdf63c60_0.tar.bz2
   sha256: 83c6fdb30a240fbaa09f5d2e2ae8f092759cb710bc3fa628ccb18934fc237b7f
   md5: 6003e09e8cef9aca91b954abfdd0f39c
   license: GPL
   size: 1336385
   timestamp: 1534628456385
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
   sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
   md5: 3080c2813e6e1d0f8a100a38b5b3456d
   depends:
@@ -1226,7 +1226,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 573231
   timestamp: 1654090775721
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.1.0-h3826bc1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libllvm11-11.1.0-h3826bc1_1.tar.bz2
   sha256: effad2034f13cf7f1cdc51127e3a88123ae957c13f8c95f1817dfd79b5eba779
   md5: c261302f1b58f6b2851f856d230dc947
   depends:
@@ -1237,7 +1237,7 @@ packages:
   license_family: Apache
   size: 29798461
   timestamp: 1647523885063
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
   sha256: bc3e6e79c32ff0ecea601aa108ae9cf4068f69703580e40e266ad4bcc52cff54
   md5: 9cb85601944ca7383b1769bff74b94e8
   depends:
@@ -1246,7 +1246,7 @@ packages:
   license: zlib/libpng
   size: 372914
   timestamp: 1556041895170
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -1254,13 +1254,13 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
   sha256: 43b0bd205f539583c088feb5b8d77b60c83d1df80c2a93dac9f2a1127001b2cf
   md5: 53fa39fdae936e9d07c4b2f5ef361993
   license: GPL3 with runtime exception
   size: 4246257
   timestamp: 1560112223556
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
   sha256: 711ea05b4c35bdafc762a172b01db896b17942f474c2b1a519f91370964bf9bc
   md5: b25d56d33596623a6a4a9d9baaa4f602
   depends:
@@ -1274,7 +1274,7 @@ packages:
   license: HPND
   size: 592974
   timestamp: 1653047881023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
   sha256: 146dbb1e4dbccdd57819e5102a8ca00970b8e33d6c6180e8007db89b184da569
   md5: c566a384259c1d2769852c3bddd81a67
   depends:
@@ -1288,7 +1288,7 @@ packages:
   license_family: BSD
   size: 90150
   timestamp: 1645441199289
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
   sha256: cffb5a063111f7a99a99c74770b23db5dde52325e25a7a46d1903d5ff4a82c88
   md5: eeb1bd66f28bed1956ab989d6eff7ae5
   depends:
@@ -1299,7 +1299,7 @@ packages:
   license_family: BSD
   size: 889956
   timestamp: 1645089138421
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
   sha256: 71f6c4a97014d745c58df52b4dd60ddd75a8508d54fe5b97f42bd1f31cb1c067
   md5: 686e77514ec9f1ef0a6feed374f14d37
   depends:
@@ -1311,7 +1311,7 @@ packages:
   license_family: MIT
   size: 789469
   timestamp: 1653546418059
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
   sha256: ea3355a67c5173f3944f09861043ca66eb7dbeff8f385d13528b3aabc0801d0c
   md5: 66e2aa12181bb2911485bdbe125d24c5
   depends:
@@ -1321,7 +1321,7 @@ packages:
   license: MIT
   size: 584199
   timestamp: 1654075843119
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
   sha256: 497e0a8e555539787dd237dea5d13a0a6061db2cb50ded20daddaf08bbf267cc
   md5: ecc0c3c465bbf6988ebbc6a38e2eeb1c
   depends:
@@ -1333,7 +1333,7 @@ packages:
   license: BSD-2-Clause
   size: 2826845
   timestamp: 1647870510956
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
   sha256: d8cd22ac7f033507549f6a0d078cd273607cb6e8246b0383375a33941969c12c
   md5: 78c7a3a437536ae24d2d7ce15ec400d2
   depends:
@@ -1342,7 +1342,7 @@ packages:
   license_family: BSD
   size: 11065
   timestamp: 1652903210940
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
   sha256: 64b022d706b76c33965a250fdc8c6008443c41bff8ab27bb1df3cb70419576fd
   md5: ec4f05846aacf634df15c389235725cc
   depends:
@@ -1354,7 +1354,7 @@ packages:
   license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
   size: 1538261
   timestamp: 1646624639995
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
   sha256: 2c6a5dda7c510a961bc78e31d4232be5e8e0760c93454f5fd200c379355e0f5e
   md5: f35d4bf2fbb39e334992f6dd39f8721e
   depends:
@@ -1364,7 +1364,7 @@ packages:
   license_family: BSD
   size: 220865
   timestamp: 1627657046002
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
   sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
   md5: 421f82c8274b44660dba629134faa6af
   depends:
@@ -1374,7 +1374,7 @@ packages:
   license_family: BSD
   size: 122221
   timestamp: 1671541990505
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
   sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
   md5: feb0e452205b44ac45d9b5e55c21a3b1
   depends:
@@ -1386,7 +1386,7 @@ packages:
   license_family: BSD
   size: 22819
   timestamp: 1654597913064
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
   sha256: dc51b316ef5dcfb82a9c0afdc40879146ae59516f6cea7db776077783dfd2d76
   md5: b0b6b57c140f026b8806051107336576
   depends:
@@ -1408,7 +1408,7 @@ packages:
   license_family: PSF
   size: 7729454
   timestamp: 1647442028622
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
   sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
   md5: c04ef34af33da4c71bcc99b7ec24d210
   depends:
@@ -1418,7 +1418,7 @@ packages:
   license_family: BSD
   size: 16391
   timestamp: 1662014553452
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
   sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
   md5: f6c734d73e6e3dbc1b62766cf18ff3e4
   depends:
@@ -1428,7 +1428,7 @@ packages:
   license_family: BSD
   size: 58153
   timestamp: 1607364912263
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
   sha256: 7c4ded8b2ef036839f988560848d2c32e1aa4627fd37a32710e42c39f5c61ac2
   md5: bd20f4410b81f327e35ffa0657961146
   depends:
@@ -1439,7 +1439,7 @@ packages:
   license_family: Proprietary
   size: 229783051
   timestamp: 1634547157986
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
   sha256: 5394f5efd53afb2c1b0abf571ce3d9cb684b6c7e255f140ba2acaa703d6113be
   md5: d3cb2bfa63e30153f5527797dcc87280
   depends:
@@ -1451,7 +1451,7 @@ packages:
   license_family: BSD
   size: 63551
   timestamp: 1626176932911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
   sha256: c244d23da2749857a993f84969fd35ffd183ab8f462986df6d33ae0f705fe034
   md5: 9b1f8ccc2488d0e04eb73211e2987483
   depends:
@@ -1465,7 +1465,7 @@ packages:
   license: BSD 3-Clause
   size: 204136
   timestamp: 1634566416657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
   sha256: f81f426f8ef306d636664bc49e7cdd70e2b4306d7c6bcb9c75fe35a45ab2087a
   md5: 77aa1d7f958d36bf227e6ff4a34d2e3d
   depends:
@@ -1479,7 +1479,7 @@ packages:
   license: BSD-3-Clause
   size: 365386
   timestamp: 1626186165897
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
   sha256: 305313d215116fbf13a38f8a321eb635b83294871801ac63e543a59ba7de642c
   md5: e0db8ae050bd0db74f47edc370dbc287
   depends:
@@ -1489,7 +1489,7 @@ packages:
   license_family: BSD
   size: 24480
   timestamp: 1607574279743
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
   sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
   md5: 95c83d71814c504b5504df4f14548f1a
   depends:
@@ -1515,7 +1515,7 @@ packages:
   license_family: BSD
   size: 8257558
   timestamp: 1681756322140
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
   sha256: 1b92d72b083f3350359b8fb2e3b5dc846f49650c9e46a6a74354b1b7f0d42730
   md5: 996babe4314515ddd41008a53cb5d47f
   depends:
@@ -1528,7 +1528,7 @@ packages:
   license_family: BSD
   size: 98791
   timestamp: 1650290544347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
   sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
   md5: 1710a25086c8098367eb36b9d441448b
   depends:
@@ -1556,7 +1556,7 @@ packages:
   license_family: BSD
   size: 569683
   timestamp: 1668450704669
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
   sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
   md5: 385cc9e53404776782502c0fdb08820f
   depends:
@@ -1569,7 +1569,7 @@ packages:
   license_family: BSD
   size: 147046
   timestamp: 1694616899309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
   sha256: 0807371380965e421cb5f3f2a30d790fd5c41db11dbb6d318e14294c3b1741ed
   md5: fca4bd4e3891aebf4fd7daf9b6d0ccfa
   depends:
@@ -1577,7 +1577,7 @@ packages:
   license: Free software (MIT-like)
   size: 1083412
   timestamp: 1636570020698
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
   sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
   md5: bbbcbebc20a4fdcadce398d0ca04f95e
   depends:
@@ -1586,7 +1586,7 @@ packages:
   license_family: BSD
   size: 13109
   timestamp: 1672387143252
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
   sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
   md5: 248ce515640465371927d46f389ed555
   depends:
@@ -1611,7 +1611,7 @@ packages:
   license_family: BSD
   size: 594054
   timestamp: 1690985006481
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
   sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
   md5: 70db71df4ee1cdd38090c0f7b80ba61f
   depends:
@@ -1621,7 +1621,7 @@ packages:
   license_family: BSD
   size: 21944
   timestamp: 1668160644514
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
   sha256: 30f95c6c51ee7ca01801778b1773d8ecb57fcf06e864093f27148e1298517c20
   md5: 1c1f0821f0dd2ece64844f39edcbd03f
   depends:
@@ -1644,7 +1644,7 @@ packages:
   license_family: BSD
   size: 3982289
   timestamp: 1648045822890
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
   sha256: 15a12c8bebcda45c577e61cea412d9aafaa433e39f9e91fd61bbfab66fcee3ab
   md5: 5239d8330e8bd34972fb80918dce79e7
   depends:
@@ -1660,7 +1660,7 @@ packages:
   license_family: MIT
   size: 136437
   timestamp: 1640689905588
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.21.5-py39he7a7128_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.21.5-py39he7a7128_2.tar.bz2
   sha256: 9195828a286d79621f63766a1ac1143de7b862ae17ce5e95ca0c3a5c171868a1
   md5: 2bd04a53d17b21af64f413dc810b3d94
   depends:
@@ -1676,7 +1676,7 @@ packages:
   license: BSD-3-Clause
   size: 9728
   timestamp: 1651566346644
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.21.5-py39hf524024_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.21.5-py39hf524024_2.tar.bz2
   sha256: dbd1301d64a55552a01d74a1928d279646a97158cad3cce7e05548b6fa112338
   md5: e5666032c7865b4977e740e6f069e540
   depends:
@@ -1691,7 +1691,7 @@ packages:
   license: BSD-3-Clause
   size: 6385715
   timestamp: 1651566332949
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
   sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
   md5: 5ad4571eba2479f77a9f849a6ae7724c
   depends:
@@ -1701,7 +1701,7 @@ packages:
   license_family: Apache
   size: 3998613
   timestamp: 1694465071784
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
   sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
   md5: 77a22ed6d0d448c5288d0f695bc9ac49
   depends:
@@ -1710,7 +1710,7 @@ packages:
   license_family: Apache
   size: 72527
   timestamp: 1693575234886
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
   sha256: e7a0abb0f00a94000876f2095f0cf531ad3803ffbd868a780b3f06816b54492c
   md5: 97ef7e1fe923d22a8e2307f3f39a92d5
   depends:
@@ -1726,7 +1726,7 @@ packages:
   license_family: BSD
   size: 13221005
   timestamp: 1650622404234
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
   sha256: 49fdb57b2ed2ce4d6bb7a2c5adec36ba59522518a41fb941f9e39a9f43750cc5
   md5: 871b65444733b7da5823ee0dc9826722
   depends:
@@ -1747,7 +1747,7 @@ packages:
   license_family: BSD
   size: 14712394
   timestamp: 1676379803902
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
   sha256: 64a732ce2661cdb6bd8f9d1484ac10afeb73082b1c2b44728d212e0117d2860e
   md5: ada303f0cf43a4e99cfa7f243b23b681
   depends:
@@ -1756,7 +1756,7 @@ packages:
   license_family: BSD
   size: 141832
   timestamp: 1684915385689
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
   sha256: 9c699bd495cbf23db7dea986deeb75183571b83adc14b3e4a36cc6cfd2a198a8
   md5: 39ed6f683307cca54ac666b2d1f849ff
   depends:
@@ -1770,7 +1770,7 @@ packages:
   license_family: BSD
   size: 35706
   timestamp: 1698702632637
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
   sha256: 8bcb1c67693f42a3170eb77ef4cdbb81b605fdf40816953e69a33a065c101638
   md5: b7689507fb5f879dc766aaa8a4c37351
   depends:
@@ -1789,7 +1789,7 @@ packages:
   license_family: Other
   size: 734566
   timestamp: 1646325095608
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
   sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
   md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
   depends:
@@ -1800,7 +1800,7 @@ packages:
   license_family: MIT
   size: 2674850
   timestamp: 1697548887851
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
   sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
   md5: fe56f0479dd414c846191116366262c3
   depends:
@@ -1809,7 +1809,7 @@ packages:
   license_family: MIT
   size: 31999
   timestamp: 1692205535111
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
   sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
   md5: 44d2a857d13bdf9d99aaac039a249d47
   depends:
@@ -1818,7 +1818,7 @@ packages:
   license_family: Apache
   size: 91137
   timestamp: 1659455142164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
   sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
   md5: eb899a739d9b58dd747f1f6bd52d4cf3
   depends:
@@ -1830,7 +1830,7 @@ packages:
   license_family: BSD
   size: 579771
   timestamp: 1672387338600
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
   sha256: 6973cfe0565ba3b5ad6d1de9e34848fbbadd78b507b2e23e1c079636b8f8f317
   md5: a924535045fb356e23e7a3cc8116b638
   depends:
@@ -1840,7 +1840,7 @@ packages:
   license_family: BSD
   size: 350026
   timestamp: 1612298042840
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
   sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
   md5: f36ecb722522cbe2e3737424edf1b5e1
   depends:
@@ -1852,7 +1852,7 @@ packages:
   license_family: BSD
   size: 29312
   timestamp: 1675441510984
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
   sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
   md5: 6d03295e544251e608a28c8d7c48115e
   depends:
@@ -1861,7 +1861,7 @@ packages:
   license_family: BSD
   size: 1862058
   timestamp: 1684280096752
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
   sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
   md5: 1f09617aecd6f3c2f2e20692c0759f34
   depends:
@@ -1871,7 +1871,7 @@ packages:
   license_family: Apache
   size: 94434
   timestamp: 1690223520097
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
   sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
   md5: ffceed627867508d73af1636ab5ebf42
   depends:
@@ -1880,7 +1880,7 @@ packages:
   license_family: MIT
   size: 156324
   timestamp: 1661452578573
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
   sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
   md5: 0e3341a4fe434167bf74b613eb6afd81
   depends:
@@ -1890,7 +1890,7 @@ packages:
   license_family: MIT
   size: 97194
   timestamp: 1636110999719
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
   sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
   md5: c5f3f7f10ad30f0945e75252615ab6e5
   depends:
@@ -1899,7 +1899,7 @@ packages:
   license_family: BSD
   size: 31331
   timestamp: 1605305847037
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
   sha256: c4b9e332a6f2b7524e8c88e2b39a2568a48e556fd9a44c30759c43611d4d023d
   md5: bb118745c9b08fc5028f45e77f371e68
   depends:
@@ -1919,7 +1919,7 @@ packages:
   license_family: PSF
   size: 24553777
   timestamp: 1654084160832
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
   sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
   md5: 0caa188a695319bdb13f53b0a2b3accc
   depends:
@@ -1928,7 +1928,7 @@ packages:
   license_family: BSD
   size: 264864
   timestamp: 1661371117920
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
   sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
   md5: bcb44ecbea441ee0d4659133d060d71f
   depends:
@@ -1937,7 +1937,7 @@ packages:
   license_family: MIT
   size: 257904
   timestamp: 1695131670290
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
   sha256: e937081facacb141dc2c9cdcced92baa9a2662e4a56100b6041df0b6b7692570
   md5: f3ac39b2349258198a9b3316636fe5d5
   depends:
@@ -1947,7 +1947,7 @@ packages:
   license_family: BSD
   size: 39972
   timestamp: 1685030752528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
   sha256: 3da9cbbd49fac566433748bd245d09d7d5fcd28b04c0397cbbf6d5bb92f5c4a5
   md5: df73a5d2f6e089d51e71e91935a82c65
   depends:
@@ -1958,7 +1958,7 @@ packages:
   license_family: MIT
   size: 183753
   timestamp: 1635775763162
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
   sha256: 26005d191bb15070aad70707ed6493f32678a67978bd3b83d4c9679cab44e717
   md5: 2dc75d5a4ccb64310939c3a72d34ae20
   depends:
@@ -1969,7 +1969,7 @@ packages:
   license_family: BSD
   size: 521583
   timestamp: 1638435042256
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
   sha256: 8c950c69bee969e2c66f88f0dc247b3ab75a753672a88009779d5f5dba193532
   md5: 150ac0eb929bab9dec912797bdfc7b95
   depends:
@@ -1979,7 +1979,7 @@ packages:
   license_family: GPL
   size: 433182
   timestamp: 1642022402894
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
   sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
   md5: c7de00b4ac2778c4e5a7816320d75391
   depends:
@@ -1995,7 +1995,7 @@ packages:
   license_family: Apache
   size: 94028
   timestamp: 1690400356879
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.6.2-py39had2a1c9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/scipy-1.6.2-py39had2a1c9_1.tar.bz2
   sha256: 2cf06019a66fbb0a9df571bac7f0460eb66f60d6b9c37f6a64a6dcddbe2c765f
   md5: 5f18311a95358bb951f98a6d005a862d
   depends:
@@ -2010,7 +2010,7 @@ packages:
   license: BSD 3-Clause
   size: 21512828
   timestamp: 1618856702227
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
   sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
   md5: 1581cafc84708ed9aafaaee1cbbf6065
   depends:
@@ -2019,7 +2019,7 @@ packages:
   license_family: MIT
   size: 1089416
   timestamp: 1690290900608
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
   sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
   md5: e19ffbfb24b990275d24fcea2bd1699b
   depends:
@@ -2028,7 +2028,7 @@ packages:
   license_family: Apache
   size: 15702
   timestamp: 1614030498860
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
   sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
   md5: ca061ce25c0f58628643abec8d6a8244
   depends:
@@ -2037,7 +2037,7 @@ packages:
   license_family: MIT
   size: 66330
   timestamp: 1696347637947
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
   sha256: 87965b7b46d93866d31696a1045216d64f077a06b2900c356aba87e8559c6188
   md5: fa334030245135b37027a882f3c468bf
   depends:
@@ -2048,7 +2048,7 @@ packages:
   license_family: Other
   size: 1561908
   timestamp: 1655328608308
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tbb-2021.5.0-hd09550d_0.tar.bz2
   sha256: d4c0f3e57d8df6042151e65a706f8cd76c9325a47548f4ca3c3516e352dd8ca3
   md5: 1decb9dd0e7bcee086d83b8b4ab8c8eb
   depends:
@@ -2057,7 +2057,7 @@ packages:
   license: Apache-2.0
   size: 171277
   timestamp: 1641830509786
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
   sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
   md5: 0e76eab58fe488e91f0aee73f46de031
   depends:
@@ -2068,7 +2068,7 @@ packages:
   license_family: BSD
   size: 29816
   timestamp: 1671751864131
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
   sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
   md5: b413a210eca82fe867e991eed085201b
   depends:
@@ -2078,7 +2078,7 @@ packages:
   license_family: BSD
   size: 38882
   timestamp: 1668168876032
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
   sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
   md5: 5b8375e2092012db69d2123dc0c68630
   depends:
@@ -2088,7 +2088,7 @@ packages:
   license_family: BSD
   size: 3485432
   timestamp: 1654088939579
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
   sha256: 57983e3eb698a3b08b570d5f398d9550cf50b9bf54b2b4728c731ecbc0c89138
   md5: 3ce956b1e1a7f77af6e6127dca987b95
   depends:
@@ -2097,7 +2097,7 @@ packages:
   license_family: BSD
   size: 101246
   timestamp: 1667464172523
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
   sha256: b746e39272888b9cc1a2a711b7b8836f2e26f4457850e43ad18bf0765e21dc3d
   md5: 200e86f8d53aeebf4b7dcfc944fd7920
   depends:
@@ -2107,7 +2107,7 @@ packages:
   license_family: Apache
   size: 661662
   timestamp: 1606942359431
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
   sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
   md5: 67a8320961ff24e92eebb661536e5cf7
   depends:
@@ -2120,7 +2120,7 @@ packages:
   license_family: MOZILLA
   size: 123763
   timestamp: 1679561904852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
   sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
   md5: 0f0b91a158dd3692cbb7a7763b657bfe
   depends:
@@ -2129,7 +2129,7 @@ packages:
   license_family: BSD
   size: 192032
   timestamp: 1671143995098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
   md5: 8515e64a3de7581360d713fe4c0a094e
   depends:
@@ -2139,7 +2139,7 @@ packages:
   license_family: PSF
   size: 8789
   timestamp: 1690297588156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
   md5: 60170012374b2a5007842fa5870d78c5
   depends:
@@ -2148,7 +2148,7 @@ packages:
   license_family: PSF
   size: 57479
   timestamp: 1690297581658
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
   sha256: 870f20a3c006a74b291910f69c3469a409bd21437142864b29cfafeb89ca7c34
   md5: 1b2f1589e3ebc3e0c6ecb38dba93e4ae
   depends:
@@ -2163,7 +2163,7 @@ packages:
   license_family: MIT
   size: 186761
   timestamp: 1686163186447
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
   sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
   md5: f8d03a15b974fc7810d9f54ae849fc8e
   depends:
@@ -2172,7 +2172,7 @@ packages:
   license_family: BSD
   size: 20781
   timestamp: 1607365390528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
   sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
   md5: d7db5d6ce1db80eade8a082ff78bf479
   depends:
@@ -2182,7 +2182,7 @@ packages:
   license_family: BSD
   size: 71044
   timestamp: 1614804011510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
   sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
   md5: b3899f8bda32734727bd5a73df1d7d17
   depends:
@@ -2191,7 +2191,7 @@ packages:
   license_family: MIT
   size: 101520
   timestamp: 1695742037911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
   sha256: d88bdc49a883a944cf1562ebb0a30d0451e28ab05521fc882615e357b105f414
   md5: c150cf16071597fa3977fb81ebb83760
   depends:
@@ -2203,7 +2203,7 @@ packages:
   license_family: Apache
   size: 1787638
   timestamp: 1689041557651
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
   sha256: 2ce360ff98c0ca4537d70c19266b5700810196c54ce2fbaff3b94a969846ee37
   md5: 94cb94dc47405b24b1b5bd0a3275ab59
   depends:
@@ -2212,7 +2212,7 @@ packages:
   license_family: GPL2
   size: 398058
   timestamp: 1651602137803
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -2220,7 +2220,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
   sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
   md5: 567b68192c387b5fc88178425577a0fe
   depends:
@@ -2230,7 +2230,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 366479
   timestamp: 1616055552392
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
   sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
   md5: 3818a9531fe74433c3b7d5144c9a58cc
   depends:
@@ -2239,7 +2239,7 @@ packages:
   license_family: MIT
   size: 18021
   timestamp: 1672387231268
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
   sha256: 513444d83ac2405e898531492ea59f3a95641e357cc39c1048d6fffc1791a16b
   md5: 601d9449c280b9b145dc8c83b6f06119
   depends:
@@ -2248,7 +2248,7 @@ packages:
   license_family: Other
   size: 133595
   timestamp: 1650637720646
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
   sha256: 1c049c23788a00b6f38bdc801245e0e60af98718d4db4c958658bcc67ff158c7
   md5: b1737dfd2e06ad69ec5cfec341e207c6
   depends:
@@ -2261,7 +2261,7 @@ packages:
   license_family: BSD
   size: 827172
   timestamp: 1650622223170
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -2274,7 +2274,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -2284,7 +2284,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
   md5: b2aa5503875aba2f1d88cae9df9a96d5
   depends:
@@ -2293,7 +2293,7 @@ packages:
   license_family: BSD
   size: 13636
   timestamp: 1611930018941
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -2305,7 +2305,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
   sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
   md5: 544adf2677c47c9b9c891aea720678f1
   depends:
@@ -2313,7 +2313,7 @@ packages:
   license: MIT
   size: 33999
   timestamp: 1630003259346
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -2322,7 +2322,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -2331,7 +2331,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -2340,7 +2340,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -2349,7 +2349,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
   sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
   md5: 9eff1a842dbda8d1bae9a2c008b599bc
   depends:
@@ -2360,7 +2360,7 @@ packages:
   license_family: MIT
   size: 690443
   timestamp: 1625743217109
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -2368,7 +2368,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
   sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
   md5: 33624a42ee387bf9918ea98b4e7b31fc
   depends:
@@ -2378,7 +2378,7 @@ packages:
   license_family: BSD
   size: 8173
   timestamp: 1601490751973
-- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
   sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
   md5: 67857cc5e9044770d2b15f9d94a4521d
   depends:
@@ -2387,7 +2387,7 @@ packages:
   license_family: Apache
   size: 12810
   timestamp: 1600445183315
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -2396,7 +2396,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -2405,7 +2405,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -2415,7 +2415,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
   sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
   md5: e68a6f315f41a8d814d833652bf38b9b
   depends:
@@ -2423,7 +2423,7 @@ packages:
   license: MIT
   size: 13374
   timestamp: 1606932077143
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -2431,7 +2431,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -2440,7 +2440,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -2449,7 +2449,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
   sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
   md5: 2eb923cc014094f4acf7f849d67d73f8
   depends:
@@ -2459,7 +2459,7 @@ packages:
   license_family: BSD
   size: 246457
   timestamp: 1626374695070
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
   sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
   md5: 02caf3f47f1d06256068053297355740
   depends:
@@ -2468,7 +2468,7 @@ packages:
   license_family: Apache
   size: 152292
   timestamp: 1690578151230
-- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
   sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
   md5: 41db68b96e114e367c4f120a3b379e59
   depends:
@@ -2477,7 +2477,7 @@ packages:
   license_family: BSD
   size: 19391
   timestamp: 1632406728844
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -2486,7 +2486,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -2498,14 +2498,14 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
   sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
   md5: a815d3bdb160bcc71687f2dda70d3ca4
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 122218
   timestamp: 1680170368293
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -2513,7 +2513,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
   sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
   md5: 447a49f7bad119faa80d7f14aa296c95
   depends:
@@ -2526,7 +2526,7 @@ packages:
   license_family: MIT
   size: 162176
   timestamp: 1644481750133
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
   sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
   md5: 8810f48fe4a4792de0fd3520b502d08b
   depends:
@@ -2535,7 +2535,7 @@ packages:
   license_family: BSD
   size: 10019
   timestamp: 1606859473259
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
   sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
   md5: 00a446b6dfc61af223df4de29fe8ad94
   depends:
@@ -2545,7 +2545,7 @@ packages:
   license_family: MIT
   size: 34305
   timestamp: 1644569782044
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
   sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
   md5: bd92dd8bd5b9d24e632b62a075426e50
   depends:
@@ -2554,7 +2554,7 @@ packages:
   license_family: MIT
   size: 133634
   timestamp: 1695718025321
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
   sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
   md5: f8ae051b591a9027adc16de1be9748f4
   depends:
@@ -2564,12 +2564,12 @@ packages:
   license_family: MIT
   size: 206198
   timestamp: 1681493096349
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
   sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
   md5: e2f3248e2a5009a02f7b8e54f83314ef
   size: 5620
   timestamp: 1528121955725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.4.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-2.4.3-py39hecd8cb5_0.tar.bz2
   sha256: 1f5dcdfd5854f527041cc8ad99de5b1e9de2cf89fc07d6ceebe773d0311a92b7
   md5: 6188865467aabac07a36811fc37b0982
   depends:
@@ -2585,7 +2585,7 @@ packages:
   license_family: BSD
   size: 14356265
   timestamp: 1658136884702
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
   sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
   md5: 0d79760d544d0bd8acb4adc4ef813418
   depends:
@@ -2595,7 +2595,7 @@ packages:
   license_family: BSD
   size: 137075
   timestamp: 1657175654487
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
   sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
   md5: 31d6d04cd2388d8f19004501271b3545
   depends:
@@ -2605,7 +2605,7 @@ packages:
   license: MIT
   size: 18982
   timestamp: 1659616229395
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
   sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
   md5: caf1073dc2ca5aeb832a2877394eae12
   depends:
@@ -2614,7 +2614,7 @@ packages:
   license: MIT
   size: 18233
   timestamp: 1659616216769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
   sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
   md5: aa1ed20c38af535c8d6a955314759d7b
   depends:
@@ -2623,14 +2623,14 @@ packages:
   license: MIT
   size: 394588
   timestamp: 1659616312678
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
   sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
   md5: ce3588e31faa79f546e0fc6a36c5543c
   license: MPL-2.0
   license_family: Other
   size: 133884
   timestamp: 1694009771475
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
   sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
   md5: 21eb7f53076d0a69513cfd258f6ef63c
   depends:
@@ -2639,7 +2639,7 @@ packages:
   license_family: Other
   size: 159756
   timestamp: 1690232346868
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
   sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
   md5: a40a04d9cda1e665565bc6c832d598b6
   depends:
@@ -2650,7 +2650,7 @@ packages:
   license_family: MIT
   size: 225258
   timestamp: 1670423337502
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
   sha256: b860f45bce9fbb40d024dcd3306e66a52010641091ca8d1fcdde6c4238717c73
   md5: 3c38f3af9c23b26efc2b11d82c95922a
   depends:
@@ -2659,7 +2659,7 @@ packages:
   license_family: BSD
   size: 153013
   timestamp: 1698129937688
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
   sha256: c368e11dc241d1b79b4bb0d9333b353dc1b966b49d145163a0590d88ad88fef2
   md5: 1e62044b8a32d1452e51773ba7a4319c
   depends:
@@ -2668,7 +2668,7 @@ packages:
   license_family: BSD
   size: 41392
   timestamp: 1683040146991
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
   sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
   md5: b2cc5f37f7bb069d061306e7eac2a011
   depends:
@@ -2678,7 +2678,7 @@ packages:
   license_family: CC
   size: 1913396
   timestamp: 1668084575248
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
   sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
   md5: 103d8c039e342115720a84d59c119d46
   depends:
@@ -2688,7 +2688,7 @@ packages:
   license_family: BSD
   size: 13774
   timestamp: 1671231190250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
   sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
   md5: f69f09e0346172f225390d2b3b0d7873
   depends:
@@ -2699,7 +2699,7 @@ packages:
   license_family: BSD
   size: 246628
   timestamp: 1663827484947
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
   sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
   md5: cb80c7ac65b48a737654f371fe31c460
   depends:
@@ -2712,7 +2712,7 @@ packages:
   license_family: BSD
   size: 1307228
   timestamp: 1694212041712
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
   sha256: e80ce32bc86af3e0b67d44bc2c774dde7490443bf6ae4bed7d9c666e3631965f
   md5: ba47d3bdf582bf15e9250bff6b2f6dbd
   depends:
@@ -2729,7 +2729,7 @@ packages:
   license_family: BSD
   size: 2125677
   timestamp: 1686783049768
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
   sha256: 7717c1f0af2af4b28b6d787b32c5e1740f391915c78707d8643e0d516088dbd0
   md5: d7ae4c5cb253fa85c0ce268d2bf9a191
   depends:
@@ -2751,7 +2751,7 @@ packages:
   license_family: BSD
   size: 17679970
   timestamp: 1692372465872
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
   sha256: 40bbbe2ed223829f4a3f91024fa409f1a665ad94294bec2c9e930989bb2b8911
   md5: 4add00dc619c12370af0ed18c76b71f6
   depends:
@@ -2763,7 +2763,7 @@ packages:
   license_family: BSD
   size: 103370
   timestamp: 1613390236788
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
   sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
   md5: 04cbe8f4bc62c34fac9d42d1124059bf
   depends:
@@ -2773,7 +2773,7 @@ packages:
   license_family: MIT
   size: 2052734
   timestamp: 1690905361158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
   sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
   md5: ef0e825982f242085574f502dfff4f6b
   depends:
@@ -2782,7 +2782,7 @@ packages:
   license_family: MIT
   size: 16594
   timestamp: 1649926538106
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
   sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
   md5: 24747a300246c016b3a7f04dabd02d4a
   depends:
@@ -2791,7 +2791,7 @@ packages:
   license_family: BSD
   size: 27709
   timestamp: 1668714497209
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -2801,7 +2801,7 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
   sha256: 95e9a45812b1b4059b973e5e6e131c7c1a8b2ce2dafc5117e7806b1c8f30de27
   md5: bc889aaa846ed177fc5f495c24041acc
   depends:
@@ -2810,14 +2810,14 @@ packages:
   license_family: BSD
   size: 262430
   timestamp: 1695734574609
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
   sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
   md5: e4a732941f74b8062c8bcbfe5c5c2b56
   license: MIT
   license_family: MIT
   size: 80252
   timestamp: 1676983220161
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.16.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.16.2-py39hecd8cb5_0.tar.bz2
   sha256: 00e402347930096d412390391e5d113dac1c28a19dcb94b7df3f68c3a38e4ed9
   md5: 33827cf9fc2386dbcc81c4376e29eca4
   depends:
@@ -2834,7 +2834,7 @@ packages:
   license_family: BSD
   size: 4528196
   timestamp: 1686339564809
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
   sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
   md5: f3ce6fe6eb760c236e5f7d04df5faa81
   depends:
@@ -2843,7 +2843,7 @@ packages:
   license_family: MIT
   size: 28138484
   timestamp: 1692293212596
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
   sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
   md5: 6dd72c43fea25b748ec7a9f6c0407e15
   depends:
@@ -2852,7 +2852,7 @@ packages:
   license_family: BSD
   size: 111810
   timestamp: 1666125671024
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
   sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
   md5: 03cdb7e679924b329ecab8f12cb8fc67
   depends:
@@ -2862,7 +2862,7 @@ packages:
   license_family: APACHE
   size: 38813
   timestamp: 1678997212422
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
   sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
   md5: e113c4e6e758dd68faf196586bf5564d
   depends:
@@ -2872,7 +2872,7 @@ packages:
   license_family: Apache
   size: 51873
   timestamp: 1698254765815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
   sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
   md5: 78baea934985ccd9514a366cc7e80ed4
   depends:
@@ -2881,7 +2881,7 @@ packages:
   license_family: Proprietary
   size: 727499
   timestamp: 1681801225190
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
   sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
   md5: da9b63e42f281f7e77b289f4b654b83b
   depends:
@@ -2903,7 +2903,7 @@ packages:
   license_family: BSD
   size: 218436
   timestamp: 1691121840155
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
   sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
   md5: 6a7cb9b49593b29933fa2b503d533a08
   depends:
@@ -2925,7 +2925,7 @@ packages:
   license_family: BSD
   size: 1257205
   timestamp: 1694181720454
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
   sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
   md5: d861ef66f5c0a282d60b65778a9de2f3
   depends:
@@ -2935,7 +2935,7 @@ packages:
   license_family: MIT
   size: 1048450
   timestamp: 1644315332508
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
   sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
   md5: f7e603c965052deed8b789c35855a42f
   depends:
@@ -2945,14 +2945,14 @@ packages:
   license_family: BSD
   size: 213537
   timestamp: 1666908270815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
   sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
   md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
   license: IJG
   license_family: Other
   size: 278924
   timestamp: 1677849185191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
   sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
   md5: a82a17e78f725dcbd71ff8dac6db05c7
   depends:
@@ -2963,7 +2963,7 @@ packages:
   license_family: MIT
   size: 133134
   timestamp: 1676558895333
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
   sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
   md5: ee9270379a9ebdb6297e4b6849b3f7f0
   depends:
@@ -2979,7 +2979,7 @@ packages:
   license_family: BSD
   size: 195479
   timestamp: 1676329410154
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 32b898a97dca7770858ab31294238fde11ab61a84831a52f320e5ee5405a147c
   md5: 926e754b8fad288b583ef2933deae1a5
   depends:
@@ -2990,7 +2990,7 @@ packages:
   license_family: BSD
   size: 92938
   timestamp: 1679906616072
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
   sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
   md5: 7e60995b3119417213e5faedda147499
   depends:
@@ -3014,7 +3014,7 @@ packages:
   license_family: BSD
   size: 403165
   timestamp: 1671707664990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
   sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
   md5: cd470bdb28bb0e8b3535c93a3a6dad07
   depends:
@@ -3024,7 +3024,7 @@ packages:
   license_family: BSD
   size: 65431
   timestamp: 1672387389172
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -3034,7 +3034,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -3043,13 +3043,13 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
   sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
   md5: 7dba7aa5b971febb55281659843586ba
   license: MIT
   size: 65470
   timestamp: 1659616172703
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
   sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
   md5: f78a158983f0bbaba56f34b976bc6dae
   depends:
@@ -3057,7 +3057,7 @@ packages:
   license: MIT
   size: 34189
   timestamp: 1659616189313
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
   sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
   md5: 36a1d885725d3ab4d1fadc5a29f978d2
   depends:
@@ -3065,28 +3065,28 @@ packages:
   license: MIT
   size: 327737
   timestamp: 1659616202869
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
   sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
   md5: 817848d0e2b2808acdc9b3fbbf581726
   license: MIT
   license_family: MIT
   size: 133887
   timestamp: 1683716590737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
   sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
   md5: e458587c87e3f2d20192f4e0738f2c63
   depends:
@@ -3095,7 +3095,7 @@ packages:
   license_family: GPL
   size: 149419
   timestamp: 1665498987619
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
   sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
   md5: 1058b661ec829b2ee3716ee2a5520641
   depends:
@@ -3106,14 +3106,14 @@ packages:
   license_family: GPL
   size: 1917987
   timestamp: 1665498925405
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
   sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
   md5: c90372428e1e4eed4fdcd790979d06b4
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1409377
   timestamp: 1650983531933
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
   sha256: 8176dd9a68815301a24ed51e72f3506f5f77c67a112efa0dd14971f2f3b3c8c1
   md5: b5e470c224000a6bda6f655c155b53e7
   depends:
@@ -3125,7 +3125,7 @@ packages:
   license_family: Apache
   size: 27861431
   timestamp: 1683292881730
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -3134,13 +3134,13 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -3157,7 +3157,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
   sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
   md5: c0b99f8e1c7475f23b1c7b4250b06e1c
   depends:
@@ -3171,7 +3171,7 @@ packages:
   license_family: BSD
   size: 88021
   timestamp: 1694778290062
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
   sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
   md5: 46a65d1fc24013217e06aaf6d65ffcad
   constrains:
@@ -3180,7 +3180,7 @@ packages:
   license_family: BSD
   size: 425478
   timestamp: 1694776947990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
   sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
   md5: 06866415ef22d5322f9bdc9956b59c4d
   depends:
@@ -3192,7 +3192,7 @@ packages:
   license_family: MIT
   size: 678174
   timestamp: 1692970318885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
   sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
   md5: 2edc6c894d6d0321304396e9bd40df94
   depends:
@@ -3202,7 +3202,7 @@ packages:
   license_family: MIT
   size: 241774
   timestamp: 1692973618934
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
   sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
   md5: 5c740b4a18a558de0ccfe601703c423c
   constrains:
@@ -3211,7 +3211,7 @@ packages:
   license_family: Apache
   size: 338738
   timestamp: 1662635677689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
   sha256: fbf3c01a0834c151485b1b2ddf0c83d43703cbea051c6dbcb0d8d41946107670
   md5: 12137025daee35f5c708ca10d0c96e3c
   depends:
@@ -3223,7 +3223,7 @@ packages:
   license_family: BSD
   size: 318622
   timestamp: 1697031357874
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 1dab4daa56408915de3ec270c8b887e7221d48633ea83b0afff61041fc197972
   md5: 1519f9b766f9f894282db8353066e3b2
   depends:
@@ -3232,7 +3232,7 @@ packages:
   license_family: BSD
   size: 11883
   timestamp: 1652903144294
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
   sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
   md5: 8bbd981ca0129d7beeacd3cd7623f714
   depends:
@@ -3243,7 +3243,7 @@ packages:
   license_family: Other
   size: 1491074
   timestamp: 1695058597986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
   sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
   md5: d5f58d056b4bfc67aec30c77035ba889
   depends:
@@ -3252,7 +3252,7 @@ packages:
   license_family: BSD
   size: 182491
   timestamp: 1670944720979
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
   sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
   md5: 1affd16b166571a91feae04baf5fd3da
   depends:
@@ -3262,7 +3262,7 @@ packages:
   license_family: BSD
   size: 123431
   timestamp: 1671542016019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
   sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
   md5: 3681ebf029211ceab26af6f5d35abf39
   depends:
@@ -3273,7 +3273,7 @@ packages:
   license_family: BSD
   size: 22254
   timestamp: 1654598220251
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
   sha256: 2fd179efa024c92d0d71179a981a781d16c70f5d8c6305e0d678b0c7ae1275ab
   md5: addda7f015d1673f794a23fdb18a3e09
   depends:
@@ -3296,7 +3296,7 @@ packages:
   license_family: PSF
   size: 8182219
   timestamp: 1698692361219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
   sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
   md5: 6eb64ecfcd754502e271db0bb51d2cfd
   depends:
@@ -3306,7 +3306,7 @@ packages:
   license_family: BSD
   size: 17374
   timestamp: 1662014643620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
   sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
   md5: 2a4d604717a647ad21af766289cbbfc3
   depends:
@@ -3315,7 +3315,7 @@ packages:
   license_family: BSD
   size: 58057
   timestamp: 1607364912348
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
   sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
   md5: 25051fe272624544652dc6d814c2943a
   depends:
@@ -3328,7 +3328,7 @@ packages:
   license_family: Proprietary
   size: 224420228
   timestamp: 1691503125614
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
   sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
   md5: 37d8cf85a63f7aa9af1624894a7d606d
   depends:
@@ -3338,7 +3338,7 @@ packages:
   license_family: BSD
   size: 48590
   timestamp: 1682969183093
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
   sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
   md5: 0b2aee6666135bbd36b46d6ac66160f7
   depends:
@@ -3351,7 +3351,7 @@ packages:
   license_family: BSD
   size: 210705
   timestamp: 1695058433223
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
   sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
   md5: e22fb55ce380d0ebd44cce3f20d5349e
   depends:
@@ -3365,7 +3365,7 @@ packages:
   license_family: BSD
   size: 296614
   timestamp: 1695060155673
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
   sha256: 5f60ca253f1fea0a1d765f535ff9ca2cf7efba90aea4c9a290d8f50ad11d4f6f
   md5: 97d6ec94e2300030bddf0e5289cd2a84
   depends:
@@ -3375,7 +3375,7 @@ packages:
   license_family: BSD
   size: 24240
   timestamp: 1607574265505
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
   sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
   md5: 1a5d4004e64e3cfb7a2a297b9117c285
   depends:
@@ -3401,7 +3401,7 @@ packages:
   license_family: BSD
   size: 8213832
   timestamp: 1681756573646
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
   sha256: 2975bd1f98ca9ec7354ee378f86f8322ec90f568374776fd90e80c534fbee882
   md5: 798627089e0ccba26695a26d9cb127ec
   depends:
@@ -3414,7 +3414,7 @@ packages:
   license_family: BSD
   size: 99066
   timestamp: 1650308465824
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
   sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
   md5: e572c1264a7af20b486f64ac8c9e1f57
   depends:
@@ -3442,7 +3442,7 @@ packages:
   license_family: BSD
   size: 573356
   timestamp: 1668450732828
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
   sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
   md5: b67569a7c30af9ffa5cde6e4b52ac68b
   depends:
@@ -3455,14 +3455,14 @@ packages:
   license_family: BSD
   size: 148342
   timestamp: 1694616917184
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
   sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
   md5: 97b81f34efbe86c5220fe82eb584fd62
   depends:
@@ -3471,7 +3471,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387288528
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
   sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
   md5: d77862975a9a1cf50acb803be26e83a1
   depends:
@@ -3496,7 +3496,7 @@ packages:
   license_family: BSD
   size: 575365
   timestamp: 1690985052739
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
   sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
   md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
   depends:
@@ -3506,7 +3506,7 @@ packages:
   license_family: BSD
   size: 22858
   timestamp: 1668160618784
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
   sha256: 249efa747726ad61bc1093f33f155f0b7a0fa5b728cb1a6a6bd126458f279c96
   md5: 1cced9a92d68307846cf59c238a42f13
   depends:
@@ -3526,7 +3526,7 @@ packages:
   license_family: BSD
   size: 4431283
   timestamp: 1697057424792
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
   sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
   md5: 185e9c41abb88ee59b52ec0f5f65d506
   depends:
@@ -3540,7 +3540,7 @@ packages:
   license_family: MIT
   size: 138305
   timestamp: 1696515469702
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
   sha256: 361754aae186c6f4f8e5ceadf02b95ae74b47a97eaf1aa37538a7c410fb3ec88
   md5: 02e4a556e3eb2375ec5a75795dd32372
   depends:
@@ -3556,7 +3556,7 @@ packages:
   license_family: BSD
   size: 12847
   timestamp: 1691166007881
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
   sha256: 94d69c58f79dea6d155debef3237f02397ab6c3d042b519ad89fc64d204507d2
   md5: 891a8850c69fd11971e58dfba0c40fcd
   depends:
@@ -3571,7 +3571,7 @@ packages:
   license_family: BSD
   size: 7529822
   timestamp: 1691165972737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
   sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
   md5: 93f5d7b66976154adeda219bea02ba45
   depends:
@@ -3581,7 +3581,7 @@ packages:
   license: BSD 2-Clause
   size: 484257
   timestamp: 1630093862501
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
   sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
   md5: 5e8713ef1215406254988163eaf34020
   depends:
@@ -3590,7 +3590,7 @@ packages:
   license_family: Apache
   size: 4965606
   timestamp: 1695323060401
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
   sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
   md5: 4154929ace2ad6ee16aea815635a6d1f
   depends:
@@ -3599,7 +3599,7 @@ packages:
   license_family: Apache
   size: 73598
   timestamp: 1693575307570
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
   sha256: aff5acedef9da91b77851e1a163b8319d72bc4152c98ac87703a2eac1e5d575b
   md5: 7df4c76aa8c52fedce5346748d56459e
   depends:
@@ -3646,7 +3646,7 @@ packages:
   license_family: BSD
   size: 13388063
   timestamp: 1697477404222
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-0.14.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-0.14.3-py39hecd8cb5_0.tar.bz2
   sha256: c63341d41ad75c475a793800d229886be5aba866e1885f23778f23093b15f891
   md5: 1eaea439a84cf758cbaab861a140f67f
   depends:
@@ -3667,7 +3667,7 @@ packages:
   license_family: BSD
   size: 14708005
   timestamp: 1676380263675
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
   sha256: 914f1ec8d911083c006c4c2d3b4c0c528e79abba3ae5f1dad825bd896870270d
   md5: 949e0e4c0ce43c92eb52241892230873
   depends:
@@ -3676,7 +3676,7 @@ packages:
   license_family: BSD
   size: 142949
   timestamp: 1684915417020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
   sha256: ddcb56e35d537f7a748b242c7c44368f112471973a52ae022945f597b7a83c7c
   md5: 94bac4f8fbfaf821ace161b9f1f58716
   depends:
@@ -3690,7 +3690,7 @@ packages:
   license_family: BSD
   size: 36756
   timestamp: 1698702713944
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
   sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
   md5: be0a90921f3bf4f0d6950fb786093de7
   depends:
@@ -3709,7 +3709,7 @@ packages:
   license_family: Other
   size: 719901
   timestamp: 1696580194417
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
   sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
   md5: 81ae9ec2d7fcf6934847bff558b619f5
   depends:
@@ -3720,7 +3720,7 @@ packages:
   license_family: MIT
   size: 2672987
   timestamp: 1697548890181
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
   sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
   md5: 1a822c206e2abddc5d6d821721af227f
   depends:
@@ -3729,7 +3729,7 @@ packages:
   license_family: MIT
   size: 33013
   timestamp: 1692205801265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
   sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
   md5: 1604d33dbdb2446c642970f8b354bedb
   depends:
@@ -3738,7 +3738,7 @@ packages:
   license_family: Apache
   size: 91266
   timestamp: 1659455269141
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
   sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
   md5: d1b3bcc35655a3123acb1fa2ad1a8511
   depends:
@@ -3750,7 +3750,7 @@ packages:
   license_family: BSD
   size: 580828
   timestamp: 1672387372015
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
   sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
   md5: 7540555d1fb192236db9a7c5c9d3601c
   depends:
@@ -3759,7 +3759,7 @@ packages:
   license_family: BSD
   size: 365765
   timestamp: 1656431373327
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
   sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
   md5: 0a73533fb6e0dc717ab906a537bc747d
   depends:
@@ -3771,7 +3771,7 @@ packages:
   license_family: BSD
   size: 30803
   timestamp: 1675441638631
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
   sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
   md5: 0a959fbad46ab38ade48dbd358002674
   depends:
@@ -3780,7 +3780,7 @@ packages:
   license_family: BSD
   size: 1864757
   timestamp: 1684280094736
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
   sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
   md5: ea24b5076ef79e4567c5a3f0cb22b470
   depends:
@@ -3790,7 +3790,7 @@ packages:
   license_family: Apache
   size: 95330
   timestamp: 1690223465114
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
   sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
   md5: bcaea6d4a47e9c874becaa700c78dcf7
   depends:
@@ -3799,7 +3799,7 @@ packages:
   license_family: MIT
   size: 157216
   timestamp: 1661452617825
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
   sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
   md5: 707110d1b49cb1864acb0bbaa103591e
   depends:
@@ -3808,7 +3808,7 @@ packages:
   license_family: MIT
   size: 95016
   timestamp: 1636111184034
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
   sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
   md5: 113a443b9c706f9f9c6187c0eaa3de27
   depends:
@@ -3817,7 +3817,7 @@ packages:
   license_family: BSD
   size: 31178
   timestamp: 1605305861851
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
   sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
   md5: 85a8d0001db70e52a479155228cb1fe0
   depends:
@@ -3836,7 +3836,7 @@ packages:
   license_family: PSF
   size: 13324979
   timestamp: 1694439878265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
   sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
   md5: 47c5e22e31ec05a7bc0ce90065a53afd
   depends:
@@ -3845,7 +3845,7 @@ packages:
   license_family: BSD
   size: 265348
   timestamp: 1661368839620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
   sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
   md5: ce9a69e1668aa1e133f2aa6d4e8d346f
   depends:
@@ -3854,7 +3854,7 @@ packages:
   license_family: MIT
   size: 254958
   timestamp: 1695131709704
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 9ee098c09f31fad7ff1856e5ce2619172eaf979997e7a427d1e05cce32c2af00
   md5: cac1d1898b69ae9646dfbf082910635d
   depends:
@@ -3864,7 +3864,7 @@ packages:
   license_family: BSD
   size: 40946
   timestamp: 1685030787453
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
   sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
   md5: 637f08b19dd8fd87347d8c44f9e3e202
   depends:
@@ -3874,7 +3874,7 @@ packages:
   license_family: MIT
   size: 170776
   timestamp: 1698096100056
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
   sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
   md5: 8ce3ac7d8a04e469b566f1b090d01140
   depends:
@@ -3885,7 +3885,7 @@ packages:
   license_family: BSD
   size: 470617
   timestamp: 1657724324011
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -3894,7 +3894,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
   sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
   md5: 6f2d41dd76a03b7f85a1ed49af1763d6
   depends:
@@ -3910,7 +3910,7 @@ packages:
   license_family: Apache
   size: 95100
   timestamp: 1690400262627
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
   sha256: a9755ecbfd42c708945027facfa11a3dc3119778326a0ae5df79f80d7b72afa5
   md5: 839ffa4e775fee9a8bdddabf4a14da43
   depends:
@@ -3927,7 +3927,7 @@ packages:
   license_family: BSD
   size: 24331914
   timestamp: 1696545397632
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
   md5: b0321e6f14e139fc15b1f8b4acb35d2f
   depends:
@@ -3936,7 +3936,7 @@ packages:
   license_family: MIT
   size: 1093966
   timestamp: 1690290944588
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
   sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
   md5: 62b64576a0aa5f6c3fb05f56650d25e1
   depends:
@@ -3945,7 +3945,7 @@ packages:
   license_family: Apache
   size: 15535
   timestamp: 1614030509324
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
   sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
   md5: 15b5595b31e39f08eaacbe2e502d8fb3
   depends:
@@ -3954,7 +3954,7 @@ packages:
   license_family: MIT
   size: 67292
   timestamp: 1696347733587
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
   sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
   md5: 82e4db6a498480a75d53c55bd35b6478
   depends:
@@ -3966,7 +3966,7 @@ packages:
   license_family: Other
   size: 1801397
   timestamp: 1681394807900
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -3975,7 +3975,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
   sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
   md5: 63b957927b9949ccb19da28ec4612706
   depends:
@@ -3986,7 +3986,7 @@ packages:
   license_family: BSD
   size: 30902
   timestamp: 1671751919031
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
   sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
   md5: e346257a2fa8e2cb48c762138a5d009b
   depends:
@@ -3996,7 +3996,7 @@ packages:
   license_family: BSD
   size: 39915
   timestamp: 1668168959656
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
   sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
   md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
   depends:
@@ -4005,7 +4005,7 @@ packages:
   license_family: BSD
   size: 3536231
   timestamp: 1654088937695
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
   sha256: 74fc3a9e308602b3710f8fa671f24f5492571d0c8f7c1b3071dac72671262d45
   md5: e08ead92568f5bd72d5ac7f08f087fee
   depends:
@@ -4014,7 +4014,7 @@ packages:
   license_family: BSD
   size: 102258
   timestamp: 1667464155001
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
   sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
   md5: a1bbf0abfb8c45541122c0eb2feee317
   depends:
@@ -4023,7 +4023,7 @@ packages:
   license_family: Apache
   size: 680464
   timestamp: 1696937112175
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
   sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
   md5: d689f6203c0a9d04fb229c73d7e80a7a
   depends:
@@ -4036,7 +4036,7 @@ packages:
   license_family: MOZILLA
   size: 125145
   timestamp: 1679561909274
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
   md5: 8a292c1ee22489bef2e84bc3aaf4098e
   depends:
@@ -4045,7 +4045,7 @@ packages:
   license_family: BSD
   size: 193141
   timestamp: 1671143985219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
   md5: 8bf0bfffc11ad06a1c94e145941b0ad4
   depends:
@@ -4055,7 +4055,7 @@ packages:
   license_family: PSF
   size: 9651
   timestamp: 1690297655669
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
   md5: 343514a174b3485fde55a73f56398dd7
   depends:
@@ -4064,7 +4064,7 @@ packages:
   license_family: PSF
   size: 58456
   timestamp: 1690297648002
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
   sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
   md5: c2242e8fd24003a74ddf37416661e06d
   depends:
@@ -4079,7 +4079,7 @@ packages:
   license_family: MIT
   size: 188757
   timestamp: 1698257668273
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
   sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
   md5: 41f445e36b6b6722a9444508eef069f8
   depends:
@@ -4088,7 +4088,7 @@ packages:
   license_family: BSD
   size: 20583
   timestamp: 1607365395045
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
   sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
   md5: 409ee46ed24267b6da6fb32d13e1f21e
   depends:
@@ -4098,7 +4098,7 @@ packages:
   license_family: BSD
   size: 70730
   timestamp: 1614804271285
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
   sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
   md5: eb74e74d8e4fd533c55eb98b7b5e83bc
   depends:
@@ -4107,7 +4107,7 @@ packages:
   license_family: MIT
   size: 102637
   timestamp: 1695742077778
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
   sha256: 9f5a34bef727052f97b1cc387c3a99a60754de99d6e4ab0b2de770d76b64dc0f
   md5: b5ce0421037c626cfcec5b43d83ec420
   depends:
@@ -4119,20 +4119,20 @@ packages:
   license_family: Apache
   size: 1787999
   timestamp: 1689041573350
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
   sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
   md5: e243baa546432c8394a8059a44a5a3e4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 419227
   timestamp: 1683113010463
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
   sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
   md5: fe4ac85ee86d3a94ea3a4ebea3779763
   depends:
@@ -4141,7 +4141,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 321797
   timestamp: 1616055526986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
   sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
   md5: bc7073d9d4c0211cc4a1207c98fb765a
   depends:
@@ -4150,14 +4150,14 @@ packages:
   license_family: MIT
   size: 19091
   timestamp: 1672387204865
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
   sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
   md5: 8e495591e369ac161857a72011c0a296
   license: Zlib
   license_family: Other
   size: 120272
   timestamp: 1666595024203
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
   sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
   md5: f1465fbd810b3746c6de6babfd4fe28a
   depends:
@@ -4169,7 +4169,7 @@ packages:
   license_family: BSD
   size: 1023573
   timestamp: 1681304595869
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
   sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
   md5: cf55cb8d7031b30c70c56fc7c782b5c7
   depends:
@@ -4182,7 +4182,7 @@ packages:
   license_family: MIT
   size: 156104
   timestamp: 1644482799136
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
   sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
   md5: 84fce327d9f0d594e86f565e5c21962e
   depends:
@@ -4191,7 +4191,7 @@ packages:
   license_family: BSD
   size: 10183
   timestamp: 1629146082730
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
   sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
   md5: 84b8b998a741b37abf5312c1c03696ef
   depends:
@@ -4201,7 +4201,7 @@ packages:
   license_family: MIT
   size: 33979
   timestamp: 1644845817952
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
   sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
   md5: 77b746931c8f31c3ae393ccb5819d43d
   depends:
@@ -4210,7 +4210,7 @@ packages:
   license_family: MIT
   size: 133628
   timestamp: 1695717890677
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
   sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
   md5: 3df6e8ba34208dea068890e5d5318cc0
   depends:
@@ -4220,12 +4220,12 @@ packages:
   license_family: MIT
   size: 206759
   timestamp: 1681493095987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-2.4.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-2.4.3-py39hca03da5_0.tar.bz2
   sha256: 7926e4d65d56b72cbce30732a5e24b075c4a9893ddb0160b90d6d08104636e49
   md5: db35093fddb91beafe2274068cebee9f
   depends:
@@ -4241,7 +4241,7 @@ packages:
   license_family: BSD
   size: 14425917
   timestamp: 1658136781676
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
   sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
   md5: bb55f81435cb6e11d264242274fccd1a
   depends:
@@ -4251,7 +4251,7 @@ packages:
   license_family: BSD
   size: 115947
   timestamp: 1657175645380
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
   md5: f860193e14afc7ef3f5b990a2ac003d2
   depends:
@@ -4261,7 +4261,7 @@ packages:
   license: MIT
   size: 18936
   timestamp: 1659616204016
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
   sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
   md5: ad53130f3fd1f8d3c2fcbb7496e5585d
   depends:
@@ -4270,7 +4270,7 @@ packages:
   license: MIT
   size: 18715
   timestamp: 1659616188888
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
   sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
   md5: 0982c046fb976e9f9fb19e7510187a18
   depends:
@@ -4279,14 +4279,14 @@ packages:
   license: MIT
   size: 366983
   timestamp: 1659616245272
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
   sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
   md5: 31ac2f5596cb7a44adf073c930641c54
   license: MPL-2.0
   license_family: Other
   size: 133817
   timestamp: 1694009762858
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
   sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
   md5: cf1f6c3c34a1e1b9ab22b04233d860f6
   depends:
@@ -4295,7 +4295,7 @@ packages:
   license_family: Other
   size: 159783
   timestamp: 1690232303987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
   sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
   md5: 0eb268e38b5174d471a6e87d9d6102b1
   depends:
@@ -4306,7 +4306,7 @@ packages:
   license_family: MIT
   size: 225355
   timestamp: 1670423312966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
   sha256: 41e76ba21b1279278a039245275eb4ee1f81b38b33cba00ca3575f06be5dc570
   md5: c5170bf12e308fb7f2d1b4b9065f3df7
   depends:
@@ -4315,7 +4315,7 @@ packages:
   license_family: BSD
   size: 153036
   timestamp: 1698129857856
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
   sha256: 36240dde0a1546469f35f3b5509b55384dfd894beb56b3ca929da4b96a2a5f24
   md5: 844539636e4c20ee99e8ceeff5e902bc
   depends:
@@ -4324,7 +4324,7 @@ packages:
   license_family: BSD
   size: 41376
   timestamp: 1683040042906
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
   sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
   md5: e68c94666cd60221b575c3814c89bac0
   depends:
@@ -4334,7 +4334,7 @@ packages:
   license_family: CC
   size: 1946451
   timestamp: 1668084573824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
   sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
   md5: 1773ae2b080cdd55827e27673351551e
   depends:
@@ -4344,7 +4344,7 @@ packages:
   license_family: BSD
   size: 13646
   timestamp: 1671231171682
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
   sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
   md5: 53bfd99ad1b09164d537209cffd98161
   depends:
@@ -4355,7 +4355,7 @@ packages:
   license_family: BSD
   size: 244040
   timestamp: 1663827469853
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
   sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
   md5: b62455043c8eb2434466885b19fed2de
   depends:
@@ -4368,7 +4368,7 @@ packages:
   license_family: BSD
   size: 1399573
   timestamp: 1694211828228
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
   sha256: fb7d12350372a70daa9f476647d04fc213ef9d8f73cbddaf30b40b1b45beef0f
   md5: 34595eb00802934d092b3086d7b4344d
   depends:
@@ -4385,7 +4385,7 @@ packages:
   license_family: BSD
   size: 2124926
   timestamp: 1686783028732
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
   sha256: d366da723fc8baf4d9de0d25688619efe4d1c7abe5407dfb28654c4c9e2ef019
   md5: d4c923ceedacd8d5d18f994feed8dbb8
   depends:
@@ -4407,7 +4407,7 @@ packages:
   license_family: BSD
   size: 17708209
   timestamp: 1692372524993
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
   sha256: 83dbf9755ea887576e3f34adb1c26d418db9aaf3c77dc07f30b58c2221b81c72
   md5: 36246697d07d6709de78abe36b6beae5
   depends:
@@ -4419,7 +4419,7 @@ packages:
   license_family: BSD
   size: 103201
   timestamp: 1629793063728
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
   sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
   md5: eb3cdc0fc210838b9271512a6a1b7c85
   depends:
@@ -4429,7 +4429,7 @@ packages:
   license_family: MIT
   size: 2067708
   timestamp: 1690905319109
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
   sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
   md5: f44b80b9405410e5bde6bfe0b31d5b3f
   depends:
@@ -4438,7 +4438,7 @@ packages:
   license_family: MIT
   size: 15135
   timestamp: 1650293774207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
   sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
   md5: f87027ccce1361d0f82c0edf1a10d53b
   depends:
@@ -4447,7 +4447,7 @@ packages:
   license_family: BSD
   size: 27677
   timestamp: 1668714367519
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -4457,7 +4457,7 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
   sha256: 296371685a5dcd98f5128f11f413e63aa59c1eba60543faf3baaebd445964c5d
   md5: 9817e8ffd3669484c9a7de99a8aceffb
   depends:
@@ -4466,14 +4466,14 @@ packages:
   license_family: BSD
   size: 257844
   timestamp: 1695734566410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
   sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
   md5: 1d0bd7e576c64c059ef781dd319ad82a
   license: MIT
   license_family: MIT
   size: 77591
   timestamp: 1676983230102
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.16.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.16.2-py39hca03da5_0.tar.bz2
   sha256: f3338a8df94863e3bc66b3b0682d6e0097168937da735452dbecb229952d7ecd
   md5: 21ca98bf948c366e8c596eea731a5e76
   depends:
@@ -4490,7 +4490,7 @@ packages:
   license_family: BSD
   size: 4456018
   timestamp: 1686339534531
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
   sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
   md5: 69eb3b03765627b6159ed23cdde78396
   depends:
@@ -4499,7 +4499,7 @@ packages:
   license_family: MIT
   size: 28399065
   timestamp: 1692293207812
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
   sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
   md5: 83366cbd3beb073112f4644a613b6bca
   depends:
@@ -4508,7 +4508,7 @@ packages:
   license_family: BSD
   size: 111933
   timestamp: 1666125627512
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
   sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
   md5: 647c1a2f8460ffa8c670a1915bbdb494
   depends:
@@ -4518,7 +4518,7 @@ packages:
   license_family: APACHE
   size: 38790
   timestamp: 1678997152549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
   sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
   md5: 35e541905426c686ef2ff010a0e502fd
   depends:
@@ -4528,7 +4528,7 @@ packages:
   license_family: Apache
   size: 51860
   timestamp: 1698254731870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
   sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
   md5: 187d7720aedf38759d122cccb4576f2c
   depends:
@@ -4550,7 +4550,7 @@ packages:
   license_family: BSD
   size: 219976
   timestamp: 1691121991680
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
   sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
   md5: e8e7f10741f9cfa737b310b334940441
   depends:
@@ -4572,7 +4572,7 @@ packages:
   license_family: BSD
   size: 1255894
   timestamp: 1694181494549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
   sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
   md5: ff209e75aee17af2e358b0008fbe8c88
   depends:
@@ -4582,7 +4582,7 @@ packages:
   license_family: MIT
   size: 1022945
   timestamp: 1644315931223
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
   sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
   md5: d3e78ef296b3c74910d003bd10b475d6
   depends:
@@ -4592,14 +4592,14 @@ packages:
   license_family: BSD
   size: 213972
   timestamp: 1666908195870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
   sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
   md5: 055e12390b844ea6c6e956ee08a618e8
   license: IJG
   license_family: Other
   size: 273479
   timestamp: 1677849171867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
   sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
   md5: 783e2ad3d36472648c5ccc9f3051db3c
   depends:
@@ -4610,7 +4610,7 @@ packages:
   license_family: MIT
   size: 133077
   timestamp: 1676558732505
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
   sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
   md5: 0677598f673f9729b5990316170a999d
   depends:
@@ -4626,7 +4626,7 @@ packages:
   license_family: BSD
   size: 197129
   timestamp: 1676329661580
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
   sha256: 05f9ca0fdcfdc2e217438be27fead588c843a3aadf7d034467c83216d1e5c214
   md5: 2d648b77d817ba38293c0728711ba8f5
   depends:
@@ -4637,7 +4637,7 @@ packages:
   license_family: BSD
   size: 92852
   timestamp: 1679906632236
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
   sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
   md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
   depends:
@@ -4661,7 +4661,7 @@ packages:
   license_family: BSD
   size: 401319
   timestamp: 1671707682572
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
   sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
   md5: 247558a0aecf1ef7e77a4343761353d6
   depends:
@@ -4671,7 +4671,7 @@ packages:
   license_family: BSD
   size: 64600
   timestamp: 1672387273585
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -4681,7 +4681,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -4690,13 +4690,13 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
   md5: a0f206782751dfffed0dd51302a1bf26
   license: MIT
   size: 68012
   timestamp: 1659616138077
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
   md5: 4c6667cdd061d28e9bc4e4300e4d115e
   depends:
@@ -4704,7 +4704,7 @@ packages:
   license: MIT
   size: 31173
   timestamp: 1659616155596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
   md5: 637e9430e258ddf050623ef2360184d8
   depends:
@@ -4712,28 +4712,28 @@ packages:
   license: MIT
   size: 298430
   timestamp: 1659616172209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
   sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
   md5: 55c615026c0869f8d3ba657f3bd38c43
   license: MIT
   license_family: MIT
   size: 120389
   timestamp: 1683716579036
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -4742,7 +4742,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -4753,14 +4753,14 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
   sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
   md5: a41117710dafe569c9cc4e83f6f29fe3
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1411339
   timestamp: 1650982753977
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
   sha256: d654027daea13ac9db36ab5fd5eff3ad398ec97c1777bf399f3ec680d2c145b9
   md5: baabb1f905054bfea3af8f5768572a34
   depends:
@@ -4772,7 +4772,7 @@ packages:
   license_family: Apache
   size: 26579907
   timestamp: 1683291669565
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -4783,7 +4783,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -4792,13 +4792,13 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -4815,7 +4815,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
   sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
   md5: 98d22e0124d55fae3c37c608dab1dcc9
   depends:
@@ -4829,7 +4829,7 @@ packages:
   license_family: BSD
   size: 89825
   timestamp: 1694778225280
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
   sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
   md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
   constrains:
@@ -4838,7 +4838,7 @@ packages:
   license_family: BSD
   size: 331675
   timestamp: 1694776939192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
   sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
   md5: 0ba499df6755eae5d2d23aa4ab004553
   depends:
@@ -4850,7 +4850,7 @@ packages:
   license_family: MIT
   size: 642657
   timestamp: 1692970217410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
   sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
   md5: c73101971e5ab6a8e8688239884eac81
   depends:
@@ -4860,7 +4860,7 @@ packages:
   license_family: MIT
   size: 241607
   timestamp: 1692973585084
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -4869,7 +4869,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
   sha256: 124d9d4f865f0f66c4e5e7f99dc1110330c9415cc51effc0a5aad4261880c2f0
   md5: c08c14e55ba470513eb6c87206fb7b30
   depends:
@@ -4881,7 +4881,7 @@ packages:
   license_family: BSD
   size: 322413
   timestamp: 1697031210019
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
   sha256: 83e1c11fb14ec2767e833b540a6a0fdbd8641523b5673273914007008e6666da
   md5: 64adbf70a0d4ab82aca039e972821537
   depends:
@@ -4890,7 +4890,7 @@ packages:
   license_family: BSD
   size: 11877
   timestamp: 1652903192510
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
   sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
   md5: 353dff9d5d996c2a260f66381b2ce3e8
   depends:
@@ -4901,7 +4901,7 @@ packages:
   license_family: Other
   size: 1470815
   timestamp: 1695058433965
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
   sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
   md5: c99006da802a97c9aae30da8c16b4820
   depends:
@@ -4910,7 +4910,7 @@ packages:
   license_family: BSD
   size: 176131
   timestamp: 1670944706815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
   sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
   md5: 60bd1e037cda86205526f77405d78129
   depends:
@@ -4920,7 +4920,7 @@ packages:
   license_family: BSD
   size: 123361
   timestamp: 1671541992772
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
   sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
   md5: 34dfd76da78de2eae95bbda390d746d6
   depends:
@@ -4931,7 +4931,7 @@ packages:
   license_family: BSD
   size: 23092
   timestamp: 1654598007056
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
   sha256: bf0eeef3c3c713515766ab8b0dc7863413de5b4b227deede97e24d90ca342345
   md5: a7bba1857eb84fb50caea377e60d2050
   depends:
@@ -4953,7 +4953,7 @@ packages:
   license_family: PSF
   size: 8066509
   timestamp: 1698692266161
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
   sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
   md5: eb79dabbeedee7da85dfbfb145bb8a26
   depends:
@@ -4963,7 +4963,7 @@ packages:
   license_family: BSD
   size: 17342
   timestamp: 1662014601345
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
   sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
   md5: 56db7bd3ff511cd839bda081523b3edd
   depends:
@@ -4972,7 +4972,7 @@ packages:
   license_family: BSD
   size: 55683
   timestamp: 1629356128780
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
   sha256: ee936ba5fd196c15c3cb538aef721e54bb4486110ae3ebbfcf78e95e8380efa4
   md5: dde1d9e040e04cbfbc0138898240a660
   depends:
@@ -4982,7 +4982,7 @@ packages:
   license_family: BSD
   size: 23003
   timestamp: 1629282780853
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
   sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
   md5: 176e0dcaeb28393881bacf69941e3889
   depends:
@@ -5008,7 +5008,7 @@ packages:
   license_family: BSD
   size: 8289638
   timestamp: 1681756329011
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
   sha256: afc6f332c51a3defc69e4c4e641988c0556039b9cd42be22f3db5292c88ccf37
   md5: 2bc409c7258160a9b739d08d5ffb5998
   depends:
@@ -5021,7 +5021,7 @@ packages:
   license_family: BSD
   size: 96942
   timestamp: 1650373637069
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
   sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
   md5: 150ea9fadddf21993d3328d3e48a18b7
   depends:
@@ -5049,7 +5049,7 @@ packages:
   license_family: BSD
   size: 557688
   timestamp: 1668450759059
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
   sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
   md5: 37163b32508f9f589b3e6462a3a47546
   depends:
@@ -5062,14 +5062,14 @@ packages:
   license_family: BSD
   size: 148426
   timestamp: 1694616771736
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
   sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
   md5: 6cdf7cbc43bf40e92b056a5576bd0086
   depends:
@@ -5078,7 +5078,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387216468
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
   sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
   md5: 0f05853a139b6cda9c73e9d2707a4976
   depends:
@@ -5103,7 +5103,7 @@ packages:
   license_family: BSD
   size: 590288
   timestamp: 1690984971741
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
   sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
   md5: 7de782e4fb34bfa95ef2fc79d27d727d
   depends:
@@ -5113,7 +5113,7 @@ packages:
   license_family: BSD
   size: 22840
   timestamp: 1668160634885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
   sha256: 0a5a7295f055d2f175528cc895dcb07533df5f0b87f05ac7839ec1af15988218
   md5: 3d8e6925b26ca29486d0b58b30f1f663
   depends:
@@ -5133,7 +5133,7 @@ packages:
   license_family: BSD
   size: 4428704
   timestamp: 1697061454581
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
   sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
   md5: 1a7b23113372c5667dbfe45976b9cc5c
   depends:
@@ -5144,7 +5144,7 @@ packages:
   license_family: MIT
   size: 126357
   timestamp: 1696515322390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
   sha256: 5332b3635fbc1a800b0fe58db7a0e57bb5ef75cbc56a0512c76f01ac7fc7139f
   md5: ab7fbf394a301d25d1bf8cfa76fd917b
   depends:
@@ -5157,7 +5157,7 @@ packages:
   license_family: BSD
   size: 12847
   timestamp: 1691092401334
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
   sha256: 114b5aa7ef0990a615e27116e05dba0e7e78df750e3592aa4b732438f391a394
   md5: 3284c63e9251227322ef9fd9c997f2c7
   depends:
@@ -5171,7 +5171,7 @@ packages:
   license_family: BSD
   size: 6338710
   timestamp: 1691092386069
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
   sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
   md5: 371358a54bbdd307603888348d1a2c6f
   depends:
@@ -5181,7 +5181,7 @@ packages:
   license: BSD 2-Clause
   size: 412248
   timestamp: 1628861367714
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
   sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
   md5: fa15d3b44ae1360ac9b640bbd5b6923c
   depends:
@@ -5190,7 +5190,7 @@ packages:
   license_family: Apache
   size: 4746123
   timestamp: 1695322833432
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
   sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
   md5: d73db95f07a282021efdf8bc09713261
   depends:
@@ -5199,7 +5199,7 @@ packages:
   license_family: Apache
   size: 73620
   timestamp: 1693575195999
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
   sha256: 247b5e4d81b6d5d013a9c27e1f30c41fff896fed98a68ebda26b19b4062a6828
   md5: 354a1d65300b4309d53dfa648014e8fe
   depends:
@@ -5246,7 +5246,7 @@ packages:
   license_family: BSD
   size: 13257999
   timestamp: 1697478739906
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-0.14.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-0.14.3-py39hca03da5_0.tar.bz2
   sha256: cb0fd0d862204d53fcd866cbe971602c3e7be58d5cc8f9dde2fd3cdf9376439e
   md5: 274366470779c9c9a91141a769c8457f
   depends:
@@ -5267,7 +5267,7 @@ packages:
   license_family: BSD
   size: 14650720
   timestamp: 1676379977310
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
   sha256: 0d64f2438be25524bbfeb8646e4fb3c18499d747398a03ed15d41b350b03e001
   md5: 6a4908a5c9f7b3f17f09ebc34b1b691c
   depends:
@@ -5276,7 +5276,7 @@ packages:
   license_family: BSD
   size: 142857
   timestamp: 1684915417403
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
   sha256: 3a6450282f56265e800500b62cd1bbe39cd5a6a09c4747c6dc3e8aab10bfa8a0
   md5: 9b01b16f9c5a033ee8b92683d66b184e
   depends:
@@ -5290,7 +5290,7 @@ packages:
   license_family: BSD
   size: 36731
   timestamp: 1698702611592
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
   sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
   md5: 6e01c592ae3b8ff2d12cae76f2f4276b
   depends:
@@ -5309,7 +5309,7 @@ packages:
   license_family: Other
   size: 715239
   timestamp: 1696580071596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
   sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
   md5: 9fb8f460c130d56caf33c6bbe46fbe8a
   depends:
@@ -5320,7 +5320,7 @@ packages:
   license_family: MIT
   size: 2678841
   timestamp: 1697548790931
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
   sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
   md5: 390b8c3cd74281abecdbfd51476922f9
   depends:
@@ -5329,7 +5329,7 @@ packages:
   license_family: MIT
   size: 33033
   timestamp: 1692205747301
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
   sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
   md5: 7896828fb3565fefad43f980d50c8723
   depends:
@@ -5338,7 +5338,7 @@ packages:
   license_family: Apache
   size: 91190
   timestamp: 1659455206354
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
   sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
   md5: d934c74eb66d01af0f45f0881f4bab77
   depends:
@@ -5350,7 +5350,7 @@ packages:
   license_family: BSD
   size: 580588
   timestamp: 1672387390426
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
   sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
   md5: 9858166e5ffb624c8b9d281f4000d725
   depends:
@@ -5359,7 +5359,7 @@ packages:
   license_family: BSD
   size: 367167
   timestamp: 1656431368885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
   sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
   md5: 4d2b45c6be8221e6a3e44c2d5838426f
   depends:
@@ -5371,7 +5371,7 @@ packages:
   license_family: BSD
   size: 30843
   timestamp: 1675441531640
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
   sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
   md5: 02521df4e2e79f75faa9cbb3560ab1dd
   depends:
@@ -5380,7 +5380,7 @@ packages:
   license_family: BSD
   size: 1861763
   timestamp: 1684280026169
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
   sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
   md5: bdebe59bffc7adbad83fdcd9d429a5f5
   depends:
@@ -5390,7 +5390,7 @@ packages:
   license_family: Apache
   size: 95234
   timestamp: 1690223494699
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
   sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
   md5: d716e5c9b5eec45ce1df8eb52cab817a
   depends:
@@ -5399,7 +5399,7 @@ packages:
   license_family: MIT
   size: 157408
   timestamp: 1661452601692
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
   sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
   md5: 1907629863ed8e7c35ead232dae7693f
   depends:
@@ -5408,7 +5408,7 @@ packages:
   license_family: MIT
   size: 91636
   timestamp: 1628941083263
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
   sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
   md5: 847b9bddf2a86e1609c0d53bbc23ea79
   depends:
@@ -5417,7 +5417,7 @@ packages:
   license_family: BSD
   size: 27378
   timestamp: 1626781391140
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
   sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
   md5: 18aa18bd0d260605923877921d26cc74
   depends:
@@ -5436,7 +5436,7 @@ packages:
   license_family: PSF
   size: 13194025
   timestamp: 1694438901368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
   sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
   md5: 45642a99c83e7aed74d1ffab1f20145b
   depends:
@@ -5445,7 +5445,7 @@ packages:
   license_family: BSD
   size: 266647
   timestamp: 1661368655993
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
   sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
   md5: fec748525144049a2fc7f52f9755232c
   depends:
@@ -5454,7 +5454,7 @@ packages:
   license_family: MIT
   size: 257235
   timestamp: 1695131702047
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
   sha256: 960192a143672e9c1d6fe4027af448512d91eee7501e5c245c21b865cf8bf429
   md5: 76d491244218505f071ba56a308673df
   depends:
@@ -5464,7 +5464,7 @@ packages:
   license_family: BSD
   size: 40950
   timestamp: 1685030774581
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
   sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
   md5: 3445d25415998c807efbe64d3a7e03c8
   depends:
@@ -5474,7 +5474,7 @@ packages:
   license_family: MIT
   size: 167068
   timestamp: 1698096118071
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
   sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
   md5: e6e92da28e9b0e428ed4b7df417bec25
   depends:
@@ -5485,7 +5485,7 @@ packages:
   license_family: BSD
   size: 472418
   timestamp: 1657724315435
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -5494,7 +5494,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
   sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
   md5: dba22515f36d3c266de5896350813ea2
   depends:
@@ -5510,7 +5510,7 @@ packages:
   license_family: Apache
   size: 95103
   timestamp: 1690400315537
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
   sha256: c35449c0ca64d0d6a23c019b6eba188f546e42379857cbc4240bbdddee1159d3
   md5: 61cb82346e21710f3e0645096cda4e12
   depends:
@@ -5526,7 +5526,7 @@ packages:
   license_family: BSD
   size: 22859180
   timestamp: 1696543469561
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
   sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
   md5: 3cd7eb43e285faba76faf67667e26b00
   depends:
@@ -5535,7 +5535,7 @@ packages:
   license_family: MIT
   size: 1093916
   timestamp: 1690290951258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
   sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
   md5: c5e9aef0d6895de1c927e9d796cd7cd3
   depends:
@@ -5544,7 +5544,7 @@ packages:
   license_family: Apache
   size: 15691
   timestamp: 1629145910454
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
   sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
   md5: 0f7c229e774146ffc4e29dedf75372bf
   depends:
@@ -5553,7 +5553,7 @@ packages:
   license_family: MIT
   size: 67279
   timestamp: 1696347632563
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
   sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
   md5: 2302a79a045f152e183a52a81adfba62
   depends:
@@ -5565,7 +5565,7 @@ packages:
   license_family: Other
   size: 1674163
   timestamp: 1681394762218
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
   sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
   md5: ae58720a18a2ed15eae214ad7a10d1b5
   depends:
@@ -5574,7 +5574,7 @@ packages:
   license_family: Apache
   size: 140125
   timestamp: 1680167256603
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
   sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
   md5: 4ae67163d55cf9df83d4027ebc38c501
   depends:
@@ -5585,7 +5585,7 @@ packages:
   license_family: BSD
   size: 30894
   timestamp: 1671751931536
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
   sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
   md5: dbb5c0cddb6661a89afee647fd3dc01e
   depends:
@@ -5595,7 +5595,7 @@ packages:
   license_family: BSD
   size: 39875
   timestamp: 1668168874870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
   sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
   md5: 667e60c8b407d73cbba40f44901f4f00
   depends:
@@ -5604,7 +5604,7 @@ packages:
   license_family: BSD
   size: 3412693
   timestamp: 1654088929697
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
   sha256: 065cf1b08faf1d28aa348d569f2266d8b33b22ba424312c7ec959be95f217646
   md5: 20370dbc92a9262e6fc8c82208f74ff2
   depends:
@@ -5613,7 +5613,7 @@ packages:
   license_family: BSD
   size: 102259
   timestamp: 1667464137769
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
   sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
   md5: 884f788a5f6a664c9b79f7a4a60362d0
   depends:
@@ -5622,7 +5622,7 @@ packages:
   license_family: Apache
   size: 680561
   timestamp: 1696937004165
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
   sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
   md5: 639a4f489af172c866c18442948e5874
   depends:
@@ -5635,7 +5635,7 @@ packages:
   license_family: MOZILLA
   size: 125170
   timestamp: 1679561942932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
   sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
   md5: e5b90eba83fddba6d7aa6072b5bf7c91
   depends:
@@ -5644,7 +5644,7 @@ packages:
   license_family: BSD
   size: 193017
   timestamp: 1671143921826
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
   md5: 644ef8830437070f60efcfcd6a987198
   depends:
@@ -5654,7 +5654,7 @@ packages:
   license_family: PSF
   size: 9670
   timestamp: 1690297532002
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
   md5: a902a833bb186a2f1a4b2b89b1195136
   depends:
@@ -5663,7 +5663,7 @@ packages:
   license_family: PSF
   size: 58466
   timestamp: 1690297524418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
   sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
   md5: f3f1d2c1028dad2f11ff950a15c99dbf
   depends:
@@ -5678,7 +5678,7 @@ packages:
   license_family: MIT
   size: 188640
   timestamp: 1698257577209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
   sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
   md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
   depends:
@@ -5687,7 +5687,7 @@ packages:
   license_family: BSD
   size: 20091
   timestamp: 1629144441130
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
   sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
   md5: 3089c63bf8f4d0423e1a287da286d83e
   depends:
@@ -5697,7 +5697,7 @@ packages:
   license_family: BSD
   size: 70923
   timestamp: 1629357115820
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
   sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
   md5: 5886b30b312445471268444f41f39dc7
   depends:
@@ -5706,7 +5706,7 @@ packages:
   license_family: MIT
   size: 102583
   timestamp: 1695741976083
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
   sha256: 300b9e4cfc9d01fa4d537060b2867f3cb89f22f932992fc2427e00dda050d55b
   md5: 768c174577b786b99f8b46c4789b36a2
   depends:
@@ -5718,20 +5718,20 @@ packages:
   license_family: Apache
   size: 1800646
   timestamp: 1689041569828
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
   sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
   md5: 2e75ad6a09c308268192efe03cc9ebf4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 411778
   timestamp: 1683113019715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
   sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
   md5: 30f666bf97c26587c5d2f68cc5f330ab
   depends:
@@ -5740,7 +5740,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 316901
   timestamp: 1629287855861
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
   sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
   md5: 584e591d36dcd5ba5c45404f0f7ebb2d
   depends:
@@ -5749,14 +5749,14 @@ packages:
   license_family: MIT
   size: 19076
   timestamp: 1672387153578
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
   sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
   md5: 467ae28215d1aa1c5688bc0c8a184269
   license: Zlib
   license_family: Other
   size: 103525
   timestamp: 1666595022664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
   sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
   md5: 7cfbed15f1feee1422810f7830075f53
   depends:
@@ -5768,7 +5768,7 @@ packages:
   license_family: BSD
   size: 779464
   timestamp: 1681304594848
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
   sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
   md5: ed14f9bc6e55220483f1a5a388625a08
   depends:
@@ -5781,7 +5781,7 @@ packages:
   license_family: MIT
   size: 162772
   timestamp: 1644481986085
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
   sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
   md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
   depends:
@@ -5793,7 +5793,7 @@ packages:
   license_family: MIT
   size: 39253
   timestamp: 1644551767970
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
   sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
   md5: b24d13c443a26f65a0778b475a5726bc
   depends:
@@ -5802,7 +5802,7 @@ packages:
   license_family: MIT
   size: 132830
   timestamp: 1695717959996
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
   sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
   md5: 302c3c0696e17eaa62e140e3892644ae
   depends:
@@ -5812,12 +5812,12 @@ packages:
   license_family: MIT
   size: 199723
   timestamp: 1681493196911
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-2.4.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-2.4.3-py39haa95532_0.tar.bz2
   sha256: a8150eba2526f695999bf260643c51779153bece456d86bb5ceaf2320dc28436
   md5: af8143c21529c930f9d54b9fa12df1f9
   depends:
@@ -5833,7 +5833,7 @@ packages:
   license_family: BSD
   size: 14460067
   timestamp: 1658137245730
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
   sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
   md5: bf930260f679bc74227bbb18bc36ae82
   depends:
@@ -5845,7 +5845,7 @@ packages:
   license_family: BSD
   size: 119700
   timestamp: 1657176150595
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
   md5: 507dfe693ef429f466d964b599f4af21
   depends:
@@ -5857,7 +5857,7 @@ packages:
   license: MIT
   size: 18650
   timestamp: 1659616328001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
   md5: d0bf43e8df60baae3b3105aa5c42a791
   depends:
@@ -5868,7 +5868,7 @@ packages:
   license: MIT
   size: 21153
   timestamp: 1659616312367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
   sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
   md5: 7bd24bf94c24e810aecaaf84a0978e6f
   depends:
@@ -5878,14 +5878,14 @@ packages:
   license: MIT
   size: 343204
   timestamp: 1659616543542
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
   sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
   md5: 092b417c11edcbe6bb9b765ab4a55d23
   license: MPL-2.0
   license_family: Other
   size: 164999
   timestamp: 1694009822357
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
   sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
   md5: 708a750d370b9d6875651021e21c4446
   depends:
@@ -5894,7 +5894,7 @@ packages:
   license_family: Other
   size: 159322
   timestamp: 1690232335307
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
   sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
   md5: c35736da3ea26782425e78061268cf5e
   depends:
@@ -5906,7 +5906,7 @@ packages:
   license_family: MIT
   size: 228713
   timestamp: 1670423312743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
   sha256: 9577ff772035cd30e72323edff379dd3df877de00f7f690fd33c8720a5a4bbc9
   md5: 1130fd979d4f97f511f10b36ff09513d
   depends:
@@ -5916,7 +5916,7 @@ packages:
   license_family: BSD
   size: 152728
   timestamp: 1698129962390
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
   sha256: e5babe79f8132c4bd44bc05307976f2c5485014ae3129655dddbd3baa8e75e46
   md5: 093223df00c6ef9db4e7e5aa7bfec00a
   depends:
@@ -5925,7 +5925,7 @@ packages:
   license_family: BSD
   size: 40844
   timestamp: 1683040252786
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
   sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
   md5: 457a4339a53c033d48ce0c72e5038d2e
   depends:
@@ -5934,7 +5934,7 @@ packages:
   license_family: BSD
   size: 30330
   timestamp: 1672387265402
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
   sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
   md5: 59ec65fd9e06b81a65cc12986c67d5da
   depends:
@@ -5944,7 +5944,7 @@ packages:
   license_family: CC
   size: 1939614
   timestamp: 1668084794027
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
   sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
   md5: 3489c1a2b73fc957b5a62cc59349e25b
   depends:
@@ -5954,7 +5954,7 @@ packages:
   license_family: BSD
   size: 13438
   timestamp: 1671231196438
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
   sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
   md5: 3492b96083c1e904cc32d26ea7f1e1d8
   depends:
@@ -5966,7 +5966,7 @@ packages:
   license_family: BSD
   size: 184280
   timestamp: 1663827558327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
   sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
   md5: f46d904bc6f220327e70474971341f52
   depends:
@@ -5981,7 +5981,7 @@ packages:
   license_family: BSD
   size: 1220835
   timestamp: 1694445639066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
   sha256: 78d66bcb1c979647e9c5473825d4a5e35afa2a0dfeef71cb0d9d9a72fea3c102
   md5: f2875875bb22ab4704a77bc368a9dc00
   depends:
@@ -5998,7 +5998,7 @@ packages:
   license_family: BSD
   size: 2180195
   timestamp: 1686783294287
-- conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
   sha256: 882a0fb257fb07bb47e8127b9ce1f556e319ce4941b74adc94f9849093e11d0d
   md5: b6ef3c0b6e49ff3d497785c744ce44cc
   depends:
@@ -6020,7 +6020,7 @@ packages:
   license_family: BSD
   size: 17688679
   timestamp: 1692373093225
-- conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
   sha256: a6c8b5d32c52ce71d41c7702265e0bb064c960ab67b88ecbea967595c5e02bc3
   md5: 112f2f9c7055656ec156fe287c97c0e9
   depends:
@@ -6032,7 +6032,7 @@ packages:
   license_family: BSD
   size: 104432
   timestamp: 1613390539244
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
   sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
   md5: 2ff4fb509788b0e47ac684ba151394d0
   depends:
@@ -6043,7 +6043,7 @@ packages:
   license_family: MIT
   size: 3289966
   timestamp: 1690907040646
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
   sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
   md5: 0f166c3e70541d8bee6e9d0cb60fb66e
   depends:
@@ -6052,7 +6052,7 @@ packages:
   license_family: MIT
   size: 16979
   timestamp: 1649926678161
-- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
   sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
   md5: ea93d413944ca6a8677eb1b284b136ae
   depends:
@@ -6061,7 +6061,7 @@ packages:
   license_family: BSD
   size: 27388
   timestamp: 1668714577678
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -6073,7 +6073,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
   sha256: 6b724886465fea70d2ca843fea1d01bcc24d496601587b87c0cb8f2626b259c2
   md5: 6c11d9242869d6c3b01698f728bd409b
   depends:
@@ -6082,7 +6082,7 @@ packages:
   license_family: BSD
   size: 260567
   timestamp: 1695734829130
-- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
   sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
   md5: 9f167d3e45441bc3633c1974b1b0ce8c
   depends:
@@ -6092,7 +6092,7 @@ packages:
   license_family: MIT
   size: 88421
   timestamp: 1676983264486
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.16.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.16.2-py39haa95532_0.tar.bz2
   sha256: 22697eed11ebd3285a5c95a03473bc49b8e6870df4351399ac881157d147b6c0
   md5: f4ee7531c4b389eb2c5a940edcde3580
   depends:
@@ -6109,13 +6109,13 @@ packages:
   license_family: BSD
   size: 4563678
   timestamp: 1686339525300
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
   sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
   md5: 582d2c1135a89da757a038de831e7f39
   license: Intel proprietary
   size: 11086648
   timestamp: 1664812389803
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
   sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
   md5: 30fdefd1541c789c163751291a8faa88
   depends:
@@ -6124,7 +6124,7 @@ packages:
   license_family: BSD
   size: 111448
   timestamp: 1666125667599
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
   sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
   md5: a10f07c7a3510272a296f9fed458a4ed
   depends:
@@ -6134,7 +6134,7 @@ packages:
   license_family: APACHE
   size: 38098
   timestamp: 1678997241511
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
   sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
   md5: fad9cf2023d807da8d44996e9d4399a0
   depends:
@@ -6144,7 +6144,7 @@ packages:
   license_family: Apache
   size: 51490
   timestamp: 1698254721864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
   sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
   md5: 9834848bd7c7759acf12e78d09388563
   depends:
@@ -6154,7 +6154,7 @@ packages:
   license_family: Proprietary
   size: 3891030
   timestamp: 1681801474383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
   sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
   md5: 1285c8c628bc912c54d0968574c9f4c9
   depends:
@@ -6175,7 +6175,7 @@ packages:
   license_family: BSD
   size: 217232
   timestamp: 1691122695748
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
   sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
   md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
   depends:
@@ -6196,7 +6196,7 @@ packages:
   license_family: BSD
   size: 1279433
   timestamp: 1694181820978
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
   sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
   md5: f5fcce35d3f21cdfc5893c5a7a86c651
   depends:
@@ -6206,7 +6206,7 @@ packages:
   license_family: MIT
   size: 1035394
   timestamp: 1644315567034
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
   sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
   md5: f67fe3337528e2886f1ac3ab8ac37985
   depends:
@@ -6216,7 +6216,7 @@ packages:
   license_family: BSD
   size: 213110
   timestamp: 1666908350218
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
   sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
   md5: 81f2c343dc4c65eea39c45383272068f
   depends:
@@ -6226,7 +6226,7 @@ packages:
   license_family: Other
   size: 407861
   timestamp: 1677849239400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
   sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
   md5: bd9526d38a145fe311a8aa36bc11e071
   depends:
@@ -6237,7 +6237,7 @@ packages:
   license_family: MIT
   size: 152006
   timestamp: 1676558783570
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
   sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
   md5: a00e6a62956fde3c4135464353ee8a53
   depends:
@@ -6253,7 +6253,7 @@ packages:
   license_family: BSD
   size: 229158
   timestamp: 1676330909084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
   sha256: db8335d6531b03c7bdfe789ebacc52631ac6ea4a37700bb3da1f6a53a1acd724
   md5: ebeba61994cc225ea5f4f42caa511019
   depends:
@@ -6265,7 +6265,7 @@ packages:
   license_family: BSD
   size: 116681
   timestamp: 1679906658986
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
   sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
   md5: 5efa1332f7c0a8d9638eda02170c4ce5
   depends:
@@ -6290,7 +6290,7 @@ packages:
   license_family: BSD
   size: 413653
   timestamp: 1671707957673
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
   sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
   md5: 891fe66a24d8714737b2874985ee1303
   depends:
@@ -6301,7 +6301,7 @@ packages:
   license_family: BSD
   size: 62298
   timestamp: 1672388166096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -6311,7 +6311,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
   sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
   md5: c345f51706eef530454f66b794e5e574
   depends:
@@ -6320,7 +6320,7 @@ packages:
   license: MIT
   size: 68189
   timestamp: 1659616216976
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
   md5: a7400cfb72042977bc047909ed504ce8
   depends:
@@ -6330,7 +6330,7 @@ packages:
   license: MIT
   size: 33743
   timestamp: 1659616248209
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
   md5: 6307f6854754ab5bd7c84e6998385bb1
   depends:
@@ -6340,7 +6340,7 @@ packages:
   license: MIT
   size: 733177
   timestamp: 1659616279453
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -6350,7 +6350,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
   sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
   md5: b812bc5d9c76242e2bb2ac87afe7d39b
   depends:
@@ -6360,7 +6360,7 @@ packages:
   license_family: GPL3
   size: 730280
   timestamp: 1650983734373
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -6371,7 +6371,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -6380,7 +6380,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -6397,7 +6397,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
   sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
   md5: ba9418df9288a2f031a02fa35b774ce0
   depends:
@@ -6413,7 +6413,7 @@ packages:
   license_family: BSD
   size: 78524
   timestamp: 1694778314659
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
   sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
   md5: b1781519a200ccbfcb4a1194005aa3ef
   depends:
@@ -6425,7 +6425,7 @@ packages:
   license_family: BSD
   size: 338459
   timestamp: 1694777084290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
   sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
   md5: 6ece7f1a3248169837714d05d7f6ef0a
   depends:
@@ -6437,7 +6437,7 @@ packages:
   license_family: MIT
   size: 3513910
   timestamp: 1692971505729
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
   sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
   md5: bd7ec244935e83e850a4ff34e8e2e64f
   depends:
@@ -6448,7 +6448,7 @@ packages:
   license_family: MIT
   size: 513971
   timestamp: 1692973657152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
   sha256: 2f610fc98b674e4eceeceaadbb94b4153759ee9249759dd27ca48bfdeeef82cf
   md5: c24005244a08cbfb665f89d8858e0187
   depends:
@@ -6460,7 +6460,7 @@ packages:
   license_family: BSD
   size: 20824879
   timestamp: 1697031479623
-- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
   sha256: 5d4cf89313147e44530dbb3cc6a93247aaded0701bbf8ba3a382ef710abf4cfa
   md5: 137deeca51202f6b4ac786472a00be55
   depends:
@@ -6469,7 +6469,7 @@ packages:
   license_family: BSD
   size: 12894
   timestamp: 1652904101694
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
   sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
   md5: fb7881e74b59262df0fa4ec981964efc
   depends:
@@ -6482,7 +6482,7 @@ packages:
   license_family: Other
   size: 1244887
   timestamp: 1695058550693
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
   sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
   md5: 6970c7f46b0164cad1d210e7a1419959
   depends:
@@ -6492,7 +6492,7 @@ packages:
   license_family: BSD
   size: 143434
   timestamp: 1670944902624
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
   sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
   md5: 1015298551c040c6d5e26eebbae12ef5
   depends:
@@ -6502,7 +6502,7 @@ packages:
   license_family: BSD
   size: 142316
   timestamp: 1671542240512
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
   sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
   md5: 466da740fafef3d6bce114220f0be306
   depends:
@@ -6515,7 +6515,7 @@ packages:
   license_family: BSD
   size: 28510
   timestamp: 1654508162239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
   sha256: 1687ae122ee7d8b583141fc5014b76d494841dc8083b854449e3d6e0f6bb7019
   md5: 3697ac26ee3c2d49338dd5b9c6551152
   depends:
@@ -6538,7 +6538,7 @@ packages:
   license_family: PSF
   size: 8080067
   timestamp: 1698692812610
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
   sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
   md5: a9fa43e694b25cd49b8b08a9eefd696e
   depends:
@@ -6548,7 +6548,7 @@ packages:
   license_family: BSD
   size: 18054
   timestamp: 1661915903969
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
   sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
   md5: 248c468abced874f0231d3cc23177c77
   depends:
@@ -6559,7 +6559,7 @@ packages:
   license_family: BSD
   size: 58488
   timestamp: 1607359497934
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
   sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
   md5: 5e763c995ff0c549f68a10bce70fede4
   depends:
@@ -6571,7 +6571,7 @@ packages:
   license_family: Proprietary
   size: 187489950
   timestamp: 1691503804820
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
   sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
   md5: dd0c2ece6a743c373c9b5a5919b4818f
   depends:
@@ -6583,7 +6583,7 @@ packages:
   license_family: BSD
   size: 49744
   timestamp: 1682975040154
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
   sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
   md5: 57cea8df7ab85f2a98f64d23afcb1f90
   depends:
@@ -6598,7 +6598,7 @@ packages:
   license_family: BSD
   size: 184956
   timestamp: 1695058491736
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
   sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
   md5: 8769cdd201d905069800488fe31574e5
   depends:
@@ -6613,7 +6613,7 @@ packages:
   license_family: BSD
   size: 256221
   timestamp: 1695060152521
-- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
   sha256: b75f28f29d60f2a8726fb0f036e5d01489942abbf77ff1e1cc8e12d7f372b8f3
   md5: 7a1d29477873480809fd3860f2e69f01
   depends:
@@ -6623,7 +6623,7 @@ packages:
   license_family: BSD
   size: 24734
   timestamp: 1607574381373
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
   sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
   md5: d9781492332e6326f9fca87f3a8efacd
   depends:
@@ -6649,7 +6649,7 @@ packages:
   license_family: BSD
   size: 8135792
   timestamp: 1681756491399
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
   sha256: 2dd3178d3c570e30b9490ebabfd7bfac806afad8302d3dee0edc619805034397
   md5: bef9da0f0694c45b6aaa4e6447479eaf
   depends:
@@ -6662,7 +6662,7 @@ packages:
   license_family: BSD
   size: 118324
   timestamp: 1650290466135
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
   sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
   md5: f1d8ce412e115986c403f223b3b47d0f
   depends:
@@ -6690,7 +6690,7 @@ packages:
   license_family: BSD
   size: 596314
   timestamp: 1668451106600
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
   sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
   md5: f96bbef0985d7e66ebf00c0d55e30e23
   depends:
@@ -6703,7 +6703,7 @@ packages:
   license_family: BSD
   size: 167045
   timestamp: 1694617078743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
   sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
   md5: 6e6ba64c8dc5025aeac606404a8df36a
   depends:
@@ -6712,7 +6712,7 @@ packages:
   license_family: BSD
   size: 13786
   timestamp: 1672387480065
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
   sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
   md5: 4a7a3286484766741f627696697c362c
   depends:
@@ -6737,7 +6737,7 @@ packages:
   license_family: BSD
   size: 609425
   timestamp: 1690985686105
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
   sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
   md5: 4269a1f93882205b90d4b2ae78fc82d5
   depends:
@@ -6747,7 +6747,7 @@ packages:
   license_family: BSD
   size: 22417
   timestamp: 1668160717305
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
   sha256: 39b52f5a3e0f71a07358f2bd07a67b950170eabc3398ae968ef523cc0854141a
   md5: 4baee3e5d96aed7d5d3e28051d6214e5
   depends:
@@ -6767,7 +6767,7 @@ packages:
   license_family: BSD
   size: 4472762
   timestamp: 1697063760024
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
   sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
   md5: a18a576b7024cfd6f905c526a786a916
   depends:
@@ -6782,7 +6782,7 @@ packages:
   license_family: MIT
   size: 135285
   timestamp: 1696515698492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
   sha256: 410f3a13eaddcfcfc65cb077dd0b85b7c66853a2447161b9022eed7d9fe472f9
   md5: c4aae7ab3842a3decd05c5c1d8b916d3
   depends:
@@ -6799,7 +6799,7 @@ packages:
   license_family: BSD
   size: 12296
   timestamp: 1691098390179
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
   sha256: 5a81ff60cc876951905995ea52d3815e38a0d757c6c674acbef1144d8dc746fb
   md5: 72413d41fe97de5da9b1ce325e544e05
   depends:
@@ -6815,7 +6815,7 @@ packages:
   license_family: BSD
   size: 6857794
   timestamp: 1691098356763
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
   sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
   md5: ab07e2a27ac08afe3d0b4c0890b8486a
   depends:
@@ -6826,7 +6826,7 @@ packages:
   license: BSD 2-Clause
   size: 249316
   timestamp: 1630094024143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
   sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
   md5: 73b17037d87b5a58feb34dafc0538f7f
   depends:
@@ -6837,7 +6837,7 @@ packages:
   license_family: Apache
   size: 8058396
   timestamp: 1695324589828
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
   sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
   md5: df1d746ba8d5d6ba01ac1373b9b71e1a
   depends:
@@ -6846,7 +6846,7 @@ packages:
   license_family: Apache
   size: 73016
   timestamp: 1693575484990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
   sha256: 1994e5831fd421bd6cf85916073d4012dec53e673b672b3985efaf771f0a7bf8
   md5: c486a5b51e3227f6ea564a9dd3125e45
   depends:
@@ -6894,7 +6894,7 @@ packages:
   license_family: BSD
   size: 12629931
   timestamp: 1697479885371
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-0.14.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-0.14.3-py39haa95532_0.tar.bz2
   sha256: 00a343d88532d207ef3f8387af638b82608a8904ef11c9a1495693bb4658c49a
   md5: 0f761c1e7e55d96c6504348291a2d7c4
   depends:
@@ -6915,7 +6915,7 @@ packages:
   license_family: BSD
   size: 14717609
   timestamp: 1676380051970
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
   sha256: 2773f47b2d745ab483cf7fcbd5b5e2f7020d45462d32d2ccd5cf232ca13c6f67
   md5: ca16cd208037bd58d2da267c338da4a4
   depends:
@@ -6924,7 +6924,7 @@ packages:
   license_family: BSD
   size: 142229
   timestamp: 1684915524241
-- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
   sha256: 5738f61dae392c171b4f699a6973e736198e4d4a63fa22dcf957afaf1de150af
   md5: cba721e73156d62fc4ff23159e96ad41
   depends:
@@ -6938,7 +6938,7 @@ packages:
   license_family: BSD
   size: 36452
   timestamp: 1698702686971
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
   sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
   md5: 427c1450bebb632f43bbc8c83006e4cd
   depends:
@@ -6957,7 +6957,7 @@ packages:
   license_family: Other
   size: 806931
   timestamp: 1696580240310
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
   sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
   md5: 21790cd3e2b8a45c4104aff0a68330d0
   depends:
@@ -6968,7 +6968,7 @@ packages:
   license_family: MIT
   size: 3001751
   timestamp: 1697549357662
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
   sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
   md5: 56f44a1054da2d10777e375838191070
   depends:
@@ -6977,7 +6977,7 @@ packages:
   license_family: MIT
   size: 32355
   timestamp: 1692205784293
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
   sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
   md5: 8a35ad65651086575ce55371f22feda8
   depends:
@@ -6986,7 +6986,7 @@ packages:
   license_family: Apache
   size: 91045
   timestamp: 1659455316472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
   sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
   md5: 186eb95f816a2eff80c3c7f7d964c7b0
   depends:
@@ -6998,7 +6998,7 @@ packages:
   license_family: BSD
   size: 578514
   timestamp: 1672388155359
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
   sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
   md5: 47b6cbe6ce9289e47d16900b03596a91
   depends:
@@ -7009,7 +7009,7 @@ packages:
   license_family: BSD
   size: 372807
   timestamp: 1656431445633
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
   sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
   md5: 07165c444adc7c7ccc8a345875adc5ef
   depends:
@@ -7021,7 +7021,7 @@ packages:
   license_family: BSD
   size: 48408
   timestamp: 1675450623287
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
   sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
   md5: d58e76a31e2f6e7410ba4afd7f385b0d
   depends:
@@ -7030,7 +7030,7 @@ packages:
   license_family: BSD
   size: 1877445
   timestamp: 1684280183367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
   sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
   md5: 0e5b0fe7debbf558ce97090f6b67cdae
   depends:
@@ -7040,7 +7040,7 @@ packages:
   license_family: Apache
   size: 94633
   timestamp: 1690225630423
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
   sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
   md5: 0fde797653e4ab589506121fb1e37555
   depends:
@@ -7049,7 +7049,7 @@ packages:
   license_family: MIT
   size: 157119
   timestamp: 1661452591647
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
   sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
   md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
   depends:
@@ -7060,7 +7060,7 @@ packages:
   license_family: MIT
   size: 92679
   timestamp: 1636093365041
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
   sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
   md5: f870859d4dc7a8d82cf3546bd9035f33
   depends:
@@ -7070,7 +7070,7 @@ packages:
   license_family: BSD
   size: 54520
   timestamp: 1605307564142
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
   sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
   md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
   depends:
@@ -7083,7 +7083,7 @@ packages:
   license_family: PSF
   size: 21172845
   timestamp: 1694442462066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
   sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
   md5: 9d99075052265ae3d718582d3b875038
   depends:
@@ -7092,7 +7092,7 @@ packages:
   license_family: BSD
   size: 269964
   timestamp: 1661376543480
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
   sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
   md5: fa9074d94236c9b768bfd2c858875b27
   depends:
@@ -7101,7 +7101,7 @@ packages:
   license_family: MIT
   size: 264836
   timestamp: 1695131770282
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
   sha256: 97243a31c39f4990c0e9d4f2307f2f7fb9421553303923bc105067ec4340bdff
   md5: 8078c5760f27398eaf1082226647d137
   depends:
@@ -7111,7 +7111,7 @@ packages:
   license_family: BSD
   size: 40145
   timestamp: 1685031143383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
   sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
   md5: 3d2841085778006c2e79f9c7300f8b9d
   depends:
@@ -7121,7 +7121,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13565975
   timestamp: 1669937633869
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
   sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
   md5: 54a4bc0724041dd173088419d6ede2af
   depends:
@@ -7133,7 +7133,7 @@ packages:
   license_family: MIT
   size: 239062
   timestamp: 1677611495106
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
   sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
   md5: f39f84115e228bad4bceaefdd637f022
   depends:
@@ -7145,7 +7145,7 @@ packages:
   license_family: MIT
   size: 158558
   timestamp: 1698096358091
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
   sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
   md5: df398a3a1668fd2a22061764e20ea91d
   depends:
@@ -7157,7 +7157,7 @@ packages:
   license_family: BSD
   size: 460913
   timestamp: 1657616061604
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
   sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
   md5: 38db77ece9dc76feffb9ef7638e38258
   depends:
@@ -7173,7 +7173,7 @@ packages:
   license_family: Apache
   size: 94397
   timestamp: 1690400496655
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
   sha256: 3a9a680173f731d515e0587d5b74583cc986b5c1ff62f4cf9e4f7ec268cbb62a
   md5: 3387bf809e3d32dde3f5cbc3ef49bf47
   depends:
@@ -7191,7 +7191,7 @@ packages:
   license_family: BSD
   size: 22779707
   timestamp: 1696550432358
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
   sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
   md5: 3e284ae6b48ee30c364ffdc5601610b0
   depends:
@@ -7200,7 +7200,7 @@ packages:
   license_family: MIT
   size: 1099842
   timestamp: 1690291374842
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
   sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
   md5: 993b3886b334bd1f49d34206f21997b4
   depends:
@@ -7209,7 +7209,7 @@ packages:
   license_family: Apache
   size: 15998
   timestamp: 1614030572433
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
   sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
   md5: 7ac9604ad7564ac0c71bff5db198656f
   depends:
@@ -7218,7 +7218,7 @@ packages:
   license_family: MIT
   size: 67012
   timestamp: 1696347795139
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
   sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
   md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
   depends:
@@ -7228,7 +7228,7 @@ packages:
   license_family: Other
   size: 1311308
   timestamp: 1681402905668
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -7238,7 +7238,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
   sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
   md5: 28b9869d8d3a839918fac4a08f38cbc2
   depends:
@@ -7249,7 +7249,7 @@ packages:
   license_family: BSD
   size: 30546
   timestamp: 1671752127904
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
   sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
   md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
   depends:
@@ -7259,7 +7259,7 @@ packages:
   license_family: BSD
   size: 39590
   timestamp: 1668168880994
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
   sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
   md5: 52cdcdb96383c010ca833a7c24b3935b
   depends:
@@ -7269,7 +7269,7 @@ packages:
   license_family: BSD
   size: 3690152
   timestamp: 1654036853710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
   sha256: 1ee791ecc17e11a31d6cf1553845e7279d9d9a2c7383a2a3e1ae131ddd024b6f
   md5: b32030d310e0437dc631e5719369004c
   depends:
@@ -7278,7 +7278,7 @@ packages:
   license_family: BSD
   size: 102033
   timestamp: 1667464306003
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
   sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
   md5: 0e054ab29119cf4c1f778613acf972f9
   depends:
@@ -7289,7 +7289,7 @@ packages:
   license_family: Apache
   size: 681780
   timestamp: 1696937326924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
   sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
   md5: b6ad839ebba536ad1c3cc58d0e2123f0
   depends:
@@ -7303,7 +7303,7 @@ packages:
   license_family: MOZILLA
   size: 143681
   timestamp: 1679562248929
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
   sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
   md5: fe78de10019085146f1cc6c94fdc2620
   depends:
@@ -7312,7 +7312,7 @@ packages:
   license_family: BSD
   size: 192822
   timestamp: 1671143999327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
   md5: ca5fc3fbdb09b6de068a8b7a8869369f
   depends:
@@ -7322,7 +7322,7 @@ packages:
   license_family: PSF
   size: 9208
   timestamp: 1690298120549
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
   md5: a86e87a10e5fdff486265e0c675fb99f
   depends:
@@ -7331,7 +7331,7 @@ packages:
   license_family: PSF
   size: 57922
   timestamp: 1690298106990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
   sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
   md5: 0d31859e0a097aedbcc1627db33b3d92
   depends:
@@ -7346,7 +7346,7 @@ packages:
   license_family: MIT
   size: 188367
   timestamp: 1698257883295
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
   sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
   md5: 45ef24c486a484f079faf1dc90e4c7e9
   depends:
@@ -7355,12 +7355,12 @@ packages:
   license_family: BSD
   size: 8277
   timestamp: 1605602889180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
   sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
   md5: 4daaceb6cfc1af6274509081d8018ef1
   size: 2316783
   timestamp: 1605602872095
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
   sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
   md5: 916c16904615c7af3b5d37cb6694f45e
   depends:
@@ -7369,7 +7369,7 @@ packages:
   license_family: BSD
   size: 21084
   timestamp: 1607347371925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
   sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
   md5: da69e6987fcc757e83a358ceaa13f62b
   depends:
@@ -7379,7 +7379,7 @@ packages:
   license_family: BSD
   size: 73391
   timestamp: 1614804425587
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
   sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
   md5: 23b9f4634b2e5450be617114f62c74f9
   depends:
@@ -7388,7 +7388,7 @@ packages:
   license_family: MIT
   size: 120873
   timestamp: 1695742300539
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
   sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
   md5: 120f0b088290fc17bd6618fc10a2f0c4
   depends:
@@ -7396,13 +7396,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 34293
   timestamp: 1605306211299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
   sha256: 6bdb88cd45b22246e84b7400159ca90faf98ab4e8c1fa2d38d031cfc73c4dc13
   md5: d6e10641ece06f67561c5f6a676a4b7e
   depends:
@@ -7414,7 +7414,7 @@ packages:
   license_family: Apache
   size: 1794729
   timestamp: 1689041580510
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
   sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
   md5: c3f7871e9a33adeccee1b1e8e216918e
   depends:
@@ -7424,7 +7424,7 @@ packages:
   license_family: GPL2
   size: 1332571
   timestamp: 1683113347814
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -7433,7 +7433,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
   sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
   md5: 1ab55f8c4b5292ec360c572120bf823e
   depends:
@@ -7443,7 +7443,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 9430705
   timestamp: 1616055773485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
   sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
   md5: 6875e0bf3828707dc9165d694c0d0a7d
   depends:
@@ -7452,7 +7452,7 @@ packages:
   license_family: MIT
   size: 18725
   timestamp: 1672387612937
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
   sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
   md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
   depends:
@@ -7462,7 +7462,7 @@ packages:
   license_family: Other
   size: 148931
   timestamp: 1666595229032
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
   sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
   md5: 8d6a1e767775fe0eb617cd6e22edc2ff
   depends:

--- a/iex_trading/pixi.toml
+++ b/iex_trading/pixi.toml
@@ -1,0 +1,46 @@
+[workspace]
+name = "iex_trading"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2019-11-20"
+maintainers = ["jlstevens"]
+categories = ["Finance"]
+labels = ["datashader", "panel", "holoviews"]
+title = "IEX trading"
+description = "Dashboard visualizing stock trades on the IEX exchange"
+notebooks_to_skip = ["IEX_to_CSV.ipynb"]
+
+[dependencies]
+python = "3.9.*"
+notebook = "*"
+bokeh = "<3"
+datashader = "*"
+holoviews = "<1.17"
+numba = "*"
+numpy = "*"
+pandas = "*"
+panel = "<1"
+pyyaml = "*"
+pip = "*"
+wheel = "*"
+
+[target.osx-64.dependencies]
+libgfortran = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks.dashboard]
+cmd = "panel serve --rest-session-info --session-history -1 IEX_stocks.ipynb --show"
+depends-on = ["download"]
+
+[tasks.notebook]
+cmd = "jupyter notebook ."
+depends-on = ["download"]
+
+[tasks.download]
+env = { FILENAME = "data/IEX_2019-10-21.csv" }
+cmd = "mkdir -p data && curl -fsSL -o $FILENAME https://s3.amazonaws.com/datashader-data/IEX_2019-10-21.csv"
+outputs = ["data/IEX_2019-10-21.csv"]

--- a/iex_trading/pixi.toml
+++ b/iex_trading/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "iex_trading"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/iex_trading/pixi.toml
+++ b/iex_trading/pixi.toml
@@ -23,14 +23,14 @@ numpy = "*"
 pandas = "*"
 panel = "<1"
 pyyaml = "*"
-pip = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks.dashboard]
 cmd = "panel serve --rest-session-info --session-history -1 IEX_stocks.ipynb --show"

--- a/landsat/pixi.lock
+++ b/landsat/pixi.lock
@@ -1,0 +1,8984 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py310h5764c6d_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.4-h0f2a231_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/boost-cpp-1.74.0-h6cacc03_7.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.0.9-h166bdaf_8.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.0.9-h166bdaf_8.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.19.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.5.7-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.16.0-ha12eb4b_1010.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.20.2-py310he9c7799_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.15.1-py310h255011f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.0.0-h9a35b8e_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.2-py310hde88566_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.0.7-py310hdf3cbec_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/curl-7.86.0-h2283fc2_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.6.7-py310heca2aa9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.5.0-hcb278e6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.39.4-py310h2372a71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-hca18f0e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-1.0.6-h166bdaf_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.10.2-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.0-h6593c0a_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.21.1-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.1-h0b41bf4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h9772cbc_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.12.1-nompi_h4df4325_104.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-69.1-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jpeg-9e-h0b41bf4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.15-h98cffda_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-5.3.0-py310hff52083_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kealib-1.4.15-hfe1a663_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.4-py310hbf28c38_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.19.3-h08a2579_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.14-h6ed2654_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-17_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.0.9-h166bdaf_8.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.0.9-h166bdaf_8.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.0.9-h166bdaf_8.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-17_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-7.86.0-h2283fc2_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdap4-3.20.6-hd7c4107_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.14-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.1.0-he5830b7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.4.1-h4ae554a_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.1.0-h69a702a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.1.0-h15d22d2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.76.3-hebfc3b9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.1.0-he5830b7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-h238a007_1014.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-17_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.8.1-nompi_h329d8a1_102.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.52.0-h61bc06f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.0-h7f98852_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.23-pthreads_h80387f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.39-h753d276_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-14.5-he2d8382_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-hf69c175_9.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.0.1-h0e567f8_14.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.42.0-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.1.0-hfd8a6a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.4.0-h82bc61c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.0-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.13-h7f98852_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.9.14-haae042b_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.9.2-hc929e4a_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-h166bdaf_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.40.0-py310h1b8f574_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.3-h9c3ff4c_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py310h2372a71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.7.1-py310he60537e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-hcb278e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.6.0-nompi_py310h947f774_100.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.82-he02c5a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.57.0-py310h0f6aa51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.24.3-py310ha4c1d20_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.0-h7d73246_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.1-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.0.2-py310h7cbd5c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-2.19.2-h32600fe_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre-8.45-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.40-hc3806b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-9.2.0-py310h454ad03_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.40.0-h36c2ea0_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/poppler-21.11.0-ha39eefc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/postgresql-14.5-ha7cec9f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-8.2.1-h277dcde_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py310h1fa729e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.3.0-py310h9e0d750_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyrsistent-0.19.3-py310h1fa729e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.11-he550d4f_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-3_cp310.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0-py310h5764c6d_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-25.1.0-py310h5bbb5d0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.2.10-py310h5e0f756_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.10.1-py310ha4c1d20_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-1.8.2-py310hb974679_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.42.0-h2c6b66d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.6.4-h3f4058f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.12-h27826a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.3.2-py310h2372a71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tzcode-2022e-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.0.0-py310h5764c6d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.3-h8ce2273_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-h7391055_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.4-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.10-h7f98852_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-h7f98852_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.4-h9c3ff4c_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-h166bdaf_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.2-h3eb15da_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-3.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-21.3.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.5.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.3-unix_pyhd8ed1ab_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.15.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashape-0.5.4-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-1.2.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flit-core-3.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.5.0-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.13.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.10.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.6.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.6.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-5.12.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.23.1-pyh210e3f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.14.0-pyh41d4057_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.18.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.17.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.6.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-2.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.3.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-2.0.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.0.0-pyhb4ecaf3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.4-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-1.13.0-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.7.0-pyha770c72_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.38-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.38-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-core-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.15.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.17.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.14.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh41d4057_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-67.7.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.3.2.post1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyh41d4057_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.65.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.6.3-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.6.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.40.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2023.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2023.5.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.15.0-pyhd8ed1ab_0.conda
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-3.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-21.3.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.5.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.3-unix_pyhd8ed1ab_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.15.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashape-0.5.4-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-1.2.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flit-core-3.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.5.0-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.13.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.10.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.6.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.6.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-5.12.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.23.1-pyh736e0ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.14.0-pyhd1c38e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.18.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.17.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.6.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-2.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.3.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-2.0.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.0.0-pyhb4ecaf3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.4-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-1.13.0-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.7.0-pyha770c72_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.38-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.38-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-core-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.15.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.17.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.14.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyhd1c38e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-67.7.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.3.2.post1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyhd1c38e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.65.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.6.3-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.6.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.40.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2023.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2023.5.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.15.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h5547dcb_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.4-heccf04b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/boost-cpp-1.78.0-hf5ba120_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.0.9-hb7f2c08_8.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.0.9-hb7f2c08_8.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.19.1-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2023.5.7-h8857fd0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.16.0-h09dd18c_1016.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cartopy-0.21.1-py311hb21c73c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.15.1-py311ha86e640_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cfitsio-4.2.0-hd56cc12_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cftime-1.6.2-py311hd5badaa_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.0.7-py311hd2070f0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/curl-8.1.2-hbee3ae8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.6.7-py311h814d153_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/expat-2.5.0-hf0c8a7f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.14.2-h5bb23bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.39.4-py311h2725bcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h3f81eb7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-1.0.6-hb7f2c08_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.11.2-hf0c8a7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/geotiff-1.7.1-h75a88c4_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.21.1-h8a4c099_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.1-hb7f2c08_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h9804679_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.0-nompi_hbf0aa07_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-72.1-h7336db1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/json-c-0.16-h01d06f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jupyter_core-5.3.0-py311h6eed73b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/kealib-1.5.1-hde10d81_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.4-py311hd2070f0_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.20.1-h049b76e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.15-h2dcdeff_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.0.6-hf0c8a7f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.6.2-h0b5dc4a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-17_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.0.9-hb7f2c08_8.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.0.9-hb7f2c08_8.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.0.9-hb7f2c08_8.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-17_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.1.2-hbee3ae8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.5-hd57cbcb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.18-hac1461d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-haf1e3a3_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.5.0-hf0c8a7f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.7.0-hd7102d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-11_3_0_h97931a8_31.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-12.2.0-he409387_31.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.76.3-hc62aa5d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hac89ed1_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-2.1.5.1-hb7f2c08_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libkml-1.3.0-haeb80ef_1015.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-17_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-hc8e404f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.2-nompi_hf077d52_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.52.0-he2ab024_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.23-openmp_h429af6e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.39-ha978bb4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpq-15.3-h9dc22bb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/librttopo-1.1.0-h5c328d2_13.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.18-hbcb3906_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libspatialite-5.0.1-h8e1627f_26.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.42.0-h58db7d2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.5.0-hedf67fa_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.3.0-hb7f2c08_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.15-hb7f2c08_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.11.4-hd95e348_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzip-1.9.2-h6db710c_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-hfd90126_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-16.0.5-hff08bdf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.40.0-py311hcbb5c6d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lzo-2.10-haf1e3a3_1000.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.3-py311h2725bcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.7.1-py311h2bf763f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-hf0c8a7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/netcdf4-1.6.4-nompi_py311h6222480_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/nspr-4.35-hea0b92c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/nss-3.89-h78b00b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.57.0-py311h5a8220d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.24.3-py311hc44ba51_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.0-h13ac156_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.1.1-h8a1eda9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.0.2-py311hab14417_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandoc-2.19.2-h694c41f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.40-h1c4e4bc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-9.5.0-py311h7cb0e2d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.40.0-hbcb3906_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/poppler-23.05.0-he041c3a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/postgresql-15.3-h325e403_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.2.0-hf909084_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.5-py311h5547dcb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-9.2-py311hf110eff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-9.2-py311hf110eff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.5.0-py311hfd16f4a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyrsistent-0.19.3-py311h5547dcb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.3-h99528f9_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-3_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0-py311h5547dcb_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-25.1.0-py311h5dacc12_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rasterio-1.3.7-py311h22430a6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.10.1-py311h16c3c4d_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.1-py311heb7bb94_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.42.0-h2b0dec6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tiledb-2.13.2-h8b9cbf0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.12-h5dbffcc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.3.2-py311h2725bcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tzcode-2023c-hb7f2c08_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xerces-c-3.2.4-h90c7484_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.4-he49afe7_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-hfd90126_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.2-hbc0c0cd_6.conda
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-3.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-21.3.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.5.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.3-unix_pyhd8ed1ab_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.15.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashape-0.5.4-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-1.2.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flit-core-3.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.5.0-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.13.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.10.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.6.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.6.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-5.12.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.23.1-pyh736e0ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.14.0-pyhd1c38e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.18.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.17.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.6.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-2.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.3.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-2.0.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.0.0-pyhb4ecaf3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.4-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-1.13.0-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.7.0-pyha770c72_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.38-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.38-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-core-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.15.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.17.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.14.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyhd1c38e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-67.7.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.3.2.post1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyhd1c38e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.65.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.6.3-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.6.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.40.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2023.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2023.5.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.15.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311he2be06e_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.4-hc338f07_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/boost-cpp-1.78.0-h9ed8d21_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.0.9-h1a8c8d9_8.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.0.9-h1a8c8d9_8.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h3422bc3_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.19.1-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.5.7-hf0a4a13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.16.0-h1e71087_1016.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cartopy-0.21.1-py311hbf64cf6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.15.1-py311hae827db_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cfitsio-4.2.0-h2f961c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.2-py311h4add359_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.0.7-py311hd6ee22a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/curl-8.1.2-h912dcd9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.6.7-py311ha397e9f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.5.0-hb7217d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.14.2-h82840c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.39.4-py311heffc1b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hd633e50_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-1.0.6-h1a8c8d9_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.11.2-hb7217d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geotiff-1.7.1-hea8fa61_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.21.1-h0186832_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.1-h1a8c8d9_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h8111dcc_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.0-nompi_h6b85c65_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-72.1-he12128b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/json-c-0.16-hc449e50_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jupyter_core-5.3.0-py311h267d04e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kealib-1.5.1-hc851fbe_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.4-py311hd6ee22a_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.20.1-h69eda48_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.15-hd835a16_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.0.6-hb7217d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.6.2-h82b9b87_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-17_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.0.9-h1a8c8d9_8.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.0.9-h1a8c8d9_8.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.0.9-h1a8c8d9_8.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-17_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.1.2-h912dcd9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.5-h4653b0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.18-h1a8c8d9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h642e427_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.5.0-hb7217d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-3.7.0-h33c4f09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-12_2_0_hd922786_31.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-12.2.0-h0eea778_31.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.76.3-h24e9cb9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-he4db4b2_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-2.1.5.1-h1a8c8d9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libkml-1.3.0-h41464e4_1015.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-17_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnetcdf-4.9.2-nompi_h0a2dbf5_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.52.0-hae82a92_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.23-openmp_hc731615_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.39-h76d750c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-15.3-h7126958_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/librttopo-1.1.0-h6ecf6d2_13.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.18-h27ca646_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libspatialite-5.0.1-h229630b_26.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.42.0-hb31c410_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.5.0-h4f7d55c_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.3.0-h1a8c8d9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.15-hf346824_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.11.4-he3bdae6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzip-1.9.2-h76ab92c_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h03a7124_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-16.0.5-h1c12783_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.40.0-py311hea943cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h642e427_1000.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.3-py311heffc1b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.7.1-py311h99a5f44_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h7ea286d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/netcdf4-1.6.4-nompi_py311h6a8bb3c_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.35-hb7217d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.89-h789eff7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.57.0-py311hbf3c4e2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.24.3-py311hb8f3215_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.0-hbc2ba62_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.1.1-h53f4e23_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.0.2-py311h9e438b8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandoc-2.19.2-hce30654_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.40-hb34f9b4_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-9.5.0-py311h095fde6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.40.0-h27ca646_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/poppler-23.05.0-h16d8c84_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/postgresql-15.3-hb5ad9d5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.2.0-h13f728c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.5-py311he2be06e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-9.2-py311hb702dc4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-9.2-py311hb702dc4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.5.0-py311h002c271_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyrsistent-0.19.3-py311he2be06e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.3-h1456518_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-3_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0-py311he2be06e_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-25.1.0-py311hb1af645_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rasterio-1.3.7-py311h2979e92_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.10.1-py311h93d07a4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.1-py311h7f8cfc4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.42.0-h203b68d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tiledb-2.13.2-h9bd36d0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.12-he1e0b03_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.3.2-py311heffc1b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tzcode-2023c-h1a8c8d9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xerces-c-3.2.4-h68f8447_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.4-hbdafb3b_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h03a7124_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.2-hf913c23_6.conda
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-3.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-21.3.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.5.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.3-win_pyhd8ed1ab_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.15.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashape-0.5.4-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-1.2.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flit-core-3.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.5.0-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.13.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.10.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.6.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.6.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-5.12.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.23.1-pyh025b116_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.14.0-pyh08f2357_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.18.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.17.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.6.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-2.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.3.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-2.0.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.0.0-pyhb4ecaf3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.4-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-1.13.0-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.7.0-pyha770c72_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.38-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.38-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-core-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.15.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.17.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.14.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh08f2357_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-67.7.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.3.2.post1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.0-pyh08f2357_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.65.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.6.3-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.6.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.40.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyhd8ed1ab_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2023.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2023.5.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.15.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311ha68e1ae_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.4-hdccc3a2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/boost-cpp-1.78.0-h9f4b32c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.0.9-hcfcfb64_8.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.0.9-hcfcfb64_8.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h8ffe710_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.5.7-h56e8100_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.16.0-hdecc03f_1016.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cartopy-0.21.1-py311h178a126_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.15.1-py311h7d9ee11_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cfitsio-4.2.0-h9ebe7e4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cftime-1.6.2-py311h59ca53f_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.0.7-py311h005e61a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/curl-8.1.2-h68f0423_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.6.7-py311h12c1d0e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/expat-2.5.0-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.14.2-hbde0cde_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.39.4-py311ha68e1ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-h546665d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-1.0.6-h67ca5e6_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.11.2-h1537add_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.1-h7222e44_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gettext-0.21.1-h5728263_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h1334946_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.0-nompi_h918d9b7_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/icu-72.1-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2023.1.0-h57928b3_46319.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jupyter_core-5.3.0-py311h1ea47a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kealib-1.5.1-hc8369a0_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.4-py311h005e61a_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.20.1-heb0366b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.15-h3e3b177_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.0.6-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.6.2-h6f8411a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-17_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.0.9-hcfcfb64_8.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.0.9-hcfcfb64_8.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.0.9-hcfcfb64_8.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-17_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.1.2-h68f0423_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.18-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.5.0-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.7.0-h4083641_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.76.3-he8f3873_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.1-nocuda_h15da153_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-h8ffe710_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-2.1.5.1-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-hf2ab4e4_1015.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-17_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_ha5afab8_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.39-h19919ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpq-15.3-ha9684e8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-he1da8c1_13.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.18-h8d14728_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.0.1-hca1f1ac_26.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.42.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.5.0-h6c8260b_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.3.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.15-hcd874cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.11.4-hc3477c8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzip-1.9.2-h519de47_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.40.0-py311h5bc0dda_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lzo-2.10-he774522_1000.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.3-py311ha68e1ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.7.1-py311h6e989c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2022.1.0-h6a75c08_874.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/netcdf4-1.6.4-nompi_py311h896b27b_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.57.0-py311h2c0921f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.24.3-py311h0b4df5a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.0-ha2aaf27_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.1.1-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.0.2-py311hf63dbb6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandoc-2.19.2-h57928b3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.40-h17e33f8_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-9.5.0-py311hde623f7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.40.0-h8ffe710_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/poppler-23.05.0-h45d20d0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/postgresql-15.3-h96452e4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.2.0-heca977f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.5-py311ha68e1ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-hcd874cb_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.5.0-py311h095e9de_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyrsistent-0.19.3-py311ha68e1ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.3-h2628c8c_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-3_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-304-py311h12c1d0e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.10-py311h12c1d0e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0-py311ha68e1ae_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-25.1.0-py311h7b3f143_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rasterio-1.3.7-py311h826718d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.10.1-py311h37ff6ca_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.1-py311h343093d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.42.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.9.0-h91493d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.13.2-h3132609_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.12-h8ffe710_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.3.2-py311ha68e1ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-hb25d44b_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.34.31931-h5081d32_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.34.31931-hed1258a_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.2.4-h63175ca_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-hcd874cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.3-hcd874cb_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.4-h0e60522_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.2.13-hcfcfb64_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.2-h12be248_6.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  license: None
+  size: 2562
+  timestamp: 1578324546067
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23621
+  timestamp: 1650670423406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py310h5764c6d_3.tar.bz2
+  sha256: 66cc235b93b36b36c90b5986979067c2e8fb2c5d9729f3a29d068664e90ffc7a
+  md5: 12f70cd23e4ea88f913dba50b0f0aba0
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 35422
+  timestamp: 1666850884532
+- conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.4-h0f2a231_0.conda
+  sha256: 40d1712aa0f4f8bac2ab5fba6179814f8ff7afbb7ffc55c8e315e7b3930b83f1
+  md5: 876286b5941933a0f558777e57d883cc
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48722
+  timestamp: 1684234948548
+- conda: https://conda.anaconda.org/conda-forge/linux-64/boost-cpp-1.74.0-h6cacc03_7.tar.bz2
+  sha256: 7516fc72e0bf3d837427a8522093205bdd5faf0447d11ad659adf74e43da5a66
+  md5: b7c1f8b1937c8572d7dce988a9df1a64
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=69.1,<70.0a0
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  - libzlib >=1.2.11,<2.0.0a0
+  - xz >=5.2.5,<6.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  constrains:
+  - libboost <0
+  license: BSL-1.0
+  size: 17072591
+  timestamp: 1644185152670
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.0.9-h166bdaf_8.tar.bz2
+  sha256: 74c0fa22ea7c62d2c8f7a7aea03a3bd4919f7f3940ef5b027ce0dfb5feb38c06
+  md5: 2ff08978892a3e8b954397c461f18418
+  depends:
+  - brotli-bin 1.0.9 h166bdaf_8
+  - libbrotlidec 1.0.9 h166bdaf_8
+  - libbrotlienc 1.0.9 h166bdaf_8
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 18900
+  timestamp: 1666788702683
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.0.9-h166bdaf_8.tar.bz2
+  sha256: ab1994e03bdd88e4b27f9f802ac18e45ed29b92cce25e1fd86da43b89734950f
+  md5: e5613f2bc717e9945840ff474419b8e4
+  depends:
+  - libbrotlidec 1.0.9 h166bdaf_8
+  - libbrotlienc 1.0.9 h166bdaf_8
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 20094
+  timestamp: 1666788689798
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2
+  sha256: cb521319804640ff2ad6a9f118d972ed76d86bea44e5626c09a13d38f562e1fa
+  md5: a1fd65c7ccbf10880423d82bca54eb54
+  depends:
+  - libgcc-ng >=9.3.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 495686
+  timestamp: 1606604745109
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.19.1-hd590300_0.conda
+  sha256: c4276b1a0e8f18ab08018b1881666656742b325e0fcf2354f714e924d28683b6
+  md5: e8c18d865be43e2fb3f7a145b6adf1f5
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 113362
+  timestamp: 1684782732180
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.5.7-hbcca054_0.conda
+  sha256: 0cf1bb3d0bfc5519b60af2c360fa4888fb838e1476b1e0f65b9dbc48b45c7345
+  md5: f5c65075fc34438d5b456c7f3f5ab695
+  license: ISC
+  size: 148360
+  timestamp: 1683451720318
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.16.0-ha12eb4b_1010.tar.bz2
+  sha256: 4e64ee154efc450d54f5ad1b674ad3ef25585f4f5c4ad60fc32b72eac6c2927f
+  md5: e15c0969bf37df9dae513a48ac871a7d
+  depends:
+  - fontconfig >=2.13.96,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.10.4,<3.0a0
+  - icu >=69.1,<70.0a0
+  - libgcc-ng >=10.3.0
+  - libglib >=2.70.2,<3.0a0
+  - libpng >=1.6.37,<1.7.0a0
+  - libxcb >=1.13,<1.14.0a0
+  - libzlib >=1.2.11,<2.0.0a0
+  - pixman >=0.40.0,<1.0a0
+  - xorg-libice
+  - xorg-libsm
+  - xorg-libx11
+  - xorg-libxext
+  - xorg-libxrender
+  - zlib >=1.2.11,<1.3.0a0
+  license: LGPL-2.1-only or MPL-1.1
+  size: 1577909
+  timestamp: 1646853569163
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.20.2-py310he9c7799_3.tar.bz2
+  sha256: 29fb9c4d3c879955f4ee35f43cad886d3c3eb3485fb37c68272c0e13164838b9
+  md5: 2087fc11706c4c20a3a31f79f7556fce
+  depends:
+  - geos >=3.10.2,<3.10.3.0a0
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  - matplotlib-base >=3.1
+  - numpy >=1.21.5,<2.0a0
+  - proj >=8.2.1,<8.2.2.0a0
+  - pyproj >=3.0
+  - pyshp >=2.1
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - scipy >=0.10
+  - shapely >=1.6.4
+  - six >=1.3.0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 2085603
+  timestamp: 1642606777111
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.15.1-py310h255011f_3.conda
+  sha256: f223c8782195f19dbe7cfd27e329de8b0e2205a090ee2a6891e0695d4d634854
+  md5: 800596144bb613cd7ac58b80900ce835
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - pycparser
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 237030
+  timestamp: 1671179461482
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.0.0-h9a35b8e_0.tar.bz2
+  sha256: 38a832176b565089e59ea3010be60373df6b70031ace924f5affc52c85cada6b
+  md5: 6b214116ecabe2c5457a93b9763de61d
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=7.79.1,<9.0a0
+  - libgcc-ng >=9.4.0
+  - libgfortran-ng
+  - libgfortran5 >=9.4.0
+  - libzlib >=1.2.11,<2.0.0a0
+  license: LicenseRef-fitsio
+  size: 1355814
+  timestamp: 1634565578564
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.2-py310hde88566_1.tar.bz2
+  sha256: fc5ff45e357bb63ca586b326e5cdd27f97934d45224af4501023e842436e3794
+  md5: 94ce7a76b0c912279f6958e0b6b21d2b
+  depends:
+  - libgcc-ng >=12
+  - numpy >=1.21.6,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 245518
+  timestamp: 1666834033473
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.0.7-py310hdf3cbec_0.conda
+  sha256: 670b736e895ed1b37187e0cbc73fd528414076f370068975135db2420af8663d
+  md5: 7bf9d8c765b6b04882c719509652c6d6
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.16
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 215697
+  timestamp: 1673633854235
+- conda: https://conda.anaconda.org/conda-forge/linux-64/curl-7.86.0-h2283fc2_1.tar.bz2
+  sha256: 9c7de3c405c8195a02dd829f4b9b1a8a14b5bca4670b8e6a05554df63d0b92af
+  md5: 9d4149760567cb232691cce2d8ccc21f
+  depends:
+  - krb5 >=1.19.3,<1.20.0a0
+  - libcurl 7.86.0 h2283fc2_1
+  - libgcc-ng >=12
+  - libssh2 >=1.10.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.0.7,<4.0a0
+  license: curl
+  license_family: MIT
+  size: 92766
+  timestamp: 1667347245435
+- conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.6.7-py310heca2aa9_0.conda
+  sha256: 4e476f11daa93d7740eaa8b13238db48c8c9e416d127bb1cda30300b63a26b52
+  md5: 8ffb020d2b722c962f0b4f06a304f533
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 1956208
+  timestamp: 1680755653448
+- conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.5.0-hcb278e6_1.conda
+  sha256: 36dfeb4375059b3bba75ce9b38c29c69fd257342a79e6cf20e9f25c1523f785f
+  md5: 8b9b5aca60558d02ddaa09d599e55920
+  depends:
+  - libexpat 2.5.0 hcb278e6_1
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 136778
+  timestamp: 1680190541750
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
+  sha256: 155d534c9037347ea7439a2c6da7c24ffec8e5dd278889b4c57274a1d91e0a83
+  md5: 0f69b688f52ff6da70bccb7ff7001d1d
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libgcc-ng >=12
+  - libuuid >=2.32.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 272010
+  timestamp: 1674828850194
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.39.4-py310h2372a71_0.conda
+  sha256: 253a41d41f4ccaef49412c3c628dc2032526821a3bad26b8cd65b311d6346519
+  md5: 76426eaff204520e719207700359a855
+  depends:
+  - brotli
+  - libgcc-ng >=12
+  - munkres
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - unicodedata2 >=14.0.0
+  license: MIT
+  license_family: MIT
+  size: 2173088
+  timestamp: 1683740642738
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-hca18f0e_1.conda
+  sha256: 1eb913727b54e9aa63c6d9a1177db4e2894cee97c5f26910a2b61899d5ac904f
+  md5: e1232042de76d24539a436d37597eb06
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only and LicenseRef-FreeType
+  size: 625655
+  timestamp: 1669232824158
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-1.0.6-h166bdaf_1.tar.bz2
+  sha256: 26045196e00b5787276c60ff83acfa8808cae550a20832f11104069e5f7f3f05
+  md5: 897e772a157faf3330d72dd291486f62
+  depends:
+  - libgcc-ng >=12
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 49640
+  timestamp: 1662819514879
+- conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.10.2-h9c3ff4c_0.tar.bz2
+  sha256: 0caba5822207c7754f0007fa2a331f616d7090d37d00ae0de08d74c6396db7bf
+  md5: fe9a66a351bfa7a84c3108304c7bcba5
+  depends:
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  license: LGPL-2.1-only
+  size: 1645774
+  timestamp: 1642312367362
+- conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.0-h6593c0a_6.tar.bz2
+  sha256: 0f63086b58d642fa9e5f20691e2d96c748ae89edaa961d970de4b3428d88a1b6
+  md5: c27cd5bfa3060e7015610387fe249142
+  depends:
+  - jpeg >=9d,<10a
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  - libtiff >=4.3.0,<4.5.0a0
+  - libzlib >=1.2.11,<2.0.0a0
+  - proj >=8.2.1,<8.2.2.0a0
+  - zlib >=1.2.11,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 305441
+  timestamp: 1641162686773
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.21.1-h27087fc_0.tar.bz2
+  sha256: 4fcfedc44e4c9a053f0416f9fc6ab6ed50644fca3a761126dbd00d09db1f546a
+  md5: 14947d8770185e5153fdd04d4673ed37
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 4320628
+  timestamp: 1665673494324
+- conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.1-h0b41bf4_3.conda
+  sha256: 41ec165704ccce2faa0437f4f53c03c06261a2cc9ff7614828e51427d9261f4b
+  md5: 96f3b11872ef6fad973eac856cd2624f
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 77385
+  timestamp: 1678717794467
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h9772cbc_5.tar.bz2
+  sha256: c343a211880a86abf99a8f117a53e251317f99faac761fc0b758f6ad737d13ff
+  md5: ee08782aff2ff9b3291c967fa6bc7336
+  depends:
+  - jpeg >=9e,<10a
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 973792
+  timestamp: 1667222658023
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.12.1-nompi_h4df4325_104.tar.bz2
+  sha256: c506a7a7114800a63652f7e82324d221bd3ca6910dcff74722fe54644f402aa8
+  md5: ddecfd15c2a412c595c68ff22d3557a0
+  depends:
+  - libcurl >=7.81.0,<9.0a0
+  - libgcc-ng >=10.3.0
+  - libgfortran-ng
+  - libgfortran5 >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  - libzlib >=1.2.11,<2.0.0a0
+  - openssl >=3.0.0,<4.0a0
+  - zlib >=1.2.11,<1.3.0a0
+  license: LicenseRef-HDF5
+  license_family: BSD
+  size: 3725303
+  timestamp: 1646413396971
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-69.1-h9c3ff4c_0.tar.bz2
+  sha256: c3a356dcee44d420ce79c55a02ced8221a3ec305de9ecf3a7f1ab1c21d2fcad4
+  md5: e0773c9556d588b062a4e1424a6a02fa
+  depends:
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 13885192
+  timestamp: 1635411478428
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jpeg-9e-h0b41bf4_3.conda
+  sha256: 8f73194d09c9ea4a7e2b3562766b8d72125cc147b62c7cf83393e3a3bbfd581b
+  md5: c7a069243e1fbe9a556ed2ec030e6407
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - libjpeg-turbo <0.0.0a
+  license: IJG
+  size: 240359
+  timestamp: 1676177310738
+- conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.15-h98cffda_0.tar.bz2
+  sha256: 3f978a326b41aa49545b53cba7fc48bb9659ca51d252b14382f7194fe0e01d23
+  md5: f32d45a88e7462be446824654dbcf4a4
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 280696
+  timestamp: 1613412286535
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-5.3.0-py310hff52083_0.conda
+  sha256: e683c10d89530e067e3be791d8a232c0a84dd3c8790657b0f815f798b08bdd1c
+  md5: 49428e10aae69baa6b34cb7e275f1ae9
+  depends:
+  - platformdirs >=2.5
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 90520
+  timestamp: 1678994476795
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kealib-1.4.15-hfe1a663_0.tar.bz2
+  sha256: 9d8802c906d25ddcf6511d368c064dd44dc8e6564e1f2ae047ebd24cabdab422
+  md5: 32fda93b8db4b6be630d1ee6a94f23b9
+  depends:
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 192974
+  timestamp: 1655956000438
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+  sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
+  md5: 30186d27e2c9fa62b45fb1476b7200e3
+  depends:
+  - libgcc-ng >=10.3.0
+  license: LGPL-2.1-or-later
+  size: 117831
+  timestamp: 1646151697040
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.4-py310hbf28c38_1.tar.bz2
+  sha256: f56d1772472b90ddda6fd0963a80dcf1960f1277b9653667a9bde62ae125f972
+  md5: ad5647e517ba68e2868ef2e6e6ff7723
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 77416
+  timestamp: 1666805829361
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.19.3-h08a2579_0.tar.bz2
+  sha256: 9faad78e078a3e671f3572a01163acc1b2a47539559c746ea3ffd17c754ea578
+  md5: d25e05e7ee0e302b52d24491db4891eb
+  depends:
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  - openssl >=3.0.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1516863
+  timestamp: 1647339263181
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.14-h6ed2654_0.tar.bz2
+  sha256: cbadb4150850941bf0518ba948effbbdd89b2c28dfdfed54eae196037e015b43
+  md5: dcc588839de1445d90995a0a2c4f3a39
+  depends:
+  - jpeg >=9e,<10a
+  - libgcc-ng >=12
+  - libtiff >=4.4.0,<4.5.0a0
+  license: MIT
+  license_family: MIT
+  size: 262144
+  timestamp: 1667332608997
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+  sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
+  md5: 7aca3059a1729aa76c597603f10b0dd3
+  constrains:
+  - binutils_impl_linux-64 2.40
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 704696
+  timestamp: 1674833944779
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+  sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
+  md5: 76bbff344f0134279f225174e9064c8f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 281798
+  timestamp: 1657977462600
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-17_linux64_openblas.conda
+  sha256: 5a9dfeb9ede4b7ac136ac8c0b589309f8aba5ce79d14ca64ad8bffb3876eb04b
+  md5: 57fb44770b1bc832fb2dbefa1bd502de
+  depends:
+  - libopenblas >=0.3.23,<0.3.24.0a0
+  - libopenblas >=0.3.23,<1.0a0
+  constrains:
+  - liblapacke 3.9.0 17_linux64_openblas
+  - libcblas 3.9.0 17_linux64_openblas
+  - blas * openblas
+  - liblapack 3.9.0 17_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14473
+  timestamp: 1685930788591
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.0.9-h166bdaf_8.tar.bz2
+  sha256: ddc961a36d498aaafd5b71078836ad5dd247cc6ba7924157f3801a2f09b77b14
+  md5: 9194c9bf9428035a05352d031462eae4
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 67181
+  timestamp: 1666788652244
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.0.9-h166bdaf_8.tar.bz2
+  sha256: d88ba07c3be27c89cb4975cc7edf63ee7b1c62d01f70d5c3f7efeb987c82b052
+  md5: 4ae4d7795d33e02bd20f6b23d91caf82
+  depends:
+  - libbrotlicommon 1.0.9 h166bdaf_8
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 34236
+  timestamp: 1666788664677
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.0.9-h166bdaf_8.tar.bz2
+  sha256: a0468858b2f647f51509a32040e93512818a8f9980f20b3554cccac747bcc4be
+  md5: 04bac51ba35ea023dc48af73c1c88c25
+  depends:
+  - libbrotlicommon 1.0.9 h166bdaf_8
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 295241
+  timestamp: 1666788677116
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-17_linux64_openblas.conda
+  sha256: 535bc0a6bc7641090b1bdd00a001bb6c4ac43bce2a11f238bc6676252f53eb3f
+  md5: 7ef0969b00fe3d6eef56a8151d3afb29
+  depends:
+  - libblas 3.9.0 17_linux64_openblas
+  constrains:
+  - liblapacke 3.9.0 17_linux64_openblas
+  - blas * openblas
+  - liblapack 3.9.0 17_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14401
+  timestamp: 1685930800770
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-7.86.0-h2283fc2_1.tar.bz2
+  sha256: 485249c8cf7c2bd67d8308f7d1fccbe64e54334ad6cc73168d665eed824ca3bc
+  md5: fdca8cd67ec2676f90a70ac73a32538b
+  depends:
+  - krb5 >=1.19.3,<1.20.0a0
+  - libgcc-ng >=12
+  - libnghttp2 >=1.47.0,<2.0a0
+  - libssh2 >=1.10.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.0.7,<4.0a0
+  license: curl
+  license_family: MIT
+  size: 359593
+  timestamp: 1667347234315
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdap4-3.20.6-hd7c4107_2.tar.bz2
+  sha256: ebc0d6a0decbd236f3cc362d7485f8ad1f7aef1246ada5507b407892e88293c5
+  md5: c265ae57e3acdc891f3e2b93cf6784f5
+  depends:
+  - curl >=7.75.0,<9.0a0
+  - libgcc-ng >=9.3.0
+  - libstdcxx-ng >=9.3.0
+  - libuuid >=2.32.1,<3.0a0
+  - libxml2 >=2.9.10,<2.14.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 11898306
+  timestamp: 1616781500733
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.14-h166bdaf_0.tar.bz2
+  sha256: 6f7cbc9347964e7f9697bde98a8fb68e0ed926888b3116474b1224eaa92209dc
+  md5: fc84a0446e4e4fb882e78d786cfb9734
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 82697
+  timestamp: 1662888469663
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+  sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
+  md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 123878
+  timestamp: 1597616541093
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2
+  sha256: 8c9635aa0ea28922877dc96358f9547f6a55fc7e2eb75a556b05f1725496baf9
+  md5: 6f8720dff19e17ce5d48cfe7f3d2f0a3
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 106190
+  timestamp: 1598867915000
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
+  sha256: 74c98a563777ae2ad71f1f74d458a8ab043cee4a513467c159ccf159d0e461f3
+  md5: 6305a3dd2752c76335295da4e581f2fd
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - expat 2.5.0.*
+  license: MIT
+  license_family: MIT
+  size: 77980
+  timestamp: 1680190528313
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+  sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+  md5: d645c6d2ac96843a2bfaccd2d62b3ac3
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 58292
+  timestamp: 1636488182923
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.1.0-he5830b7_0.conda
+  sha256: fba897a02f35b2b5e6edc43a746d1fa6970a77b422f258246316110af8966911
+  md5: cd93f779ff018dd85c7544c015c9db3c
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 13.1.0 he5830b7_0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 776294
+  timestamp: 1685816209343
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.4.1-h4ae554a_2.tar.bz2
+  sha256: 025c82a2e253549e97a5dadfaad9a9702f45e6cf82d5698a97b40577e6194e8b
+  md5: d80de7473e7a85c2e2ef520574d92ab1
+  depends:
+  - blosc >=1.21.0,<2.0a0
+  - cfitsio >=4.0.0,<4.0.1.0a0
+  - expat >=2.4.3,<3.0a0
+  - freexl >=1.0.6,<2.0a0
+  - geos >=3.10.2,<3.10.3.0a0
+  - geotiff >=1.7.0,<1.7.1.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - hdf4 >=4.2.15,<4.3.0a0
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - icu >=69.1,<70.0a0
+  - jpeg >=9d,<10a
+  - json-c >=0.15,<0.16.0a0
+  - kealib >=1.4.14,<1.5.0a0
+  - libdap4 >=3.20.6,<3.20.7.0a0
+  - libgcc-ng >=9.4.0
+  - libkml >=1.3.0,<1.4.0a0
+  - libnetcdf >=4.8.1,<4.8.2.0a0
+  - libpng >=1.6.37,<1.7.0a0
+  - libpq >=14.1,<15.0a0
+  - libspatialite >=5.0.1,<5.1.0a0
+  - libstdcxx-ng >=9.4.0
+  - libtiff >=4.3.0,<4.5.0a0
+  - libuuid >=2.32.1,<3.0a0
+  - libwebp-base
+  - libxml2 >=2.9.12,<2.14.0a0
+  - libzlib >=1.2.11,<2.0.0a0
+  - openjpeg >=2.4.0,<3.0.0a0
+  - openssl >=3.0.0,<4.0a0
+  - pcre >=8.45,<9.0a0
+  - poppler >=21.11.0,<21.12.0a0
+  - postgresql
+  - proj >=8.2.1,<8.2.2.0a0
+  - sqlite >=3.37.0,<4.0a0
+  - tiledb >=2.6.0,<2.7.0a0
+  - xerces-c >=3.2.3,<3.3.0a0
+  - xz >=5.2.5,<6.0.0a0
+  - zstd >=1.5.1,<1.6.0a0
+  size: 14563017
+  timestamp: 1642648115252
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.1.0-h69a702a_0.conda
+  sha256: 429e1d8a3e70b632df5b876e3fc322a56f769756693daa07114c46fa5098684e
+  md5: 506dc07710dd5b0ba63cbf134897fc10
+  depends:
+  - libgfortran5 13.1.0 h15d22d2_0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 23182
+  timestamp: 1685816194244
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.1.0-h15d22d2_0.conda
+  sha256: a06235f4c4b85b463d9b8a73c9e10c1b5b4105f8a0ea8ac1f2f5f64edac3dfe7
+  md5: afb656a334c409dd9805508af1c89c7a
+  constrains:
+  - libgfortran-ng 13.1.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1437388
+  timestamp: 1685816112374
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.76.3-hebfc3b9_0.conda
+  sha256: 6a34c6b123f06fcee7e28e981ec0daad09bce35616ad8e9e61ef84be7fad4d92
+  md5: a64f11b244b2c112cd3fa1cbe9493999
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - pcre2 >=10.40,<10.41.0a0
+  constrains:
+  - glib 2.76.3 *_0
+  license: LGPL-2.1-or-later
+  size: 2675188
+  timestamp: 1684848294347
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.1.0-he5830b7_0.conda
+  sha256: 5d441d80b57f857ad305a65169a6b915d4fd6735cdc9e9bded35d493c91ef16d
+  md5: 56ca14d57ac29a75d23a39eb3ee0ddeb
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 419184
+  timestamp: 1685816132543
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-h166bdaf_0.tar.bz2
+  sha256: 6a81ebac9f1aacdf2b4f945c87ad62b972f0f69c8e0981d68e111739e6720fd7
+  md5: b62b52da46c39ee2bc3c162ac7f1804d
+  depends:
+  - libgcc-ng >=10.3.0
+  license: GPL and LGPL
+  size: 1450368
+  timestamp: 1652700749886
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-h238a007_1014.tar.bz2
+  sha256: 337821b3469c1d47fe66387083659e6ef03b2f1d344301d3ff4917589ca5edb8
+  md5: abd8e196ad04781818acef26cc451d66
+  depends:
+  - boost-cpp >=1.74.0,<1.74.1.0a0
+  - expat >=2.3.0,<3.0.0a0
+  - libgcc-ng >=9.3.0
+  - libstdcxx-ng >=9.3.0
+  - zlib >=1.2.11,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 605459
+  timestamp: 1626544536843
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-17_linux64_openblas.conda
+  sha256: 45128394d2f4d4caf949c1b02bff1cace3ef2e33762dbe8f0edec7701a16aaa9
+  md5: a2103882c46492e26500fcb56c03de8b
+  depends:
+  - libblas 3.9.0 17_linux64_openblas
+  constrains:
+  - liblapacke 3.9.0 17_linux64_openblas
+  - libcblas 3.9.0 17_linux64_openblas
+  - blas * openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14408
+  timestamp: 1685930812931
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_3.conda
+  sha256: c8bf18678259c02a6bd7378e5d14f2bd64cc06428a16e939406e87e657158901
+  md5: 5c159aa79cab06c55aabcecdd9117f31
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 31400907
+  timestamp: 1685678483692
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.8.1-nompi_h329d8a1_102.tar.bz2
+  sha256: 6fa35fbc482d133fd52a75186b5237da30a0a17e638e09894220bd63153668a0
+  md5: a857af323c5edbd8e9e45fb9facb6f5f
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - curl >=7.82.0,<9.0a0
+  - hdf4 >=4.2.15,<4.3.0a0
+  - hdf5 * nompi_*
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - jpeg >=9e,<10a
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  - libzip >=1.8.0,<2.0a0
+  - libzlib >=1.2.11,<2.0.0a0
+  - zlib >=1.2.11,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 1561521
+  timestamp: 1650908784061
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.52.0-h61bc06f_0.conda
+  sha256: ecd6b08c2b5abe7d1586428c4dd257dcfa00ee53700d79cdc8bca098fdfbd79a
+  md5: 613955a50485812985c059e7b269f42e
+  depends:
+  - c-ares >=1.18.1,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.0.8,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 622366
+  timestamp: 1677678076121
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.0-h7f98852_0.tar.bz2
+  sha256: 32f4fb94d99946b0dabfbbfd442b25852baf909637f2eed1ffe3baea15d02aad
+  md5: 39b1328babf85c7c3a61636d9cd50206
+  depends:
+  - libgcc-ng >=9.4.0
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 31236
+  timestamp: 1633040059627
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.23-pthreads_h80387f5_0.conda
+  sha256: 00aee12d04979d024c7f9cabccff5f5db2852c934397ec863a4abde3e09d5a79
+  md5: 9c5ea51ccb8ffae7d06c645869d24ce6
+  depends:
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=11.3.0
+  constrains:
+  - openblas >=0.3.23,<0.3.24.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5406072
+  timestamp: 1681398290679
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.39-h753d276_0.conda
+  sha256: a32b36d34e4f2490b99bddbc77d01a674d304f667f0e62c89e02c961addef462
+  md5: e1c890aebdebbfbf87e2c917187b4416
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: zlib-acknowledgement
+  size: 282599
+  timestamp: 1669075729952
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-14.5-he2d8382_0.tar.bz2
+  sha256: fd598710ffb7f7bcd9557b4f44cb4d591bb01a864a2fca13ec7de02fe4d2e263
+  md5: 820295fc93845d2bc2d9386d5f68f99e
+  depends:
+  - krb5 >=1.19.3,<1.20.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.2.12,<2.0.0a0
+  - openssl >=3.0.5,<3.2.0a0
+  - readline >=8.1.2,<9.0a0
+  size: 3123024
+  timestamp: 1660238409182
+- conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-hf69c175_9.tar.bz2
+  sha256: 98a5d77b323b5bc3a1a6c19c9fa3361717ea1b4bd97b4d2da5229db1206a15ac
+  md5: 24be5de0faf30ce36576f3dc73bc6cbc
+  depends:
+  - geos >=3.10.2,<3.10.3.0a0
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 241090
+  timestamp: 1642610497408
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
+  sha256: 53da0c8b79659df7b53eebdb80783503ce72fb4b10ed6e9e05cc0e9e4207a130
+  md5: c3788462a6fbddafdb413a9f9053e58d
+  depends:
+  - libgcc-ng >=7.5.0
+  license: ISC
+  size: 374999
+  timestamp: 1605135674116
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.0.1-h0e567f8_14.tar.bz2
+  sha256: f015eb314eb842b18a1b9c94044fb2e0da351eb7f5e23b5c8be99479ecbb969b
+  md5: 546f00291ca5b19c496eddb1d9f757f4
+  depends:
+  - freexl >=1.0.6,<2.0a0
+  - geos >=3.10.2,<3.10.3.0a0
+  - libgcc-ng >=9.4.0
+  - librttopo >=1.1.0,<1.2.0a0
+  - libstdcxx-ng >=9.4.0
+  - libxml2 >=2.9.12,<2.14.0a0
+  - libzlib >=1.2.11,<2.0.0a0
+  - proj >=8.2.1,<8.2.2.0a0
+  - sqlite >=3.37.0,<4.0a0
+  - zlib >=1.2.11,<1.3.0a0
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 4645349
+  timestamp: 1642622937840
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.42.0-h2797004_0.conda
+  sha256: 72e958870f49174ebc0ddcd4129e9a9f48de815f20aa3b553f136b514f29bb3a
+  md5: fdaae20a1cf7cd62130a0973190a31b7
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Unlicense
+  size: 828910
+  timestamp: 1684264791037
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+  sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
+  md5: 1f5a58e686b13bcfde88b93f547d23fe
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 271133
+  timestamp: 1685837707056
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.1.0-hfd8a6a1_0.conda
+  sha256: 6f9eb2d7a96687938c0001166a3b308460a8eb02b10e9d0dd9e251f0219ea05c
+  md5: 067bcc23164642f4c226da631f2a2e1d
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3847887
+  timestamp: 1685816251278
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.4.0-h82bc61c_5.conda
+  sha256: f81d38e7458c6ba2fcf93bef4ed2c12c2977e89ca9a7f936ce53a3338a88352f
+  md5: e712a63a21f9db647982971dc121cdcf
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.14,<1.26.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libwebp-base >=1.2.4,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  size: 484764
+  timestamp: 1671300678072
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33601
+  timestamp: 1680112270483
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.0-h0b41bf4_0.conda
+  sha256: ac3e073ea77803da71eb77e7fcef07defb345bda95eee3327c73ddf85b5714da
+  md5: 0d4a7508d8c6c65314f2b9c1f56ad408
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - libwebp 1.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 356752
+  timestamp: 1678666430817
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.13-h7f98852_1004.tar.bz2
+  sha256: 8d5d24cbeda9282dd707edd3156e5fde2e3f3fe86c802fa7ce08c8f1e803bfd9
+  md5: b3653fdc58d03face9724f602218a904
+  depends:
+  - libgcc-ng >=9.4.0
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 399895
+  timestamp: 1636658924671
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.9.14-haae042b_4.conda
+  sha256: d98b647d14c405a6e2ddafab8e7e407cffb439c25a916d0cb1f596201593ae1c
+  md5: 8c9b5eeab562abb304a977c1beadc92d
+  depends:
+  - icu 69.*
+  - icu >=69.1,<70.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 737488
+  timestamp: 1673113394271
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.9.2-hc929e4a_1.tar.bz2
+  sha256: e2dbd5239f62fbac4f00f828b1de0ea5898d6ed5c1f3049baaf4dfcc4ebdbe7c
+  md5: 5b122b50e738c4be5c3f2899f010d7cf
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.2.12,<2.0.0a0
+  - openssl >=3.0.5,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99380
+  timestamp: 1660347211234
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-h166bdaf_4.tar.bz2
+  sha256: 22f3663bcf294d349327e60e464a51cd59664a71b8ed70c28a9f512d10bc77dd
+  md5: f3f9de449d32ca9b9c66a22863c96f41
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - zlib 1.2.13 *_4
+  license: Zlib
+  license_family: Other
+  size: 65503
+  timestamp: 1665759624457
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.40.0-py310h1b8f574_0.conda
+  sha256: 63ce6ee190cc4420e2370fcf79a4f61b52834a42cfc90d2927c8117320f20188
+  md5: 3e14b22cc052a9a039932825d0b276a7
+  depends:
+  - libgcc-ng >=12
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2511412
+  timestamp: 1684446995254
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.3-h9c3ff4c_1.tar.bz2
+  sha256: 56313fe4e602319682d4ea05c0ed3c5c45fc79884a5896f2cb7436b15d6987f9
+  md5: fbe97e8fa6f275d7c76a09e795adc3e6
+  depends:
+  - libgcc-ng >=9.3.0
+  - libstdcxx-ng >=9.3.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 183677
+  timestamp: 1627669079456
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py310h2372a71_0.conda
+  sha256: 91509d88d073f5baf30866219cee9c8ecef839fa9874fee600e46531c2822621
+  md5: 5597d9f9778af6883ae64f0e7d39416c
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23912
+  timestamp: 1685769225035
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.7.1-py310he60537e_0.conda
+  sha256: d2be8ac0a90aa12ba808f8777d1837b5aa983fc3c7c60c600e8fe6bd9352541c
+  md5: 68b2dd34c69d08b05a9db5e3596fe3ee
+  depends:
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.0.1
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.20
+  - numpy >=1.21.6,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.10.* *_cp310
+  - tk >=8.6.12,<8.7.0a0
+  license: LicenseRef-PSF-2.0 and CC0-1.0
+  license_family: PSF
+  size: 6792612
+  timestamp: 1678135808833
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-hcb278e6_0.conda
+  sha256: ccf61e61d58a8a7b2d66822d5568e2dc9387883dd9b2da61e1d787ece4c4979a
+  md5: 681105bccc2a3f7f1a837d47d39c9179
+  depends:
+  - libgcc-ng >=12
+  license: X11 AND BSD-3-Clause
+  size: 880967
+  timestamp: 1686076725450
+- conda: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.6.0-nompi_py310h947f774_100.tar.bz2
+  sha256: 932c436283740402881d92e0f94f1a7b35b8c2a02ce3adab87e514a3fcaaae90
+  md5: ebde0c4a610be54e818f5407ddc33af7
+  depends:
+  - cftime
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - libgcc-ng >=12
+  - libnetcdf >=4.8.1,<4.8.2.0a0
+  - numpy >=1.21.6,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 493459
+  timestamp: 1656505710929
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda
+  sha256: 8fadeebb2b7369a4f3b2c039a980d419f65c7b18267ba0c62588f9f894396d0c
+  md5: da0ec11a6454ae19bff5b02ed881a2b1
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 226848
+  timestamp: 1669784948267
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.82-he02c5a1_0.conda
+  sha256: dd848f91478b155d3b3af6e64f494d17573fce7f7ebc154d48332f259b112f72
+  md5: f8d7f11d19e4cb2207eab159fd4c0152
+  depends:
+  - libgcc-ng >=12
+  - libsqlite >=3.40.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - nspr >=4.35,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1947586
+  timestamp: 1669788299053
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.57.0-py310h0f6aa51_1.conda
+  sha256: 8dd45b93eaf7931c6670d9cd4a2a3f2be5e3bbdf4e8d7d36fd8f5ea4ee83f2b9
+  md5: 0332dd3c88c942173687b96fb30fad3c
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - llvmlite >=0.40.0,<0.41.0a0
+  - numpy >=1.21.6,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - tbb >=2021.9.0,<2022.0a0
+  - cudatoolkit >=10.2
+  - scipy >=1.0
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.25
+  - cuda-version >=10.2
+  - cuda-python >=11.6
+  - libopenblas !=0.3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4155610
+  timestamp: 1685545034537
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.24.3-py310ha4c1d20_0.conda
+  sha256: d531c8dcbecb2d47d26fcafce00dd244bfb4fdc787eddea40e61b5b57b0e5da2
+  md5: 844b150744d30f256d7937f3f60fcd2f
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6754037
+  timestamp: 1682210565158
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.0-h7d73246_1.tar.bz2
+  sha256: a715cba5649f12a1dca53dfd72fc49577152041f033d7595cf4b6a655a5b93b6
+  md5: a11b4df9271a8d7917686725aa04c8f2
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.37,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.4.0,<4.5.0a0
+  - libzlib >=1.2.12,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 546164
+  timestamp: 1660347757945
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.1-hd590300_1.conda
+  sha256: 407d655643389bdb49266842a816815c981ae98f3513a6a2059b908b3abb380a
+  md5: 2e1d7b458ac8f1e3ca4e18b77add6277
+  depends:
+  - ca-certificates
+  - libgcc-ng >=12
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2642411
+  timestamp: 1685517327134
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.0.2-py310h7cbd5c2_0.conda
+  sha256: 38b0937c9b099cc5bf7cd4b19dfb03f8b2a8454e1895d65dfa888d189e3a3ab5
+  md5: e0b845c6b29a1ed2e409bef6c0f5d96b
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.21.6,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.10.* *_cp310
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12185140
+  timestamp: 1685343549259
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-2.19.2-h32600fe_2.conda
+  sha256: f9452f407a1c298d091279c8255e1db301c1d5b772ccf2e7e60d370b45d21fc7
+  md5: 326f46f36d15c44cff5f81d505cb717f
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 27120405
+  timestamp: 1678227075811
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre-8.45-h9c3ff4c_0.tar.bz2
+  sha256: 8f35c244b1631a4f31fb1d66ab6e1d9bfac0ca9b679deced1112c7225b3ad138
+  md5: c05d1820a6d34ff07aaaab7a9b7eddaa
+  depends:
+  - libgcc-ng >=9.3.0
+  - libstdcxx-ng >=9.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 259377
+  timestamp: 1623788789327
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.40-hc3806b6_0.tar.bz2
+  sha256: 7a29ec847556eed4faa1646010baae371ced69059a4ade43851367a076d6108a
+  md5: 69e2c796349cd9b273890bee0febfe1b
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.2.12,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2412495
+  timestamp: 1665562915343
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-9.2.0-py310h454ad03_3.tar.bz2
+  sha256: 202cc5b4c60e32096b67791f822699bf91670584ac3db7e86ebb1b6a4c584218
+  md5: eb354ff791f505b1d6f13f776359d88e
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=12
+  - libtiff >=4.4.0,<4.5.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - libxcb >=1.13,<1.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - tk >=8.6.12,<8.7.0a0
+  license: LicenseRef-PIL
+  size: 47452449
+  timestamp: 1666920698626
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.40.0-h36c2ea0_0.tar.bz2
+  sha256: 6a0630fff84b5a683af6185a6c67adc8bdfa2043047fcb251add0d352ef60e79
+  md5: 660e72c82f2e75a6b3fe6a6e75c79f19
+  depends:
+  - libgcc-ng >=7.5.0
+  license: MIT
+  license_family: MIT
+  size: 642520
+  timestamp: 1604342437426
+- conda: https://conda.anaconda.org/conda-forge/linux-64/poppler-21.11.0-ha39eefc_0.tar.bz2
+  sha256: 26dc2f2c24da2bd9acb8c541d42f37e27a5a11fdaa75ec70628ed28d9ffb19db
+  md5: e8fa8792970ec9278e9ae7e4d0ff2841
+  depends:
+  - boost-cpp >=1.74.0,<1.74.1.0a0
+  - cairo >=1.16.0,<2.0.0a0
+  - fontconfig >=2.13.1,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.10.4,<3.0a0
+  - gettext >=0.19.8.1,<1.0a0
+  - jpeg >=9d,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcurl >=7.79.1,<9.0a0
+  - libgcc-ng >=9.4.0
+  - libglib >=2.70.0,<3.0a0
+  - libiconv >=1.16,<2.0.0a0
+  - libpng >=1.6.37,<1.7.0a0
+  - libstdcxx-ng >=9.4.0
+  - libtiff >=4.3.0,<4.5.0a0
+  - libzlib >=1.2.11,<2.0.0a0
+  - nss >=3.71,<4.0a0
+  - openjpeg >=2.4.0,<3.0.0a0
+  - poppler-data
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 18306195
+  timestamp: 1636474408835
+- conda: https://conda.anaconda.org/conda-forge/linux-64/postgresql-14.5-ha7cec9f_0.tar.bz2
+  sha256: ecf1d30861cfb6d116299cec281c0b615d81b95ac8002e6d145a16dfe4249500
+  md5: 95a9d42d1e2819b218a40fa174289d7f
+  depends:
+  - krb5 >=1.19.3,<1.20.0a0
+  - libgcc-ng >=12
+  - libpq 14.5 he2d8382_0
+  - libxml2 >=2.9.14,<2.14.0a0
+  - libzlib >=1.2.12,<2.0.0a0
+  - openssl >=3.0.5,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - tzcode
+  - tzdata
+  - zlib >=1.2.12,<1.3.0a0
+  size: 5767766
+  timestamp: 1660238431993
+- conda: https://conda.anaconda.org/conda-forge/linux-64/proj-8.2.1-h277dcde_0.tar.bz2
+  sha256: 9bbd2c7b22387a04462c12f84f0fa5190c953e8cb593ac2a8d15cf252d340e76
+  md5: f2ceb1be6565c35e2db0ac948754751d
+  depends:
+  - libcurl >=7.80.0,<9.0a0
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  - libtiff >=4.3.0,<4.5.0a0
+  - sqlite >=3.37.0,<4.0a0
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 3133946
+  timestamp: 1641116350074
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py310h1fa729e_0.conda
+  sha256: 6864a95001b67413f7d06e35dc2ef0f13afb8c93cde8e826321453eac1bf1991
+  md5: b0f0a014fc04012c05f39df15fe270ce
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 362309
+  timestamp: 1681775208997
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+  sha256: 67c84822f87b641d89df09758da498b2d4558d47b920fd1d3fe6d3a871e000ff
+  md5: 22dad4df6e8630e8dff2428f6f6a7036
+  depends:
+  - libgcc-ng >=7.5.0
+  license: MIT
+  license_family: MIT
+  size: 5625
+  timestamp: 1606147468727
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.3.0-py310h9e0d750_1.tar.bz2
+  sha256: a5ea7ee2e9d9ac7e5710bfbd62b3ccb5a137cae4efe2bb3e1409eb2c50fa51bf
+  md5: 8505bfe1a312460e904bcebf082dbd3f
+  depends:
+  - certifi
+  - libgcc-ng >=9.4.0
+  - proj >=8.2.1,<8.2.2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 2172106
+  timestamp: 1641210605881
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyrsistent-0.19.3-py310h1fa729e_0.conda
+  sha256: 7c1d3f51959fd5e829a114157bb110fdd6335d1c518293b4203474c78d9b48f9
+  md5: f732bec05ecc2e302a868d971ae484e0
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 100170
+  timestamp: 1672681566206
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.11-he550d4f_0_cpython.conda
+  sha256: 6682c75caf3456796fb76313a25475738d85729b43f8c0e904407c0ed8362ede
+  md5: 7439c9d24378a82b73a7a53868dacdf1
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libnsl >=2.0.0,<2.1.0a0
+  - libsqlite >=3.41.2,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.3,<7.0a0
+  - openssl >=3.1.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.10.* *_cp310
+  license: Python-2.0
+  size: 25878620
+  timestamp: 1683746291200
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-3_cp310.conda
+  sha256: bcb15db27eb6fbc0fe15d23aa60dcfa58ef451d92771441068d4a911aea7bb9f
+  md5: 4eb33d14d794b0f4be116443ffed3853
+  constrains:
+  - python 3.10.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5677
+  timestamp: 1669071721839
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0-py310h5764c6d_5.tar.bz2
+  sha256: 602d68ee4544274b12fb6d13b8d5fc61d0ebbee190292c21d8be10a4e68185bd
+  md5: 9e68d2ff6d98737c855b65f48dd3c597
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 176321
+  timestamp: 1666772551486
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-25.1.0-py310h5bbb5d0_0.conda
+  sha256: 4e0ded16cbac93dd0fe6826dd73fe3036173f7663bd2257b89de6f8f9325f82b
+  md5: 58017b4bb8fec6088a8b9ae44744ce4b
+  depends:
+  - libgcc-ng >=12
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  size: 452922
+  timestamp: 1685519462906
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.2.10-py310h5e0f756_4.tar.bz2
+  sha256: 393d3fdac25d7e023c38f765fab591bd9bb65cb079ff15a5de0d2feaecdd6ec5
+  md5: e80d5a05bb576bf3ada93dee04b8ad4a
+  depends:
+  - affine
+  - attrs
+  - certifi
+  - click >=4
+  - click-plugins
+  - cligj >=0.5
+  - libgcc-ng >=9.4.0
+  - libgdal >=3.4.1,<3.5.0a0
+  - libstdcxx-ng >=9.4.0
+  - numpy >=1.21.5,<2.0a0
+  - proj >=8.2.1,<8.2.2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14722612
+  timestamp: 1641327446583
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+  sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
+  md5: 47d31b792659ce70f470b5c82fdfb7a4
+  depends:
+  - libgcc-ng >=12
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 281456
+  timestamp: 1679532220005
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.10.1-py310ha4c1d20_3.conda
+  sha256: c7beb091db82a1be2fa9dafb878695b1e8bd6d7efe7764afa457cabfea2a93d3
+  md5: 0414d57832172f3cdcf56b5f053e177d
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - numpy >=1.21.6,<1.27
+  - numpy >=1.21.6,<2.0a0
+  - pooch
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - libopenblas <0.3.26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15123927
+  timestamp: 1683901442908
+- conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-1.8.2-py310hb974679_1.tar.bz2
+  sha256: 22cc6cc23a75a617fd89347e71a27ed9db2d5cba92d7da3733917f7f6addeccd
+  md5: fa50d09d9925ad723148c44931e653f0
+  depends:
+  - geos >=3.10.2,<3.10.3.0a0
+  - libgcc-ng >=10.3.0
+  - numpy >=1.21.6,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 371559
+  timestamp: 1651793229011
+- conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
+  sha256: 02219f2382b4fe39250627dade087a4412d811936a5a445636b7260477164eac
+  md5: e6d228cd0bb74a51dd18f5bfce0b4115
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38865
+  timestamp: 1678534590321
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.42.0-h2c6b66d_0.conda
+  sha256: 9cf59fa9891248e0e3a86a41041156cec367653d423e5d8a09b4c8ab98441a27
+  md5: 1192f6ec654a5bc4ee1d64bdc4a3e5cc
+  depends:
+  - libgcc-ng >=12
+  - libsqlite 3.42.0 h2797004_0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.3,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 818177
+  timestamp: 1684264804694
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.6.4-h3f4058f_0.tar.bz2
+  sha256: dc25af331b644d874cd921bb9b735560f340cac888efae01e96093a8298765a6
+  md5: 6161d5bca657a28c40526769d7d131ac
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - curl >=7.82.0,<9.0a0
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  - libzlib >=1.2.11,<2.0.0a0
+  - lz4-c >=1.9.3,<1.9.4.0a0
+  - openssl >=3.0.0,<4.0a0
+  - zlib >=1.2.11,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 3427339
+  timestamp: 1646843978563
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.12-h27826a3_0.tar.bz2
+  sha256: 032fd769aad9d4cad40ba261ab222675acb7ec951a8832455fce18ef33fa8df0
+  md5: 5b8c42eb62e9fc961af70bdd6a26e168
+  depends:
+  - libgcc-ng >=9.4.0
+  - libzlib >=1.2.11,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3456292
+  timestamp: 1645033615058
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.3.2-py310h2372a71_0.conda
+  sha256: 56bcfc59da0f6fc78afe79447b8b1327e9149a52c9dc6ee805ac73bf18ac22b6
+  md5: 1c510e74c87dc9b8fe1f7f9e8dbcef96
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: Apache
+  size: 638944
+  timestamp: 1684150186278
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tzcode-2022e-h166bdaf_0.tar.bz2
+  sha256: fb15e3a3228edcfde002f527ee2e9e0b5e1f15091521de1aa8429a4357138af8
+  md5: d83ab8f6570bbf0be104948fb2d0f79e
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 72542
+  timestamp: 1665540380704
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.0.0-py310h5764c6d_0.tar.bz2
+  sha256: 332732c2b87445c3e071c86cacfbc72a99ba4ea55d0b9d65416894253782ca02
+  md5: e972c5a1f472561cf4a91962cb01f4b4
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: Apache
+  size: 512210
+  timestamp: 1667239999991
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.3-h8ce2273_4.tar.bz2
+  sha256: 774286e4796fec3f677a13385c37fa2f153cd47dde1c8e046b6d8e49e260c8c4
+  md5: b313f2002c5534313e3b2b74a76a051b
+  depends:
+  - icu >=69.1,<70.0a0
+  - libgcc-ng >=9.4.0
+  - libnsl >=2.0.0,<2.1.0a0
+  - libstdcxx-ng >=9.4.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1842721
+  timestamp: 1635488331020
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
+  sha256: e90b0a6a5d41776f11add74aa030f789faf4efd3875c31964d6f9cfa63a10dd1
+  md5: 4b230e8381279d76131116660f5a241a
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 27338
+  timestamp: 1610027759842
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hd590300_0.conda
+  sha256: 5aa9b3682285bb2bf1a8adc064cb63aff76ef9178769740d855abb42b0d24236
+  md5: b462a33c0be1421532f28bfe8f4a7514
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 58469
+  timestamp: 1685307573114
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-h7391055_0.conda
+  sha256: 089ad5f0453c604e18985480218a84b27009e9e6de9a0fa5f4a20b8778ede1f1
+  md5: 93ee23f12bc2e684548181256edd2cf6
+  depends:
+  - libgcc-ng >=12
+  - libuuid >=2.38.1,<3.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 27433
+  timestamp: 1685453649160
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.4-h0b41bf4_0.conda
+  sha256: 3c6862a01a39cdea3870b132706ad7256824299947a3a94ae361d863d402d704
+  md5: ea8fbfeb976ac49cbeb594e985393514
+  depends:
+  - libgcc-ng >=12
+  - libxcb 1.*
+  - libxcb >=1.13,<1.14.0a0
+  - xorg-kbproto
+  - xorg-xextproto >=7.3.0,<8.0a0
+  - xorg-xproto
+  license: MIT
+  license_family: MIT
+  size: 829872
+  timestamp: 1677611125385
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+  sha256: 309751371d525ce50af7c87811b435c176915239fc9e132b99a25d5e1703f2d4
+  md5: 2c80dc38fface310c9bd81b17037fee5
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 14468
+  timestamp: 1684637984591
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+  sha256: 4df7c5ee11b8686d3453e7f3f4aa20ceef441262b49860733066c52cfd0e4a77
+  md5: be93aabceefa2fac576e971aef407908
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 19126
+  timestamp: 1610071769228
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
+  sha256: 73e5cfbdff41ef8a844441f884412aa5a585a0f0632ec901da035a03e1fe1249
+  md5: 82b6df12252e6f32402b96dacc656fec
+  depends:
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.7.2,<2.0a0
+  - xorg-xextproto
+  license: MIT
+  license_family: MIT
+  size: 50143
+  timestamp: 1677036907815
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.10-h7f98852_1003.tar.bz2
+  sha256: 7d907ed9e2ec5af5d7498fb3ab744accc298914ae31497ab6dcc6ef8bd134d00
+  md5: f59c1242cc1dd93e72c2ee2b360979eb
+  depends:
+  - libgcc-ng >=9.3.0
+  - xorg-libx11 >=1.7.0,<2.0a0
+  - xorg-renderproto
+  license: MIT
+  license_family: MIT
+  size: 32906
+  timestamp: 1614866792944
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-h7f98852_1002.tar.bz2
+  sha256: 38942930f233d1898594dd9edf4b0c0786f3dbc12065a0c308634c37fd936034
+  md5: 06feff3d2634e3097ce2fe681474b534
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 9621
+  timestamp: 1614866326326
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
+  sha256: b8dda3b560e8a7830fe23be1c58cc41f407b2e20ae2f3b6901eb5842ba62b743
+  md5: bce9f945da8ad2ae9b1d7165a64d0f87
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 30270
+  timestamp: 1677036833037
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
+  sha256: f197bb742a17c78234c24605ad1fe2d88b1d25f332b75d73e5ba8cf8fbc2a10d
+  md5: b4a4381d54784606820704f7b5f05a15
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 74922
+  timestamp: 1607291557628
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+  sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+  md5: 2161070d867d1b1204ea749c8eec4ef0
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1 and GPL-2.0
+  size: 418368
+  timestamp: 1660346797927
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+  sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
+  md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 89141
+  timestamp: 1641346969816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.4-h9c3ff4c_1.tar.bz2
+  sha256: 525315b0df21866d4c3d68bc2ff987d26c2fdf0e3e8fd242c49b7255adef04c6
+  md5: 21743a8d2ea0c8cfbbf8fe489b0347df
+  depends:
+  - libgcc-ng >=9.4.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=9.4.0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 359709
+  timestamp: 1629967303309
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-h166bdaf_4.tar.bz2
+  sha256: 282ce274ebe6da1fbd52efbb61bd5a93dec0365b14d64566e6819d1691b75300
+  md5: 4b11e365c0275b808be78b30f904e295
+  depends:
+  - libgcc-ng >=12
+  - libzlib 1.2.13 h166bdaf_4
+  license: Zlib
+  license_family: Other
+  size: 94099
+  timestamp: 1665759636124
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.2-h3eb15da_6.conda
+  sha256: fbe49a8c8df83c2eccb37c5863ad98baeb29796ec96f2c503783d7b89bf80c98
+  md5: 6b63daed8feeca47be78f323e793d555
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 419583
+  timestamp: 1674244601308
+- conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+  sha256: fbf0288cae7c6e5005280436ff73c95a36c5a4c978ba50175cc8e3eb22abc5f9
+  md5: ae5f4ad87126c55ba3f690ef07f81d64
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18726
+  timestamp: 1674245215155
+- conda: https://conda.anaconda.org/conda-forge/noarch/anyio-3.7.0-pyhd8ed1ab_1.conda
+  sha256: 863c11a6a0e937977229b405a16f6d43fff543dfe5b1a66da9c42ec0cbdaaf33
+  md5: 2b35a85d654a47aac8f34c1bb6de7142
+  depends:
+  - exceptiongroup
+  - idna >=2.8
+  - python >=3.7
+  - sniffio >=1.1
+  - typing_extensions
+  constrains:
+  - trio >=0.16,<0.22
+  license: MIT
+  license_family: MIT
+  size: 96586
+  timestamp: 1685486532061
+- conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.3-pyhd8ed1ab_0.tar.bz2
+  sha256: b209a68ac55eb9ecad7042f0d4eedef5da924699f6cdf54ac1826869cfdae742
+  md5: 54ac328d703bff191256ffa1183126d1
+  depends:
+  - python >=2.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 8095
+  timestamp: 1649077760928
+- conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-21.3.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 3a53cfd674641d9ff9901f5d4e1cc5e9a3ce9bb8b6a7dca826db840c2e39bc23
+  md5: a0b402db58f73aaab8ee0ca1025a362e
+  depends:
+  - argon2-cffi-bindings
+  - flit-core >=3.4,<4
+  - python >=3.6
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15708
+  timestamp: 1640817831095
+- conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.2.1-pyhd8ed1ab_0.conda
+  sha256: 7ed530efddd47a96c11197906b4008405b90e3bc2f4e0df722a36e0e6103fd9c
+  md5: bf7f54dd0f25c3f06ecb82a07341841a
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 27831
+  timestamp: 1670264089059
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+  sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
+  md5: 3edfead7cedd1ab4400a6c588f3e75f8
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 55022
+  timestamp: 1683424195402
+- conda: https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2
+  sha256: ee62d6434090c1327a48551734e06bd10e65a64ef7f3b6e68719500dab0e42b9
+  md5: 6006a6d08a3fa99268a2681c7fb55213
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13705
+  timestamp: 1592338491389
+- conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+  sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
+  md5: 54ca2e08b3220c148a1d8329c2678e02
+  depends:
+  - python >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5950
+  timestamp: 1669158729416
+- conda: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.4-pyhd8ed1ab_0.tar.bz2
+  sha256: fdea00d4b79990f3fe938e2716bc32bd895eb5c44b6c75b8261db095a1b33c16
+  md5: c5b3edc62d6309088f4970b3eaaa65a6
+  depends:
+  - backports
+  - python >=3.6
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 9039
+  timestamp: 1618230771610
+- conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.2-pyha770c72_0.conda
+  sha256: 52d3e6bcd442537e22699cd227d8fdcfd54b708eeb8ee5b4c671a6a9b9cd74da
+  md5: a362ff7d976217f8fa78c0f1c4f59717
+  depends:
+  - python >=3.6
+  - soupsieve >=1.2
+  license: MIT
+  license_family: MIT
+  size: 115011
+  timestamp: 1680888259061
+- conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.0.0-pyhd8ed1ab_0.conda
+  sha256: 59da02f550ec546f9375fa309bc7712f50b478bad67b99fbebbb5b57ee3a67d3
+  md5: d48b143d01385872a88ef8417e96c30e
+  depends:
+  - packaging
+  - python >=3.6
+  - setuptools
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 130677
+  timestamp: 1674535450476
+- conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.1.1-pyhd8ed1ab_0.conda
+  sha256: 338f8c8c4d22f160ceef1791d4c8655911546d8e56a7d7890936491b61966456
+  md5: 07401431ba1c7fae695814ae3528312a
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.8
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5942259
+  timestamp: 1683730710049
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.5.7-pyhd8ed1ab_0.conda
+  sha256: f839a6e04d94069f90dd85337ea9108f058dc76771bb469a413f32bb1ba0b256
+  md5: 5d1b71c942b8421285934dad1d891ebc
+  depends:
+  - python >=3.7
+  license: ISC
+  size: 152383
+  timestamp: 1683450391501
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.1.0-pyhd8ed1ab_0.conda
+  sha256: 06cd371fc98f076797d6450f6f337cb679b1060c99680fb7e044591493333194
+  md5: 7fcff9f6f123696e940bda77bd4d6551
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 44914
+  timestamp: 1678108997608
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.3-unix_pyhd8ed1ab_2.tar.bz2
+  sha256: 23676470b591b100393bb0f6c46fe10624dcbefc696a6a9f42932ed8816ef0ea
+  md5: 20e4087407c7cb04a40817114b333dbf
+  depends:
+  - __unix
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 76050
+  timestamp: 1666798336206
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.3-win_pyhd8ed1ab_2.tar.bz2
+  sha256: 84e80a33e9a8e5398d3e97209366b57f635462a5b894f8076ec8c95e56672c44
+  md5: 6b58680207b526c42dcff68b543803dd
+  depends:
+  - __win
+  - colorama
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 76507
+  timestamp: 1666798662649
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+  sha256: ddef6e559dde6673ee504b0e29dd814d36e22b6b9b1f519fa856ee268905bf92
+  md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
+  depends:
+  - click >=3.0
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8992
+  timestamp: 1554588104889
+- conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+  sha256: 97bd58f0cfcff56a0bcda101e26f7d936625599325beba3e3a1fa512dd7fc174
+  md5: a29b7c141d6b2de4bb67788a5f107734
+  depends:
+  - click >=4.0
+  - python <4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10255
+  timestamp: 1633637895378
+- conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-2.2.1-pyhd8ed1ab_0.conda
+  sha256: f0c2fd0e842899a05ddd7b147fb26424adf58be0e8e54e5bc68b8f7e67d05dcd
+  md5: b325bfc4cff7d7f8a868f1f7ecc4ed16
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27929
+  timestamp: 1674202405394
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+  sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+  md5: 3faab06a954c2a04039983f2c4a50d99
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25170
+  timestamp: 1666700778190
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 4e68730cc38236a736c8f1c6837c6460807cc0f0a5fd2166b3359d481e6f129f
+  md5: 1e424f22b3e2713068fe12d57f2dec5b
+  depends:
+  - pyct >=0.4.4
+  - python >=2.7
+  license: CC-BY-4.0
+  size: 1635349
+  timestamp: 1664843356249
+- conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.3-pyhd8ed1ab_0.conda
+  sha256: 657e0a513c8705dc542c54c4c5234e813b7f4e2f412688796d611e83ddf132ea
+  md5: 168ae0f82cdf7505048e81054c7354e4
+  depends:
+  - python >=3.6
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11480
+  timestamp: 1679481450658
+- conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.11.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 3b594bc8aa0b9a51269d54c7a4ef6af777d7fad4bee16b05695e1124de6563f6
+  md5: a50559fad0affdbb33729a68669ca1cb
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10307
+  timestamp: 1635519555262
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.5.1-pyhd8ed1ab_0.conda
+  sha256: 9898ad0a7c4aed4e47f8be162b03a5c71015b1622bbf0031b59512dee0b5a7aa
+  md5: b90a2dec6d308d71649dbe58dc32c337
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib_metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.9
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 846409
+  timestamp: 1685132866198
+- conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.15.0-pyhd8ed1ab_0.conda
+  sha256: 7d076acb9bab4196b71c851d83bae2cee3125007c40d68c5c025616ddd55cf3d
+  md5: adb1da69c960c07797b02fbf98a819bb
+  depends:
+  - colorcet
+  - dask-core
+  - datashape
+  - numba
+  - numpy
+  - pandas
+  - param <2.0.0a0
+  - pillow
+  - pyct
+  - python >=3.8
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17180612
+  timestamp: 1685524448345
+- conda: https://conda.anaconda.org/conda-forge/noarch/datashape-0.5.4-py_1.tar.bz2
+  sha256: a9e7312763eb6d9a20d8f12175780e33402d86009d9640b69eee8b4a1e4185fe
+  md5: 50ddfce434ea596fc4497085f403a9d5
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7
+  - python
+  - python-dateutil
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 50149
+  timestamp: 1551744455794
+- conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+  md5: 43afe5ab04e35e17ba28649471dd7364
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 12072
+  timestamp: 1641555714315
+- conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
+  md5: 961b3a227b437d82ad7054484cfa71b2
+  depends:
+  - python >=3.6
+  license: PSF-2.0
+  license_family: PSF
+  size: 24062
+  timestamp: 1615232388757
+- conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
+  md5: 3cf04868fee0a029769bd41f4b2fbf2d
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 9199
+  timestamp: 1643888357950
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.1-pyhd8ed1ab_0.conda
+  sha256: f073c3ba993912f1c0027bc34a54975642885f0a4cd5f9dc42a17ca945df2c18
+  md5: 7312299d7a0ea4993159229b7d2dceb2
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18929
+  timestamp: 1678703786698
+- conda: https://conda.anaconda.org/conda-forge/noarch/executing-1.2.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 9c03425cd58c474af20e179c9ba121a82984d6c4bfc896bbc992f5ed75dd7539
+  md5: 4c1bc140e2be5c8ba6e3acab99e25c50
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 25013
+  timestamp: 1667317463548
+- conda: https://conda.anaconda.org/conda-forge/noarch/flit-core-3.9.0-pyhd8ed1ab_0.conda
+  sha256: a2ef503739ac22bf2a5d91c6a7b0f6a4413a56fbdb9b84f8f70427b9e37fbb69
+  md5: e8cfceef004266b259604c3faa2a0191
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49072
+  timestamp: 1684084485822
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+  sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+  md5: 0c96522c6bdaed4b1566d11387caaf45
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 397370
+  timestamp: 1566932522327
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+  sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+  md5: 34893075a5c9e55cdafac56607368fc6
+  license: OFL-1.1
+  license_family: Other
+  size: 96530
+  timestamp: 1620479909603
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+  sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+  md5: 4d59c254e01d9cde7957100457e2d5fb
+  license: OFL-1.1
+  license_family: Other
+  size: 700814
+  timestamp: 1620479612257
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-hab24e00_0.tar.bz2
+  sha256: 470d5db54102bd51dbb0c5990324a2f4a0bc976faa493b22193338adb9882e2e
+  md5: 19410c3df09dfb12d1206132a1d357c5
+  license: Ubuntu Font Licence Version 1.0
+  license_family: Other
+  size: 1961279
+  timestamp: 1566932680646
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+  sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+  md5: fee5683a3f04bd15cbd8318b096a27ab
+  depends:
+  - fonts-conda-forge
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3667
+  timestamp: 1566974674465
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+  sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
+  md5: f766549260d6815b0c52253f1fb1bb29
+  depends:
+  - font-ttf-dejavu-sans-mono
+  - font-ttf-inconsolata
+  - font-ttf-source-code-pro
+  - font-ttf-ubuntu
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4102
+  timestamp: 1566932280397
+- conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.5.0-pyh1a96a4e_0.conda
+  sha256: cbb5c77c0217cda9bf4f4240158de11822a099a6eaa05ba626e822819a54f46d
+  md5: 20edd290b319aa0eff3e9055375756dc
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116111
+  timestamp: 1683495004868
+- conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.13.2-pyha770c72_1.conda
+  sha256: fc1442a799f837961c3423466ac5f7c84d49b295c76290a7983dab903546a5a7
+  md5: c6036236caae7d8ac684c41c64073b9e
+  depends:
+  - packaging
+  - pandas >=1.1.0
+  - pyproj >=3.0.1
+  - python >=3.8
+  - shapely >=1.7.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1011508
+  timestamp: 1686057753845
+- conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.10.0-pyhd8ed1ab_0.conda
+  sha256: 35d74993e2e016e610d50ac9cdf69316d85b868e796a1689817cad69de41c88b
+  md5: 7a519d88be20512ec8da9d91a52b1d9b
+  depends:
+  - bokeh >=3.1.0,<3.2.0
+  - cartopy >=0.18.0
+  - datashader
+  - geopandas-base
+  - geoviews-core 1.10.0 pyha770c72_0
+  - holoviews >=1.16.0
+  - netcdf4
+  - numpy >=1.0
+  - packaging
+  - pandas
+  - panel >=1.0.0
+  - param >=1.9.3,<2.0.0a0
+  - pyct
+  - pyproj
+  - python >=3.8
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8282
+  timestamp: 1685039198950
+- conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.10.0-pyha770c72_0.conda
+  sha256: bfdd133933c305ca53f93545af4c5942d855bc4198b3cd5d78707991a83d27b9
+  md5: 76d74af63f92b41a768b53b5ed530387
+  depends:
+  - bokeh >=3.1.0,<3.2.0
+  - cartopy >=0.18.0
+  - holoviews >=1.16.0
+  - numpy >=1.0
+  - packaging
+  - panel >=1.0.0
+  - param >=1.9.3
+  - pyproj
+  - python >=3.8
+  constrains:
+  - geoviews 1.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 370815
+  timestamp: 1685039152089
+- conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.16.1-pyhd8ed1ab_0.conda
+  sha256: f3da208ecfab5d6a31403be6b92bf56a41ff70d4f753ae8b6b2a8118577fb5d3
+  md5: a6b56b9fe733a387b3fad3d20d649672
+  depends:
+  - bokeh >=2.4.3
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0
+  - python >=3.7
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3494325
+  timestamp: 1685802966033
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 9887c35c374ec1847f167292d3fde023cb4c994a4ceeec283072b95440131f09
+  md5: 34272b248891bddccc64479f9a7fffed
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 56742
+  timestamp: 1663625484114
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.6.0-pyha770c72_0.conda
+  sha256: 33d49065756a73fbb92277c756fa00a41891408528eb90ae05ff3367a401ae6e
+  md5: f91a5d5175fb7ff2a91952ec7da59cb9
+  depends:
+  - python >=3.8
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25822
+  timestamp: 1682176834080
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.6.0-hd8ed1ab_0.conda
+  sha256: 5de35d3c019d8a36e0a0deeb04a62689837bd68234a0a73a3355b860b442eca4
+  md5: 3cbc9615f10a3d471532b83e4250b971
+  depends:
+  - importlib-metadata >=6.6.0,<6.6.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 9369
+  timestamp: 1682176840984
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-5.12.0-pyhd8ed1ab_0.conda
+  sha256: 091cca3e010f7a7353152f0abda2d68cfd83ddde80a15e974d9e18b2047e7be2
+  md5: e5fd2260a231ee63b6969f4801082f2b
+  depends:
+  - python >=3.7
+  - zipp >=3.1.0
+  constrains:
+  - importlib-resources >=5.12.0,<5.12.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 31030
+  timestamp: 1676919099370
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.23.1-pyh025b116_0.conda
+  sha256: 242a6641f884a71750d4315ffb64ba0cd8d6ae1bb29d64f0c0ef35ea3ebf6fa8
+  md5: d18e38ce1f195efa2d76f9dc33832bf5
+  depends:
+  - __win
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 113717
+  timestamp: 1684163367650
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.23.1-pyh210e3f2_0.conda
+  sha256: 8d0b0ffb93d31c24b4b5c87691a0a4695ddf54a77bdc4c1b0945aa2b5eed610c
+  md5: 4b57b688e22d094d1479a35543c18e93
+  depends:
+  - __linux
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 113165
+  timestamp: 1684162869750
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.23.1-pyh736e0ef_0.conda
+  sha256: 080ce3963f13f774a73da211519c772e1238bf006e653c24169d156dd7983177
+  md5: d5aa7d2cc9fe03f62cf6e7bcc8e1a8df
+  depends:
+  - __osx
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 113472
+  timestamp: 1684163339335
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.14.0-pyh08f2357_0.conda
+  sha256: 16a409828a1efc95b2d74f6080782ab8f7fdae2c33dde8d2f795e172d9c379a3
+  md5: 1fc684c1de5475383790ada5627c5430
+  depends:
+  - __win
+  - backcall
+  - colorama
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt_toolkit >=3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 583510
+  timestamp: 1685728341837
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.14.0-pyh41d4057_0.conda
+  sha256: 25f1e5d78f7f063b3e32b939fed1e4d797df12f384c949902a325e6539315f96
+  md5: 0a0b0d8177c4a209017b356439292db8
+  depends:
+  - __linux
+  - backcall
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt_toolkit >=3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 583448
+  timestamp: 1685727878658
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.14.0-pyhd1c38e8_0.conda
+  sha256: ea7524cd33c18c5c0d01e48e0089f339e7e8f1c3a6a8d2416c46b3d50d509894
+  md5: f56fab4cea853c2248105b6cd7d79bf0
+  depends:
+  - __osx
+  - appnope
+  - backcall
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt_toolkit >=3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 585154
+  timestamp: 1685728306650
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-py_1.tar.bz2
+  sha256: 0fafbc60209f1d8c0b89a2f79f3ff0f7bc45589a23da1d2e5cc55bcca906707b
+  md5: 5071c982548b3a20caf70462f04f5287
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 21562
+  timestamp: 1530963305778
+- conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.18.2-pyhd8ed1ab_0.conda
+  sha256: abe63ae6e1b13f83500608d94004cb8d485b264083511d77f79253e775cd546c
+  md5: b5e695ef9c3f0d27d6cd96bf5adc9e07
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 804409
+  timestamp: 1669134434500
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+  sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
+  md5: c8490ed5c70966d232fdd389d0dbed37
+  depends:
+  - markupsafe >=2.0
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101443
+  timestamp: 1654302514195
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.17.3-pyhd8ed1ab_0.conda
+  sha256: 4f68a23430d1afc5c9b41c46fbac0ade33c0bf57a293c646bfdd6dc65350eada
+  md5: 723268a468177cd44568eb8f794e0d80
+  depends:
+  - attrs >=17.4.0
+  - importlib-metadata
+  - importlib_resources >=1.4.0
+  - pkgutil-resolve-name >=1.3.10
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.7
+  - typing_extensions
+  license: MIT
+  license_family: MIT
+  size: 70487
+  timestamp: 1669810556169
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+  sha256: 38e67f3e0d631f4aeeab4bbd4062dcb6f4ae9dc35803053c995d02912a999b65
+  md5: 5cbf9a31a19d4ef9103adb7d71fd45fd
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.7
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99449
+  timestamp: 1673616104031
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.6.3-pyhd8ed1ab_0.conda
+  sha256: 16f73833537e05384d3eef27e62edb31de344d6d26666e1a465c1819014f2655
+  md5: d98c5196ab6ffeb0c2feca2912801353
+  depends:
+  - jsonschema >=3.2
+  - python >=3.7
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 76889
+  timestamp: 1673559924440
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.6.0-pyhd8ed1ab_0.conda
+  sha256: 0f0feb284f667964d1e4122a7690f6e3ace257732591a6151fdd1eb797911128
+  md5: 39fd52b0fcb2fb52bac47a1419bf09bd
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.4.0
+  - jupyter_server_terminals
+  - nbconvert-core >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.8
+  - pyzmq >=24
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 316222
+  timestamp: 1685052059053
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
+  sha256: 9f4c5fef9beef9fceed628db7a10b888f3308b37ae257ad3d50046088317ebf1
+  md5: 7c0965e1d4a0ee1529e8eaa03a78a5b3
+  depends:
+  - python >=3.8
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18974
+  timestamp: 1673491600853
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0.tar.bz2
+  sha256: 08453e09d5a6bbaeeca839553a5dfd7a377a97550efab96019c334a8042f54f5
+  md5: 243f63592c8e449f40cd42eb5cf32f40
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17410
+  timestamp: 1649936689608
+- conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 0980092a2e0a4bd263c18fb0db701589fc10fc8542ce511f844a533490d5f14e
+  md5: 25b93e66067eb496ac10da888e25cc33
+  depends:
+  - python >=3.6
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 22417
+  timestamp: 1651923701523
+- conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
+  md5: 91e27ef3d05cc772ce627e51cff111c4
+  depends:
+  - python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 8250
+  timestamp: 1650660473123
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.4.3-pyhd8ed1ab_0.conda
+  sha256: e32ac2c95112caa8cd81f0cbc710f4f4903180a115c7260f03b010d5a0aa771b
+  md5: 89ed59ad509c05db6f5f2f573d499bfe
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70916
+  timestamp: 1679584124524
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-2.2.0-pyhd8ed1ab_0.conda
+  sha256: 65ed439862c1851463f03a9bc5109992ce3e3e025e9a2d76d13ca19f576eee9f
+  md5: b2928a6c6d52d7e3562b4a59c3214e3a
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.7
+  - typing_extensions >=3.7.4
+  license: MIT
+  license_family: MIT
+  size: 62447
+  timestamp: 1677101055429
+- conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+  sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
+  md5: b21613793fcc81d944c76c9f2864a7de
+  depends:
+  - python >=3.6
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12273
+  timestamp: 1660814913405
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.3.5-pyhd8ed1ab_0.conda
+  sha256: 7d8e3a545373ab52b93439285a597a30278fd2c47d41be22f91a9dd655b8e22e
+  md5: 9eeb66a24c8f6d950eb55a9f1128da20
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 39696
+  timestamp: 1677788425432
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+  sha256: c678b9194e025b1fb665bec30ee20aab93399203583875b1dcc0a3b52a8f5523
+  md5: f8dab71fdc13b1bf29a01248b156d268
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 13707
+  timestamp: 1639515992326
+- conda: https://conda.anaconda.org/conda-forge/noarch/mistune-2.0.5-pyhd8ed1ab_0.conda
+  sha256: 2a6dff1a6326e28bf3b7c5384b4da79f32726e9b43cc9734026f3bba90cd9d36
+  md5: 61a07195cfc935f1c1901d8ecf4af441
+  depends:
+  - python >=2.7
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 74456
+  timestamp: 1675771599895
+- conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+  sha256: 6d5839f75780475ad4dffe018026d493e26076f95862550a48424b4d7f6689d8
+  md5: 1073dc92c8f247d94ac14dd79ca0bbec
+  depends:
+  - python
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 12299
+  timestamp: 1534825527617
+- conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+  sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
+  md5: 2ba8498c1018c1e9c61eb99b973dfe19
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12452
+  timestamp: 1600387789153
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.0.0-pyhb4ecaf3_1.conda
+  sha256: fc2b2e606ccbd0aaa2cdecdd33fc39e2c4bd7b5b96a64b89b3e6ad9ce20eec2f
+  md5: a0be31e9bd84d6eae87cdbf74c56b90b
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - prometheus_client
+  - python >=3.7
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5939112
+  timestamp: 1683202466763
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
+  sha256: 4ebd237cdf4bfa5226f92d2ae78fab8dba27696909391884dc6594ca6f9df5ff
+  md5: e78da91cf428faaf05701ce8cc8f2f9b
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.8
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64852
+  timestamp: 1684791049212
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.4.0-pyhd8ed1ab_0.conda
+  sha256: 9123d4ba64b3165dcfb812c5524420fb2a75dd6f82018a5597605da489fe57d3
+  md5: a86727968b41c20dd3d73b91632e77dc
+  depends:
+  - nbconvert-core 7.4.0 pyhd8ed1ab_0
+  - nbconvert-pandoc 7.4.0 pyhd8ed1ab_0
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7785
+  timestamp: 1683636445044
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.4.0-pyhd8ed1ab_0.conda
+  sha256: aa30db865de528da7996cb63901e59ef38afa16187a57c93eaada352ee0e77ea
+  md5: 4456e6030a8309bdad57569b0170b6a3
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<3
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.7
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - nbconvert =7.4.0=*_0
+  - pandoc >=1.12.1,<3.0.0
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 208667
+  timestamp: 1683636392386
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.4.0-pyhd8ed1ab_0.conda
+  sha256: 01efdeb87a354199f6e41d996952c0508a8ecd013f56bf7406d53a5637a016f9
+  md5: 127c702e1b1eff595be82bc6a78cfce0
+  depends:
+  - nbconvert-core 7.4.0 pyhd8ed1ab_0
+  - pandoc
+  - python >=3.7
+  size: 6811
+  timestamp: 1683636410320
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.0-pyhd8ed1ab_0.conda
+  sha256: 3c6be17e84dc71db605a9e088fa7af7d47edab45d15da8e2a2ab3f29ec5ec081
+  md5: f525a01528c3eba1d381a232a6971c6a
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.8
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100959
+  timestamp: 1685541504811
+- conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.6-pyhd8ed1ab_0.tar.bz2
+  sha256: 594d240d8be933b6e47b78b786269cc89ffa34874544d9dbed1c6afc9213869b
+  md5: 7b868f21adde0d9b8b38f9c16836589b
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 9739
+  timestamp: 1664685092387
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.4-pyha770c72_0.conda
+  sha256: f1fb8078ac594ff6dbca271e1432b4312cc10c16c6fbddfe77d4102c778235cf
+  md5: ec4ce3ce0a55ce21b6f5b86049b97af9
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert-core >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.7
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1,<5.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 306277
+  timestamp: 1680870781775
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
+  sha256: f028d7ad1f2175cde307db08b60d07e371b9d6f035cfae6c81ea94b4c408c538
+  md5: 67e0fe74c156267d9159e9133df7fd37
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16783
+  timestamp: 1682360712235
+- conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.3.1-pyhd8ed1ab_0.tar.bz2
+  sha256: f4d8d05292714fc8dcd3a01c57a2ad41eab88a51e7608b70ae041f2b92de16a4
+  md5: a5745ced46e69aa9754053ba061974ab
+  depends:
+  - python >=3.6
+  - typing_utils
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25464
+  timestamp: 1666057928209
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.1-pyhd8ed1ab_0.conda
+  sha256: ded536a96a00d45a693dbc2971bb688248324dadd129eddda2100e177583d768
+  md5: 91cda59e66e1e4afe9476f8ef98f5c30
+  depends:
+  - python >=3.7
+  license: Apache-2.0
+  license_family: APACHE
+  size: 46098
+  timestamp: 1681337144376
+- conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
+  md5: 457c2c8c08e54905d6954e79cb5b5db9
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11627
+  timestamp: 1631603397334
+- conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.1.0-pyhd8ed1ab_0.conda
+  sha256: feda02cd05225f36c43957028dfbfc628148324e2e86cd08ea7ee752796b216f
+  md5: c52905d6c8d0e92a22d6fb6fa1b4f701
+  depends:
+  - bleach
+  - bokeh >=3.1.1,<3.2
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - param >=1.12.0,<2.0
+  - python >=3.8
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.16.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14758743
+  timestamp: 1686042762447
+- conda: https://conda.anaconda.org/conda-forge/noarch/param-1.13.0-pyh1a96a4e_0.conda
+  sha256: 924dee0430ef46af7b28841d49b503de6a8969af1c7b06897a4cff26d429f20e
+  md5: 158eda83fd21a14b8c483c0d1d102397
+  depends:
+  - python >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 79952
+  timestamp: 1678790904486
+- conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+  sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
+  md5: 17a565a0c3899244e938cdf417e7b094
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 71048
+  timestamp: 1638335054552
+- conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.0-pyhd8ed1ab_0.conda
+  sha256: 348f0aafa85afdd422fadf82f32e48ab010eb12662ae9d08842c3d6b29dcd398
+  md5: 721dab5803ea92ce02ddc4ee50aa0c48
+  depends:
+  - locket
+  - python >=3.7
+  - toolz
+  license: BSD 3-Clause
+  size: 20453
+  timestamp: 1681246882928
+- conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
+  sha256: 07706c0417ead94f359ca7278f65452d3c396448777aba1da6a11fc351bdca9a
+  md5: 330448ce4403cc74990ac07c555942a1
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  size: 48780
+  timestamp: 1667297617062
+- conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+  sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
+  md5: 415f0ebb6198cc2801c73438a9fb5761
+  depends:
+  - python >=3
+  license: MIT
+  license_family: MIT
+  size: 9332
+  timestamp: 1602536313357
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.1.2-pyhd8ed1ab_0.conda
+  sha256: 4fe1f47f6eac5b2635a622b6f985640bf835843c1d8d7ccbbae0f7d27cadec92
+  md5: 7288da0d36821349cf1126e8670292df
+  depends:
+  - python >=3.7
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 1367644
+  timestamp: 1682507713321
+- conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_0.tar.bz2
+  sha256: 7d055ffc8a02bf781a89d069db3454b453605cdaff300b82cedcc7133283e47e
+  md5: 89e3c7cdde7d3aaa2aee933b604dd07f
+  depends:
+  - python >=3.6
+  license: BSD-4-Clause
+  size: 8717
+  timestamp: 1633982101415
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.5.1-pyhd8ed1ab_0.conda
+  sha256: d7845c01a9ee5a224cc9242782befed7d12dc6aac1103650ec87917b20f3579e
+  md5: e2be672aece1f060adf7154f76531a35
+  depends:
+  - python >=3.7
+  - typing-extensions >=4.5
+  license: MIT
+  license_family: MIT
+  size: 18515
+  timestamp: 1683850192016
+- conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.7.0-pyha770c72_3.conda
+  sha256: 64e4d633803df2e36fd141d9bf269568fbe179a313248e1dac4d364c02debdef
+  md5: 5936894aade8240c867d292aa0d980c6
+  depends:
+  - packaging >=20.0
+  - platformdirs >=2.5.0
+  - python >=3.7
+  - requests >=2.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50857
+  timestamp: 1679580483278
+- conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+  sha256: 2f227e17b3c0346112815faa605502b66c1c4511a856127f2899abf15a98a2cf
+  md5: d8d7293c5b37f39b2ac32940621c6592
+  license: BSD-3-Clause AND (GPL-2.0-only OR GPL-3.0-only)
+  license_family: OTHER
+  size: 2348171
+  timestamp: 1675353652214
+- conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.17.0-pyhd8ed1ab_0.conda
+  sha256: eb11fd8b927d9c5ff9482cfbd6cd810a43a1351c44a288e9680542ea698a19a0
+  md5: 95c5be3c7cbd872509d16c216617fdab
+  depends:
+  - python >=3.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 53053
+  timestamp: 1684971037418
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.38-pyha770c72_0.conda
+  sha256: 78c2f3c6195ec350d7d6e5fa3e43274ca8191c181c97a867e2920faaeec0e9bc
+  md5: 59ba1bf8ea558751a0d391249a248765
+  depends:
+  - python >=3.7
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.38
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269375
+  timestamp: 1677601102637
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.38-hd8ed1ab_0.conda
+  sha256: c0f24a75d27918eb33f86902aa6024783d128a89eb3a169bcb22f24163a422b3
+  md5: 45b74f64d8808eda7e6f6e6b1d641fd2
+  depends:
+  - prompt-toolkit >=3.0.38,<3.0.39.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6402
+  timestamp: 1677601110741
+- conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+  sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+  md5: 359eeb6536da0e687af562ed265ec263
+  depends:
+  - python
+  license: ISC
+  size: 16546
+  timestamp: 1609419417991
+- conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+  sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
+  md5: 6784285c7e55cb7212efabc79e4c2883
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14551
+  timestamp: 1642876055775
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+  sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
+  md5: 076becd9e05608f8dc72757d5f3a91ff
+  depends:
+  - python ==2.7.*|>=3.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102747
+  timestamp: 1636257201998
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.4.6-py_0.tar.bz2
+  sha256: 50af51619db6a35c36e65e8f50c83c722c3358f1f4b5527e87799b8f9935ace0
+  md5: 42d91c89bc3993ec88681cffd3c0e326
+  depends:
+  - pyct-core 0.4.6.*
+  - python
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2652
+  timestamp: 1545265022341
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyct-core-0.4.6-py_0.tar.bz2
+  sha256: 8abc24dcf2782feca867974ba2aa0c9aaeae0966dad3f54507b39da30123d481
+  md5: 55ec526f95e0959de3f68bc6289a20da
+  depends:
+  - param >=1.7.0
+  - python
+  constrains:
+  - pyct 0.4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13725
+  timestamp: 1541164340776
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.15.1-pyhd8ed1ab_0.conda
+  sha256: 1bddeb54863c77ed5613b535a3e06a3a16b55786301a5e28c9bf011656bda686
+  md5: d316679235612869eba305aa7d41d9bf
+  depends:
+  - python >=3.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 840719
+  timestamp: 1681904335148
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2
+  sha256: 4acc7151cef5920d130f2e0a7615559cce8bfb037aeecb14d4d359ae3d9bc51b
+  md5: e8fbc1b54b25f4b08281467bc13b70cc
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 81321
+  timestamp: 1652235496915
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 41eced0d5e855bc52018f200b239d627daa38ad78a655ffa2f1efd95b07b6bce
+  md5: 92a889dc236a5197612bc85bee6d7174
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 964060
+  timestamp: 1659003065197
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
+  sha256: b3a612bc887f3dd0fb7c4199ad8e342bd148cf69a9b74fd9468a18cf2bef07b7
+  md5: 56cd9fe388baac0e90c7149cfac95b60
+  depends:
+  - __win
+  - python >=3.8
+  - win_inet_pton
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19348
+  timestamp: 1661605138291
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+  sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+  md5: 2a7de29fb590ca14b5243c4c812c8025
+  depends:
+  - __unix
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18981
+  timestamp: 1661604969727
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+  sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
+  md5: dd999d1cc9f79e67dbb855c8924c7984
+  depends:
+  - python >=3.6
+  - six >=1.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 245987
+  timestamp: 1626286448716
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.17.1-pyhd8ed1ab_0.conda
+  sha256: b7a8b9b2310b3ee74ba99eef9692e477bb8bddf110eff45784dee7d81a693455
+  md5: dd4f393d857e9283eef2442234bd05e3
+  depends:
+  - python >=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 225777
+  timestamp: 1684761393896
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+  sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
+  md5: a61bf9ec79426938ff785eb69dbb1960
+  depends:
+  - python >=3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13383
+  timestamp: 1677079727691
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
+  sha256: 0108888507014fb24573c31e4deceb61c99e63d37776dddcadd7c89b2ecae0b6
+  md5: 2590495f608a63625e165915fb4e2e34
+  depends:
+  - python >=3.6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 143131
+  timestamp: 1680081272948
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3-pyhd8ed1ab_0.conda
+  sha256: e4999484f21763ca4b8f92c95b22cb6d1edc1b61d0a2bb073ee2bd11f39401b9
+  md5: d3076b483092a435832603243567bc31
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 186506
+  timestamp: 1680088891597
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-2.3.0-pyhd8ed1ab_0.conda
+  sha256: b2a4d54b320e43769cc7db0fb04375608413a9d1331d92bf0f09ed0135d14973
+  md5: 3e271428a09f1e15115d5da5e51b558c
+  depends:
+  - param
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30891
+  timestamp: 1684959122888
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+  sha256: 9f629d6fd3c8ac5f2a198639fe7af87c4db2ac9235279164bfe0fcb49d8c4bad
+  md5: a30144e4156cdbb236f99ebb49828f8b
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.7
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 56690
+  timestamp: 1684774408600
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
+  md5: fed45fc5ea0813240707998abe49f520
+  depends:
+  - python >=3.5
+  - six
+  license: MIT
+  license_family: MIT
+  size: 8064
+  timestamp: 1638811838081
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+  sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
+  md5: 912a71cc01012ee38e6b90ddd561e36f
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 7818
+  timestamp: 1598024297745
+- conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.14.1-pyhd8ed1ab_0.conda
+  sha256: b2b72317f24af0a3263ac95026d6c9c4f47771363e8ff2cc40150c2902a407eb
+  md5: 5156f4c96119e2832419a9b17cb82cab
+  depends:
+  - numpy >=1.21
+  - packaging
+  - pyproj >=2.2
+  - python >=3.9
+  - rasterio >=1.2
+  - scipy
+  - xarray >=0.17
+  license: Apache-2.0
+  license_family: Apache
+  size: 47279
+  timestamp: 1681506554728
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh08f2357_0.conda
+  sha256: 55208c6b48d68dc9ad2e2cf81ab9dc6b8a1d607e67acf9115bdc7794accc84bc
+  md5: c00d32dfa733d381b6a1908d0d67e0d7
+  depends:
+  - __win
+  - python >=3.6
+  - pywin32
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23279
+  timestamp: 1682601755260
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh41d4057_0.conda
+  sha256: e74d3faf51a6cc429898da0209d95b209270160f3edbf2f6d8b61a99428301cd
+  md5: ada5a17adcd10be4fc7e37e4166ba0e2
+  depends:
+  - __linux
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22821
+  timestamp: 1682601391911
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyhd1c38e8_0.conda
+  sha256: dca4022bae47618ed738ab7d45ead5202d174b741cfb98e4484acdc6e76da32a
+  md5: 2657c3de5371c571aef6678afb4aaadd
+  depends:
+  - __osx
+  - pyobjc-framework-cocoa
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23021
+  timestamp: 1682601619389
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-67.7.2-pyhd8ed1ab_0.conda
+  sha256: 3ac44771fce01f19218bcdf3992e24984748048db69889a9df65abcc6a10e29b
+  md5: 3b68bc43ec6baa48f7354a446267eefe
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 582712
+  timestamp: 1682362127707
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+  sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
+  md5: e5f25f8dbc060e9a8d912e432202afc2
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 14259
+  timestamp: 1620240338595
+- conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
+  sha256: a3fd30754c20ddb28b777db38345ea00d958f46701f0decd6291a81c0f4eee78
+  md5: dd6cbc539e74cb1f430efbd4575b9303
+  depends:
+  - python >=3.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 14358
+  timestamp: 1662051357638
+- conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2
+  sha256: ebb8f5f9e362f186fb7d732e656f85c969b86309494436eba51cc3b8b96683f7
+  md5: cb83a3d6ecf73f50117635192414426a
+  depends:
+  - numpy
+  - pyparsing >=2.1.6
+  - python
+  license: MIT
+  license_family: MIT
+  size: 8136
+  timestamp: 1568905295860
+- conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.3.2.post1-pyhd8ed1ab_0.tar.bz2
+  sha256: 72d80dda41c3902c2619e8ab49d4f5b2a894d13375e1f9ed16fc00074ddd2307
+  md5: 146f4541d643d48fc8a75cacf69f03ae
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 34736
+  timestamp: 1658207688981
+- conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+  sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
+  md5: e7df0fdd404616638df5ece6e69ba7af
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 26205
+  timestamp: 1669632203115
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.0-pyh08f2357_0.tar.bz2
+  sha256: 5c8fcf31430e0f312bc65ab5aa5b893fcc250820c023b02ff3fd188ae13199a5
+  md5: 0152a609d5748ed9887d195b1e61a6c9
+  depends:
+  - __win
+  - python >=3.7
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 19530
+  timestamp: 1666708102607
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyh41d4057_0.conda
+  sha256: bce252eb53330a8ba9617caa7a1dc75ce602c8808cf547a8f4d48285901f47c3
+  md5: 3788984d535770cad699efaeb6cb3037
+  depends:
+  - __linux
+  - ptyprocess
+  - python >=3.7
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 20787
+  timestamp: 1670253786972
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyhd1c38e8_0.conda
+  sha256: a2f8382ab390c74af592cc3566dc22e2ed81e5ac69c5b6417d1b7c22e63927bc
+  md5: 046120b71d8896cb7faef78bfdbfee1e
+  depends:
+  - __osx
+  - ptyprocess
+  - python >=3.7
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 20347
+  timestamp: 1670254383751
+- conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+  sha256: f0db1a2298a5e10e30f4b947566c7229442834702f549dded40a73ecdea7502d
+  md5: 7234c9eefff659501cd2fe0d2ede4d48
+  depends:
+  - python >=3.5
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23235
+  timestamp: 1666100385187
+- conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 90229da7665175b0185183ab7b53f50af487c7f9b0f47cf09c184cbc139fd24b
+  md5: 92facfec94bc02d6ccf42e7173831a36
+  depends:
+  - python >=3.5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49136
+  timestamp: 1657485654230
+- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.65.0-pyhd8ed1ab_1.conda
+  sha256: b35f185a678109940d34f68ac5781c3cbda9b118b8d9886b8f68ab5be6afd4fc
+  md5: ed792aff3acb977d09c7013358097f83
+  depends:
+  - colorama
+  - python >=3.7
+  license: MPL-2.0 or MIT
+  license_family: MOZILLA
+  size: 88174
+  timestamp: 1677948992969
+- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.9.0-pyhd8ed1ab_0.conda
+  sha256: 343610bce6dbe8a5090500dd2e9d1706057960b3f3120ebfe0abb4a8ecbada4d
+  md5: d0b4f5c87cd35ac3fb3d47b223263a64
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 98443
+  timestamp: 1675110676323
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.6.3-hd8ed1ab_0.conda
+  sha256: d2334dab270e13182403cc3a394e3da8e7acb409e94059a6d9223d2ac053f90a
+  md5: 3876f650ed7d0f95d70fa4b647621909
+  depends:
+  - typing_extensions 4.6.3 pyha770c72_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 10040
+  timestamp: 1685705090608
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.6.3-pyha770c72_0.conda
+  sha256: 90a8d56c8015af1575d504d5f77d95a806cd999fc178a06ab51a349f1f744672
+  md5: 4a3014a4d107d15475d106b751c4e352
+  depends:
+  - python >=3.7
+  license: PSF-2.0
+  license_family: PSF
+  size: 34905
+  timestamp: 1685705083612
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 9e3758b620397f56fb709f796969de436d63b7117897159619b87938e1f78739
+  md5: eb67e3cace64c66233e2d35949e20f92
+  depends:
+  - python >=3.6.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 13829
+  timestamp: 1622899345711
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+  sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
+  md5: 939e3e74d8be4dac89ce83b20de2492a
+  license: LicenseRef-Public-Domain
+  size: 117580
+  timestamp: 1680041306008
+- conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 04b6f17a9ff2bd36f70076dd1761408de1d38c6c791849a02c3a1d28ad466d00
+  md5: 3ddf6684d9b274a12c94e509ca45656c
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 8969
+  timestamp: 1608058755081
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.3-pyhd8ed1ab_0.conda
+  sha256: 91d999539132f4b04091642df62b51c63c8a1fd61ecdff1ed704fc11405f9a34
+  md5: ae465d0fbf9f1979cb2d8d4043d885e2
+  depends:
+  - brotli >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 98207
+  timestamp: 1686156703401
+- conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.6-pyhd8ed1ab_0.conda
+  sha256: c1bd0ad7d854cae56977b7915ac2b78b652fa5f7ec1e9fc21e7fdb30cf4519b1
+  md5: 078979d33523cb477bd1916ce41aacc9
+  depends:
+  - backports.functools_lru_cache
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 29133
+  timestamp: 1673864747518
+- conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-py_1.tar.bz2
+  sha256: 302f4f4bd1ad00c0be1426ecf6bb01db59cfd8aff3de0cf1596526dca1a6b70e
+  md5: 3563be4c5611a44210d9ba0c16113136
+  depends:
+  - python
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 11901
+  timestamp: 1535427077373
+- conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.5.2-pyhd8ed1ab_0.conda
+  sha256: 85310b382c4220d7846fa8f046216fd722b88db07991f07bd7decdf2e5dc3446
+  md5: bfe7e7cd1476092f51efbcde15dfb110
+  depends:
+  - python >=3.7
+  license: Apache-2.0
+  license_family: APACHE
+  size: 45149
+  timestamp: 1684708291139
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.40.0-pyhd8ed1ab_0.conda
+  sha256: 79b4d29b0c004014a2abd5fc2c9fcd35cc6256222b960c2a317a27c4b0d8884d
+  md5: 49bb0d9e60ce1db25e151780331bb5f3
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 55729
+  timestamp: 1678812153506
+- conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyhd8ed1ab_6.tar.bz2
+  sha256: a11ae693a0645bf6c7b8a47bac030be9c0967d0b1924537b9ff7458e832c0511
+  md5: 30878ecc4bd36e8deeea1e3c151b2e0b
+  depends:
+  - __win
+  - python >=3.6
+  license: PUBLIC-DOMAIN
+  size: 8191
+  timestamp: 1667051294134
+- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2023.5.0-pyhd8ed1ab_0.conda
+  sha256: cd98280dfb226ebb26b7d90da8f3342ecba66ea521b3df27e7a75bc709905502
+  md5: 254b5553bed6adf404ac09fa07cb54da
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 672982
+  timestamp: 1684536729882
+- conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2023.5.0-pyhd8ed1ab_1.conda
+  sha256: c7138adf405483c845ae39eaa103488e378e2c08b00a179fa0a01c4f4de3f28a
+  md5: 232ea5ed580a598cdf887a890c29b629
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36340
+  timestamp: 1684571510455
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.15.0-pyhd8ed1ab_0.conda
+  sha256: 241de30545299be9bcea3addf8a2c22a3b3d4ba6730890e150ab690ac937a3d2
+  md5: 13018819ca8f5b7cc675a8faf1f5fedf
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 17197
+  timestamp: 1677313561776
+- conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h5547dcb_3.tar.bz2
+  sha256: ec3cf8f2091e4add30482728917fddc9c5c1fa4e53c68c0ebcac8f043ad3cf11
+  md5: c09459e349fa61afc352f473766de109
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 33973
+  timestamp: 1666851121728
+- conda: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.4-heccf04b_0.conda
+  sha256: c5ac3d541876c5d19714056a4dd36fb0b0b345d1869158f40e56063c8370daf3
+  md5: 02e92eb72b9ae4c1745b95d03a9c949e
+  depends:
+  - libcxx >=15.0.7
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49720
+  timestamp: 1684235266664
+- conda: https://conda.anaconda.org/conda-forge/osx-64/boost-cpp-1.78.0-hf5ba120_3.conda
+  sha256: 533de450dfa7a1ea3717a969c3910d51bca3661fcaa493e59b75e1e17777a231
+  md5: 796dce91f7325d0bd2bc224e7b334dc6
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=72.1,<73.0a0
+  - libcxx >=12.0.1
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  constrains:
+  - libboost <0
+  license: BSL-1.0
+  size: 15346629
+  timestamp: 1680720868372
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.0.9-hb7f2c08_8.tar.bz2
+  sha256: 1272426370f1e8db1a8b245a7b522afe27413b09eab169990512a7676b802e3b
+  md5: 55f612fe4a9b5f6ac76348b6de94aaeb
+  depends:
+  - brotli-bin 1.0.9 hb7f2c08_8
+  - libbrotlidec 1.0.9 hb7f2c08_8
+  - libbrotlienc 1.0.9 hb7f2c08_8
+  license: MIT
+  license_family: MIT
+  size: 18999
+  timestamp: 1666789085284
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.0.9-hb7f2c08_8.tar.bz2
+  sha256: 36f79eb26da032c5d1ddc11e0bcac5526f249bf60d332e4743c8d48bb7334db0
+  md5: aac5ad0d8f747ef7f871508146df75d9
+  depends:
+  - libbrotlidec 1.0.9 hb7f2c08_8
+  - libbrotlienc 1.0.9 hb7f2c08_8
+  license: MIT
+  license_family: MIT
+  size: 17736
+  timestamp: 1666789050630
+- conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2
+  sha256: 60ba4c64f5d0afca0d283c7addba577d3e2efc0db86002808dadb0498661b2f2
+  md5: 37edc4e6304ca87316e160f5ca0bd1b5
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 158829
+  timestamp: 1618862580095
+- conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.19.1-h0dc2134_0.conda
+  sha256: 1de09d540facc3833e3f0a280ae987859f310f535726eff66d6f4a66045bd32c
+  md5: b3e62631b4e1b9801477523ce1d6f355
+  license: MIT
+  license_family: MIT
+  size: 103004
+  timestamp: 1684783034995
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2023.5.7-h8857fd0_0.conda
+  sha256: a06c9c788de81da3a3868ac56781680cc1fc50a0b5a545d4453818975c141b2c
+  md5: b704e4b79ba0d887c4870b7b09d6a4df
+  license: ISC
+  size: 148522
+  timestamp: 1683451939937
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.16.0-h09dd18c_1016.conda
+  sha256: d5dec1060a78deb70ddfd89c23ee683699f743fe68f78379dc4834e2553edb37
+  md5: 8f188a1368e0d5bcb017493ee83ffaf0
+  depends:
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=72.1,<73.0a0
+  - libglib >=2.76.2,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - pixman >=0.40.0,<1.0a0
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 951603
+  timestamp: 1684639693371
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cartopy-0.21.1-py311hb21c73c_1.conda
+  sha256: ba3adfdd39ac55cafecd422397e7b35ed869e84d1d7f0bfe4c87061b1e534cc6
+  md5: 7a366484090de08fc33c3ad8ba927800
+  depends:
+  - geos >=3.11.2,<3.11.3.0a0
+  - libcxx >=14.0.6
+  - matplotlib-base >=3.1
+  - numpy >=1.23.5,<2.0a0
+  - pyproj >=3.0.0
+  - pyshp >=2.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scipy >=0.10
+  - shapely >=1.6.4
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 1700030
+  timestamp: 1679098332565
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.15.1-py311ha86e640_3.conda
+  sha256: 436a99652d9b13ed4b945f05740b50c79447b581aa400f69607f56c4960b806d
+  md5: 5967be4da33261eada7cc79593f71088
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 280535
+  timestamp: 1671179829333
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cfitsio-4.2.0-hd56cc12_0.conda
+  sha256: 9e4746e64dd54030777ee77f6cb729374e877da2322236c10563dff27b877660
+  md5: 28e03cefd79aa28ec0e313e5a9c71f5b
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=7.86.0,<9.0a0
+  - libgfortran >=5
+  - libgfortran5 >=11.3.0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: LicenseRef-fitsio
+  size: 843618
+  timestamp: 1668757272528
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cftime-1.6.2-py311hd5badaa_1.tar.bz2
+  sha256: b475f5fc4a6e13982eb7d278d4f524922d606ae3f4b53eaa0b7d17144ab7067d
+  md5: 4838daf28fad712f5ac12b025b236983
+  depends:
+  - numpy >=1.23.4,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 224265
+  timestamp: 1666834257682
+- conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.0.7-py311hd2070f0_0.conda
+  sha256: 482a61d83cf792c7237e6915f66d244dbdf00e6710f6f8a34f721b07d88e9e29
+  md5: d78f75103409d2c7a8774c873821ae9a
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.16
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 218634
+  timestamp: 1673634029687
+- conda: https://conda.anaconda.org/conda-forge/osx-64/curl-8.1.2-hbee3ae8_0.conda
+  sha256: 168f860cc615a107113cfd1a90ff6a3b30c33f12a2aa2e2a5aa95299929a611a
+  md5: 6cc301a6c2ba26e29949818efdc133ca
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libcurl 8.1.2 hbee3ae8_0
+  - libssh2 >=1.10.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.0,<4.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 146226
+  timestamp: 1685448036837
+- conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.6.7-py311h814d153_0.conda
+  sha256: d6097236ed8720606c17685d759bb6010331cc4bee835921f586917b1d5ec564
+  md5: c27802860b87fe024c9b6276205a56b5
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2244926
+  timestamp: 1680756034707
+- conda: https://conda.anaconda.org/conda-forge/osx-64/expat-2.5.0-hf0c8a7f_1.conda
+  sha256: 15c04a5a690b337b50fb7550cce057d843cf94dd0109d576ec9bc3448a8571d0
+  md5: e12630038077877cbb6c7851e139c17c
+  depends:
+  - libexpat 2.5.0 hf0c8a7f_1
+  license: MIT
+  license_family: MIT
+  size: 120323
+  timestamp: 1680191057827
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.14.2-h5bb23bf_0.conda
+  sha256: f63e6d1d6aef8ba6de4fc54d3d7898a153479888d40ffdf2e4cfad6f92679d34
+  md5: 86cc5867dfbee4178118392bae4a3c89
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 237068
+  timestamp: 1674829100063
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.39.4-py311h2725bcf_0.conda
+  sha256: 7d9016041fbc5cb514f1357d4e975537bda930091c7e5aaeaecf048e877c9463
+  md5: 250388f6d2c5a20066a95cf872e22495
+  depends:
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2600056
+  timestamp: 1683741100502
+- conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h3f81eb7_1.conda
+  sha256: 0aea2b93d0da8bf022501857de93f2fc0e362fabcd83c4579be8d8f5bc3e17cb
+  md5: 852224ea3e8991a8342228eab274840e
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only and LicenseRef-FreeType
+  size: 599569
+  timestamp: 1669233263749
+- conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-1.0.6-hb7f2c08_1.tar.bz2
+  sha256: 8ef3816b290c09e313460f099d30984070766a700920265d3eb6f20106b574e3
+  md5: 4fc494f8539871247167bbe4167f3277
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 45149
+  timestamp: 1662819600347
+- conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.11.2-hf0c8a7f_0.conda
+  sha256: 5c14e176b6dfca527d663281201a5a3a0d1f1df41b4a7d04b03385e4bfd56918
+  md5: 174943c1cc025b1c526f0a464694137c
+  depends:
+  - libcxx >=14.0.6
+  license: LGPL-2.1-only
+  size: 1301680
+  timestamp: 1679049176810
+- conda: https://conda.anaconda.org/conda-forge/osx-64/geotiff-1.7.1-h75a88c4_8.conda
+  sha256: bd7a8ed57fe74166d7e7b67e8bc2cbc281603d33b9d090a407ee3e011fafb59c
+  md5: 29e1d1b706c61b78ab84ed0685e7e415
+  depends:
+  - libcxx >=14.0.6
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - proj >=9.2.0,<9.2.1.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 118310
+  timestamp: 1679226497495
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.21.1-h8a4c099_0.tar.bz2
+  sha256: 915d3cd2d777b9b3fc2e87a25901b8e4a6aa1b2b33cf2ba54e9e9ed4f6b67d94
+  md5: 1e3aff29ce703d421c43f371ad676cc5
+  depends:
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 4153781
+  timestamp: 1665674106245
+- conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.1-hb7f2c08_3.conda
+  sha256: 47515e0874bcf67e438e1d5d093b074c1781f055067195f0d00a7790a56d446d
+  md5: aca150b0186836f893ebac79019e5498
+  license: MIT
+  license_family: MIT
+  size: 76514
+  timestamp: 1678717973971
+- conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h9804679_6.conda
+  sha256: 74a309f9c885aa2b0acf4adb9a9bf6c6e8869496a6a8a79833a2796940ed0a1c
+  md5: c13d8841112ba7f5931d1d60631394f3
+  depends:
+  - libcxx >=14.0.6
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 724520
+  timestamp: 1678293107328
+- conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.0-nompi_hbf0aa07_103.conda
+  sha256: 1c57bea7086af82b57d912d806516e432a179c4a46271c1e65bbe39466722e3d
+  md5: 90f50d124606a4e62628823b614a2f4c
+  depends:
+  - libaec >=1.0.6,<2.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  - libgfortran >=5
+  - libgfortran5 >=11.3.0
+  - libgfortran5 >=12.2.0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.0.8,<4.0a0
+  license: LicenseRef-HDF5
+  license_family: BSD
+  size: 3446812
+  timestamp: 1678275279728
+- conda: https://conda.anaconda.org/conda-forge/osx-64/icu-72.1-h7336db1_0.conda
+  sha256: 3813b724fa741c63bf15698a716a9b9f4243a469cb658cdd47a1a9a602aa579e
+  md5: c9689510a50a4bb2ae978421671a125e
+  license: MIT
+  license_family: MIT
+  size: 11631741
+  timestamp: 1679314814805
+- conda: https://conda.anaconda.org/conda-forge/osx-64/json-c-0.16-h01d06f9_0.tar.bz2
+  sha256: 9db9901379d952a491f02f4325f3fb19ebb01b4dcc554472e4706a3d1d6abdad
+  md5: 6696477dbfcb5b7ea8559865e7f9dbef
+  license: MIT
+  license_family: MIT
+  size: 72535
+  timestamp: 1649932714933
+- conda: https://conda.anaconda.org/conda-forge/osx-64/jupyter_core-5.3.0-py311h6eed73b_0.conda
+  sha256: d8353a88d27030a620fe1877f5bee4ac4044ffcebd158bbd891110a79eca1016
+  md5: e0e5cfb36ece6eae9c355eed1e90ff9d
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 115737
+  timestamp: 1678994904152
+- conda: https://conda.anaconda.org/conda-forge/osx-64/kealib-1.5.1-hde10d81_3.conda
+  sha256: b3a47cf7c44b99d205cde455d0caa7e551af05262b916e8c1ae2d0747ea441d6
+  md5: 4717277790fa124705072a7e8c71fe04
+  depends:
+  - hdf5 >=1.14.0,<1.14.1.0a0
+  - libcxx >=15.0.7
+  license: MIT
+  license_family: MIT
+  size: 151030
+  timestamp: 1684390285519
+- conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.4-py311hd2070f0_1.tar.bz2
+  sha256: 49f91463ed78c6f4e31ddd12a9fe46b4d8ea85a7480620c1a39fd64971764654
+  md5: 5219e72a43e53e8f6af4fdf76a0f90ef
+  depends:
+  - libcxx >=14.0.4
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64753
+  timestamp: 1666806012673
+- conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.20.1-h049b76e_0.conda
+  sha256: 41cfbf4c5cdb4a32eb5319943113d7ef1edb894ea0a5464233e510b59450c824
+  md5: db11fa2968ef0837288fe2d7f5b77a50
+  depends:
+  - libcxx >=14.0.6
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.0.7,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1127291
+  timestamp: 1671092045705
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.15-h2dcdeff_1.conda
+  sha256: 5154e12ea600a0008ddb76a02e3f6edb373bf8c3eef47f7dd052d66b8d2fc35a
+  md5: f1df9b0c2d9fbe985e62f4b24773a9e4
+  depends:
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 227656
+  timestamp: 1678213605937
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+  sha256: e41790fc0f4089726369b3c7f813117bbc14b533e0ed8b94cf75aba252e82497
+  md5: f9d6a4c82889d5ecedec1d90eb673c55
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 290319
+  timestamp: 1657977526749
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.0.6-hf0c8a7f_1.conda
+  sha256: 38d32f4c7efddc204e53f43cd910122d3e6a997de1a3cd15f263217b225a9cdf
+  md5: 7c0f82f435ab4c48d65dc9b28db2ad9e
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29711
+  timestamp: 1673799633171
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.6.2-h0b5dc4a_1.conda
+  sha256: 078a407b6a8a7b9debd7fbb7c8696c371e2a309ef9392788c3a7742292bdf910
+  md5: 578c79bc28b8d1fa995e7cc0d3c7e965
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libiconv >=1.17,<2.0a0
+  - libxml2 >=2.11.3,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - lzo >=2.10,<3.0a0
+  - openssl >=3.1.0,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 730390
+  timestamp: 1684325192127
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-17_osx64_openblas.conda
+  sha256: d2439e4f7bbe0814128d080a01f8435875cc423543184ca0096087308631d73e
+  md5: 65299527582e2449b05d27fcf8352125
+  depends:
+  - libopenblas >=0.3.23,<0.3.24.0a0
+  - libopenblas >=0.3.23,<1.0a0
+  constrains:
+  - liblapacke 3.9.0 17_osx64_openblas
+  - libcblas 3.9.0 17_osx64_openblas
+  - blas * openblas
+  - liblapack 3.9.0 17_osx64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14710
+  timestamp: 1685930987689
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.0.9-hb7f2c08_8.tar.bz2
+  sha256: c983101653f5bffea605c4423d84fd5ca28ee36b290cdb6207ec246e293f7d94
+  md5: 37157d273eaf3bc7d6862104161d9ec9
+  license: MIT
+  license_family: MIT
+  size: 65557
+  timestamp: 1666788942461
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.0.9-hb7f2c08_8.tar.bz2
+  sha256: 52d8e8929b2476cf13fd397d88cefd911f805de00e77090fdc50b8fb11c372ca
+  md5: 7f952a036d9014b4dab96c6ea0f8c2a7
+  depends:
+  - libbrotlicommon 1.0.9 hb7f2c08_8
+  license: MIT
+  license_family: MIT
+  size: 33317
+  timestamp: 1666788975470
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.0.9-hb7f2c08_8.tar.bz2
+  sha256: be7e794c6208e7e12982872922df13fbf020ab594d516b7bc306a384ac7d3ac6
+  md5: b36a3bfe866d9127f25f286506982166
+  depends:
+  - libbrotlicommon 1.0.9 hb7f2c08_8
+  license: MIT
+  license_family: MIT
+  size: 310647
+  timestamp: 1666789012950
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-17_osx64_openblas.conda
+  sha256: 5c85941b55a8e897e11188ab66900eb3d83c87f6bdd0b88856733f8510fa4c91
+  md5: 380151ca00704172b242a63701b7bf8a
+  depends:
+  - libblas 3.9.0 17_osx64_openblas
+  constrains:
+  - liblapacke 3.9.0 17_osx64_openblas
+  - blas * openblas
+  - liblapack 3.9.0 17_osx64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14614
+  timestamp: 1685931005294
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.1.2-hbee3ae8_0.conda
+  sha256: 2f81bb06377779ea1abe373a2a89289fb440751ad6f68f947ec0f3b1e4399968
+  md5: d51e337da844262f9033c9a26452520f
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.10.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.0,<4.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 352385
+  timestamp: 1685448012016
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.5-hd57cbcb_0.conda
+  sha256: 1661ffd4e62593aed05da9ee1f7b1905711d8374a25b187e61cb7e55823440df
+  md5: d34eed0a4fb993f0d934db6394ba23ef
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1143118
+  timestamp: 1685827540043
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.18-hac1461d_0.conda
+  sha256: b985178bc45f83259c99026d988448277e17171801945769396e2577ce59778c
+  md5: 3d131584456b277ce0871e6481fde49b
+  license: MIT
+  license_family: MIT
+  size: 67061
+  timestamp: 1679647698096
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+  sha256: dbd3c3f2eca1d21c52e4c03b21930bbce414c4592f8ce805801575b9e9256095
+  md5: 6016a8a1d0e63cac3de2c352cd40208b
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 105382
+  timestamp: 1597616576726
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-haf1e3a3_1.tar.bz2
+  sha256: c4154d424431898d84d6afb8b32e3ba749fe5d270d322bb0af74571a3cb09c6b
+  md5: 79dc2be110b2a3d1e97ec21f691c50ad
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 101424
+  timestamp: 1598868359024
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.5.0-hf0c8a7f_1.conda
+  sha256: 80024bd9f44d096c4cc07fb2bac76b5f1f7553390112dab3ad6acb16a05f0b96
+  md5: 6c81cb022780ee33435cca0127dd43c9
+  constrains:
+  - expat 2.5.0.*
+  license: MIT
+  license_family: MIT
+  size: 69602
+  timestamp: 1680191040160
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+  sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
+  md5: ccb34fb14960ad8b125962d3d79b31a9
+  license: MIT
+  license_family: MIT
+  size: 51348
+  timestamp: 1636488394370
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.7.0-hd7102d7_1.conda
+  sha256: fe12e98f46fdb55d7fea52ae818e23c9e8daea4f10daed5381b4a1d2bfa3649c
+  md5: c9d5b419edb1925150077d76d15f419a
+  depends:
+  - blosc >=1.21.4,<2.0a0
+  - cfitsio >=4.2.0,<4.2.1.0a0
+  - freexl >=1.0.6,<2.0a0
+  - geos >=3.11.2,<3.11.3.0a0
+  - geotiff >=1.7.1,<1.8.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.0,<1.14.1.0a0
+  - icu >=72.1,<73.0a0
+  - json-c >=0.16,<0.17.0a0
+  - kealib >=1.5.1,<1.6.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libarchive >=3.6.2,<3.7.0a0
+  - libcurl >=8.1.0,<9.0a0
+  - libcxx >=15.0.7
+  - libdeflate >=1.18,<1.26.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=15.3,<16.0a0
+  - libspatialite >=5.0.1,<5.1.0a0
+  - libsqlite >=3.42.0,<4.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  - libwebp-base >=1.3.0,<2.0a0
+  - libxml2 >=2.11.3,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - openssl >=3.1.0,<4.0a0
+  - pcre2 >=10.40,<10.41.0a0
+  - poppler >=23.5.0,<23.6.0a0
+  - postgresql
+  - proj >=9.2.0,<9.2.1.0a0
+  - tiledb >=2.13.2,<2.14.0a0
+  - xerces-c >=3.2.4,<3.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 9137862
+  timestamp: 1684603630840
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-11_3_0_h97931a8_31.conda
+  sha256: 55d3c81ce8cd931260c3cb8c85868e36223d2bd0d5e2f35a79503810ee172769
+  md5: 97451338600bd9c5b535eb224ef6c471
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 160084
+  timestamp: 1678485362631
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-12.2.0-he409387_31.conda
+  sha256: 42ae06bbb3cf7f7c3194482894f4287fad7bc39214d1a0dbf0c43f8efb8d3c1a
+  md5: 5a544130e584b1f204ac896ff071d5b3
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_31
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1600291
+  timestamp: 1678485061597
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.76.3-hc62aa5d_0.conda
+  sha256: b9396d779ed9c12e4777500497f87414629e943f2f433d059f3378f8d5d4f57e
+  md5: 3687b3c1d257dec787418281cfc58358
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libcxx >=15.0.7
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - pcre2 >=10.40,<10.41.0a0
+  constrains:
+  - glib 2.76.3 *_0
+  license: LGPL-2.1-or-later
+  size: 2475625
+  timestamp: 1684848705854
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hac89ed1_0.tar.bz2
+  sha256: 4a3294037d595754f7da7c11a41f3922f995aaa333f3cb66f02d8afa032a7bc2
+  md5: 691d103d11180486154af49c037b7ed9
+  license: GPL and LGPL
+  size: 1378276
+  timestamp: 1652702364402
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-2.1.5.1-hb7f2c08_0.conda
+  sha256: 38288e83201639983d3e158a1e8f638334298a0ca3a59dbb188651c874fd6077
+  md5: d7309a152b9b79799063b8bb47e34a3a
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG, modified 3-clause BSD and zlib
+  size: 458439
+  timestamp: 1678127987545
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libkml-1.3.0-haeb80ef_1015.tar.bz2
+  sha256: 8ab0f6094e27d7fce097a83fccca60aa0dd5055a46335386e3fd4b417bc24d33
+  md5: f1a092ddaedbde48dcf62a9455ce7e31
+  depends:
+  - boost-cpp >=1.78.0,<1.78.1.0a0
+  - expat >=2.4.8,<3.0a0
+  - libcxx >=14.0.4
+  - libzlib >=1.2.12,<2.0.0a0
+  - zlib >=1.2.12,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 501553
+  timestamp: 1662843181011
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-17_osx64_openblas.conda
+  sha256: 7ce76f3e9578b62fbd88c094f343c1b09ec3466afccfc08347d31742e6831e97
+  md5: 6ab83532872bf3659613638589dd10af
+  depends:
+  - libblas 3.9.0 17_osx64_openblas
+  constrains:
+  - liblapacke 3.9.0 17_osx64_openblas
+  - libcblas 3.9.0 17_osx64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14619
+  timestamp: 1685931022827
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-hc8e404f_3.conda
+  sha256: 2469a23d25e2d6b782aa06621f234009f0e401bbf81b479c535809975605596c
+  md5: a6433d7252b49c2195f8aa70ad898104
+  depends:
+  - libcxx >=15
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 22443730
+  timestamp: 1685682126901
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.2-nompi_hf077d52_105.conda
+  sha256: 3df29ce3f8aa1f9786eea78e0be6c7d99ca7e378d39682e946dfe33cfe6aafd2
+  md5: 64d626e024a284777458e2b315e9eb56
+  depends:
+  - blosc >=1.21.4,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - curl
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 * nompi_*
+  - hdf5 >=1.14.0,<1.14.1.0a0
+  - libcxx >=15.0.7
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libxml2 >=2.11.3,<2.14.0a0
+  - libzip >=1.9.2,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 731704
+  timestamp: 1684497038180
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.52.0-he2ab024_0.conda
+  sha256: 093e4f3f62b3b07befa403e84a1f550cffe3b3961e435d42a75284f44be5f68a
+  md5: 12ac7d100bf260263e30a019517f42a2
+  depends:
+  - c-ares >=1.18.1,<2.0a0
+  - libcxx >=14.0.6
+  - libev >=4.33,<4.34.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.0.8,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 613074
+  timestamp: 1677678399575
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.23-openmp_h429af6e_0.conda
+  sha256: fb1ba347e07145807fb1688c78b115d5eb2f4775d9eb6d991d49cb88eef174b7
+  md5: 7000a828e29608e4f57e662b5502d2c9
+  depends:
+  - libgfortran >=5
+  - libgfortran5 >=11.3.0
+  - llvm-openmp >=14.0.6
+  constrains:
+  - openblas >=0.3.23,<0.3.24.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6018665
+  timestamp: 1681400118468
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.39-ha978bb4_0.conda
+  sha256: 5ad9f5e96e6770bfc8b0a826f48835e7f337c2d2e9512d76027a62f9c120b2a3
+  md5: 35e4928794c5391aec14ffdf1deaaee5
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: zlib-acknowledgement
+  size: 271689
+  timestamp: 1669075890643
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libpq-15.3-h9dc22bb_1.conda
+  sha256: bb084c127f22e486731704f0a515bd823ec20dc717c7d219263f244ee5b13a62
+  md5: 571aa9141d1a823202bb4cd794c939b0
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.0,<3.2.0a0
+  license: PostgreSQL
+  size: 2351517
+  timestamp: 1684452440426
+- conda: https://conda.anaconda.org/conda-forge/osx-64/librttopo-1.1.0-h5c328d2_13.conda
+  sha256: 48314f64e1d9302392394c84754e3d0386c080577085eb97f516a1e1ad17e1bb
+  md5: c40dcf99bd2da3f0b7d27c616ac2108c
+  depends:
+  - geos >=3.11.2,<3.11.3.0a0
+  - libcxx >=14.0.6
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 214120
+  timestamp: 1679087615400
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.18-hbcb3906_1.tar.bz2
+  sha256: 2da45f14e3d383b4b9e3a8bacc95cd2832aac2dbf9fbc70d255d384a310c5660
+  md5: 24632c09ed931af617fe6d5292919cab
+  license: ISC
+  size: 528765
+  timestamp: 1605135849110
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libspatialite-5.0.1-h8e1627f_26.conda
+  sha256: 5a0046e087538e1e96a2b0e6c860aa75e8e759b24f1a92e5888cf948847b47c6
+  md5: e2bf932786503f9733415f0f1142de44
+  depends:
+  - freexl >=1.0.6,<2.0a0
+  - geos >=3.11.2,<3.11.3.0a0
+  - libcxx >=15.0.7
+  - libiconv >=1.17,<2.0a0
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.42.0,<4.0a0
+  - libxml2 >=2.11.3,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - proj >=9.2.0,<9.2.1.0a0
+  - sqlite
+  - zlib
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 3035907
+  timestamp: 1684288128844
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.42.0-h58db7d2_0.conda
+  sha256: 182689f4b1a5ed638cd615c7774e1a9974842bc127c59173f1d25e31a8795eef
+  md5: a7d3b44b7b0c9901ac7813b7a0462893
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Unlicense
+  size: 878744
+  timestamp: 1684265213849
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+  sha256: f3886763b88f4b24265db6036535ef77b7b77ce91b1cbe588c0fbdd861eec515
+  md5: ca3a72efba692c59a90d4b9fc0dfe774
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 259556
+  timestamp: 1685837820566
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.5.0-hedf67fa_6.conda
+  sha256: ef38081f3523bb5c1c0bd1aaceb3137f2201ae9400cd888575f798adf03e46d6
+  md5: 800b810c1aa3eb4a08106698441871bb
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.18,<1.26.0a0
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libwebp-base >=1.3.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  size: 392837
+  timestamp: 1679672292628
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.3.0-hb7f2c08_0.conda
+  sha256: 5ed0b7f127f578ddd28e3af86af278df8d5341416935a09ae772a57579cbb11b
+  md5: 18981e4c840126d6118d8952485fea51
+  constrains:
+  - libwebp 1.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 345913
+  timestamp: 1678666635398
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.15-hb7f2c08_0.conda
+  sha256: f41904f466acc8b3197f37f2dd3a08da75720c7f7464d9267635debc4ac1902b
+  md5: 5513f57e0238c87c12dffedbcc9c1a4a
+  depends:
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 313793
+  timestamp: 1682083036825
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.11.4-hd95e348_0.conda
+  sha256: d113eeafcbbb4ee5086b31b45adac5818394dc9759e3e1d9fb95114a852ef535
+  md5: 681f8dda25e73a830d774a37b9839c85
+  depends:
+  - icu >=72.1,<73.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 623719
+  timestamp: 1684627463086
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzip-1.9.2-h6db710c_1.tar.bz2
+  sha256: 1f8399c3d70a25b74fb682cdd32d50814aa3728b152192c7aef7d7fd7a215f8c
+  md5: ce732d37e479919f3d22b1ccdeb858ac
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.12,<2.0.0a0
+  - openssl >=3.0.5,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119721
+  timestamp: 1660347362313
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-hfd90126_4.tar.bz2
+  sha256: 0d954350222cc12666a1f4852dbc9bcf4904d8e467d29505f2b04ded6518f890
+  md5: 35eb3fce8d51ed3c1fd4122bad48250b
+  constrains:
+  - zlib 1.2.13 *_4
+  license: Zlib
+  license_family: Other
+  size: 65850
+  timestamp: 1665759846257
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-16.0.5-hff08bdf_0.conda
+  sha256: 8615505724d8e4e86fc036de3aad73382bf33028f305c279cee28f10c8448291
+  md5: af8df1a61e8137e3479b0f71d5bd0a49
+  constrains:
+  - openmp 16.0.5|16.0.5.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 296131
+  timestamp: 1685774717326
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.40.0-py311hcbb5c6d_0.conda
+  sha256: abd45325d4cfd13c7645cbe071ac63ecac96764dd1b7cfda9c861d5bce89ac42
+  md5: ff4321c8283372b741e66cb829db2f72
+  depends:
+  - libcxx >=15.0.7
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 326682
+  timestamp: 1684447420832
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+  sha256: 39aa0c01696e4e202bf5e337413de09dfeec061d89acd5f28e9968b4e93c3f48
+  md5: aa04f7143228308662696ac24023f991
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 156415
+  timestamp: 1674727335352
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lzo-2.10-haf1e3a3_1000.tar.bz2
+  sha256: c8a9401eff2efbbcc6da03d0066ee85d72402f7658c240e7968c64052a0d0493
+  md5: 0b6bca372a95d6c602c7a922e928ce79
+  license: GPL v2+
+  license_family: GPL2
+  size: 194278
+  timestamp: 1597682686489
+- conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.3-py311h2725bcf_0.conda
+  sha256: 93dbcca2a1a1c0ee1dbd60b578a66b650da2b166845ccf9ec54eed948ae42e47
+  md5: 65b70928fcc2a81891ad1a8a6a7b085a
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25795
+  timestamp: 1685769434455
+- conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.7.1-py311h2bf763f_0.conda
+  sha256: 9733644a178cd3911676b0065ed24d5dda0ca7a10d60f124a63fef02a5433861
+  md5: d67ac9c9b834ae77ff7b2c59f702803c
+  depends:
+  - __osx >=10.12
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.20
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  license: LicenseRef-PSF-2.0 and CC0-1.0
+  license_family: PSF
+  size: 7584370
+  timestamp: 1678136051087
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-hf0c8a7f_0.conda
+  sha256: 7841b1fce1ffb0bfb038f9687b92f04d64acab1f7cb96431972386ea98c7b2fd
+  md5: c3dbae2411164d9b02c69090a9a91857
+  license: X11 AND BSD-3-Clause
+  size: 828118
+  timestamp: 1686077056765
+- conda: https://conda.anaconda.org/conda-forge/osx-64/netcdf4-1.6.4-nompi_py311h6222480_100.conda
+  sha256: cd5ef5b1a84282b3474bdeaa89ef004d9521c041e1a0d942bc13a4766927a18c
+  md5: 1120fd60b1ce7f70359af368ccf06658
+  depends:
+  - certifi
+  - cftime
+  - hdf5 >=1.14.0,<1.14.1.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 452884
+  timestamp: 1686025588540
+- conda: https://conda.anaconda.org/conda-forge/osx-64/nspr-4.35-hea0b92c_0.conda
+  sha256: da6e19bd0ff31e219760e647cfe1cc499a8cdfaff305f06c56d495ca062b86de
+  md5: a9e56c98d13d8b7ce72bf4357317c29b
+  depends:
+  - libcxx >=14.0.6
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 230071
+  timestamp: 1669785313586
+- conda: https://conda.anaconda.org/conda-forge/osx-64/nss-3.89-h78b00b3_0.conda
+  sha256: 284f9d58f678e82a742aecff60fced40cc944f37e13b42887b364c294abe690e
+  md5: 1eb1408ecae62d98a902636d46f5595c
+  depends:
+  - libcxx >=14.0.6
+  - libsqlite >=3.40.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - nspr >=4.35,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1858958
+  timestamp: 1678488553815
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.57.0-py311h5a8220d_1.conda
+  sha256: 2c5f8f6a53395fae80dbc07a9e3c681397610f57b8fb0b1e06938f363e509ee2
+  md5: 109401f55e33c832ac4cd0c9cdb9f910
+  depends:
+  - libcxx >=15.0.7
+  - llvm-openmp >=15.0.7
+  - llvm-openmp >=16.0.4
+  - llvmlite >=0.40.0,<0.41.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - cuda-python >=11.6
+  - cuda-version >=10.2
+  - libopenblas !=0.3.6
+  - cudatoolkit >=10.2
+  - scipy >=1.0
+  - tbb >=2021.9.0,<2022.0a0
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.25
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5525273
+  timestamp: 1685545342371
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.24.3-py311hc44ba51_0.conda
+  sha256: 837588b07c498ea3088f7b20d7cdf5a72b3505d69612b87d92dfd3893f7d7919
+  md5: 6c4b3bbdc10013352324d4cc366edb17
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=15.0.7
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7434144
+  timestamp: 1682211068475
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.0-h13ac156_2.conda
+  sha256: 2375eafbd5241d8249fb467e2a8e190646e8798c33059c72efa60f197cdf4944
+  md5: 299a29af9ac9f550ad459d655739280b
+  depends:
+  - libcxx >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 329555
+  timestamp: 1671435389000
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.1.1-h8a1eda9_1.conda
+  sha256: 67855f92bf50f24cbbc44879864d7a040b1f351e95b599cfcf4cc49b2cc3fd08
+  md5: c7822d6ee74e34af1fd74365cfd18983
+  depends:
+  - ca-certificates
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2326872
+  timestamp: 1685518213128
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.0.2-py311hab14417_0.conda
+  sha256: 09217db9ca3226dbf9316b5d4d07c5b3b0db41de28d9de1f7b521b68c0344c12
+  md5: a490b12cf9ba39a6968000e93826c283
+  depends:
+  - libcxx >=15.0.7
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14138843
+  timestamp: 1685343880007
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pandoc-2.19.2-h694c41f_2.conda
+  sha256: 318f0517df3340002ceff420f7def25e416bcbd9875621f2bde33fc8e27c2baf
+  md5: de3014568ff5004048dd09ba73990430
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 14608538
+  timestamp: 1678226654710
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.40-h1c4e4bc_0.tar.bz2
+  sha256: 60265b48c96decbea89a19a7bc34be88d9b95d4725fd4dbdae158529c601875a
+  md5: e0f80c8f3a0352a54eddfe59cd2b25b1
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.12,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2552113
+  timestamp: 1665563254214
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-9.5.0-py311h7cb0e2d_1.conda
+  sha256: f99261dcd89fce8840303febff07ee1321b303525fe042eac2592808d9730c48
+  md5: bf4feca7fd63e619c39ab32eac625edf
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  - libwebp-base >=1.3.0,<2.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.12,<8.7.0a0
+  license: LicenseRef-PIL
+  size: 46152494
+  timestamp: 1684654411903
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.40.0-hbcb3906_0.tar.bz2
+  sha256: 50646988679b823958bd99983a9e66fce58a7368fa2bab5712efb5c7ce6199af
+  md5: 09a583a6f172715be21d93aaa1b42d71
+  license: MIT
+  license_family: MIT
+  size: 629262
+  timestamp: 1604342792761
+- conda: https://conda.anaconda.org/conda-forge/osx-64/poppler-23.05.0-he041c3a_1.conda
+  sha256: 69d1cb45cce68095f51ec6d85ba892d6e6474dd75253bcb1ccc7f6b36a66cc42
+  md5: d7003c7b3865ff119e5eba90854f2fb0
+  depends:
+  - boost-cpp >=1.78.0,<1.78.1.0a0
+  - cairo >=1.16.0,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gettext >=0.21.1,<1.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libcurl >=8.0.1,<9.0a0
+  - libcxx >=15.0.7
+  - libglib >=2.76.2,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - nss >=3.89,<4.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - poppler-data
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 1558291
+  timestamp: 1683555258131
+- conda: https://conda.anaconda.org/conda-forge/osx-64/postgresql-15.3-h325e403_1.conda
+  sha256: 1877f16fe87e35928ec4b77bd233395e52cd387c85964385a69385fa5e228046
+  md5: d211ca1655c0e8b43a675e3842c1861e
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libpq 15.3 h9dc22bb_1
+  - libxml2 >=2.11.3,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tzcode
+  - tzdata
+  - zlib
+  size: 4442123
+  timestamp: 1684452513939
+- conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.2.0-hf909084_0.conda
+  sha256: fae27009b3ae972ca76c0573dd17d927eaae447060a44225bcebe940c17a7c19
+  md5: 9aba089c58568c488fde1777c28f4742
+  depends:
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  - libsqlite >=3.40.0,<4.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2685871
+  timestamp: 1679164876664
+- conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.5-py311h5547dcb_0.conda
+  sha256: 0c7a402b0b2085b9e77c741ae14a386318c24dea62e12d29385843a6e8ae00a9
+  md5: d9b4565309f4f992b42bd99031044642
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 505985
+  timestamp: 1681775450320
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
+  sha256: 6e3900bb241bcdec513d4e7180fe9a19186c1a38f0b4080ed619d26014222c53
+  md5: addd19059de62181cd11ae8f4ef26084
+  license: MIT
+  license_family: MIT
+  size: 5653
+  timestamp: 1606147699844
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-9.2-py311hf110eff_0.conda
+  sha256: 17fec1464116ce95acc1967941df0f11e0ebd61097eb98b1b8548cbb828fc25f
+  md5: 460e6d2c254ec4aa4299cd9bffa3b7f8
+  depends:
+  - libffi >=3.4,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 463112
+  timestamp: 1686129884971
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-9.2-py311hf110eff_0.conda
+  sha256: 307a3152d67152a1d63a48ec80de1b97c42e9bb7b5975d5af4bbe0cca638c4d5
+  md5: 6ba4637fa1ed0a1e829b1f278c12274a
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 9.2.*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 370409
+  timestamp: 1686136375922
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.5.0-py311hfd16f4a_1.conda
+  sha256: d842e5350263c070be4767e8c545257cd911b9108fe4d299a09c28fb9a470f86
+  md5: 9ffc3610d16b58f0dab5cdb8c8c99f9a
+  depends:
+  - certifi
+  - proj >=9.2.0,<9.2.1.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 425341
+  timestamp: 1680062527517
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyrsistent-0.19.3-py311h5547dcb_0.conda
+  sha256: 501090ab7c8b2aa0fcddf54600c3a0e3762c0ee9585a97730a73baea0dd95124
+  md5: f114c0dab9f9c894b260297371124634
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 118657
+  timestamp: 1672681864601
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.3-h99528f9_0_cpython.conda
+  sha256: 576781d2c245e0d5cc9f896cd9ab195d2c4e8175f0162fbb616b7a1e6c11087a
+  md5: c3291f9411424fc587d53a2ea57fb075
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.40.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.3,<7.0a0
+  - openssl >=3.1.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 15325572
+  timestamp: 1680773198960
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-3_cp311.conda
+  sha256: 145edb385d464227aca8ce963b9e22f5f36cacac9085eb38f574961ebc69684e
+  md5: 5e0a069a585445333868d2c6651c3b3f
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5766
+  timestamp: 1669071853731
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0-py311h5547dcb_5.tar.bz2
+  sha256: 1598d451064c39979ac61e821eab3997b03e53eaa61070c450ca05e3ebcc23da
+  md5: 8d1e456914ce961119b07f396187a564
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 197877
+  timestamp: 1666772814869
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-25.1.0-py311h5dacc12_0.conda
+  sha256: bef526f79f533f544e1486b8cc1a50af340248afdbc4e6b0de8349d85dbd5cc8
+  md5: 1f65b37886e7cb8476d48ea8bb9d19c0
+  depends:
+  - libcxx >=15.0.7
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  size: 498701
+  timestamp: 1685519609247
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rasterio-1.3.7-py311h22430a6_1.conda
+  sha256: 3308e5228f16f9878a7742c1426edc57ed6c74d8cc2d99b7f4641169bd0d2fd4
+  md5: 4b99d6a6c74ffef792be3ad30f377306
+  depends:
+  - affine
+  - attrs
+  - certifi
+  - click >=4
+  - click-plugins
+  - cligj >=0.5
+  - libcxx >=15.0.7
+  - libgdal >=3.7.0,<3.8.0a0
+  - numpy >=1.23.5,<2.0a0
+  - proj >=9.2.0,<9.2.1.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7499485
+  timestamp: 1684815760672
+- conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+  sha256: 41e7d30a097d9b060037f0c6a2b1d4c4ae7e942c06c943d23f9d481548478568
+  md5: f17f77f2acf4d344734bda76829ce14e
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 255870
+  timestamp: 1679532707590
+- conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.10.1-py311h16c3c4d_3.conda
+  sha256: 281958d583923b2c079aedffe257f94f4b1238ec959b0ebfbfc2788e7846dae9
+  md5: a3ba8e96a7511ef8c3b61d28a68da6ed
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=15.0.7
+  - libgfortran >=5
+  - libgfortran5 >=12.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy >=1.23.5,<1.27
+  - numpy >=1.23.5,<2.0a0
+  - pooch
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libopenblas <0.3.26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16109095
+  timestamp: 1683902151776
+- conda: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.1-py311heb7bb94_1.conda
+  sha256: 848a94f16c23ff829929507ed168c771571f7edf0de2b7a9085d13519c89ea91
+  md5: 61b210c25916fdcea10b814df0ff842a
+  depends:
+  - geos >=3.11.2,<3.11.3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 470147
+  timestamp: 1679081929601
+- conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
+  sha256: 575915dc13152e446a84e2f88de70a14f8b6af1a870e708f9370bd4be105583b
+  md5: 4320a8781f14cd959689b86e349f3b73
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 34657
+  timestamp: 1678534768395
+- conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.42.0-h2b0dec6_0.conda
+  sha256: ff811793c293cf861746c95fe97ad5384e917bf473337d05283afdadb3b50bc9
+  md5: 6c22b83608a6e3bd324ab29d3092592f
+  depends:
+  - libsqlite 3.42.0 h58db7d2_0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.3,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 874057
+  timestamp: 1684265240963
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tiledb-2.13.2-h8b9cbf0_0.conda
+  sha256: 0165e3597571c80b5d50af7917a048ffe70e7419cd91caf4bf69999de5a0e01d
+  md5: a10738d4788cf6b0b0d9bff2e324b942
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - curl
+  - libcxx >=14.0.6
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.0.7,<4.0a0
+  - zlib
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 4588802
+  timestamp: 1673637065532
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.12-h5dbffcc_0.tar.bz2
+  sha256: 331aa1137a264fd9cc905f04f09a161c801fe504b93da08b4e6697bd7c9ae6a6
+  md5: 8e9480d9c47061db2ed1b4ecce519a7f
+  depends:
+  - libzlib >=1.2.11,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3531016
+  timestamp: 1645032719565
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.3.2-py311h2725bcf_0.conda
+  sha256: da54e182c99e46225348192b63fc8d0d02a7fc5d405f4548828cf627705b8bc3
+  md5: 276fe4341e39dcd9d9d33ca18140d2e7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 842594
+  timestamp: 1684150681154
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tzcode-2023c-hb7f2c08_0.conda
+  sha256: 0d4b111314bea267454f48691debc1ff4c0ce8cb91491d2be30381de498ac59e
+  md5: a7ba8e96323b9d8ce4f0edc4f4dab27f
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62711
+  timestamp: 1680049599804
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xerces-c-3.2.4-h90c7484_2.conda
+  sha256: f10fb724de7e096ff325b3ae8caa270183bfd65ec407e39d91c1070d664dfb5d
+  md5: 745470e9f5d284dec2ed37b1fa8b3af3
+  depends:
+  - icu >=72.1,<73.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 1361926
+  timestamp: 1679377533153
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
+  sha256: 8a2e398c4f06f10c64e69f56bcf3ddfa30b432201446a0893505e735b346619a
+  md5: 9566b4c29274125b0266d0177b5eb97b
+  license: MIT
+  license_family: MIT
+  size: 13071
+  timestamp: 1684638167647
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2
+  sha256: 485421c16f03a01b8ed09984e0b2ababdbb3527e1abf354ff7646f8329be905f
+  md5: 86ac76d6bf1cbb9621943eb3bd9ae36e
+  license: MIT
+  license_family: MIT
+  size: 17225
+  timestamp: 1610071995461
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+  sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
+  md5: a72f9d4ea13d55d745ff1ed594747f10
+  license: LGPL-2.1 and GPL-2.0
+  size: 238119
+  timestamp: 1660346964847
+- conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+  sha256: 5301417e2c8dea45b401ffee8df3957d2447d4ce80c83c5ff151fc6bfe1c4148
+  md5: d7e08fcf8259d742156188e8762b4d20
+  license: MIT
+  license_family: MIT
+  size: 84237
+  timestamp: 1641347062780
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.4-he49afe7_1.tar.bz2
+  sha256: 991e2b42908c5793fe42a78272e6bd5e6412636274500b846991d0f3e5126952
+  md5: 1972d732b123ed04b60fd21e94f0b178
+  depends:
+  - libcxx >=11.1.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 320838
+  timestamp: 1629967617192
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-hfd90126_4.tar.bz2
+  sha256: 9db69bb5fc3e19093b550e25d1158cdf82f4f8eddc1f80f8d7d9de33eb8535a4
+  md5: be90e6223c74ea253080abae19b3bdb1
+  depends:
+  - libzlib 1.2.13 hfd90126_4
+  license: Zlib
+  license_family: Other
+  size: 95671
+  timestamp: 1665759855085
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.2-hbc0c0cd_6.conda
+  sha256: f845dafb0b488703ce81e25b6f27ed909ee9061b730c172e6b084fcf7156231f
+  md5: 40a188783d3c425bdccc9ae9104acbb8
+  depends:
+  - libcxx >=14.0.6
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 408722
+  timestamp: 1674245014688
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311he2be06e_3.tar.bz2
+  sha256: eab9a2bfad356f0055edadc2048406004e1d46107176986f6df59cf5dfeb81ac
+  md5: 268c0ecc4ad9f4d47f69785a6254334c
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 34526
+  timestamp: 1666851140553
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.4-hc338f07_0.conda
+  sha256: b1d1f554a9bcfd67f444335933fe3c5b2014fe9c812d1690419db42f5760ee31
+  md5: ff8fa8606741993b6bf57e411293f446
+  depends:
+  - libcxx >=15.0.7
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33470
+  timestamp: 1684235351868
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/boost-cpp-1.78.0-h9ed8d21_3.conda
+  sha256: d1e35b76ca4cf498f8fe0dcef0cfb36ff397ef61c4a90d7abfef5db71cb87f9c
+  md5: 1c6a6d302de4fb2fda2481400564bf10
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=72.1,<73.0a0
+  - libcxx >=12.0.1
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  constrains:
+  - libboost <0
+  license: BSL-1.0
+  size: 15200015
+  timestamp: 1680720661432
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.0.9-h1a8c8d9_8.tar.bz2
+  sha256: f97debd05c2caeeefba22e0b71173f1fff99c1e5e66e6e9caa91c1c66eb59741
+  md5: e2a5e381ddd6529eb62e7710270b2ec5
+  depends:
+  - brotli-bin 1.0.9 h1a8c8d9_8
+  - libbrotlidec 1.0.9 h1a8c8d9_8
+  - libbrotlienc 1.0.9 h1a8c8d9_8
+  license: MIT
+  license_family: MIT
+  size: 19012
+  timestamp: 1666789078281
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.0.9-h1a8c8d9_8.tar.bz2
+  sha256: d171637710bffc322b35198c03bcfd3d04f454433e845138e5120729f8941996
+  md5: f212620a4f3606ff8f800b8b1077415a
+  depends:
+  - libbrotlidec 1.0.9 h1a8c8d9_8
+  - libbrotlienc 1.0.9 h1a8c8d9_8
+  license: MIT
+  license_family: MIT
+  size: 18083
+  timestamp: 1666789045741
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h3422bc3_4.tar.bz2
+  sha256: a3efbd06ad1432edb0163c48225421f34c2660f5cc002283a8d27e791320b549
+  md5: fc76ace7b94fb1f694988ab1b14dd248
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 151850
+  timestamp: 1618862645215
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.19.1-hb547adb_0.conda
+  sha256: fc9d0fcfb30c20c0032b294120b6ba9c01078ddb372c34dd491214c598aecc06
+  md5: e7fc7430440d255e3a9c7e5a52f7b294
+  license: MIT
+  license_family: MIT
+  size: 101998
+  timestamp: 1684783026131
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.5.7-hf0a4a13_0.conda
+  sha256: 27214b54d1cb9a92455689e20d0007a0ff9ace99b853867d53a05a04c24bdae5
+  md5: a8387be82224743cf849fb907790b91a
+  license: ISC
+  size: 148524
+  timestamp: 1683451885269
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.16.0-h1e71087_1016.conda
+  sha256: 318cad8770aa5aa14a5808e1d6b39458e11d2c2411254e795269986467f864ea
+  md5: be77f5630cabe6a116a033f6fd241aa2
+  depends:
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=72.1,<73.0a0
+  - libglib >=2.76.2,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - pixman >=0.40.0,<1.0a0
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 996907
+  timestamp: 1684639742046
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cartopy-0.21.1-py311hbf64cf6_1.conda
+  sha256: 09997aa511121b4c7876f45babeeaec0c67e1974c079d958dfcc8e2a5c022691
+  md5: 980dc730110f05d52215b54382d7ec42
+  depends:
+  - geos >=3.11.2,<3.11.3.0a0
+  - libcxx >=14.0.6
+  - matplotlib-base >=3.1
+  - numpy >=1.23.5,<2.0a0
+  - pyproj >=3.0.0
+  - pyshp >=2.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - scipy >=0.10
+  - shapely >=1.6.4
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 1700840
+  timestamp: 1679098522555
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.15.1-py311hae827db_3.conda
+  sha256: 28bf7f7c1ded35d270660183990056b6192e3fe06eaebb1043fd4b97ccea2b98
+  md5: bb7a416f8871a6cf6ddec76450d6cf7b
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 278614
+  timestamp: 1671179791632
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cfitsio-4.2.0-h2f961c4_0.conda
+  sha256: f9068349eacf0fcf26fcebba89185eb97d35cdc0ac74fbd7ed7d7eb307e717ab
+  md5: 10112a8b1b7b479c7d4e87c9ade892eb
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=7.86.0,<9.0a0
+  - libgfortran >=5
+  - libgfortran5 >=11.3.0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: LicenseRef-fitsio
+  size: 748569
+  timestamp: 1668757847978
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.2-py311h4add359_1.tar.bz2
+  sha256: d604792a0d0fdb5c265e4defb06e364cb6145446023efc66ae9e9bbf5b963df5
+  md5: 63787fcb6a9ece277ae4a0160d83aacb
+  depends:
+  - numpy >=1.23.4,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 219023
+  timestamp: 1666834415610
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.0.7-py311hd6ee22a_0.conda
+  sha256: cee9e0623b657b6c6dfdd75e38577874cb3f340ccb3b79efa1fb14f25e50a5bd
+  md5: db6e99f9f62455712d051b671a8363fb
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.16
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 210730
+  timestamp: 1673634165290
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/curl-8.1.2-h912dcd9_0.conda
+  sha256: 5e9706d62fdfa208624549a5301ea53f361e377fc4b4019934a2cd9b5a07e25b
+  md5: fff3198e9cd788a52bf99a64c8212c85
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libcurl 8.1.2 h912dcd9_0
+  - libssh2 >=1.10.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.0,<4.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 146388
+  timestamp: 1685448219427
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.6.7-py311ha397e9f_0.conda
+  sha256: e0b01eece2a1155d1b5a34dfde53829c5cb96b96179cff9a9bedb8d1f0d34e9e
+  md5: 28d404816181a50fa74b8cc6c8fd5ca0
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2273997
+  timestamp: 1680756057837
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.5.0-hb7217d7_1.conda
+  sha256: 9f06afbe4604decf6a2e8e7e87f5ca218a3e9049d57d5b3fcd538ca6240d21a0
+  md5: 624fa0dd6fdeaa650b71a62296fdfedf
+  depends:
+  - libexpat 2.5.0 hb7217d7_1
+  license: MIT
+  license_family: MIT
+  size: 117851
+  timestamp: 1680190940654
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.14.2-h82840c6_0.conda
+  sha256: 7094917fc6758186e17c61d8ee8fd2bbbe9f303b4addac61d918fa415c497e2b
+  md5: f77d47ddb6d3cc5b39b9bdf65635afbb
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 237668
+  timestamp: 1674829263740
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.39.4-py311heffc1b2_0.conda
+  sha256: 343efa9d61de717343f5e2519c8432faa2d9b33bd485576506db9f260cb41cbe
+  md5: 93af500e83b7a5711edb43c2092e80af
+  depends:
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2554322
+  timestamp: 1683741276268
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hd633e50_1.conda
+  sha256: 9f20ac782386cca6295cf02a07bbc6aedc4739330dc9caba242630602a9ab7f4
+  md5: 33ea6326e26d1da25eb8dfa768195b82
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only and LicenseRef-FreeType
+  size: 572579
+  timestamp: 1669233072570
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-1.0.6-h1a8c8d9_1.tar.bz2
+  sha256: c151bc1c59d986bc89802715d57783e8536e5450eb65a1ee389c0ff2139724ee
+  md5: f9e99c94afe28d7558a5dd106fef0936
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 44788
+  timestamp: 1662819616581
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.11.2-hb7217d7_0.conda
+  sha256: f63f2780239486808f1a305fb324f08afc0b0ad6ecd7901557ea51102ba788a8
+  md5: 466a2932ae9d2b7a903e82125d72ecfe
+  depends:
+  - libcxx >=14.0.6
+  license: LGPL-2.1-only
+  size: 1219632
+  timestamp: 1679048825486
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/geotiff-1.7.1-hea8fa61_8.conda
+  sha256: 948e36a58632d2e785e98cb9b9b1b16996bf14e6031a9776392a5bbf38ba3bf0
+  md5: 111f3fc178ad06b3c7c0b844163427c4
+  depends:
+  - libcxx >=14.0.6
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - proj >=9.2.0,<9.2.1.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 116366
+  timestamp: 1679226610620
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.21.1-h0186832_0.tar.bz2
+  sha256: 093b2f96dc4b48e4952ab8946facec98b34b708a056251fc19c23c3aad30039e
+  md5: 63d2ff6fddfa74e5458488fd311bf635
+  depends:
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 4021036
+  timestamp: 1665674192347
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.1-h1a8c8d9_3.conda
+  sha256: dbf1e431d3e5e03f8eeb77ec08a4c5d6d5d9af84dbef13d4365e397dd389beb8
+  md5: f39a05d3dbb0e5024b7deabb2c0993f1
+  license: MIT
+  license_family: MIT
+  size: 71963
+  timestamp: 1678718059849
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h8111dcc_6.conda
+  sha256: d9467c97edcb5b26e8022b55e7a55aa41105d4d932b242314b1f676fa0039ec8
+  md5: 24b5b61bc36935865d904d0d6a43a4ae
+  depends:
+  - libcxx >=14.0.6
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 736874
+  timestamp: 1678293056334
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.0-nompi_h6b85c65_103.conda
+  sha256: 9e6721e487b2b5d700312897adaf19caa6a87da15f221bf06d8cfa05d29718f9
+  md5: faf772fbfc8c89d2874e32cbee498aa5
+  depends:
+  - libaec >=1.0.6,<2.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  - libgfortran >=5
+  - libgfortran5 >=11.3.0
+  - libgfortran5 >=12.2.0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.0.8,<4.0a0
+  license: LicenseRef-HDF5
+  license_family: BSD
+  size: 3182567
+  timestamp: 1678273604577
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-72.1-he12128b_0.conda
+  sha256: 997835c56e899f4717b6707ab0734c27e7cdd8c735c952334314a7c9d59808e1
+  md5: d1a11dfc54168a07856dbf87f393ca82
+  license: MIT
+  license_family: MIT
+  size: 11700891
+  timestamp: 1679315525149
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/json-c-0.16-hc449e50_0.tar.bz2
+  sha256: 3031e38c69df65fb1486b283212db90038fd59e10ecba56cbd3efa2a86b41b5b
+  md5: 0091e6c603f58202c026d3e63fc93f39
+  license: MIT
+  license_family: MIT
+  size: 73740
+  timestamp: 1649932688111
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jupyter_core-5.3.0-py311h267d04e_0.conda
+  sha256: ee8a92dedf34be869eb335fa5cb5e3a6457022bacb37c731103d71f8398cda37
+  md5: f194127e283c95eb0c40bbe6a7e0311a
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 115675
+  timestamp: 1678994818293
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/kealib-1.5.1-hc851fbe_3.conda
+  sha256: 617082b7ca15421712f2d2d96c5ec5923681d86e189d06036a316205fb22607e
+  md5: 5c912e3bda99bcb4e98d80c320a8d74e
+  depends:
+  - hdf5 >=1.14.0,<1.14.1.0a0
+  - libcxx >=15.0.7
+  license: MIT
+  license_family: MIT
+  size: 143330
+  timestamp: 1684390223508
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.4-py311hd6ee22a_1.tar.bz2
+  sha256: 9bfa08cc2cac4458537ec7dbf78fdd30379cf46a236d586117e803aecf707671
+  md5: aea430ca7df231e9d17dba5dc7ba52b5
+  depends:
+  - libcxx >=14.0.4
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62973
+  timestamp: 1666806157641
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.20.1-h69eda48_0.conda
+  sha256: 80094682db47468befef8e14a8a2ccc82cf71d6cf23bfa5d25c4de1df56e3067
+  md5: a85db53e45b1173f270fc998dd40ec03
+  depends:
+  - libcxx >=14.0.6
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.0.7,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1094005
+  timestamp: 1671091920523
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.15-hd835a16_1.conda
+  sha256: e15f3ac072a19e3ce5ff04c171b7f931e6a6c0bf3c394329b72cfb6cc69fbdbd
+  md5: 945a7b2d3fecee7299855bc0257f6f33
+  depends:
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 206190
+  timestamp: 1678213721993
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+  sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
+  md5: de462d5aacda3b30721b512c5da4e742
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 215721
+  timestamp: 1657977558796
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.0.6-hb7217d7_1.conda
+  sha256: 9a2209a30923728fd9c430695a2fea9274ac6d357e6bdfa4c7b5aa52122d9e2c
+  md5: 4f04770bf6f12d22fb6c1d91a04e0c8c
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 28016
+  timestamp: 1673801257939
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.6.2-h82b9b87_1.conda
+  sha256: 9e8e6abf0bbfe1851725fd75be22382b9f2d08e1633d660201ce56d42e0cd90f
+  md5: 0d82ec4537f2f581332087aac6e15ce1
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libiconv >=1.17,<2.0a0
+  - libxml2 >=2.11.3,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - lzo >=2.10,<3.0a0
+  - openssl >=3.1.0,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 799662
+  timestamp: 1684325143934
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-17_osxarm64_openblas.conda
+  sha256: 76c68d59491b449b7608fb5e4a86f3c292c01cf487ce47288a22fc7001a6b150
+  md5: 2597bd39632ec57ef3f5ac14865dca09
+  depends:
+  - libopenblas >=0.3.23,<0.3.24.0a0
+  - libopenblas >=0.3.23,<1.0a0
+  constrains:
+  - libcblas 3.9.0 17_osxarm64_openblas
+  - liblapacke 3.9.0 17_osxarm64_openblas
+  - blas * openblas
+  - liblapack 3.9.0 17_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14715
+  timestamp: 1685931044178
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.0.9-h1a8c8d9_8.tar.bz2
+  sha256: 1bd70570aee08fe0274dd46879d0b4c36c662c18d3afc03c41c375c84658af88
+  md5: 84eb0c3c995a865079080d092e4a3c06
+  license: MIT
+  license_family: MIT
+  size: 66814
+  timestamp: 1666788942669
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.0.9-h1a8c8d9_8.tar.bz2
+  sha256: a0a52941eb59369a8b33b01b41bcf56efd313850c583f4814e2db59448439880
+  md5: 640ea7b788cdd0420409bd8479f023f9
+  depends:
+  - libbrotlicommon 1.0.9 h1a8c8d9_8
+  license: MIT
+  license_family: MIT
+  size: 31712
+  timestamp: 1666788976088
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.0.9-h1a8c8d9_8.tar.bz2
+  sha256: c5f65062cd41d5f5fd93eadd276885efbe7ce7c9346155852d4f5b619f8a166f
+  md5: 572907b78be867937c258421bc0807a8
+  depends:
+  - libbrotlicommon 1.0.9 h1a8c8d9_8
+  license: MIT
+  license_family: MIT
+  size: 305205
+  timestamp: 1666789010699
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-17_osxarm64_openblas.conda
+  sha256: d5828db3a507790582815aaf44d54ed6bb07dfce4fd25f92e34b2eb31378a372
+  md5: cf6f9ca46e3db6b2437024df14046b48
+  depends:
+  - libblas 3.9.0 17_osxarm64_openblas
+  constrains:
+  - liblapacke 3.9.0 17_osxarm64_openblas
+  - blas * openblas
+  - liblapack 3.9.0 17_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14629
+  timestamp: 1685931056087
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.1.2-h912dcd9_0.conda
+  sha256: 5d5bbc7a6eb363b2df85c5df32d34295346fc8b4d9e3754bbaf2af3e80422fab
+  md5: af01aa21cd4bb0cf519cda6bcec83fc5
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.10.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.0,<4.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 345816
+  timestamp: 1685448186761
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.5-h4653b0c_0.conda
+  sha256: 14452e6dab03eb5260101cca926b4b96764f28726e5965067d0ba0101949e9e4
+  md5: d36fb4372ff02b2d1596366ee1d984bc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1160493
+  timestamp: 1685827582995
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.18-h1a8c8d9_0.conda
+  sha256: a7ef4fd6ca62619397af4f434e69b96dfbc2c4e13080475719a8371bfd73834a
+  md5: 73ebca3d8666fcfcf28abd74b39b99eb
+  license: MIT
+  license_family: MIT
+  size: 48428
+  timestamp: 1679647544992
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+  sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
+  md5: 30e4362988a2623e9eb34337b83e01f9
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 96607
+  timestamp: 1597616630749
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h642e427_1.tar.bz2
+  sha256: eb7325eb2e6bd4c291cb9682781b35b8c0f68cb72651c35a5b9dd22707ebd25c
+  md5: 566dbf70fe79eacdb3c3d3d195a27f55
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 100668
+  timestamp: 1598868103393
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.5.0-hb7217d7_1.conda
+  sha256: 7d143a9c991579ad4207f84c632650a571c66329090daa32b3c87cf7311c3381
+  md5: 5a097ad3d17e42c148c9566280481317
+  constrains:
+  - expat 2.5.0.*
+  license: MIT
+  license_family: MIT
+  size: 63442
+  timestamp: 1680190916539
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+  md5: 086914b672be056eb70fd4285b6783b6
+  license: MIT
+  license_family: MIT
+  size: 39020
+  timestamp: 1636488587153
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-3.7.0-h33c4f09_1.conda
+  sha256: 0ac6a8b92ee8df6ee3f39814397ca72f192516d97cc654b0cdf3aa042fd5eff9
+  md5: 60cd4ca89055b42d14feefd5678fb3a7
+  depends:
+  - blosc >=1.21.4,<2.0a0
+  - cfitsio >=4.2.0,<4.2.1.0a0
+  - freexl >=1.0.6,<2.0a0
+  - geos >=3.11.2,<3.11.3.0a0
+  - geotiff >=1.7.1,<1.8.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.0,<1.14.1.0a0
+  - icu >=72.1,<73.0a0
+  - json-c >=0.16,<0.17.0a0
+  - kealib >=1.5.1,<1.6.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libarchive >=3.6.2,<3.7.0a0
+  - libcurl >=8.1.0,<9.0a0
+  - libcxx >=15.0.7
+  - libdeflate >=1.18,<1.26.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=15.3,<16.0a0
+  - libspatialite >=5.0.1,<5.1.0a0
+  - libsqlite >=3.42.0,<4.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  - libwebp-base >=1.3.0,<2.0a0
+  - libxml2 >=2.11.3,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - openssl >=3.1.0,<4.0a0
+  - pcre2 >=10.40,<10.41.0a0
+  - poppler >=23.5.0,<23.6.0a0
+  - postgresql
+  - proj >=9.2.0,<9.2.1.0a0
+  - tiledb >=2.13.2,<2.14.0a0
+  - xerces-c >=3.2.4,<3.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 8480567
+  timestamp: 1684604660148
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-12_2_0_hd922786_31.conda
+  sha256: 1abde945c2c7377aec9f2f648d9cc1fcb5f818a1e0caf53f8188b1182cbc1332
+  md5: dfc3dff1ce831c8e821f19d5d218825a
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 160260
+  timestamp: 1678488316051
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-12.2.0-h0eea778_31.conda
+  sha256: 375b6ebafffcc1b0e377559b5ba7cb723634a88b77513ad158982d98ff98c32b
+  md5: 244a7665228221cc951d5126b8bc1465
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_31
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1049187
+  timestamp: 1678488257002
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.76.3-h24e9cb9_0.conda
+  sha256: 5b31f80d89224fbfbd0c46b313f6a8d3c43f20f2ae57613cd25d46524a3ca23d
+  md5: 30b160e9e8ca46b28491ca85eab61dce
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libcxx >=15.0.7
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - pcre2 >=10.40,<10.41.0a0
+  constrains:
+  - glib 2.76.3 *_0
+  license: LGPL-2.1-or-later
+  size: 2519808
+  timestamp: 1684848541134
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-he4db4b2_0.tar.bz2
+  sha256: 2eb33065783b802f71d52bef6f15ce0fafea0adc8506f10ebd0d490244087bec
+  md5: 686f9c755574aa221f29fbcf36a67265
+  license: GPL and LGPL
+  size: 1407036
+  timestamp: 1652700956112
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-2.1.5.1-h1a8c8d9_0.conda
+  sha256: bda32077e0024630b2348dc1eabc21246b999ece3789e45e6f778c378ec77f08
+  md5: cd9d6c05ca2e993429a90496ab7e1b99
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG, modified 3-clause BSD and zlib
+  size: 426518
+  timestamp: 1678128003762
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libkml-1.3.0-h41464e4_1015.tar.bz2
+  sha256: 0f5d466f34bd9727063e4ec45884c6a6402df5f95104b867f6cfa6cbee59b815
+  md5: 6404f2ec1ee91e48175d9e5ee1dbca5f
+  depends:
+  - boost-cpp >=1.78.0,<1.78.1.0a0
+  - expat >=2.4.8,<3.0a0
+  - libcxx >=14.0.4
+  - libzlib >=1.2.12,<2.0.0a0
+  - zlib >=1.2.12,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 474716
+  timestamp: 1662843233605
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-17_osxarm64_openblas.conda
+  sha256: 7e32d178639c5bcaac4b654438aa364eec8a42f108bc592dda8e52a432b0cdb4
+  md5: d93cc56c1467a5bcf6a4c9c0be469114
+  depends:
+  - libblas 3.9.0 17_osxarm64_openblas
+  constrains:
+  - libcblas 3.9.0 17_osxarm64_openblas
+  - liblapacke 3.9.0 17_osxarm64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14640
+  timestamp: 1685931066631
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_3.conda
+  sha256: 905f9084737336c4232c25698e0ac16f23f3d9f541647c9874e8392cbcf9e9cd
+  md5: 51d95b4036d6f7695b7dee38ea1792a6
+  depends:
+  - libcxx >=15
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 20569776
+  timestamp: 1685676531181
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnetcdf-4.9.2-nompi_h0a2dbf5_105.conda
+  sha256: 1dfef490b860e22aae61e84c736b459e2ada983ef83cf654a83b2835ee52293e
+  md5: c09f8b8405fbbc9b2fc614d47f59a2dd
+  depends:
+  - blosc >=1.21.4,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - curl
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 * nompi_*
+  - hdf5 >=1.14.0,<1.14.1.0a0
+  - libcxx >=15.0.7
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libxml2 >=2.11.3,<2.14.0a0
+  - libzip >=1.9.2,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 701769
+  timestamp: 1684496958535
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.52.0-hae82a92_0.conda
+  sha256: 1a3944d6295dcbecdf6489ce8a05fe416ad401727c901ec390e9200a351bdb10
+  md5: 1d319e95a0216f801293626a00337712
+  depends:
+  - c-ares >=1.18.1,<2.0a0
+  - libcxx >=14.0.6
+  - libev >=4.33,<4.34.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.0.8,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 564295
+  timestamp: 1677678452375
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.23-openmp_hc731615_0.conda
+  sha256: 7f88475228d306962493a3f1c52637187695f7c9716a68a75e24a8aa910be69a
+  md5: a40b73e171a91527c79fb1c8b10e3312
+  depends:
+  - libgfortran >=5
+  - libgfortran5 >=11.3.0
+  - llvm-openmp >=14.0.6
+  constrains:
+  - openblas >=0.3.23,<0.3.24.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2732539
+  timestamp: 1681398430140
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.39-h76d750c_0.conda
+  sha256: 21ab8409a8e66f9408b96428c0a36a9768faee9fe623c56614576f9e12962981
+  md5: 0078e6327c13cfdeae6ff7601e360383
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: zlib-acknowledgement
+  size: 259412
+  timestamp: 1669075883972
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-15.3-h7126958_1.conda
+  sha256: 4529f6bd6308df510ebb7493fbbfba533a13f77bdee9785b0b029e4cef194519
+  md5: ae13d3547e9d21beb88e42afd0c820cf
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.0,<3.2.0a0
+  license: PostgreSQL
+  size: 2415588
+  timestamp: 1684452698134
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/librttopo-1.1.0-h6ecf6d2_13.conda
+  sha256: bb23c6a4763c39a614028b5b29adebaa935498100c283519a79ababe801e5961
+  md5: 3ff4df203f1f14bedbca5ec421b5d92b
+  depends:
+  - geos >=3.11.2,<3.11.3.0a0
+  - libcxx >=14.0.6
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 191374
+  timestamp: 1679087626667
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.18-h27ca646_1.tar.bz2
+  sha256: 1d95fe5e5e6a0700669aab454b2a32f97289c9ed8d1f7667c2ba98327a6f05bc
+  md5: 90859688dbca4735b74c02af14c4c793
+  license: ISC
+  size: 324912
+  timestamp: 1605135878892
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libspatialite-5.0.1-h229630b_26.conda
+  sha256: b07f9e51ffd5fa223df875aabb5e21a21ccd720db86a4249482f4ee2eee284c9
+  md5: 067be330feaf4961886d36601fbcab6c
+  depends:
+  - freexl >=1.0.6,<2.0a0
+  - geos >=3.11.2,<3.11.3.0a0
+  - libcxx >=15.0.7
+  - libiconv >=1.17,<2.0a0
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.42.0,<4.0a0
+  - libxml2 >=2.11.3,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - proj >=9.2.0,<9.2.1.0a0
+  - sqlite
+  - zlib
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 2946554
+  timestamp: 1684287647589
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.42.0-hb31c410_0.conda
+  sha256: 120913cf0fb694546fbaf95dff211ac5c1e3e91bc69c73350891a05dc106355f
+  md5: 6ae1bbf3ae393a45a75685072fffbe8d
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Unlicense
+  size: 822883
+  timestamp: 1684265273102
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
+  sha256: bb57d0c53289721fff1eeb3103a1c6a988178e88d8a8f4345b0b91a35f0e0015
+  md5: 029f7dc931a3b626b94823bc77830b01
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 255610
+  timestamp: 1685837894256
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.5.0-h4f7d55c_6.conda
+  sha256: c26d28379e585dcdcc6888841135cbe007f1500e270cda9a8c6a4158004f7e1b
+  md5: 40c2f9692a179c17488a99e135cd17fa
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.18,<1.26.0a0
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libwebp-base >=1.3.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  size: 348421
+  timestamp: 1679672422743
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.3.0-h1a8c8d9_0.conda
+  sha256: f863700d96c722414d2406cfa6108f6d363068112b88d6b0a4b92e5724439070
+  md5: c316f1e4a833d49672f1df3bc015a115
+  constrains:
+  - libwebp 1.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 265954
+  timestamp: 1678666651799
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.15-hf346824_0.conda
+  sha256: 6eaa87760ff3e91bb5524189700139db46f8946ff6331f4e571e4a9356edbb0d
+  md5: 988d5f86ab60fa6de91b3ee3a88a3af9
+  depends:
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 334770
+  timestamp: 1682082734262
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.11.4-he3bdae6_0.conda
+  sha256: 8f833df2746b013af73c41621c4b4bf4492de6f4c38352a9b6df21aa0db56ed6
+  md5: 3741cfda603726c135ffe37bb83e1ca0
+  depends:
+  - icu >=72.1,<73.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 616595
+  timestamp: 1684627412037
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzip-1.9.2-h76ab92c_1.tar.bz2
+  sha256: f8532163164fd6c1063f49225acf0c4919eceaa5e464f2de26095e396909cfaf
+  md5: eee3b4ab0b5b71fbda7900785f3a46fa
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.12,<2.0.0a0
+  - openssl >=3.0.5,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 117229
+  timestamp: 1660347349764
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h03a7124_4.tar.bz2
+  sha256: a1bf4a1c107838fea4570a7f1750306d65d84fcf2913d4e0d30b4db785e8f223
+  md5: 780852dc54c4c07e64b276a97f89c162
+  constrains:
+  - zlib 1.2.13 *_4
+  license: Zlib
+  license_family: Other
+  size: 51037
+  timestamp: 1665763965480
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-16.0.5-h1c12783_0.conda
+  sha256: 8fa97c774bd670d5322b5e891d14f1fbe65704c6b2ca6964302e753b81b4d383
+  md5: ca737da88c0732ccce43b67611516c80
+  constrains:
+  - openmp 16.0.5|16.0.5.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 268968
+  timestamp: 1685774825614
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.40.0-py311hea943cd_0.conda
+  sha256: 4a1bf57f67d056afe3411f5512b866c5671ebaedce813d0441ff37a913cabcff
+  md5: 6a58db6f9e11a3d3e6bc5d1075760d97
+  depends:
+  - libcxx >=15.0.7
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 330183
+  timestamp: 1684447529644
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+  sha256: fc343b8c82efe40819b986e29ba748366514e5ab94a1e1138df195af5f45fa24
+  md5: 45505bec548634f7d05e02fb25262cb9
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 141188
+  timestamp: 1674727268278
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h642e427_1000.tar.bz2
+  sha256: ae029e5c16893071d29a11ddbfdbdb01b2ebf10d1785f54370934439d8b71817
+  md5: ddab5f96f5573a9bd5e24f9994fd6ec9
+  license: GPL v2+
+  license_family: GPL2
+  size: 157236
+  timestamp: 1597683217947
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.3-py311heffc1b2_0.conda
+  sha256: 3d8fc172185c479b9df33259300bd204e40f13d958c030249cd35952709d61bf
+  md5: 64767fbeb9e55231662b75405f9e01e4
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26729
+  timestamp: 1685769407109
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.7.1-py311h99a5f44_0.conda
+  sha256: 0366b4d905b1cae1e606b91bd5a65e6da83bf80ed8b3aa2085a6c988d2f4c104
+  md5: 5e1ec271eb52ff1f76b55b23aae88a4f
+  depends:
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.20
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  license: LicenseRef-PSF-2.0 and CC0-1.0
+  license_family: PSF
+  size: 7644068
+  timestamp: 1678136138032
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h7ea286d_0.conda
+  sha256: 017e230a1f912e15005d4c4f3d387119190b53240f9ae0ba8a319dd958901780
+  md5: 318337fb9d0c53ba635efb7888242373
+  license: X11 AND BSD-3-Clause
+  size: 799196
+  timestamp: 1686077139703
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/netcdf4-1.6.4-nompi_py311h6a8bb3c_100.conda
+  sha256: efa21215fbb88674e05d04866e7727c9aea4963a8b9494305cab7189319138cc
+  md5: d86a4d7e1f85492d0690848dff7348ba
+  depends:
+  - certifi
+  - cftime
+  - hdf5 >=1.14.0,<1.14.1.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 442595
+  timestamp: 1686026521453
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.35-hb7217d7_0.conda
+  sha256: 35959d36ea9e8a2c422db9f113ee0ac91a9b0c19c51b05f75d0793c3827cfa3a
+  md5: f81b5ec944dbbcff3dd08375eb036efa
+  depends:
+  - libcxx >=14.0.6
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 220745
+  timestamp: 1669785182058
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.89-h789eff7_0.conda
+  sha256: 483b3d89e2ed179990a79d858cb4ee8fd5e860c3b85f1a84540a798d89968b82
+  md5: dbb6be9468b513522e0b03d30cc7f1fd
+  depends:
+  - libcxx >=14.0.6
+  - libsqlite >=3.40.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - nspr >=4.35,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1734792
+  timestamp: 1678488388531
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.57.0-py311hbf3c4e2_1.conda
+  sha256: 74996ba00b1384d7e37280bba8d946e7aff918462cfefa138c6c90ce379dbe69
+  md5: eed4a97c51d880daf7e63ab01393f1e8
+  depends:
+  - libcxx >=15.0.7
+  - llvm-openmp >=15.0.7
+  - llvm-openmp >=16.0.4
+  - llvmlite >=0.40.0,<0.41.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libopenblas >=0.3.18, !=0.3.20
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.25
+  - cuda-version >=10.2
+  - cuda-python >=11.6
+  - scipy >=1.0
+  - tbb >=2021.9.0,<2022.0a0
+  - cudatoolkit >=10.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5518955
+  timestamp: 1685545660857
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.24.3-py311hb8f3215_0.conda
+  sha256: 2a7a9ffa539b041292326b84b39e8ab04d133f62fed48a9769664352d8223aaa
+  md5: 2778fb600d92e5c67b9ade981a1c72e8
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=15.0.7
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6694456
+  timestamp: 1682211125931
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.0-hbc2ba62_2.conda
+  sha256: 2bb159e385e633a08cc164f50b4e39fa465b85f54c376a5c20aa15f57ef407b3
+  md5: c3e184f0810a4614863569488b1ac709
+  depends:
+  - libcxx >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 307087
+  timestamp: 1671435439914
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.1.1-h53f4e23_1.conda
+  sha256: 898aac8f8753385e9cd378d539364647d1deb9396032b7c1fd8f0f08107e020b
+  md5: 7451b96ed28b5fd02f0df32689327755
+  depends:
+  - ca-certificates
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2223980
+  timestamp: 1685517736396
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.0.2-py311h9e438b8_0.conda
+  sha256: 99cdf3aab7d281f6b5960c983585b0a7363a5f014bae57c002cf56151f52efcb
+  md5: 2e22a600cb9d8f539d994079dbcd25ac
+  depends:
+  - libcxx >=15.0.7
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14163047
+  timestamp: 1685344277634
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandoc-2.19.2-hce30654_2.conda
+  sha256: 43c0560c691de194d23d08c4edcc1c45a639c0d540043dc99386337944f10d10
+  md5: e79494b8d990189fe4701f498f99cd8b
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 14592423
+  timestamp: 1678226936520
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.40-hb34f9b4_0.tar.bz2
+  sha256: 93503b5e05470ccc87f696c0fdf0d47938e0305b5047eacb85c15d78dcf641fe
+  md5: 721b7288270bafc83586b0f01c2a67f2
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.12,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1161688
+  timestamp: 1665563317371
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-9.5.0-py311h095fde6_1.conda
+  sha256: a3418495bebfd9afbe0687d4a07bbbbd2521f1d7bcd39d3ef5043e3a01365f95
+  md5: 69dc77378d6da40743025caf095bfeaf
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  - libwebp-base >=1.3.0,<2.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.12,<8.7.0a0
+  license: LicenseRef-PIL
+  size: 46299841
+  timestamp: 1684654701974
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.40.0-h27ca646_0.tar.bz2
+  sha256: a3bde72b3f9344ede1a189612d997f775b503a8eec61fb9720d18551f3c71080
+  md5: 0cedfe37c9aee28f5e926a870965466a
+  license: MIT
+  license_family: MIT
+  size: 291804
+  timestamp: 1604342450513
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/poppler-23.05.0-h16d8c84_1.conda
+  sha256: b5792867f249da830d97bfa586e814c9fa960a4c57cebe6caa48a7e21c527152
+  md5: 9567f2bd7c592116980c66766addbc6e
+  depends:
+  - boost-cpp >=1.78.0,<1.78.1.0a0
+  - cairo >=1.16.0,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gettext >=0.21.1,<1.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libcurl >=8.0.1,<9.0a0
+  - libcxx >=15.0.7
+  - libglib >=2.76.2,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - nss >=3.89,<4.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - poppler-data
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 1450217
+  timestamp: 1683555393581
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/postgresql-15.3-hb5ad9d5_1.conda
+  sha256: fb17ac7b1843279b9d4c01de8d36fa64e59dcba9db5c696b7ff402036763f292
+  md5: 4eea247142e5d19fb75defbe7cc5e626
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libpq 15.3 h7126958_1
+  - libxml2 >=2.11.3,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tzcode
+  - tzdata
+  - zlib
+  size: 4439118
+  timestamp: 1684452797536
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.2.0-h13f728c_0.conda
+  sha256: 80080a835f2f501d359f4f86dd80fbfebe6c1f6fd881b5b494cb6053dc10b13c
+  md5: 7f1d6f75d9289c58658d8bab52563935
+  depends:
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  - libsqlite >=3.40.0,<4.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2599276
+  timestamp: 1679164858602
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.5-py311he2be06e_0.conda
+  sha256: 0ecdf61a7314171f8abcaa75f2f0d5443c5fe66c0eb146d38428cfb479279888
+  md5: 757782088ac8e0ffc5eb68ae61bf62f9
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 507121
+  timestamp: 1681775539087
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
+  sha256: 9da9e6f5d51dff6ad2e4ee0874791437ba952e0a6249942273f0fedfd07ea826
+  md5: d3f26c6494d4105d4ecb85203d687102
+  license: MIT
+  license_family: MIT
+  size: 5696
+  timestamp: 1606147608402
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-9.2-py311hb702dc4_0.conda
+  sha256: d112c78b0da5558ab761bcddd332c36dbb5203f855eb89eea9b3af1e4142ad84
+  md5: 7cb2cc0921cb5f91ed432acb562cb8b7
+  depends:
+  - libffi >=3.4,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 469492
+  timestamp: 1686129987702
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-9.2-py311hb702dc4_0.conda
+  sha256: 1d2362008a30fcb9e83f2b7918f3a46b05a1796aa6275f775478d63a7a5493de
+  md5: 0e3f993caf313797b913dc21b5c42824
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 9.2.*
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 374505
+  timestamp: 1686136553569
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.5.0-py311h002c271_1.conda
+  sha256: acf891178d21c6698f1b1526ef443db08377f5705bb32a8c86eb2b056afbe6aa
+  md5: 5822592901d52f8ac4e8c51196a2ecd1
+  depends:
+  - certifi
+  - proj >=9.2.0,<9.2.1.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 423546
+  timestamp: 1680063006407
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyrsistent-0.19.3-py311he2be06e_0.conda
+  sha256: e7f104b2a138eb7ae0b9d34b3ba378727e3184cd7c6fb4bcd59c87832552ec8d
+  md5: 2fea901bc50cdd9760eee19376c31abc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 119002
+  timestamp: 1672681926980
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.3-h1456518_0_cpython.conda
+  sha256: 808fff7e53017753eb4fbd6e3faeb192a370cb517309fa3c104a94f505ad6fda
+  md5: 9a215527aee438cb9926e66ea6538caa
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.40.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.3,<7.0a0
+  - openssl >=3.1.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 13429572
+  timestamp: 1680771815441
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-3_cp311.conda
+  sha256: cd2bad56c398e77b7f559314c29dd54e9eeb842896ff1de5078ed3192e5e14a6
+  md5: e1586496f8acd1c9293019ab14dbde9d
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5768
+  timestamp: 1669071844807
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0-py311he2be06e_5.tar.bz2
+  sha256: b5bff9942f942dbd9caea8258c39f625ea00e48d8854ff8b7c38e9d642de1882
+  md5: bd3b5db42251cb399567fa21cea3faf6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 193122
+  timestamp: 1666773008211
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-25.1.0-py311hb1af645_0.conda
+  sha256: 4b94f875f15a225ba56ad3752373382cf07ba1509fd11a85d8de5c1e62850f23
+  md5: d318bf7187261258ab18b5197c57714a
+  depends:
+  - libcxx >=15.0.7
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  size: 507129
+  timestamp: 1685519898208
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rasterio-1.3.7-py311h2979e92_1.conda
+  sha256: b966dbc86239636a11117cf240d1a42a90798d15cacd76b1ba2d2cb8ba4905d0
+  md5: 813f1f03f4773a4e9f8c256280cff254
+  depends:
+  - affine
+  - attrs
+  - certifi
+  - click >=4
+  - click-plugins
+  - cligj >=0.5
+  - libcxx >=15.0.7
+  - libgdal >=3.7.0,<3.8.0a0
+  - numpy >=1.23.5,<2.0a0
+  - proj >=9.2.0,<9.2.1.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7022669
+  timestamp: 1684816020868
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+  sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
+  md5: 8cbb776a2f641b943d413b3e19df71f4
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 250351
+  timestamp: 1679532511311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.10.1-py311h93d07a4_3.conda
+  sha256: 8d3ecffeaa8a809afae7afc76feab777820049fd944743816d891bcf89adca8a
+  md5: 8f3bb9c3e6ee326e15a4ea7fcd9495da
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=15.0.7
+  - libgfortran >=5
+  - libgfortran5 >=12.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy >=1.23.5,<1.27
+  - numpy >=1.23.5,<2.0a0
+  - pooch
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libopenblas <0.3.26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14655325
+  timestamp: 1683902596498
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.1-py311h7f8cfc4_1.conda
+  sha256: 085096fe52e3665d3ab7488808a7a5b793b6510eb0d3147cd1c9e810eed16c80
+  md5: 3de4de569f902df426bd9b45c4b4a039
+  depends:
+  - geos >=3.11.2,<3.11.3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 463652
+  timestamp: 1679082081565
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
+  sha256: dfae03cd2339587871e53b42833657faa4c9e42e3e2c56ee9e32bc60797c7f62
+  md5: ac82a611d1a67a598096ebaa857198e3
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33879
+  timestamp: 1678534968831
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.42.0-h203b68d_0.conda
+  sha256: b6262bbe4ac38aa067e502870de005bea86aa0f4830a8d3c3a8bc026ba04a590
+  md5: 5f135a9d6d44e1a94ac6977dd3c9403b
+  depends:
+  - libsqlite 3.42.0 hb31c410_0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.3,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 812572
+  timestamp: 1684265306411
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tiledb-2.13.2-h9bd36d0_0.conda
+  sha256: 17ff5c38f13f741b61c374839f808aad824e9914d0a89d8451c5b44dd7169dd1
+  md5: d3a88ffe0cbfbd8d3532bb8ef46f0626
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - curl
+  - libcxx >=14.0.6
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.0.7,<4.0a0
+  - zlib
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 3977144
+  timestamp: 1673636951371
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.12-he1e0b03_0.tar.bz2
+  sha256: 9e43ec80045892e28233e4ca4d974e09d5837392127702fb952f3935b5e985a4
+  md5: 2cb3d18eac154109107f093860bd545f
+  depends:
+  - libzlib >=1.2.11,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3382710
+  timestamp: 1645032642101
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.3.2-py311heffc1b2_0.conda
+  sha256: c944be4e34ed3c949273a95397a85a12d7b3a395e44d11332b29129c9eca51ee
+  md5: 81e2c084528c79eb5bfd72ac575a87d1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 840900
+  timestamp: 1684150717610
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tzcode-2023c-h1a8c8d9_0.conda
+  sha256: 0a60ff53272547a0f80862f0a1969a5d1cec16bd2e9098ed5b07d317682a4361
+  md5: 96779d3be996d78411b083f99a51199c
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 63064
+  timestamp: 1680049656503
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xerces-c-3.2.4-h68f8447_2.conda
+  sha256: ccd6a29cfc636ed4301ecc63588928a506003653ebf28b8df3c15b104a9fe98d
+  md5: 519710a1d89559034560dcaffc1eb55d
+  depends:
+  - icu >=72.1,<73.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 1277259
+  timestamp: 1679377003127
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
+  sha256: 02c313a1cada46912e5b9bdb355cfb4534bfe22143b4ea4ecc419690e793023b
+  md5: ca73dc4f01ea91e44e3ed76602c5ea61
+  license: MIT
+  license_family: MIT
+  size: 13667
+  timestamp: 1684638272445
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
+  sha256: d9a2fb4762779994718832f05a7d62ab2dcf6103a312235267628b5187ce88f7
+  md5: 6738b13f7fadc18725965abdd4129c36
+  license: MIT
+  license_family: MIT
+  size: 18164
+  timestamp: 1610071737668
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+  sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
+  md5: 39c6b54e94014701dd157f4f576ed211
+  license: LGPL-2.1 and GPL-2.0
+  size: 235693
+  timestamp: 1660346961024
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+  sha256: 93181a04ba8cfecfdfb162fc958436d868cc37db504c58078eab4c1a3e57fbb7
+  md5: 4bb3f014845110883a3c5ee811fd84b4
+  license: MIT
+  license_family: MIT
+  size: 88016
+  timestamp: 1641347076660
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.4-hbdafb3b_1.tar.bz2
+  sha256: b65624f1e22f095223462807c417001b18ec17ef33a3c7065a19429f4cd42193
+  md5: 49132c08da6545dc68351ff8b659ac8e
+  depends:
+  - libcxx >=11.1.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 318091
+  timestamp: 1629967291905
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h03a7124_4.tar.bz2
+  sha256: 48844c5c911e2ef69571d6ef7181dcfae68df296c546662cb54057baed008949
+  md5: 34161cff4e29cc45e536abf2f13fd6b4
+  depends:
+  - libzlib 1.2.13 h03a7124_4
+  license: Zlib
+  license_family: Other
+  size: 80676
+  timestamp: 1665764084959
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.2-hf913c23_6.conda
+  sha256: 018989ba028e76abc332c246002e8f5975ff123c68f6116a30da8009b14ea88d
+  md5: 8f346953ef63bf5fb482488a659adcf3
+  depends:
+  - libcxx >=14.0.6
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 308282
+  timestamp: 1674244921036
+- conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311ha68e1ae_3.tar.bz2
+  sha256: 641dd4b9d7714d28a2dbc3f80e9f3503acabd5706454d54e8c04578035cb22e7
+  md5: c321cd825b72a2073dfb3f92ce1507fb
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 36208
+  timestamp: 1666851014828
+- conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.4-hdccc3a2_0.conda
+  sha256: e60b07712214092d8c3d31b582d27a149558cbe1ac92de11f8c2a5fe060d023c
+  md5: 6d88663e0ddd031e0d41f2913bbe10cc
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49692
+  timestamp: 1684235633149
+- conda: https://conda.anaconda.org/conda-forge/win-64/boost-cpp-1.78.0-h9f4b32c_3.conda
+  sha256: bf4d718e17cb115ea27d52bc84b3dff963b7ade2dda01ddb7088372833092517
+  md5: 09805934b78b0cd1a28d9e72a2a4778b
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  - zstd >=1.5.2,<1.6.0a0
+  constrains:
+  - libboost <0
+  license: BSL-1.0
+  size: 15777694
+  timestamp: 1680720350413
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.0.9-hcfcfb64_8.tar.bz2
+  sha256: 6d2fc2f147c9fc6685124d984089683988729463193578ba1d62f80263bce3c5
+  md5: 2e661f21e1741c11506bdc7226e6b0bc
+  depends:
+  - brotli-bin 1.0.9 hcfcfb64_8
+  - libbrotlidec 1.0.9 hcfcfb64_8
+  - libbrotlienc 1.0.9 hcfcfb64_8
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 19232
+  timestamp: 1666788969955
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.0.9-hcfcfb64_8.tar.bz2
+  sha256: e8b55a51cb907f336c6f308d5d052483b0cad6a8b09040b811a7f12f4f199d67
+  md5: e18b70ed349d96086fd60a9c642b1b58
+  depends:
+  - libbrotlidec 1.0.9 hcfcfb64_8
+  - libbrotlienc 1.0.9 hcfcfb64_8
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 22914
+  timestamp: 1666788946666
+- conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h8ffe710_4.tar.bz2
+  sha256: 5389dad4e73e4865bb485f460fc60b120bae74404003d457ecb1a62eb7abf0c1
+  md5: 7c03c66026944073040cb19a4f3ec3c9
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 152247
+  timestamp: 1606605223049
+- conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.5.7-h56e8100_0.conda
+  sha256: d0488a3e7a86cc11f8c847a7c12a5f1fb8567f05646faae78944807862f9d167
+  md5: 604212634bd8c4d6f20d44b946e8eedb
+  license: ISC
+  size: 148581
+  timestamp: 1683451822049
+- conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.16.0-hdecc03f_1016.conda
+  sha256: a0e37d9fdd4069141889ab78154ed0dcee5417fe8fcd3585a744993660a7adc0
+  md5: d5a082e08ff9a0206ad03ebb0fafdf8d
+  depends:
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=72.1,<73.0a0
+  - libglib >=2.76.2,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - pixman >=0.40.0,<1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 1608495
+  timestamp: 1684639521032
+- conda: https://conda.anaconda.org/conda-forge/win-64/cartopy-0.21.1-py311h178a126_1.conda
+  sha256: c56c718aabffd21d40d5cf49dee916b3c89fc4b166233226d581e0cc95b16108
+  md5: 407d26dff9a6dfd2989e274abf798da2
+  depends:
+  - geos >=3.11.2,<3.11.3.0a0
+  - matplotlib-base >=3.1
+  - numpy >=1.23.5,<2.0a0
+  - pyproj >=3.0.0
+  - pyshp >=2.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - scipy >=0.10
+  - shapely >=1.6.4
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 1701378
+  timestamp: 1679098645032
+- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.15.1-py311h7d9ee11_3.conda
+  sha256: 49ce08187365f97c67476d504411de0a17e69b972ab6b80521d01dc80dd657e6
+  md5: a8524727eb956b4741e25a64af79edb8
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 292953
+  timestamp: 1671179769667
+- conda: https://conda.anaconda.org/conda-forge/win-64/cfitsio-4.2.0-h9ebe7e4_0.conda
+  sha256: 18e893342e7ac8254741ea1dbae1b1f8e7771f2fdbb12e591e55f3a0519343ef
+  md5: cccd314cbeea4f2f70f73c763d9660e8
+  depends:
+  - libcurl >=7.86.0,<9.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: LicenseRef-fitsio
+  size: 559512
+  timestamp: 1668757474402
+- conda: https://conda.anaconda.org/conda-forge/win-64/cftime-1.6.2-py311h59ca53f_1.tar.bz2
+  sha256: cd3681852a1000573d596fe769813fe54743e06a93e28977dfdb28fbab137e9f
+  md5: 491ff9524ccc680e3302469ec9ea5909
+  depends:
+  - numpy >=1.23.4,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 180223
+  timestamp: 1666834140861
+- conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.0.7-py311h005e61a_0.conda
+  sha256: 5715b140cfe400aaab54e517a8ac834e9ad1c09019bdc174d6b384a37f2d6c44
+  md5: e7cb4befb5b37231881c2b9b5dc00bee
+  depends:
+  - numpy >=1.16
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 171401
+  timestamp: 1673634465012
+- conda: https://conda.anaconda.org/conda-forge/win-64/curl-8.1.2-h68f0423_0.conda
+  sha256: ba08ea94aa7eb8dcc4a35a7a7bb1992f04d1a0d23db5b89d4313f271fc99f52e
+  md5: fc67d347f9eaa7922fd7bc26bfa5419b
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libcurl 8.1.2 h68f0423_0
+  - libssh2 >=1.10.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: curl
+  license_family: MIT
+  size: 140500
+  timestamp: 1685448236561
+- conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.6.7-py311h12c1d0e_0.conda
+  sha256: 7e3dc2ea1f4f2bd90572c0aa5466b80d0debbc24b17f2ac778324fd56d80ce8f
+  md5: b056c7299be929b711016d2f4e48d303
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 3268456
+  timestamp: 1680756242290
+- conda: https://conda.anaconda.org/conda-forge/win-64/expat-2.5.0-h63175ca_1.conda
+  sha256: 3bcd88290cd462d5573c2923c796599d0dece2ff9d9c9d6c914d31e9c5881aaf
+  md5: 87c77fe1b445aedb5c6d207dd236fa3e
+  depends:
+  - libexpat 2.5.0 h63175ca_1
+  license: MIT
+  license_family: MIT
+  size: 226571
+  timestamp: 1680190888036
+- conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.14.2-hbde0cde_0.conda
+  sha256: 643f2b95be68abeb130c53d543dcd0c1244bebabd58c774a21b31e4b51ac3c96
+  md5: 08767992f1a4f1336a257af1241034bd
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 190111
+  timestamp: 1674829354122
+- conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.39.4-py311ha68e1ae_0.conda
+  sha256: 4606f3553c3860c88f8ac1b6a63bcdcb0a43017243fde77ac69c6dfa4bdcf6b3
+  md5: 7ee5a9db424f11d2369737c9d66f0281
+  depends:
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 2266745
+  timestamp: 1683740981193
+- conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-h546665d_1.conda
+  sha256: fe027235660d9dfe7889c350a51e96bc0134c3f408827a4c58c4b0557409984c
+  md5: 1b513009cd012591f3fdc9e03a74ec0a
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: GPL-2.0-only and LicenseRef-FreeType
+  size: 497412
+  timestamp: 1669233360876
+- conda: https://conda.anaconda.org/conda-forge/win-64/freexl-1.0.6-h67ca5e6_1.tar.bz2
+  sha256: 522a1ab55f891923f08d92e284cc1564c922f902c922101fa38121ee55535a87
+  md5: 7ddb6e879c46e78eec37f956b3ffe743
+  depends:
+  - libiconv >=1.17,<2.0.0a0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 62739
+  timestamp: 1662819638650
+- conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.11.2-h1537add_0.conda
+  sha256: d500883473ff16a4292a4406a60d53012d8d9b8ab531e8a61699109891b71122
+  md5: fce89f5f79ad360e5c183d0e982da42e
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: LGPL-2.1-only
+  size: 1400195
+  timestamp: 1679048354577
+- conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.1-h7222e44_8.conda
+  sha256: 728ac1829f775595ac58e0b714f5b283e121fb06758c9c49cf14f963e9303fbd
+  md5: f042eaae4fad4f00072e5db373c73aee
+  depends:
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - proj >=9.2.0,<9.2.1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 125707
+  timestamp: 1679226584079
+- conda: https://conda.anaconda.org/conda-forge/win-64/gettext-0.21.1-h5728263_0.tar.bz2
+  sha256: 71c75b0a4dc2cf95d2860ea0076edf9f5558baeb4dacaeecb32643b199074616
+  md5: 299d4fd6798a45337042ff5a48219e5f
+  depends:
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 5579416
+  timestamp: 1665676022441
+- conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h1334946_6.conda
+  sha256: 7114aa881e88ab0eb314f7612bef704ccf539e04965882e7b74a8c05230415b0
+  md5: 5777b72b13771944e15a839dd617c964
+  depends:
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 779782
+  timestamp: 1678293184582
+- conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.0-nompi_h918d9b7_103.conda
+  sha256: 56d4543daffd3028481e85a583ed28a74b064faf151fa4b4c0890e6a1df11312
+  md5: cdd3ab75e65f0aad08ff7e25a4dc825d
+  depends:
+  - libaec >=1.0.6,<2.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.0.8,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: LicenseRef-HDF5
+  license_family: BSD
+  size: 2017260
+  timestamp: 1678273845217
+- conda: https://conda.anaconda.org/conda-forge/win-64/icu-72.1-h63175ca_0.conda
+  sha256: 06ceff1f021f4a540a6b5c8a037b79b3d98757b1f9659a4b08ad352912b8ef2e
+  md5: a108731562663d787066bd17c9595114
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 13209837
+  timestamp: 1679314799856
+- conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2023.1.0-h57928b3_46319.conda
+  sha256: b3006690844eedbb51030e71778767acc9967f4148b6f335ba3fddf8aa42aa5b
+  md5: dbc4636f419722fbf3ab6501377228ba
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 2571975
+  timestamp: 1681819121435
+- conda: https://conda.anaconda.org/conda-forge/win-64/jupyter_core-5.3.0-py311h1ea47a8_0.conda
+  sha256: 6b2e05932fad1577b43129c04c39e55b46f23d49d58a4a7c48b2af061dd7c544
+  md5: 2b81965b74e70b89053845d1bc287561
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 131456
+  timestamp: 1678994975629
+- conda: https://conda.anaconda.org/conda-forge/win-64/kealib-1.5.1-hc8369a0_3.conda
+  sha256: 008fbff79c4f172e8f321f04c5fa07e9716bcc85bfb7a463d11e87d78c760b9e
+  md5: 3df257a636743a428882b29b0bcfc600
+  depends:
+  - hdf5 >=1.14.0,<1.14.1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 134050
+  timestamp: 1684390158643
+- conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.4-py311h005e61a_1.tar.bz2
+  sha256: 08cb19253d863d311f4b2d6f30a0a770ab0ce6365b238f3c5272c1fc6f6d5e5c
+  md5: 564530d9dd01d102b5ec76c34381f3b7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59565
+  timestamp: 1666806285110
+- conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.20.1-heb0366b_0.conda
+  sha256: 429edc4fa9e2420c55cdbd9febb154d2358bf662735efda4372f62142ff310cd
+  md5: a07b05ee8f451ab15698397185efe989
+  depends:
+  - openssl >=3.0.7,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 717332
+  timestamp: 1671092419752
+- conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.15-h3e3b177_1.conda
+  sha256: 24179aae324bcfa65ec983a389c5e048bd6b174f63afedf4cdd654da78cf9558
+  md5: a76c36ad1b4b87f038d67890122d08ec
+  depends:
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 499079
+  timestamp: 1678213836010
+- conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+  sha256: f4f39d7f6a2f9b407f8fb567a6c25755270421731d70f0ff331f5de4fa367488
+  md5: 1900cb3cab5055833cfddb0ba233b074
+  depends:
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30037
+  license: Apache-2.0
+  license_family: Apache
+  size: 194365
+  timestamp: 1657977692274
+- conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.0.6-h63175ca_1.conda
+  sha256: 441f580f90279bd62bd27fb82d0bbbb2c2d9f850fcc4c8781f199c5287cd1499
+  md5: f98474a8245f55f4a273889dbe7bf193
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 34719
+  timestamp: 1673799892542
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.6.2-h6f8411a_1.conda
+  sha256: 4699b9439453cea6a28c94eb6226929adcf4fbe3a9a635f7a7a229ed903c8987
+  md5: 314124476882f64abc20b76148d2909b
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libxml2 >=2.11.3,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - lzo >=2.10,<3.0a0
+  - openssl >=3.1.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 960678
+  timestamp: 1684325145661
+- conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-17_win64_mkl.conda
+  sha256: 56c5394e80c429acfee53a075e3d1b6ccd8c294510084cd6a2a4b7d8cc80abfb
+  md5: 9e42ac6b256b96bfaa19f829c25940e8
+  depends:
+  - mkl 2022.1.0 h6a75c08_874
+  constrains:
+  - libcblas 3.9.0 17_win64_mkl
+  - liblapack 3.9.0 17_win64_mkl
+  - liblapacke 3.9.0 17_win64_mkl
+  - blas * mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3655884
+  timestamp: 1685931194813
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.0.9-hcfcfb64_8.tar.bz2
+  sha256: 0e771d447108219f43de770f7ca9428b2e3b5a4fd08475a27ac442ad310cb684
+  md5: e8078e37208cd7d3e1eb5053f370ded8
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 69063
+  timestamp: 1666788837196
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.0.9-hcfcfb64_8.tar.bz2
+  sha256: 66814b8c0235bcc9124d32cb4b99845bcb2af0eba1d2ba609a501a6d8194e9a0
+  md5: 99839d9d81f33afa173c0fa82a702038
+  depends:
+  - libbrotlicommon 1.0.9 hcfcfb64_8
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 34744
+  timestamp: 1666788869952
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.0.9-hcfcfb64_8.tar.bz2
+  sha256: 3abf0f0b124d54ad892bd74fe77089a712d6dad81a04583331a58728c58a69e0
+  md5: 88e62627120c20289bf8982b15e0a6a1
+  depends:
+  - libbrotlicommon 1.0.9 hcfcfb64_8
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 741758
+  timestamp: 1666788910088
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-17_win64_mkl.conda
+  sha256: 5b9914c3b95d947a613a9b6d3c1c1515257a61e7838a1f2484927f0c9fe23063
+  md5: 768b2c3be666ecf9e62f939ea919f819
+  depends:
+  - libblas 3.9.0 17_win64_mkl
+  constrains:
+  - liblapack 3.9.0 17_win64_mkl
+  - liblapacke 3.9.0 17_win64_mkl
+  - blas * mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3655926
+  timestamp: 1685931229487
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.1.2-h68f0423_0.conda
+  sha256: a9d21b363c6d3c81ec85903f86989157e7d93d8f247e023ff3b3f69789115a72
+  md5: 94b9b7d0e882461fdb72d8d4e7441746
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libssh2 >=1.10.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: curl
+  license_family: MIT
+  size: 313345
+  timestamp: 1685448211604
+- conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.18-hcfcfb64_0.conda
+  sha256: 9a9a1a6e47777c9bf6086d88f6567ed3fc32d4f849b3d42b51bbf0b9fa4727f7
+  md5: 493acc14c556ef6f1d13ba00b099c679
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 152345
+  timestamp: 1679647873728
+- conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.5.0-h63175ca_1.conda
+  sha256: 794b2a9be72f176a2767c299574d330ffb76b2ed75d7fd20bee3bbadce5886cf
+  md5: 636cc3cbbd2e28bcfd2f73b2044aac2c
+  constrains:
+  - expat 2.5.0.*
+  license: MIT
+  license_family: MIT
+  size: 138689
+  timestamp: 1680190844101
+- conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+  sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
+  md5: 2c96d1b6915b408893f9472569dee135
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 42063
+  timestamp: 1636489106777
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.7.0-h4083641_1.conda
+  sha256: eef76a82f20b19b3898d75f18ff1af210a811213118877a4c167d42928c96ec1
+  md5: 724522eb2a40b05f48ad8ba8d361333b
+  depends:
+  - blosc >=1.21.4,<2.0a0
+  - cfitsio >=4.2.0,<4.2.1.0a0
+  - freexl >=1.0.6,<2.0a0
+  - geos >=3.11.2,<3.11.3.0a0
+  - geotiff >=1.7.1,<1.8.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.0,<1.14.1.0a0
+  - icu >=72.1,<73.0a0
+  - kealib >=1.5.1,<1.6.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libarchive >=3.6.2,<3.7.0a0
+  - libcurl >=8.1.0,<9.0a0
+  - libdeflate >=1.18,<1.26.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=15.3,<16.0a0
+  - libspatialite >=5.0.1,<5.1.0a0
+  - libsqlite >=3.42.0,<4.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  - libwebp-base >=1.3.0,<2.0a0
+  - libxml2 >=2.11.3,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - openssl >=3.1.0,<4.0a0
+  - pcre2 >=10.40,<10.41.0a0
+  - poppler >=23.5.0,<23.6.0a0
+  - postgresql
+  - proj >=9.2.0,<9.2.1.0a0
+  - tiledb >=2.13.2,<2.14.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xerces-c >=3.2.4,<3.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 8448950
+  timestamp: 1684603592135
+- conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.76.3-he8f3873_0.conda
+  sha256: 170d42dcf0c73f5846dfb0c4a241c065cd9830c644d98042f076f25c309e7571
+  md5: 4695e6acaf4790170161048d56cb51fc
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - pcre2 >=10.40,<10.41.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - glib 2.76.3 *_0
+  license: LGPL-2.1-or-later
+  size: 2599048
+  timestamp: 1684848450372
+- conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.1-nocuda_h15da153_6.conda
+  sha256: dbb221db2ca66075fc12976c55db511dd88433c4db91ed20da59ffada2f6e6bb
+  md5: 95b1bd8df3033d08ae5125ed69d71194
+  depends:
+  - libxml2 >=2.11.4,<2.14.0a0
+  - pthreads-win32
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2537812
+  timestamp: 1686174051116
+- conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-h8ffe710_0.tar.bz2
+  sha256: 657c2a992c896475021a25faebd9ccfaa149c5d70c7dc824d4069784b686cea1
+  md5: 050119977a86e4856f0416e2edcf81bb
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: GPL and LGPL
+  size: 714518
+  timestamp: 1652702326553
+- conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-2.1.5.1-hcfcfb64_0.conda
+  sha256: 42a874448d060b59f9b5c900b260c992df9543da55c2ac9537b442450d6e6497
+  md5: f2fad2ae9f1365e343e4329fdb1e9d63
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG, modified 3-clause BSD and zlib
+  size: 688076
+  timestamp: 1678128177975
+- conda: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-hf2ab4e4_1015.tar.bz2
+  sha256: 4d136a0f5091dc988be0bd5648a36eb27df227e14f433ea2f5f022ba17137b42
+  md5: 1f50b25e87cefda820cb71fb643bc021
+  depends:
+  - boost-cpp >=1.78.0,<1.78.1.0a0
+  - expat >=2.4.8,<3.0a0
+  - libzlib >=1.2.12,<2.0.0a0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  - zlib >=1.2.12,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3024452
+  timestamp: 1662843281735
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-17_win64_mkl.conda
+  sha256: 68922a63d92a414af06b208136c9304be179c6fc911e8636430b0e15c0a9aa3b
+  md5: 278121fe8f0d65d496998aa290f36322
+  depends:
+  - libblas 3.9.0 17_win64_mkl
+  constrains:
+  - libcblas 3.9.0 17_win64_mkl
+  - liblapacke 3.9.0 17_win64_mkl
+  - blas * mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3655939
+  timestamp: 1685931263174
+- conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_ha5afab8_105.conda
+  sha256: aeba17b1f9506ae3ffa4fdbc0598a5f8ddf01e9f3b88d9d3724e5937fe88a651
+  md5: a5f8e5024b223469f1035fc3abdc94b3
+  depends:
+  - blosc >=1.21.4,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - curl
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 * nompi_*
+  - hdf5 >=1.14.0,<1.14.1.0a0
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libxml2 >=2.11.3,<2.14.0a0
+  - libzip >=1.9.2,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 619617
+  timestamp: 1684497103900
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.39-h19919ed_0.conda
+  sha256: 1f139a72109366ba1da69f5bdc569b0e6783f887615807c02d7bfcc2c7575067
+  md5: ab6febdb2dbd9c00803609079db4de71
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: zlib-acknowledgement
+  size: 343883
+  timestamp: 1669076173145
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpq-15.3-ha9684e8_1.conda
+  sha256: 04ff073aa9ea3df666676d610b18559ba4929b91e2b4cd92ef10f509b4b777ff
+  md5: 593fbdd2cd79f98a97cd79cf6115032a
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.0,<3.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PostgreSQL
+  size: 3378185
+  timestamp: 1684452936617
+- conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-he1da8c1_13.conda
+  sha256: fc5119dc937a96d97cad8d4a5069d476f0c9daf170a75e9386774ce7feb618c1
+  md5: 8b2baf1a9f17576939439cde1f87babe
+  depends:
+  - geos >=3.11.2,<3.11.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 403121
+  timestamp: 1679087945280
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.18-h8d14728_1.tar.bz2
+  sha256: ecc463f0ab6eaf6bc5bd6ff9c17f65595de6c7a38db812222ab8ffde0d3f4bc2
+  md5: 5c1fb45b5e2912c19098750ae8a32604
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: ISC
+  size: 713431
+  timestamp: 1605135918736
+- conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.0.1-hca1f1ac_26.conda
+  sha256: d82d9ff5648d39fec05146e69a172efbd8c8462b6dad5b45da85bc8057545ca2
+  md5: 961cd188e24817aeea11554cdbf0cbfa
+  depends:
+  - freexl >=1.0.6,<2.0a0
+  - geos >=3.11.2,<3.11.3.0a0
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.42.0,<4.0a0
+  - libxml2 >=2.11.3,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - proj >=9.2.0,<9.2.1.0a0
+  - sqlite
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 7837518
+  timestamp: 1684287679969
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.42.0-hcfcfb64_0.conda
+  sha256: 70bc1fdb72de847807355c13144666d4f151894f9b141ee559f5d243bdf577e2
+  md5: 9a71d93deb99cc09d8939d5235b5909a
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 839797
+  timestamp: 1684265312954
+- conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+  sha256: 813fd04eed2a2d5d9c36e53c554f9c1f08e9324e2922bd60c9c52dbbed2dbcec
+  md5: dc262d03aae04fe26825062879141a41
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 266806
+  timestamp: 1685838242099
+- conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.5.0-h6c8260b_6.conda
+  sha256: 854c90084d43a8c5e3a41c0e698ee579257d8e3eacbed73b61728501e4f6bcc5
+  md5: 12628df645fcf0f74922138858724831
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.18,<1.26.0a0
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  size: 1057306
+  timestamp: 1679672439148
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.3.0-hcfcfb64_0.conda
+  sha256: 9355940270db76592a1cdbcb840740afb5f6b81d167ac4f2cb0fbb2c37397566
+  md5: 381a3645c51cbf478872899b16490318
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  constrains:
+  - libwebp 1.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 268368
+  timestamp: 1678667185248
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.15-hcd874cb_0.conda
+  sha256: d01322c693580f53f8d07a7420cd6879289f5ddad5531b372c3efd1c37cac3bf
+  md5: 090d91b69396f14afef450c285f9758c
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 969788
+  timestamp: 1682083087243
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.11.4-hc3477c8_0.conda
+  sha256: d9d2210436ac28d1a15de08468202a944135d17da3b37fd82c0e90a36ce8ef72
+  md5: 586627982a63815637f871a6360fe3f9
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1700060
+  timestamp: 1684627377126
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzip-1.9.2-h519de47_1.tar.bz2
+  sha256: 7551ba06879206b81637ef4206b72a8d5d23752f0c6a5be82c9865f72ecc1c81
+  md5: 9c3138e53e36c0c161a23d20db91297b
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.12,<2.0.0a0
+  - openssl >=3.0.5,<4.0a0
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 145998
+  timestamp: 1660348014066
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_4.tar.bz2
+  sha256: 184da12b4296088a47086f4e69e65eb5f8537a824ee3131d8076775e1d1ea767
+  md5: 0cc5c5cc64ee1637f37f8540a175854c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  constrains:
+  - zlib 1.2.13 *_4
+  license: Zlib
+  license_family: Other
+  size: 71198
+  timestamp: 1665760209780
+- conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.40.0-py311h5bc0dda_0.conda
+  sha256: 6765425d9f3a66c40e659a6c597e1deb999586c0f153f57f24327d1b9e307068
+  md5: 842ffa91b51edcf0fa319e297f381064
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - vs2015_runtime
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16907853
+  timestamp: 1684447483432
+- conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+  sha256: a0954b4b1590735ea5f3d0f4579c3883f8ac837387afd5b398b241fda85124ab
+  md5: e34720eb20a33fc3bfb8451dd837ab7a
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134235
+  timestamp: 1674728465431
+- conda: https://conda.anaconda.org/conda-forge/win-64/lzo-2.10-he774522_1000.tar.bz2
+  sha256: ff064e34d3cad829f1e31f2d26125b61d20ba8d3771f8f5337069027b8e3fab4
+  md5: d5cf4b7eaa52316f135eed9e8548ad57
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: GPL v2+
+  license_family: GPL2
+  size: 170192
+  timestamp: 1597682500084
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+  sha256: 9de95a7996d5366ae0808eef2acbc63f9b11b874aa42375f55379e6715845dc6
+  md5: 066552ac6b907ec6d72c0ddab29050dc
+  depends:
+  - m2w64-gcc-libs-core
+  - msys2-conda-epoch ==20160418
+  license: GPL, LGPL, FDL, custom
+  size: 350687
+  timestamp: 1608163451316
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+  sha256: 3bd1ab02b7c89a5b153a17be03b36d833f1517ff2a6a77ead7c4a808b88196aa
+  md5: fe759119b8b3bfa720b8762c6fdc35de
+  depends:
+  - m2w64-gcc-libgfortran
+  - m2w64-gcc-libs-core
+  - m2w64-gmp
+  - m2w64-libwinpthread-git
+  - msys2-conda-epoch ==20160418
+  license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  size: 532390
+  timestamp: 1608163512830
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+  sha256: 58afdfe859ed2e9a9b1cc06bc408720cb2c3a6a132e59d4805b090d7574f4ee0
+  md5: 4289d80fb4d272f1f3b56cfe87ac90bd
+  depends:
+  - m2w64-gmp
+  - m2w64-libwinpthread-git
+  - msys2-conda-epoch ==20160418
+  license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  size: 219240
+  timestamp: 1608163481341
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+  sha256: 7e3cd95f554660de45f8323fca359e904e8d203efaf07a4d311e46d611481ed1
+  md5: 53a1c73e1e3d185516d7e3af177596d9
+  depends:
+  - msys2-conda-epoch ==20160418
+  license: LGPL3
+  size: 743501
+  timestamp: 1608163782057
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+  sha256: f63a09b2cae7defae0480f1740015d6235f1861afa6fe2e2d3e10bd0d1314ee0
+  md5: 774130a326dee16f1ceb05cc687ee4f0
+  depends:
+  - msys2-conda-epoch ==20160418
+  license: MIT, BSD
+  size: 31928
+  timestamp: 1608166099896
+- conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.3-py311ha68e1ae_0.conda
+  sha256: 53093042d6223531559fab2096eed85abee39d9386df9d7d42f9398e40017f04
+  md5: db2c2f72a83bdc5b70947964e1ddc8bb
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29453
+  timestamp: 1685769449108
+- conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.7.1-py311h6e989c2_0.conda
+  sha256: 3094357a327dda7b28f26645cac998724122e9f8c8f939ca270ff66a1af61706
+  md5: 8220277205fbdf07ddfa7a124346c2dd
+  depends:
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.0.1
+  - numpy >=1.20
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: LicenseRef-PSF-2.0 and CC0-1.0
+  license_family: PSF
+  size: 7668359
+  timestamp: 1678136280288
+- conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2022.1.0-h6a75c08_874.tar.bz2
+  sha256: b130d13dba6a798cbcce8f19c52e9765b75b8668d2f8f95ba8210c63b6fa84eb
+  md5: 2ff89a7337a9636029b4db9466e9f8e3
+  depends:
+  - intel-openmp
+  - tbb 2021.*
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 191569511
+  timestamp: 1652946602922
+- conda: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+  sha256: 99358d58d778abee4dca82ad29fb58058571f19b0f86138363c260049d4ac7f1
+  md5: b0309b72560df66f71a9d5e34a5efdfa
+  size: 3227
+  timestamp: 1608166968312
+- conda: https://conda.anaconda.org/conda-forge/win-64/netcdf4-1.6.4-nompi_py311h896b27b_100.conda
+  sha256: 87fa3d71e799bfaabc7729abe6f32dbaebc059de99d245cc32b7e5f3ee47cb63
+  md5: 00045d94148d8d3564557f5bb8840910
+  depends:
+  - certifi
+  - cftime
+  - hdf5 >=1.14.0,<1.14.1.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 368633
+  timestamp: 1686026416917
+- conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.57.0-py311h2c0921f_1.conda
+  sha256: 536b34d0dfcea21b77dd1c3213c68d9b5d69a744a3f210b3765d250fb8b32910
+  md5: 54ad8f6ccb4b282c08e2dc9b4b214b68
+  depends:
+  - llvmlite >=0.40.0,<0.41.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.25
+  - libopenblas !=0.3.6
+  - tbb >=2021.9.0,<2022.0a0
+  - cudatoolkit >=10.2
+  - cuda-python >=11.6
+  - cuda-version >=10.2
+  - scipy >=1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5514323
+  timestamp: 1685545568682
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.24.3-py311h0b4df5a_0.conda
+  sha256: 5078aa980f1c1195edadc08d83476f29243ba07d0b975aa710e9b95d49f59d99
+  md5: 7efb2d8d15616284d8496235d2731ebf
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6985584
+  timestamp: 1682211084854
+- conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.0-ha2aaf27_2.conda
+  sha256: 1fb72db47e9b1cdb4980a1fd031e31fad2c6a4a632fc602e7d6fa74f4f491608
+  md5: db0490689232e8e38c312281df6f31a2
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 237111
+  timestamp: 1671435754860
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.1.1-hcfcfb64_1.conda
+  sha256: 4424486fb9a2aeaba912a8dd8a5b5cdb6fcd65d7708fd854e3ea27449bb352a3
+  md5: 1d913a5de46c6b2f7e4cfbd26b106b8b
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 7415451
+  timestamp: 1685519134254
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.0.2-py311hf63dbb6_0.conda
+  sha256: 0f34a469c11ac6eae33975cd53b117aab788dd604d61311e6b101cfa98459341
+  md5: b2cefefa3082f3298cbb62e182c5de40
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13404907
+  timestamp: 1685343975222
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandoc-2.19.2-h57928b3_2.conda
+  sha256: fd1b6a03c17a179718447afaded78ae54bbd9d1603412b704dfb97d7cb42d303
+  md5: c188f67e94153ddc7e4e10ae127cbb1a
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 15675026
+  timestamp: 1678228641642
+- conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.40-h17e33f8_0.tar.bz2
+  sha256: 5833c63548e4fae91da6d77739eab7dc9bf6542e43f105826b23c01bfdd9cb57
+  md5: 2519de0d9620dc2bc7e19caf6867136d
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.12,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2001630
+  timestamp: 1665563527916
+- conda: https://conda.anaconda.org/conda-forge/win-64/pillow-9.5.0-py311hde623f7_1.conda
+  sha256: bbe784f6b6d3dea0229c24865abb96f1018143fa363bb99db4742484423e8e82
+  md5: 6aa24353a7cb1171ed4d83ea294a79da
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  - libwebp-base >=1.3.0,<2.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.12,<8.7.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LicenseRef-PIL
+  size: 46598385
+  timestamp: 1684654466008
+- conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.40.0-h8ffe710_0.tar.bz2
+  sha256: 7f0ceed590a717ddc7612f67657119df1e6df0d031a822b570d741a89a3ba784
+  md5: 32b45d3fcffddc84cc1a014a0b5f0d58
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 493231
+  timestamp: 1604342509224
+- conda: https://conda.anaconda.org/conda-forge/win-64/poppler-23.05.0-h45d20d0_1.conda
+  sha256: 1ef9bf61a24de30a52c2f48c7500ce8aec0294f10cdc862717febed8cca156a4
+  md5: 4777ef1e95163f5fc3476c4c6abdf3bd
+  depends:
+  - boost-cpp >=1.78.0,<1.78.1.0a0
+  - cairo >=1.16.0,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gettext >=0.21.1,<1.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libcurl >=8.0.1,<9.0a0
+  - libglib >=2.76.2,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=2.1.5.1,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - poppler-data
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 2237010
+  timestamp: 1683555209864
+- conda: https://conda.anaconda.org/conda-forge/win-64/postgresql-15.3-h96452e4_1.conda
+  sha256: 51a4f9a5537d2ba0dd6df0ddcc3547f5c76a38bf686cdec1ec52f0251a8e2acb
+  md5: 26c2efbaa34ccc64e5e57dbdd2d38cc4
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libpq 15.3 ha9684e8_1
+  - libxml2 >=2.11.3,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  size: 17659492
+  timestamp: 1684453025013
+- conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.2.0-heca977f_0.conda
+  sha256: 9515d24cda37a5ef51fc13972620ce6a98189641769aba61cc1e62a73570a061
+  md5: a5c7a6b34d994f46b3cbf16d2acb383d
+  depends:
+  - libcurl >=7.88.1,<9.0a0
+  - libsqlite >=3.40.0,<4.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  - sqlite
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2616237
+  timestamp: 1679165060784
+- conda: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.5-py311ha68e1ae_0.conda
+  sha256: b7c3ea83142689ffc6029bb745f6a4836818f1b1c1ba9e9f9ba3a9498f4a3cd4
+  md5: f1a1eecd1bb4f431df5b9b6d8a152efd
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 515116
+  timestamp: 1681775399789
+- conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-hcd874cb_1001.tar.bz2
+  sha256: bb5a6ddf1a609a63addd6d7b488b0f58d05092ea84e9203283409bff539e202a
+  md5: a1f820480193ea83582b13249a7e7bd9
+  depends:
+  - m2w64-gcc-libs
+  license: MIT
+  license_family: MIT
+  size: 6417
+  timestamp: 1606147814351
+- conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
+  sha256: 576a228630a72f25d255a5e345e5f10878e153221a96560f2498040cd6f54005
+  md5: e2da8758d7d51ff6aa78a14dfb9dbed4
+  depends:
+  - vc 14.*
+  license: LGPL 2
+  size: 144301
+  timestamp: 1537755684331
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.5.0-py311h095e9de_1.conda
+  sha256: afa9b1f593f1f20164de04a840659266c3217fcc39f4750048803ea7b328ab1b
+  md5: 2bf16524acfc74d669c2bde451fdcf6a
+  depends:
+  - certifi
+  - proj >=9.2.0,<9.2.1.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 405203
+  timestamp: 1680062566259
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyrsistent-0.19.3-py311ha68e1ae_0.conda
+  sha256: 591a4b3ceeeccf801f6672b46c9a32c4ed76b78071643fdbc2cedb2decd81005
+  md5: 3f2780a49f0b4bb2c622f7cf098e3d06
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 116888
+  timestamp: 1672682160244
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.3-h2628c8c_0_cpython.conda
+  sha256: 092b7bc17a0065b82f512d56910c521fd665e8020536014f1a9e3f2a47b448bb
+  md5: 8f82e0e0ba51bed311f28eb6450393f6
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.40.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.0,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 18128687
+  timestamp: 1680771386664
+- conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-3_cp311.conda
+  sha256: e042841d13274354d651a69a4f2589e9b46fd23b416368c9821bf3c6676f19d7
+  md5: fd1634ba85cfea9376e1fc02d6f592e9
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6124
+  timestamp: 1669071848353
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-304-py311h12c1d0e_2.tar.bz2
+  sha256: cdefd0688f776940bcc74fd981328a5d45e734006538dca6d686f8d21051c753
+  md5: 20a2d8e73b0be8e27ca4096d4f3a7053
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 9916058
+  timestamp: 1666985027367
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.10-py311h12c1d0e_0.conda
+  sha256: 5dbe1f4f1dbb69d0474ca31a1a8d559eded8dd48c2e1e0089746aab477427c2b
+  md5: 4d7e034dc93f50757cf039a2e3183343
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 218364
+  timestamp: 1672754725218
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0-py311ha68e1ae_5.tar.bz2
+  sha256: b97ad8513a22204707dc9ef506f7eca70dc9027cb09e26f559ca560d8b21ae14
+  md5: 0c97d59d54eb52e170224b3de6ade906
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 181077
+  timestamp: 1666772842384
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-25.1.0-py311h7b3f143_0.conda
+  sha256: ac0f68359c7accb28b438d8a0f7b7e8827ac66d6b5f7dbe80e6570d376b235e2
+  md5: b690f6e1878ccc98e96a33658867e8e1
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zeromq >=4.3.4,<4.3.5.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  size: 479976
+  timestamp: 1685519861662
+- conda: https://conda.anaconda.org/conda-forge/win-64/rasterio-1.3.7-py311h826718d_1.conda
+  sha256: 591c7f9d364dd93a33b01c5ffd5fd1e270c483544fb4405d2760b920e72b4f57
+  md5: 4a196a6a4bae4eb7981d4a2a02992d13
+  depends:
+  - affine
+  - attrs
+  - certifi
+  - click >=4
+  - click-plugins
+  - cligj >=0.5
+  - libgdal >=3.7.0,<3.8.0a0
+  - numpy >=1.23.5,<2.0a0
+  - proj >=9.2.0,<9.2.1.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7101092
+  timestamp: 1684816202861
+- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.10.1-py311h37ff6ca_3.conda
+  sha256: 778cecd689c0139874e1263776ea6ba5d959d6d6439de8bd1d12643e18362760
+  md5: 2a46a0cbc7e2a7f7436c3d790134d434
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - numpy >=1.23.5,<1.27
+  - numpy >=1.23.5,<2.0a0
+  - pooch
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libopenblas <0.3.26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18652493
+  timestamp: 1683902319573
+- conda: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.1-py311h343093d_1.conda
+  sha256: b2a36429d85544c7c9121135f1399852fa99be05ed26021b6fc64682bd0d01da
+  md5: ffc9f50ce2af2cf4fbe3c756031c1cf1
+  depends:
+  - geos >=3.11.2,<3.11.3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 465566
+  timestamp: 1679082113095
+- conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
+  sha256: 2a195b38cb63f03ad9f73a82db52434ebefe216fb70f7ea3defe4ddf263d408a
+  md5: cff1df79c9cff719460eb2dd172568de
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 57065
+  timestamp: 1678534804734
+- conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.42.0-hcfcfb64_0.conda
+  sha256: 8f24c8c96716a57a570d9b31d69307223a3b8592ade0283e3e7a1b5c2f0fa513
+  md5: c505cc64dba674d4c419c0de772c8579
+  depends:
+  - libsqlite 3.42.0 hcfcfb64_0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 840772
+  timestamp: 1684265331419
+- conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.9.0-h91493d7_0.conda
+  sha256: bf9a0f71aa9234776fc5d940464f47b760e5b4907c6c4f7eb0273221fe1b834c
+  md5: 6aa3f1becefeaa00a4d2a79b2a478aee
+  depends:
+  - libhwloc >=2.9.1,<2.9.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 154736
+  timestamp: 1681487156667
+- conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.13.2-h3132609_0.conda
+  sha256: 96c2de92dce5de54c923d9242163196bff6bce8e0fbfdbcfd4d9c47ce2fb1123
+  md5: 07426c5e1301448738f66686548d41ff
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - curl
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.0.7,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  - zlib
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 3393329
+  timestamp: 1673637691148
+- conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.12-h8ffe710_0.tar.bz2
+  sha256: 087795090a99a1d397ef1ed80b4a01fabfb0122efb141562c168e3c0a76edba6
+  md5: c69a5047cc9291ae40afd4a1ad6f0c0f
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: TCL
+  license_family: BSD
+  size: 3681762
+  timestamp: 1645033031535
+- conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.3.2-py311ha68e1ae_0.conda
+  sha256: 861842b01e24ec66b73909027cd081e47c567710f2ecb06402dcc387c22b24ef
+  md5: e2a6c106c1cff7e884d93351cdee3c3e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 842217
+  timestamp: 1684150633803
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+  sha256: f29cdaf8712008f6b419b8b1a403923b00ab2504bfe0fb2ba8eb60e72d4f14c6
+  md5: 72608f6cd3e5898229c3ea16deb1ac43
+  constrains:
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-Proprietary
+  license_family: PROPRIETARY
+  size: 1283972
+  timestamp: 1666630199266
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-hb25d44b_16.conda
+  sha256: 29bc108d66150ca75cab937f844f4ac4a836beb6ea3ee167d03c611444bb2a82
+  md5: ea326b37e3bd6d2616988e09f3a9396c
+  depends:
+  - vc14_runtime >=14.32.31332
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16824
+  timestamp: 1683185902974
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.34.31931-h5081d32_16.conda
+  sha256: 1161f4848e1c0663897a6324fbc4ff13dafd11650b42c9864428da73593dda95
+  md5: 22125178654c6a8a393f9743d585704b
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.34.31931.* *_16
+  license: LicenseRef-ProprietaryMicrosoft
+  license_family: Proprietary
+  size: 726275
+  timestamp: 1683185768485
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.34.31931-hed1258a_16.conda
+  sha256: 25d852887a501ca8cb6753a4f3dae1549fa49592d51aec1a230b1f0c85fe4297
+  md5: 0374eae69b6dbfb27c3dc27167109eb4
+  depends:
+  - vc14_runtime >=14.34.31931
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16856
+  timestamp: 1683185788411
+- conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: 9df10c5b607dd30e05ba08cbd940009305c75db242476f4e845ea06008b0a283
+  md5: 1cee351bf20b830d991dbe0bc8cd7dfe
+  license: MIT
+  license_family: MIT
+  size: 1176306
+- conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.2.4-h63175ca_2.conda
+  sha256: ac27817d829c1f0d2dcf4622c49807fc1c2974cde8a779b2adc7699bcdca68c1
+  md5: 8ba57760b15d0c2493192908317bdf5e
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 3540772
+  timestamp: 1679377377103
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-hcd874cb_0.conda
+  sha256: 8c5b976e3b36001bdefdb41fb70415f9c07eff631f1f0155f3225a7649320e77
+  md5: c46ba8712093cb0114404ae8a7582e1a
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  license: MIT
+  license_family: MIT
+  size: 51297
+  timestamp: 1684638355740
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.3-hcd874cb_0.tar.bz2
+  sha256: f51205d33c07d744ec177243e5d9b874002910c731954f2c8da82459be462b93
+  md5: 46878ebb6b9cbd8afcf8088d7ef00ece
+  depends:
+  - m2w64-gcc-libs
+  license: MIT
+  license_family: MIT
+  size: 67908
+  timestamp: 1610072296570
+- conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+  sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
+  md5: 515d77642eaa3639413c6b1bc3f94219
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: LGPL-2.1 and GPL-2.0
+  size: 217804
+  timestamp: 1660346976440
+- conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+  sha256: 4e2246383003acbad9682c7c63178e2e715ad0eb84f03a8df1fbfba455dfedc5
+  md5: adbfb9f45d1004a26763652246a33764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 63274
+  timestamp: 1641347623319
+- conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.4-h0e60522_1.tar.bz2
+  sha256: 0489cc6c3bff50620879890431d7142fd6e66b7770ddc6f2d7852094471c0d6c
+  md5: e1aff0583dda5fb917eb3d2c1025aa80
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 9355377
+  timestamp: 1629968018045
+- conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.2.13-hcfcfb64_4.tar.bz2
+  sha256: 28e9fe3ca91ccc50080d777cb1642c64e385dbb8843162d7cadad418a12ef35d
+  md5: eed9fec3e6d2e8865135b09d24ca040c
+  depends:
+  - libzlib 1.2.13 hcfcfb64_4
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: Zlib
+  license_family: Other
+  size: 116176
+  timestamp: 1665760231168
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.2-h12be248_6.conda
+  sha256: ef23b2eb748b0b2139755e5a20d49a642340af1313017918dc91b4a4ce8f3bd9
+  md5: 62826565682d013b3e2346aaf7bded0e
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 288404
+  timestamp: 1674245855297

--- a/landsat/pixi.toml
+++ b/landsat/pixi.toml
@@ -1,0 +1,39 @@
+[workspace]
+name = "landsat"
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2016-06-20"
+maintainers = ["jbednar"]
+categories = ["Geospatial"]
+labels = ["geoviews", "holoviews", "bokeh", "datashader", "numba", "xarray"]
+description = "Datashading LandSat8 raster satellite imagery"
+
+[dependencies]
+python = "*"
+notebook = "*"
+bokeh = "*"
+cartopy = "*"
+datashader = "*"
+geoviews = "*"
+holoviews = "*"
+numpy = "*"
+pandas = "*"
+rasterio = "*"
+xarray = "*"
+numba = "*"
+param = "*"
+rioxarray = "*"
+jupyter_client = "<8"
+pip = "*"
+wheel = "*"
+
+[tasks.notebook]
+cmd = "jupyter notebook landsat.ipynb"
+depends-on = ["download"]
+
+[tasks.download]
+env = { FILENAME = "data" }
+cmd = "mkdir -p $FILENAME && curl -fsSL -o .DATA.zip http://s3.amazonaws.com/datashader-data/mobile_landsat8.zip && python -m zipfile -e .DATA.zip $FILENAME && rm .DATA.zip"
+outputs = ["data"]

--- a/landsat/pixi.toml
+++ b/landsat/pixi.toml
@@ -26,8 +26,8 @@ numba = "*"
 param = "*"
 rioxarray = "*"
 jupyter_client = "<8"
-pip = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [tasks.notebook]
 cmd = "jupyter notebook landsat.ipynb"

--- a/landsat_clustering/pixi.lock
+++ b/landsat_clustering/pixi.lock
@@ -1,0 +1,12133 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.8.6-py310h2372a71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py310h2372a71_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/arrow-cpp-10.0.1-h27aab58_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.6.21-h774e2f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.5.20-hff2c3d7_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.8.5-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.16-hf5f93bc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.2.16-h52dae97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.6.29-hf21410f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.13.11-h4f448d1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.7.13-hefb3e95_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.2.1-h927de71_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.7-hf5f93bc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.14-h6027aba_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.18.16-h89864ff_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.9.379-h33d5b13_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.5-h0f2a231_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/boost-cpp-1.74.0-h6cacc03_7.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.0.9-h166bdaf_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.0.9-h166bdaf_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.0.9-py310hd8f1fbe_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.20.1-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.7.22-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.16.0-ha12eb4b_1010.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.22.0-py310hcc13569_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py310h2fee648_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.0.0-h9a35b8e_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.3-py310h1f7b6fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.1.1-py310hd41b1e2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cramjam-2.7.0-py310hcb5633a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/curl-7.86.0-h2283fc2_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-0.12.2-py310h2372a71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.0-py310hc6cd4ac_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.5.0-hcb278e6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fastparquet-2023.10.1-py310h1f7b6fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.43.1-py310h2372a71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-1.0.6-h166bdaf_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.4.0-py310h2372a71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.10.2-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.0-h6593c0a_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.21.1-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-he1b5a44_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.1-h0b41bf4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.6.0-h6f12383_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h9772cbc_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.12.1-nompi_h4df4325_104.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-69.1-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jpeg-9e-h0b41bf4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.15-h98cffda_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-2.4-py310hff52083_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-5.5.0-py310hff52083_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kealib-1.4.15-hfe1a663_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.5-py310hd41b1e2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.19.3-h08a2579_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.14-h6ed2654_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20220623.0-cxx17_h05df665_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-10.0.1-h86614e7_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-19_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.0.9-h166bdaf_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.0.9-h166bdaf_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.0.9-h166bdaf_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-19_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-7.86.0-h2283fc2_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdap4-3.20.6-hd7c4107_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.14-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.10-h28343ad_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.4.1-h4ae554a_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.78.0-hebfc3b9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.5.0-h21dfe5b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.51.1-h30feacc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.8.0-h32351e8_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-h01aab08_1016.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-19_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.8.1-nompi_h329d8a1_102.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.55.1-h47da74e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.24-pthreads_h413a1c8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.39-h753d276_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-14.5-he2d8382_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-3.21.12-hfc55251_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-hf69c175_9.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.0.1-h0e567f8_14.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.44.0-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.16.0-he500d00_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.4.0-h82bc61c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.13-h7f98852_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.9.14-haae042b_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.10.1-h2629f0a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.40.1-py310h1b8f574_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.2-py310h350c4a5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.3-h9c3ff4c_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py310h2372a71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.8.0-py310h62c0568_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.0.6-py310hd41b1e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.0.4-py310h2372a71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.6.0-nompi_py310h947f774_100.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.82-he02c5a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.57.1-py310h0f6aa51_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.12.1-py310hc6cd4ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.24.4-py310ha4c1d20_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.0-h7d73246_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.4-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-1.8.2-hfdbbad2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.1.2-py310hcc13569_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre-8.45-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.40-hc3806b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-9.2.0-py310h454ad03_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.42.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/poppler-21.11.0-ha39eefc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/postgresql-14.5-ha7cec9f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-8.2.1-h277dcde_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py310h2372a71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-10.0.1-py310hea98ffe_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.3.0-py310h9e0d750_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.13-hd12c33a_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-snappy-0.6.1-py310hb624d98_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-4_cp310.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py310h2372a71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-25.1.1-py310h795f18f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.2.10-py310h5e0f756_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2022.06.01-h27087fc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.10.6-py310hcb5633a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.3.30-h3358134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.3.2-py310h1fdf081_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.11.3-py310hb13e2d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-1.8.2-py310hb974679_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.44.0-h2c6b66d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.7.0-h924138e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.6.4-h3f4058f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.3.3-py310h2372a71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tzcode-2022e-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py310h2372a71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.7-hcb278e6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.15.0-py310h2372a71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.3-h8ce2273_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-h7391055_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.4-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.10-h7f98852_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-h7f98852_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.9.2-py310h2372a71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-timeout-4.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.13.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.31.64-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-glm-0.2.0-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-ml-2023.3.24-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.10.0-pyhca7485f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.10.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-xarray-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.26.0-pyhf8b6a83_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh41d4057_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.9.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.0.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-1.13.0-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parquet-cpp-1.5.1-2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-core-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyepsg-0.4.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.15.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-2023.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh41d4057_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-2.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyh41d4057_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.2.0-pyha21a80b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.13.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.18-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-timeout-4.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.13.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.31.64-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-glm-0.2.0-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-ml-2023.3.24-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.10.0-pyhca7485f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.10.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-xarray-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.26.0-pyh3cd1d5f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.9.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.0.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-1.13.0-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-core-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyepsg-0.4.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.15.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-2023.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyhd1c38e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-2.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyhd1c38e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.2.0-pyha21a80b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.13.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.18-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.8.6-py310hb372a2b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py310h6729b98_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.5-h671831e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.7-h50c96e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.4-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.17-h6cdfeff_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.3.2-h74ccef4_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.7.13-h7fc0988_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.13.35-h3dcb58e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.9.8-hb951632_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.3.20-h4b852be_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.12-h6cdfeff_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.17-h6cdfeff_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.24.4-hf472077_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.182-hfd15655_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.5-heccf04b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py310h9e9d8ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.20.1-h10d778d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2023.7.22-h8857fd0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h99e66fa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cartopy-0.22.0-py310hdba192b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.16.0-py310hdca579f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cfitsio-4.3.0-h66f91ea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cftime-1.6.3-py310h91862f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.1.1-py310h88cfcbd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cramjam-2.7.0-py310h3461e44_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-0.12.2-py310h6729b98_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.0-py310h9e9d8ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/expat-2.5.0-hf0c8a7f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fastparquet-2023.10.1-py310h91862f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.14.2-h5bb23bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.43.1-py310hb372a2b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3ec172f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/frozenlist-1.4.0-py310h6729b98_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.12.0-he965462_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/geotiff-1.7.1-h889ec99_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.21.1-h8a4c099_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hb1e8313_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.1-hb7f2c08_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.6.0-h8ac2a54_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.2-nompi_hedada53_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/json-c-0.17-h8e11ae5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-2.4-py310h2ec42d9_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jupyter_core-5.5.0-py310h2ec42d9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/kealib-1.5.2-h052fcf7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.5-py310h88cfcbd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.2-hb884880_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.15-hd6ba6f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20230802.1-cxx17_h048a20a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.2-he965462_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.7.2-h0b5dc4a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-13.0.0-h5fe8ab2_13_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-19_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libboost-headers-1.82.0-h694c41f_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-19_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.4.0-h726d00d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.6-hd57cbcb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.19-ha4e1b8e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-haf1e3a3_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.5.0-hf0c8a7f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.7.2-h926149b_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.78.0-hc62aa5d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.12.0-h407922f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.58.2-hecc90c7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hac89ed1_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libkml-1.3.0-hab3ca0e_1018.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-19_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-hc8e404f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.2-nompi_h6a32802_112.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.55.1-hc0a10c5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.24-openmp_h48a4ad5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.39-ha978bb4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.0-h3df487d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.24.3-he0c2237_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2023.06.02-h4694dbf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/librttopo-1.1.0-h23f359d_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.18-hbcb3906_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libspatialite-5.1.0-h231fb02_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.44.0-h92b6c6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.19.0-h064b379_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h684deea_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.3.2-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.15-hb7f2c08_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.11.5-h3346baf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzip-1.10.1-hc158999_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-17.0.4-hb6ac08f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.40.1-py310hd8379ad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-4.3.2-py310h4c8952d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lzo-2.10-haf1e3a3_1000.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.3-py310h6729b98_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.8.0-py310h2a8a546_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.0.2-h23f18a7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.0.6-py310h88cfcbd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/multidict-6.0.4-py310h90acd4f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-h93d8f39_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/netcdf4-1.6.5-nompi_py310h30a4ba5_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/nspr-4.35-hea0b92c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/nss-3.94-hd6ac835_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.57.1-py310he09a53b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numcodecs-0.12.1-py310had63691_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.24.4-py310h7451ae0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.0-ha4da562_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.1.4-hd75f5a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-1.9.0-hb037d9a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.1.2-py310hdba192b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.40-h1c4e4bc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.1.0-py310he65384d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.42.2-he965462_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/poppler-23.10.0-hdd5a5e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/postgresql-16.0-hc940a54_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.3.0-h23b96cc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.5-py310h6729b98_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-13.0.0-py310hb3c8376_13_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.0-py310hef2d279_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.0-py310hef2d279_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.6.1-py310h7e62555_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.10.13-h00d2728_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-snappy-0.6.1-py310hc8cfbf2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.10-4_cp310.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.1-py310h6729b98_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-25.1.1-py310hd8b4af3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rasterio-1.3.9-py310hc04732b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2023.06.02-hd34609a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.10.6-py310h0e083fb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.3.2-py310h04b1a37_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.11.3-py310h2db466d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.2-py310hcbf9397_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.44.0-h7461747_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.10.0-h1c7c39f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tiledb-2.16.3-hd3a41d5_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hef22860_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.3.3-py310h6729b98_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tzcode-2023c-hb7f2c08_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-15.1.0-py310h6729b98_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/uriparser-0.9.7-hf0c8a7f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.15.0-py310h6729b98_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xerces-c-3.2.4-h6314983_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yarl-1.9.2-py310hb372a2b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h93d8f39_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-timeout-4.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.13.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.31.64-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-glm-0.2.0-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-ml-2023.3.24-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.10.0-pyhca7485f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.10.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-xarray-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.26.0-pyh3cd1d5f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.9.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.0.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-1.13.0-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-core-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyepsg-0.4.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.15.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-2023.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyhd1c38e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-2.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyhd1c38e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.2.0-pyha21a80b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.13.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.18-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.8.6-py310hd125d64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py310h2aa6e3c_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.5-he6edc6d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.7-ha251d5a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.4-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.17-ha251d5a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.3.2-hd73d0d5_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.7.13-hb3e5a72_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.13.35-h0f79f92_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.9.8-he2964ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.3.20-h8d12f51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.12-ha251d5a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.17-ha251d5a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.24.4-h5f3d163_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.182-hba14a0b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.5-hc338f07_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py310h1253130_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h3422bc3_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.20.1-h93a5062_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.7.22-hf0a4a13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hd1e100b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cartopy-0.22.0-py310h6e3cc31_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.16.0-py310hdcd7c05_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cfitsio-4.3.0-hca87796_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.3-py310h50ce23c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.1.1-py310h38f39d4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cramjam-2.7.0-py310had9acf8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-0.12.2-py310h2aa6e3c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.0-py310h1253130_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.5.0-hb7217d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fastparquet-2023.10.1-py310h50ce23c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.14.2-h82840c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.43.1-py310hd125d64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-hfbad9fb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.4.0-py310h2aa6e3c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.12.0-h13dd4ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geotiff-1.7.1-h71398c0_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.21.1-h0186832_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hc88da5d_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.1-h1a8c8d9_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.6.0-h6da1cb0_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.2-nompi_h3aba7b3_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/json-c-0.17-h40ed0f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-2.4-py310hbe9552e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jupyter_core-5.5.0-py310hbe9552e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kealib-1.5.2-h47b5e36_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.5-py310h38f39d4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.2-h92f50d5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.15-hf2736f0_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20230802.1-cxx17_h13dd4ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.2-h13dd4ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.7.2-h82b9b87_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-13.0.0-h87fad27_13_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-19_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-headers-1.82.0-hce30654_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-19_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.4.0-h2d989ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.6-h4653b0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.19-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h642e427_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.5.0-hb7217d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-3.7.2-h116f65a_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.78.0-h24e9cb9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.12.0-h5a37b55_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.58.2-h19be7b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-he4db4b2_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libkml-1.3.0-h1eb4d9f_1018.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-19_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnetcdf-4.9.2-nompi_hb2fb864_112.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.55.1-h2b02ca0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.24-openmp_hd76b1f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.39-h76d750c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.0-hcea71ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.24.3-hf590ac1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2023.06.02-h1753957_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/librttopo-1.1.0-h667cd51_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.18-h27ca646_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libspatialite-5.1.0-h32510b6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.44.0-h091b4b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.19.0-h026a170_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.6.0-ha8a6c65_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-h1a8c8d9_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.3.2-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.15-hf346824_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.11.5-h25269f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzip-1.10.1-ha0bc3c6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-17.0.4-hcd81f8e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.40.1-py310h95b248a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-4.3.2-py310hf90591b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h642e427_1000.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.3-py310h2aa6e3c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.8.0-py310h9d2df84_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/minizip-4.0.2-hd5cad61_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.0.6-py310h38f39d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.0.4-py310h8e9501a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h463b476_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/netcdf4-1.6.5-nompi_py310h3aafd6c_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.35-hb7217d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.94-hc6b9969_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.57.1-py310hb9b3264_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numcodecs-0.12.1-py310hd5a4765_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.24.4-py310haa1e00c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.0-h4c1507b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.1.4-h0d3ecfb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-1.9.0-hcd02cb2_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.1.2-py310h6e3cc31_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.40-hb34f9b4_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.1.0-py310hfae7ebd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.42.2-h13dd4ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/poppler-23.10.0-hcdd998b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/postgresql-16.0-h00cd704_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.3.0-h52fb9d0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.5-py310h2aa6e3c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-13.0.0-py310hf2cf3de_13_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.0-py310hd07e440_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.0-py310hd07e440_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.6.1-py310h2de6d0e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.13-h2469fbe_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-snappy-0.6.1-py310ha977fbf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.10-4_cp310.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.1-py310h2aa6e3c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-25.1.1-py310h7e65269_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rasterio-1.3.9-py310hdddcdff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2023.06.02-h6135d0a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.10.6-py310hd442715_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.3.2-py310h417b086_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.11.3-py310hd1cfc7d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.2-py310h656ff59_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.44.0-hf2abe2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.10.0-h1995070_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tiledb-2.16.3-he15c4da_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hb31c410_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.3.3-py310h2aa6e3c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tzcode-2023c-h1a8c8d9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-15.1.0-py310h2aa6e3c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uriparser-0.9.7-hb7217d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.15.0-py310h2aa6e3c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xerces-c-3.2.4-hd886eac_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.9.2-py310hd125d64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h965bd2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-timeout-4.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.13.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.31.64-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-glm-0.2.0-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-ml-2023.3.24-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.10.0-pyhca7485f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.10.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-xarray-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.26.0-pyha63f2e9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh5737063_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.9.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.0.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-1.13.0-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-core-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyepsg-0.4.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.15.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-2023.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh08f2357_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-2.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.0-pyh08f2357_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.2.0-pyha21a80b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.13.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.18-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyhd8ed1ab_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.8.6-py310h8d17308_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py310h8d17308_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.5-h7c265c8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.6.7-h85219b4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.4-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.17-h85219b4_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.3.2-h02e22aa_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.7.13-hddd7df3_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.13.35-h8233182_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.9.8-hf43a5ce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.3.20-h6f899c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.12-h85219b4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.17-h85219b4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.24.4-h4ff64ff_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.182-h9479ca2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.5-hdccc3a2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py310h00ffb61_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h8ffe710_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.20.1-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.7.22-h56e8100_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h1fef639_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cartopy-0.22.0-py310hecd3228_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.16.0-py310h8d17308_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cfitsio-4.3.0-h9b0cee5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cftime-1.6.3-py310h3e78b6c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.1.1-py310h232114e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cramjam-2.7.0-py310he2c049f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-0.12.2-py310h8d17308_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.0-py310h00ffb61_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/expat-2.5.0-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fastparquet-2023.10.1-py310h3e78b6c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.14.2-hbde0cde_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.43.1-py310h8d17308_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-h8276f4a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.4.0-py310h8d17308_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.12.0-h1537add_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.1-hcf4a93f_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gettext-0.21.1-h5728263_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.2-nompi_h73e8ff5_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/icu-73.2-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2023.2.0-h57928b3_50497.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-2.4-py310h5588dad_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jupyter_core-5.5.0-py310h5588dad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kealib-1.5.2-ha10e780_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.5-py310h232114e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.15-h67d730c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20230802.1-cxx17_h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.2-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.7.2-h6f8411a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-13.0.0-hc7845e2_13_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-19_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-headers-1.82.0-h57928b3_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-19_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.4.0-hd5e4a3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.19-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.5.0-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.7.2-h3217549_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.78.0-he8f3873_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.12.0-ha74b051_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.58.2-h2a9c87f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-h8ffe710_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-haf3e7a6_1018.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-19_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_h8284064_112.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.39-h19919ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpq-16.0-h43585b0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.24.3-hb8276f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2023.06.02-h8c5ae5e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-h92c5fdb_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.18-h8d14728_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-hbf340bc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.44.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.19.0-ha2b3283_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-h6e2ebb7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-h82a8f57_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.3.2-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.15-hcd874cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.11.5-hc3477c8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzip-1.10.1-h1d365fa_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.40.1-py310hb84602e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-4.3.2-py310hbbb2075_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lzo-2.10-he774522_1000.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.3-py310h8d17308_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.8.0-py310hc9baf74_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/minizip-4.0.2-h5bed578_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2023.2.0-h6a75c08_50496.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.0.6-py310h232114e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.0.4-py310h8d17308_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/netcdf4-1.6.5-nompi_py310h6477780_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.57.1-py310h19bcfe9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numcodecs-0.12.1-py310h00ffb61_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.24.4-py310hd02465a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.0-h3d672ee_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.1.4-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/orc-1.9.0-hd95f75e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.1.2-py310hecd3228_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.40-h17e33f8_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-10.1.0-py310h1e6a543_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.42.2-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/poppler-23.10.0-hc2f3c52_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/postgresql-16.0-hc80876b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.3.0-he13c7e8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.5-py310h8d17308_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-hcd874cb_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-13.0.0-py310hd0bb7c2_13_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.6.1-py310hebb2149_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.10.13-h4de0772_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-snappy-0.6.1-py310h6ed3180_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.10-4_cp310.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-306-py310h00ffb61_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.12-py310h00ffb61_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.1-py310h8d17308_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-25.1.1-py310h2849c00_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rasterio-1.3.9-py310h4d3659c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2023.06.02-hcbb65ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.10.6-py310h87d50f1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.3.2-py310hfd2573f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.11.3-py310hf667824_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.2-py310h839b4a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.44.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.10.0-h91493d7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.16.3-hbf04793_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.3.3-py310h8d17308_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-15.1.0-py310h8d17308_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.7-h1537add_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h64f974e_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.36.32532-hdcecf7f_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.36.32532-h05e6639_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.15.0-py310h8d17308_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.2.4-h63175ca_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-hcd874cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.3-hcd874cb_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yarl-1.9.2-py310h8d17308_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.2.13-hcfcfb64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  license: None
+  size: 2562
+  timestamp: 1578324546067
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23621
+  timestamp: 1650670423406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.8.6-py310h2372a71_1.conda
+  sha256: e32892fd786dc4ba150701ffd0981c8e942fc77e52754f6f1c331392004bd6f1
+  md5: d265a71480afd9479c9333ba86375d04
+  depends:
+  - aiosignal >=1.1.2
+  - async-timeout <5.0,>=4.0.0a3
+  - attrs >=17.3.0
+  - charset-normalizer >=2.0,<4.0
+  - frozenlist >=1.1.1
+  - libgcc-ng >=12
+  - multidict >=4.5,<7.0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - yarl >=1.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  size: 649665
+  timestamp: 1696765575504
+- conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py310h2372a71_4.conda
+  sha256: af94cc9b4dcaa164e1cc7e7fa0b9eb56b87ea3dc6e093c8ef6c31cfa02d9ffdf
+  md5: 68ee85860502d53c8cbfa0e4cef0f6cb
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 34384
+  timestamp: 1695386695142
+- conda: https://conda.anaconda.org/conda-forge/linux-64/arrow-cpp-10.0.1-h27aab58_4_cpu.conda
+  sha256: 2a98cf1c15752bcaed2edc6c949995c0ee5f2851084e96aff3ff3fdae5662eae
+  md5: f730b5f9959317b5f97956dcac4b18ba
+  depends:
+  - libarrow 10.0.1 h86614e7_4_cpu
+  - openssl >=3.0.7,<4.0a0
+  constrains:
+  - arrow-cpp-proc * cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 29666
+  timestamp: 1673821455715
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.6.21-h774e2f3_1.conda
+  sha256: f098a9915c3fb78dd53a0eb842c6cc8243646506055f7ece09ce6584178698f9
+  md5: 1b604a086486a97c0338b2fe3e9f79ea
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.29,<0.6.30.0a0
+  - aws-c-io >=0.13.11,<0.13.12.0a0
+  - aws-c-sdkutils >=0.1.7,<0.1.8.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 94172
+  timestamp: 1671653871506
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.5.20-hff2c3d7_3.tar.bz2
+  sha256: e340b8a12faa184582106aa4913753fead960fecc3a670c1270de8877b049a14
+  md5: afc84c17eb855bfe13a20ee603230235
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=12
+  - openssl >=3.0.7,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 44351
+  timestamp: 1667909408337
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.8.5-h166bdaf_0.tar.bz2
+  sha256: ab9278ee301ac95d54198cb75e0dbe0b27589d39bed029a13f0361c266f3e284
+  md5: 5590453a8d072c9c89bfa26fcf88d870
+  depends:
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 202952
+  timestamp: 1667631916368
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.16-hf5f93bc_0.tar.bz2
+  sha256: 214a00d101b1b0be2f130b0774dd89982070c325d6b0106e0e7a808917606ef1
+  md5: d279191a7bbce623d5087e0b1883cfb1
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 18013
+  timestamp: 1667970376193
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.2.16-h52dae97_0.conda
+  sha256: d8a9cfb3585e2ba6eab1be384a64d4de93988f8e7a26cc7f1d80e9053a4f374c
+  md5: 90cf005da709e2f8d37aec7df0ec799e
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-io >=0.13.11,<0.13.12.0a0
+  - aws-checksums >=0.1.14,<0.1.15.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 52344
+  timestamp: 1671093691850
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.6.29-hf21410f_0.conda
+  sha256: 07a88d32aaa4bb62f2e6f152b3815a9930dc56154b96d3c57720d5f214649574
+  md5: a748403b26a0ac6b09c860972927f5d3
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-compression >=0.2.16,<0.2.17.0a0
+  - aws-c-io >=0.13.11,<0.13.12.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 189322
+  timestamp: 1671614950301
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.13.11-h4f448d1_2.conda
+  sha256: a3b70245cea9a30d8f9cb216544e1563fc77e4139f8ad39639efee7be051491d
+  md5: b0eba50cc9096cd035e7978d4a2f9eda
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=12
+  - s2n >=1.3.30,<1.3.31.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 141352
+  timestamp: 1670848576201
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.7.13-hefb3e95_10.conda
+  sha256: c8c9e244a6dd70175dd017da4a484533d997fe7327d75fb2bb410bc549709d16
+  md5: 7cfd30505adc0a8f30aa45277840948b
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.29,<0.6.30.0a0
+  - aws-c-io >=0.13.11,<0.13.12.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 69016
+  timestamp: 1671653040122
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.2.1-h927de71_2.conda
+  sha256: 3a89652c6ef2ce62cf3def2e1e3cb70693ec1a90f441524e177895f350f6669b
+  md5: 1b28bd938972d159828e75aeea284a0f
+  depends:
+  - aws-c-auth >=0.6.21,<0.6.22.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.29,<0.6.30.0a0
+  - aws-c-io >=0.13.11,<0.13.12.0a0
+  - aws-checksums >=0.1.14,<0.1.15.0a0
+  - libgcc-ng >=12
+  - openssl >=3.0.7,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 76305
+  timestamp: 1671671306843
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.7-hf5f93bc_0.tar.bz2
+  sha256: bc29212f1504eaa1101e8b231dfdfc7d8bb9a111fe2d9d30704d5f68684cc9a0
+  md5: 772dcd299af4757edd9f4da140849cf2
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 53285
+  timestamp: 1668730263775
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.14-h6027aba_0.conda
+  sha256: 93f0676f8058e4c5124f924a0833c28b4a14bc17e0283c43bec12c44a333539f
+  md5: 4960e03c8b6447aebc484f5a3c340180
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 49878
+  timestamp: 1670533729017
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.18.16-h89864ff_5.conda
+  sha256: 287c0447c24e300083782b64f3eaadb150e83bc6271e96d929be283536d853df
+  md5: 9a90a2264e50b6cc73a3f526f8f9311e
+  depends:
+  - aws-c-auth >=0.6.21,<0.6.22.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.16,<0.2.17.0a0
+  - aws-c-http >=0.6.29,<0.6.30.0a0
+  - aws-c-io >=0.13.11,<0.13.12.0a0
+  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
+  - aws-c-s3 >=0.2.1,<0.2.2.0a0
+  - aws-checksums >=0.1.14,<0.1.15.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 216665
+  timestamp: 1671689446072
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.9.379-h33d5b13_6.conda
+  sha256: 74726c7b85e01837614a6f4752925603e6cf9c53b1f371d098fff800541728c5
+  md5: 2b0d27972b01992d14e3cb32311c41df
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.16,<0.2.17.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - libcurl >=7.86.0,<9.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.0.7,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3896332
+  timestamp: 1671583113186
+- conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.5-h0f2a231_0.conda
+  sha256: e2b15b017775d1bda8edbb1bc48e545e45364edefa4d926732fc5488cc600731
+  md5: 009521b7ed97cca25f8f997f9e745976
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48692
+  timestamp: 1693657088079
+- conda: https://conda.anaconda.org/conda-forge/linux-64/boost-cpp-1.74.0-h6cacc03_7.tar.bz2
+  sha256: 7516fc72e0bf3d837427a8522093205bdd5faf0447d11ad659adf74e43da5a66
+  md5: b7c1f8b1937c8572d7dce988a9df1a64
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=69.1,<70.0a0
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  - libzlib >=1.2.11,<2.0.0a0
+  - xz >=5.2.5,<6.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  constrains:
+  - libboost <0
+  license: BSL-1.0
+  size: 17072591
+  timestamp: 1644185152670
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.0.9-h166bdaf_9.conda
+  sha256: 2357d205931912def55df0dc53573361156b27856f9bf359d464da162812ec1f
+  md5: 4601544b4982ba1861fa9b9c607b2c06
+  depends:
+  - brotli-bin 1.0.9 h166bdaf_9
+  - libbrotlidec 1.0.9 h166bdaf_9
+  - libbrotlienc 1.0.9 h166bdaf_9
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 20065
+  timestamp: 1687884291946
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.0.9-h166bdaf_9.conda
+  sha256: 1c128f136a59ee2fa47d7fbd9b6fc8afa8460d340e4ae0e6f5419ebbd7539a10
+  md5: d47dee1856d9cb955b8076eeff304a5b
+  depends:
+  - libbrotlidec 1.0.9 h166bdaf_9
+  - libbrotlienc 1.0.9 h166bdaf_9
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 20361
+  timestamp: 1687884277426
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.0.9-py310hd8f1fbe_9.conda
+  sha256: a4984cb906910850ae979387f0ac4e2623e0a3c8139bc67eb1fff0403bf8388b
+  md5: e2047ad2af52c01845f58b580c6cbd5c
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - libbrotlicommon 1.0.9 h166bdaf_9
+  license: MIT
+  license_family: MIT
+  size: 326479
+  timestamp: 1687884330581
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2
+  sha256: cb521319804640ff2ad6a9f118d972ed76d86bea44e5626c09a13d38f562e1fa
+  md5: a1fd65c7ccbf10880423d82bca54eb54
+  depends:
+  - libgcc-ng >=9.3.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 495686
+  timestamp: 1606604745109
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.20.1-hd590300_1.conda
+  sha256: 1700d9ebfd3b21c8b50e12a502f26e015719e1f3dbb5d491b5be061cf148ca7a
+  md5: 2facbaf5ee1a56967aecaee89799160e
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 115956
+  timestamp: 1697955875024
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.7.22-hbcca054_0.conda
+  sha256: 525b7b6b5135b952ec1808de84e5eca57c7c7ff144e29ef3e96ae4040ff432c1
+  md5: a73ecd2988327ad4c8f2c331482917f2
+  license: ISC
+  size: 149515
+  timestamp: 1690026108541
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.16.0-ha12eb4b_1010.tar.bz2
+  sha256: 4e64ee154efc450d54f5ad1b674ad3ef25585f4f5c4ad60fc32b72eac6c2927f
+  md5: e15c0969bf37df9dae513a48ac871a7d
+  depends:
+  - fontconfig >=2.13.96,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.10.4,<3.0a0
+  - icu >=69.1,<70.0a0
+  - libgcc-ng >=10.3.0
+  - libglib >=2.70.2,<3.0a0
+  - libpng >=1.6.37,<1.7.0a0
+  - libxcb >=1.13,<1.14.0a0
+  - libzlib >=1.2.11,<2.0.0a0
+  - pixman >=0.40.0,<1.0a0
+  - xorg-libice
+  - xorg-libsm
+  - xorg-libx11
+  - xorg-libxext
+  - xorg-libxrender
+  - zlib >=1.2.11,<1.3.0a0
+  license: LGPL-2.1-only or MPL-1.1
+  size: 1577909
+  timestamp: 1646853569163
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.22.0-py310hcc13569_1.conda
+  sha256: ec73372b3945634920c115f9d04b4543cc2d459c583df329aa32be813ca21380
+  md5: 31ef447724fb19066a9d00a660dab1bd
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - matplotlib-base >=3.4
+  - numpy >=1.22.4,<2.0a0
+  - packaging >=20
+  - pyproj >=3.1.0
+  - pyshp >=2.1
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - shapely >=1.7
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 1827530
+  timestamp: 1698172887001
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py310h2fee648_0.conda
+  sha256: 007e7f69ab45553b7bf11f2c1b8d3f3a13fd42997266a0d57795f41c7d38df36
+  md5: 45846a970e71ac98fd327da5d40a0a2c
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - pycparser
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 241339
+  timestamp: 1696001848492
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.0.0-h9a35b8e_0.tar.bz2
+  sha256: 38a832176b565089e59ea3010be60373df6b70031ace924f5affc52c85cada6b
+  md5: 6b214116ecabe2c5457a93b9763de61d
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=7.79.1,<9.0a0
+  - libgcc-ng >=9.4.0
+  - libgfortran-ng
+  - libgfortran5 >=9.4.0
+  - libzlib >=1.2.11,<2.0.0a0
+  license: LicenseRef-fitsio
+  size: 1355814
+  timestamp: 1634565578564
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.3-py310h1f7b6fc_0.conda
+  sha256: 0983d88068e4bd589031582769ef7d05617edda3a7daa1f4847492f4c3538aad
+  md5: 31beda75384647959d5792a1a7dc571a
+  depends:
+  - libgcc-ng >=12
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 246545
+  timestamp: 1698610101048
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.1.1-py310hd41b1e2_1.conda
+  sha256: 16f44e7e47f7cf9c3c02d760beb9179698510740e0eb1927ade3d8fb69aa1a0d
+  md5: 6a38f65d330b74495ad6990280486049
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.16
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 223840
+  timestamp: 1695554349041
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cramjam-2.7.0-py310hcb5633a_1.conda
+  sha256: 7847d8937f0d869fbbdb59fb6f34df43216d84cee631b9b97abe9596ba227fce
+  md5: aef3efea01f29bb78c7dc6c993dce01d
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 1379348
+  timestamp: 1695450781191
+- conda: https://conda.anaconda.org/conda-forge/linux-64/curl-7.86.0-h2283fc2_1.tar.bz2
+  sha256: 9c7de3c405c8195a02dd829f4b9b1a8a14b5bca4670b8e6a05554df63d0b92af
+  md5: 9d4149760567cb232691cce2d8ccc21f
+  depends:
+  - krb5 >=1.19.3,<1.20.0a0
+  - libcurl 7.86.0 h2283fc2_1
+  - libgcc-ng >=12
+  - libssh2 >=1.10.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.0.7,<4.0a0
+  license: curl
+  license_family: MIT
+  size: 92766
+  timestamp: 1667347245435
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-0.12.2-py310h2372a71_1.conda
+  sha256: 6e722a87eb9b355a5d7fb0adeeccbf95c54a618fa55fa7fc87853a4f390b26da
+  md5: a79a93c3912e9e9b0afd3bf58f2c01d7
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 368062
+  timestamp: 1695545318690
+- conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.0-py310hc6cd4ac_1.conda
+  sha256: 77593f7b60d8f3b4d27a97a1b9e6c07c3f2490cfab77039d5e403166448b5de2
+  md5: 01388b4ec9eed3b26fa732aa39745475
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 2436014
+  timestamp: 1695534502620
+- conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.5.0-hcb278e6_1.conda
+  sha256: 36dfeb4375059b3bba75ce9b38c29c69fd257342a79e6cf20e9f25c1523f785f
+  md5: 8b9b5aca60558d02ddaa09d599e55920
+  depends:
+  - libexpat 2.5.0 hcb278e6_1
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 136778
+  timestamp: 1680190541750
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fastparquet-2023.10.1-py310h1f7b6fc_0.conda
+  sha256: 66cd5afe619110fbcbb64f01321e7f114c02d500cb5278b627a6e4e6f2a08aab
+  md5: e35344f3e87dd2552992dc1fffa65205
+  depends:
+  - cramjam >=2.3
+  - fsspec
+  - libgcc-ng >=12
+  - numpy >=1.20.3
+  - numpy >=1.22.4,<2.0a0
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 446892
+  timestamp: 1698412892081
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
+  sha256: 155d534c9037347ea7439a2c6da7c24ffec8e5dd278889b4c57274a1d91e0a83
+  md5: 0f69b688f52ff6da70bccb7ff7001d1d
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libgcc-ng >=12
+  - libuuid >=2.32.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 272010
+  timestamp: 1674828850194
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.43.1-py310h2372a71_0.conda
+  sha256: 66f89ff0c0e6cd9940e866b04f5442b4ab802d5d279012c5eb13c639cf18da76
+  md5: c7d552c32b87beb736c9658441bf93a9
+  depends:
+  - brotli
+  - libgcc-ng >=12
+  - munkres
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - unicodedata2 >=14.0.0
+  license: MIT
+  license_family: MIT
+  size: 2234075
+  timestamp: 1696601395340
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+  sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
+  md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 634972
+  timestamp: 1694615932610
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-1.0.6-h166bdaf_1.tar.bz2
+  sha256: 26045196e00b5787276c60ff83acfa8808cae550a20832f11104069e5f7f3f05
+  md5: 897e772a157faf3330d72dd291486f62
+  depends:
+  - libgcc-ng >=12
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 49640
+  timestamp: 1662819514879
+- conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.4.0-py310h2372a71_1.conda
+  sha256: cd1e59ceac047d9f692bb7cc2a6a6e2356a7d3db660b076b4afb19d35db2fd02
+  md5: c7b2865e86782925a872c8598b760c08
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: APACHE
+  size: 53928
+  timestamp: 1695377871958
+- conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.10.2-h9c3ff4c_0.tar.bz2
+  sha256: 0caba5822207c7754f0007fa2a331f616d7090d37d00ae0de08d74c6396db7bf
+  md5: fe9a66a351bfa7a84c3108304c7bcba5
+  depends:
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  license: LGPL-2.1-only
+  size: 1645774
+  timestamp: 1642312367362
+- conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.0-h6593c0a_6.tar.bz2
+  sha256: 0f63086b58d642fa9e5f20691e2d96c748ae89edaa961d970de4b3428d88a1b6
+  md5: c27cd5bfa3060e7015610387fe249142
+  depends:
+  - jpeg >=9d,<10a
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  - libtiff >=4.3.0,<4.5.0a0
+  - libzlib >=1.2.11,<2.0.0a0
+  - proj >=8.2.1,<8.2.2.0a0
+  - zlib >=1.2.11,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 305441
+  timestamp: 1641162686773
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.21.1-h27087fc_0.tar.bz2
+  sha256: 4fcfedc44e4c9a053f0416f9fc6ab6ed50644fca3a761126dbd00d09db1f546a
+  md5: 14947d8770185e5153fdd04d4673ed37
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 4320628
+  timestamp: 1665673494324
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-he1b5a44_1004.tar.bz2
+  sha256: a853c0cacf53cfc59e1bca8d6e5cdfe9f38fce836f08c2a69e35429c2a492e77
+  md5: cddaf2c63ea4a5901cf09524c490ecdc
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116549
+  timestamp: 1594303828933
+- conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.1-h0b41bf4_3.conda
+  sha256: 41ec165704ccce2faa0437f4f53c03c06261a2cc9ff7614828e51427d9261f4b
+  md5: 96f3b11872ef6fad973eac856cd2624f
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 77385
+  timestamp: 1678717794467
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.6.0-h6f12383_0.tar.bz2
+  sha256: 888cbcfb67f6e3d88a4c4ab9d26c9a406f620c4101a35dc6d2dbadb95f2221d4
+  md5: b31f3565cb84435407594e548a2fb7b2
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 114321
+  timestamp: 1649143789233
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h9772cbc_5.tar.bz2
+  sha256: c343a211880a86abf99a8f117a53e251317f99faac761fc0b758f6ad737d13ff
+  md5: ee08782aff2ff9b3291c967fa6bc7336
+  depends:
+  - jpeg >=9e,<10a
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 973792
+  timestamp: 1667222658023
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.12.1-nompi_h4df4325_104.tar.bz2
+  sha256: c506a7a7114800a63652f7e82324d221bd3ca6910dcff74722fe54644f402aa8
+  md5: ddecfd15c2a412c595c68ff22d3557a0
+  depends:
+  - libcurl >=7.81.0,<9.0a0
+  - libgcc-ng >=10.3.0
+  - libgfortran-ng
+  - libgfortran5 >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  - libzlib >=1.2.11,<2.0.0a0
+  - openssl >=3.0.0,<4.0a0
+  - zlib >=1.2.11,<1.3.0a0
+  license: LicenseRef-HDF5
+  license_family: BSD
+  size: 3725303
+  timestamp: 1646413396971
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-69.1-h9c3ff4c_0.tar.bz2
+  sha256: c3a356dcee44d420ce79c55a02ced8221a3ec305de9ecf3a7f1ab1c21d2fcad4
+  md5: e0773c9556d588b062a4e1424a6a02fa
+  depends:
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 13885192
+  timestamp: 1635411478428
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jpeg-9e-h0b41bf4_3.conda
+  sha256: 8f73194d09c9ea4a7e2b3562766b8d72125cc147b62c7cf83393e3a3bbfd581b
+  md5: c7a069243e1fbe9a556ed2ec030e6407
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - libjpeg-turbo <0.0.0a
+  license: IJG
+  size: 240359
+  timestamp: 1676177310738
+- conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.15-h98cffda_0.tar.bz2
+  sha256: 3f978a326b41aa49545b53cba7fc48bb9659ca51d252b14382f7194fe0e01d23
+  md5: f32d45a88e7462be446824654dbcf4a4
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 280696
+  timestamp: 1613412286535
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-2.4-py310hff52083_3.conda
+  sha256: 316db08863469a56cdbfd030de5a2cc11ec7649ed7c50eff507e9caa0070ccaa
+  md5: 08ec1463dbc5c806a32fc431874032ca
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16170
+  timestamp: 1695397381208
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-5.5.0-py310hff52083_0.conda
+  sha256: 35e05ff1ad8b070b1378886c5ee4b82a000ea078494af6d0552d1c455b3f6220
+  md5: 9ca8f0d07c512cef3fd07b121bb2b023
+  depends:
+  - platformdirs >=2.5
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 79275
+  timestamp: 1698673792929
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kealib-1.4.15-hfe1a663_0.tar.bz2
+  sha256: 9d8802c906d25ddcf6511d368c064dd44dc8e6564e1f2ae047ebd24cabdab422
+  md5: 32fda93b8db4b6be630d1ee6a94f23b9
+  depends:
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 192974
+  timestamp: 1655956000438
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+  sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
+  md5: 30186d27e2c9fa62b45fb1476b7200e3
+  depends:
+  - libgcc-ng >=10.3.0
+  license: LGPL-2.1-or-later
+  size: 117831
+  timestamp: 1646151697040
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.5-py310hd41b1e2_1.conda
+  sha256: bb51906639bced3de1d4d7740ac284cdaa89e2f22e0b1ec796378b090b0648ba
+  md5: b8d67603d43b23ce7e988a5d81a7ab79
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73123
+  timestamp: 1695380074542
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.19.3-h08a2579_0.tar.bz2
+  sha256: 9faad78e078a3e671f3572a01163acc1b2a47539559c746ea3ffd17c754ea578
+  md5: d25e05e7ee0e302b52d24491db4891eb
+  depends:
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  - openssl >=3.0.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1516863
+  timestamp: 1647339263181
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.14-h6ed2654_0.tar.bz2
+  sha256: cbadb4150850941bf0518ba948effbbdd89b2c28dfdfed54eae196037e015b43
+  md5: dcc588839de1445d90995a0a2c4f3a39
+  depends:
+  - jpeg >=9e,<10a
+  - libgcc-ng >=12
+  - libtiff >=4.4.0,<4.5.0a0
+  license: MIT
+  license_family: MIT
+  size: 262144
+  timestamp: 1667332608997
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+  sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
+  md5: 7aca3059a1729aa76c597603f10b0dd3
+  constrains:
+  - binutils_impl_linux-64 2.40
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 704696
+  timestamp: 1674833944779
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+  sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
+  md5: 76bbff344f0134279f225174e9064c8f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 281798
+  timestamp: 1657977462600
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20220623.0-cxx17_h05df665_6.conda
+  sha256: 3b2f0b6218d27f545aec2fa27dbb771d3b6497379c3b5804513e142a5e404ba0
+  md5: 39f6394ae835f0b16f01cbbd3bb1e8e2
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  constrains:
+  - libabseil-static =20220623.0=cxx17*
+  - abseil-cpp =20220623.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1107051
+  timestamp: 1670671741614
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-10.0.1-h86614e7_4_cpu.conda
+  sha256: dfcafec24724c30cb78372ef2cfa4efca1faaba4500467e2310fe7a548abbc1c
+  md5: 9e2fbb34a627978eb15402d91e84efcb
+  depends:
+  - aws-sdk-cpp >=1.9.379,<1.9.380.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-ares >=1.18.1,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.6.0,<0.7.0a0
+  - libabseil 20220623.0 cxx17*
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libgcc-ng >=12
+  - libgoogle-cloud >=2.5.0,<2.5.1.0a0
+  - libgrpc >=1.51.1,<1.52.0a0
+  - libprotobuf >=3.21.12,<3.22.0a0
+  - libstdcxx-ng >=12
+  - libthrift >=0.16.0,<0.16.1.0a0
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.0.7,<4.0a0
+  - orc >=1.8.2,<1.8.3.0a0
+  - re2 >=2022.6.1,<2022.6.2.0a0
+  - snappy >=1.1.9,<1.2.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  - libutf8proc <2.9
+  constrains:
+  - arrow-cpp =10.0.1
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 26664923
+  timestamp: 1673821400305
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-19_linux64_openblas.conda
+  sha256: b1311b9414559c5760b08a32e0382ca27fa302c967968aa6f78e042519f728ce
+  md5: 420f4e9be59d0dc9133a0f43f7bab3f3
+  depends:
+  - libopenblas >=0.3.24,<0.3.25.0a0
+  - libopenblas >=0.3.24,<1.0a0
+  constrains:
+  - blas * openblas
+  - libcblas 3.9.0 19_linux64_openblas
+  - liblapack 3.9.0 19_linux64_openblas
+  - liblapacke 3.9.0 19_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14566
+  timestamp: 1697484219912
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.0.9-h166bdaf_9.conda
+  sha256: fc57c0876695c5b4ab7173438580c1d7eaa7dccaf14cb6467ca9e0e97abe0cf0
+  md5: 61641e239f96eae2b8492dc7e755828c
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 71065
+  timestamp: 1687884232329
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.0.9-h166bdaf_9.conda
+  sha256: 564f301430c3c61bc5e149e74157ec181ed2a758befc89f7c38466d515a0f614
+  md5: 081aa22f4581c08e4372b0b6c2f8478e
+  depends:
+  - libbrotlicommon 1.0.9 h166bdaf_9
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 32567
+  timestamp: 1687884247423
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.0.9-h166bdaf_9.conda
+  sha256: d27bc2562ea3f3b2bfd777f074f1cac6bfa4a737233dad288cd87c4634a9bb3a
+  md5: 1f0a03af852a9659ed2bf08f2f1704fd
+  depends:
+  - libbrotlicommon 1.0.9 h166bdaf_9
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 265202
+  timestamp: 1687884262352
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-19_linux64_openblas.conda
+  sha256: 84fddccaf58f42b07af7fb42512bd617efcb072f17bdef27f4c1884dbd33c86a
+  md5: d12374af44575413fbbd4a217d46ea33
+  depends:
+  - libblas 3.9.0 19_linux64_openblas
+  constrains:
+  - blas * openblas
+  - liblapack 3.9.0 19_linux64_openblas
+  - liblapacke 3.9.0 19_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14458
+  timestamp: 1697484230827
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+  sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
+  md5: c965a5aa0d5c1c37ffc62dff36e28400
+  depends:
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20440
+  timestamp: 1633683576494
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-7.86.0-h2283fc2_1.tar.bz2
+  sha256: 485249c8cf7c2bd67d8308f7d1fccbe64e54334ad6cc73168d665eed824ca3bc
+  md5: fdca8cd67ec2676f90a70ac73a32538b
+  depends:
+  - krb5 >=1.19.3,<1.20.0a0
+  - libgcc-ng >=12
+  - libnghttp2 >=1.47.0,<2.0a0
+  - libssh2 >=1.10.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.0.7,<4.0a0
+  license: curl
+  license_family: MIT
+  size: 359593
+  timestamp: 1667347234315
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdap4-3.20.6-hd7c4107_2.tar.bz2
+  sha256: ebc0d6a0decbd236f3cc362d7485f8ad1f7aef1246ada5507b407892e88293c5
+  md5: c265ae57e3acdc891f3e2b93cf6784f5
+  depends:
+  - curl >=7.75.0,<9.0a0
+  - libgcc-ng >=9.3.0
+  - libstdcxx-ng >=9.3.0
+  - libuuid >=2.32.1,<3.0a0
+  - libxml2 >=2.9.10,<2.14.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 11898306
+  timestamp: 1616781500733
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.14-h166bdaf_0.tar.bz2
+  sha256: 6f7cbc9347964e7f9697bde98a8fb68e0ed926888b3116474b1224eaa92209dc
+  md5: fc84a0446e4e4fb882e78d786cfb9734
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 82697
+  timestamp: 1662888469663
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+  sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
+  md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 123878
+  timestamp: 1597616541093
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2
+  sha256: 8c9635aa0ea28922877dc96358f9547f6a55fc7e2eb75a556b05f1725496baf9
+  md5: 6f8720dff19e17ce5d48cfe7f3d2f0a3
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 106190
+  timestamp: 1598867915000
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.10-h28343ad_4.tar.bz2
+  sha256: 31ac7124c92628cd1c6bea368e38d7f43f8ec68d88128ecdc177773e6d00c60a
+  md5: 4a049fc560e00e43151dc51368915fdd
+  depends:
+  - libgcc-ng >=9.4.0
+  - openssl >=3.0.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1169108
+  timestamp: 1633489266107
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
+  sha256: 74c98a563777ae2ad71f1f74d458a8ab043cee4a513467c159ccf159d0e461f3
+  md5: 6305a3dd2752c76335295da4e581f2fd
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - expat 2.5.0.*
+  license: MIT
+  license_family: MIT
+  size: 77980
+  timestamp: 1680190528313
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+  sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+  md5: d645c6d2ac96843a2bfaccd2d62b3ac3
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 58292
+  timestamp: 1636488182923
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_2.conda
+  sha256: d361d3c87c376642b99c1fc25cddec4b9905d3d9b9203c1c545b8c8c1b04539a
+  md5: c28003b0be0494f9a7664389146716ff
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 13.2.0 h807b86a_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 771133
+  timestamp: 1695219384393
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.4.1-h4ae554a_2.tar.bz2
+  sha256: 025c82a2e253549e97a5dadfaad9a9702f45e6cf82d5698a97b40577e6194e8b
+  md5: d80de7473e7a85c2e2ef520574d92ab1
+  depends:
+  - blosc >=1.21.0,<2.0a0
+  - cfitsio >=4.0.0,<4.0.1.0a0
+  - expat >=2.4.3,<3.0a0
+  - freexl >=1.0.6,<2.0a0
+  - geos >=3.10.2,<3.10.3.0a0
+  - geotiff >=1.7.0,<1.7.1.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - hdf4 >=4.2.15,<4.3.0a0
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - icu >=69.1,<70.0a0
+  - jpeg >=9d,<10a
+  - json-c >=0.15,<0.16.0a0
+  - kealib >=1.4.14,<1.5.0a0
+  - libdap4 >=3.20.6,<3.20.7.0a0
+  - libgcc-ng >=9.4.0
+  - libkml >=1.3.0,<1.4.0a0
+  - libnetcdf >=4.8.1,<4.8.2.0a0
+  - libpng >=1.6.37,<1.7.0a0
+  - libpq >=14.1,<15.0a0
+  - libspatialite >=5.0.1,<5.1.0a0
+  - libstdcxx-ng >=9.4.0
+  - libtiff >=4.3.0,<4.5.0a0
+  - libuuid >=2.32.1,<3.0a0
+  - libwebp-base
+  - libxml2 >=2.9.12,<2.14.0a0
+  - libzlib >=1.2.11,<2.0.0a0
+  - openjpeg >=2.4.0,<3.0.0a0
+  - openssl >=3.0.0,<4.0a0
+  - pcre >=8.45,<9.0a0
+  - poppler >=21.11.0,<21.12.0a0
+  - postgresql
+  - proj >=8.2.1,<8.2.2.0a0
+  - sqlite >=3.37.0,<4.0a0
+  - tiledb >=2.6.0,<2.7.0a0
+  - xerces-c >=3.2.3,<3.3.0a0
+  - xz >=5.2.5,<6.0.0a0
+  - zstd >=1.5.1,<1.6.0a0
+  size: 14563017
+  timestamp: 1642648115252
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_2.conda
+  sha256: 767d71999e5386210fe2acaf1b67073e7943c2af538efa85c101e3401e94ff62
+  md5: e75a75a6eaf6f318dae2631158c46575
+  depends:
+  - libgfortran5 13.2.0 ha4646dd_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 23722
+  timestamp: 1695219642066
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_2.conda
+  sha256: 55ecf5c46c05a98b4822a041d6e1cb196a7b0606126eb96b24131b7d2c8ca561
+  md5: 78fdab09d9138851dde2b5fe2a11019e
+  depends:
+  - libgcc-ng >=13.2.0
+  constrains:
+  - libgfortran-ng 13.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1441830
+  timestamp: 1695219403435
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.78.0-hebfc3b9_0.conda
+  sha256: 96ec4dc5e38f434aa5862cb46d74923cce1445de3cd0b9d61e3e63102b163af6
+  md5: e618003da3547216310088478e475945
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - pcre2 >=10.40,<10.41.0a0
+  constrains:
+  - glib 2.78.0 *_0
+  license: LGPL-2.1-or-later
+  size: 2701539
+  timestamp: 1694381226310
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_2.conda
+  sha256: e1e82348f8296abfe344162b3b5f0ddc2f504759ebeb8b337ba99beaae583b15
+  md5: e2042154faafe61969556f28bade94b9
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 421133
+  timestamp: 1695219303065
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.5.0-h21dfe5b_1.conda
+  sha256: 66919154dd7776c4c67a43e8113cef94f5bd17e254172fa5cd86735a5e2cbc80
+  md5: af905d193c58a376621f09a21849d2c6
+  depends:
+  - libabseil 20220623.0 cxx17*
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=7.86.0,<9.0a0
+  - libgcc-ng >=12
+  - libgrpc >=1.51.1,<1.52.0a0
+  - libprotobuf >=3.21.10,<3.22.0a0
+  - libstdcxx-ng >=12
+  - openssl >=3.0.7,<4.0a0
+  constrains:
+  - google-cloud-cpp 2.5.0 *_1
+  license: Apache-2.0
+  license_family: Apache
+  size: 8299285
+  timestamp: 1670357924824
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.51.1-h30feacc_0.conda
+  sha256: 78f41244e9470cc7bab201d35d5902e11d0422eb6623e56e362bf87fa0ce09b6
+  md5: 9eae4dc6fb0a91b026d4e419f0450737
+  depends:
+  - c-ares >=1.18.1,<2.0a0
+  - libabseil 20220623.0 cxx17*
+  - libgcc-ng >=12
+  - libprotobuf >=3.21.10,<3.22.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.0.7,<4.0a0
+  - re2 >=2022.6.1,<2022.6.2.0a0
+  - zlib
+  constrains:
+  - grpc-cpp =1.51.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5186644
+  timestamp: 1670308279543
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.8.0-h32351e8_1.tar.bz2
+  sha256: 2b52bbb87f875a44ebc599c534f73e027e59f69097a1a8769bcefa8e5bf6c060
+  md5: 0c52bb2b3b621d684f3beabd4aacaca7
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.9.14,<2.14.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3111122
+  timestamp: 1663269873382
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-h166bdaf_0.tar.bz2
+  sha256: 6a81ebac9f1aacdf2b4f945c87ad62b972f0f69c8e0981d68e111739e6720fd7
+  md5: b62b52da46c39ee2bc3c162ac7f1804d
+  depends:
+  - libgcc-ng >=10.3.0
+  license: GPL and LGPL
+  size: 1450368
+  timestamp: 1652700749886
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-h01aab08_1016.conda
+  sha256: 7e8f2e2bf09e9fae7c046b35545b3c71bebf4d87b38771cc7d058e83ae4b81cc
+  md5: 4d0907546d556ef7f14b1dcfa0e217ce
+  depends:
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - uriparser >=0.9.7,<1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 511196
+  timestamp: 1696314384123
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-19_linux64_openblas.conda
+  sha256: 58f402aae605ebd0932e1cbbf855cd49dcdfa2fcb6aab790a4f6068ec5937878
+  md5: 9f100edf65436e3eabc2a51fc00b2c37
+  depends:
+  - libblas 3.9.0 19_linux64_openblas
+  constrains:
+  - blas * openblas
+  - libcblas 3.9.0 19_linux64_openblas
+  - liblapacke 3.9.0 19_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14487
+  timestamp: 1697484241613
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
+  sha256: 225cc7c3b20ac1db1bdb37fa18c95bf8aecef4388e984ab2f7540a9f4382106a
+  md5: 73301c133ded2bf71906aa2104edae8b
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 31484415
+  timestamp: 1690557554081
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.8.1-nompi_h329d8a1_102.tar.bz2
+  sha256: 6fa35fbc482d133fd52a75186b5237da30a0a17e638e09894220bd63153668a0
+  md5: a857af323c5edbd8e9e45fb9facb6f5f
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - curl >=7.82.0,<9.0a0
+  - hdf4 >=4.2.15,<4.3.0a0
+  - hdf5 * nompi_*
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - jpeg >=9e,<10a
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  - libzip >=1.8.0,<2.0a0
+  - libzlib >=1.2.11,<2.0.0a0
+  - zlib >=1.2.11,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 1561521
+  timestamp: 1650908784061
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.55.1-h47da74e_0.conda
+  sha256: 5e60b852dbde156ef1fa939af2491fe0e9eb3000de146786dede7cda8991ae4c
+  md5: a802251d1eaeeae041c867faf0f94fa8
+  depends:
+  - c-ares >=1.20.1,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.4,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 627864
+  timestamp: 1698429073582
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+  sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+  md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  license_family: GPL
+  size: 33408
+  timestamp: 1697359010159
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.24-pthreads_h413a1c8_0.conda
+  sha256: c8e080ae4d57506238023e98869928ae93564e6407ef5b0c4d3a337e8c2b7662
+  md5: 6e4ef6ca28655124dcde9bd500e44c32
+  depends:
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  constrains:
+  - openblas >=0.3.24,<0.3.25.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5492091
+  timestamp: 1693785223074
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.39-h753d276_0.conda
+  sha256: a32b36d34e4f2490b99bddbc77d01a674d304f667f0e62c89e02c961addef462
+  md5: e1c890aebdebbfbf87e2c917187b4416
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: zlib-acknowledgement
+  size: 282599
+  timestamp: 1669075729952
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-14.5-he2d8382_0.tar.bz2
+  sha256: fd598710ffb7f7bcd9557b4f44cb4d591bb01a864a2fca13ec7de02fe4d2e263
+  md5: 820295fc93845d2bc2d9386d5f68f99e
+  depends:
+  - krb5 >=1.19.3,<1.20.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.2.12,<2.0.0a0
+  - openssl >=3.0.5,<3.2.0a0
+  - readline >=8.1.2,<9.0a0
+  size: 3123024
+  timestamp: 1660238409182
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-3.21.12-hfc55251_2.conda
+  sha256: 2df8888c51c23dedc831ba4378bad259e95c3a20a6408f54926a6a6f629f6153
+  md5: e3a7d4ba09b8dc939b98fef55f539220
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2230785
+  timestamp: 1693493608116
+- conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-hf69c175_9.tar.bz2
+  sha256: 98a5d77b323b5bc3a1a6c19c9fa3361717ea1b4bd97b4d2da5229db1206a15ac
+  md5: 24be5de0faf30ce36576f3dc73bc6cbc
+  depends:
+  - geos >=3.10.2,<3.10.3.0a0
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 241090
+  timestamp: 1642610497408
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
+  sha256: 53da0c8b79659df7b53eebdb80783503ce72fb4b10ed6e9e05cc0e9e4207a130
+  md5: c3788462a6fbddafdb413a9f9053e58d
+  depends:
+  - libgcc-ng >=7.5.0
+  license: ISC
+  size: 374999
+  timestamp: 1605135674116
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.0.1-h0e567f8_14.tar.bz2
+  sha256: f015eb314eb842b18a1b9c94044fb2e0da351eb7f5e23b5c8be99479ecbb969b
+  md5: 546f00291ca5b19c496eddb1d9f757f4
+  depends:
+  - freexl >=1.0.6,<2.0a0
+  - geos >=3.10.2,<3.10.3.0a0
+  - libgcc-ng >=9.4.0
+  - librttopo >=1.1.0,<1.2.0a0
+  - libstdcxx-ng >=9.4.0
+  - libxml2 >=2.9.12,<2.14.0a0
+  - libzlib >=1.2.11,<2.0.0a0
+  - proj >=8.2.1,<8.2.2.0a0
+  - sqlite >=3.37.0,<4.0a0
+  - zlib >=1.2.11,<1.3.0a0
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 4645349
+  timestamp: 1642622937840
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.44.0-h2797004_0.conda
+  sha256: 74ef5dcb900c38bec53140036e5e2a9cc7ffcd806da479ea2305f962a358a259
+  md5: b58e6816d137f3aabf77d341dd5d732b
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Unlicense
+  size: 845977
+  timestamp: 1698854720770
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+  sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
+  md5: 1f5a58e686b13bcfde88b93f547d23fe
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 271133
+  timestamp: 1685837707056
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_2.conda
+  sha256: ab22ecdc974cdbe148874ea876d9c564294d5eafa760f403ed4fd495307b4243
+  md5: 9172c297304f2a20134fc56c97fbe229
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3842773
+  timestamp: 1695219454837
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.16.0-he500d00_2.tar.bz2
+  sha256: 99cd473cc11c4c41184236caa6edc9540087717d59e4c363db563cc8daaae5ab
+  md5: 0e169728f52de7bcf5ffdbbdd9075e1a
+  depends:
+  - libevent >=2.1.10,<2.1.11.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.12,<2.0.0a0
+  - openssl >=3.0.5,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4798208
+  timestamp: 1663078195289
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.4.0-h82bc61c_5.conda
+  sha256: f81d38e7458c6ba2fcf93bef4ed2c12c2977e89ca9a7f936ce53a3338a88352f
+  md5: e712a63a21f9db647982971dc121cdcf
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.14,<1.26.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libwebp-base >=1.2.4,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  size: 484764
+  timestamp: 1671300678072
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
+  sha256: 49082ee8d01339b225f7f8c60f32a2a2c05fe3b16f31b554b4fb2c1dea237d1c
+  md5: ede4266dc02e875fe1ea77b25dd43747
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 101070
+  timestamp: 1667316029302
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33601
+  timestamp: 1680112270483
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
+  sha256: 68764a760fa81ef35dacb067fe8ace452bbb41476536a4a147a1051df29525f0
+  md5: 30de3fd9b3b602f7473f30e684eeea8c
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 401830
+  timestamp: 1694709121323
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.13-h7f98852_1004.tar.bz2
+  sha256: 8d5d24cbeda9282dd707edd3156e5fde2e3f3fe86c802fa7ce08c8f1e803bfd9
+  md5: b3653fdc58d03face9724f602218a904
+  depends:
+  - libgcc-ng >=9.4.0
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 399895
+  timestamp: 1636658924671
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.9.14-haae042b_4.conda
+  sha256: d98b647d14c405a6e2ddafab8e7e407cffb439c25a916d0cb1f596201593ae1c
+  md5: 8c9b5eeab562abb304a977c1beadc92d
+  depends:
+  - icu 69.*
+  - icu >=69.1,<70.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 737488
+  timestamp: 1673113394271
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.10.1-h2629f0a_3.conda
+  sha256: 84e93f189072dcfcbe77744f19c7e4171523fbecfaba7352e5a23bbe014574c7
+  md5: ac79812548e7e8cf61f7b0abdef01d3b
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 107198
+  timestamp: 1694416433629
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+  sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
+  md5: f36c115f1ee199da648e0597ec2047ad
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - zlib 1.2.13 *_5
+  license: Zlib
+  license_family: Other
+  size: 61588
+  timestamp: 1686575217516
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.40.1-py310h1b8f574_0.conda
+  sha256: 284462f15daa742e48dee4a103b5de1bee3e0fcddf5f60ca5510e3ca47dbc2e0
+  md5: 610577f6de29686bca87a4a8fde5eb19
+  depends:
+  - libgcc-ng >=12
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2504766
+  timestamp: 1687806322435
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.2-py310h350c4a5_1.conda
+  sha256: 776ced47e7f861c9d3eb50a2d524c213b947d693f22fb67980ecd398dc72b2d0
+  md5: 569cff5809efcd7e6927404e5a8797d8
+  depends:
+  - libgcc-ng >=12
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37077
+  timestamp: 1695448923391
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.3-h9c3ff4c_1.tar.bz2
+  sha256: 56313fe4e602319682d4ea05c0ed3c5c45fc79884a5896f2cb7436b15d6987f9
+  md5: fbe97e8fa6f275d7c76a09e795adc3e6
+  depends:
+  - libgcc-ng >=9.3.0
+  - libstdcxx-ng >=9.3.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 183677
+  timestamp: 1627669079456
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py310h2372a71_1.conda
+  sha256: ac46cc2f6d4bbeedcd2f508e43f43143a9286ced55730d8d97a3c91ceceb0d56
+  md5: b74e07a054c479e45a83a83fc5be713c
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24054
+  timestamp: 1695367637074
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.8.0-py310h62c0568_2.conda
+  sha256: 220052334fb2b01b5a487ddf6953c1c7713b401cc0faa0898401422799cdcec1
+  md5: 5c0d101ef8fc542778aa80795a759d08
+  depends:
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.0.1
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.21,<2
+  - numpy >=1.22.4,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.10.* *_cp310
+  - tk >=8.6.13,<8.7.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 6931914
+  timestamp: 1697011598818
+- conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.0.6-py310hd41b1e2_0.conda
+  sha256: cf37ee99132533005db95b611377d99f3cf4cb6feed494806d53aa7101768cd4
+  md5: 03255e1437f31f25ad95bb45c8b398bb
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: Apache
+  size: 197088
+  timestamp: 1695464250291
+- conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.0.4-py310h2372a71_1.conda
+  sha256: d8180dcee801bcde6408d924bab0010fc956ae7a14681694af21f9d4382d8ee8
+  md5: 7ca797f0a0c390ede770f415f5d5e039
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: APACHE
+  size: 56905
+  timestamp: 1696716235723
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
+  sha256: 91cc03f14caf96243cead96c76fe91ab5925a695d892e83285461fb927dece5e
+  md5: 7dbaa197d7ba6032caf7ae7f32c1efa0
+  depends:
+  - libgcc-ng >=12
+  license: X11 AND BSD-3-Clause
+  size: 884434
+  timestamp: 1698751260967
+- conda: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.6.0-nompi_py310h947f774_100.tar.bz2
+  sha256: 932c436283740402881d92e0f94f1a7b35b8c2a02ce3adab87e514a3fcaaae90
+  md5: ebde0c4a610be54e818f5407ddc33af7
+  depends:
+  - cftime
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - libgcc-ng >=12
+  - libnetcdf >=4.8.1,<4.8.2.0a0
+  - numpy >=1.21.6,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 493459
+  timestamp: 1656505710929
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda
+  sha256: 8fadeebb2b7369a4f3b2c039a980d419f65c7b18267ba0c62588f9f894396d0c
+  md5: da0ec11a6454ae19bff5b02ed881a2b1
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 226848
+  timestamp: 1669784948267
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.82-he02c5a1_0.conda
+  sha256: dd848f91478b155d3b3af6e64f494d17573fce7f7ebc154d48332f259b112f72
+  md5: f8d7f11d19e4cb2207eab159fd4c0152
+  depends:
+  - libgcc-ng >=12
+  - libsqlite >=3.40.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - nspr >=4.35,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1947586
+  timestamp: 1669788299053
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.57.1-py310h0f6aa51_0.conda
+  sha256: 4fc115078403e79bcfb1ec9b0649618b6af634e14d57c5172fed1f7bae45dec5
+  md5: 1a9f0067a638463c0f49869cab6a1d3e
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - llvmlite >=0.40.0,<0.41.0a0
+  - numpy >=1.21.6,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - cuda-python >=11.6
+  - cudatoolkit >=10.2
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.25
+  - libopenblas !=0.3.6
+  - cuda-version >=10.2
+  - scipy >=1.0
+  - tbb >=2021.6.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4165304
+  timestamp: 1687805009043
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.12.1-py310hc6cd4ac_0.conda
+  sha256: 2adddad7a1bbaffe551e0f124943adfc757078c4faec58c56f3d00569b55b974
+  md5: ec9394896c7ae67726c4716578fc2032
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - msgpack-python
+  - numpy >=1.7
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 756779
+  timestamp: 1697592377354
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.24.4-py310ha4c1d20_0.conda
+  sha256: 99d21a8b6c5777320257a74b61f5be3be9f6cb58625265ccb50bd0bddebe3917
+  md5: 6fedacfc835e461b4c37fd8e73712753
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6751237
+  timestamp: 1687808746109
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.0-h7d73246_1.tar.bz2
+  sha256: a715cba5649f12a1dca53dfd72fc49577152041f033d7595cf4b6a655a5b93b6
+  md5: a11b4df9271a8d7917686725aa04c8f2
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.37,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.4.0,<4.5.0a0
+  - libzlib >=1.2.12,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 546164
+  timestamp: 1660347757945
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.4-hd590300_0.conda
+  sha256: d15b3e83ce66c6f6fbb4707f2f5c53337124c01fb03bfda1cf25c5b41123efc7
+  md5: 412ba6938c3e2abaca8b1129ea82e238
+  depends:
+  - ca-certificates
+  - libgcc-ng >=12
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2648006
+  timestamp: 1698164814626
+- conda: https://conda.anaconda.org/conda-forge/linux-64/orc-1.8.2-hfdbbad2_2.conda
+  sha256: 3c7c2bc0f3e22159def9ae9a8b2154535d97fc5e85d2e28765490d59bc32e2ee
+  md5: 3a7319406d88f6ad2242f29e835ac707
+  depends:
+  - libgcc-ng >=12
+  - libprotobuf >=3.21.12,<3.22.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.9,<1.2.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 906992
+  timestamp: 1675621703742
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.1.2-py310hcc13569_0.conda
+  sha256: 657ce7a2c716298483137c54ef40a5afe016af6c4e3164bf313171f26b260f16
+  md5: 775a7709c5b7554340876a6c4a0f6b61
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.10.* *_cp310
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12372502
+  timestamp: 1698376371914
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre-8.45-h9c3ff4c_0.tar.bz2
+  sha256: 8f35c244b1631a4f31fb1d66ab6e1d9bfac0ca9b679deced1112c7225b3ad138
+  md5: c05d1820a6d34ff07aaaab7a9b7eddaa
+  depends:
+  - libgcc-ng >=9.3.0
+  - libstdcxx-ng >=9.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 259377
+  timestamp: 1623788789327
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.40-hc3806b6_0.tar.bz2
+  sha256: 7a29ec847556eed4faa1646010baae371ced69059a4ade43851367a076d6108a
+  md5: 69e2c796349cd9b273890bee0febfe1b
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.2.12,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2412495
+  timestamp: 1665562915343
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-9.2.0-py310h454ad03_3.tar.bz2
+  sha256: 202cc5b4c60e32096b67791f822699bf91670584ac3db7e86ebb1b6a4c584218
+  md5: eb354ff791f505b1d6f13f776359d88e
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=12
+  - libtiff >=4.4.0,<4.5.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - libxcb >=1.13,<1.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - tk >=8.6.12,<8.7.0a0
+  license: LicenseRef-PIL
+  size: 47452449
+  timestamp: 1666920698626
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.42.2-h59595ed_0.conda
+  sha256: ae917851474eb3b08812b02c9e945d040808523ec53f828aa74a90b0cdf15f57
+  md5: 700edd63ccd5fc66b70b1c028cea9a68
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 385309
+  timestamp: 1695736061006
+- conda: https://conda.anaconda.org/conda-forge/linux-64/poppler-21.11.0-ha39eefc_0.tar.bz2
+  sha256: 26dc2f2c24da2bd9acb8c541d42f37e27a5a11fdaa75ec70628ed28d9ffb19db
+  md5: e8fa8792970ec9278e9ae7e4d0ff2841
+  depends:
+  - boost-cpp >=1.74.0,<1.74.1.0a0
+  - cairo >=1.16.0,<2.0.0a0
+  - fontconfig >=2.13.1,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.10.4,<3.0a0
+  - gettext >=0.19.8.1,<1.0a0
+  - jpeg >=9d,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcurl >=7.79.1,<9.0a0
+  - libgcc-ng >=9.4.0
+  - libglib >=2.70.0,<3.0a0
+  - libiconv >=1.16,<2.0.0a0
+  - libpng >=1.6.37,<1.7.0a0
+  - libstdcxx-ng >=9.4.0
+  - libtiff >=4.3.0,<4.5.0a0
+  - libzlib >=1.2.11,<2.0.0a0
+  - nss >=3.71,<4.0a0
+  - openjpeg >=2.4.0,<3.0.0a0
+  - poppler-data
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 18306195
+  timestamp: 1636474408835
+- conda: https://conda.anaconda.org/conda-forge/linux-64/postgresql-14.5-ha7cec9f_0.tar.bz2
+  sha256: ecf1d30861cfb6d116299cec281c0b615d81b95ac8002e6d145a16dfe4249500
+  md5: 95a9d42d1e2819b218a40fa174289d7f
+  depends:
+  - krb5 >=1.19.3,<1.20.0a0
+  - libgcc-ng >=12
+  - libpq 14.5 he2d8382_0
+  - libxml2 >=2.9.14,<2.14.0a0
+  - libzlib >=1.2.12,<2.0.0a0
+  - openssl >=3.0.5,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - tzcode
+  - tzdata
+  - zlib >=1.2.12,<1.3.0a0
+  size: 5767766
+  timestamp: 1660238431993
+- conda: https://conda.anaconda.org/conda-forge/linux-64/proj-8.2.1-h277dcde_0.tar.bz2
+  sha256: 9bbd2c7b22387a04462c12f84f0fa5190c953e8cb593ac2a8d15cf252d340e76
+  md5: f2ceb1be6565c35e2db0ac948754751d
+  depends:
+  - libcurl >=7.80.0,<9.0a0
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  - libtiff >=4.3.0,<4.5.0a0
+  - sqlite >=3.37.0,<4.0a0
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 3133946
+  timestamp: 1641116350074
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py310h2372a71_1.conda
+  sha256: db8a99bc41c1b0405c8e9daa92b9d4e7711f9717aff7fd3feeba407ca2a91aa2
+  md5: cb25177acf28cc35cfa6c1ac1c679e22
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 361313
+  timestamp: 1695367285835
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+  sha256: 67c84822f87b641d89df09758da498b2d4558d47b920fd1d3fe6d3a871e000ff
+  md5: 22dad4df6e8630e8dff2428f6f6a7036
+  depends:
+  - libgcc-ng >=7.5.0
+  license: MIT
+  license_family: MIT
+  size: 5625
+  timestamp: 1606147468727
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-10.0.1-py310hea98ffe_4_cpu.conda
+  sha256: 87e71e351a84a7cbd33c7c575a5ad90519c672063b7a093e67ca143c824a6e21
+  md5: f8ecae697df9d8a0f06d3ac68645e0c6
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libarrow 10.0.1 h86614e7_4_cpu
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.21.6,<2.0a0
+  - parquet-cpp 1.5.1.*
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - arrow-cpp-proc * cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3801843
+  timestamp: 1673821966652
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.3.0-py310h9e0d750_1.tar.bz2
+  sha256: a5ea7ee2e9d9ac7e5710bfbd62b3ccb5a137cae4efe2bb3e1409eb2c50fa51bf
+  md5: 8505bfe1a312460e904bcebf082dbd3f
+  depends:
+  - certifi
+  - libgcc-ng >=9.4.0
+  - proj >=8.2.1,<8.2.2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 2172106
+  timestamp: 1641210605881
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.13-hd12c33a_0_cpython.conda
+  sha256: a53410f459f314537b379982717b1c5911efc2f0cc26d63c4d6f831bcb31c964
+  md5: f3a8c32aa764c3e7188b4b810fc9d6ce
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.43.2,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.4,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.10.* *_cp310
+  license: Python-2.0
+  size: 25476977
+  timestamp: 1698344640413
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-snappy-0.6.1-py310hb624d98_1.conda
+  sha256: de2f09dcf211ebb4cbb11199151efef409d67ef4beb0c251261ff5ce01a90d6f
+  md5: 8e025c0b1bb10dd2a94f64f2a99c8e69
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - snappy >=1.1.10,<1.2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 31828
+  timestamp: 1695500059797
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-4_cp310.conda
+  sha256: 456bec815bfc2b364763084d08b412fdc4c17eb9ccc66a36cb775fa7ac3cbaec
+  md5: 26322ec5d7712c3ded99dd656142b8ce
+  constrains:
+  - python 3.10.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6398
+  timestamp: 1695147363189
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py310h2372a71_1.conda
+  sha256: aa78ccddb0a75fa722f0f0eb3537c73ee1219c9dd46cea99d6b9eebfdd780f3d
+  md5: bb010e368de4940771368bc3dc4c63e7
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 170627
+  timestamp: 1695373587159
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-25.1.1-py310h795f18f_2.conda
+  sha256: 68fa979d6e92ddef0a93d22a4e902383b89db7ca77aab0682272bdeb4b14881a
+  md5: 6391ac95effeebc612023b9507b558b3
+  depends:
+  - libgcc-ng >=12
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  size: 456635
+  timestamp: 1698062566269
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.2.10-py310h5e0f756_4.tar.bz2
+  sha256: 393d3fdac25d7e023c38f765fab591bd9bb65cb079ff15a5de0d2feaecdd6ec5
+  md5: e80d5a05bb576bf3ada93dee04b8ad4a
+  depends:
+  - affine
+  - attrs
+  - certifi
+  - click >=4
+  - click-plugins
+  - cligj >=0.5
+  - libgcc-ng >=9.4.0
+  - libgdal >=3.4.1,<3.5.0a0
+  - libstdcxx-ng >=9.4.0
+  - numpy >=1.21.5,<2.0a0
+  - proj >=8.2.1,<8.2.2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14722612
+  timestamp: 1641327446583
+- conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2022.06.01-h27087fc_1.conda
+  sha256: 24bd3f98530f6e3cbf4ea1bfcf99509d342ec2e301a40807b230abb18c7a5e55
+  md5: 68070cd09c67755f37e0db13f00a008b
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 195975
+  timestamp: 1668975768124
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+  sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
+  md5: 47d31b792659ce70f470b5c82fdfb7a4
+  depends:
+  - libgcc-ng >=12
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 281456
+  timestamp: 1679532220005
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.10.6-py310hcb5633a_0.conda
+  sha256: a23d2f15c48cc689d26dc3f50ee91be9ed2925c5fbae7bc5d93e49db7517b847
+  md5: 43c12d8f7891a87378eb5339c49ef051
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 992400
+  timestamp: 1697072452949
+- conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.3.30-h3358134_0.conda
+  sha256: 9972660e0e3e41cd74fb9229de122a3bb053c8896b38d02b16e33cfb490e03ef
+  md5: e8b48ce0f01d5182d400f4f822842fa9
+  depends:
+  - libgcc-ng >=12
+  - openssl >=3.0.7,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 356141
+  timestamp: 1670465348894
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.3.2-py310h1fdf081_1.conda
+  sha256: 48a7396b62d82a064ec72e96020d89da6cd208e9bfb5d508693c4a9246502dd6
+  md5: 4b496f85644cce66ae83b7ab68e781a8
+  depends:
+  - _openmp_mutex >=4.5
+  - joblib >=1.1.1
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - scipy
+  - threadpoolctl >=2.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8395896
+  timestamp: 1698225291701
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.11.3-py310hb13e2d6_1.conda
+  sha256: bb8cdaf0869979ef58b3c10491f235c0fabf0b091e591361d25a4ffd47d6aded
+  md5: 4260b359d8fbeab4f789a8b0f968079f
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - numpy >=1.22.4,<1.28
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - libopenblas <0.3.26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14983190
+  timestamp: 1696468679504
+- conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-1.8.2-py310hb974679_1.tar.bz2
+  sha256: 22cc6cc23a75a617fd89347e71a27ed9db2d5cba92d7da3733917f7f6addeccd
+  md5: fa50d09d9925ad723148c44931e653f0
+  depends:
+  - geos >=3.10.2,<3.10.3.0a0
+  - libgcc-ng >=10.3.0
+  - numpy >=1.21.6,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 371559
+  timestamp: 1651793229011
+- conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
+  sha256: 02219f2382b4fe39250627dade087a4412d811936a5a445636b7260477164eac
+  md5: e6d228cd0bb74a51dd18f5bfce0b4115
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38865
+  timestamp: 1678534590321
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.44.0-h2c6b66d_0.conda
+  sha256: ae7031a471868c7057cc16eded7bb58fa3723d9c1650c9d3eb8de1ff65d89dbb
+  md5: df56c636df4a98990462d66ac7be2330
+  depends:
+  - libgcc-ng >=12
+  - libsqlite 3.44.0 h2797004_0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 836571
+  timestamp: 1698854732353
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.7.0-h924138e_1.conda
+  sha256: 27d76fe5972b1a21ba0d3fa83764a76f20c92b42dc58d045c3f02d78056de05c
+  md5: 1a272773743a97aa044fd5bcdac2138a
+  depends:
+  - libgcc-ng >=12
+  - libhwloc >=2.8.0,<2.8.1.0a0
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: APACHE
+  size: 1557826
+  timestamp: 1670332671471
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.6.4-h3f4058f_0.tar.bz2
+  sha256: dc25af331b644d874cd921bb9b735560f340cac888efae01e96093a8298765a6
+  md5: 6161d5bca657a28c40526769d7d131ac
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - curl >=7.82.0,<9.0a0
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  - libzlib >=1.2.11,<2.0.0a0
+  - lz4-c >=1.9.3,<1.9.4.0a0
+  - openssl >=3.0.0,<4.0a0
+  - zlib >=1.2.11,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 3427339
+  timestamp: 1646843978563
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-h2797004_0.conda
+  sha256: 679e944eb93fde45d0963a22598fafacbb429bb9e7ee26009ba81c4e0c435055
+  md5: 513336054f884f95d9fd925748f41ef3
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3290187
+  timestamp: 1695506262576
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.3.3-py310h2372a71_1.conda
+  sha256: 209b6788b81739d3cdc2f04ad3f6f323efd85b1a30f2edce98ab76d98079fac8
+  md5: b23e0147fa5f7a9380e06334c7266ad5
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: Apache
+  size: 641597
+  timestamp: 1695373710038
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tzcode-2022e-h166bdaf_0.tar.bz2
+  sha256: fb15e3a3228edcfde002f527ee2e9e0b5e1f15091521de1aa8429a4357138af8
+  md5: d83ab8f6570bbf0be104948fb2d0f79e
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 72542
+  timestamp: 1665540380704
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py310h2372a71_0.conda
+  sha256: 5ab2f2d4542ba0cc27d222c08ae61706babe7173b0c6dfa748aa37ff2fa9d824
+  md5: 72637c58d36d9475fda24700c9796f19
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: Apache
+  size: 374055
+  timestamp: 1695848183607
+- conda: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.7-hcb278e6_1.conda
+  sha256: bc7670384fc3e519b376eab25b2c747afe392b243f17e881075231f4a0f2e5a0
+  md5: 2c46deb08ba9b10e90d0a6401ad65deb
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 47151
+  timestamp: 1677712960862
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.15.0-py310h2372a71_1.conda
+  sha256: a48a93a409bed1fbdb2598acebce08343e7f6006110adf8e0335829df3cee41a
+  md5: 43e5d746d736ae6c71060ed923179d6d
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 54089
+  timestamp: 1695409287255
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.3-h8ce2273_4.tar.bz2
+  sha256: 774286e4796fec3f677a13385c37fa2f153cd47dde1c8e046b6d8e49e260c8c4
+  md5: b313f2002c5534313e3b2b74a76a051b
+  depends:
+  - icu >=69.1,<70.0a0
+  - libgcc-ng >=9.4.0
+  - libnsl >=2.0.0,<2.1.0a0
+  - libstdcxx-ng >=9.4.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1842721
+  timestamp: 1635488331020
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
+  sha256: e90b0a6a5d41776f11add74aa030f789faf4efd3875c31964d6f9cfa63a10dd1
+  md5: 4b230e8381279d76131116660f5a241a
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 27338
+  timestamp: 1610027759842
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hd590300_0.conda
+  sha256: 5aa9b3682285bb2bf1a8adc064cb63aff76ef9178769740d855abb42b0d24236
+  md5: b462a33c0be1421532f28bfe8f4a7514
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 58469
+  timestamp: 1685307573114
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-h7391055_0.conda
+  sha256: 089ad5f0453c604e18985480218a84b27009e9e6de9a0fa5f4a20b8778ede1f1
+  md5: 93ee23f12bc2e684548181256edd2cf6
+  depends:
+  - libgcc-ng >=12
+  - libuuid >=2.38.1,<3.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 27433
+  timestamp: 1685453649160
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.4-h0b41bf4_0.conda
+  sha256: 3c6862a01a39cdea3870b132706ad7256824299947a3a94ae361d863d402d704
+  md5: ea8fbfeb976ac49cbeb594e985393514
+  depends:
+  - libgcc-ng >=12
+  - libxcb 1.*
+  - libxcb >=1.13,<1.14.0a0
+  - xorg-kbproto
+  - xorg-xextproto >=7.3.0,<8.0a0
+  - xorg-xproto
+  license: MIT
+  license_family: MIT
+  size: 829872
+  timestamp: 1677611125385
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+  sha256: 309751371d525ce50af7c87811b435c176915239fc9e132b99a25d5e1703f2d4
+  md5: 2c80dc38fface310c9bd81b17037fee5
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 14468
+  timestamp: 1684637984591
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+  sha256: 4df7c5ee11b8686d3453e7f3f4aa20ceef441262b49860733066c52cfd0e4a77
+  md5: be93aabceefa2fac576e971aef407908
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 19126
+  timestamp: 1610071769228
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
+  sha256: 73e5cfbdff41ef8a844441f884412aa5a585a0f0632ec901da035a03e1fe1249
+  md5: 82b6df12252e6f32402b96dacc656fec
+  depends:
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.7.2,<2.0a0
+  - xorg-xextproto
+  license: MIT
+  license_family: MIT
+  size: 50143
+  timestamp: 1677036907815
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.10-h7f98852_1003.tar.bz2
+  sha256: 7d907ed9e2ec5af5d7498fb3ab744accc298914ae31497ab6dcc6ef8bd134d00
+  md5: f59c1242cc1dd93e72c2ee2b360979eb
+  depends:
+  - libgcc-ng >=9.3.0
+  - xorg-libx11 >=1.7.0,<2.0a0
+  - xorg-renderproto
+  license: MIT
+  license_family: MIT
+  size: 32906
+  timestamp: 1614866792944
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-h7f98852_1002.tar.bz2
+  sha256: 38942930f233d1898594dd9edf4b0c0786f3dbc12065a0c308634c37fd936034
+  md5: 06feff3d2634e3097ce2fe681474b534
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 9621
+  timestamp: 1614866326326
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
+  sha256: b8dda3b560e8a7830fe23be1c58cc41f407b2e20ae2f3b6901eb5842ba62b743
+  md5: bce9f945da8ad2ae9b1d7165a64d0f87
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 30270
+  timestamp: 1677036833037
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
+  sha256: f197bb742a17c78234c24605ad1fe2d88b1d25f332b75d73e5ba8cf8fbc2a10d
+  md5: b4a4381d54784606820704f7b5f05a15
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 74922
+  timestamp: 1607291557628
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+  sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+  md5: 2161070d867d1b1204ea749c8eec4ef0
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1 and GPL-2.0
+  size: 418368
+  timestamp: 1660346797927
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+  sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
+  md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 89141
+  timestamp: 1641346969816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.9.2-py310h2372a71_1.conda
+  sha256: 0a9aeb8cf885ef6dd0a737693823a4e4d27b2ee724fa3af317d8ccd925fa4258
+  md5: 30ae8a8f248b4e7cd2622cff41cb05a7
+  depends:
+  - idna >=2.0
+  - libgcc-ng >=12
+  - multidict >=4.0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: Apache
+  size: 97911
+  timestamp: 1696732658418
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h59595ed_0.conda
+  sha256: 53bf2a18224406e9806adb3b270a2c8a028aca0c89bd40114a85d6446f5c98d1
+  md5: 8851084c192dbc56215ac4e3c9aa30fa
+  depends:
+  - libgcc-ng >=12
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=12
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 343455
+  timestamp: 1697056638125
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
+  sha256: 9887a04d7e7cb14bd2b52fa01858f05a6d7f002c890f618d9fcd864adbfecb1b
+  md5: 68c34ec6149623be41a1933ab996a209
+  depends:
+  - libgcc-ng >=12
+  - libzlib 1.2.13 hd590300_5
+  license: Zlib
+  license_family: Other
+  size: 92825
+  timestamp: 1686575231103
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
+  sha256: 607cbeb1a533be98ba96cf5cdf0ddbb101c78019f1fda063261871dad6248609
+  md5: 04b88013080254850d6c01ed54810589
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 545199
+  timestamp: 1693151163452
+- conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+  sha256: fbf0288cae7c6e5005280436ff73c95a36c5a4c978ba50175cc8e3eb22abc5f9
+  md5: ae5f4ad87126c55ba3f690ef07f81d64
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18726
+  timestamp: 1674245215155
+- conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.7.0-pyhd8ed1ab_1.conda
+  sha256: b827f1f0666abd25bc01a14828379804692603f30e999ce0eac3b0d15858efb5
+  md5: eb36e010b948b1e8e5b891ba52d7c9e1
+  depends:
+  - aiohttp >=3.7.4.post0,<4.0.0
+  - aioitertools >=0.5.1,<1.0.0
+  - botocore >=1.31.16,<1.31.65
+  - python >=3.8
+  - wrapt >=1.10.10,<2.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 64048
+  timestamp: 1698795003527
+- conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.11.0-pyhd8ed1ab_0.tar.bz2
+  sha256: be2dbd6710438fa48b83bf06841091227276ae545d145dfe5cb5149c6484e951
+  md5: 59c40397276a286241c65faec5e1be3c
+  depends:
+  - python >=3.6
+  - typing_extensions >=4.0
+  license: MIT
+  license_family: MIT
+  size: 22516
+  timestamp: 1663521346032
+- conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 575c742e14c86575986dc867463582a970463da50b77264cdf54df74f5563783
+  md5: d1e1eb7e21a9e2c74279d87dafb68156
+  depends:
+  - frozenlist >=1.1.0
+  - python >=3.7
+  license: Apache-2.0
+  license_family: APACHE
+  size: 12730
+  timestamp: 1667935912504
+- conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
+  sha256: 64125775b2e724db5c72e431dd180495d5d509d0a2d1228a122e6af9f1b60e33
+  md5: 3c4e99d3ae4ec033d4dd99fb5220e540
+  depends:
+  - exceptiongroup
+  - idna >=2.8
+  - python >=3.8
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.22
+  license: MIT
+  license_family: MIT
+  size: 98958
+  timestamp: 1693488730301
+- conda: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+  sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
+  md5: 5f095bc6454094e96f146491fd03633b
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 12840
+  timestamp: 1603108499239
+- conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.3-pyhd8ed1ab_0.tar.bz2
+  sha256: b209a68ac55eb9ecad7042f0d4eedef5da924699f6cdf54ac1826869cfdae742
+  md5: 54ac328d703bff191256ffa1183126d1
+  depends:
+  - python >=2.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 8095
+  timestamp: 1649077760928
+- conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+  sha256: 130766446f5507bd44df957b6b5c898a8bd98f024bb426ed6cb9ff1ad67fc677
+  md5: 3afef1f55a1366b4d3b6a0d92e2235e4
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.7
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 18602
+  timestamp: 1692818472638
+- conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+  sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
+  md5: b77d8c2313158e6e461ca0efb1c2c508
+  depends:
+  - python >=3.8
+  - python-dateutil >=2.7.0
+  - types-python-dateutil >=2.8.10
+  license: Apache-2.0
+  license_family: Apache
+  size: 100096
+  timestamp: 1696129131844
+- conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+  sha256: b3e9369529fe7d721b66f18680ff4b561e20dbf6507e209e1f60eac277c97560
+  md5: c0481c9de49f040272556e2cedf42816
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 6164
+  timestamp: 1531050741142
+- conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+  sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
+  md5: 5f25798dcefd8252ce5f9dc494d5f571
+  depends:
+  - python >=3.5
+  - six >=1.12.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 28922
+  timestamp: 1698341257884
+- conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+  sha256: 7ed83731979fe5b046c157730e50af0e24454468bbba1ed8fc1a3107db5d7518
+  md5: 3d081de3a6ea9f894bbb585e8e3a4dcb
+  depends:
+  - python >=3.8
+  - typing_extensions >=4.0.0
+  license: MIT
+  license_family: MIT
+  size: 15342
+  timestamp: 1690563152778
+- conda: https://conda.anaconda.org/conda-forge/noarch/async-timeout-4.0.3-pyhd8ed1ab_0.conda
+  sha256: bd8b698e7f037a9c6107216646f1191f4f7a7fc6da6c34d1a6d4c211bcca8979
+  md5: 3ce482ec3066e6d809dbbb1d1679f215
+  depends:
+  - python >=3.7
+  - typing-extensions >=3.6.5
+  license: Apache-2.0
+  license_family: Apache
+  size: 11352
+  timestamp: 1691763717537
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+  sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
+  md5: 3edfead7cedd1ab4400a6c588f3e75f8
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 55022
+  timestamp: 1683424195402
+- conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.13.1-pyhd8ed1ab_0.conda
+  sha256: 1f955c700db16f65b16c9e9c1613436480d5497970b8030b7a9ebe1620cc2147
+  md5: 3ccff479c246692468f604df9c85ef26
+  depends:
+  - python >=3.7
+  - pytz
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6948100
+  timestamp: 1698174685067
+- conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+  sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
+  md5: 54ca2e08b3220c148a1d8329c2678e02
+  depends:
+  - python >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5950
+  timestamp: 1669158729416
+- conda: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
+  sha256: 7027bb689dd4ca4a08e3b25805de9d04239be6b31125993558f21f102a9d2700
+  md5: 6b1b907661838a75d067a22f87996b2e
+  depends:
+  - backports
+  - python >=3.6
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 11519
+  timestamp: 1687772319931
+- conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.2-pyha770c72_0.conda
+  sha256: 52d3e6bcd442537e22699cd227d8fdcfd54b708eeb8ee5b4c671a6a9b9cd74da
+  md5: a362ff7d976217f8fa78c0f1c4f59717
+  depends:
+  - python >=3.6
+  - soupsieve >=1.2
+  license: MIT
+  license_family: MIT
+  size: 115011
+  timestamp: 1680888259061
+- conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+  sha256: 845e77ef495376c5c3c328ccfd746ca0ef1978150cae8eae61a300fe7755fb08
+  md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
+  depends:
+  - packaging
+  - python >=3.6
+  - setuptools
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 131220
+  timestamp: 1696630354218
+- conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.2.2-pyhd8ed1ab_0.conda
+  sha256: 8ac8cc29fba1bd48a6c511dcfa8c92435f1c4f111a96d86a630a734026e739ca
+  md5: 30488151f591379db656250b3f5fc0c6
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.16,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5345834
+  timestamp: 1692002773859
+- conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.31.64-pyhd8ed1ab_0.conda
+  sha256: f73692d2c9d4c38796d07b92b509dd9a14b036c83f520672c608d9d79eb440ba
+  md5: b208e9509d3a523b914fa21cd46e4ae2
+  depends:
+  - jmespath >=0.7.1,<2.0.0
+  - python >=3.7
+  - python-dateutil >=2.1,<3.0.0
+  - urllib3 >=1.25.4,<1.27
+  license: Apache-2.0
+  license_family: Apache
+  size: 6383885
+  timestamp: 1697493501888
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+  sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
+  md5: 9b347a7ec10940d3f7941ff6c460b551
+  depends:
+  - cached_property >=1.5.2,<1.5.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4134
+  timestamp: 1615209571450
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+  sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+  md5: 576d629e47797577ab0f1b351297ef4a
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11065
+  timestamp: 1615209567874
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
+  sha256: db66e31866ff4250c190788769e3a8a1709237c3e9c38d7143aae95ab75fcb31
+  md5: 7f3dbc9179b4dde7da98dfb151d0ad22
+  depends:
+  - python >=3.7
+  license: ISC
+  size: 153791
+  timestamp: 1690024617757
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+  sha256: 20cae47d31fdd58d99c4d2e65fbdcefa0b0de0c84e455ba9d6356a4bdbc4b5b9
+  md5: 7f4a9e3fcff3f6356ae99244a014da6a
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 46597
+  timestamp: 1698833765762
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+  sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
+  md5: f3ad426304898027fc619827ff428eca
+  depends:
+  - __unix
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84437
+  timestamp: 1692311973840
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
+  sha256: 90236b113b9a20041736e80b80ee965167f9aac0468315c55e2bad902d673fb0
+  md5: 3549ecbceb6cd77b91a105511b7d0786
+  depends:
+  - __win
+  - colorama
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 85051
+  timestamp: 1692312207348
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+  sha256: ddef6e559dde6673ee504b0e29dd814d36e22b6b9b1f519fa856ee268905bf92
+  md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
+  depends:
+  - click >=3.0
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8992
+  timestamp: 1554588104889
+- conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+  sha256: 97bd58f0cfcff56a0bcda101e26f7d936625599325beba3e3a1fa512dd7fc174
+  md5: a29b7c141d6b2de4bb67788a5f107734
+  depends:
+  - click >=4.0
+  - python <4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10255
+  timestamp: 1633637895378
+- conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+  sha256: 0dfbc1ffa72e7a0882f486c9b1e4e9cccb68cf5c576fe53a89d076c9f1d43754
+  md5: 753d29fe41bb881e4b9c004f0abf973f
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24746
+  timestamp: 1697464875382
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+  sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+  md5: 3faab06a954c2a04039983f2c4a50d99
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25170
+  timestamp: 1666700778190
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 4e68730cc38236a736c8f1c6837c6460807cc0f0a5fd2166b3359d481e6f129f
+  md5: 1e424f22b3e2713068fe12d57f2dec5b
+  depends:
+  - pyct >=0.4.4
+  - python >=2.7
+  license: CC-BY-4.0
+  size: 1635349
+  timestamp: 1664843356249
+- conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
+  sha256: 11057745946a95ee7cc4c98900a60c7362266a4cb28bc97d96cd88e3056eb701
+  md5: c8eaca39e2b6abae1fc96acc929ae939
+  depends:
+  - python >=3.6
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11682
+  timestamp: 1691045097208
+- conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+  sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
+  md5: 5cd86562580f274031ede6aa6aa24441
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13458
+  timestamp: 1696677888423
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-2023.10.1-pyhd8ed1ab_0.conda
+  sha256: a31f8d1479585f1418e4e0f1594669278590e9bf7240fb9787e1e972935575c2
+  md5: 5b5af2efa7659441a9967734d046fecf
+  depends:
+  - bokeh >=2.4.2,!=3.0.*
+  - cytoolz >=0.11.0
+  - dask-core >=2023.10.1,<2023.10.2.0a0
+  - distributed >=2023.10.1,<2023.10.2.0a0
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.21,<2.0a0
+  - pandas >=1.3
+  - pyarrow >=7.0
+  - python >=3.9
+  constrains:
+  - openssl !=1.1.1e
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7467
+  timestamp: 1698451780224
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.10.1-pyhd8ed1ab_0.conda
+  sha256: e8322cce6f097b188a5c1fa2dfb14ea26f841dd33bc965036a5236e84d455ad8
+  md5: cf1f26a9e21311f10cfe9dbf0e0d99bc
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib_metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.9
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 862751
+  timestamp: 1698445693753
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-glm-0.2.0-py_1.tar.bz2
+  sha256: 002c044dc8facfa625e5a5aaad590dbd4716482f876aa721df5ebdda39ea23e1
+  md5: 7c9c5295a0499bf56bbf084578618af5
+  depends:
+  - dask
+  - multipledispatch >=0.4.9
+  - python >=3
+  - scikit-learn >=0.18
+  - scipy >=0.18.1
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14752
+  timestamp: 1568652585765
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-ml-2023.3.24-pyhd8ed1ab_1.conda
+  sha256: cb8756b5e15e00be71c8cbf75fac6848def0eb0a7de9ec6085fec95643de1f9a
+  md5: 24849fcc0f888d2ab326e681ece8b985
+  depends:
+  - dask >=2.4.0
+  - dask-glm >=0.2.0
+  - distributed >=2.4.0
+  - multipledispatch >=0.4.9
+  - numba >=0.51.0
+  - numpy >=1.20.0
+  - packaging
+  - pandas >=0.24.2
+  - python >=3.8
+  - scikit-learn >=1.2.0
+  - scipy
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 112866
+  timestamp: 1685113776677
+- conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.0-pyhd8ed1ab_0.conda
+  sha256: a705df42edde70be101c0523867f0ac25bd99a25ce2e96bbfb879d9541de68fb
+  md5: 2bcf7e080c7a702f6a5387b57dbf404f
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy
+  - pandas
+  - param
+  - pillow
+  - pyct
+  - python >=3.9
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17218904
+  timestamp: 1698408535171
+- conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+  md5: 43afe5ab04e35e17ba28649471dd7364
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 12072
+  timestamp: 1641555714315
+- conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
+  md5: 961b3a227b437d82ad7054484cfa71b2
+  depends:
+  - python >=3.6
+  license: PSF-2.0
+  license_family: PSF
+  size: 24062
+  timestamp: 1615232388757
+- conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2023.10.1-pyhd8ed1ab_0.conda
+  sha256: 47cd01df6449f922e37ce644c815eaf04ce2a7b106da90df1ab36889aa4af787
+  md5: 9fc9e3eacf6e23f902408d38198880de
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - cytoolz >=0.10.1
+  - dask-core >=2023.10.1,<2023.10.2.0a0
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.0
+  - packaging >=20.0
+  - psutil >=5.7.2
+  - python >=3.9
+  - pyyaml >=5.3.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.10.0
+  - tornado >=6.0.4
+  - urllib3 >=1.24.3
+  - zict >=3.0.0
+  constrains:
+  - openssl !=1.1.1e
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 790972
+  timestamp: 1698448652741
+- conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
+  md5: 3cf04868fee0a029769bd41f4b2fbf2d
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 9199
+  timestamp: 1643888357950
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+  sha256: c28f715e049fe0f09785660bcbffa175ffb438720e5bc5a60d56d4b08364b315
+  md5: e6518222753f519e911e83136d2158d9
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19262
+  timestamp: 1692026296517
+- conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+  sha256: c738804ab1e6376f8ea63372229a04c8d658dc90fd5a218c6273a2eaf02f4057
+  md5: e16be50e378d8a4533b989035b196ab8
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 27689
+  timestamp: 1698580072627
+- conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+  sha256: 42be6ac8478051b26751d778490d6a71de12e5c6443e145ff3eddbc577d9bcda
+  md5: 348e27e78a5e39090031448c72f66d5e
+  depends:
+  - python >=3.6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 19975
+  timestamp: 1643971626978
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+  sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+  md5: 0c96522c6bdaed4b1566d11387caaf45
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 397370
+  timestamp: 1566932522327
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+  sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+  md5: 34893075a5c9e55cdafac56607368fc6
+  license: OFL-1.1
+  license_family: Other
+  size: 96530
+  timestamp: 1620479909603
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+  sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+  md5: 4d59c254e01d9cde7957100457e2d5fb
+  license: OFL-1.1
+  license_family: Other
+  size: 700814
+  timestamp: 1620479612257
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-hab24e00_0.tar.bz2
+  sha256: 470d5db54102bd51dbb0c5990324a2f4a0bc976faa493b22193338adb9882e2e
+  md5: 19410c3df09dfb12d1206132a1d357c5
+  license: Ubuntu Font Licence Version 1.0
+  license_family: Other
+  size: 1961279
+  timestamp: 1566932680646
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+  sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+  md5: fee5683a3f04bd15cbd8318b096a27ab
+  depends:
+  - fonts-conda-forge
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3667
+  timestamp: 1566974674465
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+  sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
+  md5: f766549260d6815b0c52253f1fb1bb29
+  depends:
+  - font-ttf-dejavu-sans-mono
+  - font-ttf-inconsolata
+  - font-ttf-source-code-pro
+  - font-ttf-ubuntu
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4102
+  timestamp: 1566932280397
+- conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 6cfd1f9bcd2358a69fb571f4b3af049b630d52647d906822dbedac03e84e4f63
+  md5: 642d35437078749ef23a5dca2c9bb1f3
+  depends:
+  - cached-property >=1.3.0
+  - python >=2.7,<4
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 14395
+  timestamp: 1638810388635
+- conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.10.0-pyhca7485f_0.conda
+  sha256: 1bbdfadb93cc768252fd207dca406cde928f9a81ff985ea1760b6539c55923e6
+  md5: 5b86cf1ceaaa9be2ec4627377e538db1
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 124907
+  timestamp: 1697919506326
+- conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.0-pyha770c72_1.conda
+  sha256: 97fe438e399d9106998e38fc700fdd6f90f15ea92d1e20cf0a01e74436aa24ba
+  md5: 614a383c5f4350e0606689f54c6497b1
+  depends:
+  - packaging
+  - pandas >=1.4.0
+  - pyproj >=3.3.0
+  - python >=3.9
+  - shapely >=1.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1017514
+  timestamp: 1697032153699
+- conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.10.1-pyhd8ed1ab_0.conda
+  sha256: a0ec5fa04c38b69648fa3fae016d7b930a25558271affa69255f7cbfae70b139
+  md5: 08f49562f35d932cb35047016c46bde3
+  depends:
+  - bokeh >=3.1.0,<3.3.0
+  - cartopy >=0.18.0
+  - datashader
+  - geopandas-base
+  - geoviews-core 1.10.1 pyha770c72_0
+  - holoviews >=1.16.0
+  - netcdf4
+  - numpy >=1.0
+  - packaging
+  - pandas
+  - panel >=1.0.0
+  - param >=1.9.3,<2.0.0a0
+  - pyct
+  - pyproj
+  - python >=3.8
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8506
+  timestamp: 1689929056825
+- conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.10.1-pyha770c72_0.conda
+  sha256: f57324b4b89fe71430351f3e14645ba53cb4c53ceae0de78cb77d870cb70d4dd
+  md5: 95d909e4a2674ae827cffc7bea89e264
+  depends:
+  - bokeh >=3.1.0,<3.3.0
+  - cartopy >=0.18.0
+  - holoviews >=1.16.0
+  - numpy >=1.0
+  - packaging
+  - panel >=1.0.0
+  - param >=1.9.3
+  - pyproj
+  - python >=3.8
+  constrains:
+  - geoviews 1.10.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372667
+  timestamp: 1689929009202
+- conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.18.0-pyhd8ed1ab_0.conda
+  sha256: cdbb34574c43ad668e9de04166cd7c5963fb1b50a0d2ba71d47d8e64ec5b8029
+  md5: e503a9cc7f8d29d1fb33d19ed7aa5d67
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3364342
+  timestamp: 1697704974932
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 9887c35c374ec1847f167292d3fde023cb4c994a4ceeec283072b95440131f09
+  md5: 34272b248891bddccc64479f9a7fffed
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 56742
+  timestamp: 1663625484114
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
+  sha256: 2797ed927d65324309b6c630190d917b9f2111e0c217b721f80429aeb57f9fcf
+  md5: 4e9f59a060c3be52bc4ddc46ee9b6946
+  depends:
+  - python >=3.8
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25910
+  timestamp: 1688754651944
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
+  sha256: b96e01dc42d547d6d9ceb1c5b52a5232cc04e40153534350f702c3e0418a6b3f
+  md5: b279b07ce18058034e5b3606ba103a8b
+  depends:
+  - importlib-metadata >=6.8.0,<6.8.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 9428
+  timestamp: 1688754660209
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.0-pyhd8ed1ab_0.conda
+  sha256: adab6da633ec3b642f036ab5c1196c3e2db0e8db57fb0c7fc9a8e06e29fa9bdc
+  md5: 48b0d98e0c0ec810d3ccc2a0926c8c0e
+  depends:
+  - python >=3.8
+  - zipp >=3.1.0
+  constrains:
+  - importlib-resources >=6.1.0,<6.1.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 30024
+  timestamp: 1695414932459
+- conda: https://conda.anaconda.org/conda-forge/noarch/intake-0.7.0-pyhd8ed1ab_0.conda
+  sha256: 8dba632e81a11347d959bb11367f6b0184e2dcc9aeab550de156beac5fa6091b
+  md5: 310f0fdaec6eecd9cc7833a788bafb1f
+  depends:
+  - appdirs
+  - cloudpickle >=0.2.2
+  - dask >=1.0
+  - entrypoints
+  - fsspec >=0.7.4
+  - jinja2
+  - msgpack-python
+  - numpy
+  - partd >=0.3.10
+  - python >=3.6
+  - pyyaml
+  - requests
+  - toolz >=0.8.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 193092
+  timestamp: 1685391772164
+- conda: https://conda.anaconda.org/conda-forge/noarch/intake-xarray-0.7.0-pyhd8ed1ab_0.conda
+  sha256: ceb8cf5761c29467684cb860f1c73fce396ed412a3b54f69cdd314b96ef736b6
+  md5: d6471673fac9fa8f13a2517315ffcf6b
+  depends:
+  - dask >=2.2
+  - fsspec >=2022
+  - intake >=0.6.6
+  - msgpack-python
+  - netcdf4
+  - python >=3.5
+  - requests
+  - xarray >=2022
+  - zarr
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 27517
+  timestamp: 1685414168477
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.26.0-pyh3cd1d5f_0.conda
+  sha256: be9927d47fe23cc4d2a09d252e37e1e56ffb137767d2c0577ed882ead16f75fa
+  md5: 3c6e2148d30e6a762d8327a433ebfb5a
+  depends:
+  - __osx
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116536
+  timestamp: 1698244546989
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.26.0-pyha63f2e9_0.conda
+  sha256: 7208f5ae35c321d03c71e4072c959c60f877d1b9cc2fb32d805972b54123fb95
+  md5: 10e1de12f78f0fedb82ff723f602b5c5
+  depends:
+  - __win
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116868
+  timestamp: 1698244441309
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.26.0-pyhf8b6a83_0.conda
+  sha256: 9e647454f7572101657a07820ebed294df9a6a527b041cd5e4dd98b8aa3db625
+  md5: 2307f71f5f0896d4b91b93e6b468abff
+  depends:
+  - __linux
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116210
+  timestamp: 1698244196564
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh31c8845_0.conda
+  sha256: b28ec68a49d8ddc41b92f3161f536d63e62eb5493021e41bb172b5f0af54ca2d
+  md5: 28e743c2963d1cecaa75f7612ade74c4
+  depends:
+  - __osx
+  - appnope
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt_toolkit >=3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 591141
+  timestamp: 1698846944668
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh41d4057_0.conda
+  sha256: 31322d58f412787f5beeb01db4d16f10f8ae4e0cc2ec99fafef1e690374fe298
+  md5: f39d0b60e268fe547f1367edbab457d4
+  depends:
+  - __linux
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt_toolkit >=3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 589731
+  timestamp: 1698846745397
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh5737063_0.conda
+  sha256: e9da075dab85ad01df4355e264220e156273f719a62f6fad588a686616e86a9c
+  md5: f303446f1ce22bd9173650d3e722e87b
+  depends:
+  - __win
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt_toolkit >=3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 592050
+  timestamp: 1698847371880
+- conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
+  md5: 4cb68948e0b8429534380243d063a27a
+  depends:
+  - arrow >=0.15.0
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 17189
+  timestamp: 1638811664194
+- conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+  sha256: 362f0936ef37dfd1eaa860190e42a6ebf8faa094eaa3be6aa4d9ace95f40047a
+  md5: 81a3be0b2023e1ea8555781f0ad904a2
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 841312
+  timestamp: 1696326218364
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+  sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
+  md5: c8490ed5c70966d232fdd389d0dbed37
+  depends:
+  - markupsafe >=2.0
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101443
+  timestamp: 1654302514195
+- conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 95ac5f9ee95fd4e34dc051746fc86016d3d4f6abefed113e2ede049d59ec2991
+  md5: 2cfa3e1cf3fb51bb9b17acc5b5e9ea11
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 21003
+  timestamp: 1655568358125
+- conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.3.2-pyhd8ed1ab_0.conda
+  sha256: 31e05d47970d956206188480b038829d24ac11fe8216409d8584d93d40233878
+  md5: 4da50d410f553db77e62ab62ffaa1abc
+  depends:
+  - python >=3.7
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 221200
+  timestamp: 1691577306309
+- conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.14-pyhd8ed1ab_0.conda
+  sha256: 41514104208c092959bef0713cbd795e72c535f2f939b7903d8c97809f2adaa7
+  md5: dac1dabba2b5a9d1aee175c5fcc7b436
+  depends:
+  - python >=3.7,<4.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25003
+  timestamp: 1688248468479
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.2-pyhd8ed1ab_0.conda
+  sha256: 07e5d395d83c4b12a7abe3989fb42abdcd3b1c51cd27549e5eab390bb8c7bf0f
+  md5: 24d41c2f9cc199d0a180ecf7ef54739c
+  depends:
+  - attrs >=22.2.0
+  - importlib_resources >=1.4.0
+  - jsonschema-specifications >=2023.03.6
+  - pkgutil-resolve-name >=1.3.10
+  - python >=3.8
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 71509
+  timestamp: 1698678642652
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
+  sha256: 7b0061e106674f27cc718f79a095e90a5667a3635ec6626dd23b3be0fd2bfbdc
+  md5: 7c27ea1bdbe520bb830dcadd59f55cbf
+  depends:
+  - importlib_resources >=1.4.0
+  - python >=3.8
+  - referencing >=0.25.0
+  license: MIT
+  license_family: MIT
+  size: 15296
+  timestamp: 1689701341221
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.2-pyhd8ed1ab_0.conda
+  sha256: b06681b4499635f0ed901f4879122bfd3ff6ef28de1797367769a4ba6b990b0d
+  md5: c447b7c28ad6bb3306f0015f1195c721
+  depends:
+  - fqdn
+  - idna
+  - isoduration
+  - jsonpointer >1.13
+  - jsonschema >=4.19.2,<4.19.3.0a0
+  - python
+  - rfc3339-validator
+  - rfc3986-validator >0.1.0
+  - uri-template
+  - webcolors >=1.11
+  license: MIT
+  license_family: MIT
+  size: 7389
+  timestamp: 1698678669876
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.0-pyhd8ed1ab_0.conda
+  sha256: 16fc7b40024adece716ba7227e5c123a2deccc13f946a10d9a3270493908d11c
+  md5: 38589f4104d11f2a59ff01a9f4e3bfb3
+  depends:
+  - importlib-metadata >=4.8.3
+  - jupyter_server >=1.1.2
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 52525
+  timestamp: 1685453825227
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.5.0-pyhd8ed1ab_0.conda
+  sha256: e4478e137e0975ce94ef4ee6e4a6736afaf4a00e99bc8007a275bcb39fe728d9
+  md5: 77e442cb7c382d01c916f91a8652811a
+  depends:
+  - importlib_metadata >=4.8.3
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.8
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105606
+  timestamp: 1698232162661
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.8.0-pyhd8ed1ab_0.conda
+  sha256: 44742f7b6453774fbbdf7cec20282f88c7362707990790116fec23270b81b447
+  md5: 04272d87d3e06c2e26af5e2d4b0e0ad8
+  depends:
+  - jsonschema-with-format-nongpl >=4.18.0
+  - python >=3.8
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21359
+  timestamp: 1697461797603
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.9.1-pyhd8ed1ab_0.conda
+  sha256: bb9a60ff41085031a28204add4e6120990437cfad341db297519f0a0f0df8e18
+  md5: 8e0cfa69e5b0062b829a9dbb14645def
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert-core >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.8
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 317157
+  timestamp: 1698244231289
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
+  sha256: 9f4c5fef9beef9fceed628db7a10b888f3308b37ae257ad3d50046088317ebf1
+  md5: 7c0965e1d4a0ee1529e8eaa03a78a5b3
+  depends:
+  - python >=3.8
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18974
+  timestamp: 1673491600853
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.7-pyhd8ed1ab_0.conda
+  sha256: 1d841546fd239d7edefbf00edd3bad4680b12c3eb2549026d6aa70a301f23295
+  md5: 80318d83f33b3bf4e57b8533b7a6691d
+  depends:
+  - async-lru >=1.0.0
+  - importlib_metadata >=4.8.3
+  - importlib_resources >=1.4
+  - ipykernel
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.19.0,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.8
+  - tomli
+  - tornado >=6.2.0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6142657
+  timestamp: 1697059891776
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0.tar.bz2
+  sha256: 08453e09d5a6bbaeeca839553a5dfd7a377a97550efab96019c334a8042f54f5
+  md5: 243f63592c8e449f40cd42eb5cf32f40
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17410
+  timestamp: 1649936689608
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.0-pyhd8ed1ab_0.conda
+  sha256: 608a878d08e0f4f51dd9a61eaead7c0e22d07f48aad06e3e2f6d6f1d0a929746
+  md5: a52834fa7e3d12abc5efdf06b2097a05
+  depends:
+  - babel >=2.10
+  - importlib-metadata >=4.8.3
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.8
+  - requests >=2.31
+  constrains:
+  - openapi-core >=0.18.0,<0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48289
+  timestamp: 1694532412609
+- conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 0980092a2e0a4bd263c18fb0db701589fc10fc8542ce511f844a533490d5f14e
+  md5: 25b93e66067eb496ac10da888e25cc33
+  depends:
+  - python >=3.6
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 22417
+  timestamp: 1651923701523
+- conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
+  md5: 91e27ef3d05cc772ce627e51cff111c4
+  depends:
+  - python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 8250
+  timestamp: 1650660473123
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.5.1-pyhd8ed1ab_0.conda
+  sha256: 35e8990504cf8dc7e2bb63efd855fb0a0d5c0d77bf79403235e757c24a83ec1d
+  md5: 323495027ffa625701129acebf861412
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 76573
+  timestamp: 1698797645633
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+  sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
+  md5: 93a8e71256479c62074356ef6ebf501b
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 64356
+  timestamp: 1686175179621
+- conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+  sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
+  md5: b21613793fcc81d944c76c9f2864a7de
+  depends:
+  - python >=3.6
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12273
+  timestamp: 1660814913405
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.0-pyhd8ed1ab_0.conda
+  sha256: 1ddac8d2be448cd1fbe49d2ca09df7e10d99679d53146a917f8bb4899f76d0ca
+  md5: 6c5358a10873a15398b6f15f60cb5e1f
+  depends:
+  - markdown-it-py >=1.0.0,<4.0.0
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 41197
+  timestamp: 1686175527330
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+  sha256: c678b9194e025b1fb665bec30ee20aab93399203583875b1dcc0a3b52a8f5523
+  md5: f8dab71fdc13b1bf29a01248b156d268
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 13707
+  timestamp: 1639515992326
+- conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.1-pyhd8ed1ab_0.conda
+  sha256: 0b4558d3afb64e23b66f5279b704de76ebeb6b4eebbf913d65fbd4ba7d9acc2f
+  md5: 1dad8397c94e4de97a70de552a7dcf49
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 66169
+  timestamp: 1692116828443
+- conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+  sha256: 6d5839f75780475ad4dffe018026d493e26076f95862550a48424b4d7f6689d8
+  md5: 1073dc92c8f247d94ac14dd79ca0bbec
+  depends:
+  - python
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 12299
+  timestamp: 1534825527617
+- conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+  sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
+  md5: 2ba8498c1018c1e9c61eb99b973dfe19
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12452
+  timestamp: 1600387789153
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
+  sha256: 4ebd237cdf4bfa5226f92d2ae78fab8dba27696909391884dc6594ca6f9df5ff
+  md5: e78da91cf428faaf05701ce8cc8f2f9b
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.8
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64852
+  timestamp: 1684791049212
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.10.0-pyhd8ed1ab_0.conda
+  sha256: 693fca2715f78faee1c5be2362d2f1ea30e6b7179b4d2762fd9ffdaae5c8a65a
+  md5: 56c421c936a17bbc7fd4b36c9bd3b236
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<3.1
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.8
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - nbconvert =7.10.0=*_0
+  - pandoc >=2.14.2,<4.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 188466
+  timestamp: 1698678612863
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
+  sha256: fc82c5a9116820757b03ffb836b36f0f50e4cd390018024dbadb0ee0217f6992
+  md5: 61ba076de6530d9301a0053b02f093d2
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.8
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100446
+  timestamp: 1690815009867
+- conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.8-pyhd8ed1ab_0.conda
+  sha256: d7b795b4e754136841c6da3f9fa1a0f7ec37bc7167e7dd68c5b45e657133e008
+  md5: a4f0e4519bc50eee4f53f689be9607f7
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11630
+  timestamp: 1697083896431
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.0.6-pyhd8ed1ab_0.conda
+  sha256: 5259ad2fb47300407dafa6ea5e78085a2c8de8dcdbfbaa58592bf2677d7187a9
+  md5: d60881c78a54cbf8042ae719f1f77a50
+  depends:
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab >=4.0.7,<4.1.0a0
+  - jupyterlab_server >=2.22.1,<3
+  - notebook-shim >=0.2,<0.3
+  - python >=3.8
+  - tornado >=6.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3122185
+  timestamp: 1697550916556
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
+  sha256: f028d7ad1f2175cde307db08b60d07e371b9d6f035cfae6c81ea94b4c408c538
+  md5: 67e0fe74c156267d9159e9133df7fd37
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16783
+  timestamp: 1682360712235
+- conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
+  sha256: 29db8c3b521d261bf71897ba3cfbebc81cd61e581b30fcb984b5a713f02fe1ff
+  md5: 4625b7b01d7f4ac9c96300a5515acfaa
+  depends:
+  - python >=3.6
+  - typing_utils
+  license: Apache-2.0
+  license_family: APACHE
+  size: 29976
+  timestamp: 1691338962381
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+  sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
+  md5: 79002079284aa895f883c6b7f3f88fd6
+  depends:
+  - python >=3.7
+  license: Apache-2.0
+  license_family: APACHE
+  size: 49452
+  timestamp: 1696202521121
+- conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
+  md5: 457c2c8c08e54905d6954e79cb5b5db9
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11627
+  timestamp: 1631603397334
+- conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.2.3-pyhd8ed1ab_0.conda
+  sha256: 646e6e60c59eb233af22c4b1d97b15f356643461836b0d76089b74b2be699d35
+  md5: 76230ad9115ff3783627f0977ed764eb
+  depends:
+  - bleach
+  - bokeh >=3.1.1,<3.3
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - param >=1.12.0,<2.0
+  - python >=3.8
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.16.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14015213
+  timestamp: 1695042991442
+- conda: https://conda.anaconda.org/conda-forge/noarch/param-1.13.0-pyh1a96a4e_0.conda
+  sha256: 924dee0430ef46af7b28841d49b503de6a8969af1c7b06897a4cff26d429f20e
+  md5: 158eda83fd21a14b8c483c0d1d102397
+  depends:
+  - python >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 79952
+  timestamp: 1678790904486
+- conda: https://conda.anaconda.org/conda-forge/noarch/parquet-cpp-1.5.1-2.tar.bz2
+  sha256: 15e50657515b791734ba045da5135377404ca37c518b2066b9c6451c65cd732e
+  md5: 79a5f78c42817594ae016a7896521a97
+  depends:
+  - arrow-cpp >=0.11.0
+  license: Apache 2.0
+  size: 3118
+  timestamp: 1541734907649
+- conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+  sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
+  md5: 17a565a0c3899244e938cdf417e7b094
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 71048
+  timestamp: 1638335054552
+- conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.1-pyhd8ed1ab_0.conda
+  sha256: b248238da2bb9dfe98e680af911dc7013af86095e3ec8baf08905555632d34c7
+  md5: acf4b7c0bcd5fa3b0e05801c4d2accd6
+  depends:
+  - locket
+  - python >=3.7
+  - toolz
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20743
+  timestamp: 1695667673391
+- conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
+  sha256: 07706c0417ead94f359ca7278f65452d3c396448777aba1da6a11fc351bdca9a
+  md5: 330448ce4403cc74990ac07c555942a1
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  size: 48780
+  timestamp: 1667297617062
+- conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+  sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
+  md5: 415f0ebb6198cc2801c73438a9fb5761
+  depends:
+  - python >=3
+  license: MIT
+  license_family: MIT
+  size: 9332
+  timestamp: 1602536313357
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
+  sha256: 435829a03e1c6009f013f29bb83de8b876c388820bf8cf69a7baeec25f6a3563
+  md5: 2400c0b86889f43aa52067161e1fb108
+  depends:
+  - python >=3.7
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 1398838
+  timestamp: 1697896918388
+- conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+  sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
+  md5: 405678b942f2481cecdb3e010f4925d9
+  depends:
+  - python >=3.6
+  license: MIT AND PSF-2.0
+  size: 10778
+  timestamp: 1694617398467
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+  sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
+  md5: 8f567c0a74aa44cf732f15773b4083b0
+  depends:
+  - python >=3.7
+  - typing-extensions >=4.6.3
+  license: MIT
+  license_family: MIT
+  size: 19985
+  timestamp: 1696272419779
+- conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
+  sha256: 2f227e17b3c0346112815faa605502b66c1c4511a856127f2899abf15a98a2cf
+  md5: d8d7293c5b37f39b2ac32940621c6592
+  license: BSD-3-Clause AND (GPL-2.0-only OR GPL-3.0-only)
+  license_family: OTHER
+  size: 2348171
+  timestamp: 1675353652214
+- conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.18.0-pyhd8ed1ab_0.conda
+  sha256: 0e0257eee11d3e0b3f73566283fd6c705b1b2a5dbc7d9a609fa885519a62913e
+  md5: ade903cbe0b4440ca6bed64932d124b5
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: Apache
+  size: 53959
+  timestamp: 1698692692135
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
+  sha256: 10e7fdc75d4b85633be6b12a70b857053987127a808caa0f88b2cba4b3ce6359
+  md5: a4986c6bb5b0d05a38855b0880a5f425
+  depends:
+  - python >=3.7
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.39
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269068
+  timestamp: 1688566090973
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
+  sha256: 89f7fecc7355181dbc2ab851e668a2fce6aa4830b336a34c93b59bda93206270
+  md5: 4bbbe67d5df19db30f04b8e344dc9976
+  depends:
+  - prompt-toolkit >=3.0.39,<3.0.40.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6731
+  timestamp: 1688566099039
+- conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+  sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+  md5: 359eeb6536da0e687af562ed265ec263
+  depends:
+  - python
+  license: ISC
+  size: 16546
+  timestamp: 1609419417991
+- conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+  sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
+  md5: 6784285c7e55cb7212efabc79e4c2883
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14551
+  timestamp: 1642876055775
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+  sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
+  md5: 076becd9e05608f8dc72757d5f3a91ff
+  depends:
+  - python ==2.7.*|>=3.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102747
+  timestamp: 1636257201998
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.4.6-py_0.tar.bz2
+  sha256: 50af51619db6a35c36e65e8f50c83c722c3358f1f4b5527e87799b8f9935ace0
+  md5: 42d91c89bc3993ec88681cffd3c0e326
+  depends:
+  - pyct-core 0.4.6.*
+  - python
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2652
+  timestamp: 1545265022341
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyct-core-0.4.6-py_0.tar.bz2
+  sha256: 8abc24dcf2782feca867974ba2aa0c9aaeae0966dad3f54507b39da30123d481
+  md5: 55ec526f95e0959de3f68bc6289a20da
+  depends:
+  - param >=1.7.0
+  - python
+  constrains:
+  - pyct 0.4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13725
+  timestamp: 1541164340776
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyepsg-0.4.0-py_0.tar.bz2
+  sha256: fb2581c8a56ac969fa4ce3becbbd9e8d3de3510216e79429fe1a0a7331a3a723
+  md5: c3de0e5a1931c6732457300d2832f02f
+  depends:
+  - python
+  - requests
+  license: LGPL-3.0
+  size: 20311
+  timestamp: 1543266859015
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
+  sha256: 3f0f0fadc6084960ec8cc00a32a03529c562ffea3b527eb73b1653183daad389
+  md5: 40e5cb18165466773619e5c963f00a7b
+  depends:
+  - python >=3.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 853439
+  timestamp: 1691408777841
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+  sha256: 4a1332d634b6c2501a973655d68f08c9c42c0bd509c349239127b10572b8354b
+  md5: 176f7d56f0cfe9008bdf1bccd7de02fb
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 89521
+  timestamp: 1690737983548
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 41eced0d5e855bc52018f200b239d627daa38ad78a655ffa2f1efd95b07b6bce
+  md5: 92a889dc236a5197612bc85bee6d7174
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 964060
+  timestamp: 1659003065197
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
+  sha256: b3a612bc887f3dd0fb7c4199ad8e342bd148cf69a9b74fd9468a18cf2bef07b7
+  md5: 56cd9fe388baac0e90c7149cfac95b60
+  depends:
+  - __win
+  - python >=3.8
+  - win_inet_pton
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19348
+  timestamp: 1661605138291
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+  sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+  md5: 2a7de29fb590ca14b5243c4c812c8025
+  depends:
+  - __unix
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18981
+  timestamp: 1661604969727
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+  sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
+  md5: dd999d1cc9f79e67dbb855c8924c7984
+  depends:
+  - python >=3.6
+  - six >=1.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 245987
+  timestamp: 1626286448716
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.1-pyhd8ed1ab_0.conda
+  sha256: 3fb1af1ac7525072c46e111bc4e96ddf971f792ab049ca3aa25dbebbaffb6f7d
+  md5: 305141cff54af2f90e089d868fffce28
+  depends:
+  - python >=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 226030
+  timestamp: 1696171963080
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+  sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
+  md5: a61bf9ec79426938ff785eb69dbb1960
+  depends:
+  - python >=3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13383
+  timestamp: 1677079727691
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
+  sha256: 0108888507014fb24573c31e4deceb61c99e63d37776dddcadd7c89b2ecae0b6
+  md5: 2590495f608a63625e165915fb4e2e34
+  depends:
+  - python >=3.6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 143131
+  timestamp: 1680081272948
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
+  sha256: 6b680e63d69aaf087cd43ca765a23838723ef59b0a328799e6363eb13f52c49e
+  md5: c93346b446cd08c169d843ae5fc0da97
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 187454
+  timestamp: 1693930444432
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.0-pyhd8ed1ab_0.conda
+  sha256: 479ef43683cdcbf414d9454309a169fe6c6a6373fc43945034e02a7e5a7b8f15
+  md5: 6a4c07fcb5e3f2fb06eca2f59d632e9b
+  depends:
+  - param
+  - python >=3.6
+  constrains:
+  - jupyterlab >=4.0,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 47588
+  timestamp: 1692264873960
+- conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
+  sha256: a6768fabc12f1eed87fec68c5c65439e908655cded1e458d70a164abbce13287
+  md5: a33161b983172ba6ef69d5fc850650cd
+  depends:
+  - attrs >=22.2.0
+  - python >=3.8
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 38061
+  timestamp: 1691337409918
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+  sha256: 9f629d6fd3c8ac5f2a198639fe7af87c4db2ac9235279164bfe0fcb49d8c4bad
+  md5: a30144e4156cdbb236f99ebb49828f8b
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.7
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 56690
+  timestamp: 1684774408600
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
+  md5: fed45fc5ea0813240707998abe49f520
+  depends:
+  - python >=3.5
+  - six
+  license: MIT
+  license_family: MIT
+  size: 8064
+  timestamp: 1638811838081
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+  sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
+  md5: 912a71cc01012ee38e6b90ddd561e36f
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 7818
+  timestamp: 1598024297745
+- conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.15.0-pyhd8ed1ab_0.conda
+  sha256: 6230b475046bd74c7b12c0c9121c57a8e18337b40265813ba9bef0866ec20866
+  md5: d0ce69099167a03cf0a1241f40284307
+  depends:
+  - numpy >=1.21
+  - packaging
+  - pyproj >=2.2
+  - python >=3.9
+  - rasterio >=1.2
+  - scipy
+  - xarray >=0.17
+  license: Apache-2.0
+  license_family: Apache
+  size: 47286
+  timestamp: 1692047062481
+- conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-2023.10.0-pyhd8ed1ab_0.conda
+  sha256: 2f190cf0c550d4ba400af6b62afefa47a01ff5b57ece67354d38037a304f0acb
+  md5: 557aa3617c92aa511841887db279dc51
+  depends:
+  - aiobotocore >=2.7.0,<2.7.1
+  - aiohttp
+  - fsspec 2023.10.0
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 31768
+  timestamp: 1697921065949
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh08f2357_0.conda
+  sha256: 55208c6b48d68dc9ad2e2cf81ab9dc6b8a1d607e67acf9115bdc7794accc84bc
+  md5: c00d32dfa733d381b6a1908d0d67e0d7
+  depends:
+  - __win
+  - python >=3.6
+  - pywin32
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23279
+  timestamp: 1682601755260
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh41d4057_0.conda
+  sha256: e74d3faf51a6cc429898da0209d95b209270160f3edbf2f6d8b61a99428301cd
+  md5: ada5a17adcd10be4fc7e37e4166ba0e2
+  depends:
+  - __linux
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22821
+  timestamp: 1682601391911
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyhd1c38e8_0.conda
+  sha256: dca4022bae47618ed738ab7d45ead5202d174b741cfb98e4484acdc6e76da32a
+  md5: 2657c3de5371c571aef6678afb4aaadd
+  depends:
+  - __osx
+  - pyobjc-framework-cocoa
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23021
+  timestamp: 1682601619389
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+  sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
+  md5: fc2166155db840c634a1291a5c35a709
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 464399
+  timestamp: 1694548452441
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+  sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
+  md5: e5f25f8dbc060e9a8d912e432202afc2
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 14259
+  timestamp: 1620240338595
+- conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
+  sha256: a3fd30754c20ddb28b777db38345ea00d958f46701f0decd6291a81c0f4eee78
+  md5: dd6cbc539e74cb1f430efbd4575b9303
+  depends:
+  - python >=3.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 14358
+  timestamp: 1662051357638
+- conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2
+  sha256: ebb8f5f9e362f186fb7d732e656f85c969b86309494436eba51cc3b8b96683f7
+  md5: cb83a3d6ecf73f50117635192414426a
+  depends:
+  - numpy
+  - pyparsing >=2.1.6
+  - python
+  license: MIT
+  license_family: MIT
+  size: 8136
+  timestamp: 1568905295860
+- conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
+  md5: 6d6552722448103793743dabfbda532d
+  depends:
+  - python >=2.7
+  license: Apache-2.0
+  license_family: APACHE
+  size: 26314
+  timestamp: 1621217159824
+- conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+  sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
+  md5: 3f144b2c34f8cb5a9abd9ed23a39c561
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 36754
+  timestamp: 1693929424267
+- conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+  sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
+  md5: e7df0fdd404616638df5ece6e69ba7af
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 26205
+  timestamp: 1669632203115
+- conda: https://conda.anaconda.org/conda-forge/noarch/tblib-2.0.0-pyhd8ed1ab_0.conda
+  sha256: 25557d772df1572e48e4c678d5825ace6411d7b6773f2d7ad4e06111bce12031
+  md5: f5580336fe091d46f9a2ea97da044550
+  depends:
+  - python >=3.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16575
+  timestamp: 1694702546560
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.0-pyh08f2357_0.tar.bz2
+  sha256: 5c8fcf31430e0f312bc65ab5aa5b893fcc250820c023b02ff3fd188ae13199a5
+  md5: 0152a609d5748ed9887d195b1e61a6c9
+  depends:
+  - __win
+  - python >=3.7
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 19530
+  timestamp: 1666708102607
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyh41d4057_0.conda
+  sha256: bce252eb53330a8ba9617caa7a1dc75ce602c8808cf547a8f4d48285901f47c3
+  md5: 3788984d535770cad699efaeb6cb3037
+  depends:
+  - __linux
+  - ptyprocess
+  - python >=3.7
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 20787
+  timestamp: 1670253786972
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyhd1c38e8_0.conda
+  sha256: a2f8382ab390c74af592cc3566dc22e2ed81e5ac69c5b6417d1b7c22e63927bc
+  md5: 046120b71d8896cb7faef78bfdbfee1e
+  depends:
+  - __osx
+  - ptyprocess
+  - python >=3.7
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 20347
+  timestamp: 1670254383751
+- conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.2.0-pyha21a80b_0.conda
+  sha256: 15e2f916fbfe3cc480160aa99eb6ba3edc183fceb234f10151d63870fdc4eccd
+  md5: 978d03388b62173b8e6f79162cf52b86
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20981
+  timestamp: 1689261378222
+- conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+  sha256: f0db1a2298a5e10e30f4b947566c7229442834702f549dded40a73ecdea7502d
+  md5: 7234c9eefff659501cd2fe0d2ede4d48
+  depends:
+  - python >=3.5
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23235
+  timestamp: 1666100385187
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+  md5: 5844808ffab9ebdb694585b50ba02a96
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 15940
+  timestamp: 1644342331069
+- conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 90229da7665175b0185183ab7b53f50af487c7f9b0f47cf09c184cbc139fd24b
+  md5: 92facfec94bc02d6ccf42e7173831a36
+  depends:
+  - python >=3.5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49136
+  timestamp: 1657485654230
+- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
+  sha256: b61c9222af05e8c5ff27e4a4d2eb81870c21ffd7478346be3ef644b7a3759cc4
+  md5: 03c97908b976498dcae97eb4e4f3149c
+  depends:
+  - colorama
+  - python >=3.7
+  license: MPL-2.0 or MIT
+  size: 89449
+  timestamp: 1691671387674
+- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.13.0-pyhd8ed1ab_0.conda
+  sha256: 7ac67960ba2e8c16818043cc65ac6190fa4fd95f5b24357df58e4f73d5e60a10
+  md5: 8a9953c15e1e5a7c1baddbbf4511a567
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 109701
+  timestamp: 1698671281969
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.14-pyhd8ed1ab_0.conda
+  sha256: 7b0129c72d371fa7a06ed5dd1d701844c20d03bb4641a38a88a982b347d087e2
+  md5: 4df15c51a543e806d439490b862be1c6
+  depends:
+  - python >=3.6
+  license: Apache-2.0 AND MIT
+  size: 21474
+  timestamp: 1689883066161
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+  sha256: d6e1dddd0c372218ef15912383d351ac8c73465cbf16238017f0269813cafe2d
+  md5: 384462e63262a527bda564fa2d9126c0
+  depends:
+  - typing_extensions 4.8.0 pyha770c72_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 10104
+  timestamp: 1695040958008
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+  sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
+  md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
+  depends:
+  - python >=3.8
+  license: PSF-2.0
+  license_family: PSF
+  size: 35108
+  timestamp: 1695040948828
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 9e3758b620397f56fb709f796969de436d63b7117897159619b87938e1f78739
+  md5: eb67e3cace64c66233e2d35949e20f92
+  depends:
+  - python >=3.6.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 13829
+  timestamp: 1622899345711
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+  sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
+  md5: 939e3e74d8be4dac89ce83b20de2492a
+  license: LicenseRef-Public-Domain
+  size: 117580
+  timestamp: 1680041306008
+- conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 04b6f17a9ff2bd36f70076dd1761408de1d38c6c791849a02c3a1d28ad466d00
+  md5: 3ddf6684d9b274a12c94e509ca45656c
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 8969
+  timestamp: 1608058755081
+- conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+  sha256: b76904b53721dc88a46352324c79d2b077c2f74a9f7208ad2c4249892669ae94
+  md5: 0944dc65cb4a9b5b68522c3bb585d41c
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 23999
+  timestamp: 1688655976471
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.18-pyhd8ed1ab_0.conda
+  sha256: 1cc0bab65a6ad0f5a8bd7657760a4fb4e670d30377f9dab88b792977cb3687e7
+  md5: bf61cfd2a7f212efba378167a07d4a6a
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 115175
+  timestamp: 1697813579644
+- conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.9-pyhd8ed1ab_0.conda
+  sha256: 7552f6545ed212b9ae5d023870481fc377c7f18b4854b63160699b95a420c42e
+  md5: 8e8280dec091763dfdc29e066de52270
+  depends:
+  - backports.functools_lru_cache
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 30316
+  timestamp: 1698744892384
+- conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
+  sha256: 6e097d5fe92849ad3af2c2a313771ad2fbf1cadd4dc4afd552303b2bf3f85211
+  md5: 166212fe82dad8735550030488a01d03
+  depends:
+  - python >=3.5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18186
+  timestamp: 1679900907305
+- conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+  sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
+  md5: daf5160ff9cde3a468556965329085b9
+  depends:
+  - python >=2.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15600
+  timestamp: 1694681458271
+- conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.4-pyhd8ed1ab_0.conda
+  sha256: df45b89862edcd7cd5180ec7b8c0c0ca9fb4d3f7d49ddafccdc76afcf50d8da6
+  md5: bdb77b28cf16deac0eef431a068320e8
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: APACHE
+  size: 45866
+  timestamp: 1696770282111
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.3-pyhd8ed1ab_0.conda
+  sha256: 84c3b57fba778add2bd47b7cc70e86f746d2c55549ffd2ccb6f3d6bf7c94d21d
+  md5: 3fc026b9c87d091c4b34a6c997324ae8
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 57901
+  timestamp: 1698670970223
+- conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyhd8ed1ab_6.tar.bz2
+  sha256: a11ae693a0645bf6c7b8a47bac030be9c0967d0b1924537b9ff7458e832c0511
+  md5: 30878ecc4bd36e8deeea1e3c151b2e0b
+  depends:
+  - __win
+  - python >=3.6
+  license: PUBLIC-DOMAIN
+  size: 8191
+  timestamp: 1667051294134
+- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2023.10.1-pyhd8ed1ab_0.conda
+  sha256: 6062114745e9c01813506527d7e48c75dbe5eb6017e4c60ce8c98ef9fd757db2
+  md5: 9b20e5d68eea6878a0a6fc57a3043889
+  depends:
+  - numpy >=1.22,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.9
+  constrains:
+  - seaborn-base >=0.11
+  - netcdf4 >=1.6.0
+  - iris >=3.2
+  - zarr >=2.12
+  - pint >=0.19
+  - h5py >=3.6
+  - hdf5 >=1.12
+  - cftime >=1.6
+  - sparse >=0.13
+  - cartopy >=0.20
+  - dask-core >=2022.7
+  - nc-time-axis >=1.4
+  - scipy >=1.8
+  - distributed >=2022.7
+  - bottleneck >=1.3
+  - matplotlib-base >=3.5
+  - toolz >=0.12
+  - h5netcdf >=1.0
+  - flox >=0.5
+  - numba >=0.55
+  license: Apache-2.0
+  license_family: APACHE
+  size: 711330
+  timestamp: 1697764509357
+- conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2023.10.1-pyhd8ed1ab_0.conda
+  sha256: da655e2e0a742fddefeeaf2dd828b62a1820a3755d13341e1a555a10fcb9cf81
+  md5: 1e0d85c0e2fef9539218da185b285f54
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36184
+  timestamp: 1698325478381
+- conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.16.1-pyhd8ed1ab_0.conda
+  sha256: a320989af085d1700ace9d982e6fdb7a63de11331ab7f8bf4cf4f636e3962b65
+  md5: 59ec835edbee50266b7bdbadab7ba335
+  depends:
+  - asciitree
+  - fasteners
+  - numcodecs >=0.10.0,<0.16.0a0
+  - numpy >=1.20,!=1.21.0
+  - python >=3.8
+  constrains:
+  - ipytree >=0.2.2
+  - ipywidgets >=8.0.0
+  - notebook
+  license: MIT
+  license_family: MIT
+  size: 157869
+  timestamp: 1692615826058
+- conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+  sha256: 3d65c081514569ab3642ba7e6c2a6b4615778b596db6b1c82ee30a2d912539e5
+  md5: cf30c2c15b82aacb07f9c09e28ff2275
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36325
+  timestamp: 1681770298596
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+  sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
+  md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 18954
+  timestamp: 1695255262261
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.8.6-py310hb372a2b_1.conda
+  sha256: e485ce2cf0b11b5f13a24ce3ec4b5d6b1fdc4ebc5cc54254870dbd4c0679da65
+  md5: abd77e19eaa1fa63abd7d00b16ce4021
+  depends:
+  - aiosignal >=1.1.2
+  - async-timeout <5.0,>=4.0.0a3
+  - attrs >=17.3.0
+  - charset-normalizer >=2.0,<4.0
+  - frozenlist >=1.1.1
+  - multidict >=4.5,<7.0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - yarl >=1.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  size: 626879
+  timestamp: 1696765706219
+- conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py310h6729b98_4.conda
+  sha256: c413de1658b9f34978e1a5c8dc1e93b75fdef8e453f0983a4d2fa4b6a669e2b2
+  md5: fea2a01f85aee10b268e0474a03eb148
+  depends:
+  - cffi >=1.0.1
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 31851
+  timestamp: 1695387111978
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.5-h671831e_0.conda
+  sha256: 1226eddda5a90a723946ae9ed7dcf9039ba56f3ee3cb078fe6f2bad465b875b7
+  md5: 7271143bc2eda1ac6e6fbe6aa9747c5f
+  depends:
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 88989
+  timestamp: 1698392883157
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.7-h50c96e6_0.conda
+  sha256: c379ddb6416bd04fc59ee877714395d0084d05406bdc05a624d59c9244dd03fa
+  md5: 542948d693c4c43fdc592b67c7bfb5e5
+  depends:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 45255
+  timestamp: 1697673379792
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.4-h10d778d_0.conda
+  sha256: 85509ce7dd7e3a62899255f6ab7b4f1c0e0698e03c2377f3cb713d4a830e827c
+  md5: 7c98964b624144db902343b456b57161
+  license: Apache-2.0
+  license_family: Apache
+  size: 204597
+  timestamp: 1697224614121
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.17-h6cdfeff_4.conda
+  sha256: d0aaf265198bd52894d69a04e2a3964343c949a4749e59f73d3fc5dc5b08df18
+  md5: 0191b03ce3829544a993d178e8b89e88
+  depends:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18008
+  timestamp: 1697276334093
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.3.2-h74ccef4_4.conda
+  sha256: 562e31046f456e90573db81114d513f4973ea62b098b5f9531b867571c1191f0
+  md5: b827ead7cf3266cd34ad3d572c009bed
+  depends:
+  - __osx >=10.9
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - libcxx >=16.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 47235
+  timestamp: 1697310241752
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.7.13-h7fc0988_7.conda
+  sha256: 136ffd3103102c4630a681973b7eaa4bf5860c77cedf0d1ef49e573d1fcd7ee1
+  md5: b071abb2d71cb995560f79d9079754c9
+  depends:
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-compression >=0.2.17,<0.2.18.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 162506
+  timestamp: 1697851135094
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.13.35-h3dcb58e_4.conda
+  sha256: 29c4484b1d8a5ede6e72eeeadb2dc7e01e1c0ed891e8535ab2f0f09f82973d6d
+  md5: d52da1ed8d8650d2dab781a19525d2f6
+  depends:
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 136648
+  timestamp: 1697832779642
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.9.8-hb951632_0.conda
+  sha256: f90837bb25f5f730f7b77c32a1f79d5e60af41ce266e51b93a6e5c8087642a5b
+  md5: 270bd917fcd02a15461a29a413cdb9b6
+  depends:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 138163
+  timestamp: 1697770881386
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.3.20-h4b852be_1.conda
+  sha256: d034cde20a7849ead712d1f93febb112837a3a7d0fb8a818a74dbaee1a30b0bf
+  md5: fab2b8a0e53821fb50ebcf51eee79bc2
+  depends:
+  - aws-c-auth >=0.7.5,<0.7.6.0a0
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 74096
+  timestamp: 1698603730478
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.12-h6cdfeff_3.conda
+  sha256: 68061052827513553fc45607ec789b3123af8981580afff40b34bc5660207c9d
+  md5: 9e5e7fab592b8800ba097e7eade71c4c
+  depends:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 47361
+  timestamp: 1697283408993
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.17-h6cdfeff_3.conda
+  sha256: a4d513e217fad50fdcf7dfec88b59a54b2b6b0c2e2567b57263bf720a1f02287
+  md5: 17e65df5303574a696923f9f8c08d8a3
+  depends:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 48720
+  timestamp: 1697283251979
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.24.4-hf472077_2.conda
+  sha256: de45d12d968fe171879fe1f742c6daf6e9dec4e711261c8f6e1d398a12523875
+  md5: bb45e023e76aa19b7a0c7eac7736fbb5
+  depends:
+  - __osx >=10.9
+  - aws-c-auth >=0.7.5,<0.7.6.0a0
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-c-mqtt >=0.9.8,<0.9.9.0a0
+  - aws-c-s3 >=0.3.20,<0.3.21.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  - libcxx >=16.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 275113
+  timestamp: 1698624323027
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.182-hfd15655_2.conda
+  sha256: 842ec140fb99701d90d32d3c022a9b75f2d611a8ba60dd40cfbb6838bc5eb407
+  md5: 69c5f6c1887d69cee963d5c5ca5fca0d
+  depends:
+  - __osx >=10.9
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - aws-crt-cpp >=0.24.4,<0.24.5.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libcxx >=16.0.6
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.4,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3167371
+  timestamp: 1698318222973
+- conda: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.5-heccf04b_0.conda
+  sha256: db629047f1721d5a6e3bd41b07c1a3bacd0dee70f4063b61db2aa46f19a0b8b4
+  md5: 3003fa6dd18769db1a616982dcee5b40
+  depends:
+  - libcxx >=15.0.7
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49891
+  timestamp: 1693657206065
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h0dc2134_1.conda
+  sha256: 4bf66d450be5d3f9ebe029b50f818d088b1ef9666b1f19e90c85479c77bbdcde
+  md5: 9272dd3b19c4e8212f8542cefd5c3d67
+  depends:
+  - brotli-bin 1.1.0 h0dc2134_1
+  - libbrotlidec 1.1.0 h0dc2134_1
+  - libbrotlienc 1.1.0 h0dc2134_1
+  license: MIT
+  license_family: MIT
+  size: 19530
+  timestamp: 1695990310168
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h0dc2134_1.conda
+  sha256: 7ca3cfb4c5df314ed481301335387ab2b2ee651e2c74fbb15bacc795c664a5f1
+  md5: ece565c215adcc47fc1db4e651ee094b
+  depends:
+  - libbrotlidec 1.1.0 h0dc2134_1
+  - libbrotlienc 1.1.0 h0dc2134_1
+  license: MIT
+  license_family: MIT
+  size: 16660
+  timestamp: 1695990286737
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py310h9e9d8ca_1.conda
+  sha256: 57d66ca3e072b889c94cfaf56eb7e1794d3b1b3179bd475a4edef50a03359354
+  md5: 2362e323293e7699cf1e621d502f86d6
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - libbrotlicommon 1.1.0 h0dc2134_1
+  license: MIT
+  license_family: MIT
+  size: 367037
+  timestamp: 1695990378635
+- conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2
+  sha256: 60ba4c64f5d0afca0d283c7addba577d3e2efc0db86002808dadb0498661b2f2
+  md5: 37edc4e6304ca87316e160f5ca0bd1b5
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 158829
+  timestamp: 1618862580095
+- conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.20.1-h10d778d_1.conda
+  sha256: 9e99ffb7e3376188c1e0c8037982a8fdc08c5736ea28f2314c20b8846179f0fe
+  md5: 0f9fe8eb46d409939d9b2a7d90a52325
+  license: MIT
+  license_family: MIT
+  size: 103592
+  timestamp: 1697955959402
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2023.7.22-h8857fd0_0.conda
+  sha256: 27de15e18a12117e83ac1eb8a8e52eb65731cc7f0b607a7922206a15e2460c7b
+  md5: bf2c54c18997bf3542af074c10191771
+  license: ISC
+  size: 149911
+  timestamp: 1690026363769
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h99e66fa_0.conda
+  sha256: f8d1142cf244eadcbc44e8ca2266aa61a05b6cda5571f9b745ba32c7ebbfdfba
+  md5: 13f830b1bf46018f7062d1b798d53eca
+  depends:
+  - __osx >=10.9
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=73.2,<74.0a0
+  - libcxx >=16.0.6
+  - libglib >=2.78.0,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - pixman >=0.42.2,<1.0a0
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 885311
+  timestamp: 1697028802967
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cartopy-0.22.0-py310hdba192b_1.conda
+  sha256: 9c0370f61dcbc40c74bc783e962cb174ade6aa8c7eb189844d19cc240396f35a
+  md5: d30880c1bf31c7227c9aaaf64d14fa4c
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - matplotlib-base >=3.4
+  - numpy >=1.22.4,<2.0a0
+  - packaging >=20
+  - pyproj >=3.1.0
+  - pyshp >=2.1
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - shapely >=1.7
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 1807364
+  timestamp: 1698173127195
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.16.0-py310hdca579f_0.conda
+  sha256: 37802485964f1a3137ed6ab21ebc08fe9d35e7dc4da39f2b72a814644dd1ac15
+  md5: b9e6213f0eb91f40c009ce69139c1869
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 229407
+  timestamp: 1696002017767
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cfitsio-4.3.0-h66f91ea_0.conda
+  sha256: 0246d80ce305609c7e810514d1aa578ef498a1f05fd2dba5fa46ea845e4e57b9
+  md5: f540472ad8a8ea2b39a4c6ca14ebc1b5
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.2.0,<9.0a0
+  - libgfortran >=5
+  - libgfortran5 >=12.2.0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: LicenseRef-fitsio
+  size: 843556
+  timestamp: 1690378027019
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cftime-1.6.3-py310h91862f5_0.conda
+  sha256: 0228455782d71f754f1f26fd1e5b0e4d62e376c7a56b3dde32f052bd56fd688b
+  md5: 19f7244847b734340cf12f5d7a5057d6
+  depends:
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 208830
+  timestamp: 1698610245564
+- conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.1.1-py310h88cfcbd_1.conda
+  sha256: 8c14e70025b7f13227ec13efcde9110f45c22c6c272a6195a6ed326844e853f8
+  md5: 6c6bb230adc009e2db377450ca8e0433
+  depends:
+  - libcxx >=15.0.7
+  - numpy >=1.16
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 218720
+  timestamp: 1695554682987
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cramjam-2.7.0-py310h3461e44_1.conda
+  sha256: 7286bd6cc650c5e38788397a91d809926216e6ae19dee2332780557745ec9d1f
+  md5: 88a1422037f4c0d12d3050f86df0465b
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 1332723
+  timestamp: 1695451167857
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-0.12.2-py310h6729b98_1.conda
+  sha256: 9e9ea124c4c01c9ebb5e2b341ef42800d23a270ea11da0306cac683c124bf9fa
+  md5: fb74453ab31604394ad6edc69eea79d0
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 316281
+  timestamp: 1695545493237
+- conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.0-py310h9e9d8ca_1.conda
+  sha256: ec80231e963753692b62245a94f5025db6a44ae70f7a36c6dcb8195f971c33ae
+  md5: 64be4364c95d1d58b2bdeba61c4ddf99
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 2386610
+  timestamp: 1695534781106
+- conda: https://conda.anaconda.org/conda-forge/osx-64/expat-2.5.0-hf0c8a7f_1.conda
+  sha256: 15c04a5a690b337b50fb7550cce057d843cf94dd0109d576ec9bc3448a8571d0
+  md5: e12630038077877cbb6c7851e139c17c
+  depends:
+  - libexpat 2.5.0 hf0c8a7f_1
+  license: MIT
+  license_family: MIT
+  size: 120323
+  timestamp: 1680191057827
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fastparquet-2023.10.1-py310h91862f5_0.conda
+  sha256: eeef7057c9ced36c1bfba2d3482dde4cce2ab79bf6140727bfb9ceff02e6911d
+  md5: 79ce3b9bcb533f522e1a0fe085470110
+  depends:
+  - cramjam >=2.3
+  - fsspec
+  - numpy >=1.20.3
+  - numpy >=1.22.4,<2.0a0
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 414555
+  timestamp: 1698413139336
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.14.2-h5bb23bf_0.conda
+  sha256: f63e6d1d6aef8ba6de4fc54d3d7898a153479888d40ffdf2e4cfad6f92679d34
+  md5: 86cc5867dfbee4178118392bae4a3c89
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 237068
+  timestamp: 1674829100063
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.43.1-py310hb372a2b_0.conda
+  sha256: 3a12906347d0c5e1070c87e351b9072b367233256559c63385c63533ae9545d9
+  md5: 2f4ffe85adb334cd58e74dd63605b66c
+  depends:
+  - brotli
+  - munkres
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - unicodedata2 >=14.0.0
+  license: MIT
+  license_family: MIT
+  size: 2146074
+  timestamp: 1696601555622
+- conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+  sha256: b292cf5a25f094eeb4b66e37d99a97894aafd04a5683980852a8cbddccdc8e4e
+  md5: 25152fce119320c980e5470e64834b50
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 599300
+  timestamp: 1694616137838
+- conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3ec172f_0.conda
+  sha256: 9d59f1894c3b526e6806e376e979b81d0df23a836415122b86458aef72cda24a
+  md5: 640c34a8084e2a812bcee5b804597fc9
+  depends:
+  - libexpat >=2.5.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - minizip >=4.0.1,<5.0a0
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 54007
+  timestamp: 1694952882265
+- conda: https://conda.anaconda.org/conda-forge/osx-64/frozenlist-1.4.0-py310h6729b98_1.conda
+  sha256: b411267747f904e76a11fe26d9a22b2102d2722e695a27c812baf22e50ca3515
+  md5: 655eb9673b2a8981b012a24d844b5a9f
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: APACHE
+  size: 46896
+  timestamp: 1695377980977
+- conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.12.0-he965462_0.conda
+  sha256: e84ff98270717ae49aeba6788476d3569ad33993a46d33d727ee528fb3386a58
+  md5: 264a53af0fb378e81b44e45e5ab5aff1
+  depends:
+  - libcxx >=15.0.7
+  license: LGPL-2.1-only
+  size: 1484046
+  timestamp: 1687940076636
+- conda: https://conda.anaconda.org/conda-forge/osx-64/geotiff-1.7.1-h889ec99_14.conda
+  sha256: 2d6d54763b4cc41a90d7ca810681c44eaff077027a7b6f5df676736fa0299746
+  md5: c994aeaa43a92403ecc723dba66b3f1f
+  depends:
+  - libcxx >=15.0.7
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - proj >=9.3.0,<9.3.1.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 118139
+  timestamp: 1695943158175
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.21.1-h8a4c099_0.tar.bz2
+  sha256: 915d3cd2d777b9b3fc2e87a25901b8e4a6aa1b2b33cf2ba54e9e9ed4f6b67d94
+  md5: 1e3aff29ce703d421c43f371ad676cc5
+  depends:
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 4153781
+  timestamp: 1665674106245
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hb1e8313_1004.tar.bz2
+  sha256: 39540f879057ae529cad131644af111a8c3c48b384ec6212de6a5381e0863948
+  md5: 3f59cc77a929537e42120faf104e0d16
+  depends:
+  - libcxx >=10.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94612
+  timestamp: 1599590973213
+- conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.1-hb7f2c08_3.conda
+  sha256: 47515e0874bcf67e438e1d5d093b074c1781f055067195f0d00a7790a56d446d
+  md5: aca150b0186836f893ebac79019e5498
+  license: MIT
+  license_family: MIT
+  size: 76514
+  timestamp: 1678717973971
+- conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.6.0-h8ac2a54_0.tar.bz2
+  sha256: fdb38560094fb4a952346dc72a79b3cb09e23e4d0cae9ba4f524e6e88203d3c8
+  md5: 69eb97ca709a136c53fdca1f2fd33ddf
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=12.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100624
+  timestamp: 1649143914155
+- conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
+  sha256: 8c767cc71226e9eb62649c903c68ba73c5f5e7e3696ec0319d1f90586cebec7d
+  md5: 7ce543bf38dbfae0de9af112ee178af2
+  depends:
+  - libcxx >=15.0.7
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 724103
+  timestamp: 1695661907511
+- conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.2-nompi_hedada53_100.conda
+  sha256: 08ab97d63ab4be60c92d3f5931effc565ae6ee0cd686eba81b9d20daf5f181ff
+  md5: 2b1d4f355b60eb10c5cb435b9f0e664f
+  depends:
+  - libaec >=1.0.6,<2.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libcxx >=15.0.7
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  license: LicenseRef-HDF5
+  license_family: BSD
+  size: 3564108
+  timestamp: 1692563939275
+- conda: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
+  sha256: f66362dc36178ac9b7c7a9b012948a9d2d050b3debec24bbd94aadbc44854185
+  md5: 5cc301d759ec03f28328428e28f65591
+  license: MIT
+  license_family: MIT
+  size: 11787527
+  timestamp: 1692901622519
+- conda: https://conda.anaconda.org/conda-forge/osx-64/json-c-0.17-h8e11ae5_0.conda
+  sha256: 2a493095fe1292108ff1799a1b47ababe82d844bfa3abcf2252676c1017a1e04
+  md5: 266d2e4ebbf37091c8322937392bb540
+  license: MIT
+  license_family: MIT
+  size: 71671
+  timestamp: 1691934144512
+- conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-2.4-py310h2ec42d9_3.conda
+  sha256: 3d1196f7c81ea64398c01e2285ae59f83e9366dda21c7427f11dde8d0da38609
+  md5: ca02450dbc1c346a06fc454b36ddab32
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16313
+  timestamp: 1695397584568
+- conda: https://conda.anaconda.org/conda-forge/osx-64/jupyter_core-5.5.0-py310h2ec42d9_0.conda
+  sha256: 14ed1c62603b53132a74cb73409cd0bfd133bbc79e7e4a78523e162e54f945ce
+  md5: e7b118f9dd76e48119bce8358a0f09c7
+  depends:
+  - platformdirs >=2.5
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 79037
+  timestamp: 1698674181050
+- conda: https://conda.anaconda.org/conda-forge/osx-64/kealib-1.5.2-h052fcf7_1.conda
+  sha256: b3982fad0bcbe07a8129d93b1977f3a8a26ea96aa5aae7ee1395917a2cac2db2
+  md5: 346aec056b5619302c4aa538fbee4bdf
+  depends:
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - libcxx >=15.0.7
+  license: MIT
+  license_family: MIT
+  size: 150105
+  timestamp: 1696011567365
+- conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.5-py310h88cfcbd_1.conda
+  sha256: ccd88bcb67f0cc8b68ed320039d58701da125de0579680d7d2ffe7857b872613
+  md5: cb1db728c5e65918e30b65f9652a3458
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 60432
+  timestamp: 1695380318538
+- conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.2-hb884880_0.conda
+  sha256: 081ae2008a21edf57c048f331a17c65d1ccb52d6ca2f87ee031a73eff4dc0fc6
+  md5: 80505a68783f01dc8d7308c075261b2f
+  depends:
+  - libcxx >=15.0.7
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.1.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1183568
+  timestamp: 1692098004387
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.15-hd6ba6f3_3.conda
+  sha256: b2234f24e3b0030762430ec3414410119d1129804a95ef65af50ad36cabd9bd5
+  md5: 8059507d52f477fbd4b81841e085e25b
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 224895
+  timestamp: 1695969874291
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+  sha256: e41790fc0f4089726369b3c7f813117bbc14b533e0ed8b94cf75aba252e82497
+  md5: f9d6a4c82889d5ecedec1d90eb673c55
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 290319
+  timestamp: 1657977526749
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20230802.1-cxx17_h048a20a_0.conda
+  sha256: 05431a6adb376a865e10d4ae673399d7890083c06f61cf18edb7c6629e75f39e
+  md5: 6554f5fb47c025273268bcdb7bf3cd48
+  depends:
+  - libcxx >=15.0.7
+  constrains:
+  - __osx >=10.13
+  - libabseil-static =20230802.1=cxx17*
+  - abseil-cpp =20230802.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 1148356
+  timestamp: 1695064289396
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.2-he965462_1.conda
+  sha256: 1b0a0b9b67e8f155ebdc7205a7421c7aff4850a740fc9f88b3fa23282c98ed72
+  md5: faa179050abc6af1385e0fe9dd074f91
+  depends:
+  - libcxx >=15.0.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29027
+  timestamp: 1696474151758
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.7.2-h0b5dc4a_0.conda
+  sha256: 77669122d52073078d55310cf21fdfc35c283243cd47a064d6dbab38d8e6ab02
+  md5: 0f8458c98eaf403501e7e699d93594e7
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libiconv >=1.17,<2.0a0
+  - libxml2 >=2.11.5,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - lzo >=2.10,<3.0a0
+  - openssl >=3.1.2,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 752960
+  timestamp: 1694542990941
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-13.0.0-h5fe8ab2_13_cpu.conda
+  sha256: 77721c6f6d61cd4d7d66295742f7b9841eb74bb3d4fd26d5f897469660fd8e3e
+  md5: bb7134adc5278c105b3d31d646362c8e
+  depends:
+  - __osx >=10.13
+  - __osx >=10.9
+  - aws-crt-cpp >=0.24.4,<0.24.5.0a0
+  - aws-sdk-cpp >=1.11.182,<1.11.183.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.6.0,<0.7.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=15.0.7
+  - libgoogle-cloud >=2.12.0,<2.13.0a0
+  - libgrpc >=1.58.1,<1.59.0a0
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libre2-11 >=2023.6.2
+  - libthrift >=0.19.0,<0.19.1.0a0
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.1.4,<4.0a0
+  - orc >=1.9.0,<1.9.1.0a0
+  - re2
+  - snappy >=1.1.10,<1.2.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  - libutf8proc <2.9
+  constrains:
+  - arrow-cpp =13.0.0
+  - parquet-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 20004504
+  timestamp: 1698343929046
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-19_osx64_openblas.conda
+  sha256: c2c96103aa23a65f45b76716df49940cb0722258d3e0416f8fa06ade02464b23
+  md5: e932b99c38915fa2ee252cdff6ea1f01
+  depends:
+  - libopenblas >=0.3.24,<0.3.25.0a0
+  - libopenblas >=0.3.24,<1.0a0
+  constrains:
+  - liblapacke 3.9.0 19_osx64_openblas
+  - libcblas 3.9.0 19_osx64_openblas
+  - liblapack 3.9.0 19_osx64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14812
+  timestamp: 1697484725085
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libboost-headers-1.82.0-h694c41f_6.conda
+  sha256: 84dae029e113178efa697fbbe6ff7aa270974f316fbf208a24242d35295e96a6
+  md5: 26a7214f82c75126cbd6d6a8e6792b31
+  constrains:
+  - boost-cpp =1.82.0
+  license: BSL-1.0
+  size: 13795494
+  timestamp: 1696732955800
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h0dc2134_1.conda
+  sha256: f57c57c442ef371982619f82af8735f93a4f50293022cfd1ffaf2ff89c2e0b2a
+  md5: 9e6c31441c9aa24e41ace40d6151aab6
+  license: MIT
+  license_family: MIT
+  size: 67476
+  timestamp: 1695990207321
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h0dc2134_1.conda
+  sha256: b11939c4c93c29448660ab5f63273216969d1f2f315dd9be60f3c43c4e61a50c
+  md5: 9ee0bab91b2ca579e10353738be36063
+  depends:
+  - libbrotlicommon 1.1.0 h0dc2134_1
+  license: MIT
+  license_family: MIT
+  size: 30327
+  timestamp: 1695990232422
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h0dc2134_1.conda
+  sha256: bc964c23e1a60ca1afe7bac38a9c1f2af3db4a8072c9f2eac4e4de537a844ac7
+  md5: 8a421fe09c6187f0eb5e2338a8a8be6d
+  depends:
+  - libbrotlicommon 1.1.0 h0dc2134_1
+  license: MIT
+  license_family: MIT
+  size: 299092
+  timestamp: 1695990259225
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-19_osx64_openblas.conda
+  sha256: 70afde49736007bbb804d126a3983ba1fa04383006aae416a2971d538e274427
+  md5: 40e412c219ad8cf87ba664466071bcf6
+  depends:
+  - libblas 3.9.0 19_osx64_openblas
+  constrains:
+  - liblapack 3.9.0 19_osx64_openblas
+  - liblapacke 3.9.0 19_osx64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14717
+  timestamp: 1697484740520
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+  sha256: 3043869ac1ee84554f177695e92f2f3c2c507b260edad38a0bf3981fce1632ff
+  md5: 23d6d5a69918a438355d7cbc4c3d54c9
+  depends:
+  - libcxx >=11.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20128
+  timestamp: 1633683906221
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.4.0-h726d00d_0.conda
+  sha256: cd3400ecb42fc420acb18e2d836535c44ebd501ebeb4e0bf3830776e9b4ca650
+  md5: 2c17b4dedf0039736951471f493353bd
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 366039
+  timestamp: 1697009485409
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.6-hd57cbcb_0.conda
+  sha256: 9063271847cf05f3a6cc6cae3e7f0ced032ab5f3a3c9d3f943f876f39c5c2549
+  md5: 7d6972792161077908b62971802f289a
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1142172
+  timestamp: 1686896907750
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.19-ha4e1b8e_0.conda
+  sha256: d0f789120fedd0881b129aba9993ec5dcf0ecca67a71ea20c74394e41adcb503
+  md5: 6a45f543c2beb40023df5ee7e3cedfbd
+  license: MIT
+  license_family: MIT
+  size: 68962
+  timestamp: 1694922440450
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+  sha256: dbd3c3f2eca1d21c52e4c03b21930bbce414c4592f8ce805801575b9e9256095
+  md5: 6016a8a1d0e63cac3de2c352cd40208b
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 105382
+  timestamp: 1597616576726
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-haf1e3a3_1.tar.bz2
+  sha256: c4154d424431898d84d6afb8b32e3ba749fe5d270d322bb0af74571a3cb09c6b
+  md5: 79dc2be110b2a3d1e97ec21f691c50ad
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 101424
+  timestamp: 1598868359024
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+  sha256: e0bd9af2a29f8dd74309c0ae4f17a7c2b8c4b89f875ff1d6540c941eefbd07fb
+  md5: e38e467e577bd193a7d5de7c2c540b04
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372661
+  timestamp: 1685726378869
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.5.0-hf0c8a7f_1.conda
+  sha256: 80024bd9f44d096c4cc07fb2bac76b5f1f7553390112dab3ad6acb16a05f0b96
+  md5: 6c81cb022780ee33435cca0127dd43c9
+  constrains:
+  - expat 2.5.0.*
+  license: MIT
+  license_family: MIT
+  size: 69602
+  timestamp: 1680191040160
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+  sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
+  md5: ccb34fb14960ad8b125962d3d79b31a9
+  license: MIT
+  license_family: MIT
+  size: 51348
+  timestamp: 1636488394370
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.7.2-h926149b_7.conda
+  sha256: 45eeefed61afa0aa6aaa68f5ab5de65a93b136bbf85a27aaad884214f69d739e
+  md5: c5acda4c49753de0e98d572fc9b111f8
+  depends:
+  - __osx >=10.9
+  - blosc >=1.21.5,<2.0a0
+  - cfitsio >=4.3.0,<4.3.1.0a0
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.12.0,<3.12.1.0a0
+  - geotiff >=1.7.1,<1.8.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - json-c >=0.17,<0.18.0a0
+  - kealib >=1.5.2,<1.6.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libarchive >=3.7.2,<3.8.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libcxx >=16.0.6
+  - libdeflate >=1.19,<1.26.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=16.0,<17.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.43.2,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxml2 >=2.11.5,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - openssl >=3.1.3,<4.0a0
+  - pcre2 >=10.40,<10.41.0a0
+  - poppler >=23.10.0,<23.11.0a0
+  - postgresql
+  - proj >=9.3.0,<9.3.1.0a0
+  - tiledb >=2.16,<2.17.0a0
+  - xerces-c >=3.2.4,<3.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 8960440
+  timestamp: 1697155015226
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_1.conda
+  sha256: 5be1a59316e5063f4e6492ea86d692600a7b8e32caa25269f8a3b386a028e5f3
+  md5: b55fd11ab6318a6e67ac191309701d5a
+  depends:
+  - libgfortran5 13.2.0 h2873a65_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 109855
+  timestamp: 1694165674845
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_1.conda
+  sha256: 44de8930eef3b14d4d9fdfe419e6c909c13b7c859617d3616d5a5e964f3fcf63
+  md5: 3af564516b5163cd8cc08820413854bc
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1571764
+  timestamp: 1694165583047
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.78.0-hc62aa5d_0.conda
+  sha256: 06baed236c43bc225b76145da50caa61d9a36f919525d3e3ed4e59b0d9b7c78a
+  md5: 2c70095fa74bf95a5fd5c830a1529a8b
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libcxx >=15.0.7
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - pcre2 >=10.40,<10.41.0a0
+  constrains:
+  - glib 2.78.0 *_0
+  license: LGPL-2.1-or-later
+  size: 2482876
+  timestamp: 1694381399072
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.12.0-h407922f_3.conda
+  sha256: ad0dbbd851ec86974b239de1c800c8ef52d665ea90c4fdc2ea855c3dcbb34983
+  md5: 9d9423eb233bbd6f82184eb9e2a95f2d
+  depends:
+  - __osx >=10.13
+  - __osx >=10.9
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libcxx >=16.0.6
+  - libgrpc >=1.58.1,<1.59.0a0
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - openssl >=3.1.3,<4.0a0
+  constrains:
+  - google-cloud-cpp 2.12.0 *_3
+  license: Apache-2.0
+  license_family: Apache
+  size: 30907199
+  timestamp: 1696838955088
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.58.2-hecc90c7_0.conda
+  sha256: 37478256b62e36ac20248ae31c9724a7ca6028fa3d88d74c956abf219507fe13
+  md5: 8084a2ff6579e8cc178457bbaaf44b6b
+  depends:
+  - __osx >=10.13
+  - __osx >=10.9
+  - c-ares >=1.20.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcxx >=16.0.6
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libre2-11 >=2023.6.2
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.4,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.58.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3980277
+  timestamp: 1698719891567
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hac89ed1_0.tar.bz2
+  sha256: 4a3294037d595754f7da7c11a41f3922f995aaa333f3cb66f02d8afa032a7bc2
+  md5: 691d103d11180486154af49c037b7ed9
+  license: GPL and LGPL
+  size: 1378276
+  timestamp: 1652702364402
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+  sha256: d9572fd1024adc374aae7c247d0f29fdf4b122f1e3586fe62acc18067f40d02f
+  md5: 72507f8e3961bc968af17435060b6dd6
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 579748
+  timestamp: 1694475265912
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libkml-1.3.0-hab3ca0e_1018.conda
+  sha256: f546750a59b85a4b721f69e34e797ceddb93c438ee384db285e3344490d6a9b5
+  md5: 535b1bb4896b113c14dfa64141370a12
+  depends:
+  - libboost-headers
+  - libcxx >=15.0.7
+  - libexpat >=2.5.0,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - uriparser >=0.9.7,<1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 398649
+  timestamp: 1696452291278
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-19_osx64_openblas.conda
+  sha256: 6a1704c43a03195fecbbb226be5c257b2e37621e793967c3f31c8521f19e18df
+  md5: 2e714df18db99ee6d7b4ac728f53ca62
+  depends:
+  - libblas 3.9.0 19_osx64_openblas
+  constrains:
+  - libcblas 3.9.0 19_osx64_openblas
+  - liblapacke 3.9.0 19_osx64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14724
+  timestamp: 1697484756327
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-hc8e404f_4.conda
+  sha256: 0df3902a300cfe092425f86144d5e00ef67be3cd1cc89fd63084d45262a772ad
+  md5: ed06753e2ba7c66ed0ca7f19578fcb68
+  depends:
+  - libcxx >=15
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 22467131
+  timestamp: 1690563140552
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.2-nompi_h6a32802_112.conda
+  sha256: 8b1bfc9322bd4f9fe770461fac5b75b1888ccdbdf72b2d2a2bec1e1c13e05f48
+  md5: 413f9a35e9f888163b922ea6cfafb9da
+  depends:
+  - blosc >=1.21.4,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - libaec >=1.0.6,<2.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libcxx >=15.0.7
+  - libxml2 >=2.11.5,<2.14.0a0
+  - libzip >=1.10.1,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  - zlib
+  - zstd >=1.5.5,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 737489
+  timestamp: 1693582116713
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.55.1-hc0a10c5_0.conda
+  sha256: a0352eafcf148aa1dfa25f28cf30c80f70bc78c1e549fdec6b7aad100b865944
+  md5: a9269f10f70851af622c112d2956d544
+  depends:
+  - __osx >=10.9
+  - c-ares >=1.20.1,<2.0a0
+  - libcxx >=15.0.7
+  - libev >=4.33,<4.34.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.4,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 602957
+  timestamp: 1698429317306
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.24-openmp_h48a4ad5_0.conda
+  sha256: ff2c14f7ed121f1df3ad06bea353288eade77c12fb891212a27af88a61483490
+  md5: 077718837dd06cf0c3089070108869f6
+  depends:
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - llvm-openmp >=15.0.7
+  constrains:
+  - openblas >=0.3.24,<0.3.25.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6157393
+  timestamp: 1693785988209
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.39-ha978bb4_0.conda
+  sha256: 5ad9f5e96e6770bfc8b0a826f48835e7f337c2d2e9512d76027a62f9c120b2a3
+  md5: 35e4928794c5391aec14ffdf1deaaee5
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: zlib-acknowledgement
+  size: 271689
+  timestamp: 1669075890643
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.0-h3df487d_1.conda
+  sha256: 57b674dbd88ed07b144ab49ef752c7a8dd6e01f393dada8ae496ca7659a0d4e5
+  md5: 0516915abcfb1cd86624f1773d12b551
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<3.2.0a0
+  license: PostgreSQL
+  size: 2362584
+  timestamp: 1696004192526
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.24.3-he0c2237_1.conda
+  sha256: 42426fb0dba77e8f8cdf7732e9ee5d1dbed6724d1d94c84deeb98376f4cdcadd
+  md5: 45b790be289d0759d1eb91283c98e95d
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcxx >=15.0.7
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2157294
+  timestamp: 1697158160443
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2023.06.02-h4694dbf_0.conda
+  sha256: 73acd1ade87762c3f1aacf2a7c6271dd1e1c972d46ea7c44d8781595bca9218e
+  md5: d7c00395eaf2446eec6ce0f34cfd5b78
+  depends:
+  - __osx >=10.13
+  - __osx >=10.9
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcxx >=16.0.6
+  constrains:
+  - re2 2023.06.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 182813
+  timestamp: 1697065869791
+- conda: https://conda.anaconda.org/conda-forge/osx-64/librttopo-1.1.0-h23f359d_14.conda
+  sha256: df61f3c42651fd02d2e5fbb3cd6a225df29dc91ec6c5a57d0d717dc14ee8e2dc
+  md5: 4cec4e76f3d1cd6ec739ca40e7e12847
+  depends:
+  - geos >=3.12.0,<3.12.1.0a0
+  - libcxx >=15.0.7
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 214159
+  timestamp: 1687974265453
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.18-hbcb3906_1.tar.bz2
+  sha256: 2da45f14e3d383b4b9e3a8bacc95cd2832aac2dbf9fbc70d255d384a310c5660
+  md5: 24632c09ed931af617fe6d5292919cab
+  license: ISC
+  size: 528765
+  timestamp: 1605135849110
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libspatialite-5.1.0-h231fb02_0.conda
+  sha256: 6a0571ce1ce67d95c4f9245645a5613247a7c425abff1e1c7edf6f402ea4e3d9
+  md5: 01e2c119c7b00f2116bc33660107ad37
+  depends:
+  - freexl >=2
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.12.0,<3.12.1.0a0
+  - libcxx >=15.0.7
+  - libiconv >=1.17,<2.0a0
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libxml2 >=2.11.5,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - proj >=9.3.0,<9.3.1.0a0
+  - sqlite
+  - zlib
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 3146968
+  timestamp: 1694987054620
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.44.0-h92b6c6a_0.conda
+  sha256: 0832dc9cf18e811d2b41f8f4951d5ab608678e3459b1a4f36347097d8a9abf68
+  md5: 5dd5e957ebfee02720c30e0e2d127bbe
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Unlicense
+  size: 891073
+  timestamp: 1698854990507
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+  sha256: f3886763b88f4b24265db6036535ef77b7b77ce91b1cbe588c0fbdd861eec515
+  md5: ca3a72efba692c59a90d4b9fc0dfe774
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 259556
+  timestamp: 1685837820566
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.19.0-h064b379_1.conda
+  sha256: 4346c25ef6e2ff3d0fc93074238508531188ecd0dbea6414f6cb93a7775072c4
+  md5: b152655bfad7c2374ff03be0596052b6
+  depends:
+  - libcxx >=15.0.7
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 325415
+  timestamp: 1695958330036
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h684deea_2.conda
+  sha256: 1ef5bd7295f4316b111f70ad21356fb9f0de50b85a341cac9e3a61ac6487fdf1
+  md5: 2ca10a325063e000ad6d2a5900061e0d
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=15.0.7
+  - libdeflate >=1.19,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: HPND
+  size: 266501
+  timestamp: 1695661828714
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
+  sha256: 55a7f96b2802e94def207fdfe92bc52c24d705d139bb6cdb3d936cbe85e1c505
+  md5: db98dc3e58cbc11583180609c429c17d
+  license: MIT
+  license_family: MIT
+  size: 98942
+  timestamp: 1667316472080
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.3.2-h0dc2134_0.conda
+  sha256: fa7580f26fec4c28321ec2ece1257f3293e0c646c635e9904679f4a8369be401
+  md5: 4e7e9d244e87d66c18d36894fd6a8ae5
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 346599
+  timestamp: 1694709233836
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.15-hb7f2c08_0.conda
+  sha256: f41904f466acc8b3197f37f2dd3a08da75720c7f7464d9267635debc4ac1902b
+  md5: 5513f57e0238c87c12dffedbcc9c1a4a
+  depends:
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 313793
+  timestamp: 1682083036825
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.11.5-h3346baf_1.conda
+  sha256: d901fab32e57a43c44e630fb1c4d0a163d23b109eecd6c68b9ee371800760bca
+  md5: 7584dee6af7de378aed0ae49aebedb8a
+  depends:
+  - icu >=73.2,<74.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 623399
+  timestamp: 1692960844532
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzip-1.10.1-hc158999_3.conda
+  sha256: 0689e4a6e67e80027e43eefb8a365273405a01f5ab2ece97319155b8be5d64f6
+  md5: 6112b3173f3aa2f12a8f40d07a77cc35
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 127599
+  timestamp: 1694416738467
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
+  sha256: fc58ad7f47ffea10df1f2165369978fba0a1cc32594aad778f5eec725f334867
+  md5: 4a3ad23f6e16f99c04e166767193d700
+  constrains:
+  - zlib 1.2.13 *_5
+  license: Zlib
+  license_family: Other
+  size: 59404
+  timestamp: 1686575566695
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-17.0.4-hb6ac08f_0.conda
+  sha256: d49b6958d22075de5fb707fd5f593cfa4be059015db48b7f1cd5e47e7efde2ff
+  md5: 31391b68245bc68504169e98ffaf2c44
+  constrains:
+  - openmp 17.0.4|17.0.4.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 299744
+  timestamp: 1698833439461
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.40.1-py310hd8379ad_0.conda
+  sha256: 4e40d94c43c581a2942fe759c88097c3c7098fe0b844605db06127adafbf7cb4
+  md5: e8b28ccb84dc768d48c9bcd27d9ff686
+  depends:
+  - libcxx >=15.0.7
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 261331
+  timestamp: 1687806752460
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-4.3.2-py310h4c8952d_1.conda
+  sha256: 94f74df2ee4c8d3e3ec814a240b152127a3ba92b911c9f178279ce12017d4b6f
+  md5: 2983e1835f50e5b9130f6969b1421eb0
+  depends:
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 34069
+  timestamp: 1695449108133
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+  sha256: 39aa0c01696e4e202bf5e337413de09dfeec061d89acd5f28e9968b4e93c3f48
+  md5: aa04f7143228308662696ac24023f991
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 156415
+  timestamp: 1674727335352
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lzo-2.10-haf1e3a3_1000.tar.bz2
+  sha256: c8a9401eff2efbbcc6da03d0066ee85d72402f7658c240e7968c64052a0d0493
+  md5: 0b6bca372a95d6c602c7a922e928ce79
+  license: GPL v2+
+  license_family: GPL2
+  size: 194278
+  timestamp: 1597682686489
+- conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.3-py310h6729b98_1.conda
+  sha256: 62076b034a92959d25a1321a4340745ff87b5d191b3fcfef607b746daeb845c5
+  md5: 000b20b3974452969efe63f980b69e33
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23056
+  timestamp: 1695367898746
+- conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.8.0-py310h2a8a546_2.conda
+  sha256: 8e40bd3c0f9e298b11547aea52ff838e205b13dd462b3865b8ca18caf1961504
+  md5: f7a246b3746e88f258e6a02135596189
+  depends:
+  - __osx >=10.12
+  - __osx >=10.9
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.0.1
+  - libcxx >=16.0.6
+  - numpy >=1.21,<2
+  - numpy >=1.22.4,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.10.* *_cp310
+  license: PSF-2.0
+  license_family: PSF
+  size: 6909372
+  timestamp: 1697011649957
+- conda: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.0.2-h23f18a7_0.conda
+  sha256: 15f1f8340693710d726a4d9063248119561c24c5922df268fad289028352dadc
+  md5: 86f4435be14480ce928083cde62e9194
+  depends:
+  - __osx >=10.9
+  - bzip2 >=1.0.8,<2.0a0
+  - libcxx >=16.0.6
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.4,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 79162
+  timestamp: 1698348786967
+- conda: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.0.6-py310h88cfcbd_0.conda
+  sha256: 159bbd6836834f33376b9f1ae0f001a48e93adcb01c14dc3ddd736a28eb87003
+  md5: 9c6130d5cf10a5da29633a8e625bbc71
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: Apache
+  size: 187648
+  timestamp: 1695464433160
+- conda: https://conda.anaconda.org/conda-forge/osx-64/multidict-6.0.4-py310h90acd4f_1.conda
+  sha256: 4691a07626fe8bde42ce31c2362744a91dfd71d788d21c913a681c3f1a971f63
+  md5: f49c126c578aea3de62a821eeedcd1b2
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: APACHE
+  size: 50647
+  timestamp: 1696716333308
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-h93d8f39_2.conda
+  sha256: ea0fca66bbb52a1ef0687d466518fe120b5f279684effd6fd336a7b0dddc423a
+  md5: e58f366bd4d767e9ab97ab8b272e7670
+  depends:
+  - __osx >=10.9
+  license: X11 AND BSD-3-Clause
+  size: 822031
+  timestamp: 1698751567986
+- conda: https://conda.anaconda.org/conda-forge/osx-64/netcdf4-1.6.5-nompi_py310h30a4ba5_100.conda
+  sha256: 6362b982a6d5f7fa1ddd09554bc6552aacd81e2fedbd0a83d15c204e4212c550
+  md5: 0062c0ed9fb5da4d358fb106379e0a5c
+  depends:
+  - certifi
+  - cftime
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 458161
+  timestamp: 1698267301054
+- conda: https://conda.anaconda.org/conda-forge/osx-64/nspr-4.35-hea0b92c_0.conda
+  sha256: da6e19bd0ff31e219760e647cfe1cc499a8cdfaff305f06c56d495ca062b86de
+  md5: a9e56c98d13d8b7ce72bf4357317c29b
+  depends:
+  - libcxx >=14.0.6
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 230071
+  timestamp: 1669785313586
+- conda: https://conda.anaconda.org/conda-forge/osx-64/nss-3.94-hd6ac835_0.conda
+  sha256: aafb8b2a51beaa407d4e712d11e2a34fc010c7727d8a5573fb0c7ae53f2fff75
+  md5: 10c69224110baa4d7d4f1bdb03d4f383
+  depends:
+  - libcxx >=15.0.7
+  - libsqlite >=3.43.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - nspr >=4.35,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1895925
+  timestamp: 1696290343167
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.57.1-py310he09a53b_0.conda
+  sha256: 67428ff71def3c5ea5d94a5a2032b59ac4188e473a0f21d8dd77d51a465489a1
+  md5: 75affaad0bf98ec1faba0c25f632638e
+  depends:
+  - libcxx >=15.0.7
+  - llvm-openmp >=15.0.7
+  - llvm-openmp >=16.0.6
+  - llvmlite >=0.40.0,<0.41.0a0
+  - numpy >=1.21.6,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.25
+  - cuda-python >=11.6
+  - tbb >=2021.6.0
+  - libopenblas !=0.3.6
+  - cudatoolkit >=10.2
+  - cuda-version >=10.2
+  - scipy >=1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4165882
+  timestamp: 1687805242512
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numcodecs-0.12.1-py310had63691_0.conda
+  sha256: 259d1af44e867e10195c29abd8b40e6ead06f931706c99c81034d442a4a47570
+  md5: b373000cc7d6900e640b9e3daf74b5e2
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - msgpack-python
+  - numpy >=1.7
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 713306
+  timestamp: 1697592596737
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.24.4-py310h7451ae0_0.conda
+  sha256: fd6f5d9b8908889b5728bef75d91cd0d3dbb28e84f3df41f3e293417012d4909
+  md5: 98bea6ef713a71206ca8028f6cac5cdd
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=15.0.7
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6178531
+  timestamp: 1687809170550
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.0-ha4da562_3.conda
+  sha256: fdccd9668b85bf6e798b628bceed5ff764e1114cfc4e6a4dee551cafbe549e74
+  md5: 40a36f8e9a6fdf6a78c6428ee6c44188
+  depends:
+  - libcxx >=15.0.7
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 335643
+  timestamp: 1694708811338
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.1.4-hd75f5a5_0.conda
+  sha256: 1c436103a8de0dc82c9c56974badaa1b8b8f8cd9f37c2766bd50cd9899720f6b
+  md5: bc9201da6eb1e0df4107901df5371347
+  depends:
+  - ca-certificates
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2320542
+  timestamp: 1698165459976
+- conda: https://conda.anaconda.org/conda-forge/osx-64/orc-1.9.0-hb037d9a_3.conda
+  sha256: b41971a64f3d12b5dd8024dc93382d30431c9fb9d42c47e96db65b528537e686
+  md5: 6f7bea3c994dc0308d467ca3871ead7f
+  depends:
+  - __osx >=10.13
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 423379
+  timestamp: 1696768921701
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.1.2-py310hdba192b_0.conda
+  sha256: 552e3cfb539d7aa3f2d3a91fd8a4ddf62b25baccc4d7b5a450c823bbb05a6cbc
+  md5: 82036b662ac55869e8aa672c4eac5604
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.10.* *_cp310
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11754710
+  timestamp: 1698376495827
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.40-h1c4e4bc_0.tar.bz2
+  sha256: 60265b48c96decbea89a19a7bc34be88d9b95d4725fd4dbdae158529c601875a
+  md5: e0f80c8f3a0352a54eddfe59cd2b25b1
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.12,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2552113
+  timestamp: 1665563254214
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.1.0-py310he65384d_0.conda
+  sha256: bde2b4eca2d4b2ab33d7195867b9a369aca4727e2e4d1f17055a1507a2a825aa
+  md5: aa3e9b34eafaca521682eb48d80b80b2
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 46263448
+  timestamp: 1697423999759
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.42.2-he965462_0.conda
+  sha256: d9181736d4b3260a03443e8fd1c47c491e189b2344913eaf5dead27947a274e4
+  md5: e4180dcfd3e3621560fe1ad522997520
+  depends:
+  - libcxx >=15.0.7
+  license: MIT
+  license_family: MIT
+  size: 336190
+  timestamp: 1695736270076
+- conda: https://conda.anaconda.org/conda-forge/osx-64/poppler-23.10.0-hdd5a5e8_0.conda
+  sha256: 604803db4148415d2096f9a2cbc29efae2755b9a65715875aeb620d6f2bb03b5
+  md5: 3ba0ca934cf0ce30de692abdc7807419
+  depends:
+  - __osx >=10.9
+  - cairo >=1.18.0,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gettext >=0.21.1,<1.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libcxx >=16.0.6
+  - libglib >=2.78.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - nspr >=4.35,<5.0a0
+  - nss >=3.94,<4.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - poppler-data
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 1555342
+  timestamp: 1697136671452
+- conda: https://conda.anaconda.org/conda-forge/osx-64/postgresql-16.0-hc940a54_1.conda
+  sha256: aa33f64d068a5d4dd996de261cd9604b4bcdaba1ca3b8ce0d0fa037c94e47c76
+  md5: d54fd3d9e90e441cc7b2f098ef002cd5
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libpq 16.0 h3df487d_1
+  - libxml2 >=2.11.5,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tzcode
+  - tzdata
+  - zlib
+  size: 4596428
+  timestamp: 1696004277646
+- conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.3.0-h23b96cc_2.conda
+  sha256: e1b0f351103555e0d8ab641aeba4076173c3b7a2f8ed738b43ec66709d51be15
+  md5: 63e960e8c8020936c0b73f23bfed16dd
+  depends:
+  - libcurl >=8.4.0,<9.0a0
+  - libsqlite >=3.43.2,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2732625
+  timestamp: 1697809094266
+- conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.5-py310h6729b98_1.conda
+  sha256: dc0079bc5833de86578da4d27ca7e44921a01e2da3cbb624922d2bcbc6b95876
+  md5: 941f32dc5bd1a725fbd4fd54aec75ed1
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 369757
+  timestamp: 1695367511232
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
+  sha256: 6e3900bb241bcdec513d4e7180fe9a19186c1a38f0b4080ed619d26014222c53
+  md5: addd19059de62181cd11ae8f4ef26084
+  license: MIT
+  license_family: MIT
+  size: 5653
+  timestamp: 1606147699844
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-13.0.0-py310hb3c8376_13_cpu.conda
+  sha256: d3b7f25f38b4f09f68d37d30f0afe6f7cfc8c5317c6216f395456552dd2e4b3e
+  md5: 93eedf0e3aaab66fb78d6c82e1a357e1
+  depends:
+  - __osx >=10.9
+  - libarrow 13.0.0 h5fe8ab2_13_cpu
+  - libcxx >=15.0.7
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3622488
+  timestamp: 1698346080162
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.0-py310hef2d279_0.conda
+  sha256: 68f246c0904266aa57b38255298710d87fb8db0b80f0e2f89b5ef488925bac80
+  md5: 9346ad035be9e76cf1184110571ab8e8
+  depends:
+  - libffi >=3.4,<4.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 418687
+  timestamp: 1695560652946
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.0-py310hef2d279_1.conda
+  sha256: 8784afcd959b99fba6bc7cf475141161f7fb7d8500ff8779fda645019973fe8d
+  md5: 801c23afa12fdaed4771a9e867cc794b
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 10.0.*
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 328263
+  timestamp: 1695716989533
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.6.1-py310h7e62555_3.conda
+  sha256: 760332fc561b29f80e106ab4b81c43723dfa81ddccad2915e5fbc9742021794d
+  md5: 2368c48d33287d9abc43b5d892717a84
+  depends:
+  - certifi
+  - proj >=9.3.0,<9.3.1.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 461041
+  timestamp: 1698058532021
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.10.13-h00d2728_0_cpython.conda
+  sha256: 388b4f2c0e638c5e3aa927256bdae3d4aca6ee70406191df378321aea3558aa3
+  md5: d09fa6ab82a97c95d3a324d79263b980
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.43.2,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.4,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.10.* *_cp310
+  license: Python-2.0
+  size: 12998833
+  timestamp: 1698344444453
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-snappy-0.6.1-py310hc8cfbf2_1.conda
+  sha256: 775ac8fe14ceae7932d9df044c8ede47b13c402324b354fa0a1c3603025443ba
+  md5: 3f735559f56138769ed0169ccfe7bec7
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - snappy >=1.1.10,<1.2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30671
+  timestamp: 1695500433567
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.10-4_cp310.conda
+  sha256: abc26b3b5a62f9c8112a2303d24b0c590d5f7fc9470521f5a520472d59c2223e
+  md5: b15c816c5a86abcc4d1458dd63aa4c65
+  constrains:
+  - python 3.10.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6484
+  timestamp: 1695147705581
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.1-py310h6729b98_1.conda
+  sha256: 00567f2cb2d1c8fede8fe7727f7bbd1c38cbca886814d612e162d5c936d8db1b
+  md5: d964cec3e7972e44bc4a328134b9eaf1
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 160097
+  timestamp: 1695373947773
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-25.1.1-py310hd8b4af3_2.conda
+  sha256: 286fd63ef90774f93956b36941487107b9e7f76807642454c4ff6d13ffd0ae83
+  md5: 077bc5af9c68c245eca66f927f93aaf1
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  size: 416671
+  timestamp: 1698062738767
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rasterio-1.3.9-py310hc04732b_0.conda
+  sha256: 2374053bd173973a696b793b6f057c7702f155ca17dd1e14a5375eaf0abb5690
+  md5: 370185fab1da6899ef0d3509dac5a338
+  depends:
+  - affine
+  - attrs
+  - certifi
+  - click >=4
+  - click-plugins
+  - cligj >=0.5
+  - libgdal >=3.7.2,<3.8.0a0
+  - numpy >=1.22.4,<2.0a0
+  - proj >=9.3.0,<9.3.1.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7324288
+  timestamp: 1697714562750
+- conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2023.06.02-hd34609a_0.conda
+  sha256: dd749346b868ac9a8765cd18e102f808103330b3fc1fac5d267fbf4257ea31c9
+  md5: e498042c254db56d398b6ee858888b9d
+  depends:
+  - libre2-11 2023.06.02 h4694dbf_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27005
+  timestamp: 1697065900029
+- conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+  sha256: 41e7d30a097d9b060037f0c6a2b1d4c4ae7e942c06c943d23f9d481548478568
+  md5: f17f77f2acf4d344734bda76829ce14e
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 255870
+  timestamp: 1679532707590
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.10.6-py310h0e083fb_0.conda
+  sha256: 5b1adacfa3c7f32bd871d31f8688e289385cd8974dcf352cdf91e9670cda458e
+  md5: 1d43921c3f2bbab79b4ba4e65a2499ab
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 289733
+  timestamp: 1697072688742
+- conda: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.3.2-py310h04b1a37_1.conda
+  sha256: 771c042832ae4e989922f10f6594a72904d70deb86766a64ba6010d5b8860c42
+  md5: c32cec2682fb588b348b1eece91870f1
+  depends:
+  - __osx >=10.9
+  - joblib >=1.1.1
+  - libcxx >=16.0.6
+  - llvm-openmp >=16.0.6
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - scipy
+  - threadpoolctl >=2.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7551821
+  timestamp: 1698225884006
+- conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.11.3-py310h2db466d_1.conda
+  sha256: 9db6844496303ff8b788b36798073d5135d73b53bf37bc17a954de47e8a82fed
+  md5: 875c5e9c67f522102bd943351b463294
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=15.0.7
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy >=1.22.4,<1.28
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - libopenblas <0.3.26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15347225
+  timestamp: 1696469010531
+- conda: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.2-py310hcbf9397_0.conda
+  sha256: 6da8b59be0821b741bcbb4abc606843e5df660c49aff21aa9b8a95550f476a01
+  md5: 4db225079fdfe3fe81cc017fb184fd90
+  depends:
+  - geos >=3.12.0,<3.12.1.0a0
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 450994
+  timestamp: 1697191863153
+- conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
+  sha256: 575915dc13152e446a84e2f88de70a14f8b6af1a870e708f9370bd4be105583b
+  md5: 4320a8781f14cd959689b86e349f3b73
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 34657
+  timestamp: 1678534768395
+- conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.44.0-h7461747_0.conda
+  sha256: a222b2686f7e62c27ec2aaa64e7f2d927a883e5ef62e4ea060b6bd53c032cfca
+  md5: 4c125fcbf57aa07682468a1e9d202cfa
+  depends:
+  - libsqlite 3.44.0 h92b6c6a_0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 886889
+  timestamp: 1698855027090
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.10.0-h1c7c39f_2.conda
+  sha256: 81e3fae041696a9a74d493e49ab08ceda0022b4bd3716c1d88c0dae5435af94a
+  md5: 73434bcf87082942e938352afae9b0fa
+  license: Apache-2.0
+  license_family: APACHE
+  size: 159786
+  timestamp: 1697713666733
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tiledb-2.16.3-hd3a41d5_3.conda
+  sha256: 9144ad40adb982107dd4f5084d1e488b216025eed91a3feeb3506ee4d5bc98dd
+  md5: 53c2d2746f21a60d0c498c36fb32ec56
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230802.0,<20230803.0a0
+  - libcxx >=15.0.7
+  - libgoogle-cloud >=2.12.0,<2.13.0a0
+  - libxml2 >=2.11.5,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.1.2,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 5380880
+  timestamp: 1694523293860
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hef22860_0.conda
+  sha256: 573e5d7dde0a63b06ceef2c574295cbc2ec8668ec08e35d2f2c6220f4aa7fb98
+  md5: 0c25eedcc888b6d765948ab62a18c03e
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3273909
+  timestamp: 1695506576288
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.3.3-py310h6729b98_1.conda
+  sha256: 04262bf61f3d36b6607ae233abcbed7edaaf5d6ca4539cf9c1b322bb465809f2
+  md5: 87e772235e713ab972ecdad6c3066ff3
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: Apache
+  size: 642837
+  timestamp: 1695373842662
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tzcode-2023c-hb7f2c08_0.conda
+  sha256: 0d4b111314bea267454f48691debc1ff4c0ce8cb91491d2be30381de498ac59e
+  md5: a7ba8e96323b9d8ce4f0edc4f4dab27f
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62711
+  timestamp: 1680049599804
+- conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-15.1.0-py310h6729b98_0.conda
+  sha256: 72fcdbd9e7b5e853ee7d25f88a54b83b69b6d6ac541f6faae393cc6475aa88be
+  md5: 5c82d8c1c3ba3b16df93ac6e7cac60bd
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: Apache
+  size: 366573
+  timestamp: 1695848504604
+- conda: https://conda.anaconda.org/conda-forge/osx-64/uriparser-0.9.7-hf0c8a7f_1.conda
+  sha256: faf0f7919851960bbb1d18d977f62082c0e4dc8f26e348d702e8a2dba53a4c37
+  md5: 998073b0ccb5f99d07d2089cf06363b3
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41455
+  timestamp: 1677713114668
+- conda: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.15.0-py310h6729b98_1.conda
+  sha256: 67972f3ce7254ef2bc0ba11677e28019482393a6849a4421c135e7876c4bf7b0
+  md5: d718c460266a1b932cb38180dd904989
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 50041
+  timestamp: 1695409392473
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xerces-c-3.2.4-h6314983_3.conda
+  sha256: 19f501a66a1ffdda31e0af7fe088a1de4405c6ce72f9a07ba0813ab8c2f0ada7
+  md5: 9623310baca5b47637cf46889bd77178
+  depends:
+  - icu >=73.2,<74.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libcxx >=15.0.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 1353734
+  timestamp: 1692976676234
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
+  sha256: 8a2e398c4f06f10c64e69f56bcf3ddfa30b432201446a0893505e735b346619a
+  md5: 9566b4c29274125b0266d0177b5eb97b
+  license: MIT
+  license_family: MIT
+  size: 13071
+  timestamp: 1684638167647
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2
+  sha256: 485421c16f03a01b8ed09984e0b2ababdbb3527e1abf354ff7646f8329be905f
+  md5: 86ac76d6bf1cbb9621943eb3bd9ae36e
+  license: MIT
+  license_family: MIT
+  size: 17225
+  timestamp: 1610071995461
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+  sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
+  md5: a72f9d4ea13d55d745ff1ed594747f10
+  license: LGPL-2.1 and GPL-2.0
+  size: 238119
+  timestamp: 1660346964847
+- conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+  sha256: 5301417e2c8dea45b401ffee8df3957d2447d4ce80c83c5ff151fc6bfe1c4148
+  md5: d7e08fcf8259d742156188e8762b4d20
+  license: MIT
+  license_family: MIT
+  size: 84237
+  timestamp: 1641347062780
+- conda: https://conda.anaconda.org/conda-forge/osx-64/yarl-1.9.2-py310hb372a2b_1.conda
+  sha256: 66463995dff5e2c3180ece556da6209a6787793eb391f72d81d4ba995a7b6cbd
+  md5: bd1812816d44029fd555fe18825fd379
+  depends:
+  - idna >=2.0
+  - multidict >=4.0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: Apache
+  size: 92298
+  timestamp: 1696732773073
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h93d8f39_0.conda
+  sha256: 19be553b3cc8352b6e842134b8de66ae39fcae80bc575c203076370faab6009c
+  md5: 4c055e46b394be36681fe476c1e2ee6e
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 294253
+  timestamp: 1697057208271
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
+  sha256: d1f4c82fd7bd240a78ce8905e931e68dca5f523c7da237b6b63c87d5625c5b35
+  md5: 75a8a98b1c4671c5d2897975731da42d
+  depends:
+  - libzlib 1.2.13 h8a1eda9_5
+  license: Zlib
+  license_family: Other
+  size: 90764
+  timestamp: 1686575574678
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
+  sha256: d54e31d3d8de5e254c0804abd984807b8ae5cd3708d758a8bf1adff1f5df166c
+  md5: 80abc41d0c48b82fe0f04e7f42f5cb7e
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 499383
+  timestamp: 1693151312586
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.8.6-py310hd125d64_1.conda
+  sha256: 9bda30113bc363acf7e03462ec0cd1b6ed411e7b3633e7b82fc4bfb4111d24e6
+  md5: d0ca0be6ba7cb192650ba13435d91dc8
+  depends:
+  - aiosignal >=1.1.2
+  - async-timeout <5.0,>=4.0.0a3
+  - attrs >=17.3.0
+  - charset-normalizer >=2.0,<4.0
+  - frozenlist >=1.1.1
+  - multidict >=4.5,<7.0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - yarl >=1.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  size: 627044
+  timestamp: 1696765841259
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py310h2aa6e3c_4.conda
+  sha256: 975ecb0ff5fe8b4d1b804ad5bd956c6f2baa2b8b346c1874444ab91e748207ba
+  md5: f3fb802f86dfd594219f0ebef6dbf2b2
+  depends:
+  - cffi >=1.0.1
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 33298
+  timestamp: 1695387264900
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.5-he6edc6d_0.conda
+  sha256: 1d07a7156091d68e244a23e7fe186406c72c821ff31b644d86f871a95618a0d6
+  md5: 85b725ebb889fdac6efc43538a8fd2fc
+  depends:
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 87771
+  timestamp: 1698392912091
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.7-ha251d5a_0.conda
+  sha256: bcba576928617754f4625fdb9e3cc4dc05debc2845506f669c942aa182494ed7
+  md5: dc40c2139c44dc8078f7dd256f03ca9d
+  depends:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 39014
+  timestamp: 1697673430797
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.4-h93a5062_0.conda
+  sha256: 297f0f7c873a50ed054b0a9969d7313ab6ab04d80bbb97f010188977f6e8ea00
+  md5: bace1115ad120bb9878ed244b7789a38
+  license: Apache-2.0
+  license_family: Apache
+  size: 199718
+  timestamp: 1697224690584
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.17-ha251d5a_4.conda
+  sha256: a995826c8074250bcbc59e4640670a66d9c0d071ea7f75ac71d2e6359fb3cf12
+  md5: e64060c7ba7008a36c39f95e94934824
+  depends:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18265
+  timestamp: 1697276370819
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.3.2-hd73d0d5_4.conda
+  sha256: 9e95a08a335eca1acd1f43e5ff1f4f425d85420d90f6b6343752b56b7396b4fc
+  md5: d393bbd203ecc8489d04a86ffcdb1f4a
+  depends:
+  - __osx >=10.9
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - libcxx >=16.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 47016
+  timestamp: 1697310283218
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.7.13-hb3e5a72_7.conda
+  sha256: 939c1c1898d228fdc7bb532cbd09517eea71c8672ce22609cb1ade9d02ce06f5
+  md5: 6343f20b5246351926e1f304084f663c
+  depends:
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-compression >=0.2.17,<0.2.18.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150599
+  timestamp: 1697851203675
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.13.35-h0f79f92_4.conda
+  sha256: 90083860c4e0f2e2d78f80b196f40b2e5d1e8340588d46e6936f21fb9a7408c2
+  md5: e5dd577f857c83f99975db7368c071a7
+  depends:
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 136780
+  timestamp: 1697832935753
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.9.8-he2964ae_0.conda
+  sha256: de85e5d0d100fc4319ccaf4540fec3f379899ced2334db47c306c1f8cd192671
+  md5: 59cad22bf55d94f54ed11a23d6f40a82
+  depends:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 117558
+  timestamp: 1697770422982
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.3.20-h8d12f51_1.conda
+  sha256: e314b2c1e0f155f66e48b3028db5541c9adce7504512f1991785f0e8bef59084
+  md5: 9d9482210bd957dfaea42a66aa63a6ae
+  depends:
+  - aws-c-auth >=0.7.5,<0.7.6.0a0
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 73756
+  timestamp: 1698603819233
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.12-ha251d5a_3.conda
+  sha256: fa4e165c179093b761e0e4a946a214b65735ffec0ddc992ef3ba98559affb9da
+  md5: ddc2ae02cdaa70989069c74995506520
+  depends:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 47056
+  timestamp: 1697283486854
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.17-ha251d5a_3.conda
+  sha256: 82534e9aa17aae584f4e3d1865f6d975c02bba98da326d309bcc309496448713
+  md5: b1082e09e43f954ea65e947a6b5029af
+  depends:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 49005
+  timestamp: 1697283369764
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.24.4-h5f3d163_2.conda
+  sha256: aa4fc69fa3bc88db6e7e4356ece31010b8bb140da553dffbe3e20823322e9a06
+  md5: 12893eeabfb81d7d6270f3798aab2e49
+  depends:
+  - __osx >=10.9
+  - aws-c-auth >=0.7.5,<0.7.6.0a0
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-c-mqtt >=0.9.8,<0.9.9.0a0
+  - aws-c-s3 >=0.3.20,<0.3.21.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  - libcxx >=16.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 212825
+  timestamp: 1698624312953
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.182-hba14a0b_2.conda
+  sha256: 3380106fedbea5bf17fd8fffa7b089b25c034d79d687505921a9c82fd8dbf726
+  md5: c33be64b53d699de9c70e046594d90fc
+  depends:
+  - __osx >=10.9
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - aws-crt-cpp >=0.24.4,<0.24.5.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libcxx >=16.0.6
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.4,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3186581
+  timestamp: 1698318357494
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.5-hc338f07_0.conda
+  sha256: 81f206dd843fe0da894d0480ea9d689fe948fa4b3cad060f97b016af4ac7b3a1
+  md5: 93fccb1150aa377576107ecd0ad375b3
+  depends:
+  - libcxx >=15.0.7
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33450
+  timestamp: 1693657320331
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hb547adb_1.conda
+  sha256: 62d1587deab752fcee07adc371eb20fcadc09f72c0c85399c22b637ca858020f
+  md5: a33aa58d448cbc054f887e39dd1dfaea
+  depends:
+  - brotli-bin 1.1.0 hb547adb_1
+  - libbrotlidec 1.1.0 hb547adb_1
+  - libbrotlienc 1.1.0 hb547adb_1
+  license: MIT
+  license_family: MIT
+  size: 19506
+  timestamp: 1695990588610
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hb547adb_1.conda
+  sha256: 8fbfc2834606292016f2faffac67deea4c5cdbc21a61169f0b355e1600105a24
+  md5: 990d04f8c017b1b77103f9a7730a5f12
+  depends:
+  - libbrotlidec 1.1.0 hb547adb_1
+  - libbrotlienc 1.1.0 hb547adb_1
+  license: MIT
+  license_family: MIT
+  size: 17001
+  timestamp: 1695990551239
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py310h1253130_1.conda
+  sha256: dab21e18c0275bfd93a09b751096998485677ed17c2e2d08298bc5b43c10bee1
+  md5: 26fab7f65a80fff9f402ec3b7860b88a
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - libbrotlicommon 1.1.0 hb547adb_1
+  license: MIT
+  license_family: MIT
+  size: 344275
+  timestamp: 1695990848681
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h3422bc3_4.tar.bz2
+  sha256: a3efbd06ad1432edb0163c48225421f34c2660f5cc002283a8d27e791320b549
+  md5: fc76ace7b94fb1f694988ab1b14dd248
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 151850
+  timestamp: 1618862645215
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.20.1-h93a5062_1.conda
+  sha256: 9f588eb920a793c6501120ed198d34afba763b2b2c0ae6de518c3735aea21d5e
+  md5: 2bb255dbcb73d1986e03cc5a7767c0bf
+  license: MIT
+  license_family: MIT
+  size: 101995
+  timestamp: 1697955983023
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.7.22-hf0a4a13_0.conda
+  sha256: b220c001b0c1448a47cc49b42a622e06a540ec60b3f7a1e057fca1f37ce515e4
+  md5: e1b99ac4dbcee71a71682996f67f7965
+  license: ISC
+  size: 149918
+  timestamp: 1690026385821
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hd1e100b_0.conda
+  sha256: 599f8820553b3a3405706d9cad390ac199e24515a0a82c87153c9b5b5fdba3b8
+  md5: 3fa6eebabb77f65e82f86b72b95482db
+  depends:
+  - __osx >=10.9
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=73.2,<74.0a0
+  - libcxx >=16.0.6
+  - libglib >=2.78.0,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - pixman >=0.42.2,<1.0a0
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 897919
+  timestamp: 1697028755150
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cartopy-0.22.0-py310h6e3cc31_1.conda
+  sha256: f5d5f28ac4f18c4d379e60c3e4b52e124ab39450829b0ee7f3fa00ab5094539d
+  md5: 4cb1cca3372c5ae18e98dbc35b4f6ced
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - matplotlib-base >=3.4
+  - numpy >=1.22.4,<2.0a0
+  - packaging >=20
+  - pyproj >=3.1.0
+  - pyshp >=2.1
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - shapely >=1.7
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 1804460
+  timestamp: 1698173250472
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.16.0-py310hdcd7c05_0.conda
+  sha256: 4edab3f1f855554e10950efe064b75138943812af829a764f9b570d1a7189d15
+  md5: 8855823d908004e4d3b4fd4218795ad2
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 232227
+  timestamp: 1696002085787
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cfitsio-4.3.0-hca87796_0.conda
+  sha256: 5d03f8d484d29f8d3bdd64afe22ed29d75c639834b40382f8a520f96a7af27c4
+  md5: a5a1019a6405052124e97999a5204a74
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.2.0,<9.0a0
+  - libgfortran >=5
+  - libgfortran5 >=12.2.0
+  - libgfortran5 >=12.3.0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: LicenseRef-fitsio
+  size: 786305
+  timestamp: 1690378144618
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.3-py310h50ce23c_0.conda
+  sha256: 3de571628e5dc47a5f4ff9e3b8386934e8dab580495119fedba230af41d94387
+  md5: fc9369c9009008aa0180523d2750ac0a
+  depends:
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 203444
+  timestamp: 1698610345834
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.1.1-py310h38f39d4_1.conda
+  sha256: 5e831ffdd51c57ab9e2acc8edaf41b7ff0f9264d668efa763f2c463757b29e77
+  md5: 5dd6328bbdd8e8bbf900c58a8a992e3f
+  depends:
+  - libcxx >=15.0.7
+  - numpy >=1.16
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217854
+  timestamp: 1695554685453
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cramjam-2.7.0-py310had9acf8_1.conda
+  sha256: 9a8ae16841a48548784299e28879cca66e673ab5e253c4041afc87047d5c89c8
+  md5: 7cde210124b9102534857347d531153c
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 1215307
+  timestamp: 1695451036836
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-0.12.2-py310h2aa6e3c_1.conda
+  sha256: 875a23aa3b2a54ae930983c4c151c52b65f9ecbf5b1db5180b35159e799d10c0
+  md5: 898856260bf1eafb55848e62adf2a4bf
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 325285
+  timestamp: 1695545616347
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.0-py310h1253130_1.conda
+  sha256: 0d3c142bf54ae8d1015c45ac1eea2df0d24b4fe9eb76454bebc1ebb1d14485f5
+  md5: 9ae552e8e386da0f03a8eecf3e291f2f
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 2373153
+  timestamp: 1695534729081
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.5.0-hb7217d7_1.conda
+  sha256: 9f06afbe4604decf6a2e8e7e87f5ca218a3e9049d57d5b3fcd538ca6240d21a0
+  md5: 624fa0dd6fdeaa650b71a62296fdfedf
+  depends:
+  - libexpat 2.5.0 hb7217d7_1
+  license: MIT
+  license_family: MIT
+  size: 117851
+  timestamp: 1680190940654
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fastparquet-2023.10.1-py310h50ce23c_0.conda
+  sha256: 3de8096017d53f2493701bf4734e9100c1ec65a1a2e3d958fd698681de1f9e1c
+  md5: 3abbcc0f55c57eb852eac4d4bbf67289
+  depends:
+  - cramjam >=2.3
+  - fsspec
+  - numpy >=1.20.3
+  - numpy >=1.22.4,<2.0a0
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411599
+  timestamp: 1698413307433
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.14.2-h82840c6_0.conda
+  sha256: 7094917fc6758186e17c61d8ee8fd2bbbe9f303b4addac61d918fa415c497e2b
+  md5: f77d47ddb6d3cc5b39b9bdf65635afbb
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 237668
+  timestamp: 1674829263740
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.43.1-py310hd125d64_0.conda
+  sha256: 4af15971bd6f5205a171a54b02122273d5168f3fd5cfe59a3091a6af883677ae
+  md5: f9cb2fb089b19c4971675947ebdd57e3
+  depends:
+  - brotli
+  - munkres
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - unicodedata2 >=14.0.0
+  license: MIT
+  license_family: MIT
+  size: 2153654
+  timestamp: 1696601781526
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+  sha256: 791673127e037a2dc0eebe122dc4f904cb3f6e635bb888f42cbe1a76b48748d9
+  md5: e6085e516a3e304ce41a8ee08b9b89ad
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 596430
+  timestamp: 1694616332835
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-hfbad9fb_0.conda
+  sha256: 9cb4957d1431bc57bc95b1e99a50669d91ac3441226a78f69fa030d52f2bda77
+  md5: 40722e5f48287567cda6fb2ec1f7891b
+  depends:
+  - libexpat >=2.5.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - minizip >=4.0.1,<5.0a0
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 55132
+  timestamp: 1694952828719
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.4.0-py310h2aa6e3c_1.conda
+  sha256: c1db0602adcc7fec7b777f15f4fbc7dfb624d323ad37e4928364caa3c938035f
+  md5: 4f6aa33b93a158da819ca98bc129e735
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: APACHE
+  size: 48827
+  timestamp: 1695378152026
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.12.0-h13dd4ca_0.conda
+  sha256: 8c21acd399d7509f6a7c7b65d5415e9500333a043f44dee063942d724adffc4a
+  md5: 18eb5904d2561c782e71bfe05b2ad755
+  depends:
+  - libcxx >=15.0.7
+  license: LGPL-2.1-only
+  size: 1441490
+  timestamp: 1687940009438
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/geotiff-1.7.1-h71398c0_14.conda
+  sha256: 0af388cc45d1813c57ba5f30032b22a8fdf9bc2762bacf4101168009d51d24ce
+  md5: f2a5ed847c17df7b45467210f5a7c15d
+  depends:
+  - libcxx >=15.0.7
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - proj >=9.3.0,<9.3.1.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 118458
+  timestamp: 1695943465844
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.21.1-h0186832_0.tar.bz2
+  sha256: 093b2f96dc4b48e4952ab8946facec98b34b708a056251fc19c23c3aad30039e
+  md5: 63d2ff6fddfa74e5458488fd311bf635
+  depends:
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 4021036
+  timestamp: 1665674192347
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hc88da5d_1004.tar.bz2
+  sha256: 25d4a20af2e5ace95fdec88970f6d190e77e20074d2f6d3cef766198b76a4289
+  md5: aab9ddfad863e9ef81229a1f8852211b
+  depends:
+  - libcxx >=11.0.0.rc1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 86690
+  timestamp: 1599590990520
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.1-h1a8c8d9_3.conda
+  sha256: dbf1e431d3e5e03f8eeb77ec08a4c5d6d5d9af84dbef13d4365e397dd389beb8
+  md5: f39a05d3dbb0e5024b7deabb2c0993f1
+  license: MIT
+  license_family: MIT
+  size: 71963
+  timestamp: 1678718059849
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.6.0-h6da1cb0_0.tar.bz2
+  sha256: 4d772c42477f64be708594ac45870feba3e838977871118eb25e00deb0e9a73c
+  md5: 5a570729c7709399cf8511aeeda6f989
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=12.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 97658
+  timestamp: 1649144191039
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
+  sha256: c3b01e3c3fe4ca1c4d28c287eaa5168a4f2fd3ffd76690082ac919244c22fa90
+  md5: ff5d749fd711dc7759e127db38005924
+  depends:
+  - libcxx >=15.0.7
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 762257
+  timestamp: 1695661864625
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.2-nompi_h3aba7b3_100.conda
+  sha256: 2749910e21a7d1f88a81dc4709fc3565a4a3954eadb4409e7a5be1fc13a5b7ca
+  md5: 842c5b010b219058098ebfe5aa5891b9
+  depends:
+  - libaec >=1.0.6,<2.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libcxx >=15.0.7
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  license: LicenseRef-HDF5
+  license_family: BSD
+  size: 3408759
+  timestamp: 1692562818610
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
+  sha256: ff9cd0c6cd1349954c801fb443c94192b637e1b414514539f3c49c56a39f51b1
+  md5: 8521bd47c0e11c5902535bb1a17c565f
+  license: MIT
+  license_family: MIT
+  size: 11997841
+  timestamp: 1692902104771
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/json-c-0.17-h40ed0f5_0.conda
+  sha256: d47138a2829ce47d2e9ec1dbe108d1a6fe58c5d8724ea904985a420ad760f93f
+  md5: 7de5604deb99090c8e8c4863f60568d1
+  license: MIT
+  license_family: MIT
+  size: 76941
+  timestamp: 1691934174484
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-2.4-py310hbe9552e_3.conda
+  sha256: ac07094026e47cd74ae431343d17fb2cff34a41de88ad8532308086d73d01d1a
+  md5: 7e521c322debe4fb1ac5fea63307a724
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16651
+  timestamp: 1695397700350
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jupyter_core-5.5.0-py310hbe9552e_0.conda
+  sha256: 3b4e054bee8cf3542ec78dae27af9e53d00c1fc51f9f8b2f7d2d927b2ae0cfcd
+  md5: daa5e800e856140e7ffeaab3d2354621
+  depends:
+  - platformdirs >=2.5
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 79480
+  timestamp: 1698674093477
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/kealib-1.5.2-h47b5e36_1.conda
+  sha256: 93e9b03cd9035766c43e5f7f851fc07a4f68b79fd48c1306280f17093a8ae746
+  md5: 88abe34211296bbc0ba1871fd2b13962
+  depends:
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - libcxx >=15.0.7
+  license: MIT
+  license_family: MIT
+  size: 142226
+  timestamp: 1696011534810
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.5-py310h38f39d4_1.conda
+  sha256: e84793b3bef7e5d92f96c511a06dc9cbcc49424995777595365c654effe67d6f
+  md5: 84392f391faad11ea910f38226590a88
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62043
+  timestamp: 1695380329047
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.2-h92f50d5_0.conda
+  sha256: 70bdb9b4589ec7c7d440e485ae22b5a352335ffeb91a771d4c162996c3070875
+  md5: 92f1cff174a538e0722bf2efb16fc0b2
+  depends:
+  - libcxx >=15.0.7
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.1.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1195575
+  timestamp: 1692098070699
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.15-hf2736f0_3.conda
+  sha256: 3d07ba04602617c3084b302c8a6fa30b2e4b20511180f45992b289c312298018
+  md5: bbaac531169fed3e09ae31aff80aa069
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 215466
+  timestamp: 1695969888308
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+  sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
+  md5: de462d5aacda3b30721b512c5da4e742
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 215721
+  timestamp: 1657977558796
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20230802.1-cxx17_h13dd4ca_0.conda
+  sha256: 459a58f36607246b4483d7a370c2d9a03e7f824e79da2c6e3e9d62abf80393e7
+  md5: fb6dfadc1898666616dfda242d8aea10
+  depends:
+  - libcxx >=15.0.7
+  constrains:
+  - libabseil-static =20230802.1=cxx17*
+  - abseil-cpp =20230802.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 1173407
+  timestamp: 1695064439482
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.2-h13dd4ca_1.conda
+  sha256: c9d6f01d511bd3686ce590addf829f34031b95e3feb34418496cbb45924c5d17
+  md5: b7962cdc2cedcc9f8d12928824c11fbd
+  depends:
+  - libcxx >=15.0.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29002
+  timestamp: 1696474168895
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.7.2-h82b9b87_0.conda
+  sha256: d8f2a19466f11ca9d6e1bf6a82cf84a5eb60dcf55d93fa2fbf47a503b953e348
+  md5: da6ec82a0e07f738afee1c4279778b30
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libiconv >=1.17,<2.0a0
+  - libxml2 >=2.11.5,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - lzo >=2.10,<3.0a0
+  - openssl >=3.1.2,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 826900
+  timestamp: 1694543052074
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-13.0.0-h87fad27_13_cpu.conda
+  sha256: cb328cef3426281f3b7ec89c8b3d65d01edff5df822a0dec4a67513e380f2106
+  md5: 8f5d385e8fd5a134f559cc1c31b7342c
+  depends:
+  - __osx >=10.9
+  - aws-crt-cpp >=0.24.4,<0.24.5.0a0
+  - aws-sdk-cpp >=1.11.182,<1.11.183.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.6.0,<0.7.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=15.0.7
+  - libgoogle-cloud >=2.12.0,<2.13.0a0
+  - libgrpc >=1.58.1,<1.59.0a0
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libre2-11 >=2023.6.2
+  - libthrift >=0.19.0,<0.19.1.0a0
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.1.4,<4.0a0
+  - orc >=1.9.0,<1.9.1.0a0
+  - re2
+  - snappy >=1.1.10,<1.2.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  - libutf8proc <2.9
+  constrains:
+  - parquet-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  - arrow-cpp =13.0.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 17933618
+  timestamp: 1698344906816
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-19_osxarm64_openblas.conda
+  sha256: 51e78e3c9fa57f3fec12936b760928715ba0ab5253d02815202f9ec4c2c9255d
+  md5: f50b1fd98593278e18319653cff9c475
+  depends:
+  - libopenblas >=0.3.24,<0.3.25.0a0
+  - libopenblas >=0.3.24,<1.0a0
+  constrains:
+  - libcblas 3.9.0 19_osxarm64_openblas
+  - liblapack 3.9.0 19_osxarm64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 19_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14817
+  timestamp: 1697484577887
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-headers-1.82.0-hce30654_6.conda
+  sha256: 19cc7fff73fda78f142a875f06f2467fcbfc5c8c3e0db92b212e425de309a27d
+  md5: ae7c68cf82c23fe6c68f0efa064ef41a
+  constrains:
+  - boost-cpp =1.82.0
+  license: BSL-1.0
+  size: 13795546
+  timestamp: 1696733002284
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hb547adb_1.conda
+  sha256: 556f0fddf4bd4d35febab404d98cb6862ce3b7ca843e393da0451bfc4654cf07
+  md5: cd68f024df0304be41d29a9088162b02
+  license: MIT
+  license_family: MIT
+  size: 68579
+  timestamp: 1695990426128
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hb547adb_1.conda
+  sha256: c1c85937828ad3bc434ac60b7bcbde376f4d2ea4ee42d15d369bf2a591775b4a
+  md5: ee1a519335cc10d0ec7e097602058c0a
+  depends:
+  - libbrotlicommon 1.1.0 hb547adb_1
+  license: MIT
+  license_family: MIT
+  size: 28928
+  timestamp: 1695990463780
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hb547adb_1.conda
+  sha256: 690dfc98e891ee1871c54166d30f6e22edfc2d7d6b29e7988dde5f1ce271c81a
+  md5: d7e077f326a98b2cc60087eaff7c730b
+  depends:
+  - libbrotlicommon 1.1.0 hb547adb_1
+  license: MIT
+  license_family: MIT
+  size: 280943
+  timestamp: 1695990509392
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-19_osxarm64_openblas.conda
+  sha256: 19b1c5e3ddd383ec14540336f4704938218d3c1db4707ae10d5357afb22cccc1
+  md5: 5460a8d1beffd7f63994d891e6a20da4
+  depends:
+  - libblas 3.9.0 19_osxarm64_openblas
+  constrains:
+  - liblapack 3.9.0 19_osxarm64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 19_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14738
+  timestamp: 1697484590682
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+  sha256: 58477b67cc719060b5b069ba57161e20ba69b8695d154a719cb4b60caf577929
+  md5: 32bd82a6a625ea6ce090a81c3d34edeb
+  depends:
+  - libcxx >=11.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18765
+  timestamp: 1633683992603
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.4.0-h2d989ff_0.conda
+  sha256: 5ca24ab030b1c56ce07921bf901ea99076e8b7e45586b4a04e5187cc67c87273
+  md5: afabb3372209028627ec03e206f4d967
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 348974
+  timestamp: 1697009607821
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.6-h4653b0c_0.conda
+  sha256: 11d3fb51c14832d9e4f6d84080a375dec21ea8a3a381a1910e67ff9cedc20355
+  md5: 9d7d724faf0413bf1dbc5a85935700c8
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1160232
+  timestamp: 1686896993785
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.19-hb547adb_0.conda
+  sha256: 6a3d188a6ae845a742dc85c5fb3f7eb1e252726cd74f0b8a7fa25ec09db6b87a
+  md5: f8c1eb0e99e90b55965c6558578537cc
+  license: MIT
+  license_family: MIT
+  size: 52841
+  timestamp: 1694924330786
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+  sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
+  md5: 30e4362988a2623e9eb34337b83e01f9
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 96607
+  timestamp: 1597616630749
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h642e427_1.tar.bz2
+  sha256: eb7325eb2e6bd4c291cb9682781b35b8c0f68cb72651c35a5b9dd22707ebd25c
+  md5: 566dbf70fe79eacdb3c3d3d195a27f55
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 100668
+  timestamp: 1598868103393
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+  sha256: 8c136d7586259bb5c0d2b913aaadc5b9737787ae4f40e3ad1beaf96c80b919b7
+  md5: 1a109764bff3bdc7bdd84088347d71dc
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 368167
+  timestamp: 1685726248899
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.5.0-hb7217d7_1.conda
+  sha256: 7d143a9c991579ad4207f84c632650a571c66329090daa32b3c87cf7311c3381
+  md5: 5a097ad3d17e42c148c9566280481317
+  constrains:
+  - expat 2.5.0.*
+  license: MIT
+  license_family: MIT
+  size: 63442
+  timestamp: 1680190916539
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+  md5: 086914b672be056eb70fd4285b6783b6
+  license: MIT
+  license_family: MIT
+  size: 39020
+  timestamp: 1636488587153
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-3.7.2-h116f65a_7.conda
+  sha256: b8a13edcbd239a96a26df15eccf10accdb2eae12bafd6229347b158af38f0c96
+  md5: e4b4a08e8b23bd9e3d2e0ffb5f8909c8
+  depends:
+  - __osx >=10.9
+  - blosc >=1.21.5,<2.0a0
+  - cfitsio >=4.3.0,<4.3.1.0a0
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.12.0,<3.12.1.0a0
+  - geotiff >=1.7.1,<1.8.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - json-c >=0.17,<0.18.0a0
+  - kealib >=1.5.2,<1.6.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libarchive >=3.7.2,<3.8.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libcxx >=16.0.6
+  - libdeflate >=1.19,<1.26.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=16.0,<17.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.43.2,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxml2 >=2.11.5,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - openssl >=3.1.3,<4.0a0
+  - pcre2 >=10.40,<10.41.0a0
+  - poppler >=23.10.0,<23.11.0a0
+  - postgresql
+  - proj >=9.3.0,<9.3.1.0a0
+  - tiledb >=2.16,<2.17.0a0
+  - xerces-c >=3.2.4,<3.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 8151044
+  timestamp: 1697154946913
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_1.conda
+  sha256: bc8750e7893e693fa380bf2f342d4a5ce44995467cbdf72e56a00e5106b4892d
+  md5: 1ad37a5c60c250bb2b4a9f75563e181c
+  depends:
+  - libgfortran5 13.2.0 hf226fd6_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110095
+  timestamp: 1694172198016
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_1.conda
+  sha256: cb9cb11e49a6a8466ea7556a723080d3aeefd556df9b444b941afc5b54368b22
+  md5: 4480d71b98c87faafab132d33e23135e
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 995733
+  timestamp: 1694172076009
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.78.0-h24e9cb9_0.conda
+  sha256: bc2fb2e307889294c15fe4f1f61c2c92832c371781654c17c5483c9e8de14d2e
+  md5: 01c86aa032cbce6aff557de3b9948aa1
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libcxx >=15.0.7
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - pcre2 >=10.40,<10.41.0a0
+  constrains:
+  - glib 2.78.0 *_0
+  license: LGPL-2.1-or-later
+  size: 2550196
+  timestamp: 1694381376914
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.12.0-h5a37b55_3.conda
+  sha256: 27e08d97642e5127eb774ff9d67efa995791d09674d5c6cdde158dfa321a0dc8
+  md5: be90da76f8805ce8a138ac47b49fa4ce
+  depends:
+  - __osx >=10.9
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libcxx >=16.0.6
+  - libgrpc >=1.58.1,<1.59.0a0
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - openssl >=3.1.3,<4.0a0
+  constrains:
+  - google-cloud-cpp 2.12.0 *_3
+  license: Apache-2.0
+  license_family: Apache
+  size: 31408040
+  timestamp: 1696838972502
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.58.2-h19be7b0_0.conda
+  sha256: 2e1cf618c66403a993b96fd14b3db7fd9371f0e51f7e1936717ae3c4a9987299
+  md5: 2e3203d9e2075ebe824e6c4150a30f4e
+  depends:
+  - __osx >=10.9
+  - c-ares >=1.20.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcxx >=16.0.6
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libre2-11 >=2023.6.2
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.4,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.58.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4358669
+  timestamp: 1698720694171
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-he4db4b2_0.tar.bz2
+  sha256: 2eb33065783b802f71d52bef6f15ce0fafea0adc8506f10ebd0d490244087bec
+  md5: 686f9c755574aa221f29fbcf36a67265
+  license: GPL and LGPL
+  size: 1407036
+  timestamp: 1652700956112
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+  sha256: a42054eaa38e84fc1e5ab443facac4bbc9d1b6b6f23f54b7bf4f1eb687e1d993
+  md5: 3ff1e053dc3a2b8e36b9bfa4256a58d1
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 547541
+  timestamp: 1694475104253
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libkml-1.3.0-h1eb4d9f_1018.conda
+  sha256: ba3833cd0c517bb7a00b235b85a35bc58096e981ef3ac392c0916d83a1abc00a
+  md5: f287028317d50fa3edad9c715d22e26b
+  depends:
+  - libboost-headers
+  - libcxx >=15.0.7
+  - libexpat >=2.5.0,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - uriparser >=0.9.7,<1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 421133
+  timestamp: 1696451613703
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-19_osxarm64_openblas.conda
+  sha256: f19cff537403c9feed98c7e18259022102b087f2b72a757e8a417476b9cf30c1
+  md5: 3638eacb084c374f41f9efa40d20a47b
+  depends:
+  - libblas 3.9.0 19_osxarm64_openblas
+  constrains:
+  - libcblas 3.9.0 19_osxarm64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 19_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14721
+  timestamp: 1697484603691
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_4.conda
+  sha256: 6f603914fe8633a615f0d2f1383978eb279eeb552079a78449c9fbb43f22a349
+  md5: 9f3dce5d26ea56a9000cd74c034582bd
+  depends:
+  - libcxx >=15
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 20571387
+  timestamp: 1690559110016
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnetcdf-4.9.2-nompi_hb2fb864_112.conda
+  sha256: fef33b99225691fce165cd1aadb85c823e2a3a9e5d67c3069f1d6b9ebbf53fdf
+  md5: fdd8c3b65f9369c4a5bbf23164ea8e19
+  depends:
+  - blosc >=1.21.4,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - libaec >=1.0.6,<2.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libcxx >=15.0.7
+  - libxml2 >=2.11.5,<2.14.0a0
+  - libzip >=1.10.1,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  - zlib
+  - zstd >=1.5.5,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 706702
+  timestamp: 1693582109664
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.55.1-h2b02ca0_0.conda
+  sha256: d30f26b57225609e1cd285921113bc634f008e83b1f2296245f468ca682e39a6
+  md5: eabfa8f7d2b7751ee28dc6762bbbf168
+  depends:
+  - __osx >=10.9
+  - c-ares >=1.20.1,<2.0a0
+  - libcxx >=15.0.7
+  - libev >=4.33,<4.34.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.4,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 590540
+  timestamp: 1698429620051
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.24-openmp_hd76b1f2_0.conda
+  sha256: 21edfdf620ac5c93571aab452199b6b4622c445441dad88ab4d2eb326a7b91b3
+  md5: aacb05989f358affe1bafd4ea7294db4
+  depends:
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - llvm-openmp >=15.0.7
+  constrains:
+  - openblas >=0.3.24,<0.3.25.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2849225
+  timestamp: 1693784744674
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.39-h76d750c_0.conda
+  sha256: 21ab8409a8e66f9408b96428c0a36a9768faee9fe623c56614576f9e12962981
+  md5: 0078e6327c13cfdeae6ff7601e360383
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: zlib-acknowledgement
+  size: 259412
+  timestamp: 1669075883972
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.0-hcea71ed_1.conda
+  sha256: 5119880e145efca6768a79649c8ed64bfdbe2f862e05c2759240f297bf300117
+  md5: 42d504f6433024058dda89ba0e1bd2f2
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<3.2.0a0
+  license: PostgreSQL
+  size: 2461648
+  timestamp: 1696004342637
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.24.3-hf590ac1_1.conda
+  sha256: d901263a547d38c65e54ff8fc53a08909ccd4b01aefa26acb68c51f7458ee54b
+  md5: e014b86bbcf828432fda839a4e714dc8
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcxx >=15.0.7
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2167180
+  timestamp: 1697157552725
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2023.06.02-h1753957_0.conda
+  sha256: 8bafee8f8ef27f4cb0afffe5404dd1abfc5fd6eac1ee9b4847a756d440bd7aa7
+  md5: 3b8652db4bf4e27fa1446526f7a78498
+  depends:
+  - __osx >=10.9
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcxx >=16.0.6
+  constrains:
+  - re2 2023.06.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 169587
+  timestamp: 1697065827986
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/librttopo-1.1.0-h667cd51_14.conda
+  sha256: 5ed612f91b1e0bfa41dca9f6bdd9edd28039b6880c3d1b9dc40aa748b6d1d7c7
+  md5: 5dfc75562bc705e4a645eb8079139c8c
+  depends:
+  - geos >=3.12.0,<3.12.1.0a0
+  - libcxx >=15.0.7
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 203261
+  timestamp: 1687974499690
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.18-h27ca646_1.tar.bz2
+  sha256: 1d95fe5e5e6a0700669aab454b2a32f97289c9ed8d1f7667c2ba98327a6f05bc
+  md5: 90859688dbca4735b74c02af14c4c793
+  license: ISC
+  size: 324912
+  timestamp: 1605135878892
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libspatialite-5.1.0-h32510b6_0.conda
+  sha256: bb84ffd0ea6e2859127e737c444898c7133c3df7c7fe41e2abda5b3cef36be60
+  md5: 075be471a7d969b14e3e49074974bac8
+  depends:
+  - freexl >=2
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.12.0,<3.12.1.0a0
+  - libcxx >=15.0.7
+  - libiconv >=1.17,<2.0a0
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libxml2 >=2.11.5,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - proj >=9.3.0,<9.3.1.0a0
+  - sqlite
+  - zlib
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 3202104
+  timestamp: 1694989568399
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.44.0-h091b4b1_0.conda
+  sha256: 38e98953b572e2871f2b318fa7fe8d9997b0927970916c2d09402273b60ff832
+  md5: 28eb31a5b4e704353ed575758e2fcf1d
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Unlicense
+  size: 815079
+  timestamp: 1698855024189
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
+  sha256: bb57d0c53289721fff1eeb3103a1c6a988178e88d8a8f4345b0b91a35f0e0015
+  md5: 029f7dc931a3b626b94823bc77830b01
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 255610
+  timestamp: 1685837894256
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.19.0-h026a170_1.conda
+  sha256: b2c1b30d36f0412c0c0313db76a0236d736f3a9b887b8ed16182f531e4b7cb80
+  md5: 4b8b21eb00d9019e9fa351141da2a6ac
+  depends:
+  - libcxx >=15.0.7
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 331154
+  timestamp: 1695958512679
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.6.0-ha8a6c65_2.conda
+  sha256: b18ef36eb90f190db22c56ae5a080bccc16669c8f5b795a6211d7b0c00c18ff7
+  md5: 596d6d949bab9a75a492d451f521f457
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=15.0.7
+  - libdeflate >=1.19,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: HPND
+  size: 246265
+  timestamp: 1695661829324
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-h1a8c8d9_0.tar.bz2
+  sha256: a3faddac08efd930fa3a1cc254b5053b4ed9428c49a888d437bf084d403c931a
+  md5: f8c9c41a122ab3abdf8943b13f4957ee
+  license: MIT
+  license_family: MIT
+  size: 103492
+  timestamp: 1667316405233
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.3.2-hb547adb_0.conda
+  sha256: a159b848193043fb58465ae6a449361615dadcf27babfe0b18db2bd3eb59e958
+  md5: 85dbc11098cdbe4244cd73f29a3ab795
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 273844
+  timestamp: 1694709510635
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.15-hf346824_0.conda
+  sha256: 6eaa87760ff3e91bb5524189700139db46f8946ff6331f4e571e4a9356edbb0d
+  md5: 988d5f86ab60fa6de91b3ee3a88a3af9
+  depends:
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 334770
+  timestamp: 1682082734262
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.11.5-h25269f3_1.conda
+  sha256: 8291549b87aca48e9cd4aec124af01b5037acd16f8ad14083d7af23c8bb6bebe
+  md5: 627b5d1377536b5b632ba53cd1455555
+  depends:
+  - icu >=73.2,<74.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 614831
+  timestamp: 1692960705224
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzip-1.10.1-ha0bc3c6_3.conda
+  sha256: fb42f34c2275523a06bc8464454fa57f2417203524cabb7aacca4e5de6cfeb69
+  md5: e37c0da207079e488709043634d6a711
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 128244
+  timestamp: 1694416824668
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
+  sha256: ab1c8aefa2d54322a63aaeeefe9cf877411851738616c4068e0dccc66b9c758a
+  md5: 1a47f5236db2e06a320ffa0392f81bd8
+  constrains:
+  - zlib 1.2.13 *_5
+  license: Zlib
+  license_family: Other
+  size: 48102
+  timestamp: 1686575426584
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-17.0.4-hcd81f8e_0.conda
+  sha256: 99a8145f38c02f317d1293eaf0e34af028d94d6854dfb2dd044702995cf74b89
+  md5: 88618857d4b3fadc13649d1a25cf1e4c
+  constrains:
+  - openmp 17.0.4|17.0.4.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 274893
+  timestamp: 1698833582372
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.40.1-py310h95b248a_0.conda
+  sha256: 257ff87893f69d65fd338e83c98caf558b9ab63d53485a7570eb87d148d2b0de
+  md5: 52cd6541bcc41ab3495c243f44ff1817
+  depends:
+  - libcxx >=15.0.7
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 264867
+  timestamp: 1687806825553
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-4.3.2-py310hf90591b_1.conda
+  sha256: 49ddaadf387ff345a71fb15d5f57e209a07f930bfd5b5c58bc8b6a474a7896ee
+  md5: 905e518f886ea161bfa446d7e7530540
+  depends:
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 108527
+  timestamp: 1695449194994
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+  sha256: fc343b8c82efe40819b986e29ba748366514e5ab94a1e1138df195af5f45fa24
+  md5: 45505bec548634f7d05e02fb25262cb9
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 141188
+  timestamp: 1674727268278
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h642e427_1000.tar.bz2
+  sha256: ae029e5c16893071d29a11ddbfdbdb01b2ebf10d1785f54370934439d8b71817
+  md5: ddab5f96f5573a9bd5e24f9994fd6ec9
+  license: GPL v2+
+  license_family: GPL2
+  size: 157236
+  timestamp: 1597683217947
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.3-py310h2aa6e3c_1.conda
+  sha256: 4ea6a82aae3c846e8d2d4bf194124d552fb648b8ba07388be71bc52441fc69f1
+  md5: bcec7846de67985acb2152aa1fc0b45f
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23850
+  timestamp: 1695368071532
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.8.0-py310h9d2df84_2.conda
+  sha256: 3f8da0701cf2b4ed600cdc61afc898d8d9fd7f1fc02d3e06d6035549335c84c5
+  md5: a2de74020069569899e06f4cc4fed327
+  depends:
+  - __osx >=10.9
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.0.1
+  - libcxx >=16.0.6
+  - numpy >=1.21,<2
+  - numpy >=1.22.4,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python-dateutil >=2.7
+  - python_abi 3.10.* *_cp310
+  license: PSF-2.0
+  license_family: PSF
+  size: 6755173
+  timestamp: 1697011850337
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/minizip-4.0.2-hd5cad61_0.conda
+  sha256: 57051f3bc2dedc7a4bcf31f36a463a683d3c131d8ff7a77bcf8be91455e70581
+  md5: 90adaefb38030b00a28dd07140ae7335
+  depends:
+  - __osx >=10.9
+  - bzip2 >=1.0.8,<2.0a0
+  - libcxx >=16.0.6
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.4,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 78361
+  timestamp: 1698348818338
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.0.6-py310h38f39d4_0.conda
+  sha256: 87cc21669998bd04597ca847b242b1ec32b61e05f403aac6581a23286548ae30
+  md5: 54213bc624820c75a217981b1152983c
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: Apache
+  size: 189329
+  timestamp: 1695464525811
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.0.4-py310h8e9501a_1.conda
+  sha256: c06cdef2cedc026a44ae084f95ae3f2086780946c047347beffcfba32c6765c7
+  md5: ca712ab597b2a0e11e0686882f0d0f04
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: APACHE
+  size: 51099
+  timestamp: 1696716466777
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h463b476_2.conda
+  sha256: f6890634f815e8408d08f36503353f8dfd7b055e4c3b9ea2ee52180255cf4b0a
+  md5: 52b6f254a7b9663e854f44b6570ed982
+  depends:
+  - __osx >=10.9
+  license: X11 AND BSD-3-Clause
+  size: 794741
+  timestamp: 1698751574074
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/netcdf4-1.6.5-nompi_py310h3aafd6c_100.conda
+  sha256: 60c146c0f8548dfa3dc82f92477fe8c029339ab85421598e62cb1690dc85321b
+  md5: 7f5c1cf29a253ba7a219ddf507607b3f
+  depends:
+  - certifi
+  - cftime
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 452198
+  timestamp: 1698267929039
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.35-hb7217d7_0.conda
+  sha256: 35959d36ea9e8a2c422db9f113ee0ac91a9b0c19c51b05f75d0793c3827cfa3a
+  md5: f81b5ec944dbbcff3dd08375eb036efa
+  depends:
+  - libcxx >=14.0.6
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 220745
+  timestamp: 1669785182058
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.94-hc6b9969_0.conda
+  sha256: 662782a095cc191c073db8e44e14bf8877252d98b1f9b69275d79c47af185bb5
+  md5: 4dec6b96cec24e41059c2e795755760a
+  depends:
+  - libcxx >=15.0.7
+  - libsqlite >=3.43.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - nspr >=4.35,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1860089
+  timestamp: 1696290169758
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.57.1-py310hb9b3264_0.conda
+  sha256: bb9da3073f7c7093a11176210798e90cabe59d99f1521c6acfa0ffd27393b9a3
+  md5: 5abd1894383216c3440b51ea74b2dcc2
+  depends:
+  - libcxx >=15.0.7
+  - llvm-openmp >=15.0.7
+  - llvm-openmp >=16.0.6
+  - llvmlite >=0.40.0,<0.41.0a0
+  - numpy >=1.21.6,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - cuda-python >=11.6
+  - cudatoolkit >=10.2
+  - scipy >=1.0
+  - libopenblas >=0.3.18, !=0.3.20
+  - tbb >=2021.6.0
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.25
+  - cuda-version >=10.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4142984
+  timestamp: 1687805259589
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numcodecs-0.12.1-py310hd5a4765_0.conda
+  sha256: ae580e4c1b039381bff4f596931856d1ad934f75dbdf37c7f54e1d171fc3db17
+  md5: 0cad814a948c9ad33f3c52a9fa4265ad
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - msgpack-python
+  - numpy >=1.7
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 635154
+  timestamp: 1697592711748
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.24.4-py310haa1e00c_0.conda
+  sha256: 1b75412b0efbf73a49f3c89b27a16d3060bd21412beb8f41458476ef262c8ddb
+  md5: 46dabb7e75e135894ff149ff30c2fe58
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=15.0.7
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5645514
+  timestamp: 1687809117801
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.0-h4c1507b_3.conda
+  sha256: a6998c0da4643a84dc7c0b3a9e5137db258619ea922317bb7d9ae64f54b4a9ed
+  md5: 4127dd217a010d9c6cbefdaae07d9f19
+  depends:
+  - libcxx >=15.0.7
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 323335
+  timestamp: 1694708748389
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.1.4-h0d3ecfb_0.conda
+  sha256: 3c715b1d4940c7ad6065935db18924b85a54048dde066f963cfc250340639457
+  md5: 5a89552fececf4cd99628318ccbb67a3
+  depends:
+  - ca-certificates
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2147225
+  timestamp: 1698164947105
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-1.9.0-hcd02cb2_3.conda
+  sha256: 745ae7b01053f2602e136d30e303ab3946f2706b502cff795b5cc18e7d17ae2f
+  md5: f641dc4341fc504ef31923bf5ded9782
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 405788
+  timestamp: 1696768918785
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.1.2-py310h6e3cc31_0.conda
+  sha256: 04f6137a2b4e7d7ca4ac8ae9172fa46f698299daf69a39241b0f06c0a84a430b
+  md5: f4541964837302ef276e39beec3930b6
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.10.* *_cp310
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11702193
+  timestamp: 1698376574975
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.40-hb34f9b4_0.tar.bz2
+  sha256: 93503b5e05470ccc87f696c0fdf0d47938e0305b5047eacb85c15d78dcf641fe
+  md5: 721b7288270bafc83586b0f01c2a67f2
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.12,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1161688
+  timestamp: 1665563317371
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.1.0-py310hfae7ebd_0.conda
+  sha256: 6eb39a548c3597e1dffb16e593e47086955c33f0214b093c3588d564afae2bdf
+  md5: c66984e8d278284deb358f239b7e6f6c
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 46369279
+  timestamp: 1697424124892
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.42.2-h13dd4ca_0.conda
+  sha256: 90e60dc5604e356d47ef97b23b13759ef3d8b70fa2c637f4809d29851435d7d7
+  md5: f96347021db6f33ccabe314ddeab62d4
+  depends:
+  - libcxx >=15.0.7
+  license: MIT
+  license_family: MIT
+  size: 213843
+  timestamp: 1695736518800
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/poppler-23.10.0-hcdd998b_0.conda
+  sha256: 53ffe710fc3c2e6af9c7b42f093b39b2626a6029bc7373509a7e054031b6cf95
+  md5: f09dca383af70b61ff5ead622d2994a1
+  depends:
+  - __osx >=10.9
+  - cairo >=1.18.0,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gettext >=0.21.1,<1.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libcxx >=16.0.6
+  - libglib >=2.78.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - nspr >=4.35,<5.0a0
+  - nss >=3.94,<4.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - poppler-data
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 1472369
+  timestamp: 1697137362003
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/postgresql-16.0-h00cd704_1.conda
+  sha256: 4d4436e7ed031e865f6d8a58c298f71898432dd9daed96d0cab555ef30a1a838
+  md5: b8284b082e2507f1dd0662bc68e00a09
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libpq 16.0 hcea71ed_1
+  - libxml2 >=2.11.5,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tzcode
+  - tzdata
+  - zlib
+  size: 4557905
+  timestamp: 1696004421616
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.3.0-h52fb9d0_2.conda
+  sha256: 6a76ab5ac69b1379d874a5b1405c15f13cc9fb3622a4a8837519c3328286e781
+  md5: 31cbb3c9d6f8611a657e1b1a4cb5c63d
+  depends:
+  - libcurl >=8.4.0,<9.0a0
+  - libsqlite >=3.43.2,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2599795
+  timestamp: 1697808957598
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.5-py310h2aa6e3c_1.conda
+  sha256: dd1c98a7d0b5d56b042d1ed4c9985efe34736e14fa01aaaa845b3fdc73ec7213
+  md5: 23345ff87d77b88a64c86e33129306bc
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372879
+  timestamp: 1695368032827
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
+  sha256: 9da9e6f5d51dff6ad2e4ee0874791437ba952e0a6249942273f0fedfd07ea826
+  md5: d3f26c6494d4105d4ecb85203d687102
+  license: MIT
+  license_family: MIT
+  size: 5696
+  timestamp: 1606147608402
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-13.0.0-py310hf2cf3de_13_cpu.conda
+  sha256: 738d4b3cba822d7b7f6327ef1b55ab360c52be8690868b8dd3077400b789b71f
+  md5: 35f075a9607d264b1bf9305fa2e9baea
+  depends:
+  - __osx >=10.9
+  - libarrow 13.0.0 h87fad27_13_cpu
+  - libcxx >=15.0.7
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3661258
+  timestamp: 1698345926778
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.0-py310hd07e440_0.conda
+  sha256: 64de496ae798d39e418d20f0152451f9f7f83ed2f204d40f942891a2f0fda4db
+  md5: 4025264a438b23779805d1fd159ba24d
+  depends:
+  - libffi >=3.4,<4.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 427210
+  timestamp: 1695560925704
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.0-py310hd07e440_1.conda
+  sha256: 85e9310323068c4e694747c28f6efd944bb87ebfa69917a64baf9a1bdc8d1107
+  md5: 28feb7a05b5f17f75f573688c402941a
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 10.0.*
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 331009
+  timestamp: 1695717008751
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.6.1-py310h2de6d0e_3.conda
+  sha256: 4b479e89e5960b74dc62b529d945f8f7066b7c7e114b1b12baf87edb55d5c4e6
+  md5: fdd61e39e6fcbb7f0f89f2711398272a
+  depends:
+  - certifi
+  - proj >=9.3.0,<9.3.1.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 467100
+  timestamp: 1698058691031
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.13-h2469fbe_0_cpython.conda
+  sha256: beac97704e80948a3bacba7001737a99e3908006aa6461d5564755854959eba2
+  md5: c962b55e55a14d30f61fe11b84c2b319
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.43.2,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.4,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.10.* *_cp310
+  license: Python-2.0
+  size: 11522758
+  timestamp: 1698344110843
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-snappy-0.6.1-py310ha977fbf_1.conda
+  sha256: 11c1bad90a25070aafa6112709bddbe9f332a4555ca72160dbb469bad1e8b810
+  md5: 8365c34c28c39d149b5069752da684b6
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - snappy >=1.1.10,<1.2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 31630
+  timestamp: 1695500314164
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.10-4_cp310.conda
+  sha256: f69bac2f28082a275ef67313968b2c366d8236c3a6869b9cdf5cdb97a5821812
+  md5: 1a3d9c6bb5f0b1b22d9e9296c127e8c7
+  constrains:
+  - python 3.10.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6490
+  timestamp: 1695147522999
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.1-py310h2aa6e3c_1.conda
+  sha256: 7b8668cd86d2421c62ec241f840d84a600b854afc91383a509bbb60ba907aeec
+  md5: 0e7ccdd121ce7b486f1de7917178387c
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 158641
+  timestamp: 1695373859696
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-25.1.1-py310h7e65269_2.conda
+  sha256: 94d83f3a975a72cc361a54dfddb027c952bfb9deda3da19e436de945a50ba498
+  md5: 7a630fcdb5d56899b166641d9e19fb64
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  size: 422340
+  timestamp: 1698062895033
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rasterio-1.3.9-py310hdddcdff_0.conda
+  sha256: feff3118aba606c7d64100d3e19139935a85fd4cddfefc5dad5acb47d441aca4
+  md5: ce48f1c107a80d6961be8213673235e1
+  depends:
+  - affine
+  - attrs
+  - certifi
+  - click >=4
+  - click-plugins
+  - cligj >=0.5
+  - libgdal >=3.7.2,<3.8.0a0
+  - numpy >=1.22.4,<2.0a0
+  - proj >=9.3.0,<9.3.1.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7132923
+  timestamp: 1697714671731
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2023.06.02-h6135d0a_0.conda
+  sha256: 963847258a82d9647311c5eb8829a49ac2161df12a304d5d6e61f788f0563442
+  md5: 8f23674174b155300696a2be8b5c1407
+  depends:
+  - libre2-11 2023.06.02 h1753957_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27073
+  timestamp: 1697065856329
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+  sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
+  md5: 8cbb776a2f641b943d413b3e19df71f4
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 250351
+  timestamp: 1679532511311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.10.6-py310hd442715_0.conda
+  sha256: ee0e8cf43afc2dfaa5c59538bd22ae1164492082386b8ce4762ec1a4d05cfdc0
+  md5: 4e8643df730421abaec73eaaf99aef2e
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 289331
+  timestamp: 1697072771524
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.3.2-py310h417b086_1.conda
+  sha256: 007317cc2fb2d2d758a77726c5c5558c3f49f8904b05adf61f8e1214a63597ea
+  md5: 8d03092a993de821d7a0b72ff3a5d47f
+  depends:
+  - __osx >=10.9
+  - joblib >=1.1.1
+  - libcxx >=16.0.6
+  - llvm-openmp >=16.0.6
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - scipy
+  - threadpoolctl >=2.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7641678
+  timestamp: 1698225918172
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.11.3-py310hd1cfc7d_1.conda
+  sha256: a5ab906f8921e9ce549f104bde9f78d67f54b17f58d56296e32dd460e7059f37
+  md5: 6d671552969c2b5843a8de25c2af3ba0
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=15.0.7
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy >=1.22.4,<1.28
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - libopenblas <0.3.26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13862445
+  timestamp: 1696469409228
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.2-py310h656ff59_0.conda
+  sha256: b8893266e77f0ae69aeb963b152fad69effcb55262b82fc85bcf90b21a66298d
+  md5: b45645084ef2ac7864efbe4d7f0a8c0e
+  depends:
+  - geos >=3.12.0,<3.12.1.0a0
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 446313
+  timestamp: 1697191756608
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
+  sha256: dfae03cd2339587871e53b42833657faa4c9e42e3e2c56ee9e32bc60797c7f62
+  md5: ac82a611d1a67a598096ebaa857198e3
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33879
+  timestamp: 1678534968831
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.44.0-hf2abe2d_0.conda
+  sha256: 8263043d2a5762a5bbbb4ceee28382d97e70182fff8d45371b65fedda0b709ee
+  md5: 0080e3f5d7d13d3b1e244ed24642ca9e
+  depends:
+  - libsqlite 3.44.0 h091b4b1_0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 800748
+  timestamp: 1698855055771
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.10.0-h1995070_2.conda
+  sha256: 5acedf2ba0d18217a6387f4788086e51cac56cef12ac120335fc3b31d40c0417
+  md5: 245760f53d4fa23bfb58ffbf89a4edc8
+  license: Apache-2.0
+  license_family: APACHE
+  size: 125356
+  timestamp: 1697713774680
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tiledb-2.16.3-he15c4da_3.conda
+  sha256: c2576bf0344b441f4c7d9212cfa68fe64de88dc9da735cb541c7faa0595d260f
+  md5: fcf3711dd1817fd6e8ab59be86aa8dd9
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230802.0,<20230803.0a0
+  - libcxx >=15.0.7
+  - libgoogle-cloud >=2.12.0,<2.13.0a0
+  - libxml2 >=2.11.5,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.1.2,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 4911600
+  timestamp: 1694523575326
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hb31c410_0.conda
+  sha256: 6df6ff49dba487eb891ddc0099642a36af2fe3929ed8023f76b745f0485c54a6
+  md5: aa913a828b65f30ee3aba9c59bb0b514
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3223549
+  timestamp: 1695506653047
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.3.3-py310h2aa6e3c_1.conda
+  sha256: 476ccfdc55e8eff548938b19cea93c5292770f8219d9b6d4f05f665ed60bc061
+  md5: 8e480fb72ff6963b2a1ceb2f2ede62cf
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: Apache
+  size: 641741
+  timestamp: 1695374073257
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tzcode-2023c-h1a8c8d9_0.conda
+  sha256: 0a60ff53272547a0f80862f0a1969a5d1cec16bd2e9098ed5b07d317682a4361
+  md5: 96779d3be996d78411b083f99a51199c
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 63064
+  timestamp: 1680049656503
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-15.1.0-py310h2aa6e3c_0.conda
+  sha256: fd33715a75bc7d4ad863ac47341e9fdf8b78e47aa55c90f89a844c660aacc352
+  md5: 9dbba0c13148e8efbb80eb60186b2d8c
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: Apache
+  size: 377237
+  timestamp: 1695848435303
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/uriparser-0.9.7-hb7217d7_1.conda
+  sha256: bedd03f3bb30b73ae7b0dc9626f1371a8568ce6d41303df3e8299688428dfa94
+  md5: 4fe532e3c6b0cfa5365eb01743d32578
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39597
+  timestamp: 1677713148574
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.15.0-py310h2aa6e3c_1.conda
+  sha256: d7db6716f15656c2dabf8e0534b3a9fef110353564d029cb9ab87ea6cb9db4c5
+  md5: 4ac4a5289646e92af304882fd61c3d1f
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 52770
+  timestamp: 1695409643854
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xerces-c-3.2.4-hd886eac_3.conda
+  sha256: 5ecc3322ddcad0a002a44bd4dddfe898b9e02951c629f6962c23b3bcf6014c9f
+  md5: 916e77cb0be0040410881fba8e28b5bb
+  depends:
+  - icu >=73.2,<74.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libcxx >=15.0.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 1332769
+  timestamp: 1692976472328
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
+  sha256: 02c313a1cada46912e5b9bdb355cfb4534bfe22143b4ea4ecc419690e793023b
+  md5: ca73dc4f01ea91e44e3ed76602c5ea61
+  license: MIT
+  license_family: MIT
+  size: 13667
+  timestamp: 1684638272445
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
+  sha256: d9a2fb4762779994718832f05a7d62ab2dcf6103a312235267628b5187ce88f7
+  md5: 6738b13f7fadc18725965abdd4129c36
+  license: MIT
+  license_family: MIT
+  size: 18164
+  timestamp: 1610071737668
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+  sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
+  md5: 39c6b54e94014701dd157f4f576ed211
+  license: LGPL-2.1 and GPL-2.0
+  size: 235693
+  timestamp: 1660346961024
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+  sha256: 93181a04ba8cfecfdfb162fc958436d868cc37db504c58078eab4c1a3e57fbb7
+  md5: 4bb3f014845110883a3c5ee811fd84b4
+  license: MIT
+  license_family: MIT
+  size: 88016
+  timestamp: 1641347076660
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.9.2-py310hd125d64_1.conda
+  sha256: e3ec3cb4407beed13739dc9bbc6ef343af9c05f40e1915afab023b05f9c346aa
+  md5: 8a6c10edb0ce538d54d3cae04949f949
+  depends:
+  - idna >=2.0
+  - multidict >=4.0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: Apache
+  size: 92592
+  timestamp: 1696732958476
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h965bd2d_0.conda
+  sha256: 06abddc92d0bf83cd9faf25f26c98d7c2cc681cb50504011580b0584cf3cb1c5
+  md5: f460bbcb0ec8dc77989288fe8caa0f84
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 287460
+  timestamp: 1697056868401
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
+  sha256: de0ee1e24aa6867058d3b852a15c8d7f49f262f5828772700c647186d4a96bbe
+  md5: a08383f223b10b71492d27566fafbf6c
+  depends:
+  - libzlib 1.2.13 h53f4e23_5
+  license: Zlib
+  license_family: Other
+  size: 79577
+  timestamp: 1686575471024
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
+  sha256: 7e1fe6057628bbb56849a6741455bbb88705bae6d6646257e57904ac5ee5a481
+  md5: 5b212cfb7f9d71d603ad891879dc7933
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 400508
+  timestamp: 1693151393180
+- conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.8.6-py310h8d17308_1.conda
+  sha256: 2e4f5402850013d6a1ab92c398a01e7323cdf8e6bfd89e548dc908286499d9ba
+  md5: e1361de6fbefdd7b5c8ca47a3699b0c8
+  depends:
+  - aiosignal >=1.1.2
+  - async-timeout <5.0,>=4.0.0a3
+  - attrs >=17.3.0
+  - charset-normalizer >=2.0,<4.0
+  - frozenlist >=1.1.1
+  - multidict >=4.5,<7.0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yarl >=1.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  size: 609407
+  timestamp: 1696765849874
+- conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py310h8d17308_4.conda
+  sha256: ae143aec777823b2291caabc3fd89078a3ff12f41945e0f9abd168997ad35d39
+  md5: ece29c9dd68f962fd416a3ddcce24080
+  depends:
+  - cffi >=1.0.1
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 33906
+  timestamp: 1695387195123
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.5-h7c265c8_0.conda
+  sha256: 74ab208974b45be4c290d32534f545e0b69c0ccb0214d047aa7250fe98e855e0
+  md5: d73f0231b3a9d12fc73b1dd10e3b46fd
+  depends:
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 98064
+  timestamp: 1698392952402
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.6.7-h85219b4_0.conda
+  sha256: 05282adc12e0603a9efb71ec721055fb409814ef4c33ea100721eacf0b01721a
+  md5: 907073c34391c73a16a2d8a8832b5781
+  depends:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 55811
+  timestamp: 1697673687140
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.4-hcfcfb64_0.conda
+  sha256: f32901b945f145d19718f0e4a38852a8b1820a529e9bbfd0d3e56856f7b72ab2
+  md5: de2da3a4925bb0631eaf77782cb5a1c3
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 218428
+  timestamp: 1697224807961
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.17-h85219b4_4.conda
+  sha256: 65c2f3b48e6d59615b5dae3ca0a1e9396c4978f4a9cfa4a492dfa04e036fbbd4
+  md5: 524e7212432b694d88787e9b3ef06f09
+  depends:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 22443
+  timestamp: 1697276610135
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.3.2-h02e22aa_4.conda
+  sha256: fc3a941a8d3e00bca9e79cd9415a94870e051f228d306b47e6843d0804de8af4
+  md5: e78656916fbb0db53831b7f06eabeb2c
+  depends:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 54561
+  timestamp: 1697310556600
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.7.13-hddd7df3_7.conda
+  sha256: 7304c23e73fc4b975c928bc1953040e02bcb850c4a5ef6c260fac48480485725
+  md5: 4143b9c8a9dafbe49f5f20aa7e39a6dd
+  depends:
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-compression >=0.2.17,<0.2.18.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 179787
+  timestamp: 1697851279463
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.13.35-h8233182_4.conda
+  sha256: 7c7c1cd69cc49b9109a6e37c13b248f04705594071d2b9c6f51ab6103401ed66
+  md5: 5317706b4f9075e4c1fdf8b72d09f266
+  depends:
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 158859
+  timestamp: 1697833111049
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.9.8-hf43a5ce_0.conda
+  sha256: 6195d5728a00a738eb0fe26b643e60d6b65c8cf4ec05cf95e4f033b8255a21d8
+  md5: e0467f27b3eeb77e49aee9a86cd7b5a2
+  depends:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 157587
+  timestamp: 1697771116588
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.3.20-h6f899c3_1.conda
+  sha256: d6f5fcaf70ffdd862e9aa550becd52e47093f3cb77ac6b295251e1358dc4525f
+  md5: a623c3e6d6bfe5c47a54eceadfddf62c
+  depends:
+  - aws-c-auth >=0.7.5,<0.7.6.0a0
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 83403
+  timestamp: 1698604138214
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.12-h85219b4_3.conda
+  sha256: 524e581e4eefec8c940772c73da4cfd1879172d70ad1b9032c497df866a60f7a
+  md5: 08fb0bce8e142624f3c30d9ec0627a6b
+  depends:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 51751
+  timestamp: 1697283702647
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.17-h85219b4_3.conda
+  sha256: 3609917ce1c3110446f27a85d6e6fcaf170f5c77620c3e368a8ef401c5f779cc
+  md5: 2df2f1365d32e5b26bee1cbe783ddc61
+  depends:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 52275
+  timestamp: 1697283441613
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.24.4-h4ff64ff_2.conda
+  sha256: 05c4dec9623c5bf6c7d8a39988c829a3c276fe221f054f8d6e48d68029fed492
+  md5: 79ecfe45f6ac81d0f15b0365a498a4e6
+  depends:
+  - aws-c-auth >=0.7.5,<0.7.6.0a0
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-c-mqtt >=0.9.8,<0.9.9.0a0
+  - aws-c-s3 >=0.3.20,<0.3.21.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 236773
+  timestamp: 1698624647282
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.182-h9479ca2_2.conda
+  sha256: 3fb838bd24c109bfff19f751df5beb8cfaf78d0ab5ea1d11b9bb9b25e3e56ada
+  md5: 3aa4471fb89baca6d88330c7cf5e4d5f
+  depends:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - aws-crt-cpp >=0.24.4,<0.24.5.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 3253371
+  timestamp: 1698319242118
+- conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.5-hdccc3a2_0.conda
+  sha256: 73cee35e5366ce998ef36ccccb4c11ef9ead297886cc08269379f91539131288
+  md5: 77a5cea2ce92907b7d1e7954457a526a
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50069
+  timestamp: 1693657396550
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-hcfcfb64_1.conda
+  sha256: b927c95121c5f3d82fe084730281739fb04621afebf2d9f05711a0f42d27e326
+  md5: f47f6db2528e38321fb00ae31674c133
+  depends:
+  - brotli-bin 1.1.0 hcfcfb64_1
+  - libbrotlidec 1.1.0 hcfcfb64_1
+  - libbrotlienc 1.1.0 hcfcfb64_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 19772
+  timestamp: 1695990547936
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-hcfcfb64_1.conda
+  sha256: 4fbcb8f94acc97b2b04adbc64e304acd7c06fa0cf01953527bddae46091cc942
+  md5: 0105229d7c5fabaa840043a86c10ec64
+  depends:
+  - libbrotlidec 1.1.0 hcfcfb64_1
+  - libbrotlienc 1.1.0 hcfcfb64_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 20885
+  timestamp: 1695990517506
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py310h00ffb61_1.conda
+  sha256: 8de77cf62a653dd6ffe19927b92c421f5fa73c078d7799181f5211a1bac2883b
+  md5: 42bfbc1d41cbe2696a3c9d8b0342324f
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libbrotlicommon 1.1.0 hcfcfb64_1
+  license: MIT
+  license_family: MIT
+  size: 321672
+  timestamp: 1695990897641
+- conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h8ffe710_4.tar.bz2
+  sha256: 5389dad4e73e4865bb485f460fc60b120bae74404003d457ecb1a62eb7abf0c1
+  md5: 7c03c66026944073040cb19a4f3ec3c9
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 152247
+  timestamp: 1606605223049
+- conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.20.1-hcfcfb64_1.conda
+  sha256: 817b2733caef6f8513ed6dc9a1b5883ddc9ac303eaf1971e4d4ec73080f6ab99
+  md5: 0a45278f9b791a68dbe4acc234fa8a26
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 112068
+  timestamp: 1697956205060
+- conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.7.22-h56e8100_0.conda
+  sha256: b85a6f307f8e1c803cb570bdfb9e4d811a361417873ecd2ecf687587405a72e0
+  md5: b1c2327b36f1a25d96f2039b0d3e3739
+  license: ISC
+  size: 150013
+  timestamp: 1690026269050
+- conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h1fef639_0.conda
+  sha256: 451e714f065b5dd0c11169058be56b10973dfd7d9a0fccf9c6a05d1e09995730
+  md5: b3fe2c6381ec74afe8128e16a11eee02
+  depends:
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=73.2,<74.0a0
+  - libglib >=2.78.0,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - pixman >=0.42.2,<1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 1520159
+  timestamp: 1697029136038
+- conda: https://conda.anaconda.org/conda-forge/win-64/cartopy-0.22.0-py310hecd3228_1.conda
+  sha256: ca4a23b933610e8922be7ae04a47504bd845327bfca5d44063cddd9161c01906
+  md5: e5776f7a1e024a4ce8d0d0d553e85b8c
+  depends:
+  - matplotlib-base >=3.4
+  - numpy >=1.22.4,<2.0a0
+  - packaging >=20
+  - pyproj >=3.1.0
+  - pyshp >=2.1
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - shapely >=1.7
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 1818314
+  timestamp: 1698173485680
+- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.16.0-py310h8d17308_0.conda
+  sha256: 1aeebb88518ab48c927d7360648a2799def172d8fcb0d7e20cb7208a3570ef9e
+  md5: b4bcce1a7ea1164e6dcea6c4f00d962b
+  depends:
+  - pycparser
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 237888
+  timestamp: 1696002116250
+- conda: https://conda.anaconda.org/conda-forge/win-64/cfitsio-4.3.0-h9b0cee5_0.conda
+  sha256: b941249b2254939a180922d7639e1517feae71d61bcca86788fb953202e2b103
+  md5: a04c557207fa9fc6f663ae1e4768d321
+  depends:
+  - libcurl >=8.2.0,<9.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LicenseRef-fitsio
+  size: 563108
+  timestamp: 1690378239344
+- conda: https://conda.anaconda.org/conda-forge/win-64/cftime-1.6.3-py310h3e78b6c_0.conda
+  sha256: 73f41269bd2052e0ee71d6a1a985dca1664222ddd50d35d18d0ac4f117de1db6
+  md5: 00d6eac027a0d5c3676a362fb48fbb73
+  depends:
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 184772
+  timestamp: 1698610687537
+- conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.1.1-py310h232114e_1.conda
+  sha256: 791066ff598112b7b892a7f03994e5597b1959da114c3f6f0a900fa6b72b62b8
+  md5: 7062335928a7ca43c0163656637f96ff
+  depends:
+  - numpy >=1.16
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 174882
+  timestamp: 1695554536953
+- conda: https://conda.anaconda.org/conda-forge/win-64/cramjam-2.7.0-py310he2c049f_1.conda
+  sha256: 8746fe55d5eb2ee27403cf63d1e17516463d7498198cfba1944a12e968fc284d
+  md5: e0a844fac9059fc2e18e8109887f721b
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 1125717
+  timestamp: 1695451297297
+- conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-0.12.2-py310h8d17308_1.conda
+  sha256: 11c553586990bf3dfa14614afa40fcc551e361b96e1d37933043ae7fa79505ef
+  md5: c58d57f0e0da299d55a888bd463dd275
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - toolz >=0.10.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 295817
+  timestamp: 1695545573451
+- conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.0-py310h00ffb61_1.conda
+  sha256: c500ddc59777e7f7fc8f364ae1b9d6487343bc34bfd078a549fbd0f59c4efc1a
+  md5: 5ccaf32fb16dd1336f74a635ef6acf7d
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 3416775
+  timestamp: 1695534920376
+- conda: https://conda.anaconda.org/conda-forge/win-64/expat-2.5.0-h63175ca_1.conda
+  sha256: 3bcd88290cd462d5573c2923c796599d0dece2ff9d9c9d6c914d31e9c5881aaf
+  md5: 87c77fe1b445aedb5c6d207dd236fa3e
+  depends:
+  - libexpat 2.5.0 h63175ca_1
+  license: MIT
+  license_family: MIT
+  size: 226571
+  timestamp: 1680190888036
+- conda: https://conda.anaconda.org/conda-forge/win-64/fastparquet-2023.10.1-py310h3e78b6c_0.conda
+  sha256: b2c0d6ab98fb50b595ce12c3b19c465b3d4c33f2a77a10680b91b5d7b245b449
+  md5: 5911ecd7640d3e34e39b09421be199cb
+  depends:
+  - cramjam >=2.3
+  - fsspec
+  - numpy >=1.20.3
+  - numpy >=1.22.4,<2.0a0
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 399197
+  timestamp: 1698413585195
+- conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.14.2-hbde0cde_0.conda
+  sha256: 643f2b95be68abeb130c53d543dcd0c1244bebabd58c774a21b31e4b51ac3c96
+  md5: 08767992f1a4f1336a257af1241034bd
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 190111
+  timestamp: 1674829354122
+- conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.43.1-py310h8d17308_0.conda
+  sha256: 52a5990e8285ff9e19523b3a54b0b12184bba6c2e0c1d6b46ea35ba6c2c87e4e
+  md5: bf7aeb6342332abb73154d09305c15b2
+  depends:
+  - brotli
+  - munkres
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - unicodedata2 >=14.0.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1845371
+  timestamp: 1696601840402
+- conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+  sha256: 2c53ee8879e05e149a9e525481d36adfd660a6abda26fd731376fa64ff03e728
+  md5: 3761b23693f768dc75a8fd0a73ca053f
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-only OR FTL
+  size: 510306
+  timestamp: 1694616398888
+- conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-h8276f4a_0.conda
+  sha256: 9ef2fcf3b35703bf61a8359038c4b707382f3d5f0c4020f3f8ffb2f665daabae
+  md5: 8e02e06229c677cbc9f5dc69ba49052c
+  depends:
+  - libexpat >=2.5.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - minizip >=4.0.1,<5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 77439
+  timestamp: 1694953013560
+- conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.4.0-py310h8d17308_1.conda
+  sha256: 83e9ede4d8ab18be6ea9cfc63fb1458455050deaaf6bd46815fe95de5eb332ca
+  md5: 4ad4c9ab9b20024e89e74e77250777f7
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 48032
+  timestamp: 1695378066459
+- conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.12.0-h1537add_0.conda
+  sha256: 096c45cb03240ae67ff9e09166110a3bd19a5ab20bf7deea8be55557792b9924
+  md5: 78119c25e59de33135b673375c6fa126
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-only
+  size: 1557552
+  timestamp: 1687939460054
+- conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.1-hcf4a93f_14.conda
+  sha256: 12f8e01f8cb4dccfbd16af9f88f81aa6ccda8607d98a9eb1f7f305c3f455439f
+  md5: ba4fadef391cfecb95ad9dc8617fe481
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - proj >=9.3.0,<9.3.1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 125625
+  timestamp: 1695943530332
+- conda: https://conda.anaconda.org/conda-forge/win-64/gettext-0.21.1-h5728263_0.tar.bz2
+  sha256: 71c75b0a4dc2cf95d2860ea0076edf9f5558baeb4dacaeecb32643b199074616
+  md5: 299d4fd6798a45337042ff5a48219e5f
+  depends:
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 5579416
+  timestamp: 1665676022441
+- conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
+  sha256: 52fa5dde69758c19c69ab68a3d7ebfb2c9042e3a55d405c29a59d3b0584fd790
+  md5: 84344a916a73727c1326841007b52ca8
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 779637
+  timestamp: 1695662145568
+- conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.2-nompi_h73e8ff5_100.conda
+  sha256: 86bab02f1dbc658a15719b27ca5dcd2b50c22905cc2296a31a0ed220dac746f9
+  md5: 7fc095c23e4519a8df15c09f3671d09a
+  depends:
+  - libaec >=1.0.6,<2.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LicenseRef-HDF5
+  license_family: BSD
+  size: 2044096
+  timestamp: 1692562772245
+- conda: https://conda.anaconda.org/conda-forge/win-64/icu-73.2-h63175ca_0.conda
+  sha256: 423aaa2b69d713520712f55c7c71994b7e6f967824bb39b59ad968e7b209ce8c
+  md5: 0f47d9e3192d9e09ae300da0d28e0f56
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 13422193
+  timestamp: 1692901469029
+- conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2023.2.0-h57928b3_50497.conda
+  sha256: dd9fded25ebe5c66af30ac6e3685146efdc2d7787035f01bfb546b347f138f6f
+  md5: a401f3cae152deb75bbed766a90a6312
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 2523079
+  timestamp: 1698351323119
+- conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-2.4-py310h5588dad_3.conda
+  sha256: 50b86f741719065c235dd00c706bc00fd5cc59cb48bf31505d8ff620a0eb7a02
+  md5: 55a7275d703b4c73bae42dcf54cc1441
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 32969
+  timestamp: 1695398011639
+- conda: https://conda.anaconda.org/conda-forge/win-64/jupyter_core-5.5.0-py310h5588dad_0.conda
+  sha256: 7dc48c8b66631de41c1f76981e05c0b2f5023bb2b95f3de088a6e2935ff8ed68
+  md5: 3e5945e27a3b647fe00097c27ffbd67c
+  depends:
+  - platformdirs >=2.5
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 95749
+  timestamp: 1698674415793
+- conda: https://conda.anaconda.org/conda-forge/win-64/kealib-1.5.2-ha10e780_1.conda
+  sha256: 1c7ee8618ca79a0738b42df539407ca4ecb16a704cc48312c3b337bcc97ec346
+  md5: b6e313824859a2408b77a0a3811a6311
+  depends:
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 133341
+  timestamp: 1696011596185
+- conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.5-py310h232114e_1.conda
+  sha256: 8969469887a0b72f732ec9250fd25982499270bda473a5db4c04ee252db96d89
+  md5: a340ed8a9c513e2782cb7feb3cfe665d
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55587
+  timestamp: 1695380469062
+- conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
+  sha256: 6002adff9e3dcfc9732b861730cb9e33d45fd76b2035b2cdb4e6daacb8262c0b
+  md5: 6e8b0f22b4eef3b3cb3849bb4c3d47f9
+  depends:
+  - openssl >=3.1.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 710894
+  timestamp: 1692098129546
+- conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.15-h67d730c_3.conda
+  sha256: 8819d74571b6321e0ed93b07c19b4fd9a9b669df3fdd797ab4798ab7c684ae1d
+  md5: f92e86636451e3f6cea03e395346fa90
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 498833
+  timestamp: 1695969944045
+- conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+  sha256: f4f39d7f6a2f9b407f8fb567a6c25755270421731d70f0ff331f5de4fa367488
+  md5: 1900cb3cab5055833cfddb0ba233b074
+  depends:
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30037
+  license: Apache-2.0
+  license_family: Apache
+  size: 194365
+  timestamp: 1657977692274
+- conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20230802.1-cxx17_h63175ca_0.conda
+  sha256: 8a016d49fad3d4216ce5ae4a60869b5384d31b2009e1ed9f445b6551ce7ef9e8
+  md5: 02674c18394394ee4f76cdbd1012f526
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - abseil-cpp =20230802.1
+  - libabseil-static =20230802.1=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1733638
+  timestamp: 1695064265262
+- conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.2-h63175ca_1.conda
+  sha256: 731dc77bce7d6425e2113b902023fba146e827cfe301bac565f92cc4e749588a
+  md5: 0b252d2bf460364bccb1523bcdbe4af6
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 33554
+  timestamp: 1696474526588
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.7.2-h6f8411a_0.conda
+  sha256: b1d05d7318901605b5833cbd8a440772cc2328335523e22f04d5c1c378121adc
+  md5: ef46bb4b1613b308b957a25407ff6f5b
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libxml2 >=2.11.5,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - lzo >=2.10,<3.0a0
+  - openssl >=3.1.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 953689
+  timestamp: 1694543279363
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-13.0.0-hc7845e2_13_cpu.conda
+  sha256: 0c163a028a59cb8bfad5138cbb975af24141c8b3280bd933082c6dd402871806
+  md5: 8f7bd67ced2f27162e1f3f33b7195296
+  depends:
+  - aws-crt-cpp >=0.24.4,<0.24.5.0a0
+  - aws-sdk-cpp >=1.11.182,<1.11.183.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libgoogle-cloud >=2.12.0,<2.13.0a0
+  - libgrpc >=1.58.1,<1.59.0a0
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libre2-11 >=2023.6.2
+  - libthrift >=0.19.0,<0.19.1.0a0
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.1.4,<4.0a0
+  - orc >=1.9.0,<1.9.1.0a0
+  - re2
+  - snappy >=1.1.10,<1.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.5,<1.6.0a0
+  - libutf8proc <2.9
+  constrains:
+  - parquet-cpp <0.0a0
+  - arrow-cpp =13.0.0
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 16639554
+  timestamp: 1698344855452
+- conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-19_win64_mkl.conda
+  sha256: 915eae5e0dedbf87733a0b8c6f410678c77111a3fb26ca0a272e11ff979e7ef2
+  md5: 4f8a1a63cfbf74bc7b2813d9c6c205be
+  depends:
+  - mkl 2023.2.0 h6a75c08_50496
+  constrains:
+  - liblapack 3.9.0 19_win64_mkl
+  - libcblas 3.9.0 19_win64_mkl
+  - liblapacke 3.9.0 19_win64_mkl
+  - blas * mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4984180
+  timestamp: 1697485304263
+- conda: https://conda.anaconda.org/conda-forge/win-64/libboost-headers-1.82.0-h57928b3_6.conda
+  sha256: fc71380196963cde339ac002e4baab53020af401d437f0a2864ad5aa60681df0
+  md5: 7feb05147c063f56714526c5833e10b7
+  constrains:
+  - boost-cpp =1.82.0
+  license: BSL-1.0
+  size: 13824625
+  timestamp: 1696733710070
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hcfcfb64_1.conda
+  sha256: f75fed29b0cc503d1b149a4945eaa32df56e19da5e2933de29e8f03947203709
+  md5: f77f319fb82980166569e1280d5b2864
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 70598
+  timestamp: 1695990405143
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hcfcfb64_1.conda
+  sha256: 1b352ee05931ea24c11cd4a994d673890fd1cc690c21e023e736bdaac2632e93
+  md5: 19ce3e1dacc7912b3d6ff40690ba9ae0
+  depends:
+  - libbrotlicommon 1.1.0 hcfcfb64_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 32788
+  timestamp: 1695990443165
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hcfcfb64_1.conda
+  sha256: eae6b76154e594c6d211160c6d1aeed848672618152a562e0eabdfa641d34aca
+  md5: 71e890a0b361fd58743a13f77e1506b7
+  depends:
+  - libbrotlicommon 1.1.0 hcfcfb64_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 246515
+  timestamp: 1695990479484
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-19_win64_mkl.conda
+  sha256: 66c8934bf8ead1e3ab3653155697a7d70878e96115742b681aac16d9bd25dd3d
+  md5: 1b9ede5cff953aa1a5f4d9f8ec644972
+  depends:
+  - libblas 3.9.0 19_win64_mkl
+  constrains:
+  - liblapack 3.9.0 19_win64_mkl
+  - liblapacke 3.9.0 19_win64_mkl
+  - blas * mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4984046
+  timestamp: 1697485351545
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+  sha256: 75e60fbe436ba8a11c170c89af5213e8bec0418f88b7771ab7e3d9710b70c54e
+  md5: cd4cc2d0c610c8cb5419ccc979f2d6ce
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25694
+  timestamp: 1633684287072
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.4.0-hd5e4a3a_0.conda
+  sha256: f1367d8a3f115ee4c16ea4bcc313c21009decb0217f65d3bb94618939c518a71
+  md5: 13e4e3824a0212103330f57058601c21
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: curl
+  license_family: MIT
+  size: 321118
+  timestamp: 1697009866852
+- conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.19-hcfcfb64_0.conda
+  sha256: e2886a84eaa0fbeca1d1d810270f234431d190402b4a79acf756ca2d16000354
+  md5: 002b1b723b44dbd286b9e3708762433c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 153203
+  timestamp: 1694922596415
+- conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+  sha256: af03882afb7a7135288becf340c2f0cf8aa8221138a9a7b108aaeb308a486da1
+  md5: 25efbd786caceef438be46da78a7b5ef
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 410555
+  timestamp: 1685726568668
+- conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.5.0-h63175ca_1.conda
+  sha256: 794b2a9be72f176a2767c299574d330ffb76b2ed75d7fd20bee3bbadce5886cf
+  md5: 636cc3cbbd2e28bcfd2f73b2044aac2c
+  constrains:
+  - expat 2.5.0.*
+  license: MIT
+  license_family: MIT
+  size: 138689
+  timestamp: 1680190844101
+- conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+  sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
+  md5: 2c96d1b6915b408893f9472569dee135
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 42063
+  timestamp: 1636489106777
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.7.2-h3217549_7.conda
+  sha256: 594ffdc14bb08cc72796012a2f017963be6651cfec425de31bf5f51a380a9e43
+  md5: dff76d7dd6e917d7909e73f806a8cf91
+  depends:
+  - blosc >=1.21.5,<2.0a0
+  - cfitsio >=4.3.0,<4.3.1.0a0
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.12.0,<3.12.1.0a0
+  - geotiff >=1.7.1,<1.8.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - kealib >=1.5.2,<1.6.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libarchive >=3.7.2,<3.8.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libdeflate >=1.19,<1.26.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=16.0,<17.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.43.2,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxml2 >=2.11.5,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - openssl >=3.1.3,<4.0a0
+  - pcre2 >=10.40,<10.41.0a0
+  - poppler >=23.10.0,<23.11.0a0
+  - postgresql
+  - proj >=9.3.0,<9.3.1.0a0
+  - tiledb >=2.16,<2.17.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xerces-c >=3.2.4,<3.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 8434140
+  timestamp: 1697154875472
+- conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.78.0-he8f3873_0.conda
+  sha256: 1417a309e40a2fae41e18170a74bface2ab67fb0d6905caeb34f91c6840edacc
+  md5: 25f5b3502a82ac425c72c3bc0efbecb5
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - pcre2 >=10.40,<10.41.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - glib 2.78.0 *_0
+  license: LGPL-2.1-or-later
+  size: 2637097
+  timestamp: 1694381512139
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.12.0-ha74b051_3.conda
+  sha256: 1aa3c5471e21713cfd955d8643f47200eb4a2d5d60dc60c9f40f04fd1f91a3a1
+  md5: 5ed09a5cc8ac4f0b2f5a1aa17baaa79a
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libgrpc >=1.58.1,<1.59.0a0
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - openssl >=3.1.3,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - google-cloud-cpp 2.12.0 *_3
+  license: Apache-2.0
+  license_family: Apache
+  size: 13288
+  timestamp: 1696833991690
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.58.2-h2a9c87f_0.conda
+  sha256: cf99715f991ffa36cc108d324983f3d4e5750a0fb8a006419c04dd15d59e6797
+  md5: 61d0c367fb3714c0e2f25c58411669f8
+  depends:
+  - c-ares >=1.20.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libre2-11 >=2023.6.2
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.4,<4.0a0
+  - re2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - grpc-cpp =1.58.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 13296094
+  timestamp: 1698719989302
+- conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
+  sha256: 2e8c4bb7173f281a8e13f333a23c9fb7a1c86d342d7dccdd74f2eb583ddde450
+  md5: 87da045f6d26ce9fe20ad76a18f6a18a
+  depends:
+  - libxml2 >=2.11.5,<2.14.0a0
+  - pthreads-win32
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2578462
+  timestamp: 1694533393675
+- conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-h8ffe710_0.tar.bz2
+  sha256: 657c2a992c896475021a25faebd9ccfaa149c5d70c7dc824d4069784b686cea1
+  md5: 050119977a86e4856f0416e2edcf81bb
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: GPL and LGPL
+  size: 714518
+  timestamp: 1652702326553
+- conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+  sha256: 4e7808e3098b4b4ed7e287f63bb24f9045cc4d95bfd39f0db870fc2837d74dff
+  md5: 3f1b948619c45b1ca714d60c7389092c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 822966
+  timestamp: 1694475223854
+- conda: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-haf3e7a6_1018.conda
+  sha256: 74117fe100d9aa3aaab25eb705c44165f8ff6feec2e7c058212a3f5434f85d5f
+  md5: 950e8765b20b79ecbd296543f848b4ec
+  depends:
+  - libboost-headers
+  - libexpat >=2.5.0,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - uriparser >=0.9.7,<1.0a0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1764160
+  timestamp: 1696451646350
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-19_win64_mkl.conda
+  sha256: e53093eab7674528e9eafbd5efa28f3170ec1388b8df6c9b8343760696f47907
+  md5: 574e6e8bcc85df2885eb2a87d31ae005
+  depends:
+  - libblas 3.9.0 19_win64_mkl
+  constrains:
+  - libcblas 3.9.0 19_win64_mkl
+  - liblapacke 3.9.0 19_win64_mkl
+  - blas * mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4984073
+  timestamp: 1697485397401
+- conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_h8284064_112.conda
+  sha256: 6694fb1a949893178c3e0c7df648f5b9875da5ba9b1d76ec5d9a5bac6647dfc6
+  md5: d13288269ee4de9079261a31028f9954
+  depends:
+  - blosc >=1.21.4,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - libaec >=1.0.6,<2.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libxml2 >=2.11.5,<2.14.0a0
+  - libzip >=1.10.1,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  - zstd >=1.5.5,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 625332
+  timestamp: 1693582445195
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.39-h19919ed_0.conda
+  sha256: 1f139a72109366ba1da69f5bdc569b0e6783f887615807c02d7bfcc2c7575067
+  md5: ab6febdb2dbd9c00803609079db4de71
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: zlib-acknowledgement
+  size: 343883
+  timestamp: 1669076173145
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpq-16.0-h43585b0_1.conda
+  sha256: cac51839cfb2aac221f6e23b305877dba8716bd20e109f2477cf92780ba8d524
+  md5: c1d1c81e2dbcd0763b80e11ad18020bf
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<3.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PostgreSQL
+  size: 3547398
+  timestamp: 1696004738683
+- conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.24.3-hb8276f3_1.conda
+  sha256: dd0f3ef35ee2774db9ca5dfcba088636bf1f0b1d3cb2c4c35ff2a2ffdf01bf09
+  md5: dad0daf4a610f3c2ba3ef3325096c5e6
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5259129
+  timestamp: 1697157938555
+- conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2023.06.02-h8c5ae5e_0.conda
+  sha256: c468915951532d0455737e08e5fb2a4e2a862c123a13feeaa12fe72671070e13
+  md5: b5c24e75399edf13660f317f5d7d751e
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - re2 2023.06.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 253568
+  timestamp: 1697066113767
+- conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-h92c5fdb_14.conda
+  sha256: e693468c519bea531c4fa3edccb906c1de5ac35f5630a1745230b5f17ab88104
+  md5: 9d3f0c286ea2df09b2c0aefbd63769c0
+  depends:
+  - geos >=3.12.0,<3.12.1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 406368
+  timestamp: 1687974615867
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.18-h8d14728_1.tar.bz2
+  sha256: ecc463f0ab6eaf6bc5bd6ff9c17f65595de6c7a38db812222ab8ffde0d3f4bc2
+  md5: 5c1fb45b5e2912c19098750ae8a32604
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: ISC
+  size: 713431
+  timestamp: 1605135918736
+- conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-hbf340bc_0.conda
+  sha256: f2fbe2e90fc5424865e03d1e4e65a4581fd55a37e487ddb31cf3e3c6add24423
+  md5: 639d349f4837fba210a0796f76612b22
+  depends:
+  - freexl >=2
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.12.0,<3.12.1.0a0
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libxml2 >=2.11.5,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - proj >=9.3.0,<9.3.1.0a0
+  - sqlite
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 8815112
+  timestamp: 1694986662946
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.44.0-hcfcfb64_0.conda
+  sha256: b2be4125343d89765269b537e90ea5ab7f219e7398e7ad610ddcdcf31e7b9e65
+  md5: 446fb1973cfeb8b32de4add3c9ac1057
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 852871
+  timestamp: 1698855272921
+- conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+  sha256: 813fd04eed2a2d5d9c36e53c554f9c1f08e9324e2922bd60c9c52dbbed2dbcec
+  md5: dc262d03aae04fe26825062879141a41
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 266806
+  timestamp: 1685838242099
+- conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.19.0-ha2b3283_1.conda
+  sha256: 89bbc59898c827429a52315c9c0dd888ea73ab1157a8c86098aeae7d13454ac4
+  md5: d3432b9d4950e91d2fdf3bed91248ee0
+  depends:
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 612342
+  timestamp: 1695958519927
+- conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-h6e2ebb7_2.conda
+  sha256: f7b50b71840a5d8edd74a8bccf0c173ca2599bd136e366c35722272b4afa0500
+  md5: 08d653b74ee2dec0131ad4259ffbb126
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.19,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: HPND
+  size: 787430
+  timestamp: 1695662030293
+- conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-h82a8f57_0.tar.bz2
+  sha256: 6efa83e3f2fb9acaf096a18d21d0f679d110934798348c5defc780d4b759a76c
+  md5: 076894846fe9f068f91c57d158c90cba
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 104389
+  timestamp: 1667316359211
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.3.2-hcfcfb64_0.conda
+  sha256: af1453fab10d1fb8b379c61a78882614051a8bac37307d7ac4fb58eac667709e
+  md5: dcde8820959e64378d4e06147ffecfdd
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 268870
+  timestamp: 1694709461733
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.15-hcd874cb_0.conda
+  sha256: d01322c693580f53f8d07a7420cd6879289f5ddad5531b372c3efd1c37cac3bf
+  md5: 090d91b69396f14afef450c285f9758c
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 969788
+  timestamp: 1682083087243
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.11.5-hc3477c8_1.conda
+  sha256: ad3b5a510be2c5f9fe90b2c20e10adb135717304bcb3a197f256feb48d713d99
+  md5: 27974f880a010b1441093d9f737a949f
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1600640
+  timestamp: 1692960798126
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzip-1.10.1-h1d365fa_3.conda
+  sha256: 221698b52dd7a3dcfc67ff9460e9c8649fc6c86506a2a2ab6f57b97e7489bb9f
+  md5: 5c629cd12d89e2856c17b1dc5fcf44a4
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 146434
+  timestamp: 1694417117772
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
+  sha256: c161822ee8130b71e08b6d282b9919c1de2c5274b29921a867bca0f7d30cad26
+  md5: 5fdb9c6a113b6b6cb5e517fd972d5f41
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - zlib 1.2.13 *_5
+  license: Zlib
+  license_family: Other
+  size: 55800
+  timestamp: 1686575452215
+- conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.40.1-py310hb84602e_0.conda
+  sha256: 32e62860f031ac439316eed422247d7921055102ab7b6263a9fa9e16b87a5af6
+  md5: c0010b84acfaf1f7b7db272bb2a5d524
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - vs2015_runtime
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16825093
+  timestamp: 1687807120034
+- conda: https://conda.anaconda.org/conda-forge/win-64/lz4-4.3.2-py310hbbb2075_1.conda
+  sha256: a6a9f701a38070d4ce5205979769f0580b58a67be7e96af2fb8e298d7c1cee40
+  md5: 1e854437a9ab4f32a0b0eb4ca8fcca52
+  depends:
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 74642
+  timestamp: 1695449220233
+- conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+  sha256: a0954b4b1590735ea5f3d0f4579c3883f8ac837387afd5b398b241fda85124ab
+  md5: e34720eb20a33fc3bfb8451dd837ab7a
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134235
+  timestamp: 1674728465431
+- conda: https://conda.anaconda.org/conda-forge/win-64/lzo-2.10-he774522_1000.tar.bz2
+  sha256: ff064e34d3cad829f1e31f2d26125b61d20ba8d3771f8f5337069027b8e3fab4
+  md5: d5cf4b7eaa52316f135eed9e8548ad57
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: GPL v2+
+  license_family: GPL2
+  size: 170192
+  timestamp: 1597682500084
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+  sha256: 9de95a7996d5366ae0808eef2acbc63f9b11b874aa42375f55379e6715845dc6
+  md5: 066552ac6b907ec6d72c0ddab29050dc
+  depends:
+  - m2w64-gcc-libs-core
+  - msys2-conda-epoch ==20160418
+  license: GPL, LGPL, FDL, custom
+  size: 350687
+  timestamp: 1608163451316
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+  sha256: 3bd1ab02b7c89a5b153a17be03b36d833f1517ff2a6a77ead7c4a808b88196aa
+  md5: fe759119b8b3bfa720b8762c6fdc35de
+  depends:
+  - m2w64-gcc-libgfortran
+  - m2w64-gcc-libs-core
+  - m2w64-gmp
+  - m2w64-libwinpthread-git
+  - msys2-conda-epoch ==20160418
+  license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  size: 532390
+  timestamp: 1608163512830
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+  sha256: 58afdfe859ed2e9a9b1cc06bc408720cb2c3a6a132e59d4805b090d7574f4ee0
+  md5: 4289d80fb4d272f1f3b56cfe87ac90bd
+  depends:
+  - m2w64-gmp
+  - m2w64-libwinpthread-git
+  - msys2-conda-epoch ==20160418
+  license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  size: 219240
+  timestamp: 1608163481341
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+  sha256: 7e3cd95f554660de45f8323fca359e904e8d203efaf07a4d311e46d611481ed1
+  md5: 53a1c73e1e3d185516d7e3af177596d9
+  depends:
+  - msys2-conda-epoch ==20160418
+  license: LGPL3
+  size: 743501
+  timestamp: 1608163782057
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+  sha256: f63a09b2cae7defae0480f1740015d6235f1861afa6fe2e2d3e10bd0d1314ee0
+  md5: 774130a326dee16f1ceb05cc687ee4f0
+  depends:
+  - msys2-conda-epoch ==20160418
+  license: MIT, BSD
+  size: 31928
+  timestamp: 1608166099896
+- conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.3-py310h8d17308_1.conda
+  sha256: cab9683af159f18b782a876afb4aa3f84512dc3c39e4315a963ba267751581da
+  md5: 8bb26993f6787d08908136ce07894bf0
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26628
+  timestamp: 1695367927795
+- conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.8.0-py310hc9baf74_2.conda
+  sha256: 5a04fd5c6d8af3a3f3344efe7df453cacf1a7c48fe5311df2744deb80ef4e133
+  md5: e9ab5874e978375481a3a138a2254c8b
+  depends:
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.0.1
+  - numpy >=1.21,<2
+  - numpy >=1.22.4,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 6923468
+  timestamp: 1697011778412
+- conda: https://conda.anaconda.org/conda-forge/win-64/minizip-4.0.2-h5bed578_0.conda
+  sha256: 2e75ba252b81e4c3c10ffb513015b9a50a427206497c24f54c378ecf10faf1ac
+  md5: b3fe453a894825361294e3fe57bb9022
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 84673
+  timestamp: 1698349061388
+- conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2023.2.0-h6a75c08_50496.conda
+  sha256: 40dc6ac2aa071ca248223de7cdbdfdb216bc8632a17104b1507bcbf9276265d4
+  md5: 03da367d935ecf4d3e4005cf705d0e21
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 144749783
+  timestamp: 1695995252418
+- conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.0.6-py310h232114e_0.conda
+  sha256: 7f293ea6478dbdc7872516a26db2f3fe5482e637c6ed2e516165ac1ceb6572ac
+  md5: 55ffac33eaacd437cf24eb031184744f
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 133965
+  timestamp: 1695464630918
+- conda: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+  sha256: 99358d58d778abee4dca82ad29fb58058571f19b0f86138363c260049d4ac7f1
+  md5: b0309b72560df66f71a9d5e34a5efdfa
+  size: 3227
+  timestamp: 1608166968312
+- conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.0.4-py310h8d17308_1.conda
+  sha256: f8a1e733d9708f0e94972fd140813a5a622b29105992ba1fc47007a0d3a5c1c4
+  md5: efdd30867042c82de3feb73f1603b00a
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 51841
+  timestamp: 1696716878966
+- conda: https://conda.anaconda.org/conda-forge/win-64/netcdf4-1.6.5-nompi_py310h6477780_100.conda
+  sha256: 404b33445e5e6787d9f12ffa673fcba18e36cecade7b565a6a2b71c00cccf623
+  md5: 61183feee146a6f0e1db2dc2503f5ad6
+  depends:
+  - certifi
+  - cftime
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - setuptools
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 409577
+  timestamp: 1698267509096
+- conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.57.1-py310h19bcfe9_0.conda
+  sha256: f6f33685b02bcd136065eac06829e853ad89b5245d00d98368af791b6ec074fa
+  md5: 2b62ef412f4d34193128d615cc4e3fa6
+  depends:
+  - llvmlite >=0.40.0,<0.41.0a0
+  - numpy >=1.21.6,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libopenblas !=0.3.6
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.25
+  - tbb >=2021.6.0
+  - cuda-version >=10.2
+  - cudatoolkit >=10.2
+  - scipy >=1.0
+  - cuda-python >=11.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4150917
+  timestamp: 1687805503375
+- conda: https://conda.anaconda.org/conda-forge/win-64/numcodecs-0.12.1-py310h00ffb61_0.conda
+  sha256: a9c626943fca0655b2b9fe25b534dfef7304a17b5a8598fa1a2c6a8aca0314df
+  md5: 574f310b153410338baeb61b83c20aa2
+  depends:
+  - msgpack-python
+  - numpy >=1.7
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 462025
+  timestamp: 1697592927278
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.24.4-py310hd02465a_0.conda
+  sha256: 2412531bd722651d3d31f7f145faf836638c526a571c5f648c7d551e43c5b987
+  md5: 243e868369165ebc2a960d5acfb38a3f
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5951617
+  timestamp: 1687809363357
+- conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.0-h3d672ee_3.conda
+  sha256: c0f64d9642f0287f17cd9b6f1633d97a91efd66a0cb9b0414c540b247684985d
+  md5: 45a9628a04efb6fc326fff0a8f47b799
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 236847
+  timestamp: 1694708878963
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.1.4-hcfcfb64_0.conda
+  sha256: e30b7f55c27d06e3322876c9433a3522e751d06a40b3bb6c4f8b4bcd781a3794
+  md5: 2eebbc64373a1c6db62ad23304e9678e
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 7427765
+  timestamp: 1698166937344
+- conda: https://conda.anaconda.org/conda-forge/win-64/orc-1.9.0-hd95f75e_3.conda
+  sha256: faf72cde79571b475a77fc036a62f73cf270b03dbfc1fbe6f6a785464b656245
+  md5: 7886f9102401c5e697187c05821cea23
+  depends:
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.5,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 881734
+  timestamp: 1696768993450
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.1.2-py310hecd3228_0.conda
+  sha256: 070cd5e5836781025c8427e727d829ea02a2e2a85fad58ca4f25aa5bc99b7ab6
+  md5: 39b6f0729da51e283460be3bb2df1722
+  depends:
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.10.* *_cp310
+  - pytz >=2020.1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11212385
+  timestamp: 1698376773341
+- conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.40-h17e33f8_0.tar.bz2
+  sha256: 5833c63548e4fae91da6d77739eab7dc9bf6542e43f105826b23c01bfdd9cb57
+  md5: 2519de0d9620dc2bc7e19caf6867136d
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.12,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2001630
+  timestamp: 1665563527916
+- conda: https://conda.anaconda.org/conda-forge/win-64/pillow-10.1.0-py310h1e6a543_0.conda
+  sha256: df8f9c4d830bd7a8400640bb01efa2a0675b26d1a9a82ab8b404c638d11dbe5b
+  md5: 8ce37528536360e773a0f80750e39a02
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - tk >=8.6.13,<8.7.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: HPND
+  size: 45101565
+  timestamp: 1697424198092
+- conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.42.2-h63175ca_0.conda
+  sha256: bc663647468255781e3fba488372b0e699b717a63fa2450b9c282e68b6eb9543
+  md5: fb6fe034c742dc8562d3197c2d91423d
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 455866
+  timestamp: 1695736519750
+- conda: https://conda.anaconda.org/conda-forge/win-64/poppler-23.10.0-hc2f3c52_0.conda
+  sha256: e8ea2bc81cfc913fc2ed641353d7262b0344fa0bff1e1b5a6cca5144c1573ae5
+  md5: 3164446cb6dd3fa81b09307cde29778b
+  depends:
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libglib >=2.78.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - poppler-data
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 2306490
+  timestamp: 1697137168235
+- conda: https://conda.anaconda.org/conda-forge/win-64/postgresql-16.0-hc80876b_1.conda
+  sha256: 34c6127a0ee424f567f5589989af31b182076ada45fefe1cb66322c74caa9adb
+  md5: 20a04feca16bfe981eccbfd25e38826b
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libpq 16.0 h43585b0_1
+  - libxml2 >=2.11.5,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  size: 18640556
+  timestamp: 1696004855822
+- conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.3.0-he13c7e8_2.conda
+  sha256: 67a5d032a0343dc8182ef50221d9ee47edb50d34cd94813e65111901cbbbc6d3
+  md5: 4e6d2a06874a1a6cd66e842d29bcd373
+  depends:
+  - libcurl >=8.4.0,<9.0a0
+  - libsqlite >=3.43.2,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2645178
+  timestamp: 1697808796596
+- conda: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.5-py310h8d17308_1.conda
+  sha256: 6c03b652b5d1488fe88ce1a20ee4a072b44277b05002d2af7d2db19643d50b3d
+  md5: bd83570cfe0ce9ccc46c9c55b0aab666
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 380206
+  timestamp: 1695367659588
+- conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-hcd874cb_1001.tar.bz2
+  sha256: bb5a6ddf1a609a63addd6d7b488b0f58d05092ea84e9203283409bff539e202a
+  md5: a1f820480193ea83582b13249a7e7bd9
+  depends:
+  - m2w64-gcc-libs
+  license: MIT
+  license_family: MIT
+  size: 6417
+  timestamp: 1606147814351
+- conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
+  sha256: 576a228630a72f25d255a5e345e5f10878e153221a96560f2498040cd6f54005
+  md5: e2da8758d7d51ff6aa78a14dfb9dbed4
+  depends:
+  - vc 14.*
+  license: LGPL 2
+  size: 144301
+  timestamp: 1537755684331
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-13.0.0-py310hd0bb7c2_13_cpu.conda
+  sha256: c7d4f33f96e91d24208b09bf021edc68f6d4b9e1074505585b5614ed1498cdf8
+  md5: ecfed43d7af893b49d3629882870aacc
+  depends:
+  - libarrow 13.0.0 hc7845e2_13_cpu
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 2992809
+  timestamp: 1698347476324
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.6.1-py310hebb2149_3.conda
+  sha256: 1ae78ab9599ce7a81b256b734612b2e58caebfee830efea218a68987e1647a84
+  md5: 1512c146408b8913baf55ab4f5fe86f3
+  depends:
+  - certifi
+  - proj >=9.3.0,<9.3.1.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 711953
+  timestamp: 1698058549786
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.10.13-h4de0772_0_cpython.conda
+  sha256: 9e55fa834ddb2c24aec8ee4d4738584fea71edc084a615facc846ce90deb58e4
+  md5: cbf696b644613f8ab6c9df6b5005c042
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.43.2,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.4,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - vc >=14.1,<15
+  - vc14_runtime >=14.16.27033
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.10.* *_cp310
+  license: Python-2.0
+  size: 15891788
+  timestamp: 1698344089500
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-snappy-0.6.1-py310h6ed3180_1.conda
+  sha256: 45793b3ded432f80d9eec66fcc6b2d58fba73ed193424ae6ebc95dcdaf9c7f72
+  md5: bebfeee0d74231fcb61baec67b21c8c4
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - snappy >=1.1.10,<1.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33356
+  timestamp: 1695500683060
+- conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.10-4_cp310.conda
+  sha256: 19066c462fd0e32c64503c688f77cb603beb4019b812caf855d03f2a5447960b
+  md5: b41195997c14fb7473d26637ea4c3946
+  constrains:
+  - python 3.10.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6773
+  timestamp: 1695147715814
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-306-py310h00ffb61_2.conda
+  sha256: 24fd15c118974da18c38870380195e633d2452a7fb7dbc0ecb96b44416989b33
+  md5: a65056c5f52aa83455577958872e4776
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 5689476
+  timestamp: 1695974437046
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.12-py310h00ffb61_0.conda
+  sha256: a9fafd16ef160c9c11ac45f932b53916c5ad4c7c06ba0fb96b4859a8af879358
+  md5: 3cc562064a5d055f371ccc281b8e6396
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 209900
+  timestamp: 1696657831046
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.1-py310h8d17308_1.conda
+  sha256: ea51291e477b44c5bb9d91cc095db0dfe07b9576831e9682100d68c820c43ae3
+  md5: ce279186f68d0f12812dc9955ea909a4
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 146195
+  timestamp: 1695374085323
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-25.1.1-py310h2849c00_2.conda
+  sha256: 5643d7efaf8cc714a1dd7f4c4a1fea36bd9d12665af40bb10137ad0ee99e956d
+  md5: 4ef6bc04df33ba9a13145bc2ac254346
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  size: 409451
+  timestamp: 1698063170421
+- conda: https://conda.anaconda.org/conda-forge/win-64/rasterio-1.3.9-py310h4d3659c_0.conda
+  sha256: e5acc366cd5a5d8609657ab75abd5fa87b7663030bd4b683eef9147ffba62216
+  md5: 41144c5d43d8b96106fb87385d77ce24
+  depends:
+  - affine
+  - attrs
+  - certifi
+  - click >=4
+  - click-plugins
+  - cligj >=0.5
+  - libgdal >=3.7.2,<3.8.0a0
+  - numpy >=1.22.4,<2.0a0
+  - proj >=9.3.0,<9.3.1.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6863766
+  timestamp: 1697715034412
+- conda: https://conda.anaconda.org/conda-forge/win-64/re2-2023.06.02-hcbb65ff_0.conda
+  sha256: 97cfa7fe2e4111bd0915b8e14f1f1a00ee3fab14758ac89620c5e119c668e5b8
+  md5: aabaf2fe639029a25b39b6b14a1aa760
+  depends:
+  - libre2-11 2023.06.02 h8c5ae5e_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203957
+  timestamp: 1697066138562
+- conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.10.6-py310h87d50f1_0.conda
+  sha256: 59c08da9235fcea135bc35205c95079cdb86e2197a54d223db8efe2818dea1b5
+  md5: 97b168f58652c59e954611962e47cd5c
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 186246
+  timestamp: 1697073096998
+- conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.3.2-py310hfd2573f_1.conda
+  sha256: d18b6b97ed1746d08c5e381bac7d8e58ace490d3119b293652e75643421744d2
+  md5: 1cd4d6ea6ee7407bfd146c4c10ebecd2
+  depends:
+  - joblib >=1.1.1
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - scipy
+  - threadpoolctl >=2.0.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7064012
+  timestamp: 1698225751102
+- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.11.3-py310hf667824_1.conda
+  sha256: f51267072791bfda871b947b43efd73f0d3c5a5e581e4f47a611000c5c34d4e5
+  md5: 1325302e74eb18b8666f53559844bf44
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy >=1.22.4,<1.28
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libopenblas <0.3.26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14064238
+  timestamp: 1696469923075
+- conda: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.2-py310h839b4a8_0.conda
+  sha256: 9eeedc0fc8f45c1ff4b196c8e9efdd408578346d246905ba371e1710176167d4
+  md5: fccafb1aec64a793deb7de374ab3f760
+  depends:
+  - geos >=3.12.0,<3.12.1.0a0
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 450886
+  timestamp: 1697191990260
+- conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
+  sha256: 2a195b38cb63f03ad9f73a82db52434ebefe216fb70f7ea3defe4ddf263d408a
+  md5: cff1df79c9cff719460eb2dd172568de
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 57065
+  timestamp: 1678534804734
+- conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.44.0-hcfcfb64_0.conda
+  sha256: f6a4ae8130b32f566d0e406ebeb315671e202f08408fd69c512f38fb8efc0c7c
+  md5: 8bd8b9fbf5116bc98f5d6eef70f82af9
+  depends:
+  - libsqlite 3.44.0 hcfcfb64_0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 856389
+  timestamp: 1698855293276
+- conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.10.0-h91493d7_2.conda
+  sha256: e55a2f1324f0fc8916ab8d590a3944ba1af62de727bb66e3019cf2744d26e679
+  md5: 5b8c97cf8f0e81d6c22c0bda9978790d
+  depends:
+  - libhwloc >=2.9.3,<2.9.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 156566
+  timestamp: 1697713986066
+- conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.16.3-hbf04793_3.conda
+  sha256: 4de5494be2ee102d15077bebc63d17422c40dc8d634097136a9a202a3930e502
+  md5: 3afaf8882d4568eb9c91870102af1b37
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230802.0,<20230803.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libgoogle-cloud >=2.12.0,<2.13.0a0
+  - libxml2 >=2.11.5,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.1.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.5,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 4146973
+  timestamp: 1694523739186
+- conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-hcfcfb64_0.conda
+  sha256: 7e42db6b5f1c5ef8d4660e6ce41b52802b6c2fdc270d5e1eccc0048d0a3f03a8
+  md5: 74405f2ccbb40af409fee1a71ce70dc6
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: TCL
+  license_family: BSD
+  size: 3478482
+  timestamp: 1695506766462
+- conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.3.3-py310h8d17308_1.conda
+  sha256: 60b864e7cf17737055016e1754534316a0234d83f15eb454b983ee1b5151f982
+  md5: 0d14d73d94d679e2fa753ea8c7f75926
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 644644
+  timestamp: 1695373991492
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+  sha256: f29cdaf8712008f6b419b8b1a403923b00ab2504bfe0fb2ba8eb60e72d4f14c6
+  md5: 72608f6cd3e5898229c3ea16deb1ac43
+  constrains:
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-Proprietary
+  license_family: PROPRIETARY
+  size: 1283972
+  timestamp: 1666630199266
+- conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-15.1.0-py310h8d17308_0.conda
+  sha256: 7beadca7de88d62b65124a98e0c442cef787dac2ac41768deb7200fd33d07603
+  md5: f9f25aeb0eed2dd8c770f137c45da3c2
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 370116
+  timestamp: 1695848575933
+- conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.7-h1537add_1.conda
+  sha256: 9b185e00da9829592300359e23e2954188d21749fda675a08abbef728f19f25b
+  md5: 5f3b2772564e761bc2287b89b9e6b14b
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48056
+  timestamp: 1677713151746
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h64f974e_17.conda
+  sha256: 86ae94bf680980776aa761c2b0909a0ddbe1f817e7eeb8b16a1730f10f8891b6
+  md5: 67ff6791f235bb606659bf2a5c169191
+  depends:
+  - vc14_runtime >=14.36.32532
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17176
+  timestamp: 1688020629925
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.36.32532-hdcecf7f_17.conda
+  sha256: b317d49af32d5c031828e62c08d56f01d9a64cd3f40d4cccb052bc38c7a9e62e
+  md5: d0de20f2f3fc806a81b44fcdd941aaf7
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.36.32532.* *_17
+  license: LicenseRef-ProprietaryMicrosoft
+  license_family: Proprietary
+  size: 739437
+  timestamp: 1694292382336
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.36.32532-h05e6639_17.conda
+  sha256: 5ecbd731dc7f13762d67be0eadc47eb7f14713005e430d9b5fc680e965ac0f81
+  md5: 4618046c39f7c81861e53ded842e738a
+  depends:
+  - vc14_runtime >=14.36.32532
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17207
+  timestamp: 1688020635322
+- conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: 9df10c5b607dd30e05ba08cbd940009305c75db242476f4e845ea06008b0a283
+  md5: 1cee351bf20b830d991dbe0bc8cd7dfe
+  license: MIT
+  license_family: MIT
+  size: 1176306
+- conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.15.0-py310h8d17308_1.conda
+  sha256: 5d89cfc85f2a9edea2b8bb1402e3b132a345faab9880696125071368d859018a
+  md5: cab76285926b92019ced7ce176fc1e46
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 52486
+  timestamp: 1695409695224
+- conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.2.4-h63175ca_3.conda
+  sha256: 76e5ba07c06947ff7dcee6e9fe47e436e7a5ec5d94ad23102186769459af1403
+  md5: 28c6b90f40c9c37d3334ba8225143690
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 3509286
+  timestamp: 1692976908514
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-hcd874cb_0.conda
+  sha256: 8c5b976e3b36001bdefdb41fb70415f9c07eff631f1f0155f3225a7649320e77
+  md5: c46ba8712093cb0114404ae8a7582e1a
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  license: MIT
+  license_family: MIT
+  size: 51297
+  timestamp: 1684638355740
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.3-hcd874cb_0.tar.bz2
+  sha256: f51205d33c07d744ec177243e5d9b874002910c731954f2c8da82459be462b93
+  md5: 46878ebb6b9cbd8afcf8088d7ef00ece
+  depends:
+  - m2w64-gcc-libs
+  license: MIT
+  license_family: MIT
+  size: 67908
+  timestamp: 1610072296570
+- conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+  sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
+  md5: 515d77642eaa3639413c6b1bc3f94219
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: LGPL-2.1 and GPL-2.0
+  size: 217804
+  timestamp: 1660346976440
+- conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+  sha256: 4e2246383003acbad9682c7c63178e2e715ad0eb84f03a8df1fbfba455dfedc5
+  md5: adbfb9f45d1004a26763652246a33764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 63274
+  timestamp: 1641347623319
+- conda: https://conda.anaconda.org/conda-forge/win-64/yarl-1.9.2-py310h8d17308_1.conda
+  sha256: 76f7946323cb43a3a872ad61a5a6b8e82ec36d5f6ae9b1b21685b7dc817a9e7b
+  md5: f769f18c6d8ef228c7069d70de2591e7
+  depends:
+  - idna >=2.0
+  - multidict >=4.0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 91699
+  timestamp: 1696733209750
+- conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-h63175ca_0.conda
+  sha256: f8377793c36e19da17bbb8cf517f1a969b89e1cc7cb9622dc6d60c3d1383c919
+  md5: e954e1881091405f36416f772292b396
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 4210250
+  timestamp: 1697057168534
+- conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.2.13-hcfcfb64_5.conda
+  sha256: 0f91b719c7558046bcd37fdc7ae4b9eb2b7a8e335beb8b59ae7ccb285a46aa46
+  md5: a318e8622e11663f645cc7fa3260f462
+  depends:
+  - libzlib 1.2.13 hcfcfb64_5
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Zlib
+  license_family: Other
+  size: 107711
+  timestamp: 1686575474476
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
+  sha256: d540dd56c5ec772b60e4ce7d45f67f01c6614942225885911964ea1e70bb99e3
+  md5: 792bb5da68bf0a6cac6a6072ecb8dbeb
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 343428
+  timestamp: 1693151615801

--- a/landsat_clustering/pixi.toml
+++ b/landsat_clustering/pixi.toml
@@ -33,8 +33,8 @@ poppler = "*"
 distributed = "*"
 tbb = "*"
 dask-ml = "*"
-pip = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [activation.env]
 INTAKE_CACHE_DIR = "data"

--- a/landsat_clustering/pixi.toml
+++ b/landsat_clustering/pixi.toml
@@ -1,0 +1,43 @@
+[workspace]
+name = "landsat_clustering"
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2018-11-26"
+maintainers = ["TomAugspurger", "jbednar"]
+categories = ["Geospatial"]
+labels = ["datashader", "holoviews", "bokeh", "dask", "dask-ml"]
+description = "Example of spectral clustering landsat data"
+
+[dependencies]
+python = "3.10.*"
+notebook = "*"
+pyepsg = "*"
+cartopy = "*"
+datashader = "*"
+fastparquet = "*"
+geoviews = "*"
+holoviews = "*"
+python-snappy = "*"
+intake = "*"
+intake-xarray = "*"
+rioxarray = "*"
+rasterio = "*"
+msgpack-python = "*"
+dask = "*"
+s3fs = "*"
+pandas = "*"
+param = "*"
+poppler = "*"
+distributed = "*"
+tbb = "*"
+dask-ml = "*"
+pip = "*"
+wheel = "*"
+
+[activation.env]
+INTAKE_CACHE_DIR = "data"
+
+[tasks]
+notebook = "jupyter notebook landsat_clustering.ipynb"

--- a/landuse_classification/pixi.lock
+++ b/landuse_classification/pixi.lock
@@ -1,0 +1,13651 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_tflow_select-2.3.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/absl-py-2.1.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aiobotocore-2.12.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aiohappyeyeballs-2.4.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aiohttp-3.10.5-py310h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.6.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aom-3.6.0-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py310h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-11.0.0-hda39474_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/async-lru-2.0.4-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/async-timeout-4.0.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-24.2.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.4.57-he6710b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.1.6-h2531618_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.9-he6710b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.8.185-hce553d0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/babel-2.11.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bleach-6.2.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blinker-1.6.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blosc-1.21.3-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.6.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.73.0-h7f8727e_12.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/botocore-1.34.69-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.4.2-py310ha9d4c09_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py310h6a678d5_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brunsli-0.1-h2531618_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.11.26-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cachetools-5.3.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.8.30-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py310h1fdaa30_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cfitsio-3.470-h5893167_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cftime-1.6.2-py310ha9d4c09_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/charls-2.2.0-h2531618_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.0.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.3.1-py310hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py310h130f0dd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.2-py310h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-2024.5.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.5.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-expr-1.1.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dav1d-1.2.1-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py310h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2024.5.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.2.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/flatbuffers-24.3.25-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py310h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/frozenlist-1.5.0-py310h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.6.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/google-auth-2.29.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/google-auth-oauthlib-0.5.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/grpc-cpp-1.48.2-h5bf31a4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/grpcio-1.48.2-py310h5bf31a4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/h11-0.14.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/h5py-3.12.1-py310hc0802c4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf4-4.2.13-h3ca952b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf5-1.12.1-h70be1eb_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.20.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/httpcore-1.0.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/httpx-0.27.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/imagecodecs-2023.1.23-py310hc4b7b5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/imageio-2.33.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-8.5.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intake-0.7.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intake-xarray-0.7.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.27.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipywidgets-8.1.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jmespath-1.0.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/json5-0.9.25-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.23.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter-lsp-2.2.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-8.6.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab-4.2.5-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_server-2.27.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_widgets-3.0.10-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jxrlib-1.1-h7b6447c_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/keras-2.12.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py310h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h568e23c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lazy_loader-0.4-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libaec-1.0.4-he6710b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libavif-0.11.1-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.73.0-h28710b8_12.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.2.1-h91b91d3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-h8f2d780_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnetcdf-4.8.1-h424c3a0_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.52.0-ha637b67_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-h37d81fd_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h0d84882_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libzip-1.8.0-h5cef20c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libzopfli-1.0.3-he6710b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py310h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py310h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.9.2-py310hbfdbfaf_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py310h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.11-py310h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.8-py310h1128e8f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py310hd09550d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multidict-6.1.0-py310h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-core-7.16.4-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/netcdf4-1.6.2-py310h6d89c78_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-7.2.2-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numcodecs-0.12.1-py310h2c38b39_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.10.1-py310h3c60e43_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.23.5-py310h5f9d8c6_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.23.5-py310hb5e798b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/oauthlib-3.2.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.3-py310h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandoc-2.12-h06a4308_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.5.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-11.0.0-py310hfdbf927_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.21.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/propcache-0.2.0-py310h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/protobuf-3.20.3-py310h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py310h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-11.0.0-py310h468efa6_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyjwt-2.9.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.2.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.10.13-h7a1cb2a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py310h06a4308_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.20.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-flatbuffers-24.3.25-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py310h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-snappy-0.6.1-py310h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py310h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-25.1.2-py310h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-oauthlib-2.0.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py310h4aa5aa6_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/s3fs-2024.6.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scikit-image-0.24.0-py310h1128e8f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.14.1-py310h5f9d8c6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-75.1.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorboard-2.12.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorboard-data-server-0.7.0-py310h52d8a92_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorboard-plugin-wit-1.8.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorflow-2.12.0-mkl_py310hc7ea715_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorflow-base-2.12.0-mkl_py310he5f8e37_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorflow-estimator-2.12.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/termcolor-2.1.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tifffile-2023.4.12-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tomli-2.0.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.1-py310h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.5-py310h2f386ee_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py310h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/werkzeug-3.0.6-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.44.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/widgetsnbextension-4.0.10-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wrapt-1.14.1-py310h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py310h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yarl-1.18.0-py310h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zarr-2.13.3-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zfp-1.0.0-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.21.0-py310h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/aioitertools-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/aiosignal-1.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/astunparse-1.6.3-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fasteners-0.16.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/gast-0.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/google-pasta-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/keras-preprocessing-1.1.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/nbconvert-7.16.4-hd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/nbconvert-pandoc-7.16.4-hd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/opt_einsum-3.3.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyasn1-0.4.8-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyasn1-modules-0.2.8-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/rsa-4.7.2-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/aioitertools-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/aiosignal-1.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/astunparse-1.6.3-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fasteners-0.16.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/gast-0.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/google-pasta-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/keras-preprocessing-1.1.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/opt_einsum-3.3.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyasn1-0.4.8-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyasn1-modules-0.2.8-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/rsa-4.7.2-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tensorboard-plugin-wit-1.6.0-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wheel-0.35.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/_tflow_select-2.2.0-eigen.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/abseil-cpp-20211102.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/absl-py-2.1.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aiobotocore-2.12.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aiohappyeyeballs-2.4.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aiohttp-3.10.5-py310h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.6.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aom-3.6.0-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py310hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py310hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/async-lru-2.0.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/async-timeout-4.0.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.2.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/babel-2.11.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bleach-6.2.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blinker-1.6.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.4.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/botocore-1.34.69-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.4.2-py310hf3fd67a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py310hcec6c5f_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brunsli-0.1-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.11.26-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cachetools-5.3.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.8.30-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py310h9205ec4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cftime-1.6.2-py310h7b7cdfe_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/charls-2.2.0-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.0.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.3.1-py310h1962661_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py310ha2381d6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.2-py310h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-2023.4.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.4.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dav1d-1.2.1-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py310hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2023.4.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.2.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/flatbuffers-24.3.25-h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py310h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/frozenlist-1.5.0-py310h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.6.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.2-h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/google-auth-2.29.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/google-auth-oauthlib-0.5.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/grpc-cpp-1.48.2-h3afe56f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/grpcio-1.48.2-py310h3afe56f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/h11-0.14.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/h5py-3.12.1-py310ha611a00_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf4-4.2.13-h39711bb_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf5-1.12.1-h2b2ad87_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.17.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/httpcore-1.0.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/httpx-0.27.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-68.1-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/imagecodecs-2023.1.23-py310hd1bf5dc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/imageio-2.33.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-8.5.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intake-0.7.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intake-xarray-0.7.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.27.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipywidgets-8.1.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py310hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jmespath-1.0.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/json5-0.9.25-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.23.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter-lsp-2.2.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-8.6.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py310hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab-4.2.5-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_server-2.27.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_widgets-3.0.10-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jxrlib-1.1-haf1e3a3_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/keras-2.12.0-py310_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py310hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lazy_loader-0.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libaec-1.0.4-hb1e8313_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libavif-0.11.1-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnetcdf-4.8.1-h9c0abef_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libzip-1.8.0-h272c8d6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libzopfli-1.0.3-hb1e8313_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py310h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.9.2-py310h919b35b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py310haf03e11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multidict-6.1.0-py310h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/netcdf4-1.6.2-py310h2f655f6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-7.2.2-py310hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numcodecs-0.12.1-py310h2d76c9a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.10.1-py310hc59c7be_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.23.5-py310he50c29a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.23.5-py310h992e150_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/oauthlib-3.2.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.3-py310h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-0.14.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-11.0.0-py310h9c91434_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.21.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/propcache-0.2.0-py310h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/protobuf-3.20.3-py310hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py310hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py310hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyjwt-2.9.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.2.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.10.13-h218abb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py310hecd8cb5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.20.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-flatbuffers-24.3.25-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py310hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-snappy-0.6.1-py310hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py310h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-25.1.2-py310hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py310hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-oauthlib-2.0.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py310h83de92b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/s3fs-2024.6.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scikit-image-0.24.0-py310h207f725_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.14.1-py310hb060737_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-75.1.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tensorboard-2.12.1-py310_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tensorboard-data-server-0.7.0-py310hf1618be_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tensorflow-2.12.0-eigen_py310hccba712_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tensorflow-base-2.12.0-eigen_py310hbf87084_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tensorflow-estimator-2.12.0-py310_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/termcolor-2.1.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tifffile-2023.4.12-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tomli-2.0.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.1-py310h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.5-py310h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py310h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py310hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/werkzeug-3.0.6-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/widgetsnbextension-4.0.10-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wrapt-1.14.1-py310hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yarl-1.18.0-py310h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zarr-2.13.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zfp-1.0.0-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.21.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/aioitertools-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/aiosignal-1.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/astunparse-1.6.3-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fasteners-0.16.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/gast-0.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/google-pasta-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/keras-preprocessing-1.1.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/opt_einsum-3.3.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyasn1-0.4.8-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyasn1-modules-0.2.8-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/rsa-4.7.2-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wheel-0.35.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/_tflow_select-2.2.0-eigen.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/abseil-cpp-20211102.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/absl-py-2.1.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aiobotocore-2.12.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aiohappyeyeballs-2.4.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aiohttp-3.10.5-py310h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.6.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aom-3.6.0-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py310hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py310h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-11.0.0-he3f21e0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/async-lru-2.0.4-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/async-timeout-4.0.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-24.2.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.6.8-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.1.6-h313beb8_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.11-h80987f9_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.8.185-h4a942e0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/babel-2.11.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bleach-6.2.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blinker-1.6.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.6.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.73.0-h1a28f6b_12.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/botocore-1.34.69-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.4.2-py310hbda83bc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py310h313beb8_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brunsli-0.1-hc377ac9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.11.26-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cachetools-5.3.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.8.30-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py310h3eb5a62_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cftime-1.6.2-py310hbda83bc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/charls-2.2.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.0.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.3.1-py310h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py310h3c57c4d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.2-py310h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-2024.5.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.5.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-expr-1.1.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dav1d-1.2.1-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py310h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2024.5.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.2.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/flatbuffers-24.3.25-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py310h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/frozenlist-1.5.0-py310h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.6.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/google-auth-2.29.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/google-auth-oauthlib-0.5.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpc-cpp-1.48.2-h877324c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpcio-1.48.2-py310h877324c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/h11-0.14.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/h5py-3.12.1-py310h8456320_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf4-4.2.13-h5e329fb_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf5-1.12.1-h160e8cb_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.20.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpcore-1.0.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpx-0.27.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-68.1-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/imagecodecs-2023.1.23-py310h604db08_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/imageio-2.33.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-8.5.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/intake-0.7.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/intake-xarray-0.7.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.27.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipywidgets-8.1.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jmespath-1.0.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/json5-0.9.25-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.23.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter-lsp-2.2.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-8.6.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab-4.2.5-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_server-2.27.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_widgets-3.0.10-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jxrlib-1.1-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/keras-2.12.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py310h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lazy_loader-0.4-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libaec-1.0.4-hc377ac9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libavif-0.11.1-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.73.0-h49e8a49_12.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-hf27765b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnetcdf-4.8.1-ha022005_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h169de6a_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzip-1.8.0-h0c481fb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzopfli-1.0.3-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.3.2-py310h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py310h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.9.2-py310h7ef442a_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py310h525c30c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multidict-6.1.0-py310h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.4-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/netcdf4-1.6.2-py310he1bbb67_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-7.2.2-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numcodecs-0.12.1-py310h1a4646a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.10.1-py310h5d9532f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.23.5-py310hb93e574_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.23.5-py310haf87e8b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/oauthlib-3.2.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.3-py310hcf29cfe_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.5.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-11.0.0-py310hfaf4e14_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.21.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/propcache-0.2.0-py310h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/protobuf-3.20.3-py310h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py310h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-11.0.0-py310hbfed03b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyjwt-2.9.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.2.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.10.13-hc0d8a6c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py310hca03da5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.20.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-flatbuffers-24.3.25-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py310h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-snappy-0.6.1-py310h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.2-py310h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-25.1.2-py310h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-oauthlib-2.0.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py310h2aea54e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/s3fs-2024.6.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scikit-image-0.24.0-py310h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.14.1-py310hd336fd7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-75.1.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorboard-2.12.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorboard-data-server-0.7.0-py310ha6e5c4f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorboard-plugin-wit-1.8.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorflow-2.12.0-eigen_py310h205ab9b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorflow-base-2.12.0-eigen_py310h0a52ebb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorflow-estimator-2.12.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/termcolor-2.1.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tifffile-2023.4.12-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomli-2.0.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.1-py310h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.5-py310h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py310h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/werkzeug-3.0.6-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/widgetsnbextension-4.0.10-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wrapt-1.14.1-py310h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py310hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yarl-1.18.0-py310h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zarr-2.13.3-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zfp-1.0.0-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.21.0-py310hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/aioitertools-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/aiosignal-1.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/astunparse-1.6.3-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fasteners-0.16.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/gast-0.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/google-auth-oauthlib-0.4.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/google-pasta-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/keras-preprocessing-1.1.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/opt_einsum-3.3.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyasn1-0.4.8-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyasn1-modules-0.2.8-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/rsa-4.7.2-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/_tflow_select-2.3.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/absl-py-2.1.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aiobotocore-2.12.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aiohappyeyeballs-2.4.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aiohttp-3.10.5-py310h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.6.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aom-3.6.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py310h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-11.0.0-h2c9b28c_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/async-lru-2.0.4-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/async-timeout-4.0.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-24.2.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.4.57-ha925a31_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.1.6-hd77b12b_5.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.9-ha925a31_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.8.185-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/babel-2.11.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bleach-6.2.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blinker-1.6.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.6.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/botocore-1.34.69-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.4.2-py310hc99e966_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py310hd77b12b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.11.26-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cachetools-5.3.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.8.30-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py310h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cftime-1.6.2-py310h9128911_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/charls-2.2.0-h6c2663c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.0.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.3.1-py310h214f63a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py310h3438e0d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.2-py310h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-2024.5.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.5.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-expr-1.1.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/dav1d-1.2.1-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py310hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2024.5.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.2.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/flatbuffers-2.0.0-h6c2663c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py310h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/frozenlist-1.5.0-py310h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.6.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.2-h7edc060_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/google-auth-2.29.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/grpc-cpp-1.48.2-hf108199_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/grpcio-1.48.2-py310hf108199_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/h11-0.14.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/h5py-3.12.1-py310h3b2c811_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/hdf4-4.2.13-h712560f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/hdf5-1.12.1-h51c971a_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.20.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/httpcore-1.0.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/httpx-0.27.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icu-58.2-ha925a31_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/imagecodecs-2023.1.23-py310h6c6a46e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/imageio-2.33.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-8.5.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intake-0.7.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intake-xarray-0.7.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.27.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipywidgets-8.1.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jmespath-1.0.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/json5-0.9.25-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.23.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter-lsp-2.2.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-8.6.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab-4.2.5-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_server-2.27.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_widgets-3.0.10-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/keras-2.10.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py310hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lazy_loader-0.4-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libaec-1.0.4-h33f27b4_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libavif-0.11.1-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.9.1-h0416ee5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-hcc03200_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libnetcdf-4.8.1-h6685c40_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-hcd4344a_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-he49ee6e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libzip-1.8.0-h49b8836_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libzopfli-1.0.3-ha925a31_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.3.2-py310h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py310h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.9.2-py310he19b0ae_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py310h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.11-py310h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.8-py310hc64d2fc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py310h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/multidict-6.1.0-py310h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.4-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/netcdf4-1.6.2-py310hadf358c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-7.2.2-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numcodecs-0.12.1-py310h3469f8a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.10.1-py310h4cd664f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py310h055cbcc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py310h65a83cf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/oauthlib-3.2.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.3-py310h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.5.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-11.0.0-py310hb5480e2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.21.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/propcache-0.2.0-py310h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/protobuf-3.20.3-py310hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py310h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-11.0.0-py310h790e06d_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyjwt-2.9.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.2.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.10.13-h966fe2a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py310haa95532_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.20.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-flatbuffers-24.3.25-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py310hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-snappy-0.6.1-py310hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py310h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py310h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.2-py310h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-25.1.2-py310hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-oauthlib-2.0.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py310h636fa0f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/s3fs-2024.6.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scikit-image-0.24.0-py310hc64d2fc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.14.1-py310h8640f81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-75.1.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tensorboard-2.10.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tensorboard-data-server-0.6.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tensorboard-plugin-wit-1.8.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tensorflow-2.10.0-mkl_py310hd99672f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tensorflow-base-2.10.0-mkl_py310h6a7f48e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tensorflow-estimator-2.10.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/termcolor-2.1.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tifffile-2023.4.12-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.0.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.1-py310h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.5-py310h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py310h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.40-haa95532_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.42.34433-h9531ae6_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/werkzeug-3.0.6-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.44.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/widgetsnbextension-4.0.10-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wrapt-1.14.1-py310h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py310haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yarl-1.18.0-py310h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zarr-2.13.3-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zfp-1.0.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.21.0-py310haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+  sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
+  md5: 613805add1c05b538ff06d217252feb7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 20810
+  timestamp: 1652859733309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_tflow_select-2.3.0-mkl.tar.bz2
+  sha256: f51493d1f78786b6ccbc1f3d8aaad96a2ff13c95c097e64a059737d2f2cfa2ce
+  md5: 5770354f88091e1944a2d1bd7257e4d0
+  size: 2049
+  timestamp: 1538592486542
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
+  sha256: 8762f481244fb151a200f01dd70e69c77171a3ee0f7f4c130e8e95b6a1626a68
+  md5: c3707fcd2efa582afc5c7e1986c6ce48
+  depends:
+  - libgcc-ng >=8.4.0
+  - libstdcxx-ng >=8.4.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1135866
+  timestamp: 1652382888447
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/absl-py-2.1.0-py310h06a4308_0.tar.bz2
+  sha256: 49a1aefd06e494b040b3ad49448e487d6dc4d68e87654bf45ec87b458c07e5bc
+  md5: 30a5cddb1667fd45e9088e187822b077
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 187536
+  timestamp: 1714140539507
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aiobotocore-2.12.3-py310h06a4308_0.tar.bz2
+  sha256: e5b413a711b42f802bf9c34e604bcb9091d8b1face92533f4212580edf0fe4e4
+  md5: 2d55540f66c7c59a7e8f45ce7bac1121
+  depends:
+  - aiohttp >=3.7.4.post0,<4.0.0
+  - aioitertools >=0.5.1,<1.0.0
+  - botocore >=1.34.41,<1.34.70
+  - python >=3.10,<3.11.0a0
+  - wrapt >=1.10.10,<2.0.0
+  constrains:
+  - boto3 >=1.34.41,<1.34.70
+  license: Apache-2.0
+  license_family: Apache
+  size: 110645
+  timestamp: 1714464458857
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aiohappyeyeballs-2.4.3-py310h06a4308_0.tar.bz2
+  sha256: b13efdec3f7e691a22d426b5f1b560555cc018b1d758980fbd825d2258ee1962
+  md5: e43beac87c30f258fb4ba282aa1921e2
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: PSF-2.0
+  license_family: Other
+  size: 25116
+  timestamp: 1732662113002
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aiohttp-3.10.5-py310h5eee18b_0.tar.bz2
+  sha256: aa03cc74d3e74cfb7acb9768162a878196bca1112feafbd1dbb75074b9b1a589
+  md5: b1153feedec1097d68128becb16a4447
+  depends:
+  - aiohappyeyeballs >=2.3.0
+  - aiosignal >=1.1.2
+  - async-timeout >=4.0,<5.0
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - libgcc-ng >=11.2.0
+  - multidict >=4.5,<7.0
+  - python >=3.10,<3.11.0a0
+  - yarl >=1.0,<2.0
+  constrains:
+  - aiodns >=3.2.0
+  license: MIT AND Apache-2.0
+  license_family: Other
+  size: 765601
+  timestamp: 1725528648182
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.6.2-py310h06a4308_0.tar.bz2
+  sha256: eaa30adc6d1614ae1adf2a24b6c5b7b6b091fb12a9a15ca960177fe7f3819d7f
+  md5: 683f616004a91dcb81b53ec8383d86c7
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.10,<3.11.0a0
+  - sniffio >=1.1
+  - typing_extensions >=4.1
+  constrains:
+  - trio >=0.26.1
+  - uvloop >=0.21
+  license: MIT
+  license_family: MIT
+  size: 191289
+  timestamp: 1729121462391
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aom-3.6.0-h6a678d5_0.tar.bz2
+  sha256: daddb86497522fd6fb8447c0aaebb763e685348b86fadb4ca6425f50f9d85f08
+  md5: 2d31ed3210e7119160eb02564154b4c1
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2958771
+  timestamp: 1688660715607
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py310h7f8727e_0.tar.bz2
+  sha256: f4d21ee48ca45cc62ae063f6de973c5599505d628e7675e512eb86f73f851410
+  md5: 96b990f76f2e61e914f5ad1958f6e7bd
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=7.5.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 85215
+  timestamp: 1644553401362
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-11.0.0-hda39474_2.tar.bz2
+  sha256: e999c26eb88acdf38a30985cd3d06aecb7e5470d71fe56aa9746d7c4ecb30c69
+  md5: 9adc4a90d3cf6871b91f9c24920f8860
+  depends:
+  - abseil-cpp >=20211102.0,<20211102.1.0a0
+  - aws-sdk-cpp >=1.8.185,<1.8.186.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.5.0,<0.6.0a0
+  - grpc-cpp >=1.48.2,<1.49.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libgcc-ng >=11.2.0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libstdcxx-ng >=11.2.0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - orc >=1.7.4,<1.7.5.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.9,<2.0a0
+  - utf8proc <2.9.0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 11652728
+  timestamp: 1693265512057
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/async-lru-2.0.4-py310h06a4308_0.tar.bz2
+  sha256: 601460633710b60d630765f72ab13c9a1a8e63bb8e50f5fbb1965fd9fdaeb9e1
+  md5: c201cfd7c0beed39075dea4de01ddae3
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing_extensions >=4.0.0
+  license: MIT
+  license_family: MIT
+  size: 17613
+  timestamp: 1699554652543
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/async-timeout-4.0.3-py310h06a4308_0.tar.bz2
+  sha256: eb930dc1b3401edb466fd9877a61a2e05965fcd3fcc9d9be572eb80af53d5c7a
+  md5: 04c061f475e7b69e0d5737ef00cc70d3
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 12101
+  timestamp: 1703097093405
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-24.2.0-py310h06a4308_0.tar.bz2
+  sha256: 381c9d6439f212eaa640a445779e3fcbfa214ec2b28d537cc6fcfddc75cadf78
+  md5: 4a93d6601c3da897265a362203cc988e
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 141817
+  timestamp: 1729089491775
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.4.57-he6710b0_1.tar.bz2
+  sha256: bc87abecbc7e34b42b5a7ec3a3470ee284ed82f5f638274f795810fd0aa85496
+  md5: e883ae27a33cff702b8a20b5394e9ae0
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 164855
+  timestamp: 1601398346279
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.1.6-h2531618_5.tar.bz2
+  sha256: 4f7d93ed96f6692266a700971029b841dc972a6af39b85ba9525eebe2c40edbb
+  md5: 6b7ceb5ff64fc9f4537bfe7a2d7fe4a0
+  depends:
+  - aws-c-common >=0.4.57,<0.4.58.0a0
+  - aws-checksums >=0.1.9,<0.1.10.0a0
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 25449
+  timestamp: 1603894551837
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.9-he6710b0_0.tar.bz2
+  sha256: 17d0e3361698b9a0a9b52836284b658886d25bf349f3a099b765eac23ceb4ebd
+  md5: 0a7ed2b675a5af15d4979f4ca5c93d39
+  depends:
+  - aws-c-common >=0.4.57,<0.4.58.0a0
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52520
+  timestamp: 1601398555928
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.8.185-hce553d0_0.tar.bz2
+  sha256: 2842aafc907c01ccbe26ca11bddad6c55e9f93d30cf57431e327f5e57666be2c
+  md5: 5b4e9429338430ef3b71802778ac2184
+  depends:
+  - aws-c-common >=0.4.57,<0.4.58.0a0
+  - aws-c-event-stream >=0.1.6,<0.1.7.0a0
+  - libcurl >=7.71.1,<9.0a0
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - openssl >=1.1.1k,<1.1.2a
+  license: Apache-2.0
+  license_family: Apache
+  size: 2442091
+  timestamp: 1618434946994
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/babel-2.11.0-py310h06a4308_0.tar.bz2
+  sha256: 959a5f86c833ccb6a15d04fde1079ddb4708762b0d90714828adbbc9b9646fc3
+  md5: 3e89c64fb56d74e0a91ec741a6661a0d
+  depends:
+  - python >=3.10,<3.11.0a0
+  - pytz >=2015.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7102372
+  timestamp: 1671782043176
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py310h06a4308_0.tar.bz2
+  sha256: 1a56d11e88d7e93e73953ca068ec493c3e98b72845d9a777f2f9c82f0664ce37
+  md5: 3a7dd040da3d8a200c4bece5ea04fce7
+  depends:
+  - python >=3.10,<3.11.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 216265
+  timestamp: 1718029855488
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bleach-6.2.0-py310h06a4308_0.tar.bz2
+  sha256: 0de865fb163e4e02d18adb13b6e9c87ca758f639bec234bd83de4c89f30c5757
+  md5: 0896c252ac541a1f8bfe342d64de1e77
+  depends:
+  - python >=3.10,<3.11.0a0
+  - webencodings
+  constrains:
+  - tinycss2 >=1.1.0,<1.5
+  license: Apache-2.0
+  license_family: Apache
+  size: 295489
+  timestamp: 1732290490993
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blinker-1.6.2-py310h06a4308_0.tar.bz2
+  sha256: 4b3993a63b36eb31757195d29b2d7fdab603518a1bf5f285a228180d323943f5
+  md5: 6a56d60fe99138bfd41124f94ee5a59f
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 28181
+  timestamp: 1696539171692
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blosc-1.21.3-h6a678d5_0.tar.bz2
+  sha256: 10b48986cb0e0c974477ac3a58aaae198270b01f19cbd3e900143c6558fa3424
+  md5: 202b4629c225257fc01a4a2180c4e2f7
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65491
+  timestamp: 1675247642609
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.6.0-py310h06a4308_0.tar.bz2
+  sha256: 8c161ae59eb3f907c2db91aff27f4795eff50f38acb4a0f6d091292ad8850225
+  md5: 9886d96bd66d3dbf940d9a311c2725ac
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5662562
+  timestamp: 1727914521304
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.73.0-h7f8727e_12.tar.bz2
+  sha256: 1239af47b8f5ca5f5f40af1056949c4dfcbdfb690d6f83dacf77d01ebbfe7b4a
+  md5: fd3834554f6e4863871ab9677997fbef
+  depends:
+  - libboost 1.73.0 h28710b8_12
+  - libgcc-ng >=7.5.0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 16854
+  timestamp: 1655879868222
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/botocore-1.34.69-py310h06a4308_0.tar.bz2
+  sha256: 22e5f5e8935f44b7f333d1c45cc4bf9bd4cbc9c73fe97ece7a9ab5cc872f75a7
+  md5: 6a0c23467a18a4f4b9bb48a5236f3940
+  depends:
+  - jmespath >=0.7.1,<2.0.0
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.1,<3.0.0
+  - urllib3 >=1.25.4,!=2.2.0,<3
+  license: Apache-2.0
+  license_family: Apache
+  size: 7719749
+  timestamp: 1714460680886
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.4.2-py310ha9d4c09_0.tar.bz2
+  sha256: 16e4fe628824931e988ff413fb31803c6a53137b0f622c7e3fdb64a6ee492325
+  md5: 128011665e69e7eb2bfac4daccc40e6e
+  depends:
+  - libgcc-ng >=11.2.0
+  - numpy >=1.21,<3
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 130623
+  timestamp: 1731058759693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 5d15605858771290fdaaae41a43941623757a25cb1292080d69d6d3857807935
+  md5: 7f517469aa5380c52e55db9f37df104f
+  depends:
+  - brotli-bin 1.0.9 h5eee18b_8
+  - libbrotlidec 1.0.9 h5eee18b_8
+  - libbrotlienc 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 18652
+  timestamp: 1714483267080
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+  sha256: a5094f078584e27c7cced4a9564ae904a329f5c1702a7c1ba092d581ba1544f1
+  md5: 6ddf45dd8a21a9512481de9bc0e5a03f
+  depends:
+  - libbrotlidec 1.0.9 h5eee18b_8
+  - libbrotlienc 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 19711
+  timestamp: 1714483255915
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py310h6a678d5_8.tar.bz2
+  sha256: a95845d31df714470de47a68332c48fbca10d7d5d3364e32c88a9cbf457fa4f3
+  md5: 92a52ee9fc7369fed7a75d90199b354a
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  size: 361077
+  timestamp: 1714483327328
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brunsli-0.1-h2531618_0.tar.bz2
+  sha256: 3a2778321f5ef815cd8aa4bf37bb1532b31656c1bf5310738146e7081b177b3e
+  md5: dc6cf5631ada26a03b237ef19e90cfd6
+  depends:
+  - brotli >=1.0.9,<2.0a0
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  license_family: MIT
+  size: 203551
+  timestamp: 1611240485163
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+  sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
+  md5: f5058c8d5b2994b7334f18e022105a14
+  depends:
+  - libgcc-ng >=11.2.0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 427542
+  timestamp: 1714510571510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+  sha256: 5b4c80587ae4ec915505469f79d866f27c80456156667c8548d31c67c2c1653e
+  md5: c3d6bfae757760082261779c406a880d
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 116270
+  timestamp: 1693902021950
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.11.26-h06a4308_0.tar.bz2
+  sha256: 0b5277b4291e4eb5993277722b6c8a4ec106f9ed73fefabc62d8ac2283c45d29
+  md5: eb5c5c81f84445b39a829d83682e3cd1
+  license: MPL-2.0
+  license_family: Other
+  size: 141126
+  timestamp: 1732804447102
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cachetools-5.3.3-py310h06a4308_0.tar.bz2
+  sha256: c933a64b2ab50d09533355fcd9c2b6742a7a0e1c073720baf53538d409255c11
+  md5: 3a98e462c68e92fd5c4d2cf34b9ebe50
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 22901
+  timestamp: 1713977109850
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.8.30-py310h06a4308_0.tar.bz2
+  sha256: fc8588f7e8e80e28c10d52dd941bb85e9c5d4759f10d89b7a892c756284b1005
+  md5: c37c40fed22998ea1ee17f6a6faf1fb9
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 167722
+  timestamp: 1725551695290
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py310h1fdaa30_0.tar.bz2
+  sha256: a0b76f0cec2177bde240f4066898d6af29dca27d393f748d7807c7aca9eae823
+  md5: 8ba0dfc3548f357374b0210c9f44e9b3
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 242787
+  timestamp: 1726856502275
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cfitsio-3.470-h5893167_7.tar.bz2
+  sha256: a4a855659e4a52515b940d1b9d8204b626c11395980e99539b24f52d658e1857
+  md5: 65a71d60ece0bd684f1be09b48de8d00
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=7.82.0,<9.0a0
+  - libgcc-ng >=11.2.0
+  - libgfortran-ng
+  - libgfortran5 >=11.2.0
+  - zlib >=1.2.12,<2.0.0a0
+  license: Other
+  license_family: Other
+  size: 1384722
+  timestamp: 1655814890848
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cftime-1.6.2-py310ha9d4c09_0.tar.bz2
+  sha256: 33c64c25ccddc93f7bdb38acf863839a323ac215a3d0a0190ecb2c460905d667
+  md5: 3d5c57533f6d4ee2e9502e5f4a2f1933
+  depends:
+  - libgcc-ng >=11.2.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 248445
+  timestamp: 1678830501437
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/charls-2.2.0-h2531618_0.tar.bz2
+  sha256: ff4a1d243f3ffbcc677b1db7b5c7af06492f2910a0f1eea6664ad0ea3125835c
+  md5: 310b9390fc05d62245c9f95ac96ac376
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 132255
+  timestamp: 1612240399775
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py310h06a4308_0.tar.bz2
+  sha256: 850d4ce317a2434516871ffd235dccbefe94a26e78e5f5dcfb0493c0091bf933
+  md5: b7a42df99108ce294f99e1a5d8426c1c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 154568
+  timestamp: 1698129845674
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.0.0-py310h06a4308_0.tar.bz2
+  sha256: 45eddf1ce563f1b849921ff8db8999be8f296a3a5dff2ab1339443147f1bb976
+  md5: 742cde3b2153865cbd40e09dd820a2dc
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 34788
+  timestamp: 1721657453266
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py310h06a4308_0.tar.bz2
+  sha256: 4b9150ff168d17abf2e28a14e436e10653d87082c8865f1dae6081932d572c0a
+  md5: 3b3d0971e24b952e00cc35e7193eeade
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 502279
+  timestamp: 1709758414744
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py310h06a4308_0.tar.bz2
+  sha256: d0081216e44fa6a474db76fc3ad26170e9578ae07f40f0a190f93ffda77ab98f
+  md5: 855af00ea0c0b401e2853080e5604d22
+  depends:
+  - python >=3.10,<3.11.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14651
+  timestamp: 1709322914698
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.3.1-py310hdb19cb5_0.tar.bz2
+  sha256: b5a23181c83817e0467d06f8e49b3ef04e2eba9b8dd7059dbd8fde0d4fca34c2
+  md5: d5535fe50ad08cf5d44a0b1a9d53a34e
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.23
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281389
+  timestamp: 1732540260436
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py310h130f0dd_0.tar.bz2
+  sha256: d2a8f02d97dfaa1759c11ac815223a8c6a2e1108c91f0a0dcb031970040b55e9
+  md5: 105134bfa872c5a8617ffe18b361319b
+  depends:
+  - cffi >=1.12
+  - libgcc-ng
+  - openssl >=1.1.1v,<1.1.2a
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 2185827
+  timestamp: 1694445068014
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.2-py310h5eee18b_0.tar.bz2
+  sha256: 13d7235a412a2dad8473c869d1a97a215399c55ee8ba1ca98837b24a54e62cf2
+  md5: 3d7f0e1365620ffb735bf64071b310b8
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 416431
+  timestamp: 1701723821963
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-2024.5.0-py310h06a4308_0.tar.bz2
+  sha256: 4a2f862735a144a81d7bbcb53839ae954c97d0857a45ac49cc1c70e5b8858bf6
+  md5: 52fe3afde30175ee783429634b359eef
+  depends:
+  - bokeh >=2.4.2
+  - cytoolz >=0.12.0
+  - dask-core 2024.5.0
+  - dask-expr >=1.1,<1.2
+  - distributed 2024.5.0
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.21,<2.0a0
+  - pandas >=1.3
+  - pyarrow >=7.0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5282
+  timestamp: 1715848852304
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.5.0-py310h06a4308_0.tar.bz2
+  sha256: 16524a2d65afdeb7961b0af2e8dacb5e5de29f21c5cf026e64ad89e7633cf216
+  md5: ecf87701803a8149521891999e8aebd6
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2240833
+  timestamp: 1715838663501
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-expr-1.1.0-py310h06a4308_0.tar.bz2
+  sha256: 9f843ba9d24593f19a1da1f0df638241770c0992a4dfc60f2d1a5f0acb6d2d21
+  md5: 50b90f625d3eec04e4b42336754e7be3
+  depends:
+  - dask-core 2024.5.0
+  - pandas >=2
+  - pyarrow >=7.0.0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 357485
+  timestamp: 1715846575852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dav1d-1.2.1-h5eee18b_0.tar.bz2
+  sha256: 9f015999d24a376602b5876f542bcb41a7db66fa73064091cccdc1b06195392c
+  md5: 29684f3832212a3c977960c62c421119
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 889577
+  timestamp: 1688746033126
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py310h6a678d5_0.tar.bz2
+  sha256: 0b674c799b7298d3c91dea9832de5c02a26238e5a13d44214c513ecc619bf2ad
+  md5: 2adc19991b72c76211696fbe79b4cf75
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 2152954
+  timestamp: 1690905105597
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2024.5.0-py310h06a4308_0.tar.bz2
+  sha256: efdd12309b7ca0193cce5646fe9a79dff692c141d26ca5c48be05c9b611685a8
+  md5: a8606369c94ba95571c6c480a80f95d1
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - dask-core 2024.5.0
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.0
+  - packaging >=20.0
+  - psutil >=5.7.2
+  - python >=3.10,<3.11.0a0
+  - pyyaml >=5.3.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.10.0
+  - tornado >=6.0.4
+  - urllib3 >=1.24.3
+  - zict >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1459221
+  timestamp: 1715844536299
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py310h06a4308_0.tar.bz2
+  sha256: 413921f9bdd75ddbf9667fc35d4f7b8ac6ce751ab992297635e0cad2a8a9174e
+  md5: 57314b5e1702906d03bfcff4d7eab35a
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16500
+  timestamp: 1649908359372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.2.0-py310h06a4308_0.tar.bz2
+  sha256: 29e4a264bc6130aa38c028b2eae9ffe99719deea638a4bff90161fb8d295cdcd
+  md5: ea8da5d9c8ccde2276129f66d424453a
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 29766
+  timestamp: 1706031514511
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/flatbuffers-24.3.25-h6a678d5_0.tar.bz2
+  sha256: a6fd11c731fd7c619192b0cbff77e8610fbd9ead3a18f5e1246b3658fef0576d
+  md5: db3bc1839b6aa7024bcceb8321518d13
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2035312
+  timestamp: 1722872893194
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py310h5eee18b_0.tar.bz2
+  sha256: e1a291ca51353618e9d44fe07dae015209170904e23fd15eb4d24617577e2b32
+  md5: 549a3dfe2d7e5a321be53f8199d84020
+  depends:
+  - brotli >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - fs >=2.2.0,<3
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  - zopfli >=0.1.4
+  - lz4 >=1.7.4.2
+  license: MIT
+  license_family: MIT
+  size: 2713424
+  timestamp: 1713551479113
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+  sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
+  md5: a5dc8677d891dff2393b63189a3ad42f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 971975
+  timestamp: 1666798278693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/frozenlist-1.5.0-py310h5eee18b_0.tar.bz2
+  sha256: 586c946cbb6a1c8157cb32fea098f947ee546b92764acb88dfc48ec5852534dc
+  md5: 0c0addf6cec28e29a9bced8682667433
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 64599
+  timestamp: 1730902835801
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.6.1-py310h06a4308_0.tar.bz2
+  sha256: 977247182a869aebd535cd4e361b48530fef4e1a19ad12deac39da8a650d3f4b
+  md5: ca6350d6f17bce135cde49e8cfa50511
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - pyarrow >=1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 287574
+  timestamp: 1724855679539
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+  sha256: 2fc1136056f41fe92de719fb821550346704965dd12a5fa35069cdb4948d5c17
+  md5: fd089b0fba2b03aafe3adb6cdaa9ac3b
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203421
+  timestamp: 1706888218007
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.2-h5eee18b_0.tar.bz2
+  sha256: 896e0a1bcf27c4ca87835382e7a9b737d7142302dbcadf388d3f2ca28b569017
+  md5: dd71853d7c8a1ca649c51956c07d32ba
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 78717
+  timestamp: 1728656289496
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+  sha256: f1e190d4ee766add8131a2b011723c472284de2bbb5e07c8f895f30e3c591df7
+  md5: 82029e0758feac811afec2a6ef9e6155
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 108438
+  timestamp: 1706895276199
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/google-auth-2.29.0-py310h06a4308_0.tar.bz2
+  sha256: ab1a7fda803a37947863249b39f28bfecc42c60c67fe5e71b8ca820002305ac7
+  md5: 41af1e687800b6c41e258ae2a7db3529
+  depends:
+  - aiohttp >=3.6.2,<4.0.0dev
+  - cachetools >=2.0.0,<6.0
+  - pyasn1-modules >=0.2.1
+  - pyopenssl >=20.0.0
+  - python >=3.10,<3.11.0a0
+  - requests >=2.20.0,<3.0.0dev
+  - rsa >=3.1.4,<5
+  constrains:
+  - cryptography >=38.0.3
+  - pyu2f >=0.1.5
+  license: Apache-2.0
+  license_family: Apache
+  size: 212384
+  timestamp: 1715111254620
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/google-auth-oauthlib-0.5.2-py310h06a4308_0.tar.bz2
+  sha256: 21eb0c746ed75350feecdb4e6087c08ca43afee660a681bd7f94b384a6eac998
+  md5: 6fa601b942709067f6e60f31b9400254
+  depends:
+  - click >=6.0.0
+  - google-auth >=1.0.0
+  - python >=3.10,<3.11.0a0
+  - requests-oauthlib >=0.7.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 27281
+  timestamp: 1660687833850
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/grpc-cpp-1.48.2-h5bf31a4_0.tar.bz2
+  sha256: 73ef97b889329d074dae35afd8237dff79ea5f8456224d9d6279eb2370192334
+  md5: 3782db0e75fe18196b4b08d1f5b78603
+  depends:
+  - abseil-cpp >=20211102.0,<20211102.1.0a0
+  - c-ares >=1.19.0,<2.0a0
+  - libgcc-ng >=11.2.0
+  - libprotobuf >=3.20.3,<3.20.4.0a0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=1.1.1t,<1.1.2a
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5408819
+  timestamp: 1681913198738
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/grpcio-1.48.2-py310h5bf31a4_0.tar.bz2
+  sha256: ce73c4ad711f135d31516777435579b217fc174650ca50c27ffed4c001d028fb
+  md5: 23edcd7ddd2bfd41f4d7c7f24a689986
+  depends:
+  - grpc-cpp 1.48.2 h5bf31a4_0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  - six >=1.6.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 823537
+  timestamp: 1681913276214
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/h11-0.14.0-py310h06a4308_0.tar.bz2
+  sha256: bdf09a1658638c9696f810ffd8ff9024492d9e57edbe4befb9c46d664d91a187
+  md5: 61687dd75da9f3c3180f351b2a8b0b6f
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 84164
+  timestamp: 1706652403551
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/h5py-3.12.1-py310hc0802c4_0.tar.bz2
+  sha256: 3ec6669b79a219704a1f40b51b7e58f8c993d1f79b322e66d13e28547f526e10
+  md5: 1045ef94f2b22ab679759b9b6021cb25
+  depends:
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - libgcc-ng >=11.2.0
+  - numpy >=1.19.3,<3
+  - numpy >=1.21,<3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1634785
+  timestamp: 1730216373630
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf4-4.2.13-h3ca952b_2.tar.bz2
+  sha256: 70e1f9fdc6b123d8270bcd8cdd555519372924d39419ef8692b36bfa9d0b4653
+  md5: 35da658876a3e2a62dda54dcd5a7e5c2
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.2.0
+  - libstdcxx-ng >=7.2.0
+  - zlib >=1.2.11,<2.0.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 937548
+  timestamp: 1510862959026
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf5-1.12.1-h70be1eb_2.tar.bz2
+  sha256: 30a88eb6e50bb2201d06734f74d3f98624f3b7ff1371607f770bb71d5dd86c61
+  md5: 9249c8c2d04f5bb91f1dffcb00be691a
+  depends:
+  - libcurl >=7.82.0,<9.0a0
+  - libgcc-ng >=11.2.0
+  - libgfortran-ng
+  - libgfortran5 >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=1.1.1o,<1.1.2a
+  - zlib >=1.2.12,<2.0.0a0
+  license: HDF5
+  license_family: BSD
+  size: 5763149
+  timestamp: 1655307949265
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.20.0-py310h06a4308_0.tar.bz2
+  sha256: 22acee607b765c48348a61f67f85099d45b6b15ea1b0d21f85a83b3a3c1da0e1
+  md5: b391ce92b7e350e9ec310bb8a3874e06
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=2.1
+  constrains:
+  - plotly >=4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5328353
+  timestamp: 1730827726905
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpcore-1.0.2-py310h06a4308_0.tar.bz2
+  sha256: b082946b54df34433bb62379daffc683075b34a8ab3cee7d570c8e1b5a487e05
+  md5: 1e25bb9ee0f040e3098c2d1f0d8fd731
+  depends:
+  - certifi
+  - h11 >=0.13,<0.15
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84383
+  timestamp: 1706728541283
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpx-0.27.0-py310h06a4308_0.tar.bz2
+  sha256: 37fcf81e13e91f940567e3a0259336227e133aea9edc45f4ea4169a1b5f9ba80
+  md5: bfe2785a6e4dd8095caa68d1bad23976
+  depends:
+  - anyio
+  - certifi
+  - httpcore >=1.0.0,<2.0.0a0
+  - idna
+  - python >=3.10,<3.11.0a0
+  - sniffio
+  constrains:
+  - socksio >=1.0.0,<2.0.0a0
+  - pygment >=2.0.0,<3.0.0a0
+  - click >=8.0.0,<9.0.0a0
+  - rich >=10.0.0,<14.0.0a0
+  - h2 >=3.0.0,<5.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 159878
+  timestamp: 1723474830579
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+  sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
+  md5: 9213e0336e3a5216c989cfe52648412e
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 23805906
+  timestamp: 1588026213084
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py310h06a4308_0.tar.bz2
+  sha256: fac4c785ed4a1343d3b00cf339cdf8068010f59c9f373dee32cb164b2733b0aa
+  md5: 43078d825ae52359500a27f564e68365
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 139387
+  timestamp: 1714398895037
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/imagecodecs-2023.1.23-py310hc4b7b5f_0.tar.bz2
+  sha256: 78863c3e301566e580499556da34dd2144dccebfcad442070b4c382b48ada776
+  md5: 8ead00d9393e21aa28cb2ccf228083d9
+  depends:
+  - blosc >=1.21.3,<2.0a0
+  - brotli >=1.0.9,<1.1.0a0
+  - brunsli >=0.1,<1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - cfitsio >=3.470,<3.471.0a0
+  - charls >=2.2.0,<2.3.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - jxrlib >=1.1,<1.2.0a0
+  - lcms2 >=2.12,<3.0a0
+  - lerc >=3.0,<4.0a0
+  - libaec >=1.0.4,<2.0a0
+  - libavif >=0.11.1,<0.11.2.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=11.2.0
+  - libtiff >=4.5.0,<4.7.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - libzopfli >=1.0.3,<1.1.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - numpy >=1.21.5,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - snappy >=1.1.9,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zfp >=1.0.0,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10625436
+  timestamp: 1695065156863
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/imageio-2.33.1-py310h06a4308_0.tar.bz2
+  sha256: 2a896657b4a0d09df27dada4d5f648fbb6337a2a3013a3492a4b40abe8e45335
+  md5: dbd14c905eeaab2930cb37410f885569
+  depends:
+  - numpy <2.0a0
+  - pillow >=8.3.2
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 523763
+  timestamp: 1707247435357
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-8.5.0-py310h06a4308_0.tar.bz2
+  sha256: 1fc2468ffede3ec24e56cd89258f6e39191d79f90f4373fd8e09661a5b6a62fc
+  md5: 68c38f21ff90342758fc2bf6ac144dd9
+  depends:
+  - python >=3.10,<3.11.0a0
+  - zipp >=3.20
+  license: Apache-2.0
+  license_family: APACHE
+  size: 45377
+  timestamp: 1732633559727
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intake-0.7.0-py310h06a4308_0.tar.bz2
+  sha256: e71e305c0d22f4163bb8145f6894e9c41bb349105011443f5137d345a31cd9b7
+  md5: d92378bbd16bcc0842f778f99735d663
+  depends:
+  - appdirs
+  - dask >=1.0
+  - entrypoints
+  - fsspec >=2021.7.0
+  - jinja2
+  - msgpack-python
+  - python >=3.10,<3.11.0a0
+  - python-snappy
+  - pyyaml
+  - requests
+  - tornado
+  constrains:
+  - bokeh
+  - hvplot
+  - panel >=0.7.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 197655
+  timestamp: 1717513957683
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intake-xarray-0.7.0-py310h06a4308_0.tar.bz2
+  sha256: 741658bf13964556c4c9ef7dffe491bcbe9eeaca6ee7ceeea887e38f14ef91ff
+  md5: ec8b50f4b0bb345e521ccf6dc76b0514
+  depends:
+  - dask-core >=2.2
+  - fsspec >=2022
+  - intake >=0.6.6
+  - msgpack-python
+  - netcdf4
+  - python >=3.10,<3.11.0a0
+  - requests
+  - xarray >=2022
+  - zarr
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 68115
+  timestamp: 1717523847861
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+  sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
+  md5: 3add2ce56858a1b8f6a37342f82773d3
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<1.2.14
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 19310769
+  timestamp: 1699647799237
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py310h06a4308_0.tar.bz2
+  sha256: b86be39d915f5e2016b7f89ede4da3cb028c52ca937f9519b414677d99af21c3
+  md5: 4da369cd74cafbc9feefaf766dc06b51
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 191433
+  timestamp: 1728665858825
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.27.0-py310h06a4308_0.tar.bz2
+  sha256: 328dbd66a00f4df59f1d8a12bcc0291b95cef2619d4deab28b0dfbef350f846c
+  md5: 4acf1050c72217392bae0eb086fd8458
+  depends:
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.10,<3.11.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1298924
+  timestamp: 1726064347754
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipywidgets-8.1.2-py310h06a4308_0.tar.bz2
+  sha256: dcc9f2f9e6e920f96937ca00eea5c248b880d88edf5d08eade3b0a1e571786d2
+  md5: 0a4134315260d005862140eea8b66f28
+  depends:
+  - comm >=0.1.3
+  - ipython >=6.1.0
+  - jupyterlab_widgets >=3.0.10,<3.1
+  - python >=3.10,<3.11.0a0
+  - traitlets >=4.3.1
+  - widgetsnbextension >=4.0.10,<4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 200721
+  timestamp: 1709574715167
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.1-py310h06a4308_0.tar.bz2
+  sha256: 460e4384ebb8546399e2af70e91d5f55727417d6d2720e36d4179b3928e5ada3
+  md5: 95e991de6c269bc3136de0ab07cbe45a
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1046913
+  timestamp: 1721058449739
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py310h06a4308_1.tar.bz2
+  sha256: 3942a64c47b2286374cae033c83072b9506999773d057ac998b59e1baf92ba8c
+  md5: 2131b364c78bf299ef56ae4ecfc7bd2a
+  depends:
+  - markupsafe >=2.0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 274809
+  timestamp: 1730902978641
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jmespath-1.0.1-py310h06a4308_0.tar.bz2
+  sha256: d3acdff9097d1ece562d3fea6ba2463e05d8c2267905e6a820be07a6721610cb
+  md5: 919e71a41fd2efacc4b67c5c587613fe
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 37456
+  timestamp: 1700144606539
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+  sha256: 8316ae3abee25edab89788ee6e9eef79c398aba192559f514674a04ee1860bca
+  md5: 112209aed451545a622ab217c70f6972
+  depends:
+  - libgcc-ng >=11.2.0
+  license: IJG
+  license_family: Other
+  size: 283506
+  timestamp: 1722872662693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/json5-0.9.25-py310h06a4308_0.tar.bz2
+  sha256: 238807f403ce9b34096dd5ecc4707015951066ad7dca61f81faee0cfa85e5135
+  md5: 20c9a5c75285aa1497d837821eaf98b1
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 45601
+  timestamp: 1730786822889
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.23.0-py310h06a4308_0.tar.bz2
+  sha256: 9564ef0b7160e66aa4bd9ad3d576a4fd5b7dffaa855367f048dc15cf04bbfb27
+  md5: c1f0fbfd87b96f8201b325cc7fbbfa30
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.10,<3.11.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 145179
+  timestamp: 1728486748314
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py310h06a4308_0.tar.bz2
+  sha256: da0f6e41d27a7d9818272d6557c62cedf9d609aac6f1e5558c703692a9b1c1cf
+  md5: f94d2d36c18202c503ca80f382c67c74
+  depends:
+  - python >=3.10,<3.11.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 14940
+  timestamp: 1699032489094
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter-lsp-2.2.0-py310h06a4308_0.tar.bz2
+  sha256: 60c7188fbadd23291cc3e946f8ac06317eaab19bbcf26365a8858429d9f2e296
+  md5: bd6483a716913a2830ec6e1b46391cdd
+  depends:
+  - jupyter_server >=1.1.2
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 81013
+  timestamp: 1699978324790
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-8.6.0-py310h06a4308_0.tar.bz2
+  sha256: e621bb072be14bb7cbbeabf10ba96244048b9f99a44d0b304c44456bcfc2311a
+  md5: 45418cb0996419efde6fc5fa384b04ca
+  depends:
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 172723
+  timestamp: 1699455939187
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py310h06a4308_0.tar.bz2
+  sha256: b2c6c5f92ac0ed1510b732bbda07f0ee7d71488975e27412655f0f71594bc35a
+  md5: 40299077d5b409ce3f3e44555251f95d
+  depends:
+  - platformdirs >=2.5
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 82697
+  timestamp: 1718818318946
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py310h06a4308_0.tar.bz2
+  sha256: 3032d4d6fb51cb28a6d6cd9eaed38a75ffb604aed71c07a72d04c7cd5fa0a52a
+  md5: c98c4693717827d34ad9816f15000826
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.10,<3.11.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35673
+  timestamp: 1718738148983
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py310h06a4308_0.tar.bz2
+  sha256: 66eb21dea9d68413ad88acd1c00946b5a94cfde1760797ccaf84557d7bc6a847
+  md5: c02afea376472f249a23af563f297a18
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 504392
+  timestamp: 1718827574049
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py310h06a4308_1.tar.bz2
+  sha256: 86f14a80966c3e6dec7a79da70edb37c678bb5854e89500c51a7551e50a4fa83
+  md5: 5801d1b34c533fa654b9fe53b4c616d7
+  depends:
+  - python >=3.10,<3.11.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23681
+  timestamp: 1686870826319
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab-4.2.5-py310h06a4308_0.tar.bz2
+  sha256: 3d97e660fa87ad67e457c205a673e1de295948617352a5c3395561c6b90e2288
+  md5: 354f959a71ded3f79553229618a805bd
+  depends:
+  - async-lru >=1.0.0
+  - httpx >=0.25.0
+  - ipykernel >=6.5.0
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.27.1,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.10,<3.11.0a0
+  - setuptools >=40.1.0
+  - tomli >=1.2.2
+  - tornado >=6.2.0
+  - traitlets
+  constrains:
+  - nodejs >=20.0.0,<21.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8318314
+  timestamp: 1725896520590
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_server-2.27.3-py310h06a4308_0.tar.bz2
+  sha256: 59646dbe79c4f601c71e65164e11b6aea97aa59fc923ef73b70ad644e3c241bc
+  md5: fcd25a200c17a669aa28cf3a24dabaac
+  depends:
+  - babel >=2.10
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18.0
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.10,<3.11.0a0
+  - requests >=2.31
+  constrains:
+  - openapi-core >=0.18.0,<0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 83159
+  timestamp: 1725865484148
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_widgets-3.0.10-py310h06a4308_0.tar.bz2
+  sha256: 10b46984ade2980925e873f73d1533dee6a4ab1868c1d3caa88861ad46a93dcd
+  md5: 90f21a94f7689cf86580799630e3454c
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jupyterlab >=3,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 191366
+  timestamp: 1709322903512
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jxrlib-1.1-h7b6447c_2.tar.bz2
+  sha256: 46fa3b9ce2790a2efd328560b7e76f6716c92288702ced1f63168f22bad487d0
+  md5: e1ae8a1211dfebe4c60b7e755200a327
+  depends:
+  - libgcc-ng >=7.3.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 244049
+  timestamp: 1593197090424
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/keras-2.12.0-py310h06a4308_0.tar.bz2
+  sha256: 6b7c9325e15622a1dfaf4f8d2a2709238f541bfead4af7bd3de1406a470440a5
+  md5: 6c5442852159cd8b656f0cd05e664249
+  depends:
+  - keras-preprocessing >=1.1.2
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - tensorflow-base  2.12.*
+  license: Apache-2.0
+  size: 2261153
+  timestamp: 1682445693643
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py310h6a678d5_0.tar.bz2
+  sha256: 847b6b284b1ddb73b398c64bffc4808ca15acd4540b0631d93c3a36c00d1fafa
+  md5: 1728f1fe8a6b260a1097d5723defc547
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 77845
+  timestamp: 1672387187154
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h568e23c_1.tar.bz2
+  sha256: 126a5fd5e59cc90c1a2c688a801dea7f352f0bb218c2f949d0f3d21db35fbe1b
+  md5: 64d1d86c812dc1843bcbb4cab2e8f60f
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=1.1.1u,<1.1.2a
+  license: MIT
+  license_family: MIT
+  size: 1426697
+  timestamp: 1686931184185
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lazy_loader-0.4-py310h06a4308_0.tar.bz2
+  sha256: 1cfc9cedce193efa49a601455363ee2883df7e8a2baf481aba708c0077b0675a
+  md5: 048cf3e2ec21f343a7c3333965d0a7d4
+  depends:
+  - packaging
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20755
+  timestamp: 1718176849479
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+  sha256: 069d33aebaf4db4ae410d4acb4851860a69d2c8f326fd45ab2a67b67fe276e6d
+  md5: 61689da52cf1fcebda8c9fb2872f94bf
+  constrains:
+  - binutils_impl_linux-64 2.40
+  license: GPL-3.0-only
+  size: 723073
+  timestamp: 1727336193185
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+  sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
+  md5: 88199c75f2ac211728febced7785c24e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 228278
+  timestamp: 1635523146417
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libaec-1.0.4-he6710b0_1.tar.bz2
+  sha256: 860ecdf2e21768f806f9c0d272e92dbc521b249a7171b0def500a30937fb079a
+  md5: e911ac853b19bd7073f1047699e2118e
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 35409
+  timestamp: 1593197267510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libavif-0.11.1-h5eee18b_0.tar.bz2
+  sha256: 0eccc12a46c14a730a55569f28a170bd315aad9df6ae7e13eba7732e6317f3df
+  md5: 5974603ff942f18b40e5156dd6819410
+  depends:
+  - aom >=3.6.0,<3.7.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - libgcc-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 105392
+  timestamp: 1689158136084
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.73.0-h28710b8_12.tar.bz2
+  sha256: 1d69d22e3a27260658d33d22c49dfa78effb9f0d612d2223a6a76dba4e55b171
+  md5: 34dd22cf2bca0dbccbb9697f190f504a
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 22152039
+  timestamp: 1655879823139
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+  sha256: bb990ea068c3b3dafd9c807e0e19570320cb2fe7d69cc326f1f0b5319b0654b2
+  md5: 3ff70744e396b1af69656c574b05c3b9
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 66940
+  timestamp: 1714483221853
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 3b87a816f72a00e1f0022a160e7eda70af89d3de2a2e08a72be1c17b31d759f3
+  md5: 4f57d3a0a13ddaf1c06efb586b702f46
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 34446
+  timestamp: 1714483232430
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 2cf15e89f910600f468edfde8d0f9b80a14fa2319ed89160dc7375dfd3764fdb
+  md5: 463adc13f2feea3570d1eccac368d9e4
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 295090
+  timestamp: 1714483244460
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.2.1-h91b91d3_0.tar.bz2
+  sha256: 8daa34822b26916b12867746d55790aa5b719e096e412aba86c5a9f13b19ee36
+  md5: bd594551d7447f93c8a1575be1b1f12e
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libgcc-ng >=11.2.0
+  - libnghttp2 >=1.52.0
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 386369
+  timestamp: 1693515365220
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+  sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
+  md5: 55dde57e63a36b202e388a39dcee9a66
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 74096
+  timestamp: 1695996494461
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+  sha256: 5bd3af246b6a93ea0912179ae66e0ad9157ca0142263010d84b65724e6db0bec
+  md5: 5cb0cc0e1783419cf8fc1c65fee0f62f
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 195807
+  timestamp: 1703006263489
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+  sha256: efdab884c85fda4461f7a393aa6d4e0e50d03cb59fb9c8a980b1307b8379ebe0
+  md5: eeca774c6154c49340dd403b1928d5e9
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 108906
+  timestamp: 1632891483341
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-h8f2d780_0.tar.bz2
+  sha256: 2b9470932f5c923f19fcc14c8d1c7ed5f58a468588c09d6b04e0a905c07a297f
+  md5: 2e3534102d10ade546c0feb056bbffbe
+  depends:
+  - libgcc-ng >=7.5.0
+  - openssl >=1.1.1m,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 491177
+  timestamp: 1642102679055
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+  sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
+  md5: 1af9b4d62c708924417f2640ef22a68f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 154016
+  timestamp: 1714483282916
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
+  md5: 641e72e5067bd6d5454405879e1cd2a7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - _libgcc_mutex * main
+  - __glibc >=2.17
+  constrains:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - libgomp 11.2.0 h1234567_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 8895144
+  timestamp: 1654090827491
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+  sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
+  md5: 27082517590f3b9fbffecc68513b461b
+  depends:
+  - libgfortran5 11.2.0.*
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 19860
+  timestamp: 1654090819660
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+  sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
+  md5: 0202c3c8ae4735cac6c7f3d1e1685964
+  constrains:
+  - libgfortran-ng 11.2.0 *_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 5228750
+  timestamp: 1654090762569
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+  sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
+  md5: 3080c2813e6e1d0f8a100a38b5b3456d
+  depends:
+  - _libgcc_mutex 0.1 main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 573231
+  timestamp: 1654090775721
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnetcdf-4.8.1-h424c3a0_4.tar.bz2
+  sha256: de65b7a86ff4c0d96eac3fa67bcdb240b0b8a2a7b0eff7acfb62785beb61c65e
+  md5: 7d2dab80f6e4cb15b31efb3830de2eda
+  depends:
+  - hdf4 >=4.2.13,<4.2.14.0a0
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libzip
+  - openssl >=1.1.1v,<1.1.2a
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1575909
+  timestamp: 1691154591143
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.52.0-ha637b67_1.tar.bz2
+  sha256: 71a65b3c05426b92e8a3002e7d42cd303255439f8a4442b4fc5aa882aef3128e
+  md5: 113b010119638c67e3b6c8570d88f5be
+  depends:
+  - c-ares >=1.19.0,<2.0a0
+  - c-ares >=1.7.5
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=1.1.1u,<1.1.2a
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 716614
+  timestamp: 1686931412665
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+  sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
+  md5: 1bffe1481ed4f88827248fb9001f8923
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 362561
+  timestamp: 1677841789536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
+  sha256: a24f7d1cdb5e18466a61860a5a66baffd608e212bbfed2935350e83d4d8659c0
+  md5: b32a43de76bc9be9c71f9a12edec8a1e
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2706964
+  timestamp: 1675278653314
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-h37d81fd_2.tar.bz2
+  sha256: 41f2e9a088031bd209d50f37f727fb9647be9316db3e149f9f2bac0057f7184d
+  md5: 778c268743d6cf857178bd1ecf6c9525
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl >=1.1.1u,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 311794
+  timestamp: 1686931200150
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
+  md5: 8c195584a5f5471b600ee180e4052773
+  depends:
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 6410287
+  timestamp: 1654090800863
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h0d84882_2.tar.bz2
+  sha256: 535b2ce4add44d604b5559fa371af020e0e242eaac402b8d5d97d9b9c9d88273
+  md5: 80ac532958a61a5339d2c7084f877bd8
+  depends:
+  - boost-cpp >=1.73
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=1.1.1u,<1.1.2a
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4631057
+  timestamp: 1687975455689
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+  sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
+  md5: ef78eebd98289aceacdfa29182426adf
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 664034
+  timestamp: 1693575237924
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+  sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
+  md5: 292768ec77416ae257cfdd44ea2071c8
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29197
+  timestamp: 1668082729834
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+  sha256: a062fad27450b94279d1688aabd11a95eedee7814462ef6364337d55412b4a7e
+  md5: e0521f84b9770830e654432364ac930e
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 484011
+  timestamp: 1729160032020
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libzip-1.8.0-h5cef20c_0.tar.bz2
+  sha256: 32af09699997b89fb3fc5fe2e2665e505faf23275268b7527e1eabae748a4cc0
+  md5: 6cde3e76dc236a20a012e7fc41224315
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=7.5.0
+  - openssl >=1.1.1o,<1.1.2a
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 106709
+  timestamp: 1652978513482
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libzopfli-1.0.3-he6710b0_0.tar.bz2
+  sha256: 04e6f97332bc583ad380f0dc6f3f38c766fe15900c29f52c8097b7743ef2b417
+  md5: 6d276711374079b0d91ea31ecbe27b31
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 183622
+  timestamp: 1593197391897
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py310h06a4308_0.tar.bz2
+  sha256: 620fbc4a92da4de3084bd55c609f16c33b241b6d21255ed9dd3e762d415c50ef
+  md5: dc293648b9caa345b01ac5f9a90392de
+  depends:
+  - python >=3.10,<3.11.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 35342
+  timestamp: 1659783460274
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py310h06a4308_0.tar.bz2
+  sha256: 4210b70b38fd509ac973d347a654f2cd670b7559411ae783e07b48c071a809e2
+  md5: e36d89397033bfc417932702d7519138
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11131
+  timestamp: 1652903185157
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py310h5eee18b_0.tar.bz2
+  sha256: 5a8af55693aba974e96a57667c650788b6f5a928dc42aade8087b7ca275b9ded
+  md5: 01b180812795b419297b1ac60c95bca9
+  depends:
+  - libgcc-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37752
+  timestamp: 1686057986134
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+  sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
+  md5: 76f089e76ec67583bb38428b51008097
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 164494
+  timestamp: 1714510587156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py310h06a4308_0.tar.bz2
+  sha256: 93b9aa3ffe66b9ea121fcb1a32a2502006df7073fa29a00ccc00b185b00721ce
+  md5: 37edf1dc070689d9f64021285157aa25
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 122987
+  timestamp: 1671541964893
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py310h06a4308_1.tar.bz2
+  sha256: 7e14cb93cf0c535ae8e0aef73c7c9ad9aa55813398438762c5f0b30347788111
+  md5: 88cc67a13bca127dea58eac5d6edca75
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 106714
+  timestamp: 1684279935424
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py310h5eee18b_0.tar.bz2
+  sha256: bd1df99e92877a31b49fe7626e1e4c045c6df46079bc1b8d8243db67ee000631
+  md5: 934e27fec3401a09e5a7f56318308e71
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23730
+  timestamp: 1704206282955
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.9.2-py310hbfdbfaf_1.tar.bz2
+  sha256: 235cc4c6306a65ce9284def09122d4ea62aaf15cd39d74aa89fc694a4a87adad
+  md5: fd12b1d438c5b2fa3f8c2ce79cdfdd21
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.23,<3.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8503856
+  timestamp: 1732550910466
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py310h06a4308_0.tar.bz2
+  sha256: be8075a8d70b0da67859d63016219e3dd1bc84a1b484abcbd8b95eff52884d88
+  md5: 6336be55da6cebfaf1cbbdc573524fc1
+  depends:
+  - python >=3.10,<3.11.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16451
+  timestamp: 1662014606193
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py310h06a4308_0.tar.bz2
+  sha256: c483a73b6b3c2bd3a0f1fbb8a2fefbba96cc3e3cc52d2a6ce121ceeecb7fa61b
+  md5: 0d626377d7aab29eb38ea16c05dbd103
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 53361
+  timestamp: 1659721352029
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py310h06a4308_0.tar.bz2
+  sha256: ae02f23d333380a31ef4bb192baa4e145524e81ad3a53e0383e38d632979cc22
+  md5: 542c95fd4b9171b036a2d501196210be
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 18793
+  timestamp: 1659716070293
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py310h06a4308_0.tar.bz2
+  sha256: c1e3fa7d8d4656779fe37d55a9f8a457c8bcde71beab78f091c35adf9de303cb
+  md5: 434eefcd517ab08422676df586e111a3
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 90224
+  timestamp: 1661496364548
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+  sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
+  md5: ce77d0f05f846da4a6b9e23fe7f21d9b
+  depends:
+  - intel-openmp 2023.*
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - tbb 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 206738176
+  timestamp: 1699648006088
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py310h5eee18b_1.tar.bz2
+  sha256: 6baedecdce1b2f6067ded74941e54f14d791bbab133cb54db32380faf75960aa
+  md5: 9b1159ecb9e0d54be20e55af3bb8035b
+  depends:
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59221
+  timestamp: 1682948537006
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.11-py310h5eee18b_0.tar.bz2
+  sha256: 6d7bfa45a3cecd1a3a94de031a3dc0ec0e0c8b8d18a6ea29c1b44481950bd42a
+  md5: 4b4389bc0f59811794afda00c5247fac
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 228812
+  timestamp: 1730824196199
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.8-py310h1128e8f_0.tar.bz2
+  sha256: 310ee2be36e889814969b3d672a09173fb60f6779fc615992a1999dfc73d4b64
+  md5: e3a557a2b0a56c59f063ac52f733a488
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16
+  - python >=3.10,<3.11.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 398672
+  timestamp: 1730824069755
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py310hd09550d_0.tar.bz2
+  sha256: 406cc2249facfd03da39731092ce33f1e6cbebf0391a75a04628626183a45f45
+  md5: e1a2611549a26e06e7f7f06ab22bf053
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 262416
+  timestamp: 1652362755770
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/multidict-6.1.0-py310h5eee18b_0.tar.bz2
+  sha256: b11ec030328164443f48bcec46dfc62bd669da1a55aa40715a28644287c20e67
+  md5: 72b4c2000937e90dadeb1d1c30e345b4
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  - typing-extensions >=4.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 58463
+  timestamp: 1730905529469
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py310h06a4308_0.tar.bz2
+  sha256: 3760ac569d7988b5c21a9a83d9cf9022deb51f6a411e48a4b33e36e93f765ad3
+  md5: a78160b2fac13c7a01629011908910fa
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100211
+  timestamp: 1698934338032
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-core-7.16.4-py310h06a4308_1.tar.bz2
+  sha256: 7fa51b6a6c4e0121bb4ebbf52162d28ab8bceb9eaf870108bd602fc4a599d27a
+  md5: 169d06d0c515b8293ca460dbee509574
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.10,<3.11.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - pandoc >=2.9.2,<4.0.0
+  - nbconvert =7.16.4=*_1
+  - tornado >=6.1
+  license: BSD-3-Clause
+  size: 487830
+  timestamp: 1732709525361
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py310h06a4308_0.tar.bz2
+  sha256: 138c44f0b4b278db0e66e7ad3a9f24d0301c4ee1257e5eb944ba954eb7169a58
+  md5: 850a5b1738512bdb0d43e89efed45b2e
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.10,<3.11.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148192
+  timestamp: 1728049506559
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+  sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
+  md5: 57ea097dc15f8d9f9eb90e1d919143b0
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1157733
+  timestamp: 1674734069410
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py310h06a4308_0.tar.bz2
+  sha256: 505a9df53a9a36030f56020d63431baa3c67c31fd66712dfa06cdc5c7265ddbd
+  md5: 2abf153bb3d9a67452fd20cf560ef446
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13461
+  timestamp: 1708532806698
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/netcdf4-1.6.2-py310h6d89c78_0.tar.bz2
+  sha256: bc1c199569e7ae2f26d5fe33913ea840635c70a388dff3c6f91a3c95917176a8
+  md5: 2ce7dea8c221031e6eba688a777e523f
+  depends:
+  - cftime
+  - hdf5
+  - libgcc-ng >=11.2.0
+  - libnetcdf >=4.8,<4.9.0a0
+  - libnetcdf >=4.8.1,<5.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 502275
+  timestamp: 1673455610537
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.3-py310h06a4308_0.tar.bz2
+  sha256: eb4a86c1ff70f7bd0e27d5da781795e48770847707d256e4f5ca4c885b73ee5e
+  md5: 080666759eec29b3b93445d143c84087
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - scipy >=1.9,!=1.11.0,!=1.11.1
+  - pydot >=2.0
+  - matplotlib-base >=3.6
+  - lxml >=4.6
+  - numpy >=1.23,<2.0a0
+  - pandas >=1.4
+  - sympy >=1.10
+  - pygraphviz >=1.12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2661048
+  timestamp: 1720002720271
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-7.2.2-py310h06a4308_1.tar.bz2
+  sha256: a4c184c2160f2b116644951d91e94cc17119a31b8e95437baab5c4f2fff80876
+  md5: 76ef2274d74332dc28ad67b9c12a528c
+  depends:
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab >=4.2.0,<4.3
+  - jupyterlab_server >=2.27.1,<3
+  - notebook-shim >=0.2,<0.3
+  - python >=3.10,<3.11.0a0
+  - tornado >=6.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4564437
+  timestamp: 1727197492038
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py310h06a4308_0.tar.bz2
+  sha256: 91bd41503b82f6b48b57c19ac02d51185335db056b2966e92d010db52c12b6a3
+  md5: 0c61fecf07ab21a2c7ea857ca277fd6e
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22570
+  timestamp: 1699456009666
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numcodecs-0.12.1-py310h2c38b39_0.tar.bz2
+  sha256: 3f44588ac2c6898740ae0e88e1fee4179feb89c327e173800f8691992e001285
+  md5: e587b958a9be5446c0475af667464c44
+  depends:
+  - blosc >=1.21.3,<2.0a0
+  - libgcc-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - msgpack-python
+  - numpy >=1.7,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 449104
+  timestamp: 1707513535069
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.10.1-py310h3c60e43_0.tar.bz2
+  sha256: 452227325362bb94604a05ebc1ca29211b25fd3e1ac9b8e3365912c44eec11f0
+  md5: 50034a1bbd4c28cb8bfb59831d8407b1
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21,<3
+  - numpy >=1.23.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 177061
+  timestamp: 1730216028480
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.23.5-py310h5f9d8c6_1.tar.bz2
+  sha256: d90f57307b9c37e77ec949ac8810a1639ec2bab13361334967771e319a27b41e
+  md5: a3bd612da6d69848eb8e0831aad7669d
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.23.5 py310hb5e798b_1
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10267
+  timestamp: 1682953408527
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.23.5-py310hb5e798b_1.tar.bz2
+  sha256: 411ed298910d5743f46adcf87df09c91877b4f8cc55447adef00fa963ab35ffb
+  md5: 768821d2a2c2a7fed0475b1717b8627e
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - numpy 1.23.5 py310h5f9d8c6_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7418523
+  timestamp: 1682953393092
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/oauthlib-3.2.2-py310h06a4308_0.tar.bz2
+  sha256: a0d3f1c48d2818c10bb2e8d3749b1b487c0caf3b950fe843a070dccf4c9b631f
+  md5: 662d78b8dafb156daef0aec61db88fe9
+  depends:
+  - blinker >=1.4.0
+  - cryptography >=3.0.0
+  - pyjwt >=2.0.0,<3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 232744
+  timestamp: 1679489651614
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
+  sha256: 1c9f6902907a3d4a7e5c3cb02236491ea4c4e66a1a0ce51fa506dffb24ba89f6
+  md5: 36d514eca3c87ab75a1d418607e26db2
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=11.2.0
+  - libtiff >=4.5.0,<4.7.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 528528
+  timestamp: 1722872671997
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+  sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
+  md5: 5ad4571eba2479f77a9f849a6ae7724c
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: OpenSSL
+  license_family: Apache
+  size: 3998613
+  timestamp: 1694465071784
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
+  sha256: 9618addfc1b940c048372ffb2c8500d4b44d02455a9bd1f411e530ed5e09b8d5
+  md5: 56057ed323f733bdcf262468682d0358
+  depends:
+  - libgcc-ng >=11.2.0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.9,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1132661
+  timestamp: 1676482768554
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py310h06a4308_0.tar.bz2
+  sha256: 14dae0db86c618d047d6d217875897e0df68ac14aa45524d06e5248527429583
+  md5: 9fbd10ecc485cd5c367d6b85ac38fc29
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 30807
+  timestamp: 1699371235539
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.1-py310h06a4308_0.tar.bz2
+  sha256: d4018553288e8ea32e4cd53e2ee6888d3b3d5bbceeff64b0239b3661dc5edfab
+  md5: 0e4afdfcdb31580a97b85f34c095a836
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 135177
+  timestamp: 1720102062205
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.3-py310h6a678d5_0.tar.bz2
+  sha256: 80b50780c7fc6c1901375ade7fdd5437df4ad8e6f017f378590962cff2864512
+  md5: e8b510f493980e17601690493fc2bd55
+  depends:
+  - bottleneck >=1.3.6
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numexpr >=2.8.4
+  - numpy >=1.22.4,<3
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - pyxlsb >=1.0.10
+  - beautifulsoup4 >=4.11.2
+  - jinja2 >=3.1.2
+  - dataframe-api-compat >=0.1.7
+  - pyarrow >=10.0.1
+  - pytables >=3.8.0
+  - pandas-gbq >=0.19.0
+  - zstandard >=0.19.0
+  - numba >=0.56.4
+  - html5lib >=1.1
+  - psycopg2 >=2.9.6
+  - blosc >=1.21.3
+  - adbc-driver-postgresql >=0.8.0
+  - pymysql >=1.0.2
+  - qtpy >=2.3.0
+  - scipy >=1.10.0
+  - lxml >=4.9.2
+  - fastparquet >=2022.12.0
+  - xlrd >=2.0.1
+  - s3fs >=2022.11.0
+  - xlsxwriter >=3.0.5
+  - gcsfs >=2022.11.0
+  - sqlalchemy >=2.0.0
+  - adbc-driver-sqlite >=0.8.0
+  - python-calamine >=0.1.7
+  - odfpy>=1.4.1
+  - pyqt >=5.15.9
+  - openpyxl >=3.1.0
+  - fsspec >=2022.11.0
+  - matplotlib-base >=3.6.3
+  - tabulate >=0.9.0
+  - pyreadstat >=1.2.0
+  - xarray >=2022.12.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14982562
+  timestamp: 1732736711665
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandoc-2.12-h06a4308_3.tar.bz2
+  sha256: 6ff476d6dcc9b5d7979206f1dbba837b32a3b78202ec5922089a5ec28b71431d
+  md5: 82bd82d1c2037a4bb712619c0e336957
+  license: GPL-2.0
+  license_family: GPL
+  size: 12963129
+  timestamp: 1677512220201
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.5.3-py310h06a4308_0.tar.bz2
+  sha256: a4420a31c7caad24c7b205269c63573e9801f069b5f7e1105646cf7ef685b0a5
+  md5: bc2719e1b75fe92ccedba1e4863628ce
+  depends:
+  - bleach
+  - bokeh >=3.5.0,<3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.1.0,<3.0
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing-extensions
+  constrains:
+  - holoviews >=1.18.0
+  - bokeh-fastapi >=0.1.2,<0.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23690561
+  timestamp: 1730380897501
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.1-py310h06a4308_0.tar.bz2
+  sha256: 9eea383212337e0612798d5067c26ca4eed4ef76650b53a477680f7c3e9507d4
+  md5: 25b6dbf04b1c2123e07c7615173a628e
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 194256
+  timestamp: 1719348006787
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py310h06a4308_0.tar.bz2
+  sha256: ac86ebb902e8517d9bc9f7fc2fe98f3ceaabcfe4eaa490c0362ec7803b3e2187
+  md5: e2efa085f753f2b05e77c44253dc2edc
+  depends:
+  - locket
+  - python >=3.10,<3.11.0a0
+  - toolz
+  constrains:
+  - pandas >=0.19.0
+  - numpy >= 1.9.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36043
+  timestamp: 1698702598285
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-11.0.0-py310hfdbf927_0.tar.bz2
+  sha256: d010f7590ef9efa98b5296c1a4f6d7696dfc22e05343da5a7488066762a297b3
+  md5: 31cd626fc6a2a8068aef35ae07f9b06d
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 844432
+  timestamp: 1731594865769
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.2-py310h06a4308_0.tar.bz2
+  sha256: c21583dfc86e0fc66964bc126dd20d4c49a767e5d1327ae40a708f0b7f4f32b1
+  md5: 69f8d3389c81cf160e9de5d24ae9ff3f
+  depends:
+  - python >=3.10,<3.11.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2345915
+  timestamp: 1723484761772
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py310h06a4308_0.tar.bz2
+  sha256: 95ee7eb5dc731152d97631e2c59572b4838b5cf96f0c7fabb7eb0258590e8267
+  md5: 93b487d749f5b5c021ec09b98b7aa5ad
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 32180
+  timestamp: 1692205504671
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.21.0-py310h06a4308_0.tar.bz2
+  sha256: 44a018528f337daca27c9b38690ac6bd10483b58bffc8aa5af6df6cb98831869
+  md5: 8834be397a2d4d0799f56251422a1cb6
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 90571
+  timestamp: 1731953200226
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py310h06a4308_0.tar.bz2
+  sha256: 622f1a83be156ad2894921a57942014edab0fb84f0aeb2a8d3e332f717179919
+  md5: b1074332ad725945bcfd509de6458031
+  depends:
+  - python >=3.10,<3.11.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 598751
+  timestamp: 1704404449548
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/propcache-0.2.0-py310h5eee18b_0.tar.bz2
+  sha256: ba646db551a83b5d07a2f4e919cbe90fa06d70f3752bd93732f489880091113e
+  md5: 3dcd429ffa02c788adb83ee071b48378
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 57401
+  timestamp: 1732304021743
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/protobuf-3.20.3-py310h6a678d5_0.tar.bz2
+  sha256: f97e7b2536ec3cdd0865e9d4f3e90cc01a701d5519e63b51da54f4a3c20ab520
+  md5: 4f0c0b5bcf17da3353117e50d6749dcd
+  depends:
+  - libgcc-ng >=11.2.0
+  - libprotobuf 3.20.3.*
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 347650
+  timestamp: 1675281211637
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py310h5eee18b_0.tar.bz2
+  sha256: d7501cd6012bb906574da7792b3c66d9a31bfabb1497882818e0d6976b686e5d
+  md5: ea6ee93562a9c94d730b0e2dcfb68941
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 393604
+  timestamp: 1656431395375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-11.0.0-py310h468efa6_1.tar.bz2
+  sha256: 695246578c0ba447d3e342a3f52c8693bd529724ab8bf52e9d868d1cc90cf282
+  md5: f7350e84855e3448fee8286ac6692bdd
+  depends:
+  - arrow-cpp >=11.0.0,<11.0.1.0a0
+  - boost-cpp
+  - gflags
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4769890
+  timestamp: 1693273939951
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py310h06a4308_1.tar.bz2
+  sha256: eba38026b96d0b3543a2a529cde8a1d82654da5cbb3030ecfe67b4247f0c8f50
+  md5: a719d98f31e467f11ddf83a7e5893b49
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1887228
+  timestamp: 1684280033582
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyjwt-2.9.0-py310h06a4308_0.tar.bz2
+  sha256: 57aff27b79a6c1a93e937b02676cd575032b899e60fd19c40f1697273e2f554a
+  md5: 559123a6fcd4e65e6dc5f45837c68e61
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - cryptography >=3.4.0
+  license: MIT
+  license_family: MIT
+  size: 76419
+  timestamp: 1730786815994
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py310h06a4308_0.tar.bz2
+  sha256: 39de2ecacca6f1a1e3cb00d90d9aa37eafd270b4dd73d34dd34b8f9ba3b39851
+  md5: 296f73e59bf7f4ab81960e2a1f03aed4
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94805
+  timestamp: 1690223492156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.2.0-py310h06a4308_0.tar.bz2
+  sha256: b1cb50a07c2fa2efd45f41171c9173679e1ee79f30391894c970d623daaabd3f
+  md5: 72b3c7645f594bc200f8b0baac0de987
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 425922
+  timestamp: 1731445592173
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py310h06a4308_0.tar.bz2
+  sha256: d01fa02148ff1717b3c13b3afc1d9f7189fa7b15d1a612d79793f6c1534875d7
+  md5: 5ad7b13cb48fc3f12d94907489550019
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 28253
+  timestamp: 1640793693853
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.10.13-h7a1cb2a_0.tar.bz2
+  sha256: eb1e12c7bc55dbf9478f5f1c6dc0d6126f5d4985b2a1e4dcfd5e76308cde741b
+  md5: b64a887f2902a46e0d1ea43a9fe88849
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.35.1
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 29074384
+  timestamp: 1694439228262
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py310h06a4308_2.tar.bz2
+  sha256: 3d3157145577a8a683deaa078c1d1221b8e1a35bdb36c530d55ec2a6471a16e4
+  md5: 254b3b65bd03143d723337c95b02d206
+  depends:
+  - python >=3.10,<3.11.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 289681
+  timestamp: 1716495830895
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.20.0-py310h06a4308_0.tar.bz2
+  sha256: 68132795eda89b7e0d56191a5286c5edb519f1970bf891db67d823bc0d097466
+  md5: 65efa10f84ac28ae312943aba805616e
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 267290
+  timestamp: 1731939387047
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-flatbuffers-24.3.25-py310h06a4308_0.tar.bz2
+  sha256: 9b6972b85c0b420e91e3cfb39fd6d8b9d7606d98709197e89e36aec5f7508431
+  md5: 05313ac9098072a7b0bd39a5d2828536
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 53433
+  timestamp: 1722369206148
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py310h06a4308_0.tar.bz2
+  sha256: eb676ada2db32f77e30dd7f9660feee8bdcb41bf78cb92e693005718f4b2e551
+  md5: 0488050433d26a279e18122cb3a8adac
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 15334
+  timestamp: 1683823906607
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py310h6a678d5_0.tar.bz2
+  sha256: f4d4b377cc3746a0806dc579f4cb9cb7498f7cde3067ea3fb5327c1b481a916b
+  md5: df2d51a297f644a8ef584f62eac40ebf
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 139256
+  timestamp: 1682522463264
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-snappy-0.6.1-py310h6a678d5_0.tar.bz2
+  sha256: 2f171053aca8ea83237e46813228d878c89ce2f90ea1b1e7124a99cca9ecf343
+  md5: 7f5b4cc5c57e4f4033265333739c0790
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  - snappy >=1.1.9,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 31806
+  timestamp: 1670944042197
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py310h06a4308_0.tar.bz2
+  sha256: 8b180ea4d00530724401932d69b5041d4f33eed1ee12d3dad6491cf172175f5c
+  md5: 5e95005903883d6f2bfa16ec1acf4a84
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 261835
+  timestamp: 1713974415056
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py310h06a4308_0.tar.bz2
+  sha256: c86bbd0a36bebb52e10ea1bf7a65389b6b678a39560d6e8958e40ba8ba243555
+  md5: e70ea9e3f1ad7084a5e6ee6400c99499
+  depends:
+  - param
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 60589
+  timestamp: 1711136949672
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py310h5eee18b_0.tar.bz2
+  sha256: 907a3739b1ba6b35da0b945801c76be949eb223e31edd08068a2c722df4feeb7
+  md5: 643fc9d0796daee0cf623fa174b2e1fd
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 191566
+  timestamp: 1728658021098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-25.1.2-py310h6a678d5_0.tar.bz2
+  sha256: fbeaa3c8b3cfe5cbd744990b7b0a51a24ef9ec951125764a5918940545a53470
+  md5: 4564067a1e894a5d456ab659bfe39013
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 481899
+  timestamp: 1705605213656
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+  sha256: 8a640736bef635346409582dbfe2b7d0ecc9da215c90173ff8a9a5fe22569107
+  md5: 6b583dce61c6feb352ef0f49f413af1e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-3-Clause
+  size: 235004
+  timestamp: 1652449537852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+  sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
+  md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 467661
+  timestamp: 1666648052561
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py310h06a4308_0.tar.bz2
+  sha256: 402250d96d94d4b2bcc75f9d0556eb56a4d85440bcdc28f859273d1caf305a63
+  md5: c04e2f621cd73f164cd5a5edc0343027
+  depends:
+  - attrs >=22.2.0
+  - python >=3.10,<3.11.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 58242
+  timestamp: 1699012076797
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py310h06a4308_1.tar.bz2
+  sha256: 13d64bd22d4c0c846aa360de8c1f2915fc2d33017e32e4036258a0c12a623740
+  md5: 7305fb0064965c1bb4cd777439915988
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.10,<3.11.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 98398
+  timestamp: 1730999204520
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-oauthlib-2.0.0-py310h06a4308_0.tar.bz2
+  sha256: 59da86e16485767158e45894e14bae130be9abd3e03f78d3535d383dcd1ffce7
+  md5: b10f04cef0b8dc3592c993c0a19d8a8c
+  depends:
+  - oauthlib >=3.0.0
+  - python >=3.10,<3.11.0a0
+  - requests >=2.0.0
+  constrains:
+  - cryptography >=3.0.0
+  - pyjwt >=2.0.0,<3
+  license: ISC
+  license_family: Other
+  size: 34204
+  timestamp: 1720615066901
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py310h06a4308_0.tar.bz2
+  sha256: 0c8e89e2795a59c995078e0433ea4baaba3e24cc5f9890bf714d8c6aacdff786
+  md5: 836d6322df28a02fddfc5ba4cfc19db6
+  depends:
+  - python >=3.10,<3.11.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 8984
+  timestamp: 1683077147812
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py310h06a4308_0.tar.bz2
+  sha256: 2f18f6e75730725b37333f8ddd744e299144ddb3313a318cb083581e85568ed3
+  md5: 67222dc42d8db7e4023f3b5243871532
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 9327
+  timestamp: 1683059043499
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py310h4aa5aa6_1.tar.bz2
+  sha256: ad40de246c99d48d5e301b59bd190e6639c78ede2a9fbc3c367f7fba75c2a057
+  md5: d58c354dca1cbe610ab6e04fd9b4654f
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 340562
+  timestamp: 1732227709147
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/s3fs-2024.6.1-py310h06a4308_0.tar.bz2
+  sha256: e660dc80febe426b5a5c2cc25e8d05840c5bcee6c7c3e813db830aba8c289081
+  md5: a72dcba559648cefb7f6e268663c6462
+  depends:
+  - aiobotocore >=2.5.4,<3.0.0
+  - aiohttp !=4.0.0a0,!=4.0.0a1
+  - fsspec 2024.6.1.*
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 56087
+  timestamp: 1724924199640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scikit-image-0.24.0-py310h1128e8f_0.tar.bz2
+  sha256: e837940ab90554118f8f5992f1a9196127498235545e671780441548ae858216
+  md5: 8526a55b1b851536668c44057a685408
+  depends:
+  - _openmp_mutex
+  - imageio >=2.33
+  - lazy_loader >=0.4
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - networkx >=2.8
+  - numpy >=1.23,<2.0a0
+  - packaging >=21
+  - pillow >=9.1
+  - python >=3.10,<3.11.0a0
+  - scipy >=1.9
+  - tifffile >=2022.8.12
+  constrains:
+  - dask-core >=2021.1.0
+  - cloudpickle >=0.2.1
+  - pywavelets >=1.1.1
+  - scikit-learn >=1.1
+  - matplotlib-base >=3.6
+  - pooch >=1.6.0
+  - astropy >=5.0
+  license: BSD-3-Clause AND MIT AND BSD-2-Clause
+  license_family: Other
+  size: 12812624
+  timestamp: 1726738776142
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.14.1-py310h5f9d8c6_0.tar.bz2
+  sha256: e93ed4dae46493ba97a7efa21152cac31adce31b53ef90261792bcc0ab38ecbf
+  md5: 52e22b678011f8f125abcb4329dd716f
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libgfortran-ng
+  - libgfortran5 >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 26084446
+  timestamp: 1731625296820
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py310h06a4308_0.tar.bz2
+  sha256: 808e8ca9ac8a80d159d53b58f0f63b6acd642d59f769b6e266b775bf29038844
+  md5: 7610d29a9f5e8a69f797096c71923259
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27051
+  timestamp: 1699371176922
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-75.1.0-py310h06a4308_0.tar.bz2
+  sha256: b0700617c1838cf150e8244bf419b4a2fdbc947daae5e19efb15ebd829ecbaf6
+  md5: 783108bda01170b35e2aaf2daf0d662f
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1763060
+  timestamp: 1726677903257
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
+  sha256: 8fd98235b37194986a5eb663c95a4a6db8c9e20a627f5c79ff8d9be3fd0e36f7
+  md5: 25ac00d957eda056675f8fa3eafdf6df
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 52749
+  timestamp: 1723557449203
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py310h06a4308_0.tar.bz2
+  sha256: 729ac3456b8ea0fe397944736f7bcc1561527a29e96fde5f84d48bcf8622b94a
+  md5: 5a86b542edbb5571edff77b429feb3cb
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 16713
+  timestamp: 1705431361480
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py310h06a4308_0.tar.bz2
+  sha256: 7b2292b384f32587828c2c7a1a099bead9d2071a8969af87349f00fe9fcd98b2
+  md5: 5106026a40ffd8c8ea10c146563947cf
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 66920
+  timestamp: 1696347609464
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+  sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
+  md5: f86119b3243fe3508160aa0406245738
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1723866
+  timestamp: 1714488309729
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+  sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
+  md5: 041a3caf09dc9ce8fc6c10925c4fe050
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1888016
+  timestamp: 1680167274961
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorboard-2.12.1-py310h06a4308_0.tar.bz2
+  sha256: cad6a6a8cac9ddd1e6099f326d5c5e2b68a149e7f22905c1374f0df978cacaef
+  md5: 677b958754d65dbb03022a8724606b83
+  depends:
+  - absl-py >=0.4
+  - google-auth >=1.6.3,<3
+  - google-auth-oauthlib >=0.4.1,<1.1
+  - grpcio >=1.48.2
+  - markdown >=2.6.8
+  - numpy >=1.12.0,<2.0a0
+  - protobuf >=3.19.6
+  - python >=3.10,<3.11.0a0
+  - requests >=2.21.0,<3
+  - setuptools >=41.0.0,<82
+  - tensorboard-data-server >=0.7.0,<0.8.0
+  - tensorboard-plugin-wit >=1.6.0
+  - werkzeug >=1.0.1
+  - wheel >=0.26
+  license: Apache-2.0
+  license_family: Apache
+  size: 5875992
+  timestamp: 1682445887420
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorboard-data-server-0.7.0-py310h52d8a92_1.tar.bz2
+  sha256: edd5f7fc9a6549678be6f8f341d1729b09b5c8e31dc9f3ea4b7a12c762ddaa5b
+  md5: eb1fa8460562b92bc73a95df545f40db
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4951041
+  timestamp: 1724173132550
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorboard-plugin-wit-1.8.1-py310h06a4308_0.tar.bz2
+  sha256: f7b9985f79bf36a524a3dd709ed31ab30d18ea4e7103220233590ce6756d2d66
+  md5: 24511128a6f40262d600ecc9b381f4dc
+  depends:
+  - python >=3.10,<3.11.0a0
+  - setuptools
+  - wheel >=0.26
+  license: Apache-2.0
+  license_family: Apache
+  size: 723387
+  timestamp: 1658918566413
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorflow-2.12.0-mkl_py310hc7ea715_0.tar.bz2
+  sha256: 3a002ee0c782c950c553023acb76f7fc3e9621b10ad9c94bd1532d0bfc3813ed
+  md5: 2427f8d419482fae8ab77beb17ff5b58
+  depends:
+  - _tflow_select 2.3.0 mkl
+  - python 3.10.*
+  - tensorboard 2.12.*
+  - tensorflow-base 2.12.0 mkl_py310he5f8e37_0
+  - tensorflow-estimator 2.12.*
+  license: Apache-2.0
+  license_family: Apache
+  size: 4736
+  timestamp: 1683035606841
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorflow-base-2.12.0-mkl_py310he5f8e37_0.tar.bz2
+  sha256: 2b735c1b601f94066a96023874ca7f6e2b433b6693e1f71d405b1d338234cec2
+  md5: 54b1f753994c48254ae3a2908b481c93
+  depends:
+  - absl-py >=1.0.0
+  - astunparse >=1.6.3
+  - flatbuffers >=2.0
+  - gast 0.4.0.*
+  - giflib >=5.2.1,<5.3.0a0
+  - google-pasta >=0.1.1
+  - grpc-cpp >=1.48.2,<1.49.0a0
+  - grpcio >=1.24.3,<2.0
+  - h5py >=2.9.0
+  - icu >=58.2,<59.0a0
+  - jpeg >=9e,<10a
+  - keras 2.12.*
+  - libcurl >=7.88.1,<9.0a0
+  - libgcc-ng >=9.3.0
+  - libpng >=1.6.39,<1.7.0a0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libstdcxx-ng >=9.3.0
+  - numpy >=1.22,<1.24
+  - openssl >=1.1.1t,<1.1.2a
+  - opt_einsum >=2.3.2
+  - packaging
+  - python >=3.10,<3.11.0a0
+  - python-flatbuffers >=2.0
+  - requests
+  - scipy >=1.7.3,<2
+  - setuptools
+  - six >=1.12.0
+  - snappy >=1.1.9,<2.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tensorboard 2.12.*
+  - tensorflow-estimator 2.12.*
+  - termcolor >=1.1.0
+  - typing_extensions >=3.6.6
+  - wrapt >=1.11.2
+  - libgomp
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 160460278
+  timestamp: 1682464576334
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorflow-estimator-2.12.0-py310h06a4308_0.tar.bz2
+  sha256: bd6a11664fd6547b99bfabd899dafa122f0bb042bc7b87acc44856550624cad6
+  md5: cee5c707043ae91fc738a142c8cee149
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - tensorflow-base  2.12.*
+  license: Apache-2.0
+  license_family: Apache
+  size: 616219
+  timestamp: 1682445997250
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/termcolor-2.1.0-py310h06a4308_0.tar.bz2
+  sha256: ce4a8bb2573f683252aa7e679fc724417f7de2ed990c3b08e3ced96285b54b92
+  md5: c4865b272b37eb679f0802ca8f7ea6e6
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 11126
+  timestamp: 1668084767143
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py310h06a4308_0.tar.bz2
+  sha256: 0baaf2c1c9c5bdd29a149877e8cce8400fd190cb9d451b74af58adc91147984f
+  md5: 00362c34088a3a02bcca1ad72df5f58a
+  depends:
+  - ptyprocess
+  - python >=3.10,<3.11.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30045
+  timestamp: 1671752107828
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tifffile-2023.4.12-py310h06a4308_0.tar.bz2
+  sha256: 1b9c6a4983b335f1c8ea88a22e7dc2e4629c8d97d7fe1a6e34a54d109a3ae175
+  md5: e7bea8d72331e234ae055002f5ef4f87
+  depends:
+  - imagecodecs >=2023.1.23
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - matplotlib-base >=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 390867
+  timestamp: 1695107559781
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py310h06a4308_0.tar.bz2
+  sha256: c839dba354cb1f6b7bf7d7a0fda8c65c1fb1ec2d2165a37cd5abe8ee1ed2ecfc
+  md5: 12d717c4e3873e295865c1666ff125ef
+  depends:
+  - python >=3.10,<3.11.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39119
+  timestamp: 1668168931128
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+  sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
+  md5: e2512d57c8a1e91e7b20e265c6906546
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3588922
+  timestamp: 1714770676475
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tomli-2.0.1-py310h06a4308_0.tar.bz2
+  sha256: 8c907320b7a66bd46b155ad9c4f6774e5abc3ce4a85f8fa9da43e1b98e1836c5
+  md5: c484ebee52415c809546b14d9d87b391
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 24991
+  timestamp: 1657175627477
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py310h06a4308_0.tar.bz2
+  sha256: 76fb218f58792fab0d456e57408e7debdb87c2ecb0497e4855c989b83282118e
+  md5: 38dac546077abb0c9721f655c381c7e6
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 103861
+  timestamp: 1667464115489
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.1-py310h5eee18b_0.tar.bz2
+  sha256: 1a4eb37f7606866aa783f5fa3dc8f4643aeb1525160f0a9cb83a5ca24e8094f8
+  md5: 6e2ab4d379cf7c3136f61e0979d962af
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 700772
+  timestamp: 1718740190483
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.5-py310h2f386ee_0.tar.bz2
+  sha256: 6749bf9f6cb577328d3d6aa858dfda98c343eabb8ccb038341f99460563f08e1
+  md5: 965afdedbcb9af928050b5ca697f6617
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 127158
+  timestamp: 1724854095297
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py310h06a4308_0.tar.bz2
+  sha256: d03a4c457adcaaab213fa99b1aaa060afddb5a99214fc8a30b271639d2f5c2ca
+  md5: 7c2b898dfd6dd4d772a82291e59f9c00
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 167463
+  timestamp: 1718227133814
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py310h06a4308_0.tar.bz2
+  sha256: 5dcc9a52109105999bc0ee901dd860baa404491f46e8839bc344d845edac67f8
+  md5: 60998ef6dade7cba5fc2efca7720d6d5
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing_extensions 4.11.0 py310h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8905
+  timestamp: 1715268910453
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py310h06a4308_0.tar.bz2
+  sha256: 2adc6fddc146748e6407868fb9e7babcec334a7e2d81261e617096f1f4926f9e
+  md5: 573ba9e89697897dd8c5ef719aae698f
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 60418
+  timestamp: 1715268904908
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py310h06a4308_0.tar.bz2
+  sha256: c67bb54cb344ab975ef08503be4a57ee320ef62c9921f26b5aaeb91131481dbe
+  md5: 6a74bf3425ae419af7b95b622b81de24
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 10781
+  timestamp: 1659769481565
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py310h5eee18b_0.tar.bz2
+  sha256: 6f6b159e41f37180c3ab594d9236b4841ea350aa3ff4e934d7b87e54f75c5813
+  md5: ff17193d8822a045e6a4664bb24221fd
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 512367
+  timestamp: 1713213088872
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.3-py310h06a4308_0.tar.bz2
+  sha256: 69c85d6257d993c6a946ea30631eb287fcd4d62d69d29b9fda6bdf9f7f0ee79a
+  md5: 9a4b0a6a87c55741d8bfcea6d368d293
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - requests >=2.26.0
+  - selenium >=4.4.3
+  - zstandard >=0.18.0
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 172981
+  timestamp: 1727769926184
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+  sha256: a8d11b0f08217607b99ba560edf66423ca1e36f4ffbb6e2377e61670e2b5f36b
+  md5: 431e82b081b08aef0259df0437e04c75
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 97535
+  timestamp: 1706894675990
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py310h06a4308_1.tar.bz2
+  sha256: a375f3ad671266b27503b33f62ceaa7be112c0e47836e38a6c6a76225aff927d
+  md5: 49b82f30a2a45b2ce167a876cdc9e21c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21391
+  timestamp: 1640795864430
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py310h06a4308_0.tar.bz2
+  sha256: c1e745d9d00966bfb077d1356a1fe848cc4ea12309f8904d1f33bc0f6ec5dddc
+  md5: 4df68f6567bcf5ef5cd6dc6449e653bf
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 86991
+  timestamp: 1715878322248
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/werkzeug-3.0.6-py310h06a4308_0.tar.bz2
+  sha256: 93c6c33f5098e70cb73c4b76d27e5bd60663d813eeaec00f3c57b5923815f014
+  md5: f2ed8091f722dbcf0d703d19efaaa735
+  depends:
+  - markupsafe >=2.1.1
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - watchdog >=2.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 347938
+  timestamp: 1731005882186
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.44.0-py310h06a4308_0.tar.bz2
+  sha256: b5e0d29bb2be1228862df02593f1f6e1ad45f61292aceebfe1ff280f61da354c
+  md5: a62ba07c41bc8187ab4ab2acffe6d457
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 105530
+  timestamp: 1726165099666
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/widgetsnbextension-4.0.10-py310h06a4308_0.tar.bz2
+  sha256: cc16282761625bd51a4cba0311995c415ff389d9eca25cd211a659589ee5b2c4
+  md5: 6b7d1b8791acac86b51b0ae5aee2207c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1930328
+  timestamp: 1709323002761
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wrapt-1.14.1-py310h5eee18b_0.tar.bz2
+  sha256: d124a4c35ad87af326dab95842b1cd26e8ea730ba3df29d79043e9baebd7f862
+  md5: d841452d35f0316511e36dd6f085f0f1
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 88964
+  timestamp: 1657814488569
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py310h06a4308_0.tar.bz2
+  sha256: 99aeddd48fdb5599e4a4a61bb7b763ca6d5956c4d04aed8aac383843b966a087
+  md5: 23e2468c2df96e0a149dcdf731a879af
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1804197
+  timestamp: 1689041511624
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py310h06a4308_1.tar.bz2
+  sha256: 3a40d7ba77be22b17da9ad610218f01b4401b05a27eaeadafa417140dac1d8b0
+  md5: 19e7ea26af10c4cab50f154f358048b3
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 47939
+  timestamp: 1675159089417
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+  sha256: 9122d6e9dabb7a47f2bcb15d86b97c96c49a9048da3f8ae59675351710c14cc5
+  md5: 660b2aead2ec87b751c86cd33934f44e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 716926
+  timestamp: 1714510796277
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yarl-1.18.0-py310h5eee18b_0.tar.bz2
+  sha256: 87225ff70e79c5c58b5ffb5a3d8e6796490b216d0d9fb673364b9d4d4f918112
+  md5: 03a3b2b614a6591a2c2f975ede388d92
+  depends:
+  - idna >=2.0
+  - libgcc-ng >=11.2.0
+  - multidict >=4.0
+  - propcache >=0.2.0
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 143625
+  timestamp: 1732547051189
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zarr-2.13.3-py310h06a4308_0.tar.bz2
+  sha256: 93c184172b3f1f6b231b20a4c64e76e0dc0845731bd66c6b6844329863f718e1
+  md5: e91564f604f2ae189eefc46505dd1127
+  depends:
+  - asciitree
+  - fasteners
+  - numcodecs >=0.10.0
+  - numpy >=1.7,<2.0a0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 342714
+  timestamp: 1669363788544
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+  sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
+  md5: 943f1247a22b6b64171363bcee1eec27
+  depends:
+  - libgcc-ng >=11.2.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=11.2.0
+  license: MPL-2.0
+  license_family: Other
+  size: 371663
+  timestamp: 1705602144682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zfp-1.0.0-h6a678d5_0.tar.bz2
+  sha256: 807521a07138f611cad037b15de8f478fc985cedb00bce3f6256c0ea14f09825
+  md5: 3a844b7ddc088e7cf5dca84d8c4e3fcd
+  depends:
+  - _openmp_mutex
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libgomp
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 305779
+  timestamp: 1681741638187
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py310h06a4308_0.tar.bz2
+  sha256: dd89ee9a721abb1007addbf785825f0435e9c6acb75f89cf9836f53efa004d01
+  md5: 0013ca0c5215bfc8d1df79b2a34d5209
+  depends:
+  - heapdict
+  - python >=3.10,<3.11.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 77624
+  timestamp: 1695832955061
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.21.0-py310h06a4308_0.tar.bz2
+  sha256: 1f8ffae8697d1f29074f7be8922292c70323c478e402a70f4d60b2f665f24559
+  md5: 4a45201520d2a7dee35eb7ecb3968c3e
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 25876
+  timestamp: 1732630793227
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+  sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
+  md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Zlib
+  license_family: Other
+  size: 127143
+  timestamp: 1714510716441
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
+  sha256: a65c6277a3045e4ea72f617f977134c18366d8142ce51512f5a3cf325226a8bf
+  md5: d941bb6fdc55cc1b3f67b3beb23d1795
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1081416
+  timestamp: 1728487031624
+- conda: https://repo.anaconda.com/pkgs/main/noarch/aioitertools-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: db0f4480d25a6fa447ce92d729c2bc7dcb2e47f958ccad99688fbb29bab6107a
+  md5: 572c3084a7886f8fd8547cc1deed4a7d
+  depends:
+  - python >=3.6
+  - typing_extensions >=3.7
+  license: MIT
+  license_family: MIT
+  size: 19602
+  timestamp: 1607109696386
+- conda: https://repo.anaconda.com/pkgs/main/noarch/aiosignal-1.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: e100b4cc8eed4c65dbc4c34fc09425488d9863b94bbe2b67f3a971ea396f44c6
+  md5: 69ca1242900a1537435a8cdc6901100a
+  depends:
+  - frozenlist >=1.1.0
+  - python >=3.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 12671
+  timestamp: 1637843091841
+- conda: https://repo.anaconda.com/pkgs/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 8f312df57fbcba29977fcc1a66017f231820699053ca3b91450fabc16ec09858
+  md5: a1914956aa26b608c4f2d17edadca061
+  depends:
+  - python
+  license: MIT
+  size: 12124
+  timestamp: 1629143509659
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asciitree-0.3.3-py_2.tar.bz2
+  sha256: dca6fab6ba10ac9af6ddb18b40f81a7e240eb954fc46f476745e2ec6de0b25b2
+  md5: c39f5ec48b011f1fe24dee7949378176
+  depends:
+  - python
+  license: MIT
+  size: 9873
+  timestamp: 1548714427462
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/astunparse-1.6.3-py_0.tar.bz2
+  sha256: ec789985c21bb166390cb69798f2233895bc06afef3b706bf5dde7c3f9daceb9
+  md5: ccbf3a1406a1db9c42dcad71268bf6e0
+  depends:
+  - python
+  - six >=1.6.1,<2.0
+  license: BSD-3-Clause AND PSF-2.0
+  size: 17457
+  timestamp: 1589913528863
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+  sha256: c0dd89ffac001588171152a285ddbbaea209ebe4116010f985f898b7e87c2f35
+  md5: 731ae7d446633bc729f3493a52d4365b
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 43502
+  timestamp: 1721748373551
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/fasteners-0.16.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 2175d81bc02b27e9a6cc724175dda066e7d3c7d000bc2f713467c51660bf68c7
+  md5: 11d4c33907e93548617df4852c881804
+  depends:
+  - python >=3.6
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 26106
+  timestamp: 1623953511907
+- conda: https://repo.anaconda.com/pkgs/main/noarch/gast-0.4.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1d68d1f43a64e5498c2c88992d607a7735119a07a6c53fc19021fda5ba307c9c
+  md5: 10a82aba1ec39fab9d158f349dc5233b
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12520
+  timestamp: 1628588912772
+- conda: https://repo.anaconda.com/pkgs/main/noarch/google-auth-oauthlib-0.4.4-pyhd3eb1b0_0.tar.bz2
+  sha256: b0f252702586d3bcc752c3931884155420005e643c3b4bed139e6ec983410e04
+  md5: a9379b5ad5373d3e7879447115b4928c
+  depends:
+  - click
+  - cryptography >=3.2
+  - google-auth
+  - python >=3.6
+  - requests-oauthlib >=0.7.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 19488
+  timestamp: 1617120604882
+- conda: https://repo.anaconda.com/pkgs/main/noarch/google-pasta-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 2ac7dff32915a322178e1efb33472527e8906e6b72bf4991fd3ff8c4a76bf3a9
+  md5: e0813186a62e13665a4e886815c50abc
+  depends:
+  - python
+  - six
+  license: Apache-2.0
+  license_family: APACHE
+  size: 43929
+  timestamp: 1630578016443
+- conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 9de8666e5b70aa2437737128eaa14ffe80a7b5235c2a6b7d3f39ccefd7816ba0
+  md5: bb52e50c5ab1a5c7778c11376404dfdb
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 7933
+  timestamp: 1630598543551
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+  sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
+  md5: 33624a42ee387bf9918ea98b4e7b31fc
+  depends:
+  - pygments >=2.4.1,<3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8173
+  timestamp: 1601490751973
+- conda: https://repo.anaconda.com/pkgs/main/noarch/keras-preprocessing-1.1.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 5d66b8a7734e9e9bcfe8191cbce8e2d6596cc6ead93fd7d245175f77f9faa780
+  md5: 85e0c4015cf695750f966b7a2ca48950
+  depends:
+  - numpy >=1.9.1
+  - python >=3.6
+  - scipy >=0.14
+  - six >=1.9.0
+  constrains:
+  - keras >=2.1.6
+  license: MIT
+  license_family: MIT
+  size: 35457
+  timestamp: 1612283681320
+- conda: https://repo.anaconda.com/pkgs/main/noarch/nbconvert-7.16.4-hd3eb1b0_1.tar.bz2
+  sha256: 66982437d81697601d01945283763aa01d4ee03b1a05a48e69809bb9c4d897ab
+  md5: 03a7057ac107d2f1409665f6f169dc21
+  depends:
+  - nbconvert-core 7.16.4 py310h06a4308_1
+  - nbconvert-pandoc 7.16.4 hd3eb1b0_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7126
+  timestamp: 1732709527394
+- conda: https://repo.anaconda.com/pkgs/main/noarch/nbconvert-pandoc-7.16.4-hd3eb1b0_1.tar.bz2
+  sha256: 8e93e86e261df0844328479598554b4f79eb6adb956a05ec81efc734ad87453a
+  md5: f82db1f6d41ceb9c4cb45bae61c41cf0
+  depends:
+  - nbconvert-core 7.16.4 py310h06a4308_1
+  - pandoc
+  license: BSD-3-Clause
+  size: 7151
+  timestamp: 1732709526799
+- conda: https://repo.anaconda.com/pkgs/main/noarch/opt_einsum-3.3.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 361ff5c0a130348810b2502b914ebc729342600d160ffe3345a2abc2239d9bc2
+  md5: 7a6355d8a9d091647226c634345213f8
+  depends:
+  - numpy
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 58106
+  timestamp: 1621500274746
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+  sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
+  md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
+  depends:
+  - prompt-toolkit >=3.0.43,<3.0.44.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5106
+  timestamp: 1704404390460
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pyasn1-0.4.8-pyhd3eb1b0_0.tar.bz2
+  sha256: a32ddfecb6ed99a6d192d352bf5afa2e53760d1d5ddf0202fb13bb0fd7d23a2a
+  md5: 4a84e67c47feb540be5d11d6f53535a5
+  depends:
+  - python
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 55350
+  timestamp: 1629708025637
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pyasn1-modules-0.2.8-py_0.tar.bz2
+  sha256: 6af43ddec74992b2752c67385ba8565570545eb83984cb37eee057a452800f03
+  md5: 4c5ff5474d4df03476d42c6c02c1878c
+  depends:
+  - pyasn1 >=0.4.6,<0.5.0
+  - python
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 68670
+  timestamp: 1600458175964
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://repo.anaconda.com/pkgs/main/noarch/rsa-4.7.2-pyhd3eb1b0_1.tar.bz2
+  sha256: 0623e679566b1823c633b3afa0210ccedcc765cfffbe1eb6d930bc38544554e7
+  md5: 45f93f7851c1420317c50d8919ebe52c
+  depends:
+  - pyasn1 >=0.1.3
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 28505
+  timestamp: 1614366267903
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 4e47f6c49ce84509f1466e8a4d728447bf4bcd9bce7b456431a789a262547067
+  md5: 4cad993b0f80bc23fb66a97592299cbb
+  depends:
+  - python >=2.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 26504
+  timestamp: 1623949147884
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+  sha256: ca2be6c7810a37cfc6db1f5383937b5d35c6d73c1fad8a9104de85f069b1df1c
+  md5: 9ccb2fb33edb152403d6ef32bf758a9d
+  depends:
+  - python
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 15614
+  timestamp: 1629402049497
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tensorboard-plugin-wit-1.6.0-py_0.tar.bz2
+  sha256: b1cd619d0fd8cc07a9221e9b46d666647b74f1eb78676e8e98c235e51cf26b05
+  md5: d6d311cce452a29369c3425c41e6204a
+  depends:
+  - python >=3
+  - setuptools
+  license: Apache 2.0
+  license_family: Apache
+  size: 678459
+  timestamp: 1590157851387
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+  sha256: bf3130b8c44a7e9bcd496f515d0ee4b2e788610f468bafd708d16d007cb47332
+  md5: 48f856789d224eae8d1979c212205fde
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 123651
+  timestamp: 1728062827250
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wheel-0.35.1-pyhd3eb1b0_0.tar.bz2
+  sha256: f596b4e7fcd72e69f405bbe37ecd9e61443ccbdb8a1cecb7554dd20f1d161bdb
+  md5: 4b8b35af9c0ea16f368eece1b331605d
+  depends:
+  - python
+  license: MIT
+  size: 37378
+  timestamp: 1605289315954
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/_tflow_select-2.2.0-eigen.tar.bz2
+  sha256: 0c6682bf48ae7bb2d44ea1f06897fd887ca63b3c749018b0951fe4cbdb0e4808
+  md5: 34203ba34d2a42af01b219940dfc4f4a
+  size: 3004
+  timestamp: 1538712271476
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/abseil-cpp-20211102.0-he9d5cce_0.tar.bz2
+  sha256: 92e2d6a5550c1edcd9ed0cbc8381a12d5ade0a62e68b399dbd24db9a01543cdf
+  md5: e2f0c404d039f95ae751384060ae2bac
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1035020
+  timestamp: 1652382905031
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/absl-py-2.1.0-py310hecd8cb5_0.tar.bz2
+  sha256: 2667ddb06b4c6b3c2861aca66bbc1338dccaae9a3b6b68a78c38224713352413
+  md5: 22469370aeb4c1f5d117c52102a5a165
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 188877
+  timestamp: 1714140609305
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aiobotocore-2.12.3-py310hecd8cb5_0.tar.bz2
+  sha256: 983564404ad498ef3a96f682f647886eeec6940f023d0b9cdba3558e92f9ed85
+  md5: 6a61700dd2d180b1b017492ed2732f75
+  depends:
+  - aiohttp >=3.7.4.post0,<4.0.0
+  - aioitertools >=0.5.1,<1.0.0
+  - botocore >=1.34.41,<1.34.70
+  - python >=3.10,<3.11.0a0
+  - wrapt >=1.10.10,<2.0.0
+  constrains:
+  - boto3 >=1.34.41,<1.34.70
+  license: Apache-2.0
+  license_family: Apache
+  size: 111964
+  timestamp: 1714464434338
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aiohappyeyeballs-2.4.3-py310hecd8cb5_0.tar.bz2
+  sha256: 0f0642a14655b681c6692f84034dafa8d4b1a32d68f22d5261f8ccde73176f0c
+  md5: 2c7331060612abb98063f9082c0eee11
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: PSF-2.0
+  license_family: Other
+  size: 26342
+  timestamp: 1732662030058
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aiohttp-3.10.5-py310h46256e1_0.tar.bz2
+  sha256: de2f7b6391b1dbb427a2a15dc3dfa8f0cdbedf7621296c04de9fda3b842f05b4
+  md5: d976e71fccb21dd8ac86e9e7f3d3cc71
+  depends:
+  - aiohappyeyeballs >=2.3.0
+  - aiosignal >=1.1.2
+  - async-timeout >=4.0,<5.0
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - multidict >=4.5,<7.0
+  - python >=3.10,<3.11.0a0
+  - yarl >=1.0,<2.0
+  constrains:
+  - aiodns >=3.2.0
+  license: MIT AND Apache-2.0
+  license_family: Other
+  size: 742029
+  timestamp: 1725528062334
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.6.2-py310hecd8cb5_0.tar.bz2
+  sha256: 00b536bb4e440d8bdc936ccabfae53277efea893bf4192c5fe4366340f7adb26
+  md5: 50bb380e6d6d69e919487b90e4ea2cc3
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.10,<3.11.0a0
+  - sniffio >=1.1
+  - typing_extensions >=4.1
+  constrains:
+  - uvloop >=0.21
+  - trio >=0.26.1
+  license: MIT
+  license_family: MIT
+  size: 192586
+  timestamp: 1729121529214
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aom-3.6.0-hcec6c5f_0.tar.bz2
+  sha256: e9e15fb1d52051c9dbb25b1f2e613eb60cf8dbe0793062c3a274e61e6a0871dc
+  md5: cb548680c2222c567784653166056c1a
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3463290
+  timestamp: 1688660834942
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py310hecd8cb5_1001.tar.bz2
+  sha256: 09c3f6c4328480f28458ea1610756de82424aef128aa9cded81f8f0766a81485
+  md5: d6b76a162e56bfc828c021c67e0c68ac
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10049
+  timestamp: 1642500631813
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py310hca72f7f_0.tar.bz2
+  sha256: 4de7fc8c8f18ca65bf023bbc60d0e4bf7d17ea01323f264668df29b736cc6580
+  md5: 7f6d95177dc7630deefb205c1e2bdbab
+  depends:
+  - cffi >=1.0.1
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 36335
+  timestamp: 1644569785995
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/async-lru-2.0.4-py310hecd8cb5_0.tar.bz2
+  sha256: 7f2654a2202f6da85a0612aabb58fbc80d3215fb86822ebb79b81b3b8c8960ff
+  md5: 02ee031f92f437f50f045449b6087319
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing_extensions >=4.0.0
+  license: MIT
+  license_family: MIT
+  size: 18536
+  timestamp: 1699554611431
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/async-timeout-4.0.3-py310hecd8cb5_0.tar.bz2
+  sha256: 4164451bcb07c4a0a9300d2d3de69d048f86c865be03c5954e14e4d68bdf021a
+  md5: e6033e6c734af4a109fca7fdef541721
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 13065
+  timestamp: 1703097151196
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.2.0-py310hecd8cb5_0.tar.bz2
+  sha256: f6aebcbfa8259ea6505e4c9d0afff7ca7593f8d04e3fbf2f30555cc00f13ce5f
+  md5: fd894a059ee44363449bee33d6bd34f8
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 143104
+  timestamp: 1729089801754
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/babel-2.11.0-py310hecd8cb5_0.tar.bz2
+  sha256: 08fe5d5d07cd5a4411acb231e14fc6fb2f74ffd6698298c2baa9ee583f4e2596
+  md5: 2d66ecb9459d2832913f67e973000beb
+  depends:
+  - python >=3.10,<3.11.0a0
+  - pytz >=2015.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7121236
+  timestamp: 1671782042229
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py310hecd8cb5_0.tar.bz2
+  sha256: bd9f64f7d4a1db524a8043cdbd44003708f9734b7cef0f34bba2412951b7154b
+  md5: 450f6c095ce62cdbf38ee2fb41efa470
+  depends:
+  - python >=3.10,<3.11.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 218203
+  timestamp: 1718029916816
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
+  sha256: 695ac69739e73351dfebfb01ea39c5e1dbfdcfb475590d6560ae318bfbad3a97
+  md5: 38fd73cba341639c45d8c747b08c9cc1
+  size: 49130
+  timestamp: 1528225884020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bleach-6.2.0-py310hecd8cb5_0.tar.bz2
+  sha256: 80f284948e221e50a375d27ced28b60fc14e9b94c70b7afebab6c94f1591e57b
+  md5: d44ba8f9caf313fdf5186c7f50e857c8
+  depends:
+  - python >=3.10,<3.11.0a0
+  - webencodings
+  constrains:
+  - tinycss2 >=1.1.0,<1.5
+  license: Apache-2.0
+  license_family: Apache
+  size: 298162
+  timestamp: 1732292174114
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blinker-1.6.2-py310hecd8cb5_0.tar.bz2
+  sha256: e8e62d30b2ceef98b36bd0eaf99002b81256776b8c02680939378dcabfac52ba
+  md5: 9a81364fe4be30f83c62b32db8adaf2d
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 29206
+  timestamp: 1696539280528
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
+  sha256: 3699a260f422443de85b74084fe36f734be1a466eeebdfdf4195d52c9fdb5508
+  md5: 132d056e66b3ae9148f53819f8368c94
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - zlib >=1.2.12,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 66125
+  timestamp: 1675247668924
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.4.3-py310hecd8cb5_0.tar.bz2
+  sha256: edadfe22baffa5b8cf9448fe3dcf9e96bf870296452f4b7e50fdc9a33b875502
+  md5: 058f3606d868d73ebd92e397ce9a8115
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3,<2.0a0
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14414029
+  timestamp: 1658136718353
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/botocore-1.34.69-py310hecd8cb5_0.tar.bz2
+  sha256: e5c5bb3e73c2fcdf81ebb0eec4c19e97b42b080e13701dbcc65caf5c0126b152
+  md5: 4742c39f8ebfa46de173b76e3f16ec19
+  depends:
+  - jmespath >=0.7.1,<2.0.0
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.1,<3.0.0
+  - urllib3 >=1.25.4,!=2.2.0,<3
+  license: Apache-2.0
+  license_family: Apache
+  size: 7716227
+  timestamp: 1714461172938
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.4.2-py310hf3fd67a_0.tar.bz2
+  sha256: ac40c8227c080120a516638f6a9190b433ed0b5b7534515cbba1cac9b6081cc3
+  md5: f81b63c81b9bb6dbd2f8b41fc5ef2c87
+  depends:
+  - numpy >=1.21,<3
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 138249
+  timestamp: 1731059410633
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: d8b1ccb15297dcfb3f9ebb8139c3e28a13d6c2e73c37612cb214ab6cc58b15fa
+  md5: e5dec9f13de061640ad2697562a99b54
+  depends:
+  - brotli-bin 1.0.9 h6c40b1e_8
+  - libbrotlidec 1.0.9 h6c40b1e_8
+  - libbrotlienc 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 19732
+  timestamp: 1714483415038
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: e9fda4393edd0234c88efc2b88e0edf42c94eb49ea5b189a80afd733058be8fb
+  md5: 13ceed558eb174d6b77ed1b0035f1785
+  depends:
+  - libbrotlidec 1.0.9 h6c40b1e_8
+  - libbrotlienc 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 18400
+  timestamp: 1714483395748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py310hcec6c5f_8.tar.bz2
+  sha256: fff6fa5c13c50b815aeb12a3c2e90ae8e3b32cf1578ebfb23374b2df366bb259
+  md5: 15c4e2d00fb974cdf15be7a206025648
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  size: 393878
+  timestamp: 1714483673596
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brunsli-0.1-h23ab428_0.tar.bz2
+  sha256: af713241455149cffec30054b5ab2f055a72c1b6bb6f492d9568deaa362597f6
+  md5: 860cc2203395527c259cabd8e3e16a36
+  depends:
+  - brotli >=1.0.9,<2.0a0
+  - libcxx >=10.0.0
+  license: MIT
+  license_family: MIT
+  size: 184792
+  timestamp: 1611240502908
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+  sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
+  md5: c5a600d81b1b48578863af2973c743ac
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 187637
+  timestamp: 1714510590009
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+  sha256: f913b61ba3c1651b36688415cc163a5d575475f7573b543f48a80e7a5002e4bb
+  md5: f11d165eaa532ce04a35382841284298
+  license: MIT
+  license_family: MIT
+  size: 107047
+  timestamp: 1693902034820
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.11.26-hecd8cb5_0.tar.bz2
+  sha256: 6012ec121e1edf165b6f877f2ce9686acdedb461ae0406ee188e863bf3d264de
+  md5: 39b94853ef9d5d79a9d8e28c6b2efc2e
+  license: MPL-2.0
+  license_family: Other
+  size: 142680
+  timestamp: 1732804456701
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cachetools-5.3.3-py310hecd8cb5_0.tar.bz2
+  sha256: dd007da9f25806ca6041a2c1e80f5777fdbefadb5fd6594e1b7e61eb881f6620
+  md5: 0af03702f1ff87a598764cc187694b89
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 23948
+  timestamp: 1713977135496
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.8.30-py310hecd8cb5_0.tar.bz2
+  sha256: e55976b8cb38daae501a302eda22ce71077b9189485cf4f566304c2ca7c1da6f
+  md5: eb359e8e2eb6003c09560ef4e25a3ab8
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 168989
+  timestamp: 1725551820641
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py310h9205ec4_0.tar.bz2
+  sha256: 94fe0635e7ee8952321117b8b779a51e2cf56b5ad4a86f8c53a1110033762777
+  md5: e92ca60616b93825ea766112b92f5259
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 233073
+  timestamp: 1726856601250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
+  sha256: 68a12eaeda90c9cdbce729f0d44d222c3f60ec4920bb781bf13fae3a89cb3dd1
+  md5: a0970a5c1c77125369aded2d4e25f870
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=7.82.0,<9.0a0
+  - libgfortran 5.*
+  - zlib >=1.2.12,<1.3.0a0
+  license: Other
+  license_family: Other
+  size: 1437665
+  timestamp: 1655814938182
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cftime-1.6.2-py310h7b7cdfe_0.tar.bz2
+  sha256: f21411a361ac53ac9b128db86533d7048a2c0e94b216da0767363159d58ba10b
+  md5: 302a18a9546c4275f32f9331ec61747e
+  depends:
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 223992
+  timestamp: 1678830614730
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/charls-2.2.0-h23ab428_0.tar.bz2
+  sha256: af3ad515ab2369e09b7a8b373025d1f7851618c2e698c7336d1296cb4f105732
+  md5: bb00d7a0d60266c9bdd9493d3f91f955
+  depends:
+  - libcxx >=10.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 96819
+  timestamp: 1612240391361
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py310hecd8cb5_0.tar.bz2
+  sha256: ebdc1573290d42968d22d4fd21d62ebffb5f73181e62e7fda28d6e3cbab5b611
+  md5: 7d9b37ba7510983192c976da9cb9d9a9
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 155703
+  timestamp: 1698129854193
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.0.0-py310hecd8cb5_0.tar.bz2
+  sha256: 36043113774c4129d90b66b6665ddcd02692eb5f090b121c6ffd71509f334f6f
+  md5: 23e1bce8369429a36a4ff19069a34dbc
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35847
+  timestamp: 1721657465524
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py310hecd8cb5_0.tar.bz2
+  sha256: 38b6b20387ada75d20393cc99de9c8a1f2b7fcd03b28720df4eef55d44ec393e
+  md5: 881ffce8c467163639bd6ed6ef941189
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 499171
+  timestamp: 1709758463351
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py310hecd8cb5_0.tar.bz2
+  sha256: cafb4b7adcb72b498a482a6b846f949e1aee350f96a79d9146b38f969b2e0a90
+  md5: a404bca7f71823adc5ef078d63b788a9
+  depends:
+  - python >=3.10,<3.11.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15750
+  timestamp: 1709322968401
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.3.1-py310h1962661_0.tar.bz2
+  sha256: b417230b26b1ce73a43ef4d6d4aa665d7cb49574ed484612b4f9c5f4ef563171
+  md5: 3063ab79f0ba0cc1349db7b443216df3
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.23
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 282429
+  timestamp: 1732540159621
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py310ha2381d6_0.tar.bz2
+  sha256: a85c2b09aa399485ca1b3ca08c28d76138832217c713ecaf74ddc01bea06e138
+  md5: 913d0518e7530c8ed01852b3b920337e
+  depends:
+  - cffi >=1.12
+  - openssl >=1.1.1v,<1.1.2a
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1310765
+  timestamp: 1694212271586
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.2-py310h6c40b1e_0.tar.bz2
+  sha256: fc3aede2139d7c260dd925c00a3789e0a25076125bb1e3f43a08012bc86c2f1f
+  md5: 8d2d3024214db6a4f151cbe09344c545
+  depends:
+  - python >=3.10,<3.11.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365217
+  timestamp: 1701729423199
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-2023.4.1-py310hecd8cb5_0.tar.bz2
+  sha256: 4e3a22058a5c4b422ebd499d09028de52cafca69e56b9f0556b3c491c9cd3cdb
+  md5: 80c65213359055e79e585d3e8cc339b9
+  depends:
+  - bokeh >=2.4.2,<3.0
+  - click >=8.0
+  - cloudpickle >=1.5.1
+  - cytoolz >=0.12.0
+  - dask-core 2023.4.1.*
+  - distributed 2023.4.1.*
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - jinja2 >=2.10.3
+  - numpy >=1.21,<2.0a0
+  - packaging >=20.0
+  - pandas >=1.3
+  - partd >=1.2.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml >=5.3.1
+  constrains:
+  - openssl !=1.1.1e,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6158
+  timestamp: 1683568527645
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.4.1-py310hecd8cb5_0.tar.bz2
+  sha256: a44f61d8477c87e832e2bfde3a6de10e9efeb7156bff392ca2ca9a9a36ae9630
+  md5: 158698f92f880704eb88f92b3588785f
+  depends:
+  - click >=7.0
+  - cloudpickle >=1.1.1
+  - fsspec >=0.6.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.8.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2132169
+  timestamp: 1683065296769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/dav1d-1.2.1-h6c40b1e_0.tar.bz2
+  sha256: 53b960dc320a73701d8faf90316a203b01b294e0a7235c7bf49bb853d71b2214
+  md5: 7a196bd419ee0f888fbbe0e6d449adda
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 812727
+  timestamp: 1688746099942
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py310hcec6c5f_0.tar.bz2
+  sha256: e2d11b07b8139917def31e4f4c1318396eae6762e18c771851cbebfe628cb157
+  md5: e3f9f6c8343ecf7dc8f311670be764fc
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 2068510
+  timestamp: 1690905208269
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2023.4.1-py310hecd8cb5_0.tar.bz2
+  sha256: 61e957bef53b5ccc161c7f71e56ecc76c613d40374febf0eec5c506cb990dc0e
+  md5: c31a0ee860acbd0be86f2ebda86e2704
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - dask-core 2023.4.1.*
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.0
+  - packaging >=20.0
+  - psutil >=5.7.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml >=5.3.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.10.0
+  - tornado >=6.0.3
+  - urllib3 >=1.24.3
+  - zict >=2.2.0
+  constrains:
+  - openssl !=1.1.1e,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1379922
+  timestamp: 1683556840173
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py310hecd8cb5_0.tar.bz2
+  sha256: 670e9476a114ca61020f1a69803661de5cc6f01a26296a4c73bbbda94164dc4e
+  md5: 12f8f558c520d5a1e25ba2967edbee89
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16685
+  timestamp: 1649926502410
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.2.0-py310hecd8cb5_0.tar.bz2
+  sha256: a31f9c19d1b9f9355dee09bc356853ee2c9b4ffc99525810a7189e3d148c2c18
+  md5: 36fd0124a6a901c880c4f80087db5803
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 30923
+  timestamp: 1706031435284
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/flatbuffers-24.3.25-h6d0c2b6_0.tar.bz2
+  sha256: 5a7d31b98c5bef5ec69c8fac1f65f37aa902abd79f2ced30a1b97ede78d8c5cd
+  md5: 74a35f3fc8ab05237ed1115133deff47
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 1804196
+  timestamp: 1722872846711
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py310h6c40b1e_0.tar.bz2
+  sha256: c9d3ce30bb1d76c60769c427ac10e11fb46dd786eaad50eca9698cbc4055335b
+  md5: 2a5cf7b319b1843d17877335fe3c4c89
+  depends:
+  - brotli >=1.0.1
+  - python >=3.10,<3.11.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lz4 >=1.7.4.2
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  license: MIT
+  license_family: MIT
+  size: 2643483
+  timestamp: 1713551859857
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/frozenlist-1.5.0-py310h46256e1_0.tar.bz2
+  sha256: 83e4ed3ef61dae0a57d76b1762746c55cb5ffd4267cb46dd46c9548dc75e4a5f
+  md5: a1abaef83d8b237d1caabf6061ab733d
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 58834
+  timestamp: 1730902924249
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.6.1-py310hecd8cb5_0.tar.bz2
+  sha256: b79899461d51593df6bd8e14d4131e0711ee6e31c4b641fdd132b241fb6104d2
+  md5: 2619cd07314d8884c72c61c0b7af0048
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - pyarrow >=1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 289204
+  timestamp: 1724855637052
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.2-h46256e1_0.tar.bz2
+  sha256: 872ab46bcd652b2381a4a1ee9de3f4399ce089a42959a7df052546aa3886d9ae
+  md5: a7bd95201a6e2c91bb5fef9765426123
+  license: MIT
+  license_family: MIT
+  size: 80346
+  timestamp: 1728656386686
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/google-auth-2.29.0-py310hecd8cb5_0.tar.bz2
+  sha256: 5acdf3d75cfc68e4450fd95b30c7ec632a2be349eb5668dfaf9af26244850192
+  md5: 6b2a3cfed208598128b9d104aef903fc
+  depends:
+  - aiohttp >=3.6.2,<4.0.0dev
+  - cachetools >=2.0.0,<6.0
+  - pyasn1-modules >=0.2.1
+  - pyopenssl >=20.0.0
+  - python >=3.10,<3.11.0a0
+  - requests >=2.20.0,<3.0.0dev
+  - rsa >=3.1.4,<5
+  constrains:
+  - pyu2f >=0.1.5
+  - cryptography >=38.0.3
+  license: Apache-2.0
+  license_family: Apache
+  size: 215667
+  timestamp: 1715111522911
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/google-auth-oauthlib-0.5.2-py310hecd8cb5_0.tar.bz2
+  sha256: 2d7a3d61e520c7572f8d7cf2411f60912b9aac7e5c1988a463152baf7aa4bb74
+  md5: 650ead0b51caed49cbdbdd817864c6cb
+  depends:
+  - click >=6.0.0
+  - google-auth >=1.0.0
+  - python >=3.10,<3.11.0a0
+  - requests-oauthlib >=0.7.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 28214
+  timestamp: 1660687937774
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/grpc-cpp-1.48.2-h3afe56f_0.tar.bz2
+  sha256: 2b96ce3762184c824178323ee109e4b1a72b9fb0e7a7d6d11e44b875e8c46eea
+  md5: a28f3cd1a5385e8effcde5dafd84fb7e
+  depends:
+  - abseil-cpp >=20211102.0,<20211102.1.0a0
+  - c-ares >=1.19.0,<2.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.20.4.0a0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - openssl >=1.1.1t,<1.1.2a
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4015834
+  timestamp: 1681912883786
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/grpcio-1.48.2-py310h3afe56f_0.tar.bz2
+  sha256: a6a94917acda4a140fde8f640bd37e32b1eaf6cab05a76e87187a6d25ae85f4f
+  md5: 9ec6202ebe4e4437047abab31bbaaa5c
+  depends:
+  - __osx >=10.9
+  - grpc-cpp 1.48.2 h3afe56f_0
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  - six >=1.6.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 769339
+  timestamp: 1681912996533
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/h11-0.14.0-py310hecd8cb5_0.tar.bz2
+  sha256: 8e96e00df805d033780a3f98d5600b24206256a95f3678fba5192d14b4b7e280
+  md5: 1251b99eae3e9d95668817f315a23cd0
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 85463
+  timestamp: 1706652358247
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/h5py-3.12.1-py310ha611a00_0.tar.bz2
+  sha256: b781726961625f671b5be5e1ad753c0a8d8010dd82550dba8f818bfff536f68f
+  md5: c9a952f4f564c62ebf4476decf7f8615
+  depends:
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - numpy >=1.19.3,<3
+  - numpy >=1.21,<3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1431283
+  timestamp: 1730216399655
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf4-4.2.13-h39711bb_2.tar.bz2
+  sha256: 85d7f9697d1243b5d088737a3f5c43610f01250f78e9a9fa9da6cca7830d73cf
+  md5: 637b7dadcfe411e14233764fd1d820a3
+  depends:
+  - jpeg >=9b,<10a
+  - libcxx >=4.0.1
+  - zlib >=1.2.11,<1.3.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 895428
+  timestamp: 1510863932515
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf5-1.12.1-h2b2ad87_2.tar.bz2
+  sha256: ec075bff8c2c519e43c9379fbdf37d8c3f00e8893ece3423c7696bc3b51d99c2
+  md5: fbcb090a7d99f1260eaf4b028bbcc3fb
+  depends:
+  - libcurl >=7.82.0,<9.0a0
+  - libcxx >=12.0.0
+  - libgfortran 5.*
+  - openssl >=1.1.1o,<1.1.2a
+  - zlib >=1.2.12,<1.3.0a0
+  license: HDF5
+  license_family: BSD
+  size: 5828704
+  timestamp: 1655307864829
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.17.1-py310hecd8cb5_0.tar.bz2
+  sha256: 4d89c45e4f6ca1b63f69d7dcccbd5934b060e13c5d2711ecf25ea6022af473b8
+  md5: 9eabc7dbf073a8276ef1b5c40bf56982
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4626418
+  timestamp: 1693378265446
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/httpcore-1.0.2-py310hecd8cb5_0.tar.bz2
+  sha256: 4bf99d699c01388de049f2b813bfd2eb89156eda3455d92baff65a10739c9f50
+  md5: a683b4f2d20ddd1bd8952a98fdbb6ca2
+  depends:
+  - certifi
+  - h11 >=0.13,<0.15
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 85818
+  timestamp: 1706728554495
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/httpx-0.27.0-py310hecd8cb5_0.tar.bz2
+  sha256: eac7150b0508a3ecb0f27ec1ff7b22283f2714da57d564bdeae06a6d6b960981
+  md5: 6a8828803dd5bbababf8a148e062fafd
+  depends:
+  - anyio
+  - certifi
+  - httpcore >=1.0.0,<2.0.0a0
+  - idna
+  - python >=3.10,<3.11.0a0
+  - sniffio
+  constrains:
+  - rich >=10.0.0,<14.0.0a0
+  - click >=8.0.0,<9.0.0a0
+  - socksio >=1.0.0,<2.0.0a0
+  - h2 >=3.0.0,<5.0.0a0
+  - pygment >=2.0.0,<3.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 160890
+  timestamp: 1723475052162
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-68.1-h23ab428_0.tar.bz2
+  sha256: 80ec818f553a590767f03a15cec450370445c41f469d1fcf1c495521ac36a71a
+  md5: aa8486cbdfa5f499508f682a55ce8493
+  depends:
+  - libcxx >=10.0.0
+  license: MIT
+  size: 25926885
+  timestamp: 1611658753217
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py310hecd8cb5_0.tar.bz2
+  sha256: c21b5d635595e087aa1135dd3b6dca63054aff33d58d70100c0b0f6648d0dae3
+  md5: b548aefceda441a37555005da1b9a4c8
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 140710
+  timestamp: 1714398998249
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/imagecodecs-2023.1.23-py310hd1bf5dc_0.tar.bz2
+  sha256: cc9676095a87b48ba60d7a84c29466c0d53569ea85d46f5a095d13787073df2c
+  md5: 7e40dba61443d45bba6ea3f77c428253
+  depends:
+  - blosc >=1.21.3,<2.0a0
+  - brotli >=1.0.9,<1.1.0a0
+  - brunsli >=0.1,<1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - cfitsio >=3.470,<3.471.0a0
+  - charls >=2.2.0,<2.3.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - jxrlib >=1.1,<1.2.0a0
+  - lcms2 >=2.12,<3.0a0
+  - lerc >=3.0,<4.0a0
+  - libaec >=1.0.4,<2.0a0
+  - libavif >=0.11.1,<0.11.2.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.7.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - libzopfli >=1.0.3,<1.1.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - numpy >=1.21.5,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - snappy >=1.1.9,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zfp >=1.0.0,<2.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10149468
+  timestamp: 1695065149592
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/imageio-2.33.1-py310hecd8cb5_0.tar.bz2
+  sha256: ddf20cea03f79a930b341414e768474b7e2da7335adf0a10d2a045572f587500
+  md5: 4b960148228834804ec7b2501fa886e5
+  depends:
+  - numpy <2.0a0
+  - pillow >=8.3.2
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 524979
+  timestamp: 1707247322058
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-8.5.0-py310hecd8cb5_0.tar.bz2
+  sha256: 0cf6ad6ad79abd553bf7362650560a0c564d679c2cf829ed35d54d8704c56bc6
+  md5: d21a65f36f7f407f0402139dadeca742
+  depends:
+  - python >=3.10,<3.11.0a0
+  - zipp >=3.20
+  license: Apache-2.0
+  license_family: APACHE
+  size: 46503
+  timestamp: 1732633599047
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intake-0.7.0-py310hecd8cb5_0.tar.bz2
+  sha256: 9a106978d505c4409b49a15a183d6ae7a32602da96fc4bd01c1c2656799c8cbc
+  md5: cc1f050fac3df4f8bc1292e88be573e8
+  depends:
+  - appdirs
+  - dask >=1.0
+  - entrypoints
+  - fsspec >=2021.7.0
+  - jinja2
+  - msgpack-python
+  - python >=3.10,<3.11.0a0
+  - python-snappy
+  - pyyaml
+  - requests
+  - tornado
+  constrains:
+  - hvplot
+  - panel >=0.7.0
+  - bokeh
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 199489
+  timestamp: 1717514211356
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intake-xarray-0.7.0-py310hecd8cb5_0.tar.bz2
+  sha256: d54aca55cd2299b2ef6eead765bcf30209b1bf808c783f4854a520a75ae8d7df
+  md5: c3ea834a6911fc9c5acfea93efacb292
+  depends:
+  - dask-core >=2.2
+  - fsspec >=2022
+  - intake >=0.6.6
+  - msgpack-python
+  - netcdf4
+  - python >=3.10,<3.11.0a0
+  - requests
+  - xarray >=2022
+  - zarr
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 69287
+  timestamp: 1717524037777
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py310hecd8cb5_0.tar.bz2
+  sha256: d0034278e28af70fbfcafa79e3883e675f819080afb4ba2611b4ce8ee4062e93
+  md5: 795107da24edcf2cc3e36abef3523f66
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192736
+  timestamp: 1728666308586
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.27.0-py310hecd8cb5_0.tar.bz2
+  sha256: 11383b9a268f6358aeed082f32b92a604daf3a8bd539c291a153d70bb5b112aa
+  md5: 2992e217939521408ea664720771cb36
+  depends:
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.10,<3.11.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1291648
+  timestamp: 1726064675161
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipywidgets-8.1.2-py310hecd8cb5_0.tar.bz2
+  sha256: dd2436bbba06d47b068791a78026eda38ca5d17fa07bd57605344f2893086be4
+  md5: 26afb0e73c8c87ebdd4cbe254a6f2751
+  depends:
+  - comm >=0.1.3
+  - ipython >=6.1.0
+  - jupyterlab_widgets >=3.0.10,<3.1
+  - python >=3.10,<3.11.0a0
+  - traitlets >=4.3.1
+  - widgetsnbextension >=4.0.10,<4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 202266
+  timestamp: 1709574940050
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.1-py310hecd8cb5_0.tar.bz2
+  sha256: 437f78774eacfc35aedccd62f280e9c498ea8dca1ffbc49c6afb9a13b525e43f
+  md5: 0315d326448f640bac44a5979f63fbc2
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1057713
+  timestamp: 1721058639924
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py310hecd8cb5_1.tar.bz2
+  sha256: 2f1416ee252096862b756d814a5029581534f2fff53ed02c58ed0c2b02725a26
+  md5: e4b59989e70ab1052c4e3a68b8703a49
+  depends:
+  - markupsafe >=2.0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279013
+  timestamp: 1730903083312
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jmespath-1.0.1-py310hecd8cb5_0.tar.bz2
+  sha256: c435150f2b9b6a5206880c109ddb175270e36f47f088efd218fca2fd3e37f7c0
+  md5: 05eb2907953e7999990fa2c3926a90a2
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 38480
+  timestamp: 1700144671754
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+  sha256: 855982a798d9af8e70635a250528a5da3b2b0cf7095e2804858caf139c8a239b
+  md5: 112a5602fe42a84a5bafa038abeddf4f
+  license: IJG
+  license_family: Other
+  size: 279686
+  timestamp: 1722872676718
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/json5-0.9.25-py310hecd8cb5_0.tar.bz2
+  sha256: bd18cb467f77e52ab27ffacadc51956b97edb120bb01afff59a4bc28166478dd
+  md5: 4826d02e10feebdb6cc44662aa98bb9b
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 46852
+  timestamp: 1730787019860
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.23.0-py310hecd8cb5_0.tar.bz2
+  sha256: a9bdf7c56d6a18d3296901290f6262a73a5e150f710b6b913bed1166619ca123
+  md5: d645418dd0292953837fec13d110014e
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.10,<3.11.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 146358
+  timestamp: 1728486784215
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py310hecd8cb5_0.tar.bz2
+  sha256: b61904f8e4c3d1726f4bbec37d1edfd69a989cab0098cfa9c422d2cf9f49ba78
+  md5: 221013125db975c3b57e7ebc93e73b2a
+  depends:
+  - python >=3.10,<3.11.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 15941
+  timestamp: 1699032432155
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter-lsp-2.2.0-py310hecd8cb5_0.tar.bz2
+  sha256: c0284cfa23bdf14449ba0eb9960264874138891e23c25beda1cc2204a00124a6
+  md5: 31d8bfed557da32b2a4750a435b42858
+  depends:
+  - jupyter_server >=1.1.2
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 82418
+  timestamp: 1699978366719
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-8.6.0-py310hecd8cb5_0.tar.bz2
+  sha256: 0e06b7af87feec4cb389ffcfb83233e552fe1ece4e6b2c03ce8db0f1b42b9698
+  md5: e23a81954301a751d94a2d9e686dcb60
+  depends:
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 173889
+  timestamp: 1699456828052
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py310hecd8cb5_0.tar.bz2
+  sha256: 8344dde53b622d2ebbdacbaa85422a3d0a97493f5915c6f2a27a74add7ab1482
+  md5: b771da116ff7a21cd82eb99667d5ef21
+  depends:
+  - platformdirs >=2.5
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 83932
+  timestamp: 1718818490484
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py310hecd8cb5_0.tar.bz2
+  sha256: 3a2e00b1914f2b34344d85a1189176ab5f52a5d89a1796ce7f2b97e16c65615d
+  md5: 357a1f12e89ec1be00e3b83db0e564fd
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.10,<3.11.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36897
+  timestamp: 1718738309903
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py310hecd8cb5_0.tar.bz2
+  sha256: f5c82bb1d90d7cc60f0dec96e3441dd8a79d28251bfdf340dd4b99cf58fe275d
+  md5: d8a2d165f4ea882ed88eb8442c1c29c9
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 512338
+  timestamp: 1718827525582
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py310hecd8cb5_1.tar.bz2
+  sha256: de99cb9520ae626ef84d929e46fbec2f944cde776405ee337a36246f0aa2b946
+  md5: 6435c2a1ce645abc13359bbec1eda7d1
+  depends:
+  - python >=3.10,<3.11.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24670
+  timestamp: 1686870766255
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab-4.2.5-py310hecd8cb5_0.tar.bz2
+  sha256: 81f4c8331608530d96d3626665c9a17df4e0991093eb3bbecde10bb8c306407e
+  md5: ba857485deb03a0f2d5b417f20f8416d
+  depends:
+  - async-lru >=1.0.0
+  - httpx >=0.25.0
+  - ipykernel >=6.5.0
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.27.1,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.10,<3.11.0a0
+  - setuptools >=40.1.0
+  - tomli >=1.2.2
+  - tornado >=6.2.0
+  - traitlets
+  constrains:
+  - nodejs >=20.0.0,<21.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8261913
+  timestamp: 1725896789318
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_server-2.27.3-py310hecd8cb5_0.tar.bz2
+  sha256: bd1e65ba93d07e22dfb980e159d7d29c88dd39b1afe7cdba403268300b2767f4
+  md5: c9b2a29f715bc7727e5916412d60fff3
+  depends:
+  - babel >=2.10
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18.0
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.10,<3.11.0a0
+  - requests >=2.31
+  constrains:
+  - openapi-core >=0.18.0,<0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84339
+  timestamp: 1725865455369
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_widgets-3.0.10-py310hecd8cb5_0.tar.bz2
+  sha256: 80528ee104798f31be0d7fd315ca6035533756ab1d8a905520be4ce05f4c258a
+  md5: adc11a6587b9ccc7d6aa78323c6b174d
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jupyterlab >=3,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192542
+  timestamp: 1709323065620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jxrlib-1.1-haf1e3a3_2.tar.bz2
+  sha256: 63b4b4e81998da78bf9a1625d122faa6aa7514f6e3c975043432da346b9a566d
+  md5: 1e527af8be0e202b459293a8a5c76c87
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 230086
+  timestamp: 1593197454386
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/keras-2.12.0-py310_0.tar.bz2
+  sha256: a169e19ebd1314f9812d18c2df659654d005249f369f42e92d55542362bd824c
+  md5: 619f00c7c2030f7d4a56a4c7144e1606
+  depends:
+  - keras-preprocessing >=1.1.2
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - tensorflow-base  2.12.*
+  license: Apache-2.0
+  size: 2271288
+  timestamp: 1683570891666
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py310hcec6c5f_0.tar.bz2
+  sha256: bde3b255886d59e9af9450489ba42e205865a223ec48c4bd3396405480715c97
+  md5: f4ed6fff2814558c3b717017465d8e2a
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65413
+  timestamp: 1672387282474
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
+  sha256: 8093a64350665d16ca2ad0acfcbba5c84b479c316a40db6b9d5f9b84b58f3b12
+  md5: cd98cc17f8297a31b1dd62f061ea4f83
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - openssl >=1.1.1u,<1.1.2a
+  license: MIT
+  license_family: MIT
+  size: 1289465
+  timestamp: 1686931250022
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lazy_loader-0.4-py310hecd8cb5_0.tar.bz2
+  sha256: 303fbe650dd1f21f60fae30eb67a15d15d141ce60ccf74d47b3c18ffbea57425
+  md5: 26f5dcc87e1cee5b8eddfa7d0882e5d4
+  depends:
+  - packaging
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21960
+  timestamp: 1718176894987
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libaec-1.0.4-hb1e8313_1.tar.bz2
+  sha256: 2a9313912b9b3ea0d306a46e20df93f7fc79bce35e895e0cb98b8cdc068e2652
+  md5: ebfa53511162e3172aa14fbd37e3ed5d
+  depends:
+  - libcxx >=10.0.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 28397
+  timestamp: 1593198224738
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libavif-0.11.1-h6c40b1e_0.tar.bz2
+  sha256: 69303ebcb28fdfcdee4190da926cc7118bff28f96be9e6e5dd92f45e8302d711
+  md5: dfe44f56908bc60af820824d24d634c4
+  depends:
+  - aom >=3.6.0,<3.7.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 98857
+  timestamp: 1689158151760
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 685c3bc9068bd485604b80bf03789e4dca95c410d33871bc1b882e47649fabed
+  md5: 6cf8e55271e150ca0961d0ddedaa61bb
+  license: MIT
+  size: 66237
+  timestamp: 1714483284541
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 69826cee54db9955f0120af21ec36d13f9211877fd67364f2068d0a54c6c97cd
+  md5: 0851917257f490d35e1f73da8a1c723c
+  depends:
+  - libbrotlicommon 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 34042
+  timestamp: 1714483343147
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 3f5a1f03b50b90b397a0ee432ad0cba13354abdaf7e5652c0fc60164b26a08b6
+  md5: a50bdc871ef4bf14deb088d888b92b5e
+  depends:
+  - libbrotlicommon 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 311597
+  timestamp: 1714483371586
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
+  sha256: 83cf762f0d09c97dfb4a1c1cd9e635de2e54c384b057afbf3c0e2e8db07d862f
+  md5: ae3a458da93940fea1fa83af80d91fd4
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.52.0
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - zlib >=1.2.13,<1.3.0a0
+  license: curl
+  license_family: MIT
+  size: 358556
+  timestamp: 1693515516157
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+  sha256: e84e6cbacb12de6fe86955449502d3956696ae583060d0d4911ea6f503cfb9ad
+  md5: 1d200c536be4172db41c49e81a3e6350
+  depends:
+  - ncurses >=6.4,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 169586
+  timestamp: 1703006265367
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+  sha256: 4786264321edbff780633a5b752995eb3193ca4bce11b0fda179577f6cf1102c
+  md5: 849fdd014c201a9d2c2aa7c7db38a778
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 103993
+  timestamp: 1632891571494
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+  sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
+  md5: 822a5b76117e56d3912f1f2153307528
+  license: MIT
+  license_family: MIT
+  size: 136045
+  timestamp: 1714483561919
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+  sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
+  md5: e458587c87e3f2d20192f4e0738f2c63
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 149419
+  timestamp: 1665498987619
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+  sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
+  md5: 1058b661ec829b2ee3716ee2a5520641
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1917987
+  timestamp: 1665498925405
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnetcdf-4.8.1-h9c0abef_4.tar.bz2
+  sha256: 549522f9e180785b2b8a8dc40fb1552007a1b435afd9371e282b17994bb07573
+  md5: ed1ad56182673d8b2d4944c926a91e1d
+  depends:
+  - hdf4 >=4.2.13,<4.2.14.0a0
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  - libzip
+  - openssl >=1.1.1v,<1.1.2a
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1530796
+  timestamp: 1691154667607
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
+  sha256: 331bc731419328a873e1a48d4257c58baa33d73b4b91ff7a3553b1c122120fb1
+  md5: 43fba990695db8556ddd0ade21d59ecc
+  depends:
+  - c-ares >=1.19.0,<2.0a0
+  - c-ares >=1.7.5
+  - libcxx >=14.0.6
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - openssl >=1.1.1u,<1.1.2a
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 782018
+  timestamp: 1686931556261
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
+  sha256: 499ebc9000c8e810081b5d7f7524b45dc99f6914096ea9e145366033514938b4
+  md5: ce5c24f93932e1a53d7d89e502f28783
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10123989
+  timestamp: 1664896966769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
+  sha256: 1884de5207f5a1210217d7132348b4944ec4b09a91085b7b47a19dfdd9b6dbba
+  md5: aa960ea0133deec4637a8d05700cc3c4
+  depends:
+  - libcxx >=14.0.6
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2412437
+  timestamp: 1675278748544
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
+  sha256: 8b1adbb78b6283c3d8df932d5aa7e8e249351aa1e206ba2949ee86052912e83f
+  md5: 2e035c81c044bff1224224ac24161dfd
+  depends:
+  - openssl >=1.1.1u,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338461
+  timestamp: 1686931232629
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+  sha256: 246c0d82766042c1a9194eecc71690918c68afa3528ff0c2c82796ce901df40b
+  md5: f33be4ed3bff89ed8f68df6c75158510
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 449215
+  timestamp: 1729160070984
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libzip-1.8.0-h272c8d6_0.tar.bz2
+  sha256: c575e9b13e704c531dab91ce87676d5a336c982273e5a361e42073b9e5817738
+  md5: 5d543db811d31c7e5703726639d034d3
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - openssl >=1.1.1o,<1.1.2a
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123384
+  timestamp: 1652978539298
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libzopfli-1.0.3-hb1e8313_0.tar.bz2
+  sha256: 1d727042cefd5fdc1eb1b5735ccb19b15ab0837e0b3c4a96841ebcd4143d31e9
+  md5: 2dffb55c068fb1561d870b5543b7966e
+  depends:
+  - libcxx >=10.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 162388
+  timestamp: 1593197747824
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+  sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
+  md5: 5c740b4a18a558de0ccfe601703c423c
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 338738
+  timestamp: 1662635677689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py310hecd8cb5_0.tar.bz2
+  sha256: ef2cc69591855744d4c5d1aeb6b325d0f9886404709cba541be075fe6f696fd5
+  md5: 46e2880168e6de564dd817fde7bf07b1
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11932
+  timestamp: 1652903221378
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+  sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
+  md5: 8f57dc3a3327bb6f7e1cba908856ac7f
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 183138
+  timestamp: 1714510756758
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py310hecd8cb5_0.tar.bz2
+  sha256: bc2f8a9d82b05e7d2e9da576d86565f085b18ad824a61729c808a35d9aa899ae
+  md5: 2b5c8d5d297342184b21138a02a4cec1
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 124321
+  timestamp: 1671541949029
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py310h6c40b1e_0.tar.bz2
+  sha256: 57e19ade13338cbe335ab420e8f5e34e5f37c7d7093a9382a4609289b08ac0a6
+  md5: 2860d43ce7cdd7b1c9ce80e2ef57bbfb
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23492
+  timestamp: 1704206268961
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.9.2-py310h919b35b_1.tar.bz2
+  sha256: 6ad9c2902379e1c17df2483396ce7dfc701fe5ccc1ca6bf2b06e8d02607e5617
+  md5: 2bce437e3808bb5f5b6d683d22f55616
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23,<3.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8456937
+  timestamp: 1732551251431
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py310hecd8cb5_0.tar.bz2
+  sha256: b0b7bf33159ad955ac6503e0008bb4f6d42a431d39750d8748f1cfd437c33982
+  md5: 95dcb73cba7ccc8d9d54ded71c43f200
+  depends:
+  - python >=3.10,<3.11.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17405
+  timestamp: 1662014515076
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py310hecd8cb5_0.tar.bz2
+  sha256: 5aacf8dd7d920d1ed998a1c94bdd1554b4f9dc7c7f34ed2901a065ac97189633
+  md5: 7da6eae2686cd9f630948ac7346b101e
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 91001
+  timestamp: 1661496330569
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py310haf03e11_0.tar.bz2
+  sha256: be629ed3ab7b02726b5c59ce24ec083091815b0379f7103e8c1d425a6e7a14c8
+  md5: 303d215b320300b4131f786e9f446354
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 89322
+  timestamp: 1652362730842
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/multidict-6.1.0-py310h46256e1_0.tar.bz2
+  sha256: 9fd653a1bdc9e9e7007e4499a0e534fdd69e8108af2d081f78de400950484c9a
+  md5: 415e11946d5db88000696bcc4e7e4849
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing-extensions >=4.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52321
+  timestamp: 1730905624850
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py310hecd8cb5_0.tar.bz2
+  sha256: 7ada341fb8fe36d073cdc35c3767a7e61d9e841fda878863d8ff3420187bde18
+  md5: 8132292734c29e95e96f0da876848cff
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101440
+  timestamp: 1698934309840
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.4-py310hecd8cb5_0.tar.bz2
+  sha256: 3746cedb6eb0ae41472c8a4324cfaf38eab56e798dc980315ba7ed262e9c4629
+  md5: 6b869c871807ba7c73ee4d92ea658edc
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.10,<3.11.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - pyqtwebengine >=5.15
+  - tornado >=6.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 491703
+  timestamp: 1728050330988
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py310hecd8cb5_0.tar.bz2
+  sha256: 5002aeb376cc6933cc225bea4841515fb2b54704696e3065610996f05750224e
+  md5: e2a7b4c2bb90517f0a29ad683c4c1e56
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.10,<3.11.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 149697
+  timestamp: 1728049994459
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py310hecd8cb5_0.tar.bz2
+  sha256: cc408a3c4fb28427161701204d608cbb03b5cbd1d4560f61b03a3aadd35fa9a5
+  md5: e1eae3de565ba8e2f102a67f9c425520
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14541
+  timestamp: 1708532847720
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/netcdf4-1.6.2-py310h2f655f6_0.tar.bz2
+  sha256: 3b59ceb30c35a4eb9f6ec537b90ff081e3d30e197cd8a91d6b792981ed8483f0
+  md5: 2e2b29016d6dc3b32e4f0be463fdb1ab
+  depends:
+  - cftime
+  - hdf5
+  - libnetcdf >=4.8,<4.9.0a0
+  - libnetcdf >=4.8.1,<5.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 464549
+  timestamp: 1673455785237
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.3-py310hecd8cb5_0.tar.bz2
+  sha256: ff45ecd0347b3fd53f9b4263d5808b95c163b1adf8d62a93b70b95aeca1e06be
+  md5: 52a8742cc97a5e0e2e4e731da3a5b2b4
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - matplotlib-base >=3.6
+  - numpy >=1.23,<2.0a0
+  - scipy >=1.9,!=1.11.0,!=1.11.1
+  - pandas >=1.4
+  - pydot >=2.0
+  - sympy >=1.10
+  - pygraphviz >=1.12
+  - lxml >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2669099
+  timestamp: 1720002535072
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-7.2.2-py310hecd8cb5_1.tar.bz2
+  sha256: 0b7f87d56591efb98842269cadfe3500af08c33c49c67550838fc2f3de48d268
+  md5: 4aab198bbe2095fe43f0f9146c76799c
+  depends:
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab >=4.2.0,<4.3
+  - jupyterlab_server >=2.27.1,<3
+  - notebook-shim >=0.2,<0.3
+  - python >=3.10,<3.11.0a0
+  - tornado >=6.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4398130
+  timestamp: 1727197706687
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py310hecd8cb5_0.tar.bz2
+  sha256: f9aad740019a0ff1bddebf5e6e0ae1e6cdb08eb3d2e99bf8d6b74f4482520a94
+  md5: c8771901013965363a841841df348f24
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23551
+  timestamp: 1699455945439
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numcodecs-0.12.1-py310h2d76c9a_0.tar.bz2
+  sha256: 0e85ad6f16c0698374a7c65a39aa910eaf96fd93b12336d939ff1d7ab66a735c
+  md5: 124f0f570043d25cbd17b405c844bb0c
+  depends:
+  - blosc >=1.21.3,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - msgpack-python
+  - numpy >=1.7,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 416888
+  timestamp: 1707513897278
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.10.1-py310hc59c7be_0.tar.bz2
+  sha256: 13fc982a7cf1ceba54d9ffbe982e2104cef2879d63fd95199ede5604242a3309
+  md5: 060059eed81a5e61e38c87a293abefff
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.21,<3
+  - numpy >=1.23.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 175288
+  timestamp: 1730216121865
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.23.5-py310he50c29a_0.tar.bz2
+  sha256: 5ab763b590c016d7aeb360a5c57787d47e77237c600ad4a96e3f0351a0001d1e
+  md5: 7a9442612db36f2621ace2671614674d
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.20,<1.0a0
+  - numpy-base 1.23.5 py310h992e150_0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11000
+  timestamp: 1672340772320
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.23.5-py310h992e150_0.tar.bz2
+  sha256: 5958f97ce24fbde3f9e93b937428c7b72d840cbd543e2808a50122ffd7dad49b
+  md5: 0467866f98ef90b80b68a6a6a24b5a64
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.20,<1.0a0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - numpy 1.23.5 py310he50c29a_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7146905
+  timestamp: 1672340757059
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/oauthlib-3.2.2-py310hecd8cb5_0.tar.bz2
+  sha256: 8142713c713cf69e619696d32cc5f86e24a13d7a8eb09d269355a038c037fc63
+  md5: d559bf15dd2726ebac5960c9425cc756
+  depends:
+  - blinker >=1.4.0
+  - cryptography >=3.0.0
+  - pyjwt >=2.0.0,<3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 235391
+  timestamp: 1679489741306
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
+  sha256: 401214a4763c79c2355b012b9f29e3cee097a598bb53e933acb6b98a2bb6614f
+  md5: 3216c5f433643ee62a8d0672c3500320
+  depends:
+  - libcxx >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.7.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 535252
+  timestamp: 1722872704730
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
+  sha256: f95f5173ab2a4529b56ff90deec905dd53877250acedd3887fb289b721396009
+  md5: 2ab1a555331747f19e4aa7a335e33a85
+  depends:
+  - ca-certificates
+  license: OpenSSL
+  license_family: Apache
+  size: 3665304
+  timestamp: 1694465313538
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py310hecd8cb5_0.tar.bz2
+  sha256: c7e6eeaed43f22e96664e0e3facadc1466824665cde18889fca81e9a3fc7b675
+  md5: 91dd93c48df10568852a9186a64b5451
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 31881
+  timestamp: 1699371179971
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.1-py310hecd8cb5_0.tar.bz2
+  sha256: bd279365a6a8b46e5e49433199c6774b77a49d9e3bf39c5de1dd47d3e80b59c2
+  md5: 22dd9b7d0b24f8c12a83273b8c21f227
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 136951
+  timestamp: 1720102132604
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.3-py310h6d0c2b6_0.tar.bz2
+  sha256: 14e53677a3508b18296bfd76d420ec19970f7ddcef13d48178d86f8c0b655eff
+  md5: 451fd6cea9a9421d4efc3bd0867548a3
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.22.4,<3
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - matplotlib-base >=3.6.3
+  - html5lib >=1.1
+  - tabulate >=0.9.0
+  - beautifulsoup4 >=4.11.2
+  - sqlalchemy >=2.0.0
+  - python-calamine >=0.1.7
+  - xlrd >=2.0.1
+  - pyqt >=5.15.9
+  - blosc >=1.21.3
+  - xarray >=2022.12.0
+  - pytables >=3.8.0
+  - zstandard >=0.19.0
+  - openpyxl >=3.1.0
+  - s3fs >=2022.11.0
+  - odfpy>=1.4.1
+  - pymysql >=1.0.2
+  - numba >=0.56.4
+  - xlsxwriter >=3.0.5
+  - lxml >=4.9.2
+  - jinja2 >=3.1.2
+  - adbc-driver-postgresql >=0.8.0
+  - adbc-driver-sqlite >=0.8.0
+  - pyarrow >=10.0.1
+  - pyxlsb >=1.0.10
+  - qtpy >=2.3.0
+  - fsspec >=2022.11.0
+  - fastparquet >=2022.12.0
+  - psycopg2 >=2.9.6
+  - scipy >=1.10.0
+  - pyreadstat >=1.2.0
+  - pandas-gbq >=0.19.0
+  - gcsfs >=2022.11.0
+  - dataframe-api-compat >=0.1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14269882
+  timestamp: 1732736984966
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-0.14.3-py310hecd8cb5_0.tar.bz2
+  sha256: c024318001df5cb61a2471404472419fb1169860cc40d4fe4580fda9a276fb65
+  md5: 1bdd6ec8be5e22e252d93b0c1d482a5d
+  depends:
+  - bleach
+  - bokeh >=2.4.0,<2.5.0
+  - markdown
+  - param >=1.12.0,<2.0.0a0
+  - pyct >=0.4.4
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - setuptools >=42
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >1.14.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14717320
+  timestamp: 1676379975819
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py310hecd8cb5_0.tar.bz2
+  sha256: 08f766f3c49a9b1bd0addb34fb0ce0739d319003aa4d7580d25b8b344b3dac8d
+  md5: 7b31c764364be71df61cd206249ccae2
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 144060
+  timestamp: 1684915450654
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py310hecd8cb5_0.tar.bz2
+  sha256: a71b522bc4cafca4934aeaf25fd963e66ceb63c0820a4a15b77f60749672ebfc
+  md5: 509208a9bb46aebc97c57884a55fbc01
+  depends:
+  - locket
+  - python >=3.10,<3.11.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37072
+  timestamp: 1698702643219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-11.0.0-py310h9c91434_0.tar.bz2
+  sha256: 07aff3aba3f6071e1099ee4d1fedc3b4877d53c2fb99d5a38c7c93033433ddfa
+  md5: 28f0596f517d402f26e0cd88de857432
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 817595
+  timestamp: 1731595132617
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.2-py310hecd8cb5_0.tar.bz2
+  sha256: f5ae0a762d0e860a6ee0d8b8218ec7734182bc03112c4e284c2e213df013b48b
+  md5: 4e1286252d25151121998b7c295db58c
+  depends:
+  - python >=3.10,<3.11.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2340044
+  timestamp: 1723484785736
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py310hecd8cb5_0.tar.bz2
+  sha256: dd5966a641fed108397a18417e59eca23b954459d8dfaf1c2b02006147bf803a
+  md5: 0ba5d202a0f8fa8addb28c3c5f411150
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 33266
+  timestamp: 1692205694975
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.21.0-py310hecd8cb5_0.tar.bz2
+  sha256: c33966b8f341dbb4505460d3ca2673524b92dff43b8bbe2b801b01d3ccef66eb
+  md5: bb519736e07f713680cde9f924da50d3
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91858
+  timestamp: 1731959028260
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py310hecd8cb5_0.tar.bz2
+  sha256: f3d00376a631252954b0c4dcc667d7b24a2f20d7e434e465c61ab7f89c8eb5e2
+  md5: 3003cb05c26ea91342726f9abe687e10
+  depends:
+  - python >=3.10,<3.11.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 600585
+  timestamp: 1704404484772
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/propcache-0.2.0-py310h46256e1_0.tar.bz2
+  sha256: 3cb75f61a4cfc6c4e02c51037bdf0e9657215b081e0593ea14d93292f82d615f
+  md5: 3aa937b8ed54f037de4ea73e782c250b
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52564
+  timestamp: 1732304105168
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/protobuf-3.20.3-py310hcec6c5f_0.tar.bz2
+  sha256: fe182e77242e2f4399acee52914f2607fe9c11aca0d1897214596336d0a6ee9c
+  md5: ae8a40c26f99db3fd5d4324eeac3ce65
+  depends:
+  - libcxx >=14.0.6
+  - libprotobuf 3.20.3.*
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 317019
+  timestamp: 1675281587244
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py310hca72f7f_0.tar.bz2
+  sha256: 5a156c5d275cd9741ece740b8e0c73cf18ed8c6964fbbf8fe77c128477ee4e8d
+  md5: a13323d851b7c615fe3c85924773d118
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 370312
+  timestamp: 1656431483235
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py310hecd8cb5_0.tar.bz2
+  sha256: 6f28fc0782ff0a1f9f44be058392efcda61a916f4687f0e349c6a0b633154a31
+  md5: 89243bf420e88ab976e19b1a91228465
+  depends:
+  - param >=1.7.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30981
+  timestamp: 1675441597598
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py310hecd8cb5_1.tar.bz2
+  sha256: 864b005b3d12d53740f42f89e7d3468b43917f6054b2a27d49d6a072a7269aae
+  md5: 29606753a2e301fe9542067780a50ec1
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1889082
+  timestamp: 1684280018937
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyjwt-2.9.0-py310hecd8cb5_0.tar.bz2
+  sha256: 73f3f672a54ff1fc8bb36230cc513ed7a651e440734aab1e53e5b1e7ad5f3023
+  md5: 7e25e4402fe9cc58f8805608bc0905ec
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - cryptography >=3.4.0
+  license: MIT
+  license_family: MIT
+  size: 77594
+  timestamp: 1730787052859
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py310hecd8cb5_0.tar.bz2
+  sha256: 487b805533d5b50277d9c89f51a3aa7e7b729c69da0405b226ba038d339bb8a5
+  md5: 61b06079b67e16ce1867a92c96d863b4
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95852
+  timestamp: 1690223503122
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.2.0-py310hecd8cb5_0.tar.bz2
+  sha256: 2900f7c5a4239523c79454eb49b084c4878a14663046547b3c23634d213f1828
+  md5: f050a05a10a265c4c09705936b9fe3c8
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 427323
+  timestamp: 1731445863523
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py310hecd8cb5_0.tar.bz2
+  sha256: 7e7ad33a42ffc0cf30a64115bbf6a4fb77e6f4ff859b5cdc1c5af35e34a77a36
+  md5: 8b1372e62747adb48891711705ecf67c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 28205
+  timestamp: 1642536392594
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.10.13-h218abb5_0.tar.bz2
+  sha256: 111bbf33325fe7c8f99a1e2d11742568b247dd9ff27f54ecae3b66f018b25228
+  md5: c808f26e8157b2ee908d7c0de3381763
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 14067764
+  timestamp: 1694438857796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py310hecd8cb5_2.tar.bz2
+  sha256: 7c48377410f36fe4c89693d59a4ade0440dd6fdf16ae1932eb46076efb1f04db
+  md5: c70567e92a388519519e994567e2a653
+  depends:
+  - python >=3.10,<3.11.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 290910
+  timestamp: 1716495929291
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.20.0-py310hecd8cb5_0.tar.bz2
+  sha256: 1824cbd95f76d8180c6de480c6471a685cf490ec52a5391d78f9d154b9b6f381
+  md5: cc764d70876d00b055033f9589affac7
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 268904
+  timestamp: 1731939855247
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-flatbuffers-24.3.25-py310hecd8cb5_0.tar.bz2
+  sha256: 70808e8addac8abd1be25265efa3197927b6552d39c17e3dbc2b5fa1cd5122cf
+  md5: 6c2c8842691f616ea3355ea56868b59c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 54651
+  timestamp: 1722369262191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py310hecd8cb5_0.tar.bz2
+  sha256: b6901329f8858d79779e9843632deb42a17b9c8ae5b54d05b46c3cdb3fff92d5
+  md5: f9342fc2602715ba2b10f7bca83f2af6
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16283
+  timestamp: 1683823855507
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py310hcec6c5f_0.tar.bz2
+  sha256: 1be9acec8525317f93da208b86531202cc206ed5d9c0faf4d888b62c82d04d9e
+  md5: 40677cd4b50a2ca4b6d255f0c120e6af
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 137271
+  timestamp: 1682522501681
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-snappy-0.6.1-py310hcec6c5f_0.tar.bz2
+  sha256: 91d85c24a2589a1ad3c62db516cbc80540b8df00145757cf6c64cd07c79ad506
+  md5: a6328c411df7f76d230289066e1c6c51
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  - snappy >=1.1.9,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 31509
+  timestamp: 1670944005960
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py310hecd8cb5_0.tar.bz2
+  sha256: a93ceba4f770df6ac7cd2d4ce9d6e576907a6f82ce26e611e97118f8e3a463fc
+  md5: 210aef7186cc7ec518b958ff5f5be9c1
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 267763
+  timestamp: 1713974515169
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py310hecd8cb5_0.tar.bz2
+  sha256: 75bc3472ad099223406433761e03c124f6cdc66f6b7d1ef12ec3d36534cb7973
+  md5: 1dca0ce5eeb9bb9fea1d39d443c393b8
+  depends:
+  - param
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 61754
+  timestamp: 1711137017218
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py310h46256e1_0.tar.bz2
+  sha256: e8721601f26109e9779eeb82cfacade26f10f0c389249a91532ff4ccdd573c5d
+  md5: e70e174b046cf351add8e693633c6659
+  depends:
+  - python >=3.10,<3.11.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 177213
+  timestamp: 1728659110037
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-25.1.2-py310hcec6c5f_0.tar.bz2
+  sha256: 95afcf82e6cb8a488c724f7470bd5eb4c99aec6fc6ce9ad61a76128e5c0db00e
+  md5: 87f0ec4489f81d8de4a2f836c1a39879
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 439367
+  timestamp: 1705605242438
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+  sha256: c69f556df9a27328c56943f3b5918cbb953cfbca987e20394d823a6174781202
+  md5: ab294ae71ecdfaa307a961cc71dd890d
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-3-Clause
+  size: 205638
+  timestamp: 1652449553607
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py310hecd8cb5_0.tar.bz2
+  sha256: c5e89495acc097c738e4dd7a26cdff24b6aa0ad82d6f0c6b9b3e7db242435894
+  md5: 4278d32b0db8529403a6eb55703dc8ef
+  depends:
+  - attrs >=22.2.0
+  - python >=3.10,<3.11.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 59367
+  timestamp: 1699012203616
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py310hecd8cb5_1.tar.bz2
+  sha256: 0a86a2ab459f70a126d51adc5e814b3ebeb7e87c14a0b3872259248fa0869145
+  md5: 263c87e2d73c72044cf9297e1ddc5591
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.10,<3.11.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 99686
+  timestamp: 1730999360018
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-oauthlib-2.0.0-py310hecd8cb5_0.tar.bz2
+  sha256: 3acb206ea8ad5d3107d6044122a62ab8ad8b1aacdb5b56a422f2ebbe3f1d796a
+  md5: fae430f80c891b84fdcfc24e42050379
+  depends:
+  - oauthlib >=3.0.0
+  - python >=3.10,<3.11.0a0
+  - requests >=2.0.0
+  constrains:
+  - pyjwt >=2.0.0,<3
+  - cryptography >=3.0.0
+  license: ISC
+  license_family: Other
+  size: 35385
+  timestamp: 1720615217974
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py310hecd8cb5_0.tar.bz2
+  sha256: ecec0cef15dd4d80f2fa892b449e16041dace4ab669617ed9e2e6ee77d0873e4
+  md5: 5b3b337fc9f8d9194cbead0e20fa0b99
+  depends:
+  - python >=3.10,<3.11.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9862
+  timestamp: 1683077133588
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py310hecd8cb5_0.tar.bz2
+  sha256: cc9d506a3f77d20dd2a3fc2567bfb0880a43bb110af639c134e18ec6bdecfaca
+  md5: 5ba77c0b6356bda301de8c3d4e45a662
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 10239
+  timestamp: 1683059221325
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py310h83de92b_1.tar.bz2
+  sha256: eddfc9f5047b968e093ed75b3f8b38082c223e0bf2c623963b84d5a76b7da60c
+  md5: 4942d45e45b775131c2a24ac6f499ca8
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - __osx >=10.12
+  license: MIT
+  license_family: MIT
+  size: 308745
+  timestamp: 1732231215768
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/s3fs-2024.6.1-py310hecd8cb5_0.tar.bz2
+  sha256: 73b4da402e726c56a7da9209a62e45b477cbdf541064764e9f8e4d80eeca9187
+  md5: 5300feb0d19f308b09105d171e17ad7f
+  depends:
+  - aiobotocore >=2.5.4,<3.0.0
+  - aiohttp !=4.0.0a0,!=4.0.0a1
+  - fsspec 2024.6.1.*
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 57137
+  timestamp: 1724924263698
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scikit-image-0.24.0-py310h207f725_0.tar.bz2
+  sha256: 98fdf7fd065cfccd60f554fe6d2aad8c7587bdeb2a9f3d5ebb19f88cd2553662
+  md5: 7cadaf9a0a579e827fb53cd28a0ea596
+  depends:
+  - imageio >=2.33
+  - lazy_loader >=0.4
+  - libcxx >=14.0.6
+  - networkx >=2.8
+  - numpy >=1.23,<2.0a0
+  - packaging >=21
+  - pillow >=9.1
+  - python >=3.10,<3.11.0a0
+  - scipy >=1.9
+  - tifffile >=2022.8.12
+  constrains:
+  - astropy >=5.0
+  - cloudpickle >=0.2.1
+  - pywavelets >=1.1.1
+  - matplotlib-base >=3.6
+  - dask-core >=2021.1.0
+  - scikit-learn >=1.1
+  - pooch >=1.6.0
+  license: BSD-3-Clause AND MIT AND BSD-2-Clause
+  license_family: Other
+  size: 12167512
+  timestamp: 1726738212267
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.14.1-py310hb060737_0.tar.bz2
+  sha256: 0f06ac5574aff56a14ec9e881442ce54b80958c6365d50162a425b54903f9877
+  md5: 0853979d6ef0b08691f52aa9ff49f75e
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.23.5,<2.3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 25377386
+  timestamp: 1731623302362
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py310hecd8cb5_0.tar.bz2
+  sha256: bf760a3e65821ac2ad5ab7b0c0dec75b2f49e6915796ecbebefc1d53096d8dc2
+  md5: a434caaa43447f752cf108a5fd644d5a
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28129
+  timestamp: 1699371282429
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-75.1.0-py310hecd8cb5_0.tar.bz2
+  sha256: c0ab38c46c050d3cea6d7ea798d8ef29ac7688b59a57734b5280fd3edaf0ac62
+  md5: 7ba32807746a88a6b5846c1744ea8e1a
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1774203
+  timestamp: 1726677994849
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
+  sha256: 9eaab5afd89c87ca139915589626785039fac30f05f8fb19e9eefe27eb935ce6
+  md5: babdcd3370f85ded3d313902dcebecfb
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 46224
+  timestamp: 1723557464934
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py310hecd8cb5_0.tar.bz2
+  sha256: e0b8413f1bebc17ea35f3b4bc1e6a28dcc69db7f791ea80d31bfa8bdbd99023d
+  md5: 9c9a20ac1397b11a4ffa611d253f83a4
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17891
+  timestamp: 1705431327614
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py310hecd8cb5_0.tar.bz2
+  sha256: 97a6ef8790155b089dc6c1c7559cac226dc8966fb7189276d43e56361fef921b
+  md5: c5fe7f5450316dd0f7c407fc6d5c4590
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 67950
+  timestamp: 1696347655636
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+  sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
+  md5: 6bef1694163a68ac4c37e5857b8da4f5
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1900191
+  timestamp: 1714488351925
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tensorboard-2.12.1-py310_0.tar.bz2
+  sha256: 29cbbc529c04aa40e10443f49b36671f5020afcb0da1df5699b5ef203959a0e8
+  md5: 4e4abcfdd63f21af8110d2110b02ac65
+  depends:
+  - absl-py >=0.4
+  - google-auth >=1.6.3,<3
+  - google-auth-oauthlib >=0.4.1,<1.1
+  - grpcio >=1.48.2
+  - markdown >=2.6.8
+  - numpy >=1.12.0,<2.0a0
+  - protobuf >=3.19.6
+  - python >=3.10,<3.11.0a0
+  - requests >=2.21.0,<3
+  - setuptools >=41.0.0,<82
+  - tensorboard-data-server >=0.7.0,<0.8.0
+  - tensorboard-plugin-wit >=1.6.0
+  - werkzeug >=1.0.1
+  - wheel >=0.26
+  license: Apache-2.0
+  license_family: Apache
+  size: 5891790
+  timestamp: 1683571007400
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tensorboard-data-server-0.7.0-py310hf1618be_1.tar.bz2
+  sha256: 4c876ff0af943d63259d88a7d646e2bab67e9f2abd6be98b0c05c61772932cf0
+  md5: 0551f3684e34ebf2e80940602cbf1015
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3866076
+  timestamp: 1724172888075
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tensorflow-2.12.0-eigen_py310hccba712_0.tar.bz2
+  sha256: 0a098125fef09c9a2f6ae7d37ac857c71a79fa3482a99740e32f7559a5de8b5e
+  md5: e0d196d0b095a4a354d11216e2be8a68
+  depends:
+  - _tflow_select 2.2.0 eigen
+  - python 3.10.*
+  - tensorboard 2.12.*
+  - tensorflow-base 2.12.0 eigen_py310hbf87084_0
+  - tensorflow-estimator 2.12.*
+  license: Apache-2.0
+  license_family: Apache
+  size: 4094
+  timestamp: 1685995198524
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tensorflow-base-2.12.0-eigen_py310hbf87084_0.tar.bz2
+  sha256: a0c0f369e09a4a793adf97624fb2865f8cf966493cbfdcde8f85a49f08384275
+  md5: 6e7df2a6f15a4bc867941dc52fdd541a
+  depends:
+  - absl-py >=1.0.0
+  - astunparse >=1.6.3
+  - flatbuffers >=2.0
+  - gast 0.4.0
+  - giflib >=5.2.1,<5.3.0a0
+  - google-pasta >=0.2
+  - grpc-cpp >=1.48.2,<1.49.0a0
+  - grpcio >=1.24.3,<2.0
+  - h5py >=3.1.0
+  - icu >=68.1,<69.0a0
+  - jpeg >=9e,<10a
+  - keras 2.12.*
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - llvm-openmp >=14.0.6
+  - numpy >=1.22,<1.24
+  - openssl >=1.1.1t,<1.1.2a
+  - opt_einsum 3.3.0.*
+  - packaging
+  - protobuf >=3.9.2
+  - python >=3.10,<3.11.0a0
+  - python-flatbuffers >=2.0
+  - requests
+  - scipy >=1.7.3,<2
+  - six >=1.15.0
+  - snappy >=1.1.9,<2.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tensorboard 2.12.*
+  - tensorflow-estimator 2.12.*
+  - termcolor >=1.1.0
+  - typing_extensions >=3.7.4
+  - wheel >=0.35,<0.36
+  - wrapt >=1.11.2
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 181129055
+  timestamp: 1683853602403
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tensorflow-estimator-2.12.0-py310_0.tar.bz2
+  sha256: 7f5a13aab9ced27b93d157325979b7b30d5481257357762be2009c55e9a412fa
+  md5: 5550557f935cd4c6d996fcea74e5f898
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - tensorflow-base  2.12.*
+  license: Apache-2.0
+  license_family: Apache
+  size: 616833
+  timestamp: 1683571149997
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/termcolor-2.1.0-py310hecd8cb5_0.tar.bz2
+  sha256: ba0172a9b29962e55799e5686c72b8c59d3f66f9d62b50ca37aeed2ba792e163
+  md5: 42e62eda291fe9c327ea3220358639d6
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 12029
+  timestamp: 1668084678654
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py310hecd8cb5_0.tar.bz2
+  sha256: 92b0454b4739557af9a8f52f040828cb343935e874144e25eebf620be61cfb85
+  md5: 39fb00364e1ae13b9fc9af51c0540648
+  depends:
+  - ptyprocess
+  - python >=3.10,<3.11.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 31114
+  timestamp: 1671751965362
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tifffile-2023.4.12-py310hecd8cb5_0.tar.bz2
+  sha256: 1198a56e13316514c673ea7b1da4a9202a828fc06bd3519e1c46d1438abff681
+  md5: 0074cbb4e2bd7ceb30dcfa126c91cdc2
+  depends:
+  - imagecodecs >=2023.1.23
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - matplotlib-base >=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 384817
+  timestamp: 1695107709236
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py310hecd8cb5_0.tar.bz2
+  sha256: 47192486a825a7723642a5ff51a6e6e1951c2d32c7788da5de2485cc06b30211
+  md5: 857b3344cb9298976756ca71dc731d60
+  depends:
+  - python >=3.10,<3.11.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40085
+  timestamp: 1668168926166
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+  sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
+  md5: 523c006cc67c011383678c762015479b
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3594448
+  timestamp: 1714770737885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tomli-2.0.1-py310hecd8cb5_0.tar.bz2
+  sha256: 15f26313ae2647e6d314f7551ed86434b0a4d06c0a000b816be336793a423165
+  md5: f6deefbee1ee7036626fc1157dd6876e
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 25771
+  timestamp: 1657175648495
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py310hecd8cb5_0.tar.bz2
+  sha256: c6704e6f0aa0d801e316697959cbf8def94a9ff730a02f2892564402736e8a97
+  md5: 1631da9c8a71594c1426ad0a4abcc728
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104877
+  timestamp: 1667464191717
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.1-py310h46256e1_0.tar.bz2
+  sha256: cd52672cdd75d1bea4809a87dcd1c1ae927a38d1d3f5b1ea1eebe3b63164f7e3
+  md5: 3ee235204cefb59d7e7512124d32b785
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 698956
+  timestamp: 1718740169096
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.5-py310h20db666_0.tar.bz2
+  sha256: 25a8f186a16cd1a015827d3517e5c29df76ff667a8f67e641418dadc811b9fad
+  md5: 9b4b931f93ff450114d2a3ef2dbd461f
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 128536
+  timestamp: 1724854365093
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py310hecd8cb5_0.tar.bz2
+  sha256: dda3761c9a87fd90628b32cc8827587856783f9df3afc59d2f412b704fce6a48
+  md5: 9f14e3c1632913c7cfec1d02df9efca0
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 168327
+  timestamp: 1718227095682
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py310hecd8cb5_0.tar.bz2
+  sha256: 4a597ce01cd7df36221a55c5d6a5391461b44c8e9485f5ff2c5f0bc290c6234f
+  md5: 48ec2e723e715b8ed73ee2dea5b32b07
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing_extensions 4.11.0 py310hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9904
+  timestamp: 1715269109824
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py310hecd8cb5_0.tar.bz2
+  sha256: 23e6a2747bb6e191119b7a23efbf5bcec7adb33b4b7ff614dd36a88e6ec37475
+  md5: 8a4219dbe4163fe4a6d1cf2f3f583e10
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 61508
+  timestamp: 1715269095906
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py310h6c40b1e_0.tar.bz2
+  sha256: 63eeef078da1a81f469a881863df2f4455268c318fbe1ae6e67d215405ecc4be
+  md5: 89fe7e3ee27bd327822946574ef5ea92
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 495761
+  timestamp: 1713213041078
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.3-py310hecd8cb5_0.tar.bz2
+  sha256: b095571e220ea9b62e01fade2c856d5f56a49489847b83994fcfc8cb421a3b0c
+  md5: 722f1da6123cfc7b1f01bed235104e3a
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - requests >=2.26.0
+  - selenium >=4.4.3
+  - h2 >=4,<5
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 174274
+  timestamp: 1727770049537
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py310hecd8cb5_1.tar.bz2
+  sha256: aae85a1650806382831d1edd5b7e8912329c2d5859dd63258f2b422d0bee1761
+  md5: 7502e3b07c9f996017a9171d056b3865
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21319
+  timestamp: 1642539070002
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py310hecd8cb5_0.tar.bz2
+  sha256: df09c3d9eb682cfb34e3d892d1a8dafe3a4b252b18cc6539c8f1c331b1a72a39
+  md5: 6632d513deb34751cfee6129f71ab6d1
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 88313
+  timestamp: 1715878355449
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/werkzeug-3.0.6-py310hecd8cb5_0.tar.bz2
+  sha256: fd644f3ab6d60d12f5732737be8ae1ddc5768786d24ed5697bf6027b76c7d02b
+  md5: 2cd1d4520af4785e12b2ccb8cefedeac
+  depends:
+  - markupsafe >=2.1.1
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - watchdog >=2.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 349380
+  timestamp: 1731005905750
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/widgetsnbextension-4.0.10-py310hecd8cb5_0.tar.bz2
+  sha256: 9f6e5649990eec219fa441fa663cd61e0e9ba3708218956094a9ed2173d7f1db
+  md5: 1c1f328c7cb0f17d37000be837fc4006
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1931296
+  timestamp: 1709323071556
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wrapt-1.14.1-py310hca72f7f_0.tar.bz2
+  sha256: 247e00f11da76e770166f4eb216693da0f571afa052775a57a8629329863610e
+  md5: 9f5c97dfc2e2cf68e0c23321209b32d2
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 49985
+  timestamp: 1657814505025
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py310hecd8cb5_0.tar.bz2
+  sha256: 1c101b0f6db62313e4d845ccbec9256e97a01b3a9bebb84174c6bd5a302ba809
+  md5: 3490e2adaefd69ec35a5f0eefa902ef7
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1812032
+  timestamp: 1689041517180
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+  sha256: ed0152ad6b87ffd9e01f4a62bc358e805ad59637f898a801b0a9cf903ae8e1fb
+  md5: 8a92f8c663608f24e14d8a2068b9d83a
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 415323
+  timestamp: 1714511993944
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yarl-1.18.0-py310h46256e1_0.tar.bz2
+  sha256: 41f4509754dc4c70fe39ee41c129ed4272ffaa2e53e3bb130f991684194e6c0e
+  md5: 7d84fe20ea6d27dd09459cc39e3eb304
+  depends:
+  - idna >=2.0
+  - multidict >=4.0
+  - propcache >=0.2.0
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 135144
+  timestamp: 1732547099966
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zarr-2.13.3-py310hecd8cb5_0.tar.bz2
+  sha256: b4db98931a6a95a647985dacdb6153f115cf8f3d84bcff6bc6ac86a8791d5d01
+  md5: 36f3ee584f4a40725f83eec631eea1e7
+  depends:
+  - asciitree
+  - fasteners
+  - numcodecs >=0.10.0
+  - numpy >=1.7,<2.0a0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 344339
+  timestamp: 1669363579779
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+  sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
+  md5: c25b6d40f834647d0bbe767f6c776031
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 329449
+  timestamp: 1705602140856
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zfp-1.0.0-hcec6c5f_0.tar.bz2
+  sha256: 47bde98853cb2914d8d63d58615edd7c9a788c5590a6a0a5c14d41051577559b
+  md5: c2e85e2f1be3fcee07bdf14d6a11519f
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 271809
+  timestamp: 1681741643951
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py310hecd8cb5_0.tar.bz2
+  sha256: 5a12afd890a62af36fa68990182fec6ce14a15836b0985ba5efcaf477e374368
+  md5: ab35b58320c81d4687504c7f6ec1d107
+  depends:
+  - heapdict
+  - python >=3.10,<3.11.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78791
+  timestamp: 1695832967750
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.21.0-py310hecd8cb5_0.tar.bz2
+  sha256: 39093c8982b24650d28be1ff138fedf7eb3ffc6f904ddd227f56b9d28241fedf
+  md5: 602a7d8d4582fe29d24e4cd02f09eb01
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 26953
+  timestamp: 1732630810165
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+  sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
+  md5: f2519b551f99765d9d98950c5e2b4713
+  license: Zlib
+  license_family: Other
+  size: 119782
+  timestamp: 1714511811597
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
+  sha256: a1f470eabe211500d2ec7866ecf421c067f159045f0245f19e9ba8272c5a177e
+  md5: f8bd5fb9fac17a47c64ae56355faba24
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1033188
+  timestamp: 1728487057684
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/_tflow_select-2.2.0-eigen.tar.bz2
+  sha256: 59bafe7c50d71da3c1f0aa99ebdc1e329f42a659dace13025cce87e065a784c5
+  md5: 246af7e262f42b5ef0c0050a2b38cb6c
+  size: 2892
+  timestamp: 1677628364852
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/abseil-cpp-20211102.0-hc377ac9_0.tar.bz2
+  sha256: 5c4e710cd4ae70aa94623c79f8528b8900dc5a2c88391f34cc11af7fb2885f1c
+  md5: 998c800e31d88a6b0c7fae9b67695e2d
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1046017
+  timestamp: 1652382871042
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/absl-py-2.1.0-py310hca03da5_0.tar.bz2
+  sha256: edbb356df4d4b4e326a031ba07d4a0cd96a2f743deeb25e5b173bc27412f56b3
+  md5: 542d3ee2df186e890bfdb01632a44683
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 188771
+  timestamp: 1714140540259
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aiobotocore-2.12.3-py310hca03da5_0.tar.bz2
+  sha256: bc625e660b37e5ae77ff2a01dbc60d9168acbf522274e9439b4384f221b2aca0
+  md5: be57ff17c7c4194f69e2407e22567348
+  depends:
+  - aiohttp >=3.7.4.post0,<4.0.0
+  - aioitertools >=0.5.1,<1.0.0
+  - botocore >=1.34.41,<1.34.70
+  - python >=3.10,<3.11.0a0
+  - wrapt >=1.10.10,<2.0.0
+  constrains:
+  - boto3 >=1.34.41,<1.34.70
+  license: Apache-2.0
+  license_family: Apache
+  size: 111965
+  timestamp: 1714464474681
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aiohappyeyeballs-2.4.3-py310hca03da5_0.tar.bz2
+  sha256: 979c98dc1cdfca83245d8d8a9edc95b902d3e2a384909f58735060ef174d3784
+  md5: 9a8fded83f9bfe981da8b76f7d9872b2
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: PSF-2.0
+  license_family: Other
+  size: 26366
+  timestamp: 1732662494086
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aiohttp-3.10.5-py310h80987f9_0.tar.bz2
+  sha256: 7e8c6366b36a396ecdc41f1ed9e37e12b48784903e09480392ede19d547276c2
+  md5: 259358d22e03ce319e20c4563825020a
+  depends:
+  - aiohappyeyeballs >=2.3.0
+  - aiosignal >=1.1.2
+  - async-timeout >=4.0,<5.0
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - multidict >=4.5,<7.0
+  - python >=3.10,<3.11.0a0
+  - yarl >=1.0,<2.0
+  constrains:
+  - aiodns >=3.2.0
+  license: MIT AND Apache-2.0
+  license_family: Other
+  size: 734360
+  timestamp: 1725528321327
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.6.2-py310hca03da5_0.tar.bz2
+  sha256: 3f6473f17d0407db15ac692c66032a637cd16a898a717d886e3df1a30fa3cd71
+  md5: 004edddb77757f2eae161031e8c2c04f
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.10,<3.11.0a0
+  - sniffio >=1.1
+  - typing_extensions >=4.1
+  constrains:
+  - uvloop >=0.21
+  - trio >=0.26.1
+  license: MIT
+  license_family: MIT
+  size: 192745
+  timestamp: 1729121306682
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aom-3.6.0-h313beb8_0.tar.bz2
+  sha256: a26e4cb399cee40b3b513563d22a8f8f87b15cfdfd645cffeb48f57a85db3ee6
+  md5: 2e643e2e6830fea3f7d6ac729f8bbccb
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2647589
+  timestamp: 1688660588288
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py310hca03da5_1001.tar.bz2
+  sha256: ab80767485355b86e85012079c6774f34b8a50cca22f6af691717dae8a6eecd3
+  md5: 313a6fb125023514957826391bd2bc9a
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10379
+  timestamp: 1643965069164
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py310h1a28f6b_0.tar.bz2
+  sha256: 88db781405798fc0a4bd4d2cfa4817d72a1717595814792b06baf438a74f971e
+  md5: 74f12ced47a5a18208005eb36438fb97
+  depends:
+  - cffi >=1.0.1
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 36148
+  timestamp: 1644845853887
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-11.0.0-he3f21e0_2.tar.bz2
+  sha256: 313d6a618fa00b3e2f94b904d7c7503ca31ad9d727a1531de73a418876bf4550
+  md5: 81d60ed6da95297b1d8111e26c79fcab
+  depends:
+  - aws-sdk-cpp >=1.8.185,<1.8.186.0a0
+  - brotli
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.5.0,<0.6.0a0
+  - grpc-cpp >=1.48.2,<1.49.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - orc >=1.7.4,<1.7.5.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.9,<2.0a0
+  - utf8proc <2.9.0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8072211
+  timestamp: 1693262997819
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/async-lru-2.0.4-py310hca03da5_0.tar.bz2
+  sha256: 3b43d45739c99e6a94f62680a84bd9a2318af2711b23cf505b2ec06664550cc2
+  md5: d4adbbd0b14c97d7d65388910ddf44d8
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing_extensions >=4.0.0
+  license: MIT
+  license_family: MIT
+  size: 18529
+  timestamp: 1699554606955
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/async-timeout-4.0.3-py310hca03da5_0.tar.bz2
+  sha256: 9e8364394f0c5647eb50adc08c9ba59e6f5ed1139d3f6408cb0187b77e4e395f
+  md5: fb2aa332a7c7f71cdb7dc156179e55bb
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 13180
+  timestamp: 1703097036878
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-24.2.0-py310hca03da5_0.tar.bz2
+  sha256: 270acc00fc48505fc3430e02dbc43663a1196637e73dc39512edda097345950e
+  md5: cf1610354be87984d45cce0784ea4a9c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 142944
+  timestamp: 1729089438536
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.6.8-h80987f9_1.tar.bz2
+  sha256: 4d63ff9d0b424c5dc2e20bb8324a348869dee0340511effadfd1d622842a8322
+  md5: 3137a10d16bb223ae981d566d60d984b
+  license: Apache-2.0
+  license_family: Apache
+  size: 153917
+  timestamp: 1685977852438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.1.6-h313beb8_6.tar.bz2
+  sha256: f41918089bd42945e10d71aaf30eacede92db2b57193c2c931a710c314a39730
+  md5: b0a63224a995df6e07fdebba41a3c1a6
+  depends:
+  - aws-c-common >=0.6.8,<0.6.9.0a0
+  - aws-checksums >=0.1.11,<0.1.12.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 24245
+  timestamp: 1686021087869
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.11-h80987f9_2.tar.bz2
+  sha256: 5068b5773e8ce07dfc34718fb6c4be364a4c79d821138d68c3d246873bd562b9
+  md5: 1efb7da0ab9ee77370640b77f74f9c7c
+  depends:
+  - aws-c-common >=0.6.8,<0.6.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51725
+  timestamp: 1685998294585
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.8.185-h4a942e0_0.tar.bz2
+  sha256: 0f257afff29f6c681b9fd8620767ce2af7b07f9068c3f0e649289ca9151591bf
+  md5: 9358450895bb23ccbd49c553dbd66589
+  depends:
+  - aws-c-common >=0.6.8,<0.6.9.0a0
+  - aws-c-event-stream >=0.1.6,<0.1.7.0a0
+  - libcurl >=7.71.1,<9.0a0
+  - libcxx >=12.0.0
+  - openssl >=1.1.1j,<1.1.2a
+  license: Apache-2.0
+  license_family: Apache
+  size: 2171325
+  timestamp: 1628727158397
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/babel-2.11.0-py310hca03da5_0.tar.bz2
+  sha256: cab586143df17aa3def1a098ff9e2b4537064efe95095ee43aef50666afacd9d
+  md5: 2b5ecb47920dea58ef381cfb7ca1d6a6
+  depends:
+  - python >=3.10,<3.11.0a0
+  - pytz >=2015.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7121729
+  timestamp: 1671782026041
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py310hca03da5_0.tar.bz2
+  sha256: 2514f9bbe8223df7338c42e3747db5d33757b5742c0f36437c854c55594ef6e1
+  md5: 30db606495e28cd684ddfbb3043ddbd0
+  depends:
+  - python >=3.10,<3.11.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 219249
+  timestamp: 1718029876220
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bleach-6.2.0-py310hca03da5_0.tar.bz2
+  sha256: 39f2e4ef0fbad4a9943efa75e503b08f3b1690b800c8535618828305ebb9008d
+  md5: 066afccd247e6e4df797cf1cd68dc6c1
+  depends:
+  - python >=3.10,<3.11.0a0
+  - webencodings
+  constrains:
+  - tinycss2 >=1.1.0,<1.5
+  license: Apache-2.0
+  license_family: Apache
+  size: 296946
+  timestamp: 1732292272756
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blinker-1.6.2-py310hca03da5_0.tar.bz2
+  sha256: 3533e937278621267c54f7435ddeb08dc11c39fce220dc1b3bfdf34f9ccc65c6
+  md5: 1f455949be1a9d4dfd05ddd5b6567c63
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 29215
+  timestamp: 1696539139293
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
+  sha256: d51b7b5841be320209706d8e9caf669c0e0094f3a40e9eea51701a564ca7c2ed
+  md5: 61647f79e0ae70e914fee23c40c4caea
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43179
+  timestamp: 1675247655207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.6.0-py310hca03da5_0.tar.bz2
+  sha256: 4e67fdf3fee5d29637bdf5e3eff737c57518335db4972070a06c3331e436aa60
+  md5: 13eb9d58f7139b020cbe7bdf76329616
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5685403
+  timestamp: 1727914527726
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.73.0-h1a28f6b_12.tar.bz2
+  sha256: 8f878b6cb432784e1a1d395069265a3643d8bb44cb5a1f552d4930895b728725
+  md5: f3e6c2c3e302d06f9734ecb2f71c2b3b
+  depends:
+  - libboost 1.73.0 h49e8a49_12
+  license: BSL-1.0
+  license_family: OTHER
+  size: 17659
+  timestamp: 1655879787473
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/botocore-1.34.69-py310hca03da5_0.tar.bz2
+  sha256: 3aa9a83ed5721eecc581dec9a17caa7b5d1938d41f453858035385878287407b
+  md5: bffd996f6abd589d9815904b8cf34ea7
+  depends:
+  - jmespath >=0.7.1,<2.0.0
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.1,<3.0.0
+  - urllib3 >=1.25.4,!=2.2.0,<3
+  license: Apache-2.0
+  license_family: Apache
+  size: 7686510
+  timestamp: 1714460595187
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.4.2-py310hbda83bc_0.tar.bz2
+  sha256: 0220046762c8f8c8f3a75f9ac81e07cc4e659718f87544a7f0f82047b1898e33
+  md5: 120e04ac71ae950c72c0262b96e2240c
+  depends:
+  - numpy >=1.21,<3
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 117882
+  timestamp: 1731058816267
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+  sha256: 048264434c33fdb53862cdd69b2e2bc4ce6f8a70b3211ad6d686d066eac2aa91
+  md5: d55696ccaf6755931cd662dfb929aa0b
+  depends:
+  - brotli-bin 1.0.9 h80987f9_8
+  - libbrotlidec 1.0.9 h80987f9_8
+  - libbrotlienc 1.0.9 h80987f9_8
+  license: MIT
+  size: 19737
+  timestamp: 1714483270447
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+  sha256: 13627293296fcc231d8dc12d803dfc9621108c60df38b0e3c64e9e02ed55e564
+  md5: 86efd4ad08cd80d3eab77873db84a255
+  depends:
+  - libbrotlidec 1.0.9 h80987f9_8
+  - libbrotlienc 1.0.9 h80987f9_8
+  license: MIT
+  size: 19083
+  timestamp: 1714483255364
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py310h313beb8_8.tar.bz2
+  sha256: 955e349120f59228466fce09cb2a6a430754ce6f6e60ab82fdedecf9bac2ba2a
+  md5: c59fe78ebe4caa829f63d92d882f036a
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  size: 380208
+  timestamp: 1714483423839
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brunsli-0.1-hc377ac9_1.tar.bz2
+  sha256: 5fb3dec9b529843f2b77a486869ffe193debac7698159c0be6d50569b14402f9
+  md5: 0034c14344b0f61079b867bd32835beb
+  depends:
+  - brotli >=1.0.7,<1.1.0a0
+  - libcxx >=12.0.0
+  license: MIT
+  license_family: MIT
+  size: 178533
+  timestamp: 1628860668184
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+  sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
+  md5: 56d1386c7f1f338f0d18f82af6525273
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 158748
+  timestamp: 1714510571033
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+  sha256: b0be79290b1df1cf1d07a1a9c3f3a92ae262643a6df3dc10dfbac22a82874dd4
+  md5: 8fdcf1c08eee91fec7eefc22863c816a
+  license: MIT
+  license_family: MIT
+  size: 106550
+  timestamp: 1693902036526
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.11.26-hca03da5_0.tar.bz2
+  sha256: e2c3a5a357ecda3f8dc7b2ca84fc749ba70affaad7e1d9964fe5c9246b9d15a0
+  md5: eb4056bb90ad65d68517441160025e1e
+  license: MPL-2.0
+  license_family: Other
+  size: 142731
+  timestamp: 1732804449627
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cachetools-5.3.3-py310hca03da5_0.tar.bz2
+  sha256: b5042509781ac5bc5cd3ff06e10ee70d2e94a482ad6a900b3cd7672fc4765fac
+  md5: 6810ff17b061398b986d62a87492a8d4
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 23953
+  timestamp: 1713977136632
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.8.30-py310hca03da5_0.tar.bz2
+  sha256: 5063169e99f9ea793bf65633fcae52a1ec0236360f9d9d563bf010ce133bbfde
+  md5: f089e9df0eb0dcb702b775c4455bec34
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 169062
+  timestamp: 1725551865064
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py310h3eb5a62_0.tar.bz2
+  sha256: 54a956a7c0a39dc886bbc810caf8f235a48ecff616fab6e38d5cccc696795746
+  md5: 95ce0947a2571b62c335c122d216d9d3
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 233086
+  timestamp: 1726856586266
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
+  sha256: 3ba74ebffd6bc4bc451864f85048dec9b6ad085eb1904ce3e5450376e15f050e
+  md5: 289f238ac78b174f01c8a2b252b17735
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=7.82.0,<9.0a0
+  - libgfortran5
+  - zlib >=1.2.12,<2.0.0a0
+  license: Other
+  license_family: Other
+  size: 1243641
+  timestamp: 1655814869383
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cftime-1.6.2-py310hbda83bc_0.tar.bz2
+  sha256: 197a3ab010194553d81893e293d5635e274b7b4fcb7708ef95d74f3a9f5b7f14
+  md5: c10acad3237d8f41c03d1f6422ec32c5
+  depends:
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 222352
+  timestamp: 1678830479751
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/charls-2.2.0-hc377ac9_0.tar.bz2
+  sha256: c048ecfd192b1c4844c077b778814be1f62017dd578bf4bf6f199be5fc7ffc65
+  md5: 3998b53d542b1c04175df5d214926067
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 91429
+  timestamp: 1628861281402
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py310hca03da5_0.tar.bz2
+  sha256: 141c21ce96ff8115ead231a457638806feb1fb4adf041e2f8ac102a5ce904660
+  md5: c5e8b68c4ebc09ceff293a97a2e35e97
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 155478
+  timestamp: 1698129833439
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.0.0-py310hca03da5_0.tar.bz2
+  sha256: 89dd920e0d6beb902cb74c9bcc793ff627de9d04b458a4d79d97bf6ce3d1b083
+  md5: 340b0fac9fff7d426d6ae3c937b69af1
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35874
+  timestamp: 1721657464815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py310hca03da5_0.tar.bz2
+  sha256: 227fe006de1e483775d205cad12d909da267c42a328fae304b8ebf9fbf5818cf
+  md5: 4f0ced86c3e12c6ae37bbb69ae883468
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 495012
+  timestamp: 1709758412929
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py310hca03da5_0.tar.bz2
+  sha256: 982ba62e9a121dd7ed150be6fcea4d1b104088f8c9cf5e87965b30a75425af03
+  md5: 77943a14af8ad7a2da2298849f2f832e
+  depends:
+  - python >=3.10,<3.11.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15736
+  timestamp: 1709322990889
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.3.1-py310h48ca7d4_0.tar.bz2
+  sha256: 95282a2e74d7369fdf21e98189bdf1d662ba779679f01ca9fcfc32c018c59d25
+  md5: 4250cc6830136878e70342948f049b6f
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.23
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279657
+  timestamp: 1732540233373
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py310h3c57c4d_0.tar.bz2
+  sha256: 7588b722a4f6e81f42a9c246540dcb9148ed6affe9f30a5f4898437a6e926017
+  md5: ecd7b6c242db72b02a87c6bc3f2332eb
+  depends:
+  - cffi >=1.12
+  - openssl >=1.1.1v,<1.1.2a
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1404100
+  timestamp: 1694211962143
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.2-py310h80987f9_0.tar.bz2
+  sha256: 04194ac6c8e61363563226ae65be7244047d18c251d9b8fad8408df07536f1d9
+  md5: e8f740bc4bd8f540e9d9ce856e64b5c6
+  depends:
+  - python >=3.10,<3.11.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 373384
+  timestamp: 1701723852993
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-2024.5.0-py310hca03da5_0.tar.bz2
+  sha256: 3fea9e2fd09e786602e1a888c39464c16e36ac44e807fbeaceb90a252578e195
+  md5: e195636143d99e1a61325d4ce4c99038
+  depends:
+  - bokeh >=2.4.2
+  - cytoolz >=0.12.0
+  - dask-core 2024.5.0
+  - dask-expr >=1.1,<1.2
+  - distributed 2024.5.0
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.21,<2.0a0
+  - pandas >=1.3
+  - pyarrow >=7.0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6280
+  timestamp: 1715848762457
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.5.0-py310hca03da5_0.tar.bz2
+  sha256: 65c9d42f648a5379c53281df3f7472fa11194920f37a54ebae2368e281e4bbf7
+  md5: 7c402e65f6db7ca65c2f1abf0ef03433
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2235870
+  timestamp: 1715838686594
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-expr-1.1.0-py310hca03da5_0.tar.bz2
+  sha256: a21ff3995375c80ea46fab88913d00f296d7b2e9a6d49d857b44b31c572628f5
+  md5: 748c71e5cff14f51d6a447d0d938f1d6
+  depends:
+  - dask-core 2024.5.0
+  - pandas >=2
+  - pyarrow >=7.0.0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 355987
+  timestamp: 1715846576841
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dav1d-1.2.1-h80987f9_0.tar.bz2
+  sha256: cdc3829b4dacd2c09ffcea509947b99dbe12eff4c9fd5f0d412795e2d3648b04
+  md5: cb80d50ff320b1865a31c59c9602ea4b
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 397700
+  timestamp: 1688746000695
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py310h313beb8_0.tar.bz2
+  sha256: cac66c2a69e5bee96de7a9a5be0ecace698915c107c9fa9047e884ca671413fe
+  md5: 28e9929e5bb06bf8df0b540b2069ba33
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 2075348
+  timestamp: 1690905262055
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2024.5.0-py310hca03da5_0.tar.bz2
+  sha256: eadea4045834154ccc67828f029b7464878959b63918e07ac1f67afc0ff96512
+  md5: e79f2987b0c06320c386ddf1f5c5c346
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - dask-core 2024.5.0
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.0
+  - packaging >=20.0
+  - psutil >=5.7.2
+  - python >=3.10,<3.11.0a0
+  - pyyaml >=5.3.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.10.0
+  - tornado >=6.0.4
+  - urllib3 >=1.24.3
+  - zict >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1451746
+  timestamp: 1715844519914
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py310hca03da5_0.tar.bz2
+  sha256: 1d532b889e0e71fe68f59e0fd328fe4c42c11660de3a32a0e31fe149f02a3eb5
+  md5: f5ec34d95710f724fd4b4c064ed0abcd
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT License
+  license_family: MIT
+  size: 15257
+  timestamp: 1650293833649
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.2.0-py310hca03da5_0.tar.bz2
+  sha256: 2ceb163a5fa46ceaa7231e4f78b47829d40f397226e2cda0d2286cbc967c8e51
+  md5: 1690bc1a003150413422613599f2d26c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 30935
+  timestamp: 1706031457824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/flatbuffers-24.3.25-h313beb8_0.tar.bz2
+  sha256: fde8be69d41255bbe39561d9788d869625964b58dd7b1e27eb497a206426efd2
+  md5: d8a28d381d4252756c22e6bf4a1c56be
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 1663962
+  timestamp: 1722872781902
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py310h80987f9_0.tar.bz2
+  sha256: 7659946cefbb015c7fb5102bfa658351b76d99b543a9a2a4f67164db68baaa38
+  md5: 480013fd51127fbc6115817e9180484e
+  depends:
+  - brotli >=1.0.1
+  - python >=3.10,<3.11.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 2642561
+  timestamp: 1713551452422
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/frozenlist-1.5.0-py310h80987f9_0.tar.bz2
+  sha256: 543d86b46735b982966157142d5970b2d1920798e3667e31e4b5c689e8771984
+  md5: 723329b90c7909a2a339cf5d1ffc1fa5
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 59173
+  timestamp: 1730902948787
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.6.1-py310hca03da5_0.tar.bz2
+  sha256: d12c11c41ece77422495a78c8ce954c6cda29ca0e9094446bc5dd007e4f3dc47
+  md5: bdb3e7e4e56e024747f36a1c3c5fe9b0
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - pyarrow >=1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 288520
+  timestamp: 1724855701047
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+  sha256: 25e05b93a99914a5fd1a298a2c5b25479fbd571b0db9caa7c6ad4336f060f62c
+  md5: e213b68bb0274e0e54c610a041e059f5
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 150168
+  timestamp: 1706888198288
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.2-h80987f9_0.tar.bz2
+  sha256: 0dcf246231852d2b5277cba97a91d8d335a4d57a27b6967b868d67572aecfa38
+  md5: edfacb0742d7dec1c039a4e9363aa336
+  license: MIT
+  license_family: MIT
+  size: 77608
+  timestamp: 1728656300028
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+  sha256: bbbcf47ef9249635b5199be1414b0b59687cc04ea9630d50ecc609dc200c095e
+  md5: 5820c373d6847a68551cadb8984a8277
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 95638
+  timestamp: 1706895270850
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/google-auth-2.29.0-py310hca03da5_0.tar.bz2
+  sha256: 268cd7e8fb909de39a48341f89341f68e0cae56cdf77cebfa3dd5c9c90022035
+  md5: 82e2f4348eb473248d3628a666be0846
+  depends:
+  - aiohttp >=3.6.2,<4.0.0dev
+  - cachetools >=2.0.0,<6.0
+  - pyasn1-modules >=0.2.1
+  - pyopenssl >=20.0.0
+  - python >=3.10,<3.11.0a0
+  - requests >=2.20.0,<3.0.0dev
+  - rsa >=3.1.4,<5
+  constrains:
+  - pyu2f >=0.1.5
+  - cryptography >=38.0.3
+  license: Apache-2.0
+  license_family: Apache
+  size: 215766
+  timestamp: 1715111181443
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/google-auth-oauthlib-0.5.2-py310hca03da5_0.tar.bz2
+  sha256: 6e15acc1da3adb1cdd179fba16a60f42c23477b07a295aa2dfdd2fd72f942bbc
+  md5: b680d8c661be931fafd1758ef2ac3d8d
+  depends:
+  - click >=6.0.0
+  - google-auth >=1.0.0
+  - python >=3.10,<3.11.0a0
+  - requests-oauthlib >=0.7.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 28219
+  timestamp: 1660687889741
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpc-cpp-1.48.2-h877324c_0.tar.bz2
+  sha256: 9963e4eea827c92de0e1f67bcd3201dd26a8f36edcaf8485ebd1b8295973c150
+  md5: 34af50f83a91586dbac69f3b857b34a7
+  depends:
+  - abseil-cpp >=20211102.0,<20211102.1.0a0
+  - c-ares >=1.19.0,<2.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.20.4.0a0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - openssl >=1.1.1t,<1.1.2a
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3906551
+  timestamp: 1681912781323
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpcio-1.48.2-py310h877324c_0.tar.bz2
+  sha256: d05dab19c46f5f75b9528f5e04eb22b1ed707902cd1d3bcd05bc4a5d29dfa577
+  md5: 13a777670b28d01e2fdb31634ba22d64
+  depends:
+  - grpc-cpp 1.48.2 h877324c_0
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  - six >=1.6.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 765128
+  timestamp: 1681912877067
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/h11-0.14.0-py310hca03da5_0.tar.bz2
+  sha256: 66cdb1d4797110ee53d4e877463ae283983cc3d54e704de0a17e0bf4a345df9a
+  md5: 3cc3aeb058849d61cbb65dc69b0f2b16
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 85406
+  timestamp: 1706652351554
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/h5py-3.12.1-py310h8456320_0.tar.bz2
+  sha256: 898853f6f4667141a33ffc91106a698c55f15c7624918039ab0fb2a64e94ba04
+  md5: fdde76f1596ce45e27df9c7f1613efd7
+  depends:
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - numpy >=1.19.3,<3
+  - numpy >=1.21,<3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1410792
+  timestamp: 1730216170930
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf4-4.2.13-h5e329fb_3.tar.bz2
+  sha256: e9ccc7a4ec25606556785100e6ee1dd5d9b04ed1973978545a37bfe6be929ddc
+  md5: 2a40342fd2402a56d833312609fcf16b
+  depends:
+  - jpeg >=9b,<10a
+  - libcxx >=12.0.0
+  - zlib >=1.2.11,<2.0.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 913497
+  timestamp: 1629192094107
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf5-1.12.1-h160e8cb_2.tar.bz2
+  sha256: 4f5dc26b65f4f1404408a52d90d867dcdaed53d6b1934b4069fca5ab69e2bf8f
+  md5: 31c93ccfd519d969aedb84bf093b3c1d
+  depends:
+  - libcurl >=7.82.0,<9.0a0
+  - libcxx >=12.0.0
+  - libgfortran5
+  - openssl >=1.1.1o,<1.1.2a
+  - zlib >=1.2.12,<2.0.0a0
+  license: HDF5
+  license_family: BSD
+  size: 6270448
+  timestamp: 1655307672422
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.20.0-py310hca03da5_0.tar.bz2
+  sha256: ca6ab23c8b062bb006a5efff2bab9000be762493a6e980c7f28e471ec8847d60
+  md5: c2271963d3121be343173d879a2b593b
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=2.1
+  constrains:
+  - plotly >=4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5300100
+  timestamp: 1730827718195
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpcore-1.0.2-py310hca03da5_0.tar.bz2
+  sha256: cb94dd4f6bb68031d020cfbdaf9eb0b01c855f4e97641e60dc17dd1a7a2f5b60
+  md5: 3cc94921555c6c7ac7b3c60908d837e2
+  depends:
+  - certifi
+  - h11 >=0.13,<0.15
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 85832
+  timestamp: 1706728507413
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpx-0.27.0-py310hca03da5_0.tar.bz2
+  sha256: cf7d268bdc6c9a8172af133392c33941847cd0bd1cc3787c980be1486e943b76
+  md5: 582426b72befd94e7becbdf1bd9941be
+  depends:
+  - anyio
+  - certifi
+  - httpcore >=1.0.0,<2.0.0a0
+  - idna
+  - python >=3.10,<3.11.0a0
+  - sniffio
+  constrains:
+  - h2 >=3.0.0,<5.0.0a0
+  - rich >=10.0.0,<14.0.0a0
+  - click >=8.0.0,<9.0.0a0
+  - socksio >=1.0.0,<2.0.0a0
+  - pygment >=2.0.0,<3.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 161137
+  timestamp: 1723475100041
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-68.1-hc377ac9_0.tar.bz2
+  sha256: ec6fe8fb2533f8fae73866531ad8c93b20a2b060737d237445f115455c3ab96b
+  md5: cec95fa3d8b36559af63caf4fb1f6caf
+  depends:
+  - libcxx >=12.0.0
+  license: MIT
+  size: 13742625
+  timestamp: 1630597537784
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py310hca03da5_0.tar.bz2
+  sha256: 360447ea7418dda653de5777d451a5560d6d41b785fc29f934db23bb792b2716
+  md5: 5164d4c696d13b8d5d568065213c1f1f
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 140568
+  timestamp: 1714398898493
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/imagecodecs-2023.1.23-py310h604db08_0.tar.bz2
+  sha256: 281b41a4108d41a042765376fd6e3a0f23d11d973104d0d137b351570027a520
+  md5: 7a15d0b37ac113fb3f4489e0b17cd606
+  depends:
+  - blosc >=1.21.3,<2.0a0
+  - brotli >=1.0.9,<1.1.0a0
+  - brunsli >=0.1,<1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - cfitsio >=3.470,<3.471.0a0
+  - charls >=2.2.0,<2.3.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - jxrlib >=1.1,<1.2.0a0
+  - lcms2 >=2.12,<3.0a0
+  - lerc >=3.0,<4.0a0
+  - libaec >=1.0.4,<2.0a0
+  - libavif >=0.11.1,<0.11.2.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.7.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - libzopfli >=1.0.3,<1.1.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - numpy >=1.21.5,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - snappy >=1.1.9,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zfp >=1.0.0,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10129220
+  timestamp: 1695065549016
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/imageio-2.33.1-py310hca03da5_0.tar.bz2
+  sha256: 61e30012ab7d690de11180363f99965d33f028b6d40384261ebca14fcfb8a60a
+  md5: faf80f005d60d080691425f637ef9674
+  depends:
+  - numpy <2.0a0
+  - pillow >=8.3.2
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 525304
+  timestamp: 1707247345409
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-8.5.0-py310hca03da5_0.tar.bz2
+  sha256: eaa322e6c0e2ec190fdc3e0c94bbc3fa31c1c6da199b3859d1011f05fa3891e4
+  md5: 32f8daf7db4e408ff4f1bd167cc298d0
+  depends:
+  - python >=3.10,<3.11.0a0
+  - zipp >=3.20
+  license: Apache-2.0
+  license_family: APACHE
+  size: 46513
+  timestamp: 1732633739325
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/intake-0.7.0-py310hca03da5_0.tar.bz2
+  sha256: 9e14b07e9b7a757db6b4dbc7722f183c2e0854ab8afc13e4eaddbc579cc91c54
+  md5: 6d8d033d3d1e6d268e3bce1623726d7d
+  depends:
+  - appdirs
+  - dask >=1.0
+  - entrypoints
+  - fsspec >=2021.7.0
+  - jinja2
+  - msgpack-python
+  - python >=3.10,<3.11.0a0
+  - python-snappy
+  - pyyaml
+  - requests
+  - tornado
+  constrains:
+  - panel >=0.7.0
+  - bokeh
+  - hvplot
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 199313
+  timestamp: 1717514041500
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/intake-xarray-0.7.0-py310hca03da5_0.tar.bz2
+  sha256: a9f0bb7b67c178831f13e5001a867ff5eb4abe7b29f23a9a47c6bc489f5dbf0a
+  md5: bbb946a18496f60736e7a355a57dce8d
+  depends:
+  - dask-core >=2.2
+  - fsspec >=2022
+  - intake >=0.6.6
+  - msgpack-python
+  - netcdf4
+  - python >=3.10,<3.11.0a0
+  - requests
+  - xarray >=2022
+  - zarr
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 69297
+  timestamp: 1717524055546
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py310hca03da5_0.tar.bz2
+  sha256: ce06824b134eedc5d74310b8a976b168f475697167bb739a74ac4156f97bd9b1
+  md5: 87019d9afe2ef0840445579775d764b5
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192712
+  timestamp: 1728666215929
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.27.0-py310hca03da5_0.tar.bz2
+  sha256: 47be5da95e64b4448247b085c8f052494c70a2afa1c80135141e36ffe4693ece
+  md5: ce38b8f0770e3f187f1c86989e2e6094
+  depends:
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.10,<3.11.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1299601
+  timestamp: 1726064513633
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipywidgets-8.1.2-py310hca03da5_0.tar.bz2
+  sha256: 23a1bbb5da8d4ef77debe076fe309ab9eadf547470f2211fbb9c685f51f7ec48
+  md5: 2d69d6b967dcd675311d57bf23ef80f6
+  depends:
+  - comm >=0.1.3
+  - ipython >=6.1.0
+  - jupyterlab_widgets >=3.0.10,<3.1
+  - python >=3.10,<3.11.0a0
+  - traitlets >=4.3.1
+  - widgetsnbextension >=4.0.10,<4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 202271
+  timestamp: 1709574791555
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.1-py310hca03da5_0.tar.bz2
+  sha256: c91df5cf80f28399c1f49e03a2c8fde564225517920a21cceb4cfb336e5adc1d
+  md5: 99efe9747834edc5ae09c7185e6b0d96
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1058032
+  timestamp: 1721058440071
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py310hca03da5_1.tar.bz2
+  sha256: dada56693dbedee088ee4523ed5248ae6a476abe9b5edc365e509833b8bf35e6
+  md5: 2e754658d98e4ff4d374441fe510586f
+  depends:
+  - markupsafe >=2.0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 276497
+  timestamp: 1730902914906
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jmespath-1.0.1-py310hca03da5_0.tar.bz2
+  sha256: 3861ca4d9fa10b2a9e10eae953aa1fe4cd8abe8d67b130ec95f110021f54d897
+  md5: 2d75084740d82363c4f88176433e4a94
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 38468
+  timestamp: 1700144671260
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+  sha256: 9d5cbffa98f3a4391f66b0c5ce1f411f0bfb0eb83137dc7146fb7bae23cb3570
+  md5: 95c92318023482e4e8c698ae6c4597fe
+  license: IJG
+  license_family: Other
+  size: 274078
+  timestamp: 1722872672311
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/json5-0.9.25-py310hca03da5_0.tar.bz2
+  sha256: 8d65efbe25a0b420ece57f79a138b09b4537040880ce44b4dd034e6f34b96d97
+  md5: cbe32d5cdd9ee7a6197957efa757af6d
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 46886
+  timestamp: 1730786846967
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.23.0-py310hca03da5_0.tar.bz2
+  sha256: 4dfab8bfd99556a2783020cc0d845bbd6a1380d5da6c9b2365d8232021358735
+  md5: 764286388774d2965f2f34ccd7916664
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.10,<3.11.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 146561
+  timestamp: 1728486802755
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py310hca03da5_0.tar.bz2
+  sha256: b6d49e1ec73a4421a78073bed47919ae47c09d66206353c268545c7eb3bb8286
+  md5: 606b118a1cbcc4e2651d863bd33d41f3
+  depends:
+  - python >=3.10,<3.11.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 15902
+  timestamp: 1699032410304
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter-lsp-2.2.0-py310hca03da5_0.tar.bz2
+  sha256: 8548081d15ed7eaf311547d08e628bf577e83e972e147b963a5668d0a00a82d7
+  md5: c93fb997d7279f2cc412a914e028798b
+  depends:
+  - jupyter_server >=1.1.2
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 82335
+  timestamp: 1699978325232
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-8.6.0-py310hca03da5_0.tar.bz2
+  sha256: b4706c21e910ed8a1d670a0dce2f39498fd554726b89bc2d678a4bf4205f730a
+  md5: 4f2e372ea9499024e660b9ae5773cbd5
+  depends:
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 173820
+  timestamp: 1699456879695
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py310hca03da5_0.tar.bz2
+  sha256: f4ff3a46e33fa359a8dc029868146908671c34cc1d71715ef4eccbb99d891aa0
+  md5: 831574b90268a2de1b53374c7c4148cc
+  depends:
+  - platformdirs >=2.5
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 83854
+  timestamp: 1718818403866
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py310hca03da5_0.tar.bz2
+  sha256: 90dffc620b1e5ee18a37251bc2b106158de2dcc246239c2f3590de79619255eb
+  md5: b8e9d261f27e2ce37e75355c5c6c8e16
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.10,<3.11.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36893
+  timestamp: 1718738185513
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py310hca03da5_0.tar.bz2
+  sha256: 0625ddfafd499065ede7b6df3e5e531d31c056dc051fda57fba9ffb4d7ffd8c2
+  md5: e4112ef7f4ba235c358985397775838a
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 504039
+  timestamp: 1718828083626
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py310hca03da5_1.tar.bz2
+  sha256: 45c774feba2c07c9fdbdb68e6f39b4d896a073d4d1e5aafb5ced7cf899a81e31
+  md5: 3f52ce26064c931ba359a6d19b72461d
+  depends:
+  - python >=3.10,<3.11.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24640
+  timestamp: 1686870953350
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab-4.2.5-py310hca03da5_0.tar.bz2
+  sha256: 6d732a5e7b9956755bbecb754ecc1ea7fe1301225da2c7c4b7f814d220f8e433
+  md5: d94af59be90031abf9f61e2c086fdaa0
+  depends:
+  - async-lru >=1.0.0
+  - httpx >=0.25.0
+  - ipykernel >=6.5.0
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.27.1,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.10,<3.11.0a0
+  - setuptools >=40.1.0
+  - tomli >=1.2.2
+  - tornado >=6.2.0
+  - traitlets
+  constrains:
+  - nodejs >=20.0.0,<21.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8331180
+  timestamp: 1725896465344
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_server-2.27.3-py310hca03da5_0.tar.bz2
+  sha256: 2600048867f3d098d5a795c7ed9786168afd296840168d7ce7010bbcdb07db58
+  md5: d0df3d705c3399cb8a2e510bda7f014a
+  depends:
+  - babel >=2.10
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18.0
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.10,<3.11.0a0
+  - requests >=2.31
+  constrains:
+  - openapi-core >=0.18.0,<0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84464
+  timestamp: 1725865508779
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_widgets-3.0.10-py310hca03da5_0.tar.bz2
+  sha256: e03f4c750ea8724e3575c1bed1469b72d4d7c149efa539f220fc2e1582132c5c
+  md5: ce7224be9130dc4700e1ed6da0a33be8
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jupyterlab >=3,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192364
+  timestamp: 1709322920540
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jxrlib-1.1-h1a28f6b_2.tar.bz2
+  sha256: bd9a167e45cb8cb9710b5a19c498a67ac78d57f252be120973e347dbdd93aa36
+  md5: 5db215a69fb5d3f393e58bc6e5df5a3a
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 220109
+  timestamp: 1628860886330
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/keras-2.12.0-py310hca03da5_0.tar.bz2
+  sha256: 3404884d2af9064b10f8bc7f2761fcb7b4a28ef19dbf0d86ff6723b58d87610d
+  md5: f1f602cd25c7e65f3b04608a5459f5e0
+  depends:
+  - keras-preprocessing >=1.1.2
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - tensorflow-base  2.12.*
+  license: Apache-2.0
+  size: 2264984
+  timestamp: 1685212966727
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py310h313beb8_0.tar.bz2
+  sha256: 379b8b9c8e45b813e6d31a712c2d5c8ae5801570b4717626971fabe87938c51f
+  md5: 2ff257d592914060b35560de4fe1c83f
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64635
+  timestamp: 1672387310531
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
+  sha256: e547a4a540ccc9db683d6d2e3e36b0d0ad99e1ad10b22b5f403af3e893b412ba
+  md5: dc5ae0ece3c4990ba5fee7b266f2a019
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - openssl >=1.1.1u,<1.1.2a
+  license: MIT
+  license_family: MIT
+  size: 1306804
+  timestamp: 1686931342120
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lazy_loader-0.4-py310hca03da5_0.tar.bz2
+  sha256: db6cf4dda70f2812e759a97352ce617af0e1cbd80d9552077947700c76cf96b5
+  md5: e13b55048fa009d4369351f2ed26c780
+  depends:
+  - packaging
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21881
+  timestamp: 1718176828263
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libaec-1.0.4-hc377ac9_1.tar.bz2
+  sha256: 7fb9ae8531636f858e80fa142bc518ec5ffe2c50e655d0b5e66982a5abd42c5b
+  md5: e97f2f3ed8030db3ed46111dc6d0dbaa
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 25647
+  timestamp: 1628861308643
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libavif-0.11.1-h80987f9_0.tar.bz2
+  sha256: 7693526f3d7e012ce568832508982154cc65e6afaacb172623e64c8f5b863e75
+  md5: bfd3a5c3793bce213c83bd8b1b837fe8
+  depends:
+  - aom >=3.6.0,<3.7.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 92755
+  timestamp: 1689158136997
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.73.0-h49e8a49_12.tar.bz2
+  sha256: 4342165ac2224b02089c3a8db136f067cabddb9f8a6a13e46b839d0b5263a841
+  md5: e13a408297da09dd8d77e6e4904f4232
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=68.1,<69.0a0
+  - libcxx >=12.0.0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 20106750
+  timestamp: 1655879742590
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+  sha256: 199042b87451abaf14546af124ae3380194cddda928e0d30ccb341e93084854c
+  md5: eaa0442887994a82486c65d87f6b71e6
+  license: MIT
+  size: 68806
+  timestamp: 1714483212137
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+  sha256: bd9a8a17fb14086446b710fa029d238e69274b83ee2e7e09093496f190de82b5
+  md5: 66615d6a0cb5dcca3e20c019cde0ed2d
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_8
+  license: MIT
+  size: 32975
+  timestamp: 1714483225840
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+  sha256: e1bf77e8b975c30a69b08a08410622e27c8cff6f592ccfa590466b83d9e6d104
+  md5: 8af86bdac01fe303d693d9b76c071059
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_8
+  license: MIT
+  size: 310266
+  timestamp: 1714483239194
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
+  sha256: a94cc52c1ca2e421342d2fefc6d7774ff5118b9d01f4e22d33314f8520d33723
+  md5: 440575339cec83722e83087db31127bf
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.52.0
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 342121
+  timestamp: 1693515586487
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+  sha256: 9597df5344a718d37837966aa05091faf210260898fad5e7a64b87f17de9e90d
+  md5: 678a1f87940ef6cc421a092301b8c3fe
+  depends:
+  - ncurses >=6.4,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 167208
+  timestamp: 1703006281321
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+  sha256: 6fc572025852b210ecddcca3ab9ff3f1d5f6bd91f1933c6e296de6bb331f6b5d
+  md5: 6dd7d9c5737bbd2a27d18f15318dc3e6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 102059
+  timestamp: 1628961869728
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-hf27765b_0.tar.bz2
+  sha256: 60321df3cac6e0b97561448810d8575945e48fb0d13f1480f83733d56801223e
+  md5: c9637ab2110623a8e6f5a0c0e0576029
+  depends:
+  - openssl >=1.1.1m,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 441685
+  timestamp: 1642102532464
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+  sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
+  md5: f31e4eb9cd6447cc2f5ef0243a76540c
+  license: MIT
+  license_family: MIT
+  size: 120460
+  timestamp: 1714483461787
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+  sha256: 72d242814b990900c9410d4738cc685f70ea71231742293cffbb475d8df100f8
+  md5: f9976688992b7ac4b56f5600ee15b5c4
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1407202
+  timestamp: 1714483550601
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnetcdf-4.8.1-ha022005_4.tar.bz2
+  sha256: 962a15d8bbf1bfa7f4f1bf2b6a547b770f16ac8f6f374ebf1205f95d6893090a
+  md5: 37d8db4c0339cedc632314a34bb69886
+  depends:
+  - hdf4 >=4.2.13,<4.2.14.0a0
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  - libzip
+  - openssl >=1.1.1v,<1.1.2a
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1461182
+  timestamp: 1691155105280
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
+  sha256: 039483aadb821adffcc2aff761ec35474d633b6bc2f1eb7cce877a881d7ed290
+  md5: d75b21db95481154cfa9d7a871f0f3bf
+  depends:
+  - c-ares >=1.19.0,<2.0a0
+  - c-ares >=1.7.5
+  - libcxx >=14.0.6
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - openssl >=1.1.1u,<1.1.2a
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 743061
+  timestamp: 1686931613436
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
+  sha256: 239ec46c06c477e722230159971bac8d9eb14793a2e75f6e3d3a7a04ed5d5ebd
+  md5: 50e9c501f39bb262703c764789099f24
+  depends:
+  - libcxx >=14.0.6
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2338901
+  timestamp: 1675278555141
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
+  sha256: 48a8617773b57a4b9a8539782bf88a317f49a644d3f858aa0ad3ab13afc03ae7
+  md5: c3bc0fb3cc9a98ef1f2f83ef497fc5da
+  depends:
+  - openssl >=1.1.1u,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 334616
+  timestamp: 1686931322663
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h169de6a_2.tar.bz2
+  sha256: bd07607554df2d9a28a6480d88d8d80c461f043c76bf71d4b0a527771dc877a4
+  md5: b24333ab90dd7a604f7a2ccc8ae85671
+  depends:
+  - boost-cpp >=1.73
+  - libcxx >=14.0.6
+  - libevent >=2.1.12,<2.1.13.0a0
+  - openssl >=1.1.1u,<1.1.2a
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 361614
+  timestamp: 1687975091526
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
+  sha256: 479cf759232c2361af87493ecd124e7d3a8940030e42e1931234c35bea73c3bd
+  md5: cd8fe2c981594a457c6af3a0d5de0bd5
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 341817
+  timestamp: 1729160040909
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzip-1.8.0-h0c481fb_0.tar.bz2
+  sha256: 7035bf74c9adbc5d98ed17a5618a7b6df97479fc60e1398fd29a9f8b42bcb1b1
+  md5: 429d9725086eceeafd42a5369c5791b1
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - openssl >=1.1.1o,<1.1.2a
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 121284
+  timestamp: 1652981900392
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzopfli-1.0.3-hc377ac9_0.tar.bz2
+  sha256: 18eda005925fe6aaddb1a7a207b4ecab85981794cf1fba0fa72b765d59e4fe18
+  md5: 042769990cec17f009a3088932e8e1c3
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 149220
+  timestamp: 1628860942228
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py310hca03da5_0.tar.bz2
+  sha256: 4e992da1d64efc2158c185b23883dee1e50ccc7a1ccb61d1b0546e6eb44bc536
+  md5: aad3f66e7d96961764d2b5d0ab08efb3
+  depends:
+  - python >=3.10,<3.11.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 36178
+  timestamp: 1659783445874
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py310hca03da5_0.tar.bz2
+  sha256: a2dfd5de8c8946e1da759975b43bb4048bf720792f63e44a8197ebf78da18560
+  md5: eb339d709764df9583302fd4796f609d
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11926
+  timestamp: 1652903163430
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.3.2-py310h80987f9_0.tar.bz2
+  sha256: c24f63e59ba98c08c8935268a7a89281de64f3fcf53b30315dc010b762774b18
+  md5: d6c5da5afa0364f5b7ed2243ccd932dd
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37324
+  timestamp: 1686063926330
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+  sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
+  md5: f5f7e6e7541d8dc3d3df270d488d2e24
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176990
+  timestamp: 1714510588159
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py310hca03da5_0.tar.bz2
+  sha256: 8303fcbfcdf8ab390e505f34c5ac6fa057815139d8e6cf7380dc108eb772485c
+  md5: c769729b709fa4dd0a8da5be358de878
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 124217
+  timestamp: 1671541964591
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py310hca03da5_1.tar.bz2
+  sha256: b0e240d3ef06e292105f4e1b161426170e5897144c142d23df66935ab4108dc5
+  md5: 8c6193fc54f6c300530527f642efadf1
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 108119
+  timestamp: 1684279956548
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py310h80987f9_0.tar.bz2
+  sha256: b6174b6bbe0c49fed05460bb5374255984f590b766978729e8061460d4adc358
+  md5: c744c544e5226317d7d6d940b7e4614e
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24323
+  timestamp: 1704206219206
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.9.2-py310h7ef442a_1.tar.bz2
+  sha256: 9facb30ac3e128767e1fc5b42daec02e7f98172dcca39207f839ecf3dae99077
+  md5: a17c3f2320aa0fd87e51bb50f5e2c20f
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23,<3.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8415403
+  timestamp: 1732550527155
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py310hca03da5_0.tar.bz2
+  sha256: 9cfad1d0d85bf4079262292b47e62355c7c1847f641ca8dfc46c4226bce2d785
+  md5: b1a3a7ea89adee337db085727216abda
+  depends:
+  - python >=3.10,<3.11.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17383
+  timestamp: 1662014500374
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py310hca03da5_0.tar.bz2
+  sha256: 66e7f61e59f392a603639c284ce06bd2930a59270990089f602cdf2628467eb8
+  md5: cf0c798d425a37c0404fd04da7afb640
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 54195
+  timestamp: 1659721278389
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py310hca03da5_0.tar.bz2
+  sha256: 7f85b9bd603910fee4f7ecac3fbc3eb4b978ab16ad2acd88d3d5a03b89c6bace
+  md5: 984724161f039112bf536366c1332531
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 19648
+  timestamp: 1659716071039
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py310hca03da5_0.tar.bz2
+  sha256: 1d3223d19faee06a13d6e784b956d2eb6840139b7948fcf359d53afd4bc71382
+  md5: 83399b08729217b8295b7a07927e42ae
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 91328
+  timestamp: 1661496331337
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py310h525c30c_0.tar.bz2
+  sha256: e559f5b8fbde9231bb4199caab5a8b7cdc5c0a19a7844a0fb5399f255058e061
+  md5: 6310ffa34960c9b79ee0e8cb49b81ef1
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 90076
+  timestamp: 1652362752668
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multidict-6.1.0-py310h80987f9_0.tar.bz2
+  sha256: 6907984390536c7fdd601fe160264e4b59a2143079e21adc84909ab5de9d6678
+  md5: 2c48a1536124f37529644bedf2ae670d
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing-extensions >=4.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 53390
+  timestamp: 1730905541289
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py310hca03da5_0.tar.bz2
+  sha256: a195b8aba2a37e8aa17f3114e282548036da3eb5a5536b67d4449b362e6cefff
+  md5: 07b1977a07d7dbff70c8f5f90b985f9c
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101332
+  timestamp: 1698934238996
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.4-py310hca03da5_0.tar.bz2
+  sha256: 268df8609f5c43d3da5c08f9f8847adbeef63c46413b83aa10f7e7bb9059c26e
+  md5: c3eefc73916dbcd8bbe53f9a8dfa007e
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.10,<3.11.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - pyqtwebengine >=5.15
+  - tornado >=6.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 491024
+  timestamp: 1728049880655
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py310hca03da5_0.tar.bz2
+  sha256: 1d56811db3dcf64f81534f8c062f13f5a0ad32a477ac34f13fc8a8d312b138d1
+  md5: d7bbf5d0fee20be1955640948e289403
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.10,<3.11.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 149708
+  timestamp: 1728049678663
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py310hca03da5_0.tar.bz2
+  sha256: 737ecaada7f80f42da43affef97fc31a8dcd3f2a0be14b377b34583a7d334fdf
+  md5: 914980d852a22de592f571dba8d4fe62
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14550
+  timestamp: 1708532774873
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/netcdf4-1.6.2-py310he1bbb67_0.tar.bz2
+  sha256: e594958884817ae602e2c2342b37767b1c5709cc2c832f26347dd90f15861136
+  md5: 0f35b88c44e7f1bf53b2c4b9d427fcf9
+  depends:
+  - cftime
+  - hdf5
+  - libnetcdf >=4.8,<4.9.0a0
+  - libnetcdf >=4.8.1,<5.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 454017
+  timestamp: 1673455699701
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.3-py310hca03da5_0.tar.bz2
+  sha256: 53a33aae2c35d13d870512c037d52a6e6e61be38cdab5726734e049db7d814ff
+  md5: 1378fd76998411b933f35f2d73e21a1f
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - pygraphviz >=1.12
+  - pydot >=2.0
+  - pandas >=1.4
+  - lxml >=4.6
+  - numpy >=1.23,<2.0a0
+  - sympy >=1.10
+  - scipy >=1.9,!=1.11.0,!=1.11.1
+  - matplotlib-base >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2666241
+  timestamp: 1720002652389
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-7.2.2-py310hca03da5_1.tar.bz2
+  sha256: d27ff21221c9033730a7ecccf28b53c7d0aebdae55388041af93a202c75d7ff9
+  md5: 5a724eca20996cae7cf89a6766bcf612
+  depends:
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab >=4.2.0,<4.3
+  - jupyterlab_server >=2.27.1,<3
+  - notebook-shim >=0.2,<0.3
+  - python >=3.10,<3.11.0a0
+  - tornado >=6.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4534081
+  timestamp: 1727199405663
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py310hca03da5_0.tar.bz2
+  sha256: 62494435862be4443468b06ed8d029ec8ef14f7945b10174fe55b345a9181567
+  md5: 1e0215bd9da3ef2be9d173891f768e23
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23537
+  timestamp: 1699455985908
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numcodecs-0.12.1-py310h1a4646a_0.tar.bz2
+  sha256: 1ba5051385eea2e2c04f0fe47d68523173090a2cb459ebe30f2d0ce417aeebb4
+  md5: 630b68d2574be70f5b9c9ec555e248b5
+  depends:
+  - blosc >=1.21.3,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - msgpack-python
+  - numpy >=1.7,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 415435
+  timestamp: 1707513273399
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.10.1-py310h5d9532f_0.tar.bz2
+  sha256: 70e26f68ff7dc69d6417069df514b1085914be61378334366b217458f1a79179
+  md5: cdd4433b58dd859c52223a31376ea329
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.21,<3
+  - numpy >=1.23.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 163018
+  timestamp: 1730216049164
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.23.5-py310hb93e574_0.tar.bz2
+  sha256: aace873ea10996846afd0487462b74e076b5e8919a9be1a71d7972ece6e744ba
+  md5: e59c523ea46b7f058a051a9ce685106b
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.20,<1.0a0
+  - numpy-base 1.23.5 py310haf87e8b_0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11053
+  timestamp: 1672337428035
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.23.5-py310haf87e8b_0.tar.bz2
+  sha256: a30f5cd0257201b7d71bdfd5536308b945ffa54f39f8ca9e76e18314e24d1ef1
+  md5: 12e1f46a552145d0b31dacfa04287738
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.20,<1.0a0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - numpy 1.23.5 py310hb93e574_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6274503
+  timestamp: 1672337414505
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/oauthlib-3.2.2-py310hca03da5_0.tar.bz2
+  sha256: 6e0712255c3f786ed3d5e8dab3ae0e9a574887d7d4862b86811bd326cebbe51a
+  md5: 506486ae577ab2cf62eea6262a1aab73
+  depends:
+  - blinker >=1.4.0
+  - cryptography >=3.0.0
+  - pyjwt >=2.0.0,<3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 235536
+  timestamp: 1679489746515
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
+  sha256: b9f781280f49644ca05e18aacbdde1c57cc5107e7cc2471b843ea8461672aa7f
+  md5: 9125d30e4e105b45f7f7d9c20acafa10
+  depends:
+  - libcxx >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.7.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 450131
+  timestamp: 1722872679313
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
+  sha256: 409ba99dd953129c0ccebb5dcbf2049920e5a755b88e7e392e4f91be924e26ef
+  md5: f05f00606c10617a61c41f23652b9a00
+  depends:
+  - ca-certificates
+  license: OpenSSL
+  license_family: Apache
+  size: 3450897
+  timestamp: 1694465216241
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
+  sha256: c4135710b5536fb859a6672c055bbc2cff0426e0655e75c7fdf808f7f3344ada
+  md5: 483605a01fccba850b7f0cbdeff29858
+  depends:
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.9,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 421604
+  timestamp: 1676482754496
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py310hca03da5_0.tar.bz2
+  sha256: 285cdb7abdf5635133d2196adf11e19d68583fdfdc52e952ba066e57c16476f0
+  md5: 1cba5fcb7ad91b512dcbf70d859059f2
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 31861
+  timestamp: 1699371195680
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.1-py310hca03da5_0.tar.bz2
+  sha256: e555b55da4d7b032148c734d3ecf07bb1a6e2276ee602d86dd7cb305117a23ce
+  md5: 106f589b3795ec7b7447f642c78bdd93
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 136781
+  timestamp: 1720102019422
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.3-py310hcf29cfe_0.tar.bz2
+  sha256: 1b5782f67429e64b3e5f3a60c06b997f2006c8c18a64c743884dcf2d0ec83ecb
+  md5: d5219a0f279106f3cad71e1fc7d01a3c
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.22.4,<3
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - pyreadstat >=1.2.0
+  - scipy >=1.10.0
+  - fsspec >=2022.11.0
+  - adbc-driver-postgresql >=0.8.0
+  - pymysql >=1.0.2
+  - openpyxl >=3.1.0
+  - jinja2 >=3.1.2
+  - numba >=0.56.4
+  - pyqt >=5.15.9
+  - sqlalchemy >=2.0.0
+  - zstandard >=0.19.0
+  - dataframe-api-compat >=0.1.7
+  - s3fs >=2022.11.0
+  - adbc-driver-sqlite >=0.8.0
+  - html5lib >=1.1
+  - fastparquet >=2022.12.0
+  - odfpy>=1.4.1
+  - xarray >=2022.12.0
+  - psycopg2 >=2.9.6
+  - xlrd >=2.0.1
+  - matplotlib-base >=3.6.3
+  - python-calamine >=0.1.7
+  - blosc >=1.21.3
+  - lxml >=4.9.2
+  - gcsfs >=2022.11.0
+  - tabulate >=0.9.0
+  - xlsxwriter >=3.0.5
+  - qtpy >=2.3.0
+  - pyxlsb >=1.0.10
+  - pandas-gbq >=0.19.0
+  - pyarrow >=10.0.1
+  - beautifulsoup4 >=4.11.2
+  - pytables >=3.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14023520
+  timestamp: 1732736308872
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.5.3-py310hca03da5_0.tar.bz2
+  sha256: 6daf5490db05533c675436669d1df97178d9e503aba6bf2620c466eef6952780
+  md5: 5a0b7f9f3e6ed6da55bb25d5aac09a1a
+  depends:
+  - bleach
+  - bokeh >=3.5.0,<3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.1.0,<3.0
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing-extensions
+  constrains:
+  - holoviews >=1.18.0
+  - bokeh-fastapi >=0.1.2,<0.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23678961
+  timestamp: 1730380929882
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.1-py310hca03da5_0.tar.bz2
+  sha256: e9c81d6bbbdbc07ca5f13bdf63d0faa9da971b5365388fc2b0ba882c7e08a427
+  md5: b2e52207827e0f168b073d366f64d029
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 195438
+  timestamp: 1719348004795
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py310hca03da5_0.tar.bz2
+  sha256: 24c36db498b26baebf4c9d1327d8e2ba533e92d7a7191c62ed5dba7581ad20b8
+  md5: 95d6ab469e9d95d9efaa03f2a4a797a4
+  depends:
+  - locket
+  - python >=3.10,<3.11.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37051
+  timestamp: 1698702637098
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-11.0.0-py310hfaf4e14_0.tar.bz2
+  sha256: 6b28449ec76cb8f5491ca1d185a92356e5fe48d916fc4d86a92b203e7b00b2ff
+  md5: f4a1d6c5978cf692033e978decdd28b8
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 787765
+  timestamp: 1731594847999
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.2-py310hca03da5_0.tar.bz2
+  sha256: 1aa0935f04ae37c9c9d1ee10d14d3a43efcb0b6fe58c5641dc846c320ad57a18
+  md5: 773dfa7c2b5ea4cae3a5937f3692d234
+  depends:
+  - python >=3.10,<3.11.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2338498
+  timestamp: 1723484780184
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py310hca03da5_0.tar.bz2
+  sha256: f90967e7b1263de747709a00d54c5c41ef7efe03ece8b480cd2f811ed6da7e68
+  md5: 68b0d1ba5f14b5296c2e880e3ce8e1cf
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 33194
+  timestamp: 1692205719500
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.21.0-py310hca03da5_0.tar.bz2
+  sha256: 8205872ee591cd1fcb943d8be888ccea474d98767cc3989a1b9927d780a17fc9
+  md5: e52f838afbf6ee8fb22e88fd5be62562
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91871
+  timestamp: 1731958921926
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py310hca03da5_0.tar.bz2
+  sha256: f6ee51edfa968855dc223819720f1519e6defd1ba724a3efc69e4d6f2ec23284
+  md5: 29b8d61161d1e8b636975eb0079559e1
+  depends:
+  - python >=3.10,<3.11.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 600549
+  timestamp: 1704404395992
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/propcache-0.2.0-py310h80987f9_0.tar.bz2
+  sha256: d7cd5fb7602991c0c970399be9337981a883ba96c905852f39695fe835733332
+  md5: f50cf5553a05c2b00fa40d6799046891
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52987
+  timestamp: 1732304251888
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/protobuf-3.20.3-py310h313beb8_0.tar.bz2
+  sha256: 10f5d2a0d42b51078a460e1b3ad43a75de0806795a1e276c2322a6abb76c8170
+  md5: b894b1606c1c320c9be4e494c4348a66
+  depends:
+  - libcxx >=14.0.6
+  - libprotobuf 3.20.3.*
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 317500
+  timestamp: 1675281450814
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py310h1a28f6b_0.tar.bz2
+  sha256: ddcca2ed0751d233e1953dcd1a373b1d778bd6c303e4bae3713fa7d20a814ed7
+  md5: 2cb18e1233648dbd160770e5941bf588
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372012
+  timestamp: 1656431417953
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-11.0.0-py310hbfed03b_1.tar.bz2
+  sha256: 3cbb59039f16b8091918228ad2f4f0d64819215bbe617ba894467a19acad32d1
+  md5: d2b3eae8855b35d2011c2e9240a5cbae
+  depends:
+  - arrow-cpp >=11.0.0,<11.0.1.0a0
+  - boost-cpp
+  - gflags
+  - libcxx >=14.0.6
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4416924
+  timestamp: 1693272945544
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py310hca03da5_1.tar.bz2
+  sha256: 5a345e4a9a6f8ff0264bd5a8238e591192915b99f44c75aef66033aecea15ec7
+  md5: e2c9a794ff909ab32cc84c4fc6964a6d
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1882595
+  timestamp: 1684280055553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyjwt-2.9.0-py310hca03da5_0.tar.bz2
+  sha256: 0158a159e5f6b894bd3cb137a87f86007b6bb962c3180175a84b2f3c0b422f2c
+  md5: d9a638f21e15e9412368125a1defcc37
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - cryptography >=3.4.0
+  license: MIT
+  license_family: MIT
+  size: 77592
+  timestamp: 1730786915454
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py310hca03da5_0.tar.bz2
+  sha256: 271d303a73878efe49bd997962fb5ba474fb118cd03d44958a3f61d446d87521
+  md5: bf861f951e567d14d903c7139c629d01
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95814
+  timestamp: 1690223518556
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.2.0-py310hca03da5_0.tar.bz2
+  sha256: 22e74c23cca917710891ff32e9945d567d1514db41c6b6b9df0824006ef41e92
+  md5: ecad23ec9b28284a55b34d641ba99d30
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 428093
+  timestamp: 1731445629850
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py310hca03da5_0.tar.bz2
+  sha256: 70946f5858f17fec169e726e761cce1d1f3e6a99ef3a8e72007c1df51e09d5a3
+  md5: f9c6d792e5983df39d7dbb8389340e9a
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 28542
+  timestamp: 1643961550827
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.10.13-hc0d8a6c_0.tar.bz2
+  sha256: db42db87d3ad4d3590482082f3164bec530214b7a485dde6f66fe4d6917cbd5c
+  md5: 5e2210c29b062f89053e706cc173d20d
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13884848
+  timestamp: 1694438892769
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py310hca03da5_2.tar.bz2
+  sha256: 7fe61148813d911c333451fa5b1752ed4da89b230a83a23b3cb3886e0ad7e1ed
+  md5: 8eef9f7a02ea012f3ae3c4cec6d09185
+  depends:
+  - python >=3.10,<3.11.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 290933
+  timestamp: 1716495762679
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.20.0-py310hca03da5_0.tar.bz2
+  sha256: 53e1d8c1d2695cd5d9f688631049f18fc2a86dc0ca525d6a3111121feaa5a67c
+  md5: af5cc0866a0e1be48e64a6f4ddfbd961
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 268376
+  timestamp: 1731939489375
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-flatbuffers-24.3.25-py310hca03da5_0.tar.bz2
+  sha256: 06eb0168744185c1c0136739329e9ff27791d601142b2338055e9c7859a6027d
+  md5: 887aae188a395583cdcd4e04dcfac52c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 54630
+  timestamp: 1722369270912
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py310hca03da5_0.tar.bz2
+  sha256: c6672f4736da5c863013a4cfc8279c278e22b8c8f355d375b1c123e6d16bea0f
+  md5: 873d8d6e3b69017e6bc0bd8f7539da58
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16249
+  timestamp: 1683823962980
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py310h313beb8_0.tar.bz2
+  sha256: bc6ee168edccda4c958ee354b6e877ea5f28014fd458f37f2031abeb7a8d5de5
+  md5: 587ddfc730311bdda83be3e7f2841f4f
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 133962
+  timestamp: 1682522396996
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-snappy-0.6.1-py310h313beb8_0.tar.bz2
+  sha256: 2dc18d37b0ad88a9a0ca2922145e73372edc821f45dbf91f97ce0676480e08c5
+  md5: 8821bbe361974618ff85599f56933bde
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  - snappy >=1.1.9,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 32077
+  timestamp: 1670943961923
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py310hca03da5_0.tar.bz2
+  sha256: 45b397640e696c094e62c9c0550f90585f1c0b1cc24b9d223f2628c0e258c673
+  md5: dd8fa678704016eda8ef7310b4b6b61e
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 267206
+  timestamp: 1713974370791
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py310hca03da5_0.tar.bz2
+  sha256: d051de2450e45b0cbb834a28fe37601d0e85751b4c57cdbd03d8c34715dafdbd
+  md5: f8ec20db3291bfbeb480cfdd09cbdde1
+  depends:
+  - param
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 61779
+  timestamp: 1711136945497
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.2-py310h80987f9_0.tar.bz2
+  sha256: febe6e3746ab0b0ca19c9b7489a3c1d56da2f4298b2f9c257be63fbb7388b4b5
+  md5: 56e8294ecd834396658ccbb5b6a468f5
+  depends:
+  - python >=3.10,<3.11.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 174905
+  timestamp: 1728658346122
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-25.1.2-py310h313beb8_0.tar.bz2
+  sha256: 7caf005fabe304f949b1c8f2a5950907e911f2ad9f475069732e468109e00550
+  md5: bd46d31905afc15f71576b9b3508b85c
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.10,<3.11.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 448576
+  timestamp: 1705605241316
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+  sha256: 089c6b9bebfa690f380710f219ab0fcc1acec9f2e187d4174a08222c45f58afc
+  md5: 11b832c6c10a6d2b0e687a20c3037c97
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-3-Clause
+  size: 194532
+  timestamp: 1652449531448
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py310hca03da5_0.tar.bz2
+  sha256: df8663fdef4fa89665fd78b0b2cd85e3f3665fcab21f1745975c7f5ca8d89abf
+  md5: 6fbce5783df1bd669bc5d9759adc4a22
+  depends:
+  - attrs >=22.2.0
+  - python >=3.10,<3.11.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 59310
+  timestamp: 1699012065626
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py310hca03da5_1.tar.bz2
+  sha256: 5d42a8a52734ee81f902f079098a076b7866a43d92c0576260b349c4380872e0
+  md5: a21325ab9964f913e7fa0a72ad612856
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.10,<3.11.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 99627
+  timestamp: 1730999198570
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-oauthlib-2.0.0-py310hca03da5_0.tar.bz2
+  sha256: 4b9e16768aa9ab3d7b22f8c6cab66417c7a0d72ba1e2a1af7f255a39c9bd5196
+  md5: f64d42cbe2d32bb9600d70eb504c63ac
+  depends:
+  - oauthlib >=3.0.0
+  - python >=3.10,<3.11.0a0
+  - requests >=2.0.0
+  constrains:
+  - pyjwt >=2.0.0,<3
+  - cryptography >=3.0.0
+  license: ISC
+  license_family: Other
+  size: 35355
+  timestamp: 1720615088130
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py310hca03da5_0.tar.bz2
+  sha256: 4f7adb8857af54586f8a27fecbd31626160f964ab18efd5a693182a91fe4a287
+  md5: 2e2a4c3a1f320aedaf65ea0deec06aa5
+  depends:
+  - python >=3.10,<3.11.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9834
+  timestamp: 1683077089689
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py310hca03da5_0.tar.bz2
+  sha256: cc20aee97ef5f28b78867fd74e2e9a5785985c3fa56d31f983fea00c2805b76d
+  md5: d566a3096aee8f6ea77d12124075ae14
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 10216
+  timestamp: 1683059019921
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py310h2aea54e_1.tar.bz2
+  sha256: 9c2239c9846736019f5a6d1dd6af71bee0e529bf2c6e9c2899893516659820e7
+  md5: 527ba0d9051dd6f9dad852c2a56510d5
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 317967
+  timestamp: 1732228735154
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/s3fs-2024.6.1-py310hca03da5_0.tar.bz2
+  sha256: a7a450f86f44c4215a0ca56bf3f847941cf2451b31ac7f7c61aff5d7eb0955ba
+  md5: 1961c61c57f1c5d49bcea378d316253f
+  depends:
+  - aiobotocore >=2.5.4,<3.0.0
+  - aiohttp !=4.0.0a0,!=4.0.0a1
+  - fsspec 2024.6.1.*
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 57141
+  timestamp: 1724924159335
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scikit-image-0.24.0-py310h46d7db6_0.tar.bz2
+  sha256: 010d94a7c55242256c32f3b42c487b53f0c5e84d941416218b706f658f332d52
+  md5: 47be83151779c61a53cb876e4828be7b
+  depends:
+  - imageio >=2.33
+  - lazy_loader >=0.4
+  - libcxx >=14.0.6
+  - networkx >=2.8
+  - numpy >=1.23,<2.0a0
+  - packaging >=21
+  - pillow >=9.1
+  - python >=3.10,<3.11.0a0
+  - scipy >=1.9
+  - tifffile >=2022.8.12
+  constrains:
+  - matplotlib-base >=3.6
+  - pooch >=1.6.0
+  - cloudpickle >=0.2.1
+  - dask-core >=2021.1.0
+  - pywavelets >=1.1.1
+  - astropy >=5.0
+  - scikit-learn >=1.1
+  license: BSD-3-Clause AND MIT AND BSD-2-Clause
+  license_family: Other
+  size: 12011432
+  timestamp: 1726738208952
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.14.1-py310hd336fd7_0.tar.bz2
+  sha256: c6e9bcae595697f632783f3ea3fbb0882e24c645f58848aeae3fbcc97d89880c
+  md5: d92ee83bf55d4364b672cda45bc1b99e
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.23.5,<2.3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 23883658
+  timestamp: 1731627266555
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py310hca03da5_0.tar.bz2
+  sha256: fd992b57890893f639b37cc529876a6efbd8acad4fb1f6e82c24994ba4bf4c69
+  md5: 47a4a8ea39e24c437515e906d8b65bf0
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28099
+  timestamp: 1699371253809
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-75.1.0-py310hca03da5_0.tar.bz2
+  sha256: d498fc185eaa21221eb23dc177ffce3ce10e6b1395e04610a011b3508757cd17
+  md5: 344e3c8d1b1fd862480b9f7fcd8d10ce
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1765257
+  timestamp: 1726677915032
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
+  sha256: 499623019bea7cd167924f7fa841237b11b81a1e9cafe9b8ffde47d329275167
+  md5: 290d04cffc69bf26a4ed9f1aa9ad42e4
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 46038
+  timestamp: 1723557442909
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py310hca03da5_0.tar.bz2
+  sha256: 74d7c55748b5c46e8ebe6249c8528de7a27426b905953f927f41a4aa61f0d6df
+  md5: 78c17d8433ab6fcbd613cd9d21bc09b7
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17940
+  timestamp: 1705431340501
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py310hca03da5_0.tar.bz2
+  sha256: 83f37d7fdb2ae2499a0d56b0d8b73aaea225272a1133ec83b7cb5a0b76dcc038
+  md5: 4cf31645d894294b7542e108702346c3
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 67932
+  timestamp: 1696347608160
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+  sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
+  md5: d8c1e9910392d0bcb22a173f9ce30fa6
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1758290
+  timestamp: 1714488307689
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+  sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
+  md5: ae58720a18a2ed15eae214ad7a10d1b5
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 140125
+  timestamp: 1680167256603
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorboard-2.12.1-py310hca03da5_0.tar.bz2
+  sha256: c311388b0f6d85e4d998b1f77fdf7b6d5e51de99cb78ace00a41cbc39c66ee85
+  md5: 095ed3fb6891f86368cb364d9ce37150
+  depends:
+  - absl-py >=0.4
+  - google-auth >=1.6.3,<3
+  - google-auth-oauthlib >=0.4.1,<1.1
+  - grpcio >=1.48.2
+  - markdown >=2.6.8
+  - numpy >=1.12.0,<2.0a0
+  - protobuf >=3.19.6
+  - python >=3.10,<3.11.0a0
+  - requests >=2.21.0,<3
+  - setuptools >=41.0.0,<82
+  - tensorboard-data-server >=0.7.0,<0.8.0
+  - tensorboard-plugin-wit >=1.6.0
+  - werkzeug >=1.0.1
+  - wheel >=0.26
+  license: Apache-2.0
+  license_family: Apache
+  size: 5869202
+  timestamp: 1685305653579
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorboard-data-server-0.7.0-py310ha6e5c4f_1.tar.bz2
+  sha256: bcf5233efed232dcefca8427720f7fb4ce72467ea0d396a7807c049d5502cfee
+  md5: e473ffbe3ae923f1e4b72add11c37cbc
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4182035
+  timestamp: 1724172754917
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorboard-plugin-wit-1.8.1-py310hca03da5_0.tar.bz2
+  sha256: 225d625c1a1cc7dbfc8541f87f41469338fc6a8eddff0b1b4814f0f8b94e108b
+  md5: 06cf2d4a33a18bcc50e77656e92808bb
+  depends:
+  - python >=3.10,<3.11.0a0
+  - setuptools
+  - wheel >=0.26
+  license: Apache-2.0
+  license_family: Apache
+  size: 722007
+  timestamp: 1685213436358
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorflow-2.12.0-eigen_py310h205ab9b_0.tar.bz2
+  sha256: 6fd1c01721aab6583c778f94044bf7f8a986d9d447fbf6f64c6f9b6aff2513c1
+  md5: 4b450488b1301f18bf11bd83b98a9efb
+  depends:
+  - _tflow_select 2.2.0 eigen
+  - python 3.10.*
+  - tensorboard 2.12.*
+  - tensorflow-base 2.12.0 eigen_py310h0a52ebb_0
+  - tensorflow-estimator 2.12.*
+  license: Apache-2.0
+  license_family: Apache
+  size: 4942
+  timestamp: 1685908005956
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorflow-base-2.12.0-eigen_py310h0a52ebb_0.tar.bz2
+  sha256: 3d985442798fbf1dd29c01728f31979c4ce2dcd03d2903970b6ca58f82759eb5
+  md5: bfcb054e066f0afbed9d9298bd3a6fe1
+  depends:
+  - absl-py >=1.0.0
+  - astunparse >=1.6.3
+  - flatbuffers >=2.0
+  - gast 0.4.0
+  - giflib >=5.2.1,<5.3.0a0
+  - google-pasta >=0.2
+  - grpc-cpp >=1.48.2,<1.49.0a0
+  - grpcio >=1.24.3,<2.0
+  - h5py >=3.1.0
+  - icu >=68.1,<69.0a0
+  - jpeg >=9e,<10a
+  - keras 2.12.*
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - llvm-openmp >=14.0.6
+  - numpy >=1.22,<1.24
+  - openssl >=1.1.1t,<1.1.2a
+  - opt_einsum 3.3.0.*
+  - packaging
+  - protobuf >=3.9.2
+  - python >=3.10,<3.11.0a0
+  - python-flatbuffers >=2.0
+  - requests
+  - scipy >=1.7.3,<2
+  - six >=1.15.0
+  - snappy >=1.1.9,<2.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tensorboard 2.12.*
+  - tensorflow-estimator 2.12.*
+  - termcolor >=1.1.0
+  - typing_extensions >=3.7.4
+  - wheel >=0.35,<0.36
+  - wrapt >=1.11.2
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 200481940
+  timestamp: 1685513389284
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorflow-estimator-2.12.0-py310hca03da5_0.tar.bz2
+  sha256: 0fc0920631637b7b0252237c998d450b5ecf7ba46ac3034fe5c7eb2e39bebf82
+  md5: d7edcb13c28ea29edc86aeb00dc2a8da
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - tensorflow-base  2.12.*
+  license: Apache-2.0
+  license_family: Apache
+  size: 619036
+  timestamp: 1684880462952
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/termcolor-2.1.0-py310hca03da5_0.tar.bz2
+  sha256: 7ff45c2465dc239ba4793d964473638382c5b6ea3ac468021c249ff55f387b21
+  md5: 5d9ac5c4207e1b41706f19820b8c1742
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 12008
+  timestamp: 1668084673536
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py310hca03da5_0.tar.bz2
+  sha256: 683dfdcb2fa481064ecb68361103214c5c3f2734cceb055af3f93a2ae4863c01
+  md5: 88e05e239da5183806dbebb6ac49cddf
+  depends:
+  - ptyprocess
+  - python >=3.10,<3.11.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 31121
+  timestamp: 1671751855788
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tifffile-2023.4.12-py310hca03da5_0.tar.bz2
+  sha256: 1ad1cd47a353b111a09f6e828e711a48f76d030f3af11323f608d7faad2b053b
+  md5: df1635abb9786209a3a0d93c55745e88
+  depends:
+  - imagecodecs >=2023.1.23
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - matplotlib-base >=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 391886
+  timestamp: 1695107571656
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py310hca03da5_0.tar.bz2
+  sha256: 1ff9b75217073a26f736b2fe32f9ccb77b145d7ff9099d5091b43276f92b1f12
+  md5: 11474a3502e9b8c16e301569b7f3d8db
+  depends:
+  - python >=3.10,<3.11.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40061
+  timestamp: 1668168847595
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+  sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
+  md5: 3c25b4f4768ccda28b20a03ba27e7759
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3484151
+  timestamp: 1714770744982
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomli-2.0.1-py310hca03da5_0.tar.bz2
+  sha256: 8ddc284644ca9b8b23562f7b03d0960b6a43beafe9cb1fa9c89c23f57a7dab06
+  md5: 343e7b890cb241ab89d2f77f22e5c152
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 25797
+  timestamp: 1657175650575
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py310hca03da5_0.tar.bz2
+  sha256: 14e106fcb4a36e245d87f22c4981abb173508a29d6067baec2c4702b6ff65e87
+  md5: 14ae49e3923e548b548f66651604f7d3
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104795
+  timestamp: 1667464180564
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.1-py310h80987f9_0.tar.bz2
+  sha256: 7a248d0a49dc40b943f1d04e4c5cb6f77513ac2600c81fe1bca42b1813da2f15
+  md5: e62c2beab656357405fee719ff66990c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 699237
+  timestamp: 1718740235165
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.5-py310h33ce5c2_0.tar.bz2
+  sha256: 817940863cce40c31c4a1a69c79396a1ed5a5870964c7b54e9c33be98e44aa90
+  md5: 438d21cdd02411d558d4fb770005002e
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 128410
+  timestamp: 1724854061501
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py310hca03da5_0.tar.bz2
+  sha256: e9de8f52d147e7dd072058d19202ee179841a56f792224729723a470571b717f
+  md5: 3369365fe73af0c8b47246afdce17709
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 168051
+  timestamp: 1718227147763
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py310hca03da5_0.tar.bz2
+  sha256: 15854b2bfac87685fa4815a8617934f5e0ff96d097c428615d879cf0c687c682
+  md5: 8816d89e20b6cac4b750be13ad73e304
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing_extensions 4.11.0 py310hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9879
+  timestamp: 1715268909862
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py310hca03da5_0.tar.bz2
+  sha256: 6ff5a1ad8c4006966bb7200399cc6d4644b0e32fe6696a1ec9c34d239f7e7128
+  md5: e2d4052bbc72e068bfe888f4e6a68097
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 61500
+  timestamp: 1715268901349
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py310hca03da5_0.tar.bz2
+  sha256: 824583d1b434a796b37b52eed6e4356ee22fb743bbef86fb59d059d100d9bbbb
+  md5: d7f13af76ca65f6145c835983c1b42df
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 11622
+  timestamp: 1659769445368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py310h80987f9_0.tar.bz2
+  sha256: 3f3a102f3b5fe0000a8680efe4999c326bb1dcb2a1d2d06ff82333039018aa21
+  md5: a84cbf641719bbd618cae4397d952e72
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 523268
+  timestamp: 1713212983398
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.3-py310hca03da5_0.tar.bz2
+  sha256: 74217fd981d1c19bad2c15bf9577093d341dc124727bc528ff5e40de5fcbbb52
+  md5: d01e93793f9fa0775bfa0b9904ebaab4
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - h2 >=4,<5
+  - selenium >=4.4.3
+  - requests >=2.26.0
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 174257
+  timestamp: 1727769883712
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+  sha256: 20ae100fd04de16356f26e7c9dab514015e57a9d54fb78767aa5ed97de7846fb
+  md5: f620d98b3d0072945948310c86f0f1c5
+  license: MIT
+  license_family: MIT
+  size: 157385
+  timestamp: 1706894678643
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py310hca03da5_1.tar.bz2
+  sha256: 380724b46ae0ae1edb42bc668055aa2f27af3054d866b1e67e5acbb8481cd3a7
+  md5: 6bf29c754086a9d03490af7ef3f22e6d
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21597
+  timestamp: 1643962111312
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py310hca03da5_0.tar.bz2
+  sha256: 3f533f0c2bc844c53f530c8a25f1e1fe27b94d38a76b9601bca8dd0379b5ec05
+  md5: 52665fad203685a097d2f3eca1085240
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 88221
+  timestamp: 1715878353350
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/werkzeug-3.0.6-py310hca03da5_0.tar.bz2
+  sha256: cb31f9c6636183bc6d72bde1208eace0e4da31b7f4ad1cd5e88f22a1180ae2ab
+  md5: 4e00e1e0d58ea83e1cc93f7d2f13ed22
+  depends:
+  - markupsafe >=2.1.1
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - watchdog >=2.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 346279
+  timestamp: 1731005809337
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/widgetsnbextension-4.0.10-py310hca03da5_0.tar.bz2
+  sha256: 647f364c602b7f26007fee632f8273849dbdf01f004e83caa8d2720f5580d442
+  md5: 7cb4009835e24e3929a19845c6b8da6b
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1930938
+  timestamp: 1709323019126
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wrapt-1.14.1-py310h1a28f6b_0.tar.bz2
+  sha256: e771100bec4b041a9048b8f5553bf1053f640bf4f25b09612adb06ed7f4c4098
+  md5: 3a4f0d98aaa4aeb854a448eed833a322
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 51834
+  timestamp: 1657814575175
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py310hca03da5_0.tar.bz2
+  sha256: 27799dc34dc007484c93c06823631ca50216f651801061db60b36fbf0b4afcf4
+  md5: 15bd618a92cbd03ec24cd6fbfe81fa68
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1818414
+  timestamp: 1689041533776
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py310hca03da5_1.tar.bz2
+  sha256: d1ff32f75206387e8ab53e1b2253668fb79d18f79811f4547fd204093a9d75f7
+  md5: 7083a0ee005b52138b63e2c3ef37df4b
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49594
+  timestamp: 1675159129875
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+  sha256: 5be8c968f2da5c4bf14f28d63e31b4c1b6993d980023769732c7f58f396c2e0b
+  md5: 3f5f62d4e85e3bdd48d39189b01805a6
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 459197
+  timestamp: 1714510992914
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yarl-1.18.0-py310h80987f9_0.tar.bz2
+  sha256: ac9a82d3399136b6eaebc9a5c278c1ce86a9f2eebdca2ae17e66358c986a1168
+  md5: c9d075e759e3d384310e8b10d092084b
+  depends:
+  - idna >=2.0
+  - multidict >=4.0
+  - propcache >=0.2.0
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 135788
+  timestamp: 1732547129408
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zarr-2.13.3-py310hca03da5_0.tar.bz2
+  sha256: e17b4b64b6058fc870e69a86ff377b06439971296093ccc9da9861c8a80b5c03
+  md5: b3ccd5d7e7c7048b7d798c9d01024620
+  depends:
+  - asciitree
+  - fasteners
+  - numcodecs >=0.10.0
+  - numpy >=1.7,<2.0a0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 344390
+  timestamp: 1669363674747
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+  sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
+  md5: 3d57d1adadca9388aaaa1c529b65ba65
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 322790
+  timestamp: 1705602163804
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zfp-1.0.0-h313beb8_0.tar.bz2
+  sha256: 181d62294369598af7fd5dea778dcddca50009e699be1572750d419beba80e6b
+  md5: 48eeb271f7289214d616f859c55dece9
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 258119
+  timestamp: 1681741613773
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py310hca03da5_0.tar.bz2
+  sha256: aaf540e76af5e232512ee8db93533fea0419fb45526e2974159bc2b5fb74f780
+  md5: b036e3a6fb1194550195539758747e43
+  depends:
+  - heapdict
+  - python >=3.10,<3.11.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78760
+  timestamp: 1695832948385
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.21.0-py310hca03da5_0.tar.bz2
+  sha256: 525dc47b438e257ee05d5132926d25ae2869f5c81facc885ad5d79d3306fff8d
+  md5: 3652cf80edd101e3c2d2fd04092e04fc
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 26912
+  timestamp: 1732630823321
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+  sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
+  md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
+  license: Zlib
+  license_family: Other
+  size: 104928
+  timestamp: 1714510936868
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
+  sha256: 43667132ec8fa4c34ba438e13a01b08073e3e3e8a648ecdb6afe4141a7c197e2
+  md5: fb8c3f5683b19dd3743d125797b8e2dd
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 817614
+  timestamp: 1728486986031
+- conda: https://repo.anaconda.com/pkgs/main/win-64/_tflow_select-2.3.0-mkl.tar.bz2
+  sha256: f3ec304f40084b29eddfbd2e1ce77877252f731f87e5db242010a7e2eef3714a
+  md5: 057245f0ffc8c7becdba042af6cb786a
+  size: 3554
+  timestamp: 1606816560846
+- conda: https://repo.anaconda.com/pkgs/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
+  sha256: c5a4f98a90713f799a73195cc159571c4bd373bfa43640dc0c1707608e582945
+  md5: 537f198da93942d8ef7008606edae551
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2363136
+  timestamp: 1652426285158
+- conda: https://repo.anaconda.com/pkgs/main/win-64/absl-py-2.1.0-py310haa95532_0.tar.bz2
+  sha256: 443e079c9e8790aba2fa7392779211d8a3bfb4f60c37f845e66f36b3535674c8
+  md5: 7d44cf22812584df7c7c8ae8f163c9cc
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 188106
+  timestamp: 1714140545616
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aiobotocore-2.12.3-py310haa95532_0.tar.bz2
+  sha256: 1fe4438f6753fb4315a0a63a9b2c92a0e1001bb10e1af65de9ebb731c22b2e06
+  md5: 782a10d443e02c44830056af068d87c0
+  depends:
+  - aiohttp >=3.7.4.post0,<4.0.0
+  - aioitertools >=0.5.1,<1.0.0
+  - botocore >=1.34.41,<1.34.70
+  - python >=3.10,<3.11.0a0
+  - wrapt >=1.10.10,<2.0.0
+  constrains:
+  - boto3 >=1.34.41,<1.34.70
+  license: Apache-2.0
+  license_family: Apache
+  size: 111953
+  timestamp: 1714464654611
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aiohappyeyeballs-2.4.3-py310haa95532_0.tar.bz2
+  sha256: 4e283289be3066a77848840fbb3412d3d0ca9558b92e58b01d0288518cfdec42
+  md5: 915a16d061e68ba8dd44b6de5f982f80
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: PSF-2.0
+  license_family: Other
+  size: 26137
+  timestamp: 1732664027237
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aiohttp-3.10.5-py310h827c3e9_0.tar.bz2
+  sha256: 2082095321722a5f7b89c4807dd1ff1da82e620ab9c9f5b2988258ae88829be1
+  md5: 593d0abb991df34fc3b4cad08b421af7
+  depends:
+  - aiohappyeyeballs >=2.3.0
+  - aiosignal >=1.1.2
+  - async-timeout >=4.0,<5.0
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - multidict >=4.5,<7.0
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - yarl >=1.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Other
+  size: 748491
+  timestamp: 1725529464978
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.6.2-py310haa95532_0.tar.bz2
+  sha256: ecfda3087fb1731cf249e5c348f924cdeb7d4cd477f58523b8cc0609c89f7d83
+  md5: db8e0e2dfaa8bf2decbc5c8fd5c290bf
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.10,<3.11.0a0
+  - sniffio >=1.1
+  - typing_extensions >=4.1
+  constrains:
+  - trio >=0.26.1
+  license: MIT
+  license_family: MIT
+  size: 192290
+  timestamp: 1729121825942
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aom-3.6.0-hd77b12b_0.tar.bz2
+  sha256: 7ad83463e67a5f6da32568a567914a0f1ed5052268548371eb9ca66b4a0eee00
+  md5: 99feb2bd2c24eb7726f4a05f9fa1b809
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 12387035
+  timestamp: 1688666342169
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py310h2bbff1b_0.tar.bz2
+  sha256: b1f650ded18f00b931bca2cfbe25d23234ebc094ceb1ff90ca0f9748773d77b0
+  md5: 2ab6af43f2a175c8cd55263ce03730e9
+  depends:
+  - cffi >=1.0.1
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 39303
+  timestamp: 1644569997665
+- conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-11.0.0-h2c9b28c_2.tar.bz2
+  sha256: f21f6ce91b4587eb51e05435b2f1ab0cbd3c33cdff7a2851451aa65a8bd2d6a3
+  md5: 6e7ca99ceca0fa3474a2e9f95e80ad15
+  depends:
+  - abseil-cpp >=20211102.0,<20211102.1.0a0
+  - aws-sdk-cpp >=1.8.185,<1.8.186.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-ares
+  - glog >=0.5.0,<0.6.0a0
+  - grpc-cpp >=1.48.2,<1.49.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - orc >=1.7.4,<1.7.5.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.9,<2.0a0
+  - utf8proc <2.9.0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8320723
+  timestamp: 1693264194855
+- conda: https://repo.anaconda.com/pkgs/main/win-64/async-lru-2.0.4-py310haa95532_0.tar.bz2
+  sha256: d2d6afdc5b62ab3edfba87aecd1e33eac7b2004ecdc3a571662870f5b25e5f3f
+  md5: 4807d2b0ec114fc10f6421446ee0ed06
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing_extensions >=4.0.0
+  license: MIT
+  license_family: MIT
+  size: 18367
+  timestamp: 1699554857322
+- conda: https://repo.anaconda.com/pkgs/main/win-64/async-timeout-4.0.3-py310haa95532_0.tar.bz2
+  sha256: e8e45168459577a436cfa023c425d1e5a1895b8108cb0cfd81704519d7a8b2b7
+  md5: 5fec752ec5dd8c9478c695bb447677dd
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 12959
+  timestamp: 1703097663627
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-24.2.0-py310haa95532_0.tar.bz2
+  sha256: 5b7f5b31348559233f13ba3a6f006e1f19a44e6d064cabdf519a05bc78005c14
+  md5: a889d7f22a91b01f5e63005a971575c8
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 142855
+  timestamp: 1729089569199
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.4.57-ha925a31_1.tar.bz2
+  sha256: 91a78979ae6c1f5ff02dd1076aa62e2da7e610647203cd8985e0ea25465f2a74
+  md5: 7878a5b35caf8db44fffffe0ba320951
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 155676
+  timestamp: 1601398472136
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.1.6-hd77b12b_5.tar.bz2
+  sha256: 08437ce1c93997e5f5e8a6a7a8835b9b3a96d8be97c7752644fc9b2ae9788c8e
+  md5: 1883d49fb78e0858f007a73e042e5c3a
+  depends:
+  - aws-c-common >=0.4.57,<0.4.58.0a0
+  - aws-checksums >=0.1.9,<0.1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 27050
+  timestamp: 1603894719881
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.9-ha925a31_0.tar.bz2
+  sha256: 6947f2b605db23cf0f80f7009fc09eba477c7ae80d55ec81f640ed8b1854a1a6
+  md5: 067a7194f4f3d8e8bbe37d8825503cd3
+  depends:
+  - aws-c-common >=0.4.57,<0.4.58.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 54104
+  timestamp: 1601398697615
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.8.185-hd77b12b_0.tar.bz2
+  sha256: ba257fb24561340ca04c372d9624954b8a57af11999eb9dea42faac47f20e5b9
+  md5: 93b4a964f3722da3eb9ad019e7e88f3f
+  depends:
+  - aws-c-common >=0.4.57,<0.4.58.0a0
+  - aws-c-event-stream >=0.1.6,<0.1.7.0a0
+  - libcurl >=7.71.1,<9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3226667
+  timestamp: 1618435213786
+- conda: https://repo.anaconda.com/pkgs/main/win-64/babel-2.11.0-py310haa95532_0.tar.bz2
+  sha256: fbb1373cda22f5a5c6f67968ed5901fb00781b7e9e87429437ac89c6cc64a168
+  md5: fea96278d6b5c42c923ba515a0b4351e
+  depends:
+  - python >=3.10,<3.11.0a0
+  - pytz >=2015.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7198403
+  timestamp: 1671783246685
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py310haa95532_0.tar.bz2
+  sha256: 12c5cb0f8234c2b749d9602992fb137a18b56d13452dcbfa80435d14122710db
+  md5: 8639e3c3c62a03f9fca459e353a3a901
+  depends:
+  - python >=3.10,<3.11.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 211275
+  timestamp: 1718030011501
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bleach-6.2.0-py310haa95532_0.tar.bz2
+  sha256: 40990071f8003e2ba59cc377b2753ba87acd501b5fff248578c1032e936348f0
+  md5: 8a53f53b041de430ce82308555b83cdc
+  depends:
+  - python >=3.10,<3.11.0a0
+  - webencodings
+  constrains:
+  - tinycss2 >=1.1.0,<1.5
+  license: Apache-2.0
+  license_family: Apache
+  size: 298165
+  timestamp: 1732293154560
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blinker-1.6.2-py310haa95532_0.tar.bz2
+  sha256: a9c2fc84a9ecaafcc2a2c37db91be89ac97a58a251df7be88847492301e8f996
+  md5: 52611d378f2d06886209e83b6de2937c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 28907
+  timestamp: 1696540014600
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
+  sha256: cf9a8a0745c5fab48394d84a58fe2f06e5fa80c87d5cc8d6c8da2e1df52cc69f
+  md5: 462987773ecda8cbf1f80734e84f080f
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 93601
+  timestamp: 1675247818708
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.6.0-py310haa95532_0.tar.bz2
+  sha256: 41ae68725c7e8e68dd28bcf4d84d590b09373f61fbcb312c68be0bfb0682e54d
+  md5: b7719d19c90e44e3c1777af8c0aedf52
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5675101
+  timestamp: 1727914954631
+- conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+  sha256: 68ef338b27c035add89c0812ad469dd8c9e94f27130f770345ea20deb049d50b
+  md5: 9ec19b145f655329532b608963cf32f4
+  depends:
+  - libboost 1.82.0 h3399ecb_2
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 11334
+  timestamp: 1696764270626
+- conda: https://repo.anaconda.com/pkgs/main/win-64/botocore-1.34.69-py310haa95532_0.tar.bz2
+  sha256: 5ca3f426a4e7843c56d555b6d98a3b384f1a5fd9cd167e3528177a505c967ddd
+  md5: 64f280dd3b623da06ba2c3776ea5e55d
+  depends:
+  - jmespath >=0.7.1,<2.0.0
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.1,<3.0.0
+  - urllib3 >=1.25.4,!=2.2.0,<3
+  license: Apache-2.0
+  license_family: Apache
+  size: 7726781
+  timestamp: 1714461508553
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.4.2-py310hc99e966_0.tar.bz2
+  sha256: 99615408b6709c6f2b7016e8e9bae3e8ac041cf5eec0c5fa8903e253eea5d959
+  md5: b34f13e06879011b21870d60e649a5db
+  depends:
+  - numpy >=1.21,<3
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 142517
+  timestamp: 1731058923141
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 751071782f597f87ed7f67437ef6cc669213902461b9795dd6eb0f4897eddc83
+  md5: 5ad8fe62aad5e16cfdf2c5a7d1327fe7
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_8
+  - libbrotlidec 1.0.9 h2bbff1b_8
+  - libbrotlienc 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 19418
+  timestamp: 1714483531456
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 9bd62d810867549b9c967c5915f3fa3f66cfbd6ede28b1cc152efd1261285c0a
+  md5: 64cc76de3662b62bc8f0e42befd92c5d
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_8
+  - libbrotlienc 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 32178
+  timestamp: 1714483513837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py310hd77b12b_8.tar.bz2
+  sha256: 57d5d504b9e650f265028f344f1063ae5a90767a475d607f3776c4553a1b78f4
+  md5: d214a86a5614ca70b68c884a71b5e576
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 356288
+  timestamp: 1714483603688
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+  sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
+  md5: 11e0af09a31e2d5df51c65a342032b85
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 112994
+  timestamp: 1714511182837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+  sha256: 41a6c5a90b88ec7010bb6dd89390754e476b52c3ab2d519bdab9556da8829479
+  md5: b047426a545e287f45e8abfbfcb0de55
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 118041
+  timestamp: 1693902191485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.11.26-haa95532_0.tar.bz2
+  sha256: 8baa3961c182bf6a3874d69bcfb8dd5350133f0ed02e3db725210a945409dcad
+  md5: e611070c5c0bee5862dfff55004f594e
+  license: MPL-2.0
+  license_family: Other
+  size: 177029
+  timestamp: 1732804476945
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cachetools-5.3.3-py310haa95532_0.tar.bz2
+  sha256: c14e090eb464660f3e2a2654a64b51d60af674b09c8581f837dd26d9a634b1f2
+  md5: f7405529b8f524525fa2d257a0202038
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 23754
+  timestamp: 1713977318112
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.8.30-py310haa95532_0.tar.bz2
+  sha256: 47e7915d7e09b88dd4bdf9c177ba02bb03673516d37c4097a58120fcf0949b0f
+  md5: 91ca0e734e3734a1cc4dcddd4806f68b
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 168558
+  timestamp: 1725551780848
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py310h827c3e9_0.tar.bz2
+  sha256: a390a89cd782595ffc6205b0f5292dbaccf41ca3e418c4934a0acf31586f7513
+  md5: fe0f8a3d45fac25ee8567607a9fe62d9
+  depends:
+  - pycparser
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 253364
+  timestamp: 1726856769034
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
+  sha256: a65386e70bdad9aa1e07ad430309c3ddc249b74bea69388dfbda99fd00069665
+  md5: e4174218de194962642b353f51a19d1e
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  license_family: Other
+  size: 617890
+  timestamp: 1655709069465
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cftime-1.6.2-py310h9128911_0.tar.bz2
+  sha256: babb47fcbc9e7fe09a29c837ae763f73d1621290e44542b660d5dc3b4e499958
+  md5: 76907acc0a04b1c50c95e00fb4be6fa8
+  depends:
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 177840
+  timestamp: 1678830649951
+- conda: https://repo.anaconda.com/pkgs/main/win-64/charls-2.2.0-h6c2663c_0.tar.bz2
+  sha256: 98e6346139899b0c9ce6518e304c8b1fd1b8746a410fcc8d83cbc9f08125ecc7
+  md5: 5cdda32dbdd11de0555c255a598173c0
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 95720
+  timestamp: 1612240685008
+- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py310haa95532_0.tar.bz2
+  sha256: b91d0263ac52eddd283bcaa76aa28a85be150103489c76fac0e9a60c75da0252
+  md5: 3753a68430067379af7ec9517a950c2d
+  depends:
+  - colorama
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 155422
+  timestamp: 1698129904518
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.0.0-py310haa95532_0.tar.bz2
+  sha256: 7dbc6578b15462c437b1b227f3bc9c2c39b5f33189a586f3553e7951d940237f
+  md5: a01b281d860965fe1d6d5c80ead35f81
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35625
+  timestamp: 1721657609411
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py310haa95532_0.tar.bz2
+  sha256: 9d1b2c34fa17a72e4e7b265cb5a421bb1a6dc893b35209739f1b710f79ebcc19
+  md5: 269703fa9499eb42cfd7b9fd349ecd22
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30646
+  timestamp: 1672387329696
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py310haa95532_0.tar.bz2
+  sha256: d7e9ef9b790e0d531490ee8eb3d727ace2a9f30d94e547029e1d0a84747c168a
+  md5: 95fcb8f56ad31f96ae9b8767ad30cd35
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 498954
+  timestamp: 1709758473914
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py310haa95532_0.tar.bz2
+  sha256: 4b53b13fd2c5a010dc8725d16bd5577c87c3db5aad4f9f52d508375dae67b45c
+  md5: bde516d96fe11739e7703be8114b49e6
+  depends:
+  - python >=3.10,<3.11.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15512
+  timestamp: 1709322968038
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.3.1-py310h214f63a_0.tar.bz2
+  sha256: b33d9792d18c1ef1cdbdee252a7340ea47d2ef5a174edaf77eb5c9bcfa88a956
+  md5: ffdd9900f86e96fc95ab0a7095a347f6
+  depends:
+  - numpy >=1.23
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 230563
+  timestamp: 1732540222453
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py310h3438e0d_0.tar.bz2
+  sha256: 3b3df6fcfbda564fb76eb78a2aec8991c63ad343c2017708c6d67f8adb3ddaf4
+  md5: ba5643f998e3253c96be64bbc08b8d65
+  depends:
+  - cffi >=1.12
+  - openssl >=1.1.1v,<1.1.2a
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1226210
+  timestamp: 1694446525776
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.2-py310h2bbff1b_0.tar.bz2
+  sha256: 34f3495bb04b571404cf9160efecbe783850436695cfd2bba5b7e08278ab4dbb
+  md5: 4434479a431a9971c90080454602a8f2
+  depends:
+  - python >=3.10,<3.11.0a0
+  - toolz >=0.10.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 342657
+  timestamp: 1701723828014
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-2024.5.0-py310haa95532_0.tar.bz2
+  sha256: 866c874e6c1845098368da1b0de6c71957b46675109fd0271422d84075f59259
+  md5: 9e3d75a91ae4f3eb3fba2cfbed94e164
+  depends:
+  - bokeh >=2.4.2
+  - cytoolz >=0.12.0
+  - dask-core 2024.5.0
+  - dask-expr >=1.1,<1.2
+  - distributed 2024.5.0
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.21,<2.0a0
+  - pandas >=1.3
+  - pyarrow >=7.0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6132
+  timestamp: 1715848980276
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.5.0-py310haa95532_0.tar.bz2
+  sha256: 968af80d08d73cd0b26028b9f039b448591e22e8afbfe9a7d920bef11cdf7ecc
+  md5: 0ae8577bdfc2743206fbc5f9230d21a6
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.10,<3.11.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2302878
+  timestamp: 1715838969439
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-expr-1.1.0-py310haa95532_0.tar.bz2
+  sha256: 34f5178da52fc6226de5a35fef4d7ffd7c653d8714ddd9e5ec7598294a3fabe7
+  md5: 8b9f4c5d8e014cc66b7e11cec425e251
+  depends:
+  - dask-core 2024.5.0
+  - pandas >=2
+  - pyarrow >=7.0.0
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 356434
+  timestamp: 1715846725323
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dav1d-1.2.1-h2bbff1b_0.tar.bz2
+  sha256: e59970edb08a1dc24d761f88657aed895d7715f66ac9a9acfda440c29fda05e0
+  md5: d3d303a3ffcedb8f4a92f29ac9e67bdc
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 723931
+  timestamp: 1688746263355
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py310hd77b12b_0.tar.bz2
+  sha256: 847a1d4e079ce688c7e984cbf0c5c8a271c8e818c394433375b5a4f2b27beed1
+  md5: 3e4eb1dbd11005205430e157cc260dd6
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3304234
+  timestamp: 1690907391803
+- conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2024.5.0-py310haa95532_0.tar.bz2
+  sha256: 6c83e6a42023316cefe72ccc2af700f2eb829036e1f82c52d09491df7360270b
+  md5: bf335d8c68f8c9fe3efbe156f43f13c8
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - dask-core 2024.5.0
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.0
+  - packaging >=20.0
+  - psutil >=5.7.2
+  - python >=3.10,<3.11.0a0
+  - pyyaml >=5.3.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.10.0
+  - tornado >=6.0.4
+  - urllib3 >=1.24.3
+  - zict >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1514046
+  timestamp: 1715844621307
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py310haa95532_0.tar.bz2
+  sha256: 542db7e187d0a9fe16b6eacb6bb93e5d574d1956687553a85a33fd580ab6ab7c
+  md5: efac5662f2dbe0fabf392e1dd89eb105
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17084
+  timestamp: 1649926751338
+- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.2.0-py310haa95532_0.tar.bz2
+  sha256: 0c56bdda8b41de6668a405a5d60f27a9420387f69fc1722ed06384fff76357e8
+  md5: 430b811c79d3f19e0d315a40a9e409f3
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 30636
+  timestamp: 1706031719341
+- conda: https://repo.anaconda.com/pkgs/main/win-64/flatbuffers-2.0.0-h6c2663c_0.tar.bz2
+  sha256: 2012b9280b6a9c3936c1581b7485f26fcec2bde169e1e779d13425bad3e5b0d8
+  md5: 518f7695450e8118b6d14d3d6eeac482
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  size: 1879231
+  timestamp: 1620826057100
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py310h2bbff1b_0.tar.bz2
+  sha256: aa103c59447a75ea3b27a31d13b439c211c8519696709a3d8afc115e03f8eab8
+  md5: e8cb69900c25f826c56fc9022b58c84b
+  depends:
+  - brotli >=1.0.1
+  - python >=3.10,<3.11.0a0
+  - unicodedata2 >=15.1.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 2213049
+  timestamp: 1713551998227
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/frozenlist-1.5.0-py310h827c3e9_0.tar.bz2
+  sha256: 1f55ce4df3915031cd22bb83f5f36318dc0abd07752e25065cdba017810d325b
+  md5: c7674837968cfe8fb5ab9150e76dfb4a
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 69733
+  timestamp: 1730903296977
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.6.1-py310haa95532_0.tar.bz2
+  sha256: 1a4cc259e7a2845dbacf388ccb9ee2b5666d1ed717d3bcdedee1b46bfb498869
+  md5: 08a003808ae433f88c2e01d96307b342
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - pyarrow >=1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 288296
+  timestamp: 1724855749600
+- conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+  sha256: 7cb0df7aa62796b0081e1708003529c02411aca6a540bae97beaec919aa64e74
+  md5: ea81fd813e10055553a8d7597c8be98f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 322778
+  timestamp: 1706888324269
+- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.2-h7edc060_0.tar.bz2
+  sha256: d71f9b4ea1ccedb85e30d9c5c32c73954055cbe98bacd26e23ef64463476b5ff
+  md5: cb30da812922490f68f90fe9224c29cb
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 114543
+  timestamp: 1728656355503
+- conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+  sha256: ed1fa1a40c6739b48ff3a2d51c3df20e4983b59684b04d93e1337c5f2e93a954
+  md5: 1797f64343a42395207cd452e6a6a751
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94476
+  timestamp: 1706895442146
+- conda: https://repo.anaconda.com/pkgs/main/win-64/google-auth-2.29.0-py310haa95532_0.tar.bz2
+  sha256: 2940356525408409c516a75d506a1b3f8365253175807b9b27a02f3c1b3ffe00
+  md5: 3496e4e012c042460fdcfef0fa3d8b4f
+  depends:
+  - aiohttp >=3.6.2,<4.0.0dev
+  - cachetools >=2.0.0,<6.0
+  - pyasn1-modules >=0.2.1
+  - pyopenssl >=20.0.0
+  - python >=3.10,<3.11.0a0
+  - requests >=2.20.0,<3.0.0dev
+  - rsa >=3.1.4,<5
+  constrains:
+  - cryptography >=38.0.3
+  - pyu2f >=0.1.5
+  license: Apache-2.0
+  license_family: Apache
+  size: 217052
+  timestamp: 1715111463428
+- conda: https://repo.anaconda.com/pkgs/main/win-64/grpc-cpp-1.48.2-hf108199_0.tar.bz2
+  sha256: 4bd6524572ee2453de9e8b4412472ef0f54a5fee126089e80bed6609ede9b225
+  md5: 28b0f9d66f90f6c671d1d30f9ea77ece
+  depends:
+  - libprotobuf >=3.20.3,<3.20.4.0a0
+  - re2
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 30981567
+  timestamp: 1681913688583
+- conda: https://repo.anaconda.com/pkgs/main/win-64/grpcio-1.48.2-py310hf108199_0.tar.bz2
+  sha256: 1261b4ce6bda202773535d24839b0f49203326f4d787c9e46e2ad01099acbf4a
+  md5: a2cc85ae6b4722e4759398db26d2f1b7
+  depends:
+  - abseil-cpp >=20211102.0,<20211102.1.0a0
+  - c-ares >=1.19.0,<2.0a0
+  - grpc-cpp 1.48.2 hf108199_0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - openssl >=1.1.1t,<1.1.2a
+  - python >=3.10,<3.11.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - six >=1.6.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 2124508
+  timestamp: 1681914008688
+- conda: https://repo.anaconda.com/pkgs/main/win-64/h11-0.14.0-py310haa95532_0.tar.bz2
+  sha256: 5e3ec21b9af596938d62cf9c4b2c84b934bccb8c22b5e6c55e51219e4fe98b70
+  md5: 00621964cab040caef35249a17950530
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 85310
+  timestamp: 1706652442736
+- conda: https://repo.anaconda.com/pkgs/main/win-64/h5py-3.12.1-py310h3b2c811_0.tar.bz2
+  sha256: 961c9925d2862e6d33ed86e7e5ee7ff0fb411644337412ce9c3cd0b0b6470d2d
+  md5: 8b6fa97b06b7d3dc1121b2e2958ca1a7
+  depends:
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - numpy >=1.19.3,<3
+  - numpy >=1.21,<3
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1416204
+  timestamp: 1730216136835
+- conda: https://repo.anaconda.com/pkgs/main/win-64/hdf4-4.2.13-h712560f_2.tar.bz2
+  sha256: 8129c8aae5860d9975f3c88c2ef874d0a746a11074f922b6318446cc45f30768
+  md5: b3a727bf1c1df5b021aaf6cc7e81deb2
+  depends:
+  - jpeg >=9b,<10a
+  - vc 14.*
+  - zlib >=1.2.11,<2.0.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 2869081
+  timestamp: 1510864340539
+- conda: https://repo.anaconda.com/pkgs/main/win-64/hdf5-1.12.1-h51c971a_3.tar.bz2
+  sha256: d32219e535ae34e9d28f94306a38a0825030967c350f19d9a5502e8005acbd5d
+  md5: 0689c2ff6f4b9c15ee072694a8cd7467
+  depends:
+  - icc_rt >=2022.1.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: OTHER
+  license_family: BSD
+  size: 23765096
+  timestamp: 1686164892135
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.20.0-py310haa95532_0.tar.bz2
+  sha256: fa0309e8e99ae610174d52ba1be603cd55e0c5746b2f6573100f3e67bf46b42a
+  md5: 0cb24dce0471cdb2400f7dea2889ab86
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=2.1
+  constrains:
+  - plotly >=4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5358091
+  timestamp: 1730828363229
+- conda: https://repo.anaconda.com/pkgs/main/win-64/httpcore-1.0.2-py310haa95532_0.tar.bz2
+  sha256: f44912e4e1518c7b611753940004204efff5732fcd03aad22818d87ddc497d36
+  md5: 41f7614c926b8ddad43cb816b3e8e452
+  depends:
+  - certifi
+  - h11 >=0.13,<0.15
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 85493
+  timestamp: 1706728684995
+- conda: https://repo.anaconda.com/pkgs/main/win-64/httpx-0.27.0-py310haa95532_0.tar.bz2
+  sha256: 9f5c5183c0c573e7170ed4b6306a991cb2c5bd338e7544158e89cd8eaae66285
+  md5: 3d2a5447f55116a9eee8691d179b4972
+  depends:
+  - anyio
+  - certifi
+  - httpcore >=1.0.0,<2.0.0a0
+  - idna
+  - python >=3.10,<3.11.0a0
+  - sniffio
+  constrains:
+  - rich >=10.0.0,<14.0.0a0
+  - h2 >=3.0.0,<5.0.0a0
+  - click >=8.0.0,<9.0.0a0
+  - pygment >=2.0.0,<3.0.0a0
+  - socksio >=1.0.0,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 191955
+  timestamp: 1723474920708
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+  sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
+  md5: 582d2c1135a89da757a038de831e7f39
+  license: Intel proprietary
+  size: 11086648
+  timestamp: 1664812389803
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icu-58.2-ha925a31_3.tar.bz2
+  sha256: e7cb511301ce3788402dce7b700ca44e1f7bc38e498d27b41060a9b48704946d
+  md5: 3b9fbd6eda81ae1b8b580b99d2d928f4
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 22885927
+  timestamp: 1588025937921
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py310haa95532_0.tar.bz2
+  sha256: a2b42aa3f456299cf89b8ff9fcc23bf34b020c79171b92dacb1d21f7f5ceaf90
+  md5: cbf290dbedee956166c1f700c188b9fa
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 140412
+  timestamp: 1714399162110
+- conda: https://repo.anaconda.com/pkgs/main/win-64/imagecodecs-2023.1.23-py310h6c6a46e_0.tar.bz2
+  sha256: 01d15c4122ae686459c503f777135d214af41145ec58a410b7e483c3782eaa60
+  md5: a6b2031cc282559b6d8e70ef0827ce75
+  depends:
+  - blosc >=1.21.3,<2.0a0
+  - brotli >=1.0.9,<1.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - cfitsio >=3.470,<3.471.0a0
+  - charls >=2.2.0,<2.3.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - lerc >=3.0,<4.0a0
+  - libaec >=1.0.4,<2.0a0
+  - libavif >=0.11.1,<0.11.2.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.7.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - libzopfli >=1.0.3,<1.1.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - numpy >=1.21.5,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - snappy >=1.1.9,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.2,<6.0a0
+  - zfp >=1.0.0,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9837809
+  timestamp: 1695067128651
+- conda: https://repo.anaconda.com/pkgs/main/win-64/imageio-2.33.1-py310haa95532_0.tar.bz2
+  sha256: 56f9a7ad7767ddd971d37f5b7138e24238ae1cb7edb8ac15632fb9980a214525
+  md5: 7d0ed0a5a9b563529f9f5907615b03a4
+  depends:
+  - numpy <2.0a0
+  - pillow >=8.3.2
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 545431
+  timestamp: 1707247743222
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-8.5.0-py310haa95532_0.tar.bz2
+  sha256: d6404ddf3aac22b94c8d9116534f4ead0709c70f912f79c33db1fbc4317cd230
+  md5: 284c1a0b3854d56cfb487204eeee18ba
+  depends:
+  - python >=3.10,<3.11.0a0
+  - zipp >=3.20
+  license: Apache-2.0
+  license_family: APACHE
+  size: 46431
+  timestamp: 1732633644401
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intake-0.7.0-py310haa95532_0.tar.bz2
+  sha256: 369aa24c4983bc72e156ece75c682ca6ad489b707e2c67317350d22ebf4f9685
+  md5: d0597ca49f255a839f147032964b506d
+  depends:
+  - appdirs
+  - dask >=1.0
+  - entrypoints
+  - fsspec >=2021.7.0
+  - jinja2
+  - msgpack-python
+  - python >=3.10,<3.11.0a0
+  - python-snappy
+  - pyyaml
+  - requests
+  - tornado
+  constrains:
+  - panel >=0.7.0
+  - bokeh
+  - hvplot
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 240958
+  timestamp: 1717514338162
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intake-xarray-0.7.0-py310haa95532_0.tar.bz2
+  sha256: a607bd0de30159c85a0b941bbfd9d91a011b2b4ea96092bb422aae2f9ae5dd4a
+  md5: 0be1438d795757b10c636aba08d50209
+  depends:
+  - dask-core >=2.2
+  - fsspec >=2022
+  - intake >=0.6.6
+  - msgpack-python
+  - netcdf4
+  - python >=3.10,<3.11.0a0
+  - requests
+  - xarray >=2022
+  - zarr
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 69150
+  timestamp: 1717523995503
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+  sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
+  md5: d215cc8ee7ca2cc83cc250cc5d822fe0
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3929136
+  timestamp: 1699647939158
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py310haa95532_0.tar.bz2
+  sha256: 5344891f7c4ec39ea02380387a148d9987e5b6746d702c47d5346318023790e8
+  md5: 495435f475c37fd888302b36f92d475e
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.10,<3.11.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192624
+  timestamp: 1728666039602
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.27.0-py310haa95532_0.tar.bz2
+  sha256: fb14764c6c9b141691acf8c821088e33d44dfc59870c15278ea12a98788665fc
+  md5: c4704a79172e458ec478433ced6cbb9e
+  depends:
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.10,<3.11.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1325894
+  timestamp: 1726064369648
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipywidgets-8.1.2-py310haa95532_0.tar.bz2
+  sha256: 68993e56971b180d1751b5855d023e13fcbe7a7d91c759762a575c23a244a3f3
+  md5: 8a44e9970e506bfd0d0cbd3f81965284
+  depends:
+  - comm >=0.1.3
+  - ipython >=6.1.0
+  - jupyterlab_widgets >=3.0.10,<3.1
+  - python >=3.10,<3.11.0a0
+  - traitlets >=4.3.1
+  - widgetsnbextension >=4.0.10,<4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 201719
+  timestamp: 1709575189593
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.1-py310haa95532_0.tar.bz2
+  sha256: 373c1964815798b7d8dfe49337390b85d1314757d6401d8269449ef108f766ac
+  md5: e5f14914bb23b1ef8167616c747a4b11
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1050991
+  timestamp: 1721058584968
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py310haa95532_1.tar.bz2
+  sha256: 05269b8df09a0ca8c4874406d513c3a4e44bdddb5c4d10d68bc93e5faabb6f48
+  md5: 0ddc6db22e391e6b26c1666fc41c8945
+  depends:
+  - markupsafe >=2.0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 275649
+  timestamp: 1730903442160
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jmespath-1.0.1-py310haa95532_0.tar.bz2
+  sha256: b274228fbed4e3fe6f6e36531dac5ae363cb23767a4ea1afdfb4b36a24069e52
+  md5: cdf6661477371254a31b2ddb323916b6
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 39174
+  timestamp: 1700144858004
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+  sha256: 0238fb10912d9345a9d327ff314a179de38369f8e1d0de0b5f4fab04defab0e4
+  md5: 16a420ea83811cfa0c7cadba8f9f0995
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 409932
+  timestamp: 1722872751697
+- conda: https://repo.anaconda.com/pkgs/main/win-64/json5-0.9.25-py310haa95532_0.tar.bz2
+  sha256: 6793048cc50f8ba8187e5c9446e93464060257d0fa350b4802b2dc6bf1b8ddeb
+  md5: 87cc72870ec2335855546a3defdd6b03
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 76183
+  timestamp: 1730787180721
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.23.0-py310haa95532_0.tar.bz2
+  sha256: a06785f98247bfb74741ef610d6f8cb20d772b42075271ee658ddf0802c62cb3
+  md5: e3d50c48ca10125913589c9b4ccc31d8
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.10,<3.11.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 177375
+  timestamp: 1728486790381
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py310haa95532_0.tar.bz2
+  sha256: b3a0eb2033947f1e0844920141bc80048ef817509f5645841d3da8bb441f678c
+  md5: a6caf81c42362d399e87e37d88596ace
+  depends:
+  - python >=3.10,<3.11.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 15572
+  timestamp: 1699032711469
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter-lsp-2.2.0-py310haa95532_0.tar.bz2
+  sha256: 071504f1837d913aca4faff72cf6fd4362287f3e33905c4c42a1ab5207277679
+  md5: 1007dfc789de43d71cf5c88b43f5a441
+  depends:
+  - jupyter_server >=1.1.2
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 82015
+  timestamp: 1699978428996
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-8.6.0-py310haa95532_0.tar.bz2
+  sha256: 1410889d957761d396a7e3105d5bd05e53a422116e1ef8e2d078186178f92a92
+  md5: 7fb7ed0ceb23c03414e9f58e0e86537d
+  depends:
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 200387
+  timestamp: 1699456906799
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py310haa95532_0.tar.bz2
+  sha256: 2156b3d773fa969e834fe017d6c3b3e099c149c3505ce628d25b7dcd9b7361ad
+  md5: 97cc5bad6423d22ed6281fdbfc398f40
+  depends:
+  - platformdirs >=2.5
+  - python >=3.10,<3.11.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 121683
+  timestamp: 1718818511830
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py310haa95532_0.tar.bz2
+  sha256: c72997b9bf1d48f1512243adfc0f92784ec01bf3da918cf3b14ef70ecbbf5eb3
+  md5: 5b1539af6d00e2df883a6f1e0ba1176d
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.10,<3.11.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65809
+  timestamp: 1718738454277
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py310haa95532_0.tar.bz2
+  sha256: 3e01417b0739e6ab08a1520f2171f085aa0a1291c19a171d2e97e727e6bcc6ae
+  md5: 30a3e15cd3d27a0edf251c8c4928a4b6
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.10,<3.11.0a0
+  - pywinpty >=2.0.1
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 547148
+  timestamp: 1718829336301
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py310haa95532_1.tar.bz2
+  sha256: 8d24fc392d2c7ca9ff3ca3c29eb55548fd62b8653f89931240bedac202f20903
+  md5: 58351ec2b67993e31095a0ea5abf213c
+  depends:
+  - python >=3.10,<3.11.0a0
+  - pywinpty >=2.0.10
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24039
+  timestamp: 1686870827419
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab-4.2.5-py310haa95532_0.tar.bz2
+  sha256: d1926dac899086eb0a536d08251493d7562721bd390824b7ec7b9ac84abdb074
+  md5: b8f93c4c3388449484544446f2d3805e
+  depends:
+  - async-lru >=1.0.0
+  - httpx >=0.25.0
+  - ipykernel >=6.5.0
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.27.1,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.10,<3.11.0a0
+  - setuptools >=40.1.0
+  - tomli >=1.2.2
+  - tornado >=6.2.0
+  - traitlets
+  - pywin32
+  constrains:
+  - nodejs >=20.0.0,<21.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8490445
+  timestamp: 1725902292546
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_server-2.27.3-py310haa95532_0.tar.bz2
+  sha256: 67656cc6749c1ae237a56ef46f38aec58a8c982227cead359007796c35ad720c
+  md5: 096c1adaef599d301913586bf9f25f21
+  depends:
+  - babel >=2.10
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18.0
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.10,<3.11.0a0
+  - requests >=2.31
+  constrains:
+  - openapi-core >=0.18.0,<0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 83900
+  timestamp: 1725865507239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_widgets-3.0.10-py310haa95532_0.tar.bz2
+  sha256: 39635ca6bd8be6c43f308f2b63cc89f61dd539d7cbbb36ae2faad1d05089f555
+  md5: d82c3ba064d2f82d9621ca6ab90a3dd2
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jupyterlab >=3,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192245
+  timestamp: 1709323574746
+- conda: https://repo.anaconda.com/pkgs/main/win-64/keras-2.10.0-py310haa95532_0.tar.bz2
+  sha256: f598010f1be3890deae69456c774e2ec23b3d33599f4d222dcc259f3591242ed
+  md5: 7ece0e174af346913da07120c66aa004
+  depends:
+  - keras-preprocessing >=1.1.2
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - tensorflow-base  2.10.*
+  license: Apache-2.0
+  size: 2183775
+  timestamp: 1669760638164
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py310hd77b12b_0.tar.bz2
+  sha256: 10f79ef1927aca5f33da1e87a065bef0edd0e7bf1c346172d0f54b9b6472cbd0
+  md5: ffd45a996d8abf95243ca820e62e696a
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62337
+  timestamp: 1672388276172
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lazy_loader-0.4-py310haa95532_0.tar.bz2
+  sha256: 4c8e40f79dbafb7f778c611850b0467e36530047e3dffa5af88cfdc0d218ba9c
+  md5: 31b413dbe0d155df2e815b5f38805997
+  depends:
+  - packaging
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21661
+  timestamp: 1718176912342
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+  sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
+  md5: f5f73266281ab12377d5d47bdf07500a
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 905072
+  timestamp: 1617648814933
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libaec-1.0.4-h33f27b4_1.tar.bz2
+  sha256: 918df9a8ca3877e44a2976f7c8f2d84f710d156809a7d8e0b79eca568c7cc3da
+  md5: 0e6b3ffa6ee7c941485dacdfcb6dd6b4
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 34175
+  timestamp: 1593197296069
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libavif-0.11.1-h2bbff1b_0.tar.bz2
+  sha256: 6adaf0429ea7418bff9eab1f723572f4330d003532292448d5334ea2d601e5ee
+  md5: b2756d031f0dcfb72f733b2c450fc32a
+  depends:
+  - aom >=3.6.0,<3.7.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2494359
+  timestamp: 1689158283018
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+  sha256: 4184dd040fc38cb123a98588a8344aa8d1ba1932df5fcc6c188f6b21f5a0c306
+  md5: da58cfa83f3d6c31ae12d8777cd1b64d
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 29803292
+  timestamp: 1696764164248
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 7c906c94a4d46ea963080a6ba5bd12c1274da66159877a544fbc70291eeed98d
+  md5: 45a3d52534fac8aa54a55ee92211a918
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 80216
+  timestamp: 1714483371043
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: daad7edc6d56abf3e176479e8628162dbf1c56b3d24db30d708aebae694a5214
+  md5: e8ecf229f7fcb4c0b76d8613627948f5
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 45189
+  timestamp: 1714483420152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 84320217abffa9386186ec8d03b4651bb4b1900d3871adc965a9a9e1d3799907
+  md5: 651312fa22168f71f9aec5f9ee2c2fcf
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 756116
+  timestamp: 1714483464368
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.9.1-h0416ee5_0.tar.bz2
+  sha256: 8823321b1f3a4dec2ba437b74f054b6188c4e86f15e9830a851c036f1000b116
+  md5: eb83a06e2e659553014b6ac66f379e09
+  depends:
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 371549
+  timestamp: 1725033449018
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-hcc03200_0.tar.bz2
+  sha256: 6aa8177f829f9608ea7403b269bf4fbad0747d3c672fa9e93a55d79efb07b948
+  md5: 2b85b2e23c0cb1c06a1100467086eb5a
+  depends:
+  - openssl >=1.1.1m,<1.1.2a
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 440007
+  timestamp: 1642102985958
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+  sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
+  md5: cf949d76148be1e2a534218d9c57df86
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 155435
+  timestamp: 1714484319443
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libnetcdf-4.8.1-h6685c40_4.tar.bz2
+  sha256: e846f05d6cdfd2850e5deb027b62e8d828fa9b12f61ae7ed6433155458032144
+  md5: 383bc5f062aafa9b714aa6204ab20daf
+  depends:
+  - hdf4 >=4.2.13,<4.2.14.0a0
+  - hdf5 >=1.12.1,<1.12.2.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libzip
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 706142
+  timestamp: 1691155040631
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
+  sha256: f7368e611e349b91315ce4ba4dbf9116d996a48f98eed425f4d5c3d5b9fcfa5e
+  md5: 77eb9daff9052f1fbf24d91c5bba1d74
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2543079
+  timestamp: 1675278760037
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-hcd4344a_2.tar.bz2
+  sha256: 0b1460332f394557429f75c871c89ad27fc2ddadbeb28bfcff8d1d8537f493ac
+  md5: 38e889ec253fe997be7f94556a0855d4
+  depends:
+  - openssl >=1.1.1u,<1.1.2a
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 230554
+  timestamp: 1686932558863
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-he49ee6e_2.tar.bz2
+  sha256: 060095497c98878e525bd8243c1cb612bd0d53c06c11f1d24f03987b1c6790b8
+  md5: 312f31016ef8cca75fef587797d94ffd
+  depends:
+  - boost-cpp >=1.73
+  - libevent
+  - openssl >=1.1.1u,<1.1.2a
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 895584
+  timestamp: 1687975375656
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
+  sha256: e54ee28f6ba01b3addf61ee9dfbdedc16eac8654fc334f713b5f181cf037d0f2
+  md5: 47aa151852fc9b07e7573d22f0af945d
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 339944
+  timestamp: 1729160123353
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libzip-1.8.0-h49b8836_0.tar.bz2
+  sha256: 0b4c8aa6e1fc2b82ce0b77c02e0e418764f94c3ea0bb18bea45a3cd265e3456f
+  md5: a51d3646b5ae61f0b7f40b55650932be
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - openssl >=1.1.1o,<1.1.2a
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102924
+  timestamp: 1652977143101
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libzopfli-1.0.3-ha925a31_0.tar.bz2
+  sha256: d5b0e01c2b80b43a0e1128a612f289891c375bd9f15b3b0d176b0658a1c3711e
+  md5: 532177b4105c87e006d9f49ba8ad399f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 210474
+  timestamp: 1593187626221
+- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py310haa95532_0.tar.bz2
+  sha256: b957593b060cc76d1e8376af052749f66268e81df18e7e8020b5d8fe5fe84690
+  md5: 4cea845047b0d40302f260127d1d02d9
+  depends:
+  - python >=3.10,<3.11.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 35946
+  timestamp: 1659783477621
+- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py310haa95532_0.tar.bz2
+  sha256: c2e861d3109533539f2fc7a8ebaeb1aafbb0960aca546ea7ed5a91376c796399
+  md5: 4d016b3bc975ab61c5786a6676693a9c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 12966
+  timestamp: 1652904192742
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.3.2-py310h2bbff1b_0.tar.bz2
+  sha256: e7947ecc85be759c379874f245b5e6390a28280fa2c17f8b9803a96aaa243491
+  md5: d82333a647626ea4158a6ce671504fac
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 83511
+  timestamp: 1686058308914
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+  sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
+  md5: 320f40b75d93f3b96931c6d13c23946c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 158902
+  timestamp: 1714512129889
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py310haa95532_0.tar.bz2
+  sha256: 88e0ad9a62f0e385ed4a36fc1bbb088a49065fafa4f08daac7c846fce26b6540
+  md5: af908af5ac51eafcb7e6332cd02c0d21
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 143240
+  timestamp: 1671542001479
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py310haa95532_1.tar.bz2
+  sha256: ab424b8036257c53eb5110f8d8817ed959718c275e2dff88407332ce783519ed
+  md5: 24f0c3faa37da73027d950da5b6cd3d3
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 126331
+  timestamp: 1684280061614
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py310h2bbff1b_0.tar.bz2
+  sha256: 10459e7599e98c67be954c34a1eba28baed7dd185f31e946a9b67784e3748dd1
+  md5: 974db1440c01eaa49bcae8d0dcd1cdbd
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27022
+  timestamp: 1704206300657
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.9.2-py310he19b0ae_1.tar.bz2
+  sha256: 998b024d02d4c41c2b2e810eb27b5d71f5724bd3fa577545aad9d8eee0a6892d
+  md5: 23640eebe09a06c7f08079d6c4e1fcab
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.23,<3.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.7
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 11230787
+  timestamp: 1732551286335
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py310haa95532_0.tar.bz2
+  sha256: cb2d90330a1c1bb4ae18110e7bc14f50287c6d603cf9c270cf98b72962ce3ea9
+  md5: 7e5b432f39238f991ea8e6c21fc7cc68
+  depends:
+  - python >=3.10,<3.11.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18107
+  timestamp: 1661934176570
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py310haa95532_0.tar.bz2
+  sha256: 8cac05d7cf61a8d4011fce8e0f3b109f8d94f06ea0dc9e0a7f0e8b208a054193
+  md5: 2cd828af0c9e8a8ecce14355b5619667
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 53824
+  timestamp: 1659721375084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py310haa95532_0.tar.bz2
+  sha256: 31152e14e45c00f079582bf2f32742b0ee2e23bd28904715092661fb7fd1d5b8
+  md5: 5205f987d201c5de2925956b8f9d8caa
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 19459
+  timestamp: 1659716154851
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py310haa95532_0.tar.bz2
+  sha256: 8c88c83f6f17de2841494075296d5514ec622337ba8f48b7ca57b836445d78f6
+  md5: 5c2188ac984be30e4f8df5ec56b56df2
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 90995
+  timestamp: 1661496484574
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+  sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
+  md5: 527155127b9fada5e5c5c69a624674b9
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187498166
+  timestamp: 1699648376430
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py310h2bbff1b_1.tar.bz2
+  sha256: 5f8249f157c4899b9c8339286067f77514e678ffa21aa03ab17812e8e96fb9d5
+  md5: a6d45a65a7468b522cb88a8f54a97b40
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49079
+  timestamp: 1682974931077
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.11-py310h827c3e9_0.tar.bz2
+  sha256: f023927c84ac294174826c15dc50b2658868eac4b377cf3f3caa2bbd13b57569
+  md5: d965190600962444e398591f0c56c7dd
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 201831
+  timestamp: 1730823204937
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.8-py310hc64d2fc_0.tar.bz2
+  sha256: b08a048bcc985742dfa499e8c79eb52461935b054d07363143610baeecb26b20
+  md5: 73054e743a0aced13bed19ba4d51b205
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 332762
+  timestamp: 1730822722584
+- conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py310h59b6b97_0.tar.bz2
+  sha256: 935ec7c1b0bfe11913631f59ac8f8337983a7d9a886ae7958d3ae3cc1bff5cda
+  md5: 3054889e8867d76ca9bcfcdfd00568fc
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 83183
+  timestamp: 1652348684261
+- conda: https://repo.anaconda.com/pkgs/main/win-64/multidict-6.1.0-py310h827c3e9_0.tar.bz2
+  sha256: a3b43158949b03068e6f81fdbc461c2d78de168e6441dad10001bc120879556c
+  md5: 5f61a666d8955b38a770a404c44e3769
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing-extensions >=4.1.0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 64045
+  timestamp: 1730905592011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py310haa95532_0.tar.bz2
+  sha256: 7ad8dd23e9743b0901a6f42d508b13015855e0ec5f9d689cfbb2ab1ba95dec02
+  md5: 13fad67eb60b89ac9d4767832c692cbc
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.10,<3.11.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119871
+  timestamp: 1698934620305
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.4-py310haa95532_0.tar.bz2
+  sha256: 3ab6907f1aa8d3f9c9d41f07a7958d78424c15c6915487c8a995f407221aecce
+  md5: 82c2dfefa7e4bdf31640e191251d4210
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.10,<3.11.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 532978
+  timestamp: 1728051166468
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py310haa95532_0.tar.bz2
+  sha256: b60400ded73de1554aebeb8c292d55bc8c98b3c5701b35285019468fb4c4ac9f
+  md5: b12bb18cd2fb67bf7bc0f2be962dd557
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.10,<3.11.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 180615
+  timestamp: 1728050835184
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py310haa95532_0.tar.bz2
+  sha256: e18ba942bb3f8a0ace571cfe58557aa5088acac13d094fde0302cf6452b2f7bf
+  md5: eb32799be5cf9de16c3688a34cb2b409
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14318
+  timestamp: 1708533067532
+- conda: https://repo.anaconda.com/pkgs/main/win-64/netcdf4-1.6.2-py310hadf358c_0.tar.bz2
+  sha256: ed27cc7b8ebf6f525ea34121861201d420fbbedea4552677b5ffeb319a21ded6
+  md5: 7b33b8cfb4753215899d4e9605e46667
+  depends:
+  - cftime
+  - hdf5
+  - libnetcdf >=4.8,<4.9.0a0
+  - libnetcdf >=4.8.1,<5.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 365383
+  timestamp: 1673455686114
+- conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.3-py310haa95532_0.tar.bz2
+  sha256: 4e959603f93deb5b50cc6991abcd34ff9366a722fb28d47a94937033c8979585
+  md5: 286db88289719c52659a06c77bfa19ad
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - lxml >=4.6
+  - numpy >=1.23,<2.0a0
+  - scipy >=1.9,!=1.11.0,!=1.11.1
+  - pydot >=2.0
+  - sympy >=1.10
+  - pandas >=1.4
+  - pygraphviz >=1.12
+  - matplotlib-base >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2660316
+  timestamp: 1720002609180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-7.2.2-py310haa95532_1.tar.bz2
+  sha256: 9ab288249fc32968e1a87c2814c515c19d1abdc6cd823ec07c1496503c0f57ea
+  md5: 89f40012edf8e38b9b40940c13f7c4ae
+  depends:
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab >=4.2.0,<4.3
+  - jupyterlab_server >=2.27.1,<3
+  - notebook-shim >=0.2,<0.3
+  - python >=3.10,<3.11.0a0
+  - tornado >=6.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4599194
+  timestamp: 1727198095117
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py310haa95532_0.tar.bz2
+  sha256: 7a659fc3d7cca9092e5e510e270499c20e32c315601fb8e22eb9248af324a06f
+  md5: fe5e24c542b36d32cc2d5382ce56b295
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23259
+  timestamp: 1699456053116
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numcodecs-0.12.1-py310h3469f8a_0.tar.bz2
+  sha256: c6bf8508df4c8d079c874c0dc86934b74646f35f0900bdaa6c9c417238cbfee3
+  md5: ce85c0c6a7e2efb7425884019a5c0885
+  depends:
+  - blosc >=1.21.3,<2.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - msgpack-python
+  - numpy >=1.7,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 344629
+  timestamp: 1707514108910
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.10.1-py310h4cd664f_0.tar.bz2
+  sha256: 97fc453b0175ce684bc0f497a5c0748bd512ef08713280074f9f227e3020c32d
+  md5: 104f87b7eb25936cc01da72eb4858880
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21,<3
+  - numpy >=1.23.0
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 184044
+  timestamp: 1730216247778
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py310h055cbcc_0.tar.bz2
+  sha256: bd9e579e6d0e639570927ece9ae3c3c5b7fe0772306cb63deb856d717c51b33e
+  md5: d1dcb19ab9483ee8a93fb46861125753
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py310h65a83cf_0
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11048
+  timestamp: 1708640486296
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py310h65a83cf_0.tar.bz2
+  sha256: 62215947f56b113eb2c8e888d934e3536fd7ce49d56b5df66e36e83086684fe9
+  md5: 952b5b3d77ca62745163be1f72b89ac9
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.26.4 py310h055cbcc_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9900493
+  timestamp: 1708640453215
+- conda: https://repo.anaconda.com/pkgs/main/win-64/oauthlib-3.2.2-py310haa95532_0.tar.bz2
+  sha256: f6e532f358cd41b5618d0f787327310ee83b1c80e3480503bdfde3ad95860794
+  md5: d35e567abeb4469237e16fc22a343d1a
+  depends:
+  - blinker >=1.4.0
+  - cryptography >=3.0.0
+  - pyjwt >=2.0.0,<3
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 233853
+  timestamp: 1679489706159
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+  sha256: e2afce0548808d27293a03661ee5f7ac3e18f82a92c9fb23f420eb5e92126fc6
+  md5: 9dd921a785844abe0aa842c3800d405a
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.7.0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 286986
+  timestamp: 1722872761369
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
+  sha256: 0474e14823c734edc088bef98b829149a47ed8b4654f9638926c2fe4bbc40f38
+  md5: a67d4a763641de641ea9dfa8c4a5f567
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: OpenSSL
+  license_family: Apache
+  size: 6048217
+  timestamp: 1694466133007
+- conda: https://repo.anaconda.com/pkgs/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
+  sha256: 417cf23716f17b6daf2b717bbd69240aa9440845dfa415f59a97961794632ce5
+  md5: 36d709d47c43a3e9b43f23cf4edb6438
+  depends:
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.9,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 877890
+  timestamp: 1676482911485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py310haa95532_0.tar.bz2
+  sha256: c0cfdc0e8a734241b5183954a0b163b7b5fb8301a621b8d5f02fe83ba5d4b520
+  md5: e30dabb368401270b542d0c3fdf391bb
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 31667
+  timestamp: 1699371284738
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.1-py310haa95532_0.tar.bz2
+  sha256: ef0f7b7fdec970067658c11a1ba012be253df497ab98bcea108dabf5c46503ce
+  md5: df86e675c7c625e4b95f68057cb3dee7
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 136214
+  timestamp: 1720104030837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.3-py310h5da7b33_0.tar.bz2
+  sha256: 6e52052955737aad9dcb2da44ec0c313399333f49f6769908d7b8014ff424c75
+  md5: 4b9d15e75b678dccd835be227105bba1
+  depends:
+  - bottleneck >=1.3.6
+  - numexpr >=2.8.4
+  - numpy >=1.22.4,<3
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - lxml >=4.9.2
+  - pyreadstat >=1.2.0
+  - psycopg2 >=2.9.6
+  - pyqt >=5.15.9
+  - python-calamine >=0.1.7
+  - dataframe-api-compat >=0.1.7
+  - scipy >=1.10.0
+  - gcsfs >=2022.11.0
+  - zstandard >=0.19.0
+  - numba >=0.56.4
+  - pymysql >=1.0.2
+  - xlsxwriter >=3.0.5
+  - sqlalchemy >=2.0.0
+  - beautifulsoup4 >=4.11.2
+  - xlrd >=2.0.1
+  - openpyxl >=3.1.0
+  - s3fs >=2022.11.0
+  - jinja2 >=3.1.2
+  - fsspec >=2022.11.0
+  - html5lib >=1.1
+  - pytables >=3.8.0
+  - blosc >=1.21.3
+  - adbc-driver-postgresql >=0.8.0
+  - pandas-gbq >=0.19.0
+  - matplotlib-base >=3.6.3
+  - qtpy >=2.3.0
+  - fastparquet >=2022.12.0
+  - odfpy>=1.4.1
+  - pyarrow >=10.0.1
+  - tabulate >=0.9.0
+  - pyxlsb >=1.0.10
+  - xarray >=2022.12.0
+  - adbc-driver-sqlite >=0.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14245891
+  timestamp: 1732735630309
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.5.3-py310haa95532_0.tar.bz2
+  sha256: fe2c7b564bedffe3272762cc2d1857e4b64ba029ade7249a28343b09d4e5568d
+  md5: 52ef05ea6b2bce889e5ed32e16755846
+  depends:
+  - bleach
+  - bokeh >=3.5.0,<3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.1.0,<3.0
+  - python >=3.10,<3.11.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing-extensions
+  constrains:
+  - holoviews >=1.18.0
+  - bokeh-fastapi >=0.1.2,<0.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23626248
+  timestamp: 1730382328245
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.1-py310haa95532_0.tar.bz2
+  sha256: 20a769a2101fa8b40eaeaa0372ad88ecf9b80af62fa4c76b29860400d0f83036
+  md5: b6df60d94ba06a3ac09d27c2e5d603f8
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 195238
+  timestamp: 1719348159340
+- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py310haa95532_0.tar.bz2
+  sha256: 53294a1845864c4e38fbb6c277e734cb6a1f1cfbd9d7b40cc760b6cb291312fb
+  md5: 9535b98f44bc4289f8e46f9a0240536f
+  depends:
+  - locket
+  - python >=3.10,<3.11.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36809
+  timestamp: 1698702886819
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-11.0.0-py310hb5480e2_0.tar.bz2
+  sha256: f635ddfeeb2243962df04ac988fe0494c757b192abfc7ed13c2e6f02c482a6e7
+  md5: e33137fdeeb695ce8542d85d7c7238ab
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 814468
+  timestamp: 1731595172979
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.2-py310haa95532_0.tar.bz2
+  sha256: 814c47a2d6ffd2200da86082d9d8b2483dab65e6622247bb9c5b01869b6f641b
+  md5: a34dd1afc9b1baea5293e6acf2fe0711
+  depends:
+  - python >=3.10,<3.11.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2615232
+  timestamp: 1723485560196
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py310haa95532_0.tar.bz2
+  sha256: e471553584e2ed5971404849a37358d13f08fabe18b0ef3ef33a3a0bc1a22fa3
+  md5: c5ebdddd493f77c393cc043a457a231b
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 32580
+  timestamp: 1692205629751
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.21.0-py310haa95532_0.tar.bz2
+  sha256: 1d7518d071614aa48150414a95339c0ed39694a48f38dd036731c16ca0cb91ee
+  md5: cb76d4e9ec4ed6e5c91efb37922d48ef
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91598
+  timestamp: 1731961823387
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py310haa95532_0.tar.bz2
+  sha256: 2270c3de7d72a7596bc5806a1450884995fcb76beabd4e6ad41ef1f36c0d0024
+  md5: ac3812fa3ac3ee2d1c2aacec313803d5
+  depends:
+  - python >=3.10,<3.11.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 600631
+  timestamp: 1704404461740
+- conda: https://repo.anaconda.com/pkgs/main/win-64/propcache-0.2.0-py310h827c3e9_0.tar.bz2
+  sha256: cde36a2103a082598e2495a60bbc95247685fd74982f1901dc1396f3cab9c7d2
+  md5: 383b0111fb200e7962e39dc90a87b06c
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 64091
+  timestamp: 1732304471844
+- conda: https://repo.anaconda.com/pkgs/main/win-64/protobuf-3.20.3-py310hd77b12b_0.tar.bz2
+  sha256: def7e976a6845fe784f10b6e70c1d51f81e942995f240e6ca28f558d119ab5ca
+  md5: 214812935599abedec64d9a769c885ff
+  depends:
+  - libprotobuf 3.20.3.*
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 240849
+  timestamp: 1675281854833
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py310h2bbff1b_0.tar.bz2
+  sha256: 8ba826d7c49fd587064175395cb0b4c956fff616b1866b4b8eaefa6baabc3415
+  md5: 8cfb596037d09d397df9bfddc7ea62a5
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 375863
+  timestamp: 1656431373274
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-11.0.0-py310h790e06d_1.tar.bz2
+  sha256: 170d1ca4533254b429386da41ce481d15316aa661cb5f076b77ce4c680436f0e
+  md5: f74880afac6d533f466e1f6a480f85bc
+  depends:
+  - arrow-cpp >=11.0.0,<11.0.1.0a0
+  - boost-cpp
+  - gflags
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3637873
+  timestamp: 1693274643129
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py310haa95532_1.tar.bz2
+  sha256: 0425af15c734660310fd267c19aca5c8bac712f737e4b97d8fcefe38c0a9886d
+  md5: 3aa71810eb4ca6e3edd0398763f6f269
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1903399
+  timestamp: 1684280387582
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyjwt-2.9.0-py310haa95532_0.tar.bz2
+  sha256: 9536746659e0fc0ef8ec5b64fb8e60df4ed905ca18f46e7aab2e0d97a89289c6
+  md5: dd0310fe94cceee0ffff2044c00cd341
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - cryptography >=3.4.0
+  license: MIT
+  license_family: MIT
+  size: 77302
+  timestamp: 1730786857459
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py310haa95532_0.tar.bz2
+  sha256: 48d4e140b012d95051d40ea19668b4660a5b35423233a4a86e09086e2803cdd8
+  md5: 3909ea700a127b6a649ea8b5859ebf2e
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95255
+  timestamp: 1690225526774
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.2.0-py310haa95532_0.tar.bz2
+  sha256: 0146cdefcf3b77324cc846b46eaf5ed451c0ae01a18f64297071b055e459ab06
+  md5: 85ef917d8557f14ad2f4ab29434ba3e9
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 427286
+  timestamp: 1731446031716
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py310haa95532_0.tar.bz2
+  sha256: 079bb5bd27170316f111209f6e034308fa6443102e62a2e29c58f73089356e37
+  md5: 8eb51a59b8c2d264f072b9686f08554b
+  depends:
+  - python >=3.10,<3.11.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 28442
+  timestamp: 1642089401419
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.10.13-h966fe2a_0.tar.bz2
+  sha256: 07a10f49f4b0b44a6607bad9fe19f7784f0f2284c02ce72da024145b5d2446c3
+  md5: bc8e0cf92bbe55ed7d5718006f1e7533
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - openssl <3.5.7
+  license: PSF-2.0
+  license_family: PSF
+  size: 16971702
+  timestamp: 1694438433227
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py310haa95532_2.tar.bz2
+  sha256: 8e12b59e93c1b5489ed6fdbd044d5626158356ea840953f0da6bfd15caf21d71
+  md5: 2a984d495e1cd2dd84c0049f248d61ab
+  depends:
+  - python >=3.10,<3.11.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 290793
+  timestamp: 1716495894571
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.20.0-py310haa95532_0.tar.bz2
+  sha256: 84f1874ce78386f6c2b9db8aa85aa756fa81756f782fb7120fc6b9a1893148ff
+  md5: 71374aee6be3bc34da7a22bd318de450
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 268237
+  timestamp: 1731939691795
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-flatbuffers-24.3.25-py310haa95532_0.tar.bz2
+  sha256: 317ac26c01451341effa39c0b9ccab7418176504749621983441e5bdf795e81a
+  md5: 0ced91f498d60e6940fb7b34bd8bc8cf
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 54405
+  timestamp: 1722369360482
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py310haa95532_0.tar.bz2
+  sha256: ef099f3c29677a1a048bed3a434acc283c1d6dfecf96cc0d722a537054b70157
+  md5: 44e942cbb9075709d5daa4c042fe098c
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 15718
+  timestamp: 1683824312523
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py310hd77b12b_0.tar.bz2
+  sha256: 263e1fb7053f5d6eaeb06d672554154f4168b8adf4cee0a67aea0817c5b4ceed
+  md5: 5563fc7d260892d8bcb788b66c3848ae
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 135816
+  timestamp: 1682522463382
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-snappy-0.6.1-py310hd77b12b_0.tar.bz2
+  sha256: d9e92ae7681f1865287ba7c32f7161bec58d9056828cac985f777f90471e2143
+  md5: a71f7c84d34a96577394fd349e921624
+  depends:
+  - python >=3.10,<3.11.0a0
+  - snappy >=1.1.9,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 34323
+  timestamp: 1670944261041
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py310haa95532_0.tar.bz2
+  sha256: 942d721dd8f7b1158eed7e3d1579eb7a844ebfa28c4b2b7953b56c6927ed0313
+  md5: 64cfe7c71ceb6ec178eb3091cf943d5b
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 264666
+  timestamp: 1713974542135
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py310haa95532_0.tar.bz2
+  sha256: 42ccd5a361ab2506e0a81e0ebdf0da6cf9ff29fdcb88548f9e55cd4aadd18637
+  md5: 7ad6254da4ad2125276f5d1a4cc4851b
+  depends:
+  - param
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 61483
+  timestamp: 1711137076808
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py310h2bbff1b_0.tar.bz2
+  sha256: 9715738e6124de2510a3bf6ca945ba361fa27e3af60bcdf3a1bc25f9c0068b3b
+  md5: b45930642e0ddbd43333c8a3ba4bc491
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13492611
+  timestamp: 1669937046724
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py310h5da7b33_0.tar.bz2
+  sha256: 5fca272384bcdd93c4caa9a753fc514b7e29d734498147c8fd26a52e3cadc2b8
+  md5: 1992345047b4f1ed52e7f85b5a0e143e
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 234279
+  timestamp: 1677610684013
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.2-py310h827c3e9_0.tar.bz2
+  sha256: d0631a65e74ec75713da22a5d6b5b2fd108ac3466e7a205c38918963823325a6
+  md5: a94652ebed826cb607a332f70ca1e6c7
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 179359
+  timestamp: 1728658051261
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-25.1.2-py310hd77b12b_0.tar.bz2
+  sha256: 0812afa6f6ab9f5562dcb03936b3a00e11124f2c55f81bcb6f463203baab0c0b
+  md5: 174ecc549eeac119dcdecfa824641cce
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 466374
+  timestamp: 1705606079526
+- conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+  sha256: 720f3dd1f933d035b1393951ffd1b6437fc5e19b1999e74096044514a46053fb
+  md5: add2dfb15b518144663fc3b897d66da7
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  size: 493391
+  timestamp: 1652432364793
+- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py310haa95532_0.tar.bz2
+  sha256: bfb71f2451660127dd40061bc6f90a41525beb76f2720cdddf0564781c8f0d8b
+  md5: 7c8e4d5ee0c84847494c56bb51fb0bcb
+  depends:
+  - attrs >=22.2.0
+  - python >=3.10,<3.11.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 59033
+  timestamp: 1699012173193
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py310haa95532_1.tar.bz2
+  sha256: 3f29161c88a3634763db60fa88ad9ee616cfc8bbb7a06e1a694d93a3773173c8
+  md5: 800a82f266a6649bb43101c966491883
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.10,<3.11.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 99564
+  timestamp: 1731000717078
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-oauthlib-2.0.0-py310haa95532_0.tar.bz2
+  sha256: cac9dd92400b331def69a7d19ebfb1bc7190f2b68fddc51ed0dd4c82346110c4
+  md5: 0f084fe04fb3e74f47766a7954ab2747
+  depends:
+  - oauthlib >=3.0.0
+  - python >=3.10,<3.11.0a0
+  - requests >=2.0.0
+  constrains:
+  - cryptography >=3.0.0
+  - pyjwt >=2.0.0,<3
+  license: ISC
+  license_family: Other
+  size: 35122
+  timestamp: 1720615136514
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py310haa95532_0.tar.bz2
+  sha256: 558cf5fcbf151bf419079e13b5f3cc5f0a51af0596661bef50290903e52cdc24
+  md5: a86808657e019161b1e8e0a492afe6e2
+  depends:
+  - python >=3.10,<3.11.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9367
+  timestamp: 1683077232021
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py310haa95532_0.tar.bz2
+  sha256: e069e307e66cf1289bad542f9293e7a79b902d15d330c875ccce709b2b2523dd
+  md5: 9f21f24f35c99c432df830795e3a33f4
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 9734
+  timestamp: 1683059168209
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py310h636fa0f_1.tar.bz2
+  sha256: d0abcaca638da1bb81db51f7f6ac6cfe431f752bdadf175ad83125984d758a46
+  md5: 75507640e623c025e944c48db1e349af
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 222239
+  timestamp: 1732235009465
+- conda: https://repo.anaconda.com/pkgs/main/win-64/s3fs-2024.6.1-py310haa95532_0.tar.bz2
+  sha256: df6b9b504b2e4aff9347b8c44dd869e1b1f4aefdade01441320ad89782fe0fd0
+  md5: 0854864a75aa3589a749d907047ad7a1
+  depends:
+  - aiobotocore >=2.5.4,<3.0.0
+  - aiohttp !=4.0.0a0,!=4.0.0a1
+  - fsspec 2024.6.1.*
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 56906
+  timestamp: 1724924191344
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scikit-image-0.24.0-py310hc64d2fc_0.tar.bz2
+  sha256: 8296b381527fc40e3d0194573d6232e2e123a2bf203e1bb325c659fad49fe801
+  md5: f03618e1b2eaba85a1630591caef59f5
+  depends:
+  - imageio >=2.33
+  - lazy_loader >=0.4
+  - networkx >=2.8
+  - numpy >=1.23,<2.0a0
+  - packaging >=21
+  - pillow >=9.1
+  - python >=3.10,<3.11.0a0
+  - scipy >=1.9
+  - tifffile >=2022.8.12
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - matplotlib-base >=3.6
+  - pywavelets >=1.1.1
+  - pooch >=1.6.0
+  - dask-core >=2021.1.0
+  - scikit-learn >=1.1
+  - astropy >=5.0
+  - cloudpickle >=0.2.1
+  license: BSD-3-Clause AND MIT AND BSD-2-Clause
+  license_family: Other
+  size: 12070959
+  timestamp: 1726765919364
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.14.1-py310h8640f81_0.tar.bz2
+  sha256: bb6b0d78f4f262f0d665945e841b59d0a3e486c010a6fa5f11095ba4a37b15a6
+  md5: 5be2c4c6c51a8e68cded3076f87cf907
+  depends:
+  - blas 1.0 mkl
+  - icc_rt >=2022.1.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.3
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 31388051
+  timestamp: 1731624128312
+- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py310haa95532_0.tar.bz2
+  sha256: b17e85b5d1d6d0e440c98ddeb98d9b57fe83882b4386a0c48fc4e6b3cbb82268
+  md5: 1e784c644bba03b661c045bedeb1ed0d
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 83392
+  timestamp: 1699371351367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-75.1.0-py310haa95532_0.tar.bz2
+  sha256: eb48d9d1c1257a83402e9346f9d0109e9c4fa3192da5400571a428acc5d43d91
+  md5: a5e6c71598e30ea5290cbd2f649c3fe4
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 1771325
+  timestamp: 1726678469224
+- conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
+  sha256: 5e5f855a70cf4c9dc6f2ac8d9fa51a3f095bf4db8e2ee3ff213ef5432556d7cd
+  md5: 9c1f7331a4116e5c27d8af7453f8ee47
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 119274
+  timestamp: 1723557526373
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py310haa95532_0.tar.bz2
+  sha256: e128bb380d423a77aaccbd1165c0fe511c9699b176ec73d452a3aca0b22c8eb4
+  md5: c948da08d73c8c8168dfa6dfe35b6350
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17619
+  timestamp: 1705431497372
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py310haa95532_0.tar.bz2
+  sha256: a23892e537aa5387f4a7e817dfdcc4b9c5fec6b40a1695f99ecb7e3896f8f1b3
+  md5: 022293f076961b460cfe654421c3a69a
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 67725
+  timestamp: 1696347732280
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+  sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
+  md5: 833b93a2daade3407898f15588945d83
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1440481
+  timestamp: 1714488344682
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tensorboard-2.10.0-py310haa95532_0.tar.bz2
+  sha256: b17a231851c5ed400ca23751838cd05ac55235de723aba1ce3b256782ea7d281
+  md5: 11104fd0b12a979c71c89c84c7dfce62
+  depends:
+  - absl-py >=0.4
+  - google-auth-oauthlib >=0.4.1,<0.5
+  - grpcio >=1.24.3
+  - markdown >=2.6.8
+  - numpy >=1.12.0,<2.0a0
+  - protobuf >=3.6.0
+  - python >=3.10,<3.11.0a0
+  - requests >=2.21.0,<3
+  - setuptools >=41.0.0,<82
+  - tensorboard-data-server >=0.6.0,<0.7.0
+  - tensorboard-plugin-wit >=1.6.0
+  - werkzeug >=1.0.1
+  - wheel >=0.26
+  license: Apache-2.0
+  license_family: Apache
+  size: 6166371
+  timestamp: 1669761179446
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tensorboard-data-server-0.6.1-py310haa95532_0.tar.bz2
+  sha256: e0c81aaa95ab4b4fa3814d60fa033c31f62c88c5ac1d19b81a53d18f2913cee3
+  md5: d68c403a89158877711adc50dcb5740d
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 13098
+  timestamp: 1670853673164
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tensorboard-plugin-wit-1.8.1-py310haa95532_0.tar.bz2
+  sha256: c3fbc5cec2a46183fbb61a4c871e1e4a8f38450830dfb8c0726d373ca3c6e3eb
+  md5: fa9eed724d1a413c1f0d2bbcc9efc65b
+  depends:
+  - python >=3.10,<3.11.0a0
+  - setuptools
+  - wheel >=0.26
+  license: Apache-2.0
+  license_family: Apache
+  size: 723939
+  timestamp: 1660162233855
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tensorflow-2.10.0-mkl_py310hd99672f_0.tar.bz2
+  sha256: 18090edb6390d7c2405646f80a96245e578249185e9b4ff550b26d24cf62f363
+  md5: d30ff93569746b295022884ca7445202
+  depends:
+  - _tflow_select 2.3.0 mkl
+  - python 3.10.*
+  - tensorboard 2.10.*
+  - tensorflow-base 2.10.0 mkl_py310h6a7f48e_0
+  - tensorflow-estimator 2.10.*
+  license: Apache-2.0
+  license_family: Apache
+  size: 4175
+  timestamp: 1670626182226
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tensorflow-base-2.10.0-mkl_py310h6a7f48e_0.tar.bz2
+  sha256: 93d17c1736652067aac3b086905521307afba09c6b576795296b7494be832e29
+  md5: cd89c55183b93ae38967e3ccd9919fb7
+  depends:
+  - absl-py >=1.0.0
+  - astunparse >=1.6.3
+  - flatbuffers >=2.0
+  - gast 0.4.0.*
+  - giflib >=5.2.1,<5.3.0a0
+  - google-pasta >=0.1.1
+  - grpcio >=1.24.3,<2.0
+  - h5py >=2.9.0
+  - icu >=58.2,<59.0a0
+  - jpeg >=9e,<10a
+  - keras 2.10.*
+  - libcurl >=7.86.0,<9.0a0
+  - libpng >=1.6.37,<1.7.0a0
+  - libprotobuf >=3.20.1,<3.21.0a0
+  - numpy >=1.20,<2
+  - openssl >=1.1.1s,<1.1.2a
+  - opt_einsum >=2.3.2
+  - packaging
+  - python >=3.10,<3.11.0a0
+  - python-flatbuffers >=2.0
+  - requests
+  - scipy >=1.7.3,<2
+  - setuptools
+  - six >=1.12.0
+  - snappy >=1.1.9,<2.0a0
+  - sqlite >=3.40.0,<4.0a0
+  - tensorboard 2.10.*
+  - tensorflow-estimator 2.10.*
+  - termcolor >=1.1.0
+  - typing_extensions >=3.6.6
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - wrapt >=1.11.2
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 131727950
+  timestamp: 1670371441333
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tensorflow-estimator-2.10.0-py310haa95532_0.tar.bz2
+  sha256: 7be590bed29cccabb9051dad5fe36b7095df7d67ab7f2f586f98048c0a7f1f69
+  md5: a9ce1e92ad3c8d229ab6ebb75f1617a0
+  depends:
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - tensorflow-base  2.10.*
+  license: Apache-2.0
+  license_family: Apache
+  size: 613286
+  timestamp: 1669761587961
+- conda: https://repo.anaconda.com/pkgs/main/win-64/termcolor-2.1.0-py310haa95532_0.tar.bz2
+  sha256: 384d57c5c37b23b1ea85d2e7b088c728edb4052a2a1cd2c3829bbcc18ead5909
+  md5: 99a18914f623b764c8653ad822ba11e5
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 11789
+  timestamp: 1668084943015
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py310haa95532_0.tar.bz2
+  sha256: d0d86ed6cd7ce216d8e9c014ccec1aca485f273a0390acd7fce88b999c5c07fc
+  md5: 0c1eef070bdc583a5f13ae6d90df9ce5
+  depends:
+  - python >=3.10,<3.11.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30837
+  timestamp: 1671752231574
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tifffile-2023.4.12-py310haa95532_0.tar.bz2
+  sha256: edd5a7f0eff16b3f970f084c651d34c455088c06fb9ed6008888dfc8400c78a5
+  md5: 63b89d9cec5c485479d1b51d9a187fa7
+  depends:
+  - imagecodecs >=2023.1.23
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - matplotlib-base >=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 415669
+  timestamp: 1695107805311
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py310haa95532_0.tar.bz2
+  sha256: bc1ddb7012553cfd0e0dfd59ac053f2c248ed6aa2f3f073535c2e3727b156081
+  md5: bea69cca66bf89b57764689750ad19b0
+  depends:
+  - python >=3.10,<3.11.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39827
+  timestamp: 1668168932332
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+  sha256: 0a95736cfd0bb25fc201cd6be4a2450ea8fc30eeb349d861812675b84c94fa74
+  md5: a8a9fb30c6dd8e7a16d5dcd2333c3c49
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3844176
+  timestamp: 1714770894235
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.0.1-py310haa95532_0.tar.bz2
+  sha256: 98e42375576fc276660159b9a9e0b1d9894f68d46b642580fae6074fc69c4152
+  md5: 1df8cd89f5453214ab5751f786b606c2
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 25628
+  timestamp: 1657175602888
+- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py310haa95532_0.tar.bz2
+  sha256: 459eaaf49856625d8d82dca32dbd401525999ec1567de125d61f81aa10d364a3
+  md5: 2a762291f7c22ce1721560de68a8210a
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104573
+  timestamp: 1667464143397
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.1-py310h827c3e9_0.tar.bz2
+  sha256: f4ddbaefe0ce5e852ddec8511dd00c6c8a2bf0f6b70931457b7a527528a06ab2
+  md5: d60ee54f17f8830d9f54d46c9886018b
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 716681
+  timestamp: 1718740308614
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.5-py310h9909e9c_0.tar.bz2
+  sha256: d9ad0a29da259d5c48097bdaa472bdcfafad862e7d22a525df894b13c9b4bb38
+  md5: b242b446e92617b01a760e02a9ace290
+  depends:
+  - colorama
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 159044
+  timestamp: 1724854408940
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py310haa95532_0.tar.bz2
+  sha256: 69030849e5c9fb4b81997b209da56a31f39f70b17cd81ad5fa87a03829aa9c04
+  md5: 7dd354534a9f7c43229a6707470c5936
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 167935
+  timestamp: 1718227167930
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py310haa95532_0.tar.bz2
+  sha256: 04c24028ee04dfc3e1743003ea20ceb8f24551efcb78ce32d5adb0676df67f3b
+  md5: 1260cd75a72036bacc486adc44d6b108
+  depends:
+  - python >=3.10,<3.11.0a0
+  - typing_extensions 4.11.0 py310haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9720
+  timestamp: 1715269070601
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py310haa95532_0.tar.bz2
+  sha256: 5d9d154041cdb878e2eabdf5ca184219b4d188fe1758ceab4beb102898d27747
+  md5: 0122be146ba1251612155eef700973f1
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 61233
+  timestamp: 1715269060734
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py310haa95532_0.tar.bz2
+  sha256: fb7d79c284177ec64a95e1786fae83070612ab4318a0cde9c4ed54fb4b95a031
+  md5: c0297d13bebf64bb81c7d9ca9ebab5d1
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 11410
+  timestamp: 1659769516199
+- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py310h2bbff1b_0.tar.bz2
+  sha256: 546ad672e5a6b88eae833dd2955160105f376be97d7d0dfdecd4164837211f0e
+  md5: d746ec7238d3b165d58ffc8e85427a03
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 517369
+  timestamp: 1713213348900
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.3-py310haa95532_0.tar.bz2
+  sha256: 3f0b42044532387eaf17272f17e644c0e097b6ad87e2bcc12b2087594401b2a4
+  md5: 21ace7c9e104b6fffd0985a16700a159
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - selenium >=4.4.3
+  - zstandard >=0.18.0
+  - h2 >=4,<5
+  - requests >=2.26.0
+  license: MIT
+  license_family: MIT
+  size: 174093
+  timestamp: 1727769895675
+- conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+  sha256: 2ef16d0252e04063d44d0683831d55b485f713fe5af2c2efd61753fb4f27d7e4
+  md5: 256ab1d5dce70111a1f4807a5a9fc322
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 100982
+  timestamp: 1706894771410
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.40-haa95532_2.tar.bz2
+  sha256: 2347a1c63da77846cb2161daaca7a7918fd1f2f8fc6c482b1da15f2c81ff9401
+  md5: 82f790121c5a4b129df23a0c264a5371
+  depends:
+  - vs2015_runtime >=14.42.34433
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9297
+  timestamp: 1733348498082
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.42.34433-h9531ae6_2.tar.bz2
+  sha256: e5a9bb7ea0534170f6cd52021dd2c9cdd2048eb7cf30bd983ce12caf7fdcdb21
+  md5: 8a633c6afbd406dcec4a824949408c1a
+  size: 2461182
+  timestamp: 1733348487481
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py310haa95532_1.tar.bz2
+  sha256: 5feccb42695e0a5f0d8e47806ec4a38d80812946bedff171a1b6bde5513843e7
+  md5: 8719f9841803cf96f733f59aafbd147e
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21579
+  timestamp: 1642093965560
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py310haa95532_0.tar.bz2
+  sha256: f371d3506e4e8480ffde0e9d0fb1b44c2bfdbea57b23cccd609ca3aa034b3f83
+  md5: 85953c8badca12976eb5d368835fcefb
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 118154
+  timestamp: 1715878578248
+- conda: https://repo.anaconda.com/pkgs/main/win-64/werkzeug-3.0.6-py310haa95532_0.tar.bz2
+  sha256: 9df6ad8542c83b87f748228b60c6eb2c29851c4b2834332e94a778fac8325b4f
+  md5: eadb854a34eaacc28d2c5616e01cc276
+  depends:
+  - markupsafe >=2.1.1
+  - python >=3.10,<3.11.0a0
+  constrains:
+  - watchdog >=2.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 348077
+  timestamp: 1731005863134
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.44.0-py310haa95532_0.tar.bz2
+  sha256: 156a33aaa1b85ec45c25e5ce0506e207c5cb0b537c975e235740be51ff3645be
+  md5: aacc9b0ca89bc616741a7b53659d0455
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 137178
+  timestamp: 1726165373287
+- conda: https://repo.anaconda.com/pkgs/main/win-64/widgetsnbextension-4.0.10-py310haa95532_0.tar.bz2
+  sha256: 1fa4fd2da9e6d6fd08162d8107f3a2d544721d97c7e187d44ee5107bf6ff2e78
+  md5: 31894196534039653b932c5bdbcc7239
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1932336
+  timestamp: 1709323320628
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py310haa95532_0.tar.bz2
+  sha256: 7c5b72bec25fabcb0a6644acee0a3f45c17d535780581a17ec6616ecd21b284d
+  md5: 43afdf809d6ddf58af49fb1fc5230808
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: PUBLIC-DOMAIN
+  size: 8531
+  timestamp: 1642658494153
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wrapt-1.14.1-py310h2bbff1b_0.tar.bz2
+  sha256: 14c8bc32b21b8cfb42efe46e6b14c0c5261895535914e7599e23f9de06e967f9
+  md5: 83d74c87c26260c95021480516300cdc
+  depends:
+  - python >=3.10,<3.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 50468
+  timestamp: 1657814949415
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py310haa95532_0.tar.bz2
+  sha256: fb467c7eacdf962bcb8f24476709a65db51ea60ee4ddb75f12ed30b4ea69d531
+  md5: 85a71410f54365f053f787ab5782859b
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.10,<3.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1813278
+  timestamp: 1689041769969
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py310haa95532_1.tar.bz2
+  sha256: 67ae0c5a80eaa449ba31d96276218bb503b2a4b1cafe064376f26d5a227e98c7
+  md5: 1cb14e0e9baf9ecb93a9268246620454
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48944
+  timestamp: 1675159282275
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+  sha256: 344a5276a9928638dcde054dfe4e87c8cb40bd2d4d356378b9ab2f863ca62e4b
+  md5: fe471fd8b5a3d77be6fa5dbf9b99dafb
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 1432281
+  timestamp: 1714515119689
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yarl-1.18.0-py310h827c3e9_0.tar.bz2
+  sha256: 4ee05f5577049f25ee1a357aeb10274584ba440a5eef496600794747419d5bb5
+  md5: 45a4d5009b0270741cad673a7fb78a2e
+  depends:
+  - idna >=2.0
+  - multidict >=4.0
+  - propcache >=0.2.0
+  - python >=3.10,<3.11.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145393
+  timestamp: 1732547101027
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zarr-2.13.3-py310haa95532_0.tar.bz2
+  sha256: a1280f41ca08b440ae997627db0eda252ecb0360f9d01235c9a2ada9c341be5c
+  md5: 56b43fbf8825f28ab9d3623962a50ec0
+  depends:
+  - asciitree
+  - fasteners
+  - numcodecs >=0.10.0
+  - numpy >=1.7,<2.0a0
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 346763
+  timestamp: 1669364054699
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+  sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
+  md5: e5aed81295b61b6d1eb62830799a0297
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 9125184
+  timestamp: 1705602328351
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zfp-1.0.0-hd77b12b_0.tar.bz2
+  sha256: 4c35ecdc3e6eac1c031fb9caad206819266a29c9b3d507e2c82a73c6b3c4aaa8
+  md5: 2440d1045b36aeaffa022e8316352a5f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 271931
+  timestamp: 1681741704356
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py310haa95532_0.tar.bz2
+  sha256: 48e843987d2df58690ada2fbbbd38fa504ae0527f8398dca88a69f207b92a57a
+  md5: d6a58dc02f3c12b71c112776a2f45d56
+  depends:
+  - heapdict
+  - python >=3.10,<3.11.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 77967
+  timestamp: 1695833117526
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.21.0-py310haa95532_0.tar.bz2
+  sha256: acab853fb614eb98cb55588889244da80ffb9caa74d291e126faf643a6d66422
+  md5: 1214d0162b72abbd2142ac7fc21b6f87
+  depends:
+  - python >=3.10,<3.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 26828
+  timestamp: 1732630857652
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+  sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
+  md5: f295b54ab59f5b8658e2a322ac6aa721
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 162161
+  timestamp: 1714514792081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
+  sha256: 1f68cd378c6cdec34a5a3a21c56c9b8422b0f037b868b3db72065c0a2ca27921
+  md5: d455a04486eddfb94c280974c0c33ae3
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1971698
+  timestamp: 1728487049972

--- a/landuse_classification/pixi.lock
+++ b/landuse_classification/pixi.lock
@@ -7,1176 +7,1176 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_tflow_select-2.3.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/absl-py-2.1.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aiobotocore-2.12.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aiohappyeyeballs-2.4.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aiohttp-3.10.5-py310h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.6.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aom-3.6.0-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py310h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-11.0.0-hda39474_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/async-lru-2.0.4-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/async-timeout-4.0.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-24.2.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.4.57-he6710b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.1.6-h2531618_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.9-he6710b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.8.185-hce553d0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/babel-2.11.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bleach-6.2.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blinker-1.6.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blosc-1.21.3-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.6.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.73.0-h7f8727e_12.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/botocore-1.34.69-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.4.2-py310ha9d4c09_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py310h6a678d5_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brunsli-0.1-h2531618_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.11.26-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cachetools-5.3.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.8.30-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py310h1fdaa30_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cfitsio-3.470-h5893167_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cftime-1.6.2-py310ha9d4c09_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/charls-2.2.0-h2531618_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.0.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.3.1-py310hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py310h130f0dd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.2-py310h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-2024.5.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.5.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-expr-1.1.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dav1d-1.2.1-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py310h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2024.5.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.2.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/flatbuffers-24.3.25-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py310h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/frozenlist-1.5.0-py310h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.6.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/google-auth-2.29.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/google-auth-oauthlib-0.5.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/grpc-cpp-1.48.2-h5bf31a4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/grpcio-1.48.2-py310h5bf31a4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/h11-0.14.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/h5py-3.12.1-py310hc0802c4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf4-4.2.13-h3ca952b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf5-1.12.1-h70be1eb_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.20.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/httpcore-1.0.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/httpx-0.27.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/imagecodecs-2023.1.23-py310hc4b7b5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/imageio-2.33.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-8.5.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intake-0.7.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intake-xarray-0.7.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.27.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipywidgets-8.1.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jmespath-1.0.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/json5-0.9.25-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.23.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter-lsp-2.2.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-8.6.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab-4.2.5-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_server-2.27.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_widgets-3.0.10-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jxrlib-1.1-h7b6447c_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/keras-2.12.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py310h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h568e23c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lazy_loader-0.4-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libaec-1.0.4-he6710b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libavif-0.11.1-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.73.0-h28710b8_12.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.2.1-h91b91d3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-h8f2d780_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnetcdf-4.8.1-h424c3a0_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.52.0-ha637b67_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-h37d81fd_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h0d84882_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libzip-1.8.0-h5cef20c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libzopfli-1.0.3-he6710b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py310h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py310h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.9.2-py310hbfdbfaf_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py310h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.11-py310h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.8-py310h1128e8f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py310hd09550d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multidict-6.1.0-py310h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-core-7.16.4-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/netcdf4-1.6.2-py310h6d89c78_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-7.2.2-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numcodecs-0.12.1-py310h2c38b39_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.10.1-py310h3c60e43_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.23.5-py310h5f9d8c6_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.23.5-py310hb5e798b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/oauthlib-3.2.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.3-py310h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandoc-2.12-h06a4308_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.5.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-11.0.0-py310hfdbf927_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.21.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/propcache-0.2.0-py310h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/protobuf-3.20.3-py310h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py310h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-11.0.0-py310h468efa6_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyjwt-2.9.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.2.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.10.13-h7a1cb2a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py310h06a4308_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.20.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-flatbuffers-24.3.25-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py310h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-snappy-0.6.1-py310h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py310h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-25.1.2-py310h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-oauthlib-2.0.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py310h4aa5aa6_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/s3fs-2024.6.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scikit-image-0.24.0-py310h1128e8f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.14.1-py310h5f9d8c6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-75.1.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorboard-2.12.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorboard-data-server-0.7.0-py310h52d8a92_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorboard-plugin-wit-1.8.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorflow-2.12.0-mkl_py310hc7ea715_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorflow-base-2.12.0-mkl_py310he5f8e37_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorflow-estimator-2.12.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/termcolor-2.1.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tifffile-2023.4.12-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tomli-2.0.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.1-py310h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.5-py310h2f386ee_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py310h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/werkzeug-3.0.6-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.44.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/widgetsnbextension-4.0.10-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wrapt-1.14.1-py310h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py310h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yarl-1.18.0-py310h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zarr-2.13.3-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zfp-1.0.0-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.21.0-py310h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/aioitertools-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/aiosignal-1.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asciitree-0.3.3-py_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/astunparse-1.6.3-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fasteners-0.16.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/gast-0.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/google-pasta-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/keras-preprocessing-1.1.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/nbconvert-7.16.4-hd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/nbconvert-pandoc-7.16.4-hd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/opt_einsum-3.3.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyasn1-0.4.8-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyasn1-modules-0.2.8-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/rsa-4.7.2-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_tflow_select-2.3.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/absl-py-2.1.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aiobotocore-2.12.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aiohappyeyeballs-2.4.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aiohttp-3.10.5-py310h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-4.6.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aom-3.6.0-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py310h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/arrow-cpp-11.0.0-hda39474_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/async-lru-2.0.4-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/async-timeout-4.0.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-24.2.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-common-0.4.57-he6710b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-event-stream-0.1.6-h2531618_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-checksums-0.1.9-he6710b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-sdk-cpp-1.8.185-hce553d0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/babel-2.11.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bleach-6.2.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blinker-1.6.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blosc-1.21.3-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-3.6.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/boost-cpp-1.73.0-h7f8727e_12.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/botocore-1.34.69-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.4.2-py310ha9d4c09_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py310h6a678d5_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brunsli-0.1-h2531618_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2024.11.26-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cachetools-5.3.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2024.8.30-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.17.1-py310h1fdaa30_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cfitsio-3.470-h5893167_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cftime-1.6.2-py310ha9d4c09_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/charls-2.2.0-h2531618_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cloudpickle-3.0.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/contourpy-1.3.1-py310hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py310h130f0dd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cytoolz-0.12.2-py310h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dask-2024.5.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dask-core-2024.5.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dask-expr-1.1.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dav1d-1.2.1-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py310h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/distributed-2024.5.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.2.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/flatbuffers-24.3.25-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fonttools-4.51.0-py310h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/frozenlist-1.5.0-py310h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fsspec-2024.6.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/google-auth-2.29.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/google-auth-oauthlib-0.5.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/grpc-cpp-1.48.2-h5bf31a4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/grpcio-1.48.2-py310h5bf31a4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/h11-0.14.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/h5py-3.12.1-py310hc0802c4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/hdf4-4.2.13-h3ca952b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/hdf5-1.12.1-h70be1eb_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.20.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/httpcore-1.0.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/httpx-0.27.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/imagecodecs-2023.1.23-py310hc4b7b5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/imageio-2.33.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-8.5.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intake-0.7.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intake-xarray-0.7.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.29.5-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.27.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipywidgets-8.1.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.19.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.4-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jmespath-1.0.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/json5-0.9.25-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.23.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter-lsp-2.2.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-8.6.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.7.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.10.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.14.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyterlab-4.2.5-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyterlab_server-2.27.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyterlab_widgets-3.0.10-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jxrlib-1.1-h7b6447c_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/keras-2.12.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py310h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/krb5-1.20.1-h568e23c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lazy_loader-0.4-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libaec-1.0.4-he6710b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libavif-0.11.1-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libboost-1.73.0-h28710b8_12.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libcurl-8.2.1-h91b91d3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libevent-2.1.12-h8f2d780_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libnetcdf-4.8.1-h424c3a0_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libnghttp2-1.52.0-ha637b67_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libssh2-1.10.0-h37d81fd_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libthrift-0.15.0-h0d84882_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libzip-1.8.0-h5cef20c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libzopfli-1.0.3-he6710b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-4.3.2-py310h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py310h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.9.2-py310hbfdbfaf_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py310h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.11-py310h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.8-py310h1128e8f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/msgpack-python-1.0.3-py310hd09550d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/multidict-6.1.0-py310h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-core-7.16.4-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.10.4-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/netcdf4-1.6.2-py310h6d89c78_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/networkx-3.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-7.2.2-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numcodecs-0.12.1-py310h2c38b39_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.10.1-py310h3c60e43_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.23.5-py310h5f9d8c6_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.23.5-py310hb5e798b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/oauthlib-3.2.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-24.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-2.2.3-py310h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandoc-2.12-h06a4308_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-1.5.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-2.1.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-11.0.0-py310hfdbf927_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-24.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.21.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/propcache-0.2.0-py310h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/protobuf-3.20.3-py310h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py310h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyarrow-11.0.0-py310h468efa6_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyjwt-2.9.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.2.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.10.13-h7a1cb2a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py310h06a4308_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.20.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-flatbuffers-24.3.25-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-json-logger-2.0.7-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-lmdb-1.4.1-py310h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-snappy-0.6.1-py310h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.2-py310h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-25.1.2-py310h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.32.3-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-oauthlib-2.0.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py310h4aa5aa6_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/s3fs-2024.6.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scikit-image-0.24.0-py310h1128e8f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scipy-1.14.1-py310h5f9d8c6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-75.1.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tensorboard-2.12.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tensorboard-data-server-0.7.0-py310h52d8a92_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tensorboard-plugin-wit-1.8.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tensorflow-2.12.0-mkl_py310hc7ea715_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tensorflow-base-2.12.0-mkl_py310he5f8e37_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tensorflow-estimator-2.12.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/termcolor-2.1.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tifffile-2023.4.12-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tomli-2.0.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.4.1-py310h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.66.5-py310h2f386ee_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.14.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.11.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.11.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py310h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-2.2.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/werkzeug-3.0.6-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.44.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/widgetsnbextension-4.0.10-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wrapt-1.14.1-py310h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py310h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yarl-1.18.0-py310h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zarr-2.13.3-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zfp-1.0.0-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zict-3.0.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.21.0-py310h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/aioitertools-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/aiosignal-1.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/astunparse-1.6.3-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fasteners-0.16.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/gast-0.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/google-pasta-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/keras-preprocessing-1.1.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/nbconvert-7.16.4-hd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/nbconvert-pandoc-7.16.4-hd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/opt_einsum-3.3.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pyasn1-0.4.8-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pyasn1-modules-0.2.8-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/rsa-4.7.2-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/aioitertools-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/aiosignal-1.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asciitree-0.3.3-py_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/astunparse-1.6.3-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fasteners-0.16.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/gast-0.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/google-pasta-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/keras-preprocessing-1.1.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/opt_einsum-3.3.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyasn1-0.4.8-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyasn1-modules-0.2.8-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/rsa-4.7.2-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tensorboard-plugin-wit-1.6.0-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wheel-0.35.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/_tflow_select-2.2.0-eigen.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/abseil-cpp-20211102.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/absl-py-2.1.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aiobotocore-2.12.3-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aiohappyeyeballs-2.4.3-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aiohttp-3.10.5-py310h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.6.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aom-3.6.0-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py310hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py310hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/async-lru-2.0.4-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/async-timeout-4.0.3-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.2.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/babel-2.11.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bleach-6.2.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blinker-1.6.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.4.3-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/botocore-1.34.69-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.4.2-py310hf3fd67a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py310hcec6c5f_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brunsli-0.1-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.11.26-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cachetools-5.3.3-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.8.30-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py310h9205ec4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cftime-1.6.2-py310h7b7cdfe_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/charls-2.2.0-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.0.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.3.1-py310h1962661_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py310ha2381d6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.2-py310h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-2023.4.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.4.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dav1d-1.2.1-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py310hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2023.4.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.2.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/flatbuffers-24.3.25-h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py310h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/frozenlist-1.5.0-py310h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.6.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.2-h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/google-auth-2.29.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/google-auth-oauthlib-0.5.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/grpc-cpp-1.48.2-h3afe56f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/grpcio-1.48.2-py310h3afe56f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/h11-0.14.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/h5py-3.12.1-py310ha611a00_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf4-4.2.13-h39711bb_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf5-1.12.1-h2b2ad87_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.17.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/httpcore-1.0.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/httpx-0.27.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-68.1-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/imagecodecs-2023.1.23-py310hd1bf5dc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/imageio-2.33.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-8.5.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intake-0.7.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intake-xarray-0.7.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.27.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipywidgets-8.1.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py310hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jmespath-1.0.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/json5-0.9.25-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.23.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter-lsp-2.2.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-8.6.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py310hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab-4.2.5-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_server-2.27.3-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_widgets-3.0.10-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jxrlib-1.1-haf1e3a3_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/keras-2.12.0-py310_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py310hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lazy_loader-0.4-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libaec-1.0.4-hb1e8313_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libavif-0.11.1-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnetcdf-4.8.1-h9c0abef_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libzip-1.8.0-h272c8d6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libzopfli-1.0.3-hb1e8313_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py310h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.9.2-py310h919b35b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py310haf03e11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multidict-6.1.0-py310h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.4-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/netcdf4-1.6.2-py310h2f655f6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.3-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-7.2.2-py310hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numcodecs-0.12.1-py310h2d76c9a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.10.1-py310hc59c7be_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.23.5-py310he50c29a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.23.5-py310h992e150_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/oauthlib-3.2.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.3-py310h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-0.14.3-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-11.0.0-py310h9c91434_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.21.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/propcache-0.2.0-py310h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/protobuf-3.20.3-py310hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py310hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py310hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyjwt-2.9.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.2.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.10.13-h218abb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py310hecd8cb5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.20.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-flatbuffers-24.3.25-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py310hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-snappy-0.6.1-py310hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py310h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-25.1.2-py310hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py310hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-oauthlib-2.0.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py310h83de92b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/s3fs-2024.6.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scikit-image-0.24.0-py310h207f725_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.14.1-py310hb060737_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-75.1.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tensorboard-2.12.1-py310_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tensorboard-data-server-0.7.0-py310hf1618be_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tensorflow-2.12.0-eigen_py310hccba712_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tensorflow-base-2.12.0-eigen_py310hbf87084_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tensorflow-estimator-2.12.0-py310_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/termcolor-2.1.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tifffile-2023.4.12-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tomli-2.0.1-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.1-py310h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.5-py310h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py310h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.3-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py310hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/werkzeug-3.0.6-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/widgetsnbextension-4.0.10-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wrapt-1.14.1-py310hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yarl-1.18.0-py310h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zarr-2.13.3-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zfp-1.0.0-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.21.0-py310hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/aioitertools-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/aiosignal-1.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/astunparse-1.6.3-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fasteners-0.16.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/gast-0.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/google-pasta-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/keras-preprocessing-1.1.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/opt_einsum-3.3.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pyasn1-0.4.8-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pyasn1-modules-0.2.8-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/rsa-4.7.2-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tensorboard-plugin-wit-1.6.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wheel-0.35.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/_tflow_select-2.2.0-eigen.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/abseil-cpp-20211102.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/absl-py-2.1.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aiobotocore-2.12.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aiohappyeyeballs-2.4.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aiohttp-3.10.5-py310h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-4.6.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aom-3.6.0-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py310hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py310hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/async-lru-2.0.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/async-timeout-4.0.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-24.2.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/babel-2.11.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bleach-6.2.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blinker-1.6.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-2.4.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/botocore-1.34.69-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.4.2-py310hf3fd67a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py310hcec6c5f_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brunsli-0.1-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2024.11.26-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cachetools-5.3.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2024.8.30-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.17.1-py310h9205ec4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cftime-1.6.2-py310h7b7cdfe_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/charls-2.2.0-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cloudpickle-3.0.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.3.1-py310h1962661_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py310ha2381d6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cytoolz-0.12.2-py310h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/dask-2023.4.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/dask-core-2023.4.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/dav1d-1.2.1-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py310hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/distributed-2023.4.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.2.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/flatbuffers-24.3.25-h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fonttools-4.51.0-py310h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/frozenlist-1.5.0-py310h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fsspec-2024.6.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.2-h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/google-auth-2.29.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/google-auth-oauthlib-0.5.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/grpc-cpp-1.48.2-h3afe56f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/grpcio-1.48.2-py310h3afe56f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/h11-0.14.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/h5py-3.12.1-py310ha611a00_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/hdf4-4.2.13-h39711bb_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/hdf5-1.12.1-h2b2ad87_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.17.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/httpcore-1.0.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/httpx-0.27.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/icu-68.1-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/imagecodecs-2023.1.23-py310hd1bf5dc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/imageio-2.33.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-8.5.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intake-0.7.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intake-xarray-0.7.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.29.5-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.27.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipywidgets-8.1.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.19.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.4-py310hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jmespath-1.0.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/json5-0.9.25-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.23.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter-lsp-2.2.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-8.6.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.7.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.10.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.14.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py310hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyterlab-4.2.5-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyterlab_server-2.27.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyterlab_widgets-3.0.10-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jxrlib-1.1-haf1e3a3_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/keras-2.12.0-py310_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py310hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lazy_loader-0.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libaec-1.0.4-hb1e8313_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libavif-0.11.1-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libnetcdf-4.8.1-h9c0abef_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libzip-1.8.0-h272c8d6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libzopfli-1.0.3-hb1e8313_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py310h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.9.2-py310h919b35b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/msgpack-python-1.0.3-py310haf03e11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/multidict-6.1.0-py310h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.16.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.10.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/netcdf4-1.6.2-py310h2f655f6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/networkx-3.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-7.2.2-py310hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numcodecs-0.12.1-py310h2d76c9a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.10.1-py310hc59c7be_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.23.5-py310he50c29a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.23.5-py310h992e150_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/oauthlib-3.2.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-24.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-2.2.3-py310h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-0.14.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-1.13.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-11.0.0-py310h9c91434_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-24.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.21.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/propcache-0.2.0-py310h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/protobuf-3.20.3-py310hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py310hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py310hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyjwt-2.9.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.2.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.10.13-h218abb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py310hecd8cb5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.20.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-flatbuffers-24.3.25-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-json-logger-2.0.7-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-lmdb-1.4.1-py310hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-snappy-0.6.1-py310hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.2-py310h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-25.1.2-py310hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.32.3-py310hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-oauthlib-2.0.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py310h83de92b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/s3fs-2024.6.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scikit-image-0.24.0-py310h207f725_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scipy-1.14.1-py310hb060737_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-75.1.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tensorboard-2.12.1-py310_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tensorboard-data-server-0.7.0-py310hf1618be_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tensorflow-2.12.0-eigen_py310hccba712_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tensorflow-base-2.12.0-eigen_py310hbf87084_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tensorflow-estimator-2.12.0-py310_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/termcolor-2.1.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tifffile-2023.4.12-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tomli-2.0.1-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.4.1-py310h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.66.5-py310h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.14.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.11.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.11.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py310h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-2.2.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py310hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/werkzeug-3.0.6-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/widgetsnbextension-4.0.10-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wrapt-1.14.1-py310hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yarl-1.18.0-py310h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zarr-2.13.3-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zfp-1.0.0-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zict-3.0.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.21.0-py310hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/aioitertools-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/aiosignal-1.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asciitree-0.3.3-py_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/astunparse-1.6.3-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fasteners-0.16.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/gast-0.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/google-pasta-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/keras-preprocessing-1.1.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/opt_einsum-3.3.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyasn1-0.4.8-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyasn1-modules-0.2.8-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/rsa-4.7.2-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wheel-0.35.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/_tflow_select-2.2.0-eigen.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/abseil-cpp-20211102.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/absl-py-2.1.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aiobotocore-2.12.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aiohappyeyeballs-2.4.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aiohttp-3.10.5-py310h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.6.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aom-3.6.0-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py310hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py310h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-11.0.0-he3f21e0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/async-lru-2.0.4-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/async-timeout-4.0.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-24.2.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.6.8-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.1.6-h313beb8_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.11-h80987f9_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.8.185-h4a942e0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/babel-2.11.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bleach-6.2.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blinker-1.6.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.6.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.73.0-h1a28f6b_12.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/botocore-1.34.69-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.4.2-py310hbda83bc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py310h313beb8_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brunsli-0.1-hc377ac9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.11.26-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cachetools-5.3.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.8.30-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py310h3eb5a62_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cftime-1.6.2-py310hbda83bc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/charls-2.2.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.0.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.3.1-py310h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py310h3c57c4d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.2-py310h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-2024.5.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.5.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-expr-1.1.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dav1d-1.2.1-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py310h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2024.5.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.2.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/flatbuffers-24.3.25-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py310h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/frozenlist-1.5.0-py310h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.6.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/google-auth-2.29.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/google-auth-oauthlib-0.5.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpc-cpp-1.48.2-h877324c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpcio-1.48.2-py310h877324c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/h11-0.14.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/h5py-3.12.1-py310h8456320_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf4-4.2.13-h5e329fb_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf5-1.12.1-h160e8cb_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.20.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpcore-1.0.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpx-0.27.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-68.1-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/imagecodecs-2023.1.23-py310h604db08_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/imageio-2.33.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-8.5.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/intake-0.7.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/intake-xarray-0.7.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.27.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipywidgets-8.1.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jmespath-1.0.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/json5-0.9.25-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.23.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter-lsp-2.2.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-8.6.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab-4.2.5-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_server-2.27.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_widgets-3.0.10-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jxrlib-1.1-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/keras-2.12.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py310h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lazy_loader-0.4-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libaec-1.0.4-hc377ac9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libavif-0.11.1-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.73.0-h49e8a49_12.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-hf27765b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnetcdf-4.8.1-ha022005_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h169de6a_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzip-1.8.0-h0c481fb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzopfli-1.0.3-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.3.2-py310h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py310h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.9.2-py310h7ef442a_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py310h525c30c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multidict-6.1.0-py310h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.4-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/netcdf4-1.6.2-py310he1bbb67_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-7.2.2-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numcodecs-0.12.1-py310h1a4646a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.10.1-py310h5d9532f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.23.5-py310hb93e574_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.23.5-py310haf87e8b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/oauthlib-3.2.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.3-py310hcf29cfe_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.5.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-11.0.0-py310hfaf4e14_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.21.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/propcache-0.2.0-py310h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/protobuf-3.20.3-py310h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py310h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-11.0.0-py310hbfed03b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyjwt-2.9.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.2.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.10.13-hc0d8a6c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py310hca03da5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.20.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-flatbuffers-24.3.25-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py310h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-snappy-0.6.1-py310h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.2-py310h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-25.1.2-py310h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-oauthlib-2.0.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py310h2aea54e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/s3fs-2024.6.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scikit-image-0.24.0-py310h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.14.1-py310hd336fd7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-75.1.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorboard-2.12.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorboard-data-server-0.7.0-py310ha6e5c4f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorboard-plugin-wit-1.8.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorflow-2.12.0-eigen_py310h205ab9b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorflow-base-2.12.0-eigen_py310h0a52ebb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorflow-estimator-2.12.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/termcolor-2.1.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tifffile-2023.4.12-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomli-2.0.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.1-py310h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.5-py310h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py310h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/werkzeug-3.0.6-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/widgetsnbextension-4.0.10-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wrapt-1.14.1-py310h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py310hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yarl-1.18.0-py310h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zarr-2.13.3-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zfp-1.0.0-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.21.0-py310hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/aioitertools-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/aiosignal-1.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/astunparse-1.6.3-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fasteners-0.16.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/gast-0.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/google-pasta-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/keras-preprocessing-1.1.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/opt_einsum-3.3.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pyasn1-0.4.8-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pyasn1-modules-0.2.8-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/rsa-4.7.2-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wheel-0.35.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/_tflow_select-2.2.0-eigen.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/abseil-cpp-20211102.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/absl-py-2.1.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aiobotocore-2.12.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aiohappyeyeballs-2.4.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aiohttp-3.10.5-py310h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.6.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aom-3.6.0-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py310hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py310h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/arrow-cpp-11.0.0-he3f21e0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/async-lru-2.0.4-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/async-timeout-4.0.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-24.2.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-common-0.6.8-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-event-stream-0.1.6-h313beb8_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-checksums-0.1.11-h80987f9_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-sdk-cpp-1.8.185-h4a942e0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/babel-2.11.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bleach-6.2.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blinker-1.6.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.6.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/boost-cpp-1.73.0-h1a28f6b_12.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/botocore-1.34.69-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.4.2-py310hbda83bc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py310h313beb8_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brunsli-0.1-hc377ac9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2024.11.26-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cachetools-5.3.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.8.30-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.17.1-py310h3eb5a62_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cftime-1.6.2-py310hbda83bc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/charls-2.2.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-3.0.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.3.1-py310h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py310h3c57c4d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cytoolz-0.12.2-py310h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/dask-2024.5.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2024.5.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/dask-expr-1.1.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/dav1d-1.2.1-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py310h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/distributed-2024.5.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.2.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/flatbuffers-24.3.25-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.51.0-py310h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/frozenlist-1.5.0-py310h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2024.6.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/google-auth-2.29.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/google-auth-oauthlib-0.5.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/grpc-cpp-1.48.2-h877324c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/grpcio-1.48.2-py310h877324c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/h11-0.14.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/h5py-3.12.1-py310h8456320_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/hdf4-4.2.13-h5e329fb_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/hdf5-1.12.1-h160e8cb_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.20.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/httpcore-1.0.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/httpx-0.27.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/icu-68.1-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/imagecodecs-2023.1.23-py310h604db08_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/imageio-2.33.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-8.5.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/intake-0.7.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/intake-xarray-0.7.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.29.5-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.27.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipywidgets-8.1.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.19.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.4-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jmespath-1.0.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/json5-0.9.25-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.23.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter-lsp-2.2.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-8.6.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.7.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.10.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.14.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab-4.2.5-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_server-2.27.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_widgets-3.0.10-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jxrlib-1.1-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/keras-2.12.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py310h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lazy_loader-0.4-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libaec-1.0.4-hc377ac9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libavif-0.11.1-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libboost-1.73.0-h49e8a49_12.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libevent-2.1.12-hf27765b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libnetcdf-4.8.1-ha022005_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libthrift-0.15.0-h169de6a_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libzip-1.8.0-h0c481fb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libzopfli-1.0.3-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-4.3.2-py310h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py310h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.9.2-py310h7ef442a_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/msgpack-python-1.0.3-py310h525c30c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/multidict-6.1.0-py310h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.16.4-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.10.4-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/netcdf4-1.6.2-py310he1bbb67_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/networkx-3.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-7.2.2-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numcodecs-0.12.1-py310h1a4646a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.10.1-py310h5d9532f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.23.5-py310hb93e574_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.23.5-py310haf87e8b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/oauthlib-3.2.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-24.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.2.3-py310hcf29cfe_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-1.5.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-2.1.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-11.0.0-py310hfaf4e14_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-24.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.21.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/propcache-0.2.0-py310h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/protobuf-3.20.3-py310h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py310h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyarrow-11.0.0-py310hbfed03b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyjwt-2.9.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.2.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.10.13-hc0d8a6c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py310hca03da5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.20.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-flatbuffers-24.3.25-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-2.0.7-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-lmdb-1.4.1-py310h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-snappy-0.6.1-py310h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.2-py310h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-25.1.2-py310h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.32.3-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-oauthlib-2.0.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py310h2aea54e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/s3fs-2024.6.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scikit-image-0.24.0-py310h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.14.1-py310hd336fd7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-75.1.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tensorboard-2.12.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tensorboard-data-server-0.7.0-py310ha6e5c4f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tensorboard-plugin-wit-1.8.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tensorflow-2.12.0-eigen_py310h205ab9b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tensorflow-base-2.12.0-eigen_py310h0a52ebb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tensorflow-estimator-2.12.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/termcolor-2.1.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tifffile-2023.4.12-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tomli-2.0.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.4.1-py310h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.66.5-py310h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.14.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.11.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.11.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py310h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.2.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/werkzeug-3.0.6-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/widgetsnbextension-4.0.10-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wrapt-1.14.1-py310h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py310hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yarl-1.18.0-py310h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zarr-2.13.3-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zfp-1.0.0-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zict-3.0.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.21.0-py310hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/aioitertools-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/aiosignal-1.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asciitree-0.3.3-py_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/astunparse-1.6.3-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fasteners-0.16.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/gast-0.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/google-auth-oauthlib-0.4.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/google-pasta-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/keras-preprocessing-1.1.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/opt_einsum-3.3.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyasn1-0.4.8-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyasn1-modules-0.2.8-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/rsa-4.7.2-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/_tflow_select-2.3.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/absl-py-2.1.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aiobotocore-2.12.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aiohappyeyeballs-2.4.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aiohttp-3.10.5-py310h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.6.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aom-3.6.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py310h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-11.0.0-h2c9b28c_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/async-lru-2.0.4-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/async-timeout-4.0.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-24.2.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.4.57-ha925a31_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.1.6-hd77b12b_5.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.9-ha925a31_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.8.185-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/babel-2.11.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bleach-6.2.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blinker-1.6.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.6.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/botocore-1.34.69-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.4.2-py310hc99e966_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py310hd77b12b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.11.26-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cachetools-5.3.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.8.30-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py310h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cftime-1.6.2-py310h9128911_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/charls-2.2.0-h6c2663c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.0.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.3.1-py310h214f63a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py310h3438e0d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.2-py310h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-2024.5.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.5.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-expr-1.1.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/dav1d-1.2.1-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py310hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2024.5.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.2.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/flatbuffers-2.0.0-h6c2663c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py310h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/frozenlist-1.5.0-py310h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.6.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.2-h7edc060_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/google-auth-2.29.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/grpc-cpp-1.48.2-hf108199_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/grpcio-1.48.2-py310hf108199_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/h11-0.14.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/h5py-3.12.1-py310h3b2c811_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/hdf4-4.2.13-h712560f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/hdf5-1.12.1-h51c971a_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.20.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/httpcore-1.0.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/httpx-0.27.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icu-58.2-ha925a31_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/imagecodecs-2023.1.23-py310h6c6a46e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/imageio-2.33.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-8.5.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intake-0.7.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intake-xarray-0.7.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.27.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipywidgets-8.1.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jmespath-1.0.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/json5-0.9.25-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.23.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter-lsp-2.2.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-8.6.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab-4.2.5-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_server-2.27.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_widgets-3.0.10-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/keras-2.10.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py310hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lazy_loader-0.4-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libaec-1.0.4-h33f27b4_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libavif-0.11.1-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.9.1-h0416ee5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-hcc03200_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libnetcdf-4.8.1-h6685c40_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-hcd4344a_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-he49ee6e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libzip-1.8.0-h49b8836_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libzopfli-1.0.3-ha925a31_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.3.2-py310h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py310h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.9.2-py310he19b0ae_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py310h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.11-py310h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.8-py310hc64d2fc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py310h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/multidict-6.1.0-py310h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.4-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/netcdf4-1.6.2-py310hadf358c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-7.2.2-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numcodecs-0.12.1-py310h3469f8a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.10.1-py310h4cd664f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py310h055cbcc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py310h65a83cf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/oauthlib-3.2.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.3-py310h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.5.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-11.0.0-py310hb5480e2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.21.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/propcache-0.2.0-py310h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/protobuf-3.20.3-py310hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py310h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-11.0.0-py310h790e06d_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyjwt-2.9.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.2.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.10.13-h966fe2a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py310haa95532_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.20.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-flatbuffers-24.3.25-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py310hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-snappy-0.6.1-py310hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py310h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py310h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.2-py310h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-25.1.2-py310hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-oauthlib-2.0.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py310h636fa0f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/s3fs-2024.6.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scikit-image-0.24.0-py310hc64d2fc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.14.1-py310h8640f81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-75.1.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tensorboard-2.10.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tensorboard-data-server-0.6.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tensorboard-plugin-wit-1.8.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tensorflow-2.10.0-mkl_py310hd99672f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tensorflow-base-2.10.0-mkl_py310h6a7f48e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tensorflow-estimator-2.10.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/termcolor-2.1.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tifffile-2023.4.12-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.0.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.1-py310h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.5-py310h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py310h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.40-haa95532_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.42.34433-h9531ae6_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/werkzeug-3.0.6-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.44.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/widgetsnbextension-4.0.10-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wrapt-1.14.1-py310h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py310haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yarl-1.18.0-py310h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zarr-2.13.3-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zfp-1.0.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.21.0-py310haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/aioitertools-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/aiosignal-1.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/astunparse-1.6.3-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fasteners-0.16.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/gast-0.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/google-auth-oauthlib-0.4.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/google-pasta-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/keras-preprocessing-1.1.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/opt_einsum-3.3.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pyasn1-0.4.8-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pyasn1-modules-0.2.8-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/rsa-4.7.2-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/_tflow_select-2.3.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/absl-py-2.1.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aiobotocore-2.12.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aiohappyeyeballs-2.4.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aiohttp-3.10.5-py310h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-4.6.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aom-3.6.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py310h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/arrow-cpp-11.0.0-h2c9b28c_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/async-lru-2.0.4-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/async-timeout-4.0.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-24.2.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-common-0.4.57-ha925a31_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-event-stream-0.1.6-hd77b12b_5.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-checksums-0.1.9-ha925a31_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-sdk-cpp-1.8.185-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/babel-2.11.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bleach-6.2.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blinker-1.6.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-3.6.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/botocore-1.34.69-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.4.2-py310hc99e966_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py310hd77b12b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2024.11.26-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cachetools-5.3.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2024.8.30-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.17.1-py310h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cftime-1.6.2-py310h9128911_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/charls-2.2.0-h6c2663c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cloudpickle-3.0.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.3.1-py310h214f63a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py310h3438e0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cytoolz-0.12.2-py310h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/dask-2024.5.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/dask-core-2024.5.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/dask-expr-1.1.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/dav1d-1.2.1-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py310hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/distributed-2024.5.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.2.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/flatbuffers-2.0.0-h6c2663c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fonttools-4.51.0-py310h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/frozenlist-1.5.0-py310h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fsspec-2024.6.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/giflib-5.2.2-h7edc060_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/google-auth-2.29.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/grpc-cpp-1.48.2-hf108199_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/grpcio-1.48.2-py310hf108199_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/h11-0.14.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/h5py-3.12.1-py310h3b2c811_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/hdf4-4.2.13-h712560f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/hdf5-1.12.1-h51c971a_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.20.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/httpcore-1.0.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/httpx-0.27.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icu-58.2-ha925a31_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.7-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/imagecodecs-2023.1.23-py310h6c6a46e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/imageio-2.33.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-8.5.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intake-0.7.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intake-xarray-0.7.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.29.5-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.27.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipywidgets-8.1.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.19.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.4-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jmespath-1.0.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/json5-0.9.25-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.23.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter-lsp-2.2.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-8.6.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.7.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.10.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.14.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyterlab-4.2.5-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyterlab_server-2.27.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyterlab_widgets-3.0.10-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/keras-2.10.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py310hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lazy_loader-0.4-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libaec-1.0.4-h33f27b4_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libavif-0.11.1-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libcurl-8.9.1-h0416ee5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libevent-2.1.12-hcc03200_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libnetcdf-4.8.1-h6685c40_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libssh2-1.10.0-hcd4344a_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libthrift-0.15.0-he49ee6e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libzip-1.8.0-h49b8836_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libzopfli-1.0.3-ha925a31_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-4.3.2-py310h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py310h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.9.2-py310he19b0ae_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py310h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.11-py310h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.8-py310hc64d2fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/msgpack-python-1.0.3-py310h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/multidict-6.1.0-py310h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-7.16.4-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.10.4-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/netcdf4-1.6.2-py310hadf358c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/networkx-3.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-7.2.2-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numcodecs-0.12.1-py310h3469f8a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.10.1-py310h4cd664f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py310h055cbcc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py310h65a83cf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/oauthlib-3.2.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-24.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-2.2.3-py310h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-1.5.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-2.1.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-11.0.0-py310hb5480e2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-24.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.21.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/propcache-0.2.0-py310h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/protobuf-3.20.3-py310hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py310h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyarrow-11.0.0-py310h790e06d_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyjwt-2.9.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.2.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.10.13-h966fe2a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py310haa95532_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.20.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-flatbuffers-24.3.25-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-json-logger-2.0.7-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-lmdb-1.4.1-py310hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-snappy-0.6.1-py310hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py310h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py310h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.2-py310h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-25.1.2-py310hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.32.3-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-oauthlib-2.0.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py310h636fa0f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/s3fs-2024.6.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scikit-image-0.24.0-py310hc64d2fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scipy-1.14.1-py310h8640f81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-75.1.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tensorboard-2.10.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tensorboard-data-server-0.6.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tensorboard-plugin-wit-1.8.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tensorflow-2.10.0-mkl_py310hd99672f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tensorflow-base-2.10.0-mkl_py310h6a7f48e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tensorflow-estimator-2.10.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/termcolor-2.1.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tifffile-2023.4.12-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tomli-2.0.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.4.1-py310h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.66.5-py310h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.14.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.11.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.11.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py310h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-2.2.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.40-haa95532_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.42.34433-h9531ae6_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/werkzeug-3.0.6-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.44.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/widgetsnbextension-4.0.10-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wrapt-1.14.1-py310h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py310haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yarl-1.18.0-py310h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zarr-2.13.3-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zfp-1.0.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zict-3.0.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.21.0-py310haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
   sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
   md5: 613805add1c05b538ff06d217252feb7
   depends:
@@ -1187,12 +1187,12 @@ packages:
   license: BSD-3-Clause
   size: 20810
   timestamp: 1652859733309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_tflow_select-2.3.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_tflow_select-2.3.0-mkl.tar.bz2
   sha256: f51493d1f78786b6ccbc1f3d8aaad96a2ff13c95c097e64a059737d2f2cfa2ce
   md5: 5770354f88091e1944a2d1bd7257e4d0
   size: 2049
   timestamp: 1538592486542
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
   sha256: 8762f481244fb151a200f01dd70e69c77171a3ee0f7f4c130e8e95b6a1626a68
   md5: c3707fcd2efa582afc5c7e1986c6ce48
   depends:
@@ -1202,7 +1202,7 @@ packages:
   license_family: Apache
   size: 1135866
   timestamp: 1652382888447
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/absl-py-2.1.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/absl-py-2.1.0-py310h06a4308_0.tar.bz2
   sha256: 49a1aefd06e494b040b3ad49448e487d6dc4d68e87654bf45ec87b458c07e5bc
   md5: 30a5cddb1667fd45e9088e187822b077
   depends:
@@ -1211,7 +1211,7 @@ packages:
   license_family: Apache
   size: 187536
   timestamp: 1714140539507
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aiobotocore-2.12.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aiobotocore-2.12.3-py310h06a4308_0.tar.bz2
   sha256: e5b413a711b42f802bf9c34e604bcb9091d8b1face92533f4212580edf0fe4e4
   md5: 2d55540f66c7c59a7e8f45ce7bac1121
   depends:
@@ -1226,7 +1226,7 @@ packages:
   license_family: Apache
   size: 110645
   timestamp: 1714464458857
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aiohappyeyeballs-2.4.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aiohappyeyeballs-2.4.3-py310h06a4308_0.tar.bz2
   sha256: b13efdec3f7e691a22d426b5f1b560555cc018b1d758980fbd825d2258ee1962
   md5: e43beac87c30f258fb4ba282aa1921e2
   depends:
@@ -1235,7 +1235,7 @@ packages:
   license_family: Other
   size: 25116
   timestamp: 1732662113002
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aiohttp-3.10.5-py310h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aiohttp-3.10.5-py310h5eee18b_0.tar.bz2
   sha256: aa03cc74d3e74cfb7acb9768162a878196bca1112feafbd1dbb75074b9b1a589
   md5: b1153feedec1097d68128becb16a4447
   depends:
@@ -1254,7 +1254,7 @@ packages:
   license_family: Other
   size: 765601
   timestamp: 1725528648182
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.6.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-4.6.2-py310h06a4308_0.tar.bz2
   sha256: eaa30adc6d1614ae1adf2a24b6c5b7b6b091fb12a9a15ca960177fe7f3819d7f
   md5: 683f616004a91dcb81b53ec8383d86c7
   depends:
@@ -1270,7 +1270,7 @@ packages:
   license_family: MIT
   size: 191289
   timestamp: 1729121462391
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aom-3.6.0-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aom-3.6.0-h6a678d5_0.tar.bz2
   sha256: daddb86497522fd6fb8447c0aaebb763e685348b86fadb4ca6425f50f9d85f08
   md5: 2d31ed3210e7119160eb02564154b4c1
   depends:
@@ -1280,7 +1280,7 @@ packages:
   license_family: BSD
   size: 2958771
   timestamp: 1688660715607
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py310h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py310h7f8727e_0.tar.bz2
   sha256: f4d21ee48ca45cc62ae063f6de973c5599505d628e7675e512eb86f73f851410
   md5: 96b990f76f2e61e914f5ad1958f6e7bd
   depends:
@@ -1291,7 +1291,7 @@ packages:
   license_family: MIT
   size: 85215
   timestamp: 1644553401362
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-11.0.0-hda39474_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/arrow-cpp-11.0.0-hda39474_2.tar.bz2
   sha256: e999c26eb88acdf38a30985cd3d06aecb7e5470d71fe56aa9746d7c4ecb30c69
   md5: 9adc4a90d3cf6871b91f9c24920f8860
   depends:
@@ -1320,7 +1320,7 @@ packages:
   license_family: Apache
   size: 11652728
   timestamp: 1693265512057
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/async-lru-2.0.4-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/async-lru-2.0.4-py310h06a4308_0.tar.bz2
   sha256: 601460633710b60d630765f72ab13c9a1a8e63bb8e50f5fbb1965fd9fdaeb9e1
   md5: c201cfd7c0beed39075dea4de01ddae3
   depends:
@@ -1330,7 +1330,7 @@ packages:
   license_family: MIT
   size: 17613
   timestamp: 1699554652543
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/async-timeout-4.0.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/async-timeout-4.0.3-py310h06a4308_0.tar.bz2
   sha256: eb930dc1b3401edb466fd9877a61a2e05965fcd3fcc9d9be572eb80af53d5c7a
   md5: 04c061f475e7b69e0d5737ef00cc70d3
   depends:
@@ -1339,7 +1339,7 @@ packages:
   license_family: Apache
   size: 12101
   timestamp: 1703097093405
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-24.2.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-24.2.0-py310h06a4308_0.tar.bz2
   sha256: 381c9d6439f212eaa640a445779e3fcbfa214ec2b28d537cc6fcfddc75cadf78
   md5: 4a93d6601c3da897265a362203cc988e
   depends:
@@ -1348,7 +1348,7 @@ packages:
   license_family: MIT
   size: 141817
   timestamp: 1729089491775
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.4.57-he6710b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-common-0.4.57-he6710b0_1.tar.bz2
   sha256: bc87abecbc7e34b42b5a7ec3a3470ee284ed82f5f638274f795810fd0aa85496
   md5: e883ae27a33cff702b8a20b5394e9ae0
   depends:
@@ -1358,7 +1358,7 @@ packages:
   license_family: Apache
   size: 164855
   timestamp: 1601398346279
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.1.6-h2531618_5.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-event-stream-0.1.6-h2531618_5.tar.bz2
   sha256: 4f7d93ed96f6692266a700971029b841dc972a6af39b85ba9525eebe2c40edbb
   md5: 6b7ceb5ff64fc9f4537bfe7a2d7fe4a0
   depends:
@@ -1370,7 +1370,7 @@ packages:
   license_family: Apache
   size: 25449
   timestamp: 1603894551837
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.9-he6710b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-checksums-0.1.9-he6710b0_0.tar.bz2
   sha256: 17d0e3361698b9a0a9b52836284b658886d25bf349f3a099b765eac23ceb4ebd
   md5: 0a7ed2b675a5af15d4979f4ca5c93d39
   depends:
@@ -1381,7 +1381,7 @@ packages:
   license_family: Apache
   size: 52520
   timestamp: 1601398555928
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.8.185-hce553d0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-sdk-cpp-1.8.185-hce553d0_0.tar.bz2
   sha256: 2842aafc907c01ccbe26ca11bddad6c55e9f93d30cf57431e327f5e57666be2c
   md5: 5b4e9429338430ef3b71802778ac2184
   depends:
@@ -1395,7 +1395,7 @@ packages:
   license_family: Apache
   size: 2442091
   timestamp: 1618434946994
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/babel-2.11.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/babel-2.11.0-py310h06a4308_0.tar.bz2
   sha256: 959a5f86c833ccb6a15d04fde1079ddb4708762b0d90714828adbbc9b9646fc3
   md5: 3e89c64fb56d74e0a91ec741a6661a0d
   depends:
@@ -1405,7 +1405,7 @@ packages:
   license_family: BSD
   size: 7102372
   timestamp: 1671782043176
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.3-py310h06a4308_0.tar.bz2
   sha256: 1a56d11e88d7e93e73953ca068ec493c3e98b72845d9a777f2f9c82f0664ce37
   md5: 3a7dd040da3d8a200c4bece5ea04fce7
   depends:
@@ -1415,12 +1415,12 @@ packages:
   license_family: MIT
   size: 216265
   timestamp: 1718029855488
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bleach-6.2.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bleach-6.2.0-py310h06a4308_0.tar.bz2
   sha256: 0de865fb163e4e02d18adb13b6e9c87ca758f639bec234bd83de4c89f30c5757
   md5: 0896c252ac541a1f8bfe342d64de1e77
   depends:
@@ -1432,7 +1432,7 @@ packages:
   license_family: Apache
   size: 295489
   timestamp: 1732290490993
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blinker-1.6.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blinker-1.6.2-py310h06a4308_0.tar.bz2
   sha256: 4b3993a63b36eb31757195d29b2d7fdab603518a1bf5f285a228180d323943f5
   md5: 6a56d60fe99138bfd41124f94ee5a59f
   depends:
@@ -1441,7 +1441,7 @@ packages:
   license_family: MIT
   size: 28181
   timestamp: 1696539171692
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blosc-1.21.3-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blosc-1.21.3-h6a678d5_0.tar.bz2
   sha256: 10b48986cb0e0c974477ac3a58aaae198270b01f19cbd3e900143c6558fa3424
   md5: 202b4629c225257fc01a4a2180c4e2f7
   depends:
@@ -1454,7 +1454,7 @@ packages:
   license_family: BSD
   size: 65491
   timestamp: 1675247642609
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.6.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-3.6.0-py310h06a4308_0.tar.bz2
   sha256: 8c161ae59eb3f907c2db91aff27f4795eff50f38acb4a0f6d091292ad8850225
   md5: 9886d96bd66d3dbf940d9a311c2725ac
   depends:
@@ -1472,7 +1472,7 @@ packages:
   license_family: BSD
   size: 5662562
   timestamp: 1727914521304
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.73.0-h7f8727e_12.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/boost-cpp-1.73.0-h7f8727e_12.tar.bz2
   sha256: 1239af47b8f5ca5f5f40af1056949c4dfcbdfb690d6f83dacf77d01ebbfe7b4a
   md5: fd3834554f6e4863871ab9677997fbef
   depends:
@@ -1482,7 +1482,7 @@ packages:
   license_family: OTHER
   size: 16854
   timestamp: 1655879868222
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/botocore-1.34.69-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/botocore-1.34.69-py310h06a4308_0.tar.bz2
   sha256: 22e5f5e8935f44b7f333d1c45cc4bf9bd4cbc9c73fe97ece7a9ab5cc872f75a7
   md5: 6a0c23467a18a4f4b9bb48a5236f3940
   depends:
@@ -1494,7 +1494,7 @@ packages:
   license_family: Apache
   size: 7719749
   timestamp: 1714460680886
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.4.2-py310ha9d4c09_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.4.2-py310ha9d4c09_0.tar.bz2
   sha256: 16e4fe628824931e988ff413fb31803c6a53137b0f622c7e3fdb64a6ee492325
   md5: 128011665e69e7eb2bfac4daccc40e6e
   depends:
@@ -1505,7 +1505,7 @@ packages:
   license_family: BSD
   size: 130623
   timestamp: 1731058759693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
   sha256: 5d15605858771290fdaaae41a43941623757a25cb1292080d69d6d3857807935
   md5: 7f517469aa5380c52e55db9f37df104f
   depends:
@@ -1516,7 +1516,7 @@ packages:
   license: MIT
   size: 18652
   timestamp: 1714483267080
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
   sha256: a5094f078584e27c7cced4a9564ae904a329f5c1702a7c1ba092d581ba1544f1
   md5: 6ddf45dd8a21a9512481de9bc0e5a03f
   depends:
@@ -1526,7 +1526,7 @@ packages:
   license: MIT
   size: 19711
   timestamp: 1714483255915
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py310h6a678d5_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py310h6a678d5_8.tar.bz2
   sha256: a95845d31df714470de47a68332c48fbca10d7d5d3364e32c88a9cbf457fa4f3
   md5: 92a52ee9fc7369fed7a75d90199b354a
   depends:
@@ -1536,7 +1536,7 @@ packages:
   license: MIT
   size: 361077
   timestamp: 1714483327328
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brunsli-0.1-h2531618_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brunsli-0.1-h2531618_0.tar.bz2
   sha256: 3a2778321f5ef815cd8aa4bf37bb1532b31656c1bf5310738146e7081b177b3e
   md5: dc6cf5631ada26a03b237ef19e90cfd6
   depends:
@@ -1547,7 +1547,7 @@ packages:
   license_family: MIT
   size: 203551
   timestamp: 1611240485163
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
   sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
   md5: f5058c8d5b2994b7334f18e022105a14
   depends:
@@ -1556,7 +1556,7 @@ packages:
   license_family: BSD
   size: 427542
   timestamp: 1714510571510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
   sha256: 5b4c80587ae4ec915505469f79d866f27c80456156667c8548d31c67c2c1653e
   md5: c3d6bfae757760082261779c406a880d
   depends:
@@ -1565,14 +1565,14 @@ packages:
   license_family: MIT
   size: 116270
   timestamp: 1693902021950
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.11.26-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2024.11.26-h06a4308_0.tar.bz2
   sha256: 0b5277b4291e4eb5993277722b6c8a4ec106f9ed73fefabc62d8ac2283c45d29
   md5: eb5c5c81f84445b39a829d83682e3cd1
   license: MPL-2.0
   license_family: Other
   size: 141126
   timestamp: 1732804447102
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cachetools-5.3.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cachetools-5.3.3-py310h06a4308_0.tar.bz2
   sha256: c933a64b2ab50d09533355fcd9c2b6742a7a0e1c073720baf53538d409255c11
   md5: 3a98e462c68e92fd5c4d2cf34b9ebe50
   depends:
@@ -1581,7 +1581,7 @@ packages:
   license_family: MIT
   size: 22901
   timestamp: 1713977109850
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.8.30-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2024.8.30-py310h06a4308_0.tar.bz2
   sha256: fc8588f7e8e80e28c10d52dd941bb85e9c5d4759f10d89b7a892c756284b1005
   md5: c37c40fed22998ea1ee17f6a6faf1fb9
   depends:
@@ -1590,7 +1590,7 @@ packages:
   license_family: Other
   size: 167722
   timestamp: 1725551695290
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py310h1fdaa30_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.17.1-py310h1fdaa30_0.tar.bz2
   sha256: a0b76f0cec2177bde240f4066898d6af29dca27d393f748d7807c7aca9eae823
   md5: 8ba0dfc3548f357374b0210c9f44e9b3
   depends:
@@ -1602,7 +1602,7 @@ packages:
   license_family: MIT
   size: 242787
   timestamp: 1726856502275
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cfitsio-3.470-h5893167_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cfitsio-3.470-h5893167_7.tar.bz2
   sha256: a4a855659e4a52515b940d1b9d8204b626c11395980e99539b24f52d658e1857
   md5: 65a71d60ece0bd684f1be09b48de8d00
   depends:
@@ -1616,7 +1616,7 @@ packages:
   license_family: Other
   size: 1384722
   timestamp: 1655814890848
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cftime-1.6.2-py310ha9d4c09_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cftime-1.6.2-py310ha9d4c09_0.tar.bz2
   sha256: 33c64c25ccddc93f7bdb38acf863839a323ac215a3d0a0190ecb2c460905d667
   md5: 3d5c57533f6d4ee2e9502e5f4a2f1933
   depends:
@@ -1627,7 +1627,7 @@ packages:
   license_family: MIT
   size: 248445
   timestamp: 1678830501437
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/charls-2.2.0-h2531618_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/charls-2.2.0-h2531618_0.tar.bz2
   sha256: ff4a1d243f3ffbcc677b1db7b5c7af06492f2910a0f1eea6664ad0ea3125835c
   md5: 310b9390fc05d62245c9f95ac96ac376
   depends:
@@ -1637,7 +1637,7 @@ packages:
   license_family: BSD
   size: 132255
   timestamp: 1612240399775
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py310h06a4308_0.tar.bz2
   sha256: 850d4ce317a2434516871ffd235dccbefe94a26e78e5f5dcfb0493c0091bf933
   md5: b7a42df99108ce294f99e1a5d8426c1c
   depends:
@@ -1646,7 +1646,7 @@ packages:
   license_family: BSD
   size: 154568
   timestamp: 1698129845674
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.0.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cloudpickle-3.0.0-py310h06a4308_0.tar.bz2
   sha256: 45eddf1ce563f1b849921ff8db8999be8f296a3a5dff2ab1339443147f1bb976
   md5: 742cde3b2153865cbd40e09dd820a2dc
   depends:
@@ -1655,7 +1655,7 @@ packages:
   license_family: BSD
   size: 34788
   timestamp: 1721657453266
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py310h06a4308_0.tar.bz2
   sha256: 4b9150ff168d17abf2e28a14e436e10653d87082c8865f1dae6081932d572c0a
   md5: 3b3d0971e24b952e00cc35e7193eeade
   depends:
@@ -1664,7 +1664,7 @@ packages:
   license_family: CC
   size: 502279
   timestamp: 1709758414744
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py310h06a4308_0.tar.bz2
   sha256: d0081216e44fa6a474db76fc3ad26170e9578ae07f40f0a190f93ffda77ab98f
   md5: 855af00ea0c0b401e2853080e5604d22
   depends:
@@ -1674,7 +1674,7 @@ packages:
   license_family: BSD
   size: 14651
   timestamp: 1709322914698
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.3.1-py310hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/contourpy-1.3.1-py310hdb19cb5_0.tar.bz2
   sha256: b5a23181c83817e0467d06f8e49b3ef04e2eba9b8dd7059dbd8fde0d4fca34c2
   md5: d5535fe50ad08cf5d44a0b1a9d53a34e
   depends:
@@ -1686,7 +1686,7 @@ packages:
   license_family: BSD
   size: 281389
   timestamp: 1732540260436
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py310h130f0dd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py310h130f0dd_0.tar.bz2
   sha256: d2a8f02d97dfaa1759c11ac815223a8c6a2e1108c91f0a0dcb031970040b55e9
   md5: 105134bfa872c5a8617ffe18b361319b
   depends:
@@ -1700,7 +1700,7 @@ packages:
   license_family: BSD
   size: 2185827
   timestamp: 1694445068014
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.2-py310h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cytoolz-0.12.2-py310h5eee18b_0.tar.bz2
   sha256: 13d7235a412a2dad8473c869d1a97a215399c55ee8ba1ca98837b24a54e62cf2
   md5: 3d7f0e1365620ffb735bf64071b310b8
   depends:
@@ -1711,7 +1711,7 @@ packages:
   license_family: BSD
   size: 416431
   timestamp: 1701723821963
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-2024.5.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dask-2024.5.0-py310h06a4308_0.tar.bz2
   sha256: 4a2f862735a144a81d7bbcb53839ae954c97d0857a45ac49cc1c70e5b8858bf6
   md5: 52fe3afde30175ee783429634b359eef
   depends:
@@ -1730,7 +1730,7 @@ packages:
   license_family: BSD
   size: 5282
   timestamp: 1715848852304
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.5.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dask-core-2024.5.0-py310h06a4308_0.tar.bz2
   sha256: 16524a2d65afdeb7961b0af2e8dacb5e5de29f21c5cf026e64ad89e7633cf216
   md5: ecf87701803a8149521891999e8aebd6
   depends:
@@ -1747,7 +1747,7 @@ packages:
   license_family: BSD
   size: 2240833
   timestamp: 1715838663501
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-expr-1.1.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dask-expr-1.1.0-py310h06a4308_0.tar.bz2
   sha256: 9f843ba9d24593f19a1da1f0df638241770c0992a4dfc60f2d1a5f0acb6d2d21
   md5: 50b90f625d3eec04e4b42336754e7be3
   depends:
@@ -1759,7 +1759,7 @@ packages:
   license_family: BSD
   size: 357485
   timestamp: 1715846575852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dav1d-1.2.1-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dav1d-1.2.1-h5eee18b_0.tar.bz2
   sha256: 9f015999d24a376602b5876f542bcb41a7db66fa73064091cccdc1b06195392c
   md5: 29684f3832212a3c977960c62c421119
   depends:
@@ -1768,7 +1768,7 @@ packages:
   license_family: BSD
   size: 889577
   timestamp: 1688746033126
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py310h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py310h6a678d5_0.tar.bz2
   sha256: 0b674c799b7298d3c91dea9832de5c02a26238e5a13d44214c513ecc619bf2ad
   md5: 2adc19991b72c76211696fbe79b4cf75
   depends:
@@ -1779,7 +1779,7 @@ packages:
   license_family: MIT
   size: 2152954
   timestamp: 1690905105597
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2024.5.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/distributed-2024.5.0-py310h06a4308_0.tar.bz2
   sha256: efdd12309b7ca0193cce5646fe9a79dff692c141d26ca5c48be05c9b611685a8
   md5: a8606369c94ba95571c6c480a80f95d1
   depends:
@@ -1803,7 +1803,7 @@ packages:
   license_family: BSD
   size: 1459221
   timestamp: 1715844536299
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py310h06a4308_0.tar.bz2
   sha256: 413921f9bdd75ddbf9667fc35d4f7b8ac6ce751ab992297635e0cad2a8a9174e
   md5: 57314b5e1702906d03bfcff4d7eab35a
   depends:
@@ -1812,7 +1812,7 @@ packages:
   license_family: MIT
   size: 16500
   timestamp: 1649908359372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.2.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.2.0-py310h06a4308_0.tar.bz2
   sha256: 29e4a264bc6130aa38c028b2eae9ffe99719deea638a4bff90161fb8d295cdcd
   md5: ea8da5d9c8ccde2276129f66d424453a
   depends:
@@ -1821,7 +1821,7 @@ packages:
   license_family: MIT
   size: 29766
   timestamp: 1706031514511
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/flatbuffers-24.3.25-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/flatbuffers-24.3.25-h6a678d5_0.tar.bz2
   sha256: a6fd11c731fd7c619192b0cbff77e8610fbd9ead3a18f5e1246b3658fef0576d
   md5: db3bc1839b6aa7024bcceb8321518d13
   depends:
@@ -1831,7 +1831,7 @@ packages:
   license_family: Apache
   size: 2035312
   timestamp: 1722872893194
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py310h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fonttools-4.51.0-py310h5eee18b_0.tar.bz2
   sha256: e1a291ca51353618e9d44fe07dae015209170904e23fd15eb4d24617577e2b32
   md5: 549a3dfe2d7e5a321be53f8199d84020
   depends:
@@ -1850,7 +1850,7 @@ packages:
   license_family: MIT
   size: 2713424
   timestamp: 1713551479113
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
   sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
   md5: a5dc8677d891dff2393b63189a3ad42f
   depends:
@@ -1861,7 +1861,7 @@ packages:
   license_family: Other
   size: 971975
   timestamp: 1666798278693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/frozenlist-1.5.0-py310h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/frozenlist-1.5.0-py310h5eee18b_0.tar.bz2
   sha256: 586c946cbb6a1c8157cb32fea098f947ee546b92764acb88dfc48ec5852534dc
   md5: 0c0addf6cec28e29a9bced8682667433
   depends:
@@ -1871,7 +1871,7 @@ packages:
   license_family: Apache
   size: 64599
   timestamp: 1730902835801
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.6.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fsspec-2024.6.1-py310h06a4308_0.tar.bz2
   sha256: 977247182a869aebd535cd4e361b48530fef4e1a19ad12deac39da8a650d3f4b
   md5: ca6350d6f17bce135cde49e8cfa50511
   depends:
@@ -1882,7 +1882,7 @@ packages:
   license_family: BSD
   size: 287574
   timestamp: 1724855679539
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
   sha256: 2fc1136056f41fe92de719fb821550346704965dd12a5fa35069cdb4948d5c17
   md5: fd089b0fba2b03aafe3adb6cdaa9ac3b
   depends:
@@ -1892,7 +1892,7 @@ packages:
   license_family: BSD
   size: 203421
   timestamp: 1706888218007
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.2-h5eee18b_0.tar.bz2
   sha256: 896e0a1bcf27c4ca87835382e7a9b737d7142302dbcadf388d3f2ca28b569017
   md5: dd71853d7c8a1ca649c51956c07d32ba
   depends:
@@ -1901,7 +1901,7 @@ packages:
   license_family: MIT
   size: 78717
   timestamp: 1728656289496
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
   sha256: f1e190d4ee766add8131a2b011723c472284de2bbb5e07c8f895f30e3c591df7
   md5: 82029e0758feac811afec2a6ef9e6155
   depends:
@@ -1912,7 +1912,7 @@ packages:
   license_family: BSD
   size: 108438
   timestamp: 1706895276199
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/google-auth-2.29.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/google-auth-2.29.0-py310h06a4308_0.tar.bz2
   sha256: ab1a7fda803a37947863249b39f28bfecc42c60c67fe5e71b8ca820002305ac7
   md5: 41af1e687800b6c41e258ae2a7db3529
   depends:
@@ -1930,7 +1930,7 @@ packages:
   license_family: Apache
   size: 212384
   timestamp: 1715111254620
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/google-auth-oauthlib-0.5.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/google-auth-oauthlib-0.5.2-py310h06a4308_0.tar.bz2
   sha256: 21eb0c746ed75350feecdb4e6087c08ca43afee660a681bd7f94b384a6eac998
   md5: 6fa601b942709067f6e60f31b9400254
   depends:
@@ -1942,7 +1942,7 @@ packages:
   license_family: Apache
   size: 27281
   timestamp: 1660687833850
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/grpc-cpp-1.48.2-h5bf31a4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/grpc-cpp-1.48.2-h5bf31a4_0.tar.bz2
   sha256: 73ef97b889329d074dae35afd8237dff79ea5f8456224d9d6279eb2370192334
   md5: 3782db0e75fe18196b4b08d1f5b78603
   depends:
@@ -1959,7 +1959,7 @@ packages:
   license_family: APACHE
   size: 5408819
   timestamp: 1681913198738
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/grpcio-1.48.2-py310h5bf31a4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/grpcio-1.48.2-py310h5bf31a4_0.tar.bz2
   sha256: ce73c4ad711f135d31516777435579b217fc174650ca50c27ffed4c001d028fb
   md5: 23edcd7ddd2bfd41f4d7c7f24a689986
   depends:
@@ -1972,7 +1972,7 @@ packages:
   license_family: APACHE
   size: 823537
   timestamp: 1681913276214
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/h11-0.14.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/h11-0.14.0-py310h06a4308_0.tar.bz2
   sha256: bdf09a1658638c9696f810ffd8ff9024492d9e57edbe4befb9c46d664d91a187
   md5: 61687dd75da9f3c3180f351b2a8b0b6f
   depends:
@@ -1981,7 +1981,7 @@ packages:
   license_family: MIT
   size: 84164
   timestamp: 1706652403551
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/h5py-3.12.1-py310hc0802c4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/h5py-3.12.1-py310hc0802c4_0.tar.bz2
   sha256: 3ec6669b79a219704a1f40b51b7e58f8c993d1f79b322e66d13e28547f526e10
   md5: 1045ef94f2b22ab679759b9b6021cb25
   depends:
@@ -1994,7 +1994,7 @@ packages:
   license_family: BSD
   size: 1634785
   timestamp: 1730216373630
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf4-4.2.13-h3ca952b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/hdf4-4.2.13-h3ca952b_2.tar.bz2
   sha256: 70e1f9fdc6b123d8270bcd8cdd555519372924d39419ef8692b36bfa9d0b4653
   md5: 35da658876a3e2a62dda54dcd5a7e5c2
   depends:
@@ -2006,7 +2006,7 @@ packages:
   license_family: BSD
   size: 937548
   timestamp: 1510862959026
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/hdf5-1.12.1-h70be1eb_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/hdf5-1.12.1-h70be1eb_2.tar.bz2
   sha256: 30a88eb6e50bb2201d06734f74d3f98624f3b7ff1371607f770bb71d5dd86c61
   md5: 9249c8c2d04f5bb91f1dffcb00be691a
   depends:
@@ -2021,7 +2021,7 @@ packages:
   license_family: BSD
   size: 5763149
   timestamp: 1655307949265
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.20.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.20.0-py310h06a4308_0.tar.bz2
   sha256: 22acee607b765c48348a61f67f85099d45b6b15ea1b0d21f85a83b3a3c1da0e1
   md5: b391ce92b7e350e9ec310bb8a3874e06
   depends:
@@ -2041,7 +2041,7 @@ packages:
   license_family: BSD
   size: 5328353
   timestamp: 1730827726905
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpcore-1.0.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/httpcore-1.0.2-py310h06a4308_0.tar.bz2
   sha256: b082946b54df34433bb62379daffc683075b34a8ab3cee7d570c8e1b5a487e05
   md5: 1e25bb9ee0f040e3098c2d1f0d8fd731
   depends:
@@ -2052,7 +2052,7 @@ packages:
   license_family: BSD
   size: 84383
   timestamp: 1706728541283
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/httpx-0.27.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/httpx-0.27.0-py310h06a4308_0.tar.bz2
   sha256: 37fcf81e13e91f940567e3a0259336227e133aea9edc45f4ea4169a1b5f9ba80
   md5: bfe2785a6e4dd8095caa68d1bad23976
   depends:
@@ -2072,7 +2072,7 @@ packages:
   license_family: BSD
   size: 159878
   timestamp: 1723474830579
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
   sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
   md5: 9213e0336e3a5216c989cfe52648412e
   depends:
@@ -2081,7 +2081,7 @@ packages:
   license: MIT
   size: 23805906
   timestamp: 1588026213084
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py310h06a4308_0.tar.bz2
   sha256: fac4c785ed4a1343d3b00cf339cdf8068010f59c9f373dee32cb164b2733b0aa
   md5: 43078d825ae52359500a27f564e68365
   depends:
@@ -2090,7 +2090,7 @@ packages:
   license_family: BSD
   size: 139387
   timestamp: 1714398895037
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/imagecodecs-2023.1.23-py310hc4b7b5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/imagecodecs-2023.1.23-py310hc4b7b5f_0.tar.bz2
   sha256: 78863c3e301566e580499556da34dd2144dccebfcad442070b4c382b48ada776
   md5: 8ead00d9393e21aa28cb2ccf228083d9
   depends:
@@ -2129,7 +2129,7 @@ packages:
   license_family: BSD
   size: 10625436
   timestamp: 1695065156863
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/imageio-2.33.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/imageio-2.33.1-py310h06a4308_0.tar.bz2
   sha256: 2a896657b4a0d09df27dada4d5f648fbb6337a2a3013a3492a4b40abe8e45335
   md5: dbd14c905eeaab2930cb37410f885569
   depends:
@@ -2140,7 +2140,7 @@ packages:
   license_family: BSD
   size: 523763
   timestamp: 1707247435357
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-8.5.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-8.5.0-py310h06a4308_0.tar.bz2
   sha256: 1fc2468ffede3ec24e56cd89258f6e39191d79f90f4373fd8e09661a5b6a62fc
   md5: 68c38f21ff90342758fc2bf6ac144dd9
   depends:
@@ -2150,7 +2150,7 @@ packages:
   license_family: APACHE
   size: 45377
   timestamp: 1732633559727
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intake-0.7.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intake-0.7.0-py310h06a4308_0.tar.bz2
   sha256: e71e305c0d22f4163bb8145f6894e9c41bb349105011443f5137d345a31cd9b7
   md5: d92378bbd16bcc0842f778f99735d663
   depends:
@@ -2173,7 +2173,7 @@ packages:
   license_family: BSD
   size: 197655
   timestamp: 1717513957683
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intake-xarray-0.7.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intake-xarray-0.7.0-py310h06a4308_0.tar.bz2
   sha256: 741658bf13964556c4c9ef7dffe491bcbe9eeaca6ee7ceeea887e38f14ef91ff
   md5: ec8b50f4b0bb345e521ccf6dc76b0514
   depends:
@@ -2190,7 +2190,7 @@ packages:
   license_family: BSD
   size: 68115
   timestamp: 1717523847861
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
   sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
   md5: 3add2ce56858a1b8f6a37342f82773d3
   depends:
@@ -2206,7 +2206,7 @@ packages:
   license_family: Proprietary
   size: 19310769
   timestamp: 1699647799237
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.29.5-py310h06a4308_0.tar.bz2
   sha256: b86be39d915f5e2016b7f89ede4da3cb028c52ca937f9519b414677d99af21c3
   md5: 4da369cd74cafbc9feefaf766dc06b51
   depends:
@@ -2227,7 +2227,7 @@ packages:
   license_family: BSD
   size: 191433
   timestamp: 1728665858825
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.27.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.27.0-py310h06a4308_0.tar.bz2
   sha256: 328dbd66a00f4df59f1d8a12bcc0291b95cef2619d4deab28b0dfbef350f846c
   md5: 4acf1050c72217392bae0eb086fd8458
   depends:
@@ -2246,7 +2246,7 @@ packages:
   license_family: BSD
   size: 1298924
   timestamp: 1726064347754
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipywidgets-8.1.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipywidgets-8.1.2-py310h06a4308_0.tar.bz2
   sha256: dcc9f2f9e6e920f96937ca00eea5c248b880d88edf5d08eade3b0a1e571786d2
   md5: 0a4134315260d005862140eea8b66f28
   depends:
@@ -2260,7 +2260,7 @@ packages:
   license_family: BSD
   size: 200721
   timestamp: 1709574715167
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.19.1-py310h06a4308_0.tar.bz2
   sha256: 460e4384ebb8546399e2af70e91d5f55727417d6d2720e36d4179b3928e5ada3
   md5: 95e991de6c269bc3136de0ab07cbe45a
   depends:
@@ -2270,7 +2270,7 @@ packages:
   license_family: MIT
   size: 1046913
   timestamp: 1721058449739
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.4-py310h06a4308_1.tar.bz2
   sha256: 3942a64c47b2286374cae033c83072b9506999773d057ac998b59e1baf92ba8c
   md5: 2131b364c78bf299ef56ae4ecfc7bd2a
   depends:
@@ -2282,7 +2282,7 @@ packages:
   license_family: BSD
   size: 274809
   timestamp: 1730902978641
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jmespath-1.0.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jmespath-1.0.1-py310h06a4308_0.tar.bz2
   sha256: d3acdff9097d1ece562d3fea6ba2463e05d8c2267905e6a820be07a6721610cb
   md5: 919e71a41fd2efacc4b67c5c587613fe
   depends:
@@ -2291,7 +2291,7 @@ packages:
   license_family: MIT
   size: 37456
   timestamp: 1700144606539
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
   sha256: 8316ae3abee25edab89788ee6e9eef79c398aba192559f514674a04ee1860bca
   md5: 112209aed451545a622ab217c70f6972
   depends:
@@ -2300,7 +2300,7 @@ packages:
   license_family: Other
   size: 283506
   timestamp: 1722872662693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/json5-0.9.25-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/json5-0.9.25-py310h06a4308_0.tar.bz2
   sha256: 238807f403ce9b34096dd5ecc4707015951066ad7dca61f81faee0cfa85e5135
   md5: 20c9a5c75285aa1497d837821eaf98b1
   depends:
@@ -2309,7 +2309,7 @@ packages:
   license_family: Apache
   size: 45601
   timestamp: 1730786822889
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.23.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.23.0-py310h06a4308_0.tar.bz2
   sha256: 9564ef0b7160e66aa4bd9ad3d576a4fd5b7dffaa855367f048dc15cf04bbfb27
   md5: c1f0fbfd87b96f8201b325cc7fbbfa30
   depends:
@@ -2322,7 +2322,7 @@ packages:
   license_family: MIT
   size: 145179
   timestamp: 1728486748314
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py310h06a4308_0.tar.bz2
   sha256: da0f6e41d27a7d9818272d6557c62cedf9d609aac6f1e5558c703692a9b1c1cf
   md5: f94d2d36c18202c503ca80f382c67c74
   depends:
@@ -2332,7 +2332,7 @@ packages:
   license_family: MIT
   size: 14940
   timestamp: 1699032489094
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter-lsp-2.2.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter-lsp-2.2.0-py310h06a4308_0.tar.bz2
   sha256: 60c7188fbadd23291cc3e946f8ac06317eaab19bbcf26365a8858429d9f2e296
   md5: bd6483a716913a2830ec6e1b46391cdd
   depends:
@@ -2342,7 +2342,7 @@ packages:
   license_family: BSD
   size: 81013
   timestamp: 1699978324790
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-8.6.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-8.6.0-py310h06a4308_0.tar.bz2
   sha256: e621bb072be14bb7cbbeabf10ba96244048b9f99a44d0b304c44456bcfc2311a
   md5: 45418cb0996419efde6fc5fa384b04ca
   depends:
@@ -2356,7 +2356,7 @@ packages:
   license_family: BSD
   size: 172723
   timestamp: 1699455939187
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.7.2-py310h06a4308_0.tar.bz2
   sha256: b2c6c5f92ac0ed1510b732bbda07f0ee7d71488975e27412655f0f71594bc35a
   md5: 40299077d5b409ce3f3e44555251f95d
   depends:
@@ -2367,7 +2367,7 @@ packages:
   license_family: BSD
   size: 82697
   timestamp: 1718818318946
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.10.0-py310h06a4308_0.tar.bz2
   sha256: 3032d4d6fb51cb28a6d6cd9eaed38a75ffb604aed71c07a72d04c7cd5fa0a52a
   md5: c98c4693717827d34ad9816f15000826
   depends:
@@ -2383,7 +2383,7 @@ packages:
   license_family: BSD
   size: 35673
   timestamp: 1718738148983
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.14.1-py310h06a4308_0.tar.bz2
   sha256: 66eb21dea9d68413ad88acd1c00946b5a94cfde1760797ccaf84557d7bc6a847
   md5: c02afea376472f249a23af563f297a18
   depends:
@@ -2410,7 +2410,7 @@ packages:
   license_family: BSD
   size: 504392
   timestamp: 1718827574049
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py310h06a4308_1.tar.bz2
   sha256: 86f14a80966c3e6dec7a79da70edb37c678bb5854e89500c51a7551e50a4fa83
   md5: 5801d1b34c533fa654b9fe53b4c616d7
   depends:
@@ -2420,7 +2420,7 @@ packages:
   license_family: BSD
   size: 23681
   timestamp: 1686870826319
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab-4.2.5-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyterlab-4.2.5-py310h06a4308_0.tar.bz2
   sha256: 3d97e660fa87ad67e457c205a673e1de295948617352a5c3395561c6b90e2288
   md5: 354f959a71ded3f79553229618a805bd
   depends:
@@ -2445,7 +2445,7 @@ packages:
   license_family: BSD
   size: 8318314
   timestamp: 1725896520590
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_server-2.27.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyterlab_server-2.27.3-py310h06a4308_0.tar.bz2
   sha256: 59646dbe79c4f601c71e65164e11b6aea97aa59fc923ef73b70ad644e3c241bc
   md5: fcd25a200c17a669aa28cf3a24dabaac
   depends:
@@ -2463,7 +2463,7 @@ packages:
   license_family: BSD
   size: 83159
   timestamp: 1725865484148
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_widgets-3.0.10-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyterlab_widgets-3.0.10-py310h06a4308_0.tar.bz2
   sha256: 10b46984ade2980925e873f73d1533dee6a4ab1868c1d3caa88861ad46a93dcd
   md5: 90f21a94f7689cf86580799630e3454c
   depends:
@@ -2474,7 +2474,7 @@ packages:
   license_family: BSD
   size: 191366
   timestamp: 1709322903512
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jxrlib-1.1-h7b6447c_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jxrlib-1.1-h7b6447c_2.tar.bz2
   sha256: 46fa3b9ce2790a2efd328560b7e76f6716c92288702ced1f63168f22bad487d0
   md5: e1ae8a1211dfebe4c60b7e755200a327
   depends:
@@ -2483,7 +2483,7 @@ packages:
   license_family: BSD
   size: 244049
   timestamp: 1593197090424
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/keras-2.12.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/keras-2.12.0-py310h06a4308_0.tar.bz2
   sha256: 6b7c9325e15622a1dfaf4f8d2a2709238f541bfead4af7bd3de1406a470440a5
   md5: 6c5442852159cd8b656f0cd05e664249
   depends:
@@ -2494,7 +2494,7 @@ packages:
   license: Apache-2.0
   size: 2261153
   timestamp: 1682445693643
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py310h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py310h6a678d5_0.tar.bz2
   sha256: 847b6b284b1ddb73b398c64bffc4808ca15acd4540b0631d93c3a36c00d1fafa
   md5: 1728f1fe8a6b260a1097d5723defc547
   depends:
@@ -2505,7 +2505,7 @@ packages:
   license_family: BSD
   size: 77845
   timestamp: 1672387187154
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h568e23c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/krb5-1.20.1-h568e23c_1.tar.bz2
   sha256: 126a5fd5e59cc90c1a2c688a801dea7f352f0bb218c2f949d0f3d21db35fbe1b
   md5: 64d1d86c812dc1843bcbb4cab2e8f60f
   depends:
@@ -2517,7 +2517,7 @@ packages:
   license_family: MIT
   size: 1426697
   timestamp: 1686931184185
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lazy_loader-0.4-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lazy_loader-0.4-py310h06a4308_0.tar.bz2
   sha256: 1cfc9cedce193efa49a601455363ee2883df7e8a2baf481aba708c0077b0675a
   md5: 048cf3e2ec21f343a7c3333965d0a7d4
   depends:
@@ -2527,7 +2527,7 @@ packages:
   license_family: BSD
   size: 20755
   timestamp: 1718176849479
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -2538,7 +2538,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
   sha256: 069d33aebaf4db4ae410d4acb4851860a69d2c8f326fd45ab2a67b67fe276e6d
   md5: 61689da52cf1fcebda8c9fb2872f94bf
   constrains:
@@ -2546,7 +2546,7 @@ packages:
   license: GPL-3.0-only
   size: 723073
   timestamp: 1727336193185
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
   sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
   md5: 88199c75f2ac211728febced7785c24e
   depends:
@@ -2556,7 +2556,7 @@ packages:
   license_family: Apache
   size: 228278
   timestamp: 1635523146417
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libaec-1.0.4-he6710b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libaec-1.0.4-he6710b0_1.tar.bz2
   sha256: 860ecdf2e21768f806f9c0d272e92dbc521b249a7171b0def500a30937fb079a
   md5: e911ac853b19bd7073f1047699e2118e
   depends:
@@ -2566,7 +2566,7 @@ packages:
   license_family: BSD
   size: 35409
   timestamp: 1593197267510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libavif-0.11.1-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libavif-0.11.1-h5eee18b_0.tar.bz2
   sha256: 0eccc12a46c14a730a55569f28a170bd315aad9df6ae7e13eba7732e6317f3df
   md5: 5974603ff942f18b40e5156dd6819410
   depends:
@@ -2577,7 +2577,7 @@ packages:
   license_family: BSD
   size: 105392
   timestamp: 1689158136084
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.73.0-h28710b8_12.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libboost-1.73.0-h28710b8_12.tar.bz2
   sha256: 1d69d22e3a27260658d33d22c49dfa78effb9f0d612d2223a6a76dba4e55b171
   md5: 34dd22cf2bca0dbccbb9697f190f504a
   depends:
@@ -2592,7 +2592,7 @@ packages:
   license_family: OTHER
   size: 22152039
   timestamp: 1655879823139
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
   sha256: bb990ea068c3b3dafd9c807e0e19570320cb2fe7d69cc326f1f0b5319b0654b2
   md5: 3ff70744e396b1af69656c574b05c3b9
   depends:
@@ -2600,7 +2600,7 @@ packages:
   license: MIT
   size: 66940
   timestamp: 1714483221853
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
   sha256: 3b87a816f72a00e1f0022a160e7eda70af89d3de2a2e08a72be1c17b31d759f3
   md5: 4f57d3a0a13ddaf1c06efb586b702f46
   depends:
@@ -2609,7 +2609,7 @@ packages:
   license: MIT
   size: 34446
   timestamp: 1714483232430
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
   sha256: 2cf15e89f910600f468edfde8d0f9b80a14fa2319ed89160dc7375dfd3764fdb
   md5: 463adc13f2feea3570d1eccac368d9e4
   depends:
@@ -2618,7 +2618,7 @@ packages:
   license: MIT
   size: 295090
   timestamp: 1714483244460
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.2.1-h91b91d3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libcurl-8.2.1-h91b91d3_0.tar.bz2
   sha256: 8daa34822b26916b12867746d55790aa5b719e096e412aba86c5a9f13b19ee36
   md5: bd594551d7447f93c8a1575be1b1f12e
   depends:
@@ -2634,7 +2634,7 @@ packages:
   license_family: MIT
   size: 386369
   timestamp: 1693515365220
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
   sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
   md5: 55dde57e63a36b202e388a39dcee9a66
   depends:
@@ -2643,7 +2643,7 @@ packages:
   license_family: MIT
   size: 74096
   timestamp: 1695996494461
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
   sha256: 5bd3af246b6a93ea0912179ae66e0ad9157ca0142263010d84b65724e6db0bec
   md5: 5cb0cc0e1783419cf8fc1c65fee0f62f
   depends:
@@ -2653,7 +2653,7 @@ packages:
   license_family: BSD
   size: 195807
   timestamp: 1703006263489
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
   sha256: efdab884c85fda4461f7a393aa6d4e0e50d03cb59fb9c8a980b1307b8379ebe0
   md5: eeca774c6154c49340dd403b1928d5e9
   depends:
@@ -2662,7 +2662,7 @@ packages:
   license_family: BSD
   size: 108906
   timestamp: 1632891483341
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-h8f2d780_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libevent-2.1.12-h8f2d780_0.tar.bz2
   sha256: 2b9470932f5c923f19fcc14c8d1c7ed5f58a468588c09d6b04e0a905c07a297f
   md5: 2e3534102d10ade546c0feb056bbffbe
   depends:
@@ -2672,7 +2672,7 @@ packages:
   license_family: BSD
   size: 491177
   timestamp: 1642102679055
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
   sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
   md5: 1af9b4d62c708924417f2640ef22a68f
   depends:
@@ -2682,7 +2682,7 @@ packages:
   license_family: MIT
   size: 154016
   timestamp: 1714483282916
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
   sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
   md5: 641e72e5067bd6d5454405879e1cd2a7
   depends:
@@ -2697,7 +2697,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 8895144
   timestamp: 1654090827491
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
   sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
   md5: 27082517590f3b9fbffecc68513b461b
   depends:
@@ -2706,7 +2706,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 19860
   timestamp: 1654090819660
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
   sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
   md5: 0202c3c8ae4735cac6c7f3d1e1685964
   constrains:
@@ -2714,7 +2714,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 5228750
   timestamp: 1654090762569
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
   sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
   md5: 3080c2813e6e1d0f8a100a38b5b3456d
   depends:
@@ -2722,7 +2722,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 573231
   timestamp: 1654090775721
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnetcdf-4.8.1-h424c3a0_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libnetcdf-4.8.1-h424c3a0_4.tar.bz2
   sha256: de65b7a86ff4c0d96eac3fa67bcdb240b0b8a2a7b0eff7acfb62785beb61c65e
   md5: 7d2dab80f6e4cb15b31efb3830de2eda
   depends:
@@ -2738,7 +2738,7 @@ packages:
   license_family: BSD
   size: 1575909
   timestamp: 1691154591143
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.52.0-ha637b67_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libnghttp2-1.52.0-ha637b67_1.tar.bz2
   sha256: 71a65b3c05426b92e8a3002e7d42cd303255439f8a4442b4fc5aa882aef3128e
   md5: 113b010119638c67e3b6c8570d88f5be
   depends:
@@ -2754,7 +2754,7 @@ packages:
   license_family: MIT
   size: 716614
   timestamp: 1686931412665
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
   sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
   md5: 1bffe1481ed4f88827248fb9001f8923
   depends:
@@ -2764,7 +2764,7 @@ packages:
   license_family: Other
   size: 362561
   timestamp: 1677841789536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
   sha256: a24f7d1cdb5e18466a61860a5a66baffd608e212bbfed2935350e83d4d8659c0
   md5: b32a43de76bc9be9c71f9a12edec8a1e
   depends:
@@ -2775,7 +2775,7 @@ packages:
   license_family: BSD
   size: 2706964
   timestamp: 1675278653314
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -2783,7 +2783,7 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-h37d81fd_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libssh2-1.10.0-h37d81fd_2.tar.bz2
   sha256: 41f2e9a088031bd209d50f37f727fb9647be9316db3e149f9f2bac0057f7184d
   md5: 778c268743d6cf857178bd1ecf6c9525
   depends:
@@ -2793,7 +2793,7 @@ packages:
   license_family: BSD
   size: 311794
   timestamp: 1686931200150
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
   sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
   md5: 8c195584a5f5471b600ee180e4052773
   depends:
@@ -2801,7 +2801,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 6410287
   timestamp: 1654090800863
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h0d84882_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libthrift-0.15.0-h0d84882_2.tar.bz2
   sha256: 535b2ce4add44d604b5559fa371af020e0e242eaac402b8d5d97d9b9c9d88273
   md5: 80ac532958a61a5339d2c7084f877bd8
   depends:
@@ -2815,7 +2815,7 @@ packages:
   license_family: Apache
   size: 4631057
   timestamp: 1687975455689
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
   sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
   md5: ef78eebd98289aceacdfa29182426adf
   depends:
@@ -2833,7 +2833,7 @@ packages:
   license_family: Other
   size: 664034
   timestamp: 1693575237924
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
   sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
   md5: 292768ec77416ae257cfdd44ea2071c8
   depends:
@@ -2842,7 +2842,7 @@ packages:
   license_family: BSD
   size: 29197
   timestamp: 1668082729834
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
   sha256: a062fad27450b94279d1688aabd11a95eedee7814462ef6364337d55412b4a7e
   md5: e0521f84b9770830e654432364ac930e
   depends:
@@ -2853,7 +2853,7 @@ packages:
   license_family: BSD
   size: 484011
   timestamp: 1729160032020
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libzip-1.8.0-h5cef20c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libzip-1.8.0-h5cef20c_0.tar.bz2
   sha256: 32af09699997b89fb3fc5fe2e2665e505faf23275268b7527e1eabae748a4cc0
   md5: 6cde3e76dc236a20a012e7fc41224315
   depends:
@@ -2867,7 +2867,7 @@ packages:
   license_family: BSD
   size: 106709
   timestamp: 1652978513482
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libzopfli-1.0.3-he6710b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libzopfli-1.0.3-he6710b0_0.tar.bz2
   sha256: 04e6f97332bc583ad380f0dc6f3f38c766fe15900c29f52c8097b7743ef2b417
   md5: 6d276711374079b0d91ea31ecbe27b31
   depends:
@@ -2877,7 +2877,7 @@ packages:
   license_family: Apache
   size: 183622
   timestamp: 1593197391897
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py310h06a4308_0.tar.bz2
   sha256: 620fbc4a92da4de3084bd55c609f16c33b241b6d21255ed9dd3e762d415c50ef
   md5: dc293648b9caa345b01ac5f9a90392de
   depends:
@@ -2887,7 +2887,7 @@ packages:
   license_family: MIT
   size: 35342
   timestamp: 1659783460274
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py310h06a4308_0.tar.bz2
   sha256: 4210b70b38fd509ac973d347a654f2cd670b7559411ae783e07b48c071a809e2
   md5: e36d89397033bfc417932702d7519138
   depends:
@@ -2896,7 +2896,7 @@ packages:
   license_family: BSD
   size: 11131
   timestamp: 1652903185157
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py310h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-4.3.2-py310h5eee18b_0.tar.bz2
   sha256: 5a8af55693aba974e96a57667c650788b6f5a928dc42aade8087b7ca275b9ded
   md5: 01b180812795b419297b1ac60c95bca9
   depends:
@@ -2907,7 +2907,7 @@ packages:
   license_family: BSD
   size: 37752
   timestamp: 1686057986134
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
   sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
   md5: 76f089e76ec67583bb38428b51008097
   depends:
@@ -2917,7 +2917,7 @@ packages:
   license_family: BSD
   size: 164494
   timestamp: 1714510587156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py310h06a4308_0.tar.bz2
   sha256: 93b9aa3ffe66b9ea121fcb1a32a2502006df7073fa29a00ccc00b185b00721ce
   md5: 37edf1dc070689d9f64021285157aa25
   depends:
@@ -2926,7 +2926,7 @@ packages:
   license_family: BSD
   size: 122987
   timestamp: 1671541964893
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py310h06a4308_1.tar.bz2
   sha256: 7e14cb93cf0c535ae8e0aef73c7c9ad9aa55813398438762c5f0b30347788111
   md5: 88cc67a13bca127dea58eac5d6edca75
   depends:
@@ -2936,7 +2936,7 @@ packages:
   license_family: MIT
   size: 106714
   timestamp: 1684279935424
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py310h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py310h5eee18b_0.tar.bz2
   sha256: bd1df99e92877a31b49fe7626e1e4c045c6df46079bc1b8d8243db67ee000631
   md5: 934e27fec3401a09e5a7f56318308e71
   depends:
@@ -2948,7 +2948,7 @@ packages:
   license_family: BSD
   size: 23730
   timestamp: 1704206282955
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.9.2-py310hbfdbfaf_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.9.2-py310hbfdbfaf_1.tar.bz2
   sha256: 235cc4c6306a65ce9284def09122d4ea62aaf15cd39d74aa89fc694a4a87adad
   md5: fd12b1d438c5b2fa3f8c2ce79cdfdd21
   depends:
@@ -2969,7 +2969,7 @@ packages:
   license_family: PSF
   size: 8503856
   timestamp: 1732550910466
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py310h06a4308_0.tar.bz2
   sha256: be8075a8d70b0da67859d63016219e3dd1bc84a1b484abcbd8b95eff52884d88
   md5: 6336be55da6cebfaf1cbbdc573524fc1
   depends:
@@ -2979,7 +2979,7 @@ packages:
   license_family: BSD
   size: 16451
   timestamp: 1662014606193
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py310h06a4308_0.tar.bz2
   sha256: c483a73b6b3c2bd3a0f1fbb8a2fefbba96cc3e3cc52d2a6ce121ceeecb7fa61b
   md5: 0d626377d7aab29eb38ea16c05dbd103
   depends:
@@ -2989,7 +2989,7 @@ packages:
   license_family: MIT
   size: 53361
   timestamp: 1659721352029
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py310h06a4308_0.tar.bz2
   sha256: ae02f23d333380a31ef4bb192baa4e145524e81ad3a53e0383e38d632979cc22
   md5: 542c95fd4b9171b036a2d501196210be
   depends:
@@ -2998,7 +2998,7 @@ packages:
   license_family: MIT
   size: 18793
   timestamp: 1659716070293
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py310h06a4308_0.tar.bz2
   sha256: c1e3fa7d8d4656779fe37d55a9f8a457c8bcde71beab78f091c35adf9de303cb
   md5: 434eefcd517ab08422676df586e111a3
   depends:
@@ -3009,7 +3009,7 @@ packages:
   license_family: BSD
   size: 90224
   timestamp: 1661496364548
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
   sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
   md5: ce77d0f05f846da4a6b9e23fe7f21d9b
   depends:
@@ -3023,7 +3023,7 @@ packages:
   license_family: Proprietary
   size: 206738176
   timestamp: 1699648006088
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py310h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py310h5eee18b_1.tar.bz2
   sha256: 6baedecdce1b2f6067ded74941e54f14d791bbab133cb54db32380faf75960aa
   md5: 9b1159ecb9e0d54be20e55af3bb8035b
   depends:
@@ -3034,7 +3034,7 @@ packages:
   license_family: BSD
   size: 59221
   timestamp: 1682948537006
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.11-py310h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.11-py310h5eee18b_0.tar.bz2
   sha256: 6d7bfa45a3cecd1a3a94de031a3dc0ec0e0c8b8d18a6ea29c1b44481950bd42a
   md5: 4b4389bc0f59811794afda00c5247fac
   depends:
@@ -3048,7 +3048,7 @@ packages:
   license_family: BSD
   size: 228812
   timestamp: 1730824196199
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.8-py310h1128e8f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.8-py310h1128e8f_0.tar.bz2
   sha256: 310ee2be36e889814969b3d672a09173fb60f6779fc615992a1999dfc73d4b64
   md5: e3a557a2b0a56c59f063ac52f733a488
   depends:
@@ -3063,7 +3063,7 @@ packages:
   license_family: BSD
   size: 398672
   timestamp: 1730824069755
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py310hd09550d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/msgpack-python-1.0.3-py310hd09550d_0.tar.bz2
   sha256: 406cc2249facfd03da39731092ce33f1e6cbebf0391a75a04628626183a45f45
   md5: e1a2611549a26e06e7f7f06ab22bf053
   depends:
@@ -3074,7 +3074,7 @@ packages:
   license_family: Apache
   size: 262416
   timestamp: 1652362755770
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/multidict-6.1.0-py310h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/multidict-6.1.0-py310h5eee18b_0.tar.bz2
   sha256: b11ec030328164443f48bcec46dfc62bd669da1a55aa40715a28644287c20e67
   md5: 72b4c2000937e90dadeb1d1c30e345b4
   depends:
@@ -3085,7 +3085,7 @@ packages:
   license_family: Apache
   size: 58463
   timestamp: 1730905529469
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py310h06a4308_0.tar.bz2
   sha256: 3760ac569d7988b5c21a9a83d9cf9022deb51f6a411e48a4b33e36e93f765ad3
   md5: a78160b2fac13c7a01629011908910fa
   depends:
@@ -3098,7 +3098,7 @@ packages:
   license_family: BSD
   size: 100211
   timestamp: 1698934338032
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-core-7.16.4-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-core-7.16.4-py310h06a4308_1.tar.bz2
   sha256: 7fa51b6a6c4e0121bb4ebbf52162d28ab8bceb9eaf870108bd602fc4a599d27a
   md5: 169d06d0c515b8293ca460dbee509574
   depends:
@@ -3125,7 +3125,7 @@ packages:
   license: BSD-3-Clause
   size: 487830
   timestamp: 1732709525361
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.10.4-py310h06a4308_0.tar.bz2
   sha256: 138c44f0b4b278db0e66e7ad3a9f24d0301c4ee1257e5eb944ba954eb7169a58
   md5: 850a5b1738512bdb0d43e89efed45b2e
   depends:
@@ -3138,7 +3138,7 @@ packages:
   license_family: BSD
   size: 148192
   timestamp: 1728049506559
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
   sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
   md5: 57ea097dc15f8d9f9eb90e1d919143b0
   depends:
@@ -3147,7 +3147,7 @@ packages:
   license_family: MIT
   size: 1157733
   timestamp: 1674734069410
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py310h06a4308_0.tar.bz2
   sha256: 505a9df53a9a36030f56020d63431baa3c67c31fd66712dfa06cdc5c7265ddbd
   md5: 2abf153bb3d9a67452fd20cf560ef446
   depends:
@@ -3156,7 +3156,7 @@ packages:
   license_family: BSD
   size: 13461
   timestamp: 1708532806698
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/netcdf4-1.6.2-py310h6d89c78_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/netcdf4-1.6.2-py310h6d89c78_0.tar.bz2
   sha256: bc1c199569e7ae2f26d5fe33913ea840635c70a388dff3c6f91a3c95917176a8
   md5: 2ce7dea8c221031e6eba688a777e523f
   depends:
@@ -3171,7 +3171,7 @@ packages:
   license_family: MIT
   size: 502275
   timestamp: 1673455610537
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/networkx-3.3-py310h06a4308_0.tar.bz2
   sha256: eb4a86c1ff70f7bd0e27d5da781795e48770847707d256e4f5ca4c885b73ee5e
   md5: 080666759eec29b3b93445d143c84087
   depends:
@@ -3189,7 +3189,7 @@ packages:
   license_family: BSD
   size: 2661048
   timestamp: 1720002720271
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-7.2.2-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-7.2.2-py310h06a4308_1.tar.bz2
   sha256: a4c184c2160f2b116644951d91e94cc17119a31b8e95437baab5c4f2fff80876
   md5: 76ef2274d74332dc28ad67b9c12a528c
   depends:
@@ -3203,7 +3203,7 @@ packages:
   license_family: BSD
   size: 4564437
   timestamp: 1727197492038
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py310h06a4308_0.tar.bz2
   sha256: 91bd41503b82f6b48b57c19ac02d51185335db056b2966e92d010db52c12b6a3
   md5: 0c61fecf07ab21a2c7ea857ca277fd6e
   depends:
@@ -3213,7 +3213,7 @@ packages:
   license_family: BSD
   size: 22570
   timestamp: 1699456009666
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numcodecs-0.12.1-py310h2c38b39_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numcodecs-0.12.1-py310h2c38b39_0.tar.bz2
   sha256: 3f44588ac2c6898740ae0e88e1fee4179feb89c327e173800f8691992e001285
   md5: e587b958a9be5446c0475af667464c44
   depends:
@@ -3228,7 +3228,7 @@ packages:
   license_family: MIT
   size: 449104
   timestamp: 1707513535069
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.10.1-py310h3c60e43_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.10.1-py310h3c60e43_0.tar.bz2
   sha256: 452227325362bb94604a05ebc1ca29211b25fd3e1ac9b8e3365912c44eec11f0
   md5: 50034a1bbd4c28cb8bfb59831d8407b1
   depends:
@@ -3244,7 +3244,7 @@ packages:
   license_family: MIT
   size: 177061
   timestamp: 1730216028480
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.23.5-py310h5f9d8c6_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.23.5-py310h5f9d8c6_1.tar.bz2
   sha256: d90f57307b9c37e77ec949ac8810a1639ec2bab13361334967771e319a27b41e
   md5: a3bd612da6d69848eb8e0831aad7669d
   depends:
@@ -3261,7 +3261,7 @@ packages:
   license_family: BSD
   size: 10267
   timestamp: 1682953408527
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.23.5-py310hb5e798b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.23.5-py310hb5e798b_1.tar.bz2
   sha256: 411ed298910d5743f46adcf87df09c91877b4f8cc55447adef00fa963ab35ffb
   md5: 768821d2a2c2a7fed0475b1717b8627e
   depends:
@@ -3277,7 +3277,7 @@ packages:
   license_family: BSD
   size: 7418523
   timestamp: 1682953393092
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/oauthlib-3.2.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/oauthlib-3.2.2-py310h06a4308_0.tar.bz2
   sha256: a0d3f1c48d2818c10bb2e8d3749b1b487c0caf3b950fe843a070dccf4c9b631f
   md5: 662d78b8dafb156daef0aec61db88fe9
   depends:
@@ -3289,7 +3289,7 @@ packages:
   license_family: BSD
   size: 232744
   timestamp: 1679489651614
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
   sha256: 1c9f6902907a3d4a7e5c3cb02236491ea4c4e66a1a0ce51fa506dffb24ba89f6
   md5: 36d514eca3c87ab75a1d418607e26db2
   depends:
@@ -3301,7 +3301,7 @@ packages:
   license_family: BSD
   size: 528528
   timestamp: 1722872671997
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
   sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
   md5: 5ad4571eba2479f77a9f849a6ae7724c
   depends:
@@ -3311,7 +3311,7 @@ packages:
   license_family: Apache
   size: 3998613
   timestamp: 1694465071784
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
   sha256: 9618addfc1b940c048372ffb2c8500d4b44d02455a9bd1f411e530ed5e09b8d5
   md5: 56057ed323f733bdcf262468682d0358
   depends:
@@ -3326,7 +3326,7 @@ packages:
   license_family: Apache
   size: 1132661
   timestamp: 1676482768554
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py310h06a4308_0.tar.bz2
   sha256: 14dae0db86c618d047d6d217875897e0df68ac14aa45524d06e5248527429583
   md5: 9fbd10ecc485cd5c367d6b85ac38fc29
   depends:
@@ -3335,7 +3335,7 @@ packages:
   license_family: APACHE
   size: 30807
   timestamp: 1699371235539
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-24.1-py310h06a4308_0.tar.bz2
   sha256: d4018553288e8ea32e4cd53e2ee6888d3b3d5bbceeff64b0239b3661dc5edfab
   md5: 0e4afdfcdb31580a97b85f34c095a836
   depends:
@@ -3344,7 +3344,7 @@ packages:
   license_family: Apache
   size: 135177
   timestamp: 1720102062205
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.3-py310h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-2.2.3-py310h6a678d5_0.tar.bz2
   sha256: 80b50780c7fc6c1901375ade7fdd5437df4ad8e6f017f378590962cff2864512
   md5: e8b510f493980e17601690493fc2bd55
   depends:
@@ -3395,14 +3395,14 @@ packages:
   license_family: BSD
   size: 14982562
   timestamp: 1732736711665
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandoc-2.12-h06a4308_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandoc-2.12-h06a4308_3.tar.bz2
   sha256: 6ff476d6dcc9b5d7979206f1dbba837b32a3b78202ec5922089a5ec28b71431d
   md5: 82bd82d1c2037a4bb712619c0e336957
   license: GPL-2.0
   license_family: GPL
   size: 12963129
   timestamp: 1677512220201
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.5.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-1.5.3-py310h06a4308_0.tar.bz2
   sha256: a4420a31c7caad24c7b205269c63573e9801f069b5f7e1105646cf7ef685b0a5
   md5: bc2719e1b75fe92ccedba1e4863628ce
   depends:
@@ -3427,7 +3427,7 @@ packages:
   license_family: BSD
   size: 23690561
   timestamp: 1730380897501
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-2.1.1-py310h06a4308_0.tar.bz2
   sha256: 9eea383212337e0612798d5067c26ca4eed4ef76650b53a477680f7c3e9507d4
   md5: 25b6dbf04b1c2123e07c7615173a628e
   depends:
@@ -3436,7 +3436,7 @@ packages:
   license_family: BSD
   size: 194256
   timestamp: 1719348006787
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py310h06a4308_0.tar.bz2
   sha256: ac86ebb902e8517d9bc9f7fc2fe98f3ceaabcfe4eaa490c0362ec7803b3e2187
   md5: e2efa085f753f2b05e77c44253dc2edc
   depends:
@@ -3450,7 +3450,7 @@ packages:
   license_family: BSD
   size: 36043
   timestamp: 1698702598285
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-11.0.0-py310hfdbf927_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-11.0.0-py310hfdbf927_0.tar.bz2
   sha256: d010f7590ef9efa98b5296c1a4f6d7696dfc22e05343da5a7488066762a297b3
   md5: 31cd626fc6a2a8068aef35ae07f9b06d
   depends:
@@ -3467,7 +3467,7 @@ packages:
   license_family: Other
   size: 844432
   timestamp: 1731594865769
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-24.2-py310h06a4308_0.tar.bz2
   sha256: c21583dfc86e0fc66964bc126dd20d4c49a767e5d1327ae40a708f0b7f4f32b1
   md5: 69f8d3389c81cf160e9de5d24ae9ff3f
   depends:
@@ -3478,7 +3478,7 @@ packages:
   license_family: MIT
   size: 2345915
   timestamp: 1723484761772
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py310h06a4308_0.tar.bz2
   sha256: 95ee7eb5dc731152d97631e2c59572b4838b5cf96f0c7fabb7eb0258590e8267
   md5: 93b487d749f5b5c021ec09b98b7aa5ad
   depends:
@@ -3487,7 +3487,7 @@ packages:
   license_family: MIT
   size: 32180
   timestamp: 1692205504671
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.21.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.21.0-py310h06a4308_0.tar.bz2
   sha256: 44a018528f337daca27c9b38690ac6bd10483b58bffc8aa5af6df6cb98831869
   md5: 8834be397a2d4d0799f56251422a1cb6
   depends:
@@ -3496,7 +3496,7 @@ packages:
   license_family: Apache
   size: 90571
   timestamp: 1731953200226
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py310h06a4308_0.tar.bz2
   sha256: 622f1a83be156ad2894921a57942014edab0fb84f0aeb2a8d3e332f717179919
   md5: b1074332ad725945bcfd509de6458031
   depends:
@@ -3508,7 +3508,7 @@ packages:
   license_family: BSD
   size: 598751
   timestamp: 1704404449548
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/propcache-0.2.0-py310h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/propcache-0.2.0-py310h5eee18b_0.tar.bz2
   sha256: ba646db551a83b5d07a2f4e919cbe90fa06d70f3752bd93732f489880091113e
   md5: 3dcd429ffa02c788adb83ee071b48378
   depends:
@@ -3518,7 +3518,7 @@ packages:
   license_family: Apache
   size: 57401
   timestamp: 1732304021743
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/protobuf-3.20.3-py310h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/protobuf-3.20.3-py310h6a678d5_0.tar.bz2
   sha256: f97e7b2536ec3cdd0865e9d4f3e90cc01a701d5519e63b51da54f4a3c20ab520
   md5: 4f0c0b5bcf17da3353117e50d6749dcd
   depends:
@@ -3531,7 +3531,7 @@ packages:
   license_family: BSD
   size: 347650
   timestamp: 1675281211637
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py310h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py310h5eee18b_0.tar.bz2
   sha256: d7501cd6012bb906574da7792b3c66d9a31bfabb1497882818e0d6976b686e5d
   md5: ea6ee93562a9c94d730b0e2dcfb68941
   depends:
@@ -3541,7 +3541,7 @@ packages:
   license_family: BSD
   size: 393604
   timestamp: 1656431395375
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-11.0.0-py310h468efa6_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyarrow-11.0.0-py310h468efa6_1.tar.bz2
   sha256: 695246578c0ba447d3e342a3f52c8693bd529724ab8bf52e9d868d1cc90cf282
   md5: f7350e84855e3448fee8286ac6692bdd
   depends:
@@ -3556,7 +3556,7 @@ packages:
   license_family: Apache
   size: 4769890
   timestamp: 1693273939951
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py310h06a4308_1.tar.bz2
   sha256: eba38026b96d0b3543a2a529cde8a1d82654da5cbb3030ecfe67b4247f0c8f50
   md5: a719d98f31e467f11ddf83a7e5893b49
   depends:
@@ -3565,7 +3565,7 @@ packages:
   license_family: BSD
   size: 1887228
   timestamp: 1684280033582
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyjwt-2.9.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyjwt-2.9.0-py310h06a4308_0.tar.bz2
   sha256: 57aff27b79a6c1a93e937b02676cd575032b899e60fd19c40f1697273e2f554a
   md5: 559123a6fcd4e65e6dc5f45837c68e61
   depends:
@@ -3576,7 +3576,7 @@ packages:
   license_family: MIT
   size: 76419
   timestamp: 1730786815994
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py310h06a4308_0.tar.bz2
   sha256: 39de2ecacca6f1a1e3cb00d90d9aa37eafd270b4dd73d34dd34b8f9ba3b39851
   md5: 296f73e59bf7f4ab81960e2a1f03aed4
   depends:
@@ -3586,7 +3586,7 @@ packages:
   license_family: Apache
   size: 94805
   timestamp: 1690223492156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.2.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.2.0-py310h06a4308_0.tar.bz2
   sha256: b1cb50a07c2fa2efd45f41171c9173679e1ee79f30391894c970d623daaabd3f
   md5: 72b3c7645f594bc200f8b0baac0de987
   depends:
@@ -3595,7 +3595,7 @@ packages:
   license_family: MIT
   size: 425922
   timestamp: 1731445592173
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py310h06a4308_0.tar.bz2
   sha256: d01fa02148ff1717b3c13b3afc1d9f7189fa7b15d1a612d79793f6c1534875d7
   md5: 5ad7b13cb48fc3f12d94907489550019
   depends:
@@ -3604,7 +3604,7 @@ packages:
   license_family: BSD
   size: 28253
   timestamp: 1640793693853
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.10.13-h7a1cb2a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.10.13-h7a1cb2a_0.tar.bz2
   sha256: eb1e12c7bc55dbf9478f5f1c6dc0d6126f5d4985b2a1e4dcfd5e76308cde741b
   md5: b64a887f2902a46e0d1ea43a9fe88849
   depends:
@@ -3626,7 +3626,7 @@ packages:
   license_family: PSF
   size: 29074384
   timestamp: 1694439228262
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py310h06a4308_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py310h06a4308_2.tar.bz2
   sha256: 3d3157145577a8a683deaa078c1d1221b8e1a35bdb36c530d55ec2a6471a16e4
   md5: 254b3b65bd03143d723337c95b02d206
   depends:
@@ -3636,7 +3636,7 @@ packages:
   license_family: BSD
   size: 289681
   timestamp: 1716495830895
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.20.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.20.0-py310h06a4308_0.tar.bz2
   sha256: 68132795eda89b7e0d56191a5286c5edb519f1970bf891db67d823bc0d097466
   md5: 65efa10f84ac28ae312943aba805616e
   depends:
@@ -3645,7 +3645,7 @@ packages:
   license_family: BSD
   size: 267290
   timestamp: 1731939387047
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-flatbuffers-24.3.25-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-flatbuffers-24.3.25-py310h06a4308_0.tar.bz2
   sha256: 9b6972b85c0b420e91e3cfb39fd6d8b9d7606d98709197e89e36aec5f7508431
   md5: 05313ac9098072a7b0bd39a5d2828536
   depends:
@@ -3654,7 +3654,7 @@ packages:
   license_family: Apache
   size: 53433
   timestamp: 1722369206148
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-json-logger-2.0.7-py310h06a4308_0.tar.bz2
   sha256: eb676ada2db32f77e30dd7f9660feee8bdcb41bf78cb92e693005718f4b2e551
   md5: 0488050433d26a279e18122cb3a8adac
   depends:
@@ -3663,7 +3663,7 @@ packages:
   license_family: BSD
   size: 15334
   timestamp: 1683823906607
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py310h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-lmdb-1.4.1-py310h6a678d5_0.tar.bz2
   sha256: f4d4b377cc3746a0806dc579f4cb9cb7498f7cde3067ea3fb5327c1b481a916b
   md5: df2d51a297f644a8ef584f62eac40ebf
   depends:
@@ -3674,7 +3674,7 @@ packages:
   license_family: Other
   size: 139256
   timestamp: 1682522463264
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-snappy-0.6.1-py310h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-snappy-0.6.1-py310h6a678d5_0.tar.bz2
   sha256: 2f171053aca8ea83237e46813228d878c89ce2f90ea1b1e7124a99cca9ecf343
   md5: 7f5b4cc5c57e4f4033265333739c0790
   depends:
@@ -3686,7 +3686,7 @@ packages:
   license_family: BSD
   size: 31806
   timestamp: 1670944042197
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py310h06a4308_0.tar.bz2
   sha256: 8b180ea4d00530724401932d69b5041d4f33eed1ee12d3dad6491cf172175f5c
   md5: 5e95005903883d6f2bfa16ec1acf4a84
   depends:
@@ -3695,7 +3695,7 @@ packages:
   license_family: MIT
   size: 261835
   timestamp: 1713974415056
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.2-py310h06a4308_0.tar.bz2
   sha256: c86bbd0a36bebb52e10ea1bf7a65389b6b678a39560d6e8958e40ba8ba243555
   md5: e70ea9e3f1ad7084a5e6ee6400c99499
   depends:
@@ -3707,7 +3707,7 @@ packages:
   license_family: BSD
   size: 60589
   timestamp: 1711136949672
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py310h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.2-py310h5eee18b_0.tar.bz2
   sha256: 907a3739b1ba6b35da0b945801c76be949eb223e31edd08068a2c722df4feeb7
   md5: 643fc9d0796daee0cf623fa174b2e1fd
   depends:
@@ -3718,7 +3718,7 @@ packages:
   license_family: MIT
   size: 191566
   timestamp: 1728658021098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-25.1.2-py310h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-25.1.2-py310h6a678d5_0.tar.bz2
   sha256: fbeaa3c8b3cfe5cbd744990b7b0a51a24ef9ec951125764a5918940545a53470
   md5: 4564067a1e894a5d456ab659bfe39013
   depends:
@@ -3730,7 +3730,7 @@ packages:
   license_family: BSD
   size: 481899
   timestamp: 1705605213656
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
   sha256: 8a640736bef635346409582dbfe2b7d0ecc9da215c90173ff8a9a5fe22569107
   md5: 6b583dce61c6feb352ef0f49f413af1e
   depends:
@@ -3739,7 +3739,7 @@ packages:
   license: BSD-3-Clause
   size: 235004
   timestamp: 1652449537852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
   sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
   md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
   depends:
@@ -3749,7 +3749,7 @@ packages:
   license_family: GPL
   size: 467661
   timestamp: 1666648052561
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py310h06a4308_0.tar.bz2
   sha256: 402250d96d94d4b2bcc75f9d0556eb56a4d85440bcdc28f859273d1caf305a63
   md5: c04e2f621cd73f164cd5a5edc0343027
   depends:
@@ -3760,7 +3760,7 @@ packages:
   license_family: MIT
   size: 58242
   timestamp: 1699012076797
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.32.3-py310h06a4308_1.tar.bz2
   sha256: 13d64bd22d4c0c846aa360de8c1f2915fc2d33017e32e4036258a0c12a623740
   md5: 7305fb0064965c1bb4cd777439915988
   depends:
@@ -3776,7 +3776,7 @@ packages:
   license_family: Apache
   size: 98398
   timestamp: 1730999204520
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-oauthlib-2.0.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-oauthlib-2.0.0-py310h06a4308_0.tar.bz2
   sha256: 59da86e16485767158e45894e14bae130be9abd3e03f78d3535d383dcd1ffce7
   md5: b10f04cef0b8dc3592c993c0a19d8a8c
   depends:
@@ -3790,7 +3790,7 @@ packages:
   license_family: Other
   size: 34204
   timestamp: 1720615066901
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py310h06a4308_0.tar.bz2
   sha256: 0c8e89e2795a59c995078e0433ea4baaba3e24cc5f9890bf714d8c6aacdff786
   md5: 836d6322df28a02fddfc5ba4cfc19db6
   depends:
@@ -3800,7 +3800,7 @@ packages:
   license_family: MIT
   size: 8984
   timestamp: 1683077147812
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py310h06a4308_0.tar.bz2
   sha256: 2f18f6e75730725b37333f8ddd744e299144ddb3313a318cb083581e85568ed3
   md5: 67222dc42d8db7e4023f3b5243871532
   depends:
@@ -3809,7 +3809,7 @@ packages:
   license_family: MIT
   size: 9327
   timestamp: 1683059043499
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py310h4aa5aa6_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py310h4aa5aa6_1.tar.bz2
   sha256: ad40de246c99d48d5e301b59bd190e6639c78ede2a9fbc3c367f7fba75c2a057
   md5: d58c354dca1cbe610ab6e04fd9b4654f
   depends:
@@ -3819,7 +3819,7 @@ packages:
   license_family: MIT
   size: 340562
   timestamp: 1732227709147
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/s3fs-2024.6.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/s3fs-2024.6.1-py310h06a4308_0.tar.bz2
   sha256: e660dc80febe426b5a5c2cc25e8d05840c5bcee6c7c3e813db830aba8c289081
   md5: a72dcba559648cefb7f6e268663c6462
   depends:
@@ -3831,7 +3831,7 @@ packages:
   license_family: BSD
   size: 56087
   timestamp: 1724924199640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scikit-image-0.24.0-py310h1128e8f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/scikit-image-0.24.0-py310h1128e8f_0.tar.bz2
   sha256: e837940ab90554118f8f5992f1a9196127498235545e671780441548ae858216
   md5: 8526a55b1b851536668c44057a685408
   depends:
@@ -3859,7 +3859,7 @@ packages:
   license_family: Other
   size: 12812624
   timestamp: 1726738776142
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.14.1-py310h5f9d8c6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/scipy-1.14.1-py310h5f9d8c6_0.tar.bz2
   sha256: e93ed4dae46493ba97a7efa21152cac31adce31b53ef90261792bcc0ab38ecbf
   md5: 52e22b678011f8f125abcb4329dd716f
   depends:
@@ -3877,7 +3877,7 @@ packages:
   license_family: BSD
   size: 26084446
   timestamp: 1731625296820
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py310h06a4308_0.tar.bz2
   sha256: 808e8ca9ac8a80d159d53b58f0f63b6acd642d59f769b6e266b775bf29038844
   md5: 7610d29a9f5e8a69f797096c71923259
   depends:
@@ -3886,7 +3886,7 @@ packages:
   license_family: BSD
   size: 27051
   timestamp: 1699371176922
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-75.1.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-75.1.0-py310h06a4308_0.tar.bz2
   sha256: b0700617c1838cf150e8244bf419b4a2fdbc947daae5e19efb15ebd829ecbaf6
   md5: 783108bda01170b35e2aaf2daf0d662f
   depends:
@@ -3895,7 +3895,7 @@ packages:
   license_family: MIT
   size: 1763060
   timestamp: 1726677903257
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
   sha256: 8fd98235b37194986a5eb663c95a4a6db8c9e20a627f5c79ff8d9be3fd0e36f7
   md5: 25ac00d957eda056675f8fa3eafdf6df
   depends:
@@ -3905,7 +3905,7 @@ packages:
   license_family: BSD
   size: 52749
   timestamp: 1723557449203
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py310h06a4308_0.tar.bz2
   sha256: 729ac3456b8ea0fe397944736f7bcc1561527a29e96fde5f84d48bcf8622b94a
   md5: 5a86b542edbb5571edff77b429feb3cb
   depends:
@@ -3914,7 +3914,7 @@ packages:
   license_family: Other
   size: 16713
   timestamp: 1705431361480
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py310h06a4308_0.tar.bz2
   sha256: 7b2292b384f32587828c2c7a1a099bead9d2071a8969af87349f00fe9fcd98b2
   md5: 5106026a40ffd8c8ea10c146563947cf
   depends:
@@ -3923,7 +3923,7 @@ packages:
   license_family: MIT
   size: 66920
   timestamp: 1696347609464
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
   sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
   md5: f86119b3243fe3508160aa0406245738
   depends:
@@ -3936,7 +3936,7 @@ packages:
   license_family: Other
   size: 1723866
   timestamp: 1714488309729
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
   sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
   md5: 041a3caf09dc9ce8fc6c10925c4fe050
   depends:
@@ -3946,7 +3946,7 @@ packages:
   license_family: Apache
   size: 1888016
   timestamp: 1680167274961
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorboard-2.12.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tensorboard-2.12.1-py310h06a4308_0.tar.bz2
   sha256: cad6a6a8cac9ddd1e6099f326d5c5e2b68a149e7f22905c1374f0df978cacaef
   md5: 677b958754d65dbb03022a8724606b83
   depends:
@@ -3968,7 +3968,7 @@ packages:
   license_family: Apache
   size: 5875992
   timestamp: 1682445887420
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorboard-data-server-0.7.0-py310h52d8a92_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tensorboard-data-server-0.7.0-py310h52d8a92_1.tar.bz2
   sha256: edd5f7fc9a6549678be6f8f341d1729b09b5c8e31dc9f3ea4b7a12c762ddaa5b
   md5: eb1fa8460562b92bc73a95df545f40db
   depends:
@@ -3978,7 +3978,7 @@ packages:
   license_family: Apache
   size: 4951041
   timestamp: 1724173132550
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorboard-plugin-wit-1.8.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tensorboard-plugin-wit-1.8.1-py310h06a4308_0.tar.bz2
   sha256: f7b9985f79bf36a524a3dd709ed31ab30d18ea4e7103220233590ce6756d2d66
   md5: 24511128a6f40262d600ecc9b381f4dc
   depends:
@@ -3989,7 +3989,7 @@ packages:
   license_family: Apache
   size: 723387
   timestamp: 1658918566413
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorflow-2.12.0-mkl_py310hc7ea715_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tensorflow-2.12.0-mkl_py310hc7ea715_0.tar.bz2
   sha256: 3a002ee0c782c950c553023acb76f7fc3e9621b10ad9c94bd1532d0bfc3813ed
   md5: 2427f8d419482fae8ab77beb17ff5b58
   depends:
@@ -4002,7 +4002,7 @@ packages:
   license_family: Apache
   size: 4736
   timestamp: 1683035606841
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorflow-base-2.12.0-mkl_py310he5f8e37_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tensorflow-base-2.12.0-mkl_py310he5f8e37_0.tar.bz2
   sha256: 2b735c1b601f94066a96023874ca7f6e2b433b6693e1f71d405b1d338234cec2
   md5: 54b1f753994c48254ae3a2908b481c93
   depends:
@@ -4046,7 +4046,7 @@ packages:
   license_family: Apache
   size: 160460278
   timestamp: 1682464576334
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tensorflow-estimator-2.12.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tensorflow-estimator-2.12.0-py310h06a4308_0.tar.bz2
   sha256: bd6a11664fd6547b99bfabd899dafa122f0bb042bc7b87acc44856550624cad6
   md5: cee5c707043ae91fc738a142c8cee149
   depends:
@@ -4057,7 +4057,7 @@ packages:
   license_family: Apache
   size: 616219
   timestamp: 1682445997250
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/termcolor-2.1.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/termcolor-2.1.0-py310h06a4308_0.tar.bz2
   sha256: ce4a8bb2573f683252aa7e679fc724417f7de2ed990c3b08e3ced96285b54b92
   md5: c4865b272b37eb679f0802ca8f7ea6e6
   depends:
@@ -4066,7 +4066,7 @@ packages:
   license_family: MIT
   size: 11126
   timestamp: 1668084767143
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py310h06a4308_0.tar.bz2
   sha256: 0baaf2c1c9c5bdd29a149877e8cce8400fd190cb9d451b74af58adc91147984f
   md5: 00362c34088a3a02bcca1ad72df5f58a
   depends:
@@ -4077,7 +4077,7 @@ packages:
   license_family: BSD
   size: 30045
   timestamp: 1671752107828
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tifffile-2023.4.12-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tifffile-2023.4.12-py310h06a4308_0.tar.bz2
   sha256: 1b9c6a4983b335f1c8ea88a22e7dc2e4629c8d97d7fe1a6e34a54d109a3ae175
   md5: e7bea8d72331e234ae055002f5ef4f87
   depends:
@@ -4090,7 +4090,7 @@ packages:
   license_family: BSD
   size: 390867
   timestamp: 1695107559781
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py310h06a4308_0.tar.bz2
   sha256: c839dba354cb1f6b7bf7d7a0fda8c65c1fb1ec2d2165a37cd5abe8ee1ed2ecfc
   md5: 12d717c4e3873e295865c1666ff125ef
   depends:
@@ -4100,7 +4100,7 @@ packages:
   license_family: BSD
   size: 39119
   timestamp: 1668168931128
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
   sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
   md5: e2512d57c8a1e91e7b20e265c6906546
   depends:
@@ -4110,7 +4110,7 @@ packages:
   license_family: BSD
   size: 3588922
   timestamp: 1714770676475
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tomli-2.0.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tomli-2.0.1-py310h06a4308_0.tar.bz2
   sha256: 8c907320b7a66bd46b155ad9c4f6774e5abc3ce4a85f8fa9da43e1b98e1836c5
   md5: c484ebee52415c809546b14d9d87b391
   depends:
@@ -4119,7 +4119,7 @@ packages:
   license_family: MIT
   size: 24991
   timestamp: 1657175627477
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py310h06a4308_0.tar.bz2
   sha256: 76fb218f58792fab0d456e57408e7debdb87c2ecb0497e4855c989b83282118e
   md5: 38dac546077abb0c9721f655c381c7e6
   depends:
@@ -4128,7 +4128,7 @@ packages:
   license_family: BSD
   size: 103861
   timestamp: 1667464115489
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.1-py310h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.4.1-py310h5eee18b_0.tar.bz2
   sha256: 1a4eb37f7606866aa783f5fa3dc8f4643aeb1525160f0a9cb83a5ca24e8094f8
   md5: 6e2ab4d379cf7c3136f61e0979d962af
   depends:
@@ -4138,7 +4138,7 @@ packages:
   license_family: Apache
   size: 700772
   timestamp: 1718740190483
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.5-py310h2f386ee_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.66.5-py310h2f386ee_0.tar.bz2
   sha256: 6749bf9f6cb577328d3d6aa858dfda98c343eabb8ccb038341f99460563f08e1
   md5: 965afdedbcb9af928050b5ca697f6617
   depends:
@@ -4149,7 +4149,7 @@ packages:
   license_family: MOZILLA
   size: 127158
   timestamp: 1724854095297
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.14.3-py310h06a4308_0.tar.bz2
   sha256: d03a4c457adcaaab213fa99b1aaa060afddb5a99214fc8a30b271639d2f5c2ca
   md5: 7c2b898dfd6dd4d772a82291e59f9c00
   depends:
@@ -4158,7 +4158,7 @@ packages:
   license_family: BSD
   size: 167463
   timestamp: 1718227133814
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.11.0-py310h06a4308_0.tar.bz2
   sha256: 5dcc9a52109105999bc0ee901dd860baa404491f46e8839bc344d845edac67f8
   md5: 60998ef6dade7cba5fc2efca7720d6d5
   depends:
@@ -4168,7 +4168,7 @@ packages:
   license_family: PSF
   size: 8905
   timestamp: 1715268910453
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.11.0-py310h06a4308_0.tar.bz2
   sha256: 2adc6fddc146748e6407868fb9e7babcec334a7e2d81261e617096f1f4926f9e
   md5: 573ba9e89697897dd8c5ef719aae698f
   depends:
@@ -4177,7 +4177,7 @@ packages:
   license_family: PSF
   size: 60418
   timestamp: 1715268904908
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py310h06a4308_0.tar.bz2
   sha256: c67bb54cb344ab975ef08503be4a57ee320ef62c9921f26b5aaeb91131481dbe
   md5: 6a74bf3425ae419af7b95b622b81de24
   depends:
@@ -4186,7 +4186,7 @@ packages:
   license_family: MIT
   size: 10781
   timestamp: 1659769481565
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py310h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py310h5eee18b_0.tar.bz2
   sha256: 6f6b159e41f37180c3ab594d9236b4841ea350aa3ff4e934d7b87e54f75c5813
   md5: ff17193d8822a045e6a4664bb24221fd
   depends:
@@ -4196,7 +4196,7 @@ packages:
   license_family: Apache
   size: 512367
   timestamp: 1713213088872
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-2.2.3-py310h06a4308_0.tar.bz2
   sha256: 69c85d6257d993c6a946ea30631eb287fcd4d62d69d29b9fda6bdf9f7f0ee79a
   md5: 9a4b0a6a87c55741d8bfcea6d368d293
   depends:
@@ -4212,7 +4212,7 @@ packages:
   license_family: MIT
   size: 172981
   timestamp: 1727769926184
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
   sha256: a8d11b0f08217607b99ba560edf66423ca1e36f4ffbb6e2377e61670e2b5f36b
   md5: 431e82b081b08aef0259df0437e04c75
   depends:
@@ -4221,7 +4221,7 @@ packages:
   license_family: MIT
   size: 97535
   timestamp: 1706894675990
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py310h06a4308_1.tar.bz2
   sha256: a375f3ad671266b27503b33f62ceaa7be112c0e47836e38a6c6a76225aff927d
   md5: 49b82f30a2a45b2ce167a876cdc9e21c
   depends:
@@ -4230,7 +4230,7 @@ packages:
   license_family: BSD
   size: 21391
   timestamp: 1640795864430
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py310h06a4308_0.tar.bz2
   sha256: c1e745d9d00966bfb077d1356a1fe848cc4ea12309f8904d1f33bc0f6ec5dddc
   md5: 4df68f6567bcf5ef5cd6dc6449e653bf
   depends:
@@ -4239,7 +4239,7 @@ packages:
   license_family: Apache
   size: 86991
   timestamp: 1715878322248
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/werkzeug-3.0.6-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/werkzeug-3.0.6-py310h06a4308_0.tar.bz2
   sha256: 93c6c33f5098e70cb73c4b76d27e5bd60663d813eeaec00f3c57b5923815f014
   md5: f2ed8091f722dbcf0d703d19efaaa735
   depends:
@@ -4251,7 +4251,7 @@ packages:
   license_family: BSD
   size: 347938
   timestamp: 1731005882186
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.44.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.44.0-py310h06a4308_0.tar.bz2
   sha256: b5e0d29bb2be1228862df02593f1f6e1ad45f61292aceebfe1ff280f61da354c
   md5: a62ba07c41bc8187ab4ab2acffe6d457
   depends:
@@ -4260,7 +4260,7 @@ packages:
   license_family: MIT
   size: 105530
   timestamp: 1726165099666
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/widgetsnbextension-4.0.10-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/widgetsnbextension-4.0.10-py310h06a4308_0.tar.bz2
   sha256: cc16282761625bd51a4cba0311995c415ff389d9eca25cd211a659589ee5b2c4
   md5: 6b7d1b8791acac86b51b0ae5aee2207c
   depends:
@@ -4269,7 +4269,7 @@ packages:
   license_family: BSD
   size: 1930328
   timestamp: 1709323002761
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wrapt-1.14.1-py310h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wrapt-1.14.1-py310h5eee18b_0.tar.bz2
   sha256: d124a4c35ad87af326dab95842b1cd26e8ea730ba3df29d79043e9baebd7f862
   md5: d841452d35f0316511e36dd6f085f0f1
   depends:
@@ -4279,7 +4279,7 @@ packages:
   license_family: BSD
   size: 88964
   timestamp: 1657814488569
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py310h06a4308_0.tar.bz2
   sha256: 99aeddd48fdb5599e4a4a61bb7b763ca6d5956c4d04aed8aac383843b966a087
   md5: 23e2468c2df96e0a149dcdf731a879af
   depends:
@@ -4291,7 +4291,7 @@ packages:
   license_family: Apache
   size: 1804197
   timestamp: 1689041511624
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py310h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py310h06a4308_1.tar.bz2
   sha256: 3a40d7ba77be22b17da9ad610218f01b4401b05a27eaeadafa417140dac1d8b0
   md5: 19e7ea26af10c4cab50f154f358048b3
   depends:
@@ -4300,7 +4300,7 @@ packages:
   license_family: BSD
   size: 47939
   timestamp: 1675159089417
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
   sha256: 9122d6e9dabb7a47f2bcb15d86b97c96c49a9048da3f8ae59675351710c14cc5
   md5: 660b2aead2ec87b751c86cd33934f44e
   depends:
@@ -4309,7 +4309,7 @@ packages:
   license_family: GPL2
   size: 716926
   timestamp: 1714510796277
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -4317,7 +4317,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yarl-1.18.0-py310h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yarl-1.18.0-py310h5eee18b_0.tar.bz2
   sha256: 87225ff70e79c5c58b5ffb5a3d8e6796490b216d0d9fb673364b9d4d4f918112
   md5: 03a3b2b614a6591a2c2f975ede388d92
   depends:
@@ -4330,7 +4330,7 @@ packages:
   license_family: Apache
   size: 143625
   timestamp: 1732547051189
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zarr-2.13.3-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zarr-2.13.3-py310h06a4308_0.tar.bz2
   sha256: 93c184172b3f1f6b231b20a4c64e76e0dc0845731bd66c6b6844329863f718e1
   md5: e91564f604f2ae189eefc46505dd1127
   depends:
@@ -4343,7 +4343,7 @@ packages:
   license_family: MIT
   size: 342714
   timestamp: 1669363788544
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
   sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
   md5: 943f1247a22b6b64171363bcee1eec27
   depends:
@@ -4354,7 +4354,7 @@ packages:
   license_family: Other
   size: 371663
   timestamp: 1705602144682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zfp-1.0.0-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zfp-1.0.0-h6a678d5_0.tar.bz2
   sha256: 807521a07138f611cad037b15de8f478fc985cedb00bce3f6256c0ea14f09825
   md5: 3a844b7ddc088e7cf5dca84d8c4e3fcd
   depends:
@@ -4366,7 +4366,7 @@ packages:
   license_family: BSD
   size: 305779
   timestamp: 1681741638187
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zict-3.0.0-py310h06a4308_0.tar.bz2
   sha256: dd89ee9a721abb1007addbf785825f0435e9c6acb75f89cf9836f53efa004d01
   md5: 0013ca0c5215bfc8d1df79b2a34d5209
   depends:
@@ -4377,7 +4377,7 @@ packages:
   license_family: BSD
   size: 77624
   timestamp: 1695832955061
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.21.0-py310h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.21.0-py310h06a4308_0.tar.bz2
   sha256: 1f8ffae8697d1f29074f7be8922292c70323c478e402a70f4d60b2f665f24559
   md5: 4a45201520d2a7dee35eb7ecb3968c3e
   depends:
@@ -4386,7 +4386,7 @@ packages:
   license_family: MIT
   size: 25876
   timestamp: 1732630793227
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
   sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
   md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
   depends:
@@ -4395,7 +4395,7 @@ packages:
   license_family: Other
   size: 127143
   timestamp: 1714510716441
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
   sha256: a65c6277a3045e4ea72f617f977134c18366d8142ce51512f5a3cf325226a8bf
   md5: d941bb6fdc55cc1b3f67b3beb23d1795
   depends:
@@ -4408,7 +4408,7 @@ packages:
   license_family: BSD
   size: 1081416
   timestamp: 1728487031624
-- conda: https://repo.anaconda.com/pkgs/main/noarch/aioitertools-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/aioitertools-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: db0f4480d25a6fa447ce92d729c2bc7dcb2e47f958ccad99688fbb29bab6107a
   md5: 572c3084a7886f8fd8547cc1deed4a7d
   depends:
@@ -4418,7 +4418,7 @@ packages:
   license_family: MIT
   size: 19602
   timestamp: 1607109696386
-- conda: https://repo.anaconda.com/pkgs/main/noarch/aiosignal-1.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/aiosignal-1.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: e100b4cc8eed4c65dbc4c34fc09425488d9863b94bbe2b67f3a971ea396f44c6
   md5: 69ca1242900a1537435a8cdc6901100a
   depends:
@@ -4428,7 +4428,7 @@ packages:
   license_family: Apache
   size: 12671
   timestamp: 1637843091841
-- conda: https://repo.anaconda.com/pkgs/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/appdirs-1.4.4-pyhd3eb1b0_0.tar.bz2
   sha256: 8f312df57fbcba29977fcc1a66017f231820699053ca3b91450fabc16ec09858
   md5: a1914956aa26b608c4f2d17edadca061
   depends:
@@ -4436,7 +4436,7 @@ packages:
   license: MIT
   size: 12124
   timestamp: 1629143509659
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -4449,7 +4449,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asciitree-0.3.3-py_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asciitree-0.3.3-py_2.tar.bz2
   sha256: dca6fab6ba10ac9af6ddb18b40f81a7e240eb954fc46f476745e2ec6de0b25b2
   md5: c39f5ec48b011f1fe24dee7949378176
   depends:
@@ -4457,7 +4457,7 @@ packages:
   license: MIT
   size: 9873
   timestamp: 1548714427462
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -4467,7 +4467,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/astunparse-1.6.3-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/astunparse-1.6.3-py_0.tar.bz2
   sha256: ec789985c21bb166390cb69798f2233895bc06afef3b706bf5dde7c3f9daceb9
   md5: ccbf3a1406a1db9c42dcad71268bf6e0
   depends:
@@ -4476,7 +4476,7 @@ packages:
   license: BSD-3-Clause AND PSF-2.0
   size: 17457
   timestamp: 1589913528863
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
   sha256: c0dd89ffac001588171152a285ddbbaea209ebe4116010f985f898b7e87c2f35
   md5: 731ae7d446633bc729f3493a52d4365b
   depends:
@@ -4485,7 +4485,7 @@ packages:
   license_family: MIT
   size: 43502
   timestamp: 1721748373551
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -4494,7 +4494,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -4503,7 +4503,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -4512,7 +4512,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -4521,7 +4521,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/fasteners-0.16.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/fasteners-0.16.3-pyhd3eb1b0_0.tar.bz2
   sha256: 2175d81bc02b27e9a6cc724175dda066e7d3c7d000bc2f713467c51660bf68c7
   md5: 11d4c33907e93548617df4852c881804
   depends:
@@ -4531,7 +4531,7 @@ packages:
   license_family: Apache
   size: 26106
   timestamp: 1623953511907
-- conda: https://repo.anaconda.com/pkgs/main/noarch/gast-0.4.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/gast-0.4.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1d68d1f43a64e5498c2c88992d607a7735119a07a6c53fc19021fda5ba307c9c
   md5: 10a82aba1ec39fab9d158f349dc5233b
   depends:
@@ -4540,7 +4540,7 @@ packages:
   license_family: BSD
   size: 12520
   timestamp: 1628588912772
-- conda: https://repo.anaconda.com/pkgs/main/noarch/google-auth-oauthlib-0.4.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/google-auth-oauthlib-0.4.4-pyhd3eb1b0_0.tar.bz2
   sha256: b0f252702586d3bcc752c3931884155420005e643c3b4bed139e6ec983410e04
   md5: a9379b5ad5373d3e7879447115b4928c
   depends:
@@ -4553,7 +4553,7 @@ packages:
   license_family: Apache
   size: 19488
   timestamp: 1617120604882
-- conda: https://repo.anaconda.com/pkgs/main/noarch/google-pasta-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/google-pasta-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 2ac7dff32915a322178e1efb33472527e8906e6b72bf4991fd3ff8c4a76bf3a9
   md5: e0813186a62e13665a4e886815c50abc
   depends:
@@ -4563,7 +4563,7 @@ packages:
   license_family: APACHE
   size: 43929
   timestamp: 1630578016443
-- conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
   sha256: 9de8666e5b70aa2437737128eaa14ffe80a7b5235c2a6b7d3f39ccefd7816ba0
   md5: bb52e50c5ab1a5c7778c11376404dfdb
   depends:
@@ -4571,7 +4571,7 @@ packages:
   license: BSD 3-Clause
   size: 7933
   timestamp: 1630598543551
-- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
   sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
   md5: 33624a42ee387bf9918ea98b4e7b31fc
   depends:
@@ -4581,7 +4581,7 @@ packages:
   license_family: BSD
   size: 8173
   timestamp: 1601490751973
-- conda: https://repo.anaconda.com/pkgs/main/noarch/keras-preprocessing-1.1.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/keras-preprocessing-1.1.2-pyhd3eb1b0_0.tar.bz2
   sha256: 5d66b8a7734e9e9bcfe8191cbce8e2d6596cc6ead93fd7d245175f77f9faa780
   md5: 85e0c4015cf695750f966b7a2ca48950
   depends:
@@ -4595,7 +4595,7 @@ packages:
   license_family: MIT
   size: 35457
   timestamp: 1612283681320
-- conda: https://repo.anaconda.com/pkgs/main/noarch/nbconvert-7.16.4-hd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/nbconvert-7.16.4-hd3eb1b0_1.tar.bz2
   sha256: 66982437d81697601d01945283763aa01d4ee03b1a05a48e69809bb9c4d897ab
   md5: 03a7057ac107d2f1409665f6f169dc21
   depends:
@@ -4605,7 +4605,7 @@ packages:
   license_family: BSD
   size: 7126
   timestamp: 1732709527394
-- conda: https://repo.anaconda.com/pkgs/main/noarch/nbconvert-pandoc-7.16.4-hd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/nbconvert-pandoc-7.16.4-hd3eb1b0_1.tar.bz2
   sha256: 8e93e86e261df0844328479598554b4f79eb6adb956a05ec81efc734ad87453a
   md5: f82db1f6d41ceb9c4cb45bae61c41cf0
   depends:
@@ -4614,7 +4614,7 @@ packages:
   license: BSD-3-Clause
   size: 7151
   timestamp: 1732709526799
-- conda: https://repo.anaconda.com/pkgs/main/noarch/opt_einsum-3.3.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/opt_einsum-3.3.0-pyhd3eb1b0_1.tar.bz2
   sha256: 361ff5c0a130348810b2502b914ebc729342600d160ffe3345a2abc2239d9bc2
   md5: 7a6355d8a9d091647226c634345213f8
   depends:
@@ -4624,7 +4624,7 @@ packages:
   license_family: MIT
   size: 58106
   timestamp: 1621500274746
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -4633,7 +4633,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -4642,7 +4642,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -4652,7 +4652,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
   sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
   md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
   depends:
@@ -4661,7 +4661,7 @@ packages:
   license_family: BSD
   size: 5106
   timestamp: 1704404390460
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -4669,7 +4669,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -4678,7 +4678,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pyasn1-0.4.8-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pyasn1-0.4.8-pyhd3eb1b0_0.tar.bz2
   sha256: a32ddfecb6ed99a6d192d352bf5afa2e53760d1d5ddf0202fb13bb0fd7d23a2a
   md5: 4a84e67c47feb540be5d11d6f53535a5
   depends:
@@ -4687,7 +4687,7 @@ packages:
   license_family: BSD
   size: 55350
   timestamp: 1629708025637
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pyasn1-modules-0.2.8-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pyasn1-modules-0.2.8-py_0.tar.bz2
   sha256: 6af43ddec74992b2752c67385ba8565570545eb83984cb37eee057a452800f03
   md5: 4c5ff5474d4df03476d42c6c02c1878c
   depends:
@@ -4697,7 +4697,7 @@ packages:
   license_family: BSD
   size: 68670
   timestamp: 1600458175964
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -4706,7 +4706,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
   sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
   md5: 02caf3f47f1d06256068053297355740
   depends:
@@ -4715,7 +4715,7 @@ packages:
   license_family: Apache
   size: 152292
   timestamp: 1690578151230
-- conda: https://repo.anaconda.com/pkgs/main/noarch/rsa-4.7.2-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/rsa-4.7.2-pyhd3eb1b0_1.tar.bz2
   sha256: 0623e679566b1823c633b3afa0210ccedcc765cfffbe1eb6d930bc38544554e7
   md5: 45f93f7851c1420317c50d8919ebe52c
   depends:
@@ -4725,7 +4725,7 @@ packages:
   license_family: APACHE
   size: 28505
   timestamp: 1614366267903
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -4734,7 +4734,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
   sha256: 4e47f6c49ce84509f1466e8a4d728447bf4bcd9bce7b456431a789a262547067
   md5: 4cad993b0f80bc23fb66a97592299cbb
   depends:
@@ -4743,7 +4743,7 @@ packages:
   license_family: Apache
   size: 26504
   timestamp: 1623949147884
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -4755,7 +4755,7 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
   sha256: ca2be6c7810a37cfc6db1f5383937b5d35c6d73c1fad8a9104de85f069b1df1c
   md5: 9ccb2fb33edb152403d6ef32bf758a9d
   depends:
@@ -4764,7 +4764,7 @@ packages:
   license_family: BSD
   size: 15614
   timestamp: 1629402049497
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tensorboard-plugin-wit-1.6.0-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tensorboard-plugin-wit-1.6.0-py_0.tar.bz2
   sha256: b1cd619d0fd8cc07a9221e9b46d666647b74f1eb78676e8e98c235e51cf26b05
   md5: d6d311cce452a29369c3425c41e6204a
   depends:
@@ -4774,14 +4774,14 @@ packages:
   license_family: Apache
   size: 678459
   timestamp: 1590157851387
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
   sha256: bf3130b8c44a7e9bcd496f515d0ee4b2e788610f468bafd708d16d007cb47332
   md5: 48f856789d224eae8d1979c212205fde
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 123651
   timestamp: 1728062827250
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -4789,7 +4789,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wheel-0.35.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wheel-0.35.1-pyhd3eb1b0_0.tar.bz2
   sha256: f596b4e7fcd72e69f405bbe37ecd9e61443ccbdb8a1cecb7554dd20f1d161bdb
   md5: 4b8b35af9c0ea16f368eece1b331605d
   depends:
@@ -4797,12 +4797,12 @@ packages:
   license: MIT
   size: 37378
   timestamp: 1605289315954
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/_tflow_select-2.2.0-eigen.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/_tflow_select-2.2.0-eigen.tar.bz2
   sha256: 0c6682bf48ae7bb2d44ea1f06897fd887ca63b3c749018b0951fe4cbdb0e4808
   md5: 34203ba34d2a42af01b219940dfc4f4a
   size: 3004
   timestamp: 1538712271476
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/abseil-cpp-20211102.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/abseil-cpp-20211102.0-he9d5cce_0.tar.bz2
   sha256: 92e2d6a5550c1edcd9ed0cbc8381a12d5ade0a62e68b399dbd24db9a01543cdf
   md5: e2f0c404d039f95ae751384060ae2bac
   depends:
@@ -4811,7 +4811,7 @@ packages:
   license_family: Apache
   size: 1035020
   timestamp: 1652382905031
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/absl-py-2.1.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/absl-py-2.1.0-py310hecd8cb5_0.tar.bz2
   sha256: 2667ddb06b4c6b3c2861aca66bbc1338dccaae9a3b6b68a78c38224713352413
   md5: 22469370aeb4c1f5d117c52102a5a165
   depends:
@@ -4820,7 +4820,7 @@ packages:
   license_family: Apache
   size: 188877
   timestamp: 1714140609305
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aiobotocore-2.12.3-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aiobotocore-2.12.3-py310hecd8cb5_0.tar.bz2
   sha256: 983564404ad498ef3a96f682f647886eeec6940f023d0b9cdba3558e92f9ed85
   md5: 6a61700dd2d180b1b017492ed2732f75
   depends:
@@ -4835,7 +4835,7 @@ packages:
   license_family: Apache
   size: 111964
   timestamp: 1714464434338
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aiohappyeyeballs-2.4.3-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aiohappyeyeballs-2.4.3-py310hecd8cb5_0.tar.bz2
   sha256: 0f0642a14655b681c6692f84034dafa8d4b1a32d68f22d5261f8ccde73176f0c
   md5: 2c7331060612abb98063f9082c0eee11
   depends:
@@ -4844,7 +4844,7 @@ packages:
   license_family: Other
   size: 26342
   timestamp: 1732662030058
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aiohttp-3.10.5-py310h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aiohttp-3.10.5-py310h46256e1_0.tar.bz2
   sha256: de2f7b6391b1dbb427a2a15dc3dfa8f0cdbedf7621296c04de9fda3b842f05b4
   md5: d976e71fccb21dd8ac86e9e7f3d3cc71
   depends:
@@ -4862,7 +4862,7 @@ packages:
   license_family: Other
   size: 742029
   timestamp: 1725528062334
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.6.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-4.6.2-py310hecd8cb5_0.tar.bz2
   sha256: 00b536bb4e440d8bdc936ccabfae53277efea893bf4192c5fe4366340f7adb26
   md5: 50bb380e6d6d69e919487b90e4ea2cc3
   depends:
@@ -4878,7 +4878,7 @@ packages:
   license_family: MIT
   size: 192586
   timestamp: 1729121529214
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aom-3.6.0-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aom-3.6.0-hcec6c5f_0.tar.bz2
   sha256: e9e15fb1d52051c9dbb25b1f2e613eb60cf8dbe0793062c3a274e61e6a0871dc
   md5: cb548680c2222c567784653166056c1a
   depends:
@@ -4887,7 +4887,7 @@ packages:
   license_family: BSD
   size: 3463290
   timestamp: 1688660834942
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py310hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py310hecd8cb5_1001.tar.bz2
   sha256: 09c3f6c4328480f28458ea1610756de82424aef128aa9cded81f8f0766a81485
   md5: d6b76a162e56bfc828c021c67e0c68ac
   depends:
@@ -4896,7 +4896,7 @@ packages:
   license_family: BSD
   size: 10049
   timestamp: 1642500631813
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py310hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py310hca72f7f_0.tar.bz2
   sha256: 4de7fc8c8f18ca65bf023bbc60d0e4bf7d17ea01323f264668df29b736cc6580
   md5: 7f6d95177dc7630deefb205c1e2bdbab
   depends:
@@ -4906,7 +4906,7 @@ packages:
   license_family: MIT
   size: 36335
   timestamp: 1644569785995
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/async-lru-2.0.4-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/async-lru-2.0.4-py310hecd8cb5_0.tar.bz2
   sha256: 7f2654a2202f6da85a0612aabb58fbc80d3215fb86822ebb79b81b3b8c8960ff
   md5: 02ee031f92f437f50f045449b6087319
   depends:
@@ -4916,7 +4916,7 @@ packages:
   license_family: MIT
   size: 18536
   timestamp: 1699554611431
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/async-timeout-4.0.3-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/async-timeout-4.0.3-py310hecd8cb5_0.tar.bz2
   sha256: 4164451bcb07c4a0a9300d2d3de69d048f86c865be03c5954e14e4d68bdf021a
   md5: e6033e6c734af4a109fca7fdef541721
   depends:
@@ -4925,7 +4925,7 @@ packages:
   license_family: Apache
   size: 13065
   timestamp: 1703097151196
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.2.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-24.2.0-py310hecd8cb5_0.tar.bz2
   sha256: f6aebcbfa8259ea6505e4c9d0afff7ca7593f8d04e3fbf2f30555cc00f13ce5f
   md5: fd894a059ee44363449bee33d6bd34f8
   depends:
@@ -4934,7 +4934,7 @@ packages:
   license_family: MIT
   size: 143104
   timestamp: 1729089801754
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/babel-2.11.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/babel-2.11.0-py310hecd8cb5_0.tar.bz2
   sha256: 08fe5d5d07cd5a4411acb231e14fc6fb2f74ffd6698298c2baa9ee583f4e2596
   md5: 2d66ecb9459d2832913f67e973000beb
   depends:
@@ -4944,7 +4944,7 @@ packages:
   license_family: BSD
   size: 7121236
   timestamp: 1671782042229
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.3-py310hecd8cb5_0.tar.bz2
   sha256: bd9f64f7d4a1db524a8043cdbd44003708f9734b7cef0f34bba2412951b7154b
   md5: 450f6c095ce62cdbf38ee2fb41efa470
   depends:
@@ -4954,12 +4954,12 @@ packages:
   license_family: MIT
   size: 218203
   timestamp: 1718029916816
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-openblas.tar.bz2
   sha256: 695ac69739e73351dfebfb01ea39c5e1dbfdcfb475590d6560ae318bfbad3a97
   md5: 38fd73cba341639c45d8c747b08c9cc1
   size: 49130
   timestamp: 1528225884020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bleach-6.2.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bleach-6.2.0-py310hecd8cb5_0.tar.bz2
   sha256: 80f284948e221e50a375d27ced28b60fc14e9b94c70b7afebab6c94f1591e57b
   md5: d44ba8f9caf313fdf5186c7f50e857c8
   depends:
@@ -4971,7 +4971,7 @@ packages:
   license_family: Apache
   size: 298162
   timestamp: 1732292174114
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blinker-1.6.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blinker-1.6.2-py310hecd8cb5_0.tar.bz2
   sha256: e8e62d30b2ceef98b36bd0eaf99002b81256776b8c02680939378dcabfac52ba
   md5: 9a81364fe4be30f83c62b32db8adaf2d
   depends:
@@ -4980,7 +4980,7 @@ packages:
   license_family: MIT
   size: 29206
   timestamp: 1696539280528
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
   sha256: 3699a260f422443de85b74084fe36f734be1a466eeebdfdf4195d52c9fdb5508
   md5: 132d056e66b3ae9148f53819f8368c94
   depends:
@@ -4992,7 +4992,7 @@ packages:
   license_family: BSD
   size: 66125
   timestamp: 1675247668924
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.4.3-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-2.4.3-py310hecd8cb5_0.tar.bz2
   sha256: edadfe22baffa5b8cf9448fe3dcf9e96bf870296452f4b7e50fdc9a33b875502
   md5: 058f3606d868d73ebd92e397ce9a8115
   depends:
@@ -5008,7 +5008,7 @@ packages:
   license_family: BSD
   size: 14414029
   timestamp: 1658136718353
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/botocore-1.34.69-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/botocore-1.34.69-py310hecd8cb5_0.tar.bz2
   sha256: e5c5bb3e73c2fcdf81ebb0eec4c19e97b42b080e13701dbcc65caf5c0126b152
   md5: 4742c39f8ebfa46de173b76e3f16ec19
   depends:
@@ -5020,7 +5020,7 @@ packages:
   license_family: Apache
   size: 7716227
   timestamp: 1714461172938
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.4.2-py310hf3fd67a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.4.2-py310hf3fd67a_0.tar.bz2
   sha256: ac40c8227c080120a516638f6a9190b433ed0b5b7534515cbba1cac9b6081cc3
   md5: f81b63c81b9bb6dbd2f8b41fc5ef2c87
   depends:
@@ -5030,7 +5030,7 @@ packages:
   license_family: BSD
   size: 138249
   timestamp: 1731059410633
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
   sha256: d8b1ccb15297dcfb3f9ebb8139c3e28a13d6c2e73c37612cb214ab6cc58b15fa
   md5: e5dec9f13de061640ad2697562a99b54
   depends:
@@ -5040,7 +5040,7 @@ packages:
   license: MIT
   size: 19732
   timestamp: 1714483415038
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
   sha256: e9fda4393edd0234c88efc2b88e0edf42c94eb49ea5b189a80afd733058be8fb
   md5: 13ceed558eb174d6b77ed1b0035f1785
   depends:
@@ -5049,7 +5049,7 @@ packages:
   license: MIT
   size: 18400
   timestamp: 1714483395748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py310hcec6c5f_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py310hcec6c5f_8.tar.bz2
   sha256: fff6fa5c13c50b815aeb12a3c2e90ae8e3b32cf1578ebfb23374b2df366bb259
   md5: 15c4e2d00fb974cdf15be7a206025648
   depends:
@@ -5058,7 +5058,7 @@ packages:
   license: MIT
   size: 393878
   timestamp: 1714483673596
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brunsli-0.1-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brunsli-0.1-h23ab428_0.tar.bz2
   sha256: af713241455149cffec30054b5ab2f055a72c1b6bb6f492d9568deaa362597f6
   md5: 860cc2203395527c259cabd8e3e16a36
   depends:
@@ -5068,28 +5068,28 @@ packages:
   license_family: MIT
   size: 184792
   timestamp: 1611240502908
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
   sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
   md5: c5a600d81b1b48578863af2973c743ac
   license: bzip2-1.0.8
   license_family: BSD
   size: 187637
   timestamp: 1714510590009
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
   sha256: f913b61ba3c1651b36688415cc163a5d575475f7573b543f48a80e7a5002e4bb
   md5: f11d165eaa532ce04a35382841284298
   license: MIT
   license_family: MIT
   size: 107047
   timestamp: 1693902034820
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.11.26-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2024.11.26-hecd8cb5_0.tar.bz2
   sha256: 6012ec121e1edf165b6f877f2ce9686acdedb461ae0406ee188e863bf3d264de
   md5: 39b94853ef9d5d79a9d8e28c6b2efc2e
   license: MPL-2.0
   license_family: Other
   size: 142680
   timestamp: 1732804456701
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cachetools-5.3.3-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cachetools-5.3.3-py310hecd8cb5_0.tar.bz2
   sha256: dd007da9f25806ca6041a2c1e80f5777fdbefadb5fd6594e1b7e61eb881f6620
   md5: 0af03702f1ff87a598764cc187694b89
   depends:
@@ -5098,7 +5098,7 @@ packages:
   license_family: MIT
   size: 23948
   timestamp: 1713977135496
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.8.30-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2024.8.30-py310hecd8cb5_0.tar.bz2
   sha256: e55976b8cb38daae501a302eda22ce71077b9189485cf4f566304c2ca7c1da6f
   md5: eb359e8e2eb6003c09560ef4e25a3ab8
   depends:
@@ -5107,7 +5107,7 @@ packages:
   license_family: Other
   size: 168989
   timestamp: 1725551820641
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py310h9205ec4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.17.1-py310h9205ec4_0.tar.bz2
   sha256: 94fe0635e7ee8952321117b8b779a51e2cf56b5ad4a86f8c53a1110033762777
   md5: e92ca60616b93825ea766112b92f5259
   depends:
@@ -5118,7 +5118,7 @@ packages:
   license_family: MIT
   size: 233073
   timestamp: 1726856601250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
   sha256: 68a12eaeda90c9cdbce729f0d44d222c3f60ec4920bb781bf13fae3a89cb3dd1
   md5: a0970a5c1c77125369aded2d4e25f870
   depends:
@@ -5130,7 +5130,7 @@ packages:
   license_family: Other
   size: 1437665
   timestamp: 1655814938182
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cftime-1.6.2-py310h7b7cdfe_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cftime-1.6.2-py310h7b7cdfe_0.tar.bz2
   sha256: f21411a361ac53ac9b128db86533d7048a2c0e94b216da0767363159d58ba10b
   md5: 302a18a9546c4275f32f9331ec61747e
   depends:
@@ -5140,7 +5140,7 @@ packages:
   license_family: MIT
   size: 223992
   timestamp: 1678830614730
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/charls-2.2.0-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/charls-2.2.0-h23ab428_0.tar.bz2
   sha256: af3ad515ab2369e09b7a8b373025d1f7851618c2e698c7336d1296cb4f105732
   md5: bb00d7a0d60266c9bdd9493d3f91f955
   depends:
@@ -5149,7 +5149,7 @@ packages:
   license_family: BSD
   size: 96819
   timestamp: 1612240391361
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py310hecd8cb5_0.tar.bz2
   sha256: ebdc1573290d42968d22d4fd21d62ebffb5f73181e62e7fda28d6e3cbab5b611
   md5: 7d9b37ba7510983192c976da9cb9d9a9
   depends:
@@ -5158,7 +5158,7 @@ packages:
   license_family: BSD
   size: 155703
   timestamp: 1698129854193
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.0.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cloudpickle-3.0.0-py310hecd8cb5_0.tar.bz2
   sha256: 36043113774c4129d90b66b6665ddcd02692eb5f090b121c6ffd71509f334f6f
   md5: 23e1bce8369429a36a4ff19069a34dbc
   depends:
@@ -5167,7 +5167,7 @@ packages:
   license_family: BSD
   size: 35847
   timestamp: 1721657465524
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py310hecd8cb5_0.tar.bz2
   sha256: 38b6b20387ada75d20393cc99de9c8a1f2b7fcd03b28720df4eef55d44ec393e
   md5: 881ffce8c467163639bd6ed6ef941189
   depends:
@@ -5176,7 +5176,7 @@ packages:
   license_family: CC
   size: 499171
   timestamp: 1709758463351
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py310hecd8cb5_0.tar.bz2
   sha256: cafb4b7adcb72b498a482a6b846f949e1aee350f96a79d9146b38f969b2e0a90
   md5: a404bca7f71823adc5ef078d63b788a9
   depends:
@@ -5186,7 +5186,7 @@ packages:
   license_family: BSD
   size: 15750
   timestamp: 1709322968401
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.3.1-py310h1962661_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.3.1-py310h1962661_0.tar.bz2
   sha256: b417230b26b1ce73a43ef4d6d4aa665d7cb49574ed484612b4f9c5f4ef563171
   md5: 3063ab79f0ba0cc1349db7b443216df3
   depends:
@@ -5197,7 +5197,7 @@ packages:
   license_family: BSD
   size: 282429
   timestamp: 1732540159621
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py310ha2381d6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py310ha2381d6_0.tar.bz2
   sha256: a85c2b09aa399485ca1b3ca08c28d76138832217c713ecaf74ddc01bea06e138
   md5: 913d0518e7530c8ed01852b3b920337e
   depends:
@@ -5210,7 +5210,7 @@ packages:
   license_family: BSD
   size: 1310765
   timestamp: 1694212271586
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.2-py310h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cytoolz-0.12.2-py310h6c40b1e_0.tar.bz2
   sha256: fc3aede2139d7c260dd925c00a3789e0a25076125bb1e3f43a08012bc86c2f1f
   md5: 8d2d3024214db6a4f151cbe09344c545
   depends:
@@ -5220,7 +5220,7 @@ packages:
   license_family: BSD
   size: 365217
   timestamp: 1701729423199
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-2023.4.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/dask-2023.4.1-py310hecd8cb5_0.tar.bz2
   sha256: 4e3a22058a5c4b422ebd499d09028de52cafca69e56b9f0556b3c491c9cd3cdb
   md5: 80c65213359055e79e585d3e8cc339b9
   depends:
@@ -5245,7 +5245,7 @@ packages:
   license_family: BSD
   size: 6158
   timestamp: 1683568527645
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.4.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/dask-core-2023.4.1-py310hecd8cb5_0.tar.bz2
   sha256: a44f61d8477c87e832e2bfde3a6de10e9efeb7156bff392ca2ca9a9a36ae9630
   md5: 158698f92f880704eb88f92b3588785f
   depends:
@@ -5262,14 +5262,14 @@ packages:
   license_family: BSD
   size: 2132169
   timestamp: 1683065296769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/dav1d-1.2.1-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/dav1d-1.2.1-h6c40b1e_0.tar.bz2
   sha256: 53b960dc320a73701d8faf90316a203b01b294e0a7235c7bf49bb853d71b2214
   md5: 7a196bd419ee0f888fbbe0e6d449adda
   license: BSD-2-Clause
   license_family: BSD
   size: 812727
   timestamp: 1688746099942
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py310hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py310hcec6c5f_0.tar.bz2
   sha256: e2d11b07b8139917def31e4f4c1318396eae6762e18c771851cbebfe628cb157
   md5: e3f9f6c8343ecf7dc8f311670be764fc
   depends:
@@ -5279,7 +5279,7 @@ packages:
   license_family: MIT
   size: 2068510
   timestamp: 1690905208269
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2023.4.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/distributed-2023.4.1-py310hecd8cb5_0.tar.bz2
   sha256: 61e957bef53b5ccc161c7f71e56ecc76c613d40374febf0eec5c506cb990dc0e
   md5: c31a0ee860acbd0be86f2ebda86e2704
   depends:
@@ -5305,7 +5305,7 @@ packages:
   license_family: BSD
   size: 1379922
   timestamp: 1683556840173
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py310hecd8cb5_0.tar.bz2
   sha256: 670e9476a114ca61020f1a69803661de5cc6f01a26296a4c73bbbda94164dc4e
   md5: 12f8f558c520d5a1e25ba2967edbee89
   depends:
@@ -5314,7 +5314,7 @@ packages:
   license_family: MIT
   size: 16685
   timestamp: 1649926502410
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.2.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.2.0-py310hecd8cb5_0.tar.bz2
   sha256: a31f9c19d1b9f9355dee09bc356853ee2c9b4ffc99525810a7189e3d148c2c18
   md5: 36fd0124a6a901c880c4f80087db5803
   depends:
@@ -5323,7 +5323,7 @@ packages:
   license_family: MIT
   size: 30923
   timestamp: 1706031435284
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/flatbuffers-24.3.25-h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/flatbuffers-24.3.25-h6d0c2b6_0.tar.bz2
   sha256: 5a7d31b98c5bef5ec69c8fac1f65f37aa902abd79f2ced30a1b97ede78d8c5cd
   md5: 74a35f3fc8ab05237ed1115133deff47
   depends:
@@ -5332,7 +5332,7 @@ packages:
   license_family: Apache
   size: 1804196
   timestamp: 1722872846711
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py310h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fonttools-4.51.0-py310h6c40b1e_0.tar.bz2
   sha256: c9d3ce30bb1d76c60769c427ac10e11fb46dd786eaad50eca9698cbc4055335b
   md5: 2a5cf7b319b1843d17877335fe3c4c89
   depends:
@@ -5350,7 +5350,7 @@ packages:
   license_family: MIT
   size: 2643483
   timestamp: 1713551859857
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -5360,7 +5360,7 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/frozenlist-1.5.0-py310h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/frozenlist-1.5.0-py310h46256e1_0.tar.bz2
   sha256: 83e4ed3ef61dae0a57d76b1762746c55cb5ffd4267cb46dd46c9548dc75e4a5f
   md5: a1abaef83d8b237d1caabf6061ab733d
   depends:
@@ -5369,7 +5369,7 @@ packages:
   license_family: Apache
   size: 58834
   timestamp: 1730902924249
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.6.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fsspec-2024.6.1-py310hecd8cb5_0.tar.bz2
   sha256: b79899461d51593df6bd8e14d4131e0711ee6e31c4b641fdd132b241fb6104d2
   md5: 2619cd07314d8884c72c61c0b7af0048
   depends:
@@ -5380,14 +5380,14 @@ packages:
   license_family: BSD
   size: 289204
   timestamp: 1724855637052
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.2-h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.2-h46256e1_0.tar.bz2
   sha256: 872ab46bcd652b2381a4a1ee9de3f4399ce089a42959a7df052546aa3886d9ae
   md5: a7bd95201a6e2c91bb5fef9765426123
   license: MIT
   license_family: MIT
   size: 80346
   timestamp: 1728656386686
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/google-auth-2.29.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/google-auth-2.29.0-py310hecd8cb5_0.tar.bz2
   sha256: 5acdf3d75cfc68e4450fd95b30c7ec632a2be349eb5668dfaf9af26244850192
   md5: 6b2a3cfed208598128b9d104aef903fc
   depends:
@@ -5405,7 +5405,7 @@ packages:
   license_family: Apache
   size: 215667
   timestamp: 1715111522911
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/google-auth-oauthlib-0.5.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/google-auth-oauthlib-0.5.2-py310hecd8cb5_0.tar.bz2
   sha256: 2d7a3d61e520c7572f8d7cf2411f60912b9aac7e5c1988a463152baf7aa4bb74
   md5: 650ead0b51caed49cbdbdd817864c6cb
   depends:
@@ -5417,7 +5417,7 @@ packages:
   license_family: Apache
   size: 28214
   timestamp: 1660687937774
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/grpc-cpp-1.48.2-h3afe56f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/grpc-cpp-1.48.2-h3afe56f_0.tar.bz2
   sha256: 2b96ce3762184c824178323ee109e4b1a72b9fb0e7a7d6d11e44b875e8c46eea
   md5: a28f3cd1a5385e8effcde5dafd84fb7e
   depends:
@@ -5433,7 +5433,7 @@ packages:
   license_family: APACHE
   size: 4015834
   timestamp: 1681912883786
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/grpcio-1.48.2-py310h3afe56f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/grpcio-1.48.2-py310h3afe56f_0.tar.bz2
   sha256: a6a94917acda4a140fde8f640bd37e32b1eaf6cab05a76e87187a6d25ae85f4f
   md5: 9ec6202ebe4e4437047abab31bbaaa5c
   depends:
@@ -5446,7 +5446,7 @@ packages:
   license_family: APACHE
   size: 769339
   timestamp: 1681912996533
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/h11-0.14.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/h11-0.14.0-py310hecd8cb5_0.tar.bz2
   sha256: 8e96e00df805d033780a3f98d5600b24206256a95f3678fba5192d14b4b7e280
   md5: 1251b99eae3e9d95668817f315a23cd0
   depends:
@@ -5455,7 +5455,7 @@ packages:
   license_family: MIT
   size: 85463
   timestamp: 1706652358247
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/h5py-3.12.1-py310ha611a00_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/h5py-3.12.1-py310ha611a00_0.tar.bz2
   sha256: b781726961625f671b5be5e1ad753c0a8d8010dd82550dba8f818bfff536f68f
   md5: c9a952f4f564c62ebf4476decf7f8615
   depends:
@@ -5467,7 +5467,7 @@ packages:
   license_family: BSD
   size: 1431283
   timestamp: 1730216399655
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf4-4.2.13-h39711bb_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/hdf4-4.2.13-h39711bb_2.tar.bz2
   sha256: 85d7f9697d1243b5d088737a3f5c43610f01250f78e9a9fa9da6cca7830d73cf
   md5: 637b7dadcfe411e14233764fd1d820a3
   depends:
@@ -5478,7 +5478,7 @@ packages:
   license_family: BSD
   size: 895428
   timestamp: 1510863932515
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/hdf5-1.12.1-h2b2ad87_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/hdf5-1.12.1-h2b2ad87_2.tar.bz2
   sha256: ec075bff8c2c519e43c9379fbdf37d8c3f00e8893ece3423c7696bc3b51d99c2
   md5: fbcb090a7d99f1260eaf4b028bbcc3fb
   depends:
@@ -5491,7 +5491,7 @@ packages:
   license_family: BSD
   size: 5828704
   timestamp: 1655307864829
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.17.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.17.1-py310hecd8cb5_0.tar.bz2
   sha256: 4d89c45e4f6ca1b63f69d7dcccbd5934b060e13c5d2711ecf25ea6022af473b8
   md5: 9eabc7dbf073a8276ef1b5c40bf56982
   depends:
@@ -5508,7 +5508,7 @@ packages:
   license_family: BSD
   size: 4626418
   timestamp: 1693378265446
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/httpcore-1.0.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/httpcore-1.0.2-py310hecd8cb5_0.tar.bz2
   sha256: 4bf99d699c01388de049f2b813bfd2eb89156eda3455d92baff65a10739c9f50
   md5: a683b4f2d20ddd1bd8952a98fdbb6ca2
   depends:
@@ -5519,7 +5519,7 @@ packages:
   license_family: BSD
   size: 85818
   timestamp: 1706728554495
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/httpx-0.27.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/httpx-0.27.0-py310hecd8cb5_0.tar.bz2
   sha256: eac7150b0508a3ecb0f27ec1ff7b22283f2714da57d564bdeae06a6d6b960981
   md5: 6a8828803dd5bbababf8a148e062fafd
   depends:
@@ -5539,7 +5539,7 @@ packages:
   license_family: BSD
   size: 160890
   timestamp: 1723475052162
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-68.1-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/icu-68.1-h23ab428_0.tar.bz2
   sha256: 80ec818f553a590767f03a15cec450370445c41f469d1fcf1c495521ac36a71a
   md5: aa8486cbdfa5f499508f682a55ce8493
   depends:
@@ -5547,7 +5547,7 @@ packages:
   license: MIT
   size: 25926885
   timestamp: 1611658753217
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py310hecd8cb5_0.tar.bz2
   sha256: c21b5d635595e087aa1135dd3b6dca63054aff33d58d70100c0b0f6648d0dae3
   md5: b548aefceda441a37555005da1b9a4c8
   depends:
@@ -5556,7 +5556,7 @@ packages:
   license_family: BSD
   size: 140710
   timestamp: 1714398998249
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/imagecodecs-2023.1.23-py310hd1bf5dc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/imagecodecs-2023.1.23-py310hd1bf5dc_0.tar.bz2
   sha256: cc9676095a87b48ba60d7a84c29466c0d53569ea85d46f5a095d13787073df2c
   md5: 7e40dba61443d45bba6ea3f77c428253
   depends:
@@ -5594,7 +5594,7 @@ packages:
   license_family: BSD
   size: 10149468
   timestamp: 1695065149592
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/imageio-2.33.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/imageio-2.33.1-py310hecd8cb5_0.tar.bz2
   sha256: ddf20cea03f79a930b341414e768474b7e2da7335adf0a10d2a045572f587500
   md5: 4b960148228834804ec7b2501fa886e5
   depends:
@@ -5605,7 +5605,7 @@ packages:
   license_family: BSD
   size: 524979
   timestamp: 1707247322058
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-8.5.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-8.5.0-py310hecd8cb5_0.tar.bz2
   sha256: 0cf6ad6ad79abd553bf7362650560a0c564d679c2cf829ed35d54d8704c56bc6
   md5: d21a65f36f7f407f0402139dadeca742
   depends:
@@ -5615,7 +5615,7 @@ packages:
   license_family: APACHE
   size: 46503
   timestamp: 1732633599047
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intake-0.7.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intake-0.7.0-py310hecd8cb5_0.tar.bz2
   sha256: 9a106978d505c4409b49a15a183d6ae7a32602da96fc4bd01c1c2656799c8cbc
   md5: cc1f050fac3df4f8bc1292e88be573e8
   depends:
@@ -5638,7 +5638,7 @@ packages:
   license_family: BSD
   size: 199489
   timestamp: 1717514211356
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intake-xarray-0.7.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intake-xarray-0.7.0-py310hecd8cb5_0.tar.bz2
   sha256: d54aca55cd2299b2ef6eead765bcf30209b1bf808c783f4854a520a75ae8d7df
   md5: c3ea834a6911fc9c5acfea93efacb292
   depends:
@@ -5655,7 +5655,7 @@ packages:
   license_family: BSD
   size: 69287
   timestamp: 1717524037777
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.29.5-py310hecd8cb5_0.tar.bz2
   sha256: d0034278e28af70fbfcafa79e3883e675f819080afb4ba2611b4ce8ee4062e93
   md5: 795107da24edcf2cc3e36abef3523f66
   depends:
@@ -5677,7 +5677,7 @@ packages:
   license_family: BSD
   size: 192736
   timestamp: 1728666308586
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.27.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.27.0-py310hecd8cb5_0.tar.bz2
   sha256: 11383b9a268f6358aeed082f32b92a604daf3a8bd539c291a153d70bb5b112aa
   md5: 2992e217939521408ea664720771cb36
   depends:
@@ -5696,7 +5696,7 @@ packages:
   license_family: BSD
   size: 1291648
   timestamp: 1726064675161
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipywidgets-8.1.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipywidgets-8.1.2-py310hecd8cb5_0.tar.bz2
   sha256: dd2436bbba06d47b068791a78026eda38ca5d17fa07bd57605344f2893086be4
   md5: 26afb0e73c8c87ebdd4cbe254a6f2751
   depends:
@@ -5710,7 +5710,7 @@ packages:
   license_family: BSD
   size: 202266
   timestamp: 1709574940050
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.19.1-py310hecd8cb5_0.tar.bz2
   sha256: 437f78774eacfc35aedccd62f280e9c498ea8dca1ffbc49c6afb9a13b525e43f
   md5: 0315d326448f640bac44a5979f63fbc2
   depends:
@@ -5720,7 +5720,7 @@ packages:
   license_family: MIT
   size: 1057713
   timestamp: 1721058639924
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py310hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.4-py310hecd8cb5_1.tar.bz2
   sha256: 2f1416ee252096862b756d814a5029581534f2fff53ed02c58ed0c2b02725a26
   md5: e4b59989e70ab1052c4e3a68b8703a49
   depends:
@@ -5732,7 +5732,7 @@ packages:
   license_family: BSD
   size: 279013
   timestamp: 1730903083312
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jmespath-1.0.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jmespath-1.0.1-py310hecd8cb5_0.tar.bz2
   sha256: c435150f2b9b6a5206880c109ddb175270e36f47f088efd218fca2fd3e37f7c0
   md5: 05eb2907953e7999990fa2c3926a90a2
   depends:
@@ -5741,14 +5741,14 @@ packages:
   license_family: MIT
   size: 38480
   timestamp: 1700144671754
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
   sha256: 855982a798d9af8e70635a250528a5da3b2b0cf7095e2804858caf139c8a239b
   md5: 112a5602fe42a84a5bafa038abeddf4f
   license: IJG
   license_family: Other
   size: 279686
   timestamp: 1722872676718
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/json5-0.9.25-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/json5-0.9.25-py310hecd8cb5_0.tar.bz2
   sha256: bd18cb467f77e52ab27ffacadc51956b97edb120bb01afff59a4bc28166478dd
   md5: 4826d02e10feebdb6cc44662aa98bb9b
   depends:
@@ -5757,7 +5757,7 @@ packages:
   license_family: Apache
   size: 46852
   timestamp: 1730787019860
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.23.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.23.0-py310hecd8cb5_0.tar.bz2
   sha256: a9bdf7c56d6a18d3296901290f6262a73a5e150f710b6b913bed1166619ca123
   md5: d645418dd0292953837fec13d110014e
   depends:
@@ -5770,7 +5770,7 @@ packages:
   license_family: MIT
   size: 146358
   timestamp: 1728486784215
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py310hecd8cb5_0.tar.bz2
   sha256: b61904f8e4c3d1726f4bbec37d1edfd69a989cab0098cfa9c422d2cf9f49ba78
   md5: 221013125db975c3b57e7ebc93e73b2a
   depends:
@@ -5780,7 +5780,7 @@ packages:
   license_family: MIT
   size: 15941
   timestamp: 1699032432155
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter-lsp-2.2.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter-lsp-2.2.0-py310hecd8cb5_0.tar.bz2
   sha256: c0284cfa23bdf14449ba0eb9960264874138891e23c25beda1cc2204a00124a6
   md5: 31d8bfed557da32b2a4750a435b42858
   depends:
@@ -5790,7 +5790,7 @@ packages:
   license_family: BSD
   size: 82418
   timestamp: 1699978366719
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-8.6.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-8.6.0-py310hecd8cb5_0.tar.bz2
   sha256: 0e06b7af87feec4cb389ffcfb83233e552fe1ece4e6b2c03ce8db0f1b42b9698
   md5: e23a81954301a751d94a2d9e686dcb60
   depends:
@@ -5804,7 +5804,7 @@ packages:
   license_family: BSD
   size: 173889
   timestamp: 1699456828052
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.7.2-py310hecd8cb5_0.tar.bz2
   sha256: 8344dde53b622d2ebbdacbaa85422a3d0a97493f5915c6f2a27a74add7ab1482
   md5: b771da116ff7a21cd82eb99667d5ef21
   depends:
@@ -5815,7 +5815,7 @@ packages:
   license_family: BSD
   size: 83932
   timestamp: 1718818490484
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.10.0-py310hecd8cb5_0.tar.bz2
   sha256: 3a2e00b1914f2b34344d85a1189176ab5f52a5d89a1796ce7f2b97e16c65615d
   md5: 357a1f12e89ec1be00e3b83db0e564fd
   depends:
@@ -5831,7 +5831,7 @@ packages:
   license_family: BSD
   size: 36897
   timestamp: 1718738309903
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.14.1-py310hecd8cb5_0.tar.bz2
   sha256: f5c82bb1d90d7cc60f0dec96e3441dd8a79d28251bfdf340dd4b99cf58fe275d
   md5: d8a2d165f4ea882ed88eb8442c1c29c9
   depends:
@@ -5858,7 +5858,7 @@ packages:
   license_family: BSD
   size: 512338
   timestamp: 1718827525582
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py310hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py310hecd8cb5_1.tar.bz2
   sha256: de99cb9520ae626ef84d929e46fbec2f944cde776405ee337a36246f0aa2b946
   md5: 6435c2a1ce645abc13359bbec1eda7d1
   depends:
@@ -5868,7 +5868,7 @@ packages:
   license_family: BSD
   size: 24670
   timestamp: 1686870766255
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab-4.2.5-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyterlab-4.2.5-py310hecd8cb5_0.tar.bz2
   sha256: 81f4c8331608530d96d3626665c9a17df4e0991093eb3bbecde10bb8c306407e
   md5: ba857485deb03a0f2d5b417f20f8416d
   depends:
@@ -5893,7 +5893,7 @@ packages:
   license_family: BSD
   size: 8261913
   timestamp: 1725896789318
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_server-2.27.3-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyterlab_server-2.27.3-py310hecd8cb5_0.tar.bz2
   sha256: bd1e65ba93d07e22dfb980e159d7d29c88dd39b1afe7cdba403268300b2767f4
   md5: c9b2a29f715bc7727e5916412d60fff3
   depends:
@@ -5911,7 +5911,7 @@ packages:
   license_family: BSD
   size: 84339
   timestamp: 1725865455369
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_widgets-3.0.10-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyterlab_widgets-3.0.10-py310hecd8cb5_0.tar.bz2
   sha256: 80528ee104798f31be0d7fd315ca6035533756ab1d8a905520be4ce05f4c258a
   md5: adc11a6587b9ccc7d6aa78323c6b174d
   depends:
@@ -5922,14 +5922,14 @@ packages:
   license_family: BSD
   size: 192542
   timestamp: 1709323065620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jxrlib-1.1-haf1e3a3_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jxrlib-1.1-haf1e3a3_2.tar.bz2
   sha256: 63b4b4e81998da78bf9a1625d122faa6aa7514f6e3c975043432da346b9a566d
   md5: 1e527af8be0e202b459293a8a5c76c87
   license: BSD-2-Clause
   license_family: BSD
   size: 230086
   timestamp: 1593197454386
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/keras-2.12.0-py310_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/keras-2.12.0-py310_0.tar.bz2
   sha256: a169e19ebd1314f9812d18c2df659654d005249f369f42e92d55542362bd824c
   md5: 619f00c7c2030f7d4a56a4c7144e1606
   depends:
@@ -5940,7 +5940,7 @@ packages:
   license: Apache-2.0
   size: 2271288
   timestamp: 1683570891666
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py310hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py310hcec6c5f_0.tar.bz2
   sha256: bde3b255886d59e9af9450489ba42e205865a223ec48c4bd3396405480715c97
   md5: f4ed6fff2814558c3b717017465d8e2a
   depends:
@@ -5950,7 +5950,7 @@ packages:
   license_family: BSD
   size: 65413
   timestamp: 1672387282474
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
   sha256: 8093a64350665d16ca2ad0acfcbba5c84b479c316a40db6b9d5f9b84b58f3b12
   md5: cd98cc17f8297a31b1dd62f061ea4f83
   depends:
@@ -5961,7 +5961,7 @@ packages:
   license_family: MIT
   size: 1289465
   timestamp: 1686931250022
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lazy_loader-0.4-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lazy_loader-0.4-py310hecd8cb5_0.tar.bz2
   sha256: 303fbe650dd1f21f60fae30eb67a15d15d141ce60ccf74d47b3c18ffbea57425
   md5: 26f5dcc87e1cee5b8eddfa7d0882e5d4
   depends:
@@ -5971,7 +5971,7 @@ packages:
   license_family: BSD
   size: 21960
   timestamp: 1718176894987
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -5981,7 +5981,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -5990,7 +5990,7 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libaec-1.0.4-hb1e8313_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libaec-1.0.4-hb1e8313_1.tar.bz2
   sha256: 2a9313912b9b3ea0d306a46e20df93f7fc79bce35e895e0cb98b8cdc068e2652
   md5: ebfa53511162e3172aa14fbd37e3ed5d
   depends:
@@ -5999,7 +5999,7 @@ packages:
   license_family: BSD
   size: 28397
   timestamp: 1593198224738
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libavif-0.11.1-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libavif-0.11.1-h6c40b1e_0.tar.bz2
   sha256: 69303ebcb28fdfcdee4190da926cc7118bff28f96be9e6e5dd92f45e8302d711
   md5: dfe44f56908bc60af820824d24d634c4
   depends:
@@ -6009,13 +6009,13 @@ packages:
   license_family: BSD
   size: 98857
   timestamp: 1689158151760
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 685c3bc9068bd485604b80bf03789e4dca95c410d33871bc1b882e47649fabed
   md5: 6cf8e55271e150ca0961d0ddedaa61bb
   license: MIT
   size: 66237
   timestamp: 1714483284541
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 69826cee54db9955f0120af21ec36d13f9211877fd67364f2068d0a54c6c97cd
   md5: 0851917257f490d35e1f73da8a1c723c
   depends:
@@ -6023,7 +6023,7 @@ packages:
   license: MIT
   size: 34042
   timestamp: 1714483343147
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 3f5a1f03b50b90b397a0ee432ad0cba13354abdaf7e5652c0fc60164b26a08b6
   md5: a50bdc871ef4bf14deb088d888b92b5e
   depends:
@@ -6031,7 +6031,7 @@ packages:
   license: MIT
   size: 311597
   timestamp: 1714483371586
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
   sha256: 83cf762f0d09c97dfb4a1c1cd9e635de2e54c384b057afbf3c0e2e8db07d862f
   md5: ae3a458da93940fea1fa83af80d91fd4
   depends:
@@ -6046,21 +6046,21 @@ packages:
   license_family: MIT
   size: 358556
   timestamp: 1693515516157
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
   sha256: e84e6cbacb12de6fe86955449502d3956696ae583060d0d4911ea6f503cfb9ad
   md5: 1d200c536be4172db41c49e81a3e6350
   depends:
@@ -6069,21 +6069,21 @@ packages:
   license_family: BSD
   size: 169586
   timestamp: 1703006265367
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
   sha256: 4786264321edbff780633a5b752995eb3193ca4bce11b0fda179577f6cf1102c
   md5: 849fdd014c201a9d2c2aa7c7db38a778
   license: BSD-2-Clause
   license_family: BSD
   size: 103993
   timestamp: 1632891571494
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
   sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
   md5: 822a5b76117e56d3912f1f2153307528
   license: MIT
   license_family: MIT
   size: 136045
   timestamp: 1714483561919
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
   sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
   md5: e458587c87e3f2d20192f4e0738f2c63
   depends:
@@ -6092,7 +6092,7 @@ packages:
   license_family: GPL
   size: 149419
   timestamp: 1665498987619
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
   sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
   md5: 1058b661ec829b2ee3716ee2a5520641
   depends:
@@ -6103,7 +6103,7 @@ packages:
   license_family: GPL
   size: 1917987
   timestamp: 1665498925405
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnetcdf-4.8.1-h9c0abef_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libnetcdf-4.8.1-h9c0abef_4.tar.bz2
   sha256: 549522f9e180785b2b8a8dc40fb1552007a1b435afd9371e282b17994bb07573
   md5: ed1ad56182673d8b2d4944c926a91e1d
   depends:
@@ -6118,7 +6118,7 @@ packages:
   license_family: BSD
   size: 1530796
   timestamp: 1691154667607
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
   sha256: 331bc731419328a873e1a48d4257c58baa33d73b4b91ff7a3553b1c122120fb1
   md5: 43fba990695db8556ddd0ade21d59ecc
   depends:
@@ -6133,7 +6133,7 @@ packages:
   license_family: MIT
   size: 782018
   timestamp: 1686931556261
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
   sha256: 499ebc9000c8e810081b5d7f7524b45dc99f6914096ea9e145366033514938b4
   md5: ce5c24f93932e1a53d7d89e502f28783
   depends:
@@ -6144,7 +6144,7 @@ packages:
   license_family: BSD
   size: 10123989
   timestamp: 1664896966769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -6153,7 +6153,7 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
   sha256: 1884de5207f5a1210217d7132348b4944ec4b09a91085b7b47a19dfdd9b6dbba
   md5: aa960ea0133deec4637a8d05700cc3c4
   depends:
@@ -6163,13 +6163,13 @@ packages:
   license_family: BSD
   size: 2412437
   timestamp: 1675278748544
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
   sha256: 8b1adbb78b6283c3d8df932d5aa7e8e249351aa1e206ba2949ee86052912e83f
   md5: 2e035c81c044bff1224224ac24161dfd
   depends:
@@ -6178,7 +6178,7 @@ packages:
   license_family: BSD
   size: 338461
   timestamp: 1686931232629
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -6195,7 +6195,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
   sha256: 246c0d82766042c1a9194eecc71690918c68afa3528ff0c2c82796ce901df40b
   md5: f33be4ed3bff89ed8f68df6c75158510
   constrains:
@@ -6204,7 +6204,7 @@ packages:
   license_family: BSD
   size: 449215
   timestamp: 1729160070984
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libzip-1.8.0-h272c8d6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libzip-1.8.0-h272c8d6_0.tar.bz2
   sha256: c575e9b13e704c531dab91ce87676d5a336c982273e5a361e42073b9e5817738
   md5: 5d543db811d31c7e5703726639d034d3
   depends:
@@ -6217,7 +6217,7 @@ packages:
   license_family: BSD
   size: 123384
   timestamp: 1652978539298
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libzopfli-1.0.3-hb1e8313_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libzopfli-1.0.3-hb1e8313_0.tar.bz2
   sha256: 1d727042cefd5fdc1eb1b5735ccb19b15ab0837e0b3c4a96841ebcd4143d31e9
   md5: 2dffb55c068fb1561d870b5543b7966e
   depends:
@@ -6226,7 +6226,7 @@ packages:
   license_family: Apache
   size: 162388
   timestamp: 1593197747824
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
   sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
   md5: 5c740b4a18a558de0ccfe601703c423c
   constrains:
@@ -6235,7 +6235,7 @@ packages:
   license_family: Apache
   size: 338738
   timestamp: 1662635677689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py310hecd8cb5_0.tar.bz2
   sha256: ef2cc69591855744d4c5d1aeb6b325d0f9886404709cba541be075fe6f696fd5
   md5: 46e2880168e6de564dd817fde7bf07b1
   depends:
@@ -6244,7 +6244,7 @@ packages:
   license_family: BSD
   size: 11932
   timestamp: 1652903221378
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
   sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
   md5: 8f57dc3a3327bb6f7e1cba908856ac7f
   depends:
@@ -6253,7 +6253,7 @@ packages:
   license_family: BSD
   size: 183138
   timestamp: 1714510756758
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py310hecd8cb5_0.tar.bz2
   sha256: bc2f8a9d82b05e7d2e9da576d86565f085b18ad824a61729c808a35d9aa899ae
   md5: 2b5c8d5d297342184b21138a02a4cec1
   depends:
@@ -6262,7 +6262,7 @@ packages:
   license_family: BSD
   size: 124321
   timestamp: 1671541949029
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py310h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py310h6c40b1e_0.tar.bz2
   sha256: 57e19ade13338cbe335ab420e8f5e34e5f37c7d7093a9382a4609289b08ac0a6
   md5: 2860d43ce7cdd7b1c9ce80e2ef57bbfb
   depends:
@@ -6273,7 +6273,7 @@ packages:
   license_family: BSD
   size: 23492
   timestamp: 1704206268961
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.9.2-py310h919b35b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.9.2-py310h919b35b_1.tar.bz2
   sha256: 6ad9c2902379e1c17df2483396ce7dfc701fe5ccc1ca6bf2b06e8d02607e5617
   md5: 2bce437e3808bb5f5b6d683d22f55616
   depends:
@@ -6293,7 +6293,7 @@ packages:
   license_family: PSF
   size: 8456937
   timestamp: 1732551251431
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py310hecd8cb5_0.tar.bz2
   sha256: b0b7bf33159ad955ac6503e0008bb4f6d42a431d39750d8748f1cfd437c33982
   md5: 95dcb73cba7ccc8d9d54ded71c43f200
   depends:
@@ -6303,7 +6303,7 @@ packages:
   license_family: BSD
   size: 17405
   timestamp: 1662014515076
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py310hecd8cb5_0.tar.bz2
   sha256: 5aacf8dd7d920d1ed998a1c94bdd1554b4f9dc7c7f34ed2901a065ac97189633
   md5: 7da6eae2686cd9f630948ac7346b101e
   depends:
@@ -6314,7 +6314,7 @@ packages:
   license_family: BSD
   size: 91001
   timestamp: 1661496330569
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py310haf03e11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/msgpack-python-1.0.3-py310haf03e11_0.tar.bz2
   sha256: be629ed3ab7b02726b5c59ce24ec083091815b0379f7103e8c1d425a6e7a14c8
   md5: 303d215b320300b4131f786e9f446354
   depends:
@@ -6324,7 +6324,7 @@ packages:
   license_family: Apache
   size: 89322
   timestamp: 1652362730842
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/multidict-6.1.0-py310h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/multidict-6.1.0-py310h46256e1_0.tar.bz2
   sha256: 9fd653a1bdc9e9e7007e4499a0e534fdd69e8108af2d081f78de400950484c9a
   md5: 415e11946d5db88000696bcc4e7e4849
   depends:
@@ -6334,7 +6334,7 @@ packages:
   license_family: Apache
   size: 52321
   timestamp: 1730905624850
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py310hecd8cb5_0.tar.bz2
   sha256: 7ada341fb8fe36d073cdc35c3767a7e61d9e841fda878863d8ff3420187bde18
   md5: 8132292734c29e95e96f0da876848cff
   depends:
@@ -6347,7 +6347,7 @@ packages:
   license_family: BSD
   size: 101440
   timestamp: 1698934309840
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.4-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.16.4-py310hecd8cb5_0.tar.bz2
   sha256: 3746cedb6eb0ae41472c8a4324cfaf38eab56e798dc980315ba7ed262e9c4629
   md5: 6b869c871807ba7c73ee4d92ea658edc
   depends:
@@ -6374,7 +6374,7 @@ packages:
   license_family: BSD
   size: 491703
   timestamp: 1728050330988
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.10.4-py310hecd8cb5_0.tar.bz2
   sha256: 5002aeb376cc6933cc225bea4841515fb2b54704696e3065610996f05750224e
   md5: e2a7b4c2bb90517f0a29ad683c4c1e56
   depends:
@@ -6387,14 +6387,14 @@ packages:
   license_family: BSD
   size: 149697
   timestamp: 1728049994459
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py310hecd8cb5_0.tar.bz2
   sha256: cc408a3c4fb28427161701204d608cbb03b5cbd1d4560f61b03a3aadd35fa9a5
   md5: e1eae3de565ba8e2f102a67f9c425520
   depends:
@@ -6403,7 +6403,7 @@ packages:
   license_family: BSD
   size: 14541
   timestamp: 1708532847720
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/netcdf4-1.6.2-py310h2f655f6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/netcdf4-1.6.2-py310h2f655f6_0.tar.bz2
   sha256: 3b59ceb30c35a4eb9f6ec537b90ff081e3d30e197cd8a91d6b792981ed8483f0
   md5: 2e2b29016d6dc3b32e4f0be463fdb1ab
   depends:
@@ -6417,7 +6417,7 @@ packages:
   license_family: MIT
   size: 464549
   timestamp: 1673455785237
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.3-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/networkx-3.3-py310hecd8cb5_0.tar.bz2
   sha256: ff45ecd0347b3fd53f9b4263d5808b95c163b1adf8d62a93b70b95aeca1e06be
   md5: 52a8742cc97a5e0e2e4e731da3a5b2b4
   depends:
@@ -6435,7 +6435,7 @@ packages:
   license_family: BSD
   size: 2669099
   timestamp: 1720002535072
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-7.2.2-py310hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-7.2.2-py310hecd8cb5_1.tar.bz2
   sha256: 0b7f87d56591efb98842269cadfe3500af08c33c49c67550838fc2f3de48d268
   md5: 4aab198bbe2095fe43f0f9146c76799c
   depends:
@@ -6449,7 +6449,7 @@ packages:
   license_family: BSD
   size: 4398130
   timestamp: 1727197706687
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py310hecd8cb5_0.tar.bz2
   sha256: f9aad740019a0ff1bddebf5e6e0ae1e6cdb08eb3d2e99bf8d6b74f4482520a94
   md5: c8771901013965363a841841df348f24
   depends:
@@ -6459,7 +6459,7 @@ packages:
   license_family: BSD
   size: 23551
   timestamp: 1699455945439
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numcodecs-0.12.1-py310h2d76c9a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numcodecs-0.12.1-py310h2d76c9a_0.tar.bz2
   sha256: 0e85ad6f16c0698374a7c65a39aa910eaf96fd93b12336d939ff1d7ab66a735c
   md5: 124f0f570043d25cbd17b405c844bb0c
   depends:
@@ -6473,7 +6473,7 @@ packages:
   license_family: MIT
   size: 416888
   timestamp: 1707513897278
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.10.1-py310hc59c7be_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.10.1-py310hc59c7be_0.tar.bz2
   sha256: 13fc982a7cf1ceba54d9ffbe982e2104cef2879d63fd95199ede5604242a3309
   md5: 060059eed81a5e61e38c87a293abefff
   depends:
@@ -6487,7 +6487,7 @@ packages:
   license_family: MIT
   size: 175288
   timestamp: 1730216121865
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.23.5-py310he50c29a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.23.5-py310he50c29a_0.tar.bz2
   sha256: 5ab763b590c016d7aeb360a5c57787d47e77237c600ad4a96e3f0351a0001d1e
   md5: 7a9442612db36f2621ace2671614674d
   depends:
@@ -6500,7 +6500,7 @@ packages:
   license_family: BSD
   size: 11000
   timestamp: 1672340772320
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.23.5-py310h992e150_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.23.5-py310h992e150_0.tar.bz2
   sha256: 5958f97ce24fbde3f9e93b937428c7b72d840cbd543e2808a50122ffd7dad49b
   md5: 0467866f98ef90b80b68a6a6a24b5a64
   depends:
@@ -6514,7 +6514,7 @@ packages:
   license_family: BSD
   size: 7146905
   timestamp: 1672340757059
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/oauthlib-3.2.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/oauthlib-3.2.2-py310hecd8cb5_0.tar.bz2
   sha256: 8142713c713cf69e619696d32cc5f86e24a13d7a8eb09d269355a038c037fc63
   md5: d559bf15dd2726ebac5960c9425cc756
   depends:
@@ -6526,7 +6526,7 @@ packages:
   license_family: BSD
   size: 235391
   timestamp: 1679489741306
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
   sha256: 401214a4763c79c2355b012b9f29e3cee097a598bb53e933acb6b98a2bb6614f
   md5: 3216c5f433643ee62a8d0672c3500320
   depends:
@@ -6537,7 +6537,7 @@ packages:
   license_family: BSD
   size: 535252
   timestamp: 1722872704730
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
   sha256: f95f5173ab2a4529b56ff90deec905dd53877250acedd3887fb289b721396009
   md5: 2ab1a555331747f19e4aa7a335e33a85
   depends:
@@ -6546,7 +6546,7 @@ packages:
   license_family: Apache
   size: 3665304
   timestamp: 1694465313538
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py310hecd8cb5_0.tar.bz2
   sha256: c7e6eeaed43f22e96664e0e3facadc1466824665cde18889fca81e9a3fc7b675
   md5: 91dd93c48df10568852a9186a64b5451
   depends:
@@ -6555,7 +6555,7 @@ packages:
   license_family: APACHE
   size: 31881
   timestamp: 1699371179971
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-24.1-py310hecd8cb5_0.tar.bz2
   sha256: bd279365a6a8b46e5e49433199c6774b77a49d9e3bf39c5de1dd47d3e80b59c2
   md5: 22dd9b7d0b24f8c12a83273b8c21f227
   depends:
@@ -6564,7 +6564,7 @@ packages:
   license_family: Apache
   size: 136951
   timestamp: 1720102132604
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.3-py310h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-2.2.3-py310h6d0c2b6_0.tar.bz2
   sha256: 14e53677a3508b18296bfd76d420ec19970f7ddcef13d48178d86f8c0b655eff
   md5: 451fd6cea9a9421d4efc3bd0867548a3
   depends:
@@ -6614,7 +6614,7 @@ packages:
   license_family: BSD
   size: 14269882
   timestamp: 1732736984966
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-0.14.3-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-0.14.3-py310hecd8cb5_0.tar.bz2
   sha256: c024318001df5cb61a2471404472419fb1169860cc40d4fe4580fda9a276fb65
   md5: 1bdd6ec8be5e22e252d93b0c1d482a5d
   depends:
@@ -6635,7 +6635,7 @@ packages:
   license_family: BSD
   size: 14717320
   timestamp: 1676379975819
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-1.13.0-py310hecd8cb5_0.tar.bz2
   sha256: 08f766f3c49a9b1bd0addb34fb0ce0739d319003aa4d7580d25b8b344b3dac8d
   md5: 7b31c764364be71df61cd206249ccae2
   depends:
@@ -6644,7 +6644,7 @@ packages:
   license_family: BSD
   size: 144060
   timestamp: 1684915450654
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py310hecd8cb5_0.tar.bz2
   sha256: a71b522bc4cafca4934aeaf25fd963e66ceb63c0820a4a15b77f60749672ebfc
   md5: 509208a9bb46aebc97c57884a55fbc01
   depends:
@@ -6658,7 +6658,7 @@ packages:
   license_family: BSD
   size: 37072
   timestamp: 1698702643219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-11.0.0-py310h9c91434_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-11.0.0-py310h9c91434_0.tar.bz2
   sha256: 07aff3aba3f6071e1099ee4d1fedc3b4877d53c2fb99d5a38c7c93033433ddfa
   md5: 28f0596f517d402f26e0cd88de857432
   depends:
@@ -6674,7 +6674,7 @@ packages:
   license_family: Other
   size: 817595
   timestamp: 1731595132617
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-24.2-py310hecd8cb5_0.tar.bz2
   sha256: f5ae0a762d0e860a6ee0d8b8218ec7734182bc03112c4e284c2e213df013b48b
   md5: 4e1286252d25151121998b7c295db58c
   depends:
@@ -6685,7 +6685,7 @@ packages:
   license_family: MIT
   size: 2340044
   timestamp: 1723484785736
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py310hecd8cb5_0.tar.bz2
   sha256: dd5966a641fed108397a18417e59eca23b954459d8dfaf1c2b02006147bf803a
   md5: 0ba5d202a0f8fa8addb28c3c5f411150
   depends:
@@ -6694,7 +6694,7 @@ packages:
   license_family: MIT
   size: 33266
   timestamp: 1692205694975
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.21.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.21.0-py310hecd8cb5_0.tar.bz2
   sha256: c33966b8f341dbb4505460d3ca2673524b92dff43b8bbe2b801b01d3ccef66eb
   md5: bb519736e07f713680cde9f924da50d3
   depends:
@@ -6703,7 +6703,7 @@ packages:
   license_family: Apache
   size: 91858
   timestamp: 1731959028260
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py310hecd8cb5_0.tar.bz2
   sha256: f3d00376a631252954b0c4dcc667d7b24a2f20d7e434e465c61ab7f89c8eb5e2
   md5: 3003cb05c26ea91342726f9abe687e10
   depends:
@@ -6715,7 +6715,7 @@ packages:
   license_family: BSD
   size: 600585
   timestamp: 1704404484772
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/propcache-0.2.0-py310h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/propcache-0.2.0-py310h46256e1_0.tar.bz2
   sha256: 3cb75f61a4cfc6c4e02c51037bdf0e9657215b081e0593ea14d93292f82d615f
   md5: 3aa937b8ed54f037de4ea73e782c250b
   depends:
@@ -6724,7 +6724,7 @@ packages:
   license_family: Apache
   size: 52564
   timestamp: 1732304105168
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/protobuf-3.20.3-py310hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/protobuf-3.20.3-py310hcec6c5f_0.tar.bz2
   sha256: fe182e77242e2f4399acee52914f2607fe9c11aca0d1897214596336d0a6ee9c
   md5: ae8a40c26f99db3fd5d4324eeac3ce65
   depends:
@@ -6736,7 +6736,7 @@ packages:
   license_family: BSD
   size: 317019
   timestamp: 1675281587244
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py310hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py310hca72f7f_0.tar.bz2
   sha256: 5a156c5d275cd9741ece740b8e0c73cf18ed8c6964fbbf8fe77c128477ee4e8d
   md5: a13323d851b7c615fe3c85924773d118
   depends:
@@ -6745,7 +6745,7 @@ packages:
   license_family: BSD
   size: 370312
   timestamp: 1656431483235
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py310hecd8cb5_0.tar.bz2
   sha256: 6f28fc0782ff0a1f9f44be058392efcda61a916f4687f0e349c6a0b633154a31
   md5: 89243bf420e88ab976e19b1a91228465
   depends:
@@ -6757,7 +6757,7 @@ packages:
   license_family: BSD
   size: 30981
   timestamp: 1675441597598
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py310hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py310hecd8cb5_1.tar.bz2
   sha256: 864b005b3d12d53740f42f89e7d3468b43917f6054b2a27d49d6a072a7269aae
   md5: 29606753a2e301fe9542067780a50ec1
   depends:
@@ -6766,7 +6766,7 @@ packages:
   license_family: BSD
   size: 1889082
   timestamp: 1684280018937
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyjwt-2.9.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyjwt-2.9.0-py310hecd8cb5_0.tar.bz2
   sha256: 73f3f672a54ff1fc8bb36230cc513ed7a651e440734aab1e53e5b1e7ad5f3023
   md5: 7e25e4402fe9cc58f8805608bc0905ec
   depends:
@@ -6777,7 +6777,7 @@ packages:
   license_family: MIT
   size: 77594
   timestamp: 1730787052859
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py310hecd8cb5_0.tar.bz2
   sha256: 487b805533d5b50277d9c89f51a3aa7e7b729c69da0405b226ba038d339bb8a5
   md5: 61b06079b67e16ce1867a92c96d863b4
   depends:
@@ -6787,7 +6787,7 @@ packages:
   license_family: Apache
   size: 95852
   timestamp: 1690223503122
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.2.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.2.0-py310hecd8cb5_0.tar.bz2
   sha256: 2900f7c5a4239523c79454eb49b084c4878a14663046547b3c23634d213f1828
   md5: f050a05a10a265c4c09705936b9fe3c8
   depends:
@@ -6796,7 +6796,7 @@ packages:
   license_family: MIT
   size: 427323
   timestamp: 1731445863523
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py310hecd8cb5_0.tar.bz2
   sha256: 7e7ad33a42ffc0cf30a64115bbf6a4fb77e6f4ff859b5cdc1c5af35e34a77a36
   md5: 8b1372e62747adb48891711705ecf67c
   depends:
@@ -6805,7 +6805,7 @@ packages:
   license_family: BSD
   size: 28205
   timestamp: 1642536392594
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.10.13-h218abb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.10.13-h218abb5_0.tar.bz2
   sha256: 111bbf33325fe7c8f99a1e2d11742568b247dd9ff27f54ecae3b66f018b25228
   md5: c808f26e8157b2ee908d7c0de3381763
   depends:
@@ -6824,7 +6824,7 @@ packages:
   license_family: PSF
   size: 14067764
   timestamp: 1694438857796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py310hecd8cb5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py310hecd8cb5_2.tar.bz2
   sha256: 7c48377410f36fe4c89693d59a4ade0440dd6fdf16ae1932eb46076efb1f04db
   md5: c70567e92a388519519e994567e2a653
   depends:
@@ -6834,7 +6834,7 @@ packages:
   license_family: BSD
   size: 290910
   timestamp: 1716495929291
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.20.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.20.0-py310hecd8cb5_0.tar.bz2
   sha256: 1824cbd95f76d8180c6de480c6471a685cf490ec52a5391d78f9d154b9b6f381
   md5: cc764d70876d00b055033f9589affac7
   depends:
@@ -6843,7 +6843,7 @@ packages:
   license_family: BSD
   size: 268904
   timestamp: 1731939855247
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-flatbuffers-24.3.25-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-flatbuffers-24.3.25-py310hecd8cb5_0.tar.bz2
   sha256: 70808e8addac8abd1be25265efa3197927b6552d39c17e3dbc2b5fa1cd5122cf
   md5: 6c2c8842691f616ea3355ea56868b59c
   depends:
@@ -6852,7 +6852,7 @@ packages:
   license_family: Apache
   size: 54651
   timestamp: 1722369262191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-json-logger-2.0.7-py310hecd8cb5_0.tar.bz2
   sha256: b6901329f8858d79779e9843632deb42a17b9c8ae5b54d05b46c3cdb3fff92d5
   md5: f9342fc2602715ba2b10f7bca83f2af6
   depends:
@@ -6861,7 +6861,7 @@ packages:
   license_family: BSD
   size: 16283
   timestamp: 1683823855507
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py310hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-lmdb-1.4.1-py310hcec6c5f_0.tar.bz2
   sha256: 1be9acec8525317f93da208b86531202cc206ed5d9c0faf4d888b62c82d04d9e
   md5: 40677cd4b50a2ca4b6d255f0c120e6af
   depends:
@@ -6871,7 +6871,7 @@ packages:
   license_family: Other
   size: 137271
   timestamp: 1682522501681
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-snappy-0.6.1-py310hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-snappy-0.6.1-py310hcec6c5f_0.tar.bz2
   sha256: 91d85c24a2589a1ad3c62db516cbc80540b8df00145757cf6c64cd07c79ad506
   md5: a6328c411df7f76d230289066e1c6c51
   depends:
@@ -6882,7 +6882,7 @@ packages:
   license_family: BSD
   size: 31509
   timestamp: 1670944005960
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py310hecd8cb5_0.tar.bz2
   sha256: a93ceba4f770df6ac7cd2d4ce9d6e576907a6f82ce26e611e97118f8e3a463fc
   md5: 210aef7186cc7ec518b958ff5f5be9c1
   depends:
@@ -6891,7 +6891,7 @@ packages:
   license_family: MIT
   size: 267763
   timestamp: 1713974515169
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py310hecd8cb5_0.tar.bz2
   sha256: 75bc3472ad099223406433761e03c124f6cdc66f6b7d1ef12ec3d36534cb7973
   md5: 1dca0ce5eeb9bb9fea1d39d443c393b8
   depends:
@@ -6903,7 +6903,7 @@ packages:
   license_family: BSD
   size: 61754
   timestamp: 1711137017218
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py310h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.2-py310h46256e1_0.tar.bz2
   sha256: e8721601f26109e9779eeb82cfacade26f10f0c389249a91532ff4ccdd573c5d
   md5: e70e174b046cf351add8e693633c6659
   depends:
@@ -6913,7 +6913,7 @@ packages:
   license_family: MIT
   size: 177213
   timestamp: 1728659110037
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-25.1.2-py310hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-25.1.2-py310hcec6c5f_0.tar.bz2
   sha256: 95afcf82e6cb8a488c724f7470bd5eb4c99aec6fc6ce9ad61a76128e5c0db00e
   md5: 87f0ec4489f81d8de4a2f836c1a39879
   depends:
@@ -6924,7 +6924,7 @@ packages:
   license_family: BSD
   size: 439367
   timestamp: 1705605242438
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
   sha256: c69f556df9a27328c56943f3b5918cbb953cfbca987e20394d823a6174781202
   md5: ab294ae71ecdfaa307a961cc71dd890d
   depends:
@@ -6932,7 +6932,7 @@ packages:
   license: BSD-3-Clause
   size: 205638
   timestamp: 1652449553607
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -6941,7 +6941,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py310hecd8cb5_0.tar.bz2
   sha256: c5e89495acc097c738e4dd7a26cdff24b6aa0ad82d6f0c6b9b3e7db242435894
   md5: 4278d32b0db8529403a6eb55703dc8ef
   depends:
@@ -6952,7 +6952,7 @@ packages:
   license_family: MIT
   size: 59367
   timestamp: 1699012203616
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py310hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.32.3-py310hecd8cb5_1.tar.bz2
   sha256: 0a86a2ab459f70a126d51adc5e814b3ebeb7e87c14a0b3872259248fa0869145
   md5: 263c87e2d73c72044cf9297e1ddc5591
   depends:
@@ -6968,7 +6968,7 @@ packages:
   license_family: Apache
   size: 99686
   timestamp: 1730999360018
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-oauthlib-2.0.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-oauthlib-2.0.0-py310hecd8cb5_0.tar.bz2
   sha256: 3acb206ea8ad5d3107d6044122a62ab8ad8b1aacdb5b56a422f2ebbe3f1d796a
   md5: fae430f80c891b84fdcfc24e42050379
   depends:
@@ -6982,7 +6982,7 @@ packages:
   license_family: Other
   size: 35385
   timestamp: 1720615217974
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py310hecd8cb5_0.tar.bz2
   sha256: ecec0cef15dd4d80f2fa892b449e16041dace4ab669617ed9e2e6ee77d0873e4
   md5: 5b3b337fc9f8d9194cbead0e20fa0b99
   depends:
@@ -6992,7 +6992,7 @@ packages:
   license_family: MIT
   size: 9862
   timestamp: 1683077133588
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py310hecd8cb5_0.tar.bz2
   sha256: cc9d506a3f77d20dd2a3fc2567bfb0880a43bb110af639c134e18ec6bdecfaca
   md5: 5ba77c0b6356bda301de8c3d4e45a662
   depends:
@@ -7001,7 +7001,7 @@ packages:
   license_family: MIT
   size: 10239
   timestamp: 1683059221325
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py310h83de92b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py310h83de92b_1.tar.bz2
   sha256: eddfc9f5047b968e093ed75b3f8b38082c223e0bf2c623963b84d5a76b7da60c
   md5: 4942d45e45b775131c2a24ac6f499ca8
   depends:
@@ -7012,7 +7012,7 @@ packages:
   license_family: MIT
   size: 308745
   timestamp: 1732231215768
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/s3fs-2024.6.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/s3fs-2024.6.1-py310hecd8cb5_0.tar.bz2
   sha256: 73b4da402e726c56a7da9209a62e45b477cbdf541064764e9f8e4d80eeca9187
   md5: 5300feb0d19f308b09105d171e17ad7f
   depends:
@@ -7024,7 +7024,7 @@ packages:
   license_family: BSD
   size: 57137
   timestamp: 1724924263698
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scikit-image-0.24.0-py310h207f725_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/scikit-image-0.24.0-py310h207f725_0.tar.bz2
   sha256: 98fdf7fd065cfccd60f554fe6d2aad8c7587bdeb2a9f3d5ebb19f88cd2553662
   md5: 7cadaf9a0a579e827fb53cd28a0ea596
   depends:
@@ -7050,7 +7050,7 @@ packages:
   license_family: Other
   size: 12167512
   timestamp: 1726738212267
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.14.1-py310hb060737_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/scipy-1.14.1-py310hb060737_0.tar.bz2
   sha256: 0f06ac5574aff56a14ec9e881442ce54b80958c6365d50162a425b54903f9877
   md5: 0853979d6ef0b08691f52aa9ff49f75e
   depends:
@@ -7067,7 +7067,7 @@ packages:
   license_family: BSD
   size: 25377386
   timestamp: 1731623302362
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py310hecd8cb5_0.tar.bz2
   sha256: bf760a3e65821ac2ad5ab7b0c0dec75b2f49e6915796ecbebefc1d53096d8dc2
   md5: a434caaa43447f752cf108a5fd644d5a
   depends:
@@ -7076,7 +7076,7 @@ packages:
   license_family: BSD
   size: 28129
   timestamp: 1699371282429
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-75.1.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-75.1.0-py310hecd8cb5_0.tar.bz2
   sha256: c0ab38c46c050d3cea6d7ea798d8ef29ac7688b59a57734b5280fd3edaf0ac62
   md5: 7ba32807746a88a6b5846c1744ea8e1a
   depends:
@@ -7085,7 +7085,7 @@ packages:
   license_family: MIT
   size: 1774203
   timestamp: 1726677994849
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
   sha256: 9eaab5afd89c87ca139915589626785039fac30f05f8fb19e9eefe27eb935ce6
   md5: babdcd3370f85ded3d313902dcebecfb
   depends:
@@ -7094,7 +7094,7 @@ packages:
   license_family: BSD
   size: 46224
   timestamp: 1723557464934
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py310hecd8cb5_0.tar.bz2
   sha256: e0b8413f1bebc17ea35f3b4bc1e6a28dcc69db7f791ea80d31bfa8bdbd99023d
   md5: 9c9a20ac1397b11a4ffa611d253f83a4
   depends:
@@ -7103,7 +7103,7 @@ packages:
   license_family: Other
   size: 17891
   timestamp: 1705431327614
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py310hecd8cb5_0.tar.bz2
   sha256: 97a6ef8790155b089dc6c1c7559cac226dc8966fb7189276d43e56361fef921b
   md5: c5fe7f5450316dd0f7c407fc6d5c4590
   depends:
@@ -7112,7 +7112,7 @@ packages:
   license_family: MIT
   size: 67950
   timestamp: 1696347655636
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
   sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
   md5: 6bef1694163a68ac4c37e5857b8da4f5
   depends:
@@ -7124,7 +7124,7 @@ packages:
   license_family: Other
   size: 1900191
   timestamp: 1714488351925
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -7133,7 +7133,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tensorboard-2.12.1-py310_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tensorboard-2.12.1-py310_0.tar.bz2
   sha256: 29cbbc529c04aa40e10443f49b36671f5020afcb0da1df5699b5ef203959a0e8
   md5: 4e4abcfdd63f21af8110d2110b02ac65
   depends:
@@ -7155,7 +7155,7 @@ packages:
   license_family: Apache
   size: 5891790
   timestamp: 1683571007400
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tensorboard-data-server-0.7.0-py310hf1618be_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tensorboard-data-server-0.7.0-py310hf1618be_1.tar.bz2
   sha256: 4c876ff0af943d63259d88a7d646e2bab67e9f2abd6be98b0c05c61772932cf0
   md5: 0551f3684e34ebf2e80940602cbf1015
   depends:
@@ -7164,7 +7164,7 @@ packages:
   license_family: Apache
   size: 3866076
   timestamp: 1724172888075
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tensorflow-2.12.0-eigen_py310hccba712_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tensorflow-2.12.0-eigen_py310hccba712_0.tar.bz2
   sha256: 0a098125fef09c9a2f6ae7d37ac857c71a79fa3482a99740e32f7559a5de8b5e
   md5: e0d196d0b095a4a354d11216e2be8a68
   depends:
@@ -7177,7 +7177,7 @@ packages:
   license_family: Apache
   size: 4094
   timestamp: 1685995198524
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tensorflow-base-2.12.0-eigen_py310hbf87084_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tensorflow-base-2.12.0-eigen_py310hbf87084_0.tar.bz2
   sha256: a0c0f369e09a4a793adf97624fb2865f8cf966493cbfdcde8f85a49f08384275
   md5: 6e7df2a6f15a4bc867941dc52fdd541a
   depends:
@@ -7221,7 +7221,7 @@ packages:
   license_family: Apache
   size: 181129055
   timestamp: 1683853602403
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tensorflow-estimator-2.12.0-py310_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tensorflow-estimator-2.12.0-py310_0.tar.bz2
   sha256: 7f5a13aab9ced27b93d157325979b7b30d5481257357762be2009c55e9a412fa
   md5: 5550557f935cd4c6d996fcea74e5f898
   depends:
@@ -7232,7 +7232,7 @@ packages:
   license_family: Apache
   size: 616833
   timestamp: 1683571149997
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/termcolor-2.1.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/termcolor-2.1.0-py310hecd8cb5_0.tar.bz2
   sha256: ba0172a9b29962e55799e5686c72b8c59d3f66f9d62b50ca37aeed2ba792e163
   md5: 42e62eda291fe9c327ea3220358639d6
   depends:
@@ -7241,7 +7241,7 @@ packages:
   license_family: MIT
   size: 12029
   timestamp: 1668084678654
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py310hecd8cb5_0.tar.bz2
   sha256: 92b0454b4739557af9a8f52f040828cb343935e874144e25eebf620be61cfb85
   md5: 39fb00364e1ae13b9fc9af51c0540648
   depends:
@@ -7252,7 +7252,7 @@ packages:
   license_family: BSD
   size: 31114
   timestamp: 1671751965362
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tifffile-2023.4.12-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tifffile-2023.4.12-py310hecd8cb5_0.tar.bz2
   sha256: 1198a56e13316514c673ea7b1da4a9202a828fc06bd3519e1c46d1438abff681
   md5: 0074cbb4e2bd7ceb30dcfa126c91cdc2
   depends:
@@ -7265,7 +7265,7 @@ packages:
   license_family: BSD
   size: 384817
   timestamp: 1695107709236
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py310hecd8cb5_0.tar.bz2
   sha256: 47192486a825a7723642a5ff51a6e6e1951c2d32c7788da5de2485cc06b30211
   md5: 857b3344cb9298976756ca71dc731d60
   depends:
@@ -7275,7 +7275,7 @@ packages:
   license_family: BSD
   size: 40085
   timestamp: 1668168926166
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
   sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
   md5: 523c006cc67c011383678c762015479b
   depends:
@@ -7284,7 +7284,7 @@ packages:
   license_family: BSD
   size: 3594448
   timestamp: 1714770737885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tomli-2.0.1-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tomli-2.0.1-py310hecd8cb5_0.tar.bz2
   sha256: 15f26313ae2647e6d314f7551ed86434b0a4d06c0a000b816be336793a423165
   md5: f6deefbee1ee7036626fc1157dd6876e
   depends:
@@ -7293,7 +7293,7 @@ packages:
   license_family: MIT
   size: 25771
   timestamp: 1657175648495
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py310hecd8cb5_0.tar.bz2
   sha256: c6704e6f0aa0d801e316697959cbf8def94a9ff730a02f2892564402736e8a97
   md5: 1631da9c8a71594c1426ad0a4abcc728
   depends:
@@ -7302,7 +7302,7 @@ packages:
   license_family: BSD
   size: 104877
   timestamp: 1667464191717
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.1-py310h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.4.1-py310h46256e1_0.tar.bz2
   sha256: cd52672cdd75d1bea4809a87dcd1c1ae927a38d1d3f5b1ea1eebe3b63164f7e3
   md5: 3ee235204cefb59d7e7512124d32b785
   depends:
@@ -7311,7 +7311,7 @@ packages:
   license_family: Apache
   size: 698956
   timestamp: 1718740169096
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.5-py310h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.66.5-py310h20db666_0.tar.bz2
   sha256: 25a8f186a16cd1a015827d3517e5c29df76ff667a8f67e641418dadc811b9fad
   md5: 9b4b931f93ff450114d2a3ef2dbd461f
   depends:
@@ -7322,7 +7322,7 @@ packages:
   license_family: MOZILLA
   size: 128536
   timestamp: 1724854365093
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.14.3-py310hecd8cb5_0.tar.bz2
   sha256: dda3761c9a87fd90628b32cc8827587856783f9df3afc59d2f412b704fce6a48
   md5: 9f14e3c1632913c7cfec1d02df9efca0
   depends:
@@ -7331,7 +7331,7 @@ packages:
   license_family: BSD
   size: 168327
   timestamp: 1718227095682
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.11.0-py310hecd8cb5_0.tar.bz2
   sha256: 4a597ce01cd7df36221a55c5d6a5391461b44c8e9485f5ff2c5f0bc290c6234f
   md5: 48ec2e723e715b8ed73ee2dea5b32b07
   depends:
@@ -7341,7 +7341,7 @@ packages:
   license_family: PSF
   size: 9904
   timestamp: 1715269109824
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.11.0-py310hecd8cb5_0.tar.bz2
   sha256: 23e6a2747bb6e191119b7a23efbf5bcec7adb33b4b7ff614dd36a88e6ec37475
   md5: 8a4219dbe4163fe4a6d1cf2f3f583e10
   depends:
@@ -7350,7 +7350,7 @@ packages:
   license_family: PSF
   size: 61508
   timestamp: 1715269095906
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py310h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py310h6c40b1e_0.tar.bz2
   sha256: 63eeef078da1a81f469a881863df2f4455268c318fbe1ae6e67d215405ecc4be
   md5: 89fe7e3ee27bd327822946574ef5ea92
   depends:
@@ -7359,7 +7359,7 @@ packages:
   license_family: Apache
   size: 495761
   timestamp: 1713213041078
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.3-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-2.2.3-py310hecd8cb5_0.tar.bz2
   sha256: b095571e220ea9b62e01fade2c856d5f56a49489847b83994fcfc8cb421a3b0c
   md5: 722f1da6123cfc7b1f01bed235104e3a
   depends:
@@ -7375,7 +7375,7 @@ packages:
   license_family: MIT
   size: 174274
   timestamp: 1727770049537
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py310hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py310hecd8cb5_1.tar.bz2
   sha256: aae85a1650806382831d1edd5b7e8912329c2d5859dd63258f2b422d0bee1761
   md5: 7502e3b07c9f996017a9171d056b3865
   depends:
@@ -7384,7 +7384,7 @@ packages:
   license_family: BSD
   size: 21319
   timestamp: 1642539070002
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py310hecd8cb5_0.tar.bz2
   sha256: df09c3d9eb682cfb34e3d892d1a8dafe3a4b252b18cc6539c8f1c331b1a72a39
   md5: 6632d513deb34751cfee6129f71ab6d1
   depends:
@@ -7393,7 +7393,7 @@ packages:
   license_family: Apache
   size: 88313
   timestamp: 1715878355449
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/werkzeug-3.0.6-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/werkzeug-3.0.6-py310hecd8cb5_0.tar.bz2
   sha256: fd644f3ab6d60d12f5732737be8ae1ddc5768786d24ed5697bf6027b76c7d02b
   md5: 2cd1d4520af4785e12b2ccb8cefedeac
   depends:
@@ -7405,7 +7405,7 @@ packages:
   license_family: BSD
   size: 349380
   timestamp: 1731005905750
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/widgetsnbextension-4.0.10-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/widgetsnbextension-4.0.10-py310hecd8cb5_0.tar.bz2
   sha256: 9f6e5649990eec219fa441fa663cd61e0e9ba3708218956094a9ed2173d7f1db
   md5: 1c1f328c7cb0f17d37000be837fc4006
   depends:
@@ -7414,7 +7414,7 @@ packages:
   license_family: BSD
   size: 1931296
   timestamp: 1709323071556
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wrapt-1.14.1-py310hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wrapt-1.14.1-py310hca72f7f_0.tar.bz2
   sha256: 247e00f11da76e770166f4eb216693da0f571afa052775a57a8629329863610e
   md5: 9f5c97dfc2e2cf68e0c23321209b32d2
   depends:
@@ -7423,7 +7423,7 @@ packages:
   license_family: BSD
   size: 49985
   timestamp: 1657814505025
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py310hecd8cb5_0.tar.bz2
   sha256: 1c101b0f6db62313e4d845ccbec9256e97a01b3a9bebb84174c6bd5a302ba809
   md5: 3490e2adaefd69ec35a5f0eefa902ef7
   depends:
@@ -7435,20 +7435,20 @@ packages:
   license_family: Apache
   size: 1812032
   timestamp: 1689041517180
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
   sha256: ed0152ad6b87ffd9e01f4a62bc358e805ad59637f898a801b0a9cf903ae8e1fb
   md5: 8a92f8c663608f24e14d8a2068b9d83a
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 415323
   timestamp: 1714511993944
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yarl-1.18.0-py310h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yarl-1.18.0-py310h46256e1_0.tar.bz2
   sha256: 41f4509754dc4c70fe39ee41c129ed4272ffaa2e53e3bb130f991684194e6c0e
   md5: 7d84fe20ea6d27dd09459cc39e3eb304
   depends:
@@ -7460,7 +7460,7 @@ packages:
   license_family: Apache
   size: 135144
   timestamp: 1732547099966
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zarr-2.13.3-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zarr-2.13.3-py310hecd8cb5_0.tar.bz2
   sha256: b4db98931a6a95a647985dacdb6153f115cf8f3d84bcff6bc6ac86a8791d5d01
   md5: 36f3ee584f4a40725f83eec631eea1e7
   depends:
@@ -7473,7 +7473,7 @@ packages:
   license_family: MIT
   size: 344339
   timestamp: 1669363579779
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
   sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
   md5: c25b6d40f834647d0bbe767f6c776031
   depends:
@@ -7483,7 +7483,7 @@ packages:
   license_family: Other
   size: 329449
   timestamp: 1705602140856
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zfp-1.0.0-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zfp-1.0.0-hcec6c5f_0.tar.bz2
   sha256: 47bde98853cb2914d8d63d58615edd7c9a788c5590a6a0a5c14d41051577559b
   md5: c2e85e2f1be3fcee07bdf14d6a11519f
   depends:
@@ -7493,7 +7493,7 @@ packages:
   license_family: BSD
   size: 271809
   timestamp: 1681741643951
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zict-3.0.0-py310hecd8cb5_0.tar.bz2
   sha256: 5a12afd890a62af36fa68990182fec6ce14a15836b0985ba5efcaf477e374368
   md5: ab35b58320c81d4687504c7f6ec1d107
   depends:
@@ -7504,7 +7504,7 @@ packages:
   license_family: BSD
   size: 78791
   timestamp: 1695832967750
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.21.0-py310hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.21.0-py310hecd8cb5_0.tar.bz2
   sha256: 39093c8982b24650d28be1ff138fedf7eb3ffc6f904ddd227f56b9d28241fedf
   md5: 602a7d8d4582fe29d24e4cd02f09eb01
   depends:
@@ -7513,14 +7513,14 @@ packages:
   license_family: MIT
   size: 26953
   timestamp: 1732630810165
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
   sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
   md5: f2519b551f99765d9d98950c5e2b4713
   license: Zlib
   license_family: Other
   size: 119782
   timestamp: 1714511811597
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
   sha256: a1f470eabe211500d2ec7866ecf421c067f159045f0245f19e9ba8272c5a177e
   md5: f8bd5fb9fac17a47c64ae56355faba24
   depends:
@@ -7531,12 +7531,12 @@ packages:
   license_family: BSD
   size: 1033188
   timestamp: 1728487057684
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/_tflow_select-2.2.0-eigen.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/_tflow_select-2.2.0-eigen.tar.bz2
   sha256: 59bafe7c50d71da3c1f0aa99ebdc1e329f42a659dace13025cce87e065a784c5
   md5: 246af7e262f42b5ef0c0050a2b38cb6c
   size: 2892
   timestamp: 1677628364852
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/abseil-cpp-20211102.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/abseil-cpp-20211102.0-hc377ac9_0.tar.bz2
   sha256: 5c4e710cd4ae70aa94623c79f8528b8900dc5a2c88391f34cc11af7fb2885f1c
   md5: 998c800e31d88a6b0c7fae9b67695e2d
   depends:
@@ -7545,7 +7545,7 @@ packages:
   license_family: Apache
   size: 1046017
   timestamp: 1652382871042
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/absl-py-2.1.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/absl-py-2.1.0-py310hca03da5_0.tar.bz2
   sha256: edbb356df4d4b4e326a031ba07d4a0cd96a2f743deeb25e5b173bc27412f56b3
   md5: 542d3ee2df186e890bfdb01632a44683
   depends:
@@ -7554,7 +7554,7 @@ packages:
   license_family: Apache
   size: 188771
   timestamp: 1714140540259
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aiobotocore-2.12.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aiobotocore-2.12.3-py310hca03da5_0.tar.bz2
   sha256: bc625e660b37e5ae77ff2a01dbc60d9168acbf522274e9439b4384f221b2aca0
   md5: be57ff17c7c4194f69e2407e22567348
   depends:
@@ -7569,7 +7569,7 @@ packages:
   license_family: Apache
   size: 111965
   timestamp: 1714464474681
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aiohappyeyeballs-2.4.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aiohappyeyeballs-2.4.3-py310hca03da5_0.tar.bz2
   sha256: 979c98dc1cdfca83245d8d8a9edc95b902d3e2a384909f58735060ef174d3784
   md5: 9a8fded83f9bfe981da8b76f7d9872b2
   depends:
@@ -7578,7 +7578,7 @@ packages:
   license_family: Other
   size: 26366
   timestamp: 1732662494086
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aiohttp-3.10.5-py310h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aiohttp-3.10.5-py310h80987f9_0.tar.bz2
   sha256: 7e8c6366b36a396ecdc41f1ed9e37e12b48784903e09480392ede19d547276c2
   md5: 259358d22e03ce319e20c4563825020a
   depends:
@@ -7596,7 +7596,7 @@ packages:
   license_family: Other
   size: 734360
   timestamp: 1725528321327
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.6.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.6.2-py310hca03da5_0.tar.bz2
   sha256: 3f6473f17d0407db15ac692c66032a637cd16a898a717d886e3df1a30fa3cd71
   md5: 004edddb77757f2eae161031e8c2c04f
   depends:
@@ -7612,7 +7612,7 @@ packages:
   license_family: MIT
   size: 192745
   timestamp: 1729121306682
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aom-3.6.0-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aom-3.6.0-h313beb8_0.tar.bz2
   sha256: a26e4cb399cee40b3b513563d22a8f8f87b15cfdfd645cffeb48f57a85db3ee6
   md5: 2e643e2e6830fea3f7d6ac729f8bbccb
   depends:
@@ -7621,7 +7621,7 @@ packages:
   license_family: BSD
   size: 2647589
   timestamp: 1688660588288
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py310hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py310hca03da5_1001.tar.bz2
   sha256: ab80767485355b86e85012079c6774f34b8a50cca22f6af691717dae8a6eecd3
   md5: 313a6fb125023514957826391bd2bc9a
   depends:
@@ -7630,7 +7630,7 @@ packages:
   license_family: BSD
   size: 10379
   timestamp: 1643965069164
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py310h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py310h1a28f6b_0.tar.bz2
   sha256: 88db781405798fc0a4bd4d2cfa4817d72a1717595814792b06baf438a74f971e
   md5: 74f12ced47a5a18208005eb36438fb97
   depends:
@@ -7640,7 +7640,7 @@ packages:
   license_family: MIT
   size: 36148
   timestamp: 1644845853887
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-11.0.0-he3f21e0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/arrow-cpp-11.0.0-he3f21e0_2.tar.bz2
   sha256: 313d6a618fa00b3e2f94b904d7c7503ca31ad9d727a1531de73a418876bf4550
   md5: 81d60ed6da95297b1d8111e26c79fcab
   depends:
@@ -7668,7 +7668,7 @@ packages:
   license_family: Apache
   size: 8072211
   timestamp: 1693262997819
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/async-lru-2.0.4-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/async-lru-2.0.4-py310hca03da5_0.tar.bz2
   sha256: 3b43d45739c99e6a94f62680a84bd9a2318af2711b23cf505b2ec06664550cc2
   md5: d4adbbd0b14c97d7d65388910ddf44d8
   depends:
@@ -7678,7 +7678,7 @@ packages:
   license_family: MIT
   size: 18529
   timestamp: 1699554606955
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/async-timeout-4.0.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/async-timeout-4.0.3-py310hca03da5_0.tar.bz2
   sha256: 9e8364394f0c5647eb50adc08c9ba59e6f5ed1139d3f6408cb0187b77e4e395f
   md5: fb2aa332a7c7f71cdb7dc156179e55bb
   depends:
@@ -7687,7 +7687,7 @@ packages:
   license_family: Apache
   size: 13180
   timestamp: 1703097036878
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-24.2.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-24.2.0-py310hca03da5_0.tar.bz2
   sha256: 270acc00fc48505fc3430e02dbc43663a1196637e73dc39512edda097345950e
   md5: cf1610354be87984d45cce0784ea4a9c
   depends:
@@ -7696,14 +7696,14 @@ packages:
   license_family: MIT
   size: 142944
   timestamp: 1729089438536
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.6.8-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-common-0.6.8-h80987f9_1.tar.bz2
   sha256: 4d63ff9d0b424c5dc2e20bb8324a348869dee0340511effadfd1d622842a8322
   md5: 3137a10d16bb223ae981d566d60d984b
   license: Apache-2.0
   license_family: Apache
   size: 153917
   timestamp: 1685977852438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.1.6-h313beb8_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-event-stream-0.1.6-h313beb8_6.tar.bz2
   sha256: f41918089bd42945e10d71aaf30eacede92db2b57193c2c931a710c314a39730
   md5: b0a63224a995df6e07fdebba41a3c1a6
   depends:
@@ -7714,7 +7714,7 @@ packages:
   license_family: Apache
   size: 24245
   timestamp: 1686021087869
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.11-h80987f9_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-checksums-0.1.11-h80987f9_2.tar.bz2
   sha256: 5068b5773e8ce07dfc34718fb6c4be364a4c79d821138d68c3d246873bd562b9
   md5: 1efb7da0ab9ee77370640b77f74f9c7c
   depends:
@@ -7723,7 +7723,7 @@ packages:
   license_family: Apache
   size: 51725
   timestamp: 1685998294585
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.8.185-h4a942e0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-sdk-cpp-1.8.185-h4a942e0_0.tar.bz2
   sha256: 0f257afff29f6c681b9fd8620767ce2af7b07f9068c3f0e649289ca9151591bf
   md5: 9358450895bb23ccbd49c553dbd66589
   depends:
@@ -7736,7 +7736,7 @@ packages:
   license_family: Apache
   size: 2171325
   timestamp: 1628727158397
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/babel-2.11.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/babel-2.11.0-py310hca03da5_0.tar.bz2
   sha256: cab586143df17aa3def1a098ff9e2b4537064efe95095ee43aef50666afacd9d
   md5: 2b5ecb47920dea58ef381cfb7ca1d6a6
   depends:
@@ -7746,7 +7746,7 @@ packages:
   license_family: BSD
   size: 7121729
   timestamp: 1671782026041
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.3-py310hca03da5_0.tar.bz2
   sha256: 2514f9bbe8223df7338c42e3747db5d33757b5742c0f36437c854c55594ef6e1
   md5: 30db606495e28cd684ddfbb3043ddbd0
   depends:
@@ -7756,12 +7756,12 @@ packages:
   license_family: MIT
   size: 219249
   timestamp: 1718029876220
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bleach-6.2.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bleach-6.2.0-py310hca03da5_0.tar.bz2
   sha256: 39f2e4ef0fbad4a9943efa75e503b08f3b1690b800c8535618828305ebb9008d
   md5: 066afccd247e6e4df797cf1cd68dc6c1
   depends:
@@ -7773,7 +7773,7 @@ packages:
   license_family: Apache
   size: 296946
   timestamp: 1732292272756
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blinker-1.6.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blinker-1.6.2-py310hca03da5_0.tar.bz2
   sha256: 3533e937278621267c54f7435ddeb08dc11c39fce220dc1b3bfdf34f9ccc65c6
   md5: 1f455949be1a9d4dfd05ddd5b6567c63
   depends:
@@ -7782,7 +7782,7 @@ packages:
   license_family: MIT
   size: 29215
   timestamp: 1696539139293
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
   sha256: d51b7b5841be320209706d8e9caf669c0e0094f3a40e9eea51701a564ca7c2ed
   md5: 61647f79e0ae70e914fee23c40c4caea
   depends:
@@ -7794,7 +7794,7 @@ packages:
   license_family: BSD
   size: 43179
   timestamp: 1675247655207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.6.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.6.0-py310hca03da5_0.tar.bz2
   sha256: 4e67fdf3fee5d29637bdf5e3eff737c57518335db4972070a06c3331e436aa60
   md5: 13eb9d58f7139b020cbe7bdf76329616
   depends:
@@ -7812,7 +7812,7 @@ packages:
   license_family: BSD
   size: 5685403
   timestamp: 1727914527726
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.73.0-h1a28f6b_12.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/boost-cpp-1.73.0-h1a28f6b_12.tar.bz2
   sha256: 8f878b6cb432784e1a1d395069265a3643d8bb44cb5a1f552d4930895b728725
   md5: f3e6c2c3e302d06f9734ecb2f71c2b3b
   depends:
@@ -7821,7 +7821,7 @@ packages:
   license_family: OTHER
   size: 17659
   timestamp: 1655879787473
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/botocore-1.34.69-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/botocore-1.34.69-py310hca03da5_0.tar.bz2
   sha256: 3aa9a83ed5721eecc581dec9a17caa7b5d1938d41f453858035385878287407b
   md5: bffd996f6abd589d9815904b8cf34ea7
   depends:
@@ -7833,7 +7833,7 @@ packages:
   license_family: Apache
   size: 7686510
   timestamp: 1714460595187
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.4.2-py310hbda83bc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.4.2-py310hbda83bc_0.tar.bz2
   sha256: 0220046762c8f8c8f3a75f9ac81e07cc4e659718f87544a7f0f82047b1898e33
   md5: 120e04ac71ae950c72c0262b96e2240c
   depends:
@@ -7843,7 +7843,7 @@ packages:
   license_family: BSD
   size: 117882
   timestamp: 1731058816267
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
   sha256: 048264434c33fdb53862cdd69b2e2bc4ce6f8a70b3211ad6d686d066eac2aa91
   md5: d55696ccaf6755931cd662dfb929aa0b
   depends:
@@ -7853,7 +7853,7 @@ packages:
   license: MIT
   size: 19737
   timestamp: 1714483270447
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
   sha256: 13627293296fcc231d8dc12d803dfc9621108c60df38b0e3c64e9e02ed55e564
   md5: 86efd4ad08cd80d3eab77873db84a255
   depends:
@@ -7862,7 +7862,7 @@ packages:
   license: MIT
   size: 19083
   timestamp: 1714483255364
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py310h313beb8_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py310h313beb8_8.tar.bz2
   sha256: 955e349120f59228466fce09cb2a6a430754ce6f6e60ab82fdedecf9bac2ba2a
   md5: c59fe78ebe4caa829f63d92d882f036a
   depends:
@@ -7871,7 +7871,7 @@ packages:
   license: MIT
   size: 380208
   timestamp: 1714483423839
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brunsli-0.1-hc377ac9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brunsli-0.1-hc377ac9_1.tar.bz2
   sha256: 5fb3dec9b529843f2b77a486869ffe193debac7698159c0be6d50569b14402f9
   md5: 0034c14344b0f61079b867bd32835beb
   depends:
@@ -7881,28 +7881,28 @@ packages:
   license_family: MIT
   size: 178533
   timestamp: 1628860668184
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
   sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
   md5: 56d1386c7f1f338f0d18f82af6525273
   license: bzip2-1.0.8
   license_family: BSD
   size: 158748
   timestamp: 1714510571033
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
   sha256: b0be79290b1df1cf1d07a1a9c3f3a92ae262643a6df3dc10dfbac22a82874dd4
   md5: 8fdcf1c08eee91fec7eefc22863c816a
   license: MIT
   license_family: MIT
   size: 106550
   timestamp: 1693902036526
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.11.26-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2024.11.26-hca03da5_0.tar.bz2
   sha256: e2c3a5a357ecda3f8dc7b2ca84fc749ba70affaad7e1d9964fe5c9246b9d15a0
   md5: eb4056bb90ad65d68517441160025e1e
   license: MPL-2.0
   license_family: Other
   size: 142731
   timestamp: 1732804449627
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cachetools-5.3.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cachetools-5.3.3-py310hca03da5_0.tar.bz2
   sha256: b5042509781ac5bc5cd3ff06e10ee70d2e94a482ad6a900b3cd7672fc4765fac
   md5: 6810ff17b061398b986d62a87492a8d4
   depends:
@@ -7911,7 +7911,7 @@ packages:
   license_family: MIT
   size: 23953
   timestamp: 1713977136632
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.8.30-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.8.30-py310hca03da5_0.tar.bz2
   sha256: 5063169e99f9ea793bf65633fcae52a1ec0236360f9d9d563bf010ce133bbfde
   md5: f089e9df0eb0dcb702b775c4455bec34
   depends:
@@ -7920,7 +7920,7 @@ packages:
   license_family: Other
   size: 169062
   timestamp: 1725551865064
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py310h3eb5a62_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.17.1-py310h3eb5a62_0.tar.bz2
   sha256: 54a956a7c0a39dc886bbc810caf8f235a48ecff616fab6e38d5cccc696795746
   md5: 95ce0947a2571b62c335c122d216d9d3
   depends:
@@ -7931,7 +7931,7 @@ packages:
   license_family: MIT
   size: 233086
   timestamp: 1726856586266
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
   sha256: 3ba74ebffd6bc4bc451864f85048dec9b6ad085eb1904ce3e5450376e15f050e
   md5: 289f238ac78b174f01c8a2b252b17735
   depends:
@@ -7943,7 +7943,7 @@ packages:
   license_family: Other
   size: 1243641
   timestamp: 1655814869383
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cftime-1.6.2-py310hbda83bc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cftime-1.6.2-py310hbda83bc_0.tar.bz2
   sha256: 197a3ab010194553d81893e293d5635e274b7b4fcb7708ef95d74f3a9f5b7f14
   md5: c10acad3237d8f41c03d1f6422ec32c5
   depends:
@@ -7953,7 +7953,7 @@ packages:
   license_family: MIT
   size: 222352
   timestamp: 1678830479751
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/charls-2.2.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/charls-2.2.0-hc377ac9_0.tar.bz2
   sha256: c048ecfd192b1c4844c077b778814be1f62017dd578bf4bf6f199be5fc7ffc65
   md5: 3998b53d542b1c04175df5d214926067
   depends:
@@ -7962,7 +7962,7 @@ packages:
   license_family: BSD
   size: 91429
   timestamp: 1628861281402
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py310hca03da5_0.tar.bz2
   sha256: 141c21ce96ff8115ead231a457638806feb1fb4adf041e2f8ac102a5ce904660
   md5: c5e8b68c4ebc09ceff293a97a2e35e97
   depends:
@@ -7971,7 +7971,7 @@ packages:
   license_family: BSD
   size: 155478
   timestamp: 1698129833439
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.0.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-3.0.0-py310hca03da5_0.tar.bz2
   sha256: 89dd920e0d6beb902cb74c9bcc793ff627de9d04b458a4d79d97bf6ce3d1b083
   md5: 340b0fac9fff7d426d6ae3c937b69af1
   depends:
@@ -7980,7 +7980,7 @@ packages:
   license_family: BSD
   size: 35874
   timestamp: 1721657464815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py310hca03da5_0.tar.bz2
   sha256: 227fe006de1e483775d205cad12d909da267c42a328fae304b8ebf9fbf5818cf
   md5: 4f0ced86c3e12c6ae37bbb69ae883468
   depends:
@@ -7989,7 +7989,7 @@ packages:
   license_family: CC
   size: 495012
   timestamp: 1709758412929
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py310hca03da5_0.tar.bz2
   sha256: 982ba62e9a121dd7ed150be6fcea4d1b104088f8c9cf5e87965b30a75425af03
   md5: 77943a14af8ad7a2da2298849f2f832e
   depends:
@@ -7999,7 +7999,7 @@ packages:
   license_family: BSD
   size: 15736
   timestamp: 1709322990889
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.3.1-py310h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.3.1-py310h48ca7d4_0.tar.bz2
   sha256: 95282a2e74d7369fdf21e98189bdf1d662ba779679f01ca9fcfc32c018c59d25
   md5: 4250cc6830136878e70342948f049b6f
   depends:
@@ -8010,7 +8010,7 @@ packages:
   license_family: BSD
   size: 279657
   timestamp: 1732540233373
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py310h3c57c4d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py310h3c57c4d_0.tar.bz2
   sha256: 7588b722a4f6e81f42a9c246540dcb9148ed6affe9f30a5f4898437a6e926017
   md5: ecd7b6c242db72b02a87c6bc3f2332eb
   depends:
@@ -8023,7 +8023,7 @@ packages:
   license_family: BSD
   size: 1404100
   timestamp: 1694211962143
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.2-py310h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cytoolz-0.12.2-py310h80987f9_0.tar.bz2
   sha256: 04194ac6c8e61363563226ae65be7244047d18c251d9b8fad8408df07536f1d9
   md5: e8f740bc4bd8f540e9d9ce856e64b5c6
   depends:
@@ -8033,7 +8033,7 @@ packages:
   license_family: BSD
   size: 373384
   timestamp: 1701723852993
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-2024.5.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/dask-2024.5.0-py310hca03da5_0.tar.bz2
   sha256: 3fea9e2fd09e786602e1a888c39464c16e36ac44e807fbeaceb90a252578e195
   md5: e195636143d99e1a61325d4ce4c99038
   depends:
@@ -8052,7 +8052,7 @@ packages:
   license_family: BSD
   size: 6280
   timestamp: 1715848762457
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.5.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2024.5.0-py310hca03da5_0.tar.bz2
   sha256: 65c9d42f648a5379c53281df3f7472fa11194920f37a54ebae2368e281e4bbf7
   md5: 7c402e65f6db7ca65c2f1abf0ef03433
   depends:
@@ -8069,7 +8069,7 @@ packages:
   license_family: BSD
   size: 2235870
   timestamp: 1715838686594
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-expr-1.1.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/dask-expr-1.1.0-py310hca03da5_0.tar.bz2
   sha256: a21ff3995375c80ea46fab88913d00f296d7b2e9a6d49d857b44b31c572628f5
   md5: 748c71e5cff14f51d6a447d0d938f1d6
   depends:
@@ -8081,14 +8081,14 @@ packages:
   license_family: BSD
   size: 355987
   timestamp: 1715846576841
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dav1d-1.2.1-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/dav1d-1.2.1-h80987f9_0.tar.bz2
   sha256: cdc3829b4dacd2c09ffcea509947b99dbe12eff4c9fd5f0d412795e2d3648b04
   md5: cb80d50ff320b1865a31c59c9602ea4b
   license: BSD-2-Clause
   license_family: BSD
   size: 397700
   timestamp: 1688746000695
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py310h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py310h313beb8_0.tar.bz2
   sha256: cac66c2a69e5bee96de7a9a5be0ecace698915c107c9fa9047e884ca671413fe
   md5: 28e9929e5bb06bf8df0b540b2069ba33
   depends:
@@ -8098,7 +8098,7 @@ packages:
   license_family: MIT
   size: 2075348
   timestamp: 1690905262055
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2024.5.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/distributed-2024.5.0-py310hca03da5_0.tar.bz2
   sha256: eadea4045834154ccc67828f029b7464878959b63918e07ac1f67afc0ff96512
   md5: e79f2987b0c06320c386ddf1f5c5c346
   depends:
@@ -8122,7 +8122,7 @@ packages:
   license_family: BSD
   size: 1451746
   timestamp: 1715844519914
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py310hca03da5_0.tar.bz2
   sha256: 1d532b889e0e71fe68f59e0fd328fe4c42c11660de3a32a0e31fe149f02a3eb5
   md5: f5ec34d95710f724fd4b4c064ed0abcd
   depends:
@@ -8131,7 +8131,7 @@ packages:
   license_family: MIT
   size: 15257
   timestamp: 1650293833649
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.2.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.2.0-py310hca03da5_0.tar.bz2
   sha256: 2ceb163a5fa46ceaa7231e4f78b47829d40f397226e2cda0d2286cbc967c8e51
   md5: 1690bc1a003150413422613599f2d26c
   depends:
@@ -8140,7 +8140,7 @@ packages:
   license_family: MIT
   size: 30935
   timestamp: 1706031457824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/flatbuffers-24.3.25-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/flatbuffers-24.3.25-h313beb8_0.tar.bz2
   sha256: fde8be69d41255bbe39561d9788d869625964b58dd7b1e27eb497a206426efd2
   md5: d8a28d381d4252756c22e6bf4a1c56be
   depends:
@@ -8149,7 +8149,7 @@ packages:
   license_family: Apache
   size: 1663962
   timestamp: 1722872781902
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py310h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.51.0-py310h80987f9_0.tar.bz2
   sha256: 7659946cefbb015c7fb5102bfa658351b76d99b543a9a2a4f67164db68baaa38
   md5: 480013fd51127fbc6115817e9180484e
   depends:
@@ -8167,7 +8167,7 @@ packages:
   license_family: MIT
   size: 2642561
   timestamp: 1713551452422
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -8177,7 +8177,7 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/frozenlist-1.5.0-py310h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/frozenlist-1.5.0-py310h80987f9_0.tar.bz2
   sha256: 543d86b46735b982966157142d5970b2d1920798e3667e31e4b5c689e8771984
   md5: 723329b90c7909a2a339cf5d1ffc1fa5
   depends:
@@ -8186,7 +8186,7 @@ packages:
   license_family: Apache
   size: 59173
   timestamp: 1730902948787
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.6.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2024.6.1-py310hca03da5_0.tar.bz2
   sha256: d12c11c41ece77422495a78c8ce954c6cda29ca0e9094446bc5dd007e4f3dc47
   md5: bdb3e7e4e56e024747f36a1c3c5fe9b0
   depends:
@@ -8197,7 +8197,7 @@ packages:
   license_family: BSD
   size: 288520
   timestamp: 1724855701047
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
   sha256: 25e05b93a99914a5fd1a298a2c5b25479fbd571b0db9caa7c6ad4336f060f62c
   md5: e213b68bb0274e0e54c610a041e059f5
   depends:
@@ -8206,14 +8206,14 @@ packages:
   license_family: BSD
   size: 150168
   timestamp: 1706888198288
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.2-h80987f9_0.tar.bz2
   sha256: 0dcf246231852d2b5277cba97a91d8d335a4d57a27b6967b868d67572aecfa38
   md5: edfacb0742d7dec1c039a4e9363aa336
   license: MIT
   license_family: MIT
   size: 77608
   timestamp: 1728656300028
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
   sha256: bbbcf47ef9249635b5199be1414b0b59687cc04ea9630d50ecc609dc200c095e
   md5: 5820c373d6847a68551cadb8984a8277
   depends:
@@ -8223,7 +8223,7 @@ packages:
   license_family: BSD
   size: 95638
   timestamp: 1706895270850
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/google-auth-2.29.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/google-auth-2.29.0-py310hca03da5_0.tar.bz2
   sha256: 268cd7e8fb909de39a48341f89341f68e0cae56cdf77cebfa3dd5c9c90022035
   md5: 82e2f4348eb473248d3628a666be0846
   depends:
@@ -8241,7 +8241,7 @@ packages:
   license_family: Apache
   size: 215766
   timestamp: 1715111181443
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/google-auth-oauthlib-0.5.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/google-auth-oauthlib-0.5.2-py310hca03da5_0.tar.bz2
   sha256: 6e15acc1da3adb1cdd179fba16a60f42c23477b07a295aa2dfdd2fd72f942bbc
   md5: b680d8c661be931fafd1758ef2ac3d8d
   depends:
@@ -8253,7 +8253,7 @@ packages:
   license_family: Apache
   size: 28219
   timestamp: 1660687889741
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpc-cpp-1.48.2-h877324c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/grpc-cpp-1.48.2-h877324c_0.tar.bz2
   sha256: 9963e4eea827c92de0e1f67bcd3201dd26a8f36edcaf8485ebd1b8295973c150
   md5: 34af50f83a91586dbac69f3b857b34a7
   depends:
@@ -8269,7 +8269,7 @@ packages:
   license_family: APACHE
   size: 3906551
   timestamp: 1681912781323
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpcio-1.48.2-py310h877324c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/grpcio-1.48.2-py310h877324c_0.tar.bz2
   sha256: d05dab19c46f5f75b9528f5e04eb22b1ed707902cd1d3bcd05bc4a5d29dfa577
   md5: 13a777670b28d01e2fdb31634ba22d64
   depends:
@@ -8281,7 +8281,7 @@ packages:
   license_family: APACHE
   size: 765128
   timestamp: 1681912877067
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/h11-0.14.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/h11-0.14.0-py310hca03da5_0.tar.bz2
   sha256: 66cdb1d4797110ee53d4e877463ae283983cc3d54e704de0a17e0bf4a345df9a
   md5: 3cc3aeb058849d61cbb65dc69b0f2b16
   depends:
@@ -8290,7 +8290,7 @@ packages:
   license_family: MIT
   size: 85406
   timestamp: 1706652351554
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/h5py-3.12.1-py310h8456320_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/h5py-3.12.1-py310h8456320_0.tar.bz2
   sha256: 898853f6f4667141a33ffc91106a698c55f15c7624918039ab0fb2a64e94ba04
   md5: fdde76f1596ce45e27df9c7f1613efd7
   depends:
@@ -8302,7 +8302,7 @@ packages:
   license_family: BSD
   size: 1410792
   timestamp: 1730216170930
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf4-4.2.13-h5e329fb_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/hdf4-4.2.13-h5e329fb_3.tar.bz2
   sha256: e9ccc7a4ec25606556785100e6ee1dd5d9b04ed1973978545a37bfe6be929ddc
   md5: 2a40342fd2402a56d833312609fcf16b
   depends:
@@ -8313,7 +8313,7 @@ packages:
   license_family: BSD
   size: 913497
   timestamp: 1629192094107
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hdf5-1.12.1-h160e8cb_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/hdf5-1.12.1-h160e8cb_2.tar.bz2
   sha256: 4f5dc26b65f4f1404408a52d90d867dcdaed53d6b1934b4069fca5ab69e2bf8f
   md5: 31c93ccfd519d969aedb84bf093b3c1d
   depends:
@@ -8326,7 +8326,7 @@ packages:
   license_family: BSD
   size: 6270448
   timestamp: 1655307672422
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.20.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.20.0-py310hca03da5_0.tar.bz2
   sha256: ca6ab23c8b062bb006a5efff2bab9000be762493a6e980c7f28e471ec8847d60
   md5: c2271963d3121be343173d879a2b593b
   depends:
@@ -8346,7 +8346,7 @@ packages:
   license_family: BSD
   size: 5300100
   timestamp: 1730827718195
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpcore-1.0.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/httpcore-1.0.2-py310hca03da5_0.tar.bz2
   sha256: cb94dd4f6bb68031d020cfbdaf9eb0b01c855f4e97641e60dc17dd1a7a2f5b60
   md5: 3cc94921555c6c7ac7b3c60908d837e2
   depends:
@@ -8357,7 +8357,7 @@ packages:
   license_family: BSD
   size: 85832
   timestamp: 1706728507413
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/httpx-0.27.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/httpx-0.27.0-py310hca03da5_0.tar.bz2
   sha256: cf7d268bdc6c9a8172af133392c33941847cd0bd1cc3787c980be1486e943b76
   md5: 582426b72befd94e7becbdf1bd9941be
   depends:
@@ -8377,7 +8377,7 @@ packages:
   license_family: BSD
   size: 161137
   timestamp: 1723475100041
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-68.1-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/icu-68.1-hc377ac9_0.tar.bz2
   sha256: ec6fe8fb2533f8fae73866531ad8c93b20a2b060737d237445f115455c3ab96b
   md5: cec95fa3d8b36559af63caf4fb1f6caf
   depends:
@@ -8385,7 +8385,7 @@ packages:
   license: MIT
   size: 13742625
   timestamp: 1630597537784
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py310hca03da5_0.tar.bz2
   sha256: 360447ea7418dda653de5777d451a5560d6d41b785fc29f934db23bb792b2716
   md5: 5164d4c696d13b8d5d568065213c1f1f
   depends:
@@ -8394,7 +8394,7 @@ packages:
   license_family: BSD
   size: 140568
   timestamp: 1714398898493
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/imagecodecs-2023.1.23-py310h604db08_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/imagecodecs-2023.1.23-py310h604db08_0.tar.bz2
   sha256: 281b41a4108d41a042765376fd6e3a0f23d11d973104d0d137b351570027a520
   md5: 7a15d0b37ac113fb3f4489e0b17cd606
   depends:
@@ -8432,7 +8432,7 @@ packages:
   license_family: BSD
   size: 10129220
   timestamp: 1695065549016
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/imageio-2.33.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/imageio-2.33.1-py310hca03da5_0.tar.bz2
   sha256: 61e30012ab7d690de11180363f99965d33f028b6d40384261ebca14fcfb8a60a
   md5: faf80f005d60d080691425f637ef9674
   depends:
@@ -8443,7 +8443,7 @@ packages:
   license_family: BSD
   size: 525304
   timestamp: 1707247345409
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-8.5.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-8.5.0-py310hca03da5_0.tar.bz2
   sha256: eaa322e6c0e2ec190fdc3e0c94bbc3fa31c1c6da199b3859d1011f05fa3891e4
   md5: 32f8daf7db4e408ff4f1bd167cc298d0
   depends:
@@ -8453,7 +8453,7 @@ packages:
   license_family: APACHE
   size: 46513
   timestamp: 1732633739325
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/intake-0.7.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/intake-0.7.0-py310hca03da5_0.tar.bz2
   sha256: 9e14b07e9b7a757db6b4dbc7722f183c2e0854ab8afc13e4eaddbc579cc91c54
   md5: 6d8d033d3d1e6d268e3bce1623726d7d
   depends:
@@ -8476,7 +8476,7 @@ packages:
   license_family: BSD
   size: 199313
   timestamp: 1717514041500
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/intake-xarray-0.7.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/intake-xarray-0.7.0-py310hca03da5_0.tar.bz2
   sha256: a9f0bb7b67c178831f13e5001a867ff5eb4abe7b29f23a9a47c6bc489f5dbf0a
   md5: bbb946a18496f60736e7a355a57dce8d
   depends:
@@ -8493,7 +8493,7 @@ packages:
   license_family: BSD
   size: 69297
   timestamp: 1717524055546
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.29.5-py310hca03da5_0.tar.bz2
   sha256: ce06824b134eedc5d74310b8a976b168f475697167bb739a74ac4156f97bd9b1
   md5: 87019d9afe2ef0840445579775d764b5
   depends:
@@ -8515,7 +8515,7 @@ packages:
   license_family: BSD
   size: 192712
   timestamp: 1728666215929
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.27.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.27.0-py310hca03da5_0.tar.bz2
   sha256: 47be5da95e64b4448247b085c8f052494c70a2afa1c80135141e36ffe4693ece
   md5: ce38b8f0770e3f187f1c86989e2e6094
   depends:
@@ -8534,7 +8534,7 @@ packages:
   license_family: BSD
   size: 1299601
   timestamp: 1726064513633
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipywidgets-8.1.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipywidgets-8.1.2-py310hca03da5_0.tar.bz2
   sha256: 23a1bbb5da8d4ef77debe076fe309ab9eadf547470f2211fbb9c685f51f7ec48
   md5: 2d69d6b967dcd675311d57bf23ef80f6
   depends:
@@ -8548,7 +8548,7 @@ packages:
   license_family: BSD
   size: 202271
   timestamp: 1709574791555
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.19.1-py310hca03da5_0.tar.bz2
   sha256: c91df5cf80f28399c1f49e03a2c8fde564225517920a21cceb4cfb336e5adc1d
   md5: 99efe9747834edc5ae09c7185e6b0d96
   depends:
@@ -8558,7 +8558,7 @@ packages:
   license_family: MIT
   size: 1058032
   timestamp: 1721058440071
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.4-py310hca03da5_1.tar.bz2
   sha256: dada56693dbedee088ee4523ed5248ae6a476abe9b5edc365e509833b8bf35e6
   md5: 2e754658d98e4ff4d374441fe510586f
   depends:
@@ -8570,7 +8570,7 @@ packages:
   license_family: BSD
   size: 276497
   timestamp: 1730902914906
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jmespath-1.0.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jmespath-1.0.1-py310hca03da5_0.tar.bz2
   sha256: 3861ca4d9fa10b2a9e10eae953aa1fe4cd8abe8d67b130ec95f110021f54d897
   md5: 2d75084740d82363c4f88176433e4a94
   depends:
@@ -8579,14 +8579,14 @@ packages:
   license_family: MIT
   size: 38468
   timestamp: 1700144671260
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
   sha256: 9d5cbffa98f3a4391f66b0c5ce1f411f0bfb0eb83137dc7146fb7bae23cb3570
   md5: 95c92318023482e4e8c698ae6c4597fe
   license: IJG
   license_family: Other
   size: 274078
   timestamp: 1722872672311
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/json5-0.9.25-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/json5-0.9.25-py310hca03da5_0.tar.bz2
   sha256: 8d65efbe25a0b420ece57f79a138b09b4537040880ce44b4dd034e6f34b96d97
   md5: cbe32d5cdd9ee7a6197957efa757af6d
   depends:
@@ -8595,7 +8595,7 @@ packages:
   license_family: Apache
   size: 46886
   timestamp: 1730786846967
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.23.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.23.0-py310hca03da5_0.tar.bz2
   sha256: 4dfab8bfd99556a2783020cc0d845bbd6a1380d5da6c9b2365d8232021358735
   md5: 764286388774d2965f2f34ccd7916664
   depends:
@@ -8608,7 +8608,7 @@ packages:
   license_family: MIT
   size: 146561
   timestamp: 1728486802755
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py310hca03da5_0.tar.bz2
   sha256: b6d49e1ec73a4421a78073bed47919ae47c09d66206353c268545c7eb3bb8286
   md5: 606b118a1cbcc4e2651d863bd33d41f3
   depends:
@@ -8618,7 +8618,7 @@ packages:
   license_family: MIT
   size: 15902
   timestamp: 1699032410304
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter-lsp-2.2.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter-lsp-2.2.0-py310hca03da5_0.tar.bz2
   sha256: 8548081d15ed7eaf311547d08e628bf577e83e972e147b963a5668d0a00a82d7
   md5: c93fb997d7279f2cc412a914e028798b
   depends:
@@ -8628,7 +8628,7 @@ packages:
   license_family: BSD
   size: 82335
   timestamp: 1699978325232
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-8.6.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-8.6.0-py310hca03da5_0.tar.bz2
   sha256: b4706c21e910ed8a1d670a0dce2f39498fd554726b89bc2d678a4bf4205f730a
   md5: 4f2e372ea9499024e660b9ae5773cbd5
   depends:
@@ -8642,7 +8642,7 @@ packages:
   license_family: BSD
   size: 173820
   timestamp: 1699456879695
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.7.2-py310hca03da5_0.tar.bz2
   sha256: f4ff3a46e33fa359a8dc029868146908671c34cc1d71715ef4eccbb99d891aa0
   md5: 831574b90268a2de1b53374c7c4148cc
   depends:
@@ -8653,7 +8653,7 @@ packages:
   license_family: BSD
   size: 83854
   timestamp: 1718818403866
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.10.0-py310hca03da5_0.tar.bz2
   sha256: 90dffc620b1e5ee18a37251bc2b106158de2dcc246239c2f3590de79619255eb
   md5: b8e9d261f27e2ce37e75355c5c6c8e16
   depends:
@@ -8669,7 +8669,7 @@ packages:
   license_family: BSD
   size: 36893
   timestamp: 1718738185513
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.14.1-py310hca03da5_0.tar.bz2
   sha256: 0625ddfafd499065ede7b6df3e5e531d31c056dc051fda57fba9ffb4d7ffd8c2
   md5: e4112ef7f4ba235c358985397775838a
   depends:
@@ -8696,7 +8696,7 @@ packages:
   license_family: BSD
   size: 504039
   timestamp: 1718828083626
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py310hca03da5_1.tar.bz2
   sha256: 45c774feba2c07c9fdbdb68e6f39b4d896a073d4d1e5aafb5ced7cf899a81e31
   md5: 3f52ce26064c931ba359a6d19b72461d
   depends:
@@ -8706,7 +8706,7 @@ packages:
   license_family: BSD
   size: 24640
   timestamp: 1686870953350
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab-4.2.5-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab-4.2.5-py310hca03da5_0.tar.bz2
   sha256: 6d732a5e7b9956755bbecb754ecc1ea7fe1301225da2c7c4b7f814d220f8e433
   md5: d94af59be90031abf9f61e2c086fdaa0
   depends:
@@ -8731,7 +8731,7 @@ packages:
   license_family: BSD
   size: 8331180
   timestamp: 1725896465344
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_server-2.27.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_server-2.27.3-py310hca03da5_0.tar.bz2
   sha256: 2600048867f3d098d5a795c7ed9786168afd296840168d7ce7010bbcdb07db58
   md5: d0df3d705c3399cb8a2e510bda7f014a
   depends:
@@ -8749,7 +8749,7 @@ packages:
   license_family: BSD
   size: 84464
   timestamp: 1725865508779
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_widgets-3.0.10-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_widgets-3.0.10-py310hca03da5_0.tar.bz2
   sha256: e03f4c750ea8724e3575c1bed1469b72d4d7c149efa539f220fc2e1582132c5c
   md5: ce7224be9130dc4700e1ed6da0a33be8
   depends:
@@ -8760,14 +8760,14 @@ packages:
   license_family: BSD
   size: 192364
   timestamp: 1709322920540
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jxrlib-1.1-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jxrlib-1.1-h1a28f6b_2.tar.bz2
   sha256: bd9a167e45cb8cb9710b5a19c498a67ac78d57f252be120973e347dbdd93aa36
   md5: 5db215a69fb5d3f393e58bc6e5df5a3a
   license: BSD-2-Clause
   license_family: BSD
   size: 220109
   timestamp: 1628860886330
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/keras-2.12.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/keras-2.12.0-py310hca03da5_0.tar.bz2
   sha256: 3404884d2af9064b10f8bc7f2761fcb7b4a28ef19dbf0d86ff6723b58d87610d
   md5: f1f602cd25c7e65f3b04608a5459f5e0
   depends:
@@ -8778,7 +8778,7 @@ packages:
   license: Apache-2.0
   size: 2264984
   timestamp: 1685212966727
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py310h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py310h313beb8_0.tar.bz2
   sha256: 379b8b9c8e45b813e6d31a712c2d5c8ae5801570b4717626971fabe87938c51f
   md5: 2ff257d592914060b35560de4fe1c83f
   depends:
@@ -8788,7 +8788,7 @@ packages:
   license_family: BSD
   size: 64635
   timestamp: 1672387310531
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
   sha256: e547a4a540ccc9db683d6d2e3e36b0d0ad99e1ad10b22b5f403af3e893b412ba
   md5: dc5ae0ece3c4990ba5fee7b266f2a019
   depends:
@@ -8799,7 +8799,7 @@ packages:
   license_family: MIT
   size: 1306804
   timestamp: 1686931342120
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lazy_loader-0.4-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lazy_loader-0.4-py310hca03da5_0.tar.bz2
   sha256: db6cf4dda70f2812e759a97352ce617af0e1cbd80d9552077947700c76cf96b5
   md5: e13b55048fa009d4369351f2ed26c780
   depends:
@@ -8809,7 +8809,7 @@ packages:
   license_family: BSD
   size: 21881
   timestamp: 1718176828263
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -8819,7 +8819,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -8828,7 +8828,7 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libaec-1.0.4-hc377ac9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libaec-1.0.4-hc377ac9_1.tar.bz2
   sha256: 7fb9ae8531636f858e80fa142bc518ec5ffe2c50e655d0b5e66982a5abd42c5b
   md5: e97f2f3ed8030db3ed46111dc6d0dbaa
   depends:
@@ -8837,7 +8837,7 @@ packages:
   license_family: BSD
   size: 25647
   timestamp: 1628861308643
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libavif-0.11.1-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libavif-0.11.1-h80987f9_0.tar.bz2
   sha256: 7693526f3d7e012ce568832508982154cc65e6afaacb172623e64c8f5b863e75
   md5: bfd3a5c3793bce213c83bd8b1b837fe8
   depends:
@@ -8847,7 +8847,7 @@ packages:
   license_family: BSD
   size: 92755
   timestamp: 1689158136997
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.73.0-h49e8a49_12.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libboost-1.73.0-h49e8a49_12.tar.bz2
   sha256: 4342165ac2224b02089c3a8db136f067cabddb9f8a6a13e46b839d0b5263a841
   md5: e13a408297da09dd8d77e6e4904f4232
   depends:
@@ -8862,13 +8862,13 @@ packages:
   license_family: OTHER
   size: 20106750
   timestamp: 1655879742590
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
   sha256: 199042b87451abaf14546af124ae3380194cddda928e0d30ccb341e93084854c
   md5: eaa0442887994a82486c65d87f6b71e6
   license: MIT
   size: 68806
   timestamp: 1714483212137
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
   sha256: bd9a8a17fb14086446b710fa029d238e69274b83ee2e7e09093496f190de82b5
   md5: 66615d6a0cb5dcca3e20c019cde0ed2d
   depends:
@@ -8876,7 +8876,7 @@ packages:
   license: MIT
   size: 32975
   timestamp: 1714483225840
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
   sha256: e1bf77e8b975c30a69b08a08410622e27c8cff6f592ccfa590466b83d9e6d104
   md5: 8af86bdac01fe303d693d9b76c071059
   depends:
@@ -8884,7 +8884,7 @@ packages:
   license: MIT
   size: 310266
   timestamp: 1714483239194
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
   sha256: a94cc52c1ca2e421342d2fefc6d7774ff5118b9d01f4e22d33314f8520d33723
   md5: 440575339cec83722e83087db31127bf
   depends:
@@ -8899,21 +8899,21 @@ packages:
   license_family: MIT
   size: 342121
   timestamp: 1693515586487
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
   sha256: 9597df5344a718d37837966aa05091faf210260898fad5e7a64b87f17de9e90d
   md5: 678a1f87940ef6cc421a092301b8c3fe
   depends:
@@ -8922,14 +8922,14 @@ packages:
   license_family: BSD
   size: 167208
   timestamp: 1703006281321
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
   sha256: 6fc572025852b210ecddcca3ab9ff3f1d5f6bd91f1933c6e296de6bb331f6b5d
   md5: 6dd7d9c5737bbd2a27d18f15318dc3e6
   license: BSD-2-Clause
   license_family: BSD
   size: 102059
   timestamp: 1628961869728
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-hf27765b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libevent-2.1.12-hf27765b_0.tar.bz2
   sha256: 60321df3cac6e0b97561448810d8575945e48fb0d13f1480f83733d56801223e
   md5: c9637ab2110623a8e6f5a0c0e0576029
   depends:
@@ -8938,14 +8938,14 @@ packages:
   license_family: BSD
   size: 441685
   timestamp: 1642102532464
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
   sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
   md5: f31e4eb9cd6447cc2f5ef0243a76540c
   license: MIT
   license_family: MIT
   size: 120460
   timestamp: 1714483461787
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -8954,7 +8954,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -8965,14 +8965,14 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
   sha256: 72d242814b990900c9410d4738cc685f70ea71231742293cffbb475d8df100f8
   md5: f9976688992b7ac4b56f5600ee15b5c4
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1407202
   timestamp: 1714483550601
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnetcdf-4.8.1-ha022005_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libnetcdf-4.8.1-ha022005_4.tar.bz2
   sha256: 962a15d8bbf1bfa7f4f1bf2b6a547b770f16ac8f6f374ebf1205f95d6893090a
   md5: 37d8db4c0339cedc632314a34bb69886
   depends:
@@ -8987,7 +8987,7 @@ packages:
   license_family: BSD
   size: 1461182
   timestamp: 1691155105280
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
   sha256: 039483aadb821adffcc2aff761ec35474d633b6bc2f1eb7cce877a881d7ed290
   md5: d75b21db95481154cfa9d7a871f0f3bf
   depends:
@@ -9002,7 +9002,7 @@ packages:
   license_family: MIT
   size: 743061
   timestamp: 1686931613436
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -9013,7 +9013,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -9022,7 +9022,7 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
   sha256: 239ec46c06c477e722230159971bac8d9eb14793a2e75f6e3d3a7a04ed5d5ebd
   md5: 50e9c501f39bb262703c764789099f24
   depends:
@@ -9032,13 +9032,13 @@ packages:
   license_family: BSD
   size: 2338901
   timestamp: 1675278555141
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
   sha256: 48a8617773b57a4b9a8539782bf88a317f49a644d3f858aa0ad3ab13afc03ae7
   md5: c3bc0fb3cc9a98ef1f2f83ef497fc5da
   depends:
@@ -9047,7 +9047,7 @@ packages:
   license_family: BSD
   size: 334616
   timestamp: 1686931322663
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h169de6a_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libthrift-0.15.0-h169de6a_2.tar.bz2
   sha256: bd07607554df2d9a28a6480d88d8d80c461f043c76bf71d4b0a527771dc877a4
   md5: b24333ab90dd7a604f7a2ccc8ae85671
   depends:
@@ -9060,7 +9060,7 @@ packages:
   license_family: Apache
   size: 361614
   timestamp: 1687975091526
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -9077,7 +9077,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
   sha256: 479cf759232c2361af87493ecd124e7d3a8940030e42e1931234c35bea73c3bd
   md5: cd8fe2c981594a457c6af3a0d5de0bd5
   constrains:
@@ -9086,7 +9086,7 @@ packages:
   license_family: BSD
   size: 341817
   timestamp: 1729160040909
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzip-1.8.0-h0c481fb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libzip-1.8.0-h0c481fb_0.tar.bz2
   sha256: 7035bf74c9adbc5d98ed17a5618a7b6df97479fc60e1398fd29a9f8b42bcb1b1
   md5: 429d9725086eceeafd42a5369c5791b1
   depends:
@@ -9099,7 +9099,7 @@ packages:
   license_family: BSD
   size: 121284
   timestamp: 1652981900392
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzopfli-1.0.3-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libzopfli-1.0.3-hc377ac9_0.tar.bz2
   sha256: 18eda005925fe6aaddb1a7a207b4ecab85981794cf1fba0fa72b765d59e4fe18
   md5: 042769990cec17f009a3088932e8e1c3
   depends:
@@ -9108,7 +9108,7 @@ packages:
   license_family: Apache
   size: 149220
   timestamp: 1628860942228
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py310hca03da5_0.tar.bz2
   sha256: 4e992da1d64efc2158c185b23883dee1e50ccc7a1ccb61d1b0546e6eb44bc536
   md5: aad3f66e7d96961764d2b5d0ab08efb3
   depends:
@@ -9118,7 +9118,7 @@ packages:
   license_family: MIT
   size: 36178
   timestamp: 1659783445874
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -9127,7 +9127,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py310hca03da5_0.tar.bz2
   sha256: a2dfd5de8c8946e1da759975b43bb4048bf720792f63e44a8197ebf78da18560
   md5: eb339d709764df9583302fd4796f609d
   depends:
@@ -9136,7 +9136,7 @@ packages:
   license_family: BSD
   size: 11926
   timestamp: 1652903163430
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.3.2-py310h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-4.3.2-py310h80987f9_0.tar.bz2
   sha256: c24f63e59ba98c08c8935268a7a89281de64f3fcf53b30315dc010b762774b18
   md5: d6c5da5afa0364f5b7ed2243ccd932dd
   depends:
@@ -9146,7 +9146,7 @@ packages:
   license_family: BSD
   size: 37324
   timestamp: 1686063926330
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
   sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
   md5: f5f7e6e7541d8dc3d3df270d488d2e24
   depends:
@@ -9155,7 +9155,7 @@ packages:
   license_family: BSD
   size: 176990
   timestamp: 1714510588159
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py310hca03da5_0.tar.bz2
   sha256: 8303fcbfcdf8ab390e505f34c5ac6fa057815139d8e6cf7380dc108eb772485c
   md5: c769729b709fa4dd0a8da5be358de878
   depends:
@@ -9164,7 +9164,7 @@ packages:
   license_family: BSD
   size: 124217
   timestamp: 1671541964591
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py310hca03da5_1.tar.bz2
   sha256: b0e240d3ef06e292105f4e1b161426170e5897144c142d23df66935ab4108dc5
   md5: 8c6193fc54f6c300530527f642efadf1
   depends:
@@ -9174,7 +9174,7 @@ packages:
   license_family: MIT
   size: 108119
   timestamp: 1684279956548
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py310h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py310h80987f9_0.tar.bz2
   sha256: b6174b6bbe0c49fed05460bb5374255984f590b766978729e8061460d4adc358
   md5: c744c544e5226317d7d6d940b7e4614e
   depends:
@@ -9185,7 +9185,7 @@ packages:
   license_family: BSD
   size: 24323
   timestamp: 1704206219206
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.9.2-py310h7ef442a_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.9.2-py310h7ef442a_1.tar.bz2
   sha256: 9facb30ac3e128767e1fc5b42daec02e7f98172dcca39207f839ecf3dae99077
   md5: a17c3f2320aa0fd87e51bb50f5e2c20f
   depends:
@@ -9205,7 +9205,7 @@ packages:
   license_family: PSF
   size: 8415403
   timestamp: 1732550527155
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py310hca03da5_0.tar.bz2
   sha256: 9cfad1d0d85bf4079262292b47e62355c7c1847f641ca8dfc46c4226bce2d785
   md5: b1a3a7ea89adee337db085727216abda
   depends:
@@ -9215,7 +9215,7 @@ packages:
   license_family: BSD
   size: 17383
   timestamp: 1662014500374
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py310hca03da5_0.tar.bz2
   sha256: 66e7f61e59f392a603639c284ce06bd2930a59270990089f602cdf2628467eb8
   md5: cf0c798d425a37c0404fd04da7afb640
   depends:
@@ -9225,7 +9225,7 @@ packages:
   license_family: MIT
   size: 54195
   timestamp: 1659721278389
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py310hca03da5_0.tar.bz2
   sha256: 7f85b9bd603910fee4f7ecac3fbc3eb4b978ab16ad2acd88d3d5a03b89c6bace
   md5: 984724161f039112bf536366c1332531
   depends:
@@ -9234,7 +9234,7 @@ packages:
   license_family: MIT
   size: 19648
   timestamp: 1659716071039
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py310hca03da5_0.tar.bz2
   sha256: 1d3223d19faee06a13d6e784b956d2eb6840139b7948fcf359d53afd4bc71382
   md5: 83399b08729217b8295b7a07927e42ae
   depends:
@@ -9245,7 +9245,7 @@ packages:
   license_family: BSD
   size: 91328
   timestamp: 1661496331337
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py310h525c30c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/msgpack-python-1.0.3-py310h525c30c_0.tar.bz2
   sha256: e559f5b8fbde9231bb4199caab5a8b7cdc5c0a19a7844a0fb5399f255058e061
   md5: 6310ffa34960c9b79ee0e8cb49b81ef1
   depends:
@@ -9255,7 +9255,7 @@ packages:
   license_family: Apache
   size: 90076
   timestamp: 1652362752668
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multidict-6.1.0-py310h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/multidict-6.1.0-py310h80987f9_0.tar.bz2
   sha256: 6907984390536c7fdd601fe160264e4b59a2143079e21adc84909ab5de9d6678
   md5: 2c48a1536124f37529644bedf2ae670d
   depends:
@@ -9265,7 +9265,7 @@ packages:
   license_family: Apache
   size: 53390
   timestamp: 1730905541289
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py310hca03da5_0.tar.bz2
   sha256: a195b8aba2a37e8aa17f3114e282548036da3eb5a5536b67d4449b362e6cefff
   md5: 07b1977a07d7dbff70c8f5f90b985f9c
   depends:
@@ -9278,7 +9278,7 @@ packages:
   license_family: BSD
   size: 101332
   timestamp: 1698934238996
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.4-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.16.4-py310hca03da5_0.tar.bz2
   sha256: 268df8609f5c43d3da5c08f9f8847adbeef63c46413b83aa10f7e7bb9059c26e
   md5: c3eefc73916dbcd8bbe53f9a8dfa007e
   depends:
@@ -9305,7 +9305,7 @@ packages:
   license_family: BSD
   size: 491024
   timestamp: 1728049880655
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.10.4-py310hca03da5_0.tar.bz2
   sha256: 1d56811db3dcf64f81534f8c062f13f5a0ad32a477ac34f13fc8a8d312b138d1
   md5: d7bbf5d0fee20be1955640948e289403
   depends:
@@ -9318,14 +9318,14 @@ packages:
   license_family: BSD
   size: 149708
   timestamp: 1728049678663
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py310hca03da5_0.tar.bz2
   sha256: 737ecaada7f80f42da43affef97fc31a8dcd3f2a0be14b377b34583a7d334fdf
   md5: 914980d852a22de592f571dba8d4fe62
   depends:
@@ -9334,7 +9334,7 @@ packages:
   license_family: BSD
   size: 14550
   timestamp: 1708532774873
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/netcdf4-1.6.2-py310he1bbb67_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/netcdf4-1.6.2-py310he1bbb67_0.tar.bz2
   sha256: e594958884817ae602e2c2342b37767b1c5709cc2c832f26347dd90f15861136
   md5: 0f35b88c44e7f1bf53b2c4b9d427fcf9
   depends:
@@ -9348,7 +9348,7 @@ packages:
   license_family: MIT
   size: 454017
   timestamp: 1673455699701
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/networkx-3.3-py310hca03da5_0.tar.bz2
   sha256: 53a33aae2c35d13d870512c037d52a6e6e61be38cdab5726734e049db7d814ff
   md5: 1378fd76998411b933f35f2d73e21a1f
   depends:
@@ -9366,7 +9366,7 @@ packages:
   license_family: BSD
   size: 2666241
   timestamp: 1720002652389
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-7.2.2-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-7.2.2-py310hca03da5_1.tar.bz2
   sha256: d27ff21221c9033730a7ecccf28b53c7d0aebdae55388041af93a202c75d7ff9
   md5: 5a724eca20996cae7cf89a6766bcf612
   depends:
@@ -9380,7 +9380,7 @@ packages:
   license_family: BSD
   size: 4534081
   timestamp: 1727199405663
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py310hca03da5_0.tar.bz2
   sha256: 62494435862be4443468b06ed8d029ec8ef14f7945b10174fe55b345a9181567
   md5: 1e0215bd9da3ef2be9d173891f768e23
   depends:
@@ -9390,7 +9390,7 @@ packages:
   license_family: BSD
   size: 23537
   timestamp: 1699455985908
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numcodecs-0.12.1-py310h1a4646a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numcodecs-0.12.1-py310h1a4646a_0.tar.bz2
   sha256: 1ba5051385eea2e2c04f0fe47d68523173090a2cb459ebe30f2d0ce417aeebb4
   md5: 630b68d2574be70f5b9c9ec555e248b5
   depends:
@@ -9404,7 +9404,7 @@ packages:
   license_family: MIT
   size: 415435
   timestamp: 1707513273399
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.10.1-py310h5d9532f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.10.1-py310h5d9532f_0.tar.bz2
   sha256: 70e26f68ff7dc69d6417069df514b1085914be61378334366b217458f1a79179
   md5: cdd4433b58dd859c52223a31376ea329
   depends:
@@ -9416,7 +9416,7 @@ packages:
   license_family: MIT
   size: 163018
   timestamp: 1730216049164
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.23.5-py310hb93e574_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.23.5-py310hb93e574_0.tar.bz2
   sha256: aace873ea10996846afd0487462b74e076b5e8919a9be1a71d7972ece6e744ba
   md5: e59c523ea46b7f058a051a9ce685106b
   depends:
@@ -9429,7 +9429,7 @@ packages:
   license_family: BSD
   size: 11053
   timestamp: 1672337428035
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.23.5-py310haf87e8b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.23.5-py310haf87e8b_0.tar.bz2
   sha256: a30f5cd0257201b7d71bdfd5536308b945ffa54f39f8ca9e76e18314e24d1ef1
   md5: 12e1f46a552145d0b31dacfa04287738
   depends:
@@ -9443,7 +9443,7 @@ packages:
   license_family: BSD
   size: 6274503
   timestamp: 1672337414505
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/oauthlib-3.2.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/oauthlib-3.2.2-py310hca03da5_0.tar.bz2
   sha256: 6e0712255c3f786ed3d5e8dab3ae0e9a574887d7d4862b86811bd326cebbe51a
   md5: 506486ae577ab2cf62eea6262a1aab73
   depends:
@@ -9455,7 +9455,7 @@ packages:
   license_family: BSD
   size: 235536
   timestamp: 1679489746515
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
   sha256: b9f781280f49644ca05e18aacbdde1c57cc5107e7cc2471b843ea8461672aa7f
   md5: 9125d30e4e105b45f7f7d9c20acafa10
   depends:
@@ -9466,7 +9466,7 @@ packages:
   license_family: BSD
   size: 450131
   timestamp: 1722872679313
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
   sha256: 409ba99dd953129c0ccebb5dcbf2049920e5a755b88e7e392e4f91be924e26ef
   md5: f05f00606c10617a61c41f23652b9a00
   depends:
@@ -9475,7 +9475,7 @@ packages:
   license_family: Apache
   size: 3450897
   timestamp: 1694465216241
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
   sha256: c4135710b5536fb859a6672c055bbc2cff0426e0655e75c7fdf808f7f3344ada
   md5: 483605a01fccba850b7f0cbdeff29858
   depends:
@@ -9489,7 +9489,7 @@ packages:
   license_family: Apache
   size: 421604
   timestamp: 1676482754496
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py310hca03da5_0.tar.bz2
   sha256: 285cdb7abdf5635133d2196adf11e19d68583fdfdc52e952ba066e57c16476f0
   md5: 1cba5fcb7ad91b512dcbf70d859059f2
   depends:
@@ -9498,7 +9498,7 @@ packages:
   license_family: APACHE
   size: 31861
   timestamp: 1699371195680
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-24.1-py310hca03da5_0.tar.bz2
   sha256: e555b55da4d7b032148c734d3ecf07bb1a6e2276ee602d86dd7cb305117a23ce
   md5: 106f589b3795ec7b7447f642c78bdd93
   depends:
@@ -9507,7 +9507,7 @@ packages:
   license_family: Apache
   size: 136781
   timestamp: 1720102019422
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.3-py310hcf29cfe_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.2.3-py310hcf29cfe_0.tar.bz2
   sha256: 1b5782f67429e64b3e5f3a60c06b997f2006c8c18a64c743884dcf2d0ec83ecb
   md5: d5219a0f279106f3cad71e1fc7d01a3c
   depends:
@@ -9557,7 +9557,7 @@ packages:
   license_family: BSD
   size: 14023520
   timestamp: 1732736308872
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.5.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-1.5.3-py310hca03da5_0.tar.bz2
   sha256: 6daf5490db05533c675436669d1df97178d9e503aba6bf2620c466eef6952780
   md5: 5a0b7f9f3e6ed6da55bb25d5aac09a1a
   depends:
@@ -9582,7 +9582,7 @@ packages:
   license_family: BSD
   size: 23678961
   timestamp: 1730380929882
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-2.1.1-py310hca03da5_0.tar.bz2
   sha256: e9c81d6bbbdbc07ca5f13bdf63d0faa9da971b5365388fc2b0ba882c7e08a427
   md5: b2e52207827e0f168b073d366f64d029
   depends:
@@ -9591,7 +9591,7 @@ packages:
   license_family: BSD
   size: 195438
   timestamp: 1719348004795
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py310hca03da5_0.tar.bz2
   sha256: 24c36db498b26baebf4c9d1327d8e2ba533e92d7a7191c62ed5dba7581ad20b8
   md5: 95d6ab469e9d95d9efaa03f2a4a797a4
   depends:
@@ -9605,7 +9605,7 @@ packages:
   license_family: BSD
   size: 37051
   timestamp: 1698702637098
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-11.0.0-py310hfaf4e14_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-11.0.0-py310hfaf4e14_0.tar.bz2
   sha256: 6b28449ec76cb8f5491ca1d185a92356e5fe48d916fc4d86a92b203e7b00b2ff
   md5: f4a1d6c5978cf692033e978decdd28b8
   depends:
@@ -9621,7 +9621,7 @@ packages:
   license_family: Other
   size: 787765
   timestamp: 1731594847999
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-24.2-py310hca03da5_0.tar.bz2
   sha256: 1aa0935f04ae37c9c9d1ee10d14d3a43efcb0b6fe58c5641dc846c320ad57a18
   md5: 773dfa7c2b5ea4cae3a5937f3692d234
   depends:
@@ -9632,7 +9632,7 @@ packages:
   license_family: MIT
   size: 2338498
   timestamp: 1723484780184
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py310hca03da5_0.tar.bz2
   sha256: f90967e7b1263de747709a00d54c5c41ef7efe03ece8b480cd2f811ed6da7e68
   md5: 68b0d1ba5f14b5296c2e880e3ce8e1cf
   depends:
@@ -9641,7 +9641,7 @@ packages:
   license_family: MIT
   size: 33194
   timestamp: 1692205719500
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.21.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.21.0-py310hca03da5_0.tar.bz2
   sha256: 8205872ee591cd1fcb943d8be888ccea474d98767cc3989a1b9927d780a17fc9
   md5: e52f838afbf6ee8fb22e88fd5be62562
   depends:
@@ -9650,7 +9650,7 @@ packages:
   license_family: Apache
   size: 91871
   timestamp: 1731958921926
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py310hca03da5_0.tar.bz2
   sha256: f6ee51edfa968855dc223819720f1519e6defd1ba724a3efc69e4d6f2ec23284
   md5: 29b8d61161d1e8b636975eb0079559e1
   depends:
@@ -9662,7 +9662,7 @@ packages:
   license_family: BSD
   size: 600549
   timestamp: 1704404395992
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/propcache-0.2.0-py310h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/propcache-0.2.0-py310h80987f9_0.tar.bz2
   sha256: d7cd5fb7602991c0c970399be9337981a883ba96c905852f39695fe835733332
   md5: f50cf5553a05c2b00fa40d6799046891
   depends:
@@ -9671,7 +9671,7 @@ packages:
   license_family: Apache
   size: 52987
   timestamp: 1732304251888
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/protobuf-3.20.3-py310h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/protobuf-3.20.3-py310h313beb8_0.tar.bz2
   sha256: 10f5d2a0d42b51078a460e1b3ad43a75de0806795a1e276c2322a6abb76c8170
   md5: b894b1606c1c320c9be4e494c4348a66
   depends:
@@ -9683,7 +9683,7 @@ packages:
   license_family: BSD
   size: 317500
   timestamp: 1675281450814
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py310h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py310h1a28f6b_0.tar.bz2
   sha256: ddcca2ed0751d233e1953dcd1a373b1d778bd6c303e4bae3713fa7d20a814ed7
   md5: 2cb18e1233648dbd160770e5941bf588
   depends:
@@ -9692,7 +9692,7 @@ packages:
   license_family: BSD
   size: 372012
   timestamp: 1656431417953
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-11.0.0-py310hbfed03b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyarrow-11.0.0-py310hbfed03b_1.tar.bz2
   sha256: 3cbb59039f16b8091918228ad2f4f0d64819215bbe617ba894467a19acad32d1
   md5: d2b3eae8855b35d2011c2e9240a5cbae
   depends:
@@ -9706,7 +9706,7 @@ packages:
   license_family: Apache
   size: 4416924
   timestamp: 1693272945544
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py310hca03da5_1.tar.bz2
   sha256: 5a345e4a9a6f8ff0264bd5a8238e591192915b99f44c75aef66033aecea15ec7
   md5: e2c9a794ff909ab32cc84c4fc6964a6d
   depends:
@@ -9715,7 +9715,7 @@ packages:
   license_family: BSD
   size: 1882595
   timestamp: 1684280055553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyjwt-2.9.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyjwt-2.9.0-py310hca03da5_0.tar.bz2
   sha256: 0158a159e5f6b894bd3cb137a87f86007b6bb962c3180175a84b2f3c0b422f2c
   md5: d9a638f21e15e9412368125a1defcc37
   depends:
@@ -9726,7 +9726,7 @@ packages:
   license_family: MIT
   size: 77592
   timestamp: 1730786915454
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py310hca03da5_0.tar.bz2
   sha256: 271d303a73878efe49bd997962fb5ba474fb118cd03d44958a3f61d446d87521
   md5: bf861f951e567d14d903c7139c629d01
   depends:
@@ -9736,7 +9736,7 @@ packages:
   license_family: Apache
   size: 95814
   timestamp: 1690223518556
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.2.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.2.0-py310hca03da5_0.tar.bz2
   sha256: 22e74c23cca917710891ff32e9945d567d1514db41c6b6b9df0824006ef41e92
   md5: ecad23ec9b28284a55b34d641ba99d30
   depends:
@@ -9745,7 +9745,7 @@ packages:
   license_family: MIT
   size: 428093
   timestamp: 1731445629850
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py310hca03da5_0.tar.bz2
   sha256: 70946f5858f17fec169e726e761cce1d1f3e6a99ef3a8e72007c1df51e09d5a3
   md5: f9c6d792e5983df39d7dbb8389340e9a
   depends:
@@ -9754,7 +9754,7 @@ packages:
   license_family: BSD
   size: 28542
   timestamp: 1643961550827
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.10.13-hc0d8a6c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.10.13-hc0d8a6c_0.tar.bz2
   sha256: db42db87d3ad4d3590482082f3164bec530214b7a485dde6f66fe4d6917cbd5c
   md5: 5e2210c29b062f89053e706cc173d20d
   depends:
@@ -9773,7 +9773,7 @@ packages:
   license_family: PSF
   size: 13884848
   timestamp: 1694438892769
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py310hca03da5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py310hca03da5_2.tar.bz2
   sha256: 7fe61148813d911c333451fa5b1752ed4da89b230a83a23b3cb3886e0ad7e1ed
   md5: 8eef9f7a02ea012f3ae3c4cec6d09185
   depends:
@@ -9783,7 +9783,7 @@ packages:
   license_family: BSD
   size: 290933
   timestamp: 1716495762679
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.20.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.20.0-py310hca03da5_0.tar.bz2
   sha256: 53e1d8c1d2695cd5d9f688631049f18fc2a86dc0ca525d6a3111121feaa5a67c
   md5: af5cc0866a0e1be48e64a6f4ddfbd961
   depends:
@@ -9792,7 +9792,7 @@ packages:
   license_family: BSD
   size: 268376
   timestamp: 1731939489375
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-flatbuffers-24.3.25-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-flatbuffers-24.3.25-py310hca03da5_0.tar.bz2
   sha256: 06eb0168744185c1c0136739329e9ff27791d601142b2338055e9c7859a6027d
   md5: 887aae188a395583cdcd4e04dcfac52c
   depends:
@@ -9801,7 +9801,7 @@ packages:
   license_family: Apache
   size: 54630
   timestamp: 1722369270912
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-2.0.7-py310hca03da5_0.tar.bz2
   sha256: c6672f4736da5c863013a4cfc8279c278e22b8c8f355d375b1c123e6d16bea0f
   md5: 873d8d6e3b69017e6bc0bd8f7539da58
   depends:
@@ -9810,7 +9810,7 @@ packages:
   license_family: BSD
   size: 16249
   timestamp: 1683823962980
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py310h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-lmdb-1.4.1-py310h313beb8_0.tar.bz2
   sha256: bc6ee168edccda4c958ee354b6e877ea5f28014fd458f37f2031abeb7a8d5de5
   md5: 587ddfc730311bdda83be3e7f2841f4f
   depends:
@@ -9820,7 +9820,7 @@ packages:
   license_family: Other
   size: 133962
   timestamp: 1682522396996
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-snappy-0.6.1-py310h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-snappy-0.6.1-py310h313beb8_0.tar.bz2
   sha256: 2dc18d37b0ad88a9a0ca2922145e73372edc821f45dbf91f97ce0676480e08c5
   md5: 8821bbe361974618ff85599f56933bde
   depends:
@@ -9831,7 +9831,7 @@ packages:
   license_family: BSD
   size: 32077
   timestamp: 1670943961923
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py310hca03da5_0.tar.bz2
   sha256: 45b397640e696c094e62c9c0550f90585f1c0b1cc24b9d223f2628c0e258c673
   md5: dd8fa678704016eda8ef7310b4b6b61e
   depends:
@@ -9840,7 +9840,7 @@ packages:
   license_family: MIT
   size: 267206
   timestamp: 1713974370791
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.2-py310hca03da5_0.tar.bz2
   sha256: d051de2450e45b0cbb834a28fe37601d0e85751b4c57cdbd03d8c34715dafdbd
   md5: f8ec20db3291bfbeb480cfdd09cbdde1
   depends:
@@ -9852,7 +9852,7 @@ packages:
   license_family: BSD
   size: 61779
   timestamp: 1711136945497
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.2-py310h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.2-py310h80987f9_0.tar.bz2
   sha256: febe6e3746ab0b0ca19c9b7489a3c1d56da2f4298b2f9c257be63fbb7388b4b5
   md5: 56e8294ecd834396658ccbb5b6a468f5
   depends:
@@ -9862,7 +9862,7 @@ packages:
   license_family: MIT
   size: 174905
   timestamp: 1728658346122
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-25.1.2-py310h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-25.1.2-py310h313beb8_0.tar.bz2
   sha256: 7caf005fabe304f949b1c8f2a5950907e911f2ad9f475069732e468109e00550
   md5: bd46d31905afc15f71576b9b3508b85c
   depends:
@@ -9873,7 +9873,7 @@ packages:
   license_family: BSD
   size: 448576
   timestamp: 1705605241316
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
   sha256: 089c6b9bebfa690f380710f219ab0fcc1acec9f2e187d4174a08222c45f58afc
   md5: 11b832c6c10a6d2b0e687a20c3037c97
   depends:
@@ -9881,7 +9881,7 @@ packages:
   license: BSD-3-Clause
   size: 194532
   timestamp: 1652449531448
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -9890,7 +9890,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py310hca03da5_0.tar.bz2
   sha256: df8663fdef4fa89665fd78b0b2cd85e3f3665fcab21f1745975c7f5ca8d89abf
   md5: 6fbce5783df1bd669bc5d9759adc4a22
   depends:
@@ -9901,7 +9901,7 @@ packages:
   license_family: MIT
   size: 59310
   timestamp: 1699012065626
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.32.3-py310hca03da5_1.tar.bz2
   sha256: 5d42a8a52734ee81f902f079098a076b7866a43d92c0576260b349c4380872e0
   md5: a21325ab9964f913e7fa0a72ad612856
   depends:
@@ -9917,7 +9917,7 @@ packages:
   license_family: Apache
   size: 99627
   timestamp: 1730999198570
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-oauthlib-2.0.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-oauthlib-2.0.0-py310hca03da5_0.tar.bz2
   sha256: 4b9e16768aa9ab3d7b22f8c6cab66417c7a0d72ba1e2a1af7f255a39c9bd5196
   md5: f64d42cbe2d32bb9600d70eb504c63ac
   depends:
@@ -9931,7 +9931,7 @@ packages:
   license_family: Other
   size: 35355
   timestamp: 1720615088130
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py310hca03da5_0.tar.bz2
   sha256: 4f7adb8857af54586f8a27fecbd31626160f964ab18efd5a693182a91fe4a287
   md5: 2e2a4c3a1f320aedaf65ea0deec06aa5
   depends:
@@ -9941,7 +9941,7 @@ packages:
   license_family: MIT
   size: 9834
   timestamp: 1683077089689
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py310hca03da5_0.tar.bz2
   sha256: cc20aee97ef5f28b78867fd74e2e9a5785985c3fa56d31f983fea00c2805b76d
   md5: d566a3096aee8f6ea77d12124075ae14
   depends:
@@ -9950,7 +9950,7 @@ packages:
   license_family: MIT
   size: 10216
   timestamp: 1683059019921
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py310h2aea54e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py310h2aea54e_1.tar.bz2
   sha256: 9c2239c9846736019f5a6d1dd6af71bee0e529bf2c6e9c2899893516659820e7
   md5: 527ba0d9051dd6f9dad852c2a56510d5
   depends:
@@ -9959,7 +9959,7 @@ packages:
   license_family: MIT
   size: 317967
   timestamp: 1732228735154
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/s3fs-2024.6.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/s3fs-2024.6.1-py310hca03da5_0.tar.bz2
   sha256: a7a450f86f44c4215a0ca56bf3f847941cf2451b31ac7f7c61aff5d7eb0955ba
   md5: 1961c61c57f1c5d49bcea378d316253f
   depends:
@@ -9971,7 +9971,7 @@ packages:
   license_family: BSD
   size: 57141
   timestamp: 1724924159335
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scikit-image-0.24.0-py310h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/scikit-image-0.24.0-py310h46d7db6_0.tar.bz2
   sha256: 010d94a7c55242256c32f3b42c487b53f0c5e84d941416218b706f658f332d52
   md5: 47be83151779c61a53cb876e4828be7b
   depends:
@@ -9997,7 +9997,7 @@ packages:
   license_family: Other
   size: 12011432
   timestamp: 1726738208952
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.14.1-py310hd336fd7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.14.1-py310hd336fd7_0.tar.bz2
   sha256: c6e9bcae595697f632783f3ea3fbb0882e24c645f58848aeae3fbcc97d89880c
   md5: d92ee83bf55d4364b672cda45bc1b99e
   depends:
@@ -10014,7 +10014,7 @@ packages:
   license_family: BSD
   size: 23883658
   timestamp: 1731627266555
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py310hca03da5_0.tar.bz2
   sha256: fd992b57890893f639b37cc529876a6efbd8acad4fb1f6e82c24994ba4bf4c69
   md5: 47a4a8ea39e24c437515e906d8b65bf0
   depends:
@@ -10023,7 +10023,7 @@ packages:
   license_family: BSD
   size: 28099
   timestamp: 1699371253809
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-75.1.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-75.1.0-py310hca03da5_0.tar.bz2
   sha256: d498fc185eaa21221eb23dc177ffce3ce10e6b1395e04610a011b3508757cd17
   md5: 344e3c8d1b1fd862480b9f7fcd8d10ce
   depends:
@@ -10032,7 +10032,7 @@ packages:
   license_family: MIT
   size: 1765257
   timestamp: 1726677915032
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
   sha256: 499623019bea7cd167924f7fa841237b11b81a1e9cafe9b8ffde47d329275167
   md5: 290d04cffc69bf26a4ed9f1aa9ad42e4
   depends:
@@ -10041,7 +10041,7 @@ packages:
   license_family: BSD
   size: 46038
   timestamp: 1723557442909
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py310hca03da5_0.tar.bz2
   sha256: 74d7c55748b5c46e8ebe6249c8528de7a27426b905953f927f41a4aa61f0d6df
   md5: 78c17d8433ab6fcbd613cd9d21bc09b7
   depends:
@@ -10050,7 +10050,7 @@ packages:
   license_family: Other
   size: 17940
   timestamp: 1705431340501
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py310hca03da5_0.tar.bz2
   sha256: 83f37d7fdb2ae2499a0d56b0d8b73aaea225272a1133ec83b7cb5a0b76dcc038
   md5: 4cf31645d894294b7542e108702346c3
   depends:
@@ -10059,7 +10059,7 @@ packages:
   license_family: MIT
   size: 67932
   timestamp: 1696347608160
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
   sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
   md5: d8c1e9910392d0bcb22a173f9ce30fa6
   depends:
@@ -10071,7 +10071,7 @@ packages:
   license_family: Other
   size: 1758290
   timestamp: 1714488307689
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
   sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
   md5: ae58720a18a2ed15eae214ad7a10d1b5
   depends:
@@ -10080,7 +10080,7 @@ packages:
   license_family: Apache
   size: 140125
   timestamp: 1680167256603
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorboard-2.12.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tensorboard-2.12.1-py310hca03da5_0.tar.bz2
   sha256: c311388b0f6d85e4d998b1f77fdf7b6d5e51de99cb78ace00a41cbc39c66ee85
   md5: 095ed3fb6891f86368cb364d9ce37150
   depends:
@@ -10102,7 +10102,7 @@ packages:
   license_family: Apache
   size: 5869202
   timestamp: 1685305653579
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorboard-data-server-0.7.0-py310ha6e5c4f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tensorboard-data-server-0.7.0-py310ha6e5c4f_1.tar.bz2
   sha256: bcf5233efed232dcefca8427720f7fb4ce72467ea0d396a7807c049d5502cfee
   md5: e473ffbe3ae923f1e4b72add11c37cbc
   depends:
@@ -10111,7 +10111,7 @@ packages:
   license_family: Apache
   size: 4182035
   timestamp: 1724172754917
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorboard-plugin-wit-1.8.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tensorboard-plugin-wit-1.8.1-py310hca03da5_0.tar.bz2
   sha256: 225d625c1a1cc7dbfc8541f87f41469338fc6a8eddff0b1b4814f0f8b94e108b
   md5: 06cf2d4a33a18bcc50e77656e92808bb
   depends:
@@ -10122,7 +10122,7 @@ packages:
   license_family: Apache
   size: 722007
   timestamp: 1685213436358
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorflow-2.12.0-eigen_py310h205ab9b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tensorflow-2.12.0-eigen_py310h205ab9b_0.tar.bz2
   sha256: 6fd1c01721aab6583c778f94044bf7f8a986d9d447fbf6f64c6f9b6aff2513c1
   md5: 4b450488b1301f18bf11bd83b98a9efb
   depends:
@@ -10135,7 +10135,7 @@ packages:
   license_family: Apache
   size: 4942
   timestamp: 1685908005956
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorflow-base-2.12.0-eigen_py310h0a52ebb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tensorflow-base-2.12.0-eigen_py310h0a52ebb_0.tar.bz2
   sha256: 3d985442798fbf1dd29c01728f31979c4ce2dcd03d2903970b6ca58f82759eb5
   md5: bfcb054e066f0afbed9d9298bd3a6fe1
   depends:
@@ -10179,7 +10179,7 @@ packages:
   license_family: Apache
   size: 200481940
   timestamp: 1685513389284
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tensorflow-estimator-2.12.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tensorflow-estimator-2.12.0-py310hca03da5_0.tar.bz2
   sha256: 0fc0920631637b7b0252237c998d450b5ecf7ba46ac3034fe5c7eb2e39bebf82
   md5: d7edcb13c28ea29edc86aeb00dc2a8da
   depends:
@@ -10190,7 +10190,7 @@ packages:
   license_family: Apache
   size: 619036
   timestamp: 1684880462952
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/termcolor-2.1.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/termcolor-2.1.0-py310hca03da5_0.tar.bz2
   sha256: 7ff45c2465dc239ba4793d964473638382c5b6ea3ac468021c249ff55f387b21
   md5: 5d9ac5c4207e1b41706f19820b8c1742
   depends:
@@ -10199,7 +10199,7 @@ packages:
   license_family: MIT
   size: 12008
   timestamp: 1668084673536
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py310hca03da5_0.tar.bz2
   sha256: 683dfdcb2fa481064ecb68361103214c5c3f2734cceb055af3f93a2ae4863c01
   md5: 88e05e239da5183806dbebb6ac49cddf
   depends:
@@ -10210,7 +10210,7 @@ packages:
   license_family: BSD
   size: 31121
   timestamp: 1671751855788
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tifffile-2023.4.12-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tifffile-2023.4.12-py310hca03da5_0.tar.bz2
   sha256: 1ad1cd47a353b111a09f6e828e711a48f76d030f3af11323f608d7faad2b053b
   md5: df1635abb9786209a3a0d93c55745e88
   depends:
@@ -10223,7 +10223,7 @@ packages:
   license_family: BSD
   size: 391886
   timestamp: 1695107571656
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py310hca03da5_0.tar.bz2
   sha256: 1ff9b75217073a26f736b2fe32f9ccb77b145d7ff9099d5091b43276f92b1f12
   md5: 11474a3502e9b8c16e301569b7f3d8db
   depends:
@@ -10233,7 +10233,7 @@ packages:
   license_family: BSD
   size: 40061
   timestamp: 1668168847595
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
   sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
   md5: 3c25b4f4768ccda28b20a03ba27e7759
   depends:
@@ -10242,7 +10242,7 @@ packages:
   license_family: BSD
   size: 3484151
   timestamp: 1714770744982
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tomli-2.0.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tomli-2.0.1-py310hca03da5_0.tar.bz2
   sha256: 8ddc284644ca9b8b23562f7b03d0960b6a43beafe9cb1fa9c89c23f57a7dab06
   md5: 343e7b890cb241ab89d2f77f22e5c152
   depends:
@@ -10251,7 +10251,7 @@ packages:
   license_family: MIT
   size: 25797
   timestamp: 1657175650575
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py310hca03da5_0.tar.bz2
   sha256: 14e106fcb4a36e245d87f22c4981abb173508a29d6067baec2c4702b6ff65e87
   md5: 14ae49e3923e548b548f66651604f7d3
   depends:
@@ -10260,7 +10260,7 @@ packages:
   license_family: BSD
   size: 104795
   timestamp: 1667464180564
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.1-py310h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.4.1-py310h80987f9_0.tar.bz2
   sha256: 7a248d0a49dc40b943f1d04e4c5cb6f77513ac2600c81fe1bca42b1813da2f15
   md5: e62c2beab656357405fee719ff66990c
   depends:
@@ -10269,7 +10269,7 @@ packages:
   license_family: Apache
   size: 699237
   timestamp: 1718740235165
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.5-py310h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.66.5-py310h33ce5c2_0.tar.bz2
   sha256: 817940863cce40c31c4a1a69c79396a1ed5a5870964c7b54e9c33be98e44aa90
   md5: 438d21cdd02411d558d4fb770005002e
   depends:
@@ -10280,7 +10280,7 @@ packages:
   license_family: MOZILLA
   size: 128410
   timestamp: 1724854061501
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.14.3-py310hca03da5_0.tar.bz2
   sha256: e9de8f52d147e7dd072058d19202ee179841a56f792224729723a470571b717f
   md5: 3369365fe73af0c8b47246afdce17709
   depends:
@@ -10289,7 +10289,7 @@ packages:
   license_family: BSD
   size: 168051
   timestamp: 1718227147763
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.11.0-py310hca03da5_0.tar.bz2
   sha256: 15854b2bfac87685fa4815a8617934f5e0ff96d097c428615d879cf0c687c682
   md5: 8816d89e20b6cac4b750be13ad73e304
   depends:
@@ -10299,7 +10299,7 @@ packages:
   license_family: PSF
   size: 9879
   timestamp: 1715268909862
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.11.0-py310hca03da5_0.tar.bz2
   sha256: 6ff5a1ad8c4006966bb7200399cc6d4644b0e32fe6696a1ec9c34d239f7e7128
   md5: e2d4052bbc72e068bfe888f4e6a68097
   depends:
@@ -10308,7 +10308,7 @@ packages:
   license_family: PSF
   size: 61500
   timestamp: 1715268901349
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py310hca03da5_0.tar.bz2
   sha256: 824583d1b434a796b37b52eed6e4356ee22fb743bbef86fb59d059d100d9bbbb
   md5: d7f13af76ca65f6145c835983c1b42df
   depends:
@@ -10317,7 +10317,7 @@ packages:
   license_family: MIT
   size: 11622
   timestamp: 1659769445368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py310h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py310h80987f9_0.tar.bz2
   sha256: 3f3a102f3b5fe0000a8680efe4999c326bb1dcb2a1d2d06ff82333039018aa21
   md5: a84cbf641719bbd618cae4397d952e72
   depends:
@@ -10326,7 +10326,7 @@ packages:
   license_family: Apache
   size: 523268
   timestamp: 1713212983398
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.2.3-py310hca03da5_0.tar.bz2
   sha256: 74217fd981d1c19bad2c15bf9577093d341dc124727bc528ff5e40de5fcbbb52
   md5: d01e93793f9fa0775bfa0b9904ebaab4
   depends:
@@ -10342,14 +10342,14 @@ packages:
   license_family: MIT
   size: 174257
   timestamp: 1727769883712
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
   sha256: 20ae100fd04de16356f26e7c9dab514015e57a9d54fb78767aa5ed97de7846fb
   md5: f620d98b3d0072945948310c86f0f1c5
   license: MIT
   license_family: MIT
   size: 157385
   timestamp: 1706894678643
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py310hca03da5_1.tar.bz2
   sha256: 380724b46ae0ae1edb42bc668055aa2f27af3054d866b1e67e5acbb8481cd3a7
   md5: 6bf29c754086a9d03490af7ef3f22e6d
   depends:
@@ -10358,7 +10358,7 @@ packages:
   license_family: BSD
   size: 21597
   timestamp: 1643962111312
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py310hca03da5_0.tar.bz2
   sha256: 3f533f0c2bc844c53f530c8a25f1e1fe27b94d38a76b9601bca8dd0379b5ec05
   md5: 52665fad203685a097d2f3eca1085240
   depends:
@@ -10367,7 +10367,7 @@ packages:
   license_family: Apache
   size: 88221
   timestamp: 1715878353350
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/werkzeug-3.0.6-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/werkzeug-3.0.6-py310hca03da5_0.tar.bz2
   sha256: cb31f9c6636183bc6d72bde1208eace0e4da31b7f4ad1cd5e88f22a1180ae2ab
   md5: 4e00e1e0d58ea83e1cc93f7d2f13ed22
   depends:
@@ -10379,7 +10379,7 @@ packages:
   license_family: BSD
   size: 346279
   timestamp: 1731005809337
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/widgetsnbextension-4.0.10-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/widgetsnbextension-4.0.10-py310hca03da5_0.tar.bz2
   sha256: 647f364c602b7f26007fee632f8273849dbdf01f004e83caa8d2720f5580d442
   md5: 7cb4009835e24e3929a19845c6b8da6b
   depends:
@@ -10388,7 +10388,7 @@ packages:
   license_family: BSD
   size: 1930938
   timestamp: 1709323019126
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wrapt-1.14.1-py310h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wrapt-1.14.1-py310h1a28f6b_0.tar.bz2
   sha256: e771100bec4b041a9048b8f5553bf1053f640bf4f25b09612adb06ed7f4c4098
   md5: 3a4f0d98aaa4aeb854a448eed833a322
   depends:
@@ -10397,7 +10397,7 @@ packages:
   license_family: BSD
   size: 51834
   timestamp: 1657814575175
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py310hca03da5_0.tar.bz2
   sha256: 27799dc34dc007484c93c06823631ca50216f651801061db60b36fbf0b4afcf4
   md5: 15bd618a92cbd03ec24cd6fbfe81fa68
   depends:
@@ -10409,7 +10409,7 @@ packages:
   license_family: Apache
   size: 1818414
   timestamp: 1689041533776
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py310hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py310hca03da5_1.tar.bz2
   sha256: d1ff32f75206387e8ab53e1b2253668fb79d18f79811f4547fd204093a9d75f7
   md5: 7083a0ee005b52138b63e2c3ef37df4b
   depends:
@@ -10418,20 +10418,20 @@ packages:
   license_family: BSD
   size: 49594
   timestamp: 1675159129875
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
   sha256: 5be8c968f2da5c4bf14f28d63e31b4c1b6993d980023769732c7f58f396c2e0b
   md5: 3f5f62d4e85e3bdd48d39189b01805a6
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 459197
   timestamp: 1714510992914
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yarl-1.18.0-py310h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yarl-1.18.0-py310h80987f9_0.tar.bz2
   sha256: ac9a82d3399136b6eaebc9a5c278c1ce86a9f2eebdca2ae17e66358c986a1168
   md5: c9d075e759e3d384310e8b10d092084b
   depends:
@@ -10443,7 +10443,7 @@ packages:
   license_family: Apache
   size: 135788
   timestamp: 1732547129408
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zarr-2.13.3-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zarr-2.13.3-py310hca03da5_0.tar.bz2
   sha256: e17b4b64b6058fc870e69a86ff377b06439971296093ccc9da9861c8a80b5c03
   md5: b3ccd5d7e7c7048b7d798c9d01024620
   depends:
@@ -10456,7 +10456,7 @@ packages:
   license_family: MIT
   size: 344390
   timestamp: 1669363674747
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
   sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
   md5: 3d57d1adadca9388aaaa1c529b65ba65
   depends:
@@ -10466,7 +10466,7 @@ packages:
   license_family: Other
   size: 322790
   timestamp: 1705602163804
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zfp-1.0.0-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zfp-1.0.0-h313beb8_0.tar.bz2
   sha256: 181d62294369598af7fd5dea778dcddca50009e699be1572750d419beba80e6b
   md5: 48eeb271f7289214d616f859c55dece9
   depends:
@@ -10476,7 +10476,7 @@ packages:
   license_family: BSD
   size: 258119
   timestamp: 1681741613773
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zict-3.0.0-py310hca03da5_0.tar.bz2
   sha256: aaf540e76af5e232512ee8db93533fea0419fb45526e2974159bc2b5fb74f780
   md5: b036e3a6fb1194550195539758747e43
   depends:
@@ -10487,7 +10487,7 @@ packages:
   license_family: BSD
   size: 78760
   timestamp: 1695832948385
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.21.0-py310hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.21.0-py310hca03da5_0.tar.bz2
   sha256: 525dc47b438e257ee05d5132926d25ae2869f5c81facc885ad5d79d3306fff8d
   md5: 3652cf80edd101e3c2d2fd04092e04fc
   depends:
@@ -10496,14 +10496,14 @@ packages:
   license_family: MIT
   size: 26912
   timestamp: 1732630823321
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
   sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
   md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
   license: Zlib
   license_family: Other
   size: 104928
   timestamp: 1714510936868
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
   sha256: 43667132ec8fa4c34ba438e13a01b08073e3e3e8a648ecdb6afe4141a7c197e2
   md5: fb8c3f5683b19dd3743d125797b8e2dd
   depends:
@@ -10514,12 +10514,12 @@ packages:
   license_family: BSD
   size: 817614
   timestamp: 1728486986031
-- conda: https://repo.anaconda.com/pkgs/main/win-64/_tflow_select-2.3.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/_tflow_select-2.3.0-mkl.tar.bz2
   sha256: f3ec304f40084b29eddfbd2e1ce77877252f731f87e5db242010a7e2eef3714a
   md5: 057245f0ffc8c7becdba042af6cb786a
   size: 3554
   timestamp: 1606816560846
-- conda: https://repo.anaconda.com/pkgs/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
   sha256: c5a4f98a90713f799a73195cc159571c4bd373bfa43640dc0c1707608e582945
   md5: 537f198da93942d8ef7008606edae551
   depends:
@@ -10529,7 +10529,7 @@ packages:
   license_family: Apache
   size: 2363136
   timestamp: 1652426285158
-- conda: https://repo.anaconda.com/pkgs/main/win-64/absl-py-2.1.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/absl-py-2.1.0-py310haa95532_0.tar.bz2
   sha256: 443e079c9e8790aba2fa7392779211d8a3bfb4f60c37f845e66f36b3535674c8
   md5: 7d44cf22812584df7c7c8ae8f163c9cc
   depends:
@@ -10538,7 +10538,7 @@ packages:
   license_family: Apache
   size: 188106
   timestamp: 1714140545616
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aiobotocore-2.12.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aiobotocore-2.12.3-py310haa95532_0.tar.bz2
   sha256: 1fe4438f6753fb4315a0a63a9b2c92a0e1001bb10e1af65de9ebb731c22b2e06
   md5: 782a10d443e02c44830056af068d87c0
   depends:
@@ -10553,7 +10553,7 @@ packages:
   license_family: Apache
   size: 111953
   timestamp: 1714464654611
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aiohappyeyeballs-2.4.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aiohappyeyeballs-2.4.3-py310haa95532_0.tar.bz2
   sha256: 4e283289be3066a77848840fbb3412d3d0ca9558b92e58b01d0288518cfdec42
   md5: 915a16d061e68ba8dd44b6de5f982f80
   depends:
@@ -10562,7 +10562,7 @@ packages:
   license_family: Other
   size: 26137
   timestamp: 1732664027237
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aiohttp-3.10.5-py310h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aiohttp-3.10.5-py310h827c3e9_0.tar.bz2
   sha256: 2082095321722a5f7b89c4807dd1ff1da82e620ab9c9f5b2988258ae88829be1
   md5: 593d0abb991df34fc3b4cad08b421af7
   depends:
@@ -10580,7 +10580,7 @@ packages:
   license_family: Other
   size: 748491
   timestamp: 1725529464978
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.6.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-4.6.2-py310haa95532_0.tar.bz2
   sha256: ecfda3087fb1731cf249e5c348f924cdeb7d4cd477f58523b8cc0609c89f7d83
   md5: db8e0e2dfaa8bf2decbc5c8fd5c290bf
   depends:
@@ -10595,7 +10595,7 @@ packages:
   license_family: MIT
   size: 192290
   timestamp: 1729121825942
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aom-3.6.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aom-3.6.0-hd77b12b_0.tar.bz2
   sha256: 7ad83463e67a5f6da32568a567914a0f1ed5052268548371eb9ca66b4a0eee00
   md5: 99feb2bd2c24eb7726f4a05f9fa1b809
   depends:
@@ -10605,7 +10605,7 @@ packages:
   license_family: BSD
   size: 12387035
   timestamp: 1688666342169
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py310h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py310h2bbff1b_0.tar.bz2
   sha256: b1f650ded18f00b931bca2cfbe25d23234ebc094ceb1ff90ca0f9748773d77b0
   md5: 2ab6af43f2a175c8cd55263ce03730e9
   depends:
@@ -10617,7 +10617,7 @@ packages:
   license_family: MIT
   size: 39303
   timestamp: 1644569997665
-- conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-11.0.0-h2c9b28c_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/arrow-cpp-11.0.0-h2c9b28c_2.tar.bz2
   sha256: f21f6ce91b4587eb51e05435b2f1ab0cbd3c33cdff7a2851451aa65a8bd2d6a3
   md5: 6e7ca99ceca0fa3474a2e9f95e80ad15
   depends:
@@ -10646,7 +10646,7 @@ packages:
   license_family: Apache
   size: 8320723
   timestamp: 1693264194855
-- conda: https://repo.anaconda.com/pkgs/main/win-64/async-lru-2.0.4-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/async-lru-2.0.4-py310haa95532_0.tar.bz2
   sha256: d2d6afdc5b62ab3edfba87aecd1e33eac7b2004ecdc3a571662870f5b25e5f3f
   md5: 4807d2b0ec114fc10f6421446ee0ed06
   depends:
@@ -10656,7 +10656,7 @@ packages:
   license_family: MIT
   size: 18367
   timestamp: 1699554857322
-- conda: https://repo.anaconda.com/pkgs/main/win-64/async-timeout-4.0.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/async-timeout-4.0.3-py310haa95532_0.tar.bz2
   sha256: e8e45168459577a436cfa023c425d1e5a1895b8108cb0cfd81704519d7a8b2b7
   md5: 5fec752ec5dd8c9478c695bb447677dd
   depends:
@@ -10665,7 +10665,7 @@ packages:
   license_family: Apache
   size: 12959
   timestamp: 1703097663627
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-24.2.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-24.2.0-py310haa95532_0.tar.bz2
   sha256: 5b7f5b31348559233f13ba3a6f006e1f19a44e6d064cabdf519a05bc78005c14
   md5: a889d7f22a91b01f5e63005a971575c8
   depends:
@@ -10674,7 +10674,7 @@ packages:
   license_family: MIT
   size: 142855
   timestamp: 1729089569199
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.4.57-ha925a31_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-common-0.4.57-ha925a31_1.tar.bz2
   sha256: 91a78979ae6c1f5ff02dd1076aa62e2da7e610647203cd8985e0ea25465f2a74
   md5: 7878a5b35caf8db44fffffe0ba320951
   depends:
@@ -10684,7 +10684,7 @@ packages:
   license_family: Apache
   size: 155676
   timestamp: 1601398472136
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.1.6-hd77b12b_5.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-event-stream-0.1.6-hd77b12b_5.tar.bz2
   sha256: 08437ce1c93997e5f5e8a6a7a8835b9b3a96d8be97c7752644fc9b2ae9788c8e
   md5: 1883d49fb78e0858f007a73e042e5c3a
   depends:
@@ -10696,7 +10696,7 @@ packages:
   license_family: Apache
   size: 27050
   timestamp: 1603894719881
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.9-ha925a31_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-checksums-0.1.9-ha925a31_0.tar.bz2
   sha256: 6947f2b605db23cf0f80f7009fc09eba477c7ae80d55ec81f640ed8b1854a1a6
   md5: 067a7194f4f3d8e8bbe37d8825503cd3
   depends:
@@ -10707,7 +10707,7 @@ packages:
   license_family: Apache
   size: 54104
   timestamp: 1601398697615
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.8.185-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-sdk-cpp-1.8.185-hd77b12b_0.tar.bz2
   sha256: ba257fb24561340ca04c372d9624954b8a57af11999eb9dea42faac47f20e5b9
   md5: 93b4a964f3722da3eb9ad019e7e88f3f
   depends:
@@ -10720,7 +10720,7 @@ packages:
   license_family: Apache
   size: 3226667
   timestamp: 1618435213786
-- conda: https://repo.anaconda.com/pkgs/main/win-64/babel-2.11.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/babel-2.11.0-py310haa95532_0.tar.bz2
   sha256: fbb1373cda22f5a5c6f67968ed5901fb00781b7e9e87429437ac89c6cc64a168
   md5: fea96278d6b5c42c923ba515a0b4351e
   depends:
@@ -10730,7 +10730,7 @@ packages:
   license_family: BSD
   size: 7198403
   timestamp: 1671783246685
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.3-py310haa95532_0.tar.bz2
   sha256: 12c5cb0f8234c2b749d9602992fb137a18b56d13452dcbfa80435d14122710db
   md5: 8639e3c3c62a03f9fca459e353a3a901
   depends:
@@ -10740,12 +10740,12 @@ packages:
   license_family: MIT
   size: 211275
   timestamp: 1718030011501
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bleach-6.2.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bleach-6.2.0-py310haa95532_0.tar.bz2
   sha256: 40990071f8003e2ba59cc377b2753ba87acd501b5fff248578c1032e936348f0
   md5: 8a53f53b041de430ce82308555b83cdc
   depends:
@@ -10757,7 +10757,7 @@ packages:
   license_family: Apache
   size: 298165
   timestamp: 1732293154560
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blinker-1.6.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blinker-1.6.2-py310haa95532_0.tar.bz2
   sha256: a9c2fc84a9ecaafcc2a2c37db91be89ac97a58a251df7be88847492301e8f996
   md5: 52611d378f2d06886209e83b6de2937c
   depends:
@@ -10766,7 +10766,7 @@ packages:
   license_family: MIT
   size: 28907
   timestamp: 1696540014600
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
   sha256: cf9a8a0745c5fab48394d84a58fe2f06e5fa80c87d5cc8d6c8da2e1df52cc69f
   md5: 462987773ecda8cbf1f80734e84f080f
   depends:
@@ -10779,7 +10779,7 @@ packages:
   license_family: BSD
   size: 93601
   timestamp: 1675247818708
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.6.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-3.6.0-py310haa95532_0.tar.bz2
   sha256: 41ae68725c7e8e68dd28bcf4d84d590b09373f61fbcb312c68be0bfb0682e54d
   md5: b7719d19c90e44e3c1777af8c0aedf52
   depends:
@@ -10797,7 +10797,7 @@ packages:
   license_family: BSD
   size: 5675101
   timestamp: 1727914954631
-- conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
   sha256: 68ef338b27c035add89c0812ad469dd8c9e94f27130f770345ea20deb049d50b
   md5: 9ec19b145f655329532b608963cf32f4
   depends:
@@ -10808,7 +10808,7 @@ packages:
   license_family: OTHER
   size: 11334
   timestamp: 1696764270626
-- conda: https://repo.anaconda.com/pkgs/main/win-64/botocore-1.34.69-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/botocore-1.34.69-py310haa95532_0.tar.bz2
   sha256: 5ca3f426a4e7843c56d555b6d98a3b384f1a5fd9cd167e3528177a505c967ddd
   md5: 64f280dd3b623da06ba2c3776ea5e55d
   depends:
@@ -10820,7 +10820,7 @@ packages:
   license_family: Apache
   size: 7726781
   timestamp: 1714461508553
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.4.2-py310hc99e966_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.4.2-py310hc99e966_0.tar.bz2
   sha256: 99615408b6709c6f2b7016e8e9bae3e8ac041cf5eec0c5fa8903e253eea5d959
   md5: b34f13e06879011b21870d60e649a5db
   depends:
@@ -10832,7 +10832,7 @@ packages:
   license_family: BSD
   size: 142517
   timestamp: 1731058923141
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 751071782f597f87ed7f67437ef6cc669213902461b9795dd6eb0f4897eddc83
   md5: 5ad8fe62aad5e16cfdf2c5a7d1327fe7
   depends:
@@ -10844,7 +10844,7 @@ packages:
   license: MIT
   size: 19418
   timestamp: 1714483531456
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 9bd62d810867549b9c967c5915f3fa3f66cfbd6ede28b1cc152efd1261285c0a
   md5: 64cc76de3662b62bc8f0e42befd92c5d
   depends:
@@ -10855,7 +10855,7 @@ packages:
   license: MIT
   size: 32178
   timestamp: 1714483513837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py310hd77b12b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py310hd77b12b_8.tar.bz2
   sha256: 57d5d504b9e650f265028f344f1063ae5a90767a475d607f3776c4553a1b78f4
   md5: d214a86a5614ca70b68c884a71b5e576
   depends:
@@ -10865,7 +10865,7 @@ packages:
   license: MIT
   size: 356288
   timestamp: 1714483603688
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
   sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
   md5: 11e0af09a31e2d5df51c65a342032b85
   depends:
@@ -10875,7 +10875,7 @@ packages:
   license_family: BSD
   size: 112994
   timestamp: 1714511182837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
   sha256: 41a6c5a90b88ec7010bb6dd89390754e476b52c3ab2d519bdab9556da8829479
   md5: b047426a545e287f45e8abfbfcb0de55
   depends:
@@ -10885,14 +10885,14 @@ packages:
   license_family: MIT
   size: 118041
   timestamp: 1693902191485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.11.26-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2024.11.26-haa95532_0.tar.bz2
   sha256: 8baa3961c182bf6a3874d69bcfb8dd5350133f0ed02e3db725210a945409dcad
   md5: e611070c5c0bee5862dfff55004f594e
   license: MPL-2.0
   license_family: Other
   size: 177029
   timestamp: 1732804476945
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cachetools-5.3.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cachetools-5.3.3-py310haa95532_0.tar.bz2
   sha256: c14e090eb464660f3e2a2654a64b51d60af674b09c8581f837dd26d9a634b1f2
   md5: f7405529b8f524525fa2d257a0202038
   depends:
@@ -10901,7 +10901,7 @@ packages:
   license_family: MIT
   size: 23754
   timestamp: 1713977318112
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.8.30-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2024.8.30-py310haa95532_0.tar.bz2
   sha256: 47e7915d7e09b88dd4bdf9c177ba02bb03673516d37c4097a58120fcf0949b0f
   md5: 91ca0e734e3734a1cc4dcddd4806f68b
   depends:
@@ -10910,7 +10910,7 @@ packages:
   license_family: Other
   size: 168558
   timestamp: 1725551780848
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py310h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.17.1-py310h827c3e9_0.tar.bz2
   sha256: a390a89cd782595ffc6205b0f5292dbaccf41ca3e418c4934a0acf31586f7513
   md5: fe0f8a3d45fac25ee8567607a9fe62d9
   depends:
@@ -10922,7 +10922,7 @@ packages:
   license_family: MIT
   size: 253364
   timestamp: 1726856769034
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
   sha256: a65386e70bdad9aa1e07ad430309c3ddc249b74bea69388dfbda99fd00069665
   md5: e4174218de194962642b353f51a19d1e
   depends:
@@ -10932,7 +10932,7 @@ packages:
   license_family: Other
   size: 617890
   timestamp: 1655709069465
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cftime-1.6.2-py310h9128911_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cftime-1.6.2-py310h9128911_0.tar.bz2
   sha256: babb47fcbc9e7fe09a29c837ae763f73d1621290e44542b660d5dc3b4e499958
   md5: 76907acc0a04b1c50c95e00fb4be6fa8
   depends:
@@ -10944,7 +10944,7 @@ packages:
   license_family: MIT
   size: 177840
   timestamp: 1678830649951
-- conda: https://repo.anaconda.com/pkgs/main/win-64/charls-2.2.0-h6c2663c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/charls-2.2.0-h6c2663c_0.tar.bz2
   sha256: 98e6346139899b0c9ce6518e304c8b1fd1b8746a410fcc8d83cbc9f08125ecc7
   md5: 5cdda32dbdd11de0555c255a598173c0
   depends:
@@ -10954,7 +10954,7 @@ packages:
   license_family: BSD
   size: 95720
   timestamp: 1612240685008
-- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py310haa95532_0.tar.bz2
   sha256: b91d0263ac52eddd283bcaa76aa28a85be150103489c76fac0e9a60c75da0252
   md5: 3753a68430067379af7ec9517a950c2d
   depends:
@@ -10964,7 +10964,7 @@ packages:
   license_family: BSD
   size: 155422
   timestamp: 1698129904518
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.0.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cloudpickle-3.0.0-py310haa95532_0.tar.bz2
   sha256: 7dbc6578b15462c437b1b227f3bc9c2c39b5f33189a586f3553e7951d940237f
   md5: a01b281d860965fe1d6d5c80ead35f81
   depends:
@@ -10973,7 +10973,7 @@ packages:
   license_family: BSD
   size: 35625
   timestamp: 1721657609411
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py310haa95532_0.tar.bz2
   sha256: 9d1b2c34fa17a72e4e7b265cb5a421bb1a6dc893b35209739f1b710f79ebcc19
   md5: 269703fa9499eb42cfd7b9fd349ecd22
   depends:
@@ -10982,7 +10982,7 @@ packages:
   license_family: BSD
   size: 30646
   timestamp: 1672387329696
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py310haa95532_0.tar.bz2
   sha256: d7e9ef9b790e0d531490ee8eb3d727ace2a9f30d94e547029e1d0a84747c168a
   md5: 95fcb8f56ad31f96ae9b8767ad30cd35
   depends:
@@ -10991,7 +10991,7 @@ packages:
   license_family: CC
   size: 498954
   timestamp: 1709758473914
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py310haa95532_0.tar.bz2
   sha256: 4b53b13fd2c5a010dc8725d16bd5577c87c3db5aad4f9f52d508375dae67b45c
   md5: bde516d96fe11739e7703be8114b49e6
   depends:
@@ -11001,7 +11001,7 @@ packages:
   license_family: BSD
   size: 15512
   timestamp: 1709322968038
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.3.1-py310h214f63a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.3.1-py310h214f63a_0.tar.bz2
   sha256: b33d9792d18c1ef1cdbdee252a7340ea47d2ef5a174edaf77eb5c9bcfa88a956
   md5: ffdd9900f86e96fc95ab0a7095a347f6
   depends:
@@ -11013,7 +11013,7 @@ packages:
   license_family: BSD
   size: 230563
   timestamp: 1732540222453
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py310h3438e0d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py310h3438e0d_0.tar.bz2
   sha256: 3b3df6fcfbda564fb76eb78a2aec8991c63ad343c2017708c6d67f8adb3ddaf4
   md5: ba5643f998e3253c96be64bbc08b8d65
   depends:
@@ -11028,7 +11028,7 @@ packages:
   license_family: BSD
   size: 1226210
   timestamp: 1694446525776
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.2-py310h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cytoolz-0.12.2-py310h2bbff1b_0.tar.bz2
   sha256: 34f3495bb04b571404cf9160efecbe783850436695cfd2bba5b7e08278ab4dbb
   md5: 4434479a431a9971c90080454602a8f2
   depends:
@@ -11040,7 +11040,7 @@ packages:
   license_family: BSD
   size: 342657
   timestamp: 1701723828014
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-2024.5.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/dask-2024.5.0-py310haa95532_0.tar.bz2
   sha256: 866c874e6c1845098368da1b0de6c71957b46675109fd0271422d84075f59259
   md5: 9e3d75a91ae4f3eb3fba2cfbed94e164
   depends:
@@ -11059,7 +11059,7 @@ packages:
   license_family: BSD
   size: 6132
   timestamp: 1715848980276
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.5.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/dask-core-2024.5.0-py310haa95532_0.tar.bz2
   sha256: 968af80d08d73cd0b26028b9f039b448591e22e8afbfe9a7d920bef11cdf7ecc
   md5: 0ae8577bdfc2743206fbc5f9230d21a6
   depends:
@@ -11076,7 +11076,7 @@ packages:
   license_family: BSD
   size: 2302878
   timestamp: 1715838969439
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-expr-1.1.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/dask-expr-1.1.0-py310haa95532_0.tar.bz2
   sha256: 34f5178da52fc6226de5a35fef4d7ffd7c653d8714ddd9e5ec7598294a3fabe7
   md5: 8b9f4c5d8e014cc66b7e11cec425e251
   depends:
@@ -11088,7 +11088,7 @@ packages:
   license_family: BSD
   size: 356434
   timestamp: 1715846725323
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dav1d-1.2.1-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/dav1d-1.2.1-h2bbff1b_0.tar.bz2
   sha256: e59970edb08a1dc24d761f88657aed895d7715f66ac9a9acfda440c29fda05e0
   md5: d3d303a3ffcedb8f4a92f29ac9e67bdc
   depends:
@@ -11098,7 +11098,7 @@ packages:
   license_family: BSD
   size: 723931
   timestamp: 1688746263355
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py310hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py310hd77b12b_0.tar.bz2
   sha256: 847a1d4e079ce688c7e984cbf0c5c8a271c8e818c394433375b5a4f2b27beed1
   md5: 3e4eb1dbd11005205430e157cc260dd6
   depends:
@@ -11109,7 +11109,7 @@ packages:
   license_family: MIT
   size: 3304234
   timestamp: 1690907391803
-- conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2024.5.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/distributed-2024.5.0-py310haa95532_0.tar.bz2
   sha256: 6c83e6a42023316cefe72ccc2af700f2eb829036e1f82c52d09491df7360270b
   md5: bf335d8c68f8c9fe3efbe156f43f13c8
   depends:
@@ -11133,7 +11133,7 @@ packages:
   license_family: BSD
   size: 1514046
   timestamp: 1715844621307
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py310haa95532_0.tar.bz2
   sha256: 542db7e187d0a9fe16b6eacb6bb93e5d574d1956687553a85a33fd580ab6ab7c
   md5: efac5662f2dbe0fabf392e1dd89eb105
   depends:
@@ -11142,7 +11142,7 @@ packages:
   license_family: MIT
   size: 17084
   timestamp: 1649926751338
-- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.2.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.2.0-py310haa95532_0.tar.bz2
   sha256: 0c56bdda8b41de6668a405a5d60f27a9420387f69fc1722ed06384fff76357e8
   md5: 430b811c79d3f19e0d315a40a9e409f3
   depends:
@@ -11151,7 +11151,7 @@ packages:
   license_family: MIT
   size: 30636
   timestamp: 1706031719341
-- conda: https://repo.anaconda.com/pkgs/main/win-64/flatbuffers-2.0.0-h6c2663c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/flatbuffers-2.0.0-h6c2663c_0.tar.bz2
   sha256: 2012b9280b6a9c3936c1581b7485f26fcec2bde169e1e779d13425bad3e5b0d8
   md5: 518f7695450e8118b6d14d3d6eeac482
   depends:
@@ -11160,7 +11160,7 @@ packages:
   license: Apache-2.0
   size: 1879231
   timestamp: 1620826057100
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py310h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fonttools-4.51.0-py310h2bbff1b_0.tar.bz2
   sha256: aa103c59447a75ea3b27a31d13b439c211c8519696709a3d8afc115e03f8eab8
   md5: e8cb69900c25f826c56fc9022b58c84b
   depends:
@@ -11180,7 +11180,7 @@ packages:
   license_family: MIT
   size: 2213049
   timestamp: 1713551998227
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -11192,7 +11192,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/frozenlist-1.5.0-py310h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/frozenlist-1.5.0-py310h827c3e9_0.tar.bz2
   sha256: 1f55ce4df3915031cd22bb83f5f36318dc0abd07752e25065cdba017810d325b
   md5: c7674837968cfe8fb5ab9150e76dfb4a
   depends:
@@ -11203,7 +11203,7 @@ packages:
   license_family: Apache
   size: 69733
   timestamp: 1730903296977
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.6.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fsspec-2024.6.1-py310haa95532_0.tar.bz2
   sha256: 1a4cc259e7a2845dbacf388ccb9ee2b5666d1ed717d3bcdedee1b46bfb498869
   md5: 08a003808ae433f88c2e01d96307b342
   depends:
@@ -11214,7 +11214,7 @@ packages:
   license_family: BSD
   size: 288296
   timestamp: 1724855749600
-- conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
   sha256: 7cb0df7aa62796b0081e1708003529c02411aca6a540bae97beaec919aa64e74
   md5: ea81fd813e10055553a8d7597c8be98f
   depends:
@@ -11224,7 +11224,7 @@ packages:
   license_family: BSD
   size: 322778
   timestamp: 1706888324269
-- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.2-h7edc060_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/giflib-5.2.2-h7edc060_0.tar.bz2
   sha256: d71f9b4ea1ccedb85e30d9c5c32c73954055cbe98bacd26e23ef64463476b5ff
   md5: cb30da812922490f68f90fe9224c29cb
   depends:
@@ -11234,7 +11234,7 @@ packages:
   license_family: MIT
   size: 114543
   timestamp: 1728656355503
-- conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
   sha256: ed1fa1a40c6739b48ff3a2d51c3df20e4983b59684b04d93e1337c5f2e93a954
   md5: 1797f64343a42395207cd452e6a6a751
   depends:
@@ -11245,7 +11245,7 @@ packages:
   license_family: BSD
   size: 94476
   timestamp: 1706895442146
-- conda: https://repo.anaconda.com/pkgs/main/win-64/google-auth-2.29.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/google-auth-2.29.0-py310haa95532_0.tar.bz2
   sha256: 2940356525408409c516a75d506a1b3f8365253175807b9b27a02f3c1b3ffe00
   md5: 3496e4e012c042460fdcfef0fa3d8b4f
   depends:
@@ -11263,7 +11263,7 @@ packages:
   license_family: Apache
   size: 217052
   timestamp: 1715111463428
-- conda: https://repo.anaconda.com/pkgs/main/win-64/grpc-cpp-1.48.2-hf108199_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/grpc-cpp-1.48.2-hf108199_0.tar.bz2
   sha256: 4bd6524572ee2453de9e8b4412472ef0f54a5fee126089e80bed6609ede9b225
   md5: 28b0f9d66f90f6c671d1d30f9ea77ece
   depends:
@@ -11276,7 +11276,7 @@ packages:
   license_family: APACHE
   size: 30981567
   timestamp: 1681913688583
-- conda: https://repo.anaconda.com/pkgs/main/win-64/grpcio-1.48.2-py310hf108199_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/grpcio-1.48.2-py310hf108199_0.tar.bz2
   sha256: 1261b4ce6bda202773535d24839b0f49203326f4d787c9e46e2ad01099acbf4a
   md5: a2cc85ae6b4722e4759398db26d2f1b7
   depends:
@@ -11295,7 +11295,7 @@ packages:
   license_family: APACHE
   size: 2124508
   timestamp: 1681914008688
-- conda: https://repo.anaconda.com/pkgs/main/win-64/h11-0.14.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/h11-0.14.0-py310haa95532_0.tar.bz2
   sha256: 5e3ec21b9af596938d62cf9c4b2c84b934bccb8c22b5e6c55e51219e4fe98b70
   md5: 00621964cab040caef35249a17950530
   depends:
@@ -11304,7 +11304,7 @@ packages:
   license_family: MIT
   size: 85310
   timestamp: 1706652442736
-- conda: https://repo.anaconda.com/pkgs/main/win-64/h5py-3.12.1-py310h3b2c811_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/h5py-3.12.1-py310h3b2c811_0.tar.bz2
   sha256: 961c9925d2862e6d33ed86e7e5ee7ff0fb411644337412ce9c3cd0b0b6470d2d
   md5: 8b6fa97b06b7d3dc1121b2e2958ca1a7
   depends:
@@ -11318,7 +11318,7 @@ packages:
   license_family: BSD
   size: 1416204
   timestamp: 1730216136835
-- conda: https://repo.anaconda.com/pkgs/main/win-64/hdf4-4.2.13-h712560f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/hdf4-4.2.13-h712560f_2.tar.bz2
   sha256: 8129c8aae5860d9975f3c88c2ef874d0a746a11074f922b6318446cc45f30768
   md5: b3a727bf1c1df5b021aaf6cc7e81deb2
   depends:
@@ -11329,7 +11329,7 @@ packages:
   license_family: BSD
   size: 2869081
   timestamp: 1510864340539
-- conda: https://repo.anaconda.com/pkgs/main/win-64/hdf5-1.12.1-h51c971a_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/hdf5-1.12.1-h51c971a_3.tar.bz2
   sha256: d32219e535ae34e9d28f94306a38a0825030967c350f19d9a5502e8005acbd5d
   md5: 0689c2ff6f4b9c15ee072694a8cd7467
   depends:
@@ -11341,7 +11341,7 @@ packages:
   license_family: BSD
   size: 23765096
   timestamp: 1686164892135
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.20.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.20.0-py310haa95532_0.tar.bz2
   sha256: fa0309e8e99ae610174d52ba1be603cd55e0c5746b2f6573100f3e67bf46b42a
   md5: 0cb24dce0471cdb2400f7dea2889ab86
   depends:
@@ -11361,7 +11361,7 @@ packages:
   license_family: BSD
   size: 5358091
   timestamp: 1730828363229
-- conda: https://repo.anaconda.com/pkgs/main/win-64/httpcore-1.0.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/httpcore-1.0.2-py310haa95532_0.tar.bz2
   sha256: f44912e4e1518c7b611753940004204efff5732fcd03aad22818d87ddc497d36
   md5: 41f7614c926b8ddad43cb816b3e8e452
   depends:
@@ -11372,7 +11372,7 @@ packages:
   license_family: BSD
   size: 85493
   timestamp: 1706728684995
-- conda: https://repo.anaconda.com/pkgs/main/win-64/httpx-0.27.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/httpx-0.27.0-py310haa95532_0.tar.bz2
   sha256: 9f5c5183c0c573e7170ed4b6306a991cb2c5bd338e7544158e89cd8eaae66285
   md5: 3d2a5447f55116a9eee8691d179b4972
   depends:
@@ -11392,13 +11392,13 @@ packages:
   license_family: BSD
   size: 191955
   timestamp: 1723474920708
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
   sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
   md5: 582d2c1135a89da757a038de831e7f39
   license: Intel proprietary
   size: 11086648
   timestamp: 1664812389803
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icu-58.2-ha925a31_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icu-58.2-ha925a31_3.tar.bz2
   sha256: e7cb511301ce3788402dce7b700ca44e1f7bc38e498d27b41060a9b48704946d
   md5: 3b9fbd6eda81ae1b8b580b99d2d928f4
   depends:
@@ -11407,7 +11407,7 @@ packages:
   license: MIT
   size: 22885927
   timestamp: 1588025937921
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.7-py310haa95532_0.tar.bz2
   sha256: a2b42aa3f456299cf89b8ff9fcc23bf34b020c79171b92dacb1d21f7f5ceaf90
   md5: cbf290dbedee956166c1f700c188b9fa
   depends:
@@ -11416,7 +11416,7 @@ packages:
   license_family: BSD
   size: 140412
   timestamp: 1714399162110
-- conda: https://repo.anaconda.com/pkgs/main/win-64/imagecodecs-2023.1.23-py310h6c6a46e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/imagecodecs-2023.1.23-py310h6c6a46e_0.tar.bz2
   sha256: 01d15c4122ae686459c503f777135d214af41145ec58a410b7e483c3782eaa60
   md5: a6b2031cc282559b6d8e70ef0827ce75
   depends:
@@ -11453,7 +11453,7 @@ packages:
   license_family: BSD
   size: 9837809
   timestamp: 1695067128651
-- conda: https://repo.anaconda.com/pkgs/main/win-64/imageio-2.33.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/imageio-2.33.1-py310haa95532_0.tar.bz2
   sha256: 56f9a7ad7767ddd971d37f5b7138e24238ae1cb7edb8ac15632fb9980a214525
   md5: 7d0ed0a5a9b563529f9f5907615b03a4
   depends:
@@ -11464,7 +11464,7 @@ packages:
   license_family: BSD
   size: 545431
   timestamp: 1707247743222
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-8.5.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-8.5.0-py310haa95532_0.tar.bz2
   sha256: d6404ddf3aac22b94c8d9116534f4ead0709c70f912f79c33db1fbc4317cd230
   md5: 284c1a0b3854d56cfb487204eeee18ba
   depends:
@@ -11474,7 +11474,7 @@ packages:
   license_family: APACHE
   size: 46431
   timestamp: 1732633644401
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intake-0.7.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intake-0.7.0-py310haa95532_0.tar.bz2
   sha256: 369aa24c4983bc72e156ece75c682ca6ad489b707e2c67317350d22ebf4f9685
   md5: d0597ca49f255a839f147032964b506d
   depends:
@@ -11497,7 +11497,7 @@ packages:
   license_family: BSD
   size: 240958
   timestamp: 1717514338162
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intake-xarray-0.7.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intake-xarray-0.7.0-py310haa95532_0.tar.bz2
   sha256: a607bd0de30159c85a0b941bbfd9d91a011b2b4ea96092bb422aae2f9ae5dd4a
   md5: 0be1438d795757b10c636aba08d50209
   depends:
@@ -11514,7 +11514,7 @@ packages:
   license_family: BSD
   size: 69150
   timestamp: 1717523995503
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
   sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
   md5: d215cc8ee7ca2cc83cc250cc5d822fe0
   depends:
@@ -11524,7 +11524,7 @@ packages:
   license_family: Proprietary
   size: 3929136
   timestamp: 1699647939158
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.29.5-py310haa95532_0.tar.bz2
   sha256: 5344891f7c4ec39ea02380387a148d9987e5b6746d702c47d5346318023790e8
   md5: 495435f475c37fd888302b36f92d475e
   depends:
@@ -11545,7 +11545,7 @@ packages:
   license_family: BSD
   size: 192624
   timestamp: 1728666039602
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.27.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.27.0-py310haa95532_0.tar.bz2
   sha256: fb14764c6c9b141691acf8c821088e33d44dfc59870c15278ea12a98788665fc
   md5: c4704a79172e458ec478433ced6cbb9e
   depends:
@@ -11564,7 +11564,7 @@ packages:
   license_family: BSD
   size: 1325894
   timestamp: 1726064369648
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipywidgets-8.1.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipywidgets-8.1.2-py310haa95532_0.tar.bz2
   sha256: 68993e56971b180d1751b5855d023e13fcbe7a7d91c759762a575c23a244a3f3
   md5: 8a44e9970e506bfd0d0cbd3f81965284
   depends:
@@ -11578,7 +11578,7 @@ packages:
   license_family: BSD
   size: 201719
   timestamp: 1709575189593
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.19.1-py310haa95532_0.tar.bz2
   sha256: 373c1964815798b7d8dfe49337390b85d1314757d6401d8269449ef108f766ac
   md5: e5f14914bb23b1ef8167616c747a4b11
   depends:
@@ -11588,7 +11588,7 @@ packages:
   license_family: MIT
   size: 1050991
   timestamp: 1721058584968
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.4-py310haa95532_1.tar.bz2
   sha256: 05269b8df09a0ca8c4874406d513c3a4e44bdddb5c4d10d68bc93e5faabb6f48
   md5: 0ddc6db22e391e6b26c1666fc41c8945
   depends:
@@ -11600,7 +11600,7 @@ packages:
   license_family: BSD
   size: 275649
   timestamp: 1730903442160
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jmespath-1.0.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jmespath-1.0.1-py310haa95532_0.tar.bz2
   sha256: b274228fbed4e3fe6f6e36531dac5ae363cb23767a4ea1afdfb4b36a24069e52
   md5: cdf6661477371254a31b2ddb323916b6
   depends:
@@ -11609,7 +11609,7 @@ packages:
   license_family: MIT
   size: 39174
   timestamp: 1700144858004
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
   sha256: 0238fb10912d9345a9d327ff314a179de38369f8e1d0de0b5f4fab04defab0e4
   md5: 16a420ea83811cfa0c7cadba8f9f0995
   depends:
@@ -11619,7 +11619,7 @@ packages:
   license_family: Other
   size: 409932
   timestamp: 1722872751697
-- conda: https://repo.anaconda.com/pkgs/main/win-64/json5-0.9.25-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/json5-0.9.25-py310haa95532_0.tar.bz2
   sha256: 6793048cc50f8ba8187e5c9446e93464060257d0fa350b4802b2dc6bf1b8ddeb
   md5: 87cc72870ec2335855546a3defdd6b03
   depends:
@@ -11628,7 +11628,7 @@ packages:
   license_family: Apache
   size: 76183
   timestamp: 1730787180721
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.23.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.23.0-py310haa95532_0.tar.bz2
   sha256: a06785f98247bfb74741ef610d6f8cb20d772b42075271ee658ddf0802c62cb3
   md5: e3d50c48ca10125913589c9b4ccc31d8
   depends:
@@ -11641,7 +11641,7 @@ packages:
   license_family: MIT
   size: 177375
   timestamp: 1728486790381
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py310haa95532_0.tar.bz2
   sha256: b3a0eb2033947f1e0844920141bc80048ef817509f5645841d3da8bb441f678c
   md5: a6caf81c42362d399e87e37d88596ace
   depends:
@@ -11651,7 +11651,7 @@ packages:
   license_family: MIT
   size: 15572
   timestamp: 1699032711469
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter-lsp-2.2.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter-lsp-2.2.0-py310haa95532_0.tar.bz2
   sha256: 071504f1837d913aca4faff72cf6fd4362287f3e33905c4c42a1ab5207277679
   md5: 1007dfc789de43d71cf5c88b43f5a441
   depends:
@@ -11661,7 +11661,7 @@ packages:
   license_family: BSD
   size: 82015
   timestamp: 1699978428996
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-8.6.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-8.6.0-py310haa95532_0.tar.bz2
   sha256: 1410889d957761d396a7e3105d5bd05e53a422116e1ef8e2d078186178f92a92
   md5: 7fb7ed0ceb23c03414e9f58e0e86537d
   depends:
@@ -11675,7 +11675,7 @@ packages:
   license_family: BSD
   size: 200387
   timestamp: 1699456906799
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.7.2-py310haa95532_0.tar.bz2
   sha256: 2156b3d773fa969e834fe017d6c3b3e099c149c3505ce628d25b7dcd9b7361ad
   md5: 97cc5bad6423d22ed6281fdbfc398f40
   depends:
@@ -11687,7 +11687,7 @@ packages:
   license_family: BSD
   size: 121683
   timestamp: 1718818511830
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.10.0-py310haa95532_0.tar.bz2
   sha256: c72997b9bf1d48f1512243adfc0f92784ec01bf3da918cf3b14ef70ecbbf5eb3
   md5: 5b1539af6d00e2df883a6f1e0ba1176d
   depends:
@@ -11703,7 +11703,7 @@ packages:
   license_family: BSD
   size: 65809
   timestamp: 1718738454277
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.14.1-py310haa95532_0.tar.bz2
   sha256: 3e01417b0739e6ab08a1520f2171f085aa0a1291c19a171d2e97e727e6bcc6ae
   md5: 30a3e15cd3d27a0edf251c8c4928a4b6
   depends:
@@ -11731,7 +11731,7 @@ packages:
   license_family: BSD
   size: 547148
   timestamp: 1718829336301
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py310haa95532_1.tar.bz2
   sha256: 8d24fc392d2c7ca9ff3ca3c29eb55548fd62b8653f89931240bedac202f20903
   md5: 58351ec2b67993e31095a0ea5abf213c
   depends:
@@ -11742,7 +11742,7 @@ packages:
   license_family: BSD
   size: 24039
   timestamp: 1686870827419
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab-4.2.5-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyterlab-4.2.5-py310haa95532_0.tar.bz2
   sha256: d1926dac899086eb0a536d08251493d7562721bd390824b7ec7b9ac84abdb074
   md5: b8f93c4c3388449484544446f2d3805e
   depends:
@@ -11768,7 +11768,7 @@ packages:
   license_family: BSD
   size: 8490445
   timestamp: 1725902292546
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_server-2.27.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyterlab_server-2.27.3-py310haa95532_0.tar.bz2
   sha256: 67656cc6749c1ae237a56ef46f38aec58a8c982227cead359007796c35ad720c
   md5: 096c1adaef599d301913586bf9f25f21
   depends:
@@ -11786,7 +11786,7 @@ packages:
   license_family: BSD
   size: 83900
   timestamp: 1725865507239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_widgets-3.0.10-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyterlab_widgets-3.0.10-py310haa95532_0.tar.bz2
   sha256: 39635ca6bd8be6c43f308f2b63cc89f61dd539d7cbbb36ae2faad1d05089f555
   md5: d82c3ba064d2f82d9621ca6ab90a3dd2
   depends:
@@ -11797,7 +11797,7 @@ packages:
   license_family: BSD
   size: 192245
   timestamp: 1709323574746
-- conda: https://repo.anaconda.com/pkgs/main/win-64/keras-2.10.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/keras-2.10.0-py310haa95532_0.tar.bz2
   sha256: f598010f1be3890deae69456c774e2ec23b3d33599f4d222dcc259f3591242ed
   md5: 7ece0e174af346913da07120c66aa004
   depends:
@@ -11808,7 +11808,7 @@ packages:
   license: Apache-2.0
   size: 2183775
   timestamp: 1669760638164
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py310hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py310hd77b12b_0.tar.bz2
   sha256: 10f79ef1927aca5f33da1e87a065bef0edd0e7bf1c346172d0f54b9b6472cbd0
   md5: ffd45a996d8abf95243ca820e62e696a
   depends:
@@ -11819,7 +11819,7 @@ packages:
   license_family: BSD
   size: 62337
   timestamp: 1672388276172
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lazy_loader-0.4-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lazy_loader-0.4-py310haa95532_0.tar.bz2
   sha256: 4c8e40f79dbafb7f778c611850b0467e36530047e3dffa5af88cfdc0d218ba9c
   md5: 31b413dbe0d155df2e815b5f38805997
   depends:
@@ -11829,7 +11829,7 @@ packages:
   license_family: BSD
   size: 21661
   timestamp: 1718176912342
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
   sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
   md5: f5f73266281ab12377d5d47bdf07500a
   depends:
@@ -11841,7 +11841,7 @@ packages:
   license_family: MIT
   size: 905072
   timestamp: 1617648814933
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -11851,7 +11851,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libaec-1.0.4-h33f27b4_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libaec-1.0.4-h33f27b4_1.tar.bz2
   sha256: 918df9a8ca3877e44a2976f7c8f2d84f710d156809a7d8e0b79eca568c7cc3da
   md5: 0e6b3ffa6ee7c941485dacdfcb6dd6b4
   depends:
@@ -11861,7 +11861,7 @@ packages:
   license_family: BSD
   size: 34175
   timestamp: 1593197296069
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libavif-0.11.1-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libavif-0.11.1-h2bbff1b_0.tar.bz2
   sha256: 6adaf0429ea7418bff9eab1f723572f4330d003532292448d5334ea2d601e5ee
   md5: b2756d031f0dcfb72f733b2c450fc32a
   depends:
@@ -11873,7 +11873,7 @@ packages:
   license_family: BSD
   size: 2494359
   timestamp: 1689158283018
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
   sha256: 4184dd040fc38cb123a98588a8344aa8d1ba1932df5fcc6c188f6b21f5a0c306
   md5: da58cfa83f3d6c31ae12d8777cd1b64d
   depends:
@@ -11886,7 +11886,7 @@ packages:
   license_family: OTHER
   size: 29803292
   timestamp: 1696764164248
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 7c906c94a4d46ea963080a6ba5bd12c1274da66159877a544fbc70291eeed98d
   md5: 45a3d52534fac8aa54a55ee92211a918
   depends:
@@ -11895,7 +11895,7 @@ packages:
   license: MIT
   size: 80216
   timestamp: 1714483371043
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
   sha256: daad7edc6d56abf3e176479e8628162dbf1c56b3d24db30d708aebae694a5214
   md5: e8ecf229f7fcb4c0b76d8613627948f5
   depends:
@@ -11905,7 +11905,7 @@ packages:
   license: MIT
   size: 45189
   timestamp: 1714483420152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 84320217abffa9386186ec8d03b4651bb4b1900d3871adc965a9a9e1d3799907
   md5: 651312fa22168f71f9aec5f9ee2c2fcf
   depends:
@@ -11915,7 +11915,7 @@ packages:
   license: MIT
   size: 756116
   timestamp: 1714483464368
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.9.1-h0416ee5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libcurl-8.9.1-h0416ee5_0.tar.bz2
   sha256: 8823321b1f3a4dec2ba437b74f054b6188c4e86f15e9830a851c036f1000b116
   md5: eb83a06e2e659553014b6ac66f379e09
   depends:
@@ -11928,7 +11928,7 @@ packages:
   license_family: MIT
   size: 371549
   timestamp: 1725033449018
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -11938,7 +11938,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-hcc03200_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libevent-2.1.12-hcc03200_0.tar.bz2
   sha256: 6aa8177f829f9608ea7403b269bf4fbad0747d3c672fa9e93a55d79efb07b948
   md5: 2b85b2e23c0cb1c06a1100467086eb5a
   depends:
@@ -11949,7 +11949,7 @@ packages:
   license_family: BSD
   size: 440007
   timestamp: 1642102985958
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
   sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
   md5: cf949d76148be1e2a534218d9c57df86
   depends:
@@ -11959,7 +11959,7 @@ packages:
   license_family: MIT
   size: 155435
   timestamp: 1714484319443
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libnetcdf-4.8.1-h6685c40_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libnetcdf-4.8.1-h6685c40_4.tar.bz2
   sha256: e846f05d6cdfd2850e5deb027b62e8d828fa9b12f61ae7ed6433155458032144
   md5: 383bc5f062aafa9b714aa6204ab20daf
   depends:
@@ -11974,7 +11974,7 @@ packages:
   license_family: BSD
   size: 706142
   timestamp: 1691155040631
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -11985,7 +11985,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
   sha256: f7368e611e349b91315ce4ba4dbf9116d996a48f98eed425f4d5c3d5b9fcfa5e
   md5: 77eb9daff9052f1fbf24d91c5bba1d74
   depends:
@@ -11996,7 +11996,7 @@ packages:
   license_family: BSD
   size: 2543079
   timestamp: 1675278760037
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -12005,7 +12005,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-hcd4344a_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libssh2-1.10.0-hcd4344a_2.tar.bz2
   sha256: 0b1460332f394557429f75c871c89ad27fc2ddadbeb28bfcff8d1d8537f493ac
   md5: 38e889ec253fe997be7f94556a0855d4
   depends:
@@ -12016,7 +12016,7 @@ packages:
   license_family: BSD
   size: 230554
   timestamp: 1686932558863
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-he49ee6e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libthrift-0.15.0-he49ee6e_2.tar.bz2
   sha256: 060095497c98878e525bd8243c1cb612bd0d53c06c11f1d24f03987b1c6790b8
   md5: 312f31016ef8cca75fef587797d94ffd
   depends:
@@ -12030,7 +12030,7 @@ packages:
   license_family: Apache
   size: 895584
   timestamp: 1687975375656
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -12047,7 +12047,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
   sha256: e54ee28f6ba01b3addf61ee9dfbdedc16eac8654fc334f713b5f181cf037d0f2
   md5: 47aa151852fc9b07e7573d22f0af945d
   depends:
@@ -12059,7 +12059,7 @@ packages:
   license_family: BSD
   size: 339944
   timestamp: 1729160123353
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libzip-1.8.0-h49b8836_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libzip-1.8.0-h49b8836_0.tar.bz2
   sha256: 0b4c8aa6e1fc2b82ce0b77c02e0e418764f94c3ea0bb18bea45a3cd265e3456f
   md5: a51d3646b5ae61f0b7f40b55650932be
   depends:
@@ -12074,7 +12074,7 @@ packages:
   license_family: BSD
   size: 102924
   timestamp: 1652977143101
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libzopfli-1.0.3-ha925a31_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libzopfli-1.0.3-ha925a31_0.tar.bz2
   sha256: d5b0e01c2b80b43a0e1128a612f289891c375bd9f15b3b0d176b0658a1c3711e
   md5: 532177b4105c87e006d9f49ba8ad399f
   depends:
@@ -12084,7 +12084,7 @@ packages:
   license_family: Apache
   size: 210474
   timestamp: 1593187626221
-- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py310haa95532_0.tar.bz2
   sha256: b957593b060cc76d1e8376af052749f66268e81df18e7e8020b5d8fe5fe84690
   md5: 4cea845047b0d40302f260127d1d02d9
   depends:
@@ -12094,7 +12094,7 @@ packages:
   license_family: MIT
   size: 35946
   timestamp: 1659783477621
-- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py310haa95532_0.tar.bz2
   sha256: c2e861d3109533539f2fc7a8ebaeb1aafbb0960aca546ea7ed5a91376c796399
   md5: 4d016b3bc975ab61c5786a6676693a9c
   depends:
@@ -12103,7 +12103,7 @@ packages:
   license_family: BSD
   size: 12966
   timestamp: 1652904192742
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.3.2-py310h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-4.3.2-py310h2bbff1b_0.tar.bz2
   sha256: e7947ecc85be759c379874f245b5e6390a28280fa2c17f8b9803a96aaa243491
   md5: d82333a647626ea4158a6ce671504fac
   depends:
@@ -12115,7 +12115,7 @@ packages:
   license_family: BSD
   size: 83511
   timestamp: 1686058308914
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
   sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
   md5: 320f40b75d93f3b96931c6d13c23946c
   depends:
@@ -12125,7 +12125,7 @@ packages:
   license_family: BSD
   size: 158902
   timestamp: 1714512129889
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py310haa95532_0.tar.bz2
   sha256: 88e0ad9a62f0e385ed4a36fc1bbb088a49065fafa4f08daac7c846fce26b6540
   md5: af908af5ac51eafcb7e6332cd02c0d21
   depends:
@@ -12134,7 +12134,7 @@ packages:
   license_family: BSD
   size: 143240
   timestamp: 1671542001479
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py310haa95532_1.tar.bz2
   sha256: ab424b8036257c53eb5110f8d8817ed959718c275e2dff88407332ce783519ed
   md5: 24f0c3faa37da73027d950da5b6cd3d3
   depends:
@@ -12144,7 +12144,7 @@ packages:
   license_family: MIT
   size: 126331
   timestamp: 1684280061614
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py310h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py310h2bbff1b_0.tar.bz2
   sha256: 10459e7599e98c67be954c34a1eba28baed7dd185f31e946a9b67784e3748dd1
   md5: 974db1440c01eaa49bcae8d0dcd1cdbd
   depends:
@@ -12157,7 +12157,7 @@ packages:
   license_family: BSD
   size: 27022
   timestamp: 1704206300657
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.9.2-py310he19b0ae_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.9.2-py310he19b0ae_1.tar.bz2
   sha256: 998b024d02d4c41c2b2e810eb27b5d71f5724bd3fa577545aad9d8eee0a6892d
   md5: 23640eebe09a06c7f08079d6c4e1fcab
   depends:
@@ -12178,7 +12178,7 @@ packages:
   license_family: PSF
   size: 11230787
   timestamp: 1732551286335
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py310haa95532_0.tar.bz2
   sha256: cb2d90330a1c1bb4ae18110e7bc14f50287c6d603cf9c270cf98b72962ce3ea9
   md5: 7e5b432f39238f991ea8e6c21fc7cc68
   depends:
@@ -12188,7 +12188,7 @@ packages:
   license_family: BSD
   size: 18107
   timestamp: 1661934176570
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py310haa95532_0.tar.bz2
   sha256: 8cac05d7cf61a8d4011fce8e0f3b109f8d94f06ea0dc9e0a7f0e8b208a054193
   md5: 2cd828af0c9e8a8ecce14355b5619667
   depends:
@@ -12198,7 +12198,7 @@ packages:
   license_family: MIT
   size: 53824
   timestamp: 1659721375084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py310haa95532_0.tar.bz2
   sha256: 31152e14e45c00f079582bf2f32742b0ee2e23bd28904715092661fb7fd1d5b8
   md5: 5205f987d201c5de2925956b8f9d8caa
   depends:
@@ -12207,7 +12207,7 @@ packages:
   license_family: MIT
   size: 19459
   timestamp: 1659716154851
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py310haa95532_0.tar.bz2
   sha256: 8c88c83f6f17de2841494075296d5514ec622337ba8f48b7ca57b836445d78f6
   md5: 5c2188ac984be30e4f8df5ec56b56df2
   depends:
@@ -12218,7 +12218,7 @@ packages:
   license_family: BSD
   size: 90995
   timestamp: 1661496484574
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
   sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
   md5: 527155127b9fada5e5c5c69a624674b9
   depends:
@@ -12230,7 +12230,7 @@ packages:
   license_family: Proprietary
   size: 187498166
   timestamp: 1699648376430
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py310h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py310h2bbff1b_1.tar.bz2
   sha256: 5f8249f157c4899b9c8339286067f77514e678ffa21aa03ab17812e8e96fb9d5
   md5: a6d45a65a7468b522cb88a8f54a97b40
   depends:
@@ -12242,7 +12242,7 @@ packages:
   license_family: BSD
   size: 49079
   timestamp: 1682974931077
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.11-py310h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.11-py310h827c3e9_0.tar.bz2
   sha256: f023927c84ac294174826c15dc50b2658868eac4b377cf3f3caa2bbd13b57569
   md5: d965190600962444e398591f0c56c7dd
   depends:
@@ -12257,7 +12257,7 @@ packages:
   license_family: BSD
   size: 201831
   timestamp: 1730823204937
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.8-py310hc64d2fc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.8-py310hc64d2fc_0.tar.bz2
   sha256: b08a048bcc985742dfa499e8c79eb52461935b054d07363143610baeecb26b20
   md5: 73054e743a0aced13bed19ba4d51b205
   depends:
@@ -12272,7 +12272,7 @@ packages:
   license_family: BSD
   size: 332762
   timestamp: 1730822722584
-- conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py310h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/msgpack-python-1.0.3-py310h59b6b97_0.tar.bz2
   sha256: 935ec7c1b0bfe11913631f59ac8f8337983a7d9a886ae7958d3ae3cc1bff5cda
   md5: 3054889e8867d76ca9bcfcdfd00568fc
   depends:
@@ -12283,7 +12283,7 @@ packages:
   license_family: Apache
   size: 83183
   timestamp: 1652348684261
-- conda: https://repo.anaconda.com/pkgs/main/win-64/multidict-6.1.0-py310h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/multidict-6.1.0-py310h827c3e9_0.tar.bz2
   sha256: a3b43158949b03068e6f81fdbc461c2d78de168e6441dad10001bc120879556c
   md5: 5f61a666d8955b38a770a404c44e3769
   depends:
@@ -12295,7 +12295,7 @@ packages:
   license_family: Apache
   size: 64045
   timestamp: 1730905592011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py310haa95532_0.tar.bz2
   sha256: 7ad8dd23e9743b0901a6f42d508b13015855e0ec5f9d689cfbb2ab1ba95dec02
   md5: 13fad67eb60b89ac9d4767832c692cbc
   depends:
@@ -12308,7 +12308,7 @@ packages:
   license_family: BSD
   size: 119871
   timestamp: 1698934620305
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.4-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-7.16.4-py310haa95532_0.tar.bz2
   sha256: 3ab6907f1aa8d3f9c9d41f07a7958d78424c15c6915487c8a995f407221aecce
   md5: 82c2dfefa7e4bdf31640e191251d4210
   depends:
@@ -12335,7 +12335,7 @@ packages:
   license_family: BSD
   size: 532978
   timestamp: 1728051166468
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.10.4-py310haa95532_0.tar.bz2
   sha256: b60400ded73de1554aebeb8c292d55bc8c98b3c5701b35285019468fb4c4ac9f
   md5: b12bb18cd2fb67bf7bc0f2be962dd557
   depends:
@@ -12348,7 +12348,7 @@ packages:
   license_family: BSD
   size: 180615
   timestamp: 1728050835184
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py310haa95532_0.tar.bz2
   sha256: e18ba942bb3f8a0ace571cfe58557aa5088acac13d094fde0302cf6452b2f7bf
   md5: eb32799be5cf9de16c3688a34cb2b409
   depends:
@@ -12357,7 +12357,7 @@ packages:
   license_family: BSD
   size: 14318
   timestamp: 1708533067532
-- conda: https://repo.anaconda.com/pkgs/main/win-64/netcdf4-1.6.2-py310hadf358c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/netcdf4-1.6.2-py310hadf358c_0.tar.bz2
   sha256: ed27cc7b8ebf6f525ea34121861201d420fbbedea4552677b5ffeb319a21ded6
   md5: 7b33b8cfb4753215899d4e9605e46667
   depends:
@@ -12373,7 +12373,7 @@ packages:
   license_family: MIT
   size: 365383
   timestamp: 1673455686114
-- conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/networkx-3.3-py310haa95532_0.tar.bz2
   sha256: 4e959603f93deb5b50cc6991abcd34ff9366a722fb28d47a94937033c8979585
   md5: 286db88289719c52659a06c77bfa19ad
   depends:
@@ -12391,7 +12391,7 @@ packages:
   license_family: BSD
   size: 2660316
   timestamp: 1720002609180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-7.2.2-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-7.2.2-py310haa95532_1.tar.bz2
   sha256: 9ab288249fc32968e1a87c2814c515c19d1abdc6cd823ec07c1496503c0f57ea
   md5: 89f40012edf8e38b9b40940c13f7c4ae
   depends:
@@ -12405,7 +12405,7 @@ packages:
   license_family: BSD
   size: 4599194
   timestamp: 1727198095117
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py310haa95532_0.tar.bz2
   sha256: 7a659fc3d7cca9092e5e510e270499c20e32c315601fb8e22eb9248af324a06f
   md5: fe5e24c542b36d32cc2d5382ce56b295
   depends:
@@ -12415,7 +12415,7 @@ packages:
   license_family: BSD
   size: 23259
   timestamp: 1699456053116
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numcodecs-0.12.1-py310h3469f8a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numcodecs-0.12.1-py310h3469f8a_0.tar.bz2
   sha256: c6bf8508df4c8d079c874c0dc86934b74646f35f0900bdaa6c9c417238cbfee3
   md5: ce85c0c6a7e2efb7425884019a5c0885
   depends:
@@ -12431,7 +12431,7 @@ packages:
   license_family: MIT
   size: 344629
   timestamp: 1707514108910
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.10.1-py310h4cd664f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.10.1-py310h4cd664f_0.tar.bz2
   sha256: 97fc453b0175ce684bc0f497a5c0748bd512ef08713280074f9f227e3020c32d
   md5: 104f87b7eb25936cc01da72eb4858880
   depends:
@@ -12447,7 +12447,7 @@ packages:
   license_family: MIT
   size: 184044
   timestamp: 1730216247778
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py310h055cbcc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py310h055cbcc_0.tar.bz2
   sha256: bd9e579e6d0e639570927ece9ae3c3c5b7fe0772306cb63deb856d717c51b33e
   md5: d1dcb19ab9483ee8a93fb46861125753
   depends:
@@ -12464,7 +12464,7 @@ packages:
   license_family: BSD
   size: 11048
   timestamp: 1708640486296
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py310h65a83cf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py310h65a83cf_0.tar.bz2
   sha256: 62215947f56b113eb2c8e888d934e3536fd7ce49d56b5df66e36e83086684fe9
   md5: 952b5b3d77ca62745163be1f72b89ac9
   depends:
@@ -12480,7 +12480,7 @@ packages:
   license_family: BSD
   size: 9900493
   timestamp: 1708640453215
-- conda: https://repo.anaconda.com/pkgs/main/win-64/oauthlib-3.2.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/oauthlib-3.2.2-py310haa95532_0.tar.bz2
   sha256: f6e532f358cd41b5618d0f787327310ee83b1c80e3480503bdfde3ad95860794
   md5: d35e567abeb4469237e16fc22a343d1a
   depends:
@@ -12492,7 +12492,7 @@ packages:
   license_family: BSD
   size: 233853
   timestamp: 1679489706159
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
   sha256: e2afce0548808d27293a03661ee5f7ac3e18f82a92c9fb23f420eb5e92126fc6
   md5: 9dd921a785844abe0aa842c3800d405a
   depends:
@@ -12504,7 +12504,7 @@ packages:
   license_family: BSD
   size: 286986
   timestamp: 1722872761369
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
   sha256: 0474e14823c734edc088bef98b829149a47ed8b4654f9638926c2fe4bbc40f38
   md5: a67d4a763641de641ea9dfa8c4a5f567
   depends:
@@ -12515,7 +12515,7 @@ packages:
   license_family: Apache
   size: 6048217
   timestamp: 1694466133007
-- conda: https://repo.anaconda.com/pkgs/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
   sha256: 417cf23716f17b6daf2b717bbd69240aa9440845dfa415f59a97961794632ce5
   md5: 36d709d47c43a3e9b43f23cf4edb6438
   depends:
@@ -12530,7 +12530,7 @@ packages:
   license_family: Apache
   size: 877890
   timestamp: 1676482911485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py310haa95532_0.tar.bz2
   sha256: c0cfdc0e8a734241b5183954a0b163b7b5fb8301a621b8d5f02fe83ba5d4b520
   md5: e30dabb368401270b542d0c3fdf391bb
   depends:
@@ -12539,7 +12539,7 @@ packages:
   license_family: APACHE
   size: 31667
   timestamp: 1699371284738
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-24.1-py310haa95532_0.tar.bz2
   sha256: ef0f7b7fdec970067658c11a1ba012be253df497ab98bcea108dabf5c46503ce
   md5: df86e675c7c625e4b95f68057cb3dee7
   depends:
@@ -12548,7 +12548,7 @@ packages:
   license_family: Apache
   size: 136214
   timestamp: 1720104030837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.3-py310h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-2.2.3-py310h5da7b33_0.tar.bz2
   sha256: 6e52052955737aad9dcb2da44ec0c313399333f49f6769908d7b8014ff424c75
   md5: 4b9d15e75b678dccd835be227105bba1
   depends:
@@ -12599,7 +12599,7 @@ packages:
   license_family: BSD
   size: 14245891
   timestamp: 1732735630309
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.5.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-1.5.3-py310haa95532_0.tar.bz2
   sha256: fe2c7b564bedffe3272762cc2d1857e4b64ba029ade7249a28343b09d4e5568d
   md5: 52ef05ea6b2bce889e5ed32e16755846
   depends:
@@ -12624,7 +12624,7 @@ packages:
   license_family: BSD
   size: 23626248
   timestamp: 1730382328245
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-2.1.1-py310haa95532_0.tar.bz2
   sha256: 20a769a2101fa8b40eaeaa0372ad88ecf9b80af62fa4c76b29860400d0f83036
   md5: b6df60d94ba06a3ac09d27c2e5d603f8
   depends:
@@ -12633,7 +12633,7 @@ packages:
   license_family: BSD
   size: 195238
   timestamp: 1719348159340
-- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py310haa95532_0.tar.bz2
   sha256: 53294a1845864c4e38fbb6c277e734cb6a1f1cfbd9d7b40cc760b6cb291312fb
   md5: 9535b98f44bc4289f8e46f9a0240536f
   depends:
@@ -12647,7 +12647,7 @@ packages:
   license_family: BSD
   size: 36809
   timestamp: 1698702886819
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-11.0.0-py310hb5480e2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-11.0.0-py310hb5480e2_0.tar.bz2
   sha256: f635ddfeeb2243962df04ac988fe0494c757b192abfc7ed13c2e6f02c482a6e7
   md5: e33137fdeeb695ce8542d85d7c7238ab
   depends:
@@ -12665,7 +12665,7 @@ packages:
   license_family: Other
   size: 814468
   timestamp: 1731595172979
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-24.2-py310haa95532_0.tar.bz2
   sha256: 814c47a2d6ffd2200da86082d9d8b2483dab65e6622247bb9c5b01869b6f641b
   md5: a34dd1afc9b1baea5293e6acf2fe0711
   depends:
@@ -12676,7 +12676,7 @@ packages:
   license_family: MIT
   size: 2615232
   timestamp: 1723485560196
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py310haa95532_0.tar.bz2
   sha256: e471553584e2ed5971404849a37358d13f08fabe18b0ef3ef33a3a0bc1a22fa3
   md5: c5ebdddd493f77c393cc043a457a231b
   depends:
@@ -12685,7 +12685,7 @@ packages:
   license_family: MIT
   size: 32580
   timestamp: 1692205629751
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.21.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.21.0-py310haa95532_0.tar.bz2
   sha256: 1d7518d071614aa48150414a95339c0ed39694a48f38dd036731c16ca0cb91ee
   md5: cb76d4e9ec4ed6e5c91efb37922d48ef
   depends:
@@ -12694,7 +12694,7 @@ packages:
   license_family: Apache
   size: 91598
   timestamp: 1731961823387
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py310haa95532_0.tar.bz2
   sha256: 2270c3de7d72a7596bc5806a1450884995fcb76beabd4e6ad41ef1f36c0d0024
   md5: ac3812fa3ac3ee2d1c2aacec313803d5
   depends:
@@ -12706,7 +12706,7 @@ packages:
   license_family: BSD
   size: 600631
   timestamp: 1704404461740
-- conda: https://repo.anaconda.com/pkgs/main/win-64/propcache-0.2.0-py310h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/propcache-0.2.0-py310h827c3e9_0.tar.bz2
   sha256: cde36a2103a082598e2495a60bbc95247685fd74982f1901dc1396f3cab9c7d2
   md5: 383b0111fb200e7962e39dc90a87b06c
   depends:
@@ -12717,7 +12717,7 @@ packages:
   license_family: Apache
   size: 64091
   timestamp: 1732304471844
-- conda: https://repo.anaconda.com/pkgs/main/win-64/protobuf-3.20.3-py310hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/protobuf-3.20.3-py310hd77b12b_0.tar.bz2
   sha256: def7e976a6845fe784f10b6e70c1d51f81e942995f240e6ca28f558d119ab5ca
   md5: 214812935599abedec64d9a769c885ff
   depends:
@@ -12730,7 +12730,7 @@ packages:
   license_family: BSD
   size: 240849
   timestamp: 1675281854833
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py310h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py310h2bbff1b_0.tar.bz2
   sha256: 8ba826d7c49fd587064175395cb0b4c956fff616b1866b4b8eaefa6baabc3415
   md5: 8cfb596037d09d397df9bfddc7ea62a5
   depends:
@@ -12741,7 +12741,7 @@ packages:
   license_family: BSD
   size: 375863
   timestamp: 1656431373274
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-11.0.0-py310h790e06d_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyarrow-11.0.0-py310h790e06d_1.tar.bz2
   sha256: 170d1ca4533254b429386da41ce481d15316aa661cb5f076b77ce4c680436f0e
   md5: f74880afac6d533f466e1f6a480f85bc
   depends:
@@ -12756,7 +12756,7 @@ packages:
   license_family: Apache
   size: 3637873
   timestamp: 1693274643129
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py310haa95532_1.tar.bz2
   sha256: 0425af15c734660310fd267c19aca5c8bac712f737e4b97d8fcefe38c0a9886d
   md5: 3aa71810eb4ca6e3edd0398763f6f269
   depends:
@@ -12765,7 +12765,7 @@ packages:
   license_family: BSD
   size: 1903399
   timestamp: 1684280387582
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyjwt-2.9.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyjwt-2.9.0-py310haa95532_0.tar.bz2
   sha256: 9536746659e0fc0ef8ec5b64fb8e60df4ed905ca18f46e7aab2e0d97a89289c6
   md5: dd0310fe94cceee0ffff2044c00cd341
   depends:
@@ -12776,7 +12776,7 @@ packages:
   license_family: MIT
   size: 77302
   timestamp: 1730786857459
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py310haa95532_0.tar.bz2
   sha256: 48d4e140b012d95051d40ea19668b4660a5b35423233a4a86e09086e2803cdd8
   md5: 3909ea700a127b6a649ea8b5859ebf2e
   depends:
@@ -12786,7 +12786,7 @@ packages:
   license_family: Apache
   size: 95255
   timestamp: 1690225526774
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.2.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.2.0-py310haa95532_0.tar.bz2
   sha256: 0146cdefcf3b77324cc846b46eaf5ed451c0ae01a18f64297071b055e459ab06
   md5: 85ef917d8557f14ad2f4ab29434ba3e9
   depends:
@@ -12795,7 +12795,7 @@ packages:
   license_family: MIT
   size: 427286
   timestamp: 1731446031716
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py310haa95532_0.tar.bz2
   sha256: 079bb5bd27170316f111209f6e034308fa6443102e62a2e29c58f73089356e37
   md5: 8eb51a59b8c2d264f072b9686f08554b
   depends:
@@ -12805,7 +12805,7 @@ packages:
   license_family: BSD
   size: 28442
   timestamp: 1642089401419
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.10.13-h966fe2a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.10.13-h966fe2a_0.tar.bz2
   sha256: 07a10f49f4b0b44a6607bad9fe19f7784f0f2284c02ce72da024145b5d2446c3
   md5: bc8e0cf92bbe55ed7d5718006f1e7533
   depends:
@@ -12826,7 +12826,7 @@ packages:
   license_family: PSF
   size: 16971702
   timestamp: 1694438433227
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py310haa95532_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py310haa95532_2.tar.bz2
   sha256: 8e12b59e93c1b5489ed6fdbd044d5626158356ea840953f0da6bfd15caf21d71
   md5: 2a984d495e1cd2dd84c0049f248d61ab
   depends:
@@ -12836,7 +12836,7 @@ packages:
   license_family: BSD
   size: 290793
   timestamp: 1716495894571
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.20.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.20.0-py310haa95532_0.tar.bz2
   sha256: 84f1874ce78386f6c2b9db8aa85aa756fa81756f782fb7120fc6b9a1893148ff
   md5: 71374aee6be3bc34da7a22bd318de450
   depends:
@@ -12845,7 +12845,7 @@ packages:
   license_family: BSD
   size: 268237
   timestamp: 1731939691795
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-flatbuffers-24.3.25-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-flatbuffers-24.3.25-py310haa95532_0.tar.bz2
   sha256: 317ac26c01451341effa39c0b9ccab7418176504749621983441e5bdf795e81a
   md5: 0ced91f498d60e6940fb7b34bd8bc8cf
   depends:
@@ -12854,7 +12854,7 @@ packages:
   license_family: Apache
   size: 54405
   timestamp: 1722369360482
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-json-logger-2.0.7-py310haa95532_0.tar.bz2
   sha256: ef099f3c29677a1a048bed3a434acc283c1d6dfecf96cc0d722a537054b70157
   md5: 44e942cbb9075709d5daa4c042fe098c
   depends:
@@ -12863,7 +12863,7 @@ packages:
   license_family: BSD
   size: 15718
   timestamp: 1683824312523
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py310hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-lmdb-1.4.1-py310hd77b12b_0.tar.bz2
   sha256: 263e1fb7053f5d6eaeb06d672554154f4168b8adf4cee0a67aea0817c5b4ceed
   md5: 5563fc7d260892d8bcb788b66c3848ae
   depends:
@@ -12874,7 +12874,7 @@ packages:
   license_family: Other
   size: 135816
   timestamp: 1682522463382
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-snappy-0.6.1-py310hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-snappy-0.6.1-py310hd77b12b_0.tar.bz2
   sha256: d9e92ae7681f1865287ba7c32f7161bec58d9056828cac985f777f90471e2143
   md5: a71f7c84d34a96577394fd349e921624
   depends:
@@ -12886,7 +12886,7 @@ packages:
   license_family: BSD
   size: 34323
   timestamp: 1670944261041
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py310haa95532_0.tar.bz2
   sha256: 942d721dd8f7b1158eed7e3d1579eb7a844ebfa28c4b2b7953b56c6927ed0313
   md5: 64cfe7c71ceb6ec178eb3091cf943d5b
   depends:
@@ -12895,7 +12895,7 @@ packages:
   license_family: MIT
   size: 264666
   timestamp: 1713974542135
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.2-py310haa95532_0.tar.bz2
   sha256: 42ccd5a361ab2506e0a81e0ebdf0da6cf9ff29fdcb88548f9e55cd4aadd18637
   md5: 7ad6254da4ad2125276f5d1a4cc4851b
   depends:
@@ -12907,7 +12907,7 @@ packages:
   license_family: BSD
   size: 61483
   timestamp: 1711137076808
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py310h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py310h2bbff1b_0.tar.bz2
   sha256: 9715738e6124de2510a3bf6ca945ba361fa27e3af60bcdf3a1bc25f9c0068b3b
   md5: b45930642e0ddbd43333c8a3ba4bc491
   depends:
@@ -12917,7 +12917,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13492611
   timestamp: 1669937046724
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py310h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py310h5da7b33_0.tar.bz2
   sha256: 5fca272384bcdd93c4caa9a753fc514b7e29d734498147c8fd26a52e3cadc2b8
   md5: 1992345047b4f1ed52e7f85b5a0e143e
   depends:
@@ -12929,7 +12929,7 @@ packages:
   license_family: MIT
   size: 234279
   timestamp: 1677610684013
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.2-py310h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.2-py310h827c3e9_0.tar.bz2
   sha256: d0631a65e74ec75713da22a5d6b5b2fd108ac3466e7a205c38918963823325a6
   md5: a94652ebed826cb607a332f70ca1e6c7
   depends:
@@ -12941,7 +12941,7 @@ packages:
   license_family: MIT
   size: 179359
   timestamp: 1728658051261
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-25.1.2-py310hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-25.1.2-py310hd77b12b_0.tar.bz2
   sha256: 0812afa6f6ab9f5562dcb03936b3a00e11124f2c55f81bcb6f463203baab0c0b
   md5: 174ecc549eeac119dcdecfa824641cce
   depends:
@@ -12953,7 +12953,7 @@ packages:
   license_family: BSD
   size: 466374
   timestamp: 1705606079526
-- conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
   sha256: 720f3dd1f933d035b1393951ffd1b6437fc5e19b1999e74096044514a46053fb
   md5: add2dfb15b518144663fc3b897d66da7
   depends:
@@ -12962,7 +12962,7 @@ packages:
   license: BSD-3-Clause
   size: 493391
   timestamp: 1652432364793
-- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py310haa95532_0.tar.bz2
   sha256: bfb71f2451660127dd40061bc6f90a41525beb76f2720cdddf0564781c8f0d8b
   md5: 7c8e4d5ee0c84847494c56bb51fb0bcb
   depends:
@@ -12973,7 +12973,7 @@ packages:
   license_family: MIT
   size: 59033
   timestamp: 1699012173193
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.32.3-py310haa95532_1.tar.bz2
   sha256: 3f29161c88a3634763db60fa88ad9ee616cfc8bbb7a06e1a694d93a3773173c8
   md5: 800a82f266a6649bb43101c966491883
   depends:
@@ -12989,7 +12989,7 @@ packages:
   license_family: Apache
   size: 99564
   timestamp: 1731000717078
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-oauthlib-2.0.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-oauthlib-2.0.0-py310haa95532_0.tar.bz2
   sha256: cac9dd92400b331def69a7d19ebfb1bc7190f2b68fddc51ed0dd4c82346110c4
   md5: 0f084fe04fb3e74f47766a7954ab2747
   depends:
@@ -13003,7 +13003,7 @@ packages:
   license_family: Other
   size: 35122
   timestamp: 1720615136514
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py310haa95532_0.tar.bz2
   sha256: 558cf5fcbf151bf419079e13b5f3cc5f0a51af0596661bef50290903e52cdc24
   md5: a86808657e019161b1e8e0a492afe6e2
   depends:
@@ -13013,7 +13013,7 @@ packages:
   license_family: MIT
   size: 9367
   timestamp: 1683077232021
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py310haa95532_0.tar.bz2
   sha256: e069e307e66cf1289bad542f9293e7a79b902d15d330c875ccce709b2b2523dd
   md5: 9f21f24f35c99c432df830795e3a33f4
   depends:
@@ -13022,7 +13022,7 @@ packages:
   license_family: MIT
   size: 9734
   timestamp: 1683059168209
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py310h636fa0f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py310h636fa0f_1.tar.bz2
   sha256: d0abcaca638da1bb81db51f7f6ac6cfe431f752bdadf175ad83125984d758a46
   md5: 75507640e623c025e944c48db1e349af
   depends:
@@ -13033,7 +13033,7 @@ packages:
   license_family: MIT
   size: 222239
   timestamp: 1732235009465
-- conda: https://repo.anaconda.com/pkgs/main/win-64/s3fs-2024.6.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/s3fs-2024.6.1-py310haa95532_0.tar.bz2
   sha256: df6b9b504b2e4aff9347b8c44dd869e1b1f4aefdade01441320ad89782fe0fd0
   md5: 0854864a75aa3589a749d907047ad7a1
   depends:
@@ -13045,7 +13045,7 @@ packages:
   license_family: BSD
   size: 56906
   timestamp: 1724924191344
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scikit-image-0.24.0-py310hc64d2fc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/scikit-image-0.24.0-py310hc64d2fc_0.tar.bz2
   sha256: 8296b381527fc40e3d0194573d6232e2e123a2bf203e1bb325c659fad49fe801
   md5: f03618e1b2eaba85a1630591caef59f5
   depends:
@@ -13072,7 +13072,7 @@ packages:
   license_family: Other
   size: 12070959
   timestamp: 1726765919364
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.14.1-py310h8640f81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/scipy-1.14.1-py310h8640f81_0.tar.bz2
   sha256: bb6b0d78f4f262f0d665945e841b59d0a3e486c010a6fa5f11095ba4a37b15a6
   md5: 5be2c4c6c51a8e68cded3076f87cf907
   depends:
@@ -13089,7 +13089,7 @@ packages:
   license_family: BSD
   size: 31388051
   timestamp: 1731624128312
-- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py310haa95532_0.tar.bz2
   sha256: b17e85b5d1d6d0e440c98ddeb98d9b57fe83882b4386a0c48fc4e6b3cbb82268
   md5: 1e784c644bba03b661c045bedeb1ed0d
   depends:
@@ -13098,7 +13098,7 @@ packages:
   license_family: BSD
   size: 83392
   timestamp: 1699371351367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-75.1.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-75.1.0-py310haa95532_0.tar.bz2
   sha256: eb48d9d1c1257a83402e9346f9d0109e9c4fa3192da5400571a428acc5d43d91
   md5: a5e6c71598e30ea5290cbd2f649c3fe4
   depends:
@@ -13107,7 +13107,7 @@ packages:
   license_family: MIT
   size: 1771325
   timestamp: 1726678469224
-- conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
   sha256: 5e5f855a70cf4c9dc6f2ac8d9fa51a3f095bf4db8e2ee3ff213ef5432556d7cd
   md5: 9c1f7331a4116e5c27d8af7453f8ee47
   depends:
@@ -13117,7 +13117,7 @@ packages:
   license_family: BSD
   size: 119274
   timestamp: 1723557526373
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py310haa95532_0.tar.bz2
   sha256: e128bb380d423a77aaccbd1165c0fe511c9699b176ec73d452a3aca0b22c8eb4
   md5: c948da08d73c8c8168dfa6dfe35b6350
   depends:
@@ -13126,7 +13126,7 @@ packages:
   license_family: Other
   size: 17619
   timestamp: 1705431497372
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py310haa95532_0.tar.bz2
   sha256: a23892e537aa5387f4a7e817dfdcc4b9c5fec6b40a1695f99ecb7e3896f8f1b3
   md5: 022293f076961b460cfe654421c3a69a
   depends:
@@ -13135,7 +13135,7 @@ packages:
   license_family: MIT
   size: 67725
   timestamp: 1696347732280
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
   sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
   md5: 833b93a2daade3407898f15588945d83
   depends:
@@ -13145,7 +13145,7 @@ packages:
   license_family: Other
   size: 1440481
   timestamp: 1714488344682
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -13155,7 +13155,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tensorboard-2.10.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tensorboard-2.10.0-py310haa95532_0.tar.bz2
   sha256: b17a231851c5ed400ca23751838cd05ac55235de723aba1ce3b256782ea7d281
   md5: 11104fd0b12a979c71c89c84c7dfce62
   depends:
@@ -13176,7 +13176,7 @@ packages:
   license_family: Apache
   size: 6166371
   timestamp: 1669761179446
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tensorboard-data-server-0.6.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tensorboard-data-server-0.6.1-py310haa95532_0.tar.bz2
   sha256: e0c81aaa95ab4b4fa3814d60fa033c31f62c88c5ac1d19b81a53d18f2913cee3
   md5: d68c403a89158877711adc50dcb5740d
   depends:
@@ -13185,7 +13185,7 @@ packages:
   license_family: Apache
   size: 13098
   timestamp: 1670853673164
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tensorboard-plugin-wit-1.8.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tensorboard-plugin-wit-1.8.1-py310haa95532_0.tar.bz2
   sha256: c3fbc5cec2a46183fbb61a4c871e1e4a8f38450830dfb8c0726d373ca3c6e3eb
   md5: fa9eed724d1a413c1f0d2bbcc9efc65b
   depends:
@@ -13196,7 +13196,7 @@ packages:
   license_family: Apache
   size: 723939
   timestamp: 1660162233855
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tensorflow-2.10.0-mkl_py310hd99672f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tensorflow-2.10.0-mkl_py310hd99672f_0.tar.bz2
   sha256: 18090edb6390d7c2405646f80a96245e578249185e9b4ff550b26d24cf62f363
   md5: d30ff93569746b295022884ca7445202
   depends:
@@ -13209,7 +13209,7 @@ packages:
   license_family: Apache
   size: 4175
   timestamp: 1670626182226
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tensorflow-base-2.10.0-mkl_py310h6a7f48e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tensorflow-base-2.10.0-mkl_py310h6a7f48e_0.tar.bz2
   sha256: 93d17c1736652067aac3b086905521307afba09c6b576795296b7494be832e29
   md5: cd89c55183b93ae38967e3ccd9919fb7
   depends:
@@ -13251,7 +13251,7 @@ packages:
   license_family: Apache
   size: 131727950
   timestamp: 1670371441333
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tensorflow-estimator-2.10.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tensorflow-estimator-2.10.0-py310haa95532_0.tar.bz2
   sha256: 7be590bed29cccabb9051dad5fe36b7095df7d67ab7f2f586f98048c0a7f1f69
   md5: a9ce1e92ad3c8d229ab6ebb75f1617a0
   depends:
@@ -13262,7 +13262,7 @@ packages:
   license_family: Apache
   size: 613286
   timestamp: 1669761587961
-- conda: https://repo.anaconda.com/pkgs/main/win-64/termcolor-2.1.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/termcolor-2.1.0-py310haa95532_0.tar.bz2
   sha256: 384d57c5c37b23b1ea85d2e7b088c728edb4052a2a1cd2c3829bbcc18ead5909
   md5: 99a18914f623b764c8653ad822ba11e5
   depends:
@@ -13271,7 +13271,7 @@ packages:
   license_family: MIT
   size: 11789
   timestamp: 1668084943015
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py310haa95532_0.tar.bz2
   sha256: d0d86ed6cd7ce216d8e9c014ccec1aca485f273a0390acd7fce88b999c5c07fc
   md5: 0c1eef070bdc583a5f13ae6d90df9ce5
   depends:
@@ -13282,7 +13282,7 @@ packages:
   license_family: BSD
   size: 30837
   timestamp: 1671752231574
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tifffile-2023.4.12-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tifffile-2023.4.12-py310haa95532_0.tar.bz2
   sha256: edd5a7f0eff16b3f970f084c651d34c455088c06fb9ed6008888dfc8400c78a5
   md5: 63b89d9cec5c485479d1b51d9a187fa7
   depends:
@@ -13295,7 +13295,7 @@ packages:
   license_family: BSD
   size: 415669
   timestamp: 1695107805311
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py310haa95532_0.tar.bz2
   sha256: bc1ddb7012553cfd0e0dfd59ac053f2c248ed6aa2f3f073535c2e3727b156081
   md5: bea69cca66bf89b57764689750ad19b0
   depends:
@@ -13305,7 +13305,7 @@ packages:
   license_family: BSD
   size: 39827
   timestamp: 1668168932332
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
   sha256: 0a95736cfd0bb25fc201cd6be4a2450ea8fc30eeb349d861812675b84c94fa74
   md5: a8a9fb30c6dd8e7a16d5dcd2333c3c49
   depends:
@@ -13316,7 +13316,7 @@ packages:
   license_family: BSD
   size: 3844176
   timestamp: 1714770894235
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.0.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tomli-2.0.1-py310haa95532_0.tar.bz2
   sha256: 98e42375576fc276660159b9a9e0b1d9894f68d46b642580fae6074fc69c4152
   md5: 1df8cd89f5453214ab5751f786b606c2
   depends:
@@ -13325,7 +13325,7 @@ packages:
   license_family: MIT
   size: 25628
   timestamp: 1657175602888
-- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py310haa95532_0.tar.bz2
   sha256: 459eaaf49856625d8d82dca32dbd401525999ec1567de125d61f81aa10d364a3
   md5: 2a762291f7c22ce1721560de68a8210a
   depends:
@@ -13334,7 +13334,7 @@ packages:
   license_family: BSD
   size: 104573
   timestamp: 1667464143397
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.1-py310h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.4.1-py310h827c3e9_0.tar.bz2
   sha256: f4ddbaefe0ce5e852ddec8511dd00c6c8a2bf0f6b70931457b7a527528a06ab2
   md5: d60ee54f17f8830d9f54d46c9886018b
   depends:
@@ -13345,7 +13345,7 @@ packages:
   license_family: Apache
   size: 716681
   timestamp: 1718740308614
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.5-py310h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.66.5-py310h9909e9c_0.tar.bz2
   sha256: d9ad0a29da259d5c48097bdaa472bdcfafad862e7d22a525df894b13c9b4bb38
   md5: b242b446e92617b01a760e02a9ace290
   depends:
@@ -13357,7 +13357,7 @@ packages:
   license_family: MOZILLA
   size: 159044
   timestamp: 1724854408940
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.14.3-py310haa95532_0.tar.bz2
   sha256: 69030849e5c9fb4b81997b209da56a31f39f70b17cd81ad5fa87a03829aa9c04
   md5: 7dd354534a9f7c43229a6707470c5936
   depends:
@@ -13366,7 +13366,7 @@ packages:
   license_family: BSD
   size: 167935
   timestamp: 1718227167930
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.11.0-py310haa95532_0.tar.bz2
   sha256: 04c24028ee04dfc3e1743003ea20ceb8f24551efcb78ce32d5adb0676df67f3b
   md5: 1260cd75a72036bacc486adc44d6b108
   depends:
@@ -13376,7 +13376,7 @@ packages:
   license_family: PSF
   size: 9720
   timestamp: 1715269070601
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.11.0-py310haa95532_0.tar.bz2
   sha256: 5d9d154041cdb878e2eabdf5ca184219b4d188fe1758ceab4beb102898d27747
   md5: 0122be146ba1251612155eef700973f1
   depends:
@@ -13385,7 +13385,7 @@ packages:
   license_family: PSF
   size: 61233
   timestamp: 1715269060734
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py310haa95532_0.tar.bz2
   sha256: fb7d79c284177ec64a95e1786fae83070612ab4318a0cde9c4ed54fb4b95a031
   md5: c0297d13bebf64bb81c7d9ca9ebab5d1
   depends:
@@ -13394,7 +13394,7 @@ packages:
   license_family: MIT
   size: 11410
   timestamp: 1659769516199
-- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py310h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py310h2bbff1b_0.tar.bz2
   sha256: 546ad672e5a6b88eae833dd2955160105f376be97d7d0dfdecd4164837211f0e
   md5: d746ec7238d3b165d58ffc8e85427a03
   depends:
@@ -13405,7 +13405,7 @@ packages:
   license_family: Apache
   size: 517369
   timestamp: 1713213348900
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-2.2.3-py310haa95532_0.tar.bz2
   sha256: 3f0b42044532387eaf17272f17e644c0e097b6ad87e2bcc12b2087594401b2a4
   md5: 21ace7c9e104b6fffd0985a16700a159
   depends:
@@ -13421,7 +13421,7 @@ packages:
   license_family: MIT
   size: 174093
   timestamp: 1727769895675
-- conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
   sha256: 2ef16d0252e04063d44d0683831d55b485f713fe5af2c2efd61753fb4f27d7e4
   md5: 256ab1d5dce70111a1f4807a5a9fc322
   depends:
@@ -13431,7 +13431,7 @@ packages:
   license_family: MIT
   size: 100982
   timestamp: 1706894771410
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.40-haa95532_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.40-haa95532_2.tar.bz2
   sha256: 2347a1c63da77846cb2161daaca7a7918fd1f2f8fc6c482b1da15f2c81ff9401
   md5: 82f790121c5a4b129df23a0c264a5371
   depends:
@@ -13440,12 +13440,12 @@ packages:
   license_family: BSD
   size: 9297
   timestamp: 1733348498082
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.42.34433-h9531ae6_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.42.34433-h9531ae6_2.tar.bz2
   sha256: e5a9bb7ea0534170f6cd52021dd2c9cdd2048eb7cf30bd983ce12caf7fdcdb21
   md5: 8a633c6afbd406dcec4a824949408c1a
   size: 2461182
   timestamp: 1733348487481
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py310haa95532_1.tar.bz2
   sha256: 5feccb42695e0a5f0d8e47806ec4a38d80812946bedff171a1b6bde5513843e7
   md5: 8719f9841803cf96f733f59aafbd147e
   depends:
@@ -13454,7 +13454,7 @@ packages:
   license_family: BSD
   size: 21579
   timestamp: 1642093965560
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py310haa95532_0.tar.bz2
   sha256: f371d3506e4e8480ffde0e9d0fb1b44c2bfdbea57b23cccd609ca3aa034b3f83
   md5: 85953c8badca12976eb5d368835fcefb
   depends:
@@ -13463,7 +13463,7 @@ packages:
   license_family: Apache
   size: 118154
   timestamp: 1715878578248
-- conda: https://repo.anaconda.com/pkgs/main/win-64/werkzeug-3.0.6-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/werkzeug-3.0.6-py310haa95532_0.tar.bz2
   sha256: 9df6ad8542c83b87f748228b60c6eb2c29851c4b2834332e94a778fac8325b4f
   md5: eadb854a34eaacc28d2c5616e01cc276
   depends:
@@ -13475,7 +13475,7 @@ packages:
   license_family: BSD
   size: 348077
   timestamp: 1731005863134
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.44.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.44.0-py310haa95532_0.tar.bz2
   sha256: 156a33aaa1b85ec45c25e5ce0506e207c5cb0b537c975e235740be51ff3645be
   md5: aacc9b0ca89bc616741a7b53659d0455
   depends:
@@ -13484,7 +13484,7 @@ packages:
   license_family: MIT
   size: 137178
   timestamp: 1726165373287
-- conda: https://repo.anaconda.com/pkgs/main/win-64/widgetsnbextension-4.0.10-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/widgetsnbextension-4.0.10-py310haa95532_0.tar.bz2
   sha256: 1fa4fd2da9e6d6fd08162d8107f3a2d544721d97c7e187d44ee5107bf6ff2e78
   md5: 31894196534039653b932c5bdbcc7239
   depends:
@@ -13493,7 +13493,7 @@ packages:
   license_family: BSD
   size: 1932336
   timestamp: 1709323320628
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py310haa95532_0.tar.bz2
   sha256: 7c5b72bec25fabcb0a6644acee0a3f45c17d535780581a17ec6616ecd21b284d
   md5: 43afdf809d6ddf58af49fb1fc5230808
   depends:
@@ -13501,13 +13501,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 8531
   timestamp: 1642658494153
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wrapt-1.14.1-py310h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wrapt-1.14.1-py310h2bbff1b_0.tar.bz2
   sha256: 14c8bc32b21b8cfb42efe46e6b14c0c5261895535914e7599e23f9de06e967f9
   md5: 83d74c87c26260c95021480516300cdc
   depends:
@@ -13518,7 +13518,7 @@ packages:
   license_family: BSD
   size: 50468
   timestamp: 1657814949415
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py310haa95532_0.tar.bz2
   sha256: fb467c7eacdf962bcb8f24476709a65db51ea60ee4ddb75f12ed30b4ea69d531
   md5: 85a71410f54365f053f787ab5782859b
   depends:
@@ -13530,7 +13530,7 @@ packages:
   license_family: Apache
   size: 1813278
   timestamp: 1689041769969
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py310haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py310haa95532_1.tar.bz2
   sha256: 67ae0c5a80eaa449ba31d96276218bb503b2a4b1cafe064376f26d5a227e98c7
   md5: 1cb14e0e9baf9ecb93a9268246620454
   depends:
@@ -13539,7 +13539,7 @@ packages:
   license_family: BSD
   size: 48944
   timestamp: 1675159282275
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
   sha256: 344a5276a9928638dcde054dfe4e87c8cb40bd2d4d356378b9ab2f863ca62e4b
   md5: fe471fd8b5a3d77be6fa5dbf9b99dafb
   depends:
@@ -13549,7 +13549,7 @@ packages:
   license_family: GPL2
   size: 1432281
   timestamp: 1714515119689
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -13558,7 +13558,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yarl-1.18.0-py310h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yarl-1.18.0-py310h827c3e9_0.tar.bz2
   sha256: 4ee05f5577049f25ee1a357aeb10274584ba440a5eef496600794747419d5bb5
   md5: 45a4d5009b0270741cad673a7fb78a2e
   depends:
@@ -13572,7 +13572,7 @@ packages:
   license_family: Apache
   size: 145393
   timestamp: 1732547101027
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zarr-2.13.3-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zarr-2.13.3-py310haa95532_0.tar.bz2
   sha256: a1280f41ca08b440ae997627db0eda252ecb0360f9d01235c9a2ada9c341be5c
   md5: 56b43fbf8825f28ab9d3623962a50ec0
   depends:
@@ -13585,7 +13585,7 @@ packages:
   license_family: MIT
   size: 346763
   timestamp: 1669364054699
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
   sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
   md5: e5aed81295b61b6d1eb62830799a0297
   depends:
@@ -13596,7 +13596,7 @@ packages:
   license_family: Other
   size: 9125184
   timestamp: 1705602328351
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zfp-1.0.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zfp-1.0.0-hd77b12b_0.tar.bz2
   sha256: 4c35ecdc3e6eac1c031fb9caad206819266a29c9b3d507e2c82a73c6b3c4aaa8
   md5: 2440d1045b36aeaffa022e8316352a5f
   depends:
@@ -13606,7 +13606,7 @@ packages:
   license_family: BSD
   size: 271931
   timestamp: 1681741704356
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zict-3.0.0-py310haa95532_0.tar.bz2
   sha256: 48e843987d2df58690ada2fbbbd38fa504ae0527f8398dca88a69f207b92a57a
   md5: d6a58dc02f3c12b71c112776a2f45d56
   depends:
@@ -13617,7 +13617,7 @@ packages:
   license_family: BSD
   size: 77967
   timestamp: 1695833117526
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.21.0-py310haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.21.0-py310haa95532_0.tar.bz2
   sha256: acab853fb614eb98cb55588889244da80ffb9caa74d291e126faf643a6d66422
   md5: 1214d0162b72abbd2142ac7fc21b6f87
   depends:
@@ -13626,7 +13626,7 @@ packages:
   license_family: MIT
   size: 26828
   timestamp: 1732630857652
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
   sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
   md5: f295b54ab59f5b8658e2a322ac6aa721
   depends:
@@ -13636,7 +13636,7 @@ packages:
   license_family: Other
   size: 162161
   timestamp: 1714514792081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
   sha256: 1f68cd378c6cdec34a5a3a21c56c9b8422b0f037b868b3db72065c0a2ca27921
   md5: d455a04486eddfb94c280974c0c33ae3
   depends:

--- a/landuse_classification/pixi.toml
+++ b/landuse_classification/pixi.toml
@@ -1,0 +1,43 @@
+[workspace]
+name = "landuse_classification"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2018-11-30"
+maintainers = ["philippjfr"]
+categories = ["Geospatial"]
+labels = ["holoviews", "bokeh", "dask", "xarray", "keras", "tensorflow"]
+title = "Land use Classification"
+description = "Image classification using the UC Merced Land Use Dataset"
+
+[dependencies]
+python = "3.10.*"
+notebook = "*"
+holoviews = ">=1.16.0"
+python-snappy = "*"
+ipywidgets = "*"
+intake = "<2"
+intake-xarray = ">=0.6.1"
+dask = ">=2023.4.1"
+s3fs = ">=2023.4.0"
+pandas = ">=1.5.3"
+distributed = ">=2023.4.1"
+tbb = ">=2021.8.0"
+scikit-image = ">=0.20.0"
+keras = ">=2.10.0"
+tqdm = ">=4.65.0"
+tensorflow = ">=2.10.0"
+pip = "*"
+
+[target.osx-64.dependencies]
+libgfortran = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[activation.env]
+INTAKE_CACHE_DIR = "data"
+
+[tasks]
+notebook = "jupyter notebook landuse_classification.ipynb"

--- a/landuse_classification/pixi.toml
+++ b/landuse_classification/pixi.toml
@@ -28,13 +28,13 @@ scikit-image = ">=0.20.0"
 keras = ">=2.10.0"
 tqdm = ">=4.65.0"
 tensorflow = ">=2.10.0"
-pip = "*"
+pip = "*"  # promoted from anaconda-project lock
 
 [target.osx-64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [activation.env]
 INTAKE_CACHE_DIR = "data"

--- a/landuse_classification/pixi.toml
+++ b/landuse_classification/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "landuse_classification"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/lsystems/pixi.lock
+++ b/lsystems/pixi.lock
@@ -1,0 +1,6774 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+  sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
+  md5: 2cf39d906cc321896ffe3e5d33d80c5c
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162166
+  timestamp: 1644463608931
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+  sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
+  md5: 2972a84e0e22ae3244bbd2f1eebcf536
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 35352
+  timestamp: 1644569715988
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+  sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
+  md5: a68016b4b06460def24cb69d932986f3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132486
+  timestamp: 1695717963702
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+  sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
+  md5: 2f6356a2f530314b4059c08c79a3d8bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 205868
+  timestamp: 1681493113570
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+  sha256: 2d8e75f31f75ea5eb8b9021b4c21eb2846a254a097e06eb68e66fc36a82e1bed
+  md5: ae374a11c789a55555f70b29b9eff1f9
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3,<2.0a0
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14430294
+  timestamp: 1658136783940
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+  sha256: f84f9caa7eb9d489fd9634419fdf766d39293a5df1104b840fa0cdc5823a5c60
+  md5: 922555c0435d6b2537cf8ced534b048c
+  depends:
+  - libgcc-ng >=7.5.0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 141903
+  timestamp: 1648028958291
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+  sha256: 0bbcb6f78eac530c6a084459ffab3238647b266d0c74d695e6e6387dd119cc67
+  md5: bdc971e2a9affb5125b68ad708172dab
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 411301
+  timestamp: 1602517685375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+  sha256: 8c2071f706c2b445dabb781f7f8f008b23a29957468ec6894f050bfb3a2d5bf4
+  md5: c203ffc7bbba991c7089d4b383cfd92c
+  depends:
+  - cffi >=1.0.0
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 357797
+  timestamp: 1605539534667
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+  sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
+  md5: 3ef00f4c5278b688552efc259c463dc8
+  license: MPL-2.0
+  license_family: Other
+  size: 132731
+  timestamp: 1694009767372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+  sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
+  md5: d5cb3d97cf5e85ffe5e94037ed8a1169
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159077
+  timestamp: 1690232254640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+  sha256: 674707b9c42e65c903c9786ee5a56b4d42aa054f1e75b328db8a2c1bfa368739
+  md5: 76ae217198b014b89b267cf41b8251dd
+  depends:
+  - libffi >=3.3
+  - libgcc-ng >=7.5.0
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 231920
+  timestamp: 1642701209740
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+  sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
+  md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1917831
+  timestamp: 1668084545510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+  sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
+  md5: 13702d3b4b744784e5bd559c7050dd6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12719
+  timestamp: 1671231205875
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+  sha256: 821af57c20a85b4e92268fbf65fbaec2f273da5bb21889d9643756ef6e473237
+  md5: f57e0f502500ffebdbec081ef61ad1d4
+  depends:
+  - cffi >=1.12
+  - libgcc-ng
+  - openssl >=1.1.1v,<1.1.2a
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 2179774
+  timestamp: 1694445209134
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+  sha256: 3a39a2d6f161080c706292e3bf480f62d2444b1d6d67b3d7db50458202ee31f1
+  md5: 0524ffca60f845eb392bbb56d56f0ce5
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2094615
+  timestamp: 1637091869922
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+  sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
+  md5: 2e6ec51066d825ef3c317abe78d6049e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16413
+  timestamp: 1649926472708
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+  sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
+  md5: b4d923222d45314856b5378cb115214d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26728
+  timestamp: 1668714462023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+  sha256: 8a121233d0b2cbb2463b67e798739ad2946f38933430a6a7fd1197cc6eab1c99
+  md5: d2b24736491290a6c6d0138932111150
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: GPL-2.0-only and LicenseRef-FreeType
+  size: 965280
+  timestamp: 1635422707211
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+  sha256: 3c8ece1a7257b1d45f8fa25f46504bb709a1923d7175f2996e891366ec434b9d
+  md5: 299bf4271d710651a1d71d3795580c2d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 83592
+  timestamp: 1603192039050
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+  sha256: 2d727f8335c59314b521b66d437ca4d51904134473ae503b7b097e239635f209
+  md5: 6991e520f353d995023404f6f524d192
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4507274
+  timestamp: 1693378095165
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+  sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
+  md5: 9213e0336e3a5216c989cfe52648412e
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 23805906
+  timestamp: 1588026213084
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+  sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
+  md5: 1eb52f9f45cea2fb9ce27b19f990160e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110793
+  timestamp: 1666125606878
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+  sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
+  md5: 126b3c1933b7364ff03f67455b687e99
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 37588
+  timestamp: 1678997134023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+  sha256: 1b424413f28b840fc6d4bf467f37e9e405823b1e3b899005df80152d48936d64
+  md5: 4aa8bcf74c81cd3600978f791191692a
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 9246735
+  timestamp: 1634546760713
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+  sha256: b51b2e0dd37a74784ba19db22aded3f4c843b6fddb4a74399f65f36fc018aaa2
+  md5: 0d56ab1950f952284b895ac0f78284a7
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.0
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203541
+  timestamp: 1671488675347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+  sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
+  md5: ff47e0be879e817713ce2a9daa76e2b0
+  depends:
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1261116
+  timestamp: 1694181530670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+  sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
+  md5: 5ef6c6a0d1ac79143c7359d305155167
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1021637
+  timestamp: 1644297140650
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+  sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
+  md5: eaeb023688f781e7dd89e74310c38195
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 211775
+  timestamp: 1666908212136
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+  sha256: 85348bfb14db4fea84078d703e766a3c978c5a592a06e41266748826dd59d8ae
+  md5: 6e1c0fb5260c590f7ef5235cb3d05863
+  depends:
+  - libgcc-ng >=7.5.0
+  license: IJG
+  license_family: Other
+  size: 279884
+  timestamp: 1651065953960
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+  sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
+  md5: 0d2c3c5edf671b575532d5a3e8bf15fc
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 131510
+  timestamp: 1676558716852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+  sha256: 92bc012f9eb4ad71158cf4826fd3e125fcebff53b529276a81224acda48be547
+  md5: c5fd100e3062e831cbdf33331042f627
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=22.3
+  - tornado >=6.0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 190884
+  timestamp: 1650622553813
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+  sha256: 0192bd48cd96c60dc3054d5addd8cdb4a29a218843181318371f79daec8242f8
+  md5: d851b401dc13d04e6848bb36e12efc1c
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 91534
+  timestamp: 1679906652183
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+  sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
+  md5: a4beb461f0a60998a090d760b5c6c907
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411564
+  timestamp: 1671707702849
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+  sha256: 974df3dc76089be57b327acd6634384def84249003f58678ca1142bb274a75d9
+  md5: 81b969d1a00153759b30554a1f11ddfd
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92144
+  timestamp: 1653292217019
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+  sha256: 3b4afe7665dcdb99bd4586a888b85b2e0325f8faecdd31c7780792080ee97872
+  md5: 822b5201dde61bc838072dc5b670c88c
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: Custom
+  size: 55183
+  timestamp: 1594054267890
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+  sha256: c6fafbe73d2f93b91b6f4b65829f925f52a8f84746a57abd216b39da9ce8c494
+  md5: 238f19c803a6ba7bd6dbd6989e03cbf1
+  depends:
+  - _libgcc_mutex * main
+  license: GPL
+  size: 8496776
+  timestamp: 1560112207081
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+  sha256: bc3e6e79c32ff0ecea601aa108ae9cf4068f69703580e40e266ad4bcc52cff54
+  md5: 9cb85601944ca7383b1769bff74b94e8
+  depends:
+  - libgcc-ng >=7.3.0
+  - zlib >=1.2.11,<2.0.0a0
+  license: zlib/libpng
+  size: 372914
+  timestamp: 1556041895170
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+  sha256: 43b0bd205f539583c088feb5b8d77b60c83d1df80c2a93dac9f2a1127001b2cf
+  md5: 53fa39fdae936e9d07c4b2f5ef361993
+  license: GPL3 with runtime exception
+  size: 4246257
+  timestamp: 1560112223556
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+  sha256: 711ea05b4c35bdafc762a172b01db896b17942f474c2b1a519f91370964bf9bc
+  md5: b25d56d33596623a6a4a9d9baaa4f602
+  depends:
+  - jpeg >=9e,<10a
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libwebp-base
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  size: 592974
+  timestamp: 1653047881023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+  sha256: 146dbb1e4dbccdd57819e5102a8ca00970b8e33d6c6180e8007db89b184da569
+  md5: c566a384259c1d2769852c3bddd81a67
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9d,<10a
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 90150
+  timestamp: 1645441199289
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+  sha256: cffb5a063111f7a99a99c74770b23db5dde52325e25a7a46d1903d5ff4a82c88
+  md5: eeb1bd66f28bed1956ab989d6eff7ae5
+  depends:
+  - libgcc-ng >=7.5.0
+  constrains:
+  - libwebp 1.2.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 889956
+  timestamp: 1645089138421
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+  sha256: 71f6c4a97014d745c58df52b4dd60ddd75a8508d54fe5b97f42bd1f31cb1c067
+  md5: 686e77514ec9f1ef0a6feed374f14d37
+  depends:
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.5.0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 789469
+  timestamp: 1653546418059
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+  sha256: ea3355a67c5173f3944f09861043ca66eb7dbeff8f385d13528b3aabc0801d0c
+  md5: 66e2aa12181bb2911485bdbe125d24c5
+  depends:
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.5.0
+  - libxml2 >=2.9.14,<2.10.0a0
+  license: MIT
+  size: 584199
+  timestamp: 1654075843119
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+  sha256: 64b022d706b76c33965a250fdc8c6008443c41bff8ab27bb1df3cb70419576fd
+  md5: ec4f05846aacf634df15c389235725cc
+  depends:
+  - libgcc-ng >=7.5.0
+  - libxml2 >=2.9.12,<2.10.0a0
+  - libxslt >=1.1.28
+  - libxslt >=1.1.34,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  size: 1538261
+  timestamp: 1646624639995
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+  sha256: 2c6a5dda7c510a961bc78e31d4232be5e8e0760c93454f5fd200c379355e0f5e
+  md5: f35d4bf2fbb39e334992f6dd39f8721e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 220865
+  timestamp: 1627657046002
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+  sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
+  md5: 421f82c8274b44660dba629134faa6af
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 122221
+  timestamp: 1671541990505
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+  sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
+  md5: feb0e452205b44ac45d9b5e55c21a3b1
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22819
+  timestamp: 1654597913064
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+  sha256: dc51b316ef5dcfb82a9c0afdc40879146ae59516f6cea7db776077783dfd2d76
+  md5: b0b6b57c140f026b8806051107336576
+  depends:
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.11.0,<3.0a0
+  - freetype >=2.3
+  - kiwisolver >=1.0.1
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - numpy >=1.19.2,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.2.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  - tk
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7729454
+  timestamp: 1647442028622
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+  sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
+  md5: c04ef34af33da4c71bcc99b7ec24d210
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16391
+  timestamp: 1662014553452
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+  sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
+  md5: f6c734d73e6e3dbc1b62766cf18ff3e4
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58153
+  timestamp: 1607364912263
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+  sha256: 7c4ded8b2ef036839f988560848d2c32e1aa4627fd37a32710e42c39f5c61ac2
+  md5: bd20f4410b81f327e35ffa0657961146
+  depends:
+  - intel-openmp 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 229783051
+  timestamp: 1634547157986
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+  sha256: 5394f5efd53afb2c1b0abf571ce3d9cb684b6c7e255f140ba2acaa703d6113be
+  md5: d3cb2bfa63e30153f5527797dcc87280
+  depends:
+  - libgcc-ng >=7.5.0
+  - mkl >=2021.2.0,<2022.0a0
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 63551
+  timestamp: 1626176932911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+  sha256: c244d23da2749857a993f84969fd35ffd183ab8f462986df6d33ae0f705fe034
+  md5: 9b1f8ccc2488d0e04eb73211e2987483
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.3.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  size: 204136
+  timestamp: 1634566416657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+  sha256: f81f426f8ef306d636664bc49e7cdd70e2b4306d7c6bcb9c75fe35a45ab2087a
+  md5: 77aa1d7f958d36bf227e6ff4a34d2e3d
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.2.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  size: 365386
+  timestamp: 1626186165897
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+  sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
+  md5: 95c83d71814c504b5504df4f14548f1a
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8257558
+  timestamp: 1681756322140
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+  sha256: 1b92d72b083f3350359b8fb2e3b5dc846f49650c9e46a6a74354b1b7f0d42730
+  md5: 996babe4314515ddd41008a53cb5d47f
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 98791
+  timestamp: 1650290544347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+  sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
+  md5: 1710a25086c8098367eb36b9d441448b
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 569683
+  timestamp: 1668450704669
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+  sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
+  md5: 385cc9e53404776782502c0fdb08820f
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147046
+  timestamp: 1694616899309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+  sha256: 0807371380965e421cb5f3f2a30d790fd5c41db11dbb6d318e14294c3b1741ed
+  md5: fca4bd4e3891aebf4fd7daf9b6d0ccfa
+  depends:
+  - libgcc-ng >=7.5.0
+  license: Free software (MIT-like)
+  size: 1083412
+  timestamp: 1636570020698
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+  sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
+  md5: bbbcbebc20a4fdcadce398d0ca04f95e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13109
+  timestamp: 1672387143252
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+  sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
+  md5: 248ce515640465371927d46f389ed555
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 594054
+  timestamp: 1690985006481
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+  sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
+  md5: 70db71df4ee1cdd38090c0f7b80ba61f
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21944
+  timestamp: 1668160644514
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+  sha256: 15a12c8bebcda45c577e61cea412d9aafaa433e39f9e91fd61bbfab66fcee3ab
+  md5: 5239d8330e8bd34972fb80918dce79e7
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16.6,<2.0a0
+  - packaging
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 136437
+  timestamp: 1640689905588
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+  sha256: ff8d0426c7096e086db818265c3edf4a820accbfb15afae0407ca578de151fa9
+  md5: d7bcf0b9ba2d85cf532059ec119d2750
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.22.3 py39hf524024_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  size: 9965
+  timestamp: 1652801901707
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+  sha256: abfdeda143b6b667d50a82ea119043fc1469ee02f094a41a2402433ff408099e
+  md5: e8dc29adc0282f4658e0e2f25ff207a2
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.22.3 py39he7a7128_0
+  license: BSD-3-Clause
+  size: 7095882
+  timestamp: 1652801886819
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+  sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
+  md5: 5ad4571eba2479f77a9f849a6ae7724c
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: OpenSSL
+  license_family: Apache
+  size: 3998613
+  timestamp: 1694465071784
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+  sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
+  md5: 77a22ed6d0d448c5288d0f695bc9ac49
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 72527
+  timestamp: 1693575234886
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+  sha256: e7a0abb0f00a94000876f2095f0cf531ad3803ffbd868a780b3f06816b54492c
+  md5: 97ef7e1fe923d22a8e2307f3f39a92d5
+  depends:
+  - bottleneck >=1.3.1
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - numexpr >=2.7.1
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13221005
+  timestamp: 1650622404234
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+  sha256: 49fdb57b2ed2ce4d6bb7a2c5adec36ba59522518a41fb941f9e39a9f43750cc5
+  md5: 871b65444733b7da5823ee0dc9826722
+  depends:
+  - bleach
+  - bokeh >=2.4.0,<2.5.0
+  - markdown
+  - param >=1.12.0,<2.0.0a0
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - setuptools >=42
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >1.14.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14712394
+  timestamp: 1676379803902
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+  sha256: 64a732ce2661cdb6bd8f9d1484ac10afeb73082b1c2b44728d212e0117d2860e
+  md5: ada303f0cf43a4e99cfa7f243b23b681
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141832
+  timestamp: 1684915385689
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+  sha256: 8bcb1c67693f42a3170eb77ef4cdbb81b605fdf40816953e69a33a065c101638
+  md5: b7689507fb5f879dc766aaa8a4c37351
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp >=0.3.0
+  - libwebp >=1.2.0,<1.3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk
+  - zlib >=1.2.11,<2.0.0a0
+  license: LicenseRef-PIL
+  license_family: Other
+  size: 734566
+  timestamp: 1646325095608
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+  sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
+  md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2674850
+  timestamp: 1697548887851
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+  sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
+  md5: fe56f0479dd414c846191116366262c3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 31999
+  timestamp: 1692205535111
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+  sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
+  md5: 44d2a857d13bdf9d99aaac039a249d47
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91137
+  timestamp: 1659455142164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+  sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
+  md5: eb899a739d9b58dd747f1f6bd52d4cf3
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 579771
+  timestamp: 1672387338600
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+  sha256: 6973cfe0565ba3b5ad6d1de9e34848fbbadd78b507b2e23e1c079636b8f8f317
+  md5: a924535045fb356e23e7a3cc8116b638
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 350026
+  timestamp: 1612298042840
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+  sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
+  md5: f36ecb722522cbe2e3737424edf1b5e1
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29312
+  timestamp: 1675441510984
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+  sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
+  md5: 6d03295e544251e608a28c8d7c48115e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1862058
+  timestamp: 1684280096752
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+  sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
+  md5: 1f09617aecd6f3c2f2e20692c0759f34
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94434
+  timestamp: 1690223520097
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+  sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
+  md5: ffceed627867508d73af1636ab5ebf42
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 156324
+  timestamp: 1661452578573
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+  sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
+  md5: 0e3341a4fe434167bf74b613eb6afd81
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 97194
+  timestamp: 1636110999719
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+  sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
+  md5: c5f3f7f10ad30f0945e75252615ab6e5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31331
+  timestamp: 1605305847037
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+  sha256: c4b9e332a6f2b7524e8c88e2b39a2568a48e556fd9a44c30759c43611d4d023d
+  md5: bb118745c9b08fc5028f45e77f371e68
+  depends:
+  - ld_impl_linux-64
+  - libffi >=3.3,<3.4.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - ncurses >=6.3,<7.0a0
+  - openssl >=1.1.1o,<1.1.2a
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.38.3,<4.0a0
+  - tk >=8.6.11,<8.7.0a0
+  - tzdata
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 24553777
+  timestamp: 1654084160832
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+  sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
+  md5: 0caa188a695319bdb13f53b0a2b3accc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264864
+  timestamp: 1661371117920
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+  sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
+  md5: bcb44ecbea441ee0d4659133d060d71f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257904
+  timestamp: 1695131670290
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+  sha256: e937081facacb141dc2c9cdcced92baa9a2662e4a56100b6041df0b6b7692570
+  md5: f3ac39b2349258198a9b3316636fe5d5
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39972
+  timestamp: 1685030752528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+  sha256: 3da9cbbd49fac566433748bd245d09d7d5fcd28b04c0397cbbf6d5bb92f5c4a5
+  md5: df73a5d2f6e089d51e71e91935a82c65
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 183753
+  timestamp: 1635775763162
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+  sha256: 26005d191bb15070aad70707ed6493f32678a67978bd3b83d4c9679cab44e717
+  md5: 2dc75d5a4ccb64310939c3a72d34ae20
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-clause
+  license_family: BSD
+  size: 521583
+  timestamp: 1638435042256
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+  sha256: 8c950c69bee969e2c66f88f0dc247b3ab75a753672a88009779d5f5dba193532
+  md5: 150ac0eb929bab9dec912797bdfc7b95
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 433182
+  timestamp: 1642022402894
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+  sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
+  md5: c7de00b4ac2778c4e5a7816320d75391
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94028
+  timestamp: 1690400356879
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+  sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
+  md5: 1581cafc84708ed9aafaaee1cbbf6065
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1089416
+  timestamp: 1690290900608
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+  sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
+  md5: e19ffbfb24b990275d24fcea2bd1699b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15702
+  timestamp: 1614030498860
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+  sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
+  md5: ca061ce25c0f58628643abec8d6a8244
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 66330
+  timestamp: 1696347637947
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+  sha256: 87965b7b46d93866d31696a1045216d64f077a06b2900c356aba87e8559c6188
+  md5: fa334030245135b37027a882f3c468bf
+  depends:
+  - libgcc-ng >=7.5.0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: blessing
+  license_family: Other
+  size: 1561908
+  timestamp: 1655328608308
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+  sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
+  md5: 0e76eab58fe488e91f0aee73f46de031
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29816
+  timestamp: 1671751864131
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+  sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
+  md5: b413a210eca82fe867e991eed085201b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38882
+  timestamp: 1668168876032
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+  sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
+  md5: 5b8375e2092012db69d2123dc0c68630
+  depends:
+  - libgcc-ng >=7.5.0
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3485432
+  timestamp: 1654088939579
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+  sha256: b746e39272888b9cc1a2a711b7b8836f2e26f4457850e43ad18bf0765e21dc3d
+  md5: 200e86f8d53aeebf4b7dcfc944fd7920
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 661662
+  timestamp: 1606942359431
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+  sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
+  md5: 67a8320961ff24e92eebb661536e5cf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - requests
+  - slack-sdk
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 123763
+  timestamp: 1679561904852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+  sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
+  md5: 0f0b91a158dd3692cbb7a7763b657bfe
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192032
+  timestamp: 1671143995098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
+  md5: 8515e64a3de7581360d713fe4c0a094e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8789
+  timestamp: 1690297588156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
+  md5: 60170012374b2a5007842fa5870d78c5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57479
+  timestamp: 1690297581658
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+  sha256: 870f20a3c006a74b291910f69c3469a409bd21437142864b29cfafeb89ca7c34
+  md5: 1b2f1589e3ebc3e0c6ecb38dba93e4ae
+  depends:
+  - brotlipy >=0.6.0
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 186761
+  timestamp: 1686163186447
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+  sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
+  md5: f8d03a15b974fc7810d9f54ae849fc8e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20781
+  timestamp: 1607365390528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+  sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
+  md5: d7db5d6ce1db80eade8a082ff78bf479
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 71044
+  timestamp: 1614804011510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+  sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
+  md5: b3899f8bda32734727bd5a73df1d7d17
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 101520
+  timestamp: 1695742037911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+  sha256: 2ce360ff98c0ca4537d70c19266b5700810196c54ce2fbaff3b94a969846ee37
+  md5: 94cb94dc47405b24b1b5bd0a3275ab59
+  depends:
+  - libgcc-ng >=7.5.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 398058
+  timestamp: 1651602137803
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+  sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
+  md5: 567b68192c387b5fc88178425577a0fe
+  depends:
+  - libgcc-ng >=7.3.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=7.3.0
+  license: LGPL-3.0-or-later
+  size: 366479
+  timestamp: 1616055552392
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+  sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
+  md5: 3818a9531fe74433c3b7d5144c9a58cc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18021
+  timestamp: 1672387231268
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+  sha256: 513444d83ac2405e898531492ea59f3a95641e357cc39c1048d6fffc1791a16b
+  md5: 601d9449c280b9b145dc8c83b6f06119
+  depends:
+  - libgcc-ng >=7.5.0
+  license: Zlib
+  license_family: Other
+  size: 133595
+  timestamp: 1650637720646
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+  sha256: 1c049c23788a00b6f38bdc801245e0e60af98718d4db4c958658bcc67ff158c7
+  md5: b1737dfd2e06ad69ec5cfec341e207c6
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 827172
+  timestamp: 1650622223170
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
+  md5: b2aa5503875aba2f1d88cae9df9a96d5
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13636
+  timestamp: 1611930018941
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
+  md5: 544adf2677c47c9b9c891aea720678f1
+  depends:
+  - python >=3.5
+  license: MIT
+  size: 33999
+  timestamp: 1630003259346
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+  sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
+  md5: 9eff1a842dbda8d1bae9a2c008b599bc
+  depends:
+  - brotli >=1.0.1
+  - munkres
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 690443
+  timestamp: 1625743217109
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+  sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
+  md5: 33624a42ee387bf9918ea98b4e7b31fc
+  depends:
+  - pygments >=2.4.1,<3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8173
+  timestamp: 1601490751973
+- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+  sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
+  md5: 67857cc5e9044770d2b15f9d94a4521d
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12810
+  timestamp: 1600445183315
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+  sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
+  md5: e68a6f315f41a8d814d833652bf38b9b
+  depends:
+  - python >=3
+  license: MIT
+  size: 13374
+  timestamp: 1606932077143
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
+  md5: 2eb923cc014094f4acf7f849d67d73f8
+  depends:
+  - python
+  - six >=1.5
+  license: BSD-3-Clause and Apache
+  license_family: BSD
+  size: 246457
+  timestamp: 1626374695070
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
+  md5: 41db68b96e114e367c4f120a3b379e59
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19391
+  timestamp: 1632406728844
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+  sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
+  md5: a815d3bdb160bcc71687f2dda70d3ca4
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 122218
+  timestamp: 1680170368293
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
+  md5: 447a49f7bad119faa80d7f14aa296c95
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162176
+  timestamp: 1644481750133
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+  sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
+  md5: 8810f48fe4a4792de0fd3520b502d08b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10019
+  timestamp: 1606859473259
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+  sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
+  md5: 00a446b6dfc61af223df4de29fe8ad94
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 34305
+  timestamp: 1644569782044
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
+  md5: bd92dd8bd5b9d24e632b62a075426e50
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133634
+  timestamp: 1695718025321
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+  sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
+  md5: f8ae051b591a9027adc16de1be9748f4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206198
+  timestamp: 1681493096349
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
+  sha256: 2936241747f6cc0f0b3afa53bb28ad6f658b53a0fc2e67a5ed34d1d5e2cce117
+  md5: bdca1b691340964271d9cfec6baaf8d0
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5719952
+  timestamp: 1697490515691
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+  sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
+  md5: 0d79760d544d0bd8acb4adc4ef813418
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 137075
+  timestamp: 1657175654487
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
+  md5: 31d6d04cd2388d8f19004501271b3545
+  depends:
+  - brotli-bin 1.0.9 hca72f7f_7
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18982
+  timestamp: 1659616229395
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
+  md5: caf1073dc2ca5aeb832a2877394eae12
+  depends:
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18233
+  timestamp: 1659616216769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+  sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
+  md5: aa1ed20c38af535c8d6a955314759d7b
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 394588
+  timestamp: 1659616312678
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+  sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
+  md5: ce3588e31faa79f546e0fc6a36c5543c
+  license: MPL-2.0
+  license_family: Other
+  size: 133884
+  timestamp: 1694009771475
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+  sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
+  md5: 21eb7f53076d0a69513cfd258f6ef63c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159756
+  timestamp: 1690232346868
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+  sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
+  md5: a40a04d9cda1e665565bc6c832d598b6
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225258
+  timestamp: 1670423337502
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+  sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
+  md5: b2cc5f37f7bb069d061306e7eac2a011
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1913396
+  timestamp: 1668084575248
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
+  md5: 103d8c039e342115720a84d59c119d46
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13774
+  timestamp: 1671231190250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+  sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
+  md5: f69f09e0346172f225390d2b3b0d7873
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 246628
+  timestamp: 1663827484947
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+  sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
+  md5: cb80c7ac65b48a737654f371fe31c460
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1307228
+  timestamp: 1694212041712
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+  sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
+  md5: 04cbe8f4bc62c34fac9d42d1124059bf
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2052734
+  timestamp: 1690905361158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
+  md5: ef0e825982f242085574f502dfff4f6b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16594
+  timestamp: 1649926538106
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
+  md5: 24747a300246c016b3a7f04dabd02d4a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27709
+  timestamp: 1668714497209
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+  sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
+  md5: e4a732941f74b8062c8bcbfe5c5c2b56
+  license: MIT
+  license_family: MIT
+  size: 80252
+  timestamp: 1676983220161
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+  sha256: 5c36d43cadbbf944d9255e79df85c2e9e6155a1d6f9158e06fcd8ffd458b7663
+  md5: a5a2cff387403ccf9cf58aac7a6dde55
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4573879
+  timestamp: 1698866750755
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+  sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
+  md5: f3ce6fe6eb760c236e5f7d04df5faa81
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28138484
+  timestamp: 1692293212596
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+  sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
+  md5: 6dd72c43fea25b748ec7a9f6c0407e15
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111810
+  timestamp: 1666125671024
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
+  md5: 03cdb7e679924b329ecab8f12cb8fc67
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38813
+  timestamp: 1678997212422
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
+  md5: e113c4e6e758dd68faf196586bf5564d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51873
+  timestamp: 1698254765815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+  sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
+  md5: 78baea934985ccd9514a366cc7e80ed4
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 727499
+  timestamp: 1681801225190
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+  sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
+  md5: da9b63e42f281f7e77b289f4b654b83b
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 218436
+  timestamp: 1691121840155
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+  sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
+  md5: 6a7cb9b49593b29933fa2b503d533a08
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1257205
+  timestamp: 1694181720454
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+  sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
+  md5: d861ef66f5c0a282d60b65778a9de2f3
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1048450
+  timestamp: 1644315332508
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
+  md5: f7e603c965052deed8b789c35855a42f
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213537
+  timestamp: 1666908270815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
+  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
+  license: IJG
+  license_family: Other
+  size: 278924
+  timestamp: 1677849185191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+  sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
+  md5: a82a17e78f725dcbd71ff8dac6db05c7
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133134
+  timestamp: 1676558895333
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+  sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
+  md5: ee9270379a9ebdb6297e4b6849b3f7f0
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 195479
+  timestamp: 1676329410154
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 32b898a97dca7770858ab31294238fde11ab61a84831a52f320e5ee5405a147c
+  md5: 926e754b8fad288b583ef2933deae1a5
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92938
+  timestamp: 1679906616072
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+  sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
+  md5: 7e60995b3119417213e5faedda147499
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 403165
+  timestamp: 1671707664990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+  sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
+  md5: cd470bdb28bb0e8b3535c93a3a6dad07
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65431
+  timestamp: 1672387389172
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
+  md5: 7dba7aa5b971febb55281659843586ba
+  license: MIT
+  size: 65470
+  timestamp: 1659616172703
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
+  md5: f78a158983f0bbaba56f34b976bc6dae
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 34189
+  timestamp: 1659616189313
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
+  md5: 36a1d885725d3ab4d1fadc5a29f978d2
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 327737
+  timestamp: 1659616202869
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+  sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
+  md5: 817848d0e2b2808acdc9b3fbbf581726
+  license: MIT
+  license_family: MIT
+  size: 133887
+  timestamp: 1683716590737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+  sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
+  md5: c90372428e1e4eed4fdcd790979d06b4
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1409377
+  timestamp: 1650983531933
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+  sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
+  md5: c0b99f8e1c7475f23b1c7b4250b06e1c
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88021
+  timestamp: 1694778290062
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+  sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
+  md5: 06866415ef22d5322f9bdc9956b59c4d
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 678174
+  timestamp: 1692970318885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+  sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
+  md5: 2edc6c894d6d0321304396e9bd40df94
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241774
+  timestamp: 1692973618934
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 0190d3b8d2939f28aa017711cf4147c51a1139da2922cc8420a71562dd99f844
+  md5: 454a7f2c4426453f17e995382a4235e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 36036
+  timestamp: 1659783508187
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+  sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
+  md5: 8bbd981ca0129d7beeacd3cd7623f714
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1491074
+  timestamp: 1695058597986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+  sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
+  md5: d5f58d056b4bfc67aec30c77035ba889
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 182491
+  timestamp: 1670944720979
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+  sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
+  md5: 1affd16b166571a91feae04baf5fd3da
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123431
+  timestamp: 1671542016019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+  sha256: e5fc51472fa0f36abd78baa5b3c9245d6627b0da11188e6a954d73f3f2bca210
+  md5: df7c519447affffb594f8c56b028ed33
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 107035
+  timestamp: 1684279974102
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+  sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
+  md5: 3681ebf029211ceab26af6f5d35abf39
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22254
+  timestamp: 1654598220251
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+  sha256: 2fd179efa024c92d0d71179a981a781d16c70f5d8c6305e0d678b0c7ae1275ab
+  md5: addda7f015d1673f794a23fdb18a3e09
+  depends:
+  - __osx >=10.12
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8182219
+  timestamp: 1698692361219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+  sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
+  md5: 6eb64ecfcd754502e271db0bb51d2cfd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17374
+  timestamp: 1662014643620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 2312ee5a6343e8495802698d7181f1b619aad7479d96ee253407b324ac884417
+  md5: 866960fa48a7ca335941786d4869802a
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53542
+  timestamp: 1659721365599
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: 37f455814ce242eb65ff80a0402f1bd231a388e6823e6c1e65f60b705c032a2d
+  md5: 4c9246c492a64729225aa5b04e12c2d1
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19573
+  timestamp: 1659716100178
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+  sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
+  md5: 2a4d604717a647ad21af766289cbbfc3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58057
+  timestamp: 1607364912348
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+  sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
+  md5: 25051fe272624544652dc6d814c2943a
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224420228
+  timestamp: 1691503125614
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+  sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
+  md5: 37d8cf85a63f7aa9af1624894a7d606d
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48590
+  timestamp: 1682969183093
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+  sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
+  md5: 0b2aee6666135bbd36b46d6ac66160f7
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 210705
+  timestamp: 1695058433223
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+  sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
+  md5: e22fb55ce380d0ebd44cce3f20d5349e
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296614
+  timestamp: 1695060155673
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+  sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
+  md5: 1a5d4004e64e3cfb7a2a297b9117c285
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8213832
+  timestamp: 1681756573646
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+  sha256: 2975bd1f98ca9ec7354ee378f86f8322ec90f568374776fd90e80c534fbee882
+  md5: 798627089e0ccba26695a26d9cb127ec
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99066
+  timestamp: 1650308465824
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+  sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
+  md5: e572c1264a7af20b486f64ac8c9e1f57
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 573356
+  timestamp: 1668450732828
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+  sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
+  md5: b67569a7c30af9ffa5cde6e4b52ac68b
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148342
+  timestamp: 1694616917184
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+  sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
+  md5: 97b81f34efbe86c5220fe82eb584fd62
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387288528
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+  sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
+  md5: d77862975a9a1cf50acb803be26e83a1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 575365
+  timestamp: 1690985052739
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+  sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
+  md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22858
+  timestamp: 1668160618784
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+  sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
+  md5: 185e9c41abb88ee59b52ec0f5f65d506
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 138305
+  timestamp: 1696515469702
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+  sha256: 82a2dd0c2ff6e20a275e5447dd03088f79694f7bfa5055a25c54bebf31aac4ca
+  md5: c157e6ab469a95b06fa822ba075978b3
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.0 py39ha186be2_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10376
+  timestamp: 1695831243158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+  sha256: b3a003b41cec2751210e542911e99437db0321542f6812c1b88608ef720ba7ef
+  md5: 56400dfe88c427cdf1854e47666b8a99
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.26.0 py39h827a554_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7570900
+  timestamp: 1695831208653
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
+  md5: 93f5d7b66976154adeda219bea02ba45
+  depends:
+  - libcxx >=10.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 484257
+  timestamp: 1630093862501
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+  sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
+  md5: 5e8713ef1215406254988163eaf34020
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4965606
+  timestamp: 1695323060401
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+  sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
+  md5: 4154929ace2ad6ee16aea815635a6d1f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73598
+  timestamp: 1693575307570
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+  sha256: aff5acedef9da91b77851e1a163b8319d72bc4152c98ac87703a2eac1e5d575b
+  md5: 7df4c76aa8c52fedce5346748d56459e
+  depends:
+  - bottleneck >=1.3.4
+  - libcxx >=14.0.6
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - tabulate >=0.8.10
+  - blosc >=1.21.0
+  - fsspec >=2022.05.0
+  - beautifulsoup4 >=4.11.1
+  - pyreadstat >=1.1.5
+  - pyqt >=5.15.6,<6
+  - s3fs >=2022.05.0
+  - numba >=0.55.2
+  - xlrd >=2.0.1
+  - qtpy >=2.2.0
+  - xarray >=2022.03.0
+  - psycopg2 >=2.9.3
+  - lxml >=4.8.0
+  - zstandard >=0.17.0
+  - pyarrow >=7.0.0
+  - pytables >=3.7.0
+  - xlsxwriter >=3.0.3
+  - gcsfs >=2022.05.0
+  - fastparquet >=0.8.1
+  - scipy >=1.8.1
+  - pymysql >=1.0.2
+  - odfpy>=1.4.1
+  - pandas-gbq >=0.17.5
+  - pyxlsb >=1.0.9
+  - matplotlib-base >=3.6.1
+  - openpyxl >=3.0.10
+  - jinja2 >=3.1.2
+  - html5lib >=1.1
+  - dataframe-api-compat >=0.1.7
+  - sqlalchemy >=1.4.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13388063
+  timestamp: 1697477404222
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
+  sha256: 42d83288119306089a06e853a37045fbb9860548b05a1e79d223f7ecf1cb349d
+  md5: 8daced11264159ff57df7bba4d0b2ec7
+  depends:
+  - bleach
+  - bokeh >=3.2.0,<3.4
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.0.0,<3
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.17.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17075803
+  timestamp: 1698867397009
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: ad7ca92e5c83a8e2181677025509ed7b8f566ec23b24f28316fa087bb591c11f
+  md5: a4ccd0fbcfb26de868f2fb4836940d7a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189263
+  timestamp: 1698263570990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+  sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
+  md5: be0a90921f3bf4f0d6950fb786093de7
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND
+  license_family: Other
+  size: 719901
+  timestamp: 1696580194417
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+  sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
+  md5: 81ae9ec2d7fcf6934847bff558b619f5
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2672987
+  timestamp: 1697548890181
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+  sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
+  md5: 1a822c206e2abddc5d6d821721af227f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33013
+  timestamp: 1692205801265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+  sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
+  md5: 1604d33dbdb2446c642970f8b354bedb
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91266
+  timestamp: 1659455269141
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+  sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
+  md5: d1b3bcc35655a3123acb1fa2ad1a8511
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580828
+  timestamp: 1672387372015
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+  sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
+  md5: 7540555d1fb192236db9a7c5c9d3601c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365765
+  timestamp: 1656431373327
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
+  md5: 0a73533fb6e0dc717ab906a537bc747d
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30803
+  timestamp: 1675441638631
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+  sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
+  md5: 0a959fbad46ab38ade48dbd358002674
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1864757
+  timestamp: 1684280094736
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+  sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
+  md5: ea24b5076ef79e4567c5a3f0cb22b470
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95330
+  timestamp: 1690223465114
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+  sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
+  md5: bcaea6d4a47e9c874becaa700c78dcf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157216
+  timestamp: 1661452617825
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+  sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
+  md5: 707110d1b49cb1864acb0bbaa103591e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 95016
+  timestamp: 1636111184034
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
+  md5: 113a443b9c706f9f9c6187c0eaa3de27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31178
+  timestamp: 1605305861851
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+  sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
+  md5: 85a8d0001db70e52a479155228cb1fe0
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13324979
+  timestamp: 1694439878265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+  sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
+  md5: 47c5e22e31ec05a7bc0ce90065a53afd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 265348
+  timestamp: 1661368839620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+  sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
+  md5: ce9a69e1668aa1e133f2aa6d4e8d346f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 254958
+  timestamp: 1695131709704
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 9ee098c09f31fad7ff1856e5ce2619172eaf979997e7a427d1e05cce32c2af00
+  md5: cac1d1898b69ae9646dfbf082910635d
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40946
+  timestamp: 1685030787453
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+  sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
+  md5: 637f08b19dd8fd87347d8c44f9e3e202
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 170776
+  timestamp: 1698096100056
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+  sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
+  md5: 8ce3ac7d8a04e469b566f1b090d01140
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 470617
+  timestamp: 1657724324011
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
+  md5: 6f2d41dd76a03b7f85a1ed49af1763d6
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95100
+  timestamp: 1690400262627
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
+  md5: b0321e6f14e139fc15b1f8b4acb35d2f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093966
+  timestamp: 1690290944588
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+  sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
+  md5: 62b64576a0aa5f6c3fb05f56650d25e1
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15535
+  timestamp: 1614030509324
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+  sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
+  md5: 15b5595b31e39f08eaacbe2e502d8fb3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67292
+  timestamp: 1696347733587
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+  sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
+  md5: 82e4db6a498480a75d53c55bd35b6478
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1801397
+  timestamp: 1681394807900
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+  sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
+  md5: 63b957927b9949ccb19da28ec4612706
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30902
+  timestamp: 1671751919031
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+  sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
+  md5: e346257a2fa8e2cb48c762138a5d009b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39915
+  timestamp: 1668168959656
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+  sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
+  md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
+  depends:
+  - zlib >=1.2.12,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3536231
+  timestamp: 1654088937695
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+  sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
+  md5: a1bbf0abfb8c45541122c0eb2feee317
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680464
+  timestamp: 1696937112175
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+  sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
+  md5: d689f6203c0a9d04fb229c73d7e80a7a
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125145
+  timestamp: 1679561909274
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
+  md5: 8a292c1ee22489bef2e84bc3aaf4098e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193141
+  timestamp: 1671143985219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
+  md5: 8bf0bfffc11ad06a1c94e145941b0ad4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9651
+  timestamp: 1690297655669
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
+  md5: 343514a174b3485fde55a73f56398dd7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58456
+  timestamp: 1690297648002
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+  sha256: 11e7401cb6805db7ce22b1f9dd6ba5b7941c92225ce440bed1da0af284bfcad4
+  md5: 5c10d68fa5616cdd82ee93ef6e0f038c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11615
+  timestamp: 1659769478980
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+  sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
+  md5: c2242e8fd24003a74ddf37416661e06d
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188757
+  timestamp: 1698257668273
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+  sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
+  md5: 41f445e36b6b6722a9444508eef069f8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20583
+  timestamp: 1607365395045
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+  sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
+  md5: 409ee46ed24267b6da6fb32d13e1f21e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70730
+  timestamp: 1614804271285
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+  sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
+  md5: eb74e74d8e4fd533c55eb98b7b5e83bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102637
+  timestamp: 1695742077778
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+  sha256: cb007615819fd240ea4e343835dfbda3c508a92b5b7158219d30a22d0e67b57c
+  md5: bf215e781ac81e0fc433eedee330c54b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49462
+  timestamp: 1675159191191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+  sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
+  md5: e243baa546432c8394a8059a44a5a3e4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 419227
+  timestamp: 1683113010463
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+  sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
+  md5: fe4ac85ee86d3a94ea3a4ebea3779763
+  depends:
+  - libcxx >=10.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 321797
+  timestamp: 1616055526986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
+  md5: bc7073d9d4c0211cc4a1207c98fb765a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19091
+  timestamp: 1672387204865
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+  sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
+  md5: 8e495591e369ac161857a72011c0a296
+  license: Zlib
+  license_family: Other
+  size: 120272
+  timestamp: 1666595024203
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+  sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
+  md5: f1465fbd810b3746c6de6babfd4fe28a
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1023573
+  timestamp: 1681304595869
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+  sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
+  md5: cf55cb8d7031b30c70c56fc7c782b5c7
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 156104
+  timestamp: 1644482799136
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+  sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
+  md5: 84fce327d9f0d594e86f565e5c21962e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10183
+  timestamp: 1629146082730
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+  sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
+  md5: 84b8b998a741b37abf5312c1c03696ef
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33979
+  timestamp: 1644845817952
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+  sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
+  md5: 77b746931c8f31c3ae393ccb5819d43d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133628
+  timestamp: 1695717890677
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+  sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
+  md5: 3df6e8ba34208dea068890e5d5318cc0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206759
+  timestamp: 1681493095987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
+  sha256: 8c31e7ede4b9a3ec6e1342f02bcff4d7113e5b25f12b91d108616a08eb8eb34f
+  md5: de3ce22af040eb01db773fcab23ef413
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5722206
+  timestamp: 1697490482051
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+  sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
+  md5: bb55f81435cb6e11d264242274fccd1a
+  depends:
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 115947
+  timestamp: 1657175645380
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
+  md5: f860193e14afc7ef3f5b990a2ac003d2
+  depends:
+  - brotli-bin 1.0.9 h1a28f6b_7
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18936
+  timestamp: 1659616204016
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
+  md5: ad53130f3fd1f8d3c2fcbb7496e5585d
+  depends:
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18715
+  timestamp: 1659616188888
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+  sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
+  md5: 0982c046fb976e9f9fb19e7510187a18
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 366983
+  timestamp: 1659616245272
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+  sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
+  md5: 31ac2f5596cb7a44adf073c930641c54
+  license: MPL-2.0
+  license_family: Other
+  size: 133817
+  timestamp: 1694009762858
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+  sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
+  md5: cf1f6c3c34a1e1b9ab22b04233d860f6
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159783
+  timestamp: 1690232303987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+  sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
+  md5: 0eb268e38b5174d471a6e87d9d6102b1
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225355
+  timestamp: 1670423312966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+  sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
+  md5: e68c94666cd60221b575c3814c89bac0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1946451
+  timestamp: 1668084573824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+  sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
+  md5: 1773ae2b080cdd55827e27673351551e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13646
+  timestamp: 1671231171682
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+  sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
+  md5: 53bfd99ad1b09164d537209cffd98161
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 244040
+  timestamp: 1663827469853
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+  sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
+  md5: b62455043c8eb2434466885b19fed2de
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1399573
+  timestamp: 1694211828228
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+  sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
+  md5: eb3cdc0fc210838b9271512a6a1b7c85
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2067708
+  timestamp: 1690905319109
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+  sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
+  md5: f44b80b9405410e5bde6bfe0b31d5b3f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 15135
+  timestamp: 1650293774207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+  sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
+  md5: f87027ccce1361d0f82c0edf1a10d53b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27677
+  timestamp: 1668714367519
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+  sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
+  md5: 1d0bd7e576c64c059ef781dd319ad82a
+  license: MIT
+  license_family: MIT
+  size: 77591
+  timestamp: 1676983230102
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+  sha256: 3e480af22e98246c056bbd91d6be5352df34ff2b8451d9c7f614baeafb450d39
+  md5: 695fe7ccaf6935d3117533d1e6737320
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4542265
+  timestamp: 1698866834303
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+  sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
+  md5: 69eb3b03765627b6159ed23cdde78396
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28399065
+  timestamp: 1692293207812
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+  sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
+  md5: 83366cbd3beb073112f4644a613b6bca
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111933
+  timestamp: 1666125627512
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+  sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
+  md5: 647c1a2f8460ffa8c670a1915bbdb494
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38790
+  timestamp: 1678997152549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+  sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
+  md5: 35e541905426c686ef2ff010a0e502fd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51860
+  timestamp: 1698254731870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+  sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
+  md5: 187d7720aedf38759d122cccb4576f2c
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 219976
+  timestamp: 1691121991680
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+  sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
+  md5: e8e7f10741f9cfa737b310b334940441
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1255894
+  timestamp: 1694181494549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+  sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
+  md5: ff209e75aee17af2e358b0008fbe8c88
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1022945
+  timestamp: 1644315931223
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+  sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
+  md5: d3e78ef296b3c74910d003bd10b475d6
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213972
+  timestamp: 1666908195870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
+  md5: 055e12390b844ea6c6e956ee08a618e8
+  license: IJG
+  license_family: Other
+  size: 273479
+  timestamp: 1677849171867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+  sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
+  md5: 783e2ad3d36472648c5ccc9f3051db3c
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133077
+  timestamp: 1676558732505
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+  sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
+  md5: 0677598f673f9729b5990316170a999d
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 197129
+  timestamp: 1676329661580
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+  sha256: 05f9ca0fdcfdc2e217438be27fead588c843a3aadf7d034467c83216d1e5c214
+  md5: 2d648b77d817ba38293c0728711ba8f5
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92852
+  timestamp: 1679906632236
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+  sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
+  md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 401319
+  timestamp: 1671707682572
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+  sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
+  md5: 247558a0aecf1ef7e77a4343761353d6
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64600
+  timestamp: 1672387273585
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
+  md5: a0f206782751dfffed0dd51302a1bf26
+  license: MIT
+  size: 68012
+  timestamp: 1659616138077
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
+  md5: 4c6667cdd061d28e9bc4e4300e4d115e
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 31173
+  timestamp: 1659616155596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
+  md5: 637e9430e258ddf050623ef2360184d8
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 298430
+  timestamp: 1659616172209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+  sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
+  md5: 55c615026c0869f8d3ba657f3bd38c43
+  license: MIT
+  license_family: MIT
+  size: 120389
+  timestamp: 1683716579036
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+  sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
+  md5: a41117710dafe569c9cc4e83f6f29fe3
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1411339
+  timestamp: 1650982753977
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+  sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
+  md5: 98d22e0124d55fae3c37c608dab1dcc9
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 89825
+  timestamp: 1694778225280
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+  sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
+  md5: 0ba499df6755eae5d2d23aa4ab004553
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 642657
+  timestamp: 1692970217410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+  sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
+  md5: c73101971e5ab6a8e8688239884eac81
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241607
+  timestamp: 1692973585084
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+  sha256: ac50f846e93e68d50bfdd5589ea8272b987243a64eba8e2e358ef311d7734001
+  md5: f19270ff954a41dabbfe36ff0656935b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 36040
+  timestamp: 1659783399073
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+  sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
+  md5: 353dff9d5d996c2a260f66381b2ce3e8
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1470815
+  timestamp: 1695058433965
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+  sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
+  md5: c99006da802a97c9aae30da8c16b4820
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176131
+  timestamp: 1670944706815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+  sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
+  md5: 60bd1e037cda86205526f77405d78129
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123361
+  timestamp: 1671541992772
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+  sha256: 2fd690fa3c54a40f0426874ea12e12aad2718263a75708ddd1fa6052a4ad7fb3
+  md5: 81388724babfe9c32ea5cdd93633c342
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 107072
+  timestamp: 1684280007887
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+  sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
+  md5: 34dfd76da78de2eae95bbda390d746d6
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23092
+  timestamp: 1654598007056
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+  sha256: bf0eeef3c3c713515766ab8b0dc7863413de5b4b227deede97e24d90ca342345
+  md5: a7bba1857eb84fb50caea377e60d2050
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8066509
+  timestamp: 1698692266161
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+  sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
+  md5: eb79dabbeedee7da85dfbfb145bb8a26
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17342
+  timestamp: 1662014601345
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+  sha256: f400ad75dd2890627dc948f3e2e6b19732d02c124723eaf22272026993a94d52
+  md5: 4a4ffc7365e30b18f4443281839e2718
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53505
+  timestamp: 1659721313693
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+  sha256: 20fb26a7ac748ce288cf8483a837b0c33f1348ae738bcdb69cdc2763c7bbf7e1
+  md5: a0aebbc6c170ebd8d4710fd70b3db503
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19562
+  timestamp: 1659716131839
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+  sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
+  md5: 56db7bd3ff511cd839bda081523b3edd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 55683
+  timestamp: 1629356128780
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+  sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
+  md5: 176e0dcaeb28393881bacf69941e3889
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8289638
+  timestamp: 1681756329011
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+  sha256: afc6f332c51a3defc69e4c4e641988c0556039b9cd42be22f3db5292c88ccf37
+  md5: 2bc409c7258160a9b739d08d5ffb5998
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 96942
+  timestamp: 1650373637069
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+  sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
+  md5: 150ea9fadddf21993d3328d3e48a18b7
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 557688
+  timestamp: 1668450759059
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+  sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
+  md5: 37163b32508f9f589b3e6462a3a47546
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148426
+  timestamp: 1694616771736
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+  sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
+  md5: 6cdf7cbc43bf40e92b056a5576bd0086
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387216468
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+  sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
+  md5: 0f05853a139b6cda9c73e9d2707a4976
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 590288
+  timestamp: 1690984971741
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+  sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
+  md5: 7de782e4fb34bfa95ef2fc79d27d727d
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22840
+  timestamp: 1668160634885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+  sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
+  md5: 1a7b23113372c5667dbfe45976b9cc5c
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 126357
+  timestamp: 1696515322390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+  sha256: 3cd1161558704176560843586b1b1f9b257fd68c0ca53a2fc09e61267f47514c
+  md5: dd162b2716dc9daf732240a343862d4a
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.26.0 py39ha9811e2_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10388
+  timestamp: 1695830584640
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+  sha256: 5f35d8c0e1768fa3a9d2e75659cd2096bea6b4e021afea114f573e95f4943fb2
+  md5: 958f78b1e2299537996f98da7a930198
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.26.0 py39h3b2db8e_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6313331
+  timestamp: 1695830570878
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
+  md5: 371358a54bbdd307603888348d1a2c6f
+  depends:
+  - libcxx >=12.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD 2-Clause
+  size: 412248
+  timestamp: 1628861367714
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+  sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
+  md5: fa15d3b44ae1360ac9b640bbd5b6923c
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4746123
+  timestamp: 1695322833432
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+  sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
+  md5: d73db95f07a282021efdf8bc09713261
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73620
+  timestamp: 1693575195999
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+  sha256: 247b5e4d81b6d5d013a9c27e1f30c41fff896fed98a68ebda26b19b4062a6828
+  md5: 354a1d65300b4309d53dfa648014e8fe
+  depends:
+  - bottleneck >=1.3.4
+  - libcxx >=14.0.6
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - lxml >=4.8.0
+  - matplotlib-base >=3.6.1
+  - tabulate >=0.8.10
+  - pyqt >=5.15.6,<6
+  - openpyxl >=3.0.10
+  - s3fs >=2022.05.0
+  - pymysql >=1.0.2
+  - beautifulsoup4 >=4.11.1
+  - scipy >=1.8.1
+  - xlsxwriter >=3.0.3
+  - fastparquet >=0.8.1
+  - xlrd >=2.0.1
+  - blosc >=1.21.0
+  - zstandard >=0.17.0
+  - psycopg2 >=2.9.3
+  - pyarrow >=7.0.0
+  - pandas-gbq >=0.17.5
+  - pytables >=3.7.0
+  - sqlalchemy >=1.4.36
+  - odfpy>=1.4.1
+  - numba >=0.55.2
+  - jinja2 >=3.1.2
+  - pyreadstat >=1.1.5
+  - gcsfs >=2022.05.0
+  - qtpy >=2.2.0
+  - html5lib >=1.1
+  - xarray >=2022.03.0
+  - fsspec >=2022.05.0
+  - dataframe-api-compat >=0.1.7
+  - pyxlsb >=1.0.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13257999
+  timestamp: 1697478739906
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
+  sha256: 90a1889cd0004bfc5e12ac94b4ea92718a473373033bb0ba5259804ed67bf2bc
+  md5: e89f615737385fee88150ab4adf037e6
+  depends:
+  - bleach
+  - bokeh >=3.2.0,<3.4
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.0.0,<3
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.17.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17147015
+  timestamp: 1698866800249
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
+  sha256: 0ae09c974297767a707642344c40f484281f0a3000251a6234e46ef19f00c10e
+  md5: 64a0eaf3381e9f6aa971229501710798
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189313
+  timestamp: 1698263486159
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+  sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
+  md5: 6e01c592ae3b8ff2d12cae76f2f4276b
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 715239
+  timestamp: 1696580071596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+  sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
+  md5: 9fb8f460c130d56caf33c6bbe46fbe8a
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2678841
+  timestamp: 1697548790931
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+  sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
+  md5: 390b8c3cd74281abecdbfd51476922f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33033
+  timestamp: 1692205747301
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+  sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
+  md5: 7896828fb3565fefad43f980d50c8723
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91190
+  timestamp: 1659455206354
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+  sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
+  md5: d934c74eb66d01af0f45f0881f4bab77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580588
+  timestamp: 1672387390426
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+  sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
+  md5: 9858166e5ffb624c8b9d281f4000d725
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 367167
+  timestamp: 1656431368885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+  sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
+  md5: 4d2b45c6be8221e6a3e44c2d5838426f
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30843
+  timestamp: 1675441531640
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+  sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
+  md5: 02521df4e2e79f75faa9cbb3560ab1dd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1861763
+  timestamp: 1684280026169
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+  sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
+  md5: bdebe59bffc7adbad83fdcd9d429a5f5
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95234
+  timestamp: 1690223494699
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+  sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
+  md5: d716e5c9b5eec45ce1df8eb52cab817a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157408
+  timestamp: 1661452601692
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+  sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
+  md5: 1907629863ed8e7c35ead232dae7693f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 91636
+  timestamp: 1628941083263
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+  sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
+  md5: 847b9bddf2a86e1609c0d53bbc23ea79
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 27378
+  timestamp: 1626781391140
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+  sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
+  md5: 18aa18bd0d260605923877921d26cc74
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13194025
+  timestamp: 1694438901368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+  sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
+  md5: 45642a99c83e7aed74d1ffab1f20145b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 266647
+  timestamp: 1661368655993
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+  sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
+  md5: fec748525144049a2fc7f52f9755232c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257235
+  timestamp: 1695131702047
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+  sha256: 960192a143672e9c1d6fe4027af448512d91eee7501e5c245c21b865cf8bf429
+  md5: 76d491244218505f071ba56a308673df
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40950
+  timestamp: 1685030774581
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+  sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
+  md5: 3445d25415998c807efbe64d3a7e03c8
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 167068
+  timestamp: 1698096118071
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+  sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
+  md5: e6e92da28e9b0e428ed4b7df417bec25
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 472418
+  timestamp: 1657724315435
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+  sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
+  md5: dba22515f36d3c266de5896350813ea2
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95103
+  timestamp: 1690400315537
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+  sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
+  md5: 3cd7eb43e285faba76faf67667e26b00
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093916
+  timestamp: 1690290951258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+  sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
+  md5: c5e9aef0d6895de1c927e9d796cd7cd3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15691
+  timestamp: 1629145910454
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+  sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
+  md5: 0f7c229e774146ffc4e29dedf75372bf
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67279
+  timestamp: 1696347632563
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+  sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
+  md5: 2302a79a045f152e183a52a81adfba62
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1674163
+  timestamp: 1681394762218
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+  sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
+  md5: 4ae67163d55cf9df83d4027ebc38c501
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30894
+  timestamp: 1671751931536
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+  sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
+  md5: dbb5c0cddb6661a89afee647fd3dc01e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39875
+  timestamp: 1668168874870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+  sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
+  md5: 667e60c8b407d73cbba40f44901f4f00
+  depends:
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3412693
+  timestamp: 1654088929697
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+  sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
+  md5: 884f788a5f6a664c9b79f7a4a60362d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680561
+  timestamp: 1696937004165
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+  sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
+  md5: 639a4f489af172c866c18442948e5874
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - slack-sdk
+  - requests
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125170
+  timestamp: 1679561942932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+  sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
+  md5: e5b90eba83fddba6d7aa6072b5bf7c91
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193017
+  timestamp: 1671143921826
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
+  md5: 644ef8830437070f60efcfcd6a987198
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9670
+  timestamp: 1690297532002
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
+  md5: a902a833bb186a2f1a4b2b89b1195136
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58466
+  timestamp: 1690297524418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+  sha256: 536045a8a172c651fd306c285a6d7409775f018dac944f2124c538ccfb195e28
+  md5: d4dc6cdf0812191b9ec78b35b4fdf3e0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11593
+  timestamp: 1659769477205
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+  sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
+  md5: f3f1d2c1028dad2f11ff950a15c99dbf
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188640
+  timestamp: 1698257577209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+  sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
+  md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20091
+  timestamp: 1629144441130
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+  sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
+  md5: 3089c63bf8f4d0423e1a287da286d83e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70923
+  timestamp: 1629357115820
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+  sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
+  md5: 5886b30b312445471268444f41f39dc7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102583
+  timestamp: 1695741976083
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+  sha256: 105e39d3eb51b47c7244b3379c0133ab7051966664f52835453b14509215b159
+  md5: ed20012c2cd99ffd04cca9929e0bc061
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49775
+  timestamp: 1675159079039
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+  sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
+  md5: 2e75ad6a09c308268192efe03cc9ebf4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 411778
+  timestamp: 1683113019715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+  sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
+  md5: 30f666bf97c26587c5d2f68cc5f330ab
+  depends:
+  - libcxx >=12.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 316901
+  timestamp: 1629287855861
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+  sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
+  md5: 584e591d36dcd5ba5c45404f0f7ebb2d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19076
+  timestamp: 1672387153578
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+  sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
+  md5: 467ae28215d1aa1c5688bc0c8a184269
+  license: Zlib
+  license_family: Other
+  size: 103525
+  timestamp: 1666595022664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+  sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
+  md5: 7cfbed15f1feee1422810f7830075f53
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 779464
+  timestamp: 1681304594848
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+  sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
+  md5: ed14f9bc6e55220483f1a5a388625a08
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162772
+  timestamp: 1644481986085
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+  sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
+  md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 39253
+  timestamp: 1644551767970
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+  sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
+  md5: b24d13c443a26f65a0778b475a5726bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132830
+  timestamp: 1695717959996
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+  sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
+  md5: 302c3c0696e17eaa62e140e3892644ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 199723
+  timestamp: 1681493196911
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
+  sha256: 812f268862208c2518b5187809a8571adb488de3604d512721035e65458dde76
+  md5: 97ce620b7dd3ee743d0ca28ed66ace74
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5721832
+  timestamp: 1697491241383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+  sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
+  md5: bf930260f679bc74227bbb18bc36ae82
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 119700
+  timestamp: 1657176150595
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
+  md5: 507dfe693ef429f466d964b599f4af21
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_7
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 18650
+  timestamp: 1659616328001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
+  md5: d0bf43e8df60baae3b3105aa5c42a791
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 21153
+  timestamp: 1659616312367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+  sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
+  md5: 7bd24bf94c24e810aecaaf84a0978e6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 343204
+  timestamp: 1659616543542
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+  sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
+  md5: 092b417c11edcbe6bb9b765ab4a55d23
+  license: MPL-2.0
+  license_family: Other
+  size: 164999
+  timestamp: 1694009822357
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+  sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
+  md5: 708a750d370b9d6875651021e21c4446
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159322
+  timestamp: 1690232335307
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+  sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
+  md5: c35736da3ea26782425e78061268cf5e
+  depends:
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 228713
+  timestamp: 1670423312743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+  sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
+  md5: 457a4339a53c033d48ce0c72e5038d2e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30330
+  timestamp: 1672387265402
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+  sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
+  md5: 59ec65fd9e06b81a65cc12986c67d5da
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1939614
+  timestamp: 1668084794027
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+  sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
+  md5: 3489c1a2b73fc957b5a62cc59349e25b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13438
+  timestamp: 1671231196438
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+  sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
+  md5: 3492b96083c1e904cc32d26ea7f1e1d8
+  depends:
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184280
+  timestamp: 1663827558327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+  sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
+  md5: f46d904bc6f220327e70474971341f52
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1220835
+  timestamp: 1694445639066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+  sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
+  md5: 2ff4fb509788b0e47ac684ba151394d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3289966
+  timestamp: 1690907040646
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+  sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
+  md5: 0f166c3e70541d8bee6e9d0cb60fb66e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16979
+  timestamp: 1649926678161
+- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+  sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
+  md5: ea93d413944ca6a8677eb1b284b136ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27388
+  timestamp: 1668714577678
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+  sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
+  md5: 9f167d3e45441bc3633c1974b1b0ce8c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 88421
+  timestamp: 1676983264486
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+  sha256: fa8f868e49721ca19912f816a6da221172758f9e3d28d8b31d53249fb14dc25f
+  md5: 09f9a2cea9425d76dccf9b026afe5bb2
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4576915
+  timestamp: 1698866895838
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+  sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
+  md5: 30fdefd1541c789c163751291a8faa88
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111448
+  timestamp: 1666125667599
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+  sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
+  md5: a10f07c7a3510272a296f9fed458a4ed
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38098
+  timestamp: 1678997241511
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+  sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
+  md5: fad9cf2023d807da8d44996e9d4399a0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51490
+  timestamp: 1698254721864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+  sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
+  md5: 9834848bd7c7759acf12e78d09388563
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3891030
+  timestamp: 1681801474383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+  sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
+  md5: 1285c8c628bc912c54d0968574c9f4c9
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217232
+  timestamp: 1691122695748
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+  sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
+  md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
+  depends:
+  - backcall
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1279433
+  timestamp: 1694181820978
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+  sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
+  md5: f5fcce35d3f21cdfc5893c5a7a86c651
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1035394
+  timestamp: 1644315567034
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+  sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
+  md5: f67fe3337528e2886f1ac3ab8ac37985
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213110
+  timestamp: 1666908350218
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
+  md5: 81f2c343dc4c65eea39c45383272068f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 407861
+  timestamp: 1677849239400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+  sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
+  md5: bd9526d38a145fe311a8aa36bc11e071
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 152006
+  timestamp: 1676558783570
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+  sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
+  md5: a00e6a62956fde3c4135464353ee8a53
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229158
+  timestamp: 1676330909084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+  sha256: db8335d6531b03c7bdfe789ebacc52631ac6ea4a37700bb3da1f6a53a1acd724
+  md5: ebeba61994cc225ea5f4f42caa511019
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116681
+  timestamp: 1679906658986
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+  sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
+  md5: 5efa1332f7c0a8d9638eda02170c4ce5
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pywinpty
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 413653
+  timestamp: 1671707957673
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+  sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
+  md5: 891fe66a24d8714737b2874985ee1303
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62298
+  timestamp: 1672388166096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
+  md5: c345f51706eef530454f66b794e5e574
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 68189
+  timestamp: 1659616216976
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
+  md5: a7400cfb72042977bc047909ed504ce8
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 33743
+  timestamp: 1659616248209
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
+  md5: 6307f6854754ab5bd7c84e6998385bb1
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 733177
+  timestamp: 1659616279453
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+  sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
+  md5: b812bc5d9c76242e2bb2ac87afe7d39b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 730280
+  timestamp: 1650983734373
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+  sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
+  md5: ba9418df9288a2f031a02fa35b774ce0
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78524
+  timestamp: 1694778314659
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+  sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
+  md5: 6ece7f1a3248169837714d05d7f6ef0a
+  depends:
+  - libiconv >=1.16,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 3513910
+  timestamp: 1692971505729
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+  sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
+  md5: bd7ec244935e83e850a4ff34e8e2e64f
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 513971
+  timestamp: 1692973657152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+  sha256: e1c0e745d9ba36a80773e841d96bf514ad1ceda419e4188aad3c22782af00234
+  md5: f226532e9bb308f20e874c56be6ceefb
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 35788
+  timestamp: 1659783414586
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+  sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
+  md5: fb7881e74b59262df0fa4ec981964efc
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1244887
+  timestamp: 1695058550693
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+  sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
+  md5: 6970c7f46b0164cad1d210e7a1419959
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143434
+  timestamp: 1670944902624
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+  sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
+  md5: 1015298551c040c6d5e26eebbae12ef5
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142316
+  timestamp: 1671542240512
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+  sha256: ab5c246c2b271acc1cdd0b9343989c0166681536e569cdbe71618f55d34c7292
+  md5: 7ce68d771cd94c9ff5efefe69d327c9a
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 125122
+  timestamp: 1684280210213
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+  sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
+  md5: 466da740fafef3d6bce114220f0be306
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28510
+  timestamp: 1654508162239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+  sha256: 1687ae122ee7d8b583141fc5014b76d494841dc8083b854449e3d6e0f6bb7019
+  md5: 3697ac26ee3c2d49338dd5b9c6551152
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8080067
+  timestamp: 1698692812610
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+  sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
+  md5: a9fa43e694b25cd49b8b08a9eefd696e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18054
+  timestamp: 1661915903969
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+  sha256: 8aa14047fac6ef8b326900c4bf1a960eaa7a1699c18fdf1e75a59101b610b6df
+  md5: 7e1d4d4700fbea6171d30f1d5ad24226
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53362
+  timestamp: 1659721308586
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+  sha256: 2017814a7cc93dd51c6b7c016e3cdf8fbc32fa20f985638aaff6a6377e9ee086
+  md5: a1a285c56b001c3b5c591bf21eec3149
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19326
+  timestamp: 1659716205153
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+  sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
+  md5: 248c468abced874f0231d3cc23177c77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58488
+  timestamp: 1607359497934
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+  sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
+  md5: 5e763c995ff0c549f68a10bce70fede4
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187489950
+  timestamp: 1691503804820
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+  sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
+  md5: dd0c2ece6a743c373c9b5a5919b4818f
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49744
+  timestamp: 1682975040154
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+  sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
+  md5: 57cea8df7ab85f2a98f64d23afcb1f90
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184956
+  timestamp: 1695058491736
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+  sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
+  md5: 8769cdd201d905069800488fe31574e5
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 256221
+  timestamp: 1695060152521
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+  sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
+  md5: d9781492332e6326f9fca87f3a8efacd
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8135792
+  timestamp: 1681756491399
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+  sha256: 2dd3178d3c570e30b9490ebabfd7bfac806afad8302d3dee0edc619805034397
+  md5: bef9da0f0694c45b6aaa4e6447479eaf
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 118324
+  timestamp: 1650290466135
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+  sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
+  md5: f1d8ce412e115986c403f223b3b47d0f
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 596314
+  timestamp: 1668451106600
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+  sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
+  md5: f96bbef0985d7e66ebf00c0d55e30e23
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 167045
+  timestamp: 1694617078743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+  sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
+  md5: 6e6ba64c8dc5025aeac606404a8df36a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13786
+  timestamp: 1672387480065
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+  sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
+  md5: 4a7a3286484766741f627696697c362c
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 609425
+  timestamp: 1690985686105
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+  sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
+  md5: 4269a1f93882205b90d4b2ae78fc82d5
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22417
+  timestamp: 1668160717305
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+  sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
+  md5: a18a576b7024cfd6f905c526a786a916
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 135285
+  timestamp: 1696515698492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+  sha256: e5e11f9b42d770ee46ac24d1cdf7aa4e9c49a60a607c8c28e7729131a99eadd5
+  md5: 4274d06db8a9a381c072d226d0322dc0
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.0 py39h65a83cf_0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9835
+  timestamp: 1695830845329
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+  sha256: dcaa1607ce40a0ed610dd5398e125c8e5b08e738e50b6037a8c72b49ca561ff2
+  md5: d99d990a60644b97ba1ff9bb8da0e66f
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.26.0 py39h055cbcc_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6778113
+  timestamp: 1695830816710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
+  md5: ab07e2a27ac08afe3d0b4c0890b8486a
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 2-Clause
+  size: 249316
+  timestamp: 1630094024143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+  sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
+  md5: 73b17037d87b5a58feb34dafc0538f7f
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8058396
+  timestamp: 1695324589828
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+  sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
+  md5: df1d746ba8d5d6ba01ac1373b9b71e1a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73016
+  timestamp: 1693575484990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+  sha256: 1994e5831fd421bd6cf85916073d4012dec53e673b672b3985efaf771f0a7bf8
+  md5: c486a5b51e3227f6ea564a9dd3125e45
+  depends:
+  - bottleneck >=1.3.4
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - openpyxl >=3.0.10
+  - jinja2 >=3.1.2
+  - qtpy >=2.2.0
+  - numba >=0.55.2
+  - pyreadstat >=1.1.5
+  - zstandard >=0.17.0
+  - xlrd >=2.0.1
+  - tabulate >=0.8.10
+  - fsspec >=2022.05.0
+  - pyqt >=5.15.6,<6
+  - xarray >=2022.03.0
+  - xlsxwriter >=3.0.3
+  - beautifulsoup4 >=4.11.1
+  - html5lib >=1.1
+  - fastparquet >=0.8.1
+  - pyarrow >=7.0.0
+  - pyxlsb >=1.0.9
+  - matplotlib-base >=3.6.1
+  - odfpy>=1.4.1
+  - pytables >=3.7.0
+  - sqlalchemy >=1.4.36
+  - psycopg2 >=2.9.3
+  - blosc >=1.21.0
+  - lxml >=4.8.0
+  - pymysql >=1.0.2
+  - gcsfs >=2022.05.0
+  - pandas-gbq >=0.17.5
+  - dataframe-api-compat >=0.1.7
+  - s3fs >=2022.05.0
+  - scipy >=1.8.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12629931
+  timestamp: 1697479885371
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
+  sha256: 270e4c3ab0f0c8d8f31fa0e45bc516c1e41be618a5c66e1c86dc39ce76cb2372
+  md5: cad52ba9eb391416112f0994b6c35249
+  depends:
+  - bleach
+  - bokeh >=3.2.0,<3.4
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.0.0,<3
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.17.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17162886
+  timestamp: 1698867967809
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
+  sha256: 56eaf7f4b1bb81e3deed55711dd2ee78f244a3cc0ad4bb7a1f09d97e46f9793f
+  md5: c24a3daed1e85ba7a100fa6966c5bb48
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189021
+  timestamp: 1698263520538
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+  sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
+  md5: 427c1450bebb632f43bbc8c83006e4cd
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 806931
+  timestamp: 1696580240310
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+  sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
+  md5: 21790cd3e2b8a45c4104aff0a68330d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3001751
+  timestamp: 1697549357662
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+  sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
+  md5: 56f44a1054da2d10777e375838191070
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 32355
+  timestamp: 1692205784293
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+  sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
+  md5: 8a35ad65651086575ce55371f22feda8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91045
+  timestamp: 1659455316472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+  sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
+  md5: 186eb95f816a2eff80c3c7f7d964c7b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 578514
+  timestamp: 1672388155359
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+  sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
+  md5: 47b6cbe6ce9289e47d16900b03596a91
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372807
+  timestamp: 1656431445633
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+  sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
+  md5: 07165c444adc7c7ccc8a345875adc5ef
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48408
+  timestamp: 1675450623287
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+  sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
+  md5: d58e76a31e2f6e7410ba4afd7f385b0d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1877445
+  timestamp: 1684280183367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+  sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
+  md5: 0e5b0fe7debbf558ce97090f6b67cdae
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94633
+  timestamp: 1690225630423
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+  sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
+  md5: 0fde797653e4ab589506121fb1e37555
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157119
+  timestamp: 1661452591647
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+  sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
+  md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 92679
+  timestamp: 1636093365041
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+  sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
+  md5: f870859d4dc7a8d82cf3546bd9035f33
+  depends:
+  - python >=3.9,<3.10.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 54520
+  timestamp: 1605307564142
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+  sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
+  md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
+  depends:
+  - openssl >=3.0.10,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 21172845
+  timestamp: 1694442462066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+  sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
+  md5: 9d99075052265ae3d718582d3b875038
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269964
+  timestamp: 1661376543480
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+  sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
+  md5: fa9074d94236c9b768bfd2c858875b27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 264836
+  timestamp: 1695131770282
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+  sha256: 97243a31c39f4990c0e9d4f2307f2f7fb9421553303923bc105067ec4340bdff
+  md5: 8078c5760f27398eaf1082226647d137
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40145
+  timestamp: 1685031143383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+  sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
+  md5: 3d2841085778006c2e79f9c7300f8b9d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13565975
+  timestamp: 1669937633869
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+  sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
+  md5: 54a4bc0724041dd173088419d6ede2af
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 239062
+  timestamp: 1677611495106
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+  sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
+  md5: f39f84115e228bad4bceaefdd637f022
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 158558
+  timestamp: 1698096358091
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+  sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
+  md5: df398a3a1668fd2a22061764e20ea91d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.4,<4.3.5.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 460913
+  timestamp: 1657616061604
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+  sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
+  md5: 38db77ece9dc76feffb9ef7638e38258
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94397
+  timestamp: 1690400496655
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+  sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
+  md5: 3e284ae6b48ee30c364ffdc5601610b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1099842
+  timestamp: 1690291374842
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+  sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
+  md5: 993b3886b334bd1f49d34206f21997b4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15998
+  timestamp: 1614030572433
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+  sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
+  md5: 7ac9604ad7564ac0c71bff5db198656f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67012
+  timestamp: 1696347795139
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+  sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
+  md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1311308
+  timestamp: 1681402905668
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+  sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
+  md5: 28b9869d8d3a839918fac4a08f38cbc2
+  depends:
+  - python >=3.9,<3.10.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30546
+  timestamp: 1671752127904
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+  sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
+  md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39590
+  timestamp: 1668168880994
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+  sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
+  md5: 52cdcdb96383c010ca833a7c24b3935b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Tcl/Tk
+  license_family: BSD
+  size: 3690152
+  timestamp: 1654036853710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+  sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
+  md5: 0e054ab29119cf4c1f778613acf972f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 681780
+  timestamp: 1696937326924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+  sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
+  md5: b6ad839ebba536ad1c3cc58d0e2123f0
+  depends:
+  - colorama
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 143681
+  timestamp: 1679562248929
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+  sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
+  md5: fe78de10019085146f1cc6c94fdc2620
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192822
+  timestamp: 1671143999327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
+  md5: ca5fc3fbdb09b6de068a8b7a8869369f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9208
+  timestamp: 1690298120549
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
+  md5: a86e87a10e5fdff486265e0c675fb99f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57922
+  timestamp: 1690298106990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+  sha256: 8057d3d2a0acd44496de33c5b222063c3f7d06b90c74fbbda45bd18b0b324219
+  md5: 398f8db5bd8cab84b3d85a9d85fa4889
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11362
+  timestamp: 1659769459206
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+  sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
+  md5: 0d31859e0a097aedbcc1627db33b3d92
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188367
+  timestamp: 1698257883295
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+  sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
+  md5: 45ef24c486a484f079faf1dc90e4c7e9
+  depends:
+  - vs2015_runtime >=14.27.29016
+  license: Modified BSD License (3-clause)
+  license_family: BSD
+  size: 8277
+  timestamp: 1605602889180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+  sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
+  md5: 4daaceb6cfc1af6274509081d8018ef1
+  size: 2316783
+  timestamp: 1605602872095
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+  sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
+  md5: 916c16904615c7af3b5d37cb6694f45e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21084
+  timestamp: 1607347371925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+  sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
+  md5: da69e6987fcc757e83a358ceaa13f62b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73391
+  timestamp: 1614804425587
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+  sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
+  md5: 23b9f4634b2e5450be617114f62c74f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 120873
+  timestamp: 1695742300539
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+  sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
+  md5: 120f0b088290fc17bd6618fc10a2f0c4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PUBLIC-DOMAIN
+  size: 34293
+  timestamp: 1605306211299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+  sha256: a5d2a216d052105fdaad7256f23da3b29f95100d1dc0f29b6ab1f3bbc75e17a9
+  md5: a558f681ebc243f86cde2515c065b62e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48805
+  timestamp: 1675159123654
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+  sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
+  md5: c3f7871e9a33adeccee1b1e8e216918e
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 1332571
+  timestamp: 1683113347814
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+  sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
+  md5: 1ab55f8c4b5292ec360c572120bf823e
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-3.0-or-later
+  size: 9430705
+  timestamp: 1616055773485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+  sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
+  md5: 6875e0bf3828707dc9165d694c0d0a7d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18725
+  timestamp: 1672387612937
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+  sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
+  md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 148931
+  timestamp: 1666595229032
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+  sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
+  md5: 8d6a1e767775fe0eb617cd6e22edc2ff
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1871867
+  timestamp: 1681304638261

--- a/lsystems/pixi.lock
+++ b/lsystems/pixi.lock
@@ -7,636 +7,636 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
   sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
   md5: 2cf39d906cc321896ffe3e5d33d80c5c
   depends:
@@ -649,7 +649,7 @@ packages:
   license_family: MIT
   size: 162166
   timestamp: 1644463608931
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
   sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
   md5: 2972a84e0e22ae3244bbd2f1eebcf536
   depends:
@@ -660,7 +660,7 @@ packages:
   license_family: MIT
   size: 35352
   timestamp: 1644569715988
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
   sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
   md5: a68016b4b06460def24cb69d932986f3
   depends:
@@ -669,7 +669,7 @@ packages:
   license_family: MIT
   size: 132486
   timestamp: 1695717963702
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
   sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
   md5: 2f6356a2f530314b4059c08c79a3d8bc
   depends:
@@ -679,12 +679,12 @@ packages:
   license_family: MIT
   size: 205868
   timestamp: 1681493113570
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
   sha256: 2d8e75f31f75ea5eb8b9021b4c21eb2846a254a097e06eb68e66fc36a82e1bed
   md5: ae374a11c789a55555f70b29b9eff1f9
   depends:
@@ -700,7 +700,7 @@ packages:
   license_family: BSD
   size: 14430294
   timestamp: 1658136783940
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
   sha256: f84f9caa7eb9d489fd9634419fdf766d39293a5df1104b840fa0cdc5823a5c60
   md5: 922555c0435d6b2537cf8ced534b048c
   depends:
@@ -711,7 +711,7 @@ packages:
   license_family: BSD
   size: 141903
   timestamp: 1648028958291
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
   sha256: 0bbcb6f78eac530c6a084459ffab3238647b266d0c74d695e6e6387dd119cc67
   md5: bdc971e2a9affb5125b68ad708172dab
   depends:
@@ -720,7 +720,7 @@ packages:
   license: MIT
   size: 411301
   timestamp: 1602517685375
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
   sha256: 8c2071f706c2b445dabb781f7f8f008b23a29957468ec6894f050bfb3a2d5bf4
   md5: c203ffc7bbba991c7089d4b383cfd92c
   depends:
@@ -731,14 +731,14 @@ packages:
   license_family: MIT
   size: 357797
   timestamp: 1605539534667
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
   sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
   md5: 3ef00f4c5278b688552efc259c463dc8
   license: MPL-2.0
   license_family: Other
   size: 132731
   timestamp: 1694009767372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
   sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
   md5: d5cb3d97cf5e85ffe5e94037ed8a1169
   depends:
@@ -747,7 +747,7 @@ packages:
   license_family: Other
   size: 159077
   timestamp: 1690232254640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
   sha256: 674707b9c42e65c903c9786ee5a56b4d42aa054f1e75b328db8a2c1bfa368739
   md5: 76ae217198b014b89b267cf41b8251dd
   depends:
@@ -759,7 +759,7 @@ packages:
   license_family: MIT
   size: 231920
   timestamp: 1642701209740
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
   sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
   md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
   depends:
@@ -769,7 +769,7 @@ packages:
   license_family: CC
   size: 1917831
   timestamp: 1668084545510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
   sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
   md5: 13702d3b4b744784e5bd559c7050dd6f
   depends:
@@ -779,7 +779,7 @@ packages:
   license_family: BSD
   size: 12719
   timestamp: 1671231205875
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
   sha256: 821af57c20a85b4e92268fbf65fbaec2f273da5bb21889d9643756ef6e473237
   md5: f57e0f502500ffebdbec081ef61ad1d4
   depends:
@@ -793,7 +793,7 @@ packages:
   license_family: BSD
   size: 2179774
   timestamp: 1694445209134
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
   sha256: 3a39a2d6f161080c706292e3bf480f62d2444b1d6d67b3d7db50458202ee31f1
   md5: 0524ffca60f845eb392bbb56d56f0ce5
   depends:
@@ -804,7 +804,7 @@ packages:
   license_family: MIT
   size: 2094615
   timestamp: 1637091869922
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
   sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
   md5: 2e6ec51066d825ef3c317abe78d6049e
   depends:
@@ -813,7 +813,7 @@ packages:
   license_family: MIT
   size: 16413
   timestamp: 1649926472708
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
   sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
   md5: b4d923222d45314856b5378cb115214d
   depends:
@@ -822,7 +822,7 @@ packages:
   license_family: BSD
   size: 26728
   timestamp: 1668714462023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
   sha256: 8a121233d0b2cbb2463b67e798739ad2946f38933430a6a7fd1197cc6eab1c99
   md5: d2b24736491290a6c6d0138932111150
   depends:
@@ -832,7 +832,7 @@ packages:
   license: GPL-2.0-only and LicenseRef-FreeType
   size: 965280
   timestamp: 1635422707211
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
   sha256: 3c8ece1a7257b1d45f8fa25f46504bb709a1923d7175f2996e891366ec434b9d
   md5: 299bf4271d710651a1d71d3795580c2d
   depends:
@@ -840,7 +840,7 @@ packages:
   license: MIT
   size: 83592
   timestamp: 1603192039050
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
   sha256: 2d727f8335c59314b521b66d437ca4d51904134473ae503b7b097e239635f209
   md5: 6991e520f353d995023404f6f524d192
   depends:
@@ -857,7 +857,7 @@ packages:
   license_family: BSD
   size: 4507274
   timestamp: 1693378095165
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
   sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
   md5: 9213e0336e3a5216c989cfe52648412e
   depends:
@@ -866,7 +866,7 @@ packages:
   license: MIT
   size: 23805906
   timestamp: 1588026213084
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
   sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
   md5: 1eb52f9f45cea2fb9ce27b19f990160e
   depends:
@@ -875,7 +875,7 @@ packages:
   license_family: BSD
   size: 110793
   timestamp: 1666125606878
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
   sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
   md5: 126b3c1933b7364ff03f67455b687e99
   depends:
@@ -885,7 +885,7 @@ packages:
   license_family: APACHE
   size: 37588
   timestamp: 1678997134023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
   sha256: 1b424413f28b840fc6d4bf467f37e9e405823b1e3b899005df80152d48936d64
   md5: 4aa8bcf74c81cd3600978f791191692a
   constrains:
@@ -894,7 +894,7 @@ packages:
   license_family: Proprietary
   size: 9246735
   timestamp: 1634546760713
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
   sha256: b51b2e0dd37a74784ba19db22aded3f4c843b6fddb4a74399f65f36fc018aaa2
   md5: 0d56ab1950f952284b895ac0f78284a7
   depends:
@@ -914,7 +914,7 @@ packages:
   license_family: BSD
   size: 203541
   timestamp: 1671488675347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
   sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
   md5: ff47e0be879e817713ce2a9daa76e2b0
   depends:
@@ -935,7 +935,7 @@ packages:
   license_family: BSD
   size: 1261116
   timestamp: 1694181530670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
   sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
   md5: 5ef6c6a0d1ac79143c7359d305155167
   depends:
@@ -945,7 +945,7 @@ packages:
   license_family: MIT
   size: 1021637
   timestamp: 1644297140650
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
   sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
   md5: eaeb023688f781e7dd89e74310c38195
   depends:
@@ -955,7 +955,7 @@ packages:
   license_family: BSD
   size: 211775
   timestamp: 1666908212136
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
   sha256: 85348bfb14db4fea84078d703e766a3c978c5a592a06e41266748826dd59d8ae
   md5: 6e1c0fb5260c590f7ef5235cb3d05863
   depends:
@@ -964,7 +964,7 @@ packages:
   license_family: Other
   size: 279884
   timestamp: 1651065953960
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
   sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
   md5: 0d2c3c5edf671b575532d5a3e8bf15fc
   depends:
@@ -975,7 +975,7 @@ packages:
   license_family: MIT
   size: 131510
   timestamp: 1676558716852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
   sha256: 92bc012f9eb4ad71158cf4826fd3e125fcebff53b529276a81224acda48be547
   md5: c5fd100e3062e831cbdf33331042f627
   depends:
@@ -991,7 +991,7 @@ packages:
   license_family: BSD
   size: 190884
   timestamp: 1650622553813
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
   sha256: 0192bd48cd96c60dc3054d5addd8cdb4a29a218843181318371f79daec8242f8
   md5: d851b401dc13d04e6848bb36e12efc1c
   depends:
@@ -1002,7 +1002,7 @@ packages:
   license_family: BSD
   size: 91534
   timestamp: 1679906652183
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
   sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
   md5: a4beb461f0a60998a090d760b5c6c907
   depends:
@@ -1026,7 +1026,7 @@ packages:
   license_family: BSD
   size: 411564
   timestamp: 1671707702849
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
   sha256: 974df3dc76089be57b327acd6634384def84249003f58678ca1142bb274a75d9
   md5: 81b969d1a00153759b30554a1f11ddfd
   depends:
@@ -1037,7 +1037,7 @@ packages:
   license_family: BSD
   size: 92144
   timestamp: 1653292217019
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -1048,7 +1048,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
   sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
   md5: 9508af80612e4fa1b5d1abb43ca7e63c
   constrains:
@@ -1056,7 +1056,7 @@ packages:
   license: GPL-3.0-only
   size: 749072
   timestamp: 1652971360657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
   sha256: 3b4afe7665dcdb99bd4586a888b85b2e0325f8faecdd31c7780792080ee97872
   md5: 822b5201dde61bc838072dc5b670c88c
   depends:
@@ -1065,7 +1065,7 @@ packages:
   license: Custom
   size: 55183
   timestamp: 1594054267890
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
   sha256: c6fafbe73d2f93b91b6f4b65829f925f52a8f84746a57abd216b39da9ce8c494
   md5: 238f19c803a6ba7bd6dbd6989e03cbf1
   depends:
@@ -1073,7 +1073,7 @@ packages:
   license: GPL
   size: 8496776
   timestamp: 1560112207081
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
   sha256: bc3e6e79c32ff0ecea601aa108ae9cf4068f69703580e40e266ad4bcc52cff54
   md5: 9cb85601944ca7383b1769bff74b94e8
   depends:
@@ -1082,7 +1082,7 @@ packages:
   license: zlib/libpng
   size: 372914
   timestamp: 1556041895170
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -1090,13 +1090,13 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
   sha256: 43b0bd205f539583c088feb5b8d77b60c83d1df80c2a93dac9f2a1127001b2cf
   md5: 53fa39fdae936e9d07c4b2f5ef361993
   license: GPL3 with runtime exception
   size: 4246257
   timestamp: 1560112223556
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
   sha256: 711ea05b4c35bdafc762a172b01db896b17942f474c2b1a519f91370964bf9bc
   md5: b25d56d33596623a6a4a9d9baaa4f602
   depends:
@@ -1110,7 +1110,7 @@ packages:
   license: HPND
   size: 592974
   timestamp: 1653047881023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
   sha256: 146dbb1e4dbccdd57819e5102a8ca00970b8e33d6c6180e8007db89b184da569
   md5: c566a384259c1d2769852c3bddd81a67
   depends:
@@ -1124,7 +1124,7 @@ packages:
   license_family: BSD
   size: 90150
   timestamp: 1645441199289
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
   sha256: cffb5a063111f7a99a99c74770b23db5dde52325e25a7a46d1903d5ff4a82c88
   md5: eeb1bd66f28bed1956ab989d6eff7ae5
   depends:
@@ -1135,7 +1135,7 @@ packages:
   license_family: BSD
   size: 889956
   timestamp: 1645089138421
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
   sha256: 71f6c4a97014d745c58df52b4dd60ddd75a8508d54fe5b97f42bd1f31cb1c067
   md5: 686e77514ec9f1ef0a6feed374f14d37
   depends:
@@ -1147,7 +1147,7 @@ packages:
   license_family: MIT
   size: 789469
   timestamp: 1653546418059
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
   sha256: ea3355a67c5173f3944f09861043ca66eb7dbeff8f385d13528b3aabc0801d0c
   md5: 66e2aa12181bb2911485bdbe125d24c5
   depends:
@@ -1157,7 +1157,7 @@ packages:
   license: MIT
   size: 584199
   timestamp: 1654075843119
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
   sha256: 64b022d706b76c33965a250fdc8c6008443c41bff8ab27bb1df3cb70419576fd
   md5: ec4f05846aacf634df15c389235725cc
   depends:
@@ -1169,7 +1169,7 @@ packages:
   license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
   size: 1538261
   timestamp: 1646624639995
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
   sha256: 2c6a5dda7c510a961bc78e31d4232be5e8e0760c93454f5fd200c379355e0f5e
   md5: f35d4bf2fbb39e334992f6dd39f8721e
   depends:
@@ -1179,7 +1179,7 @@ packages:
   license_family: BSD
   size: 220865
   timestamp: 1627657046002
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
   sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
   md5: 421f82c8274b44660dba629134faa6af
   depends:
@@ -1189,7 +1189,7 @@ packages:
   license_family: BSD
   size: 122221
   timestamp: 1671541990505
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
   sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
   md5: feb0e452205b44ac45d9b5e55c21a3b1
   depends:
@@ -1201,7 +1201,7 @@ packages:
   license_family: BSD
   size: 22819
   timestamp: 1654597913064
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
   sha256: dc51b316ef5dcfb82a9c0afdc40879146ae59516f6cea7db776077783dfd2d76
   md5: b0b6b57c140f026b8806051107336576
   depends:
@@ -1223,7 +1223,7 @@ packages:
   license_family: PSF
   size: 7729454
   timestamp: 1647442028622
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
   sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
   md5: c04ef34af33da4c71bcc99b7ec24d210
   depends:
@@ -1233,7 +1233,7 @@ packages:
   license_family: BSD
   size: 16391
   timestamp: 1662014553452
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
   sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
   md5: f6c734d73e6e3dbc1b62766cf18ff3e4
   depends:
@@ -1243,7 +1243,7 @@ packages:
   license_family: BSD
   size: 58153
   timestamp: 1607364912263
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
   sha256: 7c4ded8b2ef036839f988560848d2c32e1aa4627fd37a32710e42c39f5c61ac2
   md5: bd20f4410b81f327e35ffa0657961146
   depends:
@@ -1254,7 +1254,7 @@ packages:
   license_family: Proprietary
   size: 229783051
   timestamp: 1634547157986
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
   sha256: 5394f5efd53afb2c1b0abf571ce3d9cb684b6c7e255f140ba2acaa703d6113be
   md5: d3cb2bfa63e30153f5527797dcc87280
   depends:
@@ -1266,7 +1266,7 @@ packages:
   license_family: BSD
   size: 63551
   timestamp: 1626176932911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
   sha256: c244d23da2749857a993f84969fd35ffd183ab8f462986df6d33ae0f705fe034
   md5: 9b1f8ccc2488d0e04eb73211e2987483
   depends:
@@ -1280,7 +1280,7 @@ packages:
   license: BSD 3-Clause
   size: 204136
   timestamp: 1634566416657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
   sha256: f81f426f8ef306d636664bc49e7cdd70e2b4306d7c6bcb9c75fe35a45ab2087a
   md5: 77aa1d7f958d36bf227e6ff4a34d2e3d
   depends:
@@ -1294,7 +1294,7 @@ packages:
   license: BSD-3-Clause
   size: 365386
   timestamp: 1626186165897
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
   sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
   md5: 95c83d71814c504b5504df4f14548f1a
   depends:
@@ -1320,7 +1320,7 @@ packages:
   license_family: BSD
   size: 8257558
   timestamp: 1681756322140
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
   sha256: 1b92d72b083f3350359b8fb2e3b5dc846f49650c9e46a6a74354b1b7f0d42730
   md5: 996babe4314515ddd41008a53cb5d47f
   depends:
@@ -1333,7 +1333,7 @@ packages:
   license_family: BSD
   size: 98791
   timestamp: 1650290544347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
   sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
   md5: 1710a25086c8098367eb36b9d441448b
   depends:
@@ -1361,7 +1361,7 @@ packages:
   license_family: BSD
   size: 569683
   timestamp: 1668450704669
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
   sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
   md5: 385cc9e53404776782502c0fdb08820f
   depends:
@@ -1374,7 +1374,7 @@ packages:
   license_family: BSD
   size: 147046
   timestamp: 1694616899309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
   sha256: 0807371380965e421cb5f3f2a30d790fd5c41db11dbb6d318e14294c3b1741ed
   md5: fca4bd4e3891aebf4fd7daf9b6d0ccfa
   depends:
@@ -1382,7 +1382,7 @@ packages:
   license: Free software (MIT-like)
   size: 1083412
   timestamp: 1636570020698
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
   sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
   md5: bbbcbebc20a4fdcadce398d0ca04f95e
   depends:
@@ -1391,7 +1391,7 @@ packages:
   license_family: BSD
   size: 13109
   timestamp: 1672387143252
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
   sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
   md5: 248ce515640465371927d46f389ed555
   depends:
@@ -1416,7 +1416,7 @@ packages:
   license_family: BSD
   size: 594054
   timestamp: 1690985006481
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
   sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
   md5: 70db71df4ee1cdd38090c0f7b80ba61f
   depends:
@@ -1426,7 +1426,7 @@ packages:
   license_family: BSD
   size: 21944
   timestamp: 1668160644514
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
   sha256: 15a12c8bebcda45c577e61cea412d9aafaa433e39f9e91fd61bbfab66fcee3ab
   md5: 5239d8330e8bd34972fb80918dce79e7
   depends:
@@ -1442,7 +1442,7 @@ packages:
   license_family: MIT
   size: 136437
   timestamp: 1640689905588
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
   sha256: ff8d0426c7096e086db818265c3edf4a820accbfb15afae0407ca578de151fa9
   md5: d7bcf0b9ba2d85cf532059ec119d2750
   depends:
@@ -1458,7 +1458,7 @@ packages:
   license: BSD-3-Clause
   size: 9965
   timestamp: 1652801901707
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
   sha256: abfdeda143b6b667d50a82ea119043fc1469ee02f094a41a2402433ff408099e
   md5: e8dc29adc0282f4658e0e2f25ff207a2
   depends:
@@ -1473,7 +1473,7 @@ packages:
   license: BSD-3-Clause
   size: 7095882
   timestamp: 1652801886819
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
   sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
   md5: 5ad4571eba2479f77a9f849a6ae7724c
   depends:
@@ -1483,7 +1483,7 @@ packages:
   license_family: Apache
   size: 3998613
   timestamp: 1694465071784
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
   sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
   md5: 77a22ed6d0d448c5288d0f695bc9ac49
   depends:
@@ -1492,7 +1492,7 @@ packages:
   license_family: Apache
   size: 72527
   timestamp: 1693575234886
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
   sha256: e7a0abb0f00a94000876f2095f0cf531ad3803ffbd868a780b3f06816b54492c
   md5: 97ef7e1fe923d22a8e2307f3f39a92d5
   depends:
@@ -1508,7 +1508,7 @@ packages:
   license_family: BSD
   size: 13221005
   timestamp: 1650622404234
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
   sha256: 49fdb57b2ed2ce4d6bb7a2c5adec36ba59522518a41fb941f9e39a9f43750cc5
   md5: 871b65444733b7da5823ee0dc9826722
   depends:
@@ -1529,7 +1529,7 @@ packages:
   license_family: BSD
   size: 14712394
   timestamp: 1676379803902
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
   sha256: 64a732ce2661cdb6bd8f9d1484ac10afeb73082b1c2b44728d212e0117d2860e
   md5: ada303f0cf43a4e99cfa7f243b23b681
   depends:
@@ -1538,7 +1538,7 @@ packages:
   license_family: BSD
   size: 141832
   timestamp: 1684915385689
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
   sha256: 8bcb1c67693f42a3170eb77ef4cdbb81b605fdf40816953e69a33a065c101638
   md5: b7689507fb5f879dc766aaa8a4c37351
   depends:
@@ -1557,7 +1557,7 @@ packages:
   license_family: Other
   size: 734566
   timestamp: 1646325095608
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
   sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
   md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
   depends:
@@ -1568,7 +1568,7 @@ packages:
   license_family: MIT
   size: 2674850
   timestamp: 1697548887851
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
   sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
   md5: fe56f0479dd414c846191116366262c3
   depends:
@@ -1577,7 +1577,7 @@ packages:
   license_family: MIT
   size: 31999
   timestamp: 1692205535111
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
   sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
   md5: 44d2a857d13bdf9d99aaac039a249d47
   depends:
@@ -1586,7 +1586,7 @@ packages:
   license_family: Apache
   size: 91137
   timestamp: 1659455142164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
   sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
   md5: eb899a739d9b58dd747f1f6bd52d4cf3
   depends:
@@ -1598,7 +1598,7 @@ packages:
   license_family: BSD
   size: 579771
   timestamp: 1672387338600
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
   sha256: 6973cfe0565ba3b5ad6d1de9e34848fbbadd78b507b2e23e1c079636b8f8f317
   md5: a924535045fb356e23e7a3cc8116b638
   depends:
@@ -1608,7 +1608,7 @@ packages:
   license_family: BSD
   size: 350026
   timestamp: 1612298042840
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
   sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
   md5: f36ecb722522cbe2e3737424edf1b5e1
   depends:
@@ -1620,7 +1620,7 @@ packages:
   license_family: BSD
   size: 29312
   timestamp: 1675441510984
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
   sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
   md5: 6d03295e544251e608a28c8d7c48115e
   depends:
@@ -1629,7 +1629,7 @@ packages:
   license_family: BSD
   size: 1862058
   timestamp: 1684280096752
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
   sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
   md5: 1f09617aecd6f3c2f2e20692c0759f34
   depends:
@@ -1639,7 +1639,7 @@ packages:
   license_family: Apache
   size: 94434
   timestamp: 1690223520097
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
   sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
   md5: ffceed627867508d73af1636ab5ebf42
   depends:
@@ -1648,7 +1648,7 @@ packages:
   license_family: MIT
   size: 156324
   timestamp: 1661452578573
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
   sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
   md5: 0e3341a4fe434167bf74b613eb6afd81
   depends:
@@ -1658,7 +1658,7 @@ packages:
   license_family: MIT
   size: 97194
   timestamp: 1636110999719
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
   sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
   md5: c5f3f7f10ad30f0945e75252615ab6e5
   depends:
@@ -1667,7 +1667,7 @@ packages:
   license_family: BSD
   size: 31331
   timestamp: 1605305847037
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
   sha256: c4b9e332a6f2b7524e8c88e2b39a2568a48e556fd9a44c30759c43611d4d023d
   md5: bb118745c9b08fc5028f45e77f371e68
   depends:
@@ -1687,7 +1687,7 @@ packages:
   license_family: PSF
   size: 24553777
   timestamp: 1654084160832
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
   sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
   md5: 0caa188a695319bdb13f53b0a2b3accc
   depends:
@@ -1696,7 +1696,7 @@ packages:
   license_family: BSD
   size: 264864
   timestamp: 1661371117920
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
   sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
   md5: bcb44ecbea441ee0d4659133d060d71f
   depends:
@@ -1705,7 +1705,7 @@ packages:
   license_family: MIT
   size: 257904
   timestamp: 1695131670290
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
   sha256: e937081facacb141dc2c9cdcced92baa9a2662e4a56100b6041df0b6b7692570
   md5: f3ac39b2349258198a9b3316636fe5d5
   depends:
@@ -1715,7 +1715,7 @@ packages:
   license_family: BSD
   size: 39972
   timestamp: 1685030752528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
   sha256: 3da9cbbd49fac566433748bd245d09d7d5fcd28b04c0397cbbf6d5bb92f5c4a5
   md5: df73a5d2f6e089d51e71e91935a82c65
   depends:
@@ -1726,7 +1726,7 @@ packages:
   license_family: MIT
   size: 183753
   timestamp: 1635775763162
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
   sha256: 26005d191bb15070aad70707ed6493f32678a67978bd3b83d4c9679cab44e717
   md5: 2dc75d5a4ccb64310939c3a72d34ae20
   depends:
@@ -1737,7 +1737,7 @@ packages:
   license_family: BSD
   size: 521583
   timestamp: 1638435042256
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
   sha256: 8c950c69bee969e2c66f88f0dc247b3ab75a753672a88009779d5f5dba193532
   md5: 150ac0eb929bab9dec912797bdfc7b95
   depends:
@@ -1747,7 +1747,7 @@ packages:
   license_family: GPL
   size: 433182
   timestamp: 1642022402894
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
   sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
   md5: c7de00b4ac2778c4e5a7816320d75391
   depends:
@@ -1763,7 +1763,7 @@ packages:
   license_family: Apache
   size: 94028
   timestamp: 1690400356879
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
   sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
   md5: 1581cafc84708ed9aafaaee1cbbf6065
   depends:
@@ -1772,7 +1772,7 @@ packages:
   license_family: MIT
   size: 1089416
   timestamp: 1690290900608
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
   sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
   md5: e19ffbfb24b990275d24fcea2bd1699b
   depends:
@@ -1781,7 +1781,7 @@ packages:
   license_family: Apache
   size: 15702
   timestamp: 1614030498860
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
   sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
   md5: ca061ce25c0f58628643abec8d6a8244
   depends:
@@ -1790,7 +1790,7 @@ packages:
   license_family: MIT
   size: 66330
   timestamp: 1696347637947
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
   sha256: 87965b7b46d93866d31696a1045216d64f077a06b2900c356aba87e8559c6188
   md5: fa334030245135b37027a882f3c468bf
   depends:
@@ -1801,7 +1801,7 @@ packages:
   license_family: Other
   size: 1561908
   timestamp: 1655328608308
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
   sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
   md5: 0e76eab58fe488e91f0aee73f46de031
   depends:
@@ -1812,7 +1812,7 @@ packages:
   license_family: BSD
   size: 29816
   timestamp: 1671751864131
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
   sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
   md5: b413a210eca82fe867e991eed085201b
   depends:
@@ -1822,7 +1822,7 @@ packages:
   license_family: BSD
   size: 38882
   timestamp: 1668168876032
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
   sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
   md5: 5b8375e2092012db69d2123dc0c68630
   depends:
@@ -1832,7 +1832,7 @@ packages:
   license_family: BSD
   size: 3485432
   timestamp: 1654088939579
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
   sha256: b746e39272888b9cc1a2a711b7b8836f2e26f4457850e43ad18bf0765e21dc3d
   md5: 200e86f8d53aeebf4b7dcfc944fd7920
   depends:
@@ -1842,7 +1842,7 @@ packages:
   license_family: Apache
   size: 661662
   timestamp: 1606942359431
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
   sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
   md5: 67a8320961ff24e92eebb661536e5cf7
   depends:
@@ -1855,7 +1855,7 @@ packages:
   license_family: MOZILLA
   size: 123763
   timestamp: 1679561904852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
   sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
   md5: 0f0b91a158dd3692cbb7a7763b657bfe
   depends:
@@ -1864,7 +1864,7 @@ packages:
   license_family: BSD
   size: 192032
   timestamp: 1671143995098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
   md5: 8515e64a3de7581360d713fe4c0a094e
   depends:
@@ -1874,7 +1874,7 @@ packages:
   license_family: PSF
   size: 8789
   timestamp: 1690297588156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
   md5: 60170012374b2a5007842fa5870d78c5
   depends:
@@ -1883,7 +1883,7 @@ packages:
   license_family: PSF
   size: 57479
   timestamp: 1690297581658
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
   sha256: 870f20a3c006a74b291910f69c3469a409bd21437142864b29cfafeb89ca7c34
   md5: 1b2f1589e3ebc3e0c6ecb38dba93e4ae
   depends:
@@ -1898,7 +1898,7 @@ packages:
   license_family: MIT
   size: 186761
   timestamp: 1686163186447
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
   sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
   md5: f8d03a15b974fc7810d9f54ae849fc8e
   depends:
@@ -1907,7 +1907,7 @@ packages:
   license_family: BSD
   size: 20781
   timestamp: 1607365390528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
   sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
   md5: d7db5d6ce1db80eade8a082ff78bf479
   depends:
@@ -1917,7 +1917,7 @@ packages:
   license_family: BSD
   size: 71044
   timestamp: 1614804011510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
   sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
   md5: b3899f8bda32734727bd5a73df1d7d17
   depends:
@@ -1926,7 +1926,7 @@ packages:
   license_family: MIT
   size: 101520
   timestamp: 1695742037911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
   sha256: 2ce360ff98c0ca4537d70c19266b5700810196c54ce2fbaff3b94a969846ee37
   md5: 94cb94dc47405b24b1b5bd0a3275ab59
   depends:
@@ -1935,7 +1935,7 @@ packages:
   license_family: GPL2
   size: 398058
   timestamp: 1651602137803
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -1943,7 +1943,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
   sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
   md5: 567b68192c387b5fc88178425577a0fe
   depends:
@@ -1953,7 +1953,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 366479
   timestamp: 1616055552392
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
   sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
   md5: 3818a9531fe74433c3b7d5144c9a58cc
   depends:
@@ -1962,7 +1962,7 @@ packages:
   license_family: MIT
   size: 18021
   timestamp: 1672387231268
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
   sha256: 513444d83ac2405e898531492ea59f3a95641e357cc39c1048d6fffc1791a16b
   md5: 601d9449c280b9b145dc8c83b6f06119
   depends:
@@ -1971,7 +1971,7 @@ packages:
   license_family: Other
   size: 133595
   timestamp: 1650637720646
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
   sha256: 1c049c23788a00b6f38bdc801245e0e60af98718d4db4c958658bcc67ff158c7
   md5: b1737dfd2e06ad69ec5cfec341e207c6
   depends:
@@ -1984,7 +1984,7 @@ packages:
   license_family: BSD
   size: 827172
   timestamp: 1650622223170
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -1997,7 +1997,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -2007,7 +2007,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
   md5: b2aa5503875aba2f1d88cae9df9a96d5
   depends:
@@ -2016,7 +2016,7 @@ packages:
   license_family: BSD
   size: 13636
   timestamp: 1611930018941
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -2028,7 +2028,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
   sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
   md5: 544adf2677c47c9b9c891aea720678f1
   depends:
@@ -2036,7 +2036,7 @@ packages:
   license: MIT
   size: 33999
   timestamp: 1630003259346
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -2045,7 +2045,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -2054,7 +2054,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -2063,7 +2063,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -2072,7 +2072,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
   sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
   md5: 9eff1a842dbda8d1bae9a2c008b599bc
   depends:
@@ -2083,7 +2083,7 @@ packages:
   license_family: MIT
   size: 690443
   timestamp: 1625743217109
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -2091,7 +2091,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
   sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
   md5: 33624a42ee387bf9918ea98b4e7b31fc
   depends:
@@ -2101,7 +2101,7 @@ packages:
   license_family: BSD
   size: 8173
   timestamp: 1601490751973
-- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
   sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
   md5: 67857cc5e9044770d2b15f9d94a4521d
   depends:
@@ -2110,7 +2110,7 @@ packages:
   license_family: Apache
   size: 12810
   timestamp: 1600445183315
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -2119,7 +2119,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -2128,7 +2128,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -2138,7 +2138,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
   sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
   md5: e68a6f315f41a8d814d833652bf38b9b
   depends:
@@ -2146,7 +2146,7 @@ packages:
   license: MIT
   size: 13374
   timestamp: 1606932077143
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -2154,7 +2154,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -2163,7 +2163,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -2172,7 +2172,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
   sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
   md5: 2eb923cc014094f4acf7f849d67d73f8
   depends:
@@ -2182,7 +2182,7 @@ packages:
   license_family: BSD
   size: 246457
   timestamp: 1626374695070
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
   sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
   md5: 02caf3f47f1d06256068053297355740
   depends:
@@ -2191,7 +2191,7 @@ packages:
   license_family: Apache
   size: 152292
   timestamp: 1690578151230
-- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
   sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
   md5: 41db68b96e114e367c4f120a3b379e59
   depends:
@@ -2200,7 +2200,7 @@ packages:
   license_family: BSD
   size: 19391
   timestamp: 1632406728844
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -2209,7 +2209,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -2221,14 +2221,14 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
   sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
   md5: a815d3bdb160bcc71687f2dda70d3ca4
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 122218
   timestamp: 1680170368293
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -2236,7 +2236,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
   sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
   md5: 447a49f7bad119faa80d7f14aa296c95
   depends:
@@ -2249,7 +2249,7 @@ packages:
   license_family: MIT
   size: 162176
   timestamp: 1644481750133
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
   sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
   md5: 8810f48fe4a4792de0fd3520b502d08b
   depends:
@@ -2258,7 +2258,7 @@ packages:
   license_family: BSD
   size: 10019
   timestamp: 1606859473259
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
   sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
   md5: 00a446b6dfc61af223df4de29fe8ad94
   depends:
@@ -2268,7 +2268,7 @@ packages:
   license_family: MIT
   size: 34305
   timestamp: 1644569782044
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
   sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
   md5: bd92dd8bd5b9d24e632b62a075426e50
   depends:
@@ -2277,7 +2277,7 @@ packages:
   license_family: MIT
   size: 133634
   timestamp: 1695718025321
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
   sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
   md5: f8ae051b591a9027adc16de1be9748f4
   depends:
@@ -2287,12 +2287,12 @@ packages:
   license_family: MIT
   size: 206198
   timestamp: 1681493096349
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
   sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
   md5: e2f3248e2a5009a02f7b8e54f83314ef
   size: 5620
   timestamp: 1528121955725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
   sha256: 2936241747f6cc0f0b3afa53bb28ad6f658b53a0fc2e67a5ed34d1d5e2cce117
   md5: bdca1b691340964271d9cfec6baaf8d0
   depends:
@@ -2310,7 +2310,7 @@ packages:
   license_family: BSD
   size: 5719952
   timestamp: 1697490515691
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
   sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
   md5: 0d79760d544d0bd8acb4adc4ef813418
   depends:
@@ -2320,7 +2320,7 @@ packages:
   license_family: BSD
   size: 137075
   timestamp: 1657175654487
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
   sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
   md5: 31d6d04cd2388d8f19004501271b3545
   depends:
@@ -2330,7 +2330,7 @@ packages:
   license: MIT
   size: 18982
   timestamp: 1659616229395
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
   sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
   md5: caf1073dc2ca5aeb832a2877394eae12
   depends:
@@ -2339,7 +2339,7 @@ packages:
   license: MIT
   size: 18233
   timestamp: 1659616216769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
   sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
   md5: aa1ed20c38af535c8d6a955314759d7b
   depends:
@@ -2348,14 +2348,14 @@ packages:
   license: MIT
   size: 394588
   timestamp: 1659616312678
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
   sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
   md5: ce3588e31faa79f546e0fc6a36c5543c
   license: MPL-2.0
   license_family: Other
   size: 133884
   timestamp: 1694009771475
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
   sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
   md5: 21eb7f53076d0a69513cfd258f6ef63c
   depends:
@@ -2364,7 +2364,7 @@ packages:
   license_family: Other
   size: 159756
   timestamp: 1690232346868
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
   sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
   md5: a40a04d9cda1e665565bc6c832d598b6
   depends:
@@ -2375,7 +2375,7 @@ packages:
   license_family: MIT
   size: 225258
   timestamp: 1670423337502
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
   sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
   md5: b2cc5f37f7bb069d061306e7eac2a011
   depends:
@@ -2385,7 +2385,7 @@ packages:
   license_family: CC
   size: 1913396
   timestamp: 1668084575248
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
   sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
   md5: 103d8c039e342115720a84d59c119d46
   depends:
@@ -2395,7 +2395,7 @@ packages:
   license_family: BSD
   size: 13774
   timestamp: 1671231190250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
   sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
   md5: f69f09e0346172f225390d2b3b0d7873
   depends:
@@ -2406,7 +2406,7 @@ packages:
   license_family: BSD
   size: 246628
   timestamp: 1663827484947
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
   sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
   md5: cb80c7ac65b48a737654f371fe31c460
   depends:
@@ -2419,7 +2419,7 @@ packages:
   license_family: BSD
   size: 1307228
   timestamp: 1694212041712
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
   sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
   md5: 04cbe8f4bc62c34fac9d42d1124059bf
   depends:
@@ -2429,7 +2429,7 @@ packages:
   license_family: MIT
   size: 2052734
   timestamp: 1690905361158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
   sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
   md5: ef0e825982f242085574f502dfff4f6b
   depends:
@@ -2438,7 +2438,7 @@ packages:
   license_family: MIT
   size: 16594
   timestamp: 1649926538106
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
   sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
   md5: 24747a300246c016b3a7f04dabd02d4a
   depends:
@@ -2447,7 +2447,7 @@ packages:
   license_family: BSD
   size: 27709
   timestamp: 1668714497209
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -2457,14 +2457,14 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
   sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
   md5: e4a732941f74b8062c8bcbfe5c5c2b56
   license: MIT
   license_family: MIT
   size: 80252
   timestamp: 1676983220161
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
   sha256: 5c36d43cadbbf944d9255e79df85c2e9e6155a1d6f9158e06fcd8ffd458b7663
   md5: a5a2cff387403ccf9cf58aac7a6dde55
   depends:
@@ -2481,7 +2481,7 @@ packages:
   license_family: BSD
   size: 4573879
   timestamp: 1698866750755
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
   sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
   md5: f3ce6fe6eb760c236e5f7d04df5faa81
   depends:
@@ -2490,7 +2490,7 @@ packages:
   license_family: MIT
   size: 28138484
   timestamp: 1692293212596
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
   sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
   md5: 6dd72c43fea25b748ec7a9f6c0407e15
   depends:
@@ -2499,7 +2499,7 @@ packages:
   license_family: BSD
   size: 111810
   timestamp: 1666125671024
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
   sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
   md5: 03cdb7e679924b329ecab8f12cb8fc67
   depends:
@@ -2509,7 +2509,7 @@ packages:
   license_family: APACHE
   size: 38813
   timestamp: 1678997212422
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
   sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
   md5: e113c4e6e758dd68faf196586bf5564d
   depends:
@@ -2519,7 +2519,7 @@ packages:
   license_family: Apache
   size: 51873
   timestamp: 1698254765815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
   sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
   md5: 78baea934985ccd9514a366cc7e80ed4
   depends:
@@ -2528,7 +2528,7 @@ packages:
   license_family: Proprietary
   size: 727499
   timestamp: 1681801225190
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
   sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
   md5: da9b63e42f281f7e77b289f4b654b83b
   depends:
@@ -2550,7 +2550,7 @@ packages:
   license_family: BSD
   size: 218436
   timestamp: 1691121840155
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
   sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
   md5: 6a7cb9b49593b29933fa2b503d533a08
   depends:
@@ -2572,7 +2572,7 @@ packages:
   license_family: BSD
   size: 1257205
   timestamp: 1694181720454
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
   sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
   md5: d861ef66f5c0a282d60b65778a9de2f3
   depends:
@@ -2582,7 +2582,7 @@ packages:
   license_family: MIT
   size: 1048450
   timestamp: 1644315332508
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
   sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
   md5: f7e603c965052deed8b789c35855a42f
   depends:
@@ -2592,14 +2592,14 @@ packages:
   license_family: BSD
   size: 213537
   timestamp: 1666908270815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
   sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
   md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
   license: IJG
   license_family: Other
   size: 278924
   timestamp: 1677849185191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
   sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
   md5: a82a17e78f725dcbd71ff8dac6db05c7
   depends:
@@ -2610,7 +2610,7 @@ packages:
   license_family: MIT
   size: 133134
   timestamp: 1676558895333
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
   sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
   md5: ee9270379a9ebdb6297e4b6849b3f7f0
   depends:
@@ -2626,7 +2626,7 @@ packages:
   license_family: BSD
   size: 195479
   timestamp: 1676329410154
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 32b898a97dca7770858ab31294238fde11ab61a84831a52f320e5ee5405a147c
   md5: 926e754b8fad288b583ef2933deae1a5
   depends:
@@ -2637,7 +2637,7 @@ packages:
   license_family: BSD
   size: 92938
   timestamp: 1679906616072
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
   sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
   md5: 7e60995b3119417213e5faedda147499
   depends:
@@ -2661,7 +2661,7 @@ packages:
   license_family: BSD
   size: 403165
   timestamp: 1671707664990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
   sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
   md5: cd470bdb28bb0e8b3535c93a3a6dad07
   depends:
@@ -2671,7 +2671,7 @@ packages:
   license_family: BSD
   size: 65431
   timestamp: 1672387389172
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -2681,7 +2681,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -2690,13 +2690,13 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
   sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
   md5: 7dba7aa5b971febb55281659843586ba
   license: MIT
   size: 65470
   timestamp: 1659616172703
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
   sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
   md5: f78a158983f0bbaba56f34b976bc6dae
   depends:
@@ -2704,7 +2704,7 @@ packages:
   license: MIT
   size: 34189
   timestamp: 1659616189313
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
   sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
   md5: 36a1d885725d3ab4d1fadc5a29f978d2
   depends:
@@ -2712,35 +2712,35 @@ packages:
   license: MIT
   size: 327737
   timestamp: 1659616202869
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
   sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
   md5: 817848d0e2b2808acdc9b3fbbf581726
   license: MIT
   license_family: MIT
   size: 133887
   timestamp: 1683716590737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
   sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
   md5: c90372428e1e4eed4fdcd790979d06b4
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1409377
   timestamp: 1650983531933
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -2749,13 +2749,13 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -2772,7 +2772,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
   sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
   md5: c0b99f8e1c7475f23b1c7b4250b06e1c
   depends:
@@ -2786,7 +2786,7 @@ packages:
   license_family: BSD
   size: 88021
   timestamp: 1694778290062
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
   sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
   md5: 46a65d1fc24013217e06aaf6d65ffcad
   constrains:
@@ -2795,7 +2795,7 @@ packages:
   license_family: BSD
   size: 425478
   timestamp: 1694776947990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
   sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
   md5: 06866415ef22d5322f9bdc9956b59c4d
   depends:
@@ -2807,7 +2807,7 @@ packages:
   license_family: MIT
   size: 678174
   timestamp: 1692970318885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
   sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
   md5: 2edc6c894d6d0321304396e9bd40df94
   depends:
@@ -2817,7 +2817,7 @@ packages:
   license_family: MIT
   size: 241774
   timestamp: 1692973618934
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 0190d3b8d2939f28aa017711cf4147c51a1139da2922cc8420a71562dd99f844
   md5: 454a7f2c4426453f17e995382a4235e4
   depends:
@@ -2827,7 +2827,7 @@ packages:
   license_family: MIT
   size: 36036
   timestamp: 1659783508187
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
   sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
   md5: 8bbd981ca0129d7beeacd3cd7623f714
   depends:
@@ -2838,7 +2838,7 @@ packages:
   license_family: Other
   size: 1491074
   timestamp: 1695058597986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
   sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
   md5: d5f58d056b4bfc67aec30c77035ba889
   depends:
@@ -2847,7 +2847,7 @@ packages:
   license_family: BSD
   size: 182491
   timestamp: 1670944720979
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
   sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
   md5: 1affd16b166571a91feae04baf5fd3da
   depends:
@@ -2857,7 +2857,7 @@ packages:
   license_family: BSD
   size: 123431
   timestamp: 1671542016019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
   sha256: e5fc51472fa0f36abd78baa5b3c9245d6627b0da11188e6a954d73f3f2bca210
   md5: df7c519447affffb594f8c56b028ed33
   depends:
@@ -2867,7 +2867,7 @@ packages:
   license_family: MIT
   size: 107035
   timestamp: 1684279974102
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
   sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
   md5: 3681ebf029211ceab26af6f5d35abf39
   depends:
@@ -2878,7 +2878,7 @@ packages:
   license_family: BSD
   size: 22254
   timestamp: 1654598220251
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
   sha256: 2fd179efa024c92d0d71179a981a781d16c70f5d8c6305e0d678b0c7ae1275ab
   md5: addda7f015d1673f794a23fdb18a3e09
   depends:
@@ -2901,7 +2901,7 @@ packages:
   license_family: PSF
   size: 8182219
   timestamp: 1698692361219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
   sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
   md5: 6eb64ecfcd754502e271db0bb51d2cfd
   depends:
@@ -2911,7 +2911,7 @@ packages:
   license_family: BSD
   size: 17374
   timestamp: 1662014643620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 2312ee5a6343e8495802698d7181f1b619aad7479d96ee253407b324ac884417
   md5: 866960fa48a7ca335941786d4869802a
   depends:
@@ -2921,7 +2921,7 @@ packages:
   license_family: MIT
   size: 53542
   timestamp: 1659721365599
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
   sha256: 37f455814ce242eb65ff80a0402f1bd231a388e6823e6c1e65f60b705c032a2d
   md5: 4c9246c492a64729225aa5b04e12c2d1
   depends:
@@ -2930,7 +2930,7 @@ packages:
   license_family: MIT
   size: 19573
   timestamp: 1659716100178
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
   sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
   md5: 2a4d604717a647ad21af766289cbbfc3
   depends:
@@ -2939,7 +2939,7 @@ packages:
   license_family: BSD
   size: 58057
   timestamp: 1607364912348
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
   sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
   md5: 25051fe272624544652dc6d814c2943a
   depends:
@@ -2952,7 +2952,7 @@ packages:
   license_family: Proprietary
   size: 224420228
   timestamp: 1691503125614
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
   sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
   md5: 37d8cf85a63f7aa9af1624894a7d606d
   depends:
@@ -2962,7 +2962,7 @@ packages:
   license_family: BSD
   size: 48590
   timestamp: 1682969183093
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
   sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
   md5: 0b2aee6666135bbd36b46d6ac66160f7
   depends:
@@ -2975,7 +2975,7 @@ packages:
   license_family: BSD
   size: 210705
   timestamp: 1695058433223
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
   sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
   md5: e22fb55ce380d0ebd44cce3f20d5349e
   depends:
@@ -2989,7 +2989,7 @@ packages:
   license_family: BSD
   size: 296614
   timestamp: 1695060155673
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
   sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
   md5: 1a5d4004e64e3cfb7a2a297b9117c285
   depends:
@@ -3015,7 +3015,7 @@ packages:
   license_family: BSD
   size: 8213832
   timestamp: 1681756573646
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
   sha256: 2975bd1f98ca9ec7354ee378f86f8322ec90f568374776fd90e80c534fbee882
   md5: 798627089e0ccba26695a26d9cb127ec
   depends:
@@ -3028,7 +3028,7 @@ packages:
   license_family: BSD
   size: 99066
   timestamp: 1650308465824
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
   sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
   md5: e572c1264a7af20b486f64ac8c9e1f57
   depends:
@@ -3056,7 +3056,7 @@ packages:
   license_family: BSD
   size: 573356
   timestamp: 1668450732828
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
   sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
   md5: b67569a7c30af9ffa5cde6e4b52ac68b
   depends:
@@ -3069,14 +3069,14 @@ packages:
   license_family: BSD
   size: 148342
   timestamp: 1694616917184
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
   sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
   md5: 97b81f34efbe86c5220fe82eb584fd62
   depends:
@@ -3085,7 +3085,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387288528
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
   sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
   md5: d77862975a9a1cf50acb803be26e83a1
   depends:
@@ -3110,7 +3110,7 @@ packages:
   license_family: BSD
   size: 575365
   timestamp: 1690985052739
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
   sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
   md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
   depends:
@@ -3120,7 +3120,7 @@ packages:
   license_family: BSD
   size: 22858
   timestamp: 1668160618784
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
   sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
   md5: 185e9c41abb88ee59b52ec0f5f65d506
   depends:
@@ -3134,7 +3134,7 @@ packages:
   license_family: MIT
   size: 138305
   timestamp: 1696515469702
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
   sha256: 82a2dd0c2ff6e20a275e5447dd03088f79694f7bfa5055a25c54bebf31aac4ca
   md5: c157e6ab469a95b06fa822ba075978b3
   depends:
@@ -3150,7 +3150,7 @@ packages:
   license_family: BSD
   size: 10376
   timestamp: 1695831243158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
   sha256: b3a003b41cec2751210e542911e99437db0321542f6812c1b88608ef720ba7ef
   md5: 56400dfe88c427cdf1854e47666b8a99
   depends:
@@ -3165,7 +3165,7 @@ packages:
   license_family: BSD
   size: 7570900
   timestamp: 1695831208653
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
   sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
   md5: 93f5d7b66976154adeda219bea02ba45
   depends:
@@ -3175,7 +3175,7 @@ packages:
   license: BSD 2-Clause
   size: 484257
   timestamp: 1630093862501
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
   sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
   md5: 5e8713ef1215406254988163eaf34020
   depends:
@@ -3184,7 +3184,7 @@ packages:
   license_family: Apache
   size: 4965606
   timestamp: 1695323060401
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
   sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
   md5: 4154929ace2ad6ee16aea815635a6d1f
   depends:
@@ -3193,7 +3193,7 @@ packages:
   license_family: Apache
   size: 73598
   timestamp: 1693575307570
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
   sha256: aff5acedef9da91b77851e1a163b8319d72bc4152c98ac87703a2eac1e5d575b
   md5: 7df4c76aa8c52fedce5346748d56459e
   depends:
@@ -3240,7 +3240,7 @@ packages:
   license_family: BSD
   size: 13388063
   timestamp: 1697477404222
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
   sha256: 42d83288119306089a06e853a37045fbb9860548b05a1e79d223f7ecf1cb349d
   md5: 8daced11264159ff57df7bba4d0b2ec7
   depends:
@@ -3264,7 +3264,7 @@ packages:
   license_family: BSD
   size: 17075803
   timestamp: 1698867397009
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
   sha256: ad7ca92e5c83a8e2181677025509ed7b8f566ec23b24f28316fa087bb591c11f
   md5: a4ccd0fbcfb26de868f2fb4836940d7a
   depends:
@@ -3273,7 +3273,7 @@ packages:
   license_family: BSD
   size: 189263
   timestamp: 1698263570990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
   sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
   md5: be0a90921f3bf4f0d6950fb786093de7
   depends:
@@ -3292,7 +3292,7 @@ packages:
   license_family: Other
   size: 719901
   timestamp: 1696580194417
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
   sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
   md5: 81ae9ec2d7fcf6934847bff558b619f5
   depends:
@@ -3303,7 +3303,7 @@ packages:
   license_family: MIT
   size: 2672987
   timestamp: 1697548890181
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
   sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
   md5: 1a822c206e2abddc5d6d821721af227f
   depends:
@@ -3312,7 +3312,7 @@ packages:
   license_family: MIT
   size: 33013
   timestamp: 1692205801265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
   sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
   md5: 1604d33dbdb2446c642970f8b354bedb
   depends:
@@ -3321,7 +3321,7 @@ packages:
   license_family: Apache
   size: 91266
   timestamp: 1659455269141
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
   sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
   md5: d1b3bcc35655a3123acb1fa2ad1a8511
   depends:
@@ -3333,7 +3333,7 @@ packages:
   license_family: BSD
   size: 580828
   timestamp: 1672387372015
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
   sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
   md5: 7540555d1fb192236db9a7c5c9d3601c
   depends:
@@ -3342,7 +3342,7 @@ packages:
   license_family: BSD
   size: 365765
   timestamp: 1656431373327
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
   sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
   md5: 0a73533fb6e0dc717ab906a537bc747d
   depends:
@@ -3354,7 +3354,7 @@ packages:
   license_family: BSD
   size: 30803
   timestamp: 1675441638631
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
   sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
   md5: 0a959fbad46ab38ade48dbd358002674
   depends:
@@ -3363,7 +3363,7 @@ packages:
   license_family: BSD
   size: 1864757
   timestamp: 1684280094736
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
   sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
   md5: ea24b5076ef79e4567c5a3f0cb22b470
   depends:
@@ -3373,7 +3373,7 @@ packages:
   license_family: Apache
   size: 95330
   timestamp: 1690223465114
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
   sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
   md5: bcaea6d4a47e9c874becaa700c78dcf7
   depends:
@@ -3382,7 +3382,7 @@ packages:
   license_family: MIT
   size: 157216
   timestamp: 1661452617825
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
   sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
   md5: 707110d1b49cb1864acb0bbaa103591e
   depends:
@@ -3391,7 +3391,7 @@ packages:
   license_family: MIT
   size: 95016
   timestamp: 1636111184034
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
   sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
   md5: 113a443b9c706f9f9c6187c0eaa3de27
   depends:
@@ -3400,7 +3400,7 @@ packages:
   license_family: BSD
   size: 31178
   timestamp: 1605305861851
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
   sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
   md5: 85a8d0001db70e52a479155228cb1fe0
   depends:
@@ -3419,7 +3419,7 @@ packages:
   license_family: PSF
   size: 13324979
   timestamp: 1694439878265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
   sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
   md5: 47c5e22e31ec05a7bc0ce90065a53afd
   depends:
@@ -3428,7 +3428,7 @@ packages:
   license_family: BSD
   size: 265348
   timestamp: 1661368839620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
   sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
   md5: ce9a69e1668aa1e133f2aa6d4e8d346f
   depends:
@@ -3437,7 +3437,7 @@ packages:
   license_family: MIT
   size: 254958
   timestamp: 1695131709704
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 9ee098c09f31fad7ff1856e5ce2619172eaf979997e7a427d1e05cce32c2af00
   md5: cac1d1898b69ae9646dfbf082910635d
   depends:
@@ -3447,7 +3447,7 @@ packages:
   license_family: BSD
   size: 40946
   timestamp: 1685030787453
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
   sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
   md5: 637f08b19dd8fd87347d8c44f9e3e202
   depends:
@@ -3457,7 +3457,7 @@ packages:
   license_family: MIT
   size: 170776
   timestamp: 1698096100056
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
   sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
   md5: 8ce3ac7d8a04e469b566f1b090d01140
   depends:
@@ -3468,7 +3468,7 @@ packages:
   license_family: BSD
   size: 470617
   timestamp: 1657724324011
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -3477,7 +3477,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
   sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
   md5: 6f2d41dd76a03b7f85a1ed49af1763d6
   depends:
@@ -3493,7 +3493,7 @@ packages:
   license_family: Apache
   size: 95100
   timestamp: 1690400262627
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
   md5: b0321e6f14e139fc15b1f8b4acb35d2f
   depends:
@@ -3502,7 +3502,7 @@ packages:
   license_family: MIT
   size: 1093966
   timestamp: 1690290944588
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
   sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
   md5: 62b64576a0aa5f6c3fb05f56650d25e1
   depends:
@@ -3511,7 +3511,7 @@ packages:
   license_family: Apache
   size: 15535
   timestamp: 1614030509324
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
   sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
   md5: 15b5595b31e39f08eaacbe2e502d8fb3
   depends:
@@ -3520,7 +3520,7 @@ packages:
   license_family: MIT
   size: 67292
   timestamp: 1696347733587
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
   sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
   md5: 82e4db6a498480a75d53c55bd35b6478
   depends:
@@ -3532,7 +3532,7 @@ packages:
   license_family: Other
   size: 1801397
   timestamp: 1681394807900
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -3541,7 +3541,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
   sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
   md5: 63b957927b9949ccb19da28ec4612706
   depends:
@@ -3552,7 +3552,7 @@ packages:
   license_family: BSD
   size: 30902
   timestamp: 1671751919031
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
   sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
   md5: e346257a2fa8e2cb48c762138a5d009b
   depends:
@@ -3562,7 +3562,7 @@ packages:
   license_family: BSD
   size: 39915
   timestamp: 1668168959656
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
   sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
   md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
   depends:
@@ -3571,7 +3571,7 @@ packages:
   license_family: BSD
   size: 3536231
   timestamp: 1654088937695
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
   sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
   md5: a1bbf0abfb8c45541122c0eb2feee317
   depends:
@@ -3580,7 +3580,7 @@ packages:
   license_family: Apache
   size: 680464
   timestamp: 1696937112175
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
   sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
   md5: d689f6203c0a9d04fb229c73d7e80a7a
   depends:
@@ -3593,7 +3593,7 @@ packages:
   license_family: MOZILLA
   size: 125145
   timestamp: 1679561909274
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
   md5: 8a292c1ee22489bef2e84bc3aaf4098e
   depends:
@@ -3602,7 +3602,7 @@ packages:
   license_family: BSD
   size: 193141
   timestamp: 1671143985219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
   md5: 8bf0bfffc11ad06a1c94e145941b0ad4
   depends:
@@ -3612,7 +3612,7 @@ packages:
   license_family: PSF
   size: 9651
   timestamp: 1690297655669
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
   md5: 343514a174b3485fde55a73f56398dd7
   depends:
@@ -3621,7 +3621,7 @@ packages:
   license_family: PSF
   size: 58456
   timestamp: 1690297648002
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
   sha256: 11e7401cb6805db7ce22b1f9dd6ba5b7941c92225ce440bed1da0af284bfcad4
   md5: 5c10d68fa5616cdd82ee93ef6e0f038c
   depends:
@@ -3630,7 +3630,7 @@ packages:
   license_family: MIT
   size: 11615
   timestamp: 1659769478980
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
   sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
   md5: c2242e8fd24003a74ddf37416661e06d
   depends:
@@ -3645,7 +3645,7 @@ packages:
   license_family: MIT
   size: 188757
   timestamp: 1698257668273
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
   sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
   md5: 41f445e36b6b6722a9444508eef069f8
   depends:
@@ -3654,7 +3654,7 @@ packages:
   license_family: BSD
   size: 20583
   timestamp: 1607365395045
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
   sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
   md5: 409ee46ed24267b6da6fb32d13e1f21e
   depends:
@@ -3664,7 +3664,7 @@ packages:
   license_family: BSD
   size: 70730
   timestamp: 1614804271285
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
   sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
   md5: eb74e74d8e4fd533c55eb98b7b5e83bc
   depends:
@@ -3673,7 +3673,7 @@ packages:
   license_family: MIT
   size: 102637
   timestamp: 1695742077778
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
   sha256: cb007615819fd240ea4e343835dfbda3c508a92b5b7158219d30a22d0e67b57c
   md5: bf215e781ac81e0fc433eedee330c54b
   depends:
@@ -3682,20 +3682,20 @@ packages:
   license_family: BSD
   size: 49462
   timestamp: 1675159191191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
   sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
   md5: e243baa546432c8394a8059a44a5a3e4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 419227
   timestamp: 1683113010463
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
   sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
   md5: fe4ac85ee86d3a94ea3a4ebea3779763
   depends:
@@ -3704,7 +3704,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 321797
   timestamp: 1616055526986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
   sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
   md5: bc7073d9d4c0211cc4a1207c98fb765a
   depends:
@@ -3713,14 +3713,14 @@ packages:
   license_family: MIT
   size: 19091
   timestamp: 1672387204865
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
   sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
   md5: 8e495591e369ac161857a72011c0a296
   license: Zlib
   license_family: Other
   size: 120272
   timestamp: 1666595024203
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
   sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
   md5: f1465fbd810b3746c6de6babfd4fe28a
   depends:
@@ -3732,7 +3732,7 @@ packages:
   license_family: BSD
   size: 1023573
   timestamp: 1681304595869
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
   sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
   md5: cf55cb8d7031b30c70c56fc7c782b5c7
   depends:
@@ -3745,7 +3745,7 @@ packages:
   license_family: MIT
   size: 156104
   timestamp: 1644482799136
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
   sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
   md5: 84fce327d9f0d594e86f565e5c21962e
   depends:
@@ -3754,7 +3754,7 @@ packages:
   license_family: BSD
   size: 10183
   timestamp: 1629146082730
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
   sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
   md5: 84b8b998a741b37abf5312c1c03696ef
   depends:
@@ -3764,7 +3764,7 @@ packages:
   license_family: MIT
   size: 33979
   timestamp: 1644845817952
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
   sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
   md5: 77b746931c8f31c3ae393ccb5819d43d
   depends:
@@ -3773,7 +3773,7 @@ packages:
   license_family: MIT
   size: 133628
   timestamp: 1695717890677
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
   sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
   md5: 3df6e8ba34208dea068890e5d5318cc0
   depends:
@@ -3783,12 +3783,12 @@ packages:
   license_family: MIT
   size: 206759
   timestamp: 1681493095987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
   sha256: 8c31e7ede4b9a3ec6e1342f02bcff4d7113e5b25f12b91d108616a08eb8eb34f
   md5: de3ce22af040eb01db773fcab23ef413
   depends:
@@ -3806,7 +3806,7 @@ packages:
   license_family: BSD
   size: 5722206
   timestamp: 1697490482051
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
   sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
   md5: bb55f81435cb6e11d264242274fccd1a
   depends:
@@ -3816,7 +3816,7 @@ packages:
   license_family: BSD
   size: 115947
   timestamp: 1657175645380
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
   md5: f860193e14afc7ef3f5b990a2ac003d2
   depends:
@@ -3826,7 +3826,7 @@ packages:
   license: MIT
   size: 18936
   timestamp: 1659616204016
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
   sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
   md5: ad53130f3fd1f8d3c2fcbb7496e5585d
   depends:
@@ -3835,7 +3835,7 @@ packages:
   license: MIT
   size: 18715
   timestamp: 1659616188888
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
   sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
   md5: 0982c046fb976e9f9fb19e7510187a18
   depends:
@@ -3844,14 +3844,14 @@ packages:
   license: MIT
   size: 366983
   timestamp: 1659616245272
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
   sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
   md5: 31ac2f5596cb7a44adf073c930641c54
   license: MPL-2.0
   license_family: Other
   size: 133817
   timestamp: 1694009762858
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
   sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
   md5: cf1f6c3c34a1e1b9ab22b04233d860f6
   depends:
@@ -3860,7 +3860,7 @@ packages:
   license_family: Other
   size: 159783
   timestamp: 1690232303987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
   sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
   md5: 0eb268e38b5174d471a6e87d9d6102b1
   depends:
@@ -3871,7 +3871,7 @@ packages:
   license_family: MIT
   size: 225355
   timestamp: 1670423312966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
   sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
   md5: e68c94666cd60221b575c3814c89bac0
   depends:
@@ -3881,7 +3881,7 @@ packages:
   license_family: CC
   size: 1946451
   timestamp: 1668084573824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
   sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
   md5: 1773ae2b080cdd55827e27673351551e
   depends:
@@ -3891,7 +3891,7 @@ packages:
   license_family: BSD
   size: 13646
   timestamp: 1671231171682
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
   sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
   md5: 53bfd99ad1b09164d537209cffd98161
   depends:
@@ -3902,7 +3902,7 @@ packages:
   license_family: BSD
   size: 244040
   timestamp: 1663827469853
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
   sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
   md5: b62455043c8eb2434466885b19fed2de
   depends:
@@ -3915,7 +3915,7 @@ packages:
   license_family: BSD
   size: 1399573
   timestamp: 1694211828228
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
   sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
   md5: eb3cdc0fc210838b9271512a6a1b7c85
   depends:
@@ -3925,7 +3925,7 @@ packages:
   license_family: MIT
   size: 2067708
   timestamp: 1690905319109
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
   sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
   md5: f44b80b9405410e5bde6bfe0b31d5b3f
   depends:
@@ -3934,7 +3934,7 @@ packages:
   license_family: MIT
   size: 15135
   timestamp: 1650293774207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
   sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
   md5: f87027ccce1361d0f82c0edf1a10d53b
   depends:
@@ -3943,7 +3943,7 @@ packages:
   license_family: BSD
   size: 27677
   timestamp: 1668714367519
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -3953,14 +3953,14 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
   sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
   md5: 1d0bd7e576c64c059ef781dd319ad82a
   license: MIT
   license_family: MIT
   size: 77591
   timestamp: 1676983230102
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
   sha256: 3e480af22e98246c056bbd91d6be5352df34ff2b8451d9c7f614baeafb450d39
   md5: 695fe7ccaf6935d3117533d1e6737320
   depends:
@@ -3977,7 +3977,7 @@ packages:
   license_family: BSD
   size: 4542265
   timestamp: 1698866834303
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
   sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
   md5: 69eb3b03765627b6159ed23cdde78396
   depends:
@@ -3986,7 +3986,7 @@ packages:
   license_family: MIT
   size: 28399065
   timestamp: 1692293207812
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
   sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
   md5: 83366cbd3beb073112f4644a613b6bca
   depends:
@@ -3995,7 +3995,7 @@ packages:
   license_family: BSD
   size: 111933
   timestamp: 1666125627512
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
   sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
   md5: 647c1a2f8460ffa8c670a1915bbdb494
   depends:
@@ -4005,7 +4005,7 @@ packages:
   license_family: APACHE
   size: 38790
   timestamp: 1678997152549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
   sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
   md5: 35e541905426c686ef2ff010a0e502fd
   depends:
@@ -4015,7 +4015,7 @@ packages:
   license_family: Apache
   size: 51860
   timestamp: 1698254731870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
   sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
   md5: 187d7720aedf38759d122cccb4576f2c
   depends:
@@ -4037,7 +4037,7 @@ packages:
   license_family: BSD
   size: 219976
   timestamp: 1691121991680
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
   sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
   md5: e8e7f10741f9cfa737b310b334940441
   depends:
@@ -4059,7 +4059,7 @@ packages:
   license_family: BSD
   size: 1255894
   timestamp: 1694181494549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
   sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
   md5: ff209e75aee17af2e358b0008fbe8c88
   depends:
@@ -4069,7 +4069,7 @@ packages:
   license_family: MIT
   size: 1022945
   timestamp: 1644315931223
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
   sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
   md5: d3e78ef296b3c74910d003bd10b475d6
   depends:
@@ -4079,14 +4079,14 @@ packages:
   license_family: BSD
   size: 213972
   timestamp: 1666908195870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
   sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
   md5: 055e12390b844ea6c6e956ee08a618e8
   license: IJG
   license_family: Other
   size: 273479
   timestamp: 1677849171867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
   sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
   md5: 783e2ad3d36472648c5ccc9f3051db3c
   depends:
@@ -4097,7 +4097,7 @@ packages:
   license_family: MIT
   size: 133077
   timestamp: 1676558732505
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
   sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
   md5: 0677598f673f9729b5990316170a999d
   depends:
@@ -4113,7 +4113,7 @@ packages:
   license_family: BSD
   size: 197129
   timestamp: 1676329661580
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
   sha256: 05f9ca0fdcfdc2e217438be27fead588c843a3aadf7d034467c83216d1e5c214
   md5: 2d648b77d817ba38293c0728711ba8f5
   depends:
@@ -4124,7 +4124,7 @@ packages:
   license_family: BSD
   size: 92852
   timestamp: 1679906632236
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
   sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
   md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
   depends:
@@ -4148,7 +4148,7 @@ packages:
   license_family: BSD
   size: 401319
   timestamp: 1671707682572
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
   sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
   md5: 247558a0aecf1ef7e77a4343761353d6
   depends:
@@ -4158,7 +4158,7 @@ packages:
   license_family: BSD
   size: 64600
   timestamp: 1672387273585
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -4168,7 +4168,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -4177,13 +4177,13 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
   md5: a0f206782751dfffed0dd51302a1bf26
   license: MIT
   size: 68012
   timestamp: 1659616138077
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
   md5: 4c6667cdd061d28e9bc4e4300e4d115e
   depends:
@@ -4191,7 +4191,7 @@ packages:
   license: MIT
   size: 31173
   timestamp: 1659616155596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
   md5: 637e9430e258ddf050623ef2360184d8
   depends:
@@ -4199,28 +4199,28 @@ packages:
   license: MIT
   size: 298430
   timestamp: 1659616172209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
   sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
   md5: 55c615026c0869f8d3ba657f3bd38c43
   license: MIT
   license_family: MIT
   size: 120389
   timestamp: 1683716579036
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -4229,7 +4229,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -4240,14 +4240,14 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
   sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
   md5: a41117710dafe569c9cc4e83f6f29fe3
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1411339
   timestamp: 1650982753977
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -4258,7 +4258,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -4267,13 +4267,13 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -4290,7 +4290,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
   sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
   md5: 98d22e0124d55fae3c37c608dab1dcc9
   depends:
@@ -4304,7 +4304,7 @@ packages:
   license_family: BSD
   size: 89825
   timestamp: 1694778225280
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
   sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
   md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
   constrains:
@@ -4313,7 +4313,7 @@ packages:
   license_family: BSD
   size: 331675
   timestamp: 1694776939192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
   sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
   md5: 0ba499df6755eae5d2d23aa4ab004553
   depends:
@@ -4325,7 +4325,7 @@ packages:
   license_family: MIT
   size: 642657
   timestamp: 1692970217410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
   sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
   md5: c73101971e5ab6a8e8688239884eac81
   depends:
@@ -4335,7 +4335,7 @@ packages:
   license_family: MIT
   size: 241607
   timestamp: 1692973585084
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
   sha256: ac50f846e93e68d50bfdd5589ea8272b987243a64eba8e2e358ef311d7734001
   md5: f19270ff954a41dabbfe36ff0656935b
   depends:
@@ -4345,7 +4345,7 @@ packages:
   license_family: MIT
   size: 36040
   timestamp: 1659783399073
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -4354,7 +4354,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
   sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
   md5: 353dff9d5d996c2a260f66381b2ce3e8
   depends:
@@ -4365,7 +4365,7 @@ packages:
   license_family: Other
   size: 1470815
   timestamp: 1695058433965
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
   sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
   md5: c99006da802a97c9aae30da8c16b4820
   depends:
@@ -4374,7 +4374,7 @@ packages:
   license_family: BSD
   size: 176131
   timestamp: 1670944706815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
   sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
   md5: 60bd1e037cda86205526f77405d78129
   depends:
@@ -4384,7 +4384,7 @@ packages:
   license_family: BSD
   size: 123361
   timestamp: 1671541992772
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
   sha256: 2fd690fa3c54a40f0426874ea12e12aad2718263a75708ddd1fa6052a4ad7fb3
   md5: 81388724babfe9c32ea5cdd93633c342
   depends:
@@ -4394,7 +4394,7 @@ packages:
   license_family: MIT
   size: 107072
   timestamp: 1684280007887
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
   sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
   md5: 34dfd76da78de2eae95bbda390d746d6
   depends:
@@ -4405,7 +4405,7 @@ packages:
   license_family: BSD
   size: 23092
   timestamp: 1654598007056
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
   sha256: bf0eeef3c3c713515766ab8b0dc7863413de5b4b227deede97e24d90ca342345
   md5: a7bba1857eb84fb50caea377e60d2050
   depends:
@@ -4427,7 +4427,7 @@ packages:
   license_family: PSF
   size: 8066509
   timestamp: 1698692266161
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
   sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
   md5: eb79dabbeedee7da85dfbfb145bb8a26
   depends:
@@ -4437,7 +4437,7 @@ packages:
   license_family: BSD
   size: 17342
   timestamp: 1662014601345
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
   sha256: f400ad75dd2890627dc948f3e2e6b19732d02c124723eaf22272026993a94d52
   md5: 4a4ffc7365e30b18f4443281839e2718
   depends:
@@ -4447,7 +4447,7 @@ packages:
   license_family: MIT
   size: 53505
   timestamp: 1659721313693
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
   sha256: 20fb26a7ac748ce288cf8483a837b0c33f1348ae738bcdb69cdc2763c7bbf7e1
   md5: a0aebbc6c170ebd8d4710fd70b3db503
   depends:
@@ -4456,7 +4456,7 @@ packages:
   license_family: MIT
   size: 19562
   timestamp: 1659716131839
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
   sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
   md5: 56db7bd3ff511cd839bda081523b3edd
   depends:
@@ -4465,7 +4465,7 @@ packages:
   license_family: BSD
   size: 55683
   timestamp: 1629356128780
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
   sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
   md5: 176e0dcaeb28393881bacf69941e3889
   depends:
@@ -4491,7 +4491,7 @@ packages:
   license_family: BSD
   size: 8289638
   timestamp: 1681756329011
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
   sha256: afc6f332c51a3defc69e4c4e641988c0556039b9cd42be22f3db5292c88ccf37
   md5: 2bc409c7258160a9b739d08d5ffb5998
   depends:
@@ -4504,7 +4504,7 @@ packages:
   license_family: BSD
   size: 96942
   timestamp: 1650373637069
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
   sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
   md5: 150ea9fadddf21993d3328d3e48a18b7
   depends:
@@ -4532,7 +4532,7 @@ packages:
   license_family: BSD
   size: 557688
   timestamp: 1668450759059
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
   sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
   md5: 37163b32508f9f589b3e6462a3a47546
   depends:
@@ -4545,14 +4545,14 @@ packages:
   license_family: BSD
   size: 148426
   timestamp: 1694616771736
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
   sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
   md5: 6cdf7cbc43bf40e92b056a5576bd0086
   depends:
@@ -4561,7 +4561,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387216468
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
   sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
   md5: 0f05853a139b6cda9c73e9d2707a4976
   depends:
@@ -4586,7 +4586,7 @@ packages:
   license_family: BSD
   size: 590288
   timestamp: 1690984971741
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
   sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
   md5: 7de782e4fb34bfa95ef2fc79d27d727d
   depends:
@@ -4596,7 +4596,7 @@ packages:
   license_family: BSD
   size: 22840
   timestamp: 1668160634885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
   sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
   md5: 1a7b23113372c5667dbfe45976b9cc5c
   depends:
@@ -4607,7 +4607,7 @@ packages:
   license_family: MIT
   size: 126357
   timestamp: 1696515322390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
   sha256: 3cd1161558704176560843586b1b1f9b257fd68c0ca53a2fc09e61267f47514c
   md5: dd162b2716dc9daf732240a343862d4a
   depends:
@@ -4620,7 +4620,7 @@ packages:
   license_family: BSD
   size: 10388
   timestamp: 1695830584640
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
   sha256: 5f35d8c0e1768fa3a9d2e75659cd2096bea6b4e021afea114f573e95f4943fb2
   md5: 958f78b1e2299537996f98da7a930198
   depends:
@@ -4634,7 +4634,7 @@ packages:
   license_family: BSD
   size: 6313331
   timestamp: 1695830570878
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
   sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
   md5: 371358a54bbdd307603888348d1a2c6f
   depends:
@@ -4644,7 +4644,7 @@ packages:
   license: BSD 2-Clause
   size: 412248
   timestamp: 1628861367714
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
   sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
   md5: fa15d3b44ae1360ac9b640bbd5b6923c
   depends:
@@ -4653,7 +4653,7 @@ packages:
   license_family: Apache
   size: 4746123
   timestamp: 1695322833432
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
   sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
   md5: d73db95f07a282021efdf8bc09713261
   depends:
@@ -4662,7 +4662,7 @@ packages:
   license_family: Apache
   size: 73620
   timestamp: 1693575195999
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
   sha256: 247b5e4d81b6d5d013a9c27e1f30c41fff896fed98a68ebda26b19b4062a6828
   md5: 354a1d65300b4309d53dfa648014e8fe
   depends:
@@ -4709,7 +4709,7 @@ packages:
   license_family: BSD
   size: 13257999
   timestamp: 1697478739906
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
   sha256: 90a1889cd0004bfc5e12ac94b4ea92718a473373033bb0ba5259804ed67bf2bc
   md5: e89f615737385fee88150ab4adf037e6
   depends:
@@ -4733,7 +4733,7 @@ packages:
   license_family: BSD
   size: 17147015
   timestamp: 1698866800249
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
   sha256: 0ae09c974297767a707642344c40f484281f0a3000251a6234e46ef19f00c10e
   md5: 64a0eaf3381e9f6aa971229501710798
   depends:
@@ -4742,7 +4742,7 @@ packages:
   license_family: BSD
   size: 189313
   timestamp: 1698263486159
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
   sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
   md5: 6e01c592ae3b8ff2d12cae76f2f4276b
   depends:
@@ -4761,7 +4761,7 @@ packages:
   license_family: Other
   size: 715239
   timestamp: 1696580071596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
   sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
   md5: 9fb8f460c130d56caf33c6bbe46fbe8a
   depends:
@@ -4772,7 +4772,7 @@ packages:
   license_family: MIT
   size: 2678841
   timestamp: 1697548790931
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
   sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
   md5: 390b8c3cd74281abecdbfd51476922f9
   depends:
@@ -4781,7 +4781,7 @@ packages:
   license_family: MIT
   size: 33033
   timestamp: 1692205747301
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
   sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
   md5: 7896828fb3565fefad43f980d50c8723
   depends:
@@ -4790,7 +4790,7 @@ packages:
   license_family: Apache
   size: 91190
   timestamp: 1659455206354
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
   sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
   md5: d934c74eb66d01af0f45f0881f4bab77
   depends:
@@ -4802,7 +4802,7 @@ packages:
   license_family: BSD
   size: 580588
   timestamp: 1672387390426
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
   sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
   md5: 9858166e5ffb624c8b9d281f4000d725
   depends:
@@ -4811,7 +4811,7 @@ packages:
   license_family: BSD
   size: 367167
   timestamp: 1656431368885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
   sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
   md5: 4d2b45c6be8221e6a3e44c2d5838426f
   depends:
@@ -4823,7 +4823,7 @@ packages:
   license_family: BSD
   size: 30843
   timestamp: 1675441531640
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
   sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
   md5: 02521df4e2e79f75faa9cbb3560ab1dd
   depends:
@@ -4832,7 +4832,7 @@ packages:
   license_family: BSD
   size: 1861763
   timestamp: 1684280026169
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
   sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
   md5: bdebe59bffc7adbad83fdcd9d429a5f5
   depends:
@@ -4842,7 +4842,7 @@ packages:
   license_family: Apache
   size: 95234
   timestamp: 1690223494699
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
   sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
   md5: d716e5c9b5eec45ce1df8eb52cab817a
   depends:
@@ -4851,7 +4851,7 @@ packages:
   license_family: MIT
   size: 157408
   timestamp: 1661452601692
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
   sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
   md5: 1907629863ed8e7c35ead232dae7693f
   depends:
@@ -4860,7 +4860,7 @@ packages:
   license_family: MIT
   size: 91636
   timestamp: 1628941083263
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
   sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
   md5: 847b9bddf2a86e1609c0d53bbc23ea79
   depends:
@@ -4869,7 +4869,7 @@ packages:
   license_family: BSD
   size: 27378
   timestamp: 1626781391140
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
   sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
   md5: 18aa18bd0d260605923877921d26cc74
   depends:
@@ -4888,7 +4888,7 @@ packages:
   license_family: PSF
   size: 13194025
   timestamp: 1694438901368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
   sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
   md5: 45642a99c83e7aed74d1ffab1f20145b
   depends:
@@ -4897,7 +4897,7 @@ packages:
   license_family: BSD
   size: 266647
   timestamp: 1661368655993
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
   sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
   md5: fec748525144049a2fc7f52f9755232c
   depends:
@@ -4906,7 +4906,7 @@ packages:
   license_family: MIT
   size: 257235
   timestamp: 1695131702047
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
   sha256: 960192a143672e9c1d6fe4027af448512d91eee7501e5c245c21b865cf8bf429
   md5: 76d491244218505f071ba56a308673df
   depends:
@@ -4916,7 +4916,7 @@ packages:
   license_family: BSD
   size: 40950
   timestamp: 1685030774581
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
   sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
   md5: 3445d25415998c807efbe64d3a7e03c8
   depends:
@@ -4926,7 +4926,7 @@ packages:
   license_family: MIT
   size: 167068
   timestamp: 1698096118071
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
   sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
   md5: e6e92da28e9b0e428ed4b7df417bec25
   depends:
@@ -4937,7 +4937,7 @@ packages:
   license_family: BSD
   size: 472418
   timestamp: 1657724315435
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -4946,7 +4946,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
   sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
   md5: dba22515f36d3c266de5896350813ea2
   depends:
@@ -4962,7 +4962,7 @@ packages:
   license_family: Apache
   size: 95103
   timestamp: 1690400315537
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
   sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
   md5: 3cd7eb43e285faba76faf67667e26b00
   depends:
@@ -4971,7 +4971,7 @@ packages:
   license_family: MIT
   size: 1093916
   timestamp: 1690290951258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
   sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
   md5: c5e9aef0d6895de1c927e9d796cd7cd3
   depends:
@@ -4980,7 +4980,7 @@ packages:
   license_family: Apache
   size: 15691
   timestamp: 1629145910454
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
   sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
   md5: 0f7c229e774146ffc4e29dedf75372bf
   depends:
@@ -4989,7 +4989,7 @@ packages:
   license_family: MIT
   size: 67279
   timestamp: 1696347632563
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
   sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
   md5: 2302a79a045f152e183a52a81adfba62
   depends:
@@ -5001,7 +5001,7 @@ packages:
   license_family: Other
   size: 1674163
   timestamp: 1681394762218
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
   sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
   md5: 4ae67163d55cf9df83d4027ebc38c501
   depends:
@@ -5012,7 +5012,7 @@ packages:
   license_family: BSD
   size: 30894
   timestamp: 1671751931536
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
   sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
   md5: dbb5c0cddb6661a89afee647fd3dc01e
   depends:
@@ -5022,7 +5022,7 @@ packages:
   license_family: BSD
   size: 39875
   timestamp: 1668168874870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
   sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
   md5: 667e60c8b407d73cbba40f44901f4f00
   depends:
@@ -5031,7 +5031,7 @@ packages:
   license_family: BSD
   size: 3412693
   timestamp: 1654088929697
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
   sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
   md5: 884f788a5f6a664c9b79f7a4a60362d0
   depends:
@@ -5040,7 +5040,7 @@ packages:
   license_family: Apache
   size: 680561
   timestamp: 1696937004165
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
   sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
   md5: 639a4f489af172c866c18442948e5874
   depends:
@@ -5053,7 +5053,7 @@ packages:
   license_family: MOZILLA
   size: 125170
   timestamp: 1679561942932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
   sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
   md5: e5b90eba83fddba6d7aa6072b5bf7c91
   depends:
@@ -5062,7 +5062,7 @@ packages:
   license_family: BSD
   size: 193017
   timestamp: 1671143921826
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
   md5: 644ef8830437070f60efcfcd6a987198
   depends:
@@ -5072,7 +5072,7 @@ packages:
   license_family: PSF
   size: 9670
   timestamp: 1690297532002
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
   md5: a902a833bb186a2f1a4b2b89b1195136
   depends:
@@ -5081,7 +5081,7 @@ packages:
   license_family: PSF
   size: 58466
   timestamp: 1690297524418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
   sha256: 536045a8a172c651fd306c285a6d7409775f018dac944f2124c538ccfb195e28
   md5: d4dc6cdf0812191b9ec78b35b4fdf3e0
   depends:
@@ -5090,7 +5090,7 @@ packages:
   license_family: MIT
   size: 11593
   timestamp: 1659769477205
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
   sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
   md5: f3f1d2c1028dad2f11ff950a15c99dbf
   depends:
@@ -5105,7 +5105,7 @@ packages:
   license_family: MIT
   size: 188640
   timestamp: 1698257577209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
   sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
   md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
   depends:
@@ -5114,7 +5114,7 @@ packages:
   license_family: BSD
   size: 20091
   timestamp: 1629144441130
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
   sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
   md5: 3089c63bf8f4d0423e1a287da286d83e
   depends:
@@ -5124,7 +5124,7 @@ packages:
   license_family: BSD
   size: 70923
   timestamp: 1629357115820
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
   sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
   md5: 5886b30b312445471268444f41f39dc7
   depends:
@@ -5133,7 +5133,7 @@ packages:
   license_family: MIT
   size: 102583
   timestamp: 1695741976083
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
   sha256: 105e39d3eb51b47c7244b3379c0133ab7051966664f52835453b14509215b159
   md5: ed20012c2cd99ffd04cca9929e0bc061
   depends:
@@ -5142,20 +5142,20 @@ packages:
   license_family: BSD
   size: 49775
   timestamp: 1675159079039
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
   sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
   md5: 2e75ad6a09c308268192efe03cc9ebf4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 411778
   timestamp: 1683113019715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
   sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
   md5: 30f666bf97c26587c5d2f68cc5f330ab
   depends:
@@ -5164,7 +5164,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 316901
   timestamp: 1629287855861
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
   sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
   md5: 584e591d36dcd5ba5c45404f0f7ebb2d
   depends:
@@ -5173,14 +5173,14 @@ packages:
   license_family: MIT
   size: 19076
   timestamp: 1672387153578
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
   sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
   md5: 467ae28215d1aa1c5688bc0c8a184269
   license: Zlib
   license_family: Other
   size: 103525
   timestamp: 1666595022664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
   sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
   md5: 7cfbed15f1feee1422810f7830075f53
   depends:
@@ -5192,7 +5192,7 @@ packages:
   license_family: BSD
   size: 779464
   timestamp: 1681304594848
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
   sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
   md5: ed14f9bc6e55220483f1a5a388625a08
   depends:
@@ -5205,7 +5205,7 @@ packages:
   license_family: MIT
   size: 162772
   timestamp: 1644481986085
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
   sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
   md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
   depends:
@@ -5217,7 +5217,7 @@ packages:
   license_family: MIT
   size: 39253
   timestamp: 1644551767970
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
   sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
   md5: b24d13c443a26f65a0778b475a5726bc
   depends:
@@ -5226,7 +5226,7 @@ packages:
   license_family: MIT
   size: 132830
   timestamp: 1695717959996
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
   sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
   md5: 302c3c0696e17eaa62e140e3892644ae
   depends:
@@ -5236,12 +5236,12 @@ packages:
   license_family: MIT
   size: 199723
   timestamp: 1681493196911
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
   sha256: 812f268862208c2518b5187809a8571adb488de3604d512721035e65458dde76
   md5: 97ce620b7dd3ee743d0ca28ed66ace74
   depends:
@@ -5259,7 +5259,7 @@ packages:
   license_family: BSD
   size: 5721832
   timestamp: 1697491241383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
   sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
   md5: bf930260f679bc74227bbb18bc36ae82
   depends:
@@ -5271,7 +5271,7 @@ packages:
   license_family: BSD
   size: 119700
   timestamp: 1657176150595
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
   md5: 507dfe693ef429f466d964b599f4af21
   depends:
@@ -5283,7 +5283,7 @@ packages:
   license: MIT
   size: 18650
   timestamp: 1659616328001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
   md5: d0bf43e8df60baae3b3105aa5c42a791
   depends:
@@ -5294,7 +5294,7 @@ packages:
   license: MIT
   size: 21153
   timestamp: 1659616312367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
   sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
   md5: 7bd24bf94c24e810aecaaf84a0978e6f
   depends:
@@ -5304,14 +5304,14 @@ packages:
   license: MIT
   size: 343204
   timestamp: 1659616543542
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
   sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
   md5: 092b417c11edcbe6bb9b765ab4a55d23
   license: MPL-2.0
   license_family: Other
   size: 164999
   timestamp: 1694009822357
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
   sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
   md5: 708a750d370b9d6875651021e21c4446
   depends:
@@ -5320,7 +5320,7 @@ packages:
   license_family: Other
   size: 159322
   timestamp: 1690232335307
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
   sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
   md5: c35736da3ea26782425e78061268cf5e
   depends:
@@ -5332,7 +5332,7 @@ packages:
   license_family: MIT
   size: 228713
   timestamp: 1670423312743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
   sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
   md5: 457a4339a53c033d48ce0c72e5038d2e
   depends:
@@ -5341,7 +5341,7 @@ packages:
   license_family: BSD
   size: 30330
   timestamp: 1672387265402
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
   sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
   md5: 59ec65fd9e06b81a65cc12986c67d5da
   depends:
@@ -5351,7 +5351,7 @@ packages:
   license_family: CC
   size: 1939614
   timestamp: 1668084794027
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
   sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
   md5: 3489c1a2b73fc957b5a62cc59349e25b
   depends:
@@ -5361,7 +5361,7 @@ packages:
   license_family: BSD
   size: 13438
   timestamp: 1671231196438
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
   sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
   md5: 3492b96083c1e904cc32d26ea7f1e1d8
   depends:
@@ -5373,7 +5373,7 @@ packages:
   license_family: BSD
   size: 184280
   timestamp: 1663827558327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
   sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
   md5: f46d904bc6f220327e70474971341f52
   depends:
@@ -5388,7 +5388,7 @@ packages:
   license_family: BSD
   size: 1220835
   timestamp: 1694445639066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
   sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
   md5: 2ff4fb509788b0e47ac684ba151394d0
   depends:
@@ -5399,7 +5399,7 @@ packages:
   license_family: MIT
   size: 3289966
   timestamp: 1690907040646
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
   sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
   md5: 0f166c3e70541d8bee6e9d0cb60fb66e
   depends:
@@ -5408,7 +5408,7 @@ packages:
   license_family: MIT
   size: 16979
   timestamp: 1649926678161
-- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
   sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
   md5: ea93d413944ca6a8677eb1b284b136ae
   depends:
@@ -5417,7 +5417,7 @@ packages:
   license_family: BSD
   size: 27388
   timestamp: 1668714577678
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -5429,7 +5429,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
   sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
   md5: 9f167d3e45441bc3633c1974b1b0ce8c
   depends:
@@ -5439,7 +5439,7 @@ packages:
   license_family: MIT
   size: 88421
   timestamp: 1676983264486
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
   sha256: fa8f868e49721ca19912f816a6da221172758f9e3d28d8b31d53249fb14dc25f
   md5: 09f9a2cea9425d76dccf9b026afe5bb2
   depends:
@@ -5456,7 +5456,7 @@ packages:
   license_family: BSD
   size: 4576915
   timestamp: 1698866895838
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
   sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
   md5: 30fdefd1541c789c163751291a8faa88
   depends:
@@ -5465,7 +5465,7 @@ packages:
   license_family: BSD
   size: 111448
   timestamp: 1666125667599
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
   sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
   md5: a10f07c7a3510272a296f9fed458a4ed
   depends:
@@ -5475,7 +5475,7 @@ packages:
   license_family: APACHE
   size: 38098
   timestamp: 1678997241511
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
   sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
   md5: fad9cf2023d807da8d44996e9d4399a0
   depends:
@@ -5485,7 +5485,7 @@ packages:
   license_family: Apache
   size: 51490
   timestamp: 1698254721864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
   sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
   md5: 9834848bd7c7759acf12e78d09388563
   depends:
@@ -5495,7 +5495,7 @@ packages:
   license_family: Proprietary
   size: 3891030
   timestamp: 1681801474383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
   sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
   md5: 1285c8c628bc912c54d0968574c9f4c9
   depends:
@@ -5516,7 +5516,7 @@ packages:
   license_family: BSD
   size: 217232
   timestamp: 1691122695748
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
   sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
   md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
   depends:
@@ -5537,7 +5537,7 @@ packages:
   license_family: BSD
   size: 1279433
   timestamp: 1694181820978
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
   sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
   md5: f5fcce35d3f21cdfc5893c5a7a86c651
   depends:
@@ -5547,7 +5547,7 @@ packages:
   license_family: MIT
   size: 1035394
   timestamp: 1644315567034
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
   sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
   md5: f67fe3337528e2886f1ac3ab8ac37985
   depends:
@@ -5557,7 +5557,7 @@ packages:
   license_family: BSD
   size: 213110
   timestamp: 1666908350218
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
   sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
   md5: 81f2c343dc4c65eea39c45383272068f
   depends:
@@ -5567,7 +5567,7 @@ packages:
   license_family: Other
   size: 407861
   timestamp: 1677849239400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
   sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
   md5: bd9526d38a145fe311a8aa36bc11e071
   depends:
@@ -5578,7 +5578,7 @@ packages:
   license_family: MIT
   size: 152006
   timestamp: 1676558783570
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
   sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
   md5: a00e6a62956fde3c4135464353ee8a53
   depends:
@@ -5594,7 +5594,7 @@ packages:
   license_family: BSD
   size: 229158
   timestamp: 1676330909084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
   sha256: db8335d6531b03c7bdfe789ebacc52631ac6ea4a37700bb3da1f6a53a1acd724
   md5: ebeba61994cc225ea5f4f42caa511019
   depends:
@@ -5606,7 +5606,7 @@ packages:
   license_family: BSD
   size: 116681
   timestamp: 1679906658986
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
   sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
   md5: 5efa1332f7c0a8d9638eda02170c4ce5
   depends:
@@ -5631,7 +5631,7 @@ packages:
   license_family: BSD
   size: 413653
   timestamp: 1671707957673
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
   sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
   md5: 891fe66a24d8714737b2874985ee1303
   depends:
@@ -5642,7 +5642,7 @@ packages:
   license_family: BSD
   size: 62298
   timestamp: 1672388166096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -5652,7 +5652,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
   sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
   md5: c345f51706eef530454f66b794e5e574
   depends:
@@ -5661,7 +5661,7 @@ packages:
   license: MIT
   size: 68189
   timestamp: 1659616216976
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
   md5: a7400cfb72042977bc047909ed504ce8
   depends:
@@ -5671,7 +5671,7 @@ packages:
   license: MIT
   size: 33743
   timestamp: 1659616248209
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
   md5: 6307f6854754ab5bd7c84e6998385bb1
   depends:
@@ -5681,7 +5681,7 @@ packages:
   license: MIT
   size: 733177
   timestamp: 1659616279453
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -5691,7 +5691,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
   sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
   md5: b812bc5d9c76242e2bb2ac87afe7d39b
   depends:
@@ -5701,7 +5701,7 @@ packages:
   license_family: GPL3
   size: 730280
   timestamp: 1650983734373
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -5712,7 +5712,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -5721,7 +5721,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -5738,7 +5738,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
   sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
   md5: ba9418df9288a2f031a02fa35b774ce0
   depends:
@@ -5754,7 +5754,7 @@ packages:
   license_family: BSD
   size: 78524
   timestamp: 1694778314659
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
   sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
   md5: b1781519a200ccbfcb4a1194005aa3ef
   depends:
@@ -5766,7 +5766,7 @@ packages:
   license_family: BSD
   size: 338459
   timestamp: 1694777084290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
   sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
   md5: 6ece7f1a3248169837714d05d7f6ef0a
   depends:
@@ -5778,7 +5778,7 @@ packages:
   license_family: MIT
   size: 3513910
   timestamp: 1692971505729
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
   sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
   md5: bd7ec244935e83e850a4ff34e8e2e64f
   depends:
@@ -5789,7 +5789,7 @@ packages:
   license_family: MIT
   size: 513971
   timestamp: 1692973657152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
   sha256: e1c0e745d9ba36a80773e841d96bf514ad1ceda419e4188aad3c22782af00234
   md5: f226532e9bb308f20e874c56be6ceefb
   depends:
@@ -5799,7 +5799,7 @@ packages:
   license_family: MIT
   size: 35788
   timestamp: 1659783414586
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
   sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
   md5: fb7881e74b59262df0fa4ec981964efc
   depends:
@@ -5812,7 +5812,7 @@ packages:
   license_family: Other
   size: 1244887
   timestamp: 1695058550693
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
   sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
   md5: 6970c7f46b0164cad1d210e7a1419959
   depends:
@@ -5822,7 +5822,7 @@ packages:
   license_family: BSD
   size: 143434
   timestamp: 1670944902624
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
   sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
   md5: 1015298551c040c6d5e26eebbae12ef5
   depends:
@@ -5832,7 +5832,7 @@ packages:
   license_family: BSD
   size: 142316
   timestamp: 1671542240512
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
   sha256: ab5c246c2b271acc1cdd0b9343989c0166681536e569cdbe71618f55d34c7292
   md5: 7ce68d771cd94c9ff5efefe69d327c9a
   depends:
@@ -5842,7 +5842,7 @@ packages:
   license_family: MIT
   size: 125122
   timestamp: 1684280210213
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
   sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
   md5: 466da740fafef3d6bce114220f0be306
   depends:
@@ -5855,7 +5855,7 @@ packages:
   license_family: BSD
   size: 28510
   timestamp: 1654508162239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
   sha256: 1687ae122ee7d8b583141fc5014b76d494841dc8083b854449e3d6e0f6bb7019
   md5: 3697ac26ee3c2d49338dd5b9c6551152
   depends:
@@ -5878,7 +5878,7 @@ packages:
   license_family: PSF
   size: 8080067
   timestamp: 1698692812610
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
   sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
   md5: a9fa43e694b25cd49b8b08a9eefd696e
   depends:
@@ -5888,7 +5888,7 @@ packages:
   license_family: BSD
   size: 18054
   timestamp: 1661915903969
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
   sha256: 8aa14047fac6ef8b326900c4bf1a960eaa7a1699c18fdf1e75a59101b610b6df
   md5: 7e1d4d4700fbea6171d30f1d5ad24226
   depends:
@@ -5898,7 +5898,7 @@ packages:
   license_family: MIT
   size: 53362
   timestamp: 1659721308586
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
   sha256: 2017814a7cc93dd51c6b7c016e3cdf8fbc32fa20f985638aaff6a6377e9ee086
   md5: a1a285c56b001c3b5c591bf21eec3149
   depends:
@@ -5907,7 +5907,7 @@ packages:
   license_family: MIT
   size: 19326
   timestamp: 1659716205153
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
   sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
   md5: 248c468abced874f0231d3cc23177c77
   depends:
@@ -5918,7 +5918,7 @@ packages:
   license_family: BSD
   size: 58488
   timestamp: 1607359497934
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
   sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
   md5: 5e763c995ff0c549f68a10bce70fede4
   depends:
@@ -5930,7 +5930,7 @@ packages:
   license_family: Proprietary
   size: 187489950
   timestamp: 1691503804820
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
   sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
   md5: dd0c2ece6a743c373c9b5a5919b4818f
   depends:
@@ -5942,7 +5942,7 @@ packages:
   license_family: BSD
   size: 49744
   timestamp: 1682975040154
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
   sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
   md5: 57cea8df7ab85f2a98f64d23afcb1f90
   depends:
@@ -5957,7 +5957,7 @@ packages:
   license_family: BSD
   size: 184956
   timestamp: 1695058491736
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
   sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
   md5: 8769cdd201d905069800488fe31574e5
   depends:
@@ -5972,7 +5972,7 @@ packages:
   license_family: BSD
   size: 256221
   timestamp: 1695060152521
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
   sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
   md5: d9781492332e6326f9fca87f3a8efacd
   depends:
@@ -5998,7 +5998,7 @@ packages:
   license_family: BSD
   size: 8135792
   timestamp: 1681756491399
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
   sha256: 2dd3178d3c570e30b9490ebabfd7bfac806afad8302d3dee0edc619805034397
   md5: bef9da0f0694c45b6aaa4e6447479eaf
   depends:
@@ -6011,7 +6011,7 @@ packages:
   license_family: BSD
   size: 118324
   timestamp: 1650290466135
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
   sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
   md5: f1d8ce412e115986c403f223b3b47d0f
   depends:
@@ -6039,7 +6039,7 @@ packages:
   license_family: BSD
   size: 596314
   timestamp: 1668451106600
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
   sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
   md5: f96bbef0985d7e66ebf00c0d55e30e23
   depends:
@@ -6052,7 +6052,7 @@ packages:
   license_family: BSD
   size: 167045
   timestamp: 1694617078743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
   sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
   md5: 6e6ba64c8dc5025aeac606404a8df36a
   depends:
@@ -6061,7 +6061,7 @@ packages:
   license_family: BSD
   size: 13786
   timestamp: 1672387480065
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
   sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
   md5: 4a7a3286484766741f627696697c362c
   depends:
@@ -6086,7 +6086,7 @@ packages:
   license_family: BSD
   size: 609425
   timestamp: 1690985686105
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
   sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
   md5: 4269a1f93882205b90d4b2ae78fc82d5
   depends:
@@ -6096,7 +6096,7 @@ packages:
   license_family: BSD
   size: 22417
   timestamp: 1668160717305
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
   sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
   md5: a18a576b7024cfd6f905c526a786a916
   depends:
@@ -6111,7 +6111,7 @@ packages:
   license_family: MIT
   size: 135285
   timestamp: 1696515698492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
   sha256: e5e11f9b42d770ee46ac24d1cdf7aa4e9c49a60a607c8c28e7729131a99eadd5
   md5: 4274d06db8a9a381c072d226d0322dc0
   depends:
@@ -6128,7 +6128,7 @@ packages:
   license_family: BSD
   size: 9835
   timestamp: 1695830845329
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
   sha256: dcaa1607ce40a0ed610dd5398e125c8e5b08e738e50b6037a8c72b49ca561ff2
   md5: d99d990a60644b97ba1ff9bb8da0e66f
   depends:
@@ -6144,7 +6144,7 @@ packages:
   license_family: BSD
   size: 6778113
   timestamp: 1695830816710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
   sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
   md5: ab07e2a27ac08afe3d0b4c0890b8486a
   depends:
@@ -6155,7 +6155,7 @@ packages:
   license: BSD 2-Clause
   size: 249316
   timestamp: 1630094024143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
   sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
   md5: 73b17037d87b5a58feb34dafc0538f7f
   depends:
@@ -6166,7 +6166,7 @@ packages:
   license_family: Apache
   size: 8058396
   timestamp: 1695324589828
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
   sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
   md5: df1d746ba8d5d6ba01ac1373b9b71e1a
   depends:
@@ -6175,7 +6175,7 @@ packages:
   license_family: Apache
   size: 73016
   timestamp: 1693575484990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
   sha256: 1994e5831fd421bd6cf85916073d4012dec53e673b672b3985efaf771f0a7bf8
   md5: c486a5b51e3227f6ea564a9dd3125e45
   depends:
@@ -6223,7 +6223,7 @@ packages:
   license_family: BSD
   size: 12629931
   timestamp: 1697479885371
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
   sha256: 270e4c3ab0f0c8d8f31fa0e45bc516c1e41be618a5c66e1c86dc39ce76cb2372
   md5: cad52ba9eb391416112f0994b6c35249
   depends:
@@ -6247,7 +6247,7 @@ packages:
   license_family: BSD
   size: 17162886
   timestamp: 1698867967809
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
   sha256: 56eaf7f4b1bb81e3deed55711dd2ee78f244a3cc0ad4bb7a1f09d97e46f9793f
   md5: c24a3daed1e85ba7a100fa6966c5bb48
   depends:
@@ -6256,7 +6256,7 @@ packages:
   license_family: BSD
   size: 189021
   timestamp: 1698263520538
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
   sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
   md5: 427c1450bebb632f43bbc8c83006e4cd
   depends:
@@ -6275,7 +6275,7 @@ packages:
   license_family: Other
   size: 806931
   timestamp: 1696580240310
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
   sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
   md5: 21790cd3e2b8a45c4104aff0a68330d0
   depends:
@@ -6286,7 +6286,7 @@ packages:
   license_family: MIT
   size: 3001751
   timestamp: 1697549357662
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
   sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
   md5: 56f44a1054da2d10777e375838191070
   depends:
@@ -6295,7 +6295,7 @@ packages:
   license_family: MIT
   size: 32355
   timestamp: 1692205784293
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
   sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
   md5: 8a35ad65651086575ce55371f22feda8
   depends:
@@ -6304,7 +6304,7 @@ packages:
   license_family: Apache
   size: 91045
   timestamp: 1659455316472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
   sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
   md5: 186eb95f816a2eff80c3c7f7d964c7b0
   depends:
@@ -6316,7 +6316,7 @@ packages:
   license_family: BSD
   size: 578514
   timestamp: 1672388155359
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
   sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
   md5: 47b6cbe6ce9289e47d16900b03596a91
   depends:
@@ -6327,7 +6327,7 @@ packages:
   license_family: BSD
   size: 372807
   timestamp: 1656431445633
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
   sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
   md5: 07165c444adc7c7ccc8a345875adc5ef
   depends:
@@ -6339,7 +6339,7 @@ packages:
   license_family: BSD
   size: 48408
   timestamp: 1675450623287
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
   sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
   md5: d58e76a31e2f6e7410ba4afd7f385b0d
   depends:
@@ -6348,7 +6348,7 @@ packages:
   license_family: BSD
   size: 1877445
   timestamp: 1684280183367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
   sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
   md5: 0e5b0fe7debbf558ce97090f6b67cdae
   depends:
@@ -6358,7 +6358,7 @@ packages:
   license_family: Apache
   size: 94633
   timestamp: 1690225630423
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
   sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
   md5: 0fde797653e4ab589506121fb1e37555
   depends:
@@ -6367,7 +6367,7 @@ packages:
   license_family: MIT
   size: 157119
   timestamp: 1661452591647
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
   sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
   md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
   depends:
@@ -6378,7 +6378,7 @@ packages:
   license_family: MIT
   size: 92679
   timestamp: 1636093365041
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
   sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
   md5: f870859d4dc7a8d82cf3546bd9035f33
   depends:
@@ -6388,7 +6388,7 @@ packages:
   license_family: BSD
   size: 54520
   timestamp: 1605307564142
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
   sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
   md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
   depends:
@@ -6401,7 +6401,7 @@ packages:
   license_family: PSF
   size: 21172845
   timestamp: 1694442462066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
   sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
   md5: 9d99075052265ae3d718582d3b875038
   depends:
@@ -6410,7 +6410,7 @@ packages:
   license_family: BSD
   size: 269964
   timestamp: 1661376543480
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
   sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
   md5: fa9074d94236c9b768bfd2c858875b27
   depends:
@@ -6419,7 +6419,7 @@ packages:
   license_family: MIT
   size: 264836
   timestamp: 1695131770282
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
   sha256: 97243a31c39f4990c0e9d4f2307f2f7fb9421553303923bc105067ec4340bdff
   md5: 8078c5760f27398eaf1082226647d137
   depends:
@@ -6429,7 +6429,7 @@ packages:
   license_family: BSD
   size: 40145
   timestamp: 1685031143383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
   sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
   md5: 3d2841085778006c2e79f9c7300f8b9d
   depends:
@@ -6439,7 +6439,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13565975
   timestamp: 1669937633869
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
   sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
   md5: 54a4bc0724041dd173088419d6ede2af
   depends:
@@ -6451,7 +6451,7 @@ packages:
   license_family: MIT
   size: 239062
   timestamp: 1677611495106
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
   sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
   md5: f39f84115e228bad4bceaefdd637f022
   depends:
@@ -6463,7 +6463,7 @@ packages:
   license_family: MIT
   size: 158558
   timestamp: 1698096358091
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
   sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
   md5: df398a3a1668fd2a22061764e20ea91d
   depends:
@@ -6475,7 +6475,7 @@ packages:
   license_family: BSD
   size: 460913
   timestamp: 1657616061604
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
   sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
   md5: 38db77ece9dc76feffb9ef7638e38258
   depends:
@@ -6491,7 +6491,7 @@ packages:
   license_family: Apache
   size: 94397
   timestamp: 1690400496655
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
   sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
   md5: 3e284ae6b48ee30c364ffdc5601610b0
   depends:
@@ -6500,7 +6500,7 @@ packages:
   license_family: MIT
   size: 1099842
   timestamp: 1690291374842
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
   sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
   md5: 993b3886b334bd1f49d34206f21997b4
   depends:
@@ -6509,7 +6509,7 @@ packages:
   license_family: Apache
   size: 15998
   timestamp: 1614030572433
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
   sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
   md5: 7ac9604ad7564ac0c71bff5db198656f
   depends:
@@ -6518,7 +6518,7 @@ packages:
   license_family: MIT
   size: 67012
   timestamp: 1696347795139
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
   sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
   md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
   depends:
@@ -6528,7 +6528,7 @@ packages:
   license_family: Other
   size: 1311308
   timestamp: 1681402905668
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -6538,7 +6538,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
   sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
   md5: 28b9869d8d3a839918fac4a08f38cbc2
   depends:
@@ -6549,7 +6549,7 @@ packages:
   license_family: BSD
   size: 30546
   timestamp: 1671752127904
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
   sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
   md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
   depends:
@@ -6559,7 +6559,7 @@ packages:
   license_family: BSD
   size: 39590
   timestamp: 1668168880994
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
   sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
   md5: 52cdcdb96383c010ca833a7c24b3935b
   depends:
@@ -6569,7 +6569,7 @@ packages:
   license_family: BSD
   size: 3690152
   timestamp: 1654036853710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
   sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
   md5: 0e054ab29119cf4c1f778613acf972f9
   depends:
@@ -6580,7 +6580,7 @@ packages:
   license_family: Apache
   size: 681780
   timestamp: 1696937326924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
   sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
   md5: b6ad839ebba536ad1c3cc58d0e2123f0
   depends:
@@ -6594,7 +6594,7 @@ packages:
   license_family: MOZILLA
   size: 143681
   timestamp: 1679562248929
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
   sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
   md5: fe78de10019085146f1cc6c94fdc2620
   depends:
@@ -6603,7 +6603,7 @@ packages:
   license_family: BSD
   size: 192822
   timestamp: 1671143999327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
   md5: ca5fc3fbdb09b6de068a8b7a8869369f
   depends:
@@ -6613,7 +6613,7 @@ packages:
   license_family: PSF
   size: 9208
   timestamp: 1690298120549
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
   md5: a86e87a10e5fdff486265e0c675fb99f
   depends:
@@ -6622,7 +6622,7 @@ packages:
   license_family: PSF
   size: 57922
   timestamp: 1690298106990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
   sha256: 8057d3d2a0acd44496de33c5b222063c3f7d06b90c74fbbda45bd18b0b324219
   md5: 398f8db5bd8cab84b3d85a9d85fa4889
   depends:
@@ -6631,7 +6631,7 @@ packages:
   license_family: MIT
   size: 11362
   timestamp: 1659769459206
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
   sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
   md5: 0d31859e0a097aedbcc1627db33b3d92
   depends:
@@ -6646,7 +6646,7 @@ packages:
   license_family: MIT
   size: 188367
   timestamp: 1698257883295
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
   sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
   md5: 45ef24c486a484f079faf1dc90e4c7e9
   depends:
@@ -6655,12 +6655,12 @@ packages:
   license_family: BSD
   size: 8277
   timestamp: 1605602889180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
   sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
   md5: 4daaceb6cfc1af6274509081d8018ef1
   size: 2316783
   timestamp: 1605602872095
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
   sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
   md5: 916c16904615c7af3b5d37cb6694f45e
   depends:
@@ -6669,7 +6669,7 @@ packages:
   license_family: BSD
   size: 21084
   timestamp: 1607347371925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
   sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
   md5: da69e6987fcc757e83a358ceaa13f62b
   depends:
@@ -6679,7 +6679,7 @@ packages:
   license_family: BSD
   size: 73391
   timestamp: 1614804425587
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
   sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
   md5: 23b9f4634b2e5450be617114f62c74f9
   depends:
@@ -6688,7 +6688,7 @@ packages:
   license_family: MIT
   size: 120873
   timestamp: 1695742300539
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
   sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
   md5: 120f0b088290fc17bd6618fc10a2f0c4
   depends:
@@ -6696,13 +6696,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 34293
   timestamp: 1605306211299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
   sha256: a5d2a216d052105fdaad7256f23da3b29f95100d1dc0f29b6ab1f3bbc75e17a9
   md5: a558f681ebc243f86cde2515c065b62e
   depends:
@@ -6711,7 +6711,7 @@ packages:
   license_family: BSD
   size: 48805
   timestamp: 1675159123654
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
   sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
   md5: c3f7871e9a33adeccee1b1e8e216918e
   depends:
@@ -6721,7 +6721,7 @@ packages:
   license_family: GPL2
   size: 1332571
   timestamp: 1683113347814
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -6730,7 +6730,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
   sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
   md5: 1ab55f8c4b5292ec360c572120bf823e
   depends:
@@ -6740,7 +6740,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 9430705
   timestamp: 1616055773485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
   sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
   md5: 6875e0bf3828707dc9165d694c0d0a7d
   depends:
@@ -6749,7 +6749,7 @@ packages:
   license_family: MIT
   size: 18725
   timestamp: 1672387612937
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
   sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
   md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
   depends:
@@ -6759,7 +6759,7 @@ packages:
   license_family: Other
   size: 148931
   timestamp: 1666595229032
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
   sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
   md5: 8d6a1e767775fe0eb617cd6e22edc2ff
   depends:

--- a/lsystems/pixi.toml
+++ b/lsystems/pixi.toml
@@ -1,0 +1,31 @@
+[workspace]
+name = "lsystems"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2019-06-10"
+maintainers = ["jlstevens"]
+categories = ["Mathematics"]
+labels = ["holoviews", "bokeh"]
+title = "L-systems"
+description = "Lindenmayer system - a mathematical system used to describe growth processes"
+no_data_ingestion = true
+
+[dependencies]
+python = "3.9.*"
+notebook = "*"
+holoviews = "*"
+numpy = "*"
+bokeh = "*"
+pandas = "*"
+param = "*"
+pip = "*"
+setuptools = "*"
+wheel = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks]
+notebook = "jupyter notebook lsystems.ipynb"

--- a/lsystems/pixi.toml
+++ b/lsystems/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "lsystems"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/lsystems/pixi.toml
+++ b/lsystems/pixi.toml
@@ -20,12 +20,12 @@ numpy = "*"
 bokeh = "*"
 pandas = "*"
 param = "*"
-pip = "*"
-setuptools = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+setuptools = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks]
 notebook = "jupyter notebook lsystems.ipynb"

--- a/ml_annotators/pixi.lock
+++ b/ml_annotators/pixi.lock
@@ -1,0 +1,7202 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py310h2372a71_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.5-h0f2a231_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py310hc6cd4ac_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.20.1-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.7.22-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.22.0-py310hcc13569_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py310h2fee648_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.3-py310h1f7b6fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.1.1-py310hd41b1e2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.0-py310hc6cd4ac_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.43.1-py310h2372a71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.12.0-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.2-nompi_h4f84152_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-2.4-py310hff52083_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-5.5.0-py310hff52083_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.5-py310hd41b1e2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.15-hb7c19ff_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.2-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-19_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-19_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.4.0-hca28451_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.19-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-19_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h80fb2b6_112.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.55.1-h47da74e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.24-pthreads_h413a1c8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.39-h753d276_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.44.0-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-ha9c0a0a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.11.5-h232c23b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.10.1-h2629f0a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.40.1-py310h1b8f574_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py310h2372a71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.8.1-py310h62c0568_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.6.5-nompi_py310hba70d50_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.57.1-py310h0f6aa51_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.24.4-py310ha4c1d20_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.0-h488ebb8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.4-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.1.2-py310hcc13569_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.1.0-py310h01dd4db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.3.0-h1d62c97_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py310h2372a71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.6.1-py310h32c33b7_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.13-hd12c33a_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-4_cp310.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py310h2372a71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-25.1.1-py310h795f18f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.10.6-py310hcb5633a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.11.3-py310hb13e2d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.2-py310h7dcad9a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.44.0-h2c6b66d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.3.3-py310h2372a71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py310h2372a71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.13.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.10.0-pyhca7485f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.10.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.26.0-pyhf8b6a83_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh41d4057_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.9.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.0.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-1.13.0-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-core-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh41d4057_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyh41d4057_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.13.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.13.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.10.0-pyhca7485f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.10.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.26.0-pyh3cd1d5f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.9.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.0.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-1.13.0-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-core-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyhd1c38e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyhd1c38e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.13.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py310h6729b98_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.5-heccf04b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py310h9e9d8ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.20.1-h10d778d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2023.7.22-h8857fd0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cartopy-0.22.0-py310hdba192b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.16.0-py310hdca579f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cftime-1.6.3-py310h91862f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.1.1-py310h88cfcbd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.0-py310h9e9d8ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.43.1-py310hb372a2b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.12.0-he965462_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.2-nompi_hedada53_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-2.4-py310h2ec42d9_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jupyter_core-5.5.0-py310h2ec42d9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.5-py310h88cfcbd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.2-hb884880_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.15-hd6ba6f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.2-he965462_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-19_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-19_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.4.0-h726d00d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.6-hd57cbcb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.19-ha4e1b8e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-haf1e3a3_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hac89ed1_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-19_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-hc8e404f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.2-nompi_h6a32802_112.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.55.1-hc0a10c5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.24-openmp_h48a4ad5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.39-ha978bb4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.18-hbcb3906_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.44.0-h92b6c6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h684deea_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.3.2-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.15-hb7f2c08_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.11.5-h3346baf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzip-1.10.1-hc158999_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-17.0.4-hb6ac08f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.41.1-py310h7d48a1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.3-py310h6729b98_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.8.1-py310hec49e92_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-h93d8f39_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/netcdf4-1.6.5-nompi_py310h30a4ba5_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.25.2-py310h7451ae0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.0-ha4da562_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.1.4-hd75f5a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.1.2-py310hdba192b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.1.0-py310he65384d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.3.0-h23b96cc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.5-py310h6729b98_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.0-py310hef2d279_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.0-py310hef2d279_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.6.1-py310h7e62555_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.10.13-h00d2728_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.10-4_cp310.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.1-py310h6729b98_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-25.1.1-py310hd8b4af3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.10.6-py310h0e083fb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.11.3-py310h2db466d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.2-py310hcbf9397_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.44.0-h7461747_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.10.0-h1c7c39f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hef22860_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.3.3-py310h6729b98_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-15.1.0-py310h6729b98_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h93d8f39_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.58.0-py310h3ea8b11_0.tar.bz2
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.13.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.10.0-pyhca7485f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.10.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.26.0-pyh3cd1d5f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.9.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.0.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-1.13.0-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-core-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyhd1c38e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyhd1c38e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.13.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py310h2aa6e3c_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.5-hc338f07_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py310h1253130_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h3422bc3_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.20.1-h93a5062_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.7.22-hf0a4a13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cartopy-0.22.0-py310h6e3cc31_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.16.0-py310hdcd7c05_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.3-py310h50ce23c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.1.1-py310h38f39d4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.0-py310h1253130_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.43.1-py310hd125d64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.12.0-h13dd4ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.2-nompi_h3aba7b3_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-2.4-py310hbe9552e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jupyter_core-5.5.0-py310hbe9552e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.5-py310h38f39d4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.2-h92f50d5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.15-hf2736f0_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.2-h13dd4ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-19_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-19_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.4.0-h2d989ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.6-h4653b0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.19-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h642e427_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-he4db4b2_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-19_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnetcdf-4.9.2-nompi_hb2fb864_112.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.55.1-h2b02ca0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.24-openmp_hd76b1f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.39-h76d750c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.18-h27ca646_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.44.0-h091b4b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.6.0-ha8a6c65_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.3.2-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.15-hf346824_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.11.5-h25269f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzip-1.10.1-ha0bc3c6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-17.0.4-hcd81f8e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.41.1-py310hf7687f1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.3-py310h2aa6e3c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.8.1-py310h9d2df84_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h463b476_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/netcdf4-1.6.5-nompi_py310h3aafd6c_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.25.2-py310haa1e00c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.0-h4c1507b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.1.4-h0d3ecfb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.1.2-py310h6e3cc31_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.1.0-py310hfae7ebd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.3.0-h52fb9d0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.5-py310h2aa6e3c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.0-py310hd07e440_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.0-py310hd07e440_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.6.1-py310h2de6d0e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.13-h2469fbe_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.10-4_cp310.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.1-py310h2aa6e3c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-25.1.1-py310h7e65269_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.10.6-py310hd442715_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.11.3-py310hd1cfc7d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.2-py310h656ff59_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.44.0-hf2abe2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.10.0-h1995070_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hb31c410_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.3.3-py310h2aa6e3c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-15.1.0-py310h2aa6e3c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h965bd2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.58.0-py310h46d7db6_0.tar.bz2
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.13.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.10.0-pyhca7485f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.10.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.26.0-pyha63f2e9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh5737063_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.9.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.0.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-1.13.0-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-core-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh08f2357_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.0-pyh08f2357_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.13.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyhd8ed1ab_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2023.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py310h8d17308_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.5-hdccc3a2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py310h00ffb61_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h8ffe710_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.7.22-h56e8100_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cartopy-0.22.0-py310hecd3228_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.16.0-py310h8d17308_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cftime-1.6.3-py310h3e78b6c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.1.1-py310h232114e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.0-py310h00ffb61_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.43.1-py310h8d17308_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.12.0-h1537add_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.2-nompi_h73e8ff5_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2023.2.0-h57928b3_50497.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-2.4-py310h5588dad_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jupyter_core-5.5.0-py310h5588dad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.5-py310h232114e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.15-h67d730c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.2-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-19_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-19_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.4.0-hd5e4a3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.19-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-h8ffe710_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-19_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_h8284064_112.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.39-h19919ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.18-h8d14728_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.44.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-h6e2ebb7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.3.2-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.15-hcd874cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.11.5-hc3477c8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzip-1.10.1-h1d365fa_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.41.1-py310hb84602e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.3-py310h8d17308_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.8.1-py310hc9baf74_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2023.2.0-h6a75c08_50496.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/netcdf4-1.6.5-nompi_py310h6477780_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.25.2-py310hd02465a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.0-h3d672ee_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.1.4-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.1.2-py310hecd3228_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-10.1.0-py310h1e6a543_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.3.0-he13c7e8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.5-py310h8d17308_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-hcd874cb_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.6.1-py310hebb2149_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.10.13-h4de0772_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.10-4_cp310.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-306-py310h00ffb61_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.12-py310h00ffb61_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.1-py310h8d17308_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-25.1.1-py310h2849c00_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.10.6-py310h87d50f1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.11.3-py310hf667824_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.2-py310h839b4a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.44.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.10.0-h91493d7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.3.3-py310h8d17308_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-15.1.0-py310h8d17308_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h64f974e_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.36.32532-hdcecf7f_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.36.32532-h05e6639_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-hcd874cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.3-hcd874cb_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.2.13-hcfcfb64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.58.0-py310h4ed8f06_0.tar.bz2
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  license: None
+  size: 2562
+  timestamp: 1578324546067
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23621
+  timestamp: 1650670423406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py310h2372a71_4.conda
+  sha256: af94cc9b4dcaa164e1cc7e7fa0b9eb56b87ea3dc6e093c8ef6c31cfa02d9ffdf
+  md5: 68ee85860502d53c8cbfa0e4cef0f6cb
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 34384
+  timestamp: 1695386695142
+- conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.5-h0f2a231_0.conda
+  sha256: e2b15b017775d1bda8edbb1bc48e545e45364edefa4d926732fc5488cc600731
+  md5: 009521b7ed97cca25f8f997f9e745976
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48692
+  timestamp: 1693657088079
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hd590300_1.conda
+  sha256: f2d918d351edd06c55a6c2d84b488fe392f85ea018ff227daac07db22b408f6b
+  md5: f27a24d46e3ea7b70a1f98e50c62508f
+  depends:
+  - brotli-bin 1.1.0 hd590300_1
+  - libbrotlidec 1.1.0 hd590300_1
+  - libbrotlienc 1.1.0 hd590300_1
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 19383
+  timestamp: 1695990069230
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hd590300_1.conda
+  sha256: a641abfbaec54f454c8434061fffa7fdaa9c695e8a5a400ed96b4f07c0c00677
+  md5: 39f910d205726805a958da408ca194ba
+  depends:
+  - libbrotlidec 1.1.0 hd590300_1
+  - libbrotlienc 1.1.0 hd590300_1
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 18980
+  timestamp: 1695990054140
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py310hc6cd4ac_1.conda
+  sha256: e22268d81905338570786921b3def88e55f9ed6d0ccdd17d9fbae31a02fbef69
+  md5: 1f95722c94f00b69af69a066c7433714
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - libbrotlicommon 1.1.0 hd590300_1
+  license: MIT
+  license_family: MIT
+  size: 349397
+  timestamp: 1695990295884
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2
+  sha256: cb521319804640ff2ad6a9f118d972ed76d86bea44e5626c09a13d38f562e1fa
+  md5: a1fd65c7ccbf10880423d82bca54eb54
+  depends:
+  - libgcc-ng >=9.3.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 495686
+  timestamp: 1606604745109
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.20.1-hd590300_1.conda
+  sha256: 1700d9ebfd3b21c8b50e12a502f26e015719e1f3dbb5d491b5be061cf148ca7a
+  md5: 2facbaf5ee1a56967aecaee89799160e
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 115956
+  timestamp: 1697955875024
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.7.22-hbcca054_0.conda
+  sha256: 525b7b6b5135b952ec1808de84e5eca57c7c7ff144e29ef3e96ae4040ff432c1
+  md5: a73ecd2988327ad4c8f2c331482917f2
+  license: ISC
+  size: 149515
+  timestamp: 1690026108541
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.22.0-py310hcc13569_1.conda
+  sha256: ec73372b3945634920c115f9d04b4543cc2d459c583df329aa32be813ca21380
+  md5: 31ef447724fb19066a9d00a660dab1bd
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - matplotlib-base >=3.4
+  - numpy >=1.22.4,<2.0a0
+  - packaging >=20
+  - pyproj >=3.1.0
+  - pyshp >=2.1
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - shapely >=1.7
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 1827530
+  timestamp: 1698172887001
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py310h2fee648_0.conda
+  sha256: 007e7f69ab45553b7bf11f2c1b8d3f3a13fd42997266a0d57795f41c7d38df36
+  md5: 45846a970e71ac98fd327da5d40a0a2c
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - pycparser
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 241339
+  timestamp: 1696001848492
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.3-py310h1f7b6fc_0.conda
+  sha256: 0983d88068e4bd589031582769ef7d05617edda3a7daa1f4847492f4c3538aad
+  md5: 31beda75384647959d5792a1a7dc571a
+  depends:
+  - libgcc-ng >=12
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 246545
+  timestamp: 1698610101048
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.1.1-py310hd41b1e2_1.conda
+  sha256: 16f44e7e47f7cf9c3c02d760beb9179698510740e0eb1927ade3d8fb69aa1a0d
+  md5: 6a38f65d330b74495ad6990280486049
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.16
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 223840
+  timestamp: 1695554349041
+- conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.0-py310hc6cd4ac_1.conda
+  sha256: 77593f7b60d8f3b4d27a97a1b9e6c07c3f2490cfab77039d5e403166448b5de2
+  md5: 01388b4ec9eed3b26fa732aa39745475
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 2436014
+  timestamp: 1695534502620
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.43.1-py310h2372a71_0.conda
+  sha256: 66f89ff0c0e6cd9940e866b04f5442b4ab802d5d279012c5eb13c639cf18da76
+  md5: c7d552c32b87beb736c9658441bf93a9
+  depends:
+  - brotli
+  - libgcc-ng >=12
+  - munkres
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - unicodedata2 >=14.0.0
+  license: MIT
+  license_family: MIT
+  size: 2234075
+  timestamp: 1696601395340
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+  sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
+  md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 634972
+  timestamp: 1694615932610
+- conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.12.0-h59595ed_0.conda
+  sha256: c80ff0ed71db0d56567ee87df28bc442b596330ac241ab86f488e3139f0e2cae
+  md5: 3fdf79ef322c8379ae83be491d805369
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LGPL-2.1-only
+  size: 1731484
+  timestamp: 1687938888266
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
+  sha256: 0d09b6dc1ce5c4005ae1c6a19dc10767932ef9a5e9c755cfdbb5189ac8fb0684
+  md5: bd77f8da987968ec3927990495dc22e4
+  depends:
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 756742
+  timestamp: 1695661547874
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.2-nompi_h4f84152_100.conda
+  sha256: f70f18291f912ba019cbb736bb87b6487021154733cd109147a6d9672790b6b8
+  md5: 2de6a9bc8083b49f09b2f6eb28d3ba3c
+  depends:
+  - libaec >=1.0.6,<2.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  license: LicenseRef-HDF5
+  license_family: BSD
+  size: 3726636
+  timestamp: 1692563074131
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
+  sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
+  md5: cc47e1facc155f91abd89b11e48e72ff
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 12089150
+  timestamp: 1692900650789
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-2.4-py310hff52083_3.conda
+  sha256: 316db08863469a56cdbfd030de5a2cc11ec7649ed7c50eff507e9caa0070ccaa
+  md5: 08ec1463dbc5c806a32fc431874032ca
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16170
+  timestamp: 1695397381208
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-5.5.0-py310hff52083_0.conda
+  sha256: 35e05ff1ad8b070b1378886c5ee4b82a000ea078494af6d0552d1c455b3f6220
+  md5: 9ca8f0d07c512cef3fd07b121bb2b023
+  depends:
+  - platformdirs >=2.5
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 79275
+  timestamp: 1698673792929
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+  sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
+  md5: 30186d27e2c9fa62b45fb1476b7200e3
+  depends:
+  - libgcc-ng >=10.3.0
+  license: LGPL-2.1-or-later
+  size: 117831
+  timestamp: 1646151697040
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.5-py310hd41b1e2_1.conda
+  sha256: bb51906639bced3de1d4d7740ac284cdaa89e2f22e0b1ec796378b090b0648ba
+  md5: b8d67603d43b23ce7e988a5d81a7ab79
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73123
+  timestamp: 1695380074542
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
+  sha256: 259bfaae731989b252b7d2228c1330ef91b641c9d68ff87dae02cbae682cb3e4
+  md5: cd95826dbd331ed1be26bdf401432844
+  depends:
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.1.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1371181
+  timestamp: 1692097755782
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.15-hb7c19ff_3.conda
+  sha256: cc0b2ddab52b20698b26fe8622ebe37e0d462d8691a1f324e7b00f7d904765e3
+  md5: e96637dd92c5f340215c753a5c9a22d7
+  depends:
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 239723
+  timestamp: 1695969712554
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+  sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
+  md5: 7aca3059a1729aa76c597603f10b0dd3
+  constrains:
+  - binutils_impl_linux-64 2.40
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 704696
+  timestamp: 1674833944779
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+  sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
+  md5: 76bbff344f0134279f225174e9064c8f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 281798
+  timestamp: 1657977462600
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.2-h59595ed_1.conda
+  sha256: fdde15e74dc099ab1083823ec0f615958e53d9a8fae10405af977de251668bea
+  md5: 127b0be54c1c90760d7fe02ea7a56426
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 35228
+  timestamp: 1696474021700
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-19_linux64_openblas.conda
+  sha256: b1311b9414559c5760b08a32e0382ca27fa302c967968aa6f78e042519f728ce
+  md5: 420f4e9be59d0dc9133a0f43f7bab3f3
+  depends:
+  - libopenblas >=0.3.24,<0.3.25.0a0
+  - libopenblas >=0.3.24,<1.0a0
+  constrains:
+  - blas * openblas
+  - libcblas 3.9.0 19_linux64_openblas
+  - liblapack 3.9.0 19_linux64_openblas
+  - liblapacke 3.9.0 19_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14566
+  timestamp: 1697484219912
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
+  sha256: 40f29d1fab92c847b083739af86ad2f36d8154008cf99b64194e4705a1725d78
+  md5: aec6c91c7371c26392a06708a73c70e5
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 69403
+  timestamp: 1695990007212
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
+  sha256: 86fc861246fbe5ad85c1b6b3882aaffc89590a48b42d794d3d5c8e6d99e5f926
+  md5: f07002e225d7a60a694d42a7bf5ff53f
+  depends:
+  - libbrotlicommon 1.1.0 hd590300_1
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 32775
+  timestamp: 1695990022788
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
+  sha256: f751b8b1c4754a2a8dfdc3b4040fa7818f35bbf6b10e905a47d3a194b746b071
+  md5: 5fc11c6020d421960607d821310fcd4d
+  depends:
+  - libbrotlicommon 1.1.0 hd590300_1
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 282523
+  timestamp: 1695990038302
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-19_linux64_openblas.conda
+  sha256: 84fddccaf58f42b07af7fb42512bd617efcb072f17bdef27f4c1884dbd33c86a
+  md5: d12374af44575413fbbd4a217d46ea33
+  depends:
+  - libblas 3.9.0 19_linux64_openblas
+  constrains:
+  - blas * openblas
+  - liblapack 3.9.0 19_linux64_openblas
+  - liblapacke 3.9.0 19_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14458
+  timestamp: 1697484230827
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.4.0-hca28451_0.conda
+  sha256: 25f4b6a8827d7b17a66e0bd9b5d194bf9a9e4a46fb14e2ef472fdad4b39426a6
+  md5: 1158ac1d2613b28685644931f11ee807
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libgcc-ng >=12
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 386160
+  timestamp: 1697009208544
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.19-hd590300_0.conda
+  sha256: 985ad27aa0ba7aad82afa88a8ede6a1aacb0aaca950d710f15d85360451e72fd
+  md5: 1635570038840ee3f9c71d22aa5b8b6d
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 67080
+  timestamp: 1694922285678
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+  sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
+  md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 123878
+  timestamp: 1597616541093
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2
+  sha256: 8c9635aa0ea28922877dc96358f9547f6a55fc7e2eb75a556b05f1725496baf9
+  md5: 6f8720dff19e17ce5d48cfe7f3d2f0a3
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 106190
+  timestamp: 1598867915000
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+  sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+  md5: d645c6d2ac96843a2bfaccd2d62b3ac3
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 58292
+  timestamp: 1636488182923
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_2.conda
+  sha256: d361d3c87c376642b99c1fc25cddec4b9905d3d9b9203c1c545b8c8c1b04539a
+  md5: c28003b0be0494f9a7664389146716ff
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 13.2.0 h807b86a_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 771133
+  timestamp: 1695219384393
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_2.conda
+  sha256: 767d71999e5386210fe2acaf1b67073e7943c2af538efa85c101e3401e94ff62
+  md5: e75a75a6eaf6f318dae2631158c46575
+  depends:
+  - libgfortran5 13.2.0 ha4646dd_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 23722
+  timestamp: 1695219642066
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_2.conda
+  sha256: 55ecf5c46c05a98b4822a041d6e1cb196a7b0606126eb96b24131b7d2c8ca561
+  md5: 78fdab09d9138851dde2b5fe2a11019e
+  depends:
+  - libgcc-ng >=13.2.0
+  constrains:
+  - libgfortran-ng 13.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1441830
+  timestamp: 1695219403435
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_2.conda
+  sha256: e1e82348f8296abfe344162b3b5f0ddc2f504759ebeb8b337ba99beaae583b15
+  md5: e2042154faafe61969556f28bade94b9
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 421133
+  timestamp: 1695219303065
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-h166bdaf_0.tar.bz2
+  sha256: 6a81ebac9f1aacdf2b4f945c87ad62b972f0f69c8e0981d68e111739e6720fd7
+  md5: b62b52da46c39ee2bc3c162ac7f1804d
+  depends:
+  - libgcc-ng >=10.3.0
+  license: GPL and LGPL
+  size: 1450368
+  timestamp: 1652700749886
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+  sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
+  md5: ea25936bb4080d843790b586850f82b8
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 618575
+  timestamp: 1694474974816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-19_linux64_openblas.conda
+  sha256: 58f402aae605ebd0932e1cbbf855cd49dcdfa2fcb6aab790a4f6068ec5937878
+  md5: 9f100edf65436e3eabc2a51fc00b2c37
+  depends:
+  - libblas 3.9.0 19_linux64_openblas
+  constrains:
+  - blas * openblas
+  - libcblas 3.9.0 19_linux64_openblas
+  - liblapacke 3.9.0 19_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14487
+  timestamp: 1697484241613
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
+  sha256: 225cc7c3b20ac1db1bdb37fa18c95bf8aecef4388e984ab2f7540a9f4382106a
+  md5: 73301c133ded2bf71906aa2104edae8b
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 31484415
+  timestamp: 1690557554081
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h80fb2b6_112.conda
+  sha256: 305ffc3ecaffce10754e4d057daa9803e8dc86d68b14524a791c7dc5598c1d2f
+  md5: a19fa6cacf80c8a366572853d5890eb4
+  depends:
+  - blosc >=1.21.4,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - libaec >=1.0.6,<2.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.11.5,<2.14.0a0
+  - libzip >=1.10.1,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  - zlib
+  - zstd >=1.5.5,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 848361
+  timestamp: 1693581687090
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.55.1-h47da74e_0.conda
+  sha256: 5e60b852dbde156ef1fa939af2491fe0e9eb3000de146786dede7cda8991ae4c
+  md5: a802251d1eaeeae041c867faf0f94fa8
+  depends:
+  - c-ares >=1.20.1,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.4,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 627864
+  timestamp: 1698429073582
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+  sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+  md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  license_family: GPL
+  size: 33408
+  timestamp: 1697359010159
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.24-pthreads_h413a1c8_0.conda
+  sha256: c8e080ae4d57506238023e98869928ae93564e6407ef5b0c4d3a337e8c2b7662
+  md5: 6e4ef6ca28655124dcde9bd500e44c32
+  depends:
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  constrains:
+  - openblas >=0.3.24,<0.3.25.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5492091
+  timestamp: 1693785223074
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.39-h753d276_0.conda
+  sha256: a32b36d34e4f2490b99bddbc77d01a674d304f667f0e62c89e02c961addef462
+  md5: e1c890aebdebbfbf87e2c917187b4416
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: zlib-acknowledgement
+  size: 282599
+  timestamp: 1669075729952
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
+  sha256: 53da0c8b79659df7b53eebdb80783503ce72fb4b10ed6e9e05cc0e9e4207a130
+  md5: c3788462a6fbddafdb413a9f9053e58d
+  depends:
+  - libgcc-ng >=7.5.0
+  license: ISC
+  size: 374999
+  timestamp: 1605135674116
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.44.0-h2797004_0.conda
+  sha256: 74ef5dcb900c38bec53140036e5e2a9cc7ffcd806da479ea2305f962a358a259
+  md5: b58e6816d137f3aabf77d341dd5d732b
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Unlicense
+  size: 845977
+  timestamp: 1698854720770
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+  sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
+  md5: 1f5a58e686b13bcfde88b93f547d23fe
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 271133
+  timestamp: 1685837707056
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_2.conda
+  sha256: ab22ecdc974cdbe148874ea876d9c564294d5eafa760f403ed4fd495307b4243
+  md5: 9172c297304f2a20134fc56c97fbe229
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3842773
+  timestamp: 1695219454837
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-ha9c0a0a_2.conda
+  sha256: 45158f5fbee7ee3e257e6b9f51b9f1c919ed5518a94a9973fe7fa4764330473e
+  md5: 55ed21669b2015f77c180feb1dd41930
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.19,<1.26.0a0
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: HPND
+  size: 283198
+  timestamp: 1695661593314
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33601
+  timestamp: 1680112270483
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
+  sha256: 68764a760fa81ef35dacb067fe8ace452bbb41476536a4a147a1051df29525f0
+  md5: 30de3fd9b3b602f7473f30e684eeea8c
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 401830
+  timestamp: 1694709121323
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
+  sha256: a670902f0a3173a466c058d2ac22ca1dd0df0453d3a80e0212815c20a16b0485
+  md5: 33277193f5b92bad9fdd230eb700929c
+  depends:
+  - libgcc-ng >=12
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 384238
+  timestamp: 1682082368177
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.11.5-h232c23b_1.conda
+  sha256: 1b3cb6864de1a558ea5fb144c780121d52507837d15df0600491d8ed92cff90c
+  md5: f3858448893839820d4bcfb14ad3ecdf
+  depends:
+  - icu >=73.2,<74.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 705542
+  timestamp: 1692960341690
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.10.1-h2629f0a_3.conda
+  sha256: 84e93f189072dcfcbe77744f19c7e4171523fbecfaba7352e5a23bbe014574c7
+  md5: ac79812548e7e8cf61f7b0abdef01d3b
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 107198
+  timestamp: 1694416433629
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+  sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
+  md5: f36c115f1ee199da648e0597ec2047ad
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - zlib 1.2.13 *_5
+  license: Zlib
+  license_family: Other
+  size: 61588
+  timestamp: 1686575217516
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.40.1-py310h1b8f574_0.conda
+  sha256: 284462f15daa742e48dee4a103b5de1bee3e0fcddf5f60ca5510e3ca47dbc2e0
+  md5: 610577f6de29686bca87a4a8fde5eb19
+  depends:
+  - libgcc-ng >=12
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2504766
+  timestamp: 1687806322435
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+  sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
+  md5: 318b08df404f9c9be5712aaa5a6f0bb0
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143402
+  timestamp: 1674727076728
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py310h2372a71_1.conda
+  sha256: ac46cc2f6d4bbeedcd2f508e43f43143a9286ced55730d8d97a3c91ceceb0d56
+  md5: b74e07a054c479e45a83a83fc5be713c
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24054
+  timestamp: 1695367637074
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.8.1-py310h62c0568_0.conda
+  sha256: 615197c8b2b816aa1f7874319bd41acb134fcb9cd55e7337563295c8ced0a30e
+  md5: e650bd952e5618050ccb088bc0c6dfb4
+  depends:
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.21,<2
+  - numpy >=1.22.4,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.10.* *_cp310
+  - tk >=8.6.13,<8.7.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 6976980
+  timestamp: 1698868750483
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
+  sha256: 91cc03f14caf96243cead96c76fe91ab5925a695d892e83285461fb927dece5e
+  md5: 7dbaa197d7ba6032caf7ae7f32c1efa0
+  depends:
+  - libgcc-ng >=12
+  license: X11 AND BSD-3-Clause
+  size: 884434
+  timestamp: 1698751260967
+- conda: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.6.5-nompi_py310hba70d50_100.conda
+  sha256: b86677ca301a24ca4ff97fd617851dd2b96aa8e36db8fd493d4dd55703e829f8
+  md5: e19392760c7e4da3b9cb0ee5bf61bc4b
+  depends:
+  - certifi
+  - cftime
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - libgcc-ng >=12
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 549480
+  timestamp: 1698266906302
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.57.1-py310h0f6aa51_0.conda
+  sha256: 4fc115078403e79bcfb1ec9b0649618b6af634e14d57c5172fed1f7bae45dec5
+  md5: 1a9f0067a638463c0f49869cab6a1d3e
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - llvmlite >=0.40.0,<0.41.0a0
+  - numpy >=1.21.6,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - cuda-python >=11.6
+  - cudatoolkit >=10.2
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.25
+  - libopenblas !=0.3.6
+  - cuda-version >=10.2
+  - scipy >=1.0
+  - tbb >=2021.6.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4165304
+  timestamp: 1687805009043
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.24.4-py310ha4c1d20_0.conda
+  sha256: 99d21a8b6c5777320257a74b61f5be3be9f6cb58625265ccb50bd0bddebe3917
+  md5: 6fedacfc835e461b4c37fd8e73712753
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6751237
+  timestamp: 1687808746109
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.0-h488ebb8_3.conda
+  sha256: 9fe91b67289267de68fda485975bb48f0605ac503414dc663b50d8b5f29bc82a
+  md5: 128c25b7fe6a25286a48f3a6a9b5b6f3
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 356698
+  timestamp: 1694708325417
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.4-hd590300_0.conda
+  sha256: d15b3e83ce66c6f6fbb4707f2f5c53337124c01fb03bfda1cf25c5b41123efc7
+  md5: 412ba6938c3e2abaca8b1129ea82e238
+  depends:
+  - ca-certificates
+  - libgcc-ng >=12
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2648006
+  timestamp: 1698164814626
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.1.2-py310hcc13569_0.conda
+  sha256: 657ce7a2c716298483137c54ef40a5afe016af6c4e3164bf313171f26b260f16
+  md5: 775a7709c5b7554340876a6c4a0f6b61
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.10.* *_cp310
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12372502
+  timestamp: 1698376371914
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.1.0-py310h01dd4db_0.conda
+  sha256: dfc6b069006bd1c8dea5ad33f75ead2615ca3eb8255200c31dfa78db435017ef
+  md5: 95d87a906d88b5824d7d36eeef091dba
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 46747967
+  timestamp: 1697423797111
+- conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.3.0-h1d62c97_2.conda
+  sha256: 252f6c31101719e3d524679e69ae81e6323b93b143e1360169bf50e89386bf24
+  md5: b5e57a0c643da391bef850922963eece
+  depends:
+  - libcurl >=8.4.0,<9.0a0
+  - libgcc-ng >=12
+  - libsqlite >=3.43.2,<4.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2960725
+  timestamp: 1697808524668
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py310h2372a71_1.conda
+  sha256: db8a99bc41c1b0405c8e9daa92b9d4e7711f9717aff7fd3feeba407ca2a91aa2
+  md5: cb25177acf28cc35cfa6c1ac1c679e22
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 361313
+  timestamp: 1695367285835
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+  sha256: 67c84822f87b641d89df09758da498b2d4558d47b920fd1d3fe6d3a871e000ff
+  md5: 22dad4df6e8630e8dff2428f6f6a7036
+  depends:
+  - libgcc-ng >=7.5.0
+  license: MIT
+  license_family: MIT
+  size: 5625
+  timestamp: 1606147468727
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.6.1-py310h32c33b7_3.conda
+  sha256: 2ea04581cfed61254d0dd49307a47b86e6e370fa0c233be139f87e5f2e968b40
+  md5: eb106f2a723d1f414a7dad51de4e2924
+  depends:
+  - certifi
+  - libgcc-ng >=12
+  - proj >=9.3.0,<9.3.1.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 525400
+  timestamp: 1698058269674
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.13-hd12c33a_0_cpython.conda
+  sha256: a53410f459f314537b379982717b1c5911efc2f0cc26d63c4d6f831bcb31c964
+  md5: f3a8c32aa764c3e7188b4b810fc9d6ce
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.43.2,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.4,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.10.* *_cp310
+  license: Python-2.0
+  size: 25476977
+  timestamp: 1698344640413
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-4_cp310.conda
+  sha256: 456bec815bfc2b364763084d08b412fdc4c17eb9ccc66a36cb775fa7ac3cbaec
+  md5: 26322ec5d7712c3ded99dd656142b8ce
+  constrains:
+  - python 3.10.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6398
+  timestamp: 1695147363189
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py310h2372a71_1.conda
+  sha256: aa78ccddb0a75fa722f0f0eb3537c73ee1219c9dd46cea99d6b9eebfdd780f3d
+  md5: bb010e368de4940771368bc3dc4c63e7
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 170627
+  timestamp: 1695373587159
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-25.1.1-py310h795f18f_2.conda
+  sha256: 68fa979d6e92ddef0a93d22a4e902383b89db7ca77aab0682272bdeb4b14881a
+  md5: 6391ac95effeebc612023b9507b558b3
+  depends:
+  - libgcc-ng >=12
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  size: 456635
+  timestamp: 1698062566269
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+  sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
+  md5: 47d31b792659ce70f470b5c82fdfb7a4
+  depends:
+  - libgcc-ng >=12
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 281456
+  timestamp: 1679532220005
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.10.6-py310hcb5633a_0.conda
+  sha256: a23d2f15c48cc689d26dc3f50ee91be9ed2925c5fbae7bc5d93e49db7517b847
+  md5: 43c12d8f7891a87378eb5339c49ef051
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 992400
+  timestamp: 1697072452949
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.11.3-py310hb13e2d6_1.conda
+  sha256: bb8cdaf0869979ef58b3c10491f235c0fabf0b091e591361d25a4ffd47d6aded
+  md5: 4260b359d8fbeab4f789a8b0f968079f
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - numpy >=1.22.4,<1.28
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - libopenblas <0.3.26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14983190
+  timestamp: 1696468679504
+- conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.2-py310h7dcad9a_0.conda
+  sha256: dc45ce90e8ebbd7074c05e4003614422ea14de83527582bb2728292a69173615
+  md5: 0d7c35fe5cc1f436e368ddd500deb979
+  depends:
+  - geos >=3.12.0,<3.12.1.0a0
+  - libgcc-ng >=12
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 481789
+  timestamp: 1697191710761
+- conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
+  sha256: 02219f2382b4fe39250627dade087a4412d811936a5a445636b7260477164eac
+  md5: e6d228cd0bb74a51dd18f5bfce0b4115
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38865
+  timestamp: 1678534590321
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.44.0-h2c6b66d_0.conda
+  sha256: ae7031a471868c7057cc16eded7bb58fa3723d9c1650c9d3eb8de1ff65d89dbb
+  md5: df56c636df4a98990462d66ac7be2330
+  depends:
+  - libgcc-ng >=12
+  - libsqlite 3.44.0 h2797004_0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 836571
+  timestamp: 1698854732353
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-h2797004_0.conda
+  sha256: 679e944eb93fde45d0963a22598fafacbb429bb9e7ee26009ba81c4e0c435055
+  md5: 513336054f884f95d9fd925748f41ef3
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3290187
+  timestamp: 1695506262576
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.3.3-py310h2372a71_1.conda
+  sha256: 209b6788b81739d3cdc2f04ad3f6f323efd85b1a30f2edce98ab76d98079fac8
+  md5: b23e0147fa5f7a9380e06334c7266ad5
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: Apache
+  size: 641597
+  timestamp: 1695373710038
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py310h2372a71_0.conda
+  sha256: 5ab2f2d4542ba0cc27d222c08ae61706babe7173b0c6dfa748aa37ff2fa9d824
+  md5: 72637c58d36d9475fda24700c9796f19
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: Apache
+  size: 374055
+  timestamp: 1695848183607
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+  sha256: 309751371d525ce50af7c87811b435c176915239fc9e132b99a25d5e1703f2d4
+  md5: 2c80dc38fface310c9bd81b17037fee5
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 14468
+  timestamp: 1684637984591
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+  sha256: 4df7c5ee11b8686d3453e7f3f4aa20ceef441262b49860733066c52cfd0e4a77
+  md5: be93aabceefa2fac576e971aef407908
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 19126
+  timestamp: 1610071769228
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+  sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+  md5: 2161070d867d1b1204ea749c8eec4ef0
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1 and GPL-2.0
+  size: 418368
+  timestamp: 1660346797927
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+  sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
+  md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 89141
+  timestamp: 1641346969816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h59595ed_0.conda
+  sha256: 53bf2a18224406e9806adb3b270a2c8a028aca0c89bd40114a85d6446f5c98d1
+  md5: 8851084c192dbc56215ac4e3c9aa30fa
+  depends:
+  - libgcc-ng >=12
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=12
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 343455
+  timestamp: 1697056638125
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
+  sha256: 9887a04d7e7cb14bd2b52fa01858f05a6d7f002c890f618d9fcd864adbfecb1b
+  md5: 68c34ec6149623be41a1933ab996a209
+  depends:
+  - libgcc-ng >=12
+  - libzlib 1.2.13 hd590300_5
+  license: Zlib
+  license_family: Other
+  size: 92825
+  timestamp: 1686575231103
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
+  sha256: 607cbeb1a533be98ba96cf5cdf0ddbb101c78019f1fda063261871dad6248609
+  md5: 04b88013080254850d6c01ed54810589
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 545199
+  timestamp: 1693151163452
+- conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
+  sha256: 64125775b2e724db5c72e431dd180495d5d509d0a2d1228a122e6af9f1b60e33
+  md5: 3c4e99d3ae4ec033d4dd99fb5220e540
+  depends:
+  - exceptiongroup
+  - idna >=2.8
+  - python >=3.8
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.22
+  license: MIT
+  license_family: MIT
+  size: 98958
+  timestamp: 1693488730301
+- conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.3-pyhd8ed1ab_0.tar.bz2
+  sha256: b209a68ac55eb9ecad7042f0d4eedef5da924699f6cdf54ac1826869cfdae742
+  md5: 54ac328d703bff191256ffa1183126d1
+  depends:
+  - python >=2.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 8095
+  timestamp: 1649077760928
+- conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+  sha256: 130766446f5507bd44df957b6b5c898a8bd98f024bb426ed6cb9ff1ad67fc677
+  md5: 3afef1f55a1366b4d3b6a0d92e2235e4
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.7
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 18602
+  timestamp: 1692818472638
+- conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+  sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
+  md5: b77d8c2313158e6e461ca0efb1c2c508
+  depends:
+  - python >=3.8
+  - python-dateutil >=2.7.0
+  - types-python-dateutil >=2.8.10
+  license: Apache-2.0
+  license_family: Apache
+  size: 100096
+  timestamp: 1696129131844
+- conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+  sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
+  md5: 5f25798dcefd8252ce5f9dc494d5f571
+  depends:
+  - python >=3.5
+  - six >=1.12.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 28922
+  timestamp: 1698341257884
+- conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+  sha256: 7ed83731979fe5b046c157730e50af0e24454468bbba1ed8fc1a3107db5d7518
+  md5: 3d081de3a6ea9f894bbb585e8e3a4dcb
+  depends:
+  - python >=3.8
+  - typing_extensions >=4.0.0
+  license: MIT
+  license_family: MIT
+  size: 15342
+  timestamp: 1690563152778
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+  sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
+  md5: 3edfead7cedd1ab4400a6c588f3e75f8
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 55022
+  timestamp: 1683424195402
+- conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.13.1-pyhd8ed1ab_0.conda
+  sha256: 1f955c700db16f65b16c9e9c1613436480d5497970b8030b7a9ebe1620cc2147
+  md5: 3ccff479c246692468f604df9c85ef26
+  depends:
+  - python >=3.7
+  - pytz
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6948100
+  timestamp: 1698174685067
+- conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+  sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
+  md5: 54ca2e08b3220c148a1d8329c2678e02
+  depends:
+  - python >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5950
+  timestamp: 1669158729416
+- conda: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
+  sha256: 7027bb689dd4ca4a08e3b25805de9d04239be6b31125993558f21f102a9d2700
+  md5: 6b1b907661838a75d067a22f87996b2e
+  depends:
+  - backports
+  - python >=3.6
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 11519
+  timestamp: 1687772319931
+- conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.2-pyha770c72_0.conda
+  sha256: 52d3e6bcd442537e22699cd227d8fdcfd54b708eeb8ee5b4c671a6a9b9cd74da
+  md5: a362ff7d976217f8fa78c0f1c4f59717
+  depends:
+  - python >=3.6
+  - soupsieve >=1.2
+  license: MIT
+  license_family: MIT
+  size: 115011
+  timestamp: 1680888259061
+- conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+  sha256: 845e77ef495376c5c3c328ccfd746ca0ef1978150cae8eae61a300fe7755fb08
+  md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
+  depends:
+  - packaging
+  - python >=3.6
+  - setuptools
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 131220
+  timestamp: 1696630354218
+- conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.2.2-pyhd8ed1ab_0.conda
+  sha256: 8ac8cc29fba1bd48a6c511dcfa8c92435f1c4f111a96d86a630a734026e739ca
+  md5: 30488151f591379db656250b3f5fc0c6
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.16,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5345834
+  timestamp: 1692002773859
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+  sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
+  md5: 9b347a7ec10940d3f7941ff6c460b551
+  depends:
+  - cached_property >=1.5.2,<1.5.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4134
+  timestamp: 1615209571450
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+  sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+  md5: 576d629e47797577ab0f1b351297ef4a
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11065
+  timestamp: 1615209567874
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
+  sha256: db66e31866ff4250c190788769e3a8a1709237c3e9c38d7143aae95ab75fcb31
+  md5: 7f3dbc9179b4dde7da98dfb151d0ad22
+  depends:
+  - python >=3.7
+  license: ISC
+  size: 153791
+  timestamp: 1690024617757
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+  sha256: 20cae47d31fdd58d99c4d2e65fbdcefa0b0de0c84e455ba9d6356a4bdbc4b5b9
+  md5: 7f4a9e3fcff3f6356ae99244a014da6a
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 46597
+  timestamp: 1698833765762
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+  sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
+  md5: f3ad426304898027fc619827ff428eca
+  depends:
+  - __unix
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84437
+  timestamp: 1692311973840
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
+  sha256: 90236b113b9a20041736e80b80ee965167f9aac0468315c55e2bad902d673fb0
+  md5: 3549ecbceb6cd77b91a105511b7d0786
+  depends:
+  - __win
+  - colorama
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 85051
+  timestamp: 1692312207348
+- conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+  sha256: 0dfbc1ffa72e7a0882f486c9b1e4e9cccb68cf5c576fe53a89d076c9f1d43754
+  md5: 753d29fe41bb881e4b9c004f0abf973f
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24746
+  timestamp: 1697464875382
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+  sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+  md5: 3faab06a954c2a04039983f2c4a50d99
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25170
+  timestamp: 1666700778190
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 4e68730cc38236a736c8f1c6837c6460807cc0f0a5fd2166b3359d481e6f129f
+  md5: 1e424f22b3e2713068fe12d57f2dec5b
+  depends:
+  - pyct >=0.4.4
+  - python >=2.7
+  license: CC-BY-4.0
+  size: 1635349
+  timestamp: 1664843356249
+- conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
+  sha256: 11057745946a95ee7cc4c98900a60c7362266a4cb28bc97d96cd88e3056eb701
+  md5: c8eaca39e2b6abae1fc96acc929ae939
+  depends:
+  - python >=3.6
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11682
+  timestamp: 1691045097208
+- conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+  sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
+  md5: 5cd86562580f274031ede6aa6aa24441
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13458
+  timestamp: 1696677888423
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.10.1-pyhd8ed1ab_0.conda
+  sha256: e8322cce6f097b188a5c1fa2dfb14ea26f841dd33bc965036a5236e84d455ad8
+  md5: cf1f26a9e21311f10cfe9dbf0e0d99bc
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib_metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.9
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 862751
+  timestamp: 1698445693753
+- conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.0-pyhd8ed1ab_0.conda
+  sha256: a705df42edde70be101c0523867f0ac25bd99a25ce2e96bbfb879d9541de68fb
+  md5: 2bcf7e080c7a702f6a5387b57dbf404f
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy
+  - pandas
+  - param
+  - pillow
+  - pyct
+  - python >=3.9
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17218904
+  timestamp: 1698408535171
+- conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+  md5: 43afe5ab04e35e17ba28649471dd7364
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 12072
+  timestamp: 1641555714315
+- conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
+  md5: 961b3a227b437d82ad7054484cfa71b2
+  depends:
+  - python >=3.6
+  license: PSF-2.0
+  license_family: PSF
+  size: 24062
+  timestamp: 1615232388757
+- conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
+  md5: 3cf04868fee0a029769bd41f4b2fbf2d
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 9199
+  timestamp: 1643888357950
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+  sha256: c28f715e049fe0f09785660bcbffa175ffb438720e5bc5a60d56d4b08364b315
+  md5: e6518222753f519e911e83136d2158d9
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19262
+  timestamp: 1692026296517
+- conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+  sha256: c738804ab1e6376f8ea63372229a04c8d658dc90fd5a218c6273a2eaf02f4057
+  md5: e16be50e378d8a4533b989035b196ab8
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 27689
+  timestamp: 1698580072627
+- conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 6cfd1f9bcd2358a69fb571f4b3af049b630d52647d906822dbedac03e84e4f63
+  md5: 642d35437078749ef23a5dca2c9bb1f3
+  depends:
+  - cached-property >=1.3.0
+  - python >=2.7,<4
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 14395
+  timestamp: 1638810388635
+- conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.10.0-pyhca7485f_0.conda
+  sha256: 1bbdfadb93cc768252fd207dca406cde928f9a81ff985ea1760b6539c55923e6
+  md5: 5b86cf1ceaaa9be2ec4627377e538db1
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 124907
+  timestamp: 1697919506326
+- conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.0-pyha770c72_1.conda
+  sha256: 97fe438e399d9106998e38fc700fdd6f90f15ea92d1e20cf0a01e74436aa24ba
+  md5: 614a383c5f4350e0606689f54c6497b1
+  depends:
+  - packaging
+  - pandas >=1.4.0
+  - pyproj >=3.3.0
+  - python >=3.9
+  - shapely >=1.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1017514
+  timestamp: 1697032153699
+- conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.10.1-pyhd8ed1ab_0.conda
+  sha256: a0ec5fa04c38b69648fa3fae016d7b930a25558271affa69255f7cbfae70b139
+  md5: 08f49562f35d932cb35047016c46bde3
+  depends:
+  - bokeh >=3.1.0,<3.3.0
+  - cartopy >=0.18.0
+  - datashader
+  - geopandas-base
+  - geoviews-core 1.10.1 pyha770c72_0
+  - holoviews >=1.16.0
+  - netcdf4
+  - numpy >=1.0
+  - packaging
+  - pandas
+  - panel >=1.0.0
+  - param >=1.9.3,<2.0.0a0
+  - pyct
+  - pyproj
+  - python >=3.8
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8506
+  timestamp: 1689929056825
+- conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.10.1-pyha770c72_0.conda
+  sha256: f57324b4b89fe71430351f3e14645ba53cb4c53ceae0de78cb77d870cb70d4dd
+  md5: 95d909e4a2674ae827cffc7bea89e264
+  depends:
+  - bokeh >=3.1.0,<3.3.0
+  - cartopy >=0.18.0
+  - holoviews >=1.16.0
+  - numpy >=1.0
+  - packaging
+  - panel >=1.0.0
+  - param >=1.9.3
+  - pyproj
+  - python >=3.8
+  constrains:
+  - geoviews 1.10.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372667
+  timestamp: 1689929009202
+- conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.18.0-pyhd8ed1ab_0.conda
+  sha256: cdbb34574c43ad668e9de04166cd7c5963fb1b50a0d2ba71d47d8e64ec5b8029
+  md5: e503a9cc7f8d29d1fb33d19ed7aa5d67
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3364342
+  timestamp: 1697704974932
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 9887c35c374ec1847f167292d3fde023cb4c994a4ceeec283072b95440131f09
+  md5: 34272b248891bddccc64479f9a7fffed
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 56742
+  timestamp: 1663625484114
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
+  sha256: 2797ed927d65324309b6c630190d917b9f2111e0c217b721f80429aeb57f9fcf
+  md5: 4e9f59a060c3be52bc4ddc46ee9b6946
+  depends:
+  - python >=3.8
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25910
+  timestamp: 1688754651944
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
+  sha256: b96e01dc42d547d6d9ceb1c5b52a5232cc04e40153534350f702c3e0418a6b3f
+  md5: b279b07ce18058034e5b3606ba103a8b
+  depends:
+  - importlib-metadata >=6.8.0,<6.8.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 9428
+  timestamp: 1688754660209
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.0-pyhd8ed1ab_0.conda
+  sha256: adab6da633ec3b642f036ab5c1196c3e2db0e8db57fb0c7fc9a8e06e29fa9bdc
+  md5: 48b0d98e0c0ec810d3ccc2a0926c8c0e
+  depends:
+  - python >=3.8
+  - zipp >=3.1.0
+  constrains:
+  - importlib-resources >=6.1.0,<6.1.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 30024
+  timestamp: 1695414932459
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.26.0-pyh3cd1d5f_0.conda
+  sha256: be9927d47fe23cc4d2a09d252e37e1e56ffb137767d2c0577ed882ead16f75fa
+  md5: 3c6e2148d30e6a762d8327a433ebfb5a
+  depends:
+  - __osx
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116536
+  timestamp: 1698244546989
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.26.0-pyha63f2e9_0.conda
+  sha256: 7208f5ae35c321d03c71e4072c959c60f877d1b9cc2fb32d805972b54123fb95
+  md5: 10e1de12f78f0fedb82ff723f602b5c5
+  depends:
+  - __win
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116868
+  timestamp: 1698244441309
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.26.0-pyhf8b6a83_0.conda
+  sha256: 9e647454f7572101657a07820ebed294df9a6a527b041cd5e4dd98b8aa3db625
+  md5: 2307f71f5f0896d4b91b93e6b468abff
+  depends:
+  - __linux
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116210
+  timestamp: 1698244196564
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh31c8845_0.conda
+  sha256: b28ec68a49d8ddc41b92f3161f536d63e62eb5493021e41bb172b5f0af54ca2d
+  md5: 28e743c2963d1cecaa75f7612ade74c4
+  depends:
+  - __osx
+  - appnope
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt_toolkit >=3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 591141
+  timestamp: 1698846944668
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh41d4057_0.conda
+  sha256: 31322d58f412787f5beeb01db4d16f10f8ae4e0cc2ec99fafef1e690374fe298
+  md5: f39d0b60e268fe547f1367edbab457d4
+  depends:
+  - __linux
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt_toolkit >=3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 589731
+  timestamp: 1698846745397
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh5737063_0.conda
+  sha256: e9da075dab85ad01df4355e264220e156273f719a62f6fad588a686616e86a9c
+  md5: f303446f1ce22bd9173650d3e722e87b
+  depends:
+  - __win
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt_toolkit >=3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 592050
+  timestamp: 1698847371880
+- conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
+  md5: 4cb68948e0b8429534380243d063a27a
+  depends:
+  - arrow >=0.15.0
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 17189
+  timestamp: 1638811664194
+- conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+  sha256: 362f0936ef37dfd1eaa860190e42a6ebf8faa094eaa3be6aa4d9ace95f40047a
+  md5: 81a3be0b2023e1ea8555781f0ad904a2
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 841312
+  timestamp: 1696326218364
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+  sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
+  md5: c8490ed5c70966d232fdd389d0dbed37
+  depends:
+  - markupsafe >=2.0
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101443
+  timestamp: 1654302514195
+- conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.14-pyhd8ed1ab_0.conda
+  sha256: 41514104208c092959bef0713cbd795e72c535f2f939b7903d8c97809f2adaa7
+  md5: dac1dabba2b5a9d1aee175c5fcc7b436
+  depends:
+  - python >=3.7,<4.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25003
+  timestamp: 1688248468479
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.2-pyhd8ed1ab_0.conda
+  sha256: 07e5d395d83c4b12a7abe3989fb42abdcd3b1c51cd27549e5eab390bb8c7bf0f
+  md5: 24d41c2f9cc199d0a180ecf7ef54739c
+  depends:
+  - attrs >=22.2.0
+  - importlib_resources >=1.4.0
+  - jsonschema-specifications >=2023.03.6
+  - pkgutil-resolve-name >=1.3.10
+  - python >=3.8
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 71509
+  timestamp: 1698678642652
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
+  sha256: 7b0061e106674f27cc718f79a095e90a5667a3635ec6626dd23b3be0fd2bfbdc
+  md5: 7c27ea1bdbe520bb830dcadd59f55cbf
+  depends:
+  - importlib_resources >=1.4.0
+  - python >=3.8
+  - referencing >=0.25.0
+  license: MIT
+  license_family: MIT
+  size: 15296
+  timestamp: 1689701341221
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.2-pyhd8ed1ab_0.conda
+  sha256: b06681b4499635f0ed901f4879122bfd3ff6ef28de1797367769a4ba6b990b0d
+  md5: c447b7c28ad6bb3306f0015f1195c721
+  depends:
+  - fqdn
+  - idna
+  - isoduration
+  - jsonpointer >1.13
+  - jsonschema >=4.19.2,<4.19.3.0a0
+  - python
+  - rfc3339-validator
+  - rfc3986-validator >0.1.0
+  - uri-template
+  - webcolors >=1.11
+  license: MIT
+  license_family: MIT
+  size: 7389
+  timestamp: 1698678669876
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.0-pyhd8ed1ab_0.conda
+  sha256: 16fc7b40024adece716ba7227e5c123a2deccc13f946a10d9a3270493908d11c
+  md5: 38589f4104d11f2a59ff01a9f4e3bfb3
+  depends:
+  - importlib-metadata >=4.8.3
+  - jupyter_server >=1.1.2
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 52525
+  timestamp: 1685453825227
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.5.0-pyhd8ed1ab_0.conda
+  sha256: e4478e137e0975ce94ef4ee6e4a6736afaf4a00e99bc8007a275bcb39fe728d9
+  md5: 77e442cb7c382d01c916f91a8652811a
+  depends:
+  - importlib_metadata >=4.8.3
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.8
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105606
+  timestamp: 1698232162661
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.8.0-pyhd8ed1ab_0.conda
+  sha256: 44742f7b6453774fbbdf7cec20282f88c7362707990790116fec23270b81b447
+  md5: 04272d87d3e06c2e26af5e2d4b0e0ad8
+  depends:
+  - jsonschema-with-format-nongpl >=4.18.0
+  - python >=3.8
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21359
+  timestamp: 1697461797603
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.9.1-pyhd8ed1ab_0.conda
+  sha256: bb9a60ff41085031a28204add4e6120990437cfad341db297519f0a0f0df8e18
+  md5: 8e0cfa69e5b0062b829a9dbb14645def
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert-core >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.8
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 317157
+  timestamp: 1698244231289
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
+  sha256: 9f4c5fef9beef9fceed628db7a10b888f3308b37ae257ad3d50046088317ebf1
+  md5: 7c0965e1d4a0ee1529e8eaa03a78a5b3
+  depends:
+  - python >=3.8
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18974
+  timestamp: 1673491600853
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.7-pyhd8ed1ab_0.conda
+  sha256: 1d841546fd239d7edefbf00edd3bad4680b12c3eb2549026d6aa70a301f23295
+  md5: 80318d83f33b3bf4e57b8533b7a6691d
+  depends:
+  - async-lru >=1.0.0
+  - importlib_metadata >=4.8.3
+  - importlib_resources >=1.4
+  - ipykernel
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.19.0,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.8
+  - tomli
+  - tornado >=6.2.0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6142657
+  timestamp: 1697059891776
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0.tar.bz2
+  sha256: 08453e09d5a6bbaeeca839553a5dfd7a377a97550efab96019c334a8042f54f5
+  md5: 243f63592c8e449f40cd42eb5cf32f40
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17410
+  timestamp: 1649936689608
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.0-pyhd8ed1ab_0.conda
+  sha256: 608a878d08e0f4f51dd9a61eaead7c0e22d07f48aad06e3e2f6d6f1d0a929746
+  md5: a52834fa7e3d12abc5efdf06b2097a05
+  depends:
+  - babel >=2.10
+  - importlib-metadata >=4.8.3
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.8
+  - requests >=2.31
+  constrains:
+  - openapi-core >=0.18.0,<0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48289
+  timestamp: 1694532412609
+- conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 0980092a2e0a4bd263c18fb0db701589fc10fc8542ce511f844a533490d5f14e
+  md5: 25b93e66067eb496ac10da888e25cc33
+  depends:
+  - python >=3.6
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 22417
+  timestamp: 1651923701523
+- conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
+  md5: 91e27ef3d05cc772ce627e51cff111c4
+  depends:
+  - python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 8250
+  timestamp: 1650660473123
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.5.1-pyhd8ed1ab_0.conda
+  sha256: 35e8990504cf8dc7e2bb63efd855fb0a0d5c0d77bf79403235e757c24a83ec1d
+  md5: 323495027ffa625701129acebf861412
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 76573
+  timestamp: 1698797645633
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+  sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
+  md5: 93a8e71256479c62074356ef6ebf501b
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 64356
+  timestamp: 1686175179621
+- conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+  sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
+  md5: b21613793fcc81d944c76c9f2864a7de
+  depends:
+  - python >=3.6
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12273
+  timestamp: 1660814913405
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.0-pyhd8ed1ab_0.conda
+  sha256: 1ddac8d2be448cd1fbe49d2ca09df7e10d99679d53146a917f8bb4899f76d0ca
+  md5: 6c5358a10873a15398b6f15f60cb5e1f
+  depends:
+  - markdown-it-py >=1.0.0,<4.0.0
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 41197
+  timestamp: 1686175527330
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+  sha256: c678b9194e025b1fb665bec30ee20aab93399203583875b1dcc0a3b52a8f5523
+  md5: f8dab71fdc13b1bf29a01248b156d268
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 13707
+  timestamp: 1639515992326
+- conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.1-pyhd8ed1ab_0.conda
+  sha256: 0b4558d3afb64e23b66f5279b704de76ebeb6b4eebbf913d65fbd4ba7d9acc2f
+  md5: 1dad8397c94e4de97a70de552a7dcf49
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 66169
+  timestamp: 1692116828443
+- conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+  sha256: 6d5839f75780475ad4dffe018026d493e26076f95862550a48424b4d7f6689d8
+  md5: 1073dc92c8f247d94ac14dd79ca0bbec
+  depends:
+  - python
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 12299
+  timestamp: 1534825527617
+- conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+  sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
+  md5: 2ba8498c1018c1e9c61eb99b973dfe19
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12452
+  timestamp: 1600387789153
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
+  sha256: 4ebd237cdf4bfa5226f92d2ae78fab8dba27696909391884dc6594ca6f9df5ff
+  md5: e78da91cf428faaf05701ce8cc8f2f9b
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.8
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64852
+  timestamp: 1684791049212
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.10.0-pyhd8ed1ab_0.conda
+  sha256: 693fca2715f78faee1c5be2362d2f1ea30e6b7179b4d2762fd9ffdaae5c8a65a
+  md5: 56c421c936a17bbc7fd4b36c9bd3b236
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<3.1
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.8
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - nbconvert =7.10.0=*_0
+  - pandoc >=2.14.2,<4.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 188466
+  timestamp: 1698678612863
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
+  sha256: fc82c5a9116820757b03ffb836b36f0f50e4cd390018024dbadb0ee0217f6992
+  md5: 61ba076de6530d9301a0053b02f093d2
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.8
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100446
+  timestamp: 1690815009867
+- conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.8-pyhd8ed1ab_0.conda
+  sha256: d7b795b4e754136841c6da3f9fa1a0f7ec37bc7167e7dd68c5b45e657133e008
+  md5: a4f0e4519bc50eee4f53f689be9607f7
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11630
+  timestamp: 1697083896431
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.0.6-pyhd8ed1ab_0.conda
+  sha256: 5259ad2fb47300407dafa6ea5e78085a2c8de8dcdbfbaa58592bf2677d7187a9
+  md5: d60881c78a54cbf8042ae719f1f77a50
+  depends:
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab >=4.0.7,<4.1.0a0
+  - jupyterlab_server >=2.22.1,<3
+  - notebook-shim >=0.2,<0.3
+  - python >=3.8
+  - tornado >=6.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3122185
+  timestamp: 1697550916556
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
+  sha256: f028d7ad1f2175cde307db08b60d07e371b9d6f035cfae6c81ea94b4c408c538
+  md5: 67e0fe74c156267d9159e9133df7fd37
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16783
+  timestamp: 1682360712235
+- conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
+  sha256: 29db8c3b521d261bf71897ba3cfbebc81cd61e581b30fcb984b5a713f02fe1ff
+  md5: 4625b7b01d7f4ac9c96300a5515acfaa
+  depends:
+  - python >=3.6
+  - typing_utils
+  license: Apache-2.0
+  license_family: APACHE
+  size: 29976
+  timestamp: 1691338962381
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+  sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
+  md5: 79002079284aa895f883c6b7f3f88fd6
+  depends:
+  - python >=3.7
+  license: Apache-2.0
+  license_family: APACHE
+  size: 49452
+  timestamp: 1696202521121
+- conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
+  md5: 457c2c8c08e54905d6954e79cb5b5db9
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11627
+  timestamp: 1631603397334
+- conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.2.3-pyhd8ed1ab_0.conda
+  sha256: 646e6e60c59eb233af22c4b1d97b15f356643461836b0d76089b74b2be699d35
+  md5: 76230ad9115ff3783627f0977ed764eb
+  depends:
+  - bleach
+  - bokeh >=3.1.1,<3.3
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - param >=1.12.0,<2.0
+  - python >=3.8
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.16.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14015213
+  timestamp: 1695042991442
+- conda: https://conda.anaconda.org/conda-forge/noarch/param-1.13.0-pyh1a96a4e_0.conda
+  sha256: 924dee0430ef46af7b28841d49b503de6a8969af1c7b06897a4cff26d429f20e
+  md5: 158eda83fd21a14b8c483c0d1d102397
+  depends:
+  - python >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 79952
+  timestamp: 1678790904486
+- conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+  sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
+  md5: 17a565a0c3899244e938cdf417e7b094
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 71048
+  timestamp: 1638335054552
+- conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.1-pyhd8ed1ab_0.conda
+  sha256: b248238da2bb9dfe98e680af911dc7013af86095e3ec8baf08905555632d34c7
+  md5: acf4b7c0bcd5fa3b0e05801c4d2accd6
+  depends:
+  - locket
+  - python >=3.7
+  - toolz
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20743
+  timestamp: 1695667673391
+- conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
+  sha256: 07706c0417ead94f359ca7278f65452d3c396448777aba1da6a11fc351bdca9a
+  md5: 330448ce4403cc74990ac07c555942a1
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  size: 48780
+  timestamp: 1667297617062
+- conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+  sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
+  md5: 415f0ebb6198cc2801c73438a9fb5761
+  depends:
+  - python >=3
+  license: MIT
+  license_family: MIT
+  size: 9332
+  timestamp: 1602536313357
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
+  sha256: 435829a03e1c6009f013f29bb83de8b876c388820bf8cf69a7baeec25f6a3563
+  md5: 2400c0b86889f43aa52067161e1fb108
+  depends:
+  - python >=3.7
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 1398838
+  timestamp: 1697896918388
+- conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+  sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
+  md5: 405678b942f2481cecdb3e010f4925d9
+  depends:
+  - python >=3.6
+  license: MIT AND PSF-2.0
+  size: 10778
+  timestamp: 1694617398467
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+  sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
+  md5: 8f567c0a74aa44cf732f15773b4083b0
+  depends:
+  - python >=3.7
+  - typing-extensions >=4.6.3
+  license: MIT
+  license_family: MIT
+  size: 19985
+  timestamp: 1696272419779
+- conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.18.0-pyhd8ed1ab_0.conda
+  sha256: 0e0257eee11d3e0b3f73566283fd6c705b1b2a5dbc7d9a609fa885519a62913e
+  md5: ade903cbe0b4440ca6bed64932d124b5
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: Apache
+  size: 53959
+  timestamp: 1698692692135
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
+  sha256: 10e7fdc75d4b85633be6b12a70b857053987127a808caa0f88b2cba4b3ce6359
+  md5: a4986c6bb5b0d05a38855b0880a5f425
+  depends:
+  - python >=3.7
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.39
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269068
+  timestamp: 1688566090973
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
+  sha256: 89f7fecc7355181dbc2ab851e668a2fce6aa4830b336a34c93b59bda93206270
+  md5: 4bbbe67d5df19db30f04b8e344dc9976
+  depends:
+  - prompt-toolkit >=3.0.39,<3.0.40.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6731
+  timestamp: 1688566099039
+- conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+  sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+  md5: 359eeb6536da0e687af562ed265ec263
+  depends:
+  - python
+  license: ISC
+  size: 16546
+  timestamp: 1609419417991
+- conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+  sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
+  md5: 6784285c7e55cb7212efabc79e4c2883
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14551
+  timestamp: 1642876055775
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+  sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
+  md5: 076becd9e05608f8dc72757d5f3a91ff
+  depends:
+  - python ==2.7.*|>=3.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102747
+  timestamp: 1636257201998
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.4.6-py_0.tar.bz2
+  sha256: 50af51619db6a35c36e65e8f50c83c722c3358f1f4b5527e87799b8f9935ace0
+  md5: 42d91c89bc3993ec88681cffd3c0e326
+  depends:
+  - pyct-core 0.4.6.*
+  - python
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2652
+  timestamp: 1545265022341
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyct-core-0.4.6-py_0.tar.bz2
+  sha256: 8abc24dcf2782feca867974ba2aa0c9aaeae0966dad3f54507b39da30123d481
+  md5: 55ec526f95e0959de3f68bc6289a20da
+  depends:
+  - param >=1.7.0
+  - python
+  constrains:
+  - pyct 0.4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13725
+  timestamp: 1541164340776
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
+  sha256: 3f0f0fadc6084960ec8cc00a32a03529c562ffea3b527eb73b1653183daad389
+  md5: 40e5cb18165466773619e5c963f00a7b
+  depends:
+  - python >=3.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 853439
+  timestamp: 1691408777841
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+  sha256: 4a1332d634b6c2501a973655d68f08c9c42c0bd509c349239127b10572b8354b
+  md5: 176f7d56f0cfe9008bdf1bccd7de02fb
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 89521
+  timestamp: 1690737983548
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 41eced0d5e855bc52018f200b239d627daa38ad78a655ffa2f1efd95b07b6bce
+  md5: 92a889dc236a5197612bc85bee6d7174
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 964060
+  timestamp: 1659003065197
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
+  sha256: b3a612bc887f3dd0fb7c4199ad8e342bd148cf69a9b74fd9468a18cf2bef07b7
+  md5: 56cd9fe388baac0e90c7149cfac95b60
+  depends:
+  - __win
+  - python >=3.8
+  - win_inet_pton
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19348
+  timestamp: 1661605138291
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+  sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+  md5: 2a7de29fb590ca14b5243c4c812c8025
+  depends:
+  - __unix
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18981
+  timestamp: 1661604969727
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+  sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
+  md5: dd999d1cc9f79e67dbb855c8924c7984
+  depends:
+  - python >=3.6
+  - six >=1.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 245987
+  timestamp: 1626286448716
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.1-pyhd8ed1ab_0.conda
+  sha256: 3fb1af1ac7525072c46e111bc4e96ddf971f792ab049ca3aa25dbebbaffb6f7d
+  md5: 305141cff54af2f90e089d868fffce28
+  depends:
+  - python >=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 226030
+  timestamp: 1696171963080
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+  sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
+  md5: a61bf9ec79426938ff785eb69dbb1960
+  depends:
+  - python >=3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13383
+  timestamp: 1677079727691
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
+  sha256: 0108888507014fb24573c31e4deceb61c99e63d37776dddcadd7c89b2ecae0b6
+  md5: 2590495f608a63625e165915fb4e2e34
+  depends:
+  - python >=3.6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 143131
+  timestamp: 1680081272948
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
+  sha256: 6b680e63d69aaf087cd43ca765a23838723ef59b0a328799e6363eb13f52c49e
+  md5: c93346b446cd08c169d843ae5fc0da97
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 187454
+  timestamp: 1693930444432
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.0-pyhd8ed1ab_0.conda
+  sha256: 479ef43683cdcbf414d9454309a169fe6c6a6373fc43945034e02a7e5a7b8f15
+  md5: 6a4c07fcb5e3f2fb06eca2f59d632e9b
+  depends:
+  - param
+  - python >=3.6
+  constrains:
+  - jupyterlab >=4.0,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 47588
+  timestamp: 1692264873960
+- conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
+  sha256: a6768fabc12f1eed87fec68c5c65439e908655cded1e458d70a164abbce13287
+  md5: a33161b983172ba6ef69d5fc850650cd
+  depends:
+  - attrs >=22.2.0
+  - python >=3.8
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 38061
+  timestamp: 1691337409918
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+  sha256: 9f629d6fd3c8ac5f2a198639fe7af87c4db2ac9235279164bfe0fcb49d8c4bad
+  md5: a30144e4156cdbb236f99ebb49828f8b
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.7
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 56690
+  timestamp: 1684774408600
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
+  md5: fed45fc5ea0813240707998abe49f520
+  depends:
+  - python >=3.5
+  - six
+  license: MIT
+  license_family: MIT
+  size: 8064
+  timestamp: 1638811838081
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+  sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
+  md5: 912a71cc01012ee38e6b90ddd561e36f
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 7818
+  timestamp: 1598024297745
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh08f2357_0.conda
+  sha256: 55208c6b48d68dc9ad2e2cf81ab9dc6b8a1d607e67acf9115bdc7794accc84bc
+  md5: c00d32dfa733d381b6a1908d0d67e0d7
+  depends:
+  - __win
+  - python >=3.6
+  - pywin32
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23279
+  timestamp: 1682601755260
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh41d4057_0.conda
+  sha256: e74d3faf51a6cc429898da0209d95b209270160f3edbf2f6d8b61a99428301cd
+  md5: ada5a17adcd10be4fc7e37e4166ba0e2
+  depends:
+  - __linux
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22821
+  timestamp: 1682601391911
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyhd1c38e8_0.conda
+  sha256: dca4022bae47618ed738ab7d45ead5202d174b741cfb98e4484acdc6e76da32a
+  md5: 2657c3de5371c571aef6678afb4aaadd
+  depends:
+  - __osx
+  - pyobjc-framework-cocoa
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23021
+  timestamp: 1682601619389
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+  sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
+  md5: fc2166155db840c634a1291a5c35a709
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 464399
+  timestamp: 1694548452441
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+  sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
+  md5: e5f25f8dbc060e9a8d912e432202afc2
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 14259
+  timestamp: 1620240338595
+- conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
+  sha256: a3fd30754c20ddb28b777db38345ea00d958f46701f0decd6291a81c0f4eee78
+  md5: dd6cbc539e74cb1f430efbd4575b9303
+  depends:
+  - python >=3.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 14358
+  timestamp: 1662051357638
+- conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+  sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
+  md5: 3f144b2c34f8cb5a9abd9ed23a39c561
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 36754
+  timestamp: 1693929424267
+- conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+  sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
+  md5: e7df0fdd404616638df5ece6e69ba7af
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 26205
+  timestamp: 1669632203115
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.0-pyh08f2357_0.tar.bz2
+  sha256: 5c8fcf31430e0f312bc65ab5aa5b893fcc250820c023b02ff3fd188ae13199a5
+  md5: 0152a609d5748ed9887d195b1e61a6c9
+  depends:
+  - __win
+  - python >=3.7
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 19530
+  timestamp: 1666708102607
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyh41d4057_0.conda
+  sha256: bce252eb53330a8ba9617caa7a1dc75ce602c8808cf547a8f4d48285901f47c3
+  md5: 3788984d535770cad699efaeb6cb3037
+  depends:
+  - __linux
+  - ptyprocess
+  - python >=3.7
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 20787
+  timestamp: 1670253786972
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyhd1c38e8_0.conda
+  sha256: a2f8382ab390c74af592cc3566dc22e2ed81e5ac69c5b6417d1b7c22e63927bc
+  md5: 046120b71d8896cb7faef78bfdbfee1e
+  depends:
+  - __osx
+  - ptyprocess
+  - python >=3.7
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 20347
+  timestamp: 1670254383751
+- conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+  sha256: f0db1a2298a5e10e30f4b947566c7229442834702f549dded40a73ecdea7502d
+  md5: 7234c9eefff659501cd2fe0d2ede4d48
+  depends:
+  - python >=3.5
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23235
+  timestamp: 1666100385187
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+  md5: 5844808ffab9ebdb694585b50ba02a96
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 15940
+  timestamp: 1644342331069
+- conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 90229da7665175b0185183ab7b53f50af487c7f9b0f47cf09c184cbc139fd24b
+  md5: 92facfec94bc02d6ccf42e7173831a36
+  depends:
+  - python >=3.5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49136
+  timestamp: 1657485654230
+- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
+  sha256: b61c9222af05e8c5ff27e4a4d2eb81870c21ffd7478346be3ef644b7a3759cc4
+  md5: 03c97908b976498dcae97eb4e4f3149c
+  depends:
+  - colorama
+  - python >=3.7
+  license: MPL-2.0 or MIT
+  size: 89449
+  timestamp: 1691671387674
+- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.13.0-pyhd8ed1ab_0.conda
+  sha256: 7ac67960ba2e8c16818043cc65ac6190fa4fd95f5b24357df58e4f73d5e60a10
+  md5: 8a9953c15e1e5a7c1baddbbf4511a567
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 109701
+  timestamp: 1698671281969
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.14-pyhd8ed1ab_0.conda
+  sha256: 7b0129c72d371fa7a06ed5dd1d701844c20d03bb4641a38a88a982b347d087e2
+  md5: 4df15c51a543e806d439490b862be1c6
+  depends:
+  - python >=3.6
+  license: Apache-2.0 AND MIT
+  size: 21474
+  timestamp: 1689883066161
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+  sha256: d6e1dddd0c372218ef15912383d351ac8c73465cbf16238017f0269813cafe2d
+  md5: 384462e63262a527bda564fa2d9126c0
+  depends:
+  - typing_extensions 4.8.0 pyha770c72_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 10104
+  timestamp: 1695040958008
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+  sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
+  md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
+  depends:
+  - python >=3.8
+  license: PSF-2.0
+  license_family: PSF
+  size: 35108
+  timestamp: 1695040948828
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 9e3758b620397f56fb709f796969de436d63b7117897159619b87938e1f78739
+  md5: eb67e3cace64c66233e2d35949e20f92
+  depends:
+  - python >=3.6.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 13829
+  timestamp: 1622899345711
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+  sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
+  md5: 939e3e74d8be4dac89ce83b20de2492a
+  license: LicenseRef-Public-Domain
+  size: 117580
+  timestamp: 1680041306008
+- conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 04b6f17a9ff2bd36f70076dd1761408de1d38c6c791849a02c3a1d28ad466d00
+  md5: 3ddf6684d9b274a12c94e509ca45656c
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 8969
+  timestamp: 1608058755081
+- conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+  sha256: b76904b53721dc88a46352324c79d2b077c2f74a9f7208ad2c4249892669ae94
+  md5: 0944dc65cb4a9b5b68522c3bb585d41c
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 23999
+  timestamp: 1688655976471
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.7-pyhd8ed1ab_0.conda
+  sha256: 9fe14735dde74278c6f1710cbe883d5710fc98501a96031dec6849a8d8a1bb11
+  md5: 270e71c14d37074b1d066ee21cf0c4a6
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 98507
+  timestamp: 1697720586316
+- conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.9-pyhd8ed1ab_0.conda
+  sha256: 7552f6545ed212b9ae5d023870481fc377c7f18b4854b63160699b95a420c42e
+  md5: 8e8280dec091763dfdc29e066de52270
+  depends:
+  - backports.functools_lru_cache
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 30316
+  timestamp: 1698744892384
+- conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
+  sha256: 6e097d5fe92849ad3af2c2a313771ad2fbf1cadd4dc4afd552303b2bf3f85211
+  md5: 166212fe82dad8735550030488a01d03
+  depends:
+  - python >=3.5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18186
+  timestamp: 1679900907305
+- conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+  sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
+  md5: daf5160ff9cde3a468556965329085b9
+  depends:
+  - python >=2.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15600
+  timestamp: 1694681458271
+- conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.4-pyhd8ed1ab_0.conda
+  sha256: df45b89862edcd7cd5180ec7b8c0c0ca9fb4d3f7d49ddafccdc76afcf50d8da6
+  md5: bdb77b28cf16deac0eef431a068320e8
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: APACHE
+  size: 45866
+  timestamp: 1696770282111
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.3-pyhd8ed1ab_0.conda
+  sha256: 84c3b57fba778add2bd47b7cc70e86f746d2c55549ffd2ccb6f3d6bf7c94d21d
+  md5: 3fc026b9c87d091c4b34a6c997324ae8
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 57901
+  timestamp: 1698670970223
+- conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyhd8ed1ab_6.tar.bz2
+  sha256: a11ae693a0645bf6c7b8a47bac030be9c0967d0b1924537b9ff7458e832c0511
+  md5: 30878ecc4bd36e8deeea1e3c151b2e0b
+  depends:
+  - __win
+  - python >=3.6
+  license: PUBLIC-DOMAIN
+  size: 8191
+  timestamp: 1667051294134
+- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2023.10.1-pyhd8ed1ab_0.conda
+  sha256: 6062114745e9c01813506527d7e48c75dbe5eb6017e4c60ce8c98ef9fd757db2
+  md5: 9b20e5d68eea6878a0a6fc57a3043889
+  depends:
+  - numpy >=1.22,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.9
+  constrains:
+  - seaborn-base >=0.11
+  - netcdf4 >=1.6.0
+  - iris >=3.2
+  - zarr >=2.12
+  - pint >=0.19
+  - h5py >=3.6
+  - hdf5 >=1.12
+  - cftime >=1.6
+  - sparse >=0.13
+  - cartopy >=0.20
+  - dask-core >=2022.7
+  - nc-time-axis >=1.4
+  - scipy >=1.8
+  - distributed >=2022.7
+  - bottleneck >=1.3
+  - matplotlib-base >=3.5
+  - toolz >=0.12
+  - h5netcdf >=1.0
+  - flox >=0.5
+  - numba >=0.55
+  license: Apache-2.0
+  license_family: APACHE
+  size: 711330
+  timestamp: 1697764509357
+- conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2023.10.1-pyhd8ed1ab_0.conda
+  sha256: da655e2e0a742fddefeeaf2dd828b62a1820a3755d13341e1a555a10fcb9cf81
+  md5: 1e0d85c0e2fef9539218da185b285f54
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36184
+  timestamp: 1698325478381
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+  sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
+  md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 18954
+  timestamp: 1695255262261
+- conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py310h6729b98_4.conda
+  sha256: c413de1658b9f34978e1a5c8dc1e93b75fdef8e453f0983a4d2fa4b6a669e2b2
+  md5: fea2a01f85aee10b268e0474a03eb148
+  depends:
+  - cffi >=1.0.1
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 31851
+  timestamp: 1695387111978
+- conda: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.5-heccf04b_0.conda
+  sha256: db629047f1721d5a6e3bd41b07c1a3bacd0dee70f4063b61db2aa46f19a0b8b4
+  md5: 3003fa6dd18769db1a616982dcee5b40
+  depends:
+  - libcxx >=15.0.7
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49891
+  timestamp: 1693657206065
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h0dc2134_1.conda
+  sha256: 4bf66d450be5d3f9ebe029b50f818d088b1ef9666b1f19e90c85479c77bbdcde
+  md5: 9272dd3b19c4e8212f8542cefd5c3d67
+  depends:
+  - brotli-bin 1.1.0 h0dc2134_1
+  - libbrotlidec 1.1.0 h0dc2134_1
+  - libbrotlienc 1.1.0 h0dc2134_1
+  license: MIT
+  license_family: MIT
+  size: 19530
+  timestamp: 1695990310168
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h0dc2134_1.conda
+  sha256: 7ca3cfb4c5df314ed481301335387ab2b2ee651e2c74fbb15bacc795c664a5f1
+  md5: ece565c215adcc47fc1db4e651ee094b
+  depends:
+  - libbrotlidec 1.1.0 h0dc2134_1
+  - libbrotlienc 1.1.0 h0dc2134_1
+  license: MIT
+  license_family: MIT
+  size: 16660
+  timestamp: 1695990286737
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py310h9e9d8ca_1.conda
+  sha256: 57d66ca3e072b889c94cfaf56eb7e1794d3b1b3179bd475a4edef50a03359354
+  md5: 2362e323293e7699cf1e621d502f86d6
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - libbrotlicommon 1.1.0 h0dc2134_1
+  license: MIT
+  license_family: MIT
+  size: 367037
+  timestamp: 1695990378635
+- conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2
+  sha256: 60ba4c64f5d0afca0d283c7addba577d3e2efc0db86002808dadb0498661b2f2
+  md5: 37edc4e6304ca87316e160f5ca0bd1b5
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 158829
+  timestamp: 1618862580095
+- conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.20.1-h10d778d_1.conda
+  sha256: 9e99ffb7e3376188c1e0c8037982a8fdc08c5736ea28f2314c20b8846179f0fe
+  md5: 0f9fe8eb46d409939d9b2a7d90a52325
+  license: MIT
+  license_family: MIT
+  size: 103592
+  timestamp: 1697955959402
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2023.7.22-h8857fd0_0.conda
+  sha256: 27de15e18a12117e83ac1eb8a8e52eb65731cc7f0b607a7922206a15e2460c7b
+  md5: bf2c54c18997bf3542af074c10191771
+  license: ISC
+  size: 149911
+  timestamp: 1690026363769
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cartopy-0.22.0-py310hdba192b_1.conda
+  sha256: 9c0370f61dcbc40c74bc783e962cb174ade6aa8c7eb189844d19cc240396f35a
+  md5: d30880c1bf31c7227c9aaaf64d14fa4c
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - matplotlib-base >=3.4
+  - numpy >=1.22.4,<2.0a0
+  - packaging >=20
+  - pyproj >=3.1.0
+  - pyshp >=2.1
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - shapely >=1.7
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 1807364
+  timestamp: 1698173127195
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.16.0-py310hdca579f_0.conda
+  sha256: 37802485964f1a3137ed6ab21ebc08fe9d35e7dc4da39f2b72a814644dd1ac15
+  md5: b9e6213f0eb91f40c009ce69139c1869
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 229407
+  timestamp: 1696002017767
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cftime-1.6.3-py310h91862f5_0.conda
+  sha256: 0228455782d71f754f1f26fd1e5b0e4d62e376c7a56b3dde32f052bd56fd688b
+  md5: 19f7244847b734340cf12f5d7a5057d6
+  depends:
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 208830
+  timestamp: 1698610245564
+- conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.1.1-py310h88cfcbd_1.conda
+  sha256: 8c14e70025b7f13227ec13efcde9110f45c22c6c272a6195a6ed326844e853f8
+  md5: 6c6bb230adc009e2db377450ca8e0433
+  depends:
+  - libcxx >=15.0.7
+  - numpy >=1.16
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 218720
+  timestamp: 1695554682987
+- conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.0-py310h9e9d8ca_1.conda
+  sha256: ec80231e963753692b62245a94f5025db6a44ae70f7a36c6dcb8195f971c33ae
+  md5: 64be4364c95d1d58b2bdeba61c4ddf99
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 2386610
+  timestamp: 1695534781106
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.43.1-py310hb372a2b_0.conda
+  sha256: 3a12906347d0c5e1070c87e351b9072b367233256559c63385c63533ae9545d9
+  md5: 2f4ffe85adb334cd58e74dd63605b66c
+  depends:
+  - brotli
+  - munkres
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - unicodedata2 >=14.0.0
+  license: MIT
+  license_family: MIT
+  size: 2146074
+  timestamp: 1696601555622
+- conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+  sha256: b292cf5a25f094eeb4b66e37d99a97894aafd04a5683980852a8cbddccdc8e4e
+  md5: 25152fce119320c980e5470e64834b50
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 599300
+  timestamp: 1694616137838
+- conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.12.0-he965462_0.conda
+  sha256: e84ff98270717ae49aeba6788476d3569ad33993a46d33d727ee528fb3386a58
+  md5: 264a53af0fb378e81b44e45e5ab5aff1
+  depends:
+  - libcxx >=15.0.7
+  license: LGPL-2.1-only
+  size: 1484046
+  timestamp: 1687940076636
+- conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
+  sha256: 8c767cc71226e9eb62649c903c68ba73c5f5e7e3696ec0319d1f90586cebec7d
+  md5: 7ce543bf38dbfae0de9af112ee178af2
+  depends:
+  - libcxx >=15.0.7
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 724103
+  timestamp: 1695661907511
+- conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.2-nompi_hedada53_100.conda
+  sha256: 08ab97d63ab4be60c92d3f5931effc565ae6ee0cd686eba81b9d20daf5f181ff
+  md5: 2b1d4f355b60eb10c5cb435b9f0e664f
+  depends:
+  - libaec >=1.0.6,<2.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libcxx >=15.0.7
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  license: LicenseRef-HDF5
+  license_family: BSD
+  size: 3564108
+  timestamp: 1692563939275
+- conda: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
+  sha256: f66362dc36178ac9b7c7a9b012948a9d2d050b3debec24bbd94aadbc44854185
+  md5: 5cc301d759ec03f28328428e28f65591
+  license: MIT
+  license_family: MIT
+  size: 11787527
+  timestamp: 1692901622519
+- conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-2.4-py310h2ec42d9_3.conda
+  sha256: 3d1196f7c81ea64398c01e2285ae59f83e9366dda21c7427f11dde8d0da38609
+  md5: ca02450dbc1c346a06fc454b36ddab32
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16313
+  timestamp: 1695397584568
+- conda: https://conda.anaconda.org/conda-forge/osx-64/jupyter_core-5.5.0-py310h2ec42d9_0.conda
+  sha256: 14ed1c62603b53132a74cb73409cd0bfd133bbc79e7e4a78523e162e54f945ce
+  md5: e7b118f9dd76e48119bce8358a0f09c7
+  depends:
+  - platformdirs >=2.5
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 79037
+  timestamp: 1698674181050
+- conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.5-py310h88cfcbd_1.conda
+  sha256: ccd88bcb67f0cc8b68ed320039d58701da125de0579680d7d2ffe7857b872613
+  md5: cb1db728c5e65918e30b65f9652a3458
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 60432
+  timestamp: 1695380318538
+- conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.2-hb884880_0.conda
+  sha256: 081ae2008a21edf57c048f331a17c65d1ccb52d6ca2f87ee031a73eff4dc0fc6
+  md5: 80505a68783f01dc8d7308c075261b2f
+  depends:
+  - libcxx >=15.0.7
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.1.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1183568
+  timestamp: 1692098004387
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.15-hd6ba6f3_3.conda
+  sha256: b2234f24e3b0030762430ec3414410119d1129804a95ef65af50ad36cabd9bd5
+  md5: 8059507d52f477fbd4b81841e085e25b
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 224895
+  timestamp: 1695969874291
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+  sha256: e41790fc0f4089726369b3c7f813117bbc14b533e0ed8b94cf75aba252e82497
+  md5: f9d6a4c82889d5ecedec1d90eb673c55
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 290319
+  timestamp: 1657977526749
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.2-he965462_1.conda
+  sha256: 1b0a0b9b67e8f155ebdc7205a7421c7aff4850a740fc9f88b3fa23282c98ed72
+  md5: faa179050abc6af1385e0fe9dd074f91
+  depends:
+  - libcxx >=15.0.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29027
+  timestamp: 1696474151758
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-19_osx64_openblas.conda
+  sha256: c2c96103aa23a65f45b76716df49940cb0722258d3e0416f8fa06ade02464b23
+  md5: e932b99c38915fa2ee252cdff6ea1f01
+  depends:
+  - libopenblas >=0.3.24,<0.3.25.0a0
+  - libopenblas >=0.3.24,<1.0a0
+  constrains:
+  - liblapacke 3.9.0 19_osx64_openblas
+  - libcblas 3.9.0 19_osx64_openblas
+  - liblapack 3.9.0 19_osx64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14812
+  timestamp: 1697484725085
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h0dc2134_1.conda
+  sha256: f57c57c442ef371982619f82af8735f93a4f50293022cfd1ffaf2ff89c2e0b2a
+  md5: 9e6c31441c9aa24e41ace40d6151aab6
+  license: MIT
+  license_family: MIT
+  size: 67476
+  timestamp: 1695990207321
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h0dc2134_1.conda
+  sha256: b11939c4c93c29448660ab5f63273216969d1f2f315dd9be60f3c43c4e61a50c
+  md5: 9ee0bab91b2ca579e10353738be36063
+  depends:
+  - libbrotlicommon 1.1.0 h0dc2134_1
+  license: MIT
+  license_family: MIT
+  size: 30327
+  timestamp: 1695990232422
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h0dc2134_1.conda
+  sha256: bc964c23e1a60ca1afe7bac38a9c1f2af3db4a8072c9f2eac4e4de537a844ac7
+  md5: 8a421fe09c6187f0eb5e2338a8a8be6d
+  depends:
+  - libbrotlicommon 1.1.0 h0dc2134_1
+  license: MIT
+  license_family: MIT
+  size: 299092
+  timestamp: 1695990259225
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-19_osx64_openblas.conda
+  sha256: 70afde49736007bbb804d126a3983ba1fa04383006aae416a2971d538e274427
+  md5: 40e412c219ad8cf87ba664466071bcf6
+  depends:
+  - libblas 3.9.0 19_osx64_openblas
+  constrains:
+  - liblapack 3.9.0 19_osx64_openblas
+  - liblapacke 3.9.0 19_osx64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14717
+  timestamp: 1697484740520
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.4.0-h726d00d_0.conda
+  sha256: cd3400ecb42fc420acb18e2d836535c44ebd501ebeb4e0bf3830776e9b4ca650
+  md5: 2c17b4dedf0039736951471f493353bd
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 366039
+  timestamp: 1697009485409
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.6-hd57cbcb_0.conda
+  sha256: 9063271847cf05f3a6cc6cae3e7f0ced032ab5f3a3c9d3f943f876f39c5c2549
+  md5: 7d6972792161077908b62971802f289a
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1142172
+  timestamp: 1686896907750
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.19-ha4e1b8e_0.conda
+  sha256: d0f789120fedd0881b129aba9993ec5dcf0ecca67a71ea20c74394e41adcb503
+  md5: 6a45f543c2beb40023df5ee7e3cedfbd
+  license: MIT
+  license_family: MIT
+  size: 68962
+  timestamp: 1694922440450
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+  sha256: dbd3c3f2eca1d21c52e4c03b21930bbce414c4592f8ce805801575b9e9256095
+  md5: 6016a8a1d0e63cac3de2c352cd40208b
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 105382
+  timestamp: 1597616576726
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-haf1e3a3_1.tar.bz2
+  sha256: c4154d424431898d84d6afb8b32e3ba749fe5d270d322bb0af74571a3cb09c6b
+  md5: 79dc2be110b2a3d1e97ec21f691c50ad
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 101424
+  timestamp: 1598868359024
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+  sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
+  md5: ccb34fb14960ad8b125962d3d79b31a9
+  license: MIT
+  license_family: MIT
+  size: 51348
+  timestamp: 1636488394370
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_1.conda
+  sha256: 5be1a59316e5063f4e6492ea86d692600a7b8e32caa25269f8a3b386a028e5f3
+  md5: b55fd11ab6318a6e67ac191309701d5a
+  depends:
+  - libgfortran5 13.2.0 h2873a65_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 109855
+  timestamp: 1694165674845
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_1.conda
+  sha256: 44de8930eef3b14d4d9fdfe419e6c909c13b7c859617d3616d5a5e964f3fcf63
+  md5: 3af564516b5163cd8cc08820413854bc
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1571764
+  timestamp: 1694165583047
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hac89ed1_0.tar.bz2
+  sha256: 4a3294037d595754f7da7c11a41f3922f995aaa333f3cb66f02d8afa032a7bc2
+  md5: 691d103d11180486154af49c037b7ed9
+  license: GPL and LGPL
+  size: 1378276
+  timestamp: 1652702364402
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+  sha256: d9572fd1024adc374aae7c247d0f29fdf4b122f1e3586fe62acc18067f40d02f
+  md5: 72507f8e3961bc968af17435060b6dd6
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 579748
+  timestamp: 1694475265912
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-19_osx64_openblas.conda
+  sha256: 6a1704c43a03195fecbbb226be5c257b2e37621e793967c3f31c8521f19e18df
+  md5: 2e714df18db99ee6d7b4ac728f53ca62
+  depends:
+  - libblas 3.9.0 19_osx64_openblas
+  constrains:
+  - libcblas 3.9.0 19_osx64_openblas
+  - liblapacke 3.9.0 19_osx64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14724
+  timestamp: 1697484756327
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-hc8e404f_4.conda
+  sha256: 0df3902a300cfe092425f86144d5e00ef67be3cd1cc89fd63084d45262a772ad
+  md5: ed06753e2ba7c66ed0ca7f19578fcb68
+  depends:
+  - libcxx >=15
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 22467131
+  timestamp: 1690563140552
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.2-nompi_h6a32802_112.conda
+  sha256: 8b1bfc9322bd4f9fe770461fac5b75b1888ccdbdf72b2d2a2bec1e1c13e05f48
+  md5: 413f9a35e9f888163b922ea6cfafb9da
+  depends:
+  - blosc >=1.21.4,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - libaec >=1.0.6,<2.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libcxx >=15.0.7
+  - libxml2 >=2.11.5,<2.14.0a0
+  - libzip >=1.10.1,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  - zlib
+  - zstd >=1.5.5,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 737489
+  timestamp: 1693582116713
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.55.1-hc0a10c5_0.conda
+  sha256: a0352eafcf148aa1dfa25f28cf30c80f70bc78c1e549fdec6b7aad100b865944
+  md5: a9269f10f70851af622c112d2956d544
+  depends:
+  - __osx >=10.9
+  - c-ares >=1.20.1,<2.0a0
+  - libcxx >=15.0.7
+  - libev >=4.33,<4.34.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.4,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 602957
+  timestamp: 1698429317306
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.24-openmp_h48a4ad5_0.conda
+  sha256: ff2c14f7ed121f1df3ad06bea353288eade77c12fb891212a27af88a61483490
+  md5: 077718837dd06cf0c3089070108869f6
+  depends:
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - llvm-openmp >=15.0.7
+  constrains:
+  - openblas >=0.3.24,<0.3.25.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6157393
+  timestamp: 1693785988209
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.39-ha978bb4_0.conda
+  sha256: 5ad9f5e96e6770bfc8b0a826f48835e7f337c2d2e9512d76027a62f9c120b2a3
+  md5: 35e4928794c5391aec14ffdf1deaaee5
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: zlib-acknowledgement
+  size: 271689
+  timestamp: 1669075890643
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.18-hbcb3906_1.tar.bz2
+  sha256: 2da45f14e3d383b4b9e3a8bacc95cd2832aac2dbf9fbc70d255d384a310c5660
+  md5: 24632c09ed931af617fe6d5292919cab
+  license: ISC
+  size: 528765
+  timestamp: 1605135849110
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.44.0-h92b6c6a_0.conda
+  sha256: 0832dc9cf18e811d2b41f8f4951d5ab608678e3459b1a4f36347097d8a9abf68
+  md5: 5dd5e957ebfee02720c30e0e2d127bbe
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Unlicense
+  size: 891073
+  timestamp: 1698854990507
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+  sha256: f3886763b88f4b24265db6036535ef77b7b77ce91b1cbe588c0fbdd861eec515
+  md5: ca3a72efba692c59a90d4b9fc0dfe774
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 259556
+  timestamp: 1685837820566
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h684deea_2.conda
+  sha256: 1ef5bd7295f4316b111f70ad21356fb9f0de50b85a341cac9e3a61ac6487fdf1
+  md5: 2ca10a325063e000ad6d2a5900061e0d
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=15.0.7
+  - libdeflate >=1.19,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: HPND
+  size: 266501
+  timestamp: 1695661828714
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.3.2-h0dc2134_0.conda
+  sha256: fa7580f26fec4c28321ec2ece1257f3293e0c646c635e9904679f4a8369be401
+  md5: 4e7e9d244e87d66c18d36894fd6a8ae5
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 346599
+  timestamp: 1694709233836
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.15-hb7f2c08_0.conda
+  sha256: f41904f466acc8b3197f37f2dd3a08da75720c7f7464d9267635debc4ac1902b
+  md5: 5513f57e0238c87c12dffedbcc9c1a4a
+  depends:
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 313793
+  timestamp: 1682083036825
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.11.5-h3346baf_1.conda
+  sha256: d901fab32e57a43c44e630fb1c4d0a163d23b109eecd6c68b9ee371800760bca
+  md5: 7584dee6af7de378aed0ae49aebedb8a
+  depends:
+  - icu >=73.2,<74.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 623399
+  timestamp: 1692960844532
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzip-1.10.1-hc158999_3.conda
+  sha256: 0689e4a6e67e80027e43eefb8a365273405a01f5ab2ece97319155b8be5d64f6
+  md5: 6112b3173f3aa2f12a8f40d07a77cc35
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 127599
+  timestamp: 1694416738467
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
+  sha256: fc58ad7f47ffea10df1f2165369978fba0a1cc32594aad778f5eec725f334867
+  md5: 4a3ad23f6e16f99c04e166767193d700
+  constrains:
+  - zlib 1.2.13 *_5
+  license: Zlib
+  license_family: Other
+  size: 59404
+  timestamp: 1686575566695
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-17.0.4-hb6ac08f_0.conda
+  sha256: d49b6958d22075de5fb707fd5f593cfa4be059015db48b7f1cd5e47e7efde2ff
+  md5: 31391b68245bc68504169e98ffaf2c44
+  constrains:
+  - openmp 17.0.4|17.0.4.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 299744
+  timestamp: 1698833439461
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.41.1-py310h7d48a1f_0.conda
+  sha256: ea37ec686c046b1e17a523f9c8820a7699a725b3ae24807ddbb207a0954c0c31
+  md5: 4cba3e22aa4d619d7c77797d3414ded6
+  depends:
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 294353
+  timestamp: 1697812863856
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+  sha256: 39aa0c01696e4e202bf5e337413de09dfeec061d89acd5f28e9968b4e93c3f48
+  md5: aa04f7143228308662696ac24023f991
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 156415
+  timestamp: 1674727335352
+- conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.3-py310h6729b98_1.conda
+  sha256: 62076b034a92959d25a1321a4340745ff87b5d191b3fcfef607b746daeb845c5
+  md5: 000b20b3974452969efe63f980b69e33
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23056
+  timestamp: 1695367898746
+- conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.8.1-py310hec49e92_0.conda
+  sha256: cd59ca7eb487240c64d377e094aa17903e840baeb85cc2a67fbda28b55d2e03e
+  md5: 0865e0cbc9aefda33a8b3f5348d178ba
+  depends:
+  - __osx >=10.12
+  - __osx >=10.9
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=16.0.6
+  - numpy >=1.21,<2
+  - numpy >=1.22.4,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.10.* *_cp310
+  license: PSF-2.0
+  license_family: PSF
+  size: 6936816
+  timestamp: 1698868969207
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-h93d8f39_2.conda
+  sha256: ea0fca66bbb52a1ef0687d466518fe120b5f279684effd6fd336a7b0dddc423a
+  md5: e58f366bd4d767e9ab97ab8b272e7670
+  depends:
+  - __osx >=10.9
+  license: X11 AND BSD-3-Clause
+  size: 822031
+  timestamp: 1698751567986
+- conda: https://conda.anaconda.org/conda-forge/osx-64/netcdf4-1.6.5-nompi_py310h30a4ba5_100.conda
+  sha256: 6362b982a6d5f7fa1ddd09554bc6552aacd81e2fedbd0a83d15c204e4212c550
+  md5: 0062c0ed9fb5da4d358fb106379e0a5c
+  depends:
+  - certifi
+  - cftime
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 458161
+  timestamp: 1698267301054
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.25.2-py310h7451ae0_0.conda
+  sha256: 77dbf044b2b9149e2038fdc4e99bacbff5e6163136abf84c3f94bbc438ead546
+  md5: a0f919ff93f102cb1720f71448010c61
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=15.0.7
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6475227
+  timestamp: 1691057173893
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.0-ha4da562_3.conda
+  sha256: fdccd9668b85bf6e798b628bceed5ff764e1114cfc4e6a4dee551cafbe549e74
+  md5: 40a36f8e9a6fdf6a78c6428ee6c44188
+  depends:
+  - libcxx >=15.0.7
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 335643
+  timestamp: 1694708811338
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.1.4-hd75f5a5_0.conda
+  sha256: 1c436103a8de0dc82c9c56974badaa1b8b8f8cd9f37c2766bd50cd9899720f6b
+  md5: bc9201da6eb1e0df4107901df5371347
+  depends:
+  - ca-certificates
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2320542
+  timestamp: 1698165459976
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.1.2-py310hdba192b_0.conda
+  sha256: 552e3cfb539d7aa3f2d3a91fd8a4ddf62b25baccc4d7b5a450c823bbb05a6cbc
+  md5: 82036b662ac55869e8aa672c4eac5604
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.10.* *_cp310
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11754710
+  timestamp: 1698376495827
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.1.0-py310he65384d_0.conda
+  sha256: bde2b4eca2d4b2ab33d7195867b9a369aca4727e2e4d1f17055a1507a2a825aa
+  md5: aa3e9b34eafaca521682eb48d80b80b2
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 46263448
+  timestamp: 1697423999759
+- conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.3.0-h23b96cc_2.conda
+  sha256: e1b0f351103555e0d8ab641aeba4076173c3b7a2f8ed738b43ec66709d51be15
+  md5: 63e960e8c8020936c0b73f23bfed16dd
+  depends:
+  - libcurl >=8.4.0,<9.0a0
+  - libsqlite >=3.43.2,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2732625
+  timestamp: 1697809094266
+- conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.5-py310h6729b98_1.conda
+  sha256: dc0079bc5833de86578da4d27ca7e44921a01e2da3cbb624922d2bcbc6b95876
+  md5: 941f32dc5bd1a725fbd4fd54aec75ed1
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 369757
+  timestamp: 1695367511232
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
+  sha256: 6e3900bb241bcdec513d4e7180fe9a19186c1a38f0b4080ed619d26014222c53
+  md5: addd19059de62181cd11ae8f4ef26084
+  license: MIT
+  license_family: MIT
+  size: 5653
+  timestamp: 1606147699844
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.0-py310hef2d279_0.conda
+  sha256: 68f246c0904266aa57b38255298710d87fb8db0b80f0e2f89b5ef488925bac80
+  md5: 9346ad035be9e76cf1184110571ab8e8
+  depends:
+  - libffi >=3.4,<4.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 418687
+  timestamp: 1695560652946
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.0-py310hef2d279_1.conda
+  sha256: 8784afcd959b99fba6bc7cf475141161f7fb7d8500ff8779fda645019973fe8d
+  md5: 801c23afa12fdaed4771a9e867cc794b
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 10.0.*
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 328263
+  timestamp: 1695716989533
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.6.1-py310h7e62555_3.conda
+  sha256: 760332fc561b29f80e106ab4b81c43723dfa81ddccad2915e5fbc9742021794d
+  md5: 2368c48d33287d9abc43b5d892717a84
+  depends:
+  - certifi
+  - proj >=9.3.0,<9.3.1.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 461041
+  timestamp: 1698058532021
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.10.13-h00d2728_0_cpython.conda
+  sha256: 388b4f2c0e638c5e3aa927256bdae3d4aca6ee70406191df378321aea3558aa3
+  md5: d09fa6ab82a97c95d3a324d79263b980
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.43.2,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.4,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.10.* *_cp310
+  license: Python-2.0
+  size: 12998833
+  timestamp: 1698344444453
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.10-4_cp310.conda
+  sha256: abc26b3b5a62f9c8112a2303d24b0c590d5f7fc9470521f5a520472d59c2223e
+  md5: b15c816c5a86abcc4d1458dd63aa4c65
+  constrains:
+  - python 3.10.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6484
+  timestamp: 1695147705581
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.1-py310h6729b98_1.conda
+  sha256: 00567f2cb2d1c8fede8fe7727f7bbd1c38cbca886814d612e162d5c936d8db1b
+  md5: d964cec3e7972e44bc4a328134b9eaf1
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 160097
+  timestamp: 1695373947773
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-25.1.1-py310hd8b4af3_2.conda
+  sha256: 286fd63ef90774f93956b36941487107b9e7f76807642454c4ff6d13ffd0ae83
+  md5: 077bc5af9c68c245eca66f927f93aaf1
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  size: 416671
+  timestamp: 1698062738767
+- conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+  sha256: 41e7d30a097d9b060037f0c6a2b1d4c4ae7e942c06c943d23f9d481548478568
+  md5: f17f77f2acf4d344734bda76829ce14e
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 255870
+  timestamp: 1679532707590
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.10.6-py310h0e083fb_0.conda
+  sha256: 5b1adacfa3c7f32bd871d31f8688e289385cd8974dcf352cdf91e9670cda458e
+  md5: 1d43921c3f2bbab79b4ba4e65a2499ab
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 289733
+  timestamp: 1697072688742
+- conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.11.3-py310h2db466d_1.conda
+  sha256: 9db6844496303ff8b788b36798073d5135d73b53bf37bc17a954de47e8a82fed
+  md5: 875c5e9c67f522102bd943351b463294
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=15.0.7
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy >=1.22.4,<1.28
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - libopenblas <0.3.26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15347225
+  timestamp: 1696469010531
+- conda: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.2-py310hcbf9397_0.conda
+  sha256: 6da8b59be0821b741bcbb4abc606843e5df660c49aff21aa9b8a95550f476a01
+  md5: 4db225079fdfe3fe81cc017fb184fd90
+  depends:
+  - geos >=3.12.0,<3.12.1.0a0
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 450994
+  timestamp: 1697191863153
+- conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
+  sha256: 575915dc13152e446a84e2f88de70a14f8b6af1a870e708f9370bd4be105583b
+  md5: 4320a8781f14cd959689b86e349f3b73
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 34657
+  timestamp: 1678534768395
+- conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.44.0-h7461747_0.conda
+  sha256: a222b2686f7e62c27ec2aaa64e7f2d927a883e5ef62e4ea060b6bd53c032cfca
+  md5: 4c125fcbf57aa07682468a1e9d202cfa
+  depends:
+  - libsqlite 3.44.0 h92b6c6a_0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 886889
+  timestamp: 1698855027090
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.10.0-h1c7c39f_2.conda
+  sha256: 81e3fae041696a9a74d493e49ab08ceda0022b4bd3716c1d88c0dae5435af94a
+  md5: 73434bcf87082942e938352afae9b0fa
+  license: Apache-2.0
+  license_family: APACHE
+  size: 159786
+  timestamp: 1697713666733
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hef22860_0.conda
+  sha256: 573e5d7dde0a63b06ceef2c574295cbc2ec8668ec08e35d2f2c6220f4aa7fb98
+  md5: 0c25eedcc888b6d765948ab62a18c03e
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3273909
+  timestamp: 1695506576288
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.3.3-py310h6729b98_1.conda
+  sha256: 04262bf61f3d36b6607ae233abcbed7edaaf5d6ca4539cf9c1b322bb465809f2
+  md5: 87e772235e713ab972ecdad6c3066ff3
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: Apache
+  size: 642837
+  timestamp: 1695373842662
+- conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-15.1.0-py310h6729b98_0.conda
+  sha256: 72fcdbd9e7b5e853ee7d25f88a54b83b69b6d6ac541f6faae393cc6475aa88be
+  md5: 5c82d8c1c3ba3b16df93ac6e7cac60bd
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: Apache
+  size: 366573
+  timestamp: 1695848504604
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
+  sha256: 8a2e398c4f06f10c64e69f56bcf3ddfa30b432201446a0893505e735b346619a
+  md5: 9566b4c29274125b0266d0177b5eb97b
+  license: MIT
+  license_family: MIT
+  size: 13071
+  timestamp: 1684638167647
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2
+  sha256: 485421c16f03a01b8ed09984e0b2ababdbb3527e1abf354ff7646f8329be905f
+  md5: 86ac76d6bf1cbb9621943eb3bd9ae36e
+  license: MIT
+  license_family: MIT
+  size: 17225
+  timestamp: 1610071995461
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+  sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
+  md5: a72f9d4ea13d55d745ff1ed594747f10
+  license: LGPL-2.1 and GPL-2.0
+  size: 238119
+  timestamp: 1660346964847
+- conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+  sha256: 5301417e2c8dea45b401ffee8df3957d2447d4ce80c83c5ff151fc6bfe1c4148
+  md5: d7e08fcf8259d742156188e8762b4d20
+  license: MIT
+  license_family: MIT
+  size: 84237
+  timestamp: 1641347062780
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h93d8f39_0.conda
+  sha256: 19be553b3cc8352b6e842134b8de66ae39fcae80bc575c203076370faab6009c
+  md5: 4c055e46b394be36681fe476c1e2ee6e
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 294253
+  timestamp: 1697057208271
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
+  sha256: d1f4c82fd7bd240a78ce8905e931e68dca5f523c7da237b6b63c87d5625c5b35
+  md5: 75a8a98b1c4671c5d2897975731da42d
+  depends:
+  - libzlib 1.2.13 h8a1eda9_5
+  license: Zlib
+  license_family: Other
+  size: 90764
+  timestamp: 1686575574678
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
+  sha256: d54e31d3d8de5e254c0804abd984807b8ae5cd3708d758a8bf1adff1f5df166c
+  md5: 80abc41d0c48b82fe0f04e7f42f5cb7e
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 499383
+  timestamp: 1693151312586
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py310h2aa6e3c_4.conda
+  sha256: 975ecb0ff5fe8b4d1b804ad5bd956c6f2baa2b8b346c1874444ab91e748207ba
+  md5: f3fb802f86dfd594219f0ebef6dbf2b2
+  depends:
+  - cffi >=1.0.1
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 33298
+  timestamp: 1695387264900
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.5-hc338f07_0.conda
+  sha256: 81f206dd843fe0da894d0480ea9d689fe948fa4b3cad060f97b016af4ac7b3a1
+  md5: 93fccb1150aa377576107ecd0ad375b3
+  depends:
+  - libcxx >=15.0.7
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33450
+  timestamp: 1693657320331
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hb547adb_1.conda
+  sha256: 62d1587deab752fcee07adc371eb20fcadc09f72c0c85399c22b637ca858020f
+  md5: a33aa58d448cbc054f887e39dd1dfaea
+  depends:
+  - brotli-bin 1.1.0 hb547adb_1
+  - libbrotlidec 1.1.0 hb547adb_1
+  - libbrotlienc 1.1.0 hb547adb_1
+  license: MIT
+  license_family: MIT
+  size: 19506
+  timestamp: 1695990588610
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hb547adb_1.conda
+  sha256: 8fbfc2834606292016f2faffac67deea4c5cdbc21a61169f0b355e1600105a24
+  md5: 990d04f8c017b1b77103f9a7730a5f12
+  depends:
+  - libbrotlidec 1.1.0 hb547adb_1
+  - libbrotlienc 1.1.0 hb547adb_1
+  license: MIT
+  license_family: MIT
+  size: 17001
+  timestamp: 1695990551239
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py310h1253130_1.conda
+  sha256: dab21e18c0275bfd93a09b751096998485677ed17c2e2d08298bc5b43c10bee1
+  md5: 26fab7f65a80fff9f402ec3b7860b88a
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - libbrotlicommon 1.1.0 hb547adb_1
+  license: MIT
+  license_family: MIT
+  size: 344275
+  timestamp: 1695990848681
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h3422bc3_4.tar.bz2
+  sha256: a3efbd06ad1432edb0163c48225421f34c2660f5cc002283a8d27e791320b549
+  md5: fc76ace7b94fb1f694988ab1b14dd248
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 151850
+  timestamp: 1618862645215
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.20.1-h93a5062_1.conda
+  sha256: 9f588eb920a793c6501120ed198d34afba763b2b2c0ae6de518c3735aea21d5e
+  md5: 2bb255dbcb73d1986e03cc5a7767c0bf
+  license: MIT
+  license_family: MIT
+  size: 101995
+  timestamp: 1697955983023
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.7.22-hf0a4a13_0.conda
+  sha256: b220c001b0c1448a47cc49b42a622e06a540ec60b3f7a1e057fca1f37ce515e4
+  md5: e1b99ac4dbcee71a71682996f67f7965
+  license: ISC
+  size: 149918
+  timestamp: 1690026385821
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cartopy-0.22.0-py310h6e3cc31_1.conda
+  sha256: f5d5f28ac4f18c4d379e60c3e4b52e124ab39450829b0ee7f3fa00ab5094539d
+  md5: 4cb1cca3372c5ae18e98dbc35b4f6ced
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - matplotlib-base >=3.4
+  - numpy >=1.22.4,<2.0a0
+  - packaging >=20
+  - pyproj >=3.1.0
+  - pyshp >=2.1
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - shapely >=1.7
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 1804460
+  timestamp: 1698173250472
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.16.0-py310hdcd7c05_0.conda
+  sha256: 4edab3f1f855554e10950efe064b75138943812af829a764f9b570d1a7189d15
+  md5: 8855823d908004e4d3b4fd4218795ad2
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 232227
+  timestamp: 1696002085787
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.3-py310h50ce23c_0.conda
+  sha256: 3de571628e5dc47a5f4ff9e3b8386934e8dab580495119fedba230af41d94387
+  md5: fc9369c9009008aa0180523d2750ac0a
+  depends:
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 203444
+  timestamp: 1698610345834
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.1.1-py310h38f39d4_1.conda
+  sha256: 5e831ffdd51c57ab9e2acc8edaf41b7ff0f9264d668efa763f2c463757b29e77
+  md5: 5dd6328bbdd8e8bbf900c58a8a992e3f
+  depends:
+  - libcxx >=15.0.7
+  - numpy >=1.16
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217854
+  timestamp: 1695554685453
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.0-py310h1253130_1.conda
+  sha256: 0d3c142bf54ae8d1015c45ac1eea2df0d24b4fe9eb76454bebc1ebb1d14485f5
+  md5: 9ae552e8e386da0f03a8eecf3e291f2f
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 2373153
+  timestamp: 1695534729081
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.43.1-py310hd125d64_0.conda
+  sha256: 4af15971bd6f5205a171a54b02122273d5168f3fd5cfe59a3091a6af883677ae
+  md5: f9cb2fb089b19c4971675947ebdd57e3
+  depends:
+  - brotli
+  - munkres
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - unicodedata2 >=14.0.0
+  license: MIT
+  license_family: MIT
+  size: 2153654
+  timestamp: 1696601781526
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+  sha256: 791673127e037a2dc0eebe122dc4f904cb3f6e635bb888f42cbe1a76b48748d9
+  md5: e6085e516a3e304ce41a8ee08b9b89ad
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 596430
+  timestamp: 1694616332835
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.12.0-h13dd4ca_0.conda
+  sha256: 8c21acd399d7509f6a7c7b65d5415e9500333a043f44dee063942d724adffc4a
+  md5: 18eb5904d2561c782e71bfe05b2ad755
+  depends:
+  - libcxx >=15.0.7
+  license: LGPL-2.1-only
+  size: 1441490
+  timestamp: 1687940009438
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
+  sha256: c3b01e3c3fe4ca1c4d28c287eaa5168a4f2fd3ffd76690082ac919244c22fa90
+  md5: ff5d749fd711dc7759e127db38005924
+  depends:
+  - libcxx >=15.0.7
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 762257
+  timestamp: 1695661864625
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.2-nompi_h3aba7b3_100.conda
+  sha256: 2749910e21a7d1f88a81dc4709fc3565a4a3954eadb4409e7a5be1fc13a5b7ca
+  md5: 842c5b010b219058098ebfe5aa5891b9
+  depends:
+  - libaec >=1.0.6,<2.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libcxx >=15.0.7
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  license: LicenseRef-HDF5
+  license_family: BSD
+  size: 3408759
+  timestamp: 1692562818610
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
+  sha256: ff9cd0c6cd1349954c801fb443c94192b637e1b414514539f3c49c56a39f51b1
+  md5: 8521bd47c0e11c5902535bb1a17c565f
+  license: MIT
+  license_family: MIT
+  size: 11997841
+  timestamp: 1692902104771
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-2.4-py310hbe9552e_3.conda
+  sha256: ac07094026e47cd74ae431343d17fb2cff34a41de88ad8532308086d73d01d1a
+  md5: 7e521c322debe4fb1ac5fea63307a724
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16651
+  timestamp: 1695397700350
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jupyter_core-5.5.0-py310hbe9552e_0.conda
+  sha256: 3b4e054bee8cf3542ec78dae27af9e53d00c1fc51f9f8b2f7d2d927b2ae0cfcd
+  md5: daa5e800e856140e7ffeaab3d2354621
+  depends:
+  - platformdirs >=2.5
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 79480
+  timestamp: 1698674093477
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.5-py310h38f39d4_1.conda
+  sha256: e84793b3bef7e5d92f96c511a06dc9cbcc49424995777595365c654effe67d6f
+  md5: 84392f391faad11ea910f38226590a88
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62043
+  timestamp: 1695380329047
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.2-h92f50d5_0.conda
+  sha256: 70bdb9b4589ec7c7d440e485ae22b5a352335ffeb91a771d4c162996c3070875
+  md5: 92f1cff174a538e0722bf2efb16fc0b2
+  depends:
+  - libcxx >=15.0.7
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.1.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1195575
+  timestamp: 1692098070699
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.15-hf2736f0_3.conda
+  sha256: 3d07ba04602617c3084b302c8a6fa30b2e4b20511180f45992b289c312298018
+  md5: bbaac531169fed3e09ae31aff80aa069
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 215466
+  timestamp: 1695969888308
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+  sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
+  md5: de462d5aacda3b30721b512c5da4e742
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 215721
+  timestamp: 1657977558796
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.2-h13dd4ca_1.conda
+  sha256: c9d6f01d511bd3686ce590addf829f34031b95e3feb34418496cbb45924c5d17
+  md5: b7962cdc2cedcc9f8d12928824c11fbd
+  depends:
+  - libcxx >=15.0.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29002
+  timestamp: 1696474168895
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-19_osxarm64_openblas.conda
+  sha256: 51e78e3c9fa57f3fec12936b760928715ba0ab5253d02815202f9ec4c2c9255d
+  md5: f50b1fd98593278e18319653cff9c475
+  depends:
+  - libopenblas >=0.3.24,<0.3.25.0a0
+  - libopenblas >=0.3.24,<1.0a0
+  constrains:
+  - libcblas 3.9.0 19_osxarm64_openblas
+  - liblapack 3.9.0 19_osxarm64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 19_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14817
+  timestamp: 1697484577887
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hb547adb_1.conda
+  sha256: 556f0fddf4bd4d35febab404d98cb6862ce3b7ca843e393da0451bfc4654cf07
+  md5: cd68f024df0304be41d29a9088162b02
+  license: MIT
+  license_family: MIT
+  size: 68579
+  timestamp: 1695990426128
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hb547adb_1.conda
+  sha256: c1c85937828ad3bc434ac60b7bcbde376f4d2ea4ee42d15d369bf2a591775b4a
+  md5: ee1a519335cc10d0ec7e097602058c0a
+  depends:
+  - libbrotlicommon 1.1.0 hb547adb_1
+  license: MIT
+  license_family: MIT
+  size: 28928
+  timestamp: 1695990463780
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hb547adb_1.conda
+  sha256: 690dfc98e891ee1871c54166d30f6e22edfc2d7d6b29e7988dde5f1ce271c81a
+  md5: d7e077f326a98b2cc60087eaff7c730b
+  depends:
+  - libbrotlicommon 1.1.0 hb547adb_1
+  license: MIT
+  license_family: MIT
+  size: 280943
+  timestamp: 1695990509392
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-19_osxarm64_openblas.conda
+  sha256: 19b1c5e3ddd383ec14540336f4704938218d3c1db4707ae10d5357afb22cccc1
+  md5: 5460a8d1beffd7f63994d891e6a20da4
+  depends:
+  - libblas 3.9.0 19_osxarm64_openblas
+  constrains:
+  - liblapack 3.9.0 19_osxarm64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 19_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14738
+  timestamp: 1697484590682
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.4.0-h2d989ff_0.conda
+  sha256: 5ca24ab030b1c56ce07921bf901ea99076e8b7e45586b4a04e5187cc67c87273
+  md5: afabb3372209028627ec03e206f4d967
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 348974
+  timestamp: 1697009607821
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.6-h4653b0c_0.conda
+  sha256: 11d3fb51c14832d9e4f6d84080a375dec21ea8a3a381a1910e67ff9cedc20355
+  md5: 9d7d724faf0413bf1dbc5a85935700c8
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1160232
+  timestamp: 1686896993785
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.19-hb547adb_0.conda
+  sha256: 6a3d188a6ae845a742dc85c5fb3f7eb1e252726cd74f0b8a7fa25ec09db6b87a
+  md5: f8c1eb0e99e90b55965c6558578537cc
+  license: MIT
+  license_family: MIT
+  size: 52841
+  timestamp: 1694924330786
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+  sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
+  md5: 30e4362988a2623e9eb34337b83e01f9
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 96607
+  timestamp: 1597616630749
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h642e427_1.tar.bz2
+  sha256: eb7325eb2e6bd4c291cb9682781b35b8c0f68cb72651c35a5b9dd22707ebd25c
+  md5: 566dbf70fe79eacdb3c3d3d195a27f55
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 100668
+  timestamp: 1598868103393
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+  md5: 086914b672be056eb70fd4285b6783b6
+  license: MIT
+  license_family: MIT
+  size: 39020
+  timestamp: 1636488587153
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_1.conda
+  sha256: bc8750e7893e693fa380bf2f342d4a5ce44995467cbdf72e56a00e5106b4892d
+  md5: 1ad37a5c60c250bb2b4a9f75563e181c
+  depends:
+  - libgfortran5 13.2.0 hf226fd6_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110095
+  timestamp: 1694172198016
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_1.conda
+  sha256: cb9cb11e49a6a8466ea7556a723080d3aeefd556df9b444b941afc5b54368b22
+  md5: 4480d71b98c87faafab132d33e23135e
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 995733
+  timestamp: 1694172076009
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-he4db4b2_0.tar.bz2
+  sha256: 2eb33065783b802f71d52bef6f15ce0fafea0adc8506f10ebd0d490244087bec
+  md5: 686f9c755574aa221f29fbcf36a67265
+  license: GPL and LGPL
+  size: 1407036
+  timestamp: 1652700956112
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+  sha256: a42054eaa38e84fc1e5ab443facac4bbc9d1b6b6f23f54b7bf4f1eb687e1d993
+  md5: 3ff1e053dc3a2b8e36b9bfa4256a58d1
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 547541
+  timestamp: 1694475104253
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-19_osxarm64_openblas.conda
+  sha256: f19cff537403c9feed98c7e18259022102b087f2b72a757e8a417476b9cf30c1
+  md5: 3638eacb084c374f41f9efa40d20a47b
+  depends:
+  - libblas 3.9.0 19_osxarm64_openblas
+  constrains:
+  - libcblas 3.9.0 19_osxarm64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 19_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14721
+  timestamp: 1697484603691
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_4.conda
+  sha256: 6f603914fe8633a615f0d2f1383978eb279eeb552079a78449c9fbb43f22a349
+  md5: 9f3dce5d26ea56a9000cd74c034582bd
+  depends:
+  - libcxx >=15
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 20571387
+  timestamp: 1690559110016
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnetcdf-4.9.2-nompi_hb2fb864_112.conda
+  sha256: fef33b99225691fce165cd1aadb85c823e2a3a9e5d67c3069f1d6b9ebbf53fdf
+  md5: fdd8c3b65f9369c4a5bbf23164ea8e19
+  depends:
+  - blosc >=1.21.4,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - libaec >=1.0.6,<2.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libcxx >=15.0.7
+  - libxml2 >=2.11.5,<2.14.0a0
+  - libzip >=1.10.1,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  - zlib
+  - zstd >=1.5.5,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 706702
+  timestamp: 1693582109664
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.55.1-h2b02ca0_0.conda
+  sha256: d30f26b57225609e1cd285921113bc634f008e83b1f2296245f468ca682e39a6
+  md5: eabfa8f7d2b7751ee28dc6762bbbf168
+  depends:
+  - __osx >=10.9
+  - c-ares >=1.20.1,<2.0a0
+  - libcxx >=15.0.7
+  - libev >=4.33,<4.34.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.4,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 590540
+  timestamp: 1698429620051
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.24-openmp_hd76b1f2_0.conda
+  sha256: 21edfdf620ac5c93571aab452199b6b4622c445441dad88ab4d2eb326a7b91b3
+  md5: aacb05989f358affe1bafd4ea7294db4
+  depends:
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - llvm-openmp >=15.0.7
+  constrains:
+  - openblas >=0.3.24,<0.3.25.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2849225
+  timestamp: 1693784744674
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.39-h76d750c_0.conda
+  sha256: 21ab8409a8e66f9408b96428c0a36a9768faee9fe623c56614576f9e12962981
+  md5: 0078e6327c13cfdeae6ff7601e360383
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: zlib-acknowledgement
+  size: 259412
+  timestamp: 1669075883972
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.18-h27ca646_1.tar.bz2
+  sha256: 1d95fe5e5e6a0700669aab454b2a32f97289c9ed8d1f7667c2ba98327a6f05bc
+  md5: 90859688dbca4735b74c02af14c4c793
+  license: ISC
+  size: 324912
+  timestamp: 1605135878892
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.44.0-h091b4b1_0.conda
+  sha256: 38e98953b572e2871f2b318fa7fe8d9997b0927970916c2d09402273b60ff832
+  md5: 28eb31a5b4e704353ed575758e2fcf1d
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Unlicense
+  size: 815079
+  timestamp: 1698855024189
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
+  sha256: bb57d0c53289721fff1eeb3103a1c6a988178e88d8a8f4345b0b91a35f0e0015
+  md5: 029f7dc931a3b626b94823bc77830b01
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 255610
+  timestamp: 1685837894256
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.6.0-ha8a6c65_2.conda
+  sha256: b18ef36eb90f190db22c56ae5a080bccc16669c8f5b795a6211d7b0c00c18ff7
+  md5: 596d6d949bab9a75a492d451f521f457
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=15.0.7
+  - libdeflate >=1.19,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: HPND
+  size: 246265
+  timestamp: 1695661829324
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.3.2-hb547adb_0.conda
+  sha256: a159b848193043fb58465ae6a449361615dadcf27babfe0b18db2bd3eb59e958
+  md5: 85dbc11098cdbe4244cd73f29a3ab795
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 273844
+  timestamp: 1694709510635
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.15-hf346824_0.conda
+  sha256: 6eaa87760ff3e91bb5524189700139db46f8946ff6331f4e571e4a9356edbb0d
+  md5: 988d5f86ab60fa6de91b3ee3a88a3af9
+  depends:
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 334770
+  timestamp: 1682082734262
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.11.5-h25269f3_1.conda
+  sha256: 8291549b87aca48e9cd4aec124af01b5037acd16f8ad14083d7af23c8bb6bebe
+  md5: 627b5d1377536b5b632ba53cd1455555
+  depends:
+  - icu >=73.2,<74.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 614831
+  timestamp: 1692960705224
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzip-1.10.1-ha0bc3c6_3.conda
+  sha256: fb42f34c2275523a06bc8464454fa57f2417203524cabb7aacca4e5de6cfeb69
+  md5: e37c0da207079e488709043634d6a711
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 128244
+  timestamp: 1694416824668
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
+  sha256: ab1c8aefa2d54322a63aaeeefe9cf877411851738616c4068e0dccc66b9c758a
+  md5: 1a47f5236db2e06a320ffa0392f81bd8
+  constrains:
+  - zlib 1.2.13 *_5
+  license: Zlib
+  license_family: Other
+  size: 48102
+  timestamp: 1686575426584
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-17.0.4-hcd81f8e_0.conda
+  sha256: 99a8145f38c02f317d1293eaf0e34af028d94d6854dfb2dd044702995cf74b89
+  md5: 88618857d4b3fadc13649d1a25cf1e4c
+  constrains:
+  - openmp 17.0.4|17.0.4.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 274893
+  timestamp: 1698833582372
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.41.1-py310hf7687f1_0.conda
+  sha256: b82628f3dc0abb0ae3df36f53154b2df2313aefb6fcb00d183378a947c3939e2
+  md5: e09ce237596d916e1098b6fcd8fe9cb4
+  depends:
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 292759
+  timestamp: 1697812897903
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+  sha256: fc343b8c82efe40819b986e29ba748366514e5ab94a1e1138df195af5f45fa24
+  md5: 45505bec548634f7d05e02fb25262cb9
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 141188
+  timestamp: 1674727268278
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.3-py310h2aa6e3c_1.conda
+  sha256: 4ea6a82aae3c846e8d2d4bf194124d552fb648b8ba07388be71bc52441fc69f1
+  md5: bcec7846de67985acb2152aa1fc0b45f
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23850
+  timestamp: 1695368071532
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.8.1-py310h9d2df84_0.conda
+  sha256: 1b1f81a41f2bedaa531893afedfe020f0757dad531c503737b3dc638d89da244
+  md5: 3648f4a76e70b0cf5d517207a6e5ef3e
+  depends:
+  - __osx >=10.9
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=16.0.6
+  - numpy >=1.21,<2
+  - numpy >=1.22.4,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python-dateutil >=2.7
+  - python_abi 3.10.* *_cp310
+  license: PSF-2.0
+  license_family: PSF
+  size: 6858677
+  timestamp: 1698869274529
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h463b476_2.conda
+  sha256: f6890634f815e8408d08f36503353f8dfd7b055e4c3b9ea2ee52180255cf4b0a
+  md5: 52b6f254a7b9663e854f44b6570ed982
+  depends:
+  - __osx >=10.9
+  license: X11 AND BSD-3-Clause
+  size: 794741
+  timestamp: 1698751574074
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/netcdf4-1.6.5-nompi_py310h3aafd6c_100.conda
+  sha256: 60c146c0f8548dfa3dc82f92477fe8c029339ab85421598e62cb1690dc85321b
+  md5: 7f5c1cf29a253ba7a219ddf507607b3f
+  depends:
+  - certifi
+  - cftime
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 452198
+  timestamp: 1698267929039
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.25.2-py310haa1e00c_0.conda
+  sha256: d8eddb8573609b03fa60f5daec29da55141a1faeff8c442bb4c6fd309e40411d
+  md5: 6242d13bf330eccd490979aaf3b5f7e4
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=15.0.7
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5765063
+  timestamp: 1691057015909
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.0-h4c1507b_3.conda
+  sha256: a6998c0da4643a84dc7c0b3a9e5137db258619ea922317bb7d9ae64f54b4a9ed
+  md5: 4127dd217a010d9c6cbefdaae07d9f19
+  depends:
+  - libcxx >=15.0.7
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 323335
+  timestamp: 1694708748389
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.1.4-h0d3ecfb_0.conda
+  sha256: 3c715b1d4940c7ad6065935db18924b85a54048dde066f963cfc250340639457
+  md5: 5a89552fececf4cd99628318ccbb67a3
+  depends:
+  - ca-certificates
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2147225
+  timestamp: 1698164947105
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.1.2-py310h6e3cc31_0.conda
+  sha256: 04f6137a2b4e7d7ca4ac8ae9172fa46f698299daf69a39241b0f06c0a84a430b
+  md5: f4541964837302ef276e39beec3930b6
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.10.* *_cp310
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11702193
+  timestamp: 1698376574975
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.1.0-py310hfae7ebd_0.conda
+  sha256: 6eb39a548c3597e1dffb16e593e47086955c33f0214b093c3588d564afae2bdf
+  md5: c66984e8d278284deb358f239b7e6f6c
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 46369279
+  timestamp: 1697424124892
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.3.0-h52fb9d0_2.conda
+  sha256: 6a76ab5ac69b1379d874a5b1405c15f13cc9fb3622a4a8837519c3328286e781
+  md5: 31cbb3c9d6f8611a657e1b1a4cb5c63d
+  depends:
+  - libcurl >=8.4.0,<9.0a0
+  - libsqlite >=3.43.2,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2599795
+  timestamp: 1697808957598
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.5-py310h2aa6e3c_1.conda
+  sha256: dd1c98a7d0b5d56b042d1ed4c9985efe34736e14fa01aaaa845b3fdc73ec7213
+  md5: 23345ff87d77b88a64c86e33129306bc
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372879
+  timestamp: 1695368032827
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
+  sha256: 9da9e6f5d51dff6ad2e4ee0874791437ba952e0a6249942273f0fedfd07ea826
+  md5: d3f26c6494d4105d4ecb85203d687102
+  license: MIT
+  license_family: MIT
+  size: 5696
+  timestamp: 1606147608402
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.0-py310hd07e440_0.conda
+  sha256: 64de496ae798d39e418d20f0152451f9f7f83ed2f204d40f942891a2f0fda4db
+  md5: 4025264a438b23779805d1fd159ba24d
+  depends:
+  - libffi >=3.4,<4.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 427210
+  timestamp: 1695560925704
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.0-py310hd07e440_1.conda
+  sha256: 85e9310323068c4e694747c28f6efd944bb87ebfa69917a64baf9a1bdc8d1107
+  md5: 28feb7a05b5f17f75f573688c402941a
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 10.0.*
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 331009
+  timestamp: 1695717008751
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.6.1-py310h2de6d0e_3.conda
+  sha256: 4b479e89e5960b74dc62b529d945f8f7066b7c7e114b1b12baf87edb55d5c4e6
+  md5: fdd61e39e6fcbb7f0f89f2711398272a
+  depends:
+  - certifi
+  - proj >=9.3.0,<9.3.1.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 467100
+  timestamp: 1698058691031
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.13-h2469fbe_0_cpython.conda
+  sha256: beac97704e80948a3bacba7001737a99e3908006aa6461d5564755854959eba2
+  md5: c962b55e55a14d30f61fe11b84c2b319
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.43.2,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.4,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.10.* *_cp310
+  license: Python-2.0
+  size: 11522758
+  timestamp: 1698344110843
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.10-4_cp310.conda
+  sha256: f69bac2f28082a275ef67313968b2c366d8236c3a6869b9cdf5cdb97a5821812
+  md5: 1a3d9c6bb5f0b1b22d9e9296c127e8c7
+  constrains:
+  - python 3.10.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6490
+  timestamp: 1695147522999
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.1-py310h2aa6e3c_1.conda
+  sha256: 7b8668cd86d2421c62ec241f840d84a600b854afc91383a509bbb60ba907aeec
+  md5: 0e7ccdd121ce7b486f1de7917178387c
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 158641
+  timestamp: 1695373859696
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-25.1.1-py310h7e65269_2.conda
+  sha256: 94d83f3a975a72cc361a54dfddb027c952bfb9deda3da19e436de945a50ba498
+  md5: 7a630fcdb5d56899b166641d9e19fb64
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  size: 422340
+  timestamp: 1698062895033
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+  sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
+  md5: 8cbb776a2f641b943d413b3e19df71f4
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 250351
+  timestamp: 1679532511311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.10.6-py310hd442715_0.conda
+  sha256: ee0e8cf43afc2dfaa5c59538bd22ae1164492082386b8ce4762ec1a4d05cfdc0
+  md5: 4e8643df730421abaec73eaaf99aef2e
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 289331
+  timestamp: 1697072771524
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.11.3-py310hd1cfc7d_1.conda
+  sha256: a5ab906f8921e9ce549f104bde9f78d67f54b17f58d56296e32dd460e7059f37
+  md5: 6d671552969c2b5843a8de25c2af3ba0
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=15.0.7
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy >=1.22.4,<1.28
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - libopenblas <0.3.26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13862445
+  timestamp: 1696469409228
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.2-py310h656ff59_0.conda
+  sha256: b8893266e77f0ae69aeb963b152fad69effcb55262b82fc85bcf90b21a66298d
+  md5: b45645084ef2ac7864efbe4d7f0a8c0e
+  depends:
+  - geos >=3.12.0,<3.12.1.0a0
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 446313
+  timestamp: 1697191756608
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
+  sha256: dfae03cd2339587871e53b42833657faa4c9e42e3e2c56ee9e32bc60797c7f62
+  md5: ac82a611d1a67a598096ebaa857198e3
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33879
+  timestamp: 1678534968831
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.44.0-hf2abe2d_0.conda
+  sha256: 8263043d2a5762a5bbbb4ceee28382d97e70182fff8d45371b65fedda0b709ee
+  md5: 0080e3f5d7d13d3b1e244ed24642ca9e
+  depends:
+  - libsqlite 3.44.0 h091b4b1_0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 800748
+  timestamp: 1698855055771
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.10.0-h1995070_2.conda
+  sha256: 5acedf2ba0d18217a6387f4788086e51cac56cef12ac120335fc3b31d40c0417
+  md5: 245760f53d4fa23bfb58ffbf89a4edc8
+  license: Apache-2.0
+  license_family: APACHE
+  size: 125356
+  timestamp: 1697713774680
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hb31c410_0.conda
+  sha256: 6df6ff49dba487eb891ddc0099642a36af2fe3929ed8023f76b745f0485c54a6
+  md5: aa913a828b65f30ee3aba9c59bb0b514
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3223549
+  timestamp: 1695506653047
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.3.3-py310h2aa6e3c_1.conda
+  sha256: 476ccfdc55e8eff548938b19cea93c5292770f8219d9b6d4f05f665ed60bc061
+  md5: 8e480fb72ff6963b2a1ceb2f2ede62cf
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: Apache
+  size: 641741
+  timestamp: 1695374073257
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-15.1.0-py310h2aa6e3c_0.conda
+  sha256: fd33715a75bc7d4ad863ac47341e9fdf8b78e47aa55c90f89a844c660aacc352
+  md5: 9dbba0c13148e8efbb80eb60186b2d8c
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: Apache
+  size: 377237
+  timestamp: 1695848435303
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
+  sha256: 02c313a1cada46912e5b9bdb355cfb4534bfe22143b4ea4ecc419690e793023b
+  md5: ca73dc4f01ea91e44e3ed76602c5ea61
+  license: MIT
+  license_family: MIT
+  size: 13667
+  timestamp: 1684638272445
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
+  sha256: d9a2fb4762779994718832f05a7d62ab2dcf6103a312235267628b5187ce88f7
+  md5: 6738b13f7fadc18725965abdd4129c36
+  license: MIT
+  license_family: MIT
+  size: 18164
+  timestamp: 1610071737668
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+  sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
+  md5: 39c6b54e94014701dd157f4f576ed211
+  license: LGPL-2.1 and GPL-2.0
+  size: 235693
+  timestamp: 1660346961024
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+  sha256: 93181a04ba8cfecfdfb162fc958436d868cc37db504c58078eab4c1a3e57fbb7
+  md5: 4bb3f014845110883a3c5ee811fd84b4
+  license: MIT
+  license_family: MIT
+  size: 88016
+  timestamp: 1641347076660
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h965bd2d_0.conda
+  sha256: 06abddc92d0bf83cd9faf25f26c98d7c2cc681cb50504011580b0584cf3cb1c5
+  md5: f460bbcb0ec8dc77989288fe8caa0f84
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 287460
+  timestamp: 1697056868401
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
+  sha256: de0ee1e24aa6867058d3b852a15c8d7f49f262f5828772700c647186d4a96bbe
+  md5: a08383f223b10b71492d27566fafbf6c
+  depends:
+  - libzlib 1.2.13 h53f4e23_5
+  license: Zlib
+  license_family: Other
+  size: 79577
+  timestamp: 1686575471024
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
+  sha256: 7e1fe6057628bbb56849a6741455bbb88705bae6d6646257e57904ac5ee5a481
+  md5: 5b212cfb7f9d71d603ad891879dc7933
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 400508
+  timestamp: 1693151393180
+- conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py310h8d17308_4.conda
+  sha256: ae143aec777823b2291caabc3fd89078a3ff12f41945e0f9abd168997ad35d39
+  md5: ece29c9dd68f962fd416a3ddcce24080
+  depends:
+  - cffi >=1.0.1
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 33906
+  timestamp: 1695387195123
+- conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.5-hdccc3a2_0.conda
+  sha256: 73cee35e5366ce998ef36ccccb4c11ef9ead297886cc08269379f91539131288
+  md5: 77a5cea2ce92907b7d1e7954457a526a
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50069
+  timestamp: 1693657396550
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-hcfcfb64_1.conda
+  sha256: b927c95121c5f3d82fe084730281739fb04621afebf2d9f05711a0f42d27e326
+  md5: f47f6db2528e38321fb00ae31674c133
+  depends:
+  - brotli-bin 1.1.0 hcfcfb64_1
+  - libbrotlidec 1.1.0 hcfcfb64_1
+  - libbrotlienc 1.1.0 hcfcfb64_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 19772
+  timestamp: 1695990547936
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-hcfcfb64_1.conda
+  sha256: 4fbcb8f94acc97b2b04adbc64e304acd7c06fa0cf01953527bddae46091cc942
+  md5: 0105229d7c5fabaa840043a86c10ec64
+  depends:
+  - libbrotlidec 1.1.0 hcfcfb64_1
+  - libbrotlienc 1.1.0 hcfcfb64_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 20885
+  timestamp: 1695990517506
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py310h00ffb61_1.conda
+  sha256: 8de77cf62a653dd6ffe19927b92c421f5fa73c078d7799181f5211a1bac2883b
+  md5: 42bfbc1d41cbe2696a3c9d8b0342324f
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libbrotlicommon 1.1.0 hcfcfb64_1
+  license: MIT
+  license_family: MIT
+  size: 321672
+  timestamp: 1695990897641
+- conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h8ffe710_4.tar.bz2
+  sha256: 5389dad4e73e4865bb485f460fc60b120bae74404003d457ecb1a62eb7abf0c1
+  md5: 7c03c66026944073040cb19a4f3ec3c9
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 152247
+  timestamp: 1606605223049
+- conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.7.22-h56e8100_0.conda
+  sha256: b85a6f307f8e1c803cb570bdfb9e4d811a361417873ecd2ecf687587405a72e0
+  md5: b1c2327b36f1a25d96f2039b0d3e3739
+  license: ISC
+  size: 150013
+  timestamp: 1690026269050
+- conda: https://conda.anaconda.org/conda-forge/win-64/cartopy-0.22.0-py310hecd3228_1.conda
+  sha256: ca4a23b933610e8922be7ae04a47504bd845327bfca5d44063cddd9161c01906
+  md5: e5776f7a1e024a4ce8d0d0d553e85b8c
+  depends:
+  - matplotlib-base >=3.4
+  - numpy >=1.22.4,<2.0a0
+  - packaging >=20
+  - pyproj >=3.1.0
+  - pyshp >=2.1
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - shapely >=1.7
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 1818314
+  timestamp: 1698173485680
+- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.16.0-py310h8d17308_0.conda
+  sha256: 1aeebb88518ab48c927d7360648a2799def172d8fcb0d7e20cb7208a3570ef9e
+  md5: b4bcce1a7ea1164e6dcea6c4f00d962b
+  depends:
+  - pycparser
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 237888
+  timestamp: 1696002116250
+- conda: https://conda.anaconda.org/conda-forge/win-64/cftime-1.6.3-py310h3e78b6c_0.conda
+  sha256: 73f41269bd2052e0ee71d6a1a985dca1664222ddd50d35d18d0ac4f117de1db6
+  md5: 00d6eac027a0d5c3676a362fb48fbb73
+  depends:
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 184772
+  timestamp: 1698610687537
+- conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.1.1-py310h232114e_1.conda
+  sha256: 791066ff598112b7b892a7f03994e5597b1959da114c3f6f0a900fa6b72b62b8
+  md5: 7062335928a7ca43c0163656637f96ff
+  depends:
+  - numpy >=1.16
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 174882
+  timestamp: 1695554536953
+- conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.0-py310h00ffb61_1.conda
+  sha256: c500ddc59777e7f7fc8f364ae1b9d6487343bc34bfd078a549fbd0f59c4efc1a
+  md5: 5ccaf32fb16dd1336f74a635ef6acf7d
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 3416775
+  timestamp: 1695534920376
+- conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.43.1-py310h8d17308_0.conda
+  sha256: 52a5990e8285ff9e19523b3a54b0b12184bba6c2e0c1d6b46ea35ba6c2c87e4e
+  md5: bf7aeb6342332abb73154d09305c15b2
+  depends:
+  - brotli
+  - munkres
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - unicodedata2 >=14.0.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1845371
+  timestamp: 1696601840402
+- conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+  sha256: 2c53ee8879e05e149a9e525481d36adfd660a6abda26fd731376fa64ff03e728
+  md5: 3761b23693f768dc75a8fd0a73ca053f
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-only OR FTL
+  size: 510306
+  timestamp: 1694616398888
+- conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.12.0-h1537add_0.conda
+  sha256: 096c45cb03240ae67ff9e09166110a3bd19a5ab20bf7deea8be55557792b9924
+  md5: 78119c25e59de33135b673375c6fa126
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-only
+  size: 1557552
+  timestamp: 1687939460054
+- conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
+  sha256: 52fa5dde69758c19c69ab68a3d7ebfb2c9042e3a55d405c29a59d3b0584fd790
+  md5: 84344a916a73727c1326841007b52ca8
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 779637
+  timestamp: 1695662145568
+- conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.2-nompi_h73e8ff5_100.conda
+  sha256: 86bab02f1dbc658a15719b27ca5dcd2b50c22905cc2296a31a0ed220dac746f9
+  md5: 7fc095c23e4519a8df15c09f3671d09a
+  depends:
+  - libaec >=1.0.6,<2.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LicenseRef-HDF5
+  license_family: BSD
+  size: 2044096
+  timestamp: 1692562772245
+- conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2023.2.0-h57928b3_50497.conda
+  sha256: dd9fded25ebe5c66af30ac6e3685146efdc2d7787035f01bfb546b347f138f6f
+  md5: a401f3cae152deb75bbed766a90a6312
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 2523079
+  timestamp: 1698351323119
+- conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-2.4-py310h5588dad_3.conda
+  sha256: 50b86f741719065c235dd00c706bc00fd5cc59cb48bf31505d8ff620a0eb7a02
+  md5: 55a7275d703b4c73bae42dcf54cc1441
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 32969
+  timestamp: 1695398011639
+- conda: https://conda.anaconda.org/conda-forge/win-64/jupyter_core-5.5.0-py310h5588dad_0.conda
+  sha256: 7dc48c8b66631de41c1f76981e05c0b2f5023bb2b95f3de088a6e2935ff8ed68
+  md5: 3e5945e27a3b647fe00097c27ffbd67c
+  depends:
+  - platformdirs >=2.5
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 95749
+  timestamp: 1698674415793
+- conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.5-py310h232114e_1.conda
+  sha256: 8969469887a0b72f732ec9250fd25982499270bda473a5db4c04ee252db96d89
+  md5: a340ed8a9c513e2782cb7feb3cfe665d
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55587
+  timestamp: 1695380469062
+- conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
+  sha256: 6002adff9e3dcfc9732b861730cb9e33d45fd76b2035b2cdb4e6daacb8262c0b
+  md5: 6e8b0f22b4eef3b3cb3849bb4c3d47f9
+  depends:
+  - openssl >=3.1.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 710894
+  timestamp: 1692098129546
+- conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.15-h67d730c_3.conda
+  sha256: 8819d74571b6321e0ed93b07c19b4fd9a9b669df3fdd797ab4798ab7c684ae1d
+  md5: f92e86636451e3f6cea03e395346fa90
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 498833
+  timestamp: 1695969944045
+- conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+  sha256: f4f39d7f6a2f9b407f8fb567a6c25755270421731d70f0ff331f5de4fa367488
+  md5: 1900cb3cab5055833cfddb0ba233b074
+  depends:
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30037
+  license: Apache-2.0
+  license_family: Apache
+  size: 194365
+  timestamp: 1657977692274
+- conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.2-h63175ca_1.conda
+  sha256: 731dc77bce7d6425e2113b902023fba146e827cfe301bac565f92cc4e749588a
+  md5: 0b252d2bf460364bccb1523bcdbe4af6
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 33554
+  timestamp: 1696474526588
+- conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-19_win64_mkl.conda
+  sha256: 915eae5e0dedbf87733a0b8c6f410678c77111a3fb26ca0a272e11ff979e7ef2
+  md5: 4f8a1a63cfbf74bc7b2813d9c6c205be
+  depends:
+  - mkl 2023.2.0 h6a75c08_50496
+  constrains:
+  - liblapack 3.9.0 19_win64_mkl
+  - libcblas 3.9.0 19_win64_mkl
+  - liblapacke 3.9.0 19_win64_mkl
+  - blas * mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4984180
+  timestamp: 1697485304263
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hcfcfb64_1.conda
+  sha256: f75fed29b0cc503d1b149a4945eaa32df56e19da5e2933de29e8f03947203709
+  md5: f77f319fb82980166569e1280d5b2864
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 70598
+  timestamp: 1695990405143
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hcfcfb64_1.conda
+  sha256: 1b352ee05931ea24c11cd4a994d673890fd1cc690c21e023e736bdaac2632e93
+  md5: 19ce3e1dacc7912b3d6ff40690ba9ae0
+  depends:
+  - libbrotlicommon 1.1.0 hcfcfb64_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 32788
+  timestamp: 1695990443165
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hcfcfb64_1.conda
+  sha256: eae6b76154e594c6d211160c6d1aeed848672618152a562e0eabdfa641d34aca
+  md5: 71e890a0b361fd58743a13f77e1506b7
+  depends:
+  - libbrotlicommon 1.1.0 hcfcfb64_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 246515
+  timestamp: 1695990479484
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-19_win64_mkl.conda
+  sha256: 66c8934bf8ead1e3ab3653155697a7d70878e96115742b681aac16d9bd25dd3d
+  md5: 1b9ede5cff953aa1a5f4d9f8ec644972
+  depends:
+  - libblas 3.9.0 19_win64_mkl
+  constrains:
+  - liblapack 3.9.0 19_win64_mkl
+  - liblapacke 3.9.0 19_win64_mkl
+  - blas * mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4984046
+  timestamp: 1697485351545
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.4.0-hd5e4a3a_0.conda
+  sha256: f1367d8a3f115ee4c16ea4bcc313c21009decb0217f65d3bb94618939c518a71
+  md5: 13e4e3824a0212103330f57058601c21
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: curl
+  license_family: MIT
+  size: 321118
+  timestamp: 1697009866852
+- conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.19-hcfcfb64_0.conda
+  sha256: e2886a84eaa0fbeca1d1d810270f234431d190402b4a79acf756ca2d16000354
+  md5: 002b1b723b44dbd286b9e3708762433c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 153203
+  timestamp: 1694922596415
+- conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+  sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
+  md5: 2c96d1b6915b408893f9472569dee135
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 42063
+  timestamp: 1636489106777
+- conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
+  sha256: 2e8c4bb7173f281a8e13f333a23c9fb7a1c86d342d7dccdd74f2eb583ddde450
+  md5: 87da045f6d26ce9fe20ad76a18f6a18a
+  depends:
+  - libxml2 >=2.11.5,<2.14.0a0
+  - pthreads-win32
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2578462
+  timestamp: 1694533393675
+- conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-h8ffe710_0.tar.bz2
+  sha256: 657c2a992c896475021a25faebd9ccfaa149c5d70c7dc824d4069784b686cea1
+  md5: 050119977a86e4856f0416e2edcf81bb
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: GPL and LGPL
+  size: 714518
+  timestamp: 1652702326553
+- conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+  sha256: 4e7808e3098b4b4ed7e287f63bb24f9045cc4d95bfd39f0db870fc2837d74dff
+  md5: 3f1b948619c45b1ca714d60c7389092c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 822966
+  timestamp: 1694475223854
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-19_win64_mkl.conda
+  sha256: e53093eab7674528e9eafbd5efa28f3170ec1388b8df6c9b8343760696f47907
+  md5: 574e6e8bcc85df2885eb2a87d31ae005
+  depends:
+  - libblas 3.9.0 19_win64_mkl
+  constrains:
+  - libcblas 3.9.0 19_win64_mkl
+  - liblapacke 3.9.0 19_win64_mkl
+  - blas * mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4984073
+  timestamp: 1697485397401
+- conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_h8284064_112.conda
+  sha256: 6694fb1a949893178c3e0c7df648f5b9875da5ba9b1d76ec5d9a5bac6647dfc6
+  md5: d13288269ee4de9079261a31028f9954
+  depends:
+  - blosc >=1.21.4,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - libaec >=1.0.6,<2.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libxml2 >=2.11.5,<2.14.0a0
+  - libzip >=1.10.1,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  - zstd >=1.5.5,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 625332
+  timestamp: 1693582445195
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.39-h19919ed_0.conda
+  sha256: 1f139a72109366ba1da69f5bdc569b0e6783f887615807c02d7bfcc2c7575067
+  md5: ab6febdb2dbd9c00803609079db4de71
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: zlib-acknowledgement
+  size: 343883
+  timestamp: 1669076173145
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.18-h8d14728_1.tar.bz2
+  sha256: ecc463f0ab6eaf6bc5bd6ff9c17f65595de6c7a38db812222ab8ffde0d3f4bc2
+  md5: 5c1fb45b5e2912c19098750ae8a32604
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: ISC
+  size: 713431
+  timestamp: 1605135918736
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.44.0-hcfcfb64_0.conda
+  sha256: b2be4125343d89765269b537e90ea5ab7f219e7398e7ad610ddcdcf31e7b9e65
+  md5: 446fb1973cfeb8b32de4add3c9ac1057
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 852871
+  timestamp: 1698855272921
+- conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+  sha256: 813fd04eed2a2d5d9c36e53c554f9c1f08e9324e2922bd60c9c52dbbed2dbcec
+  md5: dc262d03aae04fe26825062879141a41
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 266806
+  timestamp: 1685838242099
+- conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-h6e2ebb7_2.conda
+  sha256: f7b50b71840a5d8edd74a8bccf0c173ca2599bd136e366c35722272b4afa0500
+  md5: 08d653b74ee2dec0131ad4259ffbb126
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.19,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: HPND
+  size: 787430
+  timestamp: 1695662030293
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.3.2-hcfcfb64_0.conda
+  sha256: af1453fab10d1fb8b379c61a78882614051a8bac37307d7ac4fb58eac667709e
+  md5: dcde8820959e64378d4e06147ffecfdd
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 268870
+  timestamp: 1694709461733
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.15-hcd874cb_0.conda
+  sha256: d01322c693580f53f8d07a7420cd6879289f5ddad5531b372c3efd1c37cac3bf
+  md5: 090d91b69396f14afef450c285f9758c
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 969788
+  timestamp: 1682083087243
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.11.5-hc3477c8_1.conda
+  sha256: ad3b5a510be2c5f9fe90b2c20e10adb135717304bcb3a197f256feb48d713d99
+  md5: 27974f880a010b1441093d9f737a949f
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1600640
+  timestamp: 1692960798126
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzip-1.10.1-h1d365fa_3.conda
+  sha256: 221698b52dd7a3dcfc67ff9460e9c8649fc6c86506a2a2ab6f57b97e7489bb9f
+  md5: 5c629cd12d89e2856c17b1dc5fcf44a4
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 146434
+  timestamp: 1694417117772
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
+  sha256: c161822ee8130b71e08b6d282b9919c1de2c5274b29921a867bca0f7d30cad26
+  md5: 5fdb9c6a113b6b6cb5e517fd972d5f41
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - zlib 1.2.13 *_5
+  license: Zlib
+  license_family: Other
+  size: 55800
+  timestamp: 1686575452215
+- conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.41.1-py310hb84602e_0.conda
+  sha256: 02aa55c906b6e93281d273ef0be245399e6eeba537aa89f29771f4a33b2032ec
+  md5: 97bdd633c07c02428c9cd3e0f96fffe2
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - vs2015_runtime
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17044662
+  timestamp: 1697813094424
+- conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+  sha256: a0954b4b1590735ea5f3d0f4579c3883f8ac837387afd5b398b241fda85124ab
+  md5: e34720eb20a33fc3bfb8451dd837ab7a
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134235
+  timestamp: 1674728465431
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+  sha256: 9de95a7996d5366ae0808eef2acbc63f9b11b874aa42375f55379e6715845dc6
+  md5: 066552ac6b907ec6d72c0ddab29050dc
+  depends:
+  - m2w64-gcc-libs-core
+  - msys2-conda-epoch ==20160418
+  license: GPL, LGPL, FDL, custom
+  size: 350687
+  timestamp: 1608163451316
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+  sha256: 3bd1ab02b7c89a5b153a17be03b36d833f1517ff2a6a77ead7c4a808b88196aa
+  md5: fe759119b8b3bfa720b8762c6fdc35de
+  depends:
+  - m2w64-gcc-libgfortran
+  - m2w64-gcc-libs-core
+  - m2w64-gmp
+  - m2w64-libwinpthread-git
+  - msys2-conda-epoch ==20160418
+  license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  size: 532390
+  timestamp: 1608163512830
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+  sha256: 58afdfe859ed2e9a9b1cc06bc408720cb2c3a6a132e59d4805b090d7574f4ee0
+  md5: 4289d80fb4d272f1f3b56cfe87ac90bd
+  depends:
+  - m2w64-gmp
+  - m2w64-libwinpthread-git
+  - msys2-conda-epoch ==20160418
+  license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  size: 219240
+  timestamp: 1608163481341
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+  sha256: 7e3cd95f554660de45f8323fca359e904e8d203efaf07a4d311e46d611481ed1
+  md5: 53a1c73e1e3d185516d7e3af177596d9
+  depends:
+  - msys2-conda-epoch ==20160418
+  license: LGPL3
+  size: 743501
+  timestamp: 1608163782057
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+  sha256: f63a09b2cae7defae0480f1740015d6235f1861afa6fe2e2d3e10bd0d1314ee0
+  md5: 774130a326dee16f1ceb05cc687ee4f0
+  depends:
+  - msys2-conda-epoch ==20160418
+  license: MIT, BSD
+  size: 31928
+  timestamp: 1608166099896
+- conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.3-py310h8d17308_1.conda
+  sha256: cab9683af159f18b782a876afb4aa3f84512dc3c39e4315a963ba267751581da
+  md5: 8bb26993f6787d08908136ce07894bf0
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26628
+  timestamp: 1695367927795
+- conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.8.1-py310hc9baf74_0.conda
+  sha256: 76664e8cd7fe300b573a425118f1dae4c3cb34103290657cafde7d784fc57eed
+  md5: fd4cfecda859c56727e7ba9e1e4aca96
+  depends:
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.21,<2
+  - numpy >=1.22.4,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 6858257
+  timestamp: 1698869437063
+- conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2023.2.0-h6a75c08_50496.conda
+  sha256: 40dc6ac2aa071ca248223de7cdbdfdb216bc8632a17104b1507bcbf9276265d4
+  md5: 03da367d935ecf4d3e4005cf705d0e21
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 144749783
+  timestamp: 1695995252418
+- conda: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+  sha256: 99358d58d778abee4dca82ad29fb58058571f19b0f86138363c260049d4ac7f1
+  md5: b0309b72560df66f71a9d5e34a5efdfa
+  size: 3227
+  timestamp: 1608166968312
+- conda: https://conda.anaconda.org/conda-forge/win-64/netcdf4-1.6.5-nompi_py310h6477780_100.conda
+  sha256: 404b33445e5e6787d9f12ffa673fcba18e36cecade7b565a6a2b71c00cccf623
+  md5: 61183feee146a6f0e1db2dc2503f5ad6
+  depends:
+  - certifi
+  - cftime
+  - hdf5 >=1.14.2,<1.14.4.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - setuptools
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 409577
+  timestamp: 1698267509096
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.25.2-py310hd02465a_0.conda
+  sha256: 4418a99e711ed162b69d57f3c277f5e4999501dc80c89fb75f51cc59abfbcdc4
+  md5: faeadcd33c1207e7bedd0ee8621ba25a
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6122526
+  timestamp: 1691057309489
+- conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.0-h3d672ee_3.conda
+  sha256: c0f64d9642f0287f17cd9b6f1633d97a91efd66a0cb9b0414c540b247684985d
+  md5: 45a9628a04efb6fc326fff0a8f47b799
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 236847
+  timestamp: 1694708878963
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.1.4-hcfcfb64_0.conda
+  sha256: e30b7f55c27d06e3322876c9433a3522e751d06a40b3bb6c4f8b4bcd781a3794
+  md5: 2eebbc64373a1c6db62ad23304e9678e
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 7427765
+  timestamp: 1698166937344
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.1.2-py310hecd3228_0.conda
+  sha256: 070cd5e5836781025c8427e727d829ea02a2e2a85fad58ca4f25aa5bc99b7ab6
+  md5: 39b6f0729da51e283460be3bb2df1722
+  depends:
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.10.* *_cp310
+  - pytz >=2020.1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11212385
+  timestamp: 1698376773341
+- conda: https://conda.anaconda.org/conda-forge/win-64/pillow-10.1.0-py310h1e6a543_0.conda
+  sha256: df8f9c4d830bd7a8400640bb01efa2a0675b26d1a9a82ab8b404c638d11dbe5b
+  md5: 8ce37528536360e773a0f80750e39a02
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - tk >=8.6.13,<8.7.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: HPND
+  size: 45101565
+  timestamp: 1697424198092
+- conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.3.0-he13c7e8_2.conda
+  sha256: 67a5d032a0343dc8182ef50221d9ee47edb50d34cd94813e65111901cbbbc6d3
+  md5: 4e6d2a06874a1a6cd66e842d29bcd373
+  depends:
+  - libcurl >=8.4.0,<9.0a0
+  - libsqlite >=3.43.2,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2645178
+  timestamp: 1697808796596
+- conda: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.5-py310h8d17308_1.conda
+  sha256: 6c03b652b5d1488fe88ce1a20ee4a072b44277b05002d2af7d2db19643d50b3d
+  md5: bd83570cfe0ce9ccc46c9c55b0aab666
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 380206
+  timestamp: 1695367659588
+- conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-hcd874cb_1001.tar.bz2
+  sha256: bb5a6ddf1a609a63addd6d7b488b0f58d05092ea84e9203283409bff539e202a
+  md5: a1f820480193ea83582b13249a7e7bd9
+  depends:
+  - m2w64-gcc-libs
+  license: MIT
+  license_family: MIT
+  size: 6417
+  timestamp: 1606147814351
+- conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
+  sha256: 576a228630a72f25d255a5e345e5f10878e153221a96560f2498040cd6f54005
+  md5: e2da8758d7d51ff6aa78a14dfb9dbed4
+  depends:
+  - vc 14.*
+  license: LGPL 2
+  size: 144301
+  timestamp: 1537755684331
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.6.1-py310hebb2149_3.conda
+  sha256: 1ae78ab9599ce7a81b256b734612b2e58caebfee830efea218a68987e1647a84
+  md5: 1512c146408b8913baf55ab4f5fe86f3
+  depends:
+  - certifi
+  - proj >=9.3.0,<9.3.1.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 711953
+  timestamp: 1698058549786
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.10.13-h4de0772_0_cpython.conda
+  sha256: 9e55fa834ddb2c24aec8ee4d4738584fea71edc084a615facc846ce90deb58e4
+  md5: cbf696b644613f8ab6c9df6b5005c042
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.43.2,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.4,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - vc >=14.1,<15
+  - vc14_runtime >=14.16.27033
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.10.* *_cp310
+  license: Python-2.0
+  size: 15891788
+  timestamp: 1698344089500
+- conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.10-4_cp310.conda
+  sha256: 19066c462fd0e32c64503c688f77cb603beb4019b812caf855d03f2a5447960b
+  md5: b41195997c14fb7473d26637ea4c3946
+  constrains:
+  - python 3.10.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6773
+  timestamp: 1695147715814
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-306-py310h00ffb61_2.conda
+  sha256: 24fd15c118974da18c38870380195e633d2452a7fb7dbc0ecb96b44416989b33
+  md5: a65056c5f52aa83455577958872e4776
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 5689476
+  timestamp: 1695974437046
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.12-py310h00ffb61_0.conda
+  sha256: a9fafd16ef160c9c11ac45f932b53916c5ad4c7c06ba0fb96b4859a8af879358
+  md5: 3cc562064a5d055f371ccc281b8e6396
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 209900
+  timestamp: 1696657831046
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.1-py310h8d17308_1.conda
+  sha256: ea51291e477b44c5bb9d91cc095db0dfe07b9576831e9682100d68c820c43ae3
+  md5: ce279186f68d0f12812dc9955ea909a4
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 146195
+  timestamp: 1695374085323
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-25.1.1-py310h2849c00_2.conda
+  sha256: 5643d7efaf8cc714a1dd7f4c4a1fea36bd9d12665af40bb10137ad0ee99e956d
+  md5: 4ef6bc04df33ba9a13145bc2ac254346
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  size: 409451
+  timestamp: 1698063170421
+- conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.10.6-py310h87d50f1_0.conda
+  sha256: 59c08da9235fcea135bc35205c95079cdb86e2197a54d223db8efe2818dea1b5
+  md5: 97b168f58652c59e954611962e47cd5c
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 186246
+  timestamp: 1697073096998
+- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.11.3-py310hf667824_1.conda
+  sha256: f51267072791bfda871b947b43efd73f0d3c5a5e581e4f47a611000c5c34d4e5
+  md5: 1325302e74eb18b8666f53559844bf44
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy >=1.22.4,<1.28
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libopenblas <0.3.26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14064238
+  timestamp: 1696469923075
+- conda: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.2-py310h839b4a8_0.conda
+  sha256: 9eeedc0fc8f45c1ff4b196c8e9efdd408578346d246905ba371e1710176167d4
+  md5: fccafb1aec64a793deb7de374ab3f760
+  depends:
+  - geos >=3.12.0,<3.12.1.0a0
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 450886
+  timestamp: 1697191990260
+- conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
+  sha256: 2a195b38cb63f03ad9f73a82db52434ebefe216fb70f7ea3defe4ddf263d408a
+  md5: cff1df79c9cff719460eb2dd172568de
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 57065
+  timestamp: 1678534804734
+- conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.44.0-hcfcfb64_0.conda
+  sha256: f6a4ae8130b32f566d0e406ebeb315671e202f08408fd69c512f38fb8efc0c7c
+  md5: 8bd8b9fbf5116bc98f5d6eef70f82af9
+  depends:
+  - libsqlite 3.44.0 hcfcfb64_0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 856389
+  timestamp: 1698855293276
+- conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.10.0-h91493d7_2.conda
+  sha256: e55a2f1324f0fc8916ab8d590a3944ba1af62de727bb66e3019cf2744d26e679
+  md5: 5b8c97cf8f0e81d6c22c0bda9978790d
+  depends:
+  - libhwloc >=2.9.3,<2.9.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 156566
+  timestamp: 1697713986066
+- conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-hcfcfb64_0.conda
+  sha256: 7e42db6b5f1c5ef8d4660e6ce41b52802b6c2fdc270d5e1eccc0048d0a3f03a8
+  md5: 74405f2ccbb40af409fee1a71ce70dc6
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: TCL
+  license_family: BSD
+  size: 3478482
+  timestamp: 1695506766462
+- conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.3.3-py310h8d17308_1.conda
+  sha256: 60b864e7cf17737055016e1754534316a0234d83f15eb454b983ee1b5151f982
+  md5: 0d14d73d94d679e2fa753ea8c7f75926
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 644644
+  timestamp: 1695373991492
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+  sha256: f29cdaf8712008f6b419b8b1a403923b00ab2504bfe0fb2ba8eb60e72d4f14c6
+  md5: 72608f6cd3e5898229c3ea16deb1ac43
+  constrains:
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-Proprietary
+  license_family: PROPRIETARY
+  size: 1283972
+  timestamp: 1666630199266
+- conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-15.1.0-py310h8d17308_0.conda
+  sha256: 7beadca7de88d62b65124a98e0c442cef787dac2ac41768deb7200fd33d07603
+  md5: f9f25aeb0eed2dd8c770f137c45da3c2
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 370116
+  timestamp: 1695848575933
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h64f974e_17.conda
+  sha256: 86ae94bf680980776aa761c2b0909a0ddbe1f817e7eeb8b16a1730f10f8891b6
+  md5: 67ff6791f235bb606659bf2a5c169191
+  depends:
+  - vc14_runtime >=14.36.32532
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17176
+  timestamp: 1688020629925
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.36.32532-hdcecf7f_17.conda
+  sha256: b317d49af32d5c031828e62c08d56f01d9a64cd3f40d4cccb052bc38c7a9e62e
+  md5: d0de20f2f3fc806a81b44fcdd941aaf7
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.36.32532.* *_17
+  license: LicenseRef-ProprietaryMicrosoft
+  license_family: Proprietary
+  size: 739437
+  timestamp: 1694292382336
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.36.32532-h05e6639_17.conda
+  sha256: 5ecbd731dc7f13762d67be0eadc47eb7f14713005e430d9b5fc680e965ac0f81
+  md5: 4618046c39f7c81861e53ded842e738a
+  depends:
+  - vc14_runtime >=14.36.32532
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17207
+  timestamp: 1688020635322
+- conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: 9df10c5b607dd30e05ba08cbd940009305c75db242476f4e845ea06008b0a283
+  md5: 1cee351bf20b830d991dbe0bc8cd7dfe
+  license: MIT
+  license_family: MIT
+  size: 1176306
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-hcd874cb_0.conda
+  sha256: 8c5b976e3b36001bdefdb41fb70415f9c07eff631f1f0155f3225a7649320e77
+  md5: c46ba8712093cb0114404ae8a7582e1a
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  license: MIT
+  license_family: MIT
+  size: 51297
+  timestamp: 1684638355740
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.3-hcd874cb_0.tar.bz2
+  sha256: f51205d33c07d744ec177243e5d9b874002910c731954f2c8da82459be462b93
+  md5: 46878ebb6b9cbd8afcf8088d7ef00ece
+  depends:
+  - m2w64-gcc-libs
+  license: MIT
+  license_family: MIT
+  size: 67908
+  timestamp: 1610072296570
+- conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+  sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
+  md5: 515d77642eaa3639413c6b1bc3f94219
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: LGPL-2.1 and GPL-2.0
+  size: 217804
+  timestamp: 1660346976440
+- conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+  sha256: 4e2246383003acbad9682c7c63178e2e715ad0eb84f03a8df1fbfba455dfedc5
+  md5: adbfb9f45d1004a26763652246a33764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 63274
+  timestamp: 1641347623319
+- conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-h63175ca_0.conda
+  sha256: f8377793c36e19da17bbb8cf517f1a969b89e1cc7cb9622dc6d60c3d1383c919
+  md5: e954e1881091405f36416f772292b396
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 4210250
+  timestamp: 1697057168534
+- conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.2.13-hcfcfb64_5.conda
+  sha256: 0f91b719c7558046bcd37fdc7ae4b9eb2b7a8e335beb8b59ae7ccb285a46aa46
+  md5: a318e8622e11663f645cc7fa3260f462
+  depends:
+  - libzlib 1.2.13 hcfcfb64_5
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Zlib
+  license_family: Other
+  size: 107711
+  timestamp: 1686575474476
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
+  sha256: d540dd56c5ec772b60e4ce7d45f67f01c6614942225885911964ea1e70bb99e3
+  md5: 792bb5da68bf0a6cac6a6072ecb8dbeb
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 343428
+  timestamp: 1693151615801
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.58.0-py310h3ea8b11_0.tar.bz2
+  sha256: 0eecaea15f46f9bcf1392262faa3ed2cbf64b4f98e95088e3f42c1efcb6bb519
+  md5: 6d825f806dc9820553efa9e66cf18441
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.41.0,<0.42.0a0
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.26
+  - python >=3.10,<3.11.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - libopenblas !=0.3.6
+  - tbb >=2021.6,<2022
+  - scipy >=1.0
+  - cuda-python >=11.6
+  - cudatoolkit >=10.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4475081
+  timestamp: 1697060520994
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.58.0-py310h46d7db6_0.tar.bz2
+  sha256: a47c3719fc68271b9f08f92d005e8b59035e667110ffd4af770f95be07dd2011
+  md5: ca2352ac96f73e72c6ee2d529f2d0f22
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.41.0,<0.42.0a0
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.26
+  - python >=3.10,<3.11.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - cuda-python >=11.6
+  - tbb >=2021.6,<2022
+  - libopenblas >=0.3.18, !=0.3.20
+  - scipy >=1.0
+  - cudatoolkit >=10.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4467616
+  timestamp: 1697059934712
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.58.0-py310h4ed8f06_0.tar.bz2
+  sha256: ef94b7ab322b2022dacf3c6d341722134392956392898993f73b4fd564956150
+  md5: ec04b1df1520441322807c9570cc2b85
+  depends:
+  - llvmlite >=0.41.0,<0.42.0a0
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.26
+  - python >=3.10,<3.11.0a0
+  - tbb >=2021.8.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - tbb >=2021.6,<2022
+  - scipy >=1.0
+  - cudatoolkit >=10.2
+  - cuda-python >=11.6
+  - libopenblas !=0.3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4516446
+  timestamp: 1697075806876

--- a/ml_annotators/pixi.lock
+++ b/ml_annotators/pixi.lock
@@ -8,8 +8,8 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -477,7 +477,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h93d8f39_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.58.0-py310h3ea8b11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numba-0.58.0-py310h3ea8b11_0.tar.bz2
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.3-pyhd8ed1ab_0.tar.bz2
@@ -709,7 +709,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h965bd2d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.58.0-py310h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numba-0.58.0-py310h46d7db6_0.tar.bz2
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
@@ -941,7 +941,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.2.13-hcfcfb64_5.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.58.0-py310h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numba-0.58.0-py310h4ed8f06_0.tar.bz2
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -7140,7 +7140,7 @@ packages:
   license_family: BSD
   size: 343428
   timestamp: 1693151615801
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.58.0-py310h3ea8b11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numba-0.58.0-py310h3ea8b11_0.tar.bz2
   sha256: 0eecaea15f46f9bcf1392262faa3ed2cbf64b4f98e95088e3f42c1efcb6bb519
   md5: 6d825f806dc9820553efa9e66cf18441
   depends:
@@ -7160,7 +7160,7 @@ packages:
   license_family: BSD
   size: 4475081
   timestamp: 1697060520994
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.58.0-py310h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numba-0.58.0-py310h46d7db6_0.tar.bz2
   sha256: a47c3719fc68271b9f08f92d005e8b59035e667110ffd4af770f95be07dd2011
   md5: ca2352ac96f73e72c6ee2d529f2d0f22
   depends:
@@ -7180,7 +7180,7 @@ packages:
   license_family: BSD
   size: 4467616
   timestamp: 1697059934712
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.58.0-py310h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numba-0.58.0-py310h4ed8f06_0.tar.bz2
   sha256: ef94b7ab322b2022dacf3c6d341722134392956392898993f73b4fd564956150
   md5: ec04b1df1520441322807c9570cc2b85
   depends:

--- a/ml_annotators/pixi.toml
+++ b/ml_annotators/pixi.toml
@@ -21,8 +21,8 @@ geoviews = "*"
 holoviews = "*"
 panel = "*"
 param = "*"
-pip = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [activation.env]
 MPLBACKEND = "Agg"

--- a/ml_annotators/pixi.toml
+++ b/ml_annotators/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "ml_annotators"
-channels = ["conda-forge", "https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["conda-forge", "main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/ml_annotators/pixi.toml
+++ b/ml_annotators/pixi.toml
@@ -1,0 +1,31 @@
+[workspace]
+name = "ml_annotators"
+channels = ["conda-forge", "https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2020-01-13"
+maintainers = ["jbednar", "philippjfr"]
+categories = ["Geospatial"]
+labels = ["holoviews", "geoviews", "bokeh"]
+description = "Using Bokeh/HoloViews/GeoViews for annotating data for ML"
+no_data_ingestion = true
+
+[dependencies]
+python = "3.10.*"
+numpy = "*"
+notebook = "*"
+pandas = "*"
+bokeh = "*"
+geoviews = "*"
+holoviews = "*"
+panel = "*"
+param = "*"
+pip = "*"
+wheel = "*"
+
+[activation.env]
+MPLBACKEND = "Agg"
+
+[tasks]
+notebook = "jupyter notebook ml_annotators.ipynb"

--- a/multichannel_timeseries/pixi.lock
+++ b/multichannel_timeseries/pixi.lock
@@ -8,7 +8,6 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
-    - url: https://conda.anaconda.org/nodefaults/
     indexes:
     - https://pypi.org/simple
     packages:

--- a/multichannel_timeseries/pixi.lock
+++ b/multichannel_timeseries/pixi.lock
@@ -1,0 +1,11846 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/nodefaults/
+    indexes:
+    - https://pypi.org/simple
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311h9ecbd09_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.8.0-hb88c0a9_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.8.0-hecf86a2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.10.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.0-hf42f96a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.0-h1ffe551_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.9.1-hab05fe4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.15.2-hdeadb07_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.11.0-h7bd072d_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.7.4-h3a84f74_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.1-hf42f96a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.2-hf42f96a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.29.6-h159bff8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.449-h5558e3c_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.14.0-h5cfcd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.10.0-h113e628_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.13.0-h3cf044e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.8.0-h736e048_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.12.0-ha633028_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-hef167b5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hfdbb021_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.3-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.1-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.0.0-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.9-py311hfdbb021_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.55.1-py311h2dc5d0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h743c826_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.13.0-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.3-h77b800c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.12.1-nompi_py311hb639ac4_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_h2d575fe_107.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.18-h6688a6e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.7-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_h5888daf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.7-hadbb8c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-18.1.0-he15abb1_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-18.1.0-h5888daf_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-18.1.0-h5888daf_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-18.1.0-h5c8f2c3_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.1.1-h1909e37_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libde265-1.0.15-h00ab1b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.10.0-h7250d82_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.31.0-h804f50b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.31.0-h0121fbd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.67.1-hc2c308b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libheif-1.18.2-gpl_hffcb242_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-hf539b9f_1021.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.6.3-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.6.3-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-18.1.0-h6bd9018_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hbbce691_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h97f6797_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h1b4f908_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hf672d98_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.21.0-h0e7cc3e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-hc4654cb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-hf23e847_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-hb346dea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.43.0-py311h9c9ff8c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.3-py311h2cbdf9a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hd590300_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py311h2dc5d0c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.3-py311h2b939e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.7-h401b404_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mne-lsl-1.8.0-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.0-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.60.0-py311h4bc866e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.14.1-py311h7db5c69_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.0.2-py311h71ddf71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.3-he039a57_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py311h7db5c69_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.0.0-py311h49e9ac3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.5.1-h0054346_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-18.1.0-py311h38be061_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-18.1.0-py311h4854187_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.27.1-py311h9e33e62_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.6.1-py311h0f98d5a_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.11-h9e4cc4f_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py311h7deb3e3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.4.3-py311h5394301_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.6.6-he8a937b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h77b4e00_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.22.3-py311h9e33e62_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.9-h0fd0ee4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py311he9a78e4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.47.0-h9eae976_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-2.3.0-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.2-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.5-h988505b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.6.3-hbcc6ac9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.6.3-hbcc6ac9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.6.3-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py311hbc35293_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cf_xarray-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.12.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.12.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.20-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.12.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holonote-0.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.10.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lazy_loader-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mne-base-1.8.0-pyh694c41f_200.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhff2d567_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ndpyramid-0.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.10.3-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyqtgraph-0.13.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/qtpy-2.4.2-pyhdecd6ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-datatree-0.0.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.18.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - pypi: https://files.pythonhosted.org/packages/07/51/e0f59b86f93e31d5c813dffbc31cf65b512a427849438189f3be8a156394/tsdownsample-0.1.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/20/8a/767a70e04e4532c05f2b60dc817672e5bfec4911ca6655e8943eadf80670/h5io-0.2.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/c7/56f50f023e19b0abd3ac93b86d64afdb58a16cca197441be9201bae367b7/pymatreader-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/45/fc303eb433e8a2a271739c98e953728422fa61a3c1f36077a49e395c972e/xmltodict-0.14.2-py2.py3-none-any.whl
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cf_xarray-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.12.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.12.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.20-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.12.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holonote-0.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.10.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lazy_loader-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mne-base-1.8.0-pyh694c41f_200.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhff2d567_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ndpyramid-0.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.10.3-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyqtgraph-0.13.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/qtpy-2.4.2-pyhdecd6ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-datatree-0.0.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.18.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.9.1-hf036a51_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h3336109_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.8.0-hb1b2711_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.8.0-h1c3498a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.10.3-h6e16a3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.3.0-h1c3498a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.5.0-heedde58_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.9.1-h0c96e2d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.15.2-h789f5c1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.11.0-h00ab244_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.7.4-h704940e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.2.1-h1c3498a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.2.2-h1c3498a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.29.6-h8618fae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.449-he3c0133_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.14.0-h9a36307_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.10.0-ha4e2ba9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.13.0-h3d2f5f1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.8.0-h1ccc5ac_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-files-datalake-cpp-12.12.0-h86941f0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.6-h7d75f6d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hd89902b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.3-hf13058a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.8.30-h8857fd0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.1-py311h137bacd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.1-py311h4e34fa0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.0.0-py311h3336109_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/dav1d-1.2.1-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.9-py311hc356e98_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.55.1-py311ha3cf9ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3ec172f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.13.0-hac325c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/geotiff-1.7.3-h2b6e260_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hac325c4_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h2790a97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.12.1-nompi_py311h82f1de1_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.3-nompi_h1607680_107.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/json-c-0.18-hc62ec3d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.7-py311hf2f7c97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240722.0-cxx17_hac325c4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.7.7-h7988bea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-18.1.0-h14b790f_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-18.1.0-he5ac762_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-18.1.0-he5ac762_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-18.1.0-h16335c3_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libavif16-1.1.1-h71406da_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-25_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-25_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.10.1-h58e7537_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.5-hf95d169_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libde265-1.0.15-h7728843_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.22-h00291cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.4-h240833e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.10.0-h04043bc_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.31.0-hd00c612_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.31.0-h3f2b517_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.67.1-he6e0b18_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libheif-1.18.2-gpl_h57a3ca0_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libkml-1.3.0-h9ee1731_1021.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-25_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-hc8e404f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.6.3-hd471939_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-devel-5.6.3-hd471939_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.64.0-hc7306c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_hbf64a52_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-18.1.0-h436316b_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.44-h4b8f8c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-5.28.2-h8b30cf6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2024.07.02-hd530cb8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/librttopo-1.1.0-hdfb80b9_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libspatialite-5.1.0-hc43c327_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.0-h2f8c449_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-h3dc7d44_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.21.0-h75589b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-hf4bdac2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.9.0-h6e16a3a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.5-h495214b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.5-ha54dae1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.43.0-py311h25b8078_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-4.3.3-py311h12b7ed1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lzo-2.10-h10d778d_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.2-py311ha3cf9ac_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.3-py311h19a4563_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.0.7-h62b0c8d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/mne-lsl-1.8.0-py311h4e34fa0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.1.0-py311hf2f7c97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.60.0-py311h0e5bd6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numcodecs-0.14.1-py311hcf53e2f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.0.2-py311h14ed71f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hd471939_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.3-h5cd248e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.3-py311haeb46be_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.44-h7634a1b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.0.0-py311h1f68098_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.5.1-h5273da6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.0-py311h1314207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-18.1.0-py311h6eed73b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-18.1.0-py311he02522f_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pydantic-core-2.27.1-py311h3b9c2be_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.3.2-py311hfbc4093_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.3.2-py311hfbc4093_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.6.1-py311h50e4d0a_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.11-h9ccd52b_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311h3336109_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.2.0-py311h4d3da15_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rasterio-1.4.3-py311h7ab2778_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rav1e-0.6.6-h7205ca4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2024.07.02-h2fb0a26_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.22.3-py311h3b9c2be_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.1-py311hed734c1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-he1e6707_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.47.0-h6285a30_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/svt-av1-2.3.0-h97d8b74_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.2-py311h4d7f069_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-15.1.0-py311h1314207_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/uriparser-0.9.8-h6aefe2f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/x265-3.5-hbb4e6a2_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xerces-c-3.2.5-h197e74d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h00291cd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.6.3-h357f2ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-gpl-tools-5.6.3-h357f2ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-tools-5.6.3-hd471939_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h7130eaa_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-hd23fc13_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py311hdf6fcd6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
+      - pypi: https://files.pythonhosted.org/packages/1d/d4/9189084a953dbb83deceb1c43f4b834986b4137f0d83059e8cb049012d74/tsdownsample-0.1.3-cp311-cp311-macosx_10_12_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/20/8a/767a70e04e4532c05f2b60dc817672e5bfec4911ca6655e8943eadf80670/h5io-0.2.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/c7/56f50f023e19b0abd3ac93b86d64afdb58a16cca197441be9201bae367b7/pymatreader-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/45/fc303eb433e8a2a271739c98e953728422fa61a3c1f36077a49e395c972e/xmltodict-0.14.2-py2.py3-none-any.whl
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cf_xarray-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.12.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.12.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.20-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.12.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holonote-0.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.10.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lazy_loader-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mne-base-1.8.0-pyh694c41f_200.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhff2d567_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ndpyramid-0.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.10.3-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyqtgraph-0.13.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/qtpy-2.4.2-pyhdecd6ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-datatree-0.0.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.18.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.9.1-h7bae524_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311h460d6c5_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.8.0-h9b725a8_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.8.0-h5d7ee29_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.10.3-h5505292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.0-h5d7ee29_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.5.0-h13ead76_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.9.1-hf483d09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.15.2-h39f8ad8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.11.0-h68a0d7e_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.7.4-h840aca7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.1-h5d7ee29_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.2-h5d7ee29_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.29.6-h8474b10_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.449-h3b64406_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.14.0-hd50102c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.10.0-hc602bab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.13.0-h7585a09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.8.0-h9ca1f76_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.12.0-hcdd55da_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h5499902_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311h3f08180_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.3-h5505292_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py311h3a79f62_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.1-py311h210dab8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.0.0-py311h460d6c5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.9-py311h155a34a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.55.1-py311h4921393_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-hfbad9fb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.13.0-hf9b8971_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geotiff-1.7.3-h82bf549_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.12.1-nompi_py311h0fa3d65_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.3-nompi_ha698983_107.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/json-c-0.18-he4178ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py311h267d04e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.7-py311h2c37856_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_hf9b8971_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.7.7-h7c07d2a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-18.1.0-h654e1bb_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-18.1.0-h605b82c_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-18.1.0-h605b82c_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-18.1.0-h9b432b6_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libavif16-1.1.1-h45b7238_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-25_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-25_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.10.1-h13a7ad3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.5-ha82da77_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libde265-1.0.15-h2ffa867_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.22-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.10.0-h9ccd308_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.31.0-h8d8be31_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.31.0-h7081f7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.67.1-hc70892a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libheif-1.18.2-gpl_he913df3_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libkml-1.3.0-he250239_1021.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-25_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.6.3-h39f12f2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-devel-5.6.3-h39f12f2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-18.1.0-h5168bdf_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.28.2-h8f0b736_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2024.07.02-h2348fd5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/librttopo-1.1.0-ha2cf0f4_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libspatialite-5.1.0-hffd3212_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.47.0-hbaaea75_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h9cc3647_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.21.0-h64651cc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-ha962b0a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.9.0-h5505292_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.13.5-hbbdcc80_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.5-hdb05f8b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.43.0-py311hc367efa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-4.3.3-py311hebe0b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h93a5062_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py311h4921393_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.9.3-py311h031da69_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/minizip-4.0.7-h27ee973_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mne-lsl-1.8.0-py311h210dab8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.0-py311h2c37856_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.60.0-py311h9506ed5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numcodecs-0.14.1-py311hca32420_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.0.2-py311h649a571_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h39f12f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.3-h121fd32_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py311h9cb3ce9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-h297a79d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.0.0-py311h3894ae9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.5.1-h1318a7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py311hae2e1ce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-18.1.0-py311ha1ab1f8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-18.1.0-py311he04fa90_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.27.1-py311h3ff9189_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.3.2-py311hab620ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.3.2-py311hab620ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.6.1-py311hb4b81e0_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.11-hc22306f_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h460d6c5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.0-py311h730b646_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rasterio-1.4.3-py311h09e72dc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rav1e-0.6.6-h69fbcac_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2024.07.02-hcd0e937_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.22.3-py311h3ff9189_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.1-py311hf1db568_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.47.0-hcd14bea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-2.3.0-hf24288c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.2-py311h917b07b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-15.1.0-py311hae2e1ce_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uriparser-0.9.8-h00cdb27_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xerces-c-3.2.5-h92fc2f4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.6.3-h9a6d368_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-gpl-tools-5.6.3-h9a6d368_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-tools-5.6.3-h39f12f2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-hc1bb282_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py311ha60cc69_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+      - pypi: https://files.pythonhosted.org/packages/20/8a/767a70e04e4532c05f2b60dc817672e5bfec4911ca6655e8943eadf80670/h5io-0.2.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/50/53/20e415e48ebd7fb7f39b369dd25734b82eae7217ff58bbf49b2a0c677743/tsdownsample-0.1.3-cp311-cp311-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/c7/56f50f023e19b0abd3ac93b86d64afdb58a16cca197441be9201bae367b7/pymatreader-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/45/fc303eb433e8a2a271739c98e953728422fa61a3c1f36077a49e395c972e/xmltodict-0.14.2-py2.py3-none-any.whl
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cf_xarray-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.11-py311hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.12.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.12.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.20-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.12.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holonote-0.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.10.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh5737063_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lazy_loader-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mne-base-1.8.0-pyh694c41f_200.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhff2d567_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ndpyramid-0.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.10.3-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyqtgraph-0.13.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/qtpy-2.4.2-pyhdecd6ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-datatree-0.0.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.18.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/_libavif_api-1.1.1-h57928b3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311he736701_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.8.0-h6c5491b_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.8.0-hb414858_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.10.3-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.3.0-hb414858_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.5.0-hab6af6e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.9.1-hab0f966_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.15.2-hef77f12_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.11.0-hbfeb708_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.7.4-h6108ab3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.2.1-hb414858_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.2.2-hb414858_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.29.6-h505e3f6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.449-h0ed5b37_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.6-h85f69ea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311hda3d55a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.34.3-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.1-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.0.0-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.9-py311hda3d55a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.55.1-py311h5082efb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-h8276f4a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.13.0-h5a68840_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.3-h496ac4d_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.12.1-nompi_py311h67016bb_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_hd5d9e70_107.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.7-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_he0c23c2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.7.7-h88ece9c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-18.1.0-h0ea94f9_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-18.1.0-hb6457b2_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-18.1.0-hb6457b2_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-18.1.0-h30d554c_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libavif16-1.1.1-h4d049a7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libde265-1.0.15-h91493d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.22-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.4-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-14.2.0-h1383e82_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.10.0-ha193a43_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-14.2.0-h1383e82_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.31.0-h07d40e7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.31.0-he5eb982_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.67.1-h7aa3b8a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libheif-1.18.2-gpl_hc631cee_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.2-default_ha69328c_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-h538826c_1021.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.6.3-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-devel-5.6.3-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-18.1.0-he61daf8_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.28.2-hcaed137_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2024.07.02-h4eb7d71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-hd4c2148_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-h939089a_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.0-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-he619c9f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.21.0-hbe90ef8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hfc51747_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.9.0-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.5-h442d1da_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.43.0-py311h7deaa30_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-4.3.3-py311h8b5e962_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lzo-2.10-hcfcfb64_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py311h5082efb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.3-py311h8f1b1e4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/minizip-4.0.6-hb638d1e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mne-lsl-1.8.0-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.0-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.60.0-py311h0673bce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numcodecs-0.14.1-py311hcf9f919_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.0.2-py311h35ffc71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.4.0-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.3-h34659fe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py311hcf9f919_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.0.0-py311h4fbf6a9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.5.1-h4f671f6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.1.0-py311h1ea47a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.1.0-py311hdea38fa_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.27.1-py311h533ab2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.6.1-py311h90dcb63_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.11-h3f84c4b_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-307-py311hda3d55a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.14-py311hda3d55a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.2.0-py311h484c95c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rasterio-1.4.3-py311hf418590_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rav1e-0.6.6-h975169c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2024.07.02-hd3b24a8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.22.3-py311h533ab2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py311hf16d85f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.47.0-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/svt-av1-2.3.0-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-h62715c5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.2-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-15.1.0-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34433-he29a5d6_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hdffcdeb_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.2.5-he0c23c2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-h0e40799_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.5-h0e40799_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.6.3-h208afaa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xz-tools-5.6.3-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py311h53056dc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+      - pypi: https://files.pythonhosted.org/packages/20/8a/767a70e04e4532c05f2b60dc817672e5bfec4911ca6655e8943eadf80670/h5io-0.2.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/66/ac/58ab1f1c86422cea13df0bf62dc0beb3d96f2c7831a4adcd49278df1f9fe/tsdownsample-0.1.3-cp311-none-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/c7/56f50f023e19b0abd3ac93b86d64afdb58a16cca197441be9201bae367b7/pymatreader-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/45/fc303eb433e8a2a271739c98e953728422fa61a3c1f36077a49e395c972e/xmltodict-0.14.2-py2.py3-none-any.whl
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  license: None
+  size: 2562
+  timestamp: 1578324546067
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23621
+  timestamp: 1650670423406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
+  sha256: b08ef033817b5f9f76ce62dfcac7694e7b6b4006420372de22494503decac855
+  md5: 346722a0be40f6edc53f12640d301338
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2706396
+  timestamp: 1718551242397
+- conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311h9ecbd09_5.conda
+  sha256: d1af1fbcb698c2e07b0d1d2b98384dd6021fa55c8bcb920e3652e0b0c393881b
+  md5: 18143eab7fcd6662c604b85850f0db1e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.0.1
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 35025
+  timestamp: 1725356735679
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.8.0-hb88c0a9_10.conda
+  sha256: d2837a84e6bd7d993a83e79f9e240e1465e375f3d57149ea5b1927c6a4133bcc
+  md5: 409b7ee6d3473cc62bda7280f6ac20d0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 107163
+  timestamp: 1731733534767
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.8.0-hecf86a2_2.conda
+  sha256: 220a37955c120bf2f565fbd5320a82fc4c8b550b2449294bc0509c296cfcb9fa
+  md5: c54459d686ad9d0502823cacff7e8423
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - libgcc >=13
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 47477
+  timestamp: 1731678510949
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.10.3-hb9d3cd8_0.conda
+  sha256: 90bd2ff40b65acb62f11e2500ee7b7e85ac77d2e332429002f4c1da949bec27f
+  md5: ff3653946d34a6a6ba10babb139d96ef
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 237137
+  timestamp: 1731567278052
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.0-hf42f96a_2.conda
+  sha256: 210ba4fff1c9500fe02de1dae311ce723bfa313a2d21b72accd745f736f56fce
+  md5: 257f4ae92fe11bd8436315c86468c39b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 19034
+  timestamp: 1731678703956
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.0-h1ffe551_7.conda
+  sha256: 3b780d6483baa889e8df5aa66ab3c439a9c81331cf2a4799e373f4174768ddd9
+  md5: 7cce4dfab184f4bbdfc160789251b3c5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 53500
+  timestamp: 1731714597524
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.9.1-hab05fe4_2.conda
+  sha256: 90a325b6f5371dd2203b643de646967fe57a4bcbbee8c91086abbf9dd733d59a
+  md5: fb409f7053fa3dbbdf6eb41045a87795
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-compression >=0.3.0,<0.3.1.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 196945
+  timestamp: 1731714483279
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.15.2-hdeadb07_2.conda
+  sha256: 1636136a5d882b4aaa13ea8b7de8cf07038a6878872e3c434df9daf478cee594
+  md5: 461a1eaa075fd391add91bcffc9de0c1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - libgcc >=13
+  - s2n >=1.5.9,<1.5.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 159368
+  timestamp: 1731702542973
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.11.0-h7bd072d_8.conda
+  sha256: 51d3d87a47c642096e2ce389a169aec2e26958042e9130857552a12d65a19045
+  md5: 0e9d67838114c0dbd267a9311268b331
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 194447
+  timestamp: 1731734668760
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.7.4-h3a84f74_0.conda
+  sha256: 91c6f7aa3dd230bcefe2654469b0704c2bdb2574e6d0d7c56cf9e9071f44cc26
+  md5: 7d029b9aa9decf4c0fb8a9a8940c9906
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - libgcc >=13
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 113660
+  timestamp: 1733299194447
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.1-hf42f96a_1.conda
+  sha256: f6e38c79b124c34edb048c28ec58fdfc4ea8f7a218dc493195afbada48ba063b
+  md5: bbdd20fb1994a9f0ba98078fcb6c12ab
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 55738
+  timestamp: 1731687063424
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.2-hf42f96a_1.conda
+  sha256: da802ace5448481c968cfec7e7a4f79f686f42df9de8e3f78c09a925c2882a79
+  md5: d908d43d87429be24edfb20e96543c20
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 72744
+  timestamp: 1731687193373
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.29.6-h159bff8_2.conda
+  sha256: 04ca62caa764bb95f304af8486c1af7c4f76d4ad5204c494edcf86af653d2ad0
+  md5: c498e6490834aacf7835c96403862881
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-mqtt >=0.11.0,<0.11.1.0a0
+  - aws-c-s3 >=0.7.4,<0.7.5.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 354822
+  timestamp: 1733333950713
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.449-h5558e3c_4.conda
+  sha256: 4881f7b4f5e3c797332cffb990df246a422346b220a9c16014f274beb2a276f5
+  md5: ba7abdc93b0ade11d774b47aaab84737
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2945541
+  timestamp: 1732812288219
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.14.0-h5cfcd09_0.conda
+  sha256: fe07debdb089a3db17f40a7f20d283d75284bb4fc269ef727b8ba6fc93f7cb5a
+  md5: 0a8838771cc2e985cd295e01ae83baf1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 345117
+  timestamp: 1728053909574
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.10.0-h113e628_0.conda
+  sha256: 286b31616c191486626cb49e9ceb5920d29394b9e913c23adb7eb637629ba4de
+  md5: 73f73f60854f325a55f1d31459f2ab73
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 232351
+  timestamp: 1728486729511
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.13.0-h3cf044e_1.conda
+  sha256: 2606260e5379eed255bcdc6adc39b93fb31477337bcd911c121fc43cd29bf394
+  md5: 7eb66060455c7a47d9dcdbfa9f46579b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  size: 549342
+  timestamp: 1728578123088
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.8.0-h736e048_1.conda
+  sha256: 273475f002b091b66ce7366da04bf164c3732c03f8692ab2ee2d23335b6a82ba
+  md5: 13de36be8de3ae3f05ba127631599213
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.12.7,<2.14.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 149312
+  timestamp: 1728563338704
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.12.0-ha633028_1.conda
+  sha256: 5371e4f3f920933bb89b926a85a67f24388227419abd6e99f6086481e5e8d5f2
+  md5: 7c1980f89dd41b097549782121a73490
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  size: 287366
+  timestamp: 1728729530295
+- conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-hef167b5_0.conda
+  sha256: 6cc260f9c6d32c5e728a2099a52fdd7ee69a782fff7b400d0606fcd32e0f5fd1
+  md5: 54fe76ab3d0189acaef95156874db7f9
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48842
+  timestamp: 1719266029046
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_2.conda
+  sha256: fcb0b5b28ba7492093e54f3184435144e074dfceab27ac8e6a9457e736565b0b
+  md5: 98514fe74548d768907ce7a13f680e8f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli-bin 1.1.0 hb9d3cd8_2
+  - libbrotlidec 1.1.0 hb9d3cd8_2
+  - libbrotlienc 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 19264
+  timestamp: 1725267697072
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_2.conda
+  sha256: 261364d7445513b9a4debc345650fad13c627029bfc800655a266bf1e375bc65
+  md5: c63b5e52939e795ba8d26e35d767a843
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlidec 1.1.0 hb9d3cd8_2
+  - libbrotlienc 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 18881
+  timestamp: 1725267688731
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hfdbb021_2.conda
+  sha256: 949913bbd1f74d1af202d3e4bff2e0a4e792ec00271dc4dd08641d4221aa2e12
+  md5: d21daab070d76490cb39a8f1d1729d79
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  license: MIT
+  license_family: MIT
+  size: 350367
+  timestamp: 1725267768486
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+  sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
+  md5: 62ee74e96c5ebb0af99386de58cf9553
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 252783
+  timestamp: 1720974456583
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.3-hb9d3cd8_1.conda
+  sha256: 732571ba6286dbccbf4c6450078a581b7a5620204faf876ff0ef282d77a6bfa8
+  md5: ee228789a85f961d14567252a03e725f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 204857
+  timestamp: 1732447031823
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
+  sha256: afee721baa6d988e27fef1832f68d6f32ac8cc99cdf6015732224c2841a09cea
+  md5: c27d1c142233b5bc9ca570c6e2e0c244
+  license: ISC
+  size: 159003
+  timestamp: 1725018903918
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
+  sha256: bc47aa39c8254e9e487b8bcd74cfa3b4a3de3648869eb1a0b89905986b668e35
+  md5: 55553ecd5328336368db611f350b7039
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 302115
+  timestamp: 1725560701719
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.1-py311hd18a35c_0.conda
+  sha256: 08be6120dc9369f07858677dde2a8474644cc7ec2ae146b39a6953aadc536dfd
+  md5: 351cb68d2081e249069748b6e60b3cd2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 278209
+  timestamp: 1731428493722
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.0.0-py311h9ecbd09_1.conda
+  sha256: 42544e13dc4bb018cec0579ad7a6158c1f296e32fa0995ffd8abb116734dc427
+  md5: 765c19c0b6df9c143ac8f959d1a1a238
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 393854
+  timestamp: 1728335173137
+- conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+  sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
+  md5: 418c6ca5929a611cbd69204907a83995
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 760229
+  timestamp: 1685695754230
+- conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.9-py311hfdbb021_0.conda
+  sha256: cc2e120f53571e19ee6ea062e85e256fce6550ee139d8127cfb24d7ba015f2ae
+  md5: e1d95dce136e7d0f6a9d7cd9b6dca985
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2567811
+  timestamp: 1732236803227
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.55.1-py311h2dc5d0c_0.conda
+  sha256: 1d130b501942bd43e9d2e47fee0321eb861853fc171e98bb3a7c6cfe2b7f7131
+  md5: 7e891abfe80fe852757e3c92d314a245
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli
+  - libgcc >=13
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2877377
+  timestamp: 1733242455265
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+  sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
+  md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 634972
+  timestamp: 1694615932610
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h743c826_0.conda
+  sha256: 9213f60ba710ecfd3632ce47e036775c9f15ce80a6682ff63cbf12d9dddd5382
+  md5: 12e6988845706b2cfbc3bc35c9a61a95
+  depends:
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - minizip >=4.0.1,<5.0a0
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 59769
+  timestamp: 1694952692595
+- conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.13.0-h5888daf_0.conda
+  sha256: 5c70d6d16e044859edca85feb9d4f1c3c6062aaf88d650826f5ccdf8c44336de
+  md5: 40b4ab956c90390e407bb177f8a58bab
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: LGPL-2.1-only
+  size: 1869233
+  timestamp: 1725676083126
+- conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.3-h77b800c_3.conda
+  sha256: 94c7d002c70a4802a78ac2925ad6b36327cff85e0af6af2825b11a968c81ec20
+  md5: 4eb52aecb43e7c72f8e4fca0c386354e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx >=13
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 131394
+  timestamp: 1726602918349
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
+  sha256: 6c33bf0c4d8f418546ba9c250db4e4221040936aef8956353bc764d4877bc39a
+  md5: d411fc29e338efb48c5fd4576d71d881
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119654
+  timestamp: 1726600001928
+- conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+  sha256: aac402a8298f0c0cc528664249170372ef6b37ac39fdc92b40601a6aed1e32ff
+  md5: 3bf7b9fd5a7136126e0234db4b87c8b6
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 77248
+  timestamp: 1712692454246
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
+  sha256: dc824dc1d0aa358e28da2ecbbb9f03d932d976c8dca11214aa1dcdfcbd054ba2
+  md5: ff862eebdfeb2fd048ae9dc92510baca
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 143452
+  timestamp: 1718284177264
+- conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.12.1-nompi_py311hb639ac4_102.conda
+  sha256: a21932ada1e7a9f95433e4b29980316dac72428bedd738e1af73cb269ed36e2a
+  md5: c2438b0f0016fbd7ea93e872c9b93309
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cached-property
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libgcc >=13
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1391677
+  timestamp: 1729617884282
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_h2d575fe_107.conda
+  sha256: 84d9427b4700ba438064e48cd3c829f83974b7d78c2b477f88685a00348eb06e
+  md5: e370421dfe789ad5177452d377d96f8a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3903048
+  timestamp: 1733018614782
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+  sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
+  md5: 8b189310083baabfb622af68fd9d3ae3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 12129203
+  timestamp: 1720853576813
+- conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.18-h6688a6e_0.conda
+  sha256: 09e706cb388d3ea977fabcee8e28384bdaad8ce1fc49340df5f868a2bd95a7da
+  md5: 38f5dbc9ac808e31c00650f7be1db93f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 82709
+  timestamp: 1726487116178
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_1.conda
+  sha256: 2f082f7b12a7c6824e051321c1029452562ad6d496ad2e8c8b7b3dea1c8feb92
+  md5: 5ca76f61b00a15a9be0612d4d883badc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17645
+  timestamp: 1725303065473
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+  sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
+  md5: 30186d27e2c9fa62b45fb1476b7200e3
+  depends:
+  - libgcc-ng >=10.3.0
+  license: LGPL-2.1-or-later
+  size: 117831
+  timestamp: 1646151697040
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.7-py311hd18a35c_0.conda
+  sha256: 4af11cbc063096a284fe1689b33424e7e49732a27fd396d74c7dee03d1e788ee
+  md5: be34c90cce87090d24da64a7c239ca96
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 72393
+  timestamp: 1725459421768
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+  sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
+  md5: 3f43953b7d3fb3aaa1d0d0723d91e368
+  depends:
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1370023
+  timestamp: 1719463201255
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+  sha256: 5c878d104b461b7ef922abe6320711c0d01772f4cd55de18b674f88547870041
+  md5: 51bb7010fc86f70eee639b4bb7a894f5
+  depends:
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 245247
+  timestamp: 1701647787198
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+  sha256: 7c91cea91b13f4314d125d1bedb9d03a29ebbd5080ccdea70260363424646dbe
+  md5: 048b02e3962f066da18efe3a21b77672
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - binutils_impl_linux-64 2.43
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 669211
+  timestamp: 1729655358674
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+  sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
+  md5: 76bbff344f0134279f225174e9064c8f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 281798
+  timestamp: 1657977462600
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_h5888daf_1.conda
+  sha256: 8f91429091183c26950f1e7ffa730e8632f0627ba35d2fccd71df31628c9b4e5
+  md5: e1f604644fe8d78e22660e2fec6756bc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  constrains:
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1310521
+  timestamp: 1727295454064
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
+  sha256: 2ef420a655528bca9d269086cf33b7e90d2f54ad941b437fb1ed5eca87cee017
+  md5: 5e97e271911b8b2001a8b71860c32faa
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 35446
+  timestamp: 1711021212685
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.7-hadbb8c3_0.conda
+  sha256: 68afcb4519d08cebf71845aff6038e7273f021efc04ef48246f8d41e4e462a61
+  md5: 4a099677417658748239616b6ca96bb6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=13
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - lzo >=2.10,<3.0a0
+  - openssl >=3.4.0,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 874221
+  timestamp: 1732614239458
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-18.1.0-he15abb1_1_cpu.conda
+  sha256: afc81af2e533cc35295aebae4fb382e770310d9b1ac31837456b440d35c54cf7
+  md5: bd3e35a6f3f869b4777488452f315008
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - aws-sdk-cpp >=1.11.449,<1.11.450.0a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-identity-cpp >=1.10.0,<1.10.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-files-datalake-cpp >=12.12.0,<12.12.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libgcc >=13
+  - libgoogle-cloud >=2.31.0,<2.32.0a0
+  - libgoogle-cloud-storage >=2.31.0,<2.32.0a0
+  - libre2-11 >=2024.7.2
+  - libstdcxx >=13
+  - libutf8proc >=2.8.0,<2.9.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.3,<2.0.4.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - parquet-cpp <0.0a0
+  - arrow-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 8780597
+  timestamp: 1732863546099
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-18.1.0-h5888daf_1_cpu.conda
+  sha256: 3de5719a7035baad7e665116dce7bb3d069f0c1916e163c553e2e491bbe8b614
+  md5: 6197dcb930f6254e9b2fdc416be56b71
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 18.1.0 he15abb1_1_cpu
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 611272
+  timestamp: 1732863586114
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-18.1.0-h5888daf_1_cpu.conda
+  sha256: 7b3db3d5a7e411f8897e8d74403c1d871f3054300f5009c4bdf75da011bc3f42
+  md5: 77501831a2aabbaabac55e8cb3b6900a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 18.1.0 he15abb1_1_cpu
+  - libarrow-acero 18.1.0 h5888daf_1_cpu
+  - libgcc >=13
+  - libparquet 18.1.0 h6bd9018_1_cpu
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 585458
+  timestamp: 1732863686753
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-18.1.0-h5c8f2c3_1_cpu.conda
+  sha256: e77a354bfc0ba7b04c856f1bb16e7b08950bcde54026087bafec46090380fcc1
+  md5: 5d47bd2674afd104dbe2f2f3534594b0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 18.1.0 he15abb1_1_cpu
+  - libarrow-acero 18.1.0 h5888daf_1_cpu
+  - libarrow-dataset 18.1.0 h5888daf_1_cpu
+  - libgcc >=13
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 520681
+  timestamp: 1732863726954
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.1.1-h1909e37_2.conda
+  sha256: e06da844b007a64a9ac35d4e3dc4dbc66583f79b57d08166cf58f2f08723a6e8
+  md5: 21e468ed3786ebcb2124b123aa2484b7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aom >=3.9.1,<3.10.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - libgcc >=13
+  - rav1e >=0.6.6,<0.7.0a0
+  - svt-av1 >=2.3.0,<2.3.1.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 116202
+  timestamp: 1730268687453
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
+  sha256: d6d12dc437d060f838820e9e61bf73baab651f91935ac594cf10beb9ef1b4450
+  md5: 8ea26d42ca88ec5258802715fe1ee10b
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - liblapack 3.9.0 25_linux64_openblas
+  - libcblas 3.9.0 25_linux64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 25_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15677
+  timestamp: 1729642900350
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
+  sha256: d9db2de60ea917298e658143354a530e9ca5f9c63471c65cf47ab39fd2f429e3
+  md5: 41b599ed2b02abcfdd84302bff174b23
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 68851
+  timestamp: 1725267660471
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
+  sha256: 2892d512cad096cb03f1b66361deeab58b64e15ba525d6592bb6d609e7045edf
+  md5: 9566f0bd264fbd463002e759b8a82401
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 32696
+  timestamp: 1725267669305
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
+  sha256: 779f58174e99de3600e939fa46eddb453ec5d3c60bb46cdaa8b4c127224dbf29
+  md5: 06f70867945ea6a84d35836af780f1de
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 281750
+  timestamp: 1725267679782
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
+  sha256: ab87b0477078837c91d9cda62a9faca18fba7c57cc77aa779ae24b3ac783b5dd
+  md5: 5dbd1b0fc0d01ec5e0e1fbe667281a11
+  depends:
+  - libblas 3.9.0 25_linux64_openblas
+  constrains:
+  - liblapack 3.9.0 25_linux64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 25_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15613
+  timestamp: 1729642905619
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+  sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
+  md5: c965a5aa0d5c1c37ffc62dff36e28400
+  depends:
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20440
+  timestamp: 1633683576494
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
+  sha256: 54e6114dfce566c3a22ad3b7b309657e3600cdb668398e95f1301360d5d52c99
+  md5: 6e801c50a40301f6978c53976917b277
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 424900
+  timestamp: 1726659794676
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libde265-1.0.15-h00ab1b0_0.conda
+  sha256: 7cf7e294e1a7c8219065885e186d8f52002fb900bf384d815f159b5874204e3d
+  md5: 407fee7a5d7ab2dca12c9ca7f62310ad
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 411814
+  timestamp: 1703088639063
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
+  sha256: 780f0530a3adfc1497ba49d626931c6afc978c540e1abfde6ccd57128ded6ad6
+  md5: b422943d5d772b7cc858b36ad2a92db5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 72242
+  timestamp: 1728177071251
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+  sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
+  md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 123878
+  timestamp: 1597616541093
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+  md5: 172bf1cd1ff8629f2b1179945ed45055
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 112766
+  timestamp: 1702146165126
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+  sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
+  md5: a1cfcc585f0c42bf8d5546bb1dfb668d
+  depends:
+  - libgcc-ng >=12
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 427426
+  timestamp: 1685725977222
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
+  sha256: 56541b98447b58e52d824bd59d6382d609e11de1f8adf20b23143e353d2b8d26
+  md5: db833e03127376d461e1e13e76f09b6c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 73304
+  timestamp: 1730967041968
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+  sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+  md5: d645c6d2ac96843a2bfaccd2d62b3ac3
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 58292
+  timestamp: 1636488182923
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
+  sha256: 53eb8a79365e58849e7b1a068d31f4f9e718dc938d6f2c03e960345739a03569
+  md5: 3cb76c3f10d3bc7f1105b2fc9db984df
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 14.2.0 h77fa898_1
+  - libgcc-ng ==14.2.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 848745
+  timestamp: 1729027721139
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+  sha256: 3a76969c80e9af8b6e7a55090088bc41da4cffcde9e2c71b17f44d37b7cb87f7
+  md5: e39480b9ca41323497b05492a63bc35b
+  depends:
+  - libgcc 14.2.0 h77fa898_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54142
+  timestamp: 1729027726517
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.10.0-h7250d82_5.conda
+  sha256: 0a3985521fd6510e4e4fcfcaba70b2fd65017cdaf04aece8ec4ef59275f1f362
+  md5: 50a0ff43c76aba36d9d70b890e90efa7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - geotiff >=1.7.3,<1.8.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - json-c >=0.18,<0.19.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libarchive >=3.7.7,<3.8.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libdeflate >=1.22,<1.26.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libheif >=1.18.2,<1.19.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.4.0,<4.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - proj >=9.5.1,<9.6.0a0
+  - xerces-c >=3.2.5,<3.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - libgdal 3.10.0.*
+  license: MIT
+  license_family: MIT
+  size: 10800461
+  timestamp: 1733328803156
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+  sha256: fc9e7f22a17faf74da904ebfc4d88699013d2992e55505e4aa0eb01770290977
+  md5: f1fd30127802683586f768875127a987
+  depends:
+  - libgfortran5 14.2.0 hd5240d6_1
+  constrains:
+  - libgfortran-ng ==14.2.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 53997
+  timestamp: 1729027752995
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
+  sha256: d149a37ca73611e425041f33b9d8dbed6e52ec506fe8cc1fc0ee054bddeb6d5d
+  md5: 9822b874ea29af082e5d36098d25427d
+  depends:
+  - libgcc >=14.2.0
+  constrains:
+  - libgfortran 14.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1462645
+  timestamp: 1729027735353
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+  sha256: 1911c29975ec99b6b906904040c855772ccb265a1c79d5d75c8ceec4ed89cd63
+  md5: cc3573974587f12dda90d96e3e55a702
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 460992
+  timestamp: 1729027639220
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.31.0-h804f50b_0.conda
+  sha256: b2de99c83516236ff591d30436779f8345bcc11bb0ec76a7ca3a38a3b23b6423
+  md5: 35ab838423b60f233391eb86d324a830
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  - openssl >=3.3.2,<4.0a0
+  constrains:
+  - libgoogle-cloud 2.31.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1248705
+  timestamp: 1731122589027
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.31.0-h0121fbd_0.conda
+  sha256: 3c38b0a80441f82323dc5a72b96c0dd7476bd5184fbfcdf825a8e15249c849af
+  md5: 568d6a09a6ed76337a7b97c84ae7c0f8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libgcc >=13
+  - libgoogle-cloud 2.31.0 h804f50b_0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  size: 782150
+  timestamp: 1731122728715
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.67.1-hc2c308b_0.conda
+  sha256: 870550c1faf524e9a695262cd4c31441b18ad542f16893bd3c5dbc93106705f7
+  md5: 4606a4647bfe857e3cfe21ca12ac3afb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - c-ares >=1.32.3,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libre2-11 >=2024.7.2
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.67.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 7362336
+  timestamp: 1730236333879
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libheif-1.18.2-gpl_hffcb242_100.conda
+  sha256: 82af131dc112f4f36ca9226f30a7b1b3e05ed4fb3f85003e8f1af72b6a8e44bc
+  md5: 76ac2c07b62d45c192940f010eea11fa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aom >=3.9.1,<3.10.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - libavif16 >=1.1.1,<2.0a0
+  - libde265 >=1.0.15,<1.0.16.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - x265 >=3.5,<3.6.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 428886
+  timestamp: 1723121455966
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+  sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
+  md5: d66573916ffcf376178462f1b61c941e
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  size: 705775
+  timestamp: 1702682170569
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+  sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
+  md5: ea25936bb4080d843790b586850f82b8
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 618575
+  timestamp: 1694474974816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-hf539b9f_1021.conda
+  sha256: 721c3916d41e052ffd8b60e77f2da6ee47ff0d18babfca48ccf93606f1e0656a
+  md5: e8c7620cc49de0c6a2349b6dd6e39beb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libexpat >=2.6.2,<3.0a0
+  - libgcc-ng >=13
+  - libstdcxx-ng >=13
+  - libzlib >=1.3.1,<2.0a0
+  - uriparser >=0.9.8,<1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 402219
+  timestamp: 1724667059411
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
+  sha256: 9d1ff017714edb2d84868f0f931a4a0e7c289a971062b2ac66cfc8145df7e20e
+  md5: 4dc03a53fc69371a6158d0ed37214cd3
+  depends:
+  - libblas 3.9.0 25_linux64_openblas
+  constrains:
+  - liblapacke 3.9.0 25_linux64_openblas
+  - libcblas 3.9.0 25_linux64_openblas
+  - blas * openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15608
+  timestamp: 1729642910812
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
+  sha256: 225cc7c3b20ac1db1bdb37fa18c95bf8aecef4388e984ab2f7540a9f4382106a
+  md5: 73301c133ded2bf71906aa2104edae8b
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 31484415
+  timestamp: 1690557554081
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.6.3-hb9d3cd8_1.conda
+  sha256: e6e425252f3839e2756e4af1ea2074dffd3396c161bf460629f9dfd6a65f15c6
+  md5: 2ecf2f1c7e4e21fcfe6423a51a992d84
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - xz ==5.6.3=*_1
+  license: 0BSD
+  size: 111132
+  timestamp: 1733407410083
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.6.3-hb9d3cd8_1.conda
+  sha256: ca17f037a0a7137874597866a171166677e4812a9a8a853007f0f582e3ff6d1d
+  md5: cc4687e1814ed459f3bd6d8e05251ab2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - liblzma 5.6.3 hb9d3cd8_1
+  license: 0BSD
+  size: 376794
+  timestamp: 1733407421190
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+  sha256: b0f2b3695b13a989f75d8fd7f4778e1c7aabe3b36db83f0fe80b2cd812c0e975
+  md5: 19e57602824042dfd0446292ef90488b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - c-ares >=1.32.3,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 647599
+  timestamp: 1729571887612
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+  sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+  md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  license_family: GPL
+  size: 33408
+  timestamp: 1697359010159
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
+  sha256: 99ba271d8a80a1af2723f2e124ffd91d850074c0389c067e6d96d72a2dbfeabe
+  md5: 62857b389e42b36b686331bec0922050
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.2.0
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5578513
+  timestamp: 1730772671118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-18.1.0-h6bd9018_1_cpu.conda
+  sha256: 0df119f4c1a2387d910e132c670b29ee5b29dd79384549de6f1a43067515c8ba
+  md5: 1054909202f86e38bbbb7ca1131b8471
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 18.1.0 he15abb1_1_cpu
+  - libgcc >=13
+  - libstdcxx >=13
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 1203523
+  timestamp: 1732863665743
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
+  sha256: e5b14f7a01c2db4362d8591f42f82f336ed48d5e4079e4d1f65d0c2a3637ea78
+  md5: f4cc49d7aa68316213e4b12be35308d1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 290661
+  timestamp: 1726234747153
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
+  sha256: 5e8fd4aa00193c85602ce6101dd28fe31306dff85c9725048f6dc828dfa7c421
+  md5: ab0bff36363bec94720275a681af8b83
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2945348
+  timestamp: 1728565355702
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hbbce691_1.conda
+  sha256: f8ad6a4f6d4fd54ebe3e5e712a01e663222fc57f49d16b6b8b10c30990dafb8f
+  md5: 2124de47357b7a516c0a3efd8f88c143
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 211096
+  timestamp: 1728778964655
+- conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h97f6797_17.conda
+  sha256: 1fb8a71bdbc236b8e74f0475887786735d5fa6f5d76d9a4135021279c7ff54b8
+  md5: e16e9b1333385c502bf915195f421934
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 231770
+  timestamp: 1727338518657
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
+  sha256: 0105bd108f19ea8e6a78d2d994a6d4a8db16d19a41212070d2d1d48a63c34161
+  md5: a587892d3c13b6621a6091be690dbca2
+  depends:
+  - libgcc-ng >=12
+  license: ISC
+  size: 205978
+  timestamp: 1716828628198
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h1b4f908_11.conda
+  sha256: 11d8537d472c5fc25176fda7af6b9aa47f37ba98d0467b77cb713be18ed847ea
+  md5: 43a7f3df7d100e8fc280e6636680a870
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freexl >=2
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - libgcc >=13
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libstdcxx >=13
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - sqlite
+  - zlib
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 4045908
+  timestamp: 1727341751247
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_1.conda
+  sha256: 8a9aadf996a2399f65b679c6e7f29139d5059f699c63e6d7b50e20db10c00508
+  md5: b6f02b52a174e612e89548f4663ce56a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 875349
+  timestamp: 1730208050020
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hf672d98_0.conda
+  sha256: 0407ac9fda2bb67e11e357066eff144c845801d00b5f664efbc48813af1e7bb9
+  md5: be2de152d8073ef1c01b7728475f2fe7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 304278
+  timestamp: 1732349402869
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+  sha256: 4661af0eb9bdcbb5fb33e5d0023b001ad4be828fccdcc56500059d56f9869462
+  md5: 234a5554c53625688d51062645337328
+  depends:
+  - libgcc 14.2.0 h77fa898_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3893695
+  timestamp: 1729027746910
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+  sha256: 25bb30b827d4f6d6f0522cc0579e431695503822f144043b93c50237017fffd8
+  md5: 8371ac6457591af2cf6159439c1fd051
+  depends:
+  - libstdcxx 14.2.0 hc0a3c3a_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54105
+  timestamp: 1729027780628
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.21.0-h0e7cc3e_0.conda
+  sha256: ebb395232973c18745b86c9a399a4725b2c39293c9a91b8e59251be013db42f0
+  md5: dcb95c0a98ba9ff737f7ae482aef7833
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 425773
+  timestamp: 1727205853307
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-hc4654cb_2.conda
+  sha256: 18653b4a5c73e19c5e86ff72dab9bf59f5cc43d7f404a6be705d152dfd5e0660
+  md5: be54fb40ea32e8fe9dbaa94d4528b57e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.22,<1.26.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libstdcxx >=13
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 429018
+  timestamp: 1733443013288
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-hf23e847_1.conda
+  sha256: 104cf5b427fc914fec63e55f685a39480abeb4beb34bdbc77dea084c8f5a55cb
+  md5: b1aa0faa95017bca11369bd080487ec4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 80852
+  timestamp: 1732829699583
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33601
+  timestamp: 1680112270483
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+  sha256: 49bc5f6b1e11cb2babf2a2a731d1a680a5e08a858280876a779dbda06c78c35f
+  md5: b26e8aa824079e1be0294e7152ca4559
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 438953
+  timestamp: 1713199854503
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+  sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
+  md5: 92ed62436b625154323d40d5f2f11dd7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 395888
+  timestamp: 1727278577118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
+  md5: 5aa797f8787fe7a17d1b0821485b5adc
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 100393
+  timestamp: 1702724383534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-hb346dea_0.conda
+  sha256: 8c9d6a3a421ac5bf965af495d1b0a08c6fb2245ba156550bc064a7b4f8fc7bd8
+  md5: c81a9f1118541aaa418ccb22190c817e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=13
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 689626
+  timestamp: 1731489608971
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
+  md5: edb0dca6bc32e4f4789199455a1dbeb8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 60963
+  timestamp: 1727963148474
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.43.0-py311h9c9ff8c_1.conda
+  sha256: fb8b3eeea19f1160343d2c84f3b3e888f8c45db563375660905e1e73a793fc74
+  md5: 9ab40f5700784bf16ff7cf8012a646e8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3471295
+  timestamp: 1725305248888
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.3-py311h2cbdf9a_1.conda
+  sha256: 83f560beb20f61bb8c6e43a0656f1e744934d41a48b8a19408e6596cf8ce99a8
+  md5: 867a4aa23ae6c0e9c84cf9aa4f2df0fe
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39383
+  timestamp: 1725089531914
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+  sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
+  md5: 318b08df404f9c9be5712aaa5a6f0bb0
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143402
+  timestamp: 1674727076728
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hd590300_1001.conda
+  sha256: 88433b98a9dd9da315400e7fb9cd5f70804cb17dca8b1c85163a64f90f584126
+  md5: ec7398d21e2651e0dcb0044d03b9a339
+  depends:
+  - libgcc-ng >=12
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  size: 171416
+  timestamp: 1713515738503
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py311h2dc5d0c_1.conda
+  sha256: 0291d90706ac6d3eea73e66cd290ef6d805da3fad388d1d476b8536ec92ca9a8
+  md5: 6565a715337ae279e351d0abd8ffe88a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25354
+  timestamp: 1733219879408
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.3-py311h2b939e6_0.conda
+  sha256: d31ebd77324b3ea74fa946043402f3bc59efd39c760835ad5f67b2b9e3c54eac
+  md5: 22a5583349cc89b5c9159b15746f27e2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  - tk >=8.6.13,<8.7.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 7980027
+  timestamp: 1733176210238
+- conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.7-h401b404_0.conda
+  sha256: 6315ea87d094418e744deb79a22331718b36a0e6e107cd7fc3c52c7922bc8133
+  md5: 4474532a312b2245c5c77f1176989b46
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 91409
+  timestamp: 1718483022284
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mne-lsl-1.8.0-py311hd18a35c_0.conda
+  sha256: 733d05f75ba76d482e0523d6f8f96430063ea96c544b835e0a289ef1cef798b2
+  md5: d9706c105c010fea0051a6a0b7eb33cb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - click >=8.1
+  - libgcc >=13
+  - libstdcxx >=13
+  - mne-base >=1.4.2
+  - numpy >=1.21
+  - packaging
+  - pooch
+  - psutil
+  - pyqtgraph
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - qtpy
+  - scipy
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 592814
+  timestamp: 1732896088289
+- conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.0-py311hd18a35c_0.conda
+  sha256: 9033fa7084cbfd10e1b7ed3b74cee17169a0731ec98244d05c372fc4a935d5c9
+  md5: 682f76920687f7d9283039eb542fdacf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 104809
+  timestamp: 1725975116412
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+  sha256: 6a1d5d8634c1a07913f1c525db6455918cbc589d745fac46d9d6e30340c8731a
+  md5: 70caf8bb6cf39a0b6b7efc885f51c0fe
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: X11 AND BSD-3-Clause
+  size: 889086
+  timestamp: 1724658547447
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.60.0-py311h4bc866e_0.conda
+  sha256: b48178613ba637b647c5738772d3efabfca502ea579b5ec10784a33d5acb0789
+  md5: e32a210e9caf97383c35685fd2343512
+  depends:
+  - _openmp_mutex >=4.5
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libopenblas !=0.3.6
+  - cuda-version >=11.2
+  - cuda-python >=11.6
+  - tbb >=2021.6.0
+  - scipy >=1.0
+  - cudatoolkit >=11.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5801568
+  timestamp: 1718888179690
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.14.1-py311h7db5c69_0.conda
+  sha256: 7a953d08194b108e68c176ebf58813df329bd40847bb92a912ea87b7d15fabbe
+  md5: a50abcda080c2a9e3c46a6985fec12c0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - msgpack-python
+  - numpy >=1.19,<3
+  - numpy >=1.24
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 848638
+  timestamp: 1732243709737
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.0.2-py311h71ddf71_1.conda
+  sha256: a922ec6947ad6953cb011b8f1a44779f6b55d62a14c5bcd25d19a8fb1629da30
+  md5: 04ce874aa54fc1d9c735a04e0c6d99c4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9148240
+  timestamp: 1732314901472
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
+  sha256: 5600a0b82df042bd27d01e4e687187411561dfc11cc05143a08ce29b64bf2af2
+  md5: 7f2e286780f072ed750df46dc2631138
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.43,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 341592
+  timestamp: 1709159244431
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
+  sha256: 814b9dff1847b132c676ee6cc1a8cb2d427320779b93e1b6d76552275c128705
+  md5: 23cc74f77eb99315c0360ec3533147a9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 2947466
+  timestamp: 1731377666602
+- conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.3-he039a57_0.conda
+  sha256: 9657ae19d6541fe67a61ef0c26ba1012ec508920b49afa897962c7d4b263ba35
+  md5: 052499acd6d6b79952197a13b23e2600
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1187593
+  timestamp: 1731664886527
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py311h7db5c69_1.conda
+  sha256: dce121d3838996b77b810ca9097cc17068552075c761408a9b2eb788cf8fd1b0
+  md5: 643f8cb35133eb1be4919fb953f0a25f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15695466
+  timestamp: 1726879158862
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
+  sha256: 1087716b399dab91cc9511d6499036ccdc53eb29a288bebcb19cf465c51d7c0d
+  md5: df359c09c41cd186fffb93a2d87aa6f5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 952308
+  timestamp: 1723488734144
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.0.0-py311h49e9ac3_0.conda
+  sha256: f0f792596ae99cba01f829d064058b1e99ca84080fc89f72d925bfe473cfc1b6
+  md5: 2bd3d0f839ec0d1eaca817c9d1feb7c2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 42421065
+  timestamp: 1729065780130
+- conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.5.1-h0054346_0.conda
+  sha256: 835afb9c8198895ec1ce2916320503d47bb0c25b75c228d744c44e505f1f4e3b
+  md5: 398cabfd9bd75e90d0901db95224f25f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libsqlite >=3.47.0,<4.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 3108751
+  timestamp: 1733138115896
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py311h9ecbd09_0.conda
+  sha256: 2ac3f1ed6e6a2a0c67a3922f4b5faf382855ad02cc0c85c5d56291c7a94296d0
+  md5: 0ffc1f53106a38f059b151c465891ed3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 505408
+  timestamp: 1729847169876
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+  sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
+  md5: b3c17d95b5a10c6e64a21fa17573e70e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 8252
+  timestamp: 1726802366959
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-18.1.0-py311h38be061_0.conda
+  sha256: 9cfd158a1bb76c4af1a51237a5c5db4a36b2e83bad625ddf6c2b65ee232c16ba
+  md5: 47b8624012486e05e66f6acf7267aa22
+  depends:
+  - libarrow-acero 18.1.0.*
+  - libarrow-dataset 18.1.0.*
+  - libarrow-substrait 18.1.0.*
+  - libparquet 18.1.0.*
+  - pyarrow-core 18.1.0 *_0_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25199
+  timestamp: 1732610760700
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-18.1.0-py311h4854187_0_cpu.conda
+  sha256: db147a0cc22b55ea3c35553b39336eb0392c33371f6efd7f9fb4efed2b728e34
+  md5: 830a64ee7a65e588c7ea615be84db2e3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 18.1.0.* *cpu
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy >=1.21,<3
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4562010
+  timestamp: 1732610600424
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.27.1-py311h9e33e62_0.conda
+  sha256: 0ae49448c55affa0e9df0e876d02aee77ad42678500a34679f9689bf3682000e
+  md5: e5192dfb2dae866470c3eec81dbe5727
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - typing-extensions >=4.6.0,!=4.7.0
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  size: 1632797
+  timestamp: 1732254154568
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.6.1-py311h0f98d5a_10.conda
+  sha256: bd03c94e159e5935116d959f5595ea4ba38910d5c05e6919b3ad28d7e4a3df20
+  md5: 37f7e40c0afe09d0f15f0da92bbde054
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - certifi
+  - libgcc >=13
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 561770
+  timestamp: 1726679886387
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.11-h9e4cc4f_1_cpython.conda
+  sha256: b29ce0836fce55bdff8d5c5b71c4921a23f87d3b950aea89a9e75784120b06b0
+  md5: 8387070aa413ce9a8cc35a509fae938b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.6.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - liblzma >=5.6.3,<6.0a0
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.4.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 30624804
+  timestamp: 1733409665928
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
+  sha256: 2660b8059b3ee854bc5d3c6b1fce946e5bd2fe8fbca7827de2c5885ead6209de
+  md5: 139a8d40c8a2f430df31048949e450de
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6211
+  timestamp: 1723823324668
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h9ecbd09_1.conda
+  sha256: e721e5ff389a7b2135917c04b27391be3d3382e261bb60a369b1620655365c3d
+  md5: abeb54d40f439b86f75ea57045ab8496
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 212644
+  timestamp: 1725456264282
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py311h7deb3e3_3.conda
+  sha256: 3fdef7b3c43474b7225868776a373289a8fd92787ffdf8bed11cf7f39b4ac741
+  md5: e0897de1d8979a3bb20ef031ae1f7d28
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 389074
+  timestamp: 1728642373938
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+  sha256: 776363493bad83308ba30bcb88c2552632581b143e8ee25b1982c8c743e73abc
+  md5: 353823361b1d27eb3960efb076dfcaf6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-Qhull
+  size: 552937
+  timestamp: 1720813982144
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.4.3-py311h5394301_0.conda
+  sha256: 724eeb5f713a0056edd155c1fca866ae396142c608a24c19f852e39c6882d63b
+  md5: 90a35941706e0cce48eed19ee4017470
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - affine
+  - attrs
+  - certifi
+  - click >=4
+  - click-plugins
+  - cligj >=0.5
+  - libgcc >=13
+  - libgdal-core >=3.10.0,<3.11.0a0
+  - libstdcxx >=13
+  - numpy >=1.21,<3
+  - proj >=9.5.1,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7606544
+  timestamp: 1733163769504
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.6.6-he8a937b_2.conda
+  sha256: 91b3c1ced90d04ee2eded1f72cf3cbc19ff05a25e41876ef0758266a5bab009f
+  md5: 77d9955b4abddb811cb8ab1aa7d743e4
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 15423721
+  timestamp: 1694329261357
+- conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h77b4e00_1.conda
+  sha256: c1721cb80f7201652fc9801f49c214c88aee835d957f2376e301bd40a8415742
+  md5: 01093ff37c1b5e6bf9f17c0116747d11
+  depends:
+  - libre2-11 2024.07.02 hbbce691_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26665
+  timestamp: 1728778975855
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+  sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
+  md5: 47d31b792659ce70f470b5c82fdfb7a4
+  depends:
+  - libgcc-ng >=12
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 281456
+  timestamp: 1679532220005
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.22.3-py311h9e33e62_0.conda
+  sha256: 0908ac4acb1a10fe63046e947a96c77cea0d392619ef965944da86c3574b68ec
+  md5: b1f5799ae0cc22198928f09879da01f5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  size: 351650
+  timestamp: 1733366766805
+- conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.9-h0fd0ee4_0.conda
+  sha256: f2c8e55d6caa8d87a482b1f133963c184de1ccb2303b77cc8ca86c794253f151
+  md5: f472432f3753c5ca763d2497e2ea30bf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 355568
+  timestamp: 1731541963573
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py311he9a78e4_1.conda
+  sha256: 59482b974c36c375fdfd0bc3e5a3003ea2d2ae72b64b8f3deaeef5a851dbc91d
+  md5: 49ba89bf4d8a995efb99517d1c7aeb1e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=13
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17592106
+  timestamp: 1729481734425
+- conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
+  sha256: dc7c8e0e8c3e8702aae81c52d940bfaabe756953ee51b1f1757e891bab62cf7f
+  md5: 6b7dcc7349efd123d493d2dbe85a045f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42465
+  timestamp: 1720003704360
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.47.0-h9eae976_1.conda
+  sha256: 8ea1a085fa95d806301aeec0df6985c3ad0852a9a46aa62dd737d228c7862f9f
+  md5: 53abf1ef70b9ae213b22caa5350f97a9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libsqlite 3.47.0 hadc24fc_1
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 883666
+  timestamp: 1730208056779
+- conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-2.3.0-h5888daf_0.conda
+  sha256: df30a9be29f1a8b5a2e314dd5b16ccfbcbd1cc6a4f659340e8bc2bd4de37bc6f
+  md5: 355898d24394b2af353eb96358db9fdd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2746291
+  timestamp: 1730246036363
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+  sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
+  md5: d453b98d9c83e71da0741bb0ff4d76bc
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3318875
+  timestamp: 1699202167581
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.2-py311h9ecbd09_0.conda
+  sha256: afa3489113154b5cb0724b0bf120b62df91f426dabfe5d02f2ba09e90d346b28
+  md5: df3aee9c3e44489257a840b8354e77b9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 855653
+  timestamp: 1732616048886
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py311h9ecbd09_1.conda
+  sha256: 5f277c801ca392512de9aa497fd8be3e168950600c438778dfc4234943c474fc
+  md5: 00895577e2b4c24dca76675ab1862551
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 368413
+  timestamp: 1729704640193
+- conda: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda
+  sha256: 2aad2aeff7c69a2d7eecd7b662eef756b27d6a6b96f3e2c2a7071340ce14543e
+  md5: d71d3a66528853c0a1ac2c02d79a0284
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48270
+  timestamp: 1715010035325
+- conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+  sha256: 76c7405bcf2af639971150f342550484efac18219c0203c5ee2e38b8956fe2a0
+  md5: e7f6ed84d4623d52ee581325c1587a6b
+  depends:
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 3357188
+  timestamp: 1646609687141
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.5-h988505b_2.conda
+  sha256: 339ab0ff05170a295e59133cd0fa9a9c4ba32b6941c8a2a73484cc13f81e248a
+  md5: 9dda9667feba914e0e80b95b82f7402b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=13
+  - libnsl >=2.0.1,<2.1.0a0
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 1648243
+  timestamp: 1727733890754
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
+  sha256: 532a046fee0b3a402db867b6ec55c84ba4cdedb91d817147c8feeae9766be3d6
+  md5: 77cbc488235ebbaab2b6e912d3934bae
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 14679
+  timestamp: 1727034741045
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+  sha256: 6b250f3e59db07c2514057944a3ea2044d6a8cdde8a47b6497c254520fade1ee
+  md5: 8035c64cb77ed555e3f150b7b3972480
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 19901
+  timestamp: 1727794976192
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.6.3-hbcc6ac9_1.conda
+  sha256: 9cef529dcff25222427c9d90b9fc376888a59e138794b4336bbcd3331a5eea22
+  md5: 62aae173382a8aae284726353c6a6a24
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - liblzma 5.6.3 hb9d3cd8_1
+  - liblzma-devel 5.6.3 hb9d3cd8_1
+  - xz-gpl-tools 5.6.3 hbcc6ac9_1
+  - xz-tools 5.6.3 hb9d3cd8_1
+  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  size: 23477
+  timestamp: 1733407455801
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.6.3-hbcc6ac9_1.conda
+  sha256: 4e104b7c75c2f26a96032a1c6cda51430da1dea318c74f9e3568902b2f5030e1
+  md5: f529917bab7862aaad6867bf2ea47a99
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - liblzma 5.6.3 hb9d3cd8_1
+  constrains:
+  - xz ==5.6.3=*_1
+  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  size: 33354
+  timestamp: 1733407444641
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.6.3-hb9d3cd8_1.conda
+  sha256: 6e80f838096345c35e8755b827814c083dd0274594006d6f76bff71bc969c3b8
+  md5: de3f31a6eed01bc2b8c7dcad07ad9034
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - liblzma 5.6.3 hb9d3cd8_1
+  constrains:
+  - xz ==5.6.3=*_1
+  license: 0BSD AND LGPL-2.1-or-later
+  size: 90354
+  timestamp: 1733407433418
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+  sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
+  md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 89141
+  timestamp: 1641346969816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_7.conda
+  sha256: a4dc72c96848f764bb5a5176aa93dd1e9b9e52804137b99daeebba277b31ea10
+  md5: 3947a35e916fcc6b9825449affbf4214
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - libstdcxx >=13
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 335400
+  timestamp: 1731585026517
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+  sha256: 5d7c0e5f0005f74112a34a7425179f4eb6e73c92f5d109e6af4ddeca407c92ab
+  md5: c9f075ab2f33b3bbee9e62d4ad0a6cd8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib 1.3.1 hb9d3cd8_2
+  license: Zlib
+  license_family: Other
+  size: 92286
+  timestamp: 1727963153079
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py311hbc35293_1.conda
+  sha256: a5cf0eef1ffce0d710eb3dffcb07d9d5922d4f7a141abc96f6476b98600f718f
+  md5: aec590674ba365e50ae83aa2d6e1efae
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.11
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 417923
+  timestamp: 1725305669690
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+  sha256: c558b9cc01d9c1444031bd1ce4b9cff86f9085765f17627a6cd85fc623c8a02b
+  md5: 4d056880988120e29d75bfff282e0f45
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 554846
+  timestamp: 1714722996770
+- conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+  sha256: fbf0288cae7c6e5005280436ff73c95a36c5a4c978ba50175cc8e3eb22abc5f9
+  md5: ae5f4ad87126c55ba3f690ef07f81d64
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18726
+  timestamp: 1674245215155
+- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+  sha256: e0ea1ba78fbb64f17062601edda82097fcf815012cf52bb704150a2668110d48
+  md5: 2934f256a8acfe48f6ebb4fce6cde29c
+  depends:
+  - python >=3.9
+  - typing-extensions >=4.0.0
+  license: MIT
+  license_family: MIT
+  size: 18074
+  timestamp: 1733247158254
+- conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+  sha256: 4b54b7ce79d818e3cce54ae4d552dba51b7afac160ceecdefd04b3917a37c502
+  md5: 688697ec5e9588bdded167d19577625b
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.9
+  - sniffio >=1.1
+  - typing_extensions >=4.1
+  constrains:
+  - uvloop >=0.21.0b1
+  - trio >=0.26.1
+  license: MIT
+  license_family: MIT
+  size: 109864
+  timestamp: 1728935803440
+- conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
+  sha256: 8f032b140ea4159806e4969a68b4a3c0a7cab1ad936eb958a2b5ffe5335e19bf
+  md5: 54898d0f524c9dee622d44bbb081a8ab
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 10076
+  timestamp: 1733332433806
+- conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
+  sha256: 7af62339394986bc470a7a231c7f37ad0173ffb41f6bc0e8e31b0be9e3b9d20f
+  md5: a7ee488b71c30ada51c48468337b85ba
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.9
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 18594
+  timestamp: 1733311166338
+- conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+  sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
+  md5: b77d8c2313158e6e461ca0efb1c2c508
+  depends:
+  - python >=3.8
+  - python-dateutil >=2.7.0
+  - types-python-dateutil >=2.8.10
+  license: Apache-2.0
+  license_family: Apache
+  size: 100096
+  timestamp: 1696129131844
+- conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+  sha256: b3e9369529fe7d721b66f18680ff4b561e20dbf6507e209e1f60eac277c97560
+  md5: c0481c9de49f040272556e2cedf42816
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 6164
+  timestamp: 1531050741142
+- conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+  sha256: 93b14414b3b3ed91e286e1cbe4e7a60c4e1b1c730b0814d1e452a8ac4b9af593
+  md5: 8f587de4bcf981e26228f268df374a9b
+  depends:
+  - python >=3.9
+  constrains:
+  - astroid >=2,<4
+  license: Apache-2.0
+  license_family: Apache
+  size: 28206
+  timestamp: 1733250564754
+- conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+  sha256: 7ed83731979fe5b046c157730e50af0e24454468bbba1ed8fc1a3107db5d7518
+  md5: 3d081de3a6ea9f894bbb585e8e3a4dcb
+  depends:
+  - python >=3.8
+  - typing_extensions >=4.0.0
+  license: MIT
+  license_family: MIT
+  size: 15342
+  timestamp: 1690563152778
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+  sha256: 28dba85a7e0f7fb57d7315e13f603d1e41b83c5b88aa2a602596b52c833a2ff8
+  md5: 6732fa52eb8e66e5afeb32db8701a791
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 56048
+  timestamp: 1722977241383
+- conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_1.conda
+  sha256: f6205d3a62e87447e06e98d911559be0208d824976d77ab092796c9176611fcb
+  md5: 3e23f7db93ec14c80525257d8affac28
+  depends:
+  - python >=3.9
+  - pytz >=2015.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6551057
+  timestamp: 1733236466015
+- conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_1.conda
+  sha256: fca842ab7be052eea1037ebee17ac25cc79c626382dd2187b5c6e007b9d9f65f
+  md5: d48f7e9fdec44baf6d1da416fe402b04
+  depends:
+  - python >=3.9
+  - soupsieve >=1.2
+  license: MIT
+  license_family: MIT
+  size: 118042
+  timestamp: 1733230951790
+- conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_1.conda
+  sha256: ffc8e4e53cd92aec0f0ea0bc9e28f5fd1b1e67bde46b0b298170e6fb78eecce1
+  md5: 707af59db75b066217403a8f00c1d826
+  depends:
+  - python >=3.9
+  - webencodings
+  license: Apache-2.0 AND MIT
+  license_family: Apache
+  size: 132933
+  timestamp: 1733302409510
+- conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.2-pyhd8ed1ab_0.conda
+  sha256: e8307f1ea9306a48c4d872f7499b4a5e6f4137c440b46554897d8c08ca2a743b
+  md5: b3335e258c6113c8a355c32dd91e954f
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.10
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4774564
+  timestamp: 1733256001780
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+  sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
+  md5: 9b347a7ec10940d3f7941ff6c460b551
+  depends:
+  - cached_property >=1.5.2,<1.5.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4134
+  timestamp: 1615209571450
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+  sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+  md5: 576d629e47797577ab0f1b351297ef4a
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11065
+  timestamp: 1615209567874
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+  sha256: 7020770df338c45ac6b560185956c32f0a5abf4b76179c037f115fc7d687819f
+  md5: 12f7d00853807b0531775e9be891cb11
+  depends:
+  - python >=3.7
+  license: ISC
+  size: 163752
+  timestamp: 1725278204397
+- conda: https://conda.anaconda.org/conda-forge/noarch/cf_xarray-0.10.0-pyhd8ed1ab_0.conda
+  sha256: 9733b1e42114f8f4be88005d89ecb39d56738750510601941e2197e1ba76efbc
+  md5: 9437cfe346eab83b011b4def99f0e879
+  depends:
+  - python >=3.10
+  - xarray >=2022.03.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 62322
+  timestamp: 1729665344149
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+  sha256: 63022ee2c6a157a9f980250a66f54bdcdf5abee817348d0f9a74c2441a6fbf0e
+  md5: 6581a17bba6b948bb60130026404a9d6
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 47533
+  timestamp: 1733218182393
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_1.conda
+  sha256: 1cd5fc6ccdd5141378e51252a7a3810b07fd5a7e6934a5b4a7eccba66566224b
+  md5: cb8e52f28f5e592598190c562e7b5bf1
+  depends:
+  - __unix
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84513
+  timestamp: 1733221925078
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_1.conda
+  sha256: 98eeb47687c0a3260c7ea1e29f41057b8e57481b834d3bf5902b7a62e194f88f
+  md5: e2afd3b7e37a5363e292a8b33dbef65c
+  depends:
+  - __win
+  - colorama
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 85069
+  timestamp: 1733222030187
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+  sha256: ddef6e559dde6673ee504b0e29dd814d36e22b6b9b1f519fa856ee268905bf92
+  md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
+  depends:
+  - click >=3.0
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8992
+  timestamp: 1554588104889
+- conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+  sha256: 97bd58f0cfcff56a0bcda101e26f7d936625599325beba3e3a1fa512dd7fc174
+  md5: a29b7c141d6b2de4bb67788a5f107734
+  depends:
+  - click >=4.0
+  - python <4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10255
+  timestamp: 1633637895378
+- conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+  sha256: 5a33d0d3ef33121c546eaf78b3dac2141fc4d30bbaeb3959bbc66fcd5e99ced6
+  md5: c88ca2bb7099167912e3b26463fff079
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25952
+  timestamp: 1729059365471
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
+  md5: 962b9857ee8e7018c22f2776ffa0b2d7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27011
+  timestamp: 1733218222191
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+  sha256: 79a6b4fff545e0b18f86ad93276a1797eb6ac3f7e1851e03f02d63b19655731b
+  md5: 4d155b600b63bc6ba89d91fab74238f8
+  depends:
+  - python >=3.7
+  license: CC-BY-4.0
+  size: 173517
+  timestamp: 1709713413736
+- conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+  sha256: e923acf02708a8a0b591f3bce4bdc11c8e63b73198b99b35fe6cd96bfb6a0dbe
+  md5: 948d84721b578d426294e17a02e24cbb
+  depends:
+  - python >=3.6
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12134
+  timestamp: 1710320435158
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.11-py311hd8ed1ab_1.conda
+  sha256: b9bb4486ba7b81d7264e92f346c9fa2d4a6c9678c28b33fb5d1652ecc7f82e26
+  md5: 6aab9c45010dc5ed92215f89cdafa201
+  depends:
+  - python 3.11.11.*
+  - python_abi * *_cp311
+  license: Python-2.0
+  size: 46068
+  timestamp: 1733407866862
+- conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+  sha256: 9827efa891e507a91a8a2acf64e210d2aff394e1cde432ad08e1f8c66b12293c
+  md5: 44600c4667a319d67dbe0681fc0bc833
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13399
+  timestamp: 1733332563512
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.12.0-pyhd8ed1ab_1.conda
+  sha256: 4808abfb6edb80c6800ea64d16369f0172fdeadf39045b4195eaaddae0021ec2
+  md5: 466d56f3108523402be464e4192f584e
+  depends:
+  - bokeh >=3.1.0
+  - cytoolz >=0.11.0
+  - dask-core >=2024.12.0,<2024.12.1.0a0
+  - dask-expr >=1.1,<1.2
+  - distributed >=2024.12.0,<2024.12.1.0a0
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.24
+  - pandas >=2.0
+  - pyarrow >=14.0.1
+  - python >=3.10
+  constrains:
+  - openssl !=1.1.1e
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7508
+  timestamp: 1733281563833
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.12.0-pyhd8ed1ab_1.conda
+  sha256: 5e93eafd70199294260135d8b42f1da3b690e3a17cd5c6067579a17811718c2d
+  md5: c3bd6d4f36c0e1ef9a8cce53997460c2
+  depends:
+  - click >=8.1
+  - cloudpickle >=3.0.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.4.0
+  - python >=3.10
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 905375
+  timestamp: 1733267492982
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.20-pyhd8ed1ab_0.conda
+  sha256: 4a75ff163162fc3ebd4ff3486d3bcd0b6bade744d2297f85ade7123a9282172b
+  md5: d43d68478e76b7c0e36c8ba73918a7ed
+  depends:
+  - dask-core 2024.12.0
+  - pandas >=2
+  - pyarrow >=14.0.1
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 186688
+  timestamp: 1733273336650
+- conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+  sha256: 8f35e2d76173d300f5e5f504d67238097c16457267d421a8ab10d1e5bd9b734d
+  md5: 1316959270592fbf8e2278a336de3ab9
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy
+  - packaging
+  - pandas
+  - param
+  - pillow
+  - pyct
+  - python >=3.9
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17230062
+  timestamp: 1720435590279
+- conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+  sha256: 84e5120c97502a3785e8c3241c3bf51f64b4d445f13b4d2445db00d9816fe479
+  md5: d622d8d7ee8868870f9cbe259f381181
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14068
+  timestamp: 1733236549190
+- conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
+  md5: 961b3a227b437d82ad7054484cfa71b2
+  depends:
+  - python >=3.6
+  license: PSF-2.0
+  license_family: PSF
+  size: 24062
+  timestamp: 1615232388757
+- conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.12.0-pyhd8ed1ab_1.conda
+  sha256: b88b11e273dc6abd1babb7edd801b07e21bdd09fd61722e4f5f8a046be83ee8b
+  md5: 1838762b4a8e33ee7d8281494b22ff80
+  depends:
+  - click >=8.0
+  - cloudpickle >=3.0.0
+  - cytoolz >=0.11.2
+  - dask-core >=2024.12.0,<2024.12.1.0a0
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.2
+  - packaging >=20.0
+  - psutil >=5.8.0
+  - python >=3.10
+  - pyyaml >=5.4.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.11.2
+  - tornado >=6.2.0
+  - urllib3 >=1.26.5
+  - zict >=3.0.0
+  constrains:
+  - openssl !=1.1.1e
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 803034
+  timestamp: 1733273316488
+- conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+  sha256: 80f579bfc71b3dab5bef74114b89e26c85cb0df8caf4c27ab5ffc16363d57ee7
+  md5: 3366592d3c219f2731721f11bc93755c
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 11259
+  timestamp: 1733327239578
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+  sha256: cbde2c64ec317118fc06b223c5fd87c8a680255e7348dd60e7b292d2e103e701
+  md5: a16662747cdeb9abbac74d0057cc976e
+  depends:
+  - python >=3.9
+  license: MIT and PSF-2.0
+  size: 20486
+  timestamp: 1733208916977
+- conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+  sha256: a52d7516e2e11d3eb10908e10d3eb3f8ef267fea99ed9b09d52d96c4db3441b8
+  md5: d0441db20c827c11721889a241df1220
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 28337
+  timestamp: 1725214501850
+- conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+  sha256: 42be6ac8478051b26751d778490d6a71de12e5c6443e145ff3eddbc577d9bcda
+  md5: 348e27e78a5e39090031448c72f66d5e
+  depends:
+  - python >=3.6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 19975
+  timestamp: 1643971626978
+- conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+  sha256: 2509992ec2fd38ab27c7cdb42cf6cadc566a1cc0d1021a2673475d9fa87c6276
+  md5: d3549fd50d450b6d9e7dddff25dd2110
+  depends:
+  - cached-property >=1.3.0
+  - python >=3.9,<4
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 16705
+  timestamp: 1733327494780
+- conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+  sha256: 40bb76981dd49d5869b48925a8975bb7bbe4e33e1e40af4ec06f6bf4a62effd7
+  md5: 816dbc4679a64e4417cd1385d661bb31
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 134745
+  timestamp: 1729608972363
+- conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
+  sha256: 622516185a7c740d5c7f27016d0c15b45782c1501e5611deec63fd70344ce7c8
+  md5: 7ee49e89531c0dcbba9466f6d115d585
+  depends:
+  - python >=3.9
+  - typing_extensions
+  license: MIT
+  license_family: MIT
+  size: 51846
+  timestamp: 1733327599467
+- conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
+  sha256: 843ddad410c370672a8250470697027618f104153612439076d4d7b91eeb7b5c
+  md5: 825927dc7b0f287ef8d4d0011bb113b1
+  depends:
+  - hpack >=4.0,<5
+  - hyperframe >=6.0,<7
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 52000
+  timestamp: 1733298867359
+- conda: https://conda.anaconda.org/conda-forge/noarch/holonote-0.2.1-pyhd8ed1ab_0.conda
+  sha256: 7f866a6590a1429ef931bafae66154745a68a5f189849152dd3a70f50bbcc125
+  md5: 5f67a58769a552a112e6c5146ef86ae4
+  depends:
+  - holoviews >=1.18.0
+  - pandas
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 45773
+  timestamp: 1726235911461
+- conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+  sha256: 369d234fb83fb37e0e8abe7a78981a533cec37053c5c15177ad6caade729118d
+  md5: a765e03fa67caf58525b08bbbd5b4f76
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.9
+  - pyviz_comms >=2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4037867
+  timestamp: 1730736003074
+- conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyhd8ed1ab_1.conda
+  sha256: ec89b7e5b8aa2f0219f666084446e1fb7b54545861e9caa892acb24d125761b5
+  md5: 2aa5ff7fa34a81b9196532c84c10d865
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 29412
+  timestamp: 1733299296857
+- conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+  sha256: c84d012a245171f3ed666a8bf9319580c269b7843ffa79f26468842da3abd5df
+  md5: 2ca8e6dbc86525c8b95e3c0ffa26442e
+  depends:
+  - python >=3.8
+  - h11 >=0.13,<0.15
+  - h2 >=3,<5
+  - sniffio 1.*
+  - anyio >=3.0,<5.0
+  - certifi
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48959
+  timestamp: 1731707562362
+- conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.0-pyhd8ed1ab_0.conda
+  sha256: cb7895446cd93091300accea6afbc8d9811a3c5899922ccfeeff97d9b55909dc
+  md5: 22878824a87f1af2ad48665f9d5bfcc8
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 63183
+  timestamp: 1732831049776
+- conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+  sha256: a0fb47776b6816990b94eab6e1a27025f643fa94646b845277d3aa8bce8fb2f1
+  md5: dbc57da07daee81a9cd76586217c7cbb
+  depends:
+  - bokeh >=3.1
+  - colorcet >=2
+  - holoviews >=1.19.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 246908
+  timestamp: 1729160766015
+- conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_1.conda
+  sha256: e91c6ef09d076e1d9a02819cd00fa7ee18ecf30cdd667605c853980216584d1b
+  md5: 566e75c90c1d0c8c459eb0ad9833dc7a
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 17239
+  timestamp: 1733298862681
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+  sha256: d7a472c9fd479e2e8dcb83fb8d433fce971ea369d704ece380e876f9c3494e87
+  md5: 39a4f67be3286c86d696df570b1201b7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49765
+  timestamp: 1733211921194
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+  sha256: 13766b88fc5b23581530d3a0287c0c58ad82f60401afefab283bf158d2be55a9
+  md5: 315607a3030ad5d5227e76e0733798ff
+  depends:
+  - python >=3.9
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 28623
+  timestamp: 1733223207185
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
+  sha256: 461199e429a3db01f0a673f8beaac5e0be75b88895952fb9183f2ab01c5c3c24
+  md5: 15798fa69312d433af690c8c42b3fb36
+  depends:
+  - python >=3.9
+  - zipp >=3.1.0
+  constrains:
+  - importlib-resources >=6.4.5,<6.4.6.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 32701
+  timestamp: 1733231441973
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+  sha256: 33cfd339bb4efac56edf93474b37ddc049e08b1b4930cf036c893cc1f5a1f32a
+  md5: b40131ab6a36ac2c09b7c57d4d3fbf99
+  depends:
+  - __linux
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119084
+  timestamp: 1719845605084
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+  sha256: dc569094125127c0078aa536f78733f383dd7e09507277ef8bcd1789786e7086
+  md5: 18df5fc4944a679e085e0e8f31775fc8
+  depends:
+  - __win
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119853
+  timestamp: 1719845858082
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+  sha256: 072534d4d379225b2c3a4e38bc7730b65ae171ac7f0c2d401141043336e97980
+  md5: 9eb15d654daa0ef5a98802f586bb4ffc
+  depends:
+  - __osx
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119568
+  timestamp: 1719845667420
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
+  sha256: 65cdc105e5effea2943d3979cc1592590c923a589009b484d07672faaf047af1
+  md5: 5d6e5cb3a4b820f61b2073f0ad5431f1
+  depends:
+  - __unix
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.10
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 600248
+  timestamp: 1732897026255
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh7428d3b_0.conda
+  sha256: 94ee8215bd1f614c9c984437b184e8dbe61a4014eb5813c276e3dcb18aaa7f46
+  md5: 6cdaebbc9e3feb2811eb9f52ed0b89e1
+  depends:
+  - __win
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.10
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 600466
+  timestamp: 1732897444811
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_2.conda
+  sha256: 45821a8986b4cb2421f766b240dbe6998a3c3123f012dd566720c1322e9b6e18
+  md5: 2f0ba4bc12af346bc6c99bdc377e8944
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28153
+  timestamp: 1733399692864
+- conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
+  md5: 4cb68948e0b8429534380243d063a27a
+  depends:
+  - arrow >=0.15.0
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 17189
+  timestamp: 1638811664194
+- conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+  sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+  md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.9
+  license: Apache-2.0 AND MIT
+  size: 843646
+  timestamp: 1733300981994
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+  sha256: 85a7169c078b8065bd9d121b0e7b99c8b88c42a411314b6ae5fcd81c48c4710a
+  md5: 08cce3151bde4ecad7885bd9fb647532
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110963
+  timestamp: 1733217424408
+- conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.10.0-pyhd8ed1ab_1.conda
+  sha256: 61bca2dac194c44603446944745566d7b4e55407280f6f6cea8bbe4de26b558f
+  md5: cd170f82d8e5b355dfdea6adab23e4af
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 31573
+  timestamp: 1733272196759
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+  sha256: 7d0c4c0346b26be9f220682b7c5c0d84606d48c6dbc36fc238e4452dda733aff
+  md5: da304c192ad59975202859b367d0f6a2
+  depends:
+  - attrs >=22.2.0
+  - importlib_resources >=1.4.0
+  - jsonschema-specifications >=2023.03.6
+  - pkgutil-resolve-name >=1.3.10
+  - python >=3.8
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 74323
+  timestamp: 1720529611305
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+  sha256: 82f8bed0f21dc0b3aff40dd4e39d77e85b93b0417bc5659b001e0109341b8b98
+  md5: 720745920222587ef942acfbc578b584
+  depends:
+  - python >=3.8
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 16165
+  timestamp: 1728418976382
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+  sha256: 007a0a506a0d1805b099629cb0ee743ad0afe7d9749e57339f32c168119e0139
+  md5: 16b37612b3a2fd77f409329e213b530c
+  depends:
+  - fqdn
+  - idna
+  - isoduration
+  - jsonpointer >1.13
+  - jsonschema >=4.23.0,<4.23.1.0a0
+  - rfc3339-validator
+  - rfc3986-validator >0.1.0
+  - uri-template
+  - webcolors >=24.6.0
+  license: MIT
+  license_family: MIT
+  size: 7143
+  timestamp: 1720529619500
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+  sha256: 2151c2c63e0442a4c69ee0ad8a634195eedab10b7b74c0ec8266471842239a93
+  md5: 885867f6adab3d7ecdf8ab6ca0785f51
+  depends:
+  - importlib-metadata >=4.8.3
+  - jupyter_server >=1.1.2
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55539
+  timestamp: 1712707521811
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+  sha256: 38e67f3e0d631f4aeeab4bbd4062dcb6f4ae9dc35803053c995d02912a999b65
+  md5: 5cbf9a31a19d4ef9103adb7d71fd45fd
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.7
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99449
+  timestamp: 1673616104031
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+  sha256: 732b1e8536bc22a5a174baa79842d79db2f4956d90293dd82dc1b3f6099bcccd
+  md5: 0a2980dada0dd7fd0998f0342308b1b1
+  depends:
+  - __unix
+  - platformdirs >=2.5
+  - python >=3.8
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 57671
+  timestamp: 1727163547058
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh5737063_1.conda
+  sha256: 7c903b2d62414c3e8da1f78db21f45b98de387aae195f8ca959794113ba4b3fd
+  md5: 46d87d1c0ea5da0aae36f77fa406e20d
+  depends:
+  - __win
+  - cpython
+  - platformdirs >=2.5
+  - python >=3.8
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 58269
+  timestamp: 1727164026641
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_1.conda
+  sha256: d7fa4c627d56ce8dc02f09f358757f8fd49eb6137216dc99340a6b4efc7e0491
+  md5: 62186e6383f38cc6a3466f0fadde3f2e
+  depends:
+  - jsonschema-with-format-nongpl >=4.18.0
+  - python >=3.9
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21434
+  timestamp: 1733441420606
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_1.conda
+  sha256: 082d3517455339c8baea245a257af249758ccec26b8832d969ac928901c234cc
+  md5: 81ea84b3212287f926e35b9036192963
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert-core >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.9
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 324289
+  timestamp: 1733428731329
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+  sha256: 0890fc79422191bc29edf17d7b42cff44ba254aa225d31eb30819f8772b775b8
+  md5: 2d983ff1b82a1ccb6f2e9d8784bdd6bd
+  depends:
+  - python >=3.9
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19711
+  timestamp: 1733428049134
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.2-pyhd8ed1ab_0.conda
+  sha256: e806f753fe91faaffbad3d1d3aab7ceee785ae01bf0d758a82f1466164d727d6
+  md5: 5f0d3b774cae26dd785e443a0e1623ae
+  depends:
+  - async-lru >=1.0.0
+  - httpx >=0.28.0,<0.29.0
+  - importlib-metadata >=4.8.3
+  - ipykernel >=6.5.0
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.27.1,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.9
+  - setuptools >=40.8.0
+  - tomli >=1.2.2
+  - tornado >=6.2.0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7396800
+  timestamp: 1733261150800
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+  sha256: dc24b900742fdaf1e077d9a3458fd865711de80bca95fe3c6d46610c532c6ef0
+  md5: fd312693df06da3578383232528c468d
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.9
+  constrains:
+  - jupyterlab >=4.0.8,<5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18711
+  timestamp: 1733328194037
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+  sha256: a23b26d1a35bccdb91b9232119e5f402624e1e1a252b0e64cc20c6eb5b87cefb
+  md5: af8239bf1ba7e8c69b689f780f653488
+  depends:
+  - babel >=2.10
+  - importlib-metadata >=4.8.3
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.8
+  - requests >=2.31
+  constrains:
+  - openapi-core >=0.18.0,<0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49355
+  timestamp: 1721163412436
+- conda: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_1.conda
+  sha256: c1ca8dc910d7c32d431d8ef4acdea8da2e876c62f096b99591f712fd62cf7269
+  md5: 4809b9f4c6ce106d443c3f90b8e10db2
+  depends:
+  - importlib-metadata
+  - packaging
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16193
+  timestamp: 1723774444381
+- conda: https://conda.anaconda.org/conda-forge/noarch/lazy_loader-0.4-pyhd8ed1ab_1.conda
+  sha256: bf5a563f4e7d2bd5d3ec0644c0cb452b1e9e4ee68a221f6c9718872a22d4fa7a
+  md5: ec6f70b8a5242936567d4f886726a372
+  depends:
+  - lazy-loader 0.4 pyhd8ed1ab_1
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6513
+  timestamp: 1723774453792
+- conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+  sha256: aa99d44e8c83865026575a8af253141c53e0b3ab05f053befaa7757c8525064f
+  md5: f1b64ca4faf563605cf6f6ca93f9ff3f
+  depends:
+  - python >=3.7
+  - uc-micro-py
+  license: MIT
+  license_family: MIT
+  size: 24035
+  timestamp: 1707129321841
+- conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
+  md5: 91e27ef3d05cc772ce627e51cff111c4
+  depends:
+  - python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 8250
+  timestamp: 1650660473123
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+  sha256: fce1fde00359696983989699c00f9891194c4ebafea647a8d21b7e2e3329b56e
+  md5: 06e9bebf748a0dea03ecbe1f0e27e909
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78331
+  timestamp: 1710435316163
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+  sha256: 0fbacdfb31e55964152b24d5567e9a9996e1e7902fb08eb7d91b5fd6ce60803a
+  md5: fee3164ac23dfca50cfcc8b85ddefb81
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 64430
+  timestamp: 1733250550053
+- conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+  sha256: 69b7dc7131703d3d60da9b0faa6dd8acbf6f6c396224cf6aef3e855b8c0c41c6
+  md5: af6ab708897df59bd6e7283ceab1b56b
+  depends:
+  - python >=3.9
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14467
+  timestamp: 1733417051523
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+  sha256: 5cedc99412278b37e9596f1f991d49f5a1663fe79767cf814a288134a1400ba9
+  md5: 5387f2cfa28f8a3afa3368bb4ba201e8
+  depends:
+  - markdown-it-py >=1.0.0,<4.0.0
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 42126
+  timestamp: 1725995333692
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+  sha256: 78c1bbe1723449c52b7a9df1af2ee5f005209f67e40b6e1d3c7619127c43b1c7
+  md5: 592132998493b3ff25fd7479396e8351
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 14465
+  timestamp: 1733255681319
+- conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_1.conda
+  sha256: 0a9faaf1692b74f321cedbd37a44f108a1ec3f5d9638bc5bbf860cb3b6ff6db4
+  md5: c46df05cae629e55426773ac1f85d68f
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65901
+  timestamp: 1733258822603
+- conda: https://conda.anaconda.org/conda-forge/noarch/mne-base-1.8.0-pyh694c41f_200.conda
+  sha256: a777fcde8b0299a8a00e67bbe058f0f48295368ca24185efc2806449987310bf
+  md5: baa925d0e4fd05b33a430913c235bd4e
+  depends:
+  - decorator
+  - jinja2
+  - lazy_loader >=0.3
+  - matplotlib-base >=3.5.0
+  - numpy >=1.21.2
+  - packaging
+  - pooch >=1.5
+  - python >=3.9
+  - scipy >=1.7.1
+  - tqdm
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7210433
+  timestamp: 1724034836971
+  purls:
+  - pkg:pypi/mne?source=hash-mapping
+- conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+  sha256: c6216a21154373b340c64f321f22fec51db4ee6156c2e642fa58368103ac5d09
+  md5: 121a57fce7fff0857ec70fa03200962f
+  depends:
+  - python >=3.6
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17254
+  timestamp: 1721907640382
+- conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+  sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
+  md5: 2ba8498c1018c1e9c61eb99b973dfe19
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12452
+  timestamp: 1600387789153
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_1.conda
+  sha256: 6f43d2096c6f98aff2a03a7fafbb948f0404f1453010407b81a3d92fd929b78d
+  md5: 7a4d3e43cf7f83774d9a50051a6a7f62
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5491952
+  timestamp: 1733410454932
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+  sha256: 564e22c4048f2f00c7ee79417dea364f95cf069a1f2565dc26d5ece1fc3fd779
+  md5: 3ee79082e59a28e1db11e2a9c3bcd85a
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.8
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27878
+  timestamp: 1732882434219
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhff2d567_2.conda
+  sha256: 03a1303ce135a8214b450e751d93c9048f55edb37f3f9f06c5e9d78ba3ef2a89
+  md5: 0457fdf55c88e52e0e7b63691eafcc48
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<3.1
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.8
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - nbconvert =7.16.4=*_2
+  - pandoc >=2.9.2,<4.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 188505
+  timestamp: 1733405603619
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+  sha256: 7a5bd30a2e7ddd7b85031a5e2e14f290898098dc85bea5b3a5bf147c25122838
+  md5: bbe1963f1e47f594070ffe87cdf612ea
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.9
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100945
+  timestamp: 1733402844974
+- conda: https://conda.anaconda.org/conda-forge/noarch/ndpyramid-0.2.0-pyhd8ed1ab_0.conda
+  sha256: 761f0a3ce17f86c060fc4d9c253df0c1fd9e22155f6e28ff3bf0afca7aacc42e
+  md5: f656db5709732b26aef926db83e8987f
+  depends:
+  - cf_xarray
+  - pydantic >=1.10
+  - pyproj
+  - python >=3.9
+  - rasterio
+  - xarray
+  - xarray-datatree >=0.0.11
+  - zarr
+  license: MIT
+  license_family: MIT
+  size: 17850
+  timestamp: 1714057156389
+- conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+  sha256: bb7b21d7fd0445ddc0631f64e66d91a179de4ba920b8381f29b9d006a42788c0
+  md5: 598fd7d4d0de2455fb74f56063969a97
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11543
+  timestamp: 1733325673691
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+  sha256: e37db45223e432bcad809897177e05fff31828dfcfc3ef18f046ae44ec01286c
+  md5: f81a6fe643390df9347984644727d796
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert-core >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.7
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 308643
+  timestamp: 1715849037288
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+  sha256: 7b920e46b9f7a2d2aa6434222e5c8d739021dbc5cc75f32d124a8191d86f9056
+  md5: e7f89ea5f7ea9401642758ff50a2d9c1
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16817
+  timestamp: 1733408419340
+- conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+  sha256: 5e238e5e646414d517a13f6786c7227206ace58271e3ef63f6adca4d6a4c2839
+  md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
+  depends:
+  - python >=3.6
+  - typing_utils
+  license: Apache-2.0
+  license_family: APACHE
+  size: 30232
+  timestamp: 1706394723472
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+  sha256: da157b19bcd398b9804c5c52fc000fcb8ab0525bdb9c70f95beaa0bb42f85af1
+  md5: 3bfed7e6228ebf2f7b9eaa47f1b4e2aa
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: APACHE
+  size: 60164
+  timestamp: 1733203368787
+- conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
+  md5: 457c2c8c08e54905d6954e79cb5b5db9
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11627
+  timestamp: 1631603397334
+- conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+  sha256: 5a05f572a610cada2fcccef8d555fddf2d01bef80da32411150735e6177d1eab
+  md5: 41c7413071c2bae37472214a3525e6bf
+  depends:
+  - bleach
+  - bokeh >=3.5.0,<3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.1.0,<3.0
+  - python >=3.10
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20670374
+  timestamp: 1731497809631
+- conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+  sha256: db644c81c1f47e1fa8134d5de935ec4269d765fbef8d44bd454eb187c7524472
+  md5: bd991333d5bc659bb82bfb5a5d4c1576
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 103339
+  timestamp: 1719325288387
+- conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
+  sha256: 17131120c10401a99205fc6fe436e7903c0fa092f1b3e80452927ab377239bcc
+  md5: 5c092057b6badd30f75b06244ecd01c9
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 75295
+  timestamp: 1733271352153
+- conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+  sha256: 472fc587c63ec4f6eba0cc0b06008a6371e0a08a5986de3cf4e8024a47b4fe6c
+  md5: 0badf9c54e24cecfb0ad2f99d680c163
+  depends:
+  - locket
+  - python >=3.9
+  - toolz
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20884
+  timestamp: 1715026639309
+- conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+  sha256: 202af1de83b585d36445dc1fda94266697341994d1a3328fabde4989e1b3d07a
+  md5: d0d408b1f18883a944376da5cf8101ea
+  depends:
+  - ptyprocess >=0.5
+  - python >=3.9
+  license: ISC
+  size: 53561
+  timestamp: 1733302019362
+- conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+  sha256: e2ac3d66c367dada209fc6da43e645672364b9fd5f9d28b9f016e24b81af475b
+  md5: 11a9d1d09a3615fc07c3faf79bc0b943
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 11748
+  timestamp: 1733327448200
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+  sha256: 499313e72e20225f84c2e9690bbaf5b952c8d7e0bf34b728278538f766b81628
+  md5: 5dd546fe99b44fda83963d15f84263b7
+  depends:
+  - python >=3.8,<3.13.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 1243168
+  timestamp: 1730203795600
+- conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+  sha256: adb2dde5b4f7da70ae81309cce6188ed3286ff280355cf1931b45d91164d2ad8
+  md5: 5a5870a74432aa332f7d32180633ad05
+  depends:
+  - python >=3.9
+  license: MIT AND PSF-2.0
+  size: 10693
+  timestamp: 1733344619659
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+  sha256: bb50f6499e8bc1d1a26f17716c97984671121608dc0c3ecd34858112bce59a27
+  md5: 577852c7e53901ddccc7e6a9959ddebe
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 20448
+  timestamp: 1733232756001
+- conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_1.conda
+  sha256: bedda6b36e8e42b0255179446699a0cf08051e6d9d358dd0dd0e787254a3620e
+  md5: b3e783e8e8ed7577cf0b6dee37d1fbac
+  depends:
+  - packaging >=20.0
+  - platformdirs >=2.5.0
+  - python >=3.9
+  - requests >=2.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54116
+  timestamp: 1733421432357
+- conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.1-pyhd8ed1ab_0.conda
+  sha256: bc8f00d5155deb7b47702cb8370f233935704100dbc23e30747c161d1b6cf3ab
+  md5: 3e01e386307acc60b2f89af0b2e161aa
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  size: 49002
+  timestamp: 1733327434163
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_1.conda
+  sha256: 79fb7d1eeb490d4cc1b79f781bb59fe302ae38cf0a30907ecde75a7d399796cc
+  md5: 368d4aa48358439e07a97ae237491785
+  depends:
+  - python >=3.9
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.48
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269848
+  timestamp: 1733302634979
+- conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+  sha256: a7713dfe30faf17508ec359e0bc7e0983f5d94682492469bd462cdaae9c64d83
+  md5: 7d9daffbb8d8e0af0f769dbbcd173a54
+  depends:
+  - python >=3.9
+  license: ISC
+  size: 19457
+  timestamp: 1733302371990
+- conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+  sha256: dcfcb3cee1ae0a89729601582cc3edea20ba13c9493967a03a693c67567af0c8
+  md5: 0f051f09d992e0d08941706ad519ee0e
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 16551
+  timestamp: 1721585805256
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+  sha256: 79db7928d13fab2d892592223d7570f5061c192f27b9febd1a418427b719acc6
+  md5: 12c566707c80111f9799308d9e265aef
+  depends:
+  - python >=3.9
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110100
+  timestamp: 1733195786147
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+  sha256: 0e1e17a37d53be84c33b88218f10afb5f8137f19a727fdc56e45ae0b8b439a57
+  md5: 24c245c82396be3297c0aa26b69e18d8
+  depends:
+  - param >=1.7.0
+  - python >=3.7
+  - pyyaml
+  - requests
+  - setuptools >=61.0
+  constrains:
+  - pyct-core <0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20096
+  timestamp: 1701103924264
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.10.3-pyh3cfb1c2_0.conda
+  sha256: cac9eebd3d5f8d8a497a9025d756257ddc75b8b3393e6737cb45077bd744d4f8
+  md5: 194ef7f91286978521350f171b117f01
+  depends:
+  - annotated-types >=0.6.0
+  - pydantic-core 2.27.1
+  - python >=3.9
+  - typing-extensions >=4.6.1
+  - typing_extensions >=4.12.2
+  license: MIT
+  license_family: MIT
+  size: 317037
+  timestamp: 1733316963547
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+  sha256: 0d6133545f268b2b89c2617c196fc791f365b538d4057ecd636d658c3b1e885d
+  md5: b38dc0206e2a530e5c2cf11dc086b31a
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 876700
+  timestamp: 1733221731178
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_2.conda
+  sha256: 09a5484532e24a33649ab612674fd0857bbdcfd6640a79d13a6690fb742a36e1
+  md5: 4c05a2bcf87bb495512374143b57cf28
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 92319
+  timestamp: 1733222687746
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyqtgraph-0.13.7-pyhd8ed1ab_0.conda
+  sha256: e0ab6d9b69bde1febba187f88c4743cb36063c3edbf3642ac0e604979bf6f126
+  md5: d31a6f00bd89ff46a5e457c935578c33
+  depends:
+  - numpy >=1.22
+  - python >=3.9
+  constrains:
+  - pyqt >=5.15
+  - pyside2 >=5.15
+  license: MIT
+  license_family: MIT
+  size: 1443102
+  timestamp: 1714681228438
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
+  sha256: d016e04b0e12063fbee4a2d5fbb9b39a8d191b5a0042f0b8459188aedeabb0ca
+  md5: e2fd202833c4a981ce8a65974fe4abd1
+  depends:
+  - __win
+  - python >=3.9
+  - win_inet_pton
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21784
+  timestamp: 1733217448189
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+  sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
+  md5: 461219d1a5bd61342293efa2c0c90eac
+  depends:
+  - __unix
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21085
+  timestamp: 1733217331982
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+  sha256: a50052536f1ef8516ed11a844f9413661829aa083304dc624c5925298d078d79
+  md5: 5ba79d7c71f03c678c8ead841f347d6e
+  depends:
+  - python >=3.9
+  - six >=1.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 222505
+  timestamp: 1733215763718
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+  sha256: 1b09a28093071c1874862422696429d0d35bd0b8420698003ac004746c5e82a2
+  md5: 38e34d2d1d9dca4fb2b9a0a04f604e2c
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 226259
+  timestamp: 1733236073335
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+  sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
+  md5: a61bf9ec79426938ff785eb69dbb1960
+  depends:
+  - python >=3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13383
+  timestamp: 1677079727691
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+  sha256: 57c9a02ec25926fb48edca59b9ede107823e5d5c473b94a0e05cc0b9a193a642
+  md5: c0def296b2f6d2dd7b030c2a7f66bb1f
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 142235
+  timestamp: 1733235414217
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+  sha256: 1a7d6b233f7e6e3bbcbad054c8fd51e690a67b129a899a056a5e45dd9f00cb41
+  md5: 3eeeeb9e4827ace8c0c1419c85d590ad
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 188538
+  timestamp: 1706886944988
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+  sha256: a7979e8e4936c430f5fe3d04fc2d67b42dab84fb4a502c4961a17dcb2327fec0
+  md5: 02b4e3a3014c1ac490ee4a4316f2d229
+  depends:
+  - param
+  - python >=3.6
+  constrains:
+  - jupyterlab >=4.0,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48061
+  timestamp: 1722535734510
+- conda: https://conda.anaconda.org/conda-forge/noarch/qtpy-2.4.2-pyhdecd6ff_0.conda
+  sha256: b1b148dfcdd9f343729f39e68851600b13c6e16c041d6cb13aaf37fb86033da3
+  md5: 5060d07c9a66612192a3f6f0609fa36f
+  depends:
+  - packaging
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 62425
+  timestamp: 1730763884592
+- conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_1.conda
+  sha256: f972eecb4dc8e06257af37642f92b0f2df04a7fe4c950f2e1045505e5e93985f
+  md5: 8c9083612c1bfe6878715ed5732605f8
+  depends:
+  - attrs >=22.2.0
+  - python >=3.9
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 42201
+  timestamp: 1733366868091
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+  sha256: d701ca1136197aa121bbbe0e8c18db6b5c94acbd041c2b43c70e5ae104e1d8ad
+  md5: a9b9368f3701a417eac9edbcae7cb737
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 58723
+  timestamp: 1733217126197
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
+  md5: fed45fc5ea0813240707998abe49f520
+  depends:
+  - python >=3.5
+  - six
+  license: MIT
+  license_family: MIT
+  size: 8064
+  timestamp: 1638811838081
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+  sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
+  md5: 912a71cc01012ee38e6b90ddd561e36f
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 7818
+  timestamp: 1598024297745
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_1.conda
+  sha256: 00926652bbb8924e265caefdb1db100f86a479e8f1066efe395d5552dde54d02
+  md5: 938c8de6b9de091997145b3bf25cdbf9
+  depends:
+  - __linux
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22736
+  timestamp: 1733322148326
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_1.conda
+  sha256: 5282eb5b462502c38df8cb37cd1542c5bbe26af2453a18a0a0602d084ca39f53
+  md5: e67b1b1fa7a79ff9e8e326d0caf55854
+  depends:
+  - __osx
+  - pyobjc-framework-cocoa
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23100
+  timestamp: 1733322309409
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_1.conda
+  sha256: ba8b93df52e0d625177907852340d735026c81118ac197f61f1f5baea19071ad
+  md5: e6a4e906051565caf5fdae5b0415b654
+  depends:
+  - __win
+  - python >=3.9
+  - pywin32
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23359
+  timestamp: 1733322590167
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+  sha256: abb12e1dd515b13660aacb5d0fd43835bc2186cab472df25b7716cd65e095111
+  md5: fc80f7995e396cbaeabd23cf46c413dc
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 774252
+  timestamp: 1732632769210
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+  sha256: 41db0180680cc67c3fa76544ffd48d6a5679d96f4b71d7498a759e94edc9a2db
+  md5: a451d576819089b0d672f18768be0f65
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 16385
+  timestamp: 1733381032766
+- conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+  sha256: c2248418c310bdd1719b186796ae50a8a77ce555228b6acd32768e2543a15012
+  md5: bf7a226e58dfb8346c70df36065d86c9
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  size: 15019
+  timestamp: 1733244175724
+- conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_1.conda
+  sha256: 4c2281d61c325f9208ce18e030efc94e44c9a4f0d28a6c5737ff79740e1db2d4
+  md5: 5abeaa41ec50d4d1421a8bc8fbc93054
+  depends:
+  - numpy
+  - pyparsing >=2.1.6
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 11131
+  timestamp: 1722610712753
+- conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
+  md5: 6d6552722448103793743dabfbda532d
+  depends:
+  - python >=2.7
+  license: Apache-2.0
+  license_family: APACHE
+  size: 26314
+  timestamp: 1621217159824
+- conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+  sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
+  md5: 3f144b2c34f8cb5a9abd9ed23a39c561
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 36754
+  timestamp: 1693929424267
+- conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+  sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
+  md5: e7df0fdd404616638df5ece6e69ba7af
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 26205
+  timestamp: 1669632203115
+- conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+  sha256: 2e2c255b6f24a6d75b9938cb184520e27db697db2c24f04e18342443ae847c0a
+  md5: 04eedddeb68ad39871c8127dd1c21f4f
+  depends:
+  - python >=3.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17386
+  timestamp: 1702066480361
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+  sha256: b300557c0382478cf661ddb520263508e4b3b5871b471410450ef2846e8c352c
+  md5: efba281bbdae5f6b0a1d53c6d4a97c93
+  depends:
+  - __linux
+  - ptyprocess
+  - python >=3.8
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22452
+  timestamp: 1710262728753
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+  sha256: 4daae56fc8da17784578fbdd064f17e3b3076b394730a14119e571707568dc8a
+  md5: 00b54981b923f5aefcd5e8547de056d5
+  depends:
+  - __osx
+  - ptyprocess
+  - python >=3.8
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22717
+  timestamp: 1710265922593
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
+  sha256: 8cb078291fd7882904e3de594d299c8de16dd3af7405787fce6919a385cfc238
+  md5: 4abd500577430a942a995fd0d09b76a2
+  depends:
+  - __win
+  - python >=3.8
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22883
+  timestamp: 1710262943966
+- conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+  sha256: cad582d6f978276522f84bd209a5ddac824742fe2d452af6acf900f8650a73a2
+  md5: f1acf5fdefa8300de697982bcb1761c9
+  depends:
+  - python >=3.5
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28285
+  timestamp: 1729802975370
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+  sha256: 18636339a79656962723077df9a56c0ac7b8a864329eb8f847ee3d38495b863e
+  md5: ac944244f1fed2eb49bae07193ae8215
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 19167
+  timestamp: 1733256819729
+- conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+  sha256: 6371cf3cf8292f2abdcc2bf783d6e70203d72f8ff0c1625f55a486711e276c75
+  md5: 34feccdd4177f2d3d53c73fc44fd9a37
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 52623
+  timestamp: 1728059623353
+- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+  sha256: 5673b7104350a6998cb86cccf1d0058217d86950e8d6c927d8530606028edb1d
+  md5: 4085c9db273a148e149c03627350e22c
+  depends:
+  - colorama
+  - python >=3.7
+  license: MPL-2.0 or MIT
+  size: 89484
+  timestamp: 1732497312317
+- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+  sha256: f39a5620c6e8e9e98357507262a7869de2ae8cc07da8b7f84e517c9fd6c2b959
+  md5: 019a7385be9af33791c989871317e1ed
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110051
+  timestamp: 1733367480074
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhd8ed1ab_1.conda
+  sha256: 78538b566f1f1cd1e309bba8361875523c69db1a25db292a54977603c5ea1421
+  md5: cb0e8ce6fe1198a058040619a09bc424
+  depends:
+  - python >=3.9
+  license: Apache-2.0 AND MIT
+  size: 21850
+  timestamp: 1733279726734
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+  sha256: c8e9c1c467b5f960b627d7adc1c65fece8e929a3de89967e91ef0f726422fd32
+  md5: b6a408c64b78ec7b779a3e5c7a902433
+  depends:
+  - typing_extensions 4.12.2 pyha770c72_1
+  license: PSF-2.0
+  license_family: PSF
+  size: 10075
+  timestamp: 1733188758872
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+  sha256: 337be7af5af8b2817f115b3b68870208b30c31d3439bec07bfb2d8f4823e3568
+  md5: d17f13df8b65464ca316cbc000a3cb64
+  depends:
+  - python >=3.9
+  license: PSF-2.0
+  license_family: PSF
+  size: 39637
+  timestamp: 1733188758212
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+  sha256: 3088d5d873411a56bf988eee774559335749aed6f6c28e07bf933256afb9eb6c
+  md5: f6d7aa696c67756a650e91e15e88223c
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 15183
+  timestamp: 1733331395943
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+  sha256: 4fde5c3008bf5d2db82f2b50204464314cc3c91c1d953652f7bd01d9e52aefdf
+  md5: 8ac3367aafb1cc0a068483c580af8015
+  license: LicenseRef-Public-Domain
+  size: 122354
+  timestamp: 1728047496079
+- conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+  sha256: 54293cd94da3a6b978b353eb7897555055d925ad0008bc73e85cca19e2587ed0
+  md5: 3b7fc78d7be7b450952aaa916fb78877
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 11162
+  timestamp: 1707507514699
+- conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+  sha256: e0eb6c8daf892b3056f08416a96d68b0a358b7c46b99c8a50481b22631a4dfc0
+  md5: e7cb0f5745e4c5035a460248334af7eb
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 23990
+  timestamp: 1733323714454
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+  sha256: 416e30a1c3262275f01a3e22e783118d9e9d2872a739a9ed860d06fa9c7593d5
+  md5: 4a2d8ef7c37b8808c5b9b750501fffce
+  depends:
+  - brotli-python >=1.0.9
+  - h2 >=4,<5
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 98077
+  timestamp: 1733206968917
+- conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+  sha256: f21e63e8f7346f9074fd00ca3b079bd3d2fa4d71f1f89d5b6934bf31446dc2a5
+  md5: b68980f2495d096e71c7fd9d7ccf63e6
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 32581
+  timestamp: 1733231433877
+- conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+  sha256: 08315dc2e61766a39219b2d82685fc25a56b2817acf84d5b390176080eaacf99
+  md5: b49f7b291e15494aafb0a7d74806f337
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18431
+  timestamp: 1733359823938
+- conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+  sha256: 19ff205e138bb056a46f9e3839935a2e60bd1cf01c8241a5e172a422fed4f9c6
+  md5: 2841eb5bfc75ce15e9a0054b98dcd64d
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15496
+  timestamp: 1733236131358
+- conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+  sha256: 1dd84764424ffc82030c19ad70607e6f9e3b9cb8e633970766d697185652053e
+  md5: 84f8f77f0a9c6ef401ee96611745da8f
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 46718
+  timestamp: 1733157432924
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+  sha256: 1b34021e815ff89a4d902d879c3bd2040bc1bd6169b32e9427497fa05c55f1ce
+  md5: 75cb7132eb58d97896e173ef12ac9986
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 62931
+  timestamp: 1733130309598
+- conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+  sha256: 93807369ab91f230cf9e6e2a237eaa812492fe00face5b38068735858fba954f
+  md5: 46e441ba871f524e2b067929da3051c2
+  depends:
+  - __win
+  - python >=3.9
+  license: LicenseRef-Public-Domain
+  size: 9555
+  timestamp: 1733130678956
+- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.9.0-pyhd8ed1ab_1.conda
+  sha256: 8bb5b522cdf1905d831a9b371a3a3bd2932a9f53398332fbd38ed3442015bbaf
+  md5: dc790d427d89b85ae12fc094e264833f
+  depends:
+  - numpy >=1.24
+  - packaging >=23.1
+  - pandas >=2.1
+  - python >=3.10
+  constrains:
+  - seaborn-base >=0.12
+  - distributed >=2023.9
+  - scipy >=1.11
+  - netcdf4 >=1.6.0
+  - toolz >=0.12
+  - nc-time-axis >=1.4
+  - cftime >=1.6
+  - h5netcdf >=1.2
+  - matplotlib-base >=3.7
+  - h5py >=3.8
+  - zarr >=2.16
+  - hdf5 >=1.12
+  - numba >=0.57
+  - iris >=3.7
+  - cartopy >=0.22
+  - dask-core >=2023.9
+  - flox >=0.7
+  - bottleneck >=1.3
+  - pint >=0.22
+  - sparse >=0.14
+  license: Apache-2.0
+  license_family: APACHE
+  size: 801066
+  timestamp: 1728453306227
+- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-datatree-0.0.14-pyhd8ed1ab_0.conda
+  sha256: 461e5c54721cf4ae0b785e3eb5fa76d6459998f29b871ab59e8d02e16fcd4a4f
+  md5: d7d176a24b7dee88e07ad75930306e6a
+  depends:
+  - python >=3.8
+  - xarray >=2022.6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 57205
+  timestamp: 1707506570063
+- conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_1.conda
+  sha256: 5f8757092fc985d7586f2659505ec28757c05fd65d8d6ae549a5cec7e3376977
+  md5: c79cea50b258f652010cb6c8d81591b5
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 46860
+  timestamp: 1733143536777
+- conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.18.3-pyhd8ed1ab_1.conda
+  sha256: 02c045d3ab97bd5a713b0f35b05f017603d33bd728694ce3cf843c45c2906535
+  md5: 3e9a0fee25417c432c4780b9597fc312
+  depends:
+  - asciitree
+  - fasteners
+  - numcodecs >=0.10.0,<0.16.0a0
+  - numpy >=1.24,<3.0
+  - python >=3.10
+  constrains:
+  - notebook
+  - ipytree >=0.2.2
+  - ipywidgets >=8.0.0
+  license: MIT
+  license_family: MIT
+  size: 160013
+  timestamp: 1733237313723
+- conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
+  sha256: 5488542dceeb9f2874e726646548ecc5608060934d6f9ceaa7c6a48c61f9cc8d
+  md5: e52c2ef711ccf31bb7f70ca87d144b9e
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36341
+  timestamp: 1733261642963
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+  sha256: 567c04f124525c97a096b65769834b7acb047db24b15a56888a322bf3966c3e1
+  md5: 0c3cc595284c5e8f0f9900a9b228a332
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 21809
+  timestamp: 1732827613585
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.9.1-hf036a51_0.conda
+  sha256: 3032f2f55d6eceb10d53217c2a7f43e1eac83603d91e21ce502e8179e63a75f5
+  md5: 3f17bc32cb7fcb2b4bf3d8d37f656eb8
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2749186
+  timestamp: 1718551450314
+- conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h3336109_5.conda
+  sha256: fa5eb633b320e10fc2138f3d842d8a8ca72815f106acbab49a68ec9783e4d70d
+  md5: 29b46bd410067f668c4cef7fdc78fe25
+  depends:
+  - __osx >=10.13
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 32275
+  timestamp: 1725356815696
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.8.0-hb1b2711_10.conda
+  sha256: 88731bee2b93e8bf5e6c0a692da9a28ac017de16880e72d6a26d4f48377a69ae
+  md5: cabb2823d1eaa138c1fa5ea3b68b9f8a
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94585
+  timestamp: 1731733610867
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.8.0-h1c3498a_2.conda
+  sha256: fa5cf06e1553198ef41d6aae29bfdf990053db185c492c27b116b2c91137e8c0
+  md5: b900b8d8f2d51c1b84ad1c8a1366c1e3
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 39373
+  timestamp: 1731678700352
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.10.3-h6e16a3a_0.conda
+  sha256: b31603e305c9a7b9f7dca010471ac2012a4c570da483737ec090db4812674fe8
+  md5: d1b72435b57b79fb97ba3ab6564db34c
+  depends:
+  - __osx >=10.13
+  license: Apache-2.0
+  license_family: Apache
+  size: 227079
+  timestamp: 1731567405398
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.3.0-h1c3498a_2.conda
+  sha256: 7cbb8cf79428c342518b2ba456361f89e48ec5ae6a974b2bb3bd8ceb84778c5c
+  md5: af56ad879a463b520989ddd774aa7695
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18023
+  timestamp: 1731678883009
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.5.0-heedde58_7.conda
+  sha256: 5fe9a5cc297d8c54536d7958738db35ae7ef561ad02494692b03c5c2b41f896e
+  md5: b1fa857b39304646770e3f0d70182ed3
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 46953
+  timestamp: 1731714670991
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.9.1-h0c96e2d_2.conda
+  sha256: dab3bc124acb36fd89839337b37fac40fcf47798a66934aa18e280a889646e8e
+  md5: e0596752aa1c4f748c88bce167ae003d
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-compression >=0.3.0,<0.3.1.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 164320
+  timestamp: 1731714564875
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.15.2-h789f5c1_2.conda
+  sha256: 57775bb51fbb45405575548d7452fc7702affac744fd6b80aebc82a28f5e2cba
+  md5: f85932994b14737e4ec6b6dc0bb66036
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 139362
+  timestamp: 1731702578455
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.11.0-h00ab244_8.conda
+  sha256: 5ba0cd019a01ca553784d18f6e4cc60a481eb88410ca689b6adbc1915cb85b89
+  md5: 0c2db3585e4c1865cdf4528720bab440
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 164288
+  timestamp: 1731734750092
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.7.4-h704940e_0.conda
+  sha256: cfc247d4cdbfe9a8ca1d6d4988ec46d1b4cec06b83a7a0d9687675b856a4c783
+  md5: 66754f738987425c35ef8c5699417fa0
+  depends:
+  - __osx >=10.13
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 98479
+  timestamp: 1733299361124
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.2.1-h1c3498a_1.conda
+  sha256: 59f47c5bea2ddc1c502999e6b2a4ebb81be7ddbf9d2b5818ff1cdc5ad58aa03d
+  md5: 70cd54aaaddb6efa4e5d41fa8f045a44
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51034
+  timestamp: 1731687124981
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.2.2-h1c3498a_1.conda
+  sha256: a52b53437bd274eeee1bdd1427686b2d3b4bed586a91f0ea5a4c45303805cd56
+  md5: a13de34c0c2224a8755ef3854f85c2a8
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 70940
+  timestamp: 1731687320283
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.29.6-h8618fae_2.conda
+  sha256: 23afda1ba3d1c2ea3d5216c30d414c1af98e87e23ab9c5bb0f99d4371c9073b6
+  md5: 33bc441e02982318b7a0b31452a7c2d2
+  depends:
+  - __osx >=10.13
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-mqtt >=0.11.0,<0.11.1.0a0
+  - aws-c-s3 >=0.7.4,<0.7.5.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 296184
+  timestamp: 1733334174094
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.449-he3c0133_4.conda
+  sha256: 17ab2acfbb32d82a4ebecf706c28ccb5b61329d5f95d2f9cb11459810b807f70
+  md5: 93a4b306f61300dac213d4433d34974c
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2784788
+  timestamp: 1732812562314
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.14.0-h9a36307_0.conda
+  sha256: c7694fc16b9aebeb6ee5e4f80019b477a181d961a3e4d9b6a66b77777eb754fe
+  md5: 1082a031824b12a2be731d600cfa5ccb
+  depends:
+  - __osx >=10.13
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 303166
+  timestamp: 1728053999891
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.10.0-ha4e2ba9_0.conda
+  sha256: b9899b9698a6c7353fc5078c449105aae58635d217befbc8ca9d5a527198019b
+  md5: ad56b6a4b8931d37a2cf5bc724a46f01
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 175344
+  timestamp: 1728487066445
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.13.0-h3d2f5f1_1.conda
+  sha256: 31984e52450230d04ca98d5232dbe256e5ef6e32b15d46124135c6e64790010d
+  md5: 3df4fb5d6d0e7b3fb28e071aff23787e
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 445040
+  timestamp: 1728578180436
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.8.0-h1ccc5ac_1.conda
+  sha256: 51fb67d2991d105b8f7b97b4810cd63bac4dc421a4a9c83c15a98ca520a42e1e
+  md5: 5b3e79eb148d6e30d6c697788bad9960
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - libxml2 >=2.12.7,<2.14.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 126229
+  timestamp: 1728563580392
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-files-datalake-cpp-12.12.0-h86941f0_1.conda
+  sha256: 12d95251a8793ea2e78f494e69353a930e9ea06bbaaaa4ccb6e5b3e35ee0744f
+  md5: 60452336e7f61f6fdaaff69264ee112e
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 200991
+  timestamp: 1728729588371
+- conda: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.6-h7d75f6d_0.conda
+  sha256: 65e5f5dd3d68ed0d9d35e79d64f8141283cad2b55dcd9a04480ceea0e436aca8
+  md5: 3e5669e51737d04f4806dd3e8c424663
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 47051
+  timestamp: 1719266142315
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h00291cd_2.conda
+  sha256: 624954bc08b3d7885a58c7d547282cfb9a201ce79b748b358f801de53e20f523
+  md5: 2db0c38a7f2321c5bdaf32b181e832c7
+  depends:
+  - __osx >=10.13
+  - brotli-bin 1.1.0 h00291cd_2
+  - libbrotlidec 1.1.0 h00291cd_2
+  - libbrotlienc 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 19450
+  timestamp: 1725267851605
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h00291cd_2.conda
+  sha256: 642a8492491109fd8270c1e2c33b18126712df0cedb94aaa2b1c6b02505a4bfa
+  md5: 049933ecbf552479a12c7917f0a4ce59
+  depends:
+  - __osx >=10.13
+  - libbrotlidec 1.1.0 h00291cd_2
+  - libbrotlienc 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 16643
+  timestamp: 1725267837325
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hd89902b_2.conda
+  sha256: 004cefbd18f581636a8dcb1964fb73478f15d496769226ec896c1d4a0161b7d8
+  md5: d75f06ee06001794aa83a05e885f1520
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 363793
+  timestamp: 1725267947069
+- conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+  sha256: cad153608b81fb24fc8c509357daa9ae4e49dfc535b2cb49b91e23dbd68fc3c5
+  md5: 7ed4301d437b59045be7e051a0308211
+  depends:
+  - __osx >=10.13
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 134188
+  timestamp: 1720974491916
+- conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.3-hf13058a_1.conda
+  sha256: 37c031f91bb4c7ebec248e283c453b24840764fb53b640768780dcd904093f17
+  md5: 7d8083876d71fe1316fc18369ee0dc58
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 184403
+  timestamp: 1732447223773
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.8.30-h8857fd0_0.conda
+  sha256: 593f302d0f44c2c771e1614ee6d56fffdc7d616e6f187669c8b0e34ffce3e1ae
+  md5: b7e5424e7f06547a903d28e4651dbb21
+  license: ISC
+  size: 158665
+  timestamp: 1725019059295
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.1-py311h137bacd_0.conda
+  sha256: 012ee7b1ed4f9b0490d6e90c72decf148d7575173c7eaf851cd87fd434d2cacc
+  md5: a4b0f531064fa3dd5e3afbb782ea2cd5
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 288762
+  timestamp: 1725560945833
+- conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.1-py311h4e34fa0_0.conda
+  sha256: 373e17f22bca3e13aac2245bb0c8a15c4a54d1ffa4c3278308eeb8d3c9435c0e
+  md5: 6bc3882064e277827934e2c6e5281661
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 255123
+  timestamp: 1731428577146
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.0.0-py311h3336109_1.conda
+  sha256: fd921e8aa9ec5d26b2aebaef91dd4bc1e6d4fd2114f2fc566578122ff95cdb3c
+  md5: d7a579f4ad0ad76e49fb62151ad6fd6f
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 344088
+  timestamp: 1728335202437
+- conda: https://conda.anaconda.org/conda-forge/osx-64/dav1d-1.2.1-h0dc2134_0.conda
+  sha256: ec71a835866b42e946cd2039a5f7a6458851a21890d315476f5e66790ac11c96
+  md5: 9d88733c715300a39f8ca2e936b7808d
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 668439
+  timestamp: 1685696184631
+- conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.9-py311hc356e98_0.conda
+  sha256: 12b1bcdbc226966ad328fbfc48c605e82e7f8e28f58905611a4789cbcc33a41d
+  md5: fb00506b224d15fdc3851a8c9985d4e1
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2499942
+  timestamp: 1732237016874
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.55.1-py311ha3cf9ac_0.conda
+  sha256: 65f05b0cabfa14486baef6f267ecea2c2fed56725cabe3767406c38349946000
+  md5: d482e362ac39ce9d0747e8f12968d3b8
+  depends:
+  - __osx >=10.13
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2835530
+  timestamp: 1733242278548
+- conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+  sha256: b292cf5a25f094eeb4b66e37d99a97894aafd04a5683980852a8cbddccdc8e4e
+  md5: 25152fce119320c980e5470e64834b50
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 599300
+  timestamp: 1694616137838
+- conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3ec172f_0.conda
+  sha256: 9d59f1894c3b526e6806e376e979b81d0df23a836415122b86458aef72cda24a
+  md5: 640c34a8084e2a812bcee5b804597fc9
+  depends:
+  - libexpat >=2.5.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - minizip >=4.0.1,<5.0a0
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 54007
+  timestamp: 1694952882265
+- conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.13.0-hac325c4_0.conda
+  sha256: 7e3201780fda37f23623e384557eb66047942db1c2fe0a7453c0caf301ec8bbb
+  md5: 905fbe84dd83254e4e0db610123dd32d
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  license: LGPL-2.1-only
+  size: 1577166
+  timestamp: 1725676182968
+- conda: https://conda.anaconda.org/conda-forge/osx-64/geotiff-1.7.3-h2b6e260_3.conda
+  sha256: 7e58d94340a499c3c62022ba070231f1dcc7c55a98f8f2a7e982d2071dfd421c
+  md5: bbc58a544b03990b3bc8c2139cc6c34f
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 115513
+  timestamp: 1726603109733
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hac325c4_1005.conda
+  sha256: c0bea66f71a6f4baa8d4f0248e17f65033d558d9e882c0af571b38bcca3e4b46
+  md5: a26de8814083a6971f14f9c8c3cb36c2
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84946
+  timestamp: 1726600054963
+- conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h10d778d_0.conda
+  sha256: 2c825df829097536314a195ae5cacaa8695209da6b4400135a65d8e23c008ff8
+  md5: 03e8c9b4d3da5f3d6eabdd020c2d63ac
+  license: MIT
+  license_family: MIT
+  size: 74516
+  timestamp: 1712692686914
+- conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h2790a97_0.conda
+  sha256: dd56547db8625eb5c91bb0a9fbe8bd6f5c7fbf5b6059d46365e94472c46b24f9
+  md5: 06cf91665775b0da395229cd4331b27d
+  depends:
+  - __osx >=10.13
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 117017
+  timestamp: 1718284325443
+- conda: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.12.1-nompi_py311h82f1de1_102.conda
+  sha256: f535bfbb313c98e6ad53c55bc7c52963f00a336625100d03967aace09d327f42
+  md5: b4470b6cac2328d45982637ae5db107e
+  depends:
+  - __osx >=10.13
+  - cached-property
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1190158
+  timestamp: 1729618122263
+- conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.3-nompi_h1607680_107.conda
+  sha256: c4bc53e88257e8e15c9966e76b890469d431a5ae44be391043e041890d5dbc3d
+  md5: 76e77282dc7b1f5ba08a4f1fb72c5208
+  depends:
+  - __osx >=10.13
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3750574
+  timestamp: 1733018945955
+- conda: https://conda.anaconda.org/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
+  sha256: 2e64307532f482a0929412976c8450c719d558ba20c0962832132fd0d07ba7a7
+  md5: d68d48a3060eb5abdc1cdc8e2a3a5966
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 11761697
+  timestamp: 1720853679409
+- conda: https://conda.anaconda.org/conda-forge/osx-64/json-c-0.18-hc62ec3d_0.conda
+  sha256: b58f8002318d6b880a98e1b0aa943789b3b0f49334a3bdb9c19b463a0b799cad
+  md5: 2c5a3c42de607dda0cfa0edd541fd279
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 71514
+  timestamp: 1726487153769
+- conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_1.conda
+  sha256: 2499e5ebb3efa4186d6922122224d16bac791a5c0adad5b48b2bcd1e1e2afc8d
+  md5: b6c1710105dad14d47001a339cd14da6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17727
+  timestamp: 1725302991176
+- conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.7-py311hf2f7c97_0.conda
+  sha256: 00b477bff9138ca51edd94f7b31ce9fe2cd13a1dc8768abcf037a22eccf26940
+  md5: 24b0e3e3444be9fabcc8457c409e297f
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 60398
+  timestamp: 1725459431458
+- conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+  sha256: 83b52685a4ce542772f0892a0f05764ac69d57187975579a0835ff255ae3ef9c
+  md5: d4765c524b1d91567886bde656fb514b
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1185323
+  timestamp: 1719463492984
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
+  sha256: 222ebc0a55544b9922f61e75015d02861e65b48f12113af41d48ba0814e14e4e
+  md5: 1442db8f03517834843666c422238c9b
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 224432
+  timestamp: 1701648089496
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+  sha256: e41790fc0f4089726369b3c7f813117bbc14b533e0ed8b94cf75aba252e82497
+  md5: f9d6a4c82889d5ecedec1d90eb673c55
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 290319
+  timestamp: 1657977526749
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240722.0-cxx17_hac325c4_1.conda
+  sha256: b548e80280242ad1d93d8d7fb48a30af7e4124959ba2031c65c9675b98163652
+  md5: 40373920232a6ac0404eee9cf39a9f09
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  constrains:
+  - abseil-cpp =20240722.0
+  - libabseil-static =20240722.0=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1170354
+  timestamp: 1727295597292
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
+  sha256: dae5921339c5d89f4bf58a95fd4e9c76270dbf7f6a94f3c5081b574905fcccf8
+  md5: 66d3c1f6dd4636216b4fca7a748d50eb
+  depends:
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 28602
+  timestamp: 1711021419744
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.7.7-h7988bea_0.conda
+  sha256: 50a5ffeeef306c9f29e2872aa011c28f546a364a8e50350bd05ff0055ad8c599
+  md5: 5af9f38826ccc57545a5c55c54cbfd92
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libiconv >=1.17,<2.0a0
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - lzo >=2.10,<3.0a0
+  - openssl >=3.4.0,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 752482
+  timestamp: 1732614525711
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-18.1.0-h14b790f_2_cpu.conda
+  sha256: 76e55b03da834e0f52f3c98d688fe09c80de54e86d73353c0f1f3ea41f038c52
+  md5: 28163b6ae1cadbfefa19a86bce1ea860
+  depends:
+  - __osx >=10.13
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - aws-sdk-cpp >=1.11.449,<1.11.450.0a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-identity-cpp >=1.10.0,<1.10.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-files-datalake-cpp >=12.12.0,<12.12.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=18
+  - libgoogle-cloud >=2.31.0,<2.32.0a0
+  - libgoogle-cloud-storage >=2.31.0,<2.32.0a0
+  - libre2-11 >=2024.7.2
+  - libutf8proc >=2.9.0,<2.10.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.3,<2.0.4.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - arrow-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  - parquet-cpp <0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 6143357
+  timestamp: 1732948790584
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-18.1.0-he5ac762_2_cpu.conda
+  sha256: 88d352e07507dc21f2dc55e073f1a98199fff1af8ab6a266182f8c369e3cf5df
+  md5: 6fdd737c49d4ab4c96228e5f1af507d7
+  depends:
+  - __osx >=10.13
+  - libarrow 18.1.0 h14b790f_2_cpu
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: APACHE
+  size: 522755
+  timestamp: 1732949132535
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-18.1.0-he5ac762_2_cpu.conda
+  sha256: 1bcdf49f9344de5c23165ca2e0ec0948e084b58ded41f8f9c9228809feea0a35
+  md5: fd9e6210ddd2541de392716ff89f4cc2
+  depends:
+  - __osx >=10.13
+  - libarrow 18.1.0 h14b790f_2_cpu
+  - libarrow-acero 18.1.0 he5ac762_2_cpu
+  - libcxx >=18
+  - libparquet 18.1.0 h436316b_2_cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 514877
+  timestamp: 1732951748681
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-18.1.0-h16335c3_2_cpu.conda
+  sha256: d304956dfc4304494f89175854069273776a0345c41b6aceaf991552f0b7c75f
+  md5: eb34cb397b31b3318503c8907101955d
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 18.1.0 h14b790f_2_cpu
+  - libarrow-acero 18.1.0 he5ac762_2_cpu
+  - libarrow-dataset 18.1.0 he5ac762_2_cpu
+  - libcxx >=18
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 465386
+  timestamp: 1732952465558
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libavif16-1.1.1-h71406da_2.conda
+  sha256: 8e3d479f13a85ee73c3152704c1d9e0430065f4824bae625f2f35c463c172831
+  md5: 804f440fd71e1a903215710826cf98aa
+  depends:
+  - __osx >=10.13
+  - aom >=3.9.1,<3.10.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - rav1e >=0.6.6,<0.7.0a0
+  - svt-av1 >=2.3.0,<2.3.1.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 108913
+  timestamp: 1730268731759
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-25_osx64_openblas.conda
+  sha256: 1b22b5322a311a775bca637b26317645cf07e35f125cede9278c6c45db6e7105
+  md5: da0a6f87958893e1d2e2bbc7e7a6541f
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - liblapack 3.9.0 25_osx64_openblas
+  - liblapacke 3.9.0 25_osx64_openblas
+  - blas * openblas
+  - libcblas 3.9.0 25_osx64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15952
+  timestamp: 1729643159199
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h00291cd_2.conda
+  sha256: b377056470a9fb4a100aa3c51b3581aab6496ba84d21cd99bcc1d5ef0359b1b6
+  md5: 58f2c4bdd56c46cc7451596e4ae68e0b
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 67267
+  timestamp: 1725267768667
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h00291cd_2.conda
+  sha256: 4d49ea72e2f44d2d7a8be5472e4bd0bc2c6b89c55569de2c43576363a0685c0c
+  md5: 34709a1f5df44e054c4a12ab536c5459
+  depends:
+  - __osx >=10.13
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 29872
+  timestamp: 1725267807289
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h00291cd_2.conda
+  sha256: 477d236d389473413a1ccd2bec1b66b2f1d2d7d1b4a57bb56421b7b611a56cd1
+  md5: 691f0dcb36f1ae67f5c489f20ae987ea
+  depends:
+  - __osx >=10.13
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 296353
+  timestamp: 1725267822076
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-25_osx64_openblas.conda
+  sha256: b04ae297aa5396df3135514866db72845b111c92524570f923625473f11cfbe2
+  md5: ab304b75ea67f850cf7adf9156e3f62f
+  depends:
+  - libblas 3.9.0 25_osx64_openblas
+  constrains:
+  - liblapack 3.9.0 25_osx64_openblas
+  - liblapacke 3.9.0 25_osx64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15842
+  timestamp: 1729643166929
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+  sha256: 3043869ac1ee84554f177695e92f2f3c2c507b260edad38a0bf3981fce1632ff
+  md5: 23d6d5a69918a438355d7cbc4c3d54c9
+  depends:
+  - libcxx >=11.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20128
+  timestamp: 1633683906221
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.10.1-h58e7537_0.conda
+  sha256: 662fe145459ed58dee882e525588d1da4dcc4cbd10cfca0725d1fc3840461798
+  md5: 6c8669d8228a2bbd0283911cc6d6726e
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 402588
+  timestamp: 1726660264675
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.5-hf95d169_0.conda
+  sha256: 57e80908add715a2198559001087de014156c4b44a722add46253465ae9daa0c
+  md5: a20d4ea6839510372d1eeb8532b09acf
+  depends:
+  - __osx >=10.13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 529401
+  timestamp: 1733291621685
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libde265-1.0.15-h7728843_0.conda
+  sha256: a67544ca45a082da0c868fbcd1a0f49fc6f92281aa9aedd20bdce9e7c7e45817
+  md5: a270b0e1a2a3326cc21eee82c42efffc
+  depends:
+  - libcxx >=15
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 331376
+  timestamp: 1703088831061
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.22-h00291cd_0.conda
+  sha256: 681035346974c3315685dc40898e26f65f1c00cbb0b5fd80cc2599e207a34b31
+  md5: a15785ccc62ae2a8febd299424081efb
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 70407
+  timestamp: 1728177128525
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+  sha256: dbd3c3f2eca1d21c52e4c03b21930bbce414c4592f8ce805801575b9e9256095
+  md5: 6016a8a1d0e63cac3de2c352cd40208b
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 105382
+  timestamp: 1597616576726
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+  sha256: 0d238488564a7992942aa165ff994eca540f687753b4f0998b29b4e4d030ff43
+  md5: 899db79329439820b7e8f8de41bca902
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 106663
+  timestamp: 1702146352558
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+  sha256: e0bd9af2a29f8dd74309c0ae4f17a7c2b8c4b89f875ff1d6540c941eefbd07fb
+  md5: e38e467e577bd193a7d5de7c2c540b04
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372661
+  timestamp: 1685726378869
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.4-h240833e_0.conda
+  sha256: d10f43d0c5df6c8cf55259bce0fe14d2377eed625956cddce06f58827d288c59
+  md5: 20307f4049a735a78a29073be1be2626
+  depends:
+  - __osx >=10.13
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 70758
+  timestamp: 1730967204736
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+  sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
+  md5: ccb34fb14960ad8b125962d3d79b31a9
+  license: MIT
+  license_family: MIT
+  size: 51348
+  timestamp: 1636488394370
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.10.0-h04043bc_5.conda
+  sha256: 136832b0ecff617e2ced73f080d2c5d45aa67eda4b48ca84b83c8bd40dbdbb8f
+  md5: 2095f060579553ea06162740855154b0
+  depends:
+  - __osx >=10.13
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - geotiff >=1.7.3,<1.8.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - json-c >=0.18,<0.19.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libarchive >=3.7.7,<3.8.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libdeflate >=1.22,<1.26.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libheif >=1.18.2,<1.19.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.4.0,<4.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - proj >=9.5.1,<9.6.0a0
+  - xerces-c >=3.2.5,<3.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - libgdal 3.10.0.*
+  license: MIT
+  license_family: MIT
+  size: 9168265
+  timestamp: 1733330471335
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+  sha256: 4874422e567b68334705c135c17e5acdca1404de8255673ce30ad3510e00be0d
+  md5: 0b6e23a012ee7a9a5f6b244f5a92c1d5
+  depends:
+  - libgfortran5 13.2.0 h2873a65_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110106
+  timestamp: 1707328956438
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+  sha256: da3db4b947e30aec7596a3ef92200d17e774cccbbf7efc47802529a4ca5ca31b
+  md5: e4fb4d23ec2870ff3c40d10afe305aec
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1571379
+  timestamp: 1707328880361
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.31.0-hd00c612_0.conda
+  sha256: 10df0003243d2ef5cca614351fa24efe42164912d358378a947c06167eba6b45
+  md5: 65d85eb999d66f8be20d3735a9ceaa7f
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - openssl >=3.3.2,<4.0a0
+  constrains:
+  - libgoogle-cloud 2.31.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 890808
+  timestamp: 1731121937109
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.31.0-h3f2b517_0.conda
+  sha256: e1f53309fe02143e1342ccb658466be015a1ee4249d306eed4158d75f680d992
+  md5: 3f8c6c99af88f5039869c24aea7024a6
+  depends:
+  - __osx >=10.13
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libcxx >=18
+  - libgoogle-cloud 2.31.0 hd00c612_0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  size: 541478
+  timestamp: 1731123018190
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.67.1-he6e0b18_0.conda
+  sha256: 0884aaa894617fac40c0e0d03a03d2ea6ea486fe9692a0ff854cbe4b080e4c6a
+  md5: 05ea1754e8da5d0e8faf9ec599505834
+  depends:
+  - __osx >=10.13
+  - c-ares >=1.34.2,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libre2-11 >=2024.7.2
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.67.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5335099
+  timestamp: 1730235623016
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libheif-1.18.2-gpl_h57a3ca0_100.conda
+  sha256: e3aaa419f3d7ff2e21710991c1dd4484ed301942dcbcb5052e6835ddfd08abed
+  md5: b08c6fdf99e131e906935a01b63e113c
+  depends:
+  - __osx >=10.13
+  - aom >=3.9.1,<3.10.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - libavif16 >=1.1.1,<2.0a0
+  - libcxx >=16
+  - libde265 >=1.0.15,<1.0.16.0a0
+  - x265 >=3.5,<3.6.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 385347
+  timestamp: 1723121606492
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
+  sha256: 23d4923baeca359423a7347c2ed7aaf48c68603df0cf8b87cc94a10b0d4e9a23
+  md5: 6c3628d047e151efba7cf08c5e54d1ca
+  license: LGPL-2.1-only
+  size: 666538
+  timestamp: 1702682713201
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+  sha256: d9572fd1024adc374aae7c247d0f29fdf4b122f1e3586fe62acc18067f40d02f
+  md5: 72507f8e3961bc968af17435060b6dd6
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 579748
+  timestamp: 1694475265912
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libkml-1.3.0-h9ee1731_1021.conda
+  sha256: dba3732e9a3b204e5af01c5ddba8630f4a337693b1c5375c2981a88b580116bd
+  md5: b098eeacf7e78f09c8771f5088b97bbb
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libexpat >=2.6.2,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - uriparser >=0.9.8,<1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 286877
+  timestamp: 1724667518323
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-25_osx64_openblas.conda
+  sha256: 2a9a6143d103e7e21511cbf439521645bdd506bfabfcac9d6398dd0562c6905c
+  md5: dda0e24b4605ebbd381e48606a107bed
+  depends:
+  - libblas 3.9.0 25_osx64_openblas
+  constrains:
+  - liblapacke 3.9.0 25_osx64_openblas
+  - blas * openblas
+  - libcblas 3.9.0 25_osx64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15852
+  timestamp: 1729643174413
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-hc8e404f_4.conda
+  sha256: 0df3902a300cfe092425f86144d5e00ef67be3cd1cc89fd63084d45262a772ad
+  md5: ed06753e2ba7c66ed0ca7f19578fcb68
+  depends:
+  - libcxx >=15
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 22467131
+  timestamp: 1690563140552
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.6.3-hd471939_1.conda
+  sha256: c70639ff3cb034a8e31cb081c907879b6a639bb12b0e090069a68eb69125b10e
+  md5: f9e9205fed9c664421c1c09f0b90ce6d
+  depends:
+  - __osx >=10.13
+  constrains:
+  - xz ==5.6.3=*_1
+  license: 0BSD
+  size: 103745
+  timestamp: 1733407504892
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-devel-5.6.3-hd471939_1.conda
+  sha256: c2858d952a019739ab8a13f8ffd9f511c07b40deed4579ddc1b2923c1011a439
+  md5: 370a48ecf97500fa1e92d49e55de3153
+  depends:
+  - __osx >=10.13
+  - liblzma 5.6.3 hd471939_1
+  license: 0BSD
+  size: 113085
+  timestamp: 1733407525591
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.64.0-hc7306c3_0.conda
+  sha256: 0dcfdcf3a445d2d7de4f3b186ab0a794dc872f4ea21622f9b997be72712c027f
+  md5: ab21007194b97beade22ceb7a3f6fee5
+  depends:
+  - __osx >=10.13
+  - c-ares >=1.34.2,<2.0a0
+  - libcxx >=17
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 606663
+  timestamp: 1729572019083
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_hbf64a52_1.conda
+  sha256: cef5856952688ce9303f85f5bc62c99e8c2256b4c679f63afdfb381f222e90c7
+  md5: cd2c572c02a73b88c4d378eb31110e85
+  depends:
+  - __osx >=10.13
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - llvm-openmp >=18.1.8
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6165715
+  timestamp: 1730773348340
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-18.1.0-h436316b_2_cpu.conda
+  sha256: a882916a5b49f2be5e4efacd8158e58814ff4dc3ed4d06e12e9ce6264deee47b
+  md5: d2e2fc66fb64473c6ec878422d777f47
+  depends:
+  - __osx >=10.13
+  - libarrow 18.1.0 h14b790f_2_cpu
+  - libcxx >=18
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 940937
+  timestamp: 1732951273222
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.44-h4b8f8c9_0.conda
+  sha256: 12b44e58f8832798d7a5c0a7480c95e905dbd6c3558dec09739062411f9e08d1
+  md5: f32ac2c8dd390dbf169f550887ed09d9
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 268073
+  timestamp: 1726234803010
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-5.28.2-h8b30cf6_0.conda
+  sha256: e240c2003e301ede0a0f4af7688adb8456559ffaa4af2eed3fce879c22c80a0e
+  md5: 2302089e5bcb04ce891ce765c963befb
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2428926
+  timestamp: 1728565541606
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2024.07.02-hd530cb8_1.conda
+  sha256: 2fac39fb704ded9584d1a9e7511163830016803f83852a724c2ccef1cc16e17b
+  md5: 1e14c67a5e8a9273a98b83fbc0905b99
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 178580
+  timestamp: 1728779037721
+- conda: https://conda.anaconda.org/conda-forge/osx-64/librttopo-1.1.0-hdfb80b9_17.conda
+  sha256: 683ec76fcc035f3803aedbffdc4e8ab62fbde360bfaa73f3693eeb429c48b029
+  md5: 627b89a9764485ebace5ebe42b6e6ab4
+  depends:
+  - __osx >=10.13
+  - geos >=3.13.0,<3.13.1.0a0
+  - libcxx >=17
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 213348
+  timestamp: 1727265795635
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
+  sha256: d3975cfe60e81072666da8c76b993af018cf2e73fe55acba2b5ba0928efaccf5
+  md5: 6af4b059e26492da6013e79cbcb4d069
+  depends:
+  - __osx >=10.13
+  license: ISC
+  size: 210249
+  timestamp: 1716828641383
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libspatialite-5.1.0-hc43c327_11.conda
+  sha256: 1e392f1f5544ffeb9ce724d06602a8f8062529824954d11b63d4ae01f45a9b49
+  md5: 59c3e269e76ec0e03802ddea2b4e44a0
+  depends:
+  - __osx >=10.13
+  - freexl >=2
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - libcxx >=17
+  - libiconv >=1.17,<2.0a0
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - sqlite
+  - zlib
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 3315985
+  timestamp: 1727341824716
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.0-h2f8c449_1.conda
+  sha256: a0f7381c867898a45018b1e5cf1aca68659d292d58252e8f489a4270b010fed8
+  md5: af445c495253a871c3d809e1199bb12b
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 915300
+  timestamp: 1730208101739
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-h3dc7d44_0.conda
+  sha256: ef2a81c9a15080b996a37f0e1712881da90a710b234e63d8539d69892353de90
+  md5: b1caec4561059e43a5d056684c5a2de0
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 283874
+  timestamp: 1732349525684
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.21.0-h75589b3_0.conda
+  sha256: 3f82eddd6de435a408538ac81a7a2c0c155877534761ec9cd7a2906c005cece2
+  md5: 7a472cd20d9ae866aeb6e292b33381d6
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 332651
+  timestamp: 1727206546431
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-hf4bdac2_2.conda
+  sha256: dba23d6c9c1df6092e894b69d53fcdb78cdd10eab8e1b57f040de91a8beed908
+  md5: 99a4153a4ee19d4902c0c08bfae4cdb4
+  depends:
+  - __osx >=10.13
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=18
+  - libdeflate >=1.22,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 399202
+  timestamp: 1733443156315
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.9.0-h6e16a3a_1.conda
+  sha256: 2c2957a94cd6c950bcdde8a55ea40ddfc65bef393f0eb76be0f281c179327a55
+  md5: 2c6188e92dbde6515162a84329c54f13
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 79297
+  timestamp: 1732868560678
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
+  sha256: 7bafd8f4c637778cd0aa390bf3a894feef0e1fcf6ea6000c7ffc25c4c5a65538
+  md5: b2c0047ea73819d992484faacbbe1c24
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 355099
+  timestamp: 1713200298965
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+  sha256: 8896cd5deff6f57d102734f3e672bc17120613647288f9122bec69098e839af7
+  md5: bbeca862892e2898bdb45792a61c4afc
+  depends:
+  - __osx >=10.13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 323770
+  timestamp: 1727278927545
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.5-h495214b_0.conda
+  sha256: 66e1bf40699daf83b39e1281f06c64cf83499de3a9c05d59477fadded6d85b18
+  md5: 8711bc6fb054192dc432741dcd233ac3
+  depends:
+  - __osx >=10.13
+  - icu >=75.1,<76.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 608931
+  timestamp: 1731489767386
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+  sha256: 8412f96504fc5993a63edf1e211d042a1fd5b1d51dedec755d2058948fcced09
+  md5: 003a54a4e32b02f7355b50a837e699da
+  depends:
+  - __osx >=10.13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 57133
+  timestamp: 1727963183990
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.5-ha54dae1_0.conda
+  sha256: e4966acfed5d3358eeec2c30b9f0f51b6c3d05bca680e87a5db210963511dadb
+  md5: fc0cec628a431e2f87d09e83a3a579e1
+  depends:
+  - __osx >=10.13
+  constrains:
+  - openmp 19.1.5|19.1.5.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 305285
+  timestamp: 1733376049594
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.43.0-py311h25b8078_1.conda
+  sha256: 8f47684beb89f6c03d10a06929365218cdf4454aee52f0bf83a97da4597c429c
+  md5: 19d1706a45751962b116123dcbc578f0
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 379249
+  timestamp: 1725305363038
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-4.3.3-py311h12b7ed1_1.conda
+  sha256: 47515c300a34c47be42b3196f6f5d400fd3f80f0ae25c73eb10ad367cef450cb
+  md5: ab30eba2d9fe565ff640369016e74fe5
+  depends:
+  - __osx >=10.13
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36652
+  timestamp: 1725089602246
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+  sha256: 39aa0c01696e4e202bf5e337413de09dfeec061d89acd5f28e9968b4e93c3f48
+  md5: aa04f7143228308662696ac24023f991
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 156415
+  timestamp: 1674727335352
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lzo-2.10-h10d778d_1001.conda
+  sha256: 4006c57f805ca6aec72ee0eb7166b2fd648dd1bf3721b9de4b909cd374196643
+  md5: bfecd73e4a2dc18ffd5288acf8a212ab
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  size: 146405
+  timestamp: 1713516112292
+- conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.2-py311ha3cf9ac_1.conda
+  sha256: e9965b5d4c29b17b1512035b24a7c126ed7bdb6b39103b52cae099d5bb4194a9
+  md5: 1d6596ca7c7b66215c5c0d58b3cb0dd3
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24688
+  timestamp: 1733219887972
+- conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.3-py311h19a4563_0.conda
+  sha256: bbcf29f1850cc8ab9d70d526cfa5515a2e6d4a4c259c0a04f72ffd38aadc4548
+  md5: 8c0cd76938ca846fda82d1fa9039e63a
+  depends:
+  - __osx >=10.13
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=18
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 7852415
+  timestamp: 1733176358042
+- conda: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.0.7-h62b0c8d_0.conda
+  sha256: e02a6e1a43b0ff44bb9460d46d3f7687a1876d435fb3c2c6cf9e19bab60901f6
+  md5: 9cb19284d7d835918241acf8180099db
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libcxx >=16
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 78595
+  timestamp: 1718483214061
+- conda: https://conda.anaconda.org/conda-forge/osx-64/mne-lsl-1.8.0-py311h4e34fa0_0.conda
+  sha256: ebb428a67edc5407d9e7c073afdbc0527e8c4aa64efb6b4a4ecf71ef594dde76
+  md5: 7b9bb186aa3d991a9c7efed6fa29b59a
+  depends:
+  - __osx >=10.13
+  - click >=8.1
+  - libcxx >=18
+  - mne-base >=1.4.2
+  - numpy >=1.21
+  - packaging
+  - pooch
+  - psutil
+  - pyqtgraph
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - qtpy
+  - scipy
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 513661
+  timestamp: 1732896193984
+- conda: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.1.0-py311hf2f7c97_0.conda
+  sha256: b56b1e7d156b88cc0c62734acf56d4ee809723614f659e4203028e7eeac16a78
+  md5: 6804cd42195bf94efd1b892688c96412
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 90868
+  timestamp: 1725975178961
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
+  sha256: b0b3180039ef19502525a2abd5833c00f9624af830fd391f851934d57bffb9af
+  md5: e102bbf8a6ceeaf429deab8032fc8977
+  depends:
+  - __osx >=10.13
+  license: X11 AND BSD-3-Clause
+  size: 822066
+  timestamp: 1724658603042
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.60.0-py311h0e5bd6a_0.conda
+  sha256: 47fbc7925d5ee5ba9d841e542752288fc7059f44c0b95c34e11c609f4754e517
+  md5: 8bd1ff28924ea52b539528d85f70a1ac
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - llvm-openmp >=16.0.6
+  - llvm-openmp >=18.1.8
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libopenblas !=0.3.6
+  - cuda-python >=11.6
+  - scipy >=1.0
+  - tbb >=2021.6.0
+  - cudatoolkit >=11.2
+  - cuda-version >=11.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5773011
+  timestamp: 1718888442395
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numcodecs-0.14.1-py311hcf53e2f_0.conda
+  sha256: 418e2f485862e77743eef4ef4ce5f2b63438dd8af09211d15151d2561c53b3ef
+  md5: 3426451554e4cd5f2925e5e7f7caeda9
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - msgpack-python
+  - numpy >=1.19,<3
+  - numpy >=1.24
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 762194
+  timestamp: 1732243827399
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.0.2-py311h14ed71f_1.conda
+  sha256: 11b26503fbcc7215ba4ccb9d4f67540f9783fe1bd01d18c54f0cf8ab03ee7295
+  md5: 3162c97b53e0e3deeb4773e9b21cbde7
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8027046
+  timestamp: 1732314989218
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
+  sha256: dc9c405119b9b54f8ca5984da27ba498bd848ab4f0f580da6f293009ca5adc13
+  md5: 05a14cc9d725dd74995927968d6547e3
+  depends:
+  - libcxx >=16
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 331273
+  timestamp: 1709159538792
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hd471939_0.conda
+  sha256: ba7e068ed469d6625e32ae60e6ad893e655b6695280dadf7e065ed0b6f3b885c
+  md5: ec99d2ce0b3033a75cbad01bbc7c5b71
+  depends:
+  - __osx >=10.13
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2590683
+  timestamp: 1731378034404
+- conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.3-h5cd248e_0.conda
+  sha256: 5254a9e811e25595ffa029f131557adf0657efbb81d659afb5561af3ef4bbffa
+  md5: fe9651fd3413eb332537f7729cebc8e1
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 467056
+  timestamp: 1731665334947
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.3-py311haeb46be_1.conda
+  sha256: ad35c52521f0946caf06e19fd3dfad55f7b30e46648f96214f59d8ca2dac95ad
+  md5: ca32a9963a1b5c636b5131831ded81f3
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14864168
+  timestamp: 1726879042435
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.44-h7634a1b_2.conda
+  sha256: 336057fce69d45e1059f138beb38d60eb87ba858c3ad729ed49d9ecafd23669f
+  md5: 58cde0663f487778bcd7a0c8daf50293
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 854306
+  timestamp: 1723488807216
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.0.0-py311h1f68098_0.conda
+  sha256: 3826fe546e711787ce5b42e2f9176589846631945a528176da0fb61e751d3749
+  md5: ab73babea5e9a94d4f0f3c8fead83459
+  depends:
+  - __osx >=10.13
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 42126861
+  timestamp: 1729065932260
+- conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.5.1-h5273da6_0.conda
+  sha256: 5d35d13994abdc6a7dd1801f37db98e9efca5983f0479e380844264343ec8096
+  md5: 523c87f13b2f99a96295993ede863b87
+  depends:
+  - __osx >=10.13
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libsqlite >=3.47.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2840582
+  timestamp: 1733138585653
+- conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.0-py311h1314207_0.conda
+  sha256: 340d19b16a2f5b663b4f000188467831b107dcaa5b15522e172d6a27820d3b01
+  md5: 446e328d89429c077ccd74d7e9d8853e
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 512211
+  timestamp: 1729847190327
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+  sha256: 05944ca3445f31614f8c674c560bca02ff05cb51637a96f665cb2bbe496099e5
+  md5: 8bcf980d2c6b17094961198284b8e862
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 8364
+  timestamp: 1726802331537
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-18.1.0-py311h6eed73b_0.conda
+  sha256: a0a27fe54d19a42a900ed00a72a68758a14e742c8e22808be1240c24622a07fb
+  md5: c1de8a6883cbb9135fbbf1e1bdbebbdc
+  depends:
+  - libarrow-acero 18.1.0.*
+  - libarrow-dataset 18.1.0.*
+  - libarrow-substrait 18.1.0.*
+  - libparquet 18.1.0.*
+  - pyarrow-core 18.1.0 *_0_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25275
+  timestamp: 1732611267588
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-18.1.0-py311he02522f_0_cpu.conda
+  sha256: 960a5cb329b82118daab50be01faa541c3542e45d30e8eeff14d93619fc0af6b
+  md5: 995e6211e8d94b51466b7d0c8ccd475b
+  depends:
+  - __osx >=10.13
+  - libarrow 18.1.0.* *cpu
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - numpy >=1.21,<3
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4068983
+  timestamp: 1732611224743
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pydantic-core-2.27.1-py311h3b9c2be_0.conda
+  sha256: 37bf1415f98aff626f200381391b0130bf9d4460edcc866e9960f2c6d7960920
+  md5: bf4260289161c2c5dab79ae4927039b9
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - typing-extensions >=4.6.0,!=4.7.0
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 1559988
+  timestamp: 1732254423976
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.3.2-py311hfbc4093_0.conda
+  sha256: 4b6729088cc2b5461b5f1cf080a400921538b52854b3ef3ef55dc3382d3dd365
+  md5: b7ae34cfc2cbd83ec8fb9783bc00df1c
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 490751
+  timestamp: 1732987367396
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.3.2-py311hfbc4093_0.conda
+  sha256: c3ceda073b0164655f16b080d9c9b9d027021e4e0142c04a029663adc8eda0ee
+  md5: 6f2fc8232ec4b6da3b7f4aac21eaaa3b
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 10.3.2.*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 381731
+  timestamp: 1733168922676
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.6.1-py311h50e4d0a_10.conda
+  sha256: dde6b51b0b6093573a16034daedf8d908c1181ecc4c1fbec7479ab61401a5c19
+  md5: 7b1a044902592d7925924b587aef244b
+  depends:
+  - __osx >=10.13
+  - certifi
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 498830
+  timestamp: 1726679935783
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.11-h9ccd52b_1_cpython.conda
+  sha256: 4c53c4c48a0f42577ae405553ab899b3ef5ee23b2a1bf4fbbc694c46f884f6fc
+  md5: 9b20fb7c571405d29f33ae2fc5990d8d
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.4.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 14221518
+  timestamp: 1733409959819
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
+  sha256: 9b092850a268aca99600b724bae849f51209ecd5628e609b4699debc59ff1945
+  md5: e6d62858c06df0be0e6255c753d74787
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6303
+  timestamp: 1723823062672
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311h3336109_1.conda
+  sha256: d8f4513c53a7c0be9f1cdb9d1af31ac85cf8a6f0e4194715e36e915c03104662
+  md5: b0132bec7165a53403dcc393ff761a9e
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 193941
+  timestamp: 1725456465818
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.2.0-py311h4d3da15_3.conda
+  sha256: 6aa664170031e36302616978404175c6ada3bd4a14c71bac826fa6a7ec15f815
+  md5: 48a614f384285254a3224d086dc84ce3
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 366412
+  timestamp: 1728642446264
+- conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+  sha256: 79d804fa6af9c750e8b09482559814ae18cd8df549ecb80a4873537a5a31e06e
+  md5: dd1ea9ff27c93db7c01a7b7656bd4ad4
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: LicenseRef-Qhull
+  size: 528122
+  timestamp: 1720814002588
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rasterio-1.4.3-py311h7ab2778_0.conda
+  sha256: 5e71425aa3752ec0ec654ad0674bcee4a43ac1eae9fb8ff0565bfdbacf75e9b5
+  md5: 7d69e94783d93ba0b4506cad4e0f1b2b
+  depends:
+  - __osx >=10.13
+  - affine
+  - attrs
+  - certifi
+  - click >=4
+  - click-plugins
+  - cligj >=0.5
+  - libcxx >=18
+  - libgdal-core >=3.10.0,<3.11.0a0
+  - numpy >=1.21,<3
+  - proj >=9.5.1,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7623295
+  timestamp: 1733164015605
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rav1e-0.6.6-h7205ca4_2.conda
+  sha256: 046ac50530590cd2a5d9bcb1e581bdd168e06049230ad3afd8cce2fa71b429d9
+  md5: ab03527926f8ce85f84a91fd35520ef2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1767853
+  timestamp: 1694329738983
+- conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2024.07.02-h2fb0a26_1.conda
+  sha256: 49ec4ed6249efe9cda173745e036137f8de1f0b22edf9b0ca4f9c6409b2b68f9
+  md5: aa8ea927cdbdf690efeae3e575716131
+  depends:
+  - libre2-11 2024.07.02 hd530cb8_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26864
+  timestamp: 1728779054104
+- conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+  sha256: 41e7d30a097d9b060037f0c6a2b1d4c4ae7e942c06c943d23f9d481548478568
+  md5: f17f77f2acf4d344734bda76829ce14e
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 255870
+  timestamp: 1679532707590
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.22.3-py311h3b9c2be_0.conda
+  sha256: 435d6ddb0a1625b91e83573b17fcd543ebedffc81d912cacb53d48a8cb59a861
+  md5: 19f12b2368042654dbc26036f036483b
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 329432
+  timestamp: 1733367026508
+- conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.1-py311hed734c1_1.conda
+  sha256: 2515954fe9f8202c35e9b2df6d65650f8ffcfa7dc99ed068b25968e8af5f1b23
+  md5: 22812381ffcab544161a257666f1c203
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16391177
+  timestamp: 1729481689967
+- conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-he1e6707_0.conda
+  sha256: a979319cd4916f0e7450aa92bb3cf4c2518afa80be50de99f31d075e693a6dd9
+  md5: ddceef5df973c8ff7d6b32353c0cb358
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37036
+  timestamp: 1720003862906
+- conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.47.0-h6285a30_1.conda
+  sha256: 34eaf24c2d0b034374d7a85026650fe28e17321fa471e5c5f654b48c5cbd3c2a
+  md5: c1d1f4d014063068fd6c402cf741e317
+  depends:
+  - __osx >=10.13
+  - libsqlite 3.47.0 h2f8c449_1
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 929527
+  timestamp: 1730208118175
+- conda: https://conda.anaconda.org/conda-forge/osx-64/svt-av1-2.3.0-h97d8b74_0.conda
+  sha256: 8cd3878eb1d31ecf21fe982e6d2ca557787100aed2f0c7fd44d01d504e704e30
+  md5: c54053b3d1752308a38a9a8c48ce10da
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2413474
+  timestamp: 1730246540736
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+  sha256: 30412b2e9de4ff82d8c2a7e5d06a15f4f4fef1809a72138b6ccb53a33b26faf5
+  md5: bf830ba5afc507c6232d4ef0fb1a882d
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3270220
+  timestamp: 1699202389792
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.2-py311h4d7f069_0.conda
+  sha256: 5273ba307489570df61d82a6b3365b2a27862765099cf4ef3830569fa4a30f27
+  md5: 073c42a2b6b7e4219325b1f5983c7579
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 858750
+  timestamp: 1732616082798
+- conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-15.1.0-py311h1314207_1.conda
+  sha256: c0be0b59fa67c3f9915d3dcd77d972656b9966b4516b3c044efe350860f7e054
+  md5: 574fd9b8168c1b109003c3c431c0bb7e
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 363667
+  timestamp: 1729704694220
+- conda: https://conda.anaconda.org/conda-forge/osx-64/uriparser-0.9.8-h6aefe2f_0.conda
+  sha256: fec8e52955fc314580a93dee665349bf430ce6df19019cea3fae7ec60f732bdd
+  md5: 649890a63cc818b24fbbf0572db221a5
+  depends:
+  - __osx >=10.9
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43396
+  timestamp: 1715010079800
+- conda: https://conda.anaconda.org/conda-forge/osx-64/x265-3.5-hbb4e6a2_3.tar.bz2
+  sha256: 6b6a57710192764d0538f72ea1ccecf2c6174a092e0bc76d790f8ca36bbe90e4
+  md5: a3bf3e95b7795871a6734a784400fcea
+  depends:
+  - libcxx >=12.0.1
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 3433205
+  timestamp: 1646610148268
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xerces-c-3.2.5-h197e74d_2.conda
+  sha256: 6218762b3ecff8e365f2880bb6a762b195e350159510d3f2dba58fa53f90a1bf
+  md5: 559e2c3fb2fe4bfc985e8486bad8ecaa
+  depends:
+  - __osx >=10.13
+  - icu >=75.1,<76.0a0
+  - libcxx >=17
+  license: Apache-2.0
+  license_family: Apache
+  size: 1352475
+  timestamp: 1727734320281
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h00291cd_1.conda
+  sha256: 96177823ec38336b0f4b7e7c2413da61f8d008d800cc4a5b8ad21f9128fb7de0
+  md5: c6cc91149a08402bbb313c5dc0142567
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 13176
+  timestamp: 1727034772877
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
+  sha256: bb4d1ef9cafef535494adf9296130b6193b3a44375883185b5167de03eb1ac7f
+  md5: 9f438e1b6f4e73fd9e6d78bfe7c36743
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 18465
+  timestamp: 1727794980957
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.6.3-h357f2ed_1.conda
+  sha256: ce1bd60d9bad89eda89c3f2d094d1f5db67e271ab35d2f74b445dc98a9e38f76
+  md5: 5b8d1e12d8a51a553b59e0957ba08103
+  depends:
+  - __osx >=10.13
+  - liblzma 5.6.3 hd471939_1
+  - liblzma-devel 5.6.3 hd471939_1
+  - xz-gpl-tools 5.6.3 h357f2ed_1
+  - xz-tools 5.6.3 hd471939_1
+  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  size: 23640
+  timestamp: 1733407599563
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xz-gpl-tools-5.6.3-h357f2ed_1.conda
+  sha256: 42f94fc8fae4ef1cd89b6e56deefdeddd065f7975a77d366ff2cb82106fb62ea
+  md5: a08d5c883e4c9df9b73afb623a3f94ab
+  depends:
+  - __osx >=10.13
+  - liblzma 5.6.3 hd471939_1
+  constrains:
+  - xz ==5.6.3=*_1
+  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  size: 33298
+  timestamp: 1733407576656
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xz-tools-5.6.3-hd471939_1.conda
+  sha256: aa025a3b2547e80b1c84732ff6a380f288c505f334411122ef7945378ccd682b
+  md5: c3b85d24bddf7f6e9d8c917c6d300b43
+  depends:
+  - __osx >=10.13
+  - liblzma 5.6.3 hd471939_1
+  constrains:
+  - xz ==5.6.3=*_1
+  license: 0BSD AND LGPL-2.1-or-later
+  size: 80968
+  timestamp: 1733407552376
+- conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+  sha256: 5301417e2c8dea45b401ffee8df3957d2447d4ce80c83c5ff151fc6bfe1c4148
+  md5: d7e08fcf8259d742156188e8762b4d20
+  license: MIT
+  license_family: MIT
+  size: 84237
+  timestamp: 1641347062780
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h7130eaa_7.conda
+  sha256: b932dce8c9de9a8ffbf0db0365d29677636e599f7763ca51e554c43a0c5f8389
+  md5: 6a0a76cd2b3d575e1b7aaeb283b9c3ed
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.3,<1.22.0a0
+  - libcxx >=18
+  - libsodium >=1.0.20,<1.0.21.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 292112
+  timestamp: 1731585246902
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-hd23fc13_2.conda
+  sha256: 219edbdfe7f073564375819732cbf7cc0d7c7c18d3f546a09c2dfaf26e4d69f3
+  md5: c989e0295dcbdc08106fe5d9e935f0b9
+  depends:
+  - __osx >=10.13
+  - libzlib 1.3.1 hd23fc13_2
+  license: Zlib
+  license_family: Other
+  size: 88544
+  timestamp: 1727963189976
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py311hdf6fcd6_1.conda
+  sha256: d9bf977b620750049eb60fffca299a701342a2df59bcc2586a79b2f7c5783fa1
+  md5: 4fc42d6f85a21b09ee6477f456554df3
+  depends:
+  - __osx >=10.13
+  - cffi >=1.11
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411350
+  timestamp: 1725305723486
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
+  sha256: efa04a98cb149643fa54c4dad5a0179e36a5fbc88427ea0eec88ceed87fd0f96
+  md5: 4cb2cd56f039b129bb0e491c1164167e
+  depends:
+  - __osx >=10.9
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 498900
+  timestamp: 1714723303098
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.9.1-h7bae524_0.conda
+  sha256: ec238f18ce8140485645252351a0eca9ef4f7a1c568a420f240a585229bc12ef
+  md5: 7adba36492a1bb22d98ffffe4f6fc6de
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2235747
+  timestamp: 1718551382432
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311h460d6c5_5.conda
+  sha256: 6eabd1bcefc235b7943688d865519577d7668a2f4dc3a24ee34d81eb4bfe77d1
+  md5: 1e8260965552c6ec86453b7d15a598de
+  depends:
+  - __osx >=11.0
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 33008
+  timestamp: 1725356833036
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.8.0-h9b725a8_10.conda
+  sha256: 63cb8c25e0a26be4261d4271de525e7e33aefe9d9b001b8abfa5c9ac69c3dab3
+  md5: 17c90d9eb8c6842fd739dc5445ce9962
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 92355
+  timestamp: 1731733738919
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.8.0-h5d7ee29_2.conda
+  sha256: 2a8c09b33400cf2b7d658e63fd5a6f9b6e9626458f6213b904592fc15220bc92
+  md5: 92734dad83d22314205ba73b679710d2
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 39966
+  timestamp: 1731678721786
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.10.3-h5505292_0.conda
+  sha256: bb2c1038726d31ffd2d35a5764f80bcd670b6a1c753aadfd261aecb9f88db6d8
+  md5: 4150339e3b08db33fe4c436340b1d7f6
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 221524
+  timestamp: 1731567512057
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.0-h5d7ee29_2.conda
+  sha256: a52ea62bf08aed3af079e16d1738f3d2a7fcdd1d260289ae27ae96298e15d12a
+  md5: 15566c36b0cf5f314e3bee7f7cc796b5
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18204
+  timestamp: 1731678916439
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.5.0-h13ead76_7.conda
+  sha256: 386965fab5f0bed4a6109cdba32579f16bee1b0f76ce1db840ce6f7070188f9f
+  md5: 55a901b6d4fb9ce1bc8328925b229f0b
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 47528
+  timestamp: 1731714690911
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.9.1-hf483d09_2.conda
+  sha256: fca9ed0f0895bab9bf737c8d8a3314556cb893d45c40f0656f21a93502db3089
+  md5: d880c40b8fc7d07374c036f93f1359d2
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-compression >=0.3.0,<0.3.1.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 153315
+  timestamp: 1731714621306
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.15.2-h39f8ad8_2.conda
+  sha256: b14e32f024f6be1610dccfdb6371e101cba204d24f37c2a63d9b6380ac74ac17
+  md5: 3b49f1dd8f20bead8b222828cfdad585
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 137610
+  timestamp: 1731702839896
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.11.0-h68a0d7e_8.conda
+  sha256: 837c24c105624e16ace94b4b566ffe45231ff275339c523571ebd45946926156
+  md5: 9e3ac70d27e7591b1310a690768cfe27
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 134573
+  timestamp: 1731734281038
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.7.4-h840aca7_0.conda
+  sha256: 564bbb781c1aebfcdda43a0e82f447e34de1764c57ebc1733fe6437248f5b7c9
+  md5: 02f78a084e101dee30c794f963549de4
+  depends:
+  - __osx >=11.0
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 97136
+  timestamp: 1733299356527
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.1-h5d7ee29_1.conda
+  sha256: ed3b272b9a345142e62f0cf9ab2a9fa909c92e09691f6a06e98ff500a1f8a303
+  md5: 0f1e5bc57d4567c9d9bec8d8982828ed
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 50276
+  timestamp: 1731687215375
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.2-h5d7ee29_1.conda
+  sha256: eb7ebe309b33a04329b3e51a7f10bb407815389dc37cc047f7d41f9c91f0d1b0
+  md5: db1ed95988a8fe6c1ce0d94abdfc8e72
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 70184
+  timestamp: 1731687342560
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.29.6-h8474b10_2.conda
+  sha256: 5ca9df9516583076ea40129e71b103efaca21ca02f40b59d69485823613cbfba
+  md5: 54c898f166bcfbe06c2b7ac36360f371
+  depends:
+  - __osx >=11.0
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-mqtt >=0.11.0,<0.11.1.0a0
+  - aws-c-s3 >=0.7.4,<0.7.5.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 235829
+  timestamp: 1733334077172
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.449-h3b64406_4.conda
+  sha256: 10ce9c203d31229432421a841d8d135d3e942637571aae4bb2d3c7d5242e7f05
+  md5: f9e46a4bb5a04cbca08355f166ce87c8
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2722689
+  timestamp: 1732812825640
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.14.0-hd50102c_0.conda
+  sha256: f5b91329ed59ffc0be8747784c6e4cc7e56250c54032883a83bc11808ef6a87e
+  md5: f093a11dcf3cdcca010b20a818fcc6dc
+  depends:
+  - __osx >=11.0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 294299
+  timestamp: 1728054014060
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.10.0-hc602bab_0.conda
+  sha256: bde446b916fff5150606f8ed3e6058ffc55a3aa72381e46f1ab346590b1ae40a
+  md5: d7b71593a937459f2d4b67e1a4727dc2
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 166907
+  timestamp: 1728486882502
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.13.0-h7585a09_1.conda
+  sha256: 08d52d130addc0fb55d5ba10d9fa483e39be25d69bac7f4c676c2c3069207590
+  md5: 704238ef05d46144dae2e6b5853df8bc
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 438636
+  timestamp: 1728578216193
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.8.0-h9ca1f76_1.conda
+  sha256: 77ab04e8fe5636a2de9c718f72a43645f7502cd208868c8a91ffba385547d585
+  md5: 7a187cd7b1445afc80253bb186a607cc
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - libxml2 >=2.12.7,<2.14.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 121278
+  timestamp: 1728563418777
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.12.0-hcdd55da_1.conda
+  sha256: f48523f8aa0b5b80f45a92f0556b388dd96f44ac2dc2f44a01d08c1822eec97d
+  md5: c49fbc5233fcbaa86391162ff1adef38
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 196032
+  timestamp: 1728729672889
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h5499902_0.conda
+  sha256: 5a1e635a371449a750b776cab64ad83f5218b58b3f137ebd33ad3ec17f1ce92e
+  md5: e94ca7aec8544f700d45b24aff2dd4d7
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33201
+  timestamp: 1719266149627
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hd74edd7_2.conda
+  sha256: a086f36ff68d6e30da625e910547f6211385246fb2474b144ac8c47c32254576
+  md5: 215e3dc8f2f837906d066e7f01aa77c0
+  depends:
+  - __osx >=11.0
+  - brotli-bin 1.1.0 hd74edd7_2
+  - libbrotlidec 1.1.0 hd74edd7_2
+  - libbrotlienc 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 19588
+  timestamp: 1725268044856
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hd74edd7_2.conda
+  sha256: 28f1af63b49fddf58084fb94e5512ad46e9c453eb4be1d97449c67059e5b0680
+  md5: b8512db2145dc3ae8d86cdc21a8d421e
+  depends:
+  - __osx >=11.0
+  - libbrotlidec 1.1.0 hd74edd7_2
+  - libbrotlienc 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 16772
+  timestamp: 1725268026061
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311h3f08180_2.conda
+  sha256: f507d65e740777a629ceacb062c768829ab76fde01446b191699a734521ecaad
+  md5: c8793a23206344faa25f4e0b5d0e7908
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 339584
+  timestamp: 1725268241628
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+  sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
+  md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
+  depends:
+  - __osx >=11.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 122909
+  timestamp: 1720974522888
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.3-h5505292_1.conda
+  sha256: 6dfa83cbd9acc8671d439fe9c745a5716faf6cbadf2f1e18c841bcf86cbba5f2
+  md5: fb72102e8a8f9bcd38e40af09ff41c42
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 179318
+  timestamp: 1732447193278
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
+  sha256: 2db1733f4b644575dbbdd7994a8f338e6ef937f5ebdb74acd557e9dda0211709
+  md5: 40dec13fd8348dbe303e57be74bd3d35
+  license: ISC
+  size: 158482
+  timestamp: 1725019034582
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py311h3a79f62_0.conda
+  sha256: 253605b305cc4548b8f97eb7c2e146697e0c7672b099c4862ec5ca7e8e995307
+  md5: a42272c5dbb6ffbc1a5af70f24c7b448
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 288211
+  timestamp: 1725560745212
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.1-py311h210dab8_0.conda
+  sha256: 8e755206b38a6e14861c79a74b51af76124bdf5c266dd6a584305e03d37c2e0c
+  md5: 7f9e9df2d62cf69aed450f6957a23e61
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 247202
+  timestamp: 1731428753912
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.0.0-py311h460d6c5_1.conda
+  sha256: cff9cd6a8652a73d9e1d73c51bfd1bac6b526e705885b1ec8f0c159bd34046d2
+  md5: 72740cbbba07d1fb0f37448e1e1c7ef9
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 341441
+  timestamp: 1728335223644
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
+  sha256: 93e077b880a85baec8227e8c72199220c7f87849ad32d02c14fb3807368260b8
+  md5: 5a74cdee497e6b65173e10d94582fae6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 316394
+  timestamp: 1685695959391
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.9-py311h155a34a_0.conda
+  sha256: 880c3de00402d6c5d61d3f64af9ecad8022f272225e3ae62fa8e9c4885b7f0e5
+  md5: d619288803d5935f771f64a7924a6aad
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2531409
+  timestamp: 1732237062084
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.55.1-py311h4921393_0.conda
+  sha256: 49f1ac7c79c546437311bbe18f075d3ad19714cd627131cb2a02ca9c660debc1
+  md5: 545ea87f1c719d9d26a4c265bcd1d7d9
+  depends:
+  - __osx >=11.0
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2803365
+  timestamp: 1733242276864
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+  sha256: 791673127e037a2dc0eebe122dc4f904cb3f6e635bb888f42cbe1a76b48748d9
+  md5: e6085e516a3e304ce41a8ee08b9b89ad
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 596430
+  timestamp: 1694616332835
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-hfbad9fb_0.conda
+  sha256: 9cb4957d1431bc57bc95b1e99a50669d91ac3441226a78f69fa030d52f2bda77
+  md5: 40722e5f48287567cda6fb2ec1f7891b
+  depends:
+  - libexpat >=2.5.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - minizip >=4.0.1,<5.0a0
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 55132
+  timestamp: 1694952828719
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.13.0-hf9b8971_0.conda
+  sha256: 273381020b72bde1597d4e07e855ed50ffac083512e61ccbdd99d93f03c6cbf2
+  md5: 45b2e9adb9663644b1eefa5300b9eef3
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: LGPL-2.1-only
+  size: 1481430
+  timestamp: 1725676193541
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/geotiff-1.7.3-h82bf549_3.conda
+  sha256: 7ce4d6dced3cd313ea170db69d6929b88d77ebd40715f9f38c3bcba3633d6c65
+  md5: cb84033d7c167a16c4577272b4493bc5
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 113739
+  timestamp: 1726603324989
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
+  sha256: fd56ed8a1dab72ab90d8a8929b6f916a6d9220ca297ff077f8f04c5ed3408e20
+  md5: 57a511a5905caa37540eb914dfcbf1fb
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 82090
+  timestamp: 1726600145480
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-h93a5062_0.conda
+  sha256: 843b3f364ff844137e37d5c0a181f11f6d51adcedd216f019d074e5aa5d7e09c
+  md5: 95fa1486c77505330c20f7202492b913
+  license: MIT
+  license_family: MIT
+  size: 71613
+  timestamp: 1712692611426
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
+  sha256: 9fc77de416953aa959039db72bc41bfa4600ae3ff84acad04a7d0c1ab9552602
+  md5: fef68d0a95aa5b84b5c1a4f6f3bf40e1
+  depends:
+  - __osx >=11.0
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 112215
+  timestamp: 1718284365403
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.12.1-nompi_py311h0fa3d65_102.conda
+  sha256: 2e4a5673bfb6750c503edeb9dfc11bcb4fe7313a2c44377ba1dafbb7527ebe48
+  md5: 679929d14a50b8ef5efafdecc52e163e
+  depends:
+  - __osx >=11.0
+  - cached-property
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1216231
+  timestamp: 1729618649075
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.3-nompi_ha698983_107.conda
+  sha256: cf36f8853e81b2742258c7f702d3498853466edd6dfd77c3dae6569f86f4eac5
+  md5: af446c2d7aff6a664828d0c1cb3bc6b7
+  depends:
+  - __osx >=11.0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3478702
+  timestamp: 1733017931067
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+  sha256: 9ba12c93406f3df5ab0a43db8a4b4ef67a5871dfd401010fbe29b218b2cbe620
+  md5: 5eb22c1d7b3fc4abb50d92d621583137
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 11857802
+  timestamp: 1720853997952
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/json-c-0.18-he4178ee_0.conda
+  sha256: 73179a1cd0b45c09d4f631cb359d9e755e6e573c5d908df42006728e0bf8297c
+  md5: 94f14ef6157687c30feb44e1abecd577
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 73715
+  timestamp: 1726487214495
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py311h267d04e_1.conda
+  sha256: 736304347653ed421b13c56ba6f4f87c1d78d24cd3fa74db0db6fb70c814fa65
+  md5: 5bce88ac1bef7d47c62cb574b25891ae
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18253
+  timestamp: 1725303181400
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.7-py311h2c37856_0.conda
+  sha256: 8ffc46f6e99c95c48426cf34c033d16cde3bcf100cd74d1d74a33943a85a6ec8
+  md5: ee572d19da1346db8e78cb8e7d5d2330
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59357
+  timestamp: 1725459504453
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+  sha256: 4442f957c3c77d69d9da3521268cad5d54c9033f1a73f99cde0a3658937b159b
+  md5: c6dc8a0fdec13a0565936655c33069a1
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1155530
+  timestamp: 1719463474401
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
+  sha256: 151e0c84feb7e0747fabcc85006b8973b22f5abbc3af76a9add0b0ef0320ebe4
+  md5: 66f6c134e76fe13cce8a9ea5814b5dd5
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 211959
+  timestamp: 1701647962657
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+  sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
+  md5: de462d5aacda3b30721b512c5da4e742
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 215721
+  timestamp: 1657977558796
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_hf9b8971_1.conda
+  sha256: 90bf08a75506dfcf28a70977da8ab050bcf594cd02abd3a9d84a22c9e8161724
+  md5: 706da5e791c569a7b9814877098a6a0a
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  constrains:
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1179072
+  timestamp: 1727295571173
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
+  sha256: 896189b7b48a194c46a3556ea04943ef81cbe0498521231f8eb25816a68bc8ed
+  md5: 6f0b8e56d2e7bae12a18fc5b2cd9f310
+  depends:
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 28451
+  timestamp: 1711021498493
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.7.7-h7c07d2a_0.conda
+  sha256: 10d5c755761c6823d20c6ddbd42292ef91f34e271b6ba3e78d0c5fa81c22b3ed
+  md5: 49b28e291693b70cf8a7e70f290834d8
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libiconv >=1.17,<2.0a0
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - lzo >=2.10,<3.0a0
+  - openssl >=3.4.0,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 777074
+  timestamp: 1732614642044
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-18.1.0-h654e1bb_2_cpu.conda
+  sha256: 925dcb034f36536eed21d9323f096bf2ebf1111d14c61e1ae0b90e5de131f1e1
+  md5: e69934ff9dd8745fea8927028d1603ee
+  depends:
+  - __osx >=11.0
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - aws-sdk-cpp >=1.11.449,<1.11.450.0a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-identity-cpp >=1.10.0,<1.10.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-files-datalake-cpp >=12.12.0,<12.12.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=18
+  - libgoogle-cloud >=2.31.0,<2.32.0a0
+  - libgoogle-cloud-storage >=2.31.0,<2.32.0a0
+  - libre2-11 >=2024.7.2
+  - libutf8proc >=2.9.0,<2.10.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.3,<2.0.4.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - arrow-cpp <0.0a0
+  - parquet-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5475725
+  timestamp: 1732947802614
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-18.1.0-h605b82c_2_cpu.conda
+  sha256: cfe32f1b0712b77d2c792a839fe4ea2790cabd99d47cd8e1b20ba2d3c8b113b2
+  md5: 60351279d7dfd7c254c46aabf9aa35a6
+  depends:
+  - __osx >=11.0
+  - libarrow 18.1.0 h654e1bb_2_cpu
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: APACHE
+  size: 483362
+  timestamp: 1732948000606
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-18.1.0-h605b82c_2_cpu.conda
+  sha256: eeae9e8d382c482076f4739455b53f16851d7f99be219b6f96dd4e765132b446
+  md5: b5fcaddabf47aa15e50feff072a55ada
+  depends:
+  - __osx >=11.0
+  - libarrow 18.1.0 h654e1bb_2_cpu
+  - libarrow-acero 18.1.0 h605b82c_2_cpu
+  - libcxx >=18
+  - libparquet 18.1.0 h5168bdf_2_cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 489769
+  timestamp: 1732949732423
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-18.1.0-h9b432b6_2_cpu.conda
+  sha256: 6dde802134bd2e78581eb838c049b2e7e378899706b471f7072222a6b1284b90
+  md5: 49e7c0460532a73f34bd127fff009224
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 18.1.0 h654e1bb_2_cpu
+  - libarrow-acero 18.1.0 h605b82c_2_cpu
+  - libarrow-dataset 18.1.0 h605b82c_2_cpu
+  - libcxx >=18
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 451127
+  timestamp: 1732950194322
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libavif16-1.1.1-h45b7238_2.conda
+  sha256: c671365e8c822d29b53f20c4573fdbc70f18b50ff9a4b5b2b6b3c8f7ad2ac2a9
+  md5: 7571064a60bc193ff5c25f36ed23394a
+  depends:
+  - __osx >=11.0
+  - aom >=3.9.1,<3.10.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - rav1e >=0.6.6,<0.7.0a0
+  - svt-av1 >=2.3.0,<2.3.1.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 96781
+  timestamp: 1730268761553
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-25_osxarm64_openblas.conda
+  sha256: f1fb9a11af0b2878bd8804b4c77d3733c40076218bcbdb35f575b1c0c9fddf11
+  md5: f8cf4d920ff36ce471619010eff59cac
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - blas * openblas
+  - liblapack 3.9.0 25_osxarm64_openblas
+  - liblapacke 3.9.0 25_osxarm64_openblas
+  - libcblas 3.9.0 25_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15913
+  timestamp: 1729643265495
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hd74edd7_2.conda
+  sha256: 839dacb741bdbb25e58f42088a2001b649f4f12195aeb700b5ddfca3267749e5
+  md5: d0bf1dff146b799b319ea0434b93f779
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 68426
+  timestamp: 1725267943211
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hd74edd7_2.conda
+  sha256: 6c6862eb274f21a7c0b60e5345467a12e6dda8b9af4438c66d496a2c1a538264
+  md5: 55e66e68ce55523a6811633dd1ac74e2
+  depends:
+  - __osx >=11.0
+  - libbrotlicommon 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 28378
+  timestamp: 1725267980316
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hd74edd7_2.conda
+  sha256: eeb1eb0d58b9d02bc1b98dc0a058f104ab168eb2f7d1c7bfa0570a12cfcdb7b7
+  md5: 4f3a434504c67b2c42565c0b85c1885c
+  depends:
+  - __osx >=11.0
+  - libbrotlicommon 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 279644
+  timestamp: 1725268003553
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-25_osxarm64_openblas.conda
+  sha256: d9fa5b6b11252132a3383bbf87bd2f1b9d6248bef1b7e113c2a8ae41b0376218
+  md5: 4df0fae81f0b5bf47d48c882b086da11
+  depends:
+  - libblas 3.9.0 25_osxarm64_openblas
+  constrains:
+  - blas * openblas
+  - liblapack 3.9.0 25_osxarm64_openblas
+  - liblapacke 3.9.0 25_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15837
+  timestamp: 1729643270793
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+  sha256: 58477b67cc719060b5b069ba57161e20ba69b8695d154a719cb4b60caf577929
+  md5: 32bd82a6a625ea6ce090a81c3d34edeb
+  depends:
+  - libcxx >=11.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18765
+  timestamp: 1633683992603
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.10.1-h13a7ad3_0.conda
+  sha256: 983a977c5627f975a930542c8aabb46089ec6ea72f28d9c4d3ee8eafaf2fc25a
+  md5: d84030d0863ffe7dea00b9a807fee961
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 379948
+  timestamp: 1726660033582
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.5-ha82da77_0.conda
+  sha256: 7918cc0bb7a6554cdd3eee634c3dc414a1ab8ec49faeca1567367bb92118f9d7
+  md5: 3c7be0df28ccda1d193ea6de56dcb5ff
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 519819
+  timestamp: 1733291654212
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libde265-1.0.15-h2ffa867_0.conda
+  sha256: 13747fa634f7f16d7f222b7d3869e3c1aab9d3a2791edeb2fc632a87663950e0
+  md5: 7c718ee6d8497702145612fa0898a12d
+  depends:
+  - libcxx >=15
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 277861
+  timestamp: 1703089176970
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.22-hd74edd7_0.conda
+  sha256: 3552894ca62bebc33d05982937cda25a4fa19e56a82af2ff20944ff4c2532fda
+  md5: 2d3e3f3d8ab315748420ef58d5a3ae0f
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 54089
+  timestamp: 1728177149927
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+  sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
+  md5: 30e4362988a2623e9eb34337b83e01f9
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 96607
+  timestamp: 1597616630749
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+  sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
+  md5: 36d33e440c31857372a72137f78bacf5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 107458
+  timestamp: 1702146414478
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+  sha256: 8c136d7586259bb5c0d2b913aaadc5b9737787ae4f40e3ad1beaf96c80b919b7
+  md5: 1a109764bff3bdc7bdd84088347d71dc
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 368167
+  timestamp: 1685726248899
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
+  sha256: e42ab5ace927ee7c84e3f0f7d813671e1cf3529f5f06ee5899606630498c2745
+  md5: 38d2656dd914feb0cab8c629370768bf
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 64693
+  timestamp: 1730967175868
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+  md5: 086914b672be056eb70fd4285b6783b6
+  license: MIT
+  license_family: MIT
+  size: 39020
+  timestamp: 1636488587153
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.10.0-h9ccd308_5.conda
+  sha256: eddfae562c97894d091f1e922ed8ef4d1f6d5010bf6604284405a1ca09b7f14e
+  md5: f30dbc8b36415e78faab80c90d7992a1
+  depends:
+  - __osx >=11.0
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - geotiff >=1.7.3,<1.8.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - json-c >=0.18,<0.19.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libarchive >=3.7.7,<3.8.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libdeflate >=1.22,<1.26.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libheif >=1.18.2,<1.19.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.4.0,<4.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - proj >=9.5.1,<9.6.0a0
+  - xerces-c >=3.2.5,<3.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - libgdal 3.10.0.*
+  license: MIT
+  license_family: MIT
+  size: 8493321
+  timestamp: 1733330099859
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+  sha256: 44e541b4821c96b28b27fef5630883a60ce4fee91fd9c79f25a199f8f73f337b
+  md5: 4a55d9e169114b2b90d3ec4604cd7bbf
+  depends:
+  - libgfortran5 13.2.0 hf226fd6_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110233
+  timestamp: 1707330749033
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+  sha256: bafc679eedb468a86aa4636061c55966186399ee0a04b605920d208d97ac579a
+  md5: 66ac81d54e95c534ae488726c1f698ea
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 997381
+  timestamp: 1707330687590
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.31.0-h8d8be31_0.conda
+  sha256: 184d650d55453a40935c128ea309088ae52e15a68cd87ab17ae7c77704251168
+  md5: a338736f1514e6f999db8726fe0965b1
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - openssl >=3.3.2,<4.0a0
+  constrains:
+  - libgoogle-cloud 2.31.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 873497
+  timestamp: 1731121684939
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.31.0-h7081f7f_0.conda
+  sha256: 01f5156584b816d34270a60a61f6b6561f2a01cb3b4eeb455a4e1808d763d486
+  md5: 548fd1d31741ee6b13df4124db4a9f5f
+  depends:
+  - __osx >=11.0
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libcxx >=18
+  - libgoogle-cloud 2.31.0 h8d8be31_0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  size: 526858
+  timestamp: 1731122580689
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.67.1-hc70892a_0.conda
+  sha256: d2393fcd3c3584e5d58da4122f48bcf297567d2f6f14b3d1fcbd34fdd5040694
+  md5: 624e27571fde34f8acc2afec840ac435
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.34.2,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libre2-11 >=2024.7.2
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.67.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4882208
+  timestamp: 1730236299095
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libheif-1.18.2-gpl_he913df3_100.conda
+  sha256: 34a70c5889989013b199c6266a30362539af9e24211a6963a0cb0d7ba786f12d
+  md5: 29911afbc2ec42a42914d5255dea52e6
+  depends:
+  - __osx >=11.0
+  - aom >=3.9.1,<3.10.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - libavif16 >=1.1.1,<2.0a0
+  - libcxx >=16
+  - libde265 >=1.0.15,<1.0.16.0a0
+  - x265 >=3.5,<3.6.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 351064
+  timestamp: 1723121589940
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
+  sha256: bc7de5097b97bcafcf7deaaed505f7ce02f648aac8eccc0d5a47cc599a1d0304
+  md5: 69bda57310071cf6d2b86caf11573d2d
+  license: LGPL-2.1-only
+  size: 676469
+  timestamp: 1702682458114
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+  sha256: a42054eaa38e84fc1e5ab443facac4bbc9d1b6b6f23f54b7bf4f1eb687e1d993
+  md5: 3ff1e053dc3a2b8e36b9bfa4256a58d1
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 547541
+  timestamp: 1694475104253
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libkml-1.3.0-he250239_1021.conda
+  sha256: e578ba448489465b8fea743e214272a9fcfccb0d152ba1ff57657aaa76a0cd7d
+  md5: 891bb2a18eaef684f37bd4fb942cd8b2
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libexpat >=2.6.2,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - uriparser >=0.9.8,<1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281362
+  timestamp: 1724667138089
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-25_osxarm64_openblas.conda
+  sha256: fdd742407672a9af20e70764550cf18b3ab67f12e48bf04163b90492fbc401e7
+  md5: 19bbddfec972d401838330453186108d
+  depends:
+  - libblas 3.9.0 25_osxarm64_openblas
+  constrains:
+  - blas * openblas
+  - liblapacke 3.9.0 25_osxarm64_openblas
+  - libcblas 3.9.0 25_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15823
+  timestamp: 1729643275943
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_4.conda
+  sha256: 6f603914fe8633a615f0d2f1383978eb279eeb552079a78449c9fbb43f22a349
+  md5: 9f3dce5d26ea56a9000cd74c034582bd
+  depends:
+  - libcxx >=15
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 20571387
+  timestamp: 1690559110016
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.6.3-h39f12f2_1.conda
+  sha256: d863b8257406918ffdc50ae65502f2b2d6cede29404d09a094f59509d6a0aaf1
+  md5: b2553114a7f5e20ccd02378a77d836aa
+  depends:
+  - __osx >=11.0
+  constrains:
+  - xz ==5.6.3=*_1
+  license: 0BSD
+  size: 99129
+  timestamp: 1733407496073
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-devel-5.6.3-h39f12f2_1.conda
+  sha256: c785d43d4758e18153b502c7d7d3a9181f3c95b2ae64a389fe49af5bf3a53f05
+  md5: 692ccac07529215d42c051c6a60bc5a5
+  depends:
+  - __osx >=11.0
+  - liblzma 5.6.3 h39f12f2_1
+  license: 0BSD
+  size: 113099
+  timestamp: 1733407511832
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
+  sha256: 00cc685824f39f51be5233b54e19f45abd60de5d8847f1a56906f8936648b72f
+  md5: 3408c02539cee5f1141f9f11450b6a51
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.34.2,<2.0a0
+  - libcxx >=17
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 566719
+  timestamp: 1729572385640
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
+  sha256: 62bb669c37a845129096f73d446cdb6bb170e4927f2fea2b661329680dbbc373
+  md5: 40803a48d947c8639da6704e9a44d3ce
+  depends:
+  - __osx >=11.0
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - llvm-openmp >=18.1.8
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4165774
+  timestamp: 1730772154295
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-18.1.0-h5168bdf_2_cpu.conda
+  sha256: 454487d113974b923b4214a65aab780fd90c4914390d0b1f4640b1bf60537bff
+  md5: f995df7ee206617a3e858fd932d7bd2d
+  depends:
+  - __osx >=11.0
+  - libarrow 18.1.0 h654e1bb_2_cpu
+  - libcxx >=18
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 872333
+  timestamp: 1732949558028
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
+  sha256: 38f8759a3eb8060deabd4db41f0f023514d853e46ddcbd0ba21768fc4e563bb1
+  md5: fb36e93f0ea6a6f5d2b99984f34b049e
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 263385
+  timestamp: 1726234714421
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.28.2-h8f0b736_0.conda
+  sha256: f732a6fa918428e2d5ba61e78fe11bb44a002cc8f6bb74c94ee5b1297fefcfd8
+  md5: d2cb5991f2fb8eb079c80084435e9ce6
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2374965
+  timestamp: 1728565334796
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2024.07.02-h2348fd5_1.conda
+  sha256: 6facca42cfc85a05b33e484a8b0df7857cc092db34806946d022270098d8d20f
+  md5: 5a7065309a66097738be6a06fd04b7ef
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 165956
+  timestamp: 1728779107218
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/librttopo-1.1.0-ha2cf0f4_17.conda
+  sha256: 9ff3162d035a1d9022f6145755a70d0c0ce6c9152792402bc42294354c871a17
+  md5: ba729f000ea379b76ed2190119d21e13
+  depends:
+  - __osx >=11.0
+  - geos >=3.13.0,<3.13.1.0a0
+  - libcxx >=17
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 191064
+  timestamp: 1727265842691
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
+  sha256: fade8223e1e1004367d7101dd17261003b60aa576df6d7802191f8972f7470b1
+  md5: a7ce36e284c5faaf93c220dfc39e3abd
+  depends:
+  - __osx >=11.0
+  license: ISC
+  size: 164972
+  timestamp: 1716828607917
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libspatialite-5.1.0-hffd3212_11.conda
+  sha256: 593f50ff3828a2760e7aa131233d9ca410bf5bca764e6eac563a4c5b4a57b2d9
+  md5: b8e9d3018a9bb0ddf92d68f19e543604
+  depends:
+  - __osx >=11.0
+  - freexl >=2
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - libcxx >=17
+  - libiconv >=1.17,<2.0a0
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - sqlite
+  - zlib
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 2984267
+  timestamp: 1727341782874
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.47.0-hbaaea75_1.conda
+  sha256: 5a96caa566c11e5a5ebdcdb86a0759a7fb27d3c5f42e6a0fd0d6023c1e935d9e
+  md5: 07a14fbe439eef078cc479deca321161
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 837683
+  timestamp: 1730208293578
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h9cc3647_0.conda
+  sha256: f7047c6ed44bcaeb04432e8c74da87591940d091b0a3940c0d884b7faa8062e9
+  md5: ddc7194676c285513706e5fc64f214d7
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279028
+  timestamp: 1732349599461
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.21.0-h64651cc_0.conda
+  sha256: 7a6c7d5f58cbbc2ccd6493b4b821639fdb0701b9b04c737a949e8cb6adf1c9ad
+  md5: 7ce2bd2f650f8c31ad7ba4c7bfea61b7
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 324342
+  timestamp: 1727206096912
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-ha962b0a_2.conda
+  sha256: d9e6835fd189b85eb90dbfdcc51f5375decbf5bb53130042f49bbd6bfb0b24be
+  md5: 8e14b5225c593f099a21971568e6d7b4
+  depends:
+  - __osx >=11.0
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=18
+  - libdeflate >=1.22,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 370387
+  timestamp: 1733443310502
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.9.0-h5505292_1.conda
+  sha256: ea88f06e97ef8fa2490f7594f8885bb542577226edf8abba3144302d951a53c2
+  md5: f777470d31c78cd0abe1903a2fda436f
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 83000
+  timestamp: 1732868631531
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+  sha256: 0d4bad713a512d79bfeb4d61821f447afab8b0792aca823f505ce6b195e9fde5
+  md5: c0af0edfebe780b19940e94871f1a765
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 287750
+  timestamp: 1713200194013
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+  sha256: bd3816218924b1e43b275863e21a3e13a5db4a6da74cca8e60bc3c213eb62f71
+  md5: af523aae2eca6dfa1c8eec693f5b9a79
+  depends:
+  - __osx >=11.0
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 323658
+  timestamp: 1727278733917
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.13.5-hbbdcc80_0.conda
+  sha256: 936de9c0e91cb6f178c48ea14313cf6c79bdb1f474c785c117c41492b0407a98
+  md5: 967d4a9dadd710415ee008d862a07c99
+  depends:
+  - __osx >=11.0
+  - icu >=75.1,<76.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 583082
+  timestamp: 1731489765442
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
+  md5: 369964e85dc26bfe78f41399b366c435
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 46438
+  timestamp: 1727963202283
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.5-hdb05f8b_0.conda
+  sha256: e7ba0d8b718925efdcf1309f5e776e3264cc172d3af8d4048b39627c50a1abc0
+  md5: f2c2e187a1d2637d282e34dc92021a70
+  depends:
+  - __osx >=11.0
+  constrains:
+  - openmp 19.1.5|19.1.5.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 281120
+  timestamp: 1733376089600
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.43.0-py311hc367efa_1.conda
+  sha256: c352b894bb07ed59d1cdaed1a64e52b054f4ff02119600a97ccf39cce06dbe5f
+  md5: d14048893b6cc8aec00b4e0e6eb78de2
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 378145
+  timestamp: 1725305457011
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-4.3.3-py311hebe0b09_1.conda
+  sha256: d68fb0bf5d74c83432155406de87b50b8c10712d331bbbab616c52d945751981
+  md5: 74df239a2926df48e2543bb6754baf61
+  depends:
+  - __osx >=11.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 108602
+  timestamp: 1725089854895
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+  sha256: fc343b8c82efe40819b986e29ba748366514e5ab94a1e1138df195af5f45fa24
+  md5: 45505bec548634f7d05e02fb25262cb9
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 141188
+  timestamp: 1674727268278
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h93a5062_1001.conda
+  sha256: b68160b0a8ec374cea12de7afb954ca47419cdc300358232e19cec666d60b929
+  md5: 915996063a7380c652f83609e970c2a7
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  size: 131447
+  timestamp: 1713516009610
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py311h4921393_1.conda
+  sha256: 4f738a7c80e34e5e5d558e946b06d08e7c40e3cc4bdf08140bf782c359845501
+  md5: 249e2f6f5393bb6b36b3d3a3eebdcdf9
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24976
+  timestamp: 1733219849253
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.9.3-py311h031da69_0.conda
+  sha256: cc8a4f695d1679d55c39ed917d5ca6dc1b8a86ddb801b339c1f91e71d5f3cfe4
+  md5: 7def9f5bdc783a319c7b1304bd6144b7
+  depends:
+  - __osx >=11.0
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=18
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 7821688
+  timestamp: 1733176518004
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/minizip-4.0.7-h27ee973_0.conda
+  sha256: 8216190bed8462758d1fea34964f4f46e6314e92696d8b6607bde588895663ad
+  md5: 73dcdab1f21da49048a4f26d648c87a9
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libcxx >=16
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 77944
+  timestamp: 1718483144234
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mne-lsl-1.8.0-py311h210dab8_0.conda
+  sha256: e391223659079c9a1dd997165f83b7f7bfd9f368b0ba0554e55464c16f82d211
+  md5: 80c914d4d7ea1c5f2fc10d8015416d81
+  depends:
+  - __osx >=11.0
+  - click >=8.1
+  - libcxx >=18
+  - mne-base >=1.4.2
+  - numpy >=1.21
+  - packaging
+  - pooch
+  - psutil
+  - pyqtgraph
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - qtpy
+  - scipy
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 500365
+  timestamp: 1732896373122
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.0-py311h2c37856_0.conda
+  sha256: aafa8572c72283801148845772fd9d494765bdcf1b8ae6f435e1caff4f1c97f3
+  md5: 6c826762702474fb0def6cedd2db5316
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 91131
+  timestamp: 1725975234150
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+  sha256: 27d0b9ff78ad46e1f3a6c96c479ab44beda5f96def88e2fe626e0a49429d8afc
+  md5: cb2b0ea909b97b3d70cd3921d1445e1a
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  size: 802321
+  timestamp: 1724658775723
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.60.0-py311h9506ed5_0.conda
+  sha256: 70435f94de8b5328b039ffff9dfdd00c8c0a503cb1a86f4b70ae9cbdd7e4ec1f
+  md5: 5e14ce0b9976d6d0370c9f5032c81bb7
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - llvm-openmp >=16.0.6
+  - llvm-openmp >=18.1.7
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - cuda-version >=11.2
+  - cudatoolkit >=11.2
+  - scipy >=1.0
+  - cuda-python >=11.6
+  - libopenblas >=0.3.18, !=0.3.20
+  - tbb >=2021.6.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5778831
+  timestamp: 1718888718616
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numcodecs-0.14.1-py311hca32420_0.conda
+  sha256: 3625553950c7ef362c291b78453023a47125ffaf3d9c0924a379bc23ec18c857
+  md5: 9d6892bb6ea4921e29259606bd6731e7
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - msgpack-python
+  - numpy >=1.19,<3
+  - numpy >=1.24
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 674849
+  timestamp: 1732243826721
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.0.2-py311h649a571_1.conda
+  sha256: 3d4c508041d17007a56f79b593a6d6a69d4f4e2453f1f7ee29ecb48992cc3acc
+  md5: 417c4c5c4a4693156f5b878cf94bf7a0
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6893464
+  timestamp: 1732314808608
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
+  sha256: 472d6eaffc1996e6af35ec8e91c967f472a536a470079bfa56383cc0dbf4d463
+  md5: 5029846003f0bc14414b9128a1f7c84b
+  depends:
+  - libcxx >=16
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 316603
+  timestamp: 1709159627299
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h39f12f2_0.conda
+  sha256: bd1d58ced46e75efa3b842c61642fd12272c69e9fe4d7261078bc082153a1d53
+  md5: df307bbc703324722df0293c9ca2e418
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2935176
+  timestamp: 1731377561525
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.3-h121fd32_0.conda
+  sha256: 4759fd0c3f06c035146100e22ee36a312c9a8226654bd2973e9ca9ac5de5cf1f
+  md5: 39995f7406b949c1bef74f0c7277afb3
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 438254
+  timestamp: 1731665228473
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py311h9cb3ce9_1.conda
+  sha256: 0a08027b25e4f6034d7733c7366f44283246d61cb82d1721f8789d50ebfef287
+  md5: 9ffa9dee175c76e68ea5de5aa1168d83
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14807397
+  timestamp: 1726879116250
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-h297a79d_2.conda
+  sha256: 83153c7d8fd99cab33c92ce820aa7bfed0f1c94fc57010cf227b6e3c50cb7796
+  md5: 147c83e5e44780c7492998acbacddf52
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 618973
+  timestamp: 1723488853807
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.0.0-py311h3894ae9_0.conda
+  sha256: 6d5307fed000e6b72b98d54dd1fea7b155f9a6453476a937522b89dde7b3d673
+  md5: a9a4adae1c4178f50ac3d1fd5d64bb85
+  depends:
+  - __osx >=11.0
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 41856994
+  timestamp: 1729066060042
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.5.1-h1318a7e_0.conda
+  sha256: c6289d6f1a13f28ff3754ac0cb2553f7e7bc4a3102291115f62a04995d0421eb
+  md5: 5eb42e77ae79b46fabcb0f6f6d130763
+  depends:
+  - __osx >=11.0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libsqlite >=3.47.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2673401
+  timestamp: 1733138376056
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py311hae2e1ce_0.conda
+  sha256: 6237f04371995fa8e8f16481dcd4e01d2733a82750180a362a9f4953ffbb3cde
+  md5: e226eba0c52ecd6786e73c8ad7f41e79
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 514316
+  timestamp: 1729847396776
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+  sha256: 8ed65e17fbb0ca944bfb8093b60086e3f9dd678c3448b5de212017394c247ee3
+  md5: 415816daf82e0b23a736a069a75e9da7
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 8381
+  timestamp: 1726802424786
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-18.1.0-py311ha1ab1f8_0.conda
+  sha256: c93f3ede66be0502b5b9afc5bc3fde50d6f8c3863d29b138ff5f536a116457f3
+  md5: 7a3b822fa6abb937651bee20878f087a
+  depends:
+  - libarrow-acero 18.1.0.*
+  - libarrow-dataset 18.1.0.*
+  - libarrow-substrait 18.1.0.*
+  - libparquet 18.1.0.*
+  - pyarrow-core 18.1.0 *_0_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25322
+  timestamp: 1732611121491
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-18.1.0-py311he04fa90_0_cpu.conda
+  sha256: 4563e2d4f41b3874b89e8e2bdebf42588c1c819bd050ae858200f60e30bae860
+  md5: 09b4a27f615d22f194466d8c274ef13e
+  depends:
+  - __osx >=11.0
+  - libarrow 18.1.0.* *cpu
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy >=1.21,<3
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3974075
+  timestamp: 1732611073316
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.27.1-py311h3ff9189_0.conda
+  sha256: fda69a0024647c988a1571a78f31d05cefb95c8580c7fea29106dc5e08b654fa
+  md5: 9a65f7d97aaa139bd8471429e192ac61
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - typing-extensions >=4.6.0,!=4.7.0
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 1451573
+  timestamp: 1732254367639
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.3.2-py311hab620ed_0.conda
+  sha256: b3990d45325f4d2716d933b1fff821b69b530889d138d6caa246a3ef3d5aaf51
+  md5: 6968e48654cd85960526f4e6ed24996c
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 479023
+  timestamp: 1732987380000
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.3.2-py311hab620ed_0.conda
+  sha256: eaa25ed388d010b298baa11dc62aebf37bb2d8e655b2f8ad0d5df0d1dde25dfd
+  md5: b8302e3047685d0c0721fb65e50039da
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 10.3.2.*
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 384939
+  timestamp: 1733168978481
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.6.1-py311hb4b81e0_10.conda
+  sha256: 8091e5c23915e65d79b3cefcd71deae71c984eb91e46375720a9e09e5ed4e15e
+  md5: 4ef8c617785e130180c0b980b864bb46
+  depends:
+  - __osx >=11.0
+  - certifi
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 503136
+  timestamp: 1726679978805
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.11-hc22306f_1_cpython.conda
+  sha256: 94e198f6a5affa1431401fca7e3b27fda68c59f5ee726083288bff1f6bed8c7f
+  md5: 8d81dcd0be5bdcdd98e0f2482bf63784
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.4.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 14647146
+  timestamp: 1733409012105
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
+  sha256: adc05729b7e0aca7b436e60a86f10822a92185dfcb48d66d6444e3629d3a1f6a
+  md5: 3b855e3734344134cb56c410f729c340
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6308
+  timestamp: 1723823096865
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h460d6c5_1.conda
+  sha256: 9ae182eef4e96a7c2f46cc9add19496276612663e17429500432631dce31a831
+  md5: d32590e7bd388f18b036c6fc402a0cb1
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 192321
+  timestamp: 1725456528007
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.0-py311h730b646_3.conda
+  sha256: 7e75589d9c3723ecf314435f15a7b486cebafa89ebf00bb616354e37587dc7ae
+  md5: b6f3e527de0c0384cd78cfa779bd6ddf
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365841
+  timestamp: 1728642472021
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+  sha256: 873ac689484262a51fd79bc6103c1a1bedbf524924d7f0088fb80703042805e4
+  md5: 6483b1f59526e05d7d894e466b5b6924
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: LicenseRef-Qhull
+  size: 516376
+  timestamp: 1720814307311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rasterio-1.4.3-py311h09e72dc_0.conda
+  sha256: 857b4c8182b5f0bdb41d34e1ec2f0f6033eefe58fc1f731a555ddc656d6ee63d
+  md5: 8897ac3d404cea935d804230f079c62c
+  depends:
+  - __osx >=11.0
+  - affine
+  - attrs
+  - certifi
+  - click >=4
+  - click-plugins
+  - cligj >=0.5
+  - libcxx >=18
+  - libgdal-core >=3.10.0,<3.11.0a0
+  - numpy >=1.21,<3
+  - proj >=9.5.1,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7838455
+  timestamp: 1733163934466
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rav1e-0.6.6-h69fbcac_2.conda
+  sha256: be6174970193cb4d0ffa7d731a93a4c9542881dbc7ab24e74b460ef312161169
+  md5: e309ae86569b1cd55a0285fa4e939844
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1526706
+  timestamp: 1694329743011
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2024.07.02-hcd0e937_1.conda
+  sha256: eebddde6cb10b146507810b701ef6df122d5309cd5151a39d0828aa44dc53725
+  md5: 19e29f2ccc9168eb0a39dc40c04c0e21
+  depends:
+  - libre2-11 2024.07.02 h2348fd5_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26860
+  timestamp: 1728779123653
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+  sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
+  md5: 8cbb776a2f641b943d413b3e19df71f4
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 250351
+  timestamp: 1679532511311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.22.3-py311h3ff9189_0.conda
+  sha256: 8b1e693f3bb84f1152858bba9e15a6717cad02f70b45df3538078c22e67f5a06
+  md5: 16669f8098b2f4a8560727efb9e65afd
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 324661
+  timestamp: 1733366968758
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.1-py311hf1db568_1.conda
+  sha256: 082a72e5f197aefb59e9f40176df835407e5f71ec832541ba14d4326d3686552
+  md5: 1163490da89fd85d00d29b4d4be7cf0c
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15242433
+  timestamp: 1729481958579
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
+  sha256: cb7a9440241c6092e0f1c795fdca149c4767023e783eaf9cfebc501f906b4897
+  md5: 69d0f9694f3294418ee935da3d5f7272
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35708
+  timestamp: 1720003794374
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.47.0-hcd14bea_1.conda
+  sha256: f9975914a78d600182ec68c963a98c6c0a07eda9b9eee7d6e8bdac9310858ad2
+  md5: ca42c22ab1d212895e58fee9ba32875f
+  depends:
+  - __osx >=11.0
+  - libsqlite 3.47.0 hbaaea75_1
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 840459
+  timestamp: 1730208324005
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-2.3.0-hf24288c_0.conda
+  sha256: ab876ed8bdd20e22a868dcb8d03e9ce9bbba7762d7e652d49bfff6af768a5b8f
+  md5: 114c33e9eec335a379c9ee6c498bb807
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1387330
+  timestamp: 1730246134730
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+  sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
+  md5: b50a57ba89c32b62428b71a875291c9b
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3145523
+  timestamp: 1699202432999
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.2-py311h917b07b_0.conda
+  sha256: 80b79a7d4ed8e16019b8c634cca66935d18fc98be358c76a6ead8c611306ee14
+  md5: 183b74c576dc7f920dae168997dbd1dd
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 858954
+  timestamp: 1732616142626
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-15.1.0-py311hae2e1ce_1.conda
+  sha256: e4b1dcf79f4d4656e538ba24c845350b147d0d9f066771f8b3f396bea828b965
+  md5: ade7687026adce6296650b21e7463758
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 372655
+  timestamp: 1729704815727
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/uriparser-0.9.8-h00cdb27_0.conda
+  sha256: fa0bcbfb20a508ca9bf482236fe799581cbd0eab016e47a865e9fa44dbe3c512
+  md5: e8ff9e11babbc8cd77af5a4258dc2802
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40625
+  timestamp: 1715010029254
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
+  sha256: 2fed6987dba7dee07bd9adc1a6f8e6c699efb851431bcb6ebad7de196e87841d
+  md5: b1f7f2780feffe310b068c021e8ff9b2
+  depends:
+  - libcxx >=12.0.1
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1832744
+  timestamp: 1646609481185
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xerces-c-3.2.5-h92fc2f4_2.conda
+  sha256: 863a7c2a991a4399d362d42c285ebc20748a4ea417647ebd3a171e2220c7457d
+  md5: 50b7325437ef0901fe25dc5c9e743b88
+  depends:
+  - __osx >=11.0
+  - icu >=75.1,<76.0a0
+  - libcxx >=17
+  license: Apache-2.0
+  license_family: Apache
+  size: 1277884
+  timestamp: 1727733870250
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
+  sha256: 7113618021cf6c80831a429b2ebb9d639f3c43cf7fe2257d235dc6ae0ab43289
+  md5: 7e0125f8fb619620a0011dc9297e2493
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 13515
+  timestamp: 1727034783560
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+  sha256: 9939a166d780700d81023546759102b33fdc2c5f11ef09f5f66c77210fd334c8
+  md5: 77c447f48cab5d3a15ac224edb86a968
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 18487
+  timestamp: 1727795205022
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.6.3-h9a6d368_1.conda
+  sha256: 84f9405312032638a7c6249573c8f50423c314c8a4d149b34b720caecc0dc83c
+  md5: 1d79c34d99f1e839a06b4631df091b64
+  depends:
+  - __osx >=11.0
+  - liblzma 5.6.3 h39f12f2_1
+  - liblzma-devel 5.6.3 h39f12f2_1
+  - xz-gpl-tools 5.6.3 h9a6d368_1
+  - xz-tools 5.6.3 h39f12f2_1
+  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  size: 23692
+  timestamp: 1733407556613
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-gpl-tools-5.6.3-h9a6d368_1.conda
+  sha256: 98f71ea5d19c9cf4daed3b26a5102862baf8c63210f039e305f283fe399554b0
+  md5: cf05cc17aa7eb2ff843ca5c45d63a324
+  depends:
+  - __osx >=11.0
+  - liblzma 5.6.3 h39f12f2_1
+  constrains:
+  - xz ==5.6.3=*_1
+  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  size: 33402
+  timestamp: 1733407540403
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-tools-5.6.3-h39f12f2_1.conda
+  sha256: b785955dd3d5eb1b00e3f1b1fbc3a9bf14276b2c0a950d0735a503d9abea7b5d
+  md5: 0fea5aff7b3a33856288c26326d937f7
+  depends:
+  - __osx >=11.0
+  - liblzma 5.6.3 h39f12f2_1
+  constrains:
+  - xz ==5.6.3=*_1
+  license: 0BSD AND LGPL-2.1-or-later
+  size: 81028
+  timestamp: 1733407527563
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+  sha256: 93181a04ba8cfecfdfb162fc958436d868cc37db504c58078eab4c1a3e57fbb7
+  md5: 4bb3f014845110883a3c5ee811fd84b4
+  license: MIT
+  license_family: MIT
+  size: 88016
+  timestamp: 1641347076660
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-hc1bb282_7.conda
+  sha256: 9e585569fe2e7d3bea71972cd4b9f06b1a7ab8fa7c5139f92a31cbceecf25a8a
+  md5: f7e6b65943cb73bce0143737fded08f1
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libcxx >=18
+  - libsodium >=1.0.20,<1.0.21.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 281565
+  timestamp: 1731585108039
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
+  sha256: 58f8860756680a4831c1bf4f294e2354d187f2e999791d53b1941834c4b37430
+  md5: e3170d898ca6cb48f1bb567afb92f775
+  depends:
+  - __osx >=11.0
+  - libzlib 1.3.1 h8359307_2
+  license: Zlib
+  license_family: Other
+  size: 77606
+  timestamp: 1727963209370
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py311ha60cc69_1.conda
+  sha256: d2f2f1a408e2353fc61d2bf064313270be2260ee212fe827dcf3cfd3754f1354
+  md5: 29d320d6450b2948740a9be3761b2e9d
+  depends:
+  - __osx >=11.0
+  - cffi >=1.11
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 332271
+  timestamp: 1725305847224
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+  sha256: 2d4fd1ff7ee79cd954ca8e81abf11d9d49954dd1fef80f27289e2402ae9c2e09
+  md5: d96942c06c3e84bfcc5efb038724a7fd
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 405089
+  timestamp: 1714723101397
+- conda: https://conda.anaconda.org/conda-forge/win-64/_libavif_api-1.1.1-h57928b3_2.conda
+  sha256: b99b8948a170ff721ea958ee04a4431797070e85dd6942cb27b73ac3102e5145
+  md5: 76cf1f62c9a62d6b8f44339483e0f016
+  size: 9286
+  timestamp: 1730268773319
+- conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
+  sha256: 1a62cd1f215fe0902e7004089693a78347a30ad687781dfda2289cab000e652d
+  md5: 37e16618af5c4851a3f3d66dd0e11141
+  depends:
+  - libgomp >=7.5.0
+  - libwinpthread >=12.0.0.r2.ggc561118da
+  constrains:
+  - openmp_impl 9999
+  - msys2-conda-epoch <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49468
+  timestamp: 1718213032772
+- conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
+  sha256: 0524d0c0b61dacd0c22ac7a8067f977b1d52380210933b04141f5099c5b6fec7
+  md5: 3d7c14285d3eb3239a76ff79063f27a5
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1958151
+  timestamp: 1718551737234
+- conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311he736701_5.conda
+  sha256: 8bbce5e61e012a06e248f58bb675fdc82ba2900c78590696d185150fb9cea91f
+  md5: 8917bf795c40ec1839ed9d0ab3ad9735
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 34883
+  timestamp: 1725357113431
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.8.0-h6c5491b_10.conda
+  sha256: f92d43e36d271194f027a49c5bd91c7f3eab0406a83734b0a2fee75e0c914546
+  md5: 78eef4154032e557c81bcd12640ee048
+  depends:
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 103029
+  timestamp: 1731733929676
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.8.0-hb414858_2.conda
+  sha256: d2327c924931550a05ab902b4aedbcf5105b581839bade4db7fba6e73dd63214
+  md5: fd898cb8119bf3ad009762df2d8068b0
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 46852
+  timestamp: 1731679007675
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.10.3-h2466b09_0.conda
+  sha256: 27c094c554a84389f0f2430e7397a1b33d558b035bbaf188877f635dbb9b26e6
+  md5: 49b50b5f5074259e9a62c0c271a24d98
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 234894
+  timestamp: 1731567453718
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.3.0-hb414858_2.conda
+  sha256: 2f8c79b24a1396ed2754379bfbe1595b50e7cf306962060b80084b46b682887f
+  md5: beb319c4aeb7de9f6cacf533ebbae94c
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 22528
+  timestamp: 1731679090015
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.5.0-hab6af6e_7.conda
+  sha256: 39fe165d6616e09d25c07a85560ec414a0b0b19c1880e0df52283196cf44896f
+  md5: 1e81f2ecfb25d4a84b4d8fa6067924e5
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 54641
+  timestamp: 1731714676039
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.9.1-hab0f966_2.conda
+  sha256: 81c93d2b8c951c18509ff1359505d01740f77865c9bef46c457607f0ca8c76ad
+  md5: e715a008f534917e93ed2238546b68b0
+  depends:
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-compression >=0.3.0,<0.3.1.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 182315
+  timestamp: 1731714924335
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.15.2-hef77f12_2.conda
+  sha256: 8c02308ad64dcccb85ea55b6fdfb6b6de4b5710a564d24faf64655c4029f4008
+  md5: ac3ab925a1345a6957d5d217fd2d9469
+  depends:
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 160495
+  timestamp: 1731702920182
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.11.0-hbfeb708_8.conda
+  sha256: c1462d6b1de9bdaf6b3233e70cdf2e49b481da9bdf91c0c3f5fcf5ed55f3ca18
+  md5: e125209fbb06e56a208a75f8aae48c00
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 186691
+  timestamp: 1731735208782
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.7.4-h6108ab3_0.conda
+  sha256: cc834920b15068b7cf5c3428de4d8e2357710ea8e7599af9f3c218b17dd8d803
+  md5: 73b7e93b2ad7633502d643a49fdd2879
+  depends:
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 108427
+  timestamp: 1733299704290
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.2.1-hb414858_1.conda
+  sha256: 6130e79950efe49460dcedc8a4845a274ed572e55667b66c815dc771f63f9eca
+  md5: 0e3318644bfcc9c42cbde728d7bb8e08
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 55188
+  timestamp: 1731687352327
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.2.2-hb414858_1.conda
+  sha256: f7d0c5c9bd65cca937ed53425800d7376e89bdac9f82fcef44698e6707784cae
+  md5: 0cb03655a7cf5b4ad9e0cd8d5a18b21d
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 91905
+  timestamp: 1731687613902
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.29.6-h505e3f6_2.conda
+  sha256: da2658ad871f650f19681ae786371bf6bbccd767781412e1fca2a6cbe1397e16
+  md5: b289b6b02d2c5bf8475d1ba0553dd81b
+  depends:
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-mqtt >=0.11.0,<0.11.1.0a0
+  - aws-c-s3 >=0.7.4,<0.7.5.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 261135
+  timestamp: 1733334487552
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.449-h0ed5b37_4.conda
+  sha256: 0057120a9a651d5a50f9fbd4a6404a5aec22885f298ec4da61a1bc1468891f0e
+  md5: da1b9b48262754a5ecf1cf494bb6c4d9
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 2845768
+  timestamp: 1732813377812
+- conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.6-h85f69ea_0.conda
+  sha256: 1289853b41df5355f45664f1cb015c868df1f570cf743e9e4a5bda8efe8c42fa
+  md5: 2390269374fded230fcbca8332a4adc0
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50135
+  timestamp: 1719266616208
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-h2466b09_2.conda
+  sha256: d8fd7d1b446706776117d2dcad1c0289b9f5e1521cb13405173bad38568dd252
+  md5: 378f1c9421775dfe644731cb121c8979
+  depends:
+  - brotli-bin 1.1.0 h2466b09_2
+  - libbrotlidec 1.1.0 h2466b09_2
+  - libbrotlienc 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 19697
+  timestamp: 1725268293988
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-h2466b09_2.conda
+  sha256: f3bf2893613540ac256c68f211861c4de618d96291719e32178d894114ac2bc2
+  md5: d22534a9be5771fc58eb7564947f669d
+  depends:
+  - libbrotlidec 1.1.0 h2466b09_2
+  - libbrotlienc 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 20837
+  timestamp: 1725268270219
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311hda3d55a_2.conda
+  sha256: aa3ac5dbf63db2f145235708973c626c2189ee4040d769fdf0076286fa45dc26
+  md5: a0ea2839841a06740a1c110ba3317b42
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  license: MIT
+  license_family: MIT
+  size: 322114
+  timestamp: 1725268368720
+- conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+  sha256: 35a5dad92e88fdd7fc405e864ec239486f4f31eec229e31686e61a140a8e573b
+  md5: 276e7ffe9ffe39688abc665ef0f45596
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 54927
+  timestamp: 1720974860185
+- conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.34.3-h2466b09_1.conda
+  sha256: 535b9dd013b8726b5147ca202f509308960ef0d050bce4872e16c0d76962147c
+  md5: f8413bb7fb62f7bdc2545c9a06937790
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 192376
+  timestamp: 1732447407728
+- conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
+  sha256: 0fcac3a7ffcc556649e034a1802aedf795e64227eaa7194d207b01eaf26454c4
+  md5: 4c4fd67c18619be5aa65dc5b6c72e490
+  license: ISC
+  size: 158773
+  timestamp: 1725019107649
+- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py311he736701_0.conda
+  sha256: 9689fbd8a31fdf273f826601e90146006f6631619767a67955048c7ad7798a1d
+  md5: e1c69be23bd05471a6c623e91680ad59
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 297627
+  timestamp: 1725561079708
+- conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.1-py311h3257749_0.conda
+  sha256: dbb0c161dd75e72e66c13f31715941adb094a45471016f89d6a1cfab30967ba8
+  md5: 91d8504588e1b3c77e605503e5a1bc11
+  depends:
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 216693
+  timestamp: 1731429286140
+- conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.0.0-py311he736701_1.conda
+  sha256: e8f2027af0cf22feebad76ccbbb3139437fd07b5c6c35497b45e8de2d1f636ea
+  md5: b0845b4087a24616d2fecc716397b3f6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 322558
+  timestamp: 1728335601937
+- conda: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
+  sha256: 2aa2083c9c186da7d6f975ccfbef654ed54fff27f4bc321dbcd12cee932ec2c4
+  md5: ed2c27bda330e3f0ab41577cf8b9b585
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 618643
+  timestamp: 1685696352968
+- conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.9-py311hda3d55a_0.conda
+  sha256: 04db57c1b8fa22d17399c8df03e0d62b365a1315318b59009980672762a6ed87
+  md5: 0f21eefbe9b04632c4e0e17636be84d3
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 3623627
+  timestamp: 1732237179740
+- conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.55.1-py311h5082efb_0.conda
+  sha256: 8b8b119d0e33998326d0cd67ff191ed61ab34e17937970fc40cd23156a88b8d1
+  md5: 4d05b5fd390be4220d5820e1d98bd870
+  depends:
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - unicodedata2 >=15.1.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 2504673
+  timestamp: 1733242460211
+- conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+  sha256: 2c53ee8879e05e149a9e525481d36adfd660a6abda26fd731376fa64ff03e728
+  md5: 3761b23693f768dc75a8fd0a73ca053f
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-only OR FTL
+  size: 510306
+  timestamp: 1694616398888
+- conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-h8276f4a_0.conda
+  sha256: 9ef2fcf3b35703bf61a8359038c4b707382f3d5f0c4020f3f8ffb2f665daabae
+  md5: 8e02e06229c677cbc9f5dc69ba49052c
+  depends:
+  - libexpat >=2.5.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - minizip >=4.0.1,<5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 77439
+  timestamp: 1694953013560
+- conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.13.0-h5a68840_0.conda
+  sha256: 2b46d6f304f70dfca304169299908b558bd1e83992acb5077766eefa3d3fe35f
+  md5: 08a30fe29a645fc5c768c0968db116d3
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-only
+  size: 1665961
+  timestamp: 1725676536384
+- conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.3-h496ac4d_3.conda
+  sha256: 116120a2f4411618800c2a5ce246dfc313298e545ce1ffaa85f28cc3ac2236ac
+  md5: fb20f424102030f3952532cc7aebdbd8
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 123087
+  timestamp: 1726603487099
+- conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.12.1-nompi_py311h67016bb_102.conda
+  sha256: 5ca110b4264f7b9567662d11fd17bb11909a012dc2da8b3fe36b255df9aac824
+  md5: cc84ef5211329e067d485f3e36bc54be
+  depends:
+  - cached-property
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1115485
+  timestamp: 1729618324428
+- conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_hd5d9e70_107.conda
+  sha256: bc06fa5d7c6e272b0d03632be2b69509705c72632fbcc4cd86017e8edcfa6af3
+  md5: 2fe16003742cbb2765462fdadadfe9d1
+  depends:
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2045376
+  timestamp: 1733017969370
+- conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+  sha256: 0fd2b0b84c854029041b0ede8f4c2369242ee92acc0092f8407b1fe9238a8209
+  md5: 2d89243bfb53652c182a7c73182cce4f
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 1852356
+  timestamp: 1723739573141
+- conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_1.conda
+  sha256: 9a667eeae67936e710ff69ee7ce0e784d6052eeba9670b268c565a55178098c4
+  md5: 943f7fab631e12750641efd7279a268c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42891
+  timestamp: 1725303340467
+- conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.7-py311h3257749_0.conda
+  sha256: a2079e13d1345a5dd61df6be933e828e805051256e7260009ba93fce55aebd75
+  md5: 18fd1ac3d79a8d6550eaea5ceaa00036
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55867
+  timestamp: 1725459681416
+- conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+  sha256: 18e8b3430d7d232dad132f574268f56b3eb1a19431d6d5de8c53c29e6c18fa81
+  md5: 31aec030344e962fbd7dbbbbd68e60a9
+  depends:
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 712034
+  timestamp: 1719463874284
+- conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
+  sha256: f9fd9e80e46358a57d9bb97b1e37a03da4022143b019aa3c4476d8a7795de290
+  md5: d3592435917b62a8becff3a60db674f6
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 507632
+  timestamp: 1701648249706
+- conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+  sha256: f4f39d7f6a2f9b407f8fb567a6c25755270421731d70f0ff331f5de4fa367488
+  md5: 1900cb3cab5055833cfddb0ba233b074
+  depends:
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30037
+  license: Apache-2.0
+  license_family: Apache
+  size: 194365
+  timestamp: 1657977692274
+- conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_he0c23c2_1.conda
+  sha256: 52ff148dee1871ef1d5c298bae20309707e866b44714a0a333a5ed2cf9a38832
+  md5: 3f59a73b07a05530b252ecb07dd882b9
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1777570
+  timestamp: 1727296115119
+- conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
+  sha256: f5c293d3cfc00f71dfdb64bd65ab53625565f8778fc2d5790575bef238976ebf
+  md5: 8723000f6ffdbdaef16025f0a01b64c5
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 32567
+  timestamp: 1711021603471
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.7.7-h88ece9c_0.conda
+  sha256: afc496c826ec21cb898018695a7785baced3ebb66a90e39a1c2604dfaa1546be
+  md5: 37c6e11d9f2e69789198ef2bfc661392
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - lzo >=2.10,<3.0a0
+  - openssl >=3.4.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 977329
+  timestamp: 1732614920501
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-18.1.0-h0ea94f9_2_cpu.conda
+  sha256: 212996b0a7efe74c01f9a045f4db2253175ad95dee088fc2cb8c2944f8df9ab0
+  md5: 0fc0ae2ddd001a52d6715ba88c651e8e
+  depends:
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - aws-sdk-cpp >=1.11.449,<1.11.450.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgoogle-cloud >=2.31.0,<2.32.0a0
+  - libgoogle-cloud-storage >=2.31.0,<2.32.0a0
+  - libre2-11 >=2024.7.2
+  - libutf8proc >=2.9.0,<2.10.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.3,<2.0.4.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - parquet-cpp <0.0a0
+  - arrow-cpp <0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5248470
+  timestamp: 1732950405896
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-18.1.0-hb6457b2_2_cpu.conda
+  sha256: e17750b6fe6c863b1f2496e5ebf5c181416a0a40526efd9072cd200b44e7d587
+  md5: b21ccd9073c96c689db3e620ffa15cc4
+  depends:
+  - libarrow 18.1.0 h0ea94f9_2_cpu
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  license: Apache-2.0
+  license_family: APACHE
+  size: 446442
+  timestamp: 1732950538361
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-18.1.0-hb6457b2_2_cpu.conda
+  sha256: 6fece2e5e0480839ce1408769ec1dbb72ba7220388a65b37ba4cdc8cc0430f31
+  md5: a33883871abd3033d5ad4096d977131a
+  depends:
+  - libarrow 18.1.0 h0ea94f9_2_cpu
+  - libarrow-acero 18.1.0 hb6457b2_2_cpu
+  - libparquet 18.1.0 he61daf8_2_cpu
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  license: Apache-2.0
+  license_family: APACHE
+  size: 433194
+  timestamp: 1732951105863
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-18.1.0-h30d554c_2_cpu.conda
+  sha256: c936be773ff3c3d87a521e8e53ff2f631474c3a9714a981027236853003c984f
+  md5: ee7c83f7afe66b6ce158632e70c36be2
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 18.1.0 h0ea94f9_2_cpu
+  - libarrow-acero 18.1.0 hb6457b2_2_cpu
+  - libarrow-dataset 18.1.0 hb6457b2_2_cpu
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  license: Apache-2.0
+  license_family: APACHE
+  size: 364194
+  timestamp: 1732951352741
+- conda: https://conda.anaconda.org/conda-forge/win-64/libavif16-1.1.1-h4d049a7_2.conda
+  sha256: f74662ac8325dedbc786bf4f3faef39ad4981739cf0239c2ea2d80c791b04de5
+  md5: e7e7405d962ebcb6803f29dc4eabae69
+  depends:
+  - _libavif_api >=1.1.1,<1.1.2.0a0
+  - aom >=3.9.1,<3.10.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - rav1e >=0.6.6,<0.7.0a0
+  - svt-av1 >=2.3.0,<2.3.1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 97828
+  timestamp: 1730269135854
+- conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_mkl.conda
+  sha256: 5468bb91c44b41ce060bbd997c797b2f91e2b7ce91a7cbf4ddf7e7b734a8dc98
+  md5: 499208e81242efb6e5abc7366c91c816
+  depends:
+  - mkl 2024.2.2 h66d3029_14
+  constrains:
+  - blas * mkl
+  - libcblas 3.9.0 25_win64_mkl
+  - liblapack 3.9.0 25_win64_mkl
+  - liblapacke 3.9.0 25_win64_mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3736641
+  timestamp: 1729643534444
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-h2466b09_2.conda
+  sha256: 33e8851c6cc8e2d93059792cd65445bfe6be47e4782f826f01593898ec95764c
+  md5: f7dc9a8f21d74eab46456df301da2972
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 70526
+  timestamp: 1725268159739
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-h2466b09_2.conda
+  sha256: 234fc92f4c4f1cf22f6464b2b15bfc872fa583c74bf3ab9539ff38892c43612f
+  md5: 9bae75ce723fa34e98e239d21d752a7e
+  depends:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 32685
+  timestamp: 1725268208844
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-h2466b09_2.conda
+  sha256: 3d0dd7ef505962f107b7ea8f894e0b3dd01bf46852b362c8a7fc136b039bc9e1
+  md5: 85741a24d97954a991e55e34bc55990b
+  depends:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 245929
+  timestamp: 1725268238259
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_mkl.conda
+  sha256: 21528cdfe67dafdb2d21925515a167f13963e002c2b6d06d68984767f731850c
+  md5: 3ed189ba03a9888a8013aaee0d67c49d
+  depends:
+  - libblas 3.9.0 25_win64_mkl
+  constrains:
+  - blas * mkl
+  - liblapack 3.9.0 25_win64_mkl
+  - liblapacke 3.9.0 25_win64_mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3732258
+  timestamp: 1729643561581
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+  sha256: 75e60fbe436ba8a11c170c89af5213e8bec0418f88b7771ab7e3d9710b70c54e
+  md5: cd4cc2d0c610c8cb5419ccc979f2d6ce
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25694
+  timestamp: 1633684287072
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
+  sha256: dfbac497c4fee74f67391f9c4a40cab559468b7d04ff9fad4b404a26b5e1d5b8
+  md5: 7ead800e22ff7b4bccb73e42a8f7a0f4
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: curl
+  license_family: MIT
+  size: 342388
+  timestamp: 1726660508261
+- conda: https://conda.anaconda.org/conda-forge/win-64/libde265-1.0.15-h91493d7_0.conda
+  sha256: f52c603151743486d2faec37e161c60731001d9c955e0f12ac9ad334c1119116
+  md5: 9dc3c1fbc1c7bc6204e8a603f45e156b
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 252968
+  timestamp: 1703089151021
+- conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.22-h2466b09_0.conda
+  sha256: 579c634b7de8869cb1d76eccd4c032dc275d5a017212128502ea4dc828a5b361
+  md5: a3439ce12d4e3cd887270d9436f9a4c8
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 155506
+  timestamp: 1728177485361
+- conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+  sha256: af03882afb7a7135288becf340c2f0cf8aa8221138a9a7b108aaeb308a486da1
+  md5: 25efbd786caceef438be46da78a7b5ef
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 410555
+  timestamp: 1685726568668
+- conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.4-he0c23c2_0.conda
+  sha256: 0c0447bf20d1013d5603499de93a16b6faa92d7ead870d96305c0f065b6a5a12
+  md5: eb383771c680aa792feb529eaf9df82f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 139068
+  timestamp: 1730967442102
+- conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+  sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
+  md5: 2c96d1b6915b408893f9472569dee135
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 42063
+  timestamp: 1636489106777
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-14.2.0-h1383e82_1.conda
+  sha256: ef840e797714440bb10b69446d815966fff41fdac79f79c4e19c475d81cd375d
+  md5: 75fdd34824997a0f9950a703b15d8ac5
+  depends:
+  - _openmp_mutex >=4.5
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - libgcc-ng ==14.2.0=*_1
+  - libgomp 14.2.0 h1383e82_1
+  - msys2-conda-epoch <0.0a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 666386
+  timestamp: 1729089506769
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.10.0-ha193a43_5.conda
+  sha256: 192e5686ce719c31de3e65a0ba7e9754002639a5d7e1ad561d9796101e0e8663
+  md5: c49f70342dc20644979b2c21f932c6fa
+  depends:
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - geotiff >=1.7.3,<1.8.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libarchive >=3.7.7,<3.8.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libdeflate >=1.22,<1.26.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libheif >=1.18.2,<1.19.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.4.0,<4.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - proj >=9.5.1,<9.6.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xerces-c >=3.2.5,<3.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - libgdal 3.10.0.*
+  license: MIT
+  license_family: MIT
+  size: 8388926
+  timestamp: 1733331232694
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-14.2.0-h1383e82_1.conda
+  sha256: d8739b834608f35775209b032f0c2be752ef187863c7ec847afcebe2f681be4e
+  md5: 9e2d4d1214df6f21cba12f6eff4972f9
+  depends:
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - msys2-conda-epoch <0.0a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 524249
+  timestamp: 1729089441747
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.31.0-h07d40e7_0.conda
+  sha256: 40d5aa338c0aca8e619c777cc552d19f5810f1408b695c9de8f1dc7e279d8550
+  md5: 94320a551af951938e22e9b5dbd60b50
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libgoogle-cloud 2.31.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 14474
+  timestamp: 1731122599862
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.31.0-he5eb982_0.conda
+  sha256: 0deaba4051d1caec99f2e76bad65979007a01e912eecf8bdd895b5bddb96a085
+  md5: 5de1d1089bc7d21b2cbc7273a0c2022d
+  depends:
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libgoogle-cloud 2.31.0 h07d40e7_0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 14355
+  timestamp: 1731122772886
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.67.1-h7aa3b8a_0.conda
+  sha256: 986dafe9c3219e88a82389e679a2804d4256aa9ddaead193f91b7d6b4ef89ea1
+  md5: daad5d4a1c24c1afe748afbb83377e43
+  depends:
+  - c-ares >=1.34.2,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libre2-11 >=2024.7.2
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - re2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - grpc-cpp =1.67.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 17167461
+  timestamp: 1730236510917
+- conda: https://conda.anaconda.org/conda-forge/win-64/libheif-1.18.2-gpl_hc631cee_100.conda
+  sha256: 8d7f1a2015d826a14728ddc1c1bb3a5619d15063d6189acb564e4e264f9255ee
+  md5: 4e127b124dcddec36018c97129720671
+  depends:
+  - aom >=3.9.1,<3.10.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - libavif16 >=1.1.1,<2.0a0
+  - libde265 >=1.0.15,<1.0.16.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - x265 >=3.5,<3.6.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 330638
+  timestamp: 1723121942820
+- conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.2-default_ha69328c_1001.conda
+  sha256: 850e255997f538d5fb6ed651321141155a33bb781d43d326fc4ff62114dd2842
+  md5: b87a0ac5ab6495d8225db5dc72dd21cd
+  depends:
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - libxml2 >=2.13.4,<2.14.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2390021
+  timestamp: 1731375651179
+- conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+  sha256: 5f844dd19b046d43174ad80c6ea75b5d504020e3b63cfbc4ace97b8730d35c7b
+  md5: e1eb10b1cca179f2baa3601e4efc8712
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-only
+  size: 636146
+  timestamp: 1702682547199
+- conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+  sha256: 4e7808e3098b4b4ed7e287f63bb24f9045cc4d95bfd39f0db870fc2837d74dff
+  md5: 3f1b948619c45b1ca714d60c7389092c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 822966
+  timestamp: 1694475223854
+- conda: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-h538826c_1021.conda
+  sha256: 81a6096a2db500f0c3527ae59398eacca0634c3381559713ab28022d711dd3bd
+  md5: 431ec3b40b041576811641e2d643954e
+  depends:
+  - libexpat >=2.6.2,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - uriparser >=0.9.8,<1.0a0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1651104
+  timestamp: 1724667610262
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_mkl.conda
+  sha256: 98c13a28596389539abe3f608c6fbd2826df47671f77c58a331df878c6140c53
+  md5: f716ef84564c574e8e74ae725f5d5f93
+  depends:
+  - libblas 3.9.0 25_win64_mkl
+  constrains:
+  - blas * mkl
+  - libcblas 3.9.0 25_win64_mkl
+  - liblapacke 3.9.0 25_win64_mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3736560
+  timestamp: 1729643588182
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.6.3-h2466b09_1.conda
+  sha256: 24d04bd55adfa44c421c99ce169df38cb1ad2bba5f43151bc847fc802496a1fa
+  md5: 015b9c0bd1eef60729ab577a38aaf0b5
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - xz ==5.6.3=*_1
+  license: 0BSD
+  size: 104332
+  timestamp: 1733407872569
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-devel-5.6.3-h2466b09_1.conda
+  sha256: 771a99f8cd58358fe38192fc0df679cf6276facb8222016469693de7b0c8ff47
+  md5: 5f9978adba7aa8aa7d237cdb8b542537
+  depends:
+  - liblzma 5.6.3 h2466b09_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: 0BSD
+  size: 125790
+  timestamp: 1733407900270
+- conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-18.1.0-he61daf8_2_cpu.conda
+  sha256: 22f314491e7f9fa3241e2ed721184c722f8b7c3bc404927385e1e30cba3d66ee
+  md5: a0b4b350dba8924ced639a629c5e3cb4
+  depends:
+  - libarrow 18.1.0 h0ea94f9_2_cpu
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.4.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  license: Apache-2.0
+  license_family: APACHE
+  size: 811713
+  timestamp: 1732950983570
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
+  sha256: 0d3d6ff9225f6918ac225e3839c0d91e5af1da08a4ebf59cac1bfd86018db945
+  md5: 639ac6b55a40aa5de7b8c1b4d78f9e81
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: zlib-acknowledgement
+  size: 348933
+  timestamp: 1726235196095
+- conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.28.2-hcaed137_0.conda
+  sha256: 798c6675fb709ceaa6a9bd83e9cffe06bc98e83f519c7d7d881243d2e6d0c34d
+  md5: 97c6d2f83edd7b400a22660e2a4d1488
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6033581
+  timestamp: 1728565880841
+- conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2024.07.02-h4eb7d71_1.conda
+  sha256: 39908d18620d48406ea3492bf111eface5b3a88c1a2d166c6d513b03f450df5d
+  md5: d8dbfb066c8e3e85439687613d32057d
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 260860
+  timestamp: 1728779502416
+- conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-hd4c2148_17.conda
+  sha256: 0f4a1c8ed579f96ccb73245b4002d7152a2a8ecd05a01d49901c5d280561f766
+  md5: 06ea16b8c60b4ce1970c06191f8639d4
+  depends:
+  - geos >=3.13.0,<3.13.1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 404515
+  timestamp: 1727265928370
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+  sha256: 7bcb3edccea30f711b6be9601e083ecf4f435b9407d70fc48fbcf9e5d69a0fc6
+  md5: 198bb594f202b205c7d18b936fa4524f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: ISC
+  size: 202344
+  timestamp: 1716828757533
+- conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-h939089a_11.conda
+  sha256: 76da01457b92be57ac0635cec2681c5423a46252713b144391c14aa0dffe61ba
+  md5: 3ff7b70e2c517f3a43f0b3f87475915a
+  depends:
+  - freexl >=2
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - sqlite
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 8293459
+  timestamp: 1727341947641
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.0-h2466b09_1.conda
+  sha256: 3342d6fe787f5830f7e8466d9c65c914bfd8d67220fb5673041b338cbba47afe
+  md5: 5b1f36012cc3d09c4eb9f24ad0e2c379
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 892175
+  timestamp: 1730208431651
+- conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-he619c9f_0.conda
+  sha256: 4b3256bd2b4e4b3183005d3bd8826d651eccd1a4740b70625afa2b7e7123d191
+  md5: af0cbf037dd614c34399b3b3e568c557
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 291889
+  timestamp: 1732349796504
+- conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.21.0-hbe90ef8_0.conda
+  sha256: 81ca4873ba09055c307f8777fb7d967b5c26291f38095785ae52caed75946488
+  md5: 7699570e1f97de7001a7107aabf2d677
+  depends:
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 633857
+  timestamp: 1727206429954
+- conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hfc51747_1.conda
+  sha256: 902cb9f7f54d17dcfd54ce050b1ce2bc944b9bbd1748913342c2ea1e1140f8bb
+  md5: eac317ed1cc6b9c0af0c27297e364665
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.22,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 978865
+  timestamp: 1728232594877
+- conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.9.0-h2466b09_1.conda
+  sha256: 19386d93341d8fa3800033a7555ab00b9fef1db1dbd0a50b6e547b532860b603
+  md5: 6f35a14d54f6fe4d013005cf56031842
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 84392
+  timestamp: 1732868780863
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+  sha256: d0ca51cb1de9192be9a3238e71fbcca5a535619c499c4f4c9b2ed41c14d36770
+  md5: abd61d0ab127ec5cd68f62c2969e6f34
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 274359
+  timestamp: 1713200524021
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_8.conda
+  sha256: 6d5e158813ab8d553fbb0fedd0abe7bf92970b0be3a9ddf12da0f6cbad78f506
+  md5: 03cccbba200ee0523bde1f3dad60b1f3
+  depends:
+  - ucrt
+  constrains:
+  - pthreads-win32 <0.0a0
+  - msys2-conda-epoch <0.0a0
+  license: MIT AND BSD-3-Clause-Clear
+  size: 35433
+  timestamp: 1724681489463
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
+  sha256: 08dec73df0e161c96765468847298a420933a36bc4f09b50e062df8793290737
+  md5: a69bbf778a462da324489976c84cfc8c
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - pthread-stubs
+  - ucrt >=10.0.20348.0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 1208687
+  timestamp: 1727279378819
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.5-h442d1da_0.conda
+  sha256: 020466b17c143190bd5a6540be2ceef4c1f8d514408bd5f0adaafcd9d0057b5c
+  md5: 1fbabbec60a3c7c519a5973b06c3b2f4
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1511585
+  timestamp: 1731489892312
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+  sha256: ba945c6493449bed0e6e29883c4943817f7c79cbff52b83360f7b341277c6402
+  md5: 41fbfac52c601159df6c01f875de31b9
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 55476
+  timestamp: 1727963768015
+- conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.43.0-py311h7deaa30_1.conda
+  sha256: 7df8480fc6c32b6f5e0b6f928332759559e9c2d6c43f94e6b51ea5d2129442a9
+  md5: c59d60615d5c5a9e9539a106478d332c
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - vs2015_runtime
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17126019
+  timestamp: 1725305442517
+- conda: https://conda.anaconda.org/conda-forge/win-64/lz4-4.3.3-py311h8b5e962_1.conda
+  sha256: 24bb321c5da9660f56759000001a6f227780348a21098164f55049b58ac78a11
+  md5: 8672eca07a3b500a9aa0483c43742f82
+  depends:
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 76663
+  timestamp: 1725090098178
+- conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+  sha256: a0954b4b1590735ea5f3d0f4579c3883f8ac837387afd5b398b241fda85124ab
+  md5: e34720eb20a33fc3bfb8451dd837ab7a
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134235
+  timestamp: 1674728465431
+- conda: https://conda.anaconda.org/conda-forge/win-64/lzo-2.10-hcfcfb64_1001.conda
+  sha256: 39e176b8cc8fe878d87594fae0504c649d1c2c6d5476dd7238237d19eb825751
+  md5: 629f4f4e874cf096eb93a23240910cee
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  size: 142771
+  timestamp: 1713516312465
+- conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py311h5082efb_1.conda
+  sha256: 6f756e13ccf1a521d3960bd3cadddf564e013e210eaeced411c5259f070da08e
+  md5: c1f2ddad665323278952a453912dc3bd
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28238
+  timestamp: 1733220208800
+- conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.3-py311h8f1b1e4_0.conda
+  sha256: 624ca657eea90a7cbb19c49b8bbb8d8e4d6e233f6e59fd10f7032623e2a7bb21
+  md5: c6e27df155392af0f22217192f8aebdd
+  depends:
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 7841204
+  timestamp: 1733177818555
+- conda: https://conda.anaconda.org/conda-forge/win-64/minizip-4.0.6-hb638d1e_0.conda
+  sha256: b334446aa40fe368ea816f5ee47145aea4408812a5a8d016db51923d7c465835
+  md5: 43e2b972e258a25a1e01790ad0e3287a
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 85324
+  timestamp: 1717296997985
+- conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_14.conda
+  sha256: 098ba4a3cb82f627bc79dc0ab1111b44859c9ef4aaa8d75ce043bce107770cb3
+  md5: f011e7cc21918dc9d1efe0209e27fa16
+  depends:
+  - intel-openmp 2024.*
+  - tbb 2021.*
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 103019089
+  timestamp: 1727378392081
+- conda: https://conda.anaconda.org/conda-forge/win-64/mne-lsl-1.8.0-py311h3257749_0.conda
+  sha256: a4b0a080a8b1716b93cfb720d5c02b7fa98ab821d7faddad1af8e3281adfe5e1
+  md5: 57ee873271707392620be179267aded4
+  depends:
+  - click >=8.1
+  - mne-base >=1.4.2
+  - numpy >=1.21
+  - packaging
+  - pooch
+  - psutil
+  - pyqtgraph
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - qtpy
+  - scipy
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 479468
+  timestamp: 1732896583315
+- conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.0-py311h3257749_0.conda
+  sha256: 4e6a7979b434308ce5588970cb613952e3340bb2f9e63aaad7e5069ef1f08d1d
+  md5: 36562593204b081d0da8a8bfabfb278b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 89472
+  timestamp: 1725975909671
+- conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.60.0-py311h0673bce_0.conda
+  sha256: b3359607051ec34c3eeb90447ece326822b6883882cf0e425cb1108dbcaebdc9
+  md5: 5d6eb2107dd921d651e46d059a82ab95
+  depends:
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - cudatoolkit >=11.2
+  - libopenblas !=0.3.6
+  - cuda-version >=11.2
+  - tbb >=2021.6.0
+  - scipy >=1.0
+  - cuda-python >=11.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5807308
+  timestamp: 1718888792863
+- conda: https://conda.anaconda.org/conda-forge/win-64/numcodecs-0.14.1-py311hcf9f919_0.conda
+  sha256: 50dc848841027218ccb52e87948e06087e434fff867cfd5ea19a31b3aebd61c8
+  md5: 2213faefca7125f0cd8f6bca9a835032
+  depends:
+  - msgpack-python
+  - numpy >=1.19,<3
+  - numpy >=1.24
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 552380
+  timestamp: 1732244009988
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.0.2-py311h35ffc71_1.conda
+  sha256: 22d8f73e0fd6477f425e6b22a2db15af73f0ce4775ae7acb1ce1b06d666256a7
+  md5: 4bb6bca8e8c20873b9036643fff8af3b
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7501226
+  timestamp: 1732315481415
+- conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
+  sha256: dda71cbe094234ab208f3552dec1f4ca6f2e614175d010808d6cb66ecf0bc753
+  md5: 7e7099ad94ac3b599808950cec30ad4e
+  depends:
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 237974
+  timestamp: 1709159764160
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.4.0-h2466b09_0.conda
+  sha256: e03045a0837e01ff5c75e9273a572553e7522290799807f918c917a9826a6484
+  md5: d0d805d9b5524a14efb51b3bff965e83
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 8491156
+  timestamp: 1731379715927
+- conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.3-h34659fe_0.conda
+  sha256: 8baa71790c9899bd7bc0d028ec0dab8180330cb12ecd6600d2b7e0cb78a79a2c
+  md5: 7d0f9831258c59c73b1dcf00b05e8785
+  depends:
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 896875
+  timestamp: 1731665181736
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py311hcf9f919_1.conda
+  sha256: f5477bf3a2b7919481009ce87212d7bbd16c61a5bb05c692a7c336fb45646534
+  md5: 5965b8926efba14e6fde98cc8713c083
+  depends:
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14587131
+  timestamp: 1726879538736
+- conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_2.conda
+  sha256: f4a12cbf8a7c5bfa2592b9dc92b492c438781898e5b02f397979b0be6e1b5851
+  md5: a3a3baddcfb8c80db84bec3cb7746fb8
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 820831
+  timestamp: 1723489427046
+- conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.0.0-py311h4fbf6a9_0.conda
+  sha256: 0d38ec638a5b266adb894f6fe4c874b46b98180a984007bf40cb030a22e8cc1e
+  md5: 44897ebc5704d3de316af26740325513
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: HPND
+  size: 42185657
+  timestamp: 1729066269713
+- conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.5.1-h4f671f6_0.conda
+  sha256: ddd0be6172e3903bc6602a93394e8051826235377c1ce8c6ba2435869794e726
+  md5: 7303dac2aa92318f319508aedab6a127
+  depends:
+  - libcurl >=8.10.1,<9.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - sqlite
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2740461
+  timestamp: 1733138695290
+- conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py311he736701_0.conda
+  sha256: 303c988247c4b1638f1cc90cd40465f5c74ca0ecfd83114033af637654dc2b6b
+  md5: 307267e6a028bca3382d98e06a372ebf
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 521434
+  timestamp: 1729847606018
+- conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
+  sha256: 7e446bafb4d692792310ed022fe284e848c6a868c861655a92435af7368bae7b
+  md5: 3c8f2573569bb816483e5cf57efbbe29
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 9389
+  timestamp: 1726802555076
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.1.0-py311h1ea47a8_0.conda
+  sha256: 78e88b5ee2d80622091e24ba74d35f425060648735f5156ac388b1fd87169958
+  md5: 3577ae265ed894dc105829e4e0a4f40c
+  depends:
+  - libarrow-acero 18.1.0.*
+  - libarrow-dataset 18.1.0.*
+  - libarrow-substrait 18.1.0.*
+  - libparquet 18.1.0.*
+  - pyarrow-core 18.1.0 *_0_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25662
+  timestamp: 1732651904499
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.1.0-py311hdea38fa_0_cpu.conda
+  sha256: 436fc748241421e39ea72c8fcfebdad20c5c39a7dfc1d9c16dda03b97b7c317d
+  md5: 3603acae16694ed5cd689e6980eb0703
+  depends:
+  - libarrow 18.1.0.* *cpu
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy >=1.21,<3
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3498372
+  timestamp: 1732651886220
+- conda: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.27.1-py311h533ab2d_0.conda
+  sha256: 59899275bff23251aab31051bf2d63f1485d2eb36049bf5fe705c74ea4739a4e
+  md5: 07c9f9f145f2eb2f8ebef853bfe8bf6a
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - typing-extensions >=4.6.0,!=4.7.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1598009
+  timestamp: 1732254638169
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.6.1-py311h90dcb63_10.conda
+  sha256: 1211a1df2461daf499943e2f298113ab0fd72179148320609492cc5bf43bab3a
+  md5: 1105032aa8fc4803164484d2a60b3d18
+  depends:
+  - certifi
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 755087
+  timestamp: 1726680254645
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.11-h3f84c4b_1_cpython.conda
+  sha256: 5be6181ab6d655ad761490b7808584c5e78e5d7139846685b1850a8b7ef6c5df
+  md5: 4d490a426481298bdd89a502253a7fd4
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 18161635
+  timestamp: 1733408064601
+- conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-5_cp311.conda
+  sha256: 9b210e5807dd9c9ed71ff192a95f1872da597ddd10e7cefec93a922fe22e598a
+  md5: 895b873644c11ccc0ab7dba2d8513ae6
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6707
+  timestamp: 1723823225752
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-307-py311hda3d55a_3.conda
+  sha256: 78a4ede098bbc122a3dff4e0e27255e30b236101818e8f499779c89670c58cd6
+  md5: 1bc10dbe3b8d03071070c962a2bdf65f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 6023110
+  timestamp: 1728636767562
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.14-py311hda3d55a_0.conda
+  sha256: 337097e3f3b71f782c43fb702893f86f080e140da467415dcaf039a7fbb8e551
+  md5: 64553b300529aa8987f6ca92c914c844
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 210973
+  timestamp: 1729202625177
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311he736701_1.conda
+  sha256: 86608f1b4f6b1819a74b6b1344c34304745fd7e84bfc9900269f57cf28178d31
+  md5: d0c5f3c595039890be0c9af47d23b9ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 187901
+  timestamp: 1725456808581
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.2.0-py311h484c95c_3.conda
+  sha256: 4d3fc4cfac284efb83a903601586cc6ee18fb556d4bf84d3bd66af76517c463e
+  md5: 4836b00658e11b466b823216f6df2424
+  depends:
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 371084
+  timestamp: 1728642713666
+- conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+  sha256: 887d53486a37bd870da62b8fa2ebe3993f912ad04bd755e7ed7c47ced97cbaa8
+  md5: 854fbdff64b572b5c0b470f334d34c11
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LicenseRef-Qhull
+  size: 1377020
+  timestamp: 1720814433486
+- conda: https://conda.anaconda.org/conda-forge/win-64/rasterio-1.4.3-py311hf418590_0.conda
+  sha256: 2684f4cd2b59a017c7a366739e878e41c8b97d361dd16d35663c57f474c16f43
+  md5: e118112c219b3ba27c0a2b8a256206f7
+  depends:
+  - affine
+  - attrs
+  - certifi
+  - click >=4
+  - click-plugins
+  - cligj >=0.5
+  - libgdal-core >=3.10.0,<3.11.0a0
+  - numpy >=1.21,<3
+  - proj >=9.5.1,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7750486
+  timestamp: 1733164148020
+- conda: https://conda.anaconda.org/conda-forge/win-64/rav1e-0.6.6-h975169c_2.conda
+  sha256: 3193451440e5ac737b7d5d2a79f9e012d426c0c53e41e60df4992150bfc39565
+  md5: bd32cc2ed62374932f9d57a2e3eb2863
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1523119
+  timestamp: 1694330157594
+- conda: https://conda.anaconda.org/conda-forge/win-64/re2-2024.07.02-hd3b24a8_1.conda
+  sha256: 5ac1c50d731c323bb52c78113792a71c5f8f060e5767c0a202120a948e0fc85b
+  md5: b4abdc84c969587219e7e759116a3e8b
+  depends:
+  - libre2-11 2024.07.02 h4eb7d71_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 214858
+  timestamp: 1728779526745
+- conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.22.3-py311h533ab2d_0.conda
+  sha256: c74b3a4430706dfb63176429cc31410dcb86a15e1d35463aae04733c4700b8d8
+  md5: 40c964a32833f3ad13ba4183cd180577
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 222035
+  timestamp: 1733367148577
+- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py311hf16d85f_1.conda
+  sha256: bd3c3ec5ba203143818fa3ca300060a459d78da566049b49ed2ef20e04ea5b96
+  md5: b7c132408b0ee7408dcfa998ef6f7939
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15858505
+  timestamp: 1729482598163
+- conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
+  sha256: 5b9450f619aabcfbf3d284a272964250b2e1971ab0f7a7ef9143dda0ecc537b8
+  md5: 7635a408509e20dcfc7653ca305ad799
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59350
+  timestamp: 1720004197144
+- conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.47.0-h2466b09_1.conda
+  sha256: bc2a5ab86dbe2352790d1742265b3b6ae9a7aa5cf80345a37f26ec3e04cf9b4a
+  md5: 93084a590e8b7d2b62b7d5b1763d5bde
+  depends:
+  - libsqlite 3.47.0 h2466b09_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 914686
+  timestamp: 1730208443157
+- conda: https://conda.anaconda.org/conda-forge/win-64/svt-av1-2.3.0-he0c23c2_0.conda
+  sha256: c25bf68ef411d41ee29f353acc698c482fdd087426a77398b7b41ce9d968519e
+  md5: ac11ae1da661e573b71870b1191ce079
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1845727
+  timestamp: 1730246453216
+- conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-h62715c5_1.conda
+  sha256: 03cc5442046485b03dd1120d0f49d35a7e522930a2ab82f275e938e17b07b302
+  md5: 9190dd0a23d925f7602f9628b3aed511
+  depends:
+  - libhwloc >=2.11.2,<2.11.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 151460
+  timestamp: 1732982860332
+- conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+  sha256: 2c4e914f521ccb2718946645108c9bd3fc3216ba69aea20c2c3cedbd8db32bb1
+  md5: fc048363eb8f03cd1737600a5d08aafe
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: TCL
+  license_family: BSD
+  size: 3503410
+  timestamp: 1699202577803
+- conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.2-py311he736701_0.conda
+  sha256: 7e313f1724e5eb7d13f7a1ebd6026a378f3f58a638ba7cdc3bd452c01323bb29
+  md5: 7e33077ce1bc0bf45c45a92e37432f16
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 859456
+  timestamp: 1732616376731
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+  sha256: db8dead3dd30fb1a032737554ce91e2819b43496a0db09927edf01c32b577450
+  md5: 6797b005cd0f439c4c5c9ac565783700
+  constrains:
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-MicrosoftWindowsSDK10
+  size: 559710
+  timestamp: 1728377334097
+- conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-15.1.0-py311he736701_1.conda
+  sha256: 07d55566e05bbadc32e989bbe50853e579fea0f8809503719d7d1438302d27be
+  md5: 6230613721d6d805d0276025ee4d7b2b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 365349
+  timestamp: 1729705070270
+- conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
+  sha256: ed0eed8ed0343d29cdbfaeb1bfd141f090af696547d69f91c18f46350299f00d
+  md5: 28b4cf9065681f43cc567410edf8243d
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49181
+  timestamp: 1715010467661
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_23.conda
+  sha256: 986ddaf8feec2904eac9535a7ddb7acda1a1dfb9482088fdb8129f1595181663
+  md5: 7c10ec3158d1eb4ddff7007c9101adb0
+  depends:
+  - vc14_runtime >=14.38.33135
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17479
+  timestamp: 1731710827215
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34433-he29a5d6_23.conda
+  sha256: c483b090c4251a260aba6ff3e83a307bcfb5fb24ad7ced872ab5d02971bd3a49
+  md5: 32b37d0cfa80da34548501cdc913a832
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.42.34433.* *_23
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  size: 754247
+  timestamp: 1731710681163
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hdffcdeb_23.conda
+  sha256: 568ce8151eaae256f1cef752fc78651ad7a86ff05153cc7a4740b52ae6536118
+  md5: 5c176975ca2b8366abad3c97b3cd1e83
+  depends:
+  - vc14_runtime >=14.42.34433
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17572
+  timestamp: 1731710685291
+- conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: 9df10c5b607dd30e05ba08cbd940009305c75db242476f4e845ea06008b0a283
+  md5: 1cee351bf20b830d991dbe0bc8cd7dfe
+  license: MIT
+  license_family: MIT
+  size: 1176306
+- conda: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
+  sha256: 02b9874049112f2b7335c9a3e880ac05d99a08d9a98160c5a98898b2b3ac42b2
+  md5: ca7129a334198f08347fb19ac98a2de9
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 5517425
+  timestamp: 1646611941216
+- conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.2.5-he0c23c2_2.conda
+  sha256: 759ae22a0a221dc1c0ba39684b0dcf696aab4132478e17e56a0366ded519e54e
+  md5: 82b6eac3c198271e98b48d52d79726d8
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 3574017
+  timestamp: 1727734520239
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-h0e40799_1.conda
+  sha256: f44bc6f568a9697b7e1eadc2d00ef5de0fe62efcf5e27e5ecc46f81046082faf
+  md5: ca66d6f8fe86dd53664e8de5087ef6b1
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 107925
+  timestamp: 1727035280560
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.5-h0e40799_0.conda
+  sha256: 9075f98dcaa8e9957e4a3d9d30db05c7578a536950a31c200854c5c34e1edb2c
+  md5: 8393c0f7e7870b4eb45553326f81f0ff
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 69920
+  timestamp: 1727795651979
+- conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.6.3-h208afaa_1.conda
+  sha256: 636687c7ff74e37e464b57ddddc921016713f13fb48126ba8db426eb2d978392
+  md5: fce59c05fc73134677e81b7b8184b397
+  depends:
+  - liblzma 5.6.3 h2466b09_1
+  - liblzma-devel 5.6.3 h2466b09_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz-tools 5.6.3 h2466b09_1
+  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  size: 23925
+  timestamp: 1733407963901
+- conda: https://conda.anaconda.org/conda-forge/win-64/xz-tools-5.6.3-h2466b09_1.conda
+  sha256: 0cb621f748ec0b9b5edafb9a15e342f6f6f42a3f462ab0276c821a35e8bf39c0
+  md5: 4100be41430c9b2310468d3489597071
+  depends:
+  - liblzma 5.6.3 h2466b09_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - xz ==5.6.3=*_1
+  license: 0BSD AND LGPL-2.1-or-later
+  size: 63898
+  timestamp: 1733407936888
+- conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+  sha256: 4e2246383003acbad9682c7c63178e2e715ad0eb84f03a8df1fbfba455dfedc5
+  md5: adbfb9f45d1004a26763652246a33764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 63274
+  timestamp: 1641347623319
+- conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_7.conda
+  sha256: 15cc8e2162d0a33ffeb3f7b7c7883fd830c54a4b1be6a4b8c7ee1f4fef0088fb
+  md5: e03f2c245a5ee6055752465519363b1c
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 2527503
+  timestamp: 1731585151036
+- conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
+  sha256: 8c688797ba23b9ab50cef404eca4d004a948941b6ee533ead0ff3bf52012528c
+  md5: be60c4e8efa55fddc17b4131aa47acbd
+  depends:
+  - libzlib 1.3.1 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Zlib
+  license_family: Other
+  size: 107439
+  timestamp: 1727963788936
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py311h53056dc_1.conda
+  sha256: a93584e6167c3598854a47f3bf8276fa646a3bb4d12fcfc23a54e37d5879f35c
+  md5: 7d4c123cbb5e6293dd4dd2f8d30f0de4
+  depends:
+  - cffi >=1.11
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 321357
+  timestamp: 1725305930669
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+  sha256: 768e30dc513568491818fb068ee867c57c514b553915536da09e5d10b4ebf3c3
+  md5: 9a17230f95733c04dc40a2b1e5491d74
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 349143
+  timestamp: 1714723445995
+- pypi: https://files.pythonhosted.org/packages/07/51/e0f59b86f93e31d5c813dffbc31cf65b512a427849438189f3be8a156394/tsdownsample-0.1.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: tsdownsample
+  version: 0.1.3
+  sha256: 08ed25561d504aad77ba815e4d176efe80a37b8761a53bf77bb087e08ae8f54b
+  requires_dist: &id001
+  - numpy
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/1d/d4/9189084a953dbb83deceb1c43f4b834986b4137f0d83059e8cb049012d74/tsdownsample-0.1.3-cp311-cp311-macosx_10_12_x86_64.whl
+  name: tsdownsample
+  version: 0.1.3
+  sha256: 539bae2e1675af94c26c8eed67f1bb8ebfc72fe44fa17965fb324ef38cb9e70d
+  requires_dist: *id001
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/20/8a/767a70e04e4532c05f2b60dc817672e5bfec4911ca6655e8943eadf80670/h5io-0.2.4-py3-none-any.whl
+  name: h5io
+  version: 0.2.4
+  sha256: 5e05bf687b5ff13e431752167caf29a40c31f8f5bca73044b32d5bc8ef18b12e
+  requires_dist:
+  - numpy
+  - h5py
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/50/53/20e415e48ebd7fb7f39b369dd25734b82eae7217ff58bbf49b2a0c677743/tsdownsample-0.1.3-cp311-cp311-macosx_11_0_arm64.whl
+  name: tsdownsample
+  version: 0.1.3
+  sha256: f547ad4b796097d314fdc5538c50db8b073b110aae13e540cd8db4802b0317f6
+  requires_dist: *id001
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/66/ac/58ab1f1c86422cea13df0bf62dc0beb3d96f2c7831a4adcd49278df1f9fe/tsdownsample-0.1.3-cp311-none-win_amd64.whl
+  name: tsdownsample
+  version: 0.1.3
+  sha256: f97a858a855d7d84c96d3b89daa2237c80da8da12ff7a3a3d13e029d6c15e69d
+  requires_dist: *id001
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/bd/c7/56f50f023e19b0abd3ac93b86d64afdb58a16cca197441be9201bae367b7/pymatreader-1.0.0-py3-none-any.whl
+  name: pymatreader
+  version: 1.0.0
+  sha256: 32de9a3b25a8eee9eed5aeef2d2f8321f0a6d952620679415aeea8b0b53e0c5c
+  requires_dist:
+  - h5py
+  - numpy
+  - scipy>=1.7.1
+  - xmltodict
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/d6/45/fc303eb433e8a2a271739c98e953728422fa61a3c1f36077a49e395c972e/xmltodict-0.14.2-py2.py3-none-any.whl
+  name: xmltodict
+  version: 0.14.2
+  sha256: 20cc7d723ed729276e808f26fb6b3599f786cbc37e06c65e192ba77c40f20aac
+  requires_python: '>=3.6'

--- a/multichannel_timeseries/pixi.toml
+++ b/multichannel_timeseries/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "multichannel_timeseries"
-channels = ["conda-forge", "nodefaults"]
+channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/multichannel_timeseries/pixi.toml
+++ b/multichannel_timeseries/pixi.toml
@@ -1,0 +1,67 @@
+[workspace]
+name = "multichannel_timeseries"
+channels = ["conda-forge", "nodefaults"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2024-11-20"
+maintainers = ["droumis"]
+categories = ["Neuroscience", "Featured"]
+labels = ["hvplot", "panel", "holoviews", "datashader", "holonote", "bokeh", "xarray", "dask"]
+title = "Multichannel Timeseries"
+description = "Display and annotate multichannel timeseries data in Neuroscience"
+
+[dependencies]
+notebook = ">=6.5.2,<7"
+python = "3.11.*"
+numpy = ">=2.0.2"
+panel = ">=1.4.2"
+hvplot = ">=0.10.0"
+pandas = ">=2.2.1"
+holoviews = ">=1.19.0"
+datashader = ">=0.16.3"
+xarray = ">=2024.5.0,<2024.10.0"
+zarr = ">=2.18.3"
+pyarrow = ">=18.0.0"
+dask = ">=2024.11.2"
+h5py = ">=3.12.1"
+mne-lsl = ">=1.6.1"
+jupyterlab = ">=4.3.0"
+holonote = ">=0.2.1"
+pyproj = "==3.6.1"
+bokeh = ">=3.6.2"
+ndpyramid = "==0.2.0"
+pooch = ">=1.8.2"
+pip = "*"
+
+[pypi-dependencies]
+tsdownsample = ">=0.1.3"
+mne = { version = ">=1.8.0", extras = ["hdf5"] }
+h5io = "*"
+pymatreader = "*"
+xmltodict = "*"
+
+[tasks.lab]
+cmd = "jupyter lab index.ipynb"
+depends-on = ["download"]
+
+[tasks.notebook]
+cmd = "jupyter notebook index.ipynb"
+depends-on = ["download"]
+
+[tasks.dashboard]
+cmd = "panel serve --rest-session-info --session-history -1 0_multichan.ipynb --show"
+depends-on = ["download"]
+
+[tasks.download]
+depends-on = ["download-EEG_data", "download-LFP_data"]
+
+[tasks.download-EEG_data]
+env = { FILENAME = "data/S001R04.edf" }
+cmd = "mkdir -p data && curl -fsSL -o $FILENAME https://datasets.holoviz.org/eeg/v1/S001R04.edf"
+outputs = ["data/S001R04.edf"]
+
+[tasks.download-LFP_data]
+env = { FILENAME = "data/sub-719828686_ses-754312389_probe-756781563_ecephys.nwb" }
+cmd = "mkdir -p data && curl -fsSL -o $FILENAME https://datasets.holoviz.org/lfp/v1/sub-719828686_ses-754312389_probe-756781563_ecephys.nwb"
+outputs = ["data/sub-719828686_ses-754312389_probe-756781563_ecephys.nwb"]

--- a/multichannel_timeseries/pixi.toml
+++ b/multichannel_timeseries/pixi.toml
@@ -37,9 +37,9 @@ pip = "*"
 [pypi-dependencies]
 tsdownsample = ">=0.1.3"
 mne = { version = ">=1.8.0", extras = ["hdf5"] }
-h5io = "*"
-pymatreader = "*"
-xmltodict = "*"
+h5io = "*"  # promoted from anaconda-project lock
+pymatreader = "*"  # promoted from anaconda-project lock
+xmltodict = "*"  # promoted from anaconda-project lock
 
 [tasks.lab]
 cmd = "jupyter lab index.ipynb"

--- a/network_packets/pixi.lock
+++ b/network_packets/pixi.lock
@@ -7,821 +7,821 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aom-3.6.0-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blosc-1.21.3-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.3.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brunsli-0.1-h2531618_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cfitsio-3.470-h5893167_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/charls-2.2.0-h2531618_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.0-py39h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dav1d-1.2.1-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2021.9.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-0.5.0-py39h7deecbd_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/imagecodecs-2023.1.23-py39hc4b7b5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/imageio-2.31.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jxrlib-1.1-h7b6447c_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h568e23c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libaec-1.0.4-he6710b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libavif-0.11.1-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.2.1-h91b91d3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20221030-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.1.0-h9e868ea_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.52.0-ha637b67_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-h37d81fd_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libzopfli-1.0.3-he6710b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.0.1-py39h27cfd23_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py39hd09550d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.4.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.21.5-py39hf6e8229_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.21.5-py39h060ed82_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.4-py39h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.18-h7a1cb2a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py39h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-snappy-0.6.0-py39h2531618_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pywavelets-1.4.1-py39h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scikit-image-0.19.3-py39h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.9.3-py39hf6e8229_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.1.9-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/testpath-0.6.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/thrift-0.17.0-py39h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tifffile-2023.4.12-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zfp-1.0.0-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2021.9.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2021.9.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.5-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyviz_comms-2.0.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aom-3.6.0-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blosc-1.21.3-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-2.3.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brunsli-0.1-h2531618_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cfitsio-3.470-h5893167_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/charls-2.2.0-h2531618_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cytoolz-0.12.0-py39h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dav1d-1.2.1-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/distributed-2021.9.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fastparquet-0.5.0-py39h7deecbd_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/imagecodecs-2023.1.23-py39hc4b7b5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/imageio-2.31.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jxrlib-1.1-h7b6447c_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/krb5-1.20.1-h568e23c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libaec-1.0.4-he6710b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libavif-0.11.1-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libcurl-8.2.1-h91b91d3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20221030-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libllvm11-11.1.0-h9e868ea_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libnghttp2-1.52.0-ha637b67_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libssh2-1.10.0-h37d81fd_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libzopfli-1.0.3-he6710b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.0.1-py39h27cfd23_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/msgpack-python-1.0.3-py39hd09550d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.4.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/networkx-3.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.21.5-py39hf6e8229_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.21.5-py39h060ed82_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-1.4.4-py39h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.9.18-h7a1cb2a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-lmdb-1.4.1-py39h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-snappy-0.6.0-py39h2531618_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pywavelets-1.4.1-py39h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scikit-image-0.19.3-py39h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scipy-1.9.3-py39hf6e8229_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/snappy-1.1.9-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/testpath-0.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/thrift-0.17.0-py39h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tifffile-2023.4.12-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zfp-1.0.0-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zict-3.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-2021.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-core-2021.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/holoviews-1.14.5-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pyviz_comms-2.0.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2021.9.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2021.9.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.5-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyviz_comms-2.0.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aom-3.6.0-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.3.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brunsli-0.1-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/charls-2.2.0-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39ha2381d6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dav1d-1.2.1-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2021.9.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-0.5.0-py39h67323c0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/imagecodecs-2023.1.23-py39hd1bf5dc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/imageio-2.31.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jxrlib-1.1-haf1e3a3_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libaec-1.0.4-hb1e8313_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libavif-0.11.1-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20221030-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm11-11.1.0-h46f1229_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libzopfli-1.0.3-hb1e8313_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.38.0-py39h8346a28_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.0.1-py39h9ed2024_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py39haf03e11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.4.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.55.1-py39hae1ba45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.21.5-py39h47b59a4_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.21.5-py39hcfaf2c3_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-1.4.4-py39he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h218abb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-snappy-0.6.0-py39h23ab428_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pywavelets-1.4.1-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scikit-image-0.19.3-py39hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.9.3-py39hf241641_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.1.9-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/testpath-0.6.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/thrift-0.17.0-py39he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tifffile-2023.4.12-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zfp-1.0.0-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-2021.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-core-2021.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/holoviews-1.14.5-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pyviz_comms-2.0.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aom-3.6.0-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-2.3.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brunsli-0.1-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/charls-2.2.0-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39ha2381d6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cytoolz-0.12.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/dav1d-1.2.1-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/distributed-2021.9.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fastparquet-0.5.0-py39h67323c0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/imagecodecs-2023.1.23-py39hd1bf5dc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/imageio-2.31.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jxrlib-1.1-haf1e3a3_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libaec-1.0.4-hb1e8313_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libavif-0.11.1-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libedit-3.1.20221030-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libllvm11-11.1.0-h46f1229_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libzopfli-1.0.3-hb1e8313_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.38.0-py39h8346a28_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.0.1-py39h9ed2024_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/msgpack-python-1.0.3-py39haf03e11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.4.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/networkx-3.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numba-0.55.1-py39hae1ba45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.21.5-py39h47b59a4_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.21.5-py39hcfaf2c3_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-1.4.4-py39he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h218abb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-lmdb-1.4.1-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-snappy-0.6.0-py39h23ab428_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pywavelets-1.4.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scikit-image-0.19.3-py39hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scipy-1.9.3-py39hf241641_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/snappy-1.1.9-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/testpath-0.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/thrift-0.17.0-py39he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tifffile-2023.4.12-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zfp-1.0.0-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zict-3.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2021.9.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2021.9.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.5-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyviz_comms-2.0.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aom-3.6.0-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-2.3.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brunsli-0.1-hc377ac9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/charls-2.2.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39h3c57c4d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dav1d-1.2.1-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2021.9.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-0.5.0-py39heec5a64_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fftw-3.3.9-h1a28f6b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/imagecodecs-2023.1.23-py39h604db08_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/imageio-2.31.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jxrlib-1.1-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lazy_loader-0.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libaec-1.0.4-hc377ac9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libavif-0.11.1-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20221030-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm11-11.1.0-h12f7ac0_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzopfli-1.0.3-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.38.0-py39h98b2900_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.0.1-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py39h525c30c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.4.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.55.1-py39h9197a36_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.21.5-py39h42add53_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.21.5-py39hadd41eb_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-1.4.4-py39hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hc0d8a6c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-snappy-0.6.0-py39hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pywavelets-1.4.1-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scikit-image-0.20.0-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.9.1-py39h9d039d2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.1.9-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/testpath-0.6.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/thrift-0.17.0-py39hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tifffile-2023.4.12-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zfp-1.0.0-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-2021.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-core-2021.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/holoviews-1.14.5-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pyviz_comms-2.0.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aom-3.6.0-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-2.3.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brunsli-0.1-hc377ac9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/charls-2.2.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39h3c57c4d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cytoolz-0.12.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/dav1d-1.2.1-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/distributed-2021.9.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fastparquet-0.5.0-py39heec5a64_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fftw-3.3.9-h1a28f6b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/imagecodecs-2023.1.23-py39h604db08_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/imageio-2.31.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jxrlib-1.1-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lazy_loader-0.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libaec-1.0.4-hc377ac9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libavif-0.11.1-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libedit-3.1.20221030-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libllvm11-11.1.0-h12f7ac0_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libzopfli-1.0.3-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.38.0-py39h98b2900_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.0.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/msgpack-python-1.0.3-py39h525c30c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.4.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/networkx-3.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numba-0.55.1-py39h9197a36_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.21.5-py39h42add53_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.21.5-py39hadd41eb_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-1.4.4-py39hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hc0d8a6c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-lmdb-1.4.1-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-snappy-0.6.0-py39hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pywavelets-1.4.1-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scikit-image-0.20.0-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.9.1-py39h9d039d2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/snappy-1.1.9-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/testpath-0.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/thrift-0.17.0-py39hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tifffile-2023.4.12-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zfp-1.0.0-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zict-3.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2021.9.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2021.9.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.5-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyviz_comms-2.0.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aom-3.6.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-2.3.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/charls-2.2.0-h6c2663c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h3438e0d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/dav1d-1.2.1-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2021.9.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-0.5.0-py39h080aedc_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/imagecodecs-2023.1.23-py39h6c6a46e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/imageio-2.31.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libaec-1.0.4-h33f27b4_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libavif-0.11.1-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libzopfli-1.0.3-ha925a31_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.38.0-py39h23ce68f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.0.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.4.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.55.1-py39hf11a4ad_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.21.5-py39h6917f2d_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.21.5-py39h46c4fa8_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-1.4.4-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h6244533_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-snappy-0.6.0-py39hd77b12b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywavelets-1.4.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scikit-image-0.19.3-py39hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.9.3-py39hdcfc7df_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.1.9-h6c2663c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/testpath-0.6.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/thrift-0.17.0-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tifffile-2023.4.12-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zfp-1.0.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-2021.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/dask-core-2021.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/holoviews-1.14.5-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pyviz_comms-2.0.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aom-3.6.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-2.3.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/charls-2.2.0-h6c2663c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h3438e0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cytoolz-0.12.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/dav1d-1.2.1-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/distributed-2021.9.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fastparquet-0.5.0-py39h080aedc_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/imagecodecs-2023.1.23-py39h6c6a46e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/imageio-2.31.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libaec-1.0.4-h33f27b4_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libavif-0.11.1-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libzopfli-1.0.3-ha925a31_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/llvmlite-0.38.0-py39h23ce68f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/msgpack-python-1.0.3-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-6.4.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/networkx-3.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numba-0.55.1-py39hf11a4ad_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.21.5-py39h6917f2d_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.21.5-py39h46c4fa8_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h6244533_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-lmdb-1.4.1-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-snappy-0.6.0-py39hd77b12b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywavelets-1.4.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scikit-image-0.19.3-py39hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scipy-1.9.3-py39hdcfc7df_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/snappy-1.1.9-h6c2663c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/testpath-0.6.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/thrift-0.17.0-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tifffile-2023.4.12-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zfp-1.0.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zict-3.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
   sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
   md5: 613805add1c05b538ff06d217252feb7
   depends:
@@ -832,7 +832,7 @@ packages:
   license: BSD-3-Clause
   size: 20810
   timestamp: 1652859733309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
   sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
   md5: 2cf39d906cc321896ffe3e5d33d80c5c
   depends:
@@ -845,7 +845,7 @@ packages:
   license_family: MIT
   size: 162166
   timestamp: 1644463608931
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aom-3.6.0-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aom-3.6.0-h6a678d5_0.tar.bz2
   sha256: daddb86497522fd6fb8447c0aaebb763e685348b86fadb4ca6425f50f9d85f08
   md5: 2d31ed3210e7119160eb02564154b4c1
   depends:
@@ -855,7 +855,7 @@ packages:
   license_family: BSD
   size: 2958771
   timestamp: 1688660715607
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
   sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
   md5: 2972a84e0e22ae3244bbd2f1eebcf536
   depends:
@@ -866,7 +866,7 @@ packages:
   license_family: MIT
   size: 35352
   timestamp: 1644569715988
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
   sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
   md5: a68016b4b06460def24cb69d932986f3
   depends:
@@ -875,7 +875,7 @@ packages:
   license_family: MIT
   size: 132486
   timestamp: 1695717963702
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
   sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
   md5: 2f6356a2f530314b4059c08c79a3d8bc
   depends:
@@ -885,12 +885,12 @@ packages:
   license_family: MIT
   size: 205868
   timestamp: 1681493113570
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blosc-1.21.3-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blosc-1.21.3-h6a678d5_0.tar.bz2
   sha256: 10b48986cb0e0c974477ac3a58aaae198270b01f19cbd3e900143c6558fa3424
   md5: 202b4629c225257fc01a4a2180c4e2f7
   depends:
@@ -903,7 +903,7 @@ packages:
   license_family: BSD
   size: 65491
   timestamp: 1675247642609
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.3.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-2.3.3-py39h06a4308_0.tar.bz2
   sha256: c97515490688900b9afd59dbff8ca2b0d1edae49b9af7c4b1cbddb874b6e0163
   md5: d0c0e898049739c075d026891c7de3cf
   depends:
@@ -920,7 +920,7 @@ packages:
   license_family: BSD
   size: 8690186
   timestamp: 1625767563920
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
   sha256: 20e381c665853131fc5c9a397b1d4b05bb05859a2bdfbb0559e85ec445ee9e7c
   md5: 14dc3c2e8eb68b1111a08de9a3ce8a00
   depends:
@@ -931,7 +931,7 @@ packages:
   license_family: BSD
   size: 128656
   timestamp: 1657175966755
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
   sha256: 11df9b719339bb40e4af8eb124a094def217f64e2440af973d7342da19c030b0
   md5: 712827b1699cc71e6240626c413408f3
   depends:
@@ -942,7 +942,7 @@ packages:
   license: MIT
   size: 18907
   timestamp: 1659616178155
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
   sha256: 6408b6849347ef01f5ed170f4b35fb4bdfed2d9cf9da4912a4b104a810518a80
   md5: d9d570587ccfd7158b66feb823c990c6
   depends:
@@ -952,7 +952,7 @@ packages:
   license: MIT
   size: 19933
   timestamp: 1659616170430
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
   sha256: 8507df3357958556aff2dea8788a3f7ddad6172fd9fe5d1bdb6c3afe9686d2f8
   md5: f0204f72bcd9ef836218cc74345e69f2
   depends:
@@ -962,7 +962,7 @@ packages:
   license: MIT
   size: 362180
   timestamp: 1659616255400
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brunsli-0.1-h2531618_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brunsli-0.1-h2531618_0.tar.bz2
   sha256: 3a2778321f5ef815cd8aa4bf37bb1532b31656c1bf5310738146e7081b177b3e
   md5: dc6cf5631ada26a03b237ef19e90cfd6
   depends:
@@ -973,7 +973,7 @@ packages:
   license_family: MIT
   size: 203551
   timestamp: 1611240485163
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
   sha256: 168c2fc4d5899ee70e85fadc998e00827e1b856a6fc4a402ed465cd7c320d19f
   md5: f52e60deb7f4c82821be9a868e889348
   depends:
@@ -982,7 +982,7 @@ packages:
   license_family: BSD
   size: 107105
   timestamp: 1563219611337
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
   sha256: 5b4c80587ae4ec915505469f79d866f27c80456156667c8548d31c67c2c1653e
   md5: c3d6bfae757760082261779c406a880d
   depends:
@@ -991,14 +991,14 @@ packages:
   license_family: MIT
   size: 116270
   timestamp: 1693902021950
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
   sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
   md5: 3ef00f4c5278b688552efc259c463dc8
   license: MPL-2.0
   license_family: Other
   size: 132731
   timestamp: 1694009767372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
   sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
   md5: d5cb3d97cf5e85ffe5e94037ed8a1169
   depends:
@@ -1007,7 +1007,7 @@ packages:
   license_family: Other
   size: 159077
   timestamp: 1690232254640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
   sha256: e99314f8809d65195dcab68a9783f70fbe990113a66c98c9b0a7ffea01226b71
   md5: fff69f95079191a10e099b21a5fd4bc3
   depends:
@@ -1019,7 +1019,7 @@ packages:
   license_family: MIT
   size: 234749
   timestamp: 1670423281079
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cfitsio-3.470-h5893167_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cfitsio-3.470-h5893167_7.tar.bz2
   sha256: a4a855659e4a52515b940d1b9d8204b626c11395980e99539b24f52d658e1857
   md5: 65a71d60ece0bd684f1be09b48de8d00
   depends:
@@ -1033,7 +1033,7 @@ packages:
   license_family: Other
   size: 1384722
   timestamp: 1655814890848
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/charls-2.2.0-h2531618_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/charls-2.2.0-h2531618_0.tar.bz2
   sha256: ff4a1d243f3ffbcc677b1db7b5c7af06492f2910a0f1eea6664ad0ea3125835c
   md5: 310b9390fc05d62245c9f95ac96ac376
   depends:
@@ -1043,7 +1043,7 @@ packages:
   license_family: BSD
   size: 132255
   timestamp: 1612240399775
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
   sha256: 762f4506c3e12b2332bd9abea3a2a1966f307b2673be7fd661dc6e316602d18b
   md5: 4b8df5459d1762495428323753438641
   depends:
@@ -1052,7 +1052,7 @@ packages:
   license_family: BSD
   size: 151844
   timestamp: 1698129872673
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
   sha256: 4fd0207b930fbc936d4b8206117cfa9792aa19bfb320eb08aab6bba10002f9ee
   md5: 7082a1ce8fa314cc2761d2f689c6bb9e
   depends:
@@ -1061,7 +1061,7 @@ packages:
   license_family: BSD
   size: 40456
   timestamp: 1683040035572
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
   sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
   md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
   depends:
@@ -1071,7 +1071,7 @@ packages:
   license_family: CC
   size: 1917831
   timestamp: 1668084545510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
   sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
   md5: 13702d3b4b744784e5bd559c7050dd6f
   depends:
@@ -1081,7 +1081,7 @@ packages:
   license_family: BSD
   size: 12719
   timestamp: 1671231205875
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
   sha256: 0b1a9a25ddfc6631390c53d6ee95706eaab0805c5a9a8d748c08120a1f421256
   md5: a93581f810ef522bd23c148195591157
   depends:
@@ -1093,7 +1093,7 @@ packages:
   license_family: BSD
   size: 234846
   timestamp: 1663827645102
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
   sha256: 821af57c20a85b4e92268fbf65fbaec2f273da5bb21889d9643756ef6e473237
   md5: f57e0f502500ffebdbec081ef61ad1d4
   depends:
@@ -1107,7 +1107,7 @@ packages:
   license_family: BSD
   size: 2179774
   timestamp: 1694445209134
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.0-py39h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cytoolz-0.12.0-py39h5eee18b_0.tar.bz2
   sha256: aac94702b3d4e4767f0bbbe3f1acfa811e18a2abb66f3afac74a51ddc3d046d9
   md5: 4c34345079d18b1203746067dcd15042
   depends:
@@ -1118,7 +1118,7 @@ packages:
   license_family: BSD
   size: 394960
   timestamp: 1667466037849
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
   sha256: 80188a9729a26e36b027e673f5f30395798eb68f9fe4721f3f33b4d4d2e58285
   md5: 686db307602cbbdc30ca7d62b765578b
   depends:
@@ -1130,7 +1130,7 @@ packages:
   license_family: BSD
   size: 103488
   timestamp: 1613390248313
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dav1d-1.2.1-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dav1d-1.2.1-h5eee18b_0.tar.bz2
   sha256: 9f015999d24a376602b5876f542bcb41a7db66fa73064091cccdc1b06195392c
   md5: 29684f3832212a3c977960c62c421119
   depends:
@@ -1139,7 +1139,7 @@ packages:
   license_family: BSD
   size: 889577
   timestamp: 1688746033126
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
   sha256: 96b5d4c87d8467ae6ba92f9c17eaa9e059b6f7e9b8ee57aee788885c7413078b
   md5: 9868912fd269f4d9d6423cfe69560131
   depends:
@@ -1150,7 +1150,7 @@ packages:
   license_family: MIT
   size: 2164334
   timestamp: 1690905228819
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2021.9.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/distributed-2021.9.1-py39h06a4308_0.tar.bz2
   sha256: cd25a05af68707a7314fd8fc6c62d87e363d58969095cd1dd96375b292b9212a
   md5: 198a950942a9eca96672b46444928289
   depends:
@@ -1175,7 +1175,7 @@ packages:
   license_family: BSD
   size: 1116020
   timestamp: 1634741468527
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
   sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
   md5: 2e6ec51066d825ef3c317abe78d6049e
   depends:
@@ -1184,7 +1184,7 @@ packages:
   license_family: MIT
   size: 16413
   timestamp: 1649926472708
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
   sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
   md5: b4d923222d45314856b5378cb115214d
   depends:
@@ -1193,7 +1193,7 @@ packages:
   license_family: BSD
   size: 26728
   timestamp: 1668714462023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-0.5.0-py39h7deecbd_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fastparquet-0.5.0-py39h7deecbd_2.tar.bz2
   sha256: 003e760b30ed5e9322c3dac37feea0552ebb9b5e92d0b1a10267592154fdc675
   md5: a9d854d6c96221d50f85a8b12e48c162
   depends:
@@ -1210,7 +1210,7 @@ packages:
   license_family: Apache
   size: 191820
   timestamp: 1658500763114
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
   sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
   md5: a5dc8677d891dff2393b63189a3ad42f
   depends:
@@ -1221,7 +1221,7 @@ packages:
   license_family: Other
   size: 971975
   timestamp: 1666798278693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
   sha256: cfef2f1f3f1aa159f87806b7fa2b65c02c0d6f9bd24ccda833b43246c5095be6
   md5: 394ec1374a92c6fd5f772343934337e4
   depends:
@@ -1230,7 +1230,7 @@ packages:
   license_family: BSD
   size: 260575
   timestamp: 1695734561396
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
   sha256: c323a9800a358c178f6f3b8860bbb77c373fbc3be981bb6420175fbb5431adf5
   md5: 6485f51176cf651b3b28c3548cef10ad
   depends:
@@ -1239,7 +1239,7 @@ packages:
   license_family: MIT
   size: 78533
   timestamp: 1676983203797
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
   sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
   md5: 1eb52f9f45cea2fb9ce27b19f990160e
   depends:
@@ -1248,7 +1248,7 @@ packages:
   license_family: BSD
   size: 110793
   timestamp: 1666125606878
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/imagecodecs-2023.1.23-py39hc4b7b5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/imagecodecs-2023.1.23-py39hc4b7b5f_0.tar.bz2
   sha256: 25a222ded2ee539c142e0c34a2bd49a2e7fda561b3359c99241b773fcd4f5010
   md5: 37c9408a5968471a536ce68d6236361f
   depends:
@@ -1287,7 +1287,7 @@ packages:
   license_family: BSD
   size: 10674908
   timestamp: 1695066538869
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/imageio-2.31.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/imageio-2.31.4-py39h06a4308_0.tar.bz2
   sha256: 6fc4b8698f4e81f0bb1394a1ced9c2a8de92e9cd03d967820a2333a3c0eb58ff
   md5: 282ce4456f36647b4e39826335d3e913
   depends:
@@ -1298,7 +1298,7 @@ packages:
   license_family: BSD
   size: 508868
   timestamp: 1695996560599
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
   sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
   md5: 126b3c1933b7364ff03f67455b687e99
   depends:
@@ -1308,7 +1308,7 @@ packages:
   license_family: APACHE
   size: 37588
   timestamp: 1678997134023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
   sha256: b6d5f6098903e5edfbc2200282efa186d446442d47ab75f51ff22c30ae0c4da4
   md5: e53a806995cedc9e5d8a96e03c9e79ac
   depends:
@@ -1318,7 +1318,7 @@ packages:
   license_family: Apache
   size: 50699
   timestamp: 1698254665788
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
   sha256: bddc8de31272a509510cc87e5ac0cdb0e7765d393ca7bdfddbfe4123979a9413
   md5: bc8a501970aadad3373edbce996b5fdf
   depends:
@@ -1334,7 +1334,7 @@ packages:
   license_family: Proprietary
   size: 19286333
   timestamp: 1681801301379
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
   sha256: c0d0714c68ed953740812688ac1b3c3e286de33b55d49f02953d705fb00c30d0
   md5: 8b65eea396159a3b59278f77c81ddd1b
   depends:
@@ -1355,7 +1355,7 @@ packages:
   license_family: BSD
   size: 217268
   timestamp: 1691122070319
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
   sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
   md5: ff47e0be879e817713ce2a9daa76e2b0
   depends:
@@ -1376,7 +1376,7 @@ packages:
   license_family: BSD
   size: 1261116
   timestamp: 1694181530670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
   sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
   md5: 5ef6c6a0d1ac79143c7359d305155167
   depends:
@@ -1386,7 +1386,7 @@ packages:
   license_family: MIT
   size: 1021637
   timestamp: 1644297140650
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
   sha256: c21f8f407266d039e819c27fe9eb4fb26587e974f3bd059b37cbaec5073722d0
   md5: ba1f47411e9e07876c7a3e9d3be6a98e
   depends:
@@ -1395,7 +1395,7 @@ packages:
   license_family: Other
   size: 281400
   timestamp: 1677849152168
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
   sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
   md5: 0d2c3c5edf671b575532d5a3e8bf15fc
   depends:
@@ -1406,7 +1406,7 @@ packages:
   license_family: MIT
   size: 131510
   timestamp: 1676558716852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
   sha256: 4ba1f5698f0b483af397021b2047554afb3129790cac3a1502c79693154331d2
   md5: 8e9c0ef4b0b57caa87c146892e56a313
   depends:
@@ -1422,7 +1422,7 @@ packages:
   license_family: BSD
   size: 192921
   timestamp: 1676329415827
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
   sha256: 0192bd48cd96c60dc3054d5addd8cdb4a29a218843181318371f79daec8242f8
   md5: d851b401dc13d04e6848bb36e12efc1c
   depends:
@@ -1433,7 +1433,7 @@ packages:
   license_family: BSD
   size: 91534
   timestamp: 1679906652183
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
   sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
   md5: a4beb461f0a60998a090d760b5c6c907
   depends:
@@ -1457,7 +1457,7 @@ packages:
   license_family: BSD
   size: 411564
   timestamp: 1671707702849
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jxrlib-1.1-h7b6447c_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jxrlib-1.1-h7b6447c_2.tar.bz2
   sha256: 46fa3b9ce2790a2efd328560b7e76f6716c92288702ced1f63168f22bad487d0
   md5: e1ae8a1211dfebe4c60b7e755200a327
   depends:
@@ -1466,7 +1466,7 @@ packages:
   license_family: BSD
   size: 244049
   timestamp: 1593197090424
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
   sha256: 6d6c384c9c65e33d5d047e01131e0687eb2bc1e5a4a67f80af3c0b773c1bba82
   md5: 07957e1d2fb6a407f7d7293b84938e1e
   depends:
@@ -1477,7 +1477,7 @@ packages:
   license_family: BSD
   size: 77689
   timestamp: 1672387301020
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h568e23c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/krb5-1.20.1-h568e23c_1.tar.bz2
   sha256: 126a5fd5e59cc90c1a2c688a801dea7f352f0bb218c2f949d0f3d21db35fbe1b
   md5: 64d1d86c812dc1843bcbb4cab2e8f60f
   depends:
@@ -1489,7 +1489,7 @@ packages:
   license_family: MIT
   size: 1426697
   timestamp: 1686931184185
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -1500,7 +1500,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
   sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
   md5: 9508af80612e4fa1b5d1abb43ca7e63c
   constrains:
@@ -1508,7 +1508,7 @@ packages:
   license: GPL-3.0-only
   size: 749072
   timestamp: 1652971360657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
   sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
   md5: 88199c75f2ac211728febced7785c24e
   depends:
@@ -1518,7 +1518,7 @@ packages:
   license_family: Apache
   size: 228278
   timestamp: 1635523146417
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libaec-1.0.4-he6710b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libaec-1.0.4-he6710b0_1.tar.bz2
   sha256: 860ecdf2e21768f806f9c0d272e92dbc521b249a7171b0def500a30937fb079a
   md5: e911ac853b19bd7073f1047699e2118e
   depends:
@@ -1528,7 +1528,7 @@ packages:
   license_family: BSD
   size: 35409
   timestamp: 1593197267510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libavif-0.11.1-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libavif-0.11.1-h5eee18b_0.tar.bz2
   sha256: 0eccc12a46c14a730a55569f28a170bd315aad9df6ae7e13eba7732e6317f3df
   md5: 5974603ff942f18b40e5156dd6819410
   depends:
@@ -1539,7 +1539,7 @@ packages:
   license_family: BSD
   size: 105392
   timestamp: 1689158136084
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
   sha256: 472cf888db65d00451fcd5fccd5244d55c061e8d7efe43f70220414ef64521a5
   md5: 787927eff72e62c270f614cbcba9479c
   depends:
@@ -1547,7 +1547,7 @@ packages:
   license: MIT
   size: 67109
   timestamp: 1659616145972
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
   sha256: 19a43182ca343510ba51baa0fce91d64c840a19cdf13c6dde4e03e819c70897e
   md5: c0608d376a30b5aa4d2f2c22978135db
   depends:
@@ -1556,7 +1556,7 @@ packages:
   license: MIT
   size: 34691
   timestamp: 1659616154057
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
   sha256: 158c401aa0bab05aa5f4134aea798085e4e3849209946f896cca352930d2225d
   md5: cc6a6d362912a2d112310bd3f8acd44e
   depends:
@@ -1565,7 +1565,7 @@ packages:
   license: MIT
   size: 295287
   timestamp: 1659616162282
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.2.1-h91b91d3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libcurl-8.2.1-h91b91d3_0.tar.bz2
   sha256: 8daa34822b26916b12867746d55790aa5b719e096e412aba86c5a9f13b19ee36
   md5: bd594551d7447f93c8a1575be1b1f12e
   depends:
@@ -1581,7 +1581,7 @@ packages:
   license_family: MIT
   size: 386369
   timestamp: 1693515365220
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
   sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
   md5: 55dde57e63a36b202e388a39dcee9a66
   depends:
@@ -1590,7 +1590,7 @@ packages:
   license_family: MIT
   size: 74096
   timestamp: 1695996494461
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20221030-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20221030-h5eee18b_0.tar.bz2
   sha256: 5d66a60672f8e7dd0c048b5f158b5d406f16133b260ffde95a93eb453a1e7af9
   md5: af7584851084abae8eaa8cee2ed288b4
   depends:
@@ -1600,7 +1600,7 @@ packages:
   license_family: BSD
   size: 195621
   timestamp: 1670840131081
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
   sha256: efdab884c85fda4461f7a393aa6d4e0e50d03cb59fb9c8a980b1307b8379ebe0
   md5: eeca774c6154c49340dd403b1928d5e9
   depends:
@@ -1609,7 +1609,7 @@ packages:
   license_family: BSD
   size: 108906
   timestamp: 1632891483341
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
   sha256: ec1c6341cf0091b55be05285037cb3fbba90573e00257f383ab274d8b8e6d46f
   md5: 32ac65d639d6c155ea7276cadf1fd2b6
   depends:
@@ -1619,7 +1619,7 @@ packages:
   license_family: MIT
   size: 147907
   timestamp: 1683716564178
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
   sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
   md5: 641e72e5067bd6d5454405879e1cd2a7
   depends:
@@ -1634,7 +1634,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 8895144
   timestamp: 1654090827491
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
   sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
   md5: 27082517590f3b9fbffecc68513b461b
   depends:
@@ -1643,7 +1643,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 19860
   timestamp: 1654090819660
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
   sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
   md5: 0202c3c8ae4735cac6c7f3d1e1685964
   constrains:
@@ -1651,7 +1651,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 5228750
   timestamp: 1654090762569
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
   sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
   md5: 3080c2813e6e1d0f8a100a38b5b3456d
   depends:
@@ -1659,7 +1659,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 573231
   timestamp: 1654090775721
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.1.0-h9e868ea_6.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libllvm11-11.1.0-h9e868ea_6.tar.bz2
   sha256: 0fd833e8a519f75e2c4b6cdbec75b8fffc1cd015b2b795d1566855e486705736
   md5: c2b4c6491de2bf531083a51092ecd077
   depends:
@@ -1670,7 +1670,7 @@ packages:
   license_family: Apache
   size: 30349190
   timestamp: 1665079289108
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.52.0-ha637b67_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libnghttp2-1.52.0-ha637b67_1.tar.bz2
   sha256: 71a65b3c05426b92e8a3002e7d42cd303255439f8a4442b4fc5aa882aef3128e
   md5: 113b010119638c67e3b6c8570d88f5be
   depends:
@@ -1686,7 +1686,7 @@ packages:
   license_family: MIT
   size: 716614
   timestamp: 1686931412665
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
   sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
   md5: 1bffe1481ed4f88827248fb9001f8923
   depends:
@@ -1696,7 +1696,7 @@ packages:
   license_family: Other
   size: 362561
   timestamp: 1677841789536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -1704,7 +1704,7 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-h37d81fd_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libssh2-1.10.0-h37d81fd_2.tar.bz2
   sha256: 41f2e9a088031bd209d50f37f727fb9647be9316db3e149f9f2bac0057f7184d
   md5: 778c268743d6cf857178bd1ecf6c9525
   depends:
@@ -1714,7 +1714,7 @@ packages:
   license_family: BSD
   size: 311794
   timestamp: 1686931200150
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
   sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
   md5: 8c195584a5f5471b600ee180e4052773
   depends:
@@ -1722,7 +1722,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 6410287
   timestamp: 1654090800863
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
   sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
   md5: ef78eebd98289aceacdfa29182426adf
   depends:
@@ -1740,7 +1740,7 @@ packages:
   license_family: Other
   size: 664034
   timestamp: 1693575237924
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
   sha256: c6aecee300c8e84a99056307ed3bdc047edd5366e55230a4eabe3ee5e8082bb8
   md5: 3a6ebf9895b1085a23783cd95460a629
   depends:
@@ -1755,7 +1755,7 @@ packages:
   license_family: BSD
   size: 88424
   timestamp: 1694778218406
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
   sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
   md5: 9cdeef1d044c7e035c006890f11569d3
   depends:
@@ -1766,7 +1766,7 @@ packages:
   license_family: BSD
   size: 436056
   timestamp: 1694776944891
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libzopfli-1.0.3-he6710b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libzopfli-1.0.3-he6710b0_0.tar.bz2
   sha256: 04e6f97332bc583ad380f0dc6f3f38c766fe15900c29f52c8097b7743ef2b417
   md5: 6d276711374079b0d91ea31ecbe27b31
   depends:
@@ -1776,7 +1776,7 @@ packages:
   license_family: Apache
   size: 183622
   timestamp: 1593197391897
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
   sha256: 497e0a8e555539787dd237dea5d13a0a6061db2cb50ded20daddaf08bbf267cc
   md5: ecc0c3c465bbf6988ebbc6a38e2eeb1c
   depends:
@@ -1788,7 +1788,7 @@ packages:
   license: BSD-2-Clause
   size: 2826845
   timestamp: 1647870510956
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
   sha256: d8cd22ac7f033507549f6a0d078cd273607cb6e8246b0383375a33941969c12c
   md5: 78c7a3a437536ae24d2d7ce15ec400d2
   depends:
@@ -1797,7 +1797,7 @@ packages:
   license_family: BSD
   size: 11065
   timestamp: 1652903210940
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
   sha256: 36b23ab8d8aa22d70a2f733462cabe95e5b27ca919ec7a75a5592bc39c5f7d16
   md5: f24adbfdfe16b0bac0d14640bb5ce616
   depends:
@@ -1807,7 +1807,7 @@ packages:
   license_family: BSD
   size: 163649
   timestamp: 1670944701605
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
   sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
   md5: 421f82c8274b44660dba629134faa6af
   depends:
@@ -1817,7 +1817,7 @@ packages:
   license_family: BSD
   size: 122221
   timestamp: 1671541990505
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.0.1-py39h27cfd23_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.0.1-py39h27cfd23_0.tar.bz2
   sha256: fe70281280902597f453c539de0391b9794d6272a1310e79e36be224204f2032
   md5: d41111388cfceda1904958476da096a1
   depends:
@@ -1827,7 +1827,7 @@ packages:
   license_family: BSD
   size: 23039
   timestamp: 1621523521377
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
   sha256: 10701d3065424bbef89c03a30c4adecd67308cd2f76e0d873aad6a180d9fe097
   md5: e196f6bace29ef34f0a996ef1c99f193
   depends:
@@ -1850,7 +1850,7 @@ packages:
   license_family: PSF
   size: 8129476
   timestamp: 1698692330174
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
   sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
   md5: c04ef34af33da4c71bcc99b7ec24d210
   depends:
@@ -1860,7 +1860,7 @@ packages:
   license_family: BSD
   size: 16391
   timestamp: 1662014553452
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
   sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
   md5: f6c734d73e6e3dbc1b62766cf18ff3e4
   depends:
@@ -1870,7 +1870,7 @@ packages:
   license_family: BSD
   size: 58153
   timestamp: 1607364912263
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
   sha256: c7dedf41acbb2a065364f949ba24479449387d54c095220ff89346d266b25347
   md5: c5f96c8ff7102e1d673829bbeb8bed84
   depends:
@@ -1884,7 +1884,7 @@ packages:
   license_family: Proprietary
   size: 206706869
   timestamp: 1691503234180
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
   sha256: 984f547627b0af8358fa83b2396e0b2c014f9bc281304b6b8d3ff139a3f04b40
   md5: 724d2559e0ed50aa0eee97c919134ded
   depends:
@@ -1895,7 +1895,7 @@ packages:
   license_family: BSD
   size: 58512
   timestamp: 1682948511810
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
   sha256: 650419991b99b810e79221e35e5a6c3e49240ed30ff3e5324eecf1cefd276110
   md5: a14b8155afdb15f3bce72e67925c0ceb
   depends:
@@ -1909,7 +1909,7 @@ packages:
   license_family: BSD
   size: 227382
   timestamp: 1695058347376
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
   sha256: 7b0eeb8acc4c6b9f45b214fbc991a4073a59a8f7b798a4cc86515b97f7af6355
   md5: eb48e45fd8d61762290e4289a52be3f7
   depends:
@@ -1924,7 +1924,7 @@ packages:
   license_family: BSD
   size: 329190
   timestamp: 1695059874042
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py39hd09550d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/msgpack-python-1.0.3-py39hd09550d_0.tar.bz2
   sha256: a138d682379358886f9d8c1e81da8d126c5cb1f0eff50e236ed471ea5b0b9d24
   md5: 5b2574b896f022cf33ed9a871aacabb3
   depends:
@@ -1935,7 +1935,7 @@ packages:
   license_family: Apache
   size: 90177
   timestamp: 1652362815706
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
   sha256: 305313d215116fbf13a38f8a321eb635b83294871801ac63e543a59ba7de642c
   md5: e0db8ae050bd0db74f47edc370dbc287
   depends:
@@ -1945,7 +1945,7 @@ packages:
   license_family: BSD
   size: 24480
   timestamp: 1607574279743
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
   sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
   md5: 95c83d71814c504b5504df4f14548f1a
   depends:
@@ -1971,7 +1971,7 @@ packages:
   license_family: BSD
   size: 8257558
   timestamp: 1681756322140
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
   sha256: 1b92d72b083f3350359b8fb2e3b5dc846f49650c9e46a6a74354b1b7f0d42730
   md5: 996babe4314515ddd41008a53cb5d47f
   depends:
@@ -1984,7 +1984,7 @@ packages:
   license_family: BSD
   size: 98791
   timestamp: 1650290544347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.4.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.4.4-py39h06a4308_0.tar.bz2
   sha256: 949f10a2e5dc054c739765c4785e8fe13181b992fddf2adc480e57686eb9453c
   md5: d263e3cdf799476e21315a41eaed3a89
   depends:
@@ -2009,7 +2009,7 @@ packages:
   license_family: BSD
   size: 568158
   timestamp: 1649752009070
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
   sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
   md5: 385cc9e53404776782502c0fdb08820f
   depends:
@@ -2022,7 +2022,7 @@ packages:
   license_family: BSD
   size: 147046
   timestamp: 1694616899309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
   sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
   md5: 57ea097dc15f8d9f9eb90e1d919143b0
   depends:
@@ -2031,7 +2031,7 @@ packages:
   license_family: MIT
   size: 1157733
   timestamp: 1674734069410
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
   sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
   md5: bbbcbebc20a4fdcadce398d0ca04f95e
   depends:
@@ -2040,7 +2040,7 @@ packages:
   license_family: BSD
   size: 13109
   timestamp: 1672387143252
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/networkx-3.1-py39h06a4308_0.tar.bz2
   sha256: 75a4858adf42d03e1ef52ea0083d7665bf3426607367cad661077199951b18a4
   md5: 357296e49c55733ecc879ffe5d612116
   depends:
@@ -2049,7 +2049,7 @@ packages:
   license_family: BSD
   size: 2955832
   timestamp: 1690562037565
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
   sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
   md5: 248ce515640465371927d46f389ed555
   depends:
@@ -2074,7 +2074,7 @@ packages:
   license_family: BSD
   size: 594054
   timestamp: 1690985006481
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
   sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
   md5: 70db71df4ee1cdd38090c0f7b80ba61f
   depends:
@@ -2084,7 +2084,7 @@ packages:
   license_family: BSD
   size: 21944
   timestamp: 1668160644514
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
   sha256: 30f95c6c51ee7ca01801778b1773d8ecb57fcf06e864093f27148e1298517c20
   md5: 1c1f0821f0dd2ece64844f39edcbd03f
   depends:
@@ -2107,7 +2107,7 @@ packages:
   license_family: BSD
   size: 3982289
   timestamp: 1648045822890
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
   sha256: e61fc626f7131f1857c703ad3bb4dcacfc6b1fd6d5da545aa8f600b840315aca
   md5: 6b689e52e3ba1fa7caaab3e6be31860c
   depends:
@@ -2122,7 +2122,7 @@ packages:
   license_family: MIT
   size: 141434
   timestamp: 1696515497148
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.21.5-py39hf6e8229_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.21.5-py39hf6e8229_4.tar.bz2
   sha256: 1e3bd69c628c9c460a99a39433384797613e2c2dc122da6073da83d0aeeb0eff
   md5: 17c5648c13f4e1a064f4b14831737f62
   depends:
@@ -2138,7 +2138,7 @@ packages:
   license: BSD-3-Clause
   size: 10146
   timestamp: 1682951728416
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.21.5-py39h060ed82_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.21.5-py39h060ed82_4.tar.bz2
   sha256: 5de427603f36549a140cc9d69d35bf2f845483973f33477b7f4d77e6fc007de3
   md5: 66cc9d79973f5588aeb44a1f8d16b3f8
   depends:
@@ -2153,7 +2153,7 @@ packages:
   license: BSD-3-Clause
   size: 6464938
   timestamp: 1682951713892
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
   sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
   md5: b0afe23033c8c5344640bc25225fa579
   depends:
@@ -2164,7 +2164,7 @@ packages:
   license: BSD 2-Clause
   size: 516994
   timestamp: 1630084830020
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
   sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
   md5: 5ad4571eba2479f77a9f849a6ae7724c
   depends:
@@ -2174,7 +2174,7 @@ packages:
   license_family: Apache
   size: 3998613
   timestamp: 1694465071784
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
   sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
   md5: 77a22ed6d0d448c5288d0f695bc9ac49
   depends:
@@ -2183,7 +2183,7 @@ packages:
   license_family: Apache
   size: 72527
   timestamp: 1693575234886
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.4-py39h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-1.4.4-py39h6a678d5_0.tar.bz2
   sha256: 35adc93d0fde9abfa7bcbaf68f024926031a6b05dcd7edfd83a7f6398c4d2843
   md5: 52ab906448f09ab3f424ac156ade715e
   depends:
@@ -2199,7 +2199,7 @@ packages:
   license_family: BSD
   size: 13151705
   timestamp: 1663773447154
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
   sha256: 9c699bd495cbf23db7dea986deeb75183571b83adc14b3e4a36cc6cfd2a198a8
   md5: 39ed6f683307cca54ac666b2d1f849ff
   depends:
@@ -2213,7 +2213,7 @@ packages:
   license_family: BSD
   size: 35706
   timestamp: 1698702632637
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
   sha256: db8122fcb6316fb86c2ff6d4dd47154a650ac26d270183a316f14004adf27525
   md5: 33ad46d04664fc8b65a545110e4fe099
   depends:
@@ -2233,7 +2233,7 @@ packages:
   license_family: Other
   size: 764331
   timestamp: 1696580179855
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
   sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
   md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
   depends:
@@ -2244,7 +2244,7 @@ packages:
   license_family: MIT
   size: 2674850
   timestamp: 1697548887851
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
   sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
   md5: fe56f0479dd414c846191116366262c3
   depends:
@@ -2253,7 +2253,7 @@ packages:
   license_family: MIT
   size: 31999
   timestamp: 1692205535111
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
   sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
   md5: 44d2a857d13bdf9d99aaac039a249d47
   depends:
@@ -2262,7 +2262,7 @@ packages:
   license_family: Apache
   size: 91137
   timestamp: 1659455142164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
   sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
   md5: eb899a739d9b58dd747f1f6bd52d4cf3
   depends:
@@ -2274,7 +2274,7 @@ packages:
   license_family: BSD
   size: 579771
   timestamp: 1672387338600
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
   sha256: a760d6c9fca08c09ff0bc9a33946188e2ea5deed2443d4acb360ce55ce36ee43
   md5: 2cb2ad8315f68f4339b9416bd9ab115e
   depends:
@@ -2284,7 +2284,7 @@ packages:
   license_family: BSD
   size: 353437
   timestamp: 1656431352923
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
   sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
   md5: f36ecb722522cbe2e3737424edf1b5e1
   depends:
@@ -2296,7 +2296,7 @@ packages:
   license_family: BSD
   size: 29312
   timestamp: 1675441510984
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
   sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
   md5: 6d03295e544251e608a28c8d7c48115e
   depends:
@@ -2305,7 +2305,7 @@ packages:
   license_family: BSD
   size: 1862058
   timestamp: 1684280096752
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
   sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
   md5: 1f09617aecd6f3c2f2e20692c0759f34
   depends:
@@ -2315,7 +2315,7 @@ packages:
   license_family: Apache
   size: 94434
   timestamp: 1690223520097
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
   sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
   md5: ffceed627867508d73af1636ab5ebf42
   depends:
@@ -2324,7 +2324,7 @@ packages:
   license_family: MIT
   size: 156324
   timestamp: 1661452578573
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
   sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
   md5: 0e3341a4fe434167bf74b613eb6afd81
   depends:
@@ -2334,7 +2334,7 @@ packages:
   license_family: MIT
   size: 97194
   timestamp: 1636110999719
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
   sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
   md5: c5f3f7f10ad30f0945e75252615ab6e5
   depends:
@@ -2343,7 +2343,7 @@ packages:
   license_family: BSD
   size: 31331
   timestamp: 1605305847037
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.18-h7a1cb2a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.9.18-h7a1cb2a_0.tar.bz2
   sha256: fea95d1b166df729a918c1a528f4eacb1ef1aefe321b966e4fcd48d871ad84ea
   md5: cac6b214644d9bbf7b398489cb16c320
   depends:
@@ -2364,7 +2364,7 @@ packages:
   license_family: PSF
   size: 26791682
   timestamp: 1694439185856
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
   sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
   md5: 0caa188a695319bdb13f53b0a2b3accc
   depends:
@@ -2373,7 +2373,7 @@ packages:
   license_family: BSD
   size: 264864
   timestamp: 1661371117920
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py39h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-lmdb-1.4.1-py39h6a678d5_0.tar.bz2
   sha256: 3d4ebba2cd88a8e2b514c061d107b33057c67d54620a2975146d51444887b543
   md5: 9ae7c3b89bdccb939936e2f087c4f761
   depends:
@@ -2384,7 +2384,7 @@ packages:
   license_family: Other
   size: 139001
   timestamp: 1682522498995
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-snappy-0.6.0-py39h2531618_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-snappy-0.6.0-py39h2531618_3.tar.bz2
   sha256: 262e568ec50e23aa7187586da450d427e36f9abd0ddfc25b6574602d835366fe
   md5: 95ef4ec206d097ce7e12f82779c58ce0
   depends:
@@ -2396,7 +2396,7 @@ packages:
   license_family: BSD
   size: 31795
   timestamp: 1610133082486
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
   sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
   md5: bcb44ecbea441ee0d4659133d060d71f
   depends:
@@ -2405,7 +2405,7 @@ packages:
   license_family: MIT
   size: 257904
   timestamp: 1695131670290
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pywavelets-1.4.1-py39h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pywavelets-1.4.1-py39h5eee18b_0.tar.bz2
   sha256: ca6f2cb564a5aaa4a71a2bc56efe40a5427ef91427c9b388fb1faace6d9922db
   md5: 533f4979d06fc728e5dfad27d61f627e
   depends:
@@ -2416,7 +2416,7 @@ packages:
   license_family: MIT
   size: 4600603
   timestamp: 1670425256409
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
   sha256: 2a535f9fdda20b536bd76dfa286fb67a7685ed2be4ad51e2860c44e144c0b457
   md5: 797c263fd5bff62987fc1da076eef0f9
   depends:
@@ -2427,7 +2427,7 @@ packages:
   license_family: MIT
   size: 184040
   timestamp: 1698096132905
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
   sha256: 70ee4fc614dd3337ad542c7c961428930160ab8c7da27775faed5ffddbd362d7
   md5: bf2a4feb20647c569f7ce5a8f63094fa
   depends:
@@ -2439,7 +2439,7 @@ packages:
   license_family: BSD
   size: 515650
   timestamp: 1657724431309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
   sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
   md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
   depends:
@@ -2449,7 +2449,7 @@ packages:
   license_family: GPL
   size: 467661
   timestamp: 1666648052561
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
   sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
   md5: c7de00b4ac2778c4e5a7816320d75391
   depends:
@@ -2465,7 +2465,7 @@ packages:
   license_family: Apache
   size: 94028
   timestamp: 1690400356879
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scikit-image-0.19.3-py39h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/scikit-image-0.19.3-py39h6a678d5_1.tar.bz2
   sha256: 2f47c942449fb5ae8a782953b3b2a7403d0d534aa1790b997f899dff2d934188
   md5: 45d3a79f50f967d198d085bd0f9a0137
   depends:
@@ -2493,7 +2493,7 @@ packages:
   license_family: BSD
   size: 12244824
   timestamp: 1669243871552
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.9.3-py39hf6e8229_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/scipy-1.9.3-py39hf6e8229_2.tar.bz2
   sha256: 6d27ec18cf6e96610204ef26a0e1858cdfefabe3514adf8d497879731d504d27
   md5: b15739fe1e09ad49a09c82d26b2330b2
   depends:
@@ -2511,7 +2511,7 @@ packages:
   license_family: BSD
   size: 26648976
   timestamp: 1683286502437
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
   sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
   md5: 1581cafc84708ed9aafaaee1cbbf6065
   depends:
@@ -2520,7 +2520,7 @@ packages:
   license_family: MIT
   size: 1089416
   timestamp: 1690290900608
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.1.9-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/snappy-1.1.9-h295c915_0.tar.bz2
   sha256: 0f5809564b323f020dec2633dc274bbc96dc13d54888bb115938d3d7f6a717bb
   md5: 71b25fd79c57bcf6bd2ba8ccf1e18506
   depends:
@@ -2530,7 +2530,7 @@ packages:
   license_family: BSD
   size: 891170
   timestamp: 1649923859475
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
   sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
   md5: e19ffbfb24b990275d24fcea2bd1699b
   depends:
@@ -2539,7 +2539,7 @@ packages:
   license_family: Apache
   size: 15702
   timestamp: 1614030498860
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
   sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
   md5: ca061ce25c0f58628643abec8d6a8244
   depends:
@@ -2548,7 +2548,7 @@ packages:
   license_family: MIT
   size: 66330
   timestamp: 1696347637947
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
   sha256: 8b45ba506984fe9c061b4acde6f5243d52dda8c1eae4992f8d80c03f425214fe
   md5: 68c24a824d36a16bbb28d80d70cee8d2
   depends:
@@ -2561,7 +2561,7 @@ packages:
   license_family: Other
   size: 1640317
   timestamp: 1681394746811
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
   sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
   md5: 041a3caf09dc9ce8fc6c10925c4fe050
   depends:
@@ -2571,7 +2571,7 @@ packages:
   license_family: Apache
   size: 1888016
   timestamp: 1680167274961
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
   sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
   md5: 0e76eab58fe488e91f0aee73f46de031
   depends:
@@ -2582,7 +2582,7 @@ packages:
   license_family: BSD
   size: 29816
   timestamp: 1671751864131
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/testpath-0.6.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/testpath-0.6.0-py39h06a4308_0.tar.bz2
   sha256: 925677ec26cb76d10c4f0598afcfd83baf8abcb53566e2e16098eb375eeb9200
   md5: 462c2a924ef617f929787960affc972c
   depends:
@@ -2591,7 +2591,7 @@ packages:
   license_family: BSD
   size: 93566
   timestamp: 1655908613837
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/thrift-0.17.0-py39h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/thrift-0.17.0-py39h6a678d5_0.tar.bz2
   sha256: 49b380af9a94648f228a38bfdb726f8047cf13cda868018ec2f5eaa410c6d626
   md5: 22475a3e47ac882de71cfd80c3771678
   depends:
@@ -2603,7 +2603,7 @@ packages:
   license_family: APACHE
   size: 129134
   timestamp: 1666296627327
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tifffile-2023.4.12-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tifffile-2023.4.12-py39h06a4308_0.tar.bz2
   sha256: c0a8e427be9a0a534ef51a4b036ef23530aaf0fe9ba251e84c5d173d80af9846
   md5: a0671ef4f75f6aa5562fec79ca64b58e
   depends:
@@ -2616,7 +2616,7 @@ packages:
   license_family: BSD
   size: 376265
   timestamp: 1695107594127
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
   sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
   md5: 5b8375e2092012db69d2123dc0c68630
   depends:
@@ -2626,7 +2626,7 @@ packages:
   license_family: BSD
   size: 3485432
   timestamp: 1654088939579
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
   sha256: 57983e3eb698a3b08b570d5f398d9550cf50b9bf54b2b4728c731ecbc0c89138
   md5: 3ce956b1e1a7f77af6e6127dca987b95
   depends:
@@ -2635,7 +2635,7 @@ packages:
   license_family: BSD
   size: 101246
   timestamp: 1667464172523
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
   sha256: bd06f7b49d9c04c51c1e825bab446ec3cdde2bce39af00bf113a05c1009595e2
   md5: 587c3f3c891901f4305653e50c18d6c0
   depends:
@@ -2645,7 +2645,7 @@ packages:
   license_family: Apache
   size: 679739
   timestamp: 1696937022519
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
   sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
   md5: 67a8320961ff24e92eebb661536e5cf7
   depends:
@@ -2658,7 +2658,7 @@ packages:
   license_family: MOZILLA
   size: 123763
   timestamp: 1679561904852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
   sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
   md5: 0f0b91a158dd3692cbb7a7763b657bfe
   depends:
@@ -2667,7 +2667,7 @@ packages:
   license_family: BSD
   size: 192032
   timestamp: 1671143995098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
   md5: 8515e64a3de7581360d713fe4c0a094e
   depends:
@@ -2677,7 +2677,7 @@ packages:
   license_family: PSF
   size: 8789
   timestamp: 1690297588156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
   md5: 60170012374b2a5007842fa5870d78c5
   depends:
@@ -2686,7 +2686,7 @@ packages:
   license_family: PSF
   size: 57479
   timestamp: 1690297581658
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
   sha256: 2f4a5979aaf22660fe9fb8c4ffd41e5a9dc012e20f78e1dbf4ad9c67e0fd28be
   md5: 0be10051dd3d6f31ba52b7c08ba3ba0a
   depends:
@@ -2701,7 +2701,7 @@ packages:
   license_family: MIT
   size: 187469
   timestamp: 1698257600264
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
   sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
   md5: f8d03a15b974fc7810d9f54ae849fc8e
   depends:
@@ -2710,7 +2710,7 @@ packages:
   license_family: BSD
   size: 20781
   timestamp: 1607365390528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
   sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
   md5: d7db5d6ce1db80eade8a082ff78bf479
   depends:
@@ -2720,7 +2720,7 @@ packages:
   license_family: BSD
   size: 71044
   timestamp: 1614804011510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
   sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
   md5: b3899f8bda32734727bd5a73df1d7d17
   depends:
@@ -2729,7 +2729,7 @@ packages:
   license_family: MIT
   size: 101520
   timestamp: 1695742037911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
   sha256: d88bdc49a883a944cf1562ebb0a30d0451e28ab05521fc882615e357b105f414
   md5: c150cf16071597fa3977fb81ebb83760
   depends:
@@ -2741,7 +2741,7 @@ packages:
   license_family: Apache
   size: 1787638
   timestamp: 1689041557651
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
   sha256: 93ca87e697bb9e045fc9cda13b05fe27e1a99f3ed143b75bbcaf4dcb745aa06f
   md5: 3eebbb22c5ca63987db36e1f19cbe872
   depends:
@@ -2750,7 +2750,7 @@ packages:
   license_family: GPL2
   size: 763941
   timestamp: 1683112966413
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -2758,7 +2758,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
   sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
   md5: 567b68192c387b5fc88178425577a0fe
   depends:
@@ -2768,7 +2768,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 366479
   timestamp: 1616055552392
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zfp-1.0.0-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zfp-1.0.0-h6a678d5_0.tar.bz2
   sha256: 807521a07138f611cad037b15de8f478fc985cedb00bce3f6256c0ea14f09825
   md5: 3a844b7ddc088e7cf5dca84d8c4e3fcd
   depends:
@@ -2780,7 +2780,7 @@ packages:
   license_family: BSD
   size: 305779
   timestamp: 1681741638187
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zict-3.0.0-py39h06a4308_0.tar.bz2
   sha256: 859398823a40ead7079055f01ad23f7f5a03ffa11ad672fa26bea38badd8ec01
   md5: b733cbb9875966a2017e7c386fb98076
   depends:
@@ -2791,7 +2791,7 @@ packages:
   license_family: BSD
   size: 76469
   timestamp: 1695832872162
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
   sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
   md5: 3818a9531fe74433c3b7d5144c9a58cc
   depends:
@@ -2800,7 +2800,7 @@ packages:
   license_family: MIT
   size: 18021
   timestamp: 1672387231268
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
   sha256: 2dc9150a95704d83efd39bb9dfb44bdf8419022f4fb0fc416380a922a27c130d
   md5: 4f315d7551f4bbeb06b6fc28342a9aa5
   depends:
@@ -2809,7 +2809,7 @@ packages:
   license_family: Other
   size: 127528
   timestamp: 1666595012798
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
   sha256: aa6aa291bec6aa66e1f063cfa75a9e0fc6bd459fcb45c372aacac9006a073900
   md5: 4e99328768f538f33aecebdae9472744
   depends:
@@ -2822,7 +2822,7 @@ packages:
   license_family: BSD
   size: 1055426
   timestamp: 1681304602537
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -2835,7 +2835,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -2845,7 +2845,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
   md5: b2aa5503875aba2f1d88cae9df9a96d5
   depends:
@@ -2854,7 +2854,7 @@ packages:
   license_family: BSD
   size: 13636
   timestamp: 1611930018941
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -2866,7 +2866,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
   sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
   md5: 544adf2677c47c9b9c891aea720678f1
   depends:
@@ -2874,7 +2874,7 @@ packages:
   license: MIT
   size: 33999
   timestamp: 1630003259346
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -2883,7 +2883,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2021.9.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/dask-2021.9.1-pyhd3eb1b0_0.tar.bz2
   sha256: 567108ad651ced20f632dc326601248b851cb775f6d318baa061bcad70aee274
   md5: 077bf2c43cb0936fcc622b56c0aac194
   depends:
@@ -2901,7 +2901,7 @@ packages:
   license_family: BSD
   size: 18809
   timestamp: 1634742792966
-- conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2021.9.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/dask-core-2021.9.1-pyhd3eb1b0_0.tar.bz2
   sha256: d32f2f7823e6643225abd1a4e450d4c2adc48b5a625e765a52dfac5f174a600a
   md5: 8a70b4c97a5c9827e9bae224d85b2cc4
   depends:
@@ -2916,7 +2916,7 @@ packages:
   license_family: BSD
   size: 786162
   timestamp: 1634728790568
-- conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
   sha256: 2de2d79a0e9784a1bf55cdb83c035072da1879753d109c0a36bbd5a357385c37
   md5: 6cfe764bb04e756d7d1319a98a05dd70
   depends:
@@ -2938,7 +2938,7 @@ packages:
   license_family: BSD
   size: 14964307
   timestamp: 1623782401693
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -2947,7 +2947,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -2956,7 +2956,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -2965,7 +2965,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
   sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
   md5: 9eff1a842dbda8d1bae9a2c008b599bc
   depends:
@@ -2976,7 +2976,7 @@ packages:
   license_family: MIT
   size: 690443
   timestamp: 1625743217109
-- conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
   sha256: 9de8666e5b70aa2437737128eaa14ffe80a7b5235c2a6b7d3f39ccefd7816ba0
   md5: bb52e50c5ab1a5c7778c11376404dfdb
   depends:
@@ -2984,7 +2984,7 @@ packages:
   license: BSD 3-Clause
   size: 7933
   timestamp: 1630598543551
-- conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.5-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/holoviews-1.14.5-pyhd3eb1b0_1.tar.bz2
   sha256: e77b4a0cc563af73e983215185e4158d11e0f9cd2cc62b8774a6b882f6846093
   md5: 38360443a9f70dac94eade937da2dc87
   depends:
@@ -3003,7 +3003,7 @@ packages:
   license_family: BSD
   size: 3606010
   timestamp: 1627946408633
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -3011,7 +3011,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
   sha256: 9c97f6b9a2cfba7b99e6732505a567787fb86da32cbf2aa6b825069361807845
   md5: e3d2afca7f53449172cb027b2164df6b
   depends:
@@ -3021,7 +3021,7 @@ packages:
   license: BSD-3-Clause
   size: 96029
   timestamp: 1612213176846
-- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
   sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
   md5: 33624a42ee387bf9918ea98b4e7b31fc
   depends:
@@ -3031,7 +3031,7 @@ packages:
   license_family: BSD
   size: 8173
   timestamp: 1601490751973
-- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
   sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
   md5: 67857cc5e9044770d2b15f9d94a4521d
   depends:
@@ -3040,7 +3040,7 @@ packages:
   license_family: Apache
   size: 12810
   timestamp: 1600445183315
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -3049,7 +3049,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
   sha256: 011406e85cbb2a3d1e687620dd18ec798ab34a7478f46e7e81b9d8a11fdd914f
   md5: 7ed543858227e957d774766cd46acba9
   depends:
@@ -3066,7 +3066,7 @@ packages:
   license_family: BSD
   size: 10334744
   timestamp: 1628798011706
-- conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
   sha256: 110a3b50f89584ccb13980a617f6258b83b0bc56c8897c96d9e0da9fdc2c957c
   md5: 6266365b47ed65cdb4737603a385c691
   depends:
@@ -3075,7 +3075,7 @@ packages:
   license_family: BSD
   size: 69119
   timestamp: 1625476602265
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -3084,7 +3084,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -3094,7 +3094,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
   sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
   md5: e68a6f315f41a8d814d833652bf38b9b
   depends:
@@ -3102,7 +3102,7 @@ packages:
   license: MIT
   size: 13374
   timestamp: 1606932077143
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -3110,7 +3110,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -3119,7 +3119,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -3128,7 +3128,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
   sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
   md5: 2eb923cc014094f4acf7f849d67d73f8
   depends:
@@ -3138,7 +3138,7 @@ packages:
   license_family: BSD
   size: 246457
   timestamp: 1626374695070
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pyviz_comms-2.0.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pyviz_comms-2.0.2-pyhd3eb1b0_0.tar.bz2
   sha256: 5004d4651d4a544b06cc3bb5dfffd65db84a31491e292e8509e6748af7fd2fca
   md5: 165985560b29068d8b832838e0a0c143
   depends:
@@ -3148,7 +3148,7 @@ packages:
   license_family: BSD
   size: 25511
   timestamp: 1623747251779
-- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
   sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
   md5: 41db68b96e114e367c4f120a3b379e59
   depends:
@@ -3157,7 +3157,7 @@ packages:
   license_family: BSD
   size: 19391
   timestamp: 1632406728844
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -3166,7 +3166,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
   sha256: 4e47f6c49ce84509f1466e8a4d728447bf4bcd9bce7b456431a789a262547067
   md5: 4cad993b0f80bc23fb66a97592299cbb
   depends:
@@ -3175,7 +3175,7 @@ packages:
   license_family: Apache
   size: 26504
   timestamp: 1623949147884
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -3187,7 +3187,7 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
   sha256: ca2be6c7810a37cfc6db1f5383937b5d35c6d73c1fad8a9104de85f069b1df1c
   md5: 9ccb2fb33edb152403d6ef32bf758a9d
   depends:
@@ -3196,14 +3196,14 @@ packages:
   license_family: BSD
   size: 15614
   timestamp: 1629402049497
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
   sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
   md5: a815d3bdb160bcc71687f2dda70d3ca4
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 122218
   timestamp: 1680170368293
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -3211,7 +3211,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
   sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
   md5: 447a49f7bad119faa80d7f14aa296c95
   depends:
@@ -3224,7 +3224,7 @@ packages:
   license_family: MIT
   size: 162176
   timestamp: 1644481750133
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aom-3.6.0-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aom-3.6.0-hcec6c5f_0.tar.bz2
   sha256: e9e15fb1d52051c9dbb25b1f2e613eb60cf8dbe0793062c3a274e61e6a0871dc
   md5: cb548680c2222c567784653166056c1a
   depends:
@@ -3233,7 +3233,7 @@ packages:
   license_family: BSD
   size: 3463290
   timestamp: 1688660834942
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
   sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
   md5: 8810f48fe4a4792de0fd3520b502d08b
   depends:
@@ -3242,7 +3242,7 @@ packages:
   license_family: BSD
   size: 10019
   timestamp: 1606859473259
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
   sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
   md5: 00a446b6dfc61af223df4de29fe8ad94
   depends:
@@ -3252,7 +3252,7 @@ packages:
   license_family: MIT
   size: 34305
   timestamp: 1644569782044
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
   sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
   md5: bd92dd8bd5b9d24e632b62a075426e50
   depends:
@@ -3261,7 +3261,7 @@ packages:
   license_family: MIT
   size: 133634
   timestamp: 1695718025321
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
   sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
   md5: f8ae051b591a9027adc16de1be9748f4
   depends:
@@ -3271,12 +3271,12 @@ packages:
   license_family: MIT
   size: 206198
   timestamp: 1681493096349
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
   sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
   md5: e2f3248e2a5009a02f7b8e54f83314ef
   size: 5620
   timestamp: 1528121955725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
   sha256: 3699a260f422443de85b74084fe36f734be1a466eeebdfdf4195d52c9fdb5508
   md5: 132d056e66b3ae9148f53819f8368c94
   depends:
@@ -3288,7 +3288,7 @@ packages:
   license_family: BSD
   size: 66125
   timestamp: 1675247668924
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.3.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-2.3.3-py39hecd8cb5_0.tar.bz2
   sha256: 7af15bbe9281f52a47d2319efa88e61716a8296d599123390dc404005275eab6
   md5: 869e984d66fe50aee77851244636a389
   depends:
@@ -3305,7 +3305,7 @@ packages:
   license_family: BSD
   size: 8652066
   timestamp: 1625767570656
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
   sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
   md5: 0d79760d544d0bd8acb4adc4ef813418
   depends:
@@ -3315,7 +3315,7 @@ packages:
   license_family: BSD
   size: 137075
   timestamp: 1657175654487
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
   sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
   md5: 31d6d04cd2388d8f19004501271b3545
   depends:
@@ -3325,7 +3325,7 @@ packages:
   license: MIT
   size: 18982
   timestamp: 1659616229395
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
   sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
   md5: caf1073dc2ca5aeb832a2877394eae12
   depends:
@@ -3334,7 +3334,7 @@ packages:
   license: MIT
   size: 18233
   timestamp: 1659616216769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
   sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
   md5: aa1ed20c38af535c8d6a955314759d7b
   depends:
@@ -3343,7 +3343,7 @@ packages:
   license: MIT
   size: 394588
   timestamp: 1659616312678
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brunsli-0.1-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brunsli-0.1-h23ab428_0.tar.bz2
   sha256: af713241455149cffec30054b5ab2f055a72c1b6bb6f492d9568deaa362597f6
   md5: 860cc2203395527c259cabd8e3e16a36
   depends:
@@ -3353,28 +3353,28 @@ packages:
   license_family: MIT
   size: 184792
   timestamp: 1611240502908
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
   sha256: 4574ffa241157e108d19ece60107a3a689cefaaca43578e6c4a6b344c7330278
   md5: ab3b4e83407001e7f1603ca1fa0f4873
   license: bzip2
   license_family: BSD
   size: 106284
   timestamp: 1563219666100
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
   sha256: f913b61ba3c1651b36688415cc163a5d575475f7573b543f48a80e7a5002e4bb
   md5: f11d165eaa532ce04a35382841284298
   license: MIT
   license_family: MIT
   size: 107047
   timestamp: 1693902034820
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
   sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
   md5: ce3588e31faa79f546e0fc6a36c5543c
   license: MPL-2.0
   license_family: Other
   size: 133884
   timestamp: 1694009771475
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
   sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
   md5: 21eb7f53076d0a69513cfd258f6ef63c
   depends:
@@ -3383,7 +3383,7 @@ packages:
   license_family: Other
   size: 159756
   timestamp: 1690232346868
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
   sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
   md5: a40a04d9cda1e665565bc6c832d598b6
   depends:
@@ -3394,7 +3394,7 @@ packages:
   license_family: MIT
   size: 225258
   timestamp: 1670423337502
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
   sha256: 68a12eaeda90c9cdbce729f0d44d222c3f60ec4920bb781bf13fae3a89cb3dd1
   md5: a0970a5c1c77125369aded2d4e25f870
   depends:
@@ -3406,7 +3406,7 @@ packages:
   license_family: Other
   size: 1437665
   timestamp: 1655814938182
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/charls-2.2.0-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/charls-2.2.0-h23ab428_0.tar.bz2
   sha256: af3ad515ab2369e09b7a8b373025d1f7851618c2e698c7336d1296cb4f105732
   md5: bb00d7a0d60266c9bdd9493d3f91f955
   depends:
@@ -3415,7 +3415,7 @@ packages:
   license_family: BSD
   size: 96819
   timestamp: 1612240391361
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
   sha256: b860f45bce9fbb40d024dcd3306e66a52010641091ca8d1fcdde6c4238717c73
   md5: 3c38f3af9c23b26efc2b11d82c95922a
   depends:
@@ -3424,7 +3424,7 @@ packages:
   license_family: BSD
   size: 153013
   timestamp: 1698129937688
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
   sha256: c368e11dc241d1b79b4bb0d9333b353dc1b966b49d145163a0590d88ad88fef2
   md5: 1e62044b8a32d1452e51773ba7a4319c
   depends:
@@ -3433,7 +3433,7 @@ packages:
   license_family: BSD
   size: 41392
   timestamp: 1683040146991
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
   sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
   md5: b2cc5f37f7bb069d061306e7eac2a011
   depends:
@@ -3443,7 +3443,7 @@ packages:
   license_family: CC
   size: 1913396
   timestamp: 1668084575248
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
   sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
   md5: 103d8c039e342115720a84d59c119d46
   depends:
@@ -3453,7 +3453,7 @@ packages:
   license_family: BSD
   size: 13774
   timestamp: 1671231190250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
   sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
   md5: f69f09e0346172f225390d2b3b0d7873
   depends:
@@ -3464,7 +3464,7 @@ packages:
   license_family: BSD
   size: 246628
   timestamp: 1663827484947
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39ha2381d6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39ha2381d6_0.tar.bz2
   sha256: 83a064ced6cfc1d96426ba1f1dbcf541cd83acd8db3f45825c34708a45151f23
   md5: d30062856f9831f71cd6db71bc418fef
   depends:
@@ -3477,7 +3477,7 @@ packages:
   license_family: BSD
   size: 1306207
   timestamp: 1694212501270
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cytoolz-0.12.0-py39hca72f7f_0.tar.bz2
   sha256: 68200788e4f482730df10be66e73ea32ae9031bb76551108e6ad8bfb197c653e
   md5: d0548e07d136d23cfc9202312a325f34
   depends:
@@ -3487,7 +3487,7 @@ packages:
   license_family: BSD
   size: 363755
   timestamp: 1667466068228
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
   sha256: 40bbbe2ed223829f4a3f91024fa409f1a665ad94294bec2c9e930989bb2b8911
   md5: 4add00dc619c12370af0ed18c76b71f6
   depends:
@@ -3499,14 +3499,14 @@ packages:
   license_family: BSD
   size: 103370
   timestamp: 1613390236788
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/dav1d-1.2.1-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/dav1d-1.2.1-h6c40b1e_0.tar.bz2
   sha256: 53b960dc320a73701d8faf90316a203b01b294e0a7235c7bf49bb853d71b2214
   md5: 7a196bd419ee0f888fbbe0e6d449adda
   license: BSD-2-Clause
   license_family: BSD
   size: 812727
   timestamp: 1688746099942
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
   sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
   md5: 04cbe8f4bc62c34fac9d42d1124059bf
   depends:
@@ -3516,7 +3516,7 @@ packages:
   license_family: MIT
   size: 2052734
   timestamp: 1690905361158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2021.9.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/distributed-2021.9.1-py39hecd8cb5_0.tar.bz2
   sha256: 1ae5b9da047685a183d334525725d042412ff0580a2dfc3b2d5475d9cf971bc8
   md5: 18f243433e329801d71defd328f98ec7
   depends:
@@ -3541,7 +3541,7 @@ packages:
   license_family: BSD
   size: 1116914
   timestamp: 1634741478920
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
   sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
   md5: ef0e825982f242085574f502dfff4f6b
   depends:
@@ -3550,7 +3550,7 @@ packages:
   license_family: MIT
   size: 16594
   timestamp: 1649926538106
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
   sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
   md5: 24747a300246c016b3a7f04dabd02d4a
   depends:
@@ -3559,7 +3559,7 @@ packages:
   license_family: BSD
   size: 27709
   timestamp: 1668714497209
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-0.5.0-py39h67323c0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fastparquet-0.5.0-py39h67323c0_2.tar.bz2
   sha256: e152325158e54e534e5eefa1a1144594f9736c73409f39102295f6c8bb91105f
   md5: 273e3bfcd0ebf58b77a74c92f606c34c
   depends:
@@ -3575,7 +3575,7 @@ packages:
   license_family: Apache
   size: 192209
   timestamp: 1658500770425
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -3585,7 +3585,7 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
   sha256: 95e9a45812b1b4059b973e5e6e131c7c1a8b2ce2dafc5117e7806b1c8f30de27
   md5: bc889aaa846ed177fc5f495c24041acc
   depends:
@@ -3594,14 +3594,14 @@ packages:
   license_family: BSD
   size: 262430
   timestamp: 1695734574609
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
   sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
   md5: e4a732941f74b8062c8bcbfe5c5c2b56
   license: MIT
   license_family: MIT
   size: 80252
   timestamp: 1676983220161
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
   sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
   md5: 6dd72c43fea25b748ec7a9f6c0407e15
   depends:
@@ -3610,7 +3610,7 @@ packages:
   license_family: BSD
   size: 111810
   timestamp: 1666125671024
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/imagecodecs-2023.1.23-py39hd1bf5dc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/imagecodecs-2023.1.23-py39hd1bf5dc_0.tar.bz2
   sha256: 4414ee6c323a190649911b401204d4d67023ecbada7eb5dbb7fb212b6b8d0faa
   md5: b1fd778d28acdf233cdc25a53ba30534
   depends:
@@ -3648,7 +3648,7 @@ packages:
   license_family: BSD
   size: 10170657
   timestamp: 1695066401424
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/imageio-2.31.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/imageio-2.31.4-py39hecd8cb5_0.tar.bz2
   sha256: 29601445c3b8a3053619fb4cfb7e0a778b592d9a6de119c32afbf56e897a03e0
   md5: 0dd424dd602f807cbb21728c6d37376e
   depends:
@@ -3659,7 +3659,7 @@ packages:
   license_family: BSD
   size: 510710
   timestamp: 1695996558417
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
   sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
   md5: 03cdb7e679924b329ecab8f12cb8fc67
   depends:
@@ -3669,7 +3669,7 @@ packages:
   license_family: APACHE
   size: 38813
   timestamp: 1678997212422
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
   sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
   md5: e113c4e6e758dd68faf196586bf5564d
   depends:
@@ -3679,7 +3679,7 @@ packages:
   license_family: Apache
   size: 51873
   timestamp: 1698254765815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
   sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
   md5: 78baea934985ccd9514a366cc7e80ed4
   depends:
@@ -3688,7 +3688,7 @@ packages:
   license_family: Proprietary
   size: 727499
   timestamp: 1681801225190
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
   sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
   md5: da9b63e42f281f7e77b289f4b654b83b
   depends:
@@ -3710,7 +3710,7 @@ packages:
   license_family: BSD
   size: 218436
   timestamp: 1691121840155
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
   sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
   md5: 6a7cb9b49593b29933fa2b503d533a08
   depends:
@@ -3732,7 +3732,7 @@ packages:
   license_family: BSD
   size: 1257205
   timestamp: 1694181720454
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
   sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
   md5: d861ef66f5c0a282d60b65778a9de2f3
   depends:
@@ -3742,14 +3742,14 @@ packages:
   license_family: MIT
   size: 1048450
   timestamp: 1644315332508
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
   sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
   md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
   license: IJG
   license_family: Other
   size: 278924
   timestamp: 1677849185191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
   sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
   md5: a82a17e78f725dcbd71ff8dac6db05c7
   depends:
@@ -3760,7 +3760,7 @@ packages:
   license_family: MIT
   size: 133134
   timestamp: 1676558895333
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
   sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
   md5: ee9270379a9ebdb6297e4b6849b3f7f0
   depends:
@@ -3776,7 +3776,7 @@ packages:
   license_family: BSD
   size: 195479
   timestamp: 1676329410154
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 32b898a97dca7770858ab31294238fde11ab61a84831a52f320e5ee5405a147c
   md5: 926e754b8fad288b583ef2933deae1a5
   depends:
@@ -3787,7 +3787,7 @@ packages:
   license_family: BSD
   size: 92938
   timestamp: 1679906616072
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
   sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
   md5: 7e60995b3119417213e5faedda147499
   depends:
@@ -3811,14 +3811,14 @@ packages:
   license_family: BSD
   size: 403165
   timestamp: 1671707664990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jxrlib-1.1-haf1e3a3_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jxrlib-1.1-haf1e3a3_2.tar.bz2
   sha256: 63b4b4e81998da78bf9a1625d122faa6aa7514f6e3c975043432da346b9a566d
   md5: 1e527af8be0e202b459293a8a5c76c87
   license: BSD-2-Clause
   license_family: BSD
   size: 230086
   timestamp: 1593197454386
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
   sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
   md5: cd470bdb28bb0e8b3535c93a3a6dad07
   depends:
@@ -3828,7 +3828,7 @@ packages:
   license_family: BSD
   size: 65431
   timestamp: 1672387389172
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
   sha256: 8093a64350665d16ca2ad0acfcbba5c84b479c316a40db6b9d5f9b84b58f3b12
   md5: cd98cc17f8297a31b1dd62f061ea4f83
   depends:
@@ -3839,7 +3839,7 @@ packages:
   license_family: MIT
   size: 1289465
   timestamp: 1686931250022
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -3849,7 +3849,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -3858,7 +3858,7 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libaec-1.0.4-hb1e8313_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libaec-1.0.4-hb1e8313_1.tar.bz2
   sha256: 2a9313912b9b3ea0d306a46e20df93f7fc79bce35e895e0cb98b8cdc068e2652
   md5: ebfa53511162e3172aa14fbd37e3ed5d
   depends:
@@ -3867,7 +3867,7 @@ packages:
   license_family: BSD
   size: 28397
   timestamp: 1593198224738
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libavif-0.11.1-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libavif-0.11.1-h6c40b1e_0.tar.bz2
   sha256: 69303ebcb28fdfcdee4190da926cc7118bff28f96be9e6e5dd92f45e8302d711
   md5: dfe44f56908bc60af820824d24d634c4
   depends:
@@ -3877,13 +3877,13 @@ packages:
   license_family: BSD
   size: 98857
   timestamp: 1689158151760
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
   sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
   md5: 7dba7aa5b971febb55281659843586ba
   license: MIT
   size: 65470
   timestamp: 1659616172703
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
   sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
   md5: f78a158983f0bbaba56f34b976bc6dae
   depends:
@@ -3891,7 +3891,7 @@ packages:
   license: MIT
   size: 34189
   timestamp: 1659616189313
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
   sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
   md5: 36a1d885725d3ab4d1fadc5a29f978d2
   depends:
@@ -3899,7 +3899,7 @@ packages:
   license: MIT
   size: 327737
   timestamp: 1659616202869
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
   sha256: 83cf762f0d09c97dfb4a1c1cd9e635de2e54c384b057afbf3c0e2e8db07d862f
   md5: ae3a458da93940fea1fa83af80d91fd4
   depends:
@@ -3914,21 +3914,21 @@ packages:
   license_family: MIT
   size: 358556
   timestamp: 1693515516157
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20221030-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libedit-3.1.20221030-h6c40b1e_0.tar.bz2
   sha256: 67e38ccc55c2d996a8a0949080949c9803ddff84a96c4e34bc4c48fa95e5f35b
   md5: b549aa024097c9f2790ba6eb89bc53fd
   depends:
@@ -3937,21 +3937,21 @@ packages:
   license_family: BSD
   size: 168786
   timestamp: 1670840154554
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
   sha256: 4786264321edbff780633a5b752995eb3193ca4bce11b0fda179577f6cf1102c
   md5: 849fdd014c201a9d2c2aa7c7db38a778
   license: BSD-2-Clause
   license_family: BSD
   size: 103993
   timestamp: 1632891571494
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
   sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
   md5: 817848d0e2b2808acdc9b3fbbf581726
   license: MIT
   license_family: MIT
   size: 133887
   timestamp: 1683716590737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
   sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
   md5: e458587c87e3f2d20192f4e0738f2c63
   depends:
@@ -3960,7 +3960,7 @@ packages:
   license_family: GPL
   size: 149419
   timestamp: 1665498987619
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
   sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
   md5: 1058b661ec829b2ee3716ee2a5520641
   depends:
@@ -3971,7 +3971,7 @@ packages:
   license_family: GPL
   size: 1917987
   timestamp: 1665498925405
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm11-11.1.0-h46f1229_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libllvm11-11.1.0-h46f1229_6.tar.bz2
   sha256: 5f31ea9ceb555ff984674f2b7eae2262f7c124c861982d863b93f3a532273349
   md5: 4e8a6604f36e94ae35c22ade431277b7
   depends:
@@ -3981,7 +3981,7 @@ packages:
   license_family: Apache
   size: 23102665
   timestamp: 1665077532507
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
   sha256: 331bc731419328a873e1a48d4257c58baa33d73b4b91ff7a3553b1c122120fb1
   md5: 43fba990695db8556ddd0ade21d59ecc
   depends:
@@ -3996,7 +3996,7 @@ packages:
   license_family: MIT
   size: 782018
   timestamp: 1686931556261
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -4005,13 +4005,13 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
   sha256: 8b1adbb78b6283c3d8df932d5aa7e8e249351aa1e206ba2949ee86052912e83f
   md5: 2e035c81c044bff1224224ac24161dfd
   depends:
@@ -4020,7 +4020,7 @@ packages:
   license_family: BSD
   size: 338461
   timestamp: 1686931232629
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -4037,7 +4037,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
   sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
   md5: c0b99f8e1c7475f23b1c7b4250b06e1c
   depends:
@@ -4051,7 +4051,7 @@ packages:
   license_family: BSD
   size: 88021
   timestamp: 1694778290062
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
   sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
   md5: 46a65d1fc24013217e06aaf6d65ffcad
   constrains:
@@ -4060,7 +4060,7 @@ packages:
   license_family: BSD
   size: 425478
   timestamp: 1694776947990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libzopfli-1.0.3-hb1e8313_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libzopfli-1.0.3-hb1e8313_0.tar.bz2
   sha256: 1d727042cefd5fdc1eb1b5735ccb19b15ab0837e0b3c4a96841ebcd4143d31e9
   md5: 2dffb55c068fb1561d870b5543b7966e
   depends:
@@ -4069,7 +4069,7 @@ packages:
   license_family: Apache
   size: 162388
   timestamp: 1593197747824
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
   sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
   md5: 5c740b4a18a558de0ccfe601703c423c
   constrains:
@@ -4078,7 +4078,7 @@ packages:
   license_family: Apache
   size: 338738
   timestamp: 1662635677689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.38.0-py39h8346a28_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.38.0-py39h8346a28_0.tar.bz2
   sha256: 47f5828dec578c863e41792ba45f4f16d3583fafb255ba2e2e8e02da50ac2952
   md5: b099b7a14714c858ec0cbe2fd254e77e
   depends:
@@ -4089,7 +4089,7 @@ packages:
   license: BSD-2-Clause
   size: 247762
   timestamp: 1647870749748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 1dab4daa56408915de3ec270c8b887e7221d48633ea83b0afff61041fc197972
   md5: 1519f9b766f9f894282db8353066e3b2
   depends:
@@ -4098,7 +4098,7 @@ packages:
   license_family: BSD
   size: 11883
   timestamp: 1652903144294
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
   sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
   md5: d5f58d056b4bfc67aec30c77035ba889
   depends:
@@ -4107,7 +4107,7 @@ packages:
   license_family: BSD
   size: 182491
   timestamp: 1670944720979
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
   sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
   md5: 1affd16b166571a91feae04baf5fd3da
   depends:
@@ -4117,7 +4117,7 @@ packages:
   license_family: BSD
   size: 123431
   timestamp: 1671542016019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.0.1-py39h9ed2024_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.0.1-py39h9ed2024_0.tar.bz2
   sha256: 154b20bbde20714bbe52dfee2eeb8604df5dbb27d89cbeff4146b58e4c178322
   md5: b5f877678a4cd266b8b0b0e2058a06b6
   depends:
@@ -4126,7 +4126,7 @@ packages:
   license_family: BSD
   size: 21379
   timestamp: 1621528240158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
   sha256: 2fd179efa024c92d0d71179a981a781d16c70f5d8c6305e0d678b0c7ae1275ab
   md5: addda7f015d1673f794a23fdb18a3e09
   depends:
@@ -4149,7 +4149,7 @@ packages:
   license_family: PSF
   size: 8182219
   timestamp: 1698692361219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
   sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
   md5: 6eb64ecfcd754502e271db0bb51d2cfd
   depends:
@@ -4159,7 +4159,7 @@ packages:
   license_family: BSD
   size: 17374
   timestamp: 1662014643620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
   sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
   md5: 2a4d604717a647ad21af766289cbbfc3
   depends:
@@ -4168,7 +4168,7 @@ packages:
   license_family: BSD
   size: 58057
   timestamp: 1607364912348
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
   sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
   md5: 25051fe272624544652dc6d814c2943a
   depends:
@@ -4181,7 +4181,7 @@ packages:
   license_family: Proprietary
   size: 224420228
   timestamp: 1691503125614
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
   sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
   md5: 37d8cf85a63f7aa9af1624894a7d606d
   depends:
@@ -4191,7 +4191,7 @@ packages:
   license_family: BSD
   size: 48590
   timestamp: 1682969183093
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
   sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
   md5: 0b2aee6666135bbd36b46d6ac66160f7
   depends:
@@ -4204,7 +4204,7 @@ packages:
   license_family: BSD
   size: 210705
   timestamp: 1695058433223
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
   sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
   md5: e22fb55ce380d0ebd44cce3f20d5349e
   depends:
@@ -4218,7 +4218,7 @@ packages:
   license_family: BSD
   size: 296614
   timestamp: 1695060155673
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py39haf03e11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/msgpack-python-1.0.3-py39haf03e11_0.tar.bz2
   sha256: e3ac58a4520466ecb759590759c86e81dcddf1c36fd25d081dd9064d9e850c48
   md5: d184127ffc4131fdef14724d5f480c99
   depends:
@@ -4228,7 +4228,7 @@ packages:
   license_family: Apache
   size: 84981
   timestamp: 1652362789251
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
   sha256: 5f60ca253f1fea0a1d765f535ff9ca2cf7efba90aea4c9a290d8f50ad11d4f6f
   md5: 97d6ec94e2300030bddf0e5289cd2a84
   depends:
@@ -4238,7 +4238,7 @@ packages:
   license_family: BSD
   size: 24240
   timestamp: 1607574265505
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
   sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
   md5: 1a5d4004e64e3cfb7a2a297b9117c285
   depends:
@@ -4264,7 +4264,7 @@ packages:
   license_family: BSD
   size: 8213832
   timestamp: 1681756573646
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
   sha256: 2975bd1f98ca9ec7354ee378f86f8322ec90f568374776fd90e80c534fbee882
   md5: 798627089e0ccba26695a26d9cb127ec
   depends:
@@ -4277,7 +4277,7 @@ packages:
   license_family: BSD
   size: 99066
   timestamp: 1650308465824
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.4.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.4.4-py39hecd8cb5_0.tar.bz2
   sha256: 0fe3fa86499687b8d9cf27c1926ed9b68a093bd6dfd0804c4e1f7fa3ad838910
   md5: 78a83d61819b9998e64e0e145f928d26
   depends:
@@ -4302,7 +4302,7 @@ packages:
   license_family: BSD
   size: 569640
   timestamp: 1649751946874
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
   sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
   md5: b67569a7c30af9ffa5cde6e4b52ac68b
   depends:
@@ -4315,14 +4315,14 @@ packages:
   license_family: BSD
   size: 148342
   timestamp: 1694616917184
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
   sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
   md5: 97b81f34efbe86c5220fe82eb584fd62
   depends:
@@ -4331,7 +4331,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387288528
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/networkx-3.1-py39hecd8cb5_0.tar.bz2
   sha256: e108c2df53ee3b3218067fd50fedcd417d5ec12d1d1247a46f0018942efd2c08
   md5: f2b02e342efea3f93ab8eee6033a332a
   depends:
@@ -4340,7 +4340,7 @@ packages:
   license_family: BSD
   size: 2958243
   timestamp: 1690562148988
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
   sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
   md5: d77862975a9a1cf50acb803be26e83a1
   depends:
@@ -4365,7 +4365,7 @@ packages:
   license_family: BSD
   size: 575365
   timestamp: 1690985052739
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
   sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
   md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
   depends:
@@ -4375,7 +4375,7 @@ packages:
   license_family: BSD
   size: 22858
   timestamp: 1668160618784
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.55.1-py39hae1ba45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numba-0.55.1-py39hae1ba45_0.tar.bz2
   sha256: 7a11498a91351f545e739fdb563edf3a0ac58dcd4104d200ee80507d9a034303
   md5: f0be888e57909d643bde1edcbbd2573b
   depends:
@@ -4396,7 +4396,7 @@ packages:
   license_family: BSD
   size: 3941575
   timestamp: 1648040596955
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
   sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
   md5: 185e9c41abb88ee59b52ec0f5f65d506
   depends:
@@ -4410,7 +4410,7 @@ packages:
   license_family: MIT
   size: 138305
   timestamp: 1696515469702
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.21.5-py39h47b59a4_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.21.5-py39h47b59a4_4.tar.bz2
   sha256: 03a8d4e8ce9d3a927e40ae3196ecc4ca697ac0357d7a5813a20d165284fa73fc
   md5: 7392c66e8d0891442d45631986beef92
   depends:
@@ -4425,7 +4425,7 @@ packages:
   license: BSD-3-Clause
   size: 10377
   timestamp: 1682972081348
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.21.5-py39hcfaf2c3_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.21.5-py39hcfaf2c3_4.tar.bz2
   sha256: 88c174064ef88955702e4b31ff40266053e4faa8391f4227bdc94d36b6ee05da
   md5: 3f999d14101885385ee5c91aa8a82b58
   depends:
@@ -4439,7 +4439,7 @@ packages:
   license: BSD-3-Clause
   size: 6232599
   timestamp: 1682972067843
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
   sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
   md5: 93f5d7b66976154adeda219bea02ba45
   depends:
@@ -4449,7 +4449,7 @@ packages:
   license: BSD 2-Clause
   size: 484257
   timestamp: 1630093862501
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
   sha256: f95f5173ab2a4529b56ff90deec905dd53877250acedd3887fb289b721396009
   md5: 2ab1a555331747f19e4aa7a335e33a85
   depends:
@@ -4458,7 +4458,7 @@ packages:
   license_family: Apache
   size: 3665304
   timestamp: 1694465313538
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
   sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
   md5: 4154929ace2ad6ee16aea815635a6d1f
   depends:
@@ -4467,7 +4467,7 @@ packages:
   license_family: Apache
   size: 73598
   timestamp: 1693575307570
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-1.4.4-py39he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-1.4.4-py39he9d5cce_0.tar.bz2
   sha256: 9c8c14f79f0a2b8ffb3f19cc9bf80eabac6d27c39266eeb6dffa76354cbb96c0
   md5: 4e87084b61971e7a8198fbae451403fe
   depends:
@@ -4482,7 +4482,7 @@ packages:
   license_family: BSD
   size: 12634563
   timestamp: 1663773428164
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
   sha256: ddcb56e35d537f7a748b242c7c44368f112471973a52ae022945f597b7a83c7c
   md5: 94bac4f8fbfaf821ace161b9f1f58716
   depends:
@@ -4496,7 +4496,7 @@ packages:
   license_family: BSD
   size: 36756
   timestamp: 1698702713944
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
   sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
   md5: be0a90921f3bf4f0d6950fb786093de7
   depends:
@@ -4515,7 +4515,7 @@ packages:
   license_family: Other
   size: 719901
   timestamp: 1696580194417
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
   sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
   md5: 81ae9ec2d7fcf6934847bff558b619f5
   depends:
@@ -4526,7 +4526,7 @@ packages:
   license_family: MIT
   size: 2672987
   timestamp: 1697548890181
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
   sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
   md5: 1a822c206e2abddc5d6d821721af227f
   depends:
@@ -4535,7 +4535,7 @@ packages:
   license_family: MIT
   size: 33013
   timestamp: 1692205801265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
   sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
   md5: 1604d33dbdb2446c642970f8b354bedb
   depends:
@@ -4544,7 +4544,7 @@ packages:
   license_family: Apache
   size: 91266
   timestamp: 1659455269141
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
   sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
   md5: d1b3bcc35655a3123acb1fa2ad1a8511
   depends:
@@ -4556,7 +4556,7 @@ packages:
   license_family: BSD
   size: 580828
   timestamp: 1672387372015
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
   sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
   md5: 7540555d1fb192236db9a7c5c9d3601c
   depends:
@@ -4565,7 +4565,7 @@ packages:
   license_family: BSD
   size: 365765
   timestamp: 1656431373327
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
   sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
   md5: 0a73533fb6e0dc717ab906a537bc747d
   depends:
@@ -4577,7 +4577,7 @@ packages:
   license_family: BSD
   size: 30803
   timestamp: 1675441638631
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
   sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
   md5: 0a959fbad46ab38ade48dbd358002674
   depends:
@@ -4586,7 +4586,7 @@ packages:
   license_family: BSD
   size: 1864757
   timestamp: 1684280094736
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
   sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
   md5: ea24b5076ef79e4567c5a3f0cb22b470
   depends:
@@ -4596,7 +4596,7 @@ packages:
   license_family: Apache
   size: 95330
   timestamp: 1690223465114
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
   sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
   md5: bcaea6d4a47e9c874becaa700c78dcf7
   depends:
@@ -4605,7 +4605,7 @@ packages:
   license_family: MIT
   size: 157216
   timestamp: 1661452617825
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
   sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
   md5: 707110d1b49cb1864acb0bbaa103591e
   depends:
@@ -4614,7 +4614,7 @@ packages:
   license_family: MIT
   size: 95016
   timestamp: 1636111184034
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
   sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
   md5: 113a443b9c706f9f9c6187c0eaa3de27
   depends:
@@ -4623,7 +4623,7 @@ packages:
   license_family: BSD
   size: 31178
   timestamp: 1605305861851
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h218abb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h218abb5_0.tar.bz2
   sha256: 697361922d420f6e9897ee11a4440beaaf189bbdaa8b2944ca0c54910a9cda2d
   md5: eb283815f176fd7109b34391d5b4ce7b
   depends:
@@ -4642,7 +4642,7 @@ packages:
   license_family: PSF
   size: 13325074
   timestamp: 1694438828125
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
   sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
   md5: 47c5e22e31ec05a7bc0ce90065a53afd
   depends:
@@ -4651,7 +4651,7 @@ packages:
   license_family: BSD
   size: 265348
   timestamp: 1661368839620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-lmdb-1.4.1-py39hcec6c5f_0.tar.bz2
   sha256: fa3f9b9aa7e0a71e0a7237adf0fdede90808fda954bebd4d10b4bea97ab7f62f
   md5: dc1fb278f98f80996a6642a03a007f34
   depends:
@@ -4661,7 +4661,7 @@ packages:
   license_family: Other
   size: 136975
   timestamp: 1682522551539
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-snappy-0.6.0-py39h23ab428_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-snappy-0.6.0-py39h23ab428_3.tar.bz2
   sha256: 54fc39c298451ed5d0e1059fdf6f2f5c0373c5f7bb56cf00018eeaa39cc0bda5
   md5: 7419fca10878b2a2b3db392af8a905ea
   depends:
@@ -4672,7 +4672,7 @@ packages:
   license_family: BSD
   size: 30136
   timestamp: 1610133399999
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
   sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
   md5: ce9a69e1668aa1e133f2aa6d4e8d346f
   depends:
@@ -4681,7 +4681,7 @@ packages:
   license_family: MIT
   size: 254958
   timestamp: 1695131709704
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pywavelets-1.4.1-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pywavelets-1.4.1-py39h6c40b1e_0.tar.bz2
   sha256: 5487ed899728b746fe5525ebdd3be0f8c4d0f1125c1e053a47305cb8ff10a892
   md5: 1b3547135510c1707cd002fcd1cc3ce8
   depends:
@@ -4691,7 +4691,7 @@ packages:
   license_family: MIT
   size: 4498115
   timestamp: 1670425476297
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
   sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
   md5: 637f08b19dd8fd87347d8c44f9e3e202
   depends:
@@ -4701,7 +4701,7 @@ packages:
   license_family: MIT
   size: 170776
   timestamp: 1698096100056
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
   sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
   md5: 8ce3ac7d8a04e469b566f1b090d01140
   depends:
@@ -4712,7 +4712,7 @@ packages:
   license_family: BSD
   size: 470617
   timestamp: 1657724324011
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -4721,7 +4721,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
   sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
   md5: 6f2d41dd76a03b7f85a1ed49af1763d6
   depends:
@@ -4737,7 +4737,7 @@ packages:
   license_family: Apache
   size: 95100
   timestamp: 1690400262627
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scikit-image-0.19.3-py39hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/scikit-image-0.19.3-py39hcec6c5f_1.tar.bz2
   sha256: 12b8cb2f2d885528e0b80f209c083163ba5b4dcba06abebf9abf75ff9d4cf2c0
   md5: aa035de764b427c6eb8f474cee28d935
   depends:
@@ -4764,7 +4764,7 @@ packages:
   license_family: BSD
   size: 11617992
   timestamp: 1669243292979
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.9.3-py39hf241641_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/scipy-1.9.3-py39hf241641_2.tar.bz2
   sha256: 1e24803f201bd254d11a1abbb98e34b1f5bd7a784ee55a412b6fccdccd831c2d
   md5: 60d3f528d752ba0baa3daf7d1ef8bdff
   depends:
@@ -4782,7 +4782,7 @@ packages:
   license_family: BSD
   size: 24139551
   timestamp: 1683295252735
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
   md5: b0321e6f14e139fc15b1f8b4acb35d2f
   depends:
@@ -4791,7 +4791,7 @@ packages:
   license_family: MIT
   size: 1093966
   timestamp: 1690290944588
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.1.9-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/snappy-1.1.9-he9d5cce_0.tar.bz2
   sha256: c7af3280189c023d0c7380a7c1bdda2f2f09b036aa507c2650503b041037bf55
   md5: 58260ae8dcdaf2ec4a07bb1bdb451b34
   depends:
@@ -4800,7 +4800,7 @@ packages:
   license_family: BSD
   size: 1357241
   timestamp: 1649923925096
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
   sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
   md5: 62b64576a0aa5f6c3fb05f56650d25e1
   depends:
@@ -4809,7 +4809,7 @@ packages:
   license_family: Apache
   size: 15535
   timestamp: 1614030509324
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
   sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
   md5: 15b5595b31e39f08eaacbe2e502d8fb3
   depends:
@@ -4818,7 +4818,7 @@ packages:
   license_family: MIT
   size: 67292
   timestamp: 1696347733587
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
   sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
   md5: 82e4db6a498480a75d53c55bd35b6478
   depends:
@@ -4830,7 +4830,7 @@ packages:
   license_family: Other
   size: 1801397
   timestamp: 1681394807900
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -4839,7 +4839,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
   sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
   md5: 63b957927b9949ccb19da28ec4612706
   depends:
@@ -4850,7 +4850,7 @@ packages:
   license_family: BSD
   size: 30902
   timestamp: 1671751919031
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/testpath-0.6.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/testpath-0.6.0-py39hecd8cb5_0.tar.bz2
   sha256: afedb4f5a1147897a717c3f6506868f276c484cadfd90f0094a2285c0f6ffb02
   md5: 4177a92eb0747cc976aa95bf098e936e
   depends:
@@ -4859,7 +4859,7 @@ packages:
   license_family: BSD
   size: 94297
   timestamp: 1655908928089
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/thrift-0.17.0-py39he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/thrift-0.17.0-py39he9d5cce_0.tar.bz2
   sha256: bc71414b17e42369a8a5c84b06ce7d115e79a7f144eb4b928fc3f2a5d231ce2b
   md5: 99c262b3ce5ca4ceabbf634437812dba
   depends:
@@ -4870,7 +4870,7 @@ packages:
   license_family: APACHE
   size: 126998
   timestamp: 1666296594473
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tifffile-2023.4.12-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tifffile-2023.4.12-py39hecd8cb5_0.tar.bz2
   sha256: 13162f88448df807f9fa41232903cbed3f849df65438d0ac30bdd7dbf8c4b7db
   md5: 147a36c1ebe687e64248248c8aeb4d88
   depends:
@@ -4883,7 +4883,7 @@ packages:
   license_family: BSD
   size: 376827
   timestamp: 1695107569165
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
   sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
   md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
   depends:
@@ -4892,7 +4892,7 @@ packages:
   license_family: BSD
   size: 3536231
   timestamp: 1654088937695
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
   sha256: 74fc3a9e308602b3710f8fa671f24f5492571d0c8f7c1b3071dac72671262d45
   md5: e08ead92568f5bd72d5ac7f08f087fee
   depends:
@@ -4901,7 +4901,7 @@ packages:
   license_family: BSD
   size: 102258
   timestamp: 1667464155001
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
   sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
   md5: a1bbf0abfb8c45541122c0eb2feee317
   depends:
@@ -4910,7 +4910,7 @@ packages:
   license_family: Apache
   size: 680464
   timestamp: 1696937112175
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
   sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
   md5: d689f6203c0a9d04fb229c73d7e80a7a
   depends:
@@ -4923,7 +4923,7 @@ packages:
   license_family: MOZILLA
   size: 125145
   timestamp: 1679561909274
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
   md5: 8a292c1ee22489bef2e84bc3aaf4098e
   depends:
@@ -4932,7 +4932,7 @@ packages:
   license_family: BSD
   size: 193141
   timestamp: 1671143985219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
   md5: 8bf0bfffc11ad06a1c94e145941b0ad4
   depends:
@@ -4942,7 +4942,7 @@ packages:
   license_family: PSF
   size: 9651
   timestamp: 1690297655669
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
   md5: 343514a174b3485fde55a73f56398dd7
   depends:
@@ -4951,7 +4951,7 @@ packages:
   license_family: PSF
   size: 58456
   timestamp: 1690297648002
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
   sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
   md5: c2242e8fd24003a74ddf37416661e06d
   depends:
@@ -4966,7 +4966,7 @@ packages:
   license_family: MIT
   size: 188757
   timestamp: 1698257668273
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
   sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
   md5: 41f445e36b6b6722a9444508eef069f8
   depends:
@@ -4975,7 +4975,7 @@ packages:
   license_family: BSD
   size: 20583
   timestamp: 1607365395045
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
   sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
   md5: 409ee46ed24267b6da6fb32d13e1f21e
   depends:
@@ -4985,7 +4985,7 @@ packages:
   license_family: BSD
   size: 70730
   timestamp: 1614804271285
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
   sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
   md5: eb74e74d8e4fd533c55eb98b7b5e83bc
   depends:
@@ -4994,7 +4994,7 @@ packages:
   license_family: MIT
   size: 102637
   timestamp: 1695742077778
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
   sha256: 9f5a34bef727052f97b1cc387c3a99a60754de99d6e4ab0b2de770d76b64dc0f
   md5: b5ce0421037c626cfcec5b43d83ec420
   depends:
@@ -5006,20 +5006,20 @@ packages:
   license_family: Apache
   size: 1787999
   timestamp: 1689041573350
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
   sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
   md5: e243baa546432c8394a8059a44a5a3e4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 419227
   timestamp: 1683113010463
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
   sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
   md5: fe4ac85ee86d3a94ea3a4ebea3779763
   depends:
@@ -5028,7 +5028,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 321797
   timestamp: 1616055526986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zfp-1.0.0-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zfp-1.0.0-hcec6c5f_0.tar.bz2
   sha256: 47bde98853cb2914d8d63d58615edd7c9a788c5590a6a0a5c14d41051577559b
   md5: c2e85e2f1be3fcee07bdf14d6a11519f
   depends:
@@ -5038,7 +5038,7 @@ packages:
   license_family: BSD
   size: 271809
   timestamp: 1681741643951
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zict-3.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 16e64fb88aec5586d199cf317f4e10cfd4cb84bc2ffa51254b44c569f7834d3f
   md5: 57b7c150445badc2b718691e67468091
   depends:
@@ -5049,7 +5049,7 @@ packages:
   license_family: BSD
   size: 77666
   timestamp: 1695833024405
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
   sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
   md5: bc7073d9d4c0211cc4a1207c98fb765a
   depends:
@@ -5058,14 +5058,14 @@ packages:
   license_family: MIT
   size: 19091
   timestamp: 1672387204865
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
   sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
   md5: 8e495591e369ac161857a72011c0a296
   license: Zlib
   license_family: Other
   size: 120272
   timestamp: 1666595024203
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
   sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
   md5: f1465fbd810b3746c6de6babfd4fe28a
   depends:
@@ -5077,7 +5077,7 @@ packages:
   license_family: BSD
   size: 1023573
   timestamp: 1681304595869
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
   sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
   md5: cf55cb8d7031b30c70c56fc7c782b5c7
   depends:
@@ -5090,7 +5090,7 @@ packages:
   license_family: MIT
   size: 156104
   timestamp: 1644482799136
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aom-3.6.0-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aom-3.6.0-h313beb8_0.tar.bz2
   sha256: a26e4cb399cee40b3b513563d22a8f8f87b15cfdfd645cffeb48f57a85db3ee6
   md5: 2e643e2e6830fea3f7d6ac729f8bbccb
   depends:
@@ -5099,7 +5099,7 @@ packages:
   license_family: BSD
   size: 2647589
   timestamp: 1688660588288
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
   sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
   md5: 84fce327d9f0d594e86f565e5c21962e
   depends:
@@ -5108,7 +5108,7 @@ packages:
   license_family: BSD
   size: 10183
   timestamp: 1629146082730
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
   sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
   md5: 84b8b998a741b37abf5312c1c03696ef
   depends:
@@ -5118,7 +5118,7 @@ packages:
   license_family: MIT
   size: 33979
   timestamp: 1644845817952
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
   sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
   md5: 77b746931c8f31c3ae393ccb5819d43d
   depends:
@@ -5127,7 +5127,7 @@ packages:
   license_family: MIT
   size: 133628
   timestamp: 1695717890677
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
   sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
   md5: 3df6e8ba34208dea068890e5d5318cc0
   depends:
@@ -5137,12 +5137,12 @@ packages:
   license_family: MIT
   size: 206759
   timestamp: 1681493095987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
   sha256: d51b7b5841be320209706d8e9caf669c0e0094f3a40e9eea51701a564ca7c2ed
   md5: 61647f79e0ae70e914fee23c40c4caea
   depends:
@@ -5154,7 +5154,7 @@ packages:
   license_family: BSD
   size: 43179
   timestamp: 1675247655207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-2.3.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-2.3.3-py39hca03da5_0.tar.bz2
   sha256: 3fd76b6a8b12726e0abe9c4d901791ad3825114f112eab2f4875e6023ac86852
   md5: 4314576480342e421939bb5db05e9192
   depends:
@@ -5171,7 +5171,7 @@ packages:
   license_family: BSD
   size: 8654537
   timestamp: 1628862423516
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
   sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
   md5: bb55f81435cb6e11d264242274fccd1a
   depends:
@@ -5181,7 +5181,7 @@ packages:
   license_family: BSD
   size: 115947
   timestamp: 1657175645380
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
   md5: f860193e14afc7ef3f5b990a2ac003d2
   depends:
@@ -5191,7 +5191,7 @@ packages:
   license: MIT
   size: 18936
   timestamp: 1659616204016
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
   sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
   md5: ad53130f3fd1f8d3c2fcbb7496e5585d
   depends:
@@ -5200,7 +5200,7 @@ packages:
   license: MIT
   size: 18715
   timestamp: 1659616188888
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
   sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
   md5: 0982c046fb976e9f9fb19e7510187a18
   depends:
@@ -5209,7 +5209,7 @@ packages:
   license: MIT
   size: 366983
   timestamp: 1659616245272
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brunsli-0.1-hc377ac9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brunsli-0.1-hc377ac9_1.tar.bz2
   sha256: 5fb3dec9b529843f2b77a486869ffe193debac7698159c0be6d50569b14402f9
   md5: 0034c14344b0f61079b867bd32835beb
   depends:
@@ -5219,28 +5219,28 @@ packages:
   license_family: MIT
   size: 178533
   timestamp: 1628860668184
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
   sha256: 019469288da4767fd021f488b907e2f4f3b34db686fa12055d52d9bb7bb4d872
   md5: 9f63c782a4d20150ae9a664ee87cce16
   license: bzip2-1.0.6
   license_family: BSD
   size: 150682
   timestamp: 1624215191959
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
   sha256: b0be79290b1df1cf1d07a1a9c3f3a92ae262643a6df3dc10dfbac22a82874dd4
   md5: 8fdcf1c08eee91fec7eefc22863c816a
   license: MIT
   license_family: MIT
   size: 106550
   timestamp: 1693902036526
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
   sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
   md5: 31ac2f5596cb7a44adf073c930641c54
   license: MPL-2.0
   license_family: Other
   size: 133817
   timestamp: 1694009762858
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
   sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
   md5: cf1f6c3c34a1e1b9ab22b04233d860f6
   depends:
@@ -5249,7 +5249,7 @@ packages:
   license_family: Other
   size: 159783
   timestamp: 1690232303987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
   sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
   md5: 0eb268e38b5174d471a6e87d9d6102b1
   depends:
@@ -5260,7 +5260,7 @@ packages:
   license_family: MIT
   size: 225355
   timestamp: 1670423312966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
   sha256: 3ba74ebffd6bc4bc451864f85048dec9b6ad085eb1904ce3e5450376e15f050e
   md5: 289f238ac78b174f01c8a2b252b17735
   depends:
@@ -5272,7 +5272,7 @@ packages:
   license_family: Other
   size: 1243641
   timestamp: 1655814869383
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/charls-2.2.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/charls-2.2.0-hc377ac9_0.tar.bz2
   sha256: c048ecfd192b1c4844c077b778814be1f62017dd578bf4bf6f199be5fc7ffc65
   md5: 3998b53d542b1c04175df5d214926067
   depends:
@@ -5281,7 +5281,7 @@ packages:
   license_family: BSD
   size: 91429
   timestamp: 1628861281402
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
   sha256: 41e76ba21b1279278a039245275eb4ee1f81b38b33cba00ca3575f06be5dc570
   md5: c5170bf12e308fb7f2d1b4b9065f3df7
   depends:
@@ -5290,7 +5290,7 @@ packages:
   license_family: BSD
   size: 153036
   timestamp: 1698129857856
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
   sha256: 36240dde0a1546469f35f3b5509b55384dfd894beb56b3ca929da4b96a2a5f24
   md5: 844539636e4c20ee99e8ceeff5e902bc
   depends:
@@ -5299,7 +5299,7 @@ packages:
   license_family: BSD
   size: 41376
   timestamp: 1683040042906
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
   sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
   md5: e68c94666cd60221b575c3814c89bac0
   depends:
@@ -5309,7 +5309,7 @@ packages:
   license_family: CC
   size: 1946451
   timestamp: 1668084573824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
   sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
   md5: 1773ae2b080cdd55827e27673351551e
   depends:
@@ -5319,7 +5319,7 @@ packages:
   license_family: BSD
   size: 13646
   timestamp: 1671231171682
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
   sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
   md5: 53bfd99ad1b09164d537209cffd98161
   depends:
@@ -5330,7 +5330,7 @@ packages:
   license_family: BSD
   size: 244040
   timestamp: 1663827469853
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39h3c57c4d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39h3c57c4d_0.tar.bz2
   sha256: ed97835694caa43a6d6244a9391ace52d0643a13d9184d71ef293062fd0cd4c1
   md5: 2d5122f002a138354102289a2c7a8560
   depends:
@@ -5343,7 +5343,7 @@ packages:
   license_family: BSD
   size: 1398898
   timestamp: 1694212091070
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cytoolz-0.12.0-py39h1a28f6b_0.tar.bz2
   sha256: 25f89dccae875d5f73e6bb41ab8bf5b39972715a304e8ce64cee93585d129825
   md5: a7c6f8274e12b068638fac6e43e9d10e
   depends:
@@ -5353,7 +5353,7 @@ packages:
   license_family: BSD
   size: 361259
   timestamp: 1667466038174
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
   sha256: 83dbf9755ea887576e3f34adb1c26d418db9aaf3c77dc07f30b58c2221b81c72
   md5: 36246697d07d6709de78abe36b6beae5
   depends:
@@ -5365,14 +5365,14 @@ packages:
   license_family: BSD
   size: 103201
   timestamp: 1629793063728
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dav1d-1.2.1-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/dav1d-1.2.1-h80987f9_0.tar.bz2
   sha256: cdc3829b4dacd2c09ffcea509947b99dbe12eff4c9fd5f0d412795e2d3648b04
   md5: cb80d50ff320b1865a31c59c9602ea4b
   license: BSD-2-Clause
   license_family: BSD
   size: 397700
   timestamp: 1688746000695
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
   sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
   md5: eb3cdc0fc210838b9271512a6a1b7c85
   depends:
@@ -5382,7 +5382,7 @@ packages:
   license_family: MIT
   size: 2067708
   timestamp: 1690905319109
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2021.9.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/distributed-2021.9.1-py39hca03da5_0.tar.bz2
   sha256: 60321d643db4e97cdab9771e91ef82a9a6f4dec094d489e32d155a225d08de04
   md5: ce360ec4c30b95c10dba6a0587308eb6
   depends:
@@ -5407,7 +5407,7 @@ packages:
   license_family: BSD
   size: 1093111
   timestamp: 1634756049598
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
   sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
   md5: f44b80b9405410e5bde6bfe0b31d5b3f
   depends:
@@ -5416,7 +5416,7 @@ packages:
   license_family: MIT
   size: 15135
   timestamp: 1650293774207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
   sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
   md5: f87027ccce1361d0f82c0edf1a10d53b
   depends:
@@ -5425,7 +5425,7 @@ packages:
   license_family: BSD
   size: 27677
   timestamp: 1668714367519
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-0.5.0-py39heec5a64_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fastparquet-0.5.0-py39heec5a64_2.tar.bz2
   sha256: 9a4d39c84248a0a99858e130a0c9c20d70bc9f4eb31831a9a5d13420c8bef06e
   md5: 17a7259e3c9ddc46474358d35f04b428
   depends:
@@ -5441,13 +5441,13 @@ packages:
   license_family: Apache
   size: 179441
   timestamp: 1658500663439
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fftw-3.3.9-h1a28f6b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fftw-3.3.9-h1a28f6b_1.tar.bz2
   sha256: dc457fe0cde973b789306f64f8cc0b5b0a5512e3685749e34ab8713d3cad9840
   md5: 9c5ac82ba31104f8cbff795ceb5c7901
   license: GPL 2
   size: 1638590
   timestamp: 1630601990060
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -5457,7 +5457,7 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
   sha256: 296371685a5dcd98f5128f11f413e63aa59c1eba60543faf3baaebd445964c5d
   md5: 9817e8ffd3669484c9a7de99a8aceffb
   depends:
@@ -5466,14 +5466,14 @@ packages:
   license_family: BSD
   size: 257844
   timestamp: 1695734566410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
   sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
   md5: 1d0bd7e576c64c059ef781dd319ad82a
   license: MIT
   license_family: MIT
   size: 77591
   timestamp: 1676983230102
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
   sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
   md5: 83366cbd3beb073112f4644a613b6bca
   depends:
@@ -5482,7 +5482,7 @@ packages:
   license_family: BSD
   size: 111933
   timestamp: 1666125627512
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/imagecodecs-2023.1.23-py39h604db08_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/imagecodecs-2023.1.23-py39h604db08_0.tar.bz2
   sha256: 89ffcea806e825fc2ee2838b692bf52ced7edf36ce129f9d174d0c72714a1e22
   md5: ea28577650b6a4e22a0d19748d6e88df
   depends:
@@ -5520,7 +5520,7 @@ packages:
   license_family: BSD
   size: 10138065
   timestamp: 1695065789385
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/imageio-2.31.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/imageio-2.31.4-py39hca03da5_0.tar.bz2
   sha256: a0dd6e0dd0ba634ea90e37500765b742d75d5543a91748b255caac0010b83509
   md5: b3b777ef913aaea8a516e8d8d26ed7fe
   depends:
@@ -5531,7 +5531,7 @@ packages:
   license_family: BSD
   size: 508873
   timestamp: 1695996477512
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
   sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
   md5: 647c1a2f8460ffa8c670a1915bbdb494
   depends:
@@ -5541,7 +5541,7 @@ packages:
   license_family: APACHE
   size: 38790
   timestamp: 1678997152549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
   sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
   md5: 35e541905426c686ef2ff010a0e502fd
   depends:
@@ -5551,7 +5551,7 @@ packages:
   license_family: Apache
   size: 51860
   timestamp: 1698254731870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
   sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
   md5: 187d7720aedf38759d122cccb4576f2c
   depends:
@@ -5573,7 +5573,7 @@ packages:
   license_family: BSD
   size: 219976
   timestamp: 1691121991680
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
   sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
   md5: e8e7f10741f9cfa737b310b334940441
   depends:
@@ -5595,7 +5595,7 @@ packages:
   license_family: BSD
   size: 1255894
   timestamp: 1694181494549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
   sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
   md5: ff209e75aee17af2e358b0008fbe8c88
   depends:
@@ -5605,14 +5605,14 @@ packages:
   license_family: MIT
   size: 1022945
   timestamp: 1644315931223
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
   sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
   md5: 055e12390b844ea6c6e956ee08a618e8
   license: IJG
   license_family: Other
   size: 273479
   timestamp: 1677849171867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
   sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
   md5: 783e2ad3d36472648c5ccc9f3051db3c
   depends:
@@ -5623,7 +5623,7 @@ packages:
   license_family: MIT
   size: 133077
   timestamp: 1676558732505
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
   sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
   md5: 0677598f673f9729b5990316170a999d
   depends:
@@ -5639,7 +5639,7 @@ packages:
   license_family: BSD
   size: 197129
   timestamp: 1676329661580
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
   sha256: 05f9ca0fdcfdc2e217438be27fead588c843a3aadf7d034467c83216d1e5c214
   md5: 2d648b77d817ba38293c0728711ba8f5
   depends:
@@ -5650,7 +5650,7 @@ packages:
   license_family: BSD
   size: 92852
   timestamp: 1679906632236
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
   sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
   md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
   depends:
@@ -5674,14 +5674,14 @@ packages:
   license_family: BSD
   size: 401319
   timestamp: 1671707682572
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jxrlib-1.1-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jxrlib-1.1-h1a28f6b_2.tar.bz2
   sha256: bd9a167e45cb8cb9710b5a19c498a67ac78d57f252be120973e347dbdd93aa36
   md5: 5db215a69fb5d3f393e58bc6e5df5a3a
   license: BSD-2-Clause
   license_family: BSD
   size: 220109
   timestamp: 1628860886330
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
   sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
   md5: 247558a0aecf1ef7e77a4343761353d6
   depends:
@@ -5691,7 +5691,7 @@ packages:
   license_family: BSD
   size: 64600
   timestamp: 1672387273585
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
   sha256: e547a4a540ccc9db683d6d2e3e36b0d0ad99e1ad10b22b5f403af3e893b412ba
   md5: dc5ae0ece3c4990ba5fee7b266f2a019
   depends:
@@ -5702,7 +5702,7 @@ packages:
   license_family: MIT
   size: 1306804
   timestamp: 1686931342120
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lazy_loader-0.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lazy_loader-0.3-py39hca03da5_0.tar.bz2
   sha256: 03937c9ae92debaf8eb966a8e293bccfbe34870f19c86e54ddc46a699e4d6e81
   md5: 49b7c74927016b9d6a24b7799da3ce15
   depends:
@@ -5711,7 +5711,7 @@ packages:
   license_family: BSD
   size: 18413
   timestamp: 1695850162765
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -5721,7 +5721,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -5730,7 +5730,7 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libaec-1.0.4-hc377ac9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libaec-1.0.4-hc377ac9_1.tar.bz2
   sha256: 7fb9ae8531636f858e80fa142bc518ec5ffe2c50e655d0b5e66982a5abd42c5b
   md5: e97f2f3ed8030db3ed46111dc6d0dbaa
   depends:
@@ -5739,7 +5739,7 @@ packages:
   license_family: BSD
   size: 25647
   timestamp: 1628861308643
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libavif-0.11.1-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libavif-0.11.1-h80987f9_0.tar.bz2
   sha256: 7693526f3d7e012ce568832508982154cc65e6afaacb172623e64c8f5b863e75
   md5: bfd3a5c3793bce213c83bd8b1b837fe8
   depends:
@@ -5749,13 +5749,13 @@ packages:
   license_family: BSD
   size: 92755
   timestamp: 1689158136997
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
   md5: a0f206782751dfffed0dd51302a1bf26
   license: MIT
   size: 68012
   timestamp: 1659616138077
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
   md5: 4c6667cdd061d28e9bc4e4300e4d115e
   depends:
@@ -5763,7 +5763,7 @@ packages:
   license: MIT
   size: 31173
   timestamp: 1659616155596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
   md5: 637e9430e258ddf050623ef2360184d8
   depends:
@@ -5771,7 +5771,7 @@ packages:
   license: MIT
   size: 298430
   timestamp: 1659616172209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
   sha256: a94cc52c1ca2e421342d2fefc6d7774ff5118b9d01f4e22d33314f8520d33723
   md5: 440575339cec83722e83087db31127bf
   depends:
@@ -5786,21 +5786,21 @@ packages:
   license_family: MIT
   size: 342121
   timestamp: 1693515586487
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20221030-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libedit-3.1.20221030-h80987f9_0.tar.bz2
   sha256: 6304be2cb816e57ac178068d49befffba4354847f9ee1cfd0ec6acf9ba4ad94a
   md5: af25d1cc1334d44d2b96eb8133c1dac9
   depends:
@@ -5809,21 +5809,21 @@ packages:
   license_family: BSD
   size: 167428
   timestamp: 1670840153090
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
   sha256: 6fc572025852b210ecddcca3ab9ff3f1d5f6bd91f1933c6e296de6bb331f6b5d
   md5: 6dd7d9c5737bbd2a27d18f15318dc3e6
   license: BSD-2-Clause
   license_family: BSD
   size: 102059
   timestamp: 1628961869728
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
   sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
   md5: 55c615026c0869f8d3ba657f3bd38c43
   license: MIT
   license_family: MIT
   size: 120389
   timestamp: 1683716579036
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -5832,7 +5832,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -5843,7 +5843,7 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm11-11.1.0-h12f7ac0_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libllvm11-11.1.0-h12f7ac0_6.tar.bz2
   sha256: 6450802cad40b813a99572891811830758393500f4c79a223e1046918872c3f7
   md5: 616a6976906afa0035a2dc2ea1c34195
   depends:
@@ -5853,7 +5853,7 @@ packages:
   license_family: Apache
   size: 21766415
   timestamp: 1665076236980
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
   sha256: 039483aadb821adffcc2aff761ec35474d633b6bc2f1eb7cce877a881d7ed290
   md5: d75b21db95481154cfa9d7a871f0f3bf
   depends:
@@ -5868,7 +5868,7 @@ packages:
   license_family: MIT
   size: 743061
   timestamp: 1686931613436
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -5879,7 +5879,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -5888,13 +5888,13 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
   sha256: 48a8617773b57a4b9a8539782bf88a317f49a644d3f858aa0ad3ab13afc03ae7
   md5: c3bc0fb3cc9a98ef1f2f83ef497fc5da
   depends:
@@ -5903,7 +5903,7 @@ packages:
   license_family: BSD
   size: 334616
   timestamp: 1686931322663
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -5920,7 +5920,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
   sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
   md5: 98d22e0124d55fae3c37c608dab1dcc9
   depends:
@@ -5934,7 +5934,7 @@ packages:
   license_family: BSD
   size: 89825
   timestamp: 1694778225280
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
   sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
   md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
   constrains:
@@ -5943,7 +5943,7 @@ packages:
   license_family: BSD
   size: 331675
   timestamp: 1694776939192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzopfli-1.0.3-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libzopfli-1.0.3-hc377ac9_0.tar.bz2
   sha256: 18eda005925fe6aaddb1a7a207b4ecab85981794cf1fba0fa72b765d59e4fe18
   md5: 042769990cec17f009a3088932e8e1c3
   depends:
@@ -5952,7 +5952,7 @@ packages:
   license_family: Apache
   size: 149220
   timestamp: 1628860942228
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -5961,7 +5961,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.38.0-py39h98b2900_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.38.0-py39h98b2900_0.tar.bz2
   sha256: d6aacfb6a6c3ec24e102b92b8e7b892cba9ba04aacae0b58592c9ccf34b37e94
   md5: 690806f2b38f73149631ed90184d041c
   depends:
@@ -5972,7 +5972,7 @@ packages:
   license: BSD-2-Clause
   size: 248899
   timestamp: 1647870588042
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
   sha256: 83e1c11fb14ec2767e833b540a6a0fdbd8641523b5673273914007008e6666da
   md5: 64adbf70a0d4ab82aca039e972821537
   depends:
@@ -5981,7 +5981,7 @@ packages:
   license_family: BSD
   size: 11877
   timestamp: 1652903192510
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
   sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
   md5: c99006da802a97c9aae30da8c16b4820
   depends:
@@ -5990,7 +5990,7 @@ packages:
   license_family: BSD
   size: 176131
   timestamp: 1670944706815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
   sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
   md5: 60bd1e037cda86205526f77405d78129
   depends:
@@ -6000,7 +6000,7 @@ packages:
   license_family: BSD
   size: 123361
   timestamp: 1671541992772
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.0.1-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.0.1-py39h1a28f6b_0.tar.bz2
   sha256: f45d137efb14a7e0b98a1de97b0163e8855a973d66087d111b858542fbd90e8e
   md5: 7f0950f7949c480df40841c942220785
   depends:
@@ -6009,7 +6009,7 @@ packages:
   license_family: BSD
   size: 22441
   timestamp: 1629137471723
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
   sha256: bf0eeef3c3c713515766ab8b0dc7863413de5b4b227deede97e24d90ca342345
   md5: a7bba1857eb84fb50caea377e60d2050
   depends:
@@ -6031,7 +6031,7 @@ packages:
   license_family: PSF
   size: 8066509
   timestamp: 1698692266161
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
   sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
   md5: eb79dabbeedee7da85dfbfb145bb8a26
   depends:
@@ -6041,7 +6041,7 @@ packages:
   license_family: BSD
   size: 17342
   timestamp: 1662014601345
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
   sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
   md5: 56db7bd3ff511cd839bda081523b3edd
   depends:
@@ -6050,7 +6050,7 @@ packages:
   license_family: BSD
   size: 55683
   timestamp: 1629356128780
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py39h525c30c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/msgpack-python-1.0.3-py39h525c30c_0.tar.bz2
   sha256: 20021076eaf466a3bd28a11a5fa28d1cec5fefcaa37d01de8e34c29bc560f8e3
   md5: 48de2033df7f3739fa92f9e9e150e2d5
   depends:
@@ -6060,7 +6060,7 @@ packages:
   license_family: Apache
   size: 85401
   timestamp: 1652362790532
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
   sha256: ee936ba5fd196c15c3cb538aef721e54bb4486110ae3ebbfcf78e95e8380efa4
   md5: dde1d9e040e04cbfbc0138898240a660
   depends:
@@ -6070,7 +6070,7 @@ packages:
   license_family: BSD
   size: 23003
   timestamp: 1629282780853
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
   sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
   md5: 176e0dcaeb28393881bacf69941e3889
   depends:
@@ -6096,7 +6096,7 @@ packages:
   license_family: BSD
   size: 8289638
   timestamp: 1681756329011
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
   sha256: afc6f332c51a3defc69e4c4e641988c0556039b9cd42be22f3db5292c88ccf37
   md5: 2bc409c7258160a9b739d08d5ffb5998
   depends:
@@ -6109,7 +6109,7 @@ packages:
   license_family: BSD
   size: 96942
   timestamp: 1650373637069
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.4.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.4.4-py39hca03da5_0.tar.bz2
   sha256: a1fd61058ae6f17199f400d6f5c825d09b1f256ec438f35d70dcd5af1dccfec4
   md5: e8128902044ffc309f5dda3aaf669cfe
   depends:
@@ -6134,7 +6134,7 @@ packages:
   license_family: BSD
   size: 581692
   timestamp: 1649751973819
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
   sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
   md5: 37163b32508f9f589b3e6462a3a47546
   depends:
@@ -6147,14 +6147,14 @@ packages:
   license_family: BSD
   size: 148426
   timestamp: 1694616771736
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
   sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
   md5: 6cdf7cbc43bf40e92b056a5576bd0086
   depends:
@@ -6163,7 +6163,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387216468
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/networkx-3.1-py39hca03da5_0.tar.bz2
   sha256: 05a45d181b83b1eb136e35faf77bcd916adbdb49e178dd563da44f8227594956
   md5: cdded8a3b2576bf9a2f103d396c47889
   depends:
@@ -6172,7 +6172,7 @@ packages:
   license_family: BSD
   size: 2964776
   timestamp: 1690562172192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
   sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
   md5: 0f05853a139b6cda9c73e9d2707a4976
   depends:
@@ -6197,7 +6197,7 @@ packages:
   license_family: BSD
   size: 590288
   timestamp: 1690984971741
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
   sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
   md5: 7de782e4fb34bfa95ef2fc79d27d727d
   depends:
@@ -6207,7 +6207,7 @@ packages:
   license_family: BSD
   size: 22840
   timestamp: 1668160634885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.55.1-py39h9197a36_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numba-0.55.1-py39h9197a36_0.tar.bz2
   sha256: dd6e3f256f7919476495c3071c05a475fe40a69b6692ce35487826c51e9669a2
   md5: 63b4dd282c252fe5098296e36fd22ab3
   depends:
@@ -6226,7 +6226,7 @@ packages:
   license_family: BSD
   size: 3953464
   timestamp: 1648042338626
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
   sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
   md5: 1a7b23113372c5667dbfe45976b9cc5c
   depends:
@@ -6237,7 +6237,7 @@ packages:
   license_family: MIT
   size: 126357
   timestamp: 1696515322390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.21.5-py39h42add53_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.21.5-py39h42add53_3.tar.bz2
   sha256: 736fd00c741cc1d3a08723dae92c2af92836de160e6bf4e3bee8d7baab21d0c1
   md5: 5f4ff7fcd329a21ae9818edd5fd3266a
   depends:
@@ -6249,7 +6249,7 @@ packages:
   license: BSD-3-Clause
   size: 10612
   timestamp: 1653915976083
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.21.5-py39hadd41eb_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.21.5-py39hadd41eb_3.tar.bz2
   sha256: 5fedd658ac2bddea4fa2f2f47b4384305e0462cb6223438e3340528153523a6b
   md5: af4f98a5bbbe280a3ddb4639061d43fa
   depends:
@@ -6262,7 +6262,7 @@ packages:
   license: BSD-3-Clause
   size: 5577512
   timestamp: 1653915960518
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
   sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
   md5: 371358a54bbdd307603888348d1a2c6f
   depends:
@@ -6272,7 +6272,7 @@ packages:
   license: BSD 2-Clause
   size: 412248
   timestamp: 1628861367714
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
   sha256: 409ba99dd953129c0ccebb5dcbf2049920e5a755b88e7e392e4f91be924e26ef
   md5: f05f00606c10617a61c41f23652b9a00
   depends:
@@ -6281,7 +6281,7 @@ packages:
   license_family: Apache
   size: 3450897
   timestamp: 1694465216241
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
   sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
   md5: d73db95f07a282021efdf8bc09713261
   depends:
@@ -6290,7 +6290,7 @@ packages:
   license_family: Apache
   size: 73620
   timestamp: 1693575195999
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-1.4.4-py39hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-1.4.4-py39hc377ac9_0.tar.bz2
   sha256: 64a5c7f7365b8c837621daeeef7e9b5341829768cb89f72026e6827a75e677b6
   md5: ef101f092953ed17f9f0b7efa2a3cb03
   depends:
@@ -6305,7 +6305,7 @@ packages:
   license_family: BSD
   size: 12433056
   timestamp: 1663773462190
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
   sha256: 3a6450282f56265e800500b62cd1bbe39cd5a6a09c4747c6dc3e8aab10bfa8a0
   md5: 9b01b16f9c5a033ee8b92683d66b184e
   depends:
@@ -6319,7 +6319,7 @@ packages:
   license_family: BSD
   size: 36731
   timestamp: 1698702611592
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
   sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
   md5: 6e01c592ae3b8ff2d12cae76f2f4276b
   depends:
@@ -6338,7 +6338,7 @@ packages:
   license_family: Other
   size: 715239
   timestamp: 1696580071596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
   sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
   md5: 9fb8f460c130d56caf33c6bbe46fbe8a
   depends:
@@ -6349,7 +6349,7 @@ packages:
   license_family: MIT
   size: 2678841
   timestamp: 1697548790931
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
   sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
   md5: 390b8c3cd74281abecdbfd51476922f9
   depends:
@@ -6358,7 +6358,7 @@ packages:
   license_family: MIT
   size: 33033
   timestamp: 1692205747301
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
   sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
   md5: 7896828fb3565fefad43f980d50c8723
   depends:
@@ -6367,7 +6367,7 @@ packages:
   license_family: Apache
   size: 91190
   timestamp: 1659455206354
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
   sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
   md5: d934c74eb66d01af0f45f0881f4bab77
   depends:
@@ -6379,7 +6379,7 @@ packages:
   license_family: BSD
   size: 580588
   timestamp: 1672387390426
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
   sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
   md5: 9858166e5ffb624c8b9d281f4000d725
   depends:
@@ -6388,7 +6388,7 @@ packages:
   license_family: BSD
   size: 367167
   timestamp: 1656431368885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
   sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
   md5: 4d2b45c6be8221e6a3e44c2d5838426f
   depends:
@@ -6400,7 +6400,7 @@ packages:
   license_family: BSD
   size: 30843
   timestamp: 1675441531640
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
   sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
   md5: 02521df4e2e79f75faa9cbb3560ab1dd
   depends:
@@ -6409,7 +6409,7 @@ packages:
   license_family: BSD
   size: 1861763
   timestamp: 1684280026169
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
   sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
   md5: bdebe59bffc7adbad83fdcd9d429a5f5
   depends:
@@ -6419,7 +6419,7 @@ packages:
   license_family: Apache
   size: 95234
   timestamp: 1690223494699
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
   sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
   md5: d716e5c9b5eec45ce1df8eb52cab817a
   depends:
@@ -6428,7 +6428,7 @@ packages:
   license_family: MIT
   size: 157408
   timestamp: 1661452601692
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
   sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
   md5: 1907629863ed8e7c35ead232dae7693f
   depends:
@@ -6437,7 +6437,7 @@ packages:
   license_family: MIT
   size: 91636
   timestamp: 1628941083263
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
   sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
   md5: 847b9bddf2a86e1609c0d53bbc23ea79
   depends:
@@ -6446,7 +6446,7 @@ packages:
   license_family: BSD
   size: 27378
   timestamp: 1626781391140
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hc0d8a6c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hc0d8a6c_0.tar.bz2
   sha256: c1196bf843431971d2be79163c1de8c58803adef00c2cf6b354e8ddae0b82807
   md5: e425277de2855516905d3eeefb83cdae
   depends:
@@ -6465,7 +6465,7 @@ packages:
   license_family: PSF
   size: 13185496
   timestamp: 1694438378335
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
   sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
   md5: 45642a99c83e7aed74d1ffab1f20145b
   depends:
@@ -6474,7 +6474,7 @@ packages:
   license_family: BSD
   size: 266647
   timestamp: 1661368655993
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-lmdb-1.4.1-py39h313beb8_0.tar.bz2
   sha256: 120745bd4e38c1ad20fbaa6a43b932e4233c349959f12c71e8dc85bc4dbd78e7
   md5: 35ffa41c6c93dc92534cd1a1ed18be5b
   depends:
@@ -6484,7 +6484,7 @@ packages:
   license_family: Other
   size: 133586
   timestamp: 1682522585527
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-snappy-0.6.0-py39hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-snappy-0.6.0-py39hc377ac9_0.tar.bz2
   sha256: 57462d734e3f384eb34b719022cbc29f39eb06a25b15969c207576c75209a78b
   md5: 540f0ccb13d648f804d7b80224e6fe5e
   depends:
@@ -6495,7 +6495,7 @@ packages:
   license_family: BSD
   size: 31108
   timestamp: 1629480003392
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
   sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
   md5: fec748525144049a2fc7f52f9755232c
   depends:
@@ -6504,7 +6504,7 @@ packages:
   license_family: MIT
   size: 257235
   timestamp: 1695131702047
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pywavelets-1.4.1-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pywavelets-1.4.1-py39h80987f9_0.tar.bz2
   sha256: 13aff6394aeaf8a4194a041e991f8426efd00c211d43b128989863e439ef54e2
   md5: f712ce2bd1b4ad5504e28df3fee5c709
   depends:
@@ -6514,7 +6514,7 @@ packages:
   license_family: MIT
   size: 4476840
   timestamp: 1670425537144
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
   sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
   md5: 3445d25415998c807efbe64d3a7e03c8
   depends:
@@ -6524,7 +6524,7 @@ packages:
   license_family: MIT
   size: 167068
   timestamp: 1698096118071
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
   sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
   md5: e6e92da28e9b0e428ed4b7df417bec25
   depends:
@@ -6535,7 +6535,7 @@ packages:
   license_family: BSD
   size: 472418
   timestamp: 1657724315435
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -6544,7 +6544,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
   sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
   md5: dba22515f36d3c266de5896350813ea2
   depends:
@@ -6560,7 +6560,7 @@ packages:
   license_family: Apache
   size: 95103
   timestamp: 1690400315537
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scikit-image-0.20.0-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/scikit-image-0.20.0-py39h313beb8_0.tar.bz2
   sha256: 69db8008ff5259e7de097c15711fb5fdb991cc3a488c855c290111c1a7d1755e
   md5: 8349b9c78b726d6575eff5911749aca5
   depends:
@@ -6589,7 +6589,7 @@ packages:
   license_family: BSD
   size: 11685800
   timestamp: 1682528582387
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.9.1-py39h9d039d2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.9.1-py39h9d039d2_0.tar.bz2
   sha256: 967f0725324b516022bed288ddd5719d8c1702a6843dbe1104f89532b5e5e9b1
   md5: 7d0adf09c67f2e4a9d17c9ae51f6926d
   depends:
@@ -6605,7 +6605,7 @@ packages:
   license_family: BSD
   size: 23061445
   timestamp: 1664916351574
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
   sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
   md5: 3cd7eb43e285faba76faf67667e26b00
   depends:
@@ -6614,7 +6614,7 @@ packages:
   license_family: MIT
   size: 1093916
   timestamp: 1690290951258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.1.9-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/snappy-1.1.9-hc377ac9_0.tar.bz2
   sha256: 1a0eb8133498944a69d432b79b3edae63d64b2ccd92aa508b89b3fa83dc7983a
   md5: c9acd31658bb93735e401406ae43089d
   depends:
@@ -6623,7 +6623,7 @@ packages:
   license_family: BSD
   size: 1304256
   timestamp: 1650293949317
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
   sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
   md5: c5e9aef0d6895de1c927e9d796cd7cd3
   depends:
@@ -6632,7 +6632,7 @@ packages:
   license_family: Apache
   size: 15691
   timestamp: 1629145910454
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
   sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
   md5: 0f7c229e774146ffc4e29dedf75372bf
   depends:
@@ -6641,7 +6641,7 @@ packages:
   license_family: MIT
   size: 67279
   timestamp: 1696347632563
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
   sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
   md5: 2302a79a045f152e183a52a81adfba62
   depends:
@@ -6653,7 +6653,7 @@ packages:
   license_family: Other
   size: 1674163
   timestamp: 1681394762218
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
   sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
   md5: ae58720a18a2ed15eae214ad7a10d1b5
   depends:
@@ -6662,7 +6662,7 @@ packages:
   license_family: Apache
   size: 140125
   timestamp: 1680167256603
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
   sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
   md5: 4ae67163d55cf9df83d4027ebc38c501
   depends:
@@ -6673,7 +6673,7 @@ packages:
   license_family: BSD
   size: 30894
   timestamp: 1671751931536
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/testpath-0.6.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/testpath-0.6.0-py39hca03da5_0.tar.bz2
   sha256: 1302850ef44a02ddc93ad2b9d5f8d32060f4262f693558c3bbc78b00590dc969
   md5: a9a8375f5cab115321e5906ca1023157
   depends:
@@ -6682,7 +6682,7 @@ packages:
   license_family: BSD
   size: 94447
   timestamp: 1655908626985
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/thrift-0.17.0-py39hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/thrift-0.17.0-py39hc377ac9_0.tar.bz2
   sha256: 6d79d4bba278e23f9b902a349db69248bb28f260f9a8d7964afb09e22b803939
   md5: 15f93217634102096db375910a9c5ae9
   depends:
@@ -6693,7 +6693,7 @@ packages:
   license_family: APACHE
   size: 126083
   timestamp: 1666296613073
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tifffile-2023.4.12-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tifffile-2023.4.12-py39hca03da5_0.tar.bz2
   sha256: 834aa371eb09c02029d772d420cbcacd35d8f4c507aed862d5afab704af997f4
   md5: 6ea6546e2eadea5242e977989eb97299
   depends:
@@ -6706,7 +6706,7 @@ packages:
   license_family: BSD
   size: 376954
   timestamp: 1695107486932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
   sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
   md5: 667e60c8b407d73cbba40f44901f4f00
   depends:
@@ -6715,7 +6715,7 @@ packages:
   license_family: BSD
   size: 3412693
   timestamp: 1654088929697
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
   sha256: 065cf1b08faf1d28aa348d569f2266d8b33b22ba424312c7ec959be95f217646
   md5: 20370dbc92a9262e6fc8c82208f74ff2
   depends:
@@ -6724,7 +6724,7 @@ packages:
   license_family: BSD
   size: 102259
   timestamp: 1667464137769
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
   sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
   md5: 884f788a5f6a664c9b79f7a4a60362d0
   depends:
@@ -6733,7 +6733,7 @@ packages:
   license_family: Apache
   size: 680561
   timestamp: 1696937004165
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
   sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
   md5: 639a4f489af172c866c18442948e5874
   depends:
@@ -6746,7 +6746,7 @@ packages:
   license_family: MOZILLA
   size: 125170
   timestamp: 1679561942932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
   sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
   md5: e5b90eba83fddba6d7aa6072b5bf7c91
   depends:
@@ -6755,7 +6755,7 @@ packages:
   license_family: BSD
   size: 193017
   timestamp: 1671143921826
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
   md5: 644ef8830437070f60efcfcd6a987198
   depends:
@@ -6765,7 +6765,7 @@ packages:
   license_family: PSF
   size: 9670
   timestamp: 1690297532002
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
   md5: a902a833bb186a2f1a4b2b89b1195136
   depends:
@@ -6774,7 +6774,7 @@ packages:
   license_family: PSF
   size: 58466
   timestamp: 1690297524418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
   sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
   md5: f3f1d2c1028dad2f11ff950a15c99dbf
   depends:
@@ -6789,7 +6789,7 @@ packages:
   license_family: MIT
   size: 188640
   timestamp: 1698257577209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
   sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
   md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
   depends:
@@ -6798,7 +6798,7 @@ packages:
   license_family: BSD
   size: 20091
   timestamp: 1629144441130
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
   sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
   md5: 3089c63bf8f4d0423e1a287da286d83e
   depends:
@@ -6808,7 +6808,7 @@ packages:
   license_family: BSD
   size: 70923
   timestamp: 1629357115820
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
   sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
   md5: 5886b30b312445471268444f41f39dc7
   depends:
@@ -6817,7 +6817,7 @@ packages:
   license_family: MIT
   size: 102583
   timestamp: 1695741976083
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
   sha256: 300b9e4cfc9d01fa4d537060b2867f3cb89f22f932992fc2427e00dda050d55b
   md5: 768c174577b786b99f8b46c4789b36a2
   depends:
@@ -6829,20 +6829,20 @@ packages:
   license_family: Apache
   size: 1800646
   timestamp: 1689041569828
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
   sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
   md5: 2e75ad6a09c308268192efe03cc9ebf4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 411778
   timestamp: 1683113019715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
   sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
   md5: 30f666bf97c26587c5d2f68cc5f330ab
   depends:
@@ -6851,7 +6851,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 316901
   timestamp: 1629287855861
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zfp-1.0.0-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zfp-1.0.0-h313beb8_0.tar.bz2
   sha256: 181d62294369598af7fd5dea778dcddca50009e699be1572750d419beba80e6b
   md5: 48eeb271f7289214d616f859c55dece9
   depends:
@@ -6861,7 +6861,7 @@ packages:
   license_family: BSD
   size: 258119
   timestamp: 1681741613773
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zict-3.0.0-py39hca03da5_0.tar.bz2
   sha256: 8d31a7e9356948fd3d715faa6111e78dec6ffb6981819dd182aed7f765ec97c1
   md5: 869dc425508ac78b9031bde17f568cd8
   depends:
@@ -6872,7 +6872,7 @@ packages:
   license_family: BSD
   size: 77665
   timestamp: 1695832985587
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
   sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
   md5: 584e591d36dcd5ba5c45404f0f7ebb2d
   depends:
@@ -6881,14 +6881,14 @@ packages:
   license_family: MIT
   size: 19076
   timestamp: 1672387153578
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
   sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
   md5: 467ae28215d1aa1c5688bc0c8a184269
   license: Zlib
   license_family: Other
   size: 103525
   timestamp: 1666595022664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
   sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
   md5: 7cfbed15f1feee1422810f7830075f53
   depends:
@@ -6900,7 +6900,7 @@ packages:
   license_family: BSD
   size: 779464
   timestamp: 1681304594848
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
   sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
   md5: ed14f9bc6e55220483f1a5a388625a08
   depends:
@@ -6913,7 +6913,7 @@ packages:
   license_family: MIT
   size: 162772
   timestamp: 1644481986085
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aom-3.6.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aom-3.6.0-hd77b12b_0.tar.bz2
   sha256: 7ad83463e67a5f6da32568a567914a0f1ed5052268548371eb9ca66b4a0eee00
   md5: 99feb2bd2c24eb7726f4a05f9fa1b809
   depends:
@@ -6923,7 +6923,7 @@ packages:
   license_family: BSD
   size: 12387035
   timestamp: 1688666342169
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
   sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
   md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
   depends:
@@ -6935,7 +6935,7 @@ packages:
   license_family: MIT
   size: 39253
   timestamp: 1644551767970
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
   sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
   md5: b24d13c443a26f65a0778b475a5726bc
   depends:
@@ -6944,7 +6944,7 @@ packages:
   license_family: MIT
   size: 132830
   timestamp: 1695717959996
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
   sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
   md5: 302c3c0696e17eaa62e140e3892644ae
   depends:
@@ -6954,12 +6954,12 @@ packages:
   license_family: MIT
   size: 199723
   timestamp: 1681493196911
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
   sha256: cf9a8a0745c5fab48394d84a58fe2f06e5fa80c87d5cc8d6c8da2e1df52cc69f
   md5: 462987773ecda8cbf1f80734e84f080f
   depends:
@@ -6972,7 +6972,7 @@ packages:
   license_family: BSD
   size: 93601
   timestamp: 1675247818708
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-2.3.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-2.3.3-py39haa95532_0.tar.bz2
   sha256: e16a5673ecfcc33520f50c5fff5f55e20c57be713c51167144db87f7983feee8
   md5: eab20446694e29eb9c77bb72e53c43d0
   depends:
@@ -6989,7 +6989,7 @@ packages:
   license_family: BSD
   size: 8615028
   timestamp: 1625767858854
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
   sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
   md5: bf930260f679bc74227bbb18bc36ae82
   depends:
@@ -7001,7 +7001,7 @@ packages:
   license_family: BSD
   size: 119700
   timestamp: 1657176150595
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
   md5: 507dfe693ef429f466d964b599f4af21
   depends:
@@ -7013,7 +7013,7 @@ packages:
   license: MIT
   size: 18650
   timestamp: 1659616328001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
   md5: d0bf43e8df60baae3b3105aa5c42a791
   depends:
@@ -7024,7 +7024,7 @@ packages:
   license: MIT
   size: 21153
   timestamp: 1659616312367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
   sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
   md5: 7bd24bf94c24e810aecaaf84a0978e6f
   depends:
@@ -7034,7 +7034,7 @@ packages:
   license: MIT
   size: 343204
   timestamp: 1659616543542
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
   sha256: 3a26c397d4e0d546b0c2f433074c20813c5f3ae98bcf07a165c648f369a850b9
   md5: 8f8069ce8c9eff1b0f124de2c0a63b86
   depends:
@@ -7043,14 +7043,14 @@ packages:
   license_family: BSD
   size: 154105
   timestamp: 1563219293348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
   sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
   md5: 092b417c11edcbe6bb9b765ab4a55d23
   license: MPL-2.0
   license_family: Other
   size: 164999
   timestamp: 1694009822357
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
   sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
   md5: 708a750d370b9d6875651021e21c4446
   depends:
@@ -7059,7 +7059,7 @@ packages:
   license_family: Other
   size: 159322
   timestamp: 1690232335307
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
   sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
   md5: c35736da3ea26782425e78061268cf5e
   depends:
@@ -7071,7 +7071,7 @@ packages:
   license_family: MIT
   size: 228713
   timestamp: 1670423312743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
   sha256: a65386e70bdad9aa1e07ad430309c3ddc249b74bea69388dfbda99fd00069665
   md5: e4174218de194962642b353f51a19d1e
   depends:
@@ -7081,7 +7081,7 @@ packages:
   license_family: Other
   size: 617890
   timestamp: 1655709069465
-- conda: https://repo.anaconda.com/pkgs/main/win-64/charls-2.2.0-h6c2663c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/charls-2.2.0-h6c2663c_0.tar.bz2
   sha256: 98e6346139899b0c9ce6518e304c8b1fd1b8746a410fcc8d83cbc9f08125ecc7
   md5: 5cdda32dbdd11de0555c255a598173c0
   depends:
@@ -7091,7 +7091,7 @@ packages:
   license_family: BSD
   size: 95720
   timestamp: 1612240685008
-- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
   sha256: 9577ff772035cd30e72323edff379dd3df877de00f7f690fd33c8720a5a4bbc9
   md5: 1130fd979d4f97f511f10b36ff09513d
   depends:
@@ -7101,7 +7101,7 @@ packages:
   license_family: BSD
   size: 152728
   timestamp: 1698129962390
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
   sha256: e5babe79f8132c4bd44bc05307976f2c5485014ae3129655dddbd3baa8e75e46
   md5: 093223df00c6ef9db4e7e5aa7bfec00a
   depends:
@@ -7110,7 +7110,7 @@ packages:
   license_family: BSD
   size: 40844
   timestamp: 1683040252786
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
   sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
   md5: 457a4339a53c033d48ce0c72e5038d2e
   depends:
@@ -7119,7 +7119,7 @@ packages:
   license_family: BSD
   size: 30330
   timestamp: 1672387265402
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
   sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
   md5: 59ec65fd9e06b81a65cc12986c67d5da
   depends:
@@ -7129,7 +7129,7 @@ packages:
   license_family: CC
   size: 1939614
   timestamp: 1668084794027
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
   sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
   md5: 3489c1a2b73fc957b5a62cc59349e25b
   depends:
@@ -7139,7 +7139,7 @@ packages:
   license_family: BSD
   size: 13438
   timestamp: 1671231196438
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
   sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
   md5: 3492b96083c1e904cc32d26ea7f1e1d8
   depends:
@@ -7151,7 +7151,7 @@ packages:
   license_family: BSD
   size: 184280
   timestamp: 1663827558327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h3438e0d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h3438e0d_0.tar.bz2
   sha256: 153757acc6c1a35dfa608a9957401052bf424a8f1c42c6a58272a35816dc5091
   md5: 3190ab0bff0ce45755e929208b54907f
   depends:
@@ -7166,7 +7166,7 @@ packages:
   license_family: BSD
   size: 1221616
   timestamp: 1694446820243
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cytoolz-0.12.0-py39h2bbff1b_0.tar.bz2
   sha256: 28c350d12caf11ba087e033289e5152ea9b9dc4abbf0229299a3e5d20759f47e
   md5: 4bac24daf8224ea465812ad92c30ad47
   depends:
@@ -7178,7 +7178,7 @@ packages:
   license_family: BSD
   size: 311754
   timestamp: 1667466298939
-- conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
   sha256: a6c8b5d32c52ce71d41c7702265e0bb064c960ab67b88ecbea967595c5e02bc3
   md5: 112f2f9c7055656ec156fe287c97c0e9
   depends:
@@ -7190,7 +7190,7 @@ packages:
   license_family: BSD
   size: 104432
   timestamp: 1613390539244
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dav1d-1.2.1-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/dav1d-1.2.1-h2bbff1b_0.tar.bz2
   sha256: e59970edb08a1dc24d761f88657aed895d7715f66ac9a9acfda440c29fda05e0
   md5: d3d303a3ffcedb8f4a92f29ac9e67bdc
   depends:
@@ -7200,7 +7200,7 @@ packages:
   license_family: BSD
   size: 723931
   timestamp: 1688746263355
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
   sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
   md5: 2ff4fb509788b0e47ac684ba151394d0
   depends:
@@ -7211,7 +7211,7 @@ packages:
   license_family: MIT
   size: 3289966
   timestamp: 1690907040646
-- conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2021.9.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/distributed-2021.9.1-py39haa95532_0.tar.bz2
   sha256: b21d7d7612917cb871c7d980918ff8bc9ed686be2cf529ddd6c449d7e3809223
   md5: d1f10508f885dffd11b6383e3f816b65
   depends:
@@ -7237,7 +7237,7 @@ packages:
   license_family: BSD
   size: 1140821
   timestamp: 1634741658358
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
   sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
   md5: 0f166c3e70541d8bee6e9d0cb60fb66e
   depends:
@@ -7246,7 +7246,7 @@ packages:
   license_family: MIT
   size: 16979
   timestamp: 1649926678161
-- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
   sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
   md5: ea93d413944ca6a8677eb1b284b136ae
   depends:
@@ -7255,7 +7255,7 @@ packages:
   license_family: BSD
   size: 27388
   timestamp: 1668714577678
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-0.5.0-py39h080aedc_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fastparquet-0.5.0-py39h080aedc_2.tar.bz2
   sha256: 9597efdd53604092fb2669a00591d5868f4bcb1c336e18763fd90423a843dc9a
   md5: ba5053e8f1135885c08bc84f548860ba
   depends:
@@ -7273,7 +7273,7 @@ packages:
   license_family: Apache
   size: 189597
   timestamp: 1658490146641
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -7285,7 +7285,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
   sha256: 6b724886465fea70d2ca843fea1d01bcc24d496601587b87c0cb8f2626b259c2
   md5: 6c11d9242869d6c3b01698f728bd409b
   depends:
@@ -7294,7 +7294,7 @@ packages:
   license_family: BSD
   size: 260567
   timestamp: 1695734829130
-- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
   sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
   md5: 9f167d3e45441bc3633c1974b1b0ce8c
   depends:
@@ -7304,13 +7304,13 @@ packages:
   license_family: MIT
   size: 88421
   timestamp: 1676983264486
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
   sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
   md5: 582d2c1135a89da757a038de831e7f39
   license: Intel proprietary
   size: 11086648
   timestamp: 1664812389803
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
   sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
   md5: 30fdefd1541c789c163751291a8faa88
   depends:
@@ -7319,7 +7319,7 @@ packages:
   license_family: BSD
   size: 111448
   timestamp: 1666125667599
-- conda: https://repo.anaconda.com/pkgs/main/win-64/imagecodecs-2023.1.23-py39h6c6a46e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/imagecodecs-2023.1.23-py39h6c6a46e_0.tar.bz2
   sha256: 2314346495ed1de94c5a8fcb03d7521c1b6bfbd9411f019d3d93f7a623be88d7
   md5: 627c13275ad14530b560703289ae7577
   depends:
@@ -7356,7 +7356,7 @@ packages:
   license_family: BSD
   size: 9882701
   timestamp: 1695065345272
-- conda: https://repo.anaconda.com/pkgs/main/win-64/imageio-2.31.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/imageio-2.31.4-py39haa95532_0.tar.bz2
   sha256: b40af938aa1f5199a25ae86d943fb37b534e806aa96228f19897d09d7dc9d57c
   md5: aa0843aadc4608117a24d2b53ed0fc82
   depends:
@@ -7367,7 +7367,7 @@ packages:
   license_family: BSD
   size: 536594
   timestamp: 1695996939235
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
   sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
   md5: a10f07c7a3510272a296f9fed458a4ed
   depends:
@@ -7377,7 +7377,7 @@ packages:
   license_family: APACHE
   size: 38098
   timestamp: 1678997241511
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
   sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
   md5: fad9cf2023d807da8d44996e9d4399a0
   depends:
@@ -7387,7 +7387,7 @@ packages:
   license_family: Apache
   size: 51490
   timestamp: 1698254721864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
   sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
   md5: 9834848bd7c7759acf12e78d09388563
   depends:
@@ -7397,7 +7397,7 @@ packages:
   license_family: Proprietary
   size: 3891030
   timestamp: 1681801474383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
   sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
   md5: 1285c8c628bc912c54d0968574c9f4c9
   depends:
@@ -7418,7 +7418,7 @@ packages:
   license_family: BSD
   size: 217232
   timestamp: 1691122695748
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
   sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
   md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
   depends:
@@ -7439,7 +7439,7 @@ packages:
   license_family: BSD
   size: 1279433
   timestamp: 1694181820978
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
   sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
   md5: f5fcce35d3f21cdfc5893c5a7a86c651
   depends:
@@ -7449,7 +7449,7 @@ packages:
   license_family: MIT
   size: 1035394
   timestamp: 1644315567034
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
   sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
   md5: 81f2c343dc4c65eea39c45383272068f
   depends:
@@ -7459,7 +7459,7 @@ packages:
   license_family: Other
   size: 407861
   timestamp: 1677849239400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
   sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
   md5: bd9526d38a145fe311a8aa36bc11e071
   depends:
@@ -7470,7 +7470,7 @@ packages:
   license_family: MIT
   size: 152006
   timestamp: 1676558783570
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
   sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
   md5: a00e6a62956fde3c4135464353ee8a53
   depends:
@@ -7486,7 +7486,7 @@ packages:
   license_family: BSD
   size: 229158
   timestamp: 1676330909084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
   sha256: db8335d6531b03c7bdfe789ebacc52631ac6ea4a37700bb3da1f6a53a1acd724
   md5: ebeba61994cc225ea5f4f42caa511019
   depends:
@@ -7498,7 +7498,7 @@ packages:
   license_family: BSD
   size: 116681
   timestamp: 1679906658986
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
   sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
   md5: 5efa1332f7c0a8d9638eda02170c4ce5
   depends:
@@ -7523,7 +7523,7 @@ packages:
   license_family: BSD
   size: 413653
   timestamp: 1671707957673
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
   sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
   md5: 891fe66a24d8714737b2874985ee1303
   depends:
@@ -7534,7 +7534,7 @@ packages:
   license_family: BSD
   size: 62298
   timestamp: 1672388166096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
   sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
   md5: f5f73266281ab12377d5d47bdf07500a
   depends:
@@ -7546,7 +7546,7 @@ packages:
   license_family: MIT
   size: 905072
   timestamp: 1617648814933
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -7556,7 +7556,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libaec-1.0.4-h33f27b4_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libaec-1.0.4-h33f27b4_1.tar.bz2
   sha256: 918df9a8ca3877e44a2976f7c8f2d84f710d156809a7d8e0b79eca568c7cc3da
   md5: 0e6b3ffa6ee7c941485dacdfcb6dd6b4
   depends:
@@ -7566,7 +7566,7 @@ packages:
   license_family: BSD
   size: 34175
   timestamp: 1593197296069
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libavif-0.11.1-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libavif-0.11.1-h2bbff1b_0.tar.bz2
   sha256: 6adaf0429ea7418bff9eab1f723572f4330d003532292448d5334ea2d601e5ee
   md5: b2756d031f0dcfb72f733b2c450fc32a
   depends:
@@ -7578,7 +7578,7 @@ packages:
   license_family: BSD
   size: 2494359
   timestamp: 1689158283018
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
   sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
   md5: c345f51706eef530454f66b794e5e574
   depends:
@@ -7587,7 +7587,7 @@ packages:
   license: MIT
   size: 68189
   timestamp: 1659616216976
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
   md5: a7400cfb72042977bc047909ed504ce8
   depends:
@@ -7597,7 +7597,7 @@ packages:
   license: MIT
   size: 33743
   timestamp: 1659616248209
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
   md5: 6307f6854754ab5bd7c84e6998385bb1
   depends:
@@ -7607,7 +7607,7 @@ packages:
   license: MIT
   size: 733177
   timestamp: 1659616279453
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -7617,7 +7617,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -7628,7 +7628,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -7637,7 +7637,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -7654,7 +7654,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
   sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
   md5: ba9418df9288a2f031a02fa35b774ce0
   depends:
@@ -7670,7 +7670,7 @@ packages:
   license_family: BSD
   size: 78524
   timestamp: 1694778314659
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
   sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
   md5: b1781519a200ccbfcb4a1194005aa3ef
   depends:
@@ -7682,7 +7682,7 @@ packages:
   license_family: BSD
   size: 338459
   timestamp: 1694777084290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libzopfli-1.0.3-ha925a31_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libzopfli-1.0.3-ha925a31_0.tar.bz2
   sha256: d5b0e01c2b80b43a0e1128a612f289891c375bd9f15b3b0d176b0658a1c3711e
   md5: 532177b4105c87e006d9f49ba8ad399f
   depends:
@@ -7692,7 +7692,7 @@ packages:
   license_family: Apache
   size: 210474
   timestamp: 1593187626221
-- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.38.0-py39h23ce68f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/llvmlite-0.38.0-py39h23ce68f_0.tar.bz2
   sha256: 7421f1f10d729ec5a71457aa0ba751c18cc25fa6e7790f438b84d676dc013972
   md5: 0981ca59642800528a2f259beffa72c1
   depends:
@@ -7703,7 +7703,7 @@ packages:
   license: BSD-2-Clause
   size: 17085863
   timestamp: 1650394083750
-- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
   sha256: 5d4cf89313147e44530dbb3cc6a93247aaded0701bbf8ba3a382ef710abf4cfa
   md5: 137deeca51202f6b4ac786472a00be55
   depends:
@@ -7712,7 +7712,7 @@ packages:
   license_family: BSD
   size: 12894
   timestamp: 1652904101694
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
   sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
   md5: 6970c7f46b0164cad1d210e7a1419959
   depends:
@@ -7722,7 +7722,7 @@ packages:
   license_family: BSD
   size: 143434
   timestamp: 1670944902624
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
   sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
   md5: 1015298551c040c6d5e26eebbae12ef5
   depends:
@@ -7732,7 +7732,7 @@ packages:
   license_family: BSD
   size: 142316
   timestamp: 1671542240512
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.0.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.0.1-py39h2bbff1b_0.tar.bz2
   sha256: 5dff37975a0b3c1b05fec07a7f7c45f0d1db02c81daedeabb6004d80f2dcea4a
   md5: 3edffbc00c56e7c33c267bcaa40f0e3f
   depends:
@@ -7743,7 +7743,7 @@ packages:
   license_family: BSD
   size: 25694
   timestamp: 1621528688654
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
   sha256: 1687ae122ee7d8b583141fc5014b76d494841dc8083b854449e3d6e0f6bb7019
   md5: 3697ac26ee3c2d49338dd5b9c6551152
   depends:
@@ -7766,7 +7766,7 @@ packages:
   license_family: PSF
   size: 8080067
   timestamp: 1698692812610
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
   sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
   md5: a9fa43e694b25cd49b8b08a9eefd696e
   depends:
@@ -7776,7 +7776,7 @@ packages:
   license_family: BSD
   size: 18054
   timestamp: 1661915903969
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
   sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
   md5: 248c468abced874f0231d3cc23177c77
   depends:
@@ -7787,7 +7787,7 @@ packages:
   license_family: BSD
   size: 58488
   timestamp: 1607359497934
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
   sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
   md5: 5e763c995ff0c549f68a10bce70fede4
   depends:
@@ -7799,7 +7799,7 @@ packages:
   license_family: Proprietary
   size: 187489950
   timestamp: 1691503804820
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
   sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
   md5: dd0c2ece6a743c373c9b5a5919b4818f
   depends:
@@ -7811,7 +7811,7 @@ packages:
   license_family: BSD
   size: 49744
   timestamp: 1682975040154
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
   sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
   md5: 57cea8df7ab85f2a98f64d23afcb1f90
   depends:
@@ -7826,7 +7826,7 @@ packages:
   license_family: BSD
   size: 184956
   timestamp: 1695058491736
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
   sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
   md5: 8769cdd201d905069800488fe31574e5
   depends:
@@ -7841,7 +7841,7 @@ packages:
   license_family: BSD
   size: 256221
   timestamp: 1695060152521
-- conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/msgpack-python-1.0.3-py39h59b6b97_0.tar.bz2
   sha256: ed64d0a3331cc40479962ed066a833243ca36035bd4cefee4fb5e42a9214f64b
   md5: 6b7d9b4724303c0159086d28e9ef4901
   depends:
@@ -7852,7 +7852,7 @@ packages:
   license_family: Apache
   size: 82755
   timestamp: 1652329408426
-- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
   sha256: b75f28f29d60f2a8726fb0f036e5d01489942abbf77ff1e1cc8e12d7f372b8f3
   md5: 7a1d29477873480809fd3860f2e69f01
   depends:
@@ -7862,7 +7862,7 @@ packages:
   license_family: BSD
   size: 24734
   timestamp: 1607574381373
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
   sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
   md5: d9781492332e6326f9fca87f3a8efacd
   depends:
@@ -7888,7 +7888,7 @@ packages:
   license_family: BSD
   size: 8135792
   timestamp: 1681756491399
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
   sha256: 2dd3178d3c570e30b9490ebabfd7bfac806afad8302d3dee0edc619805034397
   md5: bef9da0f0694c45b6aaa4e6447479eaf
   depends:
@@ -7901,7 +7901,7 @@ packages:
   license_family: BSD
   size: 118324
   timestamp: 1650290466135
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.4.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-6.4.4-py39haa95532_0.tar.bz2
   sha256: cd65b6bdcf9c9643a789182d902cd54301f5da989a45f3fed7beb5c20abcfe20
   md5: ee64ff0db569df90237785584ec97e58
   depends:
@@ -7926,7 +7926,7 @@ packages:
   license_family: BSD
   size: 582244
   timestamp: 1649741096955
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
   sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
   md5: f96bbef0985d7e66ebf00c0d55e30e23
   depends:
@@ -7939,7 +7939,7 @@ packages:
   license_family: BSD
   size: 167045
   timestamp: 1694617078743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
   sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
   md5: 6e6ba64c8dc5025aeac606404a8df36a
   depends:
@@ -7948,7 +7948,7 @@ packages:
   license_family: BSD
   size: 13786
   timestamp: 1672387480065
-- conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/networkx-3.1-py39haa95532_0.tar.bz2
   sha256: 55847705e1cb4c384a61611e15a0beb52d745b30e0fced2d9a3daa877b3d712f
   md5: 5082bfa6e6400284e8e3833a7874b789
   depends:
@@ -7957,7 +7957,7 @@ packages:
   license_family: BSD
   size: 2928272
   timestamp: 1690562181595
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
   sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
   md5: 4a7a3286484766741f627696697c362c
   depends:
@@ -7982,7 +7982,7 @@ packages:
   license_family: BSD
   size: 609425
   timestamp: 1690985686105
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
   sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
   md5: 4269a1f93882205b90d4b2ae78fc82d5
   depends:
@@ -7992,7 +7992,7 @@ packages:
   license_family: BSD
   size: 22417
   timestamp: 1668160717305
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.55.1-py39hf11a4ad_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numba-0.55.1-py39hf11a4ad_0.tar.bz2
   sha256: ae01d6d92a3887da4357ec5c42d419ca0ec09b5382283308362d169f5c64ce4e
   md5: 5fa02eab1619c73418ac459ec723efc9
   depends:
@@ -8013,7 +8013,7 @@ packages:
   license_family: BSD
   size: 3995948
   timestamp: 1650394589312
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
   sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
   md5: a18a576b7024cfd6f905c526a786a916
   depends:
@@ -8028,7 +8028,7 @@ packages:
   license_family: MIT
   size: 135285
   timestamp: 1696515698492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.21.5-py39h6917f2d_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.21.5-py39h6917f2d_4.tar.bz2
   sha256: aee7fd60e0fa3bf6c4de8045e4bcf9f79108c79692c8d63f2b1b9d7e7e3e69d0
   md5: a43634502e0708257d9cec6ca33df68a
   depends:
@@ -8044,7 +8044,7 @@ packages:
   license: BSD-3-Clause
   size: 10555
   timestamp: 1682980574564
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.21.5-py39h46c4fa8_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.21.5-py39h46c4fa8_4.tar.bz2
   sha256: 61585d772e0a0fe5316abc4e5ebf82bb025193973fc76011d36a5f5a9585914f
   md5: b735ac9ae87732f59b177c56d6d8bc76
   depends:
@@ -8059,7 +8059,7 @@ packages:
   license: BSD-3-Clause
   size: 5894357
   timestamp: 1682980554084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
   sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
   md5: ab07e2a27ac08afe3d0b4c0890b8486a
   depends:
@@ -8070,7 +8070,7 @@ packages:
   license: BSD 2-Clause
   size: 249316
   timestamp: 1630094024143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
   sha256: 0474e14823c734edc088bef98b829149a47ed8b4654f9638926c2fe4bbc40f38
   md5: a67d4a763641de641ea9dfa8c4a5f567
   depends:
@@ -8081,7 +8081,7 @@ packages:
   license_family: Apache
   size: 6048217
   timestamp: 1694466133007
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
   sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
   md5: df1d746ba8d5d6ba01ac1373b9b71e1a
   depends:
@@ -8090,7 +8090,7 @@ packages:
   license_family: Apache
   size: 73016
   timestamp: 1693575484990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-1.4.4-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-1.4.4-py39hd77b12b_0.tar.bz2
   sha256: d81d8ef52a07a9cd294e98d4e069ad86f990cfe3b3064bfde540a3f04e0ee9a4
   md5: 25de49536214af419d337679d8040cba
   depends:
@@ -8106,7 +8106,7 @@ packages:
   license_family: BSD
   size: 11584490
   timestamp: 1663773415594
-- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
   sha256: 5738f61dae392c171b4f699a6973e736198e4d4a63fa22dcf957afaf1de150af
   md5: cba721e73156d62fc4ff23159e96ad41
   depends:
@@ -8120,7 +8120,7 @@ packages:
   license_family: BSD
   size: 36452
   timestamp: 1698702686971
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
   sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
   md5: 427c1450bebb632f43bbc8c83006e4cd
   depends:
@@ -8139,7 +8139,7 @@ packages:
   license_family: Other
   size: 806931
   timestamp: 1696580240310
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
   sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
   md5: 21790cd3e2b8a45c4104aff0a68330d0
   depends:
@@ -8150,7 +8150,7 @@ packages:
   license_family: MIT
   size: 3001751
   timestamp: 1697549357662
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
   sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
   md5: 56f44a1054da2d10777e375838191070
   depends:
@@ -8159,7 +8159,7 @@ packages:
   license_family: MIT
   size: 32355
   timestamp: 1692205784293
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
   sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
   md5: 8a35ad65651086575ce55371f22feda8
   depends:
@@ -8168,7 +8168,7 @@ packages:
   license_family: Apache
   size: 91045
   timestamp: 1659455316472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
   sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
   md5: 186eb95f816a2eff80c3c7f7d964c7b0
   depends:
@@ -8180,7 +8180,7 @@ packages:
   license_family: BSD
   size: 578514
   timestamp: 1672388155359
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
   sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
   md5: 47b6cbe6ce9289e47d16900b03596a91
   depends:
@@ -8191,7 +8191,7 @@ packages:
   license_family: BSD
   size: 372807
   timestamp: 1656431445633
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
   sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
   md5: 07165c444adc7c7ccc8a345875adc5ef
   depends:
@@ -8203,7 +8203,7 @@ packages:
   license_family: BSD
   size: 48408
   timestamp: 1675450623287
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
   sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
   md5: d58e76a31e2f6e7410ba4afd7f385b0d
   depends:
@@ -8212,7 +8212,7 @@ packages:
   license_family: BSD
   size: 1877445
   timestamp: 1684280183367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
   sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
   md5: 0e5b0fe7debbf558ce97090f6b67cdae
   depends:
@@ -8222,7 +8222,7 @@ packages:
   license_family: Apache
   size: 94633
   timestamp: 1690225630423
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
   sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
   md5: 0fde797653e4ab589506121fb1e37555
   depends:
@@ -8231,7 +8231,7 @@ packages:
   license_family: MIT
   size: 157119
   timestamp: 1661452591647
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
   sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
   md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
   depends:
@@ -8242,7 +8242,7 @@ packages:
   license_family: MIT
   size: 92679
   timestamp: 1636093365041
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
   sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
   md5: f870859d4dc7a8d82cf3546bd9035f33
   depends:
@@ -8252,7 +8252,7 @@ packages:
   license_family: BSD
   size: 54520
   timestamp: 1605307564142
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h6244533_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h6244533_0.tar.bz2
   sha256: 08cc28161687c6a4d88d17c33001c6a6aaaf044b673d93df414c60fe42eeabb1
   md5: b95c7aa91366f9054fe0c9e30bd92b9e
   depends:
@@ -8265,7 +8265,7 @@ packages:
   license_family: PSF
   size: 21175634
   timestamp: 1694440134687
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
   sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
   md5: 9d99075052265ae3d718582d3b875038
   depends:
@@ -8274,7 +8274,7 @@ packages:
   license_family: BSD
   size: 269964
   timestamp: 1661376543480
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-lmdb-1.4.1-py39hd77b12b_0.tar.bz2
   sha256: 8b6a4065775dced4e05e655b2cc3a59e5dd70f3c081e0d37e6f65073cb2e2b43
   md5: 7c7beb23a7b73c5797a1ab69ab124cd7
   depends:
@@ -8285,7 +8285,7 @@ packages:
   license_family: Other
   size: 135726
   timestamp: 1682522544682
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-snappy-0.6.0-py39hd77b12b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-snappy-0.6.0-py39hd77b12b_3.tar.bz2
   sha256: 11de037a53b2815a5e30a4a7859b327ddc617632d919ed8bcef994a7a3626c78
   md5: 4ff26871cd7ff7bb0345a8c92c75d435
   depends:
@@ -8297,7 +8297,7 @@ packages:
   license_family: BSD
   size: 33738
   timestamp: 1610133461849
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
   sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
   md5: fa9074d94236c9b768bfd2c858875b27
   depends:
@@ -8306,7 +8306,7 @@ packages:
   license_family: MIT
   size: 264836
   timestamp: 1695131770282
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywavelets-1.4.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywavelets-1.4.1-py39h2bbff1b_0.tar.bz2
   sha256: 053adefe794182f43cb381d5bacae8e611840fb20e2f3f91dc570a4ae9777e57
   md5: 70d44b3a97b8a82049e09cbaaf434b8e
   depends:
@@ -8318,7 +8318,7 @@ packages:
   license_family: MIT
   size: 4502506
   timestamp: 1670425946688
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
   sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
   md5: 3d2841085778006c2e79f9c7300f8b9d
   depends:
@@ -8328,7 +8328,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13565975
   timestamp: 1669937633869
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
   sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
   md5: 54a4bc0724041dd173088419d6ede2af
   depends:
@@ -8340,7 +8340,7 @@ packages:
   license_family: MIT
   size: 239062
   timestamp: 1677611495106
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
   sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
   md5: f39f84115e228bad4bceaefdd637f022
   depends:
@@ -8352,7 +8352,7 @@ packages:
   license_family: MIT
   size: 158558
   timestamp: 1698096358091
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
   sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
   md5: df398a3a1668fd2a22061764e20ea91d
   depends:
@@ -8364,7 +8364,7 @@ packages:
   license_family: BSD
   size: 460913
   timestamp: 1657616061604
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
   sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
   md5: 38db77ece9dc76feffb9ef7638e38258
   depends:
@@ -8380,7 +8380,7 @@ packages:
   license_family: Apache
   size: 94397
   timestamp: 1690400496655
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scikit-image-0.19.3-py39hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/scikit-image-0.19.3-py39hd77b12b_1.tar.bz2
   sha256: 7bc9d9d24149d4c2f9986dec5458b936efafd681a313b040fb7a0dc2a2af5981
   md5: 77e61fcb6e3bc60979fa906515ec9b26
   depends:
@@ -8406,7 +8406,7 @@ packages:
   license_family: BSD
   size: 11681360
   timestamp: 1669245008169
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.9.3-py39hdcfc7df_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/scipy-1.9.3-py39hdcfc7df_2.tar.bz2
   sha256: 20d30019df4ee9e1facaa29500122ba7ff7e8b1ed962916cd2162fda5ed09d55
   md5: 17e5b84018da06aa9fb868bf6f216013
   depends:
@@ -8425,7 +8425,7 @@ packages:
   license_family: BSD
   size: 21517713
   timestamp: 1683294038354
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
   sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
   md5: 3e284ae6b48ee30c364ffdc5601610b0
   depends:
@@ -8434,7 +8434,7 @@ packages:
   license_family: MIT
   size: 1099842
   timestamp: 1690291374842
-- conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.1.9-h6c2663c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/snappy-1.1.9-h6c2663c_0.tar.bz2
   sha256: 25c1b4224f5d7d767d4adfe0384d585e9b3935464be3efff3120059308d9747c
   md5: faac387845d33d194eeb7d5a3d962ea5
   depends:
@@ -8444,7 +8444,7 @@ packages:
   license_family: BSD
   size: 6506572
   timestamp: 1649924235781
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
   sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
   md5: 993b3886b334bd1f49d34206f21997b4
   depends:
@@ -8453,7 +8453,7 @@ packages:
   license_family: Apache
   size: 15998
   timestamp: 1614030572433
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
   sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
   md5: 7ac9604ad7564ac0c71bff5db198656f
   depends:
@@ -8462,7 +8462,7 @@ packages:
   license_family: MIT
   size: 67012
   timestamp: 1696347795139
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
   sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
   md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
   depends:
@@ -8472,7 +8472,7 @@ packages:
   license_family: Other
   size: 1311308
   timestamp: 1681402905668
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -8482,7 +8482,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
   sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
   md5: 28b9869d8d3a839918fac4a08f38cbc2
   depends:
@@ -8493,7 +8493,7 @@ packages:
   license_family: BSD
   size: 30546
   timestamp: 1671752127904
-- conda: https://repo.anaconda.com/pkgs/main/win-64/testpath-0.6.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/testpath-0.6.0-py39haa95532_0.tar.bz2
   sha256: ad09d4b1225f40ff49f0eba9fe4e9a1dad2b36af92172e600d15328bc6bc7132
   md5: 9e19229b635f3376982268031a23587b
   depends:
@@ -8502,7 +8502,7 @@ packages:
   license_family: BSD
   size: 94147
   timestamp: 1655908617544
-- conda: https://repo.anaconda.com/pkgs/main/win-64/thrift-0.17.0-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/thrift-0.17.0-py39hd77b12b_0.tar.bz2
   sha256: 0d0e1a967ae7a502c902977a71d40c65739e0068fb9887ceaeecbfc57c656fb9
   md5: 3608289bbb69bdde682682c3d41ed90a
   depends:
@@ -8514,7 +8514,7 @@ packages:
   license_family: APACHE
   size: 124092
   timestamp: 1666296783646
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tifffile-2023.4.12-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tifffile-2023.4.12-py39haa95532_0.tar.bz2
   sha256: 2b0b9472b76cba4194f88c1b497470771c41869960960e3a4c91e43be186ad03
   md5: 75402012c8377b03335df3bfef2e2e97
   depends:
@@ -8527,7 +8527,7 @@ packages:
   license_family: BSD
   size: 407816
   timestamp: 1695107900531
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
   sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
   md5: 52cdcdb96383c010ca833a7c24b3935b
   depends:
@@ -8537,7 +8537,7 @@ packages:
   license_family: BSD
   size: 3690152
   timestamp: 1654036853710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
   sha256: 1ee791ecc17e11a31d6cf1553845e7279d9d9a2c7383a2a3e1ae131ddd024b6f
   md5: b32030d310e0437dc631e5719369004c
   depends:
@@ -8546,7 +8546,7 @@ packages:
   license_family: BSD
   size: 102033
   timestamp: 1667464306003
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
   sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
   md5: 0e054ab29119cf4c1f778613acf972f9
   depends:
@@ -8557,7 +8557,7 @@ packages:
   license_family: Apache
   size: 681780
   timestamp: 1696937326924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
   sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
   md5: b6ad839ebba536ad1c3cc58d0e2123f0
   depends:
@@ -8571,7 +8571,7 @@ packages:
   license_family: MOZILLA
   size: 143681
   timestamp: 1679562248929
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
   sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
   md5: fe78de10019085146f1cc6c94fdc2620
   depends:
@@ -8580,7 +8580,7 @@ packages:
   license_family: BSD
   size: 192822
   timestamp: 1671143999327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
   md5: ca5fc3fbdb09b6de068a8b7a8869369f
   depends:
@@ -8590,7 +8590,7 @@ packages:
   license_family: PSF
   size: 9208
   timestamp: 1690298120549
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
   md5: a86e87a10e5fdff486265e0c675fb99f
   depends:
@@ -8599,7 +8599,7 @@ packages:
   license_family: PSF
   size: 57922
   timestamp: 1690298106990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
   sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
   md5: 0d31859e0a097aedbcc1627db33b3d92
   depends:
@@ -8614,7 +8614,7 @@ packages:
   license_family: MIT
   size: 188367
   timestamp: 1698257883295
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
   sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
   md5: 45ef24c486a484f079faf1dc90e4c7e9
   depends:
@@ -8623,12 +8623,12 @@ packages:
   license_family: BSD
   size: 8277
   timestamp: 1605602889180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
   sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
   md5: 4daaceb6cfc1af6274509081d8018ef1
   size: 2316783
   timestamp: 1605602872095
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
   sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
   md5: 916c16904615c7af3b5d37cb6694f45e
   depends:
@@ -8637,7 +8637,7 @@ packages:
   license_family: BSD
   size: 21084
   timestamp: 1607347371925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
   sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
   md5: da69e6987fcc757e83a358ceaa13f62b
   depends:
@@ -8647,7 +8647,7 @@ packages:
   license_family: BSD
   size: 73391
   timestamp: 1614804425587
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
   sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
   md5: 23b9f4634b2e5450be617114f62c74f9
   depends:
@@ -8656,7 +8656,7 @@ packages:
   license_family: MIT
   size: 120873
   timestamp: 1695742300539
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
   sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
   md5: 120f0b088290fc17bd6618fc10a2f0c4
   depends:
@@ -8664,13 +8664,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 34293
   timestamp: 1605306211299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
   sha256: 6bdb88cd45b22246e84b7400159ca90faf98ab4e8c1fa2d38d031cfc73c4dc13
   md5: d6e10641ece06f67561c5f6a676a4b7e
   depends:
@@ -8682,7 +8682,7 @@ packages:
   license_family: Apache
   size: 1794729
   timestamp: 1689041580510
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
   sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
   md5: c3f7871e9a33adeccee1b1e8e216918e
   depends:
@@ -8692,7 +8692,7 @@ packages:
   license_family: GPL2
   size: 1332571
   timestamp: 1683113347814
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -8701,7 +8701,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
   sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
   md5: 1ab55f8c4b5292ec360c572120bf823e
   depends:
@@ -8711,7 +8711,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 9430705
   timestamp: 1616055773485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zfp-1.0.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zfp-1.0.0-hd77b12b_0.tar.bz2
   sha256: 4c35ecdc3e6eac1c031fb9caad206819266a29c9b3d507e2c82a73c6b3c4aaa8
   md5: 2440d1045b36aeaffa022e8316352a5f
   depends:
@@ -8721,7 +8721,7 @@ packages:
   license_family: BSD
   size: 271931
   timestamp: 1681741704356
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zict-3.0.0-py39haa95532_0.tar.bz2
   sha256: 556bdf23786b69d1699aa1313fac43589cd33f8c62b701259e0f71c52343b59a
   md5: 7bbafad85b6da7514e895923f3af7f5a
   depends:
@@ -8732,7 +8732,7 @@ packages:
   license_family: BSD
   size: 76800
   timestamp: 1695832961240
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
   sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
   md5: 6875e0bf3828707dc9165d694c0d0a7d
   depends:
@@ -8741,7 +8741,7 @@ packages:
   license_family: MIT
   size: 18725
   timestamp: 1672387612937
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
   sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
   md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
   depends:
@@ -8751,7 +8751,7 @@ packages:
   license_family: Other
   size: 148931
   timestamp: 1666595229032
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
   sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
   md5: 8d6a1e767775fe0eb617cd6e22edc2ff
   depends:

--- a/network_packets/pixi.lock
+++ b/network_packets/pixi.lock
@@ -1,0 +1,8766 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aom-3.6.0-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blosc-1.21.3-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.3.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brunsli-0.1-h2531618_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cfitsio-3.470-h5893167_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/charls-2.2.0-h2531618_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.0-py39h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dav1d-1.2.1-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2021.9.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-0.5.0-py39h7deecbd_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/imagecodecs-2023.1.23-py39hc4b7b5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/imageio-2.31.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jxrlib-1.1-h7b6447c_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h568e23c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libaec-1.0.4-he6710b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libavif-0.11.1-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.2.1-h91b91d3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20221030-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.1.0-h9e868ea_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.52.0-ha637b67_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-h37d81fd_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libzopfli-1.0.3-he6710b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.0.1-py39h27cfd23_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py39hd09550d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.4.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.21.5-py39hf6e8229_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.21.5-py39h060ed82_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.4-py39h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.18-h7a1cb2a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py39h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-snappy-0.6.0-py39h2531618_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pywavelets-1.4.1-py39h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scikit-image-0.19.3-py39h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.9.3-py39hf6e8229_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.1.9-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/testpath-0.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/thrift-0.17.0-py39h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tifffile-2023.4.12-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zfp-1.0.0-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2021.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2021.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.5-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyviz_comms-2.0.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2021.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2021.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.5-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyviz_comms-2.0.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aom-3.6.0-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.3.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brunsli-0.1-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/charls-2.2.0-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39ha2381d6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dav1d-1.2.1-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2021.9.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-0.5.0-py39h67323c0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/imagecodecs-2023.1.23-py39hd1bf5dc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/imageio-2.31.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jxrlib-1.1-haf1e3a3_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libaec-1.0.4-hb1e8313_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libavif-0.11.1-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20221030-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm11-11.1.0-h46f1229_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libzopfli-1.0.3-hb1e8313_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.38.0-py39h8346a28_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.0.1-py39h9ed2024_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py39haf03e11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.4.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.55.1-py39hae1ba45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.21.5-py39h47b59a4_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.21.5-py39hcfaf2c3_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-1.4.4-py39he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h218abb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-snappy-0.6.0-py39h23ab428_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pywavelets-1.4.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scikit-image-0.19.3-py39hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.9.3-py39hf241641_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.1.9-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/testpath-0.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/thrift-0.17.0-py39he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tifffile-2023.4.12-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zfp-1.0.0-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2021.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2021.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.5-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyviz_comms-2.0.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aom-3.6.0-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-2.3.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brunsli-0.1-hc377ac9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/charls-2.2.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39h3c57c4d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dav1d-1.2.1-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2021.9.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-0.5.0-py39heec5a64_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fftw-3.3.9-h1a28f6b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/imagecodecs-2023.1.23-py39h604db08_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/imageio-2.31.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jxrlib-1.1-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lazy_loader-0.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libaec-1.0.4-hc377ac9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libavif-0.11.1-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20221030-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm11-11.1.0-h12f7ac0_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzopfli-1.0.3-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.38.0-py39h98b2900_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.0.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py39h525c30c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.4.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.55.1-py39h9197a36_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.21.5-py39h42add53_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.21.5-py39hadd41eb_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-1.4.4-py39hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hc0d8a6c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-snappy-0.6.0-py39hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pywavelets-1.4.1-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scikit-image-0.20.0-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.9.1-py39h9d039d2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.1.9-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/testpath-0.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/thrift-0.17.0-py39hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tifffile-2023.4.12-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zfp-1.0.0-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2021.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2021.9.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.5-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pyviz_comms-2.0.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aom-3.6.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-2.3.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/charls-2.2.0-h6c2663c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h3438e0d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/dav1d-1.2.1-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2021.9.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-0.5.0-py39h080aedc_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/imagecodecs-2023.1.23-py39h6c6a46e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/imageio-2.31.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libaec-1.0.4-h33f27b4_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libavif-0.11.1-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libzopfli-1.0.3-ha925a31_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.38.0-py39h23ce68f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.4.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.55.1-py39hf11a4ad_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.21.5-py39h6917f2d_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.21.5-py39h46c4fa8_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h6244533_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-snappy-0.6.0-py39hd77b12b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywavelets-1.4.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scikit-image-0.19.3-py39hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.9.3-py39hdcfc7df_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.1.9-h6c2663c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/testpath-0.6.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/thrift-0.17.0-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tifffile-2023.4.12-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zfp-1.0.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+  sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
+  md5: 613805add1c05b538ff06d217252feb7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 20810
+  timestamp: 1652859733309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+  sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
+  md5: 2cf39d906cc321896ffe3e5d33d80c5c
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162166
+  timestamp: 1644463608931
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aom-3.6.0-h6a678d5_0.tar.bz2
+  sha256: daddb86497522fd6fb8447c0aaebb763e685348b86fadb4ca6425f50f9d85f08
+  md5: 2d31ed3210e7119160eb02564154b4c1
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2958771
+  timestamp: 1688660715607
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+  sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
+  md5: 2972a84e0e22ae3244bbd2f1eebcf536
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 35352
+  timestamp: 1644569715988
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+  sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
+  md5: a68016b4b06460def24cb69d932986f3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132486
+  timestamp: 1695717963702
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+  sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
+  md5: 2f6356a2f530314b4059c08c79a3d8bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 205868
+  timestamp: 1681493113570
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blosc-1.21.3-h6a678d5_0.tar.bz2
+  sha256: 10b48986cb0e0c974477ac3a58aaae198270b01f19cbd3e900143c6558fa3424
+  md5: 202b4629c225257fc01a4a2180c4e2f7
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65491
+  timestamp: 1675247642609
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.3.3-py39h06a4308_0.tar.bz2
+  sha256: c97515490688900b9afd59dbff8ca2b0d1edae49b9af7c4b1cbddb874b6e0163
+  md5: d0c0e898049739c075d026891c7de3cf
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3,<2.0a0
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.1
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8690186
+  timestamp: 1625767563920
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
+  sha256: 20e381c665853131fc5c9a397b1d4b05bb05859a2bdfbb0559e85ec445ee9e7c
+  md5: 14dc3c2e8eb68b1111a08de9a3ce8a00
+  depends:
+  - libgcc-ng >=11.2.0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 128656
+  timestamp: 1657175966755
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 11df9b719339bb40e4af8eb124a094def217f64e2440af973d7342da19c030b0
+  md5: 712827b1699cc71e6240626c413408f3
+  depends:
+  - brotli-bin 1.0.9 h5eee18b_7
+  - libbrotlidec 1.0.9 h5eee18b_7
+  - libbrotlienc 1.0.9 h5eee18b_7
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 18907
+  timestamp: 1659616178155
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 6408b6849347ef01f5ed170f4b35fb4bdfed2d9cf9da4912a4b104a810518a80
+  md5: d9d570587ccfd7158b66feb823c990c6
+  depends:
+  - libbrotlidec 1.0.9 h5eee18b_7
+  - libbrotlienc 1.0.9 h5eee18b_7
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 19933
+  timestamp: 1659616170430
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
+  sha256: 8507df3357958556aff2dea8788a3f7ddad6172fd9fe5d1bdb6c3afe9686d2f8
+  md5: f0204f72bcd9ef836218cc74345e69f2
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 362180
+  timestamp: 1659616255400
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brunsli-0.1-h2531618_0.tar.bz2
+  sha256: 3a2778321f5ef815cd8aa4bf37bb1532b31656c1bf5310738146e7081b177b3e
+  md5: dc6cf5631ada26a03b237ef19e90cfd6
+  depends:
+  - brotli >=1.0.9,<2.0a0
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  license_family: MIT
+  size: 203551
+  timestamp: 1611240485163
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
+  sha256: 168c2fc4d5899ee70e85fadc998e00827e1b856a6fc4a402ed465cd7c320d19f
+  md5: f52e60deb7f4c82821be9a868e889348
+  depends:
+  - libgcc-ng >=7.3.0
+  license: bzip2
+  license_family: BSD
+  size: 107105
+  timestamp: 1563219611337
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+  sha256: 5b4c80587ae4ec915505469f79d866f27c80456156667c8548d31c67c2c1653e
+  md5: c3d6bfae757760082261779c406a880d
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 116270
+  timestamp: 1693902021950
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+  sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
+  md5: 3ef00f4c5278b688552efc259c463dc8
+  license: MPL-2.0
+  license_family: Other
+  size: 132731
+  timestamp: 1694009767372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+  sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
+  md5: d5cb3d97cf5e85ffe5e94037ed8a1169
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159077
+  timestamp: 1690232254640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
+  sha256: e99314f8809d65195dcab68a9783f70fbe990113a66c98c9b0a7ffea01226b71
+  md5: fff69f95079191a10e099b21a5fd4bc3
+  depends:
+  - libffi >=3.4,<3.5
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 234749
+  timestamp: 1670423281079
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cfitsio-3.470-h5893167_7.tar.bz2
+  sha256: a4a855659e4a52515b940d1b9d8204b626c11395980e99539b24f52d658e1857
+  md5: 65a71d60ece0bd684f1be09b48de8d00
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=7.82.0,<9.0a0
+  - libgcc-ng >=11.2.0
+  - libgfortran-ng
+  - libgfortran5 >=11.2.0
+  - zlib >=1.2.12,<2.0.0a0
+  license: Other
+  license_family: Other
+  size: 1384722
+  timestamp: 1655814890848
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/charls-2.2.0-h2531618_0.tar.bz2
+  sha256: ff4a1d243f3ffbcc677b1db7b5c7af06492f2910a0f1eea6664ad0ea3125835c
+  md5: 310b9390fc05d62245c9f95ac96ac376
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 132255
+  timestamp: 1612240399775
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
+  sha256: 762f4506c3e12b2332bd9abea3a2a1966f307b2673be7fd661dc6e316602d18b
+  md5: 4b8df5459d1762495428323753438641
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 151844
+  timestamp: 1698129872673
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
+  sha256: 4fd0207b930fbc936d4b8206117cfa9792aa19bfb320eb08aab6bba10002f9ee
+  md5: 7082a1ce8fa314cc2761d2f689c6bb9e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40456
+  timestamp: 1683040035572
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+  sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
+  md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1917831
+  timestamp: 1668084545510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+  sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
+  md5: 13702d3b4b744784e5bd559c7050dd6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12719
+  timestamp: 1671231205875
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
+  sha256: 0b1a9a25ddfc6631390c53d6ee95706eaab0805c5a9a8d748c08120a1f421256
+  md5: a93581f810ef522bd23c148195591157
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 234846
+  timestamp: 1663827645102
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+  sha256: 821af57c20a85b4e92268fbf65fbaec2f273da5bb21889d9643756ef6e473237
+  md5: f57e0f502500ffebdbec081ef61ad1d4
+  depends:
+  - cffi >=1.12
+  - libgcc-ng
+  - openssl >=1.1.1v,<1.1.2a
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 2179774
+  timestamp: 1694445209134
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.0-py39h5eee18b_0.tar.bz2
+  sha256: aac94702b3d4e4767f0bbbe3f1acfa811e18a2abb66f3afac74a51ddc3d046d9
+  md5: 4c34345079d18b1203746067dcd15042
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 394960
+  timestamp: 1667466037849
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
+  sha256: 80188a9729a26e36b027e673f5f30395798eb68f9fe4721f3f33b4d4d2e58285
+  md5: 686db307602cbbdc30ca7d62b765578b
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 103488
+  timestamp: 1613390248313
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dav1d-1.2.1-h5eee18b_0.tar.bz2
+  sha256: 9f015999d24a376602b5876f542bcb41a7db66fa73064091cccdc1b06195392c
+  md5: 29684f3832212a3c977960c62c421119
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 889577
+  timestamp: 1688746033126
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
+  sha256: 96b5d4c87d8467ae6ba92f9c17eaa9e059b6f7e9b8ee57aee788885c7413078b
+  md5: 9868912fd269f4d9d6423cfe69560131
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2164334
+  timestamp: 1690905228819
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2021.9.1-py39h06a4308_0.tar.bz2
+  sha256: cd25a05af68707a7314fd8fc6c62d87e363d58969095cd1dd96375b292b9212a
+  md5: 198a950942a9eca96672b46444928289
+  depends:
+  - click >=6.6
+  - cloudpickle >=1.5.0
+  - cytoolz >=0.8.2
+  - dask-core 2021.9.1.*
+  - jinja2
+  - msgpack-python >=0.6.0
+  - psutil >=5.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - setuptools
+  - sortedcontainers !=2.0.0,!=2.0.1
+  - tblib >=1.6.0
+  - toolz >=0.8.2
+  - tornado >=6.0.3
+  - zict >=0.1.3
+  constrains:
+  - openssl !=1.1.1e,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1116020
+  timestamp: 1634741468527
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+  sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
+  md5: 2e6ec51066d825ef3c317abe78d6049e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16413
+  timestamp: 1649926472708
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+  sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
+  md5: b4d923222d45314856b5378cb115214d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26728
+  timestamp: 1668714462023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-0.5.0-py39h7deecbd_2.tar.bz2
+  sha256: 003e760b30ed5e9322c3dac37feea0552ebb9b5e92d0b1a10267592154fdc675
+  md5: a9d854d6c96221d50f85a8b12e48c162
+  depends:
+  - libgcc-ng >=11.2.0
+  - numba >=0.49
+  - numpy >=1.16.6,<2.0a0
+  - packaging
+  - pandas >=1.1.0
+  - python >=3.9,<3.10.0a0
+  - thrift >=0.11
+  constrains:
+  - numpy >=1.18,<1.22
+  license: Apache-2.0
+  license_family: Apache
+  size: 191820
+  timestamp: 1658500763114
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+  sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
+  md5: a5dc8677d891dff2393b63189a3ad42f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 971975
+  timestamp: 1666798278693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
+  sha256: cfef2f1f3f1aa159f87806b7fa2b65c02c0d6f9bd24ccda833b43246c5095be6
+  md5: 394ec1374a92c6fd5f772343934337e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 260575
+  timestamp: 1695734561396
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
+  sha256: c323a9800a358c178f6f3b8860bbb77c373fbc3be981bb6420175fbb5431adf5
+  md5: 6485f51176cf651b3b28c3548cef10ad
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 78533
+  timestamp: 1676983203797
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+  sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
+  md5: 1eb52f9f45cea2fb9ce27b19f990160e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110793
+  timestamp: 1666125606878
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/imagecodecs-2023.1.23-py39hc4b7b5f_0.tar.bz2
+  sha256: 25a222ded2ee539c142e0c34a2bd49a2e7fda561b3359c99241b773fcd4f5010
+  md5: 37c9408a5968471a536ce68d6236361f
+  depends:
+  - blosc >=1.21.3,<2.0a0
+  - brotli >=1.0.9,<1.1.0a0
+  - brunsli >=0.1,<1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - cfitsio >=3.470,<3.471.0a0
+  - charls >=2.2.0,<2.3.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - jxrlib >=1.1,<1.2.0a0
+  - lcms2 >=2.12,<3.0a0
+  - lerc >=3.0,<4.0a0
+  - libaec >=1.0.4,<2.0a0
+  - libavif >=0.11.1,<0.11.2.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=11.2.0
+  - libtiff >=4.5.0,<4.7.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - libzopfli >=1.0.3,<1.1.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - numpy >=1.21.5,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - snappy >=1.1.9,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zfp >=1.0.0,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10674908
+  timestamp: 1695066538869
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/imageio-2.31.4-py39h06a4308_0.tar.bz2
+  sha256: 6fc4b8698f4e81f0bb1394a1ced9c2a8de92e9cd03d967820a2333a3c0eb58ff
+  md5: 282ce4456f36647b4e39826335d3e913
+  depends:
+  - numpy <2.0a0
+  - pillow >=8.3.2
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 508868
+  timestamp: 1695996560599
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+  sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
+  md5: 126b3c1933b7364ff03f67455b687e99
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 37588
+  timestamp: 1678997134023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
+  sha256: b6d5f6098903e5edfbc2200282efa186d446442d47ab75f51ff22c30ae0c4da4
+  md5: e53a806995cedc9e5d8a96e03c9e79ac
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 50699
+  timestamp: 1698254665788
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
+  sha256: bddc8de31272a509510cc87e5ac0cdb0e7765d393ca7bdfddbfe4123979a9413
+  md5: bc8a501970aadad3373edbce996b5fdf
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<1.2.14
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 19286333
+  timestamp: 1681801301379
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
+  sha256: c0d0714c68ed953740812688ac1b3c3e286de33b55d49f02953d705fb00c30d0
+  md5: 8b65eea396159a3b59278f77c81ddd1b
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217268
+  timestamp: 1691122070319
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+  sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
+  md5: ff47e0be879e817713ce2a9daa76e2b0
+  depends:
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1261116
+  timestamp: 1694181530670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+  sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
+  md5: 5ef6c6a0d1ac79143c7359d305155167
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1021637
+  timestamp: 1644297140650
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+  sha256: c21f8f407266d039e819c27fe9eb4fb26587e974f3bd059b37cbaec5073722d0
+  md5: ba1f47411e9e07876c7a3e9d3be6a98e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: IJG
+  license_family: Other
+  size: 281400
+  timestamp: 1677849152168
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+  sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
+  md5: 0d2c3c5edf671b575532d5a3e8bf15fc
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 131510
+  timestamp: 1676558716852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
+  sha256: 4ba1f5698f0b483af397021b2047554afb3129790cac3a1502c79693154331d2
+  md5: 8e9c0ef4b0b57caa87c146892e56a313
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192921
+  timestamp: 1676329415827
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+  sha256: 0192bd48cd96c60dc3054d5addd8cdb4a29a218843181318371f79daec8242f8
+  md5: d851b401dc13d04e6848bb36e12efc1c
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 91534
+  timestamp: 1679906652183
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+  sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
+  md5: a4beb461f0a60998a090d760b5c6c907
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411564
+  timestamp: 1671707702849
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jxrlib-1.1-h7b6447c_2.tar.bz2
+  sha256: 46fa3b9ce2790a2efd328560b7e76f6716c92288702ced1f63168f22bad487d0
+  md5: e1ae8a1211dfebe4c60b7e755200a327
+  depends:
+  - libgcc-ng >=7.3.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 244049
+  timestamp: 1593197090424
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
+  sha256: 6d6c384c9c65e33d5d047e01131e0687eb2bc1e5a4a67f80af3c0b773c1bba82
+  md5: 07957e1d2fb6a407f7d7293b84938e1e
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 77689
+  timestamp: 1672387301020
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h568e23c_1.tar.bz2
+  sha256: 126a5fd5e59cc90c1a2c688a801dea7f352f0bb218c2f949d0f3d21db35fbe1b
+  md5: 64d1d86c812dc1843bcbb4cab2e8f60f
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=1.1.1u,<1.1.2a
+  license: MIT
+  license_family: MIT
+  size: 1426697
+  timestamp: 1686931184185
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+  sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
+  md5: 88199c75f2ac211728febced7785c24e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 228278
+  timestamp: 1635523146417
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libaec-1.0.4-he6710b0_1.tar.bz2
+  sha256: 860ecdf2e21768f806f9c0d272e92dbc521b249a7171b0def500a30937fb079a
+  md5: e911ac853b19bd7073f1047699e2118e
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 35409
+  timestamp: 1593197267510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libavif-0.11.1-h5eee18b_0.tar.bz2
+  sha256: 0eccc12a46c14a730a55569f28a170bd315aad9df6ae7e13eba7732e6317f3df
+  md5: 5974603ff942f18b40e5156dd6819410
+  depends:
+  - aom >=3.6.0,<3.7.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - libgcc-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 105392
+  timestamp: 1689158136084
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 472cf888db65d00451fcd5fccd5244d55c061e8d7efe43f70220414ef64521a5
+  md5: 787927eff72e62c270f614cbcba9479c
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 67109
+  timestamp: 1659616145972
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 19a43182ca343510ba51baa0fce91d64c840a19cdf13c6dde4e03e819c70897e
+  md5: c0608d376a30b5aa4d2f2c22978135db
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_7
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 34691
+  timestamp: 1659616154057
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 158c401aa0bab05aa5f4134aea798085e4e3849209946f896cca352930d2225d
+  md5: cc6a6d362912a2d112310bd3f8acd44e
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_7
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 295287
+  timestamp: 1659616162282
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.2.1-h91b91d3_0.tar.bz2
+  sha256: 8daa34822b26916b12867746d55790aa5b719e096e412aba86c5a9f13b19ee36
+  md5: bd594551d7447f93c8a1575be1b1f12e
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libgcc-ng >=11.2.0
+  - libnghttp2 >=1.52.0
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 386369
+  timestamp: 1693515365220
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+  sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
+  md5: 55dde57e63a36b202e388a39dcee9a66
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 74096
+  timestamp: 1695996494461
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20221030-h5eee18b_0.tar.bz2
+  sha256: 5d66a60672f8e7dd0c048b5f158b5d406f16133b260ffde95a93eb453a1e7af9
+  md5: af7584851084abae8eaa8cee2ed288b4
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.3,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 195621
+  timestamp: 1670840131081
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+  sha256: efdab884c85fda4461f7a393aa6d4e0e50d03cb59fb9c8a980b1307b8379ebe0
+  md5: eeca774c6154c49340dd403b1928d5e9
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 108906
+  timestamp: 1632891483341
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
+  sha256: ec1c6341cf0091b55be05285037cb3fbba90573e00257f383ab274d8b8e6d46f
+  md5: 32ac65d639d6c155ea7276cadf1fd2b6
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 147907
+  timestamp: 1683716564178
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
+  md5: 641e72e5067bd6d5454405879e1cd2a7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - _libgcc_mutex * main
+  - __glibc >=2.17
+  constrains:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - libgomp 11.2.0 h1234567_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 8895144
+  timestamp: 1654090827491
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+  sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
+  md5: 27082517590f3b9fbffecc68513b461b
+  depends:
+  - libgfortran5 11.2.0.*
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 19860
+  timestamp: 1654090819660
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+  sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
+  md5: 0202c3c8ae4735cac6c7f3d1e1685964
+  constrains:
+  - libgfortran-ng 11.2.0 *_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 5228750
+  timestamp: 1654090762569
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+  sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
+  md5: 3080c2813e6e1d0f8a100a38b5b3456d
+  depends:
+  - _libgcc_mutex 0.1 main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 573231
+  timestamp: 1654090775721
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm11-11.1.0-h9e868ea_6.tar.bz2
+  sha256: 0fd833e8a519f75e2c4b6cdbec75b8fffc1cd015b2b795d1566855e486705736
+  md5: c2b4c6491de2bf531083a51092ecd077
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 30349190
+  timestamp: 1665079289108
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.52.0-ha637b67_1.tar.bz2
+  sha256: 71a65b3c05426b92e8a3002e7d42cd303255439f8a4442b4fc5aa882aef3128e
+  md5: 113b010119638c67e3b6c8570d88f5be
+  depends:
+  - c-ares >=1.19.0,<2.0a0
+  - c-ares >=1.7.5
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=1.1.1u,<1.1.2a
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 716614
+  timestamp: 1686931412665
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+  sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
+  md5: 1bffe1481ed4f88827248fb9001f8923
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 362561
+  timestamp: 1677841789536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-h37d81fd_2.tar.bz2
+  sha256: 41f2e9a088031bd209d50f37f727fb9647be9316db3e149f9f2bac0057f7184d
+  md5: 778c268743d6cf857178bd1ecf6c9525
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl >=1.1.1u,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 311794
+  timestamp: 1686931200150
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
+  md5: 8c195584a5f5471b600ee180e4052773
+  depends:
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 6410287
+  timestamp: 1654090800863
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+  sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
+  md5: ef78eebd98289aceacdfa29182426adf
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 664034
+  timestamp: 1693575237924
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
+  sha256: c6aecee300c8e84a99056307ed3bdc047edd5366e55230a4eabe3ee5e8082bb8
+  md5: 3a6ebf9895b1085a23783cd95460a629
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88424
+  timestamp: 1694778218406
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+  sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
+  md5: 9cdeef1d044c7e035c006890f11569d3
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 436056
+  timestamp: 1694776944891
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libzopfli-1.0.3-he6710b0_0.tar.bz2
+  sha256: 04e6f97332bc583ad380f0dc6f3f38c766fe15900c29f52c8097b7743ef2b417
+  md5: 6d276711374079b0d91ea31ecbe27b31
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 183622
+  timestamp: 1593197391897
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.38.0-py39h4ff587b_0.tar.bz2
+  sha256: 497e0a8e555539787dd237dea5d13a0a6061db2cb50ded20daddaf08bbf267cc
+  md5: ecc0c3c465bbf6988ebbc6a38e2eeb1c
+  depends:
+  - libgcc-ng >=7.5.0
+  - libllvm11 >=11.1.0,<11.2.0a0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  - zlib
+  license: BSD-2-Clause
+  size: 2826845
+  timestamp: 1647870510956
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
+  sha256: d8cd22ac7f033507549f6a0d078cd273607cb6e8246b0383375a33941969c12c
+  md5: 78c7a3a437536ae24d2d7ce15ec400d2
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11065
+  timestamp: 1652903210940
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
+  sha256: 36b23ab8d8aa22d70a2f733462cabe95e5b27ca919ec7a75a5592bc39c5f7d16
+  md5: f24adbfdfe16b0bac0d14640bb5ce616
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 163649
+  timestamp: 1670944701605
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+  sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
+  md5: 421f82c8274b44660dba629134faa6af
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 122221
+  timestamp: 1671541990505
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.0.1-py39h27cfd23_0.tar.bz2
+  sha256: fe70281280902597f453c539de0391b9794d6272a1310e79e36be224204f2032
+  md5: d41111388cfceda1904958476da096a1
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23039
+  timestamp: 1621523521377
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
+  sha256: 10701d3065424bbef89c03a30c4adecd67308cd2f76e0d873aad6a180d9fe097
+  md5: e196f6bace29ef34f0a996ef1c99f193
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8129476
+  timestamp: 1698692330174
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+  sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
+  md5: c04ef34af33da4c71bcc99b7ec24d210
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16391
+  timestamp: 1662014553452
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+  sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
+  md5: f6c734d73e6e3dbc1b62766cf18ff3e4
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58153
+  timestamp: 1607364912263
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
+  sha256: c7dedf41acbb2a065364f949ba24479449387d54c095220ff89346d266b25347
+  md5: c5f96c8ff7102e1d673829bbeb8bed84
+  depends:
+  - intel-openmp 2023.*
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - tbb 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 206706869
+  timestamp: 1691503234180
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
+  sha256: 984f547627b0af8358fa83b2396e0b2c014f9bc281304b6b8d3ff139a3f04b40
+  md5: 724d2559e0ed50aa0eee97c919134ded
+  depends:
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 58512
+  timestamp: 1682948511810
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
+  sha256: 650419991b99b810e79221e35e5a6c3e49240ed30ff3e5324eecf1cefd276110
+  md5: a14b8155afdb15f3bce72e67925c0ceb
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 227382
+  timestamp: 1695058347376
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
+  sha256: 7b0eeb8acc4c6b9f45b214fbc991a4073a59a8f7b798a4cc86515b97f7af6355
+  md5: eb48e45fd8d61762290e4289a52be3f7
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 329190
+  timestamp: 1695059874042
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py39hd09550d_0.tar.bz2
+  sha256: a138d682379358886f9d8c1e81da8d126c5cb1f0eff50e236ed471ea5b0b9d24
+  md5: 5b2574b896f022cf33ed9a871aacabb3
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 90177
+  timestamp: 1652362815706
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
+  sha256: 305313d215116fbf13a38f8a321eb635b83294871801ac63e543a59ba7de642c
+  md5: e0db8ae050bd0db74f47edc370dbc287
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 24480
+  timestamp: 1607574279743
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+  sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
+  md5: 95c83d71814c504b5504df4f14548f1a
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8257558
+  timestamp: 1681756322140
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+  sha256: 1b92d72b083f3350359b8fb2e3b5dc846f49650c9e46a6a74354b1b7f0d42730
+  md5: 996babe4314515ddd41008a53cb5d47f
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 98791
+  timestamp: 1650290544347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.4.4-py39h06a4308_0.tar.bz2
+  sha256: 949f10a2e5dc054c739765c4785e8fe13181b992fddf2adc480e57686eb9453c
+  md5: d263e3cdf799476e21315a41eaed3a89
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=2.4
+  - jupyter_core
+  - jupyterlab_pygments
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0,<0.6.0
+  - nbformat >=4.4
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - testpath
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 568158
+  timestamp: 1649752009070
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+  sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
+  md5: 385cc9e53404776782502c0fdb08820f
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147046
+  timestamp: 1694616899309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+  sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
+  md5: 57ea097dc15f8d9f9eb90e1d919143b0
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1157733
+  timestamp: 1674734069410
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+  sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
+  md5: bbbcbebc20a4fdcadce398d0ca04f95e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13109
+  timestamp: 1672387143252
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.1-py39h06a4308_0.tar.bz2
+  sha256: 75a4858adf42d03e1ef52ea0083d7665bf3426607367cad661077199951b18a4
+  md5: 357296e49c55733ecc879ffe5d612116
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2955832
+  timestamp: 1690562037565
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+  sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
+  md5: 248ce515640465371927d46f389ed555
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 594054
+  timestamp: 1690985006481
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+  sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
+  md5: 70db71df4ee1cdd38090c0f7b80ba61f
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21944
+  timestamp: 1668160644514
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.55.1-py39h51133e4_0.tar.bz2
+  sha256: 30f95c6c51ee7ca01801778b1773d8ecb57fcf06e864093f27148e1298517c20
+  md5: 1c1f0821f0dd2ece64844f39edcbd03f
+  depends:
+  - _openmp_mutex >=4.5
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - llvmlite >=0.38.0,<0.39.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - tbb >=2021.5.0
+  - libgomp
+  constrains:
+  - cudatoolkit >=9.2
+  - scipy >=1.0
+  - libopenblas !=0.3.6
+  - tbb  >=2021.0
+  - numpy >=1.18,<1.22
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3982289
+  timestamp: 1648045822890
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
+  sha256: e61fc626f7131f1857c703ad3bb4dcacfc6b1fd6d5da545aa8f600b840315aca
+  md5: 6b689e52e3ba1fa7caaab3e6be31860c
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 141434
+  timestamp: 1696515497148
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.21.5-py39hf6e8229_4.tar.bz2
+  sha256: 1e3bd69c628c9c460a99a39433384797613e2c2dc122da6073da83d0aeeb0eff
+  md5: 17c5648c13f4e1a064f4b14831737f62
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.21.5 py39h060ed82_4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  size: 10146
+  timestamp: 1682951728416
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.21.5-py39h060ed82_4.tar.bz2
+  sha256: 5de427603f36549a140cc9d69d35bf2f845483973f33477b7f4d77e6fc007de3
+  md5: 66cc9d79973f5588aeb44a1f8d16b3f8
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.21.5 py39hf6e8229_4
+  license: BSD-3-Clause
+  size: 6464938
+  timestamp: 1682951713892
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+  sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
+  md5: b0afe23033c8c5344640bc25225fa579
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 516994
+  timestamp: 1630084830020
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+  sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
+  md5: 5ad4571eba2479f77a9f849a6ae7724c
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: OpenSSL
+  license_family: Apache
+  size: 3998613
+  timestamp: 1694465071784
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+  sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
+  md5: 77a22ed6d0d448c5288d0f695bc9ac49
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 72527
+  timestamp: 1693575234886
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.4-py39h6a678d5_0.tar.bz2
+  sha256: 35adc93d0fde9abfa7bcbaf68f024926031a6b05dcd7edfd83a7f6398c4d2843
+  md5: 52ab906448f09ab3f424ac156ade715e
+  depends:
+  - bottleneck >=1.3.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numexpr >=2.7.1
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13151705
+  timestamp: 1663773447154
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
+  sha256: 9c699bd495cbf23db7dea986deeb75183571b83adc14b3e4a36cc6cfd2a198a8
+  md5: 39ed6f683307cca54ac666b2d1f849ff
+  depends:
+  - locket
+  - python >=3.9,<3.10.0a0
+  - toolz
+  constrains:
+  - pandas >=0.19.0
+  - numpy >= 1.9.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35706
+  timestamp: 1698702632637
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
+  sha256: db8122fcb6316fb86c2ff6d4dd47154a650ac26d270183a316f14004adf27525
+  md5: 33ad46d04664fc8b65a545110e4fe099
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 764331
+  timestamp: 1696580179855
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+  sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
+  md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2674850
+  timestamp: 1697548887851
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+  sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
+  md5: fe56f0479dd414c846191116366262c3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 31999
+  timestamp: 1692205535111
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+  sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
+  md5: 44d2a857d13bdf9d99aaac039a249d47
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91137
+  timestamp: 1659455142164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+  sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
+  md5: eb899a739d9b58dd747f1f6bd52d4cf3
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 579771
+  timestamp: 1672387338600
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
+  sha256: a760d6c9fca08c09ff0bc9a33946188e2ea5deed2443d4acb360ce55ce36ee43
+  md5: 2cb2ad8315f68f4339b9416bd9ab115e
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353437
+  timestamp: 1656431352923
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+  sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
+  md5: f36ecb722522cbe2e3737424edf1b5e1
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29312
+  timestamp: 1675441510984
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+  sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
+  md5: 6d03295e544251e608a28c8d7c48115e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1862058
+  timestamp: 1684280096752
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+  sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
+  md5: 1f09617aecd6f3c2f2e20692c0759f34
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94434
+  timestamp: 1690223520097
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+  sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
+  md5: ffceed627867508d73af1636ab5ebf42
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 156324
+  timestamp: 1661452578573
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+  sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
+  md5: 0e3341a4fe434167bf74b613eb6afd81
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 97194
+  timestamp: 1636110999719
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+  sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
+  md5: c5f3f7f10ad30f0945e75252615ab6e5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31331
+  timestamp: 1605305847037
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.18-h7a1cb2a_0.tar.bz2
+  sha256: fea95d1b166df729a918c1a528f4eacb1ef1aefe321b966e4fcd48d871ad84ea
+  md5: cac6b214644d9bbf7b398489cb16c320
+  depends:
+  - ld_impl_linux-64
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 26791682
+  timestamp: 1694439185856
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+  sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
+  md5: 0caa188a695319bdb13f53b0a2b3accc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264864
+  timestamp: 1661371117920
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py39h6a678d5_0.tar.bz2
+  sha256: 3d4ebba2cd88a8e2b514c061d107b33057c67d54620a2975146d51444887b543
+  md5: 9ae7c3b89bdccb939936e2f087c4f761
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 139001
+  timestamp: 1682522498995
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-snappy-0.6.0-py39h2531618_3.tar.bz2
+  sha256: 262e568ec50e23aa7187586da450d427e36f9abd0ddfc25b6574602d835366fe
+  md5: 95ef4ec206d097ce7e12f82779c58ce0
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  - snappy >=1.1.8,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 31795
+  timestamp: 1610133082486
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+  sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
+  md5: bcb44ecbea441ee0d4659133d060d71f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257904
+  timestamp: 1695131670290
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pywavelets-1.4.1-py39h5eee18b_0.tar.bz2
+  sha256: ca6f2cb564a5aaa4a71a2bc56efe40a5427ef91427c9b388fb1faace6d9922db
+  md5: 533f4979d06fc728e5dfad27d61f627e
+  depends:
+  - libgcc-ng >=11.2.0
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 4600603
+  timestamp: 1670425256409
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
+  sha256: 2a535f9fdda20b536bd76dfa286fb67a7685ed2be4ad51e2860c44e144c0b457
+  md5: 797c263fd5bff62987fc1da076eef0f9
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 184040
+  timestamp: 1698096132905
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
+  sha256: 70ee4fc614dd3337ad542c7c961428930160ab8c7da27775faed5ffddbd362d7
+  md5: bf2a4feb20647c569f7ce5a8f63094fa
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 515650
+  timestamp: 1657724431309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+  sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
+  md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 467661
+  timestamp: 1666648052561
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+  sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
+  md5: c7de00b4ac2778c4e5a7816320d75391
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94028
+  timestamp: 1690400356879
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scikit-image-0.19.3-py39h6a678d5_1.tar.bz2
+  sha256: 2f47c942449fb5ae8a782953b3b2a7403d0d534aa1790b997f899dff2d934188
+  md5: 45d3a79f50f967d198d085bd0f9a0137
+  depends:
+  - _openmp_mutex
+  - cloudpickle >=0.2.1
+  - cytoolz >=0.7.3
+  - dask-core >=1.0.0,!=2.17.0
+  - imageio >=2.16.2
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - networkx >=2.2
+  - numpy >=1.19.2,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.1.0,!=7.1.0,!=7.1.1,!=8.3.0
+  - python >=3.9,<3.10.0a0
+  - pywavelets >=1.1.1
+  - scipy >=1.4.1
+  - tifffile >=2019.7.26
+  - toolz >=0.7.3
+  - libgomp
+  constrains:
+  - matplotlib-base >=3.0.3
+  - pooch >=1.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12244824
+  timestamp: 1669243871552
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.9.3-py39hf6e8229_2.tar.bz2
+  sha256: 6d27ec18cf6e96610204ef26a0e1858cdfefabe3514adf8d497879731d504d27
+  md5: b15739fe1e09ad49a09c82d26b2330b2
+  depends:
+  - blas 1.0 mkl
+  - intel-openmp >=2023.1.0,<2024.0a0
+  - libgcc-ng >=11.2.0
+  - libgfortran-ng
+  - libgfortran5 >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.19,<1.26.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26648976
+  timestamp: 1683286502437
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+  sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
+  md5: 1581cafc84708ed9aafaaee1cbbf6065
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1089416
+  timestamp: 1690290900608
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.1.9-h295c915_0.tar.bz2
+  sha256: 0f5809564b323f020dec2633dc274bbc96dc13d54888bb115938d3d7f6a717bb
+  md5: 71b25fd79c57bcf6bd2ba8ccf1e18506
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 891170
+  timestamp: 1649923859475
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+  sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
+  md5: e19ffbfb24b990275d24fcea2bd1699b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15702
+  timestamp: 1614030498860
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+  sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
+  md5: ca061ce25c0f58628643abec8d6a8244
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 66330
+  timestamp: 1696347637947
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
+  sha256: 8b45ba506984fe9c061b4acde6f5243d52dda8c1eae4992f8d80c03f425214fe
+  md5: 68c24a824d36a16bbb28d80d70cee8d2
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1640317
+  timestamp: 1681394746811
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+  sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
+  md5: 041a3caf09dc9ce8fc6c10925c4fe050
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1888016
+  timestamp: 1680167274961
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+  sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
+  md5: 0e76eab58fe488e91f0aee73f46de031
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29816
+  timestamp: 1671751864131
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/testpath-0.6.0-py39h06a4308_0.tar.bz2
+  sha256: 925677ec26cb76d10c4f0598afcfd83baf8abcb53566e2e16098eb375eeb9200
+  md5: 462c2a924ef617f929787960affc972c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 93566
+  timestamp: 1655908613837
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/thrift-0.17.0-py39h6a678d5_0.tar.bz2
+  sha256: 49b380af9a94648f228a38bfdb726f8047cf13cda868018ec2f5eaa410c6d626
+  md5: 22475a3e47ac882de71cfd80c3771678
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  - six >=1.7.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 129134
+  timestamp: 1666296627327
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tifffile-2023.4.12-py39h06a4308_0.tar.bz2
+  sha256: c0a8e427be9a0a534ef51a4b036ef23530aaf0fe9ba251e84c5d173d80af9846
+  md5: a0671ef4f75f6aa5562fec79ca64b58e
+  depends:
+  - imagecodecs >=2023.1.23
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - matplotlib-base >=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 376265
+  timestamp: 1695107594127
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+  sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
+  md5: 5b8375e2092012db69d2123dc0c68630
+  depends:
+  - libgcc-ng >=7.5.0
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3485432
+  timestamp: 1654088939579
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
+  sha256: 57983e3eb698a3b08b570d5f398d9550cf50b9bf54b2b4728c731ecbc0c89138
+  md5: 3ce956b1e1a7f77af6e6127dca987b95
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101246
+  timestamp: 1667464172523
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
+  sha256: bd06f7b49d9c04c51c1e825bab446ec3cdde2bce39af00bf113a05c1009595e2
+  md5: 587c3f3c891901f4305653e50c18d6c0
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 679739
+  timestamp: 1696937022519
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+  sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
+  md5: 67a8320961ff24e92eebb661536e5cf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - requests
+  - slack-sdk
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 123763
+  timestamp: 1679561904852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+  sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
+  md5: 0f0b91a158dd3692cbb7a7763b657bfe
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192032
+  timestamp: 1671143995098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
+  md5: 8515e64a3de7581360d713fe4c0a094e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8789
+  timestamp: 1690297588156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
+  md5: 60170012374b2a5007842fa5870d78c5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57479
+  timestamp: 1690297581658
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
+  sha256: 2f4a5979aaf22660fe9fb8c4ffd41e5a9dc012e20f78e1dbf4ad9c67e0fd28be
+  md5: 0be10051dd3d6f31ba52b7c08ba3ba0a
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 187469
+  timestamp: 1698257600264
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+  sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
+  md5: f8d03a15b974fc7810d9f54ae849fc8e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20781
+  timestamp: 1607365390528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+  sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
+  md5: d7db5d6ce1db80eade8a082ff78bf479
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 71044
+  timestamp: 1614804011510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+  sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
+  md5: b3899f8bda32734727bd5a73df1d7d17
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 101520
+  timestamp: 1695742037911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
+  sha256: d88bdc49a883a944cf1562ebb0a30d0451e28ab05521fc882615e357b105f414
+  md5: c150cf16071597fa3977fb81ebb83760
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1787638
+  timestamp: 1689041557651
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
+  sha256: 93ca87e697bb9e045fc9cda13b05fe27e1a99f3ed143b75bbcaf4dcb745aa06f
+  md5: 3eebbb22c5ca63987db36e1f19cbe872
+  depends:
+  - libgcc-ng >=11.2.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 763941
+  timestamp: 1683112966413
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+  sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
+  md5: 567b68192c387b5fc88178425577a0fe
+  depends:
+  - libgcc-ng >=7.3.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=7.3.0
+  license: LGPL-3.0-or-later
+  size: 366479
+  timestamp: 1616055552392
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zfp-1.0.0-h6a678d5_0.tar.bz2
+  sha256: 807521a07138f611cad037b15de8f478fc985cedb00bce3f6256c0ea14f09825
+  md5: 3a844b7ddc088e7cf5dca84d8c4e3fcd
+  depends:
+  - _openmp_mutex
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libgomp
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 305779
+  timestamp: 1681741638187
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py39h06a4308_0.tar.bz2
+  sha256: 859398823a40ead7079055f01ad23f7f5a03ffa11ad672fa26bea38badd8ec01
+  md5: b733cbb9875966a2017e7c386fb98076
+  depends:
+  - heapdict
+  - python >=3.9,<3.10.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 76469
+  timestamp: 1695832872162
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+  sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
+  md5: 3818a9531fe74433c3b7d5144c9a58cc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18021
+  timestamp: 1672387231268
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
+  sha256: 2dc9150a95704d83efd39bb9dfb44bdf8419022f4fb0fc416380a922a27c130d
+  md5: 4f315d7551f4bbeb06b6fc28342a9aa5
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Zlib
+  license_family: Other
+  size: 127528
+  timestamp: 1666595012798
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
+  sha256: aa6aa291bec6aa66e1f063cfa75a9e0fc6bd459fcb45c372aacac9006a073900
+  md5: 4e99328768f538f33aecebdae9472744
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1055426
+  timestamp: 1681304602537
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
+  md5: b2aa5503875aba2f1d88cae9df9a96d5
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13636
+  timestamp: 1611930018941
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
+  md5: 544adf2677c47c9b9c891aea720678f1
+  depends:
+  - python >=3.5
+  license: MIT
+  size: 33999
+  timestamp: 1630003259346
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/dask-2021.9.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 567108ad651ced20f632dc326601248b851cb775f6d318baa061bcad70aee274
+  md5: 077bf2c43cb0936fcc622b56c0aac194
+  depends:
+  - bokeh >=1.0.0,!=2.0.0
+  - cytoolz >=0.8.2
+  - dask-core 2021.9.1.*
+  - distributed 2021.9.1.*
+  - jinja2
+  - numpy >=1.18
+  - pandas >=1.0
+  - python >=3.7
+  constrains:
+  - openssl !=1.1.1e,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18809
+  timestamp: 1634742792966
+- conda: https://repo.anaconda.com/pkgs/main/noarch/dask-core-2021.9.1-pyhd3eb1b0_0.tar.bz2
+  sha256: d32f2f7823e6643225abd1a4e450d4c2adc48b5a625e765a52dfac5f174a600a
+  md5: 8a70b4c97a5c9827e9bae224d85b2cc4
+  depends:
+  - cloudpickle >=1.1.1
+  - fsspec >=0.6.0
+  - packaging >=20.0
+  - partd >=0.3.10
+  - python >=3.7
+  - pyyaml
+  - toolz >=0.8.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 786162
+  timestamp: 1634728790568
+- conda: https://repo.anaconda.com/pkgs/main/noarch/datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 2de2d79a0e9784a1bf55cdb83c035072da1879753d109c0a36bbd5a357385c37
+  md5: 6cfe764bb04e756d7d1319a98a05dd70
+  depends:
+  - bokeh
+  - colorcet >=0.9.0
+  - dask >=0.18.0
+  - datashape >=0.5.1
+  - numba >=0.51
+  - numpy >=1.7
+  - pandas >=0.24.1,<3.0.0
+  - param >=1.6.1,<2.0.0a0
+  - pillow >=3.1.1
+  - pyct >=0.4.5
+  - python >=2.7
+  - scipy
+  - toolz >=0.7.4
+  - xarray >=0.9.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14964307
+  timestamp: 1623782401693
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+  sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
+  md5: 9eff1a842dbda8d1bae9a2c008b599bc
+  depends:
+  - brotli >=1.0.1
+  - munkres
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 690443
+  timestamp: 1625743217109
+- conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 9de8666e5b70aa2437737128eaa14ffe80a7b5235c2a6b7d3f39ccefd7816ba0
+  md5: bb52e50c5ab1a5c7778c11376404dfdb
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 7933
+  timestamp: 1630598543551
+- conda: https://repo.anaconda.com/pkgs/main/noarch/holoviews-1.14.5-pyhd3eb1b0_1.tar.bz2
+  sha256: e77b4a0cc563af73e983215185e4158d11e0f9cd2cc62b8774a6b882f6846093
+  md5: 38360443a9f70dac94eade937da2dc87
+  depends:
+  - bokeh >=1.1.0
+  - colorcet
+  - ipython >=5.4.0
+  - matplotlib-base >=3
+  - notebook
+  - numpy >=1.0
+  - pandas >=0.20.0
+  - panel >=0.9.5
+  - param >=1.9.3,<2.0
+  - python >=2.7
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3606010
+  timestamp: 1627946408633
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jinja2-2.11.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 9c97f6b9a2cfba7b99e6732505a567787fb86da32cbf2aa6b825069361807845
+  md5: e3d2afca7f53449172cb027b2164df6b
+  depends:
+  - markupsafe >=0.23
+  - python
+  - setuptools
+  license: BSD-3-Clause
+  size: 96029
+  timestamp: 1612213176846
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+  sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
+  md5: 33624a42ee387bf9918ea98b4e7b31fc
+  depends:
+  - pygments >=2.4.1,<3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8173
+  timestamp: 1601490751973
+- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+  sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
+  md5: 67857cc5e9044770d2b15f9d94a4521d
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12810
+  timestamp: 1600445183315
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/panel-0.12.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 011406e85cbb2a3d1e687620dd18ec798ab34a7478f46e7e81b9d8a11fdd914f
+  md5: 7ed543858227e957d774766cd46acba9
+  depends:
+  - bleach
+  - bokeh >=2.3,<2.4
+  - markdown
+  - param >=1.10.0,<2.0.0a0
+  - pyct >=0.4.4
+  - python >=3
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10334744
+  timestamp: 1628798011706
+- conda: https://repo.anaconda.com/pkgs/main/noarch/param-1.11.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 110a3b50f89584ccb13980a617f6258b83b0bc56c8897c96d9e0da9fdc2c957c
+  md5: 6266365b47ed65cdb4737603a385c691
+  depends:
+  - python >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 69119
+  timestamp: 1625476602265
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+  sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
+  md5: e68a6f315f41a8d814d833652bf38b9b
+  depends:
+  - python >=3
+  license: MIT
+  size: 13374
+  timestamp: 1606932077143
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
+  md5: 2eb923cc014094f4acf7f849d67d73f8
+  depends:
+  - python
+  - six >=1.5
+  license: BSD-3-Clause and Apache
+  license_family: BSD
+  size: 246457
+  timestamp: 1626374695070
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pyviz_comms-2.0.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 5004d4651d4a544b06cc3bb5dfffd65db84a31491e292e8509e6748af7fd2fca
+  md5: 165985560b29068d8b832838e0a0c143
+  depends:
+  - param
+  - python >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25511
+  timestamp: 1623747251779
+- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
+  md5: 41db68b96e114e367c4f120a3b379e59
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19391
+  timestamp: 1632406728844
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 4e47f6c49ce84509f1466e8a4d728447bf4bcd9bce7b456431a789a262547067
+  md5: 4cad993b0f80bc23fb66a97592299cbb
+  depends:
+  - python >=2.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 26504
+  timestamp: 1623949147884
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+  sha256: ca2be6c7810a37cfc6db1f5383937b5d35c6d73c1fad8a9104de85f069b1df1c
+  md5: 9ccb2fb33edb152403d6ef32bf758a9d
+  depends:
+  - python
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 15614
+  timestamp: 1629402049497
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+  sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
+  md5: a815d3bdb160bcc71687f2dda70d3ca4
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 122218
+  timestamp: 1680170368293
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
+  md5: 447a49f7bad119faa80d7f14aa296c95
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162176
+  timestamp: 1644481750133
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aom-3.6.0-hcec6c5f_0.tar.bz2
+  sha256: e9e15fb1d52051c9dbb25b1f2e613eb60cf8dbe0793062c3a274e61e6a0871dc
+  md5: cb548680c2222c567784653166056c1a
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3463290
+  timestamp: 1688660834942
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+  sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
+  md5: 8810f48fe4a4792de0fd3520b502d08b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10019
+  timestamp: 1606859473259
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+  sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
+  md5: 00a446b6dfc61af223df4de29fe8ad94
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 34305
+  timestamp: 1644569782044
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
+  md5: bd92dd8bd5b9d24e632b62a075426e50
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133634
+  timestamp: 1695718025321
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+  sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
+  md5: f8ae051b591a9027adc16de1be9748f4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206198
+  timestamp: 1681493096349
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blosc-1.21.3-hcec6c5f_0.tar.bz2
+  sha256: 3699a260f422443de85b74084fe36f734be1a466eeebdfdf4195d52c9fdb5508
+  md5: 132d056e66b3ae9148f53819f8368c94
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - zlib >=1.2.12,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 66125
+  timestamp: 1675247668924
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-2.3.3-py39hecd8cb5_0.tar.bz2
+  sha256: 7af15bbe9281f52a47d2319efa88e61716a8296d599123390dc404005275eab6
+  md5: 869e984d66fe50aee77851244636a389
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3,<2.0a0
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.1
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8652066
+  timestamp: 1625767570656
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+  sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
+  md5: 0d79760d544d0bd8acb4adc4ef813418
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 137075
+  timestamp: 1657175654487
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
+  md5: 31d6d04cd2388d8f19004501271b3545
+  depends:
+  - brotli-bin 1.0.9 hca72f7f_7
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18982
+  timestamp: 1659616229395
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
+  md5: caf1073dc2ca5aeb832a2877394eae12
+  depends:
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18233
+  timestamp: 1659616216769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+  sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
+  md5: aa1ed20c38af535c8d6a955314759d7b
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 394588
+  timestamp: 1659616312678
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brunsli-0.1-h23ab428_0.tar.bz2
+  sha256: af713241455149cffec30054b5ab2f055a72c1b6bb6f492d9568deaa362597f6
+  md5: 860cc2203395527c259cabd8e3e16a36
+  depends:
+  - brotli >=1.0.9,<2.0a0
+  - libcxx >=10.0.0
+  license: MIT
+  license_family: MIT
+  size: 184792
+  timestamp: 1611240502908
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
+  sha256: 4574ffa241157e108d19ece60107a3a689cefaaca43578e6c4a6b344c7330278
+  md5: ab3b4e83407001e7f1603ca1fa0f4873
+  license: bzip2
+  license_family: BSD
+  size: 106284
+  timestamp: 1563219666100
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+  sha256: f913b61ba3c1651b36688415cc163a5d575475f7573b543f48a80e7a5002e4bb
+  md5: f11d165eaa532ce04a35382841284298
+  license: MIT
+  license_family: MIT
+  size: 107047
+  timestamp: 1693902034820
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+  sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
+  md5: ce3588e31faa79f546e0fc6a36c5543c
+  license: MPL-2.0
+  license_family: Other
+  size: 133884
+  timestamp: 1694009771475
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+  sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
+  md5: 21eb7f53076d0a69513cfd258f6ef63c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159756
+  timestamp: 1690232346868
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+  sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
+  md5: a40a04d9cda1e665565bc6c832d598b6
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225258
+  timestamp: 1670423337502
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cfitsio-3.470-hbd21bf8_7.tar.bz2
+  sha256: 68a12eaeda90c9cdbce729f0d44d222c3f60ec4920bb781bf13fae3a89cb3dd1
+  md5: a0970a5c1c77125369aded2d4e25f870
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=7.82.0,<9.0a0
+  - libgfortran 5.*
+  - zlib >=1.2.12,<1.3.0a0
+  license: Other
+  license_family: Other
+  size: 1437665
+  timestamp: 1655814938182
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/charls-2.2.0-h23ab428_0.tar.bz2
+  sha256: af3ad515ab2369e09b7a8b373025d1f7851618c2e698c7336d1296cb4f105732
+  md5: bb00d7a0d60266c9bdd9493d3f91f955
+  depends:
+  - libcxx >=10.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 96819
+  timestamp: 1612240391361
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
+  sha256: b860f45bce9fbb40d024dcd3306e66a52010641091ca8d1fcdde6c4238717c73
+  md5: 3c38f3af9c23b26efc2b11d82c95922a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 153013
+  timestamp: 1698129937688
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
+  sha256: c368e11dc241d1b79b4bb0d9333b353dc1b966b49d145163a0590d88ad88fef2
+  md5: 1e62044b8a32d1452e51773ba7a4319c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41392
+  timestamp: 1683040146991
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+  sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
+  md5: b2cc5f37f7bb069d061306e7eac2a011
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1913396
+  timestamp: 1668084575248
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
+  md5: 103d8c039e342115720a84d59c119d46
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13774
+  timestamp: 1671231190250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+  sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
+  md5: f69f09e0346172f225390d2b3b0d7873
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 246628
+  timestamp: 1663827484947
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39ha2381d6_0.tar.bz2
+  sha256: 83a064ced6cfc1d96426ba1f1dbcf541cd83acd8db3f45825c34708a45151f23
+  md5: d30062856f9831f71cd6db71bc418fef
+  depends:
+  - cffi >=1.12
+  - openssl >=1.1.1v,<1.1.2a
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1306207
+  timestamp: 1694212501270
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.0-py39hca72f7f_0.tar.bz2
+  sha256: 68200788e4f482730df10be66e73ea32ae9031bb76551108e6ad8bfb197c653e
+  md5: d0548e07d136d23cfc9202312a325f34
+  depends:
+  - python >=3.9,<3.10.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 363755
+  timestamp: 1667466068228
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
+  sha256: 40bbbe2ed223829f4a3f91024fa409f1a665ad94294bec2c9e930989bb2b8911
+  md5: 4add00dc619c12370af0ed18c76b71f6
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 103370
+  timestamp: 1613390236788
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/dav1d-1.2.1-h6c40b1e_0.tar.bz2
+  sha256: 53b960dc320a73701d8faf90316a203b01b294e0a7235c7bf49bb853d71b2214
+  md5: 7a196bd419ee0f888fbbe0e6d449adda
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 812727
+  timestamp: 1688746099942
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+  sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
+  md5: 04cbe8f4bc62c34fac9d42d1124059bf
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2052734
+  timestamp: 1690905361158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2021.9.1-py39hecd8cb5_0.tar.bz2
+  sha256: 1ae5b9da047685a183d334525725d042412ff0580a2dfc3b2d5475d9cf971bc8
+  md5: 18f243433e329801d71defd328f98ec7
+  depends:
+  - click >=6.6
+  - cloudpickle >=1.5.0
+  - cytoolz >=0.8.2
+  - dask-core 2021.9.1.*
+  - jinja2
+  - msgpack-python >=0.6.0
+  - psutil >=5.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - setuptools
+  - sortedcontainers !=2.0.0,!=2.0.1
+  - tblib >=1.6.0
+  - toolz >=0.8.2
+  - tornado >=6.0.3
+  - zict >=0.1.3
+  constrains:
+  - openssl !=1.1.1e,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1116914
+  timestamp: 1634741478920
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
+  md5: ef0e825982f242085574f502dfff4f6b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16594
+  timestamp: 1649926538106
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
+  md5: 24747a300246c016b3a7f04dabd02d4a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27709
+  timestamp: 1668714497209
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-0.5.0-py39h67323c0_2.tar.bz2
+  sha256: e152325158e54e534e5eefa1a1144594f9736c73409f39102295f6c8bb91105f
+  md5: 273e3bfcd0ebf58b77a74c92f606c34c
+  depends:
+  - numba >=0.49
+  - numpy >=1.16.6,<2.0a0
+  - packaging
+  - pandas >=1.1.0
+  - python >=3.9,<3.10.0a0
+  - thrift >=0.11
+  constrains:
+  - numpy >=1.18,<1.22
+  license: Apache-2.0
+  license_family: Apache
+  size: 192209
+  timestamp: 1658500770425
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
+  sha256: 95e9a45812b1b4059b973e5e6e131c7c1a8b2ce2dafc5117e7806b1c8f30de27
+  md5: bc889aaa846ed177fc5f495c24041acc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 262430
+  timestamp: 1695734574609
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+  sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
+  md5: e4a732941f74b8062c8bcbfe5c5c2b56
+  license: MIT
+  license_family: MIT
+  size: 80252
+  timestamp: 1676983220161
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+  sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
+  md5: 6dd72c43fea25b748ec7a9f6c0407e15
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111810
+  timestamp: 1666125671024
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/imagecodecs-2023.1.23-py39hd1bf5dc_0.tar.bz2
+  sha256: 4414ee6c323a190649911b401204d4d67023ecbada7eb5dbb7fb212b6b8d0faa
+  md5: b1fd778d28acdf233cdc25a53ba30534
+  depends:
+  - blosc >=1.21.3,<2.0a0
+  - brotli >=1.0.9,<1.1.0a0
+  - brunsli >=0.1,<1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - cfitsio >=3.470,<3.471.0a0
+  - charls >=2.2.0,<2.3.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - jxrlib >=1.1,<1.2.0a0
+  - lcms2 >=2.12,<3.0a0
+  - lerc >=3.0,<4.0a0
+  - libaec >=1.0.4,<2.0a0
+  - libavif >=0.11.1,<0.11.2.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.7.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - libzopfli >=1.0.3,<1.1.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - numpy >=1.21.5,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - snappy >=1.1.9,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zfp >=1.0.0,<2.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10170657
+  timestamp: 1695066401424
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/imageio-2.31.4-py39hecd8cb5_0.tar.bz2
+  sha256: 29601445c3b8a3053619fb4cfb7e0a778b592d9a6de119c32afbf56e897a03e0
+  md5: 0dd424dd602f807cbb21728c6d37376e
+  depends:
+  - numpy <2.0a0
+  - pillow >=8.3.2
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 510710
+  timestamp: 1695996558417
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
+  md5: 03cdb7e679924b329ecab8f12cb8fc67
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38813
+  timestamp: 1678997212422
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
+  md5: e113c4e6e758dd68faf196586bf5564d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51873
+  timestamp: 1698254765815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+  sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
+  md5: 78baea934985ccd9514a366cc7e80ed4
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 727499
+  timestamp: 1681801225190
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+  sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
+  md5: da9b63e42f281f7e77b289f4b654b83b
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 218436
+  timestamp: 1691121840155
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+  sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
+  md5: 6a7cb9b49593b29933fa2b503d533a08
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1257205
+  timestamp: 1694181720454
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+  sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
+  md5: d861ef66f5c0a282d60b65778a9de2f3
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1048450
+  timestamp: 1644315332508
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
+  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
+  license: IJG
+  license_family: Other
+  size: 278924
+  timestamp: 1677849185191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+  sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
+  md5: a82a17e78f725dcbd71ff8dac6db05c7
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133134
+  timestamp: 1676558895333
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+  sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
+  md5: ee9270379a9ebdb6297e4b6849b3f7f0
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 195479
+  timestamp: 1676329410154
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 32b898a97dca7770858ab31294238fde11ab61a84831a52f320e5ee5405a147c
+  md5: 926e754b8fad288b583ef2933deae1a5
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92938
+  timestamp: 1679906616072
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+  sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
+  md5: 7e60995b3119417213e5faedda147499
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 403165
+  timestamp: 1671707664990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jxrlib-1.1-haf1e3a3_2.tar.bz2
+  sha256: 63b4b4e81998da78bf9a1625d122faa6aa7514f6e3c975043432da346b9a566d
+  md5: 1e527af8be0e202b459293a8a5c76c87
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 230086
+  timestamp: 1593197454386
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+  sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
+  md5: cd470bdb28bb0e8b3535c93a3a6dad07
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65431
+  timestamp: 1672387389172
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-hdba6334_1.tar.bz2
+  sha256: 8093a64350665d16ca2ad0acfcbba5c84b479c316a40db6b9d5f9b84b58f3b12
+  md5: cd98cc17f8297a31b1dd62f061ea4f83
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - openssl >=1.1.1u,<1.1.2a
+  license: MIT
+  license_family: MIT
+  size: 1289465
+  timestamp: 1686931250022
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libaec-1.0.4-hb1e8313_1.tar.bz2
+  sha256: 2a9313912b9b3ea0d306a46e20df93f7fc79bce35e895e0cb98b8cdc068e2652
+  md5: ebfa53511162e3172aa14fbd37e3ed5d
+  depends:
+  - libcxx >=10.0.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 28397
+  timestamp: 1593198224738
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libavif-0.11.1-h6c40b1e_0.tar.bz2
+  sha256: 69303ebcb28fdfcdee4190da926cc7118bff28f96be9e6e5dd92f45e8302d711
+  md5: dfe44f56908bc60af820824d24d634c4
+  depends:
+  - aom >=3.6.0,<3.7.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 98857
+  timestamp: 1689158151760
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
+  md5: 7dba7aa5b971febb55281659843586ba
+  license: MIT
+  size: 65470
+  timestamp: 1659616172703
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
+  md5: f78a158983f0bbaba56f34b976bc6dae
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 34189
+  timestamp: 1659616189313
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
+  md5: 36a1d885725d3ab4d1fadc5a29f978d2
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 327737
+  timestamp: 1659616202869
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.2.1-ha585b31_0.tar.bz2
+  sha256: 83cf762f0d09c97dfb4a1c1cd9e635de2e54c384b057afbf3c0e2e8db07d862f
+  md5: ae3a458da93940fea1fa83af80d91fd4
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.52.0
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - zlib >=1.2.13,<1.3.0a0
+  license: curl
+  license_family: MIT
+  size: 358556
+  timestamp: 1693515516157
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20221030-h6c40b1e_0.tar.bz2
+  sha256: 67e38ccc55c2d996a8a0949080949c9803ddff84a96c4e34bc4c48fa95e5f35b
+  md5: b549aa024097c9f2790ba6eb89bc53fd
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 168786
+  timestamp: 1670840154554
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+  sha256: 4786264321edbff780633a5b752995eb3193ca4bce11b0fda179577f6cf1102c
+  md5: 849fdd014c201a9d2c2aa7c7db38a778
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 103993
+  timestamp: 1632891571494
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+  sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
+  md5: 817848d0e2b2808acdc9b3fbbf581726
+  license: MIT
+  license_family: MIT
+  size: 133887
+  timestamp: 1683716590737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+  sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
+  md5: e458587c87e3f2d20192f4e0738f2c63
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 149419
+  timestamp: 1665498987619
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+  sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
+  md5: 1058b661ec829b2ee3716ee2a5520641
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1917987
+  timestamp: 1665498925405
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm11-11.1.0-h46f1229_6.tar.bz2
+  sha256: 5f31ea9ceb555ff984674f2b7eae2262f7c124c861982d863b93f3a532273349
+  md5: 4e8a6604f36e94ae35c22ade431277b7
+  depends:
+  - libcxx >=4.0.0
+  - zlib
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 23102665
+  timestamp: 1665077532507
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.52.0-h1c88b7d_1.tar.bz2
+  sha256: 331bc731419328a873e1a48d4257c58baa33d73b4b91ff7a3553b1c122120fb1
+  md5: 43fba990695db8556ddd0ade21d59ecc
+  depends:
+  - c-ares >=1.19.0,<2.0a0
+  - c-ares >=1.7.5
+  - libcxx >=14.0.6
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - openssl >=1.1.1u,<1.1.2a
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 782018
+  timestamp: 1686931556261
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-hdb2fb19_2.tar.bz2
+  sha256: 8b1adbb78b6283c3d8df932d5aa7e8e249351aa1e206ba2949ee86052912e83f
+  md5: 2e035c81c044bff1224224ac24161dfd
+  depends:
+  - openssl >=1.1.1u,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338461
+  timestamp: 1686931232629
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+  sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
+  md5: c0b99f8e1c7475f23b1c7b4250b06e1c
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88021
+  timestamp: 1694778290062
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libzopfli-1.0.3-hb1e8313_0.tar.bz2
+  sha256: 1d727042cefd5fdc1eb1b5735ccb19b15ab0837e0b3c4a96841ebcd4143d31e9
+  md5: 2dffb55c068fb1561d870b5543b7966e
+  depends:
+  - libcxx >=10.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 162388
+  timestamp: 1593197747824
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+  sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
+  md5: 5c740b4a18a558de0ccfe601703c423c
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 338738
+  timestamp: 1662635677689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.38.0-py39h8346a28_0.tar.bz2
+  sha256: 47f5828dec578c863e41792ba45f4f16d3583fafb255ba2e2e8e02da50ac2952
+  md5: b099b7a14714c858ec0cbe2fd254e77e
+  depends:
+  - libcxx >=12.0.0
+  - libllvm11 >=11.1.0,<11.2.0a0
+  - python >=3.9,<3.10.0a0
+  - zlib
+  license: BSD-2-Clause
+  size: 247762
+  timestamp: 1647870749748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1dab4daa56408915de3ec270c8b887e7221d48633ea83b0afff61041fc197972
+  md5: 1519f9b766f9f894282db8353066e3b2
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11883
+  timestamp: 1652903144294
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+  sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
+  md5: d5f58d056b4bfc67aec30c77035ba889
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 182491
+  timestamp: 1670944720979
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+  sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
+  md5: 1affd16b166571a91feae04baf5fd3da
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123431
+  timestamp: 1671542016019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.0.1-py39h9ed2024_0.tar.bz2
+  sha256: 154b20bbde20714bbe52dfee2eeb8604df5dbb27d89cbeff4146b58e4c178322
+  md5: b5f877678a4cd266b8b0b0e2058a06b6
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21379
+  timestamp: 1621528240158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+  sha256: 2fd179efa024c92d0d71179a981a781d16c70f5d8c6305e0d678b0c7ae1275ab
+  md5: addda7f015d1673f794a23fdb18a3e09
+  depends:
+  - __osx >=10.12
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8182219
+  timestamp: 1698692361219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+  sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
+  md5: 6eb64ecfcd754502e271db0bb51d2cfd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17374
+  timestamp: 1662014643620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+  sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
+  md5: 2a4d604717a647ad21af766289cbbfc3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58057
+  timestamp: 1607364912348
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+  sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
+  md5: 25051fe272624544652dc6d814c2943a
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224420228
+  timestamp: 1691503125614
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+  sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
+  md5: 37d8cf85a63f7aa9af1624894a7d606d
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48590
+  timestamp: 1682969183093
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+  sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
+  md5: 0b2aee6666135bbd36b46d6ac66160f7
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 210705
+  timestamp: 1695058433223
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+  sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
+  md5: e22fb55ce380d0ebd44cce3f20d5349e
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296614
+  timestamp: 1695060155673
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py39haf03e11_0.tar.bz2
+  sha256: e3ac58a4520466ecb759590759c86e81dcddf1c36fd25d081dd9064d9e850c48
+  md5: d184127ffc4131fdef14724d5f480c99
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 84981
+  timestamp: 1652362789251
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
+  sha256: 5f60ca253f1fea0a1d765f535ff9ca2cf7efba90aea4c9a290d8f50ad11d4f6f
+  md5: 97d6ec94e2300030bddf0e5289cd2a84
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 24240
+  timestamp: 1607574265505
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+  sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
+  md5: 1a5d4004e64e3cfb7a2a297b9117c285
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8213832
+  timestamp: 1681756573646
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+  sha256: 2975bd1f98ca9ec7354ee378f86f8322ec90f568374776fd90e80c534fbee882
+  md5: 798627089e0ccba26695a26d9cb127ec
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99066
+  timestamp: 1650308465824
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.4.4-py39hecd8cb5_0.tar.bz2
+  sha256: 0fe3fa86499687b8d9cf27c1926ed9b68a093bd6dfd0804c4e1f7fa3ad838910
+  md5: 78a83d61819b9998e64e0e145f928d26
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=2.4
+  - jupyter_core
+  - jupyterlab_pygments
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0,<0.6.0
+  - nbformat >=4.4
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - testpath
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 569640
+  timestamp: 1649751946874
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+  sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
+  md5: b67569a7c30af9ffa5cde6e4b52ac68b
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148342
+  timestamp: 1694616917184
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+  sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
+  md5: 97b81f34efbe86c5220fe82eb584fd62
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387288528
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.1-py39hecd8cb5_0.tar.bz2
+  sha256: e108c2df53ee3b3218067fd50fedcd417d5ec12d1d1247a46f0018942efd2c08
+  md5: f2b02e342efea3f93ab8eee6033a332a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2958243
+  timestamp: 1690562148988
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+  sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
+  md5: d77862975a9a1cf50acb803be26e83a1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 575365
+  timestamp: 1690985052739
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+  sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
+  md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22858
+  timestamp: 1668160618784
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.55.1-py39hae1ba45_0.tar.bz2
+  sha256: 7a11498a91351f545e739fdb563edf3a0ac58dcd4104d200ee80507d9a034303
+  md5: f0be888e57909d643bde1edcbbd2573b
+  depends:
+  - libcxx >=12.0.0
+  - llvm-openmp >=12.0.0
+  - llvmlite >=0.38.0,<0.39.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - tbb >=2021.5.0
+  constrains:
+  - libopenblas !=0.3.6
+  - tbb  >=2021.0
+  - cudatoolkit >=9.0
+  - scipy >=1.0
+  - numpy >=1.18,<1.22
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3941575
+  timestamp: 1648040596955
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+  sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
+  md5: 185e9c41abb88ee59b52ec0f5f65d506
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 138305
+  timestamp: 1696515469702
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.21.5-py39h47b59a4_4.tar.bz2
+  sha256: 03a8d4e8ce9d3a927e40ae3196ecc4ca697ac0357d7a5813a20d165284fa73fc
+  md5: 7392c66e8d0891442d45631986beef92
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.21.5 py39hcfaf2c3_4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  size: 10377
+  timestamp: 1682972081348
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.21.5-py39hcfaf2c3_4.tar.bz2
+  sha256: 88c174064ef88955702e4b31ff40266053e4faa8391f4227bdc94d36b6ee05da
+  md5: 3f999d14101885385ee5c91aa8a82b58
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.21.5 py39h47b59a4_4
+  license: BSD-3-Clause
+  size: 6232599
+  timestamp: 1682972067843
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
+  md5: 93f5d7b66976154adeda219bea02ba45
+  depends:
+  - libcxx >=10.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 484257
+  timestamp: 1630093862501
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-1.1.1w-hca72f7f_0.tar.bz2
+  sha256: f95f5173ab2a4529b56ff90deec905dd53877250acedd3887fb289b721396009
+  md5: 2ab1a555331747f19e4aa7a335e33a85
+  depends:
+  - ca-certificates
+  license: OpenSSL
+  license_family: Apache
+  size: 3665304
+  timestamp: 1694465313538
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+  sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
+  md5: 4154929ace2ad6ee16aea815635a6d1f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73598
+  timestamp: 1693575307570
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-1.4.4-py39he9d5cce_0.tar.bz2
+  sha256: 9c8c14f79f0a2b8ffb3f19cc9bf80eabac6d27c39266eeb6dffa76354cbb96c0
+  md5: 4e87084b61971e7a8198fbae451403fe
+  depends:
+  - bottleneck >=1.3.1
+  - libcxx >=12.0.0
+  - numexpr >=2.7.1
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12634563
+  timestamp: 1663773428164
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
+  sha256: ddcb56e35d537f7a748b242c7c44368f112471973a52ae022945f597b7a83c7c
+  md5: 94bac4f8fbfaf821ace161b9f1f58716
+  depends:
+  - locket
+  - python >=3.9,<3.10.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36756
+  timestamp: 1698702713944
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+  sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
+  md5: be0a90921f3bf4f0d6950fb786093de7
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND
+  license_family: Other
+  size: 719901
+  timestamp: 1696580194417
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+  sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
+  md5: 81ae9ec2d7fcf6934847bff558b619f5
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2672987
+  timestamp: 1697548890181
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+  sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
+  md5: 1a822c206e2abddc5d6d821721af227f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33013
+  timestamp: 1692205801265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+  sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
+  md5: 1604d33dbdb2446c642970f8b354bedb
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91266
+  timestamp: 1659455269141
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+  sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
+  md5: d1b3bcc35655a3123acb1fa2ad1a8511
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580828
+  timestamp: 1672387372015
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+  sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
+  md5: 7540555d1fb192236db9a7c5c9d3601c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365765
+  timestamp: 1656431373327
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
+  md5: 0a73533fb6e0dc717ab906a537bc747d
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30803
+  timestamp: 1675441638631
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+  sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
+  md5: 0a959fbad46ab38ade48dbd358002674
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1864757
+  timestamp: 1684280094736
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+  sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
+  md5: ea24b5076ef79e4567c5a3f0cb22b470
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95330
+  timestamp: 1690223465114
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+  sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
+  md5: bcaea6d4a47e9c874becaa700c78dcf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157216
+  timestamp: 1661452617825
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+  sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
+  md5: 707110d1b49cb1864acb0bbaa103591e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 95016
+  timestamp: 1636111184034
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
+  md5: 113a443b9c706f9f9c6187c0eaa3de27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31178
+  timestamp: 1605305861851
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h218abb5_0.tar.bz2
+  sha256: 697361922d420f6e9897ee11a4440beaaf189bbdaa8b2944ca0c54910a9cda2d
+  md5: eb283815f176fd7109b34391d5b4ce7b
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13325074
+  timestamp: 1694438828125
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+  sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
+  md5: 47c5e22e31ec05a7bc0ce90065a53afd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 265348
+  timestamp: 1661368839620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py39hcec6c5f_0.tar.bz2
+  sha256: fa3f9b9aa7e0a71e0a7237adf0fdede90808fda954bebd4d10b4bea97ab7f62f
+  md5: dc1fb278f98f80996a6642a03a007f34
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 136975
+  timestamp: 1682522551539
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-snappy-0.6.0-py39h23ab428_3.tar.bz2
+  sha256: 54fc39c298451ed5d0e1059fdf6f2f5c0373c5f7bb56cf00018eeaa39cc0bda5
+  md5: 7419fca10878b2a2b3db392af8a905ea
+  depends:
+  - libcxx >=10.0.0
+  - python >=3.9,<3.10.0a0
+  - snappy >=1.1.8,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30136
+  timestamp: 1610133399999
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+  sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
+  md5: ce9a69e1668aa1e133f2aa6d4e8d346f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 254958
+  timestamp: 1695131709704
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pywavelets-1.4.1-py39h6c40b1e_0.tar.bz2
+  sha256: 5487ed899728b746fe5525ebdd3be0f8c4d0f1125c1e053a47305cb8ff10a892
+  md5: 1b3547135510c1707cd002fcd1cc3ce8
+  depends:
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 4498115
+  timestamp: 1670425476297
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+  sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
+  md5: 637f08b19dd8fd87347d8c44f9e3e202
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 170776
+  timestamp: 1698096100056
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+  sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
+  md5: 8ce3ac7d8a04e469b566f1b090d01140
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 470617
+  timestamp: 1657724324011
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
+  md5: 6f2d41dd76a03b7f85a1ed49af1763d6
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95100
+  timestamp: 1690400262627
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scikit-image-0.19.3-py39hcec6c5f_1.tar.bz2
+  sha256: 12b8cb2f2d885528e0b80f209c083163ba5b4dcba06abebf9abf75ff9d4cf2c0
+  md5: aa035de764b427c6eb8f474cee28d935
+  depends:
+  - cloudpickle >=0.2.1
+  - cytoolz >=0.7.3
+  - dask-core >=1.0.0,!=2.17.0
+  - imageio >=2.16.2
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvm-openmp >=4.0.1
+  - networkx >=2.2
+  - numpy >=1.19.2,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.1.0,!=7.1.0,!=7.1.1,!=8.3.0
+  - python >=3.9,<3.10.0a0
+  - pywavelets >=1.1.1
+  - scipy >=1.4.1
+  - tifffile >=2019.7.26
+  - toolz >=0.7.3
+  constrains:
+  - pooch >=1.3.0
+  - matplotlib-base >=3.0.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11617992
+  timestamp: 1669243292979
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.9.3-py39hf241641_2.tar.bz2
+  sha256: 1e24803f201bd254d11a1abbb98e34b1f5bd7a784ee55a412b6fccdccd831c2d
+  md5: 60d3f528d752ba0baa3daf7d1ef8bdff
+  depends:
+  - blas 1.0 mkl
+  - intel-openmp >=2023.1.0,<2024.0a0
+  - libcxx >=14.0.6
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.19,<1.26.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24139551
+  timestamp: 1683295252735
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
+  md5: b0321e6f14e139fc15b1f8b4acb35d2f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093966
+  timestamp: 1690290944588
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.1.9-he9d5cce_0.tar.bz2
+  sha256: c7af3280189c023d0c7380a7c1bdda2f2f09b036aa507c2650503b041037bf55
+  md5: 58260ae8dcdaf2ec4a07bb1bdb451b34
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 1357241
+  timestamp: 1649923925096
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+  sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
+  md5: 62b64576a0aa5f6c3fb05f56650d25e1
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15535
+  timestamp: 1614030509324
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+  sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
+  md5: 15b5595b31e39f08eaacbe2e502d8fb3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67292
+  timestamp: 1696347733587
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+  sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
+  md5: 82e4db6a498480a75d53c55bd35b6478
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1801397
+  timestamp: 1681394807900
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+  sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
+  md5: 63b957927b9949ccb19da28ec4612706
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30902
+  timestamp: 1671751919031
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/testpath-0.6.0-py39hecd8cb5_0.tar.bz2
+  sha256: afedb4f5a1147897a717c3f6506868f276c484cadfd90f0094a2285c0f6ffb02
+  md5: 4177a92eb0747cc976aa95bf098e936e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94297
+  timestamp: 1655908928089
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/thrift-0.17.0-py39he9d5cce_0.tar.bz2
+  sha256: bc71414b17e42369a8a5c84b06ce7d115e79a7f144eb4b928fc3f2a5d231ce2b
+  md5: 99c262b3ce5ca4ceabbf634437812dba
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - six >=1.7.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 126998
+  timestamp: 1666296594473
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tifffile-2023.4.12-py39hecd8cb5_0.tar.bz2
+  sha256: 13162f88448df807f9fa41232903cbed3f849df65438d0ac30bdd7dbf8c4b7db
+  md5: 147a36c1ebe687e64248248c8aeb4d88
+  depends:
+  - imagecodecs >=2023.1.23
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - matplotlib-base >=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 376827
+  timestamp: 1695107569165
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+  sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
+  md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
+  depends:
+  - zlib >=1.2.12,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3536231
+  timestamp: 1654088937695
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
+  sha256: 74fc3a9e308602b3710f8fa671f24f5492571d0c8f7c1b3071dac72671262d45
+  md5: e08ead92568f5bd72d5ac7f08f087fee
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102258
+  timestamp: 1667464155001
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+  sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
+  md5: a1bbf0abfb8c45541122c0eb2feee317
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680464
+  timestamp: 1696937112175
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+  sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
+  md5: d689f6203c0a9d04fb229c73d7e80a7a
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125145
+  timestamp: 1679561909274
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
+  md5: 8a292c1ee22489bef2e84bc3aaf4098e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193141
+  timestamp: 1671143985219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
+  md5: 8bf0bfffc11ad06a1c94e145941b0ad4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9651
+  timestamp: 1690297655669
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
+  md5: 343514a174b3485fde55a73f56398dd7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58456
+  timestamp: 1690297648002
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+  sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
+  md5: c2242e8fd24003a74ddf37416661e06d
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188757
+  timestamp: 1698257668273
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+  sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
+  md5: 41f445e36b6b6722a9444508eef069f8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20583
+  timestamp: 1607365395045
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+  sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
+  md5: 409ee46ed24267b6da6fb32d13e1f21e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70730
+  timestamp: 1614804271285
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+  sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
+  md5: eb74e74d8e4fd533c55eb98b7b5e83bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102637
+  timestamp: 1695742077778
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
+  sha256: 9f5a34bef727052f97b1cc387c3a99a60754de99d6e4ab0b2de770d76b64dc0f
+  md5: b5ce0421037c626cfcec5b43d83ec420
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1787999
+  timestamp: 1689041573350
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+  sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
+  md5: e243baa546432c8394a8059a44a5a3e4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 419227
+  timestamp: 1683113010463
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+  sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
+  md5: fe4ac85ee86d3a94ea3a4ebea3779763
+  depends:
+  - libcxx >=10.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 321797
+  timestamp: 1616055526986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zfp-1.0.0-hcec6c5f_0.tar.bz2
+  sha256: 47bde98853cb2914d8d63d58615edd7c9a788c5590a6a0a5c14d41051577559b
+  md5: c2e85e2f1be3fcee07bdf14d6a11519f
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 271809
+  timestamp: 1681741643951
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 16e64fb88aec5586d199cf317f4e10cfd4cb84bc2ffa51254b44c569f7834d3f
+  md5: 57b7c150445badc2b718691e67468091
+  depends:
+  - heapdict
+  - python >=3.9,<3.10.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 77666
+  timestamp: 1695833024405
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
+  md5: bc7073d9d4c0211cc4a1207c98fb765a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19091
+  timestamp: 1672387204865
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+  sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
+  md5: 8e495591e369ac161857a72011c0a296
+  license: Zlib
+  license_family: Other
+  size: 120272
+  timestamp: 1666595024203
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+  sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
+  md5: f1465fbd810b3746c6de6babfd4fe28a
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1023573
+  timestamp: 1681304595869
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+  sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
+  md5: cf55cb8d7031b30c70c56fc7c782b5c7
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 156104
+  timestamp: 1644482799136
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aom-3.6.0-h313beb8_0.tar.bz2
+  sha256: a26e4cb399cee40b3b513563d22a8f8f87b15cfdfd645cffeb48f57a85db3ee6
+  md5: 2e643e2e6830fea3f7d6ac729f8bbccb
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2647589
+  timestamp: 1688660588288
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+  sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
+  md5: 84fce327d9f0d594e86f565e5c21962e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10183
+  timestamp: 1629146082730
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+  sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
+  md5: 84b8b998a741b37abf5312c1c03696ef
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33979
+  timestamp: 1644845817952
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+  sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
+  md5: 77b746931c8f31c3ae393ccb5819d43d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133628
+  timestamp: 1695717890677
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+  sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
+  md5: 3df6e8ba34208dea068890e5d5318cc0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206759
+  timestamp: 1681493095987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blosc-1.21.3-h313beb8_0.tar.bz2
+  sha256: d51b7b5841be320209706d8e9caf669c0e0094f3a40e9eea51701a564ca7c2ed
+  md5: 61647f79e0ae70e914fee23c40c4caea
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43179
+  timestamp: 1675247655207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-2.3.3-py39hca03da5_0.tar.bz2
+  sha256: 3fd76b6a8b12726e0abe9c4d901791ad3825114f112eab2f4875e6023ac86852
+  md5: 4314576480342e421939bb5db05e9192
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3,<2.0a0
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.1
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8654537
+  timestamp: 1628862423516
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+  sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
+  md5: bb55f81435cb6e11d264242274fccd1a
+  depends:
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 115947
+  timestamp: 1657175645380
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
+  md5: f860193e14afc7ef3f5b990a2ac003d2
+  depends:
+  - brotli-bin 1.0.9 h1a28f6b_7
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18936
+  timestamp: 1659616204016
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
+  md5: ad53130f3fd1f8d3c2fcbb7496e5585d
+  depends:
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18715
+  timestamp: 1659616188888
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+  sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
+  md5: 0982c046fb976e9f9fb19e7510187a18
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 366983
+  timestamp: 1659616245272
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brunsli-0.1-hc377ac9_1.tar.bz2
+  sha256: 5fb3dec9b529843f2b77a486869ffe193debac7698159c0be6d50569b14402f9
+  md5: 0034c14344b0f61079b867bd32835beb
+  depends:
+  - brotli >=1.0.7,<1.1.0a0
+  - libcxx >=12.0.0
+  license: MIT
+  license_family: MIT
+  size: 178533
+  timestamp: 1628860668184
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
+  sha256: 019469288da4767fd021f488b907e2f4f3b34db686fa12055d52d9bb7bb4d872
+  md5: 9f63c782a4d20150ae9a664ee87cce16
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 150682
+  timestamp: 1624215191959
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+  sha256: b0be79290b1df1cf1d07a1a9c3f3a92ae262643a6df3dc10dfbac22a82874dd4
+  md5: 8fdcf1c08eee91fec7eefc22863c816a
+  license: MIT
+  license_family: MIT
+  size: 106550
+  timestamp: 1693902036526
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+  sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
+  md5: 31ac2f5596cb7a44adf073c930641c54
+  license: MPL-2.0
+  license_family: Other
+  size: 133817
+  timestamp: 1694009762858
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+  sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
+  md5: cf1f6c3c34a1e1b9ab22b04233d860f6
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159783
+  timestamp: 1690232303987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+  sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
+  md5: 0eb268e38b5174d471a6e87d9d6102b1
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225355
+  timestamp: 1670423312966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cfitsio-3.470-h7f6438f_7.tar.bz2
+  sha256: 3ba74ebffd6bc4bc451864f85048dec9b6ad085eb1904ce3e5450376e15f050e
+  md5: 289f238ac78b174f01c8a2b252b17735
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=7.82.0,<9.0a0
+  - libgfortran5
+  - zlib >=1.2.12,<2.0.0a0
+  license: Other
+  license_family: Other
+  size: 1243641
+  timestamp: 1655814869383
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/charls-2.2.0-hc377ac9_0.tar.bz2
+  sha256: c048ecfd192b1c4844c077b778814be1f62017dd578bf4bf6f199be5fc7ffc65
+  md5: 3998b53d542b1c04175df5d214926067
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 91429
+  timestamp: 1628861281402
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
+  sha256: 41e76ba21b1279278a039245275eb4ee1f81b38b33cba00ca3575f06be5dc570
+  md5: c5170bf12e308fb7f2d1b4b9065f3df7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 153036
+  timestamp: 1698129857856
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
+  sha256: 36240dde0a1546469f35f3b5509b55384dfd894beb56b3ca929da4b96a2a5f24
+  md5: 844539636e4c20ee99e8ceeff5e902bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41376
+  timestamp: 1683040042906
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+  sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
+  md5: e68c94666cd60221b575c3814c89bac0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1946451
+  timestamp: 1668084573824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+  sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
+  md5: 1773ae2b080cdd55827e27673351551e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13646
+  timestamp: 1671231171682
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+  sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
+  md5: 53bfd99ad1b09164d537209cffd98161
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 244040
+  timestamp: 1663827469853
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39h3c57c4d_0.tar.bz2
+  sha256: ed97835694caa43a6d6244a9391ace52d0643a13d9184d71ef293062fd0cd4c1
+  md5: 2d5122f002a138354102289a2c7a8560
+  depends:
+  - cffi >=1.12
+  - openssl >=1.1.1v,<1.1.2a
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1398898
+  timestamp: 1694212091070
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.0-py39h1a28f6b_0.tar.bz2
+  sha256: 25f89dccae875d5f73e6bb41ab8bf5b39972715a304e8ce64cee93585d129825
+  md5: a7c6f8274e12b068638fac6e43e9d10e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 361259
+  timestamp: 1667466038174
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
+  sha256: 83dbf9755ea887576e3f34adb1c26d418db9aaf3c77dc07f30b58c2221b81c72
+  md5: 36246697d07d6709de78abe36b6beae5
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 103201
+  timestamp: 1629793063728
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dav1d-1.2.1-h80987f9_0.tar.bz2
+  sha256: cdc3829b4dacd2c09ffcea509947b99dbe12eff4c9fd5f0d412795e2d3648b04
+  md5: cb80d50ff320b1865a31c59c9602ea4b
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 397700
+  timestamp: 1688746000695
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+  sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
+  md5: eb3cdc0fc210838b9271512a6a1b7c85
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2067708
+  timestamp: 1690905319109
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2021.9.1-py39hca03da5_0.tar.bz2
+  sha256: 60321d643db4e97cdab9771e91ef82a9a6f4dec094d489e32d155a225d08de04
+  md5: ce360ec4c30b95c10dba6a0587308eb6
+  depends:
+  - click >=6.6
+  - cloudpickle >=1.5.0
+  - cytoolz >=0.8.2
+  - dask-core 2021.9.1.*
+  - jinja2
+  - msgpack-python >=0.6.0
+  - psutil >=5.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - setuptools
+  - sortedcontainers !=2.0.0,!=2.0.1
+  - tblib >=1.6.0
+  - toolz >=0.8.2
+  - tornado >=6.0.3
+  - zict >=0.1.3
+  constrains:
+  - openssl !=1.1.1e,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1093111
+  timestamp: 1634756049598
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+  sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
+  md5: f44b80b9405410e5bde6bfe0b31d5b3f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 15135
+  timestamp: 1650293774207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+  sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
+  md5: f87027ccce1361d0f82c0edf1a10d53b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27677
+  timestamp: 1668714367519
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-0.5.0-py39heec5a64_2.tar.bz2
+  sha256: 9a4d39c84248a0a99858e130a0c9c20d70bc9f4eb31831a9a5d13420c8bef06e
+  md5: 17a7259e3c9ddc46474358d35f04b428
+  depends:
+  - numba >=0.49
+  - numpy >=1.19.5,<2.0a0
+  - packaging
+  - pandas >=1.1.0
+  - python >=3.9,<3.10.0a0
+  - thrift >=0.11
+  constrains:
+  - numpy >=1.18,<1.22
+  license: Apache-2.0
+  license_family: Apache
+  size: 179441
+  timestamp: 1658500663439
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fftw-3.3.9-h1a28f6b_1.tar.bz2
+  sha256: dc457fe0cde973b789306f64f8cc0b5b0a5512e3685749e34ab8713d3cad9840
+  md5: 9c5ac82ba31104f8cbff795ceb5c7901
+  license: GPL 2
+  size: 1638590
+  timestamp: 1630601990060
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
+  sha256: 296371685a5dcd98f5128f11f413e63aa59c1eba60543faf3baaebd445964c5d
+  md5: 9817e8ffd3669484c9a7de99a8aceffb
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 257844
+  timestamp: 1695734566410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+  sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
+  md5: 1d0bd7e576c64c059ef781dd319ad82a
+  license: MIT
+  license_family: MIT
+  size: 77591
+  timestamp: 1676983230102
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+  sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
+  md5: 83366cbd3beb073112f4644a613b6bca
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111933
+  timestamp: 1666125627512
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/imagecodecs-2023.1.23-py39h604db08_0.tar.bz2
+  sha256: 89ffcea806e825fc2ee2838b692bf52ced7edf36ce129f9d174d0c72714a1e22
+  md5: ea28577650b6a4e22a0d19748d6e88df
+  depends:
+  - blosc >=1.21.3,<2.0a0
+  - brotli >=1.0.9,<1.1.0a0
+  - brunsli >=0.1,<1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - cfitsio >=3.470,<3.471.0a0
+  - charls >=2.2.0,<2.3.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - jxrlib >=1.1,<1.2.0a0
+  - lcms2 >=2.12,<3.0a0
+  - lerc >=3.0,<4.0a0
+  - libaec >=1.0.4,<2.0a0
+  - libavif >=0.11.1,<0.11.2.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.7.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - libzopfli >=1.0.3,<1.1.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - numpy >=1.21.5,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - snappy >=1.1.9,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zfp >=1.0.0,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10138065
+  timestamp: 1695065789385
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/imageio-2.31.4-py39hca03da5_0.tar.bz2
+  sha256: a0dd6e0dd0ba634ea90e37500765b742d75d5543a91748b255caac0010b83509
+  md5: b3b777ef913aaea8a516e8d8d26ed7fe
+  depends:
+  - numpy <2.0a0
+  - pillow >=8.3.2
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 508873
+  timestamp: 1695996477512
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+  sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
+  md5: 647c1a2f8460ffa8c670a1915bbdb494
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38790
+  timestamp: 1678997152549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+  sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
+  md5: 35e541905426c686ef2ff010a0e502fd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51860
+  timestamp: 1698254731870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+  sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
+  md5: 187d7720aedf38759d122cccb4576f2c
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 219976
+  timestamp: 1691121991680
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+  sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
+  md5: e8e7f10741f9cfa737b310b334940441
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1255894
+  timestamp: 1694181494549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+  sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
+  md5: ff209e75aee17af2e358b0008fbe8c88
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1022945
+  timestamp: 1644315931223
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
+  md5: 055e12390b844ea6c6e956ee08a618e8
+  license: IJG
+  license_family: Other
+  size: 273479
+  timestamp: 1677849171867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+  sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
+  md5: 783e2ad3d36472648c5ccc9f3051db3c
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133077
+  timestamp: 1676558732505
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+  sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
+  md5: 0677598f673f9729b5990316170a999d
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 197129
+  timestamp: 1676329661580
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+  sha256: 05f9ca0fdcfdc2e217438be27fead588c843a3aadf7d034467c83216d1e5c214
+  md5: 2d648b77d817ba38293c0728711ba8f5
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92852
+  timestamp: 1679906632236
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+  sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
+  md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 401319
+  timestamp: 1671707682572
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jxrlib-1.1-h1a28f6b_2.tar.bz2
+  sha256: bd9a167e45cb8cb9710b5a19c498a67ac78d57f252be120973e347dbdd93aa36
+  md5: 5db215a69fb5d3f393e58bc6e5df5a3a
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 220109
+  timestamp: 1628860886330
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+  sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
+  md5: 247558a0aecf1ef7e77a4343761353d6
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64600
+  timestamp: 1672387273585
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-h8380606_1.tar.bz2
+  sha256: e547a4a540ccc9db683d6d2e3e36b0d0ad99e1ad10b22b5f403af3e893b412ba
+  md5: dc5ae0ece3c4990ba5fee7b266f2a019
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - openssl >=1.1.1u,<1.1.2a
+  license: MIT
+  license_family: MIT
+  size: 1306804
+  timestamp: 1686931342120
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lazy_loader-0.3-py39hca03da5_0.tar.bz2
+  sha256: 03937c9ae92debaf8eb966a8e293bccfbe34870f19c86e54ddc46a699e4d6e81
+  md5: 49b7c74927016b9d6a24b7799da3ce15
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18413
+  timestamp: 1695850162765
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libaec-1.0.4-hc377ac9_1.tar.bz2
+  sha256: 7fb9ae8531636f858e80fa142bc518ec5ffe2c50e655d0b5e66982a5abd42c5b
+  md5: e97f2f3ed8030db3ed46111dc6d0dbaa
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 25647
+  timestamp: 1628861308643
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libavif-0.11.1-h80987f9_0.tar.bz2
+  sha256: 7693526f3d7e012ce568832508982154cc65e6afaacb172623e64c8f5b863e75
+  md5: bfd3a5c3793bce213c83bd8b1b837fe8
+  depends:
+  - aom >=3.6.0,<3.7.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 92755
+  timestamp: 1689158136997
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
+  md5: a0f206782751dfffed0dd51302a1bf26
+  license: MIT
+  size: 68012
+  timestamp: 1659616138077
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
+  md5: 4c6667cdd061d28e9bc4e4300e4d115e
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 31173
+  timestamp: 1659616155596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
+  md5: 637e9430e258ddf050623ef2360184d8
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 298430
+  timestamp: 1659616172209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.2.1-h0f1d93c_0.tar.bz2
+  sha256: a94cc52c1ca2e421342d2fefc6d7774ff5118b9d01f4e22d33314f8520d33723
+  md5: 440575339cec83722e83087db31127bf
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.52.0
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 342121
+  timestamp: 1693515586487
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20221030-h80987f9_0.tar.bz2
+  sha256: 6304be2cb816e57ac178068d49befffba4354847f9ee1cfd0ec6acf9ba4ad94a
+  md5: af25d1cc1334d44d2b96eb8133c1dac9
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 167428
+  timestamp: 1670840153090
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+  sha256: 6fc572025852b210ecddcca3ab9ff3f1d5f6bd91f1933c6e296de6bb331f6b5d
+  md5: 6dd7d9c5737bbd2a27d18f15318dc3e6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 102059
+  timestamp: 1628961869728
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+  sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
+  md5: 55c615026c0869f8d3ba657f3bd38c43
+  license: MIT
+  license_family: MIT
+  size: 120389
+  timestamp: 1683716579036
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm11-11.1.0-h12f7ac0_6.tar.bz2
+  sha256: 6450802cad40b813a99572891811830758393500f4c79a223e1046918872c3f7
+  md5: 616a6976906afa0035a2dc2ea1c34195
+  depends:
+  - libcxx >=4.0.0
+  - zlib
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 21766415
+  timestamp: 1665076236980
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.52.0-h10c0552_1.tar.bz2
+  sha256: 039483aadb821adffcc2aff761ec35474d633b6bc2f1eb7cce877a881d7ed290
+  md5: d75b21db95481154cfa9d7a871f0f3bf
+  depends:
+  - c-ares >=1.19.0,<2.0a0
+  - c-ares >=1.7.5
+  - libcxx >=14.0.6
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - openssl >=1.1.1u,<1.1.2a
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 743061
+  timestamp: 1686931613436
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h449679c_2.tar.bz2
+  sha256: 48a8617773b57a4b9a8539782bf88a317f49a644d3f858aa0ad3ab13afc03ae7
+  md5: c3bc0fb3cc9a98ef1f2f83ef497fc5da
+  depends:
+  - openssl >=1.1.1u,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 334616
+  timestamp: 1686931322663
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+  sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
+  md5: 98d22e0124d55fae3c37c608dab1dcc9
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 89825
+  timestamp: 1694778225280
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libzopfli-1.0.3-hc377ac9_0.tar.bz2
+  sha256: 18eda005925fe6aaddb1a7a207b4ecab85981794cf1fba0fa72b765d59e4fe18
+  md5: 042769990cec17f009a3088932e8e1c3
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 149220
+  timestamp: 1628860942228
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.38.0-py39h98b2900_0.tar.bz2
+  sha256: d6aacfb6a6c3ec24e102b92b8e7b892cba9ba04aacae0b58592c9ccf34b37e94
+  md5: 690806f2b38f73149631ed90184d041c
+  depends:
+  - libcxx >=12.0.0
+  - libllvm11 >=11.1.0,<11.2.0a0
+  - python >=3.9,<3.10.0a0
+  - zlib
+  license: BSD-2-Clause
+  size: 248899
+  timestamp: 1647870588042
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
+  sha256: 83e1c11fb14ec2767e833b540a6a0fdbd8641523b5673273914007008e6666da
+  md5: 64adbf70a0d4ab82aca039e972821537
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11877
+  timestamp: 1652903192510
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+  sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
+  md5: c99006da802a97c9aae30da8c16b4820
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176131
+  timestamp: 1670944706815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+  sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
+  md5: 60bd1e037cda86205526f77405d78129
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123361
+  timestamp: 1671541992772
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.0.1-py39h1a28f6b_0.tar.bz2
+  sha256: f45d137efb14a7e0b98a1de97b0163e8855a973d66087d111b858542fbd90e8e
+  md5: 7f0950f7949c480df40841c942220785
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22441
+  timestamp: 1629137471723
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+  sha256: bf0eeef3c3c713515766ab8b0dc7863413de5b4b227deede97e24d90ca342345
+  md5: a7bba1857eb84fb50caea377e60d2050
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8066509
+  timestamp: 1698692266161
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+  sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
+  md5: eb79dabbeedee7da85dfbfb145bb8a26
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17342
+  timestamp: 1662014601345
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+  sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
+  md5: 56db7bd3ff511cd839bda081523b3edd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 55683
+  timestamp: 1629356128780
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py39h525c30c_0.tar.bz2
+  sha256: 20021076eaf466a3bd28a11a5fa28d1cec5fefcaa37d01de8e34c29bc560f8e3
+  md5: 48de2033df7f3739fa92f9e9e150e2d5
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 85401
+  timestamp: 1652362790532
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
+  sha256: ee936ba5fd196c15c3cb538aef721e54bb4486110ae3ebbfcf78e95e8380efa4
+  md5: dde1d9e040e04cbfbc0138898240a660
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 23003
+  timestamp: 1629282780853
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+  sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
+  md5: 176e0dcaeb28393881bacf69941e3889
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8289638
+  timestamp: 1681756329011
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+  sha256: afc6f332c51a3defc69e4c4e641988c0556039b9cd42be22f3db5292c88ccf37
+  md5: 2bc409c7258160a9b739d08d5ffb5998
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 96942
+  timestamp: 1650373637069
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.4.4-py39hca03da5_0.tar.bz2
+  sha256: a1fd61058ae6f17199f400d6f5c825d09b1f256ec438f35d70dcd5af1dccfec4
+  md5: e8128902044ffc309f5dda3aaf669cfe
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=2.4
+  - jupyter_core
+  - jupyterlab_pygments
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0,<0.6.0
+  - nbformat >=4.4
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - testpath
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 581692
+  timestamp: 1649751973819
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+  sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
+  md5: 37163b32508f9f589b3e6462a3a47546
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148426
+  timestamp: 1694616771736
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+  sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
+  md5: 6cdf7cbc43bf40e92b056a5576bd0086
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387216468
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.1-py39hca03da5_0.tar.bz2
+  sha256: 05a45d181b83b1eb136e35faf77bcd916adbdb49e178dd563da44f8227594956
+  md5: cdded8a3b2576bf9a2f103d396c47889
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2964776
+  timestamp: 1690562172192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+  sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
+  md5: 0f05853a139b6cda9c73e9d2707a4976
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 590288
+  timestamp: 1690984971741
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+  sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
+  md5: 7de782e4fb34bfa95ef2fc79d27d727d
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22840
+  timestamp: 1668160634885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.55.1-py39h9197a36_0.tar.bz2
+  sha256: dd6e3f256f7919476495c3071c05a475fe40a69b6692ce35487826c51e9669a2
+  md5: 63b4dd282c252fe5098296e36fd22ab3
+  depends:
+  - libcxx >=12.0.0
+  - llvm-openmp >=12.0.0
+  - llvmlite >=0.38.0,<0.39.0a0
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - tbb >=2021.5.0
+  constrains:
+  - numpy >=1.18,<1.22
+  - scipy >=1.0
+  - tbb  >=2021.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3953464
+  timestamp: 1648042338626
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+  sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
+  md5: 1a7b23113372c5667dbfe45976b9cc5c
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 126357
+  timestamp: 1696515322390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.21.5-py39h42add53_3.tar.bz2
+  sha256: 736fd00c741cc1d3a08723dae92c2af92836de160e6bf4e3bee8d7baab21d0c1
+  md5: 5f4ff7fcd329a21ae9818edd5fd3266a
+  depends:
+  - blas * openblas
+  - libcxx >=12.0.0
+  - libopenblas >=0.3.20,<1.0a0
+  - numpy-base 1.21.5 py39hadd41eb_3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  size: 10612
+  timestamp: 1653915976083
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.21.5-py39hadd41eb_3.tar.bz2
+  sha256: 5fedd658ac2bddea4fa2f2f47b4384305e0462cb6223438e3340528153523a6b
+  md5: af4f98a5bbbe280a3ddb4639061d43fa
+  depends:
+  - blas * openblas
+  - libcxx >=12.0.0
+  - libopenblas >=0.3.20,<1.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.21.5 py39h42add53_3
+  license: BSD-3-Clause
+  size: 5577512
+  timestamp: 1653915960518
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
+  md5: 371358a54bbdd307603888348d1a2c6f
+  depends:
+  - libcxx >=12.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD 2-Clause
+  size: 412248
+  timestamp: 1628861367714
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-1.1.1w-h1a28f6b_0.tar.bz2
+  sha256: 409ba99dd953129c0ccebb5dcbf2049920e5a755b88e7e392e4f91be924e26ef
+  md5: f05f00606c10617a61c41f23652b9a00
+  depends:
+  - ca-certificates
+  license: OpenSSL
+  license_family: Apache
+  size: 3450897
+  timestamp: 1694465216241
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+  sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
+  md5: d73db95f07a282021efdf8bc09713261
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73620
+  timestamp: 1693575195999
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-1.4.4-py39hc377ac9_0.tar.bz2
+  sha256: 64a5c7f7365b8c837621daeeef7e9b5341829768cb89f72026e6827a75e677b6
+  md5: ef101f092953ed17f9f0b7efa2a3cb03
+  depends:
+  - bottleneck >=1.3.1
+  - libcxx >=12.0.0
+  - numexpr >=2.7.1
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12433056
+  timestamp: 1663773462190
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
+  sha256: 3a6450282f56265e800500b62cd1bbe39cd5a6a09c4747c6dc3e8aab10bfa8a0
+  md5: 9b01b16f9c5a033ee8b92683d66b184e
+  depends:
+  - locket
+  - python >=3.9,<3.10.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36731
+  timestamp: 1698702611592
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+  sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
+  md5: 6e01c592ae3b8ff2d12cae76f2f4276b
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 715239
+  timestamp: 1696580071596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+  sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
+  md5: 9fb8f460c130d56caf33c6bbe46fbe8a
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2678841
+  timestamp: 1697548790931
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+  sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
+  md5: 390b8c3cd74281abecdbfd51476922f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33033
+  timestamp: 1692205747301
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+  sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
+  md5: 7896828fb3565fefad43f980d50c8723
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91190
+  timestamp: 1659455206354
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+  sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
+  md5: d934c74eb66d01af0f45f0881f4bab77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580588
+  timestamp: 1672387390426
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+  sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
+  md5: 9858166e5ffb624c8b9d281f4000d725
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 367167
+  timestamp: 1656431368885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+  sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
+  md5: 4d2b45c6be8221e6a3e44c2d5838426f
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30843
+  timestamp: 1675441531640
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+  sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
+  md5: 02521df4e2e79f75faa9cbb3560ab1dd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1861763
+  timestamp: 1684280026169
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+  sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
+  md5: bdebe59bffc7adbad83fdcd9d429a5f5
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95234
+  timestamp: 1690223494699
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+  sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
+  md5: d716e5c9b5eec45ce1df8eb52cab817a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157408
+  timestamp: 1661452601692
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+  sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
+  md5: 1907629863ed8e7c35ead232dae7693f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 91636
+  timestamp: 1628941083263
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+  sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
+  md5: 847b9bddf2a86e1609c0d53bbc23ea79
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 27378
+  timestamp: 1626781391140
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hc0d8a6c_0.tar.bz2
+  sha256: c1196bf843431971d2be79163c1de8c58803adef00c2cf6b354e8ddae0b82807
+  md5: e425277de2855516905d3eeefb83cdae
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=1.1.1v,<1.1.2a
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13185496
+  timestamp: 1694438378335
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+  sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
+  md5: 45642a99c83e7aed74d1ffab1f20145b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 266647
+  timestamp: 1661368655993
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py39h313beb8_0.tar.bz2
+  sha256: 120745bd4e38c1ad20fbaa6a43b932e4233c349959f12c71e8dc85bc4dbd78e7
+  md5: 35ffa41c6c93dc92534cd1a1ed18be5b
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 133586
+  timestamp: 1682522585527
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-snappy-0.6.0-py39hc377ac9_0.tar.bz2
+  sha256: 57462d734e3f384eb34b719022cbc29f39eb06a25b15969c207576c75209a78b
+  md5: 540f0ccb13d648f804d7b80224e6fe5e
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - snappy >=1.1.8,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 31108
+  timestamp: 1629480003392
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+  sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
+  md5: fec748525144049a2fc7f52f9755232c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257235
+  timestamp: 1695131702047
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pywavelets-1.4.1-py39h80987f9_0.tar.bz2
+  sha256: 13aff6394aeaf8a4194a041e991f8426efd00c211d43b128989863e439ef54e2
+  md5: f712ce2bd1b4ad5504e28df3fee5c709
+  depends:
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 4476840
+  timestamp: 1670425537144
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+  sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
+  md5: 3445d25415998c807efbe64d3a7e03c8
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 167068
+  timestamp: 1698096118071
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+  sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
+  md5: e6e92da28e9b0e428ed4b7df417bec25
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 472418
+  timestamp: 1657724315435
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+  sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
+  md5: dba22515f36d3c266de5896350813ea2
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95103
+  timestamp: 1690400315537
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scikit-image-0.20.0-py39h313beb8_0.tar.bz2
+  sha256: 69db8008ff5259e7de097c15711fb5fdb991cc3a488c855c290111c1a7d1755e
+  md5: 8349b9c78b726d6575eff5911749aca5
+  depends:
+  - cloudpickle >=0.2.1
+  - cytoolz >=0.7.3
+  - dask-core >=1.0.0,!=2.17.0
+  - imageio >=2.4.1
+  - lazy_loader >=0.1
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvm-openmp >=4.0.1
+  - networkx >=2.8
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=9.0.1
+  - python >=3.9,<3.10.0a0
+  - pywavelets >=1.1.1
+  - scipy >=1.8,<1.9.2
+  - tifffile >=2019.7.26
+  - toolz >=0.7.3
+  constrains:
+  - astropy >=3.1.2
+  - pooch >=1.3.0
+  - matplotlib-base >=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11685800
+  timestamp: 1682528582387
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.9.1-py39h9d039d2_0.tar.bz2
+  sha256: 967f0725324b516022bed288ddd5719d8c1702a6843dbe1104f89532b5e5e9b1
+  md5: 7d0adf09c67f2e4a9d17c9ae51f6926d
+  depends:
+  - blas * openblas
+  - fftw >=3.3.9,<4.0a0
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.19,<1.25.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23061445
+  timestamp: 1664916351574
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+  sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
+  md5: 3cd7eb43e285faba76faf67667e26b00
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093916
+  timestamp: 1690290951258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.1.9-hc377ac9_0.tar.bz2
+  sha256: 1a0eb8133498944a69d432b79b3edae63d64b2ccd92aa508b89b3fa83dc7983a
+  md5: c9acd31658bb93735e401406ae43089d
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 1304256
+  timestamp: 1650293949317
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+  sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
+  md5: c5e9aef0d6895de1c927e9d796cd7cd3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15691
+  timestamp: 1629145910454
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+  sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
+  md5: 0f7c229e774146ffc4e29dedf75372bf
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67279
+  timestamp: 1696347632563
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+  sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
+  md5: 2302a79a045f152e183a52a81adfba62
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1674163
+  timestamp: 1681394762218
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+  sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
+  md5: ae58720a18a2ed15eae214ad7a10d1b5
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 140125
+  timestamp: 1680167256603
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+  sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
+  md5: 4ae67163d55cf9df83d4027ebc38c501
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30894
+  timestamp: 1671751931536
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/testpath-0.6.0-py39hca03da5_0.tar.bz2
+  sha256: 1302850ef44a02ddc93ad2b9d5f8d32060f4262f693558c3bbc78b00590dc969
+  md5: a9a8375f5cab115321e5906ca1023157
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94447
+  timestamp: 1655908626985
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/thrift-0.17.0-py39hc377ac9_0.tar.bz2
+  sha256: 6d79d4bba278e23f9b902a349db69248bb28f260f9a8d7964afb09e22b803939
+  md5: 15f93217634102096db375910a9c5ae9
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - six >=1.7.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 126083
+  timestamp: 1666296613073
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tifffile-2023.4.12-py39hca03da5_0.tar.bz2
+  sha256: 834aa371eb09c02029d772d420cbcacd35d8f4c507aed862d5afab704af997f4
+  md5: 6ea6546e2eadea5242e977989eb97299
+  depends:
+  - imagecodecs >=2023.1.23
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - matplotlib-base >=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 376954
+  timestamp: 1695107486932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+  sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
+  md5: 667e60c8b407d73cbba40f44901f4f00
+  depends:
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3412693
+  timestamp: 1654088929697
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
+  sha256: 065cf1b08faf1d28aa348d569f2266d8b33b22ba424312c7ec959be95f217646
+  md5: 20370dbc92a9262e6fc8c82208f74ff2
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102259
+  timestamp: 1667464137769
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+  sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
+  md5: 884f788a5f6a664c9b79f7a4a60362d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680561
+  timestamp: 1696937004165
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+  sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
+  md5: 639a4f489af172c866c18442948e5874
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - slack-sdk
+  - requests
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125170
+  timestamp: 1679561942932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+  sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
+  md5: e5b90eba83fddba6d7aa6072b5bf7c91
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193017
+  timestamp: 1671143921826
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
+  md5: 644ef8830437070f60efcfcd6a987198
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9670
+  timestamp: 1690297532002
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
+  md5: a902a833bb186a2f1a4b2b89b1195136
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58466
+  timestamp: 1690297524418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+  sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
+  md5: f3f1d2c1028dad2f11ff950a15c99dbf
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188640
+  timestamp: 1698257577209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+  sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
+  md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20091
+  timestamp: 1629144441130
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+  sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
+  md5: 3089c63bf8f4d0423e1a287da286d83e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70923
+  timestamp: 1629357115820
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+  sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
+  md5: 5886b30b312445471268444f41f39dc7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102583
+  timestamp: 1695741976083
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
+  sha256: 300b9e4cfc9d01fa4d537060b2867f3cb89f22f932992fc2427e00dda050d55b
+  md5: 768c174577b786b99f8b46c4789b36a2
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1800646
+  timestamp: 1689041569828
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+  sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
+  md5: 2e75ad6a09c308268192efe03cc9ebf4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 411778
+  timestamp: 1683113019715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+  sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
+  md5: 30f666bf97c26587c5d2f68cc5f330ab
+  depends:
+  - libcxx >=12.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 316901
+  timestamp: 1629287855861
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zfp-1.0.0-h313beb8_0.tar.bz2
+  sha256: 181d62294369598af7fd5dea778dcddca50009e699be1572750d419beba80e6b
+  md5: 48eeb271f7289214d616f859c55dece9
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 258119
+  timestamp: 1681741613773
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py39hca03da5_0.tar.bz2
+  sha256: 8d31a7e9356948fd3d715faa6111e78dec6ffb6981819dd182aed7f765ec97c1
+  md5: 869dc425508ac78b9031bde17f568cd8
+  depends:
+  - heapdict
+  - python >=3.9,<3.10.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 77665
+  timestamp: 1695832985587
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+  sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
+  md5: 584e591d36dcd5ba5c45404f0f7ebb2d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19076
+  timestamp: 1672387153578
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+  sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
+  md5: 467ae28215d1aa1c5688bc0c8a184269
+  license: Zlib
+  license_family: Other
+  size: 103525
+  timestamp: 1666595022664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+  sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
+  md5: 7cfbed15f1feee1422810f7830075f53
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 779464
+  timestamp: 1681304594848
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+  sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
+  md5: ed14f9bc6e55220483f1a5a388625a08
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162772
+  timestamp: 1644481986085
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aom-3.6.0-hd77b12b_0.tar.bz2
+  sha256: 7ad83463e67a5f6da32568a567914a0f1ed5052268548371eb9ca66b4a0eee00
+  md5: 99feb2bd2c24eb7726f4a05f9fa1b809
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 12387035
+  timestamp: 1688666342169
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+  sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
+  md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 39253
+  timestamp: 1644551767970
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+  sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
+  md5: b24d13c443a26f65a0778b475a5726bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132830
+  timestamp: 1695717959996
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+  sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
+  md5: 302c3c0696e17eaa62e140e3892644ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 199723
+  timestamp: 1681493196911
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blosc-1.21.3-h6c2663c_0.tar.bz2
+  sha256: cf9a8a0745c5fab48394d84a58fe2f06e5fa80c87d5cc8d6c8da2e1df52cc69f
+  md5: 462987773ecda8cbf1f80734e84f080f
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 93601
+  timestamp: 1675247818708
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-2.3.3-py39haa95532_0.tar.bz2
+  sha256: e16a5673ecfcc33520f50c5fff5f55e20c57be713c51167144db87f7983feee8
+  md5: eab20446694e29eb9c77bb72e53c43d0
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3,<2.0a0
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.1
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8615028
+  timestamp: 1625767858854
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+  sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
+  md5: bf930260f679bc74227bbb18bc36ae82
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 119700
+  timestamp: 1657176150595
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
+  md5: 507dfe693ef429f466d964b599f4af21
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_7
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 18650
+  timestamp: 1659616328001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
+  md5: d0bf43e8df60baae3b3105aa5c42a791
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 21153
+  timestamp: 1659616312367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+  sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
+  md5: 7bd24bf94c24e810aecaaf84a0978e6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 343204
+  timestamp: 1659616543542
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
+  sha256: 3a26c397d4e0d546b0c2f433074c20813c5f3ae98bcf07a165c648f369a850b9
+  md5: 8f8069ce8c9eff1b0f124de2c0a63b86
+  depends:
+  - vc >=14.1,<15.0a0
+  license: bzip2
+  license_family: BSD
+  size: 154105
+  timestamp: 1563219293348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+  sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
+  md5: 092b417c11edcbe6bb9b765ab4a55d23
+  license: MPL-2.0
+  license_family: Other
+  size: 164999
+  timestamp: 1694009822357
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+  sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
+  md5: 708a750d370b9d6875651021e21c4446
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159322
+  timestamp: 1690232335307
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+  sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
+  md5: c35736da3ea26782425e78061268cf5e
+  depends:
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 228713
+  timestamp: 1670423312743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cfitsio-3.470-h2bbff1b_7.tar.bz2
+  sha256: a65386e70bdad9aa1e07ad430309c3ddc249b74bea69388dfbda99fd00069665
+  md5: e4174218de194962642b353f51a19d1e
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  license_family: Other
+  size: 617890
+  timestamp: 1655709069465
+- conda: https://repo.anaconda.com/pkgs/main/win-64/charls-2.2.0-h6c2663c_0.tar.bz2
+  sha256: 98e6346139899b0c9ce6518e304c8b1fd1b8746a410fcc8d83cbc9f08125ecc7
+  md5: 5cdda32dbdd11de0555c255a598173c0
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 95720
+  timestamp: 1612240685008
+- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
+  sha256: 9577ff772035cd30e72323edff379dd3df877de00f7f690fd33c8720a5a4bbc9
+  md5: 1130fd979d4f97f511f10b36ff09513d
+  depends:
+  - colorama
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 152728
+  timestamp: 1698129962390
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
+  sha256: e5babe79f8132c4bd44bc05307976f2c5485014ae3129655dddbd3baa8e75e46
+  md5: 093223df00c6ef9db4e7e5aa7bfec00a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40844
+  timestamp: 1683040252786
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+  sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
+  md5: 457a4339a53c033d48ce0c72e5038d2e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30330
+  timestamp: 1672387265402
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+  sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
+  md5: 59ec65fd9e06b81a65cc12986c67d5da
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1939614
+  timestamp: 1668084794027
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+  sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
+  md5: 3489c1a2b73fc957b5a62cc59349e25b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13438
+  timestamp: 1671231196438
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+  sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
+  md5: 3492b96083c1e904cc32d26ea7f1e1d8
+  depends:
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184280
+  timestamp: 1663827558327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h3438e0d_0.tar.bz2
+  sha256: 153757acc6c1a35dfa608a9957401052bf424a8f1c42c6a58272a35816dc5091
+  md5: 3190ab0bff0ce45755e929208b54907f
+  depends:
+  - cffi >=1.12
+  - openssl >=1.1.1v,<1.1.2a
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1221616
+  timestamp: 1694446820243
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.0-py39h2bbff1b_0.tar.bz2
+  sha256: 28c350d12caf11ba087e033289e5152ea9b9dc4abbf0229299a3e5d20759f47e
+  md5: 4bac24daf8224ea465812ad92c30ad47
+  depends:
+  - python >=3.9,<3.10.0a0
+  - toolz >=0.10.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 311754
+  timestamp: 1667466298939
+- conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
+  sha256: a6c8b5d32c52ce71d41c7702265e0bb064c960ab67b88ecbea967595c5e02bc3
+  md5: 112f2f9c7055656ec156fe287c97c0e9
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 104432
+  timestamp: 1613390539244
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dav1d-1.2.1-h2bbff1b_0.tar.bz2
+  sha256: e59970edb08a1dc24d761f88657aed895d7715f66ac9a9acfda440c29fda05e0
+  md5: d3d303a3ffcedb8f4a92f29ac9e67bdc
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 723931
+  timestamp: 1688746263355
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+  sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
+  md5: 2ff4fb509788b0e47ac684ba151394d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3289966
+  timestamp: 1690907040646
+- conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2021.9.1-py39haa95532_0.tar.bz2
+  sha256: b21d7d7612917cb871c7d980918ff8bc9ed686be2cf529ddd6c449d7e3809223
+  md5: d1f10508f885dffd11b6383e3f816b65
+  depends:
+  - click >=6.6
+  - cloudpickle >=1.5.0
+  - colorama
+  - cytoolz >=0.8.2
+  - dask-core 2021.9.1.*
+  - jinja2
+  - msgpack-python >=0.6.0
+  - psutil >=5.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - setuptools
+  - sortedcontainers !=2.0.0,!=2.0.1
+  - tblib >=1.6.0
+  - toolz >=0.8.2
+  - tornado >=6.0.3
+  - zict >=0.1.3
+  constrains:
+  - openssl !=1.1.1e,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1140821
+  timestamp: 1634741658358
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+  sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
+  md5: 0f166c3e70541d8bee6e9d0cb60fb66e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16979
+  timestamp: 1649926678161
+- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+  sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
+  md5: ea93d413944ca6a8677eb1b284b136ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27388
+  timestamp: 1668714577678
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-0.5.0-py39h080aedc_2.tar.bz2
+  sha256: 9597efdd53604092fb2669a00591d5868f4bcb1c336e18763fd90423a843dc9a
+  md5: ba5053e8f1135885c08bc84f548860ba
+  depends:
+  - numba >=0.49
+  - numpy >=1.16.6,<2.0a0
+  - packaging
+  - pandas >=1.1.0
+  - python >=3.9,<3.10.0a0
+  - thrift >=0.11
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - numpy >=1.18,<1.22
+  license: Apache-2.0
+  license_family: Apache
+  size: 189597
+  timestamp: 1658490146641
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
+  sha256: 6b724886465fea70d2ca843fea1d01bcc24d496601587b87c0cb8f2626b259c2
+  md5: 6c11d9242869d6c3b01698f728bd409b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 260567
+  timestamp: 1695734829130
+- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+  sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
+  md5: 9f167d3e45441bc3633c1974b1b0ce8c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 88421
+  timestamp: 1676983264486
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+  sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
+  md5: 582d2c1135a89da757a038de831e7f39
+  license: Intel proprietary
+  size: 11086648
+  timestamp: 1664812389803
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+  sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
+  md5: 30fdefd1541c789c163751291a8faa88
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111448
+  timestamp: 1666125667599
+- conda: https://repo.anaconda.com/pkgs/main/win-64/imagecodecs-2023.1.23-py39h6c6a46e_0.tar.bz2
+  sha256: 2314346495ed1de94c5a8fcb03d7521c1b6bfbd9411f019d3d93f7a623be88d7
+  md5: 627c13275ad14530b560703289ae7577
+  depends:
+  - blosc >=1.21.3,<2.0a0
+  - brotli >=1.0.9,<1.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - cfitsio >=3.470,<3.471.0a0
+  - charls >=2.2.0,<2.3.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - lerc >=3.0,<4.0a0
+  - libaec >=1.0.4,<2.0a0
+  - libavif >=0.11.1,<0.11.2.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.7.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - libzopfli >=1.0.3,<1.1.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - numpy >=1.21.5,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - snappy >=1.1.9,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.2,<6.0a0
+  - zfp >=1.0.0,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9882701
+  timestamp: 1695065345272
+- conda: https://repo.anaconda.com/pkgs/main/win-64/imageio-2.31.4-py39haa95532_0.tar.bz2
+  sha256: b40af938aa1f5199a25ae86d943fb37b534e806aa96228f19897d09d7dc9d57c
+  md5: aa0843aadc4608117a24d2b53ed0fc82
+  depends:
+  - numpy <2.0a0
+  - pillow >=8.3.2
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 536594
+  timestamp: 1695996939235
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+  sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
+  md5: a10f07c7a3510272a296f9fed458a4ed
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38098
+  timestamp: 1678997241511
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+  sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
+  md5: fad9cf2023d807da8d44996e9d4399a0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51490
+  timestamp: 1698254721864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+  sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
+  md5: 9834848bd7c7759acf12e78d09388563
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3891030
+  timestamp: 1681801474383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+  sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
+  md5: 1285c8c628bc912c54d0968574c9f4c9
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217232
+  timestamp: 1691122695748
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+  sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
+  md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
+  depends:
+  - backcall
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1279433
+  timestamp: 1694181820978
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+  sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
+  md5: f5fcce35d3f21cdfc5893c5a7a86c651
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1035394
+  timestamp: 1644315567034
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
+  md5: 81f2c343dc4c65eea39c45383272068f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 407861
+  timestamp: 1677849239400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+  sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
+  md5: bd9526d38a145fe311a8aa36bc11e071
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 152006
+  timestamp: 1676558783570
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+  sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
+  md5: a00e6a62956fde3c4135464353ee8a53
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229158
+  timestamp: 1676330909084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+  sha256: db8335d6531b03c7bdfe789ebacc52631ac6ea4a37700bb3da1f6a53a1acd724
+  md5: ebeba61994cc225ea5f4f42caa511019
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116681
+  timestamp: 1679906658986
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+  sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
+  md5: 5efa1332f7c0a8d9638eda02170c4ce5
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pywinpty
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 413653
+  timestamp: 1671707957673
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+  sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
+  md5: 891fe66a24d8714737b2874985ee1303
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62298
+  timestamp: 1672388166096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+  sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
+  md5: f5f73266281ab12377d5d47bdf07500a
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 905072
+  timestamp: 1617648814933
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libaec-1.0.4-h33f27b4_1.tar.bz2
+  sha256: 918df9a8ca3877e44a2976f7c8f2d84f710d156809a7d8e0b79eca568c7cc3da
+  md5: 0e6b3ffa6ee7c941485dacdfcb6dd6b4
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 34175
+  timestamp: 1593197296069
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libavif-0.11.1-h2bbff1b_0.tar.bz2
+  sha256: 6adaf0429ea7418bff9eab1f723572f4330d003532292448d5334ea2d601e5ee
+  md5: b2756d031f0dcfb72f733b2c450fc32a
+  depends:
+  - aom >=3.6.0,<3.7.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2494359
+  timestamp: 1689158283018
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
+  md5: c345f51706eef530454f66b794e5e574
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 68189
+  timestamp: 1659616216976
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
+  md5: a7400cfb72042977bc047909ed504ce8
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 33743
+  timestamp: 1659616248209
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
+  md5: 6307f6854754ab5bd7c84e6998385bb1
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 733177
+  timestamp: 1659616279453
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+  sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
+  md5: ba9418df9288a2f031a02fa35b774ce0
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78524
+  timestamp: 1694778314659
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libzopfli-1.0.3-ha925a31_0.tar.bz2
+  sha256: d5b0e01c2b80b43a0e1128a612f289891c375bd9f15b3b0d176b0658a1c3711e
+  md5: 532177b4105c87e006d9f49ba8ad399f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 210474
+  timestamp: 1593187626221
+- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.38.0-py39h23ce68f_0.tar.bz2
+  sha256: 7421f1f10d729ec5a71457aa0ba751c18cc25fa6e7790f438b84d676dc013972
+  md5: 0981ca59642800528a2f259beffa72c1
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib
+  license: BSD-2-Clause
+  size: 17085863
+  timestamp: 1650394083750
+- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
+  sha256: 5d4cf89313147e44530dbb3cc6a93247aaded0701bbf8ba3a382ef710abf4cfa
+  md5: 137deeca51202f6b4ac786472a00be55
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 12894
+  timestamp: 1652904101694
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+  sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
+  md5: 6970c7f46b0164cad1d210e7a1419959
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143434
+  timestamp: 1670944902624
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+  sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
+  md5: 1015298551c040c6d5e26eebbae12ef5
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142316
+  timestamp: 1671542240512
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.0.1-py39h2bbff1b_0.tar.bz2
+  sha256: 5dff37975a0b3c1b05fec07a7f7c45f0d1db02c81daedeabb6004d80f2dcea4a
+  md5: 3edffbc00c56e7c33c267bcaa40f0e3f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25694
+  timestamp: 1621528688654
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+  sha256: 1687ae122ee7d8b583141fc5014b76d494841dc8083b854449e3d6e0f6bb7019
+  md5: 3697ac26ee3c2d49338dd5b9c6551152
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8080067
+  timestamp: 1698692812610
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+  sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
+  md5: a9fa43e694b25cd49b8b08a9eefd696e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18054
+  timestamp: 1661915903969
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+  sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
+  md5: 248c468abced874f0231d3cc23177c77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58488
+  timestamp: 1607359497934
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+  sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
+  md5: 5e763c995ff0c549f68a10bce70fede4
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187489950
+  timestamp: 1691503804820
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+  sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
+  md5: dd0c2ece6a743c373c9b5a5919b4818f
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49744
+  timestamp: 1682975040154
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+  sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
+  md5: 57cea8df7ab85f2a98f64d23afcb1f90
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184956
+  timestamp: 1695058491736
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+  sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
+  md5: 8769cdd201d905069800488fe31574e5
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 256221
+  timestamp: 1695060152521
+- conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py39h59b6b97_0.tar.bz2
+  sha256: ed64d0a3331cc40479962ed066a833243ca36035bd4cefee4fb5e42a9214f64b
+  md5: 6b7d9b4724303c0159086d28e9ef4901
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 82755
+  timestamp: 1652329408426
+- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
+  sha256: b75f28f29d60f2a8726fb0f036e5d01489942abbf77ff1e1cc8e12d7f372b8f3
+  md5: 7a1d29477873480809fd3860f2e69f01
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 24734
+  timestamp: 1607574381373
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+  sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
+  md5: d9781492332e6326f9fca87f3a8efacd
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8135792
+  timestamp: 1681756491399
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+  sha256: 2dd3178d3c570e30b9490ebabfd7bfac806afad8302d3dee0edc619805034397
+  md5: bef9da0f0694c45b6aaa4e6447479eaf
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 118324
+  timestamp: 1650290466135
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.4.4-py39haa95532_0.tar.bz2
+  sha256: cd65b6bdcf9c9643a789182d902cd54301f5da989a45f3fed7beb5c20abcfe20
+  md5: ee64ff0db569df90237785584ec97e58
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=2.4
+  - jupyter_core
+  - jupyterlab_pygments
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0,<0.6.0
+  - nbformat >=4.4
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - testpath
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 582244
+  timestamp: 1649741096955
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+  sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
+  md5: f96bbef0985d7e66ebf00c0d55e30e23
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 167045
+  timestamp: 1694617078743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+  sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
+  md5: 6e6ba64c8dc5025aeac606404a8df36a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13786
+  timestamp: 1672387480065
+- conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.1-py39haa95532_0.tar.bz2
+  sha256: 55847705e1cb4c384a61611e15a0beb52d745b30e0fced2d9a3daa877b3d712f
+  md5: 5082bfa6e6400284e8e3833a7874b789
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2928272
+  timestamp: 1690562181595
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+  sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
+  md5: 4a7a3286484766741f627696697c362c
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 609425
+  timestamp: 1690985686105
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+  sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
+  md5: 4269a1f93882205b90d4b2ae78fc82d5
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22417
+  timestamp: 1668160717305
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.55.1-py39hf11a4ad_0.tar.bz2
+  sha256: ae01d6d92a3887da4357ec5c42d419ca0ec09b5382283308362d169f5c64ce4e
+  md5: 5fa02eab1619c73418ac459ec723efc9
+  depends:
+  - llvmlite >=0.38.0,<0.39.0a0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - tbb >=2021.5.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - scipy >=1.0
+  - libopenblas !=0.3.6
+  - numpy >=1.18,<1.22
+  - cudatoolkit >=9.2
+  - tbb  >=2021.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3995948
+  timestamp: 1650394589312
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+  sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
+  md5: a18a576b7024cfd6f905c526a786a916
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 135285
+  timestamp: 1696515698492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.21.5-py39h6917f2d_4.tar.bz2
+  sha256: aee7fd60e0fa3bf6c4de8045e4bcf9f79108c79692c8d63f2b1b9d7e7e3e69d0
+  md5: a43634502e0708257d9cec6ca33df68a
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.21.5 py39h46c4fa8_4
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  size: 10555
+  timestamp: 1682980574564
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.21.5-py39h46c4fa8_4.tar.bz2
+  sha256: 61585d772e0a0fe5316abc4e5ebf82bb025193973fc76011d36a5f5a9585914f
+  md5: b735ac9ae87732f59b177c56d6d8bc76
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - numpy 1.21.5 py39h6917f2d_4
+  license: BSD-3-Clause
+  size: 5894357
+  timestamp: 1682980554084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
+  md5: ab07e2a27ac08afe3d0b4c0890b8486a
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 2-Clause
+  size: 249316
+  timestamp: 1630094024143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-1.1.1w-h2bbff1b_0.tar.bz2
+  sha256: 0474e14823c734edc088bef98b829149a47ed8b4654f9638926c2fe4bbc40f38
+  md5: a67d4a763641de641ea9dfa8c4a5f567
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: OpenSSL
+  license_family: Apache
+  size: 6048217
+  timestamp: 1694466133007
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+  sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
+  md5: df1d746ba8d5d6ba01ac1373b9b71e1a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73016
+  timestamp: 1693575484990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-1.4.4-py39hd77b12b_0.tar.bz2
+  sha256: d81d8ef52a07a9cd294e98d4e069ad86f990cfe3b3064bfde540a3f04e0ee9a4
+  md5: 25de49536214af419d337679d8040cba
+  depends:
+  - bottleneck >=1.3.1
+  - numexpr >=2.7.1
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11584490
+  timestamp: 1663773415594
+- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
+  sha256: 5738f61dae392c171b4f699a6973e736198e4d4a63fa22dcf957afaf1de150af
+  md5: cba721e73156d62fc4ff23159e96ad41
+  depends:
+  - locket
+  - python >=3.9,<3.10.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36452
+  timestamp: 1698702686971
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+  sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
+  md5: 427c1450bebb632f43bbc8c83006e4cd
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 806931
+  timestamp: 1696580240310
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+  sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
+  md5: 21790cd3e2b8a45c4104aff0a68330d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3001751
+  timestamp: 1697549357662
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+  sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
+  md5: 56f44a1054da2d10777e375838191070
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 32355
+  timestamp: 1692205784293
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+  sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
+  md5: 8a35ad65651086575ce55371f22feda8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91045
+  timestamp: 1659455316472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+  sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
+  md5: 186eb95f816a2eff80c3c7f7d964c7b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 578514
+  timestamp: 1672388155359
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+  sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
+  md5: 47b6cbe6ce9289e47d16900b03596a91
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372807
+  timestamp: 1656431445633
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+  sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
+  md5: 07165c444adc7c7ccc8a345875adc5ef
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48408
+  timestamp: 1675450623287
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+  sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
+  md5: d58e76a31e2f6e7410ba4afd7f385b0d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1877445
+  timestamp: 1684280183367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+  sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
+  md5: 0e5b0fe7debbf558ce97090f6b67cdae
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94633
+  timestamp: 1690225630423
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+  sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
+  md5: 0fde797653e4ab589506121fb1e37555
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157119
+  timestamp: 1661452591647
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+  sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
+  md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 92679
+  timestamp: 1636093365041
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+  sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
+  md5: f870859d4dc7a8d82cf3546bd9035f33
+  depends:
+  - python >=3.9,<3.10.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 54520
+  timestamp: 1605307564142
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h6244533_0.tar.bz2
+  sha256: 08cc28161687c6a4d88d17c33001c6a6aaaf044b673d93df414c60fe42eeabb1
+  md5: b95c7aa91366f9054fe0c9e30bd92b9e
+  depends:
+  - openssl >=1.1.1v,<1.1.2a
+  - sqlite >=3.41.2,<4.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 21175634
+  timestamp: 1694440134687
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+  sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
+  md5: 9d99075052265ae3d718582d3b875038
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269964
+  timestamp: 1661376543480
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py39hd77b12b_0.tar.bz2
+  sha256: 8b6a4065775dced4e05e655b2cc3a59e5dd70f3c081e0d37e6f65073cb2e2b43
+  md5: 7c7beb23a7b73c5797a1ab69ab124cd7
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 135726
+  timestamp: 1682522544682
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-snappy-0.6.0-py39hd77b12b_3.tar.bz2
+  sha256: 11de037a53b2815a5e30a4a7859b327ddc617632d919ed8bcef994a7a3626c78
+  md5: 4ff26871cd7ff7bb0345a8c92c75d435
+  depends:
+  - python >=3.9,<3.10.0a0
+  - snappy >=1.1.8,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33738
+  timestamp: 1610133461849
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+  sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
+  md5: fa9074d94236c9b768bfd2c858875b27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 264836
+  timestamp: 1695131770282
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywavelets-1.4.1-py39h2bbff1b_0.tar.bz2
+  sha256: 053adefe794182f43cb381d5bacae8e611840fb20e2f3f91dc570a4ae9777e57
+  md5: 70d44b3a97b8a82049e09cbaaf434b8e
+  depends:
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 4502506
+  timestamp: 1670425946688
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+  sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
+  md5: 3d2841085778006c2e79f9c7300f8b9d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13565975
+  timestamp: 1669937633869
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+  sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
+  md5: 54a4bc0724041dd173088419d6ede2af
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 239062
+  timestamp: 1677611495106
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+  sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
+  md5: f39f84115e228bad4bceaefdd637f022
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 158558
+  timestamp: 1698096358091
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+  sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
+  md5: df398a3a1668fd2a22061764e20ea91d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.4,<4.3.5.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 460913
+  timestamp: 1657616061604
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+  sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
+  md5: 38db77ece9dc76feffb9ef7638e38258
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94397
+  timestamp: 1690400496655
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scikit-image-0.19.3-py39hd77b12b_1.tar.bz2
+  sha256: 7bc9d9d24149d4c2f9986dec5458b936efafd681a313b040fb7a0dc2a2af5981
+  md5: 77e61fcb6e3bc60979fa906515ec9b26
+  depends:
+  - cloudpickle >=0.2.1
+  - cytoolz >=0.7.3
+  - dask-core >=1.0.0,!=2.17.0
+  - imageio >=2.16.2
+  - networkx >=2.2
+  - numpy >=1.19.2,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.1.0,!=7.1.0,!=7.1.1,!=8.3.0
+  - python >=3.9,<3.10.0a0
+  - pywavelets >=1.1.1
+  - scipy >=1.4.1
+  - tifffile >=2019.7.26
+  - toolz >=0.7.3
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - matplotlib-base >=3.0.3
+  - pooch >=1.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11681360
+  timestamp: 1669245008169
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.9.3-py39hdcfc7df_2.tar.bz2
+  sha256: 20d30019df4ee9e1facaa29500122ba7ff7e8b1ed962916cd2162fda5ed09d55
+  md5: 17e5b84018da06aa9fb868bf6f216013
+  depends:
+  - blas 1.0 mkl
+  - icc_rt >=2022.1.0
+  - intel-openmp >=2023.1.0,<2024.0a0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.19,<1.26.0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21517713
+  timestamp: 1683294038354
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+  sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
+  md5: 3e284ae6b48ee30c364ffdc5601610b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1099842
+  timestamp: 1690291374842
+- conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.1.9-h6c2663c_0.tar.bz2
+  sha256: 25c1b4224f5d7d767d4adfe0384d585e9b3935464be3efff3120059308d9747c
+  md5: faac387845d33d194eeb7d5a3d962ea5
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 6506572
+  timestamp: 1649924235781
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+  sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
+  md5: 993b3886b334bd1f49d34206f21997b4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15998
+  timestamp: 1614030572433
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+  sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
+  md5: 7ac9604ad7564ac0c71bff5db198656f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67012
+  timestamp: 1696347795139
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+  sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
+  md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1311308
+  timestamp: 1681402905668
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+  sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
+  md5: 28b9869d8d3a839918fac4a08f38cbc2
+  depends:
+  - python >=3.9,<3.10.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30546
+  timestamp: 1671752127904
+- conda: https://repo.anaconda.com/pkgs/main/win-64/testpath-0.6.0-py39haa95532_0.tar.bz2
+  sha256: ad09d4b1225f40ff49f0eba9fe4e9a1dad2b36af92172e600d15328bc6bc7132
+  md5: 9e19229b635f3376982268031a23587b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94147
+  timestamp: 1655908617544
+- conda: https://repo.anaconda.com/pkgs/main/win-64/thrift-0.17.0-py39hd77b12b_0.tar.bz2
+  sha256: 0d0e1a967ae7a502c902977a71d40c65739e0068fb9887ceaeecbfc57c656fb9
+  md5: 3608289bbb69bdde682682c3d41ed90a
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six >=1.7.2
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 124092
+  timestamp: 1666296783646
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tifffile-2023.4.12-py39haa95532_0.tar.bz2
+  sha256: 2b0b9472b76cba4194f88c1b497470771c41869960960e3a4c91e43be186ad03
+  md5: 75402012c8377b03335df3bfef2e2e97
+  depends:
+  - imagecodecs >=2023.1.23
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - matplotlib-base >=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 407816
+  timestamp: 1695107900531
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+  sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
+  md5: 52cdcdb96383c010ca833a7c24b3935b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Tcl/Tk
+  license_family: BSD
+  size: 3690152
+  timestamp: 1654036853710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
+  sha256: 1ee791ecc17e11a31d6cf1553845e7279d9d9a2c7383a2a3e1ae131ddd024b6f
+  md5: b32030d310e0437dc631e5719369004c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102033
+  timestamp: 1667464306003
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+  sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
+  md5: 0e054ab29119cf4c1f778613acf972f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 681780
+  timestamp: 1696937326924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+  sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
+  md5: b6ad839ebba536ad1c3cc58d0e2123f0
+  depends:
+  - colorama
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 143681
+  timestamp: 1679562248929
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+  sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
+  md5: fe78de10019085146f1cc6c94fdc2620
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192822
+  timestamp: 1671143999327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
+  md5: ca5fc3fbdb09b6de068a8b7a8869369f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9208
+  timestamp: 1690298120549
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
+  md5: a86e87a10e5fdff486265e0c675fb99f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57922
+  timestamp: 1690298106990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+  sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
+  md5: 0d31859e0a097aedbcc1627db33b3d92
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188367
+  timestamp: 1698257883295
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+  sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
+  md5: 45ef24c486a484f079faf1dc90e4c7e9
+  depends:
+  - vs2015_runtime >=14.27.29016
+  license: Modified BSD License (3-clause)
+  license_family: BSD
+  size: 8277
+  timestamp: 1605602889180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+  sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
+  md5: 4daaceb6cfc1af6274509081d8018ef1
+  size: 2316783
+  timestamp: 1605602872095
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+  sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
+  md5: 916c16904615c7af3b5d37cb6694f45e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21084
+  timestamp: 1607347371925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+  sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
+  md5: da69e6987fcc757e83a358ceaa13f62b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73391
+  timestamp: 1614804425587
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+  sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
+  md5: 23b9f4634b2e5450be617114f62c74f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 120873
+  timestamp: 1695742300539
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+  sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
+  md5: 120f0b088290fc17bd6618fc10a2f0c4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PUBLIC-DOMAIN
+  size: 34293
+  timestamp: 1605306211299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
+  sha256: 6bdb88cd45b22246e84b7400159ca90faf98ab4e8c1fa2d38d031cfc73c4dc13
+  md5: d6e10641ece06f67561c5f6a676a4b7e
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1794729
+  timestamp: 1689041580510
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+  sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
+  md5: c3f7871e9a33adeccee1b1e8e216918e
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 1332571
+  timestamp: 1683113347814
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+  sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
+  md5: 1ab55f8c4b5292ec360c572120bf823e
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-3.0-or-later
+  size: 9430705
+  timestamp: 1616055773485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zfp-1.0.0-hd77b12b_0.tar.bz2
+  sha256: 4c35ecdc3e6eac1c031fb9caad206819266a29c9b3d507e2c82a73c6b3c4aaa8
+  md5: 2440d1045b36aeaffa022e8316352a5f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 271931
+  timestamp: 1681741704356
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py39haa95532_0.tar.bz2
+  sha256: 556bdf23786b69d1699aa1313fac43589cd33f8c62b701259e0f71c52343b59a
+  md5: 7bbafad85b6da7514e895923f3af7f5a
+  depends:
+  - heapdict
+  - python >=3.9,<3.10.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 76800
+  timestamp: 1695832961240
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+  sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
+  md5: 6875e0bf3828707dc9165d694c0d0a7d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18725
+  timestamp: 1672387612937
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+  sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
+  md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 148931
+  timestamp: 1666595229032
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+  sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
+  md5: 8d6a1e767775fe0eb617cd6e22edc2ff
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1871867
+  timestamp: 1681304638261

--- a/network_packets/pixi.toml
+++ b/network_packets/pixi.toml
@@ -1,0 +1,54 @@
+[workspace]
+name = "network_packets"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2017-07-24"
+maintainers = ["jbcrail", "jbednar"]
+categories = ["Cybersecurity"]
+labels = ["holoviews", "bokeh", "datashader", "networkx"]
+description = "Graphing network packets using networkx, holoviews, and datashader"
+
+[dependencies]
+python = "3.9.*"
+notebook = "*"
+bokeh = "2.3.3.*"
+colorcet = "*"
+dask = "2021.9.1.*"
+datashader = "0.13.0.*"
+fastparquet = "0.5.0.*"
+holoviews = "1.14.5.*"
+networkx = "*"
+scikit-image = "*"
+python-snappy = "0.6.0.*"
+pandas = "*"
+param = "1.11.1.*"
+numpy = "1.21.*"
+numba = "0.55.*"
+panel = "0.12.1.*"
+jinja2 = "<3"
+markupsafe = "2.0.1.*"
+pyviz_comms = "2.0.2.*"
+scipy = "1.9.*"
+pip = "*"
+wheel = "*"
+
+[target.osx-64.dependencies]
+libgfortran = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks.notebook]
+cmd = "jupyter notebook network_packets.ipynb"
+depends-on = ["download"]
+
+[tasks.prepare_data]
+cmd = "python pcap_to_parquet.py maccdc2012_00000.txt"
+depends-on = ["download"]
+
+[tasks.download]
+env = { FILENAME = "data" }
+cmd = "mkdir -p $FILENAME && curl -fsSL -o .DATA.zip http://s3.amazonaws.com/datashader-data/maccdc2012_graph.zip && python -m zipfile -e .DATA.zip $FILENAME && rm .DATA.zip"
+outputs = ["data"]

--- a/network_packets/pixi.toml
+++ b/network_packets/pixi.toml
@@ -31,14 +31,14 @@ jinja2 = "<3"
 markupsafe = "2.0.1.*"
 pyviz_comms = "2.0.2.*"
 scipy = "1.9.*"
-pip = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks.notebook]
 cmd = "jupyter notebook network_packets.ipynb"

--- a/network_packets/pixi.toml
+++ b/network_packets/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "network_packets"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/nyc_buildings/pixi.lock
+++ b/nyc_buildings/pixi.lock
@@ -8,7 +8,6 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
-    - url: https://conda.anaconda.org/nodefaults/
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2

--- a/nyc_buildings/pixi.lock
+++ b/nyc_buildings/pixi.lock
@@ -1,0 +1,9306 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/nodefaults/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311h9ecbd09_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.8.1-h205f482_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.8.1-h1a47875_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.10.6-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.0-h4e1184b_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.0-h7959bf6_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.9.2-hefd7a92_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.15.3-h173a860_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.11.0-h11f4f37_12.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.7.9-he1b24dc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.2-h4e1184b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.2-h4e1184b_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.29.9-he0e7f3f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.489-h4d475cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.14.0-h5cfcd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.10.0-h113e628_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.13.0-h3cf044e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.8.0-h736e048_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.12.0-ha633028_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hfdbb021_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.4-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2025.1.31-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.1-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.0.1-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.12-py311hfdbb021_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.56.0-py311h2dc5d0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.7-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.17-h717163a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_hbbce691_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-19.0.1-hfa2a6e7_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-19.0.1-hcb10f89_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-19.0.1-hcb10f89_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-19.0.1-h08228c5_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-31_h59b9bed_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-31_he106b2a_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.12.1-h332b0f4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.23-h4ddbbb0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h767d61c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hf1ad2bd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h767d61c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.35.0-h2b5623c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.35.0-h0121fbd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.67.1-h25350d4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h4ce23a2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-31_h7ac8fdf_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-ha7bfdaf_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.6.4-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.29-pthreads_h94d23a6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-1.18.0-hfcad708_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.18.0-ha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-19.0.1-h081d1f1_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.47-h943b412_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.3-h6128344_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hbbce691_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.49.1-hee588c1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hf672d98_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-h8f9b012_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.21.0-h0e7cc3e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-hd9ff511_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.10.0-h4c51ac1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.5.0-h851e524_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.6-h8d12d68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.44.0-py311h9c9ff8c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.3-py311h8c6ae76_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py311h2dc5d0c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.0-py311h2b939e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.0-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.11.3-he02047a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.61.0-py311h4e1c48f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.3-py311h71ddf71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.3-h5fbd93e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.1-h7b32b05_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.3-h12ee42a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py311h7db5c69_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.1.0-py311h1322bbf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.0.0-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-19.0.1-py311h38be061_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-19.0.1-py311h4854187_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.11-h9e4cc4f_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h2dc5d0c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.1-py311h7deb3e3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h9925aae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.23.1-py311h687327b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.11-h072c03f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.15.2-py311h8f841c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-h8bd8927_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.2-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-16.0.0-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.19.0-py311hd4cff14_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.1.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.13.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyh29332c3_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.2.0-h82add2a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.1.31-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2025.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2025.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2025.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.6.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.32.0-pyh907856f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.0-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.15.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.0.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.50-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.36.2-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/retrying-1.3.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.2-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/spatialpandas-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241206-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025a-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.1.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.13.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyh29332c3_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.2.0-h82add2a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.1.31-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2025.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2025.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2025.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.6.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.32.0-pyh907856f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.0-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.15.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.0.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.50-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.36.2-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/retrying-1.3.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.2-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/spatialpandas-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241206-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025a-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h3336109_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.8.1-h6661f4c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.8.1-hc0df2db_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.10.6-h6e16a3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.3.0-hc0df2db_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.5.0-h8236443_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.9.2-h5492b4a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.15.3-h7bd4489_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.11.0-h3488609_12.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.7.9-h702e2dd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.2.2-hc0df2db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.2.2-hc0df2db_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.29.9-h5c43303_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.489-h904bc55_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.14.0-h9a36307_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.10.0-ha4e2ba9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.13.0-h3d2f5f1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.8.0-h1ccc5ac_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-files-datalake-cpp-12.12.0-h86941f0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hd89902b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.4-hf13058a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2025.1.31-h8857fd0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.1-py311h137bacd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.1-py311h4e34fa0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.0.1-py311h4d7f069_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.12-py311hc356e98_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.56.0-py311ha3cf9ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hac325c4_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h2790a97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.7-py311hf2f7c97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.17-h72f5680_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240722.0-cxx17_h0e468a2_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-19.0.1-h91f21e1_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-19.0.1-ha6338a2_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-19.0.1-ha6338a2_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-19.0.1-h5c2345d_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-31_h7f60823_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-31_hff6cab4_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.12.1-h5dec5d8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.7-hf95d169_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.23-he65b83e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20250104-pl5321ha958ccf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.4-h240833e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.6-h281671d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.35.0-h7000a09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.35.0-h3f2b517_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.67.1-h4896ac0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4b5e92a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-31_h236ab99_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm15-15.0.7-hc29ff6c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.6.4-hd471939_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.64.0-hc7306c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.29-openmp_hbf64a52_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopentelemetry-cpp-1.18.0-h739dec3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopentelemetry-cpp-headers-1.18.0-h694c41f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-19.0.1-h3e22b07_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.47-h3c4a55f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-5.28.3-h6401091_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2024.07.02-h0e468a2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.49.1-hdb6dae5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-h3dc7d44_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.21.0-h75589b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-hb77a491_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.10.0-h777c5d8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.5.0-h6cf52b4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.6-he8ee3e7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.7-ha54dae1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.44.0-py311h79b6b59_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-4.3.3-py311h687f303_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.10.0-h240833e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.2-py311ha3cf9ac_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.10.0-py311h19a4563_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.1.0-py311hf2f7c97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/nlohmann_json-3.11.3-hf036a51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.61.0-py311h5322ac9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.1.3-py311h14ed71f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.3-h7fd6d84_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.1-hc426f3f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.3-h85ea3fe_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.3-py311haeb46be_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.1.0-py311h25da234_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/prometheus-cpp-1.3.0-h7802330_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.0.0-py311h4d7f069_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-19.0.1-py311h6eed73b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-19.0.1-py311he02522f_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.0-py311hfbc4093_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.0-py311hfbc4093_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.11-h9ccd52b_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311ha3cf9ac_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.2.1-py311hb21797c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2024.07.02-ha5e900a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h7cca4af_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.23.1-py311hab9d7c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.15.2-py311h0c91ca8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-haf3c120_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.2-py311h4d7f069_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-16.0.0-py311h4d7f069_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.12-h6e16a3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h7130eaa_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-hd23fc13_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.19.0-py311h5547dcb_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h8210216_1.conda
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.1.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.13.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyh29332c3_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.2.0-h82add2a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.1.31-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2025.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2025.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2025.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.6.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.32.0-pyh907856f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.0-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.15.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.0.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.50-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.36.2-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/retrying-1.3.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.2-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/spatialpandas-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241206-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025a-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311h460d6c5_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.8.1-hfc2798a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.8.1-hc8a0bd2_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.10.6-h5505292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.0-hc8a0bd2_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.5.0-h54f970a_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.9.2-h96aa502_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.15.3-haba67d1_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.11.0-h24f418c_12.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.7.9-hf37e03c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.2-hc8a0bd2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.2-hc8a0bd2_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.29.9-ha81f72f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.489-h0e5014b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.14.0-hd50102c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.10.0-hc602bab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.13.0-h7585a09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.8.0-h9ca1f76_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.12.0-hcdd55da_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311h3f08180_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.4-h5505292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2025.1.31-hf0a4a13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py311h3a79f62_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.1-py311h210dab8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.0.1-py311h917b07b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.12-py311h155a34a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.56.0-py311h4921393_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py311h267d04e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.7-py311h2c37856_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.17-h7eeda09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_h07bc746_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-19.0.1-h0945df6_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-19.0.1-hf07054f_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-19.0.1-hf07054f_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-19.0.1-h4239455_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-31_h10e41b3_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-31_hb3479ef_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.12.1-h73640d1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.7-ha82da77_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.23-hec38601_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.35.0-hdbe95d5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.35.0-h7081f7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.67.1-h0a426d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-hfe07756_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-31_hc9a63f6_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm15-15.0.7-h4429f82_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.6.4-h39f12f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.29-openmp_hf332438_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-1.18.0-h0c05b2d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.18.0-hce30654_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-19.0.1-h636d7b7_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.47-h3783ad8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.28.3-h3bd63a1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2024.07.02-h07bc746_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.49.1-h3f77e49_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h9cc3647_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.21.0-h64651cc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-h551f018_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.10.0-hda25de7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.5.0-h2471fea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.13.6-hce475f1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.7-hdb05f8b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.44.0-py311h55fc170_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-4.3.3-py311h3a49619_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py311h4921393_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.10.0-py311h031da69_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.0-py311h2c37856_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.11.3-h00cdb27_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.61.0-py311h74daea0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.3-py311h649a571_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.3-h8a3d83b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.1-h81ee809_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.3-h0ff2369_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py311h9cb3ce9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.1.0-py311hb9ba9e9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/prometheus-cpp-1.3.0-h0967b3e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.0.0-py311h917b07b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-19.0.1-py311ha1ab1f8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-19.0.1-py311he04fa90_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-11.0-py311hab620ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-11.0-py311hab620ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.11-hc22306f_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h4921393_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.1-py311h01f2145_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2024.07.02-h6589ca4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.23.1-py311hc9d6b66_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.15.2-py311h0675101_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-h98b9ce2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.2-py311h917b07b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-16.0.0-py311h917b07b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-h5505292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-hc1bb282_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.19.0-py311he2be06e_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_1.conda
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.1.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.13.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyh29332c3_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.2.0-h82add2a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.1.31-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.11-py311hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2025.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2025.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2025.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.6.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.32.0-pyh9ab4c32_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh5737063_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.0-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.15.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.0.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.50-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.36.2-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/retrying-1.3.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.2-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/spatialpandas-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241206-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025a-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311he736701_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.8.1-hd11252f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.8.1-h099ea23_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.10.6-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.3.0-h099ea23_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.5.0-h85d8506_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.9.2-h3888f84_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.15.3-hc5a9e45_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.11.0-h2c94728_12.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.7.9-h6a47413_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.2.2-h099ea23_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.2.2-h099ea23_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.29.9-he488853_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.489-h7d73209_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311hda3d55a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.34.4-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2025.1.31-h56e8100_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.1-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.0.1-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.12-py311hda3d55a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.56.0-py311h5082efb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.7-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.17-hbcf6048_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_h4eb7d71_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-19.0.1-h8dcb746_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-19.0.1-h7d8d6a5_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-19.0.1-h7d8d6a5_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-19.0.1-h3dbecdf_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-31_h641d27c_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-31_h5e41251_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.12.1-h88aaa65_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.23-h9062f6e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.4-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.6-h537db12_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-14.2.0-h1383e82_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-14.2.0-h1383e82_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.35.0-h95c5cb2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.35.0-he5eb982_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.67.1-h0ac93cb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.2-default_ha69328c_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-h135ad9c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-31_h1aa476e_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.6.4-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-19.0.1-ha850022_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.47-had7236b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.28.3-h8309712_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2024.07.02-h4eb7d71_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.49.1-h67fdade_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-he619c9f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.21.0-hbe90ef8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-h797046b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.10.0-hf9b99b7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.5.0-h3b0e114_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.6-he286e8c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.44.0-py311h7deaa30_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-4.3.3-py311h0476921_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.10.0-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py311h5082efb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.10.0-py311h8f1b1e4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.0-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.61.0-py311h0673bce_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.3-py311h35ffc71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.3-h4d64b90_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.4.1-ha4e3fda_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.3-haf104fe_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py311hcf9f919_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.1.0-py311h43e43bb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.0.0-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-19.0.1-py311h1ea47a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-19.0.1-py311hdea38fa_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.11-h3f84c4b_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-307-py311hda3d55a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.15-py311hda3d55a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311h5082efb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.2.1-py311h484c95c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2024.07.02-haf4117d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.23.1-py311ha250665_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.15.2-py311h99d06ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h500f7fa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-h62715c5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.2-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-16.0.0-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h5fd82a7_24.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34433-h6356254_24.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hfef2bbc_24.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.12-h0e40799_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.5-h0e40799_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.19.0-py311ha68e1ae_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-hbeecb71_1.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  license: None
+  size: 2562
+  timestamp: 1578324546067
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23621
+  timestamp: 1650670423406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311h9ecbd09_5.conda
+  sha256: d1af1fbcb698c2e07b0d1d2b98384dd6021fa55c8bcb920e3652e0b0c393881b
+  md5: 18143eab7fcd6662c604b85850f0db1e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.0.1
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 35025
+  timestamp: 1725356735679
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.8.1-h205f482_0.conda
+  sha256: ebe5e33249f37f6bb481de99581ebdc92dbfcf1b6915609bcf3c9e78661d6352
+  md5: 9c500858e88df50af3cc883d194de78a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.8.1,<0.8.2.0a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-http >=0.9.2,<0.9.3.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  - aws-c-sdkutils >=0.2.2,<0.2.3.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 108111
+  timestamp: 1737509831651
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.8.1-h1a47875_3.conda
+  sha256: 095ac824ea9303eff67e04090ae531d9eb33d2bf8f82eaade39b839c421e16e8
+  md5: 55a8561fdbbbd34f50f57d9be12ed084
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - libgcc >=13
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 47601
+  timestamp: 1733991564405
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.10.6-hb9d3cd8_0.conda
+  sha256: 496e92f2150fdc351eacf6e236015deedb3d0d3114f8e5954341cbf9f3dda257
+  md5: d7d4680337a14001b0e043e96529409b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 236574
+  timestamp: 1733975453350
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.0-h4e1184b_5.conda
+  sha256: 62ca84da83585e7814a40240a1e750b1563b2680b032a471464eccc001c3309b
+  md5: 3f4c1197462a6df2be6dc8241828fe93
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 19086
+  timestamp: 1733991637424
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.0-h7959bf6_11.conda
+  sha256: 10d7240c7db0c941fb1a59c4f8ea6689a434b03309ee7b766fa15a809c553c02
+  md5: 9b3fb60fe57925a92f399bc3fc42eccf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 54003
+  timestamp: 1734024480949
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.9.2-hefd7a92_4.conda
+  sha256: 4a330206bd51148f6c13ca0b7a4db40f29a46f090642ebacdeb88b8a4abd7f99
+  md5: 5ce4df662d32d3123ea8da15571b6f51
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.8.1,<0.8.2.0a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-compression >=0.3.0,<0.3.1.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 197731
+  timestamp: 1734008380764
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.15.3-h173a860_6.conda
+  sha256: 335d822eead0a097ffd23677a288e1f18ea22f47a92d4f877419debb93af0e81
+  md5: 9a063178f1af0a898526cc24ba7be486
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.8.1,<0.8.2.0a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - libgcc >=13
+  - s2n >=1.5.11,<1.5.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 157263
+  timestamp: 1737207617838
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.11.0-h11f4f37_12.conda
+  sha256: 512d3969426152d9d5fd886e27b13706122dc3fa90eb08c37b0d51a33d7bb14a
+  md5: 96c3e0221fa2da97619ee82faa341a73
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-http >=0.9.2,<0.9.3.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 194672
+  timestamp: 1734025626798
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.7.9-he1b24dc_1.conda
+  sha256: 15fbdedc56850f8be5be7a5bcaea1af09c97590e631c024ae089737fc932fc42
+  md5: caafc32928a5f7f3f7ef67d287689144
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-auth >=0.8.1,<0.8.2.0a0
+  - aws-c-cal >=0.8.1,<0.8.2.0a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-http >=0.9.2,<0.9.3.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - libgcc >=13
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 115413
+  timestamp: 1737558687616
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.2-h4e1184b_0.conda
+  sha256: 0424e380c435ba03b5948d02e8c958866c4eee50ed29e57f99473a5f795a4cfc
+  md5: dcd498d493818b776a77fbc242fbf8e4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 55911
+  timestamp: 1736535960724
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.2-h4e1184b_4.conda
+  sha256: 1ed9a332d06ad595694907fad2d6d801082916c27cd5076096fda4061e6d24a8
+  md5: 74e8c3e4df4ceae34aa2959df4b28101
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 72762
+  timestamp: 1733994347547
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.29.9-he0e7f3f_2.conda
+  sha256: c1930569713bd5231d48d885a5e3707ac917b428e8f08189d14064a2bb128adc
+  md5: 8a4e6fc8a3b285536202b5456a74a940
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-auth >=0.8.1,<0.8.2.0a0
+  - aws-c-cal >=0.8.1,<0.8.2.0a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-c-http >=0.9.2,<0.9.3.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  - aws-c-mqtt >=0.11.0,<0.11.1.0a0
+  - aws-c-s3 >=0.7.9,<0.7.10.0a0
+  - aws-c-sdkutils >=0.2.2,<0.2.3.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 353222
+  timestamp: 1737565463079
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.489-h4d475cb_0.conda
+  sha256: 08d6b7d2ed17bfcc7deb903c7751278ee434abdb27e3be0dceb561f30f030c75
+  md5: b775e9f46dfa94b228a81d8e8c6d8b1d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - aws-crt-cpp >=0.29.9,<0.29.10.0a0
+  - libcurl >=8.11.1,<9.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3144364
+  timestamp: 1737576036746
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.14.0-h5cfcd09_0.conda
+  sha256: fe07debdb089a3db17f40a7f20d283d75284bb4fc269ef727b8ba6fc93f7cb5a
+  md5: 0a8838771cc2e985cd295e01ae83baf1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 345117
+  timestamp: 1728053909574
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.10.0-h113e628_0.conda
+  sha256: 286b31616c191486626cb49e9ceb5920d29394b9e913c23adb7eb637629ba4de
+  md5: 73f73f60854f325a55f1d31459f2ab73
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 232351
+  timestamp: 1728486729511
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.13.0-h3cf044e_1.conda
+  sha256: 2606260e5379eed255bcdc6adc39b93fb31477337bcd911c121fc43cd29bf394
+  md5: 7eb66060455c7a47d9dcdbfa9f46579b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  size: 549342
+  timestamp: 1728578123088
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.8.0-h736e048_1.conda
+  sha256: 273475f002b091b66ce7366da04bf164c3732c03f8692ab2ee2d23335b6a82ba
+  md5: 13de36be8de3ae3f05ba127631599213
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.12.7,<2.14.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 149312
+  timestamp: 1728563338704
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.12.0-ha633028_1.conda
+  sha256: 5371e4f3f920933bb89b926a85a67f24388227419abd6e99f6086481e5e8d5f2
+  md5: 7c1980f89dd41b097549782121a73490
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  size: 287366
+  timestamp: 1728729530295
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_2.conda
+  sha256: fcb0b5b28ba7492093e54f3184435144e074dfceab27ac8e6a9457e736565b0b
+  md5: 98514fe74548d768907ce7a13f680e8f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli-bin 1.1.0 hb9d3cd8_2
+  - libbrotlidec 1.1.0 hb9d3cd8_2
+  - libbrotlienc 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 19264
+  timestamp: 1725267697072
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_2.conda
+  sha256: 261364d7445513b9a4debc345650fad13c627029bfc800655a266bf1e375bc65
+  md5: c63b5e52939e795ba8d26e35d767a843
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlidec 1.1.0 hb9d3cd8_2
+  - libbrotlienc 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 18881
+  timestamp: 1725267688731
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hfdbb021_2.conda
+  sha256: 949913bbd1f74d1af202d3e4bff2e0a4e792ec00271dc4dd08641d4221aa2e12
+  md5: d21daab070d76490cb39a8f1d1729d79
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  license: MIT
+  license_family: MIT
+  size: 350367
+  timestamp: 1725267768486
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+  sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
+  md5: 62ee74e96c5ebb0af99386de58cf9553
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 252783
+  timestamp: 1720974456583
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.4-hb9d3cd8_0.conda
+  sha256: d4f28d87b6339b94f74762c0076e29c8ef8ddfff51a564a92da2843573c18320
+  md5: e2775acf57efd5af15b8e3d1d74d72d3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 206085
+  timestamp: 1734208189009
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2025.1.31-hbcca054_0.conda
+  sha256: bf832198976d559ab44d6cdb315642655547e26d826e34da67cbee6624cda189
+  md5: 19f3a56f68d2fd06c516076bff482c52
+  license: ISC
+  size: 158144
+  timestamp: 1738298224464
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
+  sha256: bc47aa39c8254e9e487b8bcd74cfa3b4a3de3648869eb1a0b89905986b668e35
+  md5: 55553ecd5328336368db611f350b7039
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 302115
+  timestamp: 1725560701719
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.1-py311hd18a35c_0.conda
+  sha256: 08be6120dc9369f07858677dde2a8474644cc7ec2ae146b39a6953aadc536dfd
+  md5: 351cb68d2081e249069748b6e60b3cd2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 278209
+  timestamp: 1731428493722
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.0.1-py311h9ecbd09_0.conda
+  sha256: fd5a8c7e613c3c538ca775951fd814ab10cfcdaed79e193c3bf7eb59c87cd114
+  md5: 69a0a85acdcc5e6d0f1cc915c067ad4c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 394232
+  timestamp: 1734107375850
+- conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.12-py311hfdbb021_0.conda
+  sha256: 5c6e1eb9d1ce2b1474d424b10afbe1c5a992b59c002a3e8c6477be3a9accbc2c
+  md5: 2a34eab62b5927587e04c7f8beeaf0d7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2568620
+  timestamp: 1737269948630
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.56.0-py311h2dc5d0c_0.conda
+  sha256: de9c238166cbff1b06c679395d3e3b0cf1e56969289ccdfb54404ed0a52256c7
+  md5: ca3692015a53c7fcc248a324a540c54c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli
+  - libgcc >=13
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2896040
+  timestamp: 1738940522395
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+  sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
+  md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 634972
+  timestamp: 1694615932610
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
+  sha256: 6c33bf0c4d8f418546ba9c250db4e4221040936aef8956353bc764d4877bc39a
+  md5: d411fc29e338efb48c5fd4576d71d881
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119654
+  timestamp: 1726600001928
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
+  sha256: dc824dc1d0aa358e28da2ecbbb9f03d932d976c8dca11214aa1dcdfcbd054ba2
+  md5: ff862eebdfeb2fd048ae9dc92510baca
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 143452
+  timestamp: 1718284177264
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+  sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
+  md5: 8b189310083baabfb622af68fd9d3ae3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 12129203
+  timestamp: 1720853576813
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_1.conda
+  sha256: 2f082f7b12a7c6824e051321c1029452562ad6d496ad2e8c8b7b3dea1c8feb92
+  md5: 5ca76f61b00a15a9be0612d4d883badc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17645
+  timestamp: 1725303065473
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+  sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
+  md5: 30186d27e2c9fa62b45fb1476b7200e3
+  depends:
+  - libgcc-ng >=10.3.0
+  license: LGPL-2.1-or-later
+  size: 117831
+  timestamp: 1646151697040
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.7-py311hd18a35c_0.conda
+  sha256: 4af11cbc063096a284fe1689b33424e7e49732a27fd396d74c7dee03d1e788ee
+  md5: be34c90cce87090d24da64a7c239ca96
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 72393
+  timestamp: 1725459421768
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+  sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
+  md5: 3f43953b7d3fb3aaa1d0d0723d91e368
+  depends:
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1370023
+  timestamp: 1719463201255
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.17-h717163a_0.conda
+  sha256: d6a61830a354da022eae93fa896d0991385a875c6bba53c82263a289deda9db8
+  md5: 000e85703f0fd9594c81710dd5066471
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 248046
+  timestamp: 1739160907615
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_4.conda
+  sha256: db73f38155d901a610b2320525b9dd3b31e4949215c870685fd92ea61b5ce472
+  md5: 01f8d123c96816249efd255a31ad7712
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - binutils_impl_linux-64 2.43
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 671240
+  timestamp: 1740155456116
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+  sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
+  md5: 76bbff344f0134279f225174e9064c8f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 281798
+  timestamp: 1657977462600
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_hbbce691_4.conda
+  sha256: 143a586aa67d50622ef703de57b9d43f44945836d6568e0e7aa174bd8c45e0d4
+  md5: 488f260ccda0afaf08acb286db439c2f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  constrains:
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1311599
+  timestamp: 1736008414161
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-19.0.1-hfa2a6e7_0_cpu.conda
+  sha256: 7b1f61045b37266989023a007d6331875062bb658068a6e6ab49720495ca3543
+  md5: 11b712ed1316c98592f6bae7ccfaa86c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-crt-cpp >=0.29.9,<0.29.10.0a0
+  - aws-sdk-cpp >=1.11.489,<1.11.490.0a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-identity-cpp >=1.10.0,<1.10.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-files-datalake-cpp >=12.12.0,<12.12.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libgcc >=13
+  - libgoogle-cloud >=2.35.0,<2.36.0a0
+  - libgoogle-cloud-storage >=2.35.0,<2.36.0a0
+  - libopentelemetry-cpp >=1.18.0,<1.19.0a0
+  - libprotobuf >=5.28.3,<5.28.4.0a0
+  - libre2-11 >=2024.7.2
+  - libstdcxx >=13
+  - libutf8proc >=2.10.0,<2.11.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - orc >=2.0.3,<2.0.4.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - arrow-cpp <0.0a0
+  - parquet-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 8967810
+  timestamp: 1739768880886
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-19.0.1-hcb10f89_0_cpu.conda
+  sha256: 9a3c38a8f1516fe5b7801d0407ff704efd53955ebd63f7fbc439ec3b563d19cc
+  md5: 0d63e2dea06c44c9d2c8be3e7e38eea9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 19.0.1 hfa2a6e7_0_cpu
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 638054
+  timestamp: 1739768924910
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-19.0.1-hcb10f89_0_cpu.conda
+  sha256: f756208d787db50b6be68210cb9eec3644b8291a8a353bb2071ea4451bfc1412
+  md5: ec52b3b990be399f4267a9acabb73070
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 19.0.1 hfa2a6e7_0_cpu
+  - libarrow-acero 19.0.1 hcb10f89_0_cpu
+  - libgcc >=13
+  - libparquet 19.0.1 h081d1f1_0_cpu
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 604500
+  timestamp: 1739769034226
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-19.0.1-h08228c5_0_cpu.conda
+  sha256: e0b3ed06ce74c6a083dab59fb3059fdbc40fc71ff94ce470ca0a7c7ffe8d0317
+  md5: 792e2359bb93513324326cbe3ee4ebdd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 19.0.1 hfa2a6e7_0_cpu
+  - libarrow-acero 19.0.1 hcb10f89_0_cpu
+  - libarrow-dataset 19.0.1 hcb10f89_0_cpu
+  - libgcc >=13
+  - libprotobuf >=5.28.3,<5.28.4.0a0
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 523313
+  timestamp: 1739769085090
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-31_h59b9bed_openblas.conda
+  sha256: 9839fc4ac0cbb0aa3b9eea520adfb57311838959222654804e58f6f2d1771db5
+  md5: 728dbebd0f7a20337218beacffd37916
+  depends:
+  - libopenblas >=0.3.29,<0.3.30.0a0
+  - libopenblas >=0.3.29,<1.0a0
+  constrains:
+  - liblapacke =3.9.0=31*_openblas
+  - liblapack =3.9.0=31*_openblas
+  - blas =2.131=openblas
+  - mkl <2025
+  - libcblas =3.9.0=31*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16859
+  timestamp: 1740087969120
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
+  sha256: d9db2de60ea917298e658143354a530e9ca5f9c63471c65cf47ab39fd2f429e3
+  md5: 41b599ed2b02abcfdd84302bff174b23
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 68851
+  timestamp: 1725267660471
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
+  sha256: 2892d512cad096cb03f1b66361deeab58b64e15ba525d6592bb6d609e7045edf
+  md5: 9566f0bd264fbd463002e759b8a82401
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 32696
+  timestamp: 1725267669305
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
+  sha256: 779f58174e99de3600e939fa46eddb453ec5d3c60bb46cdaa8b4c127224dbf29
+  md5: 06f70867945ea6a84d35836af780f1de
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 281750
+  timestamp: 1725267679782
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-31_he106b2a_openblas.conda
+  sha256: ede8545011f5b208b151fe3e883eb4e31d495ab925ab7b9ce394edca846e0c0d
+  md5: abb32c727da370c481a1c206f5159ce9
+  depends:
+  - libblas 3.9.0 31_h59b9bed_openblas
+  constrains:
+  - liblapacke =3.9.0=31*_openblas
+  - liblapack =3.9.0=31*_openblas
+  - blas =2.131=openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16796
+  timestamp: 1740087984429
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+  sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
+  md5: c965a5aa0d5c1c37ffc62dff36e28400
+  depends:
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20440
+  timestamp: 1633683576494
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.12.1-h332b0f4_0.conda
+  sha256: 2ebc3039af29269e4cdb858fca36265e5e400c1125a4bcd84ae73a596e0e76ca
+  md5: 45e9dc4e7b25e2841deb392be085500e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libnghttp2 >=1.64.0,<2.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.1,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 426675
+  timestamp: 1739512336799
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.23-h4ddbbb0_0.conda
+  sha256: 511d801626d02f4247a04fff957cc6e9ec4cc7e8622bd9acd076bcdc5de5fe66
+  md5: 8dfae1d2e74767e9ce36d5fa0d8605db
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 72255
+  timestamp: 1734373823254
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+  sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
+  md5: c277e0a4d549b03ac1e9d6cbbe3d017b
+  depends:
+  - ncurses
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - ncurses >=6.5,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134676
+  timestamp: 1738479519902
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+  md5: 172bf1cd1ff8629f2b1179945ed45055
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 112766
+  timestamp: 1702146165126
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+  sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
+  md5: a1cfcc585f0c42bf8d5546bb1dfb668d
+  depends:
+  - libgcc-ng >=12
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 427426
+  timestamp: 1685725977222
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
+  sha256: 56541b98447b58e52d824bd59d6382d609e11de1f8adf20b23143e353d2b8d26
+  md5: db833e03127376d461e1e13e76f09b6c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 73304
+  timestamp: 1730967041968
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_0.conda
+  sha256: 67a6c95e33ebc763c1adc3455b9a9ecde901850eb2fceb8e646cc05ef3a663da
+  md5: e3eb7806380bc8bcecba6d749ad5f026
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 53415
+  timestamp: 1739260413716
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h767d61c_2.conda
+  sha256: 3a572d031cb86deb541d15c1875aaa097baefc0c580b54dc61f5edab99215792
+  md5: ef504d1acbd74b7cc6849ef8af47dd03
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 14.2.0 h767d61c_2
+  - libgcc-ng ==14.2.0=*_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 847885
+  timestamp: 1740240653082
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_2.conda
+  sha256: fb7558c328b38b2f9d2e412c48da7890e7721ba018d733ebdfea57280df01904
+  md5: a2222a6ada71fb478682efe483ce0f92
+  depends:
+  - libgcc 14.2.0 h767d61c_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 53758
+  timestamp: 1740240660904
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_2.conda
+  sha256: e05263e8960da03c341650f2a3ffa4ccae4e111cb198e8933a2908125459e5a6
+  md5: fb54c4ea68b460c278d26eea89cfbcc3
+  depends:
+  - libgfortran5 14.2.0 hf1ad2bd_2
+  constrains:
+  - libgfortran-ng ==14.2.0=*_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 53733
+  timestamp: 1740240690977
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hf1ad2bd_2.conda
+  sha256: c17b7cf3073a1f4e1f34d50872934fa326346e104d3c445abc1e62481ad6085c
+  md5: 556a4fdfac7287d349b8f09aba899693
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14.2.0
+  constrains:
+  - libgfortran 14.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1461978
+  timestamp: 1740240671964
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h767d61c_2.conda
+  sha256: 1a3130e0b9267e781b89399580f3163632d59fe5b0142900d63052ab1a53490e
+  md5: 06d02030237f4d5b3d9a7e7d348fe3c6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 459862
+  timestamp: 1740240588123
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.35.0-h2b5623c_0.conda
+  sha256: d747d14c69da512d8993a995dc2df90e857778b0a8542f12fb751544128af685
+  md5: 1040ab07d7af9f23cf2466ffe4e58db1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.11.1,<9.0a0
+  - libgcc >=13
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libprotobuf >=5.28.3,<5.28.4.0a0
+  - libstdcxx >=13
+  - openssl >=3.4.0,<4.0a0
+  constrains:
+  - libgoogle-cloud 2.35.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1258035
+  timestamp: 1738662406183
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.35.0-h0121fbd_0.conda
+  sha256: cb1ef70e55d2c1defbfd8413dbe85b5550782470dda4f8d393f28d41b6d9b007
+  md5: 34e2243e0428aac6b3e903ef99b6d57d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libgcc >=13
+  - libgoogle-cloud 2.35.0 h2b5623c_0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  size: 785777
+  timestamp: 1738662565066
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.67.1-h25350d4_1.conda
+  sha256: 014627485b3cf0ea18e04c0bab07be7fb98722a3aeeb58477acc7e1c3d2f911e
+  md5: 0c6497a760b99a926c7c12b74951a39c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - c-ares >=1.34.4,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libprotobuf >=5.28.3,<5.28.4.0a0
+  - libre2-11 >=2024.7.2
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.67.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 7792251
+  timestamp: 1735584856826
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h4ce23a2_1.conda
+  sha256: 18a4afe14f731bfb9cf388659994263904d20111e42f841e9eea1bb6f91f4ab4
+  md5: e796ff8ddc598affdf7c173d6145f087
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-only
+  size: 713084
+  timestamp: 1740128065462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+  sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
+  md5: ea25936bb4080d843790b586850f82b8
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 618575
+  timestamp: 1694474974816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-31_h7ac8fdf_openblas.conda
+  sha256: f583661921456e798aba10972a8abbd9d33571c655c1f66eff450edc9cbefcf3
+  md5: 452b98eafe050ecff932f0ec832dd03f
+  depends:
+  - libblas 3.9.0 31_h59b9bed_openblas
+  constrains:
+  - libcblas =3.9.0=31*_openblas
+  - liblapacke =3.9.0=31*_openblas
+  - blas =2.131=openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16790
+  timestamp: 1740087997375
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-ha7bfdaf_5.conda
+  sha256: 7dfa43a79a35debdff93328f9acc3b0ad859929dc7e761160ecbd93275e64e6f
+  md5: f55d1108d59fa85e6a1ded9c70766bd8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 33233890
+  timestamp: 1739680079644
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.6.4-hb9d3cd8_0.conda
+  sha256: cad52e10319ca4585bc37f0bc7cce99ec7c15dc9168e42ccb96b741b0a27db3f
+  md5: 42d5b6a0f30d3c10cd88cb8584fda1cb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - xz ==5.6.4=*_0
+  license: 0BSD
+  size: 111357
+  timestamp: 1738525339684
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+  sha256: b0f2b3695b13a989f75d8fd7f4778e1c7aabe3b36db83f0fe80b2cd812c0e975
+  md5: 19e57602824042dfd0446292ef90488b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - c-ares >=1.32.3,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 647599
+  timestamp: 1729571887612
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+  sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+  md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  license_family: GPL
+  size: 33408
+  timestamp: 1697359010159
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.29-pthreads_h94d23a6_0.conda
+  sha256: cc5389ea254f111ef17a53df75e8e5209ef2ea6117e3f8aced88b5a8e51f11c4
+  md5: 0a4d0252248ef9a0f88f2ba8b8a08e12
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.2.0
+  constrains:
+  - openblas >=0.3.29,<0.3.30.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5919288
+  timestamp: 1739825731827
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-1.18.0-hfcad708_1.conda
+  sha256: 4ea235e08676f16b0d3c3380befe1478c0fa0141512ee709b011005c55c9619f
+  md5: 1f5a5d66e77a39dc5bd639ec953705cf
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.11.1,<9.0a0
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libopentelemetry-cpp-headers 1.18.0 ha770c72_1
+  - libprotobuf >=5.28.3,<5.28.4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - nlohmann_json
+  - prometheus-cpp >=1.3.0,<1.4.0a0
+  constrains:
+  - cpp-opentelemetry-sdk =1.18.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 801927
+  timestamp: 1735643375271
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.18.0-ha770c72_1.conda
+  sha256: aa1f7dea79ea8513ff77339ba7c6e9cf10dfa537143e7718b1cfb3af52b649f2
+  md5: 4fb055f57404920a43b147031471e03b
+  license: Apache-2.0
+  license_family: APACHE
+  size: 320359
+  timestamp: 1735643346175
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-19.0.1-h081d1f1_0_cpu.conda
+  sha256: e9c4a07e79886963bfcd05894a15b5d4c7137c1122273de68845315c35d6505d
+  md5: 8b58c378d65b213c001f04a174a2a70e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 19.0.1 hfa2a6e7_0_cpu
+  - libgcc >=13
+  - libstdcxx >=13
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.4.1,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 1244749
+  timestamp: 1739769006551
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.47-h943b412_0.conda
+  sha256: 23367d71da58c9a61c8cbd963fcffb92768d4ae5ffbef9a47cdf1f54f98c5c36
+  md5: 55199e2ae2c3651f6f9b2a447b47bdc9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 288701
+  timestamp: 1739952993639
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.3-h6128344_1.conda
+  sha256: 51125ebb8b7152e4a4e69fd2398489c4ec8473195c27cde3cbdf1cb6d18c5493
+  md5: d8703f1ffe5a06356f06467f1d0b9464
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2960815
+  timestamp: 1735577210663
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hbbce691_2.conda
+  sha256: 4420f8362c71251892ba1eeb957c5e445e4e1596c0c651c28d0d8b415fe120c7
+  md5: b2fede24428726dd867611664fb372e8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 209793
+  timestamp: 1735541054068
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
+  sha256: 0105bd108f19ea8e6a78d2d994a6d4a8db16d19a41212070d2d1d48a63c34161
+  md5: a587892d3c13b6621a6091be690dbca2
+  depends:
+  - libgcc-ng >=12
+  license: ISC
+  size: 205978
+  timestamp: 1716828628198
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.49.1-hee588c1_1.conda
+  sha256: 7a09eef804ef7cf4d88215c2297eabb72af8ad0bd5b012060111c289f14bbe7d
+  md5: 73cea06049cc4174578b432320a003b8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 915956
+  timestamp: 1739953155793
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hf672d98_0.conda
+  sha256: 0407ac9fda2bb67e11e357066eff144c845801d00b5f664efbc48813af1e7bb9
+  md5: be2de152d8073ef1c01b7728475f2fe7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 304278
+  timestamp: 1732349402869
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-h8f9b012_2.conda
+  sha256: 8f5bd92e4a24e1d35ba015c5252e8f818898478cb3bc50bd8b12ab54707dc4da
+  md5: a78c856b6dc6bf4ea8daeb9beaaa3fb0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 14.2.0 h767d61c_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3884556
+  timestamp: 1740240685253
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_2.conda
+  sha256: e86f38b007cf97cc2c67cd519f2de12a313c4ee3f5ef11652ad08932a5e34189
+  md5: c75da67f045c2627f59e6fcb5f4e3a9b
+  depends:
+  - libstdcxx 14.2.0 h8f9b012_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 53830
+  timestamp: 1740240722530
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.21.0-h0e7cc3e_0.conda
+  sha256: ebb395232973c18745b86c9a399a4725b2c39293c9a91b8e59251be013db42f0
+  md5: dcb95c0a98ba9ff737f7ae482aef7833
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 425773
+  timestamp: 1727205853307
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-hd9ff511_3.conda
+  sha256: b224e16b88d76ea95e4af56e2bc638c603bd26a770b98d117d04541d3aafa002
+  md5: 0ea6510969e1296cc19966fad481f6de
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.23,<1.26.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libstdcxx >=13
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 428173
+  timestamp: 1734398813264
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.10.0-h4c51ac1_0.conda
+  sha256: 8e41563ee963bf8ded06da45f4e70bf42f913cb3c2e79364eb3218deffa3cd74
+  md5: aeccfff2806ae38430638ffbb4be9610
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 82745
+  timestamp: 1737244366901
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33601
+  timestamp: 1680112270483
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.5.0-h851e524_0.conda
+  sha256: c45283fd3e90df5f0bd3dbcd31f59cdd2b001d424cf30a07223655413b158eaf
+  md5: 63f790534398730f59e1b899c3644d4a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - libwebp 1.5.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 429973
+  timestamp: 1734777489810
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+  sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
+  md5: 92ed62436b625154323d40d5f2f11dd7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 395888
+  timestamp: 1727278577118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
+  md5: 5aa797f8787fe7a17d1b0821485b5adc
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 100393
+  timestamp: 1702724383534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.6-h8d12d68_0.conda
+  sha256: db8af71ea9c0ae95b7cb4a0f59319522ed2243942437a1200ceb391493018d85
+  md5: 328382c0e0ca648e5c189d5ec336c604
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=13
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.6.4,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 690296
+  timestamp: 1739952967309
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
+  md5: edb0dca6bc32e4f4789199455a1dbeb8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 60963
+  timestamp: 1727963148474
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.44.0-py311h9c9ff8c_0.conda
+  sha256: 4f0f29c81da661a39506b3ea9349ad8e661c96fb8e6b2858221f5523be3aa6ee
+  md5: 2982bb97e921bbc90b762ba301cc4a74
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4030446
+  timestamp: 1738108360666
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.3-py311h8c6ae76_2.conda
+  sha256: 9b4120ce388d838e4268ec688d00b8da65c248e31e5604329fe1b066c463add5
+  md5: 1488bb4acf059331210cb3397b1033d6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - lz4-c >=1.10.0,<1.11.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39918
+  timestamp: 1733474357793
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
+  sha256: 47326f811392a5fd3055f0f773036c392d26fdb32e4d8e7a8197eed951489346
+  md5: 9de5350a85c4a20c685259b889aa6393
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 167055
+  timestamp: 1733741040117
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py311h2dc5d0c_1.conda
+  sha256: 0291d90706ac6d3eea73e66cd290ef6d805da3fad388d1d476b8536ec92ca9a8
+  md5: 6565a715337ae279e351d0abd8ffe88a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25354
+  timestamp: 1733219879408
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.0-py311h2b939e6_0.conda
+  sha256: 3293589f81e6846fd4e8b8bc73299b08038d9dd8911ff4982ca7323ca553d824
+  md5: 79239585ea50c427415ef629534bb3aa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  - tk >=8.6.13,<8.7.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8478996
+  timestamp: 1734380603972
+- conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.0-py311hd18a35c_0.conda
+  sha256: 9033fa7084cbfd10e1b7ed3b74cee17169a0731ec98244d05c372fc4a935d5c9
+  md5: 682f76920687f7d9283039eb542fdacf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 104809
+  timestamp: 1725975116412
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+  sha256: 3fde293232fa3fca98635e1167de6b7c7fda83caf24b9d6c91ec9eefb4f4d586
+  md5: 47e340acb35de30501a76c7c799c41d7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: X11 AND BSD-3-Clause
+  size: 891641
+  timestamp: 1738195959188
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.11.3-he02047a_1.conda
+  sha256: ce4bcced4f8eea71b7cac8bc3daac097abf7a5792f278cd811dedada199500c1
+  md5: e46f7ac4917215b49df2ea09a694a3fa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 122743
+  timestamp: 1723652407663
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.61.0-py311h4e1c48f_1.conda
+  sha256: f0f1eae51f0a837a2902bf317819c5381b0cf76bf3abdedf218cef6b1cd6ca26
+  md5: 24b37c8a91f275959d158f5f8e3c2439
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - libgcc >=13
+  - libstdcxx >=13
+  - llvmlite >=0.44.0,<0.45.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.24,<2.2
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - cudatoolkit >=11.2
+  - cuda-version >=11.2
+  - libopenblas !=0.3.6
+  - tbb >=2021.6.0
+  - cuda-python >=11.6
+  - scipy >=1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5976694
+  timestamp: 1739224856801
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.3-py311h71ddf71_0.conda
+  sha256: d2fdae6b0e80c23248f0f6bf7b5e3b6e0f56f69f420e9f5da5a6aae2c95b1493
+  md5: 1b3c543b0cc96310bcf0b825d5a68cb1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8978113
+  timestamp: 1730588531967
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.3-h5fbd93e_0.conda
+  sha256: 5bee706ea5ba453ed7fd9da7da8380dd88b865c8d30b5aaec14d2b6dd32dbc39
+  md5: 9e5816bc95d285c115a3ebc2f8563564
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libpng >=1.6.44,<1.7.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 342988
+  timestamp: 1733816638720
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.1-h7b32b05_0.conda
+  sha256: cbf62df3c79a5c2d113247ddea5658e9ff3697b6e741c210656e239ecaf1768f
+  md5: 41adf927e746dc75ecf0ef841c454e48
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 2939306
+  timestamp: 1739301879343
+- conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.3-h12ee42a_2.conda
+  sha256: dff5cc8023905782c86b3459055f26d4b97890e403b0698477c9fed15d8669cc
+  md5: 4f6f9f3f80354ad185e276c120eac3f0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libprotobuf >=5.28.3,<5.28.4.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1188881
+  timestamp: 1735630209320
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py311h7db5c69_1.conda
+  sha256: dce121d3838996b77b810ca9097cc17068552075c761408a9b2eb788cf8fd1b0
+  md5: 643f8cb35133eb1be4919fb953f0a25f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15695466
+  timestamp: 1726879158862
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.1.0-py311h1322bbf_0.conda
+  sha256: 71e0ce18201695adec3bbbfbab74e82b0ab05fe8929ad046d2c507a71c8a3c63
+  md5: 9f4f5593335f76c1dbf7381c11fe7155
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.5.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.3,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 42021920
+  timestamp: 1735929841160
+- conda: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
+  sha256: 013669433eb447548f21c3c6b16b2ed64356f726b5f77c1b39d5ba17a8a4b8bc
+  md5: a83f6a2fdc079e643237887a37460668
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 199544
+  timestamp: 1730769112346
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.0.0-py311h9ecbd09_0.conda
+  sha256: 50d0944b59a9c6dfa6b99cc2632bf8bc9bef9c7c93710390ded6eac953f0182d
+  md5: 1a390a54b2752169f5ba4ada5a8108e4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 484778
+  timestamp: 1740663319335
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+  sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
+  md5: b3c17d95b5a10c6e64a21fa17573e70e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 8252
+  timestamp: 1726802366959
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-19.0.1-py311h38be061_0.conda
+  sha256: fedc7ab62fff534034134c7c6c8c6f85ce13d74581172d892602c6613b140b12
+  md5: fd25bdbbb08557c2fab04b26926a8c5c
+  depends:
+  - libarrow-acero 19.0.1.*
+  - libarrow-dataset 19.0.1.*
+  - libarrow-substrait 19.0.1.*
+  - libparquet 19.0.1.*
+  - pyarrow-core 19.0.1 *_0_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25284
+  timestamp: 1739792270070
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-19.0.1-py311h4854187_0_cpu.conda
+  sha256: 21dbc93641f1ffc84b04ecb7ff1419d497ba0f895b55c1f3bc06cca940f4b986
+  md5: f7912063df377c356b223f386e88cb2a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 19.0.1.* *cpu
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - numpy >=1.21,<3
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4727390
+  timestamp: 1739792249060
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.11-h9e4cc4f_1_cpython.conda
+  sha256: b29ce0836fce55bdff8d5c5b71c4921a23f87d3b950aea89a9e75784120b06b0
+  md5: 8387070aa413ce9a8cc35a509fae938b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.6.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - liblzma >=5.6.3,<6.0a0
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.4.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 30624804
+  timestamp: 1733409665928
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
+  sha256: 2660b8059b3ee854bc5d3c6b1fce946e5bd2fe8fbca7827de2c5885ead6209de
+  md5: 139a8d40c8a2f430df31048949e450de
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6211
+  timestamp: 1723823324668
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h2dc5d0c_2.conda
+  sha256: d107ad62ed5c62764fba9400f2c423d89adf917d687c7f2e56c3bfed605fb5b3
+  md5: 014417753f948da1f70d132b2de573be
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 213136
+  timestamp: 1737454846598
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.1-py311h7deb3e3_0.conda
+  sha256: bd6309ef4629744aaaccd9b33d6389dfe879e9864386137e6e4ecc7e1b9ed0f3
+  md5: 52457fbaa0aef8136d5dd7bb8a36db9e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 392547
+  timestamp: 1738271109731
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+  sha256: 776363493bad83308ba30bcb88c2552632581b143e8ee25b1982c8c743e73abc
+  md5: 353823361b1d27eb3960efb076dfcaf6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-Qhull
+  size: 552937
+  timestamp: 1720813982144
+- conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h9925aae_2.conda
+  sha256: d213c44958d49ce7e0d4d5b81afec23640cce5016685dbb2d23571a99caa4474
+  md5: e84ddf12bde691e8ec894b00ea829ddf
+  depends:
+  - libre2-11 2024.07.02 hbbce691_2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26786
+  timestamp: 1735541074034
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
+  sha256: 2d6d0c026902561ed77cd646b5021aef2d4db22e57a5b0178dfc669231e06d2c
+  md5: 283b96675859b20a825f8fa30f311446
+  depends:
+  - libgcc >=13
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 282480
+  timestamp: 1740379431762
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.23.1-py311h687327b_0.conda
+  sha256: 754d8eff118a6a01f4eb0e8bc6be7be8872f54826d6ff0402eac08d308b01099
+  md5: d35b446856b4d6644a469fd01838baff
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  size: 391827
+  timestamp: 1740153282893
+- conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.11-h072c03f_0.conda
+  sha256: cfdd98c8f9a1e5b6f9abce5dac6d590cc9fe541a08466c9e4a26f90e00b569e3
+  md5: 5e8060d52f676a40edef0006a75c718f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 356213
+  timestamp: 1737146304079
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.15.2-py311h8f841c2_0.conda
+  sha256: 6d0902775e3ff96dd1d36ac627e03fe6c0b3d2159bb71e115dd16a1f31693b25
+  md5: 5ec0a1732a05376241e1e4c6d50e0e91
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=13
+  - numpy <2.5
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17193126
+  timestamp: 1739791897768
+- conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-h8bd8927_1.conda
+  sha256: ec91e86eeb2c6bbf09d51351b851e945185d70661d2ada67204c9a6419d282d3
+  md5: 3b3e64af585eadfb52bb90b553db5edf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42739
+  timestamp: 1733501881851
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+  sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
+  md5: d453b98d9c83e71da0741bb0ff4d76bc
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3318875
+  timestamp: 1699202167581
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.2-py311h9ecbd09_0.conda
+  sha256: afa3489113154b5cb0724b0bf120b62df91f426dabfe5d02f2ba09e90d346b28
+  md5: df3aee9c3e44489257a840b8354e77b9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 855653
+  timestamp: 1732616048886
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-16.0.0-py311h9ecbd09_0.conda
+  sha256: e786fb0925515fffc83e393d2a0e2814eaf9be8a434f1982b399841a2c07980b
+  md5: 51a12678b609f5794985fda8372b1a49
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 405017
+  timestamp: 1736692662280
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb9d3cd8_0.conda
+  sha256: ed10c9283974d311855ae08a16dfd7e56241fac632aec3b92e3cfe73cff31038
+  md5: f6ebe2cb3f82ba6c057dde5d9debe4f7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 14780
+  timestamp: 1734229004433
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+  sha256: 6b250f3e59db07c2514057944a3ea2044d6a8cdde8a47b6497c254520fade1ee
+  md5: 8035c64cb77ed555e3f150b7b3972480
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 19901
+  timestamp: 1727794976192
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+  sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
+  md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 89141
+  timestamp: 1641346969816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_7.conda
+  sha256: a4dc72c96848f764bb5a5176aa93dd1e9b9e52804137b99daeebba277b31ea10
+  md5: 3947a35e916fcc6b9825449affbf4214
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - libstdcxx >=13
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 335400
+  timestamp: 1731585026517
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+  sha256: 5d7c0e5f0005f74112a34a7425179f4eb6e73c92f5d109e6af4ddeca407c92ab
+  md5: c9f075ab2f33b3bbee9e62d4ad0a6cd8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib 1.3.1 hb9d3cd8_2
+  license: Zlib
+  license_family: Other
+  size: 92286
+  timestamp: 1727963153079
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.19.0-py311hd4cff14_0.tar.bz2
+  sha256: 8aac43cc4fbdcc420fe8a22c764b67f6ac9168b103bfd10d79a82b748304ddf6
+  md5: 056b3271f46abaa4673c8c6783283a07
+  depends:
+  - cffi >=1.8
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 696792
+  timestamp: 1667296297763
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_1.conda
+  sha256: 532d3623961e34c53aba98db2ad0a33b7a52ff90d6960e505fb2d2efc06bb7da
+  md5: 02e4e2fa41a6528afba2e54cbc4280ff
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 567419
+  timestamp: 1740255350233
+- conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
+  sha256: f1455d2953e3eb6d71bc49881c8558d8e01888469dfd21061dd48afb6183e836
+  md5: 848d25bfbadf020ee4d4ba90e5668252
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.9
+  - sniffio >=1.1
+  - typing_extensions >=4.5
+  constrains:
+  - trio >=0.26.1
+  - uvloop >=0.21
+  license: MIT
+  license_family: MIT
+  size: 115305
+  timestamp: 1736174485476
+- conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
+  sha256: 8f032b140ea4159806e4969a68b4a3c0a7cab1ad936eb958a2b5ffe5335e19bf
+  md5: 54898d0f524c9dee622d44bbb081a8ab
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 10076
+  timestamp: 1733332433806
+- conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
+  sha256: 7af62339394986bc470a7a231c7f37ad0173ffb41f6bc0e8e31b0be9e3b9d20f
+  md5: a7ee488b71c30ada51c48468337b85ba
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.9
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 18594
+  timestamp: 1733311166338
+- conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_1.conda
+  sha256: c4b0bdb3d5dee50b60db92f99da3e4c524d5240aafc0a5fcc15e45ae2d1a3cd1
+  md5: 46b53236fdd990271b03c3978d4218a9
+  depends:
+  - python >=3.9
+  - python-dateutil >=2.7.0
+  - types-python-dateutil >=2.8.10
+  license: Apache-2.0
+  license_family: Apache
+  size: 99951
+  timestamp: 1733584345583
+- conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+  sha256: 93b14414b3b3ed91e286e1cbe4e7a60c4e1b1c730b0814d1e452a8ac4b9af593
+  md5: 8f587de4bcf981e26228f268df374a9b
+  depends:
+  - python >=3.9
+  constrains:
+  - astroid >=2,<4
+  license: Apache-2.0
+  license_family: Apache
+  size: 28206
+  timestamp: 1733250564754
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.1.0-pyh71513ae_0.conda
+  sha256: 1f267886522dfb9ae4e5ebbc3135b5eb13cff27bdbfe8d881a4d893459166ab4
+  md5: 2cc3f588512f04f3a0c64b4e9bedc02d
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 56370
+  timestamp: 1737819298139
+- conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.13.3-pyha770c72_0.conda
+  sha256: 4ce42860292a57867cfc81a5d261fb9886fc709a34eca52164cc8bbf6d03de9f
+  md5: 373374a3ed20141090504031dc7b693e
+  depends:
+  - python >=3.9
+  - soupsieve >=1.2
+  - typing-extensions
+  license: MIT
+  license_family: MIT
+  size: 145482
+  timestamp: 1738740460562
+- conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyh29332c3_4.conda
+  sha256: a05971bb80cca50ce9977aad3f7fc053e54ea7d5321523efc7b9a6e12901d3cd
+  md5: f0b4c8e370446ef89797608d60a564b3
+  depends:
+  - python >=3.9
+  - webencodings
+  - python
+  constrains:
+  - tinycss >=1.1.0,<1.5
+  license: Apache-2.0 AND MIT
+  size: 141405
+  timestamp: 1737382993425
+- conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.2.0-h82add2a_4.conda
+  sha256: 0aba699344275b3972bd751f9403316edea2ceb942db12f9f493b63c74774a46
+  md5: a30e9406c873940383555af4c873220d
+  depends:
+  - bleach ==6.2.0 pyh29332c3_4
+  - tinycss2
+  license: Apache-2.0 AND MIT
+  size: 4213
+  timestamp: 1737382993425
+- conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.3-pyhd8ed1ab_0.conda
+  sha256: 6cc6841b1660cd3246890d4f601baf51367526afe6256dfd8a8d9a8f7db651fe
+  md5: 606498329a91bd9d5c0439fb2815816f
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.10
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4524790
+  timestamp: 1738843545439
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+  sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
+  md5: 9b347a7ec10940d3f7941ff6c460b551
+  depends:
+  - cached_property >=1.5.2,<1.5.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4134
+  timestamp: 1615209571450
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+  sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+  md5: 576d629e47797577ab0f1b351297ef4a
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11065
+  timestamp: 1615209567874
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.1.31-pyhd8ed1ab_0.conda
+  sha256: 42a78446da06a2568cb13e69be3355169fbd0ea424b00fc80b7d840f5baaacf3
+  md5: c207fa5ac7ea99b149344385a9c0880d
+  depends:
+  - python >=3.9
+  license: ISC
+  size: 162721
+  timestamp: 1739515973129
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.1-pyhd8ed1ab_0.conda
+  sha256: 4e0ee91b97e5de3e74567bdacea27f0139709fceca4db8adffbe24deffccb09b
+  md5: e83a31202d1c0a000fce3e9cf3825875
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 47438
+  timestamp: 1735929811779
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+  sha256: c920d23cd1fcf565031c679adb62d848af60d6fbb0edc2d50ba475cea4f0d8ab
+  md5: f22f4d4970e09d68a10b922cbb0408d3
+  depends:
+  - __unix
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84705
+  timestamp: 1734858922844
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh7428d3b_0.conda
+  sha256: c889ed359ae47eead4ffe8927b7206b22c55e67d6e74a9044c23736919d61e8d
+  md5: 90e5571556f7a45db92ee51cb8f97af6
+  depends:
+  - __win
+  - colorama
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 85169
+  timestamp: 1734858972635
+- conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.1-pyhd8ed1ab_0.conda
+  sha256: 21ecead7268241007bf65691610cd7314da68c1f88113092af690203b5780db5
+  md5: 364ba6c9fb03886ac979b482f39ebb92
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25870
+  timestamp: 1736947650712
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
+  md5: 962b9857ee8e7018c22f2776ffa0b2d7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27011
+  timestamp: 1733218222191
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_1.conda
+  sha256: 46055a0524ed3a48b23cd27a52246c89ac059ccce90a50b2eeb84d2f833ae827
+  md5: 91d7152c744dc0f18ef8beb3cbc9980a
+  depends:
+  - python >=3.9
+  license: CC-BY-4.0
+  size: 173950
+  timestamp: 1734007415513
+- conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_1.conda
+  sha256: 7e87ef7c91574d9fac19faedaaee328a70f718c9b4ddadfdc0ba9ac021bd64af
+  md5: 74673132601ec2b7fc592755605f4c1b
+  depends:
+  - python >=3.9
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12103
+  timestamp: 1733503053903
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.11-py311hd8ed1ab_1.conda
+  sha256: b9bb4486ba7b81d7264e92f346c9fa2d4a6c9678c28b33fb5d1652ecc7f82e26
+  md5: 6aab9c45010dc5ed92215f89cdafa201
+  depends:
+  - python 3.11.11.*
+  - python_abi * *_cp311
+  license: Python-2.0
+  size: 46068
+  timestamp: 1733407866862
+- conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+  sha256: 9827efa891e507a91a8a2acf64e210d2aff394e1cde432ad08e1f8c66b12293c
+  md5: 44600c4667a319d67dbe0681fc0bc833
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13399
+  timestamp: 1733332563512
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-2025.2.0-pyhd8ed1ab_0.conda
+  sha256: 8be4982c98f4829a92b690dd47f516474d8e69d00f992bbf89764e08d535b679
+  md5: 60455cddc5f868d7ad37a504ff4ffd37
+  depends:
+  - bokeh >=3.1.0
+  - cytoolz >=0.11.0
+  - dask-core >=2025.2.0,<2025.2.1.0a0
+  - distributed >=2025.2.0,<2025.2.1.0a0
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.24
+  - pandas >=2.0
+  - pyarrow >=14.0.1
+  - python >=3.10
+  constrains:
+  - openssl !=1.1.1e
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7598
+  timestamp: 1739495288724
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2025.2.0-pyhd8ed1ab_0.conda
+  sha256: 22ae6c5125a08cfe6569eb729900ba7fb96320e66fe08de1c32f1191eb7e08af
+  md5: 3bc22d25e3ee83d709804a2040b4463c
+  depends:
+  - click >=8.1
+  - cloudpickle >=3.0.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.4.0
+  - python >=3.10
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 968347
+  timestamp: 1739488681467
+- conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.17.0-pyhd8ed1ab_0.conda
+  sha256: 85b1ba89064501b4ae9695aeb819db4acfec74cd3acbb56df11c93b91ac0cbd4
+  md5: e7511f05f4938cb0d988026507fed69a
+  depends:
+  - colorcet
+  - multipledispatch
+  - numba
+  - numpy
+  - packaging
+  - pandas
+  - param
+  - pyct
+  - python >=3.10
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17226809
+  timestamp: 1738222917452
+- conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
+  sha256: c17c6b9937c08ad63cb20a26f403a3234088e57d4455600974a0ce865cb14017
+  md5: 9ce473d1d1be1cc3810856a48b3fab32
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14129
+  timestamp: 1740385067843
+- conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
+  md5: 961b3a227b437d82ad7054484cfa71b2
+  depends:
+  - python >=3.6
+  license: PSF-2.0
+  license_family: PSF
+  size: 24062
+  timestamp: 1615232388757
+- conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2025.2.0-pyhd8ed1ab_0.conda
+  sha256: ccac7437df729ea2f249aef22b6e412ea7c63722cc094c4708d35453518b5c6d
+  md5: 54562a2b30c8f357097e2be75295601e
+  depends:
+  - click >=8.0
+  - cloudpickle >=3.0.0
+  - cytoolz >=0.11.2
+  - dask-core >=2025.2.0,<2025.2.1.0a0
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.2
+  - packaging >=20.0
+  - psutil >=5.8.0
+  - python >=3.10
+  - pyyaml >=5.4.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.11.2
+  - tornado >=6.2.0
+  - urllib3 >=1.26.5
+  - zict >=3.0.0
+  constrains:
+  - openssl !=1.1.1e
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 800317
+  timestamp: 1739491744587
+- conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+  sha256: 80f579bfc71b3dab5bef74114b89e26c85cb0df8caf4c27ab5ffc16363d57ee7
+  md5: 3366592d3c219f2731721f11bc93755c
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 11259
+  timestamp: 1733327239578
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+  sha256: cbde2c64ec317118fc06b223c5fd87c8a680255e7348dd60e7b292d2e103e701
+  md5: a16662747cdeb9abbac74d0057cc976e
+  depends:
+  - python >=3.9
+  license: MIT and PSF-2.0
+  size: 20486
+  timestamp: 1733208916977
+- conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_1.conda
+  sha256: 28d25ea375ebab4bf7479228f8430db20986187b04999136ff5c722ebd32eb60
+  md5: ef8b5fca76806159fc25b4f48d8737eb
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 28348
+  timestamp: 1733569440265
+- conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+  sha256: 2509992ec2fd38ab27c7cdb42cf6cadc566a1cc0d1021a2673475d9fa87c6276
+  md5: d3549fd50d450b6d9e7dddff25dd2110
+  depends:
+  - cached-property >=1.3.0
+  - python >=3.9,<4
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 16705
+  timestamp: 1733327494780
+- conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.2.0-pyhd8ed1ab_0.conda
+  sha256: 7433b8469074985b651693778ec6f03d2a23fad9919a515e3b8545996b5e721a
+  md5: d9ea16b71920b03beafc17fcca16df90
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 138186
+  timestamp: 1738501352608
+- conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.2.0-pyhd8ed1ab_0.conda
+  sha256: 0aa1cdc67a9fe75ea95b5644b734a756200d6ec9d0dff66530aec3d1c1e9df75
+  md5: b4754fb1bdcb70c8fd54f918301582c6
+  depends:
+  - hpack >=4.1,<5
+  - hyperframe >=6.1,<7
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 53888
+  timestamp: 1738578623567
+- conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.1-pyhd8ed1ab_0.conda
+  sha256: bf28b371fad75d6627b2fb4a37f6b5036e2197753355f40c6c5d450a32f8f680
+  md5: 995a8f8782e4b572141e77d0c7e0ff1e
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.9
+  - pyviz_comms >=2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3996135
+  timestamp: 1739986603096
+- conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+  sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+  md5: 0a802cb9888dd14eeefc611f05c40b6e
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 30731
+  timestamp: 1737618390337
+- conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.2-pyhd8ed1ab_0.conda
+  sha256: cc4367490e9f159d4fc91a2aecb12e37621fe38c0a9c244d3086f11a35a3186b
+  md5: a8143fe7133f43b62a96a77455c30ffe
+  depends:
+  - bokeh >=3.1
+  - colorcet >=2
+  - holoviews >=1.19.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 247667
+  timestamp: 1734388824728
+- conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+  sha256: 77af6f5fe8b62ca07d09ac60127a30d9069fdc3c68d6b256754d0ffb1f7779f8
+  md5: 8e6923fc12f1fe8f8c4e5c9f343256ac
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 17397
+  timestamp: 1737618427549
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+  sha256: d7a472c9fd479e2e8dcb83fb8d433fce971ea369d704ece380e876f9c3494e87
+  md5: 39a4f67be3286c86d696df570b1201b7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49765
+  timestamp: 1733211921194
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.6.1-pyha770c72_0.conda
+  sha256: 598951ebdb23e25e4cec4bbff0ae369cec65ead80b50bc08b441d8e54de5cf03
+  md5: f4b39bf00c69f56ac01e020ebfac066c
+  depends:
+  - python >=3.9
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 29141
+  timestamp: 1737420302391
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
+  sha256: acc1d991837c0afb67c75b77fdc72b4bf022aac71fedd8b9ea45918ac9b08a80
+  md5: c85c76dc67d75619a92f51dfbce06992
+  depends:
+  - python >=3.9
+  - zipp >=3.1.0
+  constrains:
+  - importlib-resources >=6.5.2,<6.5.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 33781
+  timestamp: 1736252433366
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+  sha256: 33cfd339bb4efac56edf93474b37ddc049e08b1b4930cf036c893cc1f5a1f32a
+  md5: b40131ab6a36ac2c09b7c57d4d3fbf99
+  depends:
+  - __linux
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119084
+  timestamp: 1719845605084
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+  sha256: dc569094125127c0078aa536f78733f383dd7e09507277ef8bcd1789786e7086
+  md5: 18df5fc4944a679e085e0e8f31775fc8
+  depends:
+  - __win
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119853
+  timestamp: 1719845858082
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+  sha256: 072534d4d379225b2c3a4e38bc7730b65ae171ac7f0c2d401141043336e97980
+  md5: 9eb15d654daa0ef5a98802f586bb4ffc
+  depends:
+  - __osx
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119568
+  timestamp: 1719845667420
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.32.0-pyh907856f_0.conda
+  sha256: b1b940cfe85d5f0aaed83ef8c9f07ee80daa68acb05feeb5142d620472b01e0d
+  md5: 9de86472b8f207fb098c69daaad50e67
+  depends:
+  - __unix
+  - pexpect >4.3
+  - python >=3.10
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 636676
+  timestamp: 1738421264236
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.32.0-pyh9ab4c32_0.conda
+  sha256: 970b10688d376dd7a9963478e78f80d62708df73b368fed9295ef100a99b6b04
+  md5: e34c8a3475d6e2743f4f5093a39004fd
+  depends:
+  - __win
+  - colorama
+  - python >=3.10
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 636000
+  timestamp: 1738421304330
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_2.conda
+  sha256: 45821a8986b4cb2421f766b240dbe6998a3c3123f012dd566720c1322e9b6e18
+  md5: 2f0ba4bc12af346bc6c99bdc377e8944
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28153
+  timestamp: 1733399692864
+- conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+  sha256: 08e838d29c134a7684bca0468401d26840f41c92267c4126d7b43a6b533b0aed
+  md5: 0b0154421989637d424ccf0f104be51a
+  depends:
+  - arrow >=0.15.0
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 19832
+  timestamp: 1733493720346
+- conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+  sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+  md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.9
+  license: Apache-2.0 AND MIT
+  size: 843646
+  timestamp: 1733300981994
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.5-pyhd8ed1ab_0.conda
+  sha256: 98977694b9ecaa3218662f843425f39501f81973c450f995eec68f1803ed71c3
+  md5: 2752a6ed44105bfb18c9bef1177d9dcd
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 112561
+  timestamp: 1734824044952
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_1.conda
+  sha256: be992a99e589146f229c58fe5083e0b60551d774511c494f91fe011931bd7893
+  md5: a3cead9264b331b32fe8f0aabc967522
+  depends:
+  - attrs >=22.2.0
+  - importlib_resources >=1.4.0
+  - jsonschema-specifications >=2023.03.6
+  - pkgutil-resolve-name >=1.3.10
+  - python >=3.9
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 74256
+  timestamp: 1733472818764
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_1.conda
+  sha256: 37127133837444cf0e6d1a95ff5a505f8214ed4e89e8e9343284840e674c6891
+  md5: 3b519bc21bc80e60b456f1e62962a766
+  depends:
+  - python >=3.9
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 16170
+  timestamp: 1733493624968
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_1.conda
+  sha256: 6e0184530011961a0802fda100ecdfd4b0eca634ed94c37e553b72e21c26627d
+  md5: a5b1a8065857cc4bd8b7a38d063bb728
+  depends:
+  - fqdn
+  - idna
+  - isoduration
+  - jsonpointer >1.13
+  - jsonschema >=4.23.0,<4.23.1.0a0
+  - rfc3339-validator
+  - rfc3986-validator >0.1.0
+  - uri-template
+  - webcolors >=24.6.0
+  license: MIT
+  license_family: MIT
+  size: 7135
+  timestamp: 1733472820035
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+  sha256: 38e67f3e0d631f4aeeab4bbd4062dcb6f4ae9dc35803053c995d02912a999b65
+  md5: 5cbf9a31a19d4ef9103adb7d71fd45fd
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.7
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99449
+  timestamp: 1673616104031
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+  sha256: 732b1e8536bc22a5a174baa79842d79db2f4956d90293dd82dc1b3f6099bcccd
+  md5: 0a2980dada0dd7fd0998f0342308b1b1
+  depends:
+  - __unix
+  - platformdirs >=2.5
+  - python >=3.8
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 57671
+  timestamp: 1727163547058
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh5737063_1.conda
+  sha256: 7c903b2d62414c3e8da1f78db21f45b98de387aae195f8ca959794113ba4b3fd
+  md5: 46d87d1c0ea5da0aae36f77fa406e20d
+  depends:
+  - __win
+  - cpython
+  - platformdirs >=2.5
+  - python >=3.8
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 58269
+  timestamp: 1727164026641
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.0-pyh29332c3_0.conda
+  sha256: 37e6ac3ccf7afcc730c3b93cb91a13b9ae827fd306f35dd28f958a74a14878b5
+  md5: f56000b36f09ab7533877e695e4e8cb0
+  depends:
+  - jsonschema-with-format-nongpl >=4.18.0
+  - packaging
+  - python >=3.9
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23647
+  timestamp: 1738765986736
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.15.0-pyhd8ed1ab_0.conda
+  sha256: be5f9774065d94c4a988f53812b83b67618bec33fcaaa005a98067d506613f8a
+  md5: 6ba8c206b5c6f52b82435056cf74ee46
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.11.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert-core >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.9
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 327747
+  timestamp: 1734702771032
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+  sha256: 0890fc79422191bc29edf17d7b42cff44ba254aa225d31eb30819f8772b775b8
+  md5: 2d983ff1b82a1ccb6f2e9d8784bdd6bd
+  depends:
+  - python >=3.9
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19711
+  timestamp: 1733428049134
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+  sha256: dc24b900742fdaf1e077d9a3458fd865711de80bca95fe3c6d46610c532c6ef0
+  md5: fd312693df06da3578383232528c468d
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.9
+  constrains:
+  - jupyterlab >=4.0.8,<5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18711
+  timestamp: 1733328194037
+- conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_1.conda
+  sha256: d975a2015803d4fdaaae3f53e21f64996577d7a069eb61c6d2792504f16eb57b
+  md5: b02fe519b5dc0dc55e7299810fcdfb8e
+  depends:
+  - python >=3.9
+  - uc-micro-py
+  license: MIT
+  license_family: MIT
+  size: 24154
+  timestamp: 1733781296133
+- conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
+  md5: 91e27ef3d05cc772ce627e51cff111c4
+  depends:
+  - python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 8250
+  timestamp: 1650660473123
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+  sha256: fce1fde00359696983989699c00f9891194c4ebafea647a8d21b7e2e3329b56e
+  md5: 06e9bebf748a0dea03ecbe1f0e27e909
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78331
+  timestamp: 1710435316163
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+  sha256: 0fbacdfb31e55964152b24d5567e9a9996e1e7902fb08eb7d91b5fd6ce60803a
+  md5: fee3164ac23dfca50cfcc8b85ddefb81
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 64430
+  timestamp: 1733250550053
+- conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+  sha256: 69b7dc7131703d3d60da9b0faa6dd8acbf6f6c396224cf6aef3e855b8c0c41c6
+  md5: af6ab708897df59bd6e7283ceab1b56b
+  depends:
+  - python >=3.9
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14467
+  timestamp: 1733417051523
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_1.conda
+  sha256: c63ed79d9745109c0a70397713b0c07f06e7d3561abcb122cfc80a141ab3b449
+  md5: af2060041d4f3250a7eb6ab3ec0e549b
+  depends:
+  - markdown-it-py >=1.0.0,<4.0.0
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 42180
+  timestamp: 1733854816517
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+  sha256: 78c1bbe1723449c52b7a9df1af2ee5f005209f67e40b6e1d3c7619127c43b1c7
+  md5: 592132998493b3ff25fd7479396e8351
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 14465
+  timestamp: 1733255681319
+- conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.1.2-pyhd8ed1ab_0.conda
+  sha256: 63d5308ac732b2f8130702c83ee40ce31c5451ebcb6e70075b771cc8f7df0156
+  md5: 0982b0f06168fe3421d09f70596ca1f0
+  depends:
+  - python >=3.9
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 68903
+  timestamp: 1739952304731
+- conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+  sha256: c6216a21154373b340c64f321f22fec51db4ee6156c2e642fa58368103ac5d09
+  md5: 121a57fce7fff0857ec70fa03200962f
+  depends:
+  - python >=3.6
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17254
+  timestamp: 1721907640382
+- conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+  sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
+  md5: 2ba8498c1018c1e9c61eb99b973dfe19
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12452
+  timestamp: 1600387789153
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.2.0-pyhd8ed1ab_0.conda
+  sha256: ed917b37260bb75fc3de2f9e27b404cf32336a51615d63b411da1dfea620d80d
+  md5: abc7d3f122281a59dbbfec4a5823e11f
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5782458
+  timestamp: 1736947321807
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
+  sha256: a20cff739d66c2f89f413e4ba4c6f6b59c50d5c30b5f0d840c13e8c9c2df9135
+  md5: 6bb0d77277061742744176ab555b723c
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.8
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28045
+  timestamp: 1734628936013
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
+  sha256: dcccb07c5a1acb7dc8be94330e62d54754c0e9c9cb2bb6865c8e3cfe44cf5a58
+  md5: d24beda1d30748afcc87c429454ece1b
+  depends:
+  - beautifulsoup4
+  - bleach-with-css !=5.0.0
+  - defusedxml
+  - importlib-metadata >=3.6
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9
+  - traitlets >=5.1
+  - python
+  constrains:
+  - pandoc >=2.9.2,<4.0.0
+  - nbconvert ==7.16.6 *_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 200601
+  timestamp: 1738067871724
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+  sha256: 7a5bd30a2e7ddd7b85031a5e2e14f290898098dc85bea5b3a5bf147c25122838
+  md5: bbe1963f1e47f594070ffe87cdf612ea
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.9
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100945
+  timestamp: 1733402844974
+- conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+  sha256: bb7b21d7fd0445ddc0631f64e66d91a179de4ba920b8381f29b9d006a42788c0
+  md5: 598fd7d4d0de2455fb74f56063969a97
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11543
+  timestamp: 1733325673691
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+  sha256: e37db45223e432bcad809897177e05fff31828dfcfc3ef18f046ae44ec01286c
+  md5: f81a6fe643390df9347984644727d796
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert-core >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.7
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 308643
+  timestamp: 1715849037288
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+  sha256: 7b920e46b9f7a2d2aa6434222e5c8d739021dbc5cc75f32d124a8191d86f9056
+  md5: e7f89ea5f7ea9401642758ff50a2d9c1
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16817
+  timestamp: 1733408419340
+- conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+  sha256: 1840bd90d25d4930d60f57b4f38d4e0ae3f5b8db2819638709c36098c6ba770c
+  md5: e51f1e4089cad105b6cac64bd8166587
+  depends:
+  - python >=3.9
+  - typing_utils
+  license: Apache-2.0
+  license_family: APACHE
+  size: 30139
+  timestamp: 1734587755455
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+  sha256: da157b19bcd398b9804c5c52fc000fcb8ab0525bdb9c70f95beaa0bb42f85af1
+  md5: 3bfed7e6228ebf2f7b9eaa47f1b4e2aa
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: APACHE
+  size: 60164
+  timestamp: 1733203368787
+- conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
+  md5: 457c2c8c08e54905d6954e79cb5b5db9
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11627
+  timestamp: 1631603397334
+- conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.6.1-pyhd8ed1ab_0.conda
+  sha256: 2decd60c2276d818ca23b134491644fe067746e11dc1501dfdafc3e523564a3c
+  md5: e52807f99bbd86f6aef02c1c954fc1c1
+  depends:
+  - bleach
+  - bokeh >=3.5.0,<3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.1.0,<3.0
+  - python >=3.10
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21525119
+  timestamp: 1739557836573
+- conda: https://conda.anaconda.org/conda-forge/noarch/param-2.2.0-pyhd8ed1ab_0.conda
+  sha256: 857c0e09b51d5c81d5a2144d4a5bd3dc15f81a52f1bf3da9290baff3deae6b5d
+  md5: 8bd46aebe85bd9c5f30affd520ab441f
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104754
+  timestamp: 1734441144421
+- conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
+  sha256: 17131120c10401a99205fc6fe436e7903c0fa092f1b3e80452927ab377239bcc
+  md5: 5c092057b6badd30f75b06244ecd01c9
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 75295
+  timestamp: 1733271352153
+- conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+  sha256: 472fc587c63ec4f6eba0cc0b06008a6371e0a08a5986de3cf4e8024a47b4fe6c
+  md5: 0badf9c54e24cecfb0ad2f99d680c163
+  depends:
+  - locket
+  - python >=3.9
+  - toolz
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20884
+  timestamp: 1715026639309
+- conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+  sha256: 202af1de83b585d36445dc1fda94266697341994d1a3328fabde4989e1b3d07a
+  md5: d0d408b1f18883a944376da5cf8101ea
+  depends:
+  - ptyprocess >=0.5
+  - python >=3.9
+  license: ISC
+  size: 53561
+  timestamp: 1733302019362
+- conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+  sha256: e2ac3d66c367dada209fc6da43e645672364b9fd5f9d28b9f016e24b81af475b
+  md5: 11a9d1d09a3615fc07c3faf79bc0b943
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 11748
+  timestamp: 1733327448200
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.0.1-pyh8b19718_0.conda
+  sha256: 585940f09d87787f79f73ff5dff8eb2af8a67e5bec5eebf2f553cd26c840ba69
+  md5: 79b5c1440aedc5010f687048d9103628
+  depends:
+  - python >=3.9,<3.13.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 1256460
+  timestamp: 1739142857253
+- conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+  sha256: adb2dde5b4f7da70ae81309cce6188ed3286ff280355cf1931b45d91164d2ad8
+  md5: 5a5870a74432aa332f7d32180633ad05
+  depends:
+  - python >=3.9
+  license: MIT AND PSF-2.0
+  size: 10693
+  timestamp: 1733344619659
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+  sha256: bb50f6499e8bc1d1a26f17716c97984671121608dc0c3ecd34858112bce59a27
+  md5: 577852c7e53901ddccc7e6a9959ddebe
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 20448
+  timestamp: 1733232756001
+- conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.1-pyhd8ed1ab_0.conda
+  sha256: bc8f00d5155deb7b47702cb8370f233935704100dbc23e30747c161d1b6cf3ab
+  md5: 3e01e386307acc60b2f89af0b2e161aa
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  size: 49002
+  timestamp: 1733327434163
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.50-pyha770c72_0.conda
+  sha256: 0749c49a349bf55b8539ce5addce559b77592165da622944a51c630e94d97889
+  md5: 7d823138f550b14ecae927a5ff3286de
+  depends:
+  - python >=3.9
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.50
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 271905
+  timestamp: 1737453457168
+- conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+  sha256: a7713dfe30faf17508ec359e0bc7e0983f5d94682492469bd462cdaae9c64d83
+  md5: 7d9daffbb8d8e0af0f769dbbcd173a54
+  depends:
+  - python >=3.9
+  license: ISC
+  size: 19457
+  timestamp: 1733302371990
+- conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+  sha256: 71bd24600d14bb171a6321d523486f6a06f855e75e547fa0cb2a0953b02047f0
+  md5: 3bfdfb8dbcdc4af1ae3f9a8eb3948f04
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 16668
+  timestamp: 1733569518868
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+  sha256: 79db7928d13fab2d892592223d7570f5061c192f27b9febd1a418427b719acc6
+  md5: 12c566707c80111f9799308d9e265aef
+  depends:
+  - python >=3.9
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110100
+  timestamp: 1733195786147
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_1.conda
+  sha256: 456d1fb91e00ea0b55efa63c64d80b18489b0b71bffaa72c7a19bed0c637b9f4
+  md5: dcd4770a9dff3c3bb2e21cb0108af3d0
+  depends:
+  - param >=1.7.0
+  - python >=3.9
+  - pyyaml
+  - requests
+  - setuptools >=61.0
+  constrains:
+  - pyct-core <0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20171
+  timestamp: 1734342620392
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.1-pyhd8ed1ab_0.conda
+  sha256: 28a3e3161390a9d23bc02b4419448f8d27679d9e2c250e29849e37749c8de86b
+  md5: 232fb4577b6687b2d503ef8e254270c9
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 888600
+  timestamp: 1736243563082
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.1-pyhd8ed1ab_0.conda
+  sha256: f513fed4001fd228d3bf386269237b4ca6bff732c99ffc11fcbad8529b35407c
+  md5: 285e237b8f351e85e7574a2c7bfa6d46
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 93082
+  timestamp: 1735698406955
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
+  sha256: d016e04b0e12063fbee4a2d5fbb9b39a8d191b5a0042f0b8459188aedeabb0ca
+  md5: e2fd202833c4a981ce8a65974fe4abd1
+  depends:
+  - __win
+  - python >=3.9
+  - win_inet_pton
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21784
+  timestamp: 1733217448189
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+  sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
+  md5: 461219d1a5bd61342293efa2c0c90eac
+  depends:
+  - __unix
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21085
+  timestamp: 1733217331982
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+  sha256: a50052536f1ef8516ed11a844f9413661829aa083304dc624c5925298d078d79
+  md5: 5ba79d7c71f03c678c8ead841f347d6e
+  depends:
+  - python >=3.9
+  - six >=1.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 222505
+  timestamp: 1733215763718
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+  sha256: 1b09a28093071c1874862422696429d0d35bd0b8420698003ac004746c5e82a2
+  md5: 38e34d2d1d9dca4fb2b9a0a04f604e2c
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 226259
+  timestamp: 1733236073335
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+  sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
+  md5: a61bf9ec79426938ff785eb69dbb1960
+  depends:
+  - python >=3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13383
+  timestamp: 1677079727691
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.1-pyhd8ed1ab_0.conda
+  sha256: 1597d6055d34e709ab8915091973552a0b8764c8032ede07c4e99670da029629
+  md5: 392c91c42edd569a7ec99ed8648f597a
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 143794
+  timestamp: 1737541204030
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+  sha256: 1a7d6b233f7e6e3bbcbad054c8fd51e690a67b129a899a056a5e45dd9f00cb41
+  md5: 3eeeeb9e4827ace8c0c1419c85d590ad
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 188538
+  timestamp: 1706886944988
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.4-pyhd8ed1ab_1.conda
+  sha256: 0352b6935ec73bc996829c61d1ebc7896caa31015073e43036af939fbe91a17a
+  md5: 99b8cf929b145ae310b333ce3496b56b
+  depends:
+  - param
+  - python >=3.9
+  constrains:
+  - jupyterlab >=4.0,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48732
+  timestamp: 1736890466861
+- conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.36.2-pyh29332c3_0.conda
+  sha256: e20909f474a6cece176dfc0dc1addac265deb5fa92ea90e975fbca48085b20c3
+  md5: 9140f1c09dd5489549c6a33931b943c7
+  depends:
+  - attrs >=22.2.0
+  - python >=3.9
+  - rpds-py >=0.7.0
+  - typing_extensions >=4.4.0
+  - python
+  license: MIT
+  license_family: MIT
+  size: 51668
+  timestamp: 1737836872415
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+  sha256: d701ca1136197aa121bbbe0e8c18db6b5c94acbd041c2b43c70e5ae104e1d8ad
+  md5: a9b9368f3701a417eac9edbcae7cb737
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 58723
+  timestamp: 1733217126197
+- conda: https://conda.anaconda.org/conda-forge/noarch/retrying-1.3.4-pyhd8ed1ab_0.conda
+  sha256: ff6c87f47b06725e34a6c7916e13a922090d586df6fd245b6cfd928ac0840dd1
+  md5: d9c8cef727d60fa29fd485ce79dd745a
+  depends:
+  - python >=3.9
+  - six >=1.7.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 16568
+  timestamp: 1740054061725
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+  sha256: 2e4372f600490a6e0b3bac60717278448e323cab1c0fecd5f43f7c56535a99c5
+  md5: 36de09a8d3e5d5e6f4ee63af49e59706
+  depends:
+  - python >=3.9
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10209
+  timestamp: 1733600040800
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+  sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
+  md5: 912a71cc01012ee38e6b90ddd561e36f
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 7818
+  timestamp: 1598024297745
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_1.conda
+  sha256: 00926652bbb8924e265caefdb1db100f86a479e8f1066efe395d5552dde54d02
+  md5: 938c8de6b9de091997145b3bf25cdbf9
+  depends:
+  - __linux
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22736
+  timestamp: 1733322148326
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_1.conda
+  sha256: 5282eb5b462502c38df8cb37cd1542c5bbe26af2453a18a0a0602d084ca39f53
+  md5: e67b1b1fa7a79ff9e8e326d0caf55854
+  depends:
+  - __osx
+  - pyobjc-framework-cocoa
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23100
+  timestamp: 1733322309409
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_1.conda
+  sha256: ba8b93df52e0d625177907852340d735026c81118ac197f61f1f5baea19071ad
+  md5: e6a4e906051565caf5fdae5b0415b654
+  depends:
+  - __win
+  - python >=3.9
+  - pywin32
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23359
+  timestamp: 1733322590167
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.2-pyhff2d567_0.conda
+  sha256: 91d664ace7c22e787775069418daa9f232ee8bafdd0a6a080a5ed2395a6fa6b2
+  md5: 9bddfdbf4e061821a1a443f93223be61
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 777736
+  timestamp: 1740654030775
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+  sha256: 41db0180680cc67c3fa76544ffd48d6a5679d96f4b71d7498a759e94edc9a2db
+  md5: a451d576819089b0d672f18768be0f65
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 16385
+  timestamp: 1733381032766
+- conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+  sha256: c2248418c310bdd1719b186796ae50a8a77ce555228b6acd32768e2543a15012
+  md5: bf7a226e58dfb8346c70df36065d86c9
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  size: 15019
+  timestamp: 1733244175724
+- conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+  sha256: d1e3e06b5cf26093047e63c8cc77b70d970411c5cbc0cb1fad461a8a8df599f7
+  md5: 0401a17ae845fa72c7210e206ec5647d
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 28657
+  timestamp: 1738440459037
+- conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+  sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
+  md5: 3f144b2c34f8cb5a9abd9ed23a39c561
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 36754
+  timestamp: 1693929424267
+- conda: https://conda.anaconda.org/conda-forge/noarch/spatialpandas-0.5.0-pyhd8ed1ab_0.conda
+  sha256: 81e0aa7d3ca621694ba8facbbf9ba0dc72d2753b4149a0d5453498b809029a1e
+  md5: e371879bca521d38ad57e88a705bcda4
+  depends:
+  - dask-core >=2025.1
+  - fsspec >=2022.8
+  - numba
+  - pandas >=2.0
+  - pyarrow >=14.0.1
+  - python >=3.10
+  - retrying
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 80784
+  timestamp: 1739873956657
+- conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+  sha256: 570da295d421661af487f1595045760526964f41471021056e993e73089e9c41
+  md5: b1b505328da7a6b246787df4b5a49fbc
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 26988
+  timestamp: 1733569565672
+- conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_1.conda
+  sha256: 6869cd2e043426d30c84d0ff6619f176b39728f9c75dc95dca89db994548bb8a
+  md5: 60ce69f73f3e75b21f1c27b1b471320c
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17421
+  timestamp: 1733842487151
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+  sha256: b300557c0382478cf661ddb520263508e4b3b5871b471410450ef2846e8c352c
+  md5: efba281bbdae5f6b0a1d53c6d4a97c93
+  depends:
+  - __linux
+  - ptyprocess
+  - python >=3.8
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22452
+  timestamp: 1710262728753
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+  sha256: 4daae56fc8da17784578fbdd064f17e3b3076b394730a14119e571707568dc8a
+  md5: 00b54981b923f5aefcd5e8547de056d5
+  depends:
+  - __osx
+  - ptyprocess
+  - python >=3.8
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22717
+  timestamp: 1710265922593
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
+  sha256: 8cb078291fd7882904e3de594d299c8de16dd3af7405787fce6919a385cfc238
+  md5: 4abd500577430a942a995fd0d09b76a2
+  depends:
+  - __win
+  - python >=3.8
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22883
+  timestamp: 1710262943966
+- conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+  sha256: cad582d6f978276522f84bd209a5ddac824742fe2d452af6acf900f8650a73a2
+  md5: f1acf5fdefa8300de697982bcb1761c9
+  depends:
+  - python >=3.5
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28285
+  timestamp: 1729802975370
+- conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_1.conda
+  sha256: eda38f423c33c2eaeca49ed946a8d3bf466cc3364970e083a65eb2fd85258d87
+  md5: 40d0ed782a8aaa16ef248e68c06c168d
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 52475
+  timestamp: 1733736126261
+- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+  sha256: 11e2c85468ae9902d24a27137b6b39b4a78099806e551d390e394a8c34b48e40
+  md5: 9efbfdc37242619130ea42b1cc4ed861
+  depends:
+  - colorama
+  - python >=3.9
+  license: MPL-2.0 or MIT
+  size: 89498
+  timestamp: 1735661472632
+- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+  sha256: f39a5620c6e8e9e98357507262a7869de2ae8cc07da8b7f84e517c9fd6c2b959
+  md5: 019a7385be9af33791c989871317e1ed
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110051
+  timestamp: 1733367480074
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241206-pyhd8ed1ab_0.conda
+  sha256: 8b98cd9464837174ab58aaa912fc95d5831879864676650a383994033533b8d1
+  md5: 1dbc4a115e2ad9fb7f9d5b68397f66f9
+  depends:
+  - python >=3.9
+  license: Apache-2.0 AND MIT
+  size: 22104
+  timestamp: 1733612458611
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+  sha256: c8e9c1c467b5f960b627d7adc1c65fece8e929a3de89967e91ef0f726422fd32
+  md5: b6a408c64b78ec7b779a3e5c7a902433
+  depends:
+  - typing_extensions 4.12.2 pyha770c72_1
+  license: PSF-2.0
+  license_family: PSF
+  size: 10075
+  timestamp: 1733188758872
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+  sha256: 337be7af5af8b2817f115b3b68870208b30c31d3439bec07bfb2d8f4823e3568
+  md5: d17f13df8b65464ca316cbc000a3cb64
+  depends:
+  - python >=3.9
+  license: PSF-2.0
+  license_family: PSF
+  size: 39637
+  timestamp: 1733188758212
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+  sha256: 3088d5d873411a56bf988eee774559335749aed6f6c28e07bf933256afb9eb6c
+  md5: f6d7aa696c67756a650e91e15e88223c
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 15183
+  timestamp: 1733331395943
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025a-h78e105d_0.conda
+  sha256: c4b1ae8a2931fe9b274c44af29c5475a85b37693999f8c792dad0f8c6734b1de
+  md5: dbcace4706afdfb7eb891f7b37d07c04
+  license: LicenseRef-Public-Domain
+  size: 122921
+  timestamp: 1737119101255
+- conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_1.conda
+  sha256: a2f837780af450d633efc052219c31378bcad31356766663fb88a99e8e4c817b
+  md5: 9c96c9876ba45368a03056ddd0f20431
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 11199
+  timestamp: 1733784280160
+- conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+  sha256: e0eb6c8daf892b3056f08416a96d68b0a358b7c46b99c8a50481b22631a4dfc0
+  md5: e7cb0f5745e4c5035a460248334af7eb
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 23990
+  timestamp: 1733323714454
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
+  sha256: 114919ffa80c328127dab9c8e7a38f9d563c617691fb81fccb11c1e86763727e
+  md5: 32674f8dbfb7b26410ed580dd3c10a29
+  depends:
+  - brotli-python >=1.0.9
+  - h2 >=4,<5
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 100102
+  timestamp: 1734859520452
+- conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+  sha256: f21e63e8f7346f9074fd00ca3b079bd3d2fa4d71f1f89d5b6934bf31446dc2a5
+  md5: b68980f2495d096e71c7fd9d7ccf63e6
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 32581
+  timestamp: 1733231433877
+- conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+  sha256: 08315dc2e61766a39219b2d82685fc25a56b2817acf84d5b390176080eaacf99
+  md5: b49f7b291e15494aafb0a7d74806f337
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18431
+  timestamp: 1733359823938
+- conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+  sha256: 19ff205e138bb056a46f9e3839935a2e60bd1cf01c8241a5e172a422fed4f9c6
+  md5: 2841eb5bfc75ce15e9a0054b98dcd64d
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15496
+  timestamp: 1733236131358
+- conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+  sha256: 1dd84764424ffc82030c19ad70607e6f9e3b9cb8e633970766d697185652053e
+  md5: 84f8f77f0a9c6ef401ee96611745da8f
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 46718
+  timestamp: 1733157432924
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+  sha256: 1b34021e815ff89a4d902d879c3bd2040bc1bd6169b32e9427497fa05c55f1ce
+  md5: 75cb7132eb58d97896e173ef12ac9986
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 62931
+  timestamp: 1733130309598
+- conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+  sha256: 93807369ab91f230cf9e6e2a237eaa812492fe00face5b38068735858fba954f
+  md5: 46e441ba871f524e2b067929da3051c2
+  depends:
+  - __win
+  - python >=3.9
+  license: LicenseRef-Public-Domain
+  size: 9555
+  timestamp: 1733130678956
+- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.1.2-pyhd8ed1ab_0.conda
+  sha256: 0f59c2718573770b01d849e05a56a7fe1461f55bf7525c4df5552079c5c03427
+  md5: b8d9af89c48fa3359f05f3324809fcde
+  depends:
+  - numpy >=1.24
+  - packaging >=23.2
+  - pandas >=2.1
+  - python >=3.10
+  constrains:
+  - pint >=0.22
+  - netcdf4 >=1.6.0
+  - cartopy >=0.22
+  - iris >=3.7
+  - h5py >=3.8
+  - nc-time-axis >=1.4
+  - sparse >=0.14
+  - bottleneck >=1.3
+  - scipy >=1.11
+  - numba >=0.57
+  - toolz >=0.12
+  - h5netcdf >=1.3
+  - distributed >=2023.11
+  - dask-core >=2023.11
+  - flox >=0.7
+  - seaborn-base >=0.13
+  - zarr >=2.16
+  - matplotlib-base >=3.8
+  - cftime >=1.6
+  - hdf5 >=1.12
+  license: Apache-2.0
+  license_family: APACHE
+  size: 837969
+  timestamp: 1738313762187
+- conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.1.0-pyhd8ed1ab_0.conda
+  sha256: 9978c22319e85026d5a4134944f73bac820c948ca6b6c32af6b6985b5221cd8a
+  md5: fdf07e281a9e5e10fc75b2dd444136e9
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48641
+  timestamp: 1737234992057
+- conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
+  sha256: 5488542dceeb9f2874e726646548ecc5608060934d6f9ceaa7c6a48c61f9cc8d
+  md5: e52c2ef711ccf31bb7f70ca87d144b9e
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36341
+  timestamp: 1733261642963
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+  sha256: 567c04f124525c97a096b65769834b7acb047db24b15a56888a322bf3966c3e1
+  md5: 0c3cc595284c5e8f0f9900a9b228a332
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 21809
+  timestamp: 1732827613585
+- conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h3336109_5.conda
+  sha256: fa5eb633b320e10fc2138f3d842d8a8ca72815f106acbab49a68ec9783e4d70d
+  md5: 29b46bd410067f668c4cef7fdc78fe25
+  depends:
+  - __osx >=10.13
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 32275
+  timestamp: 1725356815696
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.8.1-h6661f4c_0.conda
+  sha256: 276a68de081c8fb9aa6fc4b6bafe5f3488aaa9e20ee0f680ac329190f8483789
+  md5: 7045b0456fbf3620bcefa120f0bd6b96
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.8.1,<0.8.2.0a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-http >=0.9.2,<0.9.3.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  - aws-c-sdkutils >=0.2.2,<0.2.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94387
+  timestamp: 1737509851484
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.8.1-hc0df2db_3.conda
+  sha256: 11db519ebf28a11b0e5ebc14ef15afff64763f6d1df181831f1660605423a0f8
+  md5: a9d2198575baadd2211190358a2a6b3e
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 39320
+  timestamp: 1733991644367
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.10.6-h6e16a3a_0.conda
+  sha256: fd38587825ade82ddbf4752136679e5cb9700bd3520aafc2db950a28ec4ecfa8
+  md5: 9f0bbd4a339c01ec81d7e19cbb9ad2ed
+  depends:
+  - __osx >=10.13
+  license: Apache-2.0
+  license_family: Apache
+  size: 227749
+  timestamp: 1733975583583
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.3.0-hc0df2db_5.conda
+  sha256: e3aa29e79c45ea80e7eb575c461bede53a9d82905da36f4a9e0379825cc5475e
+  md5: a9c8558d5bfcc336c83ae7ea91593c18
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18022
+  timestamp: 1733991666918
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.5.0-h8236443_11.conda
+  sha256: e8403a2afca0b1f584f5b98e18a82e5b05292fb66cc24bb83c219b0ff23b814f
+  md5: b310a8a7c25dd982af1ad491b3705418
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 46857
+  timestamp: 1734024549117
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.9.2-h5492b4a_4.conda
+  sha256: bf613d96f1c71f38c93c39522f2ef8ede58571302c797316ada933a566a86ef6
+  md5: 4a93c133064fca271b5a8ea42daa5a96
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.8.1,<0.8.2.0a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-compression >=0.3.0,<0.3.1.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 165311
+  timestamp: 1734008547017
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.15.3-h7bd4489_6.conda
+  sha256: 46e46465a839a8bb22fe4cb37d64afd1df5ecb32ec864bca65fb14d6bca0c1fa
+  md5: 9c6f2cabd18b4778bf2b9a69bcbc3621
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.8.1,<0.8.2.0a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 137824
+  timestamp: 1737207664194
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.11.0-h3488609_12.conda
+  sha256: f740c56238c096dceeab635324ca9ea8a6a80bcd89a09d69616f08d0aa9f8d42
+  md5: 5028bbe899aaf6f760d1b67967d9fe58
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-http >=0.9.2,<0.9.3.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 164115
+  timestamp: 1734025863980
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.7.9-h702e2dd_1.conda
+  sha256: 6c37af382dcc99cdbdad37f5a1368ef3cb6c5a977714693d362cdc2742dc8024
+  md5: 79314d2e176c003d7b2bb78d338ae77f
+  depends:
+  - __osx >=10.13
+  - aws-c-auth >=0.8.1,<0.8.2.0a0
+  - aws-c-cal >=0.8.1,<0.8.2.0a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-http >=0.9.2,<0.9.3.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 99690
+  timestamp: 1737558726365
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.2.2-hc0df2db_0.conda
+  sha256: 0f8c22d4df2f9550e877d40df5a239cff6674e115405e88ee4cee6ae1969dfec
+  md5: d30609a69cb865c31a967447cb845fc0
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51426
+  timestamp: 1736536011735
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.2.2-hc0df2db_4.conda
+  sha256: b7dd703e9ca92f4e64d0d9f7dd1a4e87528959b3d37876a2836172f684d904bd
+  md5: 7575377b784344407b89a469e077ffa2
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 70949
+  timestamp: 1733994439164
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.29.9-h5c43303_2.conda
+  sha256: a0bcfc6c1a6dc90519f2b832cab35825a59e2bc49143faca23923b3958fdd176
+  md5: b2e8729ac755ec676e07e41e6f456c17
+  depends:
+  - __osx >=10.13
+  - aws-c-auth >=0.8.1,<0.8.2.0a0
+  - aws-c-cal >=0.8.1,<0.8.2.0a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-c-http >=0.9.2,<0.9.3.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  - aws-c-mqtt >=0.11.0,<0.11.1.0a0
+  - aws-c-s3 >=0.7.9,<0.7.10.0a0
+  - aws-c-sdkutils >=0.2.2,<0.2.3.0a0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 297636
+  timestamp: 1737565726370
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.489-h904bc55_0.conda
+  sha256: 06476455d8cd32c2f701ee609b6368b54a5e7bd8f5fd0c8b9a9240f68848703c
+  md5: b860858f5b5d146af55a3ae58574e7f6
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - aws-crt-cpp >=0.29.9,<0.29.10.0a0
+  - libcurl >=8.11.1,<9.0a0
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2938984
+  timestamp: 1737576474956
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.14.0-h9a36307_0.conda
+  sha256: c7694fc16b9aebeb6ee5e4f80019b477a181d961a3e4d9b6a66b77777eb754fe
+  md5: 1082a031824b12a2be731d600cfa5ccb
+  depends:
+  - __osx >=10.13
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 303166
+  timestamp: 1728053999891
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.10.0-ha4e2ba9_0.conda
+  sha256: b9899b9698a6c7353fc5078c449105aae58635d217befbc8ca9d5a527198019b
+  md5: ad56b6a4b8931d37a2cf5bc724a46f01
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 175344
+  timestamp: 1728487066445
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.13.0-h3d2f5f1_1.conda
+  sha256: 31984e52450230d04ca98d5232dbe256e5ef6e32b15d46124135c6e64790010d
+  md5: 3df4fb5d6d0e7b3fb28e071aff23787e
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 445040
+  timestamp: 1728578180436
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.8.0-h1ccc5ac_1.conda
+  sha256: 51fb67d2991d105b8f7b97b4810cd63bac4dc421a4a9c83c15a98ca520a42e1e
+  md5: 5b3e79eb148d6e30d6c697788bad9960
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - libxml2 >=2.12.7,<2.14.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 126229
+  timestamp: 1728563580392
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-files-datalake-cpp-12.12.0-h86941f0_1.conda
+  sha256: 12d95251a8793ea2e78f494e69353a930e9ea06bbaaaa4ccb6e5b3e35ee0744f
+  md5: 60452336e7f61f6fdaaff69264ee112e
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 200991
+  timestamp: 1728729588371
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h00291cd_2.conda
+  sha256: 624954bc08b3d7885a58c7d547282cfb9a201ce79b748b358f801de53e20f523
+  md5: 2db0c38a7f2321c5bdaf32b181e832c7
+  depends:
+  - __osx >=10.13
+  - brotli-bin 1.1.0 h00291cd_2
+  - libbrotlidec 1.1.0 h00291cd_2
+  - libbrotlienc 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 19450
+  timestamp: 1725267851605
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h00291cd_2.conda
+  sha256: 642a8492491109fd8270c1e2c33b18126712df0cedb94aaa2b1c6b02505a4bfa
+  md5: 049933ecbf552479a12c7917f0a4ce59
+  depends:
+  - __osx >=10.13
+  - libbrotlidec 1.1.0 h00291cd_2
+  - libbrotlienc 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 16643
+  timestamp: 1725267837325
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hd89902b_2.conda
+  sha256: 004cefbd18f581636a8dcb1964fb73478f15d496769226ec896c1d4a0161b7d8
+  md5: d75f06ee06001794aa83a05e885f1520
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 363793
+  timestamp: 1725267947069
+- conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+  sha256: cad153608b81fb24fc8c509357daa9ae4e49dfc535b2cb49b91e23dbd68fc3c5
+  md5: 7ed4301d437b59045be7e051a0308211
+  depends:
+  - __osx >=10.13
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 134188
+  timestamp: 1720974491916
+- conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.4-hf13058a_0.conda
+  sha256: 8dcc1628d34fe7d759f3a7dee52e09c5162a3f9669dddd6100bff965450f4a0a
+  md5: 133255af67aaf1e0c0468cc753fd800b
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 184455
+  timestamp: 1734208242547
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2025.1.31-h8857fd0_0.conda
+  sha256: 42e911ee2d8808eacedbec46d99b03200a6138b8e8a120bd8acabe1cac41c63b
+  md5: 3418b6c8cac3e71c0bc089fc5ea53042
+  license: ISC
+  size: 158408
+  timestamp: 1738298385933
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.1-py311h137bacd_0.conda
+  sha256: 012ee7b1ed4f9b0490d6e90c72decf148d7575173c7eaf851cd87fd434d2cacc
+  md5: a4b0f531064fa3dd5e3afbb782ea2cd5
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 288762
+  timestamp: 1725560945833
+- conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.1-py311h4e34fa0_0.conda
+  sha256: 373e17f22bca3e13aac2245bb0c8a15c4a54d1ffa4c3278308eeb8d3c9435c0e
+  md5: 6bc3882064e277827934e2c6e5281661
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 255123
+  timestamp: 1731428577146
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.0.1-py311h4d7f069_0.conda
+  sha256: 3c54e045c606a12738ada3b71ad79750145bddbfbe18cf1a7cddad301491ce2c
+  md5: 869c5b5cbefc4a5d23e6a9078a9b5501
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 339778
+  timestamp: 1734107398374
+- conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.12-py311hc356e98_0.conda
+  sha256: ed2a267aa76dbf1e76a5efa01dc7ac10ff5a07b700db714982d5ff1a62993e66
+  md5: 8d75ce79dc3ef8e9511d15ce84e23e35
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2485633
+  timestamp: 1737269969722
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.56.0-py311ha3cf9ac_0.conda
+  sha256: 60ebd24ca32e31425117947c783b6b40d28748bd673da4731f1fad46730c4556
+  md5: 7f8677276e7a361d0202c8240e1f8130
+  depends:
+  - __osx >=10.13
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2798979
+  timestamp: 1738940622370
+- conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+  sha256: b292cf5a25f094eeb4b66e37d99a97894aafd04a5683980852a8cbddccdc8e4e
+  md5: 25152fce119320c980e5470e64834b50
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 599300
+  timestamp: 1694616137838
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hac325c4_1005.conda
+  sha256: c0bea66f71a6f4baa8d4f0248e17f65033d558d9e882c0af571b38bcca3e4b46
+  md5: a26de8814083a6971f14f9c8c3cb36c2
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84946
+  timestamp: 1726600054963
+- conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h2790a97_0.conda
+  sha256: dd56547db8625eb5c91bb0a9fbe8bd6f5c7fbf5b6059d46365e94472c46b24f9
+  md5: 06cf91665775b0da395229cd4331b27d
+  depends:
+  - __osx >=10.13
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 117017
+  timestamp: 1718284325443
+- conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_1.conda
+  sha256: 2499e5ebb3efa4186d6922122224d16bac791a5c0adad5b48b2bcd1e1e2afc8d
+  md5: b6c1710105dad14d47001a339cd14da6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17727
+  timestamp: 1725302991176
+- conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.7-py311hf2f7c97_0.conda
+  sha256: 00b477bff9138ca51edd94f7b31ce9fe2cd13a1dc8768abcf037a22eccf26940
+  md5: 24b0e3e3444be9fabcc8457c409e297f
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 60398
+  timestamp: 1725459431458
+- conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+  sha256: 83b52685a4ce542772f0892a0f05764ac69d57187975579a0835ff255ae3ef9c
+  md5: d4765c524b1d91567886bde656fb514b
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1185323
+  timestamp: 1719463492984
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.17-h72f5680_0.conda
+  sha256: bcb81543e49ff23e18dea79ef322ab44b8189fb11141b1af99d058503233a5fc
+  md5: bf210d0c63f2afb9e414a858b79f0eaa
+  depends:
+  - __osx >=10.13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 226001
+  timestamp: 1739161050843
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+  sha256: e41790fc0f4089726369b3c7f813117bbc14b533e0ed8b94cf75aba252e82497
+  md5: f9d6a4c82889d5ecedec1d90eb673c55
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 290319
+  timestamp: 1657977526749
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240722.0-cxx17_h0e468a2_4.conda
+  sha256: 375e98c007cbe2535b89adccf4d417480d54ce2fb4b559f0b700da294dee3985
+  md5: 03dd3d0563d01c2b82881734ee0eb334
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  constrains:
+  - abseil-cpp =20240722.0
+  - libabseil-static =20240722.0=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1163503
+  timestamp: 1736008705613
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-19.0.1-h91f21e1_0_cpu.conda
+  sha256: b95b84fb2d12725c489f86d82454e03a4c9d8f0f712a4a0313ec3de17243defc
+  md5: 395782e74be0434db34a1bc3f5079fec
+  depends:
+  - __osx >=10.13
+  - aws-crt-cpp >=0.29.9,<0.29.10.0a0
+  - aws-sdk-cpp >=1.11.489,<1.11.490.0a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-identity-cpp >=1.10.0,<1.10.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-files-datalake-cpp >=12.12.0,<12.12.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=18
+  - libgoogle-cloud >=2.35.0,<2.36.0a0
+  - libgoogle-cloud-storage >=2.35.0,<2.36.0a0
+  - libopentelemetry-cpp >=1.18.0,<1.19.0a0
+  - libprotobuf >=5.28.3,<5.28.4.0a0
+  - libre2-11 >=2024.7.2
+  - libutf8proc >=2.10.0,<2.11.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - orc >=2.0.3,<2.0.4.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - arrow-cpp <0.0a0
+  - parquet-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 6224609
+  timestamp: 1739768296516
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-19.0.1-ha6338a2_0_cpu.conda
+  sha256: ddaeb87b11c030b579a0a03d884ab3cd47b6cce1640e1d064041ae9715f1c923
+  md5: 2e59e9d70c22152a6cef03af87307c72
+  depends:
+  - __osx >=10.13
+  - libarrow 19.0.1 h91f21e1_0_cpu
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: APACHE
+  size: 546083
+  timestamp: 1739768524885
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-19.0.1-ha6338a2_0_cpu.conda
+  sha256: e3b3e408f1b7d3c32c14632265c72c328f4a4d91a9faf1c1b80eccb8667d7cba
+  md5: e216040a5cd4638724044a9b9a71fbf8
+  depends:
+  - __osx >=10.13
+  - libarrow 19.0.1 h91f21e1_0_cpu
+  - libarrow-acero 19.0.1 ha6338a2_0_cpu
+  - libcxx >=18
+  - libparquet 19.0.1 h3e22b07_0_cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 528098
+  timestamp: 1739769777364
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-19.0.1-h5c2345d_0_cpu.conda
+  sha256: d5676bbe23070f26522d511a76dc81418116e89fdf21428703c185171dfcb559
+  md5: 35d97c12c0bd362347ab1a939367fe5b
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 19.0.1 h91f21e1_0_cpu
+  - libarrow-acero 19.0.1 ha6338a2_0_cpu
+  - libarrow-dataset 19.0.1 ha6338a2_0_cpu
+  - libcxx >=18
+  - libprotobuf >=5.28.3,<5.28.4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 464281
+  timestamp: 1739769997697
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-31_h7f60823_openblas.conda
+  sha256: 2192f9cfa72a1a6127eb1c57a9662eb1b44c6506f2b7517cf021f1262d2bf56d
+  md5: a8c1c9f95d1c46d67028a6146c1ea77c
+  depends:
+  - libopenblas >=0.3.29,<0.3.30.0a0
+  - libopenblas >=0.3.29,<1.0a0
+  constrains:
+  - libcblas =3.9.0=31*_openblas
+  - liblapacke =3.9.0=31*_openblas
+  - blas =2.131=openblas
+  - mkl <2025
+  - liblapack =3.9.0=31*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17105
+  timestamp: 1740087945188
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h00291cd_2.conda
+  sha256: b377056470a9fb4a100aa3c51b3581aab6496ba84d21cd99bcc1d5ef0359b1b6
+  md5: 58f2c4bdd56c46cc7451596e4ae68e0b
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 67267
+  timestamp: 1725267768667
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h00291cd_2.conda
+  sha256: 4d49ea72e2f44d2d7a8be5472e4bd0bc2c6b89c55569de2c43576363a0685c0c
+  md5: 34709a1f5df44e054c4a12ab536c5459
+  depends:
+  - __osx >=10.13
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 29872
+  timestamp: 1725267807289
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h00291cd_2.conda
+  sha256: 477d236d389473413a1ccd2bec1b66b2f1d2d7d1b4a57bb56421b7b611a56cd1
+  md5: 691f0dcb36f1ae67f5c489f20ae987ea
+  depends:
+  - __osx >=10.13
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 296353
+  timestamp: 1725267822076
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-31_hff6cab4_openblas.conda
+  sha256: a64b24e195f7790722e1557ff5ed9ecceaaf85559b182d0d03fa61c1fd60326c
+  md5: c655cc2b0c48ec454f7a4db92415d012
+  depends:
+  - libblas 3.9.0 31_h7f60823_openblas
+  constrains:
+  - liblapacke =3.9.0=31*_openblas
+  - blas =2.131=openblas
+  - liblapack =3.9.0=31*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17006
+  timestamp: 1740087955460
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+  sha256: 3043869ac1ee84554f177695e92f2f3c2c507b260edad38a0bf3981fce1632ff
+  md5: 23d6d5a69918a438355d7cbc4c3d54c9
+  depends:
+  - libcxx >=11.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20128
+  timestamp: 1633683906221
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.12.1-h5dec5d8_0.conda
+  sha256: 51168abcbee14814b94dea3358300de4053423c6ce8d4627475464fb8cf0e5d3
+  md5: b39e6b74b4eb475eacdfd463fce82138
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.64.0,<2.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.1,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 410703
+  timestamp: 1739512524410
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.7-hf95d169_0.conda
+  sha256: 6b2fa3fb1e8cd2000b0ed259e0c4e49cbef7b76890157fac3e494bc659a20330
+  md5: 4b8f8dc448d814169dbc58fc7286057d
+  depends:
+  - __osx >=10.13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 527924
+  timestamp: 1736877256721
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.23-he65b83e_0.conda
+  sha256: 20c1e685e7409bb82c819ba55b9f7d9a654e8e6d597081581493badb7464520e
+  md5: 120f8f7ba6a8defb59f4253447db4bb4
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 69309
+  timestamp: 1734374105905
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20250104-pl5321ha958ccf_0.conda
+  sha256: 6cc49785940a99e6a6b8c6edbb15f44c2dd6c789d9c283e5ee7bdfedd50b4cd6
+  md5: 1f4ed31220402fcddc083b4bff406868
+  depends:
+  - ncurses
+  - __osx >=10.13
+  - ncurses >=6.5,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 115563
+  timestamp: 1738479554273
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+  sha256: 0d238488564a7992942aa165ff994eca540f687753b4f0998b29b4e4d030ff43
+  md5: 899db79329439820b7e8f8de41bca902
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 106663
+  timestamp: 1702146352558
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+  sha256: e0bd9af2a29f8dd74309c0ae4f17a7c2b8c4b89f875ff1d6540c941eefbd07fb
+  md5: e38e467e577bd193a7d5de7c2c540b04
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372661
+  timestamp: 1685726378869
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.4-h240833e_0.conda
+  sha256: d10f43d0c5df6c8cf55259bce0fe14d2377eed625956cddce06f58827d288c59
+  md5: 20307f4049a735a78a29073be1be2626
+  depends:
+  - __osx >=10.13
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 70758
+  timestamp: 1730967204736
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.6-h281671d_0.conda
+  sha256: 7805fdc536a3da7fb63dc48e040105cd4260c69a1d2bf5804dadd31bde8bab51
+  md5: b8667b0d0400b8dcb6844d8e06b2027d
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 47258
+  timestamp: 1739260651925
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+  sha256: 4874422e567b68334705c135c17e5acdca1404de8255673ce30ad3510e00be0d
+  md5: 0b6e23a012ee7a9a5f6b244f5a92c1d5
+  depends:
+  - libgfortran5 13.2.0 h2873a65_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110106
+  timestamp: 1707328956438
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+  sha256: da3db4b947e30aec7596a3ef92200d17e774cccbbf7efc47802529a4ca5ca31b
+  md5: e4fb4d23ec2870ff3c40d10afe305aec
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1571379
+  timestamp: 1707328880361
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.35.0-h7000a09_0.conda
+  sha256: f6d497286e82dce678b0b6fac2aadbfb01aa9e9c63ac5c301ddd32c2a46e22e7
+  md5: 1f3bcfa6763b04a11af10873128d96cd
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.11.1,<9.0a0
+  - libcxx >=18
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libprotobuf >=5.28.3,<5.28.4.0a0
+  - openssl >=3.4.0,<4.0a0
+  constrains:
+  - libgoogle-cloud 2.35.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 896056
+  timestamp: 1738663689648
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.35.0-h3f2b517_0.conda
+  sha256: f7114fbed902b022a89c5f635d871c07996ddf8522069f6d87f187ad1b4bf4b7
+  md5: e2fedc41bc1b500f04476137955fd40b
+  depends:
+  - __osx >=10.13
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libcxx >=18
+  - libgoogle-cloud 2.35.0 h7000a09_0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  size: 543895
+  timestamp: 1738665086510
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.67.1-h4896ac0_1.conda
+  sha256: 7d70fb44315e58d31f3bd07319ea61db7348e51d35a7e2127908db76edccc247
+  md5: e6f9b94b637c659257d7ea8508748905
+  depends:
+  - __osx >=10.13
+  - c-ares >=1.34.4,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=18
+  - libprotobuf >=5.28.3,<5.28.4.0a0
+  - libre2-11 >=2024.7.2
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.67.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5448968
+  timestamp: 1735584736883
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4b5e92a_1.conda
+  sha256: c2a9c65a245c7bcb8c17c94dd716dad2d42b7c98e0c17cc5553a5c60242c4dda
+  md5: 6283140d7b2b55b6b095af939b71b13f
+  depends:
+  - __osx >=10.13
+  license: LGPL-2.1-only
+  size: 669052
+  timestamp: 1740128415026
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+  sha256: d9572fd1024adc374aae7c247d0f29fdf4b122f1e3586fe62acc18067f40d02f
+  md5: 72507f8e3961bc968af17435060b6dd6
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 579748
+  timestamp: 1694475265912
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-31_h236ab99_openblas.conda
+  sha256: 2d5642b07b56037ab735e5d64309dd905d5acb207a1b2ab1692f811b55a64825
+  md5: d0f3bc17e0acef003cb9d9195a205888
+  depends:
+  - libblas 3.9.0 31_h7f60823_openblas
+  constrains:
+  - libcblas =3.9.0=31*_openblas
+  - blas =2.131=openblas
+  - liblapacke =3.9.0=31*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17033
+  timestamp: 1740087965941
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm15-15.0.7-hc29ff6c_5.conda
+  sha256: 0e1ebc432627c18cff4f49096c681f63a3f0c4626a42f3fc483c3751d316e662
+  md5: 526506b4e6846e8e95fc704b9f7a7171
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 23861511
+  timestamp: 1739672679349
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.6.4-hd471939_0.conda
+  sha256: a895b5b16468a6ed436f022d72ee52a657f9b58214b91fabfab6230e3592a6dd
+  md5: db9d7b0152613f097cdb61ccf9f70ef5
+  depends:
+  - __osx >=10.13
+  constrains:
+  - xz ==5.6.4=*_0
+  license: 0BSD
+  size: 103749
+  timestamp: 1738525448522
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.64.0-hc7306c3_0.conda
+  sha256: 0dcfdcf3a445d2d7de4f3b186ab0a794dc872f4ea21622f9b997be72712c027f
+  md5: ab21007194b97beade22ceb7a3f6fee5
+  depends:
+  - __osx >=10.13
+  - c-ares >=1.34.2,<2.0a0
+  - libcxx >=17
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 606663
+  timestamp: 1729572019083
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.29-openmp_hbf64a52_0.conda
+  sha256: fbb413923f91cb80a4d23725816499b921dd87454121efcde107abc7772c937a
+  md5: a30dc52b2a8b6300f17eaabd2f940d41
+  depends:
+  - __osx >=10.13
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - llvm-openmp >=18.1.8
+  constrains:
+  - openblas >=0.3.29,<0.3.30.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6170847
+  timestamp: 1739826107594
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopentelemetry-cpp-1.18.0-h739dec3_1.conda
+  sha256: 3e5c194e503087a40fa8a316ff56afe3a4be936136ca185c35f5e39dd6bba0f8
+  md5: f567067f39b8577939373d8b4bef8863
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.11.1,<9.0a0
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libopentelemetry-cpp-headers 1.18.0 h694c41f_1
+  - libprotobuf >=5.28.3,<5.28.4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - nlohmann_json
+  - prometheus-cpp >=1.3.0,<1.4.0a0
+  constrains:
+  - cpp-opentelemetry-sdk =1.18.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 541524
+  timestamp: 1735643786734
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopentelemetry-cpp-headers-1.18.0-h694c41f_1.conda
+  sha256: 5e51b72cb76da505595059ca36378571ed1a75f5fe8ae292b16e6b1927c7cbcb
+  md5: 4c996e9294dd750e824e15f6a05ba247
+  license: Apache-2.0
+  license_family: APACHE
+  size: 321408
+  timestamp: 1735643526601
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-19.0.1-h3e22b07_0_cpu.conda
+  sha256: 01607f74a4f765a9227782a8900032cb0f5c7914f1d13fa2ebac8007ef79fc6c
+  md5: 2bee725adb307606d1acc998f42aabb8
+  depends:
+  - __osx >=10.13
+  - libarrow 19.0.1 h91f21e1_0_cpu
+  - libcxx >=18
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.4.1,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 967535
+  timestamp: 1739769659803
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.47-h3c4a55f_0.conda
+  sha256: d00a144698debb226a01646c72eff15917eb0143f92c92e1b61ce457d9367b89
+  md5: 8461ab86d2cdb76d6e971aab225be73f
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 266874
+  timestamp: 1739953034029
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-5.28.3-h6401091_1.conda
+  sha256: 7bd8467402040312cf1030d98427b6bdce9905e519a1979cd7aa5f0fb0902cad
+  md5: 5601e7ce099eb72741e9cd6413f42a07
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2312598
+  timestamp: 1735576514825
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2024.07.02-h0e468a2_2.conda
+  sha256: 8d29abd9b800f55b56e60b5acb02fab3f3269f5518a7fb4286ca93ca7fef0eff
+  md5: 975743594ba5382fe7e71cda599ac6e8
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=18
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 179212
+  timestamp: 1735541074638
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
+  sha256: d3975cfe60e81072666da8c76b993af018cf2e73fe55acba2b5ba0928efaccf5
+  md5: 6af4b059e26492da6013e79cbcb4d069
+  depends:
+  - __osx >=10.13
+  license: ISC
+  size: 210249
+  timestamp: 1716828641383
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.49.1-hdb6dae5_1.conda
+  sha256: 859e5f1a39e320b3575b98b7a80ab7c62b337465b12b181c8bbe305fecc9430b
+  md5: 7958168c20fbbc5014e1fbda868ed700
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 977598
+  timestamp: 1739953439197
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-h3dc7d44_0.conda
+  sha256: ef2a81c9a15080b996a37f0e1712881da90a710b234e63d8539d69892353de90
+  md5: b1caec4561059e43a5d056684c5a2de0
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 283874
+  timestamp: 1732349525684
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.21.0-h75589b3_0.conda
+  sha256: 3f82eddd6de435a408538ac81a7a2c0c155877534761ec9cd7a2906c005cece2
+  md5: 7a472cd20d9ae866aeb6e292b33381d6
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 332651
+  timestamp: 1727206546431
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-hb77a491_3.conda
+  sha256: bb50df7cfc1acb11eae63c5f4fdc251d381cda96bf02c086c3202c83a5200032
+  md5: 6f2f9df7b093d6b33bc0c334acc7d2d9
+  depends:
+  - __osx >=10.13
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=18
+  - libdeflate >=1.23,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 400099
+  timestamp: 1734398943635
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.10.0-h777c5d8_0.conda
+  sha256: cbac7991d6ede019fd744b9b386bb8f973ad2500c8cdcef4425e1334400125d0
+  md5: 0c9c79979aeba96d102b0628fe361c56
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 80336
+  timestamp: 1737244400359
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.5.0-h6cf52b4_0.conda
+  sha256: 7f110eba04150f1fe5fe297f08fb5b82463eed74d1f068bc67c96637f9c63569
+  md5: 5e0cefc99a231ac46ba21e27ae44689f
+  depends:
+  - __osx >=10.13
+  constrains:
+  - libwebp 1.5.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 357662
+  timestamp: 1734777539822
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+  sha256: 8896cd5deff6f57d102734f3e672bc17120613647288f9122bec69098e839af7
+  md5: bbeca862892e2898bdb45792a61c4afc
+  depends:
+  - __osx >=10.13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 323770
+  timestamp: 1727278927545
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.6-he8ee3e7_0.conda
+  sha256: 6238384f6d5b68e231f0b83d081aec23c8ac2a17458c097fc81baa089a06ab94
+  md5: 0f7ae42cd61056bfb1298f53caaddbc7
+  depends:
+  - __osx >=10.13
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.6.4,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - icu <0.0a0
+  license: MIT
+  license_family: MIT
+  size: 609656
+  timestamp: 1739953197263
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+  sha256: 8412f96504fc5993a63edf1e211d042a1fd5b1d51dedec755d2058948fcced09
+  md5: 003a54a4e32b02f7355b50a837e699da
+  depends:
+  - __osx >=10.13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 57133
+  timestamp: 1727963183990
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.7-ha54dae1_0.conda
+  sha256: b5b06821b0d4143f66ba652ffe6f535696dc3a4096175d9be8b19b1a7350c86d
+  md5: 65d08c50518999e69f421838c1d5b91f
+  depends:
+  - __osx >=10.13
+  constrains:
+  - openmp 19.1.7|19.1.7.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 304885
+  timestamp: 1736986327031
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.44.0-py311h79b6b59_0.conda
+  sha256: d3df54e64a3b944665822b440059100f39ea5c14eb5ecfbb25bbdf480e04ea27
+  md5: a5e19be31a0dfa46a727559d15e3b914
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 419852
+  timestamp: 1738108752217
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-4.3.3-py311h687f303_2.conda
+  sha256: d5ef66bad9cf8d12c15f3372bde2b40cdc3713d45c0780fae85b25680a1d86da
+  md5: 4d3b05f4db2035340119b05f7e97c363
+  depends:
+  - __osx >=10.13
+  - lz4-c >=1.10.0,<1.11.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36895
+  timestamp: 1733474528045
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.10.0-h240833e_1.conda
+  sha256: 8da3c9d4b596e481750440c0250a7e18521e7f69a47e1c8415d568c847c08a1c
+  md5: d6b9bd7e356abd7e3a633d59b753495a
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 159500
+  timestamp: 1733741074747
+- conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.2-py311ha3cf9ac_1.conda
+  sha256: e9965b5d4c29b17b1512035b24a7c126ed7bdb6b39103b52cae099d5bb4194a9
+  md5: 1d6596ca7c7b66215c5c0d58b3cb0dd3
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24688
+  timestamp: 1733219887972
+- conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.10.0-py311h19a4563_0.conda
+  sha256: de61e99030ae11a9f986f7ea6514e45bb35109c77f25d84ac421a1427d0bbed0
+  md5: e071717bfbd46c354ab37483f305cf7b
+  depends:
+  - __osx >=10.13
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=18
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8243458
+  timestamp: 1734380904335
+- conda: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.1.0-py311hf2f7c97_0.conda
+  sha256: b56b1e7d156b88cc0c62734acf56d4ee809723614f659e4203028e7eeac16a78
+  md5: 6804cd42195bf94efd1b892688c96412
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 90868
+  timestamp: 1725975178961
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
+  sha256: ea4a5d27ded18443749aefa49dc79f6356da8506d508b5296f60b8d51e0c4bd9
+  md5: ced34dd9929f491ca6dab6a2927aff25
+  depends:
+  - __osx >=10.13
+  license: X11 AND BSD-3-Clause
+  size: 822259
+  timestamp: 1738196181298
+- conda: https://conda.anaconda.org/conda-forge/osx-64/nlohmann_json-3.11.3-hf036a51_1.conda
+  sha256: 41b1aa2a67654917c9c32a5f0111970b11cfce49ed57cf44bba4aefdcd59e54b
+  md5: 00c3efa95b3a010ee85bc36aac6ab2f6
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  size: 122773
+  timestamp: 1723652497933
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.61.0-py311h5322ac9_1.conda
+  sha256: 7851f966209801f806fb5c08fbabba33afae6d56ee030b61491c0b4534cd9001
+  md5: d584c3e5005d9514fb518c1e6e947524
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - llvm-openmp >=18.1.8
+  - llvm-openmp >=19.1.7
+  - llvmlite >=0.44.0,<0.45.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.24,<2.2
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - scipy >=1.0
+  - cuda-version >=11.2
+  - tbb >=2021.6.0
+  - cuda-python >=11.6
+  - libopenblas !=0.3.6
+  - cudatoolkit >=11.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5891122
+  timestamp: 1739224907640
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.1.3-py311h14ed71f_0.conda
+  sha256: 2ddc0acaf8602eda5e555435a37641439aa7876425fe7b40214f15dab182e5e3
+  md5: 220e4e917b6133e0cbb879c48c058adc
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8262782
+  timestamp: 1730588525361
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.3-h7fd6d84_0.conda
+  sha256: faea03f36c9aa3524c911213b116da41695ff64b952d880551edee2843fe115b
+  md5: 025c711177fc3309228ca1a32374458d
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - libpng >=1.6.44,<1.7.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 332320
+  timestamp: 1733816828284
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.1-hc426f3f_0.conda
+  sha256: 505a46671dab5d66df8e684f99a9ae735a607816b12810b572d63caa512224df
+  md5: a7d63f8e7ab23f71327ea6d27e2d5eae
+  depends:
+  - __osx >=10.13
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2591479
+  timestamp: 1739302628009
+- conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.3-h85ea3fe_2.conda
+  sha256: d1f0a40fe5ee1cedfce64a233d7824d7cfd631cc1926efd76b3b3dd24038fa61
+  md5: 9b413c1921a9139e11035146f974d5b7
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - libprotobuf >=5.28.3,<5.28.4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 467437
+  timestamp: 1735630529216
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.3-py311haeb46be_1.conda
+  sha256: ad35c52521f0946caf06e19fd3dfad55f7b30e46648f96214f59d8ca2dac95ad
+  md5: ca32a9963a1b5c636b5131831ded81f3
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14864168
+  timestamp: 1726879042435
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.1.0-py311h25da234_0.conda
+  sha256: a04db4036102af89cc1c64963a90fae596d650338909380b92984703a3ec5e31
+  md5: bd7476bdaad356e51ad68ed077cda405
+  depends:
+  - __osx >=10.13
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.5.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.3,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 42402940
+  timestamp: 1735929955131
+- conda: https://conda.anaconda.org/conda-forge/osx-64/prometheus-cpp-1.3.0-h7802330_0.conda
+  sha256: af754a477ee2681cb7d5d77c621bd590d25fe1caf16741841fc2d176815fc7de
+  md5: f36107fa2557e63421a46676371c4226
+  depends:
+  - __osx >=10.13
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 179103
+  timestamp: 1730769223221
+- conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.0.0-py311h4d7f069_0.conda
+  sha256: e290563f61f810f745b32d4c1ebe4ec87827323134f6bee2e8cc894391cbc548
+  md5: 7b5cdf63ced6576ead40a82ea0616322
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 490169
+  timestamp: 1740663371249
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+  sha256: 05944ca3445f31614f8c674c560bca02ff05cb51637a96f665cb2bbe496099e5
+  md5: 8bcf980d2c6b17094961198284b8e862
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 8364
+  timestamp: 1726802331537
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-19.0.1-py311h6eed73b_0.conda
+  sha256: 5aa355886986ba381339ba2afc7ae66c9c7d4ff940c51d18ae19fbb33bc8a915
+  md5: 68e11d584e7dce6123e115f13ea3399a
+  depends:
+  - libarrow-acero 19.0.1.*
+  - libarrow-dataset 19.0.1.*
+  - libarrow-substrait 19.0.1.*
+  - libparquet 19.0.1.*
+  - pyarrow-core 19.0.1 *_0_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25346
+  timestamp: 1739792659881
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-19.0.1-py311he02522f_0_cpu.conda
+  sha256: bcf7b80a64e5ca9c2c9fd2399bff6e31be80b8ac608f72e4abad55a646baf2fe
+  md5: 1d422c3c27c9c986b46e15494c539f27
+  depends:
+  - __osx >=10.13
+  - libarrow 19.0.1.* *cpu
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - numpy >=1.21,<3
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4547265
+  timestamp: 1739792627234
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-11.0-py311hfbc4093_0.conda
+  sha256: 7cc9dd5c836631c733173c88187231bfc0438135e0ddf94e866e45b3d10592bd
+  md5: 3b2f520d27fa7cf9c6c73fb43c69a321
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 489258
+  timestamp: 1736891091428
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-11.0-py311hfbc4093_0.conda
+  sha256: 94e00e4c9b5c5d8b2374321a0f908b7812b06ac8c9cb99242ddaa4ea0091f0be
+  md5: d16654f6b3f602bb0acab446c55bcafb
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 11.0.*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 385111
+  timestamp: 1736927116099
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.11-h9ccd52b_1_cpython.conda
+  sha256: 4c53c4c48a0f42577ae405553ab899b3ef5ee23b2a1bf4fbbc694c46f884f6fc
+  md5: 9b20fb7c571405d29f33ae2fc5990d8d
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.4.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 14221518
+  timestamp: 1733409959819
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
+  sha256: 9b092850a268aca99600b724bae849f51209ecd5628e609b4699debc59ff1945
+  md5: e6d62858c06df0be0e6255c753d74787
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6303
+  timestamp: 1723823062672
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311ha3cf9ac_2.conda
+  sha256: 4855c51eedcde05f3d9666a0766050c7cbdff29b150d63c1adc4071637ba61d7
+  md5: f49b0da3b1e172263f4f1e2f261a490d
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 197287
+  timestamp: 1737454852180
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.2.1-py311hb21797c_0.conda
+  sha256: 21f069a7e5f198b81498120bf640f25b7971a04404f603b97f778dec4aa508ea
+  md5: 4af57ccfca6c171154436ae698fa88a0
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 369822
+  timestamp: 1738271196282
+- conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+  sha256: 79d804fa6af9c750e8b09482559814ae18cd8df549ecb80a4873537a5a31e06e
+  md5: dd1ea9ff27c93db7c01a7b7656bd4ad4
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: LicenseRef-Qhull
+  size: 528122
+  timestamp: 1720814002588
+- conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2024.07.02-ha5e900a_2.conda
+  sha256: 960729dd943daff21bf2b1f5a9380c17420c5307d4d250766525e266bd0acca7
+  md5: 5fd6022c97d78c252f1cc8d7433e97d0
+  depends:
+  - libre2-11 2024.07.02 h0e468a2_2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26920
+  timestamp: 1735541096841
+- conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h7cca4af_2.conda
+  sha256: 53017e80453c4c1d97aaf78369040418dea14cf8f46a2fa999f31bd70b36c877
+  md5: 342570f8e02f2f022147a7f841475784
+  depends:
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 256712
+  timestamp: 1740379577668
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.23.1-py311hab9d7c2_0.conda
+  sha256: d83ef060f75ea5b87ee1142c6e54140fcd7f34b21cd7cd55c78bdcce457f19af
+  md5: d4d43afca6dd6e0667ce236df9d942e3
+  depends:
+  - python
+  - __osx >=10.13
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 383768
+  timestamp: 1740153197689
+- conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.15.2-py311h0c91ca8_0.conda
+  sha256: 796252d7772df42edd29a45ae70eb18843a7e476d42c96c273cd6e677ec148c8
+  md5: 58c17d411ed0cd1220ed3e824a3efc82
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.5
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15759628
+  timestamp: 1739792317052
+- conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-haf3c120_1.conda
+  sha256: 26e8a2edd2a12618d9adcdcfc6cfd9adaca8da71aa334615d29e803d225b52be
+  md5: 9d6ae6d5232233e1a01eb7db524078fb
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36813
+  timestamp: 1733502097580
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+  sha256: 30412b2e9de4ff82d8c2a7e5d06a15f4f4fef1809a72138b6ccb53a33b26faf5
+  md5: bf830ba5afc507c6232d4ef0fb1a882d
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3270220
+  timestamp: 1699202389792
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.2-py311h4d7f069_0.conda
+  sha256: 5273ba307489570df61d82a6b3365b2a27862765099cf4ef3830569fa4a30f27
+  md5: 073c42a2b6b7e4219325b1f5983c7579
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 858750
+  timestamp: 1732616082798
+- conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-16.0.0-py311h4d7f069_0.conda
+  sha256: 57ece538ef5ffbb61eabe2972b05dfba0f3c48991bd406fa3ed34203102fba5b
+  md5: 8eec66bc3c7fccd3c4eec33f729aeb29
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 400137
+  timestamp: 1736692685449
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.12-h6e16a3a_0.conda
+  sha256: b4d2225135aa44e551576c4f3cf999b3252da6ffe7b92f0ad45bb44b887976fc
+  md5: 4cf40e60b444d56512a64f39d12c20bd
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 13290
+  timestamp: 1734229077182
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
+  sha256: bb4d1ef9cafef535494adf9296130b6193b3a44375883185b5167de03eb1ac7f
+  md5: 9f438e1b6f4e73fd9e6d78bfe7c36743
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 18465
+  timestamp: 1727794980957
+- conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+  sha256: 5301417e2c8dea45b401ffee8df3957d2447d4ce80c83c5ff151fc6bfe1c4148
+  md5: d7e08fcf8259d742156188e8762b4d20
+  license: MIT
+  license_family: MIT
+  size: 84237
+  timestamp: 1641347062780
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h7130eaa_7.conda
+  sha256: b932dce8c9de9a8ffbf0db0365d29677636e599f7763ca51e554c43a0c5f8389
+  md5: 6a0a76cd2b3d575e1b7aaeb283b9c3ed
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.3,<1.22.0a0
+  - libcxx >=18
+  - libsodium >=1.0.20,<1.0.21.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 292112
+  timestamp: 1731585246902
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-hd23fc13_2.conda
+  sha256: 219edbdfe7f073564375819732cbf7cc0d7c7c18d3f546a09c2dfaf26e4d69f3
+  md5: c989e0295dcbdc08106fe5d9e935f0b9
+  depends:
+  - __osx >=10.13
+  - libzlib 1.3.1 hd23fc13_2
+  license: Zlib
+  license_family: Other
+  size: 88544
+  timestamp: 1727963189976
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.19.0-py311h5547dcb_0.tar.bz2
+  sha256: b470229c05df4d96d27904def00660b5dfa7ad57bf2b9dfd826325233f9e8510
+  md5: 96e4e2aa960398abbe5c4a6cf22269b8
+  depends:
+  - cffi >=1.8
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 778546
+  timestamp: 1667296539861
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h8210216_1.conda
+  sha256: 60042f68a56124b72c7fedc3c45bf8da7a53665175fcebdf1e248f6d9a59f339
+  md5: b6931d7aedc272edf329a632d840e3d9
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 486288
+  timestamp: 1740255318890
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311h460d6c5_5.conda
+  sha256: 6eabd1bcefc235b7943688d865519577d7668a2f4dc3a24ee34d81eb4bfe77d1
+  md5: 1e8260965552c6ec86453b7d15a598de
+  depends:
+  - __osx >=11.0
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 33008
+  timestamp: 1725356833036
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.8.1-hfc2798a_0.conda
+  sha256: 5a60d196a585b25d1446fb973009e4e648e8d70beaa2793787243ede6da0fd9a
+  md5: 0abd67c0f7b60d50348fbb32fef50b65
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.8.1,<0.8.2.0a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-http >=0.9.2,<0.9.3.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  - aws-c-sdkutils >=0.2.2,<0.2.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 92562
+  timestamp: 1737509877079
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.8.1-hc8a0bd2_3.conda
+  sha256: 1f44be36e1daa17b4b081debb8aee492d13571084f38b503ad13e869fef24fe4
+  md5: 8b0ce61384e5a33d2b301a64f3d22ac5
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 39925
+  timestamp: 1733991649383
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.10.6-h5505292_0.conda
+  sha256: 3bde135c8e74987c0f79ecd4fa17ec9cff0d658b3090168727ca1af3815ae57a
+  md5: 145e5b4c9702ed279d7d68aaf096f77d
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 221863
+  timestamp: 1733975576886
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.0-hc8a0bd2_5.conda
+  sha256: 47b2813f652ce7e64ac442f771b2a5f7d4af4ad0d07ff51f6075ea80ed2e3f09
+  md5: a8b6c17732d14ed49d0e9b59c43186bc
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18068
+  timestamp: 1733991869211
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.5.0-h54f970a_11.conda
+  sha256: f0667935f4e0d4c25e0e51da035640310b5ceeb8f723156734439bde8b848d7d
+  md5: ba41238f8e653998d7d2f42e3a8db054
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 47078
+  timestamp: 1734024749727
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.9.2-h96aa502_4.conda
+  sha256: 22e4737c8a885995b7c1ae1d79c1f6e78d489e16ec079615980fdde067aeaf76
+  md5: 495c93a4f08b17deb3c04894512330e6
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.8.1,<0.8.2.0a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-compression >=0.3.0,<0.3.1.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152983
+  timestamp: 1734008451473
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.15.3-haba67d1_6.conda
+  sha256: 73722dd175af78b6cbfa033066f0933351f5382a1a737f6c6d9b8cfa84022161
+  md5: d02e8f40ff69562903e70a1c6c48b009
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.8.1,<0.8.2.0a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 136048
+  timestamp: 1737207681224
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.11.0-h24f418c_12.conda
+  sha256: 96575ea1dd2a9ea94763882e40a66dcbff9c41f702bf37c9514c4c719b3c11dd
+  md5: c072045a6206f88015d02fcba1705ea1
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-http >=0.9.2,<0.9.3.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 134371
+  timestamp: 1734025379525
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.7.9-hf37e03c_1.conda
+  sha256: 92e8ca4eefcbbdf4189584c9410382884a06ed3030e5ecaac656dab8c95e6a80
+  md5: de65f5e4ab5020103fe70a0eba9432a0
+  depends:
+  - __osx >=11.0
+  - aws-c-auth >=0.8.1,<0.8.2.0a0
+  - aws-c-cal >=0.8.1,<0.8.2.0a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-http >=0.9.2,<0.9.3.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 98731
+  timestamp: 1737558731831
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.2-hc8a0bd2_0.conda
+  sha256: ea4f0f1e99056293c69615f581a997d65ba7e229e296e402e0d8ef750648a5b5
+  md5: e7b5498ac7b7ab921a907be38f3a8080
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 49872
+  timestamp: 1736536152332
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.2-hc8a0bd2_4.conda
+  sha256: 215086d95e8ff1d3fcb0197ada116cc9d7db1fdae7573f5e810d20fa9215b47c
+  md5: e70e88a357a3749b67679c0788c5b08a
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 70186
+  timestamp: 1733994496998
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.29.9-ha81f72f_2.conda
+  sha256: ed5f1d19aad53787fdebe13db4709c97eae2092536cc55d3536eba320c4286e1
+  md5: c9c034d3239bf25687ca4dd985007ecd
+  depends:
+  - __osx >=11.0
+  - aws-c-auth >=0.8.1,<0.8.2.0a0
+  - aws-c-cal >=0.8.1,<0.8.2.0a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-c-http >=0.9.2,<0.9.3.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  - aws-c-mqtt >=0.11.0,<0.11.1.0a0
+  - aws-c-s3 >=0.7.9,<0.7.10.0a0
+  - aws-c-sdkutils >=0.2.2,<0.2.3.0a0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 235976
+  timestamp: 1737565563139
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.489-h0e5014b_0.conda
+  sha256: d82451530ddf363d8bb31a8a7391bb9699f745e940ace91d78c0e6170deef03c
+  md5: 156cfb45a1bb8cffc81e59047bb34f51
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - aws-crt-cpp >=0.29.9,<0.29.10.0a0
+  - libcurl >=8.11.1,<9.0a0
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2874126
+  timestamp: 1737577023623
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.14.0-hd50102c_0.conda
+  sha256: f5b91329ed59ffc0be8747784c6e4cc7e56250c54032883a83bc11808ef6a87e
+  md5: f093a11dcf3cdcca010b20a818fcc6dc
+  depends:
+  - __osx >=11.0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 294299
+  timestamp: 1728054014060
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.10.0-hc602bab_0.conda
+  sha256: bde446b916fff5150606f8ed3e6058ffc55a3aa72381e46f1ab346590b1ae40a
+  md5: d7b71593a937459f2d4b67e1a4727dc2
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 166907
+  timestamp: 1728486882502
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.13.0-h7585a09_1.conda
+  sha256: 08d52d130addc0fb55d5ba10d9fa483e39be25d69bac7f4c676c2c3069207590
+  md5: 704238ef05d46144dae2e6b5853df8bc
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 438636
+  timestamp: 1728578216193
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.8.0-h9ca1f76_1.conda
+  sha256: 77ab04e8fe5636a2de9c718f72a43645f7502cd208868c8a91ffba385547d585
+  md5: 7a187cd7b1445afc80253bb186a607cc
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - libxml2 >=2.12.7,<2.14.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 121278
+  timestamp: 1728563418777
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.12.0-hcdd55da_1.conda
+  sha256: f48523f8aa0b5b80f45a92f0556b388dd96f44ac2dc2f44a01d08c1822eec97d
+  md5: c49fbc5233fcbaa86391162ff1adef38
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 196032
+  timestamp: 1728729672889
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hd74edd7_2.conda
+  sha256: a086f36ff68d6e30da625e910547f6211385246fb2474b144ac8c47c32254576
+  md5: 215e3dc8f2f837906d066e7f01aa77c0
+  depends:
+  - __osx >=11.0
+  - brotli-bin 1.1.0 hd74edd7_2
+  - libbrotlidec 1.1.0 hd74edd7_2
+  - libbrotlienc 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 19588
+  timestamp: 1725268044856
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hd74edd7_2.conda
+  sha256: 28f1af63b49fddf58084fb94e5512ad46e9c453eb4be1d97449c67059e5b0680
+  md5: b8512db2145dc3ae8d86cdc21a8d421e
+  depends:
+  - __osx >=11.0
+  - libbrotlidec 1.1.0 hd74edd7_2
+  - libbrotlienc 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 16772
+  timestamp: 1725268026061
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311h3f08180_2.conda
+  sha256: f507d65e740777a629ceacb062c768829ab76fde01446b191699a734521ecaad
+  md5: c8793a23206344faa25f4e0b5d0e7908
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 339584
+  timestamp: 1725268241628
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+  sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
+  md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
+  depends:
+  - __osx >=11.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 122909
+  timestamp: 1720974522888
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.4-h5505292_0.conda
+  sha256: 09c0c8476e50b2955f474a4a1c17c4c047dd52993b5366b6ea8e968e583b921f
+  md5: c1c999a38a4303b29d75c636eaa13cf9
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 179496
+  timestamp: 1734208291879
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2025.1.31-hf0a4a13_0.conda
+  sha256: 7e12816618173fe70f5c638b72adf4bfd4ddabf27794369bb17871c5bb75b9f9
+  md5: 3569d6a9141adc64d2fe4797f3289e06
+  license: ISC
+  size: 158425
+  timestamp: 1738298167688
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py311h3a79f62_0.conda
+  sha256: 253605b305cc4548b8f97eb7c2e146697e0c7672b099c4862ec5ca7e8e995307
+  md5: a42272c5dbb6ffbc1a5af70f24c7b448
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 288211
+  timestamp: 1725560745212
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.1-py311h210dab8_0.conda
+  sha256: 8e755206b38a6e14861c79a74b51af76124bdf5c266dd6a584305e03d37c2e0c
+  md5: 7f9e9df2d62cf69aed450f6957a23e61
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 247202
+  timestamp: 1731428753912
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.0.1-py311h917b07b_0.conda
+  sha256: e555f5ca8fec8315c318a061bdcec24d58e3a0e51d2e9cfee4a858868ca972af
+  md5: 29bb5e1effb961954ba06e414b913b90
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 342319
+  timestamp: 1734107577755
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.12-py311h155a34a_0.conda
+  sha256: e97c4f4f3a0f8b965b9da6c56d85ea14f4b1a79ae67fbe65295d601b43b984ac
+  md5: 0ade5b937d2aa208c872d35eedc5e6c7
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2461504
+  timestamp: 1737269987625
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.56.0-py311h4921393_0.conda
+  sha256: 53ea25e44624765605da9f9025e8a8caff880ad7933550600a60a0c1be7466c2
+  md5: 81ba3e94da9bae67bf6e6400655a8024
+  depends:
+  - __osx >=11.0
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2785844
+  timestamp: 1738940725502
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+  sha256: 791673127e037a2dc0eebe122dc4f904cb3f6e635bb888f42cbe1a76b48748d9
+  md5: e6085e516a3e304ce41a8ee08b9b89ad
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 596430
+  timestamp: 1694616332835
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
+  sha256: fd56ed8a1dab72ab90d8a8929b6f916a6d9220ca297ff077f8f04c5ed3408e20
+  md5: 57a511a5905caa37540eb914dfcbf1fb
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 82090
+  timestamp: 1726600145480
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
+  sha256: 9fc77de416953aa959039db72bc41bfa4600ae3ff84acad04a7d0c1ab9552602
+  md5: fef68d0a95aa5b84b5c1a4f6f3bf40e1
+  depends:
+  - __osx >=11.0
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 112215
+  timestamp: 1718284365403
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py311h267d04e_1.conda
+  sha256: 736304347653ed421b13c56ba6f4f87c1d78d24cd3fa74db0db6fb70c814fa65
+  md5: 5bce88ac1bef7d47c62cb574b25891ae
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18253
+  timestamp: 1725303181400
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.7-py311h2c37856_0.conda
+  sha256: 8ffc46f6e99c95c48426cf34c033d16cde3bcf100cd74d1d74a33943a85a6ec8
+  md5: ee572d19da1346db8e78cb8e7d5d2330
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59357
+  timestamp: 1725459504453
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+  sha256: 4442f957c3c77d69d9da3521268cad5d54c9033f1a73f99cde0a3658937b159b
+  md5: c6dc8a0fdec13a0565936655c33069a1
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1155530
+  timestamp: 1719463474401
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.17-h7eeda09_0.conda
+  sha256: 310a62c2f074ebd5aa43b3cd4b00d46385ce680fa2132ecee255a200e2d2f15f
+  md5: 92a61fd30b19ebd5c1621a5bfe6d8b5f
+  depends:
+  - __osx >=11.0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 212125
+  timestamp: 1739161108467
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+  sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
+  md5: de462d5aacda3b30721b512c5da4e742
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 215721
+  timestamp: 1657977558796
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_h07bc746_4.conda
+  sha256: 05fa5e5e908962b9c5aba95f962e2ca81d9599c4715aebe5e4ddb72b309d1770
+  md5: c2d95bd7aa8d564a9bd7eca5e571a5b3
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  constrains:
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1178260
+  timestamp: 1736008642885
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-19.0.1-h0945df6_0_cpu.conda
+  sha256: e34199bea635b1bf9f3819205b291f714ddd47db1bf6e6d10a4eb61da7330214
+  md5: 21bcb04df4b1a99721199c5aa6273f53
+  depends:
+  - __osx >=11.0
+  - aws-crt-cpp >=0.29.9,<0.29.10.0a0
+  - aws-sdk-cpp >=1.11.489,<1.11.490.0a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-identity-cpp >=1.10.0,<1.10.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-files-datalake-cpp >=12.12.0,<12.12.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=18
+  - libgoogle-cloud >=2.35.0,<2.36.0a0
+  - libgoogle-cloud-storage >=2.35.0,<2.36.0a0
+  - libopentelemetry-cpp >=1.18.0,<1.19.0a0
+  - libprotobuf >=5.28.3,<5.28.4.0a0
+  - libre2-11 >=2024.7.2
+  - libutf8proc >=2.10.0,<2.11.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - orc >=2.0.3,<2.0.4.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - arrow-cpp <0.0a0
+  - parquet-cpp <0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5571369
+  timestamp: 1739767084108
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-19.0.1-hf07054f_0_cpu.conda
+  sha256: b15f5fab53d941917143bb1cf22c5a0eacffb8ff2a010ee2e909afab3821d5f9
+  md5: 9213d80ffba1921b86bfdf5fdd2c10c4
+  depends:
+  - __osx >=11.0
+  - libarrow 19.0.1 h0945df6_0_cpu
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: APACHE
+  size: 500147
+  timestamp: 1739767179329
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-19.0.1-hf07054f_0_cpu.conda
+  sha256: 21fcb9a09e5872b4f1d483d8d950a1804ccb6804881881ca6fe6c5968a5e4dbc
+  md5: 0695382a64b393765b4bc9e1ee99250c
+  depends:
+  - __osx >=11.0
+  - libarrow 19.0.1 h0945df6_0_cpu
+  - libarrow-acero 19.0.1 hf07054f_0_cpu
+  - libcxx >=18
+  - libparquet 19.0.1 h636d7b7_0_cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 501234
+  timestamp: 1739768239766
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-19.0.1-h4239455_0_cpu.conda
+  sha256: 0b5c0839102b396f8b0ba376189562a727ebbed3c6bdab74aaf56227ee45cb73
+  md5: 2893dd55f7804b9106126c2f00712ec2
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 19.0.1 h0945df6_0_cpu
+  - libarrow-acero 19.0.1 hf07054f_0_cpu
+  - libarrow-dataset 19.0.1 hf07054f_0_cpu
+  - libcxx >=18
+  - libprotobuf >=5.28.3,<5.28.4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 450361
+  timestamp: 1739768396169
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-31_h10e41b3_openblas.conda
+  sha256: 369586e7688b59b4f92c709b99d847d66d4d095425db327dd32ee5e6ab74697f
+  md5: 39b053da5e7035c6592102280aa7612a
+  depends:
+  - libopenblas >=0.3.29,<0.3.30.0a0
+  - libopenblas >=0.3.29,<1.0a0
+  constrains:
+  - liblapacke =3.9.0=31*_openblas
+  - libcblas =3.9.0=31*_openblas
+  - blas =2.131=openblas
+  - mkl <2025
+  - liblapack =3.9.0=31*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17123
+  timestamp: 1740088119350
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hd74edd7_2.conda
+  sha256: 839dacb741bdbb25e58f42088a2001b649f4f12195aeb700b5ddfca3267749e5
+  md5: d0bf1dff146b799b319ea0434b93f779
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 68426
+  timestamp: 1725267943211
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hd74edd7_2.conda
+  sha256: 6c6862eb274f21a7c0b60e5345467a12e6dda8b9af4438c66d496a2c1a538264
+  md5: 55e66e68ce55523a6811633dd1ac74e2
+  depends:
+  - __osx >=11.0
+  - libbrotlicommon 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 28378
+  timestamp: 1725267980316
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hd74edd7_2.conda
+  sha256: eeb1eb0d58b9d02bc1b98dc0a058f104ab168eb2f7d1c7bfa0570a12cfcdb7b7
+  md5: 4f3a434504c67b2c42565c0b85c1885c
+  depends:
+  - __osx >=11.0
+  - libbrotlicommon 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 279644
+  timestamp: 1725268003553
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-31_hb3479ef_openblas.conda
+  sha256: f237486cc9118d09d0f3ff8820280de34365f98ee7b7dc5ab923b04c7cbf25a5
+  md5: 7353c2bf0e90834cb70545671996d871
+  depends:
+  - libblas 3.9.0 31_h10e41b3_openblas
+  constrains:
+  - liblapacke =3.9.0=31*_openblas
+  - blas =2.131=openblas
+  - liblapack =3.9.0=31*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17032
+  timestamp: 1740088127097
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+  sha256: 58477b67cc719060b5b069ba57161e20ba69b8695d154a719cb4b60caf577929
+  md5: 32bd82a6a625ea6ce090a81c3d34edeb
+  depends:
+  - libcxx >=11.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18765
+  timestamp: 1633683992603
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.12.1-h73640d1_0.conda
+  sha256: 0bddd1791eb0602c8c6aa465802e9d4526d3ec1251d900b209e767753565d5df
+  md5: 105f0cceef753644912f42e11c1ae9cf
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.64.0,<2.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.1,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 387893
+  timestamp: 1739512564746
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.7-ha82da77_0.conda
+  sha256: 776092346da87a2a23502e14d91eb0c32699c4a1522b7331537bd1c3751dcff5
+  md5: 5b3e1610ff8bd5443476b91d618f5b77
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 523505
+  timestamp: 1736877862502
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.23-hec38601_0.conda
+  sha256: 887c02deaed6d583459eba6367023e36d8761085b2f7126e389424f57155da53
+  md5: 1d8b9588be14e71df38c525767a1ac30
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 54132
+  timestamp: 1734373971372
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
+  sha256: 66aa216a403de0bb0c1340a88d1a06adaff66bae2cfd196731aa24db9859d631
+  md5: 44083d2d2c2025afca315c7a172eab2b
+  depends:
+  - ncurses
+  - __osx >=11.0
+  - ncurses >=6.5,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 107691
+  timestamp: 1738479560845
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+  sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
+  md5: 36d33e440c31857372a72137f78bacf5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 107458
+  timestamp: 1702146414478
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+  sha256: 8c136d7586259bb5c0d2b913aaadc5b9737787ae4f40e3ad1beaf96c80b919b7
+  md5: 1a109764bff3bdc7bdd84088347d71dc
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 368167
+  timestamp: 1685726248899
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
+  sha256: e42ab5ace927ee7c84e3f0f7d813671e1cf3529f5f06ee5899606630498c2745
+  md5: 38d2656dd914feb0cab8c629370768bf
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 64693
+  timestamp: 1730967175868
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+  md5: 086914b672be056eb70fd4285b6783b6
+  license: MIT
+  license_family: MIT
+  size: 39020
+  timestamp: 1636488587153
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+  sha256: 44e541b4821c96b28b27fef5630883a60ce4fee91fd9c79f25a199f8f73f337b
+  md5: 4a55d9e169114b2b90d3ec4604cd7bbf
+  depends:
+  - libgfortran5 13.2.0 hf226fd6_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110233
+  timestamp: 1707330749033
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+  sha256: bafc679eedb468a86aa4636061c55966186399ee0a04b605920d208d97ac579a
+  md5: 66ac81d54e95c534ae488726c1f698ea
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 997381
+  timestamp: 1707330687590
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.35.0-hdbe95d5_0.conda
+  sha256: 9bee9773540956d8a2ca0b317f73d94916200a4bfd8151319bf7fdcbf704d692
+  md5: b1ea94282f38b142f8bc842ef7bcc18c
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.11.1,<9.0a0
+  - libcxx >=18
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libprotobuf >=5.28.3,<5.28.4.0a0
+  - openssl >=3.4.0,<4.0a0
+  constrains:
+  - libgoogle-cloud 2.35.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 877733
+  timestamp: 1738662822079
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.35.0-h7081f7f_0.conda
+  sha256: 52dc2d18264543b564b59fb80338fbd9cb2296f011d75f41adcd85041795201c
+  md5: 958beca4e16f59360e30c48ff0351e04
+  depends:
+  - __osx >=11.0
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libcxx >=18
+  - libgoogle-cloud 2.35.0 hdbe95d5_0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  size: 529210
+  timestamp: 1738664024959
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.67.1-h0a426d6_1.conda
+  sha256: 630edf63981818ff590367cb95fddbed0f5a390464d0952c90ec81de899e84a6
+  md5: 8a3cba079d6ac985e7d73c76a678fbb4
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.34.4,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=18
+  - libprotobuf >=5.28.3,<5.28.4.0a0
+  - libre2-11 >=2024.7.2
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.67.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5311706
+  timestamp: 1735585137716
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-hfe07756_1.conda
+  sha256: d30780d24bf3a30b4f116fca74dedb4199b34d500fe6c52cced5f8cc1e926f03
+  md5: 450e6bdc0c7d986acf7b8443dce87111
+  depends:
+  - __osx >=11.0
+  license: LGPL-2.1-only
+  size: 681804
+  timestamp: 1740128227484
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+  sha256: a42054eaa38e84fc1e5ab443facac4bbc9d1b6b6f23f54b7bf4f1eb687e1d993
+  md5: 3ff1e053dc3a2b8e36b9bfa4256a58d1
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 547541
+  timestamp: 1694475104253
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-31_hc9a63f6_openblas.conda
+  sha256: fe55b9aaf82c6c0192c3d1fcc9b8e884f97492dda9a8de5dae29334b3135fab5
+  md5: ff57a55a2cbce171ef5707fb463caf19
+  depends:
+  - libblas 3.9.0 31_h10e41b3_openblas
+  constrains:
+  - liblapacke =3.9.0=31*_openblas
+  - libcblas =3.9.0=31*_openblas
+  - blas =2.131=openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17033
+  timestamp: 1740088134988
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm15-15.0.7-h4429f82_5.conda
+  sha256: e2806042e60b1a92747298ea30007f50443e879881886c743d2ade30a1bd7da4
+  md5: e81ccd3b5e036152fe9b7be87282201b
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 22216441
+  timestamp: 1739672571591
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.6.4-h39f12f2_0.conda
+  sha256: 560c59d3834cc652a84fb45531bd335ad06e271b34ebc216e380a89798fe8e2c
+  md5: e3fd1f8320a100f2b210e690a57cd615
+  depends:
+  - __osx >=11.0
+  constrains:
+  - xz ==5.6.4=*_0
+  license: 0BSD
+  size: 98945
+  timestamp: 1738525462560
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
+  sha256: 00cc685824f39f51be5233b54e19f45abd60de5d8847f1a56906f8936648b72f
+  md5: 3408c02539cee5f1141f9f11450b6a51
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.34.2,<2.0a0
+  - libcxx >=17
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 566719
+  timestamp: 1729572385640
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.29-openmp_hf332438_0.conda
+  sha256: 8989d9e01ec8c9b2d48dbb5efbe70b356fcd15990fb53b64fcb84798982c0343
+  md5: 0cd1148c68f09027ee0b0f0179f77c30
+  depends:
+  - __osx >=11.0
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - llvm-openmp >=18.1.8
+  constrains:
+  - openblas >=0.3.29,<0.3.30.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4168442
+  timestamp: 1739825514918
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-1.18.0-h0c05b2d_1.conda
+  sha256: c6bcbd53d62a9e0d8c667e560db0ca2ecb7679277cbb3c23457aabe74fcb8cba
+  md5: 19c46cc18825f3924251c39ec1b0d983
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.11.1,<9.0a0
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libopentelemetry-cpp-headers 1.18.0 hce30654_1
+  - libprotobuf >=5.28.3,<5.28.4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - nlohmann_json
+  - prometheus-cpp >=1.3.0,<1.4.0a0
+  constrains:
+  - cpp-opentelemetry-sdk =1.18.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 529588
+  timestamp: 1735643889612
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.18.0-hce30654_1.conda
+  sha256: 82e5f5ba64debbaab3c601b265dfc0cdb4d2880feba9bada5fd2e67b9f91ada5
+  md5: e965dad955841507549fdacd8f7f94c0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 320565
+  timestamp: 1735643673319
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-19.0.1-h636d7b7_0_cpu.conda
+  sha256: 54e4a18493d63b7fbd5cf39fadabe665bcf462121a7bc2f394f510b0bcf22031
+  md5: 0cce19e6981849babe6c73797abbfa4e
+  depends:
+  - __osx >=11.0
+  - libarrow 19.0.1 h0945df6_0_cpu
+  - libcxx >=18
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.4.1,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 895659
+  timestamp: 1739768176454
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.47-h3783ad8_0.conda
+  sha256: dc93cc30f59b28e7812c6f14d2c2e590b509c38092cce7ababe6b23541b7ed8f
+  md5: 3550e05e3af94a3fa9cef2694417ccdf
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 259332
+  timestamp: 1739953032676
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.28.3-h3bd63a1_1.conda
+  sha256: f58a16b13ad53346903c833e266f83c3d770a43a432659b98710aed85ca885e7
+  md5: bdbfea4cf45ae36652c6bbcc2e7ebe91
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2271580
+  timestamp: 1735576361997
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2024.07.02-h07bc746_2.conda
+  sha256: 112a73ad483353751d4c5d63648c69a4d6fcebf5e1b698a860a3f5124fc3db96
+  md5: 6b1e3624d3488016ca4f1ca0c412efaa
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=18
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 167155
+  timestamp: 1735541067807
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
+  sha256: fade8223e1e1004367d7101dd17261003b60aa576df6d7802191f8972f7470b1
+  md5: a7ce36e284c5faaf93c220dfc39e3abd
+  depends:
+  - __osx >=11.0
+  license: ISC
+  size: 164972
+  timestamp: 1716828607917
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.49.1-h3f77e49_1.conda
+  sha256: 266639fb10ca92287961574b0b4d6031fa40dd9d723d64a0fcb08513a24dab03
+  md5: c83357a21092bd952933c36c5cb4f4d6
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 898767
+  timestamp: 1739953312379
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h9cc3647_0.conda
+  sha256: f7047c6ed44bcaeb04432e8c74da87591940d091b0a3940c0d884b7faa8062e9
+  md5: ddc7194676c285513706e5fc64f214d7
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279028
+  timestamp: 1732349599461
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.21.0-h64651cc_0.conda
+  sha256: 7a6c7d5f58cbbc2ccd6493b4b821639fdb0701b9b04c737a949e8cb6adf1c9ad
+  md5: 7ce2bd2f650f8c31ad7ba4c7bfea61b7
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 324342
+  timestamp: 1727206096912
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-h551f018_3.conda
+  sha256: 91417846157e04992801438a496b151df89604b2e7c6775d6f701fcd0cbed5ae
+  md5: a5d084a957563e614ec0c0196d890654
+  depends:
+  - __osx >=11.0
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=18
+  - libdeflate >=1.23,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 370600
+  timestamp: 1734398863052
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.10.0-hda25de7_0.conda
+  sha256: aca3ef31d3dff5cefd3790742a5ee6548f1cf0201d0e8cee08b01da503484eb6
+  md5: 5f741aed1d8d393586a5fdcaaa87f45c
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 83628
+  timestamp: 1737244450097
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.5.0-h2471fea_0.conda
+  sha256: f8bdb876b4bc8cb5df47c28af29188de8911c3fea4b799a33743500149de3f4a
+  md5: 569466afeb84f90d5bb88c11cc23d746
+  depends:
+  - __osx >=11.0
+  constrains:
+  - libwebp 1.5.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 290013
+  timestamp: 1734777593617
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+  sha256: bd3816218924b1e43b275863e21a3e13a5db4a6da74cca8e60bc3c213eb62f71
+  md5: af523aae2eca6dfa1c8eec693f5b9a79
+  depends:
+  - __osx >=11.0
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 323658
+  timestamp: 1727278733917
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.13.6-hce475f1_0.conda
+  sha256: 9ce429417545f7616ed528061305b3a1fc3732ff3bb24bd91cba260550879693
+  md5: 8654012bd68aa48b94eee6c9faab85b6
+  depends:
+  - __osx >=11.0
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.6.4,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - icu <0.0a0
+  license: MIT
+  license_family: MIT
+  size: 582490
+  timestamp: 1739953065675
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
+  md5: 369964e85dc26bfe78f41399b366c435
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 46438
+  timestamp: 1727963202283
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.7-hdb05f8b_0.conda
+  sha256: b92a669f2059874ebdcb69041b6c243d68ffc3fb356ac1339cec44aeb27245d7
+  md5: c4d54bfd3817313ce758aa76283b118d
+  depends:
+  - __osx >=11.0
+  constrains:
+  - openmp 19.1.7|19.1.7.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 280830
+  timestamp: 1736986295869
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.44.0-py311h55fc170_0.conda
+  sha256: 1db49e77594b1e5e0334ddd4498ed65833516268f591441902b7220256cf92d8
+  md5: a37417f30f2937534ec7a199c6654537
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 422228
+  timestamp: 1738108883750
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-4.3.3-py311h3a49619_2.conda
+  sha256: 61f72f410e78e23797ea4b425af63363485d736484acbc494b2442af1ae2387b
+  md5: 4e3c4e767bbd510c715a0f6f9a82194f
+  depends:
+  - __osx >=11.0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105483
+  timestamp: 1733474482334
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
+  sha256: 94d3e2a485dab8bdfdd4837880bde3dd0d701e2b97d6134b8806b7c8e69c8652
+  md5: 01511afc6cc1909c5303cf31be17b44f
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 148824
+  timestamp: 1733741047892
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py311h4921393_1.conda
+  sha256: 4f738a7c80e34e5e5d558e946b06d08e7c40e3cc4bdf08140bf782c359845501
+  md5: 249e2f6f5393bb6b36b3d3a3eebdcdf9
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24976
+  timestamp: 1733219849253
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.10.0-py311h031da69_0.conda
+  sha256: 06deb385f6f8f24971eda85de29e8b51c718afe60ab15a95d70415d89995022f
+  md5: 2dc432b2e3cb82366e2e468c0ec0c757
+  depends:
+  - __osx >=11.0
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=18
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8154531
+  timestamp: 1734380983726
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.0-py311h2c37856_0.conda
+  sha256: aafa8572c72283801148845772fd9d494765bdcf1b8ae6f435e1caff4f1c97f3
+  md5: 6c826762702474fb0def6cedd2db5316
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 91131
+  timestamp: 1725975234150
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
+  sha256: 2827ada40e8d9ca69a153a45f7fd14f32b2ead7045d3bbb5d10964898fe65733
+  md5: 068d497125e4bf8a66bf707254fff5ae
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  size: 797030
+  timestamp: 1738196177597
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.11.3-h00cdb27_1.conda
+  sha256: 3f4e6a4fa074bb297855f8111ab974dab6d9f98b7d4317d4dd46f8687ee2363b
+  md5: d2dee849c806430eee64d3acc98ce090
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  size: 123250
+  timestamp: 1723652704997
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.61.0-py311h74daea0_1.conda
+  sha256: f2a28ae15712d9bdb6efcfdd09c8ea4150bbbd9f5e2eb38aca2fc28ee70c2348
+  md5: 465a9b41e5740c9757b7de704ba6b15c
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - llvm-openmp >=18.1.8
+  - llvm-openmp >=19.1.7
+  - llvmlite >=0.44.0,<0.45.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.24,<2.2
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libopenblas >=0.3.18, !=0.3.20
+  - cudatoolkit >=11.2
+  - scipy >=1.0
+  - tbb >=2021.6.0
+  - cuda-version >=11.2
+  - cuda-python >=11.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5948621
+  timestamp: 1739225097336
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.3-py311h649a571_0.conda
+  sha256: 5a95da4a8de64fb44b0045c92f579d3529b2cccbd5a38ec7901e03ee10f707d5
+  md5: 3205b87adf34406ae1a83e8bf46cd987
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7041966
+  timestamp: 1730588523973
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.3-h8a3d83b_0.conda
+  sha256: 1d59bc72ca7faac06d349c1a280f5cfb8a57ee5896f1e24225a997189d7418c7
+  md5: 4b71d78648dbcf68ce8bf22bb07ff838
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - libpng >=1.6.44,<1.7.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 319362
+  timestamp: 1733816781741
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.1-h81ee809_0.conda
+  sha256: 4f8e2389e1b711b44182a075516d02c80fa7a3a7e25a71ff1b5ace9eae57a17a
+  md5: 75f9f0c7b1740017e2db83a53ab9a28e
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2934522
+  timestamp: 1739301896733
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.3-h0ff2369_2.conda
+  sha256: cca330695f3bdb8c0e46350c29cd4af3345865544e36f1d7c9ba9190ad22f5f4
+  md5: 24b1897c0d24afbb70704ba998793b78
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - libprotobuf >=5.28.3,<5.28.4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 438520
+  timestamp: 1735630624140
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py311h9cb3ce9_1.conda
+  sha256: 0a08027b25e4f6034d7733c7366f44283246d61cb82d1721f8789d50ebfef287
+  md5: 9ffa9dee175c76e68ea5de5aa1168d83
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14807397
+  timestamp: 1726879116250
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.1.0-py311hb9ba9e9_0.conda
+  sha256: 9d9274b1456e463401169a8b7bfc35378c09686cfac56d2b96a1393085f3fd8f
+  md5: d8bb4736b33791e270c998dd68a76621
+  depends:
+  - __osx >=11.0
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.5.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.3,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 42451890
+  timestamp: 1735929996422
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/prometheus-cpp-1.3.0-h0967b3e_0.conda
+  sha256: 851a77ae1a8e90db9b9f3c4466abea7afb52713c3d98ceb0d37ba6ff27df2eff
+  md5: 7172339b49c94275ba42fec3eaeda34f
+  depends:
+  - __osx >=11.0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 173220
+  timestamp: 1730769371051
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.0.0-py311h917b07b_0.conda
+  sha256: 3ea107f769b3ac99411f6bd6d86f946566ba3983894cbeb0e43439934a90c2f5
+  md5: 12f8d65fb5a6bd03aedd5ac74391f1ea
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 492006
+  timestamp: 1740663355030
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+  sha256: 8ed65e17fbb0ca944bfb8093b60086e3f9dd678c3448b5de212017394c247ee3
+  md5: 415816daf82e0b23a736a069a75e9da7
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 8381
+  timestamp: 1726802424786
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-19.0.1-py311ha1ab1f8_0.conda
+  sha256: 796197d36ac573c6e8185d47c070d3e0a4a4c07f4c66582a351eb3b9a97eee58
+  md5: d6fd87bcf9ffdb72542aa91983cac4a8
+  depends:
+  - libarrow-acero 19.0.1.*
+  - libarrow-dataset 19.0.1.*
+  - libarrow-substrait 19.0.1.*
+  - libparquet 19.0.1.*
+  - pyarrow-core 19.0.1 *_0_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25440
+  timestamp: 1739792592743
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-19.0.1-py311he04fa90_0_cpu.conda
+  sha256: 2984b28332a803065982573c75c2b2206bd191c9166aae248f6c9e9f214d12d3
+  md5: fc868f282261c5d6d8d22bbb615ff7d6
+  depends:
+  - __osx >=11.0
+  - libarrow 19.0.1.* *cpu
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy >=1.21,<3
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4448655
+  timestamp: 1739792563769
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-11.0-py311hab620ed_0.conda
+  sha256: 7eb9c40a460ea769f024aaf45dae9fde7ca41137ca82154c50c8aead8a32ff88
+  md5: cc865b09e7a02328840b163fb8856731
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 480994
+  timestamp: 1736891387770
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-11.0-py311hab620ed_0.conda
+  sha256: 33635759c626103696963a4d439f01cc534fe94c318ce5a14c7b9ddbe8dfb78c
+  md5: 39da4013010bd559600f775ebf6a5915
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 11.0.*
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 389214
+  timestamp: 1736927161972
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.11-hc22306f_1_cpython.conda
+  sha256: 94e198f6a5affa1431401fca7e3b27fda68c59f5ee726083288bff1f6bed8c7f
+  md5: 8d81dcd0be5bdcdd98e0f2482bf63784
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.4.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 14647146
+  timestamp: 1733409012105
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
+  sha256: adc05729b7e0aca7b436e60a86f10822a92185dfcb48d66d6444e3629d3a1f6a
+  md5: 3b855e3734344134cb56c410f729c340
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6308
+  timestamp: 1723823096865
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h4921393_2.conda
+  sha256: 2af6006c9f692742181f4aa2e0656eb112981ccb0b420b899d3dd42c881bd72f
+  md5: 250b2ee8777221153fd2de9c279a7efa
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 196951
+  timestamp: 1737454935552
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.1-py311h01f2145_0.conda
+  sha256: 29255e5ca9f0b50d551fce4d5b7745fa11b4e672418a6d88a4c3f1a974dd4e44
+  md5: 4c5daee5a983fb515460a2714b612126
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 370170
+  timestamp: 1738271259321
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+  sha256: 873ac689484262a51fd79bc6103c1a1bedbf524924d7f0088fb80703042805e4
+  md5: 6483b1f59526e05d7d894e466b5b6924
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: LicenseRef-Qhull
+  size: 516376
+  timestamp: 1720814307311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2024.07.02-h6589ca4_2.conda
+  sha256: 4d3799c05f8f662922a0acd129d119774760a3281b883603678e128d1cb307fb
+  md5: 7a8b4ad8c58a3408ca89d78788c78178
+  depends:
+  - libre2-11 2024.07.02 h07bc746_2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26861
+  timestamp: 1735541088455
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
+  sha256: 7db04684d3904f6151eff8673270922d31da1eea7fa73254d01c437f49702e34
+  md5: 63ef3f6e6d6d5c589e64f11263dc5676
+  depends:
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 252359
+  timestamp: 1740379663071
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.23.1-py311hc9d6b66_0.conda
+  sha256: 2f97abcca90080703b8f9a8975c72c2d7bf7b67b2c7bc3467b63ed0f7bdb6c59
+  md5: 743cfbdfbf99ca9edf519514acde5efa
+  depends:
+  - python
+  - python 3.11.* *_cpython
+  - __osx >=11.0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 374118
+  timestamp: 1740153123035
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.15.2-py311h0675101_0.conda
+  sha256: bc3e873e85c55deaaad446c410d9001d12a133c1b48fa2cb0050b4f46f926aa3
+  md5: df904770f3fdb6c0265a09cdc22acf54
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.5
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14569129
+  timestamp: 1739792318601
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-h98b9ce2_1.conda
+  sha256: 4242f95b215127a006eb664fe26ed5a82df87e90cbdbc7ce7ff4971f0720997f
+  md5: ded86dee325290da2967a3fea3800eb5
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35857
+  timestamp: 1733502172664
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+  sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
+  md5: b50a57ba89c32b62428b71a875291c9b
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3145523
+  timestamp: 1699202432999
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.2-py311h917b07b_0.conda
+  sha256: 80b79a7d4ed8e16019b8c634cca66935d18fc98be358c76a6ead8c611306ee14
+  md5: 183b74c576dc7f920dae168997dbd1dd
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 858954
+  timestamp: 1732616142626
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-16.0.0-py311h917b07b_0.conda
+  sha256: 4edd8c92ea579b8b5997e4b6159271dc47ce4826e880b8f8eec52be88619b03f
+  md5: d1e4a3605a1ca37cb73937772c5310af
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 411234
+  timestamp: 1736692763548
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-h5505292_0.conda
+  sha256: f33e6f013fc36ebc200f09ddead83468544cb5c353a3b50499b07b8c34e28a8d
+  md5: 50901e0764b7701d8ed7343496f4f301
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 13593
+  timestamp: 1734229104321
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+  sha256: 9939a166d780700d81023546759102b33fdc2c5f11ef09f5f66c77210fd334c8
+  md5: 77c447f48cab5d3a15ac224edb86a968
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 18487
+  timestamp: 1727795205022
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+  sha256: 93181a04ba8cfecfdfb162fc958436d868cc37db504c58078eab4c1a3e57fbb7
+  md5: 4bb3f014845110883a3c5ee811fd84b4
+  license: MIT
+  license_family: MIT
+  size: 88016
+  timestamp: 1641347076660
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-hc1bb282_7.conda
+  sha256: 9e585569fe2e7d3bea71972cd4b9f06b1a7ab8fa7c5139f92a31cbceecf25a8a
+  md5: f7e6b65943cb73bce0143737fded08f1
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libcxx >=18
+  - libsodium >=1.0.20,<1.0.21.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 281565
+  timestamp: 1731585108039
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
+  sha256: 58f8860756680a4831c1bf4f294e2354d187f2e999791d53b1941834c4b37430
+  md5: e3170d898ca6cb48f1bb567afb92f775
+  depends:
+  - __osx >=11.0
+  - libzlib 1.3.1 h8359307_2
+  license: Zlib
+  license_family: Other
+  size: 77606
+  timestamp: 1727963209370
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.19.0-py311he2be06e_0.tar.bz2
+  sha256: 43eaee70cd406468d96d1643b75d16e0da3955a9c1d37056767134b91b61d515
+  md5: ece21cb47a93c985aa4b44219c4c8c8b
+  depends:
+  - cffi >=1.8
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 575632
+  timestamp: 1667296751043
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_1.conda
+  sha256: f49bbeeb3a8ead81920e6c695fff1260cbd221e2cfcdf9fb34207260fbd60816
+  md5: 66e5c4b02aa97230459efdd4f64c8ce6
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 399981
+  timestamp: 1740255382232
+- conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
+  sha256: 1a62cd1f215fe0902e7004089693a78347a30ad687781dfda2289cab000e652d
+  md5: 37e16618af5c4851a3f3d66dd0e11141
+  depends:
+  - libgomp >=7.5.0
+  - libwinpthread >=12.0.0.r2.ggc561118da
+  constrains:
+  - openmp_impl 9999
+  - msys2-conda-epoch <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49468
+  timestamp: 1718213032772
+- conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311he736701_5.conda
+  sha256: 8bbce5e61e012a06e248f58bb675fdc82ba2900c78590696d185150fb9cea91f
+  md5: 8917bf795c40ec1839ed9d0ab3ad9735
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 34883
+  timestamp: 1725357113431
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.8.1-hd11252f_0.conda
+  sha256: 248332efb7528e512502fa03488c7694ab022cafd446cc586f5e59383c6386a5
+  md5: fe0091e429538d2687ad3353decfe532
+  depends:
+  - aws-c-cal >=0.8.1,<0.8.2.0a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-http >=0.9.2,<0.9.3.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  - aws-c-sdkutils >=0.2.2,<0.2.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 103199
+  timestamp: 1737510053257
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.8.1-h099ea23_3.conda
+  sha256: e345717c4cbef8472b3f4f90b75d326ad66a84574bfb02740a860d8de6414c44
+  md5: 767b18a469cf18d7476cab915f9fe207
+  depends:
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 47436
+  timestamp: 1733991914197
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.10.6-h2466b09_0.conda
+  sha256: 348af25291f2b4106d8453fddb8dcbfed452067bddfa0eeadd24f1c710617a4a
+  md5: 44a7e180f2054340401499de93ae39ba
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 235514
+  timestamp: 1733975788721
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.3.0-h099ea23_5.conda
+  sha256: f30956b5c450e0a21adc3d523fdbe2d0dcc79125b135f5ccc4497d97f8733891
+  md5: b4303abff1423285a2e5063d796e1614
+  depends:
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 22364
+  timestamp: 1733991973284
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.5.0-h85d8506_11.conda
+  sha256: bd7d3849ae0a12e170d4d442f7d2db7de98827d8d3505d0a60d12b1170b1ab0d
+  md5: a32c029b7e933cf93c5066b186560e62
+  depends:
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 54426
+  timestamp: 1734024881523
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.9.2-h3888f84_4.conda
+  sha256: ce0cedbe65e36f6e6dc9a8e07336f9c6ceecb09f0ed8eebdd01d74d261b59d16
+  md5: 4e7cf9b498fcc5dee5abcdf24e64a96d
+  depends:
+  - aws-c-cal >=0.8.1,<0.8.2.0a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-compression >=0.3.0,<0.3.1.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 182269
+  timestamp: 1734008780813
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.15.3-hc5a9e45_6.conda
+  sha256: 0cbf3ddd55835ba99726ffcc0118124fc8430fec41e81bb7b1d8c0c6e0d272e0
+  md5: 48a9b0c65a94282ffa149ea7c0a53239
+  depends:
+  - aws-c-cal >=0.8.1,<0.8.2.0a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 159815
+  timestamp: 1737207711320
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.11.0-h2c94728_12.conda
+  sha256: bfe3e2c5de01e285e67ac8119de58a11e594d202b3ebcfaa55ffd138a3b28279
+  md5: bad2afca289f8854d431acdcc8f1cea8
+  depends:
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-http >=0.9.2,<0.9.3.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 186987
+  timestamp: 1734025825190
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.7.9-h6a47413_1.conda
+  sha256: 8761e823ae49514f352155135030e9a57d4fe70f363ce2fa7f8c38dd8c3835d7
+  md5: 2a5283c5df98c20e695bfdf2d4019335
+  depends:
+  - aws-c-auth >=0.8.1,<0.8.2.0a0
+  - aws-c-cal >=0.8.1,<0.8.2.0a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-http >=0.9.2,<0.9.3.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 109742
+  timestamp: 1737559137789
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.2.2-h099ea23_0.conda
+  sha256: af9cc0696b9fb60e7d0738b140b3d93efcf7f354e56c3034f459fc1651d53921
+  md5: 6292ef653d6002edc721d2dc9356aa57
+  depends:
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 55109
+  timestamp: 1736536467087
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.2.2-h099ea23_4.conda
+  sha256: 577e62dbf1750219cfb017d36c9022f40d7dc287b597fd7dec1ca04cade0108c
+  md5: 5a8ce497f17cf1e6ae745f122b6a2bc3
+  depends:
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 91909
+  timestamp: 1733994821424
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.29.9-he488853_2.conda
+  sha256: dff67543a0cec319973ef17750760392623a5a0b726081378548a99f3899975f
+  md5: fd6464ad7158760f808c9b4b044cbcc0
+  depends:
+  - aws-c-auth >=0.8.1,<0.8.2.0a0
+  - aws-c-cal >=0.8.1,<0.8.2.0a0
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-c-http >=0.9.2,<0.9.3.0a0
+  - aws-c-io >=0.15.3,<0.15.4.0a0
+  - aws-c-mqtt >=0.11.0,<0.11.1.0a0
+  - aws-c-s3 >=0.7.9,<0.7.10.0a0
+  - aws-c-sdkutils >=0.2.2,<0.2.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 262083
+  timestamp: 1737566019782
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.489-h7d73209_0.conda
+  sha256: 634c2d4cf07c049e36028294d94120532ca6697c29257191b0660ee9886e4269
+  md5: 38c6bbaa9437ebd25885ce508853dc76
+  depends:
+  - aws-c-common >=0.10.6,<0.10.7.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - aws-crt-cpp >=0.29.9,<0.29.10.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 3010024
+  timestamp: 1737576786156
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-h2466b09_2.conda
+  sha256: d8fd7d1b446706776117d2dcad1c0289b9f5e1521cb13405173bad38568dd252
+  md5: 378f1c9421775dfe644731cb121c8979
+  depends:
+  - brotli-bin 1.1.0 h2466b09_2
+  - libbrotlidec 1.1.0 h2466b09_2
+  - libbrotlienc 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 19697
+  timestamp: 1725268293988
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-h2466b09_2.conda
+  sha256: f3bf2893613540ac256c68f211861c4de618d96291719e32178d894114ac2bc2
+  md5: d22534a9be5771fc58eb7564947f669d
+  depends:
+  - libbrotlidec 1.1.0 h2466b09_2
+  - libbrotlienc 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 20837
+  timestamp: 1725268270219
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311hda3d55a_2.conda
+  sha256: aa3ac5dbf63db2f145235708973c626c2189ee4040d769fdf0076286fa45dc26
+  md5: a0ea2839841a06740a1c110ba3317b42
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  license: MIT
+  license_family: MIT
+  size: 322114
+  timestamp: 1725268368720
+- conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+  sha256: 35a5dad92e88fdd7fc405e864ec239486f4f31eec229e31686e61a140a8e573b
+  md5: 276e7ffe9ffe39688abc665ef0f45596
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 54927
+  timestamp: 1720974860185
+- conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.34.4-h2466b09_0.conda
+  sha256: f364f7de63a7c35a62c8d90383dd7747b46fa6b9c35c16c99154a8c45685c86b
+  md5: d387e6f147273d548f068f49a4291aef
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 193862
+  timestamp: 1734208384429
+- conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2025.1.31-h56e8100_0.conda
+  sha256: 1bedccdf25a3bd782d6b0e57ddd97cdcda5501716009f2de4479a779221df155
+  md5: 5304a31607974dfc2110dfbb662ed092
+  license: ISC
+  size: 158690
+  timestamp: 1738298232550
+- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py311he736701_0.conda
+  sha256: 9689fbd8a31fdf273f826601e90146006f6631619767a67955048c7ad7798a1d
+  md5: e1c69be23bd05471a6c623e91680ad59
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 297627
+  timestamp: 1725561079708
+- conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.1-py311h3257749_0.conda
+  sha256: dbb0c161dd75e72e66c13f31715941adb094a45471016f89d6a1cfab30967ba8
+  md5: 91d8504588e1b3c77e605503e5a1bc11
+  depends:
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 216693
+  timestamp: 1731429286140
+- conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.0.1-py311he736701_0.conda
+  sha256: 7746ffe3a0849abbd724da6955950142ec7eedbc66053be8d3802b7885562951
+  md5: fc78ccf75bba016a930accedee7ed9af
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 322872
+  timestamp: 1734107800020
+- conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.12-py311hda3d55a_0.conda
+  sha256: 7459c8b617e0e0fb1b070a7922e511685d4cfe7e71b6cdb5542a0f93931f749d
+  md5: e37dbdf20c05395ec4a83610e6ff05f2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 3494189
+  timestamp: 1737270099537
+- conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.56.0-py311h5082efb_0.conda
+  sha256: bcfd53b83419d7a891eb77947dc1997c7b4133629988c0797404f76bdf2fe289
+  md5: 0ecd51b246e243291c68c7380e09b274
+  depends:
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - unicodedata2 >=15.1.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 2466258
+  timestamp: 1738940937712
+- conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+  sha256: 2c53ee8879e05e149a9e525481d36adfd660a6abda26fd731376fa64ff03e728
+  md5: 3761b23693f768dc75a8fd0a73ca053f
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-only OR FTL
+  size: 510306
+  timestamp: 1694616398888
+- conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+  sha256: 0fd2b0b84c854029041b0ede8f4c2369242ee92acc0092f8407b1fe9238a8209
+  md5: 2d89243bfb53652c182a7c73182cce4f
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 1852356
+  timestamp: 1723739573141
+- conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_1.conda
+  sha256: 9a667eeae67936e710ff69ee7ce0e784d6052eeba9670b268c565a55178098c4
+  md5: 943f7fab631e12750641efd7279a268c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42891
+  timestamp: 1725303340467
+- conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.7-py311h3257749_0.conda
+  sha256: a2079e13d1345a5dd61df6be933e828e805051256e7260009ba93fce55aebd75
+  md5: 18fd1ac3d79a8d6550eaea5ceaa00036
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55867
+  timestamp: 1725459681416
+- conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+  sha256: 18e8b3430d7d232dad132f574268f56b3eb1a19431d6d5de8c53c29e6c18fa81
+  md5: 31aec030344e962fbd7dbbbbd68e60a9
+  depends:
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 712034
+  timestamp: 1719463874284
+- conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.17-hbcf6048_0.conda
+  sha256: 7712eab5f1a35ca3ea6db48ead49e0d6ac7f96f8560da8023e61b3dbe4f3b25d
+  md5: 3538827f77b82a837fa681a4579e37a1
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 510641
+  timestamp: 1739161381270
+- conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+  sha256: f4f39d7f6a2f9b407f8fb567a6c25755270421731d70f0ff331f5de4fa367488
+  md5: 1900cb3cab5055833cfddb0ba233b074
+  depends:
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30037
+  license: Apache-2.0
+  license_family: Apache
+  size: 194365
+  timestamp: 1657977692274
+- conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_h4eb7d71_4.conda
+  sha256: 846eacff96d36060fe5f7b351e4df6fafae56bf34cc6426497f12b5c13f317cf
+  md5: c57ee7f404d1aa84deb3e15852bec6fa
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - abseil-cpp =20240722.0
+  - libabseil-static =20240722.0=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1784929
+  timestamp: 1736008778245
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-19.0.1-h8dcb746_0_cpu.conda
+  sha256: 567d1cf9d14d1dcea3877cd063f3381e3f5c9fd51cef72e38114f7ba48195921
+  md5: 9df767d91d5f573b1bc1d18c27f2f48a
+  depends:
+  - aws-crt-cpp >=0.29.9,<0.29.10.0a0
+  - aws-sdk-cpp >=1.11.489,<1.11.490.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.12.1,<9.0a0
+  - libgoogle-cloud >=2.35.0,<2.36.0a0
+  - libgoogle-cloud-storage >=2.35.0,<2.36.0a0
+  - libprotobuf >=5.28.3,<5.28.4.0a0
+  - libre2-11 >=2024.7.2
+  - libutf8proc >=2.10.0,<2.11.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - orc >=2.0.3,<2.0.4.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - parquet-cpp <0.0a0
+  - arrow-cpp <0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5303286
+  timestamp: 1739770845910
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-19.0.1-h7d8d6a5_0_cpu.conda
+  sha256: 3942a53d93fd743d3297757d82b7b9ee7ebdb0854d12e1e43c6946530ec65b7b
+  md5: 8b3eab29d714ce61b13aad5417ffa668
+  depends:
+  - libarrow 19.0.1 h8dcb746_0_cpu
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  license: Apache-2.0
+  license_family: APACHE
+  size: 449963
+  timestamp: 1739770921236
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-19.0.1-h7d8d6a5_0_cpu.conda
+  sha256: e7691b0f521f2f6baaf3f3ca8b1aaeb00e438612d00db531a8bb3eb67d398a98
+  md5: f880e06be679f2b9edb1abb2505f03a9
+  depends:
+  - libarrow 19.0.1 h8dcb746_0_cpu
+  - libarrow-acero 19.0.1 h7d8d6a5_0_cpu
+  - libparquet 19.0.1 ha850022_0_cpu
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  license: Apache-2.0
+  license_family: APACHE
+  size: 434909
+  timestamp: 1739771142936
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-19.0.1-h3dbecdf_0_cpu.conda
+  sha256: 03b6d6dd152865196d757a053ec8b1aad55489c8a292748dedf71429b8491ede
+  md5: d59244ba3e95ce67e8889726cb40aa1f
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 19.0.1 h8dcb746_0_cpu
+  - libarrow-acero 19.0.1 h7d8d6a5_0_cpu
+  - libarrow-dataset 19.0.1 h7d8d6a5_0_cpu
+  - libprotobuf >=5.28.3,<5.28.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  license: Apache-2.0
+  license_family: APACHE
+  size: 363280
+  timestamp: 1739771244591
+- conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-31_h641d27c_mkl.conda
+  sha256: 7bb4d5b591e98fe607279520ee78e3571a297b5720aa789a2536041ad5540de8
+  md5: d05563c577fe2f37693a554b3f271e8f
+  depends:
+  - mkl 2024.2.2 h66d3029_15
+  constrains:
+  - libcblas =3.9.0=31*_mkl
+  - blas =2.131=mkl
+  - liblapacke =3.9.0=31*_mkl
+  - liblapack =3.9.0=31*_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3733728
+  timestamp: 1740088452830
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-h2466b09_2.conda
+  sha256: 33e8851c6cc8e2d93059792cd65445bfe6be47e4782f826f01593898ec95764c
+  md5: f7dc9a8f21d74eab46456df301da2972
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 70526
+  timestamp: 1725268159739
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-h2466b09_2.conda
+  sha256: 234fc92f4c4f1cf22f6464b2b15bfc872fa583c74bf3ab9539ff38892c43612f
+  md5: 9bae75ce723fa34e98e239d21d752a7e
+  depends:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 32685
+  timestamp: 1725268208844
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-h2466b09_2.conda
+  sha256: 3d0dd7ef505962f107b7ea8f894e0b3dd01bf46852b362c8a7fc136b039bc9e1
+  md5: 85741a24d97954a991e55e34bc55990b
+  depends:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 245929
+  timestamp: 1725268238259
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-31_h5e41251_mkl.conda
+  sha256: 609f455b099919bd4d15d4a733f493dc789e02da73fe4474f1cca73afafb95b8
+  md5: 43c100b94ad2607382b0cf0f3a6b0bf3
+  depends:
+  - libblas 3.9.0 31_h641d27c_mkl
+  constrains:
+  - blas =2.131=mkl
+  - liblapacke =3.9.0=31*_mkl
+  - liblapack =3.9.0=31*_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3733549
+  timestamp: 1740088502127
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+  sha256: 75e60fbe436ba8a11c170c89af5213e8bec0418f88b7771ab7e3d9710b70c54e
+  md5: cd4cc2d0c610c8cb5419ccc979f2d6ce
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25694
+  timestamp: 1633684287072
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.12.1-h88aaa65_0.conda
+  sha256: 4c8e62fd32d59e5fbfad0f37e33083928bbb3c8800258650d4e7911e6f6fd1aa
+  md5: 2b1c729d91f3b07502981b6e0c7727cc
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: curl
+  license_family: MIT
+  size: 349696
+  timestamp: 1739512628733
+- conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.23-h9062f6e_0.conda
+  sha256: 96c47725a8258159295996ea2758fa0ff9bea330e72b59641642e16be8427ce8
+  md5: a9624935147a25b06013099d3038e467
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 155723
+  timestamp: 1734374084110
+- conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+  sha256: af03882afb7a7135288becf340c2f0cf8aa8221138a9a7b108aaeb308a486da1
+  md5: 25efbd786caceef438be46da78a7b5ef
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 410555
+  timestamp: 1685726568668
+- conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.4-he0c23c2_0.conda
+  sha256: 0c0447bf20d1013d5603499de93a16b6faa92d7ead870d96305c0f065b6a5a12
+  md5: eb383771c680aa792feb529eaf9df82f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 139068
+  timestamp: 1730967442102
+- conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.6-h537db12_0.conda
+  sha256: 77922d8dd2faf88ac6accaeebf06409d1820486fde710cff6b554d12273e46be
+  md5: 31d5107f75b2f204937728417e2e39e5
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 40830
+  timestamp: 1739260917585
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-14.2.0-h1383e82_2.conda
+  sha256: fddf2fc037bc95adb3b369e8866da8a71b6a67ebcfc4d7035ac4208309dc9e72
+  md5: 4a74c1461a0ba47a3346c04bdccbe2ad
+  depends:
+  - _openmp_mutex >=4.5
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - msys2-conda-epoch <0.0a0
+  - libgcc-ng ==14.2.0=*_2
+  - libgomp 14.2.0 h1383e82_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 666343
+  timestamp: 1740240717807
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-14.2.0-h1383e82_2.conda
+  sha256: 674ec5f1bf319eac98d0d6ecb9c38e0192f3cf41969a5621d62a7e695e1aa9f3
+  md5: dd6b1ab49e28bcb6154cd131acec985b
+  depends:
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - msys2-conda-epoch <0.0a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 524548
+  timestamp: 1740240660967
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.35.0-h95c5cb2_0.conda
+  sha256: 5c558b47346a690c490b18da2d17d877207e1e2f3a0650bbbb4433be46f88edf
+  md5: 6abfc56751ccb4e6bb936f7c5dc93ddf
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.11.1,<9.0a0
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libprotobuf >=5.28.3,<5.28.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libgoogle-cloud 2.35.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 14439
+  timestamp: 1738663276705
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.35.0-he5eb982_0.conda
+  sha256: dbdd164974e2ead7c2912764ddbaefebe81d2b19fb22c5500cf77dda5fb70855
+  md5: 6b29ee7cb57c23aa64c00de029483307
+  depends:
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libgoogle-cloud 2.35.0 h95c5cb2_0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 14355
+  timestamp: 1738663584421
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.67.1-h0ac93cb_1.conda
+  sha256: 4bf4b455fc8c56ac84001d394f93465c0cd42e78d8053a7c99668bba681b0973
+  md5: d41dfb3f07ea2f3687e9a2d7db31c506
+  depends:
+  - c-ares >=1.34.4,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libprotobuf >=5.28.3,<5.28.4.0a0
+  - libre2-11 >=2024.7.2
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  - re2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - grpc-cpp =1.67.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 17282979
+  timestamp: 1735632501670
+- conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.2-default_ha69328c_1001.conda
+  sha256: 850e255997f538d5fb6ed651321141155a33bb781d43d326fc4ff62114dd2842
+  md5: b87a0ac5ab6495d8225db5dc72dd21cd
+  depends:
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - libxml2 >=2.13.4,<2.14.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2390021
+  timestamp: 1731375651179
+- conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-h135ad9c_1.conda
+  sha256: ea5ed2b362b6dbc4ba7188eb4eaf576146e3dfc6f4395e9f0db76ad77465f786
+  md5: 21fc5dba2cbcd8e5e26ff976a312122c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-only
+  size: 638142
+  timestamp: 1740128665984
+- conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+  sha256: 4e7808e3098b4b4ed7e287f63bb24f9045cc4d95bfd39f0db870fc2837d74dff
+  md5: 3f1b948619c45b1ca714d60c7389092c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 822966
+  timestamp: 1694475223854
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-31_h1aa476e_mkl.conda
+  sha256: 9415e807aa6f8968322bbd756aab8f487379d809c74266d37c697b8d85c534ad
+  md5: 40b47ee720a185289760960fc6185750
+  depends:
+  - libblas 3.9.0 31_h641d27c_mkl
+  constrains:
+  - libcblas =3.9.0=31*_mkl
+  - blas =2.131=mkl
+  - liblapacke =3.9.0=31*_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3732648
+  timestamp: 1740088548986
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.6.4-h2466b09_0.conda
+  sha256: 3f552b0bdefdd1459ffc827ea3bf70a6a6920c7879d22b6bfd0d73015b55227b
+  md5: c48f6ad0ef0a555b27b233dfcab46a90
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - xz ==5.6.4=*_0
+  license: 0BSD
+  size: 104465
+  timestamp: 1738525557254
+- conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-19.0.1-ha850022_0_cpu.conda
+  sha256: 2c38d3e90d7f087c8e5a8361d1e4557264ecd60e98f7aa982d45563c63aa2304
+  md5: f74c0e448b71c8f4bc0c8e8fd7fc7a43
+  depends:
+  - libarrow 19.0.1 h8dcb746_0_cpu
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.4.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  license: Apache-2.0
+  license_family: APACHE
+  size: 824659
+  timestamp: 1739771094165
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.47-had7236b_0.conda
+  sha256: cf8a594b697de103025dcae2c917ec9c100609caf7c917a94c64a683cb1db1ac
+  md5: 7d717163d9dab337c65f2bf21a676b8f
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: zlib-acknowledgement
+  size: 346101
+  timestamp: 1739953426806
+- conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.28.3-h8309712_1.conda
+  sha256: 78c1b917d50c0317579bd9a5714a6d544d69786fd3228a4201dc4e8710ef6348
+  md5: 3be9f2fb7dce19d66d5cf1003a34b0e1
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6172959
+  timestamp: 1735577517299
+- conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2024.07.02-h4eb7d71_2.conda
+  sha256: f5bcc036ea1946444dc3adc772dfb045ff9e6d3486e924133ad7d018de651738
+  md5: 67612b1af5350b6dcf289db63ec3e685
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 260655
+  timestamp: 1735541391655
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+  sha256: 7bcb3edccea30f711b6be9601e083ecf4f435b9407d70fc48fbcf9e5d69a0fc6
+  md5: 198bb594f202b205c7d18b936fa4524f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: ISC
+  size: 202344
+  timestamp: 1716828757533
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.49.1-h67fdade_1.conda
+  sha256: 08669790e4de89201079e93e8a8d8c51a3cd57a19dd559bb0d5bc6c9a7970b99
+  md5: 88931435901c1f13d4e3a472c24965aa
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 1081190
+  timestamp: 1739953491995
+- conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-he619c9f_0.conda
+  sha256: 4b3256bd2b4e4b3183005d3bd8826d651eccd1a4740b70625afa2b7e7123d191
+  md5: af0cbf037dd614c34399b3b3e568c557
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 291889
+  timestamp: 1732349796504
+- conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.21.0-hbe90ef8_0.conda
+  sha256: 81ca4873ba09055c307f8777fb7d967b5c26291f38095785ae52caed75946488
+  md5: 7699570e1f97de7001a7107aabf2d677
+  depends:
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 633857
+  timestamp: 1727206429954
+- conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-h797046b_3.conda
+  sha256: c363a8baba4ce12b8f01f0ab74fe8b0dc83facd89c6604f4a191084923682768
+  md5: defed79ff7a9164ad40320e3f116a138
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.23,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 978878
+  timestamp: 1734399004259
+- conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.10.0-hf9b99b7_0.conda
+  sha256: 43cbec5355e78be500ec14322a59a6b9aac05fb72aea739356549a7637dd02a4
+  md5: a4685a23eaf9ffb3eb6506102f5360b8
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 85371
+  timestamp: 1737244781933
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.5.0-h3b0e114_0.conda
+  sha256: 1d75274614e83a5750b8b94f7bad2fc0564c2312ff407e697d99152ed095576f
+  md5: 33f7313967072c6e6d8f865f5493c7ae
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libwebp 1.5.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 273661
+  timestamp: 1734777665516
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_9.conda
+  sha256: 373f2973b8a358528b22be5e8d84322c165b4c5577d24d94fd67ad1bb0a0f261
+  md5: 08bfa5da6e242025304b206d152479ef
+  depends:
+  - ucrt
+  constrains:
+  - pthreads-win32 <0.0a0
+  - msys2-conda-epoch <0.0a0
+  license: MIT AND BSD-3-Clause-Clear
+  size: 35794
+  timestamp: 1737099561703
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
+  sha256: 08dec73df0e161c96765468847298a420933a36bc4f09b50e062df8793290737
+  md5: a69bbf778a462da324489976c84cfc8c
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - pthread-stubs
+  - ucrt >=10.0.20348.0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 1208687
+  timestamp: 1727279378819
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.6-he286e8c_0.conda
+  sha256: 2919f4e9fffefbf3ff6ecd8ebe81584d573c069b2b82eaeed797b1f56ac8d97b
+  md5: c66d5bece33033a9c028bbdf1e627ec5
+  depends:
+  - libiconv >=1.18,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1669569
+  timestamp: 1739953461426
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+  sha256: ba945c6493449bed0e6e29883c4943817f7c79cbff52b83360f7b341277c6402
+  md5: 41fbfac52c601159df6c01f875de31b9
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 55476
+  timestamp: 1727963768015
+- conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.44.0-py311h7deaa30_0.conda
+  sha256: 195d6fa97131fbfa333b55c26e0984588968b7967e58bc176930d57c9b9a79d4
+  md5: 96c2a89ac4b1c6a32e953a3b587e8725
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - vs2015_runtime
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18128467
+  timestamp: 1738108854446
+- conda: https://conda.anaconda.org/conda-forge/win-64/lz4-4.3.3-py311h0476921_2.conda
+  sha256: 8bbaa4d26804df1a0ad02b1c8d3945712b3271aac96a5172dc5e987a593f79ab
+  md5: 8d27b3521c690996a5ce3cb629e398e6
+  depends:
+  - lz4-c >=1.10.0,<1.11.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42546
+  timestamp: 1733474695777
+- conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.10.0-h2466b09_1.conda
+  sha256: 632cf3bdaf7a7aeb846de310b6044d90917728c73c77f138f08aa9438fc4d6b5
+  md5: 0b69331897a92fac3d8923549d48d092
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 139891
+  timestamp: 1733741168264
+- conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py311h5082efb_1.conda
+  sha256: 6f756e13ccf1a521d3960bd3cadddf564e013e210eaeced411c5259f070da08e
+  md5: c1f2ddad665323278952a453912dc3bd
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28238
+  timestamp: 1733220208800
+- conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.10.0-py311h8f1b1e4_0.conda
+  sha256: 8de5631b0e2d1be058ab5c409c0b8271ea9542e2c290ba6c5c0f7b3b3ac4a759
+  md5: fc1057bd7ba18ae033f80c8a9fafdccf
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 8110022
+  timestamp: 1734381580500
+- conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_15.conda
+  sha256: 20e52b0389586d0b914a49cd286c5ccc9c47949bed60ca6df004d1d295f2edbd
+  md5: 302dff2807f2927b3e9e0d19d60121de
+  depends:
+  - intel-openmp 2024.*
+  - tbb 2021.*
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 103106385
+  timestamp: 1730232843711
+- conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.0-py311h3257749_0.conda
+  sha256: 4e6a7979b434308ce5588970cb613952e3340bb2f9e63aaad7e5069ef1f08d1d
+  md5: 36562593204b081d0da8a8bfabfb278b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 89472
+  timestamp: 1725975909671
+- conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.61.0-py311h0673bce_1.conda
+  sha256: 622717601a63419e190a871cddafb6fd4110a77794099ae69805b726bab6f66c
+  md5: c45f583aa699c7c752bdd3cd4658bd4b
+  depends:
+  - llvmlite >=0.44.0,<0.45.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.24,<2.2
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - scipy >=1.0
+  - tbb >=2021.6.0
+  - cuda-python >=11.6
+  - cudatoolkit >=11.2
+  - libopenblas !=0.3.6
+  - cuda-version >=11.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5937366
+  timestamp: 1739225331647
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.3-py311h35ffc71_0.conda
+  sha256: 09b0b580e5c4e2eb5dd1b5c44487a274a444d7cc44caced61324a65a8cfa2741
+  md5: aa627d29d5d1ed4192e70cd5a6cb1f4f
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7659216
+  timestamp: 1730588918527
+- conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.3-h4d64b90_0.conda
+  sha256: 410175815df192f57a07c29a6b3fdd4231937173face9e63f0830c1234272ce3
+  md5: fc050366dd0b8313eb797ed1ffef3a29
+  depends:
+  - libpng >=1.6.44,<1.7.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 240148
+  timestamp: 1733817010335
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.4.1-ha4e3fda_0.conda
+  sha256: 56dcc2b4430bfc1724e32661c34b71ae33a23a14149866fc5645361cfd3b3a6a
+  md5: 0730f8094f7088592594f9bf3ae62b3f
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 8515197
+  timestamp: 1739304103653
+- conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.3-haf104fe_2.conda
+  sha256: 35522ebcdd10f9d8600cbffa99efd59053bf2148965cfbb4575680e61c1d41dd
+  md5: c8abacd8bdb242c9ba9c9a6c7ec09b01
+  depends:
+  - libprotobuf >=5.28.3,<5.28.4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 902551
+  timestamp: 1735630416110
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py311hcf9f919_1.conda
+  sha256: f5477bf3a2b7919481009ce87212d7bbd16c61a5bb05c692a7c336fb45646534
+  md5: 5965b8926efba14e6fde98cc8713c083
+  depends:
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14587131
+  timestamp: 1726879538736
+- conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.1.0-py311h43e43bb_0.conda
+  sha256: 0eea0c0ce4bf15d9b6dfba7e0e8a8f292a25765ba578dd84dbea0f8bf0fb450b
+  md5: bb2c647a5a1452c4271557d00c0d344b
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.5.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.3,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: HPND
+  size: 42176152
+  timestamp: 1735930533925
+- conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.0.0-py311he736701_0.conda
+  sha256: e3844e26821651f744ea57a1538a8f970872f15a1c6eb38fc208f0efd1c3706c
+  md5: fc2a628caa77146532ee4747894bccd5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 499375
+  timestamp: 1740663711326
+- conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
+  sha256: 7e446bafb4d692792310ed022fe284e848c6a868c861655a92435af7368bae7b
+  md5: 3c8f2573569bb816483e5cf57efbbe29
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 9389
+  timestamp: 1726802555076
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-19.0.1-py311h1ea47a8_0.conda
+  sha256: 2e4f8b2483ea3ed66a08d3816049602a5fea963330a9fe5c123965bd13216760
+  md5: 5c428224a3de692edef1048d94550c43
+  depends:
+  - libarrow-acero 19.0.1.*
+  - libarrow-dataset 19.0.1.*
+  - libarrow-substrait 19.0.1.*
+  - libparquet 19.0.1.*
+  - pyarrow-core 19.0.1 *_0_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25786
+  timestamp: 1739792905538
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-19.0.1-py311hdea38fa_0_cpu.conda
+  sha256: cde06054a491a8bd183aaa96a7f8ca4a607d545745ff6fc5f3bd1e230b77c6e5
+  md5: 339ba90e238abb4df79ca1701aa3205c
+  depends:
+  - libarrow 19.0.1.* *cpu
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - numpy >=1.21,<3
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3540667
+  timestamp: 1739792862712
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.11-h3f84c4b_1_cpython.conda
+  sha256: 5be6181ab6d655ad761490b7808584c5e78e5d7139846685b1850a8b7ef6c5df
+  md5: 4d490a426481298bdd89a502253a7fd4
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 18161635
+  timestamp: 1733408064601
+- conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-5_cp311.conda
+  sha256: 9b210e5807dd9c9ed71ff192a95f1872da597ddd10e7cefec93a922fe22e598a
+  md5: 895b873644c11ccc0ab7dba2d8513ae6
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6707
+  timestamp: 1723823225752
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-307-py311hda3d55a_3.conda
+  sha256: 78a4ede098bbc122a3dff4e0e27255e30b236101818e8f499779c89670c58cd6
+  md5: 1bc10dbe3b8d03071070c962a2bdf65f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 6023110
+  timestamp: 1728636767562
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.15-py311hda3d55a_0.conda
+  sha256: fbf3e3f2d5596e755bd4b83b5007fa629b184349781f46e137a4e80b6754c7c0
+  md5: 8a142e0fcd43513c2e876d97ba98c0fa
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 217009
+  timestamp: 1738661736085
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311h5082efb_2.conda
+  sha256: 6095e1d58c666f6a06c55338df09485eac34c76e43d92121d5786794e195aa4d
+  md5: e474ba674d780f0fa3b979ae9e81ba91
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 187430
+  timestamp: 1737454904007
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.2.1-py311h484c95c_0.conda
+  sha256: 1b102e3e6c8b5632c9e7b292c8fe4f06c761bffeee39389ec337d83a3388b6f0
+  md5: efe5e2d7ca651116dd17052ac4891746
+  depends:
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 373659
+  timestamp: 1738271740476
+- conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+  sha256: 887d53486a37bd870da62b8fa2ebe3993f912ad04bd755e7ed7c47ced97cbaa8
+  md5: 854fbdff64b572b5c0b470f334d34c11
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LicenseRef-Qhull
+  size: 1377020
+  timestamp: 1720814433486
+- conda: https://conda.anaconda.org/conda-forge/win-64/re2-2024.07.02-haf4117d_2.conda
+  sha256: fde3bbe0ade147bf735bf1bb5a15aa26d2cc197bfa026d2964012737f89ed351
+  md5: 10980cbe103147435a40288db9f49847
+  depends:
+  - libre2-11 2024.07.02 h4eb7d71_2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 214916
+  timestamp: 1735541425594
+- conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.23.1-py311ha250665_0.conda
+  sha256: 72ca8e7d54f79e6a99827576e53a277796ab8f4d912eba33e3b949cd757a77f7
+  md5: 8fd1344d7369c84eb7cf4c316ab86518
+  depends:
+  - python
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - ucrt >=10.0.20348.0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 251649
+  timestamp: 1740153100034
+- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.15.2-py311h99d06ae_0.conda
+  sha256: 62ae1a1e02c919513213351474d1c72480fb70388a345fa81f1c95fa822d98bf
+  md5: c7ec15b5ea6a27bb71af2ea5f7c97cbb
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.5
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15487645
+  timestamp: 1739793313482
+- conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h500f7fa_1.conda
+  sha256: 29753b51803c0396c3cb56e4f11e68c968a2f43b71b648634bef1f9193f9e78b
+  md5: e32fb978aaea855ddce624eb8c8eb69a
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59757
+  timestamp: 1733502109991
+- conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-h62715c5_1.conda
+  sha256: 03cc5442046485b03dd1120d0f49d35a7e522930a2ab82f275e938e17b07b302
+  md5: 9190dd0a23d925f7602f9628b3aed511
+  depends:
+  - libhwloc >=2.11.2,<2.11.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 151460
+  timestamp: 1732982860332
+- conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+  sha256: 2c4e914f521ccb2718946645108c9bd3fc3216ba69aea20c2c3cedbd8db32bb1
+  md5: fc048363eb8f03cd1737600a5d08aafe
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: TCL
+  license_family: BSD
+  size: 3503410
+  timestamp: 1699202577803
+- conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.2-py311he736701_0.conda
+  sha256: 7e313f1724e5eb7d13f7a1ebd6026a378f3f58a638ba7cdc3bd452c01323bb29
+  md5: 7e33077ce1bc0bf45c45a92e37432f16
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 859456
+  timestamp: 1732616376731
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+  sha256: db8dead3dd30fb1a032737554ce91e2819b43496a0db09927edf01c32b577450
+  md5: 6797b005cd0f439c4c5c9ac565783700
+  constrains:
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-MicrosoftWindowsSDK10
+  size: 559710
+  timestamp: 1728377334097
+- conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-16.0.0-py311he736701_0.conda
+  sha256: 3f626553bfb49ac756cf40e0c10ecb3a915a86f64e036924ab956b37ad1fa9f4
+  md5: 5ec4da89151e9d55f9ecad019f2d1e58
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 400391
+  timestamp: 1736692998788
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h5fd82a7_24.conda
+  sha256: 7ce178cf139ccea5079f9c353b3d8415d1d49b0a2f774662c355d3f89163d7b4
+  md5: 00cf3a61562bd53bd5ea99e6888793d0
+  depends:
+  - vc14_runtime >=14.40.33810
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17693
+  timestamp: 1737627189024
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34433-h6356254_24.conda
+  sha256: abda97b8728cf6e3c37df8f1178adde7219bed38b96e392cb3be66336386d32e
+  md5: 2441e010ee255e6a38bf16705a756e94
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.42.34433.* *_24
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  size: 753531
+  timestamp: 1737627061911
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hfef2bbc_24.conda
+  sha256: 09102e0bd283af65772c052d85028410b0c31989b3cd96c260485d28e270836e
+  md5: 117fcc5b86c48f3b322b0722258c7259
+  depends:
+  - vc14_runtime >=14.42.34433
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17669
+  timestamp: 1737627066773
+- conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: 9df10c5b607dd30e05ba08cbd940009305c75db242476f4e845ea06008b0a283
+  md5: 1cee351bf20b830d991dbe0bc8cd7dfe
+  license: MIT
+  license_family: MIT
+  size: 1176306
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.12-h0e40799_0.conda
+  sha256: 047836241b2712aab1e29474a6f728647bff3ab57de2806b0bb0a6cf9a2d2634
+  md5: 2ffbfae4548098297c033228256eb96e
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 108013
+  timestamp: 1734229474049
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.5-h0e40799_0.conda
+  sha256: 9075f98dcaa8e9957e4a3d9d30db05c7578a536950a31c200854c5c34e1edb2c
+  md5: 8393c0f7e7870b4eb45553326f81f0ff
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 69920
+  timestamp: 1727795651979
+- conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+  sha256: 4e2246383003acbad9682c7c63178e2e715ad0eb84f03a8df1fbfba455dfedc5
+  md5: adbfb9f45d1004a26763652246a33764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 63274
+  timestamp: 1641347623319
+- conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_7.conda
+  sha256: 15cc8e2162d0a33ffeb3f7b7c7883fd830c54a4b1be6a4b8c7ee1f4fef0088fb
+  md5: e03f2c245a5ee6055752465519363b1c
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 2527503
+  timestamp: 1731585151036
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.19.0-py311ha68e1ae_0.tar.bz2
+  sha256: c687a7d884e98c69f4f1fee8cb9949157bba7c76a54176edeb3262c156e08e71
+  md5: 94114ffe0cad9e1e704e2c0015c8aa87
+  depends:
+  - cffi >=1.8
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 441977
+  timestamp: 1667296911687
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-hbeecb71_1.conda
+  sha256: a59b096b95f20910158c927797e9144ed9c7970f1b4aca58e6d6c8db9f653006
+  md5: bf190adcc22f146d8ec66da215c9d78b
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353182
+  timestamp: 1740255407949

--- a/nyc_buildings/pixi.toml
+++ b/nyc_buildings/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "nyc_buildings"
-channels = ["conda-forge", "nodefaults"]
+channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/nyc_buildings/pixi.toml
+++ b/nyc_buildings/pixi.toml
@@ -22,8 +22,8 @@ holoviews = ">=1.20.1"
 pandas = ">=2.2.3"
 panel = ">=1.6.1"
 spatialpandas = ">=0.5.0"
-pip = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [activation.env]
 DASK_DATAFRAME__CONVERT_STRING = "False"

--- a/nyc_buildings/pixi.toml
+++ b/nyc_buildings/pixi.toml
@@ -1,0 +1,42 @@
+[workspace]
+name = "nyc_buildings"
+channels = ["conda-forge", "nodefaults"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2021-01-27"
+maintainers = ["philippjfr"]
+categories = ["Geospatial"]
+labels = ["datashader", "hvplot", "spatialpandas"]
+title = "NYC buildings"
+description = "Visualize on a map all the buildings of New York City"
+
+[dependencies]
+python = "3.11.*"
+notebook = "<7"
+colorcet = ">=3.1.0"
+dask = ">=2025.2.0"
+datashader = ">=0.17.0"
+hvplot = ">=0.11.2"
+holoviews = ">=1.20.1"
+pandas = ">=2.2.3"
+panel = ">=1.6.1"
+spatialpandas = ">=0.5.0"
+pip = "*"
+wheel = "*"
+
+[activation.env]
+DASK_DATAFRAME__CONVERT_STRING = "False"
+
+[tasks.dashboard]
+cmd = "panel serve --rest-session-info --session-history -1 nyc_buildings.ipynb --show"
+depends-on = ["download"]
+
+[tasks.notebook]
+cmd = "jupyter notebook nyc_buildings.ipynb"
+depends-on = ["download"]
+
+[tasks.download]
+env = { FILENAME = "data/nyc_buildings.parq" }
+cmd = "mkdir -p $FILENAME && curl -fsSL -o .DATA.zip http://s3.amazonaws.com/datashader-data/nyc_buildings.parq.zip && python -m zipfile -e .DATA.zip $FILENAME && rm .DATA.zip"
+outputs = ["data/nyc_buildings.parq"]

--- a/nyc_taxi/pixi.lock
+++ b/nyc_taxi/pixi.lock
@@ -1,0 +1,10768 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/pyviz/label/dev/
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/colorcet-3.1.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/datashader-0.16.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/holoviews-1.19.0a1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/hvplot-0.10.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/panel-1.4.3a1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/param-2.1.1a0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyct-0.5.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyct-core-0.5.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyviz_comms-3.0.0-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-14.0.2-h374c478_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/async-lru-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.10.55-h721c034_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/babel-2.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cramjam-2.7.0-py311h24d97f6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cyrus-sasl-2.1.28-h52b45da_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.2-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-2023.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2023.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.6.2-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-2023.8.0-py311hf4808d0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.14.1-h4c34cd2_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.3.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.78.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-tools-2.78.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/grpc-cpp-1.48.2-he1ff14a_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.1-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.1-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter-lsp-2.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-8.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab-4.0.11-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_server-2.25.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang-14.0.6-default_hc6dbbc7_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang13-14.0.6-default_he11475f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcups-2.4.2-h2d74bed_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.5.0-h251f7ec_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libglib-2.78.4-hdc74915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpq-12.17-hdbd6064_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-hdbd6064_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxkbcommon-1.0.1-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.10.4-hfdd30dd_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.8.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py311hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mysql-5.7.24-h721c034_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-7.0.8-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.59.1-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ply-3.11-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-14.0.2-py311hb6e97c4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.15.10-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt5-sip-12.13.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.8-h955ad1f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-25.1.2-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-main-5.15.2-h53bd1ea_10.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-6.7.12-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.1.10-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.2-py311h92b7b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.1.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py311h06a4308_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/colorcet-3.1.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/datashader-0.16.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/holoviews-1.19.0a1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/hvplot-0.10.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/panel-1.4.3a1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/param-2.1.1a0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyct-0.5.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyct-core-0.5.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyviz_comms-3.0.0-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/abseil-cpp-20230802.0-h61975a4_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-14.0.2-h3ade35f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/async-lru-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.10.55-h61975a4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/babel-2.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cramjam-2.7.0-py311h9c86198_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.2-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-2023.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2023.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-2023.8.0-py311hb3a5e46_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.3.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/grpc-cpp-1.48.2-hbe2b35a_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gtest-1.14.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter-lsp-2.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-8.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab-4.0.11-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_server-2.25.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.5.0-hf20ceda_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-h04015c4_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-4.3.2-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.8.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py311ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-7.0.8-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.59.1-py311hdb55bb0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-1.7.4-h995b336_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-14.0.2-py311h2a249a5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.8-hf27a42d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-25.1.2-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.1.10-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.2-py311h85bffb1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.1.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py311hecd8cb5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+      osx-arm64:
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/colorcet-3.1.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/datashader-0.16.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/holoviews-1.19.0a1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/hvplot-0.10.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/panel-1.4.3a1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/param-2.1.1a0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyct-0.5.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyct-core-0.5.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyviz_comms-3.0.0-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/abseil-cpp-20230802.0-h313beb8_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-14.0.2-hc7aafb3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/async-lru-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.10.55-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/babel-2.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cramjam-2.7.0-py311h62f922a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.2-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-2023.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2023.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-2023.8.0-py311hb9f6ed7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.3.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpc-cpp-1.48.2-hc60591f_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gtest-1.14.0-h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter-lsp-2.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-8.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab-4.0.11-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_server-2.25.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.5.0-h3e2b118_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h02f6b3c_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.3.2-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.8.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py311h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-7.0.8-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.59.1-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-14.0.2-py311ha07b5f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.8-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-25.1.2-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.1.10-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.2-py311hb6e6a13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.1.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py311hca03da5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+      win-64:
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/colorcet-3.1.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/datashader-0.16.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/holoviews-1.19.0a1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/hvplot-0.10.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/panel-1.4.3a1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/param-2.1.1a0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyct-0.5.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyct-core-0.5.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyviz_comms-3.0.0-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-14.0.2-ha81ea56_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/async-lru-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.10.55-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/babel-2.11.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cramjam-2.7.0-py311h005caf5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.2-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-2023.11.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.11.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2023.11.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-2023.8.0-py311hd7041d2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.3.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/grpc-cpp-1.48.2-hfe90ff0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter-lsp-2.2.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-8.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab-4.0.11-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_server-2.25.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.5.0-h86230a5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.17-h906ac69_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-he2ea4bf_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.3.2-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.8.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py311h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-7.0.8-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.59.1-py311hf62ec03_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-14.0.2-py311h847bd2a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.8-he1021f5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-25.1.2-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.1.10-h6c2663c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.2-py311h746a85d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.9.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.9.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.1.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py311haa95532_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+packages:
+- conda: https://conda.anaconda.org/pyviz/label/dev/noarch/colorcet-3.1.0-py_0.tar.bz2
+  sha256: cef06177b3a1a073bcc8479279d92b10b9ad0f6923755e991ac1bd1575a3da07
+  md5: 7f76292193a74a43e610df6bbcd08402
+  depends:
+  - python >=3.7
+  license: CC-BY License
+  size: 455403
+  timestamp: 1709234152894
+- conda: https://conda.anaconda.org/pyviz/label/dev/noarch/datashader-0.16.1-py_0.tar.bz2
+  sha256: f148e10e61a46f3f044c82280fc492dfb6e2b43df40e15532c3d67f97179a25c
+  md5: 2d8078383ba47692bd98dfab0993aa9f
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy
+  - pandas
+  - param
+  - pillow
+  - pyct
+  - python >=3.9
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  constrains:
+  - cudf >=0.10.0
+  license: New BSD
+  size: 17471577
+  timestamp: 1713531358644
+- conda: https://conda.anaconda.org/pyviz/label/dev/noarch/holoviews-1.19.0a1-py_0.tar.bz2
+  sha256: 3039bb866ff5be4984cdedb1422c96b1ff6e58821364502b91822c63c6a5df35
+  md5: 7474e8261429ac867b6c9047cb5d6966
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - ipython >=5.4.0
+  - matplotlib >=3
+  - notebook
+  - numpy >=1.0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9
+  - pyviz_comms >=2.1
+  license: BSD 3-Clause
+  size: 3417089
+  timestamp: 1713886529582
+- conda: https://conda.anaconda.org/pyviz/label/dev/noarch/hvplot-0.10.0-py_0.tar.bz2
+  sha256: 6b95100109b3dfcb793bdf9ca2c433e4d1c2a41976cc290d54252db5887d5388
+  md5: 7bee26227bd73d6f9651a12922a15ac8
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.8
+  license: BSD
+  size: 130175
+  timestamp: 1714998304188
+- conda: https://conda.anaconda.org/pyviz/label/dev/noarch/panel-1.4.3a1-py_0.tar.bz2
+  sha256: 41549cadf2096bf51805c598d80497e63f978eca7d18067ad4fc90896768588c
+  md5: db85a355284000d8c865633dd6401b67
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - pandas >=1.2
+  - param >=2.1.0,<3.0
+  - python >=3.9
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  - xyzservices >=2021.09.1
+  constrains:
+  - holoviews >=1.13.2
+  license: BSD
+  size: 20262281
+  timestamp: 1714474906854
+- conda: https://conda.anaconda.org/pyviz/label/dev/noarch/param-2.1.1a0-py_0.tar.bz2
+  sha256: 46fcb0b6d57a2d5d9493ac444b0417fb972bf2cae7e269db738c77ce1bf001c5
+  md5: 1041fb3bec34d2ea2759f9d9c2359187
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  size: 147171
+  timestamp: 1714639409106
+- conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyct-0.5.0-py_0.tar.bz2
+  sha256: 59cf40f7e30fb4d67712ac79a9d083821f47f27a3f0b0518eff41c9f95a00696
+  md5: 7f54cfa39d2817485ff5ad98eaf169f4
+  depends:
+  - pyct-core 0.5.0.*
+  - python >=3.7
+  - pyyaml
+  - requests
+  license: BSD 3-Clause License
+  size: 3243
+  timestamp: 1675077063629
+- conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyct-core-0.5.0-py_0.tar.bz2
+  sha256: a5b7d111faea1d5c6551a187c374f96e31e3b5b2a37142366109a40f4a115405
+  md5: 237a79d7b8461c8d8a2ee398d6217f80
+  depends:
+  - param >=1.7.0
+  - python >=3.7
+  constrains:
+  - pyct 0.5.0
+  license: BSD 3-Clause License
+  size: 15500
+  timestamp: 1675077093120
+- conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyviz_comms-3.0.0-py_0.tar.bz2
+  sha256: 9a2c74bd0ca40fc8a7d80b8742073bcf1c2f6889bc53babdf45e3be78213178e
+  md5: 1a30a4c245a51cf34ba030813e278d96
+  depends:
+  - param
+  - python
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54164
+  timestamp: 1699295791746
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+  sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
+  md5: 613805add1c05b538ff06d217252feb7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 20810
+  timestamp: 1652859733309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
+  sha256: 8762f481244fb151a200f01dd70e69c77171a3ee0f7f4c130e8e95b6a1626a68
+  md5: c3707fcd2efa582afc5c7e1986c6ce48
+  depends:
+  - libgcc-ng >=8.4.0
+  - libstdcxx-ng >=8.4.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1135866
+  timestamp: 1652382888447
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+  sha256: 250f50edf43a786a32942e9ae67ce807e9b3ac4cb6b58b1170cb541fb24e391f
+  md5: b48058294499d292ddf9a3b966dc9cc5
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 228473
+  timestamp: 1706220559474
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+  sha256: 0d4f5274503916e1c683dcc16e8a7c4186557afa3f62399cd628e4eb535fe77a
+  md5: 062acdb0f9ae976c25c2d15d589dc1d6
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 35809
+  timestamp: 1676823571351
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-14.0.2-h374c478_1.tar.bz2
+  sha256: df890b7a4a677687ad7964182735e2eaf433d6066e346d9878ba90788e3d468f
+  md5: 96e5995c1fe9e067faed3e61c416f54f
+  depends:
+  - abseil-cpp >=20211102.0,<20211102.1.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - aws-sdk-cpp >=1.10.55,<1.10.56.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags
+  - glog >=0.5.0,<0.6.0a0
+  - grpc-cpp >=1.48.2,<1.49.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libgcc-ng >=11.2.0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libstdcxx-ng >=11.2.0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.13,<4.0a0
+  - orc >=1.7.4,<1.7.5.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.9,<2.0a0
+  - utf8proc >=2.6.1,<2.9.0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 13402790
+  timestamp: 1707254138477
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/async-lru-2.0.4-py311h06a4308_0.tar.bz2
+  sha256: f798d8239a172da4d1b2e5e6e43ee466f303f08d62f920f35cfdd4cbd5d4b171
+  md5: 9721c4818b5eea1649443059b488209b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 20540
+  timestamp: 1699554588481
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+  sha256: 567dfdd5b986012421a736a5f1c1d5874d8d691dd483c838b55e1ab06c0b217d
+  md5: 4e0aa1543f546b898523382ee8405e84
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 152577
+  timestamp: 1695717917074
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
+  sha256: 432e4fb45ae24789afdaeca800862aad03f8ebed5af908f01eed2a09283915e5
+  md5: a88c0e111e1f47ee83f1b6f329a149ef
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 97643
+  timestamp: 1706746168671
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
+  sha256: edb54d1554aefb65ff5a3969085dd8695e1e3218a2987ac30a96901f0bbf887a
+  md5: 5f131e63f8d80f2b7ac505054204a9e3
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.12,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 44722
+  timestamp: 1706690912333
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
+  sha256: 2afbfb546992e5954748d039ea15405f99018f6de78ec2f32bc7ff9bfc428a9c
+  md5: 489017af35cf8bdb976e6fef020a4ac7
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 202658
+  timestamp: 1706189913451
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
+  sha256: 5f81f5a3ea27bd29bf32a6987290de8c7b2da6612676aa8e606a7003519cbf47
+  md5: c11e7ceff3ca45bf580d1c944d93bd1f
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 17839
+  timestamp: 1706690843204
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
+  sha256: 348ced323311d36344a0fa9e88d299b361bad1f628dfbdd34bcea8662b3ab44b
+  md5: 19a11cdc9727c5981d96983a29b93ce4
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52025
+  timestamp: 1706697274091
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
+  sha256: 14e2843a218cb01bfc499a22537eb345f6e222b8496cfda2050c73ad98f09cda
+  md5: 44cba75d1bb5122aeadcaf8bb7da5e2a
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-compression >=0.2.16,<0.2.17.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 192985
+  timestamp: 1706744140260
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
+  sha256: a0f6916d60c0e1bac6ba548bf05a491b8db048a94e13da2f1cfa51b4ca879fb8
+  md5: 1f010db4f5ef1b3d705ee04dd1d473c9
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  - s2n >=1.3.27,<1.3.28.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 143623
+  timestamp: 1706696185335
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
+  sha256: 596945a39d772056e57bb357202a17e02508f2594da9c00e00ad767b8213e998
+  md5: 98cccbcc56a28ec7339e393816f4bdf7
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 70139
+  timestamp: 1706746744249
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
+  sha256: 12bf86ab848e3311f4eed4e93734a84064dc84580ad6dd4bb823b4ab6ef09698
+  md5: 4a8c2dcf0ede655609a9fc5632a5227b
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.12,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 74700
+  timestamp: 1706747582638
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
+  sha256: f05ce64fee77518a6deb45f187fcee415328e90ea8f2bf6031bd5b8273a1028f
+  md5: b8ebb4b892d9b80d513b4ca62a8d6de2
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 53042
+  timestamp: 1706690818718
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
+  sha256: 52bb367fc367ee3923353927226299a2b8b1be6a1993c11e19b20cafe6c6db0f
+  md5: 4715508fd5f8b39e902cb2afebc13c93
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52138
+  timestamp: 1706192048702
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
+  sha256: 0d13fbdace8ab4fbfcc015cf83bead69560a3dfadc6e0ce8441001629d725834
+  md5: a02c72bff71848705e70cd6f075a28f3
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
+  - aws-c-s3 >=0.1.51,<0.1.52.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 211559
+  timestamp: 1706827608038
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.10.55-h721c034_0.tar.bz2
+  sha256: a489d946a0a70a4d31f5da9fdf38e2c0ba8122e1df4fc716961b5b02d7617dbe
+  md5: f29f551a4e61c4d8339710ba000c6da8
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.12,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2815192
+  timestamp: 1706890558504
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/babel-2.11.0-py311h06a4308_0.tar.bz2
+  sha256: 8da2bfb50812660c69643386afa2a2d0ce9f2b0168e9b7a372349901d7d4b2f7
+  md5: d0cde1ca577520a608da5ab86421f9aa
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pytz >=2015.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7241236
+  timestamp: 1676825038806
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+  sha256: 894fceb5b4f8740bcd146de8bd0f6eabf14e2407b149b790b4983b8432681e6b
+  md5: 2f0ef211bf628cd22bbfa44c3f9bc035
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 271600
+  timestamp: 1681493103694
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
+  sha256: 9f027f156744dcbf28945aad6e422ef030c84c2a5d40116d3e40407c66853bf8
+  md5: 7b52489e04f9a5585643d5578835fc68
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6059952
+  timestamp: 1712084450899
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+  sha256: 3606c8607c29229222667f66421f79df167d33043fe9245cdd4e2c4520ecc721
+  md5: eca33dcef14fa044193e43492dca8585
+  depends:
+  - libboost 1.82.0 h109eef0_2
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 10768
+  timestamp: 1696762269985
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+  sha256: 8e2b2073ff5c61d35714e8a36ce657a8ac741b7bedc2852a238c7f1625142705
+  md5: d951ab54a682b6328327fec53b1e5e72
+  depends:
+  - libgcc-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 147642
+  timestamp: 1707864274452
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 5d15605858771290fdaaae41a43941623757a25cb1292080d69d6d3857807935
+  md5: 7f517469aa5380c52e55db9f37df104f
+  depends:
+  - brotli-bin 1.0.9 h5eee18b_8
+  - libbrotlidec 1.0.9 h5eee18b_8
+  - libbrotlienc 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 18652
+  timestamp: 1714483267080
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+  sha256: a5094f078584e27c7cced4a9564ae904a329f5c1702a7c1ba092d581ba1544f1
+  md5: 6ddf45dd8a21a9512481de9bc0e5a03f
+  depends:
+  - libbrotlidec 1.0.9 h5eee18b_8
+  - libbrotlienc 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 19711
+  timestamp: 1714483255915
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+  sha256: 93180c973816246f068b742d0bf64840f0ea48e31d4f9b0747ea2ffc34d8855d
+  md5: f3a00096965a5ba1eb41d2c99a4662a2
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 361574
+  timestamp: 1714483400014
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+  sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
+  md5: f5058c8d5b2994b7334f18e022105a14
+  depends:
+  - libgcc-ng >=11.2.0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 427542
+  timestamp: 1714510571510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+  sha256: 5b4c80587ae4ec915505469f79d866f27c80456156667c8548d31c67c2c1653e
+  md5: c3d6bfae757760082261779c406a880d
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 116270
+  timestamp: 1693902021950
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+  sha256: 394f74202c2efc8fcfd02b8953f508eb6a2961d224a2f9d15091caf5cbe1be67
+  md5: 1202b4ed32215c6405bb42fbff355316
+  license: MPL-2.0
+  license_family: Other
+  size: 137411
+  timestamp: 1710764808838
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+  sha256: 6dc29d20180f6e002f37b251efa639716d3444e129a754dabf751f816aada7ef
+  md5: 5dbfa083e6ab6318fac58fe0e0c94445
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 165152
+  timestamp: 1707229213375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+  sha256: d138cc3fde270eba783baf1e2ba17c89800b2cbbf20976d0eb425b3436a4a184
+  md5: 1875e89c1a939e4e7c5e7b731c72b838
+  depends:
+  - libffi >=3.4,<3.5
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 302401
+  timestamp: 1714483186060
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+  sha256: 9ddbf05887c7d7926418520cc7848e57f6d2431bc4ec6d30e090b02dbf865041
+  md5: 57ae1141ad9a048fb2a75d7a3ef7430a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203190
+  timestamp: 1698129926216
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
+  sha256: a5beda842876d0d71598cd2a50ced5fb2731539bc4172fe501b93b60e0c6cd3f
+  md5: d5293e5fe74a4e0d71bbf14c9a57f900
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49509
+  timestamp: 1683040113536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+  sha256: 882481e441b9b93cbdfb32fbe32a6ad9f26197472f186a08fddb921f61346c02
+  md5: 443c79196064f57c98199e9990544b2f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16902
+  timestamp: 1709322958614
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+  sha256: e4877b41553e31b9f9f090dffab77a654255c63776e8b30fc91ec1f60afadbf1
+  md5: c34d3f1520f1e8c9957eb236710058c4
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281162
+  timestamp: 1700583651472
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cramjam-2.7.0-py311h24d97f6_0.tar.bz2
+  sha256: 7bb1fd85aaba31403b00722d6f142220031788e391fdaad899c816595cb3ae5d
+  md5: 6673633f2374304790bfdcaa334b14ae
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1528662
+  timestamp: 1702651329660
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cyrus-sasl-2.1.28-h52b45da_1.tar.bz2
+  sha256: 4e7eb5911636f3cac2bb22c85d56a8edf946cfd6379e8b7be6136ffdaf669c22
+  md5: dcabb2d653147fd807cf6edeb2c3522b
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.9,<4.0a0
+  license: BSD-3-Clause-Attribution
+  license_family: BSD
+  size: 239169
+  timestamp: 1688045783866
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.2-py311h5eee18b_0.tar.bz2
+  sha256: 01fa6e276a4e41ef2396c40c0993a54c2fa3f511b33424191e5af11936edba12
+  md5: d83fe12f3bf13f5171a19af502e6f4cf
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 444424
+  timestamp: 1701723706605
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-2023.11.0-py311h06a4308_0.tar.bz2
+  sha256: 17c0e8335eabae32d97a47dd6672a64786230bba566f01e9c235f198015478c0
+  md5: b2c2509bb07912005d603cdd2525f2c1
+  depends:
+  - bokeh >=2.4.2
+  - cytoolz >=0.12.0
+  - dask-core 2023.11.0.*
+  - distributed 2023.11.0.*
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.21,<2.0a0
+  - pandas >=1.3
+  - pyarrow >=7.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5148
+  timestamp: 1701444872410
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.11.0-py311h06a4308_0.tar.bz2
+  sha256: edc245960b92d491dc5bb03992ac344e206f094928dde23f814f6436b5781ac1
+  md5: 043e5bb51e65e9a64ce9d3e56b10de63
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3024310
+  timestamp: 1701396195636
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+  sha256: 469debfa966d24b8372aaf909ecbe27dc6fde186f6f0d5b9e0a8427e38053364
+  md5: 498d0788982ec4c5d13a44359b9c7afb
+  depends:
+  - expat >=2.2.10,<3.0a0
+  - glib
+  - libgcc-ng >=7.3.0
+  license: GPL2
+  size: 600218
+  timestamp: 1602701107852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+  sha256: 3b4cd8dc60572086f1a1cbb97e2712e0ffd55317ce8f0309d552eee7367855eb
+  md5: 70a1263b6e19bf2d77c020a2e77277c9
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2556575
+  timestamp: 1690905285843
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2023.11.0-py311h06a4308_0.tar.bz2
+  sha256: fea98401096cdbf2dd28b683bf2ce9a8788f59be71dc6b342332dae5910e348e
+  md5: 6f934835dd0653a632a78f3daaea7000
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - dask-core 2023.11.0.*
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.0
+  - packaging >=20.0
+  - psutil >=5.7.2
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.10.0
+  - tornado >=6.0.4
+  - urllib3 >=1.24.3
+  - zict >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1780776
+  timestamp: 1701398069193
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.6.2-h6a678d5_0.tar.bz2
+  sha256: 37a8f6792dc8e82d2cb8deb956f6e3dc45f947cb8efdab5feddd7395c638a77f
+  md5: bee6ef15f0f0e8c192094e7550b8321b
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 200172
+  timestamp: 1713531025571
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-2023.8.0-py311hf4808d0_0.tar.bz2
+  sha256: e1fa8f866d1bce81ac9a2511e0d42dd9be03d493f2e1f5318a26b5814a5a7cb0
+  md5: 1fb78f0486c2b4c9a31584ceb4d626da
+  depends:
+  - cramjam >=2.3.0
+  - fsspec
+  - libgcc-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 594660
+  timestamp: 1696541983803
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.14.1-h4c34cd2_2.tar.bz2
+  sha256: 4a623c7f73f4531a16271ded00c80e7dce65aa35b5105015fc4d0ceb37c9fa0d
+  md5: c9dc79248f887050dc89e19670dcbd66
+  depends:
+  - expat >=2.4.9,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - libxml2 >=2.10.3,<2.11.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 383064
+  timestamp: 1679578197653
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+  sha256: b75d12e85274660bb675a3e53d47a929872f2daa2ff5a76e98885ee3f2d19ad1
+  md5: f2119d0885334060d0d7fe59e5220287
+  depends:
+  - brotli >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - fs >=2.2.0,<3
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  - zopfli >=0.1.4
+  - lz4 >=1.7.4.2
+  license: MIT
+  license_family: MIT
+  size: 3237908
+  timestamp: 1713551660998
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+  sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
+  md5: a5dc8677d891dff2393b63189a3ad42f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 971975
+  timestamp: 1666798278693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.3.1-py311h06a4308_0.tar.bz2
+  sha256: a78f34d0b919c5fce722d33afc278cd48f5eec2bf186c35dd18d59d85d45909b
+  md5: 199586a3dcad8985bc4cb0e4262e06d1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 364478
+  timestamp: 1714461584790
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+  sha256: 2fc1136056f41fe92de719fb821550346704965dd12a5fa35069cdb4948d5c17
+  md5: fd089b0fba2b03aafe3adb6cdaa9ac3b
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203421
+  timestamp: 1706888218007
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.78.4-h6a678d5_0.tar.bz2
+  sha256: d9a486f0ac92b1365365c3e536040a552c2de633283f27129f16dadcbc6d2de8
+  md5: 32538e0c24874a85011a094217830bd4
+  depends:
+  - glib-tools 2.78.4 h6a678d5_0
+  - libgcc-ng >=11.2.0
+  - libglib 2.78.4 hdc74915_0
+  - libstdcxx-ng >=11.2.0
+  - python
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 499006
+  timestamp: 1708031707428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-tools-2.78.4-h6a678d5_0.tar.bz2
+  sha256: cc7d3a52acad1df08e3d4ec7eefb22f41320e7eada94e78bf4b051128cbe72d4
+  md5: d8dcbf2be12799cf7f333c21a0e91990
+  depends:
+  - libgcc-ng >=11.2.0
+  - libglib 2.78.4 hdc74915_0
+  - libstdcxx-ng >=11.2.0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 112595
+  timestamp: 1708031685927
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+  sha256: f1e190d4ee766add8131a2b011723c472284de2bbb5e07c8f895f30e3c591df7
+  md5: 82029e0758feac811afec2a6ef9e6155
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 108438
+  timestamp: 1706895276199
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/grpc-cpp-1.48.2-he1ff14a_1.tar.bz2
+  sha256: 32657e2d11dd813e5649f714c7f58115cff3387f27cf0904cee873bd0d82d2a4
+  md5: bdfb8214247977e4ededa4aeb3291ea3
+  depends:
+  - abseil-cpp >=20211102.0,<20211102.1.0a0
+  - c-ares >=1.19.0,<2.0a0
+  - libgcc-ng >=11.2.0
+  - libprotobuf >=3.20.3,<3.20.4.0a0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libstdcxx-ng >=11.2.0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5391101
+  timestamp: 1685747457305
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.1-h6a678d5_1.tar.bz2
+  sha256: 833208211f0ecb52198f5fae585f937be3c337c15b4569d8f1a28638545250d5
+  md5: 2fa837925e0633ceae4ec826f6daa93f
+  depends:
+  - glib >=2.69.1,<3.0a0
+  - gstreamer >=1.14.1,<2.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libxcb >=1.14,<2.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  size: 2253949
+  timestamp: 1677171916164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.1-h5eee18b_1.tar.bz2
+  sha256: 8257a1c1c967d48561f62adb649fe21c467f0a37c41f783ba6e2c6d79fa1cc4f
+  md5: 5cd8e1f16b1ce869d0c3a98b9f0897fb
+  depends:
+  - glib >=2.69.1,<3.0a0
+  - libgcc-ng >=11.2.0
+  size: 1690003
+  timestamp: 1677171850557
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+  sha256: b35b281dbf69b826c6ae04fcd7b6a2d1f098277a669a199906a1f23b4b0931a5
+  md5: 2a793fe24f85aa5819fe69c450cba6f7
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 29021241
+  timestamp: 1692293243228
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+  sha256: e08e27531775de40f46b6ac7bf71856963baa0c008bd2b4d112e6341cd3e8f4c
+  md5: bfc7682613c861cbcb4ac01485c05657
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147174
+  timestamp: 1714398938840
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+  sha256: c7ffa6006573483a05ef355770c3201f04dd04ab4b91ae01971a6cdc7fbdba35
+  md5: 23d7d38e93d930ea5e2cc5f4079d3816
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 49872
+  timestamp: 1704813633807
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+  sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
+  md5: 3add2ce56858a1b8f6a37342f82773d3
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<1.2.14
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 19310769
+  timestamp: 1699647799237
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+  sha256: 0b670ab17ed2e1b592079bd64386dadc249ddc892e5ae1dd99f142a918ffc75d
+  md5: 632575b9e442c1e5c146cf78424da610
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 227791
+  timestamp: 1705934138566
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+  sha256: 65228eb868c3ec8aa71f958e60a675a919f016c2057392e02fd422fc841858f9
+  md5: 68e23f14cd222c233e6b37262bc61c23
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1612840
+  timestamp: 1704833066871
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+  sha256: a2918ea8a3e2c56fc6d91191e84b2f35500c392b16ab687a0c03ded2e2e51239
+  md5: 84fadd6b7fef393cccc0d123dae6cae8
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1162207
+  timestamp: 1679336523618
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
+  sha256: 4520b83e425883981f97191986a08122fbaebc3f16b898368796314136779028
+  md5: 42a8f32c4d842d3e5410b2bc1cc2fb57
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 352284
+  timestamp: 1706733655761
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+  sha256: c21f8f407266d039e819c27fe9eb4fb26587e974f3bd059b37cbaec5073722d0
+  md5: ba1f47411e9e07876c7a3e9d3be6a98e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: IJG
+  license_family: Other
+  size: 281400
+  timestamp: 1677849152168
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+  sha256: 06b729aee6dd2a1e545f3ad64179cc0d4ef8a15e33db3be2995dd3e0868465ca
+  md5: 8bb3215912588e47e2eeb4e7a09ad64f
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 180858
+  timestamp: 1699041715847
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+  sha256: 9e3bac2d41bd432b721b009e7de981766fba396e6f238e923f304112bd88655a
+  md5: 84ae4cf3f2d01fbebdac374971192be9
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 15525
+  timestamp: 1699032521315
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter-lsp-2.2.0-py311h06a4308_0.tar.bz2
+  sha256: c4b1dcb8ba34bfb2c7fc6ccf1399dd0bd2a324e792eac722561607f2bff68d72
+  md5: d82f26a5c414b519c7737240fb7f342e
+  depends:
+  - jupyter_server >=1.1.2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100413
+  timestamp: 1699978354251
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-8.6.0-py311h06a4308_0.tar.bz2
+  sha256: d215948faad1eff39b5bec3da793d6d185b85793a1d839c3d1c196b85fd6c9b1
+  md5: 555ea509581f49256e7aae2ff5dce460
+  depends:
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 221658
+  timestamp: 1699456577818
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+  sha256: fedc7e5560252af44b0dfbe6f7acfe20ab17a6a08e758f670a1cd820551afc7a
+  md5: bd28d36963087f53a79b23fee697d665
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 93898
+  timestamp: 1698937453304
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+  sha256: 2b896fe8b2187b7df824041826e14379476eb2e61d607d8cb38ac2b3df40aaa4
+  md5: 8fc7e517da96c2c482331f6b08d07a17
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41459
+  timestamp: 1699282616532
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+  sha256: 87d372f5b23bcc2410e43b40b4ad059ea1625178b8a2b484fc63805ce517e594
+  md5: 50204f372b1672871d6ab3db6a876374
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 594177
+  timestamp: 1699467208489
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+  sha256: ddfee06ba9b149222c65d1d4270272840533aa63b56fe36363c84a891c71d328
+  md5: ee128e5c0d8d9e1952e2387b66a5b8cb
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27239
+  timestamp: 1686870958829
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab-4.0.11-py311h06a4308_0.tar.bz2
+  sha256: a2bc9b312a31e5abaedf230659ecb31f9483a1a3c0f4cd1adae7f5ea2045f9d6
+  md5: 728bdb3c057e57cd963f304d2c8a48a9
+  depends:
+  - async-lru >=1.0.0
+  - ipykernel
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.19.0,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  - traitlets
+  constrains:
+  - nodejs >=18.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6665313
+  timestamp: 1706803269767
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_server-2.25.1-py311h06a4308_0.tar.bz2
+  sha256: b8c434bad4499fc41d0e18986b7ab1fbcf5e2aabadc2658430ee1f5cd16c4cbc
+  md5: 59a08c840ebfa765cfe5d4dc764804c7
+  depends:
+  - babel >=2.10
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18.0
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.11,<3.12.0a0
+  - requests >=2.31
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 106168
+  timestamp: 1699555585974
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+  sha256: b040f0d0ee4588188ab6b83a93738b3ff6e6d1775424be97995bd0df0f4fb904
+  md5: eae62735d710cf5ff6d51e6f59fcd999
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78148
+  timestamp: 1676827253282
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+  sha256: 01bae3dd44469e34f043e0416f5f5e658429bf4031745399d9968d10b899e2c4
+  md5: 10171cca67e3d73c3646c6dc5a321460
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.8,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1427115
+  timestamp: 1686931095252
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+  sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
+  md5: 88199c75f2ac211728febced7785c24e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 228278
+  timestamp: 1635523146417
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+  sha256: e2754627e8aeb98777318939e6773b9eadbdc219dd8961aca946354d9d30f481
+  md5: 4ed89646229bee3e594cd2cc8f6060f9
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 23778916
+  timestamp: 1696762223408
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+  sha256: bb990ea068c3b3dafd9c807e0e19570320cb2fe7d69cc326f1f0b5319b0654b2
+  md5: 3ff70744e396b1af69656c574b05c3b9
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 66940
+  timestamp: 1714483221853
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 3b87a816f72a00e1f0022a160e7eda70af89d3de2a2e08a72be1c17b31d759f3
+  md5: 4f57d3a0a13ddaf1c06efb586b702f46
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 34446
+  timestamp: 1714483232430
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 2cf15e89f910600f468edfde8d0f9b80a14fa2319ed89160dc7375dfd3764fdb
+  md5: 463adc13f2feea3570d1eccac368d9e4
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 295090
+  timestamp: 1714483244460
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang-14.0.6-default_hc6dbbc7_1.tar.bz2
+  sha256: 46646ce93dafb4922f4597c34c4fec106b4ff3b9707a202387f7964601e47876
+  md5: 5eaf417727302b441025661154fc4587
+  depends:
+  - libclang13 14.0.6 default_he11475f_1
+  - libgcc-ng >=11.2.0
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 130632
+  timestamp: 1681222907766
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang13-14.0.6-default_he11475f_1.tar.bz2
+  sha256: 24d638d8577a3332a2e6cd77a5178054ca9cf7e14f71353b5b0a655155ab5c19
+  md5: 230f394424c6cc26ebbee96176b65ece
+  depends:
+  - libgcc-ng >=11.2.0
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 11152969
+  timestamp: 1681222877667
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcups-2.4.2-h2d74bed_1.tar.bz2
+  sha256: f465c8f00b075660362d8e7fba8702b1c11e56fb2c305da78b9ee69898609be7
+  md5: 8a2e46dc8bd62528a6f4d9092f2f6911
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4901408
+  timestamp: 1685057846629
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.5.0-h251f7ec_0.tar.bz2
+  sha256: 22628e28b6df8298b761c4524b086a02b0e9fe208cf37ec86090497c4db50583
+  md5: 7d328929de28a113f3e5b8e0d70ce709
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libgcc-ng >=11.2.0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.57.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=3.0.12,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 403919
+  timestamp: 1704383721246
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+  sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
+  md5: 55dde57e63a36b202e388a39dcee9a66
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 74096
+  timestamp: 1695996494461
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+  sha256: 5bd3af246b6a93ea0912179ae66e0ad9157ca0142263010d84b65724e6db0bec
+  md5: 5cb0cc0e1783419cf8fc1c65fee0f62f
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 195807
+  timestamp: 1703006263489
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+  sha256: efdab884c85fda4461f7a393aa6d4e0e50d03cb59fb9c8a980b1307b8379ebe0
+  md5: eeca774c6154c49340dd403b1928d5e9
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 108906
+  timestamp: 1632891483341
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+  sha256: 4b2518a1aa3859031a531cd1077e8a60d5b3a0dc7c83210ef27ff9ce2c78c3e3
+  md5: 49f152ee4045544c10799d32bba85c07
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 480247
+  timestamp: 1685052130829
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+  sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
+  md5: 1af9b4d62c708924417f2640ef22a68f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 154016
+  timestamp: 1714483282916
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
+  md5: 641e72e5067bd6d5454405879e1cd2a7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - _libgcc_mutex * main
+  - __glibc >=2.17
+  constrains:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - libgomp 11.2.0 h1234567_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 8895144
+  timestamp: 1654090827491
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+  sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
+  md5: 27082517590f3b9fbffecc68513b461b
+  depends:
+  - libgfortran5 11.2.0.*
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 19860
+  timestamp: 1654090819660
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+  sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
+  md5: 0202c3c8ae4735cac6c7f3d1e1685964
+  constrains:
+  - libgfortran-ng 11.2.0 *_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 5228750
+  timestamp: 1654090762569
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libglib-2.78.4-hdc74915_0.tar.bz2
+  sha256: ddda848ae8594a9a28b14439b322763e4ffb0ff8d34e492c994e434fe3fbf934
+  md5: e35935cc3937ef52b2ef721dddc45738
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libiconv >=1.16,<2.0a0
+  - libstdcxx-ng >=11.2.0
+  - pcre2 >=10.42,<10.43.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - glib 2.78.4 *_0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 1583413
+  timestamp: 1708031663093
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+  sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
+  md5: 3080c2813e6e1d0f8a100a38b5b3456d
+  depends:
+  - _libgcc_mutex 0.1 main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 573231
+  timestamp: 1654090775721
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
+  sha256: ed544d8aa7e77fc42c39c276b879955e6615b517c42fecd2624033a5050832eb
+  md5: 21ee76e09ab0a7315cbed14933d97773
+  depends:
+  - libgcc-ng >=11.2.0
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1436714
+  timestamp: 1714483320555
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+  sha256: 512fac06ddd97b4383503d4fbd8145102966055b29ccf86841a930dbb4ef3ab8
+  md5: 833c0e514ff9c8ae0511630b024d60e0
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 37179832
+  timestamp: 1683292829131
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+  sha256: 6c67d781d3c074ae46b18567f230bce4a4afa209e8b914dc2cb448502774886e
+  md5: c9627c386bbc8a1a1a0a2e736ea44501
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - c-ares >=1.7.5
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 722387
+  timestamp: 1697018420830
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+  sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
+  md5: 1bffe1481ed4f88827248fb9001f8923
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 362561
+  timestamp: 1677841789536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpq-12.17-hdbd6064_0.tar.bz2
+  sha256: 9fbd40a9bcf75d2f7aab558b3803175d419b1178ec2ece0d77c40a3e47cf0d9f
+  md5: ca25d5734b0361f78536d5e77b4b3e43
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.12,<4.0a0
+  size: 2973280
+  timestamp: 1706214551622
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
+  sha256: a24f7d1cdb5e18466a61860a5a66baffd608e212bbfed2935350e83d4d8659c0
+  md5: b32a43de76bc9be9c71f9a12edec8a1e
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2706964
+  timestamp: 1675278653314
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-hdbd6064_3.tar.bz2
+  sha256: e3aadf465217537237e9e4c849f19f1ecb76a760e4b4ac479a02971832e39e75
+  md5: c3f8eb577f0da5f7524896bd4bce2dda
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.13,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 337499
+  timestamp: 1714510585581
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
+  md5: 8c195584a5f5471b600ee180e4052773
+  depends:
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 6410287
+  timestamp: 1654090800863
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+  sha256: 974e4035c5d51cd41fa7a7f02fadc1980069c00526c1646fa18ea94e667fb137
+  md5: 188de945b4279a812953011e8c4580c2
+  depends:
+  - boost-cpp >=1.73
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.9,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4630795
+  timestamp: 1687975185557
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+  sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
+  md5: ef78eebd98289aceacdfa29182426adf
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 664034
+  timestamp: 1693575237924
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+  sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
+  md5: 292768ec77416ae257cfdd44ea2071c8
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29197
+  timestamp: 1668082729834
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+  sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
+  md5: 9cdeef1d044c7e035c006890f11569d3
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 436056
+  timestamp: 1694776944891
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+  sha256: 5d68e69709ae10bd6c4b58b6af447ad2f2bd24955994f3ec77103d1a6bf5e1f5
+  md5: 49e523de8d364b7fabc3850eccbe9bda
+  depends:
+  - libgcc-ng >=7.5.0
+  size: 623492
+  timestamp: 1652448233146
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxkbcommon-1.0.1-h5eee18b_1.tar.bz2
+  sha256: 114853749b375d54347f18b472456eb7d66beba26238c984403bdd5ff8831947
+  md5: 6225f107993ddf5e1f61111b3df025bd
+  depends:
+  - libgcc-ng >=11.2.0
+  - libxcb >=1.15,<2.0a0
+  - libxml2 >=2.10.3,<2.11.0a0
+  license: MIT/X11 Derivative
+  license_family: MIT
+  size: 640985
+  timestamp: 1679578328295
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.10.4-hfdd30dd_2.tar.bz2
+  sha256: 392fa116c728a97c17f3105a4d15b1ad86ee0b79c33c3581616b871b6d3f3f5b
+  md5: 09e1d64be1c4268bc83d1e84d28019f2
+  depends:
+  - icu >=73.1,<74.0a0
+  - libgcc-ng >=11.2.0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 745147
+  timestamp: 1713558300638
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+  sha256: fd8e30beb8c9442f16e6617fac92dd0c89ec823e98f06e60f712147380ead35f
+  md5: 7ed7caf2816c8b85b67b6f4e8833cbd5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41155
+  timestamp: 1676837080881
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
+  sha256: 05e355127db0d3ed67c4c383fd929ef1c3d7d3f19472f6e5433a866e94378bed
+  md5: b7897895622e5ab6e62279f07fa1f587
+  depends:
+  - libgcc-ng >=11.2.0
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4367002
+  timestamp: 1706910875807
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+  sha256: 95fe76d2691feb13203b55ad2aba535bb848cae21ffd05b13ff51c7a45fa2332
+  md5: 6a04ec16e3abc1c7e2104be32cd6c418
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13458
+  timestamp: 1676827287432
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py311h5eee18b_0.tar.bz2
+  sha256: fc8fa25c9629d8b5362d14ca7c90792064492aef7765a60e3574948f4659b4f2
+  md5: ed09cfc6c49987d5af17585f5e5168cb
+  depends:
+  - libgcc-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40405
+  timestamp: 1686058019487
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+  sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
+  md5: 76f089e76ec67583bb38428b51008097
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 164494
+  timestamp: 1714510587156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+  sha256: 260e26dd509834c1b225ab7bdb97b9a86e00054fbdd5dfa49e68fa4dcf85a661
+  md5: 8f5d7ddc69cc6f7d44c80d2251dea5d1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162339
+  timestamp: 1676837095436
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+  sha256: 7f5b0804d0768619b7bd93b10488067d80bf42ec29f443f00b53ba11758a1241
+  md5: 8afb45e45c0d93bfd142e682d4b021ef
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 134438
+  timestamp: 1684280014220
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+  sha256: cb03570c99c983d7bfda94bc47d8eb00d4059b8548a171130775acc998004195
+  md5: 5b1abbbf1e4f9b350b16fc9caf9e889b
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26919
+  timestamp: 1704206397615
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.8.4-py311h06a4308_0.tar.bz2
+  sha256: e7eb5bfdaf1c62bfe2489237ea4ae6a837f09a647f846c31e4022a04e07355c0
+  md5: d744bdd5306fb954b4ed65311db45174
+  depends:
+  - matplotlib-base >=3.8.4,<3.8.5.0a0
+  - pyqt >=5
+  - python >=3.11,<3.12.0a0
+  - tornado >=5
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8014
+  timestamp: 1713336708416
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+  sha256: 85fea48bea278a77d102781a1cbb6bf69307207d741251e38a6515c5fd7e3523
+  md5: d6ddba94f7c33c88c9825be8409991bf
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9150942
+  timestamp: 1713336680714
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+  sha256: 7ac07ea180b5928086075900afbc332fb1d3c81ddfacb54c891693c284056f14
+  md5: fc83dd1b3d2ec3c0a297ead0c3405907
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19573
+  timestamp: 1676823852670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+  sha256: c9ba2f9c83820712dd97d6a1b54a1215b9820a0be02ac82380b4c50911b9400c
+  md5: e5dc6b4a5b8e02733ce3bc9e9198a8d2
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67750
+  timestamp: 1676837123613
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+  sha256: 1a5141ef0de1cbff816f96bb4b212a40606e2fc11301a4c1358c8d63a6b2b027
+  md5: 22ac3bc22b68fef4c1f3f6ab3c7bfe0b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23040
+  timestamp: 1676827301164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+  sha256: 9aacfbbe6f638c58a4e8ff31374d1438d78b7db25d6ea6fd0c50ca2109f225d4
+  md5: e602057e3b3d80da88c61d66e8851c5b
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104681
+  timestamp: 1676823696152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+  sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
+  md5: ce77d0f05f846da4a6b9e23fe7f21d9b
+  depends:
+  - intel-openmp 2023.*
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - tbb 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 206738176
+  timestamp: 1699648006088
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+  sha256: 2aef0876d0df033f7fae8cddbd25d95fc1bfc067e60dd143bd8000fec0768b21
+  md5: d6cdc670327bd1675bbea642849f04e1
+  depends:
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59569
+  timestamp: 1682948560323
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+  sha256: 691c4b2b47cf3fac55b4949d7c0f547246ef19cb3510749142cee4bd01ffb055
+  md5: bbd69efa3f24ee747410f83118640d92
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 240723
+  timestamp: 1695058405382
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+  sha256: 71f5c7beca4e81b465ecfc6ed51cb3d39f51dd88df0b29eff5def3d1f12969eb
+  md5: 61d58663b7277cf4cc3cb8d9873d3ee8
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331105
+  timestamp: 1695059935112
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py311hdb19cb5_0.tar.bz2
+  sha256: ee4db7daf8d5e41a547e7790dd62aa98e203f4f857cf6018b850e7df8e613a3c
+  md5: 17145d1745996667614b52d2b27a1403
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 37588
+  timestamp: 1676823053826
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+  sha256: b558b3f6c144652b5e0d26497b3ce24c318a6b9ff8ea2079113c95e5553b3cf9
+  md5: 0b185969ac2b065c27cbcc9641d93678
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29568
+  timestamp: 1676841232463
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mysql-5.7.24-h721c034_2.tar.bz2
+  sha256: 1127b7dbb0a740f3de8931a4af5b70b3dac6dc3de162a2d8f8760335db5e6669
+  md5: b4ab7fa3430324358189ca5ff9fc8e42
+  depends:
+  - cyrus-sasl >=2.1.28,<3.0a0
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.9,<4.0a0
+  license: GPL-2.0
+  license_family: GPL
+  size: 82391019
+  timestamp: 1688563074905
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+  sha256: bb45fb0a3973caa74fd8f845e0a519895f6a378807626e15ecf72c02f2eed794
+  md5: 185f658ba8a74e326b7231c8fd0d62bf
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 121834
+  timestamp: 1698934274227
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+  sha256: 8b2fc372a6655fd5b277d07b994ce43643553fbc37e63a60e9fe527a9026ec06
+  md5: ed6ac14aed5a796b153d757862398997
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 523905
+  timestamp: 1699022906468
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+  sha256: 7908ff6c516b15e8fb677be4071145e18adea7d4c13b8485a70a5ee2f573f8cb
+  md5: 50c0e38207a131a5de6a14ef919ffcdc
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 169629
+  timestamp: 1694616826002
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+  sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
+  md5: 57ea097dc15f8d9f9eb90e1d919143b0
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1157733
+  timestamp: 1674734069410
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+  sha256: 266199dd4efde0ad342a9c500f4bc4299c5622219aea623b46315a9b4f6b8959
+  md5: 2b21844d2b0024d0ffad0e6450cf0855
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 15860
+  timestamp: 1708532713870
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-7.0.8-py311h06a4308_0.tar.bz2
+  sha256: 59e17fc80ec01ffef983431d36b41013d1da575e03f5bc1ff36fc3b7e496e7be
+  md5: b4e5249538db1bc282ac0d0d8c4f307c
+  depends:
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab >=4.0.2,<4.1
+  - jupyterlab_server >=2.22.1,<3
+  - notebook-shim >=0.2,<0.3
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3650043
+  timestamp: 1708029938702
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+  sha256: ef2857e6d3d7eb246b3abddfbd3aa2d124dd8565391ace3876b77339babc50bb
+  md5: d276d1b1774107987963135c78ca7390
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26607
+  timestamp: 1699455972519
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.59.1-py311ha02d727_0.tar.bz2
+  sha256: 1b830d1d091462cff92de55f24339365a9d2c23b27d19799833b4780efe99c15
+  md5: 06367b04f8f04c0dc4e356a2ca9dc854
+  depends:
+  - _openmp_mutex >=5.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - llvmlite >=0.42.0,<0.43.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  - libgomp
+  constrains:
+  - scipy >=1.0
+  - cudatoolkit >=10.2
+  - cuda-python >=11.6
+  - tbb >=2021.6,<2022
+  - libopenblas !=0.3.6
+  - numba-rvsdg 0.0.*
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6084284
+  timestamp: 1711988494237
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+  sha256: 2f89f38a665ece47e8868b391fc70602fcee588e989bc1ca6f17f6094892a94e
+  md5: b788c80b2d571531ea4f3f8335ae5423
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 168827
+  timestamp: 1696515597877
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+  sha256: e09e1aff2c12d4ef3fec58fb627744e4b5c7d9eaede7175e293f77272d8b8bfd
+  md5: fe8242cfd54d238507493612ae697ad4
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311hf175353_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10270
+  timestamp: 1708639794640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+  sha256: a53ad723826651041a5057a1cf31bc8689b24d335ce61b196df5124974b05a8e
+  md5: 7b29e7191c4170189d6080e61229f030
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311h08b1b3b_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9163911
+  timestamp: 1708639777712
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+  sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
+  md5: b0afe23033c8c5344640bc25225fa579
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 516994
+  timestamp: 1630084830020
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_1.tar.bz2
+  sha256: 9e90c0fd10fcc5a73afab93ed7f7f6a4d4822feded941198ae66d999923323ff
+  md5: 8d976dfed2a62a709aa759dba69da8a3
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 5512151
+  timestamp: 1714510995665
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
+  sha256: 9618addfc1b940c048372ffb2c8500d4b44d02455a9bd1f411e530ed5e09b8d5
+  md5: 56057ed323f733bdcf262468682d0358
+  depends:
+  - libgcc-ng >=11.2.0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.9,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1132661
+  timestamp: 1676482768554
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+  sha256: 280225061aeba00d7b85f46e55d7d79cd92c92f662dc749d9c53187978e8d083
+  md5: c51c21da68080d89300703ad818c824a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38606
+  timestamp: 1699371264464
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+  sha256: bd3eacd22e85f88bedd9c7e97a59eacfb3c8bb80eb59be244825d6895a0e7ac1
+  md5: 08ceb294ba8a9ae13630da789884736e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 157904
+  timestamp: 1710807470578
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
+  sha256: a2ee3a6aaf54929b82b851b2eb5436e14e5a294303ef429d6dccd33bcdfc8002
+  md5: b467a5c7ad672ccc2d498a67b9eeeaaa
+  depends:
+  - bottleneck >=1.3.6
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - fsspec >=2022.11.0
+  - matplotlib-base >=3.6.3
+  - tabulate >=0.9.0
+  - odfpy>=1.4.1
+  - pyreadstat >=1.2.0
+  - pyarrow >=10.0.1
+  - python-calamine >=0.1.7
+  - s3fs >=2022.11.0
+  - beautifulsoup4 >=4.11.2
+  - gcsfs >=2022.11.0
+  - xlrd >=2.0.1
+  - dataframe-api-compat >=0.1.7
+  - pyqt >=5.15.9
+  - adbc-driver-postgresql >=0.8.0
+  - fastparquet >=2022.12.0
+  - psycopg2 >=2.9.6
+  - qtpy >=2.3.0
+  - openpyxl >=3.1.0
+  - xarray >=2022.12.0
+  - html5lib >=1.1
+  - jinja2 >=3.1.2
+  - pyxlsb >=1.0.10
+  - sqlalchemy >=2.0.0
+  - zstandard >=0.19.0
+  - pymysql >=1.0.2
+  - pandas-gbq >=0.19.0
+  - lxml >=4.9.2
+  - numba >=0.56.4
+  - xlsxwriter >=3.0.5
+  - blosc >=1.21.3
+  - adbc-driver-sqlite >=0.8.0
+  - pytables >=3.8.0
+  - scipy >=1.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17970687
+  timestamp: 1709593080388
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+  sha256: a2e2beff710765f2e5135020121da4f227f5e1cbe142e17398a585f50a389d37
+  md5: eaf734d49b6e576e12be1398a295643a
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - pandas >=0.19.0
+  - numpy >= 1.9.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 47447
+  timestamp: 1698702703255
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
+  sha256: 71beb7373390a7c5e9bf8663d64e2b0a426755fe68adb26ed72b6570634f635e
+  md5: cd7c1793b37ba076f8515b49dbd850bd
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3346886
+  timestamp: 1714657706306
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+  sha256: 28ed719669260a20bec78971edaffb91ec917d2a3f0fac1cf9a8ba21590baa43
+  md5: 0481d078fcd64f7f981532a514d9d50d
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 960727
+  timestamp: 1714399060039
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3.1-py311h06a4308_0.tar.bz2
+  sha256: 0bedd7decde6751a3efbb2367dd22d916b61391e334833d548b285fdd3420080
+  md5: aebee46c2eadf95ea8633847612f0f15
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3443056
+  timestamp: 1700667782149
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+  sha256: d2bbab8bfc57c7f46ca8994bc87df7e744d3f036b867bc4be1145ba6d8d7e091
+  md5: de41707272a8e3ccab764f0b7010a27d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37394
+  timestamp: 1692205565974
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ply-3.11-py311h06a4308_0.tar.bz2
+  sha256: 786a4a57db582b66de12bd7e03eae83caa939136dabd8b53049cadeabc0beb6f
+  md5: 262064c348f1846011c650ad8a6cd793
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-clause
+  license_family: BSD
+  size: 111320
+  timestamp: 1676824981885
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+  sha256: e2a0e2a618aa33f0beff9583c7dc510b8d0737b023117346676aacbad33970d8
+  md5: 66a6818307261b1a28ab12d1b7776fdf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 121454
+  timestamp: 1679340540306
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+  sha256: b7f591c19b10bf0daa7e6e3b45a9f4a0a0e83188e1f8a58037caea79e60f8d91
+  md5: d945b4ccc135005839c504cc29df1745
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 749608
+  timestamp: 1704404477511
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+  sha256: 96482b49191fdac59580a95e69508367083e1f7600145e11d7c2db634337eb26
+  md5: 2d57bf8eacf3f291db845928241f724c
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 490805
+  timestamp: 1679337420563
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-14.0.2-py311hb6e97c4_0.tar.bz2
+  sha256: 252204d5e65480b83b9e31c63cecfaff95725ef5fc302714f92c344b7fdbafe3
+  md5: f2b86ab94d7af6c10b9586263b1b45df
+  depends:
+  - arrow-cpp >=14.0.2,<14.0.3.0a0
+  - boost-cpp
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 5423490
+  timestamp: 1707331892286
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+  sha256: ed927e4d058a8f4ea73edc7a43ed74877d93b88fdfa240b3b2777244386ced70
+  md5: a1f0e05fc7e49712f81ad5478ec9d51e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2121496
+  timestamp: 1684280065800
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+  sha256: ad219924e362ce7af458fa6547660181579e9a50e5aed1ffd9268cbe7c2650e3
+  md5: 2b1ac40e0df3673d33b7f4c4f93ae1ef
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207338
+  timestamp: 1677811584327
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.15.10-py311h6a678d5_0.tar.bz2
+  sha256: f0c1614d5e651ed15061d137acecda2f684189cc148f50d3e75068dc9737bcd4
+  md5: 0911e45b849687c7318f7764e2b69778
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - pyqt5-sip 12.13.0 py311h5eee18b_0
+  - python >=3.11,<3.12.0a0
+  - qt-main 5.15.*
+  - qt-main >=5.15.2,<5.16.0a0
+  - sip >=6.7.12,<6.8.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 6539272
+  timestamp: 1698775883859
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt5-sip-12.13.0-py311h5eee18b_0.tar.bz2
+  sha256: a646cae6b3d429588a3dc752819b4dcb315a814c8ad2b9fb2741b166fc4ee2a6
+  md5: eec3045856f86acc307c73749a7f7df1
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 97216
+  timestamp: 1698769366045
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+  sha256: 114b55e00f4622c90fd2b404b21ad5f94a10283fcaaf86a42174b8d39b0a3e98
+  md5: 2458e92683cc68671a6c8e1b86ce8817
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35850
+  timestamp: 1676822725516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.8-h955ad1f_0.tar.bz2
+  sha256: 8bae0856b2f337f43cb5cbbf71ebf684ef47438210465b8733304d7d7f258559
+  md5: 7fa94ac6e31488660ca09b2896b9d96d
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.35.1
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.5,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 36090392
+  timestamp: 1708984519285
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+  sha256: aadc4078311c059265706a56265f0a57ceb538d36179d5203dd487d80d0e8f16
+  md5: 59ec670fcd172447dbd9591b8fbfdd56
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 278741
+  timestamp: 1679340144625
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+  sha256: d5058d0ecc3973316c1d5f1bfb03dd119e0dade85f4c2d21b412c8db4e1636f2
+  md5: 93000e4d3603342779a2afda66fa91b8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17607
+  timestamp: 1683823841946
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py311h6a678d5_0.tar.bz2
+  sha256: d9eff881e112d0b326d0c1ee0d42d6c2c4649b1c4edd168be1006f28f1f8962e
+  md5: d9d1f41dcee9b622cbfe048ab1632a47
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 154074
+  timestamp: 1682522389521
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+  sha256: b85acb933fff864bfa89d034e8e3d85b1a9c2e69cbfc0d68c1d66ffd1443e67d
+  md5: 0cdb92d2d684ee1095310f992ed0d9b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 266796
+  timestamp: 1713974338678
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+  sha256: b2a1f649669f4336b74f6f20df711959bcd8024f8f8b94199dc0e040b06bd37a
+  md5: f9e8e3f7068f717f75e555dc04545d8d
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 206433
+  timestamp: 1698096204677
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-25.1.2-py311h6a678d5_0.tar.bz2
+  sha256: 787979e7e36b0eaf06c65f8840f3af969b6efa6ba2a7e2736b1bb52e96588242
+  md5: eb62cbfdbe25aaebbafad6166ec66903
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 583036
+  timestamp: 1705605396341
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-main-5.15.2-h53bd1ea_10.tar.bz2
+  sha256: 34fca7030324880c741f8b2030673229883cb7a11429f8e4bd2664d7d0f07ae1
+  md5: ccbd6faf6b49454aec690b72d21666dd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - dbus >=1.13.18,<2.0a0
+  - fontconfig >=2.14.1,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - glib >=2.69.1,<3.0a0
+  - gst-plugins-base >=1.14.1,<1.15.0a0
+  - gstreamer >=1.14.1,<1.15.0a0
+  - icu >=73.1,<74.0a0
+  - jpeg >=9e,<10a
+  - krb5 >=1.20.1,<1.21.0a0
+  - libclang >=14.0.6,<15.0a0
+  - libclang13 >=14.0.6
+  - libcups 2.*
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=12.15,<13.0a0
+  - libstdcxx-ng >=11.2.0
+  - libxcb >=1.15,<2.0a0
+  - libxkbcommon >=1.0.1,<2.0a0
+  - mysql 5.7.*
+  - openssl >=3.0.10,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  constrains:
+  - qt >=5.15.2,<6
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 62392312
+  timestamp: 1693222657819
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+  sha256: 8a640736bef635346409582dbfe2b7d0ecc9da215c90173ff8a9a5fe22569107
+  md5: 6b583dce61c6feb352ef0f49f413af1e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-3-Clause
+  size: 235004
+  timestamp: 1652449537852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+  sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
+  md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 467661
+  timestamp: 1666648052561
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+  sha256: 89c2f4235277b9825cc805c5c44f0b1afcb683d7b5a3f513bc4bf243b643bb0c
+  md5: db70eb57e33adf7b8bbdadd72214d48d
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 73679
+  timestamp: 1699012111499
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
+  sha256: 684037527327839d734e7eac2ee09ef5ddb4f77df22daf40c79e51db29d09543
+  md5: 57c5bcb9eae9f1d93ccfd38025660de2
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 119414
+  timestamp: 1707355661872
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+  sha256: fdae3f68ea84b99561aee6c566ab1c287d8f2ae2668424e9283a8ed86af8f1d2
+  md5: cde5b71ccbb3630053340b2c8c7dbf10
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9333
+  timestamp: 1683077183576
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+  sha256: 0bf859b06a07857099fd4f524fe5e0875fda70029e9485d95c7efa97134fbc14
+  md5: fd5815cc592fdbd4c831901541eadaba
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 9735
+  timestamp: 1683059096795
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+  sha256: 474553d01aea57214a54a7443f227da84a58e29c49eb7605ba0043c55b7d167a
+  md5: f01333e9f0a908e435db650f42fbd2db
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1096668
+  timestamp: 1698946168635
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
+  sha256: 8c8aa1eb7e215984f46c8e1c7cfa6e5e6b233993d92b835a9b1b5491a4b970ab
+  md5: 6e145b179adde03f8aa8a066c58d4e31
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.12,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 380702
+  timestamp: 1706563445897
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
+  sha256: b06b45da61807f76b6d800047f123fee2cc95eb84da508550e0908951c8d9f6f
+  md5: 9b100efb9ba2fc7f9bcfaa8fd2ab6f9f
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libgfortran-ng
+  - libgfortran5 >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 4
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 27615256
+  timestamp: 1714076660659
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+  sha256: 51bcea0e575a626f6ffbd16d1153330fda93dbe3dd31dcd3a8f469ff61dd1e4e
+  md5: 41d531c90be8c82bf79635ff3d409476
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 32295
+  timestamp: 1699371262818
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+  sha256: 0a95988ea269c96354626dcab255b65b54bb5c503d24cdeb6ef2e1c42818bd59
+  md5: 8bfb9f42492b3b53b8151d77e51c75d8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1594974
+  timestamp: 1715024182643
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-6.7.12-py311h6a678d5_0.tar.bz2
+  sha256: c1585436f502f87ee7bf6d40b7d911d1b5093dfee339db251d887bf355a23a94
+  md5: ff29bdee631a122ae9a68ff44066b02a
+  depends:
+  - libgcc-ng >=11.2.0
+  - packaging
+  - ply
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  license: LicenseRef-SIP_License OR GPL-2.0-or-later OR GPL-3.0-or-later
+  license_family: GPL
+  size: 683464
+  timestamp: 1698675983077
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.1.10-h6a678d5_1.tar.bz2
+  sha256: 15045902c5957ae0c8196ad7f1cecdadc7e6f5545f24f143339f488f063775f0
+  md5: 0b92bda0f6031b4f8fe9b4f1c0e55c06
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 48768
+  timestamp: 1702909413687
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+  sha256: 1a84b00944bc5588e14a097460175f97df49acb4f1ff2498ffd9a1893068ed81
+  md5: a456513471b2ecbed60430c21dd1ccc7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17880
+  timestamp: 1705431390054
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+  sha256: adcafd297d60af64107c113bb7b8b92160d0268a44ef9a3b79e56a88a0358ea7
+  md5: 28ed704ed26b06d32662e3a6a87e59b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 88799
+  timestamp: 1696347581401
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+  sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
+  md5: f86119b3243fe3508160aa0406245738
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1723866
+  timestamp: 1714488309729
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+  sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
+  md5: 041a3caf09dc9ce8fc6c10925c4fe050
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1888016
+  timestamp: 1680167274961
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+  sha256: 856a8ab8c350c50247b79966c6cb80fb6d4de36eef49ddf75aebbbcaf854c82d
+  md5: 442dde204d14d171aab9ee40e8de4de8
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37456
+  timestamp: 1677696176157
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+  sha256: f0a026ddc0ed041bfc60c8a1ca0b70b7a69232775b3181bfb35a39fda42d6994
+  md5: 2902d5a5854865baaaf58dc59cf06b3c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49185
+  timestamp: 1676823769869
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+  sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
+  md5: e2512d57c8a1e91e7b20e265c6906546
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3588922
+  timestamp: 1714770676475
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+  sha256: e58ff4a82819446f3c92e5b1aa2a784c4b06643e751fe67cf115858296dbfa50
+  md5: 32ee4723173f1fad5563b8afb5f1c8f1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135634
+  timestamp: 1676827536101
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+  sha256: 1bf522ade750cf0b70d61e71916ff00569e2908db1e9dedb223fda2608ed8bde
+  md5: 6793c74fe94211c0bfe6766c6dd490af
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 893808
+  timestamp: 1696937055591
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.2-py311h92b7b1e_0.tar.bz2
+  sha256: ef0c8cbb22af258e228d54e7cbb4a152c81cc64b28d009166488a2ccdb30225f
+  md5: 5e033e80b81b1830252a4c65ddf0959b
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 154337
+  timestamp: 1714567842489
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+  sha256: 0575785f6553e61cc6138abfd5de52305fac6f85971642fa1f056a76c66a52b2
+  md5: f2c25e5dfdd23f70b83776a8832893cf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270865
+  timestamp: 1676823316868
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.9.0-py311h06a4308_1.tar.bz2
+  sha256: e0dbca6707368472ef0adfe498c024de7c9a56d9c6ff25ffe1449e8e95da89aa
+  md5: 570cf697aaefcaee710444daef8a11d1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.9.0 py311h06a4308_1
+  license: PSF-2.0
+  license_family: PSF
+  size: 8792
+  timestamp: 1705599472930
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.9.0-py311h06a4308_1.tar.bz2
+  sha256: da18ffdb0ef53142aeb5d964b8db1542c290eb328ae9fbdf96690750272bd8bc
+  md5: c6d716b2a8ae08f6e4039ea74d13b79f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 70729
+  timestamp: 1705599465726
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+  sha256: 509b962773f0fe44a93a7f6196b254670a030eac8ea7f90727312e3ccd9294b2
+  md5: 6c402d5bf4e01c8c3895c9ef41707b6e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11371
+  timestamp: 1676828901104
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+  sha256: bbe7629e8ce52c82f13ed0d1fb919f3659ef466b274a7c74aa925a9bc7aee450
+  md5: 7da527bbcf71270c1abed8ea52e7d44c
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 509031
+  timestamp: 1713213062098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.1.0-py311h06a4308_1.tar.bz2
+  sha256: a0b300e422e89ca84cd1ece98b796af3133c56279871fbf0198871c9edd3585e
+  md5: 5cdea1fde6548c3a82add475b39e60c2
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - zstandard >=0.18.0
+  - selenium >=4.4.3
+  - requests >=2.26.0
+  license: MIT
+  license_family: MIT
+  size: 183475
+  timestamp: 1707770592436
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+  sha256: a8d11b0f08217607b99ba560edf66423ca1e36f4ffbb6e2377e61670e2b5f36b
+  md5: 431e82b081b08aef0259df0437e04c75
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 97535
+  timestamp: 1706894675990
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+  sha256: c3a5e0b855dc2de6c162708dfcf170a23eb9e7525d4252d8dce553369af4a330
+  md5: a4c77e204b7787f820955166a1283168
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25890
+  timestamp: 1676823132898
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py311h06a4308_4.tar.bz2
+  sha256: 7b505fdb5d801adfb3032e2541bf9bf17ed2238764b7a53cb845e33e7f835faf
+  md5: 07dc61e2e59fe57a9bfe8efcbb23ffe6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 90518
+  timestamp: 1676824901641
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+  sha256: eec0d2e0bce4b62278cacd7b0bee053160845e86507051a5434d2069bd290f36
+  md5: a069e5aef64a6dac076cc9a3d28a17c9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 136022
+  timestamp: 1714717059748
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+  sha256: 85248e503721da67797546cb8a22e303c1739100834b219c5621f216e3794e8d
+  md5: 2570956643f22d0f809b2467e02d3984
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2465865
+  timestamp: 1689041600364
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+  sha256: d18cdca154bf668826f869117ea996c4f9e8ef7d27b7c528332a7d17e5a8602c
+  md5: 9f7353d72046b16dd6ef6b5689ac9bfd
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54731
+  timestamp: 1676828934954
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+  sha256: 9122d6e9dabb7a47f2bcb15d86b97c96c49a9048da3f8ae59675351710c14cc5
+  md5: 660b2aead2ec87b751c86cd33934f44e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 716926
+  timestamp: 1714510796277
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+  sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
+  md5: 943f1247a22b6b64171363bcee1eec27
+  depends:
+  - libgcc-ng >=11.2.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=11.2.0
+  license: MPL-2.0
+  license_family: Other
+  size: 371663
+  timestamp: 1705602144682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py311h06a4308_0.tar.bz2
+  sha256: f33ed759a551e2cd64115a3b01af0fc9822b1a5a1a5c798aa0ee14292792d7c1
+  md5: 7feb38e587b3352efca77df1447858d2
+  depends:
+  - heapdict
+  - python >=3.11,<3.12.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102106
+  timestamp: 1695832995689
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
+  sha256: 7aa781d0850f97622755ed44772d2b215b253a8e211aede5f3f53e1b95b4143a
+  md5: b1d8823f50228d4efb7b7a6e267ed776
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 24333
+  timestamp: 1704207043644
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+  sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
+  md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Zlib
+  license_family: Other
+  size: 127143
+  timestamp: 1714510716441
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+  sha256: af3c032f06352e87c450739cb8aafe1ff34ad28bf074b214ea98b3d29259a85d
+  md5: 51fa34bd0e016ed7c5371cf6cb13ef6c
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1044463
+  timestamp: 1714678445052
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
+  md5: 544adf2677c47c9b9c891aea720678f1
+  depends:
+  - python >=3.5
+  license: MIT
+  size: 33999
+  timestamp: 1630003259346
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 9de8666e5b70aa2437737128eaa14ffe80a7b5235c2a6b7d3f39ccefd7816ba0
+  md5: bb52e50c5ab1a5c7778c11376404dfdb
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 7933
+  timestamp: 1630598543551
+- conda: https://repo.anaconda.com/pkgs/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
+  sha256: 6db7265c2238c6e5b4c98906498c47af341238b5d5a9baee383777181f421366
+  md5: 91e3336204a0ea3951957d7d5e8f3e26
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 21503
+  timestamp: 1624432813739
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+  sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
+  md5: 33624a42ee387bf9918ea98b4e7b31fc
+  depends:
+  - pygments >=2.4.1,<3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8173
+  timestamp: 1601490751973
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+  sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
+  md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
+  depends:
+  - prompt-toolkit >=3.0.43,<3.0.44.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5106
+  timestamp: 1704404390460
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+  sha256: 459f38609d854888998a8d76028019dbacdce2bfe401eab57b8eb8ff16da9c7f
+  md5: 2948a98ef4de5decb7e5eb888eae68ba
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13056
+  timestamp: 1682965564630
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
+  sha256: 305e5fd9993f3e5506f386f98794c7d53b6e6c68d4d411ada724de49a17945fa
+  md5: e1fbbd2d11d21aaec3c32f7d332c0e77
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13818
+  timestamp: 1712163766707
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
+  md5: 2eb923cc014094f4acf7f849d67d73f8
+  depends:
+  - python
+  - six >=1.5
+  license: BSD-3-Clause and Apache
+  license_family: BSD
+  size: 246457
+  timestamp: 1626374695070
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 4e47f6c49ce84509f1466e8a4d728447bf4bcd9bce7b456431a789a262547067
+  md5: 4cad993b0f80bc23fb66a97592299cbb
+  depends:
+  - python >=2.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 26504
+  timestamp: 1623949147884
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+  sha256: ca2be6c7810a37cfc6db1f5383937b5d35c6d73c1fad8a9104de85f069b1df1c
+  md5: 9ccb2fb33edb152403d6ef32bf758a9d
+  depends:
+  - python
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 15614
+  timestamp: 1629402049497
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+  sha256: dc9f709bacbaf08a0941d2622d82f91f18b355e82c55348ec29f1391215ca7e0
+  md5: ece0f5837a4de2d4d5f1abf8347cd10a
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 124922
+  timestamp: 1708711884650
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/abseil-cpp-20230802.0-h61975a4_2.tar.bz2
+  sha256: dc40cfc393c2acdb97ce54289d3124bdff35ffd4a6c203abb6f3f5598f49c115
+  md5: 64a761d3c1af045bf01d84d3fc4302a2
+  depends:
+  - gtest >=1.14.0,<1.14.1.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 1336618
+  timestamp: 1698327954026
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+  sha256: 5800a2466734dd1ef372bec0dd3f0880c5072fa1e8b0668f5054f834285e991c
+  md5: 18194e51d4420ac08f29f3f86581b52e
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 229003
+  timestamp: 1706220302459
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+  sha256: ab7672364f1fa55ec5d8311d85d40e5b57cbd3517b17670557b6fb822bcf759c
+  md5: 6e0159a5865cb7e96a748bd8560035ee
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 11579
+  timestamp: 1678317458652
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+  sha256: 51556902e09436d46878ef772805d06416ca96ffaa66340b5565c0245574aaf5
+  md5: 4cb1b20635cf5431d34cc96ca1e8a751
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 33355
+  timestamp: 1678317111825
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-14.0.2-h3ade35f_1.tar.bz2
+  sha256: f5480f3e450648a37debe91d0218007a976e4b046fafc8956a7351c2a20f83ec
+  md5: 2079b1125e4344044941008a444ff201
+  depends:
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - aws-sdk-cpp >=1.10.55,<1.10.56.0a0
+  - brotli
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags
+  - glog >=0.5.0,<0.6.0a0
+  - grpc-cpp >=1.48.2,<1.49.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.13,<4.0a0
+  - orc >=1.7.4,<1.7.5.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.9,<2.0a0
+  - utf8proc >=2.6.1,<2.9.0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 10268727
+  timestamp: 1707253751856
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/async-lru-2.0.4-py311hecd8cb5_0.tar.bz2
+  sha256: e6fb3357ab4e25e2e839a28def6450035a291c094ff91d4129fcdbb58f2bbe48
+  md5: d1d0d5703fa8c45784265d8dccf01334
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 21499
+  timestamp: 1699554645746
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: 188b74f717e3ce3595da404c0e027b8ccafa9c186e88325e8f02c29d7b4c0744
+  md5: 04ad90eead5812a0263b42321056ab33
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153694
+  timestamp: 1695717975427
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
+  sha256: a153eee37b30ca5c25c5c95463a8852f1cf62a8f45f73349e68f1e3b22eec6da
+  md5: 4bf760fad0e938618391f0db249d00e1
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 87236
+  timestamp: 1706746160841
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
+  sha256: 04ec5908b1dc2979ed50923af90d02da8a60434658efbc4f35fc61e7e9cafa0b
+  md5: 6ba283b7f902226f232fe8a32fa83ee4
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 37547
+  timestamp: 1706690917050
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
+  sha256: 08431c5ec5f0a9e95819b6a76c9cc870d2154e46b229431fd0b3dad25bb70b04
+  md5: 78b4b4225fdefef0b9b0d56b6e51e4a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 184146
+  timestamp: 1706189913777
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
+  sha256: 6a78705375d837a0eeeff9e914aae53a0d2cd44e9760075bdd8711a05f94ff3f
+  md5: 931b0654ae05bcd1acc760dc830b89d3
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 17410
+  timestamp: 1706690854689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
+  sha256: 1d468f7c085b73cc40f813885d77a74270f94dd973b4285546d8873030fcada7
+  md5: 3a61760bb61f85b3a0ffe7b14058801f
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 46197
+  timestamp: 1706697276616
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
+  sha256: b53432aadb2ffe2f1c584c6994b665f3620f29c51b200b03282065a480cf021e
+  md5: 9686f32b210a009048c0877ac39fe88c
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-compression >=0.2.16,<0.2.17.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 164397
+  timestamp: 1706744140750
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
+  sha256: 2ff9632eb2e2c7a70b8d64988e530d842fe5fa7fa529d34cda19f76fb40582e2
+  md5: ffbd1ff65fe9fb52d833af5d396b006d
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 125589
+  timestamp: 1706696187075
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
+  sha256: fa57f1d2b2eb56db72e4b54348452af67a1222bd4266b3d68c7b7ff00399743b
+  md5: ae9e78f6b1fef841fc0ffc7ef7c78d26
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 61379
+  timestamp: 1706746740037
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
+  sha256: 00834bd876756f1f13333c31623c2bdfa7d901b40aec161cf0343548fcd96187
+  md5: 4ef080b5a91e260d51d563218396d0f6
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 67408
+  timestamp: 1706747579372
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
+  sha256: fb3198a05c96030d8498a5c4873e56ae28a5b04fb904a5c696a2192e9ee6c45b
+  md5: 48efeda1471a50b9481c3943a0300e86
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 48055
+  timestamp: 1706690833951
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
+  sha256: f05fb72b1a5f25fab65ef416ff0d1966e3ff84f8a08c56bf809fb602028c66ec
+  md5: 86cda3f774047ff6b40eb14aab83215d
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51354
+  timestamp: 1706192066535
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
+  sha256: b8cb5f96e9eab47419622795fcdb42ad414481db9b84bbb50fcf8251a1314b59
+  md5: 335265dfe12cb6adcacf39b411cf9d7a
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
+  - aws-c-s3 >=0.1.51,<0.1.52.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 210312
+  timestamp: 1706827788950
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.10.55-h61975a4_0.tar.bz2
+  sha256: 40911c99dfa11ad32d451ab8cb5b24f0aecde231b5f8f4e9d8887bc4a720dc65
+  md5: 1078cfa7cb12f9a0d3fb4017cc9789b9
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 2322692
+  timestamp: 1706890560060
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/babel-2.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: aed8823dbb096851f6eddc345f02c23fba42decce2c584f0fe09440002c37996
+  md5: fc567742fccd3b08593b1dcca16522f7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pytz >=2015.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7215195
+  timestamp: 1678318116416
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+  sha256: bf3c60386619f08cf5105b4b903bbc109b3252c3b923fe055aa445908a01969c
+  md5: 3f84a301921ec6400b7f1f1c4ba3260d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 270017
+  timestamp: 1681493109562
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
+  sha256: 126ae8e30b8464fb2dc94ce9163dcb2d5482f7214c7d8a48340c3f09f1409d5e
+  md5: d5e0c054042910b4394a14c7eb4d8131
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6080356
+  timestamp: 1712084675745
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+  sha256: 81102f2762d8eb2f07c69fbf7ca7dad879a257a053085492d4c1b4006eb35fb8
+  md5: 3c42777bc9330fe91177ea813b9ec252
+  depends:
+  - libboost 1.82.0 hf53b9f2_2
+  - libcxx >=14.0.6
+  license: BSL-1.0
+  license_family: OTHER
+  size: 11744
+  timestamp: 1696762233693
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+  sha256: 9acafafcaebd653c2372ddc864525722e1c55b884b5eba22e28e2b2d946b853c
+  md5: 22375cc3c2edada31b85af56c8e6dee6
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 155829
+  timestamp: 1707864406086
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: d8b1ccb15297dcfb3f9ebb8139c3e28a13d6c2e73c37612cb214ab6cc58b15fa
+  md5: e5dec9f13de061640ad2697562a99b54
+  depends:
+  - brotli-bin 1.0.9 h6c40b1e_8
+  - libbrotlidec 1.0.9 h6c40b1e_8
+  - libbrotlienc 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 19732
+  timestamp: 1714483415038
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: e9fda4393edd0234c88efc2b88e0edf42c94eb49ea5b189a80afd733058be8fb
+  md5: 13ceed558eb174d6b77ed1b0035f1785
+  depends:
+  - libbrotlidec 1.0.9 h6c40b1e_8
+  - libbrotlienc 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 18400
+  timestamp: 1714483395748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+  sha256: a323af3251e426962ad16edf8f46a696ef502731faf12aee32ca289c40b11342
+  md5: 658ce49e9f07dba7a1afe70fa2666e0a
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 393858
+  timestamp: 1714483549536
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+  sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
+  md5: c5a600d81b1b48578863af2973c743ac
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 187637
+  timestamp: 1714510590009
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+  sha256: f913b61ba3c1651b36688415cc163a5d575475f7573b543f48a80e7a5002e4bb
+  md5: f11d165eaa532ce04a35382841284298
+  license: MIT
+  license_family: MIT
+  size: 107047
+  timestamp: 1693902034820
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+  sha256: 0c5f9766aa2dcc08ae71b6c0102046a56b30297d0bedc3039b7f72d1658baa43
+  md5: 34583b436e62a2ce55d6a7e8eb818e33
+  license: MPL-2.0
+  license_family: Other
+  size: 138712
+  timestamp: 1710764814844
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+  sha256: 20b1fc398e925e6c8cea6a06d3bb614e2c0de886e3f14f85b0ba26e57ff40b7e
+  md5: ac95cfe373c7fef7820e93189041b0cc
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 166856
+  timestamp: 1707229213510
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+  sha256: 6b5bebc13755b0a5ef423219eeecd1c25b97dbe83afad6e2552635387547d9f7
+  md5: b7bc4192fcfed7fc7df1ce00bce97b02
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 291802
+  timestamp: 1714483319125
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+  sha256: aceaa74365b0d8e69c817639393df3a713a802f40645ac0bd2f39adc871acf54
+  md5: 52191c9d4f4fcaeea39574819ab2f14f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204365
+  timestamp: 1698129979494
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: 53099bea1cdfeac00bf4bf48e7c3321424af31b9726a7f67033ed06e5d924f04
+  md5: 0302e97edbd24e02df7609a6072dc569
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50495
+  timestamp: 1683040190091
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: 389c63a84b92a6254c9d361ebe970d537d0b88733efd5ac5c3ee58196fd2c5a9
+  md5: c7bc5b3cbe76be83a27f00b7e4740727
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17974
+  timestamp: 1709323004148
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+  sha256: bebfc5aa6be12e61a134b580b07b67f7d8c045d6b113fca5b21fa1e83a2f03ce
+  md5: 239df72a3921c951059fa8afc09643f6
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 287736
+  timestamp: 1700583644534
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cramjam-2.7.0-py311h9c86198_0.tar.bz2
+  sha256: f480b0ed7a98e682d8cbdaeef697116a0d839cee08ec8b5f39078c4e056ec29b
+  md5: 7712882f644fca2ccd169ce2dee2b4d9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1473015
+  timestamp: 1702651642047
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.2-py311h6c40b1e_0.tar.bz2
+  sha256: fd7bceb92f6c43c6b064a1258a33c441b3b39cd08883cb73204f8d0692b709fc
+  md5: 37f8b661d31327b8dff70a4cfa63cd5b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 390733
+  timestamp: 1701729666753
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-2023.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: 663a4919f8c466b40f14ed170f378810a7202d8e689b2255d5de6454e1615b76
+  md5: 539835b03a005340a14df14b7963e099
+  depends:
+  - bokeh >=2.4.2
+  - cytoolz >=0.12.0
+  - dask-core 2023.11.0.*
+  - distributed 2023.11.0.*
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.21,<2.0a0
+  - pandas >=1.3
+  - pyarrow >=7.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6016
+  timestamp: 1701444967158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: 45a9f823c8e031b1bc78639206ff4e235ce7de67da9b991724316d00075393b0
+  md5: 9d10bc7c171e384a536f9f121d964fe7
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3027866
+  timestamp: 1701396257640
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+  sha256: e0e30590a78d99d51445ac4f668aefe1bf20025a35bdbac00f04647b95c9f152
+  md5: bd0db635eefeea82a0c567b39c9a0e3d
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2485698
+  timestamp: 1690905283575
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2023.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: e1572994d0a7c6da827b31734426cf87b3462d2707e316afc04d78aee28bfe8d
+  md5: e2935cb332d1a784b85339113f4c8273
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - dask-core 2023.11.0.*
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.0
+  - packaging >=20.0
+  - psutil >=5.7.2
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.10.0
+  - tornado >=6.0.4
+  - urllib3 >=1.24.3
+  - zict >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1788385
+  timestamp: 1701398185617
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-2023.8.0-py311hb3a5e46_0.tar.bz2
+  sha256: 4a4dc4955ebb563653b6e8fe8ccd17f7ef0ce17c29d09cc09d4e62a43241bb8e
+  md5: 765d7542be413e1b31e9a6d5b9ca9829
+  depends:
+  - cramjam >=2.3.0
+  - fsspec
+  - numpy >=1.23.5,<2.0a0
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 570485
+  timestamp: 1696541803957
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+  sha256: 54645c22fabc25b632114d1d3c403a6fad9149b51ab36719b2690a084f14a072
+  md5: a8ad2f4abfb2e17ecf6e596342528156
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lz4 >=1.7.4.2
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  license: MIT
+  license_family: MIT
+  size: 3180691
+  timestamp: 1713551771692
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.3.1-py311hecd8cb5_0.tar.bz2
+  sha256: 296e72c622f7014041055d8c7b602385ad10893aa1c0b600248c95e7d116dfa9
+  md5: 93d5cc02fe01e3b396f02df0ca682a79
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365534
+  timestamp: 1714461741656
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+  sha256: 3c7aa54548409f9343e891820ea43c195b5e4e4dce6b761bc3ae9f6c8be0fc86
+  md5: ed9629d6dc1612ec425eb8d27478b0f6
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 140316
+  timestamp: 1706888243476
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+  sha256: aed47f9ca4dd140b9c8a183e53d4b89eba84a20041d2038983cdfea8096104ef
+  md5: c0d981d7d43eaad55950ff5e57206e70
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 97828
+  timestamp: 1706895273858
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/grpc-cpp-1.48.2-hbe2b35a_4.tar.bz2
+  sha256: 5d69cd8a1582c5062ed6753ee9ba403cee89d89f6e1628bcaba823a33a92a186
+  md5: c37d24f6749355412dabe28bd64ce229
+  depends:
+  - abseil-cpp >=20230802.0,<20230802.1.0a0
+  - c-ares >=1.19.1,<2.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.20.4.0a0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - openssl 3.*
+  - openssl >=3.0.12,<4.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3994389
+  timestamp: 1701983483827
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/gtest-1.14.0-ha357a0b_0.tar.bz2
+  sha256: edfb65219af41d5037b6371c6b074c8372db90b17d25f85f55e36523c01949ec
+  md5: f21a88869091d6d4d88b9b5f064a3157
+  depends:
+  - libcxx >=14.0.6
+  constrains:
+  - gmock 1.14.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 400287
+  timestamp: 1692633607623
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+  sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
+  md5: f3ce6fe6eb760c236e5f7d04df5faa81
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28138484
+  timestamp: 1692293212596
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+  sha256: 5c2458964157fe493ca18c513c693b70cb622087e5fa0c93e65fc45217edd811
+  md5: 15629e52625221b51a443cefd9501d12
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148522
+  timestamp: 1714398885844
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+  sha256: 5a17849341e4d43fc6aff44486425852c16dee6e1cbcab1ed3f2167350f55359
+  md5: 445ac9df262ad2dcd86246a9ba5654b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 51118
+  timestamp: 1704813615186
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+  sha256: e0127f50d444bf4474e8df07d602c7f6dd38690e8bb3fb28817c164940ffcde1
+  md5: 583fcd7060cad6a77074d00d9ef62f44
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 731417
+  timestamp: 1699647668990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+  sha256: eb58fa29b1ce9aa5fc774d4c466696457695dec3b206456614b4c9cac0a94e42
+  md5: 3d3291ff58dff83dcd40ec54b435f4d2
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229910
+  timestamp: 1705934029588
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+  sha256: 73aa7662c00c73bab2dafefefc87a1b524961d2687410af624ecbd6703e483f3
+  md5: 7e71e99766107a553752ed8f22b61cf0
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1611976
+  timestamp: 1704833049616
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+  sha256: e08cda2bcbdec124c63e951eb248c503bb1467c2a6000010c6bdc0726e0e00b7
+  md5: 22c24f43b82da8b3920a913bbf452421
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1168968
+  timestamp: 1679336359851
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
+  sha256: 3b262312f1fc76e490c067408771da0a12c7691379cddc3c86121255cda7a41d
+  md5: cbf00a1bc151243cb6a33524b62f3663
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353280
+  timestamp: 1706733664000
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
+  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
+  license: IJG
+  license_family: Other
+  size: 278924
+  timestamp: 1677849185191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+  sha256: 99fc6ac82c56eb2a580f96db24a5b887f8abc8c24af445d3313d5ebb48598478
+  md5: 71892160908a6daedb5fb7c404079ae4
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 182073
+  timestamp: 1699041732321
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 0ea44d0c8044e70ab0eaf4d6f5f3e4753838dee106b5cbd36561e21a65cbac77
+  md5: 1d045016dca889d702f1caf3a16162fc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16528
+  timestamp: 1699032525791
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter-lsp-2.2.0-py311hecd8cb5_0.tar.bz2
+  sha256: 9f7e13e4b84794cc99f78e0513157be30b9c9b039c413a90c03583304b7edeba
+  md5: a76eeb3f746de2b0282bbf9872ac1e8d
+  depends:
+  - jupyter_server >=1.1.2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101678
+  timestamp: 1699978325870
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-8.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 7e100bfb19e640dd312cdb921155f67c52675cf128d1aef2f3e975d30f3171a8
+  md5: 08bbf3e56f89bc800fda1eeb998a0d1d
+  depends:
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 222285
+  timestamp: 1699456395712
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+  sha256: 8601c674f4779900f6a949e47b814be68b722b0b3d394433bec9d197924ebd69
+  md5: b8423f8caff3041a251fc3681f43496a
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94990
+  timestamp: 1698937583196
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: 6a430c812ce0415a04d9cfe6c66d9012eced2d91c04960c88bc8ec1e9f1b5d6d
+  md5: 30b3d5d6a8cf5d1604e5f5fb177917b5
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42513
+  timestamp: 1699282637015
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: c2d206db117f7161e77236ebd6b0051fc73e1731c242d1e08597d736a0376c92
+  md5: bdb61de2e20e02c93423d9de091c74ad
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 601837
+  timestamp: 1699466514455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+  sha256: fd7964657f0a8fe8b167ba860b1f960e8b7b45309eb6c7c850d50ec283fe03b5
+  md5: 2967bb345bc75f53182e263ff4743ca6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28223
+  timestamp: 1686870845224
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab-4.0.11-py311hecd8cb5_0.tar.bz2
+  sha256: ad199926171ef67c2e96e7c603c7dc6c96e25a23deb9979f1c910616df8e8b48
+  md5: d749db644752070354a015015fd1a102
+  depends:
+  - async-lru >=1.0.0
+  - ipykernel
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.19.0,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  - traitlets
+  constrains:
+  - nodejs >=18.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6618991
+  timestamp: 1706803097395
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_server-2.25.1-py311hecd8cb5_0.tar.bz2
+  sha256: 557bd1a8ff0502191adb3ff3af74b54ee2ec4800d281492bd8e588ddcf095bfb
+  md5: 14c8a1959a83eff470adc09cc65bdb57
+  depends:
+  - babel >=2.10
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18.0
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.11,<3.12.0a0
+  - requests >=2.31
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 107281
+  timestamp: 1699555527525
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+  sha256: a12382b50416803f559a03fb384ba492c1dafa351e1191a3f8dc361bee6c4f37
+  md5: f2ae846b663bbb642f4b1e90eaad38a3
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64817
+  timestamp: 1678322501509
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
+  sha256: a3a24cd84c291f7c9e28842ccfc2107d149f0aa8e676b85d9104eda77622e603
+  md5: 99ba4367783596d1bb0c7766ea6706ea
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - openssl >=3.0.8,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1290758
+  timestamp: 1686931137388
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+  sha256: 127dbf93874f1bb3493b312fecb5ffedb8f2a41d2470e2cbeb889eb58d89ebf7
+  md5: 07502b61e43a2039e4312b40d53c1db1
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 22584954
+  timestamp: 1696762195023
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 685c3bc9068bd485604b80bf03789e4dca95c410d33871bc1b882e47649fabed
+  md5: 6cf8e55271e150ca0961d0ddedaa61bb
+  license: MIT
+  size: 66237
+  timestamp: 1714483284541
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 69826cee54db9955f0120af21ec36d13f9211877fd67364f2068d0a54c6c97cd
+  md5: 0851917257f490d35e1f73da8a1c723c
+  depends:
+  - libbrotlicommon 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 34042
+  timestamp: 1714483343147
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 3f5a1f03b50b90b397a0ee432ad0cba13354abdaf7e5652c0fc60164b26a08b6
+  md5: a50bdc871ef4bf14deb088d888b92b5e
+  depends:
+  - libbrotlicommon 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 311597
+  timestamp: 1714483371586
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.5.0-hf20ceda_0.tar.bz2
+  sha256: b34c59c148f100cfabc8a55470cc0d46f4ba2d1f90dedf516b151ca1374d2e54
+  md5: 14f3b4d1790efbf8e35a9a9259cb6e8a
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.57.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=3.0.12,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: curl
+  license_family: MIT
+  size: 373198
+  timestamp: 1704383716512
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+  sha256: e84e6cbacb12de6fe86955449502d3956696ae583060d0d4911ea6f503cfb9ad
+  md5: 1d200c536be4172db41c49e81a3e6350
+  depends:
+  - ncurses >=6.4,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 169586
+  timestamp: 1703006265367
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+  sha256: 4786264321edbff780633a5b752995eb3193ca4bce11b0fda179577f6cf1102c
+  md5: 849fdd014c201a9d2c2aa7c7db38a778
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 103993
+  timestamp: 1632891571494
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+  sha256: a60941a0365ee3e8b9ff721f75b0608c234b5652f53337a918b787839de4bb53
+  md5: 4d61f019594ebccfb3f4fb87ee778416
+  depends:
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 414942
+  timestamp: 1685052318462
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+  sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
+  md5: 822a5b76117e56d3912f1f2153307528
+  license: MIT
+  license_family: MIT
+  size: 136045
+  timestamp: 1714483561919
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+  sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
+  md5: e458587c87e3f2d20192f4e0738f2c63
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 149419
+  timestamp: 1665498987619
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+  sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
+  md5: 1058b661ec829b2ee3716ee2a5520641
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1917987
+  timestamp: 1665498925405
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
+  sha256: 9ff6ed0f0b9f9f27f449e95d11aa1c4e9e80028fd9d2a8caca5a15d8df88f435
+  md5: 7b4b557afc66aba367da14d97d71934c
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1409885
+  timestamp: 1714483704680
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+  sha256: 8176dd9a68815301a24ed51e72f3506f5f77c67a112efa0dd14971f2f3b3c8c1
+  md5: b5e470c224000a6bda6f655c155b53e7
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 27861431
+  timestamp: 1683292881730
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+  sha256: 7bfcf69c31a4eb15dfab661c93463ce8dfb7b3de4356945fa5c1ca50a5ae0cb0
+  md5: 4934bb34818fa3d99b32b9cb59fed205
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - c-ares >=1.7.5
+  - libcxx >=14.0.6
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 784918
+  timestamp: 1697018436251
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
+  sha256: 1884de5207f5a1210217d7132348b4944ec4b09a91085b7b47a19dfdd9b6dbba
+  md5: aa960ea0133deec4637a8d05700cc3c4
+  depends:
+  - libcxx >=14.0.6
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2412437
+  timestamp: 1675278748544
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-h04015c4_3.tar.bz2
+  sha256: 79a36c00535053704706f6520b6a69a3fc3faa5e28e7c0a1b640c29d44899761
+  md5: a44846f7c4357de50a7d43e0bd15d5a2
+  depends:
+  - openssl >=3.0.13,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 291287
+  timestamp: 1714510620580
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+  sha256: 21ba71cdc65b56c6daefeeab55959e5a7edadfd697cfa8b2ed5c1b3e2a98586b
+  md5: cbbd369ee87aba597c942727bada4eee
+  depends:
+  - boost-cpp >=1.73
+  - libcxx >=14.0.6
+  - libevent >=2.1.12,<2.1.13.0a0
+  - openssl >=3.0.9,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 364326
+  timestamp: 1687975317748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: d28c465ec6d5f8d4962c597b249b58998300c8b4e3c937c578c3d15294ea863d
+  md5: dcaed6ddd0723c7cce6bfad917be98b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41176
+  timestamp: 1678413498410
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+  sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
+  md5: 5c740b4a18a558de0ccfe601703c423c
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 338738
+  timestamp: 1662635677689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
+  sha256: 53808184421c81e661f9927ff564a0d0ecdf3b816c8aba8e2368434e055529d4
+  md5: bee10bfbe90767fcb8f8f6ab3a05d85a
+  depends:
+  - libcxx >=14.0.6
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 407784
+  timestamp: 1706911015242
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: 716a654df2e55052193150015bd5c9856b847893fc5a229fa8669725b1c56ff2
+  md5: 687ba6c11de38ad7cc597f7188b491e7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13357
+  timestamp: 1678322560230
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-4.3.2-py311h6c40b1e_0.tar.bz2
+  sha256: e05d6b661c088efc3f7f2fc99b8faad351f7660963ca66fbe63dfc9796821eb2
+  md5: d48a23f7e388334d5e39fc36ee84441b
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37947
+  timestamp: 1686058038545
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+  sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
+  md5: 8f57dc3a3327bb6f7e1cba908856ac7f
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 183138
+  timestamp: 1714510756758
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+  sha256: 6fb2953e169ee1ae38f24d29752051501992f19b96b5ebcea9af75737bdbcb42
+  md5: 7f410cdae838c5030108d1b98a8c78f6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162478
+  timestamp: 1678377892595
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+  sha256: cd97e09a12ffb49b2a30a782fa8c7933b28f5ffdbfc5c73a9ebaa95fc9447370
+  md5: d1fb6ebc1e5728aa6377cfc71da08942
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135859
+  timestamp: 1684280005320
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+  sha256: 30c3b189462a9d0f4794d229adadf34b5f5a5f56f95c30d5afc17ef524579290
+  md5: d4e9421243129d1d57c472dab045f3dc
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26639
+  timestamp: 1704206159955
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.8.4-py311hecd8cb5_0.tar.bz2
+  sha256: 1324e1dd44723b6ba80c4cc7128b85471542cb8d60b1c7757511e56e8e2171e1
+  md5: b33ffac0fcab742473262ddb0c5ad74b
+  depends:
+  - matplotlib-base >=3.8.4,<3.8.5.0a0
+  - python >=3.11,<3.12.0a0
+  - tornado >=5
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8970
+  timestamp: 1713336829689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+  sha256: 080000a28b3ceca54eec6de0748c690ea5a4c390e358283eac03fe7a6dd87065
+  md5: 51344eca57d7940fb01eb5e8914509e3
+  depends:
+  - __osx >=10.12
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9099909
+  timestamp: 1713336790553
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+  sha256: 07e7fd5bd64e55328b4b99d92e2e2600d791f1095bf905daab4cfc59f0f0a45b
+  md5: cf53321779f4ca7e986c1468719b93f1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19500
+  timestamp: 1678317565001
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0770e02be1ea1216af493cfc03d5b8a702e14606fa93b0692bcdab1fed1b898c
+  md5: ca6f06ceaf66a32bbf5dfdb6e373a5cf
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67892
+  timestamp: 1678417734353
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: fbe95ed0501bb0f137048476fe41bc718dd659e8ecb066bc67ac17d6a50f4318
+  md5: ec162bde8d1c8a107b257df218b17035
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23030
+  timestamp: 1678381838497
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+  sha256: c20dd678655e582129a858a1c5162bdc254082d3a3c035b0f72629d9276e5b75
+  md5: 800a0738c728796e02d0386ce7d457aa
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104585
+  timestamp: 1678317269407
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+  sha256: c825bc3070f73318ffff88a7a0b7fc6d1858b058ced735efd1789053f1583918
+  md5: dea5f96459c9a6df6b026ca57d387936
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224299920
+  timestamp: 1699647835748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+  sha256: a76c134ec258612ff7d55cb2a19b9e3461cbbd375a744bd29390af9cfcd283b2
+  md5: 1c736f58992009f53f014aef163bae31
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48442
+  timestamp: 1682969160267
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+  sha256: bcfb0d1e075d043bcf05fa1a7ce3c142bf222d29693366af49a5a346c770812f
+  md5: 59e4820b34049cbc6619a8ac97290abc
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 222137
+  timestamp: 1695058350477
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+  sha256: 114e408c40b332393cf2792393e4d1ede3465abcb3d345fe647ee519565346c8
+  md5: 86b13271578e1fa5e664edcf6fcb3ce4
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296860
+  timestamp: 1695059990370
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py311ha357a0b_0.tar.bz2
+  sha256: 7517bb3a1337287e71ba182e23654f49275048389a1a3c6d750dc580caf4aaed
+  md5: 5466d265b312c4ff0ff4969ebf15c0ce
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 37529
+  timestamp: 1678318290205
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 638450a7ccb5f438ac65aa1c8d871fb5bb664e7261ec7e663d0302485c219a67
+  md5: 574875bbeabff85b5d9cfdb62066aece
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29473
+  timestamp: 1678392919304
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: e08cb3ee6df01f4c1e1ac8bc4ed1a06e549ffcc8774fe2e2842c644bb8f74a86
+  md5: 6ba0ae0fb14cbea1e3197707701dc180
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123077
+  timestamp: 1698934356774
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 2f946b5042eaac97206b5217fb203f3604ab3a60aecd99bdfc684925e3136c18
+  md5: b24026076c381ff2009e7acb9e0a6e87
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 534650
+  timestamp: 1699022791300
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+  sha256: ba368605a0af6f1dcbdcb6fddab9ce63224a85dd11bfb2b1acace1dc17899411
+  md5: 91f3ea3fe44d619ee95a6ed3773a0814
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 170926
+  timestamp: 1694616830121
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 42d803e1d8b54748db5d989ecd503826f564132df7cddc20f520460f55e523a1
+  md5: cd3fa71626ebc098da4625fc6be79752
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16952
+  timestamp: 1708532805951
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-7.0.8-py311hecd8cb5_0.tar.bz2
+  sha256: 08457eb26f6e84a25bbf413be70cd91274819e526f90ecdc859ee84af0b3491f
+  md5: a424f09e1db7fc2c399ce807e01c3713
+  depends:
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab >=4.0.2,<4.1
+  - jupyterlab_server >=2.22.1,<3
+  - notebook-shim >=0.2,<0.3
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3655911
+  timestamp: 1708029925977
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+  sha256: ed5608feb37a083d47b04203195260e801b64b5380f292cf18bb61e7ad827a2a
+  md5: daa9c1c233673b727528548454aea664
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27607
+  timestamp: 1699456006797
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.59.1-py311hdb55bb0_0.tar.bz2
+  sha256: 733ece9d325b4baeaea505bd82be98ffe9e5f15669bf079ee4f2f15225bc70cb
+  md5: c426b5fb76b3d219a2fbfa2792684ae2
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.42.0,<0.43.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - cudatoolkit >=10.2
+  - numba-rvsdg 0.0.*
+  - cuda-python >=11.6
+  - scipy >=1.0
+  - tbb >=2021.6,<2022
+  - libopenblas !=0.3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6049873
+  timestamp: 1711992424576
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+  sha256: cacba45c1eebf7d86748737717883a98cf40664231460fa41391c79f98d06f45
+  md5: 3dbfae0d5b90e77f9358564ad442ac9d
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 165572
+  timestamp: 1696515553184
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+  sha256: 1466c3af380b949612c79940124e426eccd59e335c205da0c00383a69358d1c0
+  md5: df6be53592d40ba7e03d6ffe349760bf
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311h53bf9ac_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11330
+  timestamp: 1708639985606
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+  sha256: ace67d704fa7eea1480eb463f2d91bfc161be2ee20263c5a9939805ae3c2a9da
+  md5: ec124589478fa12fba4f35f31c3a0692
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311h728a8a3_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8783230
+  timestamp: 1708639945646
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
+  md5: 93f5d7b66976154adeda219bea02ba45
+  depends:
+  - libcxx >=10.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 484257
+  timestamp: 1630093862501
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_1.tar.bz2
+  sha256: 14ee32164041ac8b077d487596d2a794391340a066ffae780176d8338da23e46
+  md5: 7d1bfacd50d591c536988670811e7bd2
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4982212
+  timestamp: 1714511433472
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-1.7.4-h995b336_1.tar.bz2
+  sha256: 281d5a10e7a0a25bd6ee20d1d0f03530dd90fe5b4e3490ad3f33f0367df36f7c
+  md5: 062f9bba1d43123d02c60d23a29831a1
+  depends:
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.9,<2.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 425422
+  timestamp: 1676482778334
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+  sha256: 8a0809f419065e014cb8e2c8a516cadca6088fb71fd1ef3ae2287d91e3360d59
+  md5: 4dc0b9bc88476fcc5246d823ff1c289a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39645
+  timestamp: 1699371213055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+  sha256: 64fbbb03570788298d8b04d4ea6cb254fef5d5eec73265aeecd72cb565617f4d
+  md5: 4b1195028bc26257df43fdd943638266
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 159450
+  timestamp: 1710811009212
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
+  sha256: 6abb7e0aeda0130f54925421900772e1bc46d1f04ae69ce1376524457686d49f
+  md5: 232a6370c3fab0c41c6d4c7339e778ca
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - xarray >=2022.12.0
+  - xlrd >=2.0.1
+  - pytables >=3.8.0
+  - qtpy >=2.3.0
+  - scipy >=1.10.0
+  - adbc-driver-sqlite >=0.8.0
+  - pyqt >=5.15.9
+  - fastparquet >=2022.12.0
+  - pyxlsb >=1.0.10
+  - gcsfs >=2022.11.0
+  - matplotlib-base >=3.6.3
+  - tabulate >=0.9.0
+  - xlsxwriter >=3.0.5
+  - html5lib >=1.1
+  - python-calamine >=0.1.7
+  - pandas-gbq >=0.19.0
+  - odfpy>=1.4.1
+  - pyreadstat >=1.2.0
+  - dataframe-api-compat >=0.1.7
+  - beautifulsoup4 >=4.11.2
+  - lxml >=4.9.2
+  - sqlalchemy >=2.0.0
+  - jinja2 >=3.1.2
+  - s3fs >=2022.11.0
+  - psycopg2 >=2.9.6
+  - openpyxl >=3.1.0
+  - fsspec >=2022.11.0
+  - adbc-driver-postgresql >=0.8.0
+  - numba >=0.56.4
+  - blosc >=1.21.3
+  - pymysql >=1.0.2
+  - zstandard >=0.19.0
+  - pyarrow >=10.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17296294
+  timestamp: 1709591285369
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+  sha256: 359b31da651ee35b9ca43974d26cd44e64f3cf412096c15dec7b720fa909a9b2
+  md5: 108e24227f8fdfc4d635bb4eedfa6cef
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48504
+  timestamp: 1698702608965
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+  sha256: 90efc71d35ab62d5b8d7b648e016444e1c4c8b83238b6dc9f2c6c3db4b14c599
+  md5: 6b6eeb0a14c5479db1dd39aa8d338150
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 939480
+  timestamp: 1714399174883
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3.1-py311hecd8cb5_0.tar.bz2
+  sha256: 62866ff6b1a021bde2758b97004ed1903fe34744be4ae8f2a0f7cd3113a45d72
+  md5: 1b9b2e51a171bc752955f3592e596184
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3454892
+  timestamp: 1700667869320
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 81719c31101d6c019150cedcc7b08adb3bdb357e8b2952e428dadaabc4dc985d
+  md5: 105825168e0a17fb007f60b5f314e311
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38405
+  timestamp: 1692205731769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+  sha256: c0982f688127129e026d2b4cdacdd5684d00796ea7bdadd7d26b1101b095d723
+  md5: 0d6910c74729fede645c010110f1c89e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 121796
+  timestamp: 1679340253537
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+  sha256: e32843723b10ecd9badde28e1085419c0b59ed8a96c7cacce6395e39e3a874f9
+  md5: 5af0280a817d2c273304cd22328124af
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763044
+  timestamp: 1704404460779
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+  sha256: 117a435c2473e2a20cc81eaacb2b45ea5e7fe3c946eec2915936d344913ede44
+  md5: 0f459ee59fda20e2077fdc2c777edfc8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 497470
+  timestamp: 1679337286052
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-14.0.2-py311h2a249a5_0.tar.bz2
+  sha256: 7ed49e248ab0fbfaea3a170c8f795e7de8ba372bfad16f53e60500b10d5ca648
+  md5: 9917697f50ec91d18d43cd9670ec8130
+  depends:
+  - arrow-cpp >=14.0.2,<14.0.3.0a0
+  - boost-cpp
+  - libcxx >=14.0.6
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 5054065
+  timestamp: 1707331316454
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+  sha256: dfb403f367c57327a4d080109df88383ecff18464de287a1ce936a7274e3656b
+  md5: 997b674bad89963af875b93b06807f51
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2120413
+  timestamp: 1684280057020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+  sha256: 9d2c0f373ac1c5db329581793dd517092cdf9a59140f2516ed8c3a1f483c0bbd
+  md5: ee10503a159e819abdc586666bdf0952
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207552
+  timestamp: 1678322848766
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 717e038567506ca58ce1cd4a3416892d02f4ebfdd332077cc3d110cfe3d36c58
+  md5: 53bbfb400668f798eef6f8c7cf938e1f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35751
+  timestamp: 1678315886516
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.8-hf27a42d_0.tar.bz2
+  sha256: dea2e1371f27376636d240d98eb9d2d1f383df0264b354c2d97c90b60358f9ab
+  md5: ff3603a0ff4f66a66856b3f09e29fec9
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.5,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16812245
+  timestamp: 1708984581993
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+  sha256: 514249897265f66f6ecca0a4427eb02a43c33b3c24974db16d05db6bbe97881d
+  md5: c9ea1437e5a3ba6a52ec2322505203e6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279116
+  timestamp: 1679338758489
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+  sha256: 78b785b9b6ed46c86b0d3a32bdceea49f816672227fb63e726b2d46eadbdba0b
+  md5: 79d783f74359141e0b06a848db33823b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18563
+  timestamp: 1683823935261
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py311hcec6c5f_0.tar.bz2
+  sha256: ceed2007dc80313fab055da9ad855aeff4178bfa03c16e78297fb77d058e6972
+  md5: 753c157b80f60f263e0fe6a2f8d4fc85
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 151925
+  timestamp: 1682522457855
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+  sha256: e358fe679e83ccdc8c433746ae6468e8e96d90d97d99530f8476ef5630b2c121
+  md5: ce30a0a31d891e69dc9b7bf8b7f0c39c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 268876
+  timestamp: 1713974360942
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+  sha256: c3e11ed944da69c11b949bb918341a0d79ef603ee34a632d6a45fbf89ff924a1
+  md5: fee7ff4d291f530b4cecb575f29807a0
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 197996
+  timestamp: 1698096137432
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-25.1.2-py311hcec6c5f_0.tar.bz2
+  sha256: 9996c79c554086df5bb4e39afa822c9f71da32a461c268829a3e849c9b4f105f
+  md5: de5b99be21f6203d7577f11140c13534
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 528098
+  timestamp: 1705605165873
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+  sha256: c69f556df9a27328c56943f3b5918cbb953cfbca987e20394d823a6174781202
+  md5: ab294ae71ecdfaa307a961cc71dd890d
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-3-Clause
+  size: 205638
+  timestamp: 1652449553607
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+  sha256: d784dc26c5de8e41845350a899e5779250b71f45d39e2aece62e739e9add7308
+  md5: 7b077b7f46112bb31dc066396c51d3fa
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74776
+  timestamp: 1699012164201
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
+  sha256: 3357b6b327b3d0a2cc0f02934a60bbd6df38f4ea7bbb3f50cb8e21332c9f5786
+  md5: bf5e48b646e36ef2b788be9665c0e5ae
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 120768
+  timestamp: 1707355762747
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+  sha256: 727fb8d957e02d03b928d049ffbc712316f176a2c331391766d646621b45655a
+  md5: 7e0e416c642f3ee4ddfb084a811fb4df
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10236
+  timestamp: 1683077214314
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+  sha256: a8a67143ccb65cfd6f50055176b6c26179a83130a45d0a12e79dd2de68d8db63
+  md5: a2065790f41e3eeb6efe0ef6daa75377
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10600
+  timestamp: 1683059285216
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+  sha256: 6aba582338faa0c26fe336bdb10c65b8f7808a6e383bd8f80f3e6b612ca209ec
+  md5: a7486349b5f7370f6902c2050a23d268
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 319197
+  timestamp: 1698946203341
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
+  sha256: 86bda04163628ef7b35528fbb4fe1d56fef50d10570a859e5ae8a7fbb60f577c
+  md5: 05e397dddd20d91460e3cedea0b3686f
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 4
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 27745043
+  timestamp: 1714075585637
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+  sha256: beba0555707dac1e8484d73cee9e4128ac4b10e2a0d4209357481179022e8fdc
+  md5: baa8b304607b3a9ae8a3d9acb354c31c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33343
+  timestamp: 1699371216044
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+  sha256: c1df29188e321abe23651c73712a6d8ed3abdc89ad38a42c33f1835b3ab77abe
+  md5: 6c984ea85326858942f7b635e0cc9ff8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1597325
+  timestamp: 1715025837032
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.1.10-hcec6c5f_1.tar.bz2
+  sha256: 9e61e80cb7cc715a3d688a660249da591e20550716a245684ffca317df9a19df
+  md5: 62a52eef7c69e9be38fa0313aa49b4be
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 42438
+  timestamp: 1702909424521
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0eb44a16ef74a13ef7839209899d009cd94974fbc406a417d958c7bc8d955245
+  md5: 41f239a5b67b1daf819849023aa5d12f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19056
+  timestamp: 1705431379885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+  sha256: 14775231982e1ea150189c956927ccfb1ad01a8c9395cdeea4d5a48b9b8ce664
+  md5: 729badc4bf7ba8ccc70e0f9e58075c99
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89812
+  timestamp: 1696347694075
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+  sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
+  md5: 6bef1694163a68ac4c37e5857b8da4f5
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1900191
+  timestamp: 1714488351925
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+  sha256: 3d5c2968f581006437df3932cd5d3c1c4afa78f0e13757b958440245d3248856
+  md5: 605ea221d225ad8e79284dbcfdab0715
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37699
+  timestamp: 1678317755913
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: ed059e32ce5a1c0511575f29d2fb6da12c54a37000bfa80f9e5aa9dfd9e04101
+  md5: 4d2261a92d25136a68b8d01d101119f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49145
+  timestamp: 1678317386284
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+  sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
+  md5: 523c006cc67c011383678c762015479b
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3594448
+  timestamp: 1714770737885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+  sha256: 424b8284072266eb59d055c0b7b58241bfb00009d445743ea261d4eeee73ea19
+  md5: f3a47898a55087edb9d65d29c24d9b88
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135757
+  timestamp: 1678323030858
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+  sha256: 6ab71b48d145c69007cfb5b4a21def2cc83bba972b7cc91c7d52d0d7eeb055bf
+  md5: f8970b0ad5c8b452b8722ceb4e5c17f7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 895379
+  timestamp: 1696937269468
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.2-py311h85bffb1_0.tar.bz2
+  sha256: e3950599a72f2093cbc99f6a2e40fb98c1731723a08f755a5c583560e5e602c3
+  md5: 46add19df747c5da0f1b7f1c8f37d842
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 155703
+  timestamp: 1714575768321
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 9e8dbede0bc54c77b974210be66503e7e8e45e0f1c71dc5c16cc9a9674d54259
+  md5: b4fcab9e63bd7b3cdf458c953904807c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270874
+  timestamp: 1678316116954
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.9.0-py311hecd8cb5_1.tar.bz2
+  sha256: c92c53f476c8157965a9637a4fd5ae7311c724396669d55fbe6b1b16c4c678c4
+  md5: 1d97af42c34da5f616ceee31e3a56d46
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.9.0 py311hecd8cb5_1
+  license: PSF-2.0
+  license_family: PSF
+  size: 9879
+  timestamp: 1705599378858
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.9.0-py311hecd8cb5_1.tar.bz2
+  sha256: 00a423edcfd3cc351068c09cf89ecacebd44425dc589aa5e2778e9b8552b521d
+  md5: 0926a658fe3590254e368b5b23a0cf3e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 71954
+  timestamp: 1705599373108
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+  sha256: a9960485ced319ac91afe69eaaf703c7e6b3049f1e06a4a8c2818b64155943f0
+  md5: 0a9c8ea92a14330a07edabac249e32a9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11399
+  timestamp: 1678394892923
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+  sha256: d42ae57366d05e12f10074583568355752436d66ad018ffbcfa24135f593810a
+  md5: 1a98e48aa0bd8b3ec09e2cbdbb236575
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 498952
+  timestamp: 1713213079520
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.1.0-py311hecd8cb5_1.tar.bz2
+  sha256: 33caa82e1fec2ce6b468392257f3556e5e6ae91654c01393b36bc340fe78f9b7
+  md5: 08b9cfb7943aadbfee616be6064cee7c
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - selenium >=4.4.3
+  - zstandard >=0.18.0
+  - requests >=2.26.0
+  license: MIT
+  license_family: MIT
+  size: 184811
+  timestamp: 1707770784530
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+  sha256: 0f8c3eb254be9c1957e748e385e20e62509d11052990c4755012be62434c9129
+  md5: 53229ba93f6e38308ae42ecfc6eaad9d
+  license: MIT
+  license_family: MIT
+  size: 96768
+  timestamp: 1706894705048
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+  sha256: 597015e8a038a111f03ffbc9a217fcda549d75230c86ce53c1f23c53d6f1a0cb
+  md5: 62e98aac883bccc1c87ca0d2ce2f08e0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25798
+  timestamp: 1678317074170
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py311hecd8cb5_4.tar.bz2
+  sha256: f60e6da6f08bf1bdcec59ed71fb53bbd3d2e3c487dba59523e956bfea6ba9ef6
+  md5: 6acead6f585f1bae0447298d4fec340c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 90538
+  timestamp: 1678317776793
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+  sha256: 885a9b6046e76f7dc1a346b14c63b4083046137bfae036362c854458e20e4fc8
+  md5: 3b279447ca282d065e681e567055b582
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 137340
+  timestamp: 1714717062907
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: cc6995f677d1628f42ae80ed47ff08d8d1c8ed12580a326af6e307f5febc594a
+  md5: d01eb964863b95ef62061b77c9037ead
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2471632
+  timestamp: 1689041625741
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+  sha256: 5b6d5246955b5f9480ff7027eb002442a7ade24f5c354da54ed513042f76cedc
+  md5: f32aa8a37d5e65a8dc30f9a1f46bc63d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54719
+  timestamp: 1678325412288
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+  sha256: ed0152ad6b87ffd9e01f4a62bc358e805ad59637f898a801b0a9cf903ae8e1fb
+  md5: 8a92f8c663608f24e14d8a2068b9d83a
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 415323
+  timestamp: 1714511993944
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+  sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
+  md5: c25b6d40f834647d0bbe767f6c776031
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 329449
+  timestamp: 1705602140856
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: e5fd1f8b8e5cc1221e85355ade7b69f0df640dbdc016b7f9ea0b0b6eda5bf9b6
+  md5: 11c4cb55382be5ab89b5c4085510db3b
+  depends:
+  - heapdict
+  - python >=3.11,<3.12.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 103266
+  timestamp: 1695833080541
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
+  sha256: 36fa7ad990aabf3607bda1f33e847888210974586363b6d69cf1ed092c192c35
+  md5: c981fe545122206cdeb647f2dc9e093d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 25496
+  timestamp: 1704207010227
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+  sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
+  md5: f2519b551f99765d9d98950c5e2b4713
+  license: Zlib
+  license_family: Other
+  size: 119782
+  timestamp: 1714511811597
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+  sha256: 7feb73e79bdbd45404ddc7a30c43bf4cc68eced8ce448ce7c31f5db134276fc5
+  md5: 48313bc6570c705cadbba3c356e0dc8e
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1014151
+  timestamp: 1714678461080
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/abseil-cpp-20230802.0-h313beb8_2.tar.bz2
+  sha256: d42422c15e115f76aec2f71e25887104359d5140af3cc6f19e358af011dc7ba9
+  md5: 9996619edfa02accc1fb7912d5ecc5fb
+  depends:
+  - gtest >=1.14.0,<1.14.1.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 1372151
+  timestamp: 1698327835928
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+  sha256: 9ca3f0dfc2bdbc109e359ba7ab246e6ae952a14819148ad069454b52f2bda802
+  md5: 51fb05873a644cac52f0d1e10cb7969a
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.23
+  - uvloop >=0.17
+  license: MIT
+  license_family: MIT
+  size: 228856
+  timestamp: 1706220385566
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+  sha256: 43405cc7341ce3efb2e24013ad62c64f26a69926635adceaa5459ccbcafb3776
+  md5: effa6d22f497e164cc8455f7f329c304
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 12510
+  timestamp: 1677917870614
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+  sha256: 947efe1c50b3280e9a67cbb18636bdade53a40960fff3056850ff81ab87acbe3
+  md5: 7d2d384ee32ccc12dcb0dc099e421482
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 35091
+  timestamp: 1677915945226
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-14.0.2-hc7aafb3_1.tar.bz2
+  sha256: 86bab32d1e41090bc20f55a7e337565aa8085b6fbafe9bab11886ccf7d938bcd
+  md5: 26f4f94a10d3fb85cfdb2ef11894d3d3
+  depends:
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - aws-sdk-cpp >=1.10.55,<1.10.56.0a0
+  - brotli
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags
+  - glog >=0.5.0,<0.6.0a0
+  - grpc-cpp >=1.48.2,<1.49.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.13,<4.0a0
+  - orc >=1.7.4,<1.7.5.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.9,<2.0a0
+  - utf8proc >=2.6.1,<2.9.0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 9537543
+  timestamp: 1707253459914
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/async-lru-2.0.4-py311hca03da5_0.tar.bz2
+  sha256: 9c64b8d25d87c43834c3f98c331598f9353b063af9456da0be91252a4433e01e
+  md5: 46c58da7041280e5ac6f5c9ce4b8b7a6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 21474
+  timestamp: 1699554635961
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+  sha256: 8259b4a0973c825ac81f581afcbe86640bd0a94b33caa996167309241877635a
+  md5: 49b8ddacfd3927bcaae139eadfb72ce1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153557
+  timestamp: 1695717951839
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
+  sha256: f536e8b60bdc895063ca0e0155d2041993caed5f932c232f2a0d8e52798da2f1
+  md5: daacfabaacebe1d1e53426ec3e385d14
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 86757
+  timestamp: 1706746162173
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
+  sha256: c356ce4cbd638a41fd3db59aa3559850e38c6b41188b8ffab32bdcbd9a55fe03
+  md5: e9dc8c248dda95e92533cae6815a0a8b
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 39456
+  timestamp: 1706690903374
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
+  sha256: 117825fcff2a68136a6e5183e05542c2654d73322e70daee3c50c0ecb3aec703
+  md5: b115d3f733fe8bae79b9d416754b260e
+  license: Apache-2.0
+  license_family: Apache
+  size: 182078
+  timestamp: 1706189905050
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
+  sha256: 241c19574abcaf91a47fc5c36f38e58c86732be5e06f5170063406098a58639f
+  md5: 3cfc3d38b8fdb25cc2e10e3e370d4106
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18039
+  timestamp: 1706690838125
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
+  sha256: d4c60f610e57b35a2962b8cea9911358d1642e0449468fa4967706af88bf5da9
+  md5: fc23856f141fe548afcfc4823881ee19
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 47155
+  timestamp: 1706697259456
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
+  sha256: c43ed35f4a64818ae39ca2c3c3652428c15da5e287f6e94254c3df4d6c759fb3
+  md5: 06366f5f8762447babf69804a04b1a69
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-compression >=0.2.16,<0.2.17.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 162746
+  timestamp: 1706744122437
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
+  sha256: 14e2ee7339c88089d1ff68f7144b3fb4f9e34fe538a9462f8de31dd6fdd1d42b
+  md5: 59ab0e7ffd73966ec6a2fa83a5df5c47
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 127084
+  timestamp: 1706696174505
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
+  sha256: 601baf006d0545ec65566701d99c601cba843e8ac03d80819d4b8bed23d1e5c4
+  md5: 2c98a19d57362cf1fbfec3dda3ea283b
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 61914
+  timestamp: 1706746732665
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
+  sha256: 16809db73ddc3c374ead2c2e9f2221894e2014d3e07ba62d79375cb4de4dfc9d
+  md5: c03f5e3b42bc59bd92db813522cce1aa
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 67560
+  timestamp: 1706747573116
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
+  sha256: 293cf6b9dfa727d0e65b383b0e434f8fb26480abd011516171b8652fd363c98e
+  md5: 2df2dd6c43a3b413b438a9ef834d78b0
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 48454
+  timestamp: 1706690816205
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
+  sha256: 773f7ff1a91af373d27f5c57833aff8912870108ddd94a5280bfdc608effe5e3
+  md5: fad8b095c03774c9d4901db7eda09002
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52142
+  timestamp: 1706192041205
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
+  sha256: 4efabe18fc312e65a5aac9b2ebe423296cfe702756891978244287ab47881927
+  md5: 5786a8ac037fd0e81e25f52dbc6dc72d
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
+  - aws-c-s3 >=0.1.51,<0.1.52.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 210683
+  timestamp: 1706827608490
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.10.55-h313beb8_0.tar.bz2
+  sha256: fe92c6408ee3ebf269b216d1c9576bc15e65a38bcf684f2a7b935e57dbf2e444
+  md5: 4c6b2dc15773f338a7f3299a753ab0af
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 2365300
+  timestamp: 1706890517127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/babel-2.11.0-py311hca03da5_0.tar.bz2
+  sha256: cbca68c98946526eb9a24c01717a0c850d1736f7530196ce627bcc33d8337a18
+  md5: 57ee914212070a75e071674d97480bd5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pytz >=2015.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7177152
+  timestamp: 1677920828584
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+  sha256: 11159a30daae77cfc1abe5e60c19261f65c005e6fbc460aecf72318514d737ad
+  md5: 0c5002654a9cb21db1fdf8c1d2017df5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 269772
+  timestamp: 1681493072129
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
+  sha256: 90439f37ede74ef464e76093e173a8e94a20ee4ad79c68c9e7570fbc67fc13cc
+  md5: bb3b906307dd679fc3276be7581494f9
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6073834
+  timestamp: 1712084392983
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
+  sha256: f1660ecfb8687d74e81a7b00699a8bb4677cbd791d14f50ba517de98e2f187ca
+  md5: 1636fc4b725da8c5e967952a55f3fd80
+  depends:
+  - libboost 1.82.0 h0bc93f9_2
+  - libcxx >=14.0.6
+  license: BSL-1.0
+  license_family: OTHER
+  size: 11780
+  timestamp: 1696762172661
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+  sha256: 688a071ba370f51b457cd32d70b7b38921ce9551203d06fa7fc2c30c4b79891d
+  md5: b2353077a39ab997463768154dd58fec
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134711
+  timestamp: 1707864978809
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+  sha256: 048264434c33fdb53862cdd69b2e2bc4ce6f8a70b3211ad6d686d066eac2aa91
+  md5: d55696ccaf6755931cd662dfb929aa0b
+  depends:
+  - brotli-bin 1.0.9 h80987f9_8
+  - libbrotlidec 1.0.9 h80987f9_8
+  - libbrotlienc 1.0.9 h80987f9_8
+  license: MIT
+  size: 19737
+  timestamp: 1714483270447
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+  sha256: 13627293296fcc231d8dc12d803dfc9621108c60df38b0e3c64e9e02ed55e564
+  md5: 86efd4ad08cd80d3eab77873db84a255
+  depends:
+  - libbrotlidec 1.0.9 h80987f9_8
+  - libbrotlienc 1.0.9 h80987f9_8
+  license: MIT
+  size: 19083
+  timestamp: 1714483255364
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+  sha256: 2e542b2bb27f8379da3efcb83ef084cb26e6a9ab576c50487c2dd996afd5ccb1
+  md5: e8cab9d1ef58a450f971690fcdb2ede2
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 380182
+  timestamp: 1714483330655
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+  sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
+  md5: 56d1386c7f1f338f0d18f82af6525273
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 158748
+  timestamp: 1714510571033
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+  sha256: b0be79290b1df1cf1d07a1a9c3f3a92ae262643a6df3dc10dfbac22a82874dd4
+  md5: 8fdcf1c08eee91fec7eefc22863c816a
+  license: MIT
+  license_family: MIT
+  size: 106550
+  timestamp: 1693902036526
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+  sha256: bbfc668f445f3584936b326dcfe92bf71971ce16241f4f79db8aeb88d7aab41c
+  md5: 10cc05ed51482e1dfcc31dbd13bb34c6
+  license: MPL-2.0
+  license_family: Other
+  size: 138641
+  timestamp: 1710764806818
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+  sha256: 512969f339a9a7b347cdb7b88f439819168089867f04732279f02759d8caf24e
+  md5: 2009c2ee465fdd74dbd046de73726234
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 166501
+  timestamp: 1707229221324
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+  sha256: 8d26cd4d16545ad8afddd5521bc6894a50d5b8faff3abbe600bb9b062f3c3a0a
+  md5: 66eb734b7d7008eb5fb537900767c7ae
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 286807
+  timestamp: 1714483190838
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+  sha256: df81a27f221d11af4a709f272dc8ba3fd3f6d5ab4ffd883c40567bcf04f0cfd3
+  md5: e49333e3ffe1fe2e701f50a6e6dccc52
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204179
+  timestamp: 1698129906257
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
+  sha256: 53edaca56d853083d44cef6234fe4b3d076d107e915781ce54ec135c25e09f0e
+  md5: 5d1d51e53c11bcb56cf863d58e37c077
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50433
+  timestamp: 1683040076511
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+  sha256: d9c126d8bcd1c89ea37186c172d6b1f73f45ada60e3ae1790a017b530baa0147
+  md5: f0223aae3d622547f6accb212579c58e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17967
+  timestamp: 1709322909223
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+  sha256: 1f908c688e47d03d92ac09d9541a1f1c773ac2ca485dd1d77441b1aaefc032db
+  md5: 444c330471496a39a97e87f41ed70c96
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281104
+  timestamp: 1700583698464
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cramjam-2.7.0-py311h62f922a_0.tar.bz2
+  sha256: 1a71c2e15872edff275f419bd1b827c2e37a4cfaf997cd30104cadb2da285a5b
+  md5: e97551b1be62a8bc30eb69e1dfe39191
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1531706
+  timestamp: 1702651054879
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.2-py311h80987f9_0.tar.bz2
+  sha256: 9e135f43ac703c578abe1b84761a1fb4ad75b63966f0b015fdcb939d3b05e7b3
+  md5: ab5b122dafc5b17f32b2ec8ce73d8adb
+  depends:
+  - python >=3.11,<3.12.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 403974
+  timestamp: 1701723703085
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-2023.11.0-py311hca03da5_0.tar.bz2
+  sha256: dfac5c394e0fa6c3bae5c8565735363a56478d512e38dc8782dd9ecfd06d5d17
+  md5: 72efbeec2089b327f3b751c45abeac10
+  depends:
+  - bokeh >=2.4.2
+  - cytoolz >=0.12.0
+  - dask-core 2023.11.0.*
+  - distributed 2023.11.0.*
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.21,<2.0a0
+  - pandas >=1.3
+  - pyarrow >=7.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6031
+  timestamp: 1701444902384
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.11.0-py311hca03da5_0.tar.bz2
+  sha256: 66b75168a7eb1fa16c9ddd7004339dab4d4bd3557f60abfcfb9de706f27cfd42
+  md5: 4c482f6b591b73d95c21f967bd69b471
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3028051
+  timestamp: 1701396155471
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+  sha256: b9356e3ada4872c7c950d2ac7e0f107c4786775191efdfda3a469dffb18f2714
+  md5: 07ddd96675caf30ea77cafb1ea5662a4
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2490144
+  timestamp: 1690905181398
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2023.11.0-py311hca03da5_0.tar.bz2
+  sha256: 9901062d92e30b3e1c7739d19be817765fa7c39458697498b06b125ce36ab8d4
+  md5: 638bd80c82a43aeac35c73909014ac92
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - dask-core 2023.11.0.*
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.0
+  - packaging >=20.0
+  - psutil >=5.7.2
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.10.0
+  - tornado >=6.0.4
+  - urllib3 >=1.24.3
+  - zict >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1789023
+  timestamp: 1701398118479
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-2023.8.0-py311hb9f6ed7_0.tar.bz2
+  sha256: f883809f6e11db2bf67fd28a0fe283fbb5ad1a6e09897c4e743465c1d0838127
+  md5: abdc285c69c9b5e9e7373ee6aec90856
+  depends:
+  - cramjam >=2.3.0
+  - fsspec
+  - numpy >=1.23.5,<2.0a0
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 563381
+  timestamp: 1696541857273
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+  sha256: eb82a0e2ca36d0973b5f6642e27609554edad4b72696f989776d5db8cd4a6a42
+  md5: fa8d9dd8a2fabba964c6bb75ace8c572
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 3201601
+  timestamp: 1713551611540
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.3.1-py311hca03da5_0.tar.bz2
+  sha256: aa53d9f23e86ac3398f6b935cea01dcd8a1b1821d9b1d37b16a5ba68a2dbe569
+  md5: 2d5841b96988498045c28e3b3951d5ac
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 373029
+  timestamp: 1714461571346
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+  sha256: 25e05b93a99914a5fd1a298a2c5b25479fbd571b0db9caa7c6ad4336f060f62c
+  md5: e213b68bb0274e0e54c610a041e059f5
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 150168
+  timestamp: 1706888198288
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+  sha256: bbbcf47ef9249635b5199be1414b0b59687cc04ea9630d50ecc609dc200c095e
+  md5: 5820c373d6847a68551cadb8984a8277
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 95638
+  timestamp: 1706895270850
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpc-cpp-1.48.2-hc60591f_4.tar.bz2
+  sha256: 4787d6730eae9c37b11f76db852a2c0a070b4dabc9abb9e423fa3ad68944ed19
+  md5: 8dff6fefff4eabeeedc5a67b15d91aff
+  depends:
+  - abseil-cpp >=20230802.0,<20230802.1.0a0
+  - c-ares >=1.19.1,<2.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.20.4.0a0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - openssl 3.*
+  - openssl >=3.0.12,<4.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3884646
+  timestamp: 1701982736145
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gtest-1.14.0-h48ca7d4_0.tar.bz2
+  sha256: 064fc752345ef3973d3ebf2145029eaa308c17e12abe72a732255db9cdea6a40
+  md5: 37ace38cf07143b39ae9b89feb204d3d
+  depends:
+  - libcxx >=14.0.6
+  constrains:
+  - gmock 1.14.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 399378
+  timestamp: 1692633568295
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+  sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
+  md5: 69eb3b03765627b6159ed23cdde78396
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28399065
+  timestamp: 1692293207812
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+  sha256: 4d4ab70ae0ce008c1cc96a4edfbf3866d5e636acc4799a545ea93acee51635f7
+  md5: 86a085a440729020d1d7b0b74d6a0c6c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148448
+  timestamp: 1714398923507
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+  sha256: ec139e4b87aadcacc0670ecbcc2a303d858d4ac38b9404458a4b676bce9d21d5
+  md5: bfcfed281f8df0f18726ec5f843b2b26
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 51053
+  timestamp: 1704813595720
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+  sha256: 63670c8f31770e1746016f645ca6b42b35f92d1c37e8025793d9490fed9998c0
+  md5: 9cb417b9fdf02b4e007a5b5781e5a8cc
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229932
+  timestamp: 1705934202146
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+  sha256: a40c76c412ec793ca26b97a9b5c496d253768438e1f7d4a0ee5f63ea79eed355
+  md5: f609e4fe044318211cf0e37e289beebd
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1614299
+  timestamp: 1704833142734
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+  sha256: e57d10579b52a3cde45aa17e1bdd95dcb9d3346aa00eb02c51e38a42db83e18d
+  md5: 05153120787fb09159b6e1ad902c6e10
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1180481
+  timestamp: 1678994989550
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
+  sha256: 06512ef9a910fa72bf5697fe89e88c605d61f8478a9d8dd233c13f40e30f8446
+  md5: cfa00c9ffd3407e29507525c020e5526
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 355730
+  timestamp: 1706733720706
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
+  md5: 055e12390b844ea6c6e956ee08a618e8
+  license: IJG
+  license_family: Other
+  size: 273479
+  timestamp: 1677849171867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+  sha256: 62025ce4a2b9244b9816c9e02487e0dda567600692b5f9ca71f425d084961c7e
+  md5: d57b7063122e5bf25cdfc2a5ea7330a8
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 181872
+  timestamp: 1699041739097
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+  sha256: 404b0847029f77bedd7902a170a046219e0dc5c0ec2be19ff45361cff25b2181
+  md5: 3a02bbe8d45fdbcb2350f672be74c9f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16524
+  timestamp: 1699032463763
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter-lsp-2.2.0-py311hca03da5_0.tar.bz2
+  sha256: 8d8eb94257336543a0c6a2168a68195ee1258af47f4b5b58d8797ac483744a63
+  md5: 191fecf4322e1348caac6337955a9e5a
+  depends:
+  - jupyter_server >=1.1.2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101675
+  timestamp: 1699978313832
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-8.6.0-py311hca03da5_0.tar.bz2
+  sha256: bb525ddbadaeb7090eb5bf8aaf2d4d01765c5e2e93136a47fbb1f5b663bab567
+  md5: df7c907e1d274521660c4e2030c5b6ef
+  depends:
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 225157
+  timestamp: 1699455930116
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+  sha256: 8220b1bbdde5e800810f7bf183a992af1a95825a837edf975fa8c4b51c5d806f
+  md5: 3a06ddad06e04d5f0211c22cd81ca75a
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94950
+  timestamp: 1698937436979
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+  sha256: 8a9a9f9ddbf1b7744ef04a8c862438499a41d81a4beb4a49860156c273bb7497
+  md5: 051355801f09eefe850ee8145151f934
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42497
+  timestamp: 1699282590553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+  sha256: 65c703cc996a705d0ee350070e313b1cae865f9d6e6490ebf1164c0f3ce22d93
+  md5: 305ad8bcaad3e352d61b1e594093b467
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 596801
+  timestamp: 1699466743685
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+  sha256: 501e929d345aaa9079c965552b942b4e8bde35b87ae89faef003687a40bab3a4
+  md5: 54c7b8554a405acd7c8326c41ba93e63
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28237
+  timestamp: 1686870817418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab-4.0.11-py311hca03da5_0.tar.bz2
+  sha256: 7c07921656d5a8f8fdc8e5edb0b18ffdfbde22a1938258cf29e78b5b66c93928
+  md5: b152aceb76578939f6aced4bf328dee9
+  depends:
+  - async-lru >=1.0.0
+  - ipykernel
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.19.0,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  - traitlets
+  constrains:
+  - nodejs >=18.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6667686
+  timestamp: 1706803531409
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_server-2.25.1-py311hca03da5_0.tar.bz2
+  sha256: e28c8ba9c667ba5a276d3302005b990874c6de77e4fc785f87224a2dc2ca5394
+  md5: 3873f22212fb841a76c5348f5f6acf98
+  depends:
+  - babel >=2.10
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18.0
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.11,<3.12.0a0
+  - requests >=2.31
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 107252
+  timestamp: 1699555538493
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+  sha256: 8c1c64d51be73aad381992a9df19d8336910bdfc40f19940231df86e177d17cc
+  md5: b1f786f96684a143cf30d1f6b8aebdb3
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65045
+  timestamp: 1677925371836
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
+  sha256: 789402b67398d3d936ac4486df01869d59b0e1ba298cbd06407d059aced871e4
+  md5: a0f50a38705d0507bbf57ee49a1d9c29
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - openssl >=3.0.8,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1308175
+  timestamp: 1686931157327
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
+  sha256: c1f104bc84ee46a3d3beafb5e35236c64e6b4fd6cceabfb420e1838171b1d9c1
+  md5: 4f95903a1be48bbee1f9a818ec810b89
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 22243663
+  timestamp: 1696762144385
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+  sha256: 199042b87451abaf14546af124ae3380194cddda928e0d30ccb341e93084854c
+  md5: eaa0442887994a82486c65d87f6b71e6
+  license: MIT
+  size: 68806
+  timestamp: 1714483212137
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+  sha256: bd9a8a17fb14086446b710fa029d238e69274b83ee2e7e09093496f190de82b5
+  md5: 66615d6a0cb5dcca3e20c019cde0ed2d
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_8
+  license: MIT
+  size: 32975
+  timestamp: 1714483225840
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+  sha256: e1bf77e8b975c30a69b08a08410622e27c8cff6f592ccfa590466b83d9e6d104
+  md5: 8af86bdac01fe303d693d9b76c071059
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_8
+  license: MIT
+  size: 310266
+  timestamp: 1714483239194
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.5.0-h3e2b118_0.tar.bz2
+  sha256: 5f11db2220b728d4e13e1d0069aeb0215719a7bdfce88ecfc7be68778986eb54
+  md5: 131c9519f6e616b3295735ac1a7f9c2e
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.57.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=3.0.12,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 357001
+  timestamp: 1704383770648
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+  sha256: 9597df5344a718d37837966aa05091faf210260898fad5e7a64b87f17de9e90d
+  md5: 678a1f87940ef6cc421a092301b8c3fe
+  depends:
+  - ncurses >=6.4,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 167208
+  timestamp: 1703006281321
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+  sha256: 6fc572025852b210ecddcca3ab9ff3f1d5f6bd91f1933c6e296de6bb331f6b5d
+  md5: 6dd7d9c5737bbd2a27d18f15318dc3e6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 102059
+  timestamp: 1628961869728
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+  sha256: 9e7b9bb9367d8725a751cdfa0b2d270434d303ea196cfaacc605ee26be09874a
+  md5: 44d1843cc2f17eb2674f35b95468f551
+  depends:
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 415467
+  timestamp: 1685052299052
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+  sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
+  md5: f31e4eb9cd6447cc2f5ef0243a76540c
+  license: MIT
+  license_family: MIT
+  size: 120460
+  timestamp: 1714483461787
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+  sha256: 72d242814b990900c9410d4738cc685f70ea71231742293cffbb475d8df100f8
+  md5: f9976688992b7ac4b56f5600ee15b5c4
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1407202
+  timestamp: 1714483550601
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+  sha256: d654027daea13ac9db36ab5fd5eff3ad398ec97c1777bf399f3ec680d2c145b9
+  md5: baabb1f905054bfea3af8f5768572a34
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 26579907
+  timestamp: 1683291669565
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
+  sha256: b7cd58ddb892ed9d3983bdde8fc2530f0653a58818c87e08659f3795f04d8aff
+  md5: cf519f7233951d00a30c3b969c4cd161
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - c-ares >=1.7.5
+  - libcxx >=14.0.6
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 728977
+  timestamp: 1697018415626
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
+  sha256: 239ec46c06c477e722230159971bac8d9eb14793a2e75f6e3d3a7a04ed5d5ebd
+  md5: 50e9c501f39bb262703c764789099f24
+  depends:
+  - libcxx >=14.0.6
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2338901
+  timestamp: 1675278555141
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h02f6b3c_3.tar.bz2
+  sha256: 41a62fd6332033289602976adc75cd67e23d9b41ae97d0a993adb41f13f83480
+  md5: e2d039fc0d9f3d32818d202f23a30e8c
+  depends:
+  - openssl >=3.0.13,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 303841
+  timestamp: 1714510628791
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
+  sha256: 82a73882a31e7a4f4edcdb0c21562e123da913d03b90b19396bd6dd4fcd9a7fc
+  md5: b5e5199892949d1e7e2db7bf0ee4dfe9
+  depends:
+  - boost-cpp >=1.73
+  - libcxx >=14.0.6
+  - libevent >=2.1.12,<2.1.13.0a0
+  - openssl >=3.0.9,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 361781
+  timestamp: 1687975246139
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+  sha256: 41c62a460bb81a1a272aa28b219fab9c26510adac177ff1528b1980eabc6e868
+  md5: 8d312c5628dc7ea833e9b4dcb73e9c45
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 42346
+  timestamp: 1677973051421
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
+  sha256: 911c7577f591311bfb000121831234e7bc6332bff62fd00c2245371e67f473c0
+  md5: 419681f23f179ba08e5fdf9884ea238d
+  depends:
+  - libcxx >=14.0.6
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 410616
+  timestamp: 1706910762686
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+  sha256: 5777bbef827f72975a36f3da80ab4af718dc781264f74ad7e3864755d620c0f0
+  md5: 4240f1a79b812387919cc710a0469556
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14318
+  timestamp: 1677925438733
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.3.2-py311h80987f9_0.tar.bz2
+  sha256: 14582ae62269dca40493afba1649f929841f5d2bc5907bf0f6f01c6a551062c4
+  md5: c920d6dea31be5638d79a76026d523a0
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39941
+  timestamp: 1686063850483
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+  sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
+  md5: f5f7e6e7541d8dc3d3df270d488d2e24
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176990
+  timestamp: 1714510588159
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+  sha256: d024f5142416961a5e66e424d4d14aec652f9e9dd738b41a97f45674c2ffc9d5
+  md5: 0e2d94b125d802f7b006cf19c71655a1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 163084
+  timestamp: 1677932947966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+  sha256: acfd84e29ff4dc2d85543bb973a07f22b4ba53c5d00bca84608ee7f13b2a8676
+  md5: 5ca161cd51e2db358e768453b3ee485e
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135871
+  timestamp: 1684279980293
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+  sha256: b1bed54c7bfb7304cde9e8e6f798543d08e808e81286a5a48296fc94d621f9da
+  md5: 774358285c9e496c9f5c121cc546c823
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27438
+  timestamp: 1704206026910
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.8.4-py311hca03da5_0.tar.bz2
+  sha256: a8d33a3b5014dabc72b49639b2b2c632b8568b692fc963d5bef0222b46c075ab
+  md5: d2d84d2224a9abd25ae550ccaf64ef4e
+  depends:
+  - matplotlib-base >=3.8.4,<3.8.5.0a0
+  - python >=3.11,<3.12.0a0
+  - tornado >=5
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8973
+  timestamp: 1713336625397
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+  sha256: 9229a6e15abf3147cfcffad4ca389dad940e45779963b4fc3fd56dfdcfca3234
+  md5: 4e1897f3cb4923de48c016468c01c051
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9100733
+  timestamp: 1713336457304
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+  sha256: 3276d61fc353c537bb09d4b7473d7abe12be38806f42c8cc383b62f40850a5cc
+  md5: 6e9c9d47f264b77d9a8461f0899848a7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20446
+  timestamp: 1677918370379
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+  sha256: 43c96d30775b61b4968422a47f9605049428120669f0742bbb9e5ba145c7d11e
+  md5: a31ca0d9284860adf5463cf45a5e3145
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 69243
+  timestamp: 1677995336989
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+  sha256: 96d8c9f42a38651b7bafe5f3cb132601db76cd1e28fa58e2eaf090e634292fff
+  md5: 5ebc793a17b6aa84d13f19433545ffa5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23895
+  timestamp: 1677942274932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+  sha256: db9bd659ada23f1ded443d2db00dd13b5d5c0b30f5062544b1ee2c2b88d63d29
+  md5: 03c48121614cf12abfe30eced9b34717
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105333
+  timestamp: 1677916687032
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py311h48ca7d4_0.tar.bz2
+  sha256: 3e370e88a51671f87fa0c0e241569950f8c5a38d5e8743c33b0193f54d73d10d
+  md5: dd70eac354c92710ce4e2be9d4b02043
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 38448
+  timestamp: 1677909415759
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+  sha256: 8b05894fdcbe5cfcdee94812b043de4cd7b4fa51d3e2aad25fc7cff50c8f82ab
+  md5: c970d49137dce1c77f782ee5725950c1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 30745
+  timestamp: 1677960816849
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+  sha256: e8eee27fb667aa10b26f3bc4b93f449b7d991ded27b9cb457effee394ce05f6f
+  md5: 6a3e5cd0e1141c01ffb91285bdccfe83
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123043
+  timestamp: 1698934328890
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+  sha256: 40230434aa2fbb33ece13632e8d4b7cd1ad68fdb8d1b00263af4a010795d25f8
+  md5: f12ce7dad3620d6d53a442fa9d36a0b0
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - pyqtwebengine >=5.15
+  - tornado >=6.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 538067
+  timestamp: 1699022954841
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+  sha256: a492acec8ceadc0911a75966ffa630a8eb15b2da8c7a8d544a645ba47771a2d1
+  md5: 4002b1b88b2ecfdfc769036f43b0a895
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 170964
+  timestamp: 1694616845237
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+  sha256: 417ace1ce51e81f3f92ddc26e0e3a83c1e19c9ebb7af7104452002a5573da534
+  md5: 3e11de6cef096091bb733e07802f00b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16979
+  timestamp: 1708532698253
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-7.0.8-py311hca03da5_0.tar.bz2
+  sha256: 0aab440b27d9cab7a31c41d0198be602a88c41a95efb9e7b5be99a96ee2fc6cb
+  md5: 959445d700f0266e95d1bdf5809d34bf
+  depends:
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab >=4.0.2,<4.1
+  - jupyterlab_server >=2.22.1,<3
+  - notebook-shim >=0.2,<0.3
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3671288
+  timestamp: 1708030081801
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+  sha256: b0cc542e2a6f42ba716e7e4ccf29eddcb155ad167fcdbc72d2db9c7873eb5639
+  md5: 7acf81b17d2c4ceb3cd39dc9f173855c
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27539
+  timestamp: 1699455954000
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.59.1-py311h7aedaa7_0.tar.bz2
+  sha256: 4e0fb594095ce53c58f97eafc1c113e150929a6935e8ee54d86359cc7a9afd14
+  md5: df6c4ead6e4bed95d012bdd5e79f10db
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.42.0,<0.43.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - libopenblas >=0.3.18, !=0.3.20
+  - numba-rvsdg 0.0.*
+  - cudatoolkit >=10.2
+  - tbb >=2021.6,<2022
+  - scipy >=1.0
+  - cuda-python >=11.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6062719
+  timestamp: 1711988782214
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+  sha256: 151a3eb68d1189e69764ece1d8fb3544d31a22f5bbbc3e19d846de8dece304d2
+  md5: eb6609e6bdc9c82d70df3f8c4c2de95b
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153313
+  timestamp: 1696515415712
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+  sha256: d3bb1d4be88320a5861cd3a0f086e9709f9b64c96c032cb9039cc4f17ec66a85
+  md5: 0a7b97665c06fcd34a70e34abc177280
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.26.4 py311hfbfe69c_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11288
+  timestamp: 1708639168951
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+  sha256: 3e70248a7069ca12ccf56252869bfdb72211fd4e4c327e6994756496df786c79
+  md5: ce4846006d98638cd86a532a72f8dfe4
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311he598dae_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7536860
+  timestamp: 1708639153133
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
+  md5: 371358a54bbdd307603888348d1a2c6f
+  depends:
+  - libcxx >=12.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD 2-Clause
+  size: 412248
+  timestamp: 1628861367714
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_1.tar.bz2
+  sha256: 3a06a4dd64641240ad4d8401105a62597fc0b876a94544bade1c6cace13b5ad7
+  md5: bdb8a787b740513c2aba7494ef62c58b
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4766262
+  timestamp: 1714511251647
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
+  sha256: c4135710b5536fb859a6672c055bbc2cff0426e0655e75c7fdf808f7f3344ada
+  md5: 483605a01fccba850b7f0cbdeff29858
+  depends:
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.9,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 421604
+  timestamp: 1676482754496
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+  sha256: 77b0c0a0fb14d817390244ebd93c36d44a7867239963f211f7c0a72a3f98d382
+  md5: b90336feb8a50d2eff880e89acb02f40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39617
+  timestamp: 1699371253760
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+  sha256: 4f6c3e8d8fc4c57975cab837ef109b9ee7af4f18aac72668334ac656e53c6edf
+  md5: fbf1b507f9a80c5de3c957e8152124da
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 159289
+  timestamp: 1710807498427
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
+  sha256: 3af823879c340838c1040e99f653c3438ccce8dc559bd91c3f4ab2579282a002
+  md5: 5b3df01fda0281dab4196bc36d1ca367
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - odfpy>=1.4.1
+  - adbc-driver-postgresql >=0.8.0
+  - scipy >=1.10.0
+  - fastparquet >=2022.12.0
+  - pyxlsb >=1.0.10
+  - pymysql >=1.0.2
+  - sqlalchemy >=2.0.0
+  - pyreadstat >=1.2.0
+  - beautifulsoup4 >=4.11.2
+  - fsspec >=2022.11.0
+  - openpyxl >=3.1.0
+  - xlsxwriter >=3.0.5
+  - jinja2 >=3.1.2
+  - zstandard >=0.19.0
+  - numba >=0.56.4
+  - matplotlib-base >=3.6.3
+  - psycopg2 >=2.9.6
+  - xlrd >=2.0.1
+  - pyarrow >=10.0.1
+  - pytables >=3.8.0
+  - html5lib >=1.1
+  - blosc >=1.21.3
+  - gcsfs >=2022.11.0
+  - dataframe-api-compat >=0.1.7
+  - qtpy >=2.3.0
+  - adbc-driver-sqlite >=0.8.0
+  - lxml >=4.9.2
+  - xarray >=2022.12.0
+  - s3fs >=2022.11.0
+  - pandas-gbq >=0.19.0
+  - pyqt >=5.15.9
+  - tabulate >=0.9.0
+  - python-calamine >=0.1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17082645
+  timestamp: 1709591689205
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+  sha256: 088245becd055af4de74e4ed13cc752ab546423f204b170ba2dd8809af30a2c7
+  md5: 2eabea5ccc56ac088e0349626e59df06
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48517
+  timestamp: 1698702686783
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+  sha256: 174b680f4bb041e8146aae80f92390122459e0ef8c911cab22d01e2e92d44ab1
+  md5: cfffc94779cd26a349bd409b5590b098
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 916496
+  timestamp: 1714399019350
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3.1-py311hca03da5_0.tar.bz2
+  sha256: f6298f1b93b2c4f62e11be8f5cb1c184b9774492626f3c93a004cf5d7e4e84f6
+  md5: 92d6c6c6a869b6d1449ddc614f622c42
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3445195
+  timestamp: 1700667693168
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+  sha256: b6200816d65673aa1707c20a768c9cff87dd8dbe1335f9c1478e5931dfa08ee0
+  md5: 14b1e0fa73eb33f9c83048482dcce57b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38423
+  timestamp: 1692205689597
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+  sha256: ebdf211edd98d88a23778551c7a9702106edd0695d4fc48e87c21f77521c1ffe
+  md5: d8c505081a468f1b99c62466e2309417
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 123084
+  timestamp: 1678996822234
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+  sha256: 07cfba50d9e94364bde077731a824ca4f537138b35ee6b66d07aee16ac9850f1
+  md5: 919bf486280a11e6acb3c2c3a82f7473
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763225
+  timestamp: 1704404463402
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+  sha256: 8094436b2c44e68e72569c704633802aad82e977b1e16026848218679c8becf4
+  md5: 2360e46d3e598dd5e2abed781fe166c5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 502115
+  timestamp: 1678995719872
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-14.0.2-py311ha07b5f9_0.tar.bz2
+  sha256: 4ef0edee30559d99ce74a3207b5e594420549d743b6a6942f4910909f0bf7f15
+  md5: ee7f74b498c265a06b470b7f853612e0
+  depends:
+  - arrow-cpp >=14.0.2,<14.0.3.0a0
+  - boost-cpp
+  - libcxx >=14.0.6
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4965174
+  timestamp: 1707331530109
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+  sha256: 121b5b66721760c05f1d4eee91626229d1814663d3fb5f23126ef870aa496e26
+  md5: 0c588c2ca790a05d422c06e8568201ad
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2124200
+  timestamp: 1684280082141
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+  sha256: 44b694db8e81d61960d28d60f9e9b573f03f7827881d302da334378881db4889
+  md5: 6c94ba7caa599ff533e0ab55d898be8a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 208454
+  timestamp: 1677910948527
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+  sha256: 0bb3d2a57b332c5cf73ea40ea13c850ae24a1f9a3a41ed9267832d9e3c767572
+  md5: 45a7fcf1641980d5114999736428502d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36755
+  timestamp: 1677906514270
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.8-hb885b13_0.tar.bz2
+  sha256: 7db8bda1ad368413284ee399322d421feb385863426f8ce3167c0eee6788b8d6
+  md5: b1b70eac1af7d86cc231d9b695ff1d3e
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.5,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16417657
+  timestamp: 1708983786954
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+  sha256: f94b3cfea6f76ea9983e16d3c4c7e0a64f02c40cc2c3ad57189bca2e67030bd9
+  md5: 0d100990ade57a02b60d1e8085db0bdf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 280263
+  timestamp: 1678996927464
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+  sha256: 252c86f5aef7f8dfce99a260c24cbb35a9adfea144a2acfabb224f516341544f
+  md5: 745b888e19a644f48800799f82c01c21
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18539
+  timestamp: 1683823925189
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py311h313beb8_0.tar.bz2
+  sha256: 5a40b7ba3aaff79b21020a5ba9df44202d9fa6152abd81f91ed1602cfa864ed7
+  md5: 95226a611d81daf647c0211ef2de31a7
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 148513
+  timestamp: 1682522467465
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+  sha256: d945744eb133f19ca61325cac5128bdb053ae04de4a0ba6f69c061449cac8af7
+  md5: 34baa81490d667381bc7021435b0e1f2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 275858
+  timestamp: 1713974457562
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+  sha256: 4f04a43cbd612ab09cefbdc2e48ee61b51967dad59d859ce0502cc2c46c88fc5
+  md5: c68bf65433b2151b51b2e699bc22c501
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 194632
+  timestamp: 1698096151085
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-25.1.2-py311h313beb8_0.tar.bz2
+  sha256: 66d6bcf8e67799c60b41ed3c14d352cc065abee1afe41fab710eac41ddb27809
+  md5: 488d9d295388699484bd2d1226157163
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 543785
+  timestamp: 1705605339487
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+  sha256: 089c6b9bebfa690f380710f219ab0fcc1acec9f2e187d4174a08222c45f58afc
+  md5: 11b832c6c10a6d2b0e687a20c3037c97
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-3-Clause
+  size: 194532
+  timestamp: 1652449531448
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+  sha256: 7a208abc002a2fc208ae25cb2cf932999a3e4980aa4c9edff315cb9ac62b12ce
+  md5: bd22ebd3cff811577ea61f115ba7f4f2
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74744
+  timestamp: 1699012126255
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
+  sha256: cc8d055a068fe5a7484284c3360d81db61656dd6118c743c740fcc47cd3da379
+  md5: e5fad71ef3b99077b79052576e51bf9f
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 120672
+  timestamp: 1707355664440
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+  sha256: 52368d9b557b8f54ef5ca4bf6cd5a3ec665171f2b2d2082cdd410bab88f4829c
+  md5: ac76fb4d2eef3ecdd491cf5d3fb8620d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10204
+  timestamp: 1683077239143
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+  sha256: 491d116c5f54ef340e3bce631835f7138cd1923d7b63e6ca9aa01b48110cb8f9
+  md5: 9b81bd8ea808704f5433884b567f1f15
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10557
+  timestamp: 1683059079547
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+  sha256: b53a5f6119173d62e4e68a37ea8511c7fc87a00af72953e0048d075a799c7a7a
+  md5: 76a16cf4edb9b12b2b96a2d323f060dc
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 342535
+  timestamp: 1698945991201
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
+  sha256: 9e8312f9452357202813aa289430c939302617f562dae9e90fdc3fb5e9be49d0
+  md5: def02b749d0c0a3675d96aeb508a2306
+  depends:
+  - blas * openblas
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 4
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 26383719
+  timestamp: 1714070280353
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+  sha256: c80d52567084b1caaed2862b77b70065ca17afaf0b020733e9d6c273b4a63e78
+  md5: ddf7d88c1967f3f7a4ce1c975fd47e0d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33321
+  timestamp: 1699371225235
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+  sha256: 6d38d171ef87340cf0fbbf4c70217df4826c65400c9290774f5cb35e381e3315
+  md5: b9529a812f9862fc89461b6b90f184ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1599110
+  timestamp: 1715024190898
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.1.10-h313beb8_1.tar.bz2
+  sha256: f340be28c71abb0b785dd78f742e12befb08e37b77087924364e01a7b1d25bda
+  md5: 4f553ef7b00e79fb67318e680da9fdaa
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 42517
+  timestamp: 1702909400491
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+  sha256: cd71091a234874d2826fa063ec5222b3191c9f47e1b5281c352d9df3f31a06bf
+  md5: 0db8e29016c6bff026c083d9923a7566
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19073
+  timestamp: 1705431415504
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+  sha256: 3e18cdafc607c6d7623b1c8f041cbfbb50a27e298f961abdcce7e36834ac39e1
+  md5: 9ee0da74c55d0b8d83edf246fd717f20
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89862
+  timestamp: 1696347657368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+  sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
+  md5: d8c1e9910392d0bcb22a173f9ce30fa6
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1758290
+  timestamp: 1714488307689
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+  sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
+  md5: ae58720a18a2ed15eae214ad7a10d1b5
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 140125
+  timestamp: 1680167256603
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+  sha256: b5c265e9ed9a1ff2238a09b83bdc1826950faa87fd6b685debe60888de6e7a50
+  md5: 5827c8a32317894ce18576e334daba47
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38559
+  timestamp: 1677918962258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+  sha256: cfefd86d0f4981d22b7611b3dc60359b8698bf39f2b743cb90b7005aaca88e1e
+  md5: a04dbcd6095f6b8f3ad195a78d48b262
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50058
+  timestamp: 1677917499177
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+  sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
+  md5: 3c25b4f4768ccda28b20a03ba27e7759
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3484151
+  timestamp: 1714770744982
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+  sha256: 0836468fafb1f5badbb573922e37200c6929bf2926ecf8d2259dff43811e0727
+  md5: 5bc56dcb4bdb7cf623b7cea499feaddb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 136409
+  timestamp: 1677925889207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+  sha256: 177246487449f87567fe56c8f20011a4350a132d1556c9f87474d7b2e8c1374f
+  md5: d465118217b9f27d47dceff89c2e9f95
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 896655
+  timestamp: 1696937042980
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.2-py311hb6e6a13_0.tar.bz2
+  sha256: 70496999384061690df49fe640fcc6d0437ce876d3096dc89c6901cb2bb63845
+  md5: 72dbbceca6984601d78c2bbb796edb66
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 155676
+  timestamp: 1714567815500
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+  sha256: 65e760119352cd85c63d365d2576c09a9ddb060e5b029a265d50bc268eed9290
+  md5: 14c241871b12dc3be52e6cd681267caf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 271445
+  timestamp: 1677911758960
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.9.0-py311hca03da5_1.tar.bz2
+  sha256: eb3608b1f32c4a791ca19a69cf611e470ec7bb722e40f27d3e5f6dbc76c69ecc
+  md5: e4ada62e242b4702435995090405d693
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.9.0 py311hca03da5_1
+  license: PSF-2.0
+  license_family: PSF
+  size: 9874
+  timestamp: 1705599390176
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.9.0-py311hca03da5_1.tar.bz2
+  sha256: 0899503a82d0e0a765a7e9d1a0480c3b1c389f4d6e68b633400271380172118e
+  md5: 224636c70a8945f989ebf39b8cfcf52a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 71941
+  timestamp: 1705599383532
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+  sha256: 2ea2d0520b330d381a2ab241bdb9ae146ef815ee7c96ee52a9773fb9ae85f4fd
+  md5: 66f7f8979cfb2cccffac972d70482130
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 12614
+  timestamp: 1677963554857
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+  sha256: df7fe7740bd853b641d624e2ec97f1aacb2b82691936a8c04ef18fa9768539c2
+  md5: d5c7626d45fd03b22797c18e47812beb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 518048
+  timestamp: 1713213046424
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.1.0-py311hca03da5_1.tar.bz2
+  sha256: ec56a4893344adc6712b9915267bb5faca7203496f8ad924cba7ebf2cec302b9
+  md5: 7dd5b6728562eaa24668abd062985f4d
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - zstandard >=0.18.0
+  - requests >=2.26.0
+  - selenium >=4.4.3
+  license: MIT
+  license_family: MIT
+  size: 184702
+  timestamp: 1707770626151
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+  sha256: 20ae100fd04de16356f26e7c9dab514015e57a9d54fb78767aa5ed97de7846fb
+  md5: f620d98b3d0072945948310c86f0f1c5
+  license: MIT
+  license_family: MIT
+  size: 157385
+  timestamp: 1706894678643
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+  sha256: 09738b7f9075386bf062b12ddb6fb72a06450d2481f6b5ca2026c811cd849569
+  md5: 9afdec076c95746ac21235f971190e40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26727
+  timestamp: 1677910175964
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py311hca03da5_4.tar.bz2
+  sha256: e7e149717c2a2f69f4e80a97aaeff1e929309abeaacf856020e709a9663df561
+  md5: 2ea9e4e91d48d4e0697990e52d1c2b96
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 91423
+  timestamp: 1677919120338
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+  sha256: aa301d9e42aadbe3dd5f301ccbf17fbadc347fd37d413c0cbcbd24403892a936
+  md5: 77097d17d835a137af7950c628b66150
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 137260
+  timestamp: 1714717037687
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+  sha256: cf030fc7020dc6d28530075468b8dc1edd843a1e393a2f81ca81c962e9af977b
+  md5: cae3fc90233f3af8f433a253d035b6e6
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2470844
+  timestamp: 1689041497962
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+  sha256: 2cd108896df65636769e3804ecc2ca421ad9b54e64fa21922bbabe40c90c247a
+  md5: b3a1e5077b28f71298d891fbfb5ff03e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55645
+  timestamp: 1677927459979
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+  sha256: 5be8c968f2da5c4bf14f28d63e31b4c1b6993d980023769732c7f58f396c2e0b
+  md5: 3f5f62d4e85e3bdd48d39189b01805a6
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 459197
+  timestamp: 1714510992914
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+  sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
+  md5: 3d57d1adadca9388aaaa1c529b65ba65
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 322790
+  timestamp: 1705602163804
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py311hca03da5_0.tar.bz2
+  sha256: db7fb95af4702cb2ce5281333fa769006f532bc39e8e5bd580a2eb9970a7a38d
+  md5: 2c13d5a0b62ff7a644a6957829dc54a6
+  depends:
+  - heapdict
+  - python >=3.11,<3.12.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 103248
+  timestamp: 1695832909752
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
+  sha256: cf38c69cf62d8f07b91b14bef8e0b6fc5ac220bd3a6cd2ab0378283f0f11494a
+  md5: 11660f745caf5eed1d03eafadb32678b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 25470
+  timestamp: 1704206932876
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+  sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
+  md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
+  license: Zlib
+  license_family: Other
+  size: 104928
+  timestamp: 1714510936868
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+  sha256: a3f3eaf240991b6bd7b0596a78d0abb3321cc79db52fa24f6f559189778871c6
+  md5: 71f035b4716322539e2461cb6667e946
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 825339
+  timestamp: 1714678419523
+- conda: https://repo.anaconda.com/pkgs/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
+  sha256: c5a4f98a90713f799a73195cc159571c4bd373bfa43640dc0c1707608e582945
+  md5: 537f198da93942d8ef7008606edae551
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2363136
+  timestamp: 1652426285158
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+  sha256: 6e6787755de0cf2fd776c9681a7b0fd0fb23e35e679a463cc2005b991c413910
+  md5: ccad42ec9a2ad48939f089c528abc8f0
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 229694
+  timestamp: 1706220431719
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+  sha256: f715f7c2e06149bd6d43258e41479d3171efe5e9d56050a0a5f5652ed9d05fff
+  md5: 11a8ca43d69881b88f95ae681478866d
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 36089
+  timestamp: 1676424516042
+- conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-14.0.2-ha81ea56_1.tar.bz2
+  sha256: 5d0903878b06d0a444fa43444390f3b662f6338750e23ee2817c784246ff7098
+  md5: e0fda639825394bcb3a87b639c0d7a11
+  depends:
+  - abseil-cpp >=20211102.0,<20211102.1.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - aws-sdk-cpp >=1.10.55,<1.10.56.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-ares >=1.18.1,<2.0a0
+  - glog >=0.5.0,<0.6.0a0
+  - grpc-cpp >=1.48.2,<1.49.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.13,<4.0a0
+  - orc >=1.7.4,<1.7.5.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.9,<2.0a0
+  - utf8proc >=2.6.1,<2.9.0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 9794512
+  timestamp: 1707254932864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/async-lru-2.0.4-py311haa95532_0.tar.bz2
+  sha256: 6acc4dc697147467d128382439a1648f2dc6c498d0a97aa9c44ef5de2962cdc6
+  md5: 8baa05a5d81f5f0dd92cdd60fd509486
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 21308
+  timestamp: 1699554782283
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+  sha256: 9adabcdd2a10f73fa5ba56adc901eeea2e379991a0d4cb9737eec7aa6b9fc5d8
+  md5: fc80b572be85601706d425b21a58d497
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153102
+  timestamp: 1695718054194
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
+  sha256: a11741c5aaa360b4772d0fb7eea606edb5266a4e2806b22f0b8b65b69b7a7273
+  md5: 9a54285c5e75ab5e6bfcb3b5590f9449
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 93395
+  timestamp: 1706746331576
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
+  sha256: 32b4da68dd0edbf0c8d7a8a18ba400b26775faabaccbc2cb3e9d2ab7c65e7714
+  md5: 48f0a7a7f739d8be4c9dd061be217619
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 45714
+  timestamp: 1706691182873
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
+  sha256: d2710c7f5b4bb8f94a964996387fbd6396f9881d163affeb7ffb050a39e58c1c
+  md5: 1a8a2f82798a94d1b272ec2d307cc5ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 195487
+  timestamp: 1706190077309
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
+  sha256: 0a5ea74ebcf9bdccfad972add8ff83a47992ab28370cebc34fc4594c1c7cf03a
+  md5: 2f90d407ca685c124ddb5fc4d79f4517
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 21804
+  timestamp: 1706690937014
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
+  sha256: 334d2d9c4181c9955256485f66bf4e48ae9b1dc03044aa0424bf1fda292b3151
+  md5: 9ab57953af3164d3d94001eeca0e6359
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52661
+  timestamp: 1706697357084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
+  sha256: 59155d1258b4e29c0046e5ab14b1e2cb3ccfca069982fe9dd4cd751b1ed67492
+  md5: 28bd7c351db93c3b8520cc1598eddf66
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-compression >=0.2.16,<0.2.17.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 177605
+  timestamp: 1706744253596
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
+  sha256: 3aa9b1c2c508a5dcfb482083cb986498f6df460e652cc7557d3c2d122d559ebe
+  md5: b8bf7ae26d234b6738fc37b7c172b3c5
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145865
+  timestamp: 1706696287610
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
+  sha256: 68564155186523ec8b97b892d0a6b62b3e6f75e4e2b80fac5684011e070295d6
+  md5: ba2fa531a69a5a7e4966eba6d7891c8b
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 69542
+  timestamp: 1706746839018
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
+  sha256: 9c0f2f18f8b7e10e940d2438d70a2a03893421f25fd50461b8b2979f3a310a15
+  md5: da0f3ce6d8f71a71e6cae01832d853f5
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 72614
+  timestamp: 1706747680710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
+  sha256: bcee1da236f6f5f88322979daddc89e8555648593f6282ad3073a68eb22a68d2
+  md5: bf4c19b0db5049930d8b2fcc3b9172fa
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51027
+  timestamp: 1706690972693
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
+  sha256: 32561df1e664cb320f79c26c5af23dd55953924e66824e2d6372a44687147bdc
+  md5: 05f4c6715180a992468035c0a86e734c
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 54300
+  timestamp: 1706192197648
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
+  sha256: 94d2fff3facfd248968d39a3fd7d3b1f7270df32a87dd567c33d60da1a5eb064
+  md5: 64fed6e7c73d88bfbfc39e838022f948
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
+  - aws-c-s3 >=0.1.51,<0.1.52.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 199877
+  timestamp: 1706827970924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.10.55-hd77b12b_0.tar.bz2
+  sha256: 813f252df10d2782fbb26e2c6348f55d44ef1618467e340224df44bcda4814ff
+  md5: 8efc1448ada827ddba894a07903808dc
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2519847
+  timestamp: 1706890866084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/babel-2.11.0-py311haa95532_0.tar.bz2
+  sha256: b94e6065a6fec9259eef85dc952c59bf20e854682cbf934f04a0c2f1ac2417f0
+  md5: 50cfce72575fcdf3757c27bc6ba5d0e9
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pytz >=2015.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7218701
+  timestamp: 1676427266094
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+  sha256: 38ccda1553733326d99a75436b4b0f7640bafbbfcdbc33838b0e59cf017de687
+  md5: 3f6812578c5e0b3ba0d2a651cc766c15
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 266405
+  timestamp: 1681493141116
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
+  sha256: fe765d810e1612af7a42f34223077f0adc05dbd386b257be24661913d067fe30
+  md5: 82e988aba03c8afa03fce78f7442806e
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6086137
+  timestamp: 1712084583317
+- conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+  sha256: 68ef338b27c035add89c0812ad469dd8c9e94f27130f770345ea20deb049d50b
+  md5: 9ec19b145f655329532b608963cf32f4
+  depends:
+  - libboost 1.82.0 h3399ecb_2
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 11334
+  timestamp: 1696764270626
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+  sha256: 5c12a5d7856d9977447360b3a99a5b99818707fe79781ba1779037f11b3fef53
+  md5: 6a125ae352306a944aabc635a5fe13a3
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 139230
+  timestamp: 1707864402762
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 751071782f597f87ed7f67437ef6cc669213902461b9795dd6eb0f4897eddc83
+  md5: 5ad8fe62aad5e16cfdf2c5a7d1327fe7
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_8
+  - libbrotlidec 1.0.9 h2bbff1b_8
+  - libbrotlienc 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 19418
+  timestamp: 1714483531456
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 9bd62d810867549b9c967c5915f3fa3f66cfbd6ede28b1cc152efd1261285c0a
+  md5: 64cc76de3662b62bc8f0e42befd92c5d
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_8
+  - libbrotlienc 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 32178
+  timestamp: 1714483513837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+  sha256: 1547fa52134cf06b8d01bdf52114db7db60a89bf35c9c95be5b5a03b13dbd565
+  md5: deb765cb7c4b7edc4d126f864f31747c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 356401
+  timestamp: 1714483740924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+  sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
+  md5: 11e0af09a31e2d5df51c65a342032b85
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 112994
+  timestamp: 1714511182837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+  sha256: 41a6c5a90b88ec7010bb6dd89390754e476b52c3ab2d519bdab9556da8829479
+  md5: b047426a545e287f45e8abfbfcb0de55
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 118041
+  timestamp: 1693902191485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+  sha256: 73391a74a5300ad3fb063ea0f0c3491d220128a0611a84036da2e23c1e93dc0e
+  md5: 501ded4f9b5ed895077802defee912cf
+  license: MPL-2.0
+  license_family: Other
+  size: 171644
+  timestamp: 1710764856021
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+  sha256: cd6545642e380b13700f2f2a7a1fb54a273365047bd23108dbd03b197f5c0c9c
+  md5: 929edc1c553d2da4d6c6c0745b033cc3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 166377
+  timestamp: 1707229328635
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+  sha256: 5cb6ac90ad234248f3795945f69b0382397714a52712337b2f86339526b822d8
+  md5: b90f3126f6315ea2e8ab242533062557
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 302693
+  timestamp: 1714483562551
+- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+  sha256: 7153817dd49ec317b519802c7c22c836602e00cbd96d68385e83eaf4c9f5ba6a
+  md5: cd829e5997611a602e29fa2fd5882635
+  depends:
+  - colorama
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204113
+  timestamp: 1698130080270
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
+  sha256: 03f00c22b6d92ee55b727b369e8dbdd9a4d590f2655b62b7c45ecd046741858e
+  md5: 116f67c13bb0b3caee6cbde334ff6abb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49934
+  timestamp: 1683040303796
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+  sha256: 4099898f02e1f6119fcda65e747c3cbfef0bf563c8855b79a0245160709d5b45
+  md5: ab9705c34e67fb8c8faec69d63ff4064
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36410
+  timestamp: 1676422341506
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+  sha256: 8fb3e816a5ad1da05125462dbc9e2a7e933b001a871aa65703802c0a894c6277
+  md5: ee4b2fa9fce130496d5c7c86c35a1a05
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17723
+  timestamp: 1709323150229
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+  sha256: eeb49cd151ecdccd40062e8123a3b7a9a8a1eda6567dd33ce909ff8ee1a97c89
+  md5: b7fe1f7ead1ec2ac642d022942282fc8
+  depends:
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 232451
+  timestamp: 1700583772701
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cramjam-2.7.0-py311h005caf5_0.tar.bz2
+  sha256: 97def042390c467aaaa3f4c33276b0c134c40eb426695332673ed1173f999258
+  md5: 13d97f9f5f7b1f8808e4a694b3305f15
+  depends:
+  - m2w64-gcc-libs
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1384742
+  timestamp: 1702664451643
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.2-py311h2bbff1b_0.tar.bz2
+  sha256: 037aab9c08cd8f7e78e65b602b3c2b61a7c812b270cbea15bef0e36d0305db6f
+  md5: b4e5dd983a62a7c27d73900400eab7ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - toolz >=0.10.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 369375
+  timestamp: 1701724118486
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-2023.11.0-py311haa95532_0.tar.bz2
+  sha256: 07c590287f10f1dd3cddeb245a8b0ff47e407c9c4847d865c970117c27f927d9
+  md5: 7443c06200da9d46add828acd021e4b8
+  depends:
+  - bokeh >=2.4.2
+  - cytoolz >=0.12.0
+  - dask-core 2023.11.0.*
+  - distributed 2023.11.0.*
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.21,<2.0a0
+  - pandas >=1.3
+  - pyarrow >=7.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6038
+  timestamp: 1701444864356
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.11.0-py311haa95532_0.tar.bz2
+  sha256: 132d5f66fb9c6b2093c5c066d3fa6ac1468d1bd3fb3b26816556f3c4c8e4be08
+  md5: aace1519be879e46f0cbc9e62bd5a4ba
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3086382
+  timestamp: 1701396440772
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+  sha256: 5c73f86e575f2ad683ee4a1c2df11020e270edd89d12f11199483d57b0b51826
+  md5: e96a12895ce374476277b1b196ba24bd
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3719519
+  timestamp: 1690907216785
+- conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2023.11.0-py311haa95532_0.tar.bz2
+  sha256: 14dd722d920d5665f456ef7493b31fb6420c622045dbbf59bf0d8ea5063cdc3d
+  md5: 857a10ff7dc92814dfec2c430655bf16
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - dask-core 2023.11.0.*
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.0
+  - packaging >=20.0
+  - psutil >=5.7.2
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.10.0
+  - tornado >=6.0.4
+  - urllib3 >=1.24.3
+  - zict >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1807075
+  timestamp: 1701398374335
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-2023.8.0-py311hd7041d2_0.tar.bz2
+  sha256: 59100f20fb5ad8ab300e7db8d461f3364a38598ae09131c7e135660d88101f93
+  md5: acd0953107d9f2e222225e47485acb16
+  depends:
+  - cramjam >=2.3.0
+  - fsspec
+  - numpy >=1.23.5,<2.0a0
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 531570
+  timestamp: 1696542815866
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+  sha256: 27fb03eb57d25711a15e145f47a64320a9955b585efc9fd0a1a51cdd71b9fde3
+  md5: eb3869e98f6f53dfec76e2eff4d6b61e
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 2732423
+  timestamp: 1713552175344
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.3.1-py311haa95532_0.tar.bz2
+  sha256: c906de92968266d481957c5776467523da53b7f4d6daadb63255bd5cefd252c3
+  md5: 2710581e3de1c90426c77e4b73185262
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372660
+  timestamp: 1714461880258
+- conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+  sha256: 7cb0df7aa62796b0081e1708003529c02411aca6a540bae97beaec919aa64e74
+  md5: ea81fd813e10055553a8d7597c8be98f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 322778
+  timestamp: 1706888324269
+- conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+  sha256: ed1fa1a40c6739b48ff3a2d51c3df20e4983b59684b04d93e1337c5f2e93a954
+  md5: 1797f64343a42395207cd452e6a6a751
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94476
+  timestamp: 1706895442146
+- conda: https://repo.anaconda.com/pkgs/main/win-64/grpc-cpp-1.48.2-hfe90ff0_1.tar.bz2
+  sha256: 0c6223208742064a2829f8dd658e04b72f5176e357a1320c0b0398b91abfd292
+  md5: 19c77d6709407253582fae939434016c
+  depends:
+  - libprotobuf >=3.20.3,<3.20.4.0a0
+  - openssl 3.*
+  - re2
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 31002375
+  timestamp: 1685747992041
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+  sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
+  md5: 582d2c1135a89da757a038de831e7f39
+  license: Intel proprietary
+  size: 11086648
+  timestamp: 1664812389803
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+  sha256: 945f4521793d7d279532d1ccd5157201c5cbf64f846bfe60249d01e1b4edf295
+  md5: 0accae23d095c165ac731f4a1f3ca497
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 37021132
+  timestamp: 1692294548916
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+  sha256: 102c803186db6d62eaf41a906f6c563ff0d62b53c1eaede8a381e18c0d005ed9
+  md5: 9d30dec03058758a428cf152e0ae28b5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148193
+  timestamp: 1714399061601
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+  sha256: db30abacf919b3f68ae1e6a94c467fd1e69fbf47ba7a86e6b491d8bfe4776f92
+  md5: 9299876e7ddc3aea3487fd93340ceae7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 50842
+  timestamp: 1704813715071
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+  sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
+  md5: d215cc8ee7ca2cc83cc250cc5d822fe0
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3929136
+  timestamp: 1699647939158
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+  sha256: 864e9598f64105769b4ec02cc404fb507bc59e217324daf1686c00cfd12c0055
+  md5: 6bb1c3be1f85799a3988afc2c3c5a4f0
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229621
+  timestamp: 1705934494547
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+  sha256: e0b44f0c3a4ead0fb8e58033c0be25524ee9ecf7f4cc632f03e9f6fac3484baa
+  md5: 50cbc18d0c7b42a4553b52d0cef2c857
+  depends:
+  - colorama
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1637367
+  timestamp: 1704834149957
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+  sha256: d81566367c79a28d4717157fc74293e846a47af99387ed479eb001a425dd398e
+  md5: 28c76079c96ad7f8b1a5ed32b438c79a
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1147434
+  timestamp: 1679427525584
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
+  sha256: f766a445df8e81447f27c830e162566b221fa1bfc41296a6c5e0789586ca1fbf
+  md5: 55bc50633414fc8616ccbf4140a42d5f
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353715
+  timestamp: 1706733949898
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
+  md5: 81f2c343dc4c65eea39c45383272068f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 407861
+  timestamp: 1677849239400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+  sha256: 5e6698015a3b048093f5737f0e54bcbae415d0f9682dfdfeae3a8cfb4ea275e2
+  md5: 0093a4214131046c4f68af0739dfbea4
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 201456
+  timestamp: 1699041872445
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+  sha256: 9581be54128954080d7cef448b1728874c2ebbe5064f55adece422cf12eafa5a
+  md5: 3adc105f87d5c7f0b1248bc3423f5b48
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16187
+  timestamp: 1699032556953
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter-lsp-2.2.0-py311haa95532_0.tar.bz2
+  sha256: 2fd9671118852dc700897fdb980a323287f40880f2ef19864e78039049f84563
+  md5: c3ab03d0742e6ca173838fae93247b04
+  depends:
+  - jupyter_server >=1.1.2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101303
+  timestamp: 1699978449116
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-8.6.0-py311haa95532_0.tar.bz2
+  sha256: 4772d37293b0350a3fbfa9b16d0b279544c753f78371b352013daa1d4769a78d
+  md5: 5cd7415248e27a289f9d6dff9b600a73
+  depends:
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 258542
+  timestamp: 1699456032957
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+  sha256: 851ae576c2b72bf3172cd460feec4f5577dc06476a043e185279071b67549fab
+  md5: fae4d214d00de6604738f39acbbb197e
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119710
+  timestamp: 1698937651636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+  sha256: d97ad90f9121ecf7f8d3af773b222c0bd244204ee73a3e44185491fa16d83104
+  md5: 73ac0fa3c67e5eb283173d74a2771752
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 60625
+  timestamp: 1699282918176
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+  sha256: 257e1102d2dc3f8b0c1708585c819e86f41abd101084cd0569e8e31652480875
+  md5: 2128c6806bba6953e1a275f37e7a295b
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pywinpty
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 614705
+  timestamp: 1699467242943
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+  sha256: 90420847230e72a648417f5f77cebcf7f17b89f70788652c276acc0c440e135f
+  md5: ef3d8dee197aa37897bf6d39d2dd878f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=2.0.10
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27639
+  timestamp: 1686871052174
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab-4.0.11-py311haa95532_0.tar.bz2
+  sha256: cc3eb5e2c513fab04e2740a093f9c44f0355f746ba4cbfeacc2ecbbd08d7096f
+  md5: 729d6b5a3d58c98e8ec73afcb59e0d0b
+  depends:
+  - async-lru >=1.0.0
+  - ipykernel
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.19.0,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  - traitlets
+  - pywin32
+  constrains:
+  - nodejs >=18.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6714941
+  timestamp: 1706809027799
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_server-2.25.1-py311haa95532_0.tar.bz2
+  sha256: 066d78020fbe62fa9401979852ddbeff05f8e9faeec861487cb2662b9b5d39f9
+  md5: 2f7340345dee00a18c766c1c1472fca3
+  depends:
+  - babel >=2.10
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18.0
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.11,<3.12.0a0
+  - requests >=2.31
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 106966
+  timestamp: 1699555552806
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+  sha256: 8a2f0909fad0387e57cb0e9ee30db2b20761a9106e794381ffeac387a298fb07
+  md5: 6058b2efc3284e27aacec2e6e6280433
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62334
+  timestamp: 1676432044242
+- conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+  sha256: ef6b0347ae565dd648a2bb40bc8b0b30f2e4f8387778fefced1d581b7d5a3e16
+  md5: 8ef1d5919aa55fe56ef34d9a7969dca7
+  depends:
+  - openssl 3.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 861982
+  timestamp: 1684424430941
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+  sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
+  md5: f5f73266281ab12377d5d47bdf07500a
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 905072
+  timestamp: 1617648814933
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+  sha256: 4184dd040fc38cb123a98588a8344aa8d1ba1932df5fcc6c188f6b21f5a0c306
+  md5: da58cfa83f3d6c31ae12d8777cd1b64d
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 29803292
+  timestamp: 1696764164248
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 7c906c94a4d46ea963080a6ba5bd12c1274da66159877a544fbc70291eeed98d
+  md5: 45a3d52534fac8aa54a55ee92211a918
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 80216
+  timestamp: 1714483371043
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: daad7edc6d56abf3e176479e8628162dbf1c56b3d24db30d708aebae694a5214
+  md5: e8ecf229f7fcb4c0b76d8613627948f5
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 45189
+  timestamp: 1714483420152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 84320217abffa9386186ec8d03b4651bb4b1900d3871adc965a9a9e1d3799907
+  md5: 651312fa22168f71f9aec5f9ee2c2fcf
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 756116
+  timestamp: 1714483464368
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+  sha256: bb17beae8860a83d081d57273825b46bf8fe9903f3b4182ab41a7ae2c7274859
+  md5: 94182f4ab8beb4eddfd8167b2e2b0380
+  depends:
+  - libclang13 14.0.6 default_h8e68704_1
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 147804
+  timestamp: 1681225547009
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+  sha256: 01b84a38c9069e7b8e6fa2a07707e785df7d40b8f01d76a504e98e5a5cd58539
+  md5: 22c9f7e59174c49f06e3c5c9384401ce
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 25699299
+  timestamp: 1681225463612
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.5.0-h86230a5_0.tar.bz2
+  sha256: d505283d2d3a94a530b341933d3047662d3481d88826ddf68bd78935c0fb94c3
+  md5: 1e9446c8a7f39247834fe0bd16d3edb0
+  depends:
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 338561
+  timestamp: 1704383910302
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
+  sha256: 6458c7a370c4e3366b3b208c5b2834a7acfb17981e47fe3fb861f225d7cefbc3
+  md5: ecabf4acab5b604856d8c7c4278c2c2c
+  depends:
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 446380
+  timestamp: 1685052520132
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+  sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
+  md5: cf949d76148be1e2a534218d9c57df86
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 155435
+  timestamp: 1714484319443
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.17-h906ac69_0.tar.bz2
+  sha256: 54b46079c184c286b2f91575d3b5917bc3e6737f06885a50426e3263227c8a00
+  md5: e4d2859474935b4873e48b09ef30a95e
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - openssl >=3.0.12,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  size: 3763163
+  timestamp: 1706215177824
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
+  sha256: f7368e611e349b91315ce4ba4dbf9116d996a48f98eed425f4d5c3d5b9fcfa5e
+  md5: 77eb9daff9052f1fbf24d91c5bba1d74
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2543079
+  timestamp: 1675278760037
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-he2ea4bf_3.tar.bz2
+  sha256: 710583b5a497bcf272fd084d935cbaac637971e33d66179de3fc5e6893dac3db
+  md5: 78ea474a8843c52f4b4fc24289593a54
+  depends:
+  - openssl >=3.0.13,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 242393
+  timestamp: 1714511648937
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
+  sha256: 238e486a0d62264e7ab35098bdc0390fb9a4649921b18827228c811ae8252c88
+  md5: f1ebe453c5a955a25e4b00f73279fc42
+  depends:
+  - boost-cpp >=1.73
+  - libevent
+  - openssl >=3.0.9,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 894777
+  timestamp: 1687975823684
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+  sha256: 4534c822511a052a72c2b070a05e5d8d6f3550f18ea00a33f9d8a9a92b4382cc
+  md5: 82f24e7660831445a2183216e280a6a4
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41464
+  timestamp: 1676474474981
+- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
+  sha256: b2b50fb4e43e4c4da8db26cf362671e03774384732e1925d82e12dfce45c5ac3
+  md5: 44ff317b1ff9bd2b1fbf39da56965b16
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 20842990
+  timestamp: 1706911120234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+  sha256: 896b7a39bd4ad3621312130122b4fe84dcb67d7355166255c58ea9bc562eb0ae
+  md5: 640b852a56296f48cf073e61a59c5256
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13751
+  timestamp: 1676428354074
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.3.2-py311h2bbff1b_0.tar.bz2
+  sha256: 5d7d4142cd2c91d151d26b7b22f1e4bd2357bcc5ee6b56516552145b43a6d022
+  md5: 35b521ddf937dab77b7720d3640761d4
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 86304
+  timestamp: 1686058058871
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+  sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
+  md5: 320f40b75d93f3b96931c6d13c23946c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 158902
+  timestamp: 1714512129889
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+  sha256: e0dc6e119b224bb31ef34b6ba270ffadc181d38b698c5318de8df7a5d2c4ccbd
+  md5: 992ccd756f09408f0b74dfb9852a8b7f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 182381
+  timestamp: 1676437963591
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+  sha256: 050b5fd4b28132d8102a7e6b40179894dc7f5e41f7ad9ee19211e67446c5740f
+  md5: 3ae0b2f6baec708554648ddafa81b756
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 154386
+  timestamp: 1684279992864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+  sha256: 8269c73b7a9c03b95a121e318d0468f35eecc016093620b0560f35238cc5df51
+  md5: 2914bea0ae29315f998e1abac79ccaa8
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30214
+  timestamp: 1704206218108
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.8.4-py311haa95532_0.tar.bz2
+  sha256: 3df5732260bbd26c10421edbe7c146326e8b1af96137e4eba70aaa246f7aaa23
+  md5: 24a282628090afa5e3f53795cc3529de
+  depends:
+  - matplotlib-base >=3.8.4,<3.8.5.0a0
+  - pyqt >=5
+  - python >=3.11,<3.12.0a0
+  - tornado >=5
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8759
+  timestamp: 1713337289997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+  sha256: 68fb7d113dbf185b571343847e3dbefdbe7d0b9b5902f1f390bc2a6e33a3f8ee
+  md5: a72ff718390a1fde0b208a43e6b9b655
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 11366001
+  timestamp: 1713336740870
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+  sha256: 43279276850eb6e621812448cddc1093524cee0b7f8ed58b4600b68a4fb659f2
+  md5: 5968b2b5c1f3cf5c8c8c9aaa4d8d66a2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19886
+  timestamp: 1676425829787
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+  sha256: 3062a8254ca351b54f15bea85cc928a3ba4d879bb98ce97ece39a9f7eca215a5
+  md5: 8f1565663abb34ad7fdd512e76da5532
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 68031
+  timestamp: 1676481862508
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+  sha256: cdff5215c292fe59649ca40ca72f5d26da352760c1d6a56feba14eb13f7bbf61
+  md5: e0f3f32b22135dfeaec277bc87183ca9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23328
+  timestamp: 1676442709081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+  sha256: 3b173a25605d2aaacc57ec0e425f1d1c51327eb2521c8742a736e2c76069bc8d
+  md5: 169f1c93a443f95a88665f3008623ce1
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104882
+  timestamp: 1676425142412
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+  sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
+  md5: 527155127b9fada5e5c5c69a624674b9
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187498166
+  timestamp: 1699648376430
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+  sha256: cea59ae60da314caecf08edb9bcb03126c6dd35837c8184bceaa194decca3341
+  md5: 30936b7263cf0171f7c86400f12ef184
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49080
+  timestamp: 1682975093455
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+  sha256: 5070ceb0a406b1b8b99e2ec58f5d224cbe16ec78109c46720bd182b509e05c6e
+  md5: 34de1af5c639f2d06c6c8d99488e4226
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 196201
+  timestamp: 1695058367111
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+  sha256: 6b4b27302e458fa527321c59be7c335d61f86da7501c4d141db20a72fad68b55
+  md5: 7db9b12da1290bb2c2fc6ee52a945905
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 256371
+  timestamp: 1695060425702
+- conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py311h59b6b97_0.tar.bz2
+  sha256: c09c5ed3f07731091958ea6ed06a1eaeaca1f7e1361d341fb06b344d51074ca2
+  md5: 520c04235cf0980e1ce908e893b4dc71
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 37775
+  timestamp: 1676427521514
+- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+  sha256: 39f09c1bc57b4800ebda331eddb462928435498705351b0432d51a4293294ad8
+  md5: 5565984a02f41e97cb9a4c9126ced14b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29808
+  timestamp: 1676442800892
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+  sha256: e940f9178ee2fa0a7c12873ae35ebea0074371653e5cfa1be8aa8d9271fd343b
+  md5: 355d0835215911738a28010dfa6aa382
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141785
+  timestamp: 1698934346590
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+  sha256: 47dd00c0179f4eb29c70d0453d340f7f5332af326b3d51c64ca3bf6a14be8e7e
+  md5: f66afe718bdb57667b03ebda4cb2ac7e
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 561655
+  timestamp: 1699023338436
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+  sha256: 4ee863a1ff697274c642b3101f82b279a354e3f033a87505655039f89127bb41
+  md5: bfaf19be6644ad2344e118aa0acccb13
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189809
+  timestamp: 1694617194065
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+  sha256: 90fb3f14c49da1397982eae21cd09e8d60d491d76f94c57590c56723fe6dc172
+  md5: 46a523661fe5c1bce7b4213fd428c3de
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16732
+  timestamp: 1708532795328
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-7.0.8-py311haa95532_0.tar.bz2
+  sha256: aa72c6e127bc394de0b570413912e0625759ba10248fbf884928c9ec3ed6fa70
+  md5: 1cdaa20793e8f70874ade8136e1dd5c2
+  depends:
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab >=4.0.2,<4.1
+  - jupyterlab_server >=2.22.1,<3
+  - notebook-shim >=0.2,<0.3
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3681116
+  timestamp: 1708030716052
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+  sha256: e040ebcab948325fbe17e4ab15be62e1fafa7bad225457e59764adb60eb40db5
+  md5: 4d40a09df8cb74a9f044eab317436d67
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27282
+  timestamp: 1699456187703
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.59.1-py311hf62ec03_0.tar.bz2
+  sha256: a20cb730d87b945125202c7f4e81490c24db708f373d1214e6b04f5d2b4177b3
+  md5: a235c61c1928d09080158ffd42ffbccc
+  depends:
+  - llvmlite >=0.42.0,<0.43.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - cuda-python >=11.6
+  - tbb >=2021.6,<2022
+  - scipy >=1.0
+  - libopenblas !=0.3.6
+  - numba-rvsdg 0.0.*
+  - cudatoolkit >=10.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6100005
+  timestamp: 1712021687877
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+  sha256: d3bd2a6614bb7e7f5ce3348d6674e71cce45cbde236beff32f0f08cd95a64ef0
+  md5: e70f15643164f432d1df68635e7c322b
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 162691
+  timestamp: 1696515822068
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+  sha256: 470fe9a0b3e196fa60d5550d8188f6074a207572fa0d353a4448d580872e7804
+  md5: 6fdb8df0613fb2fb9f1732d335fa25f1
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311hd01c5d8_0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11053
+  timestamp: 1708641901110
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+  sha256: 222c1711e7cf151e29077c7d4d86a865c9fd39615812d58a1daca6fd1b6bdfb5
+  md5: 585bcd8bc3940a8a859f38ebafdcd77d
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.26.4 py311hdab7c0b_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10723862
+  timestamp: 1708641867155
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
+  md5: ab07e2a27ac08afe3d0b4c0890b8486a
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 2-Clause
+  size: 249316
+  timestamp: 1630094024143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_1.tar.bz2
+  sha256: f98936bd261c37fb1c2d303885a0bd55cea87e2c86c6e8c6ca56c66b9079e852
+  md5: ed1708ace63b1ef7409474eedf0db1ba
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8087040
+  timestamp: 1714514472258
+- conda: https://repo.anaconda.com/pkgs/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
+  sha256: 417cf23716f17b6daf2b717bbd69240aa9440845dfa415f59a97961794632ce5
+  md5: 36d709d47c43a3e9b43f23cf4edb6438
+  depends:
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.9,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 877890
+  timestamp: 1676482911485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+  sha256: b2f5f50a1ddf811102636f3acebd76716c88ebb628754b91eda7a3a962adf26c
+  md5: 712527b4d84c350dca4b67f511c04414
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39421
+  timestamp: 1699371341381
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+  sha256: 432b8b7c4671878cbbe361e518544203f97bd2e4f24fa08cf65e8be583f25529
+  md5: e62e7c668b080e0f6ce09fd548f69f7f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 159066
+  timestamp: 1710809127954
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
+  sha256: 3ae55d8148580fc3f171c0fcc420488fbba05517cefd358fe013b45ec3594371
+  md5: bfb42ed6826a1c8cded9539fc6e07029
+  depends:
+  - bottleneck >=1.3.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - python-calamine >=0.1.7
+  - xarray >=2022.12.0
+  - lxml >=4.9.2
+  - dataframe-api-compat >=0.1.7
+  - jinja2 >=3.1.2
+  - zstandard >=0.19.0
+  - blosc >=1.21.3
+  - matplotlib-base >=3.6.3
+  - adbc-driver-postgresql >=0.8.0
+  - xlrd >=2.0.1
+  - fastparquet >=2022.12.0
+  - pymysql >=1.0.2
+  - gcsfs >=2022.11.0
+  - pandas-gbq >=0.19.0
+  - xlsxwriter >=3.0.5
+  - pyarrow >=10.0.1
+  - html5lib >=1.1
+  - pyqt >=5.15.9
+  - psycopg2 >=2.9.6
+  - scipy >=1.10.0
+  - numba >=0.56.4
+  - qtpy >=2.3.0
+  - openpyxl >=3.1.0
+  - adbc-driver-sqlite >=0.8.0
+  - tabulate >=0.9.0
+  - pyreadstat >=1.2.0
+  - pytables >=3.8.0
+  - beautifulsoup4 >=4.11.2
+  - pyxlsb >=1.0.10
+  - sqlalchemy >=2.0.0
+  - s3fs >=2022.11.0
+  - fsspec >=2022.11.0
+  - odfpy>=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16924671
+  timestamp: 1709591125871
+- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+  sha256: b0d7fbfcf1c5c682ed9934eb6a33e00a2517941f2bcb9d677379f4bb73b2c45c
+  md5: 20c8f36595a48f5cda2f4f74c02a3ea2
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48206
+  timestamp: 1698702818841
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+  sha256: 6ca54ba8ce430caa8a1838b19869814d0b7fa3592a77f75298130983e635387b
+  md5: e56c194e56d19dd8fd76f75a77f92c33
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 1070844
+  timestamp: 1714399290671
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3.1-py311haa95532_0.tar.bz2
+  sha256: 5d612af287cad7d0fc1b8e2e01d7f49b5466f2e17338b03a13cd60111f2513aa
+  md5: 1b0f29aa3fc57cc8d5a48ae392aa8567
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3752545
+  timestamp: 1700667933959
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+  sha256: e5f8cbfb5fc25d460a9117bfc5511959c5e86ccb193316033f87bd516e0c8881
+  md5: 9f7e8b5eb651539386bb92c14e5c321b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37730
+  timestamp: 1692205554840
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py311haa95532_0.tar.bz2
+  sha256: a100d5bef5d832db705558acee7ecb4ec2471c18d13ab65fb92f7bc3b3a44ae7
+  md5: 0ae839617227e2ef40d65e85607e60d6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-clause
+  license_family: BSD
+  size: 111734
+  timestamp: 1676426983345
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+  sha256: 6c5b53831273674361437fb546e08315fc11ca9275a174bca3887987e86ced5a
+  md5: f8d91daf5173eb03157f484389adcdd4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 122178
+  timestamp: 1679591983138
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+  sha256: 546819d922b03f3a25ca9f98fd069d0588d481fc0603c6d74bd598fb6a93687f
+  md5: 86c18e3e0b67ee099457475ed6caf2e6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 751763
+  timestamp: 1704404627180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+  sha256: ae06f0dfa2cfae51404afc6d6ad3a474a93015b5ba9a7d3ea24224b8e7547987
+  md5: 3e19794c806cc3e84a3080a97c359b75
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 510466
+  timestamp: 1679005998612
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-14.0.2-py311h847bd2a_0.tar.bz2
+  sha256: a33dd77a94c79ab95caaa02fbdcb399d4041806a52a82411529cf1454f031536
+  md5: 01f56e64de4eed195d72a61301444fa7
+  depends:
+  - arrow-cpp >=14.0.2,<14.0.3.0a0
+  - boost-cpp
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4504341
+  timestamp: 1707332113670
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+  sha256: d95c88d06f4f3f667bd9a39e5f18179e83b3cd4c115c06ce0fff390ff6d3a700
+  md5: c6d00a8a4d89b1be99bfa3aff19d96b4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2134881
+  timestamp: 1684280285492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+  sha256: 643a9a0eba1e2bd5980d21623d3b35188c24781ec251acc4d15714bd1ccb4c17
+  md5: b3cda0394db05be6f0f6176abacb13f3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207985
+  timestamp: 1678721438358
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py311hd77b12b_0.tar.bz2
+  sha256: d86b6f06ff63712d58bc0f82a6d345ec578c854051934ac73e5bd929782cd6ab
+  md5: d03b87499af4ad84a166b2d49db2bacf
+  depends:
+  - pyqt5-sip 12.13.0 py311h2bbff1b_0
+  - python >=3.11,<3.12.0a0
+  - qt-main 5.15.*
+  - qt-main >=5.15.2,<5.16.0a0
+  - sip >=6.7.12,<6.8.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 5041665
+  timestamp: 1698775563282
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py311h2bbff1b_0.tar.bz2
+  sha256: 449266141df059e53f3ae09ef2f1f10b94bc6ab51f919dc4533c32da3a0e808f
+  md5: f125f06594be8adff678b9b36861b847
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 84114
+  timestamp: 1698769459963
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+  sha256: 974c22de09078bf07c5db31fe12d8d89d6433508defc8237cbe52e08c69ed56b
+  md5: 9cf10bfd49140a527cf4b1d912097e6d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36072
+  timestamp: 1676426019064
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.8-he1021f5_0.tar.bz2
+  sha256: 1c557d91837e0205cd08180b604da06f28d7679df1ea1026e7954add3eb4d468
+  md5: 3901bef86daffeb6ff2317543b292766
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - openssl >=3.0.13,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.5,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - openssl <3.5.7
+  license: PSF-2.0
+  license_family: PSF
+  size: 19539055
+  timestamp: 1708983524626
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+  sha256: 9acb33db60d9319595f52337cae3b88c2a2338cd66f1f9d8ae86d0a993c2067a
+  md5: f4af8cf94d042b4dde487241bba1c457
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279780
+  timestamp: 1679500609851
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+  sha256: 48fe7373b012b51134b6b6ff67f18d2b4aae3a5c7700e4560ce002af7172f064
+  md5: 0379cd17692152c12b662b0e4ea46b88
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18008
+  timestamp: 1683824373128
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py311hd77b12b_0.tar.bz2
+  sha256: 40093db499547e192da8c52132ef1016bab65f2dfd2e4049739f2f8b574e3836
+  md5: a6b568626951b8a9070c30e043cb2603
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 150521
+  timestamp: 1682522716553
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+  sha256: 803274d986d0c4e3b5ec1018747ede86ef57137455b3e44a60e834717eafb92b
+  md5: c9f134ddeff6fdf0373a45534ddb7079
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 273009
+  timestamp: 1713974722039
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+  sha256: cd33dfee104dfbba4af38d06a09ccbae6a32e7c543afedab523303319ebb283d
+  md5: 3dfc19af0306d80921e1403f1f551bba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13679916
+  timestamp: 1676423267293
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+  sha256: 102ff1d958209e3648bb49da3503cf752abab822011fdc4e12e88145c9e73772
+  md5: 0553c2c381b6f5c836b23edc8c6db2ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 246689
+  timestamp: 1677708371873
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+  sha256: bee5c4d0f41f06a9c0aac636885e36e8b81116aafde980f9ea48fdb64abb5567
+  md5: 6c05a053240cb90765d6f8c2efdf905e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 182228
+  timestamp: 1698096268270
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-25.1.2-py311hd77b12b_0.tar.bz2
+  sha256: d08d1b2bc1859011d6d8c8e0afff0cad680c598e5ad59bb7beab9317b3bdece4
+  md5: 5e36645629336f3732b14604bb666442
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 552293
+  timestamp: 1705606206058
+- conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
+  sha256: 409f9fad42cbae8d915d1703d87db6af9f951b150517daa4e1c0220cc5eb7b0f
+  md5: 2b17abf94b02a6c5ba6b7623dba97ff9
+  depends:
+  - icu >=73.1,<74.0a0
+  - jpeg >=9e,<10a
+  - krb5 >=1.20.1,<1.21.0a0
+  - libclang >=14.0.6,<15.0a0
+  - libclang13 >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=12.15,<13.0a0
+  - openssl >=3.0.10,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  constrains:
+  - qt >=5.15.2,<6
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 69829482
+  timestamp: 1693228189080
+- conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+  sha256: 720f3dd1f933d035b1393951ffd1b6437fc5e19b1999e74096044514a46053fb
+  md5: add2dfb15b518144663fc3b897d66da7
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  size: 493391
+  timestamp: 1652432364793
+- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+  sha256: 47653b45a5f2d97b5bf0dbf0e620908880f9078da427eef69012effe3f19af67
+  md5: 44e709ae67d89bccee2d4d46d358fee3
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74493
+  timestamp: 1699012356534
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
+  sha256: d7bcba5262df162756885a773c3bf2dace27311bbbb1830a0f97aa60ac7c1239
+  md5: daeb99ccfe39f725278203412aac0873
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 120468
+  timestamp: 1707355917958
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+  sha256: d6daaa6b45272819176e4aeb467ae00e3db43386548464a9993688f292709d40
+  md5: 9fe721d7f7420c259df4f07d4503f654
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9683
+  timestamp: 1683077110211
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+  sha256: 6051860575f9448aea5799d74469c928cd7cdeeca1eb53657872262a77b1a7a8
+  md5: 60e193eca497130034facd5fed168249
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10094
+  timestamp: 1683059114376
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+  sha256: ecd310461c1b45ab92ddf15539cea5a6e837860561c974d2d7393f9a7933f116
+  md5: 1762fec2838763e904141167e18b0389
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 215600
+  timestamp: 1698947891859
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
+  sha256: 0042fa2dc2ec8c2181f28f5ee4f45087ea58dca7acc6b89c48f3ce6eac8f9bdd
+  md5: 755c9767608b233b94ec3a67c8e0da4b
+  depends:
+  - blas 1.0 mkl
+  - icc_rt >=2022.1.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 5
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 32418527
+  timestamp: 1714081783418
+- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+  sha256: 6fd52bae6360fbc8135d72e0c1e4fd407769fa4d0f4b59356e7aed3e000eb339
+  md5: 49fd52885250da8aab17ed72e2e18b81
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88901
+  timestamp: 1699371435766
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+  sha256: a2ec4690bc07be9e7f3ad8e3003803eb4304a434d3f139633e2817318a9f7b20
+  md5: dd2d225219924fc5c36598c919541271
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1593050
+  timestamp: 1715025622141
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py311hd77b12b_0.tar.bz2
+  sha256: f9b5386b4bbae4a6dbf2d391d482a4eb66067435234d990e0a3dd1ea8c710dee
+  md5: 46b9998433d3d70eb124f7d6480698b3
+  depends:
+  - packaging
+  - ply
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-SIP_License OR GPL-2.0-or-later OR GPL-3.0-or-later
+  license_family: GPL
+  size: 682181
+  timestamp: 1698676093853
+- conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.1.10-h6c2663c_1.tar.bz2
+  sha256: 7555e0d33dc29191da0f311d9e6112ddf0c200bbafe5cde89015d524dce84a72
+  md5: 54bc73a36ca51e06733d9d42f23e2ea4
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 100857
+  timestamp: 1702909533553
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+  sha256: 5d1b7e14dc04816692de0f8518ea8fcbefb26ab61cec83f96f2c44c1bee67fab
+  md5: 505d2a70a875b5082dc857aa4dfab0d4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 18830
+  timestamp: 1705431395254
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+  sha256: 5ff3b4ac3fbce4dd67a87856c04698d0397deb0ac288ff4e7eb02fbab57f1253
+  md5: 0ca650a7001c6650809d3361de8cb005
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89590
+  timestamp: 1696347858925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+  sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
+  md5: 833b93a2daade3407898f15588945d83
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1440481
+  timestamp: 1714488344682
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+  sha256: 78d89b50a29fbeb19a562f5dad95615e3f192bb4f3b86cd6ea75f2f825418232
+  md5: 4a4040df560ea47704e0898c4c015808
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38069
+  timestamp: 1678228553220
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+  sha256: 70a3cc4a4e81a6421bc19cd410d1d6064aadb2b1cce38b020f85e5346716d8e7
+  md5: 32a9a2539579a3d522dce3b5cb4f987b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49495
+  timestamp: 1676425411739
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+  sha256: 0a95736cfd0bb25fc201cd6be4a2450ea8fc30eeb349d861812675b84c94fa74
+  md5: a8a9fb30c6dd8e7a16d5dcd2333c3c49
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3844176
+  timestamp: 1714770894235
+- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+  sha256: ed5950ac0c12cc87f991a6f28112cf29057e2b7ad416ae4429a0b97c3efaf58c
+  md5: b5e2a04879e6fd19f0eb5effded4dc61
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135939
+  timestamp: 1676431438808
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+  sha256: 4febf30c11674711b86c8c10da46a5e1613071388da999210912a31508864add
+  md5: 1c109fc1112ea1f5f377bdf0d18ba75f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 895633
+  timestamp: 1696937216859
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.2-py311h746a85d_0.tar.bz2
+  sha256: fa6681ec34a560da1d44d80bb32da96165fc6063a6e000169e75bc1e5ca74194
+  md5: c5110aa6fe3bec83fe71215182b7f636
+  depends:
+  - colorama
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 186730
+  timestamp: 1714567830865
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+  sha256: e8c77efe880546252f244f995cbed5967809555127b4f818b97455d434b23415
+  md5: 7397ac07045115960ebd8dec95326a7a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270819
+  timestamp: 1676423321499
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.9.0-py311haa95532_1.tar.bz2
+  sha256: ae7b4d80613eee90d2a9d86a099327c81606cde33700e476402407f1a206362c
+  md5: d7326551a9f54853015af81861222d5f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.9.0 py311haa95532_1
+  license: PSF-2.0
+  license_family: PSF
+  size: 9651
+  timestamp: 1705599444849
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.9.0-py311haa95532_1.tar.bz2
+  sha256: 1900ee02288c0abdaa44f34bccafc34691a59069330b0fc0c0922b4b4621b786
+  md5: 0b94ee0b1e2488c3840a348d7d97aca2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 71708
+  timestamp: 1705599429360
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+  sha256: d091897f05318c22ca31028370f25355065999078f7db6f88ab27bf4cb030ec8
+  md5: 1776502c1cfb351554eeda6cddaf255f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11588
+  timestamp: 1676457729096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+  sha256: c16498f8238cc331618720d078b87995eceb6bbf20268a7a4e8efbf7b5859a9a
+  md5: 770432c0ca1ab9d99ffe95e51d3a3e74
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 517433
+  timestamp: 1713213261710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.1.0-py311haa95532_1.tar.bz2
+  sha256: 75e984e5015c5fee121159768fc92653d58303e983450308f8efee40382cc6f7
+  md5: bcaf27d1ba712299ee395d7cb0d4852b
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - requests >=2.26.0
+  - zstandard >=0.18.0
+  - selenium >=4.4.3
+  license: MIT
+  license_family: MIT
+  size: 184432
+  timestamp: 1707770951801
+- conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+  sha256: 2ef16d0252e04063d44d0683831d55b485f713fe5af2c2efd61753fb4f27d7e4
+  md5: 256ab1d5dce70111a1f4807a5a9fc322
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 100982
+  timestamp: 1706894771410
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+  sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
+  md5: 45ef24c486a484f079faf1dc90e4c7e9
+  depends:
+  - vs2015_runtime >=14.27.29016
+  license: Modified BSD License (3-clause)
+  license_family: BSD
+  size: 8277
+  timestamp: 1605602889180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+  sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
+  md5: 4daaceb6cfc1af6274509081d8018ef1
+  size: 2316783
+  timestamp: 1605602872095
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+  sha256: 24ea3d3e0cb98d0d246338dbb4562b67967bb32002e3704e495a5c863476e831
+  md5: c7b9cdbe87b3c9720aeca1164a0fd6df
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26181
+  timestamp: 1676424437003
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py311haa95532_4.tar.bz2
+  sha256: 4008652f05783c7c1ac31fb5b8cf36899c3380b24e82996c6fd44f7b6aca1278
+  md5: dd85600927df8322040c4998a114b567
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94482
+  timestamp: 1676426093953
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+  sha256: 1b086d1b079fdb2f148c7dd82658f2b7f283c88f286e1216c0f1237319039b0f
+  md5: 299e87f151a549d86a48bf24df15c607
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 168041
+  timestamp: 1714717238470
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+  sha256: 17fadf35aa8917c107e7b369e9364ac7c09537776e7943d37e225e14b7026c94
+  md5: 0e67c3b9624540581b894b11267a837b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PUBLIC-DOMAIN
+  size: 10197
+  timestamp: 1676425485716
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+  sha256: 25373efabba9a866849fe38a47c79e0fa323851b4bd4b5df357cc8d5617c2786
+  md5: a958e9d32c3b65c21e11e5d9e8491c43
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2467966
+  timestamp: 1689041676824
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+  sha256: b849b368e27920838fe40a512b102879693a55cb187dd1c8d3a83fa8c05a8054
+  md5: 7b1f6e9c71906a93039b3446b99a5498
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55114
+  timestamp: 1676434863173
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+  sha256: 344a5276a9928638dcde054dfe4e87c8cb40bd2d4d356378b9ab2f863ca62e4b
+  md5: fe471fd8b5a3d77be6fa5dbf9b99dafb
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 1432281
+  timestamp: 1714515119689
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+  sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
+  md5: e5aed81295b61b6d1eb62830799a0297
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 9125184
+  timestamp: 1705602328351
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py311haa95532_0.tar.bz2
+  sha256: 478892109d9dc82c90f82d269d3796f4f812f6cba5d3d1f9178a20bd7f583a1f
+  md5: df02873bda6c5de6331b00fb1591abac
+  depends:
+  - heapdict
+  - python >=3.11,<3.12.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102456
+  timestamp: 1695833422458
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
+  sha256: d932439798665be388bbf68f3d68da5b42ed4753a43587d3f49848a85f58add4
+  md5: e2900345674e644e05540ffac6acca89
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 25247
+  timestamp: 1704207149955
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+  sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
+  md5: f295b54ab59f5b8658e2a322ac6aa721
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 162161
+  timestamp: 1714514792081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+  sha256: b2ff66b7f6efa0831f939e57e562c244332b690af08818a540d1a97fa07d8525
+  md5: e548d528873d9a0006a36714cf36462a
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1933522
+  timestamp: 1714679197977
+- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+  sha256: 98f3bae3caff4c52615ddb56405dc51b39d9d2c47a9bccd130a5a19d10304245
+  md5: de1b7f7c8221028f6bbe103df4c53bed
+  depends:
+  - m2w64-gcc-libs-core
+  - msys2-conda-epoch >=20160418
+  license: GPL, LGPL, FDL, custom
+  size: 348607
+- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+  sha256: 2fb6488298a659c781f9294a743b0b376d9998a6b06aa2a3b85b49c38a85ea16
+  md5: 0b9caac6747002340b057a222af705b2
+  depends:
+  - m2w64-gcc-libgfortran
+  - m2w64-gcc-libs-core
+  - m2w64-gmp
+  - m2w64-libwinpthread-git
+  - msys2-conda-epoch >=20160418
+  license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  size: 530578
+- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+  sha256: 449df9debaf202928e3a0db1f059ef35b1bcb3973fa92e217ca2775f82415111
+  md5: 276d396bfe8d958f71173b7134f739fa
+  depends:
+  - m2w64-gmp
+  - m2w64-libwinpthread-git
+  - msys2-conda-epoch >=20160418
+  license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  size: 217686
+- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+  sha256: 5cf23439eef17ae158d63ff3f85f77d1dca9a45b19324fdeda9e3e48ae298d18
+  md5: fec04371463ec68eb8f5752a22c5b030
+  depends:
+  - msys2-conda-epoch >=20160418
+  license: LGPL3
+  size: 705647
+- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+  sha256: 9373b0157e08cbea09298f461d2816833281b3e22a8c9f6c5a38d7109c8a281e
+  md5: 67e61e700eb27424979778fae9293f13
+  depends:
+  - msys2-conda-epoch >=20160418
+  license: MIT, BSD
+  size: 30543
+- conda: https://repo.anaconda.com/pkgs/msys2/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+  sha256: d6a55d779052bca9accd534398b4e147d0a3dfc8f4b6528391ee9c15843784bc
+  md5: 6eaef3074f65f715ed1ca6b8a08be3aa
+  size: 2065

--- a/nyc_taxi/pixi.lock
+++ b/nyc_taxi/pixi.lock
@@ -8,10 +8,258 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/pyviz/label/dev/
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/arrow-cpp-14.0.2-h374c478_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/async-lru-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-sdk-cpp-1.10.55-h721c034_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/babel-2.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cramjam-2.7.0-py311h24d97f6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cyrus-sasl-2.1.28-h52b45da_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cytoolz-0.12.2-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dask-2023.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dask-core-2023.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/distributed-2023.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/expat-2.6.2-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fastparquet-2023.8.0-py311hf4808d0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fontconfig-2.14.1-h4c34cd2_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fsspec-2024.3.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/glib-2.78.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/glib-tools-2.78.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/grpc-cpp-1.48.2-he1ff14a_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gst-plugins-base-1.14.1-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gstreamer-1.14.1-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter-lsp-2.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-8.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyterlab-4.0.11-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyterlab_server-2.25.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libclang-14.0.6-default_hc6dbbc7_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libclang13-14.0.6-default_he11475f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libcups-2.4.2-h2d74bed_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libcurl-8.5.0-h251f7ec_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libglib-2.78.4-hdc74915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpq-12.17-hdbd6064_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libssh2-1.10.0-hdbd6064_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxkbcommon-1.0.1-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxml2-2.10.4-hfdd30dd_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-4.3.2-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-3.8.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/msgpack-python-1.0.3-py311hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mysql-5.7.24-h721c034_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-7.0.8-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numba-0.59.1-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.13-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-23.3.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ply-3.11-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyarrow-14.0.2-py311hb6e97c4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyqt-5.15.10-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyqt5-sip-12.13.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.11.8-h955ad1f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-lmdb-1.4.1-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-25.1.2-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/qt-main-5.15.2-h53bd1ea_10.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sip-6.7.12-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/snappy-1.1.10-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.66.2-py311h92b7b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-2.1.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py311h06a4308_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zict-3.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/colorcet-3.1.0-py_0.tar.bz2
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/datashader-0.16.1-py_0.tar.bz2
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/holoviews-1.19.0a1-py_0.tar.bz2
@@ -21,255 +269,228 @@ environments:
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyct-0.5.0-py_0.tar.bz2
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyct-core-0.5.0-py_0.tar.bz2
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyviz_comms-3.0.0-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-14.0.2-h374c478_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/async-lru-2.0.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.10.55-h721c034_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/babel-2.11.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cramjam-2.7.0-py311h24d97f6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cyrus-sasl-2.1.28-h52b45da_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.2-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-2023.11.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.11.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2023.11.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.6.2-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-2023.8.0-py311hf4808d0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.14.1-h4c34cd2_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.3.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.78.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-tools-2.78.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/grpc-cpp-1.48.2-he1ff14a_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.1-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.1-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter-lsp-2.2.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-8.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab-4.0.11-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_server-2.25.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang-14.0.6-default_hc6dbbc7_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang13-14.0.6-default_he11475f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcups-2.4.2-h2d74bed_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.5.0-h251f7ec_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libglib-2.78.4-hdc74915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpq-12.17-hdbd6064_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-hdbd6064_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxkbcommon-1.0.1-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.10.4-hfdd30dd_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.8.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py311hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mysql-5.7.24-h721c034_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-7.0.8-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.59.1-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ply-3.11-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-14.0.2-py311hb6e97c4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.15.10-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt5-sip-12.13.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.8-h955ad1f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-25.1.2-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-main-5.15.2-h53bd1ea_10.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-6.7.12-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.1.10-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.2-py311h92b7b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.9.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.9.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.1.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py311h06a4308_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/abseil-cpp-20230802.0-h61975a4_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/arrow-cpp-14.0.2-h3ade35f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/async-lru-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-sdk-cpp-1.10.55-h61975a4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/babel-2.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cramjam-2.7.0-py311h9c86198_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cytoolz-0.12.2-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/dask-2023.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/dask-core-2023.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/distributed-2023.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fastparquet-2023.8.0-py311hb3a5e46_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fsspec-2024.3.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/grpc-cpp-1.48.2-hbe2b35a_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/gtest-1.14.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter-lsp-2.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-8.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyterlab-4.0.11-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyterlab_server-2.25.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcurl-8.5.0-hf20ceda_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libssh2-1.10.0-h04015c4_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-4.3.2-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-3.8.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/msgpack-python-1.0.3-py311ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-7.0.8-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numba-0.59.1-py311hdb55bb0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.13-hca72f7f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/orc-1.7.4-h995b336_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-23.3.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyarrow-14.0.2-py311h2a249a5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.11.8-hf27a42d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-lmdb-1.4.1-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-25.1.2-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/snappy-1.1.10-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.66.2-py311h85bffb1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-2.1.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py311hecd8cb5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zict-3.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/colorcet-3.1.0-py_0.tar.bz2
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/datashader-0.16.1-py_0.tar.bz2
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/holoviews-1.19.0a1-py_0.tar.bz2
@@ -279,228 +500,224 @@ environments:
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyct-0.5.0-py_0.tar.bz2
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyct-core-0.5.0-py_0.tar.bz2
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyviz_comms-3.0.0-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/abseil-cpp-20230802.0-h61975a4_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-14.0.2-h3ade35f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/async-lru-2.0.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.10.55-h61975a4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/babel-2.11.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cramjam-2.7.0-py311h9c86198_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.2-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-2023.11.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.11.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2023.11.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-2023.8.0-py311hb3a5e46_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.3.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/grpc-cpp-1.48.2-hbe2b35a_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gtest-1.14.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter-lsp-2.2.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-8.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab-4.0.11-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_server-2.25.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.5.0-hf20ceda_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-h04015c4_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-4.3.2-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.8.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py311ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-7.0.8-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.59.1-py311hdb55bb0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-1.7.4-h995b336_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-14.0.2-py311h2a249a5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.8-hf27a42d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-25.1.2-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.1.10-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.2-py311h85bffb1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.9.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.9.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.1.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py311hecd8cb5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
       osx-arm64:
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/abseil-cpp-20230802.0-h313beb8_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/arrow-cpp-14.0.2-hc7aafb3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/async-lru-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-sdk-cpp-1.10.55-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/babel-2.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cramjam-2.7.0-py311h62f922a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cytoolz-0.12.2-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/dask-2023.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2023.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/distributed-2023.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fastparquet-2023.8.0-py311hb9f6ed7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2024.3.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/grpc-cpp-1.48.2-hc60591f_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/gtest-1.14.0-h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter-lsp-2.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-8.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab-4.0.11-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_server-2.25.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcurl-8.5.0-h3e2b118_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libssh2-1.10.0-h02f6b3c_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-4.3.2-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-3.8.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/msgpack-python-1.0.3-py311h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-7.0.8-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numba-0.59.1-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.13-h1a28f6b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyarrow-14.0.2-py311ha07b5f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.11.8-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-lmdb-1.4.1-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-25.1.2-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/snappy-1.1.10-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.66.2-py311hb6e6a13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.1.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py311hca03da5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zict-3.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/colorcet-3.1.0-py_0.tar.bz2
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/datashader-0.16.1-py_0.tar.bz2
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/holoviews-1.19.0a1-py_0.tar.bz2
@@ -510,224 +727,235 @@ environments:
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyct-0.5.0-py_0.tar.bz2
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyct-core-0.5.0-py_0.tar.bz2
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyviz_comms-3.0.0-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/abseil-cpp-20230802.0-h313beb8_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-14.0.2-hc7aafb3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/async-lru-2.0.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.10.55-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/babel-2.11.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cramjam-2.7.0-py311h62f922a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.2-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-2023.11.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.11.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2023.11.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-2023.8.0-py311hb9f6ed7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.3.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpc-cpp-1.48.2-hc60591f_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gtest-1.14.0-h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter-lsp-2.2.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-8.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab-4.0.11-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_server-2.25.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.5.0-h3e2b118_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h02f6b3c_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.3.2-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.8.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py311h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-7.0.8-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.59.1-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-14.0.2-py311ha07b5f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.8-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-25.1.2-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.1.10-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.2-py311hb6e6a13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.9.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.9.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.1.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py311hca03da5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
       win-64:
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/arrow-cpp-14.0.2-ha81ea56_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/async-lru-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-sdk-cpp-1.10.55-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/babel-2.11.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cramjam-2.7.0-py311h005caf5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cytoolz-0.12.2-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/dask-2023.11.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/dask-core-2023.11.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/distributed-2023.11.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fastparquet-2023.8.0-py311hd7041d2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fsspec-2024.3.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/grpc-cpp-1.48.2-hfe90ff0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter-lsp-2.2.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-8.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyterlab-4.0.11-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyterlab_server-2.25.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libcurl-8.5.0-h86230a5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpq-12.17-h906ac69_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libssh2-1.10.0-he2ea4bf_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-4.3.2-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-3.8.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/msgpack-python-1.0.3-py311h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-7.0.8-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numba-0.59.1-py311hf62ec03_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.13-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-23.3.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ply-3.11-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyarrow-14.0.2-py311h847bd2a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyqt-5.15.10-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyqt5-sip-12.13.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.11.8-he1021f5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-lmdb-1.4.1-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-25.1.2-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sip-6.7.12-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/snappy-1.1.10-h6c2663c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.66.2-py311h746a85d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.9.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.9.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-2.1.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py311haa95532_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zict-3.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+      - conda: https://conda.anaconda.org/msys2/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+      - conda: https://conda.anaconda.org/msys2/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+      - conda: https://conda.anaconda.org/msys2/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+      - conda: https://conda.anaconda.org/msys2/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+      - conda: https://conda.anaconda.org/msys2/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+      - conda: https://conda.anaconda.org/msys2/win-64/msys2-conda-epoch-20160418-1.tar.bz2
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/colorcet-3.1.0-py_0.tar.bz2
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/datashader-0.16.1-py_0.tar.bz2
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/holoviews-1.19.0a1-py_0.tar.bz2
@@ -737,235 +965,9670 @@ environments:
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyct-0.5.0-py_0.tar.bz2
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyct-core-0.5.0-py_0.tar.bz2
       - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/pyviz_comms-3.0.0-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-14.0.2-ha81ea56_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/async-lru-2.0.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.10.55-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/babel-2.11.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cramjam-2.7.0-py311h005caf5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.2-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-2023.11.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.11.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2023.11.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-2023.8.0-py311hd7041d2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.3.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/grpc-cpp-1.48.2-hfe90ff0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter-lsp-2.2.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-8.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab-4.0.11-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_server-2.25.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.5.0-h86230a5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.17-h906ac69_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-he2ea4bf_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.3.2-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.8.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py311h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-7.0.8-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.59.1-py311hf62ec03_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-14.0.2-py311h847bd2a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.8-he1021f5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-25.1.2-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.1.10-h6c2663c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.2-py311h746a85d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.9.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.9.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.1.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py311haa95532_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gmp-6.1.0-2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/msys2-conda-epoch-20160418-1.tar.bz2
 packages:
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+  sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
+  md5: 613805add1c05b538ff06d217252feb7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 20810
+  timestamp: 1652859733309
+- conda: https://conda.anaconda.org/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
+  sha256: 8762f481244fb151a200f01dd70e69c77171a3ee0f7f4c130e8e95b6a1626a68
+  md5: c3707fcd2efa582afc5c7e1986c6ce48
+  depends:
+  - libgcc-ng >=8.4.0
+  - libstdcxx-ng >=8.4.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1135866
+  timestamp: 1652382888447
+- conda: https://conda.anaconda.org/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+  sha256: 250f50edf43a786a32942e9ae67ce807e9b3ac4cb6b58b1170cb541fb24e391f
+  md5: b48058294499d292ddf9a3b966dc9cc5
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 228473
+  timestamp: 1706220559474
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+  sha256: 0d4f5274503916e1c683dcc16e8a7c4186557afa3f62399cd628e4eb535fe77a
+  md5: 062acdb0f9ae976c25c2d15d589dc1d6
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 35809
+  timestamp: 1676823571351
+- conda: https://conda.anaconda.org/main/linux-64/arrow-cpp-14.0.2-h374c478_1.tar.bz2
+  sha256: df890b7a4a677687ad7964182735e2eaf433d6066e346d9878ba90788e3d468f
+  md5: 96e5995c1fe9e067faed3e61c416f54f
+  depends:
+  - abseil-cpp >=20211102.0,<20211102.1.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - aws-sdk-cpp >=1.10.55,<1.10.56.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags
+  - glog >=0.5.0,<0.6.0a0
+  - grpc-cpp >=1.48.2,<1.49.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libgcc-ng >=11.2.0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libstdcxx-ng >=11.2.0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.13,<4.0a0
+  - orc >=1.7.4,<1.7.5.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.9,<2.0a0
+  - utf8proc >=2.6.1,<2.9.0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 13402790
+  timestamp: 1707254138477
+- conda: https://conda.anaconda.org/main/linux-64/async-lru-2.0.4-py311h06a4308_0.tar.bz2
+  sha256: f798d8239a172da4d1b2e5e6e43ee466f303f08d62f920f35cfdd4cbd5d4b171
+  md5: 9721c4818b5eea1649443059b488209b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 20540
+  timestamp: 1699554588481
+- conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+  sha256: 567dfdd5b986012421a736a5f1c1d5874d8d691dd483c838b55e1ab06c0b217d
+  md5: 4e0aa1543f546b898523382ee8405e84
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 152577
+  timestamp: 1695717917074
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
+  sha256: 432e4fb45ae24789afdaeca800862aad03f8ebed5af908f01eed2a09283915e5
+  md5: a88c0e111e1f47ee83f1b6f329a149ef
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 97643
+  timestamp: 1706746168671
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
+  sha256: edb54d1554aefb65ff5a3969085dd8695e1e3218a2987ac30a96901f0bbf887a
+  md5: 5f131e63f8d80f2b7ac505054204a9e3
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.12,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 44722
+  timestamp: 1706690912333
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
+  sha256: 2afbfb546992e5954748d039ea15405f99018f6de78ec2f32bc7ff9bfc428a9c
+  md5: 489017af35cf8bdb976e6fef020a4ac7
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 202658
+  timestamp: 1706189913451
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
+  sha256: 5f81f5a3ea27bd29bf32a6987290de8c7b2da6612676aa8e606a7003519cbf47
+  md5: c11e7ceff3ca45bf580d1c944d93bd1f
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 17839
+  timestamp: 1706690843204
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
+  sha256: 348ced323311d36344a0fa9e88d299b361bad1f628dfbdd34bcea8662b3ab44b
+  md5: 19a11cdc9727c5981d96983a29b93ce4
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52025
+  timestamp: 1706697274091
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
+  sha256: 14e2843a218cb01bfc499a22537eb345f6e222b8496cfda2050c73ad98f09cda
+  md5: 44cba75d1bb5122aeadcaf8bb7da5e2a
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-compression >=0.2.16,<0.2.17.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 192985
+  timestamp: 1706744140260
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
+  sha256: a0f6916d60c0e1bac6ba548bf05a491b8db048a94e13da2f1cfa51b4ca879fb8
+  md5: 1f010db4f5ef1b3d705ee04dd1d473c9
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  - s2n >=1.3.27,<1.3.28.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 143623
+  timestamp: 1706696185335
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
+  sha256: 596945a39d772056e57bb357202a17e02508f2594da9c00e00ad767b8213e998
+  md5: 98cccbcc56a28ec7339e393816f4bdf7
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 70139
+  timestamp: 1706746744249
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
+  sha256: 12bf86ab848e3311f4eed4e93734a84064dc84580ad6dd4bb823b4ab6ef09698
+  md5: 4a8c2dcf0ede655609a9fc5632a5227b
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.12,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 74700
+  timestamp: 1706747582638
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
+  sha256: f05ce64fee77518a6deb45f187fcee415328e90ea8f2bf6031bd5b8273a1028f
+  md5: b8ebb4b892d9b80d513b4ca62a8d6de2
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 53042
+  timestamp: 1706690818718
+- conda: https://conda.anaconda.org/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
+  sha256: 52bb367fc367ee3923353927226299a2b8b1be6a1993c11e19b20cafe6c6db0f
+  md5: 4715508fd5f8b39e902cb2afebc13c93
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52138
+  timestamp: 1706192048702
+- conda: https://conda.anaconda.org/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
+  sha256: 0d13fbdace8ab4fbfcc015cf83bead69560a3dfadc6e0ce8441001629d725834
+  md5: a02c72bff71848705e70cd6f075a28f3
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
+  - aws-c-s3 >=0.1.51,<0.1.52.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 211559
+  timestamp: 1706827608038
+- conda: https://conda.anaconda.org/main/linux-64/aws-sdk-cpp-1.10.55-h721c034_0.tar.bz2
+  sha256: a489d946a0a70a4d31f5da9fdf38e2c0ba8122e1df4fc716961b5b02d7617dbe
+  md5: f29f551a4e61c4d8339710ba000c6da8
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.12,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2815192
+  timestamp: 1706890558504
+- conda: https://conda.anaconda.org/main/linux-64/babel-2.11.0-py311h06a4308_0.tar.bz2
+  sha256: 8da2bfb50812660c69643386afa2a2d0ce9f2b0168e9b7a372349901d7d4b2f7
+  md5: d0cde1ca577520a608da5ab86421f9aa
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pytz >=2015.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7241236
+  timestamp: 1676825038806
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+  sha256: 894fceb5b4f8740bcd146de8bd0f6eabf14e2407b149b790b4983b8432681e6b
+  md5: 2f0ef211bf628cd22bbfa44c3f9bc035
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 271600
+  timestamp: 1681493103694
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
+  sha256: 9f027f156744dcbf28945aad6e422ef030c84c2a5d40116d3e40407c66853bf8
+  md5: 7b52489e04f9a5585643d5578835fc68
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6059952
+  timestamp: 1712084450899
+- conda: https://conda.anaconda.org/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+  sha256: 3606c8607c29229222667f66421f79df167d33043fe9245cdd4e2c4520ecc721
+  md5: eca33dcef14fa044193e43492dca8585
+  depends:
+  - libboost 1.82.0 h109eef0_2
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 10768
+  timestamp: 1696762269985
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+  sha256: 8e2b2073ff5c61d35714e8a36ce657a8ac741b7bedc2852a238c7f1625142705
+  md5: d951ab54a682b6328327fec53b1e5e72
+  depends:
+  - libgcc-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 147642
+  timestamp: 1707864274452
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 5d15605858771290fdaaae41a43941623757a25cb1292080d69d6d3857807935
+  md5: 7f517469aa5380c52e55db9f37df104f
+  depends:
+  - brotli-bin 1.0.9 h5eee18b_8
+  - libbrotlidec 1.0.9 h5eee18b_8
+  - libbrotlienc 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 18652
+  timestamp: 1714483267080
+- conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+  sha256: a5094f078584e27c7cced4a9564ae904a329f5c1702a7c1ba092d581ba1544f1
+  md5: 6ddf45dd8a21a9512481de9bc0e5a03f
+  depends:
+  - libbrotlidec 1.0.9 h5eee18b_8
+  - libbrotlienc 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 19711
+  timestamp: 1714483255915
+- conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+  sha256: 93180c973816246f068b742d0bf64840f0ea48e31d4f9b0747ea2ffc34d8855d
+  md5: f3a00096965a5ba1eb41d2c99a4662a2
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 361574
+  timestamp: 1714483400014
+- conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+  sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
+  md5: f5058c8d5b2994b7334f18e022105a14
+  depends:
+  - libgcc-ng >=11.2.0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 427542
+  timestamp: 1714510571510
+- conda: https://conda.anaconda.org/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+  sha256: 5b4c80587ae4ec915505469f79d866f27c80456156667c8548d31c67c2c1653e
+  md5: c3d6bfae757760082261779c406a880d
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 116270
+  timestamp: 1693902021950
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+  sha256: 394f74202c2efc8fcfd02b8953f508eb6a2961d224a2f9d15091caf5cbe1be67
+  md5: 1202b4ed32215c6405bb42fbff355316
+  license: MPL-2.0
+  license_family: Other
+  size: 137411
+  timestamp: 1710764808838
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+  sha256: 6dc29d20180f6e002f37b251efa639716d3444e129a754dabf751f816aada7ef
+  md5: 5dbfa083e6ab6318fac58fe0e0c94445
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 165152
+  timestamp: 1707229213375
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+  sha256: d138cc3fde270eba783baf1e2ba17c89800b2cbbf20976d0eb425b3436a4a184
+  md5: 1875e89c1a939e4e7c5e7b731c72b838
+  depends:
+  - libffi >=3.4,<3.5
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 302401
+  timestamp: 1714483186060
+- conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+  sha256: 9ddbf05887c7d7926418520cc7848e57f6d2431bc4ec6d30e090b02dbf865041
+  md5: 57ae1141ad9a048fb2a75d7a3ef7430a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203190
+  timestamp: 1698129926216
+- conda: https://conda.anaconda.org/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
+  sha256: a5beda842876d0d71598cd2a50ced5fb2731539bc4172fe501b93b60e0c6cd3f
+  md5: d5293e5fe74a4e0d71bbf14c9a57f900
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49509
+  timestamp: 1683040113536
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+  sha256: 882481e441b9b93cbdfb32fbe32a6ad9f26197472f186a08fddb921f61346c02
+  md5: 443c79196064f57c98199e9990544b2f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16902
+  timestamp: 1709322958614
+- conda: https://conda.anaconda.org/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+  sha256: e4877b41553e31b9f9f090dffab77a654255c63776e8b30fc91ec1f60afadbf1
+  md5: c34d3f1520f1e8c9957eb236710058c4
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281162
+  timestamp: 1700583651472
+- conda: https://conda.anaconda.org/main/linux-64/cramjam-2.7.0-py311h24d97f6_0.tar.bz2
+  sha256: 7bb1fd85aaba31403b00722d6f142220031788e391fdaad899c816595cb3ae5d
+  md5: 6673633f2374304790bfdcaa334b14ae
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1528662
+  timestamp: 1702651329660
+- conda: https://conda.anaconda.org/main/linux-64/cyrus-sasl-2.1.28-h52b45da_1.tar.bz2
+  sha256: 4e7eb5911636f3cac2bb22c85d56a8edf946cfd6379e8b7be6136ffdaf669c22
+  md5: dcabb2d653147fd807cf6edeb2c3522b
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.9,<4.0a0
+  license: BSD-3-Clause-Attribution
+  license_family: BSD
+  size: 239169
+  timestamp: 1688045783866
+- conda: https://conda.anaconda.org/main/linux-64/cytoolz-0.12.2-py311h5eee18b_0.tar.bz2
+  sha256: 01fa6e276a4e41ef2396c40c0993a54c2fa3f511b33424191e5af11936edba12
+  md5: d83fe12f3bf13f5171a19af502e6f4cf
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 444424
+  timestamp: 1701723706605
+- conda: https://conda.anaconda.org/main/linux-64/dask-2023.11.0-py311h06a4308_0.tar.bz2
+  sha256: 17c0e8335eabae32d97a47dd6672a64786230bba566f01e9c235f198015478c0
+  md5: b2c2509bb07912005d603cdd2525f2c1
+  depends:
+  - bokeh >=2.4.2
+  - cytoolz >=0.12.0
+  - dask-core 2023.11.0.*
+  - distributed 2023.11.0.*
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.21,<2.0a0
+  - pandas >=1.3
+  - pyarrow >=7.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5148
+  timestamp: 1701444872410
+- conda: https://conda.anaconda.org/main/linux-64/dask-core-2023.11.0-py311h06a4308_0.tar.bz2
+  sha256: edc245960b92d491dc5bb03992ac344e206f094928dde23f814f6436b5781ac1
+  md5: 043e5bb51e65e9a64ce9d3e56b10de63
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3024310
+  timestamp: 1701396195636
+- conda: https://conda.anaconda.org/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+  sha256: 469debfa966d24b8372aaf909ecbe27dc6fde186f6f0d5b9e0a8427e38053364
+  md5: 498d0788982ec4c5d13a44359b9c7afb
+  depends:
+  - expat >=2.2.10,<3.0a0
+  - glib
+  - libgcc-ng >=7.3.0
+  license: GPL2
+  size: 600218
+  timestamp: 1602701107852
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+  sha256: 3b4cd8dc60572086f1a1cbb97e2712e0ffd55317ce8f0309d552eee7367855eb
+  md5: 70a1263b6e19bf2d77c020a2e77277c9
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2556575
+  timestamp: 1690905285843
+- conda: https://conda.anaconda.org/main/linux-64/distributed-2023.11.0-py311h06a4308_0.tar.bz2
+  sha256: fea98401096cdbf2dd28b683bf2ce9a8788f59be71dc6b342332dae5910e348e
+  md5: 6f934835dd0653a632a78f3daaea7000
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - dask-core 2023.11.0.*
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.0
+  - packaging >=20.0
+  - psutil >=5.7.2
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.10.0
+  - tornado >=6.0.4
+  - urllib3 >=1.24.3
+  - zict >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1780776
+  timestamp: 1701398069193
+- conda: https://conda.anaconda.org/main/linux-64/expat-2.6.2-h6a678d5_0.tar.bz2
+  sha256: 37a8f6792dc8e82d2cb8deb956f6e3dc45f947cb8efdab5feddd7395c638a77f
+  md5: bee6ef15f0f0e8c192094e7550b8321b
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 200172
+  timestamp: 1713531025571
+- conda: https://conda.anaconda.org/main/linux-64/fastparquet-2023.8.0-py311hf4808d0_0.tar.bz2
+  sha256: e1fa8f866d1bce81ac9a2511e0d42dd9be03d493f2e1f5318a26b5814a5a7cb0
+  md5: 1fb78f0486c2b4c9a31584ceb4d626da
+  depends:
+  - cramjam >=2.3.0
+  - fsspec
+  - libgcc-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 594660
+  timestamp: 1696541983803
+- conda: https://conda.anaconda.org/main/linux-64/fontconfig-2.14.1-h4c34cd2_2.tar.bz2
+  sha256: 4a623c7f73f4531a16271ded00c80e7dce65aa35b5105015fc4d0ceb37c9fa0d
+  md5: c9dc79248f887050dc89e19670dcbd66
+  depends:
+  - expat >=2.4.9,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - libxml2 >=2.10.3,<2.11.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 383064
+  timestamp: 1679578197653
+- conda: https://conda.anaconda.org/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+  sha256: b75d12e85274660bb675a3e53d47a929872f2daa2ff5a76e98885ee3f2d19ad1
+  md5: f2119d0885334060d0d7fe59e5220287
+  depends:
+  - brotli >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - fs >=2.2.0,<3
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  - zopfli >=0.1.4
+  - lz4 >=1.7.4.2
+  license: MIT
+  license_family: MIT
+  size: 3237908
+  timestamp: 1713551660998
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+  sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
+  md5: a5dc8677d891dff2393b63189a3ad42f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 971975
+  timestamp: 1666798278693
+- conda: https://conda.anaconda.org/main/linux-64/fsspec-2024.3.1-py311h06a4308_0.tar.bz2
+  sha256: a78f34d0b919c5fce722d33afc278cd48f5eec2bf186c35dd18d59d85d45909b
+  md5: 199586a3dcad8985bc4cb0e4262e06d1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 364478
+  timestamp: 1714461584790
+- conda: https://conda.anaconda.org/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+  sha256: 2fc1136056f41fe92de719fb821550346704965dd12a5fa35069cdb4948d5c17
+  md5: fd089b0fba2b03aafe3adb6cdaa9ac3b
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203421
+  timestamp: 1706888218007
+- conda: https://conda.anaconda.org/main/linux-64/glib-2.78.4-h6a678d5_0.tar.bz2
+  sha256: d9a486f0ac92b1365365c3e536040a552c2de633283f27129f16dadcbc6d2de8
+  md5: 32538e0c24874a85011a094217830bd4
+  depends:
+  - glib-tools 2.78.4 h6a678d5_0
+  - libgcc-ng >=11.2.0
+  - libglib 2.78.4 hdc74915_0
+  - libstdcxx-ng >=11.2.0
+  - python
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 499006
+  timestamp: 1708031707428
+- conda: https://conda.anaconda.org/main/linux-64/glib-tools-2.78.4-h6a678d5_0.tar.bz2
+  sha256: cc7d3a52acad1df08e3d4ec7eefb22f41320e7eada94e78bf4b051128cbe72d4
+  md5: d8dcbf2be12799cf7f333c21a0e91990
+  depends:
+  - libgcc-ng >=11.2.0
+  - libglib 2.78.4 hdc74915_0
+  - libstdcxx-ng >=11.2.0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 112595
+  timestamp: 1708031685927
+- conda: https://conda.anaconda.org/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+  sha256: f1e190d4ee766add8131a2b011723c472284de2bbb5e07c8f895f30e3c591df7
+  md5: 82029e0758feac811afec2a6ef9e6155
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 108438
+  timestamp: 1706895276199
+- conda: https://conda.anaconda.org/main/linux-64/grpc-cpp-1.48.2-he1ff14a_1.tar.bz2
+  sha256: 32657e2d11dd813e5649f714c7f58115cff3387f27cf0904cee873bd0d82d2a4
+  md5: bdfb8214247977e4ededa4aeb3291ea3
+  depends:
+  - abseil-cpp >=20211102.0,<20211102.1.0a0
+  - c-ares >=1.19.0,<2.0a0
+  - libgcc-ng >=11.2.0
+  - libprotobuf >=3.20.3,<3.20.4.0a0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libstdcxx-ng >=11.2.0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5391101
+  timestamp: 1685747457305
+- conda: https://conda.anaconda.org/main/linux-64/gst-plugins-base-1.14.1-h6a678d5_1.tar.bz2
+  sha256: 833208211f0ecb52198f5fae585f937be3c337c15b4569d8f1a28638545250d5
+  md5: 2fa837925e0633ceae4ec826f6daa93f
+  depends:
+  - glib >=2.69.1,<3.0a0
+  - gstreamer >=1.14.1,<2.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libxcb >=1.14,<2.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  size: 2253949
+  timestamp: 1677171916164
+- conda: https://conda.anaconda.org/main/linux-64/gstreamer-1.14.1-h5eee18b_1.tar.bz2
+  sha256: 8257a1c1c967d48561f62adb649fe21c467f0a37c41f783ba6e2c6d79fa1cc4f
+  md5: 5cd8e1f16b1ce869d0c3a98b9f0897fb
+  depends:
+  - glib >=2.69.1,<3.0a0
+  - libgcc-ng >=11.2.0
+  size: 1690003
+  timestamp: 1677171850557
+- conda: https://conda.anaconda.org/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+  sha256: b35b281dbf69b826c6ae04fcd7b6a2d1f098277a669a199906a1f23b4b0931a5
+  md5: 2a793fe24f85aa5819fe69c450cba6f7
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 29021241
+  timestamp: 1692293243228
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+  sha256: e08e27531775de40f46b6ac7bf71856963baa0c008bd2b4d112e6341cd3e8f4c
+  md5: bfc7682613c861cbcb4ac01485c05657
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147174
+  timestamp: 1714398938840
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+  sha256: c7ffa6006573483a05ef355770c3201f04dd04ab4b91ae01971a6cdc7fbdba35
+  md5: 23d7d38e93d930ea5e2cc5f4079d3816
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 49872
+  timestamp: 1704813633807
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+  sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
+  md5: 3add2ce56858a1b8f6a37342f82773d3
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<1.2.14
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 19310769
+  timestamp: 1699647799237
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+  sha256: 0b670ab17ed2e1b592079bd64386dadc249ddc892e5ae1dd99f142a918ffc75d
+  md5: 632575b9e442c1e5c146cf78424da610
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 227791
+  timestamp: 1705934138566
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+  sha256: 65228eb868c3ec8aa71f958e60a675a919f016c2057392e02fd422fc841858f9
+  md5: 68e23f14cd222c233e6b37262bc61c23
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1612840
+  timestamp: 1704833066871
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+  sha256: a2918ea8a3e2c56fc6d91191e84b2f35500c392b16ab687a0c03ded2e2e51239
+  md5: 84fadd6b7fef393cccc0d123dae6cae8
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1162207
+  timestamp: 1679336523618
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
+  sha256: 4520b83e425883981f97191986a08122fbaebc3f16b898368796314136779028
+  md5: 42a8f32c4d842d3e5410b2bc1cc2fb57
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 352284
+  timestamp: 1706733655761
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+  sha256: c21f8f407266d039e819c27fe9eb4fb26587e974f3bd059b37cbaec5073722d0
+  md5: ba1f47411e9e07876c7a3e9d3be6a98e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: IJG
+  license_family: Other
+  size: 281400
+  timestamp: 1677849152168
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+  sha256: 06b729aee6dd2a1e545f3ad64179cc0d4ef8a15e33db3be2995dd3e0868465ca
+  md5: 8bb3215912588e47e2eeb4e7a09ad64f
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 180858
+  timestamp: 1699041715847
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+  sha256: 9e3bac2d41bd432b721b009e7de981766fba396e6f238e923f304112bd88655a
+  md5: 84ae4cf3f2d01fbebdac374971192be9
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 15525
+  timestamp: 1699032521315
+- conda: https://conda.anaconda.org/main/linux-64/jupyter-lsp-2.2.0-py311h06a4308_0.tar.bz2
+  sha256: c4b1dcb8ba34bfb2c7fc6ccf1399dd0bd2a324e792eac722561607f2bff68d72
+  md5: d82f26a5c414b519c7737240fb7f342e
+  depends:
+  - jupyter_server >=1.1.2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100413
+  timestamp: 1699978354251
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-8.6.0-py311h06a4308_0.tar.bz2
+  sha256: d215948faad1eff39b5bec3da793d6d185b85793a1d839c3d1c196b85fd6c9b1
+  md5: 555ea509581f49256e7aae2ff5dce460
+  depends:
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 221658
+  timestamp: 1699456577818
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+  sha256: fedc7e5560252af44b0dfbe6f7acfe20ab17a6a08e758f670a1cd820551afc7a
+  md5: bd28d36963087f53a79b23fee697d665
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 93898
+  timestamp: 1698937453304
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+  sha256: 2b896fe8b2187b7df824041826e14379476eb2e61d607d8cb38ac2b3df40aaa4
+  md5: 8fc7e517da96c2c482331f6b08d07a17
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41459
+  timestamp: 1699282616532
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+  sha256: 87d372f5b23bcc2410e43b40b4ad059ea1625178b8a2b484fc63805ce517e594
+  md5: 50204f372b1672871d6ab3db6a876374
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 594177
+  timestamp: 1699467208489
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+  sha256: ddfee06ba9b149222c65d1d4270272840533aa63b56fe36363c84a891c71d328
+  md5: ee128e5c0d8d9e1952e2387b66a5b8cb
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27239
+  timestamp: 1686870958829
+- conda: https://conda.anaconda.org/main/linux-64/jupyterlab-4.0.11-py311h06a4308_0.tar.bz2
+  sha256: a2bc9b312a31e5abaedf230659ecb31f9483a1a3c0f4cd1adae7f5ea2045f9d6
+  md5: 728bdb3c057e57cd963f304d2c8a48a9
+  depends:
+  - async-lru >=1.0.0
+  - ipykernel
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.19.0,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  - traitlets
+  constrains:
+  - nodejs >=18.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6665313
+  timestamp: 1706803269767
+- conda: https://conda.anaconda.org/main/linux-64/jupyterlab_server-2.25.1-py311h06a4308_0.tar.bz2
+  sha256: b8c434bad4499fc41d0e18986b7ab1fbcf5e2aabadc2658430ee1f5cd16c4cbc
+  md5: 59a08c840ebfa765cfe5d4dc764804c7
+  depends:
+  - babel >=2.10
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18.0
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.11,<3.12.0a0
+  - requests >=2.31
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 106168
+  timestamp: 1699555585974
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+  sha256: b040f0d0ee4588188ab6b83a93738b3ff6e6d1775424be97995bd0df0f4fb904
+  md5: eae62735d710cf5ff6d51e6f59fcd999
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78148
+  timestamp: 1676827253282
+- conda: https://conda.anaconda.org/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+  sha256: 01bae3dd44469e34f043e0416f5f5e658429bf4031745399d9968d10b899e2c4
+  md5: 10171cca67e3d73c3646c6dc5a321460
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.8,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1427115
+  timestamp: 1686931095252
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+  sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
+  md5: 88199c75f2ac211728febced7785c24e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 228278
+  timestamp: 1635523146417
+- conda: https://conda.anaconda.org/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+  sha256: e2754627e8aeb98777318939e6773b9eadbdc219dd8961aca946354d9d30f481
+  md5: 4ed89646229bee3e594cd2cc8f6060f9
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 23778916
+  timestamp: 1696762223408
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+  sha256: bb990ea068c3b3dafd9c807e0e19570320cb2fe7d69cc326f1f0b5319b0654b2
+  md5: 3ff70744e396b1af69656c574b05c3b9
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 66940
+  timestamp: 1714483221853
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 3b87a816f72a00e1f0022a160e7eda70af89d3de2a2e08a72be1c17b31d759f3
+  md5: 4f57d3a0a13ddaf1c06efb586b702f46
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 34446
+  timestamp: 1714483232430
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 2cf15e89f910600f468edfde8d0f9b80a14fa2319ed89160dc7375dfd3764fdb
+  md5: 463adc13f2feea3570d1eccac368d9e4
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 295090
+  timestamp: 1714483244460
+- conda: https://conda.anaconda.org/main/linux-64/libclang-14.0.6-default_hc6dbbc7_1.tar.bz2
+  sha256: 46646ce93dafb4922f4597c34c4fec106b4ff3b9707a202387f7964601e47876
+  md5: 5eaf417727302b441025661154fc4587
+  depends:
+  - libclang13 14.0.6 default_he11475f_1
+  - libgcc-ng >=11.2.0
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 130632
+  timestamp: 1681222907766
+- conda: https://conda.anaconda.org/main/linux-64/libclang13-14.0.6-default_he11475f_1.tar.bz2
+  sha256: 24d638d8577a3332a2e6cd77a5178054ca9cf7e14f71353b5b0a655155ab5c19
+  md5: 230f394424c6cc26ebbee96176b65ece
+  depends:
+  - libgcc-ng >=11.2.0
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 11152969
+  timestamp: 1681222877667
+- conda: https://conda.anaconda.org/main/linux-64/libcups-2.4.2-h2d74bed_1.tar.bz2
+  sha256: f465c8f00b075660362d8e7fba8702b1c11e56fb2c305da78b9ee69898609be7
+  md5: 8a2e46dc8bd62528a6f4d9092f2f6911
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4901408
+  timestamp: 1685057846629
+- conda: https://conda.anaconda.org/main/linux-64/libcurl-8.5.0-h251f7ec_0.tar.bz2
+  sha256: 22628e28b6df8298b761c4524b086a02b0e9fe208cf37ec86090497c4db50583
+  md5: 7d328929de28a113f3e5b8e0d70ce709
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libgcc-ng >=11.2.0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.57.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=3.0.12,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 403919
+  timestamp: 1704383721246
+- conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+  sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
+  md5: 55dde57e63a36b202e388a39dcee9a66
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 74096
+  timestamp: 1695996494461
+- conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+  sha256: 5bd3af246b6a93ea0912179ae66e0ad9157ca0142263010d84b65724e6db0bec
+  md5: 5cb0cc0e1783419cf8fc1c65fee0f62f
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 195807
+  timestamp: 1703006263489
+- conda: https://conda.anaconda.org/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+  sha256: efdab884c85fda4461f7a393aa6d4e0e50d03cb59fb9c8a980b1307b8379ebe0
+  md5: eeca774c6154c49340dd403b1928d5e9
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 108906
+  timestamp: 1632891483341
+- conda: https://conda.anaconda.org/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+  sha256: 4b2518a1aa3859031a531cd1077e8a60d5b3a0dc7c83210ef27ff9ce2c78c3e3
+  md5: 49f152ee4045544c10799d32bba85c07
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 480247
+  timestamp: 1685052130829
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+  sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
+  md5: 1af9b4d62c708924417f2640ef22a68f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 154016
+  timestamp: 1714483282916
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
+  md5: 641e72e5067bd6d5454405879e1cd2a7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - _libgcc_mutex * main
+  - __glibc >=2.17
+  constrains:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - libgomp 11.2.0 h1234567_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 8895144
+  timestamp: 1654090827491
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+  sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
+  md5: 27082517590f3b9fbffecc68513b461b
+  depends:
+  - libgfortran5 11.2.0.*
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 19860
+  timestamp: 1654090819660
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+  sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
+  md5: 0202c3c8ae4735cac6c7f3d1e1685964
+  constrains:
+  - libgfortran-ng 11.2.0 *_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 5228750
+  timestamp: 1654090762569
+- conda: https://conda.anaconda.org/main/linux-64/libglib-2.78.4-hdc74915_0.tar.bz2
+  sha256: ddda848ae8594a9a28b14439b322763e4ffb0ff8d34e492c994e434fe3fbf934
+  md5: e35935cc3937ef52b2ef721dddc45738
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libiconv >=1.16,<2.0a0
+  - libstdcxx-ng >=11.2.0
+  - pcre2 >=10.42,<10.43.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - glib 2.78.4 *_0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 1583413
+  timestamp: 1708031663093
+- conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+  sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
+  md5: 3080c2813e6e1d0f8a100a38b5b3456d
+  depends:
+  - _libgcc_mutex 0.1 main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 573231
+  timestamp: 1654090775721
+- conda: https://conda.anaconda.org/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
+  sha256: ed544d8aa7e77fc42c39c276b879955e6615b517c42fecd2624033a5050832eb
+  md5: 21ee76e09ab0a7315cbed14933d97773
+  depends:
+  - libgcc-ng >=11.2.0
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1436714
+  timestamp: 1714483320555
+- conda: https://conda.anaconda.org/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+  sha256: 512fac06ddd97b4383503d4fbd8145102966055b29ccf86841a930dbb4ef3ab8
+  md5: 833c0e514ff9c8ae0511630b024d60e0
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 37179832
+  timestamp: 1683292829131
+- conda: https://conda.anaconda.org/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+  sha256: 6c67d781d3c074ae46b18567f230bce4a4afa209e8b914dc2cb448502774886e
+  md5: c9627c386bbc8a1a1a0a2e736ea44501
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - c-ares >=1.7.5
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 722387
+  timestamp: 1697018420830
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+  sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
+  md5: 1bffe1481ed4f88827248fb9001f8923
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 362561
+  timestamp: 1677841789536
+- conda: https://conda.anaconda.org/main/linux-64/libpq-12.17-hdbd6064_0.tar.bz2
+  sha256: 9fbd40a9bcf75d2f7aab558b3803175d419b1178ec2ece0d77c40a3e47cf0d9f
+  md5: ca25d5734b0361f78536d5e77b4b3e43
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.12,<4.0a0
+  size: 2973280
+  timestamp: 1706214551622
+- conda: https://conda.anaconda.org/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
+  sha256: a24f7d1cdb5e18466a61860a5a66baffd608e212bbfed2935350e83d4d8659c0
+  md5: b32a43de76bc9be9c71f9a12edec8a1e
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2706964
+  timestamp: 1675278653314
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://conda.anaconda.org/main/linux-64/libssh2-1.10.0-hdbd6064_3.tar.bz2
+  sha256: e3aadf465217537237e9e4c849f19f1ecb76a760e4b4ac479a02971832e39e75
+  md5: c3f8eb577f0da5f7524896bd4bce2dda
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.13,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 337499
+  timestamp: 1714510585581
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
+  md5: 8c195584a5f5471b600ee180e4052773
+  depends:
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 6410287
+  timestamp: 1654090800863
+- conda: https://conda.anaconda.org/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+  sha256: 974e4035c5d51cd41fa7a7f02fadc1980069c00526c1646fa18ea94e667fb137
+  md5: 188de945b4279a812953011e8c4580c2
+  depends:
+  - boost-cpp >=1.73
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.9,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4630795
+  timestamp: 1687975185557
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+  sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
+  md5: ef78eebd98289aceacdfa29182426adf
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 664034
+  timestamp: 1693575237924
+- conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+  sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
+  md5: 292768ec77416ae257cfdd44ea2071c8
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29197
+  timestamp: 1668082729834
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+  sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
+  md5: 9cdeef1d044c7e035c006890f11569d3
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 436056
+  timestamp: 1694776944891
+- conda: https://conda.anaconda.org/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+  sha256: 5d68e69709ae10bd6c4b58b6af447ad2f2bd24955994f3ec77103d1a6bf5e1f5
+  md5: 49e523de8d364b7fabc3850eccbe9bda
+  depends:
+  - libgcc-ng >=7.5.0
+  size: 623492
+  timestamp: 1652448233146
+- conda: https://conda.anaconda.org/main/linux-64/libxkbcommon-1.0.1-h5eee18b_1.tar.bz2
+  sha256: 114853749b375d54347f18b472456eb7d66beba26238c984403bdd5ff8831947
+  md5: 6225f107993ddf5e1f61111b3df025bd
+  depends:
+  - libgcc-ng >=11.2.0
+  - libxcb >=1.15,<2.0a0
+  - libxml2 >=2.10.3,<2.11.0a0
+  license: MIT/X11 Derivative
+  license_family: MIT
+  size: 640985
+  timestamp: 1679578328295
+- conda: https://conda.anaconda.org/main/linux-64/libxml2-2.10.4-hfdd30dd_2.tar.bz2
+  sha256: 392fa116c728a97c17f3105a4d15b1ad86ee0b79c33c3581616b871b6d3f3f5b
+  md5: 09e1d64be1c4268bc83d1e84d28019f2
+  depends:
+  - icu >=73.1,<74.0a0
+  - libgcc-ng >=11.2.0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 745147
+  timestamp: 1713558300638
+- conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+  sha256: fd8e30beb8c9442f16e6617fac92dd0c89ec823e98f06e60f712147380ead35f
+  md5: 7ed7caf2816c8b85b67b6f4e8833cbd5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41155
+  timestamp: 1676837080881
+- conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
+  sha256: 05e355127db0d3ed67c4c383fd929ef1c3d7d3f19472f6e5433a866e94378bed
+  md5: b7897895622e5ab6e62279f07fa1f587
+  depends:
+  - libgcc-ng >=11.2.0
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4367002
+  timestamp: 1706910875807
+- conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+  sha256: 95fe76d2691feb13203b55ad2aba535bb848cae21ffd05b13ff51c7a45fa2332
+  md5: 6a04ec16e3abc1c7e2104be32cd6c418
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13458
+  timestamp: 1676827287432
+- conda: https://conda.anaconda.org/main/linux-64/lz4-4.3.2-py311h5eee18b_0.tar.bz2
+  sha256: fc8fa25c9629d8b5362d14ca7c90792064492aef7765a60e3574948f4659b4f2
+  md5: ed09cfc6c49987d5af17585f5e5168cb
+  depends:
+  - libgcc-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40405
+  timestamp: 1686058019487
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+  sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
+  md5: 76f089e76ec67583bb38428b51008097
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 164494
+  timestamp: 1714510587156
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+  sha256: 260e26dd509834c1b225ab7bdb97b9a86e00054fbdd5dfa49e68fa4dcf85a661
+  md5: 8f5d7ddc69cc6f7d44c80d2251dea5d1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162339
+  timestamp: 1676837095436
+- conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+  sha256: 7f5b0804d0768619b7bd93b10488067d80bf42ec29f443f00b53ba11758a1241
+  md5: 8afb45e45c0d93bfd142e682d4b021ef
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 134438
+  timestamp: 1684280014220
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+  sha256: cb03570c99c983d7bfda94bc47d8eb00d4059b8548a171130775acc998004195
+  md5: 5b1abbbf1e4f9b350b16fc9caf9e889b
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26919
+  timestamp: 1704206397615
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-3.8.4-py311h06a4308_0.tar.bz2
+  sha256: e7eb5bfdaf1c62bfe2489237ea4ae6a837f09a647f846c31e4022a04e07355c0
+  md5: d744bdd5306fb954b4ed65311db45174
+  depends:
+  - matplotlib-base >=3.8.4,<3.8.5.0a0
+  - pyqt >=5
+  - python >=3.11,<3.12.0a0
+  - tornado >=5
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8014
+  timestamp: 1713336708416
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+  sha256: 85fea48bea278a77d102781a1cbb6bf69307207d741251e38a6515c5fd7e3523
+  md5: d6ddba94f7c33c88c9825be8409991bf
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9150942
+  timestamp: 1713336680714
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+  sha256: 7ac07ea180b5928086075900afbc332fb1d3c81ddfacb54c891693c284056f14
+  md5: fc83dd1b3d2ec3c0a297ead0c3405907
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19573
+  timestamp: 1676823852670
+- conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+  sha256: c9ba2f9c83820712dd97d6a1b54a1215b9820a0be02ac82380b4c50911b9400c
+  md5: e5dc6b4a5b8e02733ce3bc9e9198a8d2
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67750
+  timestamp: 1676837123613
+- conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+  sha256: 1a5141ef0de1cbff816f96bb4b212a40606e2fc11301a4c1358c8d63a6b2b027
+  md5: 22ac3bc22b68fef4c1f3f6ab3c7bfe0b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23040
+  timestamp: 1676827301164
+- conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+  sha256: 9aacfbbe6f638c58a4e8ff31374d1438d78b7db25d6ea6fd0c50ca2109f225d4
+  md5: e602057e3b3d80da88c61d66e8851c5b
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104681
+  timestamp: 1676823696152
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+  sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
+  md5: ce77d0f05f846da4a6b9e23fe7f21d9b
+  depends:
+  - intel-openmp 2023.*
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - tbb 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 206738176
+  timestamp: 1699648006088
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+  sha256: 2aef0876d0df033f7fae8cddbd25d95fc1bfc067e60dd143bd8000fec0768b21
+  md5: d6cdc670327bd1675bbea642849f04e1
+  depends:
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59569
+  timestamp: 1682948560323
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+  sha256: 691c4b2b47cf3fac55b4949d7c0f547246ef19cb3510749142cee4bd01ffb055
+  md5: bbd69efa3f24ee747410f83118640d92
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 240723
+  timestamp: 1695058405382
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+  sha256: 71f5c7beca4e81b465ecfc6ed51cb3d39f51dd88df0b29eff5def3d1f12969eb
+  md5: 61d58663b7277cf4cc3cb8d9873d3ee8
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331105
+  timestamp: 1695059935112
+- conda: https://conda.anaconda.org/main/linux-64/msgpack-python-1.0.3-py311hdb19cb5_0.tar.bz2
+  sha256: ee4db7daf8d5e41a547e7790dd62aa98e203f4f857cf6018b850e7df8e613a3c
+  md5: 17145d1745996667614b52d2b27a1403
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 37588
+  timestamp: 1676823053826
+- conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+  sha256: b558b3f6c144652b5e0d26497b3ce24c318a6b9ff8ea2079113c95e5553b3cf9
+  md5: 0b185969ac2b065c27cbcc9641d93678
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29568
+  timestamp: 1676841232463
+- conda: https://conda.anaconda.org/main/linux-64/mysql-5.7.24-h721c034_2.tar.bz2
+  sha256: 1127b7dbb0a740f3de8931a4af5b70b3dac6dc3de162a2d8f8760335db5e6669
+  md5: b4ab7fa3430324358189ca5ff9fc8e42
+  depends:
+  - cyrus-sasl >=2.1.28,<3.0a0
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.9,<4.0a0
+  license: GPL-2.0
+  license_family: GPL
+  size: 82391019
+  timestamp: 1688563074905
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+  sha256: bb45fb0a3973caa74fd8f845e0a519895f6a378807626e15ecf72c02f2eed794
+  md5: 185f658ba8a74e326b7231c8fd0d62bf
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 121834
+  timestamp: 1698934274227
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+  sha256: 8b2fc372a6655fd5b277d07b994ce43643553fbc37e63a60e9fe527a9026ec06
+  md5: ed6ac14aed5a796b153d757862398997
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 523905
+  timestamp: 1699022906468
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+  sha256: 7908ff6c516b15e8fb677be4071145e18adea7d4c13b8485a70a5ee2f573f8cb
+  md5: 50c0e38207a131a5de6a14ef919ffcdc
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 169629
+  timestamp: 1694616826002
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+  sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
+  md5: 57ea097dc15f8d9f9eb90e1d919143b0
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1157733
+  timestamp: 1674734069410
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+  sha256: 266199dd4efde0ad342a9c500f4bc4299c5622219aea623b46315a9b4f6b8959
+  md5: 2b21844d2b0024d0ffad0e6450cf0855
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 15860
+  timestamp: 1708532713870
+- conda: https://conda.anaconda.org/main/linux-64/notebook-7.0.8-py311h06a4308_0.tar.bz2
+  sha256: 59e17fc80ec01ffef983431d36b41013d1da575e03f5bc1ff36fc3b7e496e7be
+  md5: b4e5249538db1bc282ac0d0d8c4f307c
+  depends:
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab >=4.0.2,<4.1
+  - jupyterlab_server >=2.22.1,<3
+  - notebook-shim >=0.2,<0.3
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3650043
+  timestamp: 1708029938702
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+  sha256: ef2857e6d3d7eb246b3abddfbd3aa2d124dd8565391ace3876b77339babc50bb
+  md5: d276d1b1774107987963135c78ca7390
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26607
+  timestamp: 1699455972519
+- conda: https://conda.anaconda.org/main/linux-64/numba-0.59.1-py311ha02d727_0.tar.bz2
+  sha256: 1b830d1d091462cff92de55f24339365a9d2c23b27d19799833b4780efe99c15
+  md5: 06367b04f8f04c0dc4e356a2ca9dc854
+  depends:
+  - _openmp_mutex >=5.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - llvmlite >=0.42.0,<0.43.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  - libgomp
+  constrains:
+  - scipy >=1.0
+  - cudatoolkit >=10.2
+  - cuda-python >=11.6
+  - tbb >=2021.6,<2022
+  - libopenblas !=0.3.6
+  - numba-rvsdg 0.0.*
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6084284
+  timestamp: 1711988494237
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+  sha256: 2f89f38a665ece47e8868b391fc70602fcee588e989bc1ca6f17f6094892a94e
+  md5: b788c80b2d571531ea4f3f8335ae5423
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 168827
+  timestamp: 1696515597877
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+  sha256: e09e1aff2c12d4ef3fec58fb627744e4b5c7d9eaede7175e293f77272d8b8bfd
+  md5: fe8242cfd54d238507493612ae697ad4
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311hf175353_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10270
+  timestamp: 1708639794640
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+  sha256: a53ad723826651041a5057a1cf31bc8689b24d335ce61b196df5124974b05a8e
+  md5: 7b29e7191c4170189d6080e61229f030
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311h08b1b3b_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9163911
+  timestamp: 1708639777712
+- conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+  sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
+  md5: b0afe23033c8c5344640bc25225fa579
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 516994
+  timestamp: 1630084830020
+- conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.13-h7f8727e_1.tar.bz2
+  sha256: 9e90c0fd10fcc5a73afab93ed7f7f6a4d4822feded941198ae66d999923323ff
+  md5: 8d976dfed2a62a709aa759dba69da8a3
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 5512151
+  timestamp: 1714510995665
+- conda: https://conda.anaconda.org/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
+  sha256: 9618addfc1b940c048372ffb2c8500d4b44d02455a9bd1f411e530ed5e09b8d5
+  md5: 56057ed323f733bdcf262468682d0358
+  depends:
+  - libgcc-ng >=11.2.0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.9,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1132661
+  timestamp: 1676482768554
+- conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+  sha256: 280225061aeba00d7b85f46e55d7d79cd92c92f662dc749d9c53187978e8d083
+  md5: c51c21da68080d89300703ad818c824a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38606
+  timestamp: 1699371264464
+- conda: https://conda.anaconda.org/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+  sha256: bd3eacd22e85f88bedd9c7e97a59eacfb3c8bb80eb59be244825d6895a0e7ac1
+  md5: 08ceb294ba8a9ae13630da789884736e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 157904
+  timestamp: 1710807470578
+- conda: https://conda.anaconda.org/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
+  sha256: a2ee3a6aaf54929b82b851b2eb5436e14e5a294303ef429d6dccd33bcdfc8002
+  md5: b467a5c7ad672ccc2d498a67b9eeeaaa
+  depends:
+  - bottleneck >=1.3.6
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - fsspec >=2022.11.0
+  - matplotlib-base >=3.6.3
+  - tabulate >=0.9.0
+  - odfpy>=1.4.1
+  - pyreadstat >=1.2.0
+  - pyarrow >=10.0.1
+  - python-calamine >=0.1.7
+  - s3fs >=2022.11.0
+  - beautifulsoup4 >=4.11.2
+  - gcsfs >=2022.11.0
+  - xlrd >=2.0.1
+  - dataframe-api-compat >=0.1.7
+  - pyqt >=5.15.9
+  - adbc-driver-postgresql >=0.8.0
+  - fastparquet >=2022.12.0
+  - psycopg2 >=2.9.6
+  - qtpy >=2.3.0
+  - openpyxl >=3.1.0
+  - xarray >=2022.12.0
+  - html5lib >=1.1
+  - jinja2 >=3.1.2
+  - pyxlsb >=1.0.10
+  - sqlalchemy >=2.0.0
+  - zstandard >=0.19.0
+  - pymysql >=1.0.2
+  - pandas-gbq >=0.19.0
+  - lxml >=4.9.2
+  - numba >=0.56.4
+  - xlsxwriter >=3.0.5
+  - blosc >=1.21.3
+  - adbc-driver-sqlite >=0.8.0
+  - pytables >=3.8.0
+  - scipy >=1.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17970687
+  timestamp: 1709593080388
+- conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+  sha256: a2e2beff710765f2e5135020121da4f227f5e1cbe142e17398a585f50a389d37
+  md5: eaf734d49b6e576e12be1398a295643a
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - pandas >=0.19.0
+  - numpy >= 1.9.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 47447
+  timestamp: 1698702703255
+- conda: https://conda.anaconda.org/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
+  sha256: 71beb7373390a7c5e9bf8663d64e2b0a426755fe68adb26ed72b6570634f635e
+  md5: cd7c1793b37ba076f8515b49dbd850bd
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3346886
+  timestamp: 1714657706306
+- conda: https://conda.anaconda.org/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+  sha256: 28ed719669260a20bec78971edaffb91ec917d2a3f0fac1cf9a8ba21590baa43
+  md5: 0481d078fcd64f7f981532a514d9d50d
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 960727
+  timestamp: 1714399060039
+- conda: https://conda.anaconda.org/main/linux-64/pip-23.3.1-py311h06a4308_0.tar.bz2
+  sha256: 0bedd7decde6751a3efbb2367dd22d916b61391e334833d548b285fdd3420080
+  md5: aebee46c2eadf95ea8633847612f0f15
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3443056
+  timestamp: 1700667782149
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+  sha256: d2bbab8bfc57c7f46ca8994bc87df7e744d3f036b867bc4be1145ba6d8d7e091
+  md5: de41707272a8e3ccab764f0b7010a27d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37394
+  timestamp: 1692205565974
+- conda: https://conda.anaconda.org/main/linux-64/ply-3.11-py311h06a4308_0.tar.bz2
+  sha256: 786a4a57db582b66de12bd7e03eae83caa939136dabd8b53049cadeabc0beb6f
+  md5: 262064c348f1846011c650ad8a6cd793
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-clause
+  license_family: BSD
+  size: 111320
+  timestamp: 1676824981885
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+  sha256: e2a0e2a618aa33f0beff9583c7dc510b8d0737b023117346676aacbad33970d8
+  md5: 66a6818307261b1a28ab12d1b7776fdf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 121454
+  timestamp: 1679340540306
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+  sha256: b7f591c19b10bf0daa7e6e3b45a9f4a0a0e83188e1f8a58037caea79e60f8d91
+  md5: d945b4ccc135005839c504cc29df1745
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 749608
+  timestamp: 1704404477511
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+  sha256: 96482b49191fdac59580a95e69508367083e1f7600145e11d7c2db634337eb26
+  md5: 2d57bf8eacf3f291db845928241f724c
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 490805
+  timestamp: 1679337420563
+- conda: https://conda.anaconda.org/main/linux-64/pyarrow-14.0.2-py311hb6e97c4_0.tar.bz2
+  sha256: 252204d5e65480b83b9e31c63cecfaff95725ef5fc302714f92c344b7fdbafe3
+  md5: f2b86ab94d7af6c10b9586263b1b45df
+  depends:
+  - arrow-cpp >=14.0.2,<14.0.3.0a0
+  - boost-cpp
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 5423490
+  timestamp: 1707331892286
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+  sha256: ed927e4d058a8f4ea73edc7a43ed74877d93b88fdfa240b3b2777244386ced70
+  md5: a1f0e05fc7e49712f81ad5478ec9d51e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2121496
+  timestamp: 1684280065800
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+  sha256: ad219924e362ce7af458fa6547660181579e9a50e5aed1ffd9268cbe7c2650e3
+  md5: 2b1ac40e0df3673d33b7f4c4f93ae1ef
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207338
+  timestamp: 1677811584327
+- conda: https://conda.anaconda.org/main/linux-64/pyqt-5.15.10-py311h6a678d5_0.tar.bz2
+  sha256: f0c1614d5e651ed15061d137acecda2f684189cc148f50d3e75068dc9737bcd4
+  md5: 0911e45b849687c7318f7764e2b69778
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - pyqt5-sip 12.13.0 py311h5eee18b_0
+  - python >=3.11,<3.12.0a0
+  - qt-main 5.15.*
+  - qt-main >=5.15.2,<5.16.0a0
+  - sip >=6.7.12,<6.8.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 6539272
+  timestamp: 1698775883859
+- conda: https://conda.anaconda.org/main/linux-64/pyqt5-sip-12.13.0-py311h5eee18b_0.tar.bz2
+  sha256: a646cae6b3d429588a3dc752819b4dcb315a814c8ad2b9fb2741b166fc4ee2a6
+  md5: eec3045856f86acc307c73749a7f7df1
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 97216
+  timestamp: 1698769366045
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+  sha256: 114b55e00f4622c90fd2b404b21ad5f94a10283fcaaf86a42174b8d39b0a3e98
+  md5: 2458e92683cc68671a6c8e1b86ce8817
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35850
+  timestamp: 1676822725516
+- conda: https://conda.anaconda.org/main/linux-64/python-3.11.8-h955ad1f_0.tar.bz2
+  sha256: 8bae0856b2f337f43cb5cbbf71ebf684ef47438210465b8733304d7d7f258559
+  md5: 7fa94ac6e31488660ca09b2896b9d96d
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.35.1
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.5,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 36090392
+  timestamp: 1708984519285
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+  sha256: aadc4078311c059265706a56265f0a57ceb538d36179d5203dd487d80d0e8f16
+  md5: 59ec670fcd172447dbd9591b8fbfdd56
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 278741
+  timestamp: 1679340144625
+- conda: https://conda.anaconda.org/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+  sha256: d5058d0ecc3973316c1d5f1bfb03dd119e0dade85f4c2d21b412c8db4e1636f2
+  md5: 93000e4d3603342779a2afda66fa91b8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17607
+  timestamp: 1683823841946
+- conda: https://conda.anaconda.org/main/linux-64/python-lmdb-1.4.1-py311h6a678d5_0.tar.bz2
+  sha256: d9eff881e112d0b326d0c1ee0d42d6c2c4649b1c4edd168be1006f28f1f8962e
+  md5: d9d1f41dcee9b622cbfe048ab1632a47
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 154074
+  timestamp: 1682522389521
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+  sha256: b85acb933fff864bfa89d034e8e3d85b1a9c2e69cbfc0d68c1d66ffd1443e67d
+  md5: 0cdb92d2d684ee1095310f992ed0d9b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 266796
+  timestamp: 1713974338678
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+  sha256: b2a1f649669f4336b74f6f20df711959bcd8024f8f8b94199dc0e040b06bd37a
+  md5: f9e8e3f7068f717f75e555dc04545d8d
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 206433
+  timestamp: 1698096204677
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-25.1.2-py311h6a678d5_0.tar.bz2
+  sha256: 787979e7e36b0eaf06c65f8840f3af969b6efa6ba2a7e2736b1bb52e96588242
+  md5: eb62cbfdbe25aaebbafad6166ec66903
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 583036
+  timestamp: 1705605396341
+- conda: https://conda.anaconda.org/main/linux-64/qt-main-5.15.2-h53bd1ea_10.tar.bz2
+  sha256: 34fca7030324880c741f8b2030673229883cb7a11429f8e4bd2664d7d0f07ae1
+  md5: ccbd6faf6b49454aec690b72d21666dd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - dbus >=1.13.18,<2.0a0
+  - fontconfig >=2.14.1,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - glib >=2.69.1,<3.0a0
+  - gst-plugins-base >=1.14.1,<1.15.0a0
+  - gstreamer >=1.14.1,<1.15.0a0
+  - icu >=73.1,<74.0a0
+  - jpeg >=9e,<10a
+  - krb5 >=1.20.1,<1.21.0a0
+  - libclang >=14.0.6,<15.0a0
+  - libclang13 >=14.0.6
+  - libcups 2.*
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=12.15,<13.0a0
+  - libstdcxx-ng >=11.2.0
+  - libxcb >=1.15,<2.0a0
+  - libxkbcommon >=1.0.1,<2.0a0
+  - mysql 5.7.*
+  - openssl >=3.0.10,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  constrains:
+  - qt >=5.15.2,<6
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 62392312
+  timestamp: 1693222657819
+- conda: https://conda.anaconda.org/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+  sha256: 8a640736bef635346409582dbfe2b7d0ecc9da215c90173ff8a9a5fe22569107
+  md5: 6b583dce61c6feb352ef0f49f413af1e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-3-Clause
+  size: 235004
+  timestamp: 1652449537852
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+  sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
+  md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 467661
+  timestamp: 1666648052561
+- conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+  sha256: 89c2f4235277b9825cc805c5c44f0b1afcb683d7b5a3f513bc4bf243b643bb0c
+  md5: db70eb57e33adf7b8bbdadd72214d48d
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 73679
+  timestamp: 1699012111499
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
+  sha256: 684037527327839d734e7eac2ee09ef5ddb4f77df22daf40c79e51db29d09543
+  md5: 57c5bcb9eae9f1d93ccfd38025660de2
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 119414
+  timestamp: 1707355661872
+- conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+  sha256: fdae3f68ea84b99561aee6c566ab1c287d8f2ae2668424e9283a8ed86af8f1d2
+  md5: cde5b71ccbb3630053340b2c8c7dbf10
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9333
+  timestamp: 1683077183576
+- conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+  sha256: 0bf859b06a07857099fd4f524fe5e0875fda70029e9485d95c7efa97134fbc14
+  md5: fd5815cc592fdbd4c831901541eadaba
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 9735
+  timestamp: 1683059096795
+- conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+  sha256: 474553d01aea57214a54a7443f227da84a58e29c49eb7605ba0043c55b7d167a
+  md5: f01333e9f0a908e435db650f42fbd2db
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1096668
+  timestamp: 1698946168635
+- conda: https://conda.anaconda.org/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
+  sha256: 8c8aa1eb7e215984f46c8e1c7cfa6e5e6b233993d92b835a9b1b5491a4b970ab
+  md5: 6e145b179adde03f8aa8a066c58d4e31
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.12,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 380702
+  timestamp: 1706563445897
+- conda: https://conda.anaconda.org/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
+  sha256: b06b45da61807f76b6d800047f123fee2cc95eb84da508550e0908951c8d9f6f
+  md5: 9b100efb9ba2fc7f9bcfaa8fd2ab6f9f
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libgfortran-ng
+  - libgfortran5 >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 4
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 27615256
+  timestamp: 1714076660659
+- conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+  sha256: 51bcea0e575a626f6ffbd16d1153330fda93dbe3dd31dcd3a8f469ff61dd1e4e
+  md5: 41d531c90be8c82bf79635ff3d409476
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 32295
+  timestamp: 1699371262818
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+  sha256: 0a95988ea269c96354626dcab255b65b54bb5c503d24cdeb6ef2e1c42818bd59
+  md5: 8bfb9f42492b3b53b8151d77e51c75d8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1594974
+  timestamp: 1715024182643
+- conda: https://conda.anaconda.org/main/linux-64/sip-6.7.12-py311h6a678d5_0.tar.bz2
+  sha256: c1585436f502f87ee7bf6d40b7d911d1b5093dfee339db251d887bf355a23a94
+  md5: ff29bdee631a122ae9a68ff44066b02a
+  depends:
+  - libgcc-ng >=11.2.0
+  - packaging
+  - ply
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  license: LicenseRef-SIP_License OR GPL-2.0-or-later OR GPL-3.0-or-later
+  license_family: GPL
+  size: 683464
+  timestamp: 1698675983077
+- conda: https://conda.anaconda.org/main/linux-64/snappy-1.1.10-h6a678d5_1.tar.bz2
+  sha256: 15045902c5957ae0c8196ad7f1cecdadc7e6f5545f24f143339f488f063775f0
+  md5: 0b92bda0f6031b4f8fe9b4f1c0e55c06
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 48768
+  timestamp: 1702909413687
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+  sha256: 1a84b00944bc5588e14a097460175f97df49acb4f1ff2498ffd9a1893068ed81
+  md5: a456513471b2ecbed60430c21dd1ccc7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17880
+  timestamp: 1705431390054
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+  sha256: adcafd297d60af64107c113bb7b8b92160d0268a44ef9a3b79e56a88a0358ea7
+  md5: 28ed704ed26b06d32662e3a6a87e59b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 88799
+  timestamp: 1696347581401
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+  sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
+  md5: f86119b3243fe3508160aa0406245738
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1723866
+  timestamp: 1714488309729
+- conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+  sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
+  md5: 041a3caf09dc9ce8fc6c10925c4fe050
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1888016
+  timestamp: 1680167274961
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+  sha256: 856a8ab8c350c50247b79966c6cb80fb6d4de36eef49ddf75aebbbcaf854c82d
+  md5: 442dde204d14d171aab9ee40e8de4de8
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37456
+  timestamp: 1677696176157
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+  sha256: f0a026ddc0ed041bfc60c8a1ca0b70b7a69232775b3181bfb35a39fda42d6994
+  md5: 2902d5a5854865baaaf58dc59cf06b3c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49185
+  timestamp: 1676823769869
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+  sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
+  md5: e2512d57c8a1e91e7b20e265c6906546
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3588922
+  timestamp: 1714770676475
+- conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+  sha256: e58ff4a82819446f3c92e5b1aa2a784c4b06643e751fe67cf115858296dbfa50
+  md5: 32ee4723173f1fad5563b8afb5f1c8f1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135634
+  timestamp: 1676827536101
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+  sha256: 1bf522ade750cf0b70d61e71916ff00569e2908db1e9dedb223fda2608ed8bde
+  md5: 6793c74fe94211c0bfe6766c6dd490af
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 893808
+  timestamp: 1696937055591
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.66.2-py311h92b7b1e_0.tar.bz2
+  sha256: ef0c8cbb22af258e228d54e7cbb4a152c81cc64b28d009166488a2ccdb30225f
+  md5: 5e033e80b81b1830252a4c65ddf0959b
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 154337
+  timestamp: 1714567842489
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+  sha256: 0575785f6553e61cc6138abfd5de52305fac6f85971642fa1f056a76c66a52b2
+  md5: f2c25e5dfdd23f70b83776a8832893cf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270865
+  timestamp: 1676823316868
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.9.0-py311h06a4308_1.tar.bz2
+  sha256: e0dbca6707368472ef0adfe498c024de7c9a56d9c6ff25ffe1449e8e95da89aa
+  md5: 570cf697aaefcaee710444daef8a11d1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.9.0 py311h06a4308_1
+  license: PSF-2.0
+  license_family: PSF
+  size: 8792
+  timestamp: 1705599472930
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.9.0-py311h06a4308_1.tar.bz2
+  sha256: da18ffdb0ef53142aeb5d964b8db1542c290eb328ae9fbdf96690750272bd8bc
+  md5: c6d716b2a8ae08f6e4039ea74d13b79f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 70729
+  timestamp: 1705599465726
+- conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+  sha256: 509b962773f0fe44a93a7f6196b254670a030eac8ea7f90727312e3ccd9294b2
+  md5: 6c402d5bf4e01c8c3895c9ef41707b6e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11371
+  timestamp: 1676828901104
+- conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+  sha256: bbe7629e8ce52c82f13ed0d1fb919f3659ef466b274a7c74aa925a9bc7aee450
+  md5: 7da527bbcf71270c1abed8ea52e7d44c
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 509031
+  timestamp: 1713213062098
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-2.1.0-py311h06a4308_1.tar.bz2
+  sha256: a0b300e422e89ca84cd1ece98b796af3133c56279871fbf0198871c9edd3585e
+  md5: 5cdea1fde6548c3a82add475b39e60c2
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - zstandard >=0.18.0
+  - selenium >=4.4.3
+  - requests >=2.26.0
+  license: MIT
+  license_family: MIT
+  size: 183475
+  timestamp: 1707770592436
+- conda: https://conda.anaconda.org/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+  sha256: a8d11b0f08217607b99ba560edf66423ca1e36f4ffbb6e2377e61670e2b5f36b
+  md5: 431e82b081b08aef0259df0437e04c75
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 97535
+  timestamp: 1706894675990
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+  sha256: c3a5e0b855dc2de6c162708dfcf170a23eb9e7525d4252d8dce553369af4a330
+  md5: a4c77e204b7787f820955166a1283168
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25890
+  timestamp: 1676823132898
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py311h06a4308_4.tar.bz2
+  sha256: 7b505fdb5d801adfb3032e2541bf9bf17ed2238764b7a53cb845e33e7f835faf
+  md5: 07dc61e2e59fe57a9bfe8efcbb23ffe6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 90518
+  timestamp: 1676824901641
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+  sha256: eec0d2e0bce4b62278cacd7b0bee053160845e86507051a5434d2069bd290f36
+  md5: a069e5aef64a6dac076cc9a3d28a17c9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 136022
+  timestamp: 1714717059748
+- conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+  sha256: 85248e503721da67797546cb8a22e303c1739100834b219c5621f216e3794e8d
+  md5: 2570956643f22d0f809b2467e02d3984
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2465865
+  timestamp: 1689041600364
+- conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+  sha256: d18cdca154bf668826f869117ea996c4f9e8ef7d27b7c528332a7d17e5a8602c
+  md5: 9f7353d72046b16dd6ef6b5689ac9bfd
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54731
+  timestamp: 1676828934954
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+  sha256: 9122d6e9dabb7a47f2bcb15d86b97c96c49a9048da3f8ae59675351710c14cc5
+  md5: 660b2aead2ec87b751c86cd33934f44e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 716926
+  timestamp: 1714510796277
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+  sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
+  md5: 943f1247a22b6b64171363bcee1eec27
+  depends:
+  - libgcc-ng >=11.2.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=11.2.0
+  license: MPL-2.0
+  license_family: Other
+  size: 371663
+  timestamp: 1705602144682
+- conda: https://conda.anaconda.org/main/linux-64/zict-3.0.0-py311h06a4308_0.tar.bz2
+  sha256: f33ed759a551e2cd64115a3b01af0fc9822b1a5a1a5c798aa0ee14292792d7c1
+  md5: 7feb38e587b3352efca77df1447858d2
+  depends:
+  - heapdict
+  - python >=3.11,<3.12.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102106
+  timestamp: 1695832995689
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
+  sha256: 7aa781d0850f97622755ed44772d2b215b253a8e211aede5f3f53e1b95b4143a
+  md5: b1d8823f50228d4efb7b7a6e267ed776
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 24333
+  timestamp: 1704207043644
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+  sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
+  md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Zlib
+  license_family: Other
+  size: 127143
+  timestamp: 1714510716441
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+  sha256: af3c032f06352e87c450739cb8aafe1ff34ad28bf074b214ea98b3d29259a85d
+  md5: 51fa34bd0e016ed7c5371cf6cb13ef6c
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1044463
+  timestamp: 1714678445052
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
+  md5: 544adf2677c47c9b9c891aea720678f1
+  depends:
+  - python >=3.5
+  license: MIT
+  size: 33999
+  timestamp: 1630003259346
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 9de8666e5b70aa2437737128eaa14ffe80a7b5235c2a6b7d3f39ccefd7816ba0
+  md5: bb52e50c5ab1a5c7778c11376404dfdb
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 7933
+  timestamp: 1630598543551
+- conda: https://conda.anaconda.org/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
+  sha256: 6db7265c2238c6e5b4c98906498c47af341238b5d5a9baee383777181f421366
+  md5: 91e3336204a0ea3951957d7d5e8f3e26
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 21503
+  timestamp: 1624432813739
+- conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+  sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
+  md5: 33624a42ee387bf9918ea98b4e7b31fc
+  depends:
+  - pygments >=2.4.1,<3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8173
+  timestamp: 1601490751973
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+  sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
+  md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
+  depends:
+  - prompt-toolkit >=3.0.43,<3.0.44.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5106
+  timestamp: 1704404390460
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://conda.anaconda.org/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+  sha256: 459f38609d854888998a8d76028019dbacdce2bfe401eab57b8eb8ff16da9c7f
+  md5: 2948a98ef4de5decb7e5eb888eae68ba
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13056
+  timestamp: 1682965564630
+- conda: https://conda.anaconda.org/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
+  sha256: 305e5fd9993f3e5506f386f98794c7d53b6e6c68d4d411ada724de49a17945fa
+  md5: e1fbbd2d11d21aaec3c32f7d332c0e77
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13818
+  timestamp: 1712163766707
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
+  md5: 2eb923cc014094f4acf7f849d67d73f8
+  depends:
+  - python
+  - six >=1.5
+  license: BSD-3-Clause and Apache
+  license_family: BSD
+  size: 246457
+  timestamp: 1626374695070
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 4e47f6c49ce84509f1466e8a4d728447bf4bcd9bce7b456431a789a262547067
+  md5: 4cad993b0f80bc23fb66a97592299cbb
+  depends:
+  - python >=2.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 26504
+  timestamp: 1623949147884
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+  sha256: ca2be6c7810a37cfc6db1f5383937b5d35c6d73c1fad8a9104de85f069b1df1c
+  md5: 9ccb2fb33edb152403d6ef32bf758a9d
+  depends:
+  - python
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 15614
+  timestamp: 1629402049497
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+  sha256: dc9f709bacbaf08a0941d2622d82f91f18b355e82c55348ec29f1391215ca7e0
+  md5: ece0f5837a4de2d4d5f1abf8347cd10a
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 124922
+  timestamp: 1708711884650
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://conda.anaconda.org/main/osx-64/abseil-cpp-20230802.0-h61975a4_2.tar.bz2
+  sha256: dc40cfc393c2acdb97ce54289d3124bdff35ffd4a6c203abb6f3f5598f49c115
+  md5: 64a761d3c1af045bf01d84d3fc4302a2
+  depends:
+  - gtest >=1.14.0,<1.14.1.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 1336618
+  timestamp: 1698327954026
+- conda: https://conda.anaconda.org/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+  sha256: 5800a2466734dd1ef372bec0dd3f0880c5072fa1e8b0668f5054f834285e991c
+  md5: 18194e51d4420ac08f29f3f86581b52e
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 229003
+  timestamp: 1706220302459
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+  sha256: ab7672364f1fa55ec5d8311d85d40e5b57cbd3517b17670557b6fb822bcf759c
+  md5: 6e0159a5865cb7e96a748bd8560035ee
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 11579
+  timestamp: 1678317458652
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+  sha256: 51556902e09436d46878ef772805d06416ca96ffaa66340b5565c0245574aaf5
+  md5: 4cb1b20635cf5431d34cc96ca1e8a751
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 33355
+  timestamp: 1678317111825
+- conda: https://conda.anaconda.org/main/osx-64/arrow-cpp-14.0.2-h3ade35f_1.tar.bz2
+  sha256: f5480f3e450648a37debe91d0218007a976e4b046fafc8956a7351c2a20f83ec
+  md5: 2079b1125e4344044941008a444ff201
+  depends:
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - aws-sdk-cpp >=1.10.55,<1.10.56.0a0
+  - brotli
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags
+  - glog >=0.5.0,<0.6.0a0
+  - grpc-cpp >=1.48.2,<1.49.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.13,<4.0a0
+  - orc >=1.7.4,<1.7.5.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.9,<2.0a0
+  - utf8proc >=2.6.1,<2.9.0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 10268727
+  timestamp: 1707253751856
+- conda: https://conda.anaconda.org/main/osx-64/async-lru-2.0.4-py311hecd8cb5_0.tar.bz2
+  sha256: e6fb3357ab4e25e2e839a28def6450035a291c094ff91d4129fcdbb58f2bbe48
+  md5: d1d0d5703fa8c45784265d8dccf01334
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 21499
+  timestamp: 1699554645746
+- conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: 188b74f717e3ce3595da404c0e027b8ccafa9c186e88325e8f02c29d7b4c0744
+  md5: 04ad90eead5812a0263b42321056ab33
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153694
+  timestamp: 1695717975427
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
+  sha256: a153eee37b30ca5c25c5c95463a8852f1cf62a8f45f73349e68f1e3b22eec6da
+  md5: 4bf760fad0e938618391f0db249d00e1
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 87236
+  timestamp: 1706746160841
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
+  sha256: 04ec5908b1dc2979ed50923af90d02da8a60434658efbc4f35fc61e7e9cafa0b
+  md5: 6ba283b7f902226f232fe8a32fa83ee4
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 37547
+  timestamp: 1706690917050
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
+  sha256: 08431c5ec5f0a9e95819b6a76c9cc870d2154e46b229431fd0b3dad25bb70b04
+  md5: 78b4b4225fdefef0b9b0d56b6e51e4a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 184146
+  timestamp: 1706189913777
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
+  sha256: 6a78705375d837a0eeeff9e914aae53a0d2cd44e9760075bdd8711a05f94ff3f
+  md5: 931b0654ae05bcd1acc760dc830b89d3
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 17410
+  timestamp: 1706690854689
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
+  sha256: 1d468f7c085b73cc40f813885d77a74270f94dd973b4285546d8873030fcada7
+  md5: 3a61760bb61f85b3a0ffe7b14058801f
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 46197
+  timestamp: 1706697276616
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
+  sha256: b53432aadb2ffe2f1c584c6994b665f3620f29c51b200b03282065a480cf021e
+  md5: 9686f32b210a009048c0877ac39fe88c
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-compression >=0.2.16,<0.2.17.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 164397
+  timestamp: 1706744140750
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
+  sha256: 2ff9632eb2e2c7a70b8d64988e530d842fe5fa7fa529d34cda19f76fb40582e2
+  md5: ffbd1ff65fe9fb52d833af5d396b006d
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 125589
+  timestamp: 1706696187075
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
+  sha256: fa57f1d2b2eb56db72e4b54348452af67a1222bd4266b3d68c7b7ff00399743b
+  md5: ae9e78f6b1fef841fc0ffc7ef7c78d26
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 61379
+  timestamp: 1706746740037
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
+  sha256: 00834bd876756f1f13333c31623c2bdfa7d901b40aec161cf0343548fcd96187
+  md5: 4ef080b5a91e260d51d563218396d0f6
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 67408
+  timestamp: 1706747579372
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
+  sha256: fb3198a05c96030d8498a5c4873e56ae28a5b04fb904a5c696a2192e9ee6c45b
+  md5: 48efeda1471a50b9481c3943a0300e86
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 48055
+  timestamp: 1706690833951
+- conda: https://conda.anaconda.org/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
+  sha256: f05fb72b1a5f25fab65ef416ff0d1966e3ff84f8a08c56bf809fb602028c66ec
+  md5: 86cda3f774047ff6b40eb14aab83215d
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51354
+  timestamp: 1706192066535
+- conda: https://conda.anaconda.org/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
+  sha256: b8cb5f96e9eab47419622795fcdb42ad414481db9b84bbb50fcf8251a1314b59
+  md5: 335265dfe12cb6adcacf39b411cf9d7a
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
+  - aws-c-s3 >=0.1.51,<0.1.52.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 210312
+  timestamp: 1706827788950
+- conda: https://conda.anaconda.org/main/osx-64/aws-sdk-cpp-1.10.55-h61975a4_0.tar.bz2
+  sha256: 40911c99dfa11ad32d451ab8cb5b24f0aecde231b5f8f4e9d8887bc4a720dc65
+  md5: 1078cfa7cb12f9a0d3fb4017cc9789b9
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 2322692
+  timestamp: 1706890560060
+- conda: https://conda.anaconda.org/main/osx-64/babel-2.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: aed8823dbb096851f6eddc345f02c23fba42decce2c584f0fe09440002c37996
+  md5: fc567742fccd3b08593b1dcca16522f7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pytz >=2015.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7215195
+  timestamp: 1678318116416
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+  sha256: bf3c60386619f08cf5105b4b903bbc109b3252c3b923fe055aa445908a01969c
+  md5: 3f84a301921ec6400b7f1f1c4ba3260d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 270017
+  timestamp: 1681493109562
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
+  sha256: 126ae8e30b8464fb2dc94ce9163dcb2d5482f7214c7d8a48340c3f09f1409d5e
+  md5: d5e0c054042910b4394a14c7eb4d8131
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6080356
+  timestamp: 1712084675745
+- conda: https://conda.anaconda.org/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+  sha256: 81102f2762d8eb2f07c69fbf7ca7dad879a257a053085492d4c1b4006eb35fb8
+  md5: 3c42777bc9330fe91177ea813b9ec252
+  depends:
+  - libboost 1.82.0 hf53b9f2_2
+  - libcxx >=14.0.6
+  license: BSL-1.0
+  license_family: OTHER
+  size: 11744
+  timestamp: 1696762233693
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+  sha256: 9acafafcaebd653c2372ddc864525722e1c55b884b5eba22e28e2b2d946b853c
+  md5: 22375cc3c2edada31b85af56c8e6dee6
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 155829
+  timestamp: 1707864406086
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: d8b1ccb15297dcfb3f9ebb8139c3e28a13d6c2e73c37612cb214ab6cc58b15fa
+  md5: e5dec9f13de061640ad2697562a99b54
+  depends:
+  - brotli-bin 1.0.9 h6c40b1e_8
+  - libbrotlidec 1.0.9 h6c40b1e_8
+  - libbrotlienc 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 19732
+  timestamp: 1714483415038
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: e9fda4393edd0234c88efc2b88e0edf42c94eb49ea5b189a80afd733058be8fb
+  md5: 13ceed558eb174d6b77ed1b0035f1785
+  depends:
+  - libbrotlidec 1.0.9 h6c40b1e_8
+  - libbrotlienc 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 18400
+  timestamp: 1714483395748
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+  sha256: a323af3251e426962ad16edf8f46a696ef502731faf12aee32ca289c40b11342
+  md5: 658ce49e9f07dba7a1afe70fa2666e0a
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 393858
+  timestamp: 1714483549536
+- conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+  sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
+  md5: c5a600d81b1b48578863af2973c743ac
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 187637
+  timestamp: 1714510590009
+- conda: https://conda.anaconda.org/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+  sha256: f913b61ba3c1651b36688415cc163a5d575475f7573b543f48a80e7a5002e4bb
+  md5: f11d165eaa532ce04a35382841284298
+  license: MIT
+  license_family: MIT
+  size: 107047
+  timestamp: 1693902034820
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+  sha256: 0c5f9766aa2dcc08ae71b6c0102046a56b30297d0bedc3039b7f72d1658baa43
+  md5: 34583b436e62a2ce55d6a7e8eb818e33
+  license: MPL-2.0
+  license_family: Other
+  size: 138712
+  timestamp: 1710764814844
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+  sha256: 20b1fc398e925e6c8cea6a06d3bb614e2c0de886e3f14f85b0ba26e57ff40b7e
+  md5: ac95cfe373c7fef7820e93189041b0cc
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 166856
+  timestamp: 1707229213510
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+  sha256: 6b5bebc13755b0a5ef423219eeecd1c25b97dbe83afad6e2552635387547d9f7
+  md5: b7bc4192fcfed7fc7df1ce00bce97b02
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 291802
+  timestamp: 1714483319125
+- conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+  sha256: aceaa74365b0d8e69c817639393df3a713a802f40645ac0bd2f39adc871acf54
+  md5: 52191c9d4f4fcaeea39574819ab2f14f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204365
+  timestamp: 1698129979494
+- conda: https://conda.anaconda.org/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: 53099bea1cdfeac00bf4bf48e7c3321424af31b9726a7f67033ed06e5d924f04
+  md5: 0302e97edbd24e02df7609a6072dc569
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50495
+  timestamp: 1683040190091
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: 389c63a84b92a6254c9d361ebe970d537d0b88733efd5ac5c3ee58196fd2c5a9
+  md5: c7bc5b3cbe76be83a27f00b7e4740727
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17974
+  timestamp: 1709323004148
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+  sha256: bebfc5aa6be12e61a134b580b07b67f7d8c045d6b113fca5b21fa1e83a2f03ce
+  md5: 239df72a3921c951059fa8afc09643f6
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 287736
+  timestamp: 1700583644534
+- conda: https://conda.anaconda.org/main/osx-64/cramjam-2.7.0-py311h9c86198_0.tar.bz2
+  sha256: f480b0ed7a98e682d8cbdaeef697116a0d839cee08ec8b5f39078c4e056ec29b
+  md5: 7712882f644fca2ccd169ce2dee2b4d9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1473015
+  timestamp: 1702651642047
+- conda: https://conda.anaconda.org/main/osx-64/cytoolz-0.12.2-py311h6c40b1e_0.tar.bz2
+  sha256: fd7bceb92f6c43c6b064a1258a33c441b3b39cd08883cb73204f8d0692b709fc
+  md5: 37f8b661d31327b8dff70a4cfa63cd5b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 390733
+  timestamp: 1701729666753
+- conda: https://conda.anaconda.org/main/osx-64/dask-2023.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: 663a4919f8c466b40f14ed170f378810a7202d8e689b2255d5de6454e1615b76
+  md5: 539835b03a005340a14df14b7963e099
+  depends:
+  - bokeh >=2.4.2
+  - cytoolz >=0.12.0
+  - dask-core 2023.11.0.*
+  - distributed 2023.11.0.*
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.21,<2.0a0
+  - pandas >=1.3
+  - pyarrow >=7.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6016
+  timestamp: 1701444967158
+- conda: https://conda.anaconda.org/main/osx-64/dask-core-2023.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: 45a9f823c8e031b1bc78639206ff4e235ce7de67da9b991724316d00075393b0
+  md5: 9d10bc7c171e384a536f9f121d964fe7
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3027866
+  timestamp: 1701396257640
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+  sha256: e0e30590a78d99d51445ac4f668aefe1bf20025a35bdbac00f04647b95c9f152
+  md5: bd0db635eefeea82a0c567b39c9a0e3d
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2485698
+  timestamp: 1690905283575
+- conda: https://conda.anaconda.org/main/osx-64/distributed-2023.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: e1572994d0a7c6da827b31734426cf87b3462d2707e316afc04d78aee28bfe8d
+  md5: e2935cb332d1a784b85339113f4c8273
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - dask-core 2023.11.0.*
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.0
+  - packaging >=20.0
+  - psutil >=5.7.2
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.10.0
+  - tornado >=6.0.4
+  - urllib3 >=1.24.3
+  - zict >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1788385
+  timestamp: 1701398185617
+- conda: https://conda.anaconda.org/main/osx-64/fastparquet-2023.8.0-py311hb3a5e46_0.tar.bz2
+  sha256: 4a4dc4955ebb563653b6e8fe8ccd17f7ef0ce17c29d09cc09d4e62a43241bb8e
+  md5: 765d7542be413e1b31e9a6d5b9ca9829
+  depends:
+  - cramjam >=2.3.0
+  - fsspec
+  - numpy >=1.23.5,<2.0a0
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 570485
+  timestamp: 1696541803957
+- conda: https://conda.anaconda.org/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+  sha256: 54645c22fabc25b632114d1d3c403a6fad9149b51ab36719b2690a084f14a072
+  md5: a8ad2f4abfb2e17ecf6e596342528156
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lz4 >=1.7.4.2
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  license: MIT
+  license_family: MIT
+  size: 3180691
+  timestamp: 1713551771692
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://conda.anaconda.org/main/osx-64/fsspec-2024.3.1-py311hecd8cb5_0.tar.bz2
+  sha256: 296e72c622f7014041055d8c7b602385ad10893aa1c0b600248c95e7d116dfa9
+  md5: 93d5cc02fe01e3b396f02df0ca682a79
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365534
+  timestamp: 1714461741656
+- conda: https://conda.anaconda.org/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+  sha256: 3c7aa54548409f9343e891820ea43c195b5e4e4dce6b761bc3ae9f6c8be0fc86
+  md5: ed9629d6dc1612ec425eb8d27478b0f6
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 140316
+  timestamp: 1706888243476
+- conda: https://conda.anaconda.org/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+  sha256: aed47f9ca4dd140b9c8a183e53d4b89eba84a20041d2038983cdfea8096104ef
+  md5: c0d981d7d43eaad55950ff5e57206e70
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 97828
+  timestamp: 1706895273858
+- conda: https://conda.anaconda.org/main/osx-64/grpc-cpp-1.48.2-hbe2b35a_4.tar.bz2
+  sha256: 5d69cd8a1582c5062ed6753ee9ba403cee89d89f6e1628bcaba823a33a92a186
+  md5: c37d24f6749355412dabe28bd64ce229
+  depends:
+  - abseil-cpp >=20230802.0,<20230802.1.0a0
+  - c-ares >=1.19.1,<2.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.20.4.0a0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - openssl 3.*
+  - openssl >=3.0.12,<4.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3994389
+  timestamp: 1701983483827
+- conda: https://conda.anaconda.org/main/osx-64/gtest-1.14.0-ha357a0b_0.tar.bz2
+  sha256: edfb65219af41d5037b6371c6b074c8372db90b17d25f85f55e36523c01949ec
+  md5: f21a88869091d6d4d88b9b5f064a3157
+  depends:
+  - libcxx >=14.0.6
+  constrains:
+  - gmock 1.14.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 400287
+  timestamp: 1692633607623
+- conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+  sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
+  md5: f3ce6fe6eb760c236e5f7d04df5faa81
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28138484
+  timestamp: 1692293212596
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+  sha256: 5c2458964157fe493ca18c513c693b70cb622087e5fa0c93e65fc45217edd811
+  md5: 15629e52625221b51a443cefd9501d12
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148522
+  timestamp: 1714398885844
+- conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+  sha256: 5a17849341e4d43fc6aff44486425852c16dee6e1cbcab1ed3f2167350f55359
+  md5: 445ac9df262ad2dcd86246a9ba5654b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 51118
+  timestamp: 1704813615186
+- conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+  sha256: e0127f50d444bf4474e8df07d602c7f6dd38690e8bb3fb28817c164940ffcde1
+  md5: 583fcd7060cad6a77074d00d9ef62f44
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 731417
+  timestamp: 1699647668990
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+  sha256: eb58fa29b1ce9aa5fc774d4c466696457695dec3b206456614b4c9cac0a94e42
+  md5: 3d3291ff58dff83dcd40ec54b435f4d2
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229910
+  timestamp: 1705934029588
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+  sha256: 73aa7662c00c73bab2dafefefc87a1b524961d2687410af624ecbd6703e483f3
+  md5: 7e71e99766107a553752ed8f22b61cf0
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1611976
+  timestamp: 1704833049616
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+  sha256: e08cda2bcbdec124c63e951eb248c503bb1467c2a6000010c6bdc0726e0e00b7
+  md5: 22c24f43b82da8b3920a913bbf452421
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1168968
+  timestamp: 1679336359851
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
+  sha256: 3b262312f1fc76e490c067408771da0a12c7691379cddc3c86121255cda7a41d
+  md5: cbf00a1bc151243cb6a33524b62f3663
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353280
+  timestamp: 1706733664000
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
+  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
+  license: IJG
+  license_family: Other
+  size: 278924
+  timestamp: 1677849185191
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+  sha256: 99fc6ac82c56eb2a580f96db24a5b887f8abc8c24af445d3313d5ebb48598478
+  md5: 71892160908a6daedb5fb7c404079ae4
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 182073
+  timestamp: 1699041732321
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 0ea44d0c8044e70ab0eaf4d6f5f3e4753838dee106b5cbd36561e21a65cbac77
+  md5: 1d045016dca889d702f1caf3a16162fc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16528
+  timestamp: 1699032525791
+- conda: https://conda.anaconda.org/main/osx-64/jupyter-lsp-2.2.0-py311hecd8cb5_0.tar.bz2
+  sha256: 9f7e13e4b84794cc99f78e0513157be30b9c9b039c413a90c03583304b7edeba
+  md5: a76eeb3f746de2b0282bbf9872ac1e8d
+  depends:
+  - jupyter_server >=1.1.2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101678
+  timestamp: 1699978325870
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-8.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 7e100bfb19e640dd312cdb921155f67c52675cf128d1aef2f3e975d30f3171a8
+  md5: 08bbf3e56f89bc800fda1eeb998a0d1d
+  depends:
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 222285
+  timestamp: 1699456395712
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+  sha256: 8601c674f4779900f6a949e47b814be68b722b0b3d394433bec9d197924ebd69
+  md5: b8423f8caff3041a251fc3681f43496a
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94990
+  timestamp: 1698937583196
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: 6a430c812ce0415a04d9cfe6c66d9012eced2d91c04960c88bc8ec1e9f1b5d6d
+  md5: 30b3d5d6a8cf5d1604e5f5fb177917b5
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42513
+  timestamp: 1699282637015
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: c2d206db117f7161e77236ebd6b0051fc73e1731c242d1e08597d736a0376c92
+  md5: bdb61de2e20e02c93423d9de091c74ad
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 601837
+  timestamp: 1699466514455
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+  sha256: fd7964657f0a8fe8b167ba860b1f960e8b7b45309eb6c7c850d50ec283fe03b5
+  md5: 2967bb345bc75f53182e263ff4743ca6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28223
+  timestamp: 1686870845224
+- conda: https://conda.anaconda.org/main/osx-64/jupyterlab-4.0.11-py311hecd8cb5_0.tar.bz2
+  sha256: ad199926171ef67c2e96e7c603c7dc6c96e25a23deb9979f1c910616df8e8b48
+  md5: d749db644752070354a015015fd1a102
+  depends:
+  - async-lru >=1.0.0
+  - ipykernel
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.19.0,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  - traitlets
+  constrains:
+  - nodejs >=18.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6618991
+  timestamp: 1706803097395
+- conda: https://conda.anaconda.org/main/osx-64/jupyterlab_server-2.25.1-py311hecd8cb5_0.tar.bz2
+  sha256: 557bd1a8ff0502191adb3ff3af74b54ee2ec4800d281492bd8e588ddcf095bfb
+  md5: 14c8a1959a83eff470adc09cc65bdb57
+  depends:
+  - babel >=2.10
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18.0
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.11,<3.12.0a0
+  - requests >=2.31
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 107281
+  timestamp: 1699555527525
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+  sha256: a12382b50416803f559a03fb384ba492c1dafa351e1191a3f8dc361bee6c4f37
+  md5: f2ae846b663bbb642f4b1e90eaad38a3
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64817
+  timestamp: 1678322501509
+- conda: https://conda.anaconda.org/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
+  sha256: a3a24cd84c291f7c9e28842ccfc2107d149f0aa8e676b85d9104eda77622e603
+  md5: 99ba4367783596d1bb0c7766ea6706ea
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - openssl >=3.0.8,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1290758
+  timestamp: 1686931137388
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://conda.anaconda.org/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+  sha256: 127dbf93874f1bb3493b312fecb5ffedb8f2a41d2470e2cbeb889eb58d89ebf7
+  md5: 07502b61e43a2039e4312b40d53c1db1
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 22584954
+  timestamp: 1696762195023
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 685c3bc9068bd485604b80bf03789e4dca95c410d33871bc1b882e47649fabed
+  md5: 6cf8e55271e150ca0961d0ddedaa61bb
+  license: MIT
+  size: 66237
+  timestamp: 1714483284541
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 69826cee54db9955f0120af21ec36d13f9211877fd67364f2068d0a54c6c97cd
+  md5: 0851917257f490d35e1f73da8a1c723c
+  depends:
+  - libbrotlicommon 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 34042
+  timestamp: 1714483343147
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 3f5a1f03b50b90b397a0ee432ad0cba13354abdaf7e5652c0fc60164b26a08b6
+  md5: a50bdc871ef4bf14deb088d888b92b5e
+  depends:
+  - libbrotlicommon 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 311597
+  timestamp: 1714483371586
+- conda: https://conda.anaconda.org/main/osx-64/libcurl-8.5.0-hf20ceda_0.tar.bz2
+  sha256: b34c59c148f100cfabc8a55470cc0d46f4ba2d1f90dedf516b151ca1374d2e54
+  md5: 14f3b4d1790efbf8e35a9a9259cb6e8a
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.57.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=3.0.12,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: curl
+  license_family: MIT
+  size: 373198
+  timestamp: 1704383716512
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://conda.anaconda.org/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+  sha256: e84e6cbacb12de6fe86955449502d3956696ae583060d0d4911ea6f503cfb9ad
+  md5: 1d200c536be4172db41c49e81a3e6350
+  depends:
+  - ncurses >=6.4,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 169586
+  timestamp: 1703006265367
+- conda: https://conda.anaconda.org/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+  sha256: 4786264321edbff780633a5b752995eb3193ca4bce11b0fda179577f6cf1102c
+  md5: 849fdd014c201a9d2c2aa7c7db38a778
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 103993
+  timestamp: 1632891571494
+- conda: https://conda.anaconda.org/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+  sha256: a60941a0365ee3e8b9ff721f75b0608c234b5652f53337a918b787839de4bb53
+  md5: 4d61f019594ebccfb3f4fb87ee778416
+  depends:
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 414942
+  timestamp: 1685052318462
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+  sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
+  md5: 822a5b76117e56d3912f1f2153307528
+  license: MIT
+  license_family: MIT
+  size: 136045
+  timestamp: 1714483561919
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+  sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
+  md5: e458587c87e3f2d20192f4e0738f2c63
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 149419
+  timestamp: 1665498987619
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+  sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
+  md5: 1058b661ec829b2ee3716ee2a5520641
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1917987
+  timestamp: 1665498925405
+- conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
+  sha256: 9ff6ed0f0b9f9f27f449e95d11aa1c4e9e80028fd9d2a8caca5a15d8df88f435
+  md5: 7b4b557afc66aba367da14d97d71934c
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1409885
+  timestamp: 1714483704680
+- conda: https://conda.anaconda.org/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+  sha256: 8176dd9a68815301a24ed51e72f3506f5f77c67a112efa0dd14971f2f3b3c8c1
+  md5: b5e470c224000a6bda6f655c155b53e7
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 27861431
+  timestamp: 1683292881730
+- conda: https://conda.anaconda.org/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+  sha256: 7bfcf69c31a4eb15dfab661c93463ce8dfb7b3de4356945fa5c1ca50a5ae0cb0
+  md5: 4934bb34818fa3d99b32b9cb59fed205
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - c-ares >=1.7.5
+  - libcxx >=14.0.6
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 784918
+  timestamp: 1697018436251
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://conda.anaconda.org/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
+  sha256: 1884de5207f5a1210217d7132348b4944ec4b09a91085b7b47a19dfdd9b6dbba
+  md5: aa960ea0133deec4637a8d05700cc3c4
+  depends:
+  - libcxx >=14.0.6
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2412437
+  timestamp: 1675278748544
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://conda.anaconda.org/main/osx-64/libssh2-1.10.0-h04015c4_3.tar.bz2
+  sha256: 79a36c00535053704706f6520b6a69a3fc3faa5e28e7c0a1b640c29d44899761
+  md5: a44846f7c4357de50a7d43e0bd15d5a2
+  depends:
+  - openssl >=3.0.13,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 291287
+  timestamp: 1714510620580
+- conda: https://conda.anaconda.org/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+  sha256: 21ba71cdc65b56c6daefeeab55959e5a7edadfd697cfa8b2ed5c1b3e2a98586b
+  md5: cbbd369ee87aba597c942727bada4eee
+  depends:
+  - boost-cpp >=1.73
+  - libcxx >=14.0.6
+  - libevent >=2.1.12,<2.1.13.0a0
+  - openssl >=3.0.9,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 364326
+  timestamp: 1687975317748
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: d28c465ec6d5f8d4962c597b249b58998300c8b4e3c937c578c3d15294ea863d
+  md5: dcaed6ddd0723c7cce6bfad917be98b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41176
+  timestamp: 1678413498410
+- conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+  sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
+  md5: 5c740b4a18a558de0ccfe601703c423c
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 338738
+  timestamp: 1662635677689
+- conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
+  sha256: 53808184421c81e661f9927ff564a0d0ecdf3b816c8aba8e2368434e055529d4
+  md5: bee10bfbe90767fcb8f8f6ab3a05d85a
+  depends:
+  - libcxx >=14.0.6
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 407784
+  timestamp: 1706911015242
+- conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: 716a654df2e55052193150015bd5c9856b847893fc5a229fa8669725b1c56ff2
+  md5: 687ba6c11de38ad7cc597f7188b491e7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13357
+  timestamp: 1678322560230
+- conda: https://conda.anaconda.org/main/osx-64/lz4-4.3.2-py311h6c40b1e_0.tar.bz2
+  sha256: e05d6b661c088efc3f7f2fc99b8faad351f7660963ca66fbe63dfc9796821eb2
+  md5: d48a23f7e388334d5e39fc36ee84441b
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37947
+  timestamp: 1686058038545
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+  sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
+  md5: 8f57dc3a3327bb6f7e1cba908856ac7f
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 183138
+  timestamp: 1714510756758
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+  sha256: 6fb2953e169ee1ae38f24d29752051501992f19b96b5ebcea9af75737bdbcb42
+  md5: 7f410cdae838c5030108d1b98a8c78f6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162478
+  timestamp: 1678377892595
+- conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+  sha256: cd97e09a12ffb49b2a30a782fa8c7933b28f5ffdbfc5c73a9ebaa95fc9447370
+  md5: d1fb6ebc1e5728aa6377cfc71da08942
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135859
+  timestamp: 1684280005320
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+  sha256: 30c3b189462a9d0f4794d229adadf34b5f5a5f56f95c30d5afc17ef524579290
+  md5: d4e9421243129d1d57c472dab045f3dc
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26639
+  timestamp: 1704206159955
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-3.8.4-py311hecd8cb5_0.tar.bz2
+  sha256: 1324e1dd44723b6ba80c4cc7128b85471542cb8d60b1c7757511e56e8e2171e1
+  md5: b33ffac0fcab742473262ddb0c5ad74b
+  depends:
+  - matplotlib-base >=3.8.4,<3.8.5.0a0
+  - python >=3.11,<3.12.0a0
+  - tornado >=5
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8970
+  timestamp: 1713336829689
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+  sha256: 080000a28b3ceca54eec6de0748c690ea5a4c390e358283eac03fe7a6dd87065
+  md5: 51344eca57d7940fb01eb5e8914509e3
+  depends:
+  - __osx >=10.12
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9099909
+  timestamp: 1713336790553
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+  sha256: 07e7fd5bd64e55328b4b99d92e2e2600d791f1095bf905daab4cfc59f0f0a45b
+  md5: cf53321779f4ca7e986c1468719b93f1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19500
+  timestamp: 1678317565001
+- conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0770e02be1ea1216af493cfc03d5b8a702e14606fa93b0692bcdab1fed1b898c
+  md5: ca6f06ceaf66a32bbf5dfdb6e373a5cf
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67892
+  timestamp: 1678417734353
+- conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: fbe95ed0501bb0f137048476fe41bc718dd659e8ecb066bc67ac17d6a50f4318
+  md5: ec162bde8d1c8a107b257df218b17035
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23030
+  timestamp: 1678381838497
+- conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+  sha256: c20dd678655e582129a858a1c5162bdc254082d3a3c035b0f72629d9276e5b75
+  md5: 800a0738c728796e02d0386ce7d457aa
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104585
+  timestamp: 1678317269407
+- conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+  sha256: c825bc3070f73318ffff88a7a0b7fc6d1858b058ced735efd1789053f1583918
+  md5: dea5f96459c9a6df6b026ca57d387936
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224299920
+  timestamp: 1699647835748
+- conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+  sha256: a76c134ec258612ff7d55cb2a19b9e3461cbbd375a744bd29390af9cfcd283b2
+  md5: 1c736f58992009f53f014aef163bae31
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48442
+  timestamp: 1682969160267
+- conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+  sha256: bcfb0d1e075d043bcf05fa1a7ce3c142bf222d29693366af49a5a346c770812f
+  md5: 59e4820b34049cbc6619a8ac97290abc
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 222137
+  timestamp: 1695058350477
+- conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+  sha256: 114e408c40b332393cf2792393e4d1ede3465abcb3d345fe647ee519565346c8
+  md5: 86b13271578e1fa5e664edcf6fcb3ce4
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296860
+  timestamp: 1695059990370
+- conda: https://conda.anaconda.org/main/osx-64/msgpack-python-1.0.3-py311ha357a0b_0.tar.bz2
+  sha256: 7517bb3a1337287e71ba182e23654f49275048389a1a3c6d750dc580caf4aaed
+  md5: 5466d265b312c4ff0ff4969ebf15c0ce
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 37529
+  timestamp: 1678318290205
+- conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 638450a7ccb5f438ac65aa1c8d871fb5bb664e7261ec7e663d0302485c219a67
+  md5: 574875bbeabff85b5d9cfdb62066aece
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29473
+  timestamp: 1678392919304
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: e08cb3ee6df01f4c1e1ac8bc4ed1a06e549ffcc8774fe2e2842c644bb8f74a86
+  md5: 6ba0ae0fb14cbea1e3197707701dc180
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123077
+  timestamp: 1698934356774
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 2f946b5042eaac97206b5217fb203f3604ab3a60aecd99bdfc684925e3136c18
+  md5: b24026076c381ff2009e7acb9e0a6e87
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 534650
+  timestamp: 1699022791300
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+  sha256: ba368605a0af6f1dcbdcb6fddab9ce63224a85dd11bfb2b1acace1dc17899411
+  md5: 91f3ea3fe44d619ee95a6ed3773a0814
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 170926
+  timestamp: 1694616830121
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 42d803e1d8b54748db5d989ecd503826f564132df7cddc20f520460f55e523a1
+  md5: cd3fa71626ebc098da4625fc6be79752
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16952
+  timestamp: 1708532805951
+- conda: https://conda.anaconda.org/main/osx-64/notebook-7.0.8-py311hecd8cb5_0.tar.bz2
+  sha256: 08457eb26f6e84a25bbf413be70cd91274819e526f90ecdc859ee84af0b3491f
+  md5: a424f09e1db7fc2c399ce807e01c3713
+  depends:
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab >=4.0.2,<4.1
+  - jupyterlab_server >=2.22.1,<3
+  - notebook-shim >=0.2,<0.3
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3655911
+  timestamp: 1708029925977
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+  sha256: ed5608feb37a083d47b04203195260e801b64b5380f292cf18bb61e7ad827a2a
+  md5: daa9c1c233673b727528548454aea664
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27607
+  timestamp: 1699456006797
+- conda: https://conda.anaconda.org/main/osx-64/numba-0.59.1-py311hdb55bb0_0.tar.bz2
+  sha256: 733ece9d325b4baeaea505bd82be98ffe9e5f15669bf079ee4f2f15225bc70cb
+  md5: c426b5fb76b3d219a2fbfa2792684ae2
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.42.0,<0.43.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - cudatoolkit >=10.2
+  - numba-rvsdg 0.0.*
+  - cuda-python >=11.6
+  - scipy >=1.0
+  - tbb >=2021.6,<2022
+  - libopenblas !=0.3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6049873
+  timestamp: 1711992424576
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+  sha256: cacba45c1eebf7d86748737717883a98cf40664231460fa41391c79f98d06f45
+  md5: 3dbfae0d5b90e77f9358564ad442ac9d
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 165572
+  timestamp: 1696515553184
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+  sha256: 1466c3af380b949612c79940124e426eccd59e335c205da0c00383a69358d1c0
+  md5: df6be53592d40ba7e03d6ffe349760bf
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311h53bf9ac_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11330
+  timestamp: 1708639985606
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+  sha256: ace67d704fa7eea1480eb463f2d91bfc161be2ee20263c5a9939805ae3c2a9da
+  md5: ec124589478fa12fba4f35f31c3a0692
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311h728a8a3_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8783230
+  timestamp: 1708639945646
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
+  md5: 93f5d7b66976154adeda219bea02ba45
+  depends:
+  - libcxx >=10.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 484257
+  timestamp: 1630093862501
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.13-hca72f7f_1.tar.bz2
+  sha256: 14ee32164041ac8b077d487596d2a794391340a066ffae780176d8338da23e46
+  md5: 7d1bfacd50d591c536988670811e7bd2
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4982212
+  timestamp: 1714511433472
+- conda: https://conda.anaconda.org/main/osx-64/orc-1.7.4-h995b336_1.tar.bz2
+  sha256: 281d5a10e7a0a25bd6ee20d1d0f03530dd90fe5b4e3490ad3f33f0367df36f7c
+  md5: 062f9bba1d43123d02c60d23a29831a1
+  depends:
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.9,<2.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 425422
+  timestamp: 1676482778334
+- conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+  sha256: 8a0809f419065e014cb8e2c8a516cadca6088fb71fd1ef3ae2287d91e3360d59
+  md5: 4dc0b9bc88476fcc5246d823ff1c289a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39645
+  timestamp: 1699371213055
+- conda: https://conda.anaconda.org/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+  sha256: 64fbbb03570788298d8b04d4ea6cb254fef5d5eec73265aeecd72cb565617f4d
+  md5: 4b1195028bc26257df43fdd943638266
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 159450
+  timestamp: 1710811009212
+- conda: https://conda.anaconda.org/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
+  sha256: 6abb7e0aeda0130f54925421900772e1bc46d1f04ae69ce1376524457686d49f
+  md5: 232a6370c3fab0c41c6d4c7339e778ca
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - xarray >=2022.12.0
+  - xlrd >=2.0.1
+  - pytables >=3.8.0
+  - qtpy >=2.3.0
+  - scipy >=1.10.0
+  - adbc-driver-sqlite >=0.8.0
+  - pyqt >=5.15.9
+  - fastparquet >=2022.12.0
+  - pyxlsb >=1.0.10
+  - gcsfs >=2022.11.0
+  - matplotlib-base >=3.6.3
+  - tabulate >=0.9.0
+  - xlsxwriter >=3.0.5
+  - html5lib >=1.1
+  - python-calamine >=0.1.7
+  - pandas-gbq >=0.19.0
+  - odfpy>=1.4.1
+  - pyreadstat >=1.2.0
+  - dataframe-api-compat >=0.1.7
+  - beautifulsoup4 >=4.11.2
+  - lxml >=4.9.2
+  - sqlalchemy >=2.0.0
+  - jinja2 >=3.1.2
+  - s3fs >=2022.11.0
+  - psycopg2 >=2.9.6
+  - openpyxl >=3.1.0
+  - fsspec >=2022.11.0
+  - adbc-driver-postgresql >=0.8.0
+  - numba >=0.56.4
+  - blosc >=1.21.3
+  - pymysql >=1.0.2
+  - zstandard >=0.19.0
+  - pyarrow >=10.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17296294
+  timestamp: 1709591285369
+- conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+  sha256: 359b31da651ee35b9ca43974d26cd44e64f3cf412096c15dec7b720fa909a9b2
+  md5: 108e24227f8fdfc4d635bb4eedfa6cef
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48504
+  timestamp: 1698702608965
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+  sha256: 90efc71d35ab62d5b8d7b648e016444e1c4c8b83238b6dc9f2c6c3db4b14c599
+  md5: 6b6eeb0a14c5479db1dd39aa8d338150
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 939480
+  timestamp: 1714399174883
+- conda: https://conda.anaconda.org/main/osx-64/pip-23.3.1-py311hecd8cb5_0.tar.bz2
+  sha256: 62866ff6b1a021bde2758b97004ed1903fe34744be4ae8f2a0f7cd3113a45d72
+  md5: 1b9b2e51a171bc752955f3592e596184
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3454892
+  timestamp: 1700667869320
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 81719c31101d6c019150cedcc7b08adb3bdb357e8b2952e428dadaabc4dc985d
+  md5: 105825168e0a17fb007f60b5f314e311
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38405
+  timestamp: 1692205731769
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+  sha256: c0982f688127129e026d2b4cdacdd5684d00796ea7bdadd7d26b1101b095d723
+  md5: 0d6910c74729fede645c010110f1c89e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 121796
+  timestamp: 1679340253537
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+  sha256: e32843723b10ecd9badde28e1085419c0b59ed8a96c7cacce6395e39e3a874f9
+  md5: 5af0280a817d2c273304cd22328124af
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763044
+  timestamp: 1704404460779
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+  sha256: 117a435c2473e2a20cc81eaacb2b45ea5e7fe3c946eec2915936d344913ede44
+  md5: 0f459ee59fda20e2077fdc2c777edfc8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 497470
+  timestamp: 1679337286052
+- conda: https://conda.anaconda.org/main/osx-64/pyarrow-14.0.2-py311h2a249a5_0.tar.bz2
+  sha256: 7ed49e248ab0fbfaea3a170c8f795e7de8ba372bfad16f53e60500b10d5ca648
+  md5: 9917697f50ec91d18d43cd9670ec8130
+  depends:
+  - arrow-cpp >=14.0.2,<14.0.3.0a0
+  - boost-cpp
+  - libcxx >=14.0.6
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 5054065
+  timestamp: 1707331316454
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+  sha256: dfb403f367c57327a4d080109df88383ecff18464de287a1ce936a7274e3656b
+  md5: 997b674bad89963af875b93b06807f51
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2120413
+  timestamp: 1684280057020
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+  sha256: 9d2c0f373ac1c5db329581793dd517092cdf9a59140f2516ed8c3a1f483c0bbd
+  md5: ee10503a159e819abdc586666bdf0952
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207552
+  timestamp: 1678322848766
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 717e038567506ca58ce1cd4a3416892d02f4ebfdd332077cc3d110cfe3d36c58
+  md5: 53bbfb400668f798eef6f8c7cf938e1f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35751
+  timestamp: 1678315886516
+- conda: https://conda.anaconda.org/main/osx-64/python-3.11.8-hf27a42d_0.tar.bz2
+  sha256: dea2e1371f27376636d240d98eb9d2d1f383df0264b354c2d97c90b60358f9ab
+  md5: ff3603a0ff4f66a66856b3f09e29fec9
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.5,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16812245
+  timestamp: 1708984581993
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+  sha256: 514249897265f66f6ecca0a4427eb02a43c33b3c24974db16d05db6bbe97881d
+  md5: c9ea1437e5a3ba6a52ec2322505203e6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279116
+  timestamp: 1679338758489
+- conda: https://conda.anaconda.org/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+  sha256: 78b785b9b6ed46c86b0d3a32bdceea49f816672227fb63e726b2d46eadbdba0b
+  md5: 79d783f74359141e0b06a848db33823b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18563
+  timestamp: 1683823935261
+- conda: https://conda.anaconda.org/main/osx-64/python-lmdb-1.4.1-py311hcec6c5f_0.tar.bz2
+  sha256: ceed2007dc80313fab055da9ad855aeff4178bfa03c16e78297fb77d058e6972
+  md5: 753c157b80f60f263e0fe6a2f8d4fc85
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 151925
+  timestamp: 1682522457855
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+  sha256: e358fe679e83ccdc8c433746ae6468e8e96d90d97d99530f8476ef5630b2c121
+  md5: ce30a0a31d891e69dc9b7bf8b7f0c39c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 268876
+  timestamp: 1713974360942
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+  sha256: c3e11ed944da69c11b949bb918341a0d79ef603ee34a632d6a45fbf89ff924a1
+  md5: fee7ff4d291f530b4cecb575f29807a0
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 197996
+  timestamp: 1698096137432
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-25.1.2-py311hcec6c5f_0.tar.bz2
+  sha256: 9996c79c554086df5bb4e39afa822c9f71da32a461c268829a3e849c9b4f105f
+  md5: de5b99be21f6203d7577f11140c13534
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 528098
+  timestamp: 1705605165873
+- conda: https://conda.anaconda.org/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+  sha256: c69f556df9a27328c56943f3b5918cbb953cfbca987e20394d823a6174781202
+  md5: ab294ae71ecdfaa307a961cc71dd890d
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-3-Clause
+  size: 205638
+  timestamp: 1652449553607
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+  sha256: d784dc26c5de8e41845350a899e5779250b71f45d39e2aece62e739e9add7308
+  md5: 7b077b7f46112bb31dc066396c51d3fa
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74776
+  timestamp: 1699012164201
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
+  sha256: 3357b6b327b3d0a2cc0f02934a60bbd6df38f4ea7bbb3f50cb8e21332c9f5786
+  md5: bf5e48b646e36ef2b788be9665c0e5ae
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 120768
+  timestamp: 1707355762747
+- conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+  sha256: 727fb8d957e02d03b928d049ffbc712316f176a2c331391766d646621b45655a
+  md5: 7e0e416c642f3ee4ddfb084a811fb4df
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10236
+  timestamp: 1683077214314
+- conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+  sha256: a8a67143ccb65cfd6f50055176b6c26179a83130a45d0a12e79dd2de68d8db63
+  md5: a2065790f41e3eeb6efe0ef6daa75377
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10600
+  timestamp: 1683059285216
+- conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+  sha256: 6aba582338faa0c26fe336bdb10c65b8f7808a6e383bd8f80f3e6b612ca209ec
+  md5: a7486349b5f7370f6902c2050a23d268
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 319197
+  timestamp: 1698946203341
+- conda: https://conda.anaconda.org/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
+  sha256: 86bda04163628ef7b35528fbb4fe1d56fef50d10570a859e5ae8a7fbb60f577c
+  md5: 05e397dddd20d91460e3cedea0b3686f
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 4
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 27745043
+  timestamp: 1714075585637
+- conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+  sha256: beba0555707dac1e8484d73cee9e4128ac4b10e2a0d4209357481179022e8fdc
+  md5: baa8b304607b3a9ae8a3d9acb354c31c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33343
+  timestamp: 1699371216044
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+  sha256: c1df29188e321abe23651c73712a6d8ed3abdc89ad38a42c33f1835b3ab77abe
+  md5: 6c984ea85326858942f7b635e0cc9ff8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1597325
+  timestamp: 1715025837032
+- conda: https://conda.anaconda.org/main/osx-64/snappy-1.1.10-hcec6c5f_1.tar.bz2
+  sha256: 9e61e80cb7cc715a3d688a660249da591e20550716a245684ffca317df9a19df
+  md5: 62a52eef7c69e9be38fa0313aa49b4be
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 42438
+  timestamp: 1702909424521
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0eb44a16ef74a13ef7839209899d009cd94974fbc406a417d958c7bc8d955245
+  md5: 41f239a5b67b1daf819849023aa5d12f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19056
+  timestamp: 1705431379885
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+  sha256: 14775231982e1ea150189c956927ccfb1ad01a8c9395cdeea4d5a48b9b8ce664
+  md5: 729badc4bf7ba8ccc70e0f9e58075c99
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89812
+  timestamp: 1696347694075
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+  sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
+  md5: 6bef1694163a68ac4c37e5857b8da4f5
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1900191
+  timestamp: 1714488351925
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+  sha256: 3d5c2968f581006437df3932cd5d3c1c4afa78f0e13757b958440245d3248856
+  md5: 605ea221d225ad8e79284dbcfdab0715
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37699
+  timestamp: 1678317755913
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: ed059e32ce5a1c0511575f29d2fb6da12c54a37000bfa80f9e5aa9dfd9e04101
+  md5: 4d2261a92d25136a68b8d01d101119f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49145
+  timestamp: 1678317386284
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+  sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
+  md5: 523c006cc67c011383678c762015479b
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3594448
+  timestamp: 1714770737885
+- conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+  sha256: 424b8284072266eb59d055c0b7b58241bfb00009d445743ea261d4eeee73ea19
+  md5: f3a47898a55087edb9d65d29c24d9b88
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135757
+  timestamp: 1678323030858
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+  sha256: 6ab71b48d145c69007cfb5b4a21def2cc83bba972b7cc91c7d52d0d7eeb055bf
+  md5: f8970b0ad5c8b452b8722ceb4e5c17f7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 895379
+  timestamp: 1696937269468
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.66.2-py311h85bffb1_0.tar.bz2
+  sha256: e3950599a72f2093cbc99f6a2e40fb98c1731723a08f755a5c583560e5e602c3
+  md5: 46add19df747c5da0f1b7f1c8f37d842
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 155703
+  timestamp: 1714575768321
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 9e8dbede0bc54c77b974210be66503e7e8e45e0f1c71dc5c16cc9a9674d54259
+  md5: b4fcab9e63bd7b3cdf458c953904807c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270874
+  timestamp: 1678316116954
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.9.0-py311hecd8cb5_1.tar.bz2
+  sha256: c92c53f476c8157965a9637a4fd5ae7311c724396669d55fbe6b1b16c4c678c4
+  md5: 1d97af42c34da5f616ceee31e3a56d46
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.9.0 py311hecd8cb5_1
+  license: PSF-2.0
+  license_family: PSF
+  size: 9879
+  timestamp: 1705599378858
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.9.0-py311hecd8cb5_1.tar.bz2
+  sha256: 00a423edcfd3cc351068c09cf89ecacebd44425dc589aa5e2778e9b8552b521d
+  md5: 0926a658fe3590254e368b5b23a0cf3e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 71954
+  timestamp: 1705599373108
+- conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+  sha256: a9960485ced319ac91afe69eaaf703c7e6b3049f1e06a4a8c2818b64155943f0
+  md5: 0a9c8ea92a14330a07edabac249e32a9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11399
+  timestamp: 1678394892923
+- conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+  sha256: d42ae57366d05e12f10074583568355752436d66ad018ffbcfa24135f593810a
+  md5: 1a98e48aa0bd8b3ec09e2cbdbb236575
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 498952
+  timestamp: 1713213079520
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-2.1.0-py311hecd8cb5_1.tar.bz2
+  sha256: 33caa82e1fec2ce6b468392257f3556e5e6ae91654c01393b36bc340fe78f9b7
+  md5: 08b9cfb7943aadbfee616be6064cee7c
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - selenium >=4.4.3
+  - zstandard >=0.18.0
+  - requests >=2.26.0
+  license: MIT
+  license_family: MIT
+  size: 184811
+  timestamp: 1707770784530
+- conda: https://conda.anaconda.org/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+  sha256: 0f8c3eb254be9c1957e748e385e20e62509d11052990c4755012be62434c9129
+  md5: 53229ba93f6e38308ae42ecfc6eaad9d
+  license: MIT
+  license_family: MIT
+  size: 96768
+  timestamp: 1706894705048
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+  sha256: 597015e8a038a111f03ffbc9a217fcda549d75230c86ce53c1f23c53d6f1a0cb
+  md5: 62e98aac883bccc1c87ca0d2ce2f08e0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25798
+  timestamp: 1678317074170
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py311hecd8cb5_4.tar.bz2
+  sha256: f60e6da6f08bf1bdcec59ed71fb53bbd3d2e3c487dba59523e956bfea6ba9ef6
+  md5: 6acead6f585f1bae0447298d4fec340c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 90538
+  timestamp: 1678317776793
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+  sha256: 885a9b6046e76f7dc1a346b14c63b4083046137bfae036362c854458e20e4fc8
+  md5: 3b279447ca282d065e681e567055b582
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 137340
+  timestamp: 1714717062907
+- conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: cc6995f677d1628f42ae80ed47ff08d8d1c8ed12580a326af6e307f5febc594a
+  md5: d01eb964863b95ef62061b77c9037ead
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2471632
+  timestamp: 1689041625741
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+  sha256: 5b6d5246955b5f9480ff7027eb002442a7ade24f5c354da54ed513042f76cedc
+  md5: f32aa8a37d5e65a8dc30f9a1f46bc63d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54719
+  timestamp: 1678325412288
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+  sha256: ed0152ad6b87ffd9e01f4a62bc358e805ad59637f898a801b0a9cf903ae8e1fb
+  md5: 8a92f8c663608f24e14d8a2068b9d83a
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 415323
+  timestamp: 1714511993944
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+  sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
+  md5: c25b6d40f834647d0bbe767f6c776031
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 329449
+  timestamp: 1705602140856
+- conda: https://conda.anaconda.org/main/osx-64/zict-3.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: e5fd1f8b8e5cc1221e85355ade7b69f0df640dbdc016b7f9ea0b0b6eda5bf9b6
+  md5: 11c4cb55382be5ab89b5c4085510db3b
+  depends:
+  - heapdict
+  - python >=3.11,<3.12.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 103266
+  timestamp: 1695833080541
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
+  sha256: 36fa7ad990aabf3607bda1f33e847888210974586363b6d69cf1ed092c192c35
+  md5: c981fe545122206cdeb647f2dc9e093d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 25496
+  timestamp: 1704207010227
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+  sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
+  md5: f2519b551f99765d9d98950c5e2b4713
+  license: Zlib
+  license_family: Other
+  size: 119782
+  timestamp: 1714511811597
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+  sha256: 7feb73e79bdbd45404ddc7a30c43bf4cc68eced8ce448ce7c31f5db134276fc5
+  md5: 48313bc6570c705cadbba3c356e0dc8e
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1014151
+  timestamp: 1714678461080
+- conda: https://conda.anaconda.org/main/osx-arm64/abseil-cpp-20230802.0-h313beb8_2.tar.bz2
+  sha256: d42422c15e115f76aec2f71e25887104359d5140af3cc6f19e358af011dc7ba9
+  md5: 9996619edfa02accc1fb7912d5ecc5fb
+  depends:
+  - gtest >=1.14.0,<1.14.1.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 1372151
+  timestamp: 1698327835928
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+  sha256: 9ca3f0dfc2bdbc109e359ba7ab246e6ae952a14819148ad069454b52f2bda802
+  md5: 51fb05873a644cac52f0d1e10cb7969a
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.23
+  - uvloop >=0.17
+  license: MIT
+  license_family: MIT
+  size: 228856
+  timestamp: 1706220385566
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+  sha256: 43405cc7341ce3efb2e24013ad62c64f26a69926635adceaa5459ccbcafb3776
+  md5: effa6d22f497e164cc8455f7f329c304
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 12510
+  timestamp: 1677917870614
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+  sha256: 947efe1c50b3280e9a67cbb18636bdade53a40960fff3056850ff81ab87acbe3
+  md5: 7d2d384ee32ccc12dcb0dc099e421482
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 35091
+  timestamp: 1677915945226
+- conda: https://conda.anaconda.org/main/osx-arm64/arrow-cpp-14.0.2-hc7aafb3_1.tar.bz2
+  sha256: 86bab32d1e41090bc20f55a7e337565aa8085b6fbafe9bab11886ccf7d938bcd
+  md5: 26f4f94a10d3fb85cfdb2ef11894d3d3
+  depends:
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - aws-sdk-cpp >=1.10.55,<1.10.56.0a0
+  - brotli
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags
+  - glog >=0.5.0,<0.6.0a0
+  - grpc-cpp >=1.48.2,<1.49.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.13,<4.0a0
+  - orc >=1.7.4,<1.7.5.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.9,<2.0a0
+  - utf8proc >=2.6.1,<2.9.0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 9537543
+  timestamp: 1707253459914
+- conda: https://conda.anaconda.org/main/osx-arm64/async-lru-2.0.4-py311hca03da5_0.tar.bz2
+  sha256: 9c64b8d25d87c43834c3f98c331598f9353b063af9456da0be91252a4433e01e
+  md5: 46c58da7041280e5ac6f5c9ce4b8b7a6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 21474
+  timestamp: 1699554635961
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+  sha256: 8259b4a0973c825ac81f581afcbe86640bd0a94b33caa996167309241877635a
+  md5: 49b8ddacfd3927bcaae139eadfb72ce1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153557
+  timestamp: 1695717951839
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
+  sha256: f536e8b60bdc895063ca0e0155d2041993caed5f932c232f2a0d8e52798da2f1
+  md5: daacfabaacebe1d1e53426ec3e385d14
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 86757
+  timestamp: 1706746162173
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
+  sha256: c356ce4cbd638a41fd3db59aa3559850e38c6b41188b8ffab32bdcbd9a55fe03
+  md5: e9dc8c248dda95e92533cae6815a0a8b
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 39456
+  timestamp: 1706690903374
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
+  sha256: 117825fcff2a68136a6e5183e05542c2654d73322e70daee3c50c0ecb3aec703
+  md5: b115d3f733fe8bae79b9d416754b260e
+  license: Apache-2.0
+  license_family: Apache
+  size: 182078
+  timestamp: 1706189905050
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
+  sha256: 241c19574abcaf91a47fc5c36f38e58c86732be5e06f5170063406098a58639f
+  md5: 3cfc3d38b8fdb25cc2e10e3e370d4106
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18039
+  timestamp: 1706690838125
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
+  sha256: d4c60f610e57b35a2962b8cea9911358d1642e0449468fa4967706af88bf5da9
+  md5: fc23856f141fe548afcfc4823881ee19
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 47155
+  timestamp: 1706697259456
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
+  sha256: c43ed35f4a64818ae39ca2c3c3652428c15da5e287f6e94254c3df4d6c759fb3
+  md5: 06366f5f8762447babf69804a04b1a69
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-compression >=0.2.16,<0.2.17.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 162746
+  timestamp: 1706744122437
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
+  sha256: 14e2ee7339c88089d1ff68f7144b3fb4f9e34fe538a9462f8de31dd6fdd1d42b
+  md5: 59ab0e7ffd73966ec6a2fa83a5df5c47
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 127084
+  timestamp: 1706696174505
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
+  sha256: 601baf006d0545ec65566701d99c601cba843e8ac03d80819d4b8bed23d1e5c4
+  md5: 2c98a19d57362cf1fbfec3dda3ea283b
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 61914
+  timestamp: 1706746732665
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
+  sha256: 16809db73ddc3c374ead2c2e9f2221894e2014d3e07ba62d79375cb4de4dfc9d
+  md5: c03f5e3b42bc59bd92db813522cce1aa
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 67560
+  timestamp: 1706747573116
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
+  sha256: 293cf6b9dfa727d0e65b383b0e434f8fb26480abd011516171b8652fd363c98e
+  md5: 2df2dd6c43a3b413b438a9ef834d78b0
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 48454
+  timestamp: 1706690816205
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
+  sha256: 773f7ff1a91af373d27f5c57833aff8912870108ddd94a5280bfdc608effe5e3
+  md5: fad8b095c03774c9d4901db7eda09002
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52142
+  timestamp: 1706192041205
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
+  sha256: 4efabe18fc312e65a5aac9b2ebe423296cfe702756891978244287ab47881927
+  md5: 5786a8ac037fd0e81e25f52dbc6dc72d
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
+  - aws-c-s3 >=0.1.51,<0.1.52.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 210683
+  timestamp: 1706827608490
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-sdk-cpp-1.10.55-h313beb8_0.tar.bz2
+  sha256: fe92c6408ee3ebf269b216d1c9576bc15e65a38bcf684f2a7b935e57dbf2e444
+  md5: 4c6b2dc15773f338a7f3299a753ab0af
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 2365300
+  timestamp: 1706890517127
+- conda: https://conda.anaconda.org/main/osx-arm64/babel-2.11.0-py311hca03da5_0.tar.bz2
+  sha256: cbca68c98946526eb9a24c01717a0c850d1736f7530196ce627bcc33d8337a18
+  md5: 57ee914212070a75e071674d97480bd5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pytz >=2015.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7177152
+  timestamp: 1677920828584
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+  sha256: 11159a30daae77cfc1abe5e60c19261f65c005e6fbc460aecf72318514d737ad
+  md5: 0c5002654a9cb21db1fdf8c1d2017df5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 269772
+  timestamp: 1681493072129
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
+  sha256: 90439f37ede74ef464e76093e173a8e94a20ee4ad79c68c9e7570fbc67fc13cc
+  md5: bb3b906307dd679fc3276be7581494f9
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6073834
+  timestamp: 1712084392983
+- conda: https://conda.anaconda.org/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
+  sha256: f1660ecfb8687d74e81a7b00699a8bb4677cbd791d14f50ba517de98e2f187ca
+  md5: 1636fc4b725da8c5e967952a55f3fd80
+  depends:
+  - libboost 1.82.0 h0bc93f9_2
+  - libcxx >=14.0.6
+  license: BSL-1.0
+  license_family: OTHER
+  size: 11780
+  timestamp: 1696762172661
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+  sha256: 688a071ba370f51b457cd32d70b7b38921ce9551203d06fa7fc2c30c4b79891d
+  md5: b2353077a39ab997463768154dd58fec
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134711
+  timestamp: 1707864978809
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+  sha256: 048264434c33fdb53862cdd69b2e2bc4ce6f8a70b3211ad6d686d066eac2aa91
+  md5: d55696ccaf6755931cd662dfb929aa0b
+  depends:
+  - brotli-bin 1.0.9 h80987f9_8
+  - libbrotlidec 1.0.9 h80987f9_8
+  - libbrotlienc 1.0.9 h80987f9_8
+  license: MIT
+  size: 19737
+  timestamp: 1714483270447
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+  sha256: 13627293296fcc231d8dc12d803dfc9621108c60df38b0e3c64e9e02ed55e564
+  md5: 86efd4ad08cd80d3eab77873db84a255
+  depends:
+  - libbrotlidec 1.0.9 h80987f9_8
+  - libbrotlienc 1.0.9 h80987f9_8
+  license: MIT
+  size: 19083
+  timestamp: 1714483255364
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+  sha256: 2e542b2bb27f8379da3efcb83ef084cb26e6a9ab576c50487c2dd996afd5ccb1
+  md5: e8cab9d1ef58a450f971690fcdb2ede2
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 380182
+  timestamp: 1714483330655
+- conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+  sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
+  md5: 56d1386c7f1f338f0d18f82af6525273
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 158748
+  timestamp: 1714510571033
+- conda: https://conda.anaconda.org/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+  sha256: b0be79290b1df1cf1d07a1a9c3f3a92ae262643a6df3dc10dfbac22a82874dd4
+  md5: 8fdcf1c08eee91fec7eefc22863c816a
+  license: MIT
+  license_family: MIT
+  size: 106550
+  timestamp: 1693902036526
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+  sha256: bbfc668f445f3584936b326dcfe92bf71971ce16241f4f79db8aeb88d7aab41c
+  md5: 10cc05ed51482e1dfcc31dbd13bb34c6
+  license: MPL-2.0
+  license_family: Other
+  size: 138641
+  timestamp: 1710764806818
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+  sha256: 512969f339a9a7b347cdb7b88f439819168089867f04732279f02759d8caf24e
+  md5: 2009c2ee465fdd74dbd046de73726234
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 166501
+  timestamp: 1707229221324
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+  sha256: 8d26cd4d16545ad8afddd5521bc6894a50d5b8faff3abbe600bb9b062f3c3a0a
+  md5: 66eb734b7d7008eb5fb537900767c7ae
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 286807
+  timestamp: 1714483190838
+- conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+  sha256: df81a27f221d11af4a709f272dc8ba3fd3f6d5ab4ffd883c40567bcf04f0cfd3
+  md5: e49333e3ffe1fe2e701f50a6e6dccc52
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204179
+  timestamp: 1698129906257
+- conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
+  sha256: 53edaca56d853083d44cef6234fe4b3d076d107e915781ce54ec135c25e09f0e
+  md5: 5d1d51e53c11bcb56cf863d58e37c077
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50433
+  timestamp: 1683040076511
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+  sha256: d9c126d8bcd1c89ea37186c172d6b1f73f45ada60e3ae1790a017b530baa0147
+  md5: f0223aae3d622547f6accb212579c58e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17967
+  timestamp: 1709322909223
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+  sha256: 1f908c688e47d03d92ac09d9541a1f1c773ac2ca485dd1d77441b1aaefc032db
+  md5: 444c330471496a39a97e87f41ed70c96
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281104
+  timestamp: 1700583698464
+- conda: https://conda.anaconda.org/main/osx-arm64/cramjam-2.7.0-py311h62f922a_0.tar.bz2
+  sha256: 1a71c2e15872edff275f419bd1b827c2e37a4cfaf997cd30104cadb2da285a5b
+  md5: e97551b1be62a8bc30eb69e1dfe39191
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1531706
+  timestamp: 1702651054879
+- conda: https://conda.anaconda.org/main/osx-arm64/cytoolz-0.12.2-py311h80987f9_0.tar.bz2
+  sha256: 9e135f43ac703c578abe1b84761a1fb4ad75b63966f0b015fdcb939d3b05e7b3
+  md5: ab5b122dafc5b17f32b2ec8ce73d8adb
+  depends:
+  - python >=3.11,<3.12.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 403974
+  timestamp: 1701723703085
+- conda: https://conda.anaconda.org/main/osx-arm64/dask-2023.11.0-py311hca03da5_0.tar.bz2
+  sha256: dfac5c394e0fa6c3bae5c8565735363a56478d512e38dc8782dd9ecfd06d5d17
+  md5: 72efbeec2089b327f3b751c45abeac10
+  depends:
+  - bokeh >=2.4.2
+  - cytoolz >=0.12.0
+  - dask-core 2023.11.0.*
+  - distributed 2023.11.0.*
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.21,<2.0a0
+  - pandas >=1.3
+  - pyarrow >=7.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6031
+  timestamp: 1701444902384
+- conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2023.11.0-py311hca03da5_0.tar.bz2
+  sha256: 66b75168a7eb1fa16c9ddd7004339dab4d4bd3557f60abfcfb9de706f27cfd42
+  md5: 4c482f6b591b73d95c21f967bd69b471
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3028051
+  timestamp: 1701396155471
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+  sha256: b9356e3ada4872c7c950d2ac7e0f107c4786775191efdfda3a469dffb18f2714
+  md5: 07ddd96675caf30ea77cafb1ea5662a4
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2490144
+  timestamp: 1690905181398
+- conda: https://conda.anaconda.org/main/osx-arm64/distributed-2023.11.0-py311hca03da5_0.tar.bz2
+  sha256: 9901062d92e30b3e1c7739d19be817765fa7c39458697498b06b125ce36ab8d4
+  md5: 638bd80c82a43aeac35c73909014ac92
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - dask-core 2023.11.0.*
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.0
+  - packaging >=20.0
+  - psutil >=5.7.2
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.10.0
+  - tornado >=6.0.4
+  - urllib3 >=1.24.3
+  - zict >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1789023
+  timestamp: 1701398118479
+- conda: https://conda.anaconda.org/main/osx-arm64/fastparquet-2023.8.0-py311hb9f6ed7_0.tar.bz2
+  sha256: f883809f6e11db2bf67fd28a0fe283fbb5ad1a6e09897c4e743465c1d0838127
+  md5: abdc285c69c9b5e9e7373ee6aec90856
+  depends:
+  - cramjam >=2.3.0
+  - fsspec
+  - numpy >=1.23.5,<2.0a0
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 563381
+  timestamp: 1696541857273
+- conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+  sha256: eb82a0e2ca36d0973b5f6642e27609554edad4b72696f989776d5db8cd4a6a42
+  md5: fa8d9dd8a2fabba964c6bb75ace8c572
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 3201601
+  timestamp: 1713551611540
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2024.3.1-py311hca03da5_0.tar.bz2
+  sha256: aa53d9f23e86ac3398f6b935cea01dcd8a1b1821d9b1d37b16a5ba68a2dbe569
+  md5: 2d5841b96988498045c28e3b3951d5ac
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 373029
+  timestamp: 1714461571346
+- conda: https://conda.anaconda.org/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+  sha256: 25e05b93a99914a5fd1a298a2c5b25479fbd571b0db9caa7c6ad4336f060f62c
+  md5: e213b68bb0274e0e54c610a041e059f5
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 150168
+  timestamp: 1706888198288
+- conda: https://conda.anaconda.org/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+  sha256: bbbcf47ef9249635b5199be1414b0b59687cc04ea9630d50ecc609dc200c095e
+  md5: 5820c373d6847a68551cadb8984a8277
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 95638
+  timestamp: 1706895270850
+- conda: https://conda.anaconda.org/main/osx-arm64/grpc-cpp-1.48.2-hc60591f_4.tar.bz2
+  sha256: 4787d6730eae9c37b11f76db852a2c0a070b4dabc9abb9e423fa3ad68944ed19
+  md5: 8dff6fefff4eabeeedc5a67b15d91aff
+  depends:
+  - abseil-cpp >=20230802.0,<20230802.1.0a0
+  - c-ares >=1.19.1,<2.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.20.4.0a0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - openssl 3.*
+  - openssl >=3.0.12,<4.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3884646
+  timestamp: 1701982736145
+- conda: https://conda.anaconda.org/main/osx-arm64/gtest-1.14.0-h48ca7d4_0.tar.bz2
+  sha256: 064fc752345ef3973d3ebf2145029eaa308c17e12abe72a732255db9cdea6a40
+  md5: 37ace38cf07143b39ae9b89feb204d3d
+  depends:
+  - libcxx >=14.0.6
+  constrains:
+  - gmock 1.14.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 399378
+  timestamp: 1692633568295
+- conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+  sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
+  md5: 69eb3b03765627b6159ed23cdde78396
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28399065
+  timestamp: 1692293207812
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+  sha256: 4d4ab70ae0ce008c1cc96a4edfbf3866d5e636acc4799a545ea93acee51635f7
+  md5: 86a085a440729020d1d7b0b74d6a0c6c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148448
+  timestamp: 1714398923507
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+  sha256: ec139e4b87aadcacc0670ecbcc2a303d858d4ac38b9404458a4b676bce9d21d5
+  md5: bfcfed281f8df0f18726ec5f843b2b26
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 51053
+  timestamp: 1704813595720
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+  sha256: 63670c8f31770e1746016f645ca6b42b35f92d1c37e8025793d9490fed9998c0
+  md5: 9cb417b9fdf02b4e007a5b5781e5a8cc
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229932
+  timestamp: 1705934202146
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+  sha256: a40c76c412ec793ca26b97a9b5c496d253768438e1f7d4a0ee5f63ea79eed355
+  md5: f609e4fe044318211cf0e37e289beebd
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1614299
+  timestamp: 1704833142734
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+  sha256: e57d10579b52a3cde45aa17e1bdd95dcb9d3346aa00eb02c51e38a42db83e18d
+  md5: 05153120787fb09159b6e1ad902c6e10
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1180481
+  timestamp: 1678994989550
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
+  sha256: 06512ef9a910fa72bf5697fe89e88c605d61f8478a9d8dd233c13f40e30f8446
+  md5: cfa00c9ffd3407e29507525c020e5526
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 355730
+  timestamp: 1706733720706
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
+  md5: 055e12390b844ea6c6e956ee08a618e8
+  license: IJG
+  license_family: Other
+  size: 273479
+  timestamp: 1677849171867
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+  sha256: 62025ce4a2b9244b9816c9e02487e0dda567600692b5f9ca71f425d084961c7e
+  md5: d57b7063122e5bf25cdfc2a5ea7330a8
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 181872
+  timestamp: 1699041739097
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+  sha256: 404b0847029f77bedd7902a170a046219e0dc5c0ec2be19ff45361cff25b2181
+  md5: 3a02bbe8d45fdbcb2350f672be74c9f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16524
+  timestamp: 1699032463763
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter-lsp-2.2.0-py311hca03da5_0.tar.bz2
+  sha256: 8d8eb94257336543a0c6a2168a68195ee1258af47f4b5b58d8797ac483744a63
+  md5: 191fecf4322e1348caac6337955a9e5a
+  depends:
+  - jupyter_server >=1.1.2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101675
+  timestamp: 1699978313832
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-8.6.0-py311hca03da5_0.tar.bz2
+  sha256: bb525ddbadaeb7090eb5bf8aaf2d4d01765c5e2e93136a47fbb1f5b663bab567
+  md5: df7c907e1d274521660c4e2030c5b6ef
+  depends:
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 225157
+  timestamp: 1699455930116
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+  sha256: 8220b1bbdde5e800810f7bf183a992af1a95825a837edf975fa8c4b51c5d806f
+  md5: 3a06ddad06e04d5f0211c22cd81ca75a
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94950
+  timestamp: 1698937436979
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+  sha256: 8a9a9f9ddbf1b7744ef04a8c862438499a41d81a4beb4a49860156c273bb7497
+  md5: 051355801f09eefe850ee8145151f934
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42497
+  timestamp: 1699282590553
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+  sha256: 65c703cc996a705d0ee350070e313b1cae865f9d6e6490ebf1164c0f3ce22d93
+  md5: 305ad8bcaad3e352d61b1e594093b467
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 596801
+  timestamp: 1699466743685
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+  sha256: 501e929d345aaa9079c965552b942b4e8bde35b87ae89faef003687a40bab3a4
+  md5: 54c7b8554a405acd7c8326c41ba93e63
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28237
+  timestamp: 1686870817418
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab-4.0.11-py311hca03da5_0.tar.bz2
+  sha256: 7c07921656d5a8f8fdc8e5edb0b18ffdfbde22a1938258cf29e78b5b66c93928
+  md5: b152aceb76578939f6aced4bf328dee9
+  depends:
+  - async-lru >=1.0.0
+  - ipykernel
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.19.0,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  - traitlets
+  constrains:
+  - nodejs >=18.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6667686
+  timestamp: 1706803531409
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_server-2.25.1-py311hca03da5_0.tar.bz2
+  sha256: e28c8ba9c667ba5a276d3302005b990874c6de77e4fc785f87224a2dc2ca5394
+  md5: 3873f22212fb841a76c5348f5f6acf98
+  depends:
+  - babel >=2.10
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18.0
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.11,<3.12.0a0
+  - requests >=2.31
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 107252
+  timestamp: 1699555538493
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+  sha256: 8c1c64d51be73aad381992a9df19d8336910bdfc40f19940231df86e177d17cc
+  md5: b1f786f96684a143cf30d1f6b8aebdb3
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65045
+  timestamp: 1677925371836
+- conda: https://conda.anaconda.org/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
+  sha256: 789402b67398d3d936ac4486df01869d59b0e1ba298cbd06407d059aced871e4
+  md5: a0f50a38705d0507bbf57ee49a1d9c29
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - openssl >=3.0.8,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1308175
+  timestamp: 1686931157327
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://conda.anaconda.org/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
+  sha256: c1f104bc84ee46a3d3beafb5e35236c64e6b4fd6cceabfb420e1838171b1d9c1
+  md5: 4f95903a1be48bbee1f9a818ec810b89
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 22243663
+  timestamp: 1696762144385
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+  sha256: 199042b87451abaf14546af124ae3380194cddda928e0d30ccb341e93084854c
+  md5: eaa0442887994a82486c65d87f6b71e6
+  license: MIT
+  size: 68806
+  timestamp: 1714483212137
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+  sha256: bd9a8a17fb14086446b710fa029d238e69274b83ee2e7e09093496f190de82b5
+  md5: 66615d6a0cb5dcca3e20c019cde0ed2d
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_8
+  license: MIT
+  size: 32975
+  timestamp: 1714483225840
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+  sha256: e1bf77e8b975c30a69b08a08410622e27c8cff6f592ccfa590466b83d9e6d104
+  md5: 8af86bdac01fe303d693d9b76c071059
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_8
+  license: MIT
+  size: 310266
+  timestamp: 1714483239194
+- conda: https://conda.anaconda.org/main/osx-arm64/libcurl-8.5.0-h3e2b118_0.tar.bz2
+  sha256: 5f11db2220b728d4e13e1d0069aeb0215719a7bdfce88ecfc7be68778986eb54
+  md5: 131c9519f6e616b3295735ac1a7f9c2e
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.57.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=3.0.12,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 357001
+  timestamp: 1704383770648
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://conda.anaconda.org/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+  sha256: 9597df5344a718d37837966aa05091faf210260898fad5e7a64b87f17de9e90d
+  md5: 678a1f87940ef6cc421a092301b8c3fe
+  depends:
+  - ncurses >=6.4,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 167208
+  timestamp: 1703006281321
+- conda: https://conda.anaconda.org/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+  sha256: 6fc572025852b210ecddcca3ab9ff3f1d5f6bd91f1933c6e296de6bb331f6b5d
+  md5: 6dd7d9c5737bbd2a27d18f15318dc3e6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 102059
+  timestamp: 1628961869728
+- conda: https://conda.anaconda.org/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+  sha256: 9e7b9bb9367d8725a751cdfa0b2d270434d303ea196cfaacc605ee26be09874a
+  md5: 44d1843cc2f17eb2674f35b95468f551
+  depends:
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 415467
+  timestamp: 1685052299052
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+  sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
+  md5: f31e4eb9cd6447cc2f5ef0243a76540c
+  license: MIT
+  license_family: MIT
+  size: 120460
+  timestamp: 1714483461787
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+  sha256: 72d242814b990900c9410d4738cc685f70ea71231742293cffbb475d8df100f8
+  md5: f9976688992b7ac4b56f5600ee15b5c4
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1407202
+  timestamp: 1714483550601
+- conda: https://conda.anaconda.org/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+  sha256: d654027daea13ac9db36ab5fd5eff3ad398ec97c1777bf399f3ec680d2c145b9
+  md5: baabb1f905054bfea3af8f5768572a34
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 26579907
+  timestamp: 1683291669565
+- conda: https://conda.anaconda.org/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
+  sha256: b7cd58ddb892ed9d3983bdde8fc2530f0653a58818c87e08659f3795f04d8aff
+  md5: cf519f7233951d00a30c3b969c4cd161
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - c-ares >=1.7.5
+  - libcxx >=14.0.6
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 728977
+  timestamp: 1697018415626
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://conda.anaconda.org/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
+  sha256: 239ec46c06c477e722230159971bac8d9eb14793a2e75f6e3d3a7a04ed5d5ebd
+  md5: 50e9c501f39bb262703c764789099f24
+  depends:
+  - libcxx >=14.0.6
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2338901
+  timestamp: 1675278555141
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://conda.anaconda.org/main/osx-arm64/libssh2-1.10.0-h02f6b3c_3.tar.bz2
+  sha256: 41a62fd6332033289602976adc75cd67e23d9b41ae97d0a993adb41f13f83480
+  md5: e2d039fc0d9f3d32818d202f23a30e8c
+  depends:
+  - openssl >=3.0.13,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 303841
+  timestamp: 1714510628791
+- conda: https://conda.anaconda.org/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
+  sha256: 82a73882a31e7a4f4edcdb0c21562e123da913d03b90b19396bd6dd4fcd9a7fc
+  md5: b5e5199892949d1e7e2db7bf0ee4dfe9
+  depends:
+  - boost-cpp >=1.73
+  - libcxx >=14.0.6
+  - libevent >=2.1.12,<2.1.13.0a0
+  - openssl >=3.0.9,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 361781
+  timestamp: 1687975246139
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+  sha256: 41c62a460bb81a1a272aa28b219fab9c26510adac177ff1528b1980eabc6e868
+  md5: 8d312c5628dc7ea833e9b4dcb73e9c45
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 42346
+  timestamp: 1677973051421
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
+  sha256: 911c7577f591311bfb000121831234e7bc6332bff62fd00c2245371e67f473c0
+  md5: 419681f23f179ba08e5fdf9884ea238d
+  depends:
+  - libcxx >=14.0.6
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 410616
+  timestamp: 1706910762686
+- conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+  sha256: 5777bbef827f72975a36f3da80ab4af718dc781264f74ad7e3864755d620c0f0
+  md5: 4240f1a79b812387919cc710a0469556
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14318
+  timestamp: 1677925438733
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-4.3.2-py311h80987f9_0.tar.bz2
+  sha256: 14582ae62269dca40493afba1649f929841f5d2bc5907bf0f6f01c6a551062c4
+  md5: c920d6dea31be5638d79a76026d523a0
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39941
+  timestamp: 1686063850483
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+  sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
+  md5: f5f7e6e7541d8dc3d3df270d488d2e24
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176990
+  timestamp: 1714510588159
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+  sha256: d024f5142416961a5e66e424d4d14aec652f9e9dd738b41a97f45674c2ffc9d5
+  md5: 0e2d94b125d802f7b006cf19c71655a1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 163084
+  timestamp: 1677932947966
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+  sha256: acfd84e29ff4dc2d85543bb973a07f22b4ba53c5d00bca84608ee7f13b2a8676
+  md5: 5ca161cd51e2db358e768453b3ee485e
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135871
+  timestamp: 1684279980293
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+  sha256: b1bed54c7bfb7304cde9e8e6f798543d08e808e81286a5a48296fc94d621f9da
+  md5: 774358285c9e496c9f5c121cc546c823
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27438
+  timestamp: 1704206026910
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-3.8.4-py311hca03da5_0.tar.bz2
+  sha256: a8d33a3b5014dabc72b49639b2b2c632b8568b692fc963d5bef0222b46c075ab
+  md5: d2d84d2224a9abd25ae550ccaf64ef4e
+  depends:
+  - matplotlib-base >=3.8.4,<3.8.5.0a0
+  - python >=3.11,<3.12.0a0
+  - tornado >=5
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8973
+  timestamp: 1713336625397
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+  sha256: 9229a6e15abf3147cfcffad4ca389dad940e45779963b4fc3fd56dfdcfca3234
+  md5: 4e1897f3cb4923de48c016468c01c051
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9100733
+  timestamp: 1713336457304
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+  sha256: 3276d61fc353c537bb09d4b7473d7abe12be38806f42c8cc383b62f40850a5cc
+  md5: 6e9c9d47f264b77d9a8461f0899848a7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20446
+  timestamp: 1677918370379
+- conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+  sha256: 43c96d30775b61b4968422a47f9605049428120669f0742bbb9e5ba145c7d11e
+  md5: a31ca0d9284860adf5463cf45a5e3145
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 69243
+  timestamp: 1677995336989
+- conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+  sha256: 96d8c9f42a38651b7bafe5f3cb132601db76cd1e28fa58e2eaf090e634292fff
+  md5: 5ebc793a17b6aa84d13f19433545ffa5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23895
+  timestamp: 1677942274932
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+  sha256: db9bd659ada23f1ded443d2db00dd13b5d5c0b30f5062544b1ee2c2b88d63d29
+  md5: 03c48121614cf12abfe30eced9b34717
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105333
+  timestamp: 1677916687032
+- conda: https://conda.anaconda.org/main/osx-arm64/msgpack-python-1.0.3-py311h48ca7d4_0.tar.bz2
+  sha256: 3e370e88a51671f87fa0c0e241569950f8c5a38d5e8743c33b0193f54d73d10d
+  md5: dd70eac354c92710ce4e2be9d4b02043
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 38448
+  timestamp: 1677909415759
+- conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+  sha256: 8b05894fdcbe5cfcdee94812b043de4cd7b4fa51d3e2aad25fc7cff50c8f82ab
+  md5: c970d49137dce1c77f782ee5725950c1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 30745
+  timestamp: 1677960816849
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+  sha256: e8eee27fb667aa10b26f3bc4b93f449b7d991ded27b9cb457effee394ce05f6f
+  md5: 6a3e5cd0e1141c01ffb91285bdccfe83
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123043
+  timestamp: 1698934328890
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+  sha256: 40230434aa2fbb33ece13632e8d4b7cd1ad68fdb8d1b00263af4a010795d25f8
+  md5: f12ce7dad3620d6d53a442fa9d36a0b0
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - pyqtwebengine >=5.15
+  - tornado >=6.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 538067
+  timestamp: 1699022954841
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+  sha256: a492acec8ceadc0911a75966ffa630a8eb15b2da8c7a8d544a645ba47771a2d1
+  md5: 4002b1b88b2ecfdfc769036f43b0a895
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 170964
+  timestamp: 1694616845237
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+  sha256: 417ace1ce51e81f3f92ddc26e0e3a83c1e19c9ebb7af7104452002a5573da534
+  md5: 3e11de6cef096091bb733e07802f00b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16979
+  timestamp: 1708532698253
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-7.0.8-py311hca03da5_0.tar.bz2
+  sha256: 0aab440b27d9cab7a31c41d0198be602a88c41a95efb9e7b5be99a96ee2fc6cb
+  md5: 959445d700f0266e95d1bdf5809d34bf
+  depends:
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab >=4.0.2,<4.1
+  - jupyterlab_server >=2.22.1,<3
+  - notebook-shim >=0.2,<0.3
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3671288
+  timestamp: 1708030081801
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+  sha256: b0cc542e2a6f42ba716e7e4ccf29eddcb155ad167fcdbc72d2db9c7873eb5639
+  md5: 7acf81b17d2c4ceb3cd39dc9f173855c
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27539
+  timestamp: 1699455954000
+- conda: https://conda.anaconda.org/main/osx-arm64/numba-0.59.1-py311h7aedaa7_0.tar.bz2
+  sha256: 4e0fb594095ce53c58f97eafc1c113e150929a6935e8ee54d86359cc7a9afd14
+  md5: df6c4ead6e4bed95d012bdd5e79f10db
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.42.0,<0.43.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - libopenblas >=0.3.18, !=0.3.20
+  - numba-rvsdg 0.0.*
+  - cudatoolkit >=10.2
+  - tbb >=2021.6,<2022
+  - scipy >=1.0
+  - cuda-python >=11.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6062719
+  timestamp: 1711988782214
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+  sha256: 151a3eb68d1189e69764ece1d8fb3544d31a22f5bbbc3e19d846de8dece304d2
+  md5: eb6609e6bdc9c82d70df3f8c4c2de95b
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153313
+  timestamp: 1696515415712
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+  sha256: d3bb1d4be88320a5861cd3a0f086e9709f9b64c96c032cb9039cc4f17ec66a85
+  md5: 0a7b97665c06fcd34a70e34abc177280
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.26.4 py311hfbfe69c_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11288
+  timestamp: 1708639168951
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+  sha256: 3e70248a7069ca12ccf56252869bfdb72211fd4e4c327e6994756496df786c79
+  md5: ce4846006d98638cd86a532a72f8dfe4
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311he598dae_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7536860
+  timestamp: 1708639153133
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
+  md5: 371358a54bbdd307603888348d1a2c6f
+  depends:
+  - libcxx >=12.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD 2-Clause
+  size: 412248
+  timestamp: 1628861367714
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.13-h1a28f6b_1.tar.bz2
+  sha256: 3a06a4dd64641240ad4d8401105a62597fc0b876a94544bade1c6cace13b5ad7
+  md5: bdb8a787b740513c2aba7494ef62c58b
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4766262
+  timestamp: 1714511251647
+- conda: https://conda.anaconda.org/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
+  sha256: c4135710b5536fb859a6672c055bbc2cff0426e0655e75c7fdf808f7f3344ada
+  md5: 483605a01fccba850b7f0cbdeff29858
+  depends:
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.9,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 421604
+  timestamp: 1676482754496
+- conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+  sha256: 77b0c0a0fb14d817390244ebd93c36d44a7867239963f211f7c0a72a3f98d382
+  md5: b90336feb8a50d2eff880e89acb02f40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39617
+  timestamp: 1699371253760
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+  sha256: 4f6c3e8d8fc4c57975cab837ef109b9ee7af4f18aac72668334ac656e53c6edf
+  md5: fbf1b507f9a80c5de3c957e8152124da
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 159289
+  timestamp: 1710807498427
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
+  sha256: 3af823879c340838c1040e99f653c3438ccce8dc559bd91c3f4ab2579282a002
+  md5: 5b3df01fda0281dab4196bc36d1ca367
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - odfpy>=1.4.1
+  - adbc-driver-postgresql >=0.8.0
+  - scipy >=1.10.0
+  - fastparquet >=2022.12.0
+  - pyxlsb >=1.0.10
+  - pymysql >=1.0.2
+  - sqlalchemy >=2.0.0
+  - pyreadstat >=1.2.0
+  - beautifulsoup4 >=4.11.2
+  - fsspec >=2022.11.0
+  - openpyxl >=3.1.0
+  - xlsxwriter >=3.0.5
+  - jinja2 >=3.1.2
+  - zstandard >=0.19.0
+  - numba >=0.56.4
+  - matplotlib-base >=3.6.3
+  - psycopg2 >=2.9.6
+  - xlrd >=2.0.1
+  - pyarrow >=10.0.1
+  - pytables >=3.8.0
+  - html5lib >=1.1
+  - blosc >=1.21.3
+  - gcsfs >=2022.11.0
+  - dataframe-api-compat >=0.1.7
+  - qtpy >=2.3.0
+  - adbc-driver-sqlite >=0.8.0
+  - lxml >=4.9.2
+  - xarray >=2022.12.0
+  - s3fs >=2022.11.0
+  - pandas-gbq >=0.19.0
+  - pyqt >=5.15.9
+  - tabulate >=0.9.0
+  - python-calamine >=0.1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17082645
+  timestamp: 1709591689205
+- conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+  sha256: 088245becd055af4de74e4ed13cc752ab546423f204b170ba2dd8809af30a2c7
+  md5: 2eabea5ccc56ac088e0349626e59df06
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48517
+  timestamp: 1698702686783
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+  sha256: 174b680f4bb041e8146aae80f92390122459e0ef8c911cab22d01e2e92d44ab1
+  md5: cfffc94779cd26a349bd409b5590b098
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 916496
+  timestamp: 1714399019350
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3.1-py311hca03da5_0.tar.bz2
+  sha256: f6298f1b93b2c4f62e11be8f5cb1c184b9774492626f3c93a004cf5d7e4e84f6
+  md5: 92d6c6c6a869b6d1449ddc614f622c42
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3445195
+  timestamp: 1700667693168
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+  sha256: b6200816d65673aa1707c20a768c9cff87dd8dbe1335f9c1478e5931dfa08ee0
+  md5: 14b1e0fa73eb33f9c83048482dcce57b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38423
+  timestamp: 1692205689597
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+  sha256: ebdf211edd98d88a23778551c7a9702106edd0695d4fc48e87c21f77521c1ffe
+  md5: d8c505081a468f1b99c62466e2309417
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 123084
+  timestamp: 1678996822234
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+  sha256: 07cfba50d9e94364bde077731a824ca4f537138b35ee6b66d07aee16ac9850f1
+  md5: 919bf486280a11e6acb3c2c3a82f7473
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763225
+  timestamp: 1704404463402
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+  sha256: 8094436b2c44e68e72569c704633802aad82e977b1e16026848218679c8becf4
+  md5: 2360e46d3e598dd5e2abed781fe166c5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 502115
+  timestamp: 1678995719872
+- conda: https://conda.anaconda.org/main/osx-arm64/pyarrow-14.0.2-py311ha07b5f9_0.tar.bz2
+  sha256: 4ef0edee30559d99ce74a3207b5e594420549d743b6a6942f4910909f0bf7f15
+  md5: ee7f74b498c265a06b470b7f853612e0
+  depends:
+  - arrow-cpp >=14.0.2,<14.0.3.0a0
+  - boost-cpp
+  - libcxx >=14.0.6
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4965174
+  timestamp: 1707331530109
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+  sha256: 121b5b66721760c05f1d4eee91626229d1814663d3fb5f23126ef870aa496e26
+  md5: 0c588c2ca790a05d422c06e8568201ad
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2124200
+  timestamp: 1684280082141
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+  sha256: 44b694db8e81d61960d28d60f9e9b573f03f7827881d302da334378881db4889
+  md5: 6c94ba7caa599ff533e0ab55d898be8a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 208454
+  timestamp: 1677910948527
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+  sha256: 0bb3d2a57b332c5cf73ea40ea13c850ae24a1f9a3a41ed9267832d9e3c767572
+  md5: 45a7fcf1641980d5114999736428502d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36755
+  timestamp: 1677906514270
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.11.8-hb885b13_0.tar.bz2
+  sha256: 7db8bda1ad368413284ee399322d421feb385863426f8ce3167c0eee6788b8d6
+  md5: b1b70eac1af7d86cc231d9b695ff1d3e
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.5,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16417657
+  timestamp: 1708983786954
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+  sha256: f94b3cfea6f76ea9983e16d3c4c7e0a64f02c40cc2c3ad57189bca2e67030bd9
+  md5: 0d100990ade57a02b60d1e8085db0bdf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 280263
+  timestamp: 1678996927464
+- conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+  sha256: 252c86f5aef7f8dfce99a260c24cbb35a9adfea144a2acfabb224f516341544f
+  md5: 745b888e19a644f48800799f82c01c21
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18539
+  timestamp: 1683823925189
+- conda: https://conda.anaconda.org/main/osx-arm64/python-lmdb-1.4.1-py311h313beb8_0.tar.bz2
+  sha256: 5a40b7ba3aaff79b21020a5ba9df44202d9fa6152abd81f91ed1602cfa864ed7
+  md5: 95226a611d81daf647c0211ef2de31a7
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 148513
+  timestamp: 1682522467465
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+  sha256: d945744eb133f19ca61325cac5128bdb053ae04de4a0ba6f69c061449cac8af7
+  md5: 34baa81490d667381bc7021435b0e1f2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 275858
+  timestamp: 1713974457562
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+  sha256: 4f04a43cbd612ab09cefbdc2e48ee61b51967dad59d859ce0502cc2c46c88fc5
+  md5: c68bf65433b2151b51b2e699bc22c501
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 194632
+  timestamp: 1698096151085
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-25.1.2-py311h313beb8_0.tar.bz2
+  sha256: 66d6bcf8e67799c60b41ed3c14d352cc065abee1afe41fab710eac41ddb27809
+  md5: 488d9d295388699484bd2d1226157163
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 543785
+  timestamp: 1705605339487
+- conda: https://conda.anaconda.org/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+  sha256: 089c6b9bebfa690f380710f219ab0fcc1acec9f2e187d4174a08222c45f58afc
+  md5: 11b832c6c10a6d2b0e687a20c3037c97
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-3-Clause
+  size: 194532
+  timestamp: 1652449531448
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+  sha256: 7a208abc002a2fc208ae25cb2cf932999a3e4980aa4c9edff315cb9ac62b12ce
+  md5: bd22ebd3cff811577ea61f115ba7f4f2
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74744
+  timestamp: 1699012126255
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
+  sha256: cc8d055a068fe5a7484284c3360d81db61656dd6118c743c740fcc47cd3da379
+  md5: e5fad71ef3b99077b79052576e51bf9f
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 120672
+  timestamp: 1707355664440
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+  sha256: 52368d9b557b8f54ef5ca4bf6cd5a3ec665171f2b2d2082cdd410bab88f4829c
+  md5: ac76fb4d2eef3ecdd491cf5d3fb8620d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10204
+  timestamp: 1683077239143
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+  sha256: 491d116c5f54ef340e3bce631835f7138cd1923d7b63e6ca9aa01b48110cb8f9
+  md5: 9b81bd8ea808704f5433884b567f1f15
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10557
+  timestamp: 1683059079547
+- conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+  sha256: b53a5f6119173d62e4e68a37ea8511c7fc87a00af72953e0048d075a799c7a7a
+  md5: 76a16cf4edb9b12b2b96a2d323f060dc
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 342535
+  timestamp: 1698945991201
+- conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
+  sha256: 9e8312f9452357202813aa289430c939302617f562dae9e90fdc3fb5e9be49d0
+  md5: def02b749d0c0a3675d96aeb508a2306
+  depends:
+  - blas * openblas
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 4
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 26383719
+  timestamp: 1714070280353
+- conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+  sha256: c80d52567084b1caaed2862b77b70065ca17afaf0b020733e9d6c273b4a63e78
+  md5: ddf7d88c1967f3f7a4ce1c975fd47e0d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33321
+  timestamp: 1699371225235
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+  sha256: 6d38d171ef87340cf0fbbf4c70217df4826c65400c9290774f5cb35e381e3315
+  md5: b9529a812f9862fc89461b6b90f184ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1599110
+  timestamp: 1715024190898
+- conda: https://conda.anaconda.org/main/osx-arm64/snappy-1.1.10-h313beb8_1.tar.bz2
+  sha256: f340be28c71abb0b785dd78f742e12befb08e37b77087924364e01a7b1d25bda
+  md5: 4f553ef7b00e79fb67318e680da9fdaa
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 42517
+  timestamp: 1702909400491
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+  sha256: cd71091a234874d2826fa063ec5222b3191c9f47e1b5281c352d9df3f31a06bf
+  md5: 0db8e29016c6bff026c083d9923a7566
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19073
+  timestamp: 1705431415504
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+  sha256: 3e18cdafc607c6d7623b1c8f041cbfbb50a27e298f961abdcce7e36834ac39e1
+  md5: 9ee0da74c55d0b8d83edf246fd717f20
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89862
+  timestamp: 1696347657368
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+  sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
+  md5: d8c1e9910392d0bcb22a173f9ce30fa6
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1758290
+  timestamp: 1714488307689
+- conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+  sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
+  md5: ae58720a18a2ed15eae214ad7a10d1b5
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 140125
+  timestamp: 1680167256603
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+  sha256: b5c265e9ed9a1ff2238a09b83bdc1826950faa87fd6b685debe60888de6e7a50
+  md5: 5827c8a32317894ce18576e334daba47
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38559
+  timestamp: 1677918962258
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+  sha256: cfefd86d0f4981d22b7611b3dc60359b8698bf39f2b743cb90b7005aaca88e1e
+  md5: a04dbcd6095f6b8f3ad195a78d48b262
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50058
+  timestamp: 1677917499177
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+  sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
+  md5: 3c25b4f4768ccda28b20a03ba27e7759
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3484151
+  timestamp: 1714770744982
+- conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+  sha256: 0836468fafb1f5badbb573922e37200c6929bf2926ecf8d2259dff43811e0727
+  md5: 5bc56dcb4bdb7cf623b7cea499feaddb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 136409
+  timestamp: 1677925889207
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+  sha256: 177246487449f87567fe56c8f20011a4350a132d1556c9f87474d7b2e8c1374f
+  md5: d465118217b9f27d47dceff89c2e9f95
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 896655
+  timestamp: 1696937042980
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.66.2-py311hb6e6a13_0.tar.bz2
+  sha256: 70496999384061690df49fe640fcc6d0437ce876d3096dc89c6901cb2bb63845
+  md5: 72dbbceca6984601d78c2bbb796edb66
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 155676
+  timestamp: 1714567815500
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+  sha256: 65e760119352cd85c63d365d2576c09a9ddb060e5b029a265d50bc268eed9290
+  md5: 14c241871b12dc3be52e6cd681267caf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 271445
+  timestamp: 1677911758960
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.9.0-py311hca03da5_1.tar.bz2
+  sha256: eb3608b1f32c4a791ca19a69cf611e470ec7bb722e40f27d3e5f6dbc76c69ecc
+  md5: e4ada62e242b4702435995090405d693
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.9.0 py311hca03da5_1
+  license: PSF-2.0
+  license_family: PSF
+  size: 9874
+  timestamp: 1705599390176
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.9.0-py311hca03da5_1.tar.bz2
+  sha256: 0899503a82d0e0a765a7e9d1a0480c3b1c389f4d6e68b633400271380172118e
+  md5: 224636c70a8945f989ebf39b8cfcf52a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 71941
+  timestamp: 1705599383532
+- conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+  sha256: 2ea2d0520b330d381a2ab241bdb9ae146ef815ee7c96ee52a9773fb9ae85f4fd
+  md5: 66f7f8979cfb2cccffac972d70482130
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 12614
+  timestamp: 1677963554857
+- conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+  sha256: df7fe7740bd853b641d624e2ec97f1aacb2b82691936a8c04ef18fa9768539c2
+  md5: d5c7626d45fd03b22797c18e47812beb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 518048
+  timestamp: 1713213046424
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.1.0-py311hca03da5_1.tar.bz2
+  sha256: ec56a4893344adc6712b9915267bb5faca7203496f8ad924cba7ebf2cec302b9
+  md5: 7dd5b6728562eaa24668abd062985f4d
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - zstandard >=0.18.0
+  - requests >=2.26.0
+  - selenium >=4.4.3
+  license: MIT
+  license_family: MIT
+  size: 184702
+  timestamp: 1707770626151
+- conda: https://conda.anaconda.org/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+  sha256: 20ae100fd04de16356f26e7c9dab514015e57a9d54fb78767aa5ed97de7846fb
+  md5: f620d98b3d0072945948310c86f0f1c5
+  license: MIT
+  license_family: MIT
+  size: 157385
+  timestamp: 1706894678643
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+  sha256: 09738b7f9075386bf062b12ddb6fb72a06450d2481f6b5ca2026c811cd849569
+  md5: 9afdec076c95746ac21235f971190e40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26727
+  timestamp: 1677910175964
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py311hca03da5_4.tar.bz2
+  sha256: e7e149717c2a2f69f4e80a97aaeff1e929309abeaacf856020e709a9663df561
+  md5: 2ea9e4e91d48d4e0697990e52d1c2b96
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 91423
+  timestamp: 1677919120338
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+  sha256: aa301d9e42aadbe3dd5f301ccbf17fbadc347fd37d413c0cbcbd24403892a936
+  md5: 77097d17d835a137af7950c628b66150
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 137260
+  timestamp: 1714717037687
+- conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+  sha256: cf030fc7020dc6d28530075468b8dc1edd843a1e393a2f81ca81c962e9af977b
+  md5: cae3fc90233f3af8f433a253d035b6e6
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2470844
+  timestamp: 1689041497962
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+  sha256: 2cd108896df65636769e3804ecc2ca421ad9b54e64fa21922bbabe40c90c247a
+  md5: b3a1e5077b28f71298d891fbfb5ff03e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55645
+  timestamp: 1677927459979
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+  sha256: 5be8c968f2da5c4bf14f28d63e31b4c1b6993d980023769732c7f58f396c2e0b
+  md5: 3f5f62d4e85e3bdd48d39189b01805a6
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 459197
+  timestamp: 1714510992914
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+  sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
+  md5: 3d57d1adadca9388aaaa1c529b65ba65
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 322790
+  timestamp: 1705602163804
+- conda: https://conda.anaconda.org/main/osx-arm64/zict-3.0.0-py311hca03da5_0.tar.bz2
+  sha256: db7fb95af4702cb2ce5281333fa769006f532bc39e8e5bd580a2eb9970a7a38d
+  md5: 2c13d5a0b62ff7a644a6957829dc54a6
+  depends:
+  - heapdict
+  - python >=3.11,<3.12.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 103248
+  timestamp: 1695832909752
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
+  sha256: cf38c69cf62d8f07b91b14bef8e0b6fc5ac220bd3a6cd2ab0378283f0f11494a
+  md5: 11660f745caf5eed1d03eafadb32678b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 25470
+  timestamp: 1704206932876
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+  sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
+  md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
+  license: Zlib
+  license_family: Other
+  size: 104928
+  timestamp: 1714510936868
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+  sha256: a3f3eaf240991b6bd7b0596a78d0abb3321cc79db52fa24f6f559189778871c6
+  md5: 71f035b4716322539e2461cb6667e946
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 825339
+  timestamp: 1714678419523
+- conda: https://conda.anaconda.org/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
+  sha256: c5a4f98a90713f799a73195cc159571c4bd373bfa43640dc0c1707608e582945
+  md5: 537f198da93942d8ef7008606edae551
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2363136
+  timestamp: 1652426285158
+- conda: https://conda.anaconda.org/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+  sha256: 6e6787755de0cf2fd776c9681a7b0fd0fb23e35e679a463cc2005b991c413910
+  md5: ccad42ec9a2ad48939f089c528abc8f0
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 229694
+  timestamp: 1706220431719
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+  sha256: f715f7c2e06149bd6d43258e41479d3171efe5e9d56050a0a5f5652ed9d05fff
+  md5: 11a8ca43d69881b88f95ae681478866d
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 36089
+  timestamp: 1676424516042
+- conda: https://conda.anaconda.org/main/win-64/arrow-cpp-14.0.2-ha81ea56_1.tar.bz2
+  sha256: 5d0903878b06d0a444fa43444390f3b662f6338750e23ee2817c784246ff7098
+  md5: e0fda639825394bcb3a87b639c0d7a11
+  depends:
+  - abseil-cpp >=20211102.0,<20211102.1.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - aws-sdk-cpp >=1.10.55,<1.10.56.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-ares >=1.18.1,<2.0a0
+  - glog >=0.5.0,<0.6.0a0
+  - grpc-cpp >=1.48.2,<1.49.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.13,<4.0a0
+  - orc >=1.7.4,<1.7.5.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.9,<2.0a0
+  - utf8proc >=2.6.1,<2.9.0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 9794512
+  timestamp: 1707254932864
+- conda: https://conda.anaconda.org/main/win-64/async-lru-2.0.4-py311haa95532_0.tar.bz2
+  sha256: 6acc4dc697147467d128382439a1648f2dc6c498d0a97aa9c44ef5de2962cdc6
+  md5: 8baa05a5d81f5f0dd92cdd60fd509486
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 21308
+  timestamp: 1699554782283
+- conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+  sha256: 9adabcdd2a10f73fa5ba56adc901eeea2e379991a0d4cb9737eec7aa6b9fc5d8
+  md5: fc80b572be85601706d425b21a58d497
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153102
+  timestamp: 1695718054194
+- conda: https://conda.anaconda.org/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
+  sha256: a11741c5aaa360b4772d0fb7eea606edb5266a4e2806b22f0b8b65b69b7a7273
+  md5: 9a54285c5e75ab5e6bfcb3b5590f9449
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 93395
+  timestamp: 1706746331576
+- conda: https://conda.anaconda.org/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
+  sha256: 32b4da68dd0edbf0c8d7a8a18ba400b26775faabaccbc2cb3e9d2ab7c65e7714
+  md5: 48f0a7a7f739d8be4c9dd061be217619
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 45714
+  timestamp: 1706691182873
+- conda: https://conda.anaconda.org/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
+  sha256: d2710c7f5b4bb8f94a964996387fbd6396f9881d163affeb7ffb050a39e58c1c
+  md5: 1a8a2f82798a94d1b272ec2d307cc5ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 195487
+  timestamp: 1706190077309
+- conda: https://conda.anaconda.org/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
+  sha256: 0a5ea74ebcf9bdccfad972add8ff83a47992ab28370cebc34fc4594c1c7cf03a
+  md5: 2f90d407ca685c124ddb5fc4d79f4517
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 21804
+  timestamp: 1706690937014
+- conda: https://conda.anaconda.org/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
+  sha256: 334d2d9c4181c9955256485f66bf4e48ae9b1dc03044aa0424bf1fda292b3151
+  md5: 9ab57953af3164d3d94001eeca0e6359
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52661
+  timestamp: 1706697357084
+- conda: https://conda.anaconda.org/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
+  sha256: 59155d1258b4e29c0046e5ab14b1e2cb3ccfca069982fe9dd4cd751b1ed67492
+  md5: 28bd7c351db93c3b8520cc1598eddf66
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-compression >=0.2.16,<0.2.17.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 177605
+  timestamp: 1706744253596
+- conda: https://conda.anaconda.org/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
+  sha256: 3aa9b1c2c508a5dcfb482083cb986498f6df460e652cc7557d3c2d122d559ebe
+  md5: b8bf7ae26d234b6738fc37b7c172b3c5
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145865
+  timestamp: 1706696287610
+- conda: https://conda.anaconda.org/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
+  sha256: 68564155186523ec8b97b892d0a6b62b3e6f75e4e2b80fac5684011e070295d6
+  md5: ba2fa531a69a5a7e4966eba6d7891c8b
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 69542
+  timestamp: 1706746839018
+- conda: https://conda.anaconda.org/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
+  sha256: 9c0f2f18f8b7e10e940d2438d70a2a03893421f25fd50461b8b2979f3a310a15
+  md5: da0f3ce6d8f71a71e6cae01832d853f5
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 72614
+  timestamp: 1706747680710
+- conda: https://conda.anaconda.org/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
+  sha256: bcee1da236f6f5f88322979daddc89e8555648593f6282ad3073a68eb22a68d2
+  md5: bf4c19b0db5049930d8b2fcc3b9172fa
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51027
+  timestamp: 1706690972693
+- conda: https://conda.anaconda.org/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
+  sha256: 32561df1e664cb320f79c26c5af23dd55953924e66824e2d6372a44687147bdc
+  md5: 05f4c6715180a992468035c0a86e734c
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 54300
+  timestamp: 1706192197648
+- conda: https://conda.anaconda.org/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
+  sha256: 94d2fff3facfd248968d39a3fd7d3b1f7270df32a87dd567c33d60da1a5eb064
+  md5: 64fed6e7c73d88bfbfc39e838022f948
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
+  - aws-c-s3 >=0.1.51,<0.1.52.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 199877
+  timestamp: 1706827970924
+- conda: https://conda.anaconda.org/main/win-64/aws-sdk-cpp-1.10.55-hd77b12b_0.tar.bz2
+  sha256: 813f252df10d2782fbb26e2c6348f55d44ef1618467e340224df44bcda4814ff
+  md5: 8efc1448ada827ddba894a07903808dc
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2519847
+  timestamp: 1706890866084
+- conda: https://conda.anaconda.org/main/win-64/babel-2.11.0-py311haa95532_0.tar.bz2
+  sha256: b94e6065a6fec9259eef85dc952c59bf20e854682cbf934f04a0c2f1ac2417f0
+  md5: 50cfce72575fcdf3757c27bc6ba5d0e9
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pytz >=2015.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7218701
+  timestamp: 1676427266094
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+  sha256: 38ccda1553733326d99a75436b4b0f7640bafbbfcdbc33838b0e59cf017de687
+  md5: 3f6812578c5e0b3ba0d2a651cc766c15
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 266405
+  timestamp: 1681493141116
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://conda.anaconda.org/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
+  sha256: fe765d810e1612af7a42f34223077f0adc05dbd386b257be24661913d067fe30
+  md5: 82e988aba03c8afa03fce78f7442806e
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6086137
+  timestamp: 1712084583317
+- conda: https://conda.anaconda.org/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+  sha256: 68ef338b27c035add89c0812ad469dd8c9e94f27130f770345ea20deb049d50b
+  md5: 9ec19b145f655329532b608963cf32f4
+  depends:
+  - libboost 1.82.0 h3399ecb_2
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 11334
+  timestamp: 1696764270626
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+  sha256: 5c12a5d7856d9977447360b3a99a5b99818707fe79781ba1779037f11b3fef53
+  md5: 6a125ae352306a944aabc635a5fe13a3
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 139230
+  timestamp: 1707864402762
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 751071782f597f87ed7f67437ef6cc669213902461b9795dd6eb0f4897eddc83
+  md5: 5ad8fe62aad5e16cfdf2c5a7d1327fe7
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_8
+  - libbrotlidec 1.0.9 h2bbff1b_8
+  - libbrotlienc 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 19418
+  timestamp: 1714483531456
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 9bd62d810867549b9c967c5915f3fa3f66cfbd6ede28b1cc152efd1261285c0a
+  md5: 64cc76de3662b62bc8f0e42befd92c5d
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_8
+  - libbrotlienc 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 32178
+  timestamp: 1714483513837
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+  sha256: 1547fa52134cf06b8d01bdf52114db7db60a89bf35c9c95be5b5a03b13dbd565
+  md5: deb765cb7c4b7edc4d126f864f31747c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 356401
+  timestamp: 1714483740924
+- conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+  sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
+  md5: 11e0af09a31e2d5df51c65a342032b85
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 112994
+  timestamp: 1714511182837
+- conda: https://conda.anaconda.org/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+  sha256: 41a6c5a90b88ec7010bb6dd89390754e476b52c3ab2d519bdab9556da8829479
+  md5: b047426a545e287f45e8abfbfcb0de55
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 118041
+  timestamp: 1693902191485
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+  sha256: 73391a74a5300ad3fb063ea0f0c3491d220128a0611a84036da2e23c1e93dc0e
+  md5: 501ded4f9b5ed895077802defee912cf
+  license: MPL-2.0
+  license_family: Other
+  size: 171644
+  timestamp: 1710764856021
+- conda: https://conda.anaconda.org/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+  sha256: cd6545642e380b13700f2f2a7a1fb54a273365047bd23108dbd03b197f5c0c9c
+  md5: 929edc1c553d2da4d6c6c0745b033cc3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 166377
+  timestamp: 1707229328635
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+  sha256: 5cb6ac90ad234248f3795945f69b0382397714a52712337b2f86339526b822d8
+  md5: b90f3126f6315ea2e8ab242533062557
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 302693
+  timestamp: 1714483562551
+- conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+  sha256: 7153817dd49ec317b519802c7c22c836602e00cbd96d68385e83eaf4c9f5ba6a
+  md5: cd829e5997611a602e29fa2fd5882635
+  depends:
+  - colorama
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204113
+  timestamp: 1698130080270
+- conda: https://conda.anaconda.org/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
+  sha256: 03f00c22b6d92ee55b727b369e8dbdd9a4d590f2655b62b7c45ecd046741858e
+  md5: 116f67c13bb0b3caee6cbde334ff6abb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49934
+  timestamp: 1683040303796
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+  sha256: 4099898f02e1f6119fcda65e747c3cbfef0bf563c8855b79a0245160709d5b45
+  md5: ab9705c34e67fb8c8faec69d63ff4064
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36410
+  timestamp: 1676422341506
+- conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+  sha256: 8fb3e816a5ad1da05125462dbc9e2a7e933b001a871aa65703802c0a894c6277
+  md5: ee4b2fa9fce130496d5c7c86c35a1a05
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17723
+  timestamp: 1709323150229
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+  sha256: eeb49cd151ecdccd40062e8123a3b7a9a8a1eda6567dd33ce909ff8ee1a97c89
+  md5: b7fe1f7ead1ec2ac642d022942282fc8
+  depends:
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 232451
+  timestamp: 1700583772701
+- conda: https://conda.anaconda.org/main/win-64/cramjam-2.7.0-py311h005caf5_0.tar.bz2
+  sha256: 97def042390c467aaaa3f4c33276b0c134c40eb426695332673ed1173f999258
+  md5: 13d97f9f5f7b1f8808e4a694b3305f15
+  depends:
+  - m2w64-gcc-libs
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1384742
+  timestamp: 1702664451643
+- conda: https://conda.anaconda.org/main/win-64/cytoolz-0.12.2-py311h2bbff1b_0.tar.bz2
+  sha256: 037aab9c08cd8f7e78e65b602b3c2b61a7c812b270cbea15bef0e36d0305db6f
+  md5: b4e5dd983a62a7c27d73900400eab7ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - toolz >=0.10.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 369375
+  timestamp: 1701724118486
+- conda: https://conda.anaconda.org/main/win-64/dask-2023.11.0-py311haa95532_0.tar.bz2
+  sha256: 07c590287f10f1dd3cddeb245a8b0ff47e407c9c4847d865c970117c27f927d9
+  md5: 7443c06200da9d46add828acd021e4b8
+  depends:
+  - bokeh >=2.4.2
+  - cytoolz >=0.12.0
+  - dask-core 2023.11.0.*
+  - distributed 2023.11.0.*
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.21,<2.0a0
+  - pandas >=1.3
+  - pyarrow >=7.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6038
+  timestamp: 1701444864356
+- conda: https://conda.anaconda.org/main/win-64/dask-core-2023.11.0-py311haa95532_0.tar.bz2
+  sha256: 132d5f66fb9c6b2093c5c066d3fa6ac1468d1bd3fb3b26816556f3c4c8e4be08
+  md5: aace1519be879e46f0cbc9e62bd5a4ba
+  depends:
+  - click >=8.1
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3086382
+  timestamp: 1701396440772
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+  sha256: 5c73f86e575f2ad683ee4a1c2df11020e270edd89d12f11199483d57b0b51826
+  md5: e96a12895ce374476277b1b196ba24bd
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3719519
+  timestamp: 1690907216785
+- conda: https://conda.anaconda.org/main/win-64/distributed-2023.11.0-py311haa95532_0.tar.bz2
+  sha256: 14dd722d920d5665f456ef7493b31fb6420c622045dbbf59bf0d8ea5063cdc3d
+  md5: 857a10ff7dc92814dfec2c430655bf16
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - dask-core 2023.11.0.*
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.0
+  - packaging >=20.0
+  - psutil >=5.7.2
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.10.0
+  - tornado >=6.0.4
+  - urllib3 >=1.24.3
+  - zict >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1807075
+  timestamp: 1701398374335
+- conda: https://conda.anaconda.org/main/win-64/fastparquet-2023.8.0-py311hd7041d2_0.tar.bz2
+  sha256: 59100f20fb5ad8ab300e7db8d461f3364a38598ae09131c7e135660d88101f93
+  md5: acd0953107d9f2e222225e47485acb16
+  depends:
+  - cramjam >=2.3.0
+  - fsspec
+  - numpy >=1.23.5,<2.0a0
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 531570
+  timestamp: 1696542815866
+- conda: https://conda.anaconda.org/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+  sha256: 27fb03eb57d25711a15e145f47a64320a9955b585efc9fd0a1a51cdd71b9fde3
+  md5: eb3869e98f6f53dfec76e2eff4d6b61e
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 2732423
+  timestamp: 1713552175344
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://conda.anaconda.org/main/win-64/fsspec-2024.3.1-py311haa95532_0.tar.bz2
+  sha256: c906de92968266d481957c5776467523da53b7f4d6daadb63255bd5cefd252c3
+  md5: 2710581e3de1c90426c77e4b73185262
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372660
+  timestamp: 1714461880258
+- conda: https://conda.anaconda.org/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+  sha256: 7cb0df7aa62796b0081e1708003529c02411aca6a540bae97beaec919aa64e74
+  md5: ea81fd813e10055553a8d7597c8be98f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 322778
+  timestamp: 1706888324269
+- conda: https://conda.anaconda.org/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+  sha256: ed1fa1a40c6739b48ff3a2d51c3df20e4983b59684b04d93e1337c5f2e93a954
+  md5: 1797f64343a42395207cd452e6a6a751
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94476
+  timestamp: 1706895442146
+- conda: https://conda.anaconda.org/main/win-64/grpc-cpp-1.48.2-hfe90ff0_1.tar.bz2
+  sha256: 0c6223208742064a2829f8dd658e04b72f5176e357a1320c0b0398b91abfd292
+  md5: 19c77d6709407253582fae939434016c
+  depends:
+  - libprotobuf >=3.20.3,<3.20.4.0a0
+  - openssl 3.*
+  - re2
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 31002375
+  timestamp: 1685747992041
+- conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+  sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
+  md5: 582d2c1135a89da757a038de831e7f39
+  license: Intel proprietary
+  size: 11086648
+  timestamp: 1664812389803
+- conda: https://conda.anaconda.org/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+  sha256: 945f4521793d7d279532d1ccd5157201c5cbf64f846bfe60249d01e1b4edf295
+  md5: 0accae23d095c165ac731f4a1f3ca497
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 37021132
+  timestamp: 1692294548916
+- conda: https://conda.anaconda.org/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+  sha256: 102c803186db6d62eaf41a906f6c563ff0d62b53c1eaede8a381e18c0d005ed9
+  md5: 9d30dec03058758a428cf152e0ae28b5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148193
+  timestamp: 1714399061601
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+  sha256: db30abacf919b3f68ae1e6a94c467fd1e69fbf47ba7a86e6b491d8bfe4776f92
+  md5: 9299876e7ddc3aea3487fd93340ceae7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 50842
+  timestamp: 1704813715071
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+  sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
+  md5: d215cc8ee7ca2cc83cc250cc5d822fe0
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3929136
+  timestamp: 1699647939158
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+  sha256: 864e9598f64105769b4ec02cc404fb507bc59e217324daf1686c00cfd12c0055
+  md5: 6bb1c3be1f85799a3988afc2c3c5a4f0
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229621
+  timestamp: 1705934494547
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+  sha256: e0b44f0c3a4ead0fb8e58033c0be25524ee9ecf7f4cc632f03e9f6fac3484baa
+  md5: 50cbc18d0c7b42a4553b52d0cef2c857
+  depends:
+  - colorama
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1637367
+  timestamp: 1704834149957
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+  sha256: d81566367c79a28d4717157fc74293e846a47af99387ed479eb001a425dd398e
+  md5: 28c76079c96ad7f8b1a5ed32b438c79a
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1147434
+  timestamp: 1679427525584
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
+  sha256: f766a445df8e81447f27c830e162566b221fa1bfc41296a6c5e0789586ca1fbf
+  md5: 55bc50633414fc8616ccbf4140a42d5f
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353715
+  timestamp: 1706733949898
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
+  md5: 81f2c343dc4c65eea39c45383272068f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 407861
+  timestamp: 1677849239400
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+  sha256: 5e6698015a3b048093f5737f0e54bcbae415d0f9682dfdfeae3a8cfb4ea275e2
+  md5: 0093a4214131046c4f68af0739dfbea4
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 201456
+  timestamp: 1699041872445
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+  sha256: 9581be54128954080d7cef448b1728874c2ebbe5064f55adece422cf12eafa5a
+  md5: 3adc105f87d5c7f0b1248bc3423f5b48
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16187
+  timestamp: 1699032556953
+- conda: https://conda.anaconda.org/main/win-64/jupyter-lsp-2.2.0-py311haa95532_0.tar.bz2
+  sha256: 2fd9671118852dc700897fdb980a323287f40880f2ef19864e78039049f84563
+  md5: c3ab03d0742e6ca173838fae93247b04
+  depends:
+  - jupyter_server >=1.1.2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101303
+  timestamp: 1699978449116
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-8.6.0-py311haa95532_0.tar.bz2
+  sha256: 4772d37293b0350a3fbfa9b16d0b279544c753f78371b352013daa1d4769a78d
+  md5: 5cd7415248e27a289f9d6dff9b600a73
+  depends:
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 258542
+  timestamp: 1699456032957
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+  sha256: 851ae576c2b72bf3172cd460feec4f5577dc06476a043e185279071b67549fab
+  md5: fae4d214d00de6604738f39acbbb197e
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119710
+  timestamp: 1698937651636
+- conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+  sha256: d97ad90f9121ecf7f8d3af773b222c0bd244204ee73a3e44185491fa16d83104
+  md5: 73ac0fa3c67e5eb283173d74a2771752
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 60625
+  timestamp: 1699282918176
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+  sha256: 257e1102d2dc3f8b0c1708585c819e86f41abd101084cd0569e8e31652480875
+  md5: 2128c6806bba6953e1a275f37e7a295b
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pywinpty
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 614705
+  timestamp: 1699467242943
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+  sha256: 90420847230e72a648417f5f77cebcf7f17b89f70788652c276acc0c440e135f
+  md5: ef3d8dee197aa37897bf6d39d2dd878f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=2.0.10
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27639
+  timestamp: 1686871052174
+- conda: https://conda.anaconda.org/main/win-64/jupyterlab-4.0.11-py311haa95532_0.tar.bz2
+  sha256: cc3eb5e2c513fab04e2740a093f9c44f0355f746ba4cbfeacc2ecbbd08d7096f
+  md5: 729d6b5a3d58c98e8ec73afcb59e0d0b
+  depends:
+  - async-lru >=1.0.0
+  - ipykernel
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.19.0,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  - traitlets
+  - pywin32
+  constrains:
+  - nodejs >=18.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6714941
+  timestamp: 1706809027799
+- conda: https://conda.anaconda.org/main/win-64/jupyterlab_server-2.25.1-py311haa95532_0.tar.bz2
+  sha256: 066d78020fbe62fa9401979852ddbeff05f8e9faeec861487cb2662b9b5d39f9
+  md5: 2f7340345dee00a18c766c1c1472fca3
+  depends:
+  - babel >=2.10
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18.0
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.11,<3.12.0a0
+  - requests >=2.31
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 106966
+  timestamp: 1699555552806
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+  sha256: 8a2f0909fad0387e57cb0e9ee30db2b20761a9106e794381ffeac387a298fb07
+  md5: 6058b2efc3284e27aacec2e6e6280433
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62334
+  timestamp: 1676432044242
+- conda: https://conda.anaconda.org/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+  sha256: ef6b0347ae565dd648a2bb40bc8b0b30f2e4f8387778fefced1d581b7d5a3e16
+  md5: 8ef1d5919aa55fe56ef34d9a7969dca7
+  depends:
+  - openssl 3.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 861982
+  timestamp: 1684424430941
+- conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+  sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
+  md5: f5f73266281ab12377d5d47bdf07500a
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 905072
+  timestamp: 1617648814933
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://conda.anaconda.org/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+  sha256: 4184dd040fc38cb123a98588a8344aa8d1ba1932df5fcc6c188f6b21f5a0c306
+  md5: da58cfa83f3d6c31ae12d8777cd1b64d
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 29803292
+  timestamp: 1696764164248
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 7c906c94a4d46ea963080a6ba5bd12c1274da66159877a544fbc70291eeed98d
+  md5: 45a3d52534fac8aa54a55ee92211a918
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 80216
+  timestamp: 1714483371043
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: daad7edc6d56abf3e176479e8628162dbf1c56b3d24db30d708aebae694a5214
+  md5: e8ecf229f7fcb4c0b76d8613627948f5
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 45189
+  timestamp: 1714483420152
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 84320217abffa9386186ec8d03b4651bb4b1900d3871adc965a9a9e1d3799907
+  md5: 651312fa22168f71f9aec5f9ee2c2fcf
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 756116
+  timestamp: 1714483464368
+- conda: https://conda.anaconda.org/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+  sha256: bb17beae8860a83d081d57273825b46bf8fe9903f3b4182ab41a7ae2c7274859
+  md5: 94182f4ab8beb4eddfd8167b2e2b0380
+  depends:
+  - libclang13 14.0.6 default_h8e68704_1
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 147804
+  timestamp: 1681225547009
+- conda: https://conda.anaconda.org/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+  sha256: 01b84a38c9069e7b8e6fa2a07707e785df7d40b8f01d76a504e98e5a5cd58539
+  md5: 22c9f7e59174c49f06e3c5c9384401ce
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 25699299
+  timestamp: 1681225463612
+- conda: https://conda.anaconda.org/main/win-64/libcurl-8.5.0-h86230a5_0.tar.bz2
+  sha256: d505283d2d3a94a530b341933d3047662d3481d88826ddf68bd78935c0fb94c3
+  md5: 1e9446c8a7f39247834fe0bd16d3edb0
+  depends:
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 338561
+  timestamp: 1704383910302
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://conda.anaconda.org/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
+  sha256: 6458c7a370c4e3366b3b208c5b2834a7acfb17981e47fe3fb861f225d7cefbc3
+  md5: ecabf4acab5b604856d8c7c4278c2c2c
+  depends:
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 446380
+  timestamp: 1685052520132
+- conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+  sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
+  md5: cf949d76148be1e2a534218d9c57df86
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 155435
+  timestamp: 1714484319443
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://conda.anaconda.org/main/win-64/libpq-12.17-h906ac69_0.tar.bz2
+  sha256: 54b46079c184c286b2f91575d3b5917bc3e6737f06885a50426e3263227c8a00
+  md5: e4d2859474935b4873e48b09ef30a95e
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - openssl >=3.0.12,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  size: 3763163
+  timestamp: 1706215177824
+- conda: https://conda.anaconda.org/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
+  sha256: f7368e611e349b91315ce4ba4dbf9116d996a48f98eed425f4d5c3d5b9fcfa5e
+  md5: 77eb9daff9052f1fbf24d91c5bba1d74
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2543079
+  timestamp: 1675278760037
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://conda.anaconda.org/main/win-64/libssh2-1.10.0-he2ea4bf_3.tar.bz2
+  sha256: 710583b5a497bcf272fd084d935cbaac637971e33d66179de3fc5e6893dac3db
+  md5: 78ea474a8843c52f4b4fc24289593a54
+  depends:
+  - openssl >=3.0.13,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 242393
+  timestamp: 1714511648937
+- conda: https://conda.anaconda.org/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
+  sha256: 238e486a0d62264e7ab35098bdc0390fb9a4649921b18827228c811ae8252c88
+  md5: f1ebe453c5a955a25e4b00f73279fc42
+  depends:
+  - boost-cpp >=1.73
+  - libevent
+  - openssl >=3.0.9,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 894777
+  timestamp: 1687975823684
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+  sha256: 4534c822511a052a72c2b070a05e5d8d6f3550f18ea00a33f9d8a9a92b4382cc
+  md5: 82f24e7660831445a2183216e280a6a4
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41464
+  timestamp: 1676474474981
+- conda: https://conda.anaconda.org/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
+  sha256: b2b50fb4e43e4c4da8db26cf362671e03774384732e1925d82e12dfce45c5ac3
+  md5: 44ff317b1ff9bd2b1fbf39da56965b16
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 20842990
+  timestamp: 1706911120234
+- conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+  sha256: 896b7a39bd4ad3621312130122b4fe84dcb67d7355166255c58ea9bc562eb0ae
+  md5: 640b852a56296f48cf073e61a59c5256
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13751
+  timestamp: 1676428354074
+- conda: https://conda.anaconda.org/main/win-64/lz4-4.3.2-py311h2bbff1b_0.tar.bz2
+  sha256: 5d7d4142cd2c91d151d26b7b22f1e4bd2357bcc5ee6b56516552145b43a6d022
+  md5: 35b521ddf937dab77b7720d3640761d4
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 86304
+  timestamp: 1686058058871
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+  sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
+  md5: 320f40b75d93f3b96931c6d13c23946c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 158902
+  timestamp: 1714512129889
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+  sha256: e0dc6e119b224bb31ef34b6ba270ffadc181d38b698c5318de8df7a5d2c4ccbd
+  md5: 992ccd756f09408f0b74dfb9852a8b7f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 182381
+  timestamp: 1676437963591
+- conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+  sha256: 050b5fd4b28132d8102a7e6b40179894dc7f5e41f7ad9ee19211e67446c5740f
+  md5: 3ae0b2f6baec708554648ddafa81b756
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 154386
+  timestamp: 1684279992864
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+  sha256: 8269c73b7a9c03b95a121e318d0468f35eecc016093620b0560f35238cc5df51
+  md5: 2914bea0ae29315f998e1abac79ccaa8
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30214
+  timestamp: 1704206218108
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-3.8.4-py311haa95532_0.tar.bz2
+  sha256: 3df5732260bbd26c10421edbe7c146326e8b1af96137e4eba70aaa246f7aaa23
+  md5: 24a282628090afa5e3f53795cc3529de
+  depends:
+  - matplotlib-base >=3.8.4,<3.8.5.0a0
+  - pyqt >=5
+  - python >=3.11,<3.12.0a0
+  - tornado >=5
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8759
+  timestamp: 1713337289997
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+  sha256: 68fb7d113dbf185b571343847e3dbefdbe7d0b9b5902f1f390bc2a6e33a3f8ee
+  md5: a72ff718390a1fde0b208a43e6b9b655
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 11366001
+  timestamp: 1713336740870
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+  sha256: 43279276850eb6e621812448cddc1093524cee0b7f8ed58b4600b68a4fb659f2
+  md5: 5968b2b5c1f3cf5c8c8c9aaa4d8d66a2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19886
+  timestamp: 1676425829787
+- conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+  sha256: 3062a8254ca351b54f15bea85cc928a3ba4d879bb98ce97ece39a9f7eca215a5
+  md5: 8f1565663abb34ad7fdd512e76da5532
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 68031
+  timestamp: 1676481862508
+- conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+  sha256: cdff5215c292fe59649ca40ca72f5d26da352760c1d6a56feba14eb13f7bbf61
+  md5: e0f3f32b22135dfeaec277bc87183ca9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23328
+  timestamp: 1676442709081
+- conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+  sha256: 3b173a25605d2aaacc57ec0e425f1d1c51327eb2521c8742a736e2c76069bc8d
+  md5: 169f1c93a443f95a88665f3008623ce1
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104882
+  timestamp: 1676425142412
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+  sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
+  md5: 527155127b9fada5e5c5c69a624674b9
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187498166
+  timestamp: 1699648376430
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+  sha256: cea59ae60da314caecf08edb9bcb03126c6dd35837c8184bceaa194decca3341
+  md5: 30936b7263cf0171f7c86400f12ef184
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49080
+  timestamp: 1682975093455
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+  sha256: 5070ceb0a406b1b8b99e2ec58f5d224cbe16ec78109c46720bd182b509e05c6e
+  md5: 34de1af5c639f2d06c6c8d99488e4226
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 196201
+  timestamp: 1695058367111
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+  sha256: 6b4b27302e458fa527321c59be7c335d61f86da7501c4d141db20a72fad68b55
+  md5: 7db9b12da1290bb2c2fc6ee52a945905
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 256371
+  timestamp: 1695060425702
+- conda: https://conda.anaconda.org/main/win-64/msgpack-python-1.0.3-py311h59b6b97_0.tar.bz2
+  sha256: c09c5ed3f07731091958ea6ed06a1eaeaca1f7e1361d341fb06b344d51074ca2
+  md5: 520c04235cf0980e1ce908e893b4dc71
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 37775
+  timestamp: 1676427521514
+- conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+  sha256: 39f09c1bc57b4800ebda331eddb462928435498705351b0432d51a4293294ad8
+  md5: 5565984a02f41e97cb9a4c9126ced14b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29808
+  timestamp: 1676442800892
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+  sha256: e940f9178ee2fa0a7c12873ae35ebea0074371653e5cfa1be8aa8d9271fd343b
+  md5: 355d0835215911738a28010dfa6aa382
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141785
+  timestamp: 1698934346590
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+  sha256: 47dd00c0179f4eb29c70d0453d340f7f5332af326b3d51c64ca3bf6a14be8e7e
+  md5: f66afe718bdb57667b03ebda4cb2ac7e
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 561655
+  timestamp: 1699023338436
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+  sha256: 4ee863a1ff697274c642b3101f82b279a354e3f033a87505655039f89127bb41
+  md5: bfaf19be6644ad2344e118aa0acccb13
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189809
+  timestamp: 1694617194065
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+  sha256: 90fb3f14c49da1397982eae21cd09e8d60d491d76f94c57590c56723fe6dc172
+  md5: 46a523661fe5c1bce7b4213fd428c3de
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16732
+  timestamp: 1708532795328
+- conda: https://conda.anaconda.org/main/win-64/notebook-7.0.8-py311haa95532_0.tar.bz2
+  sha256: aa72c6e127bc394de0b570413912e0625759ba10248fbf884928c9ec3ed6fa70
+  md5: 1cdaa20793e8f70874ade8136e1dd5c2
+  depends:
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab >=4.0.2,<4.1
+  - jupyterlab_server >=2.22.1,<3
+  - notebook-shim >=0.2,<0.3
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3681116
+  timestamp: 1708030716052
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+  sha256: e040ebcab948325fbe17e4ab15be62e1fafa7bad225457e59764adb60eb40db5
+  md5: 4d40a09df8cb74a9f044eab317436d67
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27282
+  timestamp: 1699456187703
+- conda: https://conda.anaconda.org/main/win-64/numba-0.59.1-py311hf62ec03_0.tar.bz2
+  sha256: a20cb730d87b945125202c7f4e81490c24db708f373d1214e6b04f5d2b4177b3
+  md5: a235c61c1928d09080158ffd42ffbccc
+  depends:
+  - llvmlite >=0.42.0,<0.43.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - cuda-python >=11.6
+  - tbb >=2021.6,<2022
+  - scipy >=1.0
+  - libopenblas !=0.3.6
+  - numba-rvsdg 0.0.*
+  - cudatoolkit >=10.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6100005
+  timestamp: 1712021687877
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+  sha256: d3bd2a6614bb7e7f5ce3348d6674e71cce45cbde236beff32f0f08cd95a64ef0
+  md5: e70f15643164f432d1df68635e7c322b
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 162691
+  timestamp: 1696515822068
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+  sha256: 470fe9a0b3e196fa60d5550d8188f6074a207572fa0d353a4448d580872e7804
+  md5: 6fdb8df0613fb2fb9f1732d335fa25f1
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311hd01c5d8_0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11053
+  timestamp: 1708641901110
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+  sha256: 222c1711e7cf151e29077c7d4d86a865c9fd39615812d58a1daca6fd1b6bdfb5
+  md5: 585bcd8bc3940a8a859f38ebafdcd77d
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.26.4 py311hdab7c0b_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10723862
+  timestamp: 1708641867155
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
+  md5: ab07e2a27ac08afe3d0b4c0890b8486a
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 2-Clause
+  size: 249316
+  timestamp: 1630094024143
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.13-h2bbff1b_1.tar.bz2
+  sha256: f98936bd261c37fb1c2d303885a0bd55cea87e2c86c6e8c6ca56c66b9079e852
+  md5: ed1708ace63b1ef7409474eedf0db1ba
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8087040
+  timestamp: 1714514472258
+- conda: https://conda.anaconda.org/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
+  sha256: 417cf23716f17b6daf2b717bbd69240aa9440845dfa415f59a97961794632ce5
+  md5: 36d709d47c43a3e9b43f23cf4edb6438
+  depends:
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.9,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 877890
+  timestamp: 1676482911485
+- conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+  sha256: b2f5f50a1ddf811102636f3acebd76716c88ebb628754b91eda7a3a962adf26c
+  md5: 712527b4d84c350dca4b67f511c04414
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39421
+  timestamp: 1699371341381
+- conda: https://conda.anaconda.org/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+  sha256: 432b8b7c4671878cbbe361e518544203f97bd2e4f24fa08cf65e8be583f25529
+  md5: e62e7c668b080e0f6ce09fd548f69f7f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 159066
+  timestamp: 1710809127954
+- conda: https://conda.anaconda.org/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
+  sha256: 3ae55d8148580fc3f171c0fcc420488fbba05517cefd358fe013b45ec3594371
+  md5: bfb42ed6826a1c8cded9539fc6e07029
+  depends:
+  - bottleneck >=1.3.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - python-calamine >=0.1.7
+  - xarray >=2022.12.0
+  - lxml >=4.9.2
+  - dataframe-api-compat >=0.1.7
+  - jinja2 >=3.1.2
+  - zstandard >=0.19.0
+  - blosc >=1.21.3
+  - matplotlib-base >=3.6.3
+  - adbc-driver-postgresql >=0.8.0
+  - xlrd >=2.0.1
+  - fastparquet >=2022.12.0
+  - pymysql >=1.0.2
+  - gcsfs >=2022.11.0
+  - pandas-gbq >=0.19.0
+  - xlsxwriter >=3.0.5
+  - pyarrow >=10.0.1
+  - html5lib >=1.1
+  - pyqt >=5.15.9
+  - psycopg2 >=2.9.6
+  - scipy >=1.10.0
+  - numba >=0.56.4
+  - qtpy >=2.3.0
+  - openpyxl >=3.1.0
+  - adbc-driver-sqlite >=0.8.0
+  - tabulate >=0.9.0
+  - pyreadstat >=1.2.0
+  - pytables >=3.8.0
+  - beautifulsoup4 >=4.11.2
+  - pyxlsb >=1.0.10
+  - sqlalchemy >=2.0.0
+  - s3fs >=2022.11.0
+  - fsspec >=2022.11.0
+  - odfpy>=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16924671
+  timestamp: 1709591125871
+- conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+  sha256: b0d7fbfcf1c5c682ed9934eb6a33e00a2517941f2bcb9d677379f4bb73b2c45c
+  md5: 20c8f36595a48f5cda2f4f74c02a3ea2
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48206
+  timestamp: 1698702818841
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+  sha256: 6ca54ba8ce430caa8a1838b19869814d0b7fa3592a77f75298130983e635387b
+  md5: e56c194e56d19dd8fd76f75a77f92c33
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 1070844
+  timestamp: 1714399290671
+- conda: https://conda.anaconda.org/main/win-64/pip-23.3.1-py311haa95532_0.tar.bz2
+  sha256: 5d612af287cad7d0fc1b8e2e01d7f49b5466f2e17338b03a13cd60111f2513aa
+  md5: 1b0f29aa3fc57cc8d5a48ae392aa8567
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3752545
+  timestamp: 1700667933959
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+  sha256: e5f8cbfb5fc25d460a9117bfc5511959c5e86ccb193316033f87bd516e0c8881
+  md5: 9f7e8b5eb651539386bb92c14e5c321b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37730
+  timestamp: 1692205554840
+- conda: https://conda.anaconda.org/main/win-64/ply-3.11-py311haa95532_0.tar.bz2
+  sha256: a100d5bef5d832db705558acee7ecb4ec2471c18d13ab65fb92f7bc3b3a44ae7
+  md5: 0ae839617227e2ef40d65e85607e60d6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-clause
+  license_family: BSD
+  size: 111734
+  timestamp: 1676426983345
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+  sha256: 6c5b53831273674361437fb546e08315fc11ca9275a174bca3887987e86ced5a
+  md5: f8d91daf5173eb03157f484389adcdd4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 122178
+  timestamp: 1679591983138
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+  sha256: 546819d922b03f3a25ca9f98fd069d0588d481fc0603c6d74bd598fb6a93687f
+  md5: 86c18e3e0b67ee099457475ed6caf2e6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 751763
+  timestamp: 1704404627180
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+  sha256: ae06f0dfa2cfae51404afc6d6ad3a474a93015b5ba9a7d3ea24224b8e7547987
+  md5: 3e19794c806cc3e84a3080a97c359b75
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 510466
+  timestamp: 1679005998612
+- conda: https://conda.anaconda.org/main/win-64/pyarrow-14.0.2-py311h847bd2a_0.tar.bz2
+  sha256: a33dd77a94c79ab95caaa02fbdcb399d4041806a52a82411529cf1454f031536
+  md5: 01f56e64de4eed195d72a61301444fa7
+  depends:
+  - arrow-cpp >=14.0.2,<14.0.3.0a0
+  - boost-cpp
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4504341
+  timestamp: 1707332113670
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+  sha256: d95c88d06f4f3f667bd9a39e5f18179e83b3cd4c115c06ce0fff390ff6d3a700
+  md5: c6d00a8a4d89b1be99bfa3aff19d96b4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2134881
+  timestamp: 1684280285492
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+  sha256: 643a9a0eba1e2bd5980d21623d3b35188c24781ec251acc4d15714bd1ccb4c17
+  md5: b3cda0394db05be6f0f6176abacb13f3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207985
+  timestamp: 1678721438358
+- conda: https://conda.anaconda.org/main/win-64/pyqt-5.15.10-py311hd77b12b_0.tar.bz2
+  sha256: d86b6f06ff63712d58bc0f82a6d345ec578c854051934ac73e5bd929782cd6ab
+  md5: d03b87499af4ad84a166b2d49db2bacf
+  depends:
+  - pyqt5-sip 12.13.0 py311h2bbff1b_0
+  - python >=3.11,<3.12.0a0
+  - qt-main 5.15.*
+  - qt-main >=5.15.2,<5.16.0a0
+  - sip >=6.7.12,<6.8.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 5041665
+  timestamp: 1698775563282
+- conda: https://conda.anaconda.org/main/win-64/pyqt5-sip-12.13.0-py311h2bbff1b_0.tar.bz2
+  sha256: 449266141df059e53f3ae09ef2f1f10b94bc6ab51f919dc4533c32da3a0e808f
+  md5: f125f06594be8adff678b9b36861b847
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 84114
+  timestamp: 1698769459963
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+  sha256: 974c22de09078bf07c5db31fe12d8d89d6433508defc8237cbe52e08c69ed56b
+  md5: 9cf10bfd49140a527cf4b1d912097e6d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36072
+  timestamp: 1676426019064
+- conda: https://conda.anaconda.org/main/win-64/python-3.11.8-he1021f5_0.tar.bz2
+  sha256: 1c557d91837e0205cd08180b604da06f28d7679df1ea1026e7954add3eb4d468
+  md5: 3901bef86daffeb6ff2317543b292766
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - openssl >=3.0.13,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.5,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - openssl <3.5.7
+  license: PSF-2.0
+  license_family: PSF
+  size: 19539055
+  timestamp: 1708983524626
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+  sha256: 9acb33db60d9319595f52337cae3b88c2a2338cd66f1f9d8ae86d0a993c2067a
+  md5: f4af8cf94d042b4dde487241bba1c457
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279780
+  timestamp: 1679500609851
+- conda: https://conda.anaconda.org/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+  sha256: 48fe7373b012b51134b6b6ff67f18d2b4aae3a5c7700e4560ce002af7172f064
+  md5: 0379cd17692152c12b662b0e4ea46b88
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18008
+  timestamp: 1683824373128
+- conda: https://conda.anaconda.org/main/win-64/python-lmdb-1.4.1-py311hd77b12b_0.tar.bz2
+  sha256: 40093db499547e192da8c52132ef1016bab65f2dfd2e4049739f2f8b574e3836
+  md5: a6b568626951b8a9070c30e043cb2603
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 150521
+  timestamp: 1682522716553
+- conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+  sha256: 803274d986d0c4e3b5ec1018747ede86ef57137455b3e44a60e834717eafb92b
+  md5: c9f134ddeff6fdf0373a45534ddb7079
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 273009
+  timestamp: 1713974722039
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+  sha256: cd33dfee104dfbba4af38d06a09ccbae6a32e7c543afedab523303319ebb283d
+  md5: 3dfc19af0306d80921e1403f1f551bba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13679916
+  timestamp: 1676423267293
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+  sha256: 102ff1d958209e3648bb49da3503cf752abab822011fdc4e12e88145c9e73772
+  md5: 0553c2c381b6f5c836b23edc8c6db2ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 246689
+  timestamp: 1677708371873
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+  sha256: bee5c4d0f41f06a9c0aac636885e36e8b81116aafde980f9ea48fdb64abb5567
+  md5: 6c05a053240cb90765d6f8c2efdf905e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 182228
+  timestamp: 1698096268270
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-25.1.2-py311hd77b12b_0.tar.bz2
+  sha256: d08d1b2bc1859011d6d8c8e0afff0cad680c598e5ad59bb7beab9317b3bdece4
+  md5: 5e36645629336f3732b14604bb666442
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 552293
+  timestamp: 1705606206058
+- conda: https://conda.anaconda.org/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
+  sha256: 409f9fad42cbae8d915d1703d87db6af9f951b150517daa4e1c0220cc5eb7b0f
+  md5: 2b17abf94b02a6c5ba6b7623dba97ff9
+  depends:
+  - icu >=73.1,<74.0a0
+  - jpeg >=9e,<10a
+  - krb5 >=1.20.1,<1.21.0a0
+  - libclang >=14.0.6,<15.0a0
+  - libclang13 >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=12.15,<13.0a0
+  - openssl >=3.0.10,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  constrains:
+  - qt >=5.15.2,<6
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 69829482
+  timestamp: 1693228189080
+- conda: https://conda.anaconda.org/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+  sha256: 720f3dd1f933d035b1393951ffd1b6437fc5e19b1999e74096044514a46053fb
+  md5: add2dfb15b518144663fc3b897d66da7
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  size: 493391
+  timestamp: 1652432364793
+- conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+  sha256: 47653b45a5f2d97b5bf0dbf0e620908880f9078da427eef69012effe3f19af67
+  md5: 44e709ae67d89bccee2d4d46d358fee3
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74493
+  timestamp: 1699012356534
+- conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
+  sha256: d7bcba5262df162756885a773c3bf2dace27311bbbb1830a0f97aa60ac7c1239
+  md5: daeb99ccfe39f725278203412aac0873
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 120468
+  timestamp: 1707355917958
+- conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+  sha256: d6daaa6b45272819176e4aeb467ae00e3db43386548464a9993688f292709d40
+  md5: 9fe721d7f7420c259df4f07d4503f654
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9683
+  timestamp: 1683077110211
+- conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+  sha256: 6051860575f9448aea5799d74469c928cd7cdeeca1eb53657872262a77b1a7a8
+  md5: 60e193eca497130034facd5fed168249
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10094
+  timestamp: 1683059114376
+- conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+  sha256: ecd310461c1b45ab92ddf15539cea5a6e837860561c974d2d7393f9a7933f116
+  md5: 1762fec2838763e904141167e18b0389
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 215600
+  timestamp: 1698947891859
+- conda: https://conda.anaconda.org/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
+  sha256: 0042fa2dc2ec8c2181f28f5ee4f45087ea58dca7acc6b89c48f3ce6eac8f9bdd
+  md5: 755c9767608b233b94ec3a67c8e0da4b
+  depends:
+  - blas 1.0 mkl
+  - icc_rt >=2022.1.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 5
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 32418527
+  timestamp: 1714081783418
+- conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+  sha256: 6fd52bae6360fbc8135d72e0c1e4fd407769fa4d0f4b59356e7aed3e000eb339
+  md5: 49fd52885250da8aab17ed72e2e18b81
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88901
+  timestamp: 1699371435766
+- conda: https://conda.anaconda.org/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+  sha256: a2ec4690bc07be9e7f3ad8e3003803eb4304a434d3f139633e2817318a9f7b20
+  md5: dd2d225219924fc5c36598c919541271
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1593050
+  timestamp: 1715025622141
+- conda: https://conda.anaconda.org/main/win-64/sip-6.7.12-py311hd77b12b_0.tar.bz2
+  sha256: f9b5386b4bbae4a6dbf2d391d482a4eb66067435234d990e0a3dd1ea8c710dee
+  md5: 46b9998433d3d70eb124f7d6480698b3
+  depends:
+  - packaging
+  - ply
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-SIP_License OR GPL-2.0-or-later OR GPL-3.0-or-later
+  license_family: GPL
+  size: 682181
+  timestamp: 1698676093853
+- conda: https://conda.anaconda.org/main/win-64/snappy-1.1.10-h6c2663c_1.tar.bz2
+  sha256: 7555e0d33dc29191da0f311d9e6112ddf0c200bbafe5cde89015d524dce84a72
+  md5: 54bc73a36ca51e06733d9d42f23e2ea4
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 100857
+  timestamp: 1702909533553
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+  sha256: 5d1b7e14dc04816692de0f8518ea8fcbefb26ab61cec83f96f2c44c1bee67fab
+  md5: 505d2a70a875b5082dc857aa4dfab0d4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 18830
+  timestamp: 1705431395254
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+  sha256: 5ff3b4ac3fbce4dd67a87856c04698d0397deb0ac288ff4e7eb02fbab57f1253
+  md5: 0ca650a7001c6650809d3361de8cb005
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89590
+  timestamp: 1696347858925
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+  sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
+  md5: 833b93a2daade3407898f15588945d83
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1440481
+  timestamp: 1714488344682
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+  sha256: 78d89b50a29fbeb19a562f5dad95615e3f192bb4f3b86cd6ea75f2f825418232
+  md5: 4a4040df560ea47704e0898c4c015808
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38069
+  timestamp: 1678228553220
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+  sha256: 70a3cc4a4e81a6421bc19cd410d1d6064aadb2b1cce38b020f85e5346716d8e7
+  md5: 32a9a2539579a3d522dce3b5cb4f987b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49495
+  timestamp: 1676425411739
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+  sha256: 0a95736cfd0bb25fc201cd6be4a2450ea8fc30eeb349d861812675b84c94fa74
+  md5: a8a9fb30c6dd8e7a16d5dcd2333c3c49
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3844176
+  timestamp: 1714770894235
+- conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+  sha256: ed5950ac0c12cc87f991a6f28112cf29057e2b7ad416ae4429a0b97c3efaf58c
+  md5: b5e2a04879e6fd19f0eb5effded4dc61
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135939
+  timestamp: 1676431438808
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+  sha256: 4febf30c11674711b86c8c10da46a5e1613071388da999210912a31508864add
+  md5: 1c109fc1112ea1f5f377bdf0d18ba75f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 895633
+  timestamp: 1696937216859
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.66.2-py311h746a85d_0.tar.bz2
+  sha256: fa6681ec34a560da1d44d80bb32da96165fc6063a6e000169e75bc1e5ca74194
+  md5: c5110aa6fe3bec83fe71215182b7f636
+  depends:
+  - colorama
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 186730
+  timestamp: 1714567830865
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+  sha256: e8c77efe880546252f244f995cbed5967809555127b4f818b97455d434b23415
+  md5: 7397ac07045115960ebd8dec95326a7a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270819
+  timestamp: 1676423321499
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.9.0-py311haa95532_1.tar.bz2
+  sha256: ae7b4d80613eee90d2a9d86a099327c81606cde33700e476402407f1a206362c
+  md5: d7326551a9f54853015af81861222d5f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.9.0 py311haa95532_1
+  license: PSF-2.0
+  license_family: PSF
+  size: 9651
+  timestamp: 1705599444849
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.9.0-py311haa95532_1.tar.bz2
+  sha256: 1900ee02288c0abdaa44f34bccafc34691a59069330b0fc0c0922b4b4621b786
+  md5: 0b94ee0b1e2488c3840a348d7d97aca2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 71708
+  timestamp: 1705599429360
+- conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+  sha256: d091897f05318c22ca31028370f25355065999078f7db6f88ab27bf4cb030ec8
+  md5: 1776502c1cfb351554eeda6cddaf255f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11588
+  timestamp: 1676457729096
+- conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+  sha256: c16498f8238cc331618720d078b87995eceb6bbf20268a7a4e8efbf7b5859a9a
+  md5: 770432c0ca1ab9d99ffe95e51d3a3e74
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 517433
+  timestamp: 1713213261710
+- conda: https://conda.anaconda.org/main/win-64/urllib3-2.1.0-py311haa95532_1.tar.bz2
+  sha256: 75e984e5015c5fee121159768fc92653d58303e983450308f8efee40382cc6f7
+  md5: bcaf27d1ba712299ee395d7cb0d4852b
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - requests >=2.26.0
+  - zstandard >=0.18.0
+  - selenium >=4.4.3
+  license: MIT
+  license_family: MIT
+  size: 184432
+  timestamp: 1707770951801
+- conda: https://conda.anaconda.org/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+  sha256: 2ef16d0252e04063d44d0683831d55b485f713fe5af2c2efd61753fb4f27d7e4
+  md5: 256ab1d5dce70111a1f4807a5a9fc322
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 100982
+  timestamp: 1706894771410
+- conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+  sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
+  md5: 45ef24c486a484f079faf1dc90e4c7e9
+  depends:
+  - vs2015_runtime >=14.27.29016
+  license: Modified BSD License (3-clause)
+  license_family: BSD
+  size: 8277
+  timestamp: 1605602889180
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+  sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
+  md5: 4daaceb6cfc1af6274509081d8018ef1
+  size: 2316783
+  timestamp: 1605602872095
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+  sha256: 24ea3d3e0cb98d0d246338dbb4562b67967bb32002e3704e495a5c863476e831
+  md5: c7b9cdbe87b3c9720aeca1164a0fd6df
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26181
+  timestamp: 1676424437003
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py311haa95532_4.tar.bz2
+  sha256: 4008652f05783c7c1ac31fb5b8cf36899c3380b24e82996c6fd44f7b6aca1278
+  md5: dd85600927df8322040c4998a114b567
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94482
+  timestamp: 1676426093953
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+  sha256: 1b086d1b079fdb2f148c7dd82658f2b7f283c88f286e1216c0f1237319039b0f
+  md5: 299e87f151a549d86a48bf24df15c607
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 168041
+  timestamp: 1714717238470
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+  sha256: 17fadf35aa8917c107e7b369e9364ac7c09537776e7943d37e225e14b7026c94
+  md5: 0e67c3b9624540581b894b11267a837b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PUBLIC-DOMAIN
+  size: 10197
+  timestamp: 1676425485716
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+  sha256: 25373efabba9a866849fe38a47c79e0fa323851b4bd4b5df357cc8d5617c2786
+  md5: a958e9d32c3b65c21e11e5d9e8491c43
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2467966
+  timestamp: 1689041676824
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+  sha256: b849b368e27920838fe40a512b102879693a55cb187dd1c8d3a83fa8c05a8054
+  md5: 7b1f6e9c71906a93039b3446b99a5498
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55114
+  timestamp: 1676434863173
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+  sha256: 344a5276a9928638dcde054dfe4e87c8cb40bd2d4d356378b9ab2f863ca62e4b
+  md5: fe471fd8b5a3d77be6fa5dbf9b99dafb
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 1432281
+  timestamp: 1714515119689
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+  sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
+  md5: e5aed81295b61b6d1eb62830799a0297
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 9125184
+  timestamp: 1705602328351
+- conda: https://conda.anaconda.org/main/win-64/zict-3.0.0-py311haa95532_0.tar.bz2
+  sha256: 478892109d9dc82c90f82d269d3796f4f812f6cba5d3d1f9178a20bd7f583a1f
+  md5: df02873bda6c5de6331b00fb1591abac
+  depends:
+  - heapdict
+  - python >=3.11,<3.12.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102456
+  timestamp: 1695833422458
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
+  sha256: d932439798665be388bbf68f3d68da5b42ed4753a43587d3f49848a85f58add4
+  md5: e2900345674e644e05540ffac6acca89
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 25247
+  timestamp: 1704207149955
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+  sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
+  md5: f295b54ab59f5b8658e2a322ac6aa721
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 162161
+  timestamp: 1714514792081
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+  sha256: b2ff66b7f6efa0831f939e57e562c244332b690af08818a540d1a97fa07d8525
+  md5: e548d528873d9a0006a36714cf36462a
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1933522
+  timestamp: 1714679197977
+- conda: https://conda.anaconda.org/msys2/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+  md5: de1b7f7c8221028f6bbe103df4c53bed
+  depends:
+  - m2w64-gcc-libs-core
+  - msys2-conda-epoch >=20160418
+  license: GPL, LGPL, FDL, custom
+  size: 348607
+- conda: https://conda.anaconda.org/msys2/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+  md5: 0b9caac6747002340b057a222af705b2
+  depends:
+  - m2w64-gcc-libgfortran
+  - m2w64-gcc-libs-core
+  - m2w64-gmp
+  - m2w64-libwinpthread-git
+  - msys2-conda-epoch >=20160418
+  license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  size: 530578
+- conda: https://conda.anaconda.org/msys2/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+  md5: 276d396bfe8d958f71173b7134f739fa
+  depends:
+  - m2w64-gmp
+  - m2w64-libwinpthread-git
+  - msys2-conda-epoch >=20160418
+  license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  size: 217686
+- conda: https://conda.anaconda.org/msys2/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+  md5: fec04371463ec68eb8f5752a22c5b030
+  depends:
+  - msys2-conda-epoch >=20160418
+  license: LGPL3
+  size: 705647
+- conda: https://conda.anaconda.org/msys2/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+  md5: 67e61e700eb27424979778fae9293f13
+  depends:
+  - msys2-conda-epoch >=20160418
+  license: MIT, BSD
+  size: 30543
+- conda: https://conda.anaconda.org/msys2/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+  md5: 6eaef3074f65f715ed1ca6b8a08be3aa
+  size: 2065
 - conda: https://conda.anaconda.org/pyviz/label/dev/noarch/colorcet-3.1.0-py_0.tar.bz2
   sha256: cef06177b3a1a073bcc8479279d92b10b9ad0f6923755e991ac1bd1575a3da07
   md5: 7f76292193a74a43e610df6bbcd08402
@@ -1097,9672 +10760,3 @@ packages:
   license_family: BSD
   size: 54164
   timestamp: 1699295791746
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
-  md5: 013d3f22cd3b87f71224bd936765bcad
-  size: 3121
-  timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
-  sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
-  md5: 613805add1c05b538ff06d217252feb7
-  depends:
-  - _libgcc_mutex 0.1 main
-  - libgomp >=7.5.0
-  constrains:
-  - openmp_impl 9999
-  license: BSD-3-Clause
-  size: 20810
-  timestamp: 1652859733309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
-  sha256: 8762f481244fb151a200f01dd70e69c77171a3ee0f7f4c130e8e95b6a1626a68
-  md5: c3707fcd2efa582afc5c7e1986c6ce48
-  depends:
-  - libgcc-ng >=8.4.0
-  - libstdcxx-ng >=8.4.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 1135866
-  timestamp: 1652382888447
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
-  sha256: 250f50edf43a786a32942e9ae67ce807e9b3ac4cb6b58b1170cb541fb24e391f
-  md5: b48058294499d292ddf9a3b966dc9cc5
-  depends:
-  - idna >=2.8
-  - python >=3.11,<3.12.0a0
-  - sniffio >=1.1
-  constrains:
-  - uvloop >=0.17
-  - trio >=0.23
-  license: MIT
-  license_family: MIT
-  size: 228473
-  timestamp: 1706220559474
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
-  sha256: 0d4f5274503916e1c683dcc16e8a7c4186557afa3f62399cd628e4eb535fe77a
-  md5: 062acdb0f9ae976c25c2d15d589dc1d6
-  depends:
-  - cffi >=1.0.1
-  - libgcc-ng >=11.2.0
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 35809
-  timestamp: 1676823571351
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-14.0.2-h374c478_1.tar.bz2
-  sha256: df890b7a4a677687ad7964182735e2eaf433d6066e346d9878ba90788e3d468f
-  md5: 96e5995c1fe9e067faed3e61c416f54f
-  depends:
-  - abseil-cpp >=20211102.0,<20211102.1.0a0
-  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
-  - aws-sdk-cpp >=1.10.55,<1.10.56.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - gflags
-  - glog >=0.5.0,<0.6.0a0
-  - grpc-cpp >=1.48.2,<1.49.0a0
-  - libbrotlicommon >=1.0.9,<1.1.0a0
-  - libbrotlidec >=1.0.9,<1.1.0a0
-  - libbrotlienc >=1.0.9,<1.1.0a0
-  - libgcc-ng >=11.2.0
-  - libprotobuf >=3.20.3,<3.21.0a0
-  - libstdcxx-ng >=11.2.0
-  - libthrift >=0.15.0,<0.16.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - openssl >=3.0.13,<4.0a0
-  - orc >=1.7.4,<1.7.5.0a0
-  - re2 >=2022.4.1,<2022.4.2.0a0
-  - snappy >=1.1.9,<2.0a0
-  - utf8proc >=2.6.1,<2.9.0
-  - zlib >=1.2.13,<2.0.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 13402790
-  timestamp: 1707254138477
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/async-lru-2.0.4-py311h06a4308_0.tar.bz2
-  sha256: f798d8239a172da4d1b2e5e6e43ee466f303f08d62f920f35cfdd4cbd5d4b171
-  md5: 9721c4818b5eea1649443059b488209b
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 20540
-  timestamp: 1699554588481
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
-  sha256: 567dfdd5b986012421a736a5f1c1d5874d8d691dd483c838b55e1ab06c0b217d
-  md5: 4e0aa1543f546b898523382ee8405e84
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 152577
-  timestamp: 1695717917074
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
-  sha256: 432e4fb45ae24789afdaeca800862aad03f8ebed5af908f01eed2a09283915e5
-  md5: a88c0e111e1f47ee83f1b6f329a149ef
-  depends:
-  - aws-c-cal >=0.5.20,<0.5.21.0a0
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-http >=0.6.25,<0.6.26.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
-  - libgcc-ng >=11.2.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 97643
-  timestamp: 1706746168671
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
-  sha256: edb54d1554aefb65ff5a3969085dd8695e1e3218a2987ac30a96901f0bbf887a
-  md5: 5f131e63f8d80f2b7ac505054204a9e3
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - libgcc-ng >=11.2.0
-  - openssl >=3.0.12,<4.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 44722
-  timestamp: 1706690912333
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
-  sha256: 2afbfb546992e5954748d039ea15405f99018f6de78ec2f32bc7ff9bfc428a9c
-  md5: 489017af35cf8bdb976e6fef020a4ac7
-  depends:
-  - libgcc-ng >=11.2.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 202658
-  timestamp: 1706189913451
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
-  sha256: 5f81f5a3ea27bd29bf32a6987290de8c7b2da6612676aa8e606a7003519cbf47
-  md5: c11e7ceff3ca45bf580d1c944d93bd1f
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - libgcc-ng >=11.2.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 17839
-  timestamp: 1706690843204
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
-  sha256: 348ced323311d36344a0fa9e88d299b361bad1f628dfbdd34bcea8662b3ab44b
-  md5: 19a11cdc9727c5981d96983a29b93ce4
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  - aws-checksums >=0.1.13,<0.1.14.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 52025
-  timestamp: 1706697274091
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
-  sha256: 14e2843a218cb01bfc499a22537eb345f6e222b8496cfda2050c73ad98f09cda
-  md5: 44cba75d1bb5122aeadcaf8bb7da5e2a
-  depends:
-  - aws-c-cal >=0.5.20,<0.5.21.0a0
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-compression >=0.2.16,<0.2.17.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  - libgcc-ng >=11.2.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 192985
-  timestamp: 1706744140260
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
-  sha256: a0f6916d60c0e1bac6ba548bf05a491b8db048a94e13da2f1cfa51b4ca879fb8
-  md5: 1f010db4f5ef1b3d705ee04dd1d473c9
-  depends:
-  - aws-c-cal >=0.5.20,<0.5.21.0a0
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - libgcc-ng >=11.2.0
-  - s2n >=1.3.27,<1.3.28.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 143623
-  timestamp: 1706696185335
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
-  sha256: 596945a39d772056e57bb357202a17e02508f2594da9c00e00ad767b8213e998
-  md5: 98cccbcc56a28ec7339e393816f4bdf7
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-http >=0.6.25,<0.6.26.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  - libgcc-ng >=11.2.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 70139
-  timestamp: 1706746744249
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
-  sha256: 12bf86ab848e3311f4eed4e93734a84064dc84580ad6dd4bb823b4ab6ef09698
-  md5: 4a8c2dcf0ede655609a9fc5632a5227b
-  depends:
-  - aws-c-auth >=0.6.19,<0.6.20.0a0
-  - aws-c-cal >=0.5.20,<0.5.21.0a0
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-http >=0.6.25,<0.6.26.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  - aws-checksums >=0.1.13,<0.1.14.0a0
-  - libgcc-ng >=11.2.0
-  - openssl >=3.0.12,<4.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 74700
-  timestamp: 1706747582638
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
-  sha256: f05ce64fee77518a6deb45f187fcee415328e90ea8f2bf6031bd5b8273a1028f
-  md5: b8ebb4b892d9b80d513b4ca62a8d6de2
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - libgcc-ng >=11.2.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 53042
-  timestamp: 1706690818718
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
-  sha256: 52bb367fc367ee3923353927226299a2b8b1be6a1993c11e19b20cafe6c6db0f
-  md5: 4715508fd5f8b39e902cb2afebc13c93
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - libgcc-ng >=11.2.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 52138
-  timestamp: 1706192048702
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
-  sha256: 0d13fbdace8ab4fbfcc015cf83bead69560a3dfadc6e0ce8441001629d725834
-  md5: a02c72bff71848705e70cd6f075a28f3
-  depends:
-  - aws-c-auth >=0.6.19,<0.6.20.0a0
-  - aws-c-cal >=0.5.20,<0.5.21.0a0
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
-  - aws-c-http >=0.6.25,<0.6.26.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
-  - aws-c-s3 >=0.1.51,<0.1.52.0a0
-  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 211559
-  timestamp: 1706827608038
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.10.55-h721c034_0.tar.bz2
-  sha256: a489d946a0a70a4d31f5da9fdf38e2c0ba8122e1df4fc716961b5b02d7617dbe
-  md5: f29f551a4e61c4d8339710ba000c6da8
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
-  - aws-checksums >=0.1.13,<0.1.14.0a0
-  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
-  - libcurl >=7.88.1,<9.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - openssl >=3.0.12,<4.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 2815192
-  timestamp: 1706890558504
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/babel-2.11.0-py311h06a4308_0.tar.bz2
-  sha256: 8da2bfb50812660c69643386afa2a2d0ce9f2b0168e9b7a372349901d7d4b2f7
-  md5: d0cde1ca577520a608da5ab86421f9aa
-  depends:
-  - python >=3.11,<3.12.0a0
-  - pytz >=2015.7
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 7241236
-  timestamp: 1676825038806
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
-  sha256: 894fceb5b4f8740bcd146de8bd0f6eabf14e2407b149b790b4983b8432681e6b
-  md5: 2f0ef211bf628cd22bbfa44c3f9bc035
-  depends:
-  - python >=3.11,<3.12.0a0
-  - soupsieve >1.2
-  license: MIT
-  license_family: MIT
-  size: 271600
-  timestamp: 1681493103694
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
-  md5: 751c2c5b239a728db05f91374aaac3a1
-  size: 5838
-  timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
-  sha256: 9f027f156744dcbf28945aad6e422ef030c84c2a5d40116d3e40407c66853bf8
-  md5: 7b52489e04f9a5585643d5578835fc68
-  depends:
-  - contourpy >=1.2
-  - jinja2 >=2.9
-  - numpy >=1.23.5,<2.0a0
-  - packaging >=16.8
-  - pandas >=1.2
-  - pillow >=7.1.0
-  - python >=3.11,<3.12.0a0
-  - pyyaml >=3.10
-  - tornado >=6.2
-  - xyzservices >=2021.09.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6059952
-  timestamp: 1712084450899
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
-  sha256: 3606c8607c29229222667f66421f79df167d33043fe9245cdd4e2c4520ecc721
-  md5: eca33dcef14fa044193e43492dca8585
-  depends:
-  - libboost 1.82.0 h109eef0_2
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: BSL-1.0
-  license_family: OTHER
-  size: 10768
-  timestamp: 1696762269985
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
-  sha256: 8e2b2073ff5c61d35714e8a36ce657a8ac741b7bedc2852a238c7f1625142705
-  md5: d951ab54a682b6328327fec53b1e5e72
-  depends:
-  - libgcc-ng >=11.2.0
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 147642
-  timestamp: 1707864274452
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
-  sha256: 5d15605858771290fdaaae41a43941623757a25cb1292080d69d6d3857807935
-  md5: 7f517469aa5380c52e55db9f37df104f
-  depends:
-  - brotli-bin 1.0.9 h5eee18b_8
-  - libbrotlidec 1.0.9 h5eee18b_8
-  - libbrotlienc 1.0.9 h5eee18b_8
-  - libgcc-ng >=11.2.0
-  license: MIT
-  size: 18652
-  timestamp: 1714483267080
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
-  sha256: a5094f078584e27c7cced4a9564ae904a329f5c1702a7c1ba092d581ba1544f1
-  md5: 6ddf45dd8a21a9512481de9bc0e5a03f
-  depends:
-  - libbrotlidec 1.0.9 h5eee18b_8
-  - libbrotlienc 1.0.9 h5eee18b_8
-  - libgcc-ng >=11.2.0
-  license: MIT
-  size: 19711
-  timestamp: 1714483255915
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
-  sha256: 93180c973816246f068b742d0bf64840f0ea48e31d4f9b0747ea2ffc34d8855d
-  md5: f3a00096965a5ba1eb41d2c99a4662a2
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  size: 361574
-  timestamp: 1714483400014
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
-  sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
-  md5: f5058c8d5b2994b7334f18e022105a14
-  depends:
-  - libgcc-ng >=11.2.0
-  license: bzip2-1.0.8
-  license_family: BSD
-  size: 427542
-  timestamp: 1714510571510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
-  sha256: 5b4c80587ae4ec915505469f79d866f27c80456156667c8548d31c67c2c1653e
-  md5: c3d6bfae757760082261779c406a880d
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 116270
-  timestamp: 1693902021950
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
-  sha256: 394f74202c2efc8fcfd02b8953f508eb6a2961d224a2f9d15091caf5cbe1be67
-  md5: 1202b4ed32215c6405bb42fbff355316
-  license: MPL-2.0
-  license_family: Other
-  size: 137411
-  timestamp: 1710764808838
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
-  sha256: 6dc29d20180f6e002f37b251efa639716d3444e129a754dabf751f816aada7ef
-  md5: 5dbfa083e6ab6318fac58fe0e0c94445
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MPL-2.0
-  license_family: Other
-  size: 165152
-  timestamp: 1707229213375
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
-  sha256: d138cc3fde270eba783baf1e2ba17c89800b2cbbf20976d0eb425b3436a4a184
-  md5: 1875e89c1a939e4e7c5e7b731c72b838
-  depends:
-  - libffi >=3.4,<3.5
-  - libgcc-ng >=11.2.0
-  - pycparser
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 302401
-  timestamp: 1714483186060
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
-  sha256: 9ddbf05887c7d7926418520cc7848e57f6d2431bc4ec6d30e090b02dbf865041
-  md5: 57ae1141ad9a048fb2a75d7a3ef7430a
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 203190
-  timestamp: 1698129926216
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py311h06a4308_0.tar.bz2
-  sha256: a5beda842876d0d71598cd2a50ced5fb2731539bc4172fe501b93b60e0c6cd3f
-  md5: d5293e5fe74a4e0d71bbf14c9a57f900
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 49509
-  timestamp: 1683040113536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
-  sha256: 882481e441b9b93cbdfb32fbe32a6ad9f26197472f186a08fddb921f61346c02
-  md5: 443c79196064f57c98199e9990544b2f
-  depends:
-  - python >=3.11,<3.12.0a0
-  - traitlets >=4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 16902
-  timestamp: 1709322958614
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
-  sha256: e4877b41553e31b9f9f090dffab77a654255c63776e8b30fc91ec1f60afadbf1
-  md5: c34d3f1520f1e8c9957eb236710058c4
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - numpy >=1.20,<2
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 281162
-  timestamp: 1700583651472
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cramjam-2.7.0-py311h24d97f6_0.tar.bz2
-  sha256: 7bb1fd85aaba31403b00722d6f142220031788e391fdaad899c816595cb3ae5d
-  md5: 6673633f2374304790bfdcaa334b14ae
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 1528662
-  timestamp: 1702651329660
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cyrus-sasl-2.1.28-h52b45da_1.tar.bz2
-  sha256: 4e7eb5911636f3cac2bb22c85d56a8edf946cfd6379e8b7be6136ffdaf669c22
-  md5: dcabb2d653147fd807cf6edeb2c3522b
-  depends:
-  - krb5 >=1.20.1,<1.21.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - openssl >=3.0.9,<4.0a0
-  license: BSD-3-Clause-Attribution
-  license_family: BSD
-  size: 239169
-  timestamp: 1688045783866
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.2-py311h5eee18b_0.tar.bz2
-  sha256: 01fa6e276a4e41ef2396c40c0993a54c2fa3f511b33424191e5af11936edba12
-  md5: d83fe12f3bf13f5171a19af502e6f4cf
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.11,<3.12.0a0
-  - toolz >=0.10.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 444424
-  timestamp: 1701723706605
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-2023.11.0-py311h06a4308_0.tar.bz2
-  sha256: 17c0e8335eabae32d97a47dd6672a64786230bba566f01e9c235f198015478c0
-  md5: b2c2509bb07912005d603cdd2525f2c1
-  depends:
-  - bokeh >=2.4.2
-  - cytoolz >=0.12.0
-  - dask-core 2023.11.0.*
-  - distributed 2023.11.0.*
-  - jinja2 >=2.10.3
-  - lz4 >=4.3.2
-  - numpy >=1.21,<2.0a0
-  - pandas >=1.3
-  - pyarrow >=7.0
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 5148
-  timestamp: 1701444872410
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.11.0-py311h06a4308_0.tar.bz2
-  sha256: edc245960b92d491dc5bb03992ac344e206f094928dde23f814f6436b5781ac1
-  md5: 043e5bb51e65e9a64ce9d3e56b10de63
-  depends:
-  - click >=8.1
-  - cloudpickle >=1.5.0
-  - fsspec >=2021.09.0
-  - importlib-metadata >=4.13.0
-  - packaging >=20.0
-  - partd >=1.2.0
-  - python >=3.11,<3.12.0a0
-  - pyyaml >=5.3.1
-  - toolz >=0.10.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 3024310
-  timestamp: 1701396195636
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
-  sha256: 469debfa966d24b8372aaf909ecbe27dc6fde186f6f0d5b9e0a8427e38053364
-  md5: 498d0788982ec4c5d13a44359b9c7afb
-  depends:
-  - expat >=2.2.10,<3.0a0
-  - glib
-  - libgcc-ng >=7.3.0
-  license: GPL2
-  size: 600218
-  timestamp: 1602701107852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
-  sha256: 3b4cd8dc60572086f1a1cbb97e2712e0ffd55317ce8f0309d552eee7367855eb
-  md5: 70a1263b6e19bf2d77c020a2e77277c9
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 2556575
-  timestamp: 1690905285843
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2023.11.0-py311h06a4308_0.tar.bz2
-  sha256: fea98401096cdbf2dd28b683bf2ce9a8788f59be71dc6b342332dae5910e348e
-  md5: 6f934835dd0653a632a78f3daaea7000
-  depends:
-  - click >=8.0
-  - cloudpickle >=1.5.0
-  - dask-core 2023.11.0.*
-  - jinja2 >=2.10.3
-  - locket >=1.0.0
-  - msgpack-python >=1.0.0
-  - packaging >=20.0
-  - psutil >=5.7.2
-  - python >=3.11,<3.12.0a0
-  - pyyaml >=5.3.1
-  - sortedcontainers >=2.0.5
-  - tblib >=1.6.0
-  - toolz >=0.10.0
-  - tornado >=6.0.4
-  - urllib3 >=1.24.3
-  - zict >=3.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1780776
-  timestamp: 1701398069193
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.6.2-h6a678d5_0.tar.bz2
-  sha256: 37a8f6792dc8e82d2cb8deb956f6e3dc45f947cb8efdab5feddd7395c638a77f
-  md5: bee6ef15f0f0e8c192094e7550b8321b
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 200172
-  timestamp: 1713531025571
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-2023.8.0-py311hf4808d0_0.tar.bz2
-  sha256: e1fa8f866d1bce81ac9a2511e0d42dd9be03d493f2e1f5318a26b5814a5a7cb0
-  md5: 1fb78f0486c2b4c9a31584ceb4d626da
-  depends:
-  - cramjam >=2.3.0
-  - fsspec
-  - libgcc-ng >=11.2.0
-  - numpy >=1.23.5,<2.0a0
-  - packaging
-  - pandas >=1.5.0
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 594660
-  timestamp: 1696541983803
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.14.1-h4c34cd2_2.tar.bz2
-  sha256: 4a623c7f73f4531a16271ded00c80e7dce65aa35b5105015fc4d0ceb37c9fa0d
-  md5: c9dc79248f887050dc89e19670dcbd66
-  depends:
-  - expat >=2.4.9,<3.0a0
-  - freetype >=2.10.4,<3.0a0
-  - libgcc-ng >=11.2.0
-  - libuuid >=1.41.5,<2.0a0
-  - libxml2 >=2.10.3,<2.11.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: MIT
-  license_family: MIT
-  size: 383064
-  timestamp: 1679578197653
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
-  sha256: b75d12e85274660bb675a3e53d47a929872f2daa2ff5a76e98885ee3f2d19ad1
-  md5: f2119d0885334060d0d7fe59e5220287
-  depends:
-  - brotli >=1.0.1
-  - libgcc-ng >=11.2.0
-  - python >=3.11,<3.12.0a0
-  - unicodedata2 >=15.1.0
-  constrains:
-  - fs >=2.2.0,<3
-  - uharfbuzz >=0.23.0
-  - lxml >=4.0
-  - skia-pathops >=0.5.0
-  - zopfli >=0.1.4
-  - lz4 >=1.7.4.2
-  license: MIT
-  license_family: MIT
-  size: 3237908
-  timestamp: 1713551660998
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
-  sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
-  md5: a5dc8677d891dff2393b63189a3ad42f
-  depends:
-  - libgcc-ng >=11.2.0
-  - libpng >=1.6.37,<1.7.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: GPL-2-only and LicenseRef-FreeType
-  license_family: Other
-  size: 971975
-  timestamp: 1666798278693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.3.1-py311h06a4308_0.tar.bz2
-  sha256: a78f34d0b919c5fce722d33afc278cd48f5eec2bf186c35dd18d59d85d45909b
-  md5: 199586a3dcad8985bc4cb0e4262e06d1
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 364478
-  timestamp: 1714461584790
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
-  sha256: 2fc1136056f41fe92de719fb821550346704965dd12a5fa35069cdb4948d5c17
-  md5: fd089b0fba2b03aafe3adb6cdaa9ac3b
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 203421
-  timestamp: 1706888218007
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.78.4-h6a678d5_0.tar.bz2
-  sha256: d9a486f0ac92b1365365c3e536040a552c2de633283f27129f16dadcbc6d2de8
-  md5: 32538e0c24874a85011a094217830bd4
-  depends:
-  - glib-tools 2.78.4 h6a678d5_0
-  - libgcc-ng >=11.2.0
-  - libglib 2.78.4 hdc74915_0
-  - libstdcxx-ng >=11.2.0
-  - python
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 499006
-  timestamp: 1708031707428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-tools-2.78.4-h6a678d5_0.tar.bz2
-  sha256: cc7d3a52acad1df08e3d4ec7eefb22f41320e7eada94e78bf4b051128cbe72d4
-  md5: d8dcbf2be12799cf7f333c21a0e91990
-  depends:
-  - libgcc-ng >=11.2.0
-  - libglib 2.78.4 hdc74915_0
-  - libstdcxx-ng >=11.2.0
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 112595
-  timestamp: 1708031685927
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
-  sha256: f1e190d4ee766add8131a2b011723c472284de2bbb5e07c8f895f30e3c591df7
-  md5: 82029e0758feac811afec2a6ef9e6155
-  depends:
-  - gflags >=2.2.2,<2.3.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 108438
-  timestamp: 1706895276199
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/grpc-cpp-1.48.2-he1ff14a_1.tar.bz2
-  sha256: 32657e2d11dd813e5649f714c7f58115cff3387f27cf0904cee873bd0d82d2a4
-  md5: bdfb8214247977e4ededa4aeb3291ea3
-  depends:
-  - abseil-cpp >=20211102.0,<20211102.1.0a0
-  - c-ares >=1.19.0,<2.0a0
-  - libgcc-ng >=11.2.0
-  - libprotobuf >=3.20.3,<3.20.4.0a0
-  - libprotobuf >=3.20.3,<3.21.0a0
-  - libstdcxx-ng >=11.2.0
-  - openssl 3.*
-  - openssl >=3.0.8,<4.0a0
-  - re2 >=2022.4.1,<2022.4.2.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 5391101
-  timestamp: 1685747457305
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.1-h6a678d5_1.tar.bz2
-  sha256: 833208211f0ecb52198f5fae585f937be3c337c15b4569d8f1a28638545250d5
-  md5: 2fa837925e0633ceae4ec826f6daa93f
-  depends:
-  - glib >=2.69.1,<3.0a0
-  - gstreamer >=1.14.1,<2.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - libxcb >=1.14,<2.0a0
-  - zlib >=1.2.11,<2.0.0a0
-  size: 2253949
-  timestamp: 1677171916164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.1-h5eee18b_1.tar.bz2
-  sha256: 8257a1c1c967d48561f62adb649fe21c467f0a37c41f783ba6e2c6d79fa1cc4f
-  md5: 5cd8e1f16b1ce869d0c3a98b9f0897fb
-  depends:
-  - glib >=2.69.1,<3.0a0
-  - libgcc-ng >=11.2.0
-  size: 1690003
-  timestamp: 1677171850557
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
-  sha256: b35b281dbf69b826c6ae04fcd7b6a2d1f098277a669a199906a1f23b4b0931a5
-  md5: 2a793fe24f85aa5819fe69c450cba6f7
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 29021241
-  timestamp: 1692293243228
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
-  sha256: e08e27531775de40f46b6ac7bf71856963baa0c008bd2b4d112e6341cd3e8f4c
-  md5: bfc7682613c861cbcb4ac01485c05657
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 147174
-  timestamp: 1714398938840
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
-  sha256: c7ffa6006573483a05ef355770c3201f04dd04ab4b91ae01971a6cdc7fbdba35
-  md5: 23d7d38e93d930ea5e2cc5f4079d3816
-  depends:
-  - python >=3.11,<3.12.0a0
-  - zipp >=0.5
-  license: Apache-2.0
-  license_family: APACHE
-  size: 49872
-  timestamp: 1704813633807
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
-  sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
-  md5: 3add2ce56858a1b8f6a37342f82773d3
-  depends:
-  - libffi >=3.4,<3.5
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - zlib >=1.2.13,<1.2.14
-  - zlib >=1.2.13,<2.0.0a0
-  constrains:
-  - __glibc >=2.17
-  license: LicenseRef-ProprietaryIntel
-  license_family: Proprietary
-  size: 19310769
-  timestamp: 1699647799237
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
-  sha256: 0b670ab17ed2e1b592079bd64386dadc249ddc892e5ae1dd99f142a918ffc75d
-  md5: 632575b9e442c1e5c146cf78424da610
-  depends:
-  - comm >=0.1.1
-  - debugpy >=1.6.5
-  - ipython >=7.23.1
-  - jupyter_client >=6.1.12
-  - jupyter_core >=4.12,!=5.0.*
-  - matplotlib-inline >=0.1
-  - nest-asyncio
-  - packaging
-  - psutil
-  - python >=3.11,<3.12.0a0
-  - pyzmq >=24
-  - tornado >=6.1
-  - traitlets >=5.4.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 227791
-  timestamp: 1705934138566
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
-  sha256: 65228eb868c3ec8aa71f958e60a675a919f016c2057392e02fd422fc841858f9
-  md5: 68e23f14cd222c233e6b37262bc61c23
-  depends:
-  - decorator
-  - jedi >=0.16
-  - matplotlib-inline
-  - pexpect >4.3
-  - prompt_toolkit >=3.0.41,<3.1.0
-  - pygments >=2.4.0
-  - python >=3.11,<3.12.0a0
-  - stack_data
-  - traitlets >=5
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1612840
-  timestamp: 1704833066871
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
-  sha256: a2918ea8a3e2c56fc6d91191e84b2f35500c392b16ab687a0c03ded2e2e51239
-  md5: 84fadd6b7fef393cccc0d123dae6cae8
-  depends:
-  - parso >=0.8.0,<0.9.0
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 1162207
-  timestamp: 1679336523618
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
-  sha256: 4520b83e425883981f97191986a08122fbaebc3f16b898368796314136779028
-  md5: 42a8f32c4d842d3e5410b2bc1cc2fb57
-  depends:
-  - markupsafe >=2.0
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 352284
-  timestamp: 1706733655761
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
-  sha256: c21f8f407266d039e819c27fe9eb4fb26587e974f3bd059b37cbaec5073722d0
-  md5: ba1f47411e9e07876c7a3e9d3be6a98e
-  depends:
-  - libgcc-ng >=11.2.0
-  license: IJG
-  license_family: Other
-  size: 281400
-  timestamp: 1677849152168
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
-  sha256: 06b729aee6dd2a1e545f3ad64179cc0d4ef8a15e33db3be2995dd3e0868465ca
-  md5: 8bb3215912588e47e2eeb4e7a09ad64f
-  depends:
-  - attrs >=22.2.0
-  - jsonschema-specifications >=2023.03.6
-  - python >=3.11,<3.12.0a0
-  - referencing >=0.28.4
-  - rpds-py >=0.7.1
-  license: MIT
-  license_family: MIT
-  size: 180858
-  timestamp: 1699041715847
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
-  sha256: 9e3bac2d41bd432b721b009e7de981766fba396e6f238e923f304112bd88655a
-  md5: 84ae4cf3f2d01fbebdac374971192be9
-  depends:
-  - python >=3.11,<3.12.0a0
-  - referencing >=0.28.0
-  license: MIT
-  license_family: MIT
-  size: 15525
-  timestamp: 1699032521315
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter-lsp-2.2.0-py311h06a4308_0.tar.bz2
-  sha256: c4b1dcb8ba34bfb2c7fc6ccf1399dd0bd2a324e792eac722561607f2bff68d72
-  md5: d82f26a5c414b519c7737240fb7f342e
-  depends:
-  - jupyter_server >=1.1.2
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 100413
-  timestamp: 1699978354251
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-8.6.0-py311h06a4308_0.tar.bz2
-  sha256: d215948faad1eff39b5bec3da793d6d185b85793a1d839c3d1c196b85fd6c9b1
-  md5: 555ea509581f49256e7aae2ff5dce460
-  depends:
-  - jupyter_core >=4.12,!=5.0.*
-  - python >=3.11,<3.12.0a0
-  - python-dateutil >=2.8.2
-  - pyzmq >=23.0
-  - tornado >=6.2
-  - traitlets >=5.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 221658
-  timestamp: 1699456577818
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
-  sha256: fedc7e5560252af44b0dfbe6f7acfe20ab17a6a08e758f670a1cd820551afc7a
-  md5: bd28d36963087f53a79b23fee697d665
-  depends:
-  - platformdirs >=2.5
-  - python >=3.11,<3.12.0a0
-  - traitlets >=5.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 93898
-  timestamp: 1698937453304
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
-  sha256: 2b896fe8b2187b7df824041826e14379476eb2e61d607d8cb38ac2b3df40aaa4
-  md5: 8fc7e517da96c2c482331f6b08d07a17
-  depends:
-  - jsonschema >=4.18.0
-  - python >=3.11,<3.12.0a0
-  - python-json-logger >=2.0.4
-  - pyyaml >=5.3
-  - referencing
-  - rfc3339-validator
-  - rfc3986-validator >=0.1.1
-  - traitlets >=5.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 41459
-  timestamp: 1699282616532
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
-  sha256: 87d372f5b23bcc2410e43b40b4ad059ea1625178b8a2b484fc63805ce517e594
-  md5: 50204f372b1672871d6ab3db6a876374
-  depends:
-  - anyio >=3.1.0
-  - argon2-cffi
-  - jinja2
-  - jupyter_client >=7.4.4
-  - jupyter_core >=4.12,!=5.0.*
-  - jupyter_events >=0.6.0
-  - jupyter_server_terminals
-  - nbconvert >=6.4.4
-  - nbformat >=5.3.0
-  - overrides
-  - packaging
-  - prometheus_client
-  - python >=3.11,<3.12.0a0
-  - pyzmq >=24
-  - send2trash >=1.8.2
-  - terminado >=0.8.3
-  - tornado >=6.2.0
-  - traitlets >=5.6.0
-  - websocket-client
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 594177
-  timestamp: 1699467208489
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
-  sha256: ddfee06ba9b149222c65d1d4270272840533aa63b56fe36363c84a891c71d328
-  md5: ee128e5c0d8d9e1952e2387b66a5b8cb
-  depends:
-  - python >=3.11,<3.12.0a0
-  - terminado >=0.8.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 27239
-  timestamp: 1686870958829
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab-4.0.11-py311h06a4308_0.tar.bz2
-  sha256: a2bc9b312a31e5abaedf230659ecb31f9483a1a3c0f4cd1adae7f5ea2045f9d6
-  md5: 728bdb3c057e57cd963f304d2c8a48a9
-  depends:
-  - async-lru >=1.0.0
-  - ipykernel
-  - jinja2 >=3.0.3
-  - jupyter-lsp >=2.0.0
-  - jupyter_core
-  - jupyter_server >=2.4.0,<3
-  - jupyterlab_server >=2.19.0,<3
-  - notebook-shim >=0.2
-  - packaging
-  - python >=3.11,<3.12.0a0
-  - tornado >=6.2.0
-  - traitlets
-  constrains:
-  - nodejs >=18.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6665313
-  timestamp: 1706803269767
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_server-2.25.1-py311h06a4308_0.tar.bz2
-  sha256: b8c434bad4499fc41d0e18986b7ab1fbcf5e2aabadc2658430ee1f5cd16c4cbc
-  md5: 59a08c840ebfa765cfe5d4dc764804c7
-  depends:
-  - babel >=2.10
-  - jinja2 >=3.0.3
-  - json5 >=0.9.0
-  - jsonschema >=4.18.0
-  - jupyter_server >=1.21,<3
-  - packaging >=21.3
-  - python >=3.11,<3.12.0a0
-  - requests >=2.31
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 106168
-  timestamp: 1699555585974
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
-  sha256: b040f0d0ee4588188ab6b83a93738b3ff6e6d1775424be97995bd0df0f4fb904
-  md5: eae62735d710cf5ff6d51e6f59fcd999
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 78148
-  timestamp: 1676827253282
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
-  sha256: 01bae3dd44469e34f043e0416f5f5e658429bf4031745399d9968d10b899e2c4
-  md5: 10171cca67e3d73c3646c6dc5a321460
-  depends:
-  - libedit >=3.1.20221030,<3.2.0a0
-  - libedit >=3.1.20221030,<4.0a0
-  - libgcc-ng >=11.2.0
-  - openssl >=3.0.8,<4.0a0
-  license: MIT
-  license_family: MIT
-  size: 1427115
-  timestamp: 1686931095252
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
-  md5: 653b4f425f6d4a21f04619b1f5f8aa43
-  depends:
-  - jpeg >=9b,<10a
-  - libgcc-ng >=7.3.0
-  - libtiff >=4.1.0,<4.7.0
-  license: MIT
-  license_family: MIT
-  size: 405739
-  timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
-  md5: 9508af80612e4fa1b5d1abb43ca7e63c
-  constrains:
-  - binutils_impl_linux-64 2.38
-  license: GPL-3.0-only
-  size: 749072
-  timestamp: 1652971360657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
-  sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
-  md5: 88199c75f2ac211728febced7785c24e
-  depends:
-  - libgcc-ng >=7.5.0
-  - libstdcxx-ng >=7.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 228278
-  timestamp: 1635523146417
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
-  sha256: e2754627e8aeb98777318939e6773b9eadbdc219dd8961aca946354d9d30f481
-  md5: 4ed89646229bee3e594cd2cc8f6060f9
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - icu >=73.1,<74.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - xz >=5.4.2,<6.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  license: BSL-1.0
-  license_family: OTHER
-  size: 23778916
-  timestamp: 1696762223408
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
-  sha256: bb990ea068c3b3dafd9c807e0e19570320cb2fe7d69cc326f1f0b5319b0654b2
-  md5: 3ff70744e396b1af69656c574b05c3b9
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  size: 66940
-  timestamp: 1714483221853
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
-  sha256: 3b87a816f72a00e1f0022a160e7eda70af89d3de2a2e08a72be1c17b31d759f3
-  md5: 4f57d3a0a13ddaf1c06efb586b702f46
-  depends:
-  - libbrotlicommon 1.0.9 h5eee18b_8
-  - libgcc-ng >=11.2.0
-  license: MIT
-  size: 34446
-  timestamp: 1714483232430
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
-  sha256: 2cf15e89f910600f468edfde8d0f9b80a14fa2319ed89160dc7375dfd3764fdb
-  md5: 463adc13f2feea3570d1eccac368d9e4
-  depends:
-  - libbrotlicommon 1.0.9 h5eee18b_8
-  - libgcc-ng >=11.2.0
-  license: MIT
-  size: 295090
-  timestamp: 1714483244460
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang-14.0.6-default_hc6dbbc7_1.tar.bz2
-  sha256: 46646ce93dafb4922f4597c34c4fec106b4ff3b9707a202387f7964601e47876
-  md5: 5eaf417727302b441025661154fc4587
-  depends:
-  - libclang13 14.0.6 default_he11475f_1
-  - libgcc-ng >=11.2.0
-  - libllvm14 >=14.0.6,<14.1.0a0
-  - libstdcxx-ng >=11.2.0
-  - zlib >=1.2.13,<2.0.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 130632
-  timestamp: 1681222907766
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang13-14.0.6-default_he11475f_1.tar.bz2
-  sha256: 24d638d8577a3332a2e6cd77a5178054ca9cf7e14f71353b5b0a655155ab5c19
-  md5: 230f394424c6cc26ebbee96176b65ece
-  depends:
-  - libgcc-ng >=11.2.0
-  - libllvm14 >=14.0.6,<14.1.0a0
-  - libstdcxx-ng >=11.2.0
-  - zlib >=1.2.13,<2.0.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 11152969
-  timestamp: 1681222877667
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcups-2.4.2-h2d74bed_1.tar.bz2
-  sha256: f465c8f00b075660362d8e7fba8702b1c11e56fb2c305da78b9ee69898609be7
-  md5: 8a2e46dc8bd62528a6f4d9092f2f6911
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - openssl 3.*
-  - openssl >=3.0.8,<4.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 4901408
-  timestamp: 1685057846629
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.5.0-h251f7ec_0.tar.bz2
-  sha256: 22628e28b6df8298b761c4524b086a02b0e9fe208cf37ec86090497c4db50583
-  md5: 7d328929de28a113f3e5b8e0d70ce709
-  depends:
-  - krb5 >=1.20.1,<1.21.0a0
-  - libgcc-ng >=11.2.0
-  - libnghttp2 >=1.57.0
-  - libnghttp2 >=1.57.0,<2.0a0
-  - libssh2 >=1.10.0
-  - libssh2 >=1.10.0,<2.0a0
-  - openssl >=3.0.12,<4.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: curl
-  license_family: MIT
-  size: 403919
-  timestamp: 1704383721246
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
-  sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
-  md5: 55dde57e63a36b202e388a39dcee9a66
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 74096
-  timestamp: 1695996494461
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
-  sha256: 5bd3af246b6a93ea0912179ae66e0ad9157ca0142263010d84b65724e6db0bec
-  md5: 5cb0cc0e1783419cf8fc1c65fee0f62f
-  depends:
-  - libgcc-ng >=11.2.0
-  - ncurses >=6.4,<7.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 195807
-  timestamp: 1703006263489
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
-  sha256: efdab884c85fda4461f7a393aa6d4e0e50d03cb59fb9c8a980b1307b8379ebe0
-  md5: eeca774c6154c49340dd403b1928d5e9
-  depends:
-  - libgcc-ng >=7.5.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 108906
-  timestamp: 1632891483341
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
-  sha256: 4b2518a1aa3859031a531cd1077e8a60d5b3a0dc7c83210ef27ff9ce2c78c3e3
-  md5: 49f152ee4045544c10799d32bba85c07
-  depends:
-  - libgcc-ng >=11.2.0
-  - openssl 3.*
-  - openssl >=3.0.8,<4.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 480247
-  timestamp: 1685052130829
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
-  sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
-  md5: 1af9b4d62c708924417f2640ef22a68f
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 154016
-  timestamp: 1714483282916
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
-  sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
-  md5: 641e72e5067bd6d5454405879e1cd2a7
-  depends:
-  - _libgcc_mutex 0.1 main
-  - _openmp_mutex
-  - _libgcc_mutex * main
-  - __glibc >=2.17
-  constrains:
-  - _libgcc_mutex 0.1 main
-  - _openmp_mutex
-  - libgomp 11.2.0 h1234567_1
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 8895144
-  timestamp: 1654090827491
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
-  sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
-  md5: 27082517590f3b9fbffecc68513b461b
-  depends:
-  - libgfortran5 11.2.0.*
-  - __glibc >=2.17
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 19860
-  timestamp: 1654090819660
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
-  sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
-  md5: 0202c3c8ae4735cac6c7f3d1e1685964
-  constrains:
-  - libgfortran-ng 11.2.0 *_1
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 5228750
-  timestamp: 1654090762569
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libglib-2.78.4-hdc74915_0.tar.bz2
-  sha256: ddda848ae8594a9a28b14439b322763e4ffb0ff8d34e492c994e434fe3fbf934
-  md5: e35935cc3937ef52b2ef721dddc45738
-  depends:
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=11.2.0
-  - libiconv >=1.16,<2.0a0
-  - libstdcxx-ng >=11.2.0
-  - pcre2 >=10.42,<10.43.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  constrains:
-  - glib 2.78.4 *_0
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 1583413
-  timestamp: 1708031663093
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
-  sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
-  md5: 3080c2813e6e1d0f8a100a38b5b3456d
-  depends:
-  - _libgcc_mutex 0.1 main
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 573231
-  timestamp: 1654090775721
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
-  sha256: ed544d8aa7e77fc42c39c276b879955e6615b517c42fecd2624033a5050832eb
-  md5: 21ee76e09ab0a7315cbed14933d97773
-  depends:
-  - libgcc-ng >=11.2.0
-  license: GPL-3.0-or-later
-  license_family: GPL3
-  size: 1436714
-  timestamp: 1714483320555
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
-  sha256: 512fac06ddd97b4383503d4fbd8145102966055b29ccf86841a930dbb4ef3ab8
-  md5: 833c0e514ff9c8ae0511630b024d60e0
-  depends:
-  - libffi >=3.4,<3.5
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - zlib >=1.2.13,<2.0.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 37179832
-  timestamp: 1683292829131
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
-  sha256: 6c67d781d3c074ae46b18567f230bce4a4afa209e8b914dc2cb448502774886e
-  md5: c9627c386bbc8a1a1a0a2e736ea44501
-  depends:
-  - c-ares >=1.19.1,<2.0a0
-  - c-ares >=1.7.5
-  - libev >=4.11
-  - libev >=4.33,<4.34.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - openssl >=3.0.11,<4.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: MIT
-  license_family: MIT
-  size: 722387
-  timestamp: 1697018420830
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
-  sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
-  md5: 1bffe1481ed4f88827248fb9001f8923
-  depends:
-  - libgcc-ng >=11.2.0
-  - zlib >=1.2.13,<2.0.0a0
-  license: Zlib
-  license_family: Other
-  size: 362561
-  timestamp: 1677841789536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpq-12.17-hdbd6064_0.tar.bz2
-  sha256: 9fbd40a9bcf75d2f7aab558b3803175d419b1178ec2ece0d77c40a3e47cf0d9f
-  md5: ca25d5734b0361f78536d5e77b4b3e43
-  depends:
-  - krb5 >=1.20.1,<1.21.0a0
-  - libgcc-ng >=11.2.0
-  - openssl >=3.0.12,<4.0a0
-  size: 2973280
-  timestamp: 1706214551622
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
-  sha256: a24f7d1cdb5e18466a61860a5a66baffd608e212bbfed2935350e83d4d8659c0
-  md5: b32a43de76bc9be9c71f9a12edec8a1e
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - zlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2706964
-  timestamp: 1675278653314
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
-  md5: 6f662c6b244a444869f0c537da106d6d
-  depends:
-  - libgcc-ng >=7.3.0
-  license: ISC
-  size: 396743
-  timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-hdbd6064_3.tar.bz2
-  sha256: e3aadf465217537237e9e4c849f19f1ecb76a760e4b4ac479a02971832e39e75
-  md5: c3f8eb577f0da5f7524896bd4bce2dda
-  depends:
-  - libgcc-ng >=11.2.0
-  - openssl >=3.0.13,<4.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 337499
-  timestamp: 1714510585581
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
-  sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
-  md5: 8c195584a5f5471b600ee180e4052773
-  depends:
-  - __glibc >=2.17
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 6410287
-  timestamp: 1654090800863
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
-  sha256: 974e4035c5d51cd41fa7a7f02fadc1980069c00526c1646fa18ea94e667fb137
-  md5: 188de945b4279a812953011e8c4580c2
-  depends:
-  - boost-cpp >=1.73
-  - libevent >=2.1.12,<2.1.13.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - openssl >=3.0.9,<4.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 4630795
-  timestamp: 1687975185557
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
-  sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
-  md5: ef78eebd98289aceacdfa29182426adf
-  depends:
-  - jpeg >=9e,<10a
-  - lerc >=3.0,<4.0a0
-  - libdeflate >=1.17,<1.18.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - libwebp-base >=1.2.4,<2.0a0
-  - xz >=5.2.10,<6.0a0
-  - xz >=5.2.4,<6.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  license: HPND
-  license_family: Other
-  size: 664034
-  timestamp: 1693575237924
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
-  sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
-  md5: 292768ec77416ae257cfdd44ea2071c8
-  depends:
-  - libgcc-ng >=11.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 29197
-  timestamp: 1668082729834
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
-  sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
-  md5: 9cdeef1d044c7e035c006890f11569d3
-  depends:
-  - libgcc-ng >=11.2.0
-  constrains:
-  - libwebp 1.3.2
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 436056
-  timestamp: 1694776944891
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
-  sha256: 5d68e69709ae10bd6c4b58b6af447ad2f2bd24955994f3ec77103d1a6bf5e1f5
-  md5: 49e523de8d364b7fabc3850eccbe9bda
-  depends:
-  - libgcc-ng >=7.5.0
-  size: 623492
-  timestamp: 1652448233146
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxkbcommon-1.0.1-h5eee18b_1.tar.bz2
-  sha256: 114853749b375d54347f18b472456eb7d66beba26238c984403bdd5ff8831947
-  md5: 6225f107993ddf5e1f61111b3df025bd
-  depends:
-  - libgcc-ng >=11.2.0
-  - libxcb >=1.15,<2.0a0
-  - libxml2 >=2.10.3,<2.11.0a0
-  license: MIT/X11 Derivative
-  license_family: MIT
-  size: 640985
-  timestamp: 1679578328295
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.10.4-hfdd30dd_2.tar.bz2
-  sha256: 392fa116c728a97c17f3105a4d15b1ad86ee0b79c33c3581616b871b6d3f3f5b
-  md5: 09e1d64be1c4268bc83d1e84d28019f2
-  depends:
-  - icu >=73.1,<74.0a0
-  - libgcc-ng >=11.2.0
-  - xz >=5.4.6,<6.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: MIT
-  license_family: MIT
-  size: 745147
-  timestamp: 1713558300638
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
-  sha256: fd8e30beb8c9442f16e6617fac92dd0c89ec823e98f06e60f712147380ead35f
-  md5: 7ed7caf2816c8b85b67b6f4e8833cbd5
-  depends:
-  - python >=3.11,<3.12.0a0
-  - uc-micro-py >=1.0.1,<2.0.0
-  license: MIT
-  license_family: MIT
-  size: 41155
-  timestamp: 1676837080881
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.42.0-py311h6a678d5_0.tar.bz2
-  sha256: 05e355127db0d3ed67c4c383fd929ef1c3d7d3f19472f6e5433a866e94378bed
-  md5: b7897895622e5ab6e62279f07fa1f587
-  depends:
-  - libgcc-ng >=11.2.0
-  - libllvm14 >=14.0.6,<14.1.0a0
-  - libstdcxx-ng >=11.2.0
-  - python >=3.11,<3.12.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 4367002
-  timestamp: 1706910875807
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
-  sha256: 95fe76d2691feb13203b55ad2aba535bb848cae21ffd05b13ff51c7a45fa2332
-  md5: 6a04ec16e3abc1c7e2104be32cd6c418
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 13458
-  timestamp: 1676827287432
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py311h5eee18b_0.tar.bz2
-  sha256: fc8fa25c9629d8b5362d14ca7c90792064492aef7765a60e3574948f4659b4f2
-  md5: ed09cfc6c49987d5af17585f5e5168cb
-  depends:
-  - libgcc-ng >=11.2.0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 40405
-  timestamp: 1686058019487
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
-  sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
-  md5: 76f089e76ec67583bb38428b51008097
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 164494
-  timestamp: 1714510587156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
-  sha256: 260e26dd509834c1b225ab7bdb97b9a86e00054fbdd5dfa49e68fa4dcf85a661
-  md5: 8f5d7ddc69cc6f7d44c80d2251dea5d1
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 162339
-  timestamp: 1676837095436
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
-  sha256: 7f5b0804d0768619b7bd93b10488067d80bf42ec29f443f00b53ba11758a1241
-  md5: 8afb45e45c0d93bfd142e682d4b021ef
-  depends:
-  - mdurl >=0.1,<1
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 134438
-  timestamp: 1684280014220
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
-  sha256: cb03570c99c983d7bfda94bc47d8eb00d4059b8548a171130775acc998004195
-  md5: 5b1abbbf1e4f9b350b16fc9caf9e889b
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.11,<3.12.0a0
-  constrains:
-  - jinja2 >=3.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 26919
-  timestamp: 1704206397615
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.8.4-py311h06a4308_0.tar.bz2
-  sha256: e7eb5bfdaf1c62bfe2489237ea4ae6a837f09a647f846c31e4022a04e07355c0
-  md5: d744bdd5306fb954b4ed65311db45174
-  depends:
-  - matplotlib-base >=3.8.4,<3.8.5.0a0
-  - pyqt >=5
-  - python >=3.11,<3.12.0a0
-  - tornado >=5
-  license: LicenseRef-PSF-based
-  license_family: PSF
-  size: 8014
-  timestamp: 1713336708416
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
-  sha256: 85fea48bea278a77d102781a1cbb6bf69307207d741251e38a6515c5fd7e3523
-  md5: d6ddba94f7c33c88c9825be8409991bf
-  depends:
-  - contourpy >=1.0.1
-  - cycler >=0.10
-  - fonttools >=4.22.0
-  - freetype >=2.10
-  - freetype >=2.10.4,<3.0a0
-  - kiwisolver >=1.3.1
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - numpy >=1.23.5,<2.0a0
-  - packaging >=20.0
-  - pillow >=8
-  - pyparsing >=2.3.1,<3.1
-  - python >=3.11,<3.12.0a0
-  - python-dateutil >=2.7
-  license: LicenseRef-PSF-based
-  license_family: PSF
-  size: 9150942
-  timestamp: 1713336680714
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
-  sha256: 7ac07ea180b5928086075900afbc332fb1d3c81ddfacb54c891693c284056f14
-  md5: fc83dd1b3d2ec3c0a297ead0c3405907
-  depends:
-  - python >=3.11,<3.12.0a0
-  - traitlets
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 19573
-  timestamp: 1676823852670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
-  sha256: c9ba2f9c83820712dd97d6a1b54a1215b9820a0be02ac82380b4c50911b9400c
-  md5: e5dc6b4a5b8e02733ce3bc9e9198a8d2
-  depends:
-  - markdown-it-py >=1.0.0,<3.0.0
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 67750
-  timestamp: 1676837123613
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
-  sha256: 1a5141ef0de1cbff816f96bb4b212a40606e2fc11301a4c1358c8d63a6b2b027
-  md5: 22ac3bc22b68fef4c1f3f6ab3c7bfe0b
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 23040
-  timestamp: 1676827301164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
-  sha256: 9aacfbbe6f638c58a4e8ff31374d1438d78b7db25d6ea6fd0c50ca2109f225d4
-  md5: e602057e3b3d80da88c61d66e8851c5b
-  depends:
-  - python >=3.11,<3.12.0a0
-  constrains:
-  - nbconvert >6.1.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 104681
-  timestamp: 1676823696152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
-  sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
-  md5: ce77d0f05f846da4a6b9e23fe7f21d9b
-  depends:
-  - intel-openmp 2023.*
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - tbb 2021.*
-  constrains:
-  - __glibc >=2.17
-  license: LicenseRef-ProprietaryIntel
-  license_family: Proprietary
-  size: 206738176
-  timestamp: 1699648006088
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
-  sha256: 2aef0876d0df033f7fae8cddbd25d95fc1bfc067e60dd143bd8000fec0768b21
-  md5: d6cdc670327bd1675bbea642849f04e1
-  depends:
-  - libgcc-ng >=11.2.0
-  - mkl >=2023.1.0,<2024.0a0
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 59569
-  timestamp: 1682948560323
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
-  sha256: 691c4b2b47cf3fac55b4949d7c0f547246ef19cb3510749142cee4bd01ffb055
-  md5: bbd69efa3f24ee747410f83118640d92
-  depends:
-  - blas 1.0 mkl
-  - libgcc-ng >=11.2.0
-  - mkl >=2023.1.0,<2024.0a0
-  - mkl-service >=2.3.0,<3.0a0
-  - numpy <2.0a0
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 240723
-  timestamp: 1695058405382
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
-  sha256: 71f5c7beca4e81b465ecfc6ed51cb3d39f51dd88df0b29eff5def3d1f12969eb
-  md5: 61d58663b7277cf4cc3cb8d9873d3ee8
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - mkl >=2023.1.0,<2024.0a0
-  - mkl-service >=2.3.0,<3.0a0
-  - python >=3.11,<3.12.0a0
-  - blas * mkl
-  - numpy <2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 331105
-  timestamp: 1695059935112
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py311hdb19cb5_0.tar.bz2
-  sha256: ee4db7daf8d5e41a547e7790dd62aa98e203f4f857cf6018b850e7df8e613a3c
-  md5: 17145d1745996667614b52d2b27a1403
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 37588
-  timestamp: 1676823053826
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
-  sha256: b558b3f6c144652b5e0d26497b3ce24c318a6b9ff8ea2079113c95e5553b3cf9
-  md5: 0b185969ac2b065c27cbcc9641d93678
-  depends:
-  - python >=3.11,<3.12.0a0
-  - six
-  license: BSD 3-Clause
-  license_family: BSD
-  size: 29568
-  timestamp: 1676841232463
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mysql-5.7.24-h721c034_2.tar.bz2
-  sha256: 1127b7dbb0a740f3de8931a4af5b70b3dac6dc3de162a2d8f8760335db5e6669
-  md5: b4ab7fa3430324358189ca5ff9fc8e42
-  depends:
-  - cyrus-sasl >=2.1.28,<3.0a0
-  - libedit >=3.1.20221030,<3.2.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - openssl >=3.0.9,<4.0a0
-  license: GPL-2.0
-  license_family: GPL
-  size: 82391019
-  timestamp: 1688563074905
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
-  sha256: bb45fb0a3973caa74fd8f845e0a519895f6a378807626e15ecf72c02f2eed794
-  md5: 185f658ba8a74e326b7231c8fd0d62bf
-  depends:
-  - jupyter_client >=6.1.12
-  - jupyter_core >=4.12,!=5.0.*
-  - nbformat >=5.1
-  - python >=3.11,<3.12.0a0
-  - traitlets >=5.4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 121834
-  timestamp: 1698934274227
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
-  sha256: 8b2fc372a6655fd5b277d07b994ce43643553fbc37e63a60e9fe527a9026ec06
-  md5: ed6ac14aed5a796b153d757862398997
-  depends:
-  - beautifulsoup4
-  - bleach !=5.0.0
-  - defusedxml
-  - jinja2 >=3.0
-  - jupyter_core >=4.7
-  - jupyterlab_pygments
-  - markupsafe >=2.0
-  - mistune >=2.0.3,<4
-  - nbclient >=0.5.0
-  - nbformat >=5.7
-  - packaging
-  - pandocfilters >=1.4.1
-  - pygments >=2.4.1
-  - python >=3.11,<3.12.0a0
-  - tinycss2
-  - traitlets >=5.1
-  constrains:
-  - tornado >=6.1
-  - pyqtwebengine >=5.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 523905
-  timestamp: 1699022906468
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
-  sha256: 7908ff6c516b15e8fb677be4071145e18adea7d4c13b8485a70a5ee2f573f8cb
-  md5: 50c0e38207a131a5de6a14ef919ffcdc
-  depends:
-  - jsonschema >=2.6
-  - jupyter_core
-  - python >=3.11,<3.12.0a0
-  - python-fastjsonschema
-  - traitlets >=5.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 169629
-  timestamp: 1694616826002
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
-  sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
-  md5: 57ea097dc15f8d9f9eb90e1d919143b0
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT AND X11
-  license_family: MIT
-  size: 1157733
-  timestamp: 1674734069410
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
-  sha256: 266199dd4efde0ad342a9c500f4bc4299c5622219aea623b46315a9b4f6b8959
-  md5: 2b21844d2b0024d0ffad0e6450cf0855
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 15860
-  timestamp: 1708532713870
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-7.0.8-py311h06a4308_0.tar.bz2
-  sha256: 59e17fc80ec01ffef983431d36b41013d1da575e03f5bc1ff36fc3b7e496e7be
-  md5: b4e5249538db1bc282ac0d0d8c4f307c
-  depends:
-  - jupyter_server >=2.4.0,<3
-  - jupyterlab >=4.0.2,<4.1
-  - jupyterlab_server >=2.22.1,<3
-  - notebook-shim >=0.2,<0.3
-  - python >=3.11,<3.12.0a0
-  - tornado >=6.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 3650043
-  timestamp: 1708029938702
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
-  sha256: ef2857e6d3d7eb246b3abddfbd3aa2d124dd8565391ace3876b77339babc50bb
-  md5: d276d1b1774107987963135c78ca7390
-  depends:
-  - jupyter_server >=1.8,<3
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 26607
-  timestamp: 1699455972519
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.59.1-py311ha02d727_0.tar.bz2
-  sha256: 1b830d1d091462cff92de55f24339365a9d2c23b27d19799833b4780efe99c15
-  md5: 06367b04f8f04c0dc4e356a2ca9dc854
-  depends:
-  - _openmp_mutex >=5.1
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - llvmlite >=0.42.0,<0.43.0a0
-  - numpy >=1.23.5,<1.27
-  - python >=3.11,<3.12.0a0
-  - tbb >=2021.8.0
-  - libgomp
-  constrains:
-  - scipy >=1.0
-  - cudatoolkit >=10.2
-  - cuda-python >=11.6
-  - tbb >=2021.6,<2022
-  - libopenblas !=0.3.6
-  - numba-rvsdg 0.0.*
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 6084284
-  timestamp: 1711988494237
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
-  sha256: 2f89f38a665ece47e8868b391fc70602fcee588e989bc1ca6f17f6094892a94e
-  md5: b788c80b2d571531ea4f3f8335ae5423
-  depends:
-  - blas 1.0 mkl
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - mkl >=2023.1.0,<2024.0a0
-  - mkl-service >=2.3.0,<3.0a0
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 168827
-  timestamp: 1696515597877
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
-  sha256: e09e1aff2c12d4ef3fec58fb627744e4b5c7d9eaede7175e293f77272d8b8bfd
-  md5: fe8242cfd54d238507493612ae697ad4
-  depends:
-  - blas 1.0 mkl
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - mkl >=2023.1.0,<2024.0a0
-  - mkl-service >=2.3.0,<3.0a0
-  - mkl_fft
-  - mkl_random
-  - numpy-base 1.26.4 py311hf175353_0
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 10270
-  timestamp: 1708639794640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
-  sha256: a53ad723826651041a5057a1cf31bc8689b24d335ce61b196df5124974b05a8e
-  md5: 7b29e7191c4170189d6080e61229f030
-  depends:
-  - blas 1.0 mkl
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - mkl >=2023.1.0,<2024.0a0
-  - mkl-service >=2.3.0,<3.0a0
-  - python >=3.11,<3.12.0a0
-  constrains:
-  - numpy 1.26.4 py311h08b1b3b_0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 9163911
-  timestamp: 1708639777712
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
-  sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
-  md5: b0afe23033c8c5344640bc25225fa579
-  depends:
-  - libgcc-ng >=7.5.0
-  - libpng >=1.6.37,<1.7.0a0
-  - libstdcxx-ng >=7.5.0
-  - libtiff >=4.1.0,<4.7.0
-  license: BSD 2-Clause
-  size: 516994
-  timestamp: 1630084830020
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_1.tar.bz2
-  sha256: 9e90c0fd10fcc5a73afab93ed7f7f6a4d4822feded941198ae66d999923323ff
-  md5: 8d976dfed2a62a709aa759dba69da8a3
-  depends:
-  - ca-certificates
-  - libgcc-ng >=7.5.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 5512151
-  timestamp: 1714510995665
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
-  sha256: 9618addfc1b940c048372ffb2c8500d4b44d02455a9bd1f411e530ed5e09b8d5
-  md5: 56057ed323f733bdcf262468682d0358
-  depends:
-  - libgcc-ng >=11.2.0
-  - libprotobuf >=3.20.3,<3.21.0a0
-  - libstdcxx-ng >=11.2.0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - snappy >=1.1.9,<2.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 1132661
-  timestamp: 1676482768554
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
-  sha256: 280225061aeba00d7b85f46e55d7d79cd92c92f662dc749d9c53187978e8d083
-  md5: c51c21da68080d89300703ad818c824a
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 38606
-  timestamp: 1699371264464
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
-  sha256: bd3eacd22e85f88bedd9c7e97a59eacfb3c8bb80eb59be244825d6895a0e7ac1
-  md5: 08ceb294ba8a9ae13630da789884736e
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0 or BSD-2-Clause
-  license_family: Apache
-  size: 157904
-  timestamp: 1710807470578
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
-  sha256: a2ee3a6aaf54929b82b851b2eb5436e14e5a294303ef429d6dccd33bcdfc8002
-  md5: b467a5c7ad672ccc2d498a67b9eeeaaa
-  depends:
-  - bottleneck >=1.3.6
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - numexpr >=2.8.4
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python-dateutil >=2.8.2
-  - python-tzdata >=2022.7
-  - pytz >=2020.1
-  constrains:
-  - fsspec >=2022.11.0
-  - matplotlib-base >=3.6.3
-  - tabulate >=0.9.0
-  - odfpy>=1.4.1
-  - pyreadstat >=1.2.0
-  - pyarrow >=10.0.1
-  - python-calamine >=0.1.7
-  - s3fs >=2022.11.0
-  - beautifulsoup4 >=4.11.2
-  - gcsfs >=2022.11.0
-  - xlrd >=2.0.1
-  - dataframe-api-compat >=0.1.7
-  - pyqt >=5.15.9
-  - adbc-driver-postgresql >=0.8.0
-  - fastparquet >=2022.12.0
-  - psycopg2 >=2.9.6
-  - qtpy >=2.3.0
-  - openpyxl >=3.1.0
-  - xarray >=2022.12.0
-  - html5lib >=1.1
-  - jinja2 >=3.1.2
-  - pyxlsb >=1.0.10
-  - sqlalchemy >=2.0.0
-  - zstandard >=0.19.0
-  - pymysql >=1.0.2
-  - pandas-gbq >=0.19.0
-  - lxml >=4.9.2
-  - numba >=0.56.4
-  - xlsxwriter >=3.0.5
-  - blosc >=1.21.3
-  - adbc-driver-sqlite >=0.8.0
-  - pytables >=3.8.0
-  - scipy >=1.10.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 17970687
-  timestamp: 1709593080388
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
-  sha256: a2e2beff710765f2e5135020121da4f227f5e1cbe142e17398a585f50a389d37
-  md5: eaf734d49b6e576e12be1398a295643a
-  depends:
-  - locket
-  - python >=3.11,<3.12.0a0
-  - toolz
-  constrains:
-  - pandas >=0.19.0
-  - numpy >= 1.9.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 47447
-  timestamp: 1698702703255
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
-  sha256: 71beb7373390a7c5e9bf8663d64e2b0a426755fe68adb26ed72b6570634f635e
-  md5: cd7c1793b37ba076f8515b49dbd850bd
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=11.2.0
-  - zlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 3346886
-  timestamp: 1714657706306
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
-  sha256: 28ed719669260a20bec78971edaffb91ec917d2a3f0fac1cf9a8ba21590baa43
-  md5: 0481d078fcd64f7f981532a514d9d50d
-  depends:
-  - freetype >=2.10.4,<3.0a0
-  - jpeg >=9e,<10a
-  - lcms2 >=2.12,<3.0a0
-  - libgcc-ng >=11.2.0
-  - libtiff >=4.2.0,<4.7.0
-  - libwebp-base >=1.3.2,<2.0a0
-  - openjpeg >=2.3.0,<3.0a0
-  - python >=3.11,<3.12.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: HPND AND TCL
-  license_family: Other
-  size: 960727
-  timestamp: 1714399060039
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3.1-py311h06a4308_0.tar.bz2
-  sha256: 0bedd7decde6751a3efbb2367dd22d916b61391e334833d548b285fdd3420080
-  md5: aebee46c2eadf95ea8633847612f0f15
-  depends:
-  - python >=3.11,<3.12.0a0
-  - setuptools
-  - wheel
-  license: MIT
-  license_family: MIT
-  size: 3443056
-  timestamp: 1700667782149
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
-  sha256: d2bbab8bfc57c7f46ca8994bc87df7e744d3f036b867bc4be1145ba6d8d7e091
-  md5: de41707272a8e3ccab764f0b7010a27d
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 37394
-  timestamp: 1692205565974
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ply-3.11-py311h06a4308_0.tar.bz2
-  sha256: 786a4a57db582b66de12bd7e03eae83caa939136dabd8b53049cadeabc0beb6f
-  md5: 262064c348f1846011c650ad8a6cd793
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD 3-clause
-  license_family: BSD
-  size: 111320
-  timestamp: 1676824981885
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
-  sha256: e2a0e2a618aa33f0beff9583c7dc510b8d0737b023117346676aacbad33970d8
-  md5: 66a6818307261b1a28ab12d1b7776fdf
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 121454
-  timestamp: 1679340540306
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
-  sha256: b7f591c19b10bf0daa7e6e3b45a9f4a0a0e83188e1f8a58037caea79e60f8d91
-  md5: d945b4ccc135005839c504cc29df1745
-  depends:
-  - python >=3.11,<3.12.0a0
-  - wcwidth
-  constrains:
-  - prompt_toolkit 3.0.43
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 749608
-  timestamp: 1704404477511
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
-  sha256: 96482b49191fdac59580a95e69508367083e1f7600145e11d7c2db634337eb26
-  md5: 2d57bf8eacf3f291db845928241f724c
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 490805
-  timestamp: 1679337420563
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-14.0.2-py311hb6e97c4_0.tar.bz2
-  sha256: 252204d5e65480b83b9e31c63cecfaff95725ef5fc302714f92c344b7fdbafe3
-  md5: f2b86ab94d7af6c10b9586263b1b45df
-  depends:
-  - arrow-cpp >=14.0.2,<14.0.3.0a0
-  - boost-cpp
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - numpy >=1.16.6,<2.0a0
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 5423490
-  timestamp: 1707331892286
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
-  sha256: ed927e4d058a8f4ea73edc7a43ed74877d93b88fdfa240b3b2777244386ced70
-  md5: a1f0e05fc7e49712f81ad5478ec9d51e
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 2121496
-  timestamp: 1684280065800
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
-  sha256: ad219924e362ce7af458fa6547660181579e9a50e5aed1ffd9268cbe7c2650e3
-  md5: 2b1ac40e0df3673d33b7f4c4f93ae1ef
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 207338
-  timestamp: 1677811584327
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.15.10-py311h6a678d5_0.tar.bz2
-  sha256: f0c1614d5e651ed15061d137acecda2f684189cc148f50d3e75068dc9737bcd4
-  md5: 0911e45b849687c7318f7764e2b69778
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - pyqt5-sip 12.13.0 py311h5eee18b_0
-  - python >=3.11,<3.12.0a0
-  - qt-main 5.15.*
-  - qt-main >=5.15.2,<5.16.0a0
-  - sip >=6.7.12,<6.8.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 6539272
-  timestamp: 1698775883859
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt5-sip-12.13.0-py311h5eee18b_0.tar.bz2
-  sha256: a646cae6b3d429588a3dc752819b4dcb315a814c8ad2b9fb2741b166fc4ee2a6
-  md5: eec3045856f86acc307c73749a7f7df1
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.11,<3.12.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 97216
-  timestamp: 1698769366045
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
-  sha256: 114b55e00f4622c90fd2b404b21ad5f94a10283fcaaf86a42174b8d39b0a3e98
-  md5: 2458e92683cc68671a6c8e1b86ce8817
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD 3-Clause
-  license_family: BSD
-  size: 35850
-  timestamp: 1676822725516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.8-h955ad1f_0.tar.bz2
-  sha256: 8bae0856b2f337f43cb5cbbf71ebf684ef47438210465b8733304d7d7f258559
-  md5: 7fa94ac6e31488660ca09b2896b9d96d
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - ld_impl_linux-64 >=2.35.1
-  - libffi >=3.4,<3.5
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=11.2.0
-  - libuuid >=1.41.5,<2.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.0.13,<4.0a0
-  - readline >=8.0,<9.0a0
-  - sqlite >=3.41.2,<4.0a0
-  - tk >=8.6.12,<8.7.0a0
-  - tzdata
-  - xz >=5.4.5,<6.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: PSF-2.0
-  license_family: PSF
-  size: 36090392
-  timestamp: 1708984519285
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
-  sha256: aadc4078311c059265706a56265f0a57ceb538d36179d5203dd487d80d0e8f16
-  md5: 59ec670fcd172447dbd9591b8fbfdd56
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 278741
-  timestamp: 1679340144625
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
-  sha256: d5058d0ecc3973316c1d5f1bfb03dd119e0dade85f4c2d21b412c8db4e1636f2
-  md5: 93000e4d3603342779a2afda66fa91b8
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 17607
-  timestamp: 1683823841946
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py311h6a678d5_0.tar.bz2
-  sha256: d9eff881e112d0b326d0c1ee0d42d6c2c4649b1c4edd168be1006f28f1f8962e
-  md5: d9d1f41dcee9b622cbfe048ab1632a47
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - python >=3.11,<3.12.0a0
-  license: OLDAP-2.8
-  license_family: Other
-  size: 154074
-  timestamp: 1682522389521
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
-  sha256: b85acb933fff864bfa89d034e8e3d85b1a9c2e69cbfc0d68c1d66ffd1443e67d
-  md5: 0cdb92d2d684ee1095310f992ed0d9b2
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 266796
-  timestamp: 1713974338678
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
-  sha256: b2a1f649669f4336b74f6f20df711959bcd8024f8f8b94199dc0e040b06bd37a
-  md5: f9e8e3f7068f717f75e555dc04545d8d
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.11,<3.12.0a0
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  size: 206433
-  timestamp: 1698096204677
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-25.1.2-py311h6a678d5_0.tar.bz2
-  sha256: 787979e7e36b0eaf06c65f8840f3af969b6efa6ba2a7e2736b1bb52e96588242
-  md5: eb62cbfdbe25aaebbafad6166ec66903
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - python >=3.11,<3.12.0a0
-  - zeromq >=4.3.5,<4.4.0a0
-  license: BSD-3-Clause AND LGPL-3.0-or-later
-  license_family: BSD
-  size: 583036
-  timestamp: 1705605396341
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-main-5.15.2-h53bd1ea_10.tar.bz2
-  sha256: 34fca7030324880c741f8b2030673229883cb7a11429f8e4bd2664d7d0f07ae1
-  md5: ccbd6faf6b49454aec690b72d21666dd
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - dbus >=1.13.18,<2.0a0
-  - fontconfig >=2.14.1,<3.0a0
-  - freetype >=2.10.4,<3.0a0
-  - glib >=2.69.1,<3.0a0
-  - gst-plugins-base >=1.14.1,<1.15.0a0
-  - gstreamer >=1.14.1,<1.15.0a0
-  - icu >=73.1,<74.0a0
-  - jpeg >=9e,<10a
-  - krb5 >=1.20.1,<1.21.0a0
-  - libclang >=14.0.6,<15.0a0
-  - libclang13 >=14.0.6
-  - libcups 2.*
-  - libgcc-ng >=11.2.0
-  - libpng >=1.6.39,<1.7.0a0
-  - libpq >=12.15,<13.0a0
-  - libstdcxx-ng >=11.2.0
-  - libxcb >=1.15,<2.0a0
-  - libxkbcommon >=1.0.1,<2.0a0
-  - mysql 5.7.*
-  - openssl >=3.0.10,<4.0a0
-  - sqlite >=3.41.2,<4.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  constrains:
-  - qt >=5.15.2,<6
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 62392312
-  timestamp: 1693222657819
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
-  sha256: 8a640736bef635346409582dbfe2b7d0ecc9da215c90173ff8a9a5fe22569107
-  md5: 6b583dce61c6feb352ef0f49f413af1e
-  depends:
-  - libgcc-ng >=7.5.0
-  - libstdcxx-ng >=7.5.0
-  license: BSD-3-Clause
-  size: 235004
-  timestamp: 1652449537852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
-  sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
-  md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
-  depends:
-  - libgcc-ng >=11.2.0
-  - ncurses >=6.3,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 467661
-  timestamp: 1666648052561
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
-  sha256: 89c2f4235277b9825cc805c5c44f0b1afcb683d7b5a3f513bc4bf243b643bb0c
-  md5: db70eb57e33adf7b8bbdadd72214d48d
-  depends:
-  - attrs >=22.2.0
-  - python >=3.11,<3.12.0a0
-  - rpds-py >=0.7.0
-  license: MIT
-  license_family: MIT
-  size: 73679
-  timestamp: 1699012111499
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
-  sha256: 684037527327839d734e7eac2ee09ef5ddb4f77df22daf40c79e51db29d09543
-  md5: 57c5bcb9eae9f1d93ccfd38025660de2
-  depends:
-  - certifi >=2017.4.17
-  - charset-normalizer >=2,<4
-  - idna >=2.5,<4
-  - python >=3.11,<3.12.0a0
-  - urllib3 >=1.21.1,<3
-  constrains:
-  - pysocks >=1.5.6,!=1.5.7
-  - chardet >=3.0.2,<6
-  license: Apache-2.0
-  license_family: Apache
-  size: 119414
-  timestamp: 1707355661872
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
-  sha256: fdae3f68ea84b99561aee6c566ab1c287d8f2ae2668424e9283a8ed86af8f1d2
-  md5: cde5b71ccbb3630053340b2c8c7dbf10
-  depends:
-  - python >=3.11,<3.12.0a0
-  - six
-  license: MIT
-  license_family: MIT
-  size: 9333
-  timestamp: 1683077183576
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
-  sha256: 0bf859b06a07857099fd4f524fe5e0875fda70029e9485d95c7efa97134fbc14
-  md5: fd5815cc592fdbd4c831901541eadaba
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 9735
-  timestamp: 1683059096795
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
-  sha256: 474553d01aea57214a54a7443f227da84a58e29c49eb7605ba0043c55b7d167a
-  md5: f01333e9f0a908e435db650f42fbd2db
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 1096668
-  timestamp: 1698946168635
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
-  sha256: 8c8aa1eb7e215984f46c8e1c7cfa6e5e6b233993d92b835a9b1b5491a4b970ab
-  md5: 6e145b179adde03f8aa8a066c58d4e31
-  depends:
-  - libgcc-ng >=11.2.0
-  - openssl >=3.0.12,<4.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 380702
-  timestamp: 1706563445897
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
-  sha256: b06b45da61807f76b6d800047f123fee2cc95eb84da508550e0908951c8d9f6f
-  md5: 9b100efb9ba2fc7f9bcfaa8fd2ab6f9f
-  depends:
-  - blas 1.0 mkl
-  - libgcc-ng >=11.2.0
-  - libgfortran-ng
-  - libgfortran5 >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - mkl >=2023.1.0,<2024.0a0
-  - mkl-service >=2.3.0,<3.0a0
-  - numpy >=1.23.5,<1.29
-  - pybind11-abi 4
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
-    BSL-1.0
-  license_family: BSD
-  size: 27615256
-  timestamp: 1714076660659
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
-  sha256: 51bcea0e575a626f6ffbd16d1153330fda93dbe3dd31dcd3a8f469ff61dd1e4e
-  md5: 41d531c90be8c82bf79635ff3d409476
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 32295
-  timestamp: 1699371262818
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
-  sha256: 0a95988ea269c96354626dcab255b65b54bb5c503d24cdeb6ef2e1c42818bd59
-  md5: 8bfb9f42492b3b53b8151d77e51c75d8
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 1594974
-  timestamp: 1715024182643
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-6.7.12-py311h6a678d5_0.tar.bz2
-  sha256: c1585436f502f87ee7bf6d40b7d911d1b5093dfee339db251d887bf355a23a94
-  md5: ff29bdee631a122ae9a68ff44066b02a
-  depends:
-  - libgcc-ng >=11.2.0
-  - packaging
-  - ply
-  - python >=3.11,<3.12.0a0
-  - setuptools
-  license: LicenseRef-SIP_License OR GPL-2.0-or-later OR GPL-3.0-or-later
-  license_family: GPL
-  size: 683464
-  timestamp: 1698675983077
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.1.10-h6a678d5_1.tar.bz2
-  sha256: 15045902c5957ae0c8196ad7f1cecdadc7e6f5545f24f143339f488f063775f0
-  md5: 0b92bda0f6031b4f8fe9b4f1c0e55c06
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
-  license_family: BSD
-  size: 48768
-  timestamp: 1702909413687
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
-  sha256: 1a84b00944bc5588e14a097460175f97df49acb4f1ff2498ffd9a1893068ed81
-  md5: a456513471b2ecbed60430c21dd1ccc7
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT OR Apache-2.0
-  license_family: Other
-  size: 17880
-  timestamp: 1705431390054
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
-  sha256: adcafd297d60af64107c113bb7b8b92160d0268a44ef9a3b79e56a88a0358ea7
-  md5: 28ed704ed26b06d32662e3a6a87e59b0
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 88799
-  timestamp: 1696347581401
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
-  sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
-  md5: f86119b3243fe3508160aa0406245738
-  depends:
-  - libgcc-ng >=11.2.0
-  - ncurses >=6.4,<7.0a0
-  - readline >=8.0,<9.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  - zlib >=1.2.13,<2.0a0
-  license: blessing
-  license_family: Other
-  size: 1723866
-  timestamp: 1714488309729
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
-  sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
-  md5: 041a3caf09dc9ce8fc6c10925c4fe050
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 1888016
-  timestamp: 1680167274961
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
-  sha256: 856a8ab8c350c50247b79966c6cb80fb6d4de36eef49ddf75aebbbcaf854c82d
-  md5: 442dde204d14d171aab9ee40e8de4de8
-  depends:
-  - ptyprocess
-  - python >=3.11,<3.12.0a0
-  - tornado >=6.1.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 37456
-  timestamp: 1677696176157
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
-  sha256: f0a026ddc0ed041bfc60c8a1ca0b70b7a69232775b3181bfb35a39fda42d6994
-  md5: 2902d5a5854865baaaf58dc59cf06b3c
-  depends:
-  - python >=3.11,<3.12.0a0
-  - webencodings >=0.4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 49185
-  timestamp: 1676823769869
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
-  sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
-  md5: e2512d57c8a1e91e7b20e265c6906546
-  depends:
-  - libgcc-ng >=11.2.0
-  - zlib >=1.2.13,<2.0.0a0
-  license: TCL
-  license_family: BSD
-  size: 3588922
-  timestamp: 1714770676475
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
-  sha256: e58ff4a82819446f3c92e5b1aa2a784c4b06643e751fe67cf115858296dbfa50
-  md5: 32ee4723173f1fad5563b8afb5f1c8f1
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 135634
-  timestamp: 1676827536101
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
-  sha256: 1bf522ade750cf0b70d61e71916ff00569e2908db1e9dedb223fda2608ed8bde
-  md5: 6793c74fe94211c0bfe6766c6dd490af
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 893808
-  timestamp: 1696937055591
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.2-py311h92b7b1e_0.tar.bz2
-  sha256: ef0c8cbb22af258e228d54e7cbb4a152c81cc64b28d009166488a2ccdb30225f
-  md5: 5e033e80b81b1830252a4c65ddf0959b
-  depends:
-  - python >=3.11,<3.12.0a0
-  constrains:
-  - ipywidgets >=6
-  license: MPL-2.0 AND MIT
-  license_family: MOZILLA
-  size: 154337
-  timestamp: 1714567842489
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
-  sha256: 0575785f6553e61cc6138abfd5de52305fac6f85971642fa1f056a76c66a52b2
-  md5: f2c25e5dfdd23f70b83776a8832893cf
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 270865
-  timestamp: 1676823316868
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.9.0-py311h06a4308_1.tar.bz2
-  sha256: e0dbca6707368472ef0adfe498c024de7c9a56d9c6ff25ffe1449e8e95da89aa
-  md5: 570cf697aaefcaee710444daef8a11d1
-  depends:
-  - python >=3.11,<3.12.0a0
-  - typing_extensions 4.9.0 py311h06a4308_1
-  license: PSF-2.0
-  license_family: PSF
-  size: 8792
-  timestamp: 1705599472930
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.9.0-py311h06a4308_1.tar.bz2
-  sha256: da18ffdb0ef53142aeb5d964b8db1542c290eb328ae9fbdf96690750272bd8bc
-  md5: c6d716b2a8ae08f6e4039ea74d13b79f
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: PSF-2.0
-  license_family: PSF
-  size: 70729
-  timestamp: 1705599465726
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
-  sha256: 509b962773f0fe44a93a7f6196b254670a030eac8ea7f90727312e3ccd9294b2
-  md5: 6c402d5bf4e01c8c3895c9ef41707b6e
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 11371
-  timestamp: 1676828901104
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
-  sha256: bbe7629e8ce52c82f13ed0d1fb919f3659ef466b274a7c74aa925a9bc7aee450
-  md5: 7da527bbcf71270c1abed8ea52e7d44c
-  depends:
-  - libgcc-ng >=11.2.0
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 509031
-  timestamp: 1713213062098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.1.0-py311h06a4308_1.tar.bz2
-  sha256: a0b300e422e89ca84cd1ece98b796af3133c56279871fbf0198871c9edd3585e
-  md5: 5cdea1fde6548c3a82add475b39e60c2
-  depends:
-  - brotli-python >=1.0.9
-  - pysocks >=1.5.6,<2.0,!=1.5.7
-  - python >=3.11,<3.12.0a0
-  constrains:
-  - zstandard >=0.18.0
-  - selenium >=4.4.3
-  - requests >=2.26.0
-  license: MIT
-  license_family: MIT
-  size: 183475
-  timestamp: 1707770592436
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
-  sha256: a8d11b0f08217607b99ba560edf66423ca1e36f4ffbb6e2377e61670e2b5f36b
-  md5: 431e82b081b08aef0259df0437e04c75
-  depends:
-  - libgcc-ng >=11.2.0
-  license: MIT
-  license_family: MIT
-  size: 97535
-  timestamp: 1706894675990
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
-  sha256: c3a5e0b855dc2de6c162708dfcf170a23eb9e7525d4252d8dce553369af4a330
-  md5: a4c77e204b7787f820955166a1283168
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD 3-Clause
-  license_family: BSD
-  size: 25890
-  timestamp: 1676823132898
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py311h06a4308_4.tar.bz2
-  sha256: 7b505fdb5d801adfb3032e2541bf9bf17ed2238764b7a53cb845e33e7f835faf
-  md5: 07dc61e2e59fe57a9bfe8efcbb23ffe6
-  depends:
-  - python >=3.11,<3.12.0a0
-  - six
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 90518
-  timestamp: 1676824901641
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
-  sha256: eec0d2e0bce4b62278cacd7b0bee053160845e86507051a5434d2069bd290f36
-  md5: a069e5aef64a6dac076cc9a3d28a17c9
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 136022
-  timestamp: 1714717059748
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
-  sha256: 85248e503721da67797546cb8a22e303c1739100834b219c5621f216e3794e8d
-  md5: 2570956643f22d0f809b2467e02d3984
-  depends:
-  - numpy >=1.21,<2.0a0
-  - packaging >=21.3
-  - pandas >=1.4
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 2465865
-  timestamp: 1689041600364
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
-  sha256: d18cdca154bf668826f869117ea996c4f9e8ef7d27b7c528332a7d17e5a8602c
-  md5: 9f7353d72046b16dd6ef6b5689ac9bfd
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 54731
-  timestamp: 1676828934954
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
-  sha256: 9122d6e9dabb7a47f2bcb15d86b97c96c49a9048da3f8ae59675351710c14cc5
-  md5: 660b2aead2ec87b751c86cd33934f44e
-  depends:
-  - libgcc-ng >=11.2.0
-  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
-  license_family: GPL2
-  size: 716926
-  timestamp: 1714510796277
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
-  md5: fcff4f33bb4e3fa91f8d5c3168807abb
-  depends:
-  - libgcc-ng >=7.3.0
-  license: MIT
-  size: 88839
-  timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
-  sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
-  md5: 943f1247a22b6b64171363bcee1eec27
-  depends:
-  - libgcc-ng >=11.2.0
-  - libsodium >=1.0.18,<1.0.19.0a0
-  - libstdcxx-ng >=11.2.0
-  license: MPL-2.0
-  license_family: Other
-  size: 371663
-  timestamp: 1705602144682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py311h06a4308_0.tar.bz2
-  sha256: f33ed759a551e2cd64115a3b01af0fc9822b1a5a1a5c798aa0ee14292792d7c1
-  md5: 7feb38e587b3352efca77df1447858d2
-  depends:
-  - heapdict
-  - python >=3.11,<3.12.0a0
-  - python-lmdb
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 102106
-  timestamp: 1695832995689
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.17.0-py311h06a4308_0.tar.bz2
-  sha256: 7aa781d0850f97622755ed44772d2b215b253a8e211aede5f3f53e1b95b4143a
-  md5: b1d8823f50228d4efb7b7a6e267ed776
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 24333
-  timestamp: 1704207043644
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
-  sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
-  md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
-  depends:
-  - libgcc-ng >=11.2.0
-  license: Zlib
-  license_family: Other
-  size: 127143
-  timestamp: 1714510716441
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
-  sha256: af3c032f06352e87c450739cb8aafe1ff34ad28bf074b214ea98b3d29259a85d
-  md5: 51fa34bd0e016ed7c5371cf6cb13ef6c
-  depends:
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - xz >=5.4.6,<6.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause AND GPL-2.0-or-later
-  license_family: BSD
-  size: 1044463
-  timestamp: 1714678445052
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
-  md5: 32685aa840f6868407a3150184ebbf90
-  depends:
-  - argon2-cffi-bindings
-  - python >=3.6
-  - typing-extensions
-  constrains:
-  - argon2_cffi ==999
-  license: MIT
-  license_family: MIT
-  size: 15512
-  timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
-  md5: d9c6faf4f1a52c664ef1343f464e45b5
-  depends:
-  - python >=3.5
-  - six
-  license: Apache-2.0
-  license_family: Apache
-  size: 21573
-  timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
-  md5: d78a456773bd4df323a2dfb4d8710b90
-  depends:
-  - packaging
-  - python >=3.6
-  - six >=1.9.0
-  - webencodings
-  license: Apache-2.0
-  license_family: Apache
-  size: 124095
-  timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
-  md5: 544adf2677c47c9b9c891aea720678f1
-  depends:
-  - python >=3.5
-  license: MIT
-  size: 33999
-  timestamp: 1630003259346
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
-  md5: dfb0ca8055c9a72aaca7b845a6edea17
-  depends:
-  - python >=3.6
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 12592
-  timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
-  md5: 6072a09eeab81c07c98065234e46af1e
-  depends:
-  - python >=3.5
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 11936
-  timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
-  md5: b9280feeee8d845ba495a701bae72de9
-  depends:
-  - python
-  license: PSF 2.0
-  license_family: PSF
-  size: 24190
-  timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
-  md5: 1bdd5a02233d229e76081a73659e9405
-  depends:
-  - python >=2.7
-  license: MIT
-  license_family: MIT
-  size: 18210
-  timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-  sha256: 9de8666e5b70aa2437737128eaa14ffe80a7b5235c2a6b7d3f39ccefd7816ba0
-  md5: bb52e50c5ab1a5c7778c11376404dfdb
-  depends:
-  - python
-  license: BSD 3-Clause
-  size: 7933
-  timestamp: 1630598543551
-- conda: https://repo.anaconda.com/pkgs/main/noarch/json5-0.9.6-pyhd3eb1b0_0.tar.bz2
-  sha256: 6db7265c2238c6e5b4c98906498c47af341238b5d5a9baee383777181f421366
-  md5: 91e3336204a0ea3951957d7d5e8f3e26
-  depends:
-  - python
-  license: Apache-2.0
-  license_family: Apache
-  size: 21503
-  timestamp: 1624432813739
-- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-  sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
-  md5: 33624a42ee387bf9918ea98b4e7b31fc
-  depends:
-  - pygments >=2.4.1,<3
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 8173
-  timestamp: 1601490751973
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
-  md5: 0cb9961d77df143d6d65580d713aade1
-  depends:
-  - python !=3.0,!=3.1,!=3.2,!=3.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 11684
-  timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
-  md5: 19dd0314629d343382a76a309cb7d183
-  depends:
-  - python >=3.6
-  license: MIT
-  license_family: MIT
-  size: 70876
-  timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
-  md5: 5122a68ef2c53409eda11f07f1c3d7c7
-  depends:
-  - ptyprocess >=0.5
-  - python
-  license: ISC
-  license_family: Other
-  size: 52491
-  timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-  sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
-  md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
-  depends:
-  - prompt-toolkit >=3.0.43,<3.0.44.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 5106
-  timestamp: 1704404390460
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
-  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
-  depends:
-  - python
-  license: ISC
-  size: 16774
-  timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
-  md5: 8be7529b5e573e3cbc6df277b9950109
-  depends:
-  - python >=3.5
-  license: MIT
-  license_family: MIT
-  size: 14248
-  timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
-  sha256: 459f38609d854888998a8d76028019dbacdce2bfe401eab57b8eb8ff16da9c7f
-  md5: 2948a98ef4de5decb7e5eb888eae68ba
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 13056
-  timestamp: 1682965564630
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
-  sha256: 305e5fd9993f3e5506f386f98794c7d53b6e6c68d4d411ada724de49a17945fa
-  md5: e1fbbd2d11d21aaec3c32f7d332c0e77
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 13818
-  timestamp: 1712163766707
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
-  md5: e70944ff53d19af4f65073a4f21c7b05
-  depends:
-  - python >=3.6
-  license: BSD-3-clause
-  license_family: BSD
-  size: 96720
-  timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-  sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
-  md5: 2eb923cc014094f4acf7f849d67d73f8
-  depends:
-  - python
-  - six >=1.5
-  license: BSD-3-Clause and Apache
-  license_family: BSD
-  size: 246457
-  timestamp: 1626374695070
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
-  md5: 02caf3f47f1d06256068053297355740
-  depends:
-  - python
-  license: Apache-2.0
-  license_family: Apache
-  size: 152292
-  timestamp: 1690578151230
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
-  md5: 0a3ab834ba49016e183e715bff48a2b6
-  depends:
-  - python
-  license: MIT
-  license_family: MIT
-  size: 19160
-  timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-  sha256: 4e47f6c49ce84509f1466e8a4d728447bf4bcd9bce7b456431a789a262547067
-  md5: 4cad993b0f80bc23fb66a97592299cbb
-  depends:
-  - python >=2.7
-  license: Apache-2.0
-  license_family: Apache
-  size: 26504
-  timestamp: 1623949147884
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
-  md5: fa3edcfd4c2c0d744bc177cbfcd77626
-  depends:
-  - asttokens
-  - executing
-  - pure_eval
-  - python >=3.5
-  license: MIT
-  license_family: MIT
-  size: 21658
-  timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-  sha256: ca2be6c7810a37cfc6db1f5383937b5d35c6d73c1fad8a9104de85f069b1df1c
-  md5: 9ccb2fb33edb152403d6ef32bf758a9d
-  depends:
-  - python
-  license: BSD 2-Clause
-  license_family: BSD
-  size: 15614
-  timestamp: 1629402049497
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-  sha256: dc9f709bacbaf08a0941d2622d82f91f18b355e82c55348ec29f1391215ca7e0
-  md5: ece0f5837a4de2d4d5f1abf8347cd10a
-  license: CC-PDDC OR BSD-3-Clause
-  license_family: BSD
-  size: 124922
-  timestamp: 1708711884650
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
-  md5: 98982290b7b7eff532ec6dead415172b
-  depends:
-  - python
-  license: MIT
-  size: 34378
-  timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/abseil-cpp-20230802.0-h61975a4_2.tar.bz2
-  sha256: dc40cfc393c2acdb97ce54289d3124bdff35ffd4a6c203abb6f3f5598f49c115
-  md5: 64a761d3c1af045bf01d84d3fc4302a2
-  depends:
-  - gtest >=1.14.0,<1.14.1.0a0
-  - libcxx >=14.0.6
-  license: Apache-2.0
-  license_family: Apache
-  size: 1336618
-  timestamp: 1698327954026
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
-  sha256: 5800a2466734dd1ef372bec0dd3f0880c5072fa1e8b0668f5054f834285e991c
-  md5: 18194e51d4420ac08f29f3f86581b52e
-  depends:
-  - idna >=2.8
-  - python >=3.11,<3.12.0a0
-  - sniffio >=1.1
-  constrains:
-  - uvloop >=0.17
-  - trio >=0.23
-  license: MIT
-  license_family: MIT
-  size: 229003
-  timestamp: 1706220302459
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
-  sha256: ab7672364f1fa55ec5d8311d85d40e5b57cbd3517b17670557b6fb822bcf759c
-  md5: 6e0159a5865cb7e96a748bd8560035ee
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD 2-Clause
-  license_family: BSD
-  size: 11579
-  timestamp: 1678317458652
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
-  sha256: 51556902e09436d46878ef772805d06416ca96ffaa66340b5565c0245574aaf5
-  md5: 4cb1b20635cf5431d34cc96ca1e8a751
-  depends:
-  - cffi >=1.0.1
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 33355
-  timestamp: 1678317111825
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-14.0.2-h3ade35f_1.tar.bz2
-  sha256: f5480f3e450648a37debe91d0218007a976e4b046fafc8956a7351c2a20f83ec
-  md5: 2079b1125e4344044941008a444ff201
-  depends:
-  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
-  - aws-sdk-cpp >=1.10.55,<1.10.56.0a0
-  - brotli
-  - bzip2 >=1.0.8,<2.0a0
-  - gflags
-  - glog >=0.5.0,<0.6.0a0
-  - grpc-cpp >=1.48.2,<1.49.0a0
-  - libbrotlicommon >=1.0.9,<1.1.0a0
-  - libbrotlidec >=1.0.9,<1.1.0a0
-  - libbrotlienc >=1.0.9,<1.1.0a0
-  - libcxx >=14.0.6
-  - libprotobuf >=3.20.3,<3.21.0a0
-  - libthrift >=0.15.0,<0.16.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - openssl >=3.0.13,<4.0a0
-  - orc >=1.7.4,<1.7.5.0a0
-  - re2 >=2022.4.1,<2022.4.2.0a0
-  - snappy >=1.1.9,<2.0a0
-  - utf8proc >=2.6.1,<2.9.0
-  - zlib >=1.2.13,<1.3.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 10268727
-  timestamp: 1707253751856
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/async-lru-2.0.4-py311hecd8cb5_0.tar.bz2
-  sha256: e6fb3357ab4e25e2e839a28def6450035a291c094ff91d4129fcdbb58f2bbe48
-  md5: d1d0d5703fa8c45784265d8dccf01334
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 21499
-  timestamp: 1699554645746
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
-  sha256: 188b74f717e3ce3595da404c0e027b8ccafa9c186e88325e8f02c29d7b4c0744
-  md5: 04ad90eead5812a0263b42321056ab33
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 153694
-  timestamp: 1695717975427
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
-  sha256: a153eee37b30ca5c25c5c95463a8852f1cf62a8f45f73349e68f1e3b22eec6da
-  md5: 4bf760fad0e938618391f0db249d00e1
-  depends:
-  - aws-c-cal >=0.5.20,<0.5.21.0a0
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-http >=0.6.25,<0.6.26.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 87236
-  timestamp: 1706746160841
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
-  sha256: 04ec5908b1dc2979ed50923af90d02da8a60434658efbc4f35fc61e7e9cafa0b
-  md5: 6ba283b7f902226f232fe8a32fa83ee4
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 37547
-  timestamp: 1706690917050
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
-  sha256: 08431c5ec5f0a9e95819b6a76c9cc870d2154e46b229431fd0b3dad25bb70b04
-  md5: 78b4b4225fdefef0b9b0d56b6e51e4a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 184146
-  timestamp: 1706189913777
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
-  sha256: 6a78705375d837a0eeeff9e914aae53a0d2cd44e9760075bdd8711a05f94ff3f
-  md5: 931b0654ae05bcd1acc760dc830b89d3
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 17410
-  timestamp: 1706690854689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
-  sha256: 1d468f7c085b73cc40f813885d77a74270f94dd973b4285546d8873030fcada7
-  md5: 3a61760bb61f85b3a0ffe7b14058801f
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  - aws-checksums >=0.1.13,<0.1.14.0a0
-  - libcxx >=14.0.6
-  license: Apache-2.0
-  license_family: Apache
-  size: 46197
-  timestamp: 1706697276616
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
-  sha256: b53432aadb2ffe2f1c584c6994b665f3620f29c51b200b03282065a480cf021e
-  md5: 9686f32b210a009048c0877ac39fe88c
-  depends:
-  - aws-c-cal >=0.5.20,<0.5.21.0a0
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-compression >=0.2.16,<0.2.17.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 164397
-  timestamp: 1706744140750
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
-  sha256: 2ff9632eb2e2c7a70b8d64988e530d842fe5fa7fa529d34cda19f76fb40582e2
-  md5: ffbd1ff65fe9fb52d833af5d396b006d
-  depends:
-  - aws-c-cal >=0.5.20,<0.5.21.0a0
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 125589
-  timestamp: 1706696187075
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
-  sha256: fa57f1d2b2eb56db72e4b54348452af67a1222bd4266b3d68c7b7ff00399743b
-  md5: ae9e78f6b1fef841fc0ffc7ef7c78d26
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-http >=0.6.25,<0.6.26.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 61379
-  timestamp: 1706746740037
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
-  sha256: 00834bd876756f1f13333c31623c2bdfa7d901b40aec161cf0343548fcd96187
-  md5: 4ef080b5a91e260d51d563218396d0f6
-  depends:
-  - aws-c-auth >=0.6.19,<0.6.20.0a0
-  - aws-c-cal >=0.5.20,<0.5.21.0a0
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-http >=0.6.25,<0.6.26.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  - aws-checksums >=0.1.13,<0.1.14.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 67408
-  timestamp: 1706747579372
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
-  sha256: fb3198a05c96030d8498a5c4873e56ae28a5b04fb904a5c696a2192e9ee6c45b
-  md5: 48efeda1471a50b9481c3943a0300e86
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 48055
-  timestamp: 1706690833951
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
-  sha256: f05fb72b1a5f25fab65ef416ff0d1966e3ff84f8a08c56bf809fb602028c66ec
-  md5: 86cda3f774047ff6b40eb14aab83215d
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 51354
-  timestamp: 1706192066535
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
-  sha256: b8cb5f96e9eab47419622795fcdb42ad414481db9b84bbb50fcf8251a1314b59
-  md5: 335265dfe12cb6adcacf39b411cf9d7a
-  depends:
-  - aws-c-auth >=0.6.19,<0.6.20.0a0
-  - aws-c-cal >=0.5.20,<0.5.21.0a0
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
-  - aws-c-http >=0.6.25,<0.6.26.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
-  - aws-c-s3 >=0.1.51,<0.1.52.0a0
-  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
-  - libcxx >=14.0.6
-  license: Apache-2.0
-  license_family: Apache
-  size: 210312
-  timestamp: 1706827788950
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.10.55-h61975a4_0.tar.bz2
-  sha256: 40911c99dfa11ad32d451ab8cb5b24f0aecde231b5f8f4e9d8887bc4a720dc65
-  md5: 1078cfa7cb12f9a0d3fb4017cc9789b9
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
-  - aws-checksums >=0.1.13,<0.1.14.0a0
-  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
-  - libcurl >=7.88.1,<9.0a0
-  - libcxx >=14.0.6
-  license: Apache-2.0
-  license_family: Apache
-  size: 2322692
-  timestamp: 1706890560060
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/babel-2.11.0-py311hecd8cb5_0.tar.bz2
-  sha256: aed8823dbb096851f6eddc345f02c23fba42decce2c584f0fe09440002c37996
-  md5: fc567742fccd3b08593b1dcca16522f7
-  depends:
-  - python >=3.11,<3.12.0a0
-  - pytz >=2015.7
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 7215195
-  timestamp: 1678318116416
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
-  sha256: bf3c60386619f08cf5105b4b903bbc109b3252c3b923fe055aa445908a01969c
-  md5: 3f84a301921ec6400b7f1f1c4ba3260d
-  depends:
-  - python >=3.11,<3.12.0a0
-  - soupsieve >1.2
-  license: MIT
-  license_family: MIT
-  size: 270017
-  timestamp: 1681493109562
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
-  md5: e2f3248e2a5009a02f7b8e54f83314ef
-  size: 5620
-  timestamp: 1528121955725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
-  sha256: 126ae8e30b8464fb2dc94ce9163dcb2d5482f7214c7d8a48340c3f09f1409d5e
-  md5: d5e0c054042910b4394a14c7eb4d8131
-  depends:
-  - contourpy >=1.2
-  - jinja2 >=2.9
-  - numpy >=1.23.5,<2.0a0
-  - packaging >=16.8
-  - pandas >=1.2
-  - pillow >=7.1.0
-  - python >=3.11,<3.12.0a0
-  - pyyaml >=3.10
-  - tornado >=6.2
-  - xyzservices >=2021.09.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6080356
-  timestamp: 1712084675745
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
-  sha256: 81102f2762d8eb2f07c69fbf7ca7dad879a257a053085492d4c1b4006eb35fb8
-  md5: 3c42777bc9330fe91177ea813b9ec252
-  depends:
-  - libboost 1.82.0 hf53b9f2_2
-  - libcxx >=14.0.6
-  license: BSL-1.0
-  license_family: OTHER
-  size: 11744
-  timestamp: 1696762233693
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
-  sha256: 9acafafcaebd653c2372ddc864525722e1c55b884b5eba22e28e2b2d946b853c
-  md5: 22375cc3c2edada31b85af56c8e6dee6
-  depends:
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 155829
-  timestamp: 1707864406086
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
-  sha256: d8b1ccb15297dcfb3f9ebb8139c3e28a13d6c2e73c37612cb214ab6cc58b15fa
-  md5: e5dec9f13de061640ad2697562a99b54
-  depends:
-  - brotli-bin 1.0.9 h6c40b1e_8
-  - libbrotlidec 1.0.9 h6c40b1e_8
-  - libbrotlienc 1.0.9 h6c40b1e_8
-  license: MIT
-  size: 19732
-  timestamp: 1714483415038
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
-  sha256: e9fda4393edd0234c88efc2b88e0edf42c94eb49ea5b189a80afd733058be8fb
-  md5: 13ceed558eb174d6b77ed1b0035f1785
-  depends:
-  - libbrotlidec 1.0.9 h6c40b1e_8
-  - libbrotlienc 1.0.9 h6c40b1e_8
-  license: MIT
-  size: 18400
-  timestamp: 1714483395748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
-  sha256: a323af3251e426962ad16edf8f46a696ef502731faf12aee32ca289c40b11342
-  md5: 658ce49e9f07dba7a1afe70fa2666e0a
-  depends:
-  - libcxx >=14.0.6
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  size: 393858
-  timestamp: 1714483549536
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
-  sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
-  md5: c5a600d81b1b48578863af2973c743ac
-  license: bzip2-1.0.8
-  license_family: BSD
-  size: 187637
-  timestamp: 1714510590009
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
-  sha256: f913b61ba3c1651b36688415cc163a5d575475f7573b543f48a80e7a5002e4bb
-  md5: f11d165eaa532ce04a35382841284298
-  license: MIT
-  license_family: MIT
-  size: 107047
-  timestamp: 1693902034820
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
-  sha256: 0c5f9766aa2dcc08ae71b6c0102046a56b30297d0bedc3039b7f72d1658baa43
-  md5: 34583b436e62a2ce55d6a7e8eb818e33
-  license: MPL-2.0
-  license_family: Other
-  size: 138712
-  timestamp: 1710764814844
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
-  sha256: 20b1fc398e925e6c8cea6a06d3bb614e2c0de886e3f14f85b0ba26e57ff40b7e
-  md5: ac95cfe373c7fef7820e93189041b0cc
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MPL-2.0
-  license_family: Other
-  size: 166856
-  timestamp: 1707229213510
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
-  sha256: 6b5bebc13755b0a5ef423219eeecd1c25b97dbe83afad6e2552635387547d9f7
-  md5: b7bc4192fcfed7fc7df1ce00bce97b02
-  depends:
-  - libffi >=3.4,<3.5
-  - pycparser
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 291802
-  timestamp: 1714483319125
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
-  sha256: aceaa74365b0d8e69c817639393df3a713a802f40645ac0bd2f39adc871acf54
-  md5: 52191c9d4f4fcaeea39574819ab2f14f
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 204365
-  timestamp: 1698129979494
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py311hecd8cb5_0.tar.bz2
-  sha256: 53099bea1cdfeac00bf4bf48e7c3321424af31b9726a7f67033ed06e5d924f04
-  md5: 0302e97edbd24e02df7609a6072dc569
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 50495
-  timestamp: 1683040190091
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
-  sha256: 389c63a84b92a6254c9d361ebe970d537d0b88733efd5ac5c3ee58196fd2c5a9
-  md5: c7bc5b3cbe76be83a27f00b7e4740727
-  depends:
-  - python >=3.11,<3.12.0a0
-  - traitlets >=4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 17974
-  timestamp: 1709323004148
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
-  sha256: bebfc5aa6be12e61a134b580b07b67f7d8c045d6b113fca5b21fa1e83a2f03ce
-  md5: 239df72a3921c951059fa8afc09643f6
-  depends:
-  - libcxx >=14.0.6
-  - numpy >=1.20,<2
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 287736
-  timestamp: 1700583644534
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cramjam-2.7.0-py311h9c86198_0.tar.bz2
-  sha256: f480b0ed7a98e682d8cbdaeef697116a0d839cee08ec8b5f39078c4e056ec29b
-  md5: 7712882f644fca2ccd169ce2dee2b4d9
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 1473015
-  timestamp: 1702651642047
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.2-py311h6c40b1e_0.tar.bz2
-  sha256: fd7bceb92f6c43c6b064a1258a33c441b3b39cd08883cb73204f8d0692b709fc
-  md5: 37f8b661d31327b8dff70a4cfa63cd5b
-  depends:
-  - python >=3.11,<3.12.0a0
-  - toolz >=0.10.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 390733
-  timestamp: 1701729666753
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-2023.11.0-py311hecd8cb5_0.tar.bz2
-  sha256: 663a4919f8c466b40f14ed170f378810a7202d8e689b2255d5de6454e1615b76
-  md5: 539835b03a005340a14df14b7963e099
-  depends:
-  - bokeh >=2.4.2
-  - cytoolz >=0.12.0
-  - dask-core 2023.11.0.*
-  - distributed 2023.11.0.*
-  - jinja2 >=2.10.3
-  - lz4 >=4.3.2
-  - numpy >=1.21,<2.0a0
-  - pandas >=1.3
-  - pyarrow >=7.0
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6016
-  timestamp: 1701444967158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.11.0-py311hecd8cb5_0.tar.bz2
-  sha256: 45a9f823c8e031b1bc78639206ff4e235ce7de67da9b991724316d00075393b0
-  md5: 9d10bc7c171e384a536f9f121d964fe7
-  depends:
-  - click >=8.1
-  - cloudpickle >=1.5.0
-  - fsspec >=2021.09.0
-  - importlib-metadata >=4.13.0
-  - packaging >=20.0
-  - partd >=1.2.0
-  - python >=3.11,<3.12.0a0
-  - pyyaml >=5.3.1
-  - toolz >=0.10.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 3027866
-  timestamp: 1701396257640
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
-  sha256: e0e30590a78d99d51445ac4f668aefe1bf20025a35bdbac00f04647b95c9f152
-  md5: bd0db635eefeea82a0c567b39c9a0e3d
-  depends:
-  - libcxx >=14.0.6
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 2485698
-  timestamp: 1690905283575
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2023.11.0-py311hecd8cb5_0.tar.bz2
-  sha256: e1572994d0a7c6da827b31734426cf87b3462d2707e316afc04d78aee28bfe8d
-  md5: e2935cb332d1a784b85339113f4c8273
-  depends:
-  - click >=8.0
-  - cloudpickle >=1.5.0
-  - dask-core 2023.11.0.*
-  - jinja2 >=2.10.3
-  - locket >=1.0.0
-  - msgpack-python >=1.0.0
-  - packaging >=20.0
-  - psutil >=5.7.2
-  - python >=3.11,<3.12.0a0
-  - pyyaml >=5.3.1
-  - sortedcontainers >=2.0.5
-  - tblib >=1.6.0
-  - toolz >=0.10.0
-  - tornado >=6.0.4
-  - urllib3 >=1.24.3
-  - zict >=3.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1788385
-  timestamp: 1701398185617
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-2023.8.0-py311hb3a5e46_0.tar.bz2
-  sha256: 4a4dc4955ebb563653b6e8fe8ccd17f7ef0ce17c29d09cc09d4e62a43241bb8e
-  md5: 765d7542be413e1b31e9a6d5b9ca9829
-  depends:
-  - cramjam >=2.3.0
-  - fsspec
-  - numpy >=1.23.5,<2.0a0
-  - packaging
-  - pandas >=1.5.0
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 570485
-  timestamp: 1696541803957
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
-  sha256: 54645c22fabc25b632114d1d3c403a6fad9149b51ab36719b2690a084f14a072
-  md5: a8ad2f4abfb2e17ecf6e596342528156
-  depends:
-  - brotli >=1.0.1
-  - python >=3.11,<3.12.0a0
-  - unicodedata2 >=15.1.0
-  constrains:
-  - zopfli >=0.1.4
-  - fs >=2.2.0,<3
-  - lz4 >=1.7.4.2
-  - uharfbuzz >=0.23.0
-  - lxml >=4.0
-  - skia-pathops >=0.5.0
-  license: MIT
-  license_family: MIT
-  size: 3180691
-  timestamp: 1713551771692
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
-  md5: 9a52880a01116b72d3e7b98d685abf67
-  depends:
-  - libpng >=1.6.37,<1.7.0a0
-  - zlib >=1.2.13,<1.3.0a0
-  license: GPL-2-only and LicenseRef-FreeType
-  license_family: Other
-  size: 924929
-  timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.3.1-py311hecd8cb5_0.tar.bz2
-  sha256: 296e72c622f7014041055d8c7b602385ad10893aa1c0b600248c95e7d116dfa9
-  md5: 93d5cc02fe01e3b396f02df0ca682a79
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 365534
-  timestamp: 1714461741656
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
-  sha256: 3c7aa54548409f9343e891820ea43c195b5e4e4dce6b761bc3ae9f6c8be0fc86
-  md5: ed9629d6dc1612ec425eb8d27478b0f6
-  depends:
-  - libcxx >=14.0.6
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 140316
-  timestamp: 1706888243476
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
-  sha256: aed47f9ca4dd140b9c8a183e53d4b89eba84a20041d2038983cdfea8096104ef
-  md5: c0d981d7d43eaad55950ff5e57206e70
-  depends:
-  - gflags >=2.2.2,<2.3.0a0
-  - libcxx >=14.0.6
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 97828
-  timestamp: 1706895273858
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/grpc-cpp-1.48.2-hbe2b35a_4.tar.bz2
-  sha256: 5d69cd8a1582c5062ed6753ee9ba403cee89d89f6e1628bcaba823a33a92a186
-  md5: c37d24f6749355412dabe28bd64ce229
-  depends:
-  - abseil-cpp >=20230802.0,<20230802.1.0a0
-  - c-ares >=1.19.1,<2.0a0
-  - libcxx >=14.0.6
-  - libprotobuf >=3.20.3,<3.20.4.0a0
-  - libprotobuf >=3.20.3,<3.21.0a0
-  - openssl 3.*
-  - openssl >=3.0.12,<4.0a0
-  - re2 >=2022.4.1,<2022.4.2.0a0
-  - zlib >=1.2.13,<1.3.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3994389
-  timestamp: 1701983483827
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/gtest-1.14.0-ha357a0b_0.tar.bz2
-  sha256: edfb65219af41d5037b6371c6b074c8372db90b17d25f85f55e36523c01949ec
-  md5: f21a88869091d6d4d88b9b5f064a3157
-  depends:
-  - libcxx >=14.0.6
-  constrains:
-  - gmock 1.14.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 400287
-  timestamp: 1692633607623
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
-  sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
-  md5: f3ce6fe6eb760c236e5f7d04df5faa81
-  depends:
-  - libcxx >=14.0.6
-  license: MIT
-  license_family: MIT
-  size: 28138484
-  timestamp: 1692293212596
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
-  sha256: 5c2458964157fe493ca18c513c693b70cb622087e5fa0c93e65fc45217edd811
-  md5: 15629e52625221b51a443cefd9501d12
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 148522
-  timestamp: 1714398885844
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
-  sha256: 5a17849341e4d43fc6aff44486425852c16dee6e1cbcab1ed3f2167350f55359
-  md5: 445ac9df262ad2dcd86246a9ba5654b2
-  depends:
-  - python >=3.11,<3.12.0a0
-  - zipp >=0.5
-  license: Apache-2.0
-  license_family: APACHE
-  size: 51118
-  timestamp: 1704813615186
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
-  sha256: e0127f50d444bf4474e8df07d602c7f6dd38690e8bb3fb28817c164940ffcde1
-  md5: 583fcd7060cad6a77074d00d9ef62f44
-  depends:
-  - libcxx >=14.0.6
-  license: LicenseRef-ProprietaryIntel
-  license_family: Proprietary
-  size: 731417
-  timestamp: 1699647668990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
-  sha256: eb58fa29b1ce9aa5fc774d4c466696457695dec3b206456614b4c9cac0a94e42
-  md5: 3d3291ff58dff83dcd40ec54b435f4d2
-  depends:
-  - appnope
-  - comm >=0.1.1
-  - debugpy >=1.6.5
-  - ipython >=7.23.1
-  - jupyter_client >=6.1.12
-  - jupyter_core >=4.12,!=5.0.*
-  - matplotlib-inline >=0.1
-  - nest-asyncio
-  - packaging
-  - psutil
-  - python >=3.11,<3.12.0a0
-  - pyzmq >=24
-  - tornado >=6.1
-  - traitlets >=5.4.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 229910
-  timestamp: 1705934029588
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
-  sha256: 73aa7662c00c73bab2dafefefc87a1b524961d2687410af624ecbd6703e483f3
-  md5: 7e71e99766107a553752ed8f22b61cf0
-  depends:
-  - decorator
-  - jedi >=0.16
-  - matplotlib-inline
-  - pexpect >4.3
-  - prompt_toolkit >=3.0.41,<3.1.0
-  - pygments >=2.4.0
-  - python >=3.11,<3.12.0a0
-  - stack_data
-  - traitlets >=5
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1611976
-  timestamp: 1704833049616
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
-  sha256: e08cda2bcbdec124c63e951eb248c503bb1467c2a6000010c6bdc0726e0e00b7
-  md5: 22c24f43b82da8b3920a913bbf452421
-  depends:
-  - parso >=0.8.0,<0.9.0
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 1168968
-  timestamp: 1679336359851
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
-  sha256: 3b262312f1fc76e490c067408771da0a12c7691379cddc3c86121255cda7a41d
-  md5: cbf00a1bc151243cb6a33524b62f3663
-  depends:
-  - markupsafe >=2.0
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 353280
-  timestamp: 1706733664000
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
-  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
-  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
-  license: IJG
-  license_family: Other
-  size: 278924
-  timestamp: 1677849185191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
-  sha256: 99fc6ac82c56eb2a580f96db24a5b887f8abc8c24af445d3313d5ebb48598478
-  md5: 71892160908a6daedb5fb7c404079ae4
-  depends:
-  - attrs >=22.2.0
-  - jsonschema-specifications >=2023.03.6
-  - python >=3.11,<3.12.0a0
-  - referencing >=0.28.4
-  - rpds-py >=0.7.1
-  license: MIT
-  license_family: MIT
-  size: 182073
-  timestamp: 1699041732321
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
-  sha256: 0ea44d0c8044e70ab0eaf4d6f5f3e4753838dee106b5cbd36561e21a65cbac77
-  md5: 1d045016dca889d702f1caf3a16162fc
-  depends:
-  - python >=3.11,<3.12.0a0
-  - referencing >=0.28.0
-  license: MIT
-  license_family: MIT
-  size: 16528
-  timestamp: 1699032525791
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter-lsp-2.2.0-py311hecd8cb5_0.tar.bz2
-  sha256: 9f7e13e4b84794cc99f78e0513157be30b9c9b039c413a90c03583304b7edeba
-  md5: a76eeb3f746de2b0282bbf9872ac1e8d
-  depends:
-  - jupyter_server >=1.1.2
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 101678
-  timestamp: 1699978325870
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-8.6.0-py311hecd8cb5_0.tar.bz2
-  sha256: 7e100bfb19e640dd312cdb921155f67c52675cf128d1aef2f3e975d30f3171a8
-  md5: 08bbf3e56f89bc800fda1eeb998a0d1d
-  depends:
-  - jupyter_core >=4.12,!=5.0.*
-  - python >=3.11,<3.12.0a0
-  - python-dateutil >=2.8.2
-  - pyzmq >=23.0
-  - tornado >=6.2
-  - traitlets >=5.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 222285
-  timestamp: 1699456395712
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
-  sha256: 8601c674f4779900f6a949e47b814be68b722b0b3d394433bec9d197924ebd69
-  md5: b8423f8caff3041a251fc3681f43496a
-  depends:
-  - platformdirs >=2.5
-  - python >=3.11,<3.12.0a0
-  - traitlets >=5.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 94990
-  timestamp: 1698937583196
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
-  sha256: 6a430c812ce0415a04d9cfe6c66d9012eced2d91c04960c88bc8ec1e9f1b5d6d
-  md5: 30b3d5d6a8cf5d1604e5f5fb177917b5
-  depends:
-  - jsonschema >=4.18.0
-  - python >=3.11,<3.12.0a0
-  - python-json-logger >=2.0.4
-  - pyyaml >=5.3
-  - referencing
-  - rfc3339-validator
-  - rfc3986-validator >=0.1.1
-  - traitlets >=5.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 42513
-  timestamp: 1699282637015
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
-  sha256: c2d206db117f7161e77236ebd6b0051fc73e1731c242d1e08597d736a0376c92
-  md5: bdb61de2e20e02c93423d9de091c74ad
-  depends:
-  - anyio >=3.1.0
-  - argon2-cffi
-  - jinja2
-  - jupyter_client >=7.4.4
-  - jupyter_core >=4.12,!=5.0.*
-  - jupyter_events >=0.6.0
-  - jupyter_server_terminals
-  - nbconvert >=6.4.4
-  - nbformat >=5.3.0
-  - overrides
-  - packaging
-  - prometheus_client
-  - python >=3.11,<3.12.0a0
-  - pyzmq >=24
-  - send2trash >=1.8.2
-  - terminado >=0.8.3
-  - tornado >=6.2.0
-  - traitlets >=5.6.0
-  - websocket-client
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 601837
-  timestamp: 1699466514455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
-  sha256: fd7964657f0a8fe8b167ba860b1f960e8b7b45309eb6c7c850d50ec283fe03b5
-  md5: 2967bb345bc75f53182e263ff4743ca6
-  depends:
-  - python >=3.11,<3.12.0a0
-  - terminado >=0.8.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 28223
-  timestamp: 1686870845224
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab-4.0.11-py311hecd8cb5_0.tar.bz2
-  sha256: ad199926171ef67c2e96e7c603c7dc6c96e25a23deb9979f1c910616df8e8b48
-  md5: d749db644752070354a015015fd1a102
-  depends:
-  - async-lru >=1.0.0
-  - ipykernel
-  - jinja2 >=3.0.3
-  - jupyter-lsp >=2.0.0
-  - jupyter_core
-  - jupyter_server >=2.4.0,<3
-  - jupyterlab_server >=2.19.0,<3
-  - notebook-shim >=0.2
-  - packaging
-  - python >=3.11,<3.12.0a0
-  - tornado >=6.2.0
-  - traitlets
-  constrains:
-  - nodejs >=18.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6618991
-  timestamp: 1706803097395
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_server-2.25.1-py311hecd8cb5_0.tar.bz2
-  sha256: 557bd1a8ff0502191adb3ff3af74b54ee2ec4800d281492bd8e588ddcf095bfb
-  md5: 14c8a1959a83eff470adc09cc65bdb57
-  depends:
-  - babel >=2.10
-  - jinja2 >=3.0.3
-  - json5 >=0.9.0
-  - jsonschema >=4.18.0
-  - jupyter_server >=1.21,<3
-  - packaging >=21.3
-  - python >=3.11,<3.12.0a0
-  - requests >=2.31
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 107281
-  timestamp: 1699555527525
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
-  sha256: a12382b50416803f559a03fb384ba492c1dafa351e1191a3f8dc361bee6c4f37
-  md5: f2ae846b663bbb642f4b1e90eaad38a3
-  depends:
-  - libcxx >=14.0.6
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 64817
-  timestamp: 1678322501509
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
-  sha256: a3a24cd84c291f7c9e28842ccfc2107d149f0aa8e676b85d9104eda77622e603
-  md5: 99ba4367783596d1bb0c7766ea6706ea
-  depends:
-  - libedit >=3.1.20221030,<3.2.0a0
-  - libedit >=3.1.20221030,<4.0a0
-  - openssl >=3.0.8,<4.0a0
-  license: MIT
-  license_family: MIT
-  size: 1290758
-  timestamp: 1686931137388
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
-  md5: 819762fdace9397c0e14a9ed2dcdb829
-  depends:
-  - jpeg >=9b,<10a
-  - libtiff >=4.1.0,<4.7.0
-  license: MIT
-  license_family: MIT
-  size: 419188
-  timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
-  md5: d9e7e12a2bc017897a1a866e972a04de
-  depends:
-  - libcxx >=12.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 203852
-  timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
-  sha256: 127dbf93874f1bb3493b312fecb5ffedb8f2a41d2470e2cbeb889eb58d89ebf7
-  md5: 07502b61e43a2039e4312b40d53c1db1
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - icu >=73.1,<74.0a0
-  - libcxx >=14.0.6
-  - libiconv >=1.16,<2.0a0
-  - xz >=5.4.2,<6.0a0
-  - zlib >=1.2.13,<1.3.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  license: BSL-1.0
-  license_family: OTHER
-  size: 22584954
-  timestamp: 1696762195023
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
-  sha256: 685c3bc9068bd485604b80bf03789e4dca95c410d33871bc1b882e47649fabed
-  md5: 6cf8e55271e150ca0961d0ddedaa61bb
-  license: MIT
-  size: 66237
-  timestamp: 1714483284541
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
-  sha256: 69826cee54db9955f0120af21ec36d13f9211877fd67364f2068d0a54c6c97cd
-  md5: 0851917257f490d35e1f73da8a1c723c
-  depends:
-  - libbrotlicommon 1.0.9 h6c40b1e_8
-  license: MIT
-  size: 34042
-  timestamp: 1714483343147
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
-  sha256: 3f5a1f03b50b90b397a0ee432ad0cba13354abdaf7e5652c0fc60164b26a08b6
-  md5: a50bdc871ef4bf14deb088d888b92b5e
-  depends:
-  - libbrotlicommon 1.0.9 h6c40b1e_8
-  license: MIT
-  size: 311597
-  timestamp: 1714483371586
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.5.0-hf20ceda_0.tar.bz2
-  sha256: b34c59c148f100cfabc8a55470cc0d46f4ba2d1f90dedf516b151ca1374d2e54
-  md5: 14f3b4d1790efbf8e35a9a9259cb6e8a
-  depends:
-  - krb5 >=1.20.1,<1.21.0a0
-  - libnghttp2 >=1.57.0
-  - libnghttp2 >=1.57.0,<2.0a0
-  - libssh2 >=1.10.0
-  - libssh2 >=1.10.0,<2.0a0
-  - openssl >=3.0.12,<4.0a0
-  - zlib >=1.2.13,<1.3.0a0
-  license: curl
-  license_family: MIT
-  size: 373198
-  timestamp: 1704383716512
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
-  md5: af92f506156c9defc9b4dff41ecea1f9
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 1391293
-  timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
-  md5: 891b155ceb619a35ae6abb1fc4225aa1
-  license: MIT
-  license_family: MIT
-  size: 77959
-  timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
-  sha256: e84e6cbacb12de6fe86955449502d3956696ae583060d0d4911ea6f503cfb9ad
-  md5: 1d200c536be4172db41c49e81a3e6350
-  depends:
-  - ncurses >=6.4,<7.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 169586
-  timestamp: 1703006265367
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
-  sha256: 4786264321edbff780633a5b752995eb3193ca4bce11b0fda179577f6cf1102c
-  md5: 849fdd014c201a9d2c2aa7c7db38a778
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 103993
-  timestamp: 1632891571494
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
-  sha256: a60941a0365ee3e8b9ff721f75b0608c234b5652f53337a918b787839de4bb53
-  md5: 4d61f019594ebccfb3f4fb87ee778416
-  depends:
-  - openssl 3.*
-  - openssl >=3.0.8,<4.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 414942
-  timestamp: 1685052318462
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
-  sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
-  md5: 822a5b76117e56d3912f1f2153307528
-  license: MIT
-  license_family: MIT
-  size: 136045
-  timestamp: 1714483561919
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
-  sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
-  md5: e458587c87e3f2d20192f4e0738f2c63
-  depends:
-  - libgfortran5
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 149419
-  timestamp: 1665498987619
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
-  sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
-  md5: 1058b661ec829b2ee3716ee2a5520641
-  depends:
-  - llvm-openmp >=8.0.0
-  constrains:
-  - libgfortran 5.0.0 *_28
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 1917987
-  timestamp: 1665498925405
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
-  sha256: 9ff6ed0f0b9f9f27f449e95d11aa1c4e9e80028fd9d2a8caca5a15d8df88f435
-  md5: 7b4b557afc66aba367da14d97d71934c
-  license: GPL-3.0-or-later
-  license_family: GPL3
-  size: 1409885
-  timestamp: 1714483704680
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
-  sha256: 8176dd9a68815301a24ed51e72f3506f5f77c67a112efa0dd14971f2f3b3c8c1
-  md5: b5e470c224000a6bda6f655c155b53e7
-  depends:
-  - libcxx >=14
-  - libffi >=3.4,<3.5
-  - libffi >=3.4,<4.0a0
-  - zlib >=1.2.13,<1.3.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 27861431
-  timestamp: 1683292881730
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
-  sha256: 7bfcf69c31a4eb15dfab661c93463ce8dfb7b3de4356945fa5c1ca50a5ae0cb0
-  md5: 4934bb34818fa3d99b32b9cb59fed205
-  depends:
-  - c-ares >=1.19.1,<2.0a0
-  - c-ares >=1.7.5
-  - libcxx >=14.0.6
-  - libev >=4.11
-  - libev >=4.33,<4.34.0a0
-  - openssl >=3.0.11,<4.0a0
-  - zlib >=1.2.13,<1.3.0a0
-  license: MIT
-  license_family: MIT
-  size: 784918
-  timestamp: 1697018436251
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
-  md5: cc2688c4d0b91033ee4d9064bebfcf3d
-  depends:
-  - zlib >=1.2.13,<1.3.0a0
-  license: Zlib
-  license_family: Other
-  size: 318453
-  timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
-  sha256: 1884de5207f5a1210217d7132348b4944ec4b09a91085b7b47a19dfdd9b6dbba
-  md5: aa960ea0133deec4637a8d05700cc3c4
-  depends:
-  - libcxx >=14.0.6
-  - zlib >=1.2.13,<1.3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2412437
-  timestamp: 1675278748544
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
-  md5: b622efec408361995816c7ded7b5625a
-  license: ISC
-  size: 365163
-  timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-h04015c4_3.tar.bz2
-  sha256: 79a36c00535053704706f6520b6a69a3fc3faa5e28e7c0a1b640c29d44899761
-  md5: a44846f7c4357de50a7d43e0bd15d5a2
-  depends:
-  - openssl >=3.0.13,<4.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 291287
-  timestamp: 1714510620580
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
-  sha256: 21ba71cdc65b56c6daefeeab55959e5a7edadfd697cfa8b2ed5c1b3e2a98586b
-  md5: cbbd369ee87aba597c942727bada4eee
-  depends:
-  - boost-cpp >=1.73
-  - libcxx >=14.0.6
-  - libevent >=2.1.12,<2.1.13.0a0
-  - openssl >=3.0.9,<4.0a0
-  - zlib >=1.2.13,<1.3.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 364326
-  timestamp: 1687975317748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
-  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
-  depends:
-  - jpeg >=9e,<10a
-  - lerc >=3.0,<4.0a0
-  - libcxx >=14.0.6
-  - libdeflate >=1.17,<1.18.0a0
-  - libwebp-base >=1.2.4,<2.0a0
-  - xz >=5.2.10,<6.0a0
-  - xz >=5.2.4,<6.0a0
-  - zlib >=1.2.13,<1.3.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  license: HPND
-  license_family: Other
-  size: 642076
-  timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
-  md5: 46a65d1fc24013217e06aaf6d65ffcad
-  constrains:
-  - libwebp 1.3.2
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 425478
-  timestamp: 1694776947990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
-  sha256: d28c465ec6d5f8d4962c597b249b58998300c8b4e3c937c578c3d15294ea863d
-  md5: dcaed6ddd0723c7cce6bfad917be98b2
-  depends:
-  - python >=3.11,<3.12.0a0
-  - uc-micro-py >=1.0.1,<2.0.0
-  license: MIT
-  license_family: MIT
-  size: 41176
-  timestamp: 1678413498410
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
-  sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
-  md5: 5c740b4a18a558de0ccfe601703c423c
-  constrains:
-  - openmp 14.0.6|14.0.6.*
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 338738
-  timestamp: 1662635677689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.42.0-py311hcec6c5f_0.tar.bz2
-  sha256: 53808184421c81e661f9927ff564a0d0ecdf3b816c8aba8e2368434e055529d4
-  md5: bee10bfbe90767fcb8f8f6ab3a05d85a
-  depends:
-  - libcxx >=14.0.6
-  - libllvm14 >=14.0.6,<14.1.0a0
-  - python >=3.11,<3.12.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 407784
-  timestamp: 1706911015242
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
-  sha256: 716a654df2e55052193150015bd5c9856b847893fc5a229fa8669725b1c56ff2
-  md5: 687ba6c11de38ad7cc597f7188b491e7
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 13357
-  timestamp: 1678322560230
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-4.3.2-py311h6c40b1e_0.tar.bz2
-  sha256: e05d6b661c088efc3f7f2fc99b8faad351f7660963ca66fbe63dfc9796821eb2
-  md5: d48a23f7e388334d5e39fc36ee84441b
-  depends:
-  - lz4-c >=1.9.4,<1.10.0a0
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 37947
-  timestamp: 1686058038545
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
-  sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
-  md5: 8f57dc3a3327bb6f7e1cba908856ac7f
-  depends:
-  - libcxx >=14.0.6
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 183138
-  timestamp: 1714510756758
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
-  sha256: 6fb2953e169ee1ae38f24d29752051501992f19b96b5ebcea9af75737bdbcb42
-  md5: 7f410cdae838c5030108d1b98a8c78f6
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 162478
-  timestamp: 1678377892595
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
-  sha256: cd97e09a12ffb49b2a30a782fa8c7933b28f5ffdbfc5c73a9ebaa95fc9447370
-  md5: d1fb6ebc1e5728aa6377cfc71da08942
-  depends:
-  - mdurl >=0.1,<1
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 135859
-  timestamp: 1684280005320
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
-  sha256: 30c3b189462a9d0f4794d229adadf34b5f5a5f56f95c30d5afc17ef524579290
-  md5: d4e9421243129d1d57c472dab045f3dc
-  depends:
-  - python >=3.11,<3.12.0a0
-  constrains:
-  - jinja2 >=3.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 26639
-  timestamp: 1704206159955
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.8.4-py311hecd8cb5_0.tar.bz2
-  sha256: 1324e1dd44723b6ba80c4cc7128b85471542cb8d60b1c7757511e56e8e2171e1
-  md5: b33ffac0fcab742473262ddb0c5ad74b
-  depends:
-  - matplotlib-base >=3.8.4,<3.8.5.0a0
-  - python >=3.11,<3.12.0a0
-  - tornado >=5
-  license: LicenseRef-PSF-based
-  license_family: PSF
-  size: 8970
-  timestamp: 1713336829689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
-  sha256: 080000a28b3ceca54eec6de0748c690ea5a4c390e358283eac03fe7a6dd87065
-  md5: 51344eca57d7940fb01eb5e8914509e3
-  depends:
-  - __osx >=10.12
-  - contourpy >=1.0.1
-  - cycler >=0.10
-  - fonttools >=4.22.0
-  - freetype >=2.10
-  - freetype >=2.10.4,<3.0a0
-  - kiwisolver >=1.3.1
-  - libcxx >=14.0.6
-  - numpy >=1.23.5,<2.0a0
-  - packaging >=20.0
-  - pillow >=8
-  - pyparsing >=2.3.1,<3.1
-  - python >=3.11,<3.12.0a0
-  - python-dateutil >=2.7
-  license: LicenseRef-PSF-based
-  license_family: PSF
-  size: 9099909
-  timestamp: 1713336790553
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
-  sha256: 07e7fd5bd64e55328b4b99d92e2e2600d791f1095bf905daab4cfc59f0f0a45b
-  md5: cf53321779f4ca7e986c1468719b93f1
-  depends:
-  - python >=3.11,<3.12.0a0
-  - traitlets
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 19500
-  timestamp: 1678317565001
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
-  sha256: 0770e02be1ea1216af493cfc03d5b8a702e14606fa93b0692bcdab1fed1b898c
-  md5: ca6f06ceaf66a32bbf5dfdb6e373a5cf
-  depends:
-  - markdown-it-py >=1.0.0,<3.0.0
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 67892
-  timestamp: 1678417734353
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
-  sha256: fbe95ed0501bb0f137048476fe41bc718dd659e8ecb066bc67ac17d6a50f4318
-  md5: ec162bde8d1c8a107b257df218b17035
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 23030
-  timestamp: 1678381838497
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
-  sha256: c20dd678655e582129a858a1c5162bdc254082d3a3c035b0f72629d9276e5b75
-  md5: 800a0738c728796e02d0386ce7d457aa
-  depends:
-  - python >=3.11,<3.12.0a0
-  constrains:
-  - nbconvert >6.1.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 104585
-  timestamp: 1678317269407
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
-  sha256: c825bc3070f73318ffff88a7a0b7fc6d1858b058ced735efd1789053f1583918
-  md5: dea5f96459c9a6df6b026ca57d387936
-  depends:
-  - intel-openmp 2023.*
-  - libcxx >=14.0.6
-  - tbb 2021.*
-  constrains:
-  - __osx >=10.13
-  license: LicenseRef-ProprietaryIntel
-  license_family: Proprietary
-  size: 224299920
-  timestamp: 1699647835748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
-  sha256: a76c134ec258612ff7d55cb2a19b9e3461cbbd375a744bd29390af9cfcd283b2
-  md5: 1c736f58992009f53f014aef163bae31
-  depends:
-  - mkl >=2023.1.0,<2024.0a0
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 48442
-  timestamp: 1682969160267
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
-  sha256: bcfb0d1e075d043bcf05fa1a7ce3c142bf222d29693366af49a5a346c770812f
-  md5: 59e4820b34049cbc6619a8ac97290abc
-  depends:
-  - blas 1.0 mkl
-  - mkl >=2023.1.0,<2024.0a0
-  - mkl-service >=2.3.0,<3.0a0
-  - numpy <2.0a0
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 222137
-  timestamp: 1695058350477
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
-  sha256: 114e408c40b332393cf2792393e4d1ede3465abcb3d345fe647ee519565346c8
-  md5: 86b13271578e1fa5e664edcf6fcb3ce4
-  depends:
-  - libcxx >=14.0.6
-  - mkl >=2023.1.0,<2024.0a0
-  - mkl-service >=2.3.0,<3.0a0
-  - python >=3.11,<3.12.0a0
-  - blas * mkl
-  - numpy <2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 296860
-  timestamp: 1695059990370
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py311ha357a0b_0.tar.bz2
-  sha256: 7517bb3a1337287e71ba182e23654f49275048389a1a3c6d750dc580caf4aaed
-  md5: 5466d265b312c4ff0ff4969ebf15c0ce
-  depends:
-  - libcxx >=14.0.6
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 37529
-  timestamp: 1678318290205
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
-  sha256: 638450a7ccb5f438ac65aa1c8d871fb5bb664e7261ec7e663d0302485c219a67
-  md5: 574875bbeabff85b5d9cfdb62066aece
-  depends:
-  - python >=3.11,<3.12.0a0
-  - six
-  license: BSD 3-Clause
-  license_family: BSD
-  size: 29473
-  timestamp: 1678392919304
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
-  sha256: e08cb3ee6df01f4c1e1ac8bc4ed1a06e549ffcc8774fe2e2842c644bb8f74a86
-  md5: 6ba0ae0fb14cbea1e3197707701dc180
-  depends:
-  - jupyter_client >=6.1.12
-  - jupyter_core >=4.12,!=5.0.*
-  - nbformat >=5.1
-  - python >=3.11,<3.12.0a0
-  - traitlets >=5.4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 123077
-  timestamp: 1698934356774
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
-  sha256: 2f946b5042eaac97206b5217fb203f3604ab3a60aecd99bdfc684925e3136c18
-  md5: b24026076c381ff2009e7acb9e0a6e87
-  depends:
-  - beautifulsoup4
-  - bleach !=5.0.0
-  - defusedxml
-  - jinja2 >=3.0
-  - jupyter_core >=4.7
-  - jupyterlab_pygments
-  - markupsafe >=2.0
-  - mistune >=2.0.3,<4
-  - nbclient >=0.5.0
-  - nbformat >=5.7
-  - packaging
-  - pandocfilters >=1.4.1
-  - pygments >=2.4.1
-  - python >=3.11,<3.12.0a0
-  - tinycss2
-  - traitlets >=5.1
-  constrains:
-  - tornado >=6.1
-  - pyqtwebengine >=5.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 534650
-  timestamp: 1699022791300
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
-  sha256: ba368605a0af6f1dcbdcb6fddab9ce63224a85dd11bfb2b1acace1dc17899411
-  md5: 91f3ea3fe44d619ee95a6ed3773a0814
-  depends:
-  - jsonschema >=2.6
-  - jupyter_core
-  - python >=3.11,<3.12.0a0
-  - python-fastjsonschema
-  - traitlets >=5.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 170926
-  timestamp: 1694616830121
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
-  md5: 20344bea303e2aff2796ee9963c12c7d
-  license: MIT AND X11
-  license_family: MIT
-  size: 1100911
-  timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
-  sha256: 42d803e1d8b54748db5d989ecd503826f564132df7cddc20f520460f55e523a1
-  md5: cd3fa71626ebc098da4625fc6be79752
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 16952
-  timestamp: 1708532805951
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-7.0.8-py311hecd8cb5_0.tar.bz2
-  sha256: 08457eb26f6e84a25bbf413be70cd91274819e526f90ecdc859ee84af0b3491f
-  md5: a424f09e1db7fc2c399ce807e01c3713
-  depends:
-  - jupyter_server >=2.4.0,<3
-  - jupyterlab >=4.0.2,<4.1
-  - jupyterlab_server >=2.22.1,<3
-  - notebook-shim >=0.2,<0.3
-  - python >=3.11,<3.12.0a0
-  - tornado >=6.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 3655911
-  timestamp: 1708029925977
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
-  sha256: ed5608feb37a083d47b04203195260e801b64b5380f292cf18bb61e7ad827a2a
-  md5: daa9c1c233673b727528548454aea664
-  depends:
-  - jupyter_server >=1.8,<3
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 27607
-  timestamp: 1699456006797
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.59.1-py311hdb55bb0_0.tar.bz2
-  sha256: 733ece9d325b4baeaea505bd82be98ffe9e5f15669bf079ee4f2f15225bc70cb
-  md5: c426b5fb76b3d219a2fbfa2792684ae2
-  depends:
-  - libcxx >=14.0.6
-  - llvm-openmp >=14.0.6
-  - llvmlite >=0.42.0,<0.43.0a0
-  - numpy >=1.23.5,<1.27
-  - python >=3.11,<3.12.0a0
-  - tbb >=2021.8.0
-  constrains:
-  - cudatoolkit >=10.2
-  - numba-rvsdg 0.0.*
-  - cuda-python >=11.6
-  - scipy >=1.0
-  - tbb >=2021.6,<2022
-  - libopenblas !=0.3.6
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 6049873
-  timestamp: 1711992424576
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
-  sha256: cacba45c1eebf7d86748737717883a98cf40664231460fa41391c79f98d06f45
-  md5: 3dbfae0d5b90e77f9358564ad442ac9d
-  depends:
-  - blas 1.0 mkl
-  - libcxx >=14.0.6
-  - mkl >=2023.1.0,<2024.0a0
-  - mkl-service >=2.3.0,<3.0a0
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 165572
-  timestamp: 1696515553184
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
-  sha256: 1466c3af380b949612c79940124e426eccd59e335c205da0c00383a69358d1c0
-  md5: df6be53592d40ba7e03d6ffe349760bf
-  depends:
-  - blas 1.0 mkl
-  - libcxx >=14.0.6
-  - mkl >=2023.1.0,<2024.0a0
-  - mkl-service >=2.3.0,<3.0a0
-  - mkl_fft
-  - mkl_random
-  - numpy-base 1.26.4 py311h53bf9ac_0
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 11330
-  timestamp: 1708639985606
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
-  sha256: ace67d704fa7eea1480eb463f2d91bfc161be2ee20263c5a9939805ae3c2a9da
-  md5: ec124589478fa12fba4f35f31c3a0692
-  depends:
-  - blas 1.0 mkl
-  - libcxx >=14.0.6
-  - mkl >=2023.1.0,<2024.0a0
-  - mkl-service >=2.3.0,<3.0a0
-  - python >=3.11,<3.12.0a0
-  constrains:
-  - numpy 1.26.4 py311h728a8a3_0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 8783230
-  timestamp: 1708639945646
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
-  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
-  md5: 93f5d7b66976154adeda219bea02ba45
-  depends:
-  - libcxx >=10.0.0
-  - libpng >=1.6.37,<1.7.0a0
-  - libtiff >=4.1.0,<4.7.0
-  license: BSD 2-Clause
-  size: 484257
-  timestamp: 1630093862501
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_1.tar.bz2
-  sha256: 14ee32164041ac8b077d487596d2a794391340a066ffae780176d8338da23e46
-  md5: 7d1bfacd50d591c536988670811e7bd2
-  depends:
-  - ca-certificates
-  license: Apache-2.0
-  license_family: Apache
-  size: 4982212
-  timestamp: 1714511433472
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-1.7.4-h995b336_1.tar.bz2
-  sha256: 281d5a10e7a0a25bd6ee20d1d0f03530dd90fe5b4e3490ad3f33f0367df36f7c
-  md5: 062f9bba1d43123d02c60d23a29831a1
-  depends:
-  - libcxx >=14.0.6
-  - libprotobuf >=3.20.3,<3.21.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - snappy >=1.1.9,<2.0a0
-  - zlib >=1.2.13,<1.3.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 425422
-  timestamp: 1676482778334
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
-  sha256: 8a0809f419065e014cb8e2c8a516cadca6088fb71fd1ef3ae2287d91e3360d59
-  md5: 4dc0b9bc88476fcc5246d823ff1c289a
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 39645
-  timestamp: 1699371213055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
-  sha256: 64fbbb03570788298d8b04d4ea6cb254fef5d5eec73265aeecd72cb565617f4d
-  md5: 4b1195028bc26257df43fdd943638266
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0 or BSD-2-Clause
-  license_family: Apache
-  size: 159450
-  timestamp: 1710811009212
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
-  sha256: 6abb7e0aeda0130f54925421900772e1bc46d1f04ae69ce1376524457686d49f
-  md5: 232a6370c3fab0c41c6d4c7339e778ca
-  depends:
-  - bottleneck >=1.3.6
-  - libcxx >=14.0.6
-  - numexpr >=2.8.4
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python-dateutil >=2.8.2
-  - python-tzdata >=2022.7
-  - pytz >=2020.1
-  constrains:
-  - xarray >=2022.12.0
-  - xlrd >=2.0.1
-  - pytables >=3.8.0
-  - qtpy >=2.3.0
-  - scipy >=1.10.0
-  - adbc-driver-sqlite >=0.8.0
-  - pyqt >=5.15.9
-  - fastparquet >=2022.12.0
-  - pyxlsb >=1.0.10
-  - gcsfs >=2022.11.0
-  - matplotlib-base >=3.6.3
-  - tabulate >=0.9.0
-  - xlsxwriter >=3.0.5
-  - html5lib >=1.1
-  - python-calamine >=0.1.7
-  - pandas-gbq >=0.19.0
-  - odfpy>=1.4.1
-  - pyreadstat >=1.2.0
-  - dataframe-api-compat >=0.1.7
-  - beautifulsoup4 >=4.11.2
-  - lxml >=4.9.2
-  - sqlalchemy >=2.0.0
-  - jinja2 >=3.1.2
-  - s3fs >=2022.11.0
-  - psycopg2 >=2.9.6
-  - openpyxl >=3.1.0
-  - fsspec >=2022.11.0
-  - adbc-driver-postgresql >=0.8.0
-  - numba >=0.56.4
-  - blosc >=1.21.3
-  - pymysql >=1.0.2
-  - zstandard >=0.19.0
-  - pyarrow >=10.0.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 17296294
-  timestamp: 1709591285369
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
-  sha256: 359b31da651ee35b9ca43974d26cd44e64f3cf412096c15dec7b720fa909a9b2
-  md5: 108e24227f8fdfc4d635bb4eedfa6cef
-  depends:
-  - locket
-  - python >=3.11,<3.12.0a0
-  - toolz
-  constrains:
-  - numpy >= 1.9.0
-  - pandas >=0.19.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 48504
-  timestamp: 1698702608965
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
-  sha256: 90efc71d35ab62d5b8d7b648e016444e1c4c8b83238b6dc9f2c6c3db4b14c599
-  md5: 6b6eeb0a14c5479db1dd39aa8d338150
-  depends:
-  - freetype >=2.10.4,<3.0a0
-  - jpeg >=9e,<10a
-  - lcms2 >=2.12,<3.0a0
-  - libtiff >=4.2.0,<4.7.0
-  - libwebp-base >=1.3.2,<2.0a0
-  - openjpeg >=2.3.0,<3.0a0
-  - python >=3.11,<3.12.0a0
-  - zlib >=1.2.13,<1.3.0a0
-  license: HPND AND TCL
-  license_family: Other
-  size: 939480
-  timestamp: 1714399174883
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3.1-py311hecd8cb5_0.tar.bz2
-  sha256: 62866ff6b1a021bde2758b97004ed1903fe34744be4ae8f2a0f7cd3113a45d72
-  md5: 1b9b2e51a171bc752955f3592e596184
-  depends:
-  - python >=3.11,<3.12.0a0
-  - setuptools
-  - wheel
-  license: MIT
-  license_family: MIT
-  size: 3454892
-  timestamp: 1700667869320
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
-  sha256: 81719c31101d6c019150cedcc7b08adb3bdb357e8b2952e428dadaabc4dc985d
-  md5: 105825168e0a17fb007f60b5f314e311
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 38405
-  timestamp: 1692205731769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
-  sha256: c0982f688127129e026d2b4cdacdd5684d00796ea7bdadd7d26b1101b095d723
-  md5: 0d6910c74729fede645c010110f1c89e
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 121796
-  timestamp: 1679340253537
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
-  sha256: e32843723b10ecd9badde28e1085419c0b59ed8a96c7cacce6395e39e3a874f9
-  md5: 5af0280a817d2c273304cd22328124af
-  depends:
-  - python >=3.11,<3.12.0a0
-  - wcwidth
-  constrains:
-  - prompt_toolkit 3.0.43
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 763044
-  timestamp: 1704404460779
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
-  sha256: 117a435c2473e2a20cc81eaacb2b45ea5e7fe3c946eec2915936d344913ede44
-  md5: 0f459ee59fda20e2077fdc2c777edfc8
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 497470
-  timestamp: 1679337286052
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-14.0.2-py311h2a249a5_0.tar.bz2
-  sha256: 7ed49e248ab0fbfaea3a170c8f795e7de8ba372bfad16f53e60500b10d5ca648
-  md5: 9917697f50ec91d18d43cd9670ec8130
-  depends:
-  - arrow-cpp >=14.0.2,<14.0.3.0a0
-  - boost-cpp
-  - libcxx >=14.0.6
-  - numpy >=1.16.6,<2.0a0
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 5054065
-  timestamp: 1707331316454
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
-  sha256: dfb403f367c57327a4d080109df88383ecff18464de287a1ce936a7274e3656b
-  md5: 997b674bad89963af875b93b06807f51
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 2120413
-  timestamp: 1684280057020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
-  sha256: 9d2c0f373ac1c5db329581793dd517092cdf9a59140f2516ed8c3a1f483c0bbd
-  md5: ee10503a159e819abdc586666bdf0952
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 207552
-  timestamp: 1678322848766
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
-  sha256: 717e038567506ca58ce1cd4a3416892d02f4ebfdd332077cc3d110cfe3d36c58
-  md5: 53bbfb400668f798eef6f8c7cf938e1f
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD 3-Clause
-  license_family: BSD
-  size: 35751
-  timestamp: 1678315886516
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.8-hf27a42d_0.tar.bz2
-  sha256: dea2e1371f27376636d240d98eb9d2d1f383df0264b354c2d97c90b60358f9ab
-  md5: ff3603a0ff4f66a66856b3f09e29fec9
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libffi >=3.4,<3.5
-  - libffi >=3.4,<4.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.0.13,<4.0a0
-  - readline >=8.0,<9.0a0
-  - sqlite >=3.41.2,<4.0a0
-  - tk >=8.6.12,<8.7.0a0
-  - tzdata
-  - xz >=5.4.5,<6.0a0
-  - zlib >=1.2.13,<1.3.0a0
-  license: PSF-2.0
-  license_family: PSF
-  size: 16812245
-  timestamp: 1708984581993
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
-  sha256: 514249897265f66f6ecca0a4427eb02a43c33b3c24974db16d05db6bbe97881d
-  md5: c9ea1437e5a3ba6a52ec2322505203e6
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 279116
-  timestamp: 1679338758489
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
-  sha256: 78b785b9b6ed46c86b0d3a32bdceea49f816672227fb63e726b2d46eadbdba0b
-  md5: 79d783f74359141e0b06a848db33823b
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 18563
-  timestamp: 1683823935261
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py311hcec6c5f_0.tar.bz2
-  sha256: ceed2007dc80313fab055da9ad855aeff4178bfa03c16e78297fb77d058e6972
-  md5: 753c157b80f60f263e0fe6a2f8d4fc85
-  depends:
-  - libcxx >=14.0.6
-  - python >=3.11,<3.12.0a0
-  license: OLDAP-2.8
-  license_family: Other
-  size: 151925
-  timestamp: 1682522457855
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
-  sha256: e358fe679e83ccdc8c433746ae6468e8e96d90d97d99530f8476ef5630b2c121
-  md5: ce30a0a31d891e69dc9b7bf8b7f0c39c
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 268876
-  timestamp: 1713974360942
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
-  sha256: c3e11ed944da69c11b949bb918341a0d79ef603ee34a632d6a45fbf89ff924a1
-  md5: fee7ff4d291f530b4cecb575f29807a0
-  depends:
-  - python >=3.11,<3.12.0a0
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  size: 197996
-  timestamp: 1698096137432
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-25.1.2-py311hcec6c5f_0.tar.bz2
-  sha256: 9996c79c554086df5bb4e39afa822c9f71da32a461c268829a3e849c9b4f105f
-  md5: de5b99be21f6203d7577f11140c13534
-  depends:
-  - libcxx >=14.0.6
-  - python >=3.11,<3.12.0a0
-  - zeromq >=4.3.5,<4.4.0a0
-  license: BSD-3-Clause AND LGPL-3.0-or-later
-  license_family: BSD
-  size: 528098
-  timestamp: 1705605165873
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
-  sha256: c69f556df9a27328c56943f3b5918cbb953cfbca987e20394d823a6174781202
-  md5: ab294ae71ecdfaa307a961cc71dd890d
-  depends:
-  - libcxx >=12.0.0
-  license: BSD-3-Clause
-  size: 205638
-  timestamp: 1652449553607
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
-  md5: e8977fc2e69cb52f8dbb1b676d04cc45
-  depends:
-  - ncurses >=6.3,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 386061
-  timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
-  sha256: d784dc26c5de8e41845350a899e5779250b71f45d39e2aece62e739e9add7308
-  md5: 7b077b7f46112bb31dc066396c51d3fa
-  depends:
-  - attrs >=22.2.0
-  - python >=3.11,<3.12.0a0
-  - rpds-py >=0.7.0
-  license: MIT
-  license_family: MIT
-  size: 74776
-  timestamp: 1699012164201
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
-  sha256: 3357b6b327b3d0a2cc0f02934a60bbd6df38f4ea7bbb3f50cb8e21332c9f5786
-  md5: bf5e48b646e36ef2b788be9665c0e5ae
-  depends:
-  - certifi >=2017.4.17
-  - charset-normalizer >=2,<4
-  - idna >=2.5,<4
-  - python >=3.11,<3.12.0a0
-  - urllib3 >=1.21.1,<3
-  constrains:
-  - chardet >=3.0.2,<6
-  - pysocks >=1.5.6,!=1.5.7
-  license: Apache-2.0
-  license_family: Apache
-  size: 120768
-  timestamp: 1707355762747
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
-  sha256: 727fb8d957e02d03b928d049ffbc712316f176a2c331391766d646621b45655a
-  md5: 7e0e416c642f3ee4ddfb084a811fb4df
-  depends:
-  - python >=3.11,<3.12.0a0
-  - six
-  license: MIT
-  license_family: MIT
-  size: 10236
-  timestamp: 1683077214314
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
-  sha256: a8a67143ccb65cfd6f50055176b6c26179a83130a45d0a12e79dd2de68d8db63
-  md5: a2065790f41e3eeb6efe0ef6daa75377
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 10600
-  timestamp: 1683059285216
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
-  sha256: 6aba582338faa0c26fe336bdb10c65b8f7808a6e383bd8f80f3e6b612ca209ec
-  md5: a7486349b5f7370f6902c2050a23d268
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 319197
-  timestamp: 1698946203341
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
-  sha256: 86bda04163628ef7b35528fbb4fe1d56fef50d10570a859e5ae8a7fbb60f577c
-  md5: 05e397dddd20d91460e3cedea0b3686f
-  depends:
-  - blas 1.0 mkl
-  - libcxx >=14.0.6
-  - libgfortran 5.*
-  - libgfortran5 >=11.2.0
-  - libgfortran5 >=11.3.0
-  - mkl >=2023.1.0,<2024.0a0
-  - mkl-service >=2.3.0,<3.0a0
-  - numpy >=1.23.5,<1.29
-  - pybind11-abi 4
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
-    BSL-1.0
-  license_family: BSD
-  size: 27745043
-  timestamp: 1714075585637
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
-  sha256: beba0555707dac1e8484d73cee9e4128ac4b10e2a0d4209357481179022e8fdc
-  md5: baa8b304607b3a9ae8a3d9acb354c31c
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 33343
-  timestamp: 1699371216044
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
-  sha256: c1df29188e321abe23651c73712a6d8ed3abdc89ad38a42c33f1835b3ab77abe
-  md5: 6c984ea85326858942f7b635e0cc9ff8
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 1597325
-  timestamp: 1715025837032
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.1.10-hcec6c5f_1.tar.bz2
-  sha256: 9e61e80cb7cc715a3d688a660249da591e20550716a245684ffca317df9a19df
-  md5: 62a52eef7c69e9be38fa0313aa49b4be
-  depends:
-  - libcxx >=14.0.6
-  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
-  license_family: BSD
-  size: 42438
-  timestamp: 1702909424521
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
-  sha256: 0eb44a16ef74a13ef7839209899d009cd94974fbc406a417d958c7bc8d955245
-  md5: 41f239a5b67b1daf819849023aa5d12f
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT OR Apache-2.0
-  license_family: Other
-  size: 19056
-  timestamp: 1705431379885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
-  sha256: 14775231982e1ea150189c956927ccfb1ad01a8c9395cdeea4d5a48b9b8ce664
-  md5: 729badc4bf7ba8ccc70e0f9e58075c99
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 89812
-  timestamp: 1696347694075
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
-  sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
-  md5: 6bef1694163a68ac4c37e5857b8da4f5
-  depends:
-  - ncurses >=6.4,<7.0a0
-  - readline >=8.0,<9.0a0
-  - zlib >=1.2.13,<1.3.0a0
-  - zlib >=1.2.13,<2.0a0
-  license: blessing
-  license_family: Other
-  size: 1900191
-  timestamp: 1714488351925
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
-  md5: 61d6251c7fd58a353ebe33d95b8ada33
-  depends:
-  - libcxx >=14.0.6
-  license: Apache-2.0
-  license_family: Apache
-  size: 180099
-  timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
-  sha256: 3d5c2968f581006437df3932cd5d3c1c4afa78f0e13757b958440245d3248856
-  md5: 605ea221d225ad8e79284dbcfdab0715
-  depends:
-  - ptyprocess
-  - python >=3.11,<3.12.0a0
-  - tornado >=6.1.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 37699
-  timestamp: 1678317755913
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
-  sha256: ed059e32ce5a1c0511575f29d2fb6da12c54a37000bfa80f9e5aa9dfd9e04101
-  md5: 4d2261a92d25136a68b8d01d101119f5
-  depends:
-  - python >=3.11,<3.12.0a0
-  - webencodings >=0.4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 49145
-  timestamp: 1678317386284
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
-  sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
-  md5: 523c006cc67c011383678c762015479b
-  depends:
-  - zlib >=1.2.13,<1.3.0a0
-  license: TCL
-  license_family: BSD
-  size: 3594448
-  timestamp: 1714770737885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
-  sha256: 424b8284072266eb59d055c0b7b58241bfb00009d445743ea261d4eeee73ea19
-  md5: f3a47898a55087edb9d65d29c24d9b88
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 135757
-  timestamp: 1678323030858
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
-  sha256: 6ab71b48d145c69007cfb5b4a21def2cc83bba972b7cc91c7d52d0d7eeb055bf
-  md5: f8970b0ad5c8b452b8722ceb4e5c17f7
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 895379
-  timestamp: 1696937269468
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.2-py311h85bffb1_0.tar.bz2
-  sha256: e3950599a72f2093cbc99f6a2e40fb98c1731723a08f755a5c583560e5e602c3
-  md5: 46add19df747c5da0f1b7f1c8f37d842
-  depends:
-  - python >=3.11,<3.12.0a0
-  constrains:
-  - ipywidgets >=6
-  license: MPL-2.0 AND MIT
-  license_family: MOZILLA
-  size: 155703
-  timestamp: 1714575768321
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
-  sha256: 9e8dbede0bc54c77b974210be66503e7e8e45e0f1c71dc5c16cc9a9674d54259
-  md5: b4fcab9e63bd7b3cdf458c953904807c
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 270874
-  timestamp: 1678316116954
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.9.0-py311hecd8cb5_1.tar.bz2
-  sha256: c92c53f476c8157965a9637a4fd5ae7311c724396669d55fbe6b1b16c4c678c4
-  md5: 1d97af42c34da5f616ceee31e3a56d46
-  depends:
-  - python >=3.11,<3.12.0a0
-  - typing_extensions 4.9.0 py311hecd8cb5_1
-  license: PSF-2.0
-  license_family: PSF
-  size: 9879
-  timestamp: 1705599378858
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.9.0-py311hecd8cb5_1.tar.bz2
-  sha256: 00a423edcfd3cc351068c09cf89ecacebd44425dc589aa5e2778e9b8552b521d
-  md5: 0926a658fe3590254e368b5b23a0cf3e
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: PSF-2.0
-  license_family: PSF
-  size: 71954
-  timestamp: 1705599373108
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
-  sha256: a9960485ced319ac91afe69eaaf703c7e6b3049f1e06a4a8c2818b64155943f0
-  md5: 0a9c8ea92a14330a07edabac249e32a9
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 11399
-  timestamp: 1678394892923
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
-  sha256: d42ae57366d05e12f10074583568355752436d66ad018ffbcfa24135f593810a
-  md5: 1a98e48aa0bd8b3ec09e2cbdbb236575
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 498952
-  timestamp: 1713213079520
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.1.0-py311hecd8cb5_1.tar.bz2
-  sha256: 33caa82e1fec2ce6b468392257f3556e5e6ae91654c01393b36bc340fe78f9b7
-  md5: 08b9cfb7943aadbfee616be6064cee7c
-  depends:
-  - brotli-python >=1.0.9
-  - pysocks >=1.5.6,<2.0,!=1.5.7
-  - python >=3.11,<3.12.0a0
-  constrains:
-  - selenium >=4.4.3
-  - zstandard >=0.18.0
-  - requests >=2.26.0
-  license: MIT
-  license_family: MIT
-  size: 184811
-  timestamp: 1707770784530
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
-  sha256: 0f8c3eb254be9c1957e748e385e20e62509d11052990c4755012be62434c9129
-  md5: 53229ba93f6e38308ae42ecfc6eaad9d
-  license: MIT
-  license_family: MIT
-  size: 96768
-  timestamp: 1706894705048
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
-  sha256: 597015e8a038a111f03ffbc9a217fcda549d75230c86ce53c1f23c53d6f1a0cb
-  md5: 62e98aac883bccc1c87ca0d2ce2f08e0
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD 3-Clause
-  license_family: BSD
-  size: 25798
-  timestamp: 1678317074170
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py311hecd8cb5_4.tar.bz2
-  sha256: f60e6da6f08bf1bdcec59ed71fb53bbd3d2e3c487dba59523e956bfea6ba9ef6
-  md5: 6acead6f585f1bae0447298d4fec340c
-  depends:
-  - python >=3.11,<3.12.0a0
-  - six
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 90538
-  timestamp: 1678317776793
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
-  sha256: 885a9b6046e76f7dc1a346b14c63b4083046137bfae036362c854458e20e4fc8
-  md5: 3b279447ca282d065e681e567055b582
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 137340
-  timestamp: 1714717062907
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
-  sha256: cc6995f677d1628f42ae80ed47ff08d8d1c8ed12580a326af6e307f5febc594a
-  md5: d01eb964863b95ef62061b77c9037ead
-  depends:
-  - numpy >=1.21,<2.0a0
-  - packaging >=21.3
-  - pandas >=1.4
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 2471632
-  timestamp: 1689041625741
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
-  sha256: 5b6d5246955b5f9480ff7027eb002442a7ade24f5c354da54ed513042f76cedc
-  md5: f32aa8a37d5e65a8dc30f9a1f46bc63d
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 54719
-  timestamp: 1678325412288
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
-  sha256: ed0152ad6b87ffd9e01f4a62bc358e805ad59637f898a801b0a9cf903ae8e1fb
-  md5: 8a92f8c663608f24e14d8a2068b9d83a
-  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
-  license_family: GPL2
-  size: 415323
-  timestamp: 1714511993944
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
-  md5: cbfabc8518e50cc4726b86d1d8b6400a
-  license: MIT
-  size: 87049
-  timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
-  sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
-  md5: c25b6d40f834647d0bbe767f6c776031
-  depends:
-  - libcxx >=14.0.6
-  - libsodium >=1.0.18,<1.0.19.0a0
-  license: MPL-2.0
-  license_family: Other
-  size: 329449
-  timestamp: 1705602140856
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py311hecd8cb5_0.tar.bz2
-  sha256: e5fd1f8b8e5cc1221e85355ade7b69f0df640dbdc016b7f9ea0b0b6eda5bf9b6
-  md5: 11c4cb55382be5ab89b5c4085510db3b
-  depends:
-  - heapdict
-  - python >=3.11,<3.12.0a0
-  - python-lmdb
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 103266
-  timestamp: 1695833080541
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.17.0-py311hecd8cb5_0.tar.bz2
-  sha256: 36fa7ad990aabf3607bda1f33e847888210974586363b6d69cf1ed092c192c35
-  md5: c981fe545122206cdeb647f2dc9e093d
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 25496
-  timestamp: 1704207010227
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
-  sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
-  md5: f2519b551f99765d9d98950c5e2b4713
-  license: Zlib
-  license_family: Other
-  size: 119782
-  timestamp: 1714511811597
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
-  sha256: 7feb73e79bdbd45404ddc7a30c43bf4cc68eced8ce448ce7c31f5db134276fc5
-  md5: 48313bc6570c705cadbba3c356e0dc8e
-  depends:
-  - libcxx >=14.0.6
-  - lz4-c >=1.9.4,<1.10.0a0
-  - xz >=5.4.6,<6.0a0
-  - zlib >=1.2.13,<1.3.0a0
-  license: BSD-3-Clause AND GPL-2.0-or-later
-  license_family: BSD
-  size: 1014151
-  timestamp: 1714678461080
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/abseil-cpp-20230802.0-h313beb8_2.tar.bz2
-  sha256: d42422c15e115f76aec2f71e25887104359d5140af3cc6f19e358af011dc7ba9
-  md5: 9996619edfa02accc1fb7912d5ecc5fb
-  depends:
-  - gtest >=1.14.0,<1.14.1.0a0
-  - libcxx >=14.0.6
-  license: Apache-2.0
-  license_family: Apache
-  size: 1372151
-  timestamp: 1698327835928
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
-  sha256: 9ca3f0dfc2bdbc109e359ba7ab246e6ae952a14819148ad069454b52f2bda802
-  md5: 51fb05873a644cac52f0d1e10cb7969a
-  depends:
-  - idna >=2.8
-  - python >=3.11,<3.12.0a0
-  - sniffio >=1.1
-  constrains:
-  - trio >=0.23
-  - uvloop >=0.17
-  license: MIT
-  license_family: MIT
-  size: 228856
-  timestamp: 1706220385566
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
-  sha256: 43405cc7341ce3efb2e24013ad62c64f26a69926635adceaa5459ccbcafb3776
-  md5: effa6d22f497e164cc8455f7f329c304
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD 2-Clause
-  license_family: BSD
-  size: 12510
-  timestamp: 1677917870614
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
-  sha256: 947efe1c50b3280e9a67cbb18636bdade53a40960fff3056850ff81ab87acbe3
-  md5: 7d2d384ee32ccc12dcb0dc099e421482
-  depends:
-  - cffi >=1.0.1
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 35091
-  timestamp: 1677915945226
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-14.0.2-hc7aafb3_1.tar.bz2
-  sha256: 86bab32d1e41090bc20f55a7e337565aa8085b6fbafe9bab11886ccf7d938bcd
-  md5: 26f4f94a10d3fb85cfdb2ef11894d3d3
-  depends:
-  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
-  - aws-sdk-cpp >=1.10.55,<1.10.56.0a0
-  - brotli
-  - bzip2 >=1.0.8,<2.0a0
-  - gflags
-  - glog >=0.5.0,<0.6.0a0
-  - grpc-cpp >=1.48.2,<1.49.0a0
-  - libbrotlicommon >=1.0.9,<1.1.0a0
-  - libbrotlidec >=1.0.9,<1.1.0a0
-  - libbrotlienc >=1.0.9,<1.1.0a0
-  - libcxx >=14.0.6
-  - libprotobuf >=3.20.3,<3.21.0a0
-  - libthrift >=0.15.0,<0.16.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - openssl >=3.0.13,<4.0a0
-  - orc >=1.7.4,<1.7.5.0a0
-  - re2 >=2022.4.1,<2022.4.2.0a0
-  - snappy >=1.1.9,<2.0a0
-  - utf8proc >=2.6.1,<2.9.0
-  - zlib >=1.2.13,<2.0.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 9537543
-  timestamp: 1707253459914
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/async-lru-2.0.4-py311hca03da5_0.tar.bz2
-  sha256: 9c64b8d25d87c43834c3f98c331598f9353b063af9456da0be91252a4433e01e
-  md5: 46c58da7041280e5ac6f5c9ce4b8b7a6
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 21474
-  timestamp: 1699554635961
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
-  sha256: 8259b4a0973c825ac81f581afcbe86640bd0a94b33caa996167309241877635a
-  md5: 49b8ddacfd3927bcaae139eadfb72ce1
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 153557
-  timestamp: 1695717951839
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
-  sha256: f536e8b60bdc895063ca0e0155d2041993caed5f932c232f2a0d8e52798da2f1
-  md5: daacfabaacebe1d1e53426ec3e385d14
-  depends:
-  - aws-c-cal >=0.5.20,<0.5.21.0a0
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-http >=0.6.25,<0.6.26.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 86757
-  timestamp: 1706746162173
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
-  sha256: c356ce4cbd638a41fd3db59aa3559850e38c6b41188b8ffab32bdcbd9a55fe03
-  md5: e9dc8c248dda95e92533cae6815a0a8b
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 39456
-  timestamp: 1706690903374
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
-  sha256: 117825fcff2a68136a6e5183e05542c2654d73322e70daee3c50c0ecb3aec703
-  md5: b115d3f733fe8bae79b9d416754b260e
-  license: Apache-2.0
-  license_family: Apache
-  size: 182078
-  timestamp: 1706189905050
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
-  sha256: 241c19574abcaf91a47fc5c36f38e58c86732be5e06f5170063406098a58639f
-  md5: 3cfc3d38b8fdb25cc2e10e3e370d4106
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 18039
-  timestamp: 1706690838125
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
-  sha256: d4c60f610e57b35a2962b8cea9911358d1642e0449468fa4967706af88bf5da9
-  md5: fc23856f141fe548afcfc4823881ee19
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  - aws-checksums >=0.1.13,<0.1.14.0a0
-  - libcxx >=14.0.6
-  license: Apache-2.0
-  license_family: Apache
-  size: 47155
-  timestamp: 1706697259456
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
-  sha256: c43ed35f4a64818ae39ca2c3c3652428c15da5e287f6e94254c3df4d6c759fb3
-  md5: 06366f5f8762447babf69804a04b1a69
-  depends:
-  - aws-c-cal >=0.5.20,<0.5.21.0a0
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-compression >=0.2.16,<0.2.17.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 162746
-  timestamp: 1706744122437
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
-  sha256: 14e2ee7339c88089d1ff68f7144b3fb4f9e34fe538a9462f8de31dd6fdd1d42b
-  md5: 59ab0e7ffd73966ec6a2fa83a5df5c47
-  depends:
-  - aws-c-cal >=0.5.20,<0.5.21.0a0
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 127084
-  timestamp: 1706696174505
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
-  sha256: 601baf006d0545ec65566701d99c601cba843e8ac03d80819d4b8bed23d1e5c4
-  md5: 2c98a19d57362cf1fbfec3dda3ea283b
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-http >=0.6.25,<0.6.26.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 61914
-  timestamp: 1706746732665
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
-  sha256: 16809db73ddc3c374ead2c2e9f2221894e2014d3e07ba62d79375cb4de4dfc9d
-  md5: c03f5e3b42bc59bd92db813522cce1aa
-  depends:
-  - aws-c-auth >=0.6.19,<0.6.20.0a0
-  - aws-c-cal >=0.5.20,<0.5.21.0a0
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-http >=0.6.25,<0.6.26.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  - aws-checksums >=0.1.13,<0.1.14.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 67560
-  timestamp: 1706747573116
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
-  sha256: 293cf6b9dfa727d0e65b383b0e434f8fb26480abd011516171b8652fd363c98e
-  md5: 2df2dd6c43a3b413b438a9ef834d78b0
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 48454
-  timestamp: 1706690816205
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
-  sha256: 773f7ff1a91af373d27f5c57833aff8912870108ddd94a5280bfdc608effe5e3
-  md5: fad8b095c03774c9d4901db7eda09002
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 52142
-  timestamp: 1706192041205
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
-  sha256: 4efabe18fc312e65a5aac9b2ebe423296cfe702756891978244287ab47881927
-  md5: 5786a8ac037fd0e81e25f52dbc6dc72d
-  depends:
-  - aws-c-auth >=0.6.19,<0.6.20.0a0
-  - aws-c-cal >=0.5.20,<0.5.21.0a0
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
-  - aws-c-http >=0.6.25,<0.6.26.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
-  - aws-c-s3 >=0.1.51,<0.1.52.0a0
-  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
-  - libcxx >=14.0.6
-  license: Apache-2.0
-  license_family: Apache
-  size: 210683
-  timestamp: 1706827608490
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.10.55-h313beb8_0.tar.bz2
-  sha256: fe92c6408ee3ebf269b216d1c9576bc15e65a38bcf684f2a7b935e57dbf2e444
-  md5: 4c6b2dc15773f338a7f3299a753ab0af
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
-  - aws-checksums >=0.1.13,<0.1.14.0a0
-  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
-  - libcurl >=7.88.1,<9.0a0
-  - libcxx >=14.0.6
-  license: Apache-2.0
-  license_family: Apache
-  size: 2365300
-  timestamp: 1706890517127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/babel-2.11.0-py311hca03da5_0.tar.bz2
-  sha256: cbca68c98946526eb9a24c01717a0c850d1736f7530196ce627bcc33d8337a18
-  md5: 57ee914212070a75e071674d97480bd5
-  depends:
-  - python >=3.11,<3.12.0a0
-  - pytz >=2015.7
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 7177152
-  timestamp: 1677920828584
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
-  sha256: 11159a30daae77cfc1abe5e60c19261f65c005e6fbc460aecf72318514d737ad
-  md5: 0c5002654a9cb21db1fdf8c1d2017df5
-  depends:
-  - python >=3.11,<3.12.0a0
-  - soupsieve >1.2
-  license: MIT
-  license_family: MIT
-  size: 269772
-  timestamp: 1681493072129
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
-  md5: 9a229bd94ce6f3045c9ffa953c602fd7
-  size: 10252
-  timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
-  sha256: 90439f37ede74ef464e76093e173a8e94a20ee4ad79c68c9e7570fbc67fc13cc
-  md5: bb3b906307dd679fc3276be7581494f9
-  depends:
-  - contourpy >=1.2
-  - jinja2 >=2.9
-  - numpy >=1.23.5,<2.0a0
-  - packaging >=16.8
-  - pandas >=1.2
-  - pillow >=7.1.0
-  - python >=3.11,<3.12.0a0
-  - pyyaml >=3.10
-  - tornado >=6.2
-  - xyzservices >=2021.09.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6073834
-  timestamp: 1712084392983
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
-  sha256: f1660ecfb8687d74e81a7b00699a8bb4677cbd791d14f50ba517de98e2f187ca
-  md5: 1636fc4b725da8c5e967952a55f3fd80
-  depends:
-  - libboost 1.82.0 h0bc93f9_2
-  - libcxx >=14.0.6
-  license: BSL-1.0
-  license_family: OTHER
-  size: 11780
-  timestamp: 1696762172661
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
-  sha256: 688a071ba370f51b457cd32d70b7b38921ce9551203d06fa7fc2c30c4b79891d
-  md5: b2353077a39ab997463768154dd58fec
-  depends:
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 134711
-  timestamp: 1707864978809
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
-  sha256: 048264434c33fdb53862cdd69b2e2bc4ce6f8a70b3211ad6d686d066eac2aa91
-  md5: d55696ccaf6755931cd662dfb929aa0b
-  depends:
-  - brotli-bin 1.0.9 h80987f9_8
-  - libbrotlidec 1.0.9 h80987f9_8
-  - libbrotlienc 1.0.9 h80987f9_8
-  license: MIT
-  size: 19737
-  timestamp: 1714483270447
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
-  sha256: 13627293296fcc231d8dc12d803dfc9621108c60df38b0e3c64e9e02ed55e564
-  md5: 86efd4ad08cd80d3eab77873db84a255
-  depends:
-  - libbrotlidec 1.0.9 h80987f9_8
-  - libbrotlienc 1.0.9 h80987f9_8
-  license: MIT
-  size: 19083
-  timestamp: 1714483255364
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
-  sha256: 2e542b2bb27f8379da3efcb83ef084cb26e6a9ab576c50487c2dd996afd5ccb1
-  md5: e8cab9d1ef58a450f971690fcdb2ede2
-  depends:
-  - libcxx >=14.0.6
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  size: 380182
-  timestamp: 1714483330655
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
-  sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
-  md5: 56d1386c7f1f338f0d18f82af6525273
-  license: bzip2-1.0.8
-  license_family: BSD
-  size: 158748
-  timestamp: 1714510571033
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
-  sha256: b0be79290b1df1cf1d07a1a9c3f3a92ae262643a6df3dc10dfbac22a82874dd4
-  md5: 8fdcf1c08eee91fec7eefc22863c816a
-  license: MIT
-  license_family: MIT
-  size: 106550
-  timestamp: 1693902036526
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
-  sha256: bbfc668f445f3584936b326dcfe92bf71971ce16241f4f79db8aeb88d7aab41c
-  md5: 10cc05ed51482e1dfcc31dbd13bb34c6
-  license: MPL-2.0
-  license_family: Other
-  size: 138641
-  timestamp: 1710764806818
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
-  sha256: 512969f339a9a7b347cdb7b88f439819168089867f04732279f02759d8caf24e
-  md5: 2009c2ee465fdd74dbd046de73726234
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MPL-2.0
-  license_family: Other
-  size: 166501
-  timestamp: 1707229221324
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
-  sha256: 8d26cd4d16545ad8afddd5521bc6894a50d5b8faff3abbe600bb9b062f3c3a0a
-  md5: 66eb734b7d7008eb5fb537900767c7ae
-  depends:
-  - libffi >=3.4,<3.5
-  - pycparser
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 286807
-  timestamp: 1714483190838
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
-  sha256: df81a27f221d11af4a709f272dc8ba3fd3f6d5ab4ffd883c40567bcf04f0cfd3
-  md5: e49333e3ffe1fe2e701f50a6e6dccc52
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 204179
-  timestamp: 1698129906257
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py311hca03da5_0.tar.bz2
-  sha256: 53edaca56d853083d44cef6234fe4b3d076d107e915781ce54ec135c25e09f0e
-  md5: 5d1d51e53c11bcb56cf863d58e37c077
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 50433
-  timestamp: 1683040076511
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
-  sha256: d9c126d8bcd1c89ea37186c172d6b1f73f45ada60e3ae1790a017b530baa0147
-  md5: f0223aae3d622547f6accb212579c58e
-  depends:
-  - python >=3.11,<3.12.0a0
-  - traitlets >=4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 17967
-  timestamp: 1709322909223
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
-  sha256: 1f908c688e47d03d92ac09d9541a1f1c773ac2ca485dd1d77441b1aaefc032db
-  md5: 444c330471496a39a97e87f41ed70c96
-  depends:
-  - libcxx >=14.0.6
-  - numpy >=1.20,<2
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 281104
-  timestamp: 1700583698464
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cramjam-2.7.0-py311h62f922a_0.tar.bz2
-  sha256: 1a71c2e15872edff275f419bd1b827c2e37a4cfaf997cd30104cadb2da285a5b
-  md5: e97551b1be62a8bc30eb69e1dfe39191
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 1531706
-  timestamp: 1702651054879
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.2-py311h80987f9_0.tar.bz2
-  sha256: 9e135f43ac703c578abe1b84761a1fb4ad75b63966f0b015fdcb939d3b05e7b3
-  md5: ab5b122dafc5b17f32b2ec8ce73d8adb
-  depends:
-  - python >=3.11,<3.12.0a0
-  - toolz >=0.10.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 403974
-  timestamp: 1701723703085
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-2023.11.0-py311hca03da5_0.tar.bz2
-  sha256: dfac5c394e0fa6c3bae5c8565735363a56478d512e38dc8782dd9ecfd06d5d17
-  md5: 72efbeec2089b327f3b751c45abeac10
-  depends:
-  - bokeh >=2.4.2
-  - cytoolz >=0.12.0
-  - dask-core 2023.11.0.*
-  - distributed 2023.11.0.*
-  - jinja2 >=2.10.3
-  - lz4 >=4.3.2
-  - numpy >=1.21,<2.0a0
-  - pandas >=1.3
-  - pyarrow >=7.0
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6031
-  timestamp: 1701444902384
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.11.0-py311hca03da5_0.tar.bz2
-  sha256: 66b75168a7eb1fa16c9ddd7004339dab4d4bd3557f60abfcfb9de706f27cfd42
-  md5: 4c482f6b591b73d95c21f967bd69b471
-  depends:
-  - click >=8.1
-  - cloudpickle >=1.5.0
-  - fsspec >=2021.09.0
-  - importlib-metadata >=4.13.0
-  - packaging >=20.0
-  - partd >=1.2.0
-  - python >=3.11,<3.12.0a0
-  - pyyaml >=5.3.1
-  - toolz >=0.10.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 3028051
-  timestamp: 1701396155471
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
-  sha256: b9356e3ada4872c7c950d2ac7e0f107c4786775191efdfda3a469dffb18f2714
-  md5: 07ddd96675caf30ea77cafb1ea5662a4
-  depends:
-  - libcxx >=14.0.6
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 2490144
-  timestamp: 1690905181398
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2023.11.0-py311hca03da5_0.tar.bz2
-  sha256: 9901062d92e30b3e1c7739d19be817765fa7c39458697498b06b125ce36ab8d4
-  md5: 638bd80c82a43aeac35c73909014ac92
-  depends:
-  - click >=8.0
-  - cloudpickle >=1.5.0
-  - dask-core 2023.11.0.*
-  - jinja2 >=2.10.3
-  - locket >=1.0.0
-  - msgpack-python >=1.0.0
-  - packaging >=20.0
-  - psutil >=5.7.2
-  - python >=3.11,<3.12.0a0
-  - pyyaml >=5.3.1
-  - sortedcontainers >=2.0.5
-  - tblib >=1.6.0
-  - toolz >=0.10.0
-  - tornado >=6.0.4
-  - urllib3 >=1.24.3
-  - zict >=3.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1789023
-  timestamp: 1701398118479
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-2023.8.0-py311hb9f6ed7_0.tar.bz2
-  sha256: f883809f6e11db2bf67fd28a0fe283fbb5ad1a6e09897c4e743465c1d0838127
-  md5: abdc285c69c9b5e9e7373ee6aec90856
-  depends:
-  - cramjam >=2.3.0
-  - fsspec
-  - numpy >=1.23.5,<2.0a0
-  - packaging
-  - pandas >=1.5.0
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 563381
-  timestamp: 1696541857273
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
-  sha256: eb82a0e2ca36d0973b5f6642e27609554edad4b72696f989776d5db8cd4a6a42
-  md5: fa8d9dd8a2fabba964c6bb75ace8c572
-  depends:
-  - brotli >=1.0.1
-  - python >=3.11,<3.12.0a0
-  - unicodedata2 >=15.1.0
-  constrains:
-  - zopfli >=0.1.4
-  - uharfbuzz >=0.23.0
-  - skia-pathops >=0.5.0
-  - lz4 >=1.7.4.2
-  - fs >=2.2.0,<3
-  - lxml >=4.0
-  license: MIT
-  license_family: MIT
-  size: 3201601
-  timestamp: 1713551611540
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
-  md5: 44de39124e1b0f5f731c11631eac18ac
-  depends:
-  - libpng >=1.6.37,<1.7.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: GPL-2-only and LicenseRef-FreeType
-  license_family: Other
-  size: 914169
-  timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.3.1-py311hca03da5_0.tar.bz2
-  sha256: aa53d9f23e86ac3398f6b935cea01dcd8a1b1821d9b1d37b16a5ba68a2dbe569
-  md5: 2d5841b96988498045c28e3b3951d5ac
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 373029
-  timestamp: 1714461571346
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
-  sha256: 25e05b93a99914a5fd1a298a2c5b25479fbd571b0db9caa7c6ad4336f060f62c
-  md5: e213b68bb0274e0e54c610a041e059f5
-  depends:
-  - libcxx >=14.0.6
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 150168
-  timestamp: 1706888198288
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
-  sha256: bbbcf47ef9249635b5199be1414b0b59687cc04ea9630d50ecc609dc200c095e
-  md5: 5820c373d6847a68551cadb8984a8277
-  depends:
-  - gflags >=2.2.2,<2.3.0a0
-  - libcxx >=14.0.6
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 95638
-  timestamp: 1706895270850
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpc-cpp-1.48.2-hc60591f_4.tar.bz2
-  sha256: 4787d6730eae9c37b11f76db852a2c0a070b4dabc9abb9e423fa3ad68944ed19
-  md5: 8dff6fefff4eabeeedc5a67b15d91aff
-  depends:
-  - abseil-cpp >=20230802.0,<20230802.1.0a0
-  - c-ares >=1.19.1,<2.0a0
-  - libcxx >=14.0.6
-  - libprotobuf >=3.20.3,<3.20.4.0a0
-  - libprotobuf >=3.20.3,<3.21.0a0
-  - openssl 3.*
-  - openssl >=3.0.12,<4.0a0
-  - re2 >=2022.4.1,<2022.4.2.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3884646
-  timestamp: 1701982736145
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gtest-1.14.0-h48ca7d4_0.tar.bz2
-  sha256: 064fc752345ef3973d3ebf2145029eaa308c17e12abe72a732255db9cdea6a40
-  md5: 37ace38cf07143b39ae9b89feb204d3d
-  depends:
-  - libcxx >=14.0.6
-  constrains:
-  - gmock 1.14.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 399378
-  timestamp: 1692633568295
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
-  sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
-  md5: 69eb3b03765627b6159ed23cdde78396
-  depends:
-  - libcxx >=14.0.6
-  license: MIT
-  license_family: MIT
-  size: 28399065
-  timestamp: 1692293207812
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
-  sha256: 4d4ab70ae0ce008c1cc96a4edfbf3866d5e636acc4799a545ea93acee51635f7
-  md5: 86a085a440729020d1d7b0b74d6a0c6c
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 148448
-  timestamp: 1714398923507
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
-  sha256: ec139e4b87aadcacc0670ecbcc2a303d858d4ac38b9404458a4b676bce9d21d5
-  md5: bfcfed281f8df0f18726ec5f843b2b26
-  depends:
-  - python >=3.11,<3.12.0a0
-  - zipp >=0.5
-  license: Apache-2.0
-  license_family: APACHE
-  size: 51053
-  timestamp: 1704813595720
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
-  sha256: 63670c8f31770e1746016f645ca6b42b35f92d1c37e8025793d9490fed9998c0
-  md5: 9cb417b9fdf02b4e007a5b5781e5a8cc
-  depends:
-  - appnope
-  - comm >=0.1.1
-  - debugpy >=1.6.5
-  - ipython >=7.23.1
-  - jupyter_client >=6.1.12
-  - jupyter_core >=4.12,!=5.0.*
-  - matplotlib-inline >=0.1
-  - nest-asyncio
-  - packaging
-  - psutil
-  - python >=3.11,<3.12.0a0
-  - pyzmq >=24
-  - tornado >=6.1
-  - traitlets >=5.4.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 229932
-  timestamp: 1705934202146
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
-  sha256: a40c76c412ec793ca26b97a9b5c496d253768438e1f7d4a0ee5f63ea79eed355
-  md5: f609e4fe044318211cf0e37e289beebd
-  depends:
-  - decorator
-  - jedi >=0.16
-  - matplotlib-inline
-  - pexpect >4.3
-  - prompt_toolkit >=3.0.41,<3.1.0
-  - pygments >=2.4.0
-  - python >=3.11,<3.12.0a0
-  - stack_data
-  - traitlets >=5
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1614299
-  timestamp: 1704833142734
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
-  sha256: e57d10579b52a3cde45aa17e1bdd95dcb9d3346aa00eb02c51e38a42db83e18d
-  md5: 05153120787fb09159b6e1ad902c6e10
-  depends:
-  - parso >=0.8.0,<0.9.0
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 1180481
-  timestamp: 1678994989550
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
-  sha256: 06512ef9a910fa72bf5697fe89e88c605d61f8478a9d8dd233c13f40e30f8446
-  md5: cfa00c9ffd3407e29507525c020e5526
-  depends:
-  - markupsafe >=2.0
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 355730
-  timestamp: 1706733720706
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
-  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
-  md5: 055e12390b844ea6c6e956ee08a618e8
-  license: IJG
-  license_family: Other
-  size: 273479
-  timestamp: 1677849171867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
-  sha256: 62025ce4a2b9244b9816c9e02487e0dda567600692b5f9ca71f425d084961c7e
-  md5: d57b7063122e5bf25cdfc2a5ea7330a8
-  depends:
-  - attrs >=22.2.0
-  - jsonschema-specifications >=2023.03.6
-  - python >=3.11,<3.12.0a0
-  - referencing >=0.28.4
-  - rpds-py >=0.7.1
-  license: MIT
-  license_family: MIT
-  size: 181872
-  timestamp: 1699041739097
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
-  sha256: 404b0847029f77bedd7902a170a046219e0dc5c0ec2be19ff45361cff25b2181
-  md5: 3a02bbe8d45fdbcb2350f672be74c9f5
-  depends:
-  - python >=3.11,<3.12.0a0
-  - referencing >=0.28.0
-  license: MIT
-  license_family: MIT
-  size: 16524
-  timestamp: 1699032463763
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter-lsp-2.2.0-py311hca03da5_0.tar.bz2
-  sha256: 8d8eb94257336543a0c6a2168a68195ee1258af47f4b5b58d8797ac483744a63
-  md5: 191fecf4322e1348caac6337955a9e5a
-  depends:
-  - jupyter_server >=1.1.2
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 101675
-  timestamp: 1699978313832
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-8.6.0-py311hca03da5_0.tar.bz2
-  sha256: bb525ddbadaeb7090eb5bf8aaf2d4d01765c5e2e93136a47fbb1f5b663bab567
-  md5: df7c907e1d274521660c4e2030c5b6ef
-  depends:
-  - jupyter_core >=4.12,!=5.0.*
-  - python >=3.11,<3.12.0a0
-  - python-dateutil >=2.8.2
-  - pyzmq >=23.0
-  - tornado >=6.2
-  - traitlets >=5.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 225157
-  timestamp: 1699455930116
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
-  sha256: 8220b1bbdde5e800810f7bf183a992af1a95825a837edf975fa8c4b51c5d806f
-  md5: 3a06ddad06e04d5f0211c22cd81ca75a
-  depends:
-  - platformdirs >=2.5
-  - python >=3.11,<3.12.0a0
-  - traitlets >=5.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 94950
-  timestamp: 1698937436979
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
-  sha256: 8a9a9f9ddbf1b7744ef04a8c862438499a41d81a4beb4a49860156c273bb7497
-  md5: 051355801f09eefe850ee8145151f934
-  depends:
-  - jsonschema >=4.18.0
-  - python >=3.11,<3.12.0a0
-  - python-json-logger >=2.0.4
-  - pyyaml >=5.3
-  - referencing
-  - rfc3339-validator
-  - rfc3986-validator >=0.1.1
-  - traitlets >=5.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 42497
-  timestamp: 1699282590553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
-  sha256: 65c703cc996a705d0ee350070e313b1cae865f9d6e6490ebf1164c0f3ce22d93
-  md5: 305ad8bcaad3e352d61b1e594093b467
-  depends:
-  - anyio >=3.1.0
-  - argon2-cffi
-  - jinja2
-  - jupyter_client >=7.4.4
-  - jupyter_core >=4.12,!=5.0.*
-  - jupyter_events >=0.6.0
-  - jupyter_server_terminals
-  - nbconvert >=6.4.4
-  - nbformat >=5.3.0
-  - overrides
-  - packaging
-  - prometheus_client
-  - python >=3.11,<3.12.0a0
-  - pyzmq >=24
-  - send2trash >=1.8.2
-  - terminado >=0.8.3
-  - tornado >=6.2.0
-  - traitlets >=5.6.0
-  - websocket-client
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 596801
-  timestamp: 1699466743685
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
-  sha256: 501e929d345aaa9079c965552b942b4e8bde35b87ae89faef003687a40bab3a4
-  md5: 54c7b8554a405acd7c8326c41ba93e63
-  depends:
-  - python >=3.11,<3.12.0a0
-  - terminado >=0.8.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 28237
-  timestamp: 1686870817418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab-4.0.11-py311hca03da5_0.tar.bz2
-  sha256: 7c07921656d5a8f8fdc8e5edb0b18ffdfbde22a1938258cf29e78b5b66c93928
-  md5: b152aceb76578939f6aced4bf328dee9
-  depends:
-  - async-lru >=1.0.0
-  - ipykernel
-  - jinja2 >=3.0.3
-  - jupyter-lsp >=2.0.0
-  - jupyter_core
-  - jupyter_server >=2.4.0,<3
-  - jupyterlab_server >=2.19.0,<3
-  - notebook-shim >=0.2
-  - packaging
-  - python >=3.11,<3.12.0a0
-  - tornado >=6.2.0
-  - traitlets
-  constrains:
-  - nodejs >=18.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6667686
-  timestamp: 1706803531409
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_server-2.25.1-py311hca03da5_0.tar.bz2
-  sha256: e28c8ba9c667ba5a276d3302005b990874c6de77e4fc785f87224a2dc2ca5394
-  md5: 3873f22212fb841a76c5348f5f6acf98
-  depends:
-  - babel >=2.10
-  - jinja2 >=3.0.3
-  - json5 >=0.9.0
-  - jsonschema >=4.18.0
-  - jupyter_server >=1.21,<3
-  - packaging >=21.3
-  - python >=3.11,<3.12.0a0
-  - requests >=2.31
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 107252
-  timestamp: 1699555538493
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
-  sha256: 8c1c64d51be73aad381992a9df19d8336910bdfc40f19940231df86e177d17cc
-  md5: b1f786f96684a143cf30d1f6b8aebdb3
-  depends:
-  - libcxx >=14.0.6
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 65045
-  timestamp: 1677925371836
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
-  sha256: 789402b67398d3d936ac4486df01869d59b0e1ba298cbd06407d059aced871e4
-  md5: a0f50a38705d0507bbf57ee49a1d9c29
-  depends:
-  - libedit >=3.1.20221030,<3.2.0a0
-  - libedit >=3.1.20221030,<4.0a0
-  - openssl >=3.0.8,<4.0a0
-  license: MIT
-  license_family: MIT
-  size: 1308175
-  timestamp: 1686931157327
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
-  md5: 7b5fd4df2a76303132c964bdc5e9c799
-  depends:
-  - jpeg >=9b,<10a
-  - libtiff >=4.2.0,<4.7.0
-  license: MIT
-  license_family: MIT
-  size: 381078
-  timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
-  md5: 255cac6bbe51bc940f6be144ce03bccf
-  depends:
-  - libcxx >=12.0.0
-  license: Apache-2.0
-  license_family: Apache
-  size: 150335
-  timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
-  sha256: c1f104bc84ee46a3d3beafb5e35236c64e6b4fd6cceabfb420e1838171b1d9c1
-  md5: 4f95903a1be48bbee1f9a818ec810b89
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - icu >=73.1,<74.0a0
-  - libcxx >=14.0.6
-  - libiconv >=1.16,<2.0a0
-  - xz >=5.4.2,<6.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  license: BSL-1.0
-  license_family: OTHER
-  size: 22243663
-  timestamp: 1696762144385
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
-  sha256: 199042b87451abaf14546af124ae3380194cddda928e0d30ccb341e93084854c
-  md5: eaa0442887994a82486c65d87f6b71e6
-  license: MIT
-  size: 68806
-  timestamp: 1714483212137
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
-  sha256: bd9a8a17fb14086446b710fa029d238e69274b83ee2e7e09093496f190de82b5
-  md5: 66615d6a0cb5dcca3e20c019cde0ed2d
-  depends:
-  - libbrotlicommon 1.0.9 h80987f9_8
-  license: MIT
-  size: 32975
-  timestamp: 1714483225840
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
-  sha256: e1bf77e8b975c30a69b08a08410622e27c8cff6f592ccfa590466b83d9e6d104
-  md5: 8af86bdac01fe303d693d9b76c071059
-  depends:
-  - libbrotlicommon 1.0.9 h80987f9_8
-  license: MIT
-  size: 310266
-  timestamp: 1714483239194
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.5.0-h3e2b118_0.tar.bz2
-  sha256: 5f11db2220b728d4e13e1d0069aeb0215719a7bdfce88ecfc7be68778986eb54
-  md5: 131c9519f6e616b3295735ac1a7f9c2e
-  depends:
-  - krb5 >=1.20.1,<1.21.0a0
-  - libnghttp2 >=1.57.0
-  - libnghttp2 >=1.57.0,<2.0a0
-  - libssh2 >=1.10.0
-  - libssh2 >=1.10.0,<2.0a0
-  - openssl >=3.0.12,<4.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: curl
-  license_family: MIT
-  size: 357001
-  timestamp: 1704383770648
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
-  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 1387034
-  timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
-  md5: d7ab3e05dd4a208d00eb99f98157073e
-  license: MIT
-  license_family: MIT
-  size: 57736
-  timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
-  sha256: 9597df5344a718d37837966aa05091faf210260898fad5e7a64b87f17de9e90d
-  md5: 678a1f87940ef6cc421a092301b8c3fe
-  depends:
-  - ncurses >=6.4,<7.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 167208
-  timestamp: 1703006281321
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
-  sha256: 6fc572025852b210ecddcca3ab9ff3f1d5f6bd91f1933c6e296de6bb331f6b5d
-  md5: 6dd7d9c5737bbd2a27d18f15318dc3e6
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 102059
-  timestamp: 1628961869728
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
-  sha256: 9e7b9bb9367d8725a751cdfa0b2d270434d303ea196cfaacc605ee26be09874a
-  md5: 44d1843cc2f17eb2674f35b95468f551
-  depends:
-  - openssl 3.*
-  - openssl >=3.0.8,<4.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 415467
-  timestamp: 1685052299052
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
-  sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
-  md5: f31e4eb9cd6447cc2f5ef0243a76540c
-  license: MIT
-  license_family: MIT
-  size: 120460
-  timestamp: 1714483461787
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
-  md5: 9a6698e6a01e492ef22889e4ec340e99
-  depends:
-  - libgfortran5
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 151487
-  timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
-  md5: 8f9dde854442b1597ec249e512b88673
-  depends:
-  - llvm-openmp >=8.0.0
-  constrains:
-  - libgfortran 5.0.0 *_28
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 1387621
-  timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
-  sha256: 72d242814b990900c9410d4738cc685f70ea71231742293cffbb475d8df100f8
-  md5: f9976688992b7ac4b56f5600ee15b5c4
-  license: GPL-3.0-or-later
-  license_family: GPL3
-  size: 1407202
-  timestamp: 1714483550601
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
-  sha256: d654027daea13ac9db36ab5fd5eff3ad398ec97c1777bf399f3ec680d2c145b9
-  md5: baabb1f905054bfea3af8f5768572a34
-  depends:
-  - libcxx >=14
-  - libffi >=3.4,<3.5
-  - libffi >=3.4,<4.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 26579907
-  timestamp: 1683291669565
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
-  sha256: b7cd58ddb892ed9d3983bdde8fc2530f0653a58818c87e08659f3795f04d8aff
-  md5: cf519f7233951d00a30c3b969c4cd161
-  depends:
-  - c-ares >=1.19.1,<2.0a0
-  - c-ares >=1.7.5
-  - libcxx >=14.0.6
-  - libev >=4.11
-  - libev >=4.33,<4.34.0a0
-  - openssl >=3.0.11,<4.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: MIT
-  license_family: MIT
-  size: 728977
-  timestamp: 1697018415626
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
-  md5: 0ba7c7444f2cbc64396d3873b874ec63
-  depends:
-  - libcxx >=12.0.0
-  - libgfortran5
-  - libgfortran5 >=11.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 13307698
-  timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
-  md5: 54add4e3b9ad35f25d34f3c2955abc7d
-  depends:
-  - zlib >=1.2.13,<2.0.0a0
-  license: Zlib
-  license_family: Other
-  size: 320926
-  timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
-  sha256: 239ec46c06c477e722230159971bac8d9eb14793a2e75f6e3d3a7a04ed5d5ebd
-  md5: 50e9c501f39bb262703c764789099f24
-  depends:
-  - libcxx >=14.0.6
-  - zlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2338901
-  timestamp: 1675278555141
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
-  md5: 189d927763e0d79f379df224726e3611
-  license: ISC
-  size: 287344
-  timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h02f6b3c_3.tar.bz2
-  sha256: 41a62fd6332033289602976adc75cd67e23d9b41ae97d0a993adb41f13f83480
-  md5: e2d039fc0d9f3d32818d202f23a30e8c
-  depends:
-  - openssl >=3.0.13,<4.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 303841
-  timestamp: 1714510628791
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
-  sha256: 82a73882a31e7a4f4edcdb0c21562e123da913d03b90b19396bd6dd4fcd9a7fc
-  md5: b5e5199892949d1e7e2db7bf0ee4dfe9
-  depends:
-  - boost-cpp >=1.73
-  - libcxx >=14.0.6
-  - libevent >=2.1.12,<2.1.13.0a0
-  - openssl >=3.0.9,<4.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 361781
-  timestamp: 1687975246139
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
-  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
-  depends:
-  - jpeg >=9e,<10a
-  - lerc >=3.0,<4.0a0
-  - libcxx >=14.0.6
-  - libdeflate >=1.17,<1.18.0a0
-  - libwebp-base >=1.2.4,<2.0a0
-  - xz >=5.2.10,<6.0a0
-  - xz >=5.2.4,<6.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  license: HPND
-  license_family: Other
-  size: 637627
-  timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
-  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
-  constrains:
-  - libwebp 1.3.2
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 331675
-  timestamp: 1694776939192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
-  sha256: 41c62a460bb81a1a272aa28b219fab9c26510adac177ff1528b1980eabc6e868
-  md5: 8d312c5628dc7ea833e9b4dcb73e9c45
-  depends:
-  - python >=3.11,<3.12.0a0
-  - uc-micro-py >=1.0.1,<2.0.0
-  license: MIT
-  license_family: MIT
-  size: 42346
-  timestamp: 1677973051421
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
-  md5: 56eac4019124c7ae17dc2ae5bffce909
-  constrains:
-  - openmp 14.0.6|14.0.6.*
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 302507
-  timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.42.0-py311h313beb8_0.tar.bz2
-  sha256: 911c7577f591311bfb000121831234e7bc6332bff62fd00c2245371e67f473c0
-  md5: 419681f23f179ba08e5fdf9884ea238d
-  depends:
-  - libcxx >=14.0.6
-  - libllvm14 >=14.0.6,<14.1.0a0
-  - python >=3.11,<3.12.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 410616
-  timestamp: 1706910762686
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
-  sha256: 5777bbef827f72975a36f3da80ab4af718dc781264f74ad7e3864755d620c0f0
-  md5: 4240f1a79b812387919cc710a0469556
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 14318
-  timestamp: 1677925438733
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.3.2-py311h80987f9_0.tar.bz2
-  sha256: 14582ae62269dca40493afba1649f929841f5d2bc5907bf0f6f01c6a551062c4
-  md5: c920d6dea31be5638d79a76026d523a0
-  depends:
-  - lz4-c >=1.9.4,<1.10.0a0
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 39941
-  timestamp: 1686063850483
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
-  sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
-  md5: f5f7e6e7541d8dc3d3df270d488d2e24
-  depends:
-  - libcxx >=14.0.6
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 176990
-  timestamp: 1714510588159
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
-  sha256: d024f5142416961a5e66e424d4d14aec652f9e9dd738b41a97f45674c2ffc9d5
-  md5: 0e2d94b125d802f7b006cf19c71655a1
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 163084
-  timestamp: 1677932947966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
-  sha256: acfd84e29ff4dc2d85543bb973a07f22b4ba53c5d00bca84608ee7f13b2a8676
-  md5: 5ca161cd51e2db358e768453b3ee485e
-  depends:
-  - mdurl >=0.1,<1
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 135871
-  timestamp: 1684279980293
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
-  sha256: b1bed54c7bfb7304cde9e8e6f798543d08e808e81286a5a48296fc94d621f9da
-  md5: 774358285c9e496c9f5c121cc546c823
-  depends:
-  - python >=3.11,<3.12.0a0
-  constrains:
-  - jinja2 >=3.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 27438
-  timestamp: 1704206026910
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.8.4-py311hca03da5_0.tar.bz2
-  sha256: a8d33a3b5014dabc72b49639b2b2c632b8568b692fc963d5bef0222b46c075ab
-  md5: d2d84d2224a9abd25ae550ccaf64ef4e
-  depends:
-  - matplotlib-base >=3.8.4,<3.8.5.0a0
-  - python >=3.11,<3.12.0a0
-  - tornado >=5
-  license: LicenseRef-PSF-based
-  license_family: PSF
-  size: 8973
-  timestamp: 1713336625397
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
-  sha256: 9229a6e15abf3147cfcffad4ca389dad940e45779963b4fc3fd56dfdcfca3234
-  md5: 4e1897f3cb4923de48c016468c01c051
-  depends:
-  - contourpy >=1.0.1
-  - cycler >=0.10
-  - fonttools >=4.22.0
-  - freetype >=2.10
-  - freetype >=2.10.4,<3.0a0
-  - kiwisolver >=1.3.1
-  - libcxx >=14.0.6
-  - numpy >=1.23.5,<2.0a0
-  - packaging >=20.0
-  - pillow >=8
-  - pyparsing >=2.3.1,<3.1
-  - python >=3.11,<3.12.0a0
-  - python-dateutil >=2.7
-  license: LicenseRef-PSF-based
-  license_family: PSF
-  size: 9100733
-  timestamp: 1713336457304
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
-  sha256: 3276d61fc353c537bb09d4b7473d7abe12be38806f42c8cc383b62f40850a5cc
-  md5: 6e9c9d47f264b77d9a8461f0899848a7
-  depends:
-  - python >=3.11,<3.12.0a0
-  - traitlets
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 20446
-  timestamp: 1677918370379
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
-  sha256: 43c96d30775b61b4968422a47f9605049428120669f0742bbb9e5ba145c7d11e
-  md5: a31ca0d9284860adf5463cf45a5e3145
-  depends:
-  - markdown-it-py >=1.0.0,<3.0.0
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 69243
-  timestamp: 1677995336989
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
-  sha256: 96d8c9f42a38651b7bafe5f3cb132601db76cd1e28fa58e2eaf090e634292fff
-  md5: 5ebc793a17b6aa84d13f19433545ffa5
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 23895
-  timestamp: 1677942274932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
-  sha256: db9bd659ada23f1ded443d2db00dd13b5d5c0b30f5062544b1ee2c2b88d63d29
-  md5: 03c48121614cf12abfe30eced9b34717
-  depends:
-  - python >=3.11,<3.12.0a0
-  constrains:
-  - nbconvert >6.1.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 105333
-  timestamp: 1677916687032
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py311h48ca7d4_0.tar.bz2
-  sha256: 3e370e88a51671f87fa0c0e241569950f8c5a38d5e8743c33b0193f54d73d10d
-  md5: dd70eac354c92710ce4e2be9d4b02043
-  depends:
-  - libcxx >=14.0.6
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 38448
-  timestamp: 1677909415759
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
-  sha256: 8b05894fdcbe5cfcdee94812b043de4cd7b4fa51d3e2aad25fc7cff50c8f82ab
-  md5: c970d49137dce1c77f782ee5725950c1
-  depends:
-  - python >=3.11,<3.12.0a0
-  - six
-  license: BSD 3-Clause
-  license_family: BSD
-  size: 30745
-  timestamp: 1677960816849
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
-  sha256: e8eee27fb667aa10b26f3bc4b93f449b7d991ded27b9cb457effee394ce05f6f
-  md5: 6a3e5cd0e1141c01ffb91285bdccfe83
-  depends:
-  - jupyter_client >=6.1.12
-  - jupyter_core >=4.12,!=5.0.*
-  - nbformat >=5.1
-  - python >=3.11,<3.12.0a0
-  - traitlets >=5.4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 123043
-  timestamp: 1698934328890
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
-  sha256: 40230434aa2fbb33ece13632e8d4b7cd1ad68fdb8d1b00263af4a010795d25f8
-  md5: f12ce7dad3620d6d53a442fa9d36a0b0
-  depends:
-  - beautifulsoup4
-  - bleach !=5.0.0
-  - defusedxml
-  - jinja2 >=3.0
-  - jupyter_core >=4.7
-  - jupyterlab_pygments
-  - markupsafe >=2.0
-  - mistune >=2.0.3,<4
-  - nbclient >=0.5.0
-  - nbformat >=5.7
-  - packaging
-  - pandocfilters >=1.4.1
-  - pygments >=2.4.1
-  - python >=3.11,<3.12.0a0
-  - tinycss2
-  - traitlets >=5.1
-  constrains:
-  - pyqtwebengine >=5.15
-  - tornado >=6.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 538067
-  timestamp: 1699022954841
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
-  sha256: a492acec8ceadc0911a75966ffa630a8eb15b2da8c7a8d544a645ba47771a2d1
-  md5: 4002b1b88b2ecfdfc769036f43b0a895
-  depends:
-  - jsonschema >=2.6
-  - jupyter_core
-  - python >=3.11,<3.12.0a0
-  - python-fastjsonschema
-  - traitlets >=5.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 170964
-  timestamp: 1694616845237
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
-  md5: 43568079a90f14ee6d763f2c1cdd3cfa
-  license: MIT AND X11
-  license_family: MIT
-  size: 1078472
-  timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
-  sha256: 417ace1ce51e81f3f92ddc26e0e3a83c1e19c9ebb7af7104452002a5573da534
-  md5: 3e11de6cef096091bb733e07802f00b0
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 16979
-  timestamp: 1708532698253
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-7.0.8-py311hca03da5_0.tar.bz2
-  sha256: 0aab440b27d9cab7a31c41d0198be602a88c41a95efb9e7b5be99a96ee2fc6cb
-  md5: 959445d700f0266e95d1bdf5809d34bf
-  depends:
-  - jupyter_server >=2.4.0,<3
-  - jupyterlab >=4.0.2,<4.1
-  - jupyterlab_server >=2.22.1,<3
-  - notebook-shim >=0.2,<0.3
-  - python >=3.11,<3.12.0a0
-  - tornado >=6.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 3671288
-  timestamp: 1708030081801
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
-  sha256: b0cc542e2a6f42ba716e7e4ccf29eddcb155ad167fcdbc72d2db9c7873eb5639
-  md5: 7acf81b17d2c4ceb3cd39dc9f173855c
-  depends:
-  - jupyter_server >=1.8,<3
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 27539
-  timestamp: 1699455954000
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.59.1-py311h7aedaa7_0.tar.bz2
-  sha256: 4e0fb594095ce53c58f97eafc1c113e150929a6935e8ee54d86359cc7a9afd14
-  md5: df6c4ead6e4bed95d012bdd5e79f10db
-  depends:
-  - libcxx >=14.0.6
-  - llvm-openmp >=14.0.6
-  - llvmlite >=0.42.0,<0.43.0a0
-  - numpy >=1.23.5,<1.27
-  - python >=3.11,<3.12.0a0
-  - tbb >=2021.8.0
-  constrains:
-  - libopenblas >=0.3.18, !=0.3.20
-  - numba-rvsdg 0.0.*
-  - cudatoolkit >=10.2
-  - tbb >=2021.6,<2022
-  - scipy >=1.0
-  - cuda-python >=11.6
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 6062719
-  timestamp: 1711988782214
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
-  sha256: 151a3eb68d1189e69764ece1d8fb3544d31a22f5bbbc3e19d846de8dece304d2
-  md5: eb6609e6bdc9c82d70df3f8c4c2de95b
-  depends:
-  - libcxx >=14.0.6
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 153313
-  timestamp: 1696515415712
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
-  sha256: d3bb1d4be88320a5861cd3a0f086e9709f9b64c96c032cb9039cc4f17ec66a85
-  md5: 0a7b97665c06fcd34a70e34abc177280
-  depends:
-  - blas * openblas
-  - libcxx >=14.0.6
-  - libopenblas >=0.3.21,<1.0a0
-  - numpy-base 1.26.4 py311hfbfe69c_0
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 11288
-  timestamp: 1708639168951
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
-  sha256: 3e70248a7069ca12ccf56252869bfdb72211fd4e4c327e6994756496df786c79
-  md5: ce4846006d98638cd86a532a72f8dfe4
-  depends:
-  - blas * openblas
-  - libcxx >=14.0.6
-  - libopenblas >=0.3.21,<1.0a0
-  - python >=3.11,<3.12.0a0
-  constrains:
-  - numpy 1.26.4 py311he598dae_0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 7536860
-  timestamp: 1708639153133
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
-  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
-  md5: 371358a54bbdd307603888348d1a2c6f
-  depends:
-  - libcxx >=12.0.0
-  - libpng >=1.6.37,<1.7.0a0
-  - libtiff >=4.2.0,<4.7.0
-  license: BSD 2-Clause
-  size: 412248
-  timestamp: 1628861367714
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_1.tar.bz2
-  sha256: 3a06a4dd64641240ad4d8401105a62597fc0b876a94544bade1c6cace13b5ad7
-  md5: bdb8a787b740513c2aba7494ef62c58b
-  depends:
-  - ca-certificates
-  license: Apache-2.0
-  license_family: Apache
-  size: 4766262
-  timestamp: 1714511251647
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
-  sha256: c4135710b5536fb859a6672c055bbc2cff0426e0655e75c7fdf808f7f3344ada
-  md5: 483605a01fccba850b7f0cbdeff29858
-  depends:
-  - libcxx >=14.0.6
-  - libprotobuf >=3.20.3,<3.21.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - snappy >=1.1.9,<2.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 421604
-  timestamp: 1676482754496
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
-  sha256: 77b0c0a0fb14d817390244ebd93c36d44a7867239963f211f7c0a72a3f98d382
-  md5: b90336feb8a50d2eff880e89acb02f40
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 39617
-  timestamp: 1699371253760
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
-  sha256: 4f6c3e8d8fc4c57975cab837ef109b9ee7af4f18aac72668334ac656e53c6edf
-  md5: fbf1b507f9a80c5de3c957e8152124da
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0 or BSD-2-Clause
-  license_family: Apache
-  size: 159289
-  timestamp: 1710807498427
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
-  sha256: 3af823879c340838c1040e99f653c3438ccce8dc559bd91c3f4ab2579282a002
-  md5: 5b3df01fda0281dab4196bc36d1ca367
-  depends:
-  - bottleneck >=1.3.6
-  - libcxx >=14.0.6
-  - numexpr >=2.8.4
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python-dateutil >=2.8.2
-  - python-tzdata >=2022.7
-  - pytz >=2020.1
-  constrains:
-  - odfpy>=1.4.1
-  - adbc-driver-postgresql >=0.8.0
-  - scipy >=1.10.0
-  - fastparquet >=2022.12.0
-  - pyxlsb >=1.0.10
-  - pymysql >=1.0.2
-  - sqlalchemy >=2.0.0
-  - pyreadstat >=1.2.0
-  - beautifulsoup4 >=4.11.2
-  - fsspec >=2022.11.0
-  - openpyxl >=3.1.0
-  - xlsxwriter >=3.0.5
-  - jinja2 >=3.1.2
-  - zstandard >=0.19.0
-  - numba >=0.56.4
-  - matplotlib-base >=3.6.3
-  - psycopg2 >=2.9.6
-  - xlrd >=2.0.1
-  - pyarrow >=10.0.1
-  - pytables >=3.8.0
-  - html5lib >=1.1
-  - blosc >=1.21.3
-  - gcsfs >=2022.11.0
-  - dataframe-api-compat >=0.1.7
-  - qtpy >=2.3.0
-  - adbc-driver-sqlite >=0.8.0
-  - lxml >=4.9.2
-  - xarray >=2022.12.0
-  - s3fs >=2022.11.0
-  - pandas-gbq >=0.19.0
-  - pyqt >=5.15.9
-  - tabulate >=0.9.0
-  - python-calamine >=0.1.7
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 17082645
-  timestamp: 1709591689205
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
-  sha256: 088245becd055af4de74e4ed13cc752ab546423f204b170ba2dd8809af30a2c7
-  md5: 2eabea5ccc56ac088e0349626e59df06
-  depends:
-  - locket
-  - python >=3.11,<3.12.0a0
-  - toolz
-  constrains:
-  - numpy >= 1.9.0
-  - pandas >=0.19.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 48517
-  timestamp: 1698702686783
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
-  sha256: 174b680f4bb041e8146aae80f92390122459e0ef8c911cab22d01e2e92d44ab1
-  md5: cfffc94779cd26a349bd409b5590b098
-  depends:
-  - freetype >=2.10.4,<3.0a0
-  - jpeg >=9e,<10a
-  - lcms2 >=2.12,<3.0a0
-  - libtiff >=4.2.0,<4.7.0
-  - libwebp-base >=1.3.2,<2.0a0
-  - openjpeg >=2.3.0,<3.0a0
-  - python >=3.11,<3.12.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: HPND AND TCL
-  license_family: Other
-  size: 916496
-  timestamp: 1714399019350
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3.1-py311hca03da5_0.tar.bz2
-  sha256: f6298f1b93b2c4f62e11be8f5cb1c184b9774492626f3c93a004cf5d7e4e84f6
-  md5: 92d6c6c6a869b6d1449ddc614f622c42
-  depends:
-  - python >=3.11,<3.12.0a0
-  - setuptools
-  - wheel
-  license: MIT
-  license_family: MIT
-  size: 3445195
-  timestamp: 1700667693168
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
-  sha256: b6200816d65673aa1707c20a768c9cff87dd8dbe1335f9c1478e5931dfa08ee0
-  md5: 14b1e0fa73eb33f9c83048482dcce57b
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 38423
-  timestamp: 1692205689597
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
-  sha256: ebdf211edd98d88a23778551c7a9702106edd0695d4fc48e87c21f77521c1ffe
-  md5: d8c505081a468f1b99c62466e2309417
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 123084
-  timestamp: 1678996822234
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
-  sha256: 07cfba50d9e94364bde077731a824ca4f537138b35ee6b66d07aee16ac9850f1
-  md5: 919bf486280a11e6acb3c2c3a82f7473
-  depends:
-  - python >=3.11,<3.12.0a0
-  - wcwidth
-  constrains:
-  - prompt_toolkit 3.0.43
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 763225
-  timestamp: 1704404463402
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
-  sha256: 8094436b2c44e68e72569c704633802aad82e977b1e16026848218679c8becf4
-  md5: 2360e46d3e598dd5e2abed781fe166c5
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 502115
-  timestamp: 1678995719872
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-14.0.2-py311ha07b5f9_0.tar.bz2
-  sha256: 4ef0edee30559d99ce74a3207b5e594420549d743b6a6942f4910909f0bf7f15
-  md5: ee7f74b498c265a06b470b7f853612e0
-  depends:
-  - arrow-cpp >=14.0.2,<14.0.3.0a0
-  - boost-cpp
-  - libcxx >=14.0.6
-  - numpy >=1.16.6,<2.0a0
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 4965174
-  timestamp: 1707331530109
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
-  sha256: 121b5b66721760c05f1d4eee91626229d1814663d3fb5f23126ef870aa496e26
-  md5: 0c588c2ca790a05d422c06e8568201ad
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 2124200
-  timestamp: 1684280082141
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
-  sha256: 44b694db8e81d61960d28d60f9e9b573f03f7827881d302da334378881db4889
-  md5: 6c94ba7caa599ff533e0ab55d898be8a
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 208454
-  timestamp: 1677910948527
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
-  sha256: 0bb3d2a57b332c5cf73ea40ea13c850ae24a1f9a3a41ed9267832d9e3c767572
-  md5: 45a7fcf1641980d5114999736428502d
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD 3-Clause
-  license_family: BSD
-  size: 36755
-  timestamp: 1677906514270
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.8-hb885b13_0.tar.bz2
-  sha256: 7db8bda1ad368413284ee399322d421feb385863426f8ce3167c0eee6788b8d6
-  md5: b1b70eac1af7d86cc231d9b695ff1d3e
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libffi >=3.4,<3.5
-  - libffi >=3.4,<4.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.0.13,<4.0a0
-  - readline >=8.1.2,<9.0a0
-  - sqlite >=3.41.2,<4.0a0
-  - tk >=8.6.12,<8.7.0a0
-  - tzdata
-  - xz >=5.4.5,<6.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: PSF-2.0
-  license_family: PSF
-  size: 16417657
-  timestamp: 1708983786954
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
-  sha256: f94b3cfea6f76ea9983e16d3c4c7e0a64f02c40cc2c3ad57189bca2e67030bd9
-  md5: 0d100990ade57a02b60d1e8085db0bdf
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 280263
-  timestamp: 1678996927464
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
-  sha256: 252c86f5aef7f8dfce99a260c24cbb35a9adfea144a2acfabb224f516341544f
-  md5: 745b888e19a644f48800799f82c01c21
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 18539
-  timestamp: 1683823925189
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py311h313beb8_0.tar.bz2
-  sha256: 5a40b7ba3aaff79b21020a5ba9df44202d9fa6152abd81f91ed1602cfa864ed7
-  md5: 95226a611d81daf647c0211ef2de31a7
-  depends:
-  - libcxx >=14.0.6
-  - python >=3.11,<3.12.0a0
-  license: OLDAP-2.8
-  license_family: Other
-  size: 148513
-  timestamp: 1682522467465
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
-  sha256: d945744eb133f19ca61325cac5128bdb053ae04de4a0ba6f69c061449cac8af7
-  md5: 34baa81490d667381bc7021435b0e1f2
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 275858
-  timestamp: 1713974457562
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
-  sha256: 4f04a43cbd612ab09cefbdc2e48ee61b51967dad59d859ce0502cc2c46c88fc5
-  md5: c68bf65433b2151b51b2e699bc22c501
-  depends:
-  - python >=3.11,<3.12.0a0
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  size: 194632
-  timestamp: 1698096151085
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-25.1.2-py311h313beb8_0.tar.bz2
-  sha256: 66d6bcf8e67799c60b41ed3c14d352cc065abee1afe41fab710eac41ddb27809
-  md5: 488d9d295388699484bd2d1226157163
-  depends:
-  - libcxx >=14.0.6
-  - python >=3.11,<3.12.0a0
-  - zeromq >=4.3.5,<4.4.0a0
-  license: BSD-3-Clause AND LGPL-3.0-or-later
-  license_family: BSD
-  size: 543785
-  timestamp: 1705605339487
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
-  sha256: 089c6b9bebfa690f380710f219ab0fcc1acec9f2e187d4174a08222c45f58afc
-  md5: 11b832c6c10a6d2b0e687a20c3037c97
-  depends:
-  - libcxx >=12.0.0
-  license: BSD-3-Clause
-  size: 194532
-  timestamp: 1652449531448
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
-  md5: a276a37815f1f5e0af0d6445e4f33e0d
-  depends:
-  - ncurses >=6.3,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 463867
-  timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
-  sha256: 7a208abc002a2fc208ae25cb2cf932999a3e4980aa4c9edff315cb9ac62b12ce
-  md5: bd22ebd3cff811577ea61f115ba7f4f2
-  depends:
-  - attrs >=22.2.0
-  - python >=3.11,<3.12.0a0
-  - rpds-py >=0.7.0
-  license: MIT
-  license_family: MIT
-  size: 74744
-  timestamp: 1699012126255
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
-  sha256: cc8d055a068fe5a7484284c3360d81db61656dd6118c743c740fcc47cd3da379
-  md5: e5fad71ef3b99077b79052576e51bf9f
-  depends:
-  - certifi >=2017.4.17
-  - charset-normalizer >=2,<4
-  - idna >=2.5,<4
-  - python >=3.11,<3.12.0a0
-  - urllib3 >=1.21.1,<3
-  constrains:
-  - pysocks >=1.5.6,!=1.5.7
-  - chardet >=3.0.2,<6
-  license: Apache-2.0
-  license_family: Apache
-  size: 120672
-  timestamp: 1707355664440
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
-  sha256: 52368d9b557b8f54ef5ca4bf6cd5a3ec665171f2b2d2082cdd410bab88f4829c
-  md5: ac76fb4d2eef3ecdd491cf5d3fb8620d
-  depends:
-  - python >=3.11,<3.12.0a0
-  - six
-  license: MIT
-  license_family: MIT
-  size: 10204
-  timestamp: 1683077239143
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
-  sha256: 491d116c5f54ef340e3bce631835f7138cd1923d7b63e6ca9aa01b48110cb8f9
-  md5: 9b81bd8ea808704f5433884b567f1f15
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 10557
-  timestamp: 1683059079547
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
-  sha256: b53a5f6119173d62e4e68a37ea8511c7fc87a00af72953e0048d075a799c7a7a
-  md5: 76a16cf4edb9b12b2b96a2d323f060dc
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 342535
-  timestamp: 1698945991201
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
-  sha256: 9e8312f9452357202813aa289430c939302617f562dae9e90fdc3fb5e9be49d0
-  md5: def02b749d0c0a3675d96aeb508a2306
-  depends:
-  - blas * openblas
-  - libcxx >=12.0.0
-  - libgfortran5
-  - libgfortran5 >=11.2.0
-  - libgfortran5 >=11.3.0
-  - libopenblas >=0.3.21,<1.0a0
-  - numpy >=1.23.5,<1.29
-  - pybind11-abi 4
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
-    BSL-1.0
-  license_family: BSD
-  size: 26383719
-  timestamp: 1714070280353
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
-  sha256: c80d52567084b1caaed2862b77b70065ca17afaf0b020733e9d6c273b4a63e78
-  md5: ddf7d88c1967f3f7a4ce1c975fd47e0d
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 33321
-  timestamp: 1699371225235
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
-  sha256: 6d38d171ef87340cf0fbbf4c70217df4826c65400c9290774f5cb35e381e3315
-  md5: b9529a812f9862fc89461b6b90f184ba
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 1599110
-  timestamp: 1715024190898
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.1.10-h313beb8_1.tar.bz2
-  sha256: f340be28c71abb0b785dd78f742e12befb08e37b77087924364e01a7b1d25bda
-  md5: 4f553ef7b00e79fb67318e680da9fdaa
-  depends:
-  - libcxx >=14.0.6
-  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
-  license_family: BSD
-  size: 42517
-  timestamp: 1702909400491
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
-  sha256: cd71091a234874d2826fa063ec5222b3191c9f47e1b5281c352d9df3f31a06bf
-  md5: 0db8e29016c6bff026c083d9923a7566
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT OR Apache-2.0
-  license_family: Other
-  size: 19073
-  timestamp: 1705431415504
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
-  sha256: 3e18cdafc607c6d7623b1c8f041cbfbb50a27e298f961abdcce7e36834ac39e1
-  md5: 9ee0da74c55d0b8d83edf246fd717f20
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 89862
-  timestamp: 1696347657368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
-  sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
-  md5: d8c1e9910392d0bcb22a173f9ce30fa6
-  depends:
-  - ncurses >=6.4,<7.0a0
-  - readline >=8.1.2,<9.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  - zlib >=1.2.13,<2.0a0
-  license: blessing
-  license_family: Other
-  size: 1758290
-  timestamp: 1714488307689
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
-  sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
-  md5: ae58720a18a2ed15eae214ad7a10d1b5
-  depends:
-  - libcxx >=14.0.6
-  license: Apache-2.0
-  license_family: Apache
-  size: 140125
-  timestamp: 1680167256603
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
-  sha256: b5c265e9ed9a1ff2238a09b83bdc1826950faa87fd6b685debe60888de6e7a50
-  md5: 5827c8a32317894ce18576e334daba47
-  depends:
-  - ptyprocess
-  - python >=3.11,<3.12.0a0
-  - tornado >=6.1.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 38559
-  timestamp: 1677918962258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
-  sha256: cfefd86d0f4981d22b7611b3dc60359b8698bf39f2b743cb90b7005aaca88e1e
-  md5: a04dbcd6095f6b8f3ad195a78d48b262
-  depends:
-  - python >=3.11,<3.12.0a0
-  - webencodings >=0.4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 50058
-  timestamp: 1677917499177
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
-  sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
-  md5: 3c25b4f4768ccda28b20a03ba27e7759
-  depends:
-  - zlib >=1.2.13,<2.0.0a0
-  license: TCL
-  license_family: BSD
-  size: 3484151
-  timestamp: 1714770744982
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
-  sha256: 0836468fafb1f5badbb573922e37200c6929bf2926ecf8d2259dff43811e0727
-  md5: 5bc56dcb4bdb7cf623b7cea499feaddb
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 136409
-  timestamp: 1677925889207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
-  sha256: 177246487449f87567fe56c8f20011a4350a132d1556c9f87474d7b2e8c1374f
-  md5: d465118217b9f27d47dceff89c2e9f95
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 896655
-  timestamp: 1696937042980
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.2-py311hb6e6a13_0.tar.bz2
-  sha256: 70496999384061690df49fe640fcc6d0437ce876d3096dc89c6901cb2bb63845
-  md5: 72dbbceca6984601d78c2bbb796edb66
-  depends:
-  - python >=3.11,<3.12.0a0
-  constrains:
-  - ipywidgets >=6
-  license: MPL-2.0 AND MIT
-  license_family: MOZILLA
-  size: 155676
-  timestamp: 1714567815500
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
-  sha256: 65e760119352cd85c63d365d2576c09a9ddb060e5b029a265d50bc268eed9290
-  md5: 14c241871b12dc3be52e6cd681267caf
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 271445
-  timestamp: 1677911758960
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.9.0-py311hca03da5_1.tar.bz2
-  sha256: eb3608b1f32c4a791ca19a69cf611e470ec7bb722e40f27d3e5f6dbc76c69ecc
-  md5: e4ada62e242b4702435995090405d693
-  depends:
-  - python >=3.11,<3.12.0a0
-  - typing_extensions 4.9.0 py311hca03da5_1
-  license: PSF-2.0
-  license_family: PSF
-  size: 9874
-  timestamp: 1705599390176
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.9.0-py311hca03da5_1.tar.bz2
-  sha256: 0899503a82d0e0a765a7e9d1a0480c3b1c389f4d6e68b633400271380172118e
-  md5: 224636c70a8945f989ebf39b8cfcf52a
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: PSF-2.0
-  license_family: PSF
-  size: 71941
-  timestamp: 1705599383532
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
-  sha256: 2ea2d0520b330d381a2ab241bdb9ae146ef815ee7c96ee52a9773fb9ae85f4fd
-  md5: 66f7f8979cfb2cccffac972d70482130
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 12614
-  timestamp: 1677963554857
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
-  sha256: df7fe7740bd853b641d624e2ec97f1aacb2b82691936a8c04ef18fa9768539c2
-  md5: d5c7626d45fd03b22797c18e47812beb
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 518048
-  timestamp: 1713213046424
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.1.0-py311hca03da5_1.tar.bz2
-  sha256: ec56a4893344adc6712b9915267bb5faca7203496f8ad924cba7ebf2cec302b9
-  md5: 7dd5b6728562eaa24668abd062985f4d
-  depends:
-  - brotli-python >=1.0.9
-  - pysocks >=1.5.6,<2.0,!=1.5.7
-  - python >=3.11,<3.12.0a0
-  constrains:
-  - zstandard >=0.18.0
-  - requests >=2.26.0
-  - selenium >=4.4.3
-  license: MIT
-  license_family: MIT
-  size: 184702
-  timestamp: 1707770626151
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
-  sha256: 20ae100fd04de16356f26e7c9dab514015e57a9d54fb78767aa5ed97de7846fb
-  md5: f620d98b3d0072945948310c86f0f1c5
-  license: MIT
-  license_family: MIT
-  size: 157385
-  timestamp: 1706894678643
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
-  sha256: 09738b7f9075386bf062b12ddb6fb72a06450d2481f6b5ca2026c811cd849569
-  md5: 9afdec076c95746ac21235f971190e40
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD 3-Clause
-  license_family: BSD
-  size: 26727
-  timestamp: 1677910175964
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py311hca03da5_4.tar.bz2
-  sha256: e7e149717c2a2f69f4e80a97aaeff1e929309abeaacf856020e709a9663df561
-  md5: 2ea9e4e91d48d4e0697990e52d1c2b96
-  depends:
-  - python >=3.11,<3.12.0a0
-  - six
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 91423
-  timestamp: 1677919120338
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
-  sha256: aa301d9e42aadbe3dd5f301ccbf17fbadc347fd37d413c0cbcbd24403892a936
-  md5: 77097d17d835a137af7950c628b66150
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 137260
-  timestamp: 1714717037687
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
-  sha256: cf030fc7020dc6d28530075468b8dc1edd843a1e393a2f81ca81c962e9af977b
-  md5: cae3fc90233f3af8f433a253d035b6e6
-  depends:
-  - numpy >=1.21,<2.0a0
-  - packaging >=21.3
-  - pandas >=1.4
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 2470844
-  timestamp: 1689041497962
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
-  sha256: 2cd108896df65636769e3804ecc2ca421ad9b54e64fa21922bbabe40c90c247a
-  md5: b3a1e5077b28f71298d891fbfb5ff03e
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 55645
-  timestamp: 1677927459979
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
-  sha256: 5be8c968f2da5c4bf14f28d63e31b4c1b6993d980023769732c7f58f396c2e0b
-  md5: 3f5f62d4e85e3bdd48d39189b01805a6
-  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
-  license_family: GPL2
-  size: 459197
-  timestamp: 1714510992914
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
-  md5: 990ccbdae7ddeea76e2bf0546d4c6369
-  license: MIT
-  size: 88367
-  timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
-  sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
-  md5: 3d57d1adadca9388aaaa1c529b65ba65
-  depends:
-  - libcxx >=14.0.6
-  - libsodium >=1.0.18,<1.0.19.0a0
-  license: MPL-2.0
-  license_family: Other
-  size: 322790
-  timestamp: 1705602163804
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py311hca03da5_0.tar.bz2
-  sha256: db7fb95af4702cb2ce5281333fa769006f532bc39e8e5bd580a2eb9970a7a38d
-  md5: 2c13d5a0b62ff7a644a6957829dc54a6
-  depends:
-  - heapdict
-  - python >=3.11,<3.12.0a0
-  - python-lmdb
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 103248
-  timestamp: 1695832909752
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.17.0-py311hca03da5_0.tar.bz2
-  sha256: cf38c69cf62d8f07b91b14bef8e0b6fc5ac220bd3a6cd2ab0378283f0f11494a
-  md5: 11660f745caf5eed1d03eafadb32678b
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 25470
-  timestamp: 1704206932876
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
-  sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
-  md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
-  license: Zlib
-  license_family: Other
-  size: 104928
-  timestamp: 1714510936868
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
-  sha256: a3f3eaf240991b6bd7b0596a78d0abb3321cc79db52fa24f6f559189778871c6
-  md5: 71f035b4716322539e2461cb6667e946
-  depends:
-  - libcxx >=14.0.6
-  - lz4-c >=1.9.4,<1.10.0a0
-  - xz >=5.4.6,<6.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause AND GPL-2.0-or-later
-  license_family: BSD
-  size: 825339
-  timestamp: 1714678419523
-- conda: https://repo.anaconda.com/pkgs/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
-  sha256: c5a4f98a90713f799a73195cc159571c4bd373bfa43640dc0c1707608e582945
-  md5: 537f198da93942d8ef7008606edae551
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 2363136
-  timestamp: 1652426285158
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
-  sha256: 6e6787755de0cf2fd776c9681a7b0fd0fb23e35e679a463cc2005b991c413910
-  md5: ccad42ec9a2ad48939f089c528abc8f0
-  depends:
-  - idna >=2.8
-  - python >=3.11,<3.12.0a0
-  - sniffio >=1.1
-  constrains:
-  - uvloop >=0.17
-  - trio >=0.23
-  license: MIT
-  license_family: MIT
-  size: 229694
-  timestamp: 1706220431719
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
-  sha256: f715f7c2e06149bd6d43258e41479d3171efe5e9d56050a0a5f5652ed9d05fff
-  md5: 11a8ca43d69881b88f95ae681478866d
-  depends:
-  - cffi >=1.0.1
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: MIT
-  license_family: MIT
-  size: 36089
-  timestamp: 1676424516042
-- conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-14.0.2-ha81ea56_1.tar.bz2
-  sha256: 5d0903878b06d0a444fa43444390f3b662f6338750e23ee2817c784246ff7098
-  md5: e0fda639825394bcb3a87b639c0d7a11
-  depends:
-  - abseil-cpp >=20211102.0,<20211102.1.0a0
-  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
-  - aws-sdk-cpp >=1.10.55,<1.10.56.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - c-ares >=1.18.1,<2.0a0
-  - glog >=0.5.0,<0.6.0a0
-  - grpc-cpp >=1.48.2,<1.49.0a0
-  - libbrotlicommon >=1.0.9,<1.1.0a0
-  - libbrotlidec >=1.0.9,<1.1.0a0
-  - libbrotlienc >=1.0.9,<1.1.0a0
-  - libprotobuf >=3.20.3,<3.21.0a0
-  - libthrift >=0.15.0,<0.16.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - openssl >=3.0.13,<4.0a0
-  - orc >=1.7.4,<1.7.5.0a0
-  - re2 >=2022.4.1,<2022.4.2.0a0
-  - snappy >=1.1.9,<2.0a0
-  - utf8proc >=2.6.1,<2.9.0
-  - vc >=14.2,<15.0a0
-  - vs2015_runtime >=14.27.29016,<15.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 9794512
-  timestamp: 1707254932864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/async-lru-2.0.4-py311haa95532_0.tar.bz2
-  sha256: 6acc4dc697147467d128382439a1648f2dc6c498d0a97aa9c44ef5de2962cdc6
-  md5: 8baa05a5d81f5f0dd92cdd60fd509486
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 21308
-  timestamp: 1699554782283
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
-  sha256: 9adabcdd2a10f73fa5ba56adc901eeea2e379991a0d4cb9737eec7aa6b9fc5d8
-  md5: fc80b572be85601706d425b21a58d497
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 153102
-  timestamp: 1695718054194
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
-  sha256: a11741c5aaa360b4772d0fb7eea606edb5266a4e2806b22f0b8b65b69b7a7273
-  md5: 9a54285c5e75ab5e6bfcb3b5590f9449
-  depends:
-  - aws-c-cal >=0.5.20,<0.5.21.0a0
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-http >=0.6.25,<0.6.26.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 93395
-  timestamp: 1706746331576
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
-  sha256: 32b4da68dd0edbf0c8d7a8a18ba400b26775faabaccbc2cb3e9d2ab7c65e7714
-  md5: 48f0a7a7f739d8be4c9dd061be217619
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 45714
-  timestamp: 1706691182873
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
-  sha256: d2710c7f5b4bb8f94a964996387fbd6396f9881d163affeb7ffb050a39e58c1c
-  md5: 1a8a2f82798a94d1b272ec2d307cc5ef
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 195487
-  timestamp: 1706190077309
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
-  sha256: 0a5ea74ebcf9bdccfad972add8ff83a47992ab28370cebc34fc4594c1c7cf03a
-  md5: 2f90d407ca685c124ddb5fc4d79f4517
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 21804
-  timestamp: 1706690937014
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
-  sha256: 334d2d9c4181c9955256485f66bf4e48ae9b1dc03044aa0424bf1fda292b3151
-  md5: 9ab57953af3164d3d94001eeca0e6359
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  - aws-checksums >=0.1.13,<0.1.14.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 52661
-  timestamp: 1706697357084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
-  sha256: 59155d1258b4e29c0046e5ab14b1e2cb3ccfca069982fe9dd4cd751b1ed67492
-  md5: 28bd7c351db93c3b8520cc1598eddf66
-  depends:
-  - aws-c-cal >=0.5.20,<0.5.21.0a0
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-compression >=0.2.16,<0.2.17.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 177605
-  timestamp: 1706744253596
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
-  sha256: 3aa9b1c2c508a5dcfb482083cb986498f6df460e652cc7557d3c2d122d559ebe
-  md5: b8bf7ae26d234b6738fc37b7c172b3c5
-  depends:
-  - aws-c-cal >=0.5.20,<0.5.21.0a0
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 145865
-  timestamp: 1706696287610
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
-  sha256: 68564155186523ec8b97b892d0a6b62b3e6f75e4e2b80fac5684011e070295d6
-  md5: ba2fa531a69a5a7e4966eba6d7891c8b
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-http >=0.6.25,<0.6.26.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 69542
-  timestamp: 1706746839018
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
-  sha256: 9c0f2f18f8b7e10e940d2438d70a2a03893421f25fd50461b8b2979f3a310a15
-  md5: da0f3ce6d8f71a71e6cae01832d853f5
-  depends:
-  - aws-c-auth >=0.6.19,<0.6.20.0a0
-  - aws-c-cal >=0.5.20,<0.5.21.0a0
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-http >=0.6.25,<0.6.26.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  - aws-checksums >=0.1.13,<0.1.14.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 72614
-  timestamp: 1706747680710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
-  sha256: bcee1da236f6f5f88322979daddc89e8555648593f6282ad3073a68eb22a68d2
-  md5: bf4c19b0db5049930d8b2fcc3b9172fa
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 51027
-  timestamp: 1706690972693
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
-  sha256: 32561df1e664cb320f79c26c5af23dd55953924e66824e2d6372a44687147bdc
-  md5: 05f4c6715180a992468035c0a86e734c
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 54300
-  timestamp: 1706192197648
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
-  sha256: 94d2fff3facfd248968d39a3fd7d3b1f7270df32a87dd567c33d60da1a5eb064
-  md5: 64fed6e7c73d88bfbfc39e838022f948
-  depends:
-  - aws-c-auth >=0.6.19,<0.6.20.0a0
-  - aws-c-cal >=0.5.20,<0.5.21.0a0
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
-  - aws-c-http >=0.6.25,<0.6.26.0a0
-  - aws-c-io >=0.13.10,<0.13.11.0a0
-  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
-  - aws-c-s3 >=0.1.51,<0.1.52.0a0
-  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 199877
-  timestamp: 1706827970924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.10.55-hd77b12b_0.tar.bz2
-  sha256: 813f252df10d2782fbb26e2c6348f55d44ef1618467e340224df44bcda4814ff
-  md5: 8efc1448ada827ddba894a07903808dc
-  depends:
-  - aws-c-common >=0.8.5,<0.8.6.0a0
-  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
-  - aws-checksums >=0.1.13,<0.1.14.0a0
-  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
-  - libcurl >=7.88.1,<9.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 2519847
-  timestamp: 1706890866084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/babel-2.11.0-py311haa95532_0.tar.bz2
-  sha256: b94e6065a6fec9259eef85dc952c59bf20e854682cbf934f04a0c2f1ac2417f0
-  md5: 50cfce72575fcdf3757c27bc6ba5d0e9
-  depends:
-  - python >=3.11,<3.12.0a0
-  - pytz >=2015.7
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 7218701
-  timestamp: 1676427266094
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
-  sha256: 38ccda1553733326d99a75436b4b0f7640bafbbfcdbc33838b0e59cf017de687
-  md5: 3f6812578c5e0b3ba0d2a651cc766c15
-  depends:
-  - python >=3.11,<3.12.0a0
-  - soupsieve >1.2
-  license: MIT
-  license_family: MIT
-  size: 266405
-  timestamp: 1681493141116
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
-  md5: e8aa6b7daaf0925245c148aaeaa0722e
-  size: 6183
-  timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
-  sha256: fe765d810e1612af7a42f34223077f0adc05dbd386b257be24661913d067fe30
-  md5: 82e988aba03c8afa03fce78f7442806e
-  depends:
-  - contourpy >=1.2
-  - jinja2 >=2.9
-  - numpy >=1.23.5,<2.0a0
-  - packaging >=16.8
-  - pandas >=1.2
-  - pillow >=7.1.0
-  - python >=3.11,<3.12.0a0
-  - pyyaml >=3.10
-  - tornado >=6.2
-  - xyzservices >=2021.09.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6086137
-  timestamp: 1712084583317
-- conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
-  sha256: 68ef338b27c035add89c0812ad469dd8c9e94f27130f770345ea20deb049d50b
-  md5: 9ec19b145f655329532b608963cf32f4
-  depends:
-  - libboost 1.82.0 h3399ecb_2
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: BSL-1.0
-  license_family: OTHER
-  size: 11334
-  timestamp: 1696764270626
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
-  sha256: 5c12a5d7856d9977447360b3a99a5b99818707fe79781ba1779037f11b3fef53
-  md5: 6a125ae352306a944aabc635a5fe13a3
-  depends:
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 139230
-  timestamp: 1707864402762
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
-  sha256: 751071782f597f87ed7f67437ef6cc669213902461b9795dd6eb0f4897eddc83
-  md5: 5ad8fe62aad5e16cfdf2c5a7d1327fe7
-  depends:
-  - brotli-bin 1.0.9 h2bbff1b_8
-  - libbrotlidec 1.0.9 h2bbff1b_8
-  - libbrotlienc 1.0.9 h2bbff1b_8
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: MIT
-  size: 19418
-  timestamp: 1714483531456
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
-  sha256: 9bd62d810867549b9c967c5915f3fa3f66cfbd6ede28b1cc152efd1261285c0a
-  md5: 64cc76de3662b62bc8f0e42befd92c5d
-  depends:
-  - libbrotlidec 1.0.9 h2bbff1b_8
-  - libbrotlienc 1.0.9 h2bbff1b_8
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: MIT
-  size: 32178
-  timestamp: 1714483513837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
-  sha256: 1547fa52134cf06b8d01bdf52114db7db60a89bf35c9c95be5b5a03b13dbd565
-  md5: deb765cb7c4b7edc4d126f864f31747c
-  depends:
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: MIT
-  size: 356401
-  timestamp: 1714483740924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
-  sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
-  md5: 11e0af09a31e2d5df51c65a342032b85
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: bzip2-1.0.8
-  license_family: BSD
-  size: 112994
-  timestamp: 1714511182837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
-  sha256: 41a6c5a90b88ec7010bb6dd89390754e476b52c3ab2d519bdab9556da8829479
-  md5: b047426a545e287f45e8abfbfcb0de55
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: MIT
-  license_family: MIT
-  size: 118041
-  timestamp: 1693902191485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
-  sha256: 73391a74a5300ad3fb063ea0f0c3491d220128a0611a84036da2e23c1e93dc0e
-  md5: 501ded4f9b5ed895077802defee912cf
-  license: MPL-2.0
-  license_family: Other
-  size: 171644
-  timestamp: 1710764856021
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
-  sha256: cd6545642e380b13700f2f2a7a1fb54a273365047bd23108dbd03b197f5c0c9c
-  md5: 929edc1c553d2da4d6c6c0745b033cc3
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MPL-2.0
-  license_family: Other
-  size: 166377
-  timestamp: 1707229328635
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
-  sha256: 5cb6ac90ad234248f3795945f69b0382397714a52712337b2f86339526b822d8
-  md5: b90f3126f6315ea2e8ab242533062557
-  depends:
-  - pycparser
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: MIT
-  license_family: MIT
-  size: 302693
-  timestamp: 1714483562551
-- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
-  sha256: 7153817dd49ec317b519802c7c22c836602e00cbd96d68385e83eaf4c9f5ba6a
-  md5: cd829e5997611a602e29fa2fd5882635
-  depends:
-  - colorama
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 204113
-  timestamp: 1698130080270
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py311haa95532_0.tar.bz2
-  sha256: 03f00c22b6d92ee55b727b369e8dbdd9a4d590f2655b62b7c45ecd046741858e
-  md5: 116f67c13bb0b3caee6cbde334ff6abb
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 49934
-  timestamp: 1683040303796
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
-  sha256: 4099898f02e1f6119fcda65e747c3cbfef0bf563c8855b79a0245160709d5b45
-  md5: ab9705c34e67fb8c8faec69d63ff4064
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 36410
-  timestamp: 1676422341506
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
-  sha256: 8fb3e816a5ad1da05125462dbc9e2a7e933b001a871aa65703802c0a894c6277
-  md5: ee4b2fa9fce130496d5c7c86c35a1a05
-  depends:
-  - python >=3.11,<3.12.0a0
-  - traitlets >=4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 17723
-  timestamp: 1709323150229
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
-  sha256: eeb49cd151ecdccd40062e8123a3b7a9a8a1eda6567dd33ce909ff8ee1a97c89
-  md5: b7fe1f7ead1ec2ac642d022942282fc8
-  depends:
-  - numpy >=1.20,<2
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 232451
-  timestamp: 1700583772701
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cramjam-2.7.0-py311h005caf5_0.tar.bz2
-  sha256: 97def042390c467aaaa3f4c33276b0c134c40eb426695332673ed1173f999258
-  md5: 13d97f9f5f7b1f8808e4a694b3305f15
-  depends:
-  - m2w64-gcc-libs
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 1384742
-  timestamp: 1702664451643
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.2-py311h2bbff1b_0.tar.bz2
-  sha256: 037aab9c08cd8f7e78e65b602b3c2b61a7c812b270cbea15bef0e36d0305db6f
-  md5: b4e5dd983a62a7c27d73900400eab7ba
-  depends:
-  - python >=3.11,<3.12.0a0
-  - toolz >=0.10.0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 369375
-  timestamp: 1701724118486
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-2023.11.0-py311haa95532_0.tar.bz2
-  sha256: 07c590287f10f1dd3cddeb245a8b0ff47e407c9c4847d865c970117c27f927d9
-  md5: 7443c06200da9d46add828acd021e4b8
-  depends:
-  - bokeh >=2.4.2
-  - cytoolz >=0.12.0
-  - dask-core 2023.11.0.*
-  - distributed 2023.11.0.*
-  - jinja2 >=2.10.3
-  - lz4 >=4.3.2
-  - numpy >=1.21,<2.0a0
-  - pandas >=1.3
-  - pyarrow >=7.0
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6038
-  timestamp: 1701444864356
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.11.0-py311haa95532_0.tar.bz2
-  sha256: 132d5f66fb9c6b2093c5c066d3fa6ac1468d1bd3fb3b26816556f3c4c8e4be08
-  md5: aace1519be879e46f0cbc9e62bd5a4ba
-  depends:
-  - click >=8.1
-  - cloudpickle >=1.5.0
-  - fsspec >=2021.09.0
-  - importlib-metadata >=4.13.0
-  - packaging >=20.0
-  - partd >=1.2.0
-  - python >=3.11,<3.12.0a0
-  - pyyaml >=5.3.1
-  - toolz >=0.10.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 3086382
-  timestamp: 1701396440772
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
-  sha256: 5c73f86e575f2ad683ee4a1c2df11020e270edd89d12f11199483d57b0b51826
-  md5: e96a12895ce374476277b1b196ba24bd
-  depends:
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: MIT
-  license_family: MIT
-  size: 3719519
-  timestamp: 1690907216785
-- conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2023.11.0-py311haa95532_0.tar.bz2
-  sha256: 14dd722d920d5665f456ef7493b31fb6420c622045dbbf59bf0d8ea5063cdc3d
-  md5: 857a10ff7dc92814dfec2c430655bf16
-  depends:
-  - click >=8.0
-  - cloudpickle >=1.5.0
-  - dask-core 2023.11.0.*
-  - jinja2 >=2.10.3
-  - locket >=1.0.0
-  - msgpack-python >=1.0.0
-  - packaging >=20.0
-  - psutil >=5.7.2
-  - python >=3.11,<3.12.0a0
-  - pyyaml >=5.3.1
-  - sortedcontainers >=2.0.5
-  - tblib >=1.6.0
-  - toolz >=0.10.0
-  - tornado >=6.0.4
-  - urllib3 >=1.24.3
-  - zict >=3.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1807075
-  timestamp: 1701398374335
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-2023.8.0-py311hd7041d2_0.tar.bz2
-  sha256: 59100f20fb5ad8ab300e7db8d461f3364a38598ae09131c7e135660d88101f93
-  md5: acd0953107d9f2e222225e47485acb16
-  depends:
-  - cramjam >=2.3.0
-  - fsspec
-  - numpy >=1.23.5,<2.0a0
-  - packaging
-  - pandas >=1.5.0
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 531570
-  timestamp: 1696542815866
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
-  sha256: 27fb03eb57d25711a15e145f47a64320a9955b585efc9fd0a1a51cdd71b9fde3
-  md5: eb3869e98f6f53dfec76e2eff4d6b61e
-  depends:
-  - brotli >=1.0.1
-  - python >=3.11,<3.12.0a0
-  - unicodedata2 >=15.1.0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  constrains:
-  - uharfbuzz >=0.23.0
-  - skia-pathops >=0.5.0
-  - lz4 >=1.7.4.2
-  - zopfli >=0.1.4
-  - fs >=2.2.0,<3
-  - lxml >=4.0
-  license: MIT
-  license_family: MIT
-  size: 2732423
-  timestamp: 1713552175344
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
-  md5: ef1b830ffb28c46ec812362318ea7ec3
-  depends:
-  - libpng >=1.6.37,<1.7.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: GPL-2-only and LicenseRef-FreeType
-  license_family: Other
-  size: 527643
-  timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.3.1-py311haa95532_0.tar.bz2
-  sha256: c906de92968266d481957c5776467523da53b7f4d6daadb63255bd5cefd252c3
-  md5: 2710581e3de1c90426c77e4b73185262
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 372660
-  timestamp: 1714461880258
-- conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
-  sha256: 7cb0df7aa62796b0081e1708003529c02411aca6a540bae97beaec919aa64e74
-  md5: ea81fd813e10055553a8d7597c8be98f
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 322778
-  timestamp: 1706888324269
-- conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
-  sha256: ed1fa1a40c6739b48ff3a2d51c3df20e4983b59684b04d93e1337c5f2e93a954
-  md5: 1797f64343a42395207cd452e6a6a751
-  depends:
-  - gflags >=2.2.2,<2.3.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 94476
-  timestamp: 1706895442146
-- conda: https://repo.anaconda.com/pkgs/main/win-64/grpc-cpp-1.48.2-hfe90ff0_1.tar.bz2
-  sha256: 0c6223208742064a2829f8dd658e04b72f5176e357a1320c0b0398b91abfd292
-  md5: 19c77d6709407253582fae939434016c
-  depends:
-  - libprotobuf >=3.20.3,<3.20.4.0a0
-  - openssl 3.*
-  - re2
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 31002375
-  timestamp: 1685747992041
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
-  sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
-  md5: 582d2c1135a89da757a038de831e7f39
-  license: Intel proprietary
-  size: 11086648
-  timestamp: 1664812389803
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
-  sha256: 945f4521793d7d279532d1ccd5157201c5cbf64f846bfe60249d01e1b4edf295
-  md5: 0accae23d095c165ac731f4a1f3ca497
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: MIT
-  license_family: MIT
-  size: 37021132
-  timestamp: 1692294548916
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
-  sha256: 102c803186db6d62eaf41a906f6c563ff0d62b53c1eaede8a381e18c0d005ed9
-  md5: 9d30dec03058758a428cf152e0ae28b5
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 148193
-  timestamp: 1714399061601
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
-  sha256: db30abacf919b3f68ae1e6a94c467fd1e69fbf47ba7a86e6b491d8bfe4776f92
-  md5: 9299876e7ddc3aea3487fd93340ceae7
-  depends:
-  - python >=3.11,<3.12.0a0
-  - zipp >=0.5
-  license: Apache-2.0
-  license_family: APACHE
-  size: 50842
-  timestamp: 1704813715071
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
-  sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
-  md5: d215cc8ee7ca2cc83cc250cc5d822fe0
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: LicenseRef-ProprietaryIntel
-  license_family: Proprietary
-  size: 3929136
-  timestamp: 1699647939158
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
-  sha256: 864e9598f64105769b4ec02cc404fb507bc59e217324daf1686c00cfd12c0055
-  md5: 6bb1c3be1f85799a3988afc2c3c5a4f0
-  depends:
-  - comm >=0.1.1
-  - debugpy >=1.6.5
-  - ipython >=7.23.1
-  - jupyter_client >=6.1.12
-  - jupyter_core >=4.12,!=5.0.*
-  - matplotlib-inline >=0.1
-  - nest-asyncio
-  - packaging
-  - psutil
-  - python >=3.11,<3.12.0a0
-  - pyzmq >=24
-  - tornado >=6.1
-  - traitlets >=5.4.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 229621
-  timestamp: 1705934494547
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
-  sha256: e0b44f0c3a4ead0fb8e58033c0be25524ee9ecf7f4cc632f03e9f6fac3484baa
-  md5: 50cbc18d0c7b42a4553b52d0cef2c857
-  depends:
-  - colorama
-  - decorator
-  - jedi >=0.16
-  - matplotlib-inline
-  - prompt_toolkit >=3.0.41,<3.1.0
-  - pygments >=2.4.0
-  - python >=3.11,<3.12.0a0
-  - stack_data
-  - traitlets >=5
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1637367
-  timestamp: 1704834149957
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
-  sha256: d81566367c79a28d4717157fc74293e846a47af99387ed479eb001a425dd398e
-  md5: 28c76079c96ad7f8b1a5ed32b438c79a
-  depends:
-  - parso >=0.8.0,<0.9.0
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 1147434
-  timestamp: 1679427525584
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
-  sha256: f766a445df8e81447f27c830e162566b221fa1bfc41296a6c5e0789586ca1fbf
-  md5: 55bc50633414fc8616ccbf4140a42d5f
-  depends:
-  - markupsafe >=2.0
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 353715
-  timestamp: 1706733949898
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
-  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
-  md5: 81f2c343dc4c65eea39c45383272068f
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: IJG
-  license_family: Other
-  size: 407861
-  timestamp: 1677849239400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
-  sha256: 5e6698015a3b048093f5737f0e54bcbae415d0f9682dfdfeae3a8cfb4ea275e2
-  md5: 0093a4214131046c4f68af0739dfbea4
-  depends:
-  - attrs >=22.2.0
-  - jsonschema-specifications >=2023.03.6
-  - python >=3.11,<3.12.0a0
-  - referencing >=0.28.4
-  - rpds-py >=0.7.1
-  license: MIT
-  license_family: MIT
-  size: 201456
-  timestamp: 1699041872445
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
-  sha256: 9581be54128954080d7cef448b1728874c2ebbe5064f55adece422cf12eafa5a
-  md5: 3adc105f87d5c7f0b1248bc3423f5b48
-  depends:
-  - python >=3.11,<3.12.0a0
-  - referencing >=0.28.0
-  license: MIT
-  license_family: MIT
-  size: 16187
-  timestamp: 1699032556953
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter-lsp-2.2.0-py311haa95532_0.tar.bz2
-  sha256: 2fd9671118852dc700897fdb980a323287f40880f2ef19864e78039049f84563
-  md5: c3ab03d0742e6ca173838fae93247b04
-  depends:
-  - jupyter_server >=1.1.2
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 101303
-  timestamp: 1699978449116
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-8.6.0-py311haa95532_0.tar.bz2
-  sha256: 4772d37293b0350a3fbfa9b16d0b279544c753f78371b352013daa1d4769a78d
-  md5: 5cd7415248e27a289f9d6dff9b600a73
-  depends:
-  - jupyter_core >=4.12,!=5.0.*
-  - python >=3.11,<3.12.0a0
-  - python-dateutil >=2.8.2
-  - pyzmq >=23.0
-  - tornado >=6.2
-  - traitlets >=5.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 258542
-  timestamp: 1699456032957
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
-  sha256: 851ae576c2b72bf3172cd460feec4f5577dc06476a043e185279071b67549fab
-  md5: fae4d214d00de6604738f39acbbb197e
-  depends:
-  - platformdirs >=2.5
-  - python >=3.11,<3.12.0a0
-  - pywin32 >=300
-  - traitlets >=5.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 119710
-  timestamp: 1698937651636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
-  sha256: d97ad90f9121ecf7f8d3af773b222c0bd244204ee73a3e44185491fa16d83104
-  md5: 73ac0fa3c67e5eb283173d74a2771752
-  depends:
-  - jsonschema >=4.18.0
-  - python >=3.11,<3.12.0a0
-  - python-json-logger >=2.0.4
-  - pyyaml >=5.3
-  - referencing
-  - rfc3339-validator
-  - rfc3986-validator >=0.1.1
-  - traitlets >=5.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 60625
-  timestamp: 1699282918176
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
-  sha256: 257e1102d2dc3f8b0c1708585c819e86f41abd101084cd0569e8e31652480875
-  md5: 2128c6806bba6953e1a275f37e7a295b
-  depends:
-  - anyio >=3.1.0
-  - argon2-cffi
-  - jinja2
-  - jupyter_client >=7.4.4
-  - jupyter_core >=4.12,!=5.0.*
-  - jupyter_events >=0.6.0
-  - jupyter_server_terminals
-  - nbconvert >=6.4.4
-  - nbformat >=5.3.0
-  - overrides
-  - packaging
-  - prometheus_client
-  - python >=3.11,<3.12.0a0
-  - pywinpty
-  - pyzmq >=24
-  - send2trash >=1.8.2
-  - terminado >=0.8.3
-  - tornado >=6.2.0
-  - traitlets >=5.6.0
-  - websocket-client
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 614705
-  timestamp: 1699467242943
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
-  sha256: 90420847230e72a648417f5f77cebcf7f17b89f70788652c276acc0c440e135f
-  md5: ef3d8dee197aa37897bf6d39d2dd878f
-  depends:
-  - python >=3.11,<3.12.0a0
-  - pywinpty >=2.0.10
-  - terminado >=0.8.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 27639
-  timestamp: 1686871052174
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab-4.0.11-py311haa95532_0.tar.bz2
-  sha256: cc3eb5e2c513fab04e2740a093f9c44f0355f746ba4cbfeacc2ecbbd08d7096f
-  md5: 729d6b5a3d58c98e8ec73afcb59e0d0b
-  depends:
-  - async-lru >=1.0.0
-  - ipykernel
-  - jinja2 >=3.0.3
-  - jupyter-lsp >=2.0.0
-  - jupyter_core
-  - jupyter_server >=2.4.0,<3
-  - jupyterlab_server >=2.19.0,<3
-  - notebook-shim >=0.2
-  - packaging
-  - python >=3.11,<3.12.0a0
-  - tornado >=6.2.0
-  - traitlets
-  - pywin32
-  constrains:
-  - nodejs >=18.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6714941
-  timestamp: 1706809027799
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_server-2.25.1-py311haa95532_0.tar.bz2
-  sha256: 066d78020fbe62fa9401979852ddbeff05f8e9faeec861487cb2662b9b5d39f9
-  md5: 2f7340345dee00a18c766c1c1472fca3
-  depends:
-  - babel >=2.10
-  - jinja2 >=3.0.3
-  - json5 >=0.9.0
-  - jsonschema >=4.18.0
-  - jupyter_server >=1.21,<3
-  - packaging >=21.3
-  - python >=3.11,<3.12.0a0
-  - requests >=2.31
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 106966
-  timestamp: 1699555552806
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
-  sha256: 8a2f0909fad0387e57cb0e9ee30db2b20761a9106e794381ffeac387a298fb07
-  md5: 6058b2efc3284e27aacec2e6e6280433
-  depends:
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 62334
-  timestamp: 1676432044242
-- conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
-  sha256: ef6b0347ae565dd648a2bb40bc8b0b30f2e4f8387778fefced1d581b7d5a3e16
-  md5: 8ef1d5919aa55fe56ef34d9a7969dca7
-  depends:
-  - openssl 3.*
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: MIT
-  license_family: MIT
-  size: 861982
-  timestamp: 1684424430941
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
-  sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
-  md5: f5f73266281ab12377d5d47bdf07500a
-  depends:
-  - jpeg >=9b,<10a
-  - libtiff >=4.1.0,<4.7.0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: MIT
-  license_family: MIT
-  size: 905072
-  timestamp: 1617648814933
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
-  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 145864
-  timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
-  sha256: 4184dd040fc38cb123a98588a8344aa8d1ba1932df5fcc6c188f6b21f5a0c306
-  md5: da58cfa83f3d6c31ae12d8777cd1b64d
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  - xz >=5.4.2,<6.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  license: BSL-1.0
-  license_family: OTHER
-  size: 29803292
-  timestamp: 1696764164248
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
-  sha256: 7c906c94a4d46ea963080a6ba5bd12c1274da66159877a544fbc70291eeed98d
-  md5: 45a3d52534fac8aa54a55ee92211a918
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: MIT
-  size: 80216
-  timestamp: 1714483371043
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
-  sha256: daad7edc6d56abf3e176479e8628162dbf1c56b3d24db30d708aebae694a5214
-  md5: e8ecf229f7fcb4c0b76d8613627948f5
-  depends:
-  - libbrotlicommon 1.0.9 h2bbff1b_8
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: MIT
-  size: 45189
-  timestamp: 1714483420152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
-  sha256: 84320217abffa9386186ec8d03b4651bb4b1900d3871adc965a9a9e1d3799907
-  md5: 651312fa22168f71f9aec5f9ee2c2fcf
-  depends:
-  - libbrotlicommon 1.0.9 h2bbff1b_8
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: MIT
-  size: 756116
-  timestamp: 1714483464368
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
-  sha256: bb17beae8860a83d081d57273825b46bf8fe9903f3b4182ab41a7ae2c7274859
-  md5: 94182f4ab8beb4eddfd8167b2e2b0380
-  depends:
-  - libclang13 14.0.6 default_h8e68704_1
-  - vc >=14.2,<15.0a0
-  - vs2015_runtime >=14.27.29016,<15.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 147804
-  timestamp: 1681225547009
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
-  sha256: 01b84a38c9069e7b8e6fa2a07707e785df7d40b8f01d76a504e98e5a5cd58539
-  md5: 22c9f7e59174c49f06e3c5c9384401ce
-  depends:
-  - vc >=14.2,<15.0a0
-  - vs2015_runtime >=14.27.29016,<15.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 25699299
-  timestamp: 1681225463612
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.5.0-h86230a5_0.tar.bz2
-  sha256: d505283d2d3a94a530b341933d3047662d3481d88826ddf68bd78935c0fb94c3
-  md5: 1e9446c8a7f39247834fe0bd16d3edb0
-  depends:
-  - libssh2 >=1.10.0
-  - libssh2 >=1.10.0,<2.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: curl
-  license_family: MIT
-  size: 338561
-  timestamp: 1704383910302
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
-  md5: 2539073f9c3b4126f8fef179e4a2697a
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: MIT
-  license_family: MIT
-  size: 187095
-  timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
-  sha256: 6458c7a370c4e3366b3b208c5b2834a7acfb17981e47fe3fb861f225d7cefbc3
-  md5: ecabf4acab5b604856d8c7c4278c2c2c
-  depends:
-  - openssl 3.*
-  - openssl >=3.0.8,<4.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 446380
-  timestamp: 1685052520132
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
-  sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
-  md5: cf949d76148be1e2a534218d9c57df86
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: MIT
-  license_family: MIT
-  size: 155435
-  timestamp: 1714484319443
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
-  md5: 78315f89b8550030dc574d04bc69c115
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: Zlib
-  license_family: Other
-  size: 707959
-  timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.17-h906ac69_0.tar.bz2
-  sha256: 54b46079c184c286b2f91575d3b5917bc3e6737f06885a50426e3263227c8a00
-  md5: e4d2859474935b4873e48b09ef30a95e
-  depends:
-  - krb5 >=1.20.1,<1.21.0a0
-  - openssl >=3.0.12,<4.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  size: 3763163
-  timestamp: 1706215177824
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
-  sha256: f7368e611e349b91315ce4ba4dbf9116d996a48f98eed425f4d5c3d5b9fcfa5e
-  md5: 77eb9daff9052f1fbf24d91c5bba1d74
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2543079
-  timestamp: 1675278760037
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
-  md5: 3151bf6860a305eeb17df6f0e7a4658a
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: ISC
-  size: 681655
-  timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-he2ea4bf_3.tar.bz2
-  sha256: 710583b5a497bcf272fd084d935cbaac637971e33d66179de3fc5e6893dac3db
-  md5: 78ea474a8843c52f4b4fc24289593a54
-  depends:
-  - openssl >=3.0.13,<4.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 242393
-  timestamp: 1714511648937
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
-  sha256: 238e486a0d62264e7ab35098bdc0390fb9a4649921b18827228c811ae8252c88
-  md5: f1ebe453c5a955a25e4b00f73279fc42
-  depends:
-  - boost-cpp >=1.73
-  - libevent
-  - openssl >=3.0.9,<4.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 894777
-  timestamp: 1687975823684
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
-  md5: 169f1c9be4b9af46ce5dfab2dab660b4
-  depends:
-  - jpeg >=9e,<10a
-  - lerc >=3.0,<4.0a0
-  - libdeflate >=1.17,<1.18.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  - xz >=5.2.10,<6.0a0
-  - xz >=5.2.4,<6.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  license: HPND
-  license_family: Other
-  size: 1460728
-  timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
-  md5: b1781519a200ccbfcb4a1194005aa3ef
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  constrains:
-  - libwebp 1.3.2
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 338459
-  timestamp: 1694777084290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
-  sha256: 4534c822511a052a72c2b070a05e5d8d6f3550f18ea00a33f9d8a9a92b4382cc
-  md5: 82f24e7660831445a2183216e280a6a4
-  depends:
-  - python >=3.11,<3.12.0a0
-  - uc-micro-py >=1.0.1,<2.0.0
-  license: MIT
-  license_family: MIT
-  size: 41464
-  timestamp: 1676474474981
-- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.42.0-py311hf2fb9eb_0.tar.bz2
-  sha256: b2b50fb4e43e4c4da8db26cf362671e03774384732e1925d82e12dfce45c5ac3
-  md5: 44ff317b1ff9bd2b1fbf39da56965b16
-  depends:
-  - python >=3.11,<3.12.0a0
-  - vc >=14.2,<15.0a0
-  - vs2015_runtime >=14.27.29016,<15.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 20842990
-  timestamp: 1706911120234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
-  sha256: 896b7a39bd4ad3621312130122b4fe84dcb67d7355166255c58ea9bc562eb0ae
-  md5: 640b852a56296f48cf073e61a59c5256
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 13751
-  timestamp: 1676428354074
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.3.2-py311h2bbff1b_0.tar.bz2
-  sha256: 5d7d4142cd2c91d151d26b7b22f1e4bd2357bcc5ee6b56516552145b43a6d022
-  md5: 35b521ddf937dab77b7720d3640761d4
-  depends:
-  - lz4-c >=1.9.4,<1.10.0a0
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 86304
-  timestamp: 1686058058871
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
-  sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
-  md5: 320f40b75d93f3b96931c6d13c23946c
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 158902
-  timestamp: 1714512129889
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
-  sha256: e0dc6e119b224bb31ef34b6ba270ffadc181d38b698c5318de8df7a5d2c4ccbd
-  md5: 992ccd756f09408f0b74dfb9852a8b7f
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 182381
-  timestamp: 1676437963591
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
-  sha256: 050b5fd4b28132d8102a7e6b40179894dc7f5e41f7ad9ee19211e67446c5740f
-  md5: 3ae0b2f6baec708554648ddafa81b756
-  depends:
-  - mdurl >=0.1,<1
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 154386
-  timestamp: 1684279992864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
-  sha256: 8269c73b7a9c03b95a121e318d0468f35eecc016093620b0560f35238cc5df51
-  md5: 2914bea0ae29315f998e1abac79ccaa8
-  depends:
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  constrains:
-  - jinja2 >=3.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 30214
-  timestamp: 1704206218108
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.8.4-py311haa95532_0.tar.bz2
-  sha256: 3df5732260bbd26c10421edbe7c146326e8b1af96137e4eba70aaa246f7aaa23
-  md5: 24a282628090afa5e3f53795cc3529de
-  depends:
-  - matplotlib-base >=3.8.4,<3.8.5.0a0
-  - pyqt >=5
-  - python >=3.11,<3.12.0a0
-  - tornado >=5
-  license: LicenseRef-PSF-based
-  license_family: PSF
-  size: 8759
-  timestamp: 1713337289997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
-  sha256: 68fb7d113dbf185b571343847e3dbefdbe7d0b9b5902f1f390bc2a6e33a3f8ee
-  md5: a72ff718390a1fde0b208a43e6b9b655
-  depends:
-  - contourpy >=1.0.1
-  - cycler >=0.10
-  - fonttools >=4.22.0
-  - freetype >=2.10
-  - freetype >=2.10.4,<3.0a0
-  - kiwisolver >=1.3.1
-  - numpy >=1.23.5,<2.0a0
-  - packaging >=20.0
-  - pillow >=8
-  - pyparsing >=2.3.1,<3.1
-  - python >=3.11,<3.12.0a0
-  - python-dateutil >=2.7
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: LicenseRef-PSF-based
-  license_family: PSF
-  size: 11366001
-  timestamp: 1713336740870
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
-  sha256: 43279276850eb6e621812448cddc1093524cee0b7f8ed58b4600b68a4fb659f2
-  md5: 5968b2b5c1f3cf5c8c8c9aaa4d8d66a2
-  depends:
-  - python >=3.11,<3.12.0a0
-  - traitlets
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 19886
-  timestamp: 1676425829787
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
-  sha256: 3062a8254ca351b54f15bea85cc928a3ba4d879bb98ce97ece39a9f7eca215a5
-  md5: 8f1565663abb34ad7fdd512e76da5532
-  depends:
-  - markdown-it-py >=1.0.0,<3.0.0
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 68031
-  timestamp: 1676481862508
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
-  sha256: cdff5215c292fe59649ca40ca72f5d26da352760c1d6a56feba14eb13f7bbf61
-  md5: e0f3f32b22135dfeaec277bc87183ca9
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 23328
-  timestamp: 1676442709081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
-  sha256: 3b173a25605d2aaacc57ec0e425f1d1c51327eb2521c8742a736e2c76069bc8d
-  md5: 169f1c93a443f95a88665f3008623ce1
-  depends:
-  - python >=3.11,<3.12.0a0
-  constrains:
-  - nbconvert >6.1.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 104882
-  timestamp: 1676425142412
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
-  sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
-  md5: 527155127b9fada5e5c5c69a624674b9
-  depends:
-  - intel-openmp 2023.*
-  - tbb 2021.*
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: LicenseRef-ProprietaryIntel
-  license_family: Proprietary
-  size: 187498166
-  timestamp: 1699648376430
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
-  sha256: cea59ae60da314caecf08edb9bcb03126c6dd35837c8184bceaa194decca3341
-  md5: 30936b7263cf0171f7c86400f12ef184
-  depends:
-  - mkl >=2023.1.0,<2024.0a0
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 49080
-  timestamp: 1682975093455
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
-  sha256: 5070ceb0a406b1b8b99e2ec58f5d224cbe16ec78109c46720bd182b509e05c6e
-  md5: 34de1af5c639f2d06c6c8d99488e4226
-  depends:
-  - blas 1.0 mkl
-  - mkl >=2023.1.0,<2024.0a0
-  - mkl-service >=2.3.0,<3.0a0
-  - numpy <2.0a0
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 196201
-  timestamp: 1695058367111
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
-  sha256: 6b4b27302e458fa527321c59be7c335d61f86da7501c4d141db20a72fad68b55
-  md5: 7db9b12da1290bb2c2fc6ee52a945905
-  depends:
-  - mkl >=2023.1.0,<2024.0a0
-  - mkl-service >=2.3.0,<3.0a0
-  - numpy <2.0a0
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  - blas * mkl
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 256371
-  timestamp: 1695060425702
-- conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py311h59b6b97_0.tar.bz2
-  sha256: c09c5ed3f07731091958ea6ed06a1eaeaca1f7e1361d341fb06b344d51074ca2
-  md5: 520c04235cf0980e1ce908e893b4dc71
-  depends:
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 37775
-  timestamp: 1676427521514
-- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
-  sha256: 39f09c1bc57b4800ebda331eddb462928435498705351b0432d51a4293294ad8
-  md5: 5565984a02f41e97cb9a4c9126ced14b
-  depends:
-  - python >=3.11,<3.12.0a0
-  - six
-  license: BSD 3-Clause
-  license_family: BSD
-  size: 29808
-  timestamp: 1676442800892
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
-  sha256: e940f9178ee2fa0a7c12873ae35ebea0074371653e5cfa1be8aa8d9271fd343b
-  md5: 355d0835215911738a28010dfa6aa382
-  depends:
-  - jupyter_client >=6.1.12
-  - jupyter_core >=4.12,!=5.0.*
-  - nbformat >=5.1
-  - python >=3.11,<3.12.0a0
-  - traitlets >=5.4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 141785
-  timestamp: 1698934346590
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
-  sha256: 47dd00c0179f4eb29c70d0453d340f7f5332af326b3d51c64ca3bf6a14be8e7e
-  md5: f66afe718bdb57667b03ebda4cb2ac7e
-  depends:
-  - beautifulsoup4
-  - bleach !=5.0.0
-  - defusedxml
-  - jinja2 >=3.0
-  - jupyter_core >=4.7
-  - jupyterlab_pygments
-  - markupsafe >=2.0
-  - mistune >=2.0.3,<4
-  - nbclient >=0.5.0
-  - nbformat >=5.7
-  - packaging
-  - pandocfilters >=1.4.1
-  - pygments >=2.4.1
-  - python >=3.11,<3.12.0a0
-  - tinycss2
-  - traitlets >=5.1
-  constrains:
-  - tornado >=6.1
-  - pyqtwebengine >=5.15
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 561655
-  timestamp: 1699023338436
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
-  sha256: 4ee863a1ff697274c642b3101f82b279a354e3f033a87505655039f89127bb41
-  md5: bfaf19be6644ad2344e118aa0acccb13
-  depends:
-  - jsonschema >=2.6
-  - jupyter_core
-  - python >=3.11,<3.12.0a0
-  - python-fastjsonschema
-  - traitlets >=5.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 189809
-  timestamp: 1694617194065
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
-  sha256: 90fb3f14c49da1397982eae21cd09e8d60d491d76f94c57590c56723fe6dc172
-  md5: 46a523661fe5c1bce7b4213fd428c3de
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 16732
-  timestamp: 1708532795328
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-7.0.8-py311haa95532_0.tar.bz2
-  sha256: aa72c6e127bc394de0b570413912e0625759ba10248fbf884928c9ec3ed6fa70
-  md5: 1cdaa20793e8f70874ade8136e1dd5c2
-  depends:
-  - jupyter_server >=2.4.0,<3
-  - jupyterlab >=4.0.2,<4.1
-  - jupyterlab_server >=2.22.1,<3
-  - notebook-shim >=0.2,<0.3
-  - python >=3.11,<3.12.0a0
-  - tornado >=6.2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 3681116
-  timestamp: 1708030716052
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
-  sha256: e040ebcab948325fbe17e4ab15be62e1fafa7bad225457e59764adb60eb40db5
-  md5: 4d40a09df8cb74a9f044eab317436d67
-  depends:
-  - jupyter_server >=1.8,<3
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 27282
-  timestamp: 1699456187703
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.59.1-py311hf62ec03_0.tar.bz2
-  sha256: a20cb730d87b945125202c7f4e81490c24db708f373d1214e6b04f5d2b4177b3
-  md5: a235c61c1928d09080158ffd42ffbccc
-  depends:
-  - llvmlite >=0.42.0,<0.43.0a0
-  - numpy >=1.23.5,<1.27
-  - python >=3.11,<3.12.0a0
-  - tbb >=2021.8.0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  constrains:
-  - cuda-python >=11.6
-  - tbb >=2021.6,<2022
-  - scipy >=1.0
-  - libopenblas !=0.3.6
-  - numba-rvsdg 0.0.*
-  - cudatoolkit >=10.2
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 6100005
-  timestamp: 1712021687877
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
-  sha256: d3bd2a6614bb7e7f5ce3348d6674e71cce45cbde236beff32f0f08cd95a64ef0
-  md5: e70f15643164f432d1df68635e7c322b
-  depends:
-  - blas 1.0 mkl
-  - mkl >=2023.1.0,<2024.0a0
-  - mkl-service >=2.3.0,<3.0a0
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: MIT
-  license_family: MIT
-  size: 162691
-  timestamp: 1696515822068
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
-  sha256: 470fe9a0b3e196fa60d5550d8188f6074a207572fa0d353a4448d580872e7804
-  md5: 6fdb8df0613fb2fb9f1732d335fa25f1
-  depends:
-  - blas 1.0 mkl
-  - mkl >=2023.1.0,<2024.0a0
-  - mkl-service >=2.3.0,<3.0a0
-  - mkl_fft
-  - mkl_random
-  - numpy-base 1.26.4 py311hd01c5d8_0
-  - python >=3.11,<3.12.0a0
-  - vc >=14.2,<15.0a0
-  - vs2015_runtime >=14.27.29016,<15.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 11053
-  timestamp: 1708641901110
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
-  sha256: 222c1711e7cf151e29077c7d4d86a865c9fd39615812d58a1daca6fd1b6bdfb5
-  md5: 585bcd8bc3940a8a859f38ebafdcd77d
-  depends:
-  - blas 1.0 mkl
-  - mkl >=2023.1.0,<2024.0a0
-  - mkl-service >=2.3.0,<3.0a0
-  - python >=3.11,<3.12.0a0
-  - vc >=14.2,<15.0a0
-  - vs2015_runtime >=14.27.29016,<15.0a0
-  constrains:
-  - numpy 1.26.4 py311hdab7c0b_0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 10723862
-  timestamp: 1708641867155
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
-  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
-  md5: ab07e2a27ac08afe3d0b4c0890b8486a
-  depends:
-  - libpng >=1.6.37,<1.7.0a0
-  - libtiff >=4.1.0,<4.7.0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: BSD 2-Clause
-  size: 249316
-  timestamp: 1630094024143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_1.tar.bz2
-  sha256: f98936bd261c37fb1c2d303885a0bd55cea87e2c86c6e8c6ca56c66b9079e852
-  md5: ed1708ace63b1ef7409474eedf0db1ba
-  depends:
-  - ca-certificates
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 8087040
-  timestamp: 1714514472258
-- conda: https://repo.anaconda.com/pkgs/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
-  sha256: 417cf23716f17b6daf2b717bbd69240aa9440845dfa415f59a97961794632ce5
-  md5: 36d709d47c43a3e9b43f23cf4edb6438
-  depends:
-  - libprotobuf >=3.20.3,<3.21.0a0
-  - lz4-c >=1.9.4,<1.10.0a0
-  - snappy >=1.1.9,<2.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 877890
-  timestamp: 1676482911485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
-  sha256: b2f5f50a1ddf811102636f3acebd76716c88ebb628754b91eda7a3a962adf26c
-  md5: 712527b4d84c350dca4b67f511c04414
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 39421
-  timestamp: 1699371341381
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
-  sha256: 432b8b7c4671878cbbe361e518544203f97bd2e4f24fa08cf65e8be583f25529
-  md5: e62e7c668b080e0f6ce09fd548f69f7f
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0 or BSD-2-Clause
-  license_family: Apache
-  size: 159066
-  timestamp: 1710809127954
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
-  sha256: 3ae55d8148580fc3f171c0fcc420488fbba05517cefd358fe013b45ec3594371
-  md5: bfb42ed6826a1c8cded9539fc6e07029
-  depends:
-  - bottleneck >=1.3.6
-  - numexpr >=2.8.4
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python-dateutil >=2.8.2
-  - python-tzdata >=2022.7
-  - pytz >=2020.1
-  - vc >=14.2,<15.0a0
-  - vs2015_runtime >=14.27.29016,<15.0a0
-  constrains:
-  - python-calamine >=0.1.7
-  - xarray >=2022.12.0
-  - lxml >=4.9.2
-  - dataframe-api-compat >=0.1.7
-  - jinja2 >=3.1.2
-  - zstandard >=0.19.0
-  - blosc >=1.21.3
-  - matplotlib-base >=3.6.3
-  - adbc-driver-postgresql >=0.8.0
-  - xlrd >=2.0.1
-  - fastparquet >=2022.12.0
-  - pymysql >=1.0.2
-  - gcsfs >=2022.11.0
-  - pandas-gbq >=0.19.0
-  - xlsxwriter >=3.0.5
-  - pyarrow >=10.0.1
-  - html5lib >=1.1
-  - pyqt >=5.15.9
-  - psycopg2 >=2.9.6
-  - scipy >=1.10.0
-  - numba >=0.56.4
-  - qtpy >=2.3.0
-  - openpyxl >=3.1.0
-  - adbc-driver-sqlite >=0.8.0
-  - tabulate >=0.9.0
-  - pyreadstat >=1.2.0
-  - pytables >=3.8.0
-  - beautifulsoup4 >=4.11.2
-  - pyxlsb >=1.0.10
-  - sqlalchemy >=2.0.0
-  - s3fs >=2022.11.0
-  - fsspec >=2022.11.0
-  - odfpy>=1.4.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 16924671
-  timestamp: 1709591125871
-- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
-  sha256: b0d7fbfcf1c5c682ed9934eb6a33e00a2517941f2bcb9d677379f4bb73b2c45c
-  md5: 20c8f36595a48f5cda2f4f74c02a3ea2
-  depends:
-  - locket
-  - python >=3.11,<3.12.0a0
-  - toolz
-  constrains:
-  - numpy >= 1.9.0
-  - pandas >=0.19.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 48206
-  timestamp: 1698702818841
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
-  sha256: 6ca54ba8ce430caa8a1838b19869814d0b7fa3592a77f75298130983e635387b
-  md5: e56c194e56d19dd8fd76f75a77f92c33
-  depends:
-  - freetype >=2.10.4,<3.0a0
-  - jpeg >=9e,<10a
-  - lcms2 >=2.12,<3.0a0
-  - libtiff >=4.2.0,<4.7.0
-  - libwebp-base >=1.3.2,<2.0a0
-  - openjpeg >=2.3.0,<3.0a0
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: HPND AND TCL
-  license_family: Other
-  size: 1070844
-  timestamp: 1714399290671
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3.1-py311haa95532_0.tar.bz2
-  sha256: 5d612af287cad7d0fc1b8e2e01d7f49b5466f2e17338b03a13cd60111f2513aa
-  md5: 1b0f29aa3fc57cc8d5a48ae392aa8567
-  depends:
-  - python >=3.11,<3.12.0a0
-  - setuptools
-  - wheel
-  license: MIT
-  license_family: MIT
-  size: 3752545
-  timestamp: 1700667933959
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
-  sha256: e5f8cbfb5fc25d460a9117bfc5511959c5e86ccb193316033f87bd516e0c8881
-  md5: 9f7e8b5eb651539386bb92c14e5c321b
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 37730
-  timestamp: 1692205554840
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py311haa95532_0.tar.bz2
-  sha256: a100d5bef5d832db705558acee7ecb4ec2471c18d13ab65fb92f7bc3b3a44ae7
-  md5: 0ae839617227e2ef40d65e85607e60d6
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD 3-clause
-  license_family: BSD
-  size: 111734
-  timestamp: 1676426983345
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
-  sha256: 6c5b53831273674361437fb546e08315fc11ca9275a174bca3887987e86ced5a
-  md5: f8d91daf5173eb03157f484389adcdd4
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 122178
-  timestamp: 1679591983138
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
-  sha256: 546819d922b03f3a25ca9f98fd069d0588d481fc0603c6d74bd598fb6a93687f
-  md5: 86c18e3e0b67ee099457475ed6caf2e6
-  depends:
-  - python >=3.11,<3.12.0a0
-  - wcwidth
-  constrains:
-  - prompt_toolkit 3.0.43
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 751763
-  timestamp: 1704404627180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
-  sha256: ae06f0dfa2cfae51404afc6d6ad3a474a93015b5ba9a7d3ea24224b8e7547987
-  md5: 3e19794c806cc3e84a3080a97c359b75
-  depends:
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 510466
-  timestamp: 1679005998612
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-14.0.2-py311h847bd2a_0.tar.bz2
-  sha256: a33dd77a94c79ab95caaa02fbdcb399d4041806a52a82411529cf1454f031536
-  md5: 01f56e64de4eed195d72a61301444fa7
-  depends:
-  - arrow-cpp >=14.0.2,<14.0.3.0a0
-  - boost-cpp
-  - numpy >=1.16.6,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - vc >=14.2,<15.0a0
-  - vs2015_runtime >=14.27.29016,<15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 4504341
-  timestamp: 1707332113670
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
-  sha256: d95c88d06f4f3f667bd9a39e5f18179e83b3cd4c115c06ce0fff390ff6d3a700
-  md5: c6d00a8a4d89b1be99bfa3aff19d96b4
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 2134881
-  timestamp: 1684280285492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
-  sha256: 643a9a0eba1e2bd5980d21623d3b35188c24781ec251acc4d15714bd1ccb4c17
-  md5: b3cda0394db05be6f0f6176abacb13f3
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 207985
-  timestamp: 1678721438358
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py311hd77b12b_0.tar.bz2
-  sha256: d86b6f06ff63712d58bc0f82a6d345ec578c854051934ac73e5bd929782cd6ab
-  md5: d03b87499af4ad84a166b2d49db2bacf
-  depends:
-  - pyqt5-sip 12.13.0 py311h2bbff1b_0
-  - python >=3.11,<3.12.0a0
-  - qt-main 5.15.*
-  - qt-main >=5.15.2,<5.16.0a0
-  - sip >=6.7.12,<6.8.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 5041665
-  timestamp: 1698775563282
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py311h2bbff1b_0.tar.bz2
-  sha256: 449266141df059e53f3ae09ef2f1f10b94bc6ab51f919dc4533c32da3a0e808f
-  md5: f125f06594be8adff678b9b36861b847
-  depends:
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 84114
-  timestamp: 1698769459963
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
-  sha256: 974c22de09078bf07c5db31fe12d8d89d6433508defc8237cbe52e08c69ed56b
-  md5: 9cf10bfd49140a527cf4b1d912097e6d
-  depends:
-  - python >=3.11,<3.12.0a0
-  - win_inet_pton
-  license: BSD 3-Clause
-  license_family: BSD
-  size: 36072
-  timestamp: 1676426019064
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.8-he1021f5_0.tar.bz2
-  sha256: 1c557d91837e0205cd08180b604da06f28d7679df1ea1026e7954add3eb4d468
-  md5: 3901bef86daffeb6ff2317543b292766
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libffi >=3.4,<3.5
-  - libffi >=3.4,<4.0a0
-  - openssl >=3.0.13,<4.0a0
-  - sqlite >=3.41.2,<4.0a0
-  - tk >=8.6.12,<8.7.0a0
-  - tzdata
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  - xz >=5.4.5,<6.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  constrains:
-  - openssl <3.5.7
-  license: PSF-2.0
-  license_family: PSF
-  size: 19539055
-  timestamp: 1708983524626
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
-  sha256: 9acb33db60d9319595f52337cae3b88c2a2338cd66f1f9d8ae86d0a993c2067a
-  md5: f4af8cf94d042b4dde487241bba1c457
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 279780
-  timestamp: 1679500609851
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
-  sha256: 48fe7373b012b51134b6b6ff67f18d2b4aae3a5c7700e4560ce002af7172f064
-  md5: 0379cd17692152c12b662b0e4ea46b88
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 18008
-  timestamp: 1683824373128
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py311hd77b12b_0.tar.bz2
-  sha256: 40093db499547e192da8c52132ef1016bab65f2dfd2e4049739f2f8b574e3836
-  md5: a6b568626951b8a9070c30e043cb2603
-  depends:
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: OLDAP-2.8
-  license_family: Other
-  size: 150521
-  timestamp: 1682522716553
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
-  sha256: 803274d986d0c4e3b5ec1018747ede86ef57137455b3e44a60e834717eafb92b
-  md5: c9f134ddeff6fdf0373a45534ddb7079
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 273009
-  timestamp: 1713974722039
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
-  sha256: cd33dfee104dfbba4af38d06a09ccbae6a32e7c543afedab523303319ebb283d
-  md5: 3dfc19af0306d80921e1403f1f551bba
-  depends:
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
-  size: 13679916
-  timestamp: 1676423267293
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
-  sha256: 102ff1d958209e3648bb49da3503cf752abab822011fdc4e12e88145c9e73772
-  md5: 0553c2c381b6f5c836b23edc8c6db2ba
-  depends:
-  - python >=3.11,<3.12.0a0
-  - vc >=14.2,<15.0a0
-  - vs2015_runtime >=14.27.29016,<15.0a0
-  - winpty
-  license: MIT
-  license_family: MIT
-  size: 246689
-  timestamp: 1677708371873
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
-  sha256: bee5c4d0f41f06a9c0aac636885e36e8b81116aafde980f9ea48fdb64abb5567
-  md5: 6c05a053240cb90765d6f8c2efdf905e
-  depends:
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  size: 182228
-  timestamp: 1698096268270
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-25.1.2-py311hd77b12b_0.tar.bz2
-  sha256: d08d1b2bc1859011d6d8c8e0afff0cad680c598e5ad59bb7beab9317b3bdece4
-  md5: 5e36645629336f3732b14604bb666442
-  depends:
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  - zeromq >=4.3.5,<4.3.6.0a0
-  license: BSD-3-Clause AND LGPL-3.0-or-later
-  license_family: BSD
-  size: 552293
-  timestamp: 1705606206058
-- conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
-  sha256: 409f9fad42cbae8d915d1703d87db6af9f951b150517daa4e1c0220cc5eb7b0f
-  md5: 2b17abf94b02a6c5ba6b7623dba97ff9
-  depends:
-  - icu >=73.1,<74.0a0
-  - jpeg >=9e,<10a
-  - krb5 >=1.20.1,<1.21.0a0
-  - libclang >=14.0.6,<15.0a0
-  - libclang13 >=14.0.6
-  - libpng >=1.6.39,<1.7.0a0
-  - libpq >=12.15,<13.0a0
-  - openssl >=3.0.10,<4.0a0
-  - sqlite >=3.41.2,<4.0a0
-  - vc >=14.2,<15.0a0
-  - vs2015_runtime >=14.27.29016,<15.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  constrains:
-  - qt >=5.15.2,<6
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 69829482
-  timestamp: 1693228189080
-- conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
-  sha256: 720f3dd1f933d035b1393951ffd1b6437fc5e19b1999e74096044514a46053fb
-  md5: add2dfb15b518144663fc3b897d66da7
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: BSD-3-Clause
-  size: 493391
-  timestamp: 1652432364793
-- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
-  sha256: 47653b45a5f2d97b5bf0dbf0e620908880f9078da427eef69012effe3f19af67
-  md5: 44e709ae67d89bccee2d4d46d358fee3
-  depends:
-  - attrs >=22.2.0
-  - python >=3.11,<3.12.0a0
-  - rpds-py >=0.7.0
-  license: MIT
-  license_family: MIT
-  size: 74493
-  timestamp: 1699012356534
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
-  sha256: d7bcba5262df162756885a773c3bf2dace27311bbbb1830a0f97aa60ac7c1239
-  md5: daeb99ccfe39f725278203412aac0873
-  depends:
-  - certifi >=2017.4.17
-  - charset-normalizer >=2,<4
-  - idna >=2.5,<4
-  - python >=3.11,<3.12.0a0
-  - urllib3 >=1.21.1,<3
-  constrains:
-  - chardet >=3.0.2,<6
-  - pysocks >=1.5.6,!=1.5.7
-  license: Apache-2.0
-  license_family: Apache
-  size: 120468
-  timestamp: 1707355917958
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
-  sha256: d6daaa6b45272819176e4aeb467ae00e3db43386548464a9993688f292709d40
-  md5: 9fe721d7f7420c259df4f07d4503f654
-  depends:
-  - python >=3.11,<3.12.0a0
-  - six
-  license: MIT
-  license_family: MIT
-  size: 9683
-  timestamp: 1683077110211
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
-  sha256: 6051860575f9448aea5799d74469c928cd7cdeeca1eb53657872262a77b1a7a8
-  md5: 60e193eca497130034facd5fed168249
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 10094
-  timestamp: 1683059114376
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
-  sha256: ecd310461c1b45ab92ddf15539cea5a6e837860561c974d2d7393f9a7933f116
-  md5: 1762fec2838763e904141167e18b0389
-  depends:
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: MIT
-  license_family: MIT
-  size: 215600
-  timestamp: 1698947891859
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
-  sha256: 0042fa2dc2ec8c2181f28f5ee4f45087ea58dca7acc6b89c48f3ce6eac8f9bdd
-  md5: 755c9767608b233b94ec3a67c8e0da4b
-  depends:
-  - blas 1.0 mkl
-  - icc_rt >=2022.1.0
-  - mkl >=2023.1.0,<2024.0a0
-  - mkl-service >=2.3.0,<3.0a0
-  - numpy >=1.23.5,<1.29
-  - pybind11-abi 5
-  - python >=3.11,<3.12.0a0
-  - vc >=14.2,<15.0a0
-  - vs2015_runtime >=14.27.29016,<15.0a0
-  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
-    BSL-1.0
-  license_family: BSD
-  size: 32418527
-  timestamp: 1714081783418
-- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
-  sha256: 6fd52bae6360fbc8135d72e0c1e4fd407769fa4d0f4b59356e7aed3e000eb339
-  md5: 49fd52885250da8aab17ed72e2e18b81
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 88901
-  timestamp: 1699371435766
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
-  sha256: a2ec4690bc07be9e7f3ad8e3003803eb4304a434d3f139633e2817318a9f7b20
-  md5: dd2d225219924fc5c36598c919541271
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 1593050
-  timestamp: 1715025622141
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py311hd77b12b_0.tar.bz2
-  sha256: f9b5386b4bbae4a6dbf2d391d482a4eb66067435234d990e0a3dd1ea8c710dee
-  md5: 46b9998433d3d70eb124f7d6480698b3
-  depends:
-  - packaging
-  - ply
-  - python >=3.11,<3.12.0a0
-  - setuptools
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: LicenseRef-SIP_License OR GPL-2.0-or-later OR GPL-3.0-or-later
-  license_family: GPL
-  size: 682181
-  timestamp: 1698676093853
-- conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.1.10-h6c2663c_1.tar.bz2
-  sha256: 7555e0d33dc29191da0f311d9e6112ddf0c200bbafe5cde89015d524dce84a72
-  md5: 54bc73a36ca51e06733d9d42f23e2ea4
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
-  license_family: BSD
-  size: 100857
-  timestamp: 1702909533553
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
-  sha256: 5d1b7e14dc04816692de0f8518ea8fcbefb26ab61cec83f96f2c44c1bee67fab
-  md5: 505d2a70a875b5082dc857aa4dfab0d4
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT OR Apache-2.0
-  license_family: Other
-  size: 18830
-  timestamp: 1705431395254
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
-  sha256: 5ff3b4ac3fbce4dd67a87856c04698d0397deb0ac288ff4e7eb02fbab57f1253
-  md5: 0ca650a7001c6650809d3361de8cb005
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 89590
-  timestamp: 1696347858925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
-  sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
-  md5: 833b93a2daade3407898f15588945d83
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: blessing
-  license_family: Other
-  size: 1440481
-  timestamp: 1714488344682
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
-  md5: 2d00fccaf04f00047d71d21d309cf764
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 152822
-  timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
-  sha256: 78d89b50a29fbeb19a562f5dad95615e3f192bb4f3b86cd6ea75f2f825418232
-  md5: 4a4040df560ea47704e0898c4c015808
-  depends:
-  - python >=3.11,<3.12.0a0
-  - pywinpty >=1.1.0
-  - tornado >=6.1.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 38069
-  timestamp: 1678228553220
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
-  sha256: 70a3cc4a4e81a6421bc19cd410d1d6064aadb2b1cce38b020f85e5346716d8e7
-  md5: 32a9a2539579a3d522dce3b5cb4f987b
-  depends:
-  - python >=3.11,<3.12.0a0
-  - webencodings >=0.4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 49495
-  timestamp: 1676425411739
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
-  sha256: 0a95736cfd0bb25fc201cd6be4a2450ea8fc30eeb349d861812675b84c94fa74
-  md5: a8a9fb30c6dd8e7a16d5dcd2333c3c49
-  depends:
-  - vc >=14.2,<15.0a0
-  - vs2015_runtime >=14.27.29016,<15.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: TCL
-  license_family: BSD
-  size: 3844176
-  timestamp: 1714770894235
-- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
-  sha256: ed5950ac0c12cc87f991a6f28112cf29057e2b7ad416ae4429a0b97c3efaf58c
-  md5: b5e2a04879e6fd19f0eb5effded4dc61
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 135939
-  timestamp: 1676431438808
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
-  sha256: 4febf30c11674711b86c8c10da46a5e1613071388da999210912a31508864add
-  md5: 1c109fc1112ea1f5f377bdf0d18ba75f
-  depends:
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 895633
-  timestamp: 1696937216859
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.2-py311h746a85d_0.tar.bz2
-  sha256: fa6681ec34a560da1d44d80bb32da96165fc6063a6e000169e75bc1e5ca74194
-  md5: c5110aa6fe3bec83fe71215182b7f636
-  depends:
-  - colorama
-  - python >=3.11,<3.12.0a0
-  constrains:
-  - ipywidgets >=6
-  license: MPL-2.0 AND MIT
-  license_family: MOZILLA
-  size: 186730
-  timestamp: 1714567830865
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
-  sha256: e8c77efe880546252f244f995cbed5967809555127b4f818b97455d434b23415
-  md5: 7397ac07045115960ebd8dec95326a7a
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 270819
-  timestamp: 1676423321499
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.9.0-py311haa95532_1.tar.bz2
-  sha256: ae7b4d80613eee90d2a9d86a099327c81606cde33700e476402407f1a206362c
-  md5: d7326551a9f54853015af81861222d5f
-  depends:
-  - python >=3.11,<3.12.0a0
-  - typing_extensions 4.9.0 py311haa95532_1
-  license: PSF-2.0
-  license_family: PSF
-  size: 9651
-  timestamp: 1705599444849
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.9.0-py311haa95532_1.tar.bz2
-  sha256: 1900ee02288c0abdaa44f34bccafc34691a59069330b0fc0c0922b4b4621b786
-  md5: 0b94ee0b1e2488c3840a348d7d97aca2
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: PSF-2.0
-  license_family: PSF
-  size: 71708
-  timestamp: 1705599429360
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
-  sha256: d091897f05318c22ca31028370f25355065999078f7db6f88ab27bf4cb030ec8
-  md5: 1776502c1cfb351554eeda6cddaf255f
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 11588
-  timestamp: 1676457729096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
-  sha256: c16498f8238cc331618720d078b87995eceb6bbf20268a7a4e8efbf7b5859a9a
-  md5: 770432c0ca1ab9d99ffe95e51d3a3e74
-  depends:
-  - python >=3.11,<3.12.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 517433
-  timestamp: 1713213261710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.1.0-py311haa95532_1.tar.bz2
-  sha256: 75e984e5015c5fee121159768fc92653d58303e983450308f8efee40382cc6f7
-  md5: bcaf27d1ba712299ee395d7cb0d4852b
-  depends:
-  - brotli-python >=1.0.9
-  - pysocks >=1.5.6,<2.0,!=1.5.7
-  - python >=3.11,<3.12.0a0
-  constrains:
-  - requests >=2.26.0
-  - zstandard >=0.18.0
-  - selenium >=4.4.3
-  license: MIT
-  license_family: MIT
-  size: 184432
-  timestamp: 1707770951801
-- conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
-  sha256: 2ef16d0252e04063d44d0683831d55b485f713fe5af2c2efd61753fb4f27d7e4
-  md5: 256ab1d5dce70111a1f4807a5a9fc322
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: MIT
-  license_family: MIT
-  size: 100982
-  timestamp: 1706894771410
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
-  sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
-  md5: 45ef24c486a484f079faf1dc90e4c7e9
-  depends:
-  - vs2015_runtime >=14.27.29016
-  license: Modified BSD License (3-clause)
-  license_family: BSD
-  size: 8277
-  timestamp: 1605602889180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
-  sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
-  md5: 4daaceb6cfc1af6274509081d8018ef1
-  size: 2316783
-  timestamp: 1605602872095
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
-  sha256: 24ea3d3e0cb98d0d246338dbb4562b67967bb32002e3704e495a5c863476e831
-  md5: c7b9cdbe87b3c9720aeca1164a0fd6df
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD 3-Clause
-  license_family: BSD
-  size: 26181
-  timestamp: 1676424437003
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py311haa95532_4.tar.bz2
-  sha256: 4008652f05783c7c1ac31fb5b8cf36899c3380b24e82996c6fd44f7b6aca1278
-  md5: dd85600927df8322040c4998a114b567
-  depends:
-  - python >=3.11,<3.12.0a0
-  - six
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 94482
-  timestamp: 1676426093953
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
-  sha256: 1b086d1b079fdb2f148c7dd82658f2b7f283c88f286e1216c0f1237319039b0f
-  md5: 299e87f151a549d86a48bf24df15c607
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 168041
-  timestamp: 1714717238470
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
-  sha256: 17fadf35aa8917c107e7b369e9364ac7c09537776e7943d37e225e14b7026c94
-  md5: 0e67c3b9624540581b894b11267a837b
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: PUBLIC-DOMAIN
-  size: 10197
-  timestamp: 1676425485716
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
-  md5: c5bdb727945bad906d23e44199144746
-  license: MIT
-  size: 1177536
-  timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
-  sha256: 25373efabba9a866849fe38a47c79e0fa323851b4bd4b5df357cc8d5617c2786
-  md5: a958e9d32c3b65c21e11e5d9e8491c43
-  depends:
-  - numpy >=1.21,<2.0a0
-  - packaging >=21.3
-  - pandas >=1.4
-  - python >=3.11,<3.12.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 2467966
-  timestamp: 1689041676824
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
-  sha256: b849b368e27920838fe40a512b102879693a55cb187dd1c8d3a83fa8c05a8054
-  md5: 7b1f6e9c71906a93039b3446b99a5498
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 55114
-  timestamp: 1676434863173
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
-  sha256: 344a5276a9928638dcde054dfe4e87c8cb40bd2d4d356378b9ab2f863ca62e4b
-  md5: fe471fd8b5a3d77be6fa5dbf9b99dafb
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
-  license_family: GPL2
-  size: 1432281
-  timestamp: 1714515119689
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
-  md5: daa42ad494a780c2f433596651132c1c
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: MIT
-  size: 66759
-  timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
-  sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
-  md5: e5aed81295b61b6d1eb62830799a0297
-  depends:
-  - libsodium >=1.0.18,<1.0.19.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: MPL-2.0
-  license_family: Other
-  size: 9125184
-  timestamp: 1705602328351
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py311haa95532_0.tar.bz2
-  sha256: 478892109d9dc82c90f82d269d3796f4f812f6cba5d3d1f9178a20bd7f583a1f
-  md5: df02873bda6c5de6331b00fb1591abac
-  depends:
-  - heapdict
-  - python >=3.11,<3.12.0a0
-  - python-lmdb
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 102456
-  timestamp: 1695833422458
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.17.0-py311haa95532_0.tar.bz2
-  sha256: d932439798665be388bbf68f3d68da5b42ed4753a43587d3f49848a85f58add4
-  md5: e2900345674e644e05540ffac6acca89
-  depends:
-  - python >=3.11,<3.12.0a0
-  license: MIT
-  license_family: MIT
-  size: 25247
-  timestamp: 1704207149955
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
-  sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
-  md5: f295b54ab59f5b8658e2a322ac6aa721
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  license: Zlib
-  license_family: Other
-  size: 162161
-  timestamp: 1714514792081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
-  sha256: b2ff66b7f6efa0831f939e57e562c244332b690af08818a540d1a97fa07d8525
-  md5: e548d528873d9a0006a36714cf36462a
-  depends:
-  - lz4-c >=1.9.4,<1.10.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012,<15.0a0
-  - xz >=5.4.6,<6.0a0
-  - zlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause AND GPL-2.0-or-later
-  license_family: BSD
-  size: 1933522
-  timestamp: 1714679197977
-- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
-  sha256: 98f3bae3caff4c52615ddb56405dc51b39d9d2c47a9bccd130a5a19d10304245
-  md5: de1b7f7c8221028f6bbe103df4c53bed
-  depends:
-  - m2w64-gcc-libs-core
-  - msys2-conda-epoch >=20160418
-  license: GPL, LGPL, FDL, custom
-  size: 348607
-- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
-  sha256: 2fb6488298a659c781f9294a743b0b376d9998a6b06aa2a3b85b49c38a85ea16
-  md5: 0b9caac6747002340b057a222af705b2
-  depends:
-  - m2w64-gcc-libgfortran
-  - m2w64-gcc-libs-core
-  - m2w64-gmp
-  - m2w64-libwinpthread-git
-  - msys2-conda-epoch >=20160418
-  license: GPL3+, partial:GCCRLE, partial:LGPL2+
-  size: 530578
-- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
-  sha256: 449df9debaf202928e3a0db1f059ef35b1bcb3973fa92e217ca2775f82415111
-  md5: 276d396bfe8d958f71173b7134f739fa
-  depends:
-  - m2w64-gmp
-  - m2w64-libwinpthread-git
-  - msys2-conda-epoch >=20160418
-  license: GPL3+, partial:GCCRLE, partial:LGPL2+
-  size: 217686
-- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gmp-6.1.0-2.tar.bz2
-  sha256: 5cf23439eef17ae158d63ff3f85f77d1dca9a45b19324fdeda9e3e48ae298d18
-  md5: fec04371463ec68eb8f5752a22c5b030
-  depends:
-  - msys2-conda-epoch >=20160418
-  license: LGPL3
-  size: 705647
-- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
-  sha256: 9373b0157e08cbea09298f461d2816833281b3e22a8c9f6c5a38d7109c8a281e
-  md5: 67e61e700eb27424979778fae9293f13
-  depends:
-  - msys2-conda-epoch >=20160418
-  license: MIT, BSD
-  size: 30543
-- conda: https://repo.anaconda.com/pkgs/msys2/win-64/msys2-conda-epoch-20160418-1.tar.bz2
-  sha256: d6a55d779052bca9accd534398b4e147d0a3dfc8f4b6528391ee9c15843784bc
-  md5: 6eaef3074f65f715ed1ca6b8a08be3aa
-  size: 2065

--- a/nyc_taxi/pixi.toml
+++ b/nyc_taxi/pixi.toml
@@ -1,0 +1,47 @@
+[workspace]
+name = "nyc_taxi"
+channels = ["pyviz/label/dev", "https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2016-01-29"
+maintainers = ["jbednar"]
+categories = ["Geospatial", "Featured"]
+labels = ["hvplot", "bokeh", "datashader", "panel", "param", "dask"]
+title = "NYC Taxi"
+description = "Plotting the NYC taxi dataset using Datashader."
+
+[dependencies]
+python = "3.11.8.*"
+notebook = ">=7.0.8"
+bokeh = ">=3.4.0"
+datashader = "*"
+fastparquet = ">=2023.8.0"
+holoviews = ">=1.19.0a0"
+hvplot = ">=0.10.0"
+numpy = ">=1.26.4"
+pandas = ">=2.2.1"
+panel = ">=1.4.1"
+dask = ">=2023.11.0"
+pip = "*"
+setuptools = "*"
+wheel = "*"
+
+[target.osx-64.dependencies]
+libgfortran = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks.dashboard]
+cmd = "panel serve --rest-session-info --session-history -1 dashboard.ipynb --show"
+depends-on = ["download"]
+
+[tasks.notebook]
+cmd = "jupyter notebook index.ipynb"
+depends-on = ["download"]
+
+[tasks.download]
+env = { FILENAME = "data/nyc_taxi_wide.parq" }
+cmd = "mkdir -p data && curl -fsSL -o $FILENAME https://s3.amazonaws.com/datashader-data/nyc_taxi_wide.parq"
+outputs = ["data/nyc_taxi_wide.parq"]

--- a/nyc_taxi/pixi.toml
+++ b/nyc_taxi/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "nyc_taxi"
-channels = ["pyviz/label/dev", "https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["pyviz/label/dev", "main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/nyc_taxi/pixi.toml
+++ b/nyc_taxi/pixi.toml
@@ -23,15 +23,15 @@ numpy = ">=1.26.4"
 pandas = ">=2.2.1"
 panel = ">=1.4.1"
 dask = ">=2023.11.0"
-pip = "*"
-setuptools = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+setuptools = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks.dashboard]
 cmd = "panel serve --rest-session-info --session-history -1 dashboard.ipynb --show"

--- a/opensky/pixi.lock
+++ b/opensky/pixi.lock
@@ -1,0 +1,8838 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.6.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-24.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.4.2-py311hf4808d0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.9.24-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.8.30-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py311h1fdaa30_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cramjam-2.7.0-py311h24d97f6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cyrus-sasl-2.1.28-h52b45da_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.16.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.6.3-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-2024.2.0-py311hf4808d0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.14.1-h55d465d_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.6.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.78.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-tools-2.78.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.1-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.1-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.20.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.11.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.27.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.23.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libabseil-20240116.2-cxx17_h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang-14.0.6-default_hc6dbbc7_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang13-14.0.6-default_he11475f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcups-2.4.2-h2d74bed_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.9.1-h251f7ec_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libglib-2.78.4-hdc74915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hecde1de_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpq-17.0-hdbd6064_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-4.25.3-he621ea3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.11.0-h251f7ec_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxkbcommon-1.0.1-h097e994_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.13.1-hfdd30dd_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.43.0-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.9.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.9.2-py311h6fb44e5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.11-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.8-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mysql-8.4.0-h29a9f33_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.16.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.60.0-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.10.1-py311h3c60e43_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openldap-2.6.4-h42fbc30_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.15-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.2-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.5.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-11.0.0-py311hfdbf927_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ply-3.11-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.15.10-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt5-sip-12.13.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.10-he870216_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-main-5.15.2-hb6262e9_11.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.14.1-py311h08b1b3b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-75.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-6.7.12-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.1-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.5-py311h92b7b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.44.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.20.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.6.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.4.2-py311h9b7fc35_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.9.24-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.8.30-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py311h9205ec4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cramjam-2.7.0-py311h9c86198_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2024.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.16.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-2024.2.0-py311hb3a5e46_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.6.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.20.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.11.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.27.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.23.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h26321d7_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.43.0-py311h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.9.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.9.2-py311hc25a08b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.60.0-py311he327ffe_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.10.1-py311hc59c7be_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h91b6869_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311hb3ec012_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.15-h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.2-py311he327ffe_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.5.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-11.0.0-py311h9c91434_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.10-h4d6d9e5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py311h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.14.1-py311hedc7b93_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-75.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.1-py311h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.5-py311h85bffb1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.44.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.20.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.6.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-24.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.4.2-py311hb9f6ed7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.9.24-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.8.30-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cramjam-2.7.0-py311h62f922a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.16.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-2024.2.0-py311hb9f6ed7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.6.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.20.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.11.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.27.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.23.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h19fdd8a_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.43.0-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.9.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.9.2-py311hecf7826_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.60.0-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.10.1-py311h5d9532f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.15-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.2-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.5.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-11.0.0-py311hfaf4e14_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.10-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.2-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.14.1-py311hac8794a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-75.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.1-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.5-py311hb6e6a13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.44.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.20.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.6.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-24.2.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.4.2-py311h57dcf0c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.9.24-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.8.30-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py311h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cramjam-2.7.0-py311h005caf5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.8.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.16.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-2024.2.0-py311hd7041d2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.6.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.20.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.11.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.27.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.23.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-17.0-h70ee33d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.43.0-py311hf2fb9eb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.9.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.9.2-py311h472561b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.11-py311h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.8-py311hea22821_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.60.0-py311hea22821_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.10.1-py311h4cd664f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.15-h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.2-py311hea22821_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.5.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-11.0.0-py311hb5480e2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.2.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.10-h4607a30_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.2-py311h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_11.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.14.1-py311h9f229c6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-75.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.1-py311h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.5-py311h746a85d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.40-h2eaa2aa_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.40.33807-h98bb1dd_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.44.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.20.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+  sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
+  md5: 613805add1c05b538ff06d217252feb7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 20810
+  timestamp: 1652859733309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.6.2-py311h06a4308_0.tar.bz2
+  sha256: d58b068fe1b9c195394e77a6fba4d152c6934e97df7757dd6b921498f8aa72f8
+  md5: 09de3b2d5519a680bda3c3771380c3da
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.26.1
+  - uvloop >=0.21
+  license: MIT
+  license_family: MIT
+  size: 243587
+  timestamp: 1729121303719
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+  sha256: 0d4f5274503916e1c683dcc16e8a7c4186557afa3f62399cd628e4eb535fe77a
+  md5: 062acdb0f9ae976c25c2d15d589dc1d6
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 35809
+  timestamp: 1676823571351
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-24.2.0-py311h06a4308_0.tar.bz2
+  sha256: 5d82019951fb117a34fdc8be3650ba14ad0cee866549cfc61e345c65782a002a
+  md5: 64e97e61d50f90fd609f91c2c5407233
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 162482
+  timestamp: 1729089522263
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
+  sha256: 5bb9bfe025d9a49af272f194278f63cea7366e83bdf3f99d25f97b820d522089
+  md5: 100d3161d97332fe38945afec8d36935
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 276381
+  timestamp: 1718029864701
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.6.0-py311h06a4308_0.tar.bz2
+  sha256: 30dedc2bed0aa72523531f5e22fff96c948bb2f68addb625161ef50b07484fb9
+  md5: 1571b1a2aded9cbd3c0c7656e9a9ebbe
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5853990
+  timestamp: 1727914619438
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.4.2-py311hf4808d0_0.tar.bz2
+  sha256: de78a7f35a57c21d8986c1084f308c98477747d6a92a0b23b5d4855333eee0c9
+  md5: 85399e523becae3ca29054b3d579b8e7
+  depends:
+  - libgcc-ng >=11.2.0
+  - numpy >=1.21,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 148890
+  timestamp: 1731058903578
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 5d15605858771290fdaaae41a43941623757a25cb1292080d69d6d3857807935
+  md5: 7f517469aa5380c52e55db9f37df104f
+  depends:
+  - brotli-bin 1.0.9 h5eee18b_8
+  - libbrotlidec 1.0.9 h5eee18b_8
+  - libbrotlienc 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 18652
+  timestamp: 1714483267080
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+  sha256: a5094f078584e27c7cced4a9564ae904a329f5c1702a7c1ba092d581ba1544f1
+  md5: 6ddf45dd8a21a9512481de9bc0e5a03f
+  depends:
+  - libbrotlidec 1.0.9 h5eee18b_8
+  - libbrotlienc 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 19711
+  timestamp: 1714483255915
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+  sha256: 93180c973816246f068b742d0bf64840f0ea48e31d4f9b0747ea2ffc34d8855d
+  md5: f3a00096965a5ba1eb41d2c99a4662a2
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 361574
+  timestamp: 1714483400014
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+  sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
+  md5: f5058c8d5b2994b7334f18e022105a14
+  depends:
+  - libgcc-ng >=11.2.0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 427542
+  timestamp: 1714510571510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+  sha256: 5b4c80587ae4ec915505469f79d866f27c80456156667c8548d31c67c2c1653e
+  md5: c3d6bfae757760082261779c406a880d
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 116270
+  timestamp: 1693902021950
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.9.24-h06a4308_0.tar.bz2
+  sha256: e9f2e55d34b1b0b9b48e48a1d6e4503653f8b7059114d23f758b7c68dde2334a
+  md5: 4a091502b44d4090f30f0be847a8139c
+  license: MPL-2.0
+  license_family: Other
+  size: 139901
+  timestamp: 1727794854964
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.8.30-py311h06a4308_0.tar.bz2
+  sha256: 6c769a7cae15ec611e2a3cc9ccfe646b6027f60c2822811b3f60f589a8c51d8f
+  md5: 6ffd4b4a690cad0ee056e659db868f56
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 169012
+  timestamp: 1725551779652
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py311h1fdaa30_0.tar.bz2
+  sha256: e0fbb102b3423152b4ec6d633ee8883628df58b80c8b44b0c6321b869106a68d
+  md5: 1febf11ae23feb3458c028479574c878
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 304269
+  timestamp: 1726856473093
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+  sha256: 9ddbf05887c7d7926418520cc7848e57f6d2431bc4ec6d30e090b02dbf865041
+  md5: 57ae1141ad9a048fb2a75d7a3ef7430a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203190
+  timestamp: 1698129926216
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.0.0-py311h06a4308_0.tar.bz2
+  sha256: 017b35122f533e4ffc48bb3e0c6fd1f16e8cbb2a67d40b3f6572b77511ffe26d
+  md5: 75eb58b2cdb0ddf4e93293cf973a0829
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41983
+  timestamp: 1721657369906
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+  sha256: d9c102b9ec7f3a635936b6f73d4db126d748a25f65407353bd76b260dc7d1cd6
+  md5: eec48dbdf5dac0ea26750cc26b58c1d9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 554986
+  timestamp: 1709758392744
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+  sha256: 882481e441b9b93cbdfb32fbe32a6ad9f26197472f186a08fddb921f61346c02
+  md5: 443c79196064f57c98199e9990544b2f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16902
+  timestamp: 1709322958614
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+  sha256: e4877b41553e31b9f9f090dffab77a654255c63776e8b30fc91ec1f60afadbf1
+  md5: c34d3f1520f1e8c9957eb236710058c4
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281162
+  timestamp: 1700583651472
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cramjam-2.7.0-py311h24d97f6_0.tar.bz2
+  sha256: 7bb1fd85aaba31403b00722d6f142220031788e391fdaad899c816595cb3ae5d
+  md5: 6673633f2374304790bfdcaa334b14ae
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1528662
+  timestamp: 1702651329660
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cyrus-sasl-2.1.28-h52b45da_1.tar.bz2
+  sha256: 4e7eb5911636f3cac2bb22c85d56a8edf946cfd6379e8b7be6136ffdaf669c22
+  md5: dcabb2d653147fd807cf6edeb2c3522b
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.9,<4.0a0
+  license: BSD-3-Clause-Attribution
+  license_family: BSD
+  size: 239169
+  timestamp: 1688045783866
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.8.2-py311h06a4308_0.tar.bz2
+  sha256: eeb6264edb355734090537f71628c795493e5848867c05fb5fd624b9c0899c64
+  md5: f2d72f1b4ba65ae83f861b1c1245a22c
+  depends:
+  - click >=8.1
+  - cloudpickle >=3.0.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.4.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3116663
+  timestamp: 1725461379792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.16.3-py311h06a4308_0.tar.bz2
+  sha256: 0333d880caa9352ba4d49ecbd3c6282a362e574374c34c07e60f7dc3168a4e39
+  md5: 6bfb802c6e2297eca13453c609826efc
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy <2.0a0
+  - packaging
+  - pandas <3.0.0
+  - param
+  - pillow
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18020969
+  timestamp: 1720534125523
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+  sha256: 469debfa966d24b8372aaf909ecbe27dc6fde186f6f0d5b9e0a8427e38053364
+  md5: 498d0788982ec4c5d13a44359b9c7afb
+  depends:
+  - expat >=2.2.10,<3.0a0
+  - glib
+  - libgcc-ng >=7.3.0
+  license: GPL2
+  size: 600218
+  timestamp: 1602701107852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+  sha256: 3b4cd8dc60572086f1a1cbb97e2712e0ffd55317ce8f0309d552eee7367855eb
+  md5: 70a1263b6e19bf2d77c020a2e77277c9
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2556575
+  timestamp: 1690905285843
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+  sha256: 4b589e3265c74159130230c164ff2d8d381be65899a249def0b53f93ce83fd47
+  md5: 245cb7173dcdba21cf368031cd87f706
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17434
+  timestamp: 1676823330845
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.6.3-h6a678d5_0.tar.bz2
+  sha256: 4239a7e8973dadc127940fb25e63a07a7ec9627c39687ae4742ce561e4fd0d63
+  md5: 2a9b1536c3f7f922a2b63fa2981e447a
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 200780
+  timestamp: 1725543341127
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-2024.2.0-py311hf4808d0_0.tar.bz2
+  sha256: b7f0f6cc1213a6f36d1ca1844b6fa918833a737703f54e719bd71cd3b39eba9e
+  md5: 9aa84ee8cddc8aaa057295e1853c3ad2
+  depends:
+  - cramjam >=2.3.0
+  - fsspec
+  - libgcc-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 683044
+  timestamp: 1715262508371
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.14.1-h55d465d_3.tar.bz2
+  sha256: dcb04f684a0182e8161eb607488cef61ad121b72eda8794b1072aad621663016
+  md5: 7fbedeb920dc384a9873983a4abf62a7
+  depends:
+  - expat >=2.6.2,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - libxml2 >=2.13.1,<2.14.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 343714
+  timestamp: 1722921016734
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+  sha256: b75d12e85274660bb675a3e53d47a929872f2daa2ff5a76e98885ee3f2d19ad1
+  md5: f2119d0885334060d0d7fe59e5220287
+  depends:
+  - brotli >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - fs >=2.2.0,<3
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  - zopfli >=0.1.4
+  - lz4 >=1.7.4.2
+  license: MIT
+  license_family: MIT
+  size: 3237908
+  timestamp: 1713551660998
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+  sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
+  md5: a5dc8677d891dff2393b63189a3ad42f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 971975
+  timestamp: 1666798278693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.6.1-py311h06a4308_0.tar.bz2
+  sha256: eb7d7646fbda149ab0291100cb5d5d964b93b04aae9423eddf7d9fae1e45f0ef
+  md5: cde515ecf78e4d4b9f6c2290eb00a952
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - pyarrow >=1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 382658
+  timestamp: 1724855656158
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.78.4-h6a678d5_0.tar.bz2
+  sha256: d9a486f0ac92b1365365c3e536040a552c2de633283f27129f16dadcbc6d2de8
+  md5: 32538e0c24874a85011a094217830bd4
+  depends:
+  - glib-tools 2.78.4 h6a678d5_0
+  - libgcc-ng >=11.2.0
+  - libglib 2.78.4 hdc74915_0
+  - libstdcxx-ng >=11.2.0
+  - python
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 499006
+  timestamp: 1708031707428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-tools-2.78.4-h6a678d5_0.tar.bz2
+  sha256: cc7d3a52acad1df08e3d4ec7eefb22f41320e7eada94e78bf4b051128cbe72d4
+  md5: d8dcbf2be12799cf7f333c21a0e91990
+  depends:
+  - libgcc-ng >=11.2.0
+  - libglib 2.78.4 hdc74915_0
+  - libstdcxx-ng >=11.2.0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 112595
+  timestamp: 1708031685927
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.1-h6a678d5_1.tar.bz2
+  sha256: 833208211f0ecb52198f5fae585f937be3c337c15b4569d8f1a28638545250d5
+  md5: 2fa837925e0633ceae4ec826f6daa93f
+  depends:
+  - glib >=2.69.1,<3.0a0
+  - gstreamer >=1.14.1,<2.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libxcb >=1.14,<2.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  size: 2253949
+  timestamp: 1677171916164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.1-h5eee18b_1.tar.bz2
+  sha256: 8257a1c1c967d48561f62adb649fe21c467f0a37c41f783ba6e2c6d79fa1cc4f
+  md5: 5cd8e1f16b1ce869d0c3a98b9f0897fb
+  depends:
+  - glib >=2.69.1,<3.0a0
+  - libgcc-ng >=11.2.0
+  size: 1690003
+  timestamp: 1677171850557
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.20.0-py311h06a4308_0.tar.bz2
+  sha256: 97633f085c543505ab0ed53de62bbe516ffdef26f11449a5a361ef6303b3142d
+  md5: 8b2ed66ea48b7e6fef1018404ddf93f1
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.1
+  constrains:
+  - plotly >=4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6141733
+  timestamp: 1730827820330
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.11.1-py311h06a4308_0.tar.bz2
+  sha256: 030ab24bf564d3fddbd2837766640042cc51b202a28ca8a892b4021d5a5cc12f
+  md5: ea48f120eed7aa3e55518d4df50c97ad
+  depends:
+  - bokeh >=3.1
+  - colorcet >=2
+  - holoviews >=1.19.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 364229
+  timestamp: 1729516850422
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+  sha256: b35b281dbf69b826c6ae04fcd7b6a2d1f098277a669a199906a1f23b4b0931a5
+  md5: 2a793fe24f85aa5819fe69c450cba6f7
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 29021241
+  timestamp: 1692293243228
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+  sha256: e08e27531775de40f46b6ac7bf71856963baa0c008bd2b4d112e6341cd3e8f4c
+  md5: bfc7682613c861cbcb4ac01485c05657
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147174
+  timestamp: 1714398938840
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+  sha256: c7ffa6006573483a05ef355770c3201f04dd04ab4b91ae01971a6cdc7fbdba35
+  md5: 23d7d38e93d930ea5e2cc5f4079d3816
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 49872
+  timestamp: 1704813633807
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+  sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
+  md5: 3add2ce56858a1b8f6a37342f82773d3
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<1.2.14
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 19310769
+  timestamp: 1699647799237
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py311h06a4308_0.tar.bz2
+  sha256: fe68041ab6344e8f2a6dd8e42032bc1332e22bc8c268e74b81e00fe10e35b822
+  md5: 382be07ff80150df0b66abae64059a40
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 238033
+  timestamp: 1728665623948
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.27.0-py311h06a4308_0.tar.bz2
+  sha256: 466a9ff4b27043bc48c6e619fe458a4d6390d7db1cc3096d971b6a6166212ee9
+  md5: e58614cdf643d299d1faf06bd2b92327
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1633729
+  timestamp: 1726064436441
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.1-py311h06a4308_0.tar.bz2
+  sha256: 527d00eacde56f9f8c391dacfca0f55c5c750c45c6400d6220b49e3ee36e5636
+  md5: a4b061aee54081589532e93572722769
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1175236
+  timestamp: 1721058517965
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py311h06a4308_1.tar.bz2
+  sha256: 1cf0f40f4bbb90b1280c32ddfa7e9a7b36b82e88a467c994b4c698c3d41ce5f2
+  md5: 0731cad6883721022d93fbd62ffe1edc
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 356018
+  timestamp: 1730903056980
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+  sha256: 8316ae3abee25edab89788ee6e9eef79c398aba192559f514674a04ee1860bca
+  md5: 112209aed451545a622ab217c70f6972
+  depends:
+  - libgcc-ng >=11.2.0
+  license: IJG
+  license_family: Other
+  size: 283506
+  timestamp: 1722872662693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.23.0-py311h06a4308_0.tar.bz2
+  sha256: caafff289b6a96f7f13668faa72e7a85346f410b1f97dc34163f70746bb98f1b
+  md5: 27d1820c6bd6185aa888ee994d290bf1
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 192447
+  timestamp: 1728486794980
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+  sha256: 9e3bac2d41bd432b721b009e7de981766fba396e6f238e923f304112bd88655a
+  md5: 84ae4cf3f2d01fbebdac374971192be9
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 15525
+  timestamp: 1699032521315
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+  sha256: 79ce6dff3d93649a2555b1d2a4ae9eb77175a1c00664cb8eb0e6f848d5cdd1b9
+  md5: db395b0efd7018fcf3a4af879170c2a8
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 276856
+  timestamp: 1676823504812
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
+  sha256: 91cca0ba49accdc9e97463bee087244a27ad107eb3af9ccb91634239f8b10f72
+  md5: a185824bfc55bd90e1cf9330b417b74c
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 97359
+  timestamp: 1718818381635
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
+  sha256: 540f8dfb7cdc3877b4e24d6af65696d0bc7eae5de1c307229f86b3fe601a2286
+  md5: f650f8c007471f6ef6c1a292918d2e1f
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41920
+  timestamp: 1718738122846
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
+  sha256: 398387b6f1ee1691b04a31fedd1320225e5553aa921b06bc013f010a0008621e
+  md5: bac66634a9133c633ddc879e14e83f23
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 610854
+  timestamp: 1718827113534
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+  sha256: ddfee06ba9b149222c65d1d4270272840533aa63b56fe36363c84a891c71d328
+  md5: ee128e5c0d8d9e1952e2387b66a5b8cb
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27239
+  timestamp: 1686870958829
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+  sha256: 0c6a074272ed58677ec17e4dbfceaffd2108841a61af92b32f156c5763108d1d
+  md5: dd3d37841d0d20c70a60e8c939923894
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19144
+  timestamp: 1700168632051
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+  sha256: b040f0d0ee4588188ab6b83a93738b3ff6e6d1775424be97995bd0df0f4fb904
+  md5: eae62735d710cf5ff6d51e6f59fcd999
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78148
+  timestamp: 1676827253282
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+  sha256: 01bae3dd44469e34f043e0416f5f5e658429bf4031745399d9968d10b899e2c4
+  md5: 10171cca67e3d73c3646c6dc5a321460
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.8,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1427115
+  timestamp: 1686931095252
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+  sha256: 069d33aebaf4db4ae410d4acb4851860a69d2c8f326fd45ab2a67b67fe276e6d
+  md5: 61689da52cf1fcebda8c9fb2872f94bf
+  constrains:
+  - binutils_impl_linux-64 2.40
+  license: GPL-3.0-only
+  size: 723073
+  timestamp: 1727336193185
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+  sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
+  md5: 88199c75f2ac211728febced7785c24e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 228278
+  timestamp: 1635523146417
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libabseil-20240116.2-cxx17_h6a678d5_0.tar.bz2
+  sha256: 799f5e019772d5d774c07dbb8b8d633e0b559921c8ab16ab2276aca1ca4f2fa2
+  md5: fe4de116b00c2c7eb7d307a58eef7429
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  constrains:
+  - abseil-cpp =20240116.2
+  - libabseil-static =20240116.2=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1316915
+  timestamp: 1716563364037
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+  sha256: bb990ea068c3b3dafd9c807e0e19570320cb2fe7d69cc326f1f0b5319b0654b2
+  md5: 3ff70744e396b1af69656c574b05c3b9
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 66940
+  timestamp: 1714483221853
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 3b87a816f72a00e1f0022a160e7eda70af89d3de2a2e08a72be1c17b31d759f3
+  md5: 4f57d3a0a13ddaf1c06efb586b702f46
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 34446
+  timestamp: 1714483232430
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 2cf15e89f910600f468edfde8d0f9b80a14fa2319ed89160dc7375dfd3764fdb
+  md5: 463adc13f2feea3570d1eccac368d9e4
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 295090
+  timestamp: 1714483244460
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang-14.0.6-default_hc6dbbc7_1.tar.bz2
+  sha256: 46646ce93dafb4922f4597c34c4fec106b4ff3b9707a202387f7964601e47876
+  md5: 5eaf417727302b441025661154fc4587
+  depends:
+  - libclang13 14.0.6 default_he11475f_1
+  - libgcc-ng >=11.2.0
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 130632
+  timestamp: 1681222907766
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang13-14.0.6-default_he11475f_1.tar.bz2
+  sha256: 24d638d8577a3332a2e6cd77a5178054ca9cf7e14f71353b5b0a655155ab5c19
+  md5: 230f394424c6cc26ebbee96176b65ece
+  depends:
+  - libgcc-ng >=11.2.0
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 11152969
+  timestamp: 1681222877667
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcups-2.4.2-h2d74bed_1.tar.bz2
+  sha256: f465c8f00b075660362d8e7fba8702b1c11e56fb2c305da78b9ee69898609be7
+  md5: 8a2e46dc8bd62528a6f4d9092f2f6911
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4901408
+  timestamp: 1685057846629
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.9.1-h251f7ec_0.tar.bz2
+  sha256: 5ed4a1b84f273bd7bcd1302c823f4fbd486567c5d7d1a1e78eff9e7188af2e36
+  md5: b1c706c4fa97ec653a40d7670f7b24a3
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libgcc-ng >=11.2.0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.57.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=3.0.14,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 426063
+  timestamp: 1725033936108
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+  sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
+  md5: 55dde57e63a36b202e388a39dcee9a66
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 74096
+  timestamp: 1695996494461
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+  sha256: 5bd3af246b6a93ea0912179ae66e0ad9157ca0142263010d84b65724e6db0bec
+  md5: 5cb0cc0e1783419cf8fc1c65fee0f62f
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 195807
+  timestamp: 1703006263489
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+  sha256: efdab884c85fda4461f7a393aa6d4e0e50d03cb59fb9c8a980b1307b8379ebe0
+  md5: eeca774c6154c49340dd403b1928d5e9
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 108906
+  timestamp: 1632891483341
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+  sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
+  md5: 1af9b4d62c708924417f2640ef22a68f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 154016
+  timestamp: 1714483282916
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
+  md5: 641e72e5067bd6d5454405879e1cd2a7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - _libgcc_mutex * main
+  - __glibc >=2.17
+  constrains:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - libgomp 11.2.0 h1234567_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 8895144
+  timestamp: 1654090827491
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+  sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
+  md5: 27082517590f3b9fbffecc68513b461b
+  depends:
+  - libgfortran5 11.2.0.*
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 19860
+  timestamp: 1654090819660
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+  sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
+  md5: 0202c3c8ae4735cac6c7f3d1e1685964
+  constrains:
+  - libgfortran-ng 11.2.0 *_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 5228750
+  timestamp: 1654090762569
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libglib-2.78.4-hdc74915_0.tar.bz2
+  sha256: ddda848ae8594a9a28b14439b322763e4ffb0ff8d34e492c994e434fe3fbf934
+  md5: e35935cc3937ef52b2ef721dddc45738
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libiconv >=1.16,<2.0a0
+  - libstdcxx-ng >=11.2.0
+  - pcre2 >=10.42,<10.43.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - glib 2.78.4 *_0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 1583413
+  timestamp: 1708031663093
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+  sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
+  md5: 3080c2813e6e1d0f8a100a38b5b3456d
+  depends:
+  - _libgcc_mutex 0.1 main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 573231
+  timestamp: 1654090775721
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
+  sha256: ed544d8aa7e77fc42c39c276b879955e6615b517c42fecd2624033a5050832eb
+  md5: 21ee76e09ab0a7315cbed14933d97773
+  depends:
+  - libgcc-ng >=11.2.0
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1436714
+  timestamp: 1714483320555
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hecde1de_4.tar.bz2
+  sha256: c50e6a07e8004849e1cf9f0a164e36a79ac9d14a14fa7d33dc5e370315800489
+  md5: 457cfe8b5e65d583e6797a1ba2b5fb4d
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 37206574
+  timestamp: 1726769447337
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+  sha256: 6c67d781d3c074ae46b18567f230bce4a4afa209e8b914dc2cb448502774886e
+  md5: c9627c386bbc8a1a1a0a2e736ea44501
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - c-ares >=1.7.5
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 722387
+  timestamp: 1697018420830
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+  sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
+  md5: 1bffe1481ed4f88827248fb9001f8923
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 362561
+  timestamp: 1677841789536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpq-17.0-hdbd6064_0.tar.bz2
+  sha256: 789ad45faa1c4c742e4de9858fa9aefe00f8fb138e3968d1dcf2d874a6a55380
+  md5: db89c360caa392b4e03932077cef5e9d
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libgcc-ng >=11.2.0
+  - openldap >=2.6.4,<2.7.0a0
+  - openssl >=3.0.15,<4.0a0
+  size: 3383536
+  timestamp: 1731525881300
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-4.25.3-he621ea3_0.tar.bz2
+  sha256: c070317f268dfcf77d5ff50c286bf430419fa9267eeea67d622f85c25fc6de9d
+  md5: 1672198ffdc6aabb8750c51496719e19
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3242840
+  timestamp: 1716568319462
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.11.0-h251f7ec_0.tar.bz2
+  sha256: 9ffb6bf8ac29a27a2faf800c0d9077f07e983a41c218f87a6013a6e1f95af2ab
+  md5: 5b81a682e40f4c00841445d130c90b20
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.13,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 276424
+  timestamp: 1715261489564
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
+  md5: 8c195584a5f5471b600ee180e4052773
+  depends:
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 6410287
+  timestamp: 1654090800863
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+  sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
+  md5: ef78eebd98289aceacdfa29182426adf
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 664034
+  timestamp: 1693575237924
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+  sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
+  md5: 292768ec77416ae257cfdd44ea2071c8
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29197
+  timestamp: 1668082729834
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+  sha256: a062fad27450b94279d1688aabd11a95eedee7814462ef6364337d55412b4a7e
+  md5: e0521f84b9770830e654432364ac930e
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 484011
+  timestamp: 1729160032020
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+  sha256: 5d68e69709ae10bd6c4b58b6af447ad2f2bd24955994f3ec77103d1a6bf5e1f5
+  md5: 49e523de8d364b7fabc3850eccbe9bda
+  depends:
+  - libgcc-ng >=7.5.0
+  size: 623492
+  timestamp: 1652448233146
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxkbcommon-1.0.1-h097e994_2.tar.bz2
+  sha256: 72f48748059c081dd359f4b7303d1af66cf6eb5c496f053c2856a65a053ecba6
+  md5: 26a52c61d45e49f89caff988460845fc
+  depends:
+  - libgcc-ng >=11.2.0
+  - libxcb >=1.15,<2.0a0
+  - libxml2 >=2.13.1,<2.14.0a0
+  license: MIT AND X11
+  license_family: MIT
+  size: 641120
+  timestamp: 1722885004470
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.13.1-hfdd30dd_2.tar.bz2
+  sha256: 2f04d75b2175c95c328235b42f3669f1bb693be63d46e689bff878f806fa378e
+  md5: d424ae0c5ca1279f734a1c52a1740d3d
+  depends:
+  - icu >=73.1,<74.0a0
+  - libgcc-ng >=11.2.0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 738961
+  timestamp: 1722441092529
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+  sha256: fd8e30beb8c9442f16e6617fac92dd0c89ec823e98f06e60f712147380ead35f
+  md5: 7ed7caf2816c8b85b67b6f4e8833cbd5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41155
+  timestamp: 1676837080881
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.43.0-py311h6a678d5_0.tar.bz2
+  sha256: ba4846b57918d712a2c9986a31ac24fc3105f7cb029d1bcd7972b4bcd7a15b1c
+  md5: 707e906a126ab3f69499704ab424b18e
+  depends:
+  - libgcc-ng >=11.2.0
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4446734
+  timestamp: 1720455383067
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+  sha256: 95fe76d2691feb13203b55ad2aba535bb848cae21ffd05b13ff51c7a45fa2332
+  md5: 6a04ec16e3abc1c7e2104be32cd6c418
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13458
+  timestamp: 1676827287432
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+  sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
+  md5: 76f089e76ec67583bb38428b51008097
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 164494
+  timestamp: 1714510587156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+  sha256: 260e26dd509834c1b225ab7bdb97b9a86e00054fbdd5dfa49e68fa4dcf85a661
+  md5: 8f5d7ddc69cc6f7d44c80d2251dea5d1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162339
+  timestamp: 1676837095436
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+  sha256: 7f5b0804d0768619b7bd93b10488067d80bf42ec29f443f00b53ba11758a1241
+  md5: 8afb45e45c0d93bfd142e682d4b021ef
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 134438
+  timestamp: 1684280014220
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+  sha256: cb03570c99c983d7bfda94bc47d8eb00d4059b8548a171130775acc998004195
+  md5: 5b1abbbf1e4f9b350b16fc9caf9e889b
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26919
+  timestamp: 1704206397615
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.9.2-py311h06a4308_0.tar.bz2
+  sha256: c0a4b63c7b4e5eb3ace819a9fa61f107658c5bf99bd3c7448e364e27cc7d50e4
+  md5: 37b73168cd1e4c5eee6b1c61bd09242d
+  depends:
+  - matplotlib-base >=3.9.2,<3.9.3.0a0
+  - pyqt >=5
+  - python >=3.11,<3.12.0a0
+  - tornado >=5
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 6764
+  timestamp: 1725264223949
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.9.2-py311h6fb44e5_0.tar.bz2
+  sha256: 3e5f475ba36d974005e6d3c4adbd1ba1874fba9d7db287eb74e7def409a5b478
+  md5: be51f267bf90790dcb7e1562ad5e4d42
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9468863
+  timestamp: 1725264212197
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+  sha256: 7ac07ea180b5928086075900afbc332fb1d3c81ddfacb54c891693c284056f14
+  md5: fc83dd1b3d2ec3c0a297ead0c3405907
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19573
+  timestamp: 1676823852670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+  sha256: c9ba2f9c83820712dd97d6a1b54a1215b9820a0be02ac82380b4c50911b9400c
+  md5: e5dc6b4a5b8e02733ce3bc9e9198a8d2
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67750
+  timestamp: 1676837123613
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+  sha256: 1a5141ef0de1cbff816f96bb4b212a40606e2fc11301a4c1358c8d63a6b2b027
+  md5: 22ac3bc22b68fef4c1f3f6ab3c7bfe0b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23040
+  timestamp: 1676827301164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+  sha256: 9aacfbbe6f638c58a4e8ff31374d1438d78b7db25d6ea6fd0c50ca2109f225d4
+  md5: e602057e3b3d80da88c61d66e8851c5b
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104681
+  timestamp: 1676823696152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+  sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
+  md5: ce77d0f05f846da4a6b9e23fe7f21d9b
+  depends:
+  - intel-openmp 2023.*
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - tbb 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 206738176
+  timestamp: 1699648006088
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+  sha256: 2aef0876d0df033f7fae8cddbd25d95fc1bfc067e60dd143bd8000fec0768b21
+  md5: d6cdc670327bd1675bbea642849f04e1
+  depends:
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59569
+  timestamp: 1682948560323
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.11-py311h5eee18b_0.tar.bz2
+  sha256: 26001bced97eaa8c3862686f48668a252b8f7fd6ed81329534bee0538ea39fe0
+  md5: eb3e382c51549878d07e5c3e207c3845
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 241049
+  timestamp: 1730824176185
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.8-py311ha02d727_0.tar.bz2
+  sha256: afc57040e0c892e46b00ecb534100fcaf05d8c75592170b0ce9119f2e5630557
+  md5: 5e47055fea53886417e9a62d4e89c7c9
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16
+  - python >=3.11,<3.12.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411216
+  timestamp: 1730824036145
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+  sha256: b558b3f6c144652b5e0d26497b3ce24c318a6b9ff8ea2079113c95e5553b3cf9
+  md5: 0b185969ac2b065c27cbcc9641d93678
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29568
+  timestamp: 1676841232463
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mysql-8.4.0-h29a9f33_1.tar.bz2
+  sha256: 4ce8e37ee2af13b445e1ed9a1f5ab2c0c36d6c30693b323610e9074e0d7405a0
+  md5: cd73c46242919e3787069508f595c188
+  depends:
+  - icu >=73.1,<74.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libcurl >=8.7.1,<9.0a0
+  - libedit >=3.1.20230828,<3.2.0a0
+  - libgcc-ng >=11.2.0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.14,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 70741824
+  timestamp: 1722531388768
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
+  sha256: 6116c133fbed1e7ea0f5e69f900e93d7977cb715920d10b10642c191d00cc9a6
+  md5: b842f7ebdc8b7b6a0dda4c5ebe12805b
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8315206
+  timestamp: 1717622768176
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+  sha256: bb45fb0a3973caa74fd8f845e0a519895f6a378807626e15ecf72c02f2eed794
+  md5: 185f658ba8a74e326b7231c8fd0d62bf
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 121834
+  timestamp: 1698934274227
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.16.4-py311h06a4308_0.tar.bz2
+  sha256: 9361ab2f7b289e9fd33ef001035fbdca9735f1c5425bb8282ce053d152ffaa2c
+  md5: f95894da2382644ab016e71dc0db3463
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 528660
+  timestamp: 1728049573278
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py311h06a4308_0.tar.bz2
+  sha256: c7aa4facc9d03e5087f9b22a88373beb43633a2c558e895303f5accc3ce95142
+  md5: 4b4927ae34aaf3ee6b008a4392afd2dd
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 169513
+  timestamp: 1728049478168
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+  sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
+  md5: 57ea097dc15f8d9f9eb90e1d919143b0
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1157733
+  timestamp: 1674734069410
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+  sha256: 266199dd4efde0ad342a9c500f4bc4299c5622219aea623b46315a9b4f6b8959
+  md5: 2b21844d2b0024d0ffad0e6450cf0855
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 15860
+  timestamp: 1708532713870
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
+  sha256: 59e169e036db0f2b98ed19f867d8ac708970214599efa0d57d3413fc1dbe8e3c
+  md5: d0faf375bfc33811456d43fe549cb939
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 710152
+  timestamp: 1717630833268
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+  sha256: ef2857e6d3d7eb246b3abddfbd3aa2d124dd8565391ace3876b77339babc50bb
+  md5: d276d1b1774107987963135c78ca7390
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26607
+  timestamp: 1699455972519
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.60.0-py311ha02d727_0.tar.bz2
+  sha256: 08a8505d44d5a51141cf4bd895fb3925ee52160bd51e8c8147f11e7f48a65a1f
+  md5: 47699f658867be16614cddc1edd70731
+  depends:
+  - _openmp_mutex >=5.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  - libgomp
+  constrains:
+  - scipy >=1.0
+  - cudatoolkit >=11.2
+  - tbb >=2021.6,<2022
+  - cuda-python >=11.6
+  - cuda-version >=11.2
+  - numba-rvsdg 0.0.*
+  - libopenblas !=0.3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6188719
+  timestamp: 1720541020279
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.10.1-py311h3c60e43_0.tar.bz2
+  sha256: c85ee5a0b557ed925a1709b7422f13e88545bd2392c63d8e65b8d4dd44bca713
+  md5: 3ca48c350f813b2e11ed2312858098f7
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21,<3
+  - numpy >=1.23.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 204257
+  timestamp: 1730216115069
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+  sha256: e09e1aff2c12d4ef3fec58fb627744e4b5c7d9eaede7175e293f77272d8b8bfd
+  md5: fe8242cfd54d238507493612ae697ad4
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311hf175353_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10270
+  timestamp: 1708639794640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+  sha256: a53ad723826651041a5057a1cf31bc8689b24d335ce61b196df5124974b05a8e
+  md5: 7b29e7191c4170189d6080e61229f030
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311h08b1b3b_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9163911
+  timestamp: 1708639777712
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
+  sha256: 1c9f6902907a3d4a7e5c3cb02236491ea4c4e66a1a0ce51fa506dffb24ba89f6
+  md5: 36d514eca3c87ab75a1d418607e26db2
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=11.2.0
+  - libtiff >=4.5.0,<4.7.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 528528
+  timestamp: 1722872671997
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openldap-2.6.4-h42fbc30_0.tar.bz2
+  sha256: 0f8ab416331b1cf627db4a1e1209074574bb066af21632f1ce4c27cc9c74e6d1
+  md5: 05cc121f5bd122219dd67cd201c174bc
+  depends:
+  - cyrus-sasl >=2.1.28,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: OLDAP-2.8
+  license_family: BSD
+  size: 1351078
+  timestamp: 1687380352694
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.15-h5eee18b_0.tar.bz2
+  sha256: f8a3dbcdabfad712311fdbec1fd49d44340818d348df5d90f420de133a4daeb1
+  md5: 4084456e619e7c2ab269f3cf2ff831f2
+  depends:
+  - ca-certificates
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 5499760
+  timestamp: 1725545717819
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+  sha256: 280225061aeba00d7b85f46e55d7d79cd92c92f662dc749d9c53187978e8d083
+  md5: c51c21da68080d89300703ad818c824a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38606
+  timestamp: 1699371264464
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.1-py311h06a4308_0.tar.bz2
+  sha256: 78b2ec7956f036125c4cd56bd8b13642b952b43a54850c778bf87a664b86d0ef
+  md5: db433aded6b3b43ee3cb5d1df0008d2e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 156677
+  timestamp: 1720101925844
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.2-py311ha02d727_0.tar.bz2
+  sha256: b5979b0d4ef5c09f9795acb6b5e322b404f4eab7d73b6ed0aa59f03ef7acd25b
+  md5: 1a353daeb78baa6b5bf8f47e1e74ca1c
+  depends:
+  - bottleneck >=1.3.6
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - xlrd >=2.0.1
+  - xlsxwriter >=3.0.5
+  - python-calamine >=0.1.7
+  - gcsfs >=2022.11.0
+  - zstandard >=0.19.0
+  - s3fs >=2022.11.0
+  - psycopg2 >=2.9.6
+  - html5lib >=1.1
+  - tabulate >=0.9.0
+  - pytables >=3.8.0
+  - scipy >=1.10.0
+  - beautifulsoup4 >=4.11.2
+  - xarray >=2022.12.0
+  - pandas-gbq >=0.19.0
+  - jinja2 >=3.1.2
+  - odfpy>=1.4.1
+  - adbc-driver-postgresql >=0.8.0
+  - qtpy >=2.3.0
+  - sqlalchemy >=2.0.0
+  - pyqt >=5.15.9
+  - pyxlsb >=1.0.10
+  - adbc-driver-sqlite >=0.8.0
+  - fastparquet >=2022.12.0
+  - dataframe-api-compat >=0.1.7
+  - openpyxl >=3.1.0
+  - lxml >=4.9.2
+  - pyreadstat >=1.2.0
+  - blosc >=1.21.3
+  - matplotlib-base >=3.6.3
+  - pyarrow >=10.0.1
+  - pymysql >=1.0.2
+  - numba >=0.56.4
+  - fsspec >=2022.11.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17976832
+  timestamp: 1718310942026
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.5.3-py311h06a4308_0.tar.bz2
+  sha256: edabd666746acfb045c1dd922835172ea94c00d33bf03337740db2af93551911
+  md5: 486d3afb94115451198410b69e3fa0b5
+  depends:
+  - bleach
+  - bokeh >=3.5.0,<3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.1.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing-extensions
+  constrains:
+  - holoviews >=1.18.0
+  - bokeh-fastapi >=0.1.2,<0.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24210987
+  timestamp: 1730381005745
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.1-py311h06a4308_0.tar.bz2
+  sha256: face211fc35bfa199b6d02f8ed25372d1f1a2093518a79a9eec9925bcf9e6d1d
+  md5: 9cd12fbc855d97b19427e911262e3bee
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 263218
+  timestamp: 1719348029519
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+  sha256: a2e2beff710765f2e5135020121da4f227f5e1cbe142e17398a585f50a389d37
+  md5: eaf734d49b6e576e12be1398a295643a
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - pandas >=0.19.0
+  - numpy >= 1.9.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 47447
+  timestamp: 1698702703255
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
+  sha256: 71beb7373390a7c5e9bf8663d64e2b0a426755fe68adb26ed72b6570634f635e
+  md5: cd7c1793b37ba076f8515b49dbd850bd
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3346886
+  timestamp: 1714657706306
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-11.0.0-py311hfdbf927_0.tar.bz2
+  sha256: b2a9d111070a9a8490fd422dd8a9362aa6e145d1404400acdffb4ce85e9886b7
+  md5: e7692de89f4413e94a253bd301150bbf
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 1001193
+  timestamp: 1731594824019
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.2-py311h06a4308_0.tar.bz2
+  sha256: 87422d1d2592abe99ee9a6c06f6653030567e88571a21edca9f4c1f2cd22ae07
+  md5: 806984470b5328d7fdb721b37ec2d73f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2913778
+  timestamp: 1723484664306
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+  sha256: d2bbab8bfc57c7f46ca8994bc87df7e744d3f036b867bc4be1145ba6d8d7e091
+  md5: de41707272a8e3ccab764f0b7010a27d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37394
+  timestamp: 1692205565974
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ply-3.11-py311h06a4308_0.tar.bz2
+  sha256: 786a4a57db582b66de12bd7e03eae83caa939136dabd8b53049cadeabc0beb6f
+  md5: 262064c348f1846011c650ad8a6cd793
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-clause
+  license_family: BSD
+  size: 111320
+  timestamp: 1676824981885
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+  sha256: e2a0e2a618aa33f0beff9583c7dc510b8d0737b023117346676aacbad33970d8
+  md5: 66a6818307261b1a28ab12d1b7776fdf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 121454
+  timestamp: 1679340540306
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+  sha256: b7f591c19b10bf0daa7e6e3b45a9f4a0a0e83188e1f8a58037caea79e60f8d91
+  md5: d945b4ccc135005839c504cc29df1745
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 749608
+  timestamp: 1704404477511
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+  sha256: 96482b49191fdac59580a95e69508367083e1f7600145e11d7c2db634337eb26
+  md5: 2d57bf8eacf3f291db845928241f724c
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 490805
+  timestamp: 1679337420563
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+  sha256: eb75b4417565d25e2d1006db75aa8bd9da6b6c72a929954b01a31b9bf5f8b42e
+  md5: bb56c0358b65665f4dd509a4635f6f3c
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37802
+  timestamp: 1676838557935
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+  sha256: ed927e4d058a8f4ea73edc7a43ed74877d93b88fdfa240b3b2777244386ced70
+  md5: a1f0e05fc7e49712f81ad5478ec9d51e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2121496
+  timestamp: 1684280065800
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.2.0-py311h06a4308_0.tar.bz2
+  sha256: b5d27b938ed374a24fcb18a66c3f1a94e28bbe01b4ac156cd26c7be1ca756622
+  md5: 244cfad440c898146039cb986864017e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 486387
+  timestamp: 1731445563066
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.15.10-py311h6a678d5_0.tar.bz2
+  sha256: f0c1614d5e651ed15061d137acecda2f684189cc148f50d3e75068dc9737bcd4
+  md5: 0911e45b849687c7318f7764e2b69778
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - pyqt5-sip 12.13.0 py311h5eee18b_0
+  - python >=3.11,<3.12.0a0
+  - qt-main 5.15.*
+  - qt-main >=5.15.2,<5.16.0a0
+  - sip >=6.7.12,<6.8.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 6539272
+  timestamp: 1698775883859
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt5-sip-12.13.0-py311h5eee18b_0.tar.bz2
+  sha256: a646cae6b3d429588a3dc752819b4dcb315a814c8ad2b9fb2741b166fc4ee2a6
+  md5: eec3045856f86acc307c73749a7f7df1
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 97216
+  timestamp: 1698769366045
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+  sha256: 114b55e00f4622c90fd2b404b21ad5f94a10283fcaaf86a42174b8d39b0a3e98
+  md5: 2458e92683cc68671a6c8e1b86ce8817
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35850
+  timestamp: 1676822725516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.10-he870216_0.tar.bz2
+  sha256: b9bca26dc975ca55d1a0da81c872a29677912cc907c7b851e62adf750adc3d15
+  md5: 9cbfa36ea4a6a61207af3f9f82ea8aea
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.35.1
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.15,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.45.3,<4.0a0
+  - tk >=8.6.14,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 36130467
+  timestamp: 1727941504946
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+  sha256: a0f008717fab060ccd003dfebc09156d90b9afd14ac3626566aa1a8f3d3b7e2f
+  md5: 357bf4fe94496cbae72ab4d780184b31
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 330924
+  timestamp: 1716495762901
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+  sha256: aadc4078311c059265706a56265f0a57ceb538d36179d5203dd487d80d0e8f16
+  md5: 59ec670fcd172447dbd9591b8fbfdd56
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 278741
+  timestamp: 1679340144625
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+  sha256: d5058d0ecc3973316c1d5f1bfb03dd119e0dade85f4c2d21b412c8db4e1636f2
+  md5: 93000e4d3603342779a2afda66fa91b8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17607
+  timestamp: 1683823841946
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+  sha256: b85acb933fff864bfa89d034e8e3d85b1a9c2e69cbfc0d68c1d66ffd1443e67d
+  md5: 0cdb92d2d684ee1095310f992ed0d9b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 266796
+  timestamp: 1713974338678
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+  sha256: 511e8206a15445715b80be76493300930686b3fe1e512ae942d6ccca36df392a
+  md5: 35a6e46ae970f8b71d78fb5a810f2e80
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64013
+  timestamp: 1711136926372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py311h5eee18b_0.tar.bz2
+  sha256: 132aa25ee904333ef338eb1935dd8e5ccffb27cacf33fdb58c1358ec22424933
+  md5: 92ce34b6f4f7a6e64c80c2ba0a96edf4
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 222337
+  timestamp: 1728658052191
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+  sha256: 7c74db4292f31619606180f86f3c1e2d913495c2c9d1195c5d51681a6a841625
+  md5: be1c05fae57d194924b9400f9b5ad3c6
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 613277
+  timestamp: 1709318516682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-main-5.15.2-hb6262e9_11.tar.bz2
+  sha256: cdcc746ef1d80cfacbe5e7ad1c3c91b97871006c5609623878ab5980f0df041a
+  md5: 3d7589161197f2e1dbd526e146bff036
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - dbus >=1.13.18,<2.0a0
+  - fontconfig >=2.14.1,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - gst-plugins-base >=1.14.1,<1.15.0a0
+  - gstreamer >=1.14.1,<1.15.0a0
+  - icu >=73.1,<74.0a0
+  - jpeg >=9e,<10a
+  - krb5 >=1.20.1,<1.21.0a0
+  - libclang >=14.0.6,<15.0a0
+  - libclang13 >=14.0.6
+  - libcups 2.*
+  - libgcc-ng >=11.2.0
+  - libglib >=2.78.4,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=17.0,<18.0a0
+  - libstdcxx-ng >=11.2.0
+  - libxcb >=1.15,<2.0a0
+  - libxkbcommon >=1.0.1,<2.0a0
+  - mysql >=8.4.0,<8.5.0a0
+  - openssl >=3.0.15,<4.0a0
+  - sqlite >=3.45.3,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  constrains:
+  - qt >=5.15.2,<6
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 62477035
+  timestamp: 1731686555318
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+  sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
+  md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 467661
+  timestamp: 1666648052561
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+  sha256: 89c2f4235277b9825cc805c5c44f0b1afcb683d7b5a3f513bc4bf243b643bb0c
+  md5: db70eb57e33adf7b8bbdadd72214d48d
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 73679
+  timestamp: 1699012111499
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py311h06a4308_1.tar.bz2
+  sha256: 1ac5ee93110e2f7f1d68b6c985e4adcc3710f537c388ae3ff4f85059288070a1
+  md5: 4385913efbeb323430797aa3b3506525
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 123440
+  timestamp: 1730999231468
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+  sha256: fdae3f68ea84b99561aee6c566ab1c287d8f2ae2668424e9283a8ed86af8f1d2
+  md5: cde5b71ccbb3630053340b2c8c7dbf10
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9333
+  timestamp: 1683077183576
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+  sha256: 0bf859b06a07857099fd4f524fe5e0875fda70029e9485d95c7efa97134fbc14
+  md5: fd5815cc592fdbd4c831901541eadaba
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 9735
+  timestamp: 1683059096795
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+  sha256: 474553d01aea57214a54a7443f227da84a58e29c49eb7605ba0043c55b7d167a
+  md5: f01333e9f0a908e435db650f42fbd2db
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1096668
+  timestamp: 1698946168635
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.14.1-py311h08b1b3b_0.tar.bz2
+  sha256: 3ec374217cda083d08d0e909e832e4881d5228b567df2280699a06257f3a71fe
+  md5: e6be323221b1c63fd108ce4681de5527
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libgfortran-ng
+  - libgfortran5 >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 28045118
+  timestamp: 1731624183722
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+  sha256: 51bcea0e575a626f6ffbd16d1153330fda93dbe3dd31dcd3a8f469ff61dd1e4e
+  md5: 41d531c90be8c82bf79635ff3d409476
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 32295
+  timestamp: 1699371262818
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-75.1.0-py311h06a4308_0.tar.bz2
+  sha256: 0012d33e169b495c9e289b185ff8d4192b93711c5dfc514b0c5efc536ea9600b
+  md5: 360f44ea616167b2c61cced23d0db311
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2311301
+  timestamp: 1726677958012
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-6.7.12-py311h6a678d5_0.tar.bz2
+  sha256: c1585436f502f87ee7bf6d40b7d911d1b5093dfee339db251d887bf355a23a94
+  md5: ff29bdee631a122ae9a68ff44066b02a
+  depends:
+  - libgcc-ng >=11.2.0
+  - packaging
+  - ply
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  license: LicenseRef-SIP_License OR GPL-2.0-or-later OR GPL-3.0-or-later
+  license_family: GPL
+  size: 683464
+  timestamp: 1698675983077
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+  sha256: 1a84b00944bc5588e14a097460175f97df49acb4f1ff2498ffd9a1893068ed81
+  md5: a456513471b2ecbed60430c21dd1ccc7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17880
+  timestamp: 1705431390054
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+  sha256: adcafd297d60af64107c113bb7b8b92160d0268a44ef9a3b79e56a88a0358ea7
+  md5: 28ed704ed26b06d32662e3a6a87e59b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 88799
+  timestamp: 1696347581401
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+  sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
+  md5: f86119b3243fe3508160aa0406245738
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1723866
+  timestamp: 1714488309729
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+  sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
+  md5: 041a3caf09dc9ce8fc6c10925c4fe050
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1888016
+  timestamp: 1680167274961
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+  sha256: 856a8ab8c350c50247b79966c6cb80fb6d4de36eef49ddf75aebbbcaf854c82d
+  md5: 442dde204d14d171aab9ee40e8de4de8
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37456
+  timestamp: 1677696176157
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+  sha256: f0a026ddc0ed041bfc60c8a1ca0b70b7a69232775b3181bfb35a39fda42d6994
+  md5: 2902d5a5854865baaaf58dc59cf06b3c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49185
+  timestamp: 1676823769869
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+  sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
+  md5: e2512d57c8a1e91e7b20e265c6906546
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3588922
+  timestamp: 1714770676475
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+  sha256: e58ff4a82819446f3c92e5b1aa2a784c4b06643e751fe67cf115858296dbfa50
+  md5: 32ee4723173f1fad5563b8afb5f1c8f1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135634
+  timestamp: 1676827536101
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.1-py311h5eee18b_0.tar.bz2
+  sha256: 394fdf404ede3bc35d697b2e445c42590ddcae86a80f39642cc5366196fcbe54
+  md5: a21cbca0664d8f34b0dca1f84998a31b
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 914199
+  timestamp: 1718740165334
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.5-py311h92b7b1e_0.tar.bz2
+  sha256: dab820faa313d62b44014841409cef89a49dbda9a7697689ce37b3032ec3276e
+  md5: 1d6513a5b915465291fdb2041815bdc6
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 154437
+  timestamp: 1724854032868
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
+  sha256: 2091b17ae4fa46ed98fd6bfe9ca1aff3b0b81d73045e0cc55774b6516b8704b3
+  md5: 183ae7b837c1c68ec1a8011011fadea7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 206924
+  timestamp: 1718227183177
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+  sha256: 8c06c291c76e8c2022ffbb9fea4727a4bf1f9b03e498bafc56ba8ac4e7604ab9
+  md5: 5adb7baf1091d09026a372cac930ce6c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8869
+  timestamp: 1715268966416
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+  sha256: 118b0801167264c401e84bbf19175546092a5569cc098146f7362bbf890dc8d9
+  md5: b3c2aa56d53b459f8365d8385f48d0c3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 74489
+  timestamp: 1715268960737
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+  sha256: 509b962773f0fe44a93a7f6196b254670a030eac8ea7f90727312e3ccd9294b2
+  md5: 6c402d5bf4e01c8c3895c9ef41707b6e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11371
+  timestamp: 1676828901104
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+  sha256: bbe7629e8ce52c82f13ed0d1fb919f3659ef466b274a7c74aa925a9bc7aee450
+  md5: 7da527bbcf71270c1abed8ea52e7d44c
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 509031
+  timestamp: 1713213062098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.3-py311h06a4308_0.tar.bz2
+  sha256: 42eaf6a7ea875b236796f58e9f06919fda206ef6a4884ce943d94aa7747ad290
+  md5: d1a78c6d9003bf2ff1cda53bde67c1f5
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - requests >=2.26.0
+  - selenium >=4.4.3
+  - zstandard >=0.18.0
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 217451
+  timestamp: 1727769856880
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+  sha256: c3a5e0b855dc2de6c162708dfcf170a23eb9e7525d4252d8dce553369af4a330
+  md5: a4c77e204b7787f820955166a1283168
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25890
+  timestamp: 1676823132898
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+  sha256: 42989f9970a8466cc4edb73463dfa194594dd1a5d42c9f820a1f86296d4af140
+  md5: 655dfd4d2f17977cb81caa1c082d2b25
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 113505
+  timestamp: 1715878346465
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.44.0-py311h06a4308_0.tar.bz2
+  sha256: 3b258ad0db82572157a72303bbd5c20399d0c7f3b48abc1435ef96e4517e59f7
+  md5: e11eb90c0ee1084a95cffe231196d98d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 138218
+  timestamp: 1726165052578
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+  sha256: 85248e503721da67797546cb8a22e303c1739100834b219c5621f216e3794e8d
+  md5: 2570956643f22d0f809b2467e02d3984
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2465865
+  timestamp: 1689041600364
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+  sha256: d18cdca154bf668826f869117ea996c4f9e8ef7d27b7c528332a7d17e5a8602c
+  md5: 9f7353d72046b16dd6ef6b5689ac9bfd
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54731
+  timestamp: 1676828934954
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+  sha256: 9122d6e9dabb7a47f2bcb15d86b97c96c49a9048da3f8ae59675351710c14cc5
+  md5: 660b2aead2ec87b751c86cd33934f44e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 716926
+  timestamp: 1714510796277
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+  sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
+  md5: 943f1247a22b6b64171363bcee1eec27
+  depends:
+  - libgcc-ng >=11.2.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=11.2.0
+  license: MPL-2.0
+  license_family: Other
+  size: 371663
+  timestamp: 1705602144682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.20.2-py311h06a4308_0.tar.bz2
+  sha256: fbc9c42ae58cc2997bfce336b31e2086ac68674bf87f54de1f0dbee55ca621fa
+  md5: c81f18822f50043c6dddd75c181e3211
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 28824
+  timestamp: 1729012405522
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+  sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
+  md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Zlib
+  license_family: Other
+  size: 127143
+  timestamp: 1714510716441
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
+  sha256: a65c6277a3045e4ea72f617f977134c18366d8142ce51512f5a3cf325226a8bf
+  md5: d941bb6fdc55cc1b3f67b3beb23d1795
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1081416
+  timestamp: 1728487031624
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+  sha256: c0dd89ffac001588171152a285ddbbaea209ebe4116010f985f898b7e87c2f35
+  md5: 731ae7d446633bc729f3493a52d4365b
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 43502
+  timestamp: 1721748373551
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+  sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
+  md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
+  depends:
+  - prompt-toolkit >=3.0.43,<3.0.44.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5106
+  timestamp: 1704404390460
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+  sha256: bf3130b8c44a7e9bcd496f515d0ee4b2e788610f468bafd708d16d007cb47332
+  md5: 48f856789d224eae8d1979c212205fde
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 123651
+  timestamp: 1728062827250
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.6.2-py311hecd8cb5_0.tar.bz2
+  sha256: 10c81c3952bdf1073713a33f65f538082b2f6de47c4dff3cf173a18e4f014e7a
+  md5: 87d1d76e942262c2c7c39370e30d7b3b
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.21
+  - trio >=0.26.1
+  license: MIT
+  license_family: MIT
+  size: 244917
+  timestamp: 1729121433463
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+  sha256: ab7672364f1fa55ec5d8311d85d40e5b57cbd3517b17670557b6fb822bcf759c
+  md5: 6e0159a5865cb7e96a748bd8560035ee
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 11579
+  timestamp: 1678317458652
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+  sha256: 51556902e09436d46878ef772805d06416ca96ffaa66340b5565c0245574aaf5
+  md5: 4cb1b20635cf5431d34cc96ca1e8a751
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 33355
+  timestamp: 1678317111825
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.2.0-py311hecd8cb5_0.tar.bz2
+  sha256: 49a9602af2808940b5f11b870939ea588e0408ed64e357db464950eb9fe77d2e
+  md5: b2f41eaf53c93ba83b99c8062f674008
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 163931
+  timestamp: 1729089648658
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
+  sha256: 365824e639808e52809f97b70b65da94a5eeb87e29dd97c8926aa72707a5a1c7
+  md5: db7813418dfe42d59363fed4a68d5c36
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 278195
+  timestamp: 1718029905185
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
+  sha256: 695ac69739e73351dfebfb01ea39c5e1dbfdcfb475590d6560ae318bfbad3a97
+  md5: 38fd73cba341639c45d8c747b08c9cc1
+  size: 49130
+  timestamp: 1528225884020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: fb5f53ec43d4ca92f433a556602a0347038856b5cdbcb2f0014b5445caa1b7a8
+  md5: 48f6989f8490bacc7ef44814c3ab7635
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5869515
+  timestamp: 1727914551902
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.4.2-py311h9b7fc35_0.tar.bz2
+  sha256: 2db3c754dcd7b5f87f8e9384509f539b3c9a80e7c26279c050814258e712a223
+  md5: 24af5157264705bc3358ec195490de59
+  depends:
+  - numpy >=1.21,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 156491
+  timestamp: 1731059250255
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: d8b1ccb15297dcfb3f9ebb8139c3e28a13d6c2e73c37612cb214ab6cc58b15fa
+  md5: e5dec9f13de061640ad2697562a99b54
+  depends:
+  - brotli-bin 1.0.9 h6c40b1e_8
+  - libbrotlidec 1.0.9 h6c40b1e_8
+  - libbrotlienc 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 19732
+  timestamp: 1714483415038
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: e9fda4393edd0234c88efc2b88e0edf42c94eb49ea5b189a80afd733058be8fb
+  md5: 13ceed558eb174d6b77ed1b0035f1785
+  depends:
+  - libbrotlidec 1.0.9 h6c40b1e_8
+  - libbrotlienc 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 18400
+  timestamp: 1714483395748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+  sha256: a323af3251e426962ad16edf8f46a696ef502731faf12aee32ca289c40b11342
+  md5: 658ce49e9f07dba7a1afe70fa2666e0a
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 393858
+  timestamp: 1714483549536
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+  sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
+  md5: c5a600d81b1b48578863af2973c743ac
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 187637
+  timestamp: 1714510590009
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.9.24-hecd8cb5_0.tar.bz2
+  sha256: 7031fa5cac3aca09b273742f9d7bdde4fb85edefc21cb3407a779a5a81438394
+  md5: c25cd4336a986ed75c92636e17953a48
+  license: MPL-2.0
+  license_family: Other
+  size: 141521
+  timestamp: 1727794863285
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.8.30-py311hecd8cb5_0.tar.bz2
+  sha256: acb2effe5ccd14a94eaf0dfe268f6b7f13165461ca60f24b8dab007259200b12
+  md5: 07e08081971e9f8255e5c4cbe19edf47
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 170244
+  timestamp: 1725551715047
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py311h9205ec4_0.tar.bz2
+  sha256: 8b66e37770f89a68ef4d7a70787720c300793e05822038379fa4068e7197fb2a
+  md5: e1f7832dcc299bc8f5069e90f7f8cc00
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 293031
+  timestamp: 1726856737247
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+  sha256: aceaa74365b0d8e69c817639393df3a713a802f40645ac0bd2f39adc871acf54
+  md5: 52191c9d4f4fcaeea39574819ab2f14f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204365
+  timestamp: 1698129979494
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: 6289468ac6d509d11f928e80005c27fcc169be379c9714f839c305949fbc22af
+  md5: 851f577d81bce100ddf9c11ded38da06
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43158
+  timestamp: 1721657395305
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: 9270668e34b00a2605584a2db5130c83826855cd05b896ce949f3156fa197429
+  md5: 2586aa55677e822e8285d777f9039ca9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 543487
+  timestamp: 1709758497949
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: 389c63a84b92a6254c9d361ebe970d537d0b88733efd5ac5c3ee58196fd2c5a9
+  md5: c7bc5b3cbe76be83a27f00b7e4740727
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17974
+  timestamp: 1709323004148
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+  sha256: bebfc5aa6be12e61a134b580b07b67f7d8c045d6b113fca5b21fa1e83a2f03ce
+  md5: 239df72a3921c951059fa8afc09643f6
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 287736
+  timestamp: 1700583644534
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cramjam-2.7.0-py311h9c86198_0.tar.bz2
+  sha256: f480b0ed7a98e682d8cbdaeef697116a0d839cee08ec8b5f39078c4e056ec29b
+  md5: 7712882f644fca2ccd169ce2dee2b4d9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1473015
+  timestamp: 1702651642047
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2024.8.2-py311hecd8cb5_0.tar.bz2
+  sha256: 3ad77286d59361920bdfe9af6e71d7f31cada0e56b1c1ee0731a0b560bc16d92
+  md5: 31e739e79d93b568735a7db5cd201f52
+  depends:
+  - click >=8.1
+  - cloudpickle >=3.0.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.4.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3118893
+  timestamp: 1725461414545
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.16.3-py311hecd8cb5_0.tar.bz2
+  sha256: 9aaeb2715d1c3de8096c489b52ecb4c71d7341ee75bb5c3ace77c50c918ec5d4
+  md5: 05a98a96b9cccb007768b87c11e92b7e
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy <2.0a0
+  - packaging
+  - pandas <3.0.0
+  - param
+  - pillow
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18011437
+  timestamp: 1720534043633
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+  sha256: e0e30590a78d99d51445ac4f668aefe1bf20025a35bdbac00f04647b95c9f152
+  md5: bd0db635eefeea82a0c567b39c9a0e3d
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2485698
+  timestamp: 1690905283575
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+  sha256: d48b47b86b09dac1fa4542ec13e1bd4e23093638e684fa66ec3afdd9ce9337c1
+  md5: 5a2d1828ab7c8eccd3c2610d13672977
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17336
+  timestamp: 1678316187749
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-2024.2.0-py311hb3a5e46_0.tar.bz2
+  sha256: 3a4f25b0833b1e459e03b22ad6f0fa21b489ca5aa9559bd18e1ed6659509766e
+  md5: f35dfe533aa5ab48ea2f7064b6b6353d
+  depends:
+  - cramjam >=2.3.0
+  - fsspec
+  - numpy >=1.23.5,<2.0a0
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 661944
+  timestamp: 1715262849492
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+  sha256: 54645c22fabc25b632114d1d3c403a6fad9149b51ab36719b2690a084f14a072
+  md5: a8ad2f4abfb2e17ecf6e596342528156
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lz4 >=1.7.4.2
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  license: MIT
+  license_family: MIT
+  size: 3180691
+  timestamp: 1713551771692
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.6.1-py311hecd8cb5_0.tar.bz2
+  sha256: 4316287b920b446149e5adf3519d12089b0c9ec49a8c1c802eee81c92d80132b
+  md5: b52775f876eba6074e08a4d65328fad0
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - pyarrow >=1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 383995
+  timestamp: 1724855682674
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.20.0-py311hecd8cb5_0.tar.bz2
+  sha256: 60fbaec8c8ddc4ac235a4c8143a1d734e34c0543ba20985973cb43a9220262c9
+  md5: f781135af3dde8699b5b3cf9bfe83b3f
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.1
+  constrains:
+  - plotly >=4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6129648
+  timestamp: 1730828256779
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.11.1-py311hecd8cb5_0.tar.bz2
+  sha256: 0a24a6f6adc180ab3395a060762ede700e0f44e6b03dfa921197ed6451062939
+  md5: b485eff7e3aa7160734b25d8dfb7734f
+  depends:
+  - bokeh >=3.1
+  - colorcet >=2
+  - holoviews >=1.19.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 371047
+  timestamp: 1729516805777
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+  sha256: 5c2458964157fe493ca18c513c693b70cb622087e5fa0c93e65fc45217edd811
+  md5: 15629e52625221b51a443cefd9501d12
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148522
+  timestamp: 1714398885844
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+  sha256: 5a17849341e4d43fc6aff44486425852c16dee6e1cbcab1ed3f2167350f55359
+  md5: 445ac9df262ad2dcd86246a9ba5654b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 51118
+  timestamp: 1704813615186
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py311hecd8cb5_0.tar.bz2
+  sha256: 4772db5a35dfbdabf55b01943916d0a5b451db757aa38372571bb3e03948527a
+  md5: f6b4cd61684c3ec067cbda883fca865d
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 240267
+  timestamp: 1728665688908
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.27.0-py311hecd8cb5_0.tar.bz2
+  sha256: 901a391e792938d690a39cbe2551d7306bf85474bb0cff4e69088f78a9f5a26d
+  md5: 84fa63c5f6182b1f06c3ffa5e611507d
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1632976
+  timestamp: 1726064292193
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.1-py311hecd8cb5_0.tar.bz2
+  sha256: 9961222f1fb3a768e9c85a03761107809b321f4bc9af02d23289c59164bed7fe
+  md5: c671e7d14b22780a7b1fa8632b0bf8ba
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1178410
+  timestamp: 1721058471712
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py311hecd8cb5_1.tar.bz2
+  sha256: f0610ceaac87ce39266f4dee8185244668ac9345143c9eb22c4cb201b79aab00
+  md5: 2d4759abb2b7a3de114fdef7bb241474
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 354673
+  timestamp: 1730902923439
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+  sha256: 855982a798d9af8e70635a250528a5da3b2b0cf7095e2804858caf139c8a239b
+  md5: 112a5602fe42a84a5bafa038abeddf4f
+  license: IJG
+  license_family: Other
+  size: 279686
+  timestamp: 1722872676718
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.23.0-py311hecd8cb5_0.tar.bz2
+  sha256: a899e7bdac6b9b734882ee44a8065d7006dd669fde9b0fb0a88ed2e2f77ec357
+  md5: 14a0abb1c37f2e37c0e55b8feec8d564
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 193788
+  timestamp: 1728487044949
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 0ea44d0c8044e70ab0eaf4d6f5f3e4753838dee106b5cbd36561e21a65cbac77
+  md5: 1d045016dca889d702f1caf3a16162fc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16528
+  timestamp: 1699032525791
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+  sha256: 70442ec4b0b7ebbdcf150963f61f797b861001092124f4ea39a16eb92a4d176e
+  md5: 63d1503915a15ae4f9ad1c46112ca374
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 272720
+  timestamp: 1678316970740
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
+  sha256: e657ec0667481d957827be1ce825b0a971aa3a211b07c1274d2c1099ded3129c
+  md5: 5e317fd45011a0003c29331a8002cb75
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 98632
+  timestamp: 1718818439542
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 2634d721123ea1e41b6e1cfe4a67552ec520ea9b5154c9e788ccb09d4745b732
+  md5: e874eba19b493b7a68161429f24b8f51
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43102
+  timestamp: 1718738272613
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
+  sha256: c353480ed4744c2a16aaccc1649bab38144436ad6d16ac2937e3e333d32fdccc
+  md5: 7de25bdf4cfd3f5485d790d9cddf427f
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 619935
+  timestamp: 1718828240904
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+  sha256: fd7964657f0a8fe8b167ba860b1f960e8b7b45309eb6c7c850d50ec283fe03b5
+  md5: 2967bb345bc75f53182e263ff4743ca6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28223
+  timestamp: 1686870845224
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+  sha256: 64cf59f0f74b0329b5069bc6135b4f40593f1dac52d85ad574d4b8e0a4b2cf16
+  md5: 35e8b80eaa03a904fc7f1da39e7f654d
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20234
+  timestamp: 1700168776500
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+  sha256: a12382b50416803f559a03fb384ba492c1dafa351e1191a3f8dc361bee6c4f37
+  md5: f2ae846b663bbb642f4b1e90eaad38a3
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64817
+  timestamp: 1678322501509
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 685c3bc9068bd485604b80bf03789e4dca95c410d33871bc1b882e47649fabed
+  md5: 6cf8e55271e150ca0961d0ddedaa61bb
+  license: MIT
+  size: 66237
+  timestamp: 1714483284541
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 69826cee54db9955f0120af21ec36d13f9211877fd67364f2068d0a54c6c97cd
+  md5: 0851917257f490d35e1f73da8a1c723c
+  depends:
+  - libbrotlicommon 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 34042
+  timestamp: 1714483343147
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 3f5a1f03b50b90b397a0ee432ad0cba13354abdaf7e5652c0fc60164b26a08b6
+  md5: a50bdc871ef4bf14deb088d888b92b5e
+  depends:
+  - libbrotlicommon 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 311597
+  timestamp: 1714483371586
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+  sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
+  md5: 822a5b76117e56d3912f1f2153307528
+  license: MIT
+  license_family: MIT
+  size: 136045
+  timestamp: 1714483561919
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+  sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
+  md5: e458587c87e3f2d20192f4e0738f2c63
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 149419
+  timestamp: 1665498987619
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+  sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
+  md5: 1058b661ec829b2ee3716ee2a5520641
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1917987
+  timestamp: 1665498925405
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h26321d7_4.tar.bz2
+  sha256: 3c62b303d658923dfd5ef7385a6560c97865e5ad22df05f2822575dc2f2f61f6
+  md5: 7a1ba247765a13e183f91bd5e857a0d6
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 27922606
+  timestamp: 1726769388473
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
+  sha256: 499ebc9000c8e810081b5d7f7524b45dc99f6914096ea9e145366033514938b4
+  md5: ce5c24f93932e1a53d7d89e502f28783
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10123989
+  timestamp: 1664896966769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+  sha256: 246c0d82766042c1a9194eecc71690918c68afa3528ff0c2c82796ce901df40b
+  md5: f33be4ed3bff89ed8f68df6c75158510
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 449215
+  timestamp: 1729160070984
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: d28c465ec6d5f8d4962c597b249b58998300c8b4e3c937c578c3d15294ea863d
+  md5: dcaed6ddd0723c7cce6bfad917be98b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41176
+  timestamp: 1678413498410
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+  sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
+  md5: 5c740b4a18a558de0ccfe601703c423c
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 338738
+  timestamp: 1662635677689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.43.0-py311h6d0c2b6_0.tar.bz2
+  sha256: 73052ee16f6d1df70d79c0258dc4e08af8840812e2d1c04a2edbb87c10ba5a34
+  md5: cd252d6bdabf736def933eb57332d0b5
+  depends:
+  - libcxx >=14.0.6
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 404923
+  timestamp: 1720455346980
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: 716a654df2e55052193150015bd5c9856b847893fc5a229fa8669725b1c56ff2
+  md5: 687ba6c11de38ad7cc597f7188b491e7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13357
+  timestamp: 1678322560230
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+  sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
+  md5: 8f57dc3a3327bb6f7e1cba908856ac7f
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 183138
+  timestamp: 1714510756758
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+  sha256: 6fb2953e169ee1ae38f24d29752051501992f19b96b5ebcea9af75737bdbcb42
+  md5: 7f410cdae838c5030108d1b98a8c78f6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162478
+  timestamp: 1678377892595
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+  sha256: cd97e09a12ffb49b2a30a782fa8c7933b28f5ffdbfc5c73a9ebaa95fc9447370
+  md5: d1fb6ebc1e5728aa6377cfc71da08942
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135859
+  timestamp: 1684280005320
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+  sha256: 30c3b189462a9d0f4794d229adadf34b5f5a5f56f95c30d5afc17ef524579290
+  md5: d4e9421243129d1d57c472dab045f3dc
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26639
+  timestamp: 1704206159955
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.9.2-py311hecd8cb5_0.tar.bz2
+  sha256: fc0efd282504e5e78ebb1e609832829339a028d28f101d7f9c9a5d8298906154
+  md5: b8c27fbded53b7c3ef35e2b4825991f0
+  depends:
+  - matplotlib-base >=3.9.2,<3.9.3.0a0
+  - python >=3.11,<3.12.0a0
+  - tornado >=5
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7738
+  timestamp: 1725264317918
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.9.2-py311hc25a08b_0.tar.bz2
+  sha256: 5fddd37bbe579892257bf574bc0b5199b97a3ba8addbf2ec73e5147609eae7cb
+  md5: 30837287c1590ec271189cb315be35d1
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9456494
+  timestamp: 1725264308019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+  sha256: 07e7fd5bd64e55328b4b99d92e2e2600d791f1095bf905daab4cfc59f0f0a45b
+  md5: cf53321779f4ca7e986c1468719b93f1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19500
+  timestamp: 1678317565001
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0770e02be1ea1216af493cfc03d5b8a702e14606fa93b0692bcdab1fed1b898c
+  md5: ca6f06ceaf66a32bbf5dfdb6e373a5cf
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67892
+  timestamp: 1678417734353
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: fbe95ed0501bb0f137048476fe41bc718dd659e8ecb066bc67ac17d6a50f4318
+  md5: ec162bde8d1c8a107b257df218b17035
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23030
+  timestamp: 1678381838497
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+  sha256: c20dd678655e582129a858a1c5162bdc254082d3a3c035b0f72629d9276e5b75
+  md5: 800a0738c728796e02d0386ce7d457aa
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104585
+  timestamp: 1678317269407
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 638450a7ccb5f438ac65aa1c8d871fb5bb664e7261ec7e663d0302485c219a67
+  md5: 574875bbeabff85b5d9cfdb62066aece
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29473
+  timestamp: 1678392919304
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: f961b1322b6b02fee53ff9bd0f56bb73886eb59debd3f3666669593de7f48894
+  md5: a1e74ccd2f341d1d672e33d79e60d200
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8183400
+  timestamp: 1717623127275
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: e08cb3ee6df01f4c1e1ac8bc4ed1a06e549ffcc8774fe2e2842c644bb8f74a86
+  md5: 6ba0ae0fb14cbea1e3197707701dc180
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123077
+  timestamp: 1698934356774
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.4-py311hecd8cb5_0.tar.bz2
+  sha256: 098d35939d62073df7fc42fadde9d9f7f646e4727382c363c02c136820555e80
+  md5: 25b1cce018e6c1b19146f117690d2b5b
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - pyqtwebengine >=5.15
+  - tornado >=6.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 533595
+  timestamp: 1728050041209
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py311hecd8cb5_0.tar.bz2
+  sha256: 3175bd2b744191da1c7477be8162a0f8d7f68363de8c2ab6df989908211ba17c
+  md5: 2508c1c6fc84c712ce0419470f60b5fb
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 171386
+  timestamp: 1728050190296
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 42d803e1d8b54748db5d989ecd503826f564132df7cddc20f520460f55e523a1
+  md5: cd3fa71626ebc098da4625fc6be79752
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16952
+  timestamp: 1708532805951
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
+  sha256: 09d88f1eb19a90dfe737f0e5b4dce7629f6076a2d91d572cbb0a41be5220a4e8
+  md5: ac8c26d949a04f478b560b7d8a2358a4
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 707187
+  timestamp: 1717630829258
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+  sha256: ed5608feb37a083d47b04203195260e801b64b5380f292cf18bb61e7ad827a2a
+  md5: daa9c1c233673b727528548454aea664
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27607
+  timestamp: 1699456006797
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.60.0-py311he327ffe_0.tar.bz2
+  sha256: 91c63f3ac3b610a957169b06171366da4cfd1f8eca7b484ee66c524de739e40c
+  md5: a1cc844a9046142569d89d3642ee460f
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - cuda-version >=11.2
+  - libopenblas !=0.3.6
+  - cuda-python >=11.6
+  - numba-rvsdg 0.0.*
+  - cudatoolkit >=11.2
+  - scipy >=1.0
+  - tbb >=2021.6,<2022
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6145701
+  timestamp: 1720541086329
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.10.1-py311hc59c7be_0.tar.bz2
+  sha256: 4b784353c86d73f10d714c039c29ca73508203cb86a7ce455f71ee52b940edb3
+  md5: a8c1b6256e1d5743bb92d9c467736aa8
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.21,<3
+  - numpy >=1.23.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 202114
+  timestamp: 1730216207054
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h91b6869_0.tar.bz2
+  sha256: 85aa18f7f372d263f1b9a6eed279e0fa048387520bf71b9c409e13801a0568d4
+  md5: c077c784069f04cc487620bcdc7707ea
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.26.4 py311hb3ec012_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11321
+  timestamp: 1708642350281
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311hb3ec012_0.tar.bz2
+  sha256: bc050bacb16826ee23329eed65b63c2625884e2af1853f901f7e09870c7dbd1f
+  md5: 96b8308a1bdb2f1e77698ea9fdf96bf3
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311h91b6869_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8784964
+  timestamp: 1708642301649
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
+  sha256: 401214a4763c79c2355b012b9f29e3cee097a598bb53e933acb6b98a2bb6614f
+  md5: 3216c5f433643ee62a8d0672c3500320
+  depends:
+  - libcxx >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.7.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 535252
+  timestamp: 1722872704730
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.15-h46256e1_0.tar.bz2
+  sha256: 8cc69ca3f77c9dc8bed662100046085536c6a95b77b2a964ba79fc81ba3f698a
+  md5: 270474613701d2371d5c5cc220a78825
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4961721
+  timestamp: 1725545867722
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+  sha256: 8a0809f419065e014cb8e2c8a516cadca6088fb71fd1ef3ae2287d91e3360d59
+  md5: 4dc0b9bc88476fcc5246d823ff1c289a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39645
+  timestamp: 1699371213055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.1-py311hecd8cb5_0.tar.bz2
+  sha256: dfeced2b57d53e4aaaf5e855c2f10b505ee74c486594bbe4b132843f12806ff3
+  md5: 05b50489c5ee7b2d5b5750f51cca96c1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 158201
+  timestamp: 1720101976586
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.2-py311he327ffe_0.tar.bz2
+  sha256: 878e8fbcca40ac0c3937780160c22b65633b32ac97a886a9e38d4453821fe8bb
+  md5: ac61107a8dd7a5a51e19e57fcc3a7a5a
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - pymysql >=1.0.2
+  - pandas-gbq >=0.19.0
+  - fsspec >=2022.11.0
+  - pyarrow >=10.0.1
+  - scipy >=1.10.0
+  - qtpy >=2.3.0
+  - lxml >=4.9.2
+  - numba >=0.56.4
+  - s3fs >=2022.11.0
+  - xlsxwriter >=3.0.5
+  - tabulate >=0.9.0
+  - adbc-driver-postgresql >=0.8.0
+  - sqlalchemy >=2.0.0
+  - python-calamine >=0.1.7
+  - adbc-driver-sqlite >=0.8.0
+  - html5lib >=1.1
+  - matplotlib-base >=3.6.3
+  - gcsfs >=2022.11.0
+  - blosc >=1.21.3
+  - xlrd >=2.0.1
+  - pyreadstat >=1.2.0
+  - fastparquet >=2022.12.0
+  - jinja2 >=3.1.2
+  - beautifulsoup4 >=4.11.2
+  - xarray >=2022.12.0
+  - pyqt >=5.15.9
+  - psycopg2 >=2.9.6
+  - pyxlsb >=1.0.10
+  - openpyxl >=3.1.0
+  - zstandard >=0.19.0
+  - odfpy>=1.4.1
+  - dataframe-api-compat >=0.1.7
+  - pytables >=3.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17291576
+  timestamp: 1718309206876
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.5.3-py311hecd8cb5_0.tar.bz2
+  sha256: da4c642c2c4d0265063a50cfc3e5437b422bb8e807934823f98e0ab23dafab40
+  md5: 7aade1ab52d00e6df57919c6cfeeb2e9
+  depends:
+  - bleach
+  - bokeh >=3.5.0,<3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.1.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing-extensions
+  constrains:
+  - holoviews >=1.18.0
+  - bokeh-fastapi >=0.1.2,<0.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24103145
+  timestamp: 1730381703387
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.1-py311hecd8cb5_0.tar.bz2
+  sha256: a33f52ee58e7856ff19bd306a7c055950d669199981874a38c2bdb1896725c8f
+  md5: 7aef330f65dd9dd63a06c89ddfb3b7bd
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 267605
+  timestamp: 1719348049109
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+  sha256: 359b31da651ee35b9ca43974d26cd44e64f3cf412096c15dec7b720fa909a9b2
+  md5: 108e24227f8fdfc4d635bb4eedfa6cef
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48504
+  timestamp: 1698702608965
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-11.0.0-py311h9c91434_0.tar.bz2
+  sha256: 055281cab4c89b4e9f8743a1fb45bc578785a6132f10b8628fac33a0959fd212
+  md5: 25bf2cadac40910d160ee357504e0a4d
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 972896
+  timestamp: 1731595038107
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.2-py311hecd8cb5_0.tar.bz2
+  sha256: 492ea4d1c5a4f860f3312c7729f1e33b706007578c25c031241d7497a115dd79
+  md5: 835f4767cdb9d80338e0bba649c1ce3c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2923519
+  timestamp: 1723484652903
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 81719c31101d6c019150cedcc7b08adb3bdb357e8b2952e428dadaabc4dc985d
+  md5: 105825168e0a17fb007f60b5f314e311
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38405
+  timestamp: 1692205731769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+  sha256: c0982f688127129e026d2b4cdacdd5684d00796ea7bdadd7d26b1101b095d723
+  md5: 0d6910c74729fede645c010110f1c89e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 121796
+  timestamp: 1679340253537
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+  sha256: e32843723b10ecd9badde28e1085419c0b59ed8a96c7cacce6395e39e3a874f9
+  md5: 5af0280a817d2c273304cd22328124af
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763044
+  timestamp: 1704404460779
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+  sha256: 117a435c2473e2a20cc81eaacb2b45ea5e7fe3c946eec2915936d344913ede44
+  md5: 0f459ee59fda20e2077fdc2c777edfc8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 497470
+  timestamp: 1679337286052
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+  sha256: 667b5cf00d31293dede2ddadcc30ab967103d585d40647f34d6d830af97ee51f
+  md5: 81d3876fa502fca91ba4136a5f3fc3d3
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37821
+  timestamp: 1678378977816
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+  sha256: dfb403f367c57327a4d080109df88383ecff18464de287a1ce936a7274e3656b
+  md5: 997b674bad89963af875b93b06807f51
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2120413
+  timestamp: 1684280057020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.2.0-py311hecd8cb5_0.tar.bz2
+  sha256: d91145c8170d70c3343e3c72de9bbd65f18dd868699d5865cfd378027ed1d1e6
+  md5: be4e175b2ddfdde750cdf6f83fb694d0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 487468
+  timestamp: 1731445595709
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 717e038567506ca58ce1cd4a3416892d02f4ebfdd332077cc3d110cfe3d36c58
+  md5: 53bbfb400668f798eef6f8c7cf938e1f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35751
+  timestamp: 1678315886516
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.10-h4d6d9e5_0.tar.bz2
+  sha256: 9d61a7f97dc7ebf7ae6c1a0444dc7a776d44170e48a3e13ee667a1d9587e38a5
+  md5: 46b63c8af5232ef16f9e5ba15d0d53cd
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.15,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.45.3,<4.0a0
+  - tk >=8.6.14,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16847299
+  timestamp: 1727942132354
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+  sha256: 04e100d0a1ea9722e24972657ec5935ad34c7c58957dabb821333e5eac80f717
+  md5: 2b6de49ad07b26e1f7084f0fda958eb1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332276
+  timestamp: 1716495830117
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+  sha256: 514249897265f66f6ecca0a4427eb02a43c33b3c24974db16d05db6bbe97881d
+  md5: c9ea1437e5a3ba6a52ec2322505203e6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279116
+  timestamp: 1679338758489
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+  sha256: 78b785b9b6ed46c86b0d3a32bdceea49f816672227fb63e726b2d46eadbdba0b
+  md5: 79d783f74359141e0b06a848db33823b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18563
+  timestamp: 1683823935261
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+  sha256: e358fe679e83ccdc8c433746ae6468e8e96d90d97d99530f8476ef5630b2c121
+  md5: ce30a0a31d891e69dc9b7bf8b7f0c39c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 268876
+  timestamp: 1713974360942
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+  sha256: eeb5a5eed93b8e311ad4d3f4389e050f11bba2eaec9536e1c3ed2f849c6c999b
+  md5: c18bd3e12de797d52a470c21a150dffe
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65270
+  timestamp: 1711136914884
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py311h46256e1_0.tar.bz2
+  sha256: eaba8d555ca65df57c5c1dfa320c6b222ddb2c428609a29765ea89179ff05a98
+  md5: 9a926091b8beee27d251241d227a646d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 208392
+  timestamp: 1728659514546
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+  sha256: aa07b90a7ee65f76c8cba1ff99a5cdeb95cbe41881ae951f64ffff06674a1b2d
+  md5: 58621e3d244137885f7dfbb35e50340a
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 594801
+  timestamp: 1709318510622
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+  sha256: d784dc26c5de8e41845350a899e5779250b71f45d39e2aece62e739e9add7308
+  md5: 7b077b7f46112bb31dc066396c51d3fa
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74776
+  timestamp: 1699012164201
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py311hecd8cb5_1.tar.bz2
+  sha256: 022bc34ef458cf0f26cb2e94f3238618e72ca59489efb074d25e5a4700e53707
+  md5: 4f1d626c702cbb79e25aa92375049279
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 124655
+  timestamp: 1730999183404
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+  sha256: 727fb8d957e02d03b928d049ffbc712316f176a2c331391766d646621b45655a
+  md5: 7e0e416c642f3ee4ddfb084a811fb4df
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10236
+  timestamp: 1683077214314
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+  sha256: a8a67143ccb65cfd6f50055176b6c26179a83130a45d0a12e79dd2de68d8db63
+  md5: a2065790f41e3eeb6efe0ef6daa75377
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10600
+  timestamp: 1683059285216
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+  sha256: 6aba582338faa0c26fe336bdb10c65b8f7808a6e383bd8f80f3e6b612ca209ec
+  md5: a7486349b5f7370f6902c2050a23d268
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 319197
+  timestamp: 1698946203341
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.14.1-py311hedc7b93_0.tar.bz2
+  sha256: 274d0fa785a3ef80b328ef228ea1dae725622ad01f180ff806c8615e7a55c175
+  md5: 18c8cc0edb49b32b465a6818b12f701f
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.23.5,<2.3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 27414506
+  timestamp: 1731626394302
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+  sha256: beba0555707dac1e8484d73cee9e4128ac4b10e2a0d4209357481179022e8fdc
+  md5: baa8b304607b3a9ae8a3d9acb354c31c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33343
+  timestamp: 1699371216044
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-75.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: c6e56b4a14e883c7296b52673b4129e933d2bcfe45fafd8b504e62442aa290ba
+  md5: e658b6de04d59ad8fb45391c7e8dce54
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2318419
+  timestamp: 1726678116770
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0eb44a16ef74a13ef7839209899d009cd94974fbc406a417d958c7bc8d955245
+  md5: 41f239a5b67b1daf819849023aa5d12f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19056
+  timestamp: 1705431379885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+  sha256: 14775231982e1ea150189c956927ccfb1ad01a8c9395cdeea4d5a48b9b8ce664
+  md5: 729badc4bf7ba8ccc70e0f9e58075c99
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89812
+  timestamp: 1696347694075
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+  sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
+  md5: 6bef1694163a68ac4c37e5857b8da4f5
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1900191
+  timestamp: 1714488351925
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+  sha256: 3d5c2968f581006437df3932cd5d3c1c4afa78f0e13757b958440245d3248856
+  md5: 605ea221d225ad8e79284dbcfdab0715
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37699
+  timestamp: 1678317755913
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: ed059e32ce5a1c0511575f29d2fb6da12c54a37000bfa80f9e5aa9dfd9e04101
+  md5: 4d2261a92d25136a68b8d01d101119f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49145
+  timestamp: 1678317386284
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+  sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
+  md5: 523c006cc67c011383678c762015479b
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3594448
+  timestamp: 1714770737885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+  sha256: 424b8284072266eb59d055c0b7b58241bfb00009d445743ea261d4eeee73ea19
+  md5: f3a47898a55087edb9d65d29c24d9b88
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135757
+  timestamp: 1678323030858
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.1-py311h46256e1_0.tar.bz2
+  sha256: f46d29f5c4f5fceb7a39343da76f5c5ab89cbb0844e80a3a90457201c3fbc168
+  md5: ee154208a17c1c4cd42d264b1a6f77c3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 914461
+  timestamp: 1718740220272
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.5-py311h85bffb1_0.tar.bz2
+  sha256: ec67885e979483932bf0ce9e720841d6f9d44bbc5a049f2e4a15232803f8362a
+  md5: 044460e02becd58190c03e794461acee
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 155741
+  timestamp: 1724854618448
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
+  sha256: 5283f2b23a6e9d888b2834cba2bbf284f551e199d2c1b4add176b1cbafb19ee0
+  md5: 58bf7871ca100fbda0492bb5a3363c80
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 208200
+  timestamp: 1718227205760
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: 17e5688d09ffbcb8b71b34b86edc7374fa0b04d60a4d729d405ffc22ef63726c
+  md5: e4bf44ddbbcb136332ccb47ac2b879a0
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9890
+  timestamp: 1715269046804
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: 7d369ec970d1d5411e457c79f94197756c7088deff8183806ea71e633b26edf9
+  md5: 9ffa197b26373667f50b21876862398e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 75595
+  timestamp: 1715269030928
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+  sha256: a9960485ced319ac91afe69eaaf703c7e6b3049f1e06a4a8c2818b64155943f0
+  md5: 0a9c8ea92a14330a07edabac249e32a9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11399
+  timestamp: 1678394892923
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+  sha256: d42ae57366d05e12f10074583568355752436d66ad018ffbcfa24135f593810a
+  md5: 1a98e48aa0bd8b3ec09e2cbdbb236575
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 498952
+  timestamp: 1713213079520
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.3-py311hecd8cb5_0.tar.bz2
+  sha256: 89314728453fa65647c24a1991a18f1105ed5da67c69dc42231d26a6bc96c42c
+  md5: 3c07406e5e9575d136d225c57159cec3
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - requests >=2.26.0
+  - selenium >=4.4.3
+  - h2 >=4,<5
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 218673
+  timestamp: 1727770118330
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+  sha256: 597015e8a038a111f03ffbc9a217fcda549d75230c86ce53c1f23c53d6f1a0cb
+  md5: 62e98aac883bccc1c87ca0d2ce2f08e0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25798
+  timestamp: 1678317074170
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: 1430e6f4b4dd9354b7bb88f7f7bc9cdbab26a034ad1ae5c278de0f5a99329372
+  md5: be0832862b29bf5767a707ac6bd53b93
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 114834
+  timestamp: 1715878445060
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.44.0-py311hecd8cb5_0.tar.bz2
+  sha256: 907fd39137318473d447c56d77f775c9d3fef5b4e840f8c43f50f8f9c016710f
+  md5: 2106db0f651f613ca1971e60afe3f5f2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 139423
+  timestamp: 1726165218455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: cc6995f677d1628f42ae80ed47ff08d8d1c8ed12580a326af6e307f5febc594a
+  md5: d01eb964863b95ef62061b77c9037ead
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2471632
+  timestamp: 1689041625741
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+  sha256: 5b6d5246955b5f9480ff7027eb002442a7ade24f5c354da54ed513042f76cedc
+  md5: f32aa8a37d5e65a8dc30f9a1f46bc63d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54719
+  timestamp: 1678325412288
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+  sha256: ed0152ad6b87ffd9e01f4a62bc358e805ad59637f898a801b0a9cf903ae8e1fb
+  md5: 8a92f8c663608f24e14d8a2068b9d83a
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 415323
+  timestamp: 1714511993944
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+  sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
+  md5: c25b6d40f834647d0bbe767f6c776031
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 329449
+  timestamp: 1705602140856
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.20.2-py311hecd8cb5_0.tar.bz2
+  sha256: e1d2b53a215470bca64137e2f9cbae072c14bf15e01db0a1e8da06b32051dd3f
+  md5: 2790f84d4d000e28df25819c22846d05
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 29925
+  timestamp: 1729012443048
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+  sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
+  md5: f2519b551f99765d9d98950c5e2b4713
+  license: Zlib
+  license_family: Other
+  size: 119782
+  timestamp: 1714511811597
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
+  sha256: a1f470eabe211500d2ec7866ecf421c067f159045f0245f19e9ba8272c5a177e
+  md5: f8bd5fb9fac17a47c64ae56355faba24
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1033188
+  timestamp: 1728487057684
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.6.2-py311hca03da5_0.tar.bz2
+  sha256: 8d925b1438e14479c33257054daaf3acab8db996d49fc1f57f9a675569a90493
+  md5: 7277b32d35b11efb43245178c3f99fb4
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.21
+  - trio >=0.26.1
+  license: MIT
+  license_family: MIT
+  size: 245764
+  timestamp: 1729121361882
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+  sha256: 43405cc7341ce3efb2e24013ad62c64f26a69926635adceaa5459ccbcafb3776
+  md5: effa6d22f497e164cc8455f7f329c304
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 12510
+  timestamp: 1677917870614
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+  sha256: 947efe1c50b3280e9a67cbb18636bdade53a40960fff3056850ff81ab87acbe3
+  md5: 7d2d384ee32ccc12dcb0dc099e421482
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 35091
+  timestamp: 1677915945226
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-24.2.0-py311hca03da5_0.tar.bz2
+  sha256: cbca44661d23850f519d90cfe520979fd35bef9e012152fa69d6d41eb373361c
+  md5: 93a707d1b918d7b2139f4cb205b17aee
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 163840
+  timestamp: 1729089502271
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
+  sha256: ae3c6633ed84bac16592b3b756f96ffc577414971014ca9efa498a162588757f
+  md5: ea600f99d012d734f831d1bc00a17661
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 281227
+  timestamp: 1718029919645
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.6.0-py311hca03da5_0.tar.bz2
+  sha256: 2504fa4295015f621e607dde7a42efba5fec71bf691785ba8e2f86e72df19e88
+  md5: c961dda50ad88ee093645de69e768a4c
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5908154
+  timestamp: 1727914592573
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.4.2-py311hb9f6ed7_0.tar.bz2
+  sha256: db1a051d5329611e3e0fab1ea11b2ec06ae511e6c34935738a701ac2ae2fcf86
+  md5: 14b2ca28694689fa950ae434e4390224
+  depends:
+  - numpy >=1.21,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 135731
+  timestamp: 1731058941306
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+  sha256: 048264434c33fdb53862cdd69b2e2bc4ce6f8a70b3211ad6d686d066eac2aa91
+  md5: d55696ccaf6755931cd662dfb929aa0b
+  depends:
+  - brotli-bin 1.0.9 h80987f9_8
+  - libbrotlidec 1.0.9 h80987f9_8
+  - libbrotlienc 1.0.9 h80987f9_8
+  license: MIT
+  size: 19737
+  timestamp: 1714483270447
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+  sha256: 13627293296fcc231d8dc12d803dfc9621108c60df38b0e3c64e9e02ed55e564
+  md5: 86efd4ad08cd80d3eab77873db84a255
+  depends:
+  - libbrotlidec 1.0.9 h80987f9_8
+  - libbrotlienc 1.0.9 h80987f9_8
+  license: MIT
+  size: 19083
+  timestamp: 1714483255364
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+  sha256: 2e542b2bb27f8379da3efcb83ef084cb26e6a9ab576c50487c2dd996afd5ccb1
+  md5: e8cab9d1ef58a450f971690fcdb2ede2
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 380182
+  timestamp: 1714483330655
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+  sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
+  md5: 56d1386c7f1f338f0d18f82af6525273
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 158748
+  timestamp: 1714510571033
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.9.24-hca03da5_0.tar.bz2
+  sha256: b3b13d44d3e05c88f411d245c052b547652be3f3ce7ba21970ba1bbf20a8ea33
+  md5: d8091745a1bfd921bf15b2f73111d299
+  license: MPL-2.0
+  license_family: Other
+  size: 141261
+  timestamp: 1727794860441
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.8.30-py311hca03da5_0.tar.bz2
+  sha256: b5bf3208e126cb67926c2a36b5438d84eee9b8352ec007d6b143b0751ac6d8a8
+  md5: 07d0c4f8a1807db57b12a461f6142eb9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 170510
+  timestamp: 1725551796823
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_0.tar.bz2
+  sha256: 5b98c2dc6ebb5b3d5bf6e58ff3f495b4bf71b28de86ca299186554639de381c7
+  md5: a95cbad1b8d8cff239a8eb5d940c663f
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 292045
+  timestamp: 1726856478903
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+  sha256: df81a27f221d11af4a709f272dc8ba3fd3f6d5ab4ffd883c40567bcf04f0cfd3
+  md5: e49333e3ffe1fe2e701f50a6e6dccc52
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204179
+  timestamp: 1698129906257
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.0.0-py311hca03da5_0.tar.bz2
+  sha256: 340739a06e25afcd23ec4c5e5d45ac940feb16bee5122e1d14d261a2c80b5617
+  md5: bd85d021206472f6a6615575f126ed65
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43128
+  timestamp: 1721657439520
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+  sha256: 808e56fb70f3d38599ee7a54c2a707b282ba9a401fa69a1f54cdc26425d9ce01
+  md5: fc37321833175bda4fc5c21afe32db49
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 539588
+  timestamp: 1709758479776
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+  sha256: d9c126d8bcd1c89ea37186c172d6b1f73f45ada60e3ae1790a017b530baa0147
+  md5: f0223aae3d622547f6accb212579c58e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17967
+  timestamp: 1709322909223
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+  sha256: 1f908c688e47d03d92ac09d9541a1f1c773ac2ca485dd1d77441b1aaefc032db
+  md5: 444c330471496a39a97e87f41ed70c96
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281104
+  timestamp: 1700583698464
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cramjam-2.7.0-py311h62f922a_0.tar.bz2
+  sha256: 1a71c2e15872edff275f419bd1b827c2e37a4cfaf997cd30104cadb2da285a5b
+  md5: e97551b1be62a8bc30eb69e1dfe39191
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1531706
+  timestamp: 1702651054879
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.8.2-py311hca03da5_0.tar.bz2
+  sha256: 15839c0b76d580d62c4f06f834c6e2539a76034fdaf982911c389a017f7cced4
+  md5: 0c589d3d6f8d6ebe5996b2fff3620e1d
+  depends:
+  - click >=8.1
+  - cloudpickle >=3.0.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.4.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3119804
+  timestamp: 1725461423376
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.16.3-py311hca03da5_0.tar.bz2
+  sha256: adf3ced9e94279c8700527309b650491a498e71cc9114caa517dd8beac136525
+  md5: de926408cadc24e8e062f5e686247c39
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy <2.0a0
+  - packaging
+  - pandas <3.0.0
+  - param
+  - pillow
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18017422
+  timestamp: 1720540529831
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+  sha256: b9356e3ada4872c7c950d2ac7e0f107c4786775191efdfda3a469dffb18f2714
+  md5: 07ddd96675caf30ea77cafb1ea5662a4
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2490144
+  timestamp: 1690905181398
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+  sha256: b1481ffa475c65200626f051d5dcbdb264730b533e928dde608a79ce7a5b4e48
+  md5: aada2761547a291d68f4c016a1a9bc7b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 18265
+  timestamp: 1677911915719
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-2024.2.0-py311hb9f6ed7_0.tar.bz2
+  sha256: 9fc5d69d32d7220004d221f730c50fedfb9d92b12751ed2992ab168dadc85864
+  md5: 5d5095c56297f7a7d0d324b496b23b98
+  depends:
+  - cramjam >=2.3.0
+  - fsspec
+  - numpy >=1.23.5,<2.0a0
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 646867
+  timestamp: 1715262347984
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+  sha256: eb82a0e2ca36d0973b5f6642e27609554edad4b72696f989776d5db8cd4a6a42
+  md5: fa8d9dd8a2fabba964c6bb75ace8c572
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 3201601
+  timestamp: 1713551611540
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.6.1-py311hca03da5_0.tar.bz2
+  sha256: dea477d2b42cc015a051cc99d3c3ac0973df6c864088c8da0e77ab0713510b41
+  md5: d66f06e18672ef030741a74261313915
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - pyarrow >=1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 383596
+  timestamp: 1724855620851
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.20.0-py311hca03da5_0.tar.bz2
+  sha256: 1fc120c7bb3c245be0b2805ffaba6518b56e32ca510439b592172138e02e8700
+  md5: be7cf3596496c3d91885749d37e71362
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.1
+  constrains:
+  - plotly >=4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6103533
+  timestamp: 1730827873611
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.11.1-py311hca03da5_0.tar.bz2
+  sha256: e8233716ac401e28fe783ac6175a88f325eea921688eee28e51c1501fa35f046
+  md5: 7d726e0a6b3533c17cba3ef1bba36dd0
+  depends:
+  - bokeh >=3.1
+  - colorcet >=2
+  - holoviews >=1.19.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372730
+  timestamp: 1729516877805
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+  sha256: 4d4ab70ae0ce008c1cc96a4edfbf3866d5e636acc4799a545ea93acee51635f7
+  md5: 86a085a440729020d1d7b0b74d6a0c6c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148448
+  timestamp: 1714398923507
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+  sha256: ec139e4b87aadcacc0670ecbcc2a303d858d4ac38b9404458a4b676bce9d21d5
+  md5: bfcfed281f8df0f18726ec5f843b2b26
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 51053
+  timestamp: 1704813595720
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py311hca03da5_0.tar.bz2
+  sha256: 12ecf9e8614e4d864a3a82d1244b35bd93a3625c7521f44d75c1fb198501e3b5
+  md5: 6c05e1ef68be71ffae5bc818f393c6fa
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 238518
+  timestamp: 1728665670755
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.27.0-py311hca03da5_0.tar.bz2
+  sha256: d2e3d351d5a509d9b384bba4684ff8ccd4fdc12a603f15a49e3d569d56ea413c
+  md5: c448971003786058866ba2239dc61986
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1636515
+  timestamp: 1726064271144
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.1-py311hca03da5_0.tar.bz2
+  sha256: 0dcfa64fca981f7c08f151bdb53b414e34c735184f1774ed9e0686f044488b9e
+  md5: 154a56110b37c8a84cc38e4f43d5ef5b
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1179602
+  timestamp: 1721058583397
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py311hca03da5_1.tar.bz2
+  sha256: 5057f548fb76e0afa997f69dd08a0c1a1d0b13382ca58e909fd378f1ff74de57
+  md5: 329e65306aa67a099eb34e39f80ef912
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 357841
+  timestamp: 1730902943889
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+  sha256: 9d5cbffa98f3a4391f66b0c5ce1f411f0bfb0eb83137dc7146fb7bae23cb3570
+  md5: 95c92318023482e4e8c698ae6c4597fe
+  license: IJG
+  license_family: Other
+  size: 274078
+  timestamp: 1722872672311
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.23.0-py311hca03da5_0.tar.bz2
+  sha256: 5e1400c72584b88b0ea13d2e66110eb7571f155f8b8d62ede4ca61b8279b8bdc
+  md5: 6924a112e8115ffdb74a5c8840903b84
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 193322
+  timestamp: 1728486773537
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+  sha256: 404b0847029f77bedd7902a170a046219e0dc5c0ec2be19ff45361cff25b2181
+  md5: 3a02bbe8d45fdbcb2350f672be74c9f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16524
+  timestamp: 1699032463763
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+  sha256: 7deb8ad28c34c369573754304a03ea2acda8ee39102a56526ec689a4d9210109
+  md5: 675ea1a746a78ff6bf8fc4b39139efff
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 277400
+  timestamp: 1677914250715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
+  sha256: ceec15c84f5c699b8055d01e046be04ccb7cfd7c8bd090fc18959f2a4d9f8cf8
+  md5: f85c11f7068312e1e84505efef9d55e3
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 98520
+  timestamp: 1718818476094
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
+  sha256: b2f1ee2a297e001a2e70bc218f60deb08c50b9b727668913ed5a106640413d2e
+  md5: fc4e797a17ff5dccadfb5d19346b7800
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43099
+  timestamp: 1718738212629
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
+  sha256: 2d96618ab2e9b3de870a713d7e5b19f6cde936291f3c87972f945b6e27024e77
+  md5: 534159d29d9aba9c7e70ee52c27b326b
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 614003
+  timestamp: 1718827110867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+  sha256: 501e929d345aaa9079c965552b942b4e8bde35b87ae89faef003687a40bab3a4
+  md5: 54c7b8554a405acd7c8326c41ba93e63
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28237
+  timestamp: 1686870817418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+  sha256: 773e7c4571f482a744dfb18ae26fb22635f5d3f51389c838bd97f9044ea55cc4
+  md5: 5161546aba5597318cb5653390cdecd8
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20235
+  timestamp: 1700168681687
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+  sha256: 8c1c64d51be73aad381992a9df19d8336910bdfc40f19940231df86e177d17cc
+  md5: b1f786f96684a143cf30d1f6b8aebdb3
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65045
+  timestamp: 1677925371836
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+  sha256: 199042b87451abaf14546af124ae3380194cddda928e0d30ccb341e93084854c
+  md5: eaa0442887994a82486c65d87f6b71e6
+  license: MIT
+  size: 68806
+  timestamp: 1714483212137
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+  sha256: bd9a8a17fb14086446b710fa029d238e69274b83ee2e7e09093496f190de82b5
+  md5: 66615d6a0cb5dcca3e20c019cde0ed2d
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_8
+  license: MIT
+  size: 32975
+  timestamp: 1714483225840
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+  sha256: e1bf77e8b975c30a69b08a08410622e27c8cff6f592ccfa590466b83d9e6d104
+  md5: 8af86bdac01fe303d693d9b76c071059
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_8
+  license: MIT
+  size: 310266
+  timestamp: 1714483239194
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+  sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
+  md5: f31e4eb9cd6447cc2f5ef0243a76540c
+  license: MIT
+  license_family: MIT
+  size: 120460
+  timestamp: 1714483461787
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h19fdd8a_4.tar.bz2
+  sha256: fd3149d43dd971c2c1243a1f06a6b4e6ca1e405f058a8a6544267de4940c0622
+  md5: 53449788cfa51053aed142dcdc1143c4
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 26599780
+  timestamp: 1726766682927
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
+  sha256: 479cf759232c2361af87493ecd124e7d3a8940030e42e1931234c35bea73c3bd
+  md5: cd8fe2c981594a457c6af3a0d5de0bd5
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 341817
+  timestamp: 1729160040909
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+  sha256: 41c62a460bb81a1a272aa28b219fab9c26510adac177ff1528b1980eabc6e868
+  md5: 8d312c5628dc7ea833e9b4dcb73e9c45
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 42346
+  timestamp: 1677973051421
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.43.0-py311h313beb8_0.tar.bz2
+  sha256: e30d9731f52550ab97edacacf9bc11f53d64202e06fbc1747b263c18f26a924b
+  md5: 36e9863286c1022e2439cb56b83bc1ce
+  depends:
+  - libcxx >=14.0.6
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 409623
+  timestamp: 1720455480232
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+  sha256: 5777bbef827f72975a36f3da80ab4af718dc781264f74ad7e3864755d620c0f0
+  md5: 4240f1a79b812387919cc710a0469556
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14318
+  timestamp: 1677925438733
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+  sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
+  md5: f5f7e6e7541d8dc3d3df270d488d2e24
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176990
+  timestamp: 1714510588159
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+  sha256: d024f5142416961a5e66e424d4d14aec652f9e9dd738b41a97f45674c2ffc9d5
+  md5: 0e2d94b125d802f7b006cf19c71655a1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 163084
+  timestamp: 1677932947966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+  sha256: acfd84e29ff4dc2d85543bb973a07f22b4ba53c5d00bca84608ee7f13b2a8676
+  md5: 5ca161cd51e2db358e768453b3ee485e
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135871
+  timestamp: 1684279980293
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+  sha256: b1bed54c7bfb7304cde9e8e6f798543d08e808e81286a5a48296fc94d621f9da
+  md5: 774358285c9e496c9f5c121cc546c823
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27438
+  timestamp: 1704206026910
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.9.2-py311hca03da5_0.tar.bz2
+  sha256: cf95a569383fae0236bacfd3ecf9bb021e2addcfcddaac76e400f8025ec7ec26
+  md5: 43d3a01ac2853a8b19ca185a42db3c36
+  depends:
+  - matplotlib-base >=3.9.2,<3.9.3.0a0
+  - python >=3.11,<3.12.0a0
+  - tornado >=5
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7710
+  timestamp: 1725263985080
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.9.2-py311hecf7826_0.tar.bz2
+  sha256: 405da586a7522b94b0fadaf268e34a289aefaa7a1cc49da8702a13fcff1152f7
+  md5: 60d5ec1d897778a50874147ffb31e7db
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9423902
+  timestamp: 1725263975062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+  sha256: 3276d61fc353c537bb09d4b7473d7abe12be38806f42c8cc383b62f40850a5cc
+  md5: 6e9c9d47f264b77d9a8461f0899848a7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20446
+  timestamp: 1677918370379
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+  sha256: 43c96d30775b61b4968422a47f9605049428120669f0742bbb9e5ba145c7d11e
+  md5: a31ca0d9284860adf5463cf45a5e3145
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 69243
+  timestamp: 1677995336989
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+  sha256: 96d8c9f42a38651b7bafe5f3cb132601db76cd1e28fa58e2eaf090e634292fff
+  md5: 5ebc793a17b6aa84d13f19433545ffa5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23895
+  timestamp: 1677942274932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+  sha256: db9bd659ada23f1ded443d2db00dd13b5d5c0b30f5062544b1ee2c2b88d63d29
+  md5: 03c48121614cf12abfe30eced9b34717
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105333
+  timestamp: 1677916687032
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+  sha256: 8b05894fdcbe5cfcdee94812b043de4cd7b4fa51d3e2aad25fc7cff50c8f82ab
+  md5: c970d49137dce1c77f782ee5725950c1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 30745
+  timestamp: 1677960816849
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
+  sha256: b6fa12e4bde747bf288bda31ce8ec5e24292dbf74fde67f18f9c9c100b845a38
+  md5: 2eddc760c15171a1e8aa838d9d162e18
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8291605
+  timestamp: 1717622676584
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+  sha256: e8eee27fb667aa10b26f3bc4b93f449b7d991ded27b9cb457effee394ce05f6f
+  md5: 6a3e5cd0e1141c01ffb91285bdccfe83
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123043
+  timestamp: 1698934328890
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.4-py311hca03da5_0.tar.bz2
+  sha256: 1f6d171443b30990cd724ef1e5fa287311d1cf9064c0f5984e6acb2225a0197c
+  md5: 9a8675276a35db6cc6649f0bddecf53d
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - pyqtwebengine >=5.15
+  - tornado >=6.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 531141
+  timestamp: 1728049778343
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py311hca03da5_0.tar.bz2
+  sha256: ae983360f1f69987f0fb3a8de9767b362dc903a9b0b130d87fcfcca445dddc4b
+  md5: f56cbcd18632f7f669a28363c6d3fe4e
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 171380
+  timestamp: 1728049515633
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+  sha256: 417ace1ce51e81f3f92ddc26e0e3a83c1e19c9ebb7af7104452002a5573da534
+  md5: 3e11de6cef096091bb733e07802f00b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16979
+  timestamp: 1708532698253
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
+  sha256: 8ea1be4285e2e7d361cbcc1daf9c220f87ceaab2308bf7b339d2513d6ea22184
+  md5: 774ce02efa90f212023541c0b24e92c1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 726598
+  timestamp: 1717630964815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+  sha256: b0cc542e2a6f42ba716e7e4ccf29eddcb155ad167fcdbc72d2db9c7873eb5639
+  md5: 7acf81b17d2c4ceb3cd39dc9f173855c
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27539
+  timestamp: 1699455954000
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.60.0-py311h7aedaa7_0.tar.bz2
+  sha256: 00a7fab2dc788b2f4d748702d9eed2cca75d7486aeff0209f0c2979e2ec28a40
+  md5: dc8ceb8ae25109aa6c9face25605e269
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - cuda-version >=11.2
+  - cuda-python >=11.6
+  - numba-rvsdg 0.0.*
+  - scipy >=1.0
+  - libopenblas >=0.3.18, !=0.3.20
+  - cudatoolkit >=11.2
+  - tbb >=2021.6,<2022
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6146936
+  timestamp: 1720609337122
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.10.1-py311h5d9532f_0.tar.bz2
+  sha256: e7085ecdcbb7814ab5b588399963d6877083cbcbce27407b5ded3c099af1e6a9
+  md5: b656e9369b00f6f0eec85203e35eaa42
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.21,<3
+  - numpy >=1.23.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 189479
+  timestamp: 1730216150682
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+  sha256: d3bb1d4be88320a5861cd3a0f086e9709f9b64c96c032cb9039cc4f17ec66a85
+  md5: 0a7b97665c06fcd34a70e34abc177280
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.26.4 py311hfbfe69c_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11288
+  timestamp: 1708639168951
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+  sha256: 3e70248a7069ca12ccf56252869bfdb72211fd4e4c327e6994756496df786c79
+  md5: ce4846006d98638cd86a532a72f8dfe4
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311he598dae_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7536860
+  timestamp: 1708639153133
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
+  sha256: b9f781280f49644ca05e18aacbdde1c57cc5107e7cc2471b843ea8461672aa7f
+  md5: 9125d30e4e105b45f7f7d9c20acafa10
+  depends:
+  - libcxx >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.7.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 450131
+  timestamp: 1722872679313
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.15-h80987f9_0.tar.bz2
+  sha256: 503def27e5229dc31eb3eea4c86ecabcd46a27b6711a968bafeaf7facfc8eeb1
+  md5: 2261823151398e7df6ee94c234f21f11
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4762637
+  timestamp: 1725545955868
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+  sha256: 77b0c0a0fb14d817390244ebd93c36d44a7867239963f211f7c0a72a3f98d382
+  md5: b90336feb8a50d2eff880e89acb02f40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39617
+  timestamp: 1699371253760
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.1-py311hca03da5_0.tar.bz2
+  sha256: 077c5a53916492c8903911dc8f2661403a95488c937c44233401aaf1b4e513a9
+  md5: f996a0feb121848b1e43889b2c523328
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 158057
+  timestamp: 1720102085523
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.2-py311h7aedaa7_0.tar.bz2
+  sha256: 3ee48b8e32d5009fccbb8e0dbb00d905f827982adae9c9f799ad85ba6f13a077
+  md5: 9e6f48d13a7911f6b5547e6a9c8dc5e1
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - jinja2 >=3.1.2
+  - xlsxwriter >=3.0.5
+  - pandas-gbq >=0.19.0
+  - scipy >=1.10.0
+  - openpyxl >=3.1.0
+  - pymysql >=1.0.2
+  - s3fs >=2022.11.0
+  - dataframe-api-compat >=0.1.7
+  - pyarrow >=10.0.1
+  - xarray >=2022.12.0
+  - fsspec >=2022.11.0
+  - sqlalchemy >=2.0.0
+  - beautifulsoup4 >=4.11.2
+  - html5lib >=1.1
+  - lxml >=4.9.2
+  - gcsfs >=2022.11.0
+  - zstandard >=0.19.0
+  - qtpy >=2.3.0
+  - tabulate >=0.9.0
+  - blosc >=1.21.3
+  - matplotlib-base >=3.6.3
+  - adbc-driver-postgresql >=0.8.0
+  - numba >=0.56.4
+  - pyqt >=5.15.9
+  - odfpy>=1.4.1
+  - pyreadstat >=1.2.0
+  - python-calamine >=0.1.7
+  - fastparquet >=2022.12.0
+  - psycopg2 >=2.9.6
+  - adbc-driver-sqlite >=0.8.0
+  - pyxlsb >=1.0.10
+  - xlrd >=2.0.1
+  - pytables >=3.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17039081
+  timestamp: 1718309063969
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.5.3-py311hca03da5_0.tar.bz2
+  sha256: aecb0fe7cd9004af633b8f2beef0f2c0eefce35f206d2ff4de80501fcb37f2dc
+  md5: b2e3ca6dd4a306e635ebd2119d58b448
+  depends:
+  - bleach
+  - bokeh >=3.5.0,<3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.1.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing-extensions
+  constrains:
+  - holoviews >=1.18.0
+  - bokeh-fastapi >=0.1.2,<0.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24200241
+  timestamp: 1730381212320
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.1-py311hca03da5_0.tar.bz2
+  sha256: 7c4d34def227ba26cea176cd3d522aeb2584989e68052c387925536097cd1f63
+  md5: 025e2c935f86e471a35d584c40bbed29
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264597
+  timestamp: 1719348054960
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+  sha256: 088245becd055af4de74e4ed13cc752ab546423f204b170ba2dd8809af30a2c7
+  md5: 2eabea5ccc56ac088e0349626e59df06
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48517
+  timestamp: 1698702686783
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-11.0.0-py311hfaf4e14_0.tar.bz2
+  sha256: 5474ea3faa0ab8c64f7264382943bf9e5360862a674d1556ac4d626e2be0a109
+  md5: 764dc809a9692f35fe4d0173b6dec174
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 947952
+  timestamp: 1731594918339
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.2-py311hca03da5_0.tar.bz2
+  sha256: 4f82ab7dc13317069ec808da81c472668e6ab85f5d74d5b385b6d86b4ef32bad
+  md5: f9c03ed21097422236806938a7b7dd64
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2918476
+  timestamp: 1723484709578
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+  sha256: b6200816d65673aa1707c20a768c9cff87dd8dbe1335f9c1478e5931dfa08ee0
+  md5: 14b1e0fa73eb33f9c83048482dcce57b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38423
+  timestamp: 1692205689597
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+  sha256: ebdf211edd98d88a23778551c7a9702106edd0695d4fc48e87c21f77521c1ffe
+  md5: d8c505081a468f1b99c62466e2309417
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 123084
+  timestamp: 1678996822234
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+  sha256: 07cfba50d9e94364bde077731a824ca4f537138b35ee6b66d07aee16ac9850f1
+  md5: 919bf486280a11e6acb3c2c3a82f7473
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763225
+  timestamp: 1704404463402
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+  sha256: 8094436b2c44e68e72569c704633802aad82e977b1e16026848218679c8becf4
+  md5: 2360e46d3e598dd5e2abed781fe166c5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 502115
+  timestamp: 1678995719872
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+  sha256: 4f17f70658e32a9a86661184cace6be3bb7bd61f9b55b513092beddf44552679
+  md5: 0aa95279688b0433badea0b660ac8146
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38653
+  timestamp: 1677933613643
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+  sha256: 121b5b66721760c05f1d4eee91626229d1814663d3fb5f23126ef870aa496e26
+  md5: 0c588c2ca790a05d422c06e8568201ad
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2124200
+  timestamp: 1684280082141
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.2.0-py311hca03da5_0.tar.bz2
+  sha256: 86cd1c9d1c73f7dac9f3038d16ac2d6952d42bda57d4da52b18c8561d2901082
+  md5: fe581970af66b493353b9dcdb6bf572f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 487783
+  timestamp: 1731445552436
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+  sha256: 0bb3d2a57b332c5cf73ea40ea13c850ae24a1f9a3a41ed9267832d9e3c767572
+  md5: 45a7fcf1641980d5114999736428502d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36755
+  timestamp: 1677906514270
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.10-hb885b13_0.tar.bz2
+  sha256: 965a3ced7445733f34a4ac805777b64e2309a36e4fe16da1a9ade408293e5e0c
+  md5: 801288e9af659ffede1719ba41fd6840
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.15,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.45.3,<4.0a0
+  - tk >=8.6.14,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16469561
+  timestamp: 1727940848930
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+  sha256: c3cbf5bd237b0a7458640191016b2701fe120c547df9afc835da76663a9c17f7
+  md5: 843568c76b6b9384635b7fca74c79792
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332222
+  timestamp: 1716495881101
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+  sha256: f94b3cfea6f76ea9983e16d3c4c7e0a64f02c40cc2c3ad57189bca2e67030bd9
+  md5: 0d100990ade57a02b60d1e8085db0bdf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 280263
+  timestamp: 1678996927464
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+  sha256: 252c86f5aef7f8dfce99a260c24cbb35a9adfea144a2acfabb224f516341544f
+  md5: 745b888e19a644f48800799f82c01c21
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18539
+  timestamp: 1683823925189
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+  sha256: d945744eb133f19ca61325cac5128bdb053ae04de4a0ba6f69c061449cac8af7
+  md5: 34baa81490d667381bc7021435b0e1f2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 275858
+  timestamp: 1713974457562
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+  sha256: 012585bdb5ae54c2cded50be703734e6dbf418b003635b6f6d7c1e36e7020c30
+  md5: da7e99a707bd0cfa20db651b5c068bfd
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65556
+  timestamp: 1711136890180
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.2-py311h80987f9_0.tar.bz2
+  sha256: 8d6910a02d0a30dabb40104565c0c74531aafd4c959431ddbfde47ef52f4c83c
+  md5: b1619588c95cb65375af1d2eb448ecc8
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 205890
+  timestamp: 1728658038659
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+  sha256: ae8cdd5be5a7ad19ff82925a035859fafcc5942cd3899d127a508dbb9a235090
+  md5: 252a7b997d08bf72f10b3bc2dc68333e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 580346
+  timestamp: 1709318480624
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+  sha256: 7a208abc002a2fc208ae25cb2cf932999a3e4980aa4c9edff315cb9ac62b12ce
+  md5: bd22ebd3cff811577ea61f115ba7f4f2
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74744
+  timestamp: 1699012126255
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py311hca03da5_1.tar.bz2
+  sha256: 4cefdf48ebab7544252ce5f4274b5b86f8107e5af556bf387445a2eb4d42449c
+  md5: 482973b9a55bd1a4cdc33c557a6afb29
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 124539
+  timestamp: 1730999249799
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+  sha256: 52368d9b557b8f54ef5ca4bf6cd5a3ec665171f2b2d2082cdd410bab88f4829c
+  md5: ac76fb4d2eef3ecdd491cf5d3fb8620d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10204
+  timestamp: 1683077239143
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+  sha256: 491d116c5f54ef340e3bce631835f7138cd1923d7b63e6ca9aa01b48110cb8f9
+  md5: 9b81bd8ea808704f5433884b567f1f15
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10557
+  timestamp: 1683059079547
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+  sha256: b53a5f6119173d62e4e68a37ea8511c7fc87a00af72953e0048d075a799c7a7a
+  md5: 76a16cf4edb9b12b2b96a2d323f060dc
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 342535
+  timestamp: 1698945991201
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.14.1-py311hac8794a_0.tar.bz2
+  sha256: 5eb2f761b843da0ee82931aec629c725bc77b62c548787ee4e31fa78d12d38f0
+  md5: effcbbb58f46894ff71270767a751265
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.23.5,<2.3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 25955155
+  timestamp: 1731628440893
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+  sha256: c80d52567084b1caaed2862b77b70065ca17afaf0b020733e9d6c273b4a63e78
+  md5: ddf7d88c1967f3f7a4ce1c975fd47e0d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33321
+  timestamp: 1699371225235
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-75.1.0-py311hca03da5_0.tar.bz2
+  sha256: 70c84e0f41fa9eac5f35d447ebc6417279180694bddecdbba5d14e12124b56f2
+  md5: cdfbbc473d52a1334490dd81c7833ae7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2317457
+  timestamp: 1726677954270
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+  sha256: cd71091a234874d2826fa063ec5222b3191c9f47e1b5281c352d9df3f31a06bf
+  md5: 0db8e29016c6bff026c083d9923a7566
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19073
+  timestamp: 1705431415504
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+  sha256: 3e18cdafc607c6d7623b1c8f041cbfbb50a27e298f961abdcce7e36834ac39e1
+  md5: 9ee0da74c55d0b8d83edf246fd717f20
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89862
+  timestamp: 1696347657368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+  sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
+  md5: d8c1e9910392d0bcb22a173f9ce30fa6
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1758290
+  timestamp: 1714488307689
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+  sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
+  md5: ae58720a18a2ed15eae214ad7a10d1b5
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 140125
+  timestamp: 1680167256603
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+  sha256: b5c265e9ed9a1ff2238a09b83bdc1826950faa87fd6b685debe60888de6e7a50
+  md5: 5827c8a32317894ce18576e334daba47
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38559
+  timestamp: 1677918962258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+  sha256: cfefd86d0f4981d22b7611b3dc60359b8698bf39f2b743cb90b7005aaca88e1e
+  md5: a04dbcd6095f6b8f3ad195a78d48b262
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50058
+  timestamp: 1677917499177
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+  sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
+  md5: 3c25b4f4768ccda28b20a03ba27e7759
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3484151
+  timestamp: 1714770744982
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+  sha256: 0836468fafb1f5badbb573922e37200c6929bf2926ecf8d2259dff43811e0727
+  md5: 5bc56dcb4bdb7cf623b7cea499feaddb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 136409
+  timestamp: 1677925889207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.1-py311h80987f9_0.tar.bz2
+  sha256: 2fd655106e52bb73deea5a0af63708e75cf66e071f0f3f15c04a67413f721430
+  md5: 324986c435dcfc101684907ce85c199e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 915790
+  timestamp: 1718740267109
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.5-py311hb6e6a13_0.tar.bz2
+  sha256: f6cda770cbe84b10f2d78d41bab43e1a1386e9722569c9b2b235083947fe90cc
+  md5: f5306a7b16da13a7258a20cecb62cdd5
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 155732
+  timestamp: 1724854273737
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
+  sha256: 707e5dfdb9116f31bc1ad7f497f6e8416683add460258fdc2a4c16eec85226be
+  md5: ffb602322a388ec8e1f385edaca3ce12
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 208171
+  timestamp: 1718227091374
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+  sha256: 96071e07e807414b7ae5a2fe958ac171e5795576b3a4c2f5e8c643fba43d760f
+  md5: a34f2b216e35a37f966883dacda229e2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9902
+  timestamp: 1715268985387
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+  sha256: b20e48aff4c781a52b6be66d77418e768527a621f5fc272ecb34ea03475b2bd7
+  md5: 707738432f16f5e63909fcaa6e65850d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 75604
+  timestamp: 1715268976065
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+  sha256: 2ea2d0520b330d381a2ab241bdb9ae146ef815ee7c96ee52a9773fb9ae85f4fd
+  md5: 66f7f8979cfb2cccffac972d70482130
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 12614
+  timestamp: 1677963554857
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+  sha256: df7fe7740bd853b641d624e2ec97f1aacb2b82691936a8c04ef18fa9768539c2
+  md5: d5c7626d45fd03b22797c18e47812beb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 518048
+  timestamp: 1713213046424
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.3-py311hca03da5_0.tar.bz2
+  sha256: 428c7365b106ed161342704298d14101e12cdd778caee3d167587fc2807e483d
+  md5: 86cd9cef3c89a98a98548f18c621e61e
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - h2 >=4,<5
+  - selenium >=4.4.3
+  - requests >=2.26.0
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 218842
+  timestamp: 1727769914621
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+  sha256: 09738b7f9075386bf062b12ddb6fb72a06450d2481f6b5ca2026c811cd849569
+  md5: 9afdec076c95746ac21235f971190e40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26727
+  timestamp: 1677910175964
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+  sha256: b4ced7366de8eb7258f31d516616e70c62ed4a798780e57e208509d2b52ab435
+  md5: 65a9a05a726734c1da667f9bd3c78c14
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 114733
+  timestamp: 1715878377412
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.44.0-py311hca03da5_0.tar.bz2
+  sha256: 088f397ff8a4a7e178415dd7e2ff987c02b3674c7b6885972fb6c669978aff40
+  md5: a87f4be160e50ea022588aab7c7322bf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 139304
+  timestamp: 1726165038360
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+  sha256: cf030fc7020dc6d28530075468b8dc1edd843a1e393a2f81ca81c962e9af977b
+  md5: cae3fc90233f3af8f433a253d035b6e6
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2470844
+  timestamp: 1689041497962
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+  sha256: 2cd108896df65636769e3804ecc2ca421ad9b54e64fa21922bbabe40c90c247a
+  md5: b3a1e5077b28f71298d891fbfb5ff03e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55645
+  timestamp: 1677927459979
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+  sha256: 5be8c968f2da5c4bf14f28d63e31b4c1b6993d980023769732c7f58f396c2e0b
+  md5: 3f5f62d4e85e3bdd48d39189b01805a6
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 459197
+  timestamp: 1714510992914
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+  sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
+  md5: 3d57d1adadca9388aaaa1c529b65ba65
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 322790
+  timestamp: 1705602163804
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.20.2-py311hca03da5_0.tar.bz2
+  sha256: cd62f8ea0090380c4b380fc29f05a145bc4d6588dc74ff0c5df910fb9fba03cd
+  md5: ca0d82aabd1595b5cd8fca3b6f5ef343
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 29898
+  timestamp: 1729012523732
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+  sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
+  md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
+  license: Zlib
+  license_family: Other
+  size: 104928
+  timestamp: 1714510936868
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
+  sha256: 43667132ec8fa4c34ba438e13a01b08073e3e3e8a648ecdb6afe4141a7c197e2
+  md5: fb8c3f5683b19dd3743d125797b8e2dd
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 817614
+  timestamp: 1728486986031
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.6.2-py311haa95532_0.tar.bz2
+  sha256: 6fbb6b2aa38cb576b17299bf2fdc3779ca090059bfd35e92127f692f2b912aef
+  md5: 403069f811c54afaf3d6e3be619bbab8
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.26.1
+  license: MIT
+  license_family: MIT
+  size: 244161
+  timestamp: 1729121358016
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+  sha256: f715f7c2e06149bd6d43258e41479d3171efe5e9d56050a0a5f5652ed9d05fff
+  md5: 11a8ca43d69881b88f95ae681478866d
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 36089
+  timestamp: 1676424516042
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-24.2.0-py311haa95532_0.tar.bz2
+  sha256: 69b730d7601c73ae983e294fecb6ab76899e74d831a09b0248beefca3457701e
+  md5: 7a18c3c1864941526e4d90de359b2a87
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 163624
+  timestamp: 1729089495660
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
+  sha256: f1eb2a5aeb25efa0b38fc1dd94a36d431bc80d654f11a052f67a899dcc471f57
+  md5: 9db5a441c7cbcf4dc617f8c722e4310d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 276663
+  timestamp: 1718029990621
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.6.0-py311haa95532_0.tar.bz2
+  sha256: d6077bf47e0740168accab42135139ebb4bdd5cf1111f81881b148777468100e
+  md5: 7281ca887bccf048f735eb5acb1e5118
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5918010
+  timestamp: 1727915199711
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.4.2-py311h57dcf0c_0.tar.bz2
+  sha256: 42f1a2eb775091e9aec87f3f08ba76891e45032c980b9c00c108437df6b5fc56
+  md5: 327b522b59ec41d6e5d4a100c228415b
+  depends:
+  - numpy >=1.21,<3
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 160724
+  timestamp: 1731059089575
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 751071782f597f87ed7f67437ef6cc669213902461b9795dd6eb0f4897eddc83
+  md5: 5ad8fe62aad5e16cfdf2c5a7d1327fe7
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_8
+  - libbrotlidec 1.0.9 h2bbff1b_8
+  - libbrotlienc 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 19418
+  timestamp: 1714483531456
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 9bd62d810867549b9c967c5915f3fa3f66cfbd6ede28b1cc152efd1261285c0a
+  md5: 64cc76de3662b62bc8f0e42befd92c5d
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_8
+  - libbrotlienc 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 32178
+  timestamp: 1714483513837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+  sha256: 1547fa52134cf06b8d01bdf52114db7db60a89bf35c9c95be5b5a03b13dbd565
+  md5: deb765cb7c4b7edc4d126f864f31747c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 356401
+  timestamp: 1714483740924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+  sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
+  md5: 11e0af09a31e2d5df51c65a342032b85
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 112994
+  timestamp: 1714511182837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.9.24-haa95532_0.tar.bz2
+  sha256: 5434767b7168e529c2c6a4bc201c783adbc3bc6480564a6fe3f869b12ed96c83
+  md5: bb0627482bac2339842e495e7d6686d2
+  license: MPL-2.0
+  license_family: Other
+  size: 175262
+  timestamp: 1727794875480
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.8.30-py311haa95532_0.tar.bz2
+  sha256: ddf997fd83ad3c39c91c80c97ffa35b76565c400a3993ff88ef3730c2cccb14b
+  md5: 5b933b0d173e2af3d30a74a74c9c3c69
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 169591
+  timestamp: 1725551908109
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py311h827c3e9_0.tar.bz2
+  sha256: 70eecd3e89d12624083a73c998d818dceb1505ab8e7be7d1f4814950b18c2fcf
+  md5: 1427fd9ad1be3e40e6dd5751d98fd96c
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 309709
+  timestamp: 1726856612505
+- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+  sha256: 7153817dd49ec317b519802c7c22c836602e00cbd96d68385e83eaf4c9f5ba6a
+  md5: cd829e5997611a602e29fa2fd5882635
+  depends:
+  - colorama
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204113
+  timestamp: 1698130080270
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.0.0-py311haa95532_0.tar.bz2
+  sha256: 364512f6fbda47a7683831e49d94cede5ea91ed57c0bcb27c4c1a95b067c7717
+  md5: c4c87a947b2f0594d0eda7d852140845
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42936
+  timestamp: 1721657516663
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+  sha256: 4099898f02e1f6119fcda65e747c3cbfef0bf563c8855b79a0245160709d5b45
+  md5: ab9705c34e67fb8c8faec69d63ff4064
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36410
+  timestamp: 1676422341506
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+  sha256: c722f50980d7416ffb2cfc7bf72649307a0bb78c5a24eccefcd049cb61d6b355
+  md5: c7c9ff0513ff3c99700919293b702410
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 543258
+  timestamp: 1709758602437
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+  sha256: 8fb3e816a5ad1da05125462dbc9e2a7e933b001a871aa65703802c0a894c6277
+  md5: ee4b2fa9fce130496d5c7c86c35a1a05
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17723
+  timestamp: 1709323150229
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+  sha256: eeb49cd151ecdccd40062e8123a3b7a9a8a1eda6567dd33ce909ff8ee1a97c89
+  md5: b7fe1f7ead1ec2ac642d022942282fc8
+  depends:
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 232451
+  timestamp: 1700583772701
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cramjam-2.7.0-py311h005caf5_0.tar.bz2
+  sha256: 97def042390c467aaaa3f4c33276b0c134c40eb426695332673ed1173f999258
+  md5: 13d97f9f5f7b1f8808e4a694b3305f15
+  depends:
+  - m2w64-gcc-libs
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1384742
+  timestamp: 1702664451643
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.8.2-py311haa95532_0.tar.bz2
+  sha256: c989952077ec0ea63cc766f6aaaf8f0ffebb12c7d2143a5cd111cc807dab253a
+  md5: 7628fc77d1af150ae6cceffcf154c990
+  depends:
+  - click >=8.1
+  - cloudpickle >=3.0.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.4.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3190714
+  timestamp: 1725464703740
+- conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.16.3-py311haa95532_0.tar.bz2
+  sha256: 029f067d71a2825e4af1ba085c792ec96d93fde7ec0590d5f6414a051085cdb9
+  md5: f4c49a5695996b1146ca460058f4abe5
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy <2.0a0
+  - packaging
+  - pandas <3.0.0
+  - param
+  - pillow
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18066407
+  timestamp: 1720535030282
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+  sha256: 5c73f86e575f2ad683ee4a1c2df11020e270edd89d12f11199483d57b0b51826
+  md5: e96a12895ce374476277b1b196ba24bd
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3719519
+  timestamp: 1690907216785
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+  sha256: 5d5fc8a24c804010b8cb5963227230352ea3ccf56bea9e8116e34f77223218f2
+  md5: 8f989a72eed6293dfe0533c83057980d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17688
+  timestamp: 1676423357100
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-2024.2.0-py311hd7041d2_0.tar.bz2
+  sha256: d3a95af9b825eb25c78876ca08bf53372e1d5dc11fae2b0469ee2d1dcba1e77c
+  md5: 1f736c03b7e7e7cb54ba193a90aef21f
+  depends:
+  - cramjam >=2.3.0
+  - fsspec
+  - numpy >=1.23.5,<2.0a0
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 677268
+  timestamp: 1715262878219
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+  sha256: 27fb03eb57d25711a15e145f47a64320a9955b585efc9fd0a1a51cdd71b9fde3
+  md5: eb3869e98f6f53dfec76e2eff4d6b61e
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 2732423
+  timestamp: 1713552175344
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.6.1-py311haa95532_0.tar.bz2
+  sha256: 20b5c643d8f2d2ca349435d8a762f1d42b7b9b4e86f154ce6722d30179f2d348
+  md5: 1db1c5f718e6a79a5f0117ec9957c6bc
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - pyarrow >=1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 383101
+  timestamp: 1724855844881
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.20.0-py311haa95532_0.tar.bz2
+  sha256: d991c3ed55771bd642ffebbef209c4d94b9db7c206fb7ef52d8013baadfb6005
+  md5: 4ec4007efb1e5167568de53a8b03ac43
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.1
+  constrains:
+  - plotly >=4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6147331
+  timestamp: 1730827981525
+- conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.11.1-py311haa95532_0.tar.bz2
+  sha256: 154f770caee47fc07126350224c6937f80e7fa29f0145e34d7594e1149b691a9
+  md5: 4b0aac2000ef4f548a7210ce6f57d79d
+  depends:
+  - bokeh >=3.1
+  - colorcet >=2
+  - holoviews >=1.19.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 371267
+  timestamp: 1729516914605
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+  sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
+  md5: 582d2c1135a89da757a038de831e7f39
+  license: Intel proprietary
+  size: 11086648
+  timestamp: 1664812389803
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+  sha256: 945f4521793d7d279532d1ccd5157201c5cbf64f846bfe60249d01e1b4edf295
+  md5: 0accae23d095c165ac731f4a1f3ca497
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 37021132
+  timestamp: 1692294548916
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+  sha256: 102c803186db6d62eaf41a906f6c563ff0d62b53c1eaede8a381e18c0d005ed9
+  md5: 9d30dec03058758a428cf152e0ae28b5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148193
+  timestamp: 1714399061601
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+  sha256: db30abacf919b3f68ae1e6a94c467fd1e69fbf47ba7a86e6b491d8bfe4776f92
+  md5: 9299876e7ddc3aea3487fd93340ceae7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 50842
+  timestamp: 1704813715071
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+  sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
+  md5: d215cc8ee7ca2cc83cc250cc5d822fe0
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3929136
+  timestamp: 1699647939158
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py311haa95532_0.tar.bz2
+  sha256: 6f702a1b807648373dff43ba42e92978b52cfe392ca426dfb9ebf556a1189a70
+  md5: db5be371e83b27b4c763d1b1c3777df0
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 237277
+  timestamp: 1728665671824
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.27.0-py311haa95532_0.tar.bz2
+  sha256: cdd0cdf851850a822f0757fd86c3492d98a5ab6a98bb3851bbec8b36a95b620f
+  md5: efc3d64ef763443d936e1a954fc9cc1f
+  depends:
+  - colorama
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1664842
+  timestamp: 1726064663198
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.1-py311haa95532_0.tar.bz2
+  sha256: 0b084d918d32ea80d965c141220384c348c9f13c5bf5dabdd49c8d2aa813c0b1
+  md5: e07d6312911028555a8d2434b60c15a8
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1168633
+  timestamp: 1721059057721
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py311haa95532_1.tar.bz2
+  sha256: 8694788240bbdddbc5d111ee8d0ef11106ddadb13d56cd4c46b8140b88ab6277
+  md5: 64856a8473ebc5effe17f370b4e91016
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 357167
+  timestamp: 1730903506013
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+  sha256: 0238fb10912d9345a9d327ff314a179de38369f8e1d0de0b5f4fab04defab0e4
+  md5: 16a420ea83811cfa0c7cadba8f9f0995
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 409932
+  timestamp: 1722872751697
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.23.0-py311haa95532_0.tar.bz2
+  sha256: 99f6618c5969b13451072defdcf3441b83f710010ef10b7a620b42e156ed919e
+  md5: 501a297479b97960e249bdb117f7cda7
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 224348
+  timestamp: 1728486919376
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+  sha256: 9581be54128954080d7cef448b1728874c2ebbe5064f55adece422cf12eafa5a
+  md5: 3adc105f87d5c7f0b1248bc3423f5b48
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16187
+  timestamp: 1699032556953
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+  sha256: ad8343bad7c8f0448cbcfbaf872cc94b56da81c52e5cdcee2a5d6b89f029eb75
+  md5: addceff8d46c9d1d322618a9ce9e5b39
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 300354
+  timestamp: 1676424060532
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
+  sha256: fe0bf805dfa60d8b5d61670900442d0cda12523135176f60e1ebafb797e521d8
+  md5: c8cf5ea3d4b0bc57dfe6b189b47e69e9
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 136783
+  timestamp: 1718818384444
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
+  sha256: 262c35a28d0af4d73ea1c010ce0c022005512a26d5c27064c8e009c0b7b789d9
+  md5: 8367c61552aa274c0843201d88e461c8
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 72131
+  timestamp: 1718738283200
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
+  sha256: 00bf8449a37eb10c91ebfaa14b231905fde9493740cbda7ec89a8d3d8d9d1ff3
+  md5: 1f3abe3cbf365249ebae7465a57e4cae
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=2.0.1
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 655133
+  timestamp: 1718827724346
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+  sha256: 90420847230e72a648417f5f77cebcf7f17b89f70788652c276acc0c440e135f
+  md5: ef3d8dee197aa37897bf6d39d2dd878f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=2.0.10
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27639
+  timestamp: 1686871052174
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+  sha256: 97faaf26ce5254ec3649a8ee7f480b1556e4e8e6e4356d2fab1e6a5532631a0f
+  md5: da23bd831c50c877f63038b7e16720ad
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20163
+  timestamp: 1700168785472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+  sha256: 8a2f0909fad0387e57cb0e9ee30db2b20761a9106e794381ffeac387a298fb07
+  md5: 6058b2efc3284e27aacec2e6e6280433
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62334
+  timestamp: 1676432044242
+- conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+  sha256: ef6b0347ae565dd648a2bb40bc8b0b30f2e4f8387778fefced1d581b7d5a3e16
+  md5: 8ef1d5919aa55fe56ef34d9a7969dca7
+  depends:
+  - openssl 3.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 861982
+  timestamp: 1684424430941
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+  sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
+  md5: f5f73266281ab12377d5d47bdf07500a
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 905072
+  timestamp: 1617648814933
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 7c906c94a4d46ea963080a6ba5bd12c1274da66159877a544fbc70291eeed98d
+  md5: 45a3d52534fac8aa54a55ee92211a918
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 80216
+  timestamp: 1714483371043
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: daad7edc6d56abf3e176479e8628162dbf1c56b3d24db30d708aebae694a5214
+  md5: e8ecf229f7fcb4c0b76d8613627948f5
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 45189
+  timestamp: 1714483420152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 84320217abffa9386186ec8d03b4651bb4b1900d3871adc965a9a9e1d3799907
+  md5: 651312fa22168f71f9aec5f9ee2c2fcf
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 756116
+  timestamp: 1714483464368
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+  sha256: bb17beae8860a83d081d57273825b46bf8fe9903f3b4182ab41a7ae2c7274859
+  md5: 94182f4ab8beb4eddfd8167b2e2b0380
+  depends:
+  - libclang13 14.0.6 default_h8e68704_1
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 147804
+  timestamp: 1681225547009
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+  sha256: 01b84a38c9069e7b8e6fa2a07707e785df7d40b8f01d76a504e98e5a5cd58539
+  md5: 22c9f7e59174c49f06e3c5c9384401ce
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 25699299
+  timestamp: 1681225463612
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+  sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
+  md5: cf949d76148be1e2a534218d9c57df86
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 155435
+  timestamp: 1714484319443
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-17.0-h70ee33d_0.tar.bz2
+  sha256: 0091f34cd09df46b1a71ac20840acae36e504ee326e0320e130ebba6fc21f198
+  md5: 4a0860ba15b5dcb33bed19b3fa1486c0
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - openssl >=3.0.15,<4.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  size: 5203786
+  timestamp: 1731540015556
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
+  sha256: e54ee28f6ba01b3addf61ee9dfbdedc16eac8654fc334f713b5f181cf037d0f2
+  md5: 47aa151852fc9b07e7573d22f0af945d
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 339944
+  timestamp: 1729160123353
+- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+  sha256: 4534c822511a052a72c2b070a05e5d8d6f3550f18ea00a33f9d8a9a92b4382cc
+  md5: 82f24e7660831445a2183216e280a6a4
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41464
+  timestamp: 1676474474981
+- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.43.0-py311hf2fb9eb_0.tar.bz2
+  sha256: bc9012cb5609cecf8ac40ad23546d10744ce2a9760781b5503df66b1aa07d1c7
+  md5: 25112566aaca1c88c03db128f681354a
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 20924132
+  timestamp: 1720456466056
+- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+  sha256: 896b7a39bd4ad3621312130122b4fe84dcb67d7355166255c58ea9bc562eb0ae
+  md5: 640b852a56296f48cf073e61a59c5256
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13751
+  timestamp: 1676428354074
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+  sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
+  md5: 320f40b75d93f3b96931c6d13c23946c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 158902
+  timestamp: 1714512129889
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+  sha256: e0dc6e119b224bb31ef34b6ba270ffadc181d38b698c5318de8df7a5d2c4ccbd
+  md5: 992ccd756f09408f0b74dfb9852a8b7f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 182381
+  timestamp: 1676437963591
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+  sha256: 050b5fd4b28132d8102a7e6b40179894dc7f5e41f7ad9ee19211e67446c5740f
+  md5: 3ae0b2f6baec708554648ddafa81b756
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 154386
+  timestamp: 1684279992864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+  sha256: 8269c73b7a9c03b95a121e318d0468f35eecc016093620b0560f35238cc5df51
+  md5: 2914bea0ae29315f998e1abac79ccaa8
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30214
+  timestamp: 1704206218108
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.9.2-py311haa95532_0.tar.bz2
+  sha256: 3731ce13933e8de156522bb0dcbeca97995ac5e2af9916ed384a3c12b4fdae61
+  md5: 59662b2df1258e002812b52fffeb8a59
+  depends:
+  - matplotlib-base >=3.9.2,<3.9.3.0a0
+  - pyqt >=5
+  - python >=3.11,<3.12.0a0
+  - tornado >=5
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7516
+  timestamp: 1725264804651
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.9.2-py311h472561b_0.tar.bz2
+  sha256: 8cbfc06d4c0bf20f4aef4e26a342f9c5abbb8411cdea98b36e9f6486657824b9
+  md5: cf7246a7ee382f69bef2143c6aa23f9d
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 11748171
+  timestamp: 1725264782314
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+  sha256: 43279276850eb6e621812448cddc1093524cee0b7f8ed58b4600b68a4fb659f2
+  md5: 5968b2b5c1f3cf5c8c8c9aaa4d8d66a2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19886
+  timestamp: 1676425829787
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+  sha256: 3062a8254ca351b54f15bea85cc928a3ba4d879bb98ce97ece39a9f7eca215a5
+  md5: 8f1565663abb34ad7fdd512e76da5532
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 68031
+  timestamp: 1676481862508
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+  sha256: cdff5215c292fe59649ca40ca72f5d26da352760c1d6a56feba14eb13f7bbf61
+  md5: e0f3f32b22135dfeaec277bc87183ca9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23328
+  timestamp: 1676442709081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+  sha256: 3b173a25605d2aaacc57ec0e425f1d1c51327eb2521c8742a736e2c76069bc8d
+  md5: 169f1c93a443f95a88665f3008623ce1
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104882
+  timestamp: 1676425142412
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+  sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
+  md5: 527155127b9fada5e5c5c69a624674b9
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187498166
+  timestamp: 1699648376430
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+  sha256: cea59ae60da314caecf08edb9bcb03126c6dd35837c8184bceaa194decca3341
+  md5: 30936b7263cf0171f7c86400f12ef184
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49080
+  timestamp: 1682975093455
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.11-py311h827c3e9_0.tar.bz2
+  sha256: 513b8fe5da01b8460084688d99c977d173b19d7d58ad2aa6b27a961665ae25f4
+  md5: c07115b0a05892c721b7324ef8598c2f
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 212966
+  timestamp: 1730823150084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.8-py311hea22821_0.tar.bz2
+  sha256: f8ea6da83e88b353bf66ae609d0377e45fe0d4dcdba2c920ca7b600559f49679
+  md5: 98805ec361a795613a97773fab63653b
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 345997
+  timestamp: 1730822892388
+- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+  sha256: 39f09c1bc57b4800ebda331eddb462928435498705351b0432d51a4293294ad8
+  md5: 5565984a02f41e97cb9a4c9126ced14b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29808
+  timestamp: 1676442800892
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
+  sha256: 636f369607118a6ee3d0b63b7edb925d8081fd3fc829a7699136ce0dedbde067
+  md5: b7e49c9cea50d8406cac81cd720dd80a
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8323655
+  timestamp: 1717622931223
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+  sha256: e940f9178ee2fa0a7c12873ae35ebea0074371653e5cfa1be8aa8d9271fd343b
+  md5: 355d0835215911738a28010dfa6aa382
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141785
+  timestamp: 1698934346590
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.4-py311haa95532_0.tar.bz2
+  sha256: d5a6346c8d081061777b5327284f3836342ad3e4869c3584a8bf1b7abac56466
+  md5: 0d00b9e90c3df8cb479490dc136f0577
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 573057
+  timestamp: 1728052469536
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py311haa95532_0.tar.bz2
+  sha256: 952df0af8037fd3131a3f64481660272040fc30816c5b6a5377fa2357d3bcede
+  md5: e0f63c7653d679b5ec3f50b14424ad1d
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 202609
+  timestamp: 1728050720194
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+  sha256: 90fb3f14c49da1397982eae21cd09e8d60d491d76f94c57590c56723fe6dc172
+  md5: 46a523661fe5c1bce7b4213fd428c3de
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16732
+  timestamp: 1708532795328
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
+  sha256: 62732e34b2cdcb73846cfdf53284067d32113aae0f6d736ca30ce2b0073bce27
+  md5: ec7191b2ea4e65b5eed6f7fdd9271d28
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 769732
+  timestamp: 1717630919732
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+  sha256: e040ebcab948325fbe17e4ab15be62e1fafa7bad225457e59764adb60eb40db5
+  md5: 4d40a09df8cb74a9f044eab317436d67
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27282
+  timestamp: 1699456187703
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.60.0-py311hea22821_0.tar.bz2
+  sha256: 3d252d3b5bb30fcacf291c414d308792cb35d528aead1ebc2255e25a3ddc13d2
+  md5: 1da6aae4b3e031c95051b21ca01fd279
+  depends:
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.23.5,<1.27
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - cuda-python >=11.6
+  - libopenblas !=0.3.6
+  - numba-rvsdg 0.0.*
+  - tbb >=2021.6,<2022
+  - cudatoolkit >=11.2
+  - scipy >=1.0
+  - cuda-version >=11.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6230264
+  timestamp: 1720555663355
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.10.1-py311h4cd664f_0.tar.bz2
+  sha256: 7bf058d86876ca3d1f23b21ca8f3d9340e7f26fef9366eca092302c4fdc04e8b
+  md5: 7492afa4cb19e783c400ae35b90753cc
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21,<3
+  - numpy >=1.23.0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 210960
+  timestamp: 1730216100891
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+  sha256: 470fe9a0b3e196fa60d5550d8188f6074a207572fa0d353a4448d580872e7804
+  md5: 6fdb8df0613fb2fb9f1732d335fa25f1
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311hd01c5d8_0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11053
+  timestamp: 1708641901110
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+  sha256: 222c1711e7cf151e29077c7d4d86a865c9fd39615812d58a1daca6fd1b6bdfb5
+  md5: 585bcd8bc3940a8a859f38ebafdcd77d
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.26.4 py311hdab7c0b_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10723862
+  timestamp: 1708641867155
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+  sha256: e2afce0548808d27293a03661ee5f7ac3e18f82a92c9fb23f420eb5e92126fc6
+  md5: 9dd921a785844abe0aa842c3800d405a
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.7.0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 286986
+  timestamp: 1722872761369
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.15-h827c3e9_0.tar.bz2
+  sha256: a72f51f69a6893797b51345f9fd6b6a3b12764b435bb50e247e9e05d75711bd0
+  md5: c05007cfd519c5097f50d9c830ad897f
+  depends:
+  - ca-certificates
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8396971
+  timestamp: 1725547066793
+- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+  sha256: b2f5f50a1ddf811102636f3acebd76716c88ebb628754b91eda7a3a962adf26c
+  md5: 712527b4d84c350dca4b67f511c04414
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39421
+  timestamp: 1699371341381
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.1-py311haa95532_0.tar.bz2
+  sha256: 01e970843b748f4af6cb1600fd2736d546158c3d69584cb915a08eb6c6924fcf
+  md5: 59b0cc461ea2af7e3f344faadc91e6aa
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 157605
+  timestamp: 1720102973406
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.2-py311hea22821_0.tar.bz2
+  sha256: 1b986a8752785cd01969e737952449f5f0f4284cab7690193fa1a602156881c2
+  md5: ecfe5661d54e32e8533c02f5fd625dcb
+  depends:
+  - bottleneck >=1.3.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - lxml >=4.9.2
+  - python-calamine >=0.1.7
+  - scipy >=1.10.0
+  - xlsxwriter >=3.0.5
+  - jinja2 >=3.1.2
+  - pyxlsb >=1.0.10
+  - pymysql >=1.0.2
+  - adbc-driver-sqlite >=0.8.0
+  - fastparquet >=2022.12.0
+  - zstandard >=0.19.0
+  - xarray >=2022.12.0
+  - blosc >=1.21.3
+  - gcsfs >=2022.11.0
+  - pytables >=3.8.0
+  - qtpy >=2.3.0
+  - sqlalchemy >=2.0.0
+  - xlrd >=2.0.1
+  - dataframe-api-compat >=0.1.7
+  - fsspec >=2022.11.0
+  - psycopg2 >=2.9.6
+  - pyreadstat >=1.2.0
+  - beautifulsoup4 >=4.11.2
+  - adbc-driver-postgresql >=0.8.0
+  - pyarrow >=10.0.1
+  - html5lib >=1.1
+  - numba >=0.56.4
+  - matplotlib-base >=3.6.3
+  - openpyxl >=3.1.0
+  - odfpy>=1.4.1
+  - s3fs >=2022.11.0
+  - pyqt >=5.15.9
+  - tabulate >=0.9.0
+  - pandas-gbq >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17245139
+  timestamp: 1718309568175
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.5.3-py311haa95532_0.tar.bz2
+  sha256: b0200b6e41271d9e8d37a423315190d4e0932c9f7fbc49895bfb6dd3af815b32
+  md5: 6e9c63ef2b4e4705c1df990034b685cb
+  depends:
+  - bleach
+  - bokeh >=3.5.0,<3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.1.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing-extensions
+  constrains:
+  - holoviews >=1.18.0
+  - bokeh-fastapi >=0.1.2,<0.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24127520
+  timestamp: 1730381316612
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.1-py311haa95532_0.tar.bz2
+  sha256: e6611058e26521784b6197418505acee343ca299b7fa3f57ec23621f869e1d57
+  md5: ffd4cc05e70b156e44f242538d81ca99
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264340
+  timestamp: 1719348210484
+- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+  sha256: b0d7fbfcf1c5c682ed9934eb6a33e00a2517941f2bcb9d677379f4bb73b2c45c
+  md5: 20c8f36595a48f5cda2f4f74c02a3ea2
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48206
+  timestamp: 1698702818841
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-11.0.0-py311hb5480e2_0.tar.bz2
+  sha256: 88962ec842c1bb41b568f2fc01ba75fde3b96273dfed0c49020cfcc4a49695b5
+  md5: d35c371f08a42f2c91e1736829477729
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 981975
+  timestamp: 1731594905700
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.2-py311haa95532_0.tar.bz2
+  sha256: 9c0dc12161f77b43137dad2e520ed7a343c5d8d8fd545492336e84201d1bb74c
+  md5: 22cda044cb24e1db8fbaa5864feb4261
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3199019
+  timestamp: 1723485404416
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+  sha256: e5f8cbfb5fc25d460a9117bfc5511959c5e86ccb193316033f87bd516e0c8881
+  md5: 9f7e8b5eb651539386bb92c14e5c321b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37730
+  timestamp: 1692205554840
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py311haa95532_0.tar.bz2
+  sha256: a100d5bef5d832db705558acee7ecb4ec2471c18d13ab65fb92f7bc3b3a44ae7
+  md5: 0ae839617227e2ef40d65e85607e60d6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-clause
+  license_family: BSD
+  size: 111734
+  timestamp: 1676426983345
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+  sha256: 6c5b53831273674361437fb546e08315fc11ca9275a174bca3887987e86ced5a
+  md5: f8d91daf5173eb03157f484389adcdd4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 122178
+  timestamp: 1679591983138
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+  sha256: 546819d922b03f3a25ca9f98fd069d0588d481fc0603c6d74bd598fb6a93687f
+  md5: 86c18e3e0b67ee099457475ed6caf2e6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 751763
+  timestamp: 1704404627180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+  sha256: ae06f0dfa2cfae51404afc6d6ad3a474a93015b5ba9a7d3ea24224b8e7547987
+  md5: 3e19794c806cc3e84a3080a97c359b75
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 510466
+  timestamp: 1679005998612
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+  sha256: e2af1efb1a5094a5962d93fa949ecab479a2ae7570e030f52eeac6761383c208
+  md5: 4cb1359e22ddf8f3996afddce5f6205c
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 56638
+  timestamp: 1676438592117
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+  sha256: d95c88d06f4f3f667bd9a39e5f18179e83b3cd4c115c06ce0fff390ff6d3a700
+  md5: c6d00a8a4d89b1be99bfa3aff19d96b4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2134881
+  timestamp: 1684280285492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.2.0-py311haa95532_0.tar.bz2
+  sha256: 30ed42a98c68d6c98d48f871197c5c9c745e7545a12818a21d36689fe1a3a856
+  md5: dfd92ad9c788e9c687ca8adc3f541ce0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 486618
+  timestamp: 1731445794006
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py311hd77b12b_0.tar.bz2
+  sha256: d86b6f06ff63712d58bc0f82a6d345ec578c854051934ac73e5bd929782cd6ab
+  md5: d03b87499af4ad84a166b2d49db2bacf
+  depends:
+  - pyqt5-sip 12.13.0 py311h2bbff1b_0
+  - python >=3.11,<3.12.0a0
+  - qt-main 5.15.*
+  - qt-main >=5.15.2,<5.16.0a0
+  - sip >=6.7.12,<6.8.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 5041665
+  timestamp: 1698775563282
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py311h2bbff1b_0.tar.bz2
+  sha256: 449266141df059e53f3ae09ef2f1f10b94bc6ab51f919dc4533c32da3a0e808f
+  md5: f125f06594be8adff678b9b36861b847
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 84114
+  timestamp: 1698769459963
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+  sha256: 974c22de09078bf07c5db31fe12d8d89d6433508defc8237cbe52e08c69ed56b
+  md5: 9cf10bfd49140a527cf4b1d912097e6d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36072
+  timestamp: 1676426019064
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.10-h4607a30_0.tar.bz2
+  sha256: 0dff21c8c9ebc1e213943cfc5478902d5e4bd5d9c8f182c75c2a79ce68cdd354
+  md5: 8df15424645a9a06e0536feb3b45e516
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - openssl >=3.0.15,<4.0a0
+  - sqlite >=3.45.3,<4.0a0
+  - tk >=8.6.14,<8.7.0a0
+  - tzdata
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - openssl <3.5.7
+  license: PSF-2.0
+  license_family: PSF
+  size: 20124673
+  timestamp: 1727940469913
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+  sha256: 2c61639b3bb56fc864c86558bceb7845b1731ac44bf1a94894172ea47a995bd4
+  md5: 404805e547b4d50b5cd17e16bca87527
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332043
+  timestamp: 1716495838826
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+  sha256: 9acb33db60d9319595f52337cae3b88c2a2338cd66f1f9d8ae86d0a993c2067a
+  md5: f4af8cf94d042b4dde487241bba1c457
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279780
+  timestamp: 1679500609851
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+  sha256: 48fe7373b012b51134b6b6ff67f18d2b4aae3a5c7700e4560ce002af7172f064
+  md5: 0379cd17692152c12b662b0e4ea46b88
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18008
+  timestamp: 1683824373128
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+  sha256: 803274d986d0c4e3b5ec1018747ede86ef57137455b3e44a60e834717eafb92b
+  md5: c9f134ddeff6fdf0373a45534ddb7079
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 273009
+  timestamp: 1713974722039
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+  sha256: 6fbcba97c1dcb5157afd23f264c3cff069c7e4be5ea55980fc349eb8dc2cb49e
+  md5: 8153e3f8b3283926bcf9403804a365f5
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65050
+  timestamp: 1711137009299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+  sha256: cd33dfee104dfbba4af38d06a09ccbae6a32e7c543afedab523303319ebb283d
+  md5: 3dfc19af0306d80921e1403f1f551bba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13679916
+  timestamp: 1676423267293
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+  sha256: 102ff1d958209e3648bb49da3503cf752abab822011fdc4e12e88145c9e73772
+  md5: 0553c2c381b6f5c836b23edc8c6db2ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 246689
+  timestamp: 1677708371873
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.2-py311h827c3e9_0.tar.bz2
+  sha256: b54065893111c3bf4ab784feb9a0b7b58bd829c414adda935624790d6541885f
+  md5: 1d84022dd238ec68d7c0499885d18c86
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 209408
+  timestamp: 1728658205944
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+  sha256: ea39db411361d96545a04fb976940e9590147acb4ca9caacf7e8264780379347
+  md5: b411b8be8e53e5059949dde02dd07faf
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 565148
+  timestamp: 1709319072176
+- conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_11.tar.bz2
+  sha256: 1ee384ba28d1d2b0c096e6879c418ba65b67c7413284e14bdc7469e275fb3224
+  md5: 9cd3131723269ddb371d6dd31f50a1e8
+  depends:
+  - icu >=73.1,<74.0a0
+  - jpeg >=9e,<10a
+  - krb5 >=1.20.1,<1.21.0a0
+  - libclang >=14.0.6,<15.0a0
+  - libclang13 >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=17.0,<18.0a0
+  - openssl >=3.0.15,<4.0a0
+  - sqlite >=3.45.3,<4.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  constrains:
+  - qt >=5.15.2,<6
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 71386363
+  timestamp: 1731691366355
+- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+  sha256: 47653b45a5f2d97b5bf0dbf0e620908880f9078da427eef69012effe3f19af67
+  md5: 44e709ae67d89bccee2d4d46d358fee3
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74493
+  timestamp: 1699012356534
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py311haa95532_1.tar.bz2
+  sha256: a225c1d6a873991bed5c9e93806f0ef0af35830cd6ce09a849e20084a8372200
+  md5: 321bb6bf4f0afb4e9175bcb75ab57976
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 124386
+  timestamp: 1731000647310
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+  sha256: d6daaa6b45272819176e4aeb467ae00e3db43386548464a9993688f292709d40
+  md5: 9fe721d7f7420c259df4f07d4503f654
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9683
+  timestamp: 1683077110211
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+  sha256: 6051860575f9448aea5799d74469c928cd7cdeeca1eb53657872262a77b1a7a8
+  md5: 60e193eca497130034facd5fed168249
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10094
+  timestamp: 1683059114376
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+  sha256: ecd310461c1b45ab92ddf15539cea5a6e837860561c974d2d7393f9a7933f116
+  md5: 1762fec2838763e904141167e18b0389
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 215600
+  timestamp: 1698947891859
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.14.1-py311h9f229c6_0.tar.bz2
+  sha256: 8dfe0cf23bd8459db29ed50ceeab3fa64c3cf8feaf8a25fdec73679be403b140
+  md5: 4b2d3cf51753889b839da0b0454c4c3e
+  depends:
+  - blas 1.0 mkl
+  - icc_rt >=2022.1.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.3
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 33339059
+  timestamp: 1731625867885
+- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+  sha256: 6fd52bae6360fbc8135d72e0c1e4fd407769fa4d0f4b59356e7aed3e000eb339
+  md5: 49fd52885250da8aab17ed72e2e18b81
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88901
+  timestamp: 1699371435766
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-75.1.0-py311haa95532_0.tar.bz2
+  sha256: 229e6de8307d0463288427283e65479a1f2b8e0f4ec49edfd419bea6fb124b33
+  md5: 253b0897800b6c739dc3ee26546ddf7e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2308770
+  timestamp: 1726678611334
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py311hd77b12b_0.tar.bz2
+  sha256: f9b5386b4bbae4a6dbf2d391d482a4eb66067435234d990e0a3dd1ea8c710dee
+  md5: 46b9998433d3d70eb124f7d6480698b3
+  depends:
+  - packaging
+  - ply
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-SIP_License OR GPL-2.0-or-later OR GPL-3.0-or-later
+  license_family: GPL
+  size: 682181
+  timestamp: 1698676093853
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+  sha256: 5d1b7e14dc04816692de0f8518ea8fcbefb26ab61cec83f96f2c44c1bee67fab
+  md5: 505d2a70a875b5082dc857aa4dfab0d4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 18830
+  timestamp: 1705431395254
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+  sha256: 5ff3b4ac3fbce4dd67a87856c04698d0397deb0ac288ff4e7eb02fbab57f1253
+  md5: 0ca650a7001c6650809d3361de8cb005
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89590
+  timestamp: 1696347858925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+  sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
+  md5: 833b93a2daade3407898f15588945d83
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1440481
+  timestamp: 1714488344682
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+  sha256: 78d89b50a29fbeb19a562f5dad95615e3f192bb4f3b86cd6ea75f2f825418232
+  md5: 4a4040df560ea47704e0898c4c015808
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38069
+  timestamp: 1678228553220
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+  sha256: 70a3cc4a4e81a6421bc19cd410d1d6064aadb2b1cce38b020f85e5346716d8e7
+  md5: 32a9a2539579a3d522dce3b5cb4f987b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49495
+  timestamp: 1676425411739
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+  sha256: 0a95736cfd0bb25fc201cd6be4a2450ea8fc30eeb349d861812675b84c94fa74
+  md5: a8a9fb30c6dd8e7a16d5dcd2333c3c49
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3844176
+  timestamp: 1714770894235
+- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+  sha256: ed5950ac0c12cc87f991a6f28112cf29057e2b7ad416ae4429a0b97c3efaf58c
+  md5: b5e2a04879e6fd19f0eb5effded4dc61
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 135939
+  timestamp: 1676431438808
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.1-py311h827c3e9_0.tar.bz2
+  sha256: 04340cd171ff970c405b4b955f825cb52deb71f4420346596744bf36214ce431
+  md5: bbab95732695d5d4c759dfbd274a15ff
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 926984
+  timestamp: 1718740216876
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.5-py311h746a85d_0.tar.bz2
+  sha256: 283f31f5ef79657b27b9a6d82b5366b869744b553f90bad219714f2771b0088f
+  md5: cea2f913161c630749f8e8ac190c99f3
+  depends:
+  - colorama
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 186694
+  timestamp: 1724854118410
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
+  sha256: a724711191ac1226bf228eab49718eed7b5c7394f539294eb0f88baf8e7bb24d
+  md5: c78482e07d0aa6df9fcfa5b366dd87e3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 207744
+  timestamp: 1718227224929
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+  sha256: ab3cce654f1e94793fff0cb03b750d9b20cdbf099263b1906c3c5eaf8b347ab6
+  md5: c68ffc771312afb6f88b94c24d2bb689
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9706
+  timestamp: 1715268972001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+  sha256: 4089efea1753ebe2f6617b46cc368738f285b1d816d4a4f01ba71524f46851b4
+  md5: 7f610528ecd0b317180efa2058c32323
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 75414
+  timestamp: 1715268958140
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+  sha256: d091897f05318c22ca31028370f25355065999078f7db6f88ab27bf4cb030ec8
+  md5: 1776502c1cfb351554eeda6cddaf255f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11588
+  timestamp: 1676457729096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+  sha256: c16498f8238cc331618720d078b87995eceb6bbf20268a7a4e8efbf7b5859a9a
+  md5: 770432c0ca1ab9d99ffe95e51d3a3e74
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 517433
+  timestamp: 1713213261710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.3-py311haa95532_0.tar.bz2
+  sha256: de79b019200fdeb430ce7971edaa7af403cbfc1b52e1bdca6e496c6eeaf6b37f
+  md5: ba54713eec74d8c2636f137608ad8959
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - selenium >=4.4.3
+  - zstandard >=0.18.0
+  - h2 >=4,<5
+  - requests >=2.26.0
+  license: MIT
+  license_family: MIT
+  size: 218619
+  timestamp: 1727770119876
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.40-h2eaa2aa_1.tar.bz2
+  sha256: 5bbfaacd95bb901683d6d2e7a1ee10f67172acc1e012f73f80bfef5237ae3ae4
+  md5: f37ef4381071123903074612dad356f4
+  depends:
+  - vs2015_runtime >=14.40.33807
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9122
+  timestamp: 1726064402583
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.40.33807-h98bb1dd_1.tar.bz2
+  sha256: d82b5b2b1a9a1b37da109039274c125355ce478a199c07c7826ac0fdc2178491
+  md5: a0f93c06400da31b9e6e0538eab91216
+  size: 2611238
+  timestamp: 1726064391949
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+  sha256: 24ea3d3e0cb98d0d246338dbb4562b67967bb32002e3704e495a5c863476e831
+  md5: c7b9cdbe87b3c9720aeca1164a0fd6df
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26181
+  timestamp: 1676424437003
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+  sha256: 92d27e41ce34387e59acb47572fcb2e92c4defaeadafd11ce190226022023e69
+  md5: f1bf142d852987acbe4b0bc94e87d958
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145306
+  timestamp: 1715878654770
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.44.0-py311haa95532_0.tar.bz2
+  sha256: 2eb16eafe8322ad10c73b19be8f2c8b6135561bead6f73f48c069417f5db8928
+  md5: b28ec461da7eac99523f146ae752529b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 170318
+  timestamp: 1726165294131
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+  sha256: 17fadf35aa8917c107e7b369e9364ac7c09537776e7943d37e225e14b7026c94
+  md5: 0e67c3b9624540581b894b11267a837b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PUBLIC-DOMAIN
+  size: 10197
+  timestamp: 1676425485716
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+  sha256: 25373efabba9a866849fe38a47c79e0fa323851b4bd4b5df357cc8d5617c2786
+  md5: a958e9d32c3b65c21e11e5d9e8491c43
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2467966
+  timestamp: 1689041676824
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+  sha256: b849b368e27920838fe40a512b102879693a55cb187dd1c8d3a83fa8c05a8054
+  md5: 7b1f6e9c71906a93039b3446b99a5498
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55114
+  timestamp: 1676434863173
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+  sha256: 344a5276a9928638dcde054dfe4e87c8cb40bd2d4d356378b9ab2f863ca62e4b
+  md5: fe471fd8b5a3d77be6fa5dbf9b99dafb
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 1432281
+  timestamp: 1714515119689
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+  sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
+  md5: e5aed81295b61b6d1eb62830799a0297
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 9125184
+  timestamp: 1705602328351
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.20.2-py311haa95532_0.tar.bz2
+  sha256: 269c2391ea63485d1bc1a0ac334425b9911782a97cd3c5cebf73b2ed224f0d77
+  md5: 61ed0fa3bd33349afb499de32b882766
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 29698
+  timestamp: 1729012608017
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+  sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
+  md5: f295b54ab59f5b8658e2a322ac6aa721
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 162161
+  timestamp: 1714514792081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
+  sha256: 1f68cd378c6cdec34a5a3a21c56c9b8422b0f037b868b3db72065c0a2ca27921
+  md5: d455a04486eddfb94c280974c0c33ae3
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1971698
+  timestamp: 1728487049972
+- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+  sha256: 98f3bae3caff4c52615ddb56405dc51b39d9d2c47a9bccd130a5a19d10304245
+  md5: de1b7f7c8221028f6bbe103df4c53bed
+  depends:
+  - m2w64-gcc-libs-core
+  - msys2-conda-epoch >=20160418
+  license: GPL, LGPL, FDL, custom
+  size: 348607
+- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+  sha256: 2fb6488298a659c781f9294a743b0b376d9998a6b06aa2a3b85b49c38a85ea16
+  md5: 0b9caac6747002340b057a222af705b2
+  depends:
+  - m2w64-gcc-libgfortran
+  - m2w64-gcc-libs-core
+  - m2w64-gmp
+  - m2w64-libwinpthread-git
+  - msys2-conda-epoch >=20160418
+  license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  size: 530578
+- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+  sha256: 449df9debaf202928e3a0db1f059ef35b1bcb3973fa92e217ca2775f82415111
+  md5: 276d396bfe8d958f71173b7134f739fa
+  depends:
+  - m2w64-gmp
+  - m2w64-libwinpthread-git
+  - msys2-conda-epoch >=20160418
+  license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  size: 217686
+- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+  sha256: 5cf23439eef17ae158d63ff3f85f77d1dca9a45b19324fdeda9e3e48ae298d18
+  md5: fec04371463ec68eb8f5752a22c5b030
+  depends:
+  - msys2-conda-epoch >=20160418
+  license: LGPL3
+  size: 705647
+- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+  sha256: 9373b0157e08cbea09298f461d2816833281b3e22a8c9f6c5a38d7109c8a281e
+  md5: 67e61e700eb27424979778fae9293f13
+  depends:
+  - msys2-conda-epoch >=20160418
+  license: MIT, BSD
+  size: 30543
+- conda: https://repo.anaconda.com/pkgs/msys2/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+  sha256: d6a55d779052bca9accd534398b4e147d0a3dfc8f4b6528391ee9c15843784bc
+  md5: 6eaef3074f65f715ed1ca6b8a08be3aa
+  size: 2065

--- a/opensky/pixi.lock
+++ b/opensky/pixi.lock
@@ -7,773 +7,773 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.6.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-24.2.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.4.2-py311hf4808d0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.9.24-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.8.30-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py311h1fdaa30_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cramjam-2.7.0-py311h24d97f6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cyrus-sasl-2.1.28-h52b45da_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.8.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.16.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.6.3-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-2024.2.0-py311hf4808d0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.14.1-h55d465d_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.6.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.78.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-tools-2.78.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.1-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.1-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.20.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.11.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.27.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.23.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libabseil-20240116.2-cxx17_h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang-14.0.6-default_hc6dbbc7_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang13-14.0.6-default_he11475f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcups-2.4.2-h2d74bed_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.9.1-h251f7ec_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libglib-2.78.4-hdc74915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hecde1de_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpq-17.0-hdbd6064_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-4.25.3-he621ea3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.11.0-h251f7ec_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxkbcommon-1.0.1-h097e994_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.13.1-hfdd30dd_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.43.0-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.9.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.9.2-py311h6fb44e5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.11-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.8-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mysql-8.4.0-h29a9f33_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.16.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.60.0-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.10.1-py311h3c60e43_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openldap-2.6.4-h42fbc30_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.15-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.2-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.5.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-11.0.0-py311hfdbf927_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ply-3.11-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.2.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.15.10-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt5-sip-12.13.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.10-he870216_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-main-5.15.2-hb6262e9_11.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.14.1-py311h08b1b3b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-75.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-6.7.12-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.1-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.5-py311h92b7b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.44.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.20.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-4.6.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-24.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-3.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.4.2-py311hf4808d0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2024.9.24-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2024.8.30-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.17.1-py311h1fdaa30_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cloudpickle-3.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cramjam-2.7.0-py311h24d97f6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cyrus-sasl-2.1.28-h52b45da_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dask-core-2024.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/datashader-0.16.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/expat-2.6.3-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fastparquet-2024.2.0-py311hf4808d0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fontconfig-2.14.1-h55d465d_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fsspec-2024.6.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/glib-2.78.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/glib-tools-2.78.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gst-plugins-base-1.14.1-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gstreamer-1.14.1-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.20.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/hvplot-0.11.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.29.5-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.27.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.19.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.4-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.23.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libabseil-20240116.2-cxx17_h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libclang-14.0.6-default_hc6dbbc7_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libclang13-14.0.6-default_he11475f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libcups-2.4.2-h2d74bed_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libcurl-8.9.1-h251f7ec_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libglib-2.78.4-hdc74915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libllvm14-14.0.6-hecde1de_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpq-17.0-hdbd6064_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libprotobuf-4.25.3-he621ea3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libssh2-1.11.0-h251f7ec_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxkbcommon-1.0.1-h097e994_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxml2-2.13.1-hfdd30dd_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.43.0-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-3.9.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.9.2-py311h6fb44e5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.11-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.8-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mysql-8.4.0-h29a9f33_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.16.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.10.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numba-0.60.0-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.10.1-py311h3c60e43_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openldap-2.6.4-h42fbc30_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.15-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-24.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-2.2.2-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-1.5.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-2.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-11.0.0-py311hfdbf927_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-24.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ply-3.11-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyqt-5.15.10-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyqt5-sip-12.13.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.11.10-he870216_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.2-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/qt-main-5.15.2-hb6262e9_11.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.32.3-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scipy-1.14.1-py311h08b1b3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-75.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sip-6.7.12-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.4.1-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.66.5-py311h92b7b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-2.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.44.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.20.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.6.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.2.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.4.2-py311h9b7fc35_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.9.24-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.8.30-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py311h9205ec4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cramjam-2.7.0-py311h9c86198_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2024.8.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.16.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-2024.2.0-py311hb3a5e46_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.6.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.20.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.11.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.27.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.23.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h26321d7_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.43.0-py311h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.9.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.9.2-py311hc25a08b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.60.0-py311he327ffe_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.10.1-py311hc59c7be_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h91b6869_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311hb3ec012_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.15-h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.2-py311he327ffe_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.5.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-11.0.0-py311h9c91434_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.2.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.10-h4d6d9e5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py311h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.14.1-py311hedc7b93_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-75.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.1-py311h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.5-py311h85bffb1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.44.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.20.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-4.6.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-24.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-3.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.4.2-py311h9b7fc35_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2024.9.24-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2024.8.30-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.17.1-py311h9205ec4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cloudpickle-3.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cramjam-2.7.0-py311h9c86198_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/dask-core-2024.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/datashader-0.16.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fastparquet-2024.2.0-py311hb3a5e46_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fsspec-2024.6.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.20.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/hvplot-0.11.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.29.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.27.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.19.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.23.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libllvm14-14.0.6-h26321d7_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.43.0-py311h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-3.9.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.9.2-py311hc25a08b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.16.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.10.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numba-0.60.0-py311he327ffe_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.10.1-py311hc59c7be_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.4-py311h91b6869_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.4-py311hb3ec012_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.15-h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-24.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-2.2.2-py311he327ffe_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-1.5.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-2.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-11.0.0-py311h9c91434_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-24.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.11.10-h4d6d9e5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.2-py311h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.32.3-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scipy-1.14.1-py311hedc7b93_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-75.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.4.1-py311h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.66.5-py311h85bffb1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-2.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.44.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.20.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.6.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-24.2.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.4.2-py311hb9f6ed7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.9.24-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.8.30-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cramjam-2.7.0-py311h62f922a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.8.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.16.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-2024.2.0-py311hb9f6ed7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.6.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.20.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.11.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.27.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.23.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h19fdd8a_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.43.0-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.9.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.9.2-py311hecf7826_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.60.0-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.10.1-py311h5d9532f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.15-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.2-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.5.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-11.0.0-py311hfaf4e14_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.2.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.10-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.2-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.14.1-py311hac8794a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-75.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.1-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.5-py311hb6e6a13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.44.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.20.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.6.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-24.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.4.2-py311hb9f6ed7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2024.9.24-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.8.30-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-3.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cramjam-2.7.0-py311h62f922a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2024.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/datashader-0.16.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fastparquet-2024.2.0-py311hb9f6ed7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2024.6.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.20.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/hvplot-0.11.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.29.5-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.27.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.19.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.4-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.23.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libllvm14-14.0.6-h19fdd8a_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.43.0-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-3.9.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.9.2-py311hecf7826_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.16.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.10.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numba-0.60.0-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.10.1-py311h5d9532f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.15-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-24.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.2.2-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-1.5.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-2.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-11.0.0-py311hfaf4e14_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-24.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.11.10-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.2-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.32.3-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.14.1-py311hac8794a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-75.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.4.1-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.66.5-py311hb6e6a13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.44.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.20.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.6.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-24.2.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.4.2-py311h57dcf0c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.9.24-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.8.30-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py311h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cramjam-2.7.0-py311h005caf5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.8.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.16.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-2024.2.0-py311hd7041d2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.6.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.20.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.11.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.27.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.23.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-17.0-h70ee33d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.43.0-py311hf2fb9eb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.9.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.9.2-py311h472561b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.11-py311h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.8-py311hea22821_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.60.0-py311hea22821_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.10.1-py311h4cd664f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.15-h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.2-py311hea22821_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.5.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-11.0.0-py311hb5480e2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.2.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.10-h4607a30_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.2-py311h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_11.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.14.1-py311h9f229c6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-75.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.1-py311h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.5-py311h746a85d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.40-h2eaa2aa_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.40.33807-h98bb1dd_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.44.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.20.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gmp-6.1.0-2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-4.6.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-24.2.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-3.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.4.2-py311h57dcf0c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2024.9.24-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2024.8.30-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.17.1-py311h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cloudpickle-3.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cramjam-2.7.0-py311h005caf5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/dask-core-2024.8.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/datashader-0.16.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fastparquet-2024.2.0-py311hd7041d2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fsspec-2024.6.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.20.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/hvplot-0.11.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.29.5-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.27.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.19.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.4-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.23.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpq-17.0-h70ee33d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/llvmlite-0.43.0-py311hf2fb9eb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-3.9.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.9.2-py311h472561b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.11-py311h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.8-py311hea22821_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-7.16.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.10.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numba-0.60.0-py311hea22821_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.10.1-py311h4cd664f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.15-h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-24.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-2.2.2-py311hea22821_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-1.5.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-2.1.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-11.0.0-py311hb5480e2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-24.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ply-3.11-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.2.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyqt-5.15.10-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyqt5-sip-12.13.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.11.10-h4607a30_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.2-py311h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/qt-main-5.15.2-h19c9488_11.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.32.3-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scipy-1.14.1-py311h9f229c6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-75.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sip-6.7.12-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.4.1-py311h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.66.5-py311h746a85d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-2.2.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.40-h2eaa2aa_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.40.33807-h98bb1dd_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.44.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.20.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
+      - conda: https://conda.anaconda.org/msys2/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+      - conda: https://conda.anaconda.org/msys2/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+      - conda: https://conda.anaconda.org/msys2/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+      - conda: https://conda.anaconda.org/msys2/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+      - conda: https://conda.anaconda.org/msys2/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+      - conda: https://conda.anaconda.org/msys2/win-64/msys2-conda-epoch-20160418-1.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
   sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
   md5: 613805add1c05b538ff06d217252feb7
   depends:
@@ -784,7 +784,7 @@ packages:
   license: BSD-3-Clause
   size: 20810
   timestamp: 1652859733309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.6.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-4.6.2-py311h06a4308_0.tar.bz2
   sha256: d58b068fe1b9c195394e77a6fba4d152c6934e97df7757dd6b921498f8aa72f8
   md5: 09de3b2d5519a680bda3c3771380c3da
   depends:
@@ -798,7 +798,7 @@ packages:
   license_family: MIT
   size: 243587
   timestamp: 1729121303719
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
   sha256: 0d4f5274503916e1c683dcc16e8a7c4186557afa3f62399cd628e4eb535fe77a
   md5: 062acdb0f9ae976c25c2d15d589dc1d6
   depends:
@@ -809,7 +809,7 @@ packages:
   license_family: MIT
   size: 35809
   timestamp: 1676823571351
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-24.2.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-24.2.0-py311h06a4308_0.tar.bz2
   sha256: 5d82019951fb117a34fdc8be3650ba14ad0cee866549cfc61e345c65782a002a
   md5: 64e97e61d50f90fd609f91c2c5407233
   depends:
@@ -818,7 +818,7 @@ packages:
   license_family: MIT
   size: 162482
   timestamp: 1729089522263
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
   sha256: 5bb9bfe025d9a49af272f194278f63cea7366e83bdf3f99d25f97b820d522089
   md5: 100d3161d97332fe38945afec8d36935
   depends:
@@ -828,12 +828,12 @@ packages:
   license_family: MIT
   size: 276381
   timestamp: 1718029864701
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-3.6.0-py311h06a4308_0.tar.bz2
   sha256: 30dedc2bed0aa72523531f5e22fff96c948bb2f68addb625161ef50b07484fb9
   md5: 1571b1a2aded9cbd3c0c7656e9a9ebbe
   depends:
@@ -851,7 +851,7 @@ packages:
   license_family: BSD
   size: 5853990
   timestamp: 1727914619438
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.4.2-py311hf4808d0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.4.2-py311hf4808d0_0.tar.bz2
   sha256: de78a7f35a57c21d8986c1084f308c98477747d6a92a0b23b5d4855333eee0c9
   md5: 85399e523becae3ca29054b3d579b8e7
   depends:
@@ -862,7 +862,7 @@ packages:
   license_family: BSD
   size: 148890
   timestamp: 1731058903578
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
   sha256: 5d15605858771290fdaaae41a43941623757a25cb1292080d69d6d3857807935
   md5: 7f517469aa5380c52e55db9f37df104f
   depends:
@@ -873,7 +873,7 @@ packages:
   license: MIT
   size: 18652
   timestamp: 1714483267080
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
   sha256: a5094f078584e27c7cced4a9564ae904a329f5c1702a7c1ba092d581ba1544f1
   md5: 6ddf45dd8a21a9512481de9bc0e5a03f
   depends:
@@ -883,7 +883,7 @@ packages:
   license: MIT
   size: 19711
   timestamp: 1714483255915
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
   sha256: 93180c973816246f068b742d0bf64840f0ea48e31d4f9b0747ea2ffc34d8855d
   md5: f3a00096965a5ba1eb41d2c99a4662a2
   depends:
@@ -893,7 +893,7 @@ packages:
   license: MIT
   size: 361574
   timestamp: 1714483400014
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
   sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
   md5: f5058c8d5b2994b7334f18e022105a14
   depends:
@@ -902,7 +902,7 @@ packages:
   license_family: BSD
   size: 427542
   timestamp: 1714510571510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
   sha256: 5b4c80587ae4ec915505469f79d866f27c80456156667c8548d31c67c2c1653e
   md5: c3d6bfae757760082261779c406a880d
   depends:
@@ -911,14 +911,14 @@ packages:
   license_family: MIT
   size: 116270
   timestamp: 1693902021950
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.9.24-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2024.9.24-h06a4308_0.tar.bz2
   sha256: e9f2e55d34b1b0b9b48e48a1d6e4503653f8b7059114d23f758b7c68dde2334a
   md5: 4a091502b44d4090f30f0be847a8139c
   license: MPL-2.0
   license_family: Other
   size: 139901
   timestamp: 1727794854964
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.8.30-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2024.8.30-py311h06a4308_0.tar.bz2
   sha256: 6c769a7cae15ec611e2a3cc9ccfe646b6027f60c2822811b3f60f589a8c51d8f
   md5: 6ffd4b4a690cad0ee056e659db868f56
   depends:
@@ -927,7 +927,7 @@ packages:
   license_family: Other
   size: 169012
   timestamp: 1725551779652
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py311h1fdaa30_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.17.1-py311h1fdaa30_0.tar.bz2
   sha256: e0fbb102b3423152b4ec6d633ee8883628df58b80c8b44b0c6321b869106a68d
   md5: 1febf11ae23feb3458c028479574c878
   depends:
@@ -939,7 +939,7 @@ packages:
   license_family: MIT
   size: 304269
   timestamp: 1726856473093
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
   sha256: 9ddbf05887c7d7926418520cc7848e57f6d2431bc4ec6d30e090b02dbf865041
   md5: 57ae1141ad9a048fb2a75d7a3ef7430a
   depends:
@@ -948,7 +948,7 @@ packages:
   license_family: BSD
   size: 203190
   timestamp: 1698129926216
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cloudpickle-3.0.0-py311h06a4308_0.tar.bz2
   sha256: 017b35122f533e4ffc48bb3e0c6fd1f16e8cbb2a67d40b3f6572b77511ffe26d
   md5: 75eb58b2cdb0ddf4e93293cf973a0829
   depends:
@@ -957,7 +957,7 @@ packages:
   license_family: BSD
   size: 41983
   timestamp: 1721657369906
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
   sha256: d9c102b9ec7f3a635936b6f73d4db126d748a25f65407353bd76b260dc7d1cd6
   md5: eec48dbdf5dac0ea26750cc26b58c1d9
   depends:
@@ -966,7 +966,7 @@ packages:
   license_family: CC
   size: 554986
   timestamp: 1709758392744
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
   sha256: 882481e441b9b93cbdfb32fbe32a6ad9f26197472f186a08fddb921f61346c02
   md5: 443c79196064f57c98199e9990544b2f
   depends:
@@ -976,7 +976,7 @@ packages:
   license_family: BSD
   size: 16902
   timestamp: 1709322958614
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
   sha256: e4877b41553e31b9f9f090dffab77a654255c63776e8b30fc91ec1f60afadbf1
   md5: c34d3f1520f1e8c9957eb236710058c4
   depends:
@@ -988,7 +988,7 @@ packages:
   license_family: BSD
   size: 281162
   timestamp: 1700583651472
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cramjam-2.7.0-py311h24d97f6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cramjam-2.7.0-py311h24d97f6_0.tar.bz2
   sha256: 7bb1fd85aaba31403b00722d6f142220031788e391fdaad899c816595cb3ae5d
   md5: 6673633f2374304790bfdcaa334b14ae
   depends:
@@ -998,7 +998,7 @@ packages:
   license_family: MIT
   size: 1528662
   timestamp: 1702651329660
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cyrus-sasl-2.1.28-h52b45da_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cyrus-sasl-2.1.28-h52b45da_1.tar.bz2
   sha256: 4e7eb5911636f3cac2bb22c85d56a8edf946cfd6379e8b7be6136ffdaf669c22
   md5: dcabb2d653147fd807cf6edeb2c3522b
   depends:
@@ -1010,7 +1010,7 @@ packages:
   license_family: BSD
   size: 239169
   timestamp: 1688045783866
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.8.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dask-core-2024.8.2-py311h06a4308_0.tar.bz2
   sha256: eeb6264edb355734090537f71628c795493e5848867c05fb5fd624b9c0899c64
   md5: f2d72f1b4ba65ae83f861b1c1245a22c
   depends:
@@ -1027,7 +1027,7 @@ packages:
   license_family: BSD
   size: 3116663
   timestamp: 1725461379792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.16.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/datashader-0.16.3-py311h06a4308_0.tar.bz2
   sha256: 0333d880caa9352ba4d49ecbd3c6282a362e574374c34c07e60f7dc3168a4e39
   md5: 6bfb802c6e2297eca13453c609826efc
   depends:
@@ -1050,7 +1050,7 @@ packages:
   license_family: BSD
   size: 18020969
   timestamp: 1720534125523
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
   sha256: 469debfa966d24b8372aaf909ecbe27dc6fde186f6f0d5b9e0a8427e38053364
   md5: 498d0788982ec4c5d13a44359b9c7afb
   depends:
@@ -1060,7 +1060,7 @@ packages:
   license: GPL2
   size: 600218
   timestamp: 1602701107852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
   sha256: 3b4cd8dc60572086f1a1cbb97e2712e0ffd55317ce8f0309d552eee7367855eb
   md5: 70a1263b6e19bf2d77c020a2e77277c9
   depends:
@@ -1071,7 +1071,7 @@ packages:
   license_family: MIT
   size: 2556575
   timestamp: 1690905285843
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
   sha256: 4b589e3265c74159130230c164ff2d8d381be65899a249def0b53f93ce83fd47
   md5: 245cb7173dcdba21cf368031cd87f706
   depends:
@@ -1080,7 +1080,7 @@ packages:
   license_family: MIT
   size: 17434
   timestamp: 1676823330845
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.6.3-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/expat-2.6.3-h6a678d5_0.tar.bz2
   sha256: 4239a7e8973dadc127940fb25e63a07a7ec9627c39687ae4742ce561e4fd0d63
   md5: 2a9b1536c3f7f922a2b63fa2981e447a
   depends:
@@ -1090,7 +1090,7 @@ packages:
   license_family: MIT
   size: 200780
   timestamp: 1725543341127
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-2024.2.0-py311hf4808d0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fastparquet-2024.2.0-py311hf4808d0_0.tar.bz2
   sha256: b7f0f6cc1213a6f36d1ca1844b6fa918833a737703f54e719bd71cd3b39eba9e
   md5: 9aa84ee8cddc8aaa057295e1853c3ad2
   depends:
@@ -1105,7 +1105,7 @@ packages:
   license_family: Apache
   size: 683044
   timestamp: 1715262508371
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.14.1-h55d465d_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fontconfig-2.14.1-h55d465d_3.tar.bz2
   sha256: dcb04f684a0182e8161eb607488cef61ad121b72eda8794b1072aad621663016
   md5: 7fbedeb920dc384a9873983a4abf62a7
   depends:
@@ -1119,7 +1119,7 @@ packages:
   license_family: MIT
   size: 343714
   timestamp: 1722921016734
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
   sha256: b75d12e85274660bb675a3e53d47a929872f2daa2ff5a76e98885ee3f2d19ad1
   md5: f2119d0885334060d0d7fe59e5220287
   depends:
@@ -1138,7 +1138,7 @@ packages:
   license_family: MIT
   size: 3237908
   timestamp: 1713551660998
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
   sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
   md5: a5dc8677d891dff2393b63189a3ad42f
   depends:
@@ -1149,7 +1149,7 @@ packages:
   license_family: Other
   size: 971975
   timestamp: 1666798278693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.6.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fsspec-2024.6.1-py311h06a4308_0.tar.bz2
   sha256: eb7d7646fbda149ab0291100cb5d5d964b93b04aae9423eddf7d9fae1e45f0ef
   md5: cde515ecf78e4d4b9f6c2290eb00a952
   depends:
@@ -1160,7 +1160,7 @@ packages:
   license_family: BSD
   size: 382658
   timestamp: 1724855656158
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.78.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/glib-2.78.4-h6a678d5_0.tar.bz2
   sha256: d9a486f0ac92b1365365c3e536040a552c2de633283f27129f16dadcbc6d2de8
   md5: 32538e0c24874a85011a094217830bd4
   depends:
@@ -1173,7 +1173,7 @@ packages:
   license_family: LGPL
   size: 499006
   timestamp: 1708031707428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-tools-2.78.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/glib-tools-2.78.4-h6a678d5_0.tar.bz2
   sha256: cc7d3a52acad1df08e3d4ec7eefb22f41320e7eada94e78bf4b051128cbe72d4
   md5: d8dcbf2be12799cf7f333c21a0e91990
   depends:
@@ -1184,7 +1184,7 @@ packages:
   license_family: LGPL
   size: 112595
   timestamp: 1708031685927
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.1-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/gst-plugins-base-1.14.1-h6a678d5_1.tar.bz2
   sha256: 833208211f0ecb52198f5fae585f937be3c337c15b4569d8f1a28638545250d5
   md5: 2fa837925e0633ceae4ec826f6daa93f
   depends:
@@ -1196,7 +1196,7 @@ packages:
   - zlib >=1.2.11,<2.0.0a0
   size: 2253949
   timestamp: 1677171916164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.1-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/gstreamer-1.14.1-h5eee18b_1.tar.bz2
   sha256: 8257a1c1c967d48561f62adb649fe21c467f0a37c41f783ba6e2c6d79fa1cc4f
   md5: 5cd8e1f16b1ce869d0c3a98b9f0897fb
   depends:
@@ -1204,7 +1204,7 @@ packages:
   - libgcc-ng >=11.2.0
   size: 1690003
   timestamp: 1677171850557
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.20.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.20.0-py311h06a4308_0.tar.bz2
   sha256: 97633f085c543505ab0ed53de62bbe516ffdef26f11449a5a361ef6303b3142d
   md5: 8b2ed66ea48b7e6fef1018404ddf93f1
   depends:
@@ -1224,7 +1224,7 @@ packages:
   license_family: BSD
   size: 6141733
   timestamp: 1730827820330
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.11.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/hvplot-0.11.1-py311h06a4308_0.tar.bz2
   sha256: 030ab24bf564d3fddbd2837766640042cc51b202a28ca8a892b4021d5a5cc12f
   md5: ea48f120eed7aa3e55518d4df50c97ad
   depends:
@@ -1241,7 +1241,7 @@ packages:
   license_family: BSD
   size: 364229
   timestamp: 1729516850422
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
   sha256: b35b281dbf69b826c6ae04fcd7b6a2d1f098277a669a199906a1f23b4b0931a5
   md5: 2a793fe24f85aa5819fe69c450cba6f7
   depends:
@@ -1251,7 +1251,7 @@ packages:
   license_family: MIT
   size: 29021241
   timestamp: 1692293243228
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
   sha256: e08e27531775de40f46b6ac7bf71856963baa0c008bd2b4d112e6341cd3e8f4c
   md5: bfc7682613c861cbcb4ac01485c05657
   depends:
@@ -1260,7 +1260,7 @@ packages:
   license_family: BSD
   size: 147174
   timestamp: 1714398938840
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-7.0.1-py311h06a4308_0.tar.bz2
   sha256: c7ffa6006573483a05ef355770c3201f04dd04ab4b91ae01971a6cdc7fbdba35
   md5: 23d7d38e93d930ea5e2cc5f4079d3816
   depends:
@@ -1270,7 +1270,7 @@ packages:
   license_family: APACHE
   size: 49872
   timestamp: 1704813633807
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
   sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
   md5: 3add2ce56858a1b8f6a37342f82773d3
   depends:
@@ -1286,7 +1286,7 @@ packages:
   license_family: Proprietary
   size: 19310769
   timestamp: 1699647799237
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.29.5-py311h06a4308_0.tar.bz2
   sha256: fe68041ab6344e8f2a6dd8e42032bc1332e22bc8c268e74b81e00fe10e35b822
   md5: 382be07ff80150df0b66abae64059a40
   depends:
@@ -1307,7 +1307,7 @@ packages:
   license_family: BSD
   size: 238033
   timestamp: 1728665623948
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.27.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.27.0-py311h06a4308_0.tar.bz2
   sha256: 466a9ff4b27043bc48c6e619fe458a4d6390d7db1cc3096d971b6a6166212ee9
   md5: e58614cdf643d299d1faf06bd2b92327
   depends:
@@ -1325,7 +1325,7 @@ packages:
   license_family: BSD
   size: 1633729
   timestamp: 1726064436441
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.19.1-py311h06a4308_0.tar.bz2
   sha256: 527d00eacde56f9f8c391dacfca0f55c5c750c45c6400d6220b49e3ee36e5636
   md5: a4b061aee54081589532e93572722769
   depends:
@@ -1335,7 +1335,7 @@ packages:
   license_family: MIT
   size: 1175236
   timestamp: 1721058517965
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.4-py311h06a4308_1.tar.bz2
   sha256: 1cf0f40f4bbb90b1280c32ddfa7e9a7b36b82e88a467c994b4c698c3d41ce5f2
   md5: 0731cad6883721022d93fbd62ffe1edc
   depends:
@@ -1347,7 +1347,7 @@ packages:
   license_family: BSD
   size: 356018
   timestamp: 1730903056980
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
   sha256: 8316ae3abee25edab89788ee6e9eef79c398aba192559f514674a04ee1860bca
   md5: 112209aed451545a622ab217c70f6972
   depends:
@@ -1356,7 +1356,7 @@ packages:
   license_family: Other
   size: 283506
   timestamp: 1722872662693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.23.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.23.0-py311h06a4308_0.tar.bz2
   sha256: caafff289b6a96f7f13668faa72e7a85346f410b1f97dc34163f70746bb98f1b
   md5: 27d1820c6bd6185aa888ee994d290bf1
   depends:
@@ -1369,7 +1369,7 @@ packages:
   license_family: MIT
   size: 192447
   timestamp: 1728486794980
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
   sha256: 9e3bac2d41bd432b721b009e7de981766fba396e6f238e923f304112bd88655a
   md5: 84ae4cf3f2d01fbebdac374971192be9
   depends:
@@ -1379,7 +1379,7 @@ packages:
   license_family: MIT
   size: 15525
   timestamp: 1699032521315
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
   sha256: 79ce6dff3d93649a2555b1d2a4ae9eb77175a1c00664cb8eb0e6f848d5cdd1b9
   md5: db395b0efd7018fcf3a4af879170c2a8
   depends:
@@ -1395,7 +1395,7 @@ packages:
   license_family: BSD
   size: 276856
   timestamp: 1676823504812
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
   sha256: 91cca0ba49accdc9e97463bee087244a27ad107eb3af9ccb91634239f8b10f72
   md5: a185824bfc55bd90e1cf9330b417b74c
   depends:
@@ -1406,7 +1406,7 @@ packages:
   license_family: BSD
   size: 97359
   timestamp: 1718818381635
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
   sha256: 540f8dfb7cdc3877b4e24d6af65696d0bc7eae5de1c307229f86b3fe601a2286
   md5: f650f8c007471f6ef6c1a292918d2e1f
   depends:
@@ -1422,7 +1422,7 @@ packages:
   license_family: BSD
   size: 41920
   timestamp: 1718738122846
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
   sha256: 398387b6f1ee1691b04a31fedd1320225e5553aa921b06bc013f010a0008621e
   md5: bac66634a9133c633ddc879e14e83f23
   depends:
@@ -1449,7 +1449,7 @@ packages:
   license_family: BSD
   size: 610854
   timestamp: 1718827113534
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
   sha256: ddfee06ba9b149222c65d1d4270272840533aa63b56fe36363c84a891c71d328
   md5: ee128e5c0d8d9e1952e2387b66a5b8cb
   depends:
@@ -1459,7 +1459,7 @@ packages:
   license_family: BSD
   size: 27239
   timestamp: 1686870958829
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
   sha256: 0c6a074272ed58677ec17e4dbfceaffd2108841a61af92b32f156c5763108d1d
   md5: dd3d37841d0d20c70a60e8c939923894
   depends:
@@ -1471,7 +1471,7 @@ packages:
   license_family: BSD
   size: 19144
   timestamp: 1700168632051
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
   sha256: b040f0d0ee4588188ab6b83a93738b3ff6e6d1775424be97995bd0df0f4fb904
   md5: eae62735d710cf5ff6d51e6f59fcd999
   depends:
@@ -1482,7 +1482,7 @@ packages:
   license_family: BSD
   size: 78148
   timestamp: 1676827253282
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
   sha256: 01bae3dd44469e34f043e0416f5f5e658429bf4031745399d9968d10b899e2c4
   md5: 10171cca67e3d73c3646c6dc5a321460
   depends:
@@ -1494,7 +1494,7 @@ packages:
   license_family: MIT
   size: 1427115
   timestamp: 1686931095252
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -1505,7 +1505,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
   sha256: 069d33aebaf4db4ae410d4acb4851860a69d2c8f326fd45ab2a67b67fe276e6d
   md5: 61689da52cf1fcebda8c9fb2872f94bf
   constrains:
@@ -1513,7 +1513,7 @@ packages:
   license: GPL-3.0-only
   size: 723073
   timestamp: 1727336193185
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
   sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
   md5: 88199c75f2ac211728febced7785c24e
   depends:
@@ -1523,7 +1523,7 @@ packages:
   license_family: Apache
   size: 228278
   timestamp: 1635523146417
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libabseil-20240116.2-cxx17_h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libabseil-20240116.2-cxx17_h6a678d5_0.tar.bz2
   sha256: 799f5e019772d5d774c07dbb8b8d633e0b559921c8ab16ab2276aca1ca4f2fa2
   md5: fe4de116b00c2c7eb7d307a58eef7429
   depends:
@@ -1536,7 +1536,7 @@ packages:
   license_family: Apache
   size: 1316915
   timestamp: 1716563364037
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
   sha256: bb990ea068c3b3dafd9c807e0e19570320cb2fe7d69cc326f1f0b5319b0654b2
   md5: 3ff70744e396b1af69656c574b05c3b9
   depends:
@@ -1544,7 +1544,7 @@ packages:
   license: MIT
   size: 66940
   timestamp: 1714483221853
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
   sha256: 3b87a816f72a00e1f0022a160e7eda70af89d3de2a2e08a72be1c17b31d759f3
   md5: 4f57d3a0a13ddaf1c06efb586b702f46
   depends:
@@ -1553,7 +1553,7 @@ packages:
   license: MIT
   size: 34446
   timestamp: 1714483232430
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
   sha256: 2cf15e89f910600f468edfde8d0f9b80a14fa2319ed89160dc7375dfd3764fdb
   md5: 463adc13f2feea3570d1eccac368d9e4
   depends:
@@ -1562,7 +1562,7 @@ packages:
   license: MIT
   size: 295090
   timestamp: 1714483244460
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang-14.0.6-default_hc6dbbc7_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libclang-14.0.6-default_hc6dbbc7_1.tar.bz2
   sha256: 46646ce93dafb4922f4597c34c4fec106b4ff3b9707a202387f7964601e47876
   md5: 5eaf417727302b441025661154fc4587
   depends:
@@ -1575,7 +1575,7 @@ packages:
   license_family: Apache
   size: 130632
   timestamp: 1681222907766
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang13-14.0.6-default_he11475f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libclang13-14.0.6-default_he11475f_1.tar.bz2
   sha256: 24d638d8577a3332a2e6cd77a5178054ca9cf7e14f71353b5b0a655155ab5c19
   md5: 230f394424c6cc26ebbee96176b65ece
   depends:
@@ -1587,7 +1587,7 @@ packages:
   license_family: Apache
   size: 11152969
   timestamp: 1681222877667
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcups-2.4.2-h2d74bed_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libcups-2.4.2-h2d74bed_1.tar.bz2
   sha256: f465c8f00b075660362d8e7fba8702b1c11e56fb2c305da78b9ee69898609be7
   md5: 8a2e46dc8bd62528a6f4d9092f2f6911
   depends:
@@ -1600,7 +1600,7 @@ packages:
   license_family: Apache
   size: 4901408
   timestamp: 1685057846629
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.9.1-h251f7ec_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libcurl-8.9.1-h251f7ec_0.tar.bz2
   sha256: 5ed4a1b84f273bd7bcd1302c823f4fbd486567c5d7d1a1e78eff9e7188af2e36
   md5: b1c706c4fa97ec653a40d7670f7b24a3
   depends:
@@ -1616,7 +1616,7 @@ packages:
   license_family: MIT
   size: 426063
   timestamp: 1725033936108
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
   sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
   md5: 55dde57e63a36b202e388a39dcee9a66
   depends:
@@ -1625,7 +1625,7 @@ packages:
   license_family: MIT
   size: 74096
   timestamp: 1695996494461
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
   sha256: 5bd3af246b6a93ea0912179ae66e0ad9157ca0142263010d84b65724e6db0bec
   md5: 5cb0cc0e1783419cf8fc1c65fee0f62f
   depends:
@@ -1635,7 +1635,7 @@ packages:
   license_family: BSD
   size: 195807
   timestamp: 1703006263489
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
   sha256: efdab884c85fda4461f7a393aa6d4e0e50d03cb59fb9c8a980b1307b8379ebe0
   md5: eeca774c6154c49340dd403b1928d5e9
   depends:
@@ -1644,7 +1644,7 @@ packages:
   license_family: BSD
   size: 108906
   timestamp: 1632891483341
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
   sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
   md5: 1af9b4d62c708924417f2640ef22a68f
   depends:
@@ -1654,7 +1654,7 @@ packages:
   license_family: MIT
   size: 154016
   timestamp: 1714483282916
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
   sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
   md5: 641e72e5067bd6d5454405879e1cd2a7
   depends:
@@ -1669,7 +1669,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 8895144
   timestamp: 1654090827491
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
   sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
   md5: 27082517590f3b9fbffecc68513b461b
   depends:
@@ -1678,7 +1678,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 19860
   timestamp: 1654090819660
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
   sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
   md5: 0202c3c8ae4735cac6c7f3d1e1685964
   constrains:
@@ -1686,7 +1686,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 5228750
   timestamp: 1654090762569
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libglib-2.78.4-hdc74915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libglib-2.78.4-hdc74915_0.tar.bz2
   sha256: ddda848ae8594a9a28b14439b322763e4ffb0ff8d34e492c994e434fe3fbf934
   md5: e35935cc3937ef52b2ef721dddc45738
   depends:
@@ -1702,7 +1702,7 @@ packages:
   license_family: LGPL
   size: 1583413
   timestamp: 1708031663093
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
   sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
   md5: 3080c2813e6e1d0f8a100a38b5b3456d
   depends:
@@ -1710,7 +1710,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 573231
   timestamp: 1654090775721
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libiconv-1.16-h5eee18b_3.tar.bz2
   sha256: ed544d8aa7e77fc42c39c276b879955e6615b517c42fecd2624033a5050832eb
   md5: 21ee76e09ab0a7315cbed14933d97773
   depends:
@@ -1719,7 +1719,7 @@ packages:
   license_family: GPL3
   size: 1436714
   timestamp: 1714483320555
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hecde1de_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libllvm14-14.0.6-hecde1de_4.tar.bz2
   sha256: c50e6a07e8004849e1cf9f0a164e36a79ac9d14a14fa7d33dc5e370315800489
   md5: 457cfe8b5e65d583e6797a1ba2b5fb4d
   depends:
@@ -1731,7 +1731,7 @@ packages:
   license_family: Apache
   size: 37206574
   timestamp: 1726769447337
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
   sha256: 6c67d781d3c074ae46b18567f230bce4a4afa209e8b914dc2cb448502774886e
   md5: c9627c386bbc8a1a1a0a2e736ea44501
   depends:
@@ -1747,7 +1747,7 @@ packages:
   license_family: MIT
   size: 722387
   timestamp: 1697018420830
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
   sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
   md5: 1bffe1481ed4f88827248fb9001f8923
   depends:
@@ -1757,7 +1757,7 @@ packages:
   license_family: Other
   size: 362561
   timestamp: 1677841789536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpq-17.0-hdbd6064_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpq-17.0-hdbd6064_0.tar.bz2
   sha256: 789ad45faa1c4c742e4de9858fa9aefe00f8fb138e3968d1dcf2d874a6a55380
   md5: db89c360caa392b4e03932077cef5e9d
   depends:
@@ -1767,7 +1767,7 @@ packages:
   - openssl >=3.0.15,<4.0a0
   size: 3383536
   timestamp: 1731525881300
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-4.25.3-he621ea3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libprotobuf-4.25.3-he621ea3_0.tar.bz2
   sha256: c070317f268dfcf77d5ff50c286bf430419fa9267eeea67d622f85c25fc6de9d
   md5: 1672198ffdc6aabb8750c51496719e19
   depends:
@@ -1780,7 +1780,7 @@ packages:
   license_family: BSD
   size: 3242840
   timestamp: 1716568319462
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -1788,7 +1788,7 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.11.0-h251f7ec_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libssh2-1.11.0-h251f7ec_0.tar.bz2
   sha256: 9ffb6bf8ac29a27a2faf800c0d9077f07e983a41c218f87a6013a6e1f95af2ab
   md5: 5b81a682e40f4c00841445d130c90b20
   depends:
@@ -1799,7 +1799,7 @@ packages:
   license_family: BSD
   size: 276424
   timestamp: 1715261489564
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
   sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
   md5: 8c195584a5f5471b600ee180e4052773
   depends:
@@ -1807,7 +1807,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 6410287
   timestamp: 1654090800863
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
   sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
   md5: ef78eebd98289aceacdfa29182426adf
   depends:
@@ -1825,7 +1825,7 @@ packages:
   license_family: Other
   size: 664034
   timestamp: 1693575237924
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
   sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
   md5: 292768ec77416ae257cfdd44ea2071c8
   depends:
@@ -1834,7 +1834,7 @@ packages:
   license_family: BSD
   size: 29197
   timestamp: 1668082729834
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
   sha256: a062fad27450b94279d1688aabd11a95eedee7814462ef6364337d55412b4a7e
   md5: e0521f84b9770830e654432364ac930e
   depends:
@@ -1845,14 +1845,14 @@ packages:
   license_family: BSD
   size: 484011
   timestamp: 1729160032020
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
   sha256: 5d68e69709ae10bd6c4b58b6af447ad2f2bd24955994f3ec77103d1a6bf5e1f5
   md5: 49e523de8d364b7fabc3850eccbe9bda
   depends:
   - libgcc-ng >=7.5.0
   size: 623492
   timestamp: 1652448233146
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxkbcommon-1.0.1-h097e994_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxkbcommon-1.0.1-h097e994_2.tar.bz2
   sha256: 72f48748059c081dd359f4b7303d1af66cf6eb5c496f053c2856a65a053ecba6
   md5: 26a52c61d45e49f89caff988460845fc
   depends:
@@ -1863,7 +1863,7 @@ packages:
   license_family: MIT
   size: 641120
   timestamp: 1722885004470
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.13.1-hfdd30dd_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxml2-2.13.1-hfdd30dd_2.tar.bz2
   sha256: 2f04d75b2175c95c328235b42f3669f1bb693be63d46e689bff878f806fa378e
   md5: d424ae0c5ca1279f734a1c52a1740d3d
   depends:
@@ -1875,7 +1875,7 @@ packages:
   license_family: MIT
   size: 738961
   timestamp: 1722441092529
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
   sha256: fd8e30beb8c9442f16e6617fac92dd0c89ec823e98f06e60f712147380ead35f
   md5: 7ed7caf2816c8b85b67b6f4e8833cbd5
   depends:
@@ -1885,7 +1885,7 @@ packages:
   license_family: MIT
   size: 41155
   timestamp: 1676837080881
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.43.0-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.43.0-py311h6a678d5_0.tar.bz2
   sha256: ba4846b57918d712a2c9986a31ac24fc3105f7cb029d1bcd7972b4bcd7a15b1c
   md5: 707e906a126ab3f69499704ab424b18e
   depends:
@@ -1897,7 +1897,7 @@ packages:
   license_family: BSD
   size: 4446734
   timestamp: 1720455383067
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
   sha256: 95fe76d2691feb13203b55ad2aba535bb848cae21ffd05b13ff51c7a45fa2332
   md5: 6a04ec16e3abc1c7e2104be32cd6c418
   depends:
@@ -1906,7 +1906,7 @@ packages:
   license_family: BSD
   size: 13458
   timestamp: 1676827287432
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
   sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
   md5: 76f089e76ec67583bb38428b51008097
   depends:
@@ -1916,7 +1916,7 @@ packages:
   license_family: BSD
   size: 164494
   timestamp: 1714510587156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
   sha256: 260e26dd509834c1b225ab7bdb97b9a86e00054fbdd5dfa49e68fa4dcf85a661
   md5: 8f5d7ddc69cc6f7d44c80d2251dea5d1
   depends:
@@ -1925,7 +1925,7 @@ packages:
   license_family: BSD
   size: 162339
   timestamp: 1676837095436
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
   sha256: 7f5b0804d0768619b7bd93b10488067d80bf42ec29f443f00b53ba11758a1241
   md5: 8afb45e45c0d93bfd142e682d4b021ef
   depends:
@@ -1935,7 +1935,7 @@ packages:
   license_family: MIT
   size: 134438
   timestamp: 1684280014220
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
   sha256: cb03570c99c983d7bfda94bc47d8eb00d4059b8548a171130775acc998004195
   md5: 5b1abbbf1e4f9b350b16fc9caf9e889b
   depends:
@@ -1947,7 +1947,7 @@ packages:
   license_family: BSD
   size: 26919
   timestamp: 1704206397615
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.9.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-3.9.2-py311h06a4308_0.tar.bz2
   sha256: c0a4b63c7b4e5eb3ace819a9fa61f107658c5bf99bd3c7448e364e27cc7d50e4
   md5: 37b73168cd1e4c5eee6b1c61bd09242d
   depends:
@@ -1959,7 +1959,7 @@ packages:
   license_family: PSF
   size: 6764
   timestamp: 1725264223949
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.9.2-py311h6fb44e5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.9.2-py311h6fb44e5_0.tar.bz2
   sha256: 3e5f475ba36d974005e6d3c4adbd1ba1874fba9d7db287eb74e7def409a5b478
   md5: be51f267bf90790dcb7e1562ad5e4d42
   depends:
@@ -1980,7 +1980,7 @@ packages:
   license_family: PSF
   size: 9468863
   timestamp: 1725264212197
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
   sha256: 7ac07ea180b5928086075900afbc332fb1d3c81ddfacb54c891693c284056f14
   md5: fc83dd1b3d2ec3c0a297ead0c3405907
   depends:
@@ -1990,7 +1990,7 @@ packages:
   license_family: BSD
   size: 19573
   timestamp: 1676823852670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
   sha256: c9ba2f9c83820712dd97d6a1b54a1215b9820a0be02ac82380b4c50911b9400c
   md5: e5dc6b4a5b8e02733ce3bc9e9198a8d2
   depends:
@@ -2000,7 +2000,7 @@ packages:
   license_family: MIT
   size: 67750
   timestamp: 1676837123613
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
   sha256: 1a5141ef0de1cbff816f96bb4b212a40606e2fc11301a4c1358c8d63a6b2b027
   md5: 22ac3bc22b68fef4c1f3f6ab3c7bfe0b
   depends:
@@ -2009,7 +2009,7 @@ packages:
   license_family: MIT
   size: 23040
   timestamp: 1676827301164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
   sha256: 9aacfbbe6f638c58a4e8ff31374d1438d78b7db25d6ea6fd0c50ca2109f225d4
   md5: e602057e3b3d80da88c61d66e8851c5b
   depends:
@@ -2020,7 +2020,7 @@ packages:
   license_family: BSD
   size: 104681
   timestamp: 1676823696152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
   sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
   md5: ce77d0f05f846da4a6b9e23fe7f21d9b
   depends:
@@ -2034,7 +2034,7 @@ packages:
   license_family: Proprietary
   size: 206738176
   timestamp: 1699648006088
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
   sha256: 2aef0876d0df033f7fae8cddbd25d95fc1bfc067e60dd143bd8000fec0768b21
   md5: d6cdc670327bd1675bbea642849f04e1
   depends:
@@ -2045,7 +2045,7 @@ packages:
   license_family: BSD
   size: 59569
   timestamp: 1682948560323
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.11-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.11-py311h5eee18b_0.tar.bz2
   sha256: 26001bced97eaa8c3862686f48668a252b8f7fd6ed81329534bee0538ea39fe0
   md5: eb3e382c51549878d07e5c3e207c3845
   depends:
@@ -2059,7 +2059,7 @@ packages:
   license_family: BSD
   size: 241049
   timestamp: 1730824176185
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.8-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.8-py311ha02d727_0.tar.bz2
   sha256: afc57040e0c892e46b00ecb534100fcaf05d8c75592170b0ce9119f2e5630557
   md5: 5e47055fea53886417e9a62d4e89c7c9
   depends:
@@ -2074,7 +2074,7 @@ packages:
   license_family: BSD
   size: 411216
   timestamp: 1730824036145
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
   sha256: b558b3f6c144652b5e0d26497b3ce24c318a6b9ff8ea2079113c95e5553b3cf9
   md5: 0b185969ac2b065c27cbcc9641d93678
   depends:
@@ -2084,7 +2084,7 @@ packages:
   license_family: BSD
   size: 29568
   timestamp: 1676841232463
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mysql-8.4.0-h29a9f33_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mysql-8.4.0-h29a9f33_1.tar.bz2
   sha256: 4ce8e37ee2af13b445e1ed9a1f5ab2c0c36d6c30693b323610e9074e0d7405a0
   md5: cd73c46242919e3787069508f595c188
   depends:
@@ -2104,7 +2104,7 @@ packages:
   license_family: GPL
   size: 70741824
   timestamp: 1722531388768
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
   sha256: 6116c133fbed1e7ea0f5e69f900e93d7977cb715920d10b10642c191d00cc9a6
   md5: b842f7ebdc8b7b6a0dda4c5ebe12805b
   depends:
@@ -2117,7 +2117,7 @@ packages:
   license_family: BSD
   size: 8315206
   timestamp: 1717622768176
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
   sha256: bb45fb0a3973caa74fd8f845e0a519895f6a378807626e15ecf72c02f2eed794
   md5: 185f658ba8a74e326b7231c8fd0d62bf
   depends:
@@ -2130,7 +2130,7 @@ packages:
   license_family: BSD
   size: 121834
   timestamp: 1698934274227
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.16.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.16.4-py311h06a4308_0.tar.bz2
   sha256: 9361ab2f7b289e9fd33ef001035fbdca9735f1c5425bb8282ce053d152ffaa2c
   md5: f95894da2382644ab016e71dc0db3463
   depends:
@@ -2157,7 +2157,7 @@ packages:
   license_family: BSD
   size: 528660
   timestamp: 1728049573278
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.10.4-py311h06a4308_0.tar.bz2
   sha256: c7aa4facc9d03e5087f9b22a88373beb43633a2c558e895303f5accc3ce95142
   md5: 4b4927ae34aaf3ee6b008a4392afd2dd
   depends:
@@ -2170,7 +2170,7 @@ packages:
   license_family: BSD
   size: 169513
   timestamp: 1728049478168
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
   sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
   md5: 57ea097dc15f8d9f9eb90e1d919143b0
   depends:
@@ -2179,7 +2179,7 @@ packages:
   license_family: MIT
   size: 1157733
   timestamp: 1674734069410
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
   sha256: 266199dd4efde0ad342a9c500f4bc4299c5622219aea623b46315a9b4f6b8959
   md5: 2b21844d2b0024d0ffad0e6450cf0855
   depends:
@@ -2188,7 +2188,7 @@ packages:
   license_family: BSD
   size: 15860
   timestamp: 1708532713870
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
   sha256: 59e169e036db0f2b98ed19f867d8ac708970214599efa0d57d3413fc1dbe8e3c
   md5: d0faf375bfc33811456d43fe549cb939
   depends:
@@ -2213,7 +2213,7 @@ packages:
   license_family: BSD
   size: 710152
   timestamp: 1717630833268
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
   sha256: ef2857e6d3d7eb246b3abddfbd3aa2d124dd8565391ace3876b77339babc50bb
   md5: d276d1b1774107987963135c78ca7390
   depends:
@@ -2223,7 +2223,7 @@ packages:
   license_family: BSD
   size: 26607
   timestamp: 1699455972519
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.60.0-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numba-0.60.0-py311ha02d727_0.tar.bz2
   sha256: 08a8505d44d5a51141cf4bd895fb3925ee52160bd51e8c8147f11e7f48a65a1f
   md5: 47699f658867be16614cddc1edd70731
   depends:
@@ -2247,7 +2247,7 @@ packages:
   license_family: BSD
   size: 6188719
   timestamp: 1720541020279
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.10.1-py311h3c60e43_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.10.1-py311h3c60e43_0.tar.bz2
   sha256: c85ee5a0b557ed925a1709b7422f13e88545bd2392c63d8e65b8d4dd44bca713
   md5: 3ca48c350f813b2e11ed2312858098f7
   depends:
@@ -2263,7 +2263,7 @@ packages:
   license_family: MIT
   size: 204257
   timestamp: 1730216115069
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
   sha256: e09e1aff2c12d4ef3fec58fb627744e4b5c7d9eaede7175e293f77272d8b8bfd
   md5: fe8242cfd54d238507493612ae697ad4
   depends:
@@ -2280,7 +2280,7 @@ packages:
   license_family: BSD
   size: 10270
   timestamp: 1708639794640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
   sha256: a53ad723826651041a5057a1cf31bc8689b24d335ce61b196df5124974b05a8e
   md5: 7b29e7191c4170189d6080e61229f030
   depends:
@@ -2296,7 +2296,7 @@ packages:
   license_family: BSD
   size: 9163911
   timestamp: 1708639777712
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
   sha256: 1c9f6902907a3d4a7e5c3cb02236491ea4c4e66a1a0ce51fa506dffb24ba89f6
   md5: 36d514eca3c87ab75a1d418607e26db2
   depends:
@@ -2308,7 +2308,7 @@ packages:
   license_family: BSD
   size: 528528
   timestamp: 1722872671997
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openldap-2.6.4-h42fbc30_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openldap-2.6.4-h42fbc30_0.tar.bz2
   sha256: 0f8ab416331b1cf627db4a1e1209074574bb066af21632f1ce4c27cc9c74e6d1
   md5: 05cc121f5bd122219dd67cd201c174bc
   depends:
@@ -2321,7 +2321,7 @@ packages:
   license_family: BSD
   size: 1351078
   timestamp: 1687380352694
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.15-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.15-h5eee18b_0.tar.bz2
   sha256: f8a3dbcdabfad712311fdbec1fd49d44340818d348df5d90f420de133a4daeb1
   md5: 4084456e619e7c2ab269f3cf2ff831f2
   depends:
@@ -2331,7 +2331,7 @@ packages:
   license_family: Apache
   size: 5499760
   timestamp: 1725545717819
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
   sha256: 280225061aeba00d7b85f46e55d7d79cd92c92f662dc749d9c53187978e8d083
   md5: c51c21da68080d89300703ad818c824a
   depends:
@@ -2340,7 +2340,7 @@ packages:
   license_family: APACHE
   size: 38606
   timestamp: 1699371264464
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-24.1-py311h06a4308_0.tar.bz2
   sha256: 78b2ec7956f036125c4cd56bd8b13642b952b43a54850c778bf87a664b86d0ef
   md5: db433aded6b3b43ee3cb5d1df0008d2e
   depends:
@@ -2349,7 +2349,7 @@ packages:
   license_family: Apache
   size: 156677
   timestamp: 1720101925844
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.2-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-2.2.2-py311ha02d727_0.tar.bz2
   sha256: b5979b0d4ef5c09f9795acb6b5e322b404f4eab7d73b6ed0aa59f03ef7acd25b
   md5: 1a353daeb78baa6b5bf8f47e1e74ca1c
   depends:
@@ -2400,7 +2400,7 @@ packages:
   license_family: BSD
   size: 17976832
   timestamp: 1718310942026
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.5.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-1.5.3-py311h06a4308_0.tar.bz2
   sha256: edabd666746acfb045c1dd922835172ea94c00d33bf03337740db2af93551911
   md5: 486d3afb94115451198410b69e3fa0b5
   depends:
@@ -2425,7 +2425,7 @@ packages:
   license_family: BSD
   size: 24210987
   timestamp: 1730381005745
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-2.1.1-py311h06a4308_0.tar.bz2
   sha256: face211fc35bfa199b6d02f8ed25372d1f1a2093518a79a9eec9925bcf9e6d1d
   md5: 9cd12fbc855d97b19427e911262e3bee
   depends:
@@ -2434,7 +2434,7 @@ packages:
   license_family: BSD
   size: 263218
   timestamp: 1719348029519
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py311h06a4308_0.tar.bz2
   sha256: a2e2beff710765f2e5135020121da4f227f5e1cbe142e17398a585f50a389d37
   md5: eaf734d49b6e576e12be1398a295643a
   depends:
@@ -2448,7 +2448,7 @@ packages:
   license_family: BSD
   size: 47447
   timestamp: 1698702703255
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pcre2-10.42-hebb0a14_1.tar.bz2
   sha256: 71beb7373390a7c5e9bf8663d64e2b0a426755fe68adb26ed72b6570634f635e
   md5: cd7c1793b37ba076f8515b49dbd850bd
   depends:
@@ -2459,7 +2459,7 @@ packages:
   license_family: BSD
   size: 3346886
   timestamp: 1714657706306
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-11.0.0-py311hfdbf927_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-11.0.0-py311hfdbf927_0.tar.bz2
   sha256: b2a9d111070a9a8490fd422dd8a9362aa6e145d1404400acdffb4ce85e9886b7
   md5: e7692de89f4413e94a253bd301150bbf
   depends:
@@ -2476,7 +2476,7 @@ packages:
   license_family: Other
   size: 1001193
   timestamp: 1731594824019
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-24.2-py311h06a4308_0.tar.bz2
   sha256: 87422d1d2592abe99ee9a6c06f6653030567e88571a21edca9f4c1f2cd22ae07
   md5: 806984470b5328d7fdb721b37ec2d73f
   depends:
@@ -2487,7 +2487,7 @@ packages:
   license_family: MIT
   size: 2913778
   timestamp: 1723484664306
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
   sha256: d2bbab8bfc57c7f46ca8994bc87df7e744d3f036b867bc4be1145ba6d8d7e091
   md5: de41707272a8e3ccab764f0b7010a27d
   depends:
@@ -2496,7 +2496,7 @@ packages:
   license_family: MIT
   size: 37394
   timestamp: 1692205565974
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ply-3.11-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ply-3.11-py311h06a4308_0.tar.bz2
   sha256: 786a4a57db582b66de12bd7e03eae83caa939136dabd8b53049cadeabc0beb6f
   md5: 262064c348f1846011c650ad8a6cd793
   depends:
@@ -2505,7 +2505,7 @@ packages:
   license_family: BSD
   size: 111320
   timestamp: 1676824981885
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
   sha256: e2a0e2a618aa33f0beff9583c7dc510b8d0737b023117346676aacbad33970d8
   md5: 66a6818307261b1a28ab12d1b7776fdf
   depends:
@@ -2514,7 +2514,7 @@ packages:
   license_family: Apache
   size: 121454
   timestamp: 1679340540306
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
   sha256: b7f591c19b10bf0daa7e6e3b45a9f4a0a0e83188e1f8a58037caea79e60f8d91
   md5: d945b4ccc135005839c504cc29df1745
   depends:
@@ -2526,7 +2526,7 @@ packages:
   license_family: BSD
   size: 749608
   timestamp: 1704404477511
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
   sha256: 96482b49191fdac59580a95e69508367083e1f7600145e11d7c2db634337eb26
   md5: 2d57bf8eacf3f291db845928241f724c
   depends:
@@ -2536,7 +2536,7 @@ packages:
   license_family: BSD
   size: 490805
   timestamp: 1679337420563
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
   sha256: eb75b4417565d25e2d1006db75aa8bd9da6b6c72a929954b01a31b9bf5f8b42e
   md5: bb56c0358b65665f4dd509a4635f6f3c
   depends:
@@ -2548,7 +2548,7 @@ packages:
   license_family: BSD
   size: 37802
   timestamp: 1676838557935
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
   sha256: ed927e4d058a8f4ea73edc7a43ed74877d93b88fdfa240b3b2777244386ced70
   md5: a1f0e05fc7e49712f81ad5478ec9d51e
   depends:
@@ -2557,7 +2557,7 @@ packages:
   license_family: BSD
   size: 2121496
   timestamp: 1684280065800
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.2.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.2.0-py311h06a4308_0.tar.bz2
   sha256: b5d27b938ed374a24fcb18a66c3f1a94e28bbe01b4ac156cd26c7be1ca756622
   md5: 244cfad440c898146039cb986864017e
   depends:
@@ -2566,7 +2566,7 @@ packages:
   license_family: MIT
   size: 486387
   timestamp: 1731445563066
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.15.10-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyqt-5.15.10-py311h6a678d5_0.tar.bz2
   sha256: f0c1614d5e651ed15061d137acecda2f684189cc148f50d3e75068dc9737bcd4
   md5: 0911e45b849687c7318f7764e2b69778
   depends:
@@ -2581,7 +2581,7 @@ packages:
   license_family: GPL
   size: 6539272
   timestamp: 1698775883859
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt5-sip-12.13.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyqt5-sip-12.13.0-py311h5eee18b_0.tar.bz2
   sha256: a646cae6b3d429588a3dc752819b4dcb315a814c8ad2b9fb2741b166fc4ee2a6
   md5: eec3045856f86acc307c73749a7f7df1
   depends:
@@ -2591,7 +2591,7 @@ packages:
   license_family: GPL
   size: 97216
   timestamp: 1698769366045
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
   sha256: 114b55e00f4622c90fd2b404b21ad5f94a10283fcaaf86a42174b8d39b0a3e98
   md5: 2458e92683cc68671a6c8e1b86ce8817
   depends:
@@ -2600,7 +2600,7 @@ packages:
   license_family: BSD
   size: 35850
   timestamp: 1676822725516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.10-he870216_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.11.10-he870216_0.tar.bz2
   sha256: b9bca26dc975ca55d1a0da81c872a29677912cc907c7b851e62adf750adc3d15
   md5: 9cbfa36ea4a6a61207af3f9f82ea8aea
   depends:
@@ -2622,7 +2622,7 @@ packages:
   license_family: PSF
   size: 36130467
   timestamp: 1727941504946
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
   sha256: a0f008717fab060ccd003dfebc09156d90b9afd14ac3626566aa1a8f3d3b7e2f
   md5: 357bf4fe94496cbae72ab4d780184b31
   depends:
@@ -2632,7 +2632,7 @@ packages:
   license_family: BSD
   size: 330924
   timestamp: 1716495762901
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
   sha256: aadc4078311c059265706a56265f0a57ceb538d36179d5203dd487d80d0e8f16
   md5: 59ec670fcd172447dbd9591b8fbfdd56
   depends:
@@ -2641,7 +2641,7 @@ packages:
   license_family: BSD
   size: 278741
   timestamp: 1679340144625
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
   sha256: d5058d0ecc3973316c1d5f1bfb03dd119e0dade85f4c2d21b412c8db4e1636f2
   md5: 93000e4d3603342779a2afda66fa91b8
   depends:
@@ -2650,7 +2650,7 @@ packages:
   license_family: BSD
   size: 17607
   timestamp: 1683823841946
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
   sha256: b85acb933fff864bfa89d034e8e3d85b1a9c2e69cbfc0d68c1d66ffd1443e67d
   md5: 0cdb92d2d684ee1095310f992ed0d9b2
   depends:
@@ -2659,7 +2659,7 @@ packages:
   license_family: MIT
   size: 266796
   timestamp: 1713974338678
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
   sha256: 511e8206a15445715b80be76493300930686b3fe1e512ae942d6ccca36df392a
   md5: 35a6e46ae970f8b71d78fb5a810f2e80
   depends:
@@ -2671,7 +2671,7 @@ packages:
   license_family: BSD
   size: 64013
   timestamp: 1711136926372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.2-py311h5eee18b_0.tar.bz2
   sha256: 132aa25ee904333ef338eb1935dd8e5ccffb27cacf33fdb58c1358ec22424933
   md5: 92ce34b6f4f7a6e64c80c2ba0a96edf4
   depends:
@@ -2682,7 +2682,7 @@ packages:
   license_family: MIT
   size: 222337
   timestamp: 1728658052191
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
   sha256: 7c74db4292f31619606180f86f3c1e2d913495c2c9d1195c5d51681a6a841625
   md5: be1c05fae57d194924b9400f9b5ad3c6
   depends:
@@ -2693,7 +2693,7 @@ packages:
   license_family: Other
   size: 613277
   timestamp: 1709318516682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-main-5.15.2-hb6262e9_11.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/qt-main-5.15.2-hb6262e9_11.tar.bz2
   sha256: cdcc746ef1d80cfacbe5e7ad1c3c91b97871006c5609623878ab5980f0df041a
   md5: 3d7589161197f2e1dbd526e146bff036
   depends:
@@ -2727,7 +2727,7 @@ packages:
   license_family: LGPL
   size: 62477035
   timestamp: 1731686555318
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
   sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
   md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
   depends:
@@ -2737,7 +2737,7 @@ packages:
   license_family: GPL
   size: 467661
   timestamp: 1666648052561
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
   sha256: 89c2f4235277b9825cc805c5c44f0b1afcb683d7b5a3f513bc4bf243b643bb0c
   md5: db70eb57e33adf7b8bbdadd72214d48d
   depends:
@@ -2748,7 +2748,7 @@ packages:
   license_family: MIT
   size: 73679
   timestamp: 1699012111499
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.32.3-py311h06a4308_1.tar.bz2
   sha256: 1ac5ee93110e2f7f1d68b6c985e4adcc3710f537c388ae3ff4f85059288070a1
   md5: 4385913efbeb323430797aa3b3506525
   depends:
@@ -2764,7 +2764,7 @@ packages:
   license_family: Apache
   size: 123440
   timestamp: 1730999231468
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
   sha256: fdae3f68ea84b99561aee6c566ab1c287d8f2ae2668424e9283a8ed86af8f1d2
   md5: cde5b71ccbb3630053340b2c8c7dbf10
   depends:
@@ -2774,7 +2774,7 @@ packages:
   license_family: MIT
   size: 9333
   timestamp: 1683077183576
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
   sha256: 0bf859b06a07857099fd4f524fe5e0875fda70029e9485d95c7efa97134fbc14
   md5: fd5815cc592fdbd4c831901541eadaba
   depends:
@@ -2783,7 +2783,7 @@ packages:
   license_family: MIT
   size: 9735
   timestamp: 1683059096795
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
   sha256: 474553d01aea57214a54a7443f227da84a58e29c49eb7605ba0043c55b7d167a
   md5: f01333e9f0a908e435db650f42fbd2db
   depends:
@@ -2793,7 +2793,7 @@ packages:
   license_family: MIT
   size: 1096668
   timestamp: 1698946168635
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.14.1-py311h08b1b3b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/scipy-1.14.1-py311h08b1b3b_0.tar.bz2
   sha256: 3ec374217cda083d08d0e909e832e4881d5228b567df2280699a06257f3a71fe
   md5: e6be323221b1c63fd108ce4681de5527
   depends:
@@ -2811,7 +2811,7 @@ packages:
   license_family: BSD
   size: 28045118
   timestamp: 1731624183722
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
   sha256: 51bcea0e575a626f6ffbd16d1153330fda93dbe3dd31dcd3a8f469ff61dd1e4e
   md5: 41d531c90be8c82bf79635ff3d409476
   depends:
@@ -2820,7 +2820,7 @@ packages:
   license_family: BSD
   size: 32295
   timestamp: 1699371262818
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-75.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-75.1.0-py311h06a4308_0.tar.bz2
   sha256: 0012d33e169b495c9e289b185ff8d4192b93711c5dfc514b0c5efc536ea9600b
   md5: 360f44ea616167b2c61cced23d0db311
   depends:
@@ -2829,7 +2829,7 @@ packages:
   license_family: MIT
   size: 2311301
   timestamp: 1726677958012
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-6.7.12-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sip-6.7.12-py311h6a678d5_0.tar.bz2
   sha256: c1585436f502f87ee7bf6d40b7d911d1b5093dfee339db251d887bf355a23a94
   md5: ff29bdee631a122ae9a68ff44066b02a
   depends:
@@ -2842,7 +2842,7 @@ packages:
   license_family: GPL
   size: 683464
   timestamp: 1698675983077
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
   sha256: 1a84b00944bc5588e14a097460175f97df49acb4f1ff2498ffd9a1893068ed81
   md5: a456513471b2ecbed60430c21dd1ccc7
   depends:
@@ -2851,7 +2851,7 @@ packages:
   license_family: Other
   size: 17880
   timestamp: 1705431390054
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
   sha256: adcafd297d60af64107c113bb7b8b92160d0268a44ef9a3b79e56a88a0358ea7
   md5: 28ed704ed26b06d32662e3a6a87e59b0
   depends:
@@ -2860,7 +2860,7 @@ packages:
   license_family: MIT
   size: 88799
   timestamp: 1696347581401
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
   sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
   md5: f86119b3243fe3508160aa0406245738
   depends:
@@ -2873,7 +2873,7 @@ packages:
   license_family: Other
   size: 1723866
   timestamp: 1714488309729
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
   sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
   md5: 041a3caf09dc9ce8fc6c10925c4fe050
   depends:
@@ -2883,7 +2883,7 @@ packages:
   license_family: Apache
   size: 1888016
   timestamp: 1680167274961
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
   sha256: 856a8ab8c350c50247b79966c6cb80fb6d4de36eef49ddf75aebbbcaf854c82d
   md5: 442dde204d14d171aab9ee40e8de4de8
   depends:
@@ -2894,7 +2894,7 @@ packages:
   license_family: BSD
   size: 37456
   timestamp: 1677696176157
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
   sha256: f0a026ddc0ed041bfc60c8a1ca0b70b7a69232775b3181bfb35a39fda42d6994
   md5: 2902d5a5854865baaaf58dc59cf06b3c
   depends:
@@ -2904,7 +2904,7 @@ packages:
   license_family: BSD
   size: 49185
   timestamp: 1676823769869
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
   sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
   md5: e2512d57c8a1e91e7b20e265c6906546
   depends:
@@ -2914,7 +2914,7 @@ packages:
   license_family: BSD
   size: 3588922
   timestamp: 1714770676475
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py311h06a4308_0.tar.bz2
   sha256: e58ff4a82819446f3c92e5b1aa2a784c4b06643e751fe67cf115858296dbfa50
   md5: 32ee4723173f1fad5563b8afb5f1c8f1
   depends:
@@ -2923,7 +2923,7 @@ packages:
   license_family: BSD
   size: 135634
   timestamp: 1676827536101
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.1-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.4.1-py311h5eee18b_0.tar.bz2
   sha256: 394fdf404ede3bc35d697b2e445c42590ddcae86a80f39642cc5366196fcbe54
   md5: a21cbca0664d8f34b0dca1f84998a31b
   depends:
@@ -2933,7 +2933,7 @@ packages:
   license_family: Apache
   size: 914199
   timestamp: 1718740165334
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.5-py311h92b7b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.66.5-py311h92b7b1e_0.tar.bz2
   sha256: dab820faa313d62b44014841409cef89a49dbda9a7697689ce37b3032ec3276e
   md5: 1d6513a5b915465291fdb2041815bdc6
   depends:
@@ -2944,7 +2944,7 @@ packages:
   license_family: MOZILLA
   size: 154437
   timestamp: 1724854032868
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
   sha256: 2091b17ae4fa46ed98fd6bfe9ca1aff3b0b81d73045e0cc55774b6516b8704b3
   md5: 183ae7b837c1c68ec1a8011011fadea7
   depends:
@@ -2953,7 +2953,7 @@ packages:
   license_family: BSD
   size: 206924
   timestamp: 1718227183177
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
   sha256: 8c06c291c76e8c2022ffbb9fea4727a4bf1f9b03e498bafc56ba8ac4e7604ab9
   md5: 5adb7baf1091d09026a372cac930ce6c
   depends:
@@ -2963,7 +2963,7 @@ packages:
   license_family: PSF
   size: 8869
   timestamp: 1715268966416
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
   sha256: 118b0801167264c401e84bbf19175546092a5569cc098146f7362bbf890dc8d9
   md5: b3c2aa56d53b459f8365d8385f48d0c3
   depends:
@@ -2972,7 +2972,7 @@ packages:
   license_family: PSF
   size: 74489
   timestamp: 1715268960737
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
   sha256: 509b962773f0fe44a93a7f6196b254670a030eac8ea7f90727312e3ccd9294b2
   md5: 6c402d5bf4e01c8c3895c9ef41707b6e
   depends:
@@ -2981,7 +2981,7 @@ packages:
   license_family: MIT
   size: 11371
   timestamp: 1676828901104
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
   sha256: bbe7629e8ce52c82f13ed0d1fb919f3659ef466b274a7c74aa925a9bc7aee450
   md5: 7da527bbcf71270c1abed8ea52e7d44c
   depends:
@@ -2991,7 +2991,7 @@ packages:
   license_family: Apache
   size: 509031
   timestamp: 1713213062098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-2.2.3-py311h06a4308_0.tar.bz2
   sha256: 42eaf6a7ea875b236796f58e9f06919fda206ef6a4884ce943d94aa7747ad290
   md5: d1a78c6d9003bf2ff1cda53bde67c1f5
   depends:
@@ -3007,7 +3007,7 @@ packages:
   license_family: MIT
   size: 217451
   timestamp: 1727769856880
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
   sha256: c3a5e0b855dc2de6c162708dfcf170a23eb9e7525d4252d8dce553369af4a330
   md5: a4c77e204b7787f820955166a1283168
   depends:
@@ -3016,7 +3016,7 @@ packages:
   license_family: BSD
   size: 25890
   timestamp: 1676823132898
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
   sha256: 42989f9970a8466cc4edb73463dfa194594dd1a5d42c9f820a1f86296d4af140
   md5: 655dfd4d2f17977cb81caa1c082d2b25
   depends:
@@ -3025,7 +3025,7 @@ packages:
   license_family: Apache
   size: 113505
   timestamp: 1715878346465
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.44.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.44.0-py311h06a4308_0.tar.bz2
   sha256: 3b258ad0db82572157a72303bbd5c20399d0c7f3b48abc1435ef96e4517e59f7
   md5: e11eb90c0ee1084a95cffe231196d98d
   depends:
@@ -3034,7 +3034,7 @@ packages:
   license_family: MIT
   size: 138218
   timestamp: 1726165052578
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py311h06a4308_0.tar.bz2
   sha256: 85248e503721da67797546cb8a22e303c1739100834b219c5621f216e3794e8d
   md5: 2570956643f22d0f809b2467e02d3984
   depends:
@@ -3046,7 +3046,7 @@ packages:
   license_family: Apache
   size: 2465865
   timestamp: 1689041600364
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
   sha256: d18cdca154bf668826f869117ea996c4f9e8ef7d27b7c528332a7d17e5a8602c
   md5: 9f7353d72046b16dd6ef6b5689ac9bfd
   depends:
@@ -3055,7 +3055,7 @@ packages:
   license_family: BSD
   size: 54731
   timestamp: 1676828934954
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
   sha256: 9122d6e9dabb7a47f2bcb15d86b97c96c49a9048da3f8ae59675351710c14cc5
   md5: 660b2aead2ec87b751c86cd33934f44e
   depends:
@@ -3064,7 +3064,7 @@ packages:
   license_family: GPL2
   size: 716926
   timestamp: 1714510796277
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -3072,7 +3072,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
   sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
   md5: 943f1247a22b6b64171363bcee1eec27
   depends:
@@ -3083,7 +3083,7 @@ packages:
   license_family: Other
   size: 371663
   timestamp: 1705602144682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.20.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.20.2-py311h06a4308_0.tar.bz2
   sha256: fbc9c42ae58cc2997bfce336b31e2086ac68674bf87f54de1f0dbee55ca621fa
   md5: c81f18822f50043c6dddd75c181e3211
   depends:
@@ -3092,7 +3092,7 @@ packages:
   license_family: MIT
   size: 28824
   timestamp: 1729012405522
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
   sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
   md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
   depends:
@@ -3101,7 +3101,7 @@ packages:
   license_family: Other
   size: 127143
   timestamp: 1714510716441
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
   sha256: a65c6277a3045e4ea72f617f977134c18366d8142ce51512f5a3cf325226a8bf
   md5: d941bb6fdc55cc1b3f67b3beb23d1795
   depends:
@@ -3114,7 +3114,7 @@ packages:
   license_family: BSD
   size: 1081416
   timestamp: 1728487031624
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -3127,7 +3127,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -3137,7 +3137,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -3149,7 +3149,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
   sha256: c0dd89ffac001588171152a285ddbbaea209ebe4116010f985f898b7e87c2f35
   md5: 731ae7d446633bc729f3493a52d4365b
   depends:
@@ -3158,7 +3158,7 @@ packages:
   license_family: MIT
   size: 43502
   timestamp: 1721748373551
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -3167,7 +3167,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -3176,7 +3176,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -3185,7 +3185,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -3194,7 +3194,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -3202,7 +3202,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -3211,7 +3211,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -3220,7 +3220,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -3230,7 +3230,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
   sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
   md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
   depends:
@@ -3239,7 +3239,7 @@ packages:
   license_family: BSD
   size: 5106
   timestamp: 1704404390460
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -3247,7 +3247,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -3256,7 +3256,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -3265,7 +3265,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
   sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
   md5: 02caf3f47f1d06256068053297355740
   depends:
@@ -3274,7 +3274,7 @@ packages:
   license_family: Apache
   size: 152292
   timestamp: 1690578151230
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -3283,7 +3283,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -3295,14 +3295,14 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
   sha256: bf3130b8c44a7e9bcd496f515d0ee4b2e788610f468bafd708d16d007cb47332
   md5: 48f856789d224eae8d1979c212205fde
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 123651
   timestamp: 1728062827250
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -3310,7 +3310,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.6.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-4.6.2-py311hecd8cb5_0.tar.bz2
   sha256: 10c81c3952bdf1073713a33f65f538082b2f6de47c4dff3cf173a18e4f014e7a
   md5: 87d1d76e942262c2c7c39370e30d7b3b
   depends:
@@ -3324,7 +3324,7 @@ packages:
   license_family: MIT
   size: 244917
   timestamp: 1729121433463
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
   sha256: ab7672364f1fa55ec5d8311d85d40e5b57cbd3517b17670557b6fb822bcf759c
   md5: 6e0159a5865cb7e96a748bd8560035ee
   depends:
@@ -3333,7 +3333,7 @@ packages:
   license_family: BSD
   size: 11579
   timestamp: 1678317458652
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
   sha256: 51556902e09436d46878ef772805d06416ca96ffaa66340b5565c0245574aaf5
   md5: 4cb1b20635cf5431d34cc96ca1e8a751
   depends:
@@ -3343,7 +3343,7 @@ packages:
   license_family: MIT
   size: 33355
   timestamp: 1678317111825
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.2.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-24.2.0-py311hecd8cb5_0.tar.bz2
   sha256: 49a9602af2808940b5f11b870939ea588e0408ed64e357db464950eb9fe77d2e
   md5: b2f41eaf53c93ba83b99c8062f674008
   depends:
@@ -3352,7 +3352,7 @@ packages:
   license_family: MIT
   size: 163931
   timestamp: 1729089648658
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
   sha256: 365824e639808e52809f97b70b65da94a5eeb87e29dd97c8926aa72707a5a1c7
   md5: db7813418dfe42d59363fed4a68d5c36
   depends:
@@ -3362,12 +3362,12 @@ packages:
   license_family: MIT
   size: 278195
   timestamp: 1718029905185
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-openblas.tar.bz2
   sha256: 695ac69739e73351dfebfb01ea39c5e1dbfdcfb475590d6560ae318bfbad3a97
   md5: 38fd73cba341639c45d8c747b08c9cc1
   size: 49130
   timestamp: 1528225884020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-3.6.0-py311hecd8cb5_0.tar.bz2
   sha256: fb5f53ec43d4ca92f433a556602a0347038856b5cdbcb2f0014b5445caa1b7a8
   md5: 48f6989f8490bacc7ef44814c3ab7635
   depends:
@@ -3385,7 +3385,7 @@ packages:
   license_family: BSD
   size: 5869515
   timestamp: 1727914551902
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.4.2-py311h9b7fc35_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.4.2-py311h9b7fc35_0.tar.bz2
   sha256: 2db3c754dcd7b5f87f8e9384509f539b3c9a80e7c26279c050814258e712a223
   md5: 24af5157264705bc3358ec195490de59
   depends:
@@ -3395,7 +3395,7 @@ packages:
   license_family: BSD
   size: 156491
   timestamp: 1731059250255
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
   sha256: d8b1ccb15297dcfb3f9ebb8139c3e28a13d6c2e73c37612cb214ab6cc58b15fa
   md5: e5dec9f13de061640ad2697562a99b54
   depends:
@@ -3405,7 +3405,7 @@ packages:
   license: MIT
   size: 19732
   timestamp: 1714483415038
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
   sha256: e9fda4393edd0234c88efc2b88e0edf42c94eb49ea5b189a80afd733058be8fb
   md5: 13ceed558eb174d6b77ed1b0035f1785
   depends:
@@ -3414,7 +3414,7 @@ packages:
   license: MIT
   size: 18400
   timestamp: 1714483395748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
   sha256: a323af3251e426962ad16edf8f46a696ef502731faf12aee32ca289c40b11342
   md5: 658ce49e9f07dba7a1afe70fa2666e0a
   depends:
@@ -3423,21 +3423,21 @@ packages:
   license: MIT
   size: 393858
   timestamp: 1714483549536
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
   sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
   md5: c5a600d81b1b48578863af2973c743ac
   license: bzip2-1.0.8
   license_family: BSD
   size: 187637
   timestamp: 1714510590009
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.9.24-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2024.9.24-hecd8cb5_0.tar.bz2
   sha256: 7031fa5cac3aca09b273742f9d7bdde4fb85edefc21cb3407a779a5a81438394
   md5: c25cd4336a986ed75c92636e17953a48
   license: MPL-2.0
   license_family: Other
   size: 141521
   timestamp: 1727794863285
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.8.30-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2024.8.30-py311hecd8cb5_0.tar.bz2
   sha256: acb2effe5ccd14a94eaf0dfe268f6b7f13165461ca60f24b8dab007259200b12
   md5: 07e08081971e9f8255e5c4cbe19edf47
   depends:
@@ -3446,7 +3446,7 @@ packages:
   license_family: Other
   size: 170244
   timestamp: 1725551715047
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py311h9205ec4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.17.1-py311h9205ec4_0.tar.bz2
   sha256: 8b66e37770f89a68ef4d7a70787720c300793e05822038379fa4068e7197fb2a
   md5: e1f7832dcc299bc8f5069e90f7f8cc00
   depends:
@@ -3457,7 +3457,7 @@ packages:
   license_family: MIT
   size: 293031
   timestamp: 1726856737247
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
   sha256: aceaa74365b0d8e69c817639393df3a713a802f40645ac0bd2f39adc871acf54
   md5: 52191c9d4f4fcaeea39574819ab2f14f
   depends:
@@ -3466,7 +3466,7 @@ packages:
   license_family: BSD
   size: 204365
   timestamp: 1698129979494
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cloudpickle-3.0.0-py311hecd8cb5_0.tar.bz2
   sha256: 6289468ac6d509d11f928e80005c27fcc169be379c9714f839c305949fbc22af
   md5: 851f577d81bce100ddf9c11ded38da06
   depends:
@@ -3475,7 +3475,7 @@ packages:
   license_family: BSD
   size: 43158
   timestamp: 1721657395305
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
   sha256: 9270668e34b00a2605584a2db5130c83826855cd05b896ce949f3156fa197429
   md5: 2586aa55677e822e8285d777f9039ca9
   depends:
@@ -3484,7 +3484,7 @@ packages:
   license_family: CC
   size: 543487
   timestamp: 1709758497949
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
   sha256: 389c63a84b92a6254c9d361ebe970d537d0b88733efd5ac5c3ee58196fd2c5a9
   md5: c7bc5b3cbe76be83a27f00b7e4740727
   depends:
@@ -3494,7 +3494,7 @@ packages:
   license_family: BSD
   size: 17974
   timestamp: 1709323004148
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
   sha256: bebfc5aa6be12e61a134b580b07b67f7d8c045d6b113fca5b21fa1e83a2f03ce
   md5: 239df72a3921c951059fa8afc09643f6
   depends:
@@ -3505,7 +3505,7 @@ packages:
   license_family: BSD
   size: 287736
   timestamp: 1700583644534
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cramjam-2.7.0-py311h9c86198_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cramjam-2.7.0-py311h9c86198_0.tar.bz2
   sha256: f480b0ed7a98e682d8cbdaeef697116a0d839cee08ec8b5f39078c4e056ec29b
   md5: 7712882f644fca2ccd169ce2dee2b4d9
   depends:
@@ -3514,7 +3514,7 @@ packages:
   license_family: MIT
   size: 1473015
   timestamp: 1702651642047
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2024.8.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/dask-core-2024.8.2-py311hecd8cb5_0.tar.bz2
   sha256: 3ad77286d59361920bdfe9af6e71d7f31cada0e56b1c1ee0731a0b560bc16d92
   md5: 31e739e79d93b568735a7db5cd201f52
   depends:
@@ -3531,7 +3531,7 @@ packages:
   license_family: BSD
   size: 3118893
   timestamp: 1725461414545
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.16.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/datashader-0.16.3-py311hecd8cb5_0.tar.bz2
   sha256: 9aaeb2715d1c3de8096c489b52ecb4c71d7341ee75bb5c3ace77c50c918ec5d4
   md5: 05a98a96b9cccb007768b87c11e92b7e
   depends:
@@ -3554,7 +3554,7 @@ packages:
   license_family: BSD
   size: 18011437
   timestamp: 1720534043633
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
   sha256: e0e30590a78d99d51445ac4f668aefe1bf20025a35bdbac00f04647b95c9f152
   md5: bd0db635eefeea82a0c567b39c9a0e3d
   depends:
@@ -3564,7 +3564,7 @@ packages:
   license_family: MIT
   size: 2485698
   timestamp: 1690905283575
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
   sha256: d48b47b86b09dac1fa4542ec13e1bd4e23093638e684fa66ec3afdd9ce9337c1
   md5: 5a2d1828ab7c8eccd3c2610d13672977
   depends:
@@ -3573,7 +3573,7 @@ packages:
   license_family: MIT
   size: 17336
   timestamp: 1678316187749
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-2024.2.0-py311hb3a5e46_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fastparquet-2024.2.0-py311hb3a5e46_0.tar.bz2
   sha256: 3a4f25b0833b1e459e03b22ad6f0fa21b489ca5aa9559bd18e1ed6659509766e
   md5: f35dfe533aa5ab48ea2f7064b6b6353d
   depends:
@@ -3587,7 +3587,7 @@ packages:
   license_family: Apache
   size: 661944
   timestamp: 1715262849492
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
   sha256: 54645c22fabc25b632114d1d3c403a6fad9149b51ab36719b2690a084f14a072
   md5: a8ad2f4abfb2e17ecf6e596342528156
   depends:
@@ -3605,7 +3605,7 @@ packages:
   license_family: MIT
   size: 3180691
   timestamp: 1713551771692
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -3615,7 +3615,7 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.6.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fsspec-2024.6.1-py311hecd8cb5_0.tar.bz2
   sha256: 4316287b920b446149e5adf3519d12089b0c9ec49a8c1c802eee81c92d80132b
   md5: b52775f876eba6074e08a4d65328fad0
   depends:
@@ -3626,7 +3626,7 @@ packages:
   license_family: BSD
   size: 383995
   timestamp: 1724855682674
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.20.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.20.0-py311hecd8cb5_0.tar.bz2
   sha256: 60fbaec8c8ddc4ac235a4c8143a1d734e34c0543ba20985973cb43a9220262c9
   md5: f781135af3dde8699b5b3cf9bfe83b3f
   depends:
@@ -3646,7 +3646,7 @@ packages:
   license_family: BSD
   size: 6129648
   timestamp: 1730828256779
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.11.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/hvplot-0.11.1-py311hecd8cb5_0.tar.bz2
   sha256: 0a24a6f6adc180ab3395a060762ede700e0f44e6b03dfa921197ed6451062939
   md5: b485eff7e3aa7160734b25d8dfb7734f
   depends:
@@ -3663,7 +3663,7 @@ packages:
   license_family: BSD
   size: 371047
   timestamp: 1729516805777
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
   sha256: 5c2458964157fe493ca18c513c693b70cb622087e5fa0c93e65fc45217edd811
   md5: 15629e52625221b51a443cefd9501d12
   depends:
@@ -3672,7 +3672,7 @@ packages:
   license_family: BSD
   size: 148522
   timestamp: 1714398885844
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-7.0.1-py311hecd8cb5_0.tar.bz2
   sha256: 5a17849341e4d43fc6aff44486425852c16dee6e1cbcab1ed3f2167350f55359
   md5: 445ac9df262ad2dcd86246a9ba5654b2
   depends:
@@ -3682,7 +3682,7 @@ packages:
   license_family: APACHE
   size: 51118
   timestamp: 1704813615186
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.29.5-py311hecd8cb5_0.tar.bz2
   sha256: 4772db5a35dfbdabf55b01943916d0a5b451db757aa38372571bb3e03948527a
   md5: f6b4cd61684c3ec067cbda883fca865d
   depends:
@@ -3704,7 +3704,7 @@ packages:
   license_family: BSD
   size: 240267
   timestamp: 1728665688908
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.27.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.27.0-py311hecd8cb5_0.tar.bz2
   sha256: 901a391e792938d690a39cbe2551d7306bf85474bb0cff4e69088f78a9f5a26d
   md5: 84fa63c5f6182b1f06c3ffa5e611507d
   depends:
@@ -3722,7 +3722,7 @@ packages:
   license_family: BSD
   size: 1632976
   timestamp: 1726064292193
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.19.1-py311hecd8cb5_0.tar.bz2
   sha256: 9961222f1fb3a768e9c85a03761107809b321f4bc9af02d23289c59164bed7fe
   md5: c671e7d14b22780a7b1fa8632b0bf8ba
   depends:
@@ -3732,7 +3732,7 @@ packages:
   license_family: MIT
   size: 1178410
   timestamp: 1721058471712
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.4-py311hecd8cb5_1.tar.bz2
   sha256: f0610ceaac87ce39266f4dee8185244668ac9345143c9eb22c4cb201b79aab00
   md5: 2d4759abb2b7a3de114fdef7bb241474
   depends:
@@ -3744,14 +3744,14 @@ packages:
   license_family: BSD
   size: 354673
   timestamp: 1730902923439
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
   sha256: 855982a798d9af8e70635a250528a5da3b2b0cf7095e2804858caf139c8a239b
   md5: 112a5602fe42a84a5bafa038abeddf4f
   license: IJG
   license_family: Other
   size: 279686
   timestamp: 1722872676718
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.23.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.23.0-py311hecd8cb5_0.tar.bz2
   sha256: a899e7bdac6b9b734882ee44a8065d7006dd669fde9b0fb0a88ed2e2f77ec357
   md5: 14a0abb1c37f2e37c0e55b8feec8d564
   depends:
@@ -3764,7 +3764,7 @@ packages:
   license_family: MIT
   size: 193788
   timestamp: 1728487044949
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 0ea44d0c8044e70ab0eaf4d6f5f3e4753838dee106b5cbd36561e21a65cbac77
   md5: 1d045016dca889d702f1caf3a16162fc
   depends:
@@ -3774,7 +3774,7 @@ packages:
   license_family: MIT
   size: 16528
   timestamp: 1699032525791
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
   sha256: 70442ec4b0b7ebbdcf150963f61f797b861001092124f4ea39a16eb92a4d176e
   md5: 63d1503915a15ae4f9ad1c46112ca374
   depends:
@@ -3790,7 +3790,7 @@ packages:
   license_family: BSD
   size: 272720
   timestamp: 1678316970740
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
   sha256: e657ec0667481d957827be1ce825b0a971aa3a211b07c1274d2c1099ded3129c
   md5: 5e317fd45011a0003c29331a8002cb75
   depends:
@@ -3801,7 +3801,7 @@ packages:
   license_family: BSD
   size: 98632
   timestamp: 1718818439542
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 2634d721123ea1e41b6e1cfe4a67552ec520ea9b5154c9e788ccb09d4745b732
   md5: e874eba19b493b7a68161429f24b8f51
   depends:
@@ -3817,7 +3817,7 @@ packages:
   license_family: BSD
   size: 43102
   timestamp: 1718738272613
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
   sha256: c353480ed4744c2a16aaccc1649bab38144436ad6d16ac2937e3e333d32fdccc
   md5: 7de25bdf4cfd3f5485d790d9cddf427f
   depends:
@@ -3844,7 +3844,7 @@ packages:
   license_family: BSD
   size: 619935
   timestamp: 1718828240904
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
   sha256: fd7964657f0a8fe8b167ba860b1f960e8b7b45309eb6c7c850d50ec283fe03b5
   md5: 2967bb345bc75f53182e263ff4743ca6
   depends:
@@ -3854,7 +3854,7 @@ packages:
   license_family: BSD
   size: 28223
   timestamp: 1686870845224
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
   sha256: 64cf59f0f74b0329b5069bc6135b4f40593f1dac52d85ad574d4b8e0a4b2cf16
   md5: 35e8b80eaa03a904fc7f1da39e7f654d
   depends:
@@ -3866,7 +3866,7 @@ packages:
   license_family: BSD
   size: 20234
   timestamp: 1700168776500
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
   sha256: a12382b50416803f559a03fb384ba492c1dafa351e1191a3f8dc361bee6c4f37
   md5: f2ae846b663bbb642f4b1e90eaad38a3
   depends:
@@ -3876,7 +3876,7 @@ packages:
   license_family: BSD
   size: 64817
   timestamp: 1678322501509
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -3886,7 +3886,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -3895,13 +3895,13 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 685c3bc9068bd485604b80bf03789e4dca95c410d33871bc1b882e47649fabed
   md5: 6cf8e55271e150ca0961d0ddedaa61bb
   license: MIT
   size: 66237
   timestamp: 1714483284541
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 69826cee54db9955f0120af21ec36d13f9211877fd67364f2068d0a54c6c97cd
   md5: 0851917257f490d35e1f73da8a1c723c
   depends:
@@ -3909,7 +3909,7 @@ packages:
   license: MIT
   size: 34042
   timestamp: 1714483343147
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 3f5a1f03b50b90b397a0ee432ad0cba13354abdaf7e5652c0fc60164b26a08b6
   md5: a50bdc871ef4bf14deb088d888b92b5e
   depends:
@@ -3917,28 +3917,28 @@ packages:
   license: MIT
   size: 311597
   timestamp: 1714483371586
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
   sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
   md5: 822a5b76117e56d3912f1f2153307528
   license: MIT
   license_family: MIT
   size: 136045
   timestamp: 1714483561919
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
   sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
   md5: e458587c87e3f2d20192f4e0738f2c63
   depends:
@@ -3947,7 +3947,7 @@ packages:
   license_family: GPL
   size: 149419
   timestamp: 1665498987619
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
   sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
   md5: 1058b661ec829b2ee3716ee2a5520641
   depends:
@@ -3958,7 +3958,7 @@ packages:
   license_family: GPL
   size: 1917987
   timestamp: 1665498925405
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h26321d7_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libllvm14-14.0.6-h26321d7_4.tar.bz2
   sha256: 3c62b303d658923dfd5ef7385a6560c97865e5ad22df05f2822575dc2f2f61f6
   md5: 7a1ba247765a13e183f91bd5e857a0d6
   depends:
@@ -3969,7 +3969,7 @@ packages:
   license_family: Apache
   size: 27922606
   timestamp: 1726769388473
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
   sha256: 499ebc9000c8e810081b5d7f7524b45dc99f6914096ea9e145366033514938b4
   md5: ce5c24f93932e1a53d7d89e502f28783
   depends:
@@ -3980,7 +3980,7 @@ packages:
   license_family: BSD
   size: 10123989
   timestamp: 1664896966769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -3989,13 +3989,13 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -4012,7 +4012,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
   sha256: 246c0d82766042c1a9194eecc71690918c68afa3528ff0c2c82796ce901df40b
   md5: f33be4ed3bff89ed8f68df6c75158510
   constrains:
@@ -4021,7 +4021,7 @@ packages:
   license_family: BSD
   size: 449215
   timestamp: 1729160070984
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
   sha256: d28c465ec6d5f8d4962c597b249b58998300c8b4e3c937c578c3d15294ea863d
   md5: dcaed6ddd0723c7cce6bfad917be98b2
   depends:
@@ -4031,7 +4031,7 @@ packages:
   license_family: MIT
   size: 41176
   timestamp: 1678413498410
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
   sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
   md5: 5c740b4a18a558de0ccfe601703c423c
   constrains:
@@ -4040,7 +4040,7 @@ packages:
   license_family: Apache
   size: 338738
   timestamp: 1662635677689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.43.0-py311h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.43.0-py311h6d0c2b6_0.tar.bz2
   sha256: 73052ee16f6d1df70d79c0258dc4e08af8840812e2d1c04a2edbb87c10ba5a34
   md5: cd252d6bdabf736def933eb57332d0b5
   depends:
@@ -4051,7 +4051,7 @@ packages:
   license_family: BSD
   size: 404923
   timestamp: 1720455346980
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
   sha256: 716a654df2e55052193150015bd5c9856b847893fc5a229fa8669725b1c56ff2
   md5: 687ba6c11de38ad7cc597f7188b491e7
   depends:
@@ -4060,7 +4060,7 @@ packages:
   license_family: BSD
   size: 13357
   timestamp: 1678322560230
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
   sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
   md5: 8f57dc3a3327bb6f7e1cba908856ac7f
   depends:
@@ -4069,7 +4069,7 @@ packages:
   license_family: BSD
   size: 183138
   timestamp: 1714510756758
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
   sha256: 6fb2953e169ee1ae38f24d29752051501992f19b96b5ebcea9af75737bdbcb42
   md5: 7f410cdae838c5030108d1b98a8c78f6
   depends:
@@ -4078,7 +4078,7 @@ packages:
   license_family: BSD
   size: 162478
   timestamp: 1678377892595
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
   sha256: cd97e09a12ffb49b2a30a782fa8c7933b28f5ffdbfc5c73a9ebaa95fc9447370
   md5: d1fb6ebc1e5728aa6377cfc71da08942
   depends:
@@ -4088,7 +4088,7 @@ packages:
   license_family: MIT
   size: 135859
   timestamp: 1684280005320
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
   sha256: 30c3b189462a9d0f4794d229adadf34b5f5a5f56f95c30d5afc17ef524579290
   md5: d4e9421243129d1d57c472dab045f3dc
   depends:
@@ -4099,7 +4099,7 @@ packages:
   license_family: BSD
   size: 26639
   timestamp: 1704206159955
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.9.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-3.9.2-py311hecd8cb5_0.tar.bz2
   sha256: fc0efd282504e5e78ebb1e609832829339a028d28f101d7f9c9a5d8298906154
   md5: b8c27fbded53b7c3ef35e2b4825991f0
   depends:
@@ -4110,7 +4110,7 @@ packages:
   license_family: PSF
   size: 7738
   timestamp: 1725264317918
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.9.2-py311hc25a08b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.9.2-py311hc25a08b_0.tar.bz2
   sha256: 5fddd37bbe579892257bf574bc0b5199b97a3ba8addbf2ec73e5147609eae7cb
   md5: 30837287c1590ec271189cb315be35d1
   depends:
@@ -4130,7 +4130,7 @@ packages:
   license_family: PSF
   size: 9456494
   timestamp: 1725264308019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
   sha256: 07e7fd5bd64e55328b4b99d92e2e2600d791f1095bf905daab4cfc59f0f0a45b
   md5: cf53321779f4ca7e986c1468719b93f1
   depends:
@@ -4140,7 +4140,7 @@ packages:
   license_family: BSD
   size: 19500
   timestamp: 1678317565001
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
   sha256: 0770e02be1ea1216af493cfc03d5b8a702e14606fa93b0692bcdab1fed1b898c
   md5: ca6f06ceaf66a32bbf5dfdb6e373a5cf
   depends:
@@ -4150,7 +4150,7 @@ packages:
   license_family: MIT
   size: 67892
   timestamp: 1678417734353
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
   sha256: fbe95ed0501bb0f137048476fe41bc718dd659e8ecb066bc67ac17d6a50f4318
   md5: ec162bde8d1c8a107b257df218b17035
   depends:
@@ -4159,7 +4159,7 @@ packages:
   license_family: MIT
   size: 23030
   timestamp: 1678381838497
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
   sha256: c20dd678655e582129a858a1c5162bdc254082d3a3c035b0f72629d9276e5b75
   md5: 800a0738c728796e02d0386ce7d457aa
   depends:
@@ -4170,7 +4170,7 @@ packages:
   license_family: BSD
   size: 104585
   timestamp: 1678317269407
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
   sha256: 638450a7ccb5f438ac65aa1c8d871fb5bb664e7261ec7e663d0302485c219a67
   md5: 574875bbeabff85b5d9cfdb62066aece
   depends:
@@ -4180,7 +4180,7 @@ packages:
   license_family: BSD
   size: 29473
   timestamp: 1678392919304
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
   sha256: f961b1322b6b02fee53ff9bd0f56bb73886eb59debd3f3666669593de7f48894
   md5: a1e74ccd2f341d1d672e33d79e60d200
   depends:
@@ -4193,7 +4193,7 @@ packages:
   license_family: BSD
   size: 8183400
   timestamp: 1717623127275
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
   sha256: e08cb3ee6df01f4c1e1ac8bc4ed1a06e549ffcc8774fe2e2842c644bb8f74a86
   md5: 6ba0ae0fb14cbea1e3197707701dc180
   depends:
@@ -4206,7 +4206,7 @@ packages:
   license_family: BSD
   size: 123077
   timestamp: 1698934356774
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.16.4-py311hecd8cb5_0.tar.bz2
   sha256: 098d35939d62073df7fc42fadde9d9f7f646e4727382c363c02c136820555e80
   md5: 25b1cce018e6c1b19146f117690d2b5b
   depends:
@@ -4233,7 +4233,7 @@ packages:
   license_family: BSD
   size: 533595
   timestamp: 1728050041209
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.10.4-py311hecd8cb5_0.tar.bz2
   sha256: 3175bd2b744191da1c7477be8162a0f8d7f68363de8c2ab6df989908211ba17c
   md5: 2508c1c6fc84c712ce0419470f60b5fb
   depends:
@@ -4246,14 +4246,14 @@ packages:
   license_family: BSD
   size: 171386
   timestamp: 1728050190296
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
   sha256: 42d803e1d8b54748db5d989ecd503826f564132df7cddc20f520460f55e523a1
   md5: cd3fa71626ebc098da4625fc6be79752
   depends:
@@ -4262,7 +4262,7 @@ packages:
   license_family: BSD
   size: 16952
   timestamp: 1708532805951
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
   sha256: 09d88f1eb19a90dfe737f0e5b4dce7629f6076a2d91d572cbb0a41be5220a4e8
   md5: ac8c26d949a04f478b560b7d8a2358a4
   depends:
@@ -4287,7 +4287,7 @@ packages:
   license_family: BSD
   size: 707187
   timestamp: 1717630829258
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
   sha256: ed5608feb37a083d47b04203195260e801b64b5380f292cf18bb61e7ad827a2a
   md5: daa9c1c233673b727528548454aea664
   depends:
@@ -4297,7 +4297,7 @@ packages:
   license_family: BSD
   size: 27607
   timestamp: 1699456006797
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.60.0-py311he327ffe_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numba-0.60.0-py311he327ffe_0.tar.bz2
   sha256: 91c63f3ac3b610a957169b06171366da4cfd1f8eca7b484ee66c524de739e40c
   md5: a1cc844a9046142569d89d3642ee460f
   depends:
@@ -4319,7 +4319,7 @@ packages:
   license_family: BSD
   size: 6145701
   timestamp: 1720541086329
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.10.1-py311hc59c7be_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.10.1-py311hc59c7be_0.tar.bz2
   sha256: 4b784353c86d73f10d714c039c29ca73508203cb86a7ce455f71ee52b940edb3
   md5: a8c1b6256e1d5743bb92d9c467736aa8
   depends:
@@ -4333,7 +4333,7 @@ packages:
   license_family: MIT
   size: 202114
   timestamp: 1730216207054
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h91b6869_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.4-py311h91b6869_0.tar.bz2
   sha256: 85aa18f7f372d263f1b9a6eed279e0fa048387520bf71b9c409e13801a0568d4
   md5: c077c784069f04cc487620bcdc7707ea
   depends:
@@ -4346,7 +4346,7 @@ packages:
   license_family: BSD
   size: 11321
   timestamp: 1708642350281
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311hb3ec012_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.4-py311hb3ec012_0.tar.bz2
   sha256: bc050bacb16826ee23329eed65b63c2625884e2af1853f901f7e09870c7dbd1f
   md5: 96b8308a1bdb2f1e77698ea9fdf96bf3
   depends:
@@ -4360,7 +4360,7 @@ packages:
   license_family: BSD
   size: 8784964
   timestamp: 1708642301649
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
   sha256: 401214a4763c79c2355b012b9f29e3cee097a598bb53e933acb6b98a2bb6614f
   md5: 3216c5f433643ee62a8d0672c3500320
   depends:
@@ -4371,7 +4371,7 @@ packages:
   license_family: BSD
   size: 535252
   timestamp: 1722872704730
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.15-h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.15-h46256e1_0.tar.bz2
   sha256: 8cc69ca3f77c9dc8bed662100046085536c6a95b77b2a964ba79fc81ba3f698a
   md5: 270474613701d2371d5c5cc220a78825
   depends:
@@ -4380,7 +4380,7 @@ packages:
   license_family: Apache
   size: 4961721
   timestamp: 1725545867722
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
   sha256: 8a0809f419065e014cb8e2c8a516cadca6088fb71fd1ef3ae2287d91e3360d59
   md5: 4dc0b9bc88476fcc5246d823ff1c289a
   depends:
@@ -4389,7 +4389,7 @@ packages:
   license_family: APACHE
   size: 39645
   timestamp: 1699371213055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-24.1-py311hecd8cb5_0.tar.bz2
   sha256: dfeced2b57d53e4aaaf5e855c2f10b505ee74c486594bbe4b132843f12806ff3
   md5: 05b50489c5ee7b2d5b5750f51cca96c1
   depends:
@@ -4398,7 +4398,7 @@ packages:
   license_family: Apache
   size: 158201
   timestamp: 1720101976586
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.2-py311he327ffe_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-2.2.2-py311he327ffe_0.tar.bz2
   sha256: 878e8fbcca40ac0c3937780160c22b65633b32ac97a886a9e38d4453821fe8bb
   md5: ac61107a8dd7a5a51e19e57fcc3a7a5a
   depends:
@@ -4448,7 +4448,7 @@ packages:
   license_family: BSD
   size: 17291576
   timestamp: 1718309206876
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.5.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-1.5.3-py311hecd8cb5_0.tar.bz2
   sha256: da4c642c2c4d0265063a50cfc3e5437b422bb8e807934823f98e0ab23dafab40
   md5: 7aade1ab52d00e6df57919c6cfeeb2e9
   depends:
@@ -4473,7 +4473,7 @@ packages:
   license_family: BSD
   size: 24103145
   timestamp: 1730381703387
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-2.1.1-py311hecd8cb5_0.tar.bz2
   sha256: a33f52ee58e7856ff19bd306a7c055950d669199981874a38c2bdb1896725c8f
   md5: 7aef330f65dd9dd63a06c89ddfb3b7bd
   depends:
@@ -4482,7 +4482,7 @@ packages:
   license_family: BSD
   size: 267605
   timestamp: 1719348049109
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py311hecd8cb5_0.tar.bz2
   sha256: 359b31da651ee35b9ca43974d26cd44e64f3cf412096c15dec7b720fa909a9b2
   md5: 108e24227f8fdfc4d635bb4eedfa6cef
   depends:
@@ -4496,7 +4496,7 @@ packages:
   license_family: BSD
   size: 48504
   timestamp: 1698702608965
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-11.0.0-py311h9c91434_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-11.0.0-py311h9c91434_0.tar.bz2
   sha256: 055281cab4c89b4e9f8743a1fb45bc578785a6132f10b8628fac33a0959fd212
   md5: 25bf2cadac40910d160ee357504e0a4d
   depends:
@@ -4512,7 +4512,7 @@ packages:
   license_family: Other
   size: 972896
   timestamp: 1731595038107
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-24.2-py311hecd8cb5_0.tar.bz2
   sha256: 492ea4d1c5a4f860f3312c7729f1e33b706007578c25c031241d7497a115dd79
   md5: 835f4767cdb9d80338e0bba649c1ce3c
   depends:
@@ -4523,7 +4523,7 @@ packages:
   license_family: MIT
   size: 2923519
   timestamp: 1723484652903
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 81719c31101d6c019150cedcc7b08adb3bdb357e8b2952e428dadaabc4dc985d
   md5: 105825168e0a17fb007f60b5f314e311
   depends:
@@ -4532,7 +4532,7 @@ packages:
   license_family: MIT
   size: 38405
   timestamp: 1692205731769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
   sha256: c0982f688127129e026d2b4cdacdd5684d00796ea7bdadd7d26b1101b095d723
   md5: 0d6910c74729fede645c010110f1c89e
   depends:
@@ -4541,7 +4541,7 @@ packages:
   license_family: Apache
   size: 121796
   timestamp: 1679340253537
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
   sha256: e32843723b10ecd9badde28e1085419c0b59ed8a96c7cacce6395e39e3a874f9
   md5: 5af0280a817d2c273304cd22328124af
   depends:
@@ -4553,7 +4553,7 @@ packages:
   license_family: BSD
   size: 763044
   timestamp: 1704404460779
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
   sha256: 117a435c2473e2a20cc81eaacb2b45ea5e7fe3c946eec2915936d344913ede44
   md5: 0f459ee59fda20e2077fdc2c777edfc8
   depends:
@@ -4562,7 +4562,7 @@ packages:
   license_family: BSD
   size: 497470
   timestamp: 1679337286052
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
   sha256: 667b5cf00d31293dede2ddadcc30ab967103d585d40647f34d6d830af97ee51f
   md5: 81d3876fa502fca91ba4136a5f3fc3d3
   depends:
@@ -4574,7 +4574,7 @@ packages:
   license_family: BSD
   size: 37821
   timestamp: 1678378977816
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
   sha256: dfb403f367c57327a4d080109df88383ecff18464de287a1ce936a7274e3656b
   md5: 997b674bad89963af875b93b06807f51
   depends:
@@ -4583,7 +4583,7 @@ packages:
   license_family: BSD
   size: 2120413
   timestamp: 1684280057020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.2.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.2.0-py311hecd8cb5_0.tar.bz2
   sha256: d91145c8170d70c3343e3c72de9bbd65f18dd868699d5865cfd378027ed1d1e6
   md5: be4e175b2ddfdde750cdf6f83fb694d0
   depends:
@@ -4592,7 +4592,7 @@ packages:
   license_family: MIT
   size: 487468
   timestamp: 1731445595709
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 717e038567506ca58ce1cd4a3416892d02f4ebfdd332077cc3d110cfe3d36c58
   md5: 53bbfb400668f798eef6f8c7cf938e1f
   depends:
@@ -4601,7 +4601,7 @@ packages:
   license_family: BSD
   size: 35751
   timestamp: 1678315886516
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.10-h4d6d9e5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.11.10-h4d6d9e5_0.tar.bz2
   sha256: 9d61a7f97dc7ebf7ae6c1a0444dc7a776d44170e48a3e13ee667a1d9587e38a5
   md5: 46b63c8af5232ef16f9e5ba15d0d53cd
   depends:
@@ -4620,7 +4620,7 @@ packages:
   license_family: PSF
   size: 16847299
   timestamp: 1727942132354
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
   sha256: 04e100d0a1ea9722e24972657ec5935ad34c7c58957dabb821333e5eac80f717
   md5: 2b6de49ad07b26e1f7084f0fda958eb1
   depends:
@@ -4630,7 +4630,7 @@ packages:
   license_family: BSD
   size: 332276
   timestamp: 1716495830117
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
   sha256: 514249897265f66f6ecca0a4427eb02a43c33b3c24974db16d05db6bbe97881d
   md5: c9ea1437e5a3ba6a52ec2322505203e6
   depends:
@@ -4639,7 +4639,7 @@ packages:
   license_family: BSD
   size: 279116
   timestamp: 1679338758489
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
   sha256: 78b785b9b6ed46c86b0d3a32bdceea49f816672227fb63e726b2d46eadbdba0b
   md5: 79d783f74359141e0b06a848db33823b
   depends:
@@ -4648,7 +4648,7 @@ packages:
   license_family: BSD
   size: 18563
   timestamp: 1683823935261
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
   sha256: e358fe679e83ccdc8c433746ae6468e8e96d90d97d99530f8476ef5630b2c121
   md5: ce30a0a31d891e69dc9b7bf8b7f0c39c
   depends:
@@ -4657,7 +4657,7 @@ packages:
   license_family: MIT
   size: 268876
   timestamp: 1713974360942
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
   sha256: eeb5a5eed93b8e311ad4d3f4389e050f11bba2eaec9536e1c3ed2f849c6c999b
   md5: c18bd3e12de797d52a470c21a150dffe
   depends:
@@ -4669,7 +4669,7 @@ packages:
   license_family: BSD
   size: 65270
   timestamp: 1711136914884
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py311h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.2-py311h46256e1_0.tar.bz2
   sha256: eaba8d555ca65df57c5c1dfa320c6b222ddb2c428609a29765ea89179ff05a98
   md5: 9a926091b8beee27d251241d227a646d
   depends:
@@ -4679,7 +4679,7 @@ packages:
   license_family: MIT
   size: 208392
   timestamp: 1728659514546
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
   sha256: aa07b90a7ee65f76c8cba1ff99a5cdeb95cbe41881ae951f64ffff06674a1b2d
   md5: 58621e3d244137885f7dfbb35e50340a
   depends:
@@ -4689,7 +4689,7 @@ packages:
   license_family: Other
   size: 594801
   timestamp: 1709318510622
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -4698,7 +4698,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
   sha256: d784dc26c5de8e41845350a899e5779250b71f45d39e2aece62e739e9add7308
   md5: 7b077b7f46112bb31dc066396c51d3fa
   depends:
@@ -4709,7 +4709,7 @@ packages:
   license_family: MIT
   size: 74776
   timestamp: 1699012164201
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.32.3-py311hecd8cb5_1.tar.bz2
   sha256: 022bc34ef458cf0f26cb2e94f3238618e72ca59489efb074d25e5a4700e53707
   md5: 4f1d626c702cbb79e25aa92375049279
   depends:
@@ -4725,7 +4725,7 @@ packages:
   license_family: Apache
   size: 124655
   timestamp: 1730999183404
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
   sha256: 727fb8d957e02d03b928d049ffbc712316f176a2c331391766d646621b45655a
   md5: 7e0e416c642f3ee4ddfb084a811fb4df
   depends:
@@ -4735,7 +4735,7 @@ packages:
   license_family: MIT
   size: 10236
   timestamp: 1683077214314
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
   sha256: a8a67143ccb65cfd6f50055176b6c26179a83130a45d0a12e79dd2de68d8db63
   md5: a2065790f41e3eeb6efe0ef6daa75377
   depends:
@@ -4744,7 +4744,7 @@ packages:
   license_family: MIT
   size: 10600
   timestamp: 1683059285216
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
   sha256: 6aba582338faa0c26fe336bdb10c65b8f7808a6e383bd8f80f3e6b612ca209ec
   md5: a7486349b5f7370f6902c2050a23d268
   depends:
@@ -4753,7 +4753,7 @@ packages:
   license_family: MIT
   size: 319197
   timestamp: 1698946203341
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.14.1-py311hedc7b93_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/scipy-1.14.1-py311hedc7b93_0.tar.bz2
   sha256: 274d0fa785a3ef80b328ef228ea1dae725622ad01f180ff806c8615e7a55c175
   md5: 18c8cc0edb49b32b465a6818b12f701f
   depends:
@@ -4770,7 +4770,7 @@ packages:
   license_family: BSD
   size: 27414506
   timestamp: 1731626394302
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
   sha256: beba0555707dac1e8484d73cee9e4128ac4b10e2a0d4209357481179022e8fdc
   md5: baa8b304607b3a9ae8a3d9acb354c31c
   depends:
@@ -4779,7 +4779,7 @@ packages:
   license_family: BSD
   size: 33343
   timestamp: 1699371216044
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-75.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-75.1.0-py311hecd8cb5_0.tar.bz2
   sha256: c6e56b4a14e883c7296b52673b4129e933d2bcfe45fafd8b504e62442aa290ba
   md5: e658b6de04d59ad8fb45391c7e8dce54
   depends:
@@ -4788,7 +4788,7 @@ packages:
   license_family: MIT
   size: 2318419
   timestamp: 1726678116770
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
   sha256: 0eb44a16ef74a13ef7839209899d009cd94974fbc406a417d958c7bc8d955245
   md5: 41f239a5b67b1daf819849023aa5d12f
   depends:
@@ -4797,7 +4797,7 @@ packages:
   license_family: Other
   size: 19056
   timestamp: 1705431379885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
   sha256: 14775231982e1ea150189c956927ccfb1ad01a8c9395cdeea4d5a48b9b8ce664
   md5: 729badc4bf7ba8ccc70e0f9e58075c99
   depends:
@@ -4806,7 +4806,7 @@ packages:
   license_family: MIT
   size: 89812
   timestamp: 1696347694075
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
   sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
   md5: 6bef1694163a68ac4c37e5857b8da4f5
   depends:
@@ -4818,7 +4818,7 @@ packages:
   license_family: Other
   size: 1900191
   timestamp: 1714488351925
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -4827,7 +4827,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
   sha256: 3d5c2968f581006437df3932cd5d3c1c4afa78f0e13757b958440245d3248856
   md5: 605ea221d225ad8e79284dbcfdab0715
   depends:
@@ -4838,7 +4838,7 @@ packages:
   license_family: BSD
   size: 37699
   timestamp: 1678317755913
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
   sha256: ed059e32ce5a1c0511575f29d2fb6da12c54a37000bfa80f9e5aa9dfd9e04101
   md5: 4d2261a92d25136a68b8d01d101119f5
   depends:
@@ -4848,7 +4848,7 @@ packages:
   license_family: BSD
   size: 49145
   timestamp: 1678317386284
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
   sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
   md5: 523c006cc67c011383678c762015479b
   depends:
@@ -4857,7 +4857,7 @@ packages:
   license_family: BSD
   size: 3594448
   timestamp: 1714770737885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py311hecd8cb5_0.tar.bz2
   sha256: 424b8284072266eb59d055c0b7b58241bfb00009d445743ea261d4eeee73ea19
   md5: f3a47898a55087edb9d65d29c24d9b88
   depends:
@@ -4866,7 +4866,7 @@ packages:
   license_family: BSD
   size: 135757
   timestamp: 1678323030858
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.1-py311h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.4.1-py311h46256e1_0.tar.bz2
   sha256: f46d29f5c4f5fceb7a39343da76f5c5ab89cbb0844e80a3a90457201c3fbc168
   md5: ee154208a17c1c4cd42d264b1a6f77c3
   depends:
@@ -4875,7 +4875,7 @@ packages:
   license_family: Apache
   size: 914461
   timestamp: 1718740220272
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.5-py311h85bffb1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.66.5-py311h85bffb1_0.tar.bz2
   sha256: ec67885e979483932bf0ce9e720841d6f9d44bbc5a049f2e4a15232803f8362a
   md5: 044460e02becd58190c03e794461acee
   depends:
@@ -4886,7 +4886,7 @@ packages:
   license_family: MOZILLA
   size: 155741
   timestamp: 1724854618448
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
   sha256: 5283f2b23a6e9d888b2834cba2bbf284f551e199d2c1b4add176b1cbafb19ee0
   md5: 58bf7871ca100fbda0492bb5a3363c80
   depends:
@@ -4895,7 +4895,7 @@ packages:
   license_family: BSD
   size: 208200
   timestamp: 1718227205760
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
   sha256: 17e5688d09ffbcb8b71b34b86edc7374fa0b04d60a4d729d405ffc22ef63726c
   md5: e4bf44ddbbcb136332ccb47ac2b879a0
   depends:
@@ -4905,7 +4905,7 @@ packages:
   license_family: PSF
   size: 9890
   timestamp: 1715269046804
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
   sha256: 7d369ec970d1d5411e457c79f94197756c7088deff8183806ea71e633b26edf9
   md5: 9ffa197b26373667f50b21876862398e
   depends:
@@ -4914,7 +4914,7 @@ packages:
   license_family: PSF
   size: 75595
   timestamp: 1715269030928
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
   sha256: a9960485ced319ac91afe69eaaf703c7e6b3049f1e06a4a8c2818b64155943f0
   md5: 0a9c8ea92a14330a07edabac249e32a9
   depends:
@@ -4923,7 +4923,7 @@ packages:
   license_family: MIT
   size: 11399
   timestamp: 1678394892923
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
   sha256: d42ae57366d05e12f10074583568355752436d66ad018ffbcfa24135f593810a
   md5: 1a98e48aa0bd8b3ec09e2cbdbb236575
   depends:
@@ -4932,7 +4932,7 @@ packages:
   license_family: Apache
   size: 498952
   timestamp: 1713213079520
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-2.2.3-py311hecd8cb5_0.tar.bz2
   sha256: 89314728453fa65647c24a1991a18f1105ed5da67c69dc42231d26a6bc96c42c
   md5: 3c07406e5e9575d136d225c57159cec3
   depends:
@@ -4948,7 +4948,7 @@ packages:
   license_family: MIT
   size: 218673
   timestamp: 1727770118330
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
   sha256: 597015e8a038a111f03ffbc9a217fcda549d75230c86ce53c1f23c53d6f1a0cb
   md5: 62e98aac883bccc1c87ca0d2ce2f08e0
   depends:
@@ -4957,7 +4957,7 @@ packages:
   license_family: BSD
   size: 25798
   timestamp: 1678317074170
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
   sha256: 1430e6f4b4dd9354b7bb88f7f7bc9cdbab26a034ad1ae5c278de0f5a99329372
   md5: be0832862b29bf5767a707ac6bd53b93
   depends:
@@ -4966,7 +4966,7 @@ packages:
   license_family: Apache
   size: 114834
   timestamp: 1715878445060
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.44.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.44.0-py311hecd8cb5_0.tar.bz2
   sha256: 907fd39137318473d447c56d77f775c9d3fef5b4e840f8c43f50f8f9c016710f
   md5: 2106db0f651f613ca1971e60afe3f5f2
   depends:
@@ -4975,7 +4975,7 @@ packages:
   license_family: MIT
   size: 139423
   timestamp: 1726165218455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py311hecd8cb5_0.tar.bz2
   sha256: cc6995f677d1628f42ae80ed47ff08d8d1c8ed12580a326af6e307f5febc594a
   md5: d01eb964863b95ef62061b77c9037ead
   depends:
@@ -4987,7 +4987,7 @@ packages:
   license_family: Apache
   size: 2471632
   timestamp: 1689041625741
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
   sha256: 5b6d5246955b5f9480ff7027eb002442a7ade24f5c354da54ed513042f76cedc
   md5: f32aa8a37d5e65a8dc30f9a1f46bc63d
   depends:
@@ -4996,20 +4996,20 @@ packages:
   license_family: BSD
   size: 54719
   timestamp: 1678325412288
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
   sha256: ed0152ad6b87ffd9e01f4a62bc358e805ad59637f898a801b0a9cf903ae8e1fb
   md5: 8a92f8c663608f24e14d8a2068b9d83a
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 415323
   timestamp: 1714511993944
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
   sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
   md5: c25b6d40f834647d0bbe767f6c776031
   depends:
@@ -5019,7 +5019,7 @@ packages:
   license_family: Other
   size: 329449
   timestamp: 1705602140856
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.20.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.20.2-py311hecd8cb5_0.tar.bz2
   sha256: e1d2b53a215470bca64137e2f9cbae072c14bf15e01db0a1e8da06b32051dd3f
   md5: 2790f84d4d000e28df25819c22846d05
   depends:
@@ -5028,14 +5028,14 @@ packages:
   license_family: MIT
   size: 29925
   timestamp: 1729012443048
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
   sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
   md5: f2519b551f99765d9d98950c5e2b4713
   license: Zlib
   license_family: Other
   size: 119782
   timestamp: 1714511811597
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
   sha256: a1f470eabe211500d2ec7866ecf421c067f159045f0245f19e9ba8272c5a177e
   md5: f8bd5fb9fac17a47c64ae56355faba24
   depends:
@@ -5046,7 +5046,7 @@ packages:
   license_family: BSD
   size: 1033188
   timestamp: 1728487057684
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.6.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.6.2-py311hca03da5_0.tar.bz2
   sha256: 8d925b1438e14479c33257054daaf3acab8db996d49fc1f57f9a675569a90493
   md5: 7277b32d35b11efb43245178c3f99fb4
   depends:
@@ -5060,7 +5060,7 @@ packages:
   license_family: MIT
   size: 245764
   timestamp: 1729121361882
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
   sha256: 43405cc7341ce3efb2e24013ad62c64f26a69926635adceaa5459ccbcafb3776
   md5: effa6d22f497e164cc8455f7f329c304
   depends:
@@ -5069,7 +5069,7 @@ packages:
   license_family: BSD
   size: 12510
   timestamp: 1677917870614
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
   sha256: 947efe1c50b3280e9a67cbb18636bdade53a40960fff3056850ff81ab87acbe3
   md5: 7d2d384ee32ccc12dcb0dc099e421482
   depends:
@@ -5079,7 +5079,7 @@ packages:
   license_family: MIT
   size: 35091
   timestamp: 1677915945226
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-24.2.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-24.2.0-py311hca03da5_0.tar.bz2
   sha256: cbca44661d23850f519d90cfe520979fd35bef9e012152fa69d6d41eb373361c
   md5: 93a707d1b918d7b2139f4cb205b17aee
   depends:
@@ -5088,7 +5088,7 @@ packages:
   license_family: MIT
   size: 163840
   timestamp: 1729089502271
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
   sha256: ae3c6633ed84bac16592b3b756f96ffc577414971014ca9efa498a162588757f
   md5: ea600f99d012d734f831d1bc00a17661
   depends:
@@ -5098,12 +5098,12 @@ packages:
   license_family: MIT
   size: 281227
   timestamp: 1718029919645
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.6.0-py311hca03da5_0.tar.bz2
   sha256: 2504fa4295015f621e607dde7a42efba5fec71bf691785ba8e2f86e72df19e88
   md5: c961dda50ad88ee093645de69e768a4c
   depends:
@@ -5121,7 +5121,7 @@ packages:
   license_family: BSD
   size: 5908154
   timestamp: 1727914592573
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.4.2-py311hb9f6ed7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.4.2-py311hb9f6ed7_0.tar.bz2
   sha256: db1a051d5329611e3e0fab1ea11b2ec06ae511e6c34935738a701ac2ae2fcf86
   md5: 14b2ca28694689fa950ae434e4390224
   depends:
@@ -5131,7 +5131,7 @@ packages:
   license_family: BSD
   size: 135731
   timestamp: 1731058941306
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
   sha256: 048264434c33fdb53862cdd69b2e2bc4ce6f8a70b3211ad6d686d066eac2aa91
   md5: d55696ccaf6755931cd662dfb929aa0b
   depends:
@@ -5141,7 +5141,7 @@ packages:
   license: MIT
   size: 19737
   timestamp: 1714483270447
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
   sha256: 13627293296fcc231d8dc12d803dfc9621108c60df38b0e3c64e9e02ed55e564
   md5: 86efd4ad08cd80d3eab77873db84a255
   depends:
@@ -5150,7 +5150,7 @@ packages:
   license: MIT
   size: 19083
   timestamp: 1714483255364
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
   sha256: 2e542b2bb27f8379da3efcb83ef084cb26e6a9ab576c50487c2dd996afd5ccb1
   md5: e8cab9d1ef58a450f971690fcdb2ede2
   depends:
@@ -5159,21 +5159,21 @@ packages:
   license: MIT
   size: 380182
   timestamp: 1714483330655
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
   sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
   md5: 56d1386c7f1f338f0d18f82af6525273
   license: bzip2-1.0.8
   license_family: BSD
   size: 158748
   timestamp: 1714510571033
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.9.24-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2024.9.24-hca03da5_0.tar.bz2
   sha256: b3b13d44d3e05c88f411d245c052b547652be3f3ce7ba21970ba1bbf20a8ea33
   md5: d8091745a1bfd921bf15b2f73111d299
   license: MPL-2.0
   license_family: Other
   size: 141261
   timestamp: 1727794860441
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.8.30-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.8.30-py311hca03da5_0.tar.bz2
   sha256: b5bf3208e126cb67926c2a36b5438d84eee9b8352ec007d6b143b0751ac6d8a8
   md5: 07d0c4f8a1807db57b12a461f6142eb9
   depends:
@@ -5182,7 +5182,7 @@ packages:
   license_family: Other
   size: 170510
   timestamp: 1725551796823
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_0.tar.bz2
   sha256: 5b98c2dc6ebb5b3d5bf6e58ff3f495b4bf71b28de86ca299186554639de381c7
   md5: a95cbad1b8d8cff239a8eb5d940c663f
   depends:
@@ -5193,7 +5193,7 @@ packages:
   license_family: MIT
   size: 292045
   timestamp: 1726856478903
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
   sha256: df81a27f221d11af4a709f272dc8ba3fd3f6d5ab4ffd883c40567bcf04f0cfd3
   md5: e49333e3ffe1fe2e701f50a6e6dccc52
   depends:
@@ -5202,7 +5202,7 @@ packages:
   license_family: BSD
   size: 204179
   timestamp: 1698129906257
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-3.0.0-py311hca03da5_0.tar.bz2
   sha256: 340739a06e25afcd23ec4c5e5d45ac940feb16bee5122e1d14d261a2c80b5617
   md5: bd85d021206472f6a6615575f126ed65
   depends:
@@ -5211,7 +5211,7 @@ packages:
   license_family: BSD
   size: 43128
   timestamp: 1721657439520
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
   sha256: 808e56fb70f3d38599ee7a54c2a707b282ba9a401fa69a1f54cdc26425d9ce01
   md5: fc37321833175bda4fc5c21afe32db49
   depends:
@@ -5220,7 +5220,7 @@ packages:
   license_family: CC
   size: 539588
   timestamp: 1709758479776
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
   sha256: d9c126d8bcd1c89ea37186c172d6b1f73f45ada60e3ae1790a017b530baa0147
   md5: f0223aae3d622547f6accb212579c58e
   depends:
@@ -5230,7 +5230,7 @@ packages:
   license_family: BSD
   size: 17967
   timestamp: 1709322909223
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
   sha256: 1f908c688e47d03d92ac09d9541a1f1c773ac2ca485dd1d77441b1aaefc032db
   md5: 444c330471496a39a97e87f41ed70c96
   depends:
@@ -5241,7 +5241,7 @@ packages:
   license_family: BSD
   size: 281104
   timestamp: 1700583698464
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cramjam-2.7.0-py311h62f922a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cramjam-2.7.0-py311h62f922a_0.tar.bz2
   sha256: 1a71c2e15872edff275f419bd1b827c2e37a4cfaf997cd30104cadb2da285a5b
   md5: e97551b1be62a8bc30eb69e1dfe39191
   depends:
@@ -5250,7 +5250,7 @@ packages:
   license_family: MIT
   size: 1531706
   timestamp: 1702651054879
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.8.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2024.8.2-py311hca03da5_0.tar.bz2
   sha256: 15839c0b76d580d62c4f06f834c6e2539a76034fdaf982911c389a017f7cced4
   md5: 0c589d3d6f8d6ebe5996b2fff3620e1d
   depends:
@@ -5267,7 +5267,7 @@ packages:
   license_family: BSD
   size: 3119804
   timestamp: 1725461423376
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.16.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/datashader-0.16.3-py311hca03da5_0.tar.bz2
   sha256: adf3ced9e94279c8700527309b650491a498e71cc9114caa517dd8beac136525
   md5: de926408cadc24e8e062f5e686247c39
   depends:
@@ -5290,7 +5290,7 @@ packages:
   license_family: BSD
   size: 18017422
   timestamp: 1720540529831
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
   sha256: b9356e3ada4872c7c950d2ac7e0f107c4786775191efdfda3a469dffb18f2714
   md5: 07ddd96675caf30ea77cafb1ea5662a4
   depends:
@@ -5300,7 +5300,7 @@ packages:
   license_family: MIT
   size: 2490144
   timestamp: 1690905181398
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
   sha256: b1481ffa475c65200626f051d5dcbdb264730b533e928dde608a79ce7a5b4e48
   md5: aada2761547a291d68f4c016a1a9bc7b
   depends:
@@ -5309,7 +5309,7 @@ packages:
   license_family: MIT
   size: 18265
   timestamp: 1677911915719
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-2024.2.0-py311hb9f6ed7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fastparquet-2024.2.0-py311hb9f6ed7_0.tar.bz2
   sha256: 9fc5d69d32d7220004d221f730c50fedfb9d92b12751ed2992ab168dadc85864
   md5: 5d5095c56297f7a7d0d324b496b23b98
   depends:
@@ -5323,7 +5323,7 @@ packages:
   license_family: Apache
   size: 646867
   timestamp: 1715262347984
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
   sha256: eb82a0e2ca36d0973b5f6642e27609554edad4b72696f989776d5db8cd4a6a42
   md5: fa8d9dd8a2fabba964c6bb75ace8c572
   depends:
@@ -5341,7 +5341,7 @@ packages:
   license_family: MIT
   size: 3201601
   timestamp: 1713551611540
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -5351,7 +5351,7 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.6.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2024.6.1-py311hca03da5_0.tar.bz2
   sha256: dea477d2b42cc015a051cc99d3c3ac0973df6c864088c8da0e77ab0713510b41
   md5: d66f06e18672ef030741a74261313915
   depends:
@@ -5362,7 +5362,7 @@ packages:
   license_family: BSD
   size: 383596
   timestamp: 1724855620851
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.20.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.20.0-py311hca03da5_0.tar.bz2
   sha256: 1fc120c7bb3c245be0b2805ffaba6518b56e32ca510439b592172138e02e8700
   md5: be7cf3596496c3d91885749d37e71362
   depends:
@@ -5382,7 +5382,7 @@ packages:
   license_family: BSD
   size: 6103533
   timestamp: 1730827873611
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.11.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/hvplot-0.11.1-py311hca03da5_0.tar.bz2
   sha256: e8233716ac401e28fe783ac6175a88f325eea921688eee28e51c1501fa35f046
   md5: 7d726e0a6b3533c17cba3ef1bba36dd0
   depends:
@@ -5399,7 +5399,7 @@ packages:
   license_family: BSD
   size: 372730
   timestamp: 1729516877805
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
   sha256: 4d4ab70ae0ce008c1cc96a4edfbf3866d5e636acc4799a545ea93acee51635f7
   md5: 86a085a440729020d1d7b0b74d6a0c6c
   depends:
@@ -5408,7 +5408,7 @@ packages:
   license_family: BSD
   size: 148448
   timestamp: 1714398923507
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-7.0.1-py311hca03da5_0.tar.bz2
   sha256: ec139e4b87aadcacc0670ecbcc2a303d858d4ac38b9404458a4b676bce9d21d5
   md5: bfcfed281f8df0f18726ec5f843b2b26
   depends:
@@ -5418,7 +5418,7 @@ packages:
   license_family: APACHE
   size: 51053
   timestamp: 1704813595720
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.29.5-py311hca03da5_0.tar.bz2
   sha256: 12ecf9e8614e4d864a3a82d1244b35bd93a3625c7521f44d75c1fb198501e3b5
   md5: 6c05e1ef68be71ffae5bc818f393c6fa
   depends:
@@ -5440,7 +5440,7 @@ packages:
   license_family: BSD
   size: 238518
   timestamp: 1728665670755
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.27.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.27.0-py311hca03da5_0.tar.bz2
   sha256: d2e3d351d5a509d9b384bba4684ff8ccd4fdc12a603f15a49e3d569d56ea413c
   md5: c448971003786058866ba2239dc61986
   depends:
@@ -5458,7 +5458,7 @@ packages:
   license_family: BSD
   size: 1636515
   timestamp: 1726064271144
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.19.1-py311hca03da5_0.tar.bz2
   sha256: 0dcfa64fca981f7c08f151bdb53b414e34c735184f1774ed9e0686f044488b9e
   md5: 154a56110b37c8a84cc38e4f43d5ef5b
   depends:
@@ -5468,7 +5468,7 @@ packages:
   license_family: MIT
   size: 1179602
   timestamp: 1721058583397
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.4-py311hca03da5_1.tar.bz2
   sha256: 5057f548fb76e0afa997f69dd08a0c1a1d0b13382ca58e909fd378f1ff74de57
   md5: 329e65306aa67a099eb34e39f80ef912
   depends:
@@ -5480,14 +5480,14 @@ packages:
   license_family: BSD
   size: 357841
   timestamp: 1730902943889
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
   sha256: 9d5cbffa98f3a4391f66b0c5ce1f411f0bfb0eb83137dc7146fb7bae23cb3570
   md5: 95c92318023482e4e8c698ae6c4597fe
   license: IJG
   license_family: Other
   size: 274078
   timestamp: 1722872672311
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.23.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.23.0-py311hca03da5_0.tar.bz2
   sha256: 5e1400c72584b88b0ea13d2e66110eb7571f155f8b8d62ede4ca61b8279b8bdc
   md5: 6924a112e8115ffdb74a5c8840903b84
   depends:
@@ -5500,7 +5500,7 @@ packages:
   license_family: MIT
   size: 193322
   timestamp: 1728486773537
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
   sha256: 404b0847029f77bedd7902a170a046219e0dc5c0ec2be19ff45361cff25b2181
   md5: 3a02bbe8d45fdbcb2350f672be74c9f5
   depends:
@@ -5510,7 +5510,7 @@ packages:
   license_family: MIT
   size: 16524
   timestamp: 1699032463763
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
   sha256: 7deb8ad28c34c369573754304a03ea2acda8ee39102a56526ec689a4d9210109
   md5: 675ea1a746a78ff6bf8fc4b39139efff
   depends:
@@ -5526,7 +5526,7 @@ packages:
   license_family: BSD
   size: 277400
   timestamp: 1677914250715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
   sha256: ceec15c84f5c699b8055d01e046be04ccb7cfd7c8bd090fc18959f2a4d9f8cf8
   md5: f85c11f7068312e1e84505efef9d55e3
   depends:
@@ -5537,7 +5537,7 @@ packages:
   license_family: BSD
   size: 98520
   timestamp: 1718818476094
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
   sha256: b2f1ee2a297e001a2e70bc218f60deb08c50b9b727668913ed5a106640413d2e
   md5: fc4e797a17ff5dccadfb5d19346b7800
   depends:
@@ -5553,7 +5553,7 @@ packages:
   license_family: BSD
   size: 43099
   timestamp: 1718738212629
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
   sha256: 2d96618ab2e9b3de870a713d7e5b19f6cde936291f3c87972f945b6e27024e77
   md5: 534159d29d9aba9c7e70ee52c27b326b
   depends:
@@ -5580,7 +5580,7 @@ packages:
   license_family: BSD
   size: 614003
   timestamp: 1718827110867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
   sha256: 501e929d345aaa9079c965552b942b4e8bde35b87ae89faef003687a40bab3a4
   md5: 54c7b8554a405acd7c8326c41ba93e63
   depends:
@@ -5590,7 +5590,7 @@ packages:
   license_family: BSD
   size: 28237
   timestamp: 1686870817418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
   sha256: 773e7c4571f482a744dfb18ae26fb22635f5d3f51389c838bd97f9044ea55cc4
   md5: 5161546aba5597318cb5653390cdecd8
   depends:
@@ -5602,7 +5602,7 @@ packages:
   license_family: BSD
   size: 20235
   timestamp: 1700168681687
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
   sha256: 8c1c64d51be73aad381992a9df19d8336910bdfc40f19940231df86e177d17cc
   md5: b1f786f96684a143cf30d1f6b8aebdb3
   depends:
@@ -5612,7 +5612,7 @@ packages:
   license_family: BSD
   size: 65045
   timestamp: 1677925371836
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -5622,7 +5622,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -5631,13 +5631,13 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
   sha256: 199042b87451abaf14546af124ae3380194cddda928e0d30ccb341e93084854c
   md5: eaa0442887994a82486c65d87f6b71e6
   license: MIT
   size: 68806
   timestamp: 1714483212137
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
   sha256: bd9a8a17fb14086446b710fa029d238e69274b83ee2e7e09093496f190de82b5
   md5: 66615d6a0cb5dcca3e20c019cde0ed2d
   depends:
@@ -5645,7 +5645,7 @@ packages:
   license: MIT
   size: 32975
   timestamp: 1714483225840
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
   sha256: e1bf77e8b975c30a69b08a08410622e27c8cff6f592ccfa590466b83d9e6d104
   md5: 8af86bdac01fe303d693d9b76c071059
   depends:
@@ -5653,28 +5653,28 @@ packages:
   license: MIT
   size: 310266
   timestamp: 1714483239194
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
   sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
   md5: f31e4eb9cd6447cc2f5ef0243a76540c
   license: MIT
   license_family: MIT
   size: 120460
   timestamp: 1714483461787
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -5683,7 +5683,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -5694,7 +5694,7 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h19fdd8a_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libllvm14-14.0.6-h19fdd8a_4.tar.bz2
   sha256: fd3149d43dd971c2c1243a1f06a6b4e6ca1e405f058a8a6544267de4940c0622
   md5: 53449788cfa51053aed142dcdc1143c4
   depends:
@@ -5705,7 +5705,7 @@ packages:
   license_family: Apache
   size: 26599780
   timestamp: 1726766682927
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -5716,7 +5716,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -5725,13 +5725,13 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -5748,7 +5748,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
   sha256: 479cf759232c2361af87493ecd124e7d3a8940030e42e1931234c35bea73c3bd
   md5: cd8fe2c981594a457c6af3a0d5de0bd5
   constrains:
@@ -5757,7 +5757,7 @@ packages:
   license_family: BSD
   size: 341817
   timestamp: 1729160040909
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
   sha256: 41c62a460bb81a1a272aa28b219fab9c26510adac177ff1528b1980eabc6e868
   md5: 8d312c5628dc7ea833e9b4dcb73e9c45
   depends:
@@ -5767,7 +5767,7 @@ packages:
   license_family: MIT
   size: 42346
   timestamp: 1677973051421
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -5776,7 +5776,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.43.0-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.43.0-py311h313beb8_0.tar.bz2
   sha256: e30d9731f52550ab97edacacf9bc11f53d64202e06fbc1747b263c18f26a924b
   md5: 36e9863286c1022e2439cb56b83bc1ce
   depends:
@@ -5787,7 +5787,7 @@ packages:
   license_family: BSD
   size: 409623
   timestamp: 1720455480232
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
   sha256: 5777bbef827f72975a36f3da80ab4af718dc781264f74ad7e3864755d620c0f0
   md5: 4240f1a79b812387919cc710a0469556
   depends:
@@ -5796,7 +5796,7 @@ packages:
   license_family: BSD
   size: 14318
   timestamp: 1677925438733
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
   sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
   md5: f5f7e6e7541d8dc3d3df270d488d2e24
   depends:
@@ -5805,7 +5805,7 @@ packages:
   license_family: BSD
   size: 176990
   timestamp: 1714510588159
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
   sha256: d024f5142416961a5e66e424d4d14aec652f9e9dd738b41a97f45674c2ffc9d5
   md5: 0e2d94b125d802f7b006cf19c71655a1
   depends:
@@ -5814,7 +5814,7 @@ packages:
   license_family: BSD
   size: 163084
   timestamp: 1677932947966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
   sha256: acfd84e29ff4dc2d85543bb973a07f22b4ba53c5d00bca84608ee7f13b2a8676
   md5: 5ca161cd51e2db358e768453b3ee485e
   depends:
@@ -5824,7 +5824,7 @@ packages:
   license_family: MIT
   size: 135871
   timestamp: 1684279980293
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
   sha256: b1bed54c7bfb7304cde9e8e6f798543d08e808e81286a5a48296fc94d621f9da
   md5: 774358285c9e496c9f5c121cc546c823
   depends:
@@ -5835,7 +5835,7 @@ packages:
   license_family: BSD
   size: 27438
   timestamp: 1704206026910
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.9.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-3.9.2-py311hca03da5_0.tar.bz2
   sha256: cf95a569383fae0236bacfd3ecf9bb021e2addcfcddaac76e400f8025ec7ec26
   md5: 43d3a01ac2853a8b19ca185a42db3c36
   depends:
@@ -5846,7 +5846,7 @@ packages:
   license_family: PSF
   size: 7710
   timestamp: 1725263985080
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.9.2-py311hecf7826_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.9.2-py311hecf7826_0.tar.bz2
   sha256: 405da586a7522b94b0fadaf268e34a289aefaa7a1cc49da8702a13fcff1152f7
   md5: 60d5ec1d897778a50874147ffb31e7db
   depends:
@@ -5866,7 +5866,7 @@ packages:
   license_family: PSF
   size: 9423902
   timestamp: 1725263975062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
   sha256: 3276d61fc353c537bb09d4b7473d7abe12be38806f42c8cc383b62f40850a5cc
   md5: 6e9c9d47f264b77d9a8461f0899848a7
   depends:
@@ -5876,7 +5876,7 @@ packages:
   license_family: BSD
   size: 20446
   timestamp: 1677918370379
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
   sha256: 43c96d30775b61b4968422a47f9605049428120669f0742bbb9e5ba145c7d11e
   md5: a31ca0d9284860adf5463cf45a5e3145
   depends:
@@ -5886,7 +5886,7 @@ packages:
   license_family: MIT
   size: 69243
   timestamp: 1677995336989
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
   sha256: 96d8c9f42a38651b7bafe5f3cb132601db76cd1e28fa58e2eaf090e634292fff
   md5: 5ebc793a17b6aa84d13f19433545ffa5
   depends:
@@ -5895,7 +5895,7 @@ packages:
   license_family: MIT
   size: 23895
   timestamp: 1677942274932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
   sha256: db9bd659ada23f1ded443d2db00dd13b5d5c0b30f5062544b1ee2c2b88d63d29
   md5: 03c48121614cf12abfe30eced9b34717
   depends:
@@ -5906,7 +5906,7 @@ packages:
   license_family: BSD
   size: 105333
   timestamp: 1677916687032
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
   sha256: 8b05894fdcbe5cfcdee94812b043de4cd7b4fa51d3e2aad25fc7cff50c8f82ab
   md5: c970d49137dce1c77f782ee5725950c1
   depends:
@@ -5916,7 +5916,7 @@ packages:
   license_family: BSD
   size: 30745
   timestamp: 1677960816849
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
   sha256: b6fa12e4bde747bf288bda31ce8ec5e24292dbf74fde67f18f9c9c100b845a38
   md5: 2eddc760c15171a1e8aa838d9d162e18
   depends:
@@ -5929,7 +5929,7 @@ packages:
   license_family: BSD
   size: 8291605
   timestamp: 1717622676584
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
   sha256: e8eee27fb667aa10b26f3bc4b93f449b7d991ded27b9cb457effee394ce05f6f
   md5: 6a3e5cd0e1141c01ffb91285bdccfe83
   depends:
@@ -5942,7 +5942,7 @@ packages:
   license_family: BSD
   size: 123043
   timestamp: 1698934328890
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.16.4-py311hca03da5_0.tar.bz2
   sha256: 1f6d171443b30990cd724ef1e5fa287311d1cf9064c0f5984e6acb2225a0197c
   md5: 9a8675276a35db6cc6649f0bddecf53d
   depends:
@@ -5969,7 +5969,7 @@ packages:
   license_family: BSD
   size: 531141
   timestamp: 1728049778343
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.10.4-py311hca03da5_0.tar.bz2
   sha256: ae983360f1f69987f0fb3a8de9767b362dc903a9b0b130d87fcfcca445dddc4b
   md5: f56cbcd18632f7f669a28363c6d3fe4e
   depends:
@@ -5982,14 +5982,14 @@ packages:
   license_family: BSD
   size: 171380
   timestamp: 1728049515633
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
   sha256: 417ace1ce51e81f3f92ddc26e0e3a83c1e19c9ebb7af7104452002a5573da534
   md5: 3e11de6cef096091bb733e07802f00b0
   depends:
@@ -5998,7 +5998,7 @@ packages:
   license_family: BSD
   size: 16979
   timestamp: 1708532698253
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
   sha256: 8ea1be4285e2e7d361cbcc1daf9c220f87ceaab2308bf7b339d2513d6ea22184
   md5: 774ce02efa90f212023541c0b24e92c1
   depends:
@@ -6023,7 +6023,7 @@ packages:
   license_family: BSD
   size: 726598
   timestamp: 1717630964815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
   sha256: b0cc542e2a6f42ba716e7e4ccf29eddcb155ad167fcdbc72d2db9c7873eb5639
   md5: 7acf81b17d2c4ceb3cd39dc9f173855c
   depends:
@@ -6033,7 +6033,7 @@ packages:
   license_family: BSD
   size: 27539
   timestamp: 1699455954000
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.60.0-py311h7aedaa7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numba-0.60.0-py311h7aedaa7_0.tar.bz2
   sha256: 00a7fab2dc788b2f4d748702d9eed2cca75d7486aeff0209f0c2979e2ec28a40
   md5: dc8ceb8ae25109aa6c9face25605e269
   depends:
@@ -6055,7 +6055,7 @@ packages:
   license_family: BSD
   size: 6146936
   timestamp: 1720609337122
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.10.1-py311h5d9532f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.10.1-py311h5d9532f_0.tar.bz2
   sha256: e7085ecdcbb7814ab5b588399963d6877083cbcbce27407b5ded3c099af1e6a9
   md5: b656e9369b00f6f0eec85203e35eaa42
   depends:
@@ -6067,7 +6067,7 @@ packages:
   license_family: MIT
   size: 189479
   timestamp: 1730216150682
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
   sha256: d3bb1d4be88320a5861cd3a0f086e9709f9b64c96c032cb9039cc4f17ec66a85
   md5: 0a7b97665c06fcd34a70e34abc177280
   depends:
@@ -6080,7 +6080,7 @@ packages:
   license_family: BSD
   size: 11288
   timestamp: 1708639168951
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
   sha256: 3e70248a7069ca12ccf56252869bfdb72211fd4e4c327e6994756496df786c79
   md5: ce4846006d98638cd86a532a72f8dfe4
   depends:
@@ -6094,7 +6094,7 @@ packages:
   license_family: BSD
   size: 7536860
   timestamp: 1708639153133
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
   sha256: b9f781280f49644ca05e18aacbdde1c57cc5107e7cc2471b843ea8461672aa7f
   md5: 9125d30e4e105b45f7f7d9c20acafa10
   depends:
@@ -6105,7 +6105,7 @@ packages:
   license_family: BSD
   size: 450131
   timestamp: 1722872679313
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.15-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.15-h80987f9_0.tar.bz2
   sha256: 503def27e5229dc31eb3eea4c86ecabcd46a27b6711a968bafeaf7facfc8eeb1
   md5: 2261823151398e7df6ee94c234f21f11
   depends:
@@ -6114,7 +6114,7 @@ packages:
   license_family: Apache
   size: 4762637
   timestamp: 1725545955868
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
   sha256: 77b0c0a0fb14d817390244ebd93c36d44a7867239963f211f7c0a72a3f98d382
   md5: b90336feb8a50d2eff880e89acb02f40
   depends:
@@ -6123,7 +6123,7 @@ packages:
   license_family: APACHE
   size: 39617
   timestamp: 1699371253760
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-24.1-py311hca03da5_0.tar.bz2
   sha256: 077c5a53916492c8903911dc8f2661403a95488c937c44233401aaf1b4e513a9
   md5: f996a0feb121848b1e43889b2c523328
   depends:
@@ -6132,7 +6132,7 @@ packages:
   license_family: Apache
   size: 158057
   timestamp: 1720102085523
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.2-py311h7aedaa7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.2.2-py311h7aedaa7_0.tar.bz2
   sha256: 3ee48b8e32d5009fccbb8e0dbb00d905f827982adae9c9f799ad85ba6f13a077
   md5: 9e6f48d13a7911f6b5547e6a9c8dc5e1
   depends:
@@ -6182,7 +6182,7 @@ packages:
   license_family: BSD
   size: 17039081
   timestamp: 1718309063969
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.5.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-1.5.3-py311hca03da5_0.tar.bz2
   sha256: aecb0fe7cd9004af633b8f2beef0f2c0eefce35f206d2ff4de80501fcb37f2dc
   md5: b2e3ca6dd4a306e635ebd2119d58b448
   depends:
@@ -6207,7 +6207,7 @@ packages:
   license_family: BSD
   size: 24200241
   timestamp: 1730381212320
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-2.1.1-py311hca03da5_0.tar.bz2
   sha256: 7c4d34def227ba26cea176cd3d522aeb2584989e68052c387925536097cd1f63
   md5: 025e2c935f86e471a35d584c40bbed29
   depends:
@@ -6216,7 +6216,7 @@ packages:
   license_family: BSD
   size: 264597
   timestamp: 1719348054960
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py311hca03da5_0.tar.bz2
   sha256: 088245becd055af4de74e4ed13cc752ab546423f204b170ba2dd8809af30a2c7
   md5: 2eabea5ccc56ac088e0349626e59df06
   depends:
@@ -6230,7 +6230,7 @@ packages:
   license_family: BSD
   size: 48517
   timestamp: 1698702686783
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-11.0.0-py311hfaf4e14_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-11.0.0-py311hfaf4e14_0.tar.bz2
   sha256: 5474ea3faa0ab8c64f7264382943bf9e5360862a674d1556ac4d626e2be0a109
   md5: 764dc809a9692f35fe4d0173b6dec174
   depends:
@@ -6246,7 +6246,7 @@ packages:
   license_family: Other
   size: 947952
   timestamp: 1731594918339
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-24.2-py311hca03da5_0.tar.bz2
   sha256: 4f82ab7dc13317069ec808da81c472668e6ab85f5d74d5b385b6d86b4ef32bad
   md5: f9c03ed21097422236806938a7b7dd64
   depends:
@@ -6257,7 +6257,7 @@ packages:
   license_family: MIT
   size: 2918476
   timestamp: 1723484709578
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
   sha256: b6200816d65673aa1707c20a768c9cff87dd8dbe1335f9c1478e5931dfa08ee0
   md5: 14b1e0fa73eb33f9c83048482dcce57b
   depends:
@@ -6266,7 +6266,7 @@ packages:
   license_family: MIT
   size: 38423
   timestamp: 1692205689597
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
   sha256: ebdf211edd98d88a23778551c7a9702106edd0695d4fc48e87c21f77521c1ffe
   md5: d8c505081a468f1b99c62466e2309417
   depends:
@@ -6275,7 +6275,7 @@ packages:
   license_family: Apache
   size: 123084
   timestamp: 1678996822234
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
   sha256: 07cfba50d9e94364bde077731a824ca4f537138b35ee6b66d07aee16ac9850f1
   md5: 919bf486280a11e6acb3c2c3a82f7473
   depends:
@@ -6287,7 +6287,7 @@ packages:
   license_family: BSD
   size: 763225
   timestamp: 1704404463402
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
   sha256: 8094436b2c44e68e72569c704633802aad82e977b1e16026848218679c8becf4
   md5: 2360e46d3e598dd5e2abed781fe166c5
   depends:
@@ -6296,7 +6296,7 @@ packages:
   license_family: BSD
   size: 502115
   timestamp: 1678995719872
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
   sha256: 4f17f70658e32a9a86661184cace6be3bb7bd61f9b55b513092beddf44552679
   md5: 0aa95279688b0433badea0b660ac8146
   depends:
@@ -6308,7 +6308,7 @@ packages:
   license_family: BSD
   size: 38653
   timestamp: 1677933613643
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
   sha256: 121b5b66721760c05f1d4eee91626229d1814663d3fb5f23126ef870aa496e26
   md5: 0c588c2ca790a05d422c06e8568201ad
   depends:
@@ -6317,7 +6317,7 @@ packages:
   license_family: BSD
   size: 2124200
   timestamp: 1684280082141
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.2.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.2.0-py311hca03da5_0.tar.bz2
   sha256: 86cd1c9d1c73f7dac9f3038d16ac2d6952d42bda57d4da52b18c8561d2901082
   md5: fe581970af66b493353b9dcdb6bf572f
   depends:
@@ -6326,7 +6326,7 @@ packages:
   license_family: MIT
   size: 487783
   timestamp: 1731445552436
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
   sha256: 0bb3d2a57b332c5cf73ea40ea13c850ae24a1f9a3a41ed9267832d9e3c767572
   md5: 45a7fcf1641980d5114999736428502d
   depends:
@@ -6335,7 +6335,7 @@ packages:
   license_family: BSD
   size: 36755
   timestamp: 1677906514270
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.10-hb885b13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.11.10-hb885b13_0.tar.bz2
   sha256: 965a3ced7445733f34a4ac805777b64e2309a36e4fe16da1a9ade408293e5e0c
   md5: 801288e9af659ffede1719ba41fd6840
   depends:
@@ -6354,7 +6354,7 @@ packages:
   license_family: PSF
   size: 16469561
   timestamp: 1727940848930
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
   sha256: c3cbf5bd237b0a7458640191016b2701fe120c547df9afc835da76663a9c17f7
   md5: 843568c76b6b9384635b7fca74c79792
   depends:
@@ -6364,7 +6364,7 @@ packages:
   license_family: BSD
   size: 332222
   timestamp: 1716495881101
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
   sha256: f94b3cfea6f76ea9983e16d3c4c7e0a64f02c40cc2c3ad57189bca2e67030bd9
   md5: 0d100990ade57a02b60d1e8085db0bdf
   depends:
@@ -6373,7 +6373,7 @@ packages:
   license_family: BSD
   size: 280263
   timestamp: 1678996927464
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
   sha256: 252c86f5aef7f8dfce99a260c24cbb35a9adfea144a2acfabb224f516341544f
   md5: 745b888e19a644f48800799f82c01c21
   depends:
@@ -6382,7 +6382,7 @@ packages:
   license_family: BSD
   size: 18539
   timestamp: 1683823925189
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
   sha256: d945744eb133f19ca61325cac5128bdb053ae04de4a0ba6f69c061449cac8af7
   md5: 34baa81490d667381bc7021435b0e1f2
   depends:
@@ -6391,7 +6391,7 @@ packages:
   license_family: MIT
   size: 275858
   timestamp: 1713974457562
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
   sha256: 012585bdb5ae54c2cded50be703734e6dbf418b003635b6f6d7c1e36e7020c30
   md5: da7e99a707bd0cfa20db651b5c068bfd
   depends:
@@ -6403,7 +6403,7 @@ packages:
   license_family: BSD
   size: 65556
   timestamp: 1711136890180
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.2-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.2-py311h80987f9_0.tar.bz2
   sha256: 8d6910a02d0a30dabb40104565c0c74531aafd4c959431ddbfde47ef52f4c83c
   md5: b1619588c95cb65375af1d2eb448ecc8
   depends:
@@ -6413,7 +6413,7 @@ packages:
   license_family: MIT
   size: 205890
   timestamp: 1728658038659
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
   sha256: ae8cdd5be5a7ad19ff82925a035859fafcc5942cd3899d127a508dbb9a235090
   md5: 252a7b997d08bf72f10b3bc2dc68333e
   depends:
@@ -6423,7 +6423,7 @@ packages:
   license_family: Other
   size: 580346
   timestamp: 1709318480624
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -6432,7 +6432,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
   sha256: 7a208abc002a2fc208ae25cb2cf932999a3e4980aa4c9edff315cb9ac62b12ce
   md5: bd22ebd3cff811577ea61f115ba7f4f2
   depends:
@@ -6443,7 +6443,7 @@ packages:
   license_family: MIT
   size: 74744
   timestamp: 1699012126255
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.32.3-py311hca03da5_1.tar.bz2
   sha256: 4cefdf48ebab7544252ce5f4274b5b86f8107e5af556bf387445a2eb4d42449c
   md5: 482973b9a55bd1a4cdc33c557a6afb29
   depends:
@@ -6459,7 +6459,7 @@ packages:
   license_family: Apache
   size: 124539
   timestamp: 1730999249799
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
   sha256: 52368d9b557b8f54ef5ca4bf6cd5a3ec665171f2b2d2082cdd410bab88f4829c
   md5: ac76fb4d2eef3ecdd491cf5d3fb8620d
   depends:
@@ -6469,7 +6469,7 @@ packages:
   license_family: MIT
   size: 10204
   timestamp: 1683077239143
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
   sha256: 491d116c5f54ef340e3bce631835f7138cd1923d7b63e6ca9aa01b48110cb8f9
   md5: 9b81bd8ea808704f5433884b567f1f15
   depends:
@@ -6478,7 +6478,7 @@ packages:
   license_family: MIT
   size: 10557
   timestamp: 1683059079547
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
   sha256: b53a5f6119173d62e4e68a37ea8511c7fc87a00af72953e0048d075a799c7a7a
   md5: 76a16cf4edb9b12b2b96a2d323f060dc
   depends:
@@ -6487,7 +6487,7 @@ packages:
   license_family: MIT
   size: 342535
   timestamp: 1698945991201
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.14.1-py311hac8794a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.14.1-py311hac8794a_0.tar.bz2
   sha256: 5eb2f761b843da0ee82931aec629c725bc77b62c548787ee4e31fa78d12d38f0
   md5: effcbbb58f46894ff71270767a751265
   depends:
@@ -6504,7 +6504,7 @@ packages:
   license_family: BSD
   size: 25955155
   timestamp: 1731628440893
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
   sha256: c80d52567084b1caaed2862b77b70065ca17afaf0b020733e9d6c273b4a63e78
   md5: ddf7d88c1967f3f7a4ce1c975fd47e0d
   depends:
@@ -6513,7 +6513,7 @@ packages:
   license_family: BSD
   size: 33321
   timestamp: 1699371225235
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-75.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-75.1.0-py311hca03da5_0.tar.bz2
   sha256: 70c84e0f41fa9eac5f35d447ebc6417279180694bddecdbba5d14e12124b56f2
   md5: cdfbbc473d52a1334490dd81c7833ae7
   depends:
@@ -6522,7 +6522,7 @@ packages:
   license_family: MIT
   size: 2317457
   timestamp: 1726677954270
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
   sha256: cd71091a234874d2826fa063ec5222b3191c9f47e1b5281c352d9df3f31a06bf
   md5: 0db8e29016c6bff026c083d9923a7566
   depends:
@@ -6531,7 +6531,7 @@ packages:
   license_family: Other
   size: 19073
   timestamp: 1705431415504
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
   sha256: 3e18cdafc607c6d7623b1c8f041cbfbb50a27e298f961abdcce7e36834ac39e1
   md5: 9ee0da74c55d0b8d83edf246fd717f20
   depends:
@@ -6540,7 +6540,7 @@ packages:
   license_family: MIT
   size: 89862
   timestamp: 1696347657368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
   sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
   md5: d8c1e9910392d0bcb22a173f9ce30fa6
   depends:
@@ -6552,7 +6552,7 @@ packages:
   license_family: Other
   size: 1758290
   timestamp: 1714488307689
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
   sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
   md5: ae58720a18a2ed15eae214ad7a10d1b5
   depends:
@@ -6561,7 +6561,7 @@ packages:
   license_family: Apache
   size: 140125
   timestamp: 1680167256603
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
   sha256: b5c265e9ed9a1ff2238a09b83bdc1826950faa87fd6b685debe60888de6e7a50
   md5: 5827c8a32317894ce18576e334daba47
   depends:
@@ -6572,7 +6572,7 @@ packages:
   license_family: BSD
   size: 38559
   timestamp: 1677918962258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
   sha256: cfefd86d0f4981d22b7611b3dc60359b8698bf39f2b743cb90b7005aaca88e1e
   md5: a04dbcd6095f6b8f3ad195a78d48b262
   depends:
@@ -6582,7 +6582,7 @@ packages:
   license_family: BSD
   size: 50058
   timestamp: 1677917499177
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
   sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
   md5: 3c25b4f4768ccda28b20a03ba27e7759
   depends:
@@ -6591,7 +6591,7 @@ packages:
   license_family: BSD
   size: 3484151
   timestamp: 1714770744982
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py311hca03da5_0.tar.bz2
   sha256: 0836468fafb1f5badbb573922e37200c6929bf2926ecf8d2259dff43811e0727
   md5: 5bc56dcb4bdb7cf623b7cea499feaddb
   depends:
@@ -6600,7 +6600,7 @@ packages:
   license_family: BSD
   size: 136409
   timestamp: 1677925889207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.1-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.4.1-py311h80987f9_0.tar.bz2
   sha256: 2fd655106e52bb73deea5a0af63708e75cf66e071f0f3f15c04a67413f721430
   md5: 324986c435dcfc101684907ce85c199e
   depends:
@@ -6609,7 +6609,7 @@ packages:
   license_family: Apache
   size: 915790
   timestamp: 1718740267109
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.5-py311hb6e6a13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.66.5-py311hb6e6a13_0.tar.bz2
   sha256: f6cda770cbe84b10f2d78d41bab43e1a1386e9722569c9b2b235083947fe90cc
   md5: f5306a7b16da13a7258a20cecb62cdd5
   depends:
@@ -6620,7 +6620,7 @@ packages:
   license_family: MOZILLA
   size: 155732
   timestamp: 1724854273737
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
   sha256: 707e5dfdb9116f31bc1ad7f497f6e8416683add460258fdc2a4c16eec85226be
   md5: ffb602322a388ec8e1f385edaca3ce12
   depends:
@@ -6629,7 +6629,7 @@ packages:
   license_family: BSD
   size: 208171
   timestamp: 1718227091374
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
   sha256: 96071e07e807414b7ae5a2fe958ac171e5795576b3a4c2f5e8c643fba43d760f
   md5: a34f2b216e35a37f966883dacda229e2
   depends:
@@ -6639,7 +6639,7 @@ packages:
   license_family: PSF
   size: 9902
   timestamp: 1715268985387
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
   sha256: b20e48aff4c781a52b6be66d77418e768527a621f5fc272ecb34ea03475b2bd7
   md5: 707738432f16f5e63909fcaa6e65850d
   depends:
@@ -6648,7 +6648,7 @@ packages:
   license_family: PSF
   size: 75604
   timestamp: 1715268976065
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
   sha256: 2ea2d0520b330d381a2ab241bdb9ae146ef815ee7c96ee52a9773fb9ae85f4fd
   md5: 66f7f8979cfb2cccffac972d70482130
   depends:
@@ -6657,7 +6657,7 @@ packages:
   license_family: MIT
   size: 12614
   timestamp: 1677963554857
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
   sha256: df7fe7740bd853b641d624e2ec97f1aacb2b82691936a8c04ef18fa9768539c2
   md5: d5c7626d45fd03b22797c18e47812beb
   depends:
@@ -6666,7 +6666,7 @@ packages:
   license_family: Apache
   size: 518048
   timestamp: 1713213046424
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.2.3-py311hca03da5_0.tar.bz2
   sha256: 428c7365b106ed161342704298d14101e12cdd778caee3d167587fc2807e483d
   md5: 86cd9cef3c89a98a98548f18c621e61e
   depends:
@@ -6682,7 +6682,7 @@ packages:
   license_family: MIT
   size: 218842
   timestamp: 1727769914621
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
   sha256: 09738b7f9075386bf062b12ddb6fb72a06450d2481f6b5ca2026c811cd849569
   md5: 9afdec076c95746ac21235f971190e40
   depends:
@@ -6691,7 +6691,7 @@ packages:
   license_family: BSD
   size: 26727
   timestamp: 1677910175964
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
   sha256: b4ced7366de8eb7258f31d516616e70c62ed4a798780e57e208509d2b52ab435
   md5: 65a9a05a726734c1da667f9bd3c78c14
   depends:
@@ -6700,7 +6700,7 @@ packages:
   license_family: Apache
   size: 114733
   timestamp: 1715878377412
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.44.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.44.0-py311hca03da5_0.tar.bz2
   sha256: 088f397ff8a4a7e178415dd7e2ff987c02b3674c7b6885972fb6c669978aff40
   md5: a87f4be160e50ea022588aab7c7322bf
   depends:
@@ -6709,7 +6709,7 @@ packages:
   license_family: MIT
   size: 139304
   timestamp: 1726165038360
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py311hca03da5_0.tar.bz2
   sha256: cf030fc7020dc6d28530075468b8dc1edd843a1e393a2f81ca81c962e9af977b
   md5: cae3fc90233f3af8f433a253d035b6e6
   depends:
@@ -6721,7 +6721,7 @@ packages:
   license_family: Apache
   size: 2470844
   timestamp: 1689041497962
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
   sha256: 2cd108896df65636769e3804ecc2ca421ad9b54e64fa21922bbabe40c90c247a
   md5: b3a1e5077b28f71298d891fbfb5ff03e
   depends:
@@ -6730,20 +6730,20 @@ packages:
   license_family: BSD
   size: 55645
   timestamp: 1677927459979
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
   sha256: 5be8c968f2da5c4bf14f28d63e31b4c1b6993d980023769732c7f58f396c2e0b
   md5: 3f5f62d4e85e3bdd48d39189b01805a6
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 459197
   timestamp: 1714510992914
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
   sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
   md5: 3d57d1adadca9388aaaa1c529b65ba65
   depends:
@@ -6753,7 +6753,7 @@ packages:
   license_family: Other
   size: 322790
   timestamp: 1705602163804
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.20.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.20.2-py311hca03da5_0.tar.bz2
   sha256: cd62f8ea0090380c4b380fc29f05a145bc4d6588dc74ff0c5df910fb9fba03cd
   md5: ca0d82aabd1595b5cd8fca3b6f5ef343
   depends:
@@ -6762,14 +6762,14 @@ packages:
   license_family: MIT
   size: 29898
   timestamp: 1729012523732
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
   sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
   md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
   license: Zlib
   license_family: Other
   size: 104928
   timestamp: 1714510936868
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
   sha256: 43667132ec8fa4c34ba438e13a01b08073e3e3e8a648ecdb6afe4141a7c197e2
   md5: fb8c3f5683b19dd3743d125797b8e2dd
   depends:
@@ -6780,7 +6780,7 @@ packages:
   license_family: BSD
   size: 817614
   timestamp: 1728486986031
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.6.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-4.6.2-py311haa95532_0.tar.bz2
   sha256: 6fbb6b2aa38cb576b17299bf2fdc3779ca090059bfd35e92127f692f2b912aef
   md5: 403069f811c54afaf3d6e3be619bbab8
   depends:
@@ -6793,7 +6793,7 @@ packages:
   license_family: MIT
   size: 244161
   timestamp: 1729121358016
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
   sha256: f715f7c2e06149bd6d43258e41479d3171efe5e9d56050a0a5f5652ed9d05fff
   md5: 11a8ca43d69881b88f95ae681478866d
   depends:
@@ -6805,7 +6805,7 @@ packages:
   license_family: MIT
   size: 36089
   timestamp: 1676424516042
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-24.2.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-24.2.0-py311haa95532_0.tar.bz2
   sha256: 69b730d7601c73ae983e294fecb6ab76899e74d831a09b0248beefca3457701e
   md5: 7a18c3c1864941526e4d90de359b2a87
   depends:
@@ -6814,7 +6814,7 @@ packages:
   license_family: MIT
   size: 163624
   timestamp: 1729089495660
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
   sha256: f1eb2a5aeb25efa0b38fc1dd94a36d431bc80d654f11a052f67a899dcc471f57
   md5: 9db5a441c7cbcf4dc617f8c722e4310d
   depends:
@@ -6824,12 +6824,12 @@ packages:
   license_family: MIT
   size: 276663
   timestamp: 1718029990621
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-3.6.0-py311haa95532_0.tar.bz2
   sha256: d6077bf47e0740168accab42135139ebb4bdd5cf1111f81881b148777468100e
   md5: 7281ca887bccf048f735eb5acb1e5118
   depends:
@@ -6847,7 +6847,7 @@ packages:
   license_family: BSD
   size: 5918010
   timestamp: 1727915199711
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.4.2-py311h57dcf0c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.4.2-py311h57dcf0c_0.tar.bz2
   sha256: 42f1a2eb775091e9aec87f3f08ba76891e45032c980b9c00c108437df6b5fc56
   md5: 327b522b59ec41d6e5d4a100c228415b
   depends:
@@ -6859,7 +6859,7 @@ packages:
   license_family: BSD
   size: 160724
   timestamp: 1731059089575
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 751071782f597f87ed7f67437ef6cc669213902461b9795dd6eb0f4897eddc83
   md5: 5ad8fe62aad5e16cfdf2c5a7d1327fe7
   depends:
@@ -6871,7 +6871,7 @@ packages:
   license: MIT
   size: 19418
   timestamp: 1714483531456
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 9bd62d810867549b9c967c5915f3fa3f66cfbd6ede28b1cc152efd1261285c0a
   md5: 64cc76de3662b62bc8f0e42befd92c5d
   depends:
@@ -6882,7 +6882,7 @@ packages:
   license: MIT
   size: 32178
   timestamp: 1714483513837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
   sha256: 1547fa52134cf06b8d01bdf52114db7db60a89bf35c9c95be5b5a03b13dbd565
   md5: deb765cb7c4b7edc4d126f864f31747c
   depends:
@@ -6892,7 +6892,7 @@ packages:
   license: MIT
   size: 356401
   timestamp: 1714483740924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
   sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
   md5: 11e0af09a31e2d5df51c65a342032b85
   depends:
@@ -6902,14 +6902,14 @@ packages:
   license_family: BSD
   size: 112994
   timestamp: 1714511182837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.9.24-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2024.9.24-haa95532_0.tar.bz2
   sha256: 5434767b7168e529c2c6a4bc201c783adbc3bc6480564a6fe3f869b12ed96c83
   md5: bb0627482bac2339842e495e7d6686d2
   license: MPL-2.0
   license_family: Other
   size: 175262
   timestamp: 1727794875480
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.8.30-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2024.8.30-py311haa95532_0.tar.bz2
   sha256: ddf997fd83ad3c39c91c80c97ffa35b76565c400a3993ff88ef3730c2cccb14b
   md5: 5b933b0d173e2af3d30a74a74c9c3c69
   depends:
@@ -6918,7 +6918,7 @@ packages:
   license_family: Other
   size: 169591
   timestamp: 1725551908109
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py311h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.17.1-py311h827c3e9_0.tar.bz2
   sha256: 70eecd3e89d12624083a73c998d818dceb1505ab8e7be7d1f4814950b18c2fcf
   md5: 1427fd9ad1be3e40e6dd5751d98fd96c
   depends:
@@ -6930,7 +6930,7 @@ packages:
   license_family: MIT
   size: 309709
   timestamp: 1726856612505
-- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
   sha256: 7153817dd49ec317b519802c7c22c836602e00cbd96d68385e83eaf4c9f5ba6a
   md5: cd829e5997611a602e29fa2fd5882635
   depends:
@@ -6940,7 +6940,7 @@ packages:
   license_family: BSD
   size: 204113
   timestamp: 1698130080270
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cloudpickle-3.0.0-py311haa95532_0.tar.bz2
   sha256: 364512f6fbda47a7683831e49d94cede5ea91ed57c0bcb27c4c1a95b067c7717
   md5: c4c87a947b2f0594d0eda7d852140845
   depends:
@@ -6949,7 +6949,7 @@ packages:
   license_family: BSD
   size: 42936
   timestamp: 1721657516663
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
   sha256: 4099898f02e1f6119fcda65e747c3cbfef0bf563c8855b79a0245160709d5b45
   md5: ab9705c34e67fb8c8faec69d63ff4064
   depends:
@@ -6958,7 +6958,7 @@ packages:
   license_family: BSD
   size: 36410
   timestamp: 1676422341506
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
   sha256: c722f50980d7416ffb2cfc7bf72649307a0bb78c5a24eccefcd049cb61d6b355
   md5: c7c9ff0513ff3c99700919293b702410
   depends:
@@ -6967,7 +6967,7 @@ packages:
   license_family: CC
   size: 543258
   timestamp: 1709758602437
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
   sha256: 8fb3e816a5ad1da05125462dbc9e2a7e933b001a871aa65703802c0a894c6277
   md5: ee4b2fa9fce130496d5c7c86c35a1a05
   depends:
@@ -6977,7 +6977,7 @@ packages:
   license_family: BSD
   size: 17723
   timestamp: 1709323150229
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
   sha256: eeb49cd151ecdccd40062e8123a3b7a9a8a1eda6567dd33ce909ff8ee1a97c89
   md5: b7fe1f7ead1ec2ac642d022942282fc8
   depends:
@@ -6989,7 +6989,7 @@ packages:
   license_family: BSD
   size: 232451
   timestamp: 1700583772701
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cramjam-2.7.0-py311h005caf5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cramjam-2.7.0-py311h005caf5_0.tar.bz2
   sha256: 97def042390c467aaaa3f4c33276b0c134c40eb426695332673ed1173f999258
   md5: 13d97f9f5f7b1f8808e4a694b3305f15
   depends:
@@ -6999,7 +6999,7 @@ packages:
   license_family: MIT
   size: 1384742
   timestamp: 1702664451643
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.8.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/dask-core-2024.8.2-py311haa95532_0.tar.bz2
   sha256: c989952077ec0ea63cc766f6aaaf8f0ffebb12c7d2143a5cd111cc807dab253a
   md5: 7628fc77d1af150ae6cceffcf154c990
   depends:
@@ -7016,7 +7016,7 @@ packages:
   license_family: BSD
   size: 3190714
   timestamp: 1725464703740
-- conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.16.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/datashader-0.16.3-py311haa95532_0.tar.bz2
   sha256: 029f067d71a2825e4af1ba085c792ec96d93fde7ec0590d5f6414a051085cdb9
   md5: f4c49a5695996b1146ca460058f4abe5
   depends:
@@ -7039,7 +7039,7 @@ packages:
   license_family: BSD
   size: 18066407
   timestamp: 1720535030282
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
   sha256: 5c73f86e575f2ad683ee4a1c2df11020e270edd89d12f11199483d57b0b51826
   md5: e96a12895ce374476277b1b196ba24bd
   depends:
@@ -7050,7 +7050,7 @@ packages:
   license_family: MIT
   size: 3719519
   timestamp: 1690907216785
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
   sha256: 5d5fc8a24c804010b8cb5963227230352ea3ccf56bea9e8116e34f77223218f2
   md5: 8f989a72eed6293dfe0533c83057980d
   depends:
@@ -7059,7 +7059,7 @@ packages:
   license_family: MIT
   size: 17688
   timestamp: 1676423357100
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-2024.2.0-py311hd7041d2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fastparquet-2024.2.0-py311hd7041d2_0.tar.bz2
   sha256: d3a95af9b825eb25c78876ca08bf53372e1d5dc11fae2b0469ee2d1dcba1e77c
   md5: 1f736c03b7e7e7cb54ba193a90aef21f
   depends:
@@ -7075,7 +7075,7 @@ packages:
   license_family: Apache
   size: 677268
   timestamp: 1715262878219
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
   sha256: 27fb03eb57d25711a15e145f47a64320a9955b585efc9fd0a1a51cdd71b9fde3
   md5: eb3869e98f6f53dfec76e2eff4d6b61e
   depends:
@@ -7095,7 +7095,7 @@ packages:
   license_family: MIT
   size: 2732423
   timestamp: 1713552175344
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -7107,7 +7107,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.6.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fsspec-2024.6.1-py311haa95532_0.tar.bz2
   sha256: 20b5c643d8f2d2ca349435d8a762f1d42b7b9b4e86f154ce6722d30179f2d348
   md5: 1db1c5f718e6a79a5f0117ec9957c6bc
   depends:
@@ -7118,7 +7118,7 @@ packages:
   license_family: BSD
   size: 383101
   timestamp: 1724855844881
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.20.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.20.0-py311haa95532_0.tar.bz2
   sha256: d991c3ed55771bd642ffebbef209c4d94b9db7c206fb7ef52d8013baadfb6005
   md5: 4ec4007efb1e5167568de53a8b03ac43
   depends:
@@ -7138,7 +7138,7 @@ packages:
   license_family: BSD
   size: 6147331
   timestamp: 1730827981525
-- conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.11.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/hvplot-0.11.1-py311haa95532_0.tar.bz2
   sha256: 154f770caee47fc07126350224c6937f80e7fa29f0145e34d7594e1149b691a9
   md5: 4b0aac2000ef4f548a7210ce6f57d79d
   depends:
@@ -7155,13 +7155,13 @@ packages:
   license_family: BSD
   size: 371267
   timestamp: 1729516914605
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
   sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
   md5: 582d2c1135a89da757a038de831e7f39
   license: Intel proprietary
   size: 11086648
   timestamp: 1664812389803
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
   sha256: 945f4521793d7d279532d1ccd5157201c5cbf64f846bfe60249d01e1b4edf295
   md5: 0accae23d095c165ac731f4a1f3ca497
   depends:
@@ -7171,7 +7171,7 @@ packages:
   license_family: MIT
   size: 37021132
   timestamp: 1692294548916
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
   sha256: 102c803186db6d62eaf41a906f6c563ff0d62b53c1eaede8a381e18c0d005ed9
   md5: 9d30dec03058758a428cf152e0ae28b5
   depends:
@@ -7180,7 +7180,7 @@ packages:
   license_family: BSD
   size: 148193
   timestamp: 1714399061601
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-7.0.1-py311haa95532_0.tar.bz2
   sha256: db30abacf919b3f68ae1e6a94c467fd1e69fbf47ba7a86e6b491d8bfe4776f92
   md5: 9299876e7ddc3aea3487fd93340ceae7
   depends:
@@ -7190,7 +7190,7 @@ packages:
   license_family: APACHE
   size: 50842
   timestamp: 1704813715071
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
   sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
   md5: d215cc8ee7ca2cc83cc250cc5d822fe0
   depends:
@@ -7200,7 +7200,7 @@ packages:
   license_family: Proprietary
   size: 3929136
   timestamp: 1699647939158
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.29.5-py311haa95532_0.tar.bz2
   sha256: 6f702a1b807648373dff43ba42e92978b52cfe392ca426dfb9ebf556a1189a70
   md5: db5be371e83b27b4c763d1b1c3777df0
   depends:
@@ -7221,7 +7221,7 @@ packages:
   license_family: BSD
   size: 237277
   timestamp: 1728665671824
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.27.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.27.0-py311haa95532_0.tar.bz2
   sha256: cdd0cdf851850a822f0757fd86c3492d98a5ab6a98bb3851bbec8b36a95b620f
   md5: efc3d64ef763443d936e1a954fc9cc1f
   depends:
@@ -7239,7 +7239,7 @@ packages:
   license_family: BSD
   size: 1664842
   timestamp: 1726064663198
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.19.1-py311haa95532_0.tar.bz2
   sha256: 0b084d918d32ea80d965c141220384c348c9f13c5bf5dabdd49c8d2aa813c0b1
   md5: e07d6312911028555a8d2434b60c15a8
   depends:
@@ -7249,7 +7249,7 @@ packages:
   license_family: MIT
   size: 1168633
   timestamp: 1721059057721
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.4-py311haa95532_1.tar.bz2
   sha256: 8694788240bbdddbc5d111ee8d0ef11106ddadb13d56cd4c46b8140b88ab6277
   md5: 64856a8473ebc5effe17f370b4e91016
   depends:
@@ -7261,7 +7261,7 @@ packages:
   license_family: BSD
   size: 357167
   timestamp: 1730903506013
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
   sha256: 0238fb10912d9345a9d327ff314a179de38369f8e1d0de0b5f4fab04defab0e4
   md5: 16a420ea83811cfa0c7cadba8f9f0995
   depends:
@@ -7271,7 +7271,7 @@ packages:
   license_family: Other
   size: 409932
   timestamp: 1722872751697
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.23.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.23.0-py311haa95532_0.tar.bz2
   sha256: 99f6618c5969b13451072defdcf3441b83f710010ef10b7a620b42e156ed919e
   md5: 501a297479b97960e249bdb117f7cda7
   depends:
@@ -7284,7 +7284,7 @@ packages:
   license_family: MIT
   size: 224348
   timestamp: 1728486919376
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
   sha256: 9581be54128954080d7cef448b1728874c2ebbe5064f55adece422cf12eafa5a
   md5: 3adc105f87d5c7f0b1248bc3423f5b48
   depends:
@@ -7294,7 +7294,7 @@ packages:
   license_family: MIT
   size: 16187
   timestamp: 1699032556953
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
   sha256: ad8343bad7c8f0448cbcfbaf872cc94b56da81c52e5cdcee2a5d6b89f029eb75
   md5: addceff8d46c9d1d322618a9ce9e5b39
   depends:
@@ -7310,7 +7310,7 @@ packages:
   license_family: BSD
   size: 300354
   timestamp: 1676424060532
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
   sha256: fe0bf805dfa60d8b5d61670900442d0cda12523135176f60e1ebafb797e521d8
   md5: c8cf5ea3d4b0bc57dfe6b189b47e69e9
   depends:
@@ -7322,7 +7322,7 @@ packages:
   license_family: BSD
   size: 136783
   timestamp: 1718818384444
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
   sha256: 262c35a28d0af4d73ea1c010ce0c022005512a26d5c27064c8e009c0b7b789d9
   md5: 8367c61552aa274c0843201d88e461c8
   depends:
@@ -7338,7 +7338,7 @@ packages:
   license_family: BSD
   size: 72131
   timestamp: 1718738283200
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
   sha256: 00bf8449a37eb10c91ebfaa14b231905fde9493740cbda7ec89a8d3d8d9d1ff3
   md5: 1f3abe3cbf365249ebae7465a57e4cae
   depends:
@@ -7366,7 +7366,7 @@ packages:
   license_family: BSD
   size: 655133
   timestamp: 1718827724346
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
   sha256: 90420847230e72a648417f5f77cebcf7f17b89f70788652c276acc0c440e135f
   md5: ef3d8dee197aa37897bf6d39d2dd878f
   depends:
@@ -7377,7 +7377,7 @@ packages:
   license_family: BSD
   size: 27639
   timestamp: 1686871052174
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
   sha256: 97faaf26ce5254ec3649a8ee7f480b1556e4e8e6e4356d2fab1e6a5532631a0f
   md5: da23bd831c50c877f63038b7e16720ad
   depends:
@@ -7389,7 +7389,7 @@ packages:
   license_family: BSD
   size: 20163
   timestamp: 1700168785472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
   sha256: 8a2f0909fad0387e57cb0e9ee30db2b20761a9106e794381ffeac387a298fb07
   md5: 6058b2efc3284e27aacec2e6e6280433
   depends:
@@ -7400,7 +7400,7 @@ packages:
   license_family: BSD
   size: 62334
   timestamp: 1676432044242
-- conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
   sha256: ef6b0347ae565dd648a2bb40bc8b0b30f2e4f8387778fefced1d581b7d5a3e16
   md5: 8ef1d5919aa55fe56ef34d9a7969dca7
   depends:
@@ -7411,7 +7411,7 @@ packages:
   license_family: MIT
   size: 861982
   timestamp: 1684424430941
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
   sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
   md5: f5f73266281ab12377d5d47bdf07500a
   depends:
@@ -7423,7 +7423,7 @@ packages:
   license_family: MIT
   size: 905072
   timestamp: 1617648814933
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -7433,7 +7433,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 7c906c94a4d46ea963080a6ba5bd12c1274da66159877a544fbc70291eeed98d
   md5: 45a3d52534fac8aa54a55ee92211a918
   depends:
@@ -7442,7 +7442,7 @@ packages:
   license: MIT
   size: 80216
   timestamp: 1714483371043
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
   sha256: daad7edc6d56abf3e176479e8628162dbf1c56b3d24db30d708aebae694a5214
   md5: e8ecf229f7fcb4c0b76d8613627948f5
   depends:
@@ -7452,7 +7452,7 @@ packages:
   license: MIT
   size: 45189
   timestamp: 1714483420152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 84320217abffa9386186ec8d03b4651bb4b1900d3871adc965a9a9e1d3799907
   md5: 651312fa22168f71f9aec5f9ee2c2fcf
   depends:
@@ -7462,7 +7462,7 @@ packages:
   license: MIT
   size: 756116
   timestamp: 1714483464368
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
   sha256: bb17beae8860a83d081d57273825b46bf8fe9903f3b4182ab41a7ae2c7274859
   md5: 94182f4ab8beb4eddfd8167b2e2b0380
   depends:
@@ -7474,7 +7474,7 @@ packages:
   license_family: Apache
   size: 147804
   timestamp: 1681225547009
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
   sha256: 01b84a38c9069e7b8e6fa2a07707e785df7d40b8f01d76a504e98e5a5cd58539
   md5: 22c9f7e59174c49f06e3c5c9384401ce
   depends:
@@ -7485,7 +7485,7 @@ packages:
   license_family: Apache
   size: 25699299
   timestamp: 1681225463612
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -7495,7 +7495,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
   sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
   md5: cf949d76148be1e2a534218d9c57df86
   depends:
@@ -7505,7 +7505,7 @@ packages:
   license_family: MIT
   size: 155435
   timestamp: 1714484319443
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -7516,7 +7516,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-17.0-h70ee33d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpq-17.0-h70ee33d_0.tar.bz2
   sha256: 0091f34cd09df46b1a71ac20840acae36e504ee326e0320e130ebba6fc21f198
   md5: 4a0860ba15b5dcb33bed19b3fa1486c0
   depends:
@@ -7527,7 +7527,7 @@ packages:
   - zlib >=1.2.13,<2.0.0a0
   size: 5203786
   timestamp: 1731540015556
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -7536,7 +7536,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -7553,7 +7553,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
   sha256: e54ee28f6ba01b3addf61ee9dfbdedc16eac8654fc334f713b5f181cf037d0f2
   md5: 47aa151852fc9b07e7573d22f0af945d
   depends:
@@ -7565,7 +7565,7 @@ packages:
   license_family: BSD
   size: 339944
   timestamp: 1729160123353
-- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
   sha256: 4534c822511a052a72c2b070a05e5d8d6f3550f18ea00a33f9d8a9a92b4382cc
   md5: 82f24e7660831445a2183216e280a6a4
   depends:
@@ -7575,7 +7575,7 @@ packages:
   license_family: MIT
   size: 41464
   timestamp: 1676474474981
-- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.43.0-py311hf2fb9eb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/llvmlite-0.43.0-py311hf2fb9eb_0.tar.bz2
   sha256: bc9012cb5609cecf8ac40ad23546d10744ce2a9760781b5503df66b1aa07d1c7
   md5: 25112566aaca1c88c03db128f681354a
   depends:
@@ -7587,7 +7587,7 @@ packages:
   license_family: BSD
   size: 20924132
   timestamp: 1720456466056
-- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
   sha256: 896b7a39bd4ad3621312130122b4fe84dcb67d7355166255c58ea9bc562eb0ae
   md5: 640b852a56296f48cf073e61a59c5256
   depends:
@@ -7596,7 +7596,7 @@ packages:
   license_family: BSD
   size: 13751
   timestamp: 1676428354074
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
   sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
   md5: 320f40b75d93f3b96931c6d13c23946c
   depends:
@@ -7606,7 +7606,7 @@ packages:
   license_family: BSD
   size: 158902
   timestamp: 1714512129889
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
   sha256: e0dc6e119b224bb31ef34b6ba270ffadc181d38b698c5318de8df7a5d2c4ccbd
   md5: 992ccd756f09408f0b74dfb9852a8b7f
   depends:
@@ -7615,7 +7615,7 @@ packages:
   license_family: BSD
   size: 182381
   timestamp: 1676437963591
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
   sha256: 050b5fd4b28132d8102a7e6b40179894dc7f5e41f7ad9ee19211e67446c5740f
   md5: 3ae0b2f6baec708554648ddafa81b756
   depends:
@@ -7625,7 +7625,7 @@ packages:
   license_family: MIT
   size: 154386
   timestamp: 1684279992864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
   sha256: 8269c73b7a9c03b95a121e318d0468f35eecc016093620b0560f35238cc5df51
   md5: 2914bea0ae29315f998e1abac79ccaa8
   depends:
@@ -7638,7 +7638,7 @@ packages:
   license_family: BSD
   size: 30214
   timestamp: 1704206218108
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.9.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-3.9.2-py311haa95532_0.tar.bz2
   sha256: 3731ce13933e8de156522bb0dcbeca97995ac5e2af9916ed384a3c12b4fdae61
   md5: 59662b2df1258e002812b52fffeb8a59
   depends:
@@ -7650,7 +7650,7 @@ packages:
   license_family: PSF
   size: 7516
   timestamp: 1725264804651
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.9.2-py311h472561b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.9.2-py311h472561b_0.tar.bz2
   sha256: 8cbfc06d4c0bf20f4aef4e26a342f9c5abbb8411cdea98b36e9f6486657824b9
   md5: cf7246a7ee382f69bef2143c6aa23f9d
   depends:
@@ -7671,7 +7671,7 @@ packages:
   license_family: PSF
   size: 11748171
   timestamp: 1725264782314
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
   sha256: 43279276850eb6e621812448cddc1093524cee0b7f8ed58b4600b68a4fb659f2
   md5: 5968b2b5c1f3cf5c8c8c9aaa4d8d66a2
   depends:
@@ -7681,7 +7681,7 @@ packages:
   license_family: BSD
   size: 19886
   timestamp: 1676425829787
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
   sha256: 3062a8254ca351b54f15bea85cc928a3ba4d879bb98ce97ece39a9f7eca215a5
   md5: 8f1565663abb34ad7fdd512e76da5532
   depends:
@@ -7691,7 +7691,7 @@ packages:
   license_family: MIT
   size: 68031
   timestamp: 1676481862508
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
   sha256: cdff5215c292fe59649ca40ca72f5d26da352760c1d6a56feba14eb13f7bbf61
   md5: e0f3f32b22135dfeaec277bc87183ca9
   depends:
@@ -7700,7 +7700,7 @@ packages:
   license_family: MIT
   size: 23328
   timestamp: 1676442709081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
   sha256: 3b173a25605d2aaacc57ec0e425f1d1c51327eb2521c8742a736e2c76069bc8d
   md5: 169f1c93a443f95a88665f3008623ce1
   depends:
@@ -7711,7 +7711,7 @@ packages:
   license_family: BSD
   size: 104882
   timestamp: 1676425142412
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
   sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
   md5: 527155127b9fada5e5c5c69a624674b9
   depends:
@@ -7723,7 +7723,7 @@ packages:
   license_family: Proprietary
   size: 187498166
   timestamp: 1699648376430
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
   sha256: cea59ae60da314caecf08edb9bcb03126c6dd35837c8184bceaa194decca3341
   md5: 30936b7263cf0171f7c86400f12ef184
   depends:
@@ -7735,7 +7735,7 @@ packages:
   license_family: BSD
   size: 49080
   timestamp: 1682975093455
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.11-py311h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.11-py311h827c3e9_0.tar.bz2
   sha256: 513b8fe5da01b8460084688d99c977d173b19d7d58ad2aa6b27a961665ae25f4
   md5: c07115b0a05892c721b7324ef8598c2f
   depends:
@@ -7750,7 +7750,7 @@ packages:
   license_family: BSD
   size: 212966
   timestamp: 1730823150084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.8-py311hea22821_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.8-py311hea22821_0.tar.bz2
   sha256: f8ea6da83e88b353bf66ae609d0377e45fe0d4dcdba2c920ca7b600559f49679
   md5: 98805ec361a795613a97773fab63653b
   depends:
@@ -7765,7 +7765,7 @@ packages:
   license_family: BSD
   size: 345997
   timestamp: 1730822892388
-- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
   sha256: 39f09c1bc57b4800ebda331eddb462928435498705351b0432d51a4293294ad8
   md5: 5565984a02f41e97cb9a4c9126ced14b
   depends:
@@ -7775,7 +7775,7 @@ packages:
   license_family: BSD
   size: 29808
   timestamp: 1676442800892
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
   sha256: 636f369607118a6ee3d0b63b7edb925d8081fd3fc829a7699136ce0dedbde067
   md5: b7e49c9cea50d8406cac81cd720dd80a
   depends:
@@ -7788,7 +7788,7 @@ packages:
   license_family: BSD
   size: 8323655
   timestamp: 1717622931223
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
   sha256: e940f9178ee2fa0a7c12873ae35ebea0074371653e5cfa1be8aa8d9271fd343b
   md5: 355d0835215911738a28010dfa6aa382
   depends:
@@ -7801,7 +7801,7 @@ packages:
   license_family: BSD
   size: 141785
   timestamp: 1698934346590
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-7.16.4-py311haa95532_0.tar.bz2
   sha256: d5a6346c8d081061777b5327284f3836342ad3e4869c3584a8bf1b7abac56466
   md5: 0d00b9e90c3df8cb479490dc136f0577
   depends:
@@ -7828,7 +7828,7 @@ packages:
   license_family: BSD
   size: 573057
   timestamp: 1728052469536
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.10.4-py311haa95532_0.tar.bz2
   sha256: 952df0af8037fd3131a3f64481660272040fc30816c5b6a5377fa2357d3bcede
   md5: e0f63c7653d679b5ec3f50b14424ad1d
   depends:
@@ -7841,7 +7841,7 @@ packages:
   license_family: BSD
   size: 202609
   timestamp: 1728050720194
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
   sha256: 90fb3f14c49da1397982eae21cd09e8d60d491d76f94c57590c56723fe6dc172
   md5: 46a523661fe5c1bce7b4213fd428c3de
   depends:
@@ -7850,7 +7850,7 @@ packages:
   license_family: BSD
   size: 16732
   timestamp: 1708532795328
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
   sha256: 62732e34b2cdcb73846cfdf53284067d32113aae0f6d736ca30ce2b0073bce27
   md5: ec7191b2ea4e65b5eed6f7fdd9271d28
   depends:
@@ -7875,7 +7875,7 @@ packages:
   license_family: BSD
   size: 769732
   timestamp: 1717630919732
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
   sha256: e040ebcab948325fbe17e4ab15be62e1fafa7bad225457e59764adb60eb40db5
   md5: 4d40a09df8cb74a9f044eab317436d67
   depends:
@@ -7885,7 +7885,7 @@ packages:
   license_family: BSD
   size: 27282
   timestamp: 1699456187703
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.60.0-py311hea22821_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numba-0.60.0-py311hea22821_0.tar.bz2
   sha256: 3d252d3b5bb30fcacf291c414d308792cb35d528aead1ebc2255e25a3ddc13d2
   md5: 1da6aae4b3e031c95051b21ca01fd279
   depends:
@@ -7907,7 +7907,7 @@ packages:
   license_family: BSD
   size: 6230264
   timestamp: 1720555663355
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.10.1-py311h4cd664f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.10.1-py311h4cd664f_0.tar.bz2
   sha256: 7bf058d86876ca3d1f23b21ca8f3d9340e7f26fef9366eca092302c4fdc04e8b
   md5: 7492afa4cb19e783c400ae35b90753cc
   depends:
@@ -7923,7 +7923,7 @@ packages:
   license_family: MIT
   size: 210960
   timestamp: 1730216100891
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
   sha256: 470fe9a0b3e196fa60d5550d8188f6074a207572fa0d353a4448d580872e7804
   md5: 6fdb8df0613fb2fb9f1732d335fa25f1
   depends:
@@ -7940,7 +7940,7 @@ packages:
   license_family: BSD
   size: 11053
   timestamp: 1708641901110
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
   sha256: 222c1711e7cf151e29077c7d4d86a865c9fd39615812d58a1daca6fd1b6bdfb5
   md5: 585bcd8bc3940a8a859f38ebafdcd77d
   depends:
@@ -7956,7 +7956,7 @@ packages:
   license_family: BSD
   size: 10723862
   timestamp: 1708641867155
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
   sha256: e2afce0548808d27293a03661ee5f7ac3e18f82a92c9fb23f420eb5e92126fc6
   md5: 9dd921a785844abe0aa842c3800d405a
   depends:
@@ -7968,7 +7968,7 @@ packages:
   license_family: BSD
   size: 286986
   timestamp: 1722872761369
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.15-h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.15-h827c3e9_0.tar.bz2
   sha256: a72f51f69a6893797b51345f9fd6b6a3b12764b435bb50e247e9e05d75711bd0
   md5: c05007cfd519c5097f50d9c830ad897f
   depends:
@@ -7979,7 +7979,7 @@ packages:
   license_family: Apache
   size: 8396971
   timestamp: 1725547066793
-- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
   sha256: b2f5f50a1ddf811102636f3acebd76716c88ebb628754b91eda7a3a962adf26c
   md5: 712527b4d84c350dca4b67f511c04414
   depends:
@@ -7988,7 +7988,7 @@ packages:
   license_family: APACHE
   size: 39421
   timestamp: 1699371341381
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-24.1-py311haa95532_0.tar.bz2
   sha256: 01e970843b748f4af6cb1600fd2736d546158c3d69584cb915a08eb6c6924fcf
   md5: 59b0cc461ea2af7e3f344faadc91e6aa
   depends:
@@ -7997,7 +7997,7 @@ packages:
   license_family: Apache
   size: 157605
   timestamp: 1720102973406
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.2-py311hea22821_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-2.2.2-py311hea22821_0.tar.bz2
   sha256: 1b986a8752785cd01969e737952449f5f0f4284cab7690193fa1a602156881c2
   md5: ecfe5661d54e32e8533c02f5fd625dcb
   depends:
@@ -8048,7 +8048,7 @@ packages:
   license_family: BSD
   size: 17245139
   timestamp: 1718309568175
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.5.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-1.5.3-py311haa95532_0.tar.bz2
   sha256: b0200b6e41271d9e8d37a423315190d4e0932c9f7fbc49895bfb6dd3af815b32
   md5: 6e9c63ef2b4e4705c1df990034b685cb
   depends:
@@ -8073,7 +8073,7 @@ packages:
   license_family: BSD
   size: 24127520
   timestamp: 1730381316612
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-2.1.1-py311haa95532_0.tar.bz2
   sha256: e6611058e26521784b6197418505acee343ca299b7fa3f57ec23621f869e1d57
   md5: ffd4cc05e70b156e44f242538d81ca99
   depends:
@@ -8082,7 +8082,7 @@ packages:
   license_family: BSD
   size: 264340
   timestamp: 1719348210484
-- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py311haa95532_0.tar.bz2
   sha256: b0d7fbfcf1c5c682ed9934eb6a33e00a2517941f2bcb9d677379f4bb73b2c45c
   md5: 20c8f36595a48f5cda2f4f74c02a3ea2
   depends:
@@ -8096,7 +8096,7 @@ packages:
   license_family: BSD
   size: 48206
   timestamp: 1698702818841
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-11.0.0-py311hb5480e2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-11.0.0-py311hb5480e2_0.tar.bz2
   sha256: 88962ec842c1bb41b568f2fc01ba75fde3b96273dfed0c49020cfcc4a49695b5
   md5: d35c371f08a42f2c91e1736829477729
   depends:
@@ -8114,7 +8114,7 @@ packages:
   license_family: Other
   size: 981975
   timestamp: 1731594905700
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-24.2-py311haa95532_0.tar.bz2
   sha256: 9c0dc12161f77b43137dad2e520ed7a343c5d8d8fd545492336e84201d1bb74c
   md5: 22cda044cb24e1db8fbaa5864feb4261
   depends:
@@ -8125,7 +8125,7 @@ packages:
   license_family: MIT
   size: 3199019
   timestamp: 1723485404416
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
   sha256: e5f8cbfb5fc25d460a9117bfc5511959c5e86ccb193316033f87bd516e0c8881
   md5: 9f7e8b5eb651539386bb92c14e5c321b
   depends:
@@ -8134,7 +8134,7 @@ packages:
   license_family: MIT
   size: 37730
   timestamp: 1692205554840
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ply-3.11-py311haa95532_0.tar.bz2
   sha256: a100d5bef5d832db705558acee7ecb4ec2471c18d13ab65fb92f7bc3b3a44ae7
   md5: 0ae839617227e2ef40d65e85607e60d6
   depends:
@@ -8143,7 +8143,7 @@ packages:
   license_family: BSD
   size: 111734
   timestamp: 1676426983345
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
   sha256: 6c5b53831273674361437fb546e08315fc11ca9275a174bca3887987e86ced5a
   md5: f8d91daf5173eb03157f484389adcdd4
   depends:
@@ -8152,7 +8152,7 @@ packages:
   license_family: Apache
   size: 122178
   timestamp: 1679591983138
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
   sha256: 546819d922b03f3a25ca9f98fd069d0588d481fc0603c6d74bd598fb6a93687f
   md5: 86c18e3e0b67ee099457475ed6caf2e6
   depends:
@@ -8164,7 +8164,7 @@ packages:
   license_family: BSD
   size: 751763
   timestamp: 1704404627180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
   sha256: ae06f0dfa2cfae51404afc6d6ad3a474a93015b5ba9a7d3ea24224b8e7547987
   md5: 3e19794c806cc3e84a3080a97c359b75
   depends:
@@ -8175,7 +8175,7 @@ packages:
   license_family: BSD
   size: 510466
   timestamp: 1679005998612
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
   sha256: e2af1efb1a5094a5962d93fa949ecab479a2ae7570e030f52eeac6761383c208
   md5: 4cb1359e22ddf8f3996afddce5f6205c
   depends:
@@ -8187,7 +8187,7 @@ packages:
   license_family: BSD
   size: 56638
   timestamp: 1676438592117
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
   sha256: d95c88d06f4f3f667bd9a39e5f18179e83b3cd4c115c06ce0fff390ff6d3a700
   md5: c6d00a8a4d89b1be99bfa3aff19d96b4
   depends:
@@ -8196,7 +8196,7 @@ packages:
   license_family: BSD
   size: 2134881
   timestamp: 1684280285492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.2.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.2.0-py311haa95532_0.tar.bz2
   sha256: 30ed42a98c68d6c98d48f871197c5c9c745e7545a12818a21d36689fe1a3a856
   md5: dfd92ad9c788e9c687ca8adc3f541ce0
   depends:
@@ -8205,7 +8205,7 @@ packages:
   license_family: MIT
   size: 486618
   timestamp: 1731445794006
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py311hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyqt-5.15.10-py311hd77b12b_0.tar.bz2
   sha256: d86b6f06ff63712d58bc0f82a6d345ec578c854051934ac73e5bd929782cd6ab
   md5: d03b87499af4ad84a166b2d49db2bacf
   depends:
@@ -8220,7 +8220,7 @@ packages:
   license_family: GPL
   size: 5041665
   timestamp: 1698775563282
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyqt5-sip-12.13.0-py311h2bbff1b_0.tar.bz2
   sha256: 449266141df059e53f3ae09ef2f1f10b94bc6ab51f919dc4533c32da3a0e808f
   md5: f125f06594be8adff678b9b36861b847
   depends:
@@ -8231,7 +8231,7 @@ packages:
   license_family: GPL
   size: 84114
   timestamp: 1698769459963
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
   sha256: 974c22de09078bf07c5db31fe12d8d89d6433508defc8237cbe52e08c69ed56b
   md5: 9cf10bfd49140a527cf4b1d912097e6d
   depends:
@@ -8241,7 +8241,7 @@ packages:
   license_family: BSD
   size: 36072
   timestamp: 1676426019064
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.10-h4607a30_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.11.10-h4607a30_0.tar.bz2
   sha256: 0dff21c8c9ebc1e213943cfc5478902d5e4bd5d9c8f182c75c2a79ce68cdd354
   md5: 8df15424645a9a06e0536feb3b45e516
   depends:
@@ -8262,7 +8262,7 @@ packages:
   license_family: PSF
   size: 20124673
   timestamp: 1727940469913
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
   sha256: 2c61639b3bb56fc864c86558bceb7845b1731ac44bf1a94894172ea47a995bd4
   md5: 404805e547b4d50b5cd17e16bca87527
   depends:
@@ -8272,7 +8272,7 @@ packages:
   license_family: BSD
   size: 332043
   timestamp: 1716495838826
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
   sha256: 9acb33db60d9319595f52337cae3b88c2a2338cd66f1f9d8ae86d0a993c2067a
   md5: f4af8cf94d042b4dde487241bba1c457
   depends:
@@ -8281,7 +8281,7 @@ packages:
   license_family: BSD
   size: 279780
   timestamp: 1679500609851
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
   sha256: 48fe7373b012b51134b6b6ff67f18d2b4aae3a5c7700e4560ce002af7172f064
   md5: 0379cd17692152c12b662b0e4ea46b88
   depends:
@@ -8290,7 +8290,7 @@ packages:
   license_family: BSD
   size: 18008
   timestamp: 1683824373128
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
   sha256: 803274d986d0c4e3b5ec1018747ede86ef57137455b3e44a60e834717eafb92b
   md5: c9f134ddeff6fdf0373a45534ddb7079
   depends:
@@ -8299,7 +8299,7 @@ packages:
   license_family: MIT
   size: 273009
   timestamp: 1713974722039
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
   sha256: 6fbcba97c1dcb5157afd23f264c3cff069c7e4be5ea55980fc349eb8dc2cb49e
   md5: 8153e3f8b3283926bcf9403804a365f5
   depends:
@@ -8311,7 +8311,7 @@ packages:
   license_family: BSD
   size: 65050
   timestamp: 1711137009299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
   sha256: cd33dfee104dfbba4af38d06a09ccbae6a32e7c543afedab523303319ebb283d
   md5: 3dfc19af0306d80921e1403f1f551bba
   depends:
@@ -8321,7 +8321,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13679916
   timestamp: 1676423267293
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
   sha256: 102ff1d958209e3648bb49da3503cf752abab822011fdc4e12e88145c9e73772
   md5: 0553c2c381b6f5c836b23edc8c6db2ba
   depends:
@@ -8333,7 +8333,7 @@ packages:
   license_family: MIT
   size: 246689
   timestamp: 1677708371873
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.2-py311h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.2-py311h827c3e9_0.tar.bz2
   sha256: b54065893111c3bf4ab784feb9a0b7b58bd829c414adda935624790d6541885f
   md5: 1d84022dd238ec68d7c0499885d18c86
   depends:
@@ -8345,7 +8345,7 @@ packages:
   license_family: MIT
   size: 209408
   timestamp: 1728658205944
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
   sha256: ea39db411361d96545a04fb976940e9590147acb4ca9caacf7e8264780379347
   md5: b411b8be8e53e5059949dde02dd07faf
   depends:
@@ -8357,7 +8357,7 @@ packages:
   license_family: Other
   size: 565148
   timestamp: 1709319072176
-- conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_11.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/qt-main-5.15.2-h19c9488_11.tar.bz2
   sha256: 1ee384ba28d1d2b0c096e6879c418ba65b67c7413284e14bdc7469e275fb3224
   md5: 9cd3131723269ddb371d6dd31f50a1e8
   depends:
@@ -8380,7 +8380,7 @@ packages:
   license_family: LGPL
   size: 71386363
   timestamp: 1731691366355
-- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
   sha256: 47653b45a5f2d97b5bf0dbf0e620908880f9078da427eef69012effe3f19af67
   md5: 44e709ae67d89bccee2d4d46d358fee3
   depends:
@@ -8391,7 +8391,7 @@ packages:
   license_family: MIT
   size: 74493
   timestamp: 1699012356534
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.32.3-py311haa95532_1.tar.bz2
   sha256: a225c1d6a873991bed5c9e93806f0ef0af35830cd6ce09a849e20084a8372200
   md5: 321bb6bf4f0afb4e9175bcb75ab57976
   depends:
@@ -8407,7 +8407,7 @@ packages:
   license_family: Apache
   size: 124386
   timestamp: 1731000647310
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
   sha256: d6daaa6b45272819176e4aeb467ae00e3db43386548464a9993688f292709d40
   md5: 9fe721d7f7420c259df4f07d4503f654
   depends:
@@ -8417,7 +8417,7 @@ packages:
   license_family: MIT
   size: 9683
   timestamp: 1683077110211
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
   sha256: 6051860575f9448aea5799d74469c928cd7cdeeca1eb53657872262a77b1a7a8
   md5: 60e193eca497130034facd5fed168249
   depends:
@@ -8426,7 +8426,7 @@ packages:
   license_family: MIT
   size: 10094
   timestamp: 1683059114376
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
   sha256: ecd310461c1b45ab92ddf15539cea5a6e837860561c974d2d7393f9a7933f116
   md5: 1762fec2838763e904141167e18b0389
   depends:
@@ -8437,7 +8437,7 @@ packages:
   license_family: MIT
   size: 215600
   timestamp: 1698947891859
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.14.1-py311h9f229c6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/scipy-1.14.1-py311h9f229c6_0.tar.bz2
   sha256: 8dfe0cf23bd8459db29ed50ceeab3fa64c3cf8feaf8a25fdec73679be403b140
   md5: 4b2d3cf51753889b839da0b0454c4c3e
   depends:
@@ -8454,7 +8454,7 @@ packages:
   license_family: BSD
   size: 33339059
   timestamp: 1731625867885
-- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
   sha256: 6fd52bae6360fbc8135d72e0c1e4fd407769fa4d0f4b59356e7aed3e000eb339
   md5: 49fd52885250da8aab17ed72e2e18b81
   depends:
@@ -8463,7 +8463,7 @@ packages:
   license_family: BSD
   size: 88901
   timestamp: 1699371435766
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-75.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-75.1.0-py311haa95532_0.tar.bz2
   sha256: 229e6de8307d0463288427283e65479a1f2b8e0f4ec49edfd419bea6fb124b33
   md5: 253b0897800b6c739dc3ee26546ddf7e
   depends:
@@ -8472,7 +8472,7 @@ packages:
   license_family: MIT
   size: 2308770
   timestamp: 1726678611334
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py311hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sip-6.7.12-py311hd77b12b_0.tar.bz2
   sha256: f9b5386b4bbae4a6dbf2d391d482a4eb66067435234d990e0a3dd1ea8c710dee
   md5: 46b9998433d3d70eb124f7d6480698b3
   depends:
@@ -8486,7 +8486,7 @@ packages:
   license_family: GPL
   size: 682181
   timestamp: 1698676093853
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
   sha256: 5d1b7e14dc04816692de0f8518ea8fcbefb26ab61cec83f96f2c44c1bee67fab
   md5: 505d2a70a875b5082dc857aa4dfab0d4
   depends:
@@ -8495,7 +8495,7 @@ packages:
   license_family: Other
   size: 18830
   timestamp: 1705431395254
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
   sha256: 5ff3b4ac3fbce4dd67a87856c04698d0397deb0ac288ff4e7eb02fbab57f1253
   md5: 0ca650a7001c6650809d3361de8cb005
   depends:
@@ -8504,7 +8504,7 @@ packages:
   license_family: MIT
   size: 89590
   timestamp: 1696347858925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
   sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
   md5: 833b93a2daade3407898f15588945d83
   depends:
@@ -8514,7 +8514,7 @@ packages:
   license_family: Other
   size: 1440481
   timestamp: 1714488344682
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -8524,7 +8524,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
   sha256: 78d89b50a29fbeb19a562f5dad95615e3f192bb4f3b86cd6ea75f2f825418232
   md5: 4a4040df560ea47704e0898c4c015808
   depends:
@@ -8535,7 +8535,7 @@ packages:
   license_family: BSD
   size: 38069
   timestamp: 1678228553220
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
   sha256: 70a3cc4a4e81a6421bc19cd410d1d6064aadb2b1cce38b020f85e5346716d8e7
   md5: 32a9a2539579a3d522dce3b5cb4f987b
   depends:
@@ -8545,7 +8545,7 @@ packages:
   license_family: BSD
   size: 49495
   timestamp: 1676425411739
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
   sha256: 0a95736cfd0bb25fc201cd6be4a2450ea8fc30eeb349d861812675b84c94fa74
   md5: a8a9fb30c6dd8e7a16d5dcd2333c3c49
   depends:
@@ -8556,7 +8556,7 @@ packages:
   license_family: BSD
   size: 3844176
   timestamp: 1714770894235
-- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py311haa95532_0.tar.bz2
   sha256: ed5950ac0c12cc87f991a6f28112cf29057e2b7ad416ae4429a0b97c3efaf58c
   md5: b5e2a04879e6fd19f0eb5effded4dc61
   depends:
@@ -8565,7 +8565,7 @@ packages:
   license_family: BSD
   size: 135939
   timestamp: 1676431438808
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.1-py311h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.4.1-py311h827c3e9_0.tar.bz2
   sha256: 04340cd171ff970c405b4b955f825cb52deb71f4420346596744bf36214ce431
   md5: bbab95732695d5d4c759dfbd274a15ff
   depends:
@@ -8576,7 +8576,7 @@ packages:
   license_family: Apache
   size: 926984
   timestamp: 1718740216876
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.5-py311h746a85d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.66.5-py311h746a85d_0.tar.bz2
   sha256: 283f31f5ef79657b27b9a6d82b5366b869744b553f90bad219714f2771b0088f
   md5: cea2f913161c630749f8e8ac190c99f3
   depends:
@@ -8588,7 +8588,7 @@ packages:
   license_family: MOZILLA
   size: 186694
   timestamp: 1724854118410
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
   sha256: a724711191ac1226bf228eab49718eed7b5c7394f539294eb0f88baf8e7bb24d
   md5: c78482e07d0aa6df9fcfa5b366dd87e3
   depends:
@@ -8597,7 +8597,7 @@ packages:
   license_family: BSD
   size: 207744
   timestamp: 1718227224929
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
   sha256: ab3cce654f1e94793fff0cb03b750d9b20cdbf099263b1906c3c5eaf8b347ab6
   md5: c68ffc771312afb6f88b94c24d2bb689
   depends:
@@ -8607,7 +8607,7 @@ packages:
   license_family: PSF
   size: 9706
   timestamp: 1715268972001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
   sha256: 4089efea1753ebe2f6617b46cc368738f285b1d816d4a4f01ba71524f46851b4
   md5: 7f610528ecd0b317180efa2058c32323
   depends:
@@ -8616,7 +8616,7 @@ packages:
   license_family: PSF
   size: 75414
   timestamp: 1715268958140
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
   sha256: d091897f05318c22ca31028370f25355065999078f7db6f88ab27bf4cb030ec8
   md5: 1776502c1cfb351554eeda6cddaf255f
   depends:
@@ -8625,7 +8625,7 @@ packages:
   license_family: MIT
   size: 11588
   timestamp: 1676457729096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
   sha256: c16498f8238cc331618720d078b87995eceb6bbf20268a7a4e8efbf7b5859a9a
   md5: 770432c0ca1ab9d99ffe95e51d3a3e74
   depends:
@@ -8636,7 +8636,7 @@ packages:
   license_family: Apache
   size: 517433
   timestamp: 1713213261710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-2.2.3-py311haa95532_0.tar.bz2
   sha256: de79b019200fdeb430ce7971edaa7af403cbfc1b52e1bdca6e496c6eeaf6b37f
   md5: ba54713eec74d8c2636f137608ad8959
   depends:
@@ -8652,7 +8652,7 @@ packages:
   license_family: MIT
   size: 218619
   timestamp: 1727770119876
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.40-h2eaa2aa_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.40-h2eaa2aa_1.tar.bz2
   sha256: 5bbfaacd95bb901683d6d2e7a1ee10f67172acc1e012f73f80bfef5237ae3ae4
   md5: f37ef4381071123903074612dad356f4
   depends:
@@ -8661,12 +8661,12 @@ packages:
   license_family: BSD
   size: 9122
   timestamp: 1726064402583
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.40.33807-h98bb1dd_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.40.33807-h98bb1dd_1.tar.bz2
   sha256: d82b5b2b1a9a1b37da109039274c125355ce478a199c07c7826ac0fdc2178491
   md5: a0f93c06400da31b9e6e0538eab91216
   size: 2611238
   timestamp: 1726064391949
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
   sha256: 24ea3d3e0cb98d0d246338dbb4562b67967bb32002e3704e495a5c863476e831
   md5: c7b9cdbe87b3c9720aeca1164a0fd6df
   depends:
@@ -8675,7 +8675,7 @@ packages:
   license_family: BSD
   size: 26181
   timestamp: 1676424437003
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
   sha256: 92d27e41ce34387e59acb47572fcb2e92c4defaeadafd11ce190226022023e69
   md5: f1bf142d852987acbe4b0bc94e87d958
   depends:
@@ -8684,7 +8684,7 @@ packages:
   license_family: Apache
   size: 145306
   timestamp: 1715878654770
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.44.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.44.0-py311haa95532_0.tar.bz2
   sha256: 2eb16eafe8322ad10c73b19be8f2c8b6135561bead6f73f48c069417f5db8928
   md5: b28ec461da7eac99523f146ae752529b
   depends:
@@ -8693,7 +8693,7 @@ packages:
   license_family: MIT
   size: 170318
   timestamp: 1726165294131
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
   sha256: 17fadf35aa8917c107e7b369e9364ac7c09537776e7943d37e225e14b7026c94
   md5: 0e67c3b9624540581b894b11267a837b
   depends:
@@ -8701,13 +8701,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 10197
   timestamp: 1676425485716
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py311haa95532_0.tar.bz2
   sha256: 25373efabba9a866849fe38a47c79e0fa323851b4bd4b5df357cc8d5617c2786
   md5: a958e9d32c3b65c21e11e5d9e8491c43
   depends:
@@ -8719,7 +8719,7 @@ packages:
   license_family: Apache
   size: 2467966
   timestamp: 1689041676824
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
   sha256: b849b368e27920838fe40a512b102879693a55cb187dd1c8d3a83fa8c05a8054
   md5: 7b1f6e9c71906a93039b3446b99a5498
   depends:
@@ -8728,7 +8728,7 @@ packages:
   license_family: BSD
   size: 55114
   timestamp: 1676434863173
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
   sha256: 344a5276a9928638dcde054dfe4e87c8cb40bd2d4d356378b9ab2f863ca62e4b
   md5: fe471fd8b5a3d77be6fa5dbf9b99dafb
   depends:
@@ -8738,7 +8738,7 @@ packages:
   license_family: GPL2
   size: 1432281
   timestamp: 1714515119689
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -8747,7 +8747,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
   sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
   md5: e5aed81295b61b6d1eb62830799a0297
   depends:
@@ -8758,7 +8758,7 @@ packages:
   license_family: Other
   size: 9125184
   timestamp: 1705602328351
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.20.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.20.2-py311haa95532_0.tar.bz2
   sha256: 269c2391ea63485d1bc1a0ac334425b9911782a97cd3c5cebf73b2ed224f0d77
   md5: 61ed0fa3bd33349afb499de32b882766
   depends:
@@ -8767,7 +8767,7 @@ packages:
   license_family: MIT
   size: 29698
   timestamp: 1729012608017
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
   sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
   md5: f295b54ab59f5b8658e2a322ac6aa721
   depends:
@@ -8777,7 +8777,7 @@ packages:
   license_family: Other
   size: 162161
   timestamp: 1714514792081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
   sha256: 1f68cd378c6cdec34a5a3a21c56c9b8422b0f037b868b3db72065c0a2ca27921
   md5: d455a04486eddfb94c280974c0c33ae3
   depends:
@@ -8790,16 +8790,14 @@ packages:
   license_family: BSD
   size: 1971698
   timestamp: 1728487049972
-- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
-  sha256: 98f3bae3caff4c52615ddb56405dc51b39d9d2c47a9bccd130a5a19d10304245
+- conda: https://conda.anaconda.org/msys2/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
   md5: de1b7f7c8221028f6bbe103df4c53bed
   depends:
   - m2w64-gcc-libs-core
   - msys2-conda-epoch >=20160418
   license: GPL, LGPL, FDL, custom
   size: 348607
-- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
-  sha256: 2fb6488298a659c781f9294a743b0b376d9998a6b06aa2a3b85b49c38a85ea16
+- conda: https://conda.anaconda.org/msys2/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
   md5: 0b9caac6747002340b057a222af705b2
   depends:
   - m2w64-gcc-libgfortran
@@ -8809,8 +8807,7 @@ packages:
   - msys2-conda-epoch >=20160418
   license: GPL3+, partial:GCCRLE, partial:LGPL2+
   size: 530578
-- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
-  sha256: 449df9debaf202928e3a0db1f059ef35b1bcb3973fa92e217ca2775f82415111
+- conda: https://conda.anaconda.org/msys2/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
   md5: 276d396bfe8d958f71173b7134f739fa
   depends:
   - m2w64-gmp
@@ -8818,21 +8815,18 @@ packages:
   - msys2-conda-epoch >=20160418
   license: GPL3+, partial:GCCRLE, partial:LGPL2+
   size: 217686
-- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gmp-6.1.0-2.tar.bz2
-  sha256: 5cf23439eef17ae158d63ff3f85f77d1dca9a45b19324fdeda9e3e48ae298d18
+- conda: https://conda.anaconda.org/msys2/win-64/m2w64-gmp-6.1.0-2.tar.bz2
   md5: fec04371463ec68eb8f5752a22c5b030
   depends:
   - msys2-conda-epoch >=20160418
   license: LGPL3
   size: 705647
-- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
-  sha256: 9373b0157e08cbea09298f461d2816833281b3e22a8c9f6c5a38d7109c8a281e
+- conda: https://conda.anaconda.org/msys2/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
   md5: 67e61e700eb27424979778fae9293f13
   depends:
   - msys2-conda-epoch >=20160418
   license: MIT, BSD
   size: 30543
-- conda: https://repo.anaconda.com/pkgs/msys2/win-64/msys2-conda-epoch-20160418-1.tar.bz2
-  sha256: d6a55d779052bca9accd534398b4e147d0a3dfc8f4b6528391ee9c15843784bc
+- conda: https://conda.anaconda.org/msys2/win-64/msys2-conda-epoch-20160418-1.tar.bz2
   md5: 6eaef3074f65f715ed1ca6b8a08be3aa
   size: 2065

--- a/opensky/pixi.toml
+++ b/opensky/pixi.toml
@@ -1,0 +1,41 @@
+[workspace]
+name = "opensky"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2017-11-03"
+maintainers = ["jbednar", "philippjfr"]
+categories = ["Geospatial"]
+labels = ["hvplot", "holoviews", "bokeh", "matplotlib", "datashader"]
+description = "Datashading OpenSky flight trajectories"
+
+[dependencies]
+python = "3.11.*"
+notebook = "<7"
+bokeh = ">=3.5.0"
+colorcet = ">=3.1.0"
+datashader = ">=0.16.0"
+fastparquet = ">=2024.2.0"
+holoviews = ">=1.20.0"
+hvplot = ">=0.11.1"
+matplotlib = ">=3.8.4"
+pandas = ">=2.2.2"
+pip = "*"
+setuptools = "*"
+wheel = "*"
+
+[target.osx-64.dependencies]
+libgfortran = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks.notebook]
+cmd = "jupyter notebook opensky.ipynb"
+depends-on = ["download"]
+
+[tasks.download]
+env = { FILENAME = "data/opensky.parq" }
+cmd = "mkdir -p data && curl -fsSL -o $FILENAME http://s3.amazonaws.com/datashader-data/opensky.parq"
+outputs = ["data/opensky.parq"]

--- a/opensky/pixi.toml
+++ b/opensky/pixi.toml
@@ -21,15 +21,15 @@ holoviews = ">=1.20.0"
 hvplot = ">=0.11.1"
 matplotlib = ">=3.8.4"
 pandas = ">=2.2.2"
-pip = "*"
-setuptools = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+setuptools = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks.notebook]
 cmd = "jupyter notebook opensky.ipynb"

--- a/opensky/pixi.toml
+++ b/opensky/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "opensky"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/osm/pixi.lock
+++ b/osm/pixi.lock
@@ -8,8 +8,8 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -252,7 +252,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2022.9.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2021.8.0-py38h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/distributed-2021.8.0-py38h06a4308_0.tar.bz2
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.3-pyhd8ed1ab_0.tar.bz2
@@ -488,7 +488,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h93d8f39_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2021.8.0-py38hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/distributed-2021.8.0-py38hecd8cb5_0.tar.bz2
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-3.7.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.3-pyhd8ed1ab_0.tar.bz2
@@ -706,8 +706,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h965bd2d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyobjc-core-9.0-py38h3eb5a62_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyobjc-framework-cocoa-9.0-py38hb094c41_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyobjc-core-9.0-py38h3eb5a62_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyobjc-framework-cocoa-9.0-py38hb094c41_0.tar.bz2
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
@@ -946,7 +946,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.4-h0e60522_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.2.13-hcfcfb64_5.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2021.8.0-py38haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/distributed-2021.8.0-py38haa95532_0.tar.bz2
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -7709,7 +7709,7 @@ packages:
   license_family: BSD
   size: 343428
   timestamp: 1693151615801
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2021.8.0-py38h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/distributed-2021.8.0-py38h06a4308_0.tar.bz2
   sha256: d462fc9de63d8ddaeaf6d74ed0f2551e6da278995b085371182035521850a7f4
   md5: 120767525583f39980d8b9f5cac094d7
   depends:
@@ -7734,7 +7734,7 @@ packages:
   license_family: BSD
   size: 1073466
   timestamp: 1629141746441
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2021.8.0-py38hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/distributed-2021.8.0-py38hecd8cb5_0.tar.bz2
   sha256: 34dacd552b9bcacb2487ddb1a07fde00e9ec4368fceac91e80c4a214dd00be18
   md5: 902b64dcbf4418647d90c6e29fec2d68
   depends:
@@ -7759,7 +7759,7 @@ packages:
   license_family: BSD
   size: 1076683
   timestamp: 1629141752006
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyobjc-core-9.0-py38h3eb5a62_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyobjc-core-9.0-py38h3eb5a62_1.tar.bz2
   sha256: 44a82e3bed2b67e7ceb6b0cdbcde45c8e9af695aab44a9cf8db0b0f1721b5942
   md5: 7a387ab242aa5e99b3c084cfc43bc816
   depends:
@@ -7770,7 +7770,7 @@ packages:
   license_family: MIT
   size: 441954
   timestamp: 1678038454553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyobjc-framework-cocoa-9.0-py38hb094c41_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyobjc-framework-cocoa-9.0-py38hb094c41_0.tar.bz2
   sha256: 6019eb669c319854cd4f15bcedf24660d489fd8a49c9e33df77bbec78f676440
   md5: 33590339a3982e0c26cb5a1ead0bc6ae
   depends:
@@ -7781,7 +7781,7 @@ packages:
   license_family: MIT
   size: 373842
   timestamp: 1678108414678
-- conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2021.8.0-py38haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/distributed-2021.8.0-py38haa95532_0.tar.bz2
   sha256: 755382bca9611273efbcf054aca30934ce6549bc6086cb72fea51b073485500d
   md5: b984800d2f287a421484576a44056ade
   depends:

--- a/osm/pixi.lock
+++ b/osm/pixi.lock
@@ -1,0 +1,7809 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/abseil-cpp-20211102.0-h93e1e8c_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py38h01eb140_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/arrow-cpp-5.0.0-py38h91fe7ba_35_cpu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.5.11-h95a6274_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.6.2-h7f98852_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.2.7-h3541f99_13.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.10.5-hfb6a706_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.11-ha31a3da_7.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.8.186-hecaee15_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bokeh-2.3.3-py38h578d9bd_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.0.9-h166bdaf_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.0.9-h166bdaf_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.0.9-py38hfa26641_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.20.1-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.7.22-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py38h6d47a40_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.1.1-py38h7f3f72f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cramjam-2.7.0-py38h0cc4f7c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-0.12.2-py38h01eb140_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.0-py38h17151c0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fastparquet-0.7.1-py38h6c62de6_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.43.1-py38h01eb140_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-he1b5a44_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.6.0-h6f12383_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.2.1-h58526e2_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/grpc-cpp-1.45.2-he70e3f0_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-2.4-py38h578d9bd_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-5.4.0-py38h578d9bd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.5-py38h7f3f72f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.20.1-hf9c8cef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.15-hb7c19ff_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20211102.0-cxx17_h48a1fff_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-19_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.0.9-h166bdaf_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.0.9-h166bdaf_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.0.9-h166bdaf_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-19_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-7.87.0-h6312ad2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.19-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.10-h9b69904_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-19_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.51.0-hdcd2b5c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.24-pthreads_h413a1c8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.39-h753d276_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-3.20.3-h3eb15da_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.43.2-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.10.0-haa6b8db_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.16.0-h491838f_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-ha9c0a0a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.40.1-py38h94a1851_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py38h01eb140_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.7.3-py38h58ed7fa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.0.6-py38h7f3f72f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-hcb278e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.57.1-py38hd559b08_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.24.4-py38h59b608b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.0-h488ebb8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-1.1.1w-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-1.7.5-h6c59b99_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-1.2.5-py38h1abd341_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.1.3-h32600fe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.1.0-py38ha43c96d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py38h01eb140_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-5.0.0-py38h9f6a473_35_cpu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.8.15-h257c98d_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-snappy-0.6.0-py38h1ddbb56_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.8-4_cp38.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py38h01eb140_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-24.0.1-py38hfc09fa9_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2022.04.01-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.10.6-py38h0cc4f7c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.0.10-h9b69904_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.10.1-py38h59b608b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/setuptools-59.8.0-py38h578d9bd_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/thrift-0.19.0-py38h17151c0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.3.3-py38h01eb140_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py38h01eb140_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2021.8.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2021.8.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.14.4-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashape-0.5.4-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.10.0-pyhca7485f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.14.5-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.26.0-pyhf8b6a83_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.12.2-pyh41d4057_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.9.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.0.0-pyhb4ecaf3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.6-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-0.12.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-1.13.0-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parquet-cpp-1.5.1-2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.17.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-core-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/retrying-1.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh41d4057_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/spatialpandas-0.4.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-2.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyh41d4057_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.12.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2022.9.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2021.8.0-py38h06a4308_0.tar.bz2
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2021.8.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2021.8.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.14.4-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashape-0.5.4-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.10.0-pyhca7485f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.14.5-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.26.0-pyh3cd1d5f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.12.2-pyhd1c38e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.9.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.0.0-pyhb4ecaf3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.6-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-0.12.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-1.13.0-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parquet-cpp-1.5.1-2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.17.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-core-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/retrying-1.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyhd1c38e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/spatialpandas-0.4.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-2.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyhd1c38e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.12.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2022.9.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/abseil-cpp-20211102.0-hddbf539_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py38hcafd530_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/arrow-cpp-5.0.0-py38h430e7ab_35_cpu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.5.11-hd2e2f4b_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.6.2-h0d85af4_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.2.7-hb9330a7_13.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.10.5-h35aa462_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.11-h0010a65_7.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.8.186-h7c85d8e_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bokeh-2.3.3-py38h50d1736_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.0.9-hb7f2c08_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.0.9-hb7f2c08_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.0.9-py38h4cd09af_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.20.1-h10d778d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2023.7.22-h8857fd0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.16.0-py38h082e395_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.1.1-py38h15a1a5b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cramjam-2.7.0-py38h7510fb3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-0.12.2-py38hcafd530_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.0-py38h940360d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fastparquet-0.7.1-py38hbe852b5_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.43.1-py38hae2e43d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hb1e8313_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.6.0-h8ac2a54_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/grpc-cpp-1.45.2-h9067f4e_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-2.4-py38h50d1736_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jupyter_core-5.4.0-py38h50d1736_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.5-py38h15a1a5b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.20.1-h0165f36_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.15-hd6ba6f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20211102.0-cxx17_h844d122_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-19_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.0.9-hb7f2c08_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.0.9-hb7f2c08_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.0.9-hb7f2c08_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-19_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-7.87.0-haf73cf8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.6-hd57cbcb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.19-ha4e1b8e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-haf1e3a3_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.10-h815e4d9_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-19_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-hc8e404f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.51.0-h0dd9d14_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.24-openmp_h48a4ad5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.39-ha978bb4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-3.20.3-hbc0c0cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.18-hbcb3906_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.43.2-h92b6c6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.10.0-h7535e13_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.16.0-h08c06f4_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h684deea_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.3.2-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.15-hb7f2c08_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-17.0.3-hb6ac08f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.40.1-py38hf646772_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.3-py38hcafd530_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.7.3-py38hcd1b199_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.0.6-py38h15a1a5b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-hf0c8a7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.57.1-py38h5c56fa7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.24.4-py38h9a4a08f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.0-ha4da562_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-1.1.1w-h8a1eda9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-1.7.5-h4856350_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-1.2.5-py38h1f261ad_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandoc-3.1.3-h9d075a6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.1.0-py38h0024655_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.5-py38hcafd530_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-5.0.0-py38h83ad6b9_35_cpu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.0-py38h095c2e5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.0-py38h095c2e5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.8.15-hc915b28_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-snappy-0.6.0-py38h16e2861_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.8-4_cp38.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.1-py38hcafd530_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-24.0.1-py38h0b711fd_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2022.04.01-h96cf925_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.10.6-py38h51dbebd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.10.1-py38h9cf86d3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/setuptools-59.8.0-py38h50d1736_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/thrift-0.19.0-py38h940360d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hef22860_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.3.3-py38hcafd530_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-15.1.0-py38hcafd530_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h93d8f39_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2021.8.0-py38hecd8cb5_0.tar.bz2
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-3.7.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2021.8.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2021.8.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.14.4-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashape-0.5.4-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.10.0-pyhca7485f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.14.5-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.26.0-pyh3cd1d5f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.12.2-pyhd1c38e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.3.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-1.24.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.0.0-pyhb4ecaf3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.6-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-0.12.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-1.13.0-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parquet-cpp-1.5.1-2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.17.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-core-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/retrying-1.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyhd1c38e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/spatialpandas-0.4.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-2.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyhd1c38e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.12.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2022.9.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/abseil-cpp-20211102.0-he4e09e4_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py38hb192615_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/arrow-cpp-5.0.0-py38hcc5bc27_35_cpu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.5.11-h4530763_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.6.2-h3422bc3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.2.7-h9972306_13.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.10.5-hea86ef8_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.11-h487e1a8_7.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.8.186-h392f50b_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bokeh-2.3.3-py38h10201cd_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.0.9-h1a8c8d9_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.0.9-h1a8c8d9_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.0.9-py38h2b1e499_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h3422bc3_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.20.1-h93a5062_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.7.22-hf0a4a13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.16.0-py38h73f40f7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/click-8.0.4-py38h10201cd_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.1.1-py38h9afee92_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cramjam-2.7.0-py38hd0c8013_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-0.12.2-py38hb192615_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.0-py38he333c0f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/distributed-2021.8.0-py38h10201cd_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fastparquet-0.7.1-py38h691f20f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.43.1-py38h336bac9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hc88da5d_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.6.0-h6da1cb0_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/grpc-cpp-1.45.2-h98c3ada_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jupyter_core-5.4.0-py38h10201cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.5-py38h9afee92_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.20.1-h127bd45_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.15-hf2736f0_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20211102.0-cxx17_h28b99d4_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-19_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.0.9-h1a8c8d9_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.0.9-h1a8c8d9_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.0.9-h1a8c8d9_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-19_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-7.87.0-hbe9bab4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.6-h4653b0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.19-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h642e427_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.10-hbae9a57_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-19_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.51.0-hd184df1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.24-openmp_hd76b1f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.39-h76d750c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-3.20.3-hb5ab8b9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.18-h27ca646_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.43.2-h091b4b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.10.0-hb80f160_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.16.0-h1a74c4f_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.6.0-ha8a6c65_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-h1a8c8d9_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.3.2-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.15-hf346824_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-17.0.3-hcd81f8e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.40.1-py38h761d82c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.3-py38hb192615_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.7.3-py38hef9d0d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.0.6-py38h9afee92_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h7ea286d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.57.1-py38h11be589_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.24.4-py38ha84db1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.0-h4c1507b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-1.1.1w-h53f4e23_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-1.7.5-h96f55be_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-1.2.5-py38h3777fb4_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandoc-3.1.3-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.1.0-py38h06aea99_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.5-py38hb192615_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-5.0.0-py38h535b32c_35_cpu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.8.15-hf452327_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-snappy-0.6.0-py38hb0889cc_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.8-4_cp38.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.1-py38hb192615_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-24.0.1-py38hb72be9f_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2022.04.01-h6b3803e_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.10.6-py38h51b07bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.10.1-py38h038e806_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/setuptools-59.8.0-py38h10201cd_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/thrift-0.19.0-py38he333c0f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hb31c410_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.1-py38h33210d7_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-15.1.0-py38hb192615_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h965bd2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyobjc-core-9.0-py38h3eb5a62_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyobjc-framework-cocoa-9.0-py38hb094c41_0.tar.bz2
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2021.8.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2021.8.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.14.4-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashape-0.5.4-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.10.0-pyhca7485f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.14.5-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.26.0-pyha63f2e9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.12.2-pyh08f2357_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.9.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.0.0-pyhb4ecaf3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.6-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-0.12.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-1.13.0-pyh1a96a4e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parquet-cpp-1.5.1-2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.17.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-core-0.4.6-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/retrying-1.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh08f2357_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/spatialpandas-0.4.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-2.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.0-pyh08f2357_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.12.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyhd8ed1ab_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2022.9.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/abseil-cpp-20211102.0-h36ffca9_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py38h91455d4_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/arrow-cpp-5.0.0-py38h0c97e59_35_cpu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.5.11-he19cf47_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.6.2-h8ffe710_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.2.7-h70e1b0c_13.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.10.5-h2fe331c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.11-h1e232aa_7.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.8.186-h93d3aa3_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bokeh-2.3.3-py38haa244fe_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.0.9-hcfcfb64_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.0.9-hcfcfb64_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.0.9-py38hd3f51b4_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h8ffe710_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.20.1-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.7.22-h56e8100_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.16.0-py38h91455d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.1.1-py38hb1fd069_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cramjam-2.7.0-py38hf90c7e5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-0.12.2-py38h91455d4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.0-py38hd3f51b4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fastparquet-0.7.1-py38h6f4d8f0_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.43.1-py38h91455d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gflags-2.2.2-ha925a31_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glog-0.6.0-h4797de2_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/grpc-cpp-1.45.2-hb22af2e_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2023.2.0-h57928b3_50497.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-2.4-py38haa244fe_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jupyter_core-5.4.0-py38haa244fe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.5-py38hb1fd069_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.20.1-h6609f42_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.15-h67d730c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-static-20211102.0-cxx11_h58a5ce6_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-19_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.0.9-hcfcfb64_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.0.9-hcfcfb64_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.0.9-hcfcfb64_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-19_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.1.2-h68f0423_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.19-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-h8ffe710_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-19_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.39-h19919ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-3.20.3-h12be248_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.18-h8d14728_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.43.2-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.10.0-h680486a_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.16.0-h9f558f2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-h6e2ebb7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-h82a8f57_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.3.2-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.15-hcd874cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.11.5-hc3477c8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.40.1-py38h19421c1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.3-py38h91455d4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.7.3-py38h2724991_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2023.2.0-h6a75c08_50496.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.0.6-py38hb1fd069_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.57.1-py38hb182ae8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.24.4-py38h1d91fd2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.0-h3d672ee_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-1.1.1w-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-1.2.5-py38h60cbd38_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandoc-3.1.3-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-10.1.0-py38hc375fad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.5-py38h91455d4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-hcd874cb_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-5.0.0-py38h155c480_35_cpu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.8.15-h0269646_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-snappy-0.6.0-py38h8566a25_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.8-4_cp38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-306-py38hd3f51b4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.12-py38hd3f51b4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.1-py38h91455d4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-24.0.1-py38ha85f68a_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2022.04.01-h0e60522_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.10.6-py38h4900a04_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.10.1-py38h1aea9ed_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/setuptools-59.8.0-py38haa244fe_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.10.0-h91493d7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/thrift-0.19.0-py38hd3f51b4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.3.3-py38h91455d4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-15.1.0-py38h91455d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h64f974e_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.36.32532-hdcecf7f_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.36.32532-h05e6639_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-hcd874cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.3-hcd874cb_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.4-h0e60522_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.2.13-hcfcfb64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2021.8.0-py38haa95532_0.tar.bz2
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  license: None
+  size: 2562
+  timestamp: 1578324546067
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23621
+  timestamp: 1650670423406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/abseil-cpp-20211102.0-h93e1e8c_3.tar.bz2
+  sha256: 3c33290bfe7751e4041ad335421210712dcfc1f6b4c4ec04232e2bda9f1e688b
+  md5: 91323cc15123b8b796049c731fec58ba
+  depends:
+  - libabseil 20211102.0 cxx17_h48a1fff_3
+  license: Apache-2.0
+  license_family: Apache
+  size: 12811
+  timestamp: 1661959958197
+- conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py38h01eb140_4.conda
+  sha256: 5f9c7bcfa280c2f666610d71f497d0fdf890ffe5b2606dbc46461b85d516a7b7
+  md5: 234c813c9d745d4bfc6a2a40514d88a6
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=12
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: MIT
+  license_family: MIT
+  size: 34538
+  timestamp: 1695386702914
+- conda: https://conda.anaconda.org/conda-forge/linux-64/arrow-cpp-5.0.0-py38h91fe7ba_35_cpu.tar.bz2
+  sha256: 0f81adacde315f2fbb1cc360db4664f8e87f3388e0b593b70d2f8777e91c88db
+  md5: 3dc713900a21777888109f2ca4d09dff
+  depends:
+  - aws-sdk-cpp >=1.8.186,<1.8.187.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-ares >=1.18.1,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.6.0,<0.7.0a0
+  - grpc-cpp >=1.45.2,<1.46.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libgcc-ng >=12
+  - libprotobuf >=3.20.1,<3.21.0a0
+  - libstdcxx-ng >=12
+  - libthrift >=0.16.0,<0.16.1.0a0
+  - libutf8proc >=2.7.0,<3.0a0
+  - libzlib >=1.2.12,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - numpy >=1.16,<2.0a0
+  - numpy >=1.19.5,<2.0a0
+  - orc >=1.7.5,<1.7.6.0a0
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.9,<1.2.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  - libutf8proc <2.9
+  constrains:
+  - arrow-cpp-proc * cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 24250378
+  timestamp: 1655703002634
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.5.11-h95a6274_0.tar.bz2
+  sha256: c04c608d185c111cb1ce21f3e7934b8c2bf63bdeac0b057deb3f8935f3333ae5
+  md5: d4e7b241fb22dd3d7be1171f813d5da3
+  depends:
+  - aws-c-common >=0.6.2,<0.6.3.0a0
+  - libgcc-ng >=9.3.0
+  - openssl >=1.1.1k,<1.1.2a
+  license: Apache-2.0
+  license_family: Apache
+  size: 37458
+  timestamp: 1623801091537
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.6.2-h7f98852_0.tar.bz2
+  sha256: 8c8e79eb74c3b4574322ea89363fb9c7c72127e8952fa913d3651166f8498c5f
+  md5: ce69a062b3080485b760378841240634
+  depends:
+  - libgcc-ng >=9.3.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 171606
+  timestamp: 1623316664770
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.2.7-h3541f99_13.tar.bz2
+  sha256: 0d688595654e98dc464f00cdb7f8d13ba1c602a71ee09f250c16045a46944547
+  md5: 39768ba0fe69c241d54703a7f5e3119f
+  depends:
+  - aws-c-common >=0.6.2,<0.6.3.0a0
+  - aws-c-io >=0.10.5,<0.10.6.0a0
+  - aws-checksums >=0.1.11,<0.1.12.0a0
+  - libgcc-ng >=9.3.0
+  - libstdcxx-ng >=9.3.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 47766
+  timestamp: 1624281371543
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.10.5-hfb6a706_0.tar.bz2
+  sha256: 74fc4b5ae00ccd913e5c71d080a40e7b5bb0928f6bdca7cceb028c3300214bba
+  md5: 47d6b88b0c42a8c9877f3993b49f052d
+  depends:
+  - aws-c-cal >=0.5.11,<0.5.12.0a0
+  - aws-c-common >=0.6.2,<0.6.3.0a0
+  - libgcc-ng >=9.3.0
+  - s2n >=1.0.10,<1.0.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 124127
+  timestamp: 1623957628504
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.11-ha31a3da_7.tar.bz2
+  sha256: ecb7903e97aea0acd861c31acf86a89367a318c7ad0025e4b72c0e7e3e679cfe
+  md5: 2fdb96aaab883abc0766ff76c0a34483
+  depends:
+  - aws-c-common >=0.6.2,<0.6.3.0a0
+  - libgcc-ng >=9.3.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51209
+  timestamp: 1623336573808
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.8.186-hecaee15_4.tar.bz2
+  sha256: 0830feba7382290c54c69fa114a60f7eb6ab062fc1604b34248663bd318fb193
+  md5: e29dc8e8611b70cdfcc3139dba6e9001
+  depends:
+  - aws-c-common >=0.6.2,<0.6.3.0a0
+  - aws-c-event-stream >=0.2.7,<0.2.8.0a0
+  - libcurl >=7.86.0,<9.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=1.1.1q,<1.1.2a
+  license: Apache-2.0
+  license_family: Apache
+  size: 4702768
+  timestamp: 1667032364752
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bokeh-2.3.3-py38h578d9bd_0.tar.bz2
+  sha256: 1b94fe43b41f2bf78944f57642fab82d45b7f6e74f2acb8b508b48f817c7b5e4
+  md5: cb11b389b83a2c5a4da1b09b1eaf704c
+  depends:
+  - jinja2 >=2.7
+  - numpy >=1.11.3
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.1
+  - python_abi 3.8.* *_cp38
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8619409
+  timestamp: 1625757053443
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.0.9-h166bdaf_9.conda
+  sha256: 2357d205931912def55df0dc53573361156b27856f9bf359d464da162812ec1f
+  md5: 4601544b4982ba1861fa9b9c607b2c06
+  depends:
+  - brotli-bin 1.0.9 h166bdaf_9
+  - libbrotlidec 1.0.9 h166bdaf_9
+  - libbrotlienc 1.0.9 h166bdaf_9
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 20065
+  timestamp: 1687884291946
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.0.9-h166bdaf_9.conda
+  sha256: 1c128f136a59ee2fa47d7fbd9b6fc8afa8460d340e4ae0e6f5419ebbd7539a10
+  md5: d47dee1856d9cb955b8076eeff304a5b
+  depends:
+  - libbrotlidec 1.0.9 h166bdaf_9
+  - libbrotlienc 1.0.9 h166bdaf_9
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 20361
+  timestamp: 1687884277426
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.0.9-py38hfa26641_9.conda
+  sha256: b3bf693eee4c85ebcbae31c446f4b5bac4ec6958467cc87dd0943eae694295c9
+  md5: d056745008e5ed73210a31dcfd4d183a
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  constrains:
+  - libbrotlicommon 1.0.9 h166bdaf_9
+  license: MIT
+  license_family: MIT
+  size: 326824
+  timestamp: 1687884452293
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2
+  sha256: cb521319804640ff2ad6a9f118d972ed76d86bea44e5626c09a13d38f562e1fa
+  md5: a1fd65c7ccbf10880423d82bca54eb54
+  depends:
+  - libgcc-ng >=9.3.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 495686
+  timestamp: 1606604745109
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.20.1-hd590300_1.conda
+  sha256: 1700d9ebfd3b21c8b50e12a502f26e015719e1f3dbb5d491b5be061cf148ca7a
+  md5: 2facbaf5ee1a56967aecaee89799160e
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 115956
+  timestamp: 1697955875024
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.7.22-hbcca054_0.conda
+  sha256: 525b7b6b5135b952ec1808de84e5eca57c7c7ff144e29ef3e96ae4040ff432c1
+  md5: a73ecd2988327ad4c8f2c331482917f2
+  license: ISC
+  size: 149515
+  timestamp: 1690026108541
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py38h6d47a40_0.conda
+  sha256: ec0a62d4836d3ec2321d07cffa5aeef37c6818c6cce6383dc6be7205d09551b3
+  md5: fc010dfb8ce6540d289436fbba499ee7
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - pycparser
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: MIT
+  license_family: MIT
+  size: 239127
+  timestamp: 1696001978654
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.1.1-py38h7f3f72f_1.conda
+  sha256: bf2617fb331fe974358568ce70b1c183ffd08dcf3e0c84478c3531a62db30fbc
+  md5: 18ae206b2d413e5cc8d2bb8ab48aa165
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.16
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 221810
+  timestamp: 1695554437032
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cramjam-2.7.0-py38h0cc4f7c_1.conda
+  sha256: 0353dbd8b204c7a7021745010f7133f233826389e8d7d54b0ce0d18ad74ca9a1
+  md5: 657f96af7bc12b7f3d6ef93960948b1b
+  depends:
+  - libgcc-ng >=12
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: MIT
+  license_family: MIT
+  size: 1375184
+  timestamp: 1695450691050
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-0.12.2-py38h01eb140_1.conda
+  sha256: b6ff58c3be6093944bb11ead7d5c0fffda044b836c7cd7ecb2ca17de260fd8f8
+  md5: 56222b99bdd044e52c364c4fbee28a7a
+  depends:
+  - libgcc-ng >=12
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 374744
+  timestamp: 1695545417678
+- conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.0-py38h17151c0_1.conda
+  sha256: 37b22f9f3567cf4c4838ba31bfdfe9bf03e33183fb6d9448d765a8197b19b61e
+  md5: b43385ccbd4fa88f2c195ad3c4101c77
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: MIT
+  license_family: MIT
+  size: 2443414
+  timestamp: 1695534461220
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fastparquet-0.7.1-py38h6c62de6_0.tar.bz2
+  sha256: 187b319d0650d2a08c496afadd10d079d3eb070f5553255678ce913dfc63b308
+  md5: 69419de63c085e10fcbd95853c02807d
+  depends:
+  - cramjam >=2.3.0
+  - fsspec
+  - libgcc-ng >=9.4.0
+  - numpy >=1.18.5,<2.0a0
+  - pandas >=1.0.0
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - thrift >=0.11
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 532575
+  timestamp: 1628091957679
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.43.1-py38h01eb140_0.conda
+  sha256: ecfed3a907871131281d66a0fa6ad0de59173fad95e15407151b0a94578f47e9
+  md5: 13ee70161cad7093ce2f9f83b300ed06
+  depends:
+  - brotli
+  - libgcc-ng >=12
+  - munkres
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - unicodedata2 >=14.0.0
+  license: MIT
+  license_family: MIT
+  size: 2225257
+  timestamp: 1696601465763
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+  sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
+  md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 634972
+  timestamp: 1694615932610
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-he1b5a44_1004.tar.bz2
+  sha256: a853c0cacf53cfc59e1bca8d6e5cdfe9f38fce836f08c2a69e35429c2a492e77
+  md5: cddaf2c63ea4a5901cf09524c490ecdc
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116549
+  timestamp: 1594303828933
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.6.0-h6f12383_0.tar.bz2
+  sha256: 888cbcfb67f6e3d88a4c4ab9d26c9a406f620c4101a35dc6d2dbadb95f2221d4
+  md5: b31f3565cb84435407594e548a2fb7b2
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 114321
+  timestamp: 1649143789233
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.2.1-h58526e2_0.tar.bz2
+  sha256: 07a5319e1ac54fe5d38f50c60f7485af7f830b036da56957d0bfb7558a886198
+  md5: b94cf2db16066b242ebd26db2facbd56
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: GPL-2.0-or-later AND LGPL-3.0-or-later
+  size: 825784
+  timestamp: 1605751468661
+- conda: https://conda.anaconda.org/conda-forge/linux-64/grpc-cpp-1.45.2-he70e3f0_3.tar.bz2
+  sha256: ca6700a3ac3407e533779c3a5bfa014fbd58a33079fbf9c70e610399f7702577
+  md5: 617b18fc828b4e3c7e695742ab81fa2e
+  depends:
+  - abseil-cpp >=20211102.0,<20211102.1.0a0
+  - c-ares >=1.18.1,<2.0a0
+  - libgcc-ng >=11.2.0
+  - libprotobuf >=3.20.1,<3.21.0a0
+  - libstdcxx-ng >=11.2.0
+  - libzlib >=1.2.11,<2.0.0a0
+  - openssl >=1.1.1o,<1.1.2a
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.11,<1.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4894651
+  timestamp: 1651993771776
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-2.4-py38h578d9bd_3.conda
+  sha256: 5004ee83f7b0259d11923a0f15e79af6b3e3e114e03191cbc0e751f787ddbcaf
+  md5: ed4beead725b2b8c6673d4d7338bce78
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16120
+  timestamp: 1695397451058
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-5.4.0-py38h578d9bd_0.conda
+  sha256: 7bb65404c5eccf314231e6d446f0d750cd5e50954b904bd0403f56f56ed625fc
+  md5: e27c9855ef0e113d4fe64c21f7b8146c
+  depends:
+  - platformdirs >=2.5
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 77968
+  timestamp: 1696972551408
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+  sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
+  md5: 30186d27e2c9fa62b45fb1476b7200e3
+  depends:
+  - libgcc-ng >=10.3.0
+  license: LGPL-2.1-or-later
+  size: 117831
+  timestamp: 1646151697040
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.5-py38h7f3f72f_1.conda
+  sha256: 68129155659ec3486aa8025477fdd6eb9da2a626173750908ee1e60b7ca47dbb
+  md5: b66dcd4f710628fc5563ad56f02ca89b
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73488
+  timestamp: 1695380139123
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.20.1-hf9c8cef_0.conda
+  sha256: 3274ef26e40df1c23bd34adc075e40cc6c335540688c36ac261d64561da56278
+  md5: 5f7e9efd540d7ac4b485660231ba6150
+  depends:
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=1.1.1s,<1.1.2a
+  license: MIT
+  license_family: MIT
+  size: 1326164
+  timestamp: 1671091702497
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.15-hb7c19ff_3.conda
+  sha256: cc0b2ddab52b20698b26fe8622ebe37e0d462d8691a1f324e7b00f7d904765e3
+  md5: e96637dd92c5f340215c753a5c9a22d7
+  depends:
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 239723
+  timestamp: 1695969712554
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+  sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
+  md5: 7aca3059a1729aa76c597603f10b0dd3
+  constrains:
+  - binutils_impl_linux-64 2.40
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 704696
+  timestamp: 1674833944779
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+  sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
+  md5: 76bbff344f0134279f225174e9064c8f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 281798
+  timestamp: 1657977462600
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20211102.0-cxx17_h48a1fff_3.tar.bz2
+  sha256: 6e60ec3955c758200ee2518e5628329be6b42f9abffb6e4c14b31620e46a5dda
+  md5: ee0ec55c780d6bffda9432c3037eb10c
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  constrains:
+  - abseil-cpp =20211102.0
+  - libabseil-static =20211102.0=cxx17*
+  - libabseil-static ==99999999999
+  license: Apache-2.0
+  license_family: Apache
+  size: 1107325
+  timestamp: 1661959951390
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-19_linux64_openblas.conda
+  sha256: b1311b9414559c5760b08a32e0382ca27fa302c967968aa6f78e042519f728ce
+  md5: 420f4e9be59d0dc9133a0f43f7bab3f3
+  depends:
+  - libopenblas >=0.3.24,<0.3.25.0a0
+  - libopenblas >=0.3.24,<1.0a0
+  constrains:
+  - blas * openblas
+  - libcblas 3.9.0 19_linux64_openblas
+  - liblapack 3.9.0 19_linux64_openblas
+  - liblapacke 3.9.0 19_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14566
+  timestamp: 1697484219912
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.0.9-h166bdaf_9.conda
+  sha256: fc57c0876695c5b4ab7173438580c1d7eaa7dccaf14cb6467ca9e0e97abe0cf0
+  md5: 61641e239f96eae2b8492dc7e755828c
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 71065
+  timestamp: 1687884232329
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.0.9-h166bdaf_9.conda
+  sha256: 564f301430c3c61bc5e149e74157ec181ed2a758befc89f7c38466d515a0f614
+  md5: 081aa22f4581c08e4372b0b6c2f8478e
+  depends:
+  - libbrotlicommon 1.0.9 h166bdaf_9
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 32567
+  timestamp: 1687884247423
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.0.9-h166bdaf_9.conda
+  sha256: d27bc2562ea3f3b2bfd777f074f1cac6bfa4a737233dad288cd87c4634a9bb3a
+  md5: 1f0a03af852a9659ed2bf08f2f1704fd
+  depends:
+  - libbrotlicommon 1.0.9 h166bdaf_9
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 265202
+  timestamp: 1687884262352
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-19_linux64_openblas.conda
+  sha256: 84fddccaf58f42b07af7fb42512bd617efcb072f17bdef27f4c1884dbd33c86a
+  md5: d12374af44575413fbbd4a217d46ea33
+  depends:
+  - libblas 3.9.0 19_linux64_openblas
+  constrains:
+  - blas * openblas
+  - liblapack 3.9.0 19_linux64_openblas
+  - liblapacke 3.9.0 19_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14458
+  timestamp: 1697484230827
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-7.87.0-h6312ad2_0.conda
+  sha256: 4e95c12244a50c8f8e9173e0bd37d6067fd753437ab636afb44ce28382a325eb
+  md5: ad07f06bd133e76e12165bc3ec2c8646
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libgcc-ng >=12
+  - libnghttp2 >=1.47.0,<2.0a0
+  - libssh2 >=1.10.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=1.1.1s,<1.1.2a
+  license: curl
+  license_family: MIT
+  size: 347431
+  timestamp: 1671621575854
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.19-hd590300_0.conda
+  sha256: 985ad27aa0ba7aad82afa88a8ede6a1aacb0aaca950d710f15d85360451e72fd
+  md5: 1635570038840ee3f9c71d22aa5b8b6d
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 67080
+  timestamp: 1694922285678
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+  sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
+  md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 123878
+  timestamp: 1597616541093
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2
+  sha256: 8c9635aa0ea28922877dc96358f9547f6a55fc7e2eb75a556b05f1725496baf9
+  md5: 6f8720dff19e17ce5d48cfe7f3d2f0a3
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 106190
+  timestamp: 1598867915000
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.10-h9b69904_4.tar.bz2
+  sha256: 18695f2fa3f19700d3f5d4f6b5fc49920685c7424b6bbbe461fa746c40996a14
+  md5: 390026683aef81db27ff1b8570ca1336
+  depends:
+  - libgcc-ng >=9.4.0
+  - openssl >=1.1.1l,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1157008
+  timestamp: 1633489356655
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+  sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+  md5: d645c6d2ac96843a2bfaccd2d62b3ac3
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 58292
+  timestamp: 1636488182923
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_2.conda
+  sha256: d361d3c87c376642b99c1fc25cddec4b9905d3d9b9203c1c545b8c8c1b04539a
+  md5: c28003b0be0494f9a7664389146716ff
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 13.2.0 h807b86a_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 771133
+  timestamp: 1695219384393
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_2.conda
+  sha256: 767d71999e5386210fe2acaf1b67073e7943c2af538efa85c101e3401e94ff62
+  md5: e75a75a6eaf6f318dae2631158c46575
+  depends:
+  - libgfortran5 13.2.0 ha4646dd_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 23722
+  timestamp: 1695219642066
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_2.conda
+  sha256: 55ecf5c46c05a98b4822a041d6e1cb196a7b0606126eb96b24131b7d2c8ca561
+  md5: 78fdab09d9138851dde2b5fe2a11019e
+  depends:
+  - libgcc-ng >=13.2.0
+  constrains:
+  - libgfortran-ng 13.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1441830
+  timestamp: 1695219403435
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_2.conda
+  sha256: e1e82348f8296abfe344162b3b5f0ddc2f504759ebeb8b337ba99beaae583b15
+  md5: e2042154faafe61969556f28bade94b9
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 421133
+  timestamp: 1695219303065
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+  sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
+  md5: ea25936bb4080d843790b586850f82b8
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 618575
+  timestamp: 1694474974816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-19_linux64_openblas.conda
+  sha256: 58f402aae605ebd0932e1cbbf855cd49dcdfa2fcb6aab790a4f6068ec5937878
+  md5: 9f100edf65436e3eabc2a51fc00b2c37
+  depends:
+  - libblas 3.9.0 19_linux64_openblas
+  constrains:
+  - blas * openblas
+  - libcblas 3.9.0 19_linux64_openblas
+  - liblapacke 3.9.0 19_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14487
+  timestamp: 1697484241613
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
+  sha256: 225cc7c3b20ac1db1bdb37fa18c95bf8aecef4388e984ab2f7540a9f4382106a
+  md5: 73301c133ded2bf71906aa2104edae8b
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 31484415
+  timestamp: 1690557554081
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.51.0-hdcd2b5c_0.conda
+  sha256: 3f76e99eacfc4ce3deac3b78d5508449efb8b72dea3e31d9f2c6db7f5cf00e75
+  md5: c42b460bae0365fb9777b1ff9d09a554
+  depends:
+  - c-ares >=1.18.1,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=1.1.1s,<1.1.2a
+  license: MIT
+  license_family: MIT
+  size: 622739
+  timestamp: 1672695694560
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+  sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+  md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  license_family: GPL
+  size: 33408
+  timestamp: 1697359010159
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.24-pthreads_h413a1c8_0.conda
+  sha256: c8e080ae4d57506238023e98869928ae93564e6407ef5b0c4d3a337e8c2b7662
+  md5: 6e4ef6ca28655124dcde9bd500e44c32
+  depends:
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  constrains:
+  - openblas >=0.3.24,<0.3.25.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5492091
+  timestamp: 1693785223074
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.39-h753d276_0.conda
+  sha256: a32b36d34e4f2490b99bddbc77d01a674d304f667f0e62c89e02c961addef462
+  md5: e1c890aebdebbfbf87e2c917187b4416
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: zlib-acknowledgement
+  size: 282599
+  timestamp: 1669075729952
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-3.20.3-h3eb15da_0.conda
+  sha256: f9a34009abbaee35f570d0e3f27a9f606e5fedd953bd7b4a6fe17febe86a15a8
+  md5: af581c55e6ff3a93af3ae710e091a80d
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2259520
+  timestamp: 1681043189741
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
+  sha256: 53da0c8b79659df7b53eebdb80783503ce72fb4b10ed6e9e05cc0e9e4207a130
+  md5: c3788462a6fbddafdb413a9f9053e58d
+  depends:
+  - libgcc-ng >=7.5.0
+  license: ISC
+  size: 374999
+  timestamp: 1605135674116
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.43.2-h2797004_0.conda
+  sha256: b30279b67fce2382a93c638625ff2b284324e2347e30bd0acab813d89289c18a
+  md5: 4b441a1ee22397d5a27dc1126b849edd
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Unlicense
+  size: 839889
+  timestamp: 1696958890942
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.10.0-haa6b8db_3.tar.bz2
+  sha256: 3c2ed83502bedf4ec8c5b972accb6ff1b6c018f72fb711cdb65cb8540d5ab89e
+  md5: 89acee135f0809a18a1f4537390aa2dd
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.12,<2.0.0a0
+  - openssl >=1.1.1q,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 239461
+  timestamp: 1660346486026
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_2.conda
+  sha256: ab22ecdc974cdbe148874ea876d9c564294d5eafa760f403ed4fd495307b4243
+  md5: 9172c297304f2a20134fc56c97fbe229
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3842773
+  timestamp: 1695219454837
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.16.0-h491838f_2.tar.bz2
+  sha256: 3a5a087dc968fc85c48eb77c2aa8913ac38de580f768f7e74de154254ea5c90a
+  md5: 9134d477d02ad9264c6ee359fa36702c
+  depends:
+  - libevent >=2.1.10,<2.1.11.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.12,<2.0.0a0
+  - openssl >=1.1.1q,<1.1.2a
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4796285
+  timestamp: 1663078273382
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-ha9c0a0a_2.conda
+  sha256: 45158f5fbee7ee3e257e6b9f51b9f1c919ed5518a94a9973fe7fa4764330473e
+  md5: 55ed21669b2015f77c180feb1dd41930
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.19,<1.26.0a0
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: HPND
+  size: 283198
+  timestamp: 1695661593314
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
+  sha256: 49082ee8d01339b225f7f8c60f32a2a2c05fe3b16f31b554b4fb2c1dea237d1c
+  md5: ede4266dc02e875fe1ea77b25dd43747
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 101070
+  timestamp: 1667316029302
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33601
+  timestamp: 1680112270483
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
+  sha256: 68764a760fa81ef35dacb067fe8ace452bbb41476536a4a147a1051df29525f0
+  md5: 30de3fd9b3b602f7473f30e684eeea8c
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 401830
+  timestamp: 1694709121323
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
+  sha256: a670902f0a3173a466c058d2ac22ca1dd0df0453d3a80e0212815c20a16b0485
+  md5: 33277193f5b92bad9fdd230eb700929c
+  depends:
+  - libgcc-ng >=12
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 384238
+  timestamp: 1682082368177
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+  sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
+  md5: f36c115f1ee199da648e0597ec2047ad
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - zlib 1.2.13 *_5
+  license: Zlib
+  license_family: Other
+  size: 61588
+  timestamp: 1686575217516
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.40.1-py38h94a1851_0.conda
+  sha256: 40c78ca3229f24a014374a4d68a439bd0f9fe8539cd85246f2bcd1994e7308cf
+  md5: 018436fcd1fcb5a8910724b58d144e07
+  depends:
+  - libgcc-ng >=12
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2496481
+  timestamp: 1687806305270
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+  sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
+  md5: 318b08df404f9c9be5712aaa5a6f0bb0
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143402
+  timestamp: 1674727076728
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py38h01eb140_1.conda
+  sha256: 3d84b787b7059039d1ef81c4a3dc78c0fba84cefff7db9bda3bf3b18a6349474
+  md5: 2dabf287937cd631e292096cc6d0867e
+  depends:
+  - libgcc-ng >=12
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23873
+  timestamp: 1695367608953
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.7.3-py38h58ed7fa_0.conda
+  sha256: 861299334d303296dfbae0a77d736a26cd3202e467fdca00c5d6f439355b13c7
+  md5: d8db25d58823182ce93233964f307a47
+  depends:
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - importlib-resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.20
+  - numpy >=1.22.4,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.8.* *_cp38
+  - tk >=8.6.12,<8.7.0a0
+  license: LicenseRef-PSF-2.0 and CC0-1.0
+  license_family: PSF
+  size: 6718528
+  timestamp: 1695076964514
+- conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.0.6-py38h7f3f72f_0.conda
+  sha256: ee03c424cf00f8d4c91d4319baefb1af8e4a75a62af313237689af6db8e140f7
+  md5: 17db5fc1bbce1f0bad1bc0aab116bb4c
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: Apache-2.0
+  license_family: Apache
+  size: 197703
+  timestamp: 1695464273612
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-hcb278e6_0.conda
+  sha256: ccf61e61d58a8a7b2d66822d5568e2dc9387883dd9b2da61e1d787ece4c4979a
+  md5: 681105bccc2a3f7f1a837d47d39c9179
+  depends:
+  - libgcc-ng >=12
+  license: X11 AND BSD-3-Clause
+  size: 880967
+  timestamp: 1686076725450
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.57.1-py38hd559b08_0.conda
+  sha256: 82ce780aca2ebe8216917fcfe1c3de3516439ea21efadd992fd3dbe710dec75e
+  md5: e2fae15289574f811da146b6e30be2d8
+  depends:
+  - importlib-metadata
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - llvmlite >=0.40.0,<0.41.0a0
+  - numpy >=1.21.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  constrains:
+  - scipy >=1.0
+  - libopenblas !=0.3.6
+  - cuda-python >=11.6
+  - cudatoolkit >=10.2
+  - tbb >=2021.6.0
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.25
+  - cuda-version >=10.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4093483
+  timestamp: 1687804924803
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.24.4-py38h59b608b_0.conda
+  sha256: 6b1fac85c497432fa5ebdd0edaa2197cc89a9fd656b2ec696c9e50e7da23663e
+  md5: 8c3e050afeeb2b32575bdb8955cc67b2
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6681715
+  timestamp: 1687808678590
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.0-h488ebb8_3.conda
+  sha256: 9fe91b67289267de68fda485975bb48f0605ac503414dc663b50d8b5f29bc82a
+  md5: 128c25b7fe6a25286a48f3a6a9b5b6f3
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 356698
+  timestamp: 1694708325417
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-1.1.1w-hd590300_0.conda
+  sha256: 4fe19885c77f0758084feb54954bd1977dfeeab7134fba0a1d9c0cfff821d6bd
+  md5: 301e70057a3bd399640bb16bbdf87995
+  depends:
+  - ca-certificates
+  - libgcc-ng >=12
+  license: OpenSSL
+  license_family: Apache
+  size: 1956010
+  timestamp: 1694461292959
+- conda: https://conda.anaconda.org/conda-forge/linux-64/orc-1.7.5-h6c59b99_0.tar.bz2
+  sha256: ffb67cea97b6284d9b5a43f55b3def14922706637f4ef176c6004ff16acc71ec
+  md5: 884b5f46b907b1f9b4a2aa60d75b4d32
+  depends:
+  - libgcc-ng >=12
+  - libprotobuf >=3.20.1,<3.21.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.12,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.9,<1.2.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1108083
+  timestamp: 1655506719633
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-1.2.5-py38h1abd341_0.tar.bz2
+  sha256: 34d9830852e3a81dda1c695bd2caff3c4e9b1eabf1bdeb5129998b243b5432cf
+  md5: b7c0ddb0b4a016268bd915d8fb55693f
+  depends:
+  - libgcc-ng >=9.3.0
+  - libstdcxx-ng >=9.3.0
+  - numpy >=1.17.5,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.7.3
+  - python_abi 3.8.* *_cp38
+  - pytz >=2017.2
+  - setuptools <60.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12648440
+  timestamp: 1624391475225
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.1.3-h32600fe_0.conda
+  sha256: 52d23e2fded05e7a19d9d7996f19ed837b46578b6e5951b8c5990cf919404ffc
+  md5: 8287aeb8462e2d4b235eff788e75919d
+  depends:
+  - gmp
+  - libzlib >=1.2.13,<2.0.0a0
+  - zlib
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 29348226
+  timestamp: 1686227552062
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.1.0-py38ha43c96d_0.conda
+  sha256: b54772bc67a0c4432872caa0f5de13e06551fc90422a921401bd8302cbc4d866
+  md5: 67ca17c651f86159a3b8ed1132d97c12
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 46537733
+  timestamp: 1697423800716
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py38h01eb140_1.conda
+  sha256: 92006eee5f889180c9d9fa7394eadba36231d3c91c3fc63ad109e8d109ccf304
+  md5: 89cb08bb523adf12fed3829558638d84
+  depends:
+  - libgcc-ng >=12
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 358746
+  timestamp: 1695367363444
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+  sha256: 67c84822f87b641d89df09758da498b2d4558d47b920fd1d3fe6d3a871e000ff
+  md5: 22dad4df6e8630e8dff2428f6f6a7036
+  depends:
+  - libgcc-ng >=7.5.0
+  license: MIT
+  license_family: MIT
+  size: 5625
+  timestamp: 1606147468727
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-5.0.0-py38h9f6a473_35_cpu.tar.bz2
+  sha256: c6ef6e71deee66c8e322accc64df3c0cd346632d33b3eb66ef6d295eca751621
+  md5: a1d9e3eefff7bd735c7d51ea4f507e3c
+  depends:
+  - arrow-cpp 5.0.0 py38h91fe7ba_35_cpu
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.16,<2.0a0
+  - numpy >=1.19.5,<2.0a0
+  - parquet-cpp 1.5.1.*
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  constrains:
+  - arrow-cpp-proc * cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 2937743
+  timestamp: 1655703303430
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.8.15-h257c98d_0_cpython.conda
+  sha256: 0648cf2b562437979168cdc0dcf26344fcd3ce2bc3c9b344e6c68163ab84ff87
+  md5: 485151f9b0c1cfb2375b6c4995ac52ba
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libnsl >=2.0.0,<2.1.0a0
+  - libsqlite >=3.40.0,<4.0a0
+  - libuuid >=2.32.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.3,<7.0a0
+  - openssl >=1.1.1s,<1.1.2a
+  - readline >=8.1.2,<9.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.8.* *_cp38
+  license: Python-2.0
+  size: 20858960
+  timestamp: 1669107668220
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-snappy-0.6.0-py38h1ddbb56_2.tar.bz2
+  sha256: 985ea7e4aed85afd2fc863c4dc1a0431ebcb5a6181f42ecf1d83e110028882fd
+  md5: 4eb8c567f5509a386c5a15b37337b46e
+  depends:
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - snappy >=1.1.8,<1.2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 31704
+  timestamp: 1649520032558
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.8-4_cp38.conda
+  sha256: 54276b9259f5c72d160c75c45c50c4e03695da56e6646518801f567fc5979030
+  md5: ea6b353536f42246cd130c7fef1285cf
+  constrains:
+  - python 3.8.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6371
+  timestamp: 1695147367061
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py38h01eb140_1.conda
+  sha256: 7741529957e3b3428af73f003f043c9983ed672c69dc4aafef848b2583c4571b
+  md5: 5f05353ae9a6c37e1b4aebc9f7834d23
+  depends:
+  - libgcc-ng >=12
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 182153
+  timestamp: 1695373618370
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-24.0.1-py38hfc09fa9_1.tar.bz2
+  sha256: 44479c3b783986f591de0e3c4db0a6cff480283022148c67db6144aa4885224b
+  md5: a0d5ef0498ced7a2afd82ee17994935e
+  depends:
+  - libgcc-ng >=12
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=12
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  size: 493668
+  timestamp: 1666828683338
+- conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2022.04.01-h27087fc_0.tar.bz2
+  sha256: a2c767f4e24daf2f68eacea1bc8abbe5ee2cd9d786846947d4aa71a944791ba7
+  md5: 7221140e556c2a65c93dbbc8675a7bea
+  depends:
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 216751
+  timestamp: 1648883899861
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+  sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
+  md5: 47d31b792659ce70f470b5c82fdfb7a4
+  depends:
+  - libgcc-ng >=12
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 281456
+  timestamp: 1679532220005
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.10.6-py38h0cc4f7c_0.conda
+  sha256: e428cf9d51a55b05c5b69e28dee60d19f6b19382596fc21802093c6e390c5f7e
+  md5: e1509df6d5aa872dde4432fcfe89747d
+  depends:
+  - libgcc-ng >=12
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: MIT
+  license_family: MIT
+  size: 992314
+  timestamp: 1697072499490
+- conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.0.10-h9b69904_0.tar.bz2
+  sha256: 75eba1f7873a734985b14b94db81dc75d1e618ab6f6938106374f314057d91fb
+  md5: 9708c3ac26c20b4c4549cbe8fef937eb
+  depends:
+  - libgcc-ng >=9.3.0
+  - openssl >=1.1.1k,<1.1.2a
+  license: Apache-2.0
+  license_family: Apache
+  size: 452368
+  timestamp: 1623272440611
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.10.1-py38h59b608b_3.conda
+  sha256: 5666133e21963c0815d150bc497d976796fbb68b79aca6d2f193827ef32b3fd8
+  md5: 2f2a57462fcfbc67dfdbb0de6f7484c2
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - numpy >=1.21.6,<1.27
+  - numpy >=1.21.6,<2.0a0
+  - pooch
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  constrains:
+  - libopenblas <0.3.26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15279053
+  timestamp: 1683901053914
+- conda: https://conda.anaconda.org/conda-forge/linux-64/setuptools-59.8.0-py38h578d9bd_1.tar.bz2
+  sha256: 655201358bbd47ff8f051f4d2a049cc53108482510c5232785e15203b23e33f5
+  md5: da023e4a9c777abc28434d7a6473dcc2
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: MIT
+  license_family: MIT
+  size: 1041224
+  timestamp: 1648692023186
+- conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
+  sha256: 02219f2382b4fe39250627dade087a4412d811936a5a445636b7260477164eac
+  md5: e6d228cd0bb74a51dd18f5bfce0b4115
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38865
+  timestamp: 1678534590321
+- conda: https://conda.anaconda.org/conda-forge/linux-64/thrift-0.19.0-py38h17151c0_1.conda
+  sha256: 87725f300399ac2324532b09cd9190f2c25ac4f08a449d34d6cc9cef2decf1af
+  md5: 5131b945346b20126836c05ff7a685a4
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - six >=1.7.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 134026
+  timestamp: 1695546225279
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-h2797004_0.conda
+  sha256: 679e944eb93fde45d0963a22598fafacbb429bb9e7ee26009ba81c4e0c435055
+  md5: 513336054f884f95d9fd925748f41ef3
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3290187
+  timestamp: 1695506262576
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.3.3-py38h01eb140_1.conda
+  sha256: e246e7668d00806ef5bdef641da602c2879aae75114aa25e3199f03569c408f2
+  md5: 660cfc2fc5bd9e3b458ad394976652cf
+  depends:
+  - libgcc-ng >=12
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: Apache-2.0
+  license_family: Apache
+  size: 629220
+  timestamp: 1695373699665
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py38h01eb140_0.conda
+  sha256: 0ca9dbb9496f740990d9c4f44733e5935bd28e583d9c94a56ace234be7f38093
+  md5: d28c162f670f8dc3a89e246573ae96c9
+  depends:
+  - libgcc-ng >=12
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: Apache-2.0
+  license_family: Apache
+  size: 373800
+  timestamp: 1695848181647
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+  sha256: 309751371d525ce50af7c87811b435c176915239fc9e132b99a25d5e1703f2d4
+  md5: 2c80dc38fface310c9bd81b17037fee5
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 14468
+  timestamp: 1684637984591
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+  sha256: 4df7c5ee11b8686d3453e7f3f4aa20ceef441262b49860733066c52cfd0e4a77
+  md5: be93aabceefa2fac576e971aef407908
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  size: 19126
+  timestamp: 1610071769228
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+  sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+  md5: 2161070d867d1b1204ea749c8eec4ef0
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1 and GPL-2.0
+  size: 418368
+  timestamp: 1660346797927
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+  sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
+  md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 89141
+  timestamp: 1641346969816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h59595ed_0.conda
+  sha256: 53bf2a18224406e9806adb3b270a2c8a028aca0c89bd40114a85d6446f5c98d1
+  md5: 8851084c192dbc56215ac4e3c9aa30fa
+  depends:
+  - libgcc-ng >=12
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=12
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 343455
+  timestamp: 1697056638125
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
+  sha256: 9887a04d7e7cb14bd2b52fa01858f05a6d7f002c890f618d9fcd864adbfecb1b
+  md5: 68c34ec6149623be41a1933ab996a209
+  depends:
+  - libgcc-ng >=12
+  - libzlib 1.2.13 hd590300_5
+  license: Zlib
+  license_family: Other
+  size: 92825
+  timestamp: 1686575231103
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
+  sha256: 607cbeb1a533be98ba96cf5cdf0ddbb101c78019f1fda063261871dad6248609
+  md5: 04b88013080254850d6c01ed54810589
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 545199
+  timestamp: 1693151163452
+- conda: https://conda.anaconda.org/conda-forge/noarch/anyio-3.7.1-pyhd8ed1ab_0.conda
+  sha256: 62637ac498bcf47783cbf4f48e9b09e4e2f5a6ad42f43ca8f632c353827b94f4
+  md5: 7b517e7a6f0790337906c055aa97ca49
+  depends:
+  - exceptiongroup
+  - idna >=2.8
+  - python >=3.7
+  - sniffio >=1.1
+  - typing_extensions
+  constrains:
+  - trio >=0.16,<0.22
+  license: MIT
+  license_family: MIT
+  size: 96707
+  timestamp: 1688651250785
+- conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
+  sha256: 64125775b2e724db5c72e431dd180495d5d509d0a2d1228a122e6af9f1b60e33
+  md5: 3c4e99d3ae4ec033d4dd99fb5220e540
+  depends:
+  - exceptiongroup
+  - idna >=2.8
+  - python >=3.8
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.22
+  license: MIT
+  license_family: MIT
+  size: 98958
+  timestamp: 1693488730301
+- conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.3-pyhd8ed1ab_0.tar.bz2
+  sha256: b209a68ac55eb9ecad7042f0d4eedef5da924699f6cdf54ac1826869cfdae742
+  md5: 54ac328d703bff191256ffa1183126d1
+  depends:
+  - python >=2.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 8095
+  timestamp: 1649077760928
+- conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+  sha256: 130766446f5507bd44df957b6b5c898a8bd98f024bb426ed6cb9ff1ad67fc677
+  md5: 3afef1f55a1366b4d3b6a0d92e2235e4
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.7
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 18602
+  timestamp: 1692818472638
+- conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+  sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
+  md5: b77d8c2313158e6e461ca0efb1c2c508
+  depends:
+  - python >=3.8
+  - python-dateutil >=2.7.0
+  - types-python-dateutil >=2.8.10
+  license: Apache-2.0
+  license_family: Apache
+  size: 100096
+  timestamp: 1696129131844
+- conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+  sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
+  md5: 5f25798dcefd8252ce5f9dc494d5f571
+  depends:
+  - python >=3.5
+  - six >=1.12.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 28922
+  timestamp: 1698341257884
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+  sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
+  md5: 3edfead7cedd1ab4400a6c588f3e75f8
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 55022
+  timestamp: 1683424195402
+- conda: https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2
+  sha256: ee62d6434090c1327a48551734e06bd10e65a64ef7f3b6e68719500dab0e42b9
+  md5: 6006a6d08a3fa99268a2681c7fb55213
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13705
+  timestamp: 1592338491389
+- conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+  sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
+  md5: 54ca2e08b3220c148a1d8329c2678e02
+  depends:
+  - python >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5950
+  timestamp: 1669158729416
+- conda: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
+  sha256: 7027bb689dd4ca4a08e3b25805de9d04239be6b31125993558f21f102a9d2700
+  md5: 6b1b907661838a75d067a22f87996b2e
+  depends:
+  - backports
+  - python >=3.6
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 11519
+  timestamp: 1687772319931
+- conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.2-pyha770c72_0.conda
+  sha256: 52d3e6bcd442537e22699cd227d8fdcfd54b708eeb8ee5b4c671a6a9b9cd74da
+  md5: a362ff7d976217f8fa78c0f1c4f59717
+  depends:
+  - python >=3.6
+  - soupsieve >=1.2
+  license: MIT
+  license_family: MIT
+  size: 115011
+  timestamp: 1680888259061
+- conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+  sha256: 845e77ef495376c5c3c328ccfd746ca0ef1978150cae8eae61a300fe7755fb08
+  md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
+  depends:
+  - packaging
+  - python >=3.6
+  - setuptools
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 131220
+  timestamp: 1696630354218
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+  sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
+  md5: 9b347a7ec10940d3f7941ff6c460b551
+  depends:
+  - cached_property >=1.5.2,<1.5.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4134
+  timestamp: 1615209571450
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+  sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+  md5: 576d629e47797577ab0f1b351297ef4a
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11065
+  timestamp: 1615209567874
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
+  sha256: db66e31866ff4250c190788769e3a8a1709237c3e9c38d7143aae95ab75fcb31
+  md5: 7f3dbc9179b4dde7da98dfb151d0ad22
+  depends:
+  - python >=3.7
+  license: ISC
+  size: 153791
+  timestamp: 1690024617757
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.1-pyhd8ed1ab_0.conda
+  sha256: a31739c49c4b1c8e0cbdec965ba152683d36ce6e23bdaefcfee99937524dabd1
+  md5: 985378f74689fccce52f158027bd9acd
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 46522
+  timestamp: 1698005510857
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+  sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
+  md5: f3ad426304898027fc619827ff428eca
+  depends:
+  - __unix
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84437
+  timestamp: 1692311973840
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
+  sha256: 90236b113b9a20041736e80b80ee965167f9aac0468315c55e2bad902d673fb0
+  md5: 3549ecbceb6cd77b91a105511b7d0786
+  depends:
+  - __win
+  - colorama
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 85051
+  timestamp: 1692312207348
+- conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+  sha256: 0dfbc1ffa72e7a0882f486c9b1e4e9cccb68cf5c576fe53a89d076c9f1d43754
+  md5: 753d29fe41bb881e4b9c004f0abf973f
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24746
+  timestamp: 1697464875382
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+  sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+  md5: 3faab06a954c2a04039983f2c4a50d99
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25170
+  timestamp: 1666700778190
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 4e68730cc38236a736c8f1c6837c6460807cc0f0a5fd2166b3359d481e6f129f
+  md5: 1e424f22b3e2713068fe12d57f2dec5b
+  depends:
+  - pyct >=0.4.4
+  - python >=2.7
+  license: CC-BY-4.0
+  size: 1635349
+  timestamp: 1664843356249
+- conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
+  sha256: 11057745946a95ee7cc4c98900a60c7362266a4cb28bc97d96cd88e3056eb701
+  md5: c8eaca39e2b6abae1fc96acc929ae939
+  depends:
+  - python >=3.6
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11682
+  timestamp: 1691045097208
+- conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+  sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
+  md5: 5cd86562580f274031ede6aa6aa24441
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13458
+  timestamp: 1696677888423
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-2021.8.0-pyhd8ed1ab_0.tar.bz2
+  sha256: f59fd63cb843e050d8b06e98e92b93a815a437391135bdd5878b1d987e777f01
+  md5: 26546282691614d813b24d2fb87fe89f
+  depends:
+  - bokeh >=1.0.0,!=2.0.0,<3.0.0a0
+  - cytoolz >=0.8.2
+  - dask-core 2021.8.0.*
+  - distributed 2021.8.0.*
+  - numpy >=1.18
+  - pandas >=1.0,<2.0a0
+  - python >=3.7
+  constrains:
+  - openssl !=1.1.1e
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4398
+  timestamp: 1628912123369
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2021.8.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 615632cb798125b9622bfe404155a02c534ca01b9561f3e70f2b337e09f43e25
+  md5: ec59ae02cc1a6f58140a42ae2e316ecc
+  depends:
+  - cloudpickle >=1.1.1
+  - fsspec >=0.6.0
+  - packaging >=20.0
+  - partd >=0.3.10
+  - python >=3.7
+  - pyyaml
+  - toolz >=0.8.2
+  - setuptools <60.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 775349
+  timestamp: 1628896565953
+- conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.14.4-pyh1a96a4e_0.conda
+  sha256: 4704cfacd35fdf61511fa5bf2542ac8dca6213307b815a3f43feff4d239be1a6
+  md5: 014241632f54724b814b4a2424864305
+  depends:
+  - colorcet >=0.9.0
+  - dask-core
+  - datashape >=0.5.1
+  - numba >=0.51.0
+  - pandas >=0.24.1
+  - param >=1.6.1,<2.0.0a0
+  - pillow >=3.1.1
+  - pyct >=0.4.5
+  - python >=3.7
+  - requests
+  - scipy
+  - xarray >=0.9.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17165373
+  timestamp: 1675374971237
+- conda: https://conda.anaconda.org/conda-forge/noarch/datashape-0.5.4-py_1.tar.bz2
+  sha256: a9e7312763eb6d9a20d8f12175780e33402d86009d9640b69eee8b4a1e4185fe
+  md5: 50ddfce434ea596fc4497085f403a9d5
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7
+  - python
+  - python-dateutil
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 50149
+  timestamp: 1551744455794
+- conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+  md5: 43afe5ab04e35e17ba28649471dd7364
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 12072
+  timestamp: 1641555714315
+- conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
+  md5: 961b3a227b437d82ad7054484cfa71b2
+  depends:
+  - python >=3.6
+  license: PSF-2.0
+  license_family: PSF
+  size: 24062
+  timestamp: 1615232388757
+- conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
+  md5: 3cf04868fee0a029769bd41f4b2fbf2d
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 9199
+  timestamp: 1643888357950
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+  sha256: c28f715e049fe0f09785660bcbffa175ffb438720e5bc5a60d56d4b08364b315
+  md5: e6518222753f519e911e83136d2158d9
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19262
+  timestamp: 1692026296517
+- conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+  sha256: c738804ab1e6376f8ea63372229a04c8d658dc90fd5a218c6273a2eaf02f4057
+  md5: e16be50e378d8a4533b989035b196ab8
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 27689
+  timestamp: 1698580072627
+- conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 6cfd1f9bcd2358a69fb571f4b3af049b630d52647d906822dbedac03e84e4f63
+  md5: 642d35437078749ef23a5dca2c9bb1f3
+  depends:
+  - cached-property >=1.3.0
+  - python >=2.7,<4
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 14395
+  timestamp: 1638810388635
+- conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.10.0-pyhca7485f_0.conda
+  sha256: 1bbdfadb93cc768252fd207dca406cde928f9a81ff985ea1760b6539c55923e6
+  md5: 5b86cf1ceaaa9be2ec4627377e538db1
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 124907
+  timestamp: 1697919506326
+- conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.14.5-pyhd8ed1ab_0.tar.bz2
+  sha256: 748cd16cf7d1d385065fbd14567f3b96b8de1e482fb422e8661d042cf322355a
+  md5: 7b4a6967601685a6fcadc3d493b0d16b
+  depends:
+  - bokeh >=1.1.0
+  - colorcet
+  - matplotlib-base >=2.2
+  - numpy >=1.0
+  - pandas >=0.20.0
+  - panel >=0.8.0
+  - param >=1.9.3,<2.0
+  - python >=2.7
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3626885
+  timestamp: 1626703225743
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 9887c35c374ec1847f167292d3fde023cb4c994a4ceeec283072b95440131f09
+  md5: 34272b248891bddccc64479f9a7fffed
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 56742
+  timestamp: 1663625484114
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
+  sha256: 2797ed927d65324309b6c630190d917b9f2111e0c217b721f80429aeb57f9fcf
+  md5: 4e9f59a060c3be52bc4ddc46ee9b6946
+  depends:
+  - python >=3.8
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25910
+  timestamp: 1688754651944
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.1.0-pyhd8ed1ab_0.conda
+  sha256: e1f0e12343a916c887648900680f93591d8a1db7c74b2d3f583f8b93855b052a
+  md5: 6a62c2cc25376a0d050b3d1d221c3ee9
+  depends:
+  - importlib_resources >=6.1.0,<6.1.1.0a0
+  - python >=3.7
+  license: Apache-2.0
+  license_family: APACHE
+  size: 9694
+  timestamp: 1695414942926
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.0-pyhd8ed1ab_0.conda
+  sha256: adab6da633ec3b642f036ab5c1196c3e2db0e8db57fb0c7fc9a8e06e29fa9bdc
+  md5: 48b0d98e0c0ec810d3ccc2a0926c8c0e
+  depends:
+  - python >=3.8
+  - zipp >=3.1.0
+  constrains:
+  - importlib-resources >=6.1.0,<6.1.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 30024
+  timestamp: 1695414932459
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.26.0-pyh3cd1d5f_0.conda
+  sha256: be9927d47fe23cc4d2a09d252e37e1e56ffb137767d2c0577ed882ead16f75fa
+  md5: 3c6e2148d30e6a762d8327a433ebfb5a
+  depends:
+  - __osx
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116536
+  timestamp: 1698244546989
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.26.0-pyha63f2e9_0.conda
+  sha256: 7208f5ae35c321d03c71e4072c959c60f877d1b9cc2fb32d805972b54123fb95
+  md5: 10e1de12f78f0fedb82ff723f602b5c5
+  depends:
+  - __win
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116868
+  timestamp: 1698244441309
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.26.0-pyhf8b6a83_0.conda
+  sha256: 9e647454f7572101657a07820ebed294df9a6a527b041cd5e4dd98b8aa3db625
+  md5: 2307f71f5f0896d4b91b93e6b468abff
+  depends:
+  - __linux
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116210
+  timestamp: 1698244196564
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.12.2-pyh08f2357_0.conda
+  sha256: ceae9864850ccc37ad8e60dde2f99241a9f4f3096afb5b4f9d8c8885b2f5525a
+  md5: f289f9dc26526b8bd9f5845486f53a4d
+  depends:
+  - __win
+  - backcall
+  - colorama
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt_toolkit >=3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.8
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 583842
+  timestamp: 1683289477064
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.12.2-pyh41d4057_0.conda
+  sha256: 40ef6ecd03981587184ca1231165f1539eeea021622eb7b08727b7e00a3094c2
+  md5: acebfd89278ecac2a67b60b657e00d5c
+  depends:
+  - __linux
+  - backcall
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt_toolkit >=3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.8
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 582476
+  timestamp: 1683289168083
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.12.2-pyhd1c38e8_0.conda
+  sha256: 4187d131e7487d0f2867e383df9b2c4a7e2bc90ee7ad5906913372f023af2ea5
+  md5: acc618532cbc899f5721cc96407b16cc
+  depends:
+  - __osx
+  - appnope
+  - backcall
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt_toolkit >=3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.8
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 584567
+  timestamp: 1683289447938
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-py_1.tar.bz2
+  sha256: 0fafbc60209f1d8c0b89a2f79f3ff0f7bc45589a23da1d2e5cc55bcca906707b
+  md5: 5071c982548b3a20caf70462f04f5287
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 21562
+  timestamp: 1530963305778
+- conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
+  md5: 4cb68948e0b8429534380243d063a27a
+  depends:
+  - arrow >=0.15.0
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 17189
+  timestamp: 1638811664194
+- conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+  sha256: 362f0936ef37dfd1eaa860190e42a6ebf8faa094eaa3be6aa4d9ace95f40047a
+  md5: 81a3be0b2023e1ea8555781f0ad904a2
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 841312
+  timestamp: 1696326218364
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+  sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
+  md5: c8490ed5c70966d232fdd389d0dbed37
+  depends:
+  - markupsafe >=2.0
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101443
+  timestamp: 1654302514195
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.1-pyhd8ed1ab_0.conda
+  sha256: b4e50e1d53b984a467e79b7ba69cc408d14e3a2002cad4eaf7798e20268cff2d
+  md5: 78aff5d2af74e6537c1ca73017f01f4f
+  depends:
+  - attrs >=22.2.0
+  - importlib_resources >=1.4.0
+  - jsonschema-specifications >=2023.03.6
+  - pkgutil-resolve-name >=1.3.10
+  - python >=3.8
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 71078
+  timestamp: 1695229168542
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
+  sha256: 7b0061e106674f27cc718f79a095e90a5667a3635ec6626dd23b3be0fd2bfbdc
+  md5: 7c27ea1bdbe520bb830dcadd59f55cbf
+  depends:
+  - importlib_resources >=1.4.0
+  - python >=3.8
+  - referencing >=0.25.0
+  license: MIT
+  license_family: MIT
+  size: 15296
+  timestamp: 1689701341221
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.1-pyhd8ed1ab_0.conda
+  sha256: af65a8783a89c03ac8437a1d95ee5ac2e50e92d3af231cec515292fe296aff8e
+  md5: daca0665e6fe8a376e48b9f0b5865326
+  depends:
+  - fqdn
+  - idna
+  - isoduration
+  - jsonpointer >1.13
+  - jsonschema >=4.19.1,<4.19.2.0a0
+  - python
+  - rfc3339-validator
+  - rfc3986-validator >0.1.0
+  - uri-template
+  - webcolors >=1.11
+  license: MIT
+  license_family: MIT
+  size: 7367
+  timestamp: 1695229193334
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.3.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 181b36306cf9f389785c63199a14df6154583b605c86ab6c81f36c2fe57b4c9b
+  md5: dad80938cdccc5c274e954dda56b6eb5
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.7
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92855
+  timestamp: 1654730948538
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+  sha256: 38e67f3e0d631f4aeeab4bbd4062dcb6f4ae9dc35803053c995d02912a999b65
+  md5: 5cbf9a31a19d4ef9103adb7d71fd45fd
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.7
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99449
+  timestamp: 1673616104031
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.8.0-pyhd8ed1ab_0.conda
+  sha256: 44742f7b6453774fbbdf7cec20282f88c7362707990790116fec23270b81b447
+  md5: 04272d87d3e06c2e26af5e2d4b0e0ad8
+  depends:
+  - jsonschema-with-format-nongpl >=4.18.0
+  - python >=3.8
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21359
+  timestamp: 1697461797603
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-1.24.0-pyhd8ed1ab_0.conda
+  sha256: 061c03642e2ecb81017b914c557755993ff71c6c7a96d4a938fd0c7b761e08da
+  md5: 7f0d2ec2d4954188ff23503f39823409
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbconvert-core >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.7
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 243746
+  timestamp: 1693923237659
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.9.1-pyhd8ed1ab_0.conda
+  sha256: bb9a60ff41085031a28204add4e6120990437cfad341db297519f0a0f0df8e18
+  md5: 8e0cfa69e5b0062b829a9dbb14645def
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert-core >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.8
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 317157
+  timestamp: 1698244231289
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
+  sha256: 9f4c5fef9beef9fceed628db7a10b888f3308b37ae257ad3d50046088317ebf1
+  md5: 7c0965e1d4a0ee1529e8eaa03a78a5b3
+  depends:
+  - python >=3.8
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18974
+  timestamp: 1673491600853
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0.tar.bz2
+  sha256: 08453e09d5a6bbaeeca839553a5dfd7a377a97550efab96019c334a8042f54f5
+  md5: 243f63592c8e449f40cd42eb5cf32f40
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17410
+  timestamp: 1649936689608
+- conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
+  md5: 91e27ef3d05cc772ce627e51cff111c4
+  depends:
+  - python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 8250
+  timestamp: 1650660473123
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.5-pyhd8ed1ab_0.conda
+  sha256: 28833c2b003d92e791d00041784a81122160888e5dca8cd594260b9363b30a0c
+  md5: 7037842bf6dfe0fdb90583b3391d21e0
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 76350
+  timestamp: 1696627878942
+- conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+  sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
+  md5: b21613793fcc81d944c76c9f2864a7de
+  depends:
+  - python >=3.6
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12273
+  timestamp: 1660814913405
+- conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.1-pyhd8ed1ab_0.conda
+  sha256: 0b4558d3afb64e23b66f5279b704de76ebeb6b4eebbf913d65fbd4ba7d9acc2f
+  md5: 1dad8397c94e4de97a70de552a7dcf49
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 66169
+  timestamp: 1692116828443
+- conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+  sha256: 6d5839f75780475ad4dffe018026d493e26076f95862550a48424b4d7f6689d8
+  md5: 1073dc92c8f247d94ac14dd79ca0bbec
+  depends:
+  - python
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 12299
+  timestamp: 1534825527617
+- conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+  sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
+  md5: 2ba8498c1018c1e9c61eb99b973dfe19
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12452
+  timestamp: 1600387789153
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.0.0-pyhb4ecaf3_1.conda
+  sha256: fc2b2e606ccbd0aaa2cdecdd33fc39e2c4bd7b5b96a64b89b3e6ad9ce20eec2f
+  md5: a0be31e9bd84d6eae87cdbf74c56b90b
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - prometheus_client
+  - python >=3.7
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5939112
+  timestamp: 1683202466763
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
+  sha256: 4ebd237cdf4bfa5226f92d2ae78fab8dba27696909391884dc6594ca6f9df5ff
+  md5: e78da91cf428faaf05701ce8cc8f2f9b
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.8
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64852
+  timestamp: 1684791049212
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.9.2-pyhd8ed1ab_0.conda
+  sha256: d7402466864e0b76d26be95235dd68dae5814bd6d25b8d5827e368b9f952961f
+  md5: 16ccaddfcfa0a1a606a9ecf6a52d6c11
+  depends:
+  - nbconvert-core 7.9.2 pyhd8ed1ab_0
+  - nbconvert-pandoc 7.9.2 pyhd8ed1ab_0
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8355
+  timestamp: 1696472965850
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.9.2-pyhd8ed1ab_0.conda
+  sha256: 2c85cf290cffb72b1fe7d24c22ad6bf89873bf0f562c9c51907dfb6c00f2d4dd
+  md5: 01e4314c780ca73759c694ce3ece281f
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<3.1
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.8
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - nbconvert =7.9.2=*_0
+  - pandoc >=2.14.2,<4.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 187699
+  timestamp: 1696472907887
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.9.2-pyhd8ed1ab_0.conda
+  sha256: 30e0a60a81fa70a10ba4cf1f9a2585f19bfe54c88bb53f0367aaf67a5c56bf37
+  md5: 1ad46253f2eb46fb8c9b2c22b7ca012f
+  depends:
+  - nbconvert-core 7.9.2 pyhd8ed1ab_0
+  - pandoc
+  - python >=3.8
+  size: 7391
+  timestamp: 1696472927698
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
+  sha256: fc82c5a9116820757b03ffb836b36f0f50e4cd390018024dbadb0ee0217f6992
+  md5: 61ba076de6530d9301a0053b02f093d2
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.8
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100446
+  timestamp: 1690815009867
+- conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.8-pyhd8ed1ab_0.conda
+  sha256: d7b795b4e754136841c6da3f9fa1a0f7ec37bc7167e7dd68c5b45e657133e008
+  md5: a4f0e4519bc50eee4f53f689be9607f7
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11630
+  timestamp: 1697083896431
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.6-pyha770c72_0.conda
+  sha256: fe8a12a311f2a9e20209d5aa8336ed638a4004b5b2da3cc2011b1c986356a590
+  md5: 2e2422cf19f555ef3ddbbeaf2eac7545
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert-core >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.7
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 306657
+  timestamp: 1695225801726
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
+  sha256: f028d7ad1f2175cde307db08b60d07e371b9d6f035cfae6c81ea94b4c408c538
+  md5: 67e0fe74c156267d9159e9133df7fd37
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16783
+  timestamp: 1682360712235
+- conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
+  sha256: 29db8c3b521d261bf71897ba3cfbebc81cd61e581b30fcb984b5a713f02fe1ff
+  md5: 4625b7b01d7f4ac9c96300a5515acfaa
+  depends:
+  - python >=3.6
+  - typing_utils
+  license: Apache-2.0
+  license_family: APACHE
+  size: 29976
+  timestamp: 1691338962381
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+  sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
+  md5: 79002079284aa895f883c6b7f3f88fd6
+  depends:
+  - python >=3.7
+  license: Apache-2.0
+  license_family: APACHE
+  size: 49452
+  timestamp: 1696202521121
+- conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
+  md5: 457c2c8c08e54905d6954e79cb5b5db9
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11627
+  timestamp: 1631603397334
+- conda: https://conda.anaconda.org/conda-forge/noarch/panel-0.12.1-pyhd8ed1ab_0.tar.bz2
+  sha256: ffcdadf983b036f9ac42ce213d33cbadf7403bf004783295111f7de8d27789f1
+  md5: 6d444294ae8004c030f87d0d9abf9e23
+  depends:
+  - bleach
+  - bokeh >=2.3,<2.4
+  - markdown
+  - param >=1.10.0,<2.0.0a0
+  - pyct >=0.4.4
+  - python >=3
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10343874
+  timestamp: 1628860429290
+- conda: https://conda.anaconda.org/conda-forge/noarch/param-1.13.0-pyh1a96a4e_0.conda
+  sha256: 924dee0430ef46af7b28841d49b503de6a8969af1c7b06897a4cff26d429f20e
+  md5: 158eda83fd21a14b8c483c0d1d102397
+  depends:
+  - python >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 79952
+  timestamp: 1678790904486
+- conda: https://conda.anaconda.org/conda-forge/noarch/parquet-cpp-1.5.1-2.tar.bz2
+  sha256: 15e50657515b791734ba045da5135377404ca37c518b2066b9c6451c65cd732e
+  md5: 79a5f78c42817594ae016a7896521a97
+  depends:
+  - arrow-cpp >=0.11.0
+  license: Apache 2.0
+  size: 3118
+  timestamp: 1541734907649
+- conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+  sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
+  md5: 17a565a0c3899244e938cdf417e7b094
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 71048
+  timestamp: 1638335054552
+- conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.1-pyhd8ed1ab_0.conda
+  sha256: b248238da2bb9dfe98e680af911dc7013af86095e3ec8baf08905555632d34c7
+  md5: acf4b7c0bcd5fa3b0e05801c4d2accd6
+  depends:
+  - locket
+  - python >=3.7
+  - toolz
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20743
+  timestamp: 1695667673391
+- conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
+  sha256: 07706c0417ead94f359ca7278f65452d3c396448777aba1da6a11fc351bdca9a
+  md5: 330448ce4403cc74990ac07c555942a1
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  size: 48780
+  timestamp: 1667297617062
+- conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+  sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
+  md5: 415f0ebb6198cc2801c73438a9fb5761
+  depends:
+  - python >=3
+  license: MIT
+  license_family: MIT
+  size: 9332
+  timestamp: 1602536313357
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
+  sha256: 435829a03e1c6009f013f29bb83de8b876c388820bf8cf69a7baeec25f6a3563
+  md5: 2400c0b86889f43aa52067161e1fb108
+  depends:
+  - python >=3.7
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 1398838
+  timestamp: 1697896918388
+- conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+  sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
+  md5: 405678b942f2481cecdb3e010f4925d9
+  depends:
+  - python >=3.6
+  license: MIT AND PSF-2.0
+  size: 10778
+  timestamp: 1694617398467
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+  sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
+  md5: 8f567c0a74aa44cf732f15773b4083b0
+  depends:
+  - python >=3.7
+  - typing-extensions >=4.6.3
+  license: MIT
+  license_family: MIT
+  size: 19985
+  timestamp: 1696272419779
+- conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.0-pyhd8ed1ab_0.conda
+  sha256: 51b02987370bbff28dbf782063c23e3b264aa34173b344454203cd691946e077
+  md5: 134b2b57b7865d2316a7cce1915a51ed
+  depends:
+  - packaging >=20.0
+  - platformdirs >=2.5.0
+  - python >=3.7
+  - requests >=2.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 52378
+  timestamp: 1698245743670
+- conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.17.1-pyhd8ed1ab_0.conda
+  sha256: a149184fde856dba7968fc50ca89dbb07ebe84abd710d4076e2fada1b9399231
+  md5: 02153b6b760bbec00cfe9e4c97993d06
+  depends:
+  - python >=3.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 53376
+  timestamp: 1689032576798
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
+  sha256: 10e7fdc75d4b85633be6b12a70b857053987127a808caa0f88b2cba4b3ce6359
+  md5: a4986c6bb5b0d05a38855b0880a5f425
+  depends:
+  - python >=3.7
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.39
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269068
+  timestamp: 1688566090973
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
+  sha256: 89f7fecc7355181dbc2ab851e668a2fce6aa4830b336a34c93b59bda93206270
+  md5: 4bbbe67d5df19db30f04b8e344dc9976
+  depends:
+  - prompt-toolkit >=3.0.39,<3.0.40.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6731
+  timestamp: 1688566099039
+- conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+  sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+  md5: 359eeb6536da0e687af562ed265ec263
+  depends:
+  - python
+  license: ISC
+  size: 16546
+  timestamp: 1609419417991
+- conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+  sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
+  md5: 6784285c7e55cb7212efabc79e4c2883
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14551
+  timestamp: 1642876055775
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+  sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
+  md5: 076becd9e05608f8dc72757d5f3a91ff
+  depends:
+  - python ==2.7.*|>=3.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102747
+  timestamp: 1636257201998
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.4.6-py_0.tar.bz2
+  sha256: 50af51619db6a35c36e65e8f50c83c722c3358f1f4b5527e87799b8f9935ace0
+  md5: 42d91c89bc3993ec88681cffd3c0e326
+  depends:
+  - pyct-core 0.4.6.*
+  - python
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2652
+  timestamp: 1545265022341
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyct-core-0.4.6-py_0.tar.bz2
+  sha256: 8abc24dcf2782feca867974ba2aa0c9aaeae0966dad3f54507b39da30123d481
+  md5: 55ec526f95e0959de3f68bc6289a20da
+  depends:
+  - param >=1.7.0
+  - python
+  constrains:
+  - pyct 0.4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13725
+  timestamp: 1541164340776
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
+  sha256: 3f0f0fadc6084960ec8cc00a32a03529c562ffea3b527eb73b1653183daad389
+  md5: 40e5cb18165466773619e5c963f00a7b
+  depends:
+  - python >=3.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 853439
+  timestamp: 1691408777841
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+  sha256: 4a1332d634b6c2501a973655d68f08c9c42c0bd509c349239127b10572b8354b
+  md5: 176f7d56f0cfe9008bdf1bccd7de02fb
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 89521
+  timestamp: 1690737983548
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
+  sha256: b3a612bc887f3dd0fb7c4199ad8e342bd148cf69a9b74fd9468a18cf2bef07b7
+  md5: 56cd9fe388baac0e90c7149cfac95b60
+  depends:
+  - __win
+  - python >=3.8
+  - win_inet_pton
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19348
+  timestamp: 1661605138291
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+  sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+  md5: 2a7de29fb590ca14b5243c4c812c8025
+  depends:
+  - __unix
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18981
+  timestamp: 1661604969727
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+  sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
+  md5: dd999d1cc9f79e67dbb855c8924c7984
+  depends:
+  - python >=3.6
+  - six >=1.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 245987
+  timestamp: 1626286448716
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.1-pyhd8ed1ab_0.conda
+  sha256: 3fb1af1ac7525072c46e111bc4e96ddf971f792ab049ca3aa25dbebbaffb6f7d
+  md5: 305141cff54af2f90e089d868fffce28
+  depends:
+  - python >=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 226030
+  timestamp: 1696171963080
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+  sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
+  md5: a61bf9ec79426938ff785eb69dbb1960
+  depends:
+  - python >=3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13383
+  timestamp: 1677079727691
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
+  sha256: 6b680e63d69aaf087cd43ca765a23838723ef59b0a328799e6363eb13f52c49e
+  md5: c93346b446cd08c169d843ae5fc0da97
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 187454
+  timestamp: 1693930444432
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.0-pyhd8ed1ab_0.conda
+  sha256: 479ef43683cdcbf414d9454309a169fe6c6a6373fc43945034e02a7e5a7b8f15
+  md5: 6a4c07fcb5e3f2fb06eca2f59d632e9b
+  depends:
+  - param
+  - python >=3.6
+  constrains:
+  - jupyterlab >=4.0,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 47588
+  timestamp: 1692264873960
+- conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
+  sha256: a6768fabc12f1eed87fec68c5c65439e908655cded1e458d70a164abbce13287
+  md5: a33161b983172ba6ef69d5fc850650cd
+  depends:
+  - attrs >=22.2.0
+  - python >=3.8
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 38061
+  timestamp: 1691337409918
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+  sha256: 9f629d6fd3c8ac5f2a198639fe7af87c4db2ac9235279164bfe0fcb49d8c4bad
+  md5: a30144e4156cdbb236f99ebb49828f8b
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.7
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 56690
+  timestamp: 1684774408600
+- conda: https://conda.anaconda.org/conda-forge/noarch/retrying-1.3.3-py_2.tar.bz2
+  sha256: ef407b88c45171f41eadcbbcfd41243cb137fe7438fc18f4cd08181c522664cf
+  md5: a11f356d6f93b74b4a84e9501afd48b4
+  depends:
+  - python
+  - six >=1.7.0
+  license: Apache 2.0
+  license_family: Apache
+  size: 11390
+  timestamp: 1531740474041
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
+  md5: fed45fc5ea0813240707998abe49f520
+  depends:
+  - python >=3.5
+  - six
+  license: MIT
+  license_family: MIT
+  size: 8064
+  timestamp: 1638811838081
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+  sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
+  md5: 912a71cc01012ee38e6b90ddd561e36f
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 7818
+  timestamp: 1598024297745
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh08f2357_0.conda
+  sha256: 55208c6b48d68dc9ad2e2cf81ab9dc6b8a1d607e67acf9115bdc7794accc84bc
+  md5: c00d32dfa733d381b6a1908d0d67e0d7
+  depends:
+  - __win
+  - python >=3.6
+  - pywin32
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23279
+  timestamp: 1682601755260
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh41d4057_0.conda
+  sha256: e74d3faf51a6cc429898da0209d95b209270160f3edbf2f6d8b61a99428301cd
+  md5: ada5a17adcd10be4fc7e37e4166ba0e2
+  depends:
+  - __linux
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22821
+  timestamp: 1682601391911
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyhd1c38e8_0.conda
+  sha256: dca4022bae47618ed738ab7d45ead5202d174b741cfb98e4484acdc6e76da32a
+  md5: 2657c3de5371c571aef6678afb4aaadd
+  depends:
+  - __osx
+  - pyobjc-framework-cocoa
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23021
+  timestamp: 1682601619389
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+  sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
+  md5: e5f25f8dbc060e9a8d912e432202afc2
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 14259
+  timestamp: 1620240338595
+- conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
+  sha256: a3fd30754c20ddb28b777db38345ea00d958f46701f0decd6291a81c0f4eee78
+  md5: dd6cbc539e74cb1f430efbd4575b9303
+  depends:
+  - python >=3.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 14358
+  timestamp: 1662051357638
+- conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
+  md5: 6d6552722448103793743dabfbda532d
+  depends:
+  - python >=2.7
+  license: Apache-2.0
+  license_family: APACHE
+  size: 26314
+  timestamp: 1621217159824
+- conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+  sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
+  md5: 3f144b2c34f8cb5a9abd9ed23a39c561
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 36754
+  timestamp: 1693929424267
+- conda: https://conda.anaconda.org/conda-forge/noarch/spatialpandas-0.4.3-pyhd8ed1ab_0.tar.bz2
+  sha256: a80c6d87b9457155ae47e5439bdeca4a81b9ac0dc71da4aef8ea0cc99537e2da
+  md5: 152d2f89de986fc90dc872c9f1e54a4f
+  depends:
+  - dask >=2.0
+  - fsspec
+  - numba
+  - numpy
+  - pandas >=0.25
+  - param
+  - pyarrow >=1.0
+  - python >=3.6
+  - python-snappy
+  - retrying
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 56731
+  timestamp: 1628862976691
+- conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+  sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
+  md5: e7df0fdd404616638df5ece6e69ba7af
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 26205
+  timestamp: 1669632203115
+- conda: https://conda.anaconda.org/conda-forge/noarch/tblib-2.0.0-pyhd8ed1ab_0.conda
+  sha256: 25557d772df1572e48e4c678d5825ace6411d7b6773f2d7ad4e06111bce12031
+  md5: f5580336fe091d46f9a2ea97da044550
+  depends:
+  - python >=3.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16575
+  timestamp: 1694702546560
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.0-pyh08f2357_0.tar.bz2
+  sha256: 5c8fcf31430e0f312bc65ab5aa5b893fcc250820c023b02ff3fd188ae13199a5
+  md5: 0152a609d5748ed9887d195b1e61a6c9
+  depends:
+  - __win
+  - python >=3.7
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 19530
+  timestamp: 1666708102607
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyh41d4057_0.conda
+  sha256: bce252eb53330a8ba9617caa7a1dc75ce602c8808cf547a8f4d48285901f47c3
+  md5: 3788984d535770cad699efaeb6cb3037
+  depends:
+  - __linux
+  - ptyprocess
+  - python >=3.7
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 20787
+  timestamp: 1670253786972
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyhd1c38e8_0.conda
+  sha256: a2f8382ab390c74af592cc3566dc22e2ed81e5ac69c5b6417d1b7c22e63927bc
+  md5: 046120b71d8896cb7faef78bfdbfee1e
+  depends:
+  - __osx
+  - ptyprocess
+  - python >=3.7
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 20347
+  timestamp: 1670254383751
+- conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+  sha256: f0db1a2298a5e10e30f4b947566c7229442834702f549dded40a73ecdea7502d
+  md5: 7234c9eefff659501cd2fe0d2ede4d48
+  depends:
+  - python >=3.5
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23235
+  timestamp: 1666100385187
+- conda: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 90229da7665175b0185183ab7b53f50af487c7f9b0f47cf09c184cbc139fd24b
+  md5: 92facfec94bc02d6ccf42e7173831a36
+  depends:
+  - python >=3.5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49136
+  timestamp: 1657485654230
+- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
+  sha256: b61c9222af05e8c5ff27e4a4d2eb81870c21ffd7478346be3ef644b7a3759cc4
+  md5: 03c97908b976498dcae97eb4e4f3149c
+  depends:
+  - colorama
+  - python >=3.7
+  license: MPL-2.0 or MIT
+  size: 89449
+  timestamp: 1691671387674
+- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.12.0-pyhd8ed1ab_0.conda
+  sha256: cd0709a388063aa4024fa9c721b91cac982983435ab12bf564871c27ef983e13
+  md5: 3ecde21191a20e0e4ab5a4d69aaaa22c
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 108826
+  timestamp: 1698232210168
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.14-pyhd8ed1ab_0.conda
+  sha256: 7b0129c72d371fa7a06ed5dd1d701844c20d03bb4641a38a88a982b347d087e2
+  md5: 4df15c51a543e806d439490b862be1c6
+  depends:
+  - python >=3.6
+  license: Apache-2.0 AND MIT
+  size: 21474
+  timestamp: 1689883066161
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+  sha256: d6e1dddd0c372218ef15912383d351ac8c73465cbf16238017f0269813cafe2d
+  md5: 384462e63262a527bda564fa2d9126c0
+  depends:
+  - typing_extensions 4.8.0 pyha770c72_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 10104
+  timestamp: 1695040958008
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+  sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
+  md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
+  depends:
+  - python >=3.8
+  license: PSF-2.0
+  license_family: PSF
+  size: 35108
+  timestamp: 1695040948828
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 9e3758b620397f56fb709f796969de436d63b7117897159619b87938e1f78739
+  md5: eb67e3cace64c66233e2d35949e20f92
+  depends:
+  - python >=3.6.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 13829
+  timestamp: 1622899345711
+- conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+  sha256: b76904b53721dc88a46352324c79d2b077c2f74a9f7208ad2c4249892669ae94
+  md5: 0944dc65cb4a9b5b68522c3bb585d41c
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 23999
+  timestamp: 1688655976471
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.7-pyhd8ed1ab_0.conda
+  sha256: 9fe14735dde74278c6f1710cbe883d5710fc98501a96031dec6849a8d8a1bb11
+  md5: 270e71c14d37074b1d066ee21cf0c4a6
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 98507
+  timestamp: 1697720586316
+- conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.8-pyhd8ed1ab_0.conda
+  sha256: e3b6d2041b4d175a1437dccc71b4ef2e53111dfcc64b219fef4bed379e6ef236
+  md5: 367386d2575a0e62412448eda1012efd
+  depends:
+  - backports.functools_lru_cache
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 30291
+  timestamp: 1696255331126
+- conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
+  sha256: 6e097d5fe92849ad3af2c2a313771ad2fbf1cadd4dc4afd552303b2bf3f85211
+  md5: 166212fe82dad8735550030488a01d03
+  depends:
+  - python >=3.5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18186
+  timestamp: 1679900907305
+- conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+  sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
+  md5: daf5160ff9cde3a468556965329085b9
+  depends:
+  - python >=2.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15600
+  timestamp: 1694681458271
+- conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.4-pyhd8ed1ab_0.conda
+  sha256: df45b89862edcd7cd5180ec7b8c0c0ca9fb4d3f7d49ddafccdc76afcf50d8da6
+  md5: bdb77b28cf16deac0eef431a068320e8
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: APACHE
+  size: 45866
+  timestamp: 1696770282111
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.2-pyhd8ed1ab_0.conda
+  sha256: 21bcec5373b04d739ab65252b5532b04a08d229865ebb24b5b94902d6d0a77b0
+  md5: 1ccd092478b3e0ee10d7a891adbf8a4f
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 57488
+  timestamp: 1692700760369
+- conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyhd8ed1ab_6.tar.bz2
+  sha256: a11ae693a0645bf6c7b8a47bac030be9c0967d0b1924537b9ff7458e832c0511
+  md5: 30878ecc4bd36e8deeea1e3c151b2e0b
+  depends:
+  - __win
+  - python >=3.6
+  license: PUBLIC-DOMAIN
+  size: 8191
+  timestamp: 1667051294134
+- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2022.9.0-pyhd8ed1ab_0.tar.bz2
+  sha256: fb406330bc9b5f80b28d812e5892a3d559e22874df7291e919f4ee6d3c33b907
+  md5: e841ab2f40fb319e6740130227904cbf
+  depends:
+  - numpy >=1.19
+  - packaging >=20.0
+  - pandas >=1.2,<2a0
+  - python >=3.8
+  license: Apache-2.0
+  license_family: APACHE
+  size: 720905
+  timestamp: 1664555820396
+- conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+  sha256: 3d65c081514569ab3642ba7e6c2a6b4615778b596db6b1c82ee30a2d912539e5
+  md5: cf30c2c15b82aacb07f9c09e28ff2275
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36325
+  timestamp: 1681770298596
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+  sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
+  md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 18954
+  timestamp: 1695255262261
+- conda: https://conda.anaconda.org/conda-forge/osx-64/abseil-cpp-20211102.0-hddbf539_3.tar.bz2
+  sha256: 83770aabed8324c74bb2b3c4cabbe2b8850237594a7870bf28ebf264389df6ce
+  md5: 7933e6ecaa67c4fc41874ac03bb9976d
+  depends:
+  - libabseil 20211102.0 cxx17_h844d122_3
+  license: Apache-2.0
+  license_family: Apache
+  size: 12951
+  timestamp: 1661960490985
+- conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py38hcafd530_4.conda
+  sha256: bf063be63c87cff3ba93b891a1d3e6d7ff9239b210971f0a789319b73281d6f7
+  md5: 5bea2cefa378752b4f1fe8d8049756fc
+  depends:
+  - cffi >=1.0.1
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: MIT
+  license_family: MIT
+  size: 32091
+  timestamp: 1695387101930
+- conda: https://conda.anaconda.org/conda-forge/osx-64/arrow-cpp-5.0.0-py38h430e7ab_35_cpu.tar.bz2
+  sha256: b5aae811ce557d36074a026797214ce822d8c84acf00a5dc54e756d1070e7013
+  md5: 115cf95a44dbedacb422534586eea6e7
+  depends:
+  - aws-sdk-cpp >=1.8.186,<1.8.187.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-ares >=1.18.1,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.6.0,<0.7.0a0
+  - grpc-cpp >=1.45.2,<1.46.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libcxx >=13.0.1
+  - libprotobuf >=3.20.1,<3.21.0a0
+  - libthrift >=0.16.0,<0.16.1.0a0
+  - libutf8proc >=2.7.0,<3.0a0
+  - libzlib >=1.2.12,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - numpy >=1.16,<2.0a0
+  - numpy >=1.19.5,<2.0a0
+  - orc >=1.7.5,<1.7.6.0a0
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.9,<1.2.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  - libutf8proc <2.9
+  constrains:
+  - arrow-cpp-proc * cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 18688830
+  timestamp: 1655711743389
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.5.11-hd2e2f4b_0.tar.bz2
+  sha256: f96ec7dcf7bc986df747560d4b415c52ef06dad5e18c5063c2ba61e65f7b24ca
+  md5: 09bd616bd04399d208dc06b909a5e1c0
+  depends:
+  - aws-c-common >=0.6.2,<0.6.3.0a0
+  - openssl >=1.1.1k,<1.1.2a
+  license: Apache-2.0
+  license_family: Apache
+  size: 30423
+  timestamp: 1623801177512
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.6.2-h0d85af4_0.tar.bz2
+  sha256: f992c11a0ea2bbae1320f2e1862f92ab1b1d1ad0bcec16c85fb49398a207a1ce
+  md5: 0f72a3415c40ead80c978fec230f49ee
+  license: Apache-2.0
+  license_family: Apache
+  size: 153218
+  timestamp: 1623316723002
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.2.7-hb9330a7_13.tar.bz2
+  sha256: e91d7616ca91ff290531207d10f93af7f75d2e8e8711362b88a5120036a6b478
+  md5: d7319f5973bc93e63eb1b32dbb4d03b8
+  depends:
+  - aws-c-common >=0.6.2,<0.6.3.0a0
+  - aws-c-io >=0.10.5,<0.10.6.0a0
+  - aws-checksums >=0.1.11,<0.1.12.0a0
+  - libcxx >=11.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 41376
+  timestamp: 1624281721985
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.10.5-h35aa462_0.tar.bz2
+  sha256: be9803d50c58d426480940302794a0424361332ecd9a8b8ef5070f48fed818d6
+  md5: 2647690fb7719e72da8a547c2c845708
+  depends:
+  - aws-c-cal >=0.5.11,<0.5.12.0a0
+  - aws-c-common >=0.6.2,<0.6.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 111230
+  timestamp: 1623957743515
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.11-h0010a65_7.tar.bz2
+  sha256: d1d92d3fdb2967903d19379349fabd788825d6f623ed1456cb467a96749dca3a
+  md5: c86bc781dc7b3ba4e6130ffb14da0d6b
+  depends:
+  - aws-c-common >=0.6.2,<0.6.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 49001
+  timestamp: 1623336674465
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.8.186-h7c85d8e_4.tar.bz2
+  sha256: 924c3978e3c7788675a54067ed133f613b1771a07236b5ffd9c66bdac87d0ae6
+  md5: 83537fd65fe827f41b96851e6c92fd73
+  depends:
+  - aws-c-common >=0.6.2,<0.6.3.0a0
+  - aws-c-event-stream >=0.2.7,<0.2.8.0a0
+  - libcurl >=7.86.0,<9.0a0
+  - libcxx >=14.0.4
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=1.1.1q,<1.1.2a
+  license: Apache-2.0
+  license_family: Apache
+  size: 3788413
+  timestamp: 1667032802248
+- conda: https://conda.anaconda.org/conda-forge/osx-64/bokeh-2.3.3-py38h50d1736_0.tar.bz2
+  sha256: a5f34e64fc5bfaa901c444653da1b4da90e3dc2361651a03b150e5b013aff271
+  md5: a0034b22ddf034e7b5fe5e5f8e7cbe36
+  depends:
+  - jinja2 >=2.7
+  - numpy >=1.11.3
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.1
+  - python_abi 3.8.* *_cp38
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8718904
+  timestamp: 1625757387993
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.0.9-hb7f2c08_9.conda
+  sha256: eb425d4075f90d90bf9de5c2e8f88fe783d70177fcdfd3d3da5ef48e444ca148
+  md5: 53cff90f0cea22e13e5b791f0e5a8e7d
+  depends:
+  - brotli-bin 1.0.9 hb7f2c08_9
+  - libbrotlidec 1.0.9 hb7f2c08_9
+  - libbrotlienc 1.0.9 hb7f2c08_9
+  license: MIT
+  license_family: MIT
+  size: 20237
+  timestamp: 1687884767757
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.0.9-hb7f2c08_9.conda
+  sha256: 98c257aee9b60dc91a86fc486b19192eebfe9ec7929b4efff99b6fb643f85b05
+  md5: 72c526f7ffa265473e6c75fd90605e52
+  depends:
+  - libbrotlidec 1.0.9 hb7f2c08_9
+  - libbrotlienc 1.0.9 hb7f2c08_9
+  license: MIT
+  license_family: MIT
+  size: 17977
+  timestamp: 1687884724119
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.0.9-py38h4cd09af_9.conda
+  sha256: 340c5a54b040ccf43bc822486f6e8a503d0eb25b7b4d7c302ef08b1a83373091
+  md5: f958e25488ff7e044031bca8a6c5267b
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  constrains:
+  - libbrotlicommon 1.0.9 hb7f2c08_9
+  license: MIT
+  license_family: MIT
+  size: 350485
+  timestamp: 1687885365422
+- conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2
+  sha256: 60ba4c64f5d0afca0d283c7addba577d3e2efc0db86002808dadb0498661b2f2
+  md5: 37edc4e6304ca87316e160f5ca0bd1b5
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 158829
+  timestamp: 1618862580095
+- conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.20.1-h10d778d_1.conda
+  sha256: 9e99ffb7e3376188c1e0c8037982a8fdc08c5736ea28f2314c20b8846179f0fe
+  md5: 0f9fe8eb46d409939d9b2a7d90a52325
+  license: MIT
+  license_family: MIT
+  size: 103592
+  timestamp: 1697955959402
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2023.7.22-h8857fd0_0.conda
+  sha256: 27de15e18a12117e83ac1eb8a8e52eb65731cc7f0b607a7922206a15e2460c7b
+  md5: bf2c54c18997bf3542af074c10191771
+  license: ISC
+  size: 149911
+  timestamp: 1690026363769
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.16.0-py38h082e395_0.conda
+  sha256: c79e5074c663670f75258f6fce8ebd0e65042bd22ecbb4979294c57ff4fa8fc5
+  md5: 046fe2a8edb11f1b8a7d3bd8e2fd1de7
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: MIT
+  license_family: MIT
+  size: 228367
+  timestamp: 1696002058694
+- conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.1.1-py38h15a1a5b_1.conda
+  sha256: da3bac66909c9fbfe0d1d106db87563dea55fd5ef4c86d50813fbf13e57a3558
+  md5: 1c702bb95106dbed8ddb262ad4041432
+  depends:
+  - libcxx >=15.0.7
+  - numpy >=1.16
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217516
+  timestamp: 1695554454574
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cramjam-2.7.0-py38h7510fb3_1.conda
+  sha256: a9d0e81c752d2508a8b1a9edef06f46248d24022cfb418ed7b2852d73247ae12
+  md5: 6ef587cb8304ae8f7cf2b4c9a8ec7f16
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: MIT
+  license_family: MIT
+  size: 1331174
+  timestamp: 1695451035609
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-0.12.2-py38hcafd530_1.conda
+  sha256: 43b31171a02b54c815504141cc47e176362ffa3c7b1614f7dc94c1245ceef211
+  md5: ec347ff8b58bb961c61e18ad4255cb56
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 315471
+  timestamp: 1695545563469
+- conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.0-py38h940360d_1.conda
+  sha256: 39b3f490a5eb001248f5b01317d7e30f8a43162615769fa6ed8631065638c8b5
+  md5: 36eb00ff62ea418a9da0b795f7886535
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: MIT
+  license_family: MIT
+  size: 2378164
+  timestamp: 1695534624459
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fastparquet-0.7.1-py38hbe852b5_0.tar.bz2
+  sha256: 93b8406640f685e100596a9104a0bc5d40aefca539ff3919ed66dbf687070d5a
+  md5: 836bdf2fadaac30c81b1f9152fc944f0
+  depends:
+  - cramjam >=2.3.0
+  - fsspec
+  - numpy >=1.18.5,<2.0a0
+  - pandas >=1.0.0
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - thrift >=0.11
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 479073
+  timestamp: 1628092252185
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.43.1-py38hae2e43d_0.conda
+  sha256: 545e732716ec65583a4580187d041f676b7cd43e06e688716a24c428911afa29
+  md5: b8c38d1f5705d63d723fbd077a79cdf6
+  depends:
+  - brotli
+  - munkres
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - unicodedata2 >=14.0.0
+  license: MIT
+  license_family: MIT
+  size: 2132914
+  timestamp: 1696601643510
+- conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+  sha256: b292cf5a25f094eeb4b66e37d99a97894aafd04a5683980852a8cbddccdc8e4e
+  md5: 25152fce119320c980e5470e64834b50
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 599300
+  timestamp: 1694616137838
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hb1e8313_1004.tar.bz2
+  sha256: 39540f879057ae529cad131644af111a8c3c48b384ec6212de6a5381e0863948
+  md5: 3f59cc77a929537e42120faf104e0d16
+  depends:
+  - libcxx >=10.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94612
+  timestamp: 1599590973213
+- conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.6.0-h8ac2a54_0.tar.bz2
+  sha256: fdb38560094fb4a952346dc72a79b3cb09e23e4d0cae9ba4f524e6e88203d3c8
+  md5: 69eb97ca709a136c53fdca1f2fd33ddf
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=12.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100624
+  timestamp: 1649143914155
+- conda: https://conda.anaconda.org/conda-forge/osx-64/grpc-cpp-1.45.2-h9067f4e_3.tar.bz2
+  sha256: 3b750cc517ee20fe47ca5aeb1d857eacb55a2b2d314f9b211b1233b272be312e
+  md5: 80a6fc95a163050206be367cd3505e25
+  depends:
+  - abseil-cpp >=20211102.0,<20211102.1.0a0
+  - c-ares >=1.18.1,<2.0a0
+  - libcxx >=13.0.1
+  - libprotobuf >=3.20.1,<3.21.0a0
+  - libzlib >=1.2.11,<2.0.0a0
+  - openssl >=1.1.1o,<1.1.2a
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.11,<1.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3659523
+  timestamp: 1651993990202
+- conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-2.4-py38h50d1736_3.conda
+  sha256: f706894de91a7c453fb8509172251d4cf99f30e0461c57a0405eac9c477faed3
+  md5: 587da7fcb04fb5d49d7caf0f0010e17f
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16364
+  timestamp: 1695397533592
+- conda: https://conda.anaconda.org/conda-forge/osx-64/jupyter_core-5.4.0-py38h50d1736_0.conda
+  sha256: 81d77c62e790918a0f64dd3773c5ea5ca87f032388bc59187c2c0ad9b22a7c40
+  md5: 16a404aa8cd87ad43ed748d4be4cbeff
+  depends:
+  - platformdirs >=2.5
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78662
+  timestamp: 1696972645584
+- conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.5-py38h15a1a5b_1.conda
+  sha256: b024d357b0cd1e160e3565f6ff6fc15f70f44beb736ac7a7ec9f714bd430140d
+  md5: a288aa741a88b5242389f05dcd9e6670
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 60607
+  timestamp: 1695380414024
+- conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.20.1-h0165f36_0.conda
+  sha256: f7352e760f792d9ed0234b180a0d09b48d71affd485549e564fd7c7c8441d8be
+  md5: 9345f11991753ef75a35754c83319db2
+  depends:
+  - libcxx >=14.0.6
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=1.1.1s,<1.1.2a
+  license: MIT
+  license_family: MIT
+  size: 1122764
+  timestamp: 1671091963740
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.15-hd6ba6f3_3.conda
+  sha256: b2234f24e3b0030762430ec3414410119d1129804a95ef65af50ad36cabd9bd5
+  md5: 8059507d52f477fbd4b81841e085e25b
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 224895
+  timestamp: 1695969874291
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+  sha256: e41790fc0f4089726369b3c7f813117bbc14b533e0ed8b94cf75aba252e82497
+  md5: f9d6a4c82889d5ecedec1d90eb673c55
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 290319
+  timestamp: 1657977526749
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20211102.0-cxx17_h844d122_3.tar.bz2
+  sha256: 673f886c3b5990b1733276fb9a1fbb0e10d8057165a47803616b5e0f75677f01
+  md5: a10f0de837fcb64a9e57739e90b1e0eb
+  depends:
+  - libcxx >=14.0.4
+  constrains:
+  - libabseil-static =20211102.0=cxx17*
+  - abseil-cpp =20211102.0
+  - libabseil-static ==99999999999
+  license: Apache-2.0
+  license_family: Apache
+  size: 1034832
+  timestamp: 1661960473742
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-19_osx64_openblas.conda
+  sha256: c2c96103aa23a65f45b76716df49940cb0722258d3e0416f8fa06ade02464b23
+  md5: e932b99c38915fa2ee252cdff6ea1f01
+  depends:
+  - libopenblas >=0.3.24,<0.3.25.0a0
+  - libopenblas >=0.3.24,<1.0a0
+  constrains:
+  - liblapacke 3.9.0 19_osx64_openblas
+  - libcblas 3.9.0 19_osx64_openblas
+  - liblapack 3.9.0 19_osx64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14812
+  timestamp: 1697484725085
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.0.9-hb7f2c08_9.conda
+  sha256: 1718e037a7ea9a1730b9f5285898528676794e2aaf5590149d239febab9a9b36
+  md5: ee1ee8c79c3426229ad03290573be552
+  license: MIT
+  license_family: MIT
+  size: 69588
+  timestamp: 1687884586401
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.0.9-hb7f2c08_9.conda
+  sha256: 3892d88f778ddcda5c2bb7d066082fc7b785dcc84ffe448c65f21cbadd856e2c
+  md5: 4043ef9fe42e178785e0e1853b79bdf9
+  depends:
+  - libbrotlicommon 1.0.9 hb7f2c08_9
+  license: MIT
+  license_family: MIT
+  size: 31929
+  timestamp: 1687884624094
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.0.9-hb7f2c08_9.conda
+  sha256: c099c964277ee7ea98cf6ba1bfe07078e662b86ed999da3fcf9eaf7d7d242e86
+  md5: b64d4dcc70aa141db7fccbf13bad81e1
+  depends:
+  - libbrotlicommon 1.0.9 hb7f2c08_9
+  license: MIT
+  license_family: MIT
+  size: 279086
+  timestamp: 1687884674212
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-19_osx64_openblas.conda
+  sha256: 70afde49736007bbb804d126a3983ba1fa04383006aae416a2971d538e274427
+  md5: 40e412c219ad8cf87ba664466071bcf6
+  depends:
+  - libblas 3.9.0 19_osx64_openblas
+  constrains:
+  - liblapack 3.9.0 19_osx64_openblas
+  - liblapacke 3.9.0 19_osx64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14717
+  timestamp: 1697484740520
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-7.87.0-haf73cf8_0.conda
+  sha256: 2880a7b88fc184fbaf710573e698ceadfde5be0511f3a69a70c6d9cadf921fd7
+  md5: c5ad60467758fbc6a285c96d3c59a74c
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.47.0,<2.0a0
+  - libssh2 >=1.10.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=1.1.1s,<1.1.2a
+  license: curl
+  license_family: MIT
+  size: 331234
+  timestamp: 1671621777290
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.6-hd57cbcb_0.conda
+  sha256: 9063271847cf05f3a6cc6cae3e7f0ced032ab5f3a3c9d3f943f876f39c5c2549
+  md5: 7d6972792161077908b62971802f289a
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1142172
+  timestamp: 1686896907750
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.19-ha4e1b8e_0.conda
+  sha256: d0f789120fedd0881b129aba9993ec5dcf0ecca67a71ea20c74394e41adcb503
+  md5: 6a45f543c2beb40023df5ee7e3cedfbd
+  license: MIT
+  license_family: MIT
+  size: 68962
+  timestamp: 1694922440450
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+  sha256: dbd3c3f2eca1d21c52e4c03b21930bbce414c4592f8ce805801575b9e9256095
+  md5: 6016a8a1d0e63cac3de2c352cd40208b
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 105382
+  timestamp: 1597616576726
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-haf1e3a3_1.tar.bz2
+  sha256: c4154d424431898d84d6afb8b32e3ba749fe5d270d322bb0af74571a3cb09c6b
+  md5: 79dc2be110b2a3d1e97ec21f691c50ad
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 101424
+  timestamp: 1598868359024
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.10-h815e4d9_4.tar.bz2
+  sha256: 8d2f1f172ba56d531428b71b7b163714393bce557f7ff83f7d9a7324b57f2164
+  md5: adc6c89498c5f6fe5ba874d8259e7eeb
+  depends:
+  - openssl >=1.1.1l,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1150901
+  timestamp: 1633489506111
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+  sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
+  md5: ccb34fb14960ad8b125962d3d79b31a9
+  license: MIT
+  license_family: MIT
+  size: 51348
+  timestamp: 1636488394370
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_1.conda
+  sha256: 5be1a59316e5063f4e6492ea86d692600a7b8e32caa25269f8a3b386a028e5f3
+  md5: b55fd11ab6318a6e67ac191309701d5a
+  depends:
+  - libgfortran5 13.2.0 h2873a65_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 109855
+  timestamp: 1694165674845
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_1.conda
+  sha256: 44de8930eef3b14d4d9fdfe419e6c909c13b7c859617d3616d5a5e964f3fcf63
+  md5: 3af564516b5163cd8cc08820413854bc
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1571764
+  timestamp: 1694165583047
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+  sha256: d9572fd1024adc374aae7c247d0f29fdf4b122f1e3586fe62acc18067f40d02f
+  md5: 72507f8e3961bc968af17435060b6dd6
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 579748
+  timestamp: 1694475265912
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-19_osx64_openblas.conda
+  sha256: 6a1704c43a03195fecbbb226be5c257b2e37621e793967c3f31c8521f19e18df
+  md5: 2e714df18db99ee6d7b4ac728f53ca62
+  depends:
+  - libblas 3.9.0 19_osx64_openblas
+  constrains:
+  - libcblas 3.9.0 19_osx64_openblas
+  - liblapacke 3.9.0 19_osx64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14724
+  timestamp: 1697484756327
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-hc8e404f_4.conda
+  sha256: 0df3902a300cfe092425f86144d5e00ef67be3cd1cc89fd63084d45262a772ad
+  md5: ed06753e2ba7c66ed0ca7f19578fcb68
+  depends:
+  - libcxx >=15
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 22467131
+  timestamp: 1690563140552
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.51.0-h0dd9d14_0.conda
+  sha256: 9949cd2c96dad3e4f1c2011c694667d837c5e617363bf0c340f15c0cbe7c901e
+  md5: 6c83a076112d9496b4cb5f940e40023a
+  depends:
+  - c-ares >=1.18.1,<2.0a0
+  - libcxx >=14.0.6
+  - libev >=4.33,<4.34.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=1.1.1s,<1.1.2a
+  license: MIT
+  license_family: MIT
+  size: 609278
+  timestamp: 1672695889664
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.24-openmp_h48a4ad5_0.conda
+  sha256: ff2c14f7ed121f1df3ad06bea353288eade77c12fb891212a27af88a61483490
+  md5: 077718837dd06cf0c3089070108869f6
+  depends:
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - llvm-openmp >=15.0.7
+  constrains:
+  - openblas >=0.3.24,<0.3.25.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6157393
+  timestamp: 1693785988209
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.39-ha978bb4_0.conda
+  sha256: 5ad9f5e96e6770bfc8b0a826f48835e7f337c2d2e9512d76027a62f9c120b2a3
+  md5: 35e4928794c5391aec14ffdf1deaaee5
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: zlib-acknowledgement
+  size: 271689
+  timestamp: 1669075890643
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-3.20.3-hbc0c0cd_0.conda
+  sha256: 0b19d1622616bcd4d0877b1f1de76ba62eaf616029d3082f56d5662ec74949c0
+  md5: 72065fed01a8859199b2aa621ffe1230
+  depends:
+  - libcxx >=14.0.6
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1972033
+  timestamp: 1681044367958
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.18-hbcb3906_1.tar.bz2
+  sha256: 2da45f14e3d383b4b9e3a8bacc95cd2832aac2dbf9fbc70d255d384a310c5660
+  md5: 24632c09ed931af617fe6d5292919cab
+  license: ISC
+  size: 528765
+  timestamp: 1605135849110
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.43.2-h92b6c6a_0.conda
+  sha256: e0ba6181738d5250213576167935a97dc3ee581032f716dd4e2acbc817c763dc
+  md5: 61b88c5f99f1537ed30b34758bd54d54
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Unlicense
+  size: 885196
+  timestamp: 1696959083399
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.10.0-h7535e13_3.tar.bz2
+  sha256: 8688c19c2158edfee7b82a673c1371ce21113b076b34c60f74f094b9841b8a16
+  md5: acc1797f7b89018eeba2029c56dfdf0c
+  depends:
+  - libzlib >=1.2.12,<2.0.0a0
+  - openssl >=1.1.1q,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 227099
+  timestamp: 1660346615008
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.16.0-h08c06f4_2.tar.bz2
+  sha256: e6d1b062e0be51ed65694bed350f8974073312e44827f72faa1e2eef89998427
+  md5: c7a0779d1b87c4ba4897fc7f12b304ca
+  depends:
+  - libcxx >=14.0.4
+  - libevent >=2.1.10,<2.1.11.0a0
+  - libzlib >=1.2.12,<2.0.0a0
+  - openssl >=1.1.1q,<1.1.2a
+  license: Apache-2.0
+  license_family: APACHE
+  size: 364250
+  timestamp: 1663079607939
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h684deea_2.conda
+  sha256: 1ef5bd7295f4316b111f70ad21356fb9f0de50b85a341cac9e3a61ac6487fdf1
+  md5: 2ca10a325063e000ad6d2a5900061e0d
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=15.0.7
+  - libdeflate >=1.19,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: HPND
+  size: 266501
+  timestamp: 1695661828714
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
+  sha256: 55a7f96b2802e94def207fdfe92bc52c24d705d139bb6cdb3d936cbe85e1c505
+  md5: db98dc3e58cbc11583180609c429c17d
+  license: MIT
+  license_family: MIT
+  size: 98942
+  timestamp: 1667316472080
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.3.2-h0dc2134_0.conda
+  sha256: fa7580f26fec4c28321ec2ece1257f3293e0c646c635e9904679f4a8369be401
+  md5: 4e7e9d244e87d66c18d36894fd6a8ae5
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 346599
+  timestamp: 1694709233836
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.15-hb7f2c08_0.conda
+  sha256: f41904f466acc8b3197f37f2dd3a08da75720c7f7464d9267635debc4ac1902b
+  md5: 5513f57e0238c87c12dffedbcc9c1a4a
+  depends:
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 313793
+  timestamp: 1682083036825
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
+  sha256: fc58ad7f47ffea10df1f2165369978fba0a1cc32594aad778f5eec725f334867
+  md5: 4a3ad23f6e16f99c04e166767193d700
+  constrains:
+  - zlib 1.2.13 *_5
+  license: Zlib
+  license_family: Other
+  size: 59404
+  timestamp: 1686575566695
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-17.0.3-hb6ac08f_0.conda
+  sha256: 5bded7aa593e4d5dea89fc19ef2aa48b531cbe455452877ef9bd5a698cf35e53
+  md5: b70adc70bc7527a207c81c2e6b43532c
+  constrains:
+  - openmp 17.0.3|17.0.3.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 299798
+  timestamp: 1697651995182
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.40.1-py38hf646772_0.conda
+  sha256: 343c5505559b1eb0df4059cef8e6b5fcd153dd338e24f7fce3cbf5971164f428
+  md5: c26ba84eb5c1ce8da0b619a3d85f7fd2
+  depends:
+  - libcxx >=15.0.7
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 258153
+  timestamp: 1687806786669
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+  sha256: 39aa0c01696e4e202bf5e337413de09dfeec061d89acd5f28e9968b4e93c3f48
+  md5: aa04f7143228308662696ac24023f991
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 156415
+  timestamp: 1674727335352
+- conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.3-py38hcafd530_1.conda
+  sha256: a907d8cab806d821918b3339e71a91cb871311ab5843e3838341e771674cfdcb
+  md5: ed178f435d4626880e8f5dd5d5f0e65c
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22829
+  timestamp: 1695367956445
+- conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.7.3-py38hcd1b199_0.conda
+  sha256: 9256e2e230c990466247b1e913182bdcdbb0045f6b053f0abc2b4ce55d10c842
+  md5: 7e17b15addb42d41728f580757e3f528
+  depends:
+  - __osx >=10.12
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - importlib-resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=15.0.7
+  - numpy >=1.20
+  - numpy >=1.22.4,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.8.* *_cp38
+  license: LicenseRef-PSF-2.0 and CC0-1.0
+  license_family: PSF
+  size: 6688465
+  timestamp: 1695077176555
+- conda: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.0.6-py38h15a1a5b_0.conda
+  sha256: 2e7524e71fefa747368b804e47f1b2b325a0b494bfdf29d1084bd3c99016ef69
+  md5: 5884be2be4206a2938351886daeac316
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: Apache-2.0
+  license_family: Apache
+  size: 186845
+  timestamp: 1695464429544
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-hf0c8a7f_0.conda
+  sha256: 7841b1fce1ffb0bfb038f9687b92f04d64acab1f7cb96431972386ea98c7b2fd
+  md5: c3dbae2411164d9b02c69090a9a91857
+  license: X11 AND BSD-3-Clause
+  size: 828118
+  timestamp: 1686077056765
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.57.1-py38h5c56fa7_0.conda
+  sha256: 7a1aca96693f3d40b5027a36990a558dbd484d1a4dd01d840b49fc4cb08fed69
+  md5: 7f7eab9d2f654ef532fb75223a4428e8
+  depends:
+  - importlib-metadata
+  - libcxx >=15.0.7
+  - llvm-openmp >=15.0.7
+  - llvm-openmp >=16.0.6
+  - llvmlite >=0.40.0,<0.41.0a0
+  - numpy >=1.21.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  constrains:
+  - cudatoolkit >=10.2
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.25
+  - libopenblas !=0.3.6
+  - scipy >=1.0
+  - cuda-version >=10.2
+  - tbb >=2021.6.0
+  - cuda-python >=11.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4079057
+  timestamp: 1687805180255
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.24.4-py38h9a4a08f_0.conda
+  sha256: 35fbebae914d7c74f87e6b26a373fb7496bba7431916c745d8db68bc8f199674
+  md5: 85debc55a30068d6bb76a6deaf599afa
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=15.0.7
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6284827
+  timestamp: 1687809164056
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.0-ha4da562_3.conda
+  sha256: fdccd9668b85bf6e798b628bceed5ff764e1114cfc4e6a4dee551cafbe549e74
+  md5: 40a36f8e9a6fdf6a78c6428ee6c44188
+  depends:
+  - libcxx >=15.0.7
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 335643
+  timestamp: 1694708811338
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-1.1.1w-h8a1eda9_0.conda
+  sha256: 58fd3b113c41202527f0bd6631887ff472cabfac67521f073fbf2bfc48e583b9
+  md5: 83cdb687c0caa41dad9d4941afcdfd64
+  depends:
+  - ca-certificates
+  license: OpenSSL
+  license_family: Apache
+  size: 1737034
+  timestamp: 1694462007875
+- conda: https://conda.anaconda.org/conda-forge/osx-64/orc-1.7.5-h4856350_0.tar.bz2
+  sha256: e0fbd056467abb290206cb241fb2a019a7fc3822d044dcdeeafaafc99530d8eb
+  md5: ad05141f778b1bc331b49ee6d6a62f72
+  depends:
+  - libcxx >=13.0.1
+  - libprotobuf >=3.20.1,<3.21.0a0
+  - libzlib >=1.2.12,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.9,<1.2.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 435867
+  timestamp: 1655617869415
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-1.2.5-py38h1f261ad_0.tar.bz2
+  sha256: cab259d810e3e640e873f726ccd79258f63e3f09e6170c11b2ae5bb11909a5db
+  md5: 55ebc532cfd1920100fe1a89ddcc452a
+  depends:
+  - libcxx >=11.1.0
+  - numpy >=1.17.5,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.7.3
+  - python_abi 3.8.* *_cp38
+  - pytz >=2017.2
+  - setuptools <60.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11169315
+  timestamp: 1624391746977
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pandoc-3.1.3-h9d075a6_0.conda
+  sha256: 3bc6bc31b96338c65c8f6e222bd8c65d47227ba4b59b2587157c3a29499123cc
+  md5: e86a3d5c966a09b6129354114483f7a7
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 16126792
+  timestamp: 1686227275745
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.1.0-py38h0024655_0.conda
+  sha256: 8da5df12e92b8ad53523f57567496aee154698d6e77c752f3f260edc984faf42
+  md5: 5b8f100a640c679c8c14258c90652e31
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 45625573
+  timestamp: 1697423929906
+- conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.5-py38hcafd530_1.conda
+  sha256: 961e84bd21fb2ca03e445bcf79fcb5b0e7b308c18abc31d3f1f7ef2caefdb6f0
+  md5: c916926d86a0578ec21f2140e661bc56
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365520
+  timestamp: 1695367399744
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
+  sha256: 6e3900bb241bcdec513d4e7180fe9a19186c1a38f0b4080ed619d26014222c53
+  md5: addd19059de62181cd11ae8f4ef26084
+  license: MIT
+  license_family: MIT
+  size: 5653
+  timestamp: 1606147699844
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-5.0.0-py38h83ad6b9_35_cpu.tar.bz2
+  sha256: e2934f256f973fbab96f767067ce5b1ecb51dc86d9a6182f013ea55c450c0a81
+  md5: 8aa71351545efae8f2a1bb2c2e6b1bde
+  depends:
+  - arrow-cpp 5.0.0 py38h430e7ab_35_cpu
+  - libcxx >=13.0.1
+  - numpy >=1.16,<2.0a0
+  - numpy >=1.19.5,<2.0a0
+  - parquet-cpp 1.5.1.*
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  constrains:
+  - arrow-cpp-proc * cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 2636873
+  timestamp: 1655714049039
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.0-py38h095c2e5_0.conda
+  sha256: 9488ff20e510d1d343db48d2ea16ab239f1684794f143aac66d8bfe5ef166ec0
+  md5: 8b11fad26ecbd9344cebca936c74cdfa
+  depends:
+  - libffi >=3.4,<4.0a0
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 414830
+  timestamp: 1695560780935
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.0-py38h095c2e5_1.conda
+  sha256: c4f0821dc11b79063fe7ef828ebcf275eb9a2dc357428ab7c79a9a0e3214cfb7
+  md5: de9d8f287891e69ac0860737b8d27488
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 10.0.*
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: MIT
+  license_family: MIT
+  size: 315451
+  timestamp: 1695716784540
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.8.15-hc915b28_0_cpython.conda
+  sha256: 53d6935e4560733e3a1cb7616f70ffefb6fe1c8c96bfe43025fa8b9515b90e20
+  md5: 241419033ffabb092e9a4fb8bc3e0d78
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.40.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.3,<7.0a0
+  - openssl >=1.1.1s,<1.1.2a
+  - readline >=8.1.2,<9.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.8.* *_cp38
+  license: Python-2.0
+  size: 10583869
+  timestamp: 1669107844956
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-snappy-0.6.0-py38h16e2861_2.tar.bz2
+  sha256: 9738b4fa7d0ab681fa7b183afcce45c3f892e6b86ea23d2fffaa93eb699c46cf
+  md5: 23f794d40ba962e5c2afd89339a32db1
+  depends:
+  - libcxx >=12.0.1
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - snappy >=1.1.8,<1.2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30481
+  timestamp: 1649520154649
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.8-4_cp38.conda
+  sha256: 0dab6ce7b8e48f2308aa9c37e8feceaa7c84ee335745c1803686fbbb59a19926
+  md5: 74bec187a12aed00501eaafd35e694bf
+  constrains:
+  - python 3.8.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6479
+  timestamp: 1695147767216
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.1-py38hcafd530_1.conda
+  sha256: cd1dceaa9bb8296ddea04cfb5e933bf5ab2b189c566bb55e1a3c9a38efffa82d
+  md5: 17cfcfdd18fa2fe701ff68c9bbcea9a5
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 161848
+  timestamp: 1695373748011
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-24.0.1-py38h0b711fd_0.tar.bz2
+  sha256: 36a691e3f8aee27b039329cfa026f791a8f82accd612ef5d6755a578930dc3b0
+  md5: 5fc7140e067ba925be8ee7aa7eec8408
+  depends:
+  - libcxx >=14.0.4
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  size: 464624
+  timestamp: 1663830828398
+- conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2022.04.01-h96cf925_0.tar.bz2
+  sha256: cdc48f372bc72481d911db4f251a98fd85409972c071de5382e8fae429fae930
+  md5: 65029ca8742d353a89f2380aec86c8e2
+  depends:
+  - libcxx >=12.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 205321
+  timestamp: 1648884065250
+- conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+  sha256: 41e7d30a097d9b060037f0c6a2b1d4c4ae7e942c06c943d23f9d481548478568
+  md5: f17f77f2acf4d344734bda76829ce14e
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 255870
+  timestamp: 1679532707590
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.10.6-py38h51dbebd_0.conda
+  sha256: 7164ebbf73b94a90133733896abb4db2a63bb095f5fb84624e5f70c97cd13571
+  md5: a6b4fc7f6541434a05c51df890ebcf5a
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: MIT
+  license_family: MIT
+  size: 290908
+  timestamp: 1697072689134
+- conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.10.1-py38h9cf86d3_3.conda
+  sha256: f38d549c75237a6c3a4d872f4153ba39411100fec4fcf166f74b4d1784792862
+  md5: 5e20c77455e815704b008ab8f42f6169
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=15.0.7
+  - libgfortran >=5
+  - libgfortran5 >=12.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy >=1.21.6,<1.27
+  - numpy >=1.21.6,<2.0a0
+  - pooch
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  constrains:
+  - libopenblas <0.3.26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15428960
+  timestamp: 1683902064237
+- conda: https://conda.anaconda.org/conda-forge/osx-64/setuptools-59.8.0-py38h50d1736_1.tar.bz2
+  sha256: 82a19903932bb3c1d3bd872bf64f51e0f73d1e1e210d7bf9c569a44ae03c7184
+  md5: c25b5974862472ee3e681a920ceaceb4
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: MIT
+  license_family: MIT
+  size: 1046124
+  timestamp: 1648692283808
+- conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
+  sha256: 575915dc13152e446a84e2f88de70a14f8b6af1a870e708f9370bd4be105583b
+  md5: 4320a8781f14cd959689b86e349f3b73
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 34657
+  timestamp: 1678534768395
+- conda: https://conda.anaconda.org/conda-forge/osx-64/thrift-0.19.0-py38h940360d_1.conda
+  sha256: 2c83c5d6fabd9cc5d29dc2fd1b3f95bbf54f8b5665dcdf74a997beca7c641a52
+  md5: e2f212b81529af37d67096deab827dca
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - six >=1.7.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 130755
+  timestamp: 1695546404683
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hef22860_0.conda
+  sha256: 573e5d7dde0a63b06ceef2c574295cbc2ec8668ec08e35d2f2c6220f4aa7fb98
+  md5: 0c25eedcc888b6d765948ab62a18c03e
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3273909
+  timestamp: 1695506576288
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.3.3-py38hcafd530_1.conda
+  sha256: dfccc751956a31a6c3487d44cec374227cd2285767f4f0de989ff71c9ce0b4e7
+  md5: b416bb581bd581ff6d2e5b532b11f19b
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: Apache-2.0
+  license_family: Apache
+  size: 630919
+  timestamp: 1695373953330
+- conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-15.1.0-py38hcafd530_0.conda
+  sha256: d3e2ba343685c366d9fe52ebc7e292c6da9bee0a7c94c8161be5b5d06d8298b9
+  md5: 0c713dba14142a6f12e87ee798a6d73d
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: Apache-2.0
+  license_family: Apache
+  size: 369401
+  timestamp: 1695848258644
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
+  sha256: 8a2e398c4f06f10c64e69f56bcf3ddfa30b432201446a0893505e735b346619a
+  md5: 9566b4c29274125b0266d0177b5eb97b
+  license: MIT
+  license_family: MIT
+  size: 13071
+  timestamp: 1684638167647
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2
+  sha256: 485421c16f03a01b8ed09984e0b2ababdbb3527e1abf354ff7646f8329be905f
+  md5: 86ac76d6bf1cbb9621943eb3bd9ae36e
+  license: MIT
+  license_family: MIT
+  size: 17225
+  timestamp: 1610071995461
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+  sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
+  md5: a72f9d4ea13d55d745ff1ed594747f10
+  license: LGPL-2.1 and GPL-2.0
+  size: 238119
+  timestamp: 1660346964847
+- conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+  sha256: 5301417e2c8dea45b401ffee8df3957d2447d4ce80c83c5ff151fc6bfe1c4148
+  md5: d7e08fcf8259d742156188e8762b4d20
+  license: MIT
+  license_family: MIT
+  size: 84237
+  timestamp: 1641347062780
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h93d8f39_0.conda
+  sha256: 19be553b3cc8352b6e842134b8de66ae39fcae80bc575c203076370faab6009c
+  md5: 4c055e46b394be36681fe476c1e2ee6e
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 294253
+  timestamp: 1697057208271
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
+  sha256: d1f4c82fd7bd240a78ce8905e931e68dca5f523c7da237b6b63c87d5625c5b35
+  md5: 75a8a98b1c4671c5d2897975731da42d
+  depends:
+  - libzlib 1.2.13 h8a1eda9_5
+  license: Zlib
+  license_family: Other
+  size: 90764
+  timestamp: 1686575574678
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
+  sha256: d54e31d3d8de5e254c0804abd984807b8ae5cd3708d758a8bf1adff1f5df166c
+  md5: 80abc41d0c48b82fe0f04e7f42f5cb7e
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 499383
+  timestamp: 1693151312586
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/abseil-cpp-20211102.0-he4e09e4_3.tar.bz2
+  sha256: 680b4edab2b201a305c46d946d690c089797306cbcf2068fe3f3461719fafeaa
+  md5: 9f7f37a7db673a07b4db85e0eac836cb
+  depends:
+  - libabseil 20211102.0 cxx17_h28b99d4_3
+  license: Apache-2.0
+  license_family: Apache
+  size: 12954
+  timestamp: 1661960372396
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py38hb192615_4.conda
+  sha256: 2f7005b947e5d3674c1233954200383aef5646143161aef76c2e625925380ad9
+  md5: b57b40ab95004241263bbdce464eb397
+  depends:
+  - cffi >=1.0.1
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  license: MIT
+  license_family: MIT
+  size: 33295
+  timestamp: 1695387183431
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/arrow-cpp-5.0.0-py38hcc5bc27_35_cpu.tar.bz2
+  sha256: bd94c0dca5278083d4a0d2ce69d1a2691f63c02a37d4c15c52603a6c3eacc8b6
+  md5: 330361fa0441b64873a6eebb29dc6494
+  depends:
+  - aws-sdk-cpp >=1.8.186,<1.8.187.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-ares >=1.18.1,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.6.0,<0.7.0a0
+  - grpc-cpp >=1.45.2,<1.46.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libcxx >=13.0.1
+  - libprotobuf >=3.20.1,<3.21.0a0
+  - libthrift >=0.16.0,<0.16.1.0a0
+  - libutf8proc >=2.7.0,<3.0a0
+  - libzlib >=1.2.12,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - numpy >=1.16,<2.0a0
+  - numpy >=1.19.5,<2.0a0
+  - orc >=1.7.5,<1.7.6.0a0
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.9,<1.2.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  - libutf8proc <2.9
+  constrains:
+  - arrow-cpp-proc * cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 6218292
+  timestamp: 1655821684739
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.5.11-h4530763_0.tar.bz2
+  sha256: 9fa477ad470373432db0458b93d57103c43dd758ef76434b045d66a6a5bb27c2
+  md5: ce11646fafb17267c81d929ca42cdb5c
+  depends:
+  - aws-c-common >=0.6.2,<0.6.3.0a0
+  - openssl >=1.1.1k,<1.1.2a
+  license: Apache-2.0
+  license_family: Apache
+  size: 28943
+  timestamp: 1623801153566
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.6.2-h3422bc3_0.tar.bz2
+  sha256: 9832dd65039c46d4828e892e92f8cdce4c0de51041acc3c8f9783d9f1333991b
+  md5: e6c0dfc1c6e34241720983abb66ec35e
+  license: Apache-2.0
+  license_family: Apache
+  size: 151441
+  timestamp: 1623316761533
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.2.7-h9972306_13.tar.bz2
+  sha256: b8e06a97f3926ced92c05dd57199031f9ed43fa452a7856ae75a712155e6099e
+  md5: 1aa327d20aec700b23809ce8c1da34cd
+  depends:
+  - aws-c-common >=0.6.2,<0.6.3.0a0
+  - aws-c-io >=0.10.5,<0.10.6.0a0
+  - aws-checksums >=0.1.11,<0.1.12.0a0
+  - libcxx >=11.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 42438
+  timestamp: 1624281710822
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.10.5-hea86ef8_0.tar.bz2
+  sha256: cbe87f68cef20ac8ebf8db8ed2d5def6a7bc96306700e66662243038147657d6
+  md5: 03d1eeb5706292ae6570456b98f38dcb
+  depends:
+  - aws-c-cal >=0.5.11,<0.5.12.0a0
+  - aws-c-common >=0.6.2,<0.6.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 112595
+  timestamp: 1623957950099
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.11-h487e1a8_7.tar.bz2
+  sha256: 5a8983ca028fb6867b9ca3372b09307e58117ed00aff9531665cd4e0f7fe7c10
+  md5: edf91bd9464b05ca9d29be2a730b9468
+  depends:
+  - aws-c-common >=0.6.2,<0.6.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 49707
+  timestamp: 1623336661049
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.8.186-h392f50b_4.tar.bz2
+  sha256: 5596c22a901cd4149fe9d0fe995c1aca040d1cd2b41a802b05994e5c41fcf1ad
+  md5: d27eeebe0e48c6c4cbd21a09f575f496
+  depends:
+  - aws-c-common >=0.6.2,<0.6.3.0a0
+  - aws-c-event-stream >=0.2.7,<0.2.8.0a0
+  - libcurl >=7.86.0,<9.0a0
+  - libcxx >=14.0.4
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=1.1.1q,<1.1.2a
+  license: Apache-2.0
+  license_family: Apache
+  size: 3776924
+  timestamp: 1667032849385
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bokeh-2.3.3-py38h10201cd_0.tar.bz2
+  sha256: e208df80f75c0b0ebb85fca9ff1236ce0e4f1eb76cbd48dfe1af3169390a1134
+  md5: 3fbaab55116ec59fc487228b8e3ac5db
+  depends:
+  - jinja2 >=2.7
+  - numpy >=1.11.3
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.1
+  - python_abi 3.8.* *_cp38
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8591705
+  timestamp: 1625757455131
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.0.9-h1a8c8d9_9.conda
+  sha256: 92c3062dd7e593a502c2f8d12e9ccca7ae1ef0363eb0b12faa47e1bb4fae42c7
+  md5: 856692dff5e450c269465e3256e1277b
+  depends:
+  - brotli-bin 1.0.9 h1a8c8d9_9
+  - libbrotlidec 1.0.9 h1a8c8d9_9
+  - libbrotlienc 1.0.9 h1a8c8d9_9
+  license: MIT
+  license_family: MIT
+  size: 20228
+  timestamp: 1687884815549
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.0.9-h1a8c8d9_9.conda
+  sha256: 4731892fb855f5993129515c5b63b36d049cc64e70611c6afa8f64aae5f51323
+  md5: 19ad562adca69541e67613022b41df5b
+  depends:
+  - libbrotlidec 1.0.9 h1a8c8d9_9
+  - libbrotlienc 1.0.9 h1a8c8d9_9
+  license: MIT
+  license_family: MIT
+  size: 18182
+  timestamp: 1687884787034
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.0.9-py38h2b1e499_9.conda
+  sha256: 571ef51270e0c3cba980dc69ba6b80b2783e23ebcf67a984eb9781fe5cc88d1e
+  md5: af1bebadb3f2c727a6d0b0daabffeb30
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  constrains:
+  - libbrotlicommon 1.0.9 h1a8c8d9_9
+  license: MIT
+  license_family: MIT
+  size: 324694
+  timestamp: 1687885278020
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h3422bc3_4.tar.bz2
+  sha256: a3efbd06ad1432edb0163c48225421f34c2660f5cc002283a8d27e791320b549
+  md5: fc76ace7b94fb1f694988ab1b14dd248
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 151850
+  timestamp: 1618862645215
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.20.1-h93a5062_1.conda
+  sha256: 9f588eb920a793c6501120ed198d34afba763b2b2c0ae6de518c3735aea21d5e
+  md5: 2bb255dbcb73d1986e03cc5a7767c0bf
+  license: MIT
+  license_family: MIT
+  size: 101995
+  timestamp: 1697955983023
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.7.22-hf0a4a13_0.conda
+  sha256: b220c001b0c1448a47cc49b42a622e06a540ec60b3f7a1e057fca1f37ce515e4
+  md5: e1b99ac4dbcee71a71682996f67f7965
+  license: ISC
+  size: 149918
+  timestamp: 1690026385821
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.16.0-py38h73f40f7_0.conda
+  sha256: 375e0be4068f4b00facfa569aa26c92ed87858f45be875f2c4bf90f33733f4de
+  md5: 02911ce6163d7a3e8fe9d9398fb9986d
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  license: MIT
+  license_family: MIT
+  size: 230759
+  timestamp: 1696002169830
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/click-8.0.4-py38h10201cd_0.tar.bz2
+  sha256: feef1d93f3964c044932e0f330220264cb8dea56dc4f12a2a3080496225c63b0
+  md5: c7fe28cf0a4aa466d262de02a7b6156f
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 150440
+  timestamp: 1645238311013
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.1.1-py38h9afee92_1.conda
+  sha256: 1874ff219be4e49bf03e2820bc0d8837b5c308e760a27e4e3b84872bc5e67901
+  md5: 7727e18567f9f74db361e3a351644f26
+  depends:
+  - libcxx >=15.0.7
+  - numpy >=1.16
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217202
+  timestamp: 1695554655899
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cramjam-2.7.0-py38hd0c8013_1.conda
+  sha256: 9376b13f274c4fd5df8c9ad70c7877b6342f9878b6603e2985b23bb5476bb0cd
+  md5: d4a14e6c43ac2ffe28fe9d36060fe3cb
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  license: MIT
+  license_family: MIT
+  size: 1217664
+  timestamp: 1695451076538
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-0.12.2-py38hb192615_1.conda
+  sha256: 6be8d7d2bc8b9fb846b8867a319074b167a809fbf14ea0617d919ba2aa1d0b45
+  md5: e605909bb521a9d8e19cfc98f6cbc589
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 324638
+  timestamp: 1695545569396
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.0-py38he333c0f_1.conda
+  sha256: fdaf9faaa26ffe4061c2798aab3fe53b42669783b1d26d5b807406af479eacbf
+  md5: 07dce7871f75c6b80a00e812e0db9332
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  license: MIT
+  license_family: MIT
+  size: 2363942
+  timestamp: 1695534779908
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/distributed-2021.8.0-py38h10201cd_0.tar.bz2
+  sha256: 83f1825045345682940ec8d0786148452a680f6909b714a20e1385ea269283ac
+  md5: f34c29b3f64956c77d84fb39568f371a
+  depends:
+  - click >=6.6,<8.1.0
+  - cloudpickle >=1.5.0
+  - cytoolz >=0.8.2
+  - dask-core 2021.8.0.*
+  - jinja2
+  - msgpack-python >=0.6.0
+  - psutil >=5.0
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - pyyaml
+  - setuptools <60.0.0
+  - sortedcontainers !=2.0.0,!=2.0.1
+  - tblib >=1.6.0
+  - toolz >=0.8.2
+  - tornado >=6.0.3
+  - zict >=0.1.3
+  - tornado <6.2
+  constrains:
+  - openssl !=1.1.1e
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1078684
+  timestamp: 1628904249653
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fastparquet-0.7.1-py38h691f20f_0.tar.bz2
+  sha256: b5dc7ab9ca75fd0e103253445da23b6695d364abbfee96034cb987e0fd9646bb
+  md5: d97b7173136f914b2a243ecde7e1c132
+  depends:
+  - cramjam >=2.3.0
+  - fsspec
+  - numpy >=1.19.5,<2.0a0
+  - pandas >=1.0.0
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - thrift >=0.11
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 477668
+  timestamp: 1628092297848
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.43.1-py38h336bac9_0.conda
+  sha256: ac97697184981c4c27a902186ff967b2d4954e02cdf55c551f937c34e6feec8d
+  md5: e3ef4e0d7c502f4dadf9e4008d7f742d
+  depends:
+  - brotli
+  - munkres
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  - unicodedata2 >=14.0.0
+  license: MIT
+  license_family: MIT
+  size: 2130396
+  timestamp: 1696601775083
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+  sha256: 791673127e037a2dc0eebe122dc4f904cb3f6e635bb888f42cbe1a76b48748d9
+  md5: e6085e516a3e304ce41a8ee08b9b89ad
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 596430
+  timestamp: 1694616332835
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hc88da5d_1004.tar.bz2
+  sha256: 25d4a20af2e5ace95fdec88970f6d190e77e20074d2f6d3cef766198b76a4289
+  md5: aab9ddfad863e9ef81229a1f8852211b
+  depends:
+  - libcxx >=11.0.0.rc1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 86690
+  timestamp: 1599590990520
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.6.0-h6da1cb0_0.tar.bz2
+  sha256: 4d772c42477f64be708594ac45870feba3e838977871118eb25e00deb0e9a73c
+  md5: 5a570729c7709399cf8511aeeda6f989
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=12.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 97658
+  timestamp: 1649144191039
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/grpc-cpp-1.45.2-h98c3ada_3.tar.bz2
+  sha256: e56855da85f3d2a0633f0bbe5f62d152f6bd1b824ed2d318ba65b714b8fc300a
+  md5: 4452f3fb92aaecd79632491a63705b0f
+  depends:
+  - abseil-cpp >=20211102.0,<20211102.1.0a0
+  - c-ares >=1.18.1,<2.0a0
+  - libcxx >=13.0.1
+  - libprotobuf >=3.20.1,<3.21.0a0
+  - libzlib >=1.2.11,<2.0.0a0
+  - openssl >=1.1.1o,<1.1.2a
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.11,<1.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3535815
+  timestamp: 1651994014917
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jupyter_core-5.4.0-py38h10201cd_0.conda
+  sha256: 59bdbcc8460b1960bb9261efd6dd204f9fdda0352b8f4727be46782441bc965e
+  md5: 16949eb2a0c3d60cc3f4e10aeada0fe7
+  depends:
+  - platformdirs >=2.5
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 79319
+  timestamp: 1696972750400
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.5-py38h9afee92_1.conda
+  sha256: 1a57135341292d1553b200f97be012e65bd2fbd460906cc922ed4a13b07b13ca
+  md5: 1730b76fb22b82403f5033e1450d9580
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62000
+  timestamp: 1695380499158
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.20.1-h127bd45_0.conda
+  sha256: 7ccdad3d665c2c9586e342fc6d756eeb8ff137419c03fbf34af1cc55de8aed1e
+  md5: 4b0bbb6209ef99080ab4acb1122c5f6b
+  depends:
+  - libcxx >=14.0.6
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=1.1.1s,<1.1.2a
+  license: MIT
+  license_family: MIT
+  size: 1090627
+  timestamp: 1671092094692
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.15-hf2736f0_3.conda
+  sha256: 3d07ba04602617c3084b302c8a6fa30b2e4b20511180f45992b289c312298018
+  md5: bbaac531169fed3e09ae31aff80aa069
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 215466
+  timestamp: 1695969888308
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+  sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
+  md5: de462d5aacda3b30721b512c5da4e742
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 215721
+  timestamp: 1657977558796
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20211102.0-cxx17_h28b99d4_3.tar.bz2
+  sha256: a8ecdcce152b2c57efac2e96903e4161057781cabbb963d7dace413faf382fa5
+  md5: 6e89c094e223c2bcfb481b4f78bdaf1b
+  depends:
+  - libcxx >=14.0.4
+  constrains:
+  - abseil-cpp =20211102.0
+  - libabseil-static =20211102.0=cxx17*
+  - libabseil-static ==99999999999
+  license: Apache-2.0
+  license_family: Apache
+  size: 1032406
+  timestamp: 1661960359618
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-19_osxarm64_openblas.conda
+  sha256: 51e78e3c9fa57f3fec12936b760928715ba0ab5253d02815202f9ec4c2c9255d
+  md5: f50b1fd98593278e18319653cff9c475
+  depends:
+  - libopenblas >=0.3.24,<0.3.25.0a0
+  - libopenblas >=0.3.24,<1.0a0
+  constrains:
+  - libcblas 3.9.0 19_osxarm64_openblas
+  - liblapack 3.9.0 19_osxarm64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 19_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14817
+  timestamp: 1697484577887
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.0.9-h1a8c8d9_9.conda
+  sha256: 53f4a6cc4f5795adf33fda00b86a0e91513c534ae44859754e9c07954d3a7148
+  md5: 82354022c67480c61419b6e47377af89
+  license: MIT
+  license_family: MIT
+  size: 70285
+  timestamp: 1687884697998
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.0.9-h1a8c8d9_9.conda
+  sha256: 2de613dcccbbe40f90a256784ab23f7292aaa0985642ca35496cb9c177d8220b
+  md5: af03c66e8cb688221bdc9e2b0faaa2bf
+  depends:
+  - libbrotlicommon 1.0.9 h1a8c8d9_9
+  license: MIT
+  license_family: MIT
+  size: 29129
+  timestamp: 1687884725821
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.0.9-h1a8c8d9_9.conda
+  sha256: 37e766c0b87d06637bdfc68e072c227ce2dac82b81d26b5f9ac57fb948e2e2b7
+  md5: 8231f81e72b1113eb2ed8d2586c82691
+  depends:
+  - libbrotlicommon 1.0.9 h1a8c8d9_9
+  license: MIT
+  license_family: MIT
+  size: 263314
+  timestamp: 1687884758242
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-19_osxarm64_openblas.conda
+  sha256: 19b1c5e3ddd383ec14540336f4704938218d3c1db4707ae10d5357afb22cccc1
+  md5: 5460a8d1beffd7f63994d891e6a20da4
+  depends:
+  - libblas 3.9.0 19_osxarm64_openblas
+  constrains:
+  - liblapack 3.9.0 19_osxarm64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 19_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14738
+  timestamp: 1697484590682
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-7.87.0-hbe9bab4_0.conda
+  sha256: bf24b3c729e4c13718c3104cafa695816ffaa9ff795ebe709f85e8c0f7e8225a
+  md5: 1db973062fa57d8bbbadfbc0baebe36a
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.47.0,<2.0a0
+  - libssh2 >=1.10.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=1.1.1s,<1.1.2a
+  license: curl
+  license_family: MIT
+  size: 310945
+  timestamp: 1671621889372
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.6-h4653b0c_0.conda
+  sha256: 11d3fb51c14832d9e4f6d84080a375dec21ea8a3a381a1910e67ff9cedc20355
+  md5: 9d7d724faf0413bf1dbc5a85935700c8
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1160232
+  timestamp: 1686896993785
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.19-hb547adb_0.conda
+  sha256: 6a3d188a6ae845a742dc85c5fb3f7eb1e252726cd74f0b8a7fa25ec09db6b87a
+  md5: f8c1eb0e99e90b55965c6558578537cc
+  license: MIT
+  license_family: MIT
+  size: 52841
+  timestamp: 1694924330786
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+  sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
+  md5: 30e4362988a2623e9eb34337b83e01f9
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 96607
+  timestamp: 1597616630749
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h642e427_1.tar.bz2
+  sha256: eb7325eb2e6bd4c291cb9682781b35b8c0f68cb72651c35a5b9dd22707ebd25c
+  md5: 566dbf70fe79eacdb3c3d3d195a27f55
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 100668
+  timestamp: 1598868103393
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.10-hbae9a57_4.tar.bz2
+  sha256: 6a22d6a76b9407cc1e9da7fa39335de8f3feff96602f6088fcc857d546041e31
+  md5: a1f2aca3c5999a24527d6f8a3a8e9320
+  depends:
+  - openssl >=1.1.1l,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1247268
+  timestamp: 1633489533390
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+  md5: 086914b672be056eb70fd4285b6783b6
+  license: MIT
+  license_family: MIT
+  size: 39020
+  timestamp: 1636488587153
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_1.conda
+  sha256: bc8750e7893e693fa380bf2f342d4a5ce44995467cbdf72e56a00e5106b4892d
+  md5: 1ad37a5c60c250bb2b4a9f75563e181c
+  depends:
+  - libgfortran5 13.2.0 hf226fd6_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110095
+  timestamp: 1694172198016
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_1.conda
+  sha256: cb9cb11e49a6a8466ea7556a723080d3aeefd556df9b444b941afc5b54368b22
+  md5: 4480d71b98c87faafab132d33e23135e
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 995733
+  timestamp: 1694172076009
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+  sha256: a42054eaa38e84fc1e5ab443facac4bbc9d1b6b6f23f54b7bf4f1eb687e1d993
+  md5: 3ff1e053dc3a2b8e36b9bfa4256a58d1
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 547541
+  timestamp: 1694475104253
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-19_osxarm64_openblas.conda
+  sha256: f19cff537403c9feed98c7e18259022102b087f2b72a757e8a417476b9cf30c1
+  md5: 3638eacb084c374f41f9efa40d20a47b
+  depends:
+  - libblas 3.9.0 19_osxarm64_openblas
+  constrains:
+  - libcblas 3.9.0 19_osxarm64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 19_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14721
+  timestamp: 1697484603691
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_4.conda
+  sha256: 6f603914fe8633a615f0d2f1383978eb279eeb552079a78449c9fbb43f22a349
+  md5: 9f3dce5d26ea56a9000cd74c034582bd
+  depends:
+  - libcxx >=15
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 20571387
+  timestamp: 1690559110016
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.51.0-hd184df1_0.conda
+  sha256: 141efbe8f646780627d34f35c1316dc5ce9c28aa79406a0c6eba791abde4d9e0
+  md5: bbc8d6defa81887dc055d9e074d751fa
+  depends:
+  - c-ares >=1.18.1,<2.0a0
+  - libcxx >=14.0.6
+  - libev >=4.33,<4.34.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=1.1.1s,<1.1.2a
+  license: MIT
+  license_family: MIT
+  size: 561446
+  timestamp: 1672695999124
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.24-openmp_hd76b1f2_0.conda
+  sha256: 21edfdf620ac5c93571aab452199b6b4622c445441dad88ab4d2eb326a7b91b3
+  md5: aacb05989f358affe1bafd4ea7294db4
+  depends:
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - llvm-openmp >=15.0.7
+  constrains:
+  - openblas >=0.3.24,<0.3.25.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2849225
+  timestamp: 1693784744674
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.39-h76d750c_0.conda
+  sha256: 21ab8409a8e66f9408b96428c0a36a9768faee9fe623c56614576f9e12962981
+  md5: 0078e6327c13cfdeae6ff7601e360383
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: zlib-acknowledgement
+  size: 259412
+  timestamp: 1669075883972
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-3.20.3-hb5ab8b9_0.conda
+  sha256: b87ce43a9258547d3a00c7e966e603eddb675293a5cd2befe1bbfaf44b99262b
+  md5: 4d1dba56d35758211c6bbfc318173f83
+  depends:
+  - libcxx >=14.0.6
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1858629
+  timestamp: 1681043309380
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.18-h27ca646_1.tar.bz2
+  sha256: 1d95fe5e5e6a0700669aab454b2a32f97289c9ed8d1f7667c2ba98327a6f05bc
+  md5: 90859688dbca4735b74c02af14c4c793
+  license: ISC
+  size: 324912
+  timestamp: 1605135878892
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.43.2-h091b4b1_0.conda
+  sha256: 93bec176e05c15a126c1c1c50b3aaef224829b81062bfd48716c5affde950a3f
+  md5: 1d8208ba1b6a8c61431e77dc4e5c8fb9
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Unlicense
+  size: 809129
+  timestamp: 1696959090990
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.10.0-hb80f160_3.tar.bz2
+  sha256: 8d05d4ef3867792967857b1599c65b4d5637fedef119665dc8b05c0f15011f7c
+  md5: 60f87fd8eb881a4c8094824dd112140c
+  depends:
+  - libzlib >=1.2.12,<2.0.0a0
+  - openssl >=1.1.1q,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 223057
+  timestamp: 1660346678860
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.16.0-h1a74c4f_2.tar.bz2
+  sha256: d9dbfae444ddaf9c4e99a943303d5f6807b5c0fd80af3daef53684550fda9f21
+  md5: 8949545ae9641f7483a88abc3635b07a
+  depends:
+  - libcxx >=14.0.4
+  - libevent >=2.1.10,<2.1.11.0a0
+  - libzlib >=1.2.12,<2.0.0a0
+  - openssl >=1.1.1q,<1.1.2a
+  license: Apache-2.0
+  license_family: APACHE
+  size: 342132
+  timestamp: 1663078815798
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.6.0-ha8a6c65_2.conda
+  sha256: b18ef36eb90f190db22c56ae5a080bccc16669c8f5b795a6211d7b0c00c18ff7
+  md5: 596d6d949bab9a75a492d451f521f457
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=15.0.7
+  - libdeflate >=1.19,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: HPND
+  size: 246265
+  timestamp: 1695661829324
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-h1a8c8d9_0.tar.bz2
+  sha256: a3faddac08efd930fa3a1cc254b5053b4ed9428c49a888d437bf084d403c931a
+  md5: f8c9c41a122ab3abdf8943b13f4957ee
+  license: MIT
+  license_family: MIT
+  size: 103492
+  timestamp: 1667316405233
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.3.2-hb547adb_0.conda
+  sha256: a159b848193043fb58465ae6a449361615dadcf27babfe0b18db2bd3eb59e958
+  md5: 85dbc11098cdbe4244cd73f29a3ab795
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 273844
+  timestamp: 1694709510635
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.15-hf346824_0.conda
+  sha256: 6eaa87760ff3e91bb5524189700139db46f8946ff6331f4e571e4a9356edbb0d
+  md5: 988d5f86ab60fa6de91b3ee3a88a3af9
+  depends:
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 334770
+  timestamp: 1682082734262
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
+  sha256: ab1c8aefa2d54322a63aaeeefe9cf877411851738616c4068e0dccc66b9c758a
+  md5: 1a47f5236db2e06a320ffa0392f81bd8
+  constrains:
+  - zlib 1.2.13 *_5
+  license: Zlib
+  license_family: Other
+  size: 48102
+  timestamp: 1686575426584
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-17.0.3-hcd81f8e_0.conda
+  sha256: e744ecb793c1e991e93855b6e6b26c43b2b6fef2ecc340f9f54f7a650ed5e41a
+  md5: bc4b8795976aae9c1ea5eb4ba26eafd8
+  constrains:
+  - openmp 17.0.3|17.0.3.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 274678
+  timestamp: 1697652011036
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.40.1-py38h761d82c_0.conda
+  sha256: b418066d867dd4f02064330f3f78bea0e0815b65521f02435cc404a754053d29
+  md5: 064a87bab47c90eb0018849b6ed079b9
+  depends:
+  - libcxx >=15.0.7
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 260771
+  timestamp: 1687806838843
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+  sha256: fc343b8c82efe40819b986e29ba748366514e5ab94a1e1138df195af5f45fa24
+  md5: 45505bec548634f7d05e02fb25262cb9
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 141188
+  timestamp: 1674727268278
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.3-py38hb192615_1.conda
+  sha256: 8eff6d050dda7a325b9c0c02c3d3f89a5aafa06718af82afad2f39e07988aa54
+  md5: 44bdf93e4d7019f5a64eff659ad86801
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23567
+  timestamp: 1695367744238
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.7.3-py38hef9d0d7_0.conda
+  sha256: 9d78cd73e27928b38a0e726a967220042f9c630b950c5dd0215d618e12c57924
+  md5: 5994835b96059c83b3c994c75ebe05c0
+  depends:
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - importlib-resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=15.0.7
+  - numpy >=1.20
+  - numpy >=1.22.4,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python-dateutil >=2.7
+  - python_abi 3.8.* *_cp38
+  license: LicenseRef-PSF-2.0 and CC0-1.0
+  license_family: PSF
+  size: 6637320
+  timestamp: 1695077431448
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.0.6-py38h9afee92_0.conda
+  sha256: e20156d4fed9c0e00c6042ddcd0f9438b0aa31752d44b3c72c0895c8f9260c17
+  md5: 8e7c641958a28650429bf36c523cef4a
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  license: Apache-2.0
+  license_family: Apache
+  size: 189141
+  timestamp: 1695464593280
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h7ea286d_0.conda
+  sha256: 017e230a1f912e15005d4c4f3d387119190b53240f9ae0ba8a319dd958901780
+  md5: 318337fb9d0c53ba635efb7888242373
+  license: X11 AND BSD-3-Clause
+  size: 799196
+  timestamp: 1686077139703
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.57.1-py38h11be589_0.conda
+  sha256: 66b063ffed612b30e1064d6654d2451f82eaedaf381dd9d6eb9d48a83cef205d
+  md5: 05d4c031cc0aad078ae94d7e14d1bce9
+  depends:
+  - importlib-metadata
+  - libcxx >=15.0.7
+  - llvm-openmp >=15.0.7
+  - llvm-openmp >=16.0.6
+  - llvmlite >=0.40.0,<0.41.0a0
+  - numpy >=1.21.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  constrains:
+  - libopenblas >=0.3.18, !=0.3.20
+  - cuda-python >=11.6
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.25
+  - tbb >=2021.6.0
+  - cuda-version >=10.2
+  - scipy >=1.0
+  - cudatoolkit >=10.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4100714
+  timestamp: 1687805414358
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.24.4-py38ha84db1f_0.conda
+  sha256: 5b3236885775a2b3c6d3396d6c29a4d4ce7687ca5534ab15ad7d6104a751dbc6
+  md5: d33566c9c3ed5938f1d30747e8787a7d
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=15.0.7
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5589840
+  timestamp: 1687809103359
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.0-h4c1507b_3.conda
+  sha256: a6998c0da4643a84dc7c0b3a9e5137db258619ea922317bb7d9ae64f54b4a9ed
+  md5: 4127dd217a010d9c6cbefdaae07d9f19
+  depends:
+  - libcxx >=15.0.7
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 323335
+  timestamp: 1694708748389
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-1.1.1w-h53f4e23_0.conda
+  sha256: 0d4f19426a152ea4ffb9926ffe2acae3362669ba9504d7eb02c22d23b203442b
+  md5: 38578a8fcd49146fb4bc13a1fca305b1
+  depends:
+  - ca-certificates
+  license: OpenSSL
+  license_family: Apache
+  size: 1652804
+  timestamp: 1694461793409
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-1.7.5-h96f55be_0.tar.bz2
+  sha256: 3fd53be034721bd6cb9ca9e2a3f99223c89d8cb5e99010d4eb8883fd570a10d9
+  md5: 33e69b3553a3c60a004bd983b819f821
+  depends:
+  - libcxx >=13.0.1
+  - libprotobuf >=3.20.1,<3.21.0a0
+  - libzlib >=1.2.12,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.9,<1.2.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 418958
+  timestamp: 1655507170387
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-1.2.5-py38h3777fb4_0.tar.bz2
+  sha256: 41ca0ee8f498fceeee44277953c639e27c6f867510f03a053aa90f4fdc69e2a5
+  md5: 7cb0f18493d326852f65b55cca2448c6
+  depends:
+  - libcxx >=11.1.0
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.7.3
+  - python_abi 3.8.* *_cp38
+  - pytz >=2017.2
+  - setuptools <60.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11013377
+  timestamp: 1624391686852
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandoc-3.1.3-hce30654_0.conda
+  sha256: 858a923c8b9082791b2c13c2ff2ae87e28dd2e2655f56117c8ecb7d366002bc7
+  md5: 7edcc75acdac60dba441b229c0ec66ee
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 26314364
+  timestamp: 1686225215970
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.1.0-py38h06aea99_0.conda
+  sha256: 7c0b8171d39f2fff98947a06fd15014340a824d71cd35f4466046892813af698
+  md5: 3b8fddb6d2ca6df79f4d583193a2dc00
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 46280107
+  timestamp: 1697424042385
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.5-py38hb192615_1.conda
+  sha256: 0a30d1fd9af070f6800ba7abb1598ac9595b24a1f8dafa36513029e8dbde2433
+  md5: 5fab624fa36ec15f74cba8bf548bbcbc
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 368555
+  timestamp: 1695367632413
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
+  sha256: 9da9e6f5d51dff6ad2e4ee0874791437ba952e0a6249942273f0fedfd07ea826
+  md5: d3f26c6494d4105d4ecb85203d687102
+  license: MIT
+  license_family: MIT
+  size: 5696
+  timestamp: 1606147608402
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-5.0.0-py38h535b32c_35_cpu.tar.bz2
+  sha256: 6da0c850ea4625074114def317eda63281819cab0293ecf343fb4e373c9304e1
+  md5: 75ac715616c393fdd05b3d20778c8b49
+  depends:
+  - arrow-cpp 5.0.0 py38hcc5bc27_35_cpu
+  - libcxx >=13.0.1
+  - numpy >=1.16,<2.0a0
+  - numpy >=1.19.5,<2.0a0
+  - parquet-cpp 1.5.1.*
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  constrains:
+  - arrow-cpp-proc * cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 2390928
+  timestamp: 1655822033123
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.8.15-hf452327_0_cpython.conda
+  sha256: 9baa178c0934ba960d531175cb279a6c37b72de0141f17501dbe441a68a108d7
+  md5: 4019c257ab32f347b073138f34bd81e6
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.40.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.3,<7.0a0
+  - openssl >=1.1.1s,<1.1.2a
+  - readline >=8.1.2,<9.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.8.* *_cp38
+  license: Python-2.0
+  size: 10133181
+  timestamp: 1669107631388
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-snappy-0.6.0-py38hb0889cc_2.tar.bz2
+  sha256: 2bd8d08985f7ffeb7423294f6eb357219b7c9ddd7d4b7dcc5681ce0f10578071
+  md5: 46d663976fe18036f827a70aa50c1813
+  depends:
+  - libcxx >=12.0.1
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  - snappy >=1.1.8,<1.2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 31084
+  timestamp: 1649520199757
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.8-4_cp38.conda
+  sha256: 81a67cd91e7f07af481bae8cdea913bccab9a1b6155b2c81d21fbf31efe846a0
+  md5: 69175aa707e394d51c35dda08bb339d9
+  constrains:
+  - python 3.8.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6461
+  timestamp: 1695147757654
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.1-py38hb192615_1.conda
+  sha256: a4bcd94eda8611ade946a52cb52cf60ca6aa4d69915a9c68a9d9b7cbf02e4ac0
+  md5: 72ee6bc5ee0182fb7c5f26461504cbf5
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 158422
+  timestamp: 1695373866893
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-24.0.1-py38hb72be9f_1.tar.bz2
+  sha256: 5c29e09e2c5e4ab7c6aba4cf771cbfbd886669ddb765c0e0cc81f8fa4b434206
+  md5: d1885d7794ad09a435da312fe1e6bcc2
+  depends:
+  - libcxx >=14.0.4
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  size: 469298
+  timestamp: 1666828863944
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2022.04.01-h6b3803e_0.tar.bz2
+  sha256: 27e74cad746f08fcc987c1f3677fcedf719dd29275df20f1d528da2361204a92
+  md5: 39dc8f13bf3483699ad0ac655b059a39
+  depends:
+  - libcxx >=12.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 191435
+  timestamp: 1648884115940
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+  sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
+  md5: 8cbb776a2f641b943d413b3e19df71f4
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 250351
+  timestamp: 1679532511311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.10.6-py38h51b07bf_0.conda
+  sha256: f4964d947be422b59efb8a057c95af23097a9a57335823e674ea6536fc2a3ac3
+  md5: 8a81e16830700ab738fec23db12c5da0
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  license: MIT
+  license_family: MIT
+  size: 289476
+  timestamp: 1697072813649
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.10.1-py38h038e806_3.conda
+  sha256: 21c104d9a10ee212f76c5384eb82a6628be7b57c5969f33c33e03e44f8fcf12e
+  md5: a690e8845ed7946f63ed7d4719a42dcb
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=15.0.7
+  - libgfortran >=5
+  - libgfortran5 >=12.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy >=1.21.6,<1.27
+  - numpy >=1.21.6,<2.0a0
+  - pooch
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  constrains:
+  - libopenblas <0.3.26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14150669
+  timestamp: 1683902234351
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/setuptools-59.8.0-py38h10201cd_1.tar.bz2
+  sha256: 566f255bf27089440b14610a5c48cef3360f11fecd537c7bda948cf17795a2e6
+  md5: 6110e5f27127fadf22a9f1df9e165b6d
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  license: MIT
+  license_family: MIT
+  size: 1045503
+  timestamp: 1648692164404
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
+  sha256: dfae03cd2339587871e53b42833657faa4c9e42e3e2c56ee9e32bc60797c7f62
+  md5: ac82a611d1a67a598096ebaa857198e3
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33879
+  timestamp: 1678534968831
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/thrift-0.19.0-py38he333c0f_1.conda
+  sha256: 5877239990dce1e9cc8ba21c014631539daeaa72e45aa194598437d4a11a3aba
+  md5: 8b114f0893cdc231edc789ebb1f7b818
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  - six >=1.7.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 130222
+  timestamp: 1695546467140
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hb31c410_0.conda
+  sha256: 6df6ff49dba487eb891ddc0099642a36af2fe3929ed8023f76b745f0485c54a6
+  md5: aa913a828b65f30ee3aba9c59bb0b514
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3223549
+  timestamp: 1695506653047
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.1-py38h33210d7_3.tar.bz2
+  sha256: eaeeab8204d2a4ab6dafc9d7503048c9995aa4d6ca05f99aaed97b8c7ed5ac24
+  md5: a936063da446a0b59c8f574fe2cbb5fa
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  license: Apache-2.0
+  license_family: Apache
+  size: 664987
+  timestamp: 1648827496241
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-15.1.0-py38hb192615_0.conda
+  sha256: 98f9fbfbc9432b55e25a1bfaff80e58cfdf496afceb39ff91d9c1277a6775674
+  md5: c5d1b1c1e6730971ca8efbe3348ac679
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python >=3.8,<3.9.0a0 *_cpython
+  - python_abi 3.8.* *_cp38
+  license: Apache-2.0
+  license_family: Apache
+  size: 376372
+  timestamp: 1695848547395
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
+  sha256: 02c313a1cada46912e5b9bdb355cfb4534bfe22143b4ea4ecc419690e793023b
+  md5: ca73dc4f01ea91e44e3ed76602c5ea61
+  license: MIT
+  license_family: MIT
+  size: 13667
+  timestamp: 1684638272445
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
+  sha256: d9a2fb4762779994718832f05a7d62ab2dcf6103a312235267628b5187ce88f7
+  md5: 6738b13f7fadc18725965abdd4129c36
+  license: MIT
+  license_family: MIT
+  size: 18164
+  timestamp: 1610071737668
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+  sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
+  md5: 39c6b54e94014701dd157f4f576ed211
+  license: LGPL-2.1 and GPL-2.0
+  size: 235693
+  timestamp: 1660346961024
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+  sha256: 93181a04ba8cfecfdfb162fc958436d868cc37db504c58078eab4c1a3e57fbb7
+  md5: 4bb3f014845110883a3c5ee811fd84b4
+  license: MIT
+  license_family: MIT
+  size: 88016
+  timestamp: 1641347076660
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h965bd2d_0.conda
+  sha256: 06abddc92d0bf83cd9faf25f26c98d7c2cc681cb50504011580b0584cf3cb1c5
+  md5: f460bbcb0ec8dc77989288fe8caa0f84
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 287460
+  timestamp: 1697056868401
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
+  sha256: de0ee1e24aa6867058d3b852a15c8d7f49f262f5828772700c647186d4a96bbe
+  md5: a08383f223b10b71492d27566fafbf6c
+  depends:
+  - libzlib 1.2.13 h53f4e23_5
+  license: Zlib
+  license_family: Other
+  size: 79577
+  timestamp: 1686575471024
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
+  sha256: 7e1fe6057628bbb56849a6741455bbb88705bae6d6646257e57904ac5ee5a481
+  md5: 5b212cfb7f9d71d603ad891879dc7933
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 400508
+  timestamp: 1693151393180
+- conda: https://conda.anaconda.org/conda-forge/win-64/abseil-cpp-20211102.0-h36ffca9_3.tar.bz2
+  sha256: d8044d84393e581736bafdde511b0a71afb8c25d89202b2abb3da8b0ba04bb98
+  md5: f6769229f6b4a769fc9359d281795874
+  depends:
+  - libabseil-static 20211102.0 cxx11_h58a5ce6_3
+  license: Apache-2.0
+  license_family: Apache
+  size: 13236
+  timestamp: 1661960246749
+- conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py38h91455d4_4.conda
+  sha256: 775e8b5cc98e0961d33ef5f31f46b55b689d523bf388d4946e7f52049182cf0e
+  md5: 1e2ce17f95a25dda494137ce93618622
+  depends:
+  - cffi >=1.0.1
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 33876
+  timestamp: 1695387222911
+- conda: https://conda.anaconda.org/conda-forge/win-64/arrow-cpp-5.0.0-py38h0c97e59_35_cpu.tar.bz2
+  sha256: 3d4577a46775c7ebd8a1f821c08ba0bee7cebba9f78f232664f0e7f094b80a64
+  md5: d24e91a438731e5600fd742624fdfedd
+  depends:
+  - aws-sdk-cpp >=1.8.186,<1.8.187.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-ares >=1.18.1,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.6.0,<0.7.0a0
+  - grpc-cpp >=1.45.2,<1.46.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libprotobuf >=3.20.1,<3.21.0a0
+  - libthrift >=0.16.0,<0.16.1.0a0
+  - libutf8proc >=2.7.0,<3.0a0
+  - libzlib >=1.2.12,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - numpy >=1.16,<2.0a0
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.9,<1.2.0a0
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  - zstd >=1.5.2,<1.6.0a0
+  - libutf8proc <2.9
+  constrains:
+  - arrow-cpp-proc * cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 15902140
+  timestamp: 1655703138685
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.5.11-he19cf47_0.tar.bz2
+  sha256: f9b900e57c7fdaf1c4ad0ce4037f5ac4e4aeaa7be9733525a2dc7b9271e7b0d3
+  md5: c8b314ff705e4de32640c748e5b9c8d2
+  depends:
+  - aws-c-common >=0.6.2,<0.6.3.0a0
+  - openssl >=1.1.1k,<1.1.2a
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: Apache-2.0
+  license_family: Apache
+  size: 36546
+  timestamp: 1623801872278
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.6.2-h8ffe710_0.tar.bz2
+  sha256: 356e66467c1d08936258937a90f6105081b45376918efe23811a7343acceb6b7
+  md5: 7eb3e6859d0da38fe0bff50391e7f9dc
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: Apache-2.0
+  license_family: Apache
+  size: 162918
+  timestamp: 1623317025800
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.2.7-h70e1b0c_13.tar.bz2
+  sha256: f5ff572e107531f39741400d6de9f751bb3c5945b077cf367a4fae5b28d79280
+  md5: c5946a20e3d686659e2173f4921160a7
+  depends:
+  - aws-c-common >=0.6.2,<0.6.3.0a0
+  - aws-c-io >=0.10.5,<0.10.6.0a0
+  - aws-checksums >=0.1.11,<0.1.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: Apache-2.0
+  license_family: Apache
+  size: 48367
+  timestamp: 1624281730198
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.10.5-h2fe331c_0.tar.bz2
+  sha256: 13893b2a57edd19a062e838d862e7ea212eab0fa483d668c70edd33379f3c0c0
+  md5: d38ee034f93fb73f3f222d1be1e9c3a3
+  depends:
+  - aws-c-cal >=0.5.11,<0.5.12.0a0
+  - aws-c-common >=0.6.2,<0.6.3.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: Apache-2.0
+  license_family: Apache
+  size: 130288
+  timestamp: 1623958019544
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.11-h1e232aa_7.tar.bz2
+  sha256: 67e861923675dc1be237e492961104369cd148b0f752749d4bd1de7bd58a9504
+  md5: c9fde0c43dce1a8eecbef5368396742c
+  depends:
+  - aws-c-common >=0.6.2,<0.6.3.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: Apache-2.0
+  license_family: Apache
+  size: 52515
+  timestamp: 1623336940848
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.8.186-h93d3aa3_4.tar.bz2
+  sha256: d131771fab24f3d58c6e3e553e877f978c8d05182f418affe7daac840b3c3a5a
+  md5: b67b8f43c04fac75e8932d6023b22ef2
+  depends:
+  - aws-c-common >=0.6.2,<0.6.3.0a0
+  - aws-c-event-stream >=0.2.7,<0.2.8.0a0
+  - libcurl >=7.86.0,<9.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=1.1.1q,<1.1.2a
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 5688159
+  timestamp: 1667033271655
+- conda: https://conda.anaconda.org/conda-forge/win-64/bokeh-2.3.3-py38haa244fe_0.tar.bz2
+  sha256: 2d4e3287b09cb32687657f3768900774efe5af87cf8affc56db295692483effc
+  md5: 02131c196d3c3fe942186c7761bc12ee
+  depends:
+  - jinja2 >=2.7
+  - numpy >=1.11.3
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.1
+  - python_abi 3.8.* *_cp38
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8677161
+  timestamp: 1625757533357
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.0.9-hcfcfb64_9.conda
+  sha256: 7bfc2b4002463dd69d140ab1b46bb36987581252d19af08b5eb9611e339cd7a3
+  md5: 5275e2634840f6d156934a16b7c0c813
+  depends:
+  - brotli-bin 1.0.9 hcfcfb64_9
+  - libbrotlidec 1.0.9 hcfcfb64_9
+  - libbrotlienc 1.0.9 hcfcfb64_9
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 20278
+  timestamp: 1687886707104
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.0.9-hcfcfb64_9.conda
+  sha256: 08c1431f7b4946a568d8f44d452a9358a841eaa58dd64dee66d8ac7bf1092673
+  md5: ba8ae6c24cf47da3fb73270e4f119f08
+  depends:
+  - libbrotlidec 1.0.9 hcfcfb64_9
+  - libbrotlienc 1.0.9 hcfcfb64_9
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 22498
+  timestamp: 1687886681486
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.0.9-py38hd3f51b4_9.conda
+  sha256: 2f4befbc9ceb13704b447264c0123c29fe71e26359a7c7a3fe4e1c78b2a7595f
+  md5: b451fb48b1337ceb34b7b39de0bc09c8
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libbrotlicommon 1.0.9 hcfcfb64_9
+  license: MIT
+  license_family: MIT
+  size: 308233
+  timestamp: 1687887065506
+- conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h8ffe710_4.tar.bz2
+  sha256: 5389dad4e73e4865bb485f460fc60b120bae74404003d457ecb1a62eb7abf0c1
+  md5: 7c03c66026944073040cb19a4f3ec3c9
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 152247
+  timestamp: 1606605223049
+- conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.20.1-hcfcfb64_1.conda
+  sha256: 817b2733caef6f8513ed6dc9a1b5883ddc9ac303eaf1971e4d4ec73080f6ab99
+  md5: 0a45278f9b791a68dbe4acc234fa8a26
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 112068
+  timestamp: 1697956205060
+- conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.7.22-h56e8100_0.conda
+  sha256: b85a6f307f8e1c803cb570bdfb9e4d811a361417873ecd2ecf687587405a72e0
+  md5: b1c2327b36f1a25d96f2039b0d3e3739
+  license: ISC
+  size: 150013
+  timestamp: 1690026269050
+- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.16.0-py38h91455d4_0.conda
+  sha256: 0704377274cfe0b3a5c308facecdeaaf2207303ee847842a4bbd3f70b7331ddc
+  md5: e9b2ac14b9c3d3eaeb2f69745e021e49
+  depends:
+  - pycparser
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 234905
+  timestamp: 1696002150251
+- conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.1.1-py38hb1fd069_1.conda
+  sha256: 0b336e92b21182e89b8d1bc59e3fc4032b3d86bbb4bb93771942c09d9ce233e7
+  md5: 13df3a01683e407c2745cc0b6aa6beca
+  depends:
+  - numpy >=1.16
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 173813
+  timestamp: 1695554707017
+- conda: https://conda.anaconda.org/conda-forge/win-64/cramjam-2.7.0-py38hf90c7e5_1.conda
+  sha256: 3974eb4205a6f131a9c2d8a4cd9a77f4527d8cea5570ea6b624e70f24bca96b9
+  md5: 8474caeaf1db56bc7b622d56e6e72071
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: MIT
+  license_family: MIT
+  size: 1124119
+  timestamp: 1695451308139
+- conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-0.12.2-py38h91455d4_1.conda
+  sha256: 5e577c9351458f1997a86cd828f73317fc58170001dcab198d8b1cb939667985
+  md5: 171567088e7fed8a4a9c7d7b698e77e1
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - toolz >=0.10.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296240
+  timestamp: 1695545746609
+- conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.0-py38hd3f51b4_1.conda
+  sha256: 97a6d0cc1e8fc5b7ac0735d6c3f090e1c89b001dbab85f58fcc890a3068e0534
+  md5: 7a11964db637a30b25586fdf5e5d3b5c
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 3367019
+  timestamp: 1695534783142
+- conda: https://conda.anaconda.org/conda-forge/win-64/fastparquet-0.7.1-py38h6f4d8f0_0.tar.bz2
+  sha256: eda389a06f77dc83528115e7c0448529b287f41ad8cdf53e4b8a362ef6e31d23
+  md5: b98868c6f5d5374b44221014c53f9899
+  depends:
+  - cramjam >=2.3.0
+  - fsspec
+  - numpy >=1.18.5,<2.0a0
+  - pandas >=1.0.0
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - thrift >=0.11
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 491495
+  timestamp: 1628092511308
+- conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.43.1-py38h91455d4_0.conda
+  sha256: 521120026b5e7204672e7f24b23edf56271963eba87a6ad3aef8f292c0781924
+  md5: d960b3ead49389adc21a688a75cd30ef
+  depends:
+  - brotli
+  - munkres
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - ucrt >=10.0.20348.0
+  - unicodedata2 >=14.0.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1836143
+  timestamp: 1696601840575
+- conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+  sha256: 2c53ee8879e05e149a9e525481d36adfd660a6abda26fd731376fa64ff03e728
+  md5: 3761b23693f768dc75a8fd0a73ca053f
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-only OR FTL
+  size: 510306
+  timestamp: 1694616398888
+- conda: https://conda.anaconda.org/conda-forge/win-64/gflags-2.2.2-ha925a31_1004.tar.bz2
+  sha256: d2dbb918efa9c89ead501347cce753bdbac3f5426d42ae5f48eee73790757f54
+  md5: e9442160f56fa442d4ff3eb2e4cf0f22
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 82263
+  timestamp: 1594304231182
+- conda: https://conda.anaconda.org/conda-forge/win-64/glog-0.6.0-h4797de2_0.tar.bz2
+  sha256: 482167f378c66ecad9debf13e642013617931fc80971fb6e7d225493dbbfb90b
+  md5: fdc11ab9a621f009995e89f52bea3004
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 97568
+  timestamp: 1649145307909
+- conda: https://conda.anaconda.org/conda-forge/win-64/grpc-cpp-1.45.2-hb22af2e_3.tar.bz2
+  sha256: 742894a5844179859f1d438e3355218d8b187ee680551152c4095e5cd153ba82
+  md5: d4efae7ffc05750ac17265a7d0c435de
+  depends:
+  - abseil-cpp >=20211102.0,<20211102.1.0a0
+  - c-ares >=1.18.1,<2.0a0
+  - libprotobuf >=3.20.1,<3.21.0a0
+  - libzlib >=1.2.11,<2.0.0a0
+  - openssl >=1.1.1o,<1.1.2a
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  - zlib >=1.2.11,<1.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 27684358
+  timestamp: 1651994723377
+- conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2023.2.0-h57928b3_50497.conda
+  sha256: dd9fded25ebe5c66af30ac6e3685146efdc2d7787035f01bfb546b347f138f6f
+  md5: a401f3cae152deb75bbed766a90a6312
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 2523079
+  timestamp: 1698351323119
+- conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-2.4-py38haa244fe_3.conda
+  sha256: d598a96a1c235c4ccbb32165c9d0bc24cc96c049c015876e442b5456c0fb9f54
+  md5: 4a682a2f267deb4c541d23ee3213f56e
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33040
+  timestamp: 1695398003277
+- conda: https://conda.anaconda.org/conda-forge/win-64/jupyter_core-5.4.0-py38haa244fe_0.conda
+  sha256: 596c88925a6446c5c8428850cf56cc9e35c4252080a9e8e7b2d21205e119cac3
+  md5: 07f324cd5b8186147a3f8d1b50474b5f
+  depends:
+  - platformdirs >=2.5
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 95224
+  timestamp: 1696972851588
+- conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.5-py38hb1fd069_1.conda
+  sha256: 6b46ec21485de6480ef2dcd5bfb123cc9c9ab7a48d1b7003fcb50fe4a2c582ba
+  md5: 19a5ecd89c16b22db1d1830e93392aab
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55790
+  timestamp: 1695380620365
+- conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.20.1-h6609f42_0.conda
+  sha256: 043d639c039dbb19e22577b832cc9124c54f50e3216b498e2cc9061c5b83da88
+  md5: a962b5937824124553d53bd9f535cc71
+  depends:
+  - openssl >=1.1.1s,<1.1.2a
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 715320
+  timestamp: 1671092368033
+- conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.15-h67d730c_3.conda
+  sha256: 8819d74571b6321e0ed93b07c19b4fd9a9b669df3fdd797ab4798ab7c684ae1d
+  md5: f92e86636451e3f6cea03e395346fa90
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 498833
+  timestamp: 1695969944045
+- conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+  sha256: f4f39d7f6a2f9b407f8fb567a6c25755270421731d70f0ff331f5de4fa367488
+  md5: 1900cb3cab5055833cfddb0ba233b074
+  depends:
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30037
+  license: Apache-2.0
+  license_family: Apache
+  size: 194365
+  timestamp: 1657977692274
+- conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-static-20211102.0-cxx11_h58a5ce6_3.tar.bz2
+  sha256: 2102f36284cbd8f8bd2f4d8b430cfbf59b2ecbece9b1df9a12ffb5ae2fe26e0c
+  md5: 8df9529daef223743d825946657bdbdf
+  depends:
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30037
+  constrains:
+  - libabseil =20211102.0=cxx11*
+  - abseil-cpp =20211102.0
+  - libabseil ==99999999999
+  license: Apache-2.0
+  license_family: Apache
+  size: 2392437
+  timestamp: 1661960228727
+- conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-19_win64_mkl.conda
+  sha256: 915eae5e0dedbf87733a0b8c6f410678c77111a3fb26ca0a272e11ff979e7ef2
+  md5: 4f8a1a63cfbf74bc7b2813d9c6c205be
+  depends:
+  - mkl 2023.2.0 h6a75c08_50496
+  constrains:
+  - liblapack 3.9.0 19_win64_mkl
+  - libcblas 3.9.0 19_win64_mkl
+  - liblapacke 3.9.0 19_win64_mkl
+  - blas * mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4984180
+  timestamp: 1697485304263
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.0.9-hcfcfb64_9.conda
+  sha256: adef98f4013859c111da28ff1f66c2c65e90213fe8bac78b7fc83a15e26bc955
+  md5: 5e0f7bd6f1d0747abd5da59cffb6f533
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 72530
+  timestamp: 1687886570242
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.0.9-hcfcfb64_9.conda
+  sha256: 12880edf7865c7acb72c8501ef71874a65ee5c7960c19cf21883390bc02860bb
+  md5: 4c502e4846bdc22b944ab9aa5a55a58f
+  depends:
+  - libbrotlicommon 1.0.9 hcfcfb64_9
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 32397
+  timestamp: 1687886606813
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.0.9-hcfcfb64_9.conda
+  sha256: d8b1ee384d368aa72f7806f771a470e9676149c57f0d12876aff6e45079745c1
+  md5: 19029748649ae0d48871d7012918efef
+  depends:
+  - libbrotlicommon 1.0.9 hcfcfb64_9
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 235953
+  timestamp: 1687886643790
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-19_win64_mkl.conda
+  sha256: 66c8934bf8ead1e3ab3653155697a7d70878e96115742b681aac16d9bd25dd3d
+  md5: 1b9ede5cff953aa1a5f4d9f8ec644972
+  depends:
+  - libblas 3.9.0 19_win64_mkl
+  constrains:
+  - liblapack 3.9.0 19_win64_mkl
+  - liblapacke 3.9.0 19_win64_mkl
+  - blas * mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4984046
+  timestamp: 1697485351545
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.1.2-h68f0423_0.conda
+  sha256: a9d21b363c6d3c81ec85903f86989157e7d93d8f247e023ff3b3f69789115a72
+  md5: 94b9b7d0e882461fdb72d8d4e7441746
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libssh2 >=1.10.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: curl
+  license_family: MIT
+  size: 313345
+  timestamp: 1685448211604
+- conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.19-hcfcfb64_0.conda
+  sha256: e2886a84eaa0fbeca1d1d810270f234431d190402b4a79acf756ca2d16000354
+  md5: 002b1b723b44dbd286b9e3708762433c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 153203
+  timestamp: 1694922596415
+- conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+  sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
+  md5: 2c96d1b6915b408893f9472569dee135
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 42063
+  timestamp: 1636489106777
+- conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
+  sha256: 2e8c4bb7173f281a8e13f333a23c9fb7a1c86d342d7dccdd74f2eb583ddde450
+  md5: 87da045f6d26ce9fe20ad76a18f6a18a
+  depends:
+  - libxml2 >=2.11.5,<2.14.0a0
+  - pthreads-win32
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2578462
+  timestamp: 1694533393675
+- conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-h8ffe710_0.tar.bz2
+  sha256: 657c2a992c896475021a25faebd9ccfaa149c5d70c7dc824d4069784b686cea1
+  md5: 050119977a86e4856f0416e2edcf81bb
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: GPL and LGPL
+  size: 714518
+  timestamp: 1652702326553
+- conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+  sha256: 4e7808e3098b4b4ed7e287f63bb24f9045cc4d95bfd39f0db870fc2837d74dff
+  md5: 3f1b948619c45b1ca714d60c7389092c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 822966
+  timestamp: 1694475223854
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-19_win64_mkl.conda
+  sha256: e53093eab7674528e9eafbd5efa28f3170ec1388b8df6c9b8343760696f47907
+  md5: 574e6e8bcc85df2885eb2a87d31ae005
+  depends:
+  - libblas 3.9.0 19_win64_mkl
+  constrains:
+  - libcblas 3.9.0 19_win64_mkl
+  - liblapacke 3.9.0 19_win64_mkl
+  - blas * mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4984073
+  timestamp: 1697485397401
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.39-h19919ed_0.conda
+  sha256: 1f139a72109366ba1da69f5bdc569b0e6783f887615807c02d7bfcc2c7575067
+  md5: ab6febdb2dbd9c00803609079db4de71
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: zlib-acknowledgement
+  size: 343883
+  timestamp: 1669076173145
+- conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-3.20.3-h12be248_0.conda
+  sha256: c272d04d95e192a0c0c4268dbaec66a6a747600c6c3e380e260a6b114e518c11
+  md5: 286cbb5c6639e7a15c2576d30c47c32c
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2041058
+  timestamp: 1681043194605
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.18-h8d14728_1.tar.bz2
+  sha256: ecc463f0ab6eaf6bc5bd6ff9c17f65595de6c7a38db812222ab8ffde0d3f4bc2
+  md5: 5c1fb45b5e2912c19098750ae8a32604
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: ISC
+  size: 713431
+  timestamp: 1605135918736
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.43.2-hcfcfb64_0.conda
+  sha256: 54cc0f0591354e4f23395ee08ca44efe584ad6df57111358d5bcb4b10259cb2e
+  md5: a4a81906f6ce911113f672973777f305
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 846363
+  timestamp: 1696959271392
+- conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.10.0-h680486a_3.tar.bz2
+  sha256: 1075fb64238aa0657752e05659542edd8f12168c14f7d00e0b105b77b1bc0c9c
+  md5: 3b2aa0d4ede640c471bd0e8f122fcbd5
+  depends:
+  - libzlib >=1.2.12,<2.0.0a0
+  - openssl >=1.1.1q,<1.1.2a
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 233343
+  timestamp: 1660347260357
+- conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.16.0-h9f558f2_2.tar.bz2
+  sha256: 98a4ae9eb3588071f8dd868c8dd19f011601ffeae21a9e756a2803fedebc2326
+  md5: 0b49bcb47e1a3c55a098cc3e78f3ee8f
+  depends:
+  - libzlib >=1.2.12,<2.0.0a0
+  - openssl >=1.1.1q,<1.1.2a
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 898013
+  timestamp: 1663078902505
+- conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-h6e2ebb7_2.conda
+  sha256: f7b50b71840a5d8edd74a8bccf0c173ca2599bd136e366c35722272b4afa0500
+  md5: 08d653b74ee2dec0131ad4259ffbb126
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.19,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: HPND
+  size: 787430
+  timestamp: 1695662030293
+- conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-h82a8f57_0.tar.bz2
+  sha256: 6efa83e3f2fb9acaf096a18d21d0f679d110934798348c5defc780d4b759a76c
+  md5: 076894846fe9f068f91c57d158c90cba
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 104389
+  timestamp: 1667316359211
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.3.2-hcfcfb64_0.conda
+  sha256: af1453fab10d1fb8b379c61a78882614051a8bac37307d7ac4fb58eac667709e
+  md5: dcde8820959e64378d4e06147ffecfdd
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 268870
+  timestamp: 1694709461733
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.15-hcd874cb_0.conda
+  sha256: d01322c693580f53f8d07a7420cd6879289f5ddad5531b372c3efd1c37cac3bf
+  md5: 090d91b69396f14afef450c285f9758c
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 969788
+  timestamp: 1682083087243
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.11.5-hc3477c8_1.conda
+  sha256: ad3b5a510be2c5f9fe90b2c20e10adb135717304bcb3a197f256feb48d713d99
+  md5: 27974f880a010b1441093d9f737a949f
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1600640
+  timestamp: 1692960798126
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
+  sha256: c161822ee8130b71e08b6d282b9919c1de2c5274b29921a867bca0f7d30cad26
+  md5: 5fdb9c6a113b6b6cb5e517fd972d5f41
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - zlib 1.2.13 *_5
+  license: Zlib
+  license_family: Other
+  size: 55800
+  timestamp: 1686575452215
+- conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.40.1-py38h19421c1_0.conda
+  sha256: a3f59274612e7ac227092c476418cadb3107f17b4c44eee8ed935af263b63584
+  md5: 97204737d8ca9d2d7b12ccf2ce4b9cc8
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - vs2015_runtime
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16824755
+  timestamp: 1687806788804
+- conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+  sha256: a0954b4b1590735ea5f3d0f4579c3883f8ac837387afd5b398b241fda85124ab
+  md5: e34720eb20a33fc3bfb8451dd837ab7a
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134235
+  timestamp: 1674728465431
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+  sha256: 9de95a7996d5366ae0808eef2acbc63f9b11b874aa42375f55379e6715845dc6
+  md5: 066552ac6b907ec6d72c0ddab29050dc
+  depends:
+  - m2w64-gcc-libs-core
+  - msys2-conda-epoch ==20160418
+  license: GPL, LGPL, FDL, custom
+  size: 350687
+  timestamp: 1608163451316
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+  sha256: 3bd1ab02b7c89a5b153a17be03b36d833f1517ff2a6a77ead7c4a808b88196aa
+  md5: fe759119b8b3bfa720b8762c6fdc35de
+  depends:
+  - m2w64-gcc-libgfortran
+  - m2w64-gcc-libs-core
+  - m2w64-gmp
+  - m2w64-libwinpthread-git
+  - msys2-conda-epoch ==20160418
+  license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  size: 532390
+  timestamp: 1608163512830
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+  sha256: 58afdfe859ed2e9a9b1cc06bc408720cb2c3a6a132e59d4805b090d7574f4ee0
+  md5: 4289d80fb4d272f1f3b56cfe87ac90bd
+  depends:
+  - m2w64-gmp
+  - m2w64-libwinpthread-git
+  - msys2-conda-epoch ==20160418
+  license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  size: 219240
+  timestamp: 1608163481341
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+  sha256: 7e3cd95f554660de45f8323fca359e904e8d203efaf07a4d311e46d611481ed1
+  md5: 53a1c73e1e3d185516d7e3af177596d9
+  depends:
+  - msys2-conda-epoch ==20160418
+  license: LGPL3
+  size: 743501
+  timestamp: 1608163782057
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+  sha256: f63a09b2cae7defae0480f1740015d6235f1861afa6fe2e2d3e10bd0d1314ee0
+  md5: 774130a326dee16f1ceb05cc687ee4f0
+  depends:
+  - msys2-conda-epoch ==20160418
+  license: MIT, BSD
+  size: 31928
+  timestamp: 1608166099896
+- conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.3-py38h91455d4_1.conda
+  sha256: e8be25c19af5781f0a5873a25c193b37f43019e73c13c7a438059dbc221b2397
+  md5: c82da8f0baf093cc23546ce37f68df87
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26570
+  timestamp: 1695367935930
+- conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.7.3-py38h2724991_0.conda
+  sha256: cb28426a3c35fe405b21ef3016f8749b14d90eb955f30e20f47e4fa9e6482f19
+  md5: 80ee24705fa140b2febf66a1f9fb9b39
+  depends:
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - importlib-resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - numpy >=1.20
+  - numpy >=1.22.4,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.8.* *_cp38
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LicenseRef-PSF-2.0 and CC0-1.0
+  license_family: PSF
+  size: 6648633
+  timestamp: 1695077748503
+- conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2023.2.0-h6a75c08_50496.conda
+  sha256: 40dc6ac2aa071ca248223de7cdbdfdb216bc8632a17104b1507bcbf9276265d4
+  md5: 03da367d935ecf4d3e4005cf705d0e21
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 144749783
+  timestamp: 1695995252418
+- conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.0.6-py38hb1fd069_0.conda
+  sha256: 2001711058b33f09966ddf031cf758eb5c566f2632304c5ed2b7f42cb4ce9a4d
+  md5: e5031e87f78543db5a2f40301a882a54
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 133674
+  timestamp: 1695464530371
+- conda: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+  sha256: 99358d58d778abee4dca82ad29fb58058571f19b0f86138363c260049d4ac7f1
+  md5: b0309b72560df66f71a9d5e34a5efdfa
+  size: 3227
+  timestamp: 1608166968312
+- conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.57.1-py38hb182ae8_0.conda
+  sha256: 3b1b51435263eaf742ff4d2d982fa87930c4c4eb7f8d77eddf2237fdc4d2400a
+  md5: 97bf6ad59e1e8a4ba283fd95afada821
+  depends:
+  - importlib-metadata
+  - llvmlite >=0.40.0,<0.41.0a0
+  - numpy >=1.21.6,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - tbb >=2021.6.0
+  - scipy >=1.0
+  - cuda-version >=10.2
+  - cuda-python >=11.6
+  - libopenblas !=0.3.6
+  - cudatoolkit >=10.2
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.25
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4090138
+  timestamp: 1687805546597
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.24.4-py38h1d91fd2_0.conda
+  sha256: 490f2cc120d6ebe3f68fb5b0335c16c0c7822acac500198fc63060bd9fe9e227
+  md5: bb13551a7913ff4de74df687f03ba14e
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6010151
+  timestamp: 1687809179674
+- conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.0-h3d672ee_3.conda
+  sha256: c0f64d9642f0287f17cd9b6f1633d97a91efd66a0cb9b0414c540b247684985d
+  md5: 45a9628a04efb6fc326fff0a8f47b799
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 236847
+  timestamp: 1694708878963
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-1.1.1w-hcfcfb64_0.conda
+  sha256: 6d46986fab161cb1b62f019c06dfc27f2e15caccd3943b3282d9e59872fa4ad2
+  md5: 5baf43b5b7f32e7d89d2287bda9cf4be
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: OpenSSL
+  license_family: Apache
+  size: 5260394
+  timestamp: 1694462543768
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-1.2.5-py38h60cbd38_0.tar.bz2
+  sha256: 0bfc24c4014ae1087c42b5b1211c71d05fd699fdffee1d812fa320cb5513ba66
+  md5: d38fa89f0ac9e229e937b93d02ce1451
+  depends:
+  - numpy >=1.17.5,<2.0a0
+  - python >=3.8,<3.9.0a0
+  - python-dateutil >=2.7.3
+  - python_abi 3.8.* *_cp38
+  - pytz >=2017.2
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  - setuptools <60.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10721116
+  timestamp: 1624391937732
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandoc-3.1.3-h57928b3_0.conda
+  sha256: a9e6d966db523ce7185ab430fb692281d69d7b1a58115b40594abfc658db1138
+  md5: 5185086e0662a98ae366212b5bef1af0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 18655054
+  timestamp: 1686228138957
+- conda: https://conda.anaconda.org/conda-forge/win-64/pillow-10.1.0-py38hc375fad_0.conda
+  sha256: e395fab19db2c154dcf84cd923039da56af87daec48475941dd6720fd92c37fd
+  md5: d671ae9247896e544d8b2df9feaf1f89
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - tk >=8.6.13,<8.7.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: HPND
+  size: 46087250
+  timestamp: 1697424170583
+- conda: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.5-py38h91455d4_1.conda
+  sha256: c7736f3574b873ea4fb3e1b91350de71a01754c076ada2ffe551ef3702b2f69c
+  md5: b56bee7988a51c8b0ddc299fddcf72e6
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 375095
+  timestamp: 1695367720818
+- conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-hcd874cb_1001.tar.bz2
+  sha256: bb5a6ddf1a609a63addd6d7b488b0f58d05092ea84e9203283409bff539e202a
+  md5: a1f820480193ea83582b13249a7e7bd9
+  depends:
+  - m2w64-gcc-libs
+  license: MIT
+  license_family: MIT
+  size: 6417
+  timestamp: 1606147814351
+- conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
+  sha256: 576a228630a72f25d255a5e345e5f10878e153221a96560f2498040cd6f54005
+  md5: e2da8758d7d51ff6aa78a14dfb9dbed4
+  depends:
+  - vc 14.*
+  license: LGPL 2
+  size: 144301
+  timestamp: 1537755684331
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-5.0.0-py38h155c480_35_cpu.tar.bz2
+  sha256: fd6e2f126af96b867ed238f6781fba0d8f93581ac671f713ee21ba7cf463b3fd
+  md5: dccd5ffa9080f2f827000f22ecb476f4
+  depends:
+  - arrow-cpp 5.0.0 py38h0c97e59_35_cpu
+  - numpy >=1.16,<2.0a0
+  - numpy >=1.19.5,<2.0a0
+  - parquet-cpp 1.5.1.*
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  constrains:
+  - arrow-cpp-proc * cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 2459799
+  timestamp: 1655703806374
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.8.15-h0269646_0_cpython.conda
+  sha256: 199b4aabde5d60b1823f5f9735d2bb320be476996f00b18f08ac496c57b3ef97
+  md5: c357e563492a7239723e3bf192151780
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.40.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=1.1.1s,<1.1.2a
+  - tk >=8.6.12,<8.7.0a0
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.8.* *_cp38
+  license: Python-2.0
+  size: 14784491
+  timestamp: 1669107228008
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-snappy-0.6.0-py38h8566a25_2.tar.bz2
+  sha256: dc4d7e76f1ef474cd92028af30e11aa5fca6024b1e9f565c06009b485d4c59b0
+  md5: f39ec28d7ccfad961e218ac070afd918
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - snappy >=1.1.8,<1.2.0a0
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33996
+  timestamp: 1649520369752
+- conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.8-4_cp38.conda
+  sha256: fa131149ca3b73aac06f839ee9525581517f50829eaa93fc0e8787b4797e4df0
+  md5: b1059de1664cef9a785dda079a50f1ed
+  constrains:
+  - python 3.8.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6751
+  timestamp: 1695147671006
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-306-py38hd3f51b4_2.conda
+  sha256: cb2c0b4391ccaab9e079df700a1746b99022e74d1b353e3c3ebd775f92027a3a
+  md5: d7658e16cdfbacb097f7ebb723c08c28
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 5867528
+  timestamp: 1695974567568
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.12-py38hd3f51b4_0.conda
+  sha256: 0903cc5f5ba6474119ac77d7646f8cbbe79a0dd27b76b319ce83d62c88fd82f2
+  md5: 905db59d672e0b91d156041af62be046
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 213178
+  timestamp: 1696657634704
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.1-py38h91455d4_1.conda
+  sha256: 1cd8fe0f885c7e491b41e55611f546d011db8ac45941202eb2ef1549f6df0507
+  md5: 4d9ea280b4f91fa5b0c0d34f2fce99cb
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 151945
+  timestamp: 1695373981322
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-24.0.1-py38ha85f68a_1.tar.bz2
+  sha256: 76bc9e54245c7e57ed9de4fdc68c660b41f4e40479dba195e6d043184e849c4a
+  md5: 6b7c99affda3594863756e296f627b67
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  - zeromq >=4.3.4,<4.3.5.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  size: 472558
+  timestamp: 1666829014933
+- conda: https://conda.anaconda.org/conda-forge/win-64/re2-2022.04.01-h0e60522_0.tar.bz2
+  sha256: 8233cfe4e5dfbd257293dfe9e54be5cbcf198e83f19e71f92e7e4b9161a0af5a
+  md5: 8e45c84e5524256a4939673d1e51298c
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 482977
+  timestamp: 1648884584886
+- conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.10.6-py38h4900a04_0.conda
+  sha256: 57863a6995f24bb798626b84396f24f9ef8f7dc872f0925bffd6f39e8c935a80
+  md5: be2a8d527937439e3d335708b3db685f
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 185605
+  timestamp: 1697073266579
+- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.10.1-py38h1aea9ed_3.conda
+  sha256: 05d6cb1d36ec15599e0b8f23c1617f6eb69e3ca04f1e27699ed4b567a28d32af
+  md5: 1ed766b46170f86ead2ae6b9b8151191
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - numpy >=1.21.6,<1.27
+  - numpy >=1.21.6,<2.0a0
+  - pooch
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libopenblas <0.3.26
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18232839
+  timestamp: 1683901937257
+- conda: https://conda.anaconda.org/conda-forge/win-64/setuptools-59.8.0-py38haa244fe_1.tar.bz2
+  sha256: c5e247b894cee34faa1667099477a99f9e381653639d1eef62a88131837576aa
+  md5: c89d90f5f7fa0ee03c23bb0f3c9e42ec
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  license: MIT
+  license_family: MIT
+  size: 1083461
+  timestamp: 1648693121615
+- conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
+  sha256: 2a195b38cb63f03ad9f73a82db52434ebefe216fb70f7ea3defe4ddf263d408a
+  md5: cff1df79c9cff719460eb2dd172568de
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 57065
+  timestamp: 1678534804734
+- conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.10.0-h91493d7_2.conda
+  sha256: e55a2f1324f0fc8916ab8d590a3944ba1af62de727bb66e3019cf2744d26e679
+  md5: 5b8c97cf8f0e81d6c22c0bda9978790d
+  depends:
+  - libhwloc >=2.9.3,<2.9.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 156566
+  timestamp: 1697713986066
+- conda: https://conda.anaconda.org/conda-forge/win-64/thrift-0.19.0-py38hd3f51b4_1.conda
+  sha256: 26ca9106b5fd29bf899ab4fbf1b7d8b37db9f79959afb28fd6a5c0a14d3dc71e
+  md5: fe28c126576de78fd0e48abebb2288f3
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - six >=1.7.2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 130180
+  timestamp: 1695546454591
+- conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-hcfcfb64_0.conda
+  sha256: 7e42db6b5f1c5ef8d4660e6ce41b52802b6c2fdc270d5e1eccc0048d0a3f03a8
+  md5: 74405f2ccbb40af409fee1a71ce70dc6
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: TCL
+  license_family: BSD
+  size: 3478482
+  timestamp: 1695506766462
+- conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.3.3-py38h91455d4_1.conda
+  sha256: 85c4a2f6a82292d28d3ad7bd20296465af65d5d60973c6d34b18ddeb04d7230f
+  md5: 1daea9d484de0ed524b80c9772484102
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 634783
+  timestamp: 1695374004890
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+  sha256: f29cdaf8712008f6b419b8b1a403923b00ab2504bfe0fb2ba8eb60e72d4f14c6
+  md5: 72608f6cd3e5898229c3ea16deb1ac43
+  constrains:
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-Proprietary
+  license_family: PROPRIETARY
+  size: 1283972
+  timestamp: 1666630199266
+- conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-15.1.0-py38h91455d4_0.conda
+  sha256: fd55477b1495809c29ac62493c71d9f54565fbd430aacd205de9c88299eb8734
+  md5: 556fb89abee3970c76556144bdab3263
+  depends:
+  - python >=3.8,<3.9.0a0
+  - python_abi 3.8.* *_cp38
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 370683
+  timestamp: 1695848484360
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h64f974e_17.conda
+  sha256: 86ae94bf680980776aa761c2b0909a0ddbe1f817e7eeb8b16a1730f10f8891b6
+  md5: 67ff6791f235bb606659bf2a5c169191
+  depends:
+  - vc14_runtime >=14.36.32532
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17176
+  timestamp: 1688020629925
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.36.32532-hdcecf7f_17.conda
+  sha256: b317d49af32d5c031828e62c08d56f01d9a64cd3f40d4cccb052bc38c7a9e62e
+  md5: d0de20f2f3fc806a81b44fcdd941aaf7
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.36.32532.* *_17
+  license: LicenseRef-ProprietaryMicrosoft
+  license_family: Proprietary
+  size: 739437
+  timestamp: 1694292382336
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.36.32532-h05e6639_17.conda
+  sha256: 5ecbd731dc7f13762d67be0eadc47eb7f14713005e430d9b5fc680e965ac0f81
+  md5: 4618046c39f7c81861e53ded842e738a
+  depends:
+  - vc14_runtime >=14.36.32532
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17207
+  timestamp: 1688020635322
+- conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: 9df10c5b607dd30e05ba08cbd940009305c75db242476f4e845ea06008b0a283
+  md5: 1cee351bf20b830d991dbe0bc8cd7dfe
+  license: MIT
+  license_family: MIT
+  size: 1176306
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-hcd874cb_0.conda
+  sha256: 8c5b976e3b36001bdefdb41fb70415f9c07eff631f1f0155f3225a7649320e77
+  md5: c46ba8712093cb0114404ae8a7582e1a
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  license: MIT
+  license_family: MIT
+  size: 51297
+  timestamp: 1684638355740
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.3-hcd874cb_0.tar.bz2
+  sha256: f51205d33c07d744ec177243e5d9b874002910c731954f2c8da82459be462b93
+  md5: 46878ebb6b9cbd8afcf8088d7ef00ece
+  depends:
+  - m2w64-gcc-libs
+  license: MIT
+  license_family: MIT
+  size: 67908
+  timestamp: 1610072296570
+- conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+  sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
+  md5: 515d77642eaa3639413c6b1bc3f94219
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: LGPL-2.1 and GPL-2.0
+  size: 217804
+  timestamp: 1660346976440
+- conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+  sha256: 4e2246383003acbad9682c7c63178e2e715ad0eb84f03a8df1fbfba455dfedc5
+  md5: adbfb9f45d1004a26763652246a33764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 63274
+  timestamp: 1641347623319
+- conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.4-h0e60522_1.tar.bz2
+  sha256: 0489cc6c3bff50620879890431d7142fd6e66b7770ddc6f2d7852094471c0d6c
+  md5: e1aff0583dda5fb917eb3d2c1025aa80
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 9355377
+  timestamp: 1629968018045
+- conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.2.13-hcfcfb64_5.conda
+  sha256: 0f91b719c7558046bcd37fdc7ae4b9eb2b7a8e335beb8b59ae7ccb285a46aa46
+  md5: a318e8622e11663f645cc7fa3260f462
+  depends:
+  - libzlib 1.2.13 hcfcfb64_5
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Zlib
+  license_family: Other
+  size: 107711
+  timestamp: 1686575474476
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
+  sha256: d540dd56c5ec772b60e4ce7d45f67f01c6614942225885911964ea1e70bb99e3
+  md5: 792bb5da68bf0a6cac6a6072ecb8dbeb
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 343428
+  timestamp: 1693151615801
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2021.8.0-py38h06a4308_0.tar.bz2
+  sha256: d462fc9de63d8ddaeaf6d74ed0f2551e6da278995b085371182035521850a7f4
+  md5: 120767525583f39980d8b9f5cac094d7
+  depends:
+  - click >=6.6
+  - cloudpickle >=1.5.0
+  - cytoolz >=0.8.2
+  - dask-core 2021.8.0.*
+  - jinja2
+  - msgpack-python >=0.6.0
+  - psutil >=5.0
+  - python >=3.8,<3.9.0a0
+  - pyyaml
+  - setuptools
+  - sortedcontainers !=2.0.0,!=2.0.1
+  - tblib >=1.6.0
+  - toolz >=0.8.2
+  - tornado >=6.0.3
+  - zict >=0.1.3
+  constrains:
+  - openssl !=1.1.1e,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1073466
+  timestamp: 1629141746441
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2021.8.0-py38hecd8cb5_0.tar.bz2
+  sha256: 34dacd552b9bcacb2487ddb1a07fde00e9ec4368fceac91e80c4a214dd00be18
+  md5: 902b64dcbf4418647d90c6e29fec2d68
+  depends:
+  - click >=6.6
+  - cloudpickle >=1.5.0
+  - cytoolz >=0.8.2
+  - dask-core 2021.8.0.*
+  - jinja2
+  - msgpack-python >=0.6.0
+  - psutil >=5.0
+  - python >=3.8,<3.9.0a0
+  - pyyaml
+  - setuptools
+  - sortedcontainers !=2.0.0,!=2.0.1
+  - tblib >=1.6.0
+  - toolz >=0.8.2
+  - tornado >=6.0.3
+  - zict >=0.1.3
+  constrains:
+  - openssl !=1.1.1e,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1076683
+  timestamp: 1629141752006
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyobjc-core-9.0-py38h3eb5a62_1.tar.bz2
+  sha256: 44a82e3bed2b67e7ceb6b0cdbcde45c8e9af695aab44a9cf8db0b0f1721b5942
+  md5: 7a387ab242aa5e99b3c084cfc43bc816
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 441954
+  timestamp: 1678038454553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyobjc-framework-cocoa-9.0-py38hb094c41_0.tar.bz2
+  sha256: 6019eb669c319854cd4f15bcedf24660d489fd8a49c9e33df77bbec78f676440
+  md5: 33590339a3982e0c26cb5a1ead0bc6ae
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 9.0.*
+  - python >=3.8,<3.9.0a0
+  license: MIT
+  license_family: MIT
+  size: 373842
+  timestamp: 1678108414678
+- conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2021.8.0-py38haa95532_0.tar.bz2
+  sha256: 755382bca9611273efbcf054aca30934ce6549bc6086cb72fea51b073485500d
+  md5: b984800d2f287a421484576a44056ade
+  depends:
+  - click >=6.6
+  - cloudpickle >=1.5.0
+  - colorama
+  - cytoolz >=0.8.2
+  - dask-core 2021.8.0.*
+  - jinja2
+  - msgpack-python >=0.6.0
+  - psutil >=5.0
+  - python >=3.8,<3.9.0a0
+  - pyyaml
+  - setuptools
+  - sortedcontainers !=2.0.0,!=2.0.1
+  - tblib >=1.6.0
+  - toolz >=0.8.2
+  - tornado >=6.0.3
+  - zict >=0.1.3
+  constrains:
+  - openssl !=1.1.1e,<1.1.2a
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1107762
+  timestamp: 1629141941987

--- a/osm/pixi.toml
+++ b/osm/pixi.toml
@@ -1,0 +1,33 @@
+[workspace]
+name = "osm"
+channels = ["conda-forge", "https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2016-02-05"
+maintainers = ["jbednar", "philippjfr"]
+categories = ["Geospatial"]
+labels = ["datashader", "holoviews", "bokeh", "dask"]
+description = "Datashading Open Street Map database"
+no_data_ingestion = true
+skip_notebooks_evaluation = true
+skip_test = true
+
+[dependencies]
+python = "3.8.*"
+notebook = "<7"
+pandas = "1.2.5.*"
+spatialpandas = "0.4.3.*"
+bokeh = "2.3.3.*"
+dask = "2021.8.0.*"
+datashader = "0.14.*"
+fastparquet = "0.7.1.*"
+holoviews = "1.14.5.*"
+python-snappy = "0.6.0.*"
+pyarrow = "5.0.*"
+pip = "*"
+wheel = "*"
+
+[tasks]
+notebook = "jupyter notebook osm-3billion.ipynb"
+osm-1billion = "jupyter notebook osm-1billion.ipynb"

--- a/osm/pixi.toml
+++ b/osm/pixi.toml
@@ -25,8 +25,8 @@ fastparquet = "0.7.1.*"
 holoviews = "1.14.5.*"
 python-snappy = "0.6.0.*"
 pyarrow = "5.0.*"
-pip = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [tasks]
 notebook = "jupyter notebook osm-3billion.ipynb"

--- a/osm/pixi.toml
+++ b/osm/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "osm"
-channels = ["conda-forge", "https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["conda-forge", "main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/particle_swarms/pixi.lock
+++ b/particle_swarms/pixi.lock
@@ -1,0 +1,6774 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+  sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
+  md5: 2cf39d906cc321896ffe3e5d33d80c5c
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162166
+  timestamp: 1644463608931
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+  sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
+  md5: 2972a84e0e22ae3244bbd2f1eebcf536
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 35352
+  timestamp: 1644569715988
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+  sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
+  md5: a68016b4b06460def24cb69d932986f3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132486
+  timestamp: 1695717963702
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+  sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
+  md5: 2f6356a2f530314b4059c08c79a3d8bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 205868
+  timestamp: 1681493113570
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+  sha256: 2d8e75f31f75ea5eb8b9021b4c21eb2846a254a097e06eb68e66fc36a82e1bed
+  md5: ae374a11c789a55555f70b29b9eff1f9
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3,<2.0a0
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14430294
+  timestamp: 1658136783940
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+  sha256: f84f9caa7eb9d489fd9634419fdf766d39293a5df1104b840fa0cdc5823a5c60
+  md5: 922555c0435d6b2537cf8ced534b048c
+  depends:
+  - libgcc-ng >=7.5.0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 141903
+  timestamp: 1648028958291
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+  sha256: 0bbcb6f78eac530c6a084459ffab3238647b266d0c74d695e6e6387dd119cc67
+  md5: bdc971e2a9affb5125b68ad708172dab
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 411301
+  timestamp: 1602517685375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+  sha256: 8c2071f706c2b445dabb781f7f8f008b23a29957468ec6894f050bfb3a2d5bf4
+  md5: c203ffc7bbba991c7089d4b383cfd92c
+  depends:
+  - cffi >=1.0.0
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 357797
+  timestamp: 1605539534667
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+  sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
+  md5: 3ef00f4c5278b688552efc259c463dc8
+  license: MPL-2.0
+  license_family: Other
+  size: 132731
+  timestamp: 1694009767372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+  sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
+  md5: d5cb3d97cf5e85ffe5e94037ed8a1169
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159077
+  timestamp: 1690232254640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+  sha256: 674707b9c42e65c903c9786ee5a56b4d42aa054f1e75b328db8a2c1bfa368739
+  md5: 76ae217198b014b89b267cf41b8251dd
+  depends:
+  - libffi >=3.3
+  - libgcc-ng >=7.5.0
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 231920
+  timestamp: 1642701209740
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+  sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
+  md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1917831
+  timestamp: 1668084545510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+  sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
+  md5: 13702d3b4b744784e5bd559c7050dd6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12719
+  timestamp: 1671231205875
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+  sha256: 821af57c20a85b4e92268fbf65fbaec2f273da5bb21889d9643756ef6e473237
+  md5: f57e0f502500ffebdbec081ef61ad1d4
+  depends:
+  - cffi >=1.12
+  - libgcc-ng
+  - openssl >=1.1.1v,<1.1.2a
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 2179774
+  timestamp: 1694445209134
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+  sha256: 3a39a2d6f161080c706292e3bf480f62d2444b1d6d67b3d7db50458202ee31f1
+  md5: 0524ffca60f845eb392bbb56d56f0ce5
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2094615
+  timestamp: 1637091869922
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+  sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
+  md5: 2e6ec51066d825ef3c317abe78d6049e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16413
+  timestamp: 1649926472708
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+  sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
+  md5: b4d923222d45314856b5378cb115214d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26728
+  timestamp: 1668714462023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+  sha256: 8a121233d0b2cbb2463b67e798739ad2946f38933430a6a7fd1197cc6eab1c99
+  md5: d2b24736491290a6c6d0138932111150
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: GPL-2.0-only and LicenseRef-FreeType
+  size: 965280
+  timestamp: 1635422707211
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+  sha256: 3c8ece1a7257b1d45f8fa25f46504bb709a1923d7175f2996e891366ec434b9d
+  md5: 299bf4271d710651a1d71d3795580c2d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 83592
+  timestamp: 1603192039050
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+  sha256: 2d727f8335c59314b521b66d437ca4d51904134473ae503b7b097e239635f209
+  md5: 6991e520f353d995023404f6f524d192
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4507274
+  timestamp: 1693378095165
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+  sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
+  md5: 9213e0336e3a5216c989cfe52648412e
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 23805906
+  timestamp: 1588026213084
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+  sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
+  md5: 1eb52f9f45cea2fb9ce27b19f990160e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110793
+  timestamp: 1666125606878
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+  sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
+  md5: 126b3c1933b7364ff03f67455b687e99
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 37588
+  timestamp: 1678997134023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+  sha256: 1b424413f28b840fc6d4bf467f37e9e405823b1e3b899005df80152d48936d64
+  md5: 4aa8bcf74c81cd3600978f791191692a
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 9246735
+  timestamp: 1634546760713
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+  sha256: b51b2e0dd37a74784ba19db22aded3f4c843b6fddb4a74399f65f36fc018aaa2
+  md5: 0d56ab1950f952284b895ac0f78284a7
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.0
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203541
+  timestamp: 1671488675347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+  sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
+  md5: ff47e0be879e817713ce2a9daa76e2b0
+  depends:
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1261116
+  timestamp: 1694181530670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+  sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
+  md5: 5ef6c6a0d1ac79143c7359d305155167
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1021637
+  timestamp: 1644297140650
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+  sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
+  md5: eaeb023688f781e7dd89e74310c38195
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 211775
+  timestamp: 1666908212136
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+  sha256: 85348bfb14db4fea84078d703e766a3c978c5a592a06e41266748826dd59d8ae
+  md5: 6e1c0fb5260c590f7ef5235cb3d05863
+  depends:
+  - libgcc-ng >=7.5.0
+  license: IJG
+  license_family: Other
+  size: 279884
+  timestamp: 1651065953960
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+  sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
+  md5: 0d2c3c5edf671b575532d5a3e8bf15fc
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 131510
+  timestamp: 1676558716852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+  sha256: 92bc012f9eb4ad71158cf4826fd3e125fcebff53b529276a81224acda48be547
+  md5: c5fd100e3062e831cbdf33331042f627
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=22.3
+  - tornado >=6.0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 190884
+  timestamp: 1650622553813
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+  sha256: 0192bd48cd96c60dc3054d5addd8cdb4a29a218843181318371f79daec8242f8
+  md5: d851b401dc13d04e6848bb36e12efc1c
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 91534
+  timestamp: 1679906652183
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+  sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
+  md5: a4beb461f0a60998a090d760b5c6c907
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411564
+  timestamp: 1671707702849
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+  sha256: 974df3dc76089be57b327acd6634384def84249003f58678ca1142bb274a75d9
+  md5: 81b969d1a00153759b30554a1f11ddfd
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92144
+  timestamp: 1653292217019
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+  sha256: 3b4afe7665dcdb99bd4586a888b85b2e0325f8faecdd31c7780792080ee97872
+  md5: 822b5201dde61bc838072dc5b670c88c
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: Custom
+  size: 55183
+  timestamp: 1594054267890
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+  sha256: c6fafbe73d2f93b91b6f4b65829f925f52a8f84746a57abd216b39da9ce8c494
+  md5: 238f19c803a6ba7bd6dbd6989e03cbf1
+  depends:
+  - _libgcc_mutex * main
+  license: GPL
+  size: 8496776
+  timestamp: 1560112207081
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+  sha256: bc3e6e79c32ff0ecea601aa108ae9cf4068f69703580e40e266ad4bcc52cff54
+  md5: 9cb85601944ca7383b1769bff74b94e8
+  depends:
+  - libgcc-ng >=7.3.0
+  - zlib >=1.2.11,<2.0.0a0
+  license: zlib/libpng
+  size: 372914
+  timestamp: 1556041895170
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+  sha256: 43b0bd205f539583c088feb5b8d77b60c83d1df80c2a93dac9f2a1127001b2cf
+  md5: 53fa39fdae936e9d07c4b2f5ef361993
+  license: GPL3 with runtime exception
+  size: 4246257
+  timestamp: 1560112223556
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+  sha256: 711ea05b4c35bdafc762a172b01db896b17942f474c2b1a519f91370964bf9bc
+  md5: b25d56d33596623a6a4a9d9baaa4f602
+  depends:
+  - jpeg >=9e,<10a
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libwebp-base
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  size: 592974
+  timestamp: 1653047881023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+  sha256: 146dbb1e4dbccdd57819e5102a8ca00970b8e33d6c6180e8007db89b184da569
+  md5: c566a384259c1d2769852c3bddd81a67
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9d,<10a
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 90150
+  timestamp: 1645441199289
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+  sha256: cffb5a063111f7a99a99c74770b23db5dde52325e25a7a46d1903d5ff4a82c88
+  md5: eeb1bd66f28bed1956ab989d6eff7ae5
+  depends:
+  - libgcc-ng >=7.5.0
+  constrains:
+  - libwebp 1.2.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 889956
+  timestamp: 1645089138421
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+  sha256: 71f6c4a97014d745c58df52b4dd60ddd75a8508d54fe5b97f42bd1f31cb1c067
+  md5: 686e77514ec9f1ef0a6feed374f14d37
+  depends:
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.5.0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 789469
+  timestamp: 1653546418059
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+  sha256: ea3355a67c5173f3944f09861043ca66eb7dbeff8f385d13528b3aabc0801d0c
+  md5: 66e2aa12181bb2911485bdbe125d24c5
+  depends:
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.5.0
+  - libxml2 >=2.9.14,<2.10.0a0
+  license: MIT
+  size: 584199
+  timestamp: 1654075843119
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+  sha256: 64b022d706b76c33965a250fdc8c6008443c41bff8ab27bb1df3cb70419576fd
+  md5: ec4f05846aacf634df15c389235725cc
+  depends:
+  - libgcc-ng >=7.5.0
+  - libxml2 >=2.9.12,<2.10.0a0
+  - libxslt >=1.1.28
+  - libxslt >=1.1.34,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  size: 1538261
+  timestamp: 1646624639995
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+  sha256: 2c6a5dda7c510a961bc78e31d4232be5e8e0760c93454f5fd200c379355e0f5e
+  md5: f35d4bf2fbb39e334992f6dd39f8721e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 220865
+  timestamp: 1627657046002
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+  sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
+  md5: 421f82c8274b44660dba629134faa6af
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 122221
+  timestamp: 1671541990505
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+  sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
+  md5: feb0e452205b44ac45d9b5e55c21a3b1
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22819
+  timestamp: 1654597913064
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+  sha256: dc51b316ef5dcfb82a9c0afdc40879146ae59516f6cea7db776077783dfd2d76
+  md5: b0b6b57c140f026b8806051107336576
+  depends:
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.11.0,<3.0a0
+  - freetype >=2.3
+  - kiwisolver >=1.0.1
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - numpy >=1.19.2,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.2.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  - tk
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7729454
+  timestamp: 1647442028622
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+  sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
+  md5: c04ef34af33da4c71bcc99b7ec24d210
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16391
+  timestamp: 1662014553452
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+  sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
+  md5: f6c734d73e6e3dbc1b62766cf18ff3e4
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58153
+  timestamp: 1607364912263
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+  sha256: 7c4ded8b2ef036839f988560848d2c32e1aa4627fd37a32710e42c39f5c61ac2
+  md5: bd20f4410b81f327e35ffa0657961146
+  depends:
+  - intel-openmp 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 229783051
+  timestamp: 1634547157986
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+  sha256: 5394f5efd53afb2c1b0abf571ce3d9cb684b6c7e255f140ba2acaa703d6113be
+  md5: d3cb2bfa63e30153f5527797dcc87280
+  depends:
+  - libgcc-ng >=7.5.0
+  - mkl >=2021.2.0,<2022.0a0
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 63551
+  timestamp: 1626176932911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+  sha256: c244d23da2749857a993f84969fd35ffd183ab8f462986df6d33ae0f705fe034
+  md5: 9b1f8ccc2488d0e04eb73211e2987483
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.3.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  size: 204136
+  timestamp: 1634566416657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+  sha256: f81f426f8ef306d636664bc49e7cdd70e2b4306d7c6bcb9c75fe35a45ab2087a
+  md5: 77aa1d7f958d36bf227e6ff4a34d2e3d
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.2.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  size: 365386
+  timestamp: 1626186165897
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+  sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
+  md5: 95c83d71814c504b5504df4f14548f1a
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8257558
+  timestamp: 1681756322140
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+  sha256: 1b92d72b083f3350359b8fb2e3b5dc846f49650c9e46a6a74354b1b7f0d42730
+  md5: 996babe4314515ddd41008a53cb5d47f
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 98791
+  timestamp: 1650290544347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+  sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
+  md5: 1710a25086c8098367eb36b9d441448b
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 569683
+  timestamp: 1668450704669
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+  sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
+  md5: 385cc9e53404776782502c0fdb08820f
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147046
+  timestamp: 1694616899309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+  sha256: 0807371380965e421cb5f3f2a30d790fd5c41db11dbb6d318e14294c3b1741ed
+  md5: fca4bd4e3891aebf4fd7daf9b6d0ccfa
+  depends:
+  - libgcc-ng >=7.5.0
+  license: Free software (MIT-like)
+  size: 1083412
+  timestamp: 1636570020698
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+  sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
+  md5: bbbcbebc20a4fdcadce398d0ca04f95e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13109
+  timestamp: 1672387143252
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+  sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
+  md5: 248ce515640465371927d46f389ed555
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 594054
+  timestamp: 1690985006481
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+  sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
+  md5: 70db71df4ee1cdd38090c0f7b80ba61f
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21944
+  timestamp: 1668160644514
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+  sha256: 15a12c8bebcda45c577e61cea412d9aafaa433e39f9e91fd61bbfab66fcee3ab
+  md5: 5239d8330e8bd34972fb80918dce79e7
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16.6,<2.0a0
+  - packaging
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 136437
+  timestamp: 1640689905588
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+  sha256: ff8d0426c7096e086db818265c3edf4a820accbfb15afae0407ca578de151fa9
+  md5: d7bcf0b9ba2d85cf532059ec119d2750
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.22.3 py39hf524024_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  size: 9965
+  timestamp: 1652801901707
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+  sha256: abfdeda143b6b667d50a82ea119043fc1469ee02f094a41a2402433ff408099e
+  md5: e8dc29adc0282f4658e0e2f25ff207a2
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.22.3 py39he7a7128_0
+  license: BSD-3-Clause
+  size: 7095882
+  timestamp: 1652801886819
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+  sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
+  md5: 5ad4571eba2479f77a9f849a6ae7724c
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: OpenSSL
+  license_family: Apache
+  size: 3998613
+  timestamp: 1694465071784
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+  sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
+  md5: 77a22ed6d0d448c5288d0f695bc9ac49
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 72527
+  timestamp: 1693575234886
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+  sha256: e7a0abb0f00a94000876f2095f0cf531ad3803ffbd868a780b3f06816b54492c
+  md5: 97ef7e1fe923d22a8e2307f3f39a92d5
+  depends:
+  - bottleneck >=1.3.1
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - numexpr >=2.7.1
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13221005
+  timestamp: 1650622404234
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+  sha256: 49fdb57b2ed2ce4d6bb7a2c5adec36ba59522518a41fb941f9e39a9f43750cc5
+  md5: 871b65444733b7da5823ee0dc9826722
+  depends:
+  - bleach
+  - bokeh >=2.4.0,<2.5.0
+  - markdown
+  - param >=1.12.0,<2.0.0a0
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - setuptools >=42
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >1.14.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14712394
+  timestamp: 1676379803902
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+  sha256: 64a732ce2661cdb6bd8f9d1484ac10afeb73082b1c2b44728d212e0117d2860e
+  md5: ada303f0cf43a4e99cfa7f243b23b681
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141832
+  timestamp: 1684915385689
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+  sha256: 8bcb1c67693f42a3170eb77ef4cdbb81b605fdf40816953e69a33a065c101638
+  md5: b7689507fb5f879dc766aaa8a4c37351
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp >=0.3.0
+  - libwebp >=1.2.0,<1.3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk
+  - zlib >=1.2.11,<2.0.0a0
+  license: LicenseRef-PIL
+  license_family: Other
+  size: 734566
+  timestamp: 1646325095608
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+  sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
+  md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2674850
+  timestamp: 1697548887851
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+  sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
+  md5: fe56f0479dd414c846191116366262c3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 31999
+  timestamp: 1692205535111
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+  sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
+  md5: 44d2a857d13bdf9d99aaac039a249d47
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91137
+  timestamp: 1659455142164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+  sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
+  md5: eb899a739d9b58dd747f1f6bd52d4cf3
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 579771
+  timestamp: 1672387338600
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+  sha256: 6973cfe0565ba3b5ad6d1de9e34848fbbadd78b507b2e23e1c079636b8f8f317
+  md5: a924535045fb356e23e7a3cc8116b638
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 350026
+  timestamp: 1612298042840
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+  sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
+  md5: f36ecb722522cbe2e3737424edf1b5e1
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29312
+  timestamp: 1675441510984
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+  sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
+  md5: 6d03295e544251e608a28c8d7c48115e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1862058
+  timestamp: 1684280096752
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+  sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
+  md5: 1f09617aecd6f3c2f2e20692c0759f34
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94434
+  timestamp: 1690223520097
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+  sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
+  md5: ffceed627867508d73af1636ab5ebf42
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 156324
+  timestamp: 1661452578573
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+  sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
+  md5: 0e3341a4fe434167bf74b613eb6afd81
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 97194
+  timestamp: 1636110999719
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+  sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
+  md5: c5f3f7f10ad30f0945e75252615ab6e5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31331
+  timestamp: 1605305847037
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+  sha256: c4b9e332a6f2b7524e8c88e2b39a2568a48e556fd9a44c30759c43611d4d023d
+  md5: bb118745c9b08fc5028f45e77f371e68
+  depends:
+  - ld_impl_linux-64
+  - libffi >=3.3,<3.4.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - ncurses >=6.3,<7.0a0
+  - openssl >=1.1.1o,<1.1.2a
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.38.3,<4.0a0
+  - tk >=8.6.11,<8.7.0a0
+  - tzdata
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 24553777
+  timestamp: 1654084160832
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+  sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
+  md5: 0caa188a695319bdb13f53b0a2b3accc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264864
+  timestamp: 1661371117920
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+  sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
+  md5: bcb44ecbea441ee0d4659133d060d71f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257904
+  timestamp: 1695131670290
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+  sha256: e937081facacb141dc2c9cdcced92baa9a2662e4a56100b6041df0b6b7692570
+  md5: f3ac39b2349258198a9b3316636fe5d5
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39972
+  timestamp: 1685030752528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+  sha256: 3da9cbbd49fac566433748bd245d09d7d5fcd28b04c0397cbbf6d5bb92f5c4a5
+  md5: df73a5d2f6e089d51e71e91935a82c65
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 183753
+  timestamp: 1635775763162
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+  sha256: 26005d191bb15070aad70707ed6493f32678a67978bd3b83d4c9679cab44e717
+  md5: 2dc75d5a4ccb64310939c3a72d34ae20
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-clause
+  license_family: BSD
+  size: 521583
+  timestamp: 1638435042256
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+  sha256: 8c950c69bee969e2c66f88f0dc247b3ab75a753672a88009779d5f5dba193532
+  md5: 150ac0eb929bab9dec912797bdfc7b95
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 433182
+  timestamp: 1642022402894
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+  sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
+  md5: c7de00b4ac2778c4e5a7816320d75391
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94028
+  timestamp: 1690400356879
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+  sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
+  md5: 1581cafc84708ed9aafaaee1cbbf6065
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1089416
+  timestamp: 1690290900608
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+  sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
+  md5: e19ffbfb24b990275d24fcea2bd1699b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15702
+  timestamp: 1614030498860
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+  sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
+  md5: ca061ce25c0f58628643abec8d6a8244
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 66330
+  timestamp: 1696347637947
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+  sha256: 87965b7b46d93866d31696a1045216d64f077a06b2900c356aba87e8559c6188
+  md5: fa334030245135b37027a882f3c468bf
+  depends:
+  - libgcc-ng >=7.5.0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: blessing
+  license_family: Other
+  size: 1561908
+  timestamp: 1655328608308
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+  sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
+  md5: 0e76eab58fe488e91f0aee73f46de031
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29816
+  timestamp: 1671751864131
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+  sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
+  md5: b413a210eca82fe867e991eed085201b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38882
+  timestamp: 1668168876032
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+  sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
+  md5: 5b8375e2092012db69d2123dc0c68630
+  depends:
+  - libgcc-ng >=7.5.0
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3485432
+  timestamp: 1654088939579
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+  sha256: b746e39272888b9cc1a2a711b7b8836f2e26f4457850e43ad18bf0765e21dc3d
+  md5: 200e86f8d53aeebf4b7dcfc944fd7920
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 661662
+  timestamp: 1606942359431
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+  sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
+  md5: 67a8320961ff24e92eebb661536e5cf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - requests
+  - slack-sdk
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 123763
+  timestamp: 1679561904852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+  sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
+  md5: 0f0b91a158dd3692cbb7a7763b657bfe
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192032
+  timestamp: 1671143995098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
+  md5: 8515e64a3de7581360d713fe4c0a094e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8789
+  timestamp: 1690297588156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
+  md5: 60170012374b2a5007842fa5870d78c5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57479
+  timestamp: 1690297581658
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+  sha256: 870f20a3c006a74b291910f69c3469a409bd21437142864b29cfafeb89ca7c34
+  md5: 1b2f1589e3ebc3e0c6ecb38dba93e4ae
+  depends:
+  - brotlipy >=0.6.0
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 186761
+  timestamp: 1686163186447
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+  sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
+  md5: f8d03a15b974fc7810d9f54ae849fc8e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20781
+  timestamp: 1607365390528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+  sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
+  md5: d7db5d6ce1db80eade8a082ff78bf479
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 71044
+  timestamp: 1614804011510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+  sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
+  md5: b3899f8bda32734727bd5a73df1d7d17
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 101520
+  timestamp: 1695742037911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+  sha256: 2ce360ff98c0ca4537d70c19266b5700810196c54ce2fbaff3b94a969846ee37
+  md5: 94cb94dc47405b24b1b5bd0a3275ab59
+  depends:
+  - libgcc-ng >=7.5.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 398058
+  timestamp: 1651602137803
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+  sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
+  md5: 567b68192c387b5fc88178425577a0fe
+  depends:
+  - libgcc-ng >=7.3.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=7.3.0
+  license: LGPL-3.0-or-later
+  size: 366479
+  timestamp: 1616055552392
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+  sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
+  md5: 3818a9531fe74433c3b7d5144c9a58cc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18021
+  timestamp: 1672387231268
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+  sha256: 513444d83ac2405e898531492ea59f3a95641e357cc39c1048d6fffc1791a16b
+  md5: 601d9449c280b9b145dc8c83b6f06119
+  depends:
+  - libgcc-ng >=7.5.0
+  license: Zlib
+  license_family: Other
+  size: 133595
+  timestamp: 1650637720646
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+  sha256: 1c049c23788a00b6f38bdc801245e0e60af98718d4db4c958658bcc67ff158c7
+  md5: b1737dfd2e06ad69ec5cfec341e207c6
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 827172
+  timestamp: 1650622223170
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
+  md5: b2aa5503875aba2f1d88cae9df9a96d5
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13636
+  timestamp: 1611930018941
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
+  md5: 544adf2677c47c9b9c891aea720678f1
+  depends:
+  - python >=3.5
+  license: MIT
+  size: 33999
+  timestamp: 1630003259346
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+  sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
+  md5: 9eff1a842dbda8d1bae9a2c008b599bc
+  depends:
+  - brotli >=1.0.1
+  - munkres
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 690443
+  timestamp: 1625743217109
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+  sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
+  md5: 33624a42ee387bf9918ea98b4e7b31fc
+  depends:
+  - pygments >=2.4.1,<3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8173
+  timestamp: 1601490751973
+- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+  sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
+  md5: 67857cc5e9044770d2b15f9d94a4521d
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12810
+  timestamp: 1600445183315
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+  sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
+  md5: e68a6f315f41a8d814d833652bf38b9b
+  depends:
+  - python >=3
+  license: MIT
+  size: 13374
+  timestamp: 1606932077143
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
+  md5: 2eb923cc014094f4acf7f849d67d73f8
+  depends:
+  - python
+  - six >=1.5
+  license: BSD-3-Clause and Apache
+  license_family: BSD
+  size: 246457
+  timestamp: 1626374695070
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
+  md5: 41db68b96e114e367c4f120a3b379e59
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19391
+  timestamp: 1632406728844
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+  sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
+  md5: a815d3bdb160bcc71687f2dda70d3ca4
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 122218
+  timestamp: 1680170368293
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
+  md5: 447a49f7bad119faa80d7f14aa296c95
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162176
+  timestamp: 1644481750133
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+  sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
+  md5: 8810f48fe4a4792de0fd3520b502d08b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10019
+  timestamp: 1606859473259
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+  sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
+  md5: 00a446b6dfc61af223df4de29fe8ad94
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 34305
+  timestamp: 1644569782044
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
+  md5: bd92dd8bd5b9d24e632b62a075426e50
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133634
+  timestamp: 1695718025321
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+  sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
+  md5: f8ae051b591a9027adc16de1be9748f4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206198
+  timestamp: 1681493096349
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
+  sha256: 2936241747f6cc0f0b3afa53bb28ad6f658b53a0fc2e67a5ed34d1d5e2cce117
+  md5: bdca1b691340964271d9cfec6baaf8d0
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5719952
+  timestamp: 1697490515691
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+  sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
+  md5: 0d79760d544d0bd8acb4adc4ef813418
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 137075
+  timestamp: 1657175654487
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
+  md5: 31d6d04cd2388d8f19004501271b3545
+  depends:
+  - brotli-bin 1.0.9 hca72f7f_7
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18982
+  timestamp: 1659616229395
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
+  md5: caf1073dc2ca5aeb832a2877394eae12
+  depends:
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18233
+  timestamp: 1659616216769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+  sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
+  md5: aa1ed20c38af535c8d6a955314759d7b
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 394588
+  timestamp: 1659616312678
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+  sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
+  md5: ce3588e31faa79f546e0fc6a36c5543c
+  license: MPL-2.0
+  license_family: Other
+  size: 133884
+  timestamp: 1694009771475
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+  sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
+  md5: 21eb7f53076d0a69513cfd258f6ef63c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159756
+  timestamp: 1690232346868
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+  sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
+  md5: a40a04d9cda1e665565bc6c832d598b6
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225258
+  timestamp: 1670423337502
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+  sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
+  md5: b2cc5f37f7bb069d061306e7eac2a011
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1913396
+  timestamp: 1668084575248
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
+  md5: 103d8c039e342115720a84d59c119d46
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13774
+  timestamp: 1671231190250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+  sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
+  md5: f69f09e0346172f225390d2b3b0d7873
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 246628
+  timestamp: 1663827484947
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+  sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
+  md5: cb80c7ac65b48a737654f371fe31c460
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1307228
+  timestamp: 1694212041712
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+  sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
+  md5: 04cbe8f4bc62c34fac9d42d1124059bf
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2052734
+  timestamp: 1690905361158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
+  md5: ef0e825982f242085574f502dfff4f6b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16594
+  timestamp: 1649926538106
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
+  md5: 24747a300246c016b3a7f04dabd02d4a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27709
+  timestamp: 1668714497209
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+  sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
+  md5: e4a732941f74b8062c8bcbfe5c5c2b56
+  license: MIT
+  license_family: MIT
+  size: 80252
+  timestamp: 1676983220161
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+  sha256: 5c36d43cadbbf944d9255e79df85c2e9e6155a1d6f9158e06fcd8ffd458b7663
+  md5: a5a2cff387403ccf9cf58aac7a6dde55
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4573879
+  timestamp: 1698866750755
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+  sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
+  md5: f3ce6fe6eb760c236e5f7d04df5faa81
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28138484
+  timestamp: 1692293212596
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+  sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
+  md5: 6dd72c43fea25b748ec7a9f6c0407e15
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111810
+  timestamp: 1666125671024
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
+  md5: 03cdb7e679924b329ecab8f12cb8fc67
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38813
+  timestamp: 1678997212422
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
+  md5: e113c4e6e758dd68faf196586bf5564d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51873
+  timestamp: 1698254765815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+  sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
+  md5: 78baea934985ccd9514a366cc7e80ed4
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 727499
+  timestamp: 1681801225190
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+  sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
+  md5: da9b63e42f281f7e77b289f4b654b83b
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 218436
+  timestamp: 1691121840155
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+  sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
+  md5: 6a7cb9b49593b29933fa2b503d533a08
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1257205
+  timestamp: 1694181720454
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+  sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
+  md5: d861ef66f5c0a282d60b65778a9de2f3
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1048450
+  timestamp: 1644315332508
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
+  md5: f7e603c965052deed8b789c35855a42f
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213537
+  timestamp: 1666908270815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
+  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
+  license: IJG
+  license_family: Other
+  size: 278924
+  timestamp: 1677849185191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+  sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
+  md5: a82a17e78f725dcbd71ff8dac6db05c7
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133134
+  timestamp: 1676558895333
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+  sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
+  md5: ee9270379a9ebdb6297e4b6849b3f7f0
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 195479
+  timestamp: 1676329410154
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 32b898a97dca7770858ab31294238fde11ab61a84831a52f320e5ee5405a147c
+  md5: 926e754b8fad288b583ef2933deae1a5
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92938
+  timestamp: 1679906616072
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+  sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
+  md5: 7e60995b3119417213e5faedda147499
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 403165
+  timestamp: 1671707664990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+  sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
+  md5: cd470bdb28bb0e8b3535c93a3a6dad07
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65431
+  timestamp: 1672387389172
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
+  md5: 7dba7aa5b971febb55281659843586ba
+  license: MIT
+  size: 65470
+  timestamp: 1659616172703
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
+  md5: f78a158983f0bbaba56f34b976bc6dae
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 34189
+  timestamp: 1659616189313
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
+  md5: 36a1d885725d3ab4d1fadc5a29f978d2
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 327737
+  timestamp: 1659616202869
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+  sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
+  md5: 817848d0e2b2808acdc9b3fbbf581726
+  license: MIT
+  license_family: MIT
+  size: 133887
+  timestamp: 1683716590737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+  sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
+  md5: c90372428e1e4eed4fdcd790979d06b4
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1409377
+  timestamp: 1650983531933
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+  sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
+  md5: c0b99f8e1c7475f23b1c7b4250b06e1c
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88021
+  timestamp: 1694778290062
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+  sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
+  md5: 06866415ef22d5322f9bdc9956b59c4d
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 678174
+  timestamp: 1692970318885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+  sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
+  md5: 2edc6c894d6d0321304396e9bd40df94
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241774
+  timestamp: 1692973618934
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 0190d3b8d2939f28aa017711cf4147c51a1139da2922cc8420a71562dd99f844
+  md5: 454a7f2c4426453f17e995382a4235e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 36036
+  timestamp: 1659783508187
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+  sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
+  md5: 8bbd981ca0129d7beeacd3cd7623f714
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1491074
+  timestamp: 1695058597986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+  sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
+  md5: d5f58d056b4bfc67aec30c77035ba889
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 182491
+  timestamp: 1670944720979
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+  sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
+  md5: 1affd16b166571a91feae04baf5fd3da
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123431
+  timestamp: 1671542016019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+  sha256: e5fc51472fa0f36abd78baa5b3c9245d6627b0da11188e6a954d73f3f2bca210
+  md5: df7c519447affffb594f8c56b028ed33
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 107035
+  timestamp: 1684279974102
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+  sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
+  md5: 3681ebf029211ceab26af6f5d35abf39
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22254
+  timestamp: 1654598220251
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+  sha256: 2fd179efa024c92d0d71179a981a781d16c70f5d8c6305e0d678b0c7ae1275ab
+  md5: addda7f015d1673f794a23fdb18a3e09
+  depends:
+  - __osx >=10.12
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8182219
+  timestamp: 1698692361219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+  sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
+  md5: 6eb64ecfcd754502e271db0bb51d2cfd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17374
+  timestamp: 1662014643620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 2312ee5a6343e8495802698d7181f1b619aad7479d96ee253407b324ac884417
+  md5: 866960fa48a7ca335941786d4869802a
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53542
+  timestamp: 1659721365599
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: 37f455814ce242eb65ff80a0402f1bd231a388e6823e6c1e65f60b705c032a2d
+  md5: 4c9246c492a64729225aa5b04e12c2d1
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19573
+  timestamp: 1659716100178
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+  sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
+  md5: 2a4d604717a647ad21af766289cbbfc3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58057
+  timestamp: 1607364912348
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+  sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
+  md5: 25051fe272624544652dc6d814c2943a
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224420228
+  timestamp: 1691503125614
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+  sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
+  md5: 37d8cf85a63f7aa9af1624894a7d606d
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48590
+  timestamp: 1682969183093
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+  sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
+  md5: 0b2aee6666135bbd36b46d6ac66160f7
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 210705
+  timestamp: 1695058433223
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+  sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
+  md5: e22fb55ce380d0ebd44cce3f20d5349e
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296614
+  timestamp: 1695060155673
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+  sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
+  md5: 1a5d4004e64e3cfb7a2a297b9117c285
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8213832
+  timestamp: 1681756573646
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+  sha256: 2975bd1f98ca9ec7354ee378f86f8322ec90f568374776fd90e80c534fbee882
+  md5: 798627089e0ccba26695a26d9cb127ec
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99066
+  timestamp: 1650308465824
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+  sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
+  md5: e572c1264a7af20b486f64ac8c9e1f57
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 573356
+  timestamp: 1668450732828
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+  sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
+  md5: b67569a7c30af9ffa5cde6e4b52ac68b
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148342
+  timestamp: 1694616917184
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+  sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
+  md5: 97b81f34efbe86c5220fe82eb584fd62
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387288528
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+  sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
+  md5: d77862975a9a1cf50acb803be26e83a1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 575365
+  timestamp: 1690985052739
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+  sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
+  md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22858
+  timestamp: 1668160618784
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+  sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
+  md5: 185e9c41abb88ee59b52ec0f5f65d506
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 138305
+  timestamp: 1696515469702
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+  sha256: 82a2dd0c2ff6e20a275e5447dd03088f79694f7bfa5055a25c54bebf31aac4ca
+  md5: c157e6ab469a95b06fa822ba075978b3
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.0 py39ha186be2_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10376
+  timestamp: 1695831243158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+  sha256: b3a003b41cec2751210e542911e99437db0321542f6812c1b88608ef720ba7ef
+  md5: 56400dfe88c427cdf1854e47666b8a99
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.26.0 py39h827a554_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7570900
+  timestamp: 1695831208653
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
+  md5: 93f5d7b66976154adeda219bea02ba45
+  depends:
+  - libcxx >=10.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 484257
+  timestamp: 1630093862501
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+  sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
+  md5: 5e8713ef1215406254988163eaf34020
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4965606
+  timestamp: 1695323060401
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+  sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
+  md5: 4154929ace2ad6ee16aea815635a6d1f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73598
+  timestamp: 1693575307570
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+  sha256: aff5acedef9da91b77851e1a163b8319d72bc4152c98ac87703a2eac1e5d575b
+  md5: 7df4c76aa8c52fedce5346748d56459e
+  depends:
+  - bottleneck >=1.3.4
+  - libcxx >=14.0.6
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - tabulate >=0.8.10
+  - blosc >=1.21.0
+  - fsspec >=2022.05.0
+  - beautifulsoup4 >=4.11.1
+  - pyreadstat >=1.1.5
+  - pyqt >=5.15.6,<6
+  - s3fs >=2022.05.0
+  - numba >=0.55.2
+  - xlrd >=2.0.1
+  - qtpy >=2.2.0
+  - xarray >=2022.03.0
+  - psycopg2 >=2.9.3
+  - lxml >=4.8.0
+  - zstandard >=0.17.0
+  - pyarrow >=7.0.0
+  - pytables >=3.7.0
+  - xlsxwriter >=3.0.3
+  - gcsfs >=2022.05.0
+  - fastparquet >=0.8.1
+  - scipy >=1.8.1
+  - pymysql >=1.0.2
+  - odfpy>=1.4.1
+  - pandas-gbq >=0.17.5
+  - pyxlsb >=1.0.9
+  - matplotlib-base >=3.6.1
+  - openpyxl >=3.0.10
+  - jinja2 >=3.1.2
+  - html5lib >=1.1
+  - dataframe-api-compat >=0.1.7
+  - sqlalchemy >=1.4.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13388063
+  timestamp: 1697477404222
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
+  sha256: 42d83288119306089a06e853a37045fbb9860548b05a1e79d223f7ecf1cb349d
+  md5: 8daced11264159ff57df7bba4d0b2ec7
+  depends:
+  - bleach
+  - bokeh >=3.2.0,<3.4
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.0.0,<3
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.17.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17075803
+  timestamp: 1698867397009
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: ad7ca92e5c83a8e2181677025509ed7b8f566ec23b24f28316fa087bb591c11f
+  md5: a4ccd0fbcfb26de868f2fb4836940d7a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189263
+  timestamp: 1698263570990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+  sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
+  md5: be0a90921f3bf4f0d6950fb786093de7
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND
+  license_family: Other
+  size: 719901
+  timestamp: 1696580194417
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+  sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
+  md5: 81ae9ec2d7fcf6934847bff558b619f5
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2672987
+  timestamp: 1697548890181
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+  sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
+  md5: 1a822c206e2abddc5d6d821721af227f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33013
+  timestamp: 1692205801265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+  sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
+  md5: 1604d33dbdb2446c642970f8b354bedb
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91266
+  timestamp: 1659455269141
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+  sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
+  md5: d1b3bcc35655a3123acb1fa2ad1a8511
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580828
+  timestamp: 1672387372015
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+  sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
+  md5: 7540555d1fb192236db9a7c5c9d3601c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365765
+  timestamp: 1656431373327
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
+  md5: 0a73533fb6e0dc717ab906a537bc747d
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30803
+  timestamp: 1675441638631
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+  sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
+  md5: 0a959fbad46ab38ade48dbd358002674
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1864757
+  timestamp: 1684280094736
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+  sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
+  md5: ea24b5076ef79e4567c5a3f0cb22b470
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95330
+  timestamp: 1690223465114
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+  sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
+  md5: bcaea6d4a47e9c874becaa700c78dcf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157216
+  timestamp: 1661452617825
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+  sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
+  md5: 707110d1b49cb1864acb0bbaa103591e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 95016
+  timestamp: 1636111184034
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
+  md5: 113a443b9c706f9f9c6187c0eaa3de27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31178
+  timestamp: 1605305861851
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+  sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
+  md5: 85a8d0001db70e52a479155228cb1fe0
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13324979
+  timestamp: 1694439878265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+  sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
+  md5: 47c5e22e31ec05a7bc0ce90065a53afd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 265348
+  timestamp: 1661368839620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+  sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
+  md5: ce9a69e1668aa1e133f2aa6d4e8d346f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 254958
+  timestamp: 1695131709704
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 9ee098c09f31fad7ff1856e5ce2619172eaf979997e7a427d1e05cce32c2af00
+  md5: cac1d1898b69ae9646dfbf082910635d
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40946
+  timestamp: 1685030787453
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+  sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
+  md5: 637f08b19dd8fd87347d8c44f9e3e202
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 170776
+  timestamp: 1698096100056
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+  sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
+  md5: 8ce3ac7d8a04e469b566f1b090d01140
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 470617
+  timestamp: 1657724324011
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
+  md5: 6f2d41dd76a03b7f85a1ed49af1763d6
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95100
+  timestamp: 1690400262627
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
+  md5: b0321e6f14e139fc15b1f8b4acb35d2f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093966
+  timestamp: 1690290944588
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+  sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
+  md5: 62b64576a0aa5f6c3fb05f56650d25e1
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15535
+  timestamp: 1614030509324
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+  sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
+  md5: 15b5595b31e39f08eaacbe2e502d8fb3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67292
+  timestamp: 1696347733587
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+  sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
+  md5: 82e4db6a498480a75d53c55bd35b6478
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1801397
+  timestamp: 1681394807900
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+  sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
+  md5: 63b957927b9949ccb19da28ec4612706
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30902
+  timestamp: 1671751919031
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+  sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
+  md5: e346257a2fa8e2cb48c762138a5d009b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39915
+  timestamp: 1668168959656
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+  sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
+  md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
+  depends:
+  - zlib >=1.2.12,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3536231
+  timestamp: 1654088937695
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+  sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
+  md5: a1bbf0abfb8c45541122c0eb2feee317
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680464
+  timestamp: 1696937112175
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+  sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
+  md5: d689f6203c0a9d04fb229c73d7e80a7a
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125145
+  timestamp: 1679561909274
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
+  md5: 8a292c1ee22489bef2e84bc3aaf4098e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193141
+  timestamp: 1671143985219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
+  md5: 8bf0bfffc11ad06a1c94e145941b0ad4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9651
+  timestamp: 1690297655669
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
+  md5: 343514a174b3485fde55a73f56398dd7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58456
+  timestamp: 1690297648002
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+  sha256: 11e7401cb6805db7ce22b1f9dd6ba5b7941c92225ce440bed1da0af284bfcad4
+  md5: 5c10d68fa5616cdd82ee93ef6e0f038c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11615
+  timestamp: 1659769478980
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+  sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
+  md5: c2242e8fd24003a74ddf37416661e06d
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188757
+  timestamp: 1698257668273
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+  sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
+  md5: 41f445e36b6b6722a9444508eef069f8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20583
+  timestamp: 1607365395045
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+  sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
+  md5: 409ee46ed24267b6da6fb32d13e1f21e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70730
+  timestamp: 1614804271285
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+  sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
+  md5: eb74e74d8e4fd533c55eb98b7b5e83bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102637
+  timestamp: 1695742077778
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+  sha256: cb007615819fd240ea4e343835dfbda3c508a92b5b7158219d30a22d0e67b57c
+  md5: bf215e781ac81e0fc433eedee330c54b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49462
+  timestamp: 1675159191191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+  sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
+  md5: e243baa546432c8394a8059a44a5a3e4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 419227
+  timestamp: 1683113010463
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+  sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
+  md5: fe4ac85ee86d3a94ea3a4ebea3779763
+  depends:
+  - libcxx >=10.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 321797
+  timestamp: 1616055526986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
+  md5: bc7073d9d4c0211cc4a1207c98fb765a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19091
+  timestamp: 1672387204865
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+  sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
+  md5: 8e495591e369ac161857a72011c0a296
+  license: Zlib
+  license_family: Other
+  size: 120272
+  timestamp: 1666595024203
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+  sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
+  md5: f1465fbd810b3746c6de6babfd4fe28a
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1023573
+  timestamp: 1681304595869
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+  sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
+  md5: cf55cb8d7031b30c70c56fc7c782b5c7
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 156104
+  timestamp: 1644482799136
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+  sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
+  md5: 84fce327d9f0d594e86f565e5c21962e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10183
+  timestamp: 1629146082730
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+  sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
+  md5: 84b8b998a741b37abf5312c1c03696ef
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33979
+  timestamp: 1644845817952
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+  sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
+  md5: 77b746931c8f31c3ae393ccb5819d43d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133628
+  timestamp: 1695717890677
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+  sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
+  md5: 3df6e8ba34208dea068890e5d5318cc0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206759
+  timestamp: 1681493095987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
+  sha256: 8c31e7ede4b9a3ec6e1342f02bcff4d7113e5b25f12b91d108616a08eb8eb34f
+  md5: de3ce22af040eb01db773fcab23ef413
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5722206
+  timestamp: 1697490482051
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+  sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
+  md5: bb55f81435cb6e11d264242274fccd1a
+  depends:
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 115947
+  timestamp: 1657175645380
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
+  md5: f860193e14afc7ef3f5b990a2ac003d2
+  depends:
+  - brotli-bin 1.0.9 h1a28f6b_7
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18936
+  timestamp: 1659616204016
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
+  md5: ad53130f3fd1f8d3c2fcbb7496e5585d
+  depends:
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18715
+  timestamp: 1659616188888
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+  sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
+  md5: 0982c046fb976e9f9fb19e7510187a18
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 366983
+  timestamp: 1659616245272
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+  sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
+  md5: 31ac2f5596cb7a44adf073c930641c54
+  license: MPL-2.0
+  license_family: Other
+  size: 133817
+  timestamp: 1694009762858
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+  sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
+  md5: cf1f6c3c34a1e1b9ab22b04233d860f6
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159783
+  timestamp: 1690232303987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+  sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
+  md5: 0eb268e38b5174d471a6e87d9d6102b1
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225355
+  timestamp: 1670423312966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+  sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
+  md5: e68c94666cd60221b575c3814c89bac0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1946451
+  timestamp: 1668084573824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+  sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
+  md5: 1773ae2b080cdd55827e27673351551e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13646
+  timestamp: 1671231171682
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+  sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
+  md5: 53bfd99ad1b09164d537209cffd98161
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 244040
+  timestamp: 1663827469853
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+  sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
+  md5: b62455043c8eb2434466885b19fed2de
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1399573
+  timestamp: 1694211828228
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+  sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
+  md5: eb3cdc0fc210838b9271512a6a1b7c85
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2067708
+  timestamp: 1690905319109
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+  sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
+  md5: f44b80b9405410e5bde6bfe0b31d5b3f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 15135
+  timestamp: 1650293774207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+  sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
+  md5: f87027ccce1361d0f82c0edf1a10d53b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27677
+  timestamp: 1668714367519
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+  sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
+  md5: 1d0bd7e576c64c059ef781dd319ad82a
+  license: MIT
+  license_family: MIT
+  size: 77591
+  timestamp: 1676983230102
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+  sha256: 3e480af22e98246c056bbd91d6be5352df34ff2b8451d9c7f614baeafb450d39
+  md5: 695fe7ccaf6935d3117533d1e6737320
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4542265
+  timestamp: 1698866834303
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+  sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
+  md5: 69eb3b03765627b6159ed23cdde78396
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28399065
+  timestamp: 1692293207812
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+  sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
+  md5: 83366cbd3beb073112f4644a613b6bca
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111933
+  timestamp: 1666125627512
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+  sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
+  md5: 647c1a2f8460ffa8c670a1915bbdb494
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38790
+  timestamp: 1678997152549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+  sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
+  md5: 35e541905426c686ef2ff010a0e502fd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51860
+  timestamp: 1698254731870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+  sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
+  md5: 187d7720aedf38759d122cccb4576f2c
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 219976
+  timestamp: 1691121991680
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+  sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
+  md5: e8e7f10741f9cfa737b310b334940441
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1255894
+  timestamp: 1694181494549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+  sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
+  md5: ff209e75aee17af2e358b0008fbe8c88
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1022945
+  timestamp: 1644315931223
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+  sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
+  md5: d3e78ef296b3c74910d003bd10b475d6
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213972
+  timestamp: 1666908195870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
+  md5: 055e12390b844ea6c6e956ee08a618e8
+  license: IJG
+  license_family: Other
+  size: 273479
+  timestamp: 1677849171867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+  sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
+  md5: 783e2ad3d36472648c5ccc9f3051db3c
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133077
+  timestamp: 1676558732505
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+  sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
+  md5: 0677598f673f9729b5990316170a999d
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 197129
+  timestamp: 1676329661580
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+  sha256: 05f9ca0fdcfdc2e217438be27fead588c843a3aadf7d034467c83216d1e5c214
+  md5: 2d648b77d817ba38293c0728711ba8f5
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92852
+  timestamp: 1679906632236
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+  sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
+  md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 401319
+  timestamp: 1671707682572
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+  sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
+  md5: 247558a0aecf1ef7e77a4343761353d6
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64600
+  timestamp: 1672387273585
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
+  md5: a0f206782751dfffed0dd51302a1bf26
+  license: MIT
+  size: 68012
+  timestamp: 1659616138077
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
+  md5: 4c6667cdd061d28e9bc4e4300e4d115e
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 31173
+  timestamp: 1659616155596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
+  md5: 637e9430e258ddf050623ef2360184d8
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 298430
+  timestamp: 1659616172209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+  sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
+  md5: 55c615026c0869f8d3ba657f3bd38c43
+  license: MIT
+  license_family: MIT
+  size: 120389
+  timestamp: 1683716579036
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+  sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
+  md5: a41117710dafe569c9cc4e83f6f29fe3
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1411339
+  timestamp: 1650982753977
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+  sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
+  md5: 98d22e0124d55fae3c37c608dab1dcc9
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 89825
+  timestamp: 1694778225280
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+  sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
+  md5: 0ba499df6755eae5d2d23aa4ab004553
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 642657
+  timestamp: 1692970217410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+  sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
+  md5: c73101971e5ab6a8e8688239884eac81
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241607
+  timestamp: 1692973585084
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+  sha256: ac50f846e93e68d50bfdd5589ea8272b987243a64eba8e2e358ef311d7734001
+  md5: f19270ff954a41dabbfe36ff0656935b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 36040
+  timestamp: 1659783399073
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+  sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
+  md5: 353dff9d5d996c2a260f66381b2ce3e8
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1470815
+  timestamp: 1695058433965
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+  sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
+  md5: c99006da802a97c9aae30da8c16b4820
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176131
+  timestamp: 1670944706815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+  sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
+  md5: 60bd1e037cda86205526f77405d78129
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123361
+  timestamp: 1671541992772
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+  sha256: 2fd690fa3c54a40f0426874ea12e12aad2718263a75708ddd1fa6052a4ad7fb3
+  md5: 81388724babfe9c32ea5cdd93633c342
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 107072
+  timestamp: 1684280007887
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+  sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
+  md5: 34dfd76da78de2eae95bbda390d746d6
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23092
+  timestamp: 1654598007056
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+  sha256: bf0eeef3c3c713515766ab8b0dc7863413de5b4b227deede97e24d90ca342345
+  md5: a7bba1857eb84fb50caea377e60d2050
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8066509
+  timestamp: 1698692266161
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+  sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
+  md5: eb79dabbeedee7da85dfbfb145bb8a26
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17342
+  timestamp: 1662014601345
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+  sha256: f400ad75dd2890627dc948f3e2e6b19732d02c124723eaf22272026993a94d52
+  md5: 4a4ffc7365e30b18f4443281839e2718
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53505
+  timestamp: 1659721313693
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+  sha256: 20fb26a7ac748ce288cf8483a837b0c33f1348ae738bcdb69cdc2763c7bbf7e1
+  md5: a0aebbc6c170ebd8d4710fd70b3db503
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19562
+  timestamp: 1659716131839
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+  sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
+  md5: 56db7bd3ff511cd839bda081523b3edd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 55683
+  timestamp: 1629356128780
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+  sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
+  md5: 176e0dcaeb28393881bacf69941e3889
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8289638
+  timestamp: 1681756329011
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+  sha256: afc6f332c51a3defc69e4c4e641988c0556039b9cd42be22f3db5292c88ccf37
+  md5: 2bc409c7258160a9b739d08d5ffb5998
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 96942
+  timestamp: 1650373637069
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+  sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
+  md5: 150ea9fadddf21993d3328d3e48a18b7
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 557688
+  timestamp: 1668450759059
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+  sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
+  md5: 37163b32508f9f589b3e6462a3a47546
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148426
+  timestamp: 1694616771736
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+  sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
+  md5: 6cdf7cbc43bf40e92b056a5576bd0086
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387216468
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+  sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
+  md5: 0f05853a139b6cda9c73e9d2707a4976
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 590288
+  timestamp: 1690984971741
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+  sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
+  md5: 7de782e4fb34bfa95ef2fc79d27d727d
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22840
+  timestamp: 1668160634885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+  sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
+  md5: 1a7b23113372c5667dbfe45976b9cc5c
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 126357
+  timestamp: 1696515322390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+  sha256: 3cd1161558704176560843586b1b1f9b257fd68c0ca53a2fc09e61267f47514c
+  md5: dd162b2716dc9daf732240a343862d4a
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.26.0 py39ha9811e2_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10388
+  timestamp: 1695830584640
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+  sha256: 5f35d8c0e1768fa3a9d2e75659cd2096bea6b4e021afea114f573e95f4943fb2
+  md5: 958f78b1e2299537996f98da7a930198
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.26.0 py39h3b2db8e_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6313331
+  timestamp: 1695830570878
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
+  md5: 371358a54bbdd307603888348d1a2c6f
+  depends:
+  - libcxx >=12.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD 2-Clause
+  size: 412248
+  timestamp: 1628861367714
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+  sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
+  md5: fa15d3b44ae1360ac9b640bbd5b6923c
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4746123
+  timestamp: 1695322833432
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+  sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
+  md5: d73db95f07a282021efdf8bc09713261
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73620
+  timestamp: 1693575195999
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+  sha256: 247b5e4d81b6d5d013a9c27e1f30c41fff896fed98a68ebda26b19b4062a6828
+  md5: 354a1d65300b4309d53dfa648014e8fe
+  depends:
+  - bottleneck >=1.3.4
+  - libcxx >=14.0.6
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - lxml >=4.8.0
+  - matplotlib-base >=3.6.1
+  - tabulate >=0.8.10
+  - pyqt >=5.15.6,<6
+  - openpyxl >=3.0.10
+  - s3fs >=2022.05.0
+  - pymysql >=1.0.2
+  - beautifulsoup4 >=4.11.1
+  - scipy >=1.8.1
+  - xlsxwriter >=3.0.3
+  - fastparquet >=0.8.1
+  - xlrd >=2.0.1
+  - blosc >=1.21.0
+  - zstandard >=0.17.0
+  - psycopg2 >=2.9.3
+  - pyarrow >=7.0.0
+  - pandas-gbq >=0.17.5
+  - pytables >=3.7.0
+  - sqlalchemy >=1.4.36
+  - odfpy>=1.4.1
+  - numba >=0.55.2
+  - jinja2 >=3.1.2
+  - pyreadstat >=1.1.5
+  - gcsfs >=2022.05.0
+  - qtpy >=2.2.0
+  - html5lib >=1.1
+  - xarray >=2022.03.0
+  - fsspec >=2022.05.0
+  - dataframe-api-compat >=0.1.7
+  - pyxlsb >=1.0.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13257999
+  timestamp: 1697478739906
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
+  sha256: 90a1889cd0004bfc5e12ac94b4ea92718a473373033bb0ba5259804ed67bf2bc
+  md5: e89f615737385fee88150ab4adf037e6
+  depends:
+  - bleach
+  - bokeh >=3.2.0,<3.4
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.0.0,<3
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.17.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17147015
+  timestamp: 1698866800249
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
+  sha256: 0ae09c974297767a707642344c40f484281f0a3000251a6234e46ef19f00c10e
+  md5: 64a0eaf3381e9f6aa971229501710798
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189313
+  timestamp: 1698263486159
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+  sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
+  md5: 6e01c592ae3b8ff2d12cae76f2f4276b
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 715239
+  timestamp: 1696580071596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+  sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
+  md5: 9fb8f460c130d56caf33c6bbe46fbe8a
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2678841
+  timestamp: 1697548790931
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+  sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
+  md5: 390b8c3cd74281abecdbfd51476922f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33033
+  timestamp: 1692205747301
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+  sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
+  md5: 7896828fb3565fefad43f980d50c8723
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91190
+  timestamp: 1659455206354
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+  sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
+  md5: d934c74eb66d01af0f45f0881f4bab77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580588
+  timestamp: 1672387390426
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+  sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
+  md5: 9858166e5ffb624c8b9d281f4000d725
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 367167
+  timestamp: 1656431368885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+  sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
+  md5: 4d2b45c6be8221e6a3e44c2d5838426f
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30843
+  timestamp: 1675441531640
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+  sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
+  md5: 02521df4e2e79f75faa9cbb3560ab1dd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1861763
+  timestamp: 1684280026169
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+  sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
+  md5: bdebe59bffc7adbad83fdcd9d429a5f5
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95234
+  timestamp: 1690223494699
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+  sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
+  md5: d716e5c9b5eec45ce1df8eb52cab817a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157408
+  timestamp: 1661452601692
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+  sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
+  md5: 1907629863ed8e7c35ead232dae7693f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 91636
+  timestamp: 1628941083263
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+  sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
+  md5: 847b9bddf2a86e1609c0d53bbc23ea79
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 27378
+  timestamp: 1626781391140
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+  sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
+  md5: 18aa18bd0d260605923877921d26cc74
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13194025
+  timestamp: 1694438901368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+  sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
+  md5: 45642a99c83e7aed74d1ffab1f20145b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 266647
+  timestamp: 1661368655993
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+  sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
+  md5: fec748525144049a2fc7f52f9755232c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257235
+  timestamp: 1695131702047
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+  sha256: 960192a143672e9c1d6fe4027af448512d91eee7501e5c245c21b865cf8bf429
+  md5: 76d491244218505f071ba56a308673df
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40950
+  timestamp: 1685030774581
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+  sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
+  md5: 3445d25415998c807efbe64d3a7e03c8
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 167068
+  timestamp: 1698096118071
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+  sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
+  md5: e6e92da28e9b0e428ed4b7df417bec25
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 472418
+  timestamp: 1657724315435
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+  sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
+  md5: dba22515f36d3c266de5896350813ea2
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95103
+  timestamp: 1690400315537
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+  sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
+  md5: 3cd7eb43e285faba76faf67667e26b00
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093916
+  timestamp: 1690290951258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+  sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
+  md5: c5e9aef0d6895de1c927e9d796cd7cd3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15691
+  timestamp: 1629145910454
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+  sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
+  md5: 0f7c229e774146ffc4e29dedf75372bf
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67279
+  timestamp: 1696347632563
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+  sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
+  md5: 2302a79a045f152e183a52a81adfba62
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1674163
+  timestamp: 1681394762218
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+  sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
+  md5: 4ae67163d55cf9df83d4027ebc38c501
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30894
+  timestamp: 1671751931536
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+  sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
+  md5: dbb5c0cddb6661a89afee647fd3dc01e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39875
+  timestamp: 1668168874870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+  sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
+  md5: 667e60c8b407d73cbba40f44901f4f00
+  depends:
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3412693
+  timestamp: 1654088929697
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+  sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
+  md5: 884f788a5f6a664c9b79f7a4a60362d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680561
+  timestamp: 1696937004165
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+  sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
+  md5: 639a4f489af172c866c18442948e5874
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - slack-sdk
+  - requests
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125170
+  timestamp: 1679561942932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+  sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
+  md5: e5b90eba83fddba6d7aa6072b5bf7c91
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193017
+  timestamp: 1671143921826
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
+  md5: 644ef8830437070f60efcfcd6a987198
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9670
+  timestamp: 1690297532002
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
+  md5: a902a833bb186a2f1a4b2b89b1195136
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58466
+  timestamp: 1690297524418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+  sha256: 536045a8a172c651fd306c285a6d7409775f018dac944f2124c538ccfb195e28
+  md5: d4dc6cdf0812191b9ec78b35b4fdf3e0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11593
+  timestamp: 1659769477205
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+  sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
+  md5: f3f1d2c1028dad2f11ff950a15c99dbf
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188640
+  timestamp: 1698257577209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+  sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
+  md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20091
+  timestamp: 1629144441130
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+  sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
+  md5: 3089c63bf8f4d0423e1a287da286d83e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70923
+  timestamp: 1629357115820
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+  sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
+  md5: 5886b30b312445471268444f41f39dc7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102583
+  timestamp: 1695741976083
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+  sha256: 105e39d3eb51b47c7244b3379c0133ab7051966664f52835453b14509215b159
+  md5: ed20012c2cd99ffd04cca9929e0bc061
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49775
+  timestamp: 1675159079039
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+  sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
+  md5: 2e75ad6a09c308268192efe03cc9ebf4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 411778
+  timestamp: 1683113019715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+  sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
+  md5: 30f666bf97c26587c5d2f68cc5f330ab
+  depends:
+  - libcxx >=12.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 316901
+  timestamp: 1629287855861
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+  sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
+  md5: 584e591d36dcd5ba5c45404f0f7ebb2d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19076
+  timestamp: 1672387153578
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+  sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
+  md5: 467ae28215d1aa1c5688bc0c8a184269
+  license: Zlib
+  license_family: Other
+  size: 103525
+  timestamp: 1666595022664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+  sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
+  md5: 7cfbed15f1feee1422810f7830075f53
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 779464
+  timestamp: 1681304594848
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+  sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
+  md5: ed14f9bc6e55220483f1a5a388625a08
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162772
+  timestamp: 1644481986085
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+  sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
+  md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 39253
+  timestamp: 1644551767970
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+  sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
+  md5: b24d13c443a26f65a0778b475a5726bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132830
+  timestamp: 1695717959996
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+  sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
+  md5: 302c3c0696e17eaa62e140e3892644ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 199723
+  timestamp: 1681493196911
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
+  sha256: 812f268862208c2518b5187809a8571adb488de3604d512721035e65458dde76
+  md5: 97ce620b7dd3ee743d0ca28ed66ace74
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5721832
+  timestamp: 1697491241383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+  sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
+  md5: bf930260f679bc74227bbb18bc36ae82
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 119700
+  timestamp: 1657176150595
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
+  md5: 507dfe693ef429f466d964b599f4af21
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_7
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 18650
+  timestamp: 1659616328001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
+  md5: d0bf43e8df60baae3b3105aa5c42a791
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 21153
+  timestamp: 1659616312367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+  sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
+  md5: 7bd24bf94c24e810aecaaf84a0978e6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 343204
+  timestamp: 1659616543542
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+  sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
+  md5: 092b417c11edcbe6bb9b765ab4a55d23
+  license: MPL-2.0
+  license_family: Other
+  size: 164999
+  timestamp: 1694009822357
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+  sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
+  md5: 708a750d370b9d6875651021e21c4446
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159322
+  timestamp: 1690232335307
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+  sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
+  md5: c35736da3ea26782425e78061268cf5e
+  depends:
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 228713
+  timestamp: 1670423312743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+  sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
+  md5: 457a4339a53c033d48ce0c72e5038d2e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30330
+  timestamp: 1672387265402
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+  sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
+  md5: 59ec65fd9e06b81a65cc12986c67d5da
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1939614
+  timestamp: 1668084794027
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+  sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
+  md5: 3489c1a2b73fc957b5a62cc59349e25b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13438
+  timestamp: 1671231196438
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+  sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
+  md5: 3492b96083c1e904cc32d26ea7f1e1d8
+  depends:
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184280
+  timestamp: 1663827558327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+  sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
+  md5: f46d904bc6f220327e70474971341f52
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1220835
+  timestamp: 1694445639066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+  sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
+  md5: 2ff4fb509788b0e47ac684ba151394d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3289966
+  timestamp: 1690907040646
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+  sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
+  md5: 0f166c3e70541d8bee6e9d0cb60fb66e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16979
+  timestamp: 1649926678161
+- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+  sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
+  md5: ea93d413944ca6a8677eb1b284b136ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27388
+  timestamp: 1668714577678
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+  sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
+  md5: 9f167d3e45441bc3633c1974b1b0ce8c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 88421
+  timestamp: 1676983264486
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+  sha256: fa8f868e49721ca19912f816a6da221172758f9e3d28d8b31d53249fb14dc25f
+  md5: 09f9a2cea9425d76dccf9b026afe5bb2
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4576915
+  timestamp: 1698866895838
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+  sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
+  md5: 30fdefd1541c789c163751291a8faa88
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111448
+  timestamp: 1666125667599
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+  sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
+  md5: a10f07c7a3510272a296f9fed458a4ed
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38098
+  timestamp: 1678997241511
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+  sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
+  md5: fad9cf2023d807da8d44996e9d4399a0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51490
+  timestamp: 1698254721864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+  sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
+  md5: 9834848bd7c7759acf12e78d09388563
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3891030
+  timestamp: 1681801474383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+  sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
+  md5: 1285c8c628bc912c54d0968574c9f4c9
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217232
+  timestamp: 1691122695748
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+  sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
+  md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
+  depends:
+  - backcall
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1279433
+  timestamp: 1694181820978
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+  sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
+  md5: f5fcce35d3f21cdfc5893c5a7a86c651
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1035394
+  timestamp: 1644315567034
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+  sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
+  md5: f67fe3337528e2886f1ac3ab8ac37985
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213110
+  timestamp: 1666908350218
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
+  md5: 81f2c343dc4c65eea39c45383272068f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 407861
+  timestamp: 1677849239400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+  sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
+  md5: bd9526d38a145fe311a8aa36bc11e071
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 152006
+  timestamp: 1676558783570
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+  sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
+  md5: a00e6a62956fde3c4135464353ee8a53
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229158
+  timestamp: 1676330909084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+  sha256: db8335d6531b03c7bdfe789ebacc52631ac6ea4a37700bb3da1f6a53a1acd724
+  md5: ebeba61994cc225ea5f4f42caa511019
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116681
+  timestamp: 1679906658986
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+  sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
+  md5: 5efa1332f7c0a8d9638eda02170c4ce5
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pywinpty
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 413653
+  timestamp: 1671707957673
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+  sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
+  md5: 891fe66a24d8714737b2874985ee1303
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62298
+  timestamp: 1672388166096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
+  md5: c345f51706eef530454f66b794e5e574
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 68189
+  timestamp: 1659616216976
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
+  md5: a7400cfb72042977bc047909ed504ce8
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 33743
+  timestamp: 1659616248209
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
+  md5: 6307f6854754ab5bd7c84e6998385bb1
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 733177
+  timestamp: 1659616279453
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+  sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
+  md5: b812bc5d9c76242e2bb2ac87afe7d39b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 730280
+  timestamp: 1650983734373
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+  sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
+  md5: ba9418df9288a2f031a02fa35b774ce0
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78524
+  timestamp: 1694778314659
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+  sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
+  md5: 6ece7f1a3248169837714d05d7f6ef0a
+  depends:
+  - libiconv >=1.16,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 3513910
+  timestamp: 1692971505729
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+  sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
+  md5: bd7ec244935e83e850a4ff34e8e2e64f
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 513971
+  timestamp: 1692973657152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+  sha256: e1c0e745d9ba36a80773e841d96bf514ad1ceda419e4188aad3c22782af00234
+  md5: f226532e9bb308f20e874c56be6ceefb
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 35788
+  timestamp: 1659783414586
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+  sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
+  md5: fb7881e74b59262df0fa4ec981964efc
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1244887
+  timestamp: 1695058550693
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+  sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
+  md5: 6970c7f46b0164cad1d210e7a1419959
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143434
+  timestamp: 1670944902624
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+  sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
+  md5: 1015298551c040c6d5e26eebbae12ef5
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142316
+  timestamp: 1671542240512
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+  sha256: ab5c246c2b271acc1cdd0b9343989c0166681536e569cdbe71618f55d34c7292
+  md5: 7ce68d771cd94c9ff5efefe69d327c9a
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 125122
+  timestamp: 1684280210213
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+  sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
+  md5: 466da740fafef3d6bce114220f0be306
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28510
+  timestamp: 1654508162239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+  sha256: 1687ae122ee7d8b583141fc5014b76d494841dc8083b854449e3d6e0f6bb7019
+  md5: 3697ac26ee3c2d49338dd5b9c6551152
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8080067
+  timestamp: 1698692812610
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+  sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
+  md5: a9fa43e694b25cd49b8b08a9eefd696e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18054
+  timestamp: 1661915903969
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+  sha256: 8aa14047fac6ef8b326900c4bf1a960eaa7a1699c18fdf1e75a59101b610b6df
+  md5: 7e1d4d4700fbea6171d30f1d5ad24226
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53362
+  timestamp: 1659721308586
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+  sha256: 2017814a7cc93dd51c6b7c016e3cdf8fbc32fa20f985638aaff6a6377e9ee086
+  md5: a1a285c56b001c3b5c591bf21eec3149
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19326
+  timestamp: 1659716205153
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+  sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
+  md5: 248c468abced874f0231d3cc23177c77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58488
+  timestamp: 1607359497934
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+  sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
+  md5: 5e763c995ff0c549f68a10bce70fede4
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187489950
+  timestamp: 1691503804820
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+  sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
+  md5: dd0c2ece6a743c373c9b5a5919b4818f
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49744
+  timestamp: 1682975040154
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+  sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
+  md5: 57cea8df7ab85f2a98f64d23afcb1f90
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184956
+  timestamp: 1695058491736
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+  sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
+  md5: 8769cdd201d905069800488fe31574e5
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 256221
+  timestamp: 1695060152521
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+  sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
+  md5: d9781492332e6326f9fca87f3a8efacd
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8135792
+  timestamp: 1681756491399
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+  sha256: 2dd3178d3c570e30b9490ebabfd7bfac806afad8302d3dee0edc619805034397
+  md5: bef9da0f0694c45b6aaa4e6447479eaf
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 118324
+  timestamp: 1650290466135
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+  sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
+  md5: f1d8ce412e115986c403f223b3b47d0f
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 596314
+  timestamp: 1668451106600
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+  sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
+  md5: f96bbef0985d7e66ebf00c0d55e30e23
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 167045
+  timestamp: 1694617078743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+  sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
+  md5: 6e6ba64c8dc5025aeac606404a8df36a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13786
+  timestamp: 1672387480065
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+  sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
+  md5: 4a7a3286484766741f627696697c362c
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 609425
+  timestamp: 1690985686105
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+  sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
+  md5: 4269a1f93882205b90d4b2ae78fc82d5
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22417
+  timestamp: 1668160717305
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+  sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
+  md5: a18a576b7024cfd6f905c526a786a916
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 135285
+  timestamp: 1696515698492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+  sha256: e5e11f9b42d770ee46ac24d1cdf7aa4e9c49a60a607c8c28e7729131a99eadd5
+  md5: 4274d06db8a9a381c072d226d0322dc0
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.0 py39h65a83cf_0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9835
+  timestamp: 1695830845329
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+  sha256: dcaa1607ce40a0ed610dd5398e125c8e5b08e738e50b6037a8c72b49ca561ff2
+  md5: d99d990a60644b97ba1ff9bb8da0e66f
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.26.0 py39h055cbcc_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6778113
+  timestamp: 1695830816710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
+  md5: ab07e2a27ac08afe3d0b4c0890b8486a
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 2-Clause
+  size: 249316
+  timestamp: 1630094024143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+  sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
+  md5: 73b17037d87b5a58feb34dafc0538f7f
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8058396
+  timestamp: 1695324589828
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+  sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
+  md5: df1d746ba8d5d6ba01ac1373b9b71e1a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73016
+  timestamp: 1693575484990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+  sha256: 1994e5831fd421bd6cf85916073d4012dec53e673b672b3985efaf771f0a7bf8
+  md5: c486a5b51e3227f6ea564a9dd3125e45
+  depends:
+  - bottleneck >=1.3.4
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - openpyxl >=3.0.10
+  - jinja2 >=3.1.2
+  - qtpy >=2.2.0
+  - numba >=0.55.2
+  - pyreadstat >=1.1.5
+  - zstandard >=0.17.0
+  - xlrd >=2.0.1
+  - tabulate >=0.8.10
+  - fsspec >=2022.05.0
+  - pyqt >=5.15.6,<6
+  - xarray >=2022.03.0
+  - xlsxwriter >=3.0.3
+  - beautifulsoup4 >=4.11.1
+  - html5lib >=1.1
+  - fastparquet >=0.8.1
+  - pyarrow >=7.0.0
+  - pyxlsb >=1.0.9
+  - matplotlib-base >=3.6.1
+  - odfpy>=1.4.1
+  - pytables >=3.7.0
+  - sqlalchemy >=1.4.36
+  - psycopg2 >=2.9.3
+  - blosc >=1.21.0
+  - lxml >=4.8.0
+  - pymysql >=1.0.2
+  - gcsfs >=2022.05.0
+  - pandas-gbq >=0.17.5
+  - dataframe-api-compat >=0.1.7
+  - s3fs >=2022.05.0
+  - scipy >=1.8.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12629931
+  timestamp: 1697479885371
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
+  sha256: 270e4c3ab0f0c8d8f31fa0e45bc516c1e41be618a5c66e1c86dc39ce76cb2372
+  md5: cad52ba9eb391416112f0994b6c35249
+  depends:
+  - bleach
+  - bokeh >=3.2.0,<3.4
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.0.0,<3
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.17.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17162886
+  timestamp: 1698867967809
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
+  sha256: 56eaf7f4b1bb81e3deed55711dd2ee78f244a3cc0ad4bb7a1f09d97e46f9793f
+  md5: c24a3daed1e85ba7a100fa6966c5bb48
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189021
+  timestamp: 1698263520538
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+  sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
+  md5: 427c1450bebb632f43bbc8c83006e4cd
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 806931
+  timestamp: 1696580240310
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+  sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
+  md5: 21790cd3e2b8a45c4104aff0a68330d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3001751
+  timestamp: 1697549357662
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+  sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
+  md5: 56f44a1054da2d10777e375838191070
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 32355
+  timestamp: 1692205784293
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+  sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
+  md5: 8a35ad65651086575ce55371f22feda8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91045
+  timestamp: 1659455316472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+  sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
+  md5: 186eb95f816a2eff80c3c7f7d964c7b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 578514
+  timestamp: 1672388155359
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+  sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
+  md5: 47b6cbe6ce9289e47d16900b03596a91
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372807
+  timestamp: 1656431445633
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+  sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
+  md5: 07165c444adc7c7ccc8a345875adc5ef
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48408
+  timestamp: 1675450623287
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+  sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
+  md5: d58e76a31e2f6e7410ba4afd7f385b0d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1877445
+  timestamp: 1684280183367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+  sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
+  md5: 0e5b0fe7debbf558ce97090f6b67cdae
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94633
+  timestamp: 1690225630423
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+  sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
+  md5: 0fde797653e4ab589506121fb1e37555
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157119
+  timestamp: 1661452591647
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+  sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
+  md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 92679
+  timestamp: 1636093365041
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+  sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
+  md5: f870859d4dc7a8d82cf3546bd9035f33
+  depends:
+  - python >=3.9,<3.10.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 54520
+  timestamp: 1605307564142
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+  sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
+  md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
+  depends:
+  - openssl >=3.0.10,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 21172845
+  timestamp: 1694442462066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+  sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
+  md5: 9d99075052265ae3d718582d3b875038
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269964
+  timestamp: 1661376543480
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+  sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
+  md5: fa9074d94236c9b768bfd2c858875b27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 264836
+  timestamp: 1695131770282
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+  sha256: 97243a31c39f4990c0e9d4f2307f2f7fb9421553303923bc105067ec4340bdff
+  md5: 8078c5760f27398eaf1082226647d137
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40145
+  timestamp: 1685031143383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+  sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
+  md5: 3d2841085778006c2e79f9c7300f8b9d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13565975
+  timestamp: 1669937633869
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+  sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
+  md5: 54a4bc0724041dd173088419d6ede2af
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 239062
+  timestamp: 1677611495106
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+  sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
+  md5: f39f84115e228bad4bceaefdd637f022
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 158558
+  timestamp: 1698096358091
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+  sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
+  md5: df398a3a1668fd2a22061764e20ea91d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.4,<4.3.5.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 460913
+  timestamp: 1657616061604
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+  sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
+  md5: 38db77ece9dc76feffb9ef7638e38258
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94397
+  timestamp: 1690400496655
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+  sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
+  md5: 3e284ae6b48ee30c364ffdc5601610b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1099842
+  timestamp: 1690291374842
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+  sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
+  md5: 993b3886b334bd1f49d34206f21997b4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15998
+  timestamp: 1614030572433
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+  sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
+  md5: 7ac9604ad7564ac0c71bff5db198656f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67012
+  timestamp: 1696347795139
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+  sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
+  md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1311308
+  timestamp: 1681402905668
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+  sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
+  md5: 28b9869d8d3a839918fac4a08f38cbc2
+  depends:
+  - python >=3.9,<3.10.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30546
+  timestamp: 1671752127904
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+  sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
+  md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39590
+  timestamp: 1668168880994
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+  sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
+  md5: 52cdcdb96383c010ca833a7c24b3935b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Tcl/Tk
+  license_family: BSD
+  size: 3690152
+  timestamp: 1654036853710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+  sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
+  md5: 0e054ab29119cf4c1f778613acf972f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 681780
+  timestamp: 1696937326924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+  sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
+  md5: b6ad839ebba536ad1c3cc58d0e2123f0
+  depends:
+  - colorama
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 143681
+  timestamp: 1679562248929
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+  sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
+  md5: fe78de10019085146f1cc6c94fdc2620
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192822
+  timestamp: 1671143999327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
+  md5: ca5fc3fbdb09b6de068a8b7a8869369f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9208
+  timestamp: 1690298120549
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
+  md5: a86e87a10e5fdff486265e0c675fb99f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57922
+  timestamp: 1690298106990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+  sha256: 8057d3d2a0acd44496de33c5b222063c3f7d06b90c74fbbda45bd18b0b324219
+  md5: 398f8db5bd8cab84b3d85a9d85fa4889
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11362
+  timestamp: 1659769459206
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+  sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
+  md5: 0d31859e0a097aedbcc1627db33b3d92
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188367
+  timestamp: 1698257883295
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+  sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
+  md5: 45ef24c486a484f079faf1dc90e4c7e9
+  depends:
+  - vs2015_runtime >=14.27.29016
+  license: Modified BSD License (3-clause)
+  license_family: BSD
+  size: 8277
+  timestamp: 1605602889180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+  sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
+  md5: 4daaceb6cfc1af6274509081d8018ef1
+  size: 2316783
+  timestamp: 1605602872095
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+  sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
+  md5: 916c16904615c7af3b5d37cb6694f45e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21084
+  timestamp: 1607347371925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+  sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
+  md5: da69e6987fcc757e83a358ceaa13f62b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73391
+  timestamp: 1614804425587
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+  sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
+  md5: 23b9f4634b2e5450be617114f62c74f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 120873
+  timestamp: 1695742300539
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+  sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
+  md5: 120f0b088290fc17bd6618fc10a2f0c4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PUBLIC-DOMAIN
+  size: 34293
+  timestamp: 1605306211299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+  sha256: a5d2a216d052105fdaad7256f23da3b29f95100d1dc0f29b6ab1f3bbc75e17a9
+  md5: a558f681ebc243f86cde2515c065b62e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48805
+  timestamp: 1675159123654
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+  sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
+  md5: c3f7871e9a33adeccee1b1e8e216918e
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 1332571
+  timestamp: 1683113347814
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+  sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
+  md5: 1ab55f8c4b5292ec360c572120bf823e
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-3.0-or-later
+  size: 9430705
+  timestamp: 1616055773485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+  sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
+  md5: 6875e0bf3828707dc9165d694c0d0a7d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18725
+  timestamp: 1672387612937
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+  sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
+  md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 148931
+  timestamp: 1666595229032
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+  sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
+  md5: 8d6a1e767775fe0eb617cd6e22edc2ff
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1871867
+  timestamp: 1681304638261

--- a/particle_swarms/pixi.lock
+++ b/particle_swarms/pixi.lock
@@ -7,636 +7,636 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
   sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
   md5: 2cf39d906cc321896ffe3e5d33d80c5c
   depends:
@@ -649,7 +649,7 @@ packages:
   license_family: MIT
   size: 162166
   timestamp: 1644463608931
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
   sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
   md5: 2972a84e0e22ae3244bbd2f1eebcf536
   depends:
@@ -660,7 +660,7 @@ packages:
   license_family: MIT
   size: 35352
   timestamp: 1644569715988
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
   sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
   md5: a68016b4b06460def24cb69d932986f3
   depends:
@@ -669,7 +669,7 @@ packages:
   license_family: MIT
   size: 132486
   timestamp: 1695717963702
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
   sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
   md5: 2f6356a2f530314b4059c08c79a3d8bc
   depends:
@@ -679,12 +679,12 @@ packages:
   license_family: MIT
   size: 205868
   timestamp: 1681493113570
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
   sha256: 2d8e75f31f75ea5eb8b9021b4c21eb2846a254a097e06eb68e66fc36a82e1bed
   md5: ae374a11c789a55555f70b29b9eff1f9
   depends:
@@ -700,7 +700,7 @@ packages:
   license_family: BSD
   size: 14430294
   timestamp: 1658136783940
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
   sha256: f84f9caa7eb9d489fd9634419fdf766d39293a5df1104b840fa0cdc5823a5c60
   md5: 922555c0435d6b2537cf8ced534b048c
   depends:
@@ -711,7 +711,7 @@ packages:
   license_family: BSD
   size: 141903
   timestamp: 1648028958291
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
   sha256: 0bbcb6f78eac530c6a084459ffab3238647b266d0c74d695e6e6387dd119cc67
   md5: bdc971e2a9affb5125b68ad708172dab
   depends:
@@ -720,7 +720,7 @@ packages:
   license: MIT
   size: 411301
   timestamp: 1602517685375
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
   sha256: 8c2071f706c2b445dabb781f7f8f008b23a29957468ec6894f050bfb3a2d5bf4
   md5: c203ffc7bbba991c7089d4b383cfd92c
   depends:
@@ -731,14 +731,14 @@ packages:
   license_family: MIT
   size: 357797
   timestamp: 1605539534667
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
   sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
   md5: 3ef00f4c5278b688552efc259c463dc8
   license: MPL-2.0
   license_family: Other
   size: 132731
   timestamp: 1694009767372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
   sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
   md5: d5cb3d97cf5e85ffe5e94037ed8a1169
   depends:
@@ -747,7 +747,7 @@ packages:
   license_family: Other
   size: 159077
   timestamp: 1690232254640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
   sha256: 674707b9c42e65c903c9786ee5a56b4d42aa054f1e75b328db8a2c1bfa368739
   md5: 76ae217198b014b89b267cf41b8251dd
   depends:
@@ -759,7 +759,7 @@ packages:
   license_family: MIT
   size: 231920
   timestamp: 1642701209740
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
   sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
   md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
   depends:
@@ -769,7 +769,7 @@ packages:
   license_family: CC
   size: 1917831
   timestamp: 1668084545510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
   sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
   md5: 13702d3b4b744784e5bd559c7050dd6f
   depends:
@@ -779,7 +779,7 @@ packages:
   license_family: BSD
   size: 12719
   timestamp: 1671231205875
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
   sha256: 821af57c20a85b4e92268fbf65fbaec2f273da5bb21889d9643756ef6e473237
   md5: f57e0f502500ffebdbec081ef61ad1d4
   depends:
@@ -793,7 +793,7 @@ packages:
   license_family: BSD
   size: 2179774
   timestamp: 1694445209134
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
   sha256: 3a39a2d6f161080c706292e3bf480f62d2444b1d6d67b3d7db50458202ee31f1
   md5: 0524ffca60f845eb392bbb56d56f0ce5
   depends:
@@ -804,7 +804,7 @@ packages:
   license_family: MIT
   size: 2094615
   timestamp: 1637091869922
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
   sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
   md5: 2e6ec51066d825ef3c317abe78d6049e
   depends:
@@ -813,7 +813,7 @@ packages:
   license_family: MIT
   size: 16413
   timestamp: 1649926472708
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
   sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
   md5: b4d923222d45314856b5378cb115214d
   depends:
@@ -822,7 +822,7 @@ packages:
   license_family: BSD
   size: 26728
   timestamp: 1668714462023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
   sha256: 8a121233d0b2cbb2463b67e798739ad2946f38933430a6a7fd1197cc6eab1c99
   md5: d2b24736491290a6c6d0138932111150
   depends:
@@ -832,7 +832,7 @@ packages:
   license: GPL-2.0-only and LicenseRef-FreeType
   size: 965280
   timestamp: 1635422707211
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
   sha256: 3c8ece1a7257b1d45f8fa25f46504bb709a1923d7175f2996e891366ec434b9d
   md5: 299bf4271d710651a1d71d3795580c2d
   depends:
@@ -840,7 +840,7 @@ packages:
   license: MIT
   size: 83592
   timestamp: 1603192039050
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
   sha256: 2d727f8335c59314b521b66d437ca4d51904134473ae503b7b097e239635f209
   md5: 6991e520f353d995023404f6f524d192
   depends:
@@ -857,7 +857,7 @@ packages:
   license_family: BSD
   size: 4507274
   timestamp: 1693378095165
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
   sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
   md5: 9213e0336e3a5216c989cfe52648412e
   depends:
@@ -866,7 +866,7 @@ packages:
   license: MIT
   size: 23805906
   timestamp: 1588026213084
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
   sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
   md5: 1eb52f9f45cea2fb9ce27b19f990160e
   depends:
@@ -875,7 +875,7 @@ packages:
   license_family: BSD
   size: 110793
   timestamp: 1666125606878
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
   sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
   md5: 126b3c1933b7364ff03f67455b687e99
   depends:
@@ -885,7 +885,7 @@ packages:
   license_family: APACHE
   size: 37588
   timestamp: 1678997134023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
   sha256: 1b424413f28b840fc6d4bf467f37e9e405823b1e3b899005df80152d48936d64
   md5: 4aa8bcf74c81cd3600978f791191692a
   constrains:
@@ -894,7 +894,7 @@ packages:
   license_family: Proprietary
   size: 9246735
   timestamp: 1634546760713
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
   sha256: b51b2e0dd37a74784ba19db22aded3f4c843b6fddb4a74399f65f36fc018aaa2
   md5: 0d56ab1950f952284b895ac0f78284a7
   depends:
@@ -914,7 +914,7 @@ packages:
   license_family: BSD
   size: 203541
   timestamp: 1671488675347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
   sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
   md5: ff47e0be879e817713ce2a9daa76e2b0
   depends:
@@ -935,7 +935,7 @@ packages:
   license_family: BSD
   size: 1261116
   timestamp: 1694181530670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
   sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
   md5: 5ef6c6a0d1ac79143c7359d305155167
   depends:
@@ -945,7 +945,7 @@ packages:
   license_family: MIT
   size: 1021637
   timestamp: 1644297140650
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
   sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
   md5: eaeb023688f781e7dd89e74310c38195
   depends:
@@ -955,7 +955,7 @@ packages:
   license_family: BSD
   size: 211775
   timestamp: 1666908212136
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
   sha256: 85348bfb14db4fea84078d703e766a3c978c5a592a06e41266748826dd59d8ae
   md5: 6e1c0fb5260c590f7ef5235cb3d05863
   depends:
@@ -964,7 +964,7 @@ packages:
   license_family: Other
   size: 279884
   timestamp: 1651065953960
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
   sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
   md5: 0d2c3c5edf671b575532d5a3e8bf15fc
   depends:
@@ -975,7 +975,7 @@ packages:
   license_family: MIT
   size: 131510
   timestamp: 1676558716852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
   sha256: 92bc012f9eb4ad71158cf4826fd3e125fcebff53b529276a81224acda48be547
   md5: c5fd100e3062e831cbdf33331042f627
   depends:
@@ -991,7 +991,7 @@ packages:
   license_family: BSD
   size: 190884
   timestamp: 1650622553813
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
   sha256: 0192bd48cd96c60dc3054d5addd8cdb4a29a218843181318371f79daec8242f8
   md5: d851b401dc13d04e6848bb36e12efc1c
   depends:
@@ -1002,7 +1002,7 @@ packages:
   license_family: BSD
   size: 91534
   timestamp: 1679906652183
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
   sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
   md5: a4beb461f0a60998a090d760b5c6c907
   depends:
@@ -1026,7 +1026,7 @@ packages:
   license_family: BSD
   size: 411564
   timestamp: 1671707702849
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
   sha256: 974df3dc76089be57b327acd6634384def84249003f58678ca1142bb274a75d9
   md5: 81b969d1a00153759b30554a1f11ddfd
   depends:
@@ -1037,7 +1037,7 @@ packages:
   license_family: BSD
   size: 92144
   timestamp: 1653292217019
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -1048,7 +1048,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
   sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
   md5: 9508af80612e4fa1b5d1abb43ca7e63c
   constrains:
@@ -1056,7 +1056,7 @@ packages:
   license: GPL-3.0-only
   size: 749072
   timestamp: 1652971360657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
   sha256: 3b4afe7665dcdb99bd4586a888b85b2e0325f8faecdd31c7780792080ee97872
   md5: 822b5201dde61bc838072dc5b670c88c
   depends:
@@ -1065,7 +1065,7 @@ packages:
   license: Custom
   size: 55183
   timestamp: 1594054267890
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
   sha256: c6fafbe73d2f93b91b6f4b65829f925f52a8f84746a57abd216b39da9ce8c494
   md5: 238f19c803a6ba7bd6dbd6989e03cbf1
   depends:
@@ -1073,7 +1073,7 @@ packages:
   license: GPL
   size: 8496776
   timestamp: 1560112207081
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
   sha256: bc3e6e79c32ff0ecea601aa108ae9cf4068f69703580e40e266ad4bcc52cff54
   md5: 9cb85601944ca7383b1769bff74b94e8
   depends:
@@ -1082,7 +1082,7 @@ packages:
   license: zlib/libpng
   size: 372914
   timestamp: 1556041895170
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -1090,13 +1090,13 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
   sha256: 43b0bd205f539583c088feb5b8d77b60c83d1df80c2a93dac9f2a1127001b2cf
   md5: 53fa39fdae936e9d07c4b2f5ef361993
   license: GPL3 with runtime exception
   size: 4246257
   timestamp: 1560112223556
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
   sha256: 711ea05b4c35bdafc762a172b01db896b17942f474c2b1a519f91370964bf9bc
   md5: b25d56d33596623a6a4a9d9baaa4f602
   depends:
@@ -1110,7 +1110,7 @@ packages:
   license: HPND
   size: 592974
   timestamp: 1653047881023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
   sha256: 146dbb1e4dbccdd57819e5102a8ca00970b8e33d6c6180e8007db89b184da569
   md5: c566a384259c1d2769852c3bddd81a67
   depends:
@@ -1124,7 +1124,7 @@ packages:
   license_family: BSD
   size: 90150
   timestamp: 1645441199289
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
   sha256: cffb5a063111f7a99a99c74770b23db5dde52325e25a7a46d1903d5ff4a82c88
   md5: eeb1bd66f28bed1956ab989d6eff7ae5
   depends:
@@ -1135,7 +1135,7 @@ packages:
   license_family: BSD
   size: 889956
   timestamp: 1645089138421
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
   sha256: 71f6c4a97014d745c58df52b4dd60ddd75a8508d54fe5b97f42bd1f31cb1c067
   md5: 686e77514ec9f1ef0a6feed374f14d37
   depends:
@@ -1147,7 +1147,7 @@ packages:
   license_family: MIT
   size: 789469
   timestamp: 1653546418059
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
   sha256: ea3355a67c5173f3944f09861043ca66eb7dbeff8f385d13528b3aabc0801d0c
   md5: 66e2aa12181bb2911485bdbe125d24c5
   depends:
@@ -1157,7 +1157,7 @@ packages:
   license: MIT
   size: 584199
   timestamp: 1654075843119
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
   sha256: 64b022d706b76c33965a250fdc8c6008443c41bff8ab27bb1df3cb70419576fd
   md5: ec4f05846aacf634df15c389235725cc
   depends:
@@ -1169,7 +1169,7 @@ packages:
   license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
   size: 1538261
   timestamp: 1646624639995
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
   sha256: 2c6a5dda7c510a961bc78e31d4232be5e8e0760c93454f5fd200c379355e0f5e
   md5: f35d4bf2fbb39e334992f6dd39f8721e
   depends:
@@ -1179,7 +1179,7 @@ packages:
   license_family: BSD
   size: 220865
   timestamp: 1627657046002
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
   sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
   md5: 421f82c8274b44660dba629134faa6af
   depends:
@@ -1189,7 +1189,7 @@ packages:
   license_family: BSD
   size: 122221
   timestamp: 1671541990505
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
   sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
   md5: feb0e452205b44ac45d9b5e55c21a3b1
   depends:
@@ -1201,7 +1201,7 @@ packages:
   license_family: BSD
   size: 22819
   timestamp: 1654597913064
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
   sha256: dc51b316ef5dcfb82a9c0afdc40879146ae59516f6cea7db776077783dfd2d76
   md5: b0b6b57c140f026b8806051107336576
   depends:
@@ -1223,7 +1223,7 @@ packages:
   license_family: PSF
   size: 7729454
   timestamp: 1647442028622
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
   sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
   md5: c04ef34af33da4c71bcc99b7ec24d210
   depends:
@@ -1233,7 +1233,7 @@ packages:
   license_family: BSD
   size: 16391
   timestamp: 1662014553452
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
   sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
   md5: f6c734d73e6e3dbc1b62766cf18ff3e4
   depends:
@@ -1243,7 +1243,7 @@ packages:
   license_family: BSD
   size: 58153
   timestamp: 1607364912263
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
   sha256: 7c4ded8b2ef036839f988560848d2c32e1aa4627fd37a32710e42c39f5c61ac2
   md5: bd20f4410b81f327e35ffa0657961146
   depends:
@@ -1254,7 +1254,7 @@ packages:
   license_family: Proprietary
   size: 229783051
   timestamp: 1634547157986
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
   sha256: 5394f5efd53afb2c1b0abf571ce3d9cb684b6c7e255f140ba2acaa703d6113be
   md5: d3cb2bfa63e30153f5527797dcc87280
   depends:
@@ -1266,7 +1266,7 @@ packages:
   license_family: BSD
   size: 63551
   timestamp: 1626176932911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
   sha256: c244d23da2749857a993f84969fd35ffd183ab8f462986df6d33ae0f705fe034
   md5: 9b1f8ccc2488d0e04eb73211e2987483
   depends:
@@ -1280,7 +1280,7 @@ packages:
   license: BSD 3-Clause
   size: 204136
   timestamp: 1634566416657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
   sha256: f81f426f8ef306d636664bc49e7cdd70e2b4306d7c6bcb9c75fe35a45ab2087a
   md5: 77aa1d7f958d36bf227e6ff4a34d2e3d
   depends:
@@ -1294,7 +1294,7 @@ packages:
   license: BSD-3-Clause
   size: 365386
   timestamp: 1626186165897
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
   sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
   md5: 95c83d71814c504b5504df4f14548f1a
   depends:
@@ -1320,7 +1320,7 @@ packages:
   license_family: BSD
   size: 8257558
   timestamp: 1681756322140
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
   sha256: 1b92d72b083f3350359b8fb2e3b5dc846f49650c9e46a6a74354b1b7f0d42730
   md5: 996babe4314515ddd41008a53cb5d47f
   depends:
@@ -1333,7 +1333,7 @@ packages:
   license_family: BSD
   size: 98791
   timestamp: 1650290544347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
   sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
   md5: 1710a25086c8098367eb36b9d441448b
   depends:
@@ -1361,7 +1361,7 @@ packages:
   license_family: BSD
   size: 569683
   timestamp: 1668450704669
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
   sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
   md5: 385cc9e53404776782502c0fdb08820f
   depends:
@@ -1374,7 +1374,7 @@ packages:
   license_family: BSD
   size: 147046
   timestamp: 1694616899309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
   sha256: 0807371380965e421cb5f3f2a30d790fd5c41db11dbb6d318e14294c3b1741ed
   md5: fca4bd4e3891aebf4fd7daf9b6d0ccfa
   depends:
@@ -1382,7 +1382,7 @@ packages:
   license: Free software (MIT-like)
   size: 1083412
   timestamp: 1636570020698
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
   sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
   md5: bbbcbebc20a4fdcadce398d0ca04f95e
   depends:
@@ -1391,7 +1391,7 @@ packages:
   license_family: BSD
   size: 13109
   timestamp: 1672387143252
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
   sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
   md5: 248ce515640465371927d46f389ed555
   depends:
@@ -1416,7 +1416,7 @@ packages:
   license_family: BSD
   size: 594054
   timestamp: 1690985006481
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
   sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
   md5: 70db71df4ee1cdd38090c0f7b80ba61f
   depends:
@@ -1426,7 +1426,7 @@ packages:
   license_family: BSD
   size: 21944
   timestamp: 1668160644514
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
   sha256: 15a12c8bebcda45c577e61cea412d9aafaa433e39f9e91fd61bbfab66fcee3ab
   md5: 5239d8330e8bd34972fb80918dce79e7
   depends:
@@ -1442,7 +1442,7 @@ packages:
   license_family: MIT
   size: 136437
   timestamp: 1640689905588
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
   sha256: ff8d0426c7096e086db818265c3edf4a820accbfb15afae0407ca578de151fa9
   md5: d7bcf0b9ba2d85cf532059ec119d2750
   depends:
@@ -1458,7 +1458,7 @@ packages:
   license: BSD-3-Clause
   size: 9965
   timestamp: 1652801901707
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
   sha256: abfdeda143b6b667d50a82ea119043fc1469ee02f094a41a2402433ff408099e
   md5: e8dc29adc0282f4658e0e2f25ff207a2
   depends:
@@ -1473,7 +1473,7 @@ packages:
   license: BSD-3-Clause
   size: 7095882
   timestamp: 1652801886819
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
   sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
   md5: 5ad4571eba2479f77a9f849a6ae7724c
   depends:
@@ -1483,7 +1483,7 @@ packages:
   license_family: Apache
   size: 3998613
   timestamp: 1694465071784
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
   sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
   md5: 77a22ed6d0d448c5288d0f695bc9ac49
   depends:
@@ -1492,7 +1492,7 @@ packages:
   license_family: Apache
   size: 72527
   timestamp: 1693575234886
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
   sha256: e7a0abb0f00a94000876f2095f0cf531ad3803ffbd868a780b3f06816b54492c
   md5: 97ef7e1fe923d22a8e2307f3f39a92d5
   depends:
@@ -1508,7 +1508,7 @@ packages:
   license_family: BSD
   size: 13221005
   timestamp: 1650622404234
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
   sha256: 49fdb57b2ed2ce4d6bb7a2c5adec36ba59522518a41fb941f9e39a9f43750cc5
   md5: 871b65444733b7da5823ee0dc9826722
   depends:
@@ -1529,7 +1529,7 @@ packages:
   license_family: BSD
   size: 14712394
   timestamp: 1676379803902
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
   sha256: 64a732ce2661cdb6bd8f9d1484ac10afeb73082b1c2b44728d212e0117d2860e
   md5: ada303f0cf43a4e99cfa7f243b23b681
   depends:
@@ -1538,7 +1538,7 @@ packages:
   license_family: BSD
   size: 141832
   timestamp: 1684915385689
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
   sha256: 8bcb1c67693f42a3170eb77ef4cdbb81b605fdf40816953e69a33a065c101638
   md5: b7689507fb5f879dc766aaa8a4c37351
   depends:
@@ -1557,7 +1557,7 @@ packages:
   license_family: Other
   size: 734566
   timestamp: 1646325095608
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
   sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
   md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
   depends:
@@ -1568,7 +1568,7 @@ packages:
   license_family: MIT
   size: 2674850
   timestamp: 1697548887851
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
   sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
   md5: fe56f0479dd414c846191116366262c3
   depends:
@@ -1577,7 +1577,7 @@ packages:
   license_family: MIT
   size: 31999
   timestamp: 1692205535111
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
   sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
   md5: 44d2a857d13bdf9d99aaac039a249d47
   depends:
@@ -1586,7 +1586,7 @@ packages:
   license_family: Apache
   size: 91137
   timestamp: 1659455142164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
   sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
   md5: eb899a739d9b58dd747f1f6bd52d4cf3
   depends:
@@ -1598,7 +1598,7 @@ packages:
   license_family: BSD
   size: 579771
   timestamp: 1672387338600
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
   sha256: 6973cfe0565ba3b5ad6d1de9e34848fbbadd78b507b2e23e1c079636b8f8f317
   md5: a924535045fb356e23e7a3cc8116b638
   depends:
@@ -1608,7 +1608,7 @@ packages:
   license_family: BSD
   size: 350026
   timestamp: 1612298042840
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
   sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
   md5: f36ecb722522cbe2e3737424edf1b5e1
   depends:
@@ -1620,7 +1620,7 @@ packages:
   license_family: BSD
   size: 29312
   timestamp: 1675441510984
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
   sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
   md5: 6d03295e544251e608a28c8d7c48115e
   depends:
@@ -1629,7 +1629,7 @@ packages:
   license_family: BSD
   size: 1862058
   timestamp: 1684280096752
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
   sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
   md5: 1f09617aecd6f3c2f2e20692c0759f34
   depends:
@@ -1639,7 +1639,7 @@ packages:
   license_family: Apache
   size: 94434
   timestamp: 1690223520097
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
   sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
   md5: ffceed627867508d73af1636ab5ebf42
   depends:
@@ -1648,7 +1648,7 @@ packages:
   license_family: MIT
   size: 156324
   timestamp: 1661452578573
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
   sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
   md5: 0e3341a4fe434167bf74b613eb6afd81
   depends:
@@ -1658,7 +1658,7 @@ packages:
   license_family: MIT
   size: 97194
   timestamp: 1636110999719
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
   sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
   md5: c5f3f7f10ad30f0945e75252615ab6e5
   depends:
@@ -1667,7 +1667,7 @@ packages:
   license_family: BSD
   size: 31331
   timestamp: 1605305847037
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
   sha256: c4b9e332a6f2b7524e8c88e2b39a2568a48e556fd9a44c30759c43611d4d023d
   md5: bb118745c9b08fc5028f45e77f371e68
   depends:
@@ -1687,7 +1687,7 @@ packages:
   license_family: PSF
   size: 24553777
   timestamp: 1654084160832
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
   sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
   md5: 0caa188a695319bdb13f53b0a2b3accc
   depends:
@@ -1696,7 +1696,7 @@ packages:
   license_family: BSD
   size: 264864
   timestamp: 1661371117920
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
   sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
   md5: bcb44ecbea441ee0d4659133d060d71f
   depends:
@@ -1705,7 +1705,7 @@ packages:
   license_family: MIT
   size: 257904
   timestamp: 1695131670290
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
   sha256: e937081facacb141dc2c9cdcced92baa9a2662e4a56100b6041df0b6b7692570
   md5: f3ac39b2349258198a9b3316636fe5d5
   depends:
@@ -1715,7 +1715,7 @@ packages:
   license_family: BSD
   size: 39972
   timestamp: 1685030752528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
   sha256: 3da9cbbd49fac566433748bd245d09d7d5fcd28b04c0397cbbf6d5bb92f5c4a5
   md5: df73a5d2f6e089d51e71e91935a82c65
   depends:
@@ -1726,7 +1726,7 @@ packages:
   license_family: MIT
   size: 183753
   timestamp: 1635775763162
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
   sha256: 26005d191bb15070aad70707ed6493f32678a67978bd3b83d4c9679cab44e717
   md5: 2dc75d5a4ccb64310939c3a72d34ae20
   depends:
@@ -1737,7 +1737,7 @@ packages:
   license_family: BSD
   size: 521583
   timestamp: 1638435042256
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
   sha256: 8c950c69bee969e2c66f88f0dc247b3ab75a753672a88009779d5f5dba193532
   md5: 150ac0eb929bab9dec912797bdfc7b95
   depends:
@@ -1747,7 +1747,7 @@ packages:
   license_family: GPL
   size: 433182
   timestamp: 1642022402894
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
   sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
   md5: c7de00b4ac2778c4e5a7816320d75391
   depends:
@@ -1763,7 +1763,7 @@ packages:
   license_family: Apache
   size: 94028
   timestamp: 1690400356879
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
   sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
   md5: 1581cafc84708ed9aafaaee1cbbf6065
   depends:
@@ -1772,7 +1772,7 @@ packages:
   license_family: MIT
   size: 1089416
   timestamp: 1690290900608
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
   sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
   md5: e19ffbfb24b990275d24fcea2bd1699b
   depends:
@@ -1781,7 +1781,7 @@ packages:
   license_family: Apache
   size: 15702
   timestamp: 1614030498860
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
   sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
   md5: ca061ce25c0f58628643abec8d6a8244
   depends:
@@ -1790,7 +1790,7 @@ packages:
   license_family: MIT
   size: 66330
   timestamp: 1696347637947
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
   sha256: 87965b7b46d93866d31696a1045216d64f077a06b2900c356aba87e8559c6188
   md5: fa334030245135b37027a882f3c468bf
   depends:
@@ -1801,7 +1801,7 @@ packages:
   license_family: Other
   size: 1561908
   timestamp: 1655328608308
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
   sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
   md5: 0e76eab58fe488e91f0aee73f46de031
   depends:
@@ -1812,7 +1812,7 @@ packages:
   license_family: BSD
   size: 29816
   timestamp: 1671751864131
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
   sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
   md5: b413a210eca82fe867e991eed085201b
   depends:
@@ -1822,7 +1822,7 @@ packages:
   license_family: BSD
   size: 38882
   timestamp: 1668168876032
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
   sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
   md5: 5b8375e2092012db69d2123dc0c68630
   depends:
@@ -1832,7 +1832,7 @@ packages:
   license_family: BSD
   size: 3485432
   timestamp: 1654088939579
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
   sha256: b746e39272888b9cc1a2a711b7b8836f2e26f4457850e43ad18bf0765e21dc3d
   md5: 200e86f8d53aeebf4b7dcfc944fd7920
   depends:
@@ -1842,7 +1842,7 @@ packages:
   license_family: Apache
   size: 661662
   timestamp: 1606942359431
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
   sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
   md5: 67a8320961ff24e92eebb661536e5cf7
   depends:
@@ -1855,7 +1855,7 @@ packages:
   license_family: MOZILLA
   size: 123763
   timestamp: 1679561904852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
   sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
   md5: 0f0b91a158dd3692cbb7a7763b657bfe
   depends:
@@ -1864,7 +1864,7 @@ packages:
   license_family: BSD
   size: 192032
   timestamp: 1671143995098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
   md5: 8515e64a3de7581360d713fe4c0a094e
   depends:
@@ -1874,7 +1874,7 @@ packages:
   license_family: PSF
   size: 8789
   timestamp: 1690297588156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
   md5: 60170012374b2a5007842fa5870d78c5
   depends:
@@ -1883,7 +1883,7 @@ packages:
   license_family: PSF
   size: 57479
   timestamp: 1690297581658
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
   sha256: 870f20a3c006a74b291910f69c3469a409bd21437142864b29cfafeb89ca7c34
   md5: 1b2f1589e3ebc3e0c6ecb38dba93e4ae
   depends:
@@ -1898,7 +1898,7 @@ packages:
   license_family: MIT
   size: 186761
   timestamp: 1686163186447
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
   sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
   md5: f8d03a15b974fc7810d9f54ae849fc8e
   depends:
@@ -1907,7 +1907,7 @@ packages:
   license_family: BSD
   size: 20781
   timestamp: 1607365390528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
   sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
   md5: d7db5d6ce1db80eade8a082ff78bf479
   depends:
@@ -1917,7 +1917,7 @@ packages:
   license_family: BSD
   size: 71044
   timestamp: 1614804011510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
   sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
   md5: b3899f8bda32734727bd5a73df1d7d17
   depends:
@@ -1926,7 +1926,7 @@ packages:
   license_family: MIT
   size: 101520
   timestamp: 1695742037911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
   sha256: 2ce360ff98c0ca4537d70c19266b5700810196c54ce2fbaff3b94a969846ee37
   md5: 94cb94dc47405b24b1b5bd0a3275ab59
   depends:
@@ -1935,7 +1935,7 @@ packages:
   license_family: GPL2
   size: 398058
   timestamp: 1651602137803
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -1943,7 +1943,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
   sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
   md5: 567b68192c387b5fc88178425577a0fe
   depends:
@@ -1953,7 +1953,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 366479
   timestamp: 1616055552392
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
   sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
   md5: 3818a9531fe74433c3b7d5144c9a58cc
   depends:
@@ -1962,7 +1962,7 @@ packages:
   license_family: MIT
   size: 18021
   timestamp: 1672387231268
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
   sha256: 513444d83ac2405e898531492ea59f3a95641e357cc39c1048d6fffc1791a16b
   md5: 601d9449c280b9b145dc8c83b6f06119
   depends:
@@ -1971,7 +1971,7 @@ packages:
   license_family: Other
   size: 133595
   timestamp: 1650637720646
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
   sha256: 1c049c23788a00b6f38bdc801245e0e60af98718d4db4c958658bcc67ff158c7
   md5: b1737dfd2e06ad69ec5cfec341e207c6
   depends:
@@ -1984,7 +1984,7 @@ packages:
   license_family: BSD
   size: 827172
   timestamp: 1650622223170
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -1997,7 +1997,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -2007,7 +2007,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
   md5: b2aa5503875aba2f1d88cae9df9a96d5
   depends:
@@ -2016,7 +2016,7 @@ packages:
   license_family: BSD
   size: 13636
   timestamp: 1611930018941
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -2028,7 +2028,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
   sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
   md5: 544adf2677c47c9b9c891aea720678f1
   depends:
@@ -2036,7 +2036,7 @@ packages:
   license: MIT
   size: 33999
   timestamp: 1630003259346
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -2045,7 +2045,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -2054,7 +2054,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -2063,7 +2063,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -2072,7 +2072,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
   sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
   md5: 9eff1a842dbda8d1bae9a2c008b599bc
   depends:
@@ -2083,7 +2083,7 @@ packages:
   license_family: MIT
   size: 690443
   timestamp: 1625743217109
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -2091,7 +2091,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
   sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
   md5: 33624a42ee387bf9918ea98b4e7b31fc
   depends:
@@ -2101,7 +2101,7 @@ packages:
   license_family: BSD
   size: 8173
   timestamp: 1601490751973
-- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
   sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
   md5: 67857cc5e9044770d2b15f9d94a4521d
   depends:
@@ -2110,7 +2110,7 @@ packages:
   license_family: Apache
   size: 12810
   timestamp: 1600445183315
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -2119,7 +2119,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -2128,7 +2128,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -2138,7 +2138,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
   sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
   md5: e68a6f315f41a8d814d833652bf38b9b
   depends:
@@ -2146,7 +2146,7 @@ packages:
   license: MIT
   size: 13374
   timestamp: 1606932077143
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -2154,7 +2154,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -2163,7 +2163,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -2172,7 +2172,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
   sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
   md5: 2eb923cc014094f4acf7f849d67d73f8
   depends:
@@ -2182,7 +2182,7 @@ packages:
   license_family: BSD
   size: 246457
   timestamp: 1626374695070
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
   sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
   md5: 02caf3f47f1d06256068053297355740
   depends:
@@ -2191,7 +2191,7 @@ packages:
   license_family: Apache
   size: 152292
   timestamp: 1690578151230
-- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
   sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
   md5: 41db68b96e114e367c4f120a3b379e59
   depends:
@@ -2200,7 +2200,7 @@ packages:
   license_family: BSD
   size: 19391
   timestamp: 1632406728844
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -2209,7 +2209,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -2221,14 +2221,14 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
   sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
   md5: a815d3bdb160bcc71687f2dda70d3ca4
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 122218
   timestamp: 1680170368293
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -2236,7 +2236,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
   sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
   md5: 447a49f7bad119faa80d7f14aa296c95
   depends:
@@ -2249,7 +2249,7 @@ packages:
   license_family: MIT
   size: 162176
   timestamp: 1644481750133
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
   sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
   md5: 8810f48fe4a4792de0fd3520b502d08b
   depends:
@@ -2258,7 +2258,7 @@ packages:
   license_family: BSD
   size: 10019
   timestamp: 1606859473259
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
   sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
   md5: 00a446b6dfc61af223df4de29fe8ad94
   depends:
@@ -2268,7 +2268,7 @@ packages:
   license_family: MIT
   size: 34305
   timestamp: 1644569782044
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
   sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
   md5: bd92dd8bd5b9d24e632b62a075426e50
   depends:
@@ -2277,7 +2277,7 @@ packages:
   license_family: MIT
   size: 133634
   timestamp: 1695718025321
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
   sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
   md5: f8ae051b591a9027adc16de1be9748f4
   depends:
@@ -2287,12 +2287,12 @@ packages:
   license_family: MIT
   size: 206198
   timestamp: 1681493096349
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
   sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
   md5: e2f3248e2a5009a02f7b8e54f83314ef
   size: 5620
   timestamp: 1528121955725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
   sha256: 2936241747f6cc0f0b3afa53bb28ad6f658b53a0fc2e67a5ed34d1d5e2cce117
   md5: bdca1b691340964271d9cfec6baaf8d0
   depends:
@@ -2310,7 +2310,7 @@ packages:
   license_family: BSD
   size: 5719952
   timestamp: 1697490515691
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
   sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
   md5: 0d79760d544d0bd8acb4adc4ef813418
   depends:
@@ -2320,7 +2320,7 @@ packages:
   license_family: BSD
   size: 137075
   timestamp: 1657175654487
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
   sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
   md5: 31d6d04cd2388d8f19004501271b3545
   depends:
@@ -2330,7 +2330,7 @@ packages:
   license: MIT
   size: 18982
   timestamp: 1659616229395
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
   sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
   md5: caf1073dc2ca5aeb832a2877394eae12
   depends:
@@ -2339,7 +2339,7 @@ packages:
   license: MIT
   size: 18233
   timestamp: 1659616216769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
   sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
   md5: aa1ed20c38af535c8d6a955314759d7b
   depends:
@@ -2348,14 +2348,14 @@ packages:
   license: MIT
   size: 394588
   timestamp: 1659616312678
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
   sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
   md5: ce3588e31faa79f546e0fc6a36c5543c
   license: MPL-2.0
   license_family: Other
   size: 133884
   timestamp: 1694009771475
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
   sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
   md5: 21eb7f53076d0a69513cfd258f6ef63c
   depends:
@@ -2364,7 +2364,7 @@ packages:
   license_family: Other
   size: 159756
   timestamp: 1690232346868
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
   sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
   md5: a40a04d9cda1e665565bc6c832d598b6
   depends:
@@ -2375,7 +2375,7 @@ packages:
   license_family: MIT
   size: 225258
   timestamp: 1670423337502
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
   sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
   md5: b2cc5f37f7bb069d061306e7eac2a011
   depends:
@@ -2385,7 +2385,7 @@ packages:
   license_family: CC
   size: 1913396
   timestamp: 1668084575248
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
   sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
   md5: 103d8c039e342115720a84d59c119d46
   depends:
@@ -2395,7 +2395,7 @@ packages:
   license_family: BSD
   size: 13774
   timestamp: 1671231190250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
   sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
   md5: f69f09e0346172f225390d2b3b0d7873
   depends:
@@ -2406,7 +2406,7 @@ packages:
   license_family: BSD
   size: 246628
   timestamp: 1663827484947
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
   sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
   md5: cb80c7ac65b48a737654f371fe31c460
   depends:
@@ -2419,7 +2419,7 @@ packages:
   license_family: BSD
   size: 1307228
   timestamp: 1694212041712
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
   sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
   md5: 04cbe8f4bc62c34fac9d42d1124059bf
   depends:
@@ -2429,7 +2429,7 @@ packages:
   license_family: MIT
   size: 2052734
   timestamp: 1690905361158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
   sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
   md5: ef0e825982f242085574f502dfff4f6b
   depends:
@@ -2438,7 +2438,7 @@ packages:
   license_family: MIT
   size: 16594
   timestamp: 1649926538106
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
   sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
   md5: 24747a300246c016b3a7f04dabd02d4a
   depends:
@@ -2447,7 +2447,7 @@ packages:
   license_family: BSD
   size: 27709
   timestamp: 1668714497209
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -2457,14 +2457,14 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
   sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
   md5: e4a732941f74b8062c8bcbfe5c5c2b56
   license: MIT
   license_family: MIT
   size: 80252
   timestamp: 1676983220161
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
   sha256: 5c36d43cadbbf944d9255e79df85c2e9e6155a1d6f9158e06fcd8ffd458b7663
   md5: a5a2cff387403ccf9cf58aac7a6dde55
   depends:
@@ -2481,7 +2481,7 @@ packages:
   license_family: BSD
   size: 4573879
   timestamp: 1698866750755
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
   sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
   md5: f3ce6fe6eb760c236e5f7d04df5faa81
   depends:
@@ -2490,7 +2490,7 @@ packages:
   license_family: MIT
   size: 28138484
   timestamp: 1692293212596
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
   sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
   md5: 6dd72c43fea25b748ec7a9f6c0407e15
   depends:
@@ -2499,7 +2499,7 @@ packages:
   license_family: BSD
   size: 111810
   timestamp: 1666125671024
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
   sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
   md5: 03cdb7e679924b329ecab8f12cb8fc67
   depends:
@@ -2509,7 +2509,7 @@ packages:
   license_family: APACHE
   size: 38813
   timestamp: 1678997212422
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
   sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
   md5: e113c4e6e758dd68faf196586bf5564d
   depends:
@@ -2519,7 +2519,7 @@ packages:
   license_family: Apache
   size: 51873
   timestamp: 1698254765815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
   sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
   md5: 78baea934985ccd9514a366cc7e80ed4
   depends:
@@ -2528,7 +2528,7 @@ packages:
   license_family: Proprietary
   size: 727499
   timestamp: 1681801225190
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
   sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
   md5: da9b63e42f281f7e77b289f4b654b83b
   depends:
@@ -2550,7 +2550,7 @@ packages:
   license_family: BSD
   size: 218436
   timestamp: 1691121840155
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
   sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
   md5: 6a7cb9b49593b29933fa2b503d533a08
   depends:
@@ -2572,7 +2572,7 @@ packages:
   license_family: BSD
   size: 1257205
   timestamp: 1694181720454
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
   sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
   md5: d861ef66f5c0a282d60b65778a9de2f3
   depends:
@@ -2582,7 +2582,7 @@ packages:
   license_family: MIT
   size: 1048450
   timestamp: 1644315332508
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
   sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
   md5: f7e603c965052deed8b789c35855a42f
   depends:
@@ -2592,14 +2592,14 @@ packages:
   license_family: BSD
   size: 213537
   timestamp: 1666908270815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
   sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
   md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
   license: IJG
   license_family: Other
   size: 278924
   timestamp: 1677849185191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
   sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
   md5: a82a17e78f725dcbd71ff8dac6db05c7
   depends:
@@ -2610,7 +2610,7 @@ packages:
   license_family: MIT
   size: 133134
   timestamp: 1676558895333
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
   sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
   md5: ee9270379a9ebdb6297e4b6849b3f7f0
   depends:
@@ -2626,7 +2626,7 @@ packages:
   license_family: BSD
   size: 195479
   timestamp: 1676329410154
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 32b898a97dca7770858ab31294238fde11ab61a84831a52f320e5ee5405a147c
   md5: 926e754b8fad288b583ef2933deae1a5
   depends:
@@ -2637,7 +2637,7 @@ packages:
   license_family: BSD
   size: 92938
   timestamp: 1679906616072
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
   sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
   md5: 7e60995b3119417213e5faedda147499
   depends:
@@ -2661,7 +2661,7 @@ packages:
   license_family: BSD
   size: 403165
   timestamp: 1671707664990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
   sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
   md5: cd470bdb28bb0e8b3535c93a3a6dad07
   depends:
@@ -2671,7 +2671,7 @@ packages:
   license_family: BSD
   size: 65431
   timestamp: 1672387389172
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -2681,7 +2681,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -2690,13 +2690,13 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
   sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
   md5: 7dba7aa5b971febb55281659843586ba
   license: MIT
   size: 65470
   timestamp: 1659616172703
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
   sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
   md5: f78a158983f0bbaba56f34b976bc6dae
   depends:
@@ -2704,7 +2704,7 @@ packages:
   license: MIT
   size: 34189
   timestamp: 1659616189313
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
   sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
   md5: 36a1d885725d3ab4d1fadc5a29f978d2
   depends:
@@ -2712,35 +2712,35 @@ packages:
   license: MIT
   size: 327737
   timestamp: 1659616202869
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
   sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
   md5: 817848d0e2b2808acdc9b3fbbf581726
   license: MIT
   license_family: MIT
   size: 133887
   timestamp: 1683716590737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
   sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
   md5: c90372428e1e4eed4fdcd790979d06b4
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1409377
   timestamp: 1650983531933
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -2749,13 +2749,13 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -2772,7 +2772,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
   sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
   md5: c0b99f8e1c7475f23b1c7b4250b06e1c
   depends:
@@ -2786,7 +2786,7 @@ packages:
   license_family: BSD
   size: 88021
   timestamp: 1694778290062
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
   sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
   md5: 46a65d1fc24013217e06aaf6d65ffcad
   constrains:
@@ -2795,7 +2795,7 @@ packages:
   license_family: BSD
   size: 425478
   timestamp: 1694776947990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
   sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
   md5: 06866415ef22d5322f9bdc9956b59c4d
   depends:
@@ -2807,7 +2807,7 @@ packages:
   license_family: MIT
   size: 678174
   timestamp: 1692970318885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
   sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
   md5: 2edc6c894d6d0321304396e9bd40df94
   depends:
@@ -2817,7 +2817,7 @@ packages:
   license_family: MIT
   size: 241774
   timestamp: 1692973618934
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 0190d3b8d2939f28aa017711cf4147c51a1139da2922cc8420a71562dd99f844
   md5: 454a7f2c4426453f17e995382a4235e4
   depends:
@@ -2827,7 +2827,7 @@ packages:
   license_family: MIT
   size: 36036
   timestamp: 1659783508187
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
   sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
   md5: 8bbd981ca0129d7beeacd3cd7623f714
   depends:
@@ -2838,7 +2838,7 @@ packages:
   license_family: Other
   size: 1491074
   timestamp: 1695058597986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
   sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
   md5: d5f58d056b4bfc67aec30c77035ba889
   depends:
@@ -2847,7 +2847,7 @@ packages:
   license_family: BSD
   size: 182491
   timestamp: 1670944720979
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
   sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
   md5: 1affd16b166571a91feae04baf5fd3da
   depends:
@@ -2857,7 +2857,7 @@ packages:
   license_family: BSD
   size: 123431
   timestamp: 1671542016019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
   sha256: e5fc51472fa0f36abd78baa5b3c9245d6627b0da11188e6a954d73f3f2bca210
   md5: df7c519447affffb594f8c56b028ed33
   depends:
@@ -2867,7 +2867,7 @@ packages:
   license_family: MIT
   size: 107035
   timestamp: 1684279974102
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
   sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
   md5: 3681ebf029211ceab26af6f5d35abf39
   depends:
@@ -2878,7 +2878,7 @@ packages:
   license_family: BSD
   size: 22254
   timestamp: 1654598220251
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
   sha256: 2fd179efa024c92d0d71179a981a781d16c70f5d8c6305e0d678b0c7ae1275ab
   md5: addda7f015d1673f794a23fdb18a3e09
   depends:
@@ -2901,7 +2901,7 @@ packages:
   license_family: PSF
   size: 8182219
   timestamp: 1698692361219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
   sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
   md5: 6eb64ecfcd754502e271db0bb51d2cfd
   depends:
@@ -2911,7 +2911,7 @@ packages:
   license_family: BSD
   size: 17374
   timestamp: 1662014643620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 2312ee5a6343e8495802698d7181f1b619aad7479d96ee253407b324ac884417
   md5: 866960fa48a7ca335941786d4869802a
   depends:
@@ -2921,7 +2921,7 @@ packages:
   license_family: MIT
   size: 53542
   timestamp: 1659721365599
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
   sha256: 37f455814ce242eb65ff80a0402f1bd231a388e6823e6c1e65f60b705c032a2d
   md5: 4c9246c492a64729225aa5b04e12c2d1
   depends:
@@ -2930,7 +2930,7 @@ packages:
   license_family: MIT
   size: 19573
   timestamp: 1659716100178
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
   sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
   md5: 2a4d604717a647ad21af766289cbbfc3
   depends:
@@ -2939,7 +2939,7 @@ packages:
   license_family: BSD
   size: 58057
   timestamp: 1607364912348
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
   sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
   md5: 25051fe272624544652dc6d814c2943a
   depends:
@@ -2952,7 +2952,7 @@ packages:
   license_family: Proprietary
   size: 224420228
   timestamp: 1691503125614
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
   sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
   md5: 37d8cf85a63f7aa9af1624894a7d606d
   depends:
@@ -2962,7 +2962,7 @@ packages:
   license_family: BSD
   size: 48590
   timestamp: 1682969183093
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
   sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
   md5: 0b2aee6666135bbd36b46d6ac66160f7
   depends:
@@ -2975,7 +2975,7 @@ packages:
   license_family: BSD
   size: 210705
   timestamp: 1695058433223
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
   sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
   md5: e22fb55ce380d0ebd44cce3f20d5349e
   depends:
@@ -2989,7 +2989,7 @@ packages:
   license_family: BSD
   size: 296614
   timestamp: 1695060155673
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
   sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
   md5: 1a5d4004e64e3cfb7a2a297b9117c285
   depends:
@@ -3015,7 +3015,7 @@ packages:
   license_family: BSD
   size: 8213832
   timestamp: 1681756573646
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
   sha256: 2975bd1f98ca9ec7354ee378f86f8322ec90f568374776fd90e80c534fbee882
   md5: 798627089e0ccba26695a26d9cb127ec
   depends:
@@ -3028,7 +3028,7 @@ packages:
   license_family: BSD
   size: 99066
   timestamp: 1650308465824
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
   sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
   md5: e572c1264a7af20b486f64ac8c9e1f57
   depends:
@@ -3056,7 +3056,7 @@ packages:
   license_family: BSD
   size: 573356
   timestamp: 1668450732828
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
   sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
   md5: b67569a7c30af9ffa5cde6e4b52ac68b
   depends:
@@ -3069,14 +3069,14 @@ packages:
   license_family: BSD
   size: 148342
   timestamp: 1694616917184
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
   sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
   md5: 97b81f34efbe86c5220fe82eb584fd62
   depends:
@@ -3085,7 +3085,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387288528
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
   sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
   md5: d77862975a9a1cf50acb803be26e83a1
   depends:
@@ -3110,7 +3110,7 @@ packages:
   license_family: BSD
   size: 575365
   timestamp: 1690985052739
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
   sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
   md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
   depends:
@@ -3120,7 +3120,7 @@ packages:
   license_family: BSD
   size: 22858
   timestamp: 1668160618784
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
   sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
   md5: 185e9c41abb88ee59b52ec0f5f65d506
   depends:
@@ -3134,7 +3134,7 @@ packages:
   license_family: MIT
   size: 138305
   timestamp: 1696515469702
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
   sha256: 82a2dd0c2ff6e20a275e5447dd03088f79694f7bfa5055a25c54bebf31aac4ca
   md5: c157e6ab469a95b06fa822ba075978b3
   depends:
@@ -3150,7 +3150,7 @@ packages:
   license_family: BSD
   size: 10376
   timestamp: 1695831243158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
   sha256: b3a003b41cec2751210e542911e99437db0321542f6812c1b88608ef720ba7ef
   md5: 56400dfe88c427cdf1854e47666b8a99
   depends:
@@ -3165,7 +3165,7 @@ packages:
   license_family: BSD
   size: 7570900
   timestamp: 1695831208653
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
   sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
   md5: 93f5d7b66976154adeda219bea02ba45
   depends:
@@ -3175,7 +3175,7 @@ packages:
   license: BSD 2-Clause
   size: 484257
   timestamp: 1630093862501
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
   sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
   md5: 5e8713ef1215406254988163eaf34020
   depends:
@@ -3184,7 +3184,7 @@ packages:
   license_family: Apache
   size: 4965606
   timestamp: 1695323060401
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
   sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
   md5: 4154929ace2ad6ee16aea815635a6d1f
   depends:
@@ -3193,7 +3193,7 @@ packages:
   license_family: Apache
   size: 73598
   timestamp: 1693575307570
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
   sha256: aff5acedef9da91b77851e1a163b8319d72bc4152c98ac87703a2eac1e5d575b
   md5: 7df4c76aa8c52fedce5346748d56459e
   depends:
@@ -3240,7 +3240,7 @@ packages:
   license_family: BSD
   size: 13388063
   timestamp: 1697477404222
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
   sha256: 42d83288119306089a06e853a37045fbb9860548b05a1e79d223f7ecf1cb349d
   md5: 8daced11264159ff57df7bba4d0b2ec7
   depends:
@@ -3264,7 +3264,7 @@ packages:
   license_family: BSD
   size: 17075803
   timestamp: 1698867397009
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
   sha256: ad7ca92e5c83a8e2181677025509ed7b8f566ec23b24f28316fa087bb591c11f
   md5: a4ccd0fbcfb26de868f2fb4836940d7a
   depends:
@@ -3273,7 +3273,7 @@ packages:
   license_family: BSD
   size: 189263
   timestamp: 1698263570990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
   sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
   md5: be0a90921f3bf4f0d6950fb786093de7
   depends:
@@ -3292,7 +3292,7 @@ packages:
   license_family: Other
   size: 719901
   timestamp: 1696580194417
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
   sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
   md5: 81ae9ec2d7fcf6934847bff558b619f5
   depends:
@@ -3303,7 +3303,7 @@ packages:
   license_family: MIT
   size: 2672987
   timestamp: 1697548890181
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
   sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
   md5: 1a822c206e2abddc5d6d821721af227f
   depends:
@@ -3312,7 +3312,7 @@ packages:
   license_family: MIT
   size: 33013
   timestamp: 1692205801265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
   sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
   md5: 1604d33dbdb2446c642970f8b354bedb
   depends:
@@ -3321,7 +3321,7 @@ packages:
   license_family: Apache
   size: 91266
   timestamp: 1659455269141
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
   sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
   md5: d1b3bcc35655a3123acb1fa2ad1a8511
   depends:
@@ -3333,7 +3333,7 @@ packages:
   license_family: BSD
   size: 580828
   timestamp: 1672387372015
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
   sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
   md5: 7540555d1fb192236db9a7c5c9d3601c
   depends:
@@ -3342,7 +3342,7 @@ packages:
   license_family: BSD
   size: 365765
   timestamp: 1656431373327
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
   sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
   md5: 0a73533fb6e0dc717ab906a537bc747d
   depends:
@@ -3354,7 +3354,7 @@ packages:
   license_family: BSD
   size: 30803
   timestamp: 1675441638631
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
   sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
   md5: 0a959fbad46ab38ade48dbd358002674
   depends:
@@ -3363,7 +3363,7 @@ packages:
   license_family: BSD
   size: 1864757
   timestamp: 1684280094736
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
   sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
   md5: ea24b5076ef79e4567c5a3f0cb22b470
   depends:
@@ -3373,7 +3373,7 @@ packages:
   license_family: Apache
   size: 95330
   timestamp: 1690223465114
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
   sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
   md5: bcaea6d4a47e9c874becaa700c78dcf7
   depends:
@@ -3382,7 +3382,7 @@ packages:
   license_family: MIT
   size: 157216
   timestamp: 1661452617825
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
   sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
   md5: 707110d1b49cb1864acb0bbaa103591e
   depends:
@@ -3391,7 +3391,7 @@ packages:
   license_family: MIT
   size: 95016
   timestamp: 1636111184034
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
   sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
   md5: 113a443b9c706f9f9c6187c0eaa3de27
   depends:
@@ -3400,7 +3400,7 @@ packages:
   license_family: BSD
   size: 31178
   timestamp: 1605305861851
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
   sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
   md5: 85a8d0001db70e52a479155228cb1fe0
   depends:
@@ -3419,7 +3419,7 @@ packages:
   license_family: PSF
   size: 13324979
   timestamp: 1694439878265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
   sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
   md5: 47c5e22e31ec05a7bc0ce90065a53afd
   depends:
@@ -3428,7 +3428,7 @@ packages:
   license_family: BSD
   size: 265348
   timestamp: 1661368839620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
   sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
   md5: ce9a69e1668aa1e133f2aa6d4e8d346f
   depends:
@@ -3437,7 +3437,7 @@ packages:
   license_family: MIT
   size: 254958
   timestamp: 1695131709704
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 9ee098c09f31fad7ff1856e5ce2619172eaf979997e7a427d1e05cce32c2af00
   md5: cac1d1898b69ae9646dfbf082910635d
   depends:
@@ -3447,7 +3447,7 @@ packages:
   license_family: BSD
   size: 40946
   timestamp: 1685030787453
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
   sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
   md5: 637f08b19dd8fd87347d8c44f9e3e202
   depends:
@@ -3457,7 +3457,7 @@ packages:
   license_family: MIT
   size: 170776
   timestamp: 1698096100056
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
   sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
   md5: 8ce3ac7d8a04e469b566f1b090d01140
   depends:
@@ -3468,7 +3468,7 @@ packages:
   license_family: BSD
   size: 470617
   timestamp: 1657724324011
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -3477,7 +3477,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
   sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
   md5: 6f2d41dd76a03b7f85a1ed49af1763d6
   depends:
@@ -3493,7 +3493,7 @@ packages:
   license_family: Apache
   size: 95100
   timestamp: 1690400262627
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
   md5: b0321e6f14e139fc15b1f8b4acb35d2f
   depends:
@@ -3502,7 +3502,7 @@ packages:
   license_family: MIT
   size: 1093966
   timestamp: 1690290944588
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
   sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
   md5: 62b64576a0aa5f6c3fb05f56650d25e1
   depends:
@@ -3511,7 +3511,7 @@ packages:
   license_family: Apache
   size: 15535
   timestamp: 1614030509324
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
   sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
   md5: 15b5595b31e39f08eaacbe2e502d8fb3
   depends:
@@ -3520,7 +3520,7 @@ packages:
   license_family: MIT
   size: 67292
   timestamp: 1696347733587
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
   sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
   md5: 82e4db6a498480a75d53c55bd35b6478
   depends:
@@ -3532,7 +3532,7 @@ packages:
   license_family: Other
   size: 1801397
   timestamp: 1681394807900
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -3541,7 +3541,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
   sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
   md5: 63b957927b9949ccb19da28ec4612706
   depends:
@@ -3552,7 +3552,7 @@ packages:
   license_family: BSD
   size: 30902
   timestamp: 1671751919031
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
   sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
   md5: e346257a2fa8e2cb48c762138a5d009b
   depends:
@@ -3562,7 +3562,7 @@ packages:
   license_family: BSD
   size: 39915
   timestamp: 1668168959656
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
   sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
   md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
   depends:
@@ -3571,7 +3571,7 @@ packages:
   license_family: BSD
   size: 3536231
   timestamp: 1654088937695
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
   sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
   md5: a1bbf0abfb8c45541122c0eb2feee317
   depends:
@@ -3580,7 +3580,7 @@ packages:
   license_family: Apache
   size: 680464
   timestamp: 1696937112175
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
   sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
   md5: d689f6203c0a9d04fb229c73d7e80a7a
   depends:
@@ -3593,7 +3593,7 @@ packages:
   license_family: MOZILLA
   size: 125145
   timestamp: 1679561909274
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
   md5: 8a292c1ee22489bef2e84bc3aaf4098e
   depends:
@@ -3602,7 +3602,7 @@ packages:
   license_family: BSD
   size: 193141
   timestamp: 1671143985219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
   md5: 8bf0bfffc11ad06a1c94e145941b0ad4
   depends:
@@ -3612,7 +3612,7 @@ packages:
   license_family: PSF
   size: 9651
   timestamp: 1690297655669
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
   md5: 343514a174b3485fde55a73f56398dd7
   depends:
@@ -3621,7 +3621,7 @@ packages:
   license_family: PSF
   size: 58456
   timestamp: 1690297648002
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
   sha256: 11e7401cb6805db7ce22b1f9dd6ba5b7941c92225ce440bed1da0af284bfcad4
   md5: 5c10d68fa5616cdd82ee93ef6e0f038c
   depends:
@@ -3630,7 +3630,7 @@ packages:
   license_family: MIT
   size: 11615
   timestamp: 1659769478980
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
   sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
   md5: c2242e8fd24003a74ddf37416661e06d
   depends:
@@ -3645,7 +3645,7 @@ packages:
   license_family: MIT
   size: 188757
   timestamp: 1698257668273
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
   sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
   md5: 41f445e36b6b6722a9444508eef069f8
   depends:
@@ -3654,7 +3654,7 @@ packages:
   license_family: BSD
   size: 20583
   timestamp: 1607365395045
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
   sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
   md5: 409ee46ed24267b6da6fb32d13e1f21e
   depends:
@@ -3664,7 +3664,7 @@ packages:
   license_family: BSD
   size: 70730
   timestamp: 1614804271285
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
   sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
   md5: eb74e74d8e4fd533c55eb98b7b5e83bc
   depends:
@@ -3673,7 +3673,7 @@ packages:
   license_family: MIT
   size: 102637
   timestamp: 1695742077778
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
   sha256: cb007615819fd240ea4e343835dfbda3c508a92b5b7158219d30a22d0e67b57c
   md5: bf215e781ac81e0fc433eedee330c54b
   depends:
@@ -3682,20 +3682,20 @@ packages:
   license_family: BSD
   size: 49462
   timestamp: 1675159191191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
   sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
   md5: e243baa546432c8394a8059a44a5a3e4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 419227
   timestamp: 1683113010463
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
   sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
   md5: fe4ac85ee86d3a94ea3a4ebea3779763
   depends:
@@ -3704,7 +3704,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 321797
   timestamp: 1616055526986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
   sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
   md5: bc7073d9d4c0211cc4a1207c98fb765a
   depends:
@@ -3713,14 +3713,14 @@ packages:
   license_family: MIT
   size: 19091
   timestamp: 1672387204865
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
   sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
   md5: 8e495591e369ac161857a72011c0a296
   license: Zlib
   license_family: Other
   size: 120272
   timestamp: 1666595024203
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
   sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
   md5: f1465fbd810b3746c6de6babfd4fe28a
   depends:
@@ -3732,7 +3732,7 @@ packages:
   license_family: BSD
   size: 1023573
   timestamp: 1681304595869
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
   sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
   md5: cf55cb8d7031b30c70c56fc7c782b5c7
   depends:
@@ -3745,7 +3745,7 @@ packages:
   license_family: MIT
   size: 156104
   timestamp: 1644482799136
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
   sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
   md5: 84fce327d9f0d594e86f565e5c21962e
   depends:
@@ -3754,7 +3754,7 @@ packages:
   license_family: BSD
   size: 10183
   timestamp: 1629146082730
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
   sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
   md5: 84b8b998a741b37abf5312c1c03696ef
   depends:
@@ -3764,7 +3764,7 @@ packages:
   license_family: MIT
   size: 33979
   timestamp: 1644845817952
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
   sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
   md5: 77b746931c8f31c3ae393ccb5819d43d
   depends:
@@ -3773,7 +3773,7 @@ packages:
   license_family: MIT
   size: 133628
   timestamp: 1695717890677
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
   sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
   md5: 3df6e8ba34208dea068890e5d5318cc0
   depends:
@@ -3783,12 +3783,12 @@ packages:
   license_family: MIT
   size: 206759
   timestamp: 1681493095987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
   sha256: 8c31e7ede4b9a3ec6e1342f02bcff4d7113e5b25f12b91d108616a08eb8eb34f
   md5: de3ce22af040eb01db773fcab23ef413
   depends:
@@ -3806,7 +3806,7 @@ packages:
   license_family: BSD
   size: 5722206
   timestamp: 1697490482051
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
   sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
   md5: bb55f81435cb6e11d264242274fccd1a
   depends:
@@ -3816,7 +3816,7 @@ packages:
   license_family: BSD
   size: 115947
   timestamp: 1657175645380
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
   md5: f860193e14afc7ef3f5b990a2ac003d2
   depends:
@@ -3826,7 +3826,7 @@ packages:
   license: MIT
   size: 18936
   timestamp: 1659616204016
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
   sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
   md5: ad53130f3fd1f8d3c2fcbb7496e5585d
   depends:
@@ -3835,7 +3835,7 @@ packages:
   license: MIT
   size: 18715
   timestamp: 1659616188888
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
   sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
   md5: 0982c046fb976e9f9fb19e7510187a18
   depends:
@@ -3844,14 +3844,14 @@ packages:
   license: MIT
   size: 366983
   timestamp: 1659616245272
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
   sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
   md5: 31ac2f5596cb7a44adf073c930641c54
   license: MPL-2.0
   license_family: Other
   size: 133817
   timestamp: 1694009762858
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
   sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
   md5: cf1f6c3c34a1e1b9ab22b04233d860f6
   depends:
@@ -3860,7 +3860,7 @@ packages:
   license_family: Other
   size: 159783
   timestamp: 1690232303987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
   sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
   md5: 0eb268e38b5174d471a6e87d9d6102b1
   depends:
@@ -3871,7 +3871,7 @@ packages:
   license_family: MIT
   size: 225355
   timestamp: 1670423312966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
   sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
   md5: e68c94666cd60221b575c3814c89bac0
   depends:
@@ -3881,7 +3881,7 @@ packages:
   license_family: CC
   size: 1946451
   timestamp: 1668084573824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
   sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
   md5: 1773ae2b080cdd55827e27673351551e
   depends:
@@ -3891,7 +3891,7 @@ packages:
   license_family: BSD
   size: 13646
   timestamp: 1671231171682
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
   sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
   md5: 53bfd99ad1b09164d537209cffd98161
   depends:
@@ -3902,7 +3902,7 @@ packages:
   license_family: BSD
   size: 244040
   timestamp: 1663827469853
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
   sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
   md5: b62455043c8eb2434466885b19fed2de
   depends:
@@ -3915,7 +3915,7 @@ packages:
   license_family: BSD
   size: 1399573
   timestamp: 1694211828228
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
   sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
   md5: eb3cdc0fc210838b9271512a6a1b7c85
   depends:
@@ -3925,7 +3925,7 @@ packages:
   license_family: MIT
   size: 2067708
   timestamp: 1690905319109
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
   sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
   md5: f44b80b9405410e5bde6bfe0b31d5b3f
   depends:
@@ -3934,7 +3934,7 @@ packages:
   license_family: MIT
   size: 15135
   timestamp: 1650293774207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
   sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
   md5: f87027ccce1361d0f82c0edf1a10d53b
   depends:
@@ -3943,7 +3943,7 @@ packages:
   license_family: BSD
   size: 27677
   timestamp: 1668714367519
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -3953,14 +3953,14 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
   sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
   md5: 1d0bd7e576c64c059ef781dd319ad82a
   license: MIT
   license_family: MIT
   size: 77591
   timestamp: 1676983230102
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
   sha256: 3e480af22e98246c056bbd91d6be5352df34ff2b8451d9c7f614baeafb450d39
   md5: 695fe7ccaf6935d3117533d1e6737320
   depends:
@@ -3977,7 +3977,7 @@ packages:
   license_family: BSD
   size: 4542265
   timestamp: 1698866834303
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
   sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
   md5: 69eb3b03765627b6159ed23cdde78396
   depends:
@@ -3986,7 +3986,7 @@ packages:
   license_family: MIT
   size: 28399065
   timestamp: 1692293207812
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
   sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
   md5: 83366cbd3beb073112f4644a613b6bca
   depends:
@@ -3995,7 +3995,7 @@ packages:
   license_family: BSD
   size: 111933
   timestamp: 1666125627512
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
   sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
   md5: 647c1a2f8460ffa8c670a1915bbdb494
   depends:
@@ -4005,7 +4005,7 @@ packages:
   license_family: APACHE
   size: 38790
   timestamp: 1678997152549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
   sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
   md5: 35e541905426c686ef2ff010a0e502fd
   depends:
@@ -4015,7 +4015,7 @@ packages:
   license_family: Apache
   size: 51860
   timestamp: 1698254731870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
   sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
   md5: 187d7720aedf38759d122cccb4576f2c
   depends:
@@ -4037,7 +4037,7 @@ packages:
   license_family: BSD
   size: 219976
   timestamp: 1691121991680
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
   sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
   md5: e8e7f10741f9cfa737b310b334940441
   depends:
@@ -4059,7 +4059,7 @@ packages:
   license_family: BSD
   size: 1255894
   timestamp: 1694181494549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
   sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
   md5: ff209e75aee17af2e358b0008fbe8c88
   depends:
@@ -4069,7 +4069,7 @@ packages:
   license_family: MIT
   size: 1022945
   timestamp: 1644315931223
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
   sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
   md5: d3e78ef296b3c74910d003bd10b475d6
   depends:
@@ -4079,14 +4079,14 @@ packages:
   license_family: BSD
   size: 213972
   timestamp: 1666908195870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
   sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
   md5: 055e12390b844ea6c6e956ee08a618e8
   license: IJG
   license_family: Other
   size: 273479
   timestamp: 1677849171867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
   sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
   md5: 783e2ad3d36472648c5ccc9f3051db3c
   depends:
@@ -4097,7 +4097,7 @@ packages:
   license_family: MIT
   size: 133077
   timestamp: 1676558732505
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
   sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
   md5: 0677598f673f9729b5990316170a999d
   depends:
@@ -4113,7 +4113,7 @@ packages:
   license_family: BSD
   size: 197129
   timestamp: 1676329661580
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
   sha256: 05f9ca0fdcfdc2e217438be27fead588c843a3aadf7d034467c83216d1e5c214
   md5: 2d648b77d817ba38293c0728711ba8f5
   depends:
@@ -4124,7 +4124,7 @@ packages:
   license_family: BSD
   size: 92852
   timestamp: 1679906632236
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
   sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
   md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
   depends:
@@ -4148,7 +4148,7 @@ packages:
   license_family: BSD
   size: 401319
   timestamp: 1671707682572
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
   sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
   md5: 247558a0aecf1ef7e77a4343761353d6
   depends:
@@ -4158,7 +4158,7 @@ packages:
   license_family: BSD
   size: 64600
   timestamp: 1672387273585
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -4168,7 +4168,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -4177,13 +4177,13 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
   md5: a0f206782751dfffed0dd51302a1bf26
   license: MIT
   size: 68012
   timestamp: 1659616138077
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
   md5: 4c6667cdd061d28e9bc4e4300e4d115e
   depends:
@@ -4191,7 +4191,7 @@ packages:
   license: MIT
   size: 31173
   timestamp: 1659616155596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
   md5: 637e9430e258ddf050623ef2360184d8
   depends:
@@ -4199,28 +4199,28 @@ packages:
   license: MIT
   size: 298430
   timestamp: 1659616172209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
   sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
   md5: 55c615026c0869f8d3ba657f3bd38c43
   license: MIT
   license_family: MIT
   size: 120389
   timestamp: 1683716579036
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -4229,7 +4229,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -4240,14 +4240,14 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
   sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
   md5: a41117710dafe569c9cc4e83f6f29fe3
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1411339
   timestamp: 1650982753977
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -4258,7 +4258,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -4267,13 +4267,13 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -4290,7 +4290,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
   sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
   md5: 98d22e0124d55fae3c37c608dab1dcc9
   depends:
@@ -4304,7 +4304,7 @@ packages:
   license_family: BSD
   size: 89825
   timestamp: 1694778225280
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
   sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
   md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
   constrains:
@@ -4313,7 +4313,7 @@ packages:
   license_family: BSD
   size: 331675
   timestamp: 1694776939192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
   sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
   md5: 0ba499df6755eae5d2d23aa4ab004553
   depends:
@@ -4325,7 +4325,7 @@ packages:
   license_family: MIT
   size: 642657
   timestamp: 1692970217410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
   sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
   md5: c73101971e5ab6a8e8688239884eac81
   depends:
@@ -4335,7 +4335,7 @@ packages:
   license_family: MIT
   size: 241607
   timestamp: 1692973585084
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
   sha256: ac50f846e93e68d50bfdd5589ea8272b987243a64eba8e2e358ef311d7734001
   md5: f19270ff954a41dabbfe36ff0656935b
   depends:
@@ -4345,7 +4345,7 @@ packages:
   license_family: MIT
   size: 36040
   timestamp: 1659783399073
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -4354,7 +4354,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
   sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
   md5: 353dff9d5d996c2a260f66381b2ce3e8
   depends:
@@ -4365,7 +4365,7 @@ packages:
   license_family: Other
   size: 1470815
   timestamp: 1695058433965
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
   sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
   md5: c99006da802a97c9aae30da8c16b4820
   depends:
@@ -4374,7 +4374,7 @@ packages:
   license_family: BSD
   size: 176131
   timestamp: 1670944706815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
   sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
   md5: 60bd1e037cda86205526f77405d78129
   depends:
@@ -4384,7 +4384,7 @@ packages:
   license_family: BSD
   size: 123361
   timestamp: 1671541992772
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
   sha256: 2fd690fa3c54a40f0426874ea12e12aad2718263a75708ddd1fa6052a4ad7fb3
   md5: 81388724babfe9c32ea5cdd93633c342
   depends:
@@ -4394,7 +4394,7 @@ packages:
   license_family: MIT
   size: 107072
   timestamp: 1684280007887
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
   sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
   md5: 34dfd76da78de2eae95bbda390d746d6
   depends:
@@ -4405,7 +4405,7 @@ packages:
   license_family: BSD
   size: 23092
   timestamp: 1654598007056
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
   sha256: bf0eeef3c3c713515766ab8b0dc7863413de5b4b227deede97e24d90ca342345
   md5: a7bba1857eb84fb50caea377e60d2050
   depends:
@@ -4427,7 +4427,7 @@ packages:
   license_family: PSF
   size: 8066509
   timestamp: 1698692266161
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
   sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
   md5: eb79dabbeedee7da85dfbfb145bb8a26
   depends:
@@ -4437,7 +4437,7 @@ packages:
   license_family: BSD
   size: 17342
   timestamp: 1662014601345
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
   sha256: f400ad75dd2890627dc948f3e2e6b19732d02c124723eaf22272026993a94d52
   md5: 4a4ffc7365e30b18f4443281839e2718
   depends:
@@ -4447,7 +4447,7 @@ packages:
   license_family: MIT
   size: 53505
   timestamp: 1659721313693
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
   sha256: 20fb26a7ac748ce288cf8483a837b0c33f1348ae738bcdb69cdc2763c7bbf7e1
   md5: a0aebbc6c170ebd8d4710fd70b3db503
   depends:
@@ -4456,7 +4456,7 @@ packages:
   license_family: MIT
   size: 19562
   timestamp: 1659716131839
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
   sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
   md5: 56db7bd3ff511cd839bda081523b3edd
   depends:
@@ -4465,7 +4465,7 @@ packages:
   license_family: BSD
   size: 55683
   timestamp: 1629356128780
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
   sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
   md5: 176e0dcaeb28393881bacf69941e3889
   depends:
@@ -4491,7 +4491,7 @@ packages:
   license_family: BSD
   size: 8289638
   timestamp: 1681756329011
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
   sha256: afc6f332c51a3defc69e4c4e641988c0556039b9cd42be22f3db5292c88ccf37
   md5: 2bc409c7258160a9b739d08d5ffb5998
   depends:
@@ -4504,7 +4504,7 @@ packages:
   license_family: BSD
   size: 96942
   timestamp: 1650373637069
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
   sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
   md5: 150ea9fadddf21993d3328d3e48a18b7
   depends:
@@ -4532,7 +4532,7 @@ packages:
   license_family: BSD
   size: 557688
   timestamp: 1668450759059
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
   sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
   md5: 37163b32508f9f589b3e6462a3a47546
   depends:
@@ -4545,14 +4545,14 @@ packages:
   license_family: BSD
   size: 148426
   timestamp: 1694616771736
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
   sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
   md5: 6cdf7cbc43bf40e92b056a5576bd0086
   depends:
@@ -4561,7 +4561,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387216468
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
   sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
   md5: 0f05853a139b6cda9c73e9d2707a4976
   depends:
@@ -4586,7 +4586,7 @@ packages:
   license_family: BSD
   size: 590288
   timestamp: 1690984971741
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
   sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
   md5: 7de782e4fb34bfa95ef2fc79d27d727d
   depends:
@@ -4596,7 +4596,7 @@ packages:
   license_family: BSD
   size: 22840
   timestamp: 1668160634885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
   sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
   md5: 1a7b23113372c5667dbfe45976b9cc5c
   depends:
@@ -4607,7 +4607,7 @@ packages:
   license_family: MIT
   size: 126357
   timestamp: 1696515322390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
   sha256: 3cd1161558704176560843586b1b1f9b257fd68c0ca53a2fc09e61267f47514c
   md5: dd162b2716dc9daf732240a343862d4a
   depends:
@@ -4620,7 +4620,7 @@ packages:
   license_family: BSD
   size: 10388
   timestamp: 1695830584640
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
   sha256: 5f35d8c0e1768fa3a9d2e75659cd2096bea6b4e021afea114f573e95f4943fb2
   md5: 958f78b1e2299537996f98da7a930198
   depends:
@@ -4634,7 +4634,7 @@ packages:
   license_family: BSD
   size: 6313331
   timestamp: 1695830570878
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
   sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
   md5: 371358a54bbdd307603888348d1a2c6f
   depends:
@@ -4644,7 +4644,7 @@ packages:
   license: BSD 2-Clause
   size: 412248
   timestamp: 1628861367714
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
   sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
   md5: fa15d3b44ae1360ac9b640bbd5b6923c
   depends:
@@ -4653,7 +4653,7 @@ packages:
   license_family: Apache
   size: 4746123
   timestamp: 1695322833432
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
   sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
   md5: d73db95f07a282021efdf8bc09713261
   depends:
@@ -4662,7 +4662,7 @@ packages:
   license_family: Apache
   size: 73620
   timestamp: 1693575195999
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
   sha256: 247b5e4d81b6d5d013a9c27e1f30c41fff896fed98a68ebda26b19b4062a6828
   md5: 354a1d65300b4309d53dfa648014e8fe
   depends:
@@ -4709,7 +4709,7 @@ packages:
   license_family: BSD
   size: 13257999
   timestamp: 1697478739906
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
   sha256: 90a1889cd0004bfc5e12ac94b4ea92718a473373033bb0ba5259804ed67bf2bc
   md5: e89f615737385fee88150ab4adf037e6
   depends:
@@ -4733,7 +4733,7 @@ packages:
   license_family: BSD
   size: 17147015
   timestamp: 1698866800249
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
   sha256: 0ae09c974297767a707642344c40f484281f0a3000251a6234e46ef19f00c10e
   md5: 64a0eaf3381e9f6aa971229501710798
   depends:
@@ -4742,7 +4742,7 @@ packages:
   license_family: BSD
   size: 189313
   timestamp: 1698263486159
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
   sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
   md5: 6e01c592ae3b8ff2d12cae76f2f4276b
   depends:
@@ -4761,7 +4761,7 @@ packages:
   license_family: Other
   size: 715239
   timestamp: 1696580071596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
   sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
   md5: 9fb8f460c130d56caf33c6bbe46fbe8a
   depends:
@@ -4772,7 +4772,7 @@ packages:
   license_family: MIT
   size: 2678841
   timestamp: 1697548790931
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
   sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
   md5: 390b8c3cd74281abecdbfd51476922f9
   depends:
@@ -4781,7 +4781,7 @@ packages:
   license_family: MIT
   size: 33033
   timestamp: 1692205747301
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
   sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
   md5: 7896828fb3565fefad43f980d50c8723
   depends:
@@ -4790,7 +4790,7 @@ packages:
   license_family: Apache
   size: 91190
   timestamp: 1659455206354
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
   sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
   md5: d934c74eb66d01af0f45f0881f4bab77
   depends:
@@ -4802,7 +4802,7 @@ packages:
   license_family: BSD
   size: 580588
   timestamp: 1672387390426
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
   sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
   md5: 9858166e5ffb624c8b9d281f4000d725
   depends:
@@ -4811,7 +4811,7 @@ packages:
   license_family: BSD
   size: 367167
   timestamp: 1656431368885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
   sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
   md5: 4d2b45c6be8221e6a3e44c2d5838426f
   depends:
@@ -4823,7 +4823,7 @@ packages:
   license_family: BSD
   size: 30843
   timestamp: 1675441531640
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
   sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
   md5: 02521df4e2e79f75faa9cbb3560ab1dd
   depends:
@@ -4832,7 +4832,7 @@ packages:
   license_family: BSD
   size: 1861763
   timestamp: 1684280026169
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
   sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
   md5: bdebe59bffc7adbad83fdcd9d429a5f5
   depends:
@@ -4842,7 +4842,7 @@ packages:
   license_family: Apache
   size: 95234
   timestamp: 1690223494699
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
   sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
   md5: d716e5c9b5eec45ce1df8eb52cab817a
   depends:
@@ -4851,7 +4851,7 @@ packages:
   license_family: MIT
   size: 157408
   timestamp: 1661452601692
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
   sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
   md5: 1907629863ed8e7c35ead232dae7693f
   depends:
@@ -4860,7 +4860,7 @@ packages:
   license_family: MIT
   size: 91636
   timestamp: 1628941083263
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
   sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
   md5: 847b9bddf2a86e1609c0d53bbc23ea79
   depends:
@@ -4869,7 +4869,7 @@ packages:
   license_family: BSD
   size: 27378
   timestamp: 1626781391140
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
   sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
   md5: 18aa18bd0d260605923877921d26cc74
   depends:
@@ -4888,7 +4888,7 @@ packages:
   license_family: PSF
   size: 13194025
   timestamp: 1694438901368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
   sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
   md5: 45642a99c83e7aed74d1ffab1f20145b
   depends:
@@ -4897,7 +4897,7 @@ packages:
   license_family: BSD
   size: 266647
   timestamp: 1661368655993
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
   sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
   md5: fec748525144049a2fc7f52f9755232c
   depends:
@@ -4906,7 +4906,7 @@ packages:
   license_family: MIT
   size: 257235
   timestamp: 1695131702047
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
   sha256: 960192a143672e9c1d6fe4027af448512d91eee7501e5c245c21b865cf8bf429
   md5: 76d491244218505f071ba56a308673df
   depends:
@@ -4916,7 +4916,7 @@ packages:
   license_family: BSD
   size: 40950
   timestamp: 1685030774581
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
   sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
   md5: 3445d25415998c807efbe64d3a7e03c8
   depends:
@@ -4926,7 +4926,7 @@ packages:
   license_family: MIT
   size: 167068
   timestamp: 1698096118071
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
   sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
   md5: e6e92da28e9b0e428ed4b7df417bec25
   depends:
@@ -4937,7 +4937,7 @@ packages:
   license_family: BSD
   size: 472418
   timestamp: 1657724315435
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -4946,7 +4946,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
   sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
   md5: dba22515f36d3c266de5896350813ea2
   depends:
@@ -4962,7 +4962,7 @@ packages:
   license_family: Apache
   size: 95103
   timestamp: 1690400315537
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
   sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
   md5: 3cd7eb43e285faba76faf67667e26b00
   depends:
@@ -4971,7 +4971,7 @@ packages:
   license_family: MIT
   size: 1093916
   timestamp: 1690290951258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
   sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
   md5: c5e9aef0d6895de1c927e9d796cd7cd3
   depends:
@@ -4980,7 +4980,7 @@ packages:
   license_family: Apache
   size: 15691
   timestamp: 1629145910454
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
   sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
   md5: 0f7c229e774146ffc4e29dedf75372bf
   depends:
@@ -4989,7 +4989,7 @@ packages:
   license_family: MIT
   size: 67279
   timestamp: 1696347632563
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
   sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
   md5: 2302a79a045f152e183a52a81adfba62
   depends:
@@ -5001,7 +5001,7 @@ packages:
   license_family: Other
   size: 1674163
   timestamp: 1681394762218
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
   sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
   md5: 4ae67163d55cf9df83d4027ebc38c501
   depends:
@@ -5012,7 +5012,7 @@ packages:
   license_family: BSD
   size: 30894
   timestamp: 1671751931536
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
   sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
   md5: dbb5c0cddb6661a89afee647fd3dc01e
   depends:
@@ -5022,7 +5022,7 @@ packages:
   license_family: BSD
   size: 39875
   timestamp: 1668168874870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
   sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
   md5: 667e60c8b407d73cbba40f44901f4f00
   depends:
@@ -5031,7 +5031,7 @@ packages:
   license_family: BSD
   size: 3412693
   timestamp: 1654088929697
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
   sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
   md5: 884f788a5f6a664c9b79f7a4a60362d0
   depends:
@@ -5040,7 +5040,7 @@ packages:
   license_family: Apache
   size: 680561
   timestamp: 1696937004165
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
   sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
   md5: 639a4f489af172c866c18442948e5874
   depends:
@@ -5053,7 +5053,7 @@ packages:
   license_family: MOZILLA
   size: 125170
   timestamp: 1679561942932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
   sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
   md5: e5b90eba83fddba6d7aa6072b5bf7c91
   depends:
@@ -5062,7 +5062,7 @@ packages:
   license_family: BSD
   size: 193017
   timestamp: 1671143921826
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
   md5: 644ef8830437070f60efcfcd6a987198
   depends:
@@ -5072,7 +5072,7 @@ packages:
   license_family: PSF
   size: 9670
   timestamp: 1690297532002
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
   md5: a902a833bb186a2f1a4b2b89b1195136
   depends:
@@ -5081,7 +5081,7 @@ packages:
   license_family: PSF
   size: 58466
   timestamp: 1690297524418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
   sha256: 536045a8a172c651fd306c285a6d7409775f018dac944f2124c538ccfb195e28
   md5: d4dc6cdf0812191b9ec78b35b4fdf3e0
   depends:
@@ -5090,7 +5090,7 @@ packages:
   license_family: MIT
   size: 11593
   timestamp: 1659769477205
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
   sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
   md5: f3f1d2c1028dad2f11ff950a15c99dbf
   depends:
@@ -5105,7 +5105,7 @@ packages:
   license_family: MIT
   size: 188640
   timestamp: 1698257577209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
   sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
   md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
   depends:
@@ -5114,7 +5114,7 @@ packages:
   license_family: BSD
   size: 20091
   timestamp: 1629144441130
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
   sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
   md5: 3089c63bf8f4d0423e1a287da286d83e
   depends:
@@ -5124,7 +5124,7 @@ packages:
   license_family: BSD
   size: 70923
   timestamp: 1629357115820
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
   sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
   md5: 5886b30b312445471268444f41f39dc7
   depends:
@@ -5133,7 +5133,7 @@ packages:
   license_family: MIT
   size: 102583
   timestamp: 1695741976083
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
   sha256: 105e39d3eb51b47c7244b3379c0133ab7051966664f52835453b14509215b159
   md5: ed20012c2cd99ffd04cca9929e0bc061
   depends:
@@ -5142,20 +5142,20 @@ packages:
   license_family: BSD
   size: 49775
   timestamp: 1675159079039
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
   sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
   md5: 2e75ad6a09c308268192efe03cc9ebf4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 411778
   timestamp: 1683113019715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
   sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
   md5: 30f666bf97c26587c5d2f68cc5f330ab
   depends:
@@ -5164,7 +5164,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 316901
   timestamp: 1629287855861
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
   sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
   md5: 584e591d36dcd5ba5c45404f0f7ebb2d
   depends:
@@ -5173,14 +5173,14 @@ packages:
   license_family: MIT
   size: 19076
   timestamp: 1672387153578
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
   sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
   md5: 467ae28215d1aa1c5688bc0c8a184269
   license: Zlib
   license_family: Other
   size: 103525
   timestamp: 1666595022664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
   sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
   md5: 7cfbed15f1feee1422810f7830075f53
   depends:
@@ -5192,7 +5192,7 @@ packages:
   license_family: BSD
   size: 779464
   timestamp: 1681304594848
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
   sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
   md5: ed14f9bc6e55220483f1a5a388625a08
   depends:
@@ -5205,7 +5205,7 @@ packages:
   license_family: MIT
   size: 162772
   timestamp: 1644481986085
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
   sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
   md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
   depends:
@@ -5217,7 +5217,7 @@ packages:
   license_family: MIT
   size: 39253
   timestamp: 1644551767970
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
   sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
   md5: b24d13c443a26f65a0778b475a5726bc
   depends:
@@ -5226,7 +5226,7 @@ packages:
   license_family: MIT
   size: 132830
   timestamp: 1695717959996
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
   sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
   md5: 302c3c0696e17eaa62e140e3892644ae
   depends:
@@ -5236,12 +5236,12 @@ packages:
   license_family: MIT
   size: 199723
   timestamp: 1681493196911
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
   sha256: 812f268862208c2518b5187809a8571adb488de3604d512721035e65458dde76
   md5: 97ce620b7dd3ee743d0ca28ed66ace74
   depends:
@@ -5259,7 +5259,7 @@ packages:
   license_family: BSD
   size: 5721832
   timestamp: 1697491241383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
   sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
   md5: bf930260f679bc74227bbb18bc36ae82
   depends:
@@ -5271,7 +5271,7 @@ packages:
   license_family: BSD
   size: 119700
   timestamp: 1657176150595
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
   md5: 507dfe693ef429f466d964b599f4af21
   depends:
@@ -5283,7 +5283,7 @@ packages:
   license: MIT
   size: 18650
   timestamp: 1659616328001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
   md5: d0bf43e8df60baae3b3105aa5c42a791
   depends:
@@ -5294,7 +5294,7 @@ packages:
   license: MIT
   size: 21153
   timestamp: 1659616312367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
   sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
   md5: 7bd24bf94c24e810aecaaf84a0978e6f
   depends:
@@ -5304,14 +5304,14 @@ packages:
   license: MIT
   size: 343204
   timestamp: 1659616543542
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
   sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
   md5: 092b417c11edcbe6bb9b765ab4a55d23
   license: MPL-2.0
   license_family: Other
   size: 164999
   timestamp: 1694009822357
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
   sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
   md5: 708a750d370b9d6875651021e21c4446
   depends:
@@ -5320,7 +5320,7 @@ packages:
   license_family: Other
   size: 159322
   timestamp: 1690232335307
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
   sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
   md5: c35736da3ea26782425e78061268cf5e
   depends:
@@ -5332,7 +5332,7 @@ packages:
   license_family: MIT
   size: 228713
   timestamp: 1670423312743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
   sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
   md5: 457a4339a53c033d48ce0c72e5038d2e
   depends:
@@ -5341,7 +5341,7 @@ packages:
   license_family: BSD
   size: 30330
   timestamp: 1672387265402
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
   sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
   md5: 59ec65fd9e06b81a65cc12986c67d5da
   depends:
@@ -5351,7 +5351,7 @@ packages:
   license_family: CC
   size: 1939614
   timestamp: 1668084794027
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
   sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
   md5: 3489c1a2b73fc957b5a62cc59349e25b
   depends:
@@ -5361,7 +5361,7 @@ packages:
   license_family: BSD
   size: 13438
   timestamp: 1671231196438
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
   sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
   md5: 3492b96083c1e904cc32d26ea7f1e1d8
   depends:
@@ -5373,7 +5373,7 @@ packages:
   license_family: BSD
   size: 184280
   timestamp: 1663827558327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
   sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
   md5: f46d904bc6f220327e70474971341f52
   depends:
@@ -5388,7 +5388,7 @@ packages:
   license_family: BSD
   size: 1220835
   timestamp: 1694445639066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
   sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
   md5: 2ff4fb509788b0e47ac684ba151394d0
   depends:
@@ -5399,7 +5399,7 @@ packages:
   license_family: MIT
   size: 3289966
   timestamp: 1690907040646
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
   sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
   md5: 0f166c3e70541d8bee6e9d0cb60fb66e
   depends:
@@ -5408,7 +5408,7 @@ packages:
   license_family: MIT
   size: 16979
   timestamp: 1649926678161
-- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
   sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
   md5: ea93d413944ca6a8677eb1b284b136ae
   depends:
@@ -5417,7 +5417,7 @@ packages:
   license_family: BSD
   size: 27388
   timestamp: 1668714577678
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -5429,7 +5429,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
   sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
   md5: 9f167d3e45441bc3633c1974b1b0ce8c
   depends:
@@ -5439,7 +5439,7 @@ packages:
   license_family: MIT
   size: 88421
   timestamp: 1676983264486
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
   sha256: fa8f868e49721ca19912f816a6da221172758f9e3d28d8b31d53249fb14dc25f
   md5: 09f9a2cea9425d76dccf9b026afe5bb2
   depends:
@@ -5456,7 +5456,7 @@ packages:
   license_family: BSD
   size: 4576915
   timestamp: 1698866895838
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
   sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
   md5: 30fdefd1541c789c163751291a8faa88
   depends:
@@ -5465,7 +5465,7 @@ packages:
   license_family: BSD
   size: 111448
   timestamp: 1666125667599
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
   sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
   md5: a10f07c7a3510272a296f9fed458a4ed
   depends:
@@ -5475,7 +5475,7 @@ packages:
   license_family: APACHE
   size: 38098
   timestamp: 1678997241511
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
   sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
   md5: fad9cf2023d807da8d44996e9d4399a0
   depends:
@@ -5485,7 +5485,7 @@ packages:
   license_family: Apache
   size: 51490
   timestamp: 1698254721864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
   sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
   md5: 9834848bd7c7759acf12e78d09388563
   depends:
@@ -5495,7 +5495,7 @@ packages:
   license_family: Proprietary
   size: 3891030
   timestamp: 1681801474383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
   sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
   md5: 1285c8c628bc912c54d0968574c9f4c9
   depends:
@@ -5516,7 +5516,7 @@ packages:
   license_family: BSD
   size: 217232
   timestamp: 1691122695748
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
   sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
   md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
   depends:
@@ -5537,7 +5537,7 @@ packages:
   license_family: BSD
   size: 1279433
   timestamp: 1694181820978
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
   sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
   md5: f5fcce35d3f21cdfc5893c5a7a86c651
   depends:
@@ -5547,7 +5547,7 @@ packages:
   license_family: MIT
   size: 1035394
   timestamp: 1644315567034
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
   sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
   md5: f67fe3337528e2886f1ac3ab8ac37985
   depends:
@@ -5557,7 +5557,7 @@ packages:
   license_family: BSD
   size: 213110
   timestamp: 1666908350218
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
   sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
   md5: 81f2c343dc4c65eea39c45383272068f
   depends:
@@ -5567,7 +5567,7 @@ packages:
   license_family: Other
   size: 407861
   timestamp: 1677849239400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
   sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
   md5: bd9526d38a145fe311a8aa36bc11e071
   depends:
@@ -5578,7 +5578,7 @@ packages:
   license_family: MIT
   size: 152006
   timestamp: 1676558783570
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
   sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
   md5: a00e6a62956fde3c4135464353ee8a53
   depends:
@@ -5594,7 +5594,7 @@ packages:
   license_family: BSD
   size: 229158
   timestamp: 1676330909084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
   sha256: db8335d6531b03c7bdfe789ebacc52631ac6ea4a37700bb3da1f6a53a1acd724
   md5: ebeba61994cc225ea5f4f42caa511019
   depends:
@@ -5606,7 +5606,7 @@ packages:
   license_family: BSD
   size: 116681
   timestamp: 1679906658986
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
   sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
   md5: 5efa1332f7c0a8d9638eda02170c4ce5
   depends:
@@ -5631,7 +5631,7 @@ packages:
   license_family: BSD
   size: 413653
   timestamp: 1671707957673
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
   sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
   md5: 891fe66a24d8714737b2874985ee1303
   depends:
@@ -5642,7 +5642,7 @@ packages:
   license_family: BSD
   size: 62298
   timestamp: 1672388166096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -5652,7 +5652,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
   sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
   md5: c345f51706eef530454f66b794e5e574
   depends:
@@ -5661,7 +5661,7 @@ packages:
   license: MIT
   size: 68189
   timestamp: 1659616216976
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
   md5: a7400cfb72042977bc047909ed504ce8
   depends:
@@ -5671,7 +5671,7 @@ packages:
   license: MIT
   size: 33743
   timestamp: 1659616248209
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
   md5: 6307f6854754ab5bd7c84e6998385bb1
   depends:
@@ -5681,7 +5681,7 @@ packages:
   license: MIT
   size: 733177
   timestamp: 1659616279453
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -5691,7 +5691,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
   sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
   md5: b812bc5d9c76242e2bb2ac87afe7d39b
   depends:
@@ -5701,7 +5701,7 @@ packages:
   license_family: GPL3
   size: 730280
   timestamp: 1650983734373
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -5712,7 +5712,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -5721,7 +5721,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -5738,7 +5738,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
   sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
   md5: ba9418df9288a2f031a02fa35b774ce0
   depends:
@@ -5754,7 +5754,7 @@ packages:
   license_family: BSD
   size: 78524
   timestamp: 1694778314659
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
   sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
   md5: b1781519a200ccbfcb4a1194005aa3ef
   depends:
@@ -5766,7 +5766,7 @@ packages:
   license_family: BSD
   size: 338459
   timestamp: 1694777084290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
   sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
   md5: 6ece7f1a3248169837714d05d7f6ef0a
   depends:
@@ -5778,7 +5778,7 @@ packages:
   license_family: MIT
   size: 3513910
   timestamp: 1692971505729
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
   sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
   md5: bd7ec244935e83e850a4ff34e8e2e64f
   depends:
@@ -5789,7 +5789,7 @@ packages:
   license_family: MIT
   size: 513971
   timestamp: 1692973657152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
   sha256: e1c0e745d9ba36a80773e841d96bf514ad1ceda419e4188aad3c22782af00234
   md5: f226532e9bb308f20e874c56be6ceefb
   depends:
@@ -5799,7 +5799,7 @@ packages:
   license_family: MIT
   size: 35788
   timestamp: 1659783414586
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
   sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
   md5: fb7881e74b59262df0fa4ec981964efc
   depends:
@@ -5812,7 +5812,7 @@ packages:
   license_family: Other
   size: 1244887
   timestamp: 1695058550693
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
   sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
   md5: 6970c7f46b0164cad1d210e7a1419959
   depends:
@@ -5822,7 +5822,7 @@ packages:
   license_family: BSD
   size: 143434
   timestamp: 1670944902624
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
   sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
   md5: 1015298551c040c6d5e26eebbae12ef5
   depends:
@@ -5832,7 +5832,7 @@ packages:
   license_family: BSD
   size: 142316
   timestamp: 1671542240512
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
   sha256: ab5c246c2b271acc1cdd0b9343989c0166681536e569cdbe71618f55d34c7292
   md5: 7ce68d771cd94c9ff5efefe69d327c9a
   depends:
@@ -5842,7 +5842,7 @@ packages:
   license_family: MIT
   size: 125122
   timestamp: 1684280210213
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
   sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
   md5: 466da740fafef3d6bce114220f0be306
   depends:
@@ -5855,7 +5855,7 @@ packages:
   license_family: BSD
   size: 28510
   timestamp: 1654508162239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
   sha256: 1687ae122ee7d8b583141fc5014b76d494841dc8083b854449e3d6e0f6bb7019
   md5: 3697ac26ee3c2d49338dd5b9c6551152
   depends:
@@ -5878,7 +5878,7 @@ packages:
   license_family: PSF
   size: 8080067
   timestamp: 1698692812610
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
   sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
   md5: a9fa43e694b25cd49b8b08a9eefd696e
   depends:
@@ -5888,7 +5888,7 @@ packages:
   license_family: BSD
   size: 18054
   timestamp: 1661915903969
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
   sha256: 8aa14047fac6ef8b326900c4bf1a960eaa7a1699c18fdf1e75a59101b610b6df
   md5: 7e1d4d4700fbea6171d30f1d5ad24226
   depends:
@@ -5898,7 +5898,7 @@ packages:
   license_family: MIT
   size: 53362
   timestamp: 1659721308586
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
   sha256: 2017814a7cc93dd51c6b7c016e3cdf8fbc32fa20f985638aaff6a6377e9ee086
   md5: a1a285c56b001c3b5c591bf21eec3149
   depends:
@@ -5907,7 +5907,7 @@ packages:
   license_family: MIT
   size: 19326
   timestamp: 1659716205153
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
   sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
   md5: 248c468abced874f0231d3cc23177c77
   depends:
@@ -5918,7 +5918,7 @@ packages:
   license_family: BSD
   size: 58488
   timestamp: 1607359497934
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
   sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
   md5: 5e763c995ff0c549f68a10bce70fede4
   depends:
@@ -5930,7 +5930,7 @@ packages:
   license_family: Proprietary
   size: 187489950
   timestamp: 1691503804820
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
   sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
   md5: dd0c2ece6a743c373c9b5a5919b4818f
   depends:
@@ -5942,7 +5942,7 @@ packages:
   license_family: BSD
   size: 49744
   timestamp: 1682975040154
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
   sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
   md5: 57cea8df7ab85f2a98f64d23afcb1f90
   depends:
@@ -5957,7 +5957,7 @@ packages:
   license_family: BSD
   size: 184956
   timestamp: 1695058491736
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
   sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
   md5: 8769cdd201d905069800488fe31574e5
   depends:
@@ -5972,7 +5972,7 @@ packages:
   license_family: BSD
   size: 256221
   timestamp: 1695060152521
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
   sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
   md5: d9781492332e6326f9fca87f3a8efacd
   depends:
@@ -5998,7 +5998,7 @@ packages:
   license_family: BSD
   size: 8135792
   timestamp: 1681756491399
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
   sha256: 2dd3178d3c570e30b9490ebabfd7bfac806afad8302d3dee0edc619805034397
   md5: bef9da0f0694c45b6aaa4e6447479eaf
   depends:
@@ -6011,7 +6011,7 @@ packages:
   license_family: BSD
   size: 118324
   timestamp: 1650290466135
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
   sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
   md5: f1d8ce412e115986c403f223b3b47d0f
   depends:
@@ -6039,7 +6039,7 @@ packages:
   license_family: BSD
   size: 596314
   timestamp: 1668451106600
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
   sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
   md5: f96bbef0985d7e66ebf00c0d55e30e23
   depends:
@@ -6052,7 +6052,7 @@ packages:
   license_family: BSD
   size: 167045
   timestamp: 1694617078743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
   sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
   md5: 6e6ba64c8dc5025aeac606404a8df36a
   depends:
@@ -6061,7 +6061,7 @@ packages:
   license_family: BSD
   size: 13786
   timestamp: 1672387480065
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
   sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
   md5: 4a7a3286484766741f627696697c362c
   depends:
@@ -6086,7 +6086,7 @@ packages:
   license_family: BSD
   size: 609425
   timestamp: 1690985686105
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
   sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
   md5: 4269a1f93882205b90d4b2ae78fc82d5
   depends:
@@ -6096,7 +6096,7 @@ packages:
   license_family: BSD
   size: 22417
   timestamp: 1668160717305
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
   sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
   md5: a18a576b7024cfd6f905c526a786a916
   depends:
@@ -6111,7 +6111,7 @@ packages:
   license_family: MIT
   size: 135285
   timestamp: 1696515698492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
   sha256: e5e11f9b42d770ee46ac24d1cdf7aa4e9c49a60a607c8c28e7729131a99eadd5
   md5: 4274d06db8a9a381c072d226d0322dc0
   depends:
@@ -6128,7 +6128,7 @@ packages:
   license_family: BSD
   size: 9835
   timestamp: 1695830845329
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
   sha256: dcaa1607ce40a0ed610dd5398e125c8e5b08e738e50b6037a8c72b49ca561ff2
   md5: d99d990a60644b97ba1ff9bb8da0e66f
   depends:
@@ -6144,7 +6144,7 @@ packages:
   license_family: BSD
   size: 6778113
   timestamp: 1695830816710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
   sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
   md5: ab07e2a27ac08afe3d0b4c0890b8486a
   depends:
@@ -6155,7 +6155,7 @@ packages:
   license: BSD 2-Clause
   size: 249316
   timestamp: 1630094024143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
   sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
   md5: 73b17037d87b5a58feb34dafc0538f7f
   depends:
@@ -6166,7 +6166,7 @@ packages:
   license_family: Apache
   size: 8058396
   timestamp: 1695324589828
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
   sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
   md5: df1d746ba8d5d6ba01ac1373b9b71e1a
   depends:
@@ -6175,7 +6175,7 @@ packages:
   license_family: Apache
   size: 73016
   timestamp: 1693575484990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
   sha256: 1994e5831fd421bd6cf85916073d4012dec53e673b672b3985efaf771f0a7bf8
   md5: c486a5b51e3227f6ea564a9dd3125e45
   depends:
@@ -6223,7 +6223,7 @@ packages:
   license_family: BSD
   size: 12629931
   timestamp: 1697479885371
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
   sha256: 270e4c3ab0f0c8d8f31fa0e45bc516c1e41be618a5c66e1c86dc39ce76cb2372
   md5: cad52ba9eb391416112f0994b6c35249
   depends:
@@ -6247,7 +6247,7 @@ packages:
   license_family: BSD
   size: 17162886
   timestamp: 1698867967809
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
   sha256: 56eaf7f4b1bb81e3deed55711dd2ee78f244a3cc0ad4bb7a1f09d97e46f9793f
   md5: c24a3daed1e85ba7a100fa6966c5bb48
   depends:
@@ -6256,7 +6256,7 @@ packages:
   license_family: BSD
   size: 189021
   timestamp: 1698263520538
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
   sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
   md5: 427c1450bebb632f43bbc8c83006e4cd
   depends:
@@ -6275,7 +6275,7 @@ packages:
   license_family: Other
   size: 806931
   timestamp: 1696580240310
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
   sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
   md5: 21790cd3e2b8a45c4104aff0a68330d0
   depends:
@@ -6286,7 +6286,7 @@ packages:
   license_family: MIT
   size: 3001751
   timestamp: 1697549357662
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
   sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
   md5: 56f44a1054da2d10777e375838191070
   depends:
@@ -6295,7 +6295,7 @@ packages:
   license_family: MIT
   size: 32355
   timestamp: 1692205784293
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
   sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
   md5: 8a35ad65651086575ce55371f22feda8
   depends:
@@ -6304,7 +6304,7 @@ packages:
   license_family: Apache
   size: 91045
   timestamp: 1659455316472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
   sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
   md5: 186eb95f816a2eff80c3c7f7d964c7b0
   depends:
@@ -6316,7 +6316,7 @@ packages:
   license_family: BSD
   size: 578514
   timestamp: 1672388155359
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
   sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
   md5: 47b6cbe6ce9289e47d16900b03596a91
   depends:
@@ -6327,7 +6327,7 @@ packages:
   license_family: BSD
   size: 372807
   timestamp: 1656431445633
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
   sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
   md5: 07165c444adc7c7ccc8a345875adc5ef
   depends:
@@ -6339,7 +6339,7 @@ packages:
   license_family: BSD
   size: 48408
   timestamp: 1675450623287
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
   sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
   md5: d58e76a31e2f6e7410ba4afd7f385b0d
   depends:
@@ -6348,7 +6348,7 @@ packages:
   license_family: BSD
   size: 1877445
   timestamp: 1684280183367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
   sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
   md5: 0e5b0fe7debbf558ce97090f6b67cdae
   depends:
@@ -6358,7 +6358,7 @@ packages:
   license_family: Apache
   size: 94633
   timestamp: 1690225630423
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
   sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
   md5: 0fde797653e4ab589506121fb1e37555
   depends:
@@ -6367,7 +6367,7 @@ packages:
   license_family: MIT
   size: 157119
   timestamp: 1661452591647
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
   sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
   md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
   depends:
@@ -6378,7 +6378,7 @@ packages:
   license_family: MIT
   size: 92679
   timestamp: 1636093365041
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
   sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
   md5: f870859d4dc7a8d82cf3546bd9035f33
   depends:
@@ -6388,7 +6388,7 @@ packages:
   license_family: BSD
   size: 54520
   timestamp: 1605307564142
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
   sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
   md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
   depends:
@@ -6401,7 +6401,7 @@ packages:
   license_family: PSF
   size: 21172845
   timestamp: 1694442462066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
   sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
   md5: 9d99075052265ae3d718582d3b875038
   depends:
@@ -6410,7 +6410,7 @@ packages:
   license_family: BSD
   size: 269964
   timestamp: 1661376543480
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
   sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
   md5: fa9074d94236c9b768bfd2c858875b27
   depends:
@@ -6419,7 +6419,7 @@ packages:
   license_family: MIT
   size: 264836
   timestamp: 1695131770282
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
   sha256: 97243a31c39f4990c0e9d4f2307f2f7fb9421553303923bc105067ec4340bdff
   md5: 8078c5760f27398eaf1082226647d137
   depends:
@@ -6429,7 +6429,7 @@ packages:
   license_family: BSD
   size: 40145
   timestamp: 1685031143383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
   sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
   md5: 3d2841085778006c2e79f9c7300f8b9d
   depends:
@@ -6439,7 +6439,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13565975
   timestamp: 1669937633869
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
   sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
   md5: 54a4bc0724041dd173088419d6ede2af
   depends:
@@ -6451,7 +6451,7 @@ packages:
   license_family: MIT
   size: 239062
   timestamp: 1677611495106
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
   sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
   md5: f39f84115e228bad4bceaefdd637f022
   depends:
@@ -6463,7 +6463,7 @@ packages:
   license_family: MIT
   size: 158558
   timestamp: 1698096358091
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
   sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
   md5: df398a3a1668fd2a22061764e20ea91d
   depends:
@@ -6475,7 +6475,7 @@ packages:
   license_family: BSD
   size: 460913
   timestamp: 1657616061604
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
   sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
   md5: 38db77ece9dc76feffb9ef7638e38258
   depends:
@@ -6491,7 +6491,7 @@ packages:
   license_family: Apache
   size: 94397
   timestamp: 1690400496655
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
   sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
   md5: 3e284ae6b48ee30c364ffdc5601610b0
   depends:
@@ -6500,7 +6500,7 @@ packages:
   license_family: MIT
   size: 1099842
   timestamp: 1690291374842
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
   sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
   md5: 993b3886b334bd1f49d34206f21997b4
   depends:
@@ -6509,7 +6509,7 @@ packages:
   license_family: Apache
   size: 15998
   timestamp: 1614030572433
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
   sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
   md5: 7ac9604ad7564ac0c71bff5db198656f
   depends:
@@ -6518,7 +6518,7 @@ packages:
   license_family: MIT
   size: 67012
   timestamp: 1696347795139
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
   sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
   md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
   depends:
@@ -6528,7 +6528,7 @@ packages:
   license_family: Other
   size: 1311308
   timestamp: 1681402905668
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -6538,7 +6538,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
   sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
   md5: 28b9869d8d3a839918fac4a08f38cbc2
   depends:
@@ -6549,7 +6549,7 @@ packages:
   license_family: BSD
   size: 30546
   timestamp: 1671752127904
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
   sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
   md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
   depends:
@@ -6559,7 +6559,7 @@ packages:
   license_family: BSD
   size: 39590
   timestamp: 1668168880994
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
   sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
   md5: 52cdcdb96383c010ca833a7c24b3935b
   depends:
@@ -6569,7 +6569,7 @@ packages:
   license_family: BSD
   size: 3690152
   timestamp: 1654036853710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
   sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
   md5: 0e054ab29119cf4c1f778613acf972f9
   depends:
@@ -6580,7 +6580,7 @@ packages:
   license_family: Apache
   size: 681780
   timestamp: 1696937326924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
   sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
   md5: b6ad839ebba536ad1c3cc58d0e2123f0
   depends:
@@ -6594,7 +6594,7 @@ packages:
   license_family: MOZILLA
   size: 143681
   timestamp: 1679562248929
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
   sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
   md5: fe78de10019085146f1cc6c94fdc2620
   depends:
@@ -6603,7 +6603,7 @@ packages:
   license_family: BSD
   size: 192822
   timestamp: 1671143999327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
   md5: ca5fc3fbdb09b6de068a8b7a8869369f
   depends:
@@ -6613,7 +6613,7 @@ packages:
   license_family: PSF
   size: 9208
   timestamp: 1690298120549
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
   md5: a86e87a10e5fdff486265e0c675fb99f
   depends:
@@ -6622,7 +6622,7 @@ packages:
   license_family: PSF
   size: 57922
   timestamp: 1690298106990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
   sha256: 8057d3d2a0acd44496de33c5b222063c3f7d06b90c74fbbda45bd18b0b324219
   md5: 398f8db5bd8cab84b3d85a9d85fa4889
   depends:
@@ -6631,7 +6631,7 @@ packages:
   license_family: MIT
   size: 11362
   timestamp: 1659769459206
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
   sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
   md5: 0d31859e0a097aedbcc1627db33b3d92
   depends:
@@ -6646,7 +6646,7 @@ packages:
   license_family: MIT
   size: 188367
   timestamp: 1698257883295
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
   sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
   md5: 45ef24c486a484f079faf1dc90e4c7e9
   depends:
@@ -6655,12 +6655,12 @@ packages:
   license_family: BSD
   size: 8277
   timestamp: 1605602889180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
   sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
   md5: 4daaceb6cfc1af6274509081d8018ef1
   size: 2316783
   timestamp: 1605602872095
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
   sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
   md5: 916c16904615c7af3b5d37cb6694f45e
   depends:
@@ -6669,7 +6669,7 @@ packages:
   license_family: BSD
   size: 21084
   timestamp: 1607347371925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
   sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
   md5: da69e6987fcc757e83a358ceaa13f62b
   depends:
@@ -6679,7 +6679,7 @@ packages:
   license_family: BSD
   size: 73391
   timestamp: 1614804425587
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
   sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
   md5: 23b9f4634b2e5450be617114f62c74f9
   depends:
@@ -6688,7 +6688,7 @@ packages:
   license_family: MIT
   size: 120873
   timestamp: 1695742300539
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
   sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
   md5: 120f0b088290fc17bd6618fc10a2f0c4
   depends:
@@ -6696,13 +6696,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 34293
   timestamp: 1605306211299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
   sha256: a5d2a216d052105fdaad7256f23da3b29f95100d1dc0f29b6ab1f3bbc75e17a9
   md5: a558f681ebc243f86cde2515c065b62e
   depends:
@@ -6711,7 +6711,7 @@ packages:
   license_family: BSD
   size: 48805
   timestamp: 1675159123654
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
   sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
   md5: c3f7871e9a33adeccee1b1e8e216918e
   depends:
@@ -6721,7 +6721,7 @@ packages:
   license_family: GPL2
   size: 1332571
   timestamp: 1683113347814
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -6730,7 +6730,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
   sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
   md5: 1ab55f8c4b5292ec360c572120bf823e
   depends:
@@ -6740,7 +6740,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 9430705
   timestamp: 1616055773485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
   sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
   md5: 6875e0bf3828707dc9165d694c0d0a7d
   depends:
@@ -6749,7 +6749,7 @@ packages:
   license_family: MIT
   size: 18725
   timestamp: 1672387612937
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
   sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
   md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
   depends:
@@ -6759,7 +6759,7 @@ packages:
   license_family: Other
   size: 148931
   timestamp: 1666595229032
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
   sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
   md5: 8d6a1e767775fe0eb617cd6e22edc2ff
   depends:

--- a/particle_swarms/pixi.toml
+++ b/particle_swarms/pixi.toml
@@ -1,0 +1,32 @@
+[workspace]
+name = "particle_swarms"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2020-08-10"
+maintainers = ["scottire"]
+categories = ["Mathematics"]
+labels = ["holoviews", "bokeh", "panel"]
+description = "Interactive dashboard for Particle Swarm Optimisation"
+no_data_ingestion = true
+
+[dependencies]
+python = "3.9.*"
+notebook = "*"
+holoviews = "*"
+panel = "*"
+param = "*"
+numpy = "*"
+pandas = "*"
+bokeh = "*"
+pip = "*"
+setuptools = "*"
+wheel = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks]
+dashboard = "panel serve --rest-session-info --session-history -1 particle_swarms.ipynb --show"
+notebook = "jupyter notebook particle_swarms.ipynb"

--- a/particle_swarms/pixi.toml
+++ b/particle_swarms/pixi.toml
@@ -20,12 +20,12 @@ param = "*"
 numpy = "*"
 pandas = "*"
 bokeh = "*"
-pip = "*"
-setuptools = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+setuptools = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks]
 dashboard = "panel serve --rest-session-info --session-history -1 particle_swarms.ipynb --show"

--- a/particle_swarms/pixi.toml
+++ b/particle_swarms/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "particle_swarms"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/penguin_crossfilter/pixi.lock
+++ b/penguin_crossfilter/pixi.lock
@@ -1,0 +1,7246 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.3.0-py39h2f386ee_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39hdda0065_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.9.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.10.4-hf1b16e4_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.37-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.9.3-py39hdbbb534_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.0-py39h5f9d8c6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.0-py39hb5e798b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.11-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.1.1-py39h1128e8f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.3.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.18-h955ad1f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.11.3-py39h5f9d8c6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.9.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.9.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.9.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+  sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
+  md5: 613805add1c05b538ff06d217252feb7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 20810
+  timestamp: 1652859733309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+  sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
+  md5: 2cf39d906cc321896ffe3e5d33d80c5c
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162166
+  timestamp: 1644463608931
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+  sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
+  md5: 2972a84e0e22ae3244bbd2f1eebcf536
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 35352
+  timestamp: 1644569715988
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+  sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
+  md5: a68016b4b06460def24cb69d932986f3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132486
+  timestamp: 1695717963702
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+  sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
+  md5: 2f6356a2f530314b4059c08c79a3d8bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 205868
+  timestamp: 1681493113570
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.3.0-py39h2f386ee_0.tar.bz2
+  sha256: f2a4f2dbea826cfaf59d09e53a4bb951ffd77becb2f53f5b4ddb6ef63cdd5210
+  md5: 1d420e8258cf81e6cebc7320e5cf6a0a
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5706055
+  timestamp: 1697490557655
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
+  sha256: 20e381c665853131fc5c9a397b1d4b05bb05859a2bdfbb0559e85ec445ee9e7c
+  md5: 14dc3c2e8eb68b1111a08de9a3ce8a00
+  depends:
+  - libgcc-ng >=11.2.0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 128656
+  timestamp: 1657175966755
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 11df9b719339bb40e4af8eb124a094def217f64e2440af973d7342da19c030b0
+  md5: 712827b1699cc71e6240626c413408f3
+  depends:
+  - brotli-bin 1.0.9 h5eee18b_7
+  - libbrotlidec 1.0.9 h5eee18b_7
+  - libbrotlienc 1.0.9 h5eee18b_7
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 18907
+  timestamp: 1659616178155
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 6408b6849347ef01f5ed170f4b35fb4bdfed2d9cf9da4912a4b104a810518a80
+  md5: d9d570587ccfd7158b66feb823c990c6
+  depends:
+  - libbrotlidec 1.0.9 h5eee18b_7
+  - libbrotlienc 1.0.9 h5eee18b_7
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 19933
+  timestamp: 1659616170430
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
+  sha256: 8507df3357958556aff2dea8788a3f7ddad6172fd9fe5d1bdb6c3afe9686d2f8
+  md5: f0204f72bcd9ef836218cc74345e69f2
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 362180
+  timestamp: 1659616255400
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+  sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
+  md5: 3ef00f4c5278b688552efc259c463dc8
+  license: MPL-2.0
+  license_family: Other
+  size: 132731
+  timestamp: 1694009767372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+  sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
+  md5: d5cb3d97cf5e85ffe5e94037ed8a1169
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159077
+  timestamp: 1690232254640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
+  sha256: e99314f8809d65195dcab68a9783f70fbe990113a66c98c9b0a7ffea01226b71
+  md5: fff69f95079191a10e099b21a5fd4bc3
+  depends:
+  - libffi >=3.4,<3.5
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 234749
+  timestamp: 1670423281079
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+  sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
+  md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1917831
+  timestamp: 1668084545510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+  sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
+  md5: 13702d3b4b744784e5bd559c7050dd6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12719
+  timestamp: 1671231205875
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
+  sha256: 0b1a9a25ddfc6631390c53d6ee95706eaab0805c5a9a8d748c08120a1f421256
+  md5: a93581f810ef522bd23c148195591157
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 234846
+  timestamp: 1663827645102
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39hdda0065_0.tar.bz2
+  sha256: 6a08c501a310e5e482df8e917a7b0cd438e83f33a44aaec49c2ab53eeda5ebf1
+  md5: 3f8c39c0ce002faf6719b8d2d5f31941
+  depends:
+  - cffi >=1.12
+  - libgcc-ng
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 2181966
+  timestamp: 1694444647708
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
+  sha256: 96b5d4c87d8467ae6ba92f9c17eaa9e059b6f7e9b8ee57aee788885c7413078b
+  md5: 9868912fd269f4d9d6423cfe69560131
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2164334
+  timestamp: 1690905228819
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+  sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
+  md5: 2e6ec51066d825ef3c317abe78d6049e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16413
+  timestamp: 1649926472708
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+  sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
+  md5: b4d923222d45314856b5378cb115214d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26728
+  timestamp: 1668714462023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+  sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
+  md5: a5dc8677d891dff2393b63189a3ad42f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 971975
+  timestamp: 1666798278693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
+  sha256: c323a9800a358c178f6f3b8860bbb77c373fbc3be981bb6420175fbb5431adf5
+  md5: 6485f51176cf651b3b28c3548cef10ad
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 78533
+  timestamp: 1676983203797
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.0-py39h06a4308_0.tar.bz2
+  sha256: 6d934b1d532f644e148bcf51f9c8d0c7623e832fd29282bc6c4cb64b9e027884
+  md5: b18725efd77d3fb6c9addf81dac09081
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4576699
+  timestamp: 1698866790345
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.9.0-py39h06a4308_0.tar.bz2
+  sha256: ebe76b5a96add44b3befafb39e1b1946306cc0f1f98e8cf1fdfeb134a6fbd2fd
+  md5: 74ad1a52b081ba48af21ea48697c06aa
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.9.0,<3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3310817
+  timestamp: 1697560077151
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+  sha256: b35b281dbf69b826c6ae04fcd7b6a2d1f098277a669a199906a1f23b4b0931a5
+  md5: 2a793fe24f85aa5819fe69c450cba6f7
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 29021241
+  timestamp: 1692293243228
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+  sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
+  md5: 1eb52f9f45cea2fb9ce27b19f990160e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110793
+  timestamp: 1666125606878
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+  sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
+  md5: 126b3c1933b7364ff03f67455b687e99
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 37588
+  timestamp: 1678997134023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
+  sha256: b6d5f6098903e5edfbc2200282efa186d446442d47ab75f51ff22c30ae0c4da4
+  md5: e53a806995cedc9e5d8a96e03c9e79ac
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 50699
+  timestamp: 1698254665788
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
+  sha256: bddc8de31272a509510cc87e5ac0cdb0e7765d393ca7bdfddbfe4123979a9413
+  md5: bc8a501970aadad3373edbce996b5fdf
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<1.2.14
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 19286333
+  timestamp: 1681801301379
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
+  sha256: c0d0714c68ed953740812688ac1b3c3e286de33b55d49f02953d705fb00c30d0
+  md5: 8b65eea396159a3b59278f77c81ddd1b
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217268
+  timestamp: 1691122070319
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+  sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
+  md5: ff47e0be879e817713ce2a9daa76e2b0
+  depends:
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1261116
+  timestamp: 1694181530670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+  sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
+  md5: 5ef6c6a0d1ac79143c7359d305155167
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1021637
+  timestamp: 1644297140650
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+  sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
+  md5: eaeb023688f781e7dd89e74310c38195
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 211775
+  timestamp: 1666908212136
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+  sha256: c21f8f407266d039e819c27fe9eb4fb26587e974f3bd059b37cbaec5073722d0
+  md5: ba1f47411e9e07876c7a3e9d3be6a98e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: IJG
+  license_family: Other
+  size: 281400
+  timestamp: 1677849152168
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+  sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
+  md5: 0d2c3c5edf671b575532d5a3e8bf15fc
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 131510
+  timestamp: 1676558716852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
+  sha256: 4ba1f5698f0b483af397021b2047554afb3129790cac3a1502c79693154331d2
+  md5: 8e9c0ef4b0b57caa87c146892e56a313
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192921
+  timestamp: 1676329415827
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+  sha256: 0192bd48cd96c60dc3054d5addd8cdb4a29a218843181318371f79daec8242f8
+  md5: d851b401dc13d04e6848bb36e12efc1c
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 91534
+  timestamp: 1679906652183
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+  sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
+  md5: a4beb461f0a60998a090d760b5c6c907
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411564
+  timestamp: 1671707702849
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
+  sha256: 6d6c384c9c65e33d5d047e01131e0687eb2bc1e5a4a67f80af3c0b773c1bba82
+  md5: 07957e1d2fb6a407f7d7293b84938e1e
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 77689
+  timestamp: 1672387301020
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+  sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
+  md5: 88199c75f2ac211728febced7785c24e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 228278
+  timestamp: 1635523146417
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 472cf888db65d00451fcd5fccd5244d55c061e8d7efe43f70220414ef64521a5
+  md5: 787927eff72e62c270f614cbcba9479c
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 67109
+  timestamp: 1659616145972
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 19a43182ca343510ba51baa0fce91d64c840a19cdf13c6dde4e03e819c70897e
+  md5: c0608d376a30b5aa4d2f2c22978135db
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_7
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 34691
+  timestamp: 1659616154057
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 158c401aa0bab05aa5f4134aea798085e4e3849209946f896cca352930d2225d
+  md5: cc6a6d362912a2d112310bd3f8acd44e
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_7
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 295287
+  timestamp: 1659616162282
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+  sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
+  md5: 55dde57e63a36b202e388a39dcee9a66
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 74096
+  timestamp: 1695996494461
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
+  sha256: ec1c6341cf0091b55be05285037cb3fbba90573e00257f383ab274d8b8e6d46f
+  md5: 32ac65d639d6c155ea7276cadf1fd2b6
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 147907
+  timestamp: 1683716564178
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
+  md5: 641e72e5067bd6d5454405879e1cd2a7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - _libgcc_mutex * main
+  - __glibc >=2.17
+  constrains:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - libgomp 11.2.0 h1234567_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 8895144
+  timestamp: 1654090827491
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+  sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
+  md5: 27082517590f3b9fbffecc68513b461b
+  depends:
+  - libgfortran5 11.2.0.*
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 19860
+  timestamp: 1654090819660
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+  sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
+  md5: 0202c3c8ae4735cac6c7f3d1e1685964
+  constrains:
+  - libgfortran-ng 11.2.0 *_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 5228750
+  timestamp: 1654090762569
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+  sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
+  md5: 3080c2813e6e1d0f8a100a38b5b3456d
+  depends:
+  - _libgcc_mutex 0.1 main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 573231
+  timestamp: 1654090775721
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+  sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
+  md5: 1bffe1481ed4f88827248fb9001f8923
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 362561
+  timestamp: 1677841789536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
+  md5: 8c195584a5f5471b600ee180e4052773
+  depends:
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 6410287
+  timestamp: 1654090800863
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+  sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
+  md5: ef78eebd98289aceacdfa29182426adf
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 664034
+  timestamp: 1693575237924
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
+  sha256: c6aecee300c8e84a99056307ed3bdc047edd5366e55230a4eabe3ee5e8082bb8
+  md5: 3a6ebf9895b1085a23783cd95460a629
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88424
+  timestamp: 1694778218406
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+  sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
+  md5: 9cdeef1d044c7e035c006890f11569d3
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 436056
+  timestamp: 1694776944891
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.10.4-hf1b16e4_1.tar.bz2
+  sha256: 93b155c0472d424dce940921ff368a3e4fd70fa41f5f934e58a4b7ec24722f95
+  md5: 2d7bb4d2ef09d62843f8be03b55fce18
+  depends:
+  - icu >=73.1,<74.0a0
+  - libgcc-ng >=11.2.0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 744988
+  timestamp: 1692970212537
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.37-h5eee18b_1.tar.bz2
+  sha256: e4e42cc28f7d509980afa2b1e76266d997628c9ff5d194c8460228279c0b6cdc
+  md5: ff861c432be5a684783732ad1eb4c39f
+  depends:
+  - icu >=73.1,<74.0a0
+  - libgcc-ng >=11.2.0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 258682
+  timestamp: 1692973520375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py39h06a4308_0.tar.bz2
+  sha256: 0e4d61ed508712fc16117fc41f0f5bfedd319cfefd114749689db5f78242b0a5
+  md5: d40d6b6ea51683b29a9e210831db4a13
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 35171
+  timestamp: 1659783489143
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.9.3-py39hdbbb534_0.tar.bz2
+  sha256: b961c12e78000995cfcc5769c64b1c146f917e640e999e290bb2b36468bd7dbe
+  md5: a3a5039a19997b8cee4ddf538472358c
+  depends:
+  - libgcc-ng >=11.2.0
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1616363
+  timestamp: 1695058577405
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
+  sha256: 36b23ab8d8aa22d70a2f733462cabe95e5b27ca919ec7a75a5592bc39c5f7d16
+  md5: f24adbfdfe16b0bac0d14640bb5ce616
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 163649
+  timestamp: 1670944701605
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+  sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
+  md5: 421f82c8274b44660dba629134faa6af
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 122221
+  timestamp: 1671541990505
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py39h06a4308_1.tar.bz2
+  sha256: 9332b39039a52ecc802ddc2c4a3bde95a3141aff0ccab19a7591ec6ef72bfe07
+  md5: 622bb5a6eeeadeb8731e5e1bf4f0d7a2
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 105637
+  timestamp: 1684279960746
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+  sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
+  md5: feb0e452205b44ac45d9b5e55c21a3b1
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22819
+  timestamp: 1654597913064
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
+  sha256: 10701d3065424bbef89c03a30c4adecd67308cd2f76e0d873aad6a180d9fe097
+  md5: e196f6bace29ef34f0a996ef1c99f193
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8129476
+  timestamp: 1698692330174
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+  sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
+  md5: c04ef34af33da4c71bcc99b7ec24d210
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16391
+  timestamp: 1662014553452
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py39h06a4308_0.tar.bz2
+  sha256: 0dd0157d3d6c591a1087f7b96993412ac9194b7ea0ee2d667b1dc1c587eb0e33
+  md5: 975a78ae464b1cd9541c498fd8299858
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 52857
+  timestamp: 1659721312521
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py39h06a4308_0.tar.bz2
+  sha256: cae67d22945f16e1034fc53144eea8bb67f2fecf6d60b22c43822094b6ca2b49
+  md5: 19932cd4f64628bf6db1accebdaf7eac
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18689
+  timestamp: 1659716096534
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+  sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
+  md5: f6c734d73e6e3dbc1b62766cf18ff3e4
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58153
+  timestamp: 1607364912263
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
+  sha256: c7dedf41acbb2a065364f949ba24479449387d54c095220ff89346d266b25347
+  md5: c5f96c8ff7102e1d673829bbeb8bed84
+  depends:
+  - intel-openmp 2023.*
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - tbb 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 206706869
+  timestamp: 1691503234180
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
+  sha256: 984f547627b0af8358fa83b2396e0b2c014f9bc281304b6b8d3ff139a3f04b40
+  md5: 724d2559e0ed50aa0eee97c919134ded
+  depends:
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 58512
+  timestamp: 1682948511810
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
+  sha256: 650419991b99b810e79221e35e5a6c3e49240ed30ff3e5324eecf1cefd276110
+  md5: a14b8155afdb15f3bce72e67925c0ceb
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 227382
+  timestamp: 1695058347376
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
+  sha256: 7b0eeb8acc4c6b9f45b214fbc991a4073a59a8f7b798a4cc86515b97f7af6355
+  md5: eb48e45fd8d61762290e4289a52be3f7
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 329190
+  timestamp: 1695059874042
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+  sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
+  md5: 95c83d71814c504b5504df4f14548f1a
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8257558
+  timestamp: 1681756322140
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+  sha256: 1b92d72b083f3350359b8fb2e3b5dc846f49650c9e46a6a74354b1b7f0d42730
+  md5: 996babe4314515ddd41008a53cb5d47f
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 98791
+  timestamp: 1650290544347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+  sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
+  md5: 1710a25086c8098367eb36b9d441448b
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 569683
+  timestamp: 1668450704669
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+  sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
+  md5: 385cc9e53404776782502c0fdb08820f
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147046
+  timestamp: 1694616899309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+  sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
+  md5: 57ea097dc15f8d9f9eb90e1d919143b0
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1157733
+  timestamp: 1674734069410
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+  sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
+  md5: bbbcbebc20a4fdcadce398d0ca04f95e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13109
+  timestamp: 1672387143252
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+  sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
+  md5: 248ce515640465371927d46f389ed555
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 594054
+  timestamp: 1690985006481
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+  sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
+  md5: 70db71df4ee1cdd38090c0f7b80ba61f
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21944
+  timestamp: 1668160644514
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
+  sha256: e61fc626f7131f1857c703ad3bb4dcacfc6b1fd6d5da545aa8f600b840315aca
+  md5: 6b689e52e3ba1fa7caaab3e6be31860c
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 141434
+  timestamp: 1696515497148
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.0-py39h5f9d8c6_0.tar.bz2
+  sha256: de22d445f66249c5bf5fbef2f4bba81baa0eb13e5050036da9ffacd46b3ee1ea
+  md5: 0c454790ce9011e27e597f8b1ce5e769
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.0 py39hb5e798b_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9526
+  timestamp: 1695832867641
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.0-py39hb5e798b_0.tar.bz2
+  sha256: 0f8233bca839fed724ee08cf5cb1bafffd72bd3f588401adb3bf126990d8bf19
+  md5: 068fb4b40cd349a7db1d9ed214178ca6
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.26.0 py39h5f9d8c6_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7858953
+  timestamp: 1695832851373
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+  sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
+  md5: b0afe23033c8c5344640bc25225fa579
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 516994
+  timestamp: 1630084830020
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.11-h7f8727e_2.tar.bz2
+  sha256: 3a01ea7f58c487ee5d30251c089137ad9600dc305a82e09231dd112e19824e71
+  md5: 39ef8bbb036d537b1deb7f7ac32ea87e
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 5493777
+  timestamp: 1695322649929
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+  sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
+  md5: 77a22ed6d0d448c5288d0f695bc9ac49
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 72527
+  timestamp: 1693575234886
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.1.1-py39h1128e8f_0.tar.bz2
+  sha256: 525a877de379651efc20862a77deb470c9c4ff3cfa470d3643c5036de0ec5d17
+  md5: dd9fcd456d8fb03daad201cf130d28bd
+  depends:
+  - bottleneck >=1.3.4
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - pyreadstat >=1.1.5
+  - zstandard >=0.17.0
+  - pyqt >=5.15.6,<6
+  - qtpy >=2.2.0
+  - gcsfs >=2022.05.0
+  - blosc >=1.21.0
+  - lxml >=4.8.0
+  - odfpy>=1.4.1
+  - xlrd >=2.0.1
+  - jinja2 >=3.1.2
+  - matplotlib-base >=3.6.1
+  - fastparquet >=0.8.1
+  - numba >=0.55.2
+  - pyxlsb >=1.0.9
+  - xarray >=2022.03.0
+  - pyarrow >=7.0.0
+  - s3fs >=2022.05.0
+  - tabulate >=0.8.10
+  - pandas-gbq >=0.17.5
+  - psycopg2 >=2.9.3
+  - openpyxl >=3.0.10
+  - xlsxwriter >=3.0.3
+  - scipy >=1.8.1
+  - dataframe-api-compat >=0.1.7
+  - sqlalchemy >=1.4.36
+  - fsspec >=2022.05.0
+  - beautifulsoup4 >=4.11.1
+  - pymysql >=1.0.2
+  - html5lib >=1.1
+  - pytables >=3.7.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14140649
+  timestamp: 1697477421901
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.3.1-py39h06a4308_0.tar.bz2
+  sha256: a521bbf5ace95000eefefc5b4e6ff599f7607aea6878a5bf61cd58e9232850fc
+  md5: 76e793d8f5634ca4d10cbc6c15a84e65
+  depends:
+  - bleach
+  - bokeh >=3.2.0,<3.4
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.0.0,<3
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.17.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17121173
+  timestamp: 1698867093476
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.0.0-py39h06a4308_0.tar.bz2
+  sha256: 5ee99045a6225d67f275d2b934e0c406aa18e78606933d3e180884e85ab07755
+  md5: e9f0d25cb34c847f93a8269f2b8cc674
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 188223
+  timestamp: 1698263473172
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
+  sha256: db8122fcb6316fb86c2ff6d4dd47154a650ac26d270183a316f14004adf27525
+  md5: 33ad46d04664fc8b65a545110e4fe099
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 764331
+  timestamp: 1696580179855
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+  sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
+  md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2674850
+  timestamp: 1697548887851
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+  sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
+  md5: fe56f0479dd414c846191116366262c3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 31999
+  timestamp: 1692205535111
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+  sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
+  md5: 44d2a857d13bdf9d99aaac039a249d47
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91137
+  timestamp: 1659455142164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+  sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
+  md5: eb899a739d9b58dd747f1f6bd52d4cf3
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 579771
+  timestamp: 1672387338600
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
+  sha256: a760d6c9fca08c09ff0bc9a33946188e2ea5deed2443d4acb360ce55ce36ee43
+  md5: 2cb2ad8315f68f4339b9416bd9ab115e
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353437
+  timestamp: 1656431352923
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+  sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
+  md5: f36ecb722522cbe2e3737424edf1b5e1
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29312
+  timestamp: 1675441510984
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+  sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
+  md5: 6d03295e544251e608a28c8d7c48115e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1862058
+  timestamp: 1684280096752
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+  sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
+  md5: 1f09617aecd6f3c2f2e20692c0759f34
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94434
+  timestamp: 1690223520097
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+  sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
+  md5: ffceed627867508d73af1636ab5ebf42
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 156324
+  timestamp: 1661452578573
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+  sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
+  md5: 0e3341a4fe434167bf74b613eb6afd81
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 97194
+  timestamp: 1636110999719
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+  sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
+  md5: c5f3f7f10ad30f0945e75252615ab6e5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31331
+  timestamp: 1605305847037
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.18-h955ad1f_0.tar.bz2
+  sha256: e9cc8f89dc327997339bedd9961428a13dda3893e3dba46358e73b1fd1ffa37a
+  md5: e99f4c3215771cd11de42d30ac8ada47
+  depends:
+  - ld_impl_linux-64
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 26811973
+  timestamp: 1694440290734
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+  sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
+  md5: 0caa188a695319bdb13f53b0a2b3accc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264864
+  timestamp: 1661371117920
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+  sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
+  md5: bcb44ecbea441ee0d4659133d060d71f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257904
+  timestamp: 1695131670290
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+  sha256: e937081facacb141dc2c9cdcced92baa9a2662e4a56100b6041df0b6b7692570
+  md5: f3ac39b2349258198a9b3316636fe5d5
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39972
+  timestamp: 1685030752528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
+  sha256: 2a535f9fdda20b536bd76dfa286fb67a7685ed2be4ad51e2860c44e144c0b457
+  md5: 797c263fd5bff62987fc1da076eef0f9
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 184040
+  timestamp: 1698096132905
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
+  sha256: 70ee4fc614dd3337ad542c7c961428930160ab8c7da27775faed5ffddbd362d7
+  md5: bf2a4feb20647c569f7ce5a8f63094fa
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 515650
+  timestamp: 1657724431309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+  sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
+  md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 467661
+  timestamp: 1666648052561
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+  sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
+  md5: c7de00b4ac2778c4e5a7816320d75391
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94028
+  timestamp: 1690400356879
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.11.3-py39h5f9d8c6_0.tar.bz2
+  sha256: 8ddacf409396338156d1a09da3f8f0f3b3b473c679bcfefd2de154f7d8f91344
+  md5: 6d6d7ca3d32075d8a57131d589851dd2
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libgfortran-ng
+  - libgfortran5 >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<1.28
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23630389
+  timestamp: 1696544992719
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+  sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
+  md5: 1581cafc84708ed9aafaaee1cbbf6065
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1089416
+  timestamp: 1690290900608
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+  sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
+  md5: e19ffbfb24b990275d24fcea2bd1699b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15702
+  timestamp: 1614030498860
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+  sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
+  md5: ca061ce25c0f58628643abec8d6a8244
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 66330
+  timestamp: 1696347637947
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
+  sha256: 8b45ba506984fe9c061b4acde6f5243d52dda8c1eae4992f8d80c03f425214fe
+  md5: 68c24a824d36a16bbb28d80d70cee8d2
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1640317
+  timestamp: 1681394746811
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+  sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
+  md5: 041a3caf09dc9ce8fc6c10925c4fe050
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1888016
+  timestamp: 1680167274961
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+  sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
+  md5: 0e76eab58fe488e91f0aee73f46de031
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29816
+  timestamp: 1671751864131
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+  sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
+  md5: b413a210eca82fe867e991eed085201b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38882
+  timestamp: 1668168876032
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+  sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
+  md5: 5b8375e2092012db69d2123dc0c68630
+  depends:
+  - libgcc-ng >=7.5.0
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3485432
+  timestamp: 1654088939579
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
+  sha256: bd06f7b49d9c04c51c1e825bab446ec3cdde2bce39af00bf113a05c1009595e2
+  md5: 587c3f3c891901f4305653e50c18d6c0
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 679739
+  timestamp: 1696937022519
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+  sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
+  md5: 67a8320961ff24e92eebb661536e5cf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - requests
+  - slack-sdk
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 123763
+  timestamp: 1679561904852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+  sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
+  md5: 0f0b91a158dd3692cbb7a7763b657bfe
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192032
+  timestamp: 1671143995098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
+  md5: 8515e64a3de7581360d713fe4c0a094e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8789
+  timestamp: 1690297588156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
+  md5: 60170012374b2a5007842fa5870d78c5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57479
+  timestamp: 1690297581658
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py39h06a4308_0.tar.bz2
+  sha256: bdafa637d91ee2986a37cc82eb18c7b9b6e467eddd2eac3f510ad878a5b45da2
+  md5: 89e6a047e97aa6b06c8a217e64182646
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 10729
+  timestamp: 1659769510353
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
+  sha256: 2f4a5979aaf22660fe9fb8c4ffd41e5a9dc012e20f78e1dbf4ad9c67e0fd28be
+  md5: 0be10051dd3d6f31ba52b7c08ba3ba0a
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 187469
+  timestamp: 1698257600264
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+  sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
+  md5: f8d03a15b974fc7810d9f54ae849fc8e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20781
+  timestamp: 1607365390528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+  sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
+  md5: d7db5d6ce1db80eade8a082ff78bf479
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 71044
+  timestamp: 1614804011510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+  sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
+  md5: b3899f8bda32734727bd5a73df1d7d17
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 101520
+  timestamp: 1695742037911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py39h06a4308_1.tar.bz2
+  sha256: 8e8d728472d26c1a42345003d69bf381c062db8050d3444a6ccced7e5dcc3524
+  md5: dd9bda05830964c550a69b70178ee6f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48001
+  timestamp: 1675159114742
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
+  sha256: 93ca87e697bb9e045fc9cda13b05fe27e1a99f3ed143b75bbcaf4dcb745aa06f
+  md5: 3eebbb22c5ca63987db36e1f19cbe872
+  depends:
+  - libgcc-ng >=11.2.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 763941
+  timestamp: 1683112966413
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+  sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
+  md5: 567b68192c387b5fc88178425577a0fe
+  depends:
+  - libgcc-ng >=7.3.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=7.3.0
+  license: LGPL-3.0-or-later
+  size: 366479
+  timestamp: 1616055552392
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+  sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
+  md5: 3818a9531fe74433c3b7d5144c9a58cc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18021
+  timestamp: 1672387231268
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
+  sha256: 2dc9150a95704d83efd39bb9dfb44bdf8419022f4fb0fc416380a922a27c130d
+  md5: 4f315d7551f4bbeb06b6fc28342a9aa5
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Zlib
+  license_family: Other
+  size: 127528
+  timestamp: 1666595012798
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
+  sha256: aa6aa291bec6aa66e1f063cfa75a9e0fc6bd459fcb45c372aacac9006a073900
+  md5: 4e99328768f538f33aecebdae9472744
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1055426
+  timestamp: 1681304602537
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
+  md5: b2aa5503875aba2f1d88cae9df9a96d5
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13636
+  timestamp: 1611930018941
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
+  md5: 544adf2677c47c9b9c891aea720678f1
+  depends:
+  - python >=3.5
+  license: MIT
+  size: 33999
+  timestamp: 1630003259346
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+  sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
+  md5: 9eff1a842dbda8d1bae9a2c008b599bc
+  depends:
+  - brotli >=1.0.1
+  - munkres
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 690443
+  timestamp: 1625743217109
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+  sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
+  md5: 33624a42ee387bf9918ea98b4e7b31fc
+  depends:
+  - pygments >=2.4.1,<3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8173
+  timestamp: 1601490751973
+- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+  sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
+  md5: 67857cc5e9044770d2b15f9d94a4521d
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12810
+  timestamp: 1600445183315
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+  sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
+  md5: e68a6f315f41a8d814d833652bf38b9b
+  depends:
+  - python >=3
+  license: MIT
+  size: 13374
+  timestamp: 1606932077143
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
+  md5: 2eb923cc014094f4acf7f849d67d73f8
+  depends:
+  - python
+  - six >=1.5
+  license: BSD-3-Clause and Apache
+  license_family: BSD
+  size: 246457
+  timestamp: 1626374695070
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
+  md5: 41db68b96e114e367c4f120a3b379e59
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19391
+  timestamp: 1632406728844
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+  sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
+  md5: a815d3bdb160bcc71687f2dda70d3ca4
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 122218
+  timestamp: 1680170368293
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
+  md5: 447a49f7bad119faa80d7f14aa296c95
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162176
+  timestamp: 1644481750133
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+  sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
+  md5: 8810f48fe4a4792de0fd3520b502d08b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10019
+  timestamp: 1606859473259
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+  sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
+  md5: 00a446b6dfc61af223df4de29fe8ad94
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 34305
+  timestamp: 1644569782044
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
+  md5: bd92dd8bd5b9d24e632b62a075426e50
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133634
+  timestamp: 1695718025321
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+  sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
+  md5: f8ae051b591a9027adc16de1be9748f4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206198
+  timestamp: 1681493096349
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
+  sha256: 2936241747f6cc0f0b3afa53bb28ad6f658b53a0fc2e67a5ed34d1d5e2cce117
+  md5: bdca1b691340964271d9cfec6baaf8d0
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5719952
+  timestamp: 1697490515691
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+  sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
+  md5: 0d79760d544d0bd8acb4adc4ef813418
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 137075
+  timestamp: 1657175654487
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
+  md5: 31d6d04cd2388d8f19004501271b3545
+  depends:
+  - brotli-bin 1.0.9 hca72f7f_7
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18982
+  timestamp: 1659616229395
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
+  md5: caf1073dc2ca5aeb832a2877394eae12
+  depends:
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18233
+  timestamp: 1659616216769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+  sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
+  md5: aa1ed20c38af535c8d6a955314759d7b
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 394588
+  timestamp: 1659616312678
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+  sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
+  md5: ce3588e31faa79f546e0fc6a36c5543c
+  license: MPL-2.0
+  license_family: Other
+  size: 133884
+  timestamp: 1694009771475
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+  sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
+  md5: 21eb7f53076d0a69513cfd258f6ef63c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159756
+  timestamp: 1690232346868
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+  sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
+  md5: a40a04d9cda1e665565bc6c832d598b6
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225258
+  timestamp: 1670423337502
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+  sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
+  md5: b2cc5f37f7bb069d061306e7eac2a011
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1913396
+  timestamp: 1668084575248
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
+  md5: 103d8c039e342115720a84d59c119d46
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13774
+  timestamp: 1671231190250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+  sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
+  md5: f69f09e0346172f225390d2b3b0d7873
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 246628
+  timestamp: 1663827484947
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+  sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
+  md5: cb80c7ac65b48a737654f371fe31c460
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1307228
+  timestamp: 1694212041712
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+  sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
+  md5: 04cbe8f4bc62c34fac9d42d1124059bf
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2052734
+  timestamp: 1690905361158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
+  md5: ef0e825982f242085574f502dfff4f6b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16594
+  timestamp: 1649926538106
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
+  md5: 24747a300246c016b3a7f04dabd02d4a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27709
+  timestamp: 1668714497209
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+  sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
+  md5: e4a732941f74b8062c8bcbfe5c5c2b56
+  license: MIT
+  license_family: MIT
+  size: 80252
+  timestamp: 1676983220161
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+  sha256: 5c36d43cadbbf944d9255e79df85c2e9e6155a1d6f9158e06fcd8ffd458b7663
+  md5: a5a2cff387403ccf9cf58aac7a6dde55
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4573879
+  timestamp: 1698866750755
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.9.0-py39hecd8cb5_0.tar.bz2
+  sha256: 80f22084b7a306946e7bc7756d289703255d3760ff7c23f9b6193bf294feac10
+  md5: a6e68eab5b8d73a9048c89189f2a9f21
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.9.0,<3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3339771
+  timestamp: 1697559946138
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+  sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
+  md5: f3ce6fe6eb760c236e5f7d04df5faa81
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28138484
+  timestamp: 1692293212596
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+  sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
+  md5: 6dd72c43fea25b748ec7a9f6c0407e15
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111810
+  timestamp: 1666125671024
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
+  md5: 03cdb7e679924b329ecab8f12cb8fc67
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38813
+  timestamp: 1678997212422
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
+  md5: e113c4e6e758dd68faf196586bf5564d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51873
+  timestamp: 1698254765815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+  sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
+  md5: 78baea934985ccd9514a366cc7e80ed4
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 727499
+  timestamp: 1681801225190
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+  sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
+  md5: da9b63e42f281f7e77b289f4b654b83b
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 218436
+  timestamp: 1691121840155
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+  sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
+  md5: 6a7cb9b49593b29933fa2b503d533a08
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1257205
+  timestamp: 1694181720454
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+  sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
+  md5: d861ef66f5c0a282d60b65778a9de2f3
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1048450
+  timestamp: 1644315332508
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
+  md5: f7e603c965052deed8b789c35855a42f
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213537
+  timestamp: 1666908270815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
+  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
+  license: IJG
+  license_family: Other
+  size: 278924
+  timestamp: 1677849185191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+  sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
+  md5: a82a17e78f725dcbd71ff8dac6db05c7
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133134
+  timestamp: 1676558895333
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+  sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
+  md5: ee9270379a9ebdb6297e4b6849b3f7f0
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 195479
+  timestamp: 1676329410154
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 32b898a97dca7770858ab31294238fde11ab61a84831a52f320e5ee5405a147c
+  md5: 926e754b8fad288b583ef2933deae1a5
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92938
+  timestamp: 1679906616072
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+  sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
+  md5: 7e60995b3119417213e5faedda147499
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 403165
+  timestamp: 1671707664990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+  sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
+  md5: cd470bdb28bb0e8b3535c93a3a6dad07
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65431
+  timestamp: 1672387389172
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
+  md5: 7dba7aa5b971febb55281659843586ba
+  license: MIT
+  size: 65470
+  timestamp: 1659616172703
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
+  md5: f78a158983f0bbaba56f34b976bc6dae
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 34189
+  timestamp: 1659616189313
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
+  md5: 36a1d885725d3ab4d1fadc5a29f978d2
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 327737
+  timestamp: 1659616202869
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+  sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
+  md5: 817848d0e2b2808acdc9b3fbbf581726
+  license: MIT
+  license_family: MIT
+  size: 133887
+  timestamp: 1683716590737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+  sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
+  md5: e458587c87e3f2d20192f4e0738f2c63
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 149419
+  timestamp: 1665498987619
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+  sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
+  md5: 1058b661ec829b2ee3716ee2a5520641
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1917987
+  timestamp: 1665498925405
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+  sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
+  md5: c90372428e1e4eed4fdcd790979d06b4
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1409377
+  timestamp: 1650983531933
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+  sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
+  md5: c0b99f8e1c7475f23b1c7b4250b06e1c
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88021
+  timestamp: 1694778290062
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+  sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
+  md5: 06866415ef22d5322f9bdc9956b59c4d
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 678174
+  timestamp: 1692970318885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+  sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
+  md5: 2edc6c894d6d0321304396e9bd40df94
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241774
+  timestamp: 1692973618934
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 0190d3b8d2939f28aa017711cf4147c51a1139da2922cc8420a71562dd99f844
+  md5: 454a7f2c4426453f17e995382a4235e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 36036
+  timestamp: 1659783508187
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+  sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
+  md5: 5c740b4a18a558de0ccfe601703c423c
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 338738
+  timestamp: 1662635677689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+  sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
+  md5: 8bbd981ca0129d7beeacd3cd7623f714
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1491074
+  timestamp: 1695058597986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+  sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
+  md5: d5f58d056b4bfc67aec30c77035ba889
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 182491
+  timestamp: 1670944720979
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+  sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
+  md5: 1affd16b166571a91feae04baf5fd3da
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123431
+  timestamp: 1671542016019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+  sha256: e5fc51472fa0f36abd78baa5b3c9245d6627b0da11188e6a954d73f3f2bca210
+  md5: df7c519447affffb594f8c56b028ed33
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 107035
+  timestamp: 1684279974102
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+  sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
+  md5: 3681ebf029211ceab26af6f5d35abf39
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22254
+  timestamp: 1654598220251
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+  sha256: 2fd179efa024c92d0d71179a981a781d16c70f5d8c6305e0d678b0c7ae1275ab
+  md5: addda7f015d1673f794a23fdb18a3e09
+  depends:
+  - __osx >=10.12
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8182219
+  timestamp: 1698692361219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+  sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
+  md5: 6eb64ecfcd754502e271db0bb51d2cfd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17374
+  timestamp: 1662014643620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 2312ee5a6343e8495802698d7181f1b619aad7479d96ee253407b324ac884417
+  md5: 866960fa48a7ca335941786d4869802a
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53542
+  timestamp: 1659721365599
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: 37f455814ce242eb65ff80a0402f1bd231a388e6823e6c1e65f60b705c032a2d
+  md5: 4c9246c492a64729225aa5b04e12c2d1
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19573
+  timestamp: 1659716100178
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+  sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
+  md5: 2a4d604717a647ad21af766289cbbfc3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58057
+  timestamp: 1607364912348
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+  sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
+  md5: 25051fe272624544652dc6d814c2943a
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224420228
+  timestamp: 1691503125614
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+  sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
+  md5: 37d8cf85a63f7aa9af1624894a7d606d
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48590
+  timestamp: 1682969183093
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+  sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
+  md5: 0b2aee6666135bbd36b46d6ac66160f7
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 210705
+  timestamp: 1695058433223
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+  sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
+  md5: e22fb55ce380d0ebd44cce3f20d5349e
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296614
+  timestamp: 1695060155673
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+  sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
+  md5: 1a5d4004e64e3cfb7a2a297b9117c285
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8213832
+  timestamp: 1681756573646
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+  sha256: 2975bd1f98ca9ec7354ee378f86f8322ec90f568374776fd90e80c534fbee882
+  md5: 798627089e0ccba26695a26d9cb127ec
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99066
+  timestamp: 1650308465824
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+  sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
+  md5: e572c1264a7af20b486f64ac8c9e1f57
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 573356
+  timestamp: 1668450732828
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+  sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
+  md5: b67569a7c30af9ffa5cde6e4b52ac68b
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148342
+  timestamp: 1694616917184
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+  sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
+  md5: 97b81f34efbe86c5220fe82eb584fd62
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387288528
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+  sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
+  md5: d77862975a9a1cf50acb803be26e83a1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 575365
+  timestamp: 1690985052739
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+  sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
+  md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22858
+  timestamp: 1668160618784
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+  sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
+  md5: 185e9c41abb88ee59b52ec0f5f65d506
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 138305
+  timestamp: 1696515469702
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+  sha256: 82a2dd0c2ff6e20a275e5447dd03088f79694f7bfa5055a25c54bebf31aac4ca
+  md5: c157e6ab469a95b06fa822ba075978b3
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.0 py39ha186be2_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10376
+  timestamp: 1695831243158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+  sha256: b3a003b41cec2751210e542911e99437db0321542f6812c1b88608ef720ba7ef
+  md5: 56400dfe88c427cdf1854e47666b8a99
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.26.0 py39h827a554_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7570900
+  timestamp: 1695831208653
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
+  md5: 93f5d7b66976154adeda219bea02ba45
+  depends:
+  - libcxx >=10.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 484257
+  timestamp: 1630093862501
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+  sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
+  md5: 5e8713ef1215406254988163eaf34020
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4965606
+  timestamp: 1695323060401
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+  sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
+  md5: 4154929ace2ad6ee16aea815635a6d1f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73598
+  timestamp: 1693575307570
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+  sha256: aff5acedef9da91b77851e1a163b8319d72bc4152c98ac87703a2eac1e5d575b
+  md5: 7df4c76aa8c52fedce5346748d56459e
+  depends:
+  - bottleneck >=1.3.4
+  - libcxx >=14.0.6
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - tabulate >=0.8.10
+  - blosc >=1.21.0
+  - fsspec >=2022.05.0
+  - beautifulsoup4 >=4.11.1
+  - pyreadstat >=1.1.5
+  - pyqt >=5.15.6,<6
+  - s3fs >=2022.05.0
+  - numba >=0.55.2
+  - xlrd >=2.0.1
+  - qtpy >=2.2.0
+  - xarray >=2022.03.0
+  - psycopg2 >=2.9.3
+  - lxml >=4.8.0
+  - zstandard >=0.17.0
+  - pyarrow >=7.0.0
+  - pytables >=3.7.0
+  - xlsxwriter >=3.0.3
+  - gcsfs >=2022.05.0
+  - fastparquet >=0.8.1
+  - scipy >=1.8.1
+  - pymysql >=1.0.2
+  - odfpy>=1.4.1
+  - pandas-gbq >=0.17.5
+  - pyxlsb >=1.0.9
+  - matplotlib-base >=3.6.1
+  - openpyxl >=3.0.10
+  - jinja2 >=3.1.2
+  - html5lib >=1.1
+  - dataframe-api-compat >=0.1.7
+  - sqlalchemy >=1.4.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13388063
+  timestamp: 1697477404222
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
+  sha256: 42d83288119306089a06e853a37045fbb9860548b05a1e79d223f7ecf1cb349d
+  md5: 8daced11264159ff57df7bba4d0b2ec7
+  depends:
+  - bleach
+  - bokeh >=3.2.0,<3.4
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.0.0,<3
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.17.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17075803
+  timestamp: 1698867397009
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: ad7ca92e5c83a8e2181677025509ed7b8f566ec23b24f28316fa087bb591c11f
+  md5: a4ccd0fbcfb26de868f2fb4836940d7a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189263
+  timestamp: 1698263570990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+  sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
+  md5: be0a90921f3bf4f0d6950fb786093de7
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND
+  license_family: Other
+  size: 719901
+  timestamp: 1696580194417
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+  sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
+  md5: 81ae9ec2d7fcf6934847bff558b619f5
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2672987
+  timestamp: 1697548890181
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+  sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
+  md5: 1a822c206e2abddc5d6d821721af227f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33013
+  timestamp: 1692205801265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+  sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
+  md5: 1604d33dbdb2446c642970f8b354bedb
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91266
+  timestamp: 1659455269141
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+  sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
+  md5: d1b3bcc35655a3123acb1fa2ad1a8511
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580828
+  timestamp: 1672387372015
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+  sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
+  md5: 7540555d1fb192236db9a7c5c9d3601c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365765
+  timestamp: 1656431373327
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
+  md5: 0a73533fb6e0dc717ab906a537bc747d
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30803
+  timestamp: 1675441638631
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+  sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
+  md5: 0a959fbad46ab38ade48dbd358002674
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1864757
+  timestamp: 1684280094736
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+  sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
+  md5: ea24b5076ef79e4567c5a3f0cb22b470
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95330
+  timestamp: 1690223465114
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+  sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
+  md5: bcaea6d4a47e9c874becaa700c78dcf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157216
+  timestamp: 1661452617825
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+  sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
+  md5: 707110d1b49cb1864acb0bbaa103591e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 95016
+  timestamp: 1636111184034
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
+  md5: 113a443b9c706f9f9c6187c0eaa3de27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31178
+  timestamp: 1605305861851
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+  sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
+  md5: 85a8d0001db70e52a479155228cb1fe0
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13324979
+  timestamp: 1694439878265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+  sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
+  md5: 47c5e22e31ec05a7bc0ce90065a53afd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 265348
+  timestamp: 1661368839620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+  sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
+  md5: ce9a69e1668aa1e133f2aa6d4e8d346f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 254958
+  timestamp: 1695131709704
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 9ee098c09f31fad7ff1856e5ce2619172eaf979997e7a427d1e05cce32c2af00
+  md5: cac1d1898b69ae9646dfbf082910635d
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40946
+  timestamp: 1685030787453
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+  sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
+  md5: 637f08b19dd8fd87347d8c44f9e3e202
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 170776
+  timestamp: 1698096100056
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+  sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
+  md5: 8ce3ac7d8a04e469b566f1b090d01140
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 470617
+  timestamp: 1657724324011
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
+  md5: 6f2d41dd76a03b7f85a1ed49af1763d6
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95100
+  timestamp: 1690400262627
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+  sha256: a9755ecbfd42c708945027facfa11a3dc3119778326a0ae5df79f80d7b72afa5
+  md5: 839ffa4e775fee9a8bdddabf4a14da43
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<1.28
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24331914
+  timestamp: 1696545397632
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
+  md5: b0321e6f14e139fc15b1f8b4acb35d2f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093966
+  timestamp: 1690290944588
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+  sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
+  md5: 62b64576a0aa5f6c3fb05f56650d25e1
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15535
+  timestamp: 1614030509324
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+  sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
+  md5: 15b5595b31e39f08eaacbe2e502d8fb3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67292
+  timestamp: 1696347733587
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+  sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
+  md5: 82e4db6a498480a75d53c55bd35b6478
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1801397
+  timestamp: 1681394807900
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+  sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
+  md5: 63b957927b9949ccb19da28ec4612706
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30902
+  timestamp: 1671751919031
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+  sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
+  md5: e346257a2fa8e2cb48c762138a5d009b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39915
+  timestamp: 1668168959656
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+  sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
+  md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
+  depends:
+  - zlib >=1.2.12,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3536231
+  timestamp: 1654088937695
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+  sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
+  md5: a1bbf0abfb8c45541122c0eb2feee317
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680464
+  timestamp: 1696937112175
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+  sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
+  md5: d689f6203c0a9d04fb229c73d7e80a7a
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125145
+  timestamp: 1679561909274
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
+  md5: 8a292c1ee22489bef2e84bc3aaf4098e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193141
+  timestamp: 1671143985219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
+  md5: 8bf0bfffc11ad06a1c94e145941b0ad4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9651
+  timestamp: 1690297655669
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
+  md5: 343514a174b3485fde55a73f56398dd7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58456
+  timestamp: 1690297648002
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+  sha256: 11e7401cb6805db7ce22b1f9dd6ba5b7941c92225ce440bed1da0af284bfcad4
+  md5: 5c10d68fa5616cdd82ee93ef6e0f038c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11615
+  timestamp: 1659769478980
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+  sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
+  md5: c2242e8fd24003a74ddf37416661e06d
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188757
+  timestamp: 1698257668273
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+  sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
+  md5: 41f445e36b6b6722a9444508eef069f8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20583
+  timestamp: 1607365395045
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+  sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
+  md5: 409ee46ed24267b6da6fb32d13e1f21e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70730
+  timestamp: 1614804271285
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+  sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
+  md5: eb74e74d8e4fd533c55eb98b7b5e83bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102637
+  timestamp: 1695742077778
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+  sha256: cb007615819fd240ea4e343835dfbda3c508a92b5b7158219d30a22d0e67b57c
+  md5: bf215e781ac81e0fc433eedee330c54b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49462
+  timestamp: 1675159191191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+  sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
+  md5: e243baa546432c8394a8059a44a5a3e4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 419227
+  timestamp: 1683113010463
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+  sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
+  md5: fe4ac85ee86d3a94ea3a4ebea3779763
+  depends:
+  - libcxx >=10.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 321797
+  timestamp: 1616055526986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
+  md5: bc7073d9d4c0211cc4a1207c98fb765a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19091
+  timestamp: 1672387204865
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+  sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
+  md5: 8e495591e369ac161857a72011c0a296
+  license: Zlib
+  license_family: Other
+  size: 120272
+  timestamp: 1666595024203
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+  sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
+  md5: f1465fbd810b3746c6de6babfd4fe28a
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1023573
+  timestamp: 1681304595869
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+  sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
+  md5: cf55cb8d7031b30c70c56fc7c782b5c7
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 156104
+  timestamp: 1644482799136
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+  sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
+  md5: 84fce327d9f0d594e86f565e5c21962e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10183
+  timestamp: 1629146082730
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+  sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
+  md5: 84b8b998a741b37abf5312c1c03696ef
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33979
+  timestamp: 1644845817952
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+  sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
+  md5: 77b746931c8f31c3ae393ccb5819d43d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133628
+  timestamp: 1695717890677
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+  sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
+  md5: 3df6e8ba34208dea068890e5d5318cc0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206759
+  timestamp: 1681493095987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
+  sha256: 8c31e7ede4b9a3ec6e1342f02bcff4d7113e5b25f12b91d108616a08eb8eb34f
+  md5: de3ce22af040eb01db773fcab23ef413
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5722206
+  timestamp: 1697490482051
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+  sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
+  md5: bb55f81435cb6e11d264242274fccd1a
+  depends:
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 115947
+  timestamp: 1657175645380
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
+  md5: f860193e14afc7ef3f5b990a2ac003d2
+  depends:
+  - brotli-bin 1.0.9 h1a28f6b_7
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18936
+  timestamp: 1659616204016
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
+  md5: ad53130f3fd1f8d3c2fcbb7496e5585d
+  depends:
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18715
+  timestamp: 1659616188888
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+  sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
+  md5: 0982c046fb976e9f9fb19e7510187a18
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 366983
+  timestamp: 1659616245272
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+  sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
+  md5: 31ac2f5596cb7a44adf073c930641c54
+  license: MPL-2.0
+  license_family: Other
+  size: 133817
+  timestamp: 1694009762858
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+  sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
+  md5: cf1f6c3c34a1e1b9ab22b04233d860f6
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159783
+  timestamp: 1690232303987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+  sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
+  md5: 0eb268e38b5174d471a6e87d9d6102b1
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225355
+  timestamp: 1670423312966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+  sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
+  md5: e68c94666cd60221b575c3814c89bac0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1946451
+  timestamp: 1668084573824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+  sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
+  md5: 1773ae2b080cdd55827e27673351551e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13646
+  timestamp: 1671231171682
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+  sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
+  md5: 53bfd99ad1b09164d537209cffd98161
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 244040
+  timestamp: 1663827469853
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+  sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
+  md5: b62455043c8eb2434466885b19fed2de
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1399573
+  timestamp: 1694211828228
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+  sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
+  md5: eb3cdc0fc210838b9271512a6a1b7c85
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2067708
+  timestamp: 1690905319109
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+  sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
+  md5: f44b80b9405410e5bde6bfe0b31d5b3f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 15135
+  timestamp: 1650293774207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+  sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
+  md5: f87027ccce1361d0f82c0edf1a10d53b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27677
+  timestamp: 1668714367519
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+  sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
+  md5: 1d0bd7e576c64c059ef781dd319ad82a
+  license: MIT
+  license_family: MIT
+  size: 77591
+  timestamp: 1676983230102
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+  sha256: 3e480af22e98246c056bbd91d6be5352df34ff2b8451d9c7f614baeafb450d39
+  md5: 695fe7ccaf6935d3117533d1e6737320
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4542265
+  timestamp: 1698866834303
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.9.0-py39hca03da5_0.tar.bz2
+  sha256: 519ed44b20355e914a87c6e6ecfcc6ac47b088b52223d64a052f73d98d5464a9
+  md5: 792b62dde64917556bdc4ba7b822c7ae
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.9.0,<3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3339433
+  timestamp: 1697560078781
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+  sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
+  md5: 69eb3b03765627b6159ed23cdde78396
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28399065
+  timestamp: 1692293207812
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+  sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
+  md5: 83366cbd3beb073112f4644a613b6bca
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111933
+  timestamp: 1666125627512
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+  sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
+  md5: 647c1a2f8460ffa8c670a1915bbdb494
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38790
+  timestamp: 1678997152549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+  sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
+  md5: 35e541905426c686ef2ff010a0e502fd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51860
+  timestamp: 1698254731870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+  sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
+  md5: 187d7720aedf38759d122cccb4576f2c
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 219976
+  timestamp: 1691121991680
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+  sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
+  md5: e8e7f10741f9cfa737b310b334940441
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1255894
+  timestamp: 1694181494549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+  sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
+  md5: ff209e75aee17af2e358b0008fbe8c88
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1022945
+  timestamp: 1644315931223
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+  sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
+  md5: d3e78ef296b3c74910d003bd10b475d6
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213972
+  timestamp: 1666908195870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
+  md5: 055e12390b844ea6c6e956ee08a618e8
+  license: IJG
+  license_family: Other
+  size: 273479
+  timestamp: 1677849171867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+  sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
+  md5: 783e2ad3d36472648c5ccc9f3051db3c
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133077
+  timestamp: 1676558732505
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+  sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
+  md5: 0677598f673f9729b5990316170a999d
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 197129
+  timestamp: 1676329661580
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+  sha256: 05f9ca0fdcfdc2e217438be27fead588c843a3aadf7d034467c83216d1e5c214
+  md5: 2d648b77d817ba38293c0728711ba8f5
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92852
+  timestamp: 1679906632236
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+  sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
+  md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 401319
+  timestamp: 1671707682572
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+  sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
+  md5: 247558a0aecf1ef7e77a4343761353d6
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64600
+  timestamp: 1672387273585
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
+  md5: a0f206782751dfffed0dd51302a1bf26
+  license: MIT
+  size: 68012
+  timestamp: 1659616138077
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
+  md5: 4c6667cdd061d28e9bc4e4300e4d115e
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 31173
+  timestamp: 1659616155596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
+  md5: 637e9430e258ddf050623ef2360184d8
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 298430
+  timestamp: 1659616172209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+  sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
+  md5: 55c615026c0869f8d3ba657f3bd38c43
+  license: MIT
+  license_family: MIT
+  size: 120389
+  timestamp: 1683716579036
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+  sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
+  md5: a41117710dafe569c9cc4e83f6f29fe3
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1411339
+  timestamp: 1650982753977
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+  sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
+  md5: 98d22e0124d55fae3c37c608dab1dcc9
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 89825
+  timestamp: 1694778225280
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+  sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
+  md5: 0ba499df6755eae5d2d23aa4ab004553
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 642657
+  timestamp: 1692970217410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+  sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
+  md5: c73101971e5ab6a8e8688239884eac81
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241607
+  timestamp: 1692973585084
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+  sha256: ac50f846e93e68d50bfdd5589ea8272b987243a64eba8e2e358ef311d7734001
+  md5: f19270ff954a41dabbfe36ff0656935b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 36040
+  timestamp: 1659783399073
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+  sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
+  md5: 353dff9d5d996c2a260f66381b2ce3e8
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1470815
+  timestamp: 1695058433965
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+  sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
+  md5: c99006da802a97c9aae30da8c16b4820
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176131
+  timestamp: 1670944706815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+  sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
+  md5: 60bd1e037cda86205526f77405d78129
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123361
+  timestamp: 1671541992772
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+  sha256: 2fd690fa3c54a40f0426874ea12e12aad2718263a75708ddd1fa6052a4ad7fb3
+  md5: 81388724babfe9c32ea5cdd93633c342
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 107072
+  timestamp: 1684280007887
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+  sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
+  md5: 34dfd76da78de2eae95bbda390d746d6
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23092
+  timestamp: 1654598007056
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+  sha256: bf0eeef3c3c713515766ab8b0dc7863413de5b4b227deede97e24d90ca342345
+  md5: a7bba1857eb84fb50caea377e60d2050
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8066509
+  timestamp: 1698692266161
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+  sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
+  md5: eb79dabbeedee7da85dfbfb145bb8a26
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17342
+  timestamp: 1662014601345
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+  sha256: f400ad75dd2890627dc948f3e2e6b19732d02c124723eaf22272026993a94d52
+  md5: 4a4ffc7365e30b18f4443281839e2718
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53505
+  timestamp: 1659721313693
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+  sha256: 20fb26a7ac748ce288cf8483a837b0c33f1348ae738bcdb69cdc2763c7bbf7e1
+  md5: a0aebbc6c170ebd8d4710fd70b3db503
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19562
+  timestamp: 1659716131839
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+  sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
+  md5: 56db7bd3ff511cd839bda081523b3edd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 55683
+  timestamp: 1629356128780
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+  sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
+  md5: 176e0dcaeb28393881bacf69941e3889
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8289638
+  timestamp: 1681756329011
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+  sha256: afc6f332c51a3defc69e4c4e641988c0556039b9cd42be22f3db5292c88ccf37
+  md5: 2bc409c7258160a9b739d08d5ffb5998
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 96942
+  timestamp: 1650373637069
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+  sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
+  md5: 150ea9fadddf21993d3328d3e48a18b7
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 557688
+  timestamp: 1668450759059
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+  sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
+  md5: 37163b32508f9f589b3e6462a3a47546
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148426
+  timestamp: 1694616771736
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+  sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
+  md5: 6cdf7cbc43bf40e92b056a5576bd0086
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387216468
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+  sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
+  md5: 0f05853a139b6cda9c73e9d2707a4976
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 590288
+  timestamp: 1690984971741
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+  sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
+  md5: 7de782e4fb34bfa95ef2fc79d27d727d
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22840
+  timestamp: 1668160634885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+  sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
+  md5: 1a7b23113372c5667dbfe45976b9cc5c
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 126357
+  timestamp: 1696515322390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+  sha256: 3cd1161558704176560843586b1b1f9b257fd68c0ca53a2fc09e61267f47514c
+  md5: dd162b2716dc9daf732240a343862d4a
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.26.0 py39ha9811e2_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10388
+  timestamp: 1695830584640
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+  sha256: 5f35d8c0e1768fa3a9d2e75659cd2096bea6b4e021afea114f573e95f4943fb2
+  md5: 958f78b1e2299537996f98da7a930198
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.26.0 py39h3b2db8e_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6313331
+  timestamp: 1695830570878
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
+  md5: 371358a54bbdd307603888348d1a2c6f
+  depends:
+  - libcxx >=12.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD 2-Clause
+  size: 412248
+  timestamp: 1628861367714
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+  sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
+  md5: fa15d3b44ae1360ac9b640bbd5b6923c
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4746123
+  timestamp: 1695322833432
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+  sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
+  md5: d73db95f07a282021efdf8bc09713261
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73620
+  timestamp: 1693575195999
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+  sha256: 247b5e4d81b6d5d013a9c27e1f30c41fff896fed98a68ebda26b19b4062a6828
+  md5: 354a1d65300b4309d53dfa648014e8fe
+  depends:
+  - bottleneck >=1.3.4
+  - libcxx >=14.0.6
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - lxml >=4.8.0
+  - matplotlib-base >=3.6.1
+  - tabulate >=0.8.10
+  - pyqt >=5.15.6,<6
+  - openpyxl >=3.0.10
+  - s3fs >=2022.05.0
+  - pymysql >=1.0.2
+  - beautifulsoup4 >=4.11.1
+  - scipy >=1.8.1
+  - xlsxwriter >=3.0.3
+  - fastparquet >=0.8.1
+  - xlrd >=2.0.1
+  - blosc >=1.21.0
+  - zstandard >=0.17.0
+  - psycopg2 >=2.9.3
+  - pyarrow >=7.0.0
+  - pandas-gbq >=0.17.5
+  - pytables >=3.7.0
+  - sqlalchemy >=1.4.36
+  - odfpy>=1.4.1
+  - numba >=0.55.2
+  - jinja2 >=3.1.2
+  - pyreadstat >=1.1.5
+  - gcsfs >=2022.05.0
+  - qtpy >=2.2.0
+  - html5lib >=1.1
+  - xarray >=2022.03.0
+  - fsspec >=2022.05.0
+  - dataframe-api-compat >=0.1.7
+  - pyxlsb >=1.0.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13257999
+  timestamp: 1697478739906
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
+  sha256: 90a1889cd0004bfc5e12ac94b4ea92718a473373033bb0ba5259804ed67bf2bc
+  md5: e89f615737385fee88150ab4adf037e6
+  depends:
+  - bleach
+  - bokeh >=3.2.0,<3.4
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.0.0,<3
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.17.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17147015
+  timestamp: 1698866800249
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
+  sha256: 0ae09c974297767a707642344c40f484281f0a3000251a6234e46ef19f00c10e
+  md5: 64a0eaf3381e9f6aa971229501710798
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189313
+  timestamp: 1698263486159
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+  sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
+  md5: 6e01c592ae3b8ff2d12cae76f2f4276b
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 715239
+  timestamp: 1696580071596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+  sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
+  md5: 9fb8f460c130d56caf33c6bbe46fbe8a
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2678841
+  timestamp: 1697548790931
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+  sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
+  md5: 390b8c3cd74281abecdbfd51476922f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33033
+  timestamp: 1692205747301
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+  sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
+  md5: 7896828fb3565fefad43f980d50c8723
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91190
+  timestamp: 1659455206354
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+  sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
+  md5: d934c74eb66d01af0f45f0881f4bab77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580588
+  timestamp: 1672387390426
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+  sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
+  md5: 9858166e5ffb624c8b9d281f4000d725
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 367167
+  timestamp: 1656431368885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+  sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
+  md5: 4d2b45c6be8221e6a3e44c2d5838426f
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30843
+  timestamp: 1675441531640
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+  sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
+  md5: 02521df4e2e79f75faa9cbb3560ab1dd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1861763
+  timestamp: 1684280026169
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+  sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
+  md5: bdebe59bffc7adbad83fdcd9d429a5f5
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95234
+  timestamp: 1690223494699
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+  sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
+  md5: d716e5c9b5eec45ce1df8eb52cab817a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157408
+  timestamp: 1661452601692
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+  sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
+  md5: 1907629863ed8e7c35ead232dae7693f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 91636
+  timestamp: 1628941083263
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+  sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
+  md5: 847b9bddf2a86e1609c0d53bbc23ea79
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 27378
+  timestamp: 1626781391140
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+  sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
+  md5: 18aa18bd0d260605923877921d26cc74
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13194025
+  timestamp: 1694438901368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+  sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
+  md5: 45642a99c83e7aed74d1ffab1f20145b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 266647
+  timestamp: 1661368655993
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+  sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
+  md5: fec748525144049a2fc7f52f9755232c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257235
+  timestamp: 1695131702047
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+  sha256: 960192a143672e9c1d6fe4027af448512d91eee7501e5c245c21b865cf8bf429
+  md5: 76d491244218505f071ba56a308673df
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40950
+  timestamp: 1685030774581
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+  sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
+  md5: 3445d25415998c807efbe64d3a7e03c8
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 167068
+  timestamp: 1698096118071
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+  sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
+  md5: e6e92da28e9b0e428ed4b7df417bec25
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 472418
+  timestamp: 1657724315435
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+  sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
+  md5: dba22515f36d3c266de5896350813ea2
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95103
+  timestamp: 1690400315537
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+  sha256: c35449c0ca64d0d6a23c019b6eba188f546e42379857cbc4240bbdddee1159d3
+  md5: 61cb82346e21710f3e0645096cda4e12
+  depends:
+  - blas * openblas
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.21.5,<1.28
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22859180
+  timestamp: 1696543469561
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+  sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
+  md5: 3cd7eb43e285faba76faf67667e26b00
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093916
+  timestamp: 1690290951258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+  sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
+  md5: c5e9aef0d6895de1c927e9d796cd7cd3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15691
+  timestamp: 1629145910454
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+  sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
+  md5: 0f7c229e774146ffc4e29dedf75372bf
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67279
+  timestamp: 1696347632563
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+  sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
+  md5: 2302a79a045f152e183a52a81adfba62
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1674163
+  timestamp: 1681394762218
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+  sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
+  md5: 4ae67163d55cf9df83d4027ebc38c501
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30894
+  timestamp: 1671751931536
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+  sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
+  md5: dbb5c0cddb6661a89afee647fd3dc01e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39875
+  timestamp: 1668168874870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+  sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
+  md5: 667e60c8b407d73cbba40f44901f4f00
+  depends:
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3412693
+  timestamp: 1654088929697
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+  sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
+  md5: 884f788a5f6a664c9b79f7a4a60362d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680561
+  timestamp: 1696937004165
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+  sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
+  md5: 639a4f489af172c866c18442948e5874
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - slack-sdk
+  - requests
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125170
+  timestamp: 1679561942932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+  sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
+  md5: e5b90eba83fddba6d7aa6072b5bf7c91
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193017
+  timestamp: 1671143921826
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
+  md5: 644ef8830437070f60efcfcd6a987198
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9670
+  timestamp: 1690297532002
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
+  md5: a902a833bb186a2f1a4b2b89b1195136
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58466
+  timestamp: 1690297524418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+  sha256: 536045a8a172c651fd306c285a6d7409775f018dac944f2124c538ccfb195e28
+  md5: d4dc6cdf0812191b9ec78b35b4fdf3e0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11593
+  timestamp: 1659769477205
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+  sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
+  md5: f3f1d2c1028dad2f11ff950a15c99dbf
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188640
+  timestamp: 1698257577209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+  sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
+  md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20091
+  timestamp: 1629144441130
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+  sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
+  md5: 3089c63bf8f4d0423e1a287da286d83e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70923
+  timestamp: 1629357115820
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+  sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
+  md5: 5886b30b312445471268444f41f39dc7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102583
+  timestamp: 1695741976083
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+  sha256: 105e39d3eb51b47c7244b3379c0133ab7051966664f52835453b14509215b159
+  md5: ed20012c2cd99ffd04cca9929e0bc061
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49775
+  timestamp: 1675159079039
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+  sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
+  md5: 2e75ad6a09c308268192efe03cc9ebf4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 411778
+  timestamp: 1683113019715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+  sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
+  md5: 30f666bf97c26587c5d2f68cc5f330ab
+  depends:
+  - libcxx >=12.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 316901
+  timestamp: 1629287855861
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+  sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
+  md5: 584e591d36dcd5ba5c45404f0f7ebb2d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19076
+  timestamp: 1672387153578
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+  sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
+  md5: 467ae28215d1aa1c5688bc0c8a184269
+  license: Zlib
+  license_family: Other
+  size: 103525
+  timestamp: 1666595022664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+  sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
+  md5: 7cfbed15f1feee1422810f7830075f53
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 779464
+  timestamp: 1681304594848
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+  sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
+  md5: ed14f9bc6e55220483f1a5a388625a08
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162772
+  timestamp: 1644481986085
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+  sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
+  md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 39253
+  timestamp: 1644551767970
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+  sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
+  md5: b24d13c443a26f65a0778b475a5726bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132830
+  timestamp: 1695717959996
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+  sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
+  md5: 302c3c0696e17eaa62e140e3892644ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 199723
+  timestamp: 1681493196911
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
+  sha256: 812f268862208c2518b5187809a8571adb488de3604d512721035e65458dde76
+  md5: 97ce620b7dd3ee743d0ca28ed66ace74
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5721832
+  timestamp: 1697491241383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+  sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
+  md5: bf930260f679bc74227bbb18bc36ae82
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 119700
+  timestamp: 1657176150595
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
+  md5: 507dfe693ef429f466d964b599f4af21
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_7
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 18650
+  timestamp: 1659616328001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
+  md5: d0bf43e8df60baae3b3105aa5c42a791
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 21153
+  timestamp: 1659616312367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+  sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
+  md5: 7bd24bf94c24e810aecaaf84a0978e6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 343204
+  timestamp: 1659616543542
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+  sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
+  md5: 092b417c11edcbe6bb9b765ab4a55d23
+  license: MPL-2.0
+  license_family: Other
+  size: 164999
+  timestamp: 1694009822357
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+  sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
+  md5: 708a750d370b9d6875651021e21c4446
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159322
+  timestamp: 1690232335307
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+  sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
+  md5: c35736da3ea26782425e78061268cf5e
+  depends:
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 228713
+  timestamp: 1670423312743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+  sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
+  md5: 457a4339a53c033d48ce0c72e5038d2e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30330
+  timestamp: 1672387265402
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+  sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
+  md5: 59ec65fd9e06b81a65cc12986c67d5da
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1939614
+  timestamp: 1668084794027
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+  sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
+  md5: 3489c1a2b73fc957b5a62cc59349e25b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13438
+  timestamp: 1671231196438
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+  sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
+  md5: 3492b96083c1e904cc32d26ea7f1e1d8
+  depends:
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184280
+  timestamp: 1663827558327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+  sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
+  md5: f46d904bc6f220327e70474971341f52
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1220835
+  timestamp: 1694445639066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+  sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
+  md5: 2ff4fb509788b0e47ac684ba151394d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3289966
+  timestamp: 1690907040646
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+  sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
+  md5: 0f166c3e70541d8bee6e9d0cb60fb66e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16979
+  timestamp: 1649926678161
+- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+  sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
+  md5: ea93d413944ca6a8677eb1b284b136ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27388
+  timestamp: 1668714577678
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+  sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
+  md5: 9f167d3e45441bc3633c1974b1b0ce8c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 88421
+  timestamp: 1676983264486
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+  sha256: fa8f868e49721ca19912f816a6da221172758f9e3d28d8b31d53249fb14dc25f
+  md5: 09f9a2cea9425d76dccf9b026afe5bb2
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4576915
+  timestamp: 1698866895838
+- conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.9.0-py39haa95532_0.tar.bz2
+  sha256: fc1399ca859fa3cbb80f94869de2930299b9a4b72b88c29005d32d961738ad01
+  md5: bf03cceaecd14cb1b4c2955bddc1a2a9
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.9.0,<3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3358682
+  timestamp: 1697560035937
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+  sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
+  md5: 582d2c1135a89da757a038de831e7f39
+  license: Intel proprietary
+  size: 11086648
+  timestamp: 1664812389803
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+  sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
+  md5: 30fdefd1541c789c163751291a8faa88
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111448
+  timestamp: 1666125667599
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+  sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
+  md5: a10f07c7a3510272a296f9fed458a4ed
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38098
+  timestamp: 1678997241511
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+  sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
+  md5: fad9cf2023d807da8d44996e9d4399a0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51490
+  timestamp: 1698254721864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+  sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
+  md5: 9834848bd7c7759acf12e78d09388563
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3891030
+  timestamp: 1681801474383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+  sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
+  md5: 1285c8c628bc912c54d0968574c9f4c9
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217232
+  timestamp: 1691122695748
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+  sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
+  md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
+  depends:
+  - backcall
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1279433
+  timestamp: 1694181820978
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+  sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
+  md5: f5fcce35d3f21cdfc5893c5a7a86c651
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1035394
+  timestamp: 1644315567034
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+  sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
+  md5: f67fe3337528e2886f1ac3ab8ac37985
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213110
+  timestamp: 1666908350218
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
+  md5: 81f2c343dc4c65eea39c45383272068f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 407861
+  timestamp: 1677849239400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+  sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
+  md5: bd9526d38a145fe311a8aa36bc11e071
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 152006
+  timestamp: 1676558783570
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+  sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
+  md5: a00e6a62956fde3c4135464353ee8a53
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229158
+  timestamp: 1676330909084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+  sha256: db8335d6531b03c7bdfe789ebacc52631ac6ea4a37700bb3da1f6a53a1acd724
+  md5: ebeba61994cc225ea5f4f42caa511019
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116681
+  timestamp: 1679906658986
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+  sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
+  md5: 5efa1332f7c0a8d9638eda02170c4ce5
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pywinpty
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 413653
+  timestamp: 1671707957673
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+  sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
+  md5: 891fe66a24d8714737b2874985ee1303
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62298
+  timestamp: 1672388166096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
+  md5: c345f51706eef530454f66b794e5e574
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 68189
+  timestamp: 1659616216976
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
+  md5: a7400cfb72042977bc047909ed504ce8
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 33743
+  timestamp: 1659616248209
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
+  md5: 6307f6854754ab5bd7c84e6998385bb1
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 733177
+  timestamp: 1659616279453
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+  sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
+  md5: b812bc5d9c76242e2bb2ac87afe7d39b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 730280
+  timestamp: 1650983734373
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+  sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
+  md5: ba9418df9288a2f031a02fa35b774ce0
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78524
+  timestamp: 1694778314659
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+  sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
+  md5: 6ece7f1a3248169837714d05d7f6ef0a
+  depends:
+  - libiconv >=1.16,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 3513910
+  timestamp: 1692971505729
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+  sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
+  md5: bd7ec244935e83e850a4ff34e8e2e64f
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 513971
+  timestamp: 1692973657152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+  sha256: e1c0e745d9ba36a80773e841d96bf514ad1ceda419e4188aad3c22782af00234
+  md5: f226532e9bb308f20e874c56be6ceefb
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 35788
+  timestamp: 1659783414586
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+  sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
+  md5: fb7881e74b59262df0fa4ec981964efc
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1244887
+  timestamp: 1695058550693
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+  sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
+  md5: 6970c7f46b0164cad1d210e7a1419959
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143434
+  timestamp: 1670944902624
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+  sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
+  md5: 1015298551c040c6d5e26eebbae12ef5
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142316
+  timestamp: 1671542240512
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+  sha256: ab5c246c2b271acc1cdd0b9343989c0166681536e569cdbe71618f55d34c7292
+  md5: 7ce68d771cd94c9ff5efefe69d327c9a
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 125122
+  timestamp: 1684280210213
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+  sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
+  md5: 466da740fafef3d6bce114220f0be306
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28510
+  timestamp: 1654508162239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+  sha256: 1687ae122ee7d8b583141fc5014b76d494841dc8083b854449e3d6e0f6bb7019
+  md5: 3697ac26ee3c2d49338dd5b9c6551152
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8080067
+  timestamp: 1698692812610
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+  sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
+  md5: a9fa43e694b25cd49b8b08a9eefd696e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18054
+  timestamp: 1661915903969
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+  sha256: 8aa14047fac6ef8b326900c4bf1a960eaa7a1699c18fdf1e75a59101b610b6df
+  md5: 7e1d4d4700fbea6171d30f1d5ad24226
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53362
+  timestamp: 1659721308586
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+  sha256: 2017814a7cc93dd51c6b7c016e3cdf8fbc32fa20f985638aaff6a6377e9ee086
+  md5: a1a285c56b001c3b5c591bf21eec3149
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19326
+  timestamp: 1659716205153
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+  sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
+  md5: 248c468abced874f0231d3cc23177c77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58488
+  timestamp: 1607359497934
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+  sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
+  md5: 5e763c995ff0c549f68a10bce70fede4
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187489950
+  timestamp: 1691503804820
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+  sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
+  md5: dd0c2ece6a743c373c9b5a5919b4818f
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49744
+  timestamp: 1682975040154
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+  sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
+  md5: 57cea8df7ab85f2a98f64d23afcb1f90
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184956
+  timestamp: 1695058491736
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+  sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
+  md5: 8769cdd201d905069800488fe31574e5
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 256221
+  timestamp: 1695060152521
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+  sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
+  md5: d9781492332e6326f9fca87f3a8efacd
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8135792
+  timestamp: 1681756491399
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+  sha256: 2dd3178d3c570e30b9490ebabfd7bfac806afad8302d3dee0edc619805034397
+  md5: bef9da0f0694c45b6aaa4e6447479eaf
+  depends:
+  - jupyter_client >=6.1.5
+  - nbformat >=5.0
+  - nest-asyncio
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 118324
+  timestamp: 1650290466135
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+  sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
+  md5: f1d8ce412e115986c403f223b3b47d0f
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 596314
+  timestamp: 1668451106600
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+  sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
+  md5: f96bbef0985d7e66ebf00c0d55e30e23
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 167045
+  timestamp: 1694617078743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+  sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
+  md5: 6e6ba64c8dc5025aeac606404a8df36a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13786
+  timestamp: 1672387480065
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+  sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
+  md5: 4a7a3286484766741f627696697c362c
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 609425
+  timestamp: 1690985686105
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+  sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
+  md5: 4269a1f93882205b90d4b2ae78fc82d5
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22417
+  timestamp: 1668160717305
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+  sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
+  md5: a18a576b7024cfd6f905c526a786a916
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 135285
+  timestamp: 1696515698492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+  sha256: e5e11f9b42d770ee46ac24d1cdf7aa4e9c49a60a607c8c28e7729131a99eadd5
+  md5: 4274d06db8a9a381c072d226d0322dc0
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.0 py39h65a83cf_0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9835
+  timestamp: 1695830845329
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+  sha256: dcaa1607ce40a0ed610dd5398e125c8e5b08e738e50b6037a8c72b49ca561ff2
+  md5: d99d990a60644b97ba1ff9bb8da0e66f
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.26.0 py39h055cbcc_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6778113
+  timestamp: 1695830816710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
+  md5: ab07e2a27ac08afe3d0b4c0890b8486a
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 2-Clause
+  size: 249316
+  timestamp: 1630094024143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+  sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
+  md5: 73b17037d87b5a58feb34dafc0538f7f
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8058396
+  timestamp: 1695324589828
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+  sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
+  md5: df1d746ba8d5d6ba01ac1373b9b71e1a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73016
+  timestamp: 1693575484990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+  sha256: 1994e5831fd421bd6cf85916073d4012dec53e673b672b3985efaf771f0a7bf8
+  md5: c486a5b51e3227f6ea564a9dd3125e45
+  depends:
+  - bottleneck >=1.3.4
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - openpyxl >=3.0.10
+  - jinja2 >=3.1.2
+  - qtpy >=2.2.0
+  - numba >=0.55.2
+  - pyreadstat >=1.1.5
+  - zstandard >=0.17.0
+  - xlrd >=2.0.1
+  - tabulate >=0.8.10
+  - fsspec >=2022.05.0
+  - pyqt >=5.15.6,<6
+  - xarray >=2022.03.0
+  - xlsxwriter >=3.0.3
+  - beautifulsoup4 >=4.11.1
+  - html5lib >=1.1
+  - fastparquet >=0.8.1
+  - pyarrow >=7.0.0
+  - pyxlsb >=1.0.9
+  - matplotlib-base >=3.6.1
+  - odfpy>=1.4.1
+  - pytables >=3.7.0
+  - sqlalchemy >=1.4.36
+  - psycopg2 >=2.9.3
+  - blosc >=1.21.0
+  - lxml >=4.8.0
+  - pymysql >=1.0.2
+  - gcsfs >=2022.05.0
+  - pandas-gbq >=0.17.5
+  - dataframe-api-compat >=0.1.7
+  - s3fs >=2022.05.0
+  - scipy >=1.8.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12629931
+  timestamp: 1697479885371
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
+  sha256: 270e4c3ab0f0c8d8f31fa0e45bc516c1e41be618a5c66e1c86dc39ce76cb2372
+  md5: cad52ba9eb391416112f0994b6c35249
+  depends:
+  - bleach
+  - bokeh >=3.2.0,<3.4
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.0.0,<3
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.17.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17162886
+  timestamp: 1698867967809
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
+  sha256: 56eaf7f4b1bb81e3deed55711dd2ee78f244a3cc0ad4bb7a1f09d97e46f9793f
+  md5: c24a3daed1e85ba7a100fa6966c5bb48
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189021
+  timestamp: 1698263520538
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+  sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
+  md5: 427c1450bebb632f43bbc8c83006e4cd
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 806931
+  timestamp: 1696580240310
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+  sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
+  md5: 21790cd3e2b8a45c4104aff0a68330d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3001751
+  timestamp: 1697549357662
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+  sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
+  md5: 56f44a1054da2d10777e375838191070
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 32355
+  timestamp: 1692205784293
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+  sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
+  md5: 8a35ad65651086575ce55371f22feda8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91045
+  timestamp: 1659455316472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+  sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
+  md5: 186eb95f816a2eff80c3c7f7d964c7b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 578514
+  timestamp: 1672388155359
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+  sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
+  md5: 47b6cbe6ce9289e47d16900b03596a91
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372807
+  timestamp: 1656431445633
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+  sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
+  md5: 07165c444adc7c7ccc8a345875adc5ef
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48408
+  timestamp: 1675450623287
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+  sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
+  md5: d58e76a31e2f6e7410ba4afd7f385b0d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1877445
+  timestamp: 1684280183367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+  sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
+  md5: 0e5b0fe7debbf558ce97090f6b67cdae
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94633
+  timestamp: 1690225630423
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+  sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
+  md5: 0fde797653e4ab589506121fb1e37555
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157119
+  timestamp: 1661452591647
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+  sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
+  md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 92679
+  timestamp: 1636093365041
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+  sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
+  md5: f870859d4dc7a8d82cf3546bd9035f33
+  depends:
+  - python >=3.9,<3.10.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 54520
+  timestamp: 1605307564142
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+  sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
+  md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
+  depends:
+  - openssl >=3.0.10,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 21172845
+  timestamp: 1694442462066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+  sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
+  md5: 9d99075052265ae3d718582d3b875038
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269964
+  timestamp: 1661376543480
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+  sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
+  md5: fa9074d94236c9b768bfd2c858875b27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 264836
+  timestamp: 1695131770282
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+  sha256: 97243a31c39f4990c0e9d4f2307f2f7fb9421553303923bc105067ec4340bdff
+  md5: 8078c5760f27398eaf1082226647d137
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40145
+  timestamp: 1685031143383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+  sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
+  md5: 3d2841085778006c2e79f9c7300f8b9d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13565975
+  timestamp: 1669937633869
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+  sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
+  md5: 54a4bc0724041dd173088419d6ede2af
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 239062
+  timestamp: 1677611495106
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+  sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
+  md5: f39f84115e228bad4bceaefdd637f022
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 158558
+  timestamp: 1698096358091
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+  sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
+  md5: df398a3a1668fd2a22061764e20ea91d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.4,<4.3.5.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 460913
+  timestamp: 1657616061604
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+  sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
+  md5: 38db77ece9dc76feffb9ef7638e38258
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94397
+  timestamp: 1690400496655
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+  sha256: 3a9a680173f731d515e0587d5b74583cc986b5c1ff62f4cf9e4f7ec268cbb62a
+  md5: 3387bf809e3d32dde3f5cbc3ef49bf47
+  depends:
+  - blas 1.0 mkl
+  - icc_rt >=2022.1.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<1.28
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22779707
+  timestamp: 1696550432358
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+  sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
+  md5: 3e284ae6b48ee30c364ffdc5601610b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1099842
+  timestamp: 1690291374842
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+  sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
+  md5: 993b3886b334bd1f49d34206f21997b4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15998
+  timestamp: 1614030572433
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+  sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
+  md5: 7ac9604ad7564ac0c71bff5db198656f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67012
+  timestamp: 1696347795139
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+  sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
+  md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1311308
+  timestamp: 1681402905668
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+  sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
+  md5: 28b9869d8d3a839918fac4a08f38cbc2
+  depends:
+  - python >=3.9,<3.10.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30546
+  timestamp: 1671752127904
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+  sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
+  md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39590
+  timestamp: 1668168880994
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+  sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
+  md5: 52cdcdb96383c010ca833a7c24b3935b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Tcl/Tk
+  license_family: BSD
+  size: 3690152
+  timestamp: 1654036853710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+  sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
+  md5: 0e054ab29119cf4c1f778613acf972f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 681780
+  timestamp: 1696937326924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+  sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
+  md5: b6ad839ebba536ad1c3cc58d0e2123f0
+  depends:
+  - colorama
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 143681
+  timestamp: 1679562248929
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+  sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
+  md5: fe78de10019085146f1cc6c94fdc2620
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192822
+  timestamp: 1671143999327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
+  md5: ca5fc3fbdb09b6de068a8b7a8869369f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9208
+  timestamp: 1690298120549
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
+  md5: a86e87a10e5fdff486265e0c675fb99f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57922
+  timestamp: 1690298106990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+  sha256: 8057d3d2a0acd44496de33c5b222063c3f7d06b90c74fbbda45bd18b0b324219
+  md5: 398f8db5bd8cab84b3d85a9d85fa4889
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11362
+  timestamp: 1659769459206
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+  sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
+  md5: 0d31859e0a097aedbcc1627db33b3d92
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188367
+  timestamp: 1698257883295
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+  sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
+  md5: 45ef24c486a484f079faf1dc90e4c7e9
+  depends:
+  - vs2015_runtime >=14.27.29016
+  license: Modified BSD License (3-clause)
+  license_family: BSD
+  size: 8277
+  timestamp: 1605602889180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+  sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
+  md5: 4daaceb6cfc1af6274509081d8018ef1
+  size: 2316783
+  timestamp: 1605602872095
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+  sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
+  md5: 916c16904615c7af3b5d37cb6694f45e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21084
+  timestamp: 1607347371925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+  sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
+  md5: da69e6987fcc757e83a358ceaa13f62b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73391
+  timestamp: 1614804425587
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+  sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
+  md5: 23b9f4634b2e5450be617114f62c74f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 120873
+  timestamp: 1695742300539
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+  sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
+  md5: 120f0b088290fc17bd6618fc10a2f0c4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PUBLIC-DOMAIN
+  size: 34293
+  timestamp: 1605306211299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+  sha256: a5d2a216d052105fdaad7256f23da3b29f95100d1dc0f29b6ab1f3bbc75e17a9
+  md5: a558f681ebc243f86cde2515c065b62e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48805
+  timestamp: 1675159123654
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+  sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
+  md5: c3f7871e9a33adeccee1b1e8e216918e
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 1332571
+  timestamp: 1683113347814
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+  sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
+  md5: 1ab55f8c4b5292ec360c572120bf823e
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-3.0-or-later
+  size: 9430705
+  timestamp: 1616055773485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+  sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
+  md5: 6875e0bf3828707dc9165d694c0d0a7d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18725
+  timestamp: 1672387612937
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+  sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
+  md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 148931
+  timestamp: 1666595229032
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+  sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
+  md5: 8d6a1e767775fe0eb617cd6e22edc2ff
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1871867
+  timestamp: 1681304638261

--- a/penguin_crossfilter/pixi.lock
+++ b/penguin_crossfilter/pixi.lock
@@ -7,669 +7,669 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.3.0-py39h2f386ee_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39hdda0065_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.9.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.10.4-hf1b16e4_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.37-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.9.3-py39hdbbb534_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.0-py39h5f9d8c6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.0-py39hb5e798b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.11-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.1.1-py39h1128e8f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.3.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.18-h955ad1f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.11.3-py39h5f9d8c6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-3.3.0-py39h2f386ee_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39hdda0065_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.18.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/hvplot-0.9.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxml2-2.10.4-hf1b16e4_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.37-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lxml-4.9.3-py39hdbbb534_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.0-py39h5f9d8c6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.0-py39hb5e798b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.11-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-2.1.1-py39h1128e8f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-1.3.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-2.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.9.18-h955ad1f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scipy-1.11.3-py39h5f9d8c6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.9.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/hvplot-0.9.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.9.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/hvplot-0.9.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.9.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/hvplot-0.9.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
   sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
   md5: 613805add1c05b538ff06d217252feb7
   depends:
@@ -680,7 +680,7 @@ packages:
   license: BSD-3-Clause
   size: 20810
   timestamp: 1652859733309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
   sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
   md5: 2cf39d906cc321896ffe3e5d33d80c5c
   depends:
@@ -693,7 +693,7 @@ packages:
   license_family: MIT
   size: 162166
   timestamp: 1644463608931
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
   sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
   md5: 2972a84e0e22ae3244bbd2f1eebcf536
   depends:
@@ -704,7 +704,7 @@ packages:
   license_family: MIT
   size: 35352
   timestamp: 1644569715988
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
   sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
   md5: a68016b4b06460def24cb69d932986f3
   depends:
@@ -713,7 +713,7 @@ packages:
   license_family: MIT
   size: 132486
   timestamp: 1695717963702
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
   sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
   md5: 2f6356a2f530314b4059c08c79a3d8bc
   depends:
@@ -723,12 +723,12 @@ packages:
   license_family: MIT
   size: 205868
   timestamp: 1681493113570
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.3.0-py39h2f386ee_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-3.3.0-py39h2f386ee_0.tar.bz2
   sha256: f2a4f2dbea826cfaf59d09e53a4bb951ffd77becb2f53f5b4ddb6ef63cdd5210
   md5: 1d420e8258cf81e6cebc7320e5cf6a0a
   depends:
@@ -746,7 +746,7 @@ packages:
   license_family: BSD
   size: 5706055
   timestamp: 1697490557655
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
   sha256: 20e381c665853131fc5c9a397b1d4b05bb05859a2bdfbb0559e85ec445ee9e7c
   md5: 14dc3c2e8eb68b1111a08de9a3ce8a00
   depends:
@@ -757,7 +757,7 @@ packages:
   license_family: BSD
   size: 128656
   timestamp: 1657175966755
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
   sha256: 11df9b719339bb40e4af8eb124a094def217f64e2440af973d7342da19c030b0
   md5: 712827b1699cc71e6240626c413408f3
   depends:
@@ -768,7 +768,7 @@ packages:
   license: MIT
   size: 18907
   timestamp: 1659616178155
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
   sha256: 6408b6849347ef01f5ed170f4b35fb4bdfed2d9cf9da4912a4b104a810518a80
   md5: d9d570587ccfd7158b66feb823c990c6
   depends:
@@ -778,7 +778,7 @@ packages:
   license: MIT
   size: 19933
   timestamp: 1659616170430
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
   sha256: 8507df3357958556aff2dea8788a3f7ddad6172fd9fe5d1bdb6c3afe9686d2f8
   md5: f0204f72bcd9ef836218cc74345e69f2
   depends:
@@ -788,14 +788,14 @@ packages:
   license: MIT
   size: 362180
   timestamp: 1659616255400
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
   sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
   md5: 3ef00f4c5278b688552efc259c463dc8
   license: MPL-2.0
   license_family: Other
   size: 132731
   timestamp: 1694009767372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
   sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
   md5: d5cb3d97cf5e85ffe5e94037ed8a1169
   depends:
@@ -804,7 +804,7 @@ packages:
   license_family: Other
   size: 159077
   timestamp: 1690232254640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
   sha256: e99314f8809d65195dcab68a9783f70fbe990113a66c98c9b0a7ffea01226b71
   md5: fff69f95079191a10e099b21a5fd4bc3
   depends:
@@ -816,7 +816,7 @@ packages:
   license_family: MIT
   size: 234749
   timestamp: 1670423281079
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
   sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
   md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
   depends:
@@ -826,7 +826,7 @@ packages:
   license_family: CC
   size: 1917831
   timestamp: 1668084545510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
   sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
   md5: 13702d3b4b744784e5bd559c7050dd6f
   depends:
@@ -836,7 +836,7 @@ packages:
   license_family: BSD
   size: 12719
   timestamp: 1671231205875
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
   sha256: 0b1a9a25ddfc6631390c53d6ee95706eaab0805c5a9a8d748c08120a1f421256
   md5: a93581f810ef522bd23c148195591157
   depends:
@@ -848,7 +848,7 @@ packages:
   license_family: BSD
   size: 234846
   timestamp: 1663827645102
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39hdda0065_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39hdda0065_0.tar.bz2
   sha256: 6a08c501a310e5e482df8e917a7b0cd438e83f33a44aaec49c2ab53eeda5ebf1
   md5: 3f8c39c0ce002faf6719b8d2d5f31941
   depends:
@@ -862,7 +862,7 @@ packages:
   license_family: BSD
   size: 2181966
   timestamp: 1694444647708
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
   sha256: 96b5d4c87d8467ae6ba92f9c17eaa9e059b6f7e9b8ee57aee788885c7413078b
   md5: 9868912fd269f4d9d6423cfe69560131
   depends:
@@ -873,7 +873,7 @@ packages:
   license_family: MIT
   size: 2164334
   timestamp: 1690905228819
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
   sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
   md5: 2e6ec51066d825ef3c317abe78d6049e
   depends:
@@ -882,7 +882,7 @@ packages:
   license_family: MIT
   size: 16413
   timestamp: 1649926472708
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
   sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
   md5: b4d923222d45314856b5378cb115214d
   depends:
@@ -891,7 +891,7 @@ packages:
   license_family: BSD
   size: 26728
   timestamp: 1668714462023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
   sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
   md5: a5dc8677d891dff2393b63189a3ad42f
   depends:
@@ -902,7 +902,7 @@ packages:
   license_family: Other
   size: 971975
   timestamp: 1666798278693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
   sha256: c323a9800a358c178f6f3b8860bbb77c373fbc3be981bb6420175fbb5431adf5
   md5: 6485f51176cf651b3b28c3548cef10ad
   depends:
@@ -911,7 +911,7 @@ packages:
   license_family: MIT
   size: 78533
   timestamp: 1676983203797
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.18.0-py39h06a4308_0.tar.bz2
   sha256: 6d934b1d532f644e148bcf51f9c8d0c7623e832fd29282bc6c4cb64b9e027884
   md5: b18725efd77d3fb6c9addf81dac09081
   depends:
@@ -928,7 +928,7 @@ packages:
   license_family: BSD
   size: 4576699
   timestamp: 1698866790345
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.9.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/hvplot-0.9.0-py39h06a4308_0.tar.bz2
   sha256: ebe76b5a96add44b3befafb39e1b1946306cc0f1f98e8cf1fdfeb134a6fbd2fd
   md5: 74ad1a52b081ba48af21ea48697c06aa
   depends:
@@ -945,7 +945,7 @@ packages:
   license_family: BSD
   size: 3310817
   timestamp: 1697560077151
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
   sha256: b35b281dbf69b826c6ae04fcd7b6a2d1f098277a669a199906a1f23b4b0931a5
   md5: 2a793fe24f85aa5819fe69c450cba6f7
   depends:
@@ -955,7 +955,7 @@ packages:
   license_family: MIT
   size: 29021241
   timestamp: 1692293243228
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
   sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
   md5: 1eb52f9f45cea2fb9ce27b19f990160e
   depends:
@@ -964,7 +964,7 @@ packages:
   license_family: BSD
   size: 110793
   timestamp: 1666125606878
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
   sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
   md5: 126b3c1933b7364ff03f67455b687e99
   depends:
@@ -974,7 +974,7 @@ packages:
   license_family: APACHE
   size: 37588
   timestamp: 1678997134023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
   sha256: b6d5f6098903e5edfbc2200282efa186d446442d47ab75f51ff22c30ae0c4da4
   md5: e53a806995cedc9e5d8a96e03c9e79ac
   depends:
@@ -984,7 +984,7 @@ packages:
   license_family: Apache
   size: 50699
   timestamp: 1698254665788
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
   sha256: bddc8de31272a509510cc87e5ac0cdb0e7765d393ca7bdfddbfe4123979a9413
   md5: bc8a501970aadad3373edbce996b5fdf
   depends:
@@ -1000,7 +1000,7 @@ packages:
   license_family: Proprietary
   size: 19286333
   timestamp: 1681801301379
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
   sha256: c0d0714c68ed953740812688ac1b3c3e286de33b55d49f02953d705fb00c30d0
   md5: 8b65eea396159a3b59278f77c81ddd1b
   depends:
@@ -1021,7 +1021,7 @@ packages:
   license_family: BSD
   size: 217268
   timestamp: 1691122070319
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
   sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
   md5: ff47e0be879e817713ce2a9daa76e2b0
   depends:
@@ -1042,7 +1042,7 @@ packages:
   license_family: BSD
   size: 1261116
   timestamp: 1694181530670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
   sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
   md5: 5ef6c6a0d1ac79143c7359d305155167
   depends:
@@ -1052,7 +1052,7 @@ packages:
   license_family: MIT
   size: 1021637
   timestamp: 1644297140650
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
   sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
   md5: eaeb023688f781e7dd89e74310c38195
   depends:
@@ -1062,7 +1062,7 @@ packages:
   license_family: BSD
   size: 211775
   timestamp: 1666908212136
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
   sha256: c21f8f407266d039e819c27fe9eb4fb26587e974f3bd059b37cbaec5073722d0
   md5: ba1f47411e9e07876c7a3e9d3be6a98e
   depends:
@@ -1071,7 +1071,7 @@ packages:
   license_family: Other
   size: 281400
   timestamp: 1677849152168
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
   sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
   md5: 0d2c3c5edf671b575532d5a3e8bf15fc
   depends:
@@ -1082,7 +1082,7 @@ packages:
   license_family: MIT
   size: 131510
   timestamp: 1676558716852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
   sha256: 4ba1f5698f0b483af397021b2047554afb3129790cac3a1502c79693154331d2
   md5: 8e9c0ef4b0b57caa87c146892e56a313
   depends:
@@ -1098,7 +1098,7 @@ packages:
   license_family: BSD
   size: 192921
   timestamp: 1676329415827
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.3.0-py39h06a4308_0.tar.bz2
   sha256: 0192bd48cd96c60dc3054d5addd8cdb4a29a218843181318371f79daec8242f8
   md5: d851b401dc13d04e6848bb36e12efc1c
   depends:
@@ -1109,7 +1109,7 @@ packages:
   license_family: BSD
   size: 91534
   timestamp: 1679906652183
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
   sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
   md5: a4beb461f0a60998a090d760b5c6c907
   depends:
@@ -1133,7 +1133,7 @@ packages:
   license_family: BSD
   size: 411564
   timestamp: 1671707702849
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
   sha256: 6d6c384c9c65e33d5d047e01131e0687eb2bc1e5a4a67f80af3c0b773c1bba82
   md5: 07957e1d2fb6a407f7d7293b84938e1e
   depends:
@@ -1144,7 +1144,7 @@ packages:
   license_family: BSD
   size: 77689
   timestamp: 1672387301020
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -1155,7 +1155,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
   sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
   md5: 9508af80612e4fa1b5d1abb43ca7e63c
   constrains:
@@ -1163,7 +1163,7 @@ packages:
   license: GPL-3.0-only
   size: 749072
   timestamp: 1652971360657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
   sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
   md5: 88199c75f2ac211728febced7785c24e
   depends:
@@ -1173,7 +1173,7 @@ packages:
   license_family: Apache
   size: 228278
   timestamp: 1635523146417
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
   sha256: 472cf888db65d00451fcd5fccd5244d55c061e8d7efe43f70220414ef64521a5
   md5: 787927eff72e62c270f614cbcba9479c
   depends:
@@ -1181,7 +1181,7 @@ packages:
   license: MIT
   size: 67109
   timestamp: 1659616145972
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
   sha256: 19a43182ca343510ba51baa0fce91d64c840a19cdf13c6dde4e03e819c70897e
   md5: c0608d376a30b5aa4d2f2c22978135db
   depends:
@@ -1190,7 +1190,7 @@ packages:
   license: MIT
   size: 34691
   timestamp: 1659616154057
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
   sha256: 158c401aa0bab05aa5f4134aea798085e4e3849209946f896cca352930d2225d
   md5: cc6a6d362912a2d112310bd3f8acd44e
   depends:
@@ -1199,7 +1199,7 @@ packages:
   license: MIT
   size: 295287
   timestamp: 1659616162282
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
   sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
   md5: 55dde57e63a36b202e388a39dcee9a66
   depends:
@@ -1208,7 +1208,7 @@ packages:
   license_family: MIT
   size: 74096
   timestamp: 1695996494461
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
   sha256: ec1c6341cf0091b55be05285037cb3fbba90573e00257f383ab274d8b8e6d46f
   md5: 32ac65d639d6c155ea7276cadf1fd2b6
   depends:
@@ -1218,7 +1218,7 @@ packages:
   license_family: MIT
   size: 147907
   timestamp: 1683716564178
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
   sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
   md5: 641e72e5067bd6d5454405879e1cd2a7
   depends:
@@ -1233,7 +1233,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 8895144
   timestamp: 1654090827491
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
   sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
   md5: 27082517590f3b9fbffecc68513b461b
   depends:
@@ -1242,7 +1242,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 19860
   timestamp: 1654090819660
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
   sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
   md5: 0202c3c8ae4735cac6c7f3d1e1685964
   constrains:
@@ -1250,7 +1250,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 5228750
   timestamp: 1654090762569
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
   sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
   md5: 3080c2813e6e1d0f8a100a38b5b3456d
   depends:
@@ -1258,7 +1258,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 573231
   timestamp: 1654090775721
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
   sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
   md5: 1bffe1481ed4f88827248fb9001f8923
   depends:
@@ -1268,7 +1268,7 @@ packages:
   license_family: Other
   size: 362561
   timestamp: 1677841789536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -1276,7 +1276,7 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
   sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
   md5: 8c195584a5f5471b600ee180e4052773
   depends:
@@ -1284,7 +1284,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 6410287
   timestamp: 1654090800863
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
   sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
   md5: ef78eebd98289aceacdfa29182426adf
   depends:
@@ -1302,7 +1302,7 @@ packages:
   license_family: Other
   size: 664034
   timestamp: 1693575237924
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
   sha256: c6aecee300c8e84a99056307ed3bdc047edd5366e55230a4eabe3ee5e8082bb8
   md5: 3a6ebf9895b1085a23783cd95460a629
   depends:
@@ -1317,7 +1317,7 @@ packages:
   license_family: BSD
   size: 88424
   timestamp: 1694778218406
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
   sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
   md5: 9cdeef1d044c7e035c006890f11569d3
   depends:
@@ -1328,7 +1328,7 @@ packages:
   license_family: BSD
   size: 436056
   timestamp: 1694776944891
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.10.4-hf1b16e4_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxml2-2.10.4-hf1b16e4_1.tar.bz2
   sha256: 93b155c0472d424dce940921ff368a3e4fd70fa41f5f934e58a4b7ec24722f95
   md5: 2d7bb4d2ef09d62843f8be03b55fce18
   depends:
@@ -1340,7 +1340,7 @@ packages:
   license_family: MIT
   size: 744988
   timestamp: 1692970212537
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.37-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.37-h5eee18b_1.tar.bz2
   sha256: e4e42cc28f7d509980afa2b1e76266d997628c9ff5d194c8460228279c0b6cdc
   md5: ff861c432be5a684783732ad1eb4c39f
   depends:
@@ -1351,7 +1351,7 @@ packages:
   license_family: MIT
   size: 258682
   timestamp: 1692973520375
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py39h06a4308_0.tar.bz2
   sha256: 0e4d61ed508712fc16117fc41f0f5bfedd319cfefd114749689db5f78242b0a5
   md5: d40d6b6ea51683b29a9e210831db4a13
   depends:
@@ -1361,7 +1361,7 @@ packages:
   license_family: MIT
   size: 35171
   timestamp: 1659783489143
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.9.3-py39hdbbb534_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lxml-4.9.3-py39hdbbb534_0.tar.bz2
   sha256: b961c12e78000995cfcc5769c64b1c146f917e640e999e290bb2b36468bd7dbe
   md5: a3a5039a19997b8cee4ddf538472358c
   depends:
@@ -1373,7 +1373,7 @@ packages:
   license_family: Other
   size: 1616363
   timestamp: 1695058577405
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
   sha256: 36b23ab8d8aa22d70a2f733462cabe95e5b27ca919ec7a75a5592bc39c5f7d16
   md5: f24adbfdfe16b0bac0d14640bb5ce616
   depends:
@@ -1383,7 +1383,7 @@ packages:
   license_family: BSD
   size: 163649
   timestamp: 1670944701605
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
   sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
   md5: 421f82c8274b44660dba629134faa6af
   depends:
@@ -1393,7 +1393,7 @@ packages:
   license_family: BSD
   size: 122221
   timestamp: 1671541990505
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py39h06a4308_1.tar.bz2
   sha256: 9332b39039a52ecc802ddc2c4a3bde95a3141aff0ccab19a7591ec6ef72bfe07
   md5: 622bb5a6eeeadeb8731e5e1bf4f0d7a2
   depends:
@@ -1403,7 +1403,7 @@ packages:
   license_family: MIT
   size: 105637
   timestamp: 1684279960746
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
   sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
   md5: feb0e452205b44ac45d9b5e55c21a3b1
   depends:
@@ -1415,7 +1415,7 @@ packages:
   license_family: BSD
   size: 22819
   timestamp: 1654597913064
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
   sha256: 10701d3065424bbef89c03a30c4adecd67308cd2f76e0d873aad6a180d9fe097
   md5: e196f6bace29ef34f0a996ef1c99f193
   depends:
@@ -1438,7 +1438,7 @@ packages:
   license_family: PSF
   size: 8129476
   timestamp: 1698692330174
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
   sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
   md5: c04ef34af33da4c71bcc99b7ec24d210
   depends:
@@ -1448,7 +1448,7 @@ packages:
   license_family: BSD
   size: 16391
   timestamp: 1662014553452
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py39h06a4308_0.tar.bz2
   sha256: 0dd0157d3d6c591a1087f7b96993412ac9194b7ea0ee2d667b1dc1c587eb0e33
   md5: 975a78ae464b1cd9541c498fd8299858
   depends:
@@ -1458,7 +1458,7 @@ packages:
   license_family: MIT
   size: 52857
   timestamp: 1659721312521
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py39h06a4308_0.tar.bz2
   sha256: cae67d22945f16e1034fc53144eea8bb67f2fecf6d60b22c43822094b6ca2b49
   md5: 19932cd4f64628bf6db1accebdaf7eac
   depends:
@@ -1467,7 +1467,7 @@ packages:
   license_family: MIT
   size: 18689
   timestamp: 1659716096534
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
   sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
   md5: f6c734d73e6e3dbc1b62766cf18ff3e4
   depends:
@@ -1477,7 +1477,7 @@ packages:
   license_family: BSD
   size: 58153
   timestamp: 1607364912263
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
   sha256: c7dedf41acbb2a065364f949ba24479449387d54c095220ff89346d266b25347
   md5: c5f96c8ff7102e1d673829bbeb8bed84
   depends:
@@ -1491,7 +1491,7 @@ packages:
   license_family: Proprietary
   size: 206706869
   timestamp: 1691503234180
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
   sha256: 984f547627b0af8358fa83b2396e0b2c014f9bc281304b6b8d3ff139a3f04b40
   md5: 724d2559e0ed50aa0eee97c919134ded
   depends:
@@ -1502,7 +1502,7 @@ packages:
   license_family: BSD
   size: 58512
   timestamp: 1682948511810
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
   sha256: 650419991b99b810e79221e35e5a6c3e49240ed30ff3e5324eecf1cefd276110
   md5: a14b8155afdb15f3bce72e67925c0ceb
   depends:
@@ -1516,7 +1516,7 @@ packages:
   license_family: BSD
   size: 227382
   timestamp: 1695058347376
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
   sha256: 7b0eeb8acc4c6b9f45b214fbc991a4073a59a8f7b798a4cc86515b97f7af6355
   md5: eb48e45fd8d61762290e4289a52be3f7
   depends:
@@ -1531,7 +1531,7 @@ packages:
   license_family: BSD
   size: 329190
   timestamp: 1695059874042
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
   sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
   md5: 95c83d71814c504b5504df4f14548f1a
   depends:
@@ -1557,7 +1557,7 @@ packages:
   license_family: BSD
   size: 8257558
   timestamp: 1681756322140
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.5.13-py39h06a4308_0.tar.bz2
   sha256: 1b92d72b083f3350359b8fb2e3b5dc846f49650c9e46a6a74354b1b7f0d42730
   md5: 996babe4314515ddd41008a53cb5d47f
   depends:
@@ -1570,7 +1570,7 @@ packages:
   license_family: BSD
   size: 98791
   timestamp: 1650290544347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
   sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
   md5: 1710a25086c8098367eb36b9d441448b
   depends:
@@ -1598,7 +1598,7 @@ packages:
   license_family: BSD
   size: 569683
   timestamp: 1668450704669
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
   sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
   md5: 385cc9e53404776782502c0fdb08820f
   depends:
@@ -1611,7 +1611,7 @@ packages:
   license_family: BSD
   size: 147046
   timestamp: 1694616899309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
   sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
   md5: 57ea097dc15f8d9f9eb90e1d919143b0
   depends:
@@ -1620,7 +1620,7 @@ packages:
   license_family: MIT
   size: 1157733
   timestamp: 1674734069410
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
   sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
   md5: bbbcbebc20a4fdcadce398d0ca04f95e
   depends:
@@ -1629,7 +1629,7 @@ packages:
   license_family: BSD
   size: 13109
   timestamp: 1672387143252
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
   sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
   md5: 248ce515640465371927d46f389ed555
   depends:
@@ -1654,7 +1654,7 @@ packages:
   license_family: BSD
   size: 594054
   timestamp: 1690985006481
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
   sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
   md5: 70db71df4ee1cdd38090c0f7b80ba61f
   depends:
@@ -1664,7 +1664,7 @@ packages:
   license_family: BSD
   size: 21944
   timestamp: 1668160644514
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
   sha256: e61fc626f7131f1857c703ad3bb4dcacfc6b1fd6d5da545aa8f600b840315aca
   md5: 6b689e52e3ba1fa7caaab3e6be31860c
   depends:
@@ -1679,7 +1679,7 @@ packages:
   license_family: MIT
   size: 141434
   timestamp: 1696515497148
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.0-py39h5f9d8c6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.0-py39h5f9d8c6_0.tar.bz2
   sha256: de22d445f66249c5bf5fbef2f4bba81baa0eb13e5050036da9ffacd46b3ee1ea
   md5: 0c454790ce9011e27e597f8b1ce5e769
   depends:
@@ -1696,7 +1696,7 @@ packages:
   license_family: BSD
   size: 9526
   timestamp: 1695832867641
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.0-py39hb5e798b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.0-py39hb5e798b_0.tar.bz2
   sha256: 0f8233bca839fed724ee08cf5cb1bafffd72bd3f588401adb3bf126990d8bf19
   md5: 068fb4b40cd349a7db1d9ed214178ca6
   depends:
@@ -1712,7 +1712,7 @@ packages:
   license_family: BSD
   size: 7858953
   timestamp: 1695832851373
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
   sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
   md5: b0afe23033c8c5344640bc25225fa579
   depends:
@@ -1723,7 +1723,7 @@ packages:
   license: BSD 2-Clause
   size: 516994
   timestamp: 1630084830020
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.11-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.11-h7f8727e_2.tar.bz2
   sha256: 3a01ea7f58c487ee5d30251c089137ad9600dc305a82e09231dd112e19824e71
   md5: 39ef8bbb036d537b1deb7f7ac32ea87e
   depends:
@@ -1733,7 +1733,7 @@ packages:
   license_family: Apache
   size: 5493777
   timestamp: 1695322649929
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
   sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
   md5: 77a22ed6d0d448c5288d0f695bc9ac49
   depends:
@@ -1742,7 +1742,7 @@ packages:
   license_family: Apache
   size: 72527
   timestamp: 1693575234886
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.1.1-py39h1128e8f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-2.1.1-py39h1128e8f_0.tar.bz2
   sha256: 525a877de379651efc20862a77deb470c9c4ff3cfa470d3643c5036de0ec5d17
   md5: dd9fcd456d8fb03daad201cf130d28bd
   depends:
@@ -1790,7 +1790,7 @@ packages:
   license_family: BSD
   size: 14140649
   timestamp: 1697477421901
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.3.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-1.3.1-py39h06a4308_0.tar.bz2
   sha256: a521bbf5ace95000eefefc5b4e6ff599f7607aea6878a5bf61cd58e9232850fc
   md5: 76e793d8f5634ca4d10cbc6c15a84e65
   depends:
@@ -1814,7 +1814,7 @@ packages:
   license_family: BSD
   size: 17121173
   timestamp: 1698867093476
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-2.0.0-py39h06a4308_0.tar.bz2
   sha256: 5ee99045a6225d67f275d2b934e0c406aa18e78606933d3e180884e85ab07755
   md5: e9f0d25cb34c847f93a8269f2b8cc674
   depends:
@@ -1823,7 +1823,7 @@ packages:
   license_family: BSD
   size: 188223
   timestamp: 1698263473172
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
   sha256: db8122fcb6316fb86c2ff6d4dd47154a650ac26d270183a316f14004adf27525
   md5: 33ad46d04664fc8b65a545110e4fe099
   depends:
@@ -1843,7 +1843,7 @@ packages:
   license_family: Other
   size: 764331
   timestamp: 1696580179855
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
   sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
   md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
   depends:
@@ -1854,7 +1854,7 @@ packages:
   license_family: MIT
   size: 2674850
   timestamp: 1697548887851
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
   sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
   md5: fe56f0479dd414c846191116366262c3
   depends:
@@ -1863,7 +1863,7 @@ packages:
   license_family: MIT
   size: 31999
   timestamp: 1692205535111
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
   sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
   md5: 44d2a857d13bdf9d99aaac039a249d47
   depends:
@@ -1872,7 +1872,7 @@ packages:
   license_family: Apache
   size: 91137
   timestamp: 1659455142164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
   sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
   md5: eb899a739d9b58dd747f1f6bd52d4cf3
   depends:
@@ -1884,7 +1884,7 @@ packages:
   license_family: BSD
   size: 579771
   timestamp: 1672387338600
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
   sha256: a760d6c9fca08c09ff0bc9a33946188e2ea5deed2443d4acb360ce55ce36ee43
   md5: 2cb2ad8315f68f4339b9416bd9ab115e
   depends:
@@ -1894,7 +1894,7 @@ packages:
   license_family: BSD
   size: 353437
   timestamp: 1656431352923
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
   sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
   md5: f36ecb722522cbe2e3737424edf1b5e1
   depends:
@@ -1906,7 +1906,7 @@ packages:
   license_family: BSD
   size: 29312
   timestamp: 1675441510984
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
   sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
   md5: 6d03295e544251e608a28c8d7c48115e
   depends:
@@ -1915,7 +1915,7 @@ packages:
   license_family: BSD
   size: 1862058
   timestamp: 1684280096752
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
   sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
   md5: 1f09617aecd6f3c2f2e20692c0759f34
   depends:
@@ -1925,7 +1925,7 @@ packages:
   license_family: Apache
   size: 94434
   timestamp: 1690223520097
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
   sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
   md5: ffceed627867508d73af1636ab5ebf42
   depends:
@@ -1934,7 +1934,7 @@ packages:
   license_family: MIT
   size: 156324
   timestamp: 1661452578573
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
   sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
   md5: 0e3341a4fe434167bf74b613eb6afd81
   depends:
@@ -1944,7 +1944,7 @@ packages:
   license_family: MIT
   size: 97194
   timestamp: 1636110999719
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
   sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
   md5: c5f3f7f10ad30f0945e75252615ab6e5
   depends:
@@ -1953,7 +1953,7 @@ packages:
   license_family: BSD
   size: 31331
   timestamp: 1605305847037
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.18-h955ad1f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.9.18-h955ad1f_0.tar.bz2
   sha256: e9cc8f89dc327997339bedd9961428a13dda3893e3dba46358e73b1fd1ffa37a
   md5: e99f4c3215771cd11de42d30ac8ada47
   depends:
@@ -1974,7 +1974,7 @@ packages:
   license_family: PSF
   size: 26811973
   timestamp: 1694440290734
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
   sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
   md5: 0caa188a695319bdb13f53b0a2b3accc
   depends:
@@ -1983,7 +1983,7 @@ packages:
   license_family: BSD
   size: 264864
   timestamp: 1661371117920
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
   sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
   md5: bcb44ecbea441ee0d4659133d060d71f
   depends:
@@ -1992,7 +1992,7 @@ packages:
   license_family: MIT
   size: 257904
   timestamp: 1695131670290
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
   sha256: e937081facacb141dc2c9cdcced92baa9a2662e4a56100b6041df0b6b7692570
   md5: f3ac39b2349258198a9b3316636fe5d5
   depends:
@@ -2002,7 +2002,7 @@ packages:
   license_family: BSD
   size: 39972
   timestamp: 1685030752528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
   sha256: 2a535f9fdda20b536bd76dfa286fb67a7685ed2be4ad51e2860c44e144c0b457
   md5: 797c263fd5bff62987fc1da076eef0f9
   depends:
@@ -2013,7 +2013,7 @@ packages:
   license_family: MIT
   size: 184040
   timestamp: 1698096132905
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
   sha256: 70ee4fc614dd3337ad542c7c961428930160ab8c7da27775faed5ffddbd362d7
   md5: bf2a4feb20647c569f7ce5a8f63094fa
   depends:
@@ -2025,7 +2025,7 @@ packages:
   license_family: BSD
   size: 515650
   timestamp: 1657724431309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
   sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
   md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
   depends:
@@ -2035,7 +2035,7 @@ packages:
   license_family: GPL
   size: 467661
   timestamp: 1666648052561
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
   sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
   md5: c7de00b4ac2778c4e5a7816320d75391
   depends:
@@ -2051,7 +2051,7 @@ packages:
   license_family: Apache
   size: 94028
   timestamp: 1690400356879
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.11.3-py39h5f9d8c6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/scipy-1.11.3-py39h5f9d8c6_0.tar.bz2
   sha256: 8ddacf409396338156d1a09da3f8f0f3b3b473c679bcfefd2de154f7d8f91344
   md5: 6d6d7ca3d32075d8a57131d589851dd2
   depends:
@@ -2068,7 +2068,7 @@ packages:
   license_family: BSD
   size: 23630389
   timestamp: 1696544992719
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
   sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
   md5: 1581cafc84708ed9aafaaee1cbbf6065
   depends:
@@ -2077,7 +2077,7 @@ packages:
   license_family: MIT
   size: 1089416
   timestamp: 1690290900608
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
   sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
   md5: e19ffbfb24b990275d24fcea2bd1699b
   depends:
@@ -2086,7 +2086,7 @@ packages:
   license_family: Apache
   size: 15702
   timestamp: 1614030498860
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
   sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
   md5: ca061ce25c0f58628643abec8d6a8244
   depends:
@@ -2095,7 +2095,7 @@ packages:
   license_family: MIT
   size: 66330
   timestamp: 1696347637947
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
   sha256: 8b45ba506984fe9c061b4acde6f5243d52dda8c1eae4992f8d80c03f425214fe
   md5: 68c24a824d36a16bbb28d80d70cee8d2
   depends:
@@ -2108,7 +2108,7 @@ packages:
   license_family: Other
   size: 1640317
   timestamp: 1681394746811
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
   sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
   md5: 041a3caf09dc9ce8fc6c10925c4fe050
   depends:
@@ -2118,7 +2118,7 @@ packages:
   license_family: Apache
   size: 1888016
   timestamp: 1680167274961
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
   sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
   md5: 0e76eab58fe488e91f0aee73f46de031
   depends:
@@ -2129,7 +2129,7 @@ packages:
   license_family: BSD
   size: 29816
   timestamp: 1671751864131
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
   sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
   md5: b413a210eca82fe867e991eed085201b
   depends:
@@ -2139,7 +2139,7 @@ packages:
   license_family: BSD
   size: 38882
   timestamp: 1668168876032
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
   sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
   md5: 5b8375e2092012db69d2123dc0c68630
   depends:
@@ -2149,7 +2149,7 @@ packages:
   license_family: BSD
   size: 3485432
   timestamp: 1654088939579
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
   sha256: bd06f7b49d9c04c51c1e825bab446ec3cdde2bce39af00bf113a05c1009595e2
   md5: 587c3f3c891901f4305653e50c18d6c0
   depends:
@@ -2159,7 +2159,7 @@ packages:
   license_family: Apache
   size: 679739
   timestamp: 1696937022519
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
   sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
   md5: 67a8320961ff24e92eebb661536e5cf7
   depends:
@@ -2172,7 +2172,7 @@ packages:
   license_family: MOZILLA
   size: 123763
   timestamp: 1679561904852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
   sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
   md5: 0f0b91a158dd3692cbb7a7763b657bfe
   depends:
@@ -2181,7 +2181,7 @@ packages:
   license_family: BSD
   size: 192032
   timestamp: 1671143995098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
   md5: 8515e64a3de7581360d713fe4c0a094e
   depends:
@@ -2191,7 +2191,7 @@ packages:
   license_family: PSF
   size: 8789
   timestamp: 1690297588156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
   md5: 60170012374b2a5007842fa5870d78c5
   depends:
@@ -2200,7 +2200,7 @@ packages:
   license_family: PSF
   size: 57479
   timestamp: 1690297581658
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py39h06a4308_0.tar.bz2
   sha256: bdafa637d91ee2986a37cc82eb18c7b9b6e467eddd2eac3f510ad878a5b45da2
   md5: 89e6a047e97aa6b06c8a217e64182646
   depends:
@@ -2209,7 +2209,7 @@ packages:
   license_family: MIT
   size: 10729
   timestamp: 1659769510353
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
   sha256: 2f4a5979aaf22660fe9fb8c4ffd41e5a9dc012e20f78e1dbf4ad9c67e0fd28be
   md5: 0be10051dd3d6f31ba52b7c08ba3ba0a
   depends:
@@ -2224,7 +2224,7 @@ packages:
   license_family: MIT
   size: 187469
   timestamp: 1698257600264
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
   sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
   md5: f8d03a15b974fc7810d9f54ae849fc8e
   depends:
@@ -2233,7 +2233,7 @@ packages:
   license_family: BSD
   size: 20781
   timestamp: 1607365390528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
   sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
   md5: d7db5d6ce1db80eade8a082ff78bf479
   depends:
@@ -2243,7 +2243,7 @@ packages:
   license_family: BSD
   size: 71044
   timestamp: 1614804011510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
   sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
   md5: b3899f8bda32734727bd5a73df1d7d17
   depends:
@@ -2252,7 +2252,7 @@ packages:
   license_family: MIT
   size: 101520
   timestamp: 1695742037911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py39h06a4308_1.tar.bz2
   sha256: 8e8d728472d26c1a42345003d69bf381c062db8050d3444a6ccced7e5dcc3524
   md5: dd9bda05830964c550a69b70178ee6f9
   depends:
@@ -2261,7 +2261,7 @@ packages:
   license_family: BSD
   size: 48001
   timestamp: 1675159114742
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
   sha256: 93ca87e697bb9e045fc9cda13b05fe27e1a99f3ed143b75bbcaf4dcb745aa06f
   md5: 3eebbb22c5ca63987db36e1f19cbe872
   depends:
@@ -2270,7 +2270,7 @@ packages:
   license_family: GPL2
   size: 763941
   timestamp: 1683112966413
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -2278,7 +2278,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
   sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
   md5: 567b68192c387b5fc88178425577a0fe
   depends:
@@ -2288,7 +2288,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 366479
   timestamp: 1616055552392
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
   sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
   md5: 3818a9531fe74433c3b7d5144c9a58cc
   depends:
@@ -2297,7 +2297,7 @@ packages:
   license_family: MIT
   size: 18021
   timestamp: 1672387231268
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
   sha256: 2dc9150a95704d83efd39bb9dfb44bdf8419022f4fb0fc416380a922a27c130d
   md5: 4f315d7551f4bbeb06b6fc28342a9aa5
   depends:
@@ -2306,7 +2306,7 @@ packages:
   license_family: Other
   size: 127528
   timestamp: 1666595012798
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
   sha256: aa6aa291bec6aa66e1f063cfa75a9e0fc6bd459fcb45c372aacac9006a073900
   md5: 4e99328768f538f33aecebdae9472744
   depends:
@@ -2319,7 +2319,7 @@ packages:
   license_family: BSD
   size: 1055426
   timestamp: 1681304602537
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -2332,7 +2332,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -2342,7 +2342,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
   md5: b2aa5503875aba2f1d88cae9df9a96d5
   depends:
@@ -2351,7 +2351,7 @@ packages:
   license_family: BSD
   size: 13636
   timestamp: 1611930018941
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -2363,7 +2363,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
   sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
   md5: 544adf2677c47c9b9c891aea720678f1
   depends:
@@ -2371,7 +2371,7 @@ packages:
   license: MIT
   size: 33999
   timestamp: 1630003259346
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -2380,7 +2380,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -2389,7 +2389,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -2398,7 +2398,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -2407,7 +2407,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
   sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
   md5: 9eff1a842dbda8d1bae9a2c008b599bc
   depends:
@@ -2418,7 +2418,7 @@ packages:
   license_family: MIT
   size: 690443
   timestamp: 1625743217109
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -2426,7 +2426,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
   sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
   md5: 33624a42ee387bf9918ea98b4e7b31fc
   depends:
@@ -2436,7 +2436,7 @@ packages:
   license_family: BSD
   size: 8173
   timestamp: 1601490751973
-- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
   sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
   md5: 67857cc5e9044770d2b15f9d94a4521d
   depends:
@@ -2445,7 +2445,7 @@ packages:
   license_family: Apache
   size: 12810
   timestamp: 1600445183315
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -2454,7 +2454,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -2463,7 +2463,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -2473,7 +2473,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
   sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
   md5: e68a6f315f41a8d814d833652bf38b9b
   depends:
@@ -2481,7 +2481,7 @@ packages:
   license: MIT
   size: 13374
   timestamp: 1606932077143
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -2489,7 +2489,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -2498,7 +2498,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -2507,7 +2507,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
   sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
   md5: 2eb923cc014094f4acf7f849d67d73f8
   depends:
@@ -2517,7 +2517,7 @@ packages:
   license_family: BSD
   size: 246457
   timestamp: 1626374695070
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
   sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
   md5: 02caf3f47f1d06256068053297355740
   depends:
@@ -2526,7 +2526,7 @@ packages:
   license_family: Apache
   size: 152292
   timestamp: 1690578151230
-- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
   sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
   md5: 41db68b96e114e367c4f120a3b379e59
   depends:
@@ -2535,7 +2535,7 @@ packages:
   license_family: BSD
   size: 19391
   timestamp: 1632406728844
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -2544,7 +2544,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -2556,14 +2556,14 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
   sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
   md5: a815d3bdb160bcc71687f2dda70d3ca4
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 122218
   timestamp: 1680170368293
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -2571,7 +2571,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
   sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
   md5: 447a49f7bad119faa80d7f14aa296c95
   depends:
@@ -2584,7 +2584,7 @@ packages:
   license_family: MIT
   size: 162176
   timestamp: 1644481750133
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
   sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
   md5: 8810f48fe4a4792de0fd3520b502d08b
   depends:
@@ -2593,7 +2593,7 @@ packages:
   license_family: BSD
   size: 10019
   timestamp: 1606859473259
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
   sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
   md5: 00a446b6dfc61af223df4de29fe8ad94
   depends:
@@ -2603,7 +2603,7 @@ packages:
   license_family: MIT
   size: 34305
   timestamp: 1644569782044
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
   sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
   md5: bd92dd8bd5b9d24e632b62a075426e50
   depends:
@@ -2612,7 +2612,7 @@ packages:
   license_family: MIT
   size: 133634
   timestamp: 1695718025321
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
   sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
   md5: f8ae051b591a9027adc16de1be9748f4
   depends:
@@ -2622,12 +2622,12 @@ packages:
   license_family: MIT
   size: 206198
   timestamp: 1681493096349
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
   sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
   md5: e2f3248e2a5009a02f7b8e54f83314ef
   size: 5620
   timestamp: 1528121955725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
   sha256: 2936241747f6cc0f0b3afa53bb28ad6f658b53a0fc2e67a5ed34d1d5e2cce117
   md5: bdca1b691340964271d9cfec6baaf8d0
   depends:
@@ -2645,7 +2645,7 @@ packages:
   license_family: BSD
   size: 5719952
   timestamp: 1697490515691
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
   sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
   md5: 0d79760d544d0bd8acb4adc4ef813418
   depends:
@@ -2655,7 +2655,7 @@ packages:
   license_family: BSD
   size: 137075
   timestamp: 1657175654487
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
   sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
   md5: 31d6d04cd2388d8f19004501271b3545
   depends:
@@ -2665,7 +2665,7 @@ packages:
   license: MIT
   size: 18982
   timestamp: 1659616229395
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
   sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
   md5: caf1073dc2ca5aeb832a2877394eae12
   depends:
@@ -2674,7 +2674,7 @@ packages:
   license: MIT
   size: 18233
   timestamp: 1659616216769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
   sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
   md5: aa1ed20c38af535c8d6a955314759d7b
   depends:
@@ -2683,14 +2683,14 @@ packages:
   license: MIT
   size: 394588
   timestamp: 1659616312678
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
   sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
   md5: ce3588e31faa79f546e0fc6a36c5543c
   license: MPL-2.0
   license_family: Other
   size: 133884
   timestamp: 1694009771475
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
   sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
   md5: 21eb7f53076d0a69513cfd258f6ef63c
   depends:
@@ -2699,7 +2699,7 @@ packages:
   license_family: Other
   size: 159756
   timestamp: 1690232346868
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
   sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
   md5: a40a04d9cda1e665565bc6c832d598b6
   depends:
@@ -2710,7 +2710,7 @@ packages:
   license_family: MIT
   size: 225258
   timestamp: 1670423337502
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
   sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
   md5: b2cc5f37f7bb069d061306e7eac2a011
   depends:
@@ -2720,7 +2720,7 @@ packages:
   license_family: CC
   size: 1913396
   timestamp: 1668084575248
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
   sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
   md5: 103d8c039e342115720a84d59c119d46
   depends:
@@ -2730,7 +2730,7 @@ packages:
   license_family: BSD
   size: 13774
   timestamp: 1671231190250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
   sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
   md5: f69f09e0346172f225390d2b3b0d7873
   depends:
@@ -2741,7 +2741,7 @@ packages:
   license_family: BSD
   size: 246628
   timestamp: 1663827484947
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
   sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
   md5: cb80c7ac65b48a737654f371fe31c460
   depends:
@@ -2754,7 +2754,7 @@ packages:
   license_family: BSD
   size: 1307228
   timestamp: 1694212041712
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
   sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
   md5: 04cbe8f4bc62c34fac9d42d1124059bf
   depends:
@@ -2764,7 +2764,7 @@ packages:
   license_family: MIT
   size: 2052734
   timestamp: 1690905361158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
   sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
   md5: ef0e825982f242085574f502dfff4f6b
   depends:
@@ -2773,7 +2773,7 @@ packages:
   license_family: MIT
   size: 16594
   timestamp: 1649926538106
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
   sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
   md5: 24747a300246c016b3a7f04dabd02d4a
   depends:
@@ -2782,7 +2782,7 @@ packages:
   license_family: BSD
   size: 27709
   timestamp: 1668714497209
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -2792,14 +2792,14 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
   sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
   md5: e4a732941f74b8062c8bcbfe5c5c2b56
   license: MIT
   license_family: MIT
   size: 80252
   timestamp: 1676983220161
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
   sha256: 5c36d43cadbbf944d9255e79df85c2e9e6155a1d6f9158e06fcd8ffd458b7663
   md5: a5a2cff387403ccf9cf58aac7a6dde55
   depends:
@@ -2816,7 +2816,7 @@ packages:
   license_family: BSD
   size: 4573879
   timestamp: 1698866750755
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.9.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/hvplot-0.9.0-py39hecd8cb5_0.tar.bz2
   sha256: 80f22084b7a306946e7bc7756d289703255d3760ff7c23f9b6193bf294feac10
   md5: a6e68eab5b8d73a9048c89189f2a9f21
   depends:
@@ -2833,7 +2833,7 @@ packages:
   license_family: BSD
   size: 3339771
   timestamp: 1697559946138
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
   sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
   md5: f3ce6fe6eb760c236e5f7d04df5faa81
   depends:
@@ -2842,7 +2842,7 @@ packages:
   license_family: MIT
   size: 28138484
   timestamp: 1692293212596
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
   sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
   md5: 6dd72c43fea25b748ec7a9f6c0407e15
   depends:
@@ -2851,7 +2851,7 @@ packages:
   license_family: BSD
   size: 111810
   timestamp: 1666125671024
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
   sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
   md5: 03cdb7e679924b329ecab8f12cb8fc67
   depends:
@@ -2861,7 +2861,7 @@ packages:
   license_family: APACHE
   size: 38813
   timestamp: 1678997212422
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
   sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
   md5: e113c4e6e758dd68faf196586bf5564d
   depends:
@@ -2871,7 +2871,7 @@ packages:
   license_family: Apache
   size: 51873
   timestamp: 1698254765815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
   sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
   md5: 78baea934985ccd9514a366cc7e80ed4
   depends:
@@ -2880,7 +2880,7 @@ packages:
   license_family: Proprietary
   size: 727499
   timestamp: 1681801225190
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
   sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
   md5: da9b63e42f281f7e77b289f4b654b83b
   depends:
@@ -2902,7 +2902,7 @@ packages:
   license_family: BSD
   size: 218436
   timestamp: 1691121840155
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
   sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
   md5: 6a7cb9b49593b29933fa2b503d533a08
   depends:
@@ -2924,7 +2924,7 @@ packages:
   license_family: BSD
   size: 1257205
   timestamp: 1694181720454
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
   sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
   md5: d861ef66f5c0a282d60b65778a9de2f3
   depends:
@@ -2934,7 +2934,7 @@ packages:
   license_family: MIT
   size: 1048450
   timestamp: 1644315332508
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
   sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
   md5: f7e603c965052deed8b789c35855a42f
   depends:
@@ -2944,14 +2944,14 @@ packages:
   license_family: BSD
   size: 213537
   timestamp: 1666908270815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
   sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
   md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
   license: IJG
   license_family: Other
   size: 278924
   timestamp: 1677849185191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
   sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
   md5: a82a17e78f725dcbd71ff8dac6db05c7
   depends:
@@ -2962,7 +2962,7 @@ packages:
   license_family: MIT
   size: 133134
   timestamp: 1676558895333
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
   sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
   md5: ee9270379a9ebdb6297e4b6849b3f7f0
   depends:
@@ -2978,7 +2978,7 @@ packages:
   license_family: BSD
   size: 195479
   timestamp: 1676329410154
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 32b898a97dca7770858ab31294238fde11ab61a84831a52f320e5ee5405a147c
   md5: 926e754b8fad288b583ef2933deae1a5
   depends:
@@ -2989,7 +2989,7 @@ packages:
   license_family: BSD
   size: 92938
   timestamp: 1679906616072
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
   sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
   md5: 7e60995b3119417213e5faedda147499
   depends:
@@ -3013,7 +3013,7 @@ packages:
   license_family: BSD
   size: 403165
   timestamp: 1671707664990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
   sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
   md5: cd470bdb28bb0e8b3535c93a3a6dad07
   depends:
@@ -3023,7 +3023,7 @@ packages:
   license_family: BSD
   size: 65431
   timestamp: 1672387389172
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -3033,7 +3033,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -3042,13 +3042,13 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
   sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
   md5: 7dba7aa5b971febb55281659843586ba
   license: MIT
   size: 65470
   timestamp: 1659616172703
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
   sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
   md5: f78a158983f0bbaba56f34b976bc6dae
   depends:
@@ -3056,7 +3056,7 @@ packages:
   license: MIT
   size: 34189
   timestamp: 1659616189313
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
   sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
   md5: 36a1d885725d3ab4d1fadc5a29f978d2
   depends:
@@ -3064,28 +3064,28 @@ packages:
   license: MIT
   size: 327737
   timestamp: 1659616202869
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
   sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
   md5: 817848d0e2b2808acdc9b3fbbf581726
   license: MIT
   license_family: MIT
   size: 133887
   timestamp: 1683716590737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
   sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
   md5: e458587c87e3f2d20192f4e0738f2c63
   depends:
@@ -3094,7 +3094,7 @@ packages:
   license_family: GPL
   size: 149419
   timestamp: 1665498987619
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
   sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
   md5: 1058b661ec829b2ee3716ee2a5520641
   depends:
@@ -3105,14 +3105,14 @@ packages:
   license_family: GPL
   size: 1917987
   timestamp: 1665498925405
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
   sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
   md5: c90372428e1e4eed4fdcd790979d06b4
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1409377
   timestamp: 1650983531933
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -3121,13 +3121,13 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -3144,7 +3144,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
   sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
   md5: c0b99f8e1c7475f23b1c7b4250b06e1c
   depends:
@@ -3158,7 +3158,7 @@ packages:
   license_family: BSD
   size: 88021
   timestamp: 1694778290062
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
   sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
   md5: 46a65d1fc24013217e06aaf6d65ffcad
   constrains:
@@ -3167,7 +3167,7 @@ packages:
   license_family: BSD
   size: 425478
   timestamp: 1694776947990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
   sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
   md5: 06866415ef22d5322f9bdc9956b59c4d
   depends:
@@ -3179,7 +3179,7 @@ packages:
   license_family: MIT
   size: 678174
   timestamp: 1692970318885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
   sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
   md5: 2edc6c894d6d0321304396e9bd40df94
   depends:
@@ -3189,7 +3189,7 @@ packages:
   license_family: MIT
   size: 241774
   timestamp: 1692973618934
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 0190d3b8d2939f28aa017711cf4147c51a1139da2922cc8420a71562dd99f844
   md5: 454a7f2c4426453f17e995382a4235e4
   depends:
@@ -3199,7 +3199,7 @@ packages:
   license_family: MIT
   size: 36036
   timestamp: 1659783508187
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
   sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
   md5: 5c740b4a18a558de0ccfe601703c423c
   constrains:
@@ -3208,7 +3208,7 @@ packages:
   license_family: Apache
   size: 338738
   timestamp: 1662635677689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
   sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
   md5: 8bbd981ca0129d7beeacd3cd7623f714
   depends:
@@ -3219,7 +3219,7 @@ packages:
   license_family: Other
   size: 1491074
   timestamp: 1695058597986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
   sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
   md5: d5f58d056b4bfc67aec30c77035ba889
   depends:
@@ -3228,7 +3228,7 @@ packages:
   license_family: BSD
   size: 182491
   timestamp: 1670944720979
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
   sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
   md5: 1affd16b166571a91feae04baf5fd3da
   depends:
@@ -3238,7 +3238,7 @@ packages:
   license_family: BSD
   size: 123431
   timestamp: 1671542016019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
   sha256: e5fc51472fa0f36abd78baa5b3c9245d6627b0da11188e6a954d73f3f2bca210
   md5: df7c519447affffb594f8c56b028ed33
   depends:
@@ -3248,7 +3248,7 @@ packages:
   license_family: MIT
   size: 107035
   timestamp: 1684279974102
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
   sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
   md5: 3681ebf029211ceab26af6f5d35abf39
   depends:
@@ -3259,7 +3259,7 @@ packages:
   license_family: BSD
   size: 22254
   timestamp: 1654598220251
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
   sha256: 2fd179efa024c92d0d71179a981a781d16c70f5d8c6305e0d678b0c7ae1275ab
   md5: addda7f015d1673f794a23fdb18a3e09
   depends:
@@ -3282,7 +3282,7 @@ packages:
   license_family: PSF
   size: 8182219
   timestamp: 1698692361219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
   sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
   md5: 6eb64ecfcd754502e271db0bb51d2cfd
   depends:
@@ -3292,7 +3292,7 @@ packages:
   license_family: BSD
   size: 17374
   timestamp: 1662014643620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 2312ee5a6343e8495802698d7181f1b619aad7479d96ee253407b324ac884417
   md5: 866960fa48a7ca335941786d4869802a
   depends:
@@ -3302,7 +3302,7 @@ packages:
   license_family: MIT
   size: 53542
   timestamp: 1659721365599
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
   sha256: 37f455814ce242eb65ff80a0402f1bd231a388e6823e6c1e65f60b705c032a2d
   md5: 4c9246c492a64729225aa5b04e12c2d1
   depends:
@@ -3311,7 +3311,7 @@ packages:
   license_family: MIT
   size: 19573
   timestamp: 1659716100178
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
   sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
   md5: 2a4d604717a647ad21af766289cbbfc3
   depends:
@@ -3320,7 +3320,7 @@ packages:
   license_family: BSD
   size: 58057
   timestamp: 1607364912348
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
   sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
   md5: 25051fe272624544652dc6d814c2943a
   depends:
@@ -3333,7 +3333,7 @@ packages:
   license_family: Proprietary
   size: 224420228
   timestamp: 1691503125614
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
   sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
   md5: 37d8cf85a63f7aa9af1624894a7d606d
   depends:
@@ -3343,7 +3343,7 @@ packages:
   license_family: BSD
   size: 48590
   timestamp: 1682969183093
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
   sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
   md5: 0b2aee6666135bbd36b46d6ac66160f7
   depends:
@@ -3356,7 +3356,7 @@ packages:
   license_family: BSD
   size: 210705
   timestamp: 1695058433223
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
   sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
   md5: e22fb55ce380d0ebd44cce3f20d5349e
   depends:
@@ -3370,7 +3370,7 @@ packages:
   license_family: BSD
   size: 296614
   timestamp: 1695060155673
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
   sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
   md5: 1a5d4004e64e3cfb7a2a297b9117c285
   depends:
@@ -3396,7 +3396,7 @@ packages:
   license_family: BSD
   size: 8213832
   timestamp: 1681756573646
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.5.13-py39hecd8cb5_0.tar.bz2
   sha256: 2975bd1f98ca9ec7354ee378f86f8322ec90f568374776fd90e80c534fbee882
   md5: 798627089e0ccba26695a26d9cb127ec
   depends:
@@ -3409,7 +3409,7 @@ packages:
   license_family: BSD
   size: 99066
   timestamp: 1650308465824
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
   sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
   md5: e572c1264a7af20b486f64ac8c9e1f57
   depends:
@@ -3437,7 +3437,7 @@ packages:
   license_family: BSD
   size: 573356
   timestamp: 1668450732828
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
   sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
   md5: b67569a7c30af9ffa5cde6e4b52ac68b
   depends:
@@ -3450,14 +3450,14 @@ packages:
   license_family: BSD
   size: 148342
   timestamp: 1694616917184
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
   sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
   md5: 97b81f34efbe86c5220fe82eb584fd62
   depends:
@@ -3466,7 +3466,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387288528
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
   sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
   md5: d77862975a9a1cf50acb803be26e83a1
   depends:
@@ -3491,7 +3491,7 @@ packages:
   license_family: BSD
   size: 575365
   timestamp: 1690985052739
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
   sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
   md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
   depends:
@@ -3501,7 +3501,7 @@ packages:
   license_family: BSD
   size: 22858
   timestamp: 1668160618784
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
   sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
   md5: 185e9c41abb88ee59b52ec0f5f65d506
   depends:
@@ -3515,7 +3515,7 @@ packages:
   license_family: MIT
   size: 138305
   timestamp: 1696515469702
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
   sha256: 82a2dd0c2ff6e20a275e5447dd03088f79694f7bfa5055a25c54bebf31aac4ca
   md5: c157e6ab469a95b06fa822ba075978b3
   depends:
@@ -3531,7 +3531,7 @@ packages:
   license_family: BSD
   size: 10376
   timestamp: 1695831243158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
   sha256: b3a003b41cec2751210e542911e99437db0321542f6812c1b88608ef720ba7ef
   md5: 56400dfe88c427cdf1854e47666b8a99
   depends:
@@ -3546,7 +3546,7 @@ packages:
   license_family: BSD
   size: 7570900
   timestamp: 1695831208653
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
   sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
   md5: 93f5d7b66976154adeda219bea02ba45
   depends:
@@ -3556,7 +3556,7 @@ packages:
   license: BSD 2-Clause
   size: 484257
   timestamp: 1630093862501
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
   sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
   md5: 5e8713ef1215406254988163eaf34020
   depends:
@@ -3565,7 +3565,7 @@ packages:
   license_family: Apache
   size: 4965606
   timestamp: 1695323060401
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
   sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
   md5: 4154929ace2ad6ee16aea815635a6d1f
   depends:
@@ -3574,7 +3574,7 @@ packages:
   license_family: Apache
   size: 73598
   timestamp: 1693575307570
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
   sha256: aff5acedef9da91b77851e1a163b8319d72bc4152c98ac87703a2eac1e5d575b
   md5: 7df4c76aa8c52fedce5346748d56459e
   depends:
@@ -3621,7 +3621,7 @@ packages:
   license_family: BSD
   size: 13388063
   timestamp: 1697477404222
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
   sha256: 42d83288119306089a06e853a37045fbb9860548b05a1e79d223f7ecf1cb349d
   md5: 8daced11264159ff57df7bba4d0b2ec7
   depends:
@@ -3645,7 +3645,7 @@ packages:
   license_family: BSD
   size: 17075803
   timestamp: 1698867397009
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
   sha256: ad7ca92e5c83a8e2181677025509ed7b8f566ec23b24f28316fa087bb591c11f
   md5: a4ccd0fbcfb26de868f2fb4836940d7a
   depends:
@@ -3654,7 +3654,7 @@ packages:
   license_family: BSD
   size: 189263
   timestamp: 1698263570990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
   sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
   md5: be0a90921f3bf4f0d6950fb786093de7
   depends:
@@ -3673,7 +3673,7 @@ packages:
   license_family: Other
   size: 719901
   timestamp: 1696580194417
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
   sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
   md5: 81ae9ec2d7fcf6934847bff558b619f5
   depends:
@@ -3684,7 +3684,7 @@ packages:
   license_family: MIT
   size: 2672987
   timestamp: 1697548890181
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
   sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
   md5: 1a822c206e2abddc5d6d821721af227f
   depends:
@@ -3693,7 +3693,7 @@ packages:
   license_family: MIT
   size: 33013
   timestamp: 1692205801265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
   sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
   md5: 1604d33dbdb2446c642970f8b354bedb
   depends:
@@ -3702,7 +3702,7 @@ packages:
   license_family: Apache
   size: 91266
   timestamp: 1659455269141
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
   sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
   md5: d1b3bcc35655a3123acb1fa2ad1a8511
   depends:
@@ -3714,7 +3714,7 @@ packages:
   license_family: BSD
   size: 580828
   timestamp: 1672387372015
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
   sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
   md5: 7540555d1fb192236db9a7c5c9d3601c
   depends:
@@ -3723,7 +3723,7 @@ packages:
   license_family: BSD
   size: 365765
   timestamp: 1656431373327
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
   sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
   md5: 0a73533fb6e0dc717ab906a537bc747d
   depends:
@@ -3735,7 +3735,7 @@ packages:
   license_family: BSD
   size: 30803
   timestamp: 1675441638631
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
   sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
   md5: 0a959fbad46ab38ade48dbd358002674
   depends:
@@ -3744,7 +3744,7 @@ packages:
   license_family: BSD
   size: 1864757
   timestamp: 1684280094736
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
   sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
   md5: ea24b5076ef79e4567c5a3f0cb22b470
   depends:
@@ -3754,7 +3754,7 @@ packages:
   license_family: Apache
   size: 95330
   timestamp: 1690223465114
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
   sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
   md5: bcaea6d4a47e9c874becaa700c78dcf7
   depends:
@@ -3763,7 +3763,7 @@ packages:
   license_family: MIT
   size: 157216
   timestamp: 1661452617825
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
   sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
   md5: 707110d1b49cb1864acb0bbaa103591e
   depends:
@@ -3772,7 +3772,7 @@ packages:
   license_family: MIT
   size: 95016
   timestamp: 1636111184034
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
   sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
   md5: 113a443b9c706f9f9c6187c0eaa3de27
   depends:
@@ -3781,7 +3781,7 @@ packages:
   license_family: BSD
   size: 31178
   timestamp: 1605305861851
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
   sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
   md5: 85a8d0001db70e52a479155228cb1fe0
   depends:
@@ -3800,7 +3800,7 @@ packages:
   license_family: PSF
   size: 13324979
   timestamp: 1694439878265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
   sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
   md5: 47c5e22e31ec05a7bc0ce90065a53afd
   depends:
@@ -3809,7 +3809,7 @@ packages:
   license_family: BSD
   size: 265348
   timestamp: 1661368839620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
   sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
   md5: ce9a69e1668aa1e133f2aa6d4e8d346f
   depends:
@@ -3818,7 +3818,7 @@ packages:
   license_family: MIT
   size: 254958
   timestamp: 1695131709704
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 9ee098c09f31fad7ff1856e5ce2619172eaf979997e7a427d1e05cce32c2af00
   md5: cac1d1898b69ae9646dfbf082910635d
   depends:
@@ -3828,7 +3828,7 @@ packages:
   license_family: BSD
   size: 40946
   timestamp: 1685030787453
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
   sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
   md5: 637f08b19dd8fd87347d8c44f9e3e202
   depends:
@@ -3838,7 +3838,7 @@ packages:
   license_family: MIT
   size: 170776
   timestamp: 1698096100056
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
   sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
   md5: 8ce3ac7d8a04e469b566f1b090d01140
   depends:
@@ -3849,7 +3849,7 @@ packages:
   license_family: BSD
   size: 470617
   timestamp: 1657724324011
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -3858,7 +3858,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
   sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
   md5: 6f2d41dd76a03b7f85a1ed49af1763d6
   depends:
@@ -3874,7 +3874,7 @@ packages:
   license_family: Apache
   size: 95100
   timestamp: 1690400262627
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
   sha256: a9755ecbfd42c708945027facfa11a3dc3119778326a0ae5df79f80d7b72afa5
   md5: 839ffa4e775fee9a8bdddabf4a14da43
   depends:
@@ -3891,7 +3891,7 @@ packages:
   license_family: BSD
   size: 24331914
   timestamp: 1696545397632
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
   md5: b0321e6f14e139fc15b1f8b4acb35d2f
   depends:
@@ -3900,7 +3900,7 @@ packages:
   license_family: MIT
   size: 1093966
   timestamp: 1690290944588
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
   sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
   md5: 62b64576a0aa5f6c3fb05f56650d25e1
   depends:
@@ -3909,7 +3909,7 @@ packages:
   license_family: Apache
   size: 15535
   timestamp: 1614030509324
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
   sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
   md5: 15b5595b31e39f08eaacbe2e502d8fb3
   depends:
@@ -3918,7 +3918,7 @@ packages:
   license_family: MIT
   size: 67292
   timestamp: 1696347733587
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
   sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
   md5: 82e4db6a498480a75d53c55bd35b6478
   depends:
@@ -3930,7 +3930,7 @@ packages:
   license_family: Other
   size: 1801397
   timestamp: 1681394807900
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -3939,7 +3939,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
   sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
   md5: 63b957927b9949ccb19da28ec4612706
   depends:
@@ -3950,7 +3950,7 @@ packages:
   license_family: BSD
   size: 30902
   timestamp: 1671751919031
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
   sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
   md5: e346257a2fa8e2cb48c762138a5d009b
   depends:
@@ -3960,7 +3960,7 @@ packages:
   license_family: BSD
   size: 39915
   timestamp: 1668168959656
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
   sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
   md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
   depends:
@@ -3969,7 +3969,7 @@ packages:
   license_family: BSD
   size: 3536231
   timestamp: 1654088937695
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
   sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
   md5: a1bbf0abfb8c45541122c0eb2feee317
   depends:
@@ -3978,7 +3978,7 @@ packages:
   license_family: Apache
   size: 680464
   timestamp: 1696937112175
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
   sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
   md5: d689f6203c0a9d04fb229c73d7e80a7a
   depends:
@@ -3991,7 +3991,7 @@ packages:
   license_family: MOZILLA
   size: 125145
   timestamp: 1679561909274
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
   md5: 8a292c1ee22489bef2e84bc3aaf4098e
   depends:
@@ -4000,7 +4000,7 @@ packages:
   license_family: BSD
   size: 193141
   timestamp: 1671143985219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
   md5: 8bf0bfffc11ad06a1c94e145941b0ad4
   depends:
@@ -4010,7 +4010,7 @@ packages:
   license_family: PSF
   size: 9651
   timestamp: 1690297655669
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
   md5: 343514a174b3485fde55a73f56398dd7
   depends:
@@ -4019,7 +4019,7 @@ packages:
   license_family: PSF
   size: 58456
   timestamp: 1690297648002
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
   sha256: 11e7401cb6805db7ce22b1f9dd6ba5b7941c92225ce440bed1da0af284bfcad4
   md5: 5c10d68fa5616cdd82ee93ef6e0f038c
   depends:
@@ -4028,7 +4028,7 @@ packages:
   license_family: MIT
   size: 11615
   timestamp: 1659769478980
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
   sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
   md5: c2242e8fd24003a74ddf37416661e06d
   depends:
@@ -4043,7 +4043,7 @@ packages:
   license_family: MIT
   size: 188757
   timestamp: 1698257668273
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
   sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
   md5: 41f445e36b6b6722a9444508eef069f8
   depends:
@@ -4052,7 +4052,7 @@ packages:
   license_family: BSD
   size: 20583
   timestamp: 1607365395045
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
   sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
   md5: 409ee46ed24267b6da6fb32d13e1f21e
   depends:
@@ -4062,7 +4062,7 @@ packages:
   license_family: BSD
   size: 70730
   timestamp: 1614804271285
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
   sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
   md5: eb74e74d8e4fd533c55eb98b7b5e83bc
   depends:
@@ -4071,7 +4071,7 @@ packages:
   license_family: MIT
   size: 102637
   timestamp: 1695742077778
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
   sha256: cb007615819fd240ea4e343835dfbda3c508a92b5b7158219d30a22d0e67b57c
   md5: bf215e781ac81e0fc433eedee330c54b
   depends:
@@ -4080,20 +4080,20 @@ packages:
   license_family: BSD
   size: 49462
   timestamp: 1675159191191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
   sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
   md5: e243baa546432c8394a8059a44a5a3e4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 419227
   timestamp: 1683113010463
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
   sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
   md5: fe4ac85ee86d3a94ea3a4ebea3779763
   depends:
@@ -4102,7 +4102,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 321797
   timestamp: 1616055526986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
   sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
   md5: bc7073d9d4c0211cc4a1207c98fb765a
   depends:
@@ -4111,14 +4111,14 @@ packages:
   license_family: MIT
   size: 19091
   timestamp: 1672387204865
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
   sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
   md5: 8e495591e369ac161857a72011c0a296
   license: Zlib
   license_family: Other
   size: 120272
   timestamp: 1666595024203
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
   sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
   md5: f1465fbd810b3746c6de6babfd4fe28a
   depends:
@@ -4130,7 +4130,7 @@ packages:
   license_family: BSD
   size: 1023573
   timestamp: 1681304595869
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
   sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
   md5: cf55cb8d7031b30c70c56fc7c782b5c7
   depends:
@@ -4143,7 +4143,7 @@ packages:
   license_family: MIT
   size: 156104
   timestamp: 1644482799136
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
   sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
   md5: 84fce327d9f0d594e86f565e5c21962e
   depends:
@@ -4152,7 +4152,7 @@ packages:
   license_family: BSD
   size: 10183
   timestamp: 1629146082730
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
   sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
   md5: 84b8b998a741b37abf5312c1c03696ef
   depends:
@@ -4162,7 +4162,7 @@ packages:
   license_family: MIT
   size: 33979
   timestamp: 1644845817952
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
   sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
   md5: 77b746931c8f31c3ae393ccb5819d43d
   depends:
@@ -4171,7 +4171,7 @@ packages:
   license_family: MIT
   size: 133628
   timestamp: 1695717890677
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
   sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
   md5: 3df6e8ba34208dea068890e5d5318cc0
   depends:
@@ -4181,12 +4181,12 @@ packages:
   license_family: MIT
   size: 206759
   timestamp: 1681493095987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
   sha256: 8c31e7ede4b9a3ec6e1342f02bcff4d7113e5b25f12b91d108616a08eb8eb34f
   md5: de3ce22af040eb01db773fcab23ef413
   depends:
@@ -4204,7 +4204,7 @@ packages:
   license_family: BSD
   size: 5722206
   timestamp: 1697490482051
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
   sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
   md5: bb55f81435cb6e11d264242274fccd1a
   depends:
@@ -4214,7 +4214,7 @@ packages:
   license_family: BSD
   size: 115947
   timestamp: 1657175645380
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
   md5: f860193e14afc7ef3f5b990a2ac003d2
   depends:
@@ -4224,7 +4224,7 @@ packages:
   license: MIT
   size: 18936
   timestamp: 1659616204016
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
   sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
   md5: ad53130f3fd1f8d3c2fcbb7496e5585d
   depends:
@@ -4233,7 +4233,7 @@ packages:
   license: MIT
   size: 18715
   timestamp: 1659616188888
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
   sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
   md5: 0982c046fb976e9f9fb19e7510187a18
   depends:
@@ -4242,14 +4242,14 @@ packages:
   license: MIT
   size: 366983
   timestamp: 1659616245272
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
   sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
   md5: 31ac2f5596cb7a44adf073c930641c54
   license: MPL-2.0
   license_family: Other
   size: 133817
   timestamp: 1694009762858
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
   sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
   md5: cf1f6c3c34a1e1b9ab22b04233d860f6
   depends:
@@ -4258,7 +4258,7 @@ packages:
   license_family: Other
   size: 159783
   timestamp: 1690232303987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
   sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
   md5: 0eb268e38b5174d471a6e87d9d6102b1
   depends:
@@ -4269,7 +4269,7 @@ packages:
   license_family: MIT
   size: 225355
   timestamp: 1670423312966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
   sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
   md5: e68c94666cd60221b575c3814c89bac0
   depends:
@@ -4279,7 +4279,7 @@ packages:
   license_family: CC
   size: 1946451
   timestamp: 1668084573824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
   sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
   md5: 1773ae2b080cdd55827e27673351551e
   depends:
@@ -4289,7 +4289,7 @@ packages:
   license_family: BSD
   size: 13646
   timestamp: 1671231171682
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
   sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
   md5: 53bfd99ad1b09164d537209cffd98161
   depends:
@@ -4300,7 +4300,7 @@ packages:
   license_family: BSD
   size: 244040
   timestamp: 1663827469853
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
   sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
   md5: b62455043c8eb2434466885b19fed2de
   depends:
@@ -4313,7 +4313,7 @@ packages:
   license_family: BSD
   size: 1399573
   timestamp: 1694211828228
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
   sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
   md5: eb3cdc0fc210838b9271512a6a1b7c85
   depends:
@@ -4323,7 +4323,7 @@ packages:
   license_family: MIT
   size: 2067708
   timestamp: 1690905319109
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
   sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
   md5: f44b80b9405410e5bde6bfe0b31d5b3f
   depends:
@@ -4332,7 +4332,7 @@ packages:
   license_family: MIT
   size: 15135
   timestamp: 1650293774207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
   sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
   md5: f87027ccce1361d0f82c0edf1a10d53b
   depends:
@@ -4341,7 +4341,7 @@ packages:
   license_family: BSD
   size: 27677
   timestamp: 1668714367519
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -4351,14 +4351,14 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
   sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
   md5: 1d0bd7e576c64c059ef781dd319ad82a
   license: MIT
   license_family: MIT
   size: 77591
   timestamp: 1676983230102
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
   sha256: 3e480af22e98246c056bbd91d6be5352df34ff2b8451d9c7f614baeafb450d39
   md5: 695fe7ccaf6935d3117533d1e6737320
   depends:
@@ -4375,7 +4375,7 @@ packages:
   license_family: BSD
   size: 4542265
   timestamp: 1698866834303
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.9.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/hvplot-0.9.0-py39hca03da5_0.tar.bz2
   sha256: 519ed44b20355e914a87c6e6ecfcc6ac47b088b52223d64a052f73d98d5464a9
   md5: 792b62dde64917556bdc4ba7b822c7ae
   depends:
@@ -4392,7 +4392,7 @@ packages:
   license_family: BSD
   size: 3339433
   timestamp: 1697560078781
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
   sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
   md5: 69eb3b03765627b6159ed23cdde78396
   depends:
@@ -4401,7 +4401,7 @@ packages:
   license_family: MIT
   size: 28399065
   timestamp: 1692293207812
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
   sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
   md5: 83366cbd3beb073112f4644a613b6bca
   depends:
@@ -4410,7 +4410,7 @@ packages:
   license_family: BSD
   size: 111933
   timestamp: 1666125627512
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
   sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
   md5: 647c1a2f8460ffa8c670a1915bbdb494
   depends:
@@ -4420,7 +4420,7 @@ packages:
   license_family: APACHE
   size: 38790
   timestamp: 1678997152549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
   sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
   md5: 35e541905426c686ef2ff010a0e502fd
   depends:
@@ -4430,7 +4430,7 @@ packages:
   license_family: Apache
   size: 51860
   timestamp: 1698254731870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
   sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
   md5: 187d7720aedf38759d122cccb4576f2c
   depends:
@@ -4452,7 +4452,7 @@ packages:
   license_family: BSD
   size: 219976
   timestamp: 1691121991680
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
   sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
   md5: e8e7f10741f9cfa737b310b334940441
   depends:
@@ -4474,7 +4474,7 @@ packages:
   license_family: BSD
   size: 1255894
   timestamp: 1694181494549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
   sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
   md5: ff209e75aee17af2e358b0008fbe8c88
   depends:
@@ -4484,7 +4484,7 @@ packages:
   license_family: MIT
   size: 1022945
   timestamp: 1644315931223
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
   sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
   md5: d3e78ef296b3c74910d003bd10b475d6
   depends:
@@ -4494,14 +4494,14 @@ packages:
   license_family: BSD
   size: 213972
   timestamp: 1666908195870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
   sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
   md5: 055e12390b844ea6c6e956ee08a618e8
   license: IJG
   license_family: Other
   size: 273479
   timestamp: 1677849171867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
   sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
   md5: 783e2ad3d36472648c5ccc9f3051db3c
   depends:
@@ -4512,7 +4512,7 @@ packages:
   license_family: MIT
   size: 133077
   timestamp: 1676558732505
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
   sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
   md5: 0677598f673f9729b5990316170a999d
   depends:
@@ -4528,7 +4528,7 @@ packages:
   license_family: BSD
   size: 197129
   timestamp: 1676329661580
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.3.0-py39hca03da5_0.tar.bz2
   sha256: 05f9ca0fdcfdc2e217438be27fead588c843a3aadf7d034467c83216d1e5c214
   md5: 2d648b77d817ba38293c0728711ba8f5
   depends:
@@ -4539,7 +4539,7 @@ packages:
   license_family: BSD
   size: 92852
   timestamp: 1679906632236
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
   sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
   md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
   depends:
@@ -4563,7 +4563,7 @@ packages:
   license_family: BSD
   size: 401319
   timestamp: 1671707682572
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
   sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
   md5: 247558a0aecf1ef7e77a4343761353d6
   depends:
@@ -4573,7 +4573,7 @@ packages:
   license_family: BSD
   size: 64600
   timestamp: 1672387273585
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -4583,7 +4583,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -4592,13 +4592,13 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
   md5: a0f206782751dfffed0dd51302a1bf26
   license: MIT
   size: 68012
   timestamp: 1659616138077
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
   md5: 4c6667cdd061d28e9bc4e4300e4d115e
   depends:
@@ -4606,7 +4606,7 @@ packages:
   license: MIT
   size: 31173
   timestamp: 1659616155596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
   md5: 637e9430e258ddf050623ef2360184d8
   depends:
@@ -4614,28 +4614,28 @@ packages:
   license: MIT
   size: 298430
   timestamp: 1659616172209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
   sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
   md5: 55c615026c0869f8d3ba657f3bd38c43
   license: MIT
   license_family: MIT
   size: 120389
   timestamp: 1683716579036
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -4644,7 +4644,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -4655,14 +4655,14 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
   sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
   md5: a41117710dafe569c9cc4e83f6f29fe3
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1411339
   timestamp: 1650982753977
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -4673,7 +4673,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -4682,13 +4682,13 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -4705,7 +4705,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
   sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
   md5: 98d22e0124d55fae3c37c608dab1dcc9
   depends:
@@ -4719,7 +4719,7 @@ packages:
   license_family: BSD
   size: 89825
   timestamp: 1694778225280
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
   sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
   md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
   constrains:
@@ -4728,7 +4728,7 @@ packages:
   license_family: BSD
   size: 331675
   timestamp: 1694776939192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
   sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
   md5: 0ba499df6755eae5d2d23aa4ab004553
   depends:
@@ -4740,7 +4740,7 @@ packages:
   license_family: MIT
   size: 642657
   timestamp: 1692970217410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
   sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
   md5: c73101971e5ab6a8e8688239884eac81
   depends:
@@ -4750,7 +4750,7 @@ packages:
   license_family: MIT
   size: 241607
   timestamp: 1692973585084
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
   sha256: ac50f846e93e68d50bfdd5589ea8272b987243a64eba8e2e358ef311d7734001
   md5: f19270ff954a41dabbfe36ff0656935b
   depends:
@@ -4760,7 +4760,7 @@ packages:
   license_family: MIT
   size: 36040
   timestamp: 1659783399073
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -4769,7 +4769,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
   sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
   md5: 353dff9d5d996c2a260f66381b2ce3e8
   depends:
@@ -4780,7 +4780,7 @@ packages:
   license_family: Other
   size: 1470815
   timestamp: 1695058433965
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
   sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
   md5: c99006da802a97c9aae30da8c16b4820
   depends:
@@ -4789,7 +4789,7 @@ packages:
   license_family: BSD
   size: 176131
   timestamp: 1670944706815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
   sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
   md5: 60bd1e037cda86205526f77405d78129
   depends:
@@ -4799,7 +4799,7 @@ packages:
   license_family: BSD
   size: 123361
   timestamp: 1671541992772
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
   sha256: 2fd690fa3c54a40f0426874ea12e12aad2718263a75708ddd1fa6052a4ad7fb3
   md5: 81388724babfe9c32ea5cdd93633c342
   depends:
@@ -4809,7 +4809,7 @@ packages:
   license_family: MIT
   size: 107072
   timestamp: 1684280007887
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
   sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
   md5: 34dfd76da78de2eae95bbda390d746d6
   depends:
@@ -4820,7 +4820,7 @@ packages:
   license_family: BSD
   size: 23092
   timestamp: 1654598007056
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
   sha256: bf0eeef3c3c713515766ab8b0dc7863413de5b4b227deede97e24d90ca342345
   md5: a7bba1857eb84fb50caea377e60d2050
   depends:
@@ -4842,7 +4842,7 @@ packages:
   license_family: PSF
   size: 8066509
   timestamp: 1698692266161
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
   sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
   md5: eb79dabbeedee7da85dfbfb145bb8a26
   depends:
@@ -4852,7 +4852,7 @@ packages:
   license_family: BSD
   size: 17342
   timestamp: 1662014601345
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
   sha256: f400ad75dd2890627dc948f3e2e6b19732d02c124723eaf22272026993a94d52
   md5: 4a4ffc7365e30b18f4443281839e2718
   depends:
@@ -4862,7 +4862,7 @@ packages:
   license_family: MIT
   size: 53505
   timestamp: 1659721313693
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
   sha256: 20fb26a7ac748ce288cf8483a837b0c33f1348ae738bcdb69cdc2763c7bbf7e1
   md5: a0aebbc6c170ebd8d4710fd70b3db503
   depends:
@@ -4871,7 +4871,7 @@ packages:
   license_family: MIT
   size: 19562
   timestamp: 1659716131839
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
   sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
   md5: 56db7bd3ff511cd839bda081523b3edd
   depends:
@@ -4880,7 +4880,7 @@ packages:
   license_family: BSD
   size: 55683
   timestamp: 1629356128780
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
   sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
   md5: 176e0dcaeb28393881bacf69941e3889
   depends:
@@ -4906,7 +4906,7 @@ packages:
   license_family: BSD
   size: 8289638
   timestamp: 1681756329011
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.5.13-py39hca03da5_0.tar.bz2
   sha256: afc6f332c51a3defc69e4c4e641988c0556039b9cd42be22f3db5292c88ccf37
   md5: 2bc409c7258160a9b739d08d5ffb5998
   depends:
@@ -4919,7 +4919,7 @@ packages:
   license_family: BSD
   size: 96942
   timestamp: 1650373637069
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
   sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
   md5: 150ea9fadddf21993d3328d3e48a18b7
   depends:
@@ -4947,7 +4947,7 @@ packages:
   license_family: BSD
   size: 557688
   timestamp: 1668450759059
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
   sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
   md5: 37163b32508f9f589b3e6462a3a47546
   depends:
@@ -4960,14 +4960,14 @@ packages:
   license_family: BSD
   size: 148426
   timestamp: 1694616771736
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
   sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
   md5: 6cdf7cbc43bf40e92b056a5576bd0086
   depends:
@@ -4976,7 +4976,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387216468
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
   sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
   md5: 0f05853a139b6cda9c73e9d2707a4976
   depends:
@@ -5001,7 +5001,7 @@ packages:
   license_family: BSD
   size: 590288
   timestamp: 1690984971741
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
   sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
   md5: 7de782e4fb34bfa95ef2fc79d27d727d
   depends:
@@ -5011,7 +5011,7 @@ packages:
   license_family: BSD
   size: 22840
   timestamp: 1668160634885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
   sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
   md5: 1a7b23113372c5667dbfe45976b9cc5c
   depends:
@@ -5022,7 +5022,7 @@ packages:
   license_family: MIT
   size: 126357
   timestamp: 1696515322390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
   sha256: 3cd1161558704176560843586b1b1f9b257fd68c0ca53a2fc09e61267f47514c
   md5: dd162b2716dc9daf732240a343862d4a
   depends:
@@ -5035,7 +5035,7 @@ packages:
   license_family: BSD
   size: 10388
   timestamp: 1695830584640
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
   sha256: 5f35d8c0e1768fa3a9d2e75659cd2096bea6b4e021afea114f573e95f4943fb2
   md5: 958f78b1e2299537996f98da7a930198
   depends:
@@ -5049,7 +5049,7 @@ packages:
   license_family: BSD
   size: 6313331
   timestamp: 1695830570878
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
   sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
   md5: 371358a54bbdd307603888348d1a2c6f
   depends:
@@ -5059,7 +5059,7 @@ packages:
   license: BSD 2-Clause
   size: 412248
   timestamp: 1628861367714
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
   sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
   md5: fa15d3b44ae1360ac9b640bbd5b6923c
   depends:
@@ -5068,7 +5068,7 @@ packages:
   license_family: Apache
   size: 4746123
   timestamp: 1695322833432
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
   sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
   md5: d73db95f07a282021efdf8bc09713261
   depends:
@@ -5077,7 +5077,7 @@ packages:
   license_family: Apache
   size: 73620
   timestamp: 1693575195999
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
   sha256: 247b5e4d81b6d5d013a9c27e1f30c41fff896fed98a68ebda26b19b4062a6828
   md5: 354a1d65300b4309d53dfa648014e8fe
   depends:
@@ -5124,7 +5124,7 @@ packages:
   license_family: BSD
   size: 13257999
   timestamp: 1697478739906
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
   sha256: 90a1889cd0004bfc5e12ac94b4ea92718a473373033bb0ba5259804ed67bf2bc
   md5: e89f615737385fee88150ab4adf037e6
   depends:
@@ -5148,7 +5148,7 @@ packages:
   license_family: BSD
   size: 17147015
   timestamp: 1698866800249
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
   sha256: 0ae09c974297767a707642344c40f484281f0a3000251a6234e46ef19f00c10e
   md5: 64a0eaf3381e9f6aa971229501710798
   depends:
@@ -5157,7 +5157,7 @@ packages:
   license_family: BSD
   size: 189313
   timestamp: 1698263486159
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
   sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
   md5: 6e01c592ae3b8ff2d12cae76f2f4276b
   depends:
@@ -5176,7 +5176,7 @@ packages:
   license_family: Other
   size: 715239
   timestamp: 1696580071596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
   sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
   md5: 9fb8f460c130d56caf33c6bbe46fbe8a
   depends:
@@ -5187,7 +5187,7 @@ packages:
   license_family: MIT
   size: 2678841
   timestamp: 1697548790931
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
   sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
   md5: 390b8c3cd74281abecdbfd51476922f9
   depends:
@@ -5196,7 +5196,7 @@ packages:
   license_family: MIT
   size: 33033
   timestamp: 1692205747301
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
   sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
   md5: 7896828fb3565fefad43f980d50c8723
   depends:
@@ -5205,7 +5205,7 @@ packages:
   license_family: Apache
   size: 91190
   timestamp: 1659455206354
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
   sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
   md5: d934c74eb66d01af0f45f0881f4bab77
   depends:
@@ -5217,7 +5217,7 @@ packages:
   license_family: BSD
   size: 580588
   timestamp: 1672387390426
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
   sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
   md5: 9858166e5ffb624c8b9d281f4000d725
   depends:
@@ -5226,7 +5226,7 @@ packages:
   license_family: BSD
   size: 367167
   timestamp: 1656431368885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
   sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
   md5: 4d2b45c6be8221e6a3e44c2d5838426f
   depends:
@@ -5238,7 +5238,7 @@ packages:
   license_family: BSD
   size: 30843
   timestamp: 1675441531640
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
   sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
   md5: 02521df4e2e79f75faa9cbb3560ab1dd
   depends:
@@ -5247,7 +5247,7 @@ packages:
   license_family: BSD
   size: 1861763
   timestamp: 1684280026169
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
   sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
   md5: bdebe59bffc7adbad83fdcd9d429a5f5
   depends:
@@ -5257,7 +5257,7 @@ packages:
   license_family: Apache
   size: 95234
   timestamp: 1690223494699
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
   sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
   md5: d716e5c9b5eec45ce1df8eb52cab817a
   depends:
@@ -5266,7 +5266,7 @@ packages:
   license_family: MIT
   size: 157408
   timestamp: 1661452601692
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
   sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
   md5: 1907629863ed8e7c35ead232dae7693f
   depends:
@@ -5275,7 +5275,7 @@ packages:
   license_family: MIT
   size: 91636
   timestamp: 1628941083263
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
   sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
   md5: 847b9bddf2a86e1609c0d53bbc23ea79
   depends:
@@ -5284,7 +5284,7 @@ packages:
   license_family: BSD
   size: 27378
   timestamp: 1626781391140
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
   sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
   md5: 18aa18bd0d260605923877921d26cc74
   depends:
@@ -5303,7 +5303,7 @@ packages:
   license_family: PSF
   size: 13194025
   timestamp: 1694438901368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
   sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
   md5: 45642a99c83e7aed74d1ffab1f20145b
   depends:
@@ -5312,7 +5312,7 @@ packages:
   license_family: BSD
   size: 266647
   timestamp: 1661368655993
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
   sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
   md5: fec748525144049a2fc7f52f9755232c
   depends:
@@ -5321,7 +5321,7 @@ packages:
   license_family: MIT
   size: 257235
   timestamp: 1695131702047
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
   sha256: 960192a143672e9c1d6fe4027af448512d91eee7501e5c245c21b865cf8bf429
   md5: 76d491244218505f071ba56a308673df
   depends:
@@ -5331,7 +5331,7 @@ packages:
   license_family: BSD
   size: 40950
   timestamp: 1685030774581
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
   sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
   md5: 3445d25415998c807efbe64d3a7e03c8
   depends:
@@ -5341,7 +5341,7 @@ packages:
   license_family: MIT
   size: 167068
   timestamp: 1698096118071
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
   sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
   md5: e6e92da28e9b0e428ed4b7df417bec25
   depends:
@@ -5352,7 +5352,7 @@ packages:
   license_family: BSD
   size: 472418
   timestamp: 1657724315435
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -5361,7 +5361,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
   sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
   md5: dba22515f36d3c266de5896350813ea2
   depends:
@@ -5377,7 +5377,7 @@ packages:
   license_family: Apache
   size: 95103
   timestamp: 1690400315537
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
   sha256: c35449c0ca64d0d6a23c019b6eba188f546e42379857cbc4240bbdddee1159d3
   md5: 61cb82346e21710f3e0645096cda4e12
   depends:
@@ -5393,7 +5393,7 @@ packages:
   license_family: BSD
   size: 22859180
   timestamp: 1696543469561
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
   sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
   md5: 3cd7eb43e285faba76faf67667e26b00
   depends:
@@ -5402,7 +5402,7 @@ packages:
   license_family: MIT
   size: 1093916
   timestamp: 1690290951258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
   sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
   md5: c5e9aef0d6895de1c927e9d796cd7cd3
   depends:
@@ -5411,7 +5411,7 @@ packages:
   license_family: Apache
   size: 15691
   timestamp: 1629145910454
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
   sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
   md5: 0f7c229e774146ffc4e29dedf75372bf
   depends:
@@ -5420,7 +5420,7 @@ packages:
   license_family: MIT
   size: 67279
   timestamp: 1696347632563
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
   sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
   md5: 2302a79a045f152e183a52a81adfba62
   depends:
@@ -5432,7 +5432,7 @@ packages:
   license_family: Other
   size: 1674163
   timestamp: 1681394762218
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
   sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
   md5: 4ae67163d55cf9df83d4027ebc38c501
   depends:
@@ -5443,7 +5443,7 @@ packages:
   license_family: BSD
   size: 30894
   timestamp: 1671751931536
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
   sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
   md5: dbb5c0cddb6661a89afee647fd3dc01e
   depends:
@@ -5453,7 +5453,7 @@ packages:
   license_family: BSD
   size: 39875
   timestamp: 1668168874870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
   sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
   md5: 667e60c8b407d73cbba40f44901f4f00
   depends:
@@ -5462,7 +5462,7 @@ packages:
   license_family: BSD
   size: 3412693
   timestamp: 1654088929697
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
   sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
   md5: 884f788a5f6a664c9b79f7a4a60362d0
   depends:
@@ -5471,7 +5471,7 @@ packages:
   license_family: Apache
   size: 680561
   timestamp: 1696937004165
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
   sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
   md5: 639a4f489af172c866c18442948e5874
   depends:
@@ -5484,7 +5484,7 @@ packages:
   license_family: MOZILLA
   size: 125170
   timestamp: 1679561942932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
   sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
   md5: e5b90eba83fddba6d7aa6072b5bf7c91
   depends:
@@ -5493,7 +5493,7 @@ packages:
   license_family: BSD
   size: 193017
   timestamp: 1671143921826
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
   md5: 644ef8830437070f60efcfcd6a987198
   depends:
@@ -5503,7 +5503,7 @@ packages:
   license_family: PSF
   size: 9670
   timestamp: 1690297532002
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
   md5: a902a833bb186a2f1a4b2b89b1195136
   depends:
@@ -5512,7 +5512,7 @@ packages:
   license_family: PSF
   size: 58466
   timestamp: 1690297524418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
   sha256: 536045a8a172c651fd306c285a6d7409775f018dac944f2124c538ccfb195e28
   md5: d4dc6cdf0812191b9ec78b35b4fdf3e0
   depends:
@@ -5521,7 +5521,7 @@ packages:
   license_family: MIT
   size: 11593
   timestamp: 1659769477205
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
   sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
   md5: f3f1d2c1028dad2f11ff950a15c99dbf
   depends:
@@ -5536,7 +5536,7 @@ packages:
   license_family: MIT
   size: 188640
   timestamp: 1698257577209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
   sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
   md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
   depends:
@@ -5545,7 +5545,7 @@ packages:
   license_family: BSD
   size: 20091
   timestamp: 1629144441130
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
   sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
   md5: 3089c63bf8f4d0423e1a287da286d83e
   depends:
@@ -5555,7 +5555,7 @@ packages:
   license_family: BSD
   size: 70923
   timestamp: 1629357115820
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
   sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
   md5: 5886b30b312445471268444f41f39dc7
   depends:
@@ -5564,7 +5564,7 @@ packages:
   license_family: MIT
   size: 102583
   timestamp: 1695741976083
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
   sha256: 105e39d3eb51b47c7244b3379c0133ab7051966664f52835453b14509215b159
   md5: ed20012c2cd99ffd04cca9929e0bc061
   depends:
@@ -5573,20 +5573,20 @@ packages:
   license_family: BSD
   size: 49775
   timestamp: 1675159079039
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
   sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
   md5: 2e75ad6a09c308268192efe03cc9ebf4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 411778
   timestamp: 1683113019715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
   sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
   md5: 30f666bf97c26587c5d2f68cc5f330ab
   depends:
@@ -5595,7 +5595,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 316901
   timestamp: 1629287855861
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
   sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
   md5: 584e591d36dcd5ba5c45404f0f7ebb2d
   depends:
@@ -5604,14 +5604,14 @@ packages:
   license_family: MIT
   size: 19076
   timestamp: 1672387153578
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
   sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
   md5: 467ae28215d1aa1c5688bc0c8a184269
   license: Zlib
   license_family: Other
   size: 103525
   timestamp: 1666595022664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
   sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
   md5: 7cfbed15f1feee1422810f7830075f53
   depends:
@@ -5623,7 +5623,7 @@ packages:
   license_family: BSD
   size: 779464
   timestamp: 1681304594848
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
   sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
   md5: ed14f9bc6e55220483f1a5a388625a08
   depends:
@@ -5636,7 +5636,7 @@ packages:
   license_family: MIT
   size: 162772
   timestamp: 1644481986085
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
   sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
   md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
   depends:
@@ -5648,7 +5648,7 @@ packages:
   license_family: MIT
   size: 39253
   timestamp: 1644551767970
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
   sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
   md5: b24d13c443a26f65a0778b475a5726bc
   depends:
@@ -5657,7 +5657,7 @@ packages:
   license_family: MIT
   size: 132830
   timestamp: 1695717959996
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
   sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
   md5: 302c3c0696e17eaa62e140e3892644ae
   depends:
@@ -5667,12 +5667,12 @@ packages:
   license_family: MIT
   size: 199723
   timestamp: 1681493196911
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
   sha256: 812f268862208c2518b5187809a8571adb488de3604d512721035e65458dde76
   md5: 97ce620b7dd3ee743d0ca28ed66ace74
   depends:
@@ -5690,7 +5690,7 @@ packages:
   license_family: BSD
   size: 5721832
   timestamp: 1697491241383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
   sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
   md5: bf930260f679bc74227bbb18bc36ae82
   depends:
@@ -5702,7 +5702,7 @@ packages:
   license_family: BSD
   size: 119700
   timestamp: 1657176150595
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
   md5: 507dfe693ef429f466d964b599f4af21
   depends:
@@ -5714,7 +5714,7 @@ packages:
   license: MIT
   size: 18650
   timestamp: 1659616328001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
   md5: d0bf43e8df60baae3b3105aa5c42a791
   depends:
@@ -5725,7 +5725,7 @@ packages:
   license: MIT
   size: 21153
   timestamp: 1659616312367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
   sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
   md5: 7bd24bf94c24e810aecaaf84a0978e6f
   depends:
@@ -5735,14 +5735,14 @@ packages:
   license: MIT
   size: 343204
   timestamp: 1659616543542
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
   sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
   md5: 092b417c11edcbe6bb9b765ab4a55d23
   license: MPL-2.0
   license_family: Other
   size: 164999
   timestamp: 1694009822357
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
   sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
   md5: 708a750d370b9d6875651021e21c4446
   depends:
@@ -5751,7 +5751,7 @@ packages:
   license_family: Other
   size: 159322
   timestamp: 1690232335307
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
   sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
   md5: c35736da3ea26782425e78061268cf5e
   depends:
@@ -5763,7 +5763,7 @@ packages:
   license_family: MIT
   size: 228713
   timestamp: 1670423312743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
   sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
   md5: 457a4339a53c033d48ce0c72e5038d2e
   depends:
@@ -5772,7 +5772,7 @@ packages:
   license_family: BSD
   size: 30330
   timestamp: 1672387265402
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
   sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
   md5: 59ec65fd9e06b81a65cc12986c67d5da
   depends:
@@ -5782,7 +5782,7 @@ packages:
   license_family: CC
   size: 1939614
   timestamp: 1668084794027
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
   sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
   md5: 3489c1a2b73fc957b5a62cc59349e25b
   depends:
@@ -5792,7 +5792,7 @@ packages:
   license_family: BSD
   size: 13438
   timestamp: 1671231196438
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
   sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
   md5: 3492b96083c1e904cc32d26ea7f1e1d8
   depends:
@@ -5804,7 +5804,7 @@ packages:
   license_family: BSD
   size: 184280
   timestamp: 1663827558327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
   sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
   md5: f46d904bc6f220327e70474971341f52
   depends:
@@ -5819,7 +5819,7 @@ packages:
   license_family: BSD
   size: 1220835
   timestamp: 1694445639066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
   sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
   md5: 2ff4fb509788b0e47ac684ba151394d0
   depends:
@@ -5830,7 +5830,7 @@ packages:
   license_family: MIT
   size: 3289966
   timestamp: 1690907040646
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
   sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
   md5: 0f166c3e70541d8bee6e9d0cb60fb66e
   depends:
@@ -5839,7 +5839,7 @@ packages:
   license_family: MIT
   size: 16979
   timestamp: 1649926678161
-- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
   sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
   md5: ea93d413944ca6a8677eb1b284b136ae
   depends:
@@ -5848,7 +5848,7 @@ packages:
   license_family: BSD
   size: 27388
   timestamp: 1668714577678
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -5860,7 +5860,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
   sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
   md5: 9f167d3e45441bc3633c1974b1b0ce8c
   depends:
@@ -5870,7 +5870,7 @@ packages:
   license_family: MIT
   size: 88421
   timestamp: 1676983264486
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
   sha256: fa8f868e49721ca19912f816a6da221172758f9e3d28d8b31d53249fb14dc25f
   md5: 09f9a2cea9425d76dccf9b026afe5bb2
   depends:
@@ -5887,7 +5887,7 @@ packages:
   license_family: BSD
   size: 4576915
   timestamp: 1698866895838
-- conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.9.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/hvplot-0.9.0-py39haa95532_0.tar.bz2
   sha256: fc1399ca859fa3cbb80f94869de2930299b9a4b72b88c29005d32d961738ad01
   md5: bf03cceaecd14cb1b4c2955bddc1a2a9
   depends:
@@ -5904,13 +5904,13 @@ packages:
   license_family: BSD
   size: 3358682
   timestamp: 1697560035937
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
   sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
   md5: 582d2c1135a89da757a038de831e7f39
   license: Intel proprietary
   size: 11086648
   timestamp: 1664812389803
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
   sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
   md5: 30fdefd1541c789c163751291a8faa88
   depends:
@@ -5919,7 +5919,7 @@ packages:
   license_family: BSD
   size: 111448
   timestamp: 1666125667599
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
   sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
   md5: a10f07c7a3510272a296f9fed458a4ed
   depends:
@@ -5929,7 +5929,7 @@ packages:
   license_family: APACHE
   size: 38098
   timestamp: 1678997241511
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
   sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
   md5: fad9cf2023d807da8d44996e9d4399a0
   depends:
@@ -5939,7 +5939,7 @@ packages:
   license_family: Apache
   size: 51490
   timestamp: 1698254721864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
   sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
   md5: 9834848bd7c7759acf12e78d09388563
   depends:
@@ -5949,7 +5949,7 @@ packages:
   license_family: Proprietary
   size: 3891030
   timestamp: 1681801474383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
   sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
   md5: 1285c8c628bc912c54d0968574c9f4c9
   depends:
@@ -5970,7 +5970,7 @@ packages:
   license_family: BSD
   size: 217232
   timestamp: 1691122695748
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
   sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
   md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
   depends:
@@ -5991,7 +5991,7 @@ packages:
   license_family: BSD
   size: 1279433
   timestamp: 1694181820978
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
   sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
   md5: f5fcce35d3f21cdfc5893c5a7a86c651
   depends:
@@ -6001,7 +6001,7 @@ packages:
   license_family: MIT
   size: 1035394
   timestamp: 1644315567034
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
   sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
   md5: f67fe3337528e2886f1ac3ab8ac37985
   depends:
@@ -6011,7 +6011,7 @@ packages:
   license_family: BSD
   size: 213110
   timestamp: 1666908350218
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
   sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
   md5: 81f2c343dc4c65eea39c45383272068f
   depends:
@@ -6021,7 +6021,7 @@ packages:
   license_family: Other
   size: 407861
   timestamp: 1677849239400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
   sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
   md5: bd9526d38a145fe311a8aa36bc11e071
   depends:
@@ -6032,7 +6032,7 @@ packages:
   license_family: MIT
   size: 152006
   timestamp: 1676558783570
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
   sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
   md5: a00e6a62956fde3c4135464353ee8a53
   depends:
@@ -6048,7 +6048,7 @@ packages:
   license_family: BSD
   size: 229158
   timestamp: 1676330909084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.3.0-py39haa95532_0.tar.bz2
   sha256: db8335d6531b03c7bdfe789ebacc52631ac6ea4a37700bb3da1f6a53a1acd724
   md5: ebeba61994cc225ea5f4f42caa511019
   depends:
@@ -6060,7 +6060,7 @@ packages:
   license_family: BSD
   size: 116681
   timestamp: 1679906658986
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
   sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
   md5: 5efa1332f7c0a8d9638eda02170c4ce5
   depends:
@@ -6085,7 +6085,7 @@ packages:
   license_family: BSD
   size: 413653
   timestamp: 1671707957673
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
   sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
   md5: 891fe66a24d8714737b2874985ee1303
   depends:
@@ -6096,7 +6096,7 @@ packages:
   license_family: BSD
   size: 62298
   timestamp: 1672388166096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -6106,7 +6106,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
   sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
   md5: c345f51706eef530454f66b794e5e574
   depends:
@@ -6115,7 +6115,7 @@ packages:
   license: MIT
   size: 68189
   timestamp: 1659616216976
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
   md5: a7400cfb72042977bc047909ed504ce8
   depends:
@@ -6125,7 +6125,7 @@ packages:
   license: MIT
   size: 33743
   timestamp: 1659616248209
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
   md5: 6307f6854754ab5bd7c84e6998385bb1
   depends:
@@ -6135,7 +6135,7 @@ packages:
   license: MIT
   size: 733177
   timestamp: 1659616279453
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -6145,7 +6145,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
   sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
   md5: b812bc5d9c76242e2bb2ac87afe7d39b
   depends:
@@ -6155,7 +6155,7 @@ packages:
   license_family: GPL3
   size: 730280
   timestamp: 1650983734373
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -6166,7 +6166,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -6175,7 +6175,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -6192,7 +6192,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
   sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
   md5: ba9418df9288a2f031a02fa35b774ce0
   depends:
@@ -6208,7 +6208,7 @@ packages:
   license_family: BSD
   size: 78524
   timestamp: 1694778314659
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
   sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
   md5: b1781519a200ccbfcb4a1194005aa3ef
   depends:
@@ -6220,7 +6220,7 @@ packages:
   license_family: BSD
   size: 338459
   timestamp: 1694777084290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
   sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
   md5: 6ece7f1a3248169837714d05d7f6ef0a
   depends:
@@ -6232,7 +6232,7 @@ packages:
   license_family: MIT
   size: 3513910
   timestamp: 1692971505729
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
   sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
   md5: bd7ec244935e83e850a4ff34e8e2e64f
   depends:
@@ -6243,7 +6243,7 @@ packages:
   license_family: MIT
   size: 513971
   timestamp: 1692973657152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
   sha256: e1c0e745d9ba36a80773e841d96bf514ad1ceda419e4188aad3c22782af00234
   md5: f226532e9bb308f20e874c56be6ceefb
   depends:
@@ -6253,7 +6253,7 @@ packages:
   license_family: MIT
   size: 35788
   timestamp: 1659783414586
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
   sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
   md5: fb7881e74b59262df0fa4ec981964efc
   depends:
@@ -6266,7 +6266,7 @@ packages:
   license_family: Other
   size: 1244887
   timestamp: 1695058550693
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
   sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
   md5: 6970c7f46b0164cad1d210e7a1419959
   depends:
@@ -6276,7 +6276,7 @@ packages:
   license_family: BSD
   size: 143434
   timestamp: 1670944902624
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
   sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
   md5: 1015298551c040c6d5e26eebbae12ef5
   depends:
@@ -6286,7 +6286,7 @@ packages:
   license_family: BSD
   size: 142316
   timestamp: 1671542240512
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
   sha256: ab5c246c2b271acc1cdd0b9343989c0166681536e569cdbe71618f55d34c7292
   md5: 7ce68d771cd94c9ff5efefe69d327c9a
   depends:
@@ -6296,7 +6296,7 @@ packages:
   license_family: MIT
   size: 125122
   timestamp: 1684280210213
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
   sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
   md5: 466da740fafef3d6bce114220f0be306
   depends:
@@ -6309,7 +6309,7 @@ packages:
   license_family: BSD
   size: 28510
   timestamp: 1654508162239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
   sha256: 1687ae122ee7d8b583141fc5014b76d494841dc8083b854449e3d6e0f6bb7019
   md5: 3697ac26ee3c2d49338dd5b9c6551152
   depends:
@@ -6332,7 +6332,7 @@ packages:
   license_family: PSF
   size: 8080067
   timestamp: 1698692812610
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
   sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
   md5: a9fa43e694b25cd49b8b08a9eefd696e
   depends:
@@ -6342,7 +6342,7 @@ packages:
   license_family: BSD
   size: 18054
   timestamp: 1661915903969
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
   sha256: 8aa14047fac6ef8b326900c4bf1a960eaa7a1699c18fdf1e75a59101b610b6df
   md5: 7e1d4d4700fbea6171d30f1d5ad24226
   depends:
@@ -6352,7 +6352,7 @@ packages:
   license_family: MIT
   size: 53362
   timestamp: 1659721308586
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
   sha256: 2017814a7cc93dd51c6b7c016e3cdf8fbc32fa20f985638aaff6a6377e9ee086
   md5: a1a285c56b001c3b5c591bf21eec3149
   depends:
@@ -6361,7 +6361,7 @@ packages:
   license_family: MIT
   size: 19326
   timestamp: 1659716205153
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
   sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
   md5: 248c468abced874f0231d3cc23177c77
   depends:
@@ -6372,7 +6372,7 @@ packages:
   license_family: BSD
   size: 58488
   timestamp: 1607359497934
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
   sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
   md5: 5e763c995ff0c549f68a10bce70fede4
   depends:
@@ -6384,7 +6384,7 @@ packages:
   license_family: Proprietary
   size: 187489950
   timestamp: 1691503804820
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
   sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
   md5: dd0c2ece6a743c373c9b5a5919b4818f
   depends:
@@ -6396,7 +6396,7 @@ packages:
   license_family: BSD
   size: 49744
   timestamp: 1682975040154
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
   sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
   md5: 57cea8df7ab85f2a98f64d23afcb1f90
   depends:
@@ -6411,7 +6411,7 @@ packages:
   license_family: BSD
   size: 184956
   timestamp: 1695058491736
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
   sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
   md5: 8769cdd201d905069800488fe31574e5
   depends:
@@ -6426,7 +6426,7 @@ packages:
   license_family: BSD
   size: 256221
   timestamp: 1695060152521
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
   sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
   md5: d9781492332e6326f9fca87f3a8efacd
   depends:
@@ -6452,7 +6452,7 @@ packages:
   license_family: BSD
   size: 8135792
   timestamp: 1681756491399
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.5.13-py39haa95532_0.tar.bz2
   sha256: 2dd3178d3c570e30b9490ebabfd7bfac806afad8302d3dee0edc619805034397
   md5: bef9da0f0694c45b6aaa4e6447479eaf
   depends:
@@ -6465,7 +6465,7 @@ packages:
   license_family: BSD
   size: 118324
   timestamp: 1650290466135
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
   sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
   md5: f1d8ce412e115986c403f223b3b47d0f
   depends:
@@ -6493,7 +6493,7 @@ packages:
   license_family: BSD
   size: 596314
   timestamp: 1668451106600
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
   sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
   md5: f96bbef0985d7e66ebf00c0d55e30e23
   depends:
@@ -6506,7 +6506,7 @@ packages:
   license_family: BSD
   size: 167045
   timestamp: 1694617078743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
   sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
   md5: 6e6ba64c8dc5025aeac606404a8df36a
   depends:
@@ -6515,7 +6515,7 @@ packages:
   license_family: BSD
   size: 13786
   timestamp: 1672387480065
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
   sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
   md5: 4a7a3286484766741f627696697c362c
   depends:
@@ -6540,7 +6540,7 @@ packages:
   license_family: BSD
   size: 609425
   timestamp: 1690985686105
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
   sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
   md5: 4269a1f93882205b90d4b2ae78fc82d5
   depends:
@@ -6550,7 +6550,7 @@ packages:
   license_family: BSD
   size: 22417
   timestamp: 1668160717305
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
   sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
   md5: a18a576b7024cfd6f905c526a786a916
   depends:
@@ -6565,7 +6565,7 @@ packages:
   license_family: MIT
   size: 135285
   timestamp: 1696515698492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
   sha256: e5e11f9b42d770ee46ac24d1cdf7aa4e9c49a60a607c8c28e7729131a99eadd5
   md5: 4274d06db8a9a381c072d226d0322dc0
   depends:
@@ -6582,7 +6582,7 @@ packages:
   license_family: BSD
   size: 9835
   timestamp: 1695830845329
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
   sha256: dcaa1607ce40a0ed610dd5398e125c8e5b08e738e50b6037a8c72b49ca561ff2
   md5: d99d990a60644b97ba1ff9bb8da0e66f
   depends:
@@ -6598,7 +6598,7 @@ packages:
   license_family: BSD
   size: 6778113
   timestamp: 1695830816710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
   sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
   md5: ab07e2a27ac08afe3d0b4c0890b8486a
   depends:
@@ -6609,7 +6609,7 @@ packages:
   license: BSD 2-Clause
   size: 249316
   timestamp: 1630094024143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
   sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
   md5: 73b17037d87b5a58feb34dafc0538f7f
   depends:
@@ -6620,7 +6620,7 @@ packages:
   license_family: Apache
   size: 8058396
   timestamp: 1695324589828
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
   sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
   md5: df1d746ba8d5d6ba01ac1373b9b71e1a
   depends:
@@ -6629,7 +6629,7 @@ packages:
   license_family: Apache
   size: 73016
   timestamp: 1693575484990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
   sha256: 1994e5831fd421bd6cf85916073d4012dec53e673b672b3985efaf771f0a7bf8
   md5: c486a5b51e3227f6ea564a9dd3125e45
   depends:
@@ -6677,7 +6677,7 @@ packages:
   license_family: BSD
   size: 12629931
   timestamp: 1697479885371
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
   sha256: 270e4c3ab0f0c8d8f31fa0e45bc516c1e41be618a5c66e1c86dc39ce76cb2372
   md5: cad52ba9eb391416112f0994b6c35249
   depends:
@@ -6701,7 +6701,7 @@ packages:
   license_family: BSD
   size: 17162886
   timestamp: 1698867967809
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
   sha256: 56eaf7f4b1bb81e3deed55711dd2ee78f244a3cc0ad4bb7a1f09d97e46f9793f
   md5: c24a3daed1e85ba7a100fa6966c5bb48
   depends:
@@ -6710,7 +6710,7 @@ packages:
   license_family: BSD
   size: 189021
   timestamp: 1698263520538
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
   sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
   md5: 427c1450bebb632f43bbc8c83006e4cd
   depends:
@@ -6729,7 +6729,7 @@ packages:
   license_family: Other
   size: 806931
   timestamp: 1696580240310
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
   sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
   md5: 21790cd3e2b8a45c4104aff0a68330d0
   depends:
@@ -6740,7 +6740,7 @@ packages:
   license_family: MIT
   size: 3001751
   timestamp: 1697549357662
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
   sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
   md5: 56f44a1054da2d10777e375838191070
   depends:
@@ -6749,7 +6749,7 @@ packages:
   license_family: MIT
   size: 32355
   timestamp: 1692205784293
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
   sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
   md5: 8a35ad65651086575ce55371f22feda8
   depends:
@@ -6758,7 +6758,7 @@ packages:
   license_family: Apache
   size: 91045
   timestamp: 1659455316472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
   sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
   md5: 186eb95f816a2eff80c3c7f7d964c7b0
   depends:
@@ -6770,7 +6770,7 @@ packages:
   license_family: BSD
   size: 578514
   timestamp: 1672388155359
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
   sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
   md5: 47b6cbe6ce9289e47d16900b03596a91
   depends:
@@ -6781,7 +6781,7 @@ packages:
   license_family: BSD
   size: 372807
   timestamp: 1656431445633
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
   sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
   md5: 07165c444adc7c7ccc8a345875adc5ef
   depends:
@@ -6793,7 +6793,7 @@ packages:
   license_family: BSD
   size: 48408
   timestamp: 1675450623287
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
   sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
   md5: d58e76a31e2f6e7410ba4afd7f385b0d
   depends:
@@ -6802,7 +6802,7 @@ packages:
   license_family: BSD
   size: 1877445
   timestamp: 1684280183367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
   sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
   md5: 0e5b0fe7debbf558ce97090f6b67cdae
   depends:
@@ -6812,7 +6812,7 @@ packages:
   license_family: Apache
   size: 94633
   timestamp: 1690225630423
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
   sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
   md5: 0fde797653e4ab589506121fb1e37555
   depends:
@@ -6821,7 +6821,7 @@ packages:
   license_family: MIT
   size: 157119
   timestamp: 1661452591647
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
   sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
   md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
   depends:
@@ -6832,7 +6832,7 @@ packages:
   license_family: MIT
   size: 92679
   timestamp: 1636093365041
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
   sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
   md5: f870859d4dc7a8d82cf3546bd9035f33
   depends:
@@ -6842,7 +6842,7 @@ packages:
   license_family: BSD
   size: 54520
   timestamp: 1605307564142
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
   sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
   md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
   depends:
@@ -6855,7 +6855,7 @@ packages:
   license_family: PSF
   size: 21172845
   timestamp: 1694442462066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
   sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
   md5: 9d99075052265ae3d718582d3b875038
   depends:
@@ -6864,7 +6864,7 @@ packages:
   license_family: BSD
   size: 269964
   timestamp: 1661376543480
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
   sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
   md5: fa9074d94236c9b768bfd2c858875b27
   depends:
@@ -6873,7 +6873,7 @@ packages:
   license_family: MIT
   size: 264836
   timestamp: 1695131770282
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
   sha256: 97243a31c39f4990c0e9d4f2307f2f7fb9421553303923bc105067ec4340bdff
   md5: 8078c5760f27398eaf1082226647d137
   depends:
@@ -6883,7 +6883,7 @@ packages:
   license_family: BSD
   size: 40145
   timestamp: 1685031143383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
   sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
   md5: 3d2841085778006c2e79f9c7300f8b9d
   depends:
@@ -6893,7 +6893,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13565975
   timestamp: 1669937633869
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
   sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
   md5: 54a4bc0724041dd173088419d6ede2af
   depends:
@@ -6905,7 +6905,7 @@ packages:
   license_family: MIT
   size: 239062
   timestamp: 1677611495106
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
   sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
   md5: f39f84115e228bad4bceaefdd637f022
   depends:
@@ -6917,7 +6917,7 @@ packages:
   license_family: MIT
   size: 158558
   timestamp: 1698096358091
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
   sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
   md5: df398a3a1668fd2a22061764e20ea91d
   depends:
@@ -6929,7 +6929,7 @@ packages:
   license_family: BSD
   size: 460913
   timestamp: 1657616061604
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
   sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
   md5: 38db77ece9dc76feffb9ef7638e38258
   depends:
@@ -6945,7 +6945,7 @@ packages:
   license_family: Apache
   size: 94397
   timestamp: 1690400496655
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
   sha256: 3a9a680173f731d515e0587d5b74583cc986b5c1ff62f4cf9e4f7ec268cbb62a
   md5: 3387bf809e3d32dde3f5cbc3ef49bf47
   depends:
@@ -6963,7 +6963,7 @@ packages:
   license_family: BSD
   size: 22779707
   timestamp: 1696550432358
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
   sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
   md5: 3e284ae6b48ee30c364ffdc5601610b0
   depends:
@@ -6972,7 +6972,7 @@ packages:
   license_family: MIT
   size: 1099842
   timestamp: 1690291374842
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
   sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
   md5: 993b3886b334bd1f49d34206f21997b4
   depends:
@@ -6981,7 +6981,7 @@ packages:
   license_family: Apache
   size: 15998
   timestamp: 1614030572433
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
   sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
   md5: 7ac9604ad7564ac0c71bff5db198656f
   depends:
@@ -6990,7 +6990,7 @@ packages:
   license_family: MIT
   size: 67012
   timestamp: 1696347795139
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
   sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
   md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
   depends:
@@ -7000,7 +7000,7 @@ packages:
   license_family: Other
   size: 1311308
   timestamp: 1681402905668
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -7010,7 +7010,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
   sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
   md5: 28b9869d8d3a839918fac4a08f38cbc2
   depends:
@@ -7021,7 +7021,7 @@ packages:
   license_family: BSD
   size: 30546
   timestamp: 1671752127904
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
   sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
   md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
   depends:
@@ -7031,7 +7031,7 @@ packages:
   license_family: BSD
   size: 39590
   timestamp: 1668168880994
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
   sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
   md5: 52cdcdb96383c010ca833a7c24b3935b
   depends:
@@ -7041,7 +7041,7 @@ packages:
   license_family: BSD
   size: 3690152
   timestamp: 1654036853710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
   sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
   md5: 0e054ab29119cf4c1f778613acf972f9
   depends:
@@ -7052,7 +7052,7 @@ packages:
   license_family: Apache
   size: 681780
   timestamp: 1696937326924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
   sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
   md5: b6ad839ebba536ad1c3cc58d0e2123f0
   depends:
@@ -7066,7 +7066,7 @@ packages:
   license_family: MOZILLA
   size: 143681
   timestamp: 1679562248929
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
   sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
   md5: fe78de10019085146f1cc6c94fdc2620
   depends:
@@ -7075,7 +7075,7 @@ packages:
   license_family: BSD
   size: 192822
   timestamp: 1671143999327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
   md5: ca5fc3fbdb09b6de068a8b7a8869369f
   depends:
@@ -7085,7 +7085,7 @@ packages:
   license_family: PSF
   size: 9208
   timestamp: 1690298120549
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
   md5: a86e87a10e5fdff486265e0c675fb99f
   depends:
@@ -7094,7 +7094,7 @@ packages:
   license_family: PSF
   size: 57922
   timestamp: 1690298106990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
   sha256: 8057d3d2a0acd44496de33c5b222063c3f7d06b90c74fbbda45bd18b0b324219
   md5: 398f8db5bd8cab84b3d85a9d85fa4889
   depends:
@@ -7103,7 +7103,7 @@ packages:
   license_family: MIT
   size: 11362
   timestamp: 1659769459206
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
   sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
   md5: 0d31859e0a097aedbcc1627db33b3d92
   depends:
@@ -7118,7 +7118,7 @@ packages:
   license_family: MIT
   size: 188367
   timestamp: 1698257883295
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
   sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
   md5: 45ef24c486a484f079faf1dc90e4c7e9
   depends:
@@ -7127,12 +7127,12 @@ packages:
   license_family: BSD
   size: 8277
   timestamp: 1605602889180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
   sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
   md5: 4daaceb6cfc1af6274509081d8018ef1
   size: 2316783
   timestamp: 1605602872095
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
   sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
   md5: 916c16904615c7af3b5d37cb6694f45e
   depends:
@@ -7141,7 +7141,7 @@ packages:
   license_family: BSD
   size: 21084
   timestamp: 1607347371925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
   sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
   md5: da69e6987fcc757e83a358ceaa13f62b
   depends:
@@ -7151,7 +7151,7 @@ packages:
   license_family: BSD
   size: 73391
   timestamp: 1614804425587
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
   sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
   md5: 23b9f4634b2e5450be617114f62c74f9
   depends:
@@ -7160,7 +7160,7 @@ packages:
   license_family: MIT
   size: 120873
   timestamp: 1695742300539
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
   sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
   md5: 120f0b088290fc17bd6618fc10a2f0c4
   depends:
@@ -7168,13 +7168,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 34293
   timestamp: 1605306211299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
   sha256: a5d2a216d052105fdaad7256f23da3b29f95100d1dc0f29b6ab1f3bbc75e17a9
   md5: a558f681ebc243f86cde2515c065b62e
   depends:
@@ -7183,7 +7183,7 @@ packages:
   license_family: BSD
   size: 48805
   timestamp: 1675159123654
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
   sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
   md5: c3f7871e9a33adeccee1b1e8e216918e
   depends:
@@ -7193,7 +7193,7 @@ packages:
   license_family: GPL2
   size: 1332571
   timestamp: 1683113347814
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -7202,7 +7202,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
   sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
   md5: 1ab55f8c4b5292ec360c572120bf823e
   depends:
@@ -7212,7 +7212,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 9430705
   timestamp: 1616055773485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
   sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
   md5: 6875e0bf3828707dc9165d694c0d0a7d
   depends:
@@ -7221,7 +7221,7 @@ packages:
   license_family: MIT
   size: 18725
   timestamp: 1672387612937
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
   sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
   md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
   depends:
@@ -7231,7 +7231,7 @@ packages:
   license_family: Other
   size: 148931
   timestamp: 1666595229032
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
   sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
   md5: 8d6a1e767775fe0eb617cd6e22edc2ff
   depends:

--- a/penguin_crossfilter/pixi.toml
+++ b/penguin_crossfilter/pixi.toml
@@ -19,15 +19,15 @@ panel = ">=1"
 hvplot = "*"
 param = "*"
 pandas = "*"
-pip = "*"
-setuptools = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+setuptools = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks]
 dashboard = "panel serve --rest-session-info --session-history -1 penguin_crossfilter.ipynb --show"

--- a/penguin_crossfilter/pixi.toml
+++ b/penguin_crossfilter/pixi.toml
@@ -1,0 +1,34 @@
+[workspace]
+name = "penguin_crossfilter"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
+
+[tool.metadata]
+created = "2020-12-29"
+maintainers = ["philippjfr"]
+categories = ["Other Sciences"]
+labels = ["panel", "holoviews", "hvplot", "bokeh"]
+description = "Palmer Penguin Cross-Filtering"
+
+[dependencies]
+python = "3.9.*"
+scipy = "*"
+notebook = "*"
+holoviews = "*"
+panel = ">=1"
+hvplot = "*"
+param = "*"
+pandas = "*"
+pip = "*"
+setuptools = "*"
+wheel = "*"
+
+[target.osx-64.dependencies]
+libgfortran = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks]
+dashboard = "panel serve --rest-session-info --session-history -1 penguin_crossfilter.ipynb --show"
+notebook = "jupyter notebook penguin_crossfilter.ipynb"

--- a/penguin_crossfilter/pixi.toml
+++ b/penguin_crossfilter/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "penguin_crossfilter"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
 
 [tool.metadata]

--- a/portfolio_optimizer/pixi.lock
+++ b/portfolio_optimizer/pixi.lock
@@ -1,0 +1,7273 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+  sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
+  md5: 613805add1c05b538ff06d217252feb7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 20810
+  timestamp: 1652859733309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+  sha256: 250f50edf43a786a32942e9ae67ce807e9b3ac4cb6b58b1170cb541fb24e391f
+  md5: b48058294499d292ddf9a3b966dc9cc5
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 228473
+  timestamp: 1706220559474
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+  sha256: 0d4f5274503916e1c683dcc16e8a7c4186557afa3f62399cd628e4eb535fe77a
+  md5: 062acdb0f9ae976c25c2d15d589dc1d6
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 35809
+  timestamp: 1676823571351
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+  sha256: 567dfdd5b986012421a736a5f1c1d5874d8d691dd483c838b55e1ab06c0b217d
+  md5: 4e0aa1543f546b898523382ee8405e84
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 152577
+  timestamp: 1695717917074
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+  sha256: 894fceb5b4f8740bcd146de8bd0f6eabf14e2407b149b790b4983b8432681e6b
+  md5: 2f0ef211bf628cd22bbfa44c3f9bc035
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 271600
+  timestamp: 1681493103694
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
+  sha256: 9f027f156744dcbf28945aad6e422ef030c84c2a5d40116d3e40407c66853bf8
+  md5: 7b52489e04f9a5585643d5578835fc68
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6059952
+  timestamp: 1712084450899
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+  sha256: 8e2b2073ff5c61d35714e8a36ce657a8ac741b7bedc2852a238c7f1625142705
+  md5: d951ab54a682b6328327fec53b1e5e72
+  depends:
+  - libgcc-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 147642
+  timestamp: 1707864274452
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 5d15605858771290fdaaae41a43941623757a25cb1292080d69d6d3857807935
+  md5: 7f517469aa5380c52e55db9f37df104f
+  depends:
+  - brotli-bin 1.0.9 h5eee18b_8
+  - libbrotlidec 1.0.9 h5eee18b_8
+  - libbrotlienc 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 18652
+  timestamp: 1714483267080
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+  sha256: a5094f078584e27c7cced4a9564ae904a329f5c1702a7c1ba092d581ba1544f1
+  md5: 6ddf45dd8a21a9512481de9bc0e5a03f
+  depends:
+  - libbrotlidec 1.0.9 h5eee18b_8
+  - libbrotlienc 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 19711
+  timestamp: 1714483255915
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+  sha256: 93180c973816246f068b742d0bf64840f0ea48e31d4f9b0747ea2ffc34d8855d
+  md5: f3a00096965a5ba1eb41d2c99a4662a2
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 361574
+  timestamp: 1714483400014
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+  sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
+  md5: f5058c8d5b2994b7334f18e022105a14
+  depends:
+  - libgcc-ng >=11.2.0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 427542
+  timestamp: 1714510571510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+  sha256: 394f74202c2efc8fcfd02b8953f508eb6a2961d224a2f9d15091caf5cbe1be67
+  md5: 1202b4ed32215c6405bb42fbff355316
+  license: MPL-2.0
+  license_family: Other
+  size: 137411
+  timestamp: 1710764808838
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+  sha256: 6dc29d20180f6e002f37b251efa639716d3444e129a754dabf751f816aada7ef
+  md5: 5dbfa083e6ab6318fac58fe0e0c94445
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 165152
+  timestamp: 1707229213375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+  sha256: d138cc3fde270eba783baf1e2ba17c89800b2cbbf20976d0eb425b3436a4a184
+  md5: 1875e89c1a939e4e7c5e7b731c72b838
+  depends:
+  - libffi >=3.4,<3.5
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 302401
+  timestamp: 1714483186060
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+  sha256: d9c102b9ec7f3a635936b6f73d4db126d748a25f65407353bd76b260dc7d1cd6
+  md5: eec48dbdf5dac0ea26750cc26b58c1d9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 554986
+  timestamp: 1709758392744
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+  sha256: 882481e441b9b93cbdfb32fbe32a6ad9f26197472f186a08fddb921f61346c02
+  md5: 443c79196064f57c98199e9990544b2f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16902
+  timestamp: 1709322958614
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+  sha256: e4877b41553e31b9f9f090dffab77a654255c63776e8b30fc91ec1f60afadbf1
+  md5: c34d3f1520f1e8c9957eb236710058c4
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281162
+  timestamp: 1700583651472
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+  sha256: 3b4cd8dc60572086f1a1cbb97e2712e0ffd55317ce8f0309d552eee7367855eb
+  md5: 70a1263b6e19bf2d77c020a2e77277c9
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2556575
+  timestamp: 1690905285843
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+  sha256: 4b589e3265c74159130230c164ff2d8d381be65899a249def0b53f93ce83fd47
+  md5: 245cb7173dcdba21cf368031cd87f706
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17434
+  timestamp: 1676823330845
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+  sha256: b75d12e85274660bb675a3e53d47a929872f2daa2ff5a76e98885ee3f2d19ad1
+  md5: f2119d0885334060d0d7fe59e5220287
+  depends:
+  - brotli >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - fs >=2.2.0,<3
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  - zopfli >=0.1.4
+  - lz4 >=1.7.4.2
+  license: MIT
+  license_family: MIT
+  size: 3237908
+  timestamp: 1713551660998
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+  sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
+  md5: a5dc8677d891dff2393b63189a3ad42f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 971975
+  timestamp: 1666798278693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
+  sha256: f48ccfb4214e2af41e73a3904e343ecd1eb1ae06578c26f55a5dd247771b2c86
+  md5: d58e9eb09817935eb7342ceff889f481
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5335524
+  timestamp: 1707836581350
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+  sha256: a0ae6c5a6b615d73d9a243331f3f7d749b4feafdf2f334337fda8abd6c8355ed
+  md5: e61d8dcd4dfd6d165e6e480cee846bf5
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 357992
+  timestamp: 1715090462763
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+  sha256: e08e27531775de40f46b6ac7bf71856963baa0c008bd2b4d112e6341cd3e8f4c
+  md5: bfc7682613c861cbcb4ac01485c05657
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147174
+  timestamp: 1714398938840
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+  sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
+  md5: 3add2ce56858a1b8f6a37342f82773d3
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<1.2.14
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 19310769
+  timestamp: 1699647799237
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+  sha256: 0b670ab17ed2e1b592079bd64386dadc249ddc892e5ae1dd99f142a918ffc75d
+  md5: 632575b9e442c1e5c146cf78424da610
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 227791
+  timestamp: 1705934138566
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+  sha256: 65228eb868c3ec8aa71f958e60a675a919f016c2057392e02fd422fc841858f9
+  md5: 68e23f14cd222c233e6b37262bc61c23
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1612840
+  timestamp: 1704833066871
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+  sha256: a2918ea8a3e2c56fc6d91191e84b2f35500c392b16ab687a0c03ded2e2e51239
+  md5: 84fadd6b7fef393cccc0d123dae6cae8
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1162207
+  timestamp: 1679336523618
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py311h06a4308_0.tar.bz2
+  sha256: f8c1f9c49e58fd9adfefbe99d055a8045643b620902c4758a07d689b21418900
+  md5: 77918475e3a5511cd5a0f595a751b881
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 354911
+  timestamp: 1716993527421
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+  sha256: c21f8f407266d039e819c27fe9eb4fb26587e974f3bd059b37cbaec5073722d0
+  md5: ba1f47411e9e07876c7a3e9d3be6a98e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: IJG
+  license_family: Other
+  size: 281400
+  timestamp: 1677849152168
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+  sha256: 06b729aee6dd2a1e545f3ad64179cc0d4ef8a15e33db3be2995dd3e0868465ca
+  md5: 8bb3215912588e47e2eeb4e7a09ad64f
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 180858
+  timestamp: 1699041715847
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+  sha256: 9e3bac2d41bd432b721b009e7de981766fba396e6f238e923f304112bd88655a
+  md5: 84ae4cf3f2d01fbebdac374971192be9
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 15525
+  timestamp: 1699032521315
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+  sha256: 79ce6dff3d93649a2555b1d2a4ae9eb77175a1c00664cb8eb0e6f848d5cdd1b9
+  md5: db395b0efd7018fcf3a4af879170c2a8
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 276856
+  timestamp: 1676823504812
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+  sha256: fedc7e5560252af44b0dfbe6f7acfe20ab17a6a08e758f670a1cd820551afc7a
+  md5: bd28d36963087f53a79b23fee697d665
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 93898
+  timestamp: 1698937453304
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+  sha256: 2b896fe8b2187b7df824041826e14379476eb2e61d607d8cb38ac2b3df40aaa4
+  md5: 8fc7e517da96c2c482331f6b08d07a17
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41459
+  timestamp: 1699282616532
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+  sha256: 87d372f5b23bcc2410e43b40b4ad059ea1625178b8a2b484fc63805ce517e594
+  md5: 50204f372b1672871d6ab3db6a876374
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 594177
+  timestamp: 1699467208489
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+  sha256: ddfee06ba9b149222c65d1d4270272840533aa63b56fe36363c84a891c71d328
+  md5: ee128e5c0d8d9e1952e2387b66a5b8cb
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27239
+  timestamp: 1686870958829
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+  sha256: 0c6a074272ed58677ec17e4dbfceaffd2108841a61af92b32f156c5763108d1d
+  md5: dd3d37841d0d20c70a60e8c939923894
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19144
+  timestamp: 1700168632051
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+  sha256: b040f0d0ee4588188ab6b83a93738b3ff6e6d1775424be97995bd0df0f4fb904
+  md5: eae62735d710cf5ff6d51e6f59fcd999
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78148
+  timestamp: 1676827253282
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+  sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
+  md5: 88199c75f2ac211728febced7785c24e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 228278
+  timestamp: 1635523146417
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+  sha256: bb990ea068c3b3dafd9c807e0e19570320cb2fe7d69cc326f1f0b5319b0654b2
+  md5: 3ff70744e396b1af69656c574b05c3b9
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 66940
+  timestamp: 1714483221853
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 3b87a816f72a00e1f0022a160e7eda70af89d3de2a2e08a72be1c17b31d759f3
+  md5: 4f57d3a0a13ddaf1c06efb586b702f46
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 34446
+  timestamp: 1714483232430
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 2cf15e89f910600f468edfde8d0f9b80a14fa2319ed89160dc7375dfd3764fdb
+  md5: 463adc13f2feea3570d1eccac368d9e4
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 295090
+  timestamp: 1714483244460
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+  sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
+  md5: 55dde57e63a36b202e388a39dcee9a66
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 74096
+  timestamp: 1695996494461
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+  sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
+  md5: 1af9b4d62c708924417f2640ef22a68f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 154016
+  timestamp: 1714483282916
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
+  md5: 641e72e5067bd6d5454405879e1cd2a7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - _libgcc_mutex * main
+  - __glibc >=2.17
+  constrains:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - libgomp 11.2.0 h1234567_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 8895144
+  timestamp: 1654090827491
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+  sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
+  md5: 27082517590f3b9fbffecc68513b461b
+  depends:
+  - libgfortran5 11.2.0.*
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 19860
+  timestamp: 1654090819660
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+  sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
+  md5: 0202c3c8ae4735cac6c7f3d1e1685964
+  constrains:
+  - libgfortran-ng 11.2.0 *_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 5228750
+  timestamp: 1654090762569
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+  sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
+  md5: 3080c2813e6e1d0f8a100a38b5b3456d
+  depends:
+  - _libgcc_mutex 0.1 main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 573231
+  timestamp: 1654090775721
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+  sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
+  md5: 1bffe1481ed4f88827248fb9001f8923
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 362561
+  timestamp: 1677841789536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
+  md5: 8c195584a5f5471b600ee180e4052773
+  depends:
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 6410287
+  timestamp: 1654090800863
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+  sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
+  md5: ef78eebd98289aceacdfa29182426adf
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 664034
+  timestamp: 1693575237924
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+  sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
+  md5: 292768ec77416ae257cfdd44ea2071c8
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29197
+  timestamp: 1668082729834
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+  sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
+  md5: 9cdeef1d044c7e035c006890f11569d3
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 436056
+  timestamp: 1694776944891
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+  sha256: fd8e30beb8c9442f16e6617fac92dd0c89ec823e98f06e60f712147380ead35f
+  md5: 7ed7caf2816c8b85b67b6f4e8833cbd5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41155
+  timestamp: 1676837080881
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+  sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
+  md5: 76f089e76ec67583bb38428b51008097
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 164494
+  timestamp: 1714510587156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+  sha256: 260e26dd509834c1b225ab7bdb97b9a86e00054fbdd5dfa49e68fa4dcf85a661
+  md5: 8f5d7ddc69cc6f7d44c80d2251dea5d1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162339
+  timestamp: 1676837095436
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+  sha256: 7f5b0804d0768619b7bd93b10488067d80bf42ec29f443f00b53ba11758a1241
+  md5: 8afb45e45c0d93bfd142e682d4b021ef
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 134438
+  timestamp: 1684280014220
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+  sha256: cb03570c99c983d7bfda94bc47d8eb00d4059b8548a171130775acc998004195
+  md5: 5b1abbbf1e4f9b350b16fc9caf9e889b
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26919
+  timestamp: 1704206397615
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+  sha256: 85fea48bea278a77d102781a1cbb6bf69307207d741251e38a6515c5fd7e3523
+  md5: d6ddba94f7c33c88c9825be8409991bf
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9150942
+  timestamp: 1713336680714
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+  sha256: 7ac07ea180b5928086075900afbc332fb1d3c81ddfacb54c891693c284056f14
+  md5: fc83dd1b3d2ec3c0a297ead0c3405907
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19573
+  timestamp: 1676823852670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+  sha256: c9ba2f9c83820712dd97d6a1b54a1215b9820a0be02ac82380b4c50911b9400c
+  md5: e5dc6b4a5b8e02733ce3bc9e9198a8d2
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67750
+  timestamp: 1676837123613
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+  sha256: 1a5141ef0de1cbff816f96bb4b212a40606e2fc11301a4c1358c8d63a6b2b027
+  md5: 22ac3bc22b68fef4c1f3f6ab3c7bfe0b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23040
+  timestamp: 1676827301164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+  sha256: 9aacfbbe6f638c58a4e8ff31374d1438d78b7db25d6ea6fd0c50ca2109f225d4
+  md5: e602057e3b3d80da88c61d66e8851c5b
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104681
+  timestamp: 1676823696152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+  sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
+  md5: ce77d0f05f846da4a6b9e23fe7f21d9b
+  depends:
+  - intel-openmp 2023.*
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - tbb 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 206738176
+  timestamp: 1699648006088
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+  sha256: 2aef0876d0df033f7fae8cddbd25d95fc1bfc067e60dd143bd8000fec0768b21
+  md5: d6cdc670327bd1675bbea642849f04e1
+  depends:
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59569
+  timestamp: 1682948560323
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+  sha256: 691c4b2b47cf3fac55b4949d7c0f547246ef19cb3510749142cee4bd01ffb055
+  md5: bbd69efa3f24ee747410f83118640d92
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 240723
+  timestamp: 1695058405382
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+  sha256: 71f5c7beca4e81b465ecfc6ed51cb3d39f51dd88df0b29eff5def3d1f12969eb
+  md5: 61d58663b7277cf4cc3cb8d9873d3ee8
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331105
+  timestamp: 1695059935112
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
+  sha256: 20d832ce714465ae1685d29e2f913fd105d385d003fe1bef71ef472e6f3489e6
+  md5: ad76299b0c33b7a5c0d45905271165c1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8303422
+  timestamp: 1699542957307
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+  sha256: bb45fb0a3973caa74fd8f845e0a519895f6a378807626e15ecf72c02f2eed794
+  md5: 185f658ba8a74e326b7231c8fd0d62bf
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 121834
+  timestamp: 1698934274227
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+  sha256: 8b2fc372a6655fd5b277d07b994ce43643553fbc37e63a60e9fe527a9026ec06
+  md5: ed6ac14aed5a796b153d757862398997
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 523905
+  timestamp: 1699022906468
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+  sha256: 7908ff6c516b15e8fb677be4071145e18adea7d4c13b8485a70a5ee2f573f8cb
+  md5: 50c0e38207a131a5de6a14ef919ffcdc
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 169629
+  timestamp: 1694616826002
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+  sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
+  md5: 57ea097dc15f8d9f9eb90e1d919143b0
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1157733
+  timestamp: 1674734069410
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+  sha256: 266199dd4efde0ad342a9c500f4bc4299c5622219aea623b46315a9b4f6b8959
+  md5: 2b21844d2b0024d0ffad0e6450cf0855
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 15860
+  timestamp: 1708532713870
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
+  sha256: 13d6c640710895e9732225cdedbe47fcd756887fffeb0cf9bc149ee7234dfc27
+  md5: a87d55e3d071f2c435b10db49a9911af
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 730963
+  timestamp: 1690984942516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+  sha256: ef2857e6d3d7eb246b3abddfbd3aa2d124dd8565391ace3876b77339babc50bb
+  md5: d276d1b1774107987963135c78ca7390
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26607
+  timestamp: 1699455972519
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+  sha256: 2f89f38a665ece47e8868b391fc70602fcee588e989bc1ca6f17f6094892a94e
+  md5: b788c80b2d571531ea4f3f8335ae5423
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 168827
+  timestamp: 1696515597877
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+  sha256: e09e1aff2c12d4ef3fec58fb627744e4b5c7d9eaede7175e293f77272d8b8bfd
+  md5: fe8242cfd54d238507493612ae697ad4
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311hf175353_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10270
+  timestamp: 1708639794640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+  sha256: a53ad723826651041a5057a1cf31bc8689b24d335ce61b196df5124974b05a8e
+  md5: 7b29e7191c4170189d6080e61229f030
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311h08b1b3b_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9163911
+  timestamp: 1708639777712
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+  sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
+  md5: b0afe23033c8c5344640bc25225fa579
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 516994
+  timestamp: 1630084830020
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
+  sha256: 6c7cb4097e4f3655b54a119304e50f0edbc4bd52f36c84629b64674cf8d468b8
+  md5: f1e48c973646ded3c2e1a189a9d8b8c9
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 5498991
+  timestamp: 1716318104769
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+  sha256: 280225061aeba00d7b85f46e55d7d79cd92c92f662dc749d9c53187978e8d083
+  md5: c51c21da68080d89300703ad818c824a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38606
+  timestamp: 1699371264464
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+  sha256: bd3eacd22e85f88bedd9c7e97a59eacfb3c8bb80eb59be244825d6895a0e7ac1
+  md5: 08ceb294ba8a9ae13630da789884736e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 157904
+  timestamp: 1710807470578
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
+  sha256: a2ee3a6aaf54929b82b851b2eb5436e14e5a294303ef429d6dccd33bcdfc8002
+  md5: b467a5c7ad672ccc2d498a67b9eeeaaa
+  depends:
+  - bottleneck >=1.3.6
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - fsspec >=2022.11.0
+  - matplotlib-base >=3.6.3
+  - tabulate >=0.9.0
+  - odfpy>=1.4.1
+  - pyreadstat >=1.2.0
+  - pyarrow >=10.0.1
+  - python-calamine >=0.1.7
+  - s3fs >=2022.11.0
+  - beautifulsoup4 >=4.11.2
+  - gcsfs >=2022.11.0
+  - xlrd >=2.0.1
+  - dataframe-api-compat >=0.1.7
+  - pyqt >=5.15.9
+  - adbc-driver-postgresql >=0.8.0
+  - fastparquet >=2022.12.0
+  - psycopg2 >=2.9.6
+  - qtpy >=2.3.0
+  - openpyxl >=3.1.0
+  - xarray >=2022.12.0
+  - html5lib >=1.1
+  - jinja2 >=3.1.2
+  - pyxlsb >=1.0.10
+  - sqlalchemy >=2.0.0
+  - zstandard >=0.19.0
+  - pymysql >=1.0.2
+  - pandas-gbq >=0.19.0
+  - lxml >=4.9.2
+  - numba >=0.56.4
+  - xlsxwriter >=3.0.5
+  - blosc >=1.21.3
+  - adbc-driver-sqlite >=0.8.0
+  - pytables >=3.8.0
+  - scipy >=1.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17970687
+  timestamp: 1709593080388
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
+  sha256: aa05415302a27a82105e9d0800151f09fd1bb896b90854dc23989f9aecd9200b
+  md5: 4974b1ae5f1a3b6d9fb26e7eb2c26733
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.0.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21869200
+  timestamp: 1714071532259
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
+  sha256: c6c782537b96ab9caf3e25f5a33799c727e84664cdbab37a8d3359a221e2d2e3
+  md5: 8f56d0f63e0589dd7e4a004678307813
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 263438
+  timestamp: 1711136934516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+  sha256: 28ed719669260a20bec78971edaffb91ec917d2a3f0fac1cf9a8ba21590baa43
+  md5: 0481d078fcd64f7f981532a514d9d50d
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 960727
+  timestamp: 1714399060039
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
+  sha256: d527189038b376a982c18613df808f25dc40314b0dc8fe5549f3ae9f4288e497
+  md5: 68dad015e796cc26364b55f92f61faa7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3451714
+  timestamp: 1715097126399
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+  sha256: d2bbab8bfc57c7f46ca8994bc87df7e744d3f036b867bc4be1145ba6d8d7e091
+  md5: de41707272a8e3ccab764f0b7010a27d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37394
+  timestamp: 1692205565974
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+  sha256: e2a0e2a618aa33f0beff9583c7dc510b8d0737b023117346676aacbad33970d8
+  md5: 66a6818307261b1a28ab12d1b7776fdf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 121454
+  timestamp: 1679340540306
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+  sha256: b7f591c19b10bf0daa7e6e3b45a9f4a0a0e83188e1f8a58037caea79e60f8d91
+  md5: d945b4ccc135005839c504cc29df1745
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 749608
+  timestamp: 1704404477511
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+  sha256: 96482b49191fdac59580a95e69508367083e1f7600145e11d7c2db634337eb26
+  md5: 2d57bf8eacf3f291db845928241f724c
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 490805
+  timestamp: 1679337420563
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+  sha256: ed927e4d058a8f4ea73edc7a43ed74877d93b88fdfa240b3b2777244386ced70
+  md5: a1f0e05fc7e49712f81ad5478ec9d51e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2121496
+  timestamp: 1684280065800
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+  sha256: ad219924e362ce7af458fa6547660181579e9a50e5aed1ffd9268cbe7c2650e3
+  md5: 2b1ac40e0df3673d33b7f4c4f93ae1ef
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207338
+  timestamp: 1677811584327
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+  sha256: 114b55e00f4622c90fd2b404b21ad5f94a10283fcaaf86a42174b8d39b0a3e98
+  md5: 2458e92683cc68671a6c8e1b86ce8817
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35850
+  timestamp: 1676822725516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
+  sha256: ef622eb34669f3518d2f855cb333c56b106d02cdeac9d58e5a1a5a3097e4978d
+  md5: 9d4f211d050d511b0b84c2e57e7fb1d7
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.35.1
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 36072860
+  timestamp: 1713546307595
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+  sha256: a0f008717fab060ccd003dfebc09156d90b9afd14ac3626566aa1a8f3d3b7e2f
+  md5: 357bf4fe94496cbae72ab4d780184b31
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 330924
+  timestamp: 1716495762901
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+  sha256: aadc4078311c059265706a56265f0a57ceb538d36179d5203dd487d80d0e8f16
+  md5: 59ec670fcd172447dbd9591b8fbfdd56
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 278741
+  timestamp: 1679340144625
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+  sha256: d5058d0ecc3973316c1d5f1bfb03dd119e0dade85f4c2d21b412c8db4e1636f2
+  md5: 93000e4d3603342779a2afda66fa91b8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17607
+  timestamp: 1683823841946
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+  sha256: b85acb933fff864bfa89d034e8e3d85b1a9c2e69cbfc0d68c1d66ffd1443e67d
+  md5: 0cdb92d2d684ee1095310f992ed0d9b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 266796
+  timestamp: 1713974338678
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+  sha256: 511e8206a15445715b80be76493300930686b3fe1e512ae942d6ccca36df392a
+  md5: 35a6e46ae970f8b71d78fb5a810f2e80
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64013
+  timestamp: 1711136926372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+  sha256: b2a1f649669f4336b74f6f20df711959bcd8024f8f8b94199dc0e040b06bd37a
+  md5: f9e8e3f7068f717f75e555dc04545d8d
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 206433
+  timestamp: 1698096204677
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+  sha256: 7c74db4292f31619606180f86f3c1e2d913495c2c9d1195c5d51681a6a841625
+  md5: be1c05fae57d194924b9400f9b5ad3c6
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 613277
+  timestamp: 1709318516682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+  sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
+  md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 467661
+  timestamp: 1666648052561
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+  sha256: 89c2f4235277b9825cc805c5c44f0b1afcb683d7b5a3f513bc4bf243b643bb0c
+  md5: db70eb57e33adf7b8bbdadd72214d48d
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 73679
+  timestamp: 1699012111499
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.2-py311h06a4308_0.tar.bz2
+  sha256: 12c831fad9b6e0acd3821819072a81c4ed7007e90f2daa9c711732b69c57548b
+  md5: 0b9387d074f6714268bcc44c1f2634d9
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 121943
+  timestamp: 1716902856135
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+  sha256: fdae3f68ea84b99561aee6c566ab1c287d8f2ae2668424e9283a8ed86af8f1d2
+  md5: cde5b71ccbb3630053340b2c8c7dbf10
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9333
+  timestamp: 1683077183576
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+  sha256: 0bf859b06a07857099fd4f524fe5e0875fda70029e9485d95c7efa97134fbc14
+  md5: fd5815cc592fdbd4c831901541eadaba
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 9735
+  timestamp: 1683059096795
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+  sha256: 474553d01aea57214a54a7443f227da84a58e29c49eb7605ba0043c55b7d167a
+  md5: f01333e9f0a908e435db650f42fbd2db
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1096668
+  timestamp: 1698946168635
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
+  sha256: b06b45da61807f76b6d800047f123fee2cc95eb84da508550e0908951c8d9f6f
+  md5: 9b100efb9ba2fc7f9bcfaa8fd2ab6f9f
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libgfortran-ng
+  - libgfortran5 >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 4
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 27615256
+  timestamp: 1714076660659
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+  sha256: 51bcea0e575a626f6ffbd16d1153330fda93dbe3dd31dcd3a8f469ff61dd1e4e
+  md5: 41d531c90be8c82bf79635ff3d409476
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 32295
+  timestamp: 1699371262818
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+  sha256: 0a95988ea269c96354626dcab255b65b54bb5c503d24cdeb6ef2e1c42818bd59
+  md5: 8bfb9f42492b3b53b8151d77e51c75d8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1594974
+  timestamp: 1715024182643
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+  sha256: 1a84b00944bc5588e14a097460175f97df49acb4f1ff2498ffd9a1893068ed81
+  md5: a456513471b2ecbed60430c21dd1ccc7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17880
+  timestamp: 1705431390054
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+  sha256: adcafd297d60af64107c113bb7b8b92160d0268a44ef9a3b79e56a88a0358ea7
+  md5: 28ed704ed26b06d32662e3a6a87e59b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 88799
+  timestamp: 1696347581401
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+  sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
+  md5: f86119b3243fe3508160aa0406245738
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1723866
+  timestamp: 1714488309729
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+  sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
+  md5: 041a3caf09dc9ce8fc6c10925c4fe050
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1888016
+  timestamp: 1680167274961
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+  sha256: 856a8ab8c350c50247b79966c6cb80fb6d4de36eef49ddf75aebbbcaf854c82d
+  md5: 442dde204d14d171aab9ee40e8de4de8
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37456
+  timestamp: 1677696176157
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+  sha256: f0a026ddc0ed041bfc60c8a1ca0b70b7a69232775b3181bfb35a39fda42d6994
+  md5: 2902d5a5854865baaaf58dc59cf06b3c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49185
+  timestamp: 1676823769869
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+  sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
+  md5: e2512d57c8a1e91e7b20e265c6906546
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3588922
+  timestamp: 1714770676475
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+  sha256: 1bf522ade750cf0b70d61e71916ff00569e2908db1e9dedb223fda2608ed8bde
+  md5: 6793c74fe94211c0bfe6766c6dd490af
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 893808
+  timestamp: 1696937055591
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
+  sha256: 54f41afbea1c01a10e5703e64645de145f34ad6d89cf245fbc5cfaaff58a8743
+  md5: 15b6c8bee4c28c6efb3e388178b37145
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 154276
+  timestamp: 1716395957568
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+  sha256: 0575785f6553e61cc6138abfd5de52305fac6f85971642fa1f056a76c66a52b2
+  md5: f2c25e5dfdd23f70b83776a8832893cf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270865
+  timestamp: 1676823316868
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+  sha256: 8c06c291c76e8c2022ffbb9fea4727a4bf1f9b03e498bafc56ba8ac4e7604ab9
+  md5: 5adb7baf1091d09026a372cac930ce6c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8869
+  timestamp: 1715268966416
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+  sha256: 118b0801167264c401e84bbf19175546092a5569cc098146f7362bbf890dc8d9
+  md5: b3c2aa56d53b459f8365d8385f48d0c3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 74489
+  timestamp: 1715268960737
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+  sha256: 509b962773f0fe44a93a7f6196b254670a030eac8ea7f90727312e3ccd9294b2
+  md5: 6c402d5bf4e01c8c3895c9ef41707b6e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11371
+  timestamp: 1676828901104
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+  sha256: bbe7629e8ce52c82f13ed0d1fb919f3659ef466b274a7c74aa925a9bc7aee450
+  md5: 7da527bbcf71270c1abed8ea52e7d44c
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 509031
+  timestamp: 1713213062098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
+  sha256: 5c6afad310db12b3658a652efc5de45c182164a0b537cb2cdae5885428b30d22
+  md5: 89ea2fed160a633e0a6d152b61cb0dd2
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - zstandard >=0.18.0
+  - requests >=2.26.0
+  - selenium >=4.4.3
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 209068
+  timestamp: 1715635972793
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+  sha256: c3a5e0b855dc2de6c162708dfcf170a23eb9e7525d4252d8dce553369af4a330
+  md5: a4c77e204b7787f820955166a1283168
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25890
+  timestamp: 1676823132898
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+  sha256: 42989f9970a8466cc4edb73463dfa194594dd1a5d42c9f820a1f86296d4af140
+  md5: 655dfd4d2f17977cb81caa1c082d2b25
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 113505
+  timestamp: 1715878346465
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+  sha256: eec0d2e0bce4b62278cacd7b0bee053160845e86507051a5434d2069bd290f36
+  md5: a069e5aef64a6dac076cc9a3d28a17c9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 136022
+  timestamp: 1714717059748
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+  sha256: d18cdca154bf668826f869117ea996c4f9e8ef7d27b7c528332a7d17e5a8602c
+  md5: 9f7353d72046b16dd6ef6b5689ac9bfd
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54731
+  timestamp: 1676828934954
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+  sha256: 9122d6e9dabb7a47f2bcb15d86b97c96c49a9048da3f8ae59675351710c14cc5
+  md5: 660b2aead2ec87b751c86cd33934f44e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 716926
+  timestamp: 1714510796277
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+  sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
+  md5: 943f1247a22b6b64171363bcee1eec27
+  depends:
+  - libgcc-ng >=11.2.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=11.2.0
+  license: MPL-2.0
+  license_family: Other
+  size: 371663
+  timestamp: 1705602144682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+  sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
+  md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Zlib
+  license_family: Other
+  size: 127143
+  timestamp: 1714510716441
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+  sha256: af3c032f06352e87c450739cb8aafe1ff34ad28bf074b214ea98b3d29259a85d
+  md5: 51fa34bd0e016ed7c5371cf6cb13ef6c
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1044463
+  timestamp: 1714678445052
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
+  md5: 544adf2677c47c9b9c891aea720678f1
+  depends:
+  - python >=3.5
+  license: MIT
+  size: 33999
+  timestamp: 1630003259346
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+  sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
+  md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
+  depends:
+  - prompt-toolkit >=3.0.43,<3.0.44.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5106
+  timestamp: 1704404390460
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+  sha256: 459f38609d854888998a8d76028019dbacdce2bfe401eab57b8eb8ff16da9c7f
+  md5: 2948a98ef4de5decb7e5eb888eae68ba
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13056
+  timestamp: 1682965564630
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
+  sha256: 305e5fd9993f3e5506f386f98794c7d53b6e6c68d4d411ada724de49a17945fa
+  md5: e1fbbd2d11d21aaec3c32f7d332c0e77
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13818
+  timestamp: 1712163766707
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+  sha256: dc9f709bacbaf08a0941d2622d82f91f18b355e82c55348ec29f1391215ca7e0
+  md5: ece0f5837a4de2d4d5f1abf8347cd10a
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 124922
+  timestamp: 1708711884650
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+  sha256: 5800a2466734dd1ef372bec0dd3f0880c5072fa1e8b0668f5054f834285e991c
+  md5: 18194e51d4420ac08f29f3f86581b52e
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 229003
+  timestamp: 1706220302459
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+  sha256: ab7672364f1fa55ec5d8311d85d40e5b57cbd3517b17670557b6fb822bcf759c
+  md5: 6e0159a5865cb7e96a748bd8560035ee
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 11579
+  timestamp: 1678317458652
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+  sha256: 51556902e09436d46878ef772805d06416ca96ffaa66340b5565c0245574aaf5
+  md5: 4cb1b20635cf5431d34cc96ca1e8a751
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 33355
+  timestamp: 1678317111825
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: 188b74f717e3ce3595da404c0e027b8ccafa9c186e88325e8f02c29d7b4c0744
+  md5: 04ad90eead5812a0263b42321056ab33
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153694
+  timestamp: 1695717975427
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+  sha256: bf3c60386619f08cf5105b4b903bbc109b3252c3b923fe055aa445908a01969c
+  md5: 3f84a301921ec6400b7f1f1c4ba3260d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 270017
+  timestamp: 1681493109562
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
+  sha256: 126ae8e30b8464fb2dc94ce9163dcb2d5482f7214c7d8a48340c3f09f1409d5e
+  md5: d5e0c054042910b4394a14c7eb4d8131
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6080356
+  timestamp: 1712084675745
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+  sha256: 9acafafcaebd653c2372ddc864525722e1c55b884b5eba22e28e2b2d946b853c
+  md5: 22375cc3c2edada31b85af56c8e6dee6
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 155829
+  timestamp: 1707864406086
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: d8b1ccb15297dcfb3f9ebb8139c3e28a13d6c2e73c37612cb214ab6cc58b15fa
+  md5: e5dec9f13de061640ad2697562a99b54
+  depends:
+  - brotli-bin 1.0.9 h6c40b1e_8
+  - libbrotlidec 1.0.9 h6c40b1e_8
+  - libbrotlienc 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 19732
+  timestamp: 1714483415038
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: e9fda4393edd0234c88efc2b88e0edf42c94eb49ea5b189a80afd733058be8fb
+  md5: 13ceed558eb174d6b77ed1b0035f1785
+  depends:
+  - libbrotlidec 1.0.9 h6c40b1e_8
+  - libbrotlienc 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 18400
+  timestamp: 1714483395748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+  sha256: a323af3251e426962ad16edf8f46a696ef502731faf12aee32ca289c40b11342
+  md5: 658ce49e9f07dba7a1afe70fa2666e0a
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 393858
+  timestamp: 1714483549536
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+  sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
+  md5: c5a600d81b1b48578863af2973c743ac
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 187637
+  timestamp: 1714510590009
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+  sha256: 0c5f9766aa2dcc08ae71b6c0102046a56b30297d0bedc3039b7f72d1658baa43
+  md5: 34583b436e62a2ce55d6a7e8eb818e33
+  license: MPL-2.0
+  license_family: Other
+  size: 138712
+  timestamp: 1710764814844
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+  sha256: 20b1fc398e925e6c8cea6a06d3bb614e2c0de886e3f14f85b0ba26e57ff40b7e
+  md5: ac95cfe373c7fef7820e93189041b0cc
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 166856
+  timestamp: 1707229213510
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+  sha256: 6b5bebc13755b0a5ef423219eeecd1c25b97dbe83afad6e2552635387547d9f7
+  md5: b7bc4192fcfed7fc7df1ce00bce97b02
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 291802
+  timestamp: 1714483319125
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: 9270668e34b00a2605584a2db5130c83826855cd05b896ce949f3156fa197429
+  md5: 2586aa55677e822e8285d777f9039ca9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 543487
+  timestamp: 1709758497949
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: 389c63a84b92a6254c9d361ebe970d537d0b88733efd5ac5c3ee58196fd2c5a9
+  md5: c7bc5b3cbe76be83a27f00b7e4740727
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17974
+  timestamp: 1709323004148
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+  sha256: bebfc5aa6be12e61a134b580b07b67f7d8c045d6b113fca5b21fa1e83a2f03ce
+  md5: 239df72a3921c951059fa8afc09643f6
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 287736
+  timestamp: 1700583644534
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+  sha256: e0e30590a78d99d51445ac4f668aefe1bf20025a35bdbac00f04647b95c9f152
+  md5: bd0db635eefeea82a0c567b39c9a0e3d
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2485698
+  timestamp: 1690905283575
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+  sha256: d48b47b86b09dac1fa4542ec13e1bd4e23093638e684fa66ec3afdd9ce9337c1
+  md5: 5a2d1828ab7c8eccd3c2610d13672977
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17336
+  timestamp: 1678316187749
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+  sha256: 54645c22fabc25b632114d1d3c403a6fad9149b51ab36719b2690a084f14a072
+  md5: a8ad2f4abfb2e17ecf6e596342528156
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lz4 >=1.7.4.2
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  license: MIT
+  license_family: MIT
+  size: 3180691
+  timestamp: 1713551771692
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
+  sha256: 4120472ee1c5d31efffeb045892bece27b9a15a30d77c35212f6508221635918
+  md5: 9561a225b5171285250c9071f8cab074
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5368257
+  timestamp: 1707836808668
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 50dee40e4a9ea7a035baeecc85770c88d63d4e6b0c3c2519c1429e881171150c
+  md5: 4d465f453dca5c65224dccbe953f600c
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 359293
+  timestamp: 1715090716440
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+  sha256: 5c2458964157fe493ca18c513c693b70cb622087e5fa0c93e65fc45217edd811
+  md5: 15629e52625221b51a443cefd9501d12
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148522
+  timestamp: 1714398885844
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+  sha256: e0127f50d444bf4474e8df07d602c7f6dd38690e8bb3fb28817c164940ffcde1
+  md5: 583fcd7060cad6a77074d00d9ef62f44
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 731417
+  timestamp: 1699647668990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+  sha256: eb58fa29b1ce9aa5fc774d4c466696457695dec3b206456614b4c9cac0a94e42
+  md5: 3d3291ff58dff83dcd40ec54b435f4d2
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229910
+  timestamp: 1705934029588
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+  sha256: 73aa7662c00c73bab2dafefefc87a1b524961d2687410af624ecbd6703e483f3
+  md5: 7e71e99766107a553752ed8f22b61cf0
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1611976
+  timestamp: 1704833049616
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+  sha256: e08cda2bcbdec124c63e951eb248c503bb1467c2a6000010c6bdc0726e0e00b7
+  md5: 22c24f43b82da8b3920a913bbf452421
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1168968
+  timestamp: 1679336359851
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py311hecd8cb5_0.tar.bz2
+  sha256: b80384bec95335d8ad37895f5cfd2d8fdfaae7be05507f218344ddb5c6713d38
+  md5: 8ac4f4807344f09b39c1b303cd2d1937
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 356777
+  timestamp: 1716993516277
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
+  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
+  license: IJG
+  license_family: Other
+  size: 278924
+  timestamp: 1677849185191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+  sha256: 99fc6ac82c56eb2a580f96db24a5b887f8abc8c24af445d3313d5ebb48598478
+  md5: 71892160908a6daedb5fb7c404079ae4
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 182073
+  timestamp: 1699041732321
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 0ea44d0c8044e70ab0eaf4d6f5f3e4753838dee106b5cbd36561e21a65cbac77
+  md5: 1d045016dca889d702f1caf3a16162fc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16528
+  timestamp: 1699032525791
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+  sha256: 70442ec4b0b7ebbdcf150963f61f797b861001092124f4ea39a16eb92a4d176e
+  md5: 63d1503915a15ae4f9ad1c46112ca374
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 272720
+  timestamp: 1678316970740
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+  sha256: 8601c674f4779900f6a949e47b814be68b722b0b3d394433bec9d197924ebd69
+  md5: b8423f8caff3041a251fc3681f43496a
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94990
+  timestamp: 1698937583196
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: 6a430c812ce0415a04d9cfe6c66d9012eced2d91c04960c88bc8ec1e9f1b5d6d
+  md5: 30b3d5d6a8cf5d1604e5f5fb177917b5
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42513
+  timestamp: 1699282637015
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: c2d206db117f7161e77236ebd6b0051fc73e1731c242d1e08597d736a0376c92
+  md5: bdb61de2e20e02c93423d9de091c74ad
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 601837
+  timestamp: 1699466514455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+  sha256: fd7964657f0a8fe8b167ba860b1f960e8b7b45309eb6c7c850d50ec283fe03b5
+  md5: 2967bb345bc75f53182e263ff4743ca6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28223
+  timestamp: 1686870845224
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+  sha256: 64cf59f0f74b0329b5069bc6135b4f40593f1dac52d85ad574d4b8e0a4b2cf16
+  md5: 35e8b80eaa03a904fc7f1da39e7f654d
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20234
+  timestamp: 1700168776500
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+  sha256: a12382b50416803f559a03fb384ba492c1dafa351e1191a3f8dc361bee6c4f37
+  md5: f2ae846b663bbb642f4b1e90eaad38a3
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64817
+  timestamp: 1678322501509
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 685c3bc9068bd485604b80bf03789e4dca95c410d33871bc1b882e47649fabed
+  md5: 6cf8e55271e150ca0961d0ddedaa61bb
+  license: MIT
+  size: 66237
+  timestamp: 1714483284541
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 69826cee54db9955f0120af21ec36d13f9211877fd67364f2068d0a54c6c97cd
+  md5: 0851917257f490d35e1f73da8a1c723c
+  depends:
+  - libbrotlicommon 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 34042
+  timestamp: 1714483343147
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 3f5a1f03b50b90b397a0ee432ad0cba13354abdaf7e5652c0fc60164b26a08b6
+  md5: a50bdc871ef4bf14deb088d888b92b5e
+  depends:
+  - libbrotlicommon 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 311597
+  timestamp: 1714483371586
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+  sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
+  md5: 822a5b76117e56d3912f1f2153307528
+  license: MIT
+  license_family: MIT
+  size: 136045
+  timestamp: 1714483561919
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+  sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
+  md5: e458587c87e3f2d20192f4e0738f2c63
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 149419
+  timestamp: 1665498987619
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+  sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
+  md5: 1058b661ec829b2ee3716ee2a5520641
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1917987
+  timestamp: 1665498925405
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: d28c465ec6d5f8d4962c597b249b58998300c8b4e3c937c578c3d15294ea863d
+  md5: dcaed6ddd0723c7cce6bfad917be98b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41176
+  timestamp: 1678413498410
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+  sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
+  md5: 5c740b4a18a558de0ccfe601703c423c
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 338738
+  timestamp: 1662635677689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+  sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
+  md5: 8f57dc3a3327bb6f7e1cba908856ac7f
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 183138
+  timestamp: 1714510756758
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+  sha256: 6fb2953e169ee1ae38f24d29752051501992f19b96b5ebcea9af75737bdbcb42
+  md5: 7f410cdae838c5030108d1b98a8c78f6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162478
+  timestamp: 1678377892595
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+  sha256: cd97e09a12ffb49b2a30a782fa8c7933b28f5ffdbfc5c73a9ebaa95fc9447370
+  md5: d1fb6ebc1e5728aa6377cfc71da08942
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135859
+  timestamp: 1684280005320
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+  sha256: 30c3b189462a9d0f4794d229adadf34b5f5a5f56f95c30d5afc17ef524579290
+  md5: d4e9421243129d1d57c472dab045f3dc
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26639
+  timestamp: 1704206159955
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+  sha256: 080000a28b3ceca54eec6de0748c690ea5a4c390e358283eac03fe7a6dd87065
+  md5: 51344eca57d7940fb01eb5e8914509e3
+  depends:
+  - __osx >=10.12
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9099909
+  timestamp: 1713336790553
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+  sha256: 07e7fd5bd64e55328b4b99d92e2e2600d791f1095bf905daab4cfc59f0f0a45b
+  md5: cf53321779f4ca7e986c1468719b93f1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19500
+  timestamp: 1678317565001
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0770e02be1ea1216af493cfc03d5b8a702e14606fa93b0692bcdab1fed1b898c
+  md5: ca6f06ceaf66a32bbf5dfdb6e373a5cf
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67892
+  timestamp: 1678417734353
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: fbe95ed0501bb0f137048476fe41bc718dd659e8ecb066bc67ac17d6a50f4318
+  md5: ec162bde8d1c8a107b257df218b17035
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23030
+  timestamp: 1678381838497
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+  sha256: c20dd678655e582129a858a1c5162bdc254082d3a3c035b0f72629d9276e5b75
+  md5: 800a0738c728796e02d0386ce7d457aa
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104585
+  timestamp: 1678317269407
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+  sha256: c825bc3070f73318ffff88a7a0b7fc6d1858b058ced735efd1789053f1583918
+  md5: dea5f96459c9a6df6b026ca57d387936
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224299920
+  timestamp: 1699647835748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+  sha256: a76c134ec258612ff7d55cb2a19b9e3461cbbd375a744bd29390af9cfcd283b2
+  md5: 1c736f58992009f53f014aef163bae31
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48442
+  timestamp: 1682969160267
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+  sha256: bcfb0d1e075d043bcf05fa1a7ce3c142bf222d29693366af49a5a346c770812f
+  md5: 59e4820b34049cbc6619a8ac97290abc
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 222137
+  timestamp: 1695058350477
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+  sha256: 114e408c40b332393cf2792393e4d1ede3465abcb3d345fe647ee519565346c8
+  md5: 86b13271578e1fa5e664edcf6fcb3ce4
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296860
+  timestamp: 1695059990370
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: a58960e88525a202ba193b4dd8227c4d9c3dd98b8b43edea34b05a9a9fd1121c
+  md5: 71a37f987c3df6657548d098bd2a58e7
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8286383
+  timestamp: 1699543227340
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: e08cb3ee6df01f4c1e1ac8bc4ed1a06e549ffcc8774fe2e2842c644bb8f74a86
+  md5: 6ba0ae0fb14cbea1e3197707701dc180
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123077
+  timestamp: 1698934356774
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 2f946b5042eaac97206b5217fb203f3604ab3a60aecd99bdfc684925e3136c18
+  md5: b24026076c381ff2009e7acb9e0a6e87
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 534650
+  timestamp: 1699022791300
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+  sha256: ba368605a0af6f1dcbdcb6fddab9ce63224a85dd11bfb2b1acace1dc17899411
+  md5: 91f3ea3fe44d619ee95a6ed3773a0814
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 170926
+  timestamp: 1694616830121
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 42d803e1d8b54748db5d989ecd503826f564132df7cddc20f520460f55e523a1
+  md5: cd3fa71626ebc098da4625fc6be79752
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16952
+  timestamp: 1708532805951
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
+  sha256: 92d50872fad0d1fecfea42cbfdb69887def80927c169a88204d163c2d3c7d035
+  md5: fe6780b8659ff5d6061268708a7b2032
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 716120
+  timestamp: 1690984968401
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+  sha256: ed5608feb37a083d47b04203195260e801b64b5380f292cf18bb61e7ad827a2a
+  md5: daa9c1c233673b727528548454aea664
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27607
+  timestamp: 1699456006797
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+  sha256: cacba45c1eebf7d86748737717883a98cf40664231460fa41391c79f98d06f45
+  md5: 3dbfae0d5b90e77f9358564ad442ac9d
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 165572
+  timestamp: 1696515553184
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+  sha256: 1466c3af380b949612c79940124e426eccd59e335c205da0c00383a69358d1c0
+  md5: df6be53592d40ba7e03d6ffe349760bf
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311h53bf9ac_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11330
+  timestamp: 1708639985606
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+  sha256: ace67d704fa7eea1480eb463f2d91bfc161be2ee20263c5a9939805ae3c2a9da
+  md5: ec124589478fa12fba4f35f31c3a0692
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311h728a8a3_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8783230
+  timestamp: 1708639945646
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
+  md5: 93f5d7b66976154adeda219bea02ba45
+  depends:
+  - libcxx >=10.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 484257
+  timestamp: 1630093862501
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
+  sha256: 891ffe9826f6f9ec9a4fc5d1bbb9a64f9de23f27705c2202f7d475b7cd14dd83
+  md5: ab0d447c9eb4fcada05d853bd13a24ac
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4970613
+  timestamp: 1716319014066
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+  sha256: 8a0809f419065e014cb8e2c8a516cadca6088fb71fd1ef3ae2287d91e3360d59
+  md5: 4dc0b9bc88476fcc5246d823ff1c289a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39645
+  timestamp: 1699371213055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+  sha256: 64fbbb03570788298d8b04d4ea6cb254fef5d5eec73265aeecd72cb565617f4d
+  md5: 4b1195028bc26257df43fdd943638266
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 159450
+  timestamp: 1710811009212
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
+  sha256: 6abb7e0aeda0130f54925421900772e1bc46d1f04ae69ce1376524457686d49f
+  md5: 232a6370c3fab0c41c6d4c7339e778ca
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - xarray >=2022.12.0
+  - xlrd >=2.0.1
+  - pytables >=3.8.0
+  - qtpy >=2.3.0
+  - scipy >=1.10.0
+  - adbc-driver-sqlite >=0.8.0
+  - pyqt >=5.15.9
+  - fastparquet >=2022.12.0
+  - pyxlsb >=1.0.10
+  - gcsfs >=2022.11.0
+  - matplotlib-base >=3.6.3
+  - tabulate >=0.9.0
+  - xlsxwriter >=3.0.5
+  - html5lib >=1.1
+  - python-calamine >=0.1.7
+  - pandas-gbq >=0.19.0
+  - odfpy>=1.4.1
+  - pyreadstat >=1.2.0
+  - dataframe-api-compat >=0.1.7
+  - beautifulsoup4 >=4.11.2
+  - lxml >=4.9.2
+  - sqlalchemy >=2.0.0
+  - jinja2 >=3.1.2
+  - s3fs >=2022.11.0
+  - psycopg2 >=2.9.6
+  - openpyxl >=3.1.0
+  - fsspec >=2022.11.0
+  - adbc-driver-postgresql >=0.8.0
+  - numba >=0.56.4
+  - blosc >=1.21.3
+  - pymysql >=1.0.2
+  - zstandard >=0.19.0
+  - pyarrow >=10.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17296294
+  timestamp: 1709591285369
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
+  sha256: 10a5eb185aa5dcfecfa854c2e66b3779cb6d2dee85f1b2236f43234a1c1ba9e0
+  md5: 2200abcb857e6bb8cb46b861cb4d2fd7
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.0.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22071486
+  timestamp: 1714072093679
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: daf01c56a3c44555ecb61e9a0e899a7b58872c6b7631f00a04ee8d3199e9e568
+  md5: 2163ed8005a14ecda15efe5586582cce
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 267508
+  timestamp: 1711137004592
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+  sha256: 90efc71d35ab62d5b8d7b648e016444e1c4c8b83238b6dc9f2c6c3db4b14c599
+  md5: 6b6eeb0a14c5479db1dd39aa8d338150
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 939480
+  timestamp: 1714399174883
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
+  sha256: f6b0ded7010706431f2a6d9776aa6033dfd19d2264b3cebf28072629160090a8
+  md5: 02de6d0d9cc23fafe2e3597ed0e52693
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3444268
+  timestamp: 1715097155645
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 81719c31101d6c019150cedcc7b08adb3bdb357e8b2952e428dadaabc4dc985d
+  md5: 105825168e0a17fb007f60b5f314e311
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38405
+  timestamp: 1692205731769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+  sha256: c0982f688127129e026d2b4cdacdd5684d00796ea7bdadd7d26b1101b095d723
+  md5: 0d6910c74729fede645c010110f1c89e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 121796
+  timestamp: 1679340253537
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+  sha256: e32843723b10ecd9badde28e1085419c0b59ed8a96c7cacce6395e39e3a874f9
+  md5: 5af0280a817d2c273304cd22328124af
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763044
+  timestamp: 1704404460779
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+  sha256: 117a435c2473e2a20cc81eaacb2b45ea5e7fe3c946eec2915936d344913ede44
+  md5: 0f459ee59fda20e2077fdc2c777edfc8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 497470
+  timestamp: 1679337286052
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+  sha256: dfb403f367c57327a4d080109df88383ecff18464de287a1ce936a7274e3656b
+  md5: 997b674bad89963af875b93b06807f51
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2120413
+  timestamp: 1684280057020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+  sha256: 9d2c0f373ac1c5db329581793dd517092cdf9a59140f2516ed8c3a1f483c0bbd
+  md5: ee10503a159e819abdc586666bdf0952
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207552
+  timestamp: 1678322848766
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 717e038567506ca58ce1cd4a3416892d02f4ebfdd332077cc3d110cfe3d36c58
+  md5: 53bbfb400668f798eef6f8c7cf938e1f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35751
+  timestamp: 1678315886516
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
+  sha256: 092dea8d520acff3e64c71155e666b0b6074d37a71d5eb32f3cd485b0d185d0b
+  md5: 9fbaf2d9534c26e76aa14b11b23de332
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16852220
+  timestamp: 1713545835789
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+  sha256: 04e100d0a1ea9722e24972657ec5935ad34c7c58957dabb821333e5eac80f717
+  md5: 2b6de49ad07b26e1f7084f0fda958eb1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332276
+  timestamp: 1716495830117
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+  sha256: 514249897265f66f6ecca0a4427eb02a43c33b3c24974db16d05db6bbe97881d
+  md5: c9ea1437e5a3ba6a52ec2322505203e6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279116
+  timestamp: 1679338758489
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+  sha256: 78b785b9b6ed46c86b0d3a32bdceea49f816672227fb63e726b2d46eadbdba0b
+  md5: 79d783f74359141e0b06a848db33823b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18563
+  timestamp: 1683823935261
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+  sha256: e358fe679e83ccdc8c433746ae6468e8e96d90d97d99530f8476ef5630b2c121
+  md5: ce30a0a31d891e69dc9b7bf8b7f0c39c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 268876
+  timestamp: 1713974360942
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+  sha256: eeb5a5eed93b8e311ad4d3f4389e050f11bba2eaec9536e1c3ed2f849c6c999b
+  md5: c18bd3e12de797d52a470c21a150dffe
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65270
+  timestamp: 1711136914884
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+  sha256: c3e11ed944da69c11b949bb918341a0d79ef603ee34a632d6a45fbf89ff924a1
+  md5: fee7ff4d291f530b4cecb575f29807a0
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 197996
+  timestamp: 1698096137432
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+  sha256: aa07b90a7ee65f76c8cba1ff99a5cdeb95cbe41881ae951f64ffff06674a1b2d
+  md5: 58621e3d244137885f7dfbb35e50340a
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 594801
+  timestamp: 1709318510622
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+  sha256: d784dc26c5de8e41845350a899e5779250b71f45d39e2aece62e739e9add7308
+  md5: 7b077b7f46112bb31dc066396c51d3fa
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74776
+  timestamp: 1699012164201
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.2-py311hecd8cb5_0.tar.bz2
+  sha256: e8c25fe5f26c25cc3cd5a744448a791c246610d3fa8690251f9e1fbc44188248
+  md5: 28182e1a6b8c2c519dafc90093396a7a
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 123233
+  timestamp: 1716902968357
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+  sha256: 727fb8d957e02d03b928d049ffbc712316f176a2c331391766d646621b45655a
+  md5: 7e0e416c642f3ee4ddfb084a811fb4df
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10236
+  timestamp: 1683077214314
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+  sha256: a8a67143ccb65cfd6f50055176b6c26179a83130a45d0a12e79dd2de68d8db63
+  md5: a2065790f41e3eeb6efe0ef6daa75377
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10600
+  timestamp: 1683059285216
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+  sha256: 6aba582338faa0c26fe336bdb10c65b8f7808a6e383bd8f80f3e6b612ca209ec
+  md5: a7486349b5f7370f6902c2050a23d268
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 319197
+  timestamp: 1698946203341
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
+  sha256: 86bda04163628ef7b35528fbb4fe1d56fef50d10570a859e5ae8a7fbb60f577c
+  md5: 05e397dddd20d91460e3cedea0b3686f
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 4
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 27745043
+  timestamp: 1714075585637
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+  sha256: beba0555707dac1e8484d73cee9e4128ac4b10e2a0d4209357481179022e8fdc
+  md5: baa8b304607b3a9ae8a3d9acb354c31c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33343
+  timestamp: 1699371216044
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+  sha256: c1df29188e321abe23651c73712a6d8ed3abdc89ad38a42c33f1835b3ab77abe
+  md5: 6c984ea85326858942f7b635e0cc9ff8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1597325
+  timestamp: 1715025837032
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0eb44a16ef74a13ef7839209899d009cd94974fbc406a417d958c7bc8d955245
+  md5: 41f239a5b67b1daf819849023aa5d12f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19056
+  timestamp: 1705431379885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+  sha256: 14775231982e1ea150189c956927ccfb1ad01a8c9395cdeea4d5a48b9b8ce664
+  md5: 729badc4bf7ba8ccc70e0f9e58075c99
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89812
+  timestamp: 1696347694075
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+  sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
+  md5: 6bef1694163a68ac4c37e5857b8da4f5
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1900191
+  timestamp: 1714488351925
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+  sha256: 3d5c2968f581006437df3932cd5d3c1c4afa78f0e13757b958440245d3248856
+  md5: 605ea221d225ad8e79284dbcfdab0715
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37699
+  timestamp: 1678317755913
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: ed059e32ce5a1c0511575f29d2fb6da12c54a37000bfa80f9e5aa9dfd9e04101
+  md5: 4d2261a92d25136a68b8d01d101119f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49145
+  timestamp: 1678317386284
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+  sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
+  md5: 523c006cc67c011383678c762015479b
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3594448
+  timestamp: 1714770737885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+  sha256: 6ab71b48d145c69007cfb5b4a21def2cc83bba972b7cc91c7d52d0d7eeb055bf
+  md5: f8970b0ad5c8b452b8722ceb4e5c17f7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 895379
+  timestamp: 1696937269468
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
+  sha256: 3df84b9897f05a104c99e297dc29ad8f718982fc64c61b5a2204c19c578f47e5
+  md5: deab971930d242221ed86bfd768dde40
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 155545
+  timestamp: 1716396266697
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 9e8dbede0bc54c77b974210be66503e7e8e45e0f1c71dc5c16cc9a9674d54259
+  md5: b4fcab9e63bd7b3cdf458c953904807c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270874
+  timestamp: 1678316116954
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: 17e5688d09ffbcb8b71b34b86edc7374fa0b04d60a4d729d405ffc22ef63726c
+  md5: e4bf44ddbbcb136332ccb47ac2b879a0
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9890
+  timestamp: 1715269046804
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: 7d369ec970d1d5411e457c79f94197756c7088deff8183806ea71e633b26edf9
+  md5: 9ffa197b26373667f50b21876862398e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 75595
+  timestamp: 1715269030928
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+  sha256: a9960485ced319ac91afe69eaaf703c7e6b3049f1e06a4a8c2818b64155943f0
+  md5: 0a9c8ea92a14330a07edabac249e32a9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11399
+  timestamp: 1678394892923
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+  sha256: d42ae57366d05e12f10074583568355752436d66ad018ffbcfa24135f593810a
+  md5: 1a98e48aa0bd8b3ec09e2cbdbb236575
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 498952
+  timestamp: 1713213079520
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: 5dc693f0e0aeb30cb6033015b13e75c8a21c56b1262d9652788c3e73a5c5c4a5
+  md5: 6b5cc9b43aa34431f8c30b5cdc22004b
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - selenium >=4.4.3
+  - h2 >=4,<5
+  - requests >=2.26.0
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 210522
+  timestamp: 1715636148762
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+  sha256: 597015e8a038a111f03ffbc9a217fcda549d75230c86ce53c1f23c53d6f1a0cb
+  md5: 62e98aac883bccc1c87ca0d2ce2f08e0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25798
+  timestamp: 1678317074170
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: 1430e6f4b4dd9354b7bb88f7f7bc9cdbab26a034ad1ae5c278de0f5a99329372
+  md5: be0832862b29bf5767a707ac6bd53b93
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 114834
+  timestamp: 1715878445060
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+  sha256: 885a9b6046e76f7dc1a346b14c63b4083046137bfae036362c854458e20e4fc8
+  md5: 3b279447ca282d065e681e567055b582
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 137340
+  timestamp: 1714717062907
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+  sha256: 5b6d5246955b5f9480ff7027eb002442a7ade24f5c354da54ed513042f76cedc
+  md5: f32aa8a37d5e65a8dc30f9a1f46bc63d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54719
+  timestamp: 1678325412288
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+  sha256: ed0152ad6b87ffd9e01f4a62bc358e805ad59637f898a801b0a9cf903ae8e1fb
+  md5: 8a92f8c663608f24e14d8a2068b9d83a
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 415323
+  timestamp: 1714511993944
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+  sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
+  md5: c25b6d40f834647d0bbe767f6c776031
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 329449
+  timestamp: 1705602140856
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+  sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
+  md5: f2519b551f99765d9d98950c5e2b4713
+  license: Zlib
+  license_family: Other
+  size: 119782
+  timestamp: 1714511811597
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+  sha256: 7feb73e79bdbd45404ddc7a30c43bf4cc68eced8ce448ce7c31f5db134276fc5
+  md5: 48313bc6570c705cadbba3c356e0dc8e
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1014151
+  timestamp: 1714678461080
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+  sha256: 9ca3f0dfc2bdbc109e359ba7ab246e6ae952a14819148ad069454b52f2bda802
+  md5: 51fb05873a644cac52f0d1e10cb7969a
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.23
+  - uvloop >=0.17
+  license: MIT
+  license_family: MIT
+  size: 228856
+  timestamp: 1706220385566
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+  sha256: 43405cc7341ce3efb2e24013ad62c64f26a69926635adceaa5459ccbcafb3776
+  md5: effa6d22f497e164cc8455f7f329c304
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 12510
+  timestamp: 1677917870614
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+  sha256: 947efe1c50b3280e9a67cbb18636bdade53a40960fff3056850ff81ab87acbe3
+  md5: 7d2d384ee32ccc12dcb0dc099e421482
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 35091
+  timestamp: 1677915945226
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+  sha256: 8259b4a0973c825ac81f581afcbe86640bd0a94b33caa996167309241877635a
+  md5: 49b8ddacfd3927bcaae139eadfb72ce1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153557
+  timestamp: 1695717951839
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+  sha256: 11159a30daae77cfc1abe5e60c19261f65c005e6fbc460aecf72318514d737ad
+  md5: 0c5002654a9cb21db1fdf8c1d2017df5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 269772
+  timestamp: 1681493072129
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
+  sha256: 90439f37ede74ef464e76093e173a8e94a20ee4ad79c68c9e7570fbc67fc13cc
+  md5: bb3b906307dd679fc3276be7581494f9
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6073834
+  timestamp: 1712084392983
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+  sha256: 688a071ba370f51b457cd32d70b7b38921ce9551203d06fa7fc2c30c4b79891d
+  md5: b2353077a39ab997463768154dd58fec
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134711
+  timestamp: 1707864978809
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+  sha256: 048264434c33fdb53862cdd69b2e2bc4ce6f8a70b3211ad6d686d066eac2aa91
+  md5: d55696ccaf6755931cd662dfb929aa0b
+  depends:
+  - brotli-bin 1.0.9 h80987f9_8
+  - libbrotlidec 1.0.9 h80987f9_8
+  - libbrotlienc 1.0.9 h80987f9_8
+  license: MIT
+  size: 19737
+  timestamp: 1714483270447
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+  sha256: 13627293296fcc231d8dc12d803dfc9621108c60df38b0e3c64e9e02ed55e564
+  md5: 86efd4ad08cd80d3eab77873db84a255
+  depends:
+  - libbrotlidec 1.0.9 h80987f9_8
+  - libbrotlienc 1.0.9 h80987f9_8
+  license: MIT
+  size: 19083
+  timestamp: 1714483255364
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+  sha256: 2e542b2bb27f8379da3efcb83ef084cb26e6a9ab576c50487c2dd996afd5ccb1
+  md5: e8cab9d1ef58a450f971690fcdb2ede2
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 380182
+  timestamp: 1714483330655
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+  sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
+  md5: 56d1386c7f1f338f0d18f82af6525273
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 158748
+  timestamp: 1714510571033
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+  sha256: bbfc668f445f3584936b326dcfe92bf71971ce16241f4f79db8aeb88d7aab41c
+  md5: 10cc05ed51482e1dfcc31dbd13bb34c6
+  license: MPL-2.0
+  license_family: Other
+  size: 138641
+  timestamp: 1710764806818
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+  sha256: 512969f339a9a7b347cdb7b88f439819168089867f04732279f02759d8caf24e
+  md5: 2009c2ee465fdd74dbd046de73726234
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 166501
+  timestamp: 1707229221324
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+  sha256: 8d26cd4d16545ad8afddd5521bc6894a50d5b8faff3abbe600bb9b062f3c3a0a
+  md5: 66eb734b7d7008eb5fb537900767c7ae
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 286807
+  timestamp: 1714483190838
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+  sha256: 808e56fb70f3d38599ee7a54c2a707b282ba9a401fa69a1f54cdc26425d9ce01
+  md5: fc37321833175bda4fc5c21afe32db49
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 539588
+  timestamp: 1709758479776
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+  sha256: d9c126d8bcd1c89ea37186c172d6b1f73f45ada60e3ae1790a017b530baa0147
+  md5: f0223aae3d622547f6accb212579c58e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17967
+  timestamp: 1709322909223
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+  sha256: 1f908c688e47d03d92ac09d9541a1f1c773ac2ca485dd1d77441b1aaefc032db
+  md5: 444c330471496a39a97e87f41ed70c96
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281104
+  timestamp: 1700583698464
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+  sha256: b9356e3ada4872c7c950d2ac7e0f107c4786775191efdfda3a469dffb18f2714
+  md5: 07ddd96675caf30ea77cafb1ea5662a4
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2490144
+  timestamp: 1690905181398
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+  sha256: b1481ffa475c65200626f051d5dcbdb264730b533e928dde608a79ce7a5b4e48
+  md5: aada2761547a291d68f4c016a1a9bc7b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 18265
+  timestamp: 1677911915719
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+  sha256: eb82a0e2ca36d0973b5f6642e27609554edad4b72696f989776d5db8cd4a6a42
+  md5: fa8d9dd8a2fabba964c6bb75ace8c572
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 3201601
+  timestamp: 1713551611540
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
+  sha256: 898d10bc1ededb43b7339ccf57fef404d96184de8ebaa788dba0b36a8c8a282d
+  md5: a1925e4ff9f6124ca7d439430bc110fb
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5399311
+  timestamp: 1707836657705
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+  sha256: 765d5b7ef75ed7f52a110504cd88e9b0c9977b841f1beaeeabb17e629b462908
+  md5: 0af9cd26a7c9eb8b77d3cbacb93a118b
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 360105
+  timestamp: 1715090588763
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+  sha256: 4d4ab70ae0ce008c1cc96a4edfbf3866d5e636acc4799a545ea93acee51635f7
+  md5: 86a085a440729020d1d7b0b74d6a0c6c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148448
+  timestamp: 1714398923507
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+  sha256: 63670c8f31770e1746016f645ca6b42b35f92d1c37e8025793d9490fed9998c0
+  md5: 9cb417b9fdf02b4e007a5b5781e5a8cc
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229932
+  timestamp: 1705934202146
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+  sha256: a40c76c412ec793ca26b97a9b5c496d253768438e1f7d4a0ee5f63ea79eed355
+  md5: f609e4fe044318211cf0e37e289beebd
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1614299
+  timestamp: 1704833142734
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+  sha256: e57d10579b52a3cde45aa17e1bdd95dcb9d3346aa00eb02c51e38a42db83e18d
+  md5: 05153120787fb09159b6e1ad902c6e10
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1180481
+  timestamp: 1678994989550
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py311hca03da5_0.tar.bz2
+  sha256: bdbc36a516717a24b40e2a4ac812c4d097b6733f4c6654602556969e5e0d4062
+  md5: b31b2f2fd10d919c58c51fcbe54ef5c6
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353970
+  timestamp: 1716993463263
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
+  md5: 055e12390b844ea6c6e956ee08a618e8
+  license: IJG
+  license_family: Other
+  size: 273479
+  timestamp: 1677849171867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+  sha256: 62025ce4a2b9244b9816c9e02487e0dda567600692b5f9ca71f425d084961c7e
+  md5: d57b7063122e5bf25cdfc2a5ea7330a8
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 181872
+  timestamp: 1699041739097
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+  sha256: 404b0847029f77bedd7902a170a046219e0dc5c0ec2be19ff45361cff25b2181
+  md5: 3a02bbe8d45fdbcb2350f672be74c9f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16524
+  timestamp: 1699032463763
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+  sha256: 7deb8ad28c34c369573754304a03ea2acda8ee39102a56526ec689a4d9210109
+  md5: 675ea1a746a78ff6bf8fc4b39139efff
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 277400
+  timestamp: 1677914250715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+  sha256: 8220b1bbdde5e800810f7bf183a992af1a95825a837edf975fa8c4b51c5d806f
+  md5: 3a06ddad06e04d5f0211c22cd81ca75a
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94950
+  timestamp: 1698937436979
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+  sha256: 8a9a9f9ddbf1b7744ef04a8c862438499a41d81a4beb4a49860156c273bb7497
+  md5: 051355801f09eefe850ee8145151f934
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42497
+  timestamp: 1699282590553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+  sha256: 65c703cc996a705d0ee350070e313b1cae865f9d6e6490ebf1164c0f3ce22d93
+  md5: 305ad8bcaad3e352d61b1e594093b467
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 596801
+  timestamp: 1699466743685
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+  sha256: 501e929d345aaa9079c965552b942b4e8bde35b87ae89faef003687a40bab3a4
+  md5: 54c7b8554a405acd7c8326c41ba93e63
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28237
+  timestamp: 1686870817418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+  sha256: 773e7c4571f482a744dfb18ae26fb22635f5d3f51389c838bd97f9044ea55cc4
+  md5: 5161546aba5597318cb5653390cdecd8
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20235
+  timestamp: 1700168681687
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+  sha256: 8c1c64d51be73aad381992a9df19d8336910bdfc40f19940231df86e177d17cc
+  md5: b1f786f96684a143cf30d1f6b8aebdb3
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65045
+  timestamp: 1677925371836
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+  sha256: 199042b87451abaf14546af124ae3380194cddda928e0d30ccb341e93084854c
+  md5: eaa0442887994a82486c65d87f6b71e6
+  license: MIT
+  size: 68806
+  timestamp: 1714483212137
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+  sha256: bd9a8a17fb14086446b710fa029d238e69274b83ee2e7e09093496f190de82b5
+  md5: 66615d6a0cb5dcca3e20c019cde0ed2d
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_8
+  license: MIT
+  size: 32975
+  timestamp: 1714483225840
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+  sha256: e1bf77e8b975c30a69b08a08410622e27c8cff6f592ccfa590466b83d9e6d104
+  md5: 8af86bdac01fe303d693d9b76c071059
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_8
+  license: MIT
+  size: 310266
+  timestamp: 1714483239194
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+  sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
+  md5: f31e4eb9cd6447cc2f5ef0243a76540c
+  license: MIT
+  license_family: MIT
+  size: 120460
+  timestamp: 1714483461787
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+  sha256: 41c62a460bb81a1a272aa28b219fab9c26510adac177ff1528b1980eabc6e868
+  md5: 8d312c5628dc7ea833e9b4dcb73e9c45
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 42346
+  timestamp: 1677973051421
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+  sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
+  md5: f5f7e6e7541d8dc3d3df270d488d2e24
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176990
+  timestamp: 1714510588159
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+  sha256: d024f5142416961a5e66e424d4d14aec652f9e9dd738b41a97f45674c2ffc9d5
+  md5: 0e2d94b125d802f7b006cf19c71655a1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 163084
+  timestamp: 1677932947966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+  sha256: acfd84e29ff4dc2d85543bb973a07f22b4ba53c5d00bca84608ee7f13b2a8676
+  md5: 5ca161cd51e2db358e768453b3ee485e
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135871
+  timestamp: 1684279980293
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+  sha256: b1bed54c7bfb7304cde9e8e6f798543d08e808e81286a5a48296fc94d621f9da
+  md5: 774358285c9e496c9f5c121cc546c823
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27438
+  timestamp: 1704206026910
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+  sha256: 9229a6e15abf3147cfcffad4ca389dad940e45779963b4fc3fd56dfdcfca3234
+  md5: 4e1897f3cb4923de48c016468c01c051
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9100733
+  timestamp: 1713336457304
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+  sha256: 3276d61fc353c537bb09d4b7473d7abe12be38806f42c8cc383b62f40850a5cc
+  md5: 6e9c9d47f264b77d9a8461f0899848a7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20446
+  timestamp: 1677918370379
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+  sha256: 43c96d30775b61b4968422a47f9605049428120669f0742bbb9e5ba145c7d11e
+  md5: a31ca0d9284860adf5463cf45a5e3145
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 69243
+  timestamp: 1677995336989
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+  sha256: 96d8c9f42a38651b7bafe5f3cb132601db76cd1e28fa58e2eaf090e634292fff
+  md5: 5ebc793a17b6aa84d13f19433545ffa5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23895
+  timestamp: 1677942274932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+  sha256: db9bd659ada23f1ded443d2db00dd13b5d5c0b30f5062544b1ee2c2b88d63d29
+  md5: 03c48121614cf12abfe30eced9b34717
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105333
+  timestamp: 1677916687032
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
+  sha256: a8b3d349481dc694eb9a507f55c91e8981e2a3bc41743023ca01248c8a6d779a
+  md5: 71e6e29ec3b98fb282c01b012a5df236
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8294656
+  timestamp: 1699543119360
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+  sha256: e8eee27fb667aa10b26f3bc4b93f449b7d991ded27b9cb457effee394ce05f6f
+  md5: 6a3e5cd0e1141c01ffb91285bdccfe83
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123043
+  timestamp: 1698934328890
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+  sha256: 40230434aa2fbb33ece13632e8d4b7cd1ad68fdb8d1b00263af4a010795d25f8
+  md5: f12ce7dad3620d6d53a442fa9d36a0b0
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - pyqtwebengine >=5.15
+  - tornado >=6.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 538067
+  timestamp: 1699022954841
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+  sha256: a492acec8ceadc0911a75966ffa630a8eb15b2da8c7a8d544a645ba47771a2d1
+  md5: 4002b1b88b2ecfdfc769036f43b0a895
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 170964
+  timestamp: 1694616845237
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+  sha256: 417ace1ce51e81f3f92ddc26e0e3a83c1e19c9ebb7af7104452002a5573da534
+  md5: 3e11de6cef096091bb733e07802f00b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16979
+  timestamp: 1708532698253
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
+  sha256: 2e09ae8d10d7e5651727aab66a1e89b59e716295267a8295eaa53760c4c38533
+  md5: 8d52be8699bf030546811bb69fbeb2b1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 728383
+  timestamp: 1690985022565
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+  sha256: b0cc542e2a6f42ba716e7e4ccf29eddcb155ad167fcdbc72d2db9c7873eb5639
+  md5: 7acf81b17d2c4ceb3cd39dc9f173855c
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27539
+  timestamp: 1699455954000
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+  sha256: 151a3eb68d1189e69764ece1d8fb3544d31a22f5bbbc3e19d846de8dece304d2
+  md5: eb6609e6bdc9c82d70df3f8c4c2de95b
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153313
+  timestamp: 1696515415712
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+  sha256: d3bb1d4be88320a5861cd3a0f086e9709f9b64c96c032cb9039cc4f17ec66a85
+  md5: 0a7b97665c06fcd34a70e34abc177280
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.26.4 py311hfbfe69c_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11288
+  timestamp: 1708639168951
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+  sha256: 3e70248a7069ca12ccf56252869bfdb72211fd4e4c327e6994756496df786c79
+  md5: ce4846006d98638cd86a532a72f8dfe4
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311he598dae_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7536860
+  timestamp: 1708639153133
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
+  md5: 371358a54bbdd307603888348d1a2c6f
+  depends:
+  - libcxx >=12.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD 2-Clause
+  size: 412248
+  timestamp: 1628861367714
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
+  sha256: da78bd65c91881856baadf977534832f68db3938c1b5b713c8797be70b83c98c
+  md5: f728656890f860eec5ad2899e657df3a
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4763426
+  timestamp: 1716318333548
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+  sha256: 77b0c0a0fb14d817390244ebd93c36d44a7867239963f211f7c0a72a3f98d382
+  md5: b90336feb8a50d2eff880e89acb02f40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39617
+  timestamp: 1699371253760
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+  sha256: 4f6c3e8d8fc4c57975cab837ef109b9ee7af4f18aac72668334ac656e53c6edf
+  md5: fbf1b507f9a80c5de3c957e8152124da
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 159289
+  timestamp: 1710807498427
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
+  sha256: 3af823879c340838c1040e99f653c3438ccce8dc559bd91c3f4ab2579282a002
+  md5: 5b3df01fda0281dab4196bc36d1ca367
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - odfpy>=1.4.1
+  - adbc-driver-postgresql >=0.8.0
+  - scipy >=1.10.0
+  - fastparquet >=2022.12.0
+  - pyxlsb >=1.0.10
+  - pymysql >=1.0.2
+  - sqlalchemy >=2.0.0
+  - pyreadstat >=1.2.0
+  - beautifulsoup4 >=4.11.2
+  - fsspec >=2022.11.0
+  - openpyxl >=3.1.0
+  - xlsxwriter >=3.0.5
+  - jinja2 >=3.1.2
+  - zstandard >=0.19.0
+  - numba >=0.56.4
+  - matplotlib-base >=3.6.3
+  - psycopg2 >=2.9.6
+  - xlrd >=2.0.1
+  - pyarrow >=10.0.1
+  - pytables >=3.8.0
+  - html5lib >=1.1
+  - blosc >=1.21.3
+  - gcsfs >=2022.11.0
+  - dataframe-api-compat >=0.1.7
+  - qtpy >=2.3.0
+  - adbc-driver-sqlite >=0.8.0
+  - lxml >=4.9.2
+  - xarray >=2022.12.0
+  - s3fs >=2022.11.0
+  - pandas-gbq >=0.19.0
+  - pyqt >=5.15.9
+  - tabulate >=0.9.0
+  - python-calamine >=0.1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17082645
+  timestamp: 1709591689205
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
+  sha256: 8bf772501cf4b49a939de17bf378d3e395f452d3070d05871354bd2bc915d012
+  md5: 753d2070a2aea47934ecf6ac1ea0bc04
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.0.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21901817
+  timestamp: 1714071405089
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
+  sha256: 67feb8232961ad9d7672a49f6f86f0b86764f62a97d86d58b90ca7e8345bab76
+  md5: 3afb6e6747bd29e9483d35dbf8b24f74
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264413
+  timestamp: 1711136882294
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+  sha256: 174b680f4bb041e8146aae80f92390122459e0ef8c911cab22d01e2e92d44ab1
+  md5: cfffc94779cd26a349bd409b5590b098
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 916496
+  timestamp: 1714399019350
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
+  sha256: 102c3c35a9dfa0f10ec8f4a040a24295f9c736443ccae2f685348a44f62a4d68
+  md5: 027b347e79e252aa17b534e1a02bccd6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3447682
+  timestamp: 1715097070362
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+  sha256: b6200816d65673aa1707c20a768c9cff87dd8dbe1335f9c1478e5931dfa08ee0
+  md5: 14b1e0fa73eb33f9c83048482dcce57b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38423
+  timestamp: 1692205689597
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+  sha256: ebdf211edd98d88a23778551c7a9702106edd0695d4fc48e87c21f77521c1ffe
+  md5: d8c505081a468f1b99c62466e2309417
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 123084
+  timestamp: 1678996822234
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+  sha256: 07cfba50d9e94364bde077731a824ca4f537138b35ee6b66d07aee16ac9850f1
+  md5: 919bf486280a11e6acb3c2c3a82f7473
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763225
+  timestamp: 1704404463402
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+  sha256: 8094436b2c44e68e72569c704633802aad82e977b1e16026848218679c8becf4
+  md5: 2360e46d3e598dd5e2abed781fe166c5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 502115
+  timestamp: 1678995719872
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+  sha256: 121b5b66721760c05f1d4eee91626229d1814663d3fb5f23126ef870aa496e26
+  md5: 0c588c2ca790a05d422c06e8568201ad
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2124200
+  timestamp: 1684280082141
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+  sha256: 44b694db8e81d61960d28d60f9e9b573f03f7827881d302da334378881db4889
+  md5: 6c94ba7caa599ff533e0ab55d898be8a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 208454
+  timestamp: 1677910948527
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+  sha256: 0bb3d2a57b332c5cf73ea40ea13c850ae24a1f9a3a41ed9267832d9e3c767572
+  md5: 45a7fcf1641980d5114999736428502d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36755
+  timestamp: 1677906514270
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
+  sha256: 960c343b7b8569dfe4e71a395f7bede1e749da7b02c17506b590c9e1839e6fd7
+  md5: 722c4b4386af73cf1562974a00c880a4
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16494386
+  timestamp: 1713545544909
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+  sha256: c3cbf5bd237b0a7458640191016b2701fe120c547df9afc835da76663a9c17f7
+  md5: 843568c76b6b9384635b7fca74c79792
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332222
+  timestamp: 1716495881101
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+  sha256: f94b3cfea6f76ea9983e16d3c4c7e0a64f02c40cc2c3ad57189bca2e67030bd9
+  md5: 0d100990ade57a02b60d1e8085db0bdf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 280263
+  timestamp: 1678996927464
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+  sha256: 252c86f5aef7f8dfce99a260c24cbb35a9adfea144a2acfabb224f516341544f
+  md5: 745b888e19a644f48800799f82c01c21
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18539
+  timestamp: 1683823925189
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+  sha256: d945744eb133f19ca61325cac5128bdb053ae04de4a0ba6f69c061449cac8af7
+  md5: 34baa81490d667381bc7021435b0e1f2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 275858
+  timestamp: 1713974457562
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+  sha256: 012585bdb5ae54c2cded50be703734e6dbf418b003635b6f6d7c1e36e7020c30
+  md5: da7e99a707bd0cfa20db651b5c068bfd
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65556
+  timestamp: 1711136890180
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+  sha256: 4f04a43cbd612ab09cefbdc2e48ee61b51967dad59d859ce0502cc2c46c88fc5
+  md5: c68bf65433b2151b51b2e699bc22c501
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 194632
+  timestamp: 1698096151085
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+  sha256: ae8cdd5be5a7ad19ff82925a035859fafcc5942cd3899d127a508dbb9a235090
+  md5: 252a7b997d08bf72f10b3bc2dc68333e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 580346
+  timestamp: 1709318480624
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+  sha256: 7a208abc002a2fc208ae25cb2cf932999a3e4980aa4c9edff315cb9ac62b12ce
+  md5: bd22ebd3cff811577ea61f115ba7f4f2
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74744
+  timestamp: 1699012126255
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.2-py311hca03da5_0.tar.bz2
+  sha256: c6eff6c175590d7fd2e500ff1673b160a4c2b67e1cb99370ec8b5a2c998e8025
+  md5: a60c7eef247742967bca814d7f1d90ab
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 123308
+  timestamp: 1716902854898
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+  sha256: 52368d9b557b8f54ef5ca4bf6cd5a3ec665171f2b2d2082cdd410bab88f4829c
+  md5: ac76fb4d2eef3ecdd491cf5d3fb8620d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10204
+  timestamp: 1683077239143
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+  sha256: 491d116c5f54ef340e3bce631835f7138cd1923d7b63e6ca9aa01b48110cb8f9
+  md5: 9b81bd8ea808704f5433884b567f1f15
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10557
+  timestamp: 1683059079547
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+  sha256: b53a5f6119173d62e4e68a37ea8511c7fc87a00af72953e0048d075a799c7a7a
+  md5: 76a16cf4edb9b12b2b96a2d323f060dc
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 342535
+  timestamp: 1698945991201
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
+  sha256: 9e8312f9452357202813aa289430c939302617f562dae9e90fdc3fb5e9be49d0
+  md5: def02b749d0c0a3675d96aeb508a2306
+  depends:
+  - blas * openblas
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 4
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 26383719
+  timestamp: 1714070280353
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+  sha256: c80d52567084b1caaed2862b77b70065ca17afaf0b020733e9d6c273b4a63e78
+  md5: ddf7d88c1967f3f7a4ce1c975fd47e0d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33321
+  timestamp: 1699371225235
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+  sha256: 6d38d171ef87340cf0fbbf4c70217df4826c65400c9290774f5cb35e381e3315
+  md5: b9529a812f9862fc89461b6b90f184ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1599110
+  timestamp: 1715024190898
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+  sha256: cd71091a234874d2826fa063ec5222b3191c9f47e1b5281c352d9df3f31a06bf
+  md5: 0db8e29016c6bff026c083d9923a7566
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19073
+  timestamp: 1705431415504
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+  sha256: 3e18cdafc607c6d7623b1c8f041cbfbb50a27e298f961abdcce7e36834ac39e1
+  md5: 9ee0da74c55d0b8d83edf246fd717f20
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89862
+  timestamp: 1696347657368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+  sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
+  md5: d8c1e9910392d0bcb22a173f9ce30fa6
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1758290
+  timestamp: 1714488307689
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+  sha256: b5c265e9ed9a1ff2238a09b83bdc1826950faa87fd6b685debe60888de6e7a50
+  md5: 5827c8a32317894ce18576e334daba47
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38559
+  timestamp: 1677918962258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+  sha256: cfefd86d0f4981d22b7611b3dc60359b8698bf39f2b743cb90b7005aaca88e1e
+  md5: a04dbcd6095f6b8f3ad195a78d48b262
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50058
+  timestamp: 1677917499177
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+  sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
+  md5: 3c25b4f4768ccda28b20a03ba27e7759
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3484151
+  timestamp: 1714770744982
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+  sha256: 177246487449f87567fe56c8f20011a4350a132d1556c9f87474d7b2e8c1374f
+  md5: d465118217b9f27d47dceff89c2e9f95
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 896655
+  timestamp: 1696937042980
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
+  sha256: 81efb240a49cede5ece3a8ad48f1d9dfdeb56260bf1a20e25ec53cdb202f7c3e
+  md5: 81a17d13c75596841b95340a34bbe929
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 155516
+  timestamp: 1716396017482
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+  sha256: 65e760119352cd85c63d365d2576c09a9ddb060e5b029a265d50bc268eed9290
+  md5: 14c241871b12dc3be52e6cd681267caf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 271445
+  timestamp: 1677911758960
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+  sha256: 96071e07e807414b7ae5a2fe958ac171e5795576b3a4c2f5e8c643fba43d760f
+  md5: a34f2b216e35a37f966883dacda229e2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9902
+  timestamp: 1715268985387
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+  sha256: b20e48aff4c781a52b6be66d77418e768527a621f5fc272ecb34ea03475b2bd7
+  md5: 707738432f16f5e63909fcaa6e65850d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 75604
+  timestamp: 1715268976065
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+  sha256: 2ea2d0520b330d381a2ab241bdb9ae146ef815ee7c96ee52a9773fb9ae85f4fd
+  md5: 66f7f8979cfb2cccffac972d70482130
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 12614
+  timestamp: 1677963554857
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+  sha256: df7fe7740bd853b641d624e2ec97f1aacb2b82691936a8c04ef18fa9768539c2
+  md5: d5c7626d45fd03b22797c18e47812beb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 518048
+  timestamp: 1713213046424
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
+  sha256: 3fbcccceb4d7d99f60a6e6e013ab84c4532244c42ab9d65b6fdaab6bd30f7269
+  md5: 6a7e05872852d4bcde959f7cc8407672
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - requests >=2.26.0
+  - selenium >=4.4.3
+  - zstandard >=0.18.0
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 210307
+  timestamp: 1715635933070
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+  sha256: 09738b7f9075386bf062b12ddb6fb72a06450d2481f6b5ca2026c811cd849569
+  md5: 9afdec076c95746ac21235f971190e40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26727
+  timestamp: 1677910175964
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+  sha256: b4ced7366de8eb7258f31d516616e70c62ed4a798780e57e208509d2b52ab435
+  md5: 65a9a05a726734c1da667f9bd3c78c14
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 114733
+  timestamp: 1715878377412
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+  sha256: aa301d9e42aadbe3dd5f301ccbf17fbadc347fd37d413c0cbcbd24403892a936
+  md5: 77097d17d835a137af7950c628b66150
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 137260
+  timestamp: 1714717037687
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+  sha256: 2cd108896df65636769e3804ecc2ca421ad9b54e64fa21922bbabe40c90c247a
+  md5: b3a1e5077b28f71298d891fbfb5ff03e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55645
+  timestamp: 1677927459979
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+  sha256: 5be8c968f2da5c4bf14f28d63e31b4c1b6993d980023769732c7f58f396c2e0b
+  md5: 3f5f62d4e85e3bdd48d39189b01805a6
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 459197
+  timestamp: 1714510992914
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+  sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
+  md5: 3d57d1adadca9388aaaa1c529b65ba65
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 322790
+  timestamp: 1705602163804
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+  sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
+  md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
+  license: Zlib
+  license_family: Other
+  size: 104928
+  timestamp: 1714510936868
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+  sha256: a3f3eaf240991b6bd7b0596a78d0abb3321cc79db52fa24f6f559189778871c6
+  md5: 71f035b4716322539e2461cb6667e946
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 825339
+  timestamp: 1714678419523
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+  sha256: 6e6787755de0cf2fd776c9681a7b0fd0fb23e35e679a463cc2005b991c413910
+  md5: ccad42ec9a2ad48939f089c528abc8f0
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 229694
+  timestamp: 1706220431719
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+  sha256: f715f7c2e06149bd6d43258e41479d3171efe5e9d56050a0a5f5652ed9d05fff
+  md5: 11a8ca43d69881b88f95ae681478866d
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 36089
+  timestamp: 1676424516042
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+  sha256: 9adabcdd2a10f73fa5ba56adc901eeea2e379991a0d4cb9737eec7aa6b9fc5d8
+  md5: fc80b572be85601706d425b21a58d497
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153102
+  timestamp: 1695718054194
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+  sha256: 38ccda1553733326d99a75436b4b0f7640bafbbfcdbc33838b0e59cf017de687
+  md5: 3f6812578c5e0b3ba0d2a651cc766c15
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 266405
+  timestamp: 1681493141116
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
+  sha256: fe765d810e1612af7a42f34223077f0adc05dbd386b257be24661913d067fe30
+  md5: 82e988aba03c8afa03fce78f7442806e
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6086137
+  timestamp: 1712084583317
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+  sha256: 5c12a5d7856d9977447360b3a99a5b99818707fe79781ba1779037f11b3fef53
+  md5: 6a125ae352306a944aabc635a5fe13a3
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 139230
+  timestamp: 1707864402762
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 751071782f597f87ed7f67437ef6cc669213902461b9795dd6eb0f4897eddc83
+  md5: 5ad8fe62aad5e16cfdf2c5a7d1327fe7
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_8
+  - libbrotlidec 1.0.9 h2bbff1b_8
+  - libbrotlienc 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 19418
+  timestamp: 1714483531456
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 9bd62d810867549b9c967c5915f3fa3f66cfbd6ede28b1cc152efd1261285c0a
+  md5: 64cc76de3662b62bc8f0e42befd92c5d
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_8
+  - libbrotlienc 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 32178
+  timestamp: 1714483513837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+  sha256: 1547fa52134cf06b8d01bdf52114db7db60a89bf35c9c95be5b5a03b13dbd565
+  md5: deb765cb7c4b7edc4d126f864f31747c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 356401
+  timestamp: 1714483740924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+  sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
+  md5: 11e0af09a31e2d5df51c65a342032b85
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 112994
+  timestamp: 1714511182837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+  sha256: 73391a74a5300ad3fb063ea0f0c3491d220128a0611a84036da2e23c1e93dc0e
+  md5: 501ded4f9b5ed895077802defee912cf
+  license: MPL-2.0
+  license_family: Other
+  size: 171644
+  timestamp: 1710764856021
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+  sha256: cd6545642e380b13700f2f2a7a1fb54a273365047bd23108dbd03b197f5c0c9c
+  md5: 929edc1c553d2da4d6c6c0745b033cc3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 166377
+  timestamp: 1707229328635
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+  sha256: 5cb6ac90ad234248f3795945f69b0382397714a52712337b2f86339526b822d8
+  md5: b90f3126f6315ea2e8ab242533062557
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 302693
+  timestamp: 1714483562551
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+  sha256: 4099898f02e1f6119fcda65e747c3cbfef0bf563c8855b79a0245160709d5b45
+  md5: ab9705c34e67fb8c8faec69d63ff4064
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36410
+  timestamp: 1676422341506
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+  sha256: c722f50980d7416ffb2cfc7bf72649307a0bb78c5a24eccefcd049cb61d6b355
+  md5: c7c9ff0513ff3c99700919293b702410
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 543258
+  timestamp: 1709758602437
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+  sha256: 8fb3e816a5ad1da05125462dbc9e2a7e933b001a871aa65703802c0a894c6277
+  md5: ee4b2fa9fce130496d5c7c86c35a1a05
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17723
+  timestamp: 1709323150229
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+  sha256: eeb49cd151ecdccd40062e8123a3b7a9a8a1eda6567dd33ce909ff8ee1a97c89
+  md5: b7fe1f7ead1ec2ac642d022942282fc8
+  depends:
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 232451
+  timestamp: 1700583772701
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+  sha256: 5c73f86e575f2ad683ee4a1c2df11020e270edd89d12f11199483d57b0b51826
+  md5: e96a12895ce374476277b1b196ba24bd
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3719519
+  timestamp: 1690907216785
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+  sha256: 5d5fc8a24c804010b8cb5963227230352ea3ccf56bea9e8116e34f77223218f2
+  md5: 8f989a72eed6293dfe0533c83057980d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17688
+  timestamp: 1676423357100
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+  sha256: 27fb03eb57d25711a15e145f47a64320a9955b585efc9fd0a1a51cdd71b9fde3
+  md5: eb3869e98f6f53dfec76e2eff4d6b61e
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 2732423
+  timestamp: 1713552175344
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
+  sha256: 68d59a361a93a5ae36542f667138b4ab072e1abff15b3aa2dc55575baf86a3e9
+  md5: 383239566d9506b743c7bc65d709b7e1
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5374020
+  timestamp: 1707836834797
+- conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+  sha256: dee3fc68ed81398d232b3afe9a032837bdbef98c1b2478604d6abd397e3e7d64
+  md5: 3f75535ca6dfee0745b221922f21f6de
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353312
+  timestamp: 1715090519918
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+  sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
+  md5: 582d2c1135a89da757a038de831e7f39
+  license: Intel proprietary
+  size: 11086648
+  timestamp: 1664812389803
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+  sha256: 102c803186db6d62eaf41a906f6c563ff0d62b53c1eaede8a381e18c0d005ed9
+  md5: 9d30dec03058758a428cf152e0ae28b5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148193
+  timestamp: 1714399061601
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+  sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
+  md5: d215cc8ee7ca2cc83cc250cc5d822fe0
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3929136
+  timestamp: 1699647939158
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+  sha256: 864e9598f64105769b4ec02cc404fb507bc59e217324daf1686c00cfd12c0055
+  md5: 6bb1c3be1f85799a3988afc2c3c5a4f0
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229621
+  timestamp: 1705934494547
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+  sha256: e0b44f0c3a4ead0fb8e58033c0be25524ee9ecf7f4cc632f03e9f6fac3484baa
+  md5: 50cbc18d0c7b42a4553b52d0cef2c857
+  depends:
+  - colorama
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1637367
+  timestamp: 1704834149957
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+  sha256: d81566367c79a28d4717157fc74293e846a47af99387ed479eb001a425dd398e
+  md5: 28c76079c96ad7f8b1a5ed32b438c79a
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1147434
+  timestamp: 1679427525584
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py311haa95532_0.tar.bz2
+  sha256: 74c339ca0a20f4bc324974c2c28901c1f478ca7c8898483482883a7a82896d15
+  md5: b3d3352c9d3bfe46f924b8e15fedf9be
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353862
+  timestamp: 1716993519832
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
+  md5: 81f2c343dc4c65eea39c45383272068f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 407861
+  timestamp: 1677849239400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+  sha256: 5e6698015a3b048093f5737f0e54bcbae415d0f9682dfdfeae3a8cfb4ea275e2
+  md5: 0093a4214131046c4f68af0739dfbea4
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 201456
+  timestamp: 1699041872445
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+  sha256: 9581be54128954080d7cef448b1728874c2ebbe5064f55adece422cf12eafa5a
+  md5: 3adc105f87d5c7f0b1248bc3423f5b48
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16187
+  timestamp: 1699032556953
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+  sha256: ad8343bad7c8f0448cbcfbaf872cc94b56da81c52e5cdcee2a5d6b89f029eb75
+  md5: addceff8d46c9d1d322618a9ce9e5b39
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 300354
+  timestamp: 1676424060532
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+  sha256: 851ae576c2b72bf3172cd460feec4f5577dc06476a043e185279071b67549fab
+  md5: fae4d214d00de6604738f39acbbb197e
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119710
+  timestamp: 1698937651636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+  sha256: d97ad90f9121ecf7f8d3af773b222c0bd244204ee73a3e44185491fa16d83104
+  md5: 73ac0fa3c67e5eb283173d74a2771752
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 60625
+  timestamp: 1699282918176
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+  sha256: 257e1102d2dc3f8b0c1708585c819e86f41abd101084cd0569e8e31652480875
+  md5: 2128c6806bba6953e1a275f37e7a295b
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pywinpty
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 614705
+  timestamp: 1699467242943
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+  sha256: 90420847230e72a648417f5f77cebcf7f17b89f70788652c276acc0c440e135f
+  md5: ef3d8dee197aa37897bf6d39d2dd878f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=2.0.10
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27639
+  timestamp: 1686871052174
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+  sha256: 97faaf26ce5254ec3649a8ee7f480b1556e4e8e6e4356d2fab1e6a5532631a0f
+  md5: da23bd831c50c877f63038b7e16720ad
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20163
+  timestamp: 1700168785472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+  sha256: 8a2f0909fad0387e57cb0e9ee30db2b20761a9106e794381ffeac387a298fb07
+  md5: 6058b2efc3284e27aacec2e6e6280433
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62334
+  timestamp: 1676432044242
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+  sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
+  md5: f5f73266281ab12377d5d47bdf07500a
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 905072
+  timestamp: 1617648814933
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 7c906c94a4d46ea963080a6ba5bd12c1274da66159877a544fbc70291eeed98d
+  md5: 45a3d52534fac8aa54a55ee92211a918
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 80216
+  timestamp: 1714483371043
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: daad7edc6d56abf3e176479e8628162dbf1c56b3d24db30d708aebae694a5214
+  md5: e8ecf229f7fcb4c0b76d8613627948f5
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 45189
+  timestamp: 1714483420152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 84320217abffa9386186ec8d03b4651bb4b1900d3871adc965a9a9e1d3799907
+  md5: 651312fa22168f71f9aec5f9ee2c2fcf
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 756116
+  timestamp: 1714483464368
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+  sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
+  md5: cf949d76148be1e2a534218d9c57df86
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 155435
+  timestamp: 1714484319443
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+  sha256: 4534c822511a052a72c2b070a05e5d8d6f3550f18ea00a33f9d8a9a92b4382cc
+  md5: 82f24e7660831445a2183216e280a6a4
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41464
+  timestamp: 1676474474981
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+  sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
+  md5: 320f40b75d93f3b96931c6d13c23946c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 158902
+  timestamp: 1714512129889
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+  sha256: e0dc6e119b224bb31ef34b6ba270ffadc181d38b698c5318de8df7a5d2c4ccbd
+  md5: 992ccd756f09408f0b74dfb9852a8b7f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 182381
+  timestamp: 1676437963591
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+  sha256: 050b5fd4b28132d8102a7e6b40179894dc7f5e41f7ad9ee19211e67446c5740f
+  md5: 3ae0b2f6baec708554648ddafa81b756
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 154386
+  timestamp: 1684279992864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+  sha256: 8269c73b7a9c03b95a121e318d0468f35eecc016093620b0560f35238cc5df51
+  md5: 2914bea0ae29315f998e1abac79ccaa8
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30214
+  timestamp: 1704206218108
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+  sha256: 68fb7d113dbf185b571343847e3dbefdbe7d0b9b5902f1f390bc2a6e33a3f8ee
+  md5: a72ff718390a1fde0b208a43e6b9b655
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 11366001
+  timestamp: 1713336740870
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+  sha256: 43279276850eb6e621812448cddc1093524cee0b7f8ed58b4600b68a4fb659f2
+  md5: 5968b2b5c1f3cf5c8c8c9aaa4d8d66a2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19886
+  timestamp: 1676425829787
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+  sha256: 3062a8254ca351b54f15bea85cc928a3ba4d879bb98ce97ece39a9f7eca215a5
+  md5: 8f1565663abb34ad7fdd512e76da5532
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 68031
+  timestamp: 1676481862508
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+  sha256: cdff5215c292fe59649ca40ca72f5d26da352760c1d6a56feba14eb13f7bbf61
+  md5: e0f3f32b22135dfeaec277bc87183ca9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23328
+  timestamp: 1676442709081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+  sha256: 3b173a25605d2aaacc57ec0e425f1d1c51327eb2521c8742a736e2c76069bc8d
+  md5: 169f1c93a443f95a88665f3008623ce1
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104882
+  timestamp: 1676425142412
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+  sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
+  md5: 527155127b9fada5e5c5c69a624674b9
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187498166
+  timestamp: 1699648376430
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+  sha256: cea59ae60da314caecf08edb9bcb03126c6dd35837c8184bceaa194decca3341
+  md5: 30936b7263cf0171f7c86400f12ef184
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49080
+  timestamp: 1682975093455
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+  sha256: 5070ceb0a406b1b8b99e2ec58f5d224cbe16ec78109c46720bd182b509e05c6e
+  md5: 34de1af5c639f2d06c6c8d99488e4226
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 196201
+  timestamp: 1695058367111
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+  sha256: 6b4b27302e458fa527321c59be7c335d61f86da7501c4d141db20a72fad68b55
+  md5: 7db9b12da1290bb2c2fc6ee52a945905
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 256371
+  timestamp: 1695060425702
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
+  sha256: 5422fc4dc6708279223027e45dd1ccffe4dc2feb93c60c8a683946a398c60a1c
+  md5: 62d16437707dd382c21a9ed1d8b375dc
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8304222
+  timestamp: 1699543942441
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+  sha256: e940f9178ee2fa0a7c12873ae35ebea0074371653e5cfa1be8aa8d9271fd343b
+  md5: 355d0835215911738a28010dfa6aa382
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141785
+  timestamp: 1698934346590
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+  sha256: 47dd00c0179f4eb29c70d0453d340f7f5332af326b3d51c64ca3bf6a14be8e7e
+  md5: f66afe718bdb57667b03ebda4cb2ac7e
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 561655
+  timestamp: 1699023338436
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+  sha256: 4ee863a1ff697274c642b3101f82b279a354e3f033a87505655039f89127bb41
+  md5: bfaf19be6644ad2344e118aa0acccb13
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189809
+  timestamp: 1694617194065
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+  sha256: 90fb3f14c49da1397982eae21cd09e8d60d491d76f94c57590c56723fe6dc172
+  md5: 46a523661fe5c1bce7b4213fd428c3de
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16732
+  timestamp: 1708532795328
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
+  sha256: 5db3fd8b4d97e2a6232e2f7c62f1ce82ae3876326aed9f8c3ea656eda83e55da
+  md5: 39c36df9dac13398e8a54497dcc14611
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 755697
+  timestamp: 1690986137327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+  sha256: e040ebcab948325fbe17e4ab15be62e1fafa7bad225457e59764adb60eb40db5
+  md5: 4d40a09df8cb74a9f044eab317436d67
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27282
+  timestamp: 1699456187703
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+  sha256: d3bd2a6614bb7e7f5ce3348d6674e71cce45cbde236beff32f0f08cd95a64ef0
+  md5: e70f15643164f432d1df68635e7c322b
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 162691
+  timestamp: 1696515822068
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+  sha256: 470fe9a0b3e196fa60d5550d8188f6074a207572fa0d353a4448d580872e7804
+  md5: 6fdb8df0613fb2fb9f1732d335fa25f1
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311hd01c5d8_0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11053
+  timestamp: 1708641901110
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+  sha256: 222c1711e7cf151e29077c7d4d86a865c9fd39615812d58a1daca6fd1b6bdfb5
+  md5: 585bcd8bc3940a8a859f38ebafdcd77d
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.26.4 py311hdab7c0b_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10723862
+  timestamp: 1708641867155
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
+  md5: ab07e2a27ac08afe3d0b4c0890b8486a
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 2-Clause
+  size: 249316
+  timestamp: 1630094024143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
+  sha256: c8e066c2cb547914401ec29b7356914ca3cdf6ac37eead248fe0c41236a7838c
+  md5: 5879739cc77497a518b2ebd55857183b
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8118619
+  timestamp: 1716319803768
+- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+  sha256: b2f5f50a1ddf811102636f3acebd76716c88ebb628754b91eda7a3a962adf26c
+  md5: 712527b4d84c350dca4b67f511c04414
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39421
+  timestamp: 1699371341381
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+  sha256: 432b8b7c4671878cbbe361e518544203f97bd2e4f24fa08cf65e8be583f25529
+  md5: e62e7c668b080e0f6ce09fd548f69f7f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 159066
+  timestamp: 1710809127954
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
+  sha256: 3ae55d8148580fc3f171c0fcc420488fbba05517cefd358fe013b45ec3594371
+  md5: bfb42ed6826a1c8cded9539fc6e07029
+  depends:
+  - bottleneck >=1.3.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - python-calamine >=0.1.7
+  - xarray >=2022.12.0
+  - lxml >=4.9.2
+  - dataframe-api-compat >=0.1.7
+  - jinja2 >=3.1.2
+  - zstandard >=0.19.0
+  - blosc >=1.21.3
+  - matplotlib-base >=3.6.3
+  - adbc-driver-postgresql >=0.8.0
+  - xlrd >=2.0.1
+  - fastparquet >=2022.12.0
+  - pymysql >=1.0.2
+  - gcsfs >=2022.11.0
+  - pandas-gbq >=0.19.0
+  - xlsxwriter >=3.0.5
+  - pyarrow >=10.0.1
+  - html5lib >=1.1
+  - pyqt >=5.15.9
+  - psycopg2 >=2.9.6
+  - scipy >=1.10.0
+  - numba >=0.56.4
+  - qtpy >=2.3.0
+  - openpyxl >=3.1.0
+  - adbc-driver-sqlite >=0.8.0
+  - tabulate >=0.9.0
+  - pyreadstat >=1.2.0
+  - pytables >=3.8.0
+  - beautifulsoup4 >=4.11.2
+  - pyxlsb >=1.0.10
+  - sqlalchemy >=2.0.0
+  - s3fs >=2022.11.0
+  - fsspec >=2022.11.0
+  - odfpy>=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16924671
+  timestamp: 1709591125871
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
+  sha256: b529eac4abff05f13760c51ad37adf24e744109a6fb30471b26dc1f6a1c23847
+  md5: b690cc140a7866280131762a26c05f39
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.0.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21902721
+  timestamp: 1714073654508
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
+  sha256: e77795e1af9bc27d45841d6b9c51e0e7da31e0eabaaffa99162245adc55d13a3
+  md5: 14046398ac44f496bc9df300285ec586
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 267222
+  timestamp: 1711137058994
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+  sha256: 6ca54ba8ce430caa8a1838b19869814d0b7fa3592a77f75298130983e635387b
+  md5: e56c194e56d19dd8fd76f75a77f92c33
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 1070844
+  timestamp: 1714399290671
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
+  sha256: 15001c7ee6cf6e0ef7afc2f313114f6103e7b6f641fac9a6899ee02d6537c822
+  md5: 250ba95e77f5fcb3fe2aefa85157e859
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3759346
+  timestamp: 1715097175495
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+  sha256: e5f8cbfb5fc25d460a9117bfc5511959c5e86ccb193316033f87bd516e0c8881
+  md5: 9f7e8b5eb651539386bb92c14e5c321b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37730
+  timestamp: 1692205554840
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+  sha256: 6c5b53831273674361437fb546e08315fc11ca9275a174bca3887987e86ced5a
+  md5: f8d91daf5173eb03157f484389adcdd4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 122178
+  timestamp: 1679591983138
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+  sha256: 546819d922b03f3a25ca9f98fd069d0588d481fc0603c6d74bd598fb6a93687f
+  md5: 86c18e3e0b67ee099457475ed6caf2e6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 751763
+  timestamp: 1704404627180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+  sha256: ae06f0dfa2cfae51404afc6d6ad3a474a93015b5ba9a7d3ea24224b8e7547987
+  md5: 3e19794c806cc3e84a3080a97c359b75
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 510466
+  timestamp: 1679005998612
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+  sha256: d95c88d06f4f3f667bd9a39e5f18179e83b3cd4c115c06ce0fff390ff6d3a700
+  md5: c6d00a8a4d89b1be99bfa3aff19d96b4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2134881
+  timestamp: 1684280285492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+  sha256: 643a9a0eba1e2bd5980d21623d3b35188c24781ec251acc4d15714bd1ccb4c17
+  md5: b3cda0394db05be6f0f6176abacb13f3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207985
+  timestamp: 1678721438358
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+  sha256: 974c22de09078bf07c5db31fe12d8d89d6433508defc8237cbe52e08c69ed56b
+  md5: 9cf10bfd49140a527cf4b1d912097e6d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36072
+  timestamp: 1676426019064
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
+  sha256: f43aca7a222c983c25c3e15f79c7e7e3c4909bb7839a1dd0ee327def81aa476e
+  md5: 2b61f1cb7fec068c76ef0ff97c2c62b5
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - openssl >=3.0.13,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - openssl <3.5.7
+  license: PSF-2.0
+  license_family: PSF
+  size: 19811751
+  timestamp: 1713545124922
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+  sha256: 2c61639b3bb56fc864c86558bceb7845b1731ac44bf1a94894172ea47a995bd4
+  md5: 404805e547b4d50b5cd17e16bca87527
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332043
+  timestamp: 1716495838826
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+  sha256: 9acb33db60d9319595f52337cae3b88c2a2338cd66f1f9d8ae86d0a993c2067a
+  md5: f4af8cf94d042b4dde487241bba1c457
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279780
+  timestamp: 1679500609851
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+  sha256: 48fe7373b012b51134b6b6ff67f18d2b4aae3a5c7700e4560ce002af7172f064
+  md5: 0379cd17692152c12b662b0e4ea46b88
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18008
+  timestamp: 1683824373128
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+  sha256: 803274d986d0c4e3b5ec1018747ede86ef57137455b3e44a60e834717eafb92b
+  md5: c9f134ddeff6fdf0373a45534ddb7079
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 273009
+  timestamp: 1713974722039
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+  sha256: 6fbcba97c1dcb5157afd23f264c3cff069c7e4be5ea55980fc349eb8dc2cb49e
+  md5: 8153e3f8b3283926bcf9403804a365f5
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65050
+  timestamp: 1711137009299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+  sha256: cd33dfee104dfbba4af38d06a09ccbae6a32e7c543afedab523303319ebb283d
+  md5: 3dfc19af0306d80921e1403f1f551bba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13679916
+  timestamp: 1676423267293
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+  sha256: 102ff1d958209e3648bb49da3503cf752abab822011fdc4e12e88145c9e73772
+  md5: 0553c2c381b6f5c836b23edc8c6db2ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 246689
+  timestamp: 1677708371873
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+  sha256: bee5c4d0f41f06a9c0aac636885e36e8b81116aafde980f9ea48fdb64abb5567
+  md5: 6c05a053240cb90765d6f8c2efdf905e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 182228
+  timestamp: 1698096268270
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+  sha256: ea39db411361d96545a04fb976940e9590147acb4ca9caacf7e8264780379347
+  md5: b411b8be8e53e5059949dde02dd07faf
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 565148
+  timestamp: 1709319072176
+- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+  sha256: 47653b45a5f2d97b5bf0dbf0e620908880f9078da427eef69012effe3f19af67
+  md5: 44e709ae67d89bccee2d4d46d358fee3
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74493
+  timestamp: 1699012356534
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.2-py311haa95532_0.tar.bz2
+  sha256: 8b9586873f05e6ce14c4e067efc0a61effc8d163d5129447515234a4c43b5f43
+  md5: 5fbd94c1f1e7c0a934eb8c9a00b34acb
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 122975
+  timestamp: 1716903247759
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+  sha256: d6daaa6b45272819176e4aeb467ae00e3db43386548464a9993688f292709d40
+  md5: 9fe721d7f7420c259df4f07d4503f654
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9683
+  timestamp: 1683077110211
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+  sha256: 6051860575f9448aea5799d74469c928cd7cdeeca1eb53657872262a77b1a7a8
+  md5: 60e193eca497130034facd5fed168249
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10094
+  timestamp: 1683059114376
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+  sha256: ecd310461c1b45ab92ddf15539cea5a6e837860561c974d2d7393f9a7933f116
+  md5: 1762fec2838763e904141167e18b0389
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 215600
+  timestamp: 1698947891859
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
+  sha256: 0042fa2dc2ec8c2181f28f5ee4f45087ea58dca7acc6b89c48f3ce6eac8f9bdd
+  md5: 755c9767608b233b94ec3a67c8e0da4b
+  depends:
+  - blas 1.0 mkl
+  - icc_rt >=2022.1.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<1.29
+  - pybind11-abi 5
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 32418527
+  timestamp: 1714081783418
+- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+  sha256: 6fd52bae6360fbc8135d72e0c1e4fd407769fa4d0f4b59356e7aed3e000eb339
+  md5: 49fd52885250da8aab17ed72e2e18b81
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88901
+  timestamp: 1699371435766
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+  sha256: a2ec4690bc07be9e7f3ad8e3003803eb4304a434d3f139633e2817318a9f7b20
+  md5: dd2d225219924fc5c36598c919541271
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1593050
+  timestamp: 1715025622141
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+  sha256: 5d1b7e14dc04816692de0f8518ea8fcbefb26ab61cec83f96f2c44c1bee67fab
+  md5: 505d2a70a875b5082dc857aa4dfab0d4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 18830
+  timestamp: 1705431395254
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+  sha256: 5ff3b4ac3fbce4dd67a87856c04698d0397deb0ac288ff4e7eb02fbab57f1253
+  md5: 0ca650a7001c6650809d3361de8cb005
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89590
+  timestamp: 1696347858925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+  sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
+  md5: 833b93a2daade3407898f15588945d83
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1440481
+  timestamp: 1714488344682
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+  sha256: 78d89b50a29fbeb19a562f5dad95615e3f192bb4f3b86cd6ea75f2f825418232
+  md5: 4a4040df560ea47704e0898c4c015808
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38069
+  timestamp: 1678228553220
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+  sha256: 70a3cc4a4e81a6421bc19cd410d1d6064aadb2b1cce38b020f85e5346716d8e7
+  md5: 32a9a2539579a3d522dce3b5cb4f987b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49495
+  timestamp: 1676425411739
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+  sha256: 0a95736cfd0bb25fc201cd6be4a2450ea8fc30eeb349d861812675b84c94fa74
+  md5: a8a9fb30c6dd8e7a16d5dcd2333c3c49
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3844176
+  timestamp: 1714770894235
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+  sha256: 4febf30c11674711b86c8c10da46a5e1613071388da999210912a31508864add
+  md5: 1c109fc1112ea1f5f377bdf0d18ba75f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 895633
+  timestamp: 1696937216859
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
+  sha256: 973dc7991dd5976ce2d27a94739712cac4d31f2d2958fbf23adb844f5ac999c8
+  md5: ca74b36907b3f4f8a51bd5b2e4d8220b
+  depends:
+  - colorama
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 186541
+  timestamp: 1716396206048
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+  sha256: e8c77efe880546252f244f995cbed5967809555127b4f818b97455d434b23415
+  md5: 7397ac07045115960ebd8dec95326a7a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270819
+  timestamp: 1676423321499
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+  sha256: ab3cce654f1e94793fff0cb03b750d9b20cdbf099263b1906c3c5eaf8b347ab6
+  md5: c68ffc771312afb6f88b94c24d2bb689
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9706
+  timestamp: 1715268972001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+  sha256: 4089efea1753ebe2f6617b46cc368738f285b1d816d4a4f01ba71524f46851b4
+  md5: 7f610528ecd0b317180efa2058c32323
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 75414
+  timestamp: 1715268958140
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+  sha256: d091897f05318c22ca31028370f25355065999078f7db6f88ab27bf4cb030ec8
+  md5: 1776502c1cfb351554eeda6cddaf255f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11588
+  timestamp: 1676457729096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+  sha256: c16498f8238cc331618720d078b87995eceb6bbf20268a7a4e8efbf7b5859a9a
+  md5: 770432c0ca1ab9d99ffe95e51d3a3e74
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 517433
+  timestamp: 1713213261710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
+  sha256: 3009bd4e7e8126309e606c81cb75d4b8d4fbb2bceac10ec43f7eb6eaaf717ac2
+  md5: ee6e87af42008a762d3531771c1a2b18
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - selenium >=4.4.3
+  - requests >=2.26.0
+  - h2 >=4,<5
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 210034
+  timestamp: 1715636431813
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
+  sha256: 906048f3b1dc326b367a08edc91816ff523b5f06cd45d985b4dbb7cfe8017559
+  md5: e509c495aaa92d767d554cd43a990ee5
+  depends:
+  - vs2015_runtime >=14.29.30133
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8900
+  timestamp: 1715797316229
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
+  sha256: ab224d078734a23527716388ddffc034d18254843881d0fc068c2efa35bacfe1
+  md5: 73f5831d017e5572330d2459844718f3
+  size: 2246565
+  timestamp: 1715797302913
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+  sha256: 24ea3d3e0cb98d0d246338dbb4562b67967bb32002e3704e495a5c863476e831
+  md5: c7b9cdbe87b3c9720aeca1164a0fd6df
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26181
+  timestamp: 1676424437003
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+  sha256: 92d27e41ce34387e59acb47572fcb2e92c4defaeadafd11ce190226022023e69
+  md5: f1bf142d852987acbe4b0bc94e87d958
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145306
+  timestamp: 1715878654770
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+  sha256: 1b086d1b079fdb2f148c7dd82658f2b7f283c88f286e1216c0f1237319039b0f
+  md5: 299e87f151a549d86a48bf24df15c607
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 168041
+  timestamp: 1714717238470
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+  sha256: 17fadf35aa8917c107e7b369e9364ac7c09537776e7943d37e225e14b7026c94
+  md5: 0e67c3b9624540581b894b11267a837b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PUBLIC-DOMAIN
+  size: 10197
+  timestamp: 1676425485716
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+  sha256: b849b368e27920838fe40a512b102879693a55cb187dd1c8d3a83fa8c05a8054
+  md5: 7b1f6e9c71906a93039b3446b99a5498
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55114
+  timestamp: 1676434863173
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+  sha256: 344a5276a9928638dcde054dfe4e87c8cb40bd2d4d356378b9ab2f863ca62e4b
+  md5: fe471fd8b5a3d77be6fa5dbf9b99dafb
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 1432281
+  timestamp: 1714515119689
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+  sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
+  md5: e5aed81295b61b6d1eb62830799a0297
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 9125184
+  timestamp: 1705602328351
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+  sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
+  md5: f295b54ab59f5b8658e2a322ac6aa721
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 162161
+  timestamp: 1714514792081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+  sha256: b2ff66b7f6efa0831f939e57e562c244332b690af08818a540d1a97fa07d8525
+  md5: e548d528873d9a0006a36714cf36462a
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1933522
+  timestamp: 1714679197977

--- a/portfolio_optimizer/pixi.lock
+++ b/portfolio_optimizer/pixi.lock
@@ -7,654 +7,654 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.32.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.32.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.32.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.32.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
   sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
   md5: 613805add1c05b538ff06d217252feb7
   depends:
@@ -665,7 +665,7 @@ packages:
   license: BSD-3-Clause
   size: 20810
   timestamp: 1652859733309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
   sha256: 250f50edf43a786a32942e9ae67ce807e9b3ac4cb6b58b1170cb541fb24e391f
   md5: b48058294499d292ddf9a3b966dc9cc5
   depends:
@@ -679,7 +679,7 @@ packages:
   license_family: MIT
   size: 228473
   timestamp: 1706220559474
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
   sha256: 0d4f5274503916e1c683dcc16e8a7c4186557afa3f62399cd628e4eb535fe77a
   md5: 062acdb0f9ae976c25c2d15d589dc1d6
   depends:
@@ -690,7 +690,7 @@ packages:
   license_family: MIT
   size: 35809
   timestamp: 1676823571351
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
   sha256: 567dfdd5b986012421a736a5f1c1d5874d8d691dd483c838b55e1ab06c0b217d
   md5: 4e0aa1543f546b898523382ee8405e84
   depends:
@@ -699,7 +699,7 @@ packages:
   license_family: MIT
   size: 152577
   timestamp: 1695717917074
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
   sha256: 894fceb5b4f8740bcd146de8bd0f6eabf14e2407b149b790b4983b8432681e6b
   md5: 2f0ef211bf628cd22bbfa44c3f9bc035
   depends:
@@ -709,12 +709,12 @@ packages:
   license_family: MIT
   size: 271600
   timestamp: 1681493103694
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
   sha256: 9f027f156744dcbf28945aad6e422ef030c84c2a5d40116d3e40407c66853bf8
   md5: 7b52489e04f9a5585643d5578835fc68
   depends:
@@ -732,7 +732,7 @@ packages:
   license_family: BSD
   size: 6059952
   timestamp: 1712084450899
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
   sha256: 8e2b2073ff5c61d35714e8a36ce657a8ac741b7bedc2852a238c7f1625142705
   md5: d951ab54a682b6328327fec53b1e5e72
   depends:
@@ -743,7 +743,7 @@ packages:
   license_family: BSD
   size: 147642
   timestamp: 1707864274452
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
   sha256: 5d15605858771290fdaaae41a43941623757a25cb1292080d69d6d3857807935
   md5: 7f517469aa5380c52e55db9f37df104f
   depends:
@@ -754,7 +754,7 @@ packages:
   license: MIT
   size: 18652
   timestamp: 1714483267080
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
   sha256: a5094f078584e27c7cced4a9564ae904a329f5c1702a7c1ba092d581ba1544f1
   md5: 6ddf45dd8a21a9512481de9bc0e5a03f
   depends:
@@ -764,7 +764,7 @@ packages:
   license: MIT
   size: 19711
   timestamp: 1714483255915
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
   sha256: 93180c973816246f068b742d0bf64840f0ea48e31d4f9b0747ea2ffc34d8855d
   md5: f3a00096965a5ba1eb41d2c99a4662a2
   depends:
@@ -774,7 +774,7 @@ packages:
   license: MIT
   size: 361574
   timestamp: 1714483400014
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
   sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
   md5: f5058c8d5b2994b7334f18e022105a14
   depends:
@@ -783,14 +783,14 @@ packages:
   license_family: BSD
   size: 427542
   timestamp: 1714510571510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
   sha256: 394f74202c2efc8fcfd02b8953f508eb6a2961d224a2f9d15091caf5cbe1be67
   md5: 1202b4ed32215c6405bb42fbff355316
   license: MPL-2.0
   license_family: Other
   size: 137411
   timestamp: 1710764808838
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
   sha256: 6dc29d20180f6e002f37b251efa639716d3444e129a754dabf751f816aada7ef
   md5: 5dbfa083e6ab6318fac58fe0e0c94445
   depends:
@@ -799,7 +799,7 @@ packages:
   license_family: Other
   size: 165152
   timestamp: 1707229213375
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
   sha256: d138cc3fde270eba783baf1e2ba17c89800b2cbbf20976d0eb425b3436a4a184
   md5: 1875e89c1a939e4e7c5e7b731c72b838
   depends:
@@ -811,7 +811,7 @@ packages:
   license_family: MIT
   size: 302401
   timestamp: 1714483186060
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
   sha256: d9c102b9ec7f3a635936b6f73d4db126d748a25f65407353bd76b260dc7d1cd6
   md5: eec48dbdf5dac0ea26750cc26b58c1d9
   depends:
@@ -820,7 +820,7 @@ packages:
   license_family: CC
   size: 554986
   timestamp: 1709758392744
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
   sha256: 882481e441b9b93cbdfb32fbe32a6ad9f26197472f186a08fddb921f61346c02
   md5: 443c79196064f57c98199e9990544b2f
   depends:
@@ -830,7 +830,7 @@ packages:
   license_family: BSD
   size: 16902
   timestamp: 1709322958614
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
   sha256: e4877b41553e31b9f9f090dffab77a654255c63776e8b30fc91ec1f60afadbf1
   md5: c34d3f1520f1e8c9957eb236710058c4
   depends:
@@ -842,7 +842,7 @@ packages:
   license_family: BSD
   size: 281162
   timestamp: 1700583651472
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
   sha256: 3b4cd8dc60572086f1a1cbb97e2712e0ffd55317ce8f0309d552eee7367855eb
   md5: 70a1263b6e19bf2d77c020a2e77277c9
   depends:
@@ -853,7 +853,7 @@ packages:
   license_family: MIT
   size: 2556575
   timestamp: 1690905285843
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
   sha256: 4b589e3265c74159130230c164ff2d8d381be65899a249def0b53f93ce83fd47
   md5: 245cb7173dcdba21cf368031cd87f706
   depends:
@@ -862,7 +862,7 @@ packages:
   license_family: MIT
   size: 17434
   timestamp: 1676823330845
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
   sha256: b75d12e85274660bb675a3e53d47a929872f2daa2ff5a76e98885ee3f2d19ad1
   md5: f2119d0885334060d0d7fe59e5220287
   depends:
@@ -881,7 +881,7 @@ packages:
   license_family: MIT
   size: 3237908
   timestamp: 1713551660998
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
   sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
   md5: a5dc8677d891dff2393b63189a3ad42f
   depends:
@@ -892,7 +892,7 @@ packages:
   license_family: Other
   size: 971975
   timestamp: 1666798278693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
   sha256: f48ccfb4214e2af41e73a3904e343ecd1eb1ae06578c26f55a5dd247771b2c86
   md5: d58e9eb09817935eb7342ceff889f481
   depends:
@@ -909,7 +909,7 @@ packages:
   license_family: BSD
   size: 5335524
   timestamp: 1707836581350
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
   sha256: a0ae6c5a6b615d73d9a243331f3f7d749b4feafdf2f334337fda8abd6c8355ed
   md5: e61d8dcd4dfd6d165e6e480cee846bf5
   depends:
@@ -926,7 +926,7 @@ packages:
   license_family: BSD
   size: 357992
   timestamp: 1715090462763
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
   sha256: e08e27531775de40f46b6ac7bf71856963baa0c008bd2b4d112e6341cd3e8f4c
   md5: bfc7682613c861cbcb4ac01485c05657
   depends:
@@ -935,7 +935,7 @@ packages:
   license_family: BSD
   size: 147174
   timestamp: 1714398938840
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
   sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
   md5: 3add2ce56858a1b8f6a37342f82773d3
   depends:
@@ -951,7 +951,7 @@ packages:
   license_family: Proprietary
   size: 19310769
   timestamp: 1699647799237
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
   sha256: 0b670ab17ed2e1b592079bd64386dadc249ddc892e5ae1dd99f142a918ffc75d
   md5: 632575b9e442c1e5c146cf78424da610
   depends:
@@ -972,7 +972,7 @@ packages:
   license_family: BSD
   size: 227791
   timestamp: 1705934138566
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
   sha256: 65228eb868c3ec8aa71f958e60a675a919f016c2057392e02fd422fc841858f9
   md5: 68e23f14cd222c233e6b37262bc61c23
   depends:
@@ -989,7 +989,7 @@ packages:
   license_family: BSD
   size: 1612840
   timestamp: 1704833066871
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
   sha256: a2918ea8a3e2c56fc6d91191e84b2f35500c392b16ab687a0c03ded2e2e51239
   md5: 84fadd6b7fef393cccc0d123dae6cae8
   depends:
@@ -999,7 +999,7 @@ packages:
   license_family: MIT
   size: 1162207
   timestamp: 1679336523618
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.4-py311h06a4308_0.tar.bz2
   sha256: f8c1f9c49e58fd9adfefbe99d055a8045643b620902c4758a07d689b21418900
   md5: 77918475e3a5511cd5a0f595a751b881
   depends:
@@ -1011,7 +1011,7 @@ packages:
   license_family: BSD
   size: 354911
   timestamp: 1716993527421
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
   sha256: c21f8f407266d039e819c27fe9eb4fb26587e974f3bd059b37cbaec5073722d0
   md5: ba1f47411e9e07876c7a3e9d3be6a98e
   depends:
@@ -1020,7 +1020,7 @@ packages:
   license_family: Other
   size: 281400
   timestamp: 1677849152168
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
   sha256: 06b729aee6dd2a1e545f3ad64179cc0d4ef8a15e33db3be2995dd3e0868465ca
   md5: 8bb3215912588e47e2eeb4e7a09ad64f
   depends:
@@ -1033,7 +1033,7 @@ packages:
   license_family: MIT
   size: 180858
   timestamp: 1699041715847
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
   sha256: 9e3bac2d41bd432b721b009e7de981766fba396e6f238e923f304112bd88655a
   md5: 84ae4cf3f2d01fbebdac374971192be9
   depends:
@@ -1043,7 +1043,7 @@ packages:
   license_family: MIT
   size: 15525
   timestamp: 1699032521315
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
   sha256: 79ce6dff3d93649a2555b1d2a4ae9eb77175a1c00664cb8eb0e6f848d5cdd1b9
   md5: db395b0efd7018fcf3a4af879170c2a8
   depends:
@@ -1059,7 +1059,7 @@ packages:
   license_family: BSD
   size: 276856
   timestamp: 1676823504812
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
   sha256: fedc7e5560252af44b0dfbe6f7acfe20ab17a6a08e758f670a1cd820551afc7a
   md5: bd28d36963087f53a79b23fee697d665
   depends:
@@ -1070,7 +1070,7 @@ packages:
   license_family: BSD
   size: 93898
   timestamp: 1698937453304
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
   sha256: 2b896fe8b2187b7df824041826e14379476eb2e61d607d8cb38ac2b3df40aaa4
   md5: 8fc7e517da96c2c482331f6b08d07a17
   depends:
@@ -1086,7 +1086,7 @@ packages:
   license_family: BSD
   size: 41459
   timestamp: 1699282616532
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
   sha256: 87d372f5b23bcc2410e43b40b4ad059ea1625178b8a2b484fc63805ce517e594
   md5: 50204f372b1672871d6ab3db6a876374
   depends:
@@ -1113,7 +1113,7 @@ packages:
   license_family: BSD
   size: 594177
   timestamp: 1699467208489
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
   sha256: ddfee06ba9b149222c65d1d4270272840533aa63b56fe36363c84a891c71d328
   md5: ee128e5c0d8d9e1952e2387b66a5b8cb
   depends:
@@ -1123,7 +1123,7 @@ packages:
   license_family: BSD
   size: 27239
   timestamp: 1686870958829
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
   sha256: 0c6a074272ed58677ec17e4dbfceaffd2108841a61af92b32f156c5763108d1d
   md5: dd3d37841d0d20c70a60e8c939923894
   depends:
@@ -1135,7 +1135,7 @@ packages:
   license_family: BSD
   size: 19144
   timestamp: 1700168632051
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
   sha256: b040f0d0ee4588188ab6b83a93738b3ff6e6d1775424be97995bd0df0f4fb904
   md5: eae62735d710cf5ff6d51e6f59fcd999
   depends:
@@ -1146,7 +1146,7 @@ packages:
   license_family: BSD
   size: 78148
   timestamp: 1676827253282
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -1157,7 +1157,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
   sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
   md5: 9508af80612e4fa1b5d1abb43ca7e63c
   constrains:
@@ -1165,7 +1165,7 @@ packages:
   license: GPL-3.0-only
   size: 749072
   timestamp: 1652971360657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
   sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
   md5: 88199c75f2ac211728febced7785c24e
   depends:
@@ -1175,7 +1175,7 @@ packages:
   license_family: Apache
   size: 228278
   timestamp: 1635523146417
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
   sha256: bb990ea068c3b3dafd9c807e0e19570320cb2fe7d69cc326f1f0b5319b0654b2
   md5: 3ff70744e396b1af69656c574b05c3b9
   depends:
@@ -1183,7 +1183,7 @@ packages:
   license: MIT
   size: 66940
   timestamp: 1714483221853
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
   sha256: 3b87a816f72a00e1f0022a160e7eda70af89d3de2a2e08a72be1c17b31d759f3
   md5: 4f57d3a0a13ddaf1c06efb586b702f46
   depends:
@@ -1192,7 +1192,7 @@ packages:
   license: MIT
   size: 34446
   timestamp: 1714483232430
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
   sha256: 2cf15e89f910600f468edfde8d0f9b80a14fa2319ed89160dc7375dfd3764fdb
   md5: 463adc13f2feea3570d1eccac368d9e4
   depends:
@@ -1201,7 +1201,7 @@ packages:
   license: MIT
   size: 295090
   timestamp: 1714483244460
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
   sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
   md5: 55dde57e63a36b202e388a39dcee9a66
   depends:
@@ -1210,7 +1210,7 @@ packages:
   license_family: MIT
   size: 74096
   timestamp: 1695996494461
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
   sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
   md5: 1af9b4d62c708924417f2640ef22a68f
   depends:
@@ -1220,7 +1220,7 @@ packages:
   license_family: MIT
   size: 154016
   timestamp: 1714483282916
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
   sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
   md5: 641e72e5067bd6d5454405879e1cd2a7
   depends:
@@ -1235,7 +1235,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 8895144
   timestamp: 1654090827491
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
   sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
   md5: 27082517590f3b9fbffecc68513b461b
   depends:
@@ -1244,7 +1244,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 19860
   timestamp: 1654090819660
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
   sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
   md5: 0202c3c8ae4735cac6c7f3d1e1685964
   constrains:
@@ -1252,7 +1252,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 5228750
   timestamp: 1654090762569
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
   sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
   md5: 3080c2813e6e1d0f8a100a38b5b3456d
   depends:
@@ -1260,7 +1260,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 573231
   timestamp: 1654090775721
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
   sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
   md5: 1bffe1481ed4f88827248fb9001f8923
   depends:
@@ -1270,7 +1270,7 @@ packages:
   license_family: Other
   size: 362561
   timestamp: 1677841789536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -1278,7 +1278,7 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
   sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
   md5: 8c195584a5f5471b600ee180e4052773
   depends:
@@ -1286,7 +1286,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 6410287
   timestamp: 1654090800863
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
   sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
   md5: ef78eebd98289aceacdfa29182426adf
   depends:
@@ -1304,7 +1304,7 @@ packages:
   license_family: Other
   size: 664034
   timestamp: 1693575237924
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
   sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
   md5: 292768ec77416ae257cfdd44ea2071c8
   depends:
@@ -1313,7 +1313,7 @@ packages:
   license_family: BSD
   size: 29197
   timestamp: 1668082729834
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
   sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
   md5: 9cdeef1d044c7e035c006890f11569d3
   depends:
@@ -1324,7 +1324,7 @@ packages:
   license_family: BSD
   size: 436056
   timestamp: 1694776944891
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
   sha256: fd8e30beb8c9442f16e6617fac92dd0c89ec823e98f06e60f712147380ead35f
   md5: 7ed7caf2816c8b85b67b6f4e8833cbd5
   depends:
@@ -1334,7 +1334,7 @@ packages:
   license_family: MIT
   size: 41155
   timestamp: 1676837080881
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
   sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
   md5: 76f089e76ec67583bb38428b51008097
   depends:
@@ -1344,7 +1344,7 @@ packages:
   license_family: BSD
   size: 164494
   timestamp: 1714510587156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
   sha256: 260e26dd509834c1b225ab7bdb97b9a86e00054fbdd5dfa49e68fa4dcf85a661
   md5: 8f5d7ddc69cc6f7d44c80d2251dea5d1
   depends:
@@ -1353,7 +1353,7 @@ packages:
   license_family: BSD
   size: 162339
   timestamp: 1676837095436
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
   sha256: 7f5b0804d0768619b7bd93b10488067d80bf42ec29f443f00b53ba11758a1241
   md5: 8afb45e45c0d93bfd142e682d4b021ef
   depends:
@@ -1363,7 +1363,7 @@ packages:
   license_family: MIT
   size: 134438
   timestamp: 1684280014220
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
   sha256: cb03570c99c983d7bfda94bc47d8eb00d4059b8548a171130775acc998004195
   md5: 5b1abbbf1e4f9b350b16fc9caf9e889b
   depends:
@@ -1375,7 +1375,7 @@ packages:
   license_family: BSD
   size: 26919
   timestamp: 1704206397615
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
   sha256: 85fea48bea278a77d102781a1cbb6bf69307207d741251e38a6515c5fd7e3523
   md5: d6ddba94f7c33c88c9825be8409991bf
   depends:
@@ -1397,7 +1397,7 @@ packages:
   license_family: PSF
   size: 9150942
   timestamp: 1713336680714
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
   sha256: 7ac07ea180b5928086075900afbc332fb1d3c81ddfacb54c891693c284056f14
   md5: fc83dd1b3d2ec3c0a297ead0c3405907
   depends:
@@ -1407,7 +1407,7 @@ packages:
   license_family: BSD
   size: 19573
   timestamp: 1676823852670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
   sha256: c9ba2f9c83820712dd97d6a1b54a1215b9820a0be02ac82380b4c50911b9400c
   md5: e5dc6b4a5b8e02733ce3bc9e9198a8d2
   depends:
@@ -1417,7 +1417,7 @@ packages:
   license_family: MIT
   size: 67750
   timestamp: 1676837123613
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
   sha256: 1a5141ef0de1cbff816f96bb4b212a40606e2fc11301a4c1358c8d63a6b2b027
   md5: 22ac3bc22b68fef4c1f3f6ab3c7bfe0b
   depends:
@@ -1426,7 +1426,7 @@ packages:
   license_family: MIT
   size: 23040
   timestamp: 1676827301164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
   sha256: 9aacfbbe6f638c58a4e8ff31374d1438d78b7db25d6ea6fd0c50ca2109f225d4
   md5: e602057e3b3d80da88c61d66e8851c5b
   depends:
@@ -1437,7 +1437,7 @@ packages:
   license_family: BSD
   size: 104681
   timestamp: 1676823696152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
   sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
   md5: ce77d0f05f846da4a6b9e23fe7f21d9b
   depends:
@@ -1451,7 +1451,7 @@ packages:
   license_family: Proprietary
   size: 206738176
   timestamp: 1699648006088
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
   sha256: 2aef0876d0df033f7fae8cddbd25d95fc1bfc067e60dd143bd8000fec0768b21
   md5: d6cdc670327bd1675bbea642849f04e1
   depends:
@@ -1462,7 +1462,7 @@ packages:
   license_family: BSD
   size: 59569
   timestamp: 1682948560323
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
   sha256: 691c4b2b47cf3fac55b4949d7c0f547246ef19cb3510749142cee4bd01ffb055
   md5: bbd69efa3f24ee747410f83118640d92
   depends:
@@ -1476,7 +1476,7 @@ packages:
   license_family: BSD
   size: 240723
   timestamp: 1695058405382
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
   sha256: 71f5c7beca4e81b465ecfc6ed51cb3d39f51dd88df0b29eff5def3d1f12969eb
   md5: 61d58663b7277cf4cc3cb8d9873d3ee8
   depends:
@@ -1491,7 +1491,7 @@ packages:
   license_family: BSD
   size: 331105
   timestamp: 1695059935112
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
   sha256: 20d832ce714465ae1685d29e2f913fd105d385d003fe1bef71ef472e6f3489e6
   md5: ad76299b0c33b7a5c0d45905271165c1
   depends:
@@ -1517,7 +1517,7 @@ packages:
   license_family: BSD
   size: 8303422
   timestamp: 1699542957307
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
   sha256: bb45fb0a3973caa74fd8f845e0a519895f6a378807626e15ecf72c02f2eed794
   md5: 185f658ba8a74e326b7231c8fd0d62bf
   depends:
@@ -1530,7 +1530,7 @@ packages:
   license_family: BSD
   size: 121834
   timestamp: 1698934274227
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
   sha256: 8b2fc372a6655fd5b277d07b994ce43643553fbc37e63a60e9fe527a9026ec06
   md5: ed6ac14aed5a796b153d757862398997
   depends:
@@ -1557,7 +1557,7 @@ packages:
   license_family: BSD
   size: 523905
   timestamp: 1699022906468
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
   sha256: 7908ff6c516b15e8fb677be4071145e18adea7d4c13b8485a70a5ee2f573f8cb
   md5: 50c0e38207a131a5de6a14ef919ffcdc
   depends:
@@ -1570,7 +1570,7 @@ packages:
   license_family: BSD
   size: 169629
   timestamp: 1694616826002
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
   sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
   md5: 57ea097dc15f8d9f9eb90e1d919143b0
   depends:
@@ -1579,7 +1579,7 @@ packages:
   license_family: MIT
   size: 1157733
   timestamp: 1674734069410
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
   sha256: 266199dd4efde0ad342a9c500f4bc4299c5622219aea623b46315a9b4f6b8959
   md5: 2b21844d2b0024d0ffad0e6450cf0855
   depends:
@@ -1588,7 +1588,7 @@ packages:
   license_family: BSD
   size: 15860
   timestamp: 1708532713870
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
   sha256: 13d6c640710895e9732225cdedbe47fcd756887fffeb0cf9bc149ee7234dfc27
   md5: a87d55e3d071f2c435b10db49a9911af
   depends:
@@ -1613,7 +1613,7 @@ packages:
   license_family: BSD
   size: 730963
   timestamp: 1690984942516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
   sha256: ef2857e6d3d7eb246b3abddfbd3aa2d124dd8565391ace3876b77339babc50bb
   md5: d276d1b1774107987963135c78ca7390
   depends:
@@ -1623,7 +1623,7 @@ packages:
   license_family: BSD
   size: 26607
   timestamp: 1699455972519
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
   sha256: 2f89f38a665ece47e8868b391fc70602fcee588e989bc1ca6f17f6094892a94e
   md5: b788c80b2d571531ea4f3f8335ae5423
   depends:
@@ -1638,7 +1638,7 @@ packages:
   license_family: MIT
   size: 168827
   timestamp: 1696515597877
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
   sha256: e09e1aff2c12d4ef3fec58fb627744e4b5c7d9eaede7175e293f77272d8b8bfd
   md5: fe8242cfd54d238507493612ae697ad4
   depends:
@@ -1655,7 +1655,7 @@ packages:
   license_family: BSD
   size: 10270
   timestamp: 1708639794640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
   sha256: a53ad723826651041a5057a1cf31bc8689b24d335ce61b196df5124974b05a8e
   md5: 7b29e7191c4170189d6080e61229f030
   depends:
@@ -1671,7 +1671,7 @@ packages:
   license_family: BSD
   size: 9163911
   timestamp: 1708639777712
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
   sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
   md5: b0afe23033c8c5344640bc25225fa579
   depends:
@@ -1682,7 +1682,7 @@ packages:
   license: BSD 2-Clause
   size: 516994
   timestamp: 1630084830020
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
   sha256: 6c7cb4097e4f3655b54a119304e50f0edbc4bd52f36c84629b64674cf8d468b8
   md5: f1e48c973646ded3c2e1a189a9d8b8c9
   depends:
@@ -1692,7 +1692,7 @@ packages:
   license_family: Apache
   size: 5498991
   timestamp: 1716318104769
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
   sha256: 280225061aeba00d7b85f46e55d7d79cd92c92f662dc749d9c53187978e8d083
   md5: c51c21da68080d89300703ad818c824a
   depends:
@@ -1701,7 +1701,7 @@ packages:
   license_family: APACHE
   size: 38606
   timestamp: 1699371264464
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
   sha256: bd3eacd22e85f88bedd9c7e97a59eacfb3c8bb80eb59be244825d6895a0e7ac1
   md5: 08ceb294ba8a9ae13630da789884736e
   depends:
@@ -1710,7 +1710,7 @@ packages:
   license_family: Apache
   size: 157904
   timestamp: 1710807470578
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
   sha256: a2ee3a6aaf54929b82b851b2eb5436e14e5a294303ef429d6dccd33bcdfc8002
   md5: b467a5c7ad672ccc2d498a67b9eeeaaa
   depends:
@@ -1761,7 +1761,7 @@ packages:
   license_family: BSD
   size: 17970687
   timestamp: 1709593080388
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
   sha256: aa05415302a27a82105e9d0800151f09fd1bb896b90854dc23989f9aecd9200b
   md5: 4974b1ae5f1a3b6d9fb26e7eb2c26733
   depends:
@@ -1785,7 +1785,7 @@ packages:
   license_family: BSD
   size: 21869200
   timestamp: 1714071532259
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
   sha256: c6c782537b96ab9caf3e25f5a33799c727e84664cdbab37a8d3359a221e2d2e3
   md5: 8f56d0f63e0589dd7e4a004678307813
   depends:
@@ -1794,7 +1794,7 @@ packages:
   license_family: BSD
   size: 263438
   timestamp: 1711136934516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
   sha256: 28ed719669260a20bec78971edaffb91ec917d2a3f0fac1cf9a8ba21590baa43
   md5: 0481d078fcd64f7f981532a514d9d50d
   depends:
@@ -1811,7 +1811,7 @@ packages:
   license_family: Other
   size: 960727
   timestamp: 1714399060039
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
   sha256: d527189038b376a982c18613df808f25dc40314b0dc8fe5549f3ae9f4288e497
   md5: 68dad015e796cc26364b55f92f61faa7
   depends:
@@ -1822,7 +1822,7 @@ packages:
   license_family: MIT
   size: 3451714
   timestamp: 1715097126399
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
   sha256: d2bbab8bfc57c7f46ca8994bc87df7e744d3f036b867bc4be1145ba6d8d7e091
   md5: de41707272a8e3ccab764f0b7010a27d
   depends:
@@ -1831,7 +1831,7 @@ packages:
   license_family: MIT
   size: 37394
   timestamp: 1692205565974
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
   sha256: e2a0e2a618aa33f0beff9583c7dc510b8d0737b023117346676aacbad33970d8
   md5: 66a6818307261b1a28ab12d1b7776fdf
   depends:
@@ -1840,7 +1840,7 @@ packages:
   license_family: Apache
   size: 121454
   timestamp: 1679340540306
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
   sha256: b7f591c19b10bf0daa7e6e3b45a9f4a0a0e83188e1f8a58037caea79e60f8d91
   md5: d945b4ccc135005839c504cc29df1745
   depends:
@@ -1852,7 +1852,7 @@ packages:
   license_family: BSD
   size: 749608
   timestamp: 1704404477511
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
   sha256: 96482b49191fdac59580a95e69508367083e1f7600145e11d7c2db634337eb26
   md5: 2d57bf8eacf3f291db845928241f724c
   depends:
@@ -1862,7 +1862,7 @@ packages:
   license_family: BSD
   size: 490805
   timestamp: 1679337420563
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
   sha256: ed927e4d058a8f4ea73edc7a43ed74877d93b88fdfa240b3b2777244386ced70
   md5: a1f0e05fc7e49712f81ad5478ec9d51e
   depends:
@@ -1871,7 +1871,7 @@ packages:
   license_family: BSD
   size: 2121496
   timestamp: 1684280065800
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
   sha256: ad219924e362ce7af458fa6547660181579e9a50e5aed1ffd9268cbe7c2650e3
   md5: 2b1ac40e0df3673d33b7f4c4f93ae1ef
   depends:
@@ -1880,7 +1880,7 @@ packages:
   license_family: MIT
   size: 207338
   timestamp: 1677811584327
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
   sha256: 114b55e00f4622c90fd2b404b21ad5f94a10283fcaaf86a42174b8d39b0a3e98
   md5: 2458e92683cc68671a6c8e1b86ce8817
   depends:
@@ -1889,7 +1889,7 @@ packages:
   license_family: BSD
   size: 35850
   timestamp: 1676822725516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
   sha256: ef622eb34669f3518d2f855cb333c56b106d02cdeac9d58e5a1a5a3097e4978d
   md5: 9d4f211d050d511b0b84c2e57e7fb1d7
   depends:
@@ -1911,7 +1911,7 @@ packages:
   license_family: PSF
   size: 36072860
   timestamp: 1713546307595
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
   sha256: a0f008717fab060ccd003dfebc09156d90b9afd14ac3626566aa1a8f3d3b7e2f
   md5: 357bf4fe94496cbae72ab4d780184b31
   depends:
@@ -1921,7 +1921,7 @@ packages:
   license_family: BSD
   size: 330924
   timestamp: 1716495762901
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
   sha256: aadc4078311c059265706a56265f0a57ceb538d36179d5203dd487d80d0e8f16
   md5: 59ec670fcd172447dbd9591b8fbfdd56
   depends:
@@ -1930,7 +1930,7 @@ packages:
   license_family: BSD
   size: 278741
   timestamp: 1679340144625
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
   sha256: d5058d0ecc3973316c1d5f1bfb03dd119e0dade85f4c2d21b412c8db4e1636f2
   md5: 93000e4d3603342779a2afda66fa91b8
   depends:
@@ -1939,7 +1939,7 @@ packages:
   license_family: BSD
   size: 17607
   timestamp: 1683823841946
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
   sha256: b85acb933fff864bfa89d034e8e3d85b1a9c2e69cbfc0d68c1d66ffd1443e67d
   md5: 0cdb92d2d684ee1095310f992ed0d9b2
   depends:
@@ -1948,7 +1948,7 @@ packages:
   license_family: MIT
   size: 266796
   timestamp: 1713974338678
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
   sha256: 511e8206a15445715b80be76493300930686b3fe1e512ae942d6ccca36df392a
   md5: 35a6e46ae970f8b71d78fb5a810f2e80
   depends:
@@ -1960,7 +1960,7 @@ packages:
   license_family: BSD
   size: 64013
   timestamp: 1711136926372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
   sha256: b2a1f649669f4336b74f6f20df711959bcd8024f8f8b94199dc0e040b06bd37a
   md5: f9e8e3f7068f717f75e555dc04545d8d
   depends:
@@ -1971,7 +1971,7 @@ packages:
   license_family: MIT
   size: 206433
   timestamp: 1698096204677
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
   sha256: 7c74db4292f31619606180f86f3c1e2d913495c2c9d1195c5d51681a6a841625
   md5: be1c05fae57d194924b9400f9b5ad3c6
   depends:
@@ -1982,7 +1982,7 @@ packages:
   license_family: Other
   size: 613277
   timestamp: 1709318516682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
   sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
   md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
   depends:
@@ -1992,7 +1992,7 @@ packages:
   license_family: GPL
   size: 467661
   timestamp: 1666648052561
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
   sha256: 89c2f4235277b9825cc805c5c44f0b1afcb683d7b5a3f513bc4bf243b643bb0c
   md5: db70eb57e33adf7b8bbdadd72214d48d
   depends:
@@ -2003,7 +2003,7 @@ packages:
   license_family: MIT
   size: 73679
   timestamp: 1699012111499
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.32.2-py311h06a4308_0.tar.bz2
   sha256: 12c831fad9b6e0acd3821819072a81c4ed7007e90f2daa9c711732b69c57548b
   md5: 0b9387d074f6714268bcc44c1f2634d9
   depends:
@@ -2019,7 +2019,7 @@ packages:
   license_family: Apache
   size: 121943
   timestamp: 1716902856135
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
   sha256: fdae3f68ea84b99561aee6c566ab1c287d8f2ae2668424e9283a8ed86af8f1d2
   md5: cde5b71ccbb3630053340b2c8c7dbf10
   depends:
@@ -2029,7 +2029,7 @@ packages:
   license_family: MIT
   size: 9333
   timestamp: 1683077183576
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
   sha256: 0bf859b06a07857099fd4f524fe5e0875fda70029e9485d95c7efa97134fbc14
   md5: fd5815cc592fdbd4c831901541eadaba
   depends:
@@ -2038,7 +2038,7 @@ packages:
   license_family: MIT
   size: 9735
   timestamp: 1683059096795
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
   sha256: 474553d01aea57214a54a7443f227da84a58e29c49eb7605ba0043c55b7d167a
   md5: f01333e9f0a908e435db650f42fbd2db
   depends:
@@ -2048,7 +2048,7 @@ packages:
   license_family: MIT
   size: 1096668
   timestamp: 1698946168635
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/scipy-1.13.0-py311h08b1b3b_0.tar.bz2
   sha256: b06b45da61807f76b6d800047f123fee2cc95eb84da508550e0908951c8d9f6f
   md5: 9b100efb9ba2fc7f9bcfaa8fd2ab6f9f
   depends:
@@ -2067,7 +2067,7 @@ packages:
   license_family: BSD
   size: 27615256
   timestamp: 1714076660659
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
   sha256: 51bcea0e575a626f6ffbd16d1153330fda93dbe3dd31dcd3a8f469ff61dd1e4e
   md5: 41d531c90be8c82bf79635ff3d409476
   depends:
@@ -2076,7 +2076,7 @@ packages:
   license_family: BSD
   size: 32295
   timestamp: 1699371262818
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
   sha256: 0a95988ea269c96354626dcab255b65b54bb5c503d24cdeb6ef2e1c42818bd59
   md5: 8bfb9f42492b3b53b8151d77e51c75d8
   depends:
@@ -2085,7 +2085,7 @@ packages:
   license_family: MIT
   size: 1594974
   timestamp: 1715024182643
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
   sha256: 1a84b00944bc5588e14a097460175f97df49acb4f1ff2498ffd9a1893068ed81
   md5: a456513471b2ecbed60430c21dd1ccc7
   depends:
@@ -2094,7 +2094,7 @@ packages:
   license_family: Other
   size: 17880
   timestamp: 1705431390054
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
   sha256: adcafd297d60af64107c113bb7b8b92160d0268a44ef9a3b79e56a88a0358ea7
   md5: 28ed704ed26b06d32662e3a6a87e59b0
   depends:
@@ -2103,7 +2103,7 @@ packages:
   license_family: MIT
   size: 88799
   timestamp: 1696347581401
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
   sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
   md5: f86119b3243fe3508160aa0406245738
   depends:
@@ -2116,7 +2116,7 @@ packages:
   license_family: Other
   size: 1723866
   timestamp: 1714488309729
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
   sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
   md5: 041a3caf09dc9ce8fc6c10925c4fe050
   depends:
@@ -2126,7 +2126,7 @@ packages:
   license_family: Apache
   size: 1888016
   timestamp: 1680167274961
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
   sha256: 856a8ab8c350c50247b79966c6cb80fb6d4de36eef49ddf75aebbbcaf854c82d
   md5: 442dde204d14d171aab9ee40e8de4de8
   depends:
@@ -2137,7 +2137,7 @@ packages:
   license_family: BSD
   size: 37456
   timestamp: 1677696176157
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
   sha256: f0a026ddc0ed041bfc60c8a1ca0b70b7a69232775b3181bfb35a39fda42d6994
   md5: 2902d5a5854865baaaf58dc59cf06b3c
   depends:
@@ -2147,7 +2147,7 @@ packages:
   license_family: BSD
   size: 49185
   timestamp: 1676823769869
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
   sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
   md5: e2512d57c8a1e91e7b20e265c6906546
   depends:
@@ -2157,7 +2157,7 @@ packages:
   license_family: BSD
   size: 3588922
   timestamp: 1714770676475
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
   sha256: 1bf522ade750cf0b70d61e71916ff00569e2908db1e9dedb223fda2608ed8bde
   md5: 6793c74fe94211c0bfe6766c6dd490af
   depends:
@@ -2167,7 +2167,7 @@ packages:
   license_family: Apache
   size: 893808
   timestamp: 1696937055591
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
   sha256: 54f41afbea1c01a10e5703e64645de145f34ad6d89cf245fbc5cfaaff58a8743
   md5: 15b6c8bee4c28c6efb3e388178b37145
   depends:
@@ -2178,7 +2178,7 @@ packages:
   license_family: MOZILLA
   size: 154276
   timestamp: 1716395957568
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
   sha256: 0575785f6553e61cc6138abfd5de52305fac6f85971642fa1f056a76c66a52b2
   md5: f2c25e5dfdd23f70b83776a8832893cf
   depends:
@@ -2187,7 +2187,7 @@ packages:
   license_family: BSD
   size: 270865
   timestamp: 1676823316868
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
   sha256: 8c06c291c76e8c2022ffbb9fea4727a4bf1f9b03e498bafc56ba8ac4e7604ab9
   md5: 5adb7baf1091d09026a372cac930ce6c
   depends:
@@ -2197,7 +2197,7 @@ packages:
   license_family: PSF
   size: 8869
   timestamp: 1715268966416
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
   sha256: 118b0801167264c401e84bbf19175546092a5569cc098146f7362bbf890dc8d9
   md5: b3c2aa56d53b459f8365d8385f48d0c3
   depends:
@@ -2206,7 +2206,7 @@ packages:
   license_family: PSF
   size: 74489
   timestamp: 1715268960737
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
   sha256: 509b962773f0fe44a93a7f6196b254670a030eac8ea7f90727312e3ccd9294b2
   md5: 6c402d5bf4e01c8c3895c9ef41707b6e
   depends:
@@ -2215,7 +2215,7 @@ packages:
   license_family: MIT
   size: 11371
   timestamp: 1676828901104
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
   sha256: bbe7629e8ce52c82f13ed0d1fb919f3659ef466b274a7c74aa925a9bc7aee450
   md5: 7da527bbcf71270c1abed8ea52e7d44c
   depends:
@@ -2225,7 +2225,7 @@ packages:
   license_family: Apache
   size: 509031
   timestamp: 1713213062098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
   sha256: 5c6afad310db12b3658a652efc5de45c182164a0b537cb2cdae5885428b30d22
   md5: 89ea2fed160a633e0a6d152b61cb0dd2
   depends:
@@ -2241,7 +2241,7 @@ packages:
   license_family: MIT
   size: 209068
   timestamp: 1715635972793
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
   sha256: c3a5e0b855dc2de6c162708dfcf170a23eb9e7525d4252d8dce553369af4a330
   md5: a4c77e204b7787f820955166a1283168
   depends:
@@ -2250,7 +2250,7 @@ packages:
   license_family: BSD
   size: 25890
   timestamp: 1676823132898
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
   sha256: 42989f9970a8466cc4edb73463dfa194594dd1a5d42c9f820a1f86296d4af140
   md5: 655dfd4d2f17977cb81caa1c082d2b25
   depends:
@@ -2259,7 +2259,7 @@ packages:
   license_family: Apache
   size: 113505
   timestamp: 1715878346465
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
   sha256: eec0d2e0bce4b62278cacd7b0bee053160845e86507051a5434d2069bd290f36
   md5: a069e5aef64a6dac076cc9a3d28a17c9
   depends:
@@ -2268,7 +2268,7 @@ packages:
   license_family: MIT
   size: 136022
   timestamp: 1714717059748
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
   sha256: d18cdca154bf668826f869117ea996c4f9e8ef7d27b7c528332a7d17e5a8602c
   md5: 9f7353d72046b16dd6ef6b5689ac9bfd
   depends:
@@ -2277,7 +2277,7 @@ packages:
   license_family: BSD
   size: 54731
   timestamp: 1676828934954
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
   sha256: 9122d6e9dabb7a47f2bcb15d86b97c96c49a9048da3f8ae59675351710c14cc5
   md5: 660b2aead2ec87b751c86cd33934f44e
   depends:
@@ -2286,7 +2286,7 @@ packages:
   license_family: GPL2
   size: 716926
   timestamp: 1714510796277
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -2294,7 +2294,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
   sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
   md5: 943f1247a22b6b64171363bcee1eec27
   depends:
@@ -2305,7 +2305,7 @@ packages:
   license_family: Other
   size: 371663
   timestamp: 1705602144682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
   sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
   md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
   depends:
@@ -2314,7 +2314,7 @@ packages:
   license_family: Other
   size: 127143
   timestamp: 1714510716441
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
   sha256: af3c032f06352e87c450739cb8aafe1ff34ad28bf074b214ea98b3d29259a85d
   md5: 51fa34bd0e016ed7c5371cf6cb13ef6c
   depends:
@@ -2327,7 +2327,7 @@ packages:
   license_family: BSD
   size: 1044463
   timestamp: 1714678445052
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -2340,7 +2340,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -2350,7 +2350,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -2362,7 +2362,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
   sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
   md5: 544adf2677c47c9b9c891aea720678f1
   depends:
@@ -2370,7 +2370,7 @@ packages:
   license: MIT
   size: 33999
   timestamp: 1630003259346
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -2379,7 +2379,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -2388,7 +2388,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -2397,7 +2397,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -2406,7 +2406,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -2414,7 +2414,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -2423,7 +2423,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -2432,7 +2432,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -2442,7 +2442,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
   sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
   md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
   depends:
@@ -2451,7 +2451,7 @@ packages:
   license_family: BSD
   size: 5106
   timestamp: 1704404390460
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -2459,7 +2459,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -2468,21 +2468,21 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pybind11-abi-4-hd3eb1b0_1.tar.bz2
   sha256: 459f38609d854888998a8d76028019dbacdce2bfe401eab57b8eb8ff16da9c7f
   md5: 2948a98ef4de5decb7e5eb888eae68ba
   license: BSD-3-Clause
   license_family: BSD
   size: 13056
   timestamp: 1682965564630
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pybind11-abi-5-hd3eb1b0_0.tar.bz2
   sha256: 305e5fd9993f3e5506f386f98794c7d53b6e6c68d4d411ada724de49a17945fa
   md5: e1fbbd2d11d21aaec3c32f7d332c0e77
   license: BSD-3-Clause
   license_family: BSD
   size: 13818
   timestamp: 1712163766707
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -2491,7 +2491,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
   sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
   md5: 02caf3f47f1d06256068053297355740
   depends:
@@ -2500,7 +2500,7 @@ packages:
   license_family: Apache
   size: 152292
   timestamp: 1690578151230
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -2509,7 +2509,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -2521,14 +2521,14 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
   sha256: dc9f709bacbaf08a0941d2622d82f91f18b355e82c55348ec29f1391215ca7e0
   md5: ece0f5837a4de2d4d5f1abf8347cd10a
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 124922
   timestamp: 1708711884650
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -2536,7 +2536,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
   sha256: 5800a2466734dd1ef372bec0dd3f0880c5072fa1e8b0668f5054f834285e991c
   md5: 18194e51d4420ac08f29f3f86581b52e
   depends:
@@ -2550,7 +2550,7 @@ packages:
   license_family: MIT
   size: 229003
   timestamp: 1706220302459
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
   sha256: ab7672364f1fa55ec5d8311d85d40e5b57cbd3517b17670557b6fb822bcf759c
   md5: 6e0159a5865cb7e96a748bd8560035ee
   depends:
@@ -2559,7 +2559,7 @@ packages:
   license_family: BSD
   size: 11579
   timestamp: 1678317458652
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
   sha256: 51556902e09436d46878ef772805d06416ca96ffaa66340b5565c0245574aaf5
   md5: 4cb1b20635cf5431d34cc96ca1e8a751
   depends:
@@ -2569,7 +2569,7 @@ packages:
   license_family: MIT
   size: 33355
   timestamp: 1678317111825
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
   sha256: 188b74f717e3ce3595da404c0e027b8ccafa9c186e88325e8f02c29d7b4c0744
   md5: 04ad90eead5812a0263b42321056ab33
   depends:
@@ -2578,7 +2578,7 @@ packages:
   license_family: MIT
   size: 153694
   timestamp: 1695717975427
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
   sha256: bf3c60386619f08cf5105b4b903bbc109b3252c3b923fe055aa445908a01969c
   md5: 3f84a301921ec6400b7f1f1c4ba3260d
   depends:
@@ -2588,12 +2588,12 @@ packages:
   license_family: MIT
   size: 270017
   timestamp: 1681493109562
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
   sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
   md5: e2f3248e2a5009a02f7b8e54f83314ef
   size: 5620
   timestamp: 1528121955725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
   sha256: 126ae8e30b8464fb2dc94ce9163dcb2d5482f7214c7d8a48340c3f09f1409d5e
   md5: d5e0c054042910b4394a14c7eb4d8131
   depends:
@@ -2611,7 +2611,7 @@ packages:
   license_family: BSD
   size: 6080356
   timestamp: 1712084675745
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
   sha256: 9acafafcaebd653c2372ddc864525722e1c55b884b5eba22e28e2b2d946b853c
   md5: 22375cc3c2edada31b85af56c8e6dee6
   depends:
@@ -2621,7 +2621,7 @@ packages:
   license_family: BSD
   size: 155829
   timestamp: 1707864406086
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
   sha256: d8b1ccb15297dcfb3f9ebb8139c3e28a13d6c2e73c37612cb214ab6cc58b15fa
   md5: e5dec9f13de061640ad2697562a99b54
   depends:
@@ -2631,7 +2631,7 @@ packages:
   license: MIT
   size: 19732
   timestamp: 1714483415038
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
   sha256: e9fda4393edd0234c88efc2b88e0edf42c94eb49ea5b189a80afd733058be8fb
   md5: 13ceed558eb174d6b77ed1b0035f1785
   depends:
@@ -2640,7 +2640,7 @@ packages:
   license: MIT
   size: 18400
   timestamp: 1714483395748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
   sha256: a323af3251e426962ad16edf8f46a696ef502731faf12aee32ca289c40b11342
   md5: 658ce49e9f07dba7a1afe70fa2666e0a
   depends:
@@ -2649,21 +2649,21 @@ packages:
   license: MIT
   size: 393858
   timestamp: 1714483549536
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
   sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
   md5: c5a600d81b1b48578863af2973c743ac
   license: bzip2-1.0.8
   license_family: BSD
   size: 187637
   timestamp: 1714510590009
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
   sha256: 0c5f9766aa2dcc08ae71b6c0102046a56b30297d0bedc3039b7f72d1658baa43
   md5: 34583b436e62a2ce55d6a7e8eb818e33
   license: MPL-2.0
   license_family: Other
   size: 138712
   timestamp: 1710764814844
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
   sha256: 20b1fc398e925e6c8cea6a06d3bb614e2c0de886e3f14f85b0ba26e57ff40b7e
   md5: ac95cfe373c7fef7820e93189041b0cc
   depends:
@@ -2672,7 +2672,7 @@ packages:
   license_family: Other
   size: 166856
   timestamp: 1707229213510
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
   sha256: 6b5bebc13755b0a5ef423219eeecd1c25b97dbe83afad6e2552635387547d9f7
   md5: b7bc4192fcfed7fc7df1ce00bce97b02
   depends:
@@ -2683,7 +2683,7 @@ packages:
   license_family: MIT
   size: 291802
   timestamp: 1714483319125
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
   sha256: 9270668e34b00a2605584a2db5130c83826855cd05b896ce949f3156fa197429
   md5: 2586aa55677e822e8285d777f9039ca9
   depends:
@@ -2692,7 +2692,7 @@ packages:
   license_family: CC
   size: 543487
   timestamp: 1709758497949
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
   sha256: 389c63a84b92a6254c9d361ebe970d537d0b88733efd5ac5c3ee58196fd2c5a9
   md5: c7bc5b3cbe76be83a27f00b7e4740727
   depends:
@@ -2702,7 +2702,7 @@ packages:
   license_family: BSD
   size: 17974
   timestamp: 1709323004148
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
   sha256: bebfc5aa6be12e61a134b580b07b67f7d8c045d6b113fca5b21fa1e83a2f03ce
   md5: 239df72a3921c951059fa8afc09643f6
   depends:
@@ -2713,7 +2713,7 @@ packages:
   license_family: BSD
   size: 287736
   timestamp: 1700583644534
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
   sha256: e0e30590a78d99d51445ac4f668aefe1bf20025a35bdbac00f04647b95c9f152
   md5: bd0db635eefeea82a0c567b39c9a0e3d
   depends:
@@ -2723,7 +2723,7 @@ packages:
   license_family: MIT
   size: 2485698
   timestamp: 1690905283575
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
   sha256: d48b47b86b09dac1fa4542ec13e1bd4e23093638e684fa66ec3afdd9ce9337c1
   md5: 5a2d1828ab7c8eccd3c2610d13672977
   depends:
@@ -2732,7 +2732,7 @@ packages:
   license_family: MIT
   size: 17336
   timestamp: 1678316187749
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
   sha256: 54645c22fabc25b632114d1d3c403a6fad9149b51ab36719b2690a084f14a072
   md5: a8ad2f4abfb2e17ecf6e596342528156
   depends:
@@ -2750,7 +2750,7 @@ packages:
   license_family: MIT
   size: 3180691
   timestamp: 1713551771692
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -2760,7 +2760,7 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
   sha256: 4120472ee1c5d31efffeb045892bece27b9a15a30d77c35212f6508221635918
   md5: 9561a225b5171285250c9071f8cab074
   depends:
@@ -2777,7 +2777,7 @@ packages:
   license_family: BSD
   size: 5368257
   timestamp: 1707836808668
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 50dee40e4a9ea7a035baeecc85770c88d63d4e6b0c3c2519c1429e881171150c
   md5: 4d465f453dca5c65224dccbe953f600c
   depends:
@@ -2794,7 +2794,7 @@ packages:
   license_family: BSD
   size: 359293
   timestamp: 1715090716440
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
   sha256: 5c2458964157fe493ca18c513c693b70cb622087e5fa0c93e65fc45217edd811
   md5: 15629e52625221b51a443cefd9501d12
   depends:
@@ -2803,7 +2803,7 @@ packages:
   license_family: BSD
   size: 148522
   timestamp: 1714398885844
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
   sha256: e0127f50d444bf4474e8df07d602c7f6dd38690e8bb3fb28817c164940ffcde1
   md5: 583fcd7060cad6a77074d00d9ef62f44
   depends:
@@ -2812,7 +2812,7 @@ packages:
   license_family: Proprietary
   size: 731417
   timestamp: 1699647668990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
   sha256: eb58fa29b1ce9aa5fc774d4c466696457695dec3b206456614b4c9cac0a94e42
   md5: 3d3291ff58dff83dcd40ec54b435f4d2
   depends:
@@ -2834,7 +2834,7 @@ packages:
   license_family: BSD
   size: 229910
   timestamp: 1705934029588
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
   sha256: 73aa7662c00c73bab2dafefefc87a1b524961d2687410af624ecbd6703e483f3
   md5: 7e71e99766107a553752ed8f22b61cf0
   depends:
@@ -2851,7 +2851,7 @@ packages:
   license_family: BSD
   size: 1611976
   timestamp: 1704833049616
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
   sha256: e08cda2bcbdec124c63e951eb248c503bb1467c2a6000010c6bdc0726e0e00b7
   md5: 22c24f43b82da8b3920a913bbf452421
   depends:
@@ -2861,7 +2861,7 @@ packages:
   license_family: MIT
   size: 1168968
   timestamp: 1679336359851
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.4-py311hecd8cb5_0.tar.bz2
   sha256: b80384bec95335d8ad37895f5cfd2d8fdfaae7be05507f218344ddb5c6713d38
   md5: 8ac4f4807344f09b39c1b303cd2d1937
   depends:
@@ -2873,14 +2873,14 @@ packages:
   license_family: BSD
   size: 356777
   timestamp: 1716993516277
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
   sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
   md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
   license: IJG
   license_family: Other
   size: 278924
   timestamp: 1677849185191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
   sha256: 99fc6ac82c56eb2a580f96db24a5b887f8abc8c24af445d3313d5ebb48598478
   md5: 71892160908a6daedb5fb7c404079ae4
   depends:
@@ -2893,7 +2893,7 @@ packages:
   license_family: MIT
   size: 182073
   timestamp: 1699041732321
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 0ea44d0c8044e70ab0eaf4d6f5f3e4753838dee106b5cbd36561e21a65cbac77
   md5: 1d045016dca889d702f1caf3a16162fc
   depends:
@@ -2903,7 +2903,7 @@ packages:
   license_family: MIT
   size: 16528
   timestamp: 1699032525791
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
   sha256: 70442ec4b0b7ebbdcf150963f61f797b861001092124f4ea39a16eb92a4d176e
   md5: 63d1503915a15ae4f9ad1c46112ca374
   depends:
@@ -2919,7 +2919,7 @@ packages:
   license_family: BSD
   size: 272720
   timestamp: 1678316970740
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
   sha256: 8601c674f4779900f6a949e47b814be68b722b0b3d394433bec9d197924ebd69
   md5: b8423f8caff3041a251fc3681f43496a
   depends:
@@ -2930,7 +2930,7 @@ packages:
   license_family: BSD
   size: 94990
   timestamp: 1698937583196
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
   sha256: 6a430c812ce0415a04d9cfe6c66d9012eced2d91c04960c88bc8ec1e9f1b5d6d
   md5: 30b3d5d6a8cf5d1604e5f5fb177917b5
   depends:
@@ -2946,7 +2946,7 @@ packages:
   license_family: BSD
   size: 42513
   timestamp: 1699282637015
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
   sha256: c2d206db117f7161e77236ebd6b0051fc73e1731c242d1e08597d736a0376c92
   md5: bdb61de2e20e02c93423d9de091c74ad
   depends:
@@ -2973,7 +2973,7 @@ packages:
   license_family: BSD
   size: 601837
   timestamp: 1699466514455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
   sha256: fd7964657f0a8fe8b167ba860b1f960e8b7b45309eb6c7c850d50ec283fe03b5
   md5: 2967bb345bc75f53182e263ff4743ca6
   depends:
@@ -2983,7 +2983,7 @@ packages:
   license_family: BSD
   size: 28223
   timestamp: 1686870845224
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
   sha256: 64cf59f0f74b0329b5069bc6135b4f40593f1dac52d85ad574d4b8e0a4b2cf16
   md5: 35e8b80eaa03a904fc7f1da39e7f654d
   depends:
@@ -2995,7 +2995,7 @@ packages:
   license_family: BSD
   size: 20234
   timestamp: 1700168776500
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
   sha256: a12382b50416803f559a03fb384ba492c1dafa351e1191a3f8dc361bee6c4f37
   md5: f2ae846b663bbb642f4b1e90eaad38a3
   depends:
@@ -3005,7 +3005,7 @@ packages:
   license_family: BSD
   size: 64817
   timestamp: 1678322501509
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -3015,7 +3015,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -3024,13 +3024,13 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 685c3bc9068bd485604b80bf03789e4dca95c410d33871bc1b882e47649fabed
   md5: 6cf8e55271e150ca0961d0ddedaa61bb
   license: MIT
   size: 66237
   timestamp: 1714483284541
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 69826cee54db9955f0120af21ec36d13f9211877fd67364f2068d0a54c6c97cd
   md5: 0851917257f490d35e1f73da8a1c723c
   depends:
@@ -3038,7 +3038,7 @@ packages:
   license: MIT
   size: 34042
   timestamp: 1714483343147
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 3f5a1f03b50b90b397a0ee432ad0cba13354abdaf7e5652c0fc60164b26a08b6
   md5: a50bdc871ef4bf14deb088d888b92b5e
   depends:
@@ -3046,28 +3046,28 @@ packages:
   license: MIT
   size: 311597
   timestamp: 1714483371586
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
   sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
   md5: 822a5b76117e56d3912f1f2153307528
   license: MIT
   license_family: MIT
   size: 136045
   timestamp: 1714483561919
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
   sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
   md5: e458587c87e3f2d20192f4e0738f2c63
   depends:
@@ -3076,7 +3076,7 @@ packages:
   license_family: GPL
   size: 149419
   timestamp: 1665498987619
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
   sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
   md5: 1058b661ec829b2ee3716ee2a5520641
   depends:
@@ -3087,7 +3087,7 @@ packages:
   license_family: GPL
   size: 1917987
   timestamp: 1665498925405
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -3096,13 +3096,13 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -3119,7 +3119,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
   sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
   md5: 46a65d1fc24013217e06aaf6d65ffcad
   constrains:
@@ -3128,7 +3128,7 @@ packages:
   license_family: BSD
   size: 425478
   timestamp: 1694776947990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
   sha256: d28c465ec6d5f8d4962c597b249b58998300c8b4e3c937c578c3d15294ea863d
   md5: dcaed6ddd0723c7cce6bfad917be98b2
   depends:
@@ -3138,7 +3138,7 @@ packages:
   license_family: MIT
   size: 41176
   timestamp: 1678413498410
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
   sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
   md5: 5c740b4a18a558de0ccfe601703c423c
   constrains:
@@ -3147,7 +3147,7 @@ packages:
   license_family: Apache
   size: 338738
   timestamp: 1662635677689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
   sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
   md5: 8f57dc3a3327bb6f7e1cba908856ac7f
   depends:
@@ -3156,7 +3156,7 @@ packages:
   license_family: BSD
   size: 183138
   timestamp: 1714510756758
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
   sha256: 6fb2953e169ee1ae38f24d29752051501992f19b96b5ebcea9af75737bdbcb42
   md5: 7f410cdae838c5030108d1b98a8c78f6
   depends:
@@ -3165,7 +3165,7 @@ packages:
   license_family: BSD
   size: 162478
   timestamp: 1678377892595
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
   sha256: cd97e09a12ffb49b2a30a782fa8c7933b28f5ffdbfc5c73a9ebaa95fc9447370
   md5: d1fb6ebc1e5728aa6377cfc71da08942
   depends:
@@ -3175,7 +3175,7 @@ packages:
   license_family: MIT
   size: 135859
   timestamp: 1684280005320
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
   sha256: 30c3b189462a9d0f4794d229adadf34b5f5a5f56f95c30d5afc17ef524579290
   md5: d4e9421243129d1d57c472dab045f3dc
   depends:
@@ -3186,7 +3186,7 @@ packages:
   license_family: BSD
   size: 26639
   timestamp: 1704206159955
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
   sha256: 080000a28b3ceca54eec6de0748c690ea5a4c390e358283eac03fe7a6dd87065
   md5: 51344eca57d7940fb01eb5e8914509e3
   depends:
@@ -3208,7 +3208,7 @@ packages:
   license_family: PSF
   size: 9099909
   timestamp: 1713336790553
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
   sha256: 07e7fd5bd64e55328b4b99d92e2e2600d791f1095bf905daab4cfc59f0f0a45b
   md5: cf53321779f4ca7e986c1468719b93f1
   depends:
@@ -3218,7 +3218,7 @@ packages:
   license_family: BSD
   size: 19500
   timestamp: 1678317565001
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
   sha256: 0770e02be1ea1216af493cfc03d5b8a702e14606fa93b0692bcdab1fed1b898c
   md5: ca6f06ceaf66a32bbf5dfdb6e373a5cf
   depends:
@@ -3228,7 +3228,7 @@ packages:
   license_family: MIT
   size: 67892
   timestamp: 1678417734353
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
   sha256: fbe95ed0501bb0f137048476fe41bc718dd659e8ecb066bc67ac17d6a50f4318
   md5: ec162bde8d1c8a107b257df218b17035
   depends:
@@ -3237,7 +3237,7 @@ packages:
   license_family: MIT
   size: 23030
   timestamp: 1678381838497
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
   sha256: c20dd678655e582129a858a1c5162bdc254082d3a3c035b0f72629d9276e5b75
   md5: 800a0738c728796e02d0386ce7d457aa
   depends:
@@ -3248,7 +3248,7 @@ packages:
   license_family: BSD
   size: 104585
   timestamp: 1678317269407
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
   sha256: c825bc3070f73318ffff88a7a0b7fc6d1858b058ced735efd1789053f1583918
   md5: dea5f96459c9a6df6b026ca57d387936
   depends:
@@ -3261,7 +3261,7 @@ packages:
   license_family: Proprietary
   size: 224299920
   timestamp: 1699647835748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
   sha256: a76c134ec258612ff7d55cb2a19b9e3461cbbd375a744bd29390af9cfcd283b2
   md5: 1c736f58992009f53f014aef163bae31
   depends:
@@ -3271,7 +3271,7 @@ packages:
   license_family: BSD
   size: 48442
   timestamp: 1682969160267
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
   sha256: bcfb0d1e075d043bcf05fa1a7ce3c142bf222d29693366af49a5a346c770812f
   md5: 59e4820b34049cbc6619a8ac97290abc
   depends:
@@ -3284,7 +3284,7 @@ packages:
   license_family: BSD
   size: 222137
   timestamp: 1695058350477
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
   sha256: 114e408c40b332393cf2792393e4d1ede3465abcb3d345fe647ee519565346c8
   md5: 86b13271578e1fa5e664edcf6fcb3ce4
   depends:
@@ -3298,7 +3298,7 @@ packages:
   license_family: BSD
   size: 296860
   timestamp: 1695059990370
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
   sha256: a58960e88525a202ba193b4dd8227c4d9c3dd98b8b43edea34b05a9a9fd1121c
   md5: 71a37f987c3df6657548d098bd2a58e7
   depends:
@@ -3324,7 +3324,7 @@ packages:
   license_family: BSD
   size: 8286383
   timestamp: 1699543227340
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
   sha256: e08cb3ee6df01f4c1e1ac8bc4ed1a06e549ffcc8774fe2e2842c644bb8f74a86
   md5: 6ba0ae0fb14cbea1e3197707701dc180
   depends:
@@ -3337,7 +3337,7 @@ packages:
   license_family: BSD
   size: 123077
   timestamp: 1698934356774
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 2f946b5042eaac97206b5217fb203f3604ab3a60aecd99bdfc684925e3136c18
   md5: b24026076c381ff2009e7acb9e0a6e87
   depends:
@@ -3364,7 +3364,7 @@ packages:
   license_family: BSD
   size: 534650
   timestamp: 1699022791300
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
   sha256: ba368605a0af6f1dcbdcb6fddab9ce63224a85dd11bfb2b1acace1dc17899411
   md5: 91f3ea3fe44d619ee95a6ed3773a0814
   depends:
@@ -3377,14 +3377,14 @@ packages:
   license_family: BSD
   size: 170926
   timestamp: 1694616830121
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
   sha256: 42d803e1d8b54748db5d989ecd503826f564132df7cddc20f520460f55e523a1
   md5: cd3fa71626ebc098da4625fc6be79752
   depends:
@@ -3393,7 +3393,7 @@ packages:
   license_family: BSD
   size: 16952
   timestamp: 1708532805951
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
   sha256: 92d50872fad0d1fecfea42cbfdb69887def80927c169a88204d163c2d3c7d035
   md5: fe6780b8659ff5d6061268708a7b2032
   depends:
@@ -3418,7 +3418,7 @@ packages:
   license_family: BSD
   size: 716120
   timestamp: 1690984968401
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
   sha256: ed5608feb37a083d47b04203195260e801b64b5380f292cf18bb61e7ad827a2a
   md5: daa9c1c233673b727528548454aea664
   depends:
@@ -3428,7 +3428,7 @@ packages:
   license_family: BSD
   size: 27607
   timestamp: 1699456006797
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
   sha256: cacba45c1eebf7d86748737717883a98cf40664231460fa41391c79f98d06f45
   md5: 3dbfae0d5b90e77f9358564ad442ac9d
   depends:
@@ -3442,7 +3442,7 @@ packages:
   license_family: MIT
   size: 165572
   timestamp: 1696515553184
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
   sha256: 1466c3af380b949612c79940124e426eccd59e335c205da0c00383a69358d1c0
   md5: df6be53592d40ba7e03d6ffe349760bf
   depends:
@@ -3458,7 +3458,7 @@ packages:
   license_family: BSD
   size: 11330
   timestamp: 1708639985606
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
   sha256: ace67d704fa7eea1480eb463f2d91bfc161be2ee20263c5a9939805ae3c2a9da
   md5: ec124589478fa12fba4f35f31c3a0692
   depends:
@@ -3473,7 +3473,7 @@ packages:
   license_family: BSD
   size: 8783230
   timestamp: 1708639945646
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
   sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
   md5: 93f5d7b66976154adeda219bea02ba45
   depends:
@@ -3483,7 +3483,7 @@ packages:
   license: BSD 2-Clause
   size: 484257
   timestamp: 1630093862501
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
   sha256: 891ffe9826f6f9ec9a4fc5d1bbb9a64f9de23f27705c2202f7d475b7cd14dd83
   md5: ab0d447c9eb4fcada05d853bd13a24ac
   depends:
@@ -3492,7 +3492,7 @@ packages:
   license_family: Apache
   size: 4970613
   timestamp: 1716319014066
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
   sha256: 8a0809f419065e014cb8e2c8a516cadca6088fb71fd1ef3ae2287d91e3360d59
   md5: 4dc0b9bc88476fcc5246d823ff1c289a
   depends:
@@ -3501,7 +3501,7 @@ packages:
   license_family: APACHE
   size: 39645
   timestamp: 1699371213055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
   sha256: 64fbbb03570788298d8b04d4ea6cb254fef5d5eec73265aeecd72cb565617f4d
   md5: 4b1195028bc26257df43fdd943638266
   depends:
@@ -3510,7 +3510,7 @@ packages:
   license_family: Apache
   size: 159450
   timestamp: 1710811009212
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
   sha256: 6abb7e0aeda0130f54925421900772e1bc46d1f04ae69ce1376524457686d49f
   md5: 232a6370c3fab0c41c6d4c7339e778ca
   depends:
@@ -3560,7 +3560,7 @@ packages:
   license_family: BSD
   size: 17296294
   timestamp: 1709591285369
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
   sha256: 10a5eb185aa5dcfecfa854c2e66b3779cb6d2dee85f1b2236f43234a1c1ba9e0
   md5: 2200abcb857e6bb8cb46b861cb4d2fd7
   depends:
@@ -3584,7 +3584,7 @@ packages:
   license_family: BSD
   size: 22071486
   timestamp: 1714072093679
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
   sha256: daf01c56a3c44555ecb61e9a0e899a7b58872c6b7631f00a04ee8d3199e9e568
   md5: 2163ed8005a14ecda15efe5586582cce
   depends:
@@ -3593,7 +3593,7 @@ packages:
   license_family: BSD
   size: 267508
   timestamp: 1711137004592
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
   sha256: 90efc71d35ab62d5b8d7b648e016444e1c4c8b83238b6dc9f2c6c3db4b14c599
   md5: 6b6eeb0a14c5479db1dd39aa8d338150
   depends:
@@ -3609,7 +3609,7 @@ packages:
   license_family: Other
   size: 939480
   timestamp: 1714399174883
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
   sha256: f6b0ded7010706431f2a6d9776aa6033dfd19d2264b3cebf28072629160090a8
   md5: 02de6d0d9cc23fafe2e3597ed0e52693
   depends:
@@ -3620,7 +3620,7 @@ packages:
   license_family: MIT
   size: 3444268
   timestamp: 1715097155645
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 81719c31101d6c019150cedcc7b08adb3bdb357e8b2952e428dadaabc4dc985d
   md5: 105825168e0a17fb007f60b5f314e311
   depends:
@@ -3629,7 +3629,7 @@ packages:
   license_family: MIT
   size: 38405
   timestamp: 1692205731769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
   sha256: c0982f688127129e026d2b4cdacdd5684d00796ea7bdadd7d26b1101b095d723
   md5: 0d6910c74729fede645c010110f1c89e
   depends:
@@ -3638,7 +3638,7 @@ packages:
   license_family: Apache
   size: 121796
   timestamp: 1679340253537
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
   sha256: e32843723b10ecd9badde28e1085419c0b59ed8a96c7cacce6395e39e3a874f9
   md5: 5af0280a817d2c273304cd22328124af
   depends:
@@ -3650,7 +3650,7 @@ packages:
   license_family: BSD
   size: 763044
   timestamp: 1704404460779
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
   sha256: 117a435c2473e2a20cc81eaacb2b45ea5e7fe3c946eec2915936d344913ede44
   md5: 0f459ee59fda20e2077fdc2c777edfc8
   depends:
@@ -3659,7 +3659,7 @@ packages:
   license_family: BSD
   size: 497470
   timestamp: 1679337286052
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
   sha256: dfb403f367c57327a4d080109df88383ecff18464de287a1ce936a7274e3656b
   md5: 997b674bad89963af875b93b06807f51
   depends:
@@ -3668,7 +3668,7 @@ packages:
   license_family: BSD
   size: 2120413
   timestamp: 1684280057020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
   sha256: 9d2c0f373ac1c5db329581793dd517092cdf9a59140f2516ed8c3a1f483c0bbd
   md5: ee10503a159e819abdc586666bdf0952
   depends:
@@ -3677,7 +3677,7 @@ packages:
   license_family: MIT
   size: 207552
   timestamp: 1678322848766
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 717e038567506ca58ce1cd4a3416892d02f4ebfdd332077cc3d110cfe3d36c58
   md5: 53bbfb400668f798eef6f8c7cf938e1f
   depends:
@@ -3686,7 +3686,7 @@ packages:
   license_family: BSD
   size: 35751
   timestamp: 1678315886516
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
   sha256: 092dea8d520acff3e64c71155e666b0b6074d37a71d5eb32f3cd485b0d185d0b
   md5: 9fbaf2d9534c26e76aa14b11b23de332
   depends:
@@ -3705,7 +3705,7 @@ packages:
   license_family: PSF
   size: 16852220
   timestamp: 1713545835789
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
   sha256: 04e100d0a1ea9722e24972657ec5935ad34c7c58957dabb821333e5eac80f717
   md5: 2b6de49ad07b26e1f7084f0fda958eb1
   depends:
@@ -3715,7 +3715,7 @@ packages:
   license_family: BSD
   size: 332276
   timestamp: 1716495830117
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
   sha256: 514249897265f66f6ecca0a4427eb02a43c33b3c24974db16d05db6bbe97881d
   md5: c9ea1437e5a3ba6a52ec2322505203e6
   depends:
@@ -3724,7 +3724,7 @@ packages:
   license_family: BSD
   size: 279116
   timestamp: 1679338758489
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
   sha256: 78b785b9b6ed46c86b0d3a32bdceea49f816672227fb63e726b2d46eadbdba0b
   md5: 79d783f74359141e0b06a848db33823b
   depends:
@@ -3733,7 +3733,7 @@ packages:
   license_family: BSD
   size: 18563
   timestamp: 1683823935261
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
   sha256: e358fe679e83ccdc8c433746ae6468e8e96d90d97d99530f8476ef5630b2c121
   md5: ce30a0a31d891e69dc9b7bf8b7f0c39c
   depends:
@@ -3742,7 +3742,7 @@ packages:
   license_family: MIT
   size: 268876
   timestamp: 1713974360942
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
   sha256: eeb5a5eed93b8e311ad4d3f4389e050f11bba2eaec9536e1c3ed2f849c6c999b
   md5: c18bd3e12de797d52a470c21a150dffe
   depends:
@@ -3754,7 +3754,7 @@ packages:
   license_family: BSD
   size: 65270
   timestamp: 1711136914884
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
   sha256: c3e11ed944da69c11b949bb918341a0d79ef603ee34a632d6a45fbf89ff924a1
   md5: fee7ff4d291f530b4cecb575f29807a0
   depends:
@@ -3764,7 +3764,7 @@ packages:
   license_family: MIT
   size: 197996
   timestamp: 1698096137432
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
   sha256: aa07b90a7ee65f76c8cba1ff99a5cdeb95cbe41881ae951f64ffff06674a1b2d
   md5: 58621e3d244137885f7dfbb35e50340a
   depends:
@@ -3774,7 +3774,7 @@ packages:
   license_family: Other
   size: 594801
   timestamp: 1709318510622
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -3783,7 +3783,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
   sha256: d784dc26c5de8e41845350a899e5779250b71f45d39e2aece62e739e9add7308
   md5: 7b077b7f46112bb31dc066396c51d3fa
   depends:
@@ -3794,7 +3794,7 @@ packages:
   license_family: MIT
   size: 74776
   timestamp: 1699012164201
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.32.2-py311hecd8cb5_0.tar.bz2
   sha256: e8c25fe5f26c25cc3cd5a744448a791c246610d3fa8690251f9e1fbc44188248
   md5: 28182e1a6b8c2c519dafc90093396a7a
   depends:
@@ -3810,7 +3810,7 @@ packages:
   license_family: Apache
   size: 123233
   timestamp: 1716902968357
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
   sha256: 727fb8d957e02d03b928d049ffbc712316f176a2c331391766d646621b45655a
   md5: 7e0e416c642f3ee4ddfb084a811fb4df
   depends:
@@ -3820,7 +3820,7 @@ packages:
   license_family: MIT
   size: 10236
   timestamp: 1683077214314
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
   sha256: a8a67143ccb65cfd6f50055176b6c26179a83130a45d0a12e79dd2de68d8db63
   md5: a2065790f41e3eeb6efe0ef6daa75377
   depends:
@@ -3829,7 +3829,7 @@ packages:
   license_family: MIT
   size: 10600
   timestamp: 1683059285216
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
   sha256: 6aba582338faa0c26fe336bdb10c65b8f7808a6e383bd8f80f3e6b612ca209ec
   md5: a7486349b5f7370f6902c2050a23d268
   depends:
@@ -3838,7 +3838,7 @@ packages:
   license_family: MIT
   size: 319197
   timestamp: 1698946203341
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/scipy-1.13.0-py311h224febf_0.tar.bz2
   sha256: 86bda04163628ef7b35528fbb4fe1d56fef50d10570a859e5ae8a7fbb60f577c
   md5: 05e397dddd20d91460e3cedea0b3686f
   depends:
@@ -3857,7 +3857,7 @@ packages:
   license_family: BSD
   size: 27745043
   timestamp: 1714075585637
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
   sha256: beba0555707dac1e8484d73cee9e4128ac4b10e2a0d4209357481179022e8fdc
   md5: baa8b304607b3a9ae8a3d9acb354c31c
   depends:
@@ -3866,7 +3866,7 @@ packages:
   license_family: BSD
   size: 33343
   timestamp: 1699371216044
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
   sha256: c1df29188e321abe23651c73712a6d8ed3abdc89ad38a42c33f1835b3ab77abe
   md5: 6c984ea85326858942f7b635e0cc9ff8
   depends:
@@ -3875,7 +3875,7 @@ packages:
   license_family: MIT
   size: 1597325
   timestamp: 1715025837032
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
   sha256: 0eb44a16ef74a13ef7839209899d009cd94974fbc406a417d958c7bc8d955245
   md5: 41f239a5b67b1daf819849023aa5d12f
   depends:
@@ -3884,7 +3884,7 @@ packages:
   license_family: Other
   size: 19056
   timestamp: 1705431379885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
   sha256: 14775231982e1ea150189c956927ccfb1ad01a8c9395cdeea4d5a48b9b8ce664
   md5: 729badc4bf7ba8ccc70e0f9e58075c99
   depends:
@@ -3893,7 +3893,7 @@ packages:
   license_family: MIT
   size: 89812
   timestamp: 1696347694075
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
   sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
   md5: 6bef1694163a68ac4c37e5857b8da4f5
   depends:
@@ -3905,7 +3905,7 @@ packages:
   license_family: Other
   size: 1900191
   timestamp: 1714488351925
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -3914,7 +3914,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
   sha256: 3d5c2968f581006437df3932cd5d3c1c4afa78f0e13757b958440245d3248856
   md5: 605ea221d225ad8e79284dbcfdab0715
   depends:
@@ -3925,7 +3925,7 @@ packages:
   license_family: BSD
   size: 37699
   timestamp: 1678317755913
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
   sha256: ed059e32ce5a1c0511575f29d2fb6da12c54a37000bfa80f9e5aa9dfd9e04101
   md5: 4d2261a92d25136a68b8d01d101119f5
   depends:
@@ -3935,7 +3935,7 @@ packages:
   license_family: BSD
   size: 49145
   timestamp: 1678317386284
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
   sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
   md5: 523c006cc67c011383678c762015479b
   depends:
@@ -3944,7 +3944,7 @@ packages:
   license_family: BSD
   size: 3594448
   timestamp: 1714770737885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
   sha256: 6ab71b48d145c69007cfb5b4a21def2cc83bba972b7cc91c7d52d0d7eeb055bf
   md5: f8970b0ad5c8b452b8722ceb4e5c17f7
   depends:
@@ -3953,7 +3953,7 @@ packages:
   license_family: Apache
   size: 895379
   timestamp: 1696937269468
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
   sha256: 3df84b9897f05a104c99e297dc29ad8f718982fc64c61b5a2204c19c578f47e5
   md5: deab971930d242221ed86bfd768dde40
   depends:
@@ -3964,7 +3964,7 @@ packages:
   license_family: MOZILLA
   size: 155545
   timestamp: 1716396266697
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 9e8dbede0bc54c77b974210be66503e7e8e45e0f1c71dc5c16cc9a9674d54259
   md5: b4fcab9e63bd7b3cdf458c953904807c
   depends:
@@ -3973,7 +3973,7 @@ packages:
   license_family: BSD
   size: 270874
   timestamp: 1678316116954
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
   sha256: 17e5688d09ffbcb8b71b34b86edc7374fa0b04d60a4d729d405ffc22ef63726c
   md5: e4bf44ddbbcb136332ccb47ac2b879a0
   depends:
@@ -3983,7 +3983,7 @@ packages:
   license_family: PSF
   size: 9890
   timestamp: 1715269046804
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
   sha256: 7d369ec970d1d5411e457c79f94197756c7088deff8183806ea71e633b26edf9
   md5: 9ffa197b26373667f50b21876862398e
   depends:
@@ -3992,7 +3992,7 @@ packages:
   license_family: PSF
   size: 75595
   timestamp: 1715269030928
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
   sha256: a9960485ced319ac91afe69eaaf703c7e6b3049f1e06a4a8c2818b64155943f0
   md5: 0a9c8ea92a14330a07edabac249e32a9
   depends:
@@ -4001,7 +4001,7 @@ packages:
   license_family: MIT
   size: 11399
   timestamp: 1678394892923
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
   sha256: d42ae57366d05e12f10074583568355752436d66ad018ffbcfa24135f593810a
   md5: 1a98e48aa0bd8b3ec09e2cbdbb236575
   depends:
@@ -4010,7 +4010,7 @@ packages:
   license_family: Apache
   size: 498952
   timestamp: 1713213079520
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
   sha256: 5dc693f0e0aeb30cb6033015b13e75c8a21c56b1262d9652788c3e73a5c5c4a5
   md5: 6b5cc9b43aa34431f8c30b5cdc22004b
   depends:
@@ -4026,7 +4026,7 @@ packages:
   license_family: MIT
   size: 210522
   timestamp: 1715636148762
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
   sha256: 597015e8a038a111f03ffbc9a217fcda549d75230c86ce53c1f23c53d6f1a0cb
   md5: 62e98aac883bccc1c87ca0d2ce2f08e0
   depends:
@@ -4035,7 +4035,7 @@ packages:
   license_family: BSD
   size: 25798
   timestamp: 1678317074170
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
   sha256: 1430e6f4b4dd9354b7bb88f7f7bc9cdbab26a034ad1ae5c278de0f5a99329372
   md5: be0832862b29bf5767a707ac6bd53b93
   depends:
@@ -4044,7 +4044,7 @@ packages:
   license_family: Apache
   size: 114834
   timestamp: 1715878445060
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
   sha256: 885a9b6046e76f7dc1a346b14c63b4083046137bfae036362c854458e20e4fc8
   md5: 3b279447ca282d065e681e567055b582
   depends:
@@ -4053,7 +4053,7 @@ packages:
   license_family: MIT
   size: 137340
   timestamp: 1714717062907
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
   sha256: 5b6d5246955b5f9480ff7027eb002442a7ade24f5c354da54ed513042f76cedc
   md5: f32aa8a37d5e65a8dc30f9a1f46bc63d
   depends:
@@ -4062,20 +4062,20 @@ packages:
   license_family: BSD
   size: 54719
   timestamp: 1678325412288
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
   sha256: ed0152ad6b87ffd9e01f4a62bc358e805ad59637f898a801b0a9cf903ae8e1fb
   md5: 8a92f8c663608f24e14d8a2068b9d83a
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 415323
   timestamp: 1714511993944
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
   sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
   md5: c25b6d40f834647d0bbe767f6c776031
   depends:
@@ -4085,14 +4085,14 @@ packages:
   license_family: Other
   size: 329449
   timestamp: 1705602140856
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
   sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
   md5: f2519b551f99765d9d98950c5e2b4713
   license: Zlib
   license_family: Other
   size: 119782
   timestamp: 1714511811597
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
   sha256: 7feb73e79bdbd45404ddc7a30c43bf4cc68eced8ce448ce7c31f5db134276fc5
   md5: 48313bc6570c705cadbba3c356e0dc8e
   depends:
@@ -4104,7 +4104,7 @@ packages:
   license_family: BSD
   size: 1014151
   timestamp: 1714678461080
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
   sha256: 9ca3f0dfc2bdbc109e359ba7ab246e6ae952a14819148ad069454b52f2bda802
   md5: 51fb05873a644cac52f0d1e10cb7969a
   depends:
@@ -4118,7 +4118,7 @@ packages:
   license_family: MIT
   size: 228856
   timestamp: 1706220385566
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
   sha256: 43405cc7341ce3efb2e24013ad62c64f26a69926635adceaa5459ccbcafb3776
   md5: effa6d22f497e164cc8455f7f329c304
   depends:
@@ -4127,7 +4127,7 @@ packages:
   license_family: BSD
   size: 12510
   timestamp: 1677917870614
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
   sha256: 947efe1c50b3280e9a67cbb18636bdade53a40960fff3056850ff81ab87acbe3
   md5: 7d2d384ee32ccc12dcb0dc099e421482
   depends:
@@ -4137,7 +4137,7 @@ packages:
   license_family: MIT
   size: 35091
   timestamp: 1677915945226
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
   sha256: 8259b4a0973c825ac81f581afcbe86640bd0a94b33caa996167309241877635a
   md5: 49b8ddacfd3927bcaae139eadfb72ce1
   depends:
@@ -4146,7 +4146,7 @@ packages:
   license_family: MIT
   size: 153557
   timestamp: 1695717951839
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
   sha256: 11159a30daae77cfc1abe5e60c19261f65c005e6fbc460aecf72318514d737ad
   md5: 0c5002654a9cb21db1fdf8c1d2017df5
   depends:
@@ -4156,12 +4156,12 @@ packages:
   license_family: MIT
   size: 269772
   timestamp: 1681493072129
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
   sha256: 90439f37ede74ef464e76093e173a8e94a20ee4ad79c68c9e7570fbc67fc13cc
   md5: bb3b906307dd679fc3276be7581494f9
   depends:
@@ -4179,7 +4179,7 @@ packages:
   license_family: BSD
   size: 6073834
   timestamp: 1712084392983
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
   sha256: 688a071ba370f51b457cd32d70b7b38921ce9551203d06fa7fc2c30c4b79891d
   md5: b2353077a39ab997463768154dd58fec
   depends:
@@ -4189,7 +4189,7 @@ packages:
   license_family: BSD
   size: 134711
   timestamp: 1707864978809
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
   sha256: 048264434c33fdb53862cdd69b2e2bc4ce6f8a70b3211ad6d686d066eac2aa91
   md5: d55696ccaf6755931cd662dfb929aa0b
   depends:
@@ -4199,7 +4199,7 @@ packages:
   license: MIT
   size: 19737
   timestamp: 1714483270447
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
   sha256: 13627293296fcc231d8dc12d803dfc9621108c60df38b0e3c64e9e02ed55e564
   md5: 86efd4ad08cd80d3eab77873db84a255
   depends:
@@ -4208,7 +4208,7 @@ packages:
   license: MIT
   size: 19083
   timestamp: 1714483255364
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
   sha256: 2e542b2bb27f8379da3efcb83ef084cb26e6a9ab576c50487c2dd996afd5ccb1
   md5: e8cab9d1ef58a450f971690fcdb2ede2
   depends:
@@ -4217,21 +4217,21 @@ packages:
   license: MIT
   size: 380182
   timestamp: 1714483330655
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
   sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
   md5: 56d1386c7f1f338f0d18f82af6525273
   license: bzip2-1.0.8
   license_family: BSD
   size: 158748
   timestamp: 1714510571033
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
   sha256: bbfc668f445f3584936b326dcfe92bf71971ce16241f4f79db8aeb88d7aab41c
   md5: 10cc05ed51482e1dfcc31dbd13bb34c6
   license: MPL-2.0
   license_family: Other
   size: 138641
   timestamp: 1710764806818
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
   sha256: 512969f339a9a7b347cdb7b88f439819168089867f04732279f02759d8caf24e
   md5: 2009c2ee465fdd74dbd046de73726234
   depends:
@@ -4240,7 +4240,7 @@ packages:
   license_family: Other
   size: 166501
   timestamp: 1707229221324
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
   sha256: 8d26cd4d16545ad8afddd5521bc6894a50d5b8faff3abbe600bb9b062f3c3a0a
   md5: 66eb734b7d7008eb5fb537900767c7ae
   depends:
@@ -4251,7 +4251,7 @@ packages:
   license_family: MIT
   size: 286807
   timestamp: 1714483190838
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
   sha256: 808e56fb70f3d38599ee7a54c2a707b282ba9a401fa69a1f54cdc26425d9ce01
   md5: fc37321833175bda4fc5c21afe32db49
   depends:
@@ -4260,7 +4260,7 @@ packages:
   license_family: CC
   size: 539588
   timestamp: 1709758479776
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
   sha256: d9c126d8bcd1c89ea37186c172d6b1f73f45ada60e3ae1790a017b530baa0147
   md5: f0223aae3d622547f6accb212579c58e
   depends:
@@ -4270,7 +4270,7 @@ packages:
   license_family: BSD
   size: 17967
   timestamp: 1709322909223
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
   sha256: 1f908c688e47d03d92ac09d9541a1f1c773ac2ca485dd1d77441b1aaefc032db
   md5: 444c330471496a39a97e87f41ed70c96
   depends:
@@ -4281,7 +4281,7 @@ packages:
   license_family: BSD
   size: 281104
   timestamp: 1700583698464
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
   sha256: b9356e3ada4872c7c950d2ac7e0f107c4786775191efdfda3a469dffb18f2714
   md5: 07ddd96675caf30ea77cafb1ea5662a4
   depends:
@@ -4291,7 +4291,7 @@ packages:
   license_family: MIT
   size: 2490144
   timestamp: 1690905181398
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
   sha256: b1481ffa475c65200626f051d5dcbdb264730b533e928dde608a79ce7a5b4e48
   md5: aada2761547a291d68f4c016a1a9bc7b
   depends:
@@ -4300,7 +4300,7 @@ packages:
   license_family: MIT
   size: 18265
   timestamp: 1677911915719
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
   sha256: eb82a0e2ca36d0973b5f6642e27609554edad4b72696f989776d5db8cd4a6a42
   md5: fa8d9dd8a2fabba964c6bb75ace8c572
   depends:
@@ -4318,7 +4318,7 @@ packages:
   license_family: MIT
   size: 3201601
   timestamp: 1713551611540
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -4328,7 +4328,7 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
   sha256: 898d10bc1ededb43b7339ccf57fef404d96184de8ebaa788dba0b36a8c8a282d
   md5: a1925e4ff9f6124ca7d439430bc110fb
   depends:
@@ -4345,7 +4345,7 @@ packages:
   license_family: BSD
   size: 5399311
   timestamp: 1707836657705
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
   sha256: 765d5b7ef75ed7f52a110504cd88e9b0c9977b841f1beaeeabb17e629b462908
   md5: 0af9cd26a7c9eb8b77d3cbacb93a118b
   depends:
@@ -4362,7 +4362,7 @@ packages:
   license_family: BSD
   size: 360105
   timestamp: 1715090588763
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
   sha256: 4d4ab70ae0ce008c1cc96a4edfbf3866d5e636acc4799a545ea93acee51635f7
   md5: 86a085a440729020d1d7b0b74d6a0c6c
   depends:
@@ -4371,7 +4371,7 @@ packages:
   license_family: BSD
   size: 148448
   timestamp: 1714398923507
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
   sha256: 63670c8f31770e1746016f645ca6b42b35f92d1c37e8025793d9490fed9998c0
   md5: 9cb417b9fdf02b4e007a5b5781e5a8cc
   depends:
@@ -4393,7 +4393,7 @@ packages:
   license_family: BSD
   size: 229932
   timestamp: 1705934202146
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
   sha256: a40c76c412ec793ca26b97a9b5c496d253768438e1f7d4a0ee5f63ea79eed355
   md5: f609e4fe044318211cf0e37e289beebd
   depends:
@@ -4410,7 +4410,7 @@ packages:
   license_family: BSD
   size: 1614299
   timestamp: 1704833142734
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
   sha256: e57d10579b52a3cde45aa17e1bdd95dcb9d3346aa00eb02c51e38a42db83e18d
   md5: 05153120787fb09159b6e1ad902c6e10
   depends:
@@ -4420,7 +4420,7 @@ packages:
   license_family: MIT
   size: 1180481
   timestamp: 1678994989550
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.4-py311hca03da5_0.tar.bz2
   sha256: bdbc36a516717a24b40e2a4ac812c4d097b6733f4c6654602556969e5e0d4062
   md5: b31b2f2fd10d919c58c51fcbe54ef5c6
   depends:
@@ -4432,14 +4432,14 @@ packages:
   license_family: BSD
   size: 353970
   timestamp: 1716993463263
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
   sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
   md5: 055e12390b844ea6c6e956ee08a618e8
   license: IJG
   license_family: Other
   size: 273479
   timestamp: 1677849171867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
   sha256: 62025ce4a2b9244b9816c9e02487e0dda567600692b5f9ca71f425d084961c7e
   md5: d57b7063122e5bf25cdfc2a5ea7330a8
   depends:
@@ -4452,7 +4452,7 @@ packages:
   license_family: MIT
   size: 181872
   timestamp: 1699041739097
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
   sha256: 404b0847029f77bedd7902a170a046219e0dc5c0ec2be19ff45361cff25b2181
   md5: 3a02bbe8d45fdbcb2350f672be74c9f5
   depends:
@@ -4462,7 +4462,7 @@ packages:
   license_family: MIT
   size: 16524
   timestamp: 1699032463763
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
   sha256: 7deb8ad28c34c369573754304a03ea2acda8ee39102a56526ec689a4d9210109
   md5: 675ea1a746a78ff6bf8fc4b39139efff
   depends:
@@ -4478,7 +4478,7 @@ packages:
   license_family: BSD
   size: 277400
   timestamp: 1677914250715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
   sha256: 8220b1bbdde5e800810f7bf183a992af1a95825a837edf975fa8c4b51c5d806f
   md5: 3a06ddad06e04d5f0211c22cd81ca75a
   depends:
@@ -4489,7 +4489,7 @@ packages:
   license_family: BSD
   size: 94950
   timestamp: 1698937436979
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
   sha256: 8a9a9f9ddbf1b7744ef04a8c862438499a41d81a4beb4a49860156c273bb7497
   md5: 051355801f09eefe850ee8145151f934
   depends:
@@ -4505,7 +4505,7 @@ packages:
   license_family: BSD
   size: 42497
   timestamp: 1699282590553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
   sha256: 65c703cc996a705d0ee350070e313b1cae865f9d6e6490ebf1164c0f3ce22d93
   md5: 305ad8bcaad3e352d61b1e594093b467
   depends:
@@ -4532,7 +4532,7 @@ packages:
   license_family: BSD
   size: 596801
   timestamp: 1699466743685
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
   sha256: 501e929d345aaa9079c965552b942b4e8bde35b87ae89faef003687a40bab3a4
   md5: 54c7b8554a405acd7c8326c41ba93e63
   depends:
@@ -4542,7 +4542,7 @@ packages:
   license_family: BSD
   size: 28237
   timestamp: 1686870817418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
   sha256: 773e7c4571f482a744dfb18ae26fb22635f5d3f51389c838bd97f9044ea55cc4
   md5: 5161546aba5597318cb5653390cdecd8
   depends:
@@ -4554,7 +4554,7 @@ packages:
   license_family: BSD
   size: 20235
   timestamp: 1700168681687
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
   sha256: 8c1c64d51be73aad381992a9df19d8336910bdfc40f19940231df86e177d17cc
   md5: b1f786f96684a143cf30d1f6b8aebdb3
   depends:
@@ -4564,7 +4564,7 @@ packages:
   license_family: BSD
   size: 65045
   timestamp: 1677925371836
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -4574,7 +4574,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -4583,13 +4583,13 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
   sha256: 199042b87451abaf14546af124ae3380194cddda928e0d30ccb341e93084854c
   md5: eaa0442887994a82486c65d87f6b71e6
   license: MIT
   size: 68806
   timestamp: 1714483212137
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
   sha256: bd9a8a17fb14086446b710fa029d238e69274b83ee2e7e09093496f190de82b5
   md5: 66615d6a0cb5dcca3e20c019cde0ed2d
   depends:
@@ -4597,7 +4597,7 @@ packages:
   license: MIT
   size: 32975
   timestamp: 1714483225840
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
   sha256: e1bf77e8b975c30a69b08a08410622e27c8cff6f592ccfa590466b83d9e6d104
   md5: 8af86bdac01fe303d693d9b76c071059
   depends:
@@ -4605,28 +4605,28 @@ packages:
   license: MIT
   size: 310266
   timestamp: 1714483239194
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
   sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
   md5: f31e4eb9cd6447cc2f5ef0243a76540c
   license: MIT
   license_family: MIT
   size: 120460
   timestamp: 1714483461787
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -4635,7 +4635,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -4646,7 +4646,7 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -4657,7 +4657,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -4666,13 +4666,13 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -4689,7 +4689,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
   sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
   md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
   constrains:
@@ -4698,7 +4698,7 @@ packages:
   license_family: BSD
   size: 331675
   timestamp: 1694776939192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
   sha256: 41c62a460bb81a1a272aa28b219fab9c26510adac177ff1528b1980eabc6e868
   md5: 8d312c5628dc7ea833e9b4dcb73e9c45
   depends:
@@ -4708,7 +4708,7 @@ packages:
   license_family: MIT
   size: 42346
   timestamp: 1677973051421
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -4717,7 +4717,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
   sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
   md5: f5f7e6e7541d8dc3d3df270d488d2e24
   depends:
@@ -4726,7 +4726,7 @@ packages:
   license_family: BSD
   size: 176990
   timestamp: 1714510588159
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
   sha256: d024f5142416961a5e66e424d4d14aec652f9e9dd738b41a97f45674c2ffc9d5
   md5: 0e2d94b125d802f7b006cf19c71655a1
   depends:
@@ -4735,7 +4735,7 @@ packages:
   license_family: BSD
   size: 163084
   timestamp: 1677932947966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
   sha256: acfd84e29ff4dc2d85543bb973a07f22b4ba53c5d00bca84608ee7f13b2a8676
   md5: 5ca161cd51e2db358e768453b3ee485e
   depends:
@@ -4745,7 +4745,7 @@ packages:
   license_family: MIT
   size: 135871
   timestamp: 1684279980293
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
   sha256: b1bed54c7bfb7304cde9e8e6f798543d08e808e81286a5a48296fc94d621f9da
   md5: 774358285c9e496c9f5c121cc546c823
   depends:
@@ -4756,7 +4756,7 @@ packages:
   license_family: BSD
   size: 27438
   timestamp: 1704206026910
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
   sha256: 9229a6e15abf3147cfcffad4ca389dad940e45779963b4fc3fd56dfdcfca3234
   md5: 4e1897f3cb4923de48c016468c01c051
   depends:
@@ -4777,7 +4777,7 @@ packages:
   license_family: PSF
   size: 9100733
   timestamp: 1713336457304
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
   sha256: 3276d61fc353c537bb09d4b7473d7abe12be38806f42c8cc383b62f40850a5cc
   md5: 6e9c9d47f264b77d9a8461f0899848a7
   depends:
@@ -4787,7 +4787,7 @@ packages:
   license_family: BSD
   size: 20446
   timestamp: 1677918370379
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
   sha256: 43c96d30775b61b4968422a47f9605049428120669f0742bbb9e5ba145c7d11e
   md5: a31ca0d9284860adf5463cf45a5e3145
   depends:
@@ -4797,7 +4797,7 @@ packages:
   license_family: MIT
   size: 69243
   timestamp: 1677995336989
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
   sha256: 96d8c9f42a38651b7bafe5f3cb132601db76cd1e28fa58e2eaf090e634292fff
   md5: 5ebc793a17b6aa84d13f19433545ffa5
   depends:
@@ -4806,7 +4806,7 @@ packages:
   license_family: MIT
   size: 23895
   timestamp: 1677942274932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
   sha256: db9bd659ada23f1ded443d2db00dd13b5d5c0b30f5062544b1ee2c2b88d63d29
   md5: 03c48121614cf12abfe30eced9b34717
   depends:
@@ -4817,7 +4817,7 @@ packages:
   license_family: BSD
   size: 105333
   timestamp: 1677916687032
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
   sha256: a8b3d349481dc694eb9a507f55c91e8981e2a3bc41743023ca01248c8a6d779a
   md5: 71e6e29ec3b98fb282c01b012a5df236
   depends:
@@ -4843,7 +4843,7 @@ packages:
   license_family: BSD
   size: 8294656
   timestamp: 1699543119360
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
   sha256: e8eee27fb667aa10b26f3bc4b93f449b7d991ded27b9cb457effee394ce05f6f
   md5: 6a3e5cd0e1141c01ffb91285bdccfe83
   depends:
@@ -4856,7 +4856,7 @@ packages:
   license_family: BSD
   size: 123043
   timestamp: 1698934328890
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
   sha256: 40230434aa2fbb33ece13632e8d4b7cd1ad68fdb8d1b00263af4a010795d25f8
   md5: f12ce7dad3620d6d53a442fa9d36a0b0
   depends:
@@ -4883,7 +4883,7 @@ packages:
   license_family: BSD
   size: 538067
   timestamp: 1699022954841
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
   sha256: a492acec8ceadc0911a75966ffa630a8eb15b2da8c7a8d544a645ba47771a2d1
   md5: 4002b1b88b2ecfdfc769036f43b0a895
   depends:
@@ -4896,14 +4896,14 @@ packages:
   license_family: BSD
   size: 170964
   timestamp: 1694616845237
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
   sha256: 417ace1ce51e81f3f92ddc26e0e3a83c1e19c9ebb7af7104452002a5573da534
   md5: 3e11de6cef096091bb733e07802f00b0
   depends:
@@ -4912,7 +4912,7 @@ packages:
   license_family: BSD
   size: 16979
   timestamp: 1708532698253
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
   sha256: 2e09ae8d10d7e5651727aab66a1e89b59e716295267a8295eaa53760c4c38533
   md5: 8d52be8699bf030546811bb69fbeb2b1
   depends:
@@ -4937,7 +4937,7 @@ packages:
   license_family: BSD
   size: 728383
   timestamp: 1690985022565
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
   sha256: b0cc542e2a6f42ba716e7e4ccf29eddcb155ad167fcdbc72d2db9c7873eb5639
   md5: 7acf81b17d2c4ceb3cd39dc9f173855c
   depends:
@@ -4947,7 +4947,7 @@ packages:
   license_family: BSD
   size: 27539
   timestamp: 1699455954000
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
   sha256: 151a3eb68d1189e69764ece1d8fb3544d31a22f5bbbc3e19d846de8dece304d2
   md5: eb6609e6bdc9c82d70df3f8c4c2de95b
   depends:
@@ -4958,7 +4958,7 @@ packages:
   license_family: MIT
   size: 153313
   timestamp: 1696515415712
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
   sha256: d3bb1d4be88320a5861cd3a0f086e9709f9b64c96c032cb9039cc4f17ec66a85
   md5: 0a7b97665c06fcd34a70e34abc177280
   depends:
@@ -4971,7 +4971,7 @@ packages:
   license_family: BSD
   size: 11288
   timestamp: 1708639168951
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
   sha256: 3e70248a7069ca12ccf56252869bfdb72211fd4e4c327e6994756496df786c79
   md5: ce4846006d98638cd86a532a72f8dfe4
   depends:
@@ -4985,7 +4985,7 @@ packages:
   license_family: BSD
   size: 7536860
   timestamp: 1708639153133
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
   sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
   md5: 371358a54bbdd307603888348d1a2c6f
   depends:
@@ -4995,7 +4995,7 @@ packages:
   license: BSD 2-Clause
   size: 412248
   timestamp: 1628861367714
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
   sha256: da78bd65c91881856baadf977534832f68db3938c1b5b713c8797be70b83c98c
   md5: f728656890f860eec5ad2899e657df3a
   depends:
@@ -5004,7 +5004,7 @@ packages:
   license_family: Apache
   size: 4763426
   timestamp: 1716318333548
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
   sha256: 77b0c0a0fb14d817390244ebd93c36d44a7867239963f211f7c0a72a3f98d382
   md5: b90336feb8a50d2eff880e89acb02f40
   depends:
@@ -5013,7 +5013,7 @@ packages:
   license_family: APACHE
   size: 39617
   timestamp: 1699371253760
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
   sha256: 4f6c3e8d8fc4c57975cab837ef109b9ee7af4f18aac72668334ac656e53c6edf
   md5: fbf1b507f9a80c5de3c957e8152124da
   depends:
@@ -5022,7 +5022,7 @@ packages:
   license_family: Apache
   size: 159289
   timestamp: 1710807498427
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
   sha256: 3af823879c340838c1040e99f653c3438ccce8dc559bd91c3f4ab2579282a002
   md5: 5b3df01fda0281dab4196bc36d1ca367
   depends:
@@ -5072,7 +5072,7 @@ packages:
   license_family: BSD
   size: 17082645
   timestamp: 1709591689205
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
   sha256: 8bf772501cf4b49a939de17bf378d3e395f452d3070d05871354bd2bc915d012
   md5: 753d2070a2aea47934ecf6ac1ea0bc04
   depends:
@@ -5096,7 +5096,7 @@ packages:
   license_family: BSD
   size: 21901817
   timestamp: 1714071405089
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
   sha256: 67feb8232961ad9d7672a49f6f86f0b86764f62a97d86d58b90ca7e8345bab76
   md5: 3afb6e6747bd29e9483d35dbf8b24f74
   depends:
@@ -5105,7 +5105,7 @@ packages:
   license_family: BSD
   size: 264413
   timestamp: 1711136882294
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
   sha256: 174b680f4bb041e8146aae80f92390122459e0ef8c911cab22d01e2e92d44ab1
   md5: cfffc94779cd26a349bd409b5590b098
   depends:
@@ -5121,7 +5121,7 @@ packages:
   license_family: Other
   size: 916496
   timestamp: 1714399019350
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
   sha256: 102c3c35a9dfa0f10ec8f4a040a24295f9c736443ccae2f685348a44f62a4d68
   md5: 027b347e79e252aa17b534e1a02bccd6
   depends:
@@ -5132,7 +5132,7 @@ packages:
   license_family: MIT
   size: 3447682
   timestamp: 1715097070362
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
   sha256: b6200816d65673aa1707c20a768c9cff87dd8dbe1335f9c1478e5931dfa08ee0
   md5: 14b1e0fa73eb33f9c83048482dcce57b
   depends:
@@ -5141,7 +5141,7 @@ packages:
   license_family: MIT
   size: 38423
   timestamp: 1692205689597
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
   sha256: ebdf211edd98d88a23778551c7a9702106edd0695d4fc48e87c21f77521c1ffe
   md5: d8c505081a468f1b99c62466e2309417
   depends:
@@ -5150,7 +5150,7 @@ packages:
   license_family: Apache
   size: 123084
   timestamp: 1678996822234
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
   sha256: 07cfba50d9e94364bde077731a824ca4f537138b35ee6b66d07aee16ac9850f1
   md5: 919bf486280a11e6acb3c2c3a82f7473
   depends:
@@ -5162,7 +5162,7 @@ packages:
   license_family: BSD
   size: 763225
   timestamp: 1704404463402
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
   sha256: 8094436b2c44e68e72569c704633802aad82e977b1e16026848218679c8becf4
   md5: 2360e46d3e598dd5e2abed781fe166c5
   depends:
@@ -5171,7 +5171,7 @@ packages:
   license_family: BSD
   size: 502115
   timestamp: 1678995719872
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
   sha256: 121b5b66721760c05f1d4eee91626229d1814663d3fb5f23126ef870aa496e26
   md5: 0c588c2ca790a05d422c06e8568201ad
   depends:
@@ -5180,7 +5180,7 @@ packages:
   license_family: BSD
   size: 2124200
   timestamp: 1684280082141
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
   sha256: 44b694db8e81d61960d28d60f9e9b573f03f7827881d302da334378881db4889
   md5: 6c94ba7caa599ff533e0ab55d898be8a
   depends:
@@ -5189,7 +5189,7 @@ packages:
   license_family: MIT
   size: 208454
   timestamp: 1677910948527
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
   sha256: 0bb3d2a57b332c5cf73ea40ea13c850ae24a1f9a3a41ed9267832d9e3c767572
   md5: 45a7fcf1641980d5114999736428502d
   depends:
@@ -5198,7 +5198,7 @@ packages:
   license_family: BSD
   size: 36755
   timestamp: 1677906514270
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
   sha256: 960c343b7b8569dfe4e71a395f7bede1e749da7b02c17506b590c9e1839e6fd7
   md5: 722c4b4386af73cf1562974a00c880a4
   depends:
@@ -5217,7 +5217,7 @@ packages:
   license_family: PSF
   size: 16494386
   timestamp: 1713545544909
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
   sha256: c3cbf5bd237b0a7458640191016b2701fe120c547df9afc835da76663a9c17f7
   md5: 843568c76b6b9384635b7fca74c79792
   depends:
@@ -5227,7 +5227,7 @@ packages:
   license_family: BSD
   size: 332222
   timestamp: 1716495881101
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
   sha256: f94b3cfea6f76ea9983e16d3c4c7e0a64f02c40cc2c3ad57189bca2e67030bd9
   md5: 0d100990ade57a02b60d1e8085db0bdf
   depends:
@@ -5236,7 +5236,7 @@ packages:
   license_family: BSD
   size: 280263
   timestamp: 1678996927464
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
   sha256: 252c86f5aef7f8dfce99a260c24cbb35a9adfea144a2acfabb224f516341544f
   md5: 745b888e19a644f48800799f82c01c21
   depends:
@@ -5245,7 +5245,7 @@ packages:
   license_family: BSD
   size: 18539
   timestamp: 1683823925189
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
   sha256: d945744eb133f19ca61325cac5128bdb053ae04de4a0ba6f69c061449cac8af7
   md5: 34baa81490d667381bc7021435b0e1f2
   depends:
@@ -5254,7 +5254,7 @@ packages:
   license_family: MIT
   size: 275858
   timestamp: 1713974457562
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
   sha256: 012585bdb5ae54c2cded50be703734e6dbf418b003635b6f6d7c1e36e7020c30
   md5: da7e99a707bd0cfa20db651b5c068bfd
   depends:
@@ -5266,7 +5266,7 @@ packages:
   license_family: BSD
   size: 65556
   timestamp: 1711136890180
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
   sha256: 4f04a43cbd612ab09cefbdc2e48ee61b51967dad59d859ce0502cc2c46c88fc5
   md5: c68bf65433b2151b51b2e699bc22c501
   depends:
@@ -5276,7 +5276,7 @@ packages:
   license_family: MIT
   size: 194632
   timestamp: 1698096151085
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
   sha256: ae8cdd5be5a7ad19ff82925a035859fafcc5942cd3899d127a508dbb9a235090
   md5: 252a7b997d08bf72f10b3bc2dc68333e
   depends:
@@ -5286,7 +5286,7 @@ packages:
   license_family: Other
   size: 580346
   timestamp: 1709318480624
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -5295,7 +5295,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
   sha256: 7a208abc002a2fc208ae25cb2cf932999a3e4980aa4c9edff315cb9ac62b12ce
   md5: bd22ebd3cff811577ea61f115ba7f4f2
   depends:
@@ -5306,7 +5306,7 @@ packages:
   license_family: MIT
   size: 74744
   timestamp: 1699012126255
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.32.2-py311hca03da5_0.tar.bz2
   sha256: c6eff6c175590d7fd2e500ff1673b160a4c2b67e1cb99370ec8b5a2c998e8025
   md5: a60c7eef247742967bca814d7f1d90ab
   depends:
@@ -5322,7 +5322,7 @@ packages:
   license_family: Apache
   size: 123308
   timestamp: 1716902854898
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
   sha256: 52368d9b557b8f54ef5ca4bf6cd5a3ec665171f2b2d2082cdd410bab88f4829c
   md5: ac76fb4d2eef3ecdd491cf5d3fb8620d
   depends:
@@ -5332,7 +5332,7 @@ packages:
   license_family: MIT
   size: 10204
   timestamp: 1683077239143
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
   sha256: 491d116c5f54ef340e3bce631835f7138cd1923d7b63e6ca9aa01b48110cb8f9
   md5: 9b81bd8ea808704f5433884b567f1f15
   depends:
@@ -5341,7 +5341,7 @@ packages:
   license_family: MIT
   size: 10557
   timestamp: 1683059079547
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
   sha256: b53a5f6119173d62e4e68a37ea8511c7fc87a00af72953e0048d075a799c7a7a
   md5: 76a16cf4edb9b12b2b96a2d323f060dc
   depends:
@@ -5350,7 +5350,7 @@ packages:
   license_family: MIT
   size: 342535
   timestamp: 1698945991201
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.13.0-py311hc76d9b0_0.tar.bz2
   sha256: 9e8312f9452357202813aa289430c939302617f562dae9e90fdc3fb5e9be49d0
   md5: def02b749d0c0a3675d96aeb508a2306
   depends:
@@ -5368,7 +5368,7 @@ packages:
   license_family: BSD
   size: 26383719
   timestamp: 1714070280353
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
   sha256: c80d52567084b1caaed2862b77b70065ca17afaf0b020733e9d6c273b4a63e78
   md5: ddf7d88c1967f3f7a4ce1c975fd47e0d
   depends:
@@ -5377,7 +5377,7 @@ packages:
   license_family: BSD
   size: 33321
   timestamp: 1699371225235
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
   sha256: 6d38d171ef87340cf0fbbf4c70217df4826c65400c9290774f5cb35e381e3315
   md5: b9529a812f9862fc89461b6b90f184ba
   depends:
@@ -5386,7 +5386,7 @@ packages:
   license_family: MIT
   size: 1599110
   timestamp: 1715024190898
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
   sha256: cd71091a234874d2826fa063ec5222b3191c9f47e1b5281c352d9df3f31a06bf
   md5: 0db8e29016c6bff026c083d9923a7566
   depends:
@@ -5395,7 +5395,7 @@ packages:
   license_family: Other
   size: 19073
   timestamp: 1705431415504
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
   sha256: 3e18cdafc607c6d7623b1c8f041cbfbb50a27e298f961abdcce7e36834ac39e1
   md5: 9ee0da74c55d0b8d83edf246fd717f20
   depends:
@@ -5404,7 +5404,7 @@ packages:
   license_family: MIT
   size: 89862
   timestamp: 1696347657368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
   sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
   md5: d8c1e9910392d0bcb22a173f9ce30fa6
   depends:
@@ -5416,7 +5416,7 @@ packages:
   license_family: Other
   size: 1758290
   timestamp: 1714488307689
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
   sha256: b5c265e9ed9a1ff2238a09b83bdc1826950faa87fd6b685debe60888de6e7a50
   md5: 5827c8a32317894ce18576e334daba47
   depends:
@@ -5427,7 +5427,7 @@ packages:
   license_family: BSD
   size: 38559
   timestamp: 1677918962258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
   sha256: cfefd86d0f4981d22b7611b3dc60359b8698bf39f2b743cb90b7005aaca88e1e
   md5: a04dbcd6095f6b8f3ad195a78d48b262
   depends:
@@ -5437,7 +5437,7 @@ packages:
   license_family: BSD
   size: 50058
   timestamp: 1677917499177
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
   sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
   md5: 3c25b4f4768ccda28b20a03ba27e7759
   depends:
@@ -5446,7 +5446,7 @@ packages:
   license_family: BSD
   size: 3484151
   timestamp: 1714770744982
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
   sha256: 177246487449f87567fe56c8f20011a4350a132d1556c9f87474d7b2e8c1374f
   md5: d465118217b9f27d47dceff89c2e9f95
   depends:
@@ -5455,7 +5455,7 @@ packages:
   license_family: Apache
   size: 896655
   timestamp: 1696937042980
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
   sha256: 81efb240a49cede5ece3a8ad48f1d9dfdeb56260bf1a20e25ec53cdb202f7c3e
   md5: 81a17d13c75596841b95340a34bbe929
   depends:
@@ -5466,7 +5466,7 @@ packages:
   license_family: MOZILLA
   size: 155516
   timestamp: 1716396017482
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
   sha256: 65e760119352cd85c63d365d2576c09a9ddb060e5b029a265d50bc268eed9290
   md5: 14c241871b12dc3be52e6cd681267caf
   depends:
@@ -5475,7 +5475,7 @@ packages:
   license_family: BSD
   size: 271445
   timestamp: 1677911758960
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
   sha256: 96071e07e807414b7ae5a2fe958ac171e5795576b3a4c2f5e8c643fba43d760f
   md5: a34f2b216e35a37f966883dacda229e2
   depends:
@@ -5485,7 +5485,7 @@ packages:
   license_family: PSF
   size: 9902
   timestamp: 1715268985387
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
   sha256: b20e48aff4c781a52b6be66d77418e768527a621f5fc272ecb34ea03475b2bd7
   md5: 707738432f16f5e63909fcaa6e65850d
   depends:
@@ -5494,7 +5494,7 @@ packages:
   license_family: PSF
   size: 75604
   timestamp: 1715268976065
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
   sha256: 2ea2d0520b330d381a2ab241bdb9ae146ef815ee7c96ee52a9773fb9ae85f4fd
   md5: 66f7f8979cfb2cccffac972d70482130
   depends:
@@ -5503,7 +5503,7 @@ packages:
   license_family: MIT
   size: 12614
   timestamp: 1677963554857
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
   sha256: df7fe7740bd853b641d624e2ec97f1aacb2b82691936a8c04ef18fa9768539c2
   md5: d5c7626d45fd03b22797c18e47812beb
   depends:
@@ -5512,7 +5512,7 @@ packages:
   license_family: Apache
   size: 518048
   timestamp: 1713213046424
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
   sha256: 3fbcccceb4d7d99f60a6e6e013ab84c4532244c42ab9d65b6fdaab6bd30f7269
   md5: 6a7e05872852d4bcde959f7cc8407672
   depends:
@@ -5528,7 +5528,7 @@ packages:
   license_family: MIT
   size: 210307
   timestamp: 1715635933070
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
   sha256: 09738b7f9075386bf062b12ddb6fb72a06450d2481f6b5ca2026c811cd849569
   md5: 9afdec076c95746ac21235f971190e40
   depends:
@@ -5537,7 +5537,7 @@ packages:
   license_family: BSD
   size: 26727
   timestamp: 1677910175964
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
   sha256: b4ced7366de8eb7258f31d516616e70c62ed4a798780e57e208509d2b52ab435
   md5: 65a9a05a726734c1da667f9bd3c78c14
   depends:
@@ -5546,7 +5546,7 @@ packages:
   license_family: Apache
   size: 114733
   timestamp: 1715878377412
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
   sha256: aa301d9e42aadbe3dd5f301ccbf17fbadc347fd37d413c0cbcbd24403892a936
   md5: 77097d17d835a137af7950c628b66150
   depends:
@@ -5555,7 +5555,7 @@ packages:
   license_family: MIT
   size: 137260
   timestamp: 1714717037687
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
   sha256: 2cd108896df65636769e3804ecc2ca421ad9b54e64fa21922bbabe40c90c247a
   md5: b3a1e5077b28f71298d891fbfb5ff03e
   depends:
@@ -5564,20 +5564,20 @@ packages:
   license_family: BSD
   size: 55645
   timestamp: 1677927459979
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
   sha256: 5be8c968f2da5c4bf14f28d63e31b4c1b6993d980023769732c7f58f396c2e0b
   md5: 3f5f62d4e85e3bdd48d39189b01805a6
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 459197
   timestamp: 1714510992914
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
   sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
   md5: 3d57d1adadca9388aaaa1c529b65ba65
   depends:
@@ -5587,14 +5587,14 @@ packages:
   license_family: Other
   size: 322790
   timestamp: 1705602163804
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
   sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
   md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
   license: Zlib
   license_family: Other
   size: 104928
   timestamp: 1714510936868
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
   sha256: a3f3eaf240991b6bd7b0596a78d0abb3321cc79db52fa24f6f559189778871c6
   md5: 71f035b4716322539e2461cb6667e946
   depends:
@@ -5606,7 +5606,7 @@ packages:
   license_family: BSD
   size: 825339
   timestamp: 1714678419523
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
   sha256: 6e6787755de0cf2fd776c9681a7b0fd0fb23e35e679a463cc2005b991c413910
   md5: ccad42ec9a2ad48939f089c528abc8f0
   depends:
@@ -5620,7 +5620,7 @@ packages:
   license_family: MIT
   size: 229694
   timestamp: 1706220431719
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
   sha256: f715f7c2e06149bd6d43258e41479d3171efe5e9d56050a0a5f5652ed9d05fff
   md5: 11a8ca43d69881b88f95ae681478866d
   depends:
@@ -5632,7 +5632,7 @@ packages:
   license_family: MIT
   size: 36089
   timestamp: 1676424516042
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
   sha256: 9adabcdd2a10f73fa5ba56adc901eeea2e379991a0d4cb9737eec7aa6b9fc5d8
   md5: fc80b572be85601706d425b21a58d497
   depends:
@@ -5641,7 +5641,7 @@ packages:
   license_family: MIT
   size: 153102
   timestamp: 1695718054194
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
   sha256: 38ccda1553733326d99a75436b4b0f7640bafbbfcdbc33838b0e59cf017de687
   md5: 3f6812578c5e0b3ba0d2a651cc766c15
   depends:
@@ -5651,12 +5651,12 @@ packages:
   license_family: MIT
   size: 266405
   timestamp: 1681493141116
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
   sha256: fe765d810e1612af7a42f34223077f0adc05dbd386b257be24661913d067fe30
   md5: 82e988aba03c8afa03fce78f7442806e
   depends:
@@ -5674,7 +5674,7 @@ packages:
   license_family: BSD
   size: 6086137
   timestamp: 1712084583317
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
   sha256: 5c12a5d7856d9977447360b3a99a5b99818707fe79781ba1779037f11b3fef53
   md5: 6a125ae352306a944aabc635a5fe13a3
   depends:
@@ -5686,7 +5686,7 @@ packages:
   license_family: BSD
   size: 139230
   timestamp: 1707864402762
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 751071782f597f87ed7f67437ef6cc669213902461b9795dd6eb0f4897eddc83
   md5: 5ad8fe62aad5e16cfdf2c5a7d1327fe7
   depends:
@@ -5698,7 +5698,7 @@ packages:
   license: MIT
   size: 19418
   timestamp: 1714483531456
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 9bd62d810867549b9c967c5915f3fa3f66cfbd6ede28b1cc152efd1261285c0a
   md5: 64cc76de3662b62bc8f0e42befd92c5d
   depends:
@@ -5709,7 +5709,7 @@ packages:
   license: MIT
   size: 32178
   timestamp: 1714483513837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
   sha256: 1547fa52134cf06b8d01bdf52114db7db60a89bf35c9c95be5b5a03b13dbd565
   md5: deb765cb7c4b7edc4d126f864f31747c
   depends:
@@ -5719,7 +5719,7 @@ packages:
   license: MIT
   size: 356401
   timestamp: 1714483740924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
   sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
   md5: 11e0af09a31e2d5df51c65a342032b85
   depends:
@@ -5729,14 +5729,14 @@ packages:
   license_family: BSD
   size: 112994
   timestamp: 1714511182837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
   sha256: 73391a74a5300ad3fb063ea0f0c3491d220128a0611a84036da2e23c1e93dc0e
   md5: 501ded4f9b5ed895077802defee912cf
   license: MPL-2.0
   license_family: Other
   size: 171644
   timestamp: 1710764856021
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
   sha256: cd6545642e380b13700f2f2a7a1fb54a273365047bd23108dbd03b197f5c0c9c
   md5: 929edc1c553d2da4d6c6c0745b033cc3
   depends:
@@ -5745,7 +5745,7 @@ packages:
   license_family: Other
   size: 166377
   timestamp: 1707229328635
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
   sha256: 5cb6ac90ad234248f3795945f69b0382397714a52712337b2f86339526b822d8
   md5: b90f3126f6315ea2e8ab242533062557
   depends:
@@ -5757,7 +5757,7 @@ packages:
   license_family: MIT
   size: 302693
   timestamp: 1714483562551
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
   sha256: 4099898f02e1f6119fcda65e747c3cbfef0bf563c8855b79a0245160709d5b45
   md5: ab9705c34e67fb8c8faec69d63ff4064
   depends:
@@ -5766,7 +5766,7 @@ packages:
   license_family: BSD
   size: 36410
   timestamp: 1676422341506
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
   sha256: c722f50980d7416ffb2cfc7bf72649307a0bb78c5a24eccefcd049cb61d6b355
   md5: c7c9ff0513ff3c99700919293b702410
   depends:
@@ -5775,7 +5775,7 @@ packages:
   license_family: CC
   size: 543258
   timestamp: 1709758602437
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
   sha256: 8fb3e816a5ad1da05125462dbc9e2a7e933b001a871aa65703802c0a894c6277
   md5: ee4b2fa9fce130496d5c7c86c35a1a05
   depends:
@@ -5785,7 +5785,7 @@ packages:
   license_family: BSD
   size: 17723
   timestamp: 1709323150229
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
   sha256: eeb49cd151ecdccd40062e8123a3b7a9a8a1eda6567dd33ce909ff8ee1a97c89
   md5: b7fe1f7ead1ec2ac642d022942282fc8
   depends:
@@ -5797,7 +5797,7 @@ packages:
   license_family: BSD
   size: 232451
   timestamp: 1700583772701
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
   sha256: 5c73f86e575f2ad683ee4a1c2df11020e270edd89d12f11199483d57b0b51826
   md5: e96a12895ce374476277b1b196ba24bd
   depends:
@@ -5808,7 +5808,7 @@ packages:
   license_family: MIT
   size: 3719519
   timestamp: 1690907216785
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
   sha256: 5d5fc8a24c804010b8cb5963227230352ea3ccf56bea9e8116e34f77223218f2
   md5: 8f989a72eed6293dfe0533c83057980d
   depends:
@@ -5817,7 +5817,7 @@ packages:
   license_family: MIT
   size: 17688
   timestamp: 1676423357100
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
   sha256: 27fb03eb57d25711a15e145f47a64320a9955b585efc9fd0a1a51cdd71b9fde3
   md5: eb3869e98f6f53dfec76e2eff4d6b61e
   depends:
@@ -5837,7 +5837,7 @@ packages:
   license_family: MIT
   size: 2732423
   timestamp: 1713552175344
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -5849,7 +5849,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
   sha256: 68d59a361a93a5ae36542f667138b4ab072e1abff15b3aa2dc55575baf86a3e9
   md5: 383239566d9506b743c7bc65d709b7e1
   depends:
@@ -5866,7 +5866,7 @@ packages:
   license_family: BSD
   size: 5374020
   timestamp: 1707836834797
-- conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
   sha256: dee3fc68ed81398d232b3afe9a032837bdbef98c1b2478604d6abd397e3e7d64
   md5: 3f75535ca6dfee0745b221922f21f6de
   depends:
@@ -5883,13 +5883,13 @@ packages:
   license_family: BSD
   size: 353312
   timestamp: 1715090519918
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
   sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
   md5: 582d2c1135a89da757a038de831e7f39
   license: Intel proprietary
   size: 11086648
   timestamp: 1664812389803
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
   sha256: 102c803186db6d62eaf41a906f6c563ff0d62b53c1eaede8a381e18c0d005ed9
   md5: 9d30dec03058758a428cf152e0ae28b5
   depends:
@@ -5898,7 +5898,7 @@ packages:
   license_family: BSD
   size: 148193
   timestamp: 1714399061601
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
   sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
   md5: d215cc8ee7ca2cc83cc250cc5d822fe0
   depends:
@@ -5908,7 +5908,7 @@ packages:
   license_family: Proprietary
   size: 3929136
   timestamp: 1699647939158
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
   sha256: 864e9598f64105769b4ec02cc404fb507bc59e217324daf1686c00cfd12c0055
   md5: 6bb1c3be1f85799a3988afc2c3c5a4f0
   depends:
@@ -5929,7 +5929,7 @@ packages:
   license_family: BSD
   size: 229621
   timestamp: 1705934494547
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
   sha256: e0b44f0c3a4ead0fb8e58033c0be25524ee9ecf7f4cc632f03e9f6fac3484baa
   md5: 50cbc18d0c7b42a4553b52d0cef2c857
   depends:
@@ -5946,7 +5946,7 @@ packages:
   license_family: BSD
   size: 1637367
   timestamp: 1704834149957
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
   sha256: d81566367c79a28d4717157fc74293e846a47af99387ed479eb001a425dd398e
   md5: 28c76079c96ad7f8b1a5ed32b438c79a
   depends:
@@ -5956,7 +5956,7 @@ packages:
   license_family: MIT
   size: 1147434
   timestamp: 1679427525584
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.4-py311haa95532_0.tar.bz2
   sha256: 74c339ca0a20f4bc324974c2c28901c1f478ca7c8898483482883a7a82896d15
   md5: b3d3352c9d3bfe46f924b8e15fedf9be
   depends:
@@ -5968,7 +5968,7 @@ packages:
   license_family: BSD
   size: 353862
   timestamp: 1716993519832
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
   sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
   md5: 81f2c343dc4c65eea39c45383272068f
   depends:
@@ -5978,7 +5978,7 @@ packages:
   license_family: Other
   size: 407861
   timestamp: 1677849239400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
   sha256: 5e6698015a3b048093f5737f0e54bcbae415d0f9682dfdfeae3a8cfb4ea275e2
   md5: 0093a4214131046c4f68af0739dfbea4
   depends:
@@ -5991,7 +5991,7 @@ packages:
   license_family: MIT
   size: 201456
   timestamp: 1699041872445
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
   sha256: 9581be54128954080d7cef448b1728874c2ebbe5064f55adece422cf12eafa5a
   md5: 3adc105f87d5c7f0b1248bc3423f5b48
   depends:
@@ -6001,7 +6001,7 @@ packages:
   license_family: MIT
   size: 16187
   timestamp: 1699032556953
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
   sha256: ad8343bad7c8f0448cbcfbaf872cc94b56da81c52e5cdcee2a5d6b89f029eb75
   md5: addceff8d46c9d1d322618a9ce9e5b39
   depends:
@@ -6017,7 +6017,7 @@ packages:
   license_family: BSD
   size: 300354
   timestamp: 1676424060532
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
   sha256: 851ae576c2b72bf3172cd460feec4f5577dc06476a043e185279071b67549fab
   md5: fae4d214d00de6604738f39acbbb197e
   depends:
@@ -6029,7 +6029,7 @@ packages:
   license_family: BSD
   size: 119710
   timestamp: 1698937651636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
   sha256: d97ad90f9121ecf7f8d3af773b222c0bd244204ee73a3e44185491fa16d83104
   md5: 73ac0fa3c67e5eb283173d74a2771752
   depends:
@@ -6045,7 +6045,7 @@ packages:
   license_family: BSD
   size: 60625
   timestamp: 1699282918176
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
   sha256: 257e1102d2dc3f8b0c1708585c819e86f41abd101084cd0569e8e31652480875
   md5: 2128c6806bba6953e1a275f37e7a295b
   depends:
@@ -6073,7 +6073,7 @@ packages:
   license_family: BSD
   size: 614705
   timestamp: 1699467242943
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
   sha256: 90420847230e72a648417f5f77cebcf7f17b89f70788652c276acc0c440e135f
   md5: ef3d8dee197aa37897bf6d39d2dd878f
   depends:
@@ -6084,7 +6084,7 @@ packages:
   license_family: BSD
   size: 27639
   timestamp: 1686871052174
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
   sha256: 97faaf26ce5254ec3649a8ee7f480b1556e4e8e6e4356d2fab1e6a5532631a0f
   md5: da23bd831c50c877f63038b7e16720ad
   depends:
@@ -6096,7 +6096,7 @@ packages:
   license_family: BSD
   size: 20163
   timestamp: 1700168785472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
   sha256: 8a2f0909fad0387e57cb0e9ee30db2b20761a9106e794381ffeac387a298fb07
   md5: 6058b2efc3284e27aacec2e6e6280433
   depends:
@@ -6107,7 +6107,7 @@ packages:
   license_family: BSD
   size: 62334
   timestamp: 1676432044242
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
   sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
   md5: f5f73266281ab12377d5d47bdf07500a
   depends:
@@ -6119,7 +6119,7 @@ packages:
   license_family: MIT
   size: 905072
   timestamp: 1617648814933
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -6129,7 +6129,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 7c906c94a4d46ea963080a6ba5bd12c1274da66159877a544fbc70291eeed98d
   md5: 45a3d52534fac8aa54a55ee92211a918
   depends:
@@ -6138,7 +6138,7 @@ packages:
   license: MIT
   size: 80216
   timestamp: 1714483371043
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
   sha256: daad7edc6d56abf3e176479e8628162dbf1c56b3d24db30d708aebae694a5214
   md5: e8ecf229f7fcb4c0b76d8613627948f5
   depends:
@@ -6148,7 +6148,7 @@ packages:
   license: MIT
   size: 45189
   timestamp: 1714483420152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 84320217abffa9386186ec8d03b4651bb4b1900d3871adc965a9a9e1d3799907
   md5: 651312fa22168f71f9aec5f9ee2c2fcf
   depends:
@@ -6158,7 +6158,7 @@ packages:
   license: MIT
   size: 756116
   timestamp: 1714483464368
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -6168,7 +6168,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
   sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
   md5: cf949d76148be1e2a534218d9c57df86
   depends:
@@ -6178,7 +6178,7 @@ packages:
   license_family: MIT
   size: 155435
   timestamp: 1714484319443
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -6189,7 +6189,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -6198,7 +6198,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -6215,7 +6215,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
   sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
   md5: b1781519a200ccbfcb4a1194005aa3ef
   depends:
@@ -6227,7 +6227,7 @@ packages:
   license_family: BSD
   size: 338459
   timestamp: 1694777084290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
   sha256: 4534c822511a052a72c2b070a05e5d8d6f3550f18ea00a33f9d8a9a92b4382cc
   md5: 82f24e7660831445a2183216e280a6a4
   depends:
@@ -6237,7 +6237,7 @@ packages:
   license_family: MIT
   size: 41464
   timestamp: 1676474474981
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
   sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
   md5: 320f40b75d93f3b96931c6d13c23946c
   depends:
@@ -6247,7 +6247,7 @@ packages:
   license_family: BSD
   size: 158902
   timestamp: 1714512129889
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
   sha256: e0dc6e119b224bb31ef34b6ba270ffadc181d38b698c5318de8df7a5d2c4ccbd
   md5: 992ccd756f09408f0b74dfb9852a8b7f
   depends:
@@ -6256,7 +6256,7 @@ packages:
   license_family: BSD
   size: 182381
   timestamp: 1676437963591
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
   sha256: 050b5fd4b28132d8102a7e6b40179894dc7f5e41f7ad9ee19211e67446c5740f
   md5: 3ae0b2f6baec708554648ddafa81b756
   depends:
@@ -6266,7 +6266,7 @@ packages:
   license_family: MIT
   size: 154386
   timestamp: 1684279992864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
   sha256: 8269c73b7a9c03b95a121e318d0468f35eecc016093620b0560f35238cc5df51
   md5: 2914bea0ae29315f998e1abac79ccaa8
   depends:
@@ -6279,7 +6279,7 @@ packages:
   license_family: BSD
   size: 30214
   timestamp: 1704206218108
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
   sha256: 68fb7d113dbf185b571343847e3dbefdbe7d0b9b5902f1f390bc2a6e33a3f8ee
   md5: a72ff718390a1fde0b208a43e6b9b655
   depends:
@@ -6301,7 +6301,7 @@ packages:
   license_family: PSF
   size: 11366001
   timestamp: 1713336740870
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
   sha256: 43279276850eb6e621812448cddc1093524cee0b7f8ed58b4600b68a4fb659f2
   md5: 5968b2b5c1f3cf5c8c8c9aaa4d8d66a2
   depends:
@@ -6311,7 +6311,7 @@ packages:
   license_family: BSD
   size: 19886
   timestamp: 1676425829787
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
   sha256: 3062a8254ca351b54f15bea85cc928a3ba4d879bb98ce97ece39a9f7eca215a5
   md5: 8f1565663abb34ad7fdd512e76da5532
   depends:
@@ -6321,7 +6321,7 @@ packages:
   license_family: MIT
   size: 68031
   timestamp: 1676481862508
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
   sha256: cdff5215c292fe59649ca40ca72f5d26da352760c1d6a56feba14eb13f7bbf61
   md5: e0f3f32b22135dfeaec277bc87183ca9
   depends:
@@ -6330,7 +6330,7 @@ packages:
   license_family: MIT
   size: 23328
   timestamp: 1676442709081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
   sha256: 3b173a25605d2aaacc57ec0e425f1d1c51327eb2521c8742a736e2c76069bc8d
   md5: 169f1c93a443f95a88665f3008623ce1
   depends:
@@ -6341,7 +6341,7 @@ packages:
   license_family: BSD
   size: 104882
   timestamp: 1676425142412
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
   sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
   md5: 527155127b9fada5e5c5c69a624674b9
   depends:
@@ -6353,7 +6353,7 @@ packages:
   license_family: Proprietary
   size: 187498166
   timestamp: 1699648376430
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
   sha256: cea59ae60da314caecf08edb9bcb03126c6dd35837c8184bceaa194decca3341
   md5: 30936b7263cf0171f7c86400f12ef184
   depends:
@@ -6365,7 +6365,7 @@ packages:
   license_family: BSD
   size: 49080
   timestamp: 1682975093455
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
   sha256: 5070ceb0a406b1b8b99e2ec58f5d224cbe16ec78109c46720bd182b509e05c6e
   md5: 34de1af5c639f2d06c6c8d99488e4226
   depends:
@@ -6380,7 +6380,7 @@ packages:
   license_family: BSD
   size: 196201
   timestamp: 1695058367111
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
   sha256: 6b4b27302e458fa527321c59be7c335d61f86da7501c4d141db20a72fad68b55
   md5: 7db9b12da1290bb2c2fc6ee52a945905
   depends:
@@ -6395,7 +6395,7 @@ packages:
   license_family: BSD
   size: 256371
   timestamp: 1695060425702
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
   sha256: 5422fc4dc6708279223027e45dd1ccffe4dc2feb93c60c8a683946a398c60a1c
   md5: 62d16437707dd382c21a9ed1d8b375dc
   depends:
@@ -6421,7 +6421,7 @@ packages:
   license_family: BSD
   size: 8304222
   timestamp: 1699543942441
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
   sha256: e940f9178ee2fa0a7c12873ae35ebea0074371653e5cfa1be8aa8d9271fd343b
   md5: 355d0835215911738a28010dfa6aa382
   depends:
@@ -6434,7 +6434,7 @@ packages:
   license_family: BSD
   size: 141785
   timestamp: 1698934346590
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
   sha256: 47dd00c0179f4eb29c70d0453d340f7f5332af326b3d51c64ca3bf6a14be8e7e
   md5: f66afe718bdb57667b03ebda4cb2ac7e
   depends:
@@ -6461,7 +6461,7 @@ packages:
   license_family: BSD
   size: 561655
   timestamp: 1699023338436
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
   sha256: 4ee863a1ff697274c642b3101f82b279a354e3f033a87505655039f89127bb41
   md5: bfaf19be6644ad2344e118aa0acccb13
   depends:
@@ -6474,7 +6474,7 @@ packages:
   license_family: BSD
   size: 189809
   timestamp: 1694617194065
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
   sha256: 90fb3f14c49da1397982eae21cd09e8d60d491d76f94c57590c56723fe6dc172
   md5: 46a523661fe5c1bce7b4213fd428c3de
   depends:
@@ -6483,7 +6483,7 @@ packages:
   license_family: BSD
   size: 16732
   timestamp: 1708532795328
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
   sha256: 5db3fd8b4d97e2a6232e2f7c62f1ce82ae3876326aed9f8c3ea656eda83e55da
   md5: 39c36df9dac13398e8a54497dcc14611
   depends:
@@ -6508,7 +6508,7 @@ packages:
   license_family: BSD
   size: 755697
   timestamp: 1690986137327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
   sha256: e040ebcab948325fbe17e4ab15be62e1fafa7bad225457e59764adb60eb40db5
   md5: 4d40a09df8cb74a9f044eab317436d67
   depends:
@@ -6518,7 +6518,7 @@ packages:
   license_family: BSD
   size: 27282
   timestamp: 1699456187703
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
   sha256: d3bd2a6614bb7e7f5ce3348d6674e71cce45cbde236beff32f0f08cd95a64ef0
   md5: e70f15643164f432d1df68635e7c322b
   depends:
@@ -6533,7 +6533,7 @@ packages:
   license_family: MIT
   size: 162691
   timestamp: 1696515822068
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
   sha256: 470fe9a0b3e196fa60d5550d8188f6074a207572fa0d353a4448d580872e7804
   md5: 6fdb8df0613fb2fb9f1732d335fa25f1
   depends:
@@ -6550,7 +6550,7 @@ packages:
   license_family: BSD
   size: 11053
   timestamp: 1708641901110
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
   sha256: 222c1711e7cf151e29077c7d4d86a865c9fd39615812d58a1daca6fd1b6bdfb5
   md5: 585bcd8bc3940a8a859f38ebafdcd77d
   depends:
@@ -6566,7 +6566,7 @@ packages:
   license_family: BSD
   size: 10723862
   timestamp: 1708641867155
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
   sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
   md5: ab07e2a27ac08afe3d0b4c0890b8486a
   depends:
@@ -6577,7 +6577,7 @@ packages:
   license: BSD 2-Clause
   size: 249316
   timestamp: 1630094024143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
   sha256: c8e066c2cb547914401ec29b7356914ca3cdf6ac37eead248fe0c41236a7838c
   md5: 5879739cc77497a518b2ebd55857183b
   depends:
@@ -6588,7 +6588,7 @@ packages:
   license_family: Apache
   size: 8118619
   timestamp: 1716319803768
-- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
   sha256: b2f5f50a1ddf811102636f3acebd76716c88ebb628754b91eda7a3a962adf26c
   md5: 712527b4d84c350dca4b67f511c04414
   depends:
@@ -6597,7 +6597,7 @@ packages:
   license_family: APACHE
   size: 39421
   timestamp: 1699371341381
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
   sha256: 432b8b7c4671878cbbe361e518544203f97bd2e4f24fa08cf65e8be583f25529
   md5: e62e7c668b080e0f6ce09fd548f69f7f
   depends:
@@ -6606,7 +6606,7 @@ packages:
   license_family: Apache
   size: 159066
   timestamp: 1710809127954
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
   sha256: 3ae55d8148580fc3f171c0fcc420488fbba05517cefd358fe013b45ec3594371
   md5: bfb42ed6826a1c8cded9539fc6e07029
   depends:
@@ -6657,7 +6657,7 @@ packages:
   license_family: BSD
   size: 16924671
   timestamp: 1709591125871
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
   sha256: b529eac4abff05f13760c51ad37adf24e744109a6fb30471b26dc1f6a1c23847
   md5: b690cc140a7866280131762a26c05f39
   depends:
@@ -6681,7 +6681,7 @@ packages:
   license_family: BSD
   size: 21902721
   timestamp: 1714073654508
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
   sha256: e77795e1af9bc27d45841d6b9c51e0e7da31e0eabaaffa99162245adc55d13a3
   md5: 14046398ac44f496bc9df300285ec586
   depends:
@@ -6690,7 +6690,7 @@ packages:
   license_family: BSD
   size: 267222
   timestamp: 1711137058994
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
   sha256: 6ca54ba8ce430caa8a1838b19869814d0b7fa3592a77f75298130983e635387b
   md5: e56c194e56d19dd8fd76f75a77f92c33
   depends:
@@ -6708,7 +6708,7 @@ packages:
   license_family: Other
   size: 1070844
   timestamp: 1714399290671
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
   sha256: 15001c7ee6cf6e0ef7afc2f313114f6103e7b6f641fac9a6899ee02d6537c822
   md5: 250ba95e77f5fcb3fe2aefa85157e859
   depends:
@@ -6719,7 +6719,7 @@ packages:
   license_family: MIT
   size: 3759346
   timestamp: 1715097175495
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
   sha256: e5f8cbfb5fc25d460a9117bfc5511959c5e86ccb193316033f87bd516e0c8881
   md5: 9f7e8b5eb651539386bb92c14e5c321b
   depends:
@@ -6728,7 +6728,7 @@ packages:
   license_family: MIT
   size: 37730
   timestamp: 1692205554840
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
   sha256: 6c5b53831273674361437fb546e08315fc11ca9275a174bca3887987e86ced5a
   md5: f8d91daf5173eb03157f484389adcdd4
   depends:
@@ -6737,7 +6737,7 @@ packages:
   license_family: Apache
   size: 122178
   timestamp: 1679591983138
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
   sha256: 546819d922b03f3a25ca9f98fd069d0588d481fc0603c6d74bd598fb6a93687f
   md5: 86c18e3e0b67ee099457475ed6caf2e6
   depends:
@@ -6749,7 +6749,7 @@ packages:
   license_family: BSD
   size: 751763
   timestamp: 1704404627180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
   sha256: ae06f0dfa2cfae51404afc6d6ad3a474a93015b5ba9a7d3ea24224b8e7547987
   md5: 3e19794c806cc3e84a3080a97c359b75
   depends:
@@ -6760,7 +6760,7 @@ packages:
   license_family: BSD
   size: 510466
   timestamp: 1679005998612
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
   sha256: d95c88d06f4f3f667bd9a39e5f18179e83b3cd4c115c06ce0fff390ff6d3a700
   md5: c6d00a8a4d89b1be99bfa3aff19d96b4
   depends:
@@ -6769,7 +6769,7 @@ packages:
   license_family: BSD
   size: 2134881
   timestamp: 1684280285492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
   sha256: 643a9a0eba1e2bd5980d21623d3b35188c24781ec251acc4d15714bd1ccb4c17
   md5: b3cda0394db05be6f0f6176abacb13f3
   depends:
@@ -6778,7 +6778,7 @@ packages:
   license_family: MIT
   size: 207985
   timestamp: 1678721438358
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
   sha256: 974c22de09078bf07c5db31fe12d8d89d6433508defc8237cbe52e08c69ed56b
   md5: 9cf10bfd49140a527cf4b1d912097e6d
   depends:
@@ -6788,7 +6788,7 @@ packages:
   license_family: BSD
   size: 36072
   timestamp: 1676426019064
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
   sha256: f43aca7a222c983c25c3e15f79c7e7e3c4909bb7839a1dd0ee327def81aa476e
   md5: 2b61f1cb7fec068c76ef0ff97c2c62b5
   depends:
@@ -6809,7 +6809,7 @@ packages:
   license_family: PSF
   size: 19811751
   timestamp: 1713545124922
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
   sha256: 2c61639b3bb56fc864c86558bceb7845b1731ac44bf1a94894172ea47a995bd4
   md5: 404805e547b4d50b5cd17e16bca87527
   depends:
@@ -6819,7 +6819,7 @@ packages:
   license_family: BSD
   size: 332043
   timestamp: 1716495838826
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
   sha256: 9acb33db60d9319595f52337cae3b88c2a2338cd66f1f9d8ae86d0a993c2067a
   md5: f4af8cf94d042b4dde487241bba1c457
   depends:
@@ -6828,7 +6828,7 @@ packages:
   license_family: BSD
   size: 279780
   timestamp: 1679500609851
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
   sha256: 48fe7373b012b51134b6b6ff67f18d2b4aae3a5c7700e4560ce002af7172f064
   md5: 0379cd17692152c12b662b0e4ea46b88
   depends:
@@ -6837,7 +6837,7 @@ packages:
   license_family: BSD
   size: 18008
   timestamp: 1683824373128
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
   sha256: 803274d986d0c4e3b5ec1018747ede86ef57137455b3e44a60e834717eafb92b
   md5: c9f134ddeff6fdf0373a45534ddb7079
   depends:
@@ -6846,7 +6846,7 @@ packages:
   license_family: MIT
   size: 273009
   timestamp: 1713974722039
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
   sha256: 6fbcba97c1dcb5157afd23f264c3cff069c7e4be5ea55980fc349eb8dc2cb49e
   md5: 8153e3f8b3283926bcf9403804a365f5
   depends:
@@ -6858,7 +6858,7 @@ packages:
   license_family: BSD
   size: 65050
   timestamp: 1711137009299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
   sha256: cd33dfee104dfbba4af38d06a09ccbae6a32e7c543afedab523303319ebb283d
   md5: 3dfc19af0306d80921e1403f1f551bba
   depends:
@@ -6868,7 +6868,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13679916
   timestamp: 1676423267293
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
   sha256: 102ff1d958209e3648bb49da3503cf752abab822011fdc4e12e88145c9e73772
   md5: 0553c2c381b6f5c836b23edc8c6db2ba
   depends:
@@ -6880,7 +6880,7 @@ packages:
   license_family: MIT
   size: 246689
   timestamp: 1677708371873
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
   sha256: bee5c4d0f41f06a9c0aac636885e36e8b81116aafde980f9ea48fdb64abb5567
   md5: 6c05a053240cb90765d6f8c2efdf905e
   depends:
@@ -6892,7 +6892,7 @@ packages:
   license_family: MIT
   size: 182228
   timestamp: 1698096268270
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
   sha256: ea39db411361d96545a04fb976940e9590147acb4ca9caacf7e8264780379347
   md5: b411b8be8e53e5059949dde02dd07faf
   depends:
@@ -6904,7 +6904,7 @@ packages:
   license_family: Other
   size: 565148
   timestamp: 1709319072176
-- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
   sha256: 47653b45a5f2d97b5bf0dbf0e620908880f9078da427eef69012effe3f19af67
   md5: 44e709ae67d89bccee2d4d46d358fee3
   depends:
@@ -6915,7 +6915,7 @@ packages:
   license_family: MIT
   size: 74493
   timestamp: 1699012356534
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.32.2-py311haa95532_0.tar.bz2
   sha256: 8b9586873f05e6ce14c4e067efc0a61effc8d163d5129447515234a4c43b5f43
   md5: 5fbd94c1f1e7c0a934eb8c9a00b34acb
   depends:
@@ -6931,7 +6931,7 @@ packages:
   license_family: Apache
   size: 122975
   timestamp: 1716903247759
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
   sha256: d6daaa6b45272819176e4aeb467ae00e3db43386548464a9993688f292709d40
   md5: 9fe721d7f7420c259df4f07d4503f654
   depends:
@@ -6941,7 +6941,7 @@ packages:
   license_family: MIT
   size: 9683
   timestamp: 1683077110211
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
   sha256: 6051860575f9448aea5799d74469c928cd7cdeeca1eb53657872262a77b1a7a8
   md5: 60e193eca497130034facd5fed168249
   depends:
@@ -6950,7 +6950,7 @@ packages:
   license_family: MIT
   size: 10094
   timestamp: 1683059114376
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
   sha256: ecd310461c1b45ab92ddf15539cea5a6e837860561c974d2d7393f9a7933f116
   md5: 1762fec2838763e904141167e18b0389
   depends:
@@ -6961,7 +6961,7 @@ packages:
   license_family: MIT
   size: 215600
   timestamp: 1698947891859
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/scipy-1.13.0-py311h9f229c6_0.tar.bz2
   sha256: 0042fa2dc2ec8c2181f28f5ee4f45087ea58dca7acc6b89c48f3ce6eac8f9bdd
   md5: 755c9767608b233b94ec3a67c8e0da4b
   depends:
@@ -6979,7 +6979,7 @@ packages:
   license_family: BSD
   size: 32418527
   timestamp: 1714081783418
-- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
   sha256: 6fd52bae6360fbc8135d72e0c1e4fd407769fa4d0f4b59356e7aed3e000eb339
   md5: 49fd52885250da8aab17ed72e2e18b81
   depends:
@@ -6988,7 +6988,7 @@ packages:
   license_family: BSD
   size: 88901
   timestamp: 1699371435766
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
   sha256: a2ec4690bc07be9e7f3ad8e3003803eb4304a434d3f139633e2817318a9f7b20
   md5: dd2d225219924fc5c36598c919541271
   depends:
@@ -6997,7 +6997,7 @@ packages:
   license_family: MIT
   size: 1593050
   timestamp: 1715025622141
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
   sha256: 5d1b7e14dc04816692de0f8518ea8fcbefb26ab61cec83f96f2c44c1bee67fab
   md5: 505d2a70a875b5082dc857aa4dfab0d4
   depends:
@@ -7006,7 +7006,7 @@ packages:
   license_family: Other
   size: 18830
   timestamp: 1705431395254
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
   sha256: 5ff3b4ac3fbce4dd67a87856c04698d0397deb0ac288ff4e7eb02fbab57f1253
   md5: 0ca650a7001c6650809d3361de8cb005
   depends:
@@ -7015,7 +7015,7 @@ packages:
   license_family: MIT
   size: 89590
   timestamp: 1696347858925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
   sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
   md5: 833b93a2daade3407898f15588945d83
   depends:
@@ -7025,7 +7025,7 @@ packages:
   license_family: Other
   size: 1440481
   timestamp: 1714488344682
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -7035,7 +7035,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
   sha256: 78d89b50a29fbeb19a562f5dad95615e3f192bb4f3b86cd6ea75f2f825418232
   md5: 4a4040df560ea47704e0898c4c015808
   depends:
@@ -7046,7 +7046,7 @@ packages:
   license_family: BSD
   size: 38069
   timestamp: 1678228553220
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
   sha256: 70a3cc4a4e81a6421bc19cd410d1d6064aadb2b1cce38b020f85e5346716d8e7
   md5: 32a9a2539579a3d522dce3b5cb4f987b
   depends:
@@ -7056,7 +7056,7 @@ packages:
   license_family: BSD
   size: 49495
   timestamp: 1676425411739
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
   sha256: 0a95736cfd0bb25fc201cd6be4a2450ea8fc30eeb349d861812675b84c94fa74
   md5: a8a9fb30c6dd8e7a16d5dcd2333c3c49
   depends:
@@ -7067,7 +7067,7 @@ packages:
   license_family: BSD
   size: 3844176
   timestamp: 1714770894235
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
   sha256: 4febf30c11674711b86c8c10da46a5e1613071388da999210912a31508864add
   md5: 1c109fc1112ea1f5f377bdf0d18ba75f
   depends:
@@ -7078,7 +7078,7 @@ packages:
   license_family: Apache
   size: 895633
   timestamp: 1696937216859
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
   sha256: 973dc7991dd5976ce2d27a94739712cac4d31f2d2958fbf23adb844f5ac999c8
   md5: ca74b36907b3f4f8a51bd5b2e4d8220b
   depends:
@@ -7090,7 +7090,7 @@ packages:
   license_family: MOZILLA
   size: 186541
   timestamp: 1716396206048
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
   sha256: e8c77efe880546252f244f995cbed5967809555127b4f818b97455d434b23415
   md5: 7397ac07045115960ebd8dec95326a7a
   depends:
@@ -7099,7 +7099,7 @@ packages:
   license_family: BSD
   size: 270819
   timestamp: 1676423321499
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
   sha256: ab3cce654f1e94793fff0cb03b750d9b20cdbf099263b1906c3c5eaf8b347ab6
   md5: c68ffc771312afb6f88b94c24d2bb689
   depends:
@@ -7109,7 +7109,7 @@ packages:
   license_family: PSF
   size: 9706
   timestamp: 1715268972001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
   sha256: 4089efea1753ebe2f6617b46cc368738f285b1d816d4a4f01ba71524f46851b4
   md5: 7f610528ecd0b317180efa2058c32323
   depends:
@@ -7118,7 +7118,7 @@ packages:
   license_family: PSF
   size: 75414
   timestamp: 1715268958140
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
   sha256: d091897f05318c22ca31028370f25355065999078f7db6f88ab27bf4cb030ec8
   md5: 1776502c1cfb351554eeda6cddaf255f
   depends:
@@ -7127,7 +7127,7 @@ packages:
   license_family: MIT
   size: 11588
   timestamp: 1676457729096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
   sha256: c16498f8238cc331618720d078b87995eceb6bbf20268a7a4e8efbf7b5859a9a
   md5: 770432c0ca1ab9d99ffe95e51d3a3e74
   depends:
@@ -7138,7 +7138,7 @@ packages:
   license_family: Apache
   size: 517433
   timestamp: 1713213261710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
   sha256: 3009bd4e7e8126309e606c81cb75d4b8d4fbb2bceac10ec43f7eb6eaaf717ac2
   md5: ee6e87af42008a762d3531771c1a2b18
   depends:
@@ -7154,7 +7154,7 @@ packages:
   license_family: MIT
   size: 210034
   timestamp: 1715636431813
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
   sha256: 906048f3b1dc326b367a08edc91816ff523b5f06cd45d985b4dbb7cfe8017559
   md5: e509c495aaa92d767d554cd43a990ee5
   depends:
@@ -7163,12 +7163,12 @@ packages:
   license_family: BSD
   size: 8900
   timestamp: 1715797316229
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
   sha256: ab224d078734a23527716388ddffc034d18254843881d0fc068c2efa35bacfe1
   md5: 73f5831d017e5572330d2459844718f3
   size: 2246565
   timestamp: 1715797302913
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
   sha256: 24ea3d3e0cb98d0d246338dbb4562b67967bb32002e3704e495a5c863476e831
   md5: c7b9cdbe87b3c9720aeca1164a0fd6df
   depends:
@@ -7177,7 +7177,7 @@ packages:
   license_family: BSD
   size: 26181
   timestamp: 1676424437003
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
   sha256: 92d27e41ce34387e59acb47572fcb2e92c4defaeadafd11ce190226022023e69
   md5: f1bf142d852987acbe4b0bc94e87d958
   depends:
@@ -7186,7 +7186,7 @@ packages:
   license_family: Apache
   size: 145306
   timestamp: 1715878654770
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
   sha256: 1b086d1b079fdb2f148c7dd82658f2b7f283c88f286e1216c0f1237319039b0f
   md5: 299e87f151a549d86a48bf24df15c607
   depends:
@@ -7195,7 +7195,7 @@ packages:
   license_family: MIT
   size: 168041
   timestamp: 1714717238470
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
   sha256: 17fadf35aa8917c107e7b369e9364ac7c09537776e7943d37e225e14b7026c94
   md5: 0e67c3b9624540581b894b11267a837b
   depends:
@@ -7203,13 +7203,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 10197
   timestamp: 1676425485716
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
   sha256: b849b368e27920838fe40a512b102879693a55cb187dd1c8d3a83fa8c05a8054
   md5: 7b1f6e9c71906a93039b3446b99a5498
   depends:
@@ -7218,7 +7218,7 @@ packages:
   license_family: BSD
   size: 55114
   timestamp: 1676434863173
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
   sha256: 344a5276a9928638dcde054dfe4e87c8cb40bd2d4d356378b9ab2f863ca62e4b
   md5: fe471fd8b5a3d77be6fa5dbf9b99dafb
   depends:
@@ -7228,7 +7228,7 @@ packages:
   license_family: GPL2
   size: 1432281
   timestamp: 1714515119689
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -7237,7 +7237,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
   sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
   md5: e5aed81295b61b6d1eb62830799a0297
   depends:
@@ -7248,7 +7248,7 @@ packages:
   license_family: Other
   size: 9125184
   timestamp: 1705602328351
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
   sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
   md5: f295b54ab59f5b8658e2a322ac6aa721
   depends:
@@ -7258,7 +7258,7 @@ packages:
   license_family: Other
   size: 162161
   timestamp: 1714514792081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
   sha256: b2ff66b7f6efa0831f939e57e562c244332b690af08818a540d1a97fa07d8525
   md5: e548d528873d9a0006a36714cf36462a
   depends:

--- a/portfolio_optimizer/pixi.toml
+++ b/portfolio_optimizer/pixi.toml
@@ -1,0 +1,33 @@
+[workspace]
+name = "portfolio_optimizer"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2019-11-12"
+maintainers = ["philippjfr"]
+categories = ["Finance", "Featured"]
+labels = ["panel", "hvplot", "holoviews", "bokeh"]
+description = "Portfolio Optimizer Application By Using The Efficient Frontier"
+
+[dependencies]
+python = "3.11.*"
+notebook = "<7"
+bokeh = ">=3.4.0"
+holoviews = ">=1.18.3"
+hvplot = ">=0.9.2"
+panel = ">=1.4.2"
+scipy = ">1.12.0"
+pip = "*"
+setuptools = "*"
+wheel = "*"
+
+[target.osx-64.dependencies]
+libgfortran = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks]
+dashboard = "panel serve --rest-session-info --session-history -1 portfolio.py --show"
+notebook = "jupyter notebook portfolio_optimizer.ipynb"

--- a/portfolio_optimizer/pixi.toml
+++ b/portfolio_optimizer/pixi.toml
@@ -18,15 +18,15 @@ holoviews = ">=1.18.3"
 hvplot = ">=0.9.2"
 panel = ">=1.4.2"
 scipy = ">1.12.0"
-pip = "*"
-setuptools = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+setuptools = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks]
 dashboard = "panel serve --rest-session-info --session-history -1 portfolio.py --show"

--- a/portfolio_optimizer/pixi.toml
+++ b/portfolio_optimizer/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "portfolio_optimizer"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/seattle_lidar/pixi.lock
+++ b/seattle_lidar/pixi.lock
@@ -8,7 +8,6 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
-    - url: https://conda.anaconda.org/nodefaults/
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2

--- a/seattle_lidar/pixi.lock
+++ b/seattle_lidar/pixi.lock
@@ -1,0 +1,11854 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/nodefaults/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.11.2-py311h2dc5d0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311h9ecbd09_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.8.0-hb88c0a9_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.8.0-hecf86a2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.10.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.0-hf42f96a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.0-h1ffe551_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.9.1-hab05fe4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.15.2-hdeadb07_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.11.0-h7bd072d_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.7.1-h3a84f74_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.1-hf42f96a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.2-hf42f96a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.29.4-h21d7256_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.449-h1a02111_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.14.0-h5cfcd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.10.0-h113e628_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.13.0-h3cf044e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.8.0-h736e048_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.12.0-ha633028_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-hef167b5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hfdbb021_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.3-heb4867d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hebfffa5_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.4-py311h9f3472d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.1-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.0.0-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.8-py311hfdbb021_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.55.0-py311h2dc5d0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.10-h36c2ea0_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.5.0-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.42.12-hb9ae30d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphviz-12.0.0-hba01fac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk2-2.24.33-h6470451_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hda332d3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.4-nompi_h2d575fe_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.7-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_h5888daf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-18.0.0-h3b997a5_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-18.0.0-h5888daf_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-18.0.0-h5888daf_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-18.0.0-h5c8f2c3_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-hd3e95f3_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.2-h2ff4ddf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.31.0-h804f50b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.31.0-h0121fbd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.67.1-hc2c308b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h2564987_115.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-18.0.0-h6bd9018_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hbbce691_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-hc0ffecb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.21.0-h0e7cc3e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-he137b08_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-hb346dea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.11.2-h6991a6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.43.0-py311h9c9ff8c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.3-py311h2cbdf9a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py311h2dc5d0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.2-py311h2b939e6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.0-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.1.0-py311h2dc5d0c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.2-nompi_py311h7c29e4f_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.60.0-py311h4bc866e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.14.0-py311h7db5c69_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.0.2-py311h71ddf71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.3-he039a57_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py311h7db5c69_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.54.0-h4c5309f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.0.0-py311h49e9ac3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.5.0-h12925eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.2.0-py311h9ecbd09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-18.0.0-py311h38be061_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-18.0.0-py311h4854187_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.0-py311h0f98d5a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.10-hc5c86c4_3_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py311h7deb3e3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h77b4e00_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.21.0-py311h9e33e62_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.9-h0fd0ee4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py311he9a78e4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.47.0-h9eae976_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.1-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.16.0-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-he73a12e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.10-h4f16b4b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.17.2-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py311hbc35293_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.15.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.36-pyge310_1234567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.5.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-xarray-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.3.3-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.29.0-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.28-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.2.6-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-graphviz-0.20.3-pyhe28f650_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.5.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/spectate-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.1.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.18.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_0.conda
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.15.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.36-pyge310_1234567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.5.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-xarray-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.3.3-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.29.0-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.28-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.2.6-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-graphviz-0.20.3-pyhe28f650_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.5.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/spectate-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.1.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.18.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.11.2-py311ha3cf9ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h3336109_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/atk-1.0-2.38.0-h4bec284_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.8.0-hb1b2711_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.8.0-h1c3498a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.10.3-h6e16a3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.3.0-h1c3498a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.5.0-heedde58_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.9.1-h0c96e2d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.15.2-h789f5c1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.11.0-h00ab244_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.7.1-h704940e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.2.1-h1c3498a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.2.2-h1c3498a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.29.4-h44c5c52_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.449-h7bf9075_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.14.0-h9a36307_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.10.0-ha4e2ba9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.13.0-h3d2f5f1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.8.0-h1ccc5ac_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-files-datalake-cpp-12.12.0-h86941f0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.6-h7d75f6d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hd89902b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.3-hf13058a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.8.30-h8857fd0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h37bd5c4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.1-py311h137bacd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cftime-1.6.4-py311h0034819_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.1-py311h4e34fa0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.0.0-py311h3336109_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.8-py311hc356e98_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.15.0-h37eeddb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.55.0-py311ha3cf9ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fribidi-1.0.10-hbcb3906_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/frozenlist-1.5.0-py311h1314207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdk-pixbuf-2.42.12-ha587570_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hac325c4_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h2790a97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/graphite2-1.3.13-h73e2aa4_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/graphviz-12.0.0-he14ced1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gtk2-2.24.33-h2c15c3c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gts-0.7.6-h53e17e3_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-9.0.0-h098a298_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.4-nompi_h1607680_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.7-py311hf2f7c97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240722.0-cxx17_hac325c4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-18.0.0-hd4c0275_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-18.0.0-h240833e_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-18.0.0-h240833e_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-18.0.0-h5c0c8cd_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-25_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-25_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.10.1-h58e7537_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.3-hf95d169_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.22-h00291cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.4-h240833e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgd-2.3.3-h2e77e4f_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.82.2-hb6ef654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.31.0-hd00c612_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.31.0-h3f2b517_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.67.1-he6e0b18_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-hdfe23c8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-25_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-hc8e404f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.2-nompi_h976d569_115.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.64.0-hc7306c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_hbf64a52_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-18.0.0-hc957f30_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.44-h4b8f8c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-5.28.2-h8b30cf6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2024.07.02-hd530cb8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/librsvg-2.58.4-h2682814_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.0-h2f8c449_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.21.0-h75589b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-h583c2ba_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.5-h495214b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzip-1.11.2-h31df5bb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.3-hf78d878_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.43.0-py311h25b8078_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-4.3.3-py311h12b7ed1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.2-py311h8b4e8a7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.2-py311h8b21175_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.1.0-py311hf2f7c97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/multidict-6.1.0-py311h1cc1194_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/netcdf4-1.7.2-nompi_py311h62486fc_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.60.0-py311h0e5bd6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numcodecs-0.14.0-py311hcf53e2f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.0.2-py311h394b0bb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hd471939_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.3-h5cd248e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.3-py311haeb46be_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pango-1.54.0-h115fe74_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.44-h7634a1b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.0.0-py311h1f68098_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.4-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.5.0-h70d2bda_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/propcache-0.2.0-py311h3336109_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.0-py311h1314207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-18.0.0-py311h6eed73b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-18.0.0-py311he02522f_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.3.1-py311hd6939f8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.3.1-py311hd6939f8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.7.0-py311h50e4d0a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.10-ha513fb2_3_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311h3336109_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.2.0-py311h4d3da15_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2024.07.02-h2fb0a26_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.21.0-py311h3b9c2be_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.1-py311hed734c1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-he1e6707_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.47.0-h6285a30_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.1-py311h3336109_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-15.1.0-py311h1314207_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.16.0-py311h3336109_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h00291cd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yarl-1.17.2-py311h4d7f069_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h7130eaa_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-hd23fc13_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py311hdf6fcd6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.15.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.36-pyge310_1234567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.5.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-xarray-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.3.3-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.29.0-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.28-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.2.6-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-graphviz-0.20.3-pyhe28f650_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.5.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/spectate-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.1.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.18.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.11.2-py311h4921393_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311h460d6c5_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/atk-1.0-2.38.0-hd03087b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.8.0-h9b725a8_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.8.0-h5d7ee29_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.10.3-h5505292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.0-h5d7ee29_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.5.0-h13ead76_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.9.1-hf483d09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.15.2-h39f8ad8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.11.0-h68a0d7e_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.7.1-h840aca7_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.1-h5d7ee29_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.2-h5d7ee29_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.29.4-h6832833_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.449-h8f08b23_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.14.0-hd50102c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.10.0-hc602bab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.13.0-h7585a09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.8.0-h9ca1f76_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.12.0-hcdd55da_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h5499902_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311h3f08180_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.3-h5505292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hb4a6bf7_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py311h3a79f62_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.4-py311h0f07fe1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.1-py311h210dab8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.0.0-py311h460d6c5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.8-py311h155a34a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.15.0-h1383a14_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.55.0-py311h4921393_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.10-h27ca646_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.5.0-py311hae2e1ce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.42.12-h7ddc832_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-hebf3989_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphviz-12.0.0-hbf8cc41_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gtk2-2.24.33-h91d5085_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gts-0.7.6-he42f4ea_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-9.0.0-h997cde5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.4-nompi_ha698983_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py311h267d04e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.7-py311h2c37856_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_hf9b8971_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-18.0.0-h2409f62_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-18.0.0-h286801f_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-18.0.0-h286801f_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-18.0.0-h6a6e5c5_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-25_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-25_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.10.1-h13a7ad3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.3-ha82da77_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.22-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgd-2.3.3-hac1b3a8_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.82.2-h07bd6cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.31.0-h8d8be31_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.31.0-h7081f7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.67.1-hc70892a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.22.5-h8414b35_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-25_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnetcdf-4.9.2-nompi_h853a48d_115.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-18.0.0-hda0ea68_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.28.2-h8f0b736_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2024.07.02-h2348fd5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.58.4-h40956f1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.47.0-hbaaea75_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.21.0-h64651cc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-hfce79cd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-h1a8c8d9_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.13.5-hbbdcc80_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzip-1.11.2-h1336266_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.3-hb52a8e5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.43.0-py311hc367efa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-4.3.3-py311hebe0b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py311h56c23cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.9.2-py311hbe3227e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.0-py311h2c37856_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.1.0-py311h30e7462_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/netcdf4-1.7.2-nompi_py311hd13e3db_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.60.0-py311h9506ed5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numcodecs-0.14.0-py311hca32420_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.0.2-py311h6de8079_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h39f12f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.3-h121fd32_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py311h9cb3ce9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.54.0-h9ee27a3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-h297a79d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.0.0-py311h3894ae9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.4-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.5.0-h61a8e3e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/propcache-0.2.0-py311h460d6c5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py311hae2e1ce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-18.0.0-py311ha1ab1f8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-18.0.0-py311he04fa90_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.3.1-py311h09e6bbd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.3.1-py311h09e6bbd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.0-py311hb4b81e0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.10-hc51fdd5_3_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h460d6c5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.0-py311h730b646_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2024.07.02-hcd0e937_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.21.0-py311h3ff9189_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.1-py311hf1db568_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.47.0-hcd14bea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.1-py311h460d6c5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-15.1.0-py311hae2e1ce_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.16.0-py311h460d6c5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.17.2-py311h917b07b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-hc1bb282_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py311ha60cc69_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.15.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.36-pyge310_1234567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.10-py311hd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.11.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.5.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/intake-xarray-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.3.3-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.29.0-pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.28-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh5737063_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.2.6-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-graphviz-0.20.3-pyhe28f650_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.5.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/spectate-1.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.1.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.18.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.11.2-py311h5082efb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311he736701_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.8.0-h6c5491b_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.8.0-hb414858_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.10.3-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.3.0-hb414858_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.5.0-hab6af6e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.9.1-hab0f966_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.15.2-hef77f12_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.11.0-hbfeb708_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.7.1-h6108ab3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.2.1-hb414858_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.2.2-hb414858_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.29.4-h1e7036a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.449-h922649a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.6-h85f69ea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311hda3d55a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.34.3-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h32b962e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cftime-1.6.4-py311h0a17f05_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.1-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.0.0-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.8-py311hda3d55a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.15.0-h765892d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.55.0-py311h5082efb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fribidi-1.0.10-h8d14728_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.5.0-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/getopt-win32-0.1-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-h63175ca_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/graphviz-12.0.0-hb01754f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gts-0.7.6-h6b5321d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-9.0.0-h2bedf89_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.4-nompi_hd5d9e70_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/icu-75.1-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.7-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_he0c23c2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-18.0.0-h7b593d6_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-18.0.0-hac47afa_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-18.0.0-hac47afa_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-18.0.0-hcd1cebd_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.22-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.4-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-14.2.0-h1383e82_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgd-2.3.3-h085315d_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.82.2-h7025463_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-14.2.0-h1383e82_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.31.0-h07d40e7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.31.0-he5eb982_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.67.1-h7aa3b8a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_he239ae6_115.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-18.0.0-h59f2d37_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.28.2-hcaed137_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2024.07.02-h4eb7d71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.0-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.21.0-hbe90ef8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hfc51747_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-h82a8f57_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.5-h442d1da_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzip-1.11.2-h3135430_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.43.0-py311h7deaa30_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-4.3.3-py311h8b5e962_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py311h5082efb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.2-py311h8f1b1e4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.0-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.1.0-py311h5082efb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/netcdf4-1.7.2-nompi_py311hc43f1c8_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.60.0-py311h0673bce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numcodecs-0.14.0-py311hcf9f919_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.0.2-py311h35ffc71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.4.0-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.3-h34659fe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py311hcf9f919_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pango-1.54.0-hbb871f6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.0.0-py311h4fbf6a9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.5.0-hd9569ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/propcache-0.2.0-py311he736701_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.0.0-py311h1ea47a8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.0.0-py311hdea38fa_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.7.0-py311h90dcb63_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.10-hce54a09_3_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-307-py311hda3d55a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.14-py311hda3d55a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.2.0-py311h484c95c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2024.07.02-hd3b24a8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.21.0-py311h533ab2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py311hf16d85f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.47.0-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.7.0-h91493d7_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.1-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-15.1.0-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34433-he29a5d6_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hdffcdeb_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.16.0-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libice-1.1.1-h0e40799_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libsm-1.2.4-h0e40799_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libx11-1.8.10-hf48077a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-h0e40799_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.5-h0e40799_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxext-1.3.6-h0e40799_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxpm-3.5.17-h0e40799_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxt-1.3.1-h0e40799_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-xorgproto-2024.1-h0e40799_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yarl-1.17.2-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py311h53056dc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  license: None
+  size: 2562
+  timestamp: 1578324546067
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23621
+  timestamp: 1650670423406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.11.2-py311h2dc5d0c_0.conda
+  sha256: f5c9f060394a8af6b3d46754d056cf72df7968e296a71138b69a64367688880d
+  md5: 3911c41f7d01402fd1b54c2a32d9cd1c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aiohappyeyeballs >=2.3.0
+  - aiosignal >=1.1.2
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - libgcc >=13
+  - multidict >=4.5,<7.0
+  - propcache >=0.2.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yarl >=1.17.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  size: 910812
+  timestamp: 1731703417329
+- conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311h9ecbd09_5.conda
+  sha256: d1af1fbcb698c2e07b0d1d2b98384dd6021fa55c8bcb920e3652e0b0c393881b
+  md5: 18143eab7fcd6662c604b85850f0db1e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.0.1
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 35025
+  timestamp: 1725356735679
+- conda: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
+  sha256: df682395d05050cd1222740a42a551281210726a67447e5258968dd55854302e
+  md5: f730d54ba9cd543666d7220c9f7ed563
+  depends:
+  - libgcc-ng >=12
+  - libglib >=2.80.0,<3.0a0
+  - libstdcxx-ng >=12
+  constrains:
+  - atk-1.0 2.38.0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 355900
+  timestamp: 1713896169874
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.8.0-hb88c0a9_10.conda
+  sha256: d2837a84e6bd7d993a83e79f9e240e1465e375f3d57149ea5b1927c6a4133bcc
+  md5: 409b7ee6d3473cc62bda7280f6ac20d0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 107163
+  timestamp: 1731733534767
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.8.0-hecf86a2_2.conda
+  sha256: 220a37955c120bf2f565fbd5320a82fc4c8b550b2449294bc0509c296cfcb9fa
+  md5: c54459d686ad9d0502823cacff7e8423
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - libgcc >=13
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 47477
+  timestamp: 1731678510949
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.10.3-hb9d3cd8_0.conda
+  sha256: 90bd2ff40b65acb62f11e2500ee7b7e85ac77d2e332429002f4c1da949bec27f
+  md5: ff3653946d34a6a6ba10babb139d96ef
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 237137
+  timestamp: 1731567278052
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.0-hf42f96a_2.conda
+  sha256: 210ba4fff1c9500fe02de1dae311ce723bfa313a2d21b72accd745f736f56fce
+  md5: 257f4ae92fe11bd8436315c86468c39b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 19034
+  timestamp: 1731678703956
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.0-h1ffe551_7.conda
+  sha256: 3b780d6483baa889e8df5aa66ab3c439a9c81331cf2a4799e373f4174768ddd9
+  md5: 7cce4dfab184f4bbdfc160789251b3c5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 53500
+  timestamp: 1731714597524
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.9.1-hab05fe4_2.conda
+  sha256: 90a325b6f5371dd2203b643de646967fe57a4bcbbee8c91086abbf9dd733d59a
+  md5: fb409f7053fa3dbbdf6eb41045a87795
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-compression >=0.3.0,<0.3.1.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 196945
+  timestamp: 1731714483279
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.15.2-hdeadb07_2.conda
+  sha256: 1636136a5d882b4aaa13ea8b7de8cf07038a6878872e3c434df9daf478cee594
+  md5: 461a1eaa075fd391add91bcffc9de0c1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - libgcc >=13
+  - s2n >=1.5.9,<1.5.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 159368
+  timestamp: 1731702542973
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.11.0-h7bd072d_8.conda
+  sha256: 51d3d87a47c642096e2ce389a169aec2e26958042e9130857552a12d65a19045
+  md5: 0e9d67838114c0dbd267a9311268b331
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 194447
+  timestamp: 1731734668760
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.7.1-h3a84f74_3.conda
+  sha256: 274c9ec3c173a2979b949ccc10a6013673c4391502a4a71e07070d6c50eabc60
+  md5: e7a54821aaa774cfd64efcd45114a4d7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - libgcc >=13
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 113837
+  timestamp: 1731745115080
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.1-hf42f96a_1.conda
+  sha256: f6e38c79b124c34edb048c28ec58fdfc4ea8f7a218dc493195afbada48ba063b
+  md5: bbdd20fb1994a9f0ba98078fcb6c12ab
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 55738
+  timestamp: 1731687063424
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.2-hf42f96a_1.conda
+  sha256: da802ace5448481c968cfec7e7a4f79f686f42df9de8e3f78c09a925c2882a79
+  md5: d908d43d87429be24edfb20e96543c20
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 72744
+  timestamp: 1731687193373
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.29.4-h21d7256_1.conda
+  sha256: 0de8dc3a6a9aab74049d85d407d204623a638ade4221a428cef4d91d25d41ef5
+  md5: 963a310ba64fd6a113eb4f7fcf89f935
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-mqtt >=0.11.0,<0.11.1.0a0
+  - aws-c-s3 >=0.7.1,<0.7.2.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 354101
+  timestamp: 1731787070984
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.449-h1a02111_2.conda
+  sha256: 697d0055c4838f882d029d05baf432fb4d6fbebd92d60edfadeb10fea66f1755
+  md5: 109ff9aa7347ca004a3f496a5160cdb9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - aws-crt-cpp >=0.29.4,<0.29.5.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2951572
+  timestamp: 1731927266611
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.14.0-h5cfcd09_0.conda
+  sha256: fe07debdb089a3db17f40a7f20d283d75284bb4fc269ef727b8ba6fc93f7cb5a
+  md5: 0a8838771cc2e985cd295e01ae83baf1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 345117
+  timestamp: 1728053909574
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.10.0-h113e628_0.conda
+  sha256: 286b31616c191486626cb49e9ceb5920d29394b9e913c23adb7eb637629ba4de
+  md5: 73f73f60854f325a55f1d31459f2ab73
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 232351
+  timestamp: 1728486729511
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.13.0-h3cf044e_1.conda
+  sha256: 2606260e5379eed255bcdc6adc39b93fb31477337bcd911c121fc43cd29bf394
+  md5: 7eb66060455c7a47d9dcdbfa9f46579b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  size: 549342
+  timestamp: 1728578123088
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.8.0-h736e048_1.conda
+  sha256: 273475f002b091b66ce7366da04bf164c3732c03f8692ab2ee2d23335b6a82ba
+  md5: 13de36be8de3ae3f05ba127631599213
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.12.7,<2.14.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 149312
+  timestamp: 1728563338704
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.12.0-ha633028_1.conda
+  sha256: 5371e4f3f920933bb89b926a85a67f24388227419abd6e99f6086481e5e8d5f2
+  md5: 7c1980f89dd41b097549782121a73490
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  size: 287366
+  timestamp: 1728729530295
+- conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-hef167b5_0.conda
+  sha256: 6cc260f9c6d32c5e728a2099a52fdd7ee69a782fff7b400d0606fcd32e0f5fd1
+  md5: 54fe76ab3d0189acaef95156874db7f9
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48842
+  timestamp: 1719266029046
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_2.conda
+  sha256: fcb0b5b28ba7492093e54f3184435144e074dfceab27ac8e6a9457e736565b0b
+  md5: 98514fe74548d768907ce7a13f680e8f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli-bin 1.1.0 hb9d3cd8_2
+  - libbrotlidec 1.1.0 hb9d3cd8_2
+  - libbrotlienc 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 19264
+  timestamp: 1725267697072
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_2.conda
+  sha256: 261364d7445513b9a4debc345650fad13c627029bfc800655a266bf1e375bc65
+  md5: c63b5e52939e795ba8d26e35d767a843
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlidec 1.1.0 hb9d3cd8_2
+  - libbrotlienc 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 18881
+  timestamp: 1725267688731
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hfdbb021_2.conda
+  sha256: 949913bbd1f74d1af202d3e4bff2e0a4e792ec00271dc4dd08641d4221aa2e12
+  md5: d21daab070d76490cb39a8f1d1729d79
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  license: MIT
+  license_family: MIT
+  size: 350367
+  timestamp: 1725267768486
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+  sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
+  md5: 62ee74e96c5ebb0af99386de58cf9553
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 252783
+  timestamp: 1720974456583
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.3-heb4867d_0.conda
+  sha256: 1015d731c05ef7de298834833d680b08dea58980b907f644345bd457f9498c99
+  md5: 09a6c610d002e54e18353c06ef61a253
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 205575
+  timestamp: 1731181837907
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
+  sha256: afee721baa6d988e27fef1832f68d6f32ac8cc99cdf6015732224c2841a09cea
+  md5: c27d1c142233b5bc9ca570c6e2e0c244
+  license: ISC
+  size: 159003
+  timestamp: 1725018903918
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hebfffa5_3.conda
+  sha256: aee5b9e6ef71cdfb2aee9beae3ea91910ca761c01c0ef32052e3f94a252fa173
+  md5: fceaedf1cdbcb02df9699a0d9b005292
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libgcc-ng >=12
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.2,<1.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 983604
+  timestamp: 1721138900054
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
+  sha256: bc47aa39c8254e9e487b8bcd74cfa3b4a3de3648869eb1a0b89905986b668e35
+  md5: 55553ecd5328336368db611f350b7039
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 302115
+  timestamp: 1725560701719
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.4-py311h9f3472d_1.conda
+  sha256: 8fa32d106c8757eac936105a5a14eb2eac0c66398cfa954855cb0bd220f003a5
+  md5: 2c3c4f115d28ed9e001a271d5d8585aa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 249930
+  timestamp: 1725400597307
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.1-py311hd18a35c_0.conda
+  sha256: 08be6120dc9369f07858677dde2a8474644cc7ec2ae146b39a6953aadc536dfd
+  md5: 351cb68d2081e249069748b6e60b3cd2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 278209
+  timestamp: 1731428493722
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.0.0-py311h9ecbd09_1.conda
+  sha256: 42544e13dc4bb018cec0579ad7a6158c1f296e32fa0995ffd8abb116734dc427
+  md5: 765c19c0b6df9c143ac8f959d1a1a238
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 393854
+  timestamp: 1728335173137
+- conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.8-py311hfdbb021_0.conda
+  sha256: 4a326b01252ebae38a84cb8c37470283ebb37fd1db71469e0e23ca253a0fbe83
+  md5: 698c1e95b2af120f318a0bdec35552b6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2532053
+  timestamp: 1731045057237
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
+  sha256: 7093aa19d6df5ccb6ca50329ef8510c6acb6b0d8001191909397368b65b02113
+  md5: 8f5b0b297b59e1ac160ad4beec99dbee
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freetype >=2.12.1,<3.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libgcc >=13
+  - libuuid >=2.38.1,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 265599
+  timestamp: 1730283881107
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.55.0-py311h2dc5d0c_0.conda
+  sha256: b959bbe11eda7f4443e635a95347de40d834484f7ad971a0d0953f327d2d86f8
+  md5: 8b056dbb53df32a9dbf1718a04dc4138
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli
+  - libgcc >=13
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2885790
+  timestamp: 1731643615522
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+  sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
+  md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 634972
+  timestamp: 1694615932610
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.10-h36c2ea0_0.tar.bz2
+  sha256: 5d7b6c0ee7743ba41399e9e05a58ccc1cfc903942e49ff6f677f6e423ea7a627
+  md5: ac7bc6a654f8f41b352b38f4051135f8
+  depends:
+  - libgcc-ng >=7.5.0
+  license: LGPL-2.1
+  size: 114383
+  timestamp: 1604416621168
+- conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.5.0-py311h9ecbd09_0.conda
+  sha256: 5bde4e41dd1bdf42488f1b86039f38914e87f4a6b46c15224c217651f964de8b
+  md5: 75424a18fb275a18b288c099b869c3bc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 60988
+  timestamp: 1729699558841
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.42.12-hb9ae30d_0.conda
+  sha256: d5283b95a8d49dcd88d29b360d8b38694aaa905d968d156d72ab71d32b38facb
+  md5: 201db6c2d9a3c5e46573ac4cb2e92f4f
+  depends:
+  - libgcc-ng >=12
+  - libglib >=2.80.2,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 528149
+  timestamp: 1715782983957
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
+  sha256: 6c33bf0c4d8f418546ba9c250db4e4221040936aef8956353bc764d4877bc39a
+  md5: d411fc29e338efb48c5fd4576d71d881
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119654
+  timestamp: 1726600001928
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
+  sha256: dc824dc1d0aa358e28da2ecbbb9f03d932d976c8dca11214aa1dcdfcbd054ba2
+  md5: ff862eebdfeb2fd048ae9dc92510baca
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 143452
+  timestamp: 1718284177264
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
+  sha256: 0595b009f20f8f60f13a6398e7cdcbd2acea5f986633adcf85f5a2283c992add
+  md5: f87c7b7c2cb45f323ffbce941c78ab7c
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 96855
+  timestamp: 1711634169756
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphviz-12.0.0-hba01fac_0.conda
+  sha256: 2eb794ae1de42b688f89811113ae3dcb63698272ee8f87029abce5f77c742c2a
+  md5: 953e31ea00d46beb7e64a79fc291ec44
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.0,<2.0a0
+  - fonts-conda-ecosystem
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - gtk2
+  - gts >=0.7.6,<0.8.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libgcc-ng >=12
+  - libgd >=2.3.3,<2.4.0a0
+  - libglib >=2.80.3,<3.0a0
+  - librsvg >=2.58.2,<3.0a0
+  - libstdcxx-ng >=12
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pango >=1.50.14,<2.0a0
+  license: EPL-1.0
+  license_family: Other
+  size: 2303111
+  timestamp: 1722673717117
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gtk2-2.24.33-h6470451_5.conda
+  sha256: 16644d036321b32635369c183502974c8b989fa516c313bd379f9aa4adcdf642
+  md5: 1483ba046164be27df7f6eddbcec3a12
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - atk-1.0 >=2.38.0
+  - cairo >=1.18.0,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - harfbuzz >=9.0.0
+  - libgcc-ng >=12
+  - libglib >=2.80.3,<3.0a0
+  - pango >=1.54.0,<2.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  license: LGPL-2.1-or-later
+  size: 6501561
+  timestamp: 1721285940408
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
+  sha256: b5cd16262fefb836f69dc26d879b6508d29f8a5c5948a966c47fe99e2e19c99b
+  md5: 4d8df0b0db060d33c9a702ada998a8fe
+  depends:
+  - libgcc-ng >=12
+  - libglib >=2.76.3,<3.0a0
+  - libstdcxx-ng >=12
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 318312
+  timestamp: 1686545244763
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hda332d3_1.conda
+  sha256: 973afa37840b4e55e2540018902255cfb0d953aaed6353bb83a4d120f5256767
+  md5: 76b32dcf243444aea9c6b804bcfa40b8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=75.1,<76.0a0
+  - libgcc-ng >=12
+  - libglib >=2.80.3,<3.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 1603653
+  timestamp: 1721186240105
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
+  sha256: 0d09b6dc1ce5c4005ae1c6a19dc10767932ef9a5e9c755cfdbb5189ac8fb0684
+  md5: bd77f8da987968ec3927990495dc22e4
+  depends:
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 756742
+  timestamp: 1695661547874
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.4-nompi_h2d575fe_103.conda
+  sha256: 50bcd6cd6e8853321e87d359571d187f8e18fa1c73b711074e551417c2163483
+  md5: f8416d7ff13707bd8eb75d6b8235857e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3940636
+  timestamp: 1730830832687
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+  sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
+  md5: 8b189310083baabfb622af68fd9d3ae3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 12129203
+  timestamp: 1720853576813
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_1.conda
+  sha256: 2f082f7b12a7c6824e051321c1029452562ad6d496ad2e8c8b7b3dea1c8feb92
+  md5: 5ca76f61b00a15a9be0612d4d883badc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17645
+  timestamp: 1725303065473
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+  sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
+  md5: 30186d27e2c9fa62b45fb1476b7200e3
+  depends:
+  - libgcc-ng >=10.3.0
+  license: LGPL-2.1-or-later
+  size: 117831
+  timestamp: 1646151697040
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.7-py311hd18a35c_0.conda
+  sha256: 4af11cbc063096a284fe1689b33424e7e49732a27fd396d74c7dee03d1e788ee
+  md5: be34c90cce87090d24da64a7c239ca96
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 72393
+  timestamp: 1725459421768
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+  sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
+  md5: 3f43953b7d3fb3aaa1d0d0723d91e368
+  depends:
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1370023
+  timestamp: 1719463201255
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+  sha256: 5c878d104b461b7ef922abe6320711c0d01772f4cd55de18b674f88547870041
+  md5: 51bb7010fc86f70eee639b4bb7a894f5
+  depends:
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 245247
+  timestamp: 1701647787198
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+  sha256: 7c91cea91b13f4314d125d1bedb9d03a29ebbd5080ccdea70260363424646dbe
+  md5: 048b02e3962f066da18efe3a21b77672
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - binutils_impl_linux-64 2.43
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 669211
+  timestamp: 1729655358674
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+  sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
+  md5: 76bbff344f0134279f225174e9064c8f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 281798
+  timestamp: 1657977462600
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_h5888daf_1.conda
+  sha256: 8f91429091183c26950f1e7ffa730e8632f0627ba35d2fccd71df31628c9b4e5
+  md5: e1f604644fe8d78e22660e2fec6756bc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  constrains:
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1310521
+  timestamp: 1727295454064
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
+  sha256: 2ef420a655528bca9d269086cf33b7e90d2f54ad941b437fb1ed5eca87cee017
+  md5: 5e97e271911b8b2001a8b71860c32faa
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 35446
+  timestamp: 1711021212685
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-18.0.0-h3b997a5_7_cpu.conda
+  sha256: d8e179b123ca9f62b83115091d3936c64d55506fef9c516b90cd3f2bdea304ca
+  md5: 32897a50e7f68187c4a524c439c0943c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-crt-cpp >=0.29.4,<0.29.5.0a0
+  - aws-sdk-cpp >=1.11.449,<1.11.450.0a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-identity-cpp >=1.10.0,<1.10.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-files-datalake-cpp >=12.12.0,<12.12.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libgcc >=13
+  - libgoogle-cloud >=2.31.0,<2.32.0a0
+  - libgoogle-cloud-storage >=2.31.0,<2.32.0a0
+  - libre2-11 >=2024.7.2
+  - libstdcxx >=13
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.3,<2.0.4.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  - libutf8proc <2.9
+  constrains:
+  - arrow-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  - parquet-cpp <0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 8714651
+  timestamp: 1731789983840
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-18.0.0-h5888daf_7_cpu.conda
+  sha256: bc0aa7f6c05c097f224cb2a8f72d22a5cde7ef239fde7a57f18061bf74776cd5
+  md5: 786a275d019708cd1c963b12a8fb0c72
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 18.0.0 h3b997a5_7_cpu
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 618726
+  timestamp: 1731790016942
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-18.0.0-h5888daf_7_cpu.conda
+  sha256: ecfcea86bf62a498eb59bfa28c8d6e28e842e9c8eeb594d059ef0fdc7064154f
+  md5: a742b9a0452b55020ccf662721c1ce44
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 18.0.0 h3b997a5_7_cpu
+  - libarrow-acero 18.0.0 h5888daf_7_cpu
+  - libgcc >=13
+  - libparquet 18.0.0 h6bd9018_7_cpu
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 594424
+  timestamp: 1731790074886
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-18.0.0-h5c8f2c3_7_cpu.conda
+  sha256: f4e12c8f48449b47ec7642f5cc0705d59e59c608d563e2848ffceec779c7c220
+  md5: be76013fa3fdaec2c0c504e6fdfd282d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 18.0.0 h3b997a5_7_cpu
+  - libarrow-acero 18.0.0 h5888daf_7_cpu
+  - libarrow-dataset 18.0.0 h5888daf_7_cpu
+  - libgcc >=13
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 528172
+  timestamp: 1731790101854
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
+  sha256: d6d12dc437d060f838820e9e61bf73baab651f91935ac594cf10beb9ef1b4450
+  md5: 8ea26d42ca88ec5258802715fe1ee10b
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - liblapack 3.9.0 25_linux64_openblas
+  - libcblas 3.9.0 25_linux64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 25_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15677
+  timestamp: 1729642900350
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
+  sha256: d9db2de60ea917298e658143354a530e9ca5f9c63471c65cf47ab39fd2f429e3
+  md5: 41b599ed2b02abcfdd84302bff174b23
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 68851
+  timestamp: 1725267660471
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
+  sha256: 2892d512cad096cb03f1b66361deeab58b64e15ba525d6592bb6d609e7045edf
+  md5: 9566f0bd264fbd463002e759b8a82401
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 32696
+  timestamp: 1725267669305
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
+  sha256: 779f58174e99de3600e939fa46eddb453ec5d3c60bb46cdaa8b4c127224dbf29
+  md5: 06f70867945ea6a84d35836af780f1de
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 281750
+  timestamp: 1725267679782
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
+  sha256: ab87b0477078837c91d9cda62a9faca18fba7c57cc77aa779ae24b3ac783b5dd
+  md5: 5dbd1b0fc0d01ec5e0e1fbe667281a11
+  depends:
+  - libblas 3.9.0 25_linux64_openblas
+  constrains:
+  - liblapack 3.9.0 25_linux64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 25_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15613
+  timestamp: 1729642905619
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+  sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
+  md5: c965a5aa0d5c1c37ffc62dff36e28400
+  depends:
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20440
+  timestamp: 1633683576494
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
+  sha256: 54e6114dfce566c3a22ad3b7b309657e3600cdb668398e95f1301360d5d52c99
+  md5: 6e801c50a40301f6978c53976917b277
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 424900
+  timestamp: 1726659794676
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
+  sha256: 780f0530a3adfc1497ba49d626931c6afc978c540e1abfde6ccd57128ded6ad6
+  md5: b422943d5d772b7cc858b36ad2a92db5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 72242
+  timestamp: 1728177071251
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+  sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
+  md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 123878
+  timestamp: 1597616541093
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+  md5: 172bf1cd1ff8629f2b1179945ed45055
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 112766
+  timestamp: 1702146165126
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+  sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
+  md5: a1cfcc585f0c42bf8d5546bb1dfb668d
+  depends:
+  - libgcc-ng >=12
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 427426
+  timestamp: 1685725977222
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
+  sha256: 56541b98447b58e52d824bd59d6382d609e11de1f8adf20b23143e353d2b8d26
+  md5: db833e03127376d461e1e13e76f09b6c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 73304
+  timestamp: 1730967041968
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+  sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+  md5: d645c6d2ac96843a2bfaccd2d62b3ac3
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 58292
+  timestamp: 1636488182923
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
+  sha256: 53eb8a79365e58849e7b1a068d31f4f9e718dc938d6f2c03e960345739a03569
+  md5: 3cb76c3f10d3bc7f1105b2fc9db984df
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 14.2.0 h77fa898_1
+  - libgcc-ng ==14.2.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 848745
+  timestamp: 1729027721139
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+  sha256: 3a76969c80e9af8b6e7a55090088bc41da4cffcde9e2c71b17f44d37b7cb87f7
+  md5: e39480b9ca41323497b05492a63bc35b
+  depends:
+  - libgcc 14.2.0 h77fa898_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54142
+  timestamp: 1729027726517
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-hd3e95f3_10.conda
+  sha256: b0fa27d4d09fb24750c04e89dbd0aee898dc028bde99e62621065a9bde43efe8
+  md5: 30ee3a29c84cf7b842a8c5828c4b7c13
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: GD
+  license_family: BSD
+  size: 225113
+  timestamp: 1722928278395
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+  sha256: fc9e7f22a17faf74da904ebfc4d88699013d2992e55505e4aa0eb01770290977
+  md5: f1fd30127802683586f768875127a987
+  depends:
+  - libgfortran5 14.2.0 hd5240d6_1
+  constrains:
+  - libgfortran-ng ==14.2.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 53997
+  timestamp: 1729027752995
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
+  sha256: d149a37ca73611e425041f33b9d8dbed6e52ec506fe8cc1fc0ee054bddeb6d5d
+  md5: 9822b874ea29af082e5d36098d25427d
+  depends:
+  - libgcc >=14.2.0
+  constrains:
+  - libgfortran 14.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1462645
+  timestamp: 1729027735353
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.2-h2ff4ddf_0.conda
+  sha256: 49ee9401d483a76423461c50dcd37f91d070efaec7e4dc2828d8cdd2ce694231
+  md5: 13e8e54035ddd2b91875ba399f0f7c04
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  constrains:
+  - glib 2.82.2 *_0
+  license: LGPL-2.1-or-later
+  size: 3931898
+  timestamp: 1729191404130
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+  sha256: 1911c29975ec99b6b906904040c855772ccb265a1c79d5d75c8ceec4ed89cd63
+  md5: cc3573974587f12dda90d96e3e55a702
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 460992
+  timestamp: 1729027639220
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.31.0-h804f50b_0.conda
+  sha256: b2de99c83516236ff591d30436779f8345bcc11bb0ec76a7ca3a38a3b23b6423
+  md5: 35ab838423b60f233391eb86d324a830
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  - openssl >=3.3.2,<4.0a0
+  constrains:
+  - libgoogle-cloud 2.31.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1248705
+  timestamp: 1731122589027
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.31.0-h0121fbd_0.conda
+  sha256: 3c38b0a80441f82323dc5a72b96c0dd7476bd5184fbfcdf825a8e15249c849af
+  md5: 568d6a09a6ed76337a7b97c84ae7c0f8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libgcc >=13
+  - libgoogle-cloud 2.31.0 h804f50b_0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  size: 782150
+  timestamp: 1731122728715
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.67.1-hc2c308b_0.conda
+  sha256: 870550c1faf524e9a695262cd4c31441b18ad542f16893bd3c5dbc93106705f7
+  md5: 4606a4647bfe857e3cfe21ca12ac3afb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - c-ares >=1.32.3,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libre2-11 >=2024.7.2
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.67.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 7362336
+  timestamp: 1730236333879
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+  sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
+  md5: d66573916ffcf376178462f1b61c941e
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  size: 705775
+  timestamp: 1702682170569
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+  sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
+  md5: ea25936bb4080d843790b586850f82b8
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 618575
+  timestamp: 1694474974816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
+  sha256: 9d1ff017714edb2d84868f0f931a4a0e7c289a971062b2ac66cfc8145df7e20e
+  md5: 4dc03a53fc69371a6158d0ed37214cd3
+  depends:
+  - libblas 3.9.0 25_linux64_openblas
+  constrains:
+  - liblapacke 3.9.0 25_linux64_openblas
+  - libcblas 3.9.0 25_linux64_openblas
+  - blas * openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15608
+  timestamp: 1729642910812
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
+  sha256: 225cc7c3b20ac1db1bdb37fa18c95bf8aecef4388e984ab2f7540a9f4382106a
+  md5: 73301c133ded2bf71906aa2104edae8b
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 31484415
+  timestamp: 1690557554081
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h2564987_115.conda
+  sha256: 77d9536095a076414b787a0c2497bb35fcd72f71eb899fae5acb9853a64b4ec4
+  md5: c5ce70b76c77a6c9a3107be8d8e8ab0b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - blosc >=1.21.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzip >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zlib
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 835104
+  timestamp: 1728055792846
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+  sha256: b0f2b3695b13a989f75d8fd7f4778e1c7aabe3b36db83f0fe80b2cd812c0e975
+  md5: 19e57602824042dfd0446292ef90488b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - c-ares >=1.32.3,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 647599
+  timestamp: 1729571887612
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+  sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+  md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  license_family: GPL
+  size: 33408
+  timestamp: 1697359010159
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
+  sha256: 99ba271d8a80a1af2723f2e124ffd91d850074c0389c067e6d96d72a2dbfeabe
+  md5: 62857b389e42b36b686331bec0922050
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.2.0
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5578513
+  timestamp: 1730772671118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-18.0.0-h6bd9018_7_cpu.conda
+  sha256: 908e21eab32839375ebe59952e783e40645ca5083b64001679960f2e38e64c31
+  md5: 687870f7d9cba5262fdd7e730e9e9ba8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 18.0.0 h3b997a5_7_cpu
+  - libgcc >=13
+  - libstdcxx >=13
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 1212405
+  timestamp: 1731790060397
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
+  sha256: e5b14f7a01c2db4362d8591f42f82f336ed48d5e4079e4d1f65d0c2a3637ea78
+  md5: f4cc49d7aa68316213e4b12be35308d1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 290661
+  timestamp: 1726234747153
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
+  sha256: 5e8fd4aa00193c85602ce6101dd28fe31306dff85c9725048f6dc828dfa7c421
+  md5: ab0bff36363bec94720275a681af8b83
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2945348
+  timestamp: 1728565355702
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hbbce691_1.conda
+  sha256: f8ad6a4f6d4fd54ebe3e5e712a01e663222fc57f49d16b6b8b10c30990dafb8f
+  md5: 2124de47357b7a516c0a3efd8f88c143
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 211096
+  timestamp: 1728778964655
+- conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-hc0ffecb_0.conda
+  sha256: fda3197ffb24512e719d55defa02f9f70286038e56cad8c1d580ed6460f417fa
+  md5: 83f045969988f5c7a65f3950b95a8b35
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - harfbuzz >=9.0.0
+  - libgcc >=13
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - pango >=1.54.0,<2.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LGPL-2.1-or-later
+  size: 6390511
+  timestamp: 1726227212382
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
+  sha256: 0105bd108f19ea8e6a78d2d994a6d4a8db16d19a41212070d2d1d48a63c34161
+  md5: a587892d3c13b6621a6091be690dbca2
+  depends:
+  - libgcc-ng >=12
+  license: ISC
+  size: 205978
+  timestamp: 1716828628198
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_1.conda
+  sha256: 8a9aadf996a2399f65b679c6e7f29139d5059f699c63e6d7b50e20db10c00508
+  md5: b6f02b52a174e612e89548f4663ce56a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 875349
+  timestamp: 1730208050020
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+  sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
+  md5: 1f5a58e686b13bcfde88b93f547d23fe
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 271133
+  timestamp: 1685837707056
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+  sha256: 4661af0eb9bdcbb5fb33e5d0023b001ad4be828fccdcc56500059d56f9869462
+  md5: 234a5554c53625688d51062645337328
+  depends:
+  - libgcc 14.2.0 h77fa898_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3893695
+  timestamp: 1729027746910
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+  sha256: 25bb30b827d4f6d6f0522cc0579e431695503822f144043b93c50237017fffd8
+  md5: 8371ac6457591af2cf6159439c1fd051
+  depends:
+  - libstdcxx 14.2.0 hc0a3c3a_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54105
+  timestamp: 1729027780628
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.21.0-h0e7cc3e_0.conda
+  sha256: ebb395232973c18745b86c9a399a4725b2c39293c9a91b8e59251be013db42f0
+  md5: dcb95c0a98ba9ff737f7ae482aef7833
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 425773
+  timestamp: 1727205853307
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-he137b08_1.conda
+  sha256: 9890121db85f6ef463fe12eb04ef1471176e3ef3b5e2d62e8d6dac713df00df4
+  md5: 63872517c98aa305da58a757c443698e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.22,<1.26.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx >=13
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 428156
+  timestamp: 1728232228989
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
+  sha256: 49082ee8d01339b225f7f8c60f32a2a2c05fe3b16f31b554b4fb2c1dea237d1c
+  md5: ede4266dc02e875fe1ea77b25dd43747
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 101070
+  timestamp: 1667316029302
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33601
+  timestamp: 1680112270483
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+  sha256: 49bc5f6b1e11cb2babf2a2a731d1a680a5e08a858280876a779dbda06c78c35f
+  md5: b26e8aa824079e1be0294e7152ca4559
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 438953
+  timestamp: 1713199854503
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+  sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
+  md5: 92ed62436b625154323d40d5f2f11dd7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 395888
+  timestamp: 1727278577118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
+  md5: 5aa797f8787fe7a17d1b0821485b5adc
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 100393
+  timestamp: 1702724383534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-hb346dea_0.conda
+  sha256: 8c9d6a3a421ac5bf965af495d1b0a08c6fb2245ba156550bc064a7b4f8fc7bd8
+  md5: c81a9f1118541aaa418ccb22190c817e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=13
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 689626
+  timestamp: 1731489608971
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.11.2-h6991a6a_0.conda
+  sha256: 991e7348b0f650d495fb6d8aa9f8c727bdf52dabf5853c0cc671439b160dce48
+  md5: a7b27c075c9b7f459f1c022090697cba
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 109043
+  timestamp: 1730442108429
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
+  md5: edb0dca6bc32e4f4789199455a1dbeb8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 60963
+  timestamp: 1727963148474
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.43.0-py311h9c9ff8c_1.conda
+  sha256: fb8b3eeea19f1160343d2c84f3b3e888f8c45db563375660905e1e73a793fc74
+  md5: 9ab40f5700784bf16ff7cf8012a646e8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3471295
+  timestamp: 1725305248888
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.3-py311h2cbdf9a_1.conda
+  sha256: 83f560beb20f61bb8c6e43a0656f1e744934d41a48b8a19408e6596cf8ce99a8
+  md5: 867a4aa23ae6c0e9c84cf9aa4f2df0fe
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39383
+  timestamp: 1725089531914
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+  sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
+  md5: 318b08df404f9c9be5712aaa5a6f0bb0
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143402
+  timestamp: 1674727076728
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py311h2dc5d0c_0.conda
+  sha256: 364a0d55abc4c60bc575c81a4acc9e98ea27565147d4d4dc672bad4b2d069710
+  md5: 15e4dadd59e93baad7275249f10b9472
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25591
+  timestamp: 1729351519326
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.2-py311h2b939e6_2.conda
+  sha256: 92fd9a8c19130064daba8b95bde172c77cbb6105cd7bc928bb0b1174c4a1faec
+  md5: 2e8401a7780e33e9ca76034d0ed24c3c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  - tk >=8.6.13,<8.7.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8014605
+  timestamp: 1731025323671
+- conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.0-py311hd18a35c_0.conda
+  sha256: 9033fa7084cbfd10e1b7ed3b74cee17169a0731ec98244d05c372fc4a935d5c9
+  md5: 682f76920687f7d9283039eb542fdacf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 104809
+  timestamp: 1725975116412
+- conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.1.0-py311h2dc5d0c_1.conda
+  sha256: a7216675325306e3efe30d7036c53379eb391517792d051d738027bc3740aad5
+  md5: 5384f857bd8b0fc3a62ce1ece858c89f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 63150
+  timestamp: 1729065611493
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+  sha256: 6a1d5d8634c1a07913f1c525db6455918cbc589d745fac46d9d6e30340c8731a
+  md5: 70caf8bb6cf39a0b6b7efc885f51c0fe
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: X11 AND BSD-3-Clause
+  size: 889086
+  timestamp: 1724658547447
+- conda: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.2-nompi_py311h7c29e4f_100.conda
+  sha256: bc94802624f241fdb7999d414a7bd5e4a6d3a0e6ae5454bdf428819c07261754
+  md5: 11395670c4eeda7a60c13c313a83727f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - certifi
+  - cftime
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libgcc >=13
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 1154059
+  timestamp: 1729667693885
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.60.0-py311h4bc866e_0.conda
+  sha256: b48178613ba637b647c5738772d3efabfca502ea579b5ec10784a33d5acb0789
+  md5: e32a210e9caf97383c35685fd2343512
+  depends:
+  - _openmp_mutex >=4.5
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libopenblas !=0.3.6
+  - cuda-version >=11.2
+  - cuda-python >=11.6
+  - tbb >=2021.6.0
+  - scipy >=1.0
+  - cudatoolkit >=11.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5801568
+  timestamp: 1718888179690
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.14.0-py311h7db5c69_0.conda
+  sha256: 193ffff3dd715fe39555bf9c5dbf2187a7d9dfb56320871216d9a2143e901c08
+  md5: 85920f968bd41ad59609dba81bba2f7f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - msgpack-python
+  - numpy >=1.19,<3
+  - numpy >=1.24
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 848483
+  timestamp: 1731918896347
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.0.2-py311h71ddf71_0.conda
+  sha256: f4e20d4045ad117499eaf44aaad2a17dd810b332c9407b9c4e7c155d56157a6f
+  md5: cb1476d753a69a42978fe7b303721df7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=13
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8961918
+  timestamp: 1724749067277
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
+  sha256: 5600a0b82df042bd27d01e4e687187411561dfc11cc05143a08ce29b64bf2af2
+  md5: 7f2e286780f072ed750df46dc2631138
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.43,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 341592
+  timestamp: 1709159244431
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
+  sha256: 814b9dff1847b132c676ee6cc1a8cb2d427320779b93e1b6d76552275c128705
+  md5: 23cc74f77eb99315c0360ec3533147a9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 2947466
+  timestamp: 1731377666602
+- conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.3-he039a57_0.conda
+  sha256: 9657ae19d6541fe67a61ef0c26ba1012ec508920b49afa897962c7d4b263ba35
+  md5: 052499acd6d6b79952197a13b23e2600
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1187593
+  timestamp: 1731664886527
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py311h7db5c69_1.conda
+  sha256: dce121d3838996b77b810ca9097cc17068552075c761408a9b2eb788cf8fd1b0
+  md5: 643f8cb35133eb1be4919fb953f0a25f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15695466
+  timestamp: 1726879158862
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.54.0-h4c5309f_1.conda
+  sha256: d362237be82d5a0d532fe66ec8d68018c3b2a9705bad6d73c2b63dae2970da02
+  md5: 7df02e445367703cd87a574046e3a6f0
+  depends:
+  - cairo >=1.18.0,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=9.0.0
+  - libgcc-ng >=12
+  - libglib >=2.80.2,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  license: LGPL-2.1-or-later
+  size: 447117
+  timestamp: 1719839527713
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
+  sha256: 1087716b399dab91cc9511d6499036ccdc53eb29a288bebcb19cf465c51d7c0d
+  md5: df359c09c41cd186fffb93a2d87aa6f5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 952308
+  timestamp: 1723488734144
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.0.0-py311h49e9ac3_0.conda
+  sha256: f0f792596ae99cba01f829d064058b1e99ca84080fc89f72d925bfe473cfc1b6
+  md5: 2bd3d0f839ec0d1eaca817c9d1feb7c2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 42421065
+  timestamp: 1729065780130
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
+  sha256: 366d28e2a0a191d6c535e234741e0cd1d94d713f76073d8af4a5ccb2a266121e
+  md5: 71004cbf7924e19c02746ccde9fd7123
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 386826
+  timestamp: 1706549500138
+- conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.5.0-h12925eb_0.conda
+  sha256: 936de8754054d97223e87cc87b72641d2c7582d536ee9eee4b0443fa66e2733f
+  md5: 8c29983ebe50cc7e0998c34bc7614222
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcurl >=8.10.0,<9.0a0
+  - libgcc >=13
+  - libsqlite >=3.46.1,<4.0a0
+  - libstdcxx >=13
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 3093445
+  timestamp: 1726489083290
+- conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.2.0-py311h9ecbd09_2.conda
+  sha256: bc2fbbc3f494884b62f288db2f6d53f57a9a1129cc95138780abdb783c487bc4
+  md5: 85a56dd3b692fb5435de1e901354b5b8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 53716
+  timestamp: 1728545855994
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py311h9ecbd09_0.conda
+  sha256: 2ac3f1ed6e6a2a0c67a3922f4b5faf382855ad02cc0c85c5d56291c7a94296d0
+  md5: 0ffc1f53106a38f059b151c465891ed3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 505408
+  timestamp: 1729847169876
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+  sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
+  md5: b3c17d95b5a10c6e64a21fa17573e70e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 8252
+  timestamp: 1726802366959
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-18.0.0-py311h38be061_1.conda
+  sha256: 4248bbc50c631c824d05b2a648ee7c650960d080aa4abc0f25336726d995b6fb
+  md5: eeda074d8e993dac2355fa8887320359
+  depends:
+  - libarrow-acero 18.0.0.*
+  - libarrow-dataset 18.0.0.*
+  - libarrow-substrait 18.0.0.*
+  - libparquet 18.0.0.*
+  - pyarrow-core 18.0.0 *_1_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25157
+  timestamp: 1731058869216
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-18.0.0-py311h4854187_1_cpu.conda
+  sha256: 5009dceb335479761fe3efcc41aa4829cf924d19cb63dde74da08da30aff48aa
+  md5: 3c14bc71dda64e1eb6273a63b2561cc9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 18.0.0.* *cpu
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy >=1.21,<3
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4589659
+  timestamp: 1731058468008
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.0-py311h0f98d5a_0.conda
+  sha256: 194440401fba9fb3903aa921abcf3da468172700b5b5c9b21f98fb7be469a54f
+  md5: 22531205a97c116251713008d65dfefd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - certifi
+  - libgcc >=13
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 562000
+  timestamp: 1727795513365
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.10-hc5c86c4_3_cpython.conda
+  sha256: b7fa3bd48e3a3d30f65608e07759cefd27885c6388b3f612af85ce40282e6936
+  md5: 9e1ad55c87368e662177661a998feed5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 30543977
+  timestamp: 1729043512711
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
+  sha256: 2660b8059b3ee854bc5d3c6b1fce946e5bd2fe8fbca7827de2c5885ead6209de
+  md5: 139a8d40c8a2f430df31048949e450de
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6211
+  timestamp: 1723823324668
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h9ecbd09_1.conda
+  sha256: e721e5ff389a7b2135917c04b27391be3d3382e261bb60a369b1620655365c3d
+  md5: abeb54d40f439b86f75ea57045ab8496
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 212644
+  timestamp: 1725456264282
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py311h7deb3e3_3.conda
+  sha256: 3fdef7b3c43474b7225868776a373289a8fd92787ffdf8bed11cf7f39b4ac741
+  md5: e0897de1d8979a3bb20ef031ae1f7d28
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 389074
+  timestamp: 1728642373938
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+  sha256: 776363493bad83308ba30bcb88c2552632581b143e8ee25b1982c8c743e73abc
+  md5: 353823361b1d27eb3960efb076dfcaf6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-Qhull
+  size: 552937
+  timestamp: 1720813982144
+- conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h77b4e00_1.conda
+  sha256: c1721cb80f7201652fc9801f49c214c88aee835d957f2376e301bd40a8415742
+  md5: 01093ff37c1b5e6bf9f17c0116747d11
+  depends:
+  - libre2-11 2024.07.02 hbbce691_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26665
+  timestamp: 1728778975855
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+  sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
+  md5: 47d31b792659ce70f470b5c82fdfb7a4
+  depends:
+  - libgcc-ng >=12
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 281456
+  timestamp: 1679532220005
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.21.0-py311h9e33e62_0.conda
+  sha256: 41b1c00f08d2b09243ca184af6f4fe8ca9fee418a62aec1cf1555bfd0b1b2eac
+  md5: befdb32741d8686b860232ca80178d63
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  size: 334025
+  timestamp: 1730922823065
+- conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.9-h0fd0ee4_0.conda
+  sha256: f2c8e55d6caa8d87a482b1f133963c184de1ccb2303b77cc8ca86c794253f151
+  md5: f472432f3753c5ca763d2497e2ea30bf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 355568
+  timestamp: 1731541963573
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py311he9a78e4_1.conda
+  sha256: 59482b974c36c375fdfd0bc3e5a3003ea2d2ae72b64b8f3deaeef5a851dbc91d
+  md5: 49ba89bf4d8a995efb99517d1c7aeb1e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=13
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17592106
+  timestamp: 1729481734425
+- conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
+  sha256: dc7c8e0e8c3e8702aae81c52d940bfaabe756953ee51b1f1757e891bab62cf7f
+  md5: 6b7dcc7349efd123d493d2dbe85a045f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42465
+  timestamp: 1720003704360
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.47.0-h9eae976_1.conda
+  sha256: 8ea1a085fa95d806301aeec0df6985c3ad0852a9a46aa62dd737d228c7862f9f
+  md5: 53abf1ef70b9ae213b22caa5350f97a9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libsqlite 3.47.0 hadc24fc_1
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 883666
+  timestamp: 1730208056779
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+  sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
+  md5: d453b98d9c83e71da0741bb0ff4d76bc
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3318875
+  timestamp: 1699202167581
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.1-py311h9ecbd09_1.conda
+  sha256: 21390d0c5708581959ebd89702433c1d06a56ddd834797a194b217f98e38df53
+  md5: 616fed0b6f5c925250be779b05d1d7f7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 856725
+  timestamp: 1724956239832
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py311h9ecbd09_1.conda
+  sha256: 5f277c801ca392512de9aa497fd8be3e168950600c438778dfc4234943c474fc
+  md5: 00895577e2b4c24dca76675ab1862551
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 368413
+  timestamp: 1729704640193
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.16.0-py311h9ecbd09_1.conda
+  sha256: 426ee582e676e15a85846743060710fc4dbe4dd562b21d80d751694ffa263e41
+  md5: 810ae646bcc50a017380336d874e4014
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 63403
+  timestamp: 1724958070675
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hb9d3cd8_1.conda
+  sha256: ec276da68d1c4a3d34a63195b35ca5b248d4aff0812464dcd843d74649b5cec4
+  md5: 19608a9656912805b2b9a2f6bd257b04
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 58159
+  timestamp: 1727531850109
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-he73a12e_1.conda
+  sha256: 70e903370977d44c9120a5641ab563887bd48446e9ef6fc2a3f5f60531c2cd6c
+  md5: 05a8ea5f446de33006171a7afe6ae857
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libuuid >=2.38.1,<3.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 27516
+  timestamp: 1727634669421
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.10-h4f16b4b_0.conda
+  sha256: c4650634607864630fb03696474a0535f6fce5fda7d81a6462346e071b53dfa7
+  md5: 0b666058a179b744a622d0a4a0c56353
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libxcb >=1.17.0,<2.0a0
+  - xorg-xorgproto
+  license: MIT
+  license_family: MIT
+  size: 838308
+  timestamp: 1727356837875
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
+  sha256: 532a046fee0b3a402db867b6ec55c84ba4cdedb91d817147c8feeae9766be3d6
+  md5: 77cbc488235ebbaab2b6e912d3934bae
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 14679
+  timestamp: 1727034741045
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+  sha256: 6b250f3e59db07c2514057944a3ea2044d6a8cdde8a47b6497c254520fade1ee
+  md5: 8035c64cb77ed555e3f150b7b3972480
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 19901
+  timestamp: 1727794976192
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
+  sha256: da5dc921c017c05f38a38bd75245017463104457b63a1ce633ed41f214159c14
+  md5: febbab7d15033c913d53c7a2c102309d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 50060
+  timestamp: 1727752228921
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hb9d3cd8_1.conda
+  sha256: f1217e902c0b1d8bc5d3ce65e483ebf38b049c823c9117b7198cfb16bd2b9143
+  md5: a7a49a8b85122b49214798321e2e96b4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-xorgproto
+  license: MIT
+  license_family: MIT
+  size: 37780
+  timestamp: 1727529943015
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
+  sha256: 1316680be6edddee0156b86ec1102fc8286f51c1a5440366ed1db596a2dc3731
+  md5: 7c21106b851ec72c037b162c216d8f05
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 565425
+  timestamp: 1726846388217
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+  sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+  md5: 2161070d867d1b1204ea749c8eec4ef0
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1 and GPL-2.0
+  size: 418368
+  timestamp: 1660346797927
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+  sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
+  md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 89141
+  timestamp: 1641346969816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.17.2-py311h9ecbd09_0.conda
+  sha256: 76f0c0a55af42386c6d11a95ae3a056c05762576cafda4a9a15a011869361bfb
+  md5: a13b1162515c6d66cc16336caccbb388
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - idna >=2.0
+  - libgcc >=13
+  - multidict >=4.0
+  - propcache >=0.2.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 152868
+  timestamp: 1731927069636
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_7.conda
+  sha256: a4dc72c96848f764bb5a5176aa93dd1e9b9e52804137b99daeebba277b31ea10
+  md5: 3947a35e916fcc6b9825449affbf4214
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - libstdcxx >=13
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 335400
+  timestamp: 1731585026517
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+  sha256: 5d7c0e5f0005f74112a34a7425179f4eb6e73c92f5d109e6af4ddeca407c92ab
+  md5: c9f075ab2f33b3bbee9e62d4ad0a6cd8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib 1.3.1 hb9d3cd8_2
+  license: Zlib
+  license_family: Other
+  size: 92286
+  timestamp: 1727963153079
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py311hbc35293_1.conda
+  sha256: a5cf0eef1ffce0d710eb3dffcb07d9d5922d4f7a141abc96f6476b98600f718f
+  md5: aec590674ba365e50ae83aa2d6e1efae
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.11
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 417923
+  timestamp: 1725305669690
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+  sha256: c558b9cc01d9c1444031bd1ce4b9cff86f9085765f17627a6cd85fc623c8a02b
+  md5: 4d056880988120e29d75bfff282e0f45
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 554846
+  timestamp: 1714722996770
+- conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.15.2-pyhd8ed1ab_0.conda
+  sha256: f259688172928255e39e5e2eeb1c8c739cd364a028acbeab7f8f5706a76f14b7
+  md5: d37891ef3f5282de913e632c7e9e289d
+  depends:
+  - aiohttp >=3.9.2,<4.0.0
+  - aioitertools >=0.5.1,<1.0.0
+  - botocore >=1.35.16,<1.35.37
+  - python >=3.8
+  - wrapt >=1.10.10,<2.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 66850
+  timestamp: 1731276208354
+- conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.3-pyhd8ed1ab_0.conda
+  sha256: cfa5bed6ad8d00c2bc2c6ccf115e91ef1a9981b73c68537b247f1a964a841cac
+  md5: ec763b0a58960558ca0ad7255a51a237
+  depends:
+  - python >=3.8.0
+  license: PSF-2.0
+  license_family: PSF
+  size: 19271
+  timestamp: 1727779893392
+- conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_0.conda
+  sha256: b1a2574b136938fc4cc54403766032575a046a611d95899537ba2a6e0b6d98f1
+  md5: 222c275312d71dd318108df50d6452a1
+  depends:
+  - python >=3.6
+  - typing_extensions >=4.0
+  license: MIT
+  license_family: MIT
+  size: 24990
+  timestamp: 1727030367306
+- conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 575c742e14c86575986dc867463582a970463da50b77264cdf54df74f5563783
+  md5: d1e1eb7e21a9e2c74279d87dafb68156
+  depends:
+  - frozenlist >=1.1.0
+  - python >=3.7
+  license: Apache-2.0
+  license_family: APACHE
+  size: 12730
+  timestamp: 1667935912504
+- conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+  sha256: 4b54b7ce79d818e3cce54ae4d552dba51b7afac160ceecdefd04b3917a37c502
+  md5: 688697ec5e9588bdded167d19577625b
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.9
+  - sniffio >=1.1
+  - typing_extensions >=4.1
+  constrains:
+  - uvloop >=0.21.0b1
+  - trio >=0.26.1
+  license: MIT
+  license_family: MIT
+  size: 109864
+  timestamp: 1728935803440
+- conda: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+  sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
+  md5: 5f095bc6454094e96f146491fd03633b
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 12840
+  timestamp: 1603108499239
+- conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
+  sha256: 45ae2d41f4a4dcf8707633d3d7ae376fc62f0c09b1d063c3049c3f6f8c911670
+  md5: cc4834a9ee7cc49ce8d25177c47b10d8
+  depends:
+  - python >=3.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 10241
+  timestamp: 1707233195627
+- conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+  sha256: 130766446f5507bd44df957b6b5c898a8bd98f024bb426ed6cb9ff1ad67fc677
+  md5: 3afef1f55a1366b4d3b6a0d92e2235e4
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.7
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 18602
+  timestamp: 1692818472638
+- conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+  sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
+  md5: b77d8c2313158e6e461ca0efb1c2c508
+  depends:
+  - python >=3.8
+  - python-dateutil >=2.7.0
+  - types-python-dateutil >=2.8.10
+  license: Apache-2.0
+  license_family: Apache
+  size: 100096
+  timestamp: 1696129131844
+- conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+  sha256: b3e9369529fe7d721b66f18680ff4b561e20dbf6507e209e1f60eac277c97560
+  md5: c0481c9de49f040272556e2cedf42816
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 6164
+  timestamp: 1531050741142
+- conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+  sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
+  md5: 5f25798dcefd8252ce5f9dc494d5f571
+  depends:
+  - python >=3.5
+  - six >=1.12.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 28922
+  timestamp: 1698341257884
+- conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+  sha256: 7ed83731979fe5b046c157730e50af0e24454468bbba1ed8fc1a3107db5d7518
+  md5: 3d081de3a6ea9f894bbb585e8e3a4dcb
+  depends:
+  - python >=3.8
+  - typing_extensions >=4.0.0
+  license: MIT
+  license_family: MIT
+  size: 15342
+  timestamp: 1690563152778
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+  sha256: 28dba85a7e0f7fb57d7315e13f603d1e41b83c5b88aa2a602596b52c833a2ff8
+  md5: 6732fa52eb8e66e5afeb32db8701a791
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 56048
+  timestamp: 1722977241383
+- conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_0.conda
+  sha256: fce1d78e42665bb26d3f2b45ce9cacf0d9dbe4c1b2db3879a384eadee53c6231
+  md5: 6d4e9ecca8d88977147e109fc7053184
+  depends:
+  - python >=3.8
+  - pytz >=2015.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6525614
+  timestamp: 1730878929589
+- conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+  sha256: 7b05b2d0669029326c623b9df7a29fa49d1982a9e7e31b2fea34b4c9a4a72317
+  md5: 332493000404d8411859539a5a630865
+  depends:
+  - python >=3.6
+  - soupsieve >=1.2
+  license: MIT
+  license_family: MIT
+  size: 118200
+  timestamp: 1705564819537
+- conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
+  sha256: 01be7fb5163e7c31356a18c259ddc19a5431b8b974dc65e2427b88c2d30034f3
+  md5: 461bcfab8e65c166e297222ae919a2d4
+  depends:
+  - python >=3.9
+  - webencodings
+  license: Apache-2.0 AND MIT
+  license_family: Apache
+  size: 132652
+  timestamp: 1730286301829
+- conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.1-pyhd8ed1ab_0.conda
+  sha256: f917c7c60ac9c8066fb389432876fe381d2068758a87d0a06e79428c46091ee4
+  md5: e88d74bb7b9b89d4c9764286ceb94cc9
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.10
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4520636
+  timestamp: 1730964473035
+- conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.36-pyge310_1234567_0.conda
+  sha256: 3aad7fd70c80b858587c2b3fc8151dc29c02e4afdb38103d9e927e8a544138ef
+  md5: 3bd2289a7a4ae56ff449b49069426638
+  depends:
+  - jmespath >=0.7.1,<2.0.0
+  - python >=3.10
+  - python-dateutil >=2.1,<3.0.0
+  - urllib3 >=1.25.4,!=2.2.0,<3
+  license: Apache-2.0
+  license_family: Apache
+  size: 7231188
+  timestamp: 1728459804449
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+  sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
+  md5: 9b347a7ec10940d3f7941ff6c460b551
+  depends:
+  - cached_property >=1.5.2,<1.5.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4134
+  timestamp: 1615209571450
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+  sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+  md5: 576d629e47797577ab0f1b351297ef4a
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11065
+  timestamp: 1615209567874
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+  sha256: 7020770df338c45ac6b560185956c32f0a5abf4b76179c037f115fc7d687819f
+  md5: 12f7d00853807b0531775e9be891cb11
+  depends:
+  - python >=3.7
+  license: ISC
+  size: 163752
+  timestamp: 1725278204397
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_0.conda
+  sha256: 1873ac45ea61f95750cb0b4e5e675d1c5b3def937e80c7eebb19297f76810be8
+  md5: a374efa97290b8799046df7c5ca17164
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 47314
+  timestamp: 1728479405343
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+  sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
+  md5: f3ad426304898027fc619827ff428eca
+  depends:
+  - __unix
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84437
+  timestamp: 1692311973840
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
+  sha256: 90236b113b9a20041736e80b80ee965167f9aac0468315c55e2bad902d673fb0
+  md5: 3549ecbceb6cd77b91a105511b7d0786
+  depends:
+  - __win
+  - colorama
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 85051
+  timestamp: 1692312207348
+- conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+  sha256: 5a33d0d3ef33121c546eaf78b3dac2141fc4d30bbaeb3959bbc66fcd5e99ced6
+  md5: c88ca2bb7099167912e3b26463fff079
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25952
+  timestamp: 1729059365471
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+  sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+  md5: 3faab06a954c2a04039983f2c4a50d99
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25170
+  timestamp: 1666700778190
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+  sha256: 79a6b4fff545e0b18f86ad93276a1797eb6ac3f7e1851e03f02d63b19655731b
+  md5: 4d155b600b63bc6ba89d91fab74238f8
+  depends:
+  - python >=3.7
+  license: CC-BY-4.0
+  size: 173517
+  timestamp: 1709713413736
+- conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+  sha256: e923acf02708a8a0b591f3bce4bdc11c8e63b73198b99b35fe6cd96bfb6a0dbe
+  md5: 948d84721b578d426294e17a02e24cbb
+  depends:
+  - python >=3.6
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12134
+  timestamp: 1710320435158
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.10-py311hd8ed1ab_3.conda
+  sha256: 3b2460b6cce53ce95f1f3aeb8ef7a50b356226dc48d45265ce5e585fc5e8cbed
+  md5: b6d1a583921c24bb45feef32262b10aa
+  depends:
+  - python 3.11.10.*
+  - python_abi * *_cp311
+  license: Python-2.0
+  size: 45741
+  timestamp: 1729041746101
+- conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+  sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
+  md5: 5cd86562580f274031ede6aa6aa24441
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13458
+  timestamp: 1696677888423
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.11.2-pyhd8ed1ab_0.conda
+  sha256: 4f9566a7455442a9d4eeaaf00dde0ba8c93b163f2c877ea28ffe4c9cc8edf4c7
+  md5: 2271232349fb358aeafb6a8a7fd575a8
+  depends:
+  - bokeh >=3.1.0
+  - cytoolz >=0.11.0
+  - dask-core >=2024.11.2,<2024.11.3.0a0
+  - dask-expr >=1.1,<1.2
+  - distributed >=2024.11.2,<2024.11.3.0a0
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.24
+  - pandas >=2.0
+  - pyarrow >=14.0.1
+  - python >=3.10
+  constrains:
+  - openssl !=1.1.1e
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7438
+  timestamp: 1731527931906
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.11.2-pyhd8ed1ab_0.conda
+  sha256: f7991985162a9ef8b506192cddfe95a5bee45a42b70c00bea39693dcb340f38d
+  md5: 86269596fa40b5b59b1eb8187f04ca1c
+  depends:
+  - click >=8.1
+  - cloudpickle >=3.0.0
+  - fsspec >=2021.09.0
+  - importlib_metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.4.0
+  - python >=3.10
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 903582
+  timestamp: 1731512203592
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.19-pyhd8ed1ab_0.conda
+  sha256: 5f2c9e8f49c016a249d07eb46bae5b4085f3750827d12aff8aa0db1be4665165
+  md5: 09ea33eb6525cc703ce1d39c88378320
+  depends:
+  - dask-core 2024.11.2
+  - pandas >=2
+  - pyarrow >=14.0.1
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 185913
+  timestamp: 1731515130979
+- conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+  sha256: 8f35e2d76173d300f5e5f504d67238097c16457267d421a8ab10d1e5bd9b734d
+  md5: 1316959270592fbf8e2278a336de3ab9
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy
+  - packaging
+  - pandas
+  - param
+  - pillow
+  - pyct
+  - python >=3.9
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17230062
+  timestamp: 1720435590279
+- conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+  md5: 43afe5ab04e35e17ba28649471dd7364
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 12072
+  timestamp: 1641555714315
+- conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
+  md5: 961b3a227b437d82ad7054484cfa71b2
+  depends:
+  - python >=3.6
+  license: PSF-2.0
+  license_family: PSF
+  size: 24062
+  timestamp: 1615232388757
+- conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.11.2-pyhd8ed1ab_0.conda
+  sha256: f2d5369065a399791502929422370c4b0ee091eab6f173eefb79608f9e3fc80c
+  md5: 82613fc096ecd4a0a0f50681e0e1f994
+  depends:
+  - click >=8.0
+  - cloudpickle >=3.0.0
+  - cytoolz >=0.11.2
+  - dask-core >=2024.11.2,<2024.11.3.0a0
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.2
+  - packaging >=20.0
+  - psutil >=5.8.0
+  - python >=3.10
+  - pyyaml >=5.4.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.11.2
+  - tornado >=6.2.0
+  - urllib3 >=1.26.5
+  - zict >=3.0.0
+  constrains:
+  - openssl !=1.1.1e
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 804212
+  timestamp: 1731514505114
+- conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
+  md5: 3cf04868fee0a029769bd41f4b2fbf2d
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 9199
+  timestamp: 1643888357950
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+  sha256: e0edd30c4b7144406bb4da975e6bb97d6bc9c0e999aa4efe66ae108cada5d5b5
+  md5: d02ae936e42063ca46af6cdad2dbd1e0
+  depends:
+  - python >=3.7
+  license: MIT and PSF-2.0
+  size: 20418
+  timestamp: 1720869435725
+- conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+  sha256: a52d7516e2e11d3eb10908e10d3eb3f8ef267fea99ed9b09d52d96c4db3441b8
+  md5: d0441db20c827c11721889a241df1220
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 28337
+  timestamp: 1725214501850
+- conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+  sha256: 42be6ac8478051b26751d778490d6a71de12e5c6443e145ff3eddbc577d9bcda
+  md5: 348e27e78a5e39090031448c72f66d5e
+  depends:
+  - python >=3.6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 19975
+  timestamp: 1643971626978
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+  sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+  md5: 0c96522c6bdaed4b1566d11387caaf45
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 397370
+  timestamp: 1566932522327
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+  sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+  md5: 34893075a5c9e55cdafac56607368fc6
+  license: OFL-1.1
+  license_family: Other
+  size: 96530
+  timestamp: 1620479909603
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+  sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+  md5: 4d59c254e01d9cde7957100457e2d5fb
+  license: OFL-1.1
+  license_family: Other
+  size: 700814
+  timestamp: 1620479612257
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+  sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+  md5: 49023d73832ef61042f6a237cb2687e7
+  license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
+  license_family: Other
+  size: 1620504
+  timestamp: 1727511233259
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+  sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+  md5: fee5683a3f04bd15cbd8318b096a27ab
+  depends:
+  - fonts-conda-forge
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3667
+  timestamp: 1566974674465
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+  sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
+  md5: f766549260d6815b0c52253f1fb1bb29
+  depends:
+  - font-ttf-dejavu-sans-mono
+  - font-ttf-inconsolata
+  - font-ttf-source-code-pro
+  - font-ttf-ubuntu
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4102
+  timestamp: 1566932280397
+- conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 6cfd1f9bcd2358a69fb571f4b3af049b630d52647d906822dbedac03e84e4f63
+  md5: 642d35437078749ef23a5dca2c9bb1f3
+  depends:
+  - cached-property >=1.3.0
+  - python >=2.7,<4
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 14395
+  timestamp: 1638810388635
+- conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+  sha256: 40bb76981dd49d5869b48925a8975bb7bbe4e33e1e40af4ec06f6bf4a62effd7
+  md5: 816dbc4679a64e4417cd1385d661bb31
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 134745
+  timestamp: 1729608972363
+- conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 817d2c77d53afe3f3d9cf7f6eb8745cdd8ea76c7adaa9d7ced75c455a2c2c085
+  md5: b21ed0883505ba1910994f1df031a428
+  depends:
+  - python >=3
+  - typing_extensions
+  license: MIT
+  license_family: MIT
+  size: 48251
+  timestamp: 1664132995560
+- conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+  sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
+  md5: b748fbf7060927a6e82df7cb5ee8f097
+  depends:
+  - hpack >=4.0,<5
+  - hyperframe >=6.0,<7
+  - python >=3.6.1
+  license: MIT
+  license_family: MIT
+  size: 46754
+  timestamp: 1634280590080
+- conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+  sha256: 369d234fb83fb37e0e8abe7a78981a533cec37053c5c15177ad6caade729118d
+  md5: a765e03fa67caf58525b08bbbd5b4f76
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.9
+  - pyviz_comms >=2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4037867
+  timestamp: 1730736003074
+- conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+  sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
+  md5: 914d6646c4dbb1fd3ff539830a12fd71
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 25341
+  timestamp: 1598856368685
+- conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+  sha256: c84d012a245171f3ed666a8bf9319580c269b7843ffa79f26468842da3abd5df
+  md5: 2ca8e6dbc86525c8b95e3c0ffa26442e
+  depends:
+  - python >=3.8
+  - h11 >=0.13,<0.15
+  - h2 >=3,<5
+  - sniffio 1.*
+  - anyio >=3.0,<5.0
+  - certifi
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48959
+  timestamp: 1731707562362
+- conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.2-pyhd8ed1ab_0.conda
+  sha256: 1a33f160548bf447e15c0273899d27e4473f1d5b7ca1441232ec2d9d07c56d03
+  md5: 7e9ac3faeebdbd7b53b462c41891e7f7
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.8
+  - sniffio
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65085
+  timestamp: 1724778453275
+- conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+  sha256: a0fb47776b6816990b94eab6e1a27025f643fa94646b845277d3aa8bce8fb2f1
+  md5: dbc57da07daee81a9cd76586217c7cbb
+  depends:
+  - bokeh >=3.1
+  - colorcet >=2
+  - holoviews >=1.19.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 246908
+  timestamp: 1729160766015
+- conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
+  md5: 9f765cbfab6870c8435b9eefecd7a1f4
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 14646
+  timestamp: 1619110249723
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
+  sha256: 8c57fd68e6be5eecba4462e983aed7e85761a519aab80e834bbd7794d4b545b2
+  md5: 7ba2ede0e7c795ff95088daf0dc59753
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49837
+  timestamp: 1726459583613
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
+  sha256: 7194700ce1a5ad2621fd68e894dd8c1ceaff9a38723e6e0e5298fdef13017b1c
+  md5: 54198435fce4d64d8a89af22573012a8
+  depends:
+  - python >=3.8
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 28646
+  timestamp: 1726082927916
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.5.0-hd8ed1ab_0.conda
+  sha256: 313b8a05211bacd6b15ab2621cb73d7f41ea5c6cae98db53367d47833f03fef1
+  md5: 2a92e152208121afadf85a5e1f3a5f4d
+  depends:
+  - importlib-metadata >=8.5.0,<8.5.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 9385
+  timestamp: 1726082930346
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_0.conda
+  sha256: 2cb9db3e40033c3df72d3defc678a012840378fd55a67e4351363d4b321a0dc1
+  md5: c808991d29b9838fb4d96ce8267ec9ec
+  depends:
+  - python >=3.8
+  - zipp >=3.1.0
+  constrains:
+  - importlib-resources >=6.4.5,<6.4.6.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 32725
+  timestamp: 1725921462405
+- conda: https://conda.anaconda.org/conda-forge/noarch/intake-0.7.0-pyhd8ed1ab_0.conda
+  sha256: 8dba632e81a11347d959bb11367f6b0184e2dcc9aeab550de156beac5fa6091b
+  md5: 310f0fdaec6eecd9cc7833a788bafb1f
+  depends:
+  - appdirs
+  - cloudpickle >=0.2.2
+  - dask >=1.0
+  - entrypoints
+  - fsspec >=0.7.4
+  - jinja2
+  - msgpack-python
+  - numpy
+  - partd >=0.3.10
+  - python >=3.6
+  - pyyaml
+  - requests
+  - toolz >=0.8.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 193092
+  timestamp: 1685391772164
+- conda: https://conda.anaconda.org/conda-forge/noarch/intake-xarray-0.7.0-pyhd8ed1ab_0.conda
+  sha256: ceb8cf5761c29467684cb860f1c73fce396ed412a3b54f69cdd314b96ef736b6
+  md5: d6471673fac9fa8f13a2517315ffcf6b
+  depends:
+  - dask >=2.2
+  - fsspec >=2022
+  - intake >=0.6.6
+  - msgpack-python
+  - netcdf4
+  - python >=3.5
+  - requests
+  - xarray >=2022
+  - zarr
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 27517
+  timestamp: 1685414168477
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.3.3-pyhd8ed1ab_1.tar.bz2
+  sha256: f005438f3cbec00bad44504fe7ef04f198282c284d49839c934130547949e7b2
+  md5: e06e117809798ba07e052b84e1475e31
+  depends:
+  - ipywidgets >=7.6.0
+  - python >=3.7
+  - spectate
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3075874
+  timestamp: 1662990191967
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+  sha256: 33cfd339bb4efac56edf93474b37ddc049e08b1b4930cf036c893cc1f5a1f32a
+  md5: b40131ab6a36ac2c09b7c57d4d3fbf99
+  depends:
+  - __linux
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119084
+  timestamp: 1719845605084
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+  sha256: dc569094125127c0078aa536f78733f383dd7e09507277ef8bcd1789786e7086
+  md5: 18df5fc4944a679e085e0e8f31775fc8
+  depends:
+  - __win
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119853
+  timestamp: 1719845858082
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+  sha256: 072534d4d379225b2c3a4e38bc7730b65ae171ac7f0c2d401141043336e97980
+  md5: 9eb15d654daa0ef5a98802f586bb4ffc
+  depends:
+  - __osx
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119568
+  timestamp: 1719845667420
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.29.0-pyh707e725_0.conda
+  sha256: 606723272a208cca1036852e04fbb61741b78451784746e75edd1becb70347d2
+  md5: 56db21d7d51410fcfbfeca3d1a6b4269
+  depends:
+  - __unix
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.10
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 599356
+  timestamp: 1729866495921
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.29.0-pyh7428d3b_0.conda
+  sha256: 2208dbe96e94ba653c4e0a5f302e36f16df73eec1968cfb85eff2d9775c9ced1
+  md5: 9dc505b3569b4c26cffc241c50695f75
+  depends:
+  - __win
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.10
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 600237
+  timestamp: 1729866942619
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.5-pyhd8ed1ab_0.conda
+  sha256: ae27447f300c85a184d5d4fa08674eaa93931c12275daca981eb986f5d7795b3
+  md5: a022d34163147d16b27de86dc53e93fc
+  depends:
+  - comm >=0.1.3
+  - ipython >=6.1.0
+  - jupyterlab_widgets >=3.0.13,<3.1.0
+  - python >=3.7
+  - traitlets >=4.3.1
+  - widgetsnbextension >=4.0.13,<4.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 113497
+  timestamp: 1724334989324
+- conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
+  md5: 4cb68948e0b8429534380243d063a27a
+  depends:
+  - arrow >=0.15.0
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 17189
+  timestamp: 1638811664194
+- conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhff2d567_0.conda
+  sha256: d37dad14c00d06d33bfb99c378d0abd7645224a9491c433af5028f24863341ab
+  md5: 11ead81b00e0f7cc901fceb7ccfb92c1
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.9
+  license: Apache-2.0 AND MIT
+  size: 842916
+  timestamp: 1731317305873
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+  sha256: 27380d870d42d00350d2d52598cddaf02f9505fb24be09488da0c9b8d1428f2d
+  md5: 7b86ecb7d3557821c649b3c31e3eb9f2
+  depends:
+  - markupsafe >=2.0
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111565
+  timestamp: 1715127275924
+- conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 95ac5f9ee95fd4e34dc051746fc86016d3d4f6abefed113e2ede049d59ec2991
+  md5: 2cfa3e1cf3fb51bb9b17acc5b5e9ea11
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 21003
+  timestamp: 1655568358125
+- conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.28-pyhff2d567_0.conda
+  sha256: 402586e586761e0d51dd590fb71786f7f4e21c16353ca7d1c559358a1f849b26
+  md5: b5fd1ac9269dd22e003eaac27e249d97
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 28525
+  timestamp: 1731366079831
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+  sha256: 7d0c4c0346b26be9f220682b7c5c0d84606d48c6dbc36fc238e4452dda733aff
+  md5: da304c192ad59975202859b367d0f6a2
+  depends:
+  - attrs >=22.2.0
+  - importlib_resources >=1.4.0
+  - jsonschema-specifications >=2023.03.6
+  - pkgutil-resolve-name >=1.3.10
+  - python >=3.8
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 74323
+  timestamp: 1720529611305
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+  sha256: 82f8bed0f21dc0b3aff40dd4e39d77e85b93b0417bc5659b001e0109341b8b98
+  md5: 720745920222587ef942acfbc578b584
+  depends:
+  - python >=3.8
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 16165
+  timestamp: 1728418976382
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+  sha256: 007a0a506a0d1805b099629cb0ee743ad0afe7d9749e57339f32c168119e0139
+  md5: 16b37612b3a2fd77f409329e213b530c
+  depends:
+  - fqdn
+  - idna
+  - isoduration
+  - jsonpointer >1.13
+  - jsonschema >=4.23.0,<4.23.1.0a0
+  - rfc3339-validator
+  - rfc3986-validator >0.1.0
+  - uri-template
+  - webcolors >=24.6.0
+  license: MIT
+  license_family: MIT
+  size: 7143
+  timestamp: 1720529619500
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+  sha256: 2151c2c63e0442a4c69ee0ad8a634195eedab10b7b74c0ec8266471842239a93
+  md5: 885867f6adab3d7ecdf8ab6ca0785f51
+  depends:
+  - importlib-metadata >=4.8.3
+  - jupyter_server >=1.1.2
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55539
+  timestamp: 1712707521811
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_0.conda
+  sha256: 4419c85e209a715f551a5c9bead746f29ee9d0fc41e772a76db3868622795671
+  md5: a14218cfb29662b4a19ceb04e93e298e
+  depends:
+  - importlib-metadata >=4.8.3
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.8
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 106055
+  timestamp: 1726610805505
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+  sha256: 732b1e8536bc22a5a174baa79842d79db2f4956d90293dd82dc1b3f6099bcccd
+  md5: 0a2980dada0dd7fd0998f0342308b1b1
+  depends:
+  - __unix
+  - platformdirs >=2.5
+  - python >=3.8
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 57671
+  timestamp: 1727163547058
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh5737063_1.conda
+  sha256: 7c903b2d62414c3e8da1f78db21f45b98de387aae195f8ca959794113ba4b3fd
+  md5: 46d87d1c0ea5da0aae36f77fa406e20d
+  depends:
+  - __win
+  - cpython
+  - platformdirs >=2.5
+  - python >=3.8
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 58269
+  timestamp: 1727164026641
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+  sha256: cd3f41dc093162a41d4bae171e40a1b9b115c4d488e9bb837a8fa9d084931fb9
+  md5: ed45423c41b3da15ea1df39b1f80c2ca
+  depends:
+  - jsonschema-with-format-nongpl >=4.18.0
+  - python >=3.8
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21475
+  timestamp: 1710805759187
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+  sha256: edab71a05feceac54bdb90e755a257545af7832b9911607c1a70f09be44ba985
+  md5: ca23c71f70a7c7935b3d03f0f1a5801d
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert-core >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.8
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 323978
+  timestamp: 1720816754998
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+  sha256: 038efbc7e4b2e72d49ed193cfb2bbbe9fbab2459786ce9350301f466a32567db
+  md5: 219b3833aa8ed91d47d1be6ca03f30be
+  depends:
+  - python >=3.8
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19818
+  timestamp: 1710262791393
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.2.6-pyhff2d567_0.conda
+  sha256: af085cc8d27fdcda4940de2391232b0be1e7fb0448bce0ec03035c0c878a6a80
+  md5: 8e8787ab1bc5210800aaae43c69973b1
+  depends:
+  - async-lru >=1.0.0
+  - httpx >=0.25.0
+  - importlib-metadata >=4.8.3
+  - ipykernel >=6.5.0
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.27.1,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.9
+  - setuptools >=40.1.0
+  - tomli >=1.2.2
+  - tornado >=6.2.0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7122193
+  timestamp: 1731778766670
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+  sha256: 4aa622bbcf97e44cd1adf0100b7ff71b7e20268f043bdf6feae4d16152f1f242
+  md5: afcd1b53bcac8844540358e33f33d28f
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.7
+  constrains:
+  - jupyterlab >=4.0.8,<5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18776
+  timestamp: 1707149279640
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+  sha256: a23b26d1a35bccdb91b9232119e5f402624e1e1a252b0e64cc20c6eb5b87cefb
+  md5: af8239bf1ba7e8c69b689f780f653488
+  depends:
+  - babel >=2.10
+  - importlib-metadata >=4.8.3
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.8
+  - requests >=2.31
+  constrains:
+  - openapi-core >=0.18.0,<0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49355
+  timestamp: 1721163412436
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.13-pyhd8ed1ab_0.conda
+  sha256: 0e7ec7936d766f39d5a0a8eafc63f5543f488883ad3645246bc22db6d632566e
+  md5: ccea946e6dce9f330fbf7fca97fe8de7
+  depends:
+  - python >=3.7
+  constrains:
+  - jupyterlab >=3,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 186024
+  timestamp: 1724331451102
+- conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+  sha256: aa99d44e8c83865026575a8af253141c53e0b3ab05f053befaa7757c8525064f
+  md5: f1b64ca4faf563605cf6f6ca93f9ff3f
+  depends:
+  - python >=3.7
+  - uc-micro-py
+  license: MIT
+  license_family: MIT
+  size: 24035
+  timestamp: 1707129321841
+- conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
+  md5: 91e27ef3d05cc772ce627e51cff111c4
+  depends:
+  - python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 8250
+  timestamp: 1650660473123
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+  sha256: fce1fde00359696983989699c00f9891194c4ebafea647a8d21b7e2e3329b56e
+  md5: 06e9bebf748a0dea03ecbe1f0e27e909
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78331
+  timestamp: 1710435316163
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+  sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
+  md5: 93a8e71256479c62074356ef6ebf501b
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 64356
+  timestamp: 1686175179621
+- conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+  sha256: 7ea68676ea35fbb095420bbcc1c82c4767b8be7bb56abb6989b7f89d957a3bab
+  md5: 779345c95648be40d22aaa89de7d4254
+  depends:
+  - python >=3.6
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14599
+  timestamp: 1713250613726
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+  sha256: 5cedc99412278b37e9596f1f991d49f5a1663fe79767cf814a288134a1400ba9
+  md5: 5387f2cfa28f8a3afa3368bb4ba201e8
+  depends:
+  - markdown-it-py >=1.0.0,<4.0.0
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 42126
+  timestamp: 1725995333692
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+  sha256: 64073dfb6bb429d52fff30891877b48c7ec0f89625b1bf844905b66a81cce6e1
+  md5: 776a8dd9e824f77abac30e6ef43a8f7a
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 14680
+  timestamp: 1704317789138
+- conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+  sha256: f95cb70007e3cc2ba44e17c29a056b499e6dadf08746706d0c817c8e2f47e05c
+  md5: 5cbee699846772cc939bef23a0d524ed
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 66022
+  timestamp: 1698947249750
+- conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+  sha256: c6216a21154373b340c64f321f22fec51db4ee6156c2e642fa58368103ac5d09
+  md5: 121a57fce7fff0857ec70fa03200962f
+  depends:
+  - python >=3.6
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17254
+  timestamp: 1721907640382
+- conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+  sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
+  md5: 2ba8498c1018c1e9c61eb99b973dfe19
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12452
+  timestamp: 1600387789153
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
+  sha256: 589d72d36d61a23b39d6fff2c488f93e29e20de4fc6f5d315b5f2c16e81028bf
+  md5: 15b51397e0fe8ea7d7da60d83eb76ebc
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.8
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27851
+  timestamp: 1710317767117
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+  sha256: 074d858c5808e0a832acc0da37cd70de1565e8d6e17a62d5a11b3902b5e78319
+  md5: e2d2abb421c13456a9a9f80272fdf543
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<3.1
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.8
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - nbconvert =7.16.4=*_1
+  - pandoc >=2.9.2,<4.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189599
+  timestamp: 1718135529468
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+  sha256: 36fe73da4d37bc7ac2d1540526ecd294fbd09acda04e096181ab8f1ccd2b464c
+  md5: 0b57b5368ab7fc7cdc9e3511fa867214
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.8
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101232
+  timestamp: 1712239122969
+- conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+  sha256: 30db21d1f7e59b3408b831a7e0417b83b53ee6223afae56482c5f26da3ceb49a
+  md5: 6598c056f64dc8800d40add25e4e2c34
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11638
+  timestamp: 1705850780510
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.2.2-pyhd8ed1ab_0.conda
+  sha256: 613242d5151a4d70438bb2d65041c509e4376b7e18c06c3795c52a18176e41dc
+  md5: c4d5a58f43ce9ffa430e6ecad6c30a42
+  depends:
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab >=4.2.0,<4.3
+  - jupyterlab_server >=2.27.1,<3
+  - notebook-shim >=0.2,<0.3
+  - python >=3.8
+  - tornado >=6.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3904930
+  timestamp: 1724861465900
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+  sha256: 9b5fdef9ebe89222baa9da2796ebe7bc02ec6c5a1f61327b651d6b92cf9a0230
+  md5: 3d85618e2c97ab896b5b5e298d32b5b3
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16880
+  timestamp: 1707957948029
+- conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+  sha256: 5e238e5e646414d517a13f6786c7227206ace58271e3ef63f6adca4d6a4c2839
+  md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
+  depends:
+  - python >=3.6
+  - typing_utils
+  license: Apache-2.0
+  license_family: APACHE
+  size: 30232
+  timestamp: 1706394723472
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhff2d567_1.conda
+  sha256: 74843f871e5cd8a1baf5ed8c406c571139c287141efe532f8ffbdafa3664d244
+  md5: 8508b703977f4c4ada34d657d051972c
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: APACHE
+  size: 60380
+  timestamp: 1731802602808
+- conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
+  md5: 457c2c8c08e54905d6954e79cb5b5db9
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11627
+  timestamp: 1631603397334
+- conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+  sha256: 5a05f572a610cada2fcccef8d555fddf2d01bef80da32411150735e6177d1eab
+  md5: 41c7413071c2bae37472214a3525e6bf
+  depends:
+  - bleach
+  - bokeh >=3.5.0,<3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.1.0,<3.0
+  - python >=3.10
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20670374
+  timestamp: 1731497809631
+- conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+  sha256: db644c81c1f47e1fa8134d5de935ec4269d765fbef8d44bd454eb187c7524472
+  md5: bd991333d5bc659bb82bfb5a5d4c1576
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 103339
+  timestamp: 1719325288387
+- conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+  sha256: bfe404eebb930cc41782d34f8fc04c0388ea692eeebe2c5fc28df8ec8d4d61ae
+  md5: 81534b420deb77da8833f2289b8d47ac
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 75191
+  timestamp: 1712320447201
+- conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+  sha256: 472fc587c63ec4f6eba0cc0b06008a6371e0a08a5986de3cf4e8024a47b4fe6c
+  md5: 0badf9c54e24cecfb0ad2f99d680c163
+  depends:
+  - locket
+  - python >=3.9
+  - toolz
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20884
+  timestamp: 1715026639309
+- conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+  sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
+  md5: 629f3203c99b32e0988910c93e77f3b6
+  depends:
+  - ptyprocess >=0.5
+  - python >=3.7
+  license: ISC
+  size: 53600
+  timestamp: 1706113273252
+- conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+  sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
+  md5: 415f0ebb6198cc2801c73438a9fb5761
+  depends:
+  - python >=3
+  license: MIT
+  license_family: MIT
+  size: 9332
+  timestamp: 1602536313357
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+  sha256: 499313e72e20225f84c2e9690bbaf5b952c8d7e0bf34b728278538f766b81628
+  md5: 5dd546fe99b44fda83963d15f84263b7
+  depends:
+  - python >=3.8,<3.13.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 1243168
+  timestamp: 1730203795600
+- conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+  sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
+  md5: 405678b942f2481cecdb3e010f4925d9
+  depends:
+  - python >=3.6
+  license: MIT AND PSF-2.0
+  size: 10778
+  timestamp: 1694617398467
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
+  sha256: c81bdeadc4adcda216b2c7b373f0335f5c78cc480d1d55d10f21823590d7e46f
+  md5: fd8f2b18b65bbf62e8f653100690c8d2
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 20625
+  timestamp: 1726613611845
+- conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
+  sha256: 01f0c3dd00081637ed920a922b17bcc8ed49608404ee466ced806856e671f6b9
+  md5: 07e9550ddff45150bfc7da146268e165
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: Apache
+  size: 49024
+  timestamp: 1726902073034
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_0.conda
+  sha256: 44e4e6108d425a666856a52d1523e5d70890256a8920bb0dcd3d55cc750f3207
+  md5: 4c05134c48b6a74f33bbb9938e4a115e
+  depends:
+  - python >=3.7
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.48
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270271
+  timestamp: 1727341744544
+- conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+  sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+  md5: 359eeb6536da0e687af562ed265ec263
+  depends:
+  - python
+  license: ISC
+  size: 16546
+  timestamp: 1609419417991
+- conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+  sha256: dcfcb3cee1ae0a89729601582cc3edea20ba13c9493967a03a693c67567af0c8
+  md5: 0f051f09d992e0d08941706ad519ee0e
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 16551
+  timestamp: 1721585805256
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+  sha256: 406001ebf017688b1a1554b49127ca3a4ac4626ec0fd51dc75ffa4415b720b64
+  md5: 844d9eb3b43095b031874477f7d70088
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105098
+  timestamp: 1711811634025
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+  sha256: 0e1e17a37d53be84c33b88218f10afb5f8137f19a727fdc56e45ae0b8b439a57
+  md5: 24c245c82396be3297c0aa26b69e18d8
+  depends:
+  - param >=1.7.0
+  - python >=3.7
+  - pyyaml
+  - requests
+  - setuptools >=61.0
+  constrains:
+  - pyct-core <0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20096
+  timestamp: 1701103924264
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+  sha256: 78267adf4e76d0d64ea2ffab008c501156c108bb08fecb703816fb63e279780b
+  md5: b7f5c092b8f9800150d998a71b76d5a1
+  depends:
+  - python >=3.8
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 879295
+  timestamp: 1714846885370
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_1.conda
+  sha256: b846e3965cd106438cf0b9dc0de8d519670ac065f822a7d66862e9423e0229cb
+  md5: 035c17fbf099f50ff60bf2eb303b0a83
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 92444
+  timestamp: 1728880549923
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
+  sha256: b3a612bc887f3dd0fb7c4199ad8e342bd148cf69a9b74fd9468a18cf2bef07b7
+  md5: 56cd9fe388baac0e90c7149cfac95b60
+  depends:
+  - __win
+  - python >=3.8
+  - win_inet_pton
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19348
+  timestamp: 1661605138291
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+  sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+  md5: 2a7de29fb590ca14b5243c4c812c8025
+  depends:
+  - __unix
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18981
+  timestamp: 1661604969727
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_0.conda
+  sha256: 3888012c5916efaef45d503e3e544bbcc571b84426c1bb9577799ada9efefb54
+  md5: b6dfd90a2141e573e4b6a81630b56df5
+  depends:
+  - python >=3.9
+  - six >=1.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 221925
+  timestamp: 1731919374686
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
+  sha256: 7d8c931b89c9980434986b4deb22c2917b58d9936c3974139b9c10ae86fdfe60
+  md5: b98d2018c01ce9980c03ee2850690fab
+  depends:
+  - python >=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 226165
+  timestamp: 1718477110630
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-graphviz-0.20.3-pyhe28f650_1.conda
+  sha256: 0eca3595a52dd7ad83ebca1ee738af50bf21dbd70d623583b0185d84074e21af
+  md5: 881be78ca9f3f2f5f6aa45d9b38a799f
+  depends:
+  - graphviz >=2.46.1
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 38168
+  timestamp: 1727718740290
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+  sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
+  md5: a61bf9ec79426938ff785eb69dbb1960
+  depends:
+  - python >=3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13383
+  timestamp: 1677079727691
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_0.conda
+  sha256: fe3f62ce2bc714bdaa222ab3f0344a2815ad9e853c6df38d15c9f25de8a3a6d4
+  md5: 986287f89929b2d629bd6ef6497dc307
+  depends:
+  - python >=3.6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 142527
+  timestamp: 1727140688093
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+  sha256: 1a7d6b233f7e6e3bbcbad054c8fd51e690a67b129a899a056a5e45dd9f00cb41
+  md5: 3eeeeb9e4827ace8c0c1419c85d590ad
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 188538
+  timestamp: 1706886944988
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+  sha256: a7979e8e4936c430f5fe3d04fc2d67b42dab84fb4a502c4961a17dcb2327fec0
+  md5: 02b4e3a3014c1ac490ee4a4316f2d229
+  depends:
+  - param
+  - python >=3.6
+  constrains:
+  - jupyterlab >=4.0,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48061
+  timestamp: 1722535734510
+- conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+  sha256: be8d6d9e86b1a3fef5424127ff81782f8ca63d3058980859609f6f1ecdd34cb3
+  md5: 0fc8b52192a8898627c3efae1003e9f6
+  depends:
+  - attrs >=22.2.0
+  - python >=3.8
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 42210
+  timestamp: 1714619625532
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+  sha256: 5845ffe82a6fa4d437a2eae1e32a1ad308d7ad349f61e337c0a890fe04c513cc
+  md5: 5ede4753180c7a550a443c430dc8ab52
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.8
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 58810
+  timestamp: 1717057174842
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
+  md5: fed45fc5ea0813240707998abe49f520
+  depends:
+  - python >=3.5
+  - six
+  license: MIT
+  license_family: MIT
+  size: 8064
+  timestamp: 1638811838081
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+  sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
+  md5: 912a71cc01012ee38e6b90ddd561e36f
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 7818
+  timestamp: 1598024297745
+- conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.10.0-pyhd8ed1ab_0.conda
+  sha256: b5a8e8fb68087166abef44c185dfb8c6ad1e4b54c56e82c03a3e3b306e0ca757
+  md5: 18cc1c4f5b104400d75be999b56486a1
+  depends:
+  - aiobotocore >=2.5.4,<3.0.0
+  - aiohttp
+  - fsspec 2024.10.0
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 32521
+  timestamp: 1729650409739
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_0.conda
+  sha256: c4401b071e86ddfa0ea4f34b85308db2516b6aeca50053535996864cfdee7b3f
+  md5: 778594b20097b5a948c59e50ae42482a
+  depends:
+  - __linux
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22868
+  timestamp: 1712585140895
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
+  sha256: f911307db932c92510da6c3c15b461aef935720776643a1fbf3683f61001068b
+  md5: c3cb67fc72fb38020fe7923dbbcf69b0
+  depends:
+  - __osx
+  - pyobjc-framework-cocoa
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23165
+  timestamp: 1712585504123
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_0.conda
+  sha256: d8aa230501a33250af2deee03006a2579f0335e7240a9c7286834788dcdcfaa8
+  md5: 5a86a21050ca3831ec7f77fb302f1132
+  depends:
+  - __win
+  - python >=3.7
+  - pywin32
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23319
+  timestamp: 1712585816346
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.5.0-pyhff2d567_0.conda
+  sha256: 54dcf5f09f74f69641e0063bc695b38340d0349fa8371b1f2ed0c45c5b2fd224
+  md5: ade63405adb52eeff89d506cd55908c0
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 772480
+  timestamp: 1731707561164
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+  sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
+  md5: e5f25f8dbc060e9a8d912e432202afc2
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 14259
+  timestamp: 1620240338595
+- conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+  sha256: bc12100b2d8836b93c55068b463190505b8064d0fc7d025e89f20ebf22fe6c2b
+  md5: 490730480d76cf9c8f8f2849719c6e2b
+  depends:
+  - python >=3.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 15064
+  timestamp: 1708953086199
+- conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
+  md5: 6d6552722448103793743dabfbda532d
+  depends:
+  - python >=2.7
+  license: Apache-2.0
+  license_family: APACHE
+  size: 26314
+  timestamp: 1621217159824
+- conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+  sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
+  md5: 3f144b2c34f8cb5a9abd9ed23a39c561
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 36754
+  timestamp: 1693929424267
+- conda: https://conda.anaconda.org/conda-forge/noarch/spectate-1.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 8cb681b5bfe986ef88bff649a37cfcc7c88608525e0bf12a1afe0769a3931ccf
+  md5: 33e8cb574899a6790ace9692e9de22d6
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 16292
+  timestamp: 1616655076957
+- conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+  sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
+  md5: e7df0fdd404616638df5ece6e69ba7af
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 26205
+  timestamp: 1669632203115
+- conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+  sha256: 2e2c255b6f24a6d75b9938cb184520e27db697db2c24f04e18342443ae847c0a
+  md5: 04eedddeb68ad39871c8127dd1c21f4f
+  depends:
+  - python >=3.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17386
+  timestamp: 1702066480361
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+  sha256: b300557c0382478cf661ddb520263508e4b3b5871b471410450ef2846e8c352c
+  md5: efba281bbdae5f6b0a1d53c6d4a97c93
+  depends:
+  - __linux
+  - ptyprocess
+  - python >=3.8
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22452
+  timestamp: 1710262728753
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+  sha256: 4daae56fc8da17784578fbdd064f17e3b3076b394730a14119e571707568dc8a
+  md5: 00b54981b923f5aefcd5e8547de056d5
+  depends:
+  - __osx
+  - ptyprocess
+  - python >=3.8
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22717
+  timestamp: 1710265922593
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
+  sha256: 8cb078291fd7882904e3de594d299c8de16dd3af7405787fce6919a385cfc238
+  md5: 4abd500577430a942a995fd0d09b76a2
+  depends:
+  - __win
+  - python >=3.8
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22883
+  timestamp: 1710262943966
+- conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+  sha256: cad582d6f978276522f84bd209a5ddac824742fe2d452af6acf900f8650a73a2
+  md5: f1acf5fdefa8300de697982bcb1761c9
+  depends:
+  - python >=3.5
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28285
+  timestamp: 1729802975370
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.1.0-pyhff2d567_0.conda
+  sha256: 354b8a64d4f3311179d85aefc529ca201a36afc1af090d0010c46be7b79f9a47
+  md5: 3fa1089b4722df3a900135925f4519d9
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 18741
+  timestamp: 1731426862834
+- conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+  sha256: 6371cf3cf8292f2abdcc2bf783d6e70203d72f8ff0c1625f55a486711e276c75
+  md5: 34feccdd4177f2d3d53c73fc44fd9a37
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 52623
+  timestamp: 1728059623353
+- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.0-pyhd8ed1ab_0.conda
+  sha256: fb25b18cec1ebae56e7d7ebbd3e504f063b61a0fac17b1ca798fcaf205bdc874
+  md5: 196a9e6ab4e036ceafa516ea036619b0
+  depends:
+  - colorama
+  - python >=3.7
+  license: MPL-2.0 or MIT
+  size: 89434
+  timestamp: 1730926216380
+- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+  sha256: 8a64fa0f19022828513667c2c7176cfd125001f3f4b9bc00d33732e627dd2592
+  md5: 3df84416a021220d8b5700c613af2dc5
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110187
+  timestamp: 1713535244513
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
+  sha256: 8489af986daebfbcd13d3748ba55431259206e37f184ab42a57e107fecd85e02
+  md5: 3d326f8a2aa2d14d51d8c513426b5def
+  depends:
+  - python >=3.6
+  license: Apache-2.0 AND MIT
+  size: 21765
+  timestamp: 1727940339297
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+  sha256: d3b9a8ed6da7c9f9553c5fd8a4fca9c3e0ab712fa5f497859f82337d67533b73
+  md5: 52d648bd608f5737b123f510bb5514b5
+  depends:
+  - typing_extensions 4.12.2 pyha770c72_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 10097
+  timestamp: 1717802659025
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+  sha256: 0fce54f8ec3e59f5ef3bb7641863be4e1bf1279623e5af3d3fa726e8f7628ddb
+  md5: ebe6952715e1d5eb567eeebf25250fa7
+  depends:
+  - python >=3.8
+  license: PSF-2.0
+  license_family: PSF
+  size: 39888
+  timestamp: 1717802653893
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 9e3758b620397f56fb709f796969de436d63b7117897159619b87938e1f78739
+  md5: eb67e3cace64c66233e2d35949e20f92
+  depends:
+  - python >=3.6.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 13829
+  timestamp: 1622899345711
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+  sha256: 4fde5c3008bf5d2db82f2b50204464314cc3c91c1d953652f7bd01d9e52aefdf
+  md5: 8ac3367aafb1cc0a068483c580af8015
+  license: LicenseRef-Public-Domain
+  size: 122354
+  timestamp: 1728047496079
+- conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+  sha256: 54293cd94da3a6b978b353eb7897555055d925ad0008bc73e85cca19e2587ed0
+  md5: 3b7fc78d7be7b450952aaa916fb78877
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 11162
+  timestamp: 1707507514699
+- conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+  sha256: b76904b53721dc88a46352324c79d2b077c2f74a9f7208ad2c4249892669ae94
+  md5: 0944dc65cb4a9b5b68522c3bb585d41c
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 23999
+  timestamp: 1688655976471
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
+  sha256: b6bb34ce41cd93956ad6eeee275ed52390fb3788d6c75e753172ea7ac60b66e5
+  md5: 6b55867f385dd762ed99ea687af32a69
+  depends:
+  - brotli-python >=1.0.9
+  - h2 >=4,<5
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.8
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 98076
+  timestamp: 1726496531769
+- conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+  sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
+  md5: 68f0738df502a14213624b288c60c9ad
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 32709
+  timestamp: 1704731373922
+- conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
+  sha256: ec71f97c332a7d328ae038990b8090cbfa772f82845b5d2233defd167b7cc5ac
+  md5: eb48b812eb4fbb9ff238a6651fdbbcae
+  depends:
+  - python >=3.5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18378
+  timestamp: 1723294800217
+- conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+  sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
+  md5: daf5160ff9cde3a468556965329085b9
+  depends:
+  - python >=2.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15600
+  timestamp: 1694681458271
+- conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+  sha256: 44a5e3b97feef24cd719f7851cca9af9799dc9c17d3e0298d5856baab2d682f5
+  md5: f372c576b8774922da83cda2b12f9d29
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: APACHE
+  size: 47066
+  timestamp: 1713923494501
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.0-pyhd8ed1ab_0.conda
+  sha256: 8a51067f8e1a2cb0b5e89672dbcc0369e344a92e869c38b2946584aa09ab7088
+  md5: f9751d7c71df27b2d29f5cab3378982e
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 62755
+  timestamp: 1731120002488
+- conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.13-pyhd8ed1ab_0.conda
+  sha256: d155adc10f8c96f76d4468dbe37b33b4334dadf5cd4a95841aa009ca9bced5fa
+  md5: 6372cd99502721bd7499f8d16b56268d
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 898656
+  timestamp: 1724331433259
+- conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_7.conda
+  sha256: c5297692ab34aade5e21107abaf623d6f93847662e25f655320038d2bfa1a812
+  md5: c998c13b2f998af57c3b88c7a47979e0
+  depends:
+  - __win
+  - python >=3.6
+  license: LicenseRef-Public-Domain
+  size: 9602
+  timestamp: 1727796413384
+- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.10.0-pyhd8ed1ab_0.conda
+  sha256: a35c8291de55f96ecc9121d1ebd4995977ea2f51d9e529e97749abc108afb0e4
+  md5: 53e365732dfa053c4d19fc6b927392c4
+  depends:
+  - numpy >=1.24
+  - packaging >=23.1
+  - pandas >=2.1
+  - python >=3.10
+  constrains:
+  - matplotlib-base >=3.7
+  - netcdf4 >=1.6.0
+  - numba >=0.57
+  - hdf5 >=1.12
+  - sparse >=0.14
+  - cftime >=1.6
+  - zarr >=2.16
+  - flox >=0.7
+  - pint >=0.22
+  - toolz >=0.12
+  - scipy >=1.11
+  - seaborn-base >=0.12
+  - distributed >=2023.9
+  - iris >=3.7
+  - cartopy >=0.22
+  - bottleneck >=1.3
+  - dask-core >=2023.9
+  - h5py >=3.8
+  - h5netcdf >=1.2
+  - nc-time-axis >=1.4
+  license: Apache-2.0
+  license_family: APACHE
+  size: 813754
+  timestamp: 1729867978934
+- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.4.0-pyhd8ed1ab_0.conda
+  sha256: b6211a7e1eb3dce320b2baa11134561d29bad46a37e273bab69461f4e9d80251
+  md5: 892f97df8ce15d77157696d2d38866f4
+  depends:
+  - datashader >=0.15.0
+  - numba
+  - numpy
+  - python >=3.8
+  - xarray
+  license: MIT
+  license_family: MIT
+  size: 1704148
+  timestamp: 1714314358485
+- conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_0.conda
+  sha256: 2dd2825b5a246461a95a0affaf7e1d459f7cc0ae68ad2dd8aab360c2e5859488
+  md5: 156c91e778c1d4d57b709f8c5333fd06
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 46887
+  timestamp: 1725366457240
+- conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.18.3-pyhd8ed1ab_0.conda
+  sha256: 0fd9bf7ba90088115c52dad7b9d44fbffeabe34cb35299b2c38d5f17851fda36
+  md5: 41abde21508578e02e3fd492e82a05cd
+  depends:
+  - asciitree
+  - fasteners
+  - numcodecs >=0.10.0,<0.16.0a0
+  - numpy >=1.24,<3.0
+  - python >=3.10
+  constrains:
+  - ipywidgets >=8.0.0
+  - notebook
+  - ipytree >=0.2.2
+  license: MIT
+  license_family: MIT
+  size: 159273
+  timestamp: 1725539879186
+- conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+  sha256: 3d65c081514569ab3642ba7e6c2a6b4615778b596db6b1c82ee30a2d912539e5
+  md5: cf30c2c15b82aacb07f9c09e28ff2275
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36325
+  timestamp: 1681770298596
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_0.conda
+  sha256: 232a30e4b0045c9de5e168dda0328dc0e28df9439cdecdfb97dd79c1c82c4cec
+  md5: fee389bf8a4843bd7a2248ce11b7f188
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 21702
+  timestamp: 1731262194278
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.11.2-py311ha3cf9ac_0.conda
+  sha256: 24172aa0d08ffad2cf5054a313c2dc80814ff4358c363ee66a43dc84bf71649a
+  md5: 97f2f6a8e4d04668e96019a91882be6a
+  depends:
+  - __osx >=10.13
+  - aiohappyeyeballs >=2.3.0
+  - aiosignal >=1.1.2
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - multidict >=4.5,<7.0
+  - propcache >=0.2.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yarl >=1.17.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  size: 864953
+  timestamp: 1731703691611
+- conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h3336109_5.conda
+  sha256: fa5eb633b320e10fc2138f3d842d8a8ca72815f106acbab49a68ec9783e4d70d
+  md5: 29b46bd410067f668c4cef7fdc78fe25
+  depends:
+  - __osx >=10.13
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 32275
+  timestamp: 1725356815696
+- conda: https://conda.anaconda.org/conda-forge/osx-64/atk-1.0-2.38.0-h4bec284_2.conda
+  sha256: a5972a943764e46478c966b26be61de70dcd7d0cfda4bd0b0c46916ae32e0492
+  md5: d9684247c943d492d9aac8687bc5db77
+  depends:
+  - __osx >=10.9
+  - libcxx >=16
+  - libglib >=2.80.0,<3.0a0
+  - libintl >=0.22.5,<1.0a0
+  constrains:
+  - atk-1.0 2.38.0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 349989
+  timestamp: 1713896423623
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.8.0-hb1b2711_10.conda
+  sha256: 88731bee2b93e8bf5e6c0a692da9a28ac017de16880e72d6a26d4f48377a69ae
+  md5: cabb2823d1eaa138c1fa5ea3b68b9f8a
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94585
+  timestamp: 1731733610867
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.8.0-h1c3498a_2.conda
+  sha256: fa5cf06e1553198ef41d6aae29bfdf990053db185c492c27b116b2c91137e8c0
+  md5: b900b8d8f2d51c1b84ad1c8a1366c1e3
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 39373
+  timestamp: 1731678700352
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.10.3-h6e16a3a_0.conda
+  sha256: b31603e305c9a7b9f7dca010471ac2012a4c570da483737ec090db4812674fe8
+  md5: d1b72435b57b79fb97ba3ab6564db34c
+  depends:
+  - __osx >=10.13
+  license: Apache-2.0
+  license_family: Apache
+  size: 227079
+  timestamp: 1731567405398
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.3.0-h1c3498a_2.conda
+  sha256: 7cbb8cf79428c342518b2ba456361f89e48ec5ae6a974b2bb3bd8ceb84778c5c
+  md5: af56ad879a463b520989ddd774aa7695
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18023
+  timestamp: 1731678883009
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.5.0-heedde58_7.conda
+  sha256: 5fe9a5cc297d8c54536d7958738db35ae7ef561ad02494692b03c5c2b41f896e
+  md5: b1fa857b39304646770e3f0d70182ed3
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 46953
+  timestamp: 1731714670991
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.9.1-h0c96e2d_2.conda
+  sha256: dab3bc124acb36fd89839337b37fac40fcf47798a66934aa18e280a889646e8e
+  md5: e0596752aa1c4f748c88bce167ae003d
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-compression >=0.3.0,<0.3.1.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 164320
+  timestamp: 1731714564875
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.15.2-h789f5c1_2.conda
+  sha256: 57775bb51fbb45405575548d7452fc7702affac744fd6b80aebc82a28f5e2cba
+  md5: f85932994b14737e4ec6b6dc0bb66036
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 139362
+  timestamp: 1731702578455
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.11.0-h00ab244_8.conda
+  sha256: 5ba0cd019a01ca553784d18f6e4cc60a481eb88410ca689b6adbc1915cb85b89
+  md5: 0c2db3585e4c1865cdf4528720bab440
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 164288
+  timestamp: 1731734750092
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.7.1-h704940e_3.conda
+  sha256: 976099a58d2f171b1ba4ffe7e3fc1431cf903d70360e6705c3633bc87c1090b1
+  md5: 6ac3fb96662302c6db50afdb7c3bc71b
+  depends:
+  - __osx >=10.13
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 98295
+  timestamp: 1731745189033
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.2.1-h1c3498a_1.conda
+  sha256: 59f47c5bea2ddc1c502999e6b2a4ebb81be7ddbf9d2b5818ff1cdc5ad58aa03d
+  md5: 70cd54aaaddb6efa4e5d41fa8f045a44
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51034
+  timestamp: 1731687124981
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.2.2-h1c3498a_1.conda
+  sha256: a52b53437bd274eeee1bdd1427686b2d3b4bed586a91f0ea5a4c45303805cd56
+  md5: a13de34c0c2224a8755ef3854f85c2a8
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 70940
+  timestamp: 1731687320283
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.29.4-h44c5c52_1.conda
+  sha256: ad20dc69b25262631f2f7f33f3b93049722a9480df8ae64f8d5b23251d1d36a4
+  md5: 9ec205c058461ca674e3194e31de68ab
+  depends:
+  - __osx >=10.13
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-mqtt >=0.11.0,<0.11.1.0a0
+  - aws-c-s3 >=0.7.1,<0.7.2.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 298024
+  timestamp: 1731787266415
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.449-h7bf9075_2.conda
+  sha256: acf125902c715c0a8c53b3e2005406d4df25cc48530a7239606ebcb45019e1e9
+  md5: f22a9a4d62f1ab66a6b0ff3f978e9447
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - aws-crt-cpp >=0.29.4,<0.29.5.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2777262
+  timestamp: 1731927927590
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.14.0-h9a36307_0.conda
+  sha256: c7694fc16b9aebeb6ee5e4f80019b477a181d961a3e4d9b6a66b77777eb754fe
+  md5: 1082a031824b12a2be731d600cfa5ccb
+  depends:
+  - __osx >=10.13
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 303166
+  timestamp: 1728053999891
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.10.0-ha4e2ba9_0.conda
+  sha256: b9899b9698a6c7353fc5078c449105aae58635d217befbc8ca9d5a527198019b
+  md5: ad56b6a4b8931d37a2cf5bc724a46f01
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 175344
+  timestamp: 1728487066445
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.13.0-h3d2f5f1_1.conda
+  sha256: 31984e52450230d04ca98d5232dbe256e5ef6e32b15d46124135c6e64790010d
+  md5: 3df4fb5d6d0e7b3fb28e071aff23787e
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 445040
+  timestamp: 1728578180436
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.8.0-h1ccc5ac_1.conda
+  sha256: 51fb67d2991d105b8f7b97b4810cd63bac4dc421a4a9c83c15a98ca520a42e1e
+  md5: 5b3e79eb148d6e30d6c697788bad9960
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - libxml2 >=2.12.7,<2.14.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 126229
+  timestamp: 1728563580392
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-files-datalake-cpp-12.12.0-h86941f0_1.conda
+  sha256: 12d95251a8793ea2e78f494e69353a930e9ea06bbaaaa4ccb6e5b3e35ee0744f
+  md5: 60452336e7f61f6fdaaff69264ee112e
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 200991
+  timestamp: 1728729588371
+- conda: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.6-h7d75f6d_0.conda
+  sha256: 65e5f5dd3d68ed0d9d35e79d64f8141283cad2b55dcd9a04480ceea0e436aca8
+  md5: 3e5669e51737d04f4806dd3e8c424663
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 47051
+  timestamp: 1719266142315
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h00291cd_2.conda
+  sha256: 624954bc08b3d7885a58c7d547282cfb9a201ce79b748b358f801de53e20f523
+  md5: 2db0c38a7f2321c5bdaf32b181e832c7
+  depends:
+  - __osx >=10.13
+  - brotli-bin 1.1.0 h00291cd_2
+  - libbrotlidec 1.1.0 h00291cd_2
+  - libbrotlienc 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 19450
+  timestamp: 1725267851605
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h00291cd_2.conda
+  sha256: 642a8492491109fd8270c1e2c33b18126712df0cedb94aaa2b1c6b02505a4bfa
+  md5: 049933ecbf552479a12c7917f0a4ce59
+  depends:
+  - __osx >=10.13
+  - libbrotlidec 1.1.0 h00291cd_2
+  - libbrotlienc 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 16643
+  timestamp: 1725267837325
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hd89902b_2.conda
+  sha256: 004cefbd18f581636a8dcb1964fb73478f15d496769226ec896c1d4a0161b7d8
+  md5: d75f06ee06001794aa83a05e885f1520
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 363793
+  timestamp: 1725267947069
+- conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+  sha256: cad153608b81fb24fc8c509357daa9ae4e49dfc535b2cb49b91e23dbd68fc3c5
+  md5: 7ed4301d437b59045be7e051a0308211
+  depends:
+  - __osx >=10.13
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 134188
+  timestamp: 1720974491916
+- conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.3-hf13058a_0.conda
+  sha256: e1bc2520ba9bfa55cd487efabd6bfaa49ccd944847895472133ba919810c9978
+  md5: c36355bc08d4623c210b00f9935ee632
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 183798
+  timestamp: 1731181957603
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.8.30-h8857fd0_0.conda
+  sha256: 593f302d0f44c2c771e1614ee6d56fffdc7d616e6f187669c8b0e34ffce3e1ae
+  md5: b7e5424e7f06547a903d28e4651dbb21
+  license: ISC
+  size: 158665
+  timestamp: 1725019059295
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h37bd5c4_3.conda
+  sha256: 8d70fbca4887b9b580de0f3715026e05f9e74fad8a652364aa0bccd795b1fa87
+  md5: 448aad56614db52338dc4fd4c758cfb6
+  depends:
+  - __osx >=10.13
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libcxx >=16
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.4,<1.0a0
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 892544
+  timestamp: 1721139116538
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.1-py311h137bacd_0.conda
+  sha256: 012ee7b1ed4f9b0490d6e90c72decf148d7575173c7eaf851cd87fd434d2cacc
+  md5: a4b0f531064fa3dd5e3afbb782ea2cd5
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 288762
+  timestamp: 1725560945833
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cftime-1.6.4-py311h0034819_1.conda
+  sha256: 025d33877c4e3558bd3d8c8d11bcd11760d61634d1b1be819203c5b00b770132
+  md5: cda3610885501f18aec020da7f92cf25
+  depends:
+  - __osx >=10.13
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 211019
+  timestamp: 1725400678395
+- conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.1-py311h4e34fa0_0.conda
+  sha256: 373e17f22bca3e13aac2245bb0c8a15c4a54d1ffa4c3278308eeb8d3c9435c0e
+  md5: 6bc3882064e277827934e2c6e5281661
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 255123
+  timestamp: 1731428577146
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.0.0-py311h3336109_1.conda
+  sha256: fd921e8aa9ec5d26b2aebaef91dd4bc1e6d4fd2114f2fc566578122ff95cdb3c
+  md5: d7a579f4ad0ad76e49fb62151ad6fd6f
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 344088
+  timestamp: 1728335202437
+- conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.8-py311hc356e98_0.conda
+  sha256: 34f83a442443323f02e7674a5accadd376324535db561415c7ce6796c88cb5dc
+  md5: 89062c093aafdfa2155f13967177ef8a
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2492179
+  timestamp: 1731045106437
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.15.0-h37eeddb_1.conda
+  sha256: 61a9aa1d2dd115ffc1ab372966dc8b1ac7b69870e6b1744641da276b31ea5c0b
+  md5: 84ccec5ee37eb03dd352db0a3f89ada3
+  depends:
+  - __osx >=10.13
+  - freetype >=2.12.1,<3.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 232313
+  timestamp: 1730283983397
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.55.0-py311ha3cf9ac_0.conda
+  sha256: 14c8fe864b2b0df5f74e9f5079cbbbd614bf35135746473276fc40e82128f364
+  md5: 57ae8d06b0d70028a20d2e87b3ea8724
+  depends:
+  - __osx >=10.13
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2808934
+  timestamp: 1731643652637
+- conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+  sha256: b292cf5a25f094eeb4b66e37d99a97894aafd04a5683980852a8cbddccdc8e4e
+  md5: 25152fce119320c980e5470e64834b50
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 599300
+  timestamp: 1694616137838
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fribidi-1.0.10-hbcb3906_0.tar.bz2
+  sha256: 4f6db86ecc4984cd4ac88ca52030726c3cfd11a64dfb15c8602025ee3001a2b5
+  md5: f1c6b41e0f56998ecd9a3e210faa1dc0
+  license: LGPL-2.1
+  size: 65388
+  timestamp: 1604417213000
+- conda: https://conda.anaconda.org/conda-forge/osx-64/frozenlist-1.5.0-py311h1314207_0.conda
+  sha256: 36e430566ea33d33d4b6092e74b75a52d40bc15ea53534f3fad4f3fb971cf021
+  md5: 00c859c1395300f2679bc81e055f3dae
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 53479
+  timestamp: 1729699615503
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gdk-pixbuf-2.42.12-ha587570_0.conda
+  sha256: 92cb602ef86feb35252ee909e19536fa043bd85b8507450ad8264cfa518a5881
+  md5: ee186d2e8db4605030753dc05025d4a0
+  depends:
+  - __osx >=10.13
+  - libglib >=2.80.2,<3.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 516815
+  timestamp: 1715783154558
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hac325c4_1005.conda
+  sha256: c0bea66f71a6f4baa8d4f0248e17f65033d558d9e882c0af571b38bcca3e4b46
+  md5: a26de8814083a6971f14f9c8c3cb36c2
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84946
+  timestamp: 1726600054963
+- conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h2790a97_0.conda
+  sha256: dd56547db8625eb5c91bb0a9fbe8bd6f5c7fbf5b6059d46365e94472c46b24f9
+  md5: 06cf91665775b0da395229cd4331b27d
+  depends:
+  - __osx >=10.13
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 117017
+  timestamp: 1718284325443
+- conda: https://conda.anaconda.org/conda-forge/osx-64/graphite2-1.3.13-h73e2aa4_1003.conda
+  sha256: b71db966e47cd83b16bfcc2099b8fa87c07286f24a0742078fede4c84314f91a
+  md5: fc7124f86e1d359fc5d878accd9e814c
+  depends:
+  - libcxx >=16
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 84384
+  timestamp: 1711634311095
+- conda: https://conda.anaconda.org/conda-forge/osx-64/graphviz-12.0.0-he14ced1_0.conda
+  sha256: 91fbeecf3aaa4032c6f01c4242cfe2ee1bee21e70d085bafb3958ce7d6ab7c3c
+  md5: ef49aa1e3614bfc6fb5369675129c09b
+  depends:
+  - __osx >=10.13
+  - cairo >=1.18.0,<2.0a0
+  - fonts-conda-ecosystem
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - gtk2
+  - gts >=0.7.6,<0.8.0a0
+  - libcxx >=16
+  - libexpat >=2.6.2,<3.0a0
+  - libgd >=2.3.3,<2.4.0a0
+  - libglib >=2.80.3,<3.0a0
+  - librsvg >=2.58.2,<3.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pango >=1.50.14,<2.0a0
+  license: EPL-1.0
+  license_family: Other
+  size: 4984341
+  timestamp: 1722673941539
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gtk2-2.24.33-h2c15c3c_5.conda
+  sha256: 9d7a50dae4aef357473b16c5121c1803a0c9ee1b8f93c4d90dc0196ae5007208
+  md5: 308376a1154bc0ab3bbeeccf6ff986be
+  depends:
+  - __osx >=10.13
+  - atk-1.0 >=2.38.0
+  - cairo >=1.18.0,<2.0a0
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - libglib >=2.80.3,<3.0a0
+  - libintl >=0.22.5,<1.0a0
+  - pango >=1.54.0,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 6162947
+  timestamp: 1721286459536
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gts-0.7.6-h53e17e3_4.conda
+  sha256: d5b82a36f7e9d7636b854e56d1b4fe01c4d895128a7b73e2ec6945b691ff3314
+  md5: 848cc963fcfbd063c7a023024aa3bec0
+  depends:
+  - libcxx >=15.0.7
+  - libglib >=2.76.3,<3.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 280972
+  timestamp: 1686545425074
+- conda: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-9.0.0-h098a298_1.conda
+  sha256: dbc7783ea89faaf3a810d0e55979be02031551be8edad00de915807b3b148ff1
+  md5: 8dd3c790d5ce9f3bc94c46e5b218e5f8
+  depends:
+  - __osx >=10.13
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=75.1,<76.0a0
+  - libcxx >=16
+  - libglib >=2.80.3,<3.0a0
+  license: MIT
+  license_family: MIT
+  size: 1372588
+  timestamp: 1721186294497
+- conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
+  sha256: 8c767cc71226e9eb62649c903c68ba73c5f5e7e3696ec0319d1f90586cebec7d
+  md5: 7ce543bf38dbfae0de9af112ee178af2
+  depends:
+  - libcxx >=15.0.7
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 724103
+  timestamp: 1695661907511
+- conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.4-nompi_h1607680_103.conda
+  sha256: bcec9cfa16cd8a3562255d3a97930716cf7c788aad6338baf6bd7bd7c803aa32
+  md5: 23eb36be1235e5986845d9f7d1acedc0
+  depends:
+  - __osx >=10.13
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3733556
+  timestamp: 1730831490461
+- conda: https://conda.anaconda.org/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
+  sha256: 2e64307532f482a0929412976c8450c719d558ba20c0962832132fd0d07ba7a7
+  md5: d68d48a3060eb5abdc1cdc8e2a3a5966
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 11761697
+  timestamp: 1720853679409
+- conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_1.conda
+  sha256: 2499e5ebb3efa4186d6922122224d16bac791a5c0adad5b48b2bcd1e1e2afc8d
+  md5: b6c1710105dad14d47001a339cd14da6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17727
+  timestamp: 1725302991176
+- conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.7-py311hf2f7c97_0.conda
+  sha256: 00b477bff9138ca51edd94f7b31ce9fe2cd13a1dc8768abcf037a22eccf26940
+  md5: 24b0e3e3444be9fabcc8457c409e297f
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 60398
+  timestamp: 1725459431458
+- conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+  sha256: 83b52685a4ce542772f0892a0f05764ac69d57187975579a0835ff255ae3ef9c
+  md5: d4765c524b1d91567886bde656fb514b
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1185323
+  timestamp: 1719463492984
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
+  sha256: 222ebc0a55544b9922f61e75015d02861e65b48f12113af41d48ba0814e14e4e
+  md5: 1442db8f03517834843666c422238c9b
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 224432
+  timestamp: 1701648089496
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+  sha256: e41790fc0f4089726369b3c7f813117bbc14b533e0ed8b94cf75aba252e82497
+  md5: f9d6a4c82889d5ecedec1d90eb673c55
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 290319
+  timestamp: 1657977526749
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240722.0-cxx17_hac325c4_1.conda
+  sha256: b548e80280242ad1d93d8d7fb48a30af7e4124959ba2031c65c9675b98163652
+  md5: 40373920232a6ac0404eee9cf39a9f09
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  constrains:
+  - abseil-cpp =20240722.0
+  - libabseil-static =20240722.0=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1170354
+  timestamp: 1727295597292
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
+  sha256: dae5921339c5d89f4bf58a95fd4e9c76270dbf7f6a94f3c5081b574905fcccf8
+  md5: 66d3c1f6dd4636216b4fca7a748d50eb
+  depends:
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 28602
+  timestamp: 1711021419744
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-18.0.0-hd4c0275_7_cpu.conda
+  sha256: e66ca68afd9976cc6fdeed81eaabfe539ecca097aaea1583968d8b355a3b4a3c
+  md5: 9370f2e706f21f65a57cf9db054f72f2
+  depends:
+  - __osx >=10.13
+  - aws-crt-cpp >=0.29.4,<0.29.5.0a0
+  - aws-sdk-cpp >=1.11.449,<1.11.450.0a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-identity-cpp >=1.10.0,<1.10.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-files-datalake-cpp >=12.12.0,<12.12.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=18
+  - libgoogle-cloud >=2.31.0,<2.32.0a0
+  - libgoogle-cloud-storage >=2.31.0,<2.32.0a0
+  - libre2-11 >=2024.7.2
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.3,<2.0.4.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  - libutf8proc <2.9
+  constrains:
+  - arrow-cpp <0.0a0
+  - parquet-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 6094679
+  timestamp: 1731789696651
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-18.0.0-h240833e_7_cpu.conda
+  sha256: 4673a97dd65858cbb917395602a0ba9be600d2fcbfbbfb337214a3e000c37556
+  md5: 6ccd41d5bce7e86eb0d7c4cece6deb67
+  depends:
+  - __osx >=10.13
+  - libarrow 18.0.0 hd4c0275_7_cpu
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: APACHE
+  size: 530643
+  timestamp: 1731789802596
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-18.0.0-h240833e_7_cpu.conda
+  sha256: 78e16510e02df6defcfe4bc4cface772ae5b705c65d4164e2a653bebed3faea9
+  md5: 98178eabf3aa43b160b0e8167ebe6ed0
+  depends:
+  - __osx >=10.13
+  - libarrow 18.0.0 hd4c0275_7_cpu
+  - libarrow-acero 18.0.0 h240833e_7_cpu
+  - libcxx >=18
+  - libparquet 18.0.0 hc957f30_7_cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 522338
+  timestamp: 1731790824839
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-18.0.0-h5c0c8cd_7_cpu.conda
+  sha256: 69057a37bbfd5b60f299638c82c266a2dd03e3d5b4e28d3ea4480fed036409b0
+  md5: 87ff9930ff9be7ea7d8caa49dde049fa
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 18.0.0 hd4c0275_7_cpu
+  - libarrow-acero 18.0.0 h240833e_7_cpu
+  - libarrow-dataset 18.0.0 h240833e_7_cpu
+  - libcxx >=18
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 473844
+  timestamp: 1731790970090
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-25_osx64_openblas.conda
+  sha256: 1b22b5322a311a775bca637b26317645cf07e35f125cede9278c6c45db6e7105
+  md5: da0a6f87958893e1d2e2bbc7e7a6541f
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - liblapack 3.9.0 25_osx64_openblas
+  - liblapacke 3.9.0 25_osx64_openblas
+  - blas * openblas
+  - libcblas 3.9.0 25_osx64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15952
+  timestamp: 1729643159199
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h00291cd_2.conda
+  sha256: b377056470a9fb4a100aa3c51b3581aab6496ba84d21cd99bcc1d5ef0359b1b6
+  md5: 58f2c4bdd56c46cc7451596e4ae68e0b
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 67267
+  timestamp: 1725267768667
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h00291cd_2.conda
+  sha256: 4d49ea72e2f44d2d7a8be5472e4bd0bc2c6b89c55569de2c43576363a0685c0c
+  md5: 34709a1f5df44e054c4a12ab536c5459
+  depends:
+  - __osx >=10.13
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 29872
+  timestamp: 1725267807289
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h00291cd_2.conda
+  sha256: 477d236d389473413a1ccd2bec1b66b2f1d2d7d1b4a57bb56421b7b611a56cd1
+  md5: 691f0dcb36f1ae67f5c489f20ae987ea
+  depends:
+  - __osx >=10.13
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 296353
+  timestamp: 1725267822076
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-25_osx64_openblas.conda
+  sha256: b04ae297aa5396df3135514866db72845b111c92524570f923625473f11cfbe2
+  md5: ab304b75ea67f850cf7adf9156e3f62f
+  depends:
+  - libblas 3.9.0 25_osx64_openblas
+  constrains:
+  - liblapack 3.9.0 25_osx64_openblas
+  - liblapacke 3.9.0 25_osx64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15842
+  timestamp: 1729643166929
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+  sha256: 3043869ac1ee84554f177695e92f2f3c2c507b260edad38a0bf3981fce1632ff
+  md5: 23d6d5a69918a438355d7cbc4c3d54c9
+  depends:
+  - libcxx >=11.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20128
+  timestamp: 1633683906221
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.10.1-h58e7537_0.conda
+  sha256: 662fe145459ed58dee882e525588d1da4dcc4cbd10cfca0725d1fc3840461798
+  md5: 6c8669d8228a2bbd0283911cc6d6726e
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 402588
+  timestamp: 1726660264675
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.3-hf95d169_0.conda
+  sha256: 466f259bb13a8058fef28843977c090d21ad337b71a842ccc0407bccf8d27011
+  md5: 86801fc56d4641e3ef7a63f5d996b960
+  depends:
+  - __osx >=10.13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 528991
+  timestamp: 1730314340106
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.22-h00291cd_0.conda
+  sha256: 681035346974c3315685dc40898e26f65f1c00cbb0b5fd80cc2599e207a34b31
+  md5: a15785ccc62ae2a8febd299424081efb
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 70407
+  timestamp: 1728177128525
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+  sha256: dbd3c3f2eca1d21c52e4c03b21930bbce414c4592f8ce805801575b9e9256095
+  md5: 6016a8a1d0e63cac3de2c352cd40208b
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 105382
+  timestamp: 1597616576726
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+  sha256: 0d238488564a7992942aa165ff994eca540f687753b4f0998b29b4e4d030ff43
+  md5: 899db79329439820b7e8f8de41bca902
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 106663
+  timestamp: 1702146352558
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+  sha256: e0bd9af2a29f8dd74309c0ae4f17a7c2b8c4b89f875ff1d6540c941eefbd07fb
+  md5: e38e467e577bd193a7d5de7c2c540b04
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372661
+  timestamp: 1685726378869
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.4-h240833e_0.conda
+  sha256: d10f43d0c5df6c8cf55259bce0fe14d2377eed625956cddce06f58827d288c59
+  md5: 20307f4049a735a78a29073be1be2626
+  depends:
+  - __osx >=10.13
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 70758
+  timestamp: 1730967204736
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+  sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
+  md5: ccb34fb14960ad8b125962d3d79b31a9
+  license: MIT
+  license_family: MIT
+  size: 51348
+  timestamp: 1636488394370
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgd-2.3.3-h2e77e4f_10.conda
+  sha256: b5ae19078f96912058d0f96120bf56dae11a417178cfcf220219486778ef868d
+  md5: a87f68ea91c66e1a9fb515f6aeba6ba2
+  depends:
+  - __osx >=10.13
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: GD
+  license_family: BSD
+  size: 200456
+  timestamp: 1722928713359
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+  sha256: 4874422e567b68334705c135c17e5acdca1404de8255673ce30ad3510e00be0d
+  md5: 0b6e23a012ee7a9a5f6b244f5a92c1d5
+  depends:
+  - libgfortran5 13.2.0 h2873a65_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110106
+  timestamp: 1707328956438
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+  sha256: da3db4b947e30aec7596a3ef92200d17e774cccbbf7efc47802529a4ca5ca31b
+  md5: e4fb4d23ec2870ff3c40d10afe305aec
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1571379
+  timestamp: 1707328880361
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.82.2-hb6ef654_0.conda
+  sha256: d782be2d8d6784f0b8584ca3cfa93357cddc71b0975560a2bcabd174dac60fff
+  md5: 2e0511f82f1481210f148e1205fe2482
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  constrains:
+  - glib 2.82.2 *_0
+  license: LGPL-2.1-or-later
+  size: 3692367
+  timestamp: 1729191628049
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.31.0-hd00c612_0.conda
+  sha256: 10df0003243d2ef5cca614351fa24efe42164912d358378a947c06167eba6b45
+  md5: 65d85eb999d66f8be20d3735a9ceaa7f
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - openssl >=3.3.2,<4.0a0
+  constrains:
+  - libgoogle-cloud 2.31.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 890808
+  timestamp: 1731121937109
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.31.0-h3f2b517_0.conda
+  sha256: e1f53309fe02143e1342ccb658466be015a1ee4249d306eed4158d75f680d992
+  md5: 3f8c6c99af88f5039869c24aea7024a6
+  depends:
+  - __osx >=10.13
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libcxx >=18
+  - libgoogle-cloud 2.31.0 hd00c612_0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  size: 541478
+  timestamp: 1731123018190
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.67.1-he6e0b18_0.conda
+  sha256: 0884aaa894617fac40c0e0d03a03d2ea6ea486fe9692a0ff854cbe4b080e4c6a
+  md5: 05ea1754e8da5d0e8faf9ec599505834
+  depends:
+  - __osx >=10.13
+  - c-ares >=1.34.2,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libre2-11 >=2024.7.2
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.67.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5335099
+  timestamp: 1730235623016
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
+  sha256: 23d4923baeca359423a7347c2ed7aaf48c68603df0cf8b87cc94a10b0d4e9a23
+  md5: 6c3628d047e151efba7cf08c5e54d1ca
+  license: LGPL-2.1-only
+  size: 666538
+  timestamp: 1702682713201
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-hdfe23c8_3.conda
+  sha256: 0dbb662440a73e20742f12d88e51785a5a5117b8b150783a032b8818a8c043af
+  md5: 52d4d643ed26c07599736326c46bf12f
+  depends:
+  - __osx >=10.13
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 88086
+  timestamp: 1723626826235
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+  sha256: d9572fd1024adc374aae7c247d0f29fdf4b122f1e3586fe62acc18067f40d02f
+  md5: 72507f8e3961bc968af17435060b6dd6
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 579748
+  timestamp: 1694475265912
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-25_osx64_openblas.conda
+  sha256: 2a9a6143d103e7e21511cbf439521645bdd506bfabfcac9d6398dd0562c6905c
+  md5: dda0e24b4605ebbd381e48606a107bed
+  depends:
+  - libblas 3.9.0 25_osx64_openblas
+  constrains:
+  - liblapacke 3.9.0 25_osx64_openblas
+  - blas * openblas
+  - libcblas 3.9.0 25_osx64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15852
+  timestamp: 1729643174413
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-hc8e404f_4.conda
+  sha256: 0df3902a300cfe092425f86144d5e00ef67be3cd1cc89fd63084d45262a772ad
+  md5: ed06753e2ba7c66ed0ca7f19578fcb68
+  depends:
+  - libcxx >=15
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 22467131
+  timestamp: 1690563140552
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.2-nompi_h976d569_115.conda
+  sha256: 90fbe85be42ce31b4d41b54fe2d686049435c08ffbc60f8b6a9c39de51102031
+  md5: cece37517cf646a6a710080f8fc1528d
+  depends:
+  - __osx >=10.13
+  - blosc >=1.21.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzip >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zlib
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 724239
+  timestamp: 1728056183743
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.64.0-hc7306c3_0.conda
+  sha256: 0dcfdcf3a445d2d7de4f3b186ab0a794dc872f4ea21622f9b997be72712c027f
+  md5: ab21007194b97beade22ceb7a3f6fee5
+  depends:
+  - __osx >=10.13
+  - c-ares >=1.34.2,<2.0a0
+  - libcxx >=17
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 606663
+  timestamp: 1729572019083
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_hbf64a52_1.conda
+  sha256: cef5856952688ce9303f85f5bc62c99e8c2256b4c679f63afdfb381f222e90c7
+  md5: cd2c572c02a73b88c4d378eb31110e85
+  depends:
+  - __osx >=10.13
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - llvm-openmp >=18.1.8
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6165715
+  timestamp: 1730773348340
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-18.0.0-hc957f30_7_cpu.conda
+  sha256: 05e729252f6645ca0da3819dbac920dc6bae742b957235258577b7cff6320464
+  md5: 3fcdd24e220f71d572a3d7bc14b14ed5
+  depends:
+  - __osx >=10.13
+  - libarrow 18.0.0 hd4c0275_7_cpu
+  - libcxx >=18
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 948962
+  timestamp: 1731790749269
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.44-h4b8f8c9_0.conda
+  sha256: 12b44e58f8832798d7a5c0a7480c95e905dbd6c3558dec09739062411f9e08d1
+  md5: f32ac2c8dd390dbf169f550887ed09d9
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 268073
+  timestamp: 1726234803010
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-5.28.2-h8b30cf6_0.conda
+  sha256: e240c2003e301ede0a0f4af7688adb8456559ffaa4af2eed3fce879c22c80a0e
+  md5: 2302089e5bcb04ce891ce765c963befb
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2428926
+  timestamp: 1728565541606
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2024.07.02-hd530cb8_1.conda
+  sha256: 2fac39fb704ded9584d1a9e7511163830016803f83852a724c2ccef1cc16e17b
+  md5: 1e14c67a5e8a9273a98b83fbc0905b99
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 178580
+  timestamp: 1728779037721
+- conda: https://conda.anaconda.org/conda-forge/osx-64/librsvg-2.58.4-h2682814_0.conda
+  sha256: ed2d08ef3647d1c10fa51a0480f215ddae04f73a2bd9bbd135d3f37d313d84a6
+  md5: 0022c69263e9bb8c530feff2dfc431f9
+  depends:
+  - __osx >=10.13
+  - cairo >=1.18.0,<2.0a0
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - libglib >=2.80.3,<3.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - pango >=1.54.0,<2.0a0
+  constrains:
+  - __osx >=10.13
+  license: LGPL-2.1-or-later
+  size: 4919155
+  timestamp: 1726227702081
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
+  sha256: d3975cfe60e81072666da8c76b993af018cf2e73fe55acba2b5ba0928efaccf5
+  md5: 6af4b059e26492da6013e79cbcb4d069
+  depends:
+  - __osx >=10.13
+  license: ISC
+  size: 210249
+  timestamp: 1716828641383
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.0-h2f8c449_1.conda
+  sha256: a0f7381c867898a45018b1e5cf1aca68659d292d58252e8f489a4270b010fed8
+  md5: af445c495253a871c3d809e1199bb12b
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 915300
+  timestamp: 1730208101739
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+  sha256: f3886763b88f4b24265db6036535ef77b7b77ce91b1cbe588c0fbdd861eec515
+  md5: ca3a72efba692c59a90d4b9fc0dfe774
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 259556
+  timestamp: 1685837820566
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.21.0-h75589b3_0.conda
+  sha256: 3f82eddd6de435a408538ac81a7a2c0c155877534761ec9cd7a2906c005cece2
+  md5: 7a472cd20d9ae866aeb6e292b33381d6
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 332651
+  timestamp: 1727206546431
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-h583c2ba_1.conda
+  sha256: 4d58c695dfed6f308d0fd3ff552e0078bb98bc0be2ea0bf55820eb6e86fa5355
+  md5: 4b78bcdcc8780cede8b3d090deba874d
+  depends:
+  - __osx >=10.13
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=17
+  - libdeflate >=1.22,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 395980
+  timestamp: 1728232302162
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
+  sha256: 55a7f96b2802e94def207fdfe92bc52c24d705d139bb6cdb3d936cbe85e1c505
+  md5: db98dc3e58cbc11583180609c429c17d
+  license: MIT
+  license_family: MIT
+  size: 98942
+  timestamp: 1667316472080
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
+  sha256: 7bafd8f4c637778cd0aa390bf3a894feef0e1fcf6ea6000c7ffc25c4c5a65538
+  md5: b2c0047ea73819d992484faacbbe1c24
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 355099
+  timestamp: 1713200298965
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+  sha256: 8896cd5deff6f57d102734f3e672bc17120613647288f9122bec69098e839af7
+  md5: bbeca862892e2898bdb45792a61c4afc
+  depends:
+  - __osx >=10.13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 323770
+  timestamp: 1727278927545
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.5-h495214b_0.conda
+  sha256: 66e1bf40699daf83b39e1281f06c64cf83499de3a9c05d59477fadded6d85b18
+  md5: 8711bc6fb054192dc432741dcd233ac3
+  depends:
+  - __osx >=10.13
+  - icu >=75.1,<76.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 608931
+  timestamp: 1731489767386
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzip-1.11.2-h31df5bb_0.conda
+  sha256: 434a4d1ad23c1c8deb7ec2da94aca05e22bc29dee445b4f7642e1c2f20fc0b0b
+  md5: 3cf12c97a18312c9243a895580bf5be6
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 129542
+  timestamp: 1730442392952
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+  sha256: 8412f96504fc5993a63edf1e211d042a1fd5b1d51dedec755d2058948fcced09
+  md5: 003a54a4e32b02f7355b50a837e699da
+  depends:
+  - __osx >=10.13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 57133
+  timestamp: 1727963183990
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.3-hf78d878_0.conda
+  sha256: 3d28e9938ab1400322ba76968cdbee035009d611bbee94ec6b38a154551954b4
+  md5: 18a8498d57d871da066beaa09263a638
+  depends:
+  - __osx >=10.13
+  constrains:
+  - openmp 19.1.3|19.1.3.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 305524
+  timestamp: 1730364180247
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.43.0-py311h25b8078_1.conda
+  sha256: 8f47684beb89f6c03d10a06929365218cdf4454aee52f0bf83a97da4597c429c
+  md5: 19d1706a45751962b116123dcbc578f0
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 379249
+  timestamp: 1725305363038
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-4.3.3-py311h12b7ed1_1.conda
+  sha256: 47515c300a34c47be42b3196f6f5d400fd3f80f0ae25c73eb10ad367cef450cb
+  md5: ab30eba2d9fe565ff640369016e74fe5
+  depends:
+  - __osx >=10.13
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36652
+  timestamp: 1725089602246
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+  sha256: 39aa0c01696e4e202bf5e337413de09dfeec061d89acd5f28e9968b4e93c3f48
+  md5: aa04f7143228308662696ac24023f991
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 156415
+  timestamp: 1674727335352
+- conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.2-py311h8b4e8a7_0.conda
+  sha256: dd3554cee0aedc19a0cd56b52555c26fb0392e97749ceb202ddac7de55e3acf2
+  md5: 87074906abc091b40ac46e7881b7e45d
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24409
+  timestamp: 1729351443593
+- conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.2-py311h8b21175_2.conda
+  sha256: 26efe199ae6d1cadd2cab43d75f05b6b9b9236db731d605c4a079fe3706b7ea7
+  md5: baafa77537c20f3b575f5729de00d487
+  depends:
+  - __osx >=10.13
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8100228
+  timestamp: 1731025375118
+- conda: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.1.0-py311hf2f7c97_0.conda
+  sha256: b56b1e7d156b88cc0c62734acf56d4ee809723614f659e4203028e7eeac16a78
+  md5: 6804cd42195bf94efd1b892688c96412
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 90868
+  timestamp: 1725975178961
+- conda: https://conda.anaconda.org/conda-forge/osx-64/multidict-6.1.0-py311h1cc1194_1.conda
+  sha256: 2a6125f3f0ead2acc2c3af744e3cf76317dade0f7eb57f21a7512f0e6ddcb8d4
+  md5: 4ab98d43b99358e7e068b52bafe462bf
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 55833
+  timestamp: 1729065694959
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
+  sha256: b0b3180039ef19502525a2abd5833c00f9624af830fd391f851934d57bffb9af
+  md5: e102bbf8a6ceeaf429deab8032fc8977
+  depends:
+  - __osx >=10.13
+  license: X11 AND BSD-3-Clause
+  size: 822066
+  timestamp: 1724658603042
+- conda: https://conda.anaconda.org/conda-forge/osx-64/netcdf4-1.7.2-nompi_py311h62486fc_100.conda
+  sha256: 9980fad2c45510c6e7311825566fb9b9e5fe526e14b14d7f69d51abde6b55717
+  md5: 2c509bde20d3dd0a0d1f1283aa2d434a
+  depends:
+  - __osx >=10.13
+  - certifi
+  - cftime
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 1055069
+  timestamp: 1729662554732
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.60.0-py311h0e5bd6a_0.conda
+  sha256: 47fbc7925d5ee5ba9d841e542752288fc7059f44c0b95c34e11c609f4754e517
+  md5: 8bd1ff28924ea52b539528d85f70a1ac
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - llvm-openmp >=16.0.6
+  - llvm-openmp >=18.1.8
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libopenblas !=0.3.6
+  - cuda-python >=11.6
+  - scipy >=1.0
+  - tbb >=2021.6.0
+  - cudatoolkit >=11.2
+  - cuda-version >=11.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5773011
+  timestamp: 1718888442395
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numcodecs-0.14.0-py311hcf53e2f_0.conda
+  sha256: e4e1fedf4be9a2c49a935dc34a3083b4dbfd35c6391aebbf53cd9583c534f657
+  md5: 7ace9005b135c2ff6390e083fbd470b1
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - msgpack-python
+  - numpy >=1.19,<3
+  - numpy >=1.24
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 767667
+  timestamp: 1731919101562
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.0.2-py311h394b0bb_0.conda
+  sha256: 9c244959047306c7551a94e71f9227e46ee59782e5f5fe81be713d7a4ce3b26f
+  md5: 2711f0de1d44b82d1e023b73b612e901
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8106762
+  timestamp: 1724749068929
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
+  sha256: dc9c405119b9b54f8ca5984da27ba498bd848ab4f0f580da6f293009ca5adc13
+  md5: 05a14cc9d725dd74995927968d6547e3
+  depends:
+  - libcxx >=16
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 331273
+  timestamp: 1709159538792
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hd471939_0.conda
+  sha256: ba7e068ed469d6625e32ae60e6ad893e655b6695280dadf7e065ed0b6f3b885c
+  md5: ec99d2ce0b3033a75cbad01bbc7c5b71
+  depends:
+  - __osx >=10.13
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2590683
+  timestamp: 1731378034404
+- conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.3-h5cd248e_0.conda
+  sha256: 5254a9e811e25595ffa029f131557adf0657efbb81d659afb5561af3ef4bbffa
+  md5: fe9651fd3413eb332537f7729cebc8e1
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 467056
+  timestamp: 1731665334947
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.3-py311haeb46be_1.conda
+  sha256: ad35c52521f0946caf06e19fd3dfad55f7b30e46648f96214f59d8ca2dac95ad
+  md5: ca32a9963a1b5c636b5131831ded81f3
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14864168
+  timestamp: 1726879042435
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pango-1.54.0-h115fe74_2.conda
+  sha256: ed400571a75027563b91bc48054a6599f22c8c2a7ee94a9c3d4e9932c02581ac
+  md5: 9bfd18e7d9292154b2b79ddb7145f9cf
+  depends:
+  - __osx >=10.13
+  - cairo >=1.18.0,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=9.0.0
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  license: LGPL-2.1-or-later
+  size: 423324
+  timestamp: 1723832327771
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.44-h7634a1b_2.conda
+  sha256: 336057fce69d45e1059f138beb38d60eb87ba858c3ad729ed49d9ecafd23669f
+  md5: 58cde0663f487778bcd7a0c8daf50293
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 854306
+  timestamp: 1723488807216
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.0.0-py311h1f68098_0.conda
+  sha256: 3826fe546e711787ce5b42e2f9176589846631945a528176da0fb61e751d3749
+  md5: ab73babea5e9a94d4f0f3c8fead83459
+  depends:
+  - __osx >=10.13
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 42126861
+  timestamp: 1729065932260
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.4-h73e2aa4_0.conda
+  sha256: 3ab44e12e566c67a6e9fd831f557ab195456aa996b8dd9af19787ca80caa5cd1
+  md5: cb134c1e03fd32f4e6bea3f6de2614fd
+  depends:
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  size: 323904
+  timestamp: 1709239931160
+- conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.5.0-h70d2bda_0.conda
+  sha256: 9530508868971b9866486c6cb370a18ca97d6960ccb010f9ca0eaeb539b16910
+  md5: bc2d54e486a633b5f6c3f18c1fe734fb
+  depends:
+  - __osx >=10.13
+  - libcurl >=8.10.0,<9.0a0
+  - libcxx >=17
+  - libsqlite >=3.46.1,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2790379
+  timestamp: 1726489327240
+- conda: https://conda.anaconda.org/conda-forge/osx-64/propcache-0.2.0-py311h3336109_2.conda
+  sha256: 34d5eba45fd4bc40d3e1e2eb39d1e3e418725d51406db4bce4c745689c4102e6
+  md5: 8d1662b4a3df11cef61afa54a2748f4d
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 47401
+  timestamp: 1728546044739
+- conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.0-py311h1314207_0.conda
+  sha256: 340d19b16a2f5b663b4f000188467831b107dcaa5b15522e172d6a27820d3b01
+  md5: 446e328d89429c077ccd74d7e9d8853e
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 512211
+  timestamp: 1729847190327
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+  sha256: 05944ca3445f31614f8c674c560bca02ff05cb51637a96f665cb2bbe496099e5
+  md5: 8bcf980d2c6b17094961198284b8e862
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 8364
+  timestamp: 1726802331537
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-18.0.0-py311h6eed73b_1.conda
+  sha256: 0dcb479fd94a4231a37611658b8b2df2d90b6ce2efa569d9901ca273ec8fc137
+  md5: 1883b0cbb8df31c1cc67239775ab0817
+  depends:
+  - libarrow-acero 18.0.0.*
+  - libarrow-dataset 18.0.0.*
+  - libarrow-substrait 18.0.0.*
+  - libparquet 18.0.0.*
+  - pyarrow-core 18.0.0 *_1_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25274
+  timestamp: 1731058535191
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-18.0.0-py311he02522f_1_cpu.conda
+  sha256: f79d2cb3f6a2b4f7ed7b230f7a51a04eb3d1ef53282e1b78caf09ed4cb0ad699
+  md5: df3ea8a426ce2ae5b996d68b46df5348
+  depends:
+  - __osx >=10.13
+  - libarrow 18.0.0.* *cpu
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy >=1.21,<3
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4026075
+  timestamp: 1731058509706
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.3.1-py311hd6939f8_1.conda
+  sha256: 48de2a78d71e6c1a2681c1fbcf1f1503a29c58cc42cfc0fafa5c1b59a10eda94
+  md5: c8e529b8f6a408dfc6a2bc0c607e2338
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 491149
+  timestamp: 1725739585987
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.3.1-py311hd6939f8_1.conda
+  sha256: bf6179d71edb920cedf7ce4395f4447d5ae96a9deb5a44dcc1a6abffea0de4aa
+  md5: f3f565f99289de1cd140bdbea51b94eb
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 10.3.1.*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 381020
+  timestamp: 1725875173947
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.7.0-py311h50e4d0a_0.conda
+  sha256: a269c953b5c7d789e330db13cb693d6aec6f176cc249cd36607850e826f3deae
+  md5: 53d4a946f02d1b811035310cf575990c
+  depends:
+  - __osx >=10.13
+  - certifi
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 498197
+  timestamp: 1727795466468
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.10-ha513fb2_3_cpython.conda
+  sha256: 670ba83b2aab2204f3254ed47ac0e4b8cad82478e5821727aeab69a2912aa1a0
+  md5: 1a88c32ab9e997380ba1f9306624f805
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 15442415
+  timestamp: 1729043110107
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
+  sha256: 9b092850a268aca99600b724bae849f51209ecd5628e609b4699debc59ff1945
+  md5: e6d62858c06df0be0e6255c753d74787
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6303
+  timestamp: 1723823062672
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311h3336109_1.conda
+  sha256: d8f4513c53a7c0be9f1cdb9d1af31ac85cf8a6f0e4194715e36e915c03104662
+  md5: b0132bec7165a53403dcc393ff761a9e
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 193941
+  timestamp: 1725456465818
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.2.0-py311h4d3da15_3.conda
+  sha256: 6aa664170031e36302616978404175c6ada3bd4a14c71bac826fa6a7ec15f815
+  md5: 48a614f384285254a3224d086dc84ce3
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 366412
+  timestamp: 1728642446264
+- conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+  sha256: 79d804fa6af9c750e8b09482559814ae18cd8df549ecb80a4873537a5a31e06e
+  md5: dd1ea9ff27c93db7c01a7b7656bd4ad4
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: LicenseRef-Qhull
+  size: 528122
+  timestamp: 1720814002588
+- conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2024.07.02-h2fb0a26_1.conda
+  sha256: 49ec4ed6249efe9cda173745e036137f8de1f0b22edf9b0ca4f9c6409b2b68f9
+  md5: aa8ea927cdbdf690efeae3e575716131
+  depends:
+  - libre2-11 2024.07.02 hd530cb8_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26864
+  timestamp: 1728779054104
+- conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+  sha256: 41e7d30a097d9b060037f0c6a2b1d4c4ae7e942c06c943d23f9d481548478568
+  md5: f17f77f2acf4d344734bda76829ce14e
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 255870
+  timestamp: 1679532707590
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.21.0-py311h3b9c2be_0.conda
+  sha256: 234429609e71e568d1dcd7113e9a3c53c231079166ec89364b7c1158ea989776
+  md5: 230b5b87921887039af74b783d8ff095
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 301356
+  timestamp: 1730922990073
+- conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.1-py311hed734c1_1.conda
+  sha256: 2515954fe9f8202c35e9b2df6d65650f8ffcfa7dc99ed068b25968e8af5f1b23
+  md5: 22812381ffcab544161a257666f1c203
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16391177
+  timestamp: 1729481689967
+- conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-he1e6707_0.conda
+  sha256: a979319cd4916f0e7450aa92bb3cf4c2518afa80be50de99f31d075e693a6dd9
+  md5: ddceef5df973c8ff7d6b32353c0cb358
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37036
+  timestamp: 1720003862906
+- conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.47.0-h6285a30_1.conda
+  sha256: 34eaf24c2d0b034374d7a85026650fe28e17321fa471e5c5f654b48c5cbd3c2a
+  md5: c1d1f4d014063068fd6c402cf741e317
+  depends:
+  - __osx >=10.13
+  - libsqlite 3.47.0 h2f8c449_1
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 929527
+  timestamp: 1730208118175
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+  sha256: 30412b2e9de4ff82d8c2a7e5d06a15f4f4fef1809a72138b6ccb53a33b26faf5
+  md5: bf830ba5afc507c6232d4ef0fb1a882d
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3270220
+  timestamp: 1699202389792
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.1-py311h3336109_1.conda
+  sha256: 2e54c0d478b8d0793f89b855749aa74acaa185d08d353d8e5aa95f8e89eb6123
+  md5: 5e051c4c2b80c381173b2c1719265617
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 856251
+  timestamp: 1724956238423
+- conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-15.1.0-py311h1314207_1.conda
+  sha256: c0be0b59fa67c3f9915d3dcd77d972656b9966b4516b3c044efe350860f7e054
+  md5: 574fd9b8168c1b109003c3c431c0bb7e
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 363667
+  timestamp: 1729704694220
+- conda: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.16.0-py311h3336109_1.conda
+  sha256: b27b52c77fc29c42923a82480f3cc19dffc95139ce418f47a9463c7b23f46c3b
+  md5: acb599cfd03298bd560740fee0d1609e
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 59864
+  timestamp: 1724958037718
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h00291cd_1.conda
+  sha256: 96177823ec38336b0f4b7e7c2413da61f8d008d800cc4a5b8ad21f9128fb7de0
+  md5: c6cc91149a08402bbb313c5dc0142567
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 13176
+  timestamp: 1727034772877
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
+  sha256: bb4d1ef9cafef535494adf9296130b6193b3a44375883185b5167de03eb1ac7f
+  md5: 9f438e1b6f4e73fd9e6d78bfe7c36743
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 18465
+  timestamp: 1727794980957
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+  sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
+  md5: a72f9d4ea13d55d745ff1ed594747f10
+  license: LGPL-2.1 and GPL-2.0
+  size: 238119
+  timestamp: 1660346964847
+- conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+  sha256: 5301417e2c8dea45b401ffee8df3957d2447d4ce80c83c5ff151fc6bfe1c4148
+  md5: d7e08fcf8259d742156188e8762b4d20
+  license: MIT
+  license_family: MIT
+  size: 84237
+  timestamp: 1641347062780
+- conda: https://conda.anaconda.org/conda-forge/osx-64/yarl-1.17.2-py311h4d7f069_0.conda
+  sha256: 79f9a4d192df1aebb3cad4c44fc0b0bba1cdc7267ec079aa1684c6967924d366
+  md5: 4a44918dce5a9ccadef69196185bc282
+  depends:
+  - __osx >=10.13
+  - idna >=2.0
+  - multidict >=4.0
+  - propcache >=0.2.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 141173
+  timestamp: 1731927184460
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h7130eaa_7.conda
+  sha256: b932dce8c9de9a8ffbf0db0365d29677636e599f7763ca51e554c43a0c5f8389
+  md5: 6a0a76cd2b3d575e1b7aaeb283b9c3ed
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.3,<1.22.0a0
+  - libcxx >=18
+  - libsodium >=1.0.20,<1.0.21.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 292112
+  timestamp: 1731585246902
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-hd23fc13_2.conda
+  sha256: 219edbdfe7f073564375819732cbf7cc0d7c7c18d3f546a09c2dfaf26e4d69f3
+  md5: c989e0295dcbdc08106fe5d9e935f0b9
+  depends:
+  - __osx >=10.13
+  - libzlib 1.3.1 hd23fc13_2
+  license: Zlib
+  license_family: Other
+  size: 88544
+  timestamp: 1727963189976
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py311hdf6fcd6_1.conda
+  sha256: d9bf977b620750049eb60fffca299a701342a2df59bcc2586a79b2f7c5783fa1
+  md5: 4fc42d6f85a21b09ee6477f456554df3
+  depends:
+  - __osx >=10.13
+  - cffi >=1.11
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411350
+  timestamp: 1725305723486
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
+  sha256: efa04a98cb149643fa54c4dad5a0179e36a5fbc88427ea0eec88ceed87fd0f96
+  md5: 4cb2cd56f039b129bb0e491c1164167e
+  depends:
+  - __osx >=10.9
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 498900
+  timestamp: 1714723303098
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.11.2-py311h4921393_0.conda
+  sha256: 1a2f4de6149ecd1eafdb168c368202ccb3225c2b422f21ce49afbd6fb96908e2
+  md5: d911e422e883f61315e9ed08b7506cbe
+  depends:
+  - __osx >=11.0
+  - aiohappyeyeballs >=2.3.0
+  - aiosignal >=1.1.2
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - multidict >=4.5,<7.0
+  - propcache >=0.2.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - yarl >=1.17.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  size: 870301
+  timestamp: 1731703770556
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311h460d6c5_5.conda
+  sha256: 6eabd1bcefc235b7943688d865519577d7668a2f4dc3a24ee34d81eb4bfe77d1
+  md5: 1e8260965552c6ec86453b7d15a598de
+  depends:
+  - __osx >=11.0
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 33008
+  timestamp: 1725356833036
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/atk-1.0-2.38.0-hd03087b_2.conda
+  sha256: b0747f9b1bc03d1932b4d8c586f39a35ac97e7e72fe6e63f2b2a2472d466f3c1
+  md5: 57301986d02d30d6805fdce6c99074ee
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libglib >=2.80.0,<3.0a0
+  - libintl >=0.22.5,<1.0a0
+  constrains:
+  - atk-1.0 2.38.0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 347530
+  timestamp: 1713896411580
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.8.0-h9b725a8_10.conda
+  sha256: 63cb8c25e0a26be4261d4271de525e7e33aefe9d9b001b8abfa5c9ac69c3dab3
+  md5: 17c90d9eb8c6842fd739dc5445ce9962
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 92355
+  timestamp: 1731733738919
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.8.0-h5d7ee29_2.conda
+  sha256: 2a8c09b33400cf2b7d658e63fd5a6f9b6e9626458f6213b904592fc15220bc92
+  md5: 92734dad83d22314205ba73b679710d2
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 39966
+  timestamp: 1731678721786
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.10.3-h5505292_0.conda
+  sha256: bb2c1038726d31ffd2d35a5764f80bcd670b6a1c753aadfd261aecb9f88db6d8
+  md5: 4150339e3b08db33fe4c436340b1d7f6
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 221524
+  timestamp: 1731567512057
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.0-h5d7ee29_2.conda
+  sha256: a52ea62bf08aed3af079e16d1738f3d2a7fcdd1d260289ae27ae96298e15d12a
+  md5: 15566c36b0cf5f314e3bee7f7cc796b5
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18204
+  timestamp: 1731678916439
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.5.0-h13ead76_7.conda
+  sha256: 386965fab5f0bed4a6109cdba32579f16bee1b0f76ce1db840ce6f7070188f9f
+  md5: 55a901b6d4fb9ce1bc8328925b229f0b
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 47528
+  timestamp: 1731714690911
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.9.1-hf483d09_2.conda
+  sha256: fca9ed0f0895bab9bf737c8d8a3314556cb893d45c40f0656f21a93502db3089
+  md5: d880c40b8fc7d07374c036f93f1359d2
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-compression >=0.3.0,<0.3.1.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 153315
+  timestamp: 1731714621306
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.15.2-h39f8ad8_2.conda
+  sha256: b14e32f024f6be1610dccfdb6371e101cba204d24f37c2a63d9b6380ac74ac17
+  md5: 3b49f1dd8f20bead8b222828cfdad585
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 137610
+  timestamp: 1731702839896
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.11.0-h68a0d7e_8.conda
+  sha256: 837c24c105624e16ace94b4b566ffe45231ff275339c523571ebd45946926156
+  md5: 9e3ac70d27e7591b1310a690768cfe27
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 134573
+  timestamp: 1731734281038
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.7.1-h840aca7_3.conda
+  sha256: a75dce44667327d365abdcd68c525913c7dd948ea26d4709386acd58717307fc
+  md5: 540af65a722c5e490012153673793df5
+  depends:
+  - __osx >=11.0
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 96830
+  timestamp: 1731745236535
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.1-h5d7ee29_1.conda
+  sha256: ed3b272b9a345142e62f0cf9ab2a9fa909c92e09691f6a06e98ff500a1f8a303
+  md5: 0f1e5bc57d4567c9d9bec8d8982828ed
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 50276
+  timestamp: 1731687215375
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.2-h5d7ee29_1.conda
+  sha256: eb7ebe309b33a04329b3e51a7f10bb407815389dc37cc047f7d41f9c91f0d1b0
+  md5: db1ed95988a8fe6c1ce0d94abdfc8e72
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 70184
+  timestamp: 1731687342560
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.29.4-h6832833_1.conda
+  sha256: 9c94db7881035bd1cfb24985668c5c7a693d70ecbf46e4b23c453774400e4437
+  md5: 452a0da8c040f2aa825727af66d05b42
+  depends:
+  - __osx >=11.0
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-mqtt >=0.11.0,<0.11.1.0a0
+  - aws-c-s3 >=0.7.1,<0.7.2.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 237267
+  timestamp: 1731787157065
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.449-h8f08b23_2.conda
+  sha256: 7b7e17c332d7f382f5f97cefe477cb5e9fae171a00d0c40a78ad6263c64a0af2
+  md5: c1111d86333195e42ae29d02d64a545c
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - aws-crt-cpp >=0.29.4,<0.29.5.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2733405
+  timestamp: 1731927979855
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.14.0-hd50102c_0.conda
+  sha256: f5b91329ed59ffc0be8747784c6e4cc7e56250c54032883a83bc11808ef6a87e
+  md5: f093a11dcf3cdcca010b20a818fcc6dc
+  depends:
+  - __osx >=11.0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 294299
+  timestamp: 1728054014060
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.10.0-hc602bab_0.conda
+  sha256: bde446b916fff5150606f8ed3e6058ffc55a3aa72381e46f1ab346590b1ae40a
+  md5: d7b71593a937459f2d4b67e1a4727dc2
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 166907
+  timestamp: 1728486882502
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.13.0-h7585a09_1.conda
+  sha256: 08d52d130addc0fb55d5ba10d9fa483e39be25d69bac7f4c676c2c3069207590
+  md5: 704238ef05d46144dae2e6b5853df8bc
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 438636
+  timestamp: 1728578216193
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.8.0-h9ca1f76_1.conda
+  sha256: 77ab04e8fe5636a2de9c718f72a43645f7502cd208868c8a91ffba385547d585
+  md5: 7a187cd7b1445afc80253bb186a607cc
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - libxml2 >=2.12.7,<2.14.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 121278
+  timestamp: 1728563418777
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.12.0-hcdd55da_1.conda
+  sha256: f48523f8aa0b5b80f45a92f0556b388dd96f44ac2dc2f44a01d08c1822eec97d
+  md5: c49fbc5233fcbaa86391162ff1adef38
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 196032
+  timestamp: 1728729672889
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h5499902_0.conda
+  sha256: 5a1e635a371449a750b776cab64ad83f5218b58b3f137ebd33ad3ec17f1ce92e
+  md5: e94ca7aec8544f700d45b24aff2dd4d7
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33201
+  timestamp: 1719266149627
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hd74edd7_2.conda
+  sha256: a086f36ff68d6e30da625e910547f6211385246fb2474b144ac8c47c32254576
+  md5: 215e3dc8f2f837906d066e7f01aa77c0
+  depends:
+  - __osx >=11.0
+  - brotli-bin 1.1.0 hd74edd7_2
+  - libbrotlidec 1.1.0 hd74edd7_2
+  - libbrotlienc 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 19588
+  timestamp: 1725268044856
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hd74edd7_2.conda
+  sha256: 28f1af63b49fddf58084fb94e5512ad46e9c453eb4be1d97449c67059e5b0680
+  md5: b8512db2145dc3ae8d86cdc21a8d421e
+  depends:
+  - __osx >=11.0
+  - libbrotlidec 1.1.0 hd74edd7_2
+  - libbrotlienc 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 16772
+  timestamp: 1725268026061
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311h3f08180_2.conda
+  sha256: f507d65e740777a629ceacb062c768829ab76fde01446b191699a734521ecaad
+  md5: c8793a23206344faa25f4e0b5d0e7908
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 339584
+  timestamp: 1725268241628
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+  sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
+  md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
+  depends:
+  - __osx >=11.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 122909
+  timestamp: 1720974522888
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.3-h5505292_0.conda
+  sha256: e9e0f737286f9f4173c76fb01a11ffbe87cfc2da4e99760e1e18f47851d7ae06
+  md5: d0155a4f41f28628c7409ea000eeb19c
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 178951
+  timestamp: 1731182071026
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
+  sha256: 2db1733f4b644575dbbdd7994a8f338e6ef937f5ebdb74acd557e9dda0211709
+  md5: 40dec13fd8348dbe303e57be74bd3d35
+  license: ISC
+  size: 158482
+  timestamp: 1725019034582
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hb4a6bf7_3.conda
+  sha256: f7603b7f6ee7c6e07c23d77302420194f4ec1b8e8facfff2b6aab17c7988a102
+  md5: 08bd0752f3de8a2d8a35fd012f09531f
+  depends:
+  - __osx >=11.0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libcxx >=16
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.4,<1.0a0
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 899126
+  timestamp: 1721139203735
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py311h3a79f62_0.conda
+  sha256: 253605b305cc4548b8f97eb7c2e146697e0c7672b099c4862ec5ca7e8e995307
+  md5: a42272c5dbb6ffbc1a5af70f24c7b448
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 288211
+  timestamp: 1725560745212
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.4-py311h0f07fe1_1.conda
+  sha256: a77f11a4e202e7e856b368e7bae7a463d4193d5263927ca8c6e02eee6e5a0703
+  md5: f239945e88a60c79f705944b22ab56d3
+  depends:
+  - __osx >=11.0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 206517
+  timestamp: 1725400747908
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.1-py311h210dab8_0.conda
+  sha256: 8e755206b38a6e14861c79a74b51af76124bdf5c266dd6a584305e03d37c2e0c
+  md5: 7f9e9df2d62cf69aed450f6957a23e61
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 247202
+  timestamp: 1731428753912
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.0.0-py311h460d6c5_1.conda
+  sha256: cff9cd6a8652a73d9e1d73c51bfd1bac6b526e705885b1ec8f0c159bd34046d2
+  md5: 72740cbbba07d1fb0f37448e1e1c7ef9
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 341441
+  timestamp: 1728335223644
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.8-py311h155a34a_0.conda
+  sha256: 959e7cdeb6627d64228a6cbaf91e5bd674465d81619b410c8ce772fa9db1a594
+  md5: 376b9971d7b47dab0b5197bd3efc74d4
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2489339
+  timestamp: 1731045144242
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.15.0-h1383a14_1.conda
+  sha256: f79d3d816fafbd6a2b0f75ebc3251a30d3294b08af9bb747194121f5efa364bc
+  md5: 7b29f48742cea5d1ccb5edd839cb5621
+  depends:
+  - __osx >=11.0
+  - freetype >=2.12.1,<3.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 234227
+  timestamp: 1730284037572
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.55.0-py311h4921393_0.conda
+  sha256: d4a66eafaaa94618f9218881d24fd60f4b93c2d629cab14ddb98216e1cf83fda
+  md5: 9dbec219c6180471bada3b40199f2239
+  depends:
+  - __osx >=11.0
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2781319
+  timestamp: 1731643650622
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+  sha256: 791673127e037a2dc0eebe122dc4f904cb3f6e635bb888f42cbe1a76b48748d9
+  md5: e6085e516a3e304ce41a8ee08b9b89ad
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 596430
+  timestamp: 1694616332835
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.10-h27ca646_0.tar.bz2
+  sha256: 4b37ea851a2cf85edf0a63d2a63266847ec3dcbba4a31156d430cdd6aa811303
+  md5: c64443234ff91d70cb9c7dc926c58834
+  license: LGPL-2.1
+  size: 60255
+  timestamp: 1604417405528
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.5.0-py311hae2e1ce_0.conda
+  sha256: 3df51bbf74052c5d29a33cf8c8c57302699937f883e0e4e9e506c7e0b09e45a5
+  md5: 7f28e6daf0b4963be1061291cbe10bfb
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 54023
+  timestamp: 1729699703032
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.42.12-h7ddc832_0.conda
+  sha256: 72bcf0a4d3f9aa6d99d7d1d224d19f76ccdb3a4fa85e60f77d17e17985c81bd2
+  md5: 151309a7e1eb57a3c2ab8088a1d74f3e
+  depends:
+  - __osx >=11.0
+  - libglib >=2.80.2,<3.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 509570
+  timestamp: 1715783199780
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
+  sha256: fd56ed8a1dab72ab90d8a8929b6f916a6d9220ca297ff077f8f04c5ed3408e20
+  md5: 57a511a5905caa37540eb914dfcbf1fb
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 82090
+  timestamp: 1726600145480
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
+  sha256: 9fc77de416953aa959039db72bc41bfa4600ae3ff84acad04a7d0c1ab9552602
+  md5: fef68d0a95aa5b84b5c1a4f6f3bf40e1
+  depends:
+  - __osx >=11.0
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 112215
+  timestamp: 1718284365403
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-hebf3989_1003.conda
+  sha256: 2eadafbfc52f5e7df3da3c3b7e5bbe34d970bea1d645ffe60b0b1c3a216657f5
+  md5: 339991336eeddb70076d8ca826dac625
+  depends:
+  - libcxx >=16
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 79774
+  timestamp: 1711634444608
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphviz-12.0.0-hbf8cc41_0.conda
+  sha256: 33867d6ebc54f290dfb511fdca0297b30ca06985ac4443e1fc9d7fe03bfbad05
+  md5: 29c0dcbd4ec7135b7a55805aa3a5a331
+  depends:
+  - __osx >=11.0
+  - cairo >=1.18.0,<2.0a0
+  - fonts-conda-ecosystem
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - gtk2
+  - gts >=0.7.6,<0.8.0a0
+  - libcxx >=16
+  - libexpat >=2.6.2,<3.0a0
+  - libgd >=2.3.3,<2.4.0a0
+  - libglib >=2.80.3,<3.0a0
+  - librsvg >=2.58.2,<3.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pango >=1.50.14,<2.0a0
+  license: EPL-1.0
+  license_family: Other
+  size: 5082874
+  timestamp: 1722673934247
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gtk2-2.24.33-h91d5085_5.conda
+  sha256: 26ca08e16bb530465370d94309bfb500438f6cff4d6cf85725db3b7afcd9eccd
+  md5: 23558d38b8e80959b74cfe83acad7c66
+  depends:
+  - __osx >=11.0
+  - atk-1.0 >=2.38.0
+  - cairo >=1.18.0,<2.0a0
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - libglib >=2.80.3,<3.0a0
+  - libintl >=0.22.5,<1.0a0
+  - pango >=1.54.0,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 6152068
+  timestamp: 1721286930050
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gts-0.7.6-he42f4ea_4.conda
+  sha256: e0f8c7bc1b9ea62ded78ffa848e37771eeaaaf55b3146580513c7266862043ba
+  md5: 21b4dd3098f63a74cf2aa9159cbef57d
+  depends:
+  - libcxx >=15.0.7
+  - libglib >=2.76.3,<3.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 304331
+  timestamp: 1686545503242
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-9.0.0-h997cde5_1.conda
+  sha256: 5f78f5dcbbfef59b3549ecb6cc2fa9de7b22abda7c8afaf0fa787ceea37a914f
+  md5: 50f6825d3c4a6fca6fefdefa98081554
+  depends:
+  - __osx >=11.0
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=75.1,<76.0a0
+  - libcxx >=16
+  - libglib >=2.80.3,<3.0a0
+  license: MIT
+  license_family: MIT
+  size: 1317509
+  timestamp: 1721186764931
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
+  sha256: c3b01e3c3fe4ca1c4d28c287eaa5168a4f2fd3ffd76690082ac919244c22fa90
+  md5: ff5d749fd711dc7759e127db38005924
+  depends:
+  - libcxx >=15.0.7
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 762257
+  timestamp: 1695661864625
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.4-nompi_ha698983_103.conda
+  sha256: 01c2792588db2ac16e758a2898e4ec40955a2abcbc30f0212b7a669e1d094cae
+  md5: b779eb51bbfdf8d1b4539199b76839b4
+  depends:
+  - __osx >=11.0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3495866
+  timestamp: 1730831045992
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+  sha256: 9ba12c93406f3df5ab0a43db8a4b4ef67a5871dfd401010fbe29b218b2cbe620
+  md5: 5eb22c1d7b3fc4abb50d92d621583137
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 11857802
+  timestamp: 1720853997952
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py311h267d04e_1.conda
+  sha256: 736304347653ed421b13c56ba6f4f87c1d78d24cd3fa74db0db6fb70c814fa65
+  md5: 5bce88ac1bef7d47c62cb574b25891ae
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18253
+  timestamp: 1725303181400
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.7-py311h2c37856_0.conda
+  sha256: 8ffc46f6e99c95c48426cf34c033d16cde3bcf100cd74d1d74a33943a85a6ec8
+  md5: ee572d19da1346db8e78cb8e7d5d2330
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59357
+  timestamp: 1725459504453
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+  sha256: 4442f957c3c77d69d9da3521268cad5d54c9033f1a73f99cde0a3658937b159b
+  md5: c6dc8a0fdec13a0565936655c33069a1
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1155530
+  timestamp: 1719463474401
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
+  sha256: 151e0c84feb7e0747fabcc85006b8973b22f5abbc3af76a9add0b0ef0320ebe4
+  md5: 66f6c134e76fe13cce8a9ea5814b5dd5
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 211959
+  timestamp: 1701647962657
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+  sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
+  md5: de462d5aacda3b30721b512c5da4e742
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 215721
+  timestamp: 1657977558796
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_hf9b8971_1.conda
+  sha256: 90bf08a75506dfcf28a70977da8ab050bcf594cd02abd3a9d84a22c9e8161724
+  md5: 706da5e791c569a7b9814877098a6a0a
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  constrains:
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1179072
+  timestamp: 1727295571173
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
+  sha256: 896189b7b48a194c46a3556ea04943ef81cbe0498521231f8eb25816a68bc8ed
+  md5: 6f0b8e56d2e7bae12a18fc5b2cd9f310
+  depends:
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 28451
+  timestamp: 1711021498493
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-18.0.0-h2409f62_7_cpu.conda
+  sha256: baf7322466c5849f0ef4c8bab9f394c1448fc7a1d42f74d775b49e20cea8fcf8
+  md5: da6e0816fe9639c270cafdec68b411d6
+  depends:
+  - __osx >=11.0
+  - aws-crt-cpp >=0.29.4,<0.29.5.0a0
+  - aws-sdk-cpp >=1.11.449,<1.11.450.0a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-identity-cpp >=1.10.0,<1.10.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-files-datalake-cpp >=12.12.0,<12.12.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=18
+  - libgoogle-cloud >=2.31.0,<2.32.0a0
+  - libgoogle-cloud-storage >=2.31.0,<2.32.0a0
+  - libre2-11 >=2024.7.2
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.3,<2.0.4.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  - libutf8proc <2.9
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - parquet-cpp <0.0a0
+  - arrow-cpp <0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5455595
+  timestamp: 1731789726593
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-18.0.0-h286801f_7_cpu.conda
+  sha256: 8df47c06ad5b839393aa4703721385d3529a64971227a3a342a1100eeb2fbe78
+  md5: 67a94caeec254580852dd71b0cb5bfc7
+  depends:
+  - __osx >=11.0
+  - libarrow 18.0.0 h2409f62_7_cpu
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: APACHE
+  size: 491285
+  timestamp: 1731789825049
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-18.0.0-h286801f_7_cpu.conda
+  sha256: 3d17beb5e336507443f436f21658e0baf6d6dbacc83938a60e7eac20886e5f78
+  md5: 75cec89177549b4a87faa6c952fb07a6
+  depends:
+  - __osx >=11.0
+  - libarrow 18.0.0 h2409f62_7_cpu
+  - libarrow-acero 18.0.0 h286801f_7_cpu
+  - libcxx >=18
+  - libparquet 18.0.0 hda0ea68_7_cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 497438
+  timestamp: 1731791003104
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-18.0.0-h6a6e5c5_7_cpu.conda
+  sha256: 775c202c379c712f3e77d43ce54d3f9a7ef8dd37d3b68911e886b89f5502eeac
+  md5: 2a3910690b531fdc9553e2889fda97bf
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 18.0.0 h2409f62_7_cpu
+  - libarrow-acero 18.0.0 h286801f_7_cpu
+  - libarrow-dataset 18.0.0 h286801f_7_cpu
+  - libcxx >=18
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 459246
+  timestamp: 1731791195089
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-25_osxarm64_openblas.conda
+  sha256: f1fb9a11af0b2878bd8804b4c77d3733c40076218bcbdb35f575b1c0c9fddf11
+  md5: f8cf4d920ff36ce471619010eff59cac
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - blas * openblas
+  - liblapack 3.9.0 25_osxarm64_openblas
+  - liblapacke 3.9.0 25_osxarm64_openblas
+  - libcblas 3.9.0 25_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15913
+  timestamp: 1729643265495
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hd74edd7_2.conda
+  sha256: 839dacb741bdbb25e58f42088a2001b649f4f12195aeb700b5ddfca3267749e5
+  md5: d0bf1dff146b799b319ea0434b93f779
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 68426
+  timestamp: 1725267943211
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hd74edd7_2.conda
+  sha256: 6c6862eb274f21a7c0b60e5345467a12e6dda8b9af4438c66d496a2c1a538264
+  md5: 55e66e68ce55523a6811633dd1ac74e2
+  depends:
+  - __osx >=11.0
+  - libbrotlicommon 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 28378
+  timestamp: 1725267980316
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hd74edd7_2.conda
+  sha256: eeb1eb0d58b9d02bc1b98dc0a058f104ab168eb2f7d1c7bfa0570a12cfcdb7b7
+  md5: 4f3a434504c67b2c42565c0b85c1885c
+  depends:
+  - __osx >=11.0
+  - libbrotlicommon 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 279644
+  timestamp: 1725268003553
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-25_osxarm64_openblas.conda
+  sha256: d9fa5b6b11252132a3383bbf87bd2f1b9d6248bef1b7e113c2a8ae41b0376218
+  md5: 4df0fae81f0b5bf47d48c882b086da11
+  depends:
+  - libblas 3.9.0 25_osxarm64_openblas
+  constrains:
+  - blas * openblas
+  - liblapack 3.9.0 25_osxarm64_openblas
+  - liblapacke 3.9.0 25_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15837
+  timestamp: 1729643270793
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+  sha256: 58477b67cc719060b5b069ba57161e20ba69b8695d154a719cb4b60caf577929
+  md5: 32bd82a6a625ea6ce090a81c3d34edeb
+  depends:
+  - libcxx >=11.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18765
+  timestamp: 1633683992603
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.10.1-h13a7ad3_0.conda
+  sha256: 983a977c5627f975a930542c8aabb46089ec6ea72f28d9c4d3ee8eafaf2fc25a
+  md5: d84030d0863ffe7dea00b9a807fee961
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 379948
+  timestamp: 1726660033582
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.3-ha82da77_0.conda
+  sha256: 6d062760c6439e75b9a44d800d89aff60fe3441998d87506c62dc94c50412ef4
+  md5: bf691071fba4734984231617783225bc
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 520771
+  timestamp: 1730314603920
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.22-hd74edd7_0.conda
+  sha256: 3552894ca62bebc33d05982937cda25a4fa19e56a82af2ff20944ff4c2532fda
+  md5: 2d3e3f3d8ab315748420ef58d5a3ae0f
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 54089
+  timestamp: 1728177149927
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+  sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
+  md5: 30e4362988a2623e9eb34337b83e01f9
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 96607
+  timestamp: 1597616630749
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+  sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
+  md5: 36d33e440c31857372a72137f78bacf5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 107458
+  timestamp: 1702146414478
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+  sha256: 8c136d7586259bb5c0d2b913aaadc5b9737787ae4f40e3ad1beaf96c80b919b7
+  md5: 1a109764bff3bdc7bdd84088347d71dc
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 368167
+  timestamp: 1685726248899
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
+  sha256: e42ab5ace927ee7c84e3f0f7d813671e1cf3529f5f06ee5899606630498c2745
+  md5: 38d2656dd914feb0cab8c629370768bf
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 64693
+  timestamp: 1730967175868
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+  md5: 086914b672be056eb70fd4285b6783b6
+  license: MIT
+  license_family: MIT
+  size: 39020
+  timestamp: 1636488587153
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgd-2.3.3-hac1b3a8_10.conda
+  sha256: d15beaa2e862a09526e704f22f7d0b7fa73b114b868106dd686e167b9d65558e
+  md5: c9e450ce5ced76f107c494fbd37325f5
+  depends:
+  - __osx >=11.0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: GD
+  license_family: BSD
+  size: 200309
+  timestamp: 1722928354606
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+  sha256: 44e541b4821c96b28b27fef5630883a60ce4fee91fd9c79f25a199f8f73f337b
+  md5: 4a55d9e169114b2b90d3ec4604cd7bbf
+  depends:
+  - libgfortran5 13.2.0 hf226fd6_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110233
+  timestamp: 1707330749033
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+  sha256: bafc679eedb468a86aa4636061c55966186399ee0a04b605920d208d97ac579a
+  md5: 66ac81d54e95c534ae488726c1f698ea
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 997381
+  timestamp: 1707330687590
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.82.2-h07bd6cf_0.conda
+  sha256: 101fb31c509d6a69ac5d612b51d4088ddbc675fca18cf0c3589cfee26cd01ca0
+  md5: 890783f64502fa6bfcdc723cfbf581b4
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  constrains:
+  - glib 2.82.2 *_0
+  license: LGPL-2.1-or-later
+  size: 3635416
+  timestamp: 1729191799117
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.31.0-h8d8be31_0.conda
+  sha256: 184d650d55453a40935c128ea309088ae52e15a68cd87ab17ae7c77704251168
+  md5: a338736f1514e6f999db8726fe0965b1
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - openssl >=3.3.2,<4.0a0
+  constrains:
+  - libgoogle-cloud 2.31.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 873497
+  timestamp: 1731121684939
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.31.0-h7081f7f_0.conda
+  sha256: 01f5156584b816d34270a60a61f6b6561f2a01cb3b4eeb455a4e1808d763d486
+  md5: 548fd1d31741ee6b13df4124db4a9f5f
+  depends:
+  - __osx >=11.0
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libcxx >=18
+  - libgoogle-cloud 2.31.0 h8d8be31_0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  size: 526858
+  timestamp: 1731122580689
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.67.1-hc70892a_0.conda
+  sha256: d2393fcd3c3584e5d58da4122f48bcf297567d2f6f14b3d1fcbd34fdd5040694
+  md5: 624e27571fde34f8acc2afec840ac435
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.34.2,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libre2-11 >=2024.7.2
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.67.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4882208
+  timestamp: 1730236299095
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
+  sha256: bc7de5097b97bcafcf7deaaed505f7ce02f648aac8eccc0d5a47cc599a1d0304
+  md5: 69bda57310071cf6d2b86caf11573d2d
+  license: LGPL-2.1-only
+  size: 676469
+  timestamp: 1702682458114
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.22.5-h8414b35_3.conda
+  sha256: 7c1d238d4333af385e594c89ebcb520caad7ed83a735c901099ec0970a87a891
+  md5: 3b98ec32e91b3b59ad53dbb9c96dd334
+  depends:
+  - __osx >=11.0
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 81171
+  timestamp: 1723626968270
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+  sha256: a42054eaa38e84fc1e5ab443facac4bbc9d1b6b6f23f54b7bf4f1eb687e1d993
+  md5: 3ff1e053dc3a2b8e36b9bfa4256a58d1
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 547541
+  timestamp: 1694475104253
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-25_osxarm64_openblas.conda
+  sha256: fdd742407672a9af20e70764550cf18b3ab67f12e48bf04163b90492fbc401e7
+  md5: 19bbddfec972d401838330453186108d
+  depends:
+  - libblas 3.9.0 25_osxarm64_openblas
+  constrains:
+  - blas * openblas
+  - liblapacke 3.9.0 25_osxarm64_openblas
+  - libcblas 3.9.0 25_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15823
+  timestamp: 1729643275943
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_4.conda
+  sha256: 6f603914fe8633a615f0d2f1383978eb279eeb552079a78449c9fbb43f22a349
+  md5: 9f3dce5d26ea56a9000cd74c034582bd
+  depends:
+  - libcxx >=15
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 20571387
+  timestamp: 1690559110016
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnetcdf-4.9.2-nompi_h853a48d_115.conda
+  sha256: 8d7c9ede65241de34aa5aa4c1cf04964fd6e027e2a7d4e8cce654b2350c0f2d3
+  md5: 94b3a12456a4e257e65c6b962c785190
+  depends:
+  - __osx >=11.0
+  - blosc >=1.21.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzip >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zlib
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 678786
+  timestamp: 1728055979264
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
+  sha256: 00cc685824f39f51be5233b54e19f45abd60de5d8847f1a56906f8936648b72f
+  md5: 3408c02539cee5f1141f9f11450b6a51
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.34.2,<2.0a0
+  - libcxx >=17
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 566719
+  timestamp: 1729572385640
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
+  sha256: 62bb669c37a845129096f73d446cdb6bb170e4927f2fea2b661329680dbbc373
+  md5: 40803a48d947c8639da6704e9a44d3ce
+  depends:
+  - __osx >=11.0
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - llvm-openmp >=18.1.8
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4165774
+  timestamp: 1730772154295
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-18.0.0-hda0ea68_7_cpu.conda
+  sha256: 8343a369243b7c87993955e39fbbac3617413f4a963e271fda5079b6c8fec7b0
+  md5: fd32f3b3115477411f3790eb67272081
+  depends:
+  - __osx >=11.0
+  - libarrow 18.0.0 h2409f62_7_cpu
+  - libcxx >=18
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 881594
+  timestamp: 1731790946184
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
+  sha256: 38f8759a3eb8060deabd4db41f0f023514d853e46ddcbd0ba21768fc4e563bb1
+  md5: fb36e93f0ea6a6f5d2b99984f34b049e
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 263385
+  timestamp: 1726234714421
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.28.2-h8f0b736_0.conda
+  sha256: f732a6fa918428e2d5ba61e78fe11bb44a002cc8f6bb74c94ee5b1297fefcfd8
+  md5: d2cb5991f2fb8eb079c80084435e9ce6
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2374965
+  timestamp: 1728565334796
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2024.07.02-h2348fd5_1.conda
+  sha256: 6facca42cfc85a05b33e484a8b0df7857cc092db34806946d022270098d8d20f
+  md5: 5a7065309a66097738be6a06fd04b7ef
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 165956
+  timestamp: 1728779107218
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.58.4-h40956f1_0.conda
+  sha256: 88cd8603a6fe6c3299e9cd0a81f5e38cf431d20b7d3e2e6642c8a41113ede6db
+  md5: 27c333944e11caae7bc3a35178d32ac5
+  depends:
+  - __osx >=11.0
+  - cairo >=1.18.0,<2.0a0
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - libglib >=2.80.3,<3.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - pango >=1.54.0,<2.0a0
+  constrains:
+  - __osx >=11.0
+  license: LGPL-2.1-or-later
+  size: 4688893
+  timestamp: 1726228099207
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
+  sha256: fade8223e1e1004367d7101dd17261003b60aa576df6d7802191f8972f7470b1
+  md5: a7ce36e284c5faaf93c220dfc39e3abd
+  depends:
+  - __osx >=11.0
+  license: ISC
+  size: 164972
+  timestamp: 1716828607917
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.47.0-hbaaea75_1.conda
+  sha256: 5a96caa566c11e5a5ebdcdb86a0759a7fb27d3c5f42e6a0fd0d6023c1e935d9e
+  md5: 07a14fbe439eef078cc479deca321161
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 837683
+  timestamp: 1730208293578
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
+  sha256: bb57d0c53289721fff1eeb3103a1c6a988178e88d8a8f4345b0b91a35f0e0015
+  md5: 029f7dc931a3b626b94823bc77830b01
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 255610
+  timestamp: 1685837894256
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.21.0-h64651cc_0.conda
+  sha256: 7a6c7d5f58cbbc2ccd6493b4b821639fdb0701b9b04c737a949e8cb6adf1c9ad
+  md5: 7ce2bd2f650f8c31ad7ba4c7bfea61b7
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 324342
+  timestamp: 1727206096912
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-hfce79cd_1.conda
+  sha256: 97ba24c74750b6e731b3fe0d2a751cda6148b4937d2cc3f72d43bf7b3885c39d
+  md5: b9abf45f7c64caf3303725f1aa0e9a4d
+  depends:
+  - __osx >=11.0
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=17
+  - libdeflate >=1.22,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 366323
+  timestamp: 1728232400072
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-h1a8c8d9_0.tar.bz2
+  sha256: a3faddac08efd930fa3a1cc254b5053b4ed9428c49a888d437bf084d403c931a
+  md5: f8c9c41a122ab3abdf8943b13f4957ee
+  license: MIT
+  license_family: MIT
+  size: 103492
+  timestamp: 1667316405233
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+  sha256: 0d4bad713a512d79bfeb4d61821f447afab8b0792aca823f505ce6b195e9fde5
+  md5: c0af0edfebe780b19940e94871f1a765
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 287750
+  timestamp: 1713200194013
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+  sha256: bd3816218924b1e43b275863e21a3e13a5db4a6da74cca8e60bc3c213eb62f71
+  md5: af523aae2eca6dfa1c8eec693f5b9a79
+  depends:
+  - __osx >=11.0
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 323658
+  timestamp: 1727278733917
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.13.5-hbbdcc80_0.conda
+  sha256: 936de9c0e91cb6f178c48ea14313cf6c79bdb1f474c785c117c41492b0407a98
+  md5: 967d4a9dadd710415ee008d862a07c99
+  depends:
+  - __osx >=11.0
+  - icu >=75.1,<76.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 583082
+  timestamp: 1731489765442
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzip-1.11.2-h1336266_0.conda
+  sha256: 507599a77c1ce823c2d3acaefaae4ead0686f183f3980467a4c4b8ba209eff40
+  md5: 7177414f275db66735a17d316b0a81d6
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 125507
+  timestamp: 1730442214849
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
+  md5: 369964e85dc26bfe78f41399b366c435
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 46438
+  timestamp: 1727963202283
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.3-hb52a8e5_0.conda
+  sha256: 49a8940e727aa82ee034fa9a60b3fcababec41b3192d955772aab635a5374b82
+  md5: dd695d23e78d1ca4fecce969b1e1db61
+  depends:
+  - __osx >=11.0
+  constrains:
+  - openmp 19.1.3|19.1.3.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 280488
+  timestamp: 1730364082380
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.43.0-py311hc367efa_1.conda
+  sha256: c352b894bb07ed59d1cdaed1a64e52b054f4ff02119600a97ccf39cce06dbe5f
+  md5: d14048893b6cc8aec00b4e0e6eb78de2
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 378145
+  timestamp: 1725305457011
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-4.3.3-py311hebe0b09_1.conda
+  sha256: d68fb0bf5d74c83432155406de87b50b8c10712d331bbbab616c52d945751981
+  md5: 74df239a2926df48e2543bb6754baf61
+  depends:
+  - __osx >=11.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 108602
+  timestamp: 1725089854895
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+  sha256: fc343b8c82efe40819b986e29ba748366514e5ab94a1e1138df195af5f45fa24
+  md5: 45505bec548634f7d05e02fb25262cb9
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 141188
+  timestamp: 1674727268278
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py311h56c23cb_0.conda
+  sha256: 74bbdf6dbfe561026fed5c7d5c1a123e6dff0fedc5bc7ed0c6e9037c95ca96d7
+  md5: be48a4cc178a91af3b1ccd58c14efde2
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25180
+  timestamp: 1729351536390
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.9.2-py311hbe3227e_2.conda
+  sha256: bf2f04ad5d57b2042eb58fe1f969e4b263e8edcee971396005aa4dbb39ceab14
+  md5: 2c4e7ee255a37a3dc2ab9ee684b407f4
+  depends:
+  - __osx >=11.0
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 7902037
+  timestamp: 1731025458642
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.0-py311h2c37856_0.conda
+  sha256: aafa8572c72283801148845772fd9d494765bdcf1b8ae6f435e1caff4f1c97f3
+  md5: 6c826762702474fb0def6cedd2db5316
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 91131
+  timestamp: 1725975234150
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.1.0-py311h30e7462_1.conda
+  sha256: 9e7beeeef3c13e000e2e9dab38dff3a5284a8c8665019be149db50b4eff9a340
+  md5: ff4227ea49745aeddbf45edef09036bc
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 56769
+  timestamp: 1729065684471
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+  sha256: 27d0b9ff78ad46e1f3a6c96c479ab44beda5f96def88e2fe626e0a49429d8afc
+  md5: cb2b0ea909b97b3d70cd3921d1445e1a
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  size: 802321
+  timestamp: 1724658775723
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/netcdf4-1.7.2-nompi_py311hd13e3db_100.conda
+  sha256: deaffc773f838f2677791aedf3bfd4dc72e3f4bc1b5e46c831734aa11ef32101
+  md5: e4c8b38c12de3bb2be288862acd8e5ca
+  depends:
+  - __osx >=11.0
+  - certifi
+  - cftime
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 1048689
+  timestamp: 1729663101204
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.60.0-py311h9506ed5_0.conda
+  sha256: 70435f94de8b5328b039ffff9dfdd00c8c0a503cb1a86f4b70ae9cbdd7e4ec1f
+  md5: 5e14ce0b9976d6d0370c9f5032c81bb7
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - llvm-openmp >=16.0.6
+  - llvm-openmp >=18.1.7
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - cuda-version >=11.2
+  - cudatoolkit >=11.2
+  - scipy >=1.0
+  - cuda-python >=11.6
+  - libopenblas >=0.3.18, !=0.3.20
+  - tbb >=2021.6.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5778831
+  timestamp: 1718888718616
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numcodecs-0.14.0-py311hca32420_0.conda
+  sha256: 4576ddcd7cb7d97b1e2a7510ef941ed595f1c3b0caa8a931e4ffc03d92e7ddc0
+  md5: cd1e817aab8043a3901fe8d2c0f707e3
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - msgpack-python
+  - numpy >=1.19,<3
+  - numpy >=1.24
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 676274
+  timestamp: 1731918953895
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.0.2-py311h6de8079_0.conda
+  sha256: ed06d3eb948a581da08675dbbfedc6019bf10d74c03865ecbc2acd4ba625974c
+  md5: 2bd1d7e02190016932c5e02ed1aece33
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6995279
+  timestamp: 1724749148131
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
+  sha256: 472d6eaffc1996e6af35ec8e91c967f472a536a470079bfa56383cc0dbf4d463
+  md5: 5029846003f0bc14414b9128a1f7c84b
+  depends:
+  - libcxx >=16
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 316603
+  timestamp: 1709159627299
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h39f12f2_0.conda
+  sha256: bd1d58ced46e75efa3b842c61642fd12272c69e9fe4d7261078bc082153a1d53
+  md5: df307bbc703324722df0293c9ca2e418
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2935176
+  timestamp: 1731377561525
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.3-h121fd32_0.conda
+  sha256: 4759fd0c3f06c035146100e22ee36a312c9a8226654bd2973e9ca9ac5de5cf1f
+  md5: 39995f7406b949c1bef74f0c7277afb3
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 438254
+  timestamp: 1731665228473
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py311h9cb3ce9_1.conda
+  sha256: 0a08027b25e4f6034d7733c7366f44283246d61cb82d1721f8789d50ebfef287
+  md5: 9ffa9dee175c76e68ea5de5aa1168d83
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14807397
+  timestamp: 1726879116250
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.54.0-h9ee27a3_2.conda
+  sha256: cfa2d11204bb75f6fbcfe1ff0cc1f6e4fc01185bf07b8eee8f698bfbd3702a79
+  md5: af2a2118261adf2d7a350d6767b450f2
+  depends:
+  - __osx >=11.0
+  - cairo >=1.18.0,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=9.0.0
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  license: LGPL-2.1-or-later
+  size: 417224
+  timestamp: 1723832458095
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-h297a79d_2.conda
+  sha256: 83153c7d8fd99cab33c92ce820aa7bfed0f1c94fc57010cf227b6e3c50cb7796
+  md5: 147c83e5e44780c7492998acbacddf52
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 618973
+  timestamp: 1723488853807
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.0.0-py311h3894ae9_0.conda
+  sha256: 6d5307fed000e6b72b98d54dd1fea7b155f9a6453476a937522b89dde7b3d673
+  md5: a9a4adae1c4178f50ac3d1fd5d64bb85
+  depends:
+  - __osx >=11.0
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 41856994
+  timestamp: 1729066060042
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.4-hebf3989_0.conda
+  sha256: df0ba2710ccdea5c909b63635529797f6eb3635b6fb77ae9cb2f183d08818409
+  md5: 0308c68e711cd295aaa026a4f8c4b1e5
+  depends:
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  size: 198755
+  timestamp: 1709239846651
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.5.0-h61a8e3e_0.conda
+  sha256: df44f24dc325fff7480f20fb404dad03015b9e646aa25e0eb24d1edd3930164e
+  md5: 7b9888f46634eb49eece8fa6e16406d6
+  depends:
+  - __osx >=11.0
+  - libcurl >=8.10.0,<9.0a0
+  - libcxx >=17
+  - libsqlite >=3.46.1,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2732379
+  timestamp: 1726489115567
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/propcache-0.2.0-py311h460d6c5_2.conda
+  sha256: 7e6a656b09d494f0623c8bd0969195d1cd3f62a2ab5a2474a667c88e21cca971
+  md5: 8fb75727dfbab541ece9542718cc30f4
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 48222
+  timestamp: 1728546126843
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py311hae2e1ce_0.conda
+  sha256: 6237f04371995fa8e8f16481dcd4e01d2733a82750180a362a9f4953ffbb3cde
+  md5: e226eba0c52ecd6786e73c8ad7f41e79
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 514316
+  timestamp: 1729847396776
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+  sha256: 8ed65e17fbb0ca944bfb8093b60086e3f9dd678c3448b5de212017394c247ee3
+  md5: 415816daf82e0b23a736a069a75e9da7
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 8381
+  timestamp: 1726802424786
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-18.0.0-py311ha1ab1f8_1.conda
+  sha256: 5f087472e5eb7577e97c030cbc527e1c24ee290f259379e8deabcd6a17838638
+  md5: 342deac3c2230b86fdd97fafaf7d22ac
+  depends:
+  - libarrow-acero 18.0.0.*
+  - libarrow-dataset 18.0.0.*
+  - libarrow-substrait 18.0.0.*
+  - libparquet 18.0.0.*
+  - pyarrow-core 18.0.0 *_1_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25371
+  timestamp: 1731058530169
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-18.0.0-py311he04fa90_1_cpu.conda
+  sha256: 3b4bc16e3f044a4f0ac75955ddf17fb4fc4e39feef7e5af8ede834ffbf52e888
+  md5: f1da706c05d2113a7a1a1d8d07a63c7d
+  depends:
+  - __osx >=11.0
+  - libarrow 18.0.0.* *cpu
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - numpy >=1.21,<3
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3934172
+  timestamp: 1731058505049
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.3.1-py311h09e6bbd_1.conda
+  sha256: 698b08ca54169a744a1a087130ece9528f18da5e3be33ff6799ac6337d2a5e7f
+  md5: a0a43da9ec3ffb6195e7621fd959f430
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 485377
+  timestamp: 1725739643057
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.3.1-py311h09e6bbd_1.conda
+  sha256: 1d9f2c68ba6c7812f0c1e4a9bf9a5ad0a691b7b7b7694cb7ec0f05f1c24906f1
+  md5: 9c3fc1bf9718d8340f41b0fab06ecdaa
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 10.3.1.*
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 384333
+  timestamp: 1725875205492
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.0-py311hb4b81e0_0.conda
+  sha256: c2c06cca4ce9fd72f1bf8d69703a8c5c2252efd497619d09f47d95d18d3cccf9
+  md5: e3c2e5ded5b6e4b3c2600d033929645c
+  depends:
+  - __osx >=11.0
+  - certifi
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 501267
+  timestamp: 1727795522741
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.10-hc51fdd5_3_cpython.conda
+  sha256: 95a2c487176867ded825e23eab1e581398f75c5323da0cb7577c3cff3d2f955b
+  md5: 2a47a0061d7d3030e45b66d23f01d101
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 14598065
+  timestamp: 1729042279642
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
+  sha256: adc05729b7e0aca7b436e60a86f10822a92185dfcb48d66d6444e3629d3a1f6a
+  md5: 3b855e3734344134cb56c410f729c340
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6308
+  timestamp: 1723823096865
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h460d6c5_1.conda
+  sha256: 9ae182eef4e96a7c2f46cc9add19496276612663e17429500432631dce31a831
+  md5: d32590e7bd388f18b036c6fc402a0cb1
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 192321
+  timestamp: 1725456528007
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.0-py311h730b646_3.conda
+  sha256: 7e75589d9c3723ecf314435f15a7b486cebafa89ebf00bb616354e37587dc7ae
+  md5: b6f3e527de0c0384cd78cfa779bd6ddf
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365841
+  timestamp: 1728642472021
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+  sha256: 873ac689484262a51fd79bc6103c1a1bedbf524924d7f0088fb80703042805e4
+  md5: 6483b1f59526e05d7d894e466b5b6924
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: LicenseRef-Qhull
+  size: 516376
+  timestamp: 1720814307311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2024.07.02-hcd0e937_1.conda
+  sha256: eebddde6cb10b146507810b701ef6df122d5309cd5151a39d0828aa44dc53725
+  md5: 19e29f2ccc9168eb0a39dc40c04c0e21
+  depends:
+  - libre2-11 2024.07.02 h2348fd5_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26860
+  timestamp: 1728779123653
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+  sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
+  md5: 8cbb776a2f641b943d413b3e19df71f4
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 250351
+  timestamp: 1679532511311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.21.0-py311h3ff9189_0.conda
+  sha256: 309be68ba0cac227dbc288576b1b35a4f57cea85ca8891689399c384ac04b254
+  md5: ae72e9942de84200f16d91a1c3418116
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 294014
+  timestamp: 1730923248201
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.1-py311hf1db568_1.conda
+  sha256: 082a72e5f197aefb59e9f40176df835407e5f71ec832541ba14d4326d3686552
+  md5: 1163490da89fd85d00d29b4d4be7cf0c
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15242433
+  timestamp: 1729481958579
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
+  sha256: cb7a9440241c6092e0f1c795fdca149c4767023e783eaf9cfebc501f906b4897
+  md5: 69d0f9694f3294418ee935da3d5f7272
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35708
+  timestamp: 1720003794374
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.47.0-hcd14bea_1.conda
+  sha256: f9975914a78d600182ec68c963a98c6c0a07eda9b9eee7d6e8bdac9310858ad2
+  md5: ca42c22ab1d212895e58fee9ba32875f
+  depends:
+  - __osx >=11.0
+  - libsqlite 3.47.0 hbaaea75_1
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 840459
+  timestamp: 1730208324005
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+  sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
+  md5: b50a57ba89c32b62428b71a875291c9b
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3145523
+  timestamp: 1699202432999
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.1-py311h460d6c5_1.conda
+  sha256: bba4940ef7522c3b4ae6eacd296e5e110de3659f7e4c3654d4fc2bb213c2091c
+  md5: 8ba6d177509dc4fac7af09749556eed0
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 859139
+  timestamp: 1724956356600
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-15.1.0-py311hae2e1ce_1.conda
+  sha256: e4b1dcf79f4d4656e538ba24c845350b147d0d9f066771f8b3f396bea828b965
+  md5: ade7687026adce6296650b21e7463758
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 372655
+  timestamp: 1729704815727
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.16.0-py311h460d6c5_1.conda
+  sha256: 5667c48efd5e19e2754660293f00899dfd92b9228e19e7140cc46efcd0af8784
+  md5: ff3535f6abd3ec8e0589ead32a8c86fc
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 60435
+  timestamp: 1724958101626
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
+  sha256: 7113618021cf6c80831a429b2ebb9d639f3c43cf7fe2257d235dc6ae0ab43289
+  md5: 7e0125f8fb619620a0011dc9297e2493
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 13515
+  timestamp: 1727034783560
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+  sha256: 9939a166d780700d81023546759102b33fdc2c5f11ef09f5f66c77210fd334c8
+  md5: 77c447f48cab5d3a15ac224edb86a968
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 18487
+  timestamp: 1727795205022
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+  sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
+  md5: 39c6b54e94014701dd157f4f576ed211
+  license: LGPL-2.1 and GPL-2.0
+  size: 235693
+  timestamp: 1660346961024
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+  sha256: 93181a04ba8cfecfdfb162fc958436d868cc37db504c58078eab4c1a3e57fbb7
+  md5: 4bb3f014845110883a3c5ee811fd84b4
+  license: MIT
+  license_family: MIT
+  size: 88016
+  timestamp: 1641347076660
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.17.2-py311h917b07b_0.conda
+  sha256: 9f36ca92a19b11f3f5c79cc954f1ad9fee574bada0680df2dd44eec6933c8bf9
+  md5: 37a19c890f2e7b4cfabcdf4e4ef7288f
+  depends:
+  - __osx >=11.0
+  - idna >=2.0
+  - multidict >=4.0
+  - propcache >=0.2.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 141207
+  timestamp: 1731927269197
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-hc1bb282_7.conda
+  sha256: 9e585569fe2e7d3bea71972cd4b9f06b1a7ab8fa7c5139f92a31cbceecf25a8a
+  md5: f7e6b65943cb73bce0143737fded08f1
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libcxx >=18
+  - libsodium >=1.0.20,<1.0.21.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 281565
+  timestamp: 1731585108039
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
+  sha256: 58f8860756680a4831c1bf4f294e2354d187f2e999791d53b1941834c4b37430
+  md5: e3170d898ca6cb48f1bb567afb92f775
+  depends:
+  - __osx >=11.0
+  - libzlib 1.3.1 h8359307_2
+  license: Zlib
+  license_family: Other
+  size: 77606
+  timestamp: 1727963209370
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py311ha60cc69_1.conda
+  sha256: d2f2f1a408e2353fc61d2bf064313270be2260ee212fe827dcf3cfd3754f1354
+  md5: 29d320d6450b2948740a9be3761b2e9d
+  depends:
+  - __osx >=11.0
+  - cffi >=1.11
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 332271
+  timestamp: 1725305847224
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+  sha256: 2d4fd1ff7ee79cd954ca8e81abf11d9d49954dd1fef80f27289e2402ae9c2e09
+  md5: d96942c06c3e84bfcc5efb038724a7fd
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 405089
+  timestamp: 1714723101397
+- conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
+  sha256: 1a62cd1f215fe0902e7004089693a78347a30ad687781dfda2289cab000e652d
+  md5: 37e16618af5c4851a3f3d66dd0e11141
+  depends:
+  - libgomp >=7.5.0
+  - libwinpthread >=12.0.0.r2.ggc561118da
+  constrains:
+  - openmp_impl 9999
+  - msys2-conda-epoch <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49468
+  timestamp: 1718213032772
+- conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.11.2-py311h5082efb_0.conda
+  sha256: 03cec31c1f9767fcea20f2ec2412c74566ac91c3281d1ca1bc0083285e69ac7c
+  md5: 3dc8d1a23603d517124ec58264790215
+  depends:
+  - aiohappyeyeballs >=2.3.0
+  - aiosignal >=1.1.2
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - multidict >=4.5,<7.0
+  - propcache >=0.2.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yarl >=1.17.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  size: 854372
+  timestamp: 1731703780582
+- conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311he736701_5.conda
+  sha256: 8bbce5e61e012a06e248f58bb675fdc82ba2900c78590696d185150fb9cea91f
+  md5: 8917bf795c40ec1839ed9d0ab3ad9735
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 34883
+  timestamp: 1725357113431
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.8.0-h6c5491b_10.conda
+  sha256: f92d43e36d271194f027a49c5bd91c7f3eab0406a83734b0a2fee75e0c914546
+  md5: 78eef4154032e557c81bcd12640ee048
+  depends:
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 103029
+  timestamp: 1731733929676
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.8.0-hb414858_2.conda
+  sha256: d2327c924931550a05ab902b4aedbcf5105b581839bade4db7fba6e73dd63214
+  md5: fd898cb8119bf3ad009762df2d8068b0
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 46852
+  timestamp: 1731679007675
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.10.3-h2466b09_0.conda
+  sha256: 27c094c554a84389f0f2430e7397a1b33d558b035bbaf188877f635dbb9b26e6
+  md5: 49b50b5f5074259e9a62c0c271a24d98
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 234894
+  timestamp: 1731567453718
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.3.0-hb414858_2.conda
+  sha256: 2f8c79b24a1396ed2754379bfbe1595b50e7cf306962060b80084b46b682887f
+  md5: beb319c4aeb7de9f6cacf533ebbae94c
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 22528
+  timestamp: 1731679090015
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.5.0-hab6af6e_7.conda
+  sha256: 39fe165d6616e09d25c07a85560ec414a0b0b19c1880e0df52283196cf44896f
+  md5: 1e81f2ecfb25d4a84b4d8fa6067924e5
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 54641
+  timestamp: 1731714676039
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.9.1-hab0f966_2.conda
+  sha256: 81c93d2b8c951c18509ff1359505d01740f77865c9bef46c457607f0ca8c76ad
+  md5: e715a008f534917e93ed2238546b68b0
+  depends:
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-compression >=0.3.0,<0.3.1.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 182315
+  timestamp: 1731714924335
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.15.2-hef77f12_2.conda
+  sha256: 8c02308ad64dcccb85ea55b6fdfb6b6de4b5710a564d24faf64655c4029f4008
+  md5: ac3ab925a1345a6957d5d217fd2d9469
+  depends:
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 160495
+  timestamp: 1731702920182
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.11.0-hbfeb708_8.conda
+  sha256: c1462d6b1de9bdaf6b3233e70cdf2e49b481da9bdf91c0c3f5fcf5ed55f3ca18
+  md5: e125209fbb06e56a208a75f8aae48c00
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 186691
+  timestamp: 1731735208782
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.7.1-h6108ab3_3.conda
+  sha256: d1fbcf4bc0b14ecb36c478f174c886b28149a99198f70d064629d576db32e2ec
+  md5: 5b74f3d69d265068ddd53b21af16a29a
+  depends:
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 109065
+  timestamp: 1731745786696
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.2.1-hb414858_1.conda
+  sha256: 6130e79950efe49460dcedc8a4845a274ed572e55667b66c815dc771f63f9eca
+  md5: 0e3318644bfcc9c42cbde728d7bb8e08
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 55188
+  timestamp: 1731687352327
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.2.2-hb414858_1.conda
+  sha256: f7d0c5c9bd65cca937ed53425800d7376e89bdac9f82fcef44698e6707784cae
+  md5: 0cb03655a7cf5b4ad9e0cd8d5a18b21d
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 91905
+  timestamp: 1731687613902
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.29.4-h1e7036a_1.conda
+  sha256: ea3262ff39797a5ff4120d00f75de49abf49b81f70952f805373197432802f82
+  md5: e77d1847e340f272a791e8a6cc38bdd3
+  depends:
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-mqtt >=0.11.0,<0.11.1.0a0
+  - aws-c-s3 >=0.7.1,<0.7.2.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 263018
+  timestamp: 1731787600543
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.449-h922649a_2.conda
+  sha256: bf45247a4c28d14e7240c5cbd2f635edbe5597970fc3c150478262d41d5e07bd
+  md5: 31a040ebe846198fce79599ecb37bd2d
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - aws-crt-cpp >=0.29.4,<0.29.5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 2869232
+  timestamp: 1731927853656
+- conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.6-h85f69ea_0.conda
+  sha256: 1289853b41df5355f45664f1cb015c868df1f570cf743e9e4a5bda8efe8c42fa
+  md5: 2390269374fded230fcbca8332a4adc0
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50135
+  timestamp: 1719266616208
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-h2466b09_2.conda
+  sha256: d8fd7d1b446706776117d2dcad1c0289b9f5e1521cb13405173bad38568dd252
+  md5: 378f1c9421775dfe644731cb121c8979
+  depends:
+  - brotli-bin 1.1.0 h2466b09_2
+  - libbrotlidec 1.1.0 h2466b09_2
+  - libbrotlienc 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 19697
+  timestamp: 1725268293988
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-h2466b09_2.conda
+  sha256: f3bf2893613540ac256c68f211861c4de618d96291719e32178d894114ac2bc2
+  md5: d22534a9be5771fc58eb7564947f669d
+  depends:
+  - libbrotlidec 1.1.0 h2466b09_2
+  - libbrotlienc 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 20837
+  timestamp: 1725268270219
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311hda3d55a_2.conda
+  sha256: aa3ac5dbf63db2f145235708973c626c2189ee4040d769fdf0076286fa45dc26
+  md5: a0ea2839841a06740a1c110ba3317b42
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  license: MIT
+  license_family: MIT
+  size: 322114
+  timestamp: 1725268368720
+- conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+  sha256: 35a5dad92e88fdd7fc405e864ec239486f4f31eec229e31686e61a140a8e573b
+  md5: 276e7ffe9ffe39688abc665ef0f45596
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 54927
+  timestamp: 1720974860185
+- conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.34.3-h2466b09_0.conda
+  sha256: 1ddad30ee6de501a65b2431427800cb79fdb34a1650f291bb477a6c1c78fc1f1
+  md5: 7dd8f0c4af6a36df3b402fa12e19854c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 192873
+  timestamp: 1731182126180
+- conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
+  sha256: 0fcac3a7ffcc556649e034a1802aedf795e64227eaa7194d207b01eaf26454c4
+  md5: 4c4fd67c18619be5aa65dc5b6c72e490
+  license: ISC
+  size: 158773
+  timestamp: 1725019107649
+- conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h32b962e_3.conda
+  sha256: 127101c9c2d1a56f8791c19141ceff13fd1d1a1da28cfaca549dc99d210cec6a
+  md5: 8f43723a4925c51e55c2d81725a97db4
+  depends:
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.4,<1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  size: 1516680
+  timestamp: 1721139332360
+- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py311he736701_0.conda
+  sha256: 9689fbd8a31fdf273f826601e90146006f6631619767a67955048c7ad7798a1d
+  md5: e1c69be23bd05471a6c623e91680ad59
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 297627
+  timestamp: 1725561079708
+- conda: https://conda.anaconda.org/conda-forge/win-64/cftime-1.6.4-py311h0a17f05_1.conda
+  sha256: 1ab7b1dd6e6610042b48adc47dd85f4b0bdfe19230585a75fdec2d1bb4c64f3a
+  md5: a46fb98d896ccf723aa9f1bba8ccdef1
+  depends:
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 187832
+  timestamp: 1725401239339
+- conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.1-py311h3257749_0.conda
+  sha256: dbb0c161dd75e72e66c13f31715941adb094a45471016f89d6a1cfab30967ba8
+  md5: 91d8504588e1b3c77e605503e5a1bc11
+  depends:
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 216693
+  timestamp: 1731429286140
+- conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.0.0-py311he736701_1.conda
+  sha256: e8f2027af0cf22feebad76ccbbb3139437fd07b5c6c35497b45e8de2d1f636ea
+  md5: b0845b4087a24616d2fecc716397b3f6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 322558
+  timestamp: 1728335601937
+- conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.8-py311hda3d55a_0.conda
+  sha256: ee15fa3cb625d02cba59cb8b60575de721d44798029be8b2c961a613f714ff7e
+  md5: 77d256e98801d3f1066993c6602579c0
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 3631650
+  timestamp: 1731045182872
+- conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.15.0-h765892d_1.conda
+  sha256: ed122fc858fb95768ca9ca77e73c8d9ddc21d4b2e13aaab5281e27593e840691
+  md5: 9bb0026a2131b09404c59c4290c697cd
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 192355
+  timestamp: 1730284147944
+- conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.55.0-py311h5082efb_0.conda
+  sha256: 3a031bac21b8057a9e337ecb586eda89ebdfd3f8ccb46b59b5df4883bdd6cb35
+  md5: 9c27840f1f26f6abe84d9b41ff1dcc03
+  depends:
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - unicodedata2 >=15.1.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 2478943
+  timestamp: 1731643729545
+- conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+  sha256: 2c53ee8879e05e149a9e525481d36adfd660a6abda26fd731376fa64ff03e728
+  md5: 3761b23693f768dc75a8fd0a73ca053f
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-only OR FTL
+  size: 510306
+  timestamp: 1694616398888
+- conda: https://conda.anaconda.org/conda-forge/win-64/fribidi-1.0.10-h8d14728_0.tar.bz2
+  sha256: e0323e6d7b6047042970812ee810c6b1e1a11a3af4025db26d0965ae5d206104
+  md5: 807e81d915f2bb2e49951648615241f6
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: LGPL-2.1
+  size: 64567
+  timestamp: 1604417122064
+- conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.5.0-py311he736701_0.conda
+  sha256: 2a3975f8a179d3b58ea1818753a4920ae6e1188c6e8239107f076bde149be569
+  md5: 228d16664f7938586d813a1df2637934
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 54934
+  timestamp: 1729699828246
+- conda: https://conda.anaconda.org/conda-forge/win-64/getopt-win32-0.1-hcfcfb64_1.conda
+  sha256: f3b6e689724a62f36591f6f0e4657db5507feca78e7ef08690a6b2a384216a5c
+  md5: 714d0882dc5e692ca4683d8e520f73c6
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-3.0-only
+  license_family: GPL
+  size: 21903
+  timestamp: 1694400856979
+- conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-h63175ca_1003.conda
+  sha256: 25040a4f371b9b51663f546bac620122c237fa1d5d32968e21b0751af9b7f56f
+  md5: 3194499ee7d1a67404a87d0eefdd92c6
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 95406
+  timestamp: 1711634622644
+- conda: https://conda.anaconda.org/conda-forge/win-64/graphviz-12.0.0-hb01754f_0.conda
+  sha256: 19c229d7ca0e866c70ffe79e1258aaab598e7caa7fa258ffe6cbff15b71c1ced
+  md5: 8074641ca215d6f30b6152d9d79f0b9e
+  depends:
+  - cairo >=1.18.0,<2.0a0
+  - getopt-win32 >=0.1,<0.2.0a0
+  - gts >=0.7.6,<0.8.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libgd >=2.3.3,<2.4.0a0
+  - libglib >=2.80.3,<3.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pango >=1.50.14,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: EPL-1.0
+  license_family: Other
+  size: 1157652
+  timestamp: 1722674488876
+- conda: https://conda.anaconda.org/conda-forge/win-64/gts-0.7.6-h6b5321d_4.conda
+  sha256: b79755d2f9fc2113b6949bfc170c067902bc776e2c20da26e746e780f4f5a2d4
+  md5: a41f14768d5e377426ad60c613f2923b
+  depends:
+  - libglib >=2.76.3,<3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 188688
+  timestamp: 1686545648050
+- conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-9.0.0-h2bedf89_1.conda
+  sha256: 20f42ec76e075902c22c1f8ddc71fb88eff0b93e74f5705c1e72220030965810
+  md5: 254f119aaed2c0be271c1114ae18d09b
+  depends:
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=75.1,<76.0a0
+  - libglib >=2.80.3,<3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1095620
+  timestamp: 1721187287831
+- conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
+  sha256: 52fa5dde69758c19c69ab68a3d7ebfb2c9042e3a55d405c29a59d3b0584fd790
+  md5: 84344a916a73727c1326841007b52ca8
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 779637
+  timestamp: 1695662145568
+- conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.4-nompi_hd5d9e70_103.conda
+  sha256: c7fefe41464651e807f61d42803a670f25dbe0cb59677af97b9dda3e8cb675fd
+  md5: 6d72be86cae448cfc7bf93d51cd642bb
+  depends:
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2049966
+  timestamp: 1730830694091
+- conda: https://conda.anaconda.org/conda-forge/win-64/icu-75.1-he0c23c2_0.conda
+  sha256: 1d04369a1860a1e9e371b9fc82dd0092b616adcf057d6c88371856669280e920
+  md5: 8579b6bb8d18be7c0b27fb08adeeeb40
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 14544252
+  timestamp: 1720853966338
+- conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+  sha256: 0fd2b0b84c854029041b0ede8f4c2369242ee92acc0092f8407b1fe9238a8209
+  md5: 2d89243bfb53652c182a7c73182cce4f
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 1852356
+  timestamp: 1723739573141
+- conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_1.conda
+  sha256: 9a667eeae67936e710ff69ee7ce0e784d6052eeba9670b268c565a55178098c4
+  md5: 943f7fab631e12750641efd7279a268c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42891
+  timestamp: 1725303340467
+- conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.7-py311h3257749_0.conda
+  sha256: a2079e13d1345a5dd61df6be933e828e805051256e7260009ba93fce55aebd75
+  md5: 18fd1ac3d79a8d6550eaea5ceaa00036
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55867
+  timestamp: 1725459681416
+- conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+  sha256: 18e8b3430d7d232dad132f574268f56b3eb1a19431d6d5de8c53c29e6c18fa81
+  md5: 31aec030344e962fbd7dbbbbd68e60a9
+  depends:
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 712034
+  timestamp: 1719463874284
+- conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
+  sha256: f9fd9e80e46358a57d9bb97b1e37a03da4022143b019aa3c4476d8a7795de290
+  md5: d3592435917b62a8becff3a60db674f6
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 507632
+  timestamp: 1701648249706
+- conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+  sha256: f4f39d7f6a2f9b407f8fb567a6c25755270421731d70f0ff331f5de4fa367488
+  md5: 1900cb3cab5055833cfddb0ba233b074
+  depends:
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30037
+  license: Apache-2.0
+  license_family: Apache
+  size: 194365
+  timestamp: 1657977692274
+- conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_he0c23c2_1.conda
+  sha256: 52ff148dee1871ef1d5c298bae20309707e866b44714a0a333a5ed2cf9a38832
+  md5: 3f59a73b07a05530b252ecb07dd882b9
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1777570
+  timestamp: 1727296115119
+- conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
+  sha256: f5c293d3cfc00f71dfdb64bd65ab53625565f8778fc2d5790575bef238976ebf
+  md5: 8723000f6ffdbdaef16025f0a01b64c5
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 32567
+  timestamp: 1711021603471
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-18.0.0-h7b593d6_7_cpu.conda
+  sha256: 7a872d40337162d342c9811f7d4272769c7cc9d06307fa10eea257d6afe952f0
+  md5: a5acda3f3970b977debc4c7b758c0e99
+  depends:
+  - aws-crt-cpp >=0.29.4,<0.29.5.0a0
+  - aws-sdk-cpp >=1.11.449,<1.11.450.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgoogle-cloud >=2.31.0,<2.32.0a0
+  - libgoogle-cloud-storage >=2.31.0,<2.32.0a0
+  - libre2-11 >=2024.7.2
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.3,<2.0.4.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  - zstd >=1.5.6,<1.6.0a0
+  - libutf8proc <2.9
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - arrow-cpp <0.0a0
+  - parquet-cpp <0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5213890
+  timestamp: 1731791745173
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-18.0.0-hac47afa_7_cpu.conda
+  sha256: cf9a0a88146b14ba0e029b70e5d8d2852a1e090589d6cf77387c4c8b368cde80
+  md5: 89b203b8042189d72fb0df290ab3ec22
+  depends:
+  - libarrow 18.0.0 h7b593d6_7_cpu
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  license: Apache-2.0
+  license_family: APACHE
+  size: 455982
+  timestamp: 1731791798644
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-18.0.0-hac47afa_7_cpu.conda
+  sha256: feb3f8f3627fbcc01d8baadafca2384f23312803e5227bbdf9487f9f2494cc8a
+  md5: 3709baac004f54b43befb64b9c930e9d
+  depends:
+  - libarrow 18.0.0 h7b593d6_7_cpu
+  - libarrow-acero 18.0.0 hac47afa_7_cpu
+  - libparquet 18.0.0 h59f2d37_7_cpu
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  license: Apache-2.0
+  license_family: APACHE
+  size: 443680
+  timestamp: 1731791974256
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-18.0.0-hcd1cebd_7_cpu.conda
+  sha256: 0b18111fc682670aa4f06a378cdda0584baa3020d5a6836a0e33c78648e4da4f
+  md5: 1f033feb0e982b58297a1113a09e7c6b
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 18.0.0 h7b593d6_7_cpu
+  - libarrow-acero 18.0.0 hac47afa_7_cpu
+  - libarrow-dataset 18.0.0 hac47afa_7_cpu
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  license: Apache-2.0
+  license_family: APACHE
+  size: 372949
+  timestamp: 1731792050356
+- conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_mkl.conda
+  sha256: 5468bb91c44b41ce060bbd997c797b2f91e2b7ce91a7cbf4ddf7e7b734a8dc98
+  md5: 499208e81242efb6e5abc7366c91c816
+  depends:
+  - mkl 2024.2.2 h66d3029_14
+  constrains:
+  - blas * mkl
+  - libcblas 3.9.0 25_win64_mkl
+  - liblapack 3.9.0 25_win64_mkl
+  - liblapacke 3.9.0 25_win64_mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3736641
+  timestamp: 1729643534444
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-h2466b09_2.conda
+  sha256: 33e8851c6cc8e2d93059792cd65445bfe6be47e4782f826f01593898ec95764c
+  md5: f7dc9a8f21d74eab46456df301da2972
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 70526
+  timestamp: 1725268159739
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-h2466b09_2.conda
+  sha256: 234fc92f4c4f1cf22f6464b2b15bfc872fa583c74bf3ab9539ff38892c43612f
+  md5: 9bae75ce723fa34e98e239d21d752a7e
+  depends:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 32685
+  timestamp: 1725268208844
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-h2466b09_2.conda
+  sha256: 3d0dd7ef505962f107b7ea8f894e0b3dd01bf46852b362c8a7fc136b039bc9e1
+  md5: 85741a24d97954a991e55e34bc55990b
+  depends:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 245929
+  timestamp: 1725268238259
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_mkl.conda
+  sha256: 21528cdfe67dafdb2d21925515a167f13963e002c2b6d06d68984767f731850c
+  md5: 3ed189ba03a9888a8013aaee0d67c49d
+  depends:
+  - libblas 3.9.0 25_win64_mkl
+  constrains:
+  - blas * mkl
+  - liblapack 3.9.0 25_win64_mkl
+  - liblapacke 3.9.0 25_win64_mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3732258
+  timestamp: 1729643561581
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+  sha256: 75e60fbe436ba8a11c170c89af5213e8bec0418f88b7771ab7e3d9710b70c54e
+  md5: cd4cc2d0c610c8cb5419ccc979f2d6ce
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25694
+  timestamp: 1633684287072
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
+  sha256: dfbac497c4fee74f67391f9c4a40cab559468b7d04ff9fad4b404a26b5e1d5b8
+  md5: 7ead800e22ff7b4bccb73e42a8f7a0f4
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: curl
+  license_family: MIT
+  size: 342388
+  timestamp: 1726660508261
+- conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.22-h2466b09_0.conda
+  sha256: 579c634b7de8869cb1d76eccd4c032dc275d5a017212128502ea4dc828a5b361
+  md5: a3439ce12d4e3cd887270d9436f9a4c8
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 155506
+  timestamp: 1728177485361
+- conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+  sha256: af03882afb7a7135288becf340c2f0cf8aa8221138a9a7b108aaeb308a486da1
+  md5: 25efbd786caceef438be46da78a7b5ef
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 410555
+  timestamp: 1685726568668
+- conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.4-he0c23c2_0.conda
+  sha256: 0c0447bf20d1013d5603499de93a16b6faa92d7ead870d96305c0f065b6a5a12
+  md5: eb383771c680aa792feb529eaf9df82f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 139068
+  timestamp: 1730967442102
+- conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+  sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
+  md5: 2c96d1b6915b408893f9472569dee135
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 42063
+  timestamp: 1636489106777
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-14.2.0-h1383e82_1.conda
+  sha256: ef840e797714440bb10b69446d815966fff41fdac79f79c4e19c475d81cd375d
+  md5: 75fdd34824997a0f9950a703b15d8ac5
+  depends:
+  - _openmp_mutex >=4.5
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - libgcc-ng ==14.2.0=*_1
+  - libgomp 14.2.0 h1383e82_1
+  - msys2-conda-epoch <0.0a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 666386
+  timestamp: 1729089506769
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgd-2.3.3-h085315d_10.conda
+  sha256: 301b6da73cef796766945299a3dea776728703298aac90827aa6bf15134bc03c
+  md5: ac0cda3730da6013715a0d9e8e677d83
+  depends:
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xorg-libxpm >=3.5.17,<4.0a0
+  license: GD
+  license_family: BSD
+  size: 344264
+  timestamp: 1722928697150
+- conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.82.2-h7025463_0.conda
+  sha256: 7dfbf492b736f8d379f8c3b32a823f0bf2167ff69963e4c940339b146a04c54a
+  md5: 3e379c1b908a7101ecbc503def24613f
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - glib 2.82.2 *_0
+  license: LGPL-2.1-or-later
+  size: 3810166
+  timestamp: 1729192227078
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-14.2.0-h1383e82_1.conda
+  sha256: d8739b834608f35775209b032f0c2be752ef187863c7ec847afcebe2f681be4e
+  md5: 9e2d4d1214df6f21cba12f6eff4972f9
+  depends:
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - msys2-conda-epoch <0.0a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 524249
+  timestamp: 1729089441747
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.31.0-h07d40e7_0.conda
+  sha256: 40d5aa338c0aca8e619c777cc552d19f5810f1408b695c9de8f1dc7e279d8550
+  md5: 94320a551af951938e22e9b5dbd60b50
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libgoogle-cloud 2.31.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 14474
+  timestamp: 1731122599862
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.31.0-he5eb982_0.conda
+  sha256: 0deaba4051d1caec99f2e76bad65979007a01e912eecf8bdd895b5bddb96a085
+  md5: 5de1d1089bc7d21b2cbc7273a0c2022d
+  depends:
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libgoogle-cloud 2.31.0 h07d40e7_0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 14355
+  timestamp: 1731122772886
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.67.1-h7aa3b8a_0.conda
+  sha256: 986dafe9c3219e88a82389e679a2804d4256aa9ddaead193f91b7d6b4ef89ea1
+  md5: daad5d4a1c24c1afe748afbb83377e43
+  depends:
+  - c-ares >=1.34.2,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libre2-11 >=2024.7.2
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - re2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - grpc-cpp =1.67.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 17167461
+  timestamp: 1730236510917
+- conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+  sha256: 5f844dd19b046d43174ad80c6ea75b5d504020e3b63cfbc4ace97b8730d35c7b
+  md5: e1eb10b1cca179f2baa3601e4efc8712
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-only
+  size: 636146
+  timestamp: 1702682547199
+- conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
+  sha256: c7e4600f28bcada8ea81456a6530c2329312519efcf0c886030ada38976b0511
+  md5: 2cf0cf76cc15d360dfa2f17fd6cf9772
+  depends:
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 95568
+  timestamp: 1723629479451
+- conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+  sha256: 4e7808e3098b4b4ed7e287f63bb24f9045cc4d95bfd39f0db870fc2837d74dff
+  md5: 3f1b948619c45b1ca714d60c7389092c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 822966
+  timestamp: 1694475223854
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_mkl.conda
+  sha256: 98c13a28596389539abe3f608c6fbd2826df47671f77c58a331df878c6140c53
+  md5: f716ef84564c574e8e74ae725f5d5f93
+  depends:
+  - libblas 3.9.0 25_win64_mkl
+  constrains:
+  - blas * mkl
+  - libcblas 3.9.0 25_win64_mkl
+  - liblapacke 3.9.0 25_win64_mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3736560
+  timestamp: 1729643588182
+- conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_he239ae6_115.conda
+  sha256: bdf67732b92836287bdf6618093dada2ec20f2be4102d031a80f736e082cc410
+  md5: 582fd971ca8f54b59f007f2c1f1a113e
+  depends:
+  - blosc >=1.21.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzip >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 625327
+  timestamp: 1728056291410
+- conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-18.0.0-h59f2d37_7_cpu.conda
+  sha256: 11d4ee9467e08d8c832352e5646e8955fc49edcc8ef1186180b52844a2002be6
+  md5: c970cf15c8269a3e48ac933a1e73a9d6
+  depends:
+  - libarrow 18.0.0 h7b593d6_7_cpu
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.4.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  license: Apache-2.0
+  license_family: APACHE
+  size: 820038
+  timestamp: 1731791939088
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
+  sha256: 0d3d6ff9225f6918ac225e3839c0d91e5af1da08a4ebf59cac1bfd86018db945
+  md5: 639ac6b55a40aa5de7b8c1b4d78f9e81
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: zlib-acknowledgement
+  size: 348933
+  timestamp: 1726235196095
+- conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.28.2-hcaed137_0.conda
+  sha256: 798c6675fb709ceaa6a9bd83e9cffe06bc98e83f519c7d7d881243d2e6d0c34d
+  md5: 97c6d2f83edd7b400a22660e2a4d1488
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6033581
+  timestamp: 1728565880841
+- conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2024.07.02-h4eb7d71_1.conda
+  sha256: 39908d18620d48406ea3492bf111eface5b3a88c1a2d166c6d513b03f450df5d
+  md5: d8dbfb066c8e3e85439687613d32057d
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 260860
+  timestamp: 1728779502416
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+  sha256: 7bcb3edccea30f711b6be9601e083ecf4f435b9407d70fc48fbcf9e5d69a0fc6
+  md5: 198bb594f202b205c7d18b936fa4524f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: ISC
+  size: 202344
+  timestamp: 1716828757533
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.0-h2466b09_1.conda
+  sha256: 3342d6fe787f5830f7e8466d9c65c914bfd8d67220fb5673041b338cbba47afe
+  md5: 5b1f36012cc3d09c4eb9f24ad0e2c379
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 892175
+  timestamp: 1730208431651
+- conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+  sha256: 813fd04eed2a2d5d9c36e53c554f9c1f08e9324e2922bd60c9c52dbbed2dbcec
+  md5: dc262d03aae04fe26825062879141a41
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 266806
+  timestamp: 1685838242099
+- conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.21.0-hbe90ef8_0.conda
+  sha256: 81ca4873ba09055c307f8777fb7d967b5c26291f38095785ae52caed75946488
+  md5: 7699570e1f97de7001a7107aabf2d677
+  depends:
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 633857
+  timestamp: 1727206429954
+- conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hfc51747_1.conda
+  sha256: 902cb9f7f54d17dcfd54ce050b1ce2bc944b9bbd1748913342c2ea1e1140f8bb
+  md5: eac317ed1cc6b9c0af0c27297e364665
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.22,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 978865
+  timestamp: 1728232594877
+- conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-h82a8f57_0.tar.bz2
+  sha256: 6efa83e3f2fb9acaf096a18d21d0f679d110934798348c5defc780d4b759a76c
+  md5: 076894846fe9f068f91c57d158c90cba
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 104389
+  timestamp: 1667316359211
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+  sha256: d0ca51cb1de9192be9a3238e71fbcca5a535619c499c4f4c9b2ed41c14d36770
+  md5: abd61d0ab127ec5cd68f62c2969e6f34
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 274359
+  timestamp: 1713200524021
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_8.conda
+  sha256: 6d5e158813ab8d553fbb0fedd0abe7bf92970b0be3a9ddf12da0f6cbad78f506
+  md5: 03cccbba200ee0523bde1f3dad60b1f3
+  depends:
+  - ucrt
+  constrains:
+  - pthreads-win32 <0.0a0
+  - msys2-conda-epoch <0.0a0
+  license: MIT AND BSD-3-Clause-Clear
+  size: 35433
+  timestamp: 1724681489463
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
+  sha256: 08dec73df0e161c96765468847298a420933a36bc4f09b50e062df8793290737
+  md5: a69bbf778a462da324489976c84cfc8c
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - pthread-stubs
+  - ucrt >=10.0.20348.0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 1208687
+  timestamp: 1727279378819
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.5-h442d1da_0.conda
+  sha256: 020466b17c143190bd5a6540be2ceef4c1f8d514408bd5f0adaafcd9d0057b5c
+  md5: 1fbabbec60a3c7c519a5973b06c3b2f4
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1511585
+  timestamp: 1731489892312
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzip-1.11.2-h3135430_0.conda
+  sha256: 8ed49d8aa0ff908e16c82f92154174027c8906429e8b63d71f0b27ecc987b43e
+  md5: 09066edc7810e4bd1b41ad01a6cc4706
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 146856
+  timestamp: 1730442305774
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+  sha256: ba945c6493449bed0e6e29883c4943817f7c79cbff52b83360f7b341277c6402
+  md5: 41fbfac52c601159df6c01f875de31b9
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 55476
+  timestamp: 1727963768015
+- conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.43.0-py311h7deaa30_1.conda
+  sha256: 7df8480fc6c32b6f5e0b6f928332759559e9c2d6c43f94e6b51ea5d2129442a9
+  md5: c59d60615d5c5a9e9539a106478d332c
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - vs2015_runtime
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17126019
+  timestamp: 1725305442517
+- conda: https://conda.anaconda.org/conda-forge/win-64/lz4-4.3.3-py311h8b5e962_1.conda
+  sha256: 24bb321c5da9660f56759000001a6f227780348a21098164f55049b58ac78a11
+  md5: 8672eca07a3b500a9aa0483c43742f82
+  depends:
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 76663
+  timestamp: 1725090098178
+- conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+  sha256: a0954b4b1590735ea5f3d0f4579c3883f8ac837387afd5b398b241fda85124ab
+  md5: e34720eb20a33fc3bfb8451dd837ab7a
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134235
+  timestamp: 1674728465431
+- conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py311h5082efb_0.conda
+  sha256: 8a2022af5237e0fdf7e646856f1122735b71e4cdeaf42684b533ec4bad5a885f
+  md5: 84e78e335b0f9292060f1ac6d8ce0e3e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28244
+  timestamp: 1729351760960
+- conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.2-py311h8f1b1e4_2.conda
+  sha256: 45d3c5e41275b8333d0622a8f7642d049d9cbbe6c80cf7beb1aa371f1e79dffe
+  md5: f7d8036f3808253ae132500eaa8d65d9
+  depends:
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 7939436
+  timestamp: 1731026260055
+- conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_14.conda
+  sha256: 098ba4a3cb82f627bc79dc0ab1111b44859c9ef4aaa8d75ce043bce107770cb3
+  md5: f011e7cc21918dc9d1efe0209e27fa16
+  depends:
+  - intel-openmp 2024.*
+  - tbb 2021.*
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 103019089
+  timestamp: 1727378392081
+- conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.0-py311h3257749_0.conda
+  sha256: 4e6a7979b434308ce5588970cb613952e3340bb2f9e63aaad7e5069ef1f08d1d
+  md5: 36562593204b081d0da8a8bfabfb278b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 89472
+  timestamp: 1725975909671
+- conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.1.0-py311h5082efb_1.conda
+  sha256: 2e56ad9c72a9a757dc192b16efdc36681a5a963ca2bc4b798b5ddc4a271dbe7e
+  md5: 43817f67897069a44137321949264aab
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 57534
+  timestamp: 1729066160777
+- conda: https://conda.anaconda.org/conda-forge/win-64/netcdf4-1.7.2-nompi_py311hc43f1c8_100.conda
+  sha256: 83089e3b03bdfc048a1e2a0b860e6882031a72eac8c7aecd13b0e9402745f07c
+  md5: 5871f94c855c953ca3abc768f1420f3c
+  depends:
+  - certifi
+  - cftime
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1013027
+  timestamp: 1729662815776
+- conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.60.0-py311h0673bce_0.conda
+  sha256: b3359607051ec34c3eeb90447ece326822b6883882cf0e425cb1108dbcaebdc9
+  md5: 5d6eb2107dd921d651e46d059a82ab95
+  depends:
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - cudatoolkit >=11.2
+  - libopenblas !=0.3.6
+  - cuda-version >=11.2
+  - tbb >=2021.6.0
+  - scipy >=1.0
+  - cuda-python >=11.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5807308
+  timestamp: 1718888792863
+- conda: https://conda.anaconda.org/conda-forge/win-64/numcodecs-0.14.0-py311hcf9f919_0.conda
+  sha256: 16e3ccc7285db3ce9e5276c8536e29bf15b65efd5e16016eb801e5bcc0117eaa
+  md5: 20da4759814853839edf550346e41448
+  depends:
+  - msgpack-python
+  - numpy >=1.19,<3
+  - numpy >=1.24
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 554658
+  timestamp: 1731919257261
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.0.2-py311h35ffc71_0.conda
+  sha256: c373acdeea9897da86ecf757417d7591d28043ffa2da57e4b723b15daa936caa
+  md5: 573b96ee4daa4fe59211982afc575afc
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7507136
+  timestamp: 1724749843736
+- conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
+  sha256: dda71cbe094234ab208f3552dec1f4ca6f2e614175d010808d6cb66ecf0bc753
+  md5: 7e7099ad94ac3b599808950cec30ad4e
+  depends:
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 237974
+  timestamp: 1709159764160
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.4.0-h2466b09_0.conda
+  sha256: e03045a0837e01ff5c75e9273a572553e7522290799807f918c917a9826a6484
+  md5: d0d805d9b5524a14efb51b3bff965e83
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 8491156
+  timestamp: 1731379715927
+- conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.3-h34659fe_0.conda
+  sha256: 8baa71790c9899bd7bc0d028ec0dab8180330cb12ecd6600d2b7e0cb78a79a2c
+  md5: 7d0f9831258c59c73b1dcf00b05e8785
+  depends:
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 896875
+  timestamp: 1731665181736
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py311hcf9f919_1.conda
+  sha256: f5477bf3a2b7919481009ce87212d7bbd16c61a5bb05c692a7c336fb45646534
+  md5: 5965b8926efba14e6fde98cc8713c083
+  depends:
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14587131
+  timestamp: 1726879538736
+- conda: https://conda.anaconda.org/conda-forge/win-64/pango-1.54.0-hbb871f6_2.conda
+  sha256: 90327dd606f78ae9c881e285f85bc2b0f57d11c807be58ee3f690742354918b2
+  md5: 409c0b778deee649c025b7106549a24f
+  depends:
+  - cairo >=1.18.0,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=9.0.0
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-or-later
+  size: 450610
+  timestamp: 1723832834434
+- conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_2.conda
+  sha256: f4a12cbf8a7c5bfa2592b9dc92b492c438781898e5b02f397979b0be6e1b5851
+  md5: a3a3baddcfb8c80db84bec3cb7746fb8
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 820831
+  timestamp: 1723489427046
+- conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.0.0-py311h4fbf6a9_0.conda
+  sha256: 0d38ec638a5b266adb894f6fe4c874b46b98180a984007bf40cb030a22e8cc1e
+  md5: 44897ebc5704d3de316af26740325513
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: HPND
+  size: 42185657
+  timestamp: 1729066269713
+- conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
+  sha256: 51de4d7fb41597b06d60f1b82e269dafcb55e994e08fdcca8e4d6f7d42bedd07
+  md5: b98135614135d5f458b75ab9ebb9558c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 461854
+  timestamp: 1709239971654
+- conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.5.0-hd9569ee_0.conda
+  sha256: ebd1fee2834cf5971a08dfb665606f775302aa22e98d5d893d35323805311419
+  md5: 4cfbffd1cd2bbff30e975a71b1769597
+  depends:
+  - libcurl >=8.10.0,<9.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2709612
+  timestamp: 1726489723807
+- conda: https://conda.anaconda.org/conda-forge/win-64/propcache-0.2.0-py311he736701_2.conda
+  sha256: a9e90e6fd386ad9effc8e7c7e119ef15a913acc9c65897f649f32f61464ebcc9
+  md5: cf6d45e5a2054bc666c0d7f9a124ee20
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 50352
+  timestamp: 1728546232937
+- conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py311he736701_0.conda
+  sha256: 303c988247c4b1638f1cc90cd40465f5c74ca0ecfd83114033af637654dc2b6b
+  md5: 307267e6a028bca3382d98e06a372ebf
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 521434
+  timestamp: 1729847606018
+- conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
+  sha256: 7e446bafb4d692792310ed022fe284e848c6a868c861655a92435af7368bae7b
+  md5: 3c8f2573569bb816483e5cf57efbbe29
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 9389
+  timestamp: 1726802555076
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.0.0-py311h1ea47a8_1.conda
+  sha256: f05ee52c9f341be84a89ea336cd3526ca3627457c7bba78c722d99871fb85e9f
+  md5: 863a7894a5858878ae0490173538b3aa
+  depends:
+  - libarrow-acero 18.0.0.*
+  - libarrow-dataset 18.0.0.*
+  - libarrow-substrait 18.0.0.*
+  - libparquet 18.0.0.*
+  - pyarrow-core 18.0.0 *_1_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25669
+  timestamp: 1731059391882
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.0.0-py311hdea38fa_1_cpu.conda
+  sha256: e551fffe344eeb7bc6c0260fe40511208e67d27730d9e59c1a1a815bf3d0fecf
+  md5: 5e22f204915b905b7c2f9b0c0c55f231
+  depends:
+  - libarrow 18.0.0.* *cpu
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - numpy >=1.21,<3
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3470347
+  timestamp: 1731058670092
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.7.0-py311h90dcb63_0.conda
+  sha256: 36644db864de2ae57573d61bff0c46f3e5cb1efc86bd43756fdec9365ee8b5b3
+  md5: 423256766e9b9ba6c01c39b0ea992f1e
+  depends:
+  - certifi
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 760981
+  timestamp: 1727796239898
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.10-hce54a09_3_cpython.conda
+  sha256: 3931c546219d069918389e4dbe12057af4cc68a1060577a04014c6b5fc618aa0
+  md5: 5d54d429c0eb2273d1cc69763de6edaf
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 18206702
+  timestamp: 1729041779073
+- conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-5_cp311.conda
+  sha256: 9b210e5807dd9c9ed71ff192a95f1872da597ddd10e7cefec93a922fe22e598a
+  md5: 895b873644c11ccc0ab7dba2d8513ae6
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6707
+  timestamp: 1723823225752
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-307-py311hda3d55a_3.conda
+  sha256: 78a4ede098bbc122a3dff4e0e27255e30b236101818e8f499779c89670c58cd6
+  md5: 1bc10dbe3b8d03071070c962a2bdf65f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 6023110
+  timestamp: 1728636767562
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.14-py311hda3d55a_0.conda
+  sha256: 337097e3f3b71f782c43fb702893f86f080e140da467415dcaf039a7fbb8e551
+  md5: 64553b300529aa8987f6ca92c914c844
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 210973
+  timestamp: 1729202625177
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311he736701_1.conda
+  sha256: 86608f1b4f6b1819a74b6b1344c34304745fd7e84bfc9900269f57cf28178d31
+  md5: d0c5f3c595039890be0c9af47d23b9ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 187901
+  timestamp: 1725456808581
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.2.0-py311h484c95c_3.conda
+  sha256: 4d3fc4cfac284efb83a903601586cc6ee18fb556d4bf84d3bd66af76517c463e
+  md5: 4836b00658e11b466b823216f6df2424
+  depends:
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 371084
+  timestamp: 1728642713666
+- conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+  sha256: 887d53486a37bd870da62b8fa2ebe3993f912ad04bd755e7ed7c47ced97cbaa8
+  md5: 854fbdff64b572b5c0b470f334d34c11
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LicenseRef-Qhull
+  size: 1377020
+  timestamp: 1720814433486
+- conda: https://conda.anaconda.org/conda-forge/win-64/re2-2024.07.02-hd3b24a8_1.conda
+  sha256: 5ac1c50d731c323bb52c78113792a71c5f8f060e5767c0a202120a948e0fc85b
+  md5: b4abdc84c969587219e7e759116a3e8b
+  depends:
+  - libre2-11 2024.07.02 h4eb7d71_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 214858
+  timestamp: 1728779526745
+- conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.21.0-py311h533ab2d_0.conda
+  sha256: 217c9ce9bcb50ea55ba1148a7b85ae945015c68ecae914707eff0fce5c175cdf
+  md5: 56ff25ebb744a6aa97ff02b8c263c892
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 211208
+  timestamp: 1730923228503
+- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py311hf16d85f_1.conda
+  sha256: bd3c3ec5ba203143818fa3ca300060a459d78da566049b49ed2ef20e04ea5b96
+  md5: b7c132408b0ee7408dcfa998ef6f7939
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15858505
+  timestamp: 1729482598163
+- conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
+  sha256: 5b9450f619aabcfbf3d284a272964250b2e1971ab0f7a7ef9143dda0ecc537b8
+  md5: 7635a408509e20dcfc7653ca305ad799
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59350
+  timestamp: 1720004197144
+- conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.47.0-h2466b09_1.conda
+  sha256: bc2a5ab86dbe2352790d1742265b3b6ae9a7aa5cf80345a37f26ec3e04cf9b4a
+  md5: 93084a590e8b7d2b62b7d5b1763d5bde
+  depends:
+  - libsqlite 3.47.0 h2466b09_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 914686
+  timestamp: 1730208443157
+- conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.7.0-h91493d7_0.tar.bz2
+  sha256: c3d607499a6e097f4b8b27048ee7166319fd3dfe98aea9e69a69a3d087b986e3
+  md5: f57be598137919e4f7e7d159960d66a1
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 178574
+  timestamp: 1668617991077
+- conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+  sha256: 2c4e914f521ccb2718946645108c9bd3fc3216ba69aea20c2c3cedbd8db32bb1
+  md5: fc048363eb8f03cd1737600a5d08aafe
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: TCL
+  license_family: BSD
+  size: 3503410
+  timestamp: 1699202577803
+- conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.1-py311he736701_1.conda
+  sha256: 8e448bc682a6540a0aadc1f821c0d60f03d70272350caa2af519316fd1753f68
+  md5: f361535f90629358e3ea8f2161b239f3
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 860730
+  timestamp: 1724956581349
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+  sha256: db8dead3dd30fb1a032737554ce91e2819b43496a0db09927edf01c32b577450
+  md5: 6797b005cd0f439c4c5c9ac565783700
+  constrains:
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-MicrosoftWindowsSDK10
+  size: 559710
+  timestamp: 1728377334097
+- conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-15.1.0-py311he736701_1.conda
+  sha256: 07d55566e05bbadc32e989bbe50853e579fea0f8809503719d7d1438302d27be
+  md5: 6230613721d6d805d0276025ee4d7b2b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 365349
+  timestamp: 1729705070270
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_23.conda
+  sha256: 986ddaf8feec2904eac9535a7ddb7acda1a1dfb9482088fdb8129f1595181663
+  md5: 7c10ec3158d1eb4ddff7007c9101adb0
+  depends:
+  - vc14_runtime >=14.38.33135
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17479
+  timestamp: 1731710827215
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34433-he29a5d6_23.conda
+  sha256: c483b090c4251a260aba6ff3e83a307bcfb5fb24ad7ced872ab5d02971bd3a49
+  md5: 32b37d0cfa80da34548501cdc913a832
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.42.34433.* *_23
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  size: 754247
+  timestamp: 1731710681163
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hdffcdeb_23.conda
+  sha256: 568ce8151eaae256f1cef752fc78651ad7a86ff05153cc7a4740b52ae6536118
+  md5: 5c176975ca2b8366abad3c97b3cd1e83
+  depends:
+  - vc14_runtime >=14.42.34433
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17572
+  timestamp: 1731710685291
+- conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: 9df10c5b607dd30e05ba08cbd940009305c75db242476f4e845ea06008b0a283
+  md5: 1cee351bf20b830d991dbe0bc8cd7dfe
+  license: MIT
+  license_family: MIT
+  size: 1176306
+- conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.16.0-py311he736701_1.conda
+  sha256: b5d845acf27a2c4f236c905ac8366938a03ca292e58567236432c99462db9371
+  md5: 8d03f171fdeadfee26e33374274c702f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 62417
+  timestamp: 1724958420987
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libice-1.1.1-h0e40799_1.conda
+  sha256: 786dc4b9ebaad7dfab8aaed700e4b79dfeaecaf89fef1815ff5c19055d9e2c8c
+  md5: 78ef693fed85f1bf30d3a15983427c10
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 234740
+  timestamp: 1727532401173
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libsm-1.2.4-h0e40799_1.conda
+  sha256: f9944a672b9e8a043fd8dc417c233ad4e30502e369def2a257cdbdcf5e9463e0
+  md5: 27c850e290d5d8c31336c5c5d8d43a88
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  - xorg-libice >=1.1.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 96841
+  timestamp: 1727635068698
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libx11-1.8.10-hf48077a_0.conda
+  sha256: d1d6d2b5d33c35a39f7efacc3d2bc84332f0592d5435628dae89207bddeeaf5e
+  md5: 97e52b3d384cc7d3be4873bec28f050e
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - libxcb >=1.17.0,<2.0a0
+  - ucrt >=10.0.20348.0
+  - xorg-xorgproto
+  license: MIT
+  license_family: MIT
+  size: 952088
+  timestamp: 1727357732462
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-h0e40799_1.conda
+  sha256: f44bc6f568a9697b7e1eadc2d00ef5de0fe62efcf5e27e5ecc46f81046082faf
+  md5: ca66d6f8fe86dd53664e8de5087ef6b1
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 107925
+  timestamp: 1727035280560
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.5-h0e40799_0.conda
+  sha256: 9075f98dcaa8e9957e4a3d9d30db05c7578a536950a31c200854c5c34e1edb2c
+  md5: 8393c0f7e7870b4eb45553326f81f0ff
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 69920
+  timestamp: 1727795651979
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxext-1.3.6-h0e40799_0.conda
+  sha256: 7fdc3135a340893aa544921115c3994ef4071a385d47cc11232d818f006c63e4
+  md5: 4cd74e74f063fb6900d6eed2e9288112
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 284715
+  timestamp: 1727752838922
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxpm-3.5.17-h0e40799_1.conda
+  sha256: a605b43b2622a4cae8df6edc148c02b527da4ea165ec67cabb5c9bc4f3f8ef13
+  md5: e8b816fb37bc61aa3f1c08034331ef53
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxt >=1.3.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 236112
+  timestamp: 1727801849623
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxt-1.3.1-h0e40799_0.conda
+  sha256: c940a6b71a1e59450b01ebfb3e21f3bbf0a8e611e5fbfc7982145736b0f20133
+  md5: 31baf0ce8ef19f5617be73aee0527618
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 918674
+  timestamp: 1731861024233
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-xorgproto-2024.1-h0e40799_1.conda
+  sha256: 78a7211266821fd98c4a250f28dac7f8a6abbf8bff339990c6969d8d0712f11d
+  md5: de202fa8beaa5f5d4a085a82913143cd
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 569140
+  timestamp: 1726846656126
+- conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+  sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
+  md5: 515d77642eaa3639413c6b1bc3f94219
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: LGPL-2.1 and GPL-2.0
+  size: 217804
+  timestamp: 1660346976440
+- conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+  sha256: 4e2246383003acbad9682c7c63178e2e715ad0eb84f03a8df1fbfba455dfedc5
+  md5: adbfb9f45d1004a26763652246a33764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 63274
+  timestamp: 1641347623319
+- conda: https://conda.anaconda.org/conda-forge/win-64/yarl-1.17.2-py311he736701_0.conda
+  sha256: 897782fa6fb0039f4e08c47985dea4f2e78d06aac35551caabf78aa5ff7b6299
+  md5: f0acb82a53ea27060de29d4026efd3a7
+  depends:
+  - idna >=2.0
+  - multidict >=4.0
+  - propcache >=0.2.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 142253
+  timestamp: 1731927414370
+- conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_7.conda
+  sha256: 15cc8e2162d0a33ffeb3f7b7c7883fd830c54a4b1be6a4b8c7ee1f4fef0088fb
+  md5: e03f2c245a5ee6055752465519363b1c
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 2527503
+  timestamp: 1731585151036
+- conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
+  sha256: 8c688797ba23b9ab50cef404eca4d004a948941b6ee533ead0ff3bf52012528c
+  md5: be60c4e8efa55fddc17b4131aa47acbd
+  depends:
+  - libzlib 1.3.1 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Zlib
+  license_family: Other
+  size: 107439
+  timestamp: 1727963788936
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py311h53056dc_1.conda
+  sha256: a93584e6167c3598854a47f3bf8276fa646a3bb4d12fcfc23a54e37d5879f35c
+  md5: 7d4c123cbb5e6293dd4dd2f8d30f0de4
+  depends:
+  - cffi >=1.11
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 321357
+  timestamp: 1725305930669
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+  sha256: 768e30dc513568491818fb068ee867c57c514b553915536da09e5d10b4ebf3c3
+  md5: 9a17230f95733c04dc40a2b1e5491d74
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 349143
+  timestamp: 1714723445995

--- a/seattle_lidar/pixi.toml
+++ b/seattle_lidar/pixi.toml
@@ -26,8 +26,8 @@ hvplot = ">=0.11.1"
 python-graphviz = ">=0.20.3"
 ipycytoscape = ">=1.3.3"
 xarray-spatial = ">=0.4.0"
-pip = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [activation.env]
 INTAKE_CACHE_DIR = "data"

--- a/seattle_lidar/pixi.toml
+++ b/seattle_lidar/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "seattle_lidar"
-channels = ["conda-forge", "nodefaults"]
+channels = ["conda-forge"]
 platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
 
 [tool.metadata]

--- a/seattle_lidar/pixi.toml
+++ b/seattle_lidar/pixi.toml
@@ -1,0 +1,36 @@
+[workspace]
+name = "seattle_lidar"
+channels = ["conda-forge", "nodefaults"]
+platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2017-04-20"
+maintainers = ["jbednar", "PeterDSteinberg"]
+categories = ["Geospatial"]
+labels = ["datashader", "hvplot", "bokeh", "dask", "xarray-spatial"]
+description = "Visualize Lidar Scattered Point Elevation Data in Seattle"
+
+[dependencies]
+python = "3.11.*"
+notebook = ">=7.2.1"
+datashader = ">=0.16.3"
+holoviews = ">=1.20.0"
+intake = "<2"
+intake-xarray = ">=0.7.0"
+dask = ">=2024.7.1"
+s3fs = ">=2024.6.1"
+pandas = ">=2.2.2"
+distributed = ">=2024.7.1"
+pyproj = ">=3.7.0"
+hvplot = ">=0.11.1"
+python-graphviz = ">=0.20.3"
+ipycytoscape = ">=1.3.3"
+xarray-spatial = ">=0.4.0"
+pip = "*"
+wheel = "*"
+
+[activation.env]
+INTAKE_CACHE_DIR = "data"
+
+[tasks]
+notebook = "jupyter notebook seattle_lidar.ipynb"

--- a/ship_traffic/pixi.lock
+++ b/ship_traffic/pixi.lock
@@ -1,0 +1,9818 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-11.0.0-h374c478_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.6.8-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.1.6-h6a678d5_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.11-h5eee18b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.8.185-h721c034_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.2.1-py39h2f386ee_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39hdda0065_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.0-py39h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-2023.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2023.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-he6710b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h2531618_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/grpc-cpp-1.48.2-he1ff14a_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.4.0-h251f7ec_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20221030-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-hdbd6064_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.10.4-hf1b16e4_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.37-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.41.0-py39he621ea3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.9.3-py39hdbbb534_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py39h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py39hd09550d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.58.0-py39h1128e8f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.25.2-py39h5f9d8c6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.25.2-py39hb5e798b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.12-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.1.1-py39h1128e8f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.2.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-11.0.0-py39h468efa6_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.18-h955ad1f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py39h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.11.3-py39h5f9d8c6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.1.9-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/spatialpandas-0.4.9-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h27cfd23_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/abseil-cpp-20230802.0-h61975a4_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-11.0.0-h89a8245_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.6.8-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.1.6-hcec6c5f_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.11-h6c40b1e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.8.185-h1a8d504_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-2023.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2023.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-h0a44026_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/grpc-cpp-1.48.2-hbe2b35a_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gtest-1.14.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.4.0-hf20ceda_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20221030-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-h04015c4_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-4.3.2-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py39haf03e11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.12-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-1.7.4-h995b336_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-11.0.0-py39he65a03e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.1.9-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/spatialpandas-0.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h9ed2024_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/abseil-cpp-20230802.0-h313beb8_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-11.0.0-hc7aafb3_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.6.8-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.1.6-h313beb8_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.11-h80987f9_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.8.185-ha71a6ea_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-2023.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2023.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpc-cpp-1.48.2-hc60591f_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gtest-1.14.0-h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.4.0-h3e2b118_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20221030-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h02f6b3c_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.3.2-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py39h525c30c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.12-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-11.0.0-py39hbfed03b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.1.9-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/spatialpandas-0.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-11.0.0-ha81ea56_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.6.8-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.1.6-hd77b12b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.11-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.8.185-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-2023.6.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2023.6.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-ha925a31_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/grpc-cpp-1.48.2-hfe90ff0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.1.1-h86230a5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-he2ea4bf_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.3.2-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.12-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-11.0.0-py39h790e06d_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.1.9-h6c2663c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/spatialpandas-0.4.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+  sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
+  md5: 613805add1c05b538ff06d217252feb7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 20810
+  timestamp: 1652859733309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
+  sha256: 8762f481244fb151a200f01dd70e69c77171a3ee0f7f4c130e8e95b6a1626a68
+  md5: c3707fcd2efa582afc5c7e1986c6ce48
+  depends:
+  - libgcc-ng >=8.4.0
+  - libstdcxx-ng >=8.4.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1135866
+  timestamp: 1652382888447
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+  sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
+  md5: 2cf39d906cc321896ffe3e5d33d80c5c
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162166
+  timestamp: 1644463608931
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+  sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
+  md5: 2972a84e0e22ae3244bbd2f1eebcf536
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 35352
+  timestamp: 1644569715988
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-11.0.0-h374c478_2.tar.bz2
+  sha256: d4800b8aedf8fbd9b2ea0d8326144a8dfc6f54a20b0fe8cf4c07b09b931b7c7c
+  md5: c907d45aa4355477499984b4afaf1ea6
+  depends:
+  - abseil-cpp >=20211102.0,<20211102.1.0a0
+  - aws-sdk-cpp >=1.8.185,<1.8.186.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.5.0,<0.6.0a0
+  - grpc-cpp >=1.48.2,<1.49.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libgcc-ng >=11.2.0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libstdcxx-ng >=11.2.0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.10,<4.0a0
+  - orc >=1.7.4,<1.7.5.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.9,<2.0a0
+  - utf8proc <2.9.0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 11652427
+  timestamp: 1693264125605
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+  sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
+  md5: a68016b4b06460def24cb69d932986f3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132486
+  timestamp: 1695717963702
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.6.8-h5eee18b_1.tar.bz2
+  sha256: 1ce66314d08e9e942891e9de722b0881ae366eddda92ce5531dd405b61a0c66f
+  md5: e9c686e865033b3258219d863b17d318
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 172946
+  timestamp: 1685977805041
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.1.6-h6a678d5_6.tar.bz2
+  sha256: e6b4b9a4d81eb8c6050a08000df32f9158811e5b4a4379f3c3c14c1db9b94ba3
+  md5: 3943c28b998aa149a38724f9ce8c3f41
+  depends:
+  - aws-c-common >=0.6.8,<0.6.9.0a0
+  - aws-checksums >=0.1.11,<0.1.12.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 25977
+  timestamp: 1685999011516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.11-h5eee18b_2.tar.bz2
+  sha256: 4b5623e05f4b9756739c109bcbcdd95c4fa3888fe3402e5cc9e15d40f37d7881
+  md5: fa9ebd6fddf05d571aba2ee50266cbcb
+  depends:
+  - aws-c-common >=0.6.8,<0.6.9.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51973
+  timestamp: 1685994640393
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.8.185-h721c034_1.tar.bz2
+  sha256: 703ed4542bb40bb4daac768505521395605ac32b1b383c43d7e59c224ae010ad
+  md5: 2b02ca97a26097b453f8ef956081fc43
+  depends:
+  - aws-c-common >=0.6.8,<0.6.9.0a0
+  - aws-c-event-stream >=0.1.6,<0.1.7.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2528606
+  timestamp: 1686057539519
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+  sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
+  md5: 2f6356a2f530314b4059c08c79a3d8bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 205868
+  timestamp: 1681493113570
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.2.1-py39h2f386ee_0.tar.bz2
+  sha256: e6f5db63551cd4edaaeb2e7b9e8eb0ceec1e2370d5e1c469bffbcd2584ecea4e
+  md5: 4854bd2f4f65a8f30a5127a07d44cbe0
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6483397
+  timestamp: 1690546140960
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+  sha256: 3606c8607c29229222667f66421f79df167d33043fe9245cdd4e2c4520ecc721
+  md5: eca33dcef14fa044193e43492dca8585
+  depends:
+  - libboost 1.82.0 h109eef0_2
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 10768
+  timestamp: 1696762269985
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
+  sha256: 20e381c665853131fc5c9a397b1d4b05bb05859a2bdfbb0559e85ec445ee9e7c
+  md5: 14dc3c2e8eb68b1111a08de9a3ce8a00
+  depends:
+  - libgcc-ng >=11.2.0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 128656
+  timestamp: 1657175966755
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 11df9b719339bb40e4af8eb124a094def217f64e2440af973d7342da19c030b0
+  md5: 712827b1699cc71e6240626c413408f3
+  depends:
+  - brotli-bin 1.0.9 h5eee18b_7
+  - libbrotlidec 1.0.9 h5eee18b_7
+  - libbrotlienc 1.0.9 h5eee18b_7
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 18907
+  timestamp: 1659616178155
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 6408b6849347ef01f5ed170f4b35fb4bdfed2d9cf9da4912a4b104a810518a80
+  md5: d9d570587ccfd7158b66feb823c990c6
+  depends:
+  - libbrotlidec 1.0.9 h5eee18b_7
+  - libbrotlienc 1.0.9 h5eee18b_7
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 19933
+  timestamp: 1659616170430
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
+  sha256: 8507df3357958556aff2dea8788a3f7ddad6172fd9fe5d1bdb6c3afe9686d2f8
+  md5: f0204f72bcd9ef836218cc74345e69f2
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 362180
+  timestamp: 1659616255400
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
+  sha256: 168c2fc4d5899ee70e85fadc998e00827e1b856a6fc4a402ed465cd7c320d19f
+  md5: f52e60deb7f4c82821be9a868e889348
+  depends:
+  - libgcc-ng >=7.3.0
+  license: bzip2
+  license_family: BSD
+  size: 107105
+  timestamp: 1563219611337
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+  sha256: 5b4c80587ae4ec915505469f79d866f27c80456156667c8548d31c67c2c1653e
+  md5: c3d6bfae757760082261779c406a880d
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 116270
+  timestamp: 1693902021950
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+  sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
+  md5: 3ef00f4c5278b688552efc259c463dc8
+  license: MPL-2.0
+  license_family: Other
+  size: 132731
+  timestamp: 1694009767372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+  sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
+  md5: d5cb3d97cf5e85ffe5e94037ed8a1169
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159077
+  timestamp: 1690232254640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
+  sha256: e99314f8809d65195dcab68a9783f70fbe990113a66c98c9b0a7ffea01226b71
+  md5: fff69f95079191a10e099b21a5fd4bc3
+  depends:
+  - libffi >=3.4,<3.5
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 234749
+  timestamp: 1670423281079
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
+  sha256: 762f4506c3e12b2332bd9abea3a2a1966f307b2673be7fd661dc6e316602d18b
+  md5: 4b8df5459d1762495428323753438641
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 151844
+  timestamp: 1698129872673
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
+  sha256: 4fd0207b930fbc936d4b8206117cfa9792aa19bfb320eb08aab6bba10002f9ee
+  md5: 7082a1ce8fa314cc2761d2f689c6bb9e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40456
+  timestamp: 1683040035572
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+  sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
+  md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1917831
+  timestamp: 1668084545510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+  sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
+  md5: 13702d3b4b744784e5bd559c7050dd6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12719
+  timestamp: 1671231205875
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
+  sha256: 0b1a9a25ddfc6631390c53d6ee95706eaab0805c5a9a8d748c08120a1f421256
+  md5: a93581f810ef522bd23c148195591157
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 234846
+  timestamp: 1663827645102
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39hdda0065_0.tar.bz2
+  sha256: 6a08c501a310e5e482df8e917a7b0cd438e83f33a44aaec49c2ab53eeda5ebf1
+  md5: 3f8c39c0ce002faf6719b8d2d5f31941
+  depends:
+  - cffi >=1.12
+  - libgcc-ng
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 2181966
+  timestamp: 1694444647708
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.0-py39h5eee18b_0.tar.bz2
+  sha256: aac94702b3d4e4767f0bbbe3f1acfa811e18a2abb66f3afac74a51ddc3d046d9
+  md5: 4c34345079d18b1203746067dcd15042
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 394960
+  timestamp: 1667466037849
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-2023.6.0-py39h06a4308_0.tar.bz2
+  sha256: f17cae7cee82184f8ecdb8f1b42bd0dc9d1d76fb19ea4febdabcfcb1397ad025
+  md5: 2fe097998562477a3131010972f1d649
+  depends:
+  - bokeh >=2.4.2
+  - cytoolz >=0.12.0
+  - dask-core 2023.6.0.*
+  - distributed 2023.6.0.*
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.21,<2.0a0
+  - pandas >=1.3
+  - pyarrow >=7.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5234
+  timestamp: 1687284923315
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
+  sha256: 2084ad037e4b67a158facc0d1b21d1de16df7fe758e2bf08f6e48c6b75626cb8
+  md5: 8bb8a915dda236f7a2cf790490983445
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2121644
+  timestamp: 1686782977519
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
+  sha256: 161644f5f183f5632806cb2cb31890d06a1a575bed7949fe11bc59d3d4344e9d
+  md5: 96baa11147a42b64dcaa233a1733b8ee
+  depends:
+  - colorcet
+  - dask-core
+  - datashape
+  - numba
+  - numpy <2.0a0
+  - pandas
+  - param <2.0.0a0
+  - pillow
+  - pyct
+  - python >=3.9,<3.10.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17667549
+  timestamp: 1692372404139
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
+  sha256: 80188a9729a26e36b027e673f5f30395798eb68f9fe4721f3f33b4d4d2e58285
+  md5: 686db307602cbbdc30ca7d62b765578b
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 103488
+  timestamp: 1613390248313
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
+  sha256: 96b5d4c87d8467ae6ba92f9c17eaa9e059b6f7e9b8ee57aee788885c7413078b
+  md5: 9868912fd269f4d9d6423cfe69560131
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2164334
+  timestamp: 1690905228819
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2023.6.0-py39h06a4308_0.tar.bz2
+  sha256: 5223d52058a7f4de043e7f8d3b03163626a4da7a8b0b7f3ab1403c23ad20173c
+  md5: 1d6b6b067820cf7078380495d5b8cbe9
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - dask-core 2023.6.0.*
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.0
+  - packaging >=20.0
+  - psutil >=5.7.2
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=5.3.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.10.0
+  - tornado >=6.0.4
+  - urllib3 >=1.24.3
+  - zict >=2.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1390378
+  timestamp: 1686866113775
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+  sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
+  md5: 2e6ec51066d825ef3c317abe78d6049e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16413
+  timestamp: 1649926472708
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+  sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
+  md5: b4d923222d45314856b5378cb115214d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26728
+  timestamp: 1668714462023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+  sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
+  md5: a5dc8677d891dff2393b63189a3ad42f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 971975
+  timestamp: 1666798278693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
+  sha256: cfef2f1f3f1aa159f87806b7fa2b65c02c0d6f9bd24ccda833b43246c5095be6
+  md5: 394ec1374a92c6fd5f772343934337e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 260575
+  timestamp: 1695734561396
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-he6710b0_0.tar.bz2
+  sha256: bb154050063e427d00f261baa1e7884a0a2db54d57791322048296439147a89a
+  md5: bcb2fff3ff80e0466eb2dafc93f88fa1
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 164178
+  timestamp: 1542388351673
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
+  sha256: c323a9800a358c178f6f3b8860bbb77c373fbc3be981bb6420175fbb5431adf5
+  md5: 6485f51176cf651b3b28c3548cef10ad
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 78533
+  timestamp: 1676983203797
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h2531618_0.tar.bz2
+  sha256: cb4410750b5d94bd1a75e6dff662e4192481d0f5fd53dcbfa5853e21d20b20c8
+  md5: bfbf6dcde0288f43857e8371087e81da
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: BSD-3-Clause
+  size: 108274
+  timestamp: 1620732909459
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/grpc-cpp-1.48.2-he1ff14a_1.tar.bz2
+  sha256: 32657e2d11dd813e5649f714c7f58115cff3387f27cf0904cee873bd0d82d2a4
+  md5: bdfb8214247977e4ededa4aeb3291ea3
+  depends:
+  - abseil-cpp >=20211102.0,<20211102.1.0a0
+  - c-ares >=1.19.0,<2.0a0
+  - libgcc-ng >=11.2.0
+  - libprotobuf >=3.20.3,<3.20.4.0a0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libstdcxx-ng >=11.2.0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5391101
+  timestamp: 1685747457305
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.0-py39h06a4308_0.tar.bz2
+  sha256: 6d934b1d532f644e148bcf51f9c8d0c7623e832fd29282bc6c4cb64b9e027884
+  md5: b18725efd77d3fb6c9addf81dac09081
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4576699
+  timestamp: 1698866790345
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+  sha256: b35b281dbf69b826c6ae04fcd7b6a2d1f098277a669a199906a1f23b4b0931a5
+  md5: 2a793fe24f85aa5819fe69c450cba6f7
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 29021241
+  timestamp: 1692293243228
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+  sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
+  md5: 1eb52f9f45cea2fb9ce27b19f990160e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110793
+  timestamp: 1666125606878
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+  sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
+  md5: 126b3c1933b7364ff03f67455b687e99
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 37588
+  timestamp: 1678997134023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
+  sha256: b6d5f6098903e5edfbc2200282efa186d446442d47ab75f51ff22c30ae0c4da4
+  md5: e53a806995cedc9e5d8a96e03c9e79ac
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 50699
+  timestamp: 1698254665788
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
+  sha256: bddc8de31272a509510cc87e5ac0cdb0e7765d393ca7bdfddbfe4123979a9413
+  md5: bc8a501970aadad3373edbce996b5fdf
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<1.2.14
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 19286333
+  timestamp: 1681801301379
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
+  sha256: c0d0714c68ed953740812688ac1b3c3e286de33b55d49f02953d705fb00c30d0
+  md5: 8b65eea396159a3b59278f77c81ddd1b
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217268
+  timestamp: 1691122070319
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+  sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
+  md5: ff47e0be879e817713ce2a9daa76e2b0
+  depends:
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1261116
+  timestamp: 1694181530670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+  sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
+  md5: 5ef6c6a0d1ac79143c7359d305155167
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1021637
+  timestamp: 1644297140650
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+  sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
+  md5: eaeb023688f781e7dd89e74310c38195
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 211775
+  timestamp: 1666908212136
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+  sha256: c21f8f407266d039e819c27fe9eb4fb26587e974f3bd059b37cbaec5073722d0
+  md5: ba1f47411e9e07876c7a3e9d3be6a98e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: IJG
+  license_family: Other
+  size: 281400
+  timestamp: 1677849152168
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+  sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
+  md5: 0d2c3c5edf671b575532d5a3e8bf15fc
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 131510
+  timestamp: 1676558716852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
+  sha256: 4ba1f5698f0b483af397021b2047554afb3129790cac3a1502c79693154331d2
+  md5: 8e9c0ef4b0b57caa87c146892e56a313
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192921
+  timestamp: 1676329415827
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py39h06a4308_0.tar.bz2
+  sha256: b791f2f86fe1993ddfcd10a80a92fb098c2b4792f0ce13da9269cac6b3647d0b
+  md5: ac7c5e38691312d195fdd1f23b33f779
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78853
+  timestamp: 1698937381669
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+  sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
+  md5: a4beb461f0a60998a090d760b5c6c907
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411564
+  timestamp: 1671707702849
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
+  sha256: 6d6c384c9c65e33d5d047e01131e0687eb2bc1e5a4a67f80af3c0b773c1bba82
+  md5: 07957e1d2fb6a407f7d7293b84938e1e
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 77689
+  timestamp: 1672387301020
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+  sha256: 01bae3dd44469e34f043e0416f5f5e658429bf4031745399d9968d10b899e2c4
+  md5: 10171cca67e3d73c3646c6dc5a321460
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.8,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1427115
+  timestamp: 1686931095252
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+  sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
+  md5: 88199c75f2ac211728febced7785c24e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 228278
+  timestamp: 1635523146417
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+  sha256: e2754627e8aeb98777318939e6773b9eadbdc219dd8961aca946354d9d30f481
+  md5: 4ed89646229bee3e594cd2cc8f6060f9
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 23778916
+  timestamp: 1696762223408
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 472cf888db65d00451fcd5fccd5244d55c061e8d7efe43f70220414ef64521a5
+  md5: 787927eff72e62c270f614cbcba9479c
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 67109
+  timestamp: 1659616145972
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 19a43182ca343510ba51baa0fce91d64c840a19cdf13c6dde4e03e819c70897e
+  md5: c0608d376a30b5aa4d2f2c22978135db
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_7
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 34691
+  timestamp: 1659616154057
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 158c401aa0bab05aa5f4134aea798085e4e3849209946f896cca352930d2225d
+  md5: cc6a6d362912a2d112310bd3f8acd44e
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_7
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 295287
+  timestamp: 1659616162282
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.4.0-h251f7ec_0.tar.bz2
+  sha256: ba5af576db57611030cfcfaca376b08c417ef7ee5dbe065710d64aaca30748f5
+  md5: 1a56ed5ad456aa2d140fc69dc862cfe0
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libgcc-ng >=11.2.0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.57.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 396955
+  timestamp: 1697023405523
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+  sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
+  md5: 55dde57e63a36b202e388a39dcee9a66
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 74096
+  timestamp: 1695996494461
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20221030-h5eee18b_0.tar.bz2
+  sha256: 5d66a60672f8e7dd0c048b5f158b5d406f16133b260ffde95a93eb453a1e7af9
+  md5: af7584851084abae8eaa8cee2ed288b4
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.3,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 195621
+  timestamp: 1670840131081
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+  sha256: efdab884c85fda4461f7a393aa6d4e0e50d03cb59fb9c8a980b1307b8379ebe0
+  md5: eeca774c6154c49340dd403b1928d5e9
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 108906
+  timestamp: 1632891483341
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+  sha256: 4b2518a1aa3859031a531cd1077e8a60d5b3a0dc7c83210ef27ff9ce2c78c3e3
+  md5: 49f152ee4045544c10799d32bba85c07
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 480247
+  timestamp: 1685052130829
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
+  sha256: ec1c6341cf0091b55be05285037cb3fbba90573e00257f383ab274d8b8e6d46f
+  md5: 32ac65d639d6c155ea7276cadf1fd2b6
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 147907
+  timestamp: 1683716564178
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
+  md5: 641e72e5067bd6d5454405879e1cd2a7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - _libgcc_mutex * main
+  - __glibc >=2.17
+  constrains:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - libgomp 11.2.0 h1234567_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 8895144
+  timestamp: 1654090827491
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+  sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
+  md5: 27082517590f3b9fbffecc68513b461b
+  depends:
+  - libgfortran5 11.2.0.*
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 19860
+  timestamp: 1654090819660
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+  sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
+  md5: 0202c3c8ae4735cac6c7f3d1e1685964
+  constrains:
+  - libgfortran-ng 11.2.0 *_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 5228750
+  timestamp: 1654090762569
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+  sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
+  md5: 3080c2813e6e1d0f8a100a38b5b3456d
+  depends:
+  - _libgcc_mutex 0.1 main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 573231
+  timestamp: 1654090775721
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+  sha256: 512fac06ddd97b4383503d4fbd8145102966055b29ccf86841a930dbb4ef3ab8
+  md5: 833c0e514ff9c8ae0511630b024d60e0
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 37179832
+  timestamp: 1683292829131
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+  sha256: 6c67d781d3c074ae46b18567f230bce4a4afa209e8b914dc2cb448502774886e
+  md5: c9627c386bbc8a1a1a0a2e736ea44501
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - c-ares >=1.7.5
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 722387
+  timestamp: 1697018420830
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+  sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
+  md5: 1bffe1481ed4f88827248fb9001f8923
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 362561
+  timestamp: 1677841789536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
+  sha256: a24f7d1cdb5e18466a61860a5a66baffd608e212bbfed2935350e83d4d8659c0
+  md5: b32a43de76bc9be9c71f9a12edec8a1e
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2706964
+  timestamp: 1675278653314
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-hdbd6064_2.tar.bz2
+  sha256: d011fe14e4b5752feb7f1d6b7c1a7913cb153f8759b4befdf53ed7a5d846cd52
+  md5: c29b0f58de6585e5220e10eb5ac2f9e2
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 311498
+  timestamp: 1686931236351
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
+  md5: 8c195584a5f5471b600ee180e4052773
+  depends:
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 6410287
+  timestamp: 1654090800863
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+  sha256: 974e4035c5d51cd41fa7a7f02fadc1980069c00526c1646fa18ea94e667fb137
+  md5: 188de945b4279a812953011e8c4580c2
+  depends:
+  - boost-cpp >=1.73
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.9,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4630795
+  timestamp: 1687975185557
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+  sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
+  md5: ef78eebd98289aceacdfa29182426adf
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 664034
+  timestamp: 1693575237924
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
+  sha256: c6aecee300c8e84a99056307ed3bdc047edd5366e55230a4eabe3ee5e8082bb8
+  md5: 3a6ebf9895b1085a23783cd95460a629
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88424
+  timestamp: 1694778218406
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+  sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
+  md5: 9cdeef1d044c7e035c006890f11569d3
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 436056
+  timestamp: 1694776944891
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.10.4-hf1b16e4_1.tar.bz2
+  sha256: 93b155c0472d424dce940921ff368a3e4fd70fa41f5f934e58a4b7ec24722f95
+  md5: 2d7bb4d2ef09d62843f8be03b55fce18
+  depends:
+  - icu >=73.1,<74.0a0
+  - libgcc-ng >=11.2.0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 744988
+  timestamp: 1692970212537
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.37-h5eee18b_1.tar.bz2
+  sha256: e4e42cc28f7d509980afa2b1e76266d997628c9ff5d194c8460228279c0b6cdc
+  md5: ff861c432be5a684783732ad1eb4c39f
+  depends:
+  - icu >=73.1,<74.0a0
+  - libgcc-ng >=11.2.0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 258682
+  timestamp: 1692973520375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py39h06a4308_0.tar.bz2
+  sha256: 0e4d61ed508712fc16117fc41f0f5bfedd319cfefd114749689db5f78242b0a5
+  md5: d40d6b6ea51683b29a9e210831db4a13
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 35171
+  timestamp: 1659783489143
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.41.0-py39he621ea3_0.tar.bz2
+  sha256: 2246a2cfd4902904e047c598f3860e592ca2d4779d01c231149a73933e6e5921
+  md5: fc49dbd83aa5e65e5c1e90a79baf663e
+  depends:
+  - libgcc-ng >=11.2.0
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  - zlib
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4040718
+  timestamp: 1697031344309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
+  sha256: d8cd22ac7f033507549f6a0d078cd273607cb6e8246b0383375a33941969c12c
+  md5: 78c7a3a437536ae24d2d7ce15ec400d2
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11065
+  timestamp: 1652903210940
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.9.3-py39hdbbb534_0.tar.bz2
+  sha256: b961c12e78000995cfcc5769c64b1c146f917e640e999e290bb2b36468bd7dbe
+  md5: a3a5039a19997b8cee4ddf538472358c
+  depends:
+  - libgcc-ng >=11.2.0
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1616363
+  timestamp: 1695058577405
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py39h5eee18b_0.tar.bz2
+  sha256: 2af4de285aede9dfaa53b4c542ba500b01420156aa6fabfd0fdc426dd3110e51
+  md5: a7a6a481ac90c173785513e0b28d0ed3
+  depends:
+  - libgcc-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37668
+  timestamp: 1686057919336
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
+  sha256: 36b23ab8d8aa22d70a2f733462cabe95e5b27ca919ec7a75a5592bc39c5f7d16
+  md5: f24adbfdfe16b0bac0d14640bb5ce616
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 163649
+  timestamp: 1670944701605
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+  sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
+  md5: 421f82c8274b44660dba629134faa6af
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 122221
+  timestamp: 1671541990505
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py39h06a4308_1.tar.bz2
+  sha256: 9332b39039a52ecc802ddc2c4a3bde95a3141aff0ccab19a7591ec6ef72bfe07
+  md5: 622bb5a6eeeadeb8731e5e1bf4f0d7a2
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 105637
+  timestamp: 1684279960746
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+  sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
+  md5: feb0e452205b44ac45d9b5e55c21a3b1
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22819
+  timestamp: 1654597913064
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
+  sha256: 10701d3065424bbef89c03a30c4adecd67308cd2f76e0d873aad6a180d9fe097
+  md5: e196f6bace29ef34f0a996ef1c99f193
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8129476
+  timestamp: 1698692330174
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+  sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
+  md5: c04ef34af33da4c71bcc99b7ec24d210
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16391
+  timestamp: 1662014553452
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py39h06a4308_0.tar.bz2
+  sha256: 0dd0157d3d6c591a1087f7b96993412ac9194b7ea0ee2d667b1dc1c587eb0e33
+  md5: 975a78ae464b1cd9541c498fd8299858
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 52857
+  timestamp: 1659721312521
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py39h06a4308_0.tar.bz2
+  sha256: cae67d22945f16e1034fc53144eea8bb67f2fecf6d60b22c43822094b6ca2b49
+  md5: 19932cd4f64628bf6db1accebdaf7eac
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18689
+  timestamp: 1659716096534
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+  sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
+  md5: f6c734d73e6e3dbc1b62766cf18ff3e4
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58153
+  timestamp: 1607364912263
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
+  sha256: c7dedf41acbb2a065364f949ba24479449387d54c095220ff89346d266b25347
+  md5: c5f96c8ff7102e1d673829bbeb8bed84
+  depends:
+  - intel-openmp 2023.*
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - tbb 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 206706869
+  timestamp: 1691503234180
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
+  sha256: 984f547627b0af8358fa83b2396e0b2c014f9bc281304b6b8d3ff139a3f04b40
+  md5: 724d2559e0ed50aa0eee97c919134ded
+  depends:
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 58512
+  timestamp: 1682948511810
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
+  sha256: 650419991b99b810e79221e35e5a6c3e49240ed30ff3e5324eecf1cefd276110
+  md5: a14b8155afdb15f3bce72e67925c0ceb
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 227382
+  timestamp: 1695058347376
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
+  sha256: 7b0eeb8acc4c6b9f45b214fbc991a4073a59a8f7b798a4cc86515b97f7af6355
+  md5: eb48e45fd8d61762290e4289a52be3f7
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 329190
+  timestamp: 1695059874042
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py39hd09550d_0.tar.bz2
+  sha256: a138d682379358886f9d8c1e81da8d126c5cb1f0eff50e236ed471ea5b0b9d24
+  md5: 5b2574b896f022cf33ed9a871aacabb3
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 90177
+  timestamp: 1652362815706
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
+  sha256: 305313d215116fbf13a38f8a321eb635b83294871801ac63e543a59ba7de642c
+  md5: e0db8ae050bd0db74f47edc370dbc287
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 24480
+  timestamp: 1607574279743
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+  sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
+  md5: 95c83d71814c504b5504df4f14548f1a
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8257558
+  timestamp: 1681756322140
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py39h06a4308_0.tar.bz2
+  sha256: 79e10dc933d22aa99de3543071f1beaaf0ff24df9fed7d2ef5e765f3ed766064
+  md5: ea6ebe4e8d6af98128d32606da618a29
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99555
+  timestamp: 1698934242626
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+  sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
+  md5: 1710a25086c8098367eb36b9d441448b
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 569683
+  timestamp: 1668450704669
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+  sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
+  md5: 385cc9e53404776782502c0fdb08820f
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147046
+  timestamp: 1694616899309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+  sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
+  md5: 57ea097dc15f8d9f9eb90e1d919143b0
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1157733
+  timestamp: 1674734069410
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+  sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
+  md5: bbbcbebc20a4fdcadce398d0ca04f95e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13109
+  timestamp: 1672387143252
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+  sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
+  md5: 248ce515640465371927d46f389ed555
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 594054
+  timestamp: 1690985006481
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+  sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
+  md5: 70db71df4ee1cdd38090c0f7b80ba61f
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21944
+  timestamp: 1668160644514
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.58.0-py39h1128e8f_0.tar.bz2
+  sha256: f8dd4d134d271bd5c598a751a97bd762af9d521da397c3d7c9bf27f075766786
+  md5: 1b6b9a910a63651d7b0730fb8efb715d
+  depends:
+  - _openmp_mutex >=5.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - llvmlite >=0.41.0,<0.42.0a0
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.26
+  - python >=3.9,<3.10.0a0
+  - tbb >=2021.8.0
+  - libgomp
+  constrains:
+  - libopenblas !=0.3.6
+  - cuda-python >=11.6
+  - tbb >=2021.6,<2022
+  - scipy >=1.0
+  - cudatoolkit >=10.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4454092
+  timestamp: 1697065406496
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
+  sha256: e61fc626f7131f1857c703ad3bb4dcacfc6b1fd6d5da545aa8f600b840315aca
+  md5: 6b689e52e3ba1fa7caaab3e6be31860c
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 141434
+  timestamp: 1696515497148
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.25.2-py39h5f9d8c6_0.tar.bz2
+  sha256: 546e81b24b7718627a403582cdfd604df8c250373afc65620df65e9d7bc52209
+  md5: abfffef48047ff2b9e1aa14435b3b51f
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.25.2 py39hb5e798b_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11965
+  timestamp: 1691097038493
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.25.2-py39hb5e798b_0.tar.bz2
+  sha256: f822485f35430e652cd400ddc551991a02cff7f41823733536d74431b48454d8
+  md5: 7fa1afb4996b13c22a2c4f0ee0800bfc
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.25.2 py39h5f9d8c6_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7863917
+  timestamp: 1691097022810
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+  sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
+  md5: b0afe23033c8c5344640bc25225fa579
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 516994
+  timestamp: 1630084830020
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.12-h7f8727e_0.tar.bz2
+  sha256: f29899dc427cc09b2668b1e6db7718574809497c73bd725c682088053852aa16
+  md5: bbd867a77bbde74015a8db1b3f3a01a8
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 5486812
+  timestamp: 1699012426314
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
+  sha256: 9618addfc1b940c048372ffb2c8500d4b44d02455a9bd1f411e530ed5e09b8d5
+  md5: 56057ed323f733bdcf262468682d0358
+  depends:
+  - libgcc-ng >=11.2.0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.9,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1132661
+  timestamp: 1676482768554
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+  sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
+  md5: 77a22ed6d0d448c5288d0f695bc9ac49
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 72527
+  timestamp: 1693575234886
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.1.1-py39h1128e8f_0.tar.bz2
+  sha256: 525a877de379651efc20862a77deb470c9c4ff3cfa470d3643c5036de0ec5d17
+  md5: dd9fcd456d8fb03daad201cf130d28bd
+  depends:
+  - bottleneck >=1.3.4
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - pyreadstat >=1.1.5
+  - zstandard >=0.17.0
+  - pyqt >=5.15.6,<6
+  - qtpy >=2.2.0
+  - gcsfs >=2022.05.0
+  - blosc >=1.21.0
+  - lxml >=4.8.0
+  - odfpy>=1.4.1
+  - xlrd >=2.0.1
+  - jinja2 >=3.1.2
+  - matplotlib-base >=3.6.1
+  - fastparquet >=0.8.1
+  - numba >=0.55.2
+  - pyxlsb >=1.0.9
+  - xarray >=2022.03.0
+  - pyarrow >=7.0.0
+  - s3fs >=2022.05.0
+  - tabulate >=0.8.10
+  - pandas-gbq >=0.17.5
+  - psycopg2 >=2.9.3
+  - openpyxl >=3.0.10
+  - xlsxwriter >=3.0.3
+  - scipy >=1.8.1
+  - dataframe-api-compat >=0.1.7
+  - sqlalchemy >=1.4.36
+  - fsspec >=2022.05.0
+  - beautifulsoup4 >=4.11.1
+  - pymysql >=1.0.2
+  - html5lib >=1.1
+  - pytables >=3.7.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14140649
+  timestamp: 1697477421901
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.2.3-py39h06a4308_0.tar.bz2
+  sha256: ef7397640e2220170a3bb0a65afe9e9093d2072d5aeb15a50cbd7ec0b90aee67
+  md5: 2b592717e374c813b8fba0022e83b5b7
+  depends:
+  - bleach
+  - bokeh >=3.1.1,<3.3
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.16.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16953995
+  timestamp: 1695146143065
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+  sha256: 64a732ce2661cdb6bd8f9d1484ac10afeb73082b1c2b44728d212e0117d2860e
+  md5: ada303f0cf43a4e99cfa7f243b23b681
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141832
+  timestamp: 1684915385689
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
+  sha256: 9c699bd495cbf23db7dea986deeb75183571b83adc14b3e4a36cc6cfd2a198a8
+  md5: 39ed6f683307cca54ac666b2d1f849ff
+  depends:
+  - locket
+  - python >=3.9,<3.10.0a0
+  - toolz
+  constrains:
+  - pandas >=0.19.0
+  - numpy >= 1.9.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35706
+  timestamp: 1698702632637
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
+  sha256: db8122fcb6316fb86c2ff6d4dd47154a650ac26d270183a316f14004adf27525
+  md5: 33ad46d04664fc8b65a545110e4fe099
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 764331
+  timestamp: 1696580179855
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+  sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
+  md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2674850
+  timestamp: 1697548887851
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+  sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
+  md5: fe56f0479dd414c846191116366262c3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 31999
+  timestamp: 1692205535111
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+  sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
+  md5: 44d2a857d13bdf9d99aaac039a249d47
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91137
+  timestamp: 1659455142164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+  sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
+  md5: eb899a739d9b58dd747f1f6bd52d4cf3
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 579771
+  timestamp: 1672387338600
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
+  sha256: a760d6c9fca08c09ff0bc9a33946188e2ea5deed2443d4acb360ce55ce36ee43
+  md5: 2cb2ad8315f68f4339b9416bd9ab115e
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353437
+  timestamp: 1656431352923
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-11.0.0-py39h468efa6_1.tar.bz2
+  sha256: 2bcd948dd7720e29dc17e1a71bcd97a990b392cbbaa0714dd15befb8126fc37b
+  md5: 57791bf3248bd3092cf3ca737445f934
+  depends:
+  - arrow-cpp >=11.0.0,<11.0.1.0a0
+  - boost-cpp
+  - gflags
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4814185
+  timestamp: 1693273169679
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+  sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
+  md5: f36ecb722522cbe2e3737424edf1b5e1
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29312
+  timestamp: 1675441510984
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+  sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
+  md5: 6d03295e544251e608a28c8d7c48115e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1862058
+  timestamp: 1684280096752
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+  sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
+  md5: 1f09617aecd6f3c2f2e20692c0759f34
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94434
+  timestamp: 1690223520097
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+  sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
+  md5: ffceed627867508d73af1636ab5ebf42
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 156324
+  timestamp: 1661452578573
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+  sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
+  md5: 0e3341a4fe434167bf74b613eb6afd81
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 97194
+  timestamp: 1636110999719
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+  sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
+  md5: c5f3f7f10ad30f0945e75252615ab6e5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31331
+  timestamp: 1605305847037
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.18-h955ad1f_0.tar.bz2
+  sha256: e9cc8f89dc327997339bedd9961428a13dda3893e3dba46358e73b1fd1ffa37a
+  md5: e99f4c3215771cd11de42d30ac8ada47
+  depends:
+  - ld_impl_linux-64
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 26811973
+  timestamp: 1694440290734
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+  sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
+  md5: 0caa188a695319bdb13f53b0a2b3accc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264864
+  timestamp: 1661371117920
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py39h6a678d5_0.tar.bz2
+  sha256: 3d4ebba2cd88a8e2b514c061d107b33057c67d54620a2975146d51444887b543
+  md5: 9ae7c3b89bdccb939936e2f087c4f761
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 139001
+  timestamp: 1682522498995
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+  sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
+  md5: bcb44ecbea441ee0d4659133d060d71f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257904
+  timestamp: 1695131670290
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+  sha256: e937081facacb141dc2c9cdcced92baa9a2662e4a56100b6041df0b6b7692570
+  md5: f3ac39b2349258198a9b3316636fe5d5
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39972
+  timestamp: 1685030752528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
+  sha256: 2a535f9fdda20b536bd76dfa286fb67a7685ed2be4ad51e2860c44e144c0b457
+  md5: 797c263fd5bff62987fc1da076eef0f9
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 184040
+  timestamp: 1698096132905
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
+  sha256: 70ee4fc614dd3337ad542c7c961428930160ab8c7da27775faed5ffddbd362d7
+  md5: bf2a4feb20647c569f7ce5a8f63094fa
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 515650
+  timestamp: 1657724431309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+  sha256: 8a640736bef635346409582dbfe2b7d0ecc9da215c90173ff8a9a5fe22569107
+  md5: 6b583dce61c6feb352ef0f49f413af1e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-3-Clause
+  size: 235004
+  timestamp: 1652449537852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+  sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
+  md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 467661
+  timestamp: 1666648052561
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+  sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
+  md5: c7de00b4ac2778c4e5a7816320d75391
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94028
+  timestamp: 1690400356879
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.11.3-py39h5f9d8c6_0.tar.bz2
+  sha256: 8ddacf409396338156d1a09da3f8f0f3b3b473c679bcfefd2de154f7d8f91344
+  md5: 6d6d7ca3d32075d8a57131d589851dd2
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libgfortran-ng
+  - libgfortran5 >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<1.28
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23630389
+  timestamp: 1696544992719
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+  sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
+  md5: 1581cafc84708ed9aafaaee1cbbf6065
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1089416
+  timestamp: 1690290900608
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.1.9-h295c915_0.tar.bz2
+  sha256: 0f5809564b323f020dec2633dc274bbc96dc13d54888bb115938d3d7f6a717bb
+  md5: 71b25fd79c57bcf6bd2ba8ccf1e18506
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 891170
+  timestamp: 1649923859475
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+  sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
+  md5: e19ffbfb24b990275d24fcea2bd1699b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15702
+  timestamp: 1614030498860
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+  sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
+  md5: ca061ce25c0f58628643abec8d6a8244
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 66330
+  timestamp: 1696347637947
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/spatialpandas-0.4.9-py39h06a4308_0.tar.bz2
+  sha256: b88b9369baba9167eb3df4193de695f3f7fb605ca3a6dcfa6ee3b46db5ccb6f2
+  md5: 34a3e041868a5667eb24bcc5f73adc8b
+  depends:
+  - dask-core
+  - fsspec
+  - numba
+  - pandas
+  - param
+  - pyarrow >=1.0
+  - python >=3.9,<3.10.0a0
+  - retrying
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 147839
+  timestamp: 1695247335265
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
+  sha256: 8b45ba506984fe9c061b4acde6f5243d52dda8c1eae4992f8d80c03f425214fe
+  md5: 68c24a824d36a16bbb28d80d70cee8d2
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1640317
+  timestamp: 1681394746811
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+  sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
+  md5: 041a3caf09dc9ce8fc6c10925c4fe050
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1888016
+  timestamp: 1680167274961
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+  sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
+  md5: 0e76eab58fe488e91f0aee73f46de031
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29816
+  timestamp: 1671751864131
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+  sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
+  md5: b413a210eca82fe867e991eed085201b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38882
+  timestamp: 1668168876032
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+  sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
+  md5: 5b8375e2092012db69d2123dc0c68630
+  depends:
+  - libgcc-ng >=7.5.0
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3485432
+  timestamp: 1654088939579
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
+  sha256: 57983e3eb698a3b08b570d5f398d9550cf50b9bf54b2b4728c731ecbc0c89138
+  md5: 3ce956b1e1a7f77af6e6127dca987b95
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101246
+  timestamp: 1667464172523
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
+  sha256: bd06f7b49d9c04c51c1e825bab446ec3cdde2bce39af00bf113a05c1009595e2
+  md5: 587c3f3c891901f4305653e50c18d6c0
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 679739
+  timestamp: 1696937022519
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+  sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
+  md5: 67a8320961ff24e92eebb661536e5cf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - requests
+  - slack-sdk
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 123763
+  timestamp: 1679561904852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+  sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
+  md5: 0f0b91a158dd3692cbb7a7763b657bfe
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192032
+  timestamp: 1671143995098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
+  md5: 8515e64a3de7581360d713fe4c0a094e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8789
+  timestamp: 1690297588156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
+  md5: 60170012374b2a5007842fa5870d78c5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57479
+  timestamp: 1690297581658
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py39h06a4308_0.tar.bz2
+  sha256: bdafa637d91ee2986a37cc82eb18c7b9b6e467eddd2eac3f510ad878a5b45da2
+  md5: 89e6a047e97aa6b06c8a217e64182646
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 10729
+  timestamp: 1659769510353
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
+  sha256: 2f4a5979aaf22660fe9fb8c4ffd41e5a9dc012e20f78e1dbf4ad9c67e0fd28be
+  md5: 0be10051dd3d6f31ba52b7c08ba3ba0a
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 187469
+  timestamp: 1698257600264
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h27cfd23_0.tar.bz2
+  sha256: 3573b5d63801189ea8a1cbaffce73171f2c4c3b77c5c4952bf2b709694e140ff
+  md5: b45754c4fa24c5b4ce9d504c5b6cc4f1
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  license_family: MIT
+  size: 309353
+  timestamp: 1611836033971
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+  sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
+  md5: f8d03a15b974fc7810d9f54ae849fc8e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20781
+  timestamp: 1607365390528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+  sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
+  md5: d7db5d6ce1db80eade8a082ff78bf479
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 71044
+  timestamp: 1614804011510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+  sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
+  md5: b3899f8bda32734727bd5a73df1d7d17
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 101520
+  timestamp: 1695742037911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
+  sha256: d88bdc49a883a944cf1562ebb0a30d0451e28ab05521fc882615e357b105f414
+  md5: c150cf16071597fa3977fb81ebb83760
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1787638
+  timestamp: 1689041557651
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py39h06a4308_1.tar.bz2
+  sha256: 8e8d728472d26c1a42345003d69bf381c062db8050d3444a6ccced7e5dcc3524
+  md5: dd9bda05830964c550a69b70178ee6f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48001
+  timestamp: 1675159114742
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
+  sha256: 93ca87e697bb9e045fc9cda13b05fe27e1a99f3ed143b75bbcaf4dcb745aa06f
+  md5: 3eebbb22c5ca63987db36e1f19cbe872
+  depends:
+  - libgcc-ng >=11.2.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 763941
+  timestamp: 1683112966413
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+  sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
+  md5: 567b68192c387b5fc88178425577a0fe
+  depends:
+  - libgcc-ng >=7.3.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=7.3.0
+  license: LGPL-3.0-or-later
+  size: 366479
+  timestamp: 1616055552392
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py39h06a4308_0.tar.bz2
+  sha256: 859398823a40ead7079055f01ad23f7f5a03ffa11ad672fa26bea38badd8ec01
+  md5: b733cbb9875966a2017e7c386fb98076
+  depends:
+  - heapdict
+  - python >=3.9,<3.10.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 76469
+  timestamp: 1695832872162
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+  sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
+  md5: 3818a9531fe74433c3b7d5144c9a58cc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18021
+  timestamp: 1672387231268
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
+  sha256: 2dc9150a95704d83efd39bb9dfb44bdf8419022f4fb0fc416380a922a27c130d
+  md5: 4f315d7551f4bbeb06b6fc28342a9aa5
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Zlib
+  license_family: Other
+  size: 127528
+  timestamp: 1666595012798
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
+  sha256: aa6aa291bec6aa66e1f063cfa75a9e0fc6bd459fcb45c372aacac9006a073900
+  md5: 4e99328768f538f33aecebdae9472744
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1055426
+  timestamp: 1681304602537
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
+  md5: b2aa5503875aba2f1d88cae9df9a96d5
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13636
+  timestamp: 1611930018941
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
+  md5: 544adf2677c47c9b9c891aea720678f1
+  depends:
+  - python >=3.5
+  license: MIT
+  size: 33999
+  timestamp: 1630003259346
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+  sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
+  md5: 9eff1a842dbda8d1bae9a2c008b599bc
+  depends:
+  - brotli >=1.0.1
+  - munkres
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 690443
+  timestamp: 1625743217109
+- conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 9de8666e5b70aa2437737128eaa14ffe80a7b5235c2a6b7d3f39ccefd7816ba0
+  md5: bb52e50c5ab1a5c7778c11376404dfdb
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 7933
+  timestamp: 1630598543551
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+  sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
+  md5: 33624a42ee387bf9918ea98b4e7b31fc
+  depends:
+  - pygments >=2.4.1,<3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8173
+  timestamp: 1601490751973
+- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+  sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
+  md5: 67857cc5e9044770d2b15f9d94a4521d
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12810
+  timestamp: 1600445183315
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+  sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
+  md5: e68a6f315f41a8d814d833652bf38b9b
+  depends:
+  - python >=3
+  license: MIT
+  size: 13374
+  timestamp: 1606932077143
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
+  md5: 2eb923cc014094f4acf7f849d67d73f8
+  depends:
+  - python
+  - six >=1.5
+  license: BSD-3-Clause and Apache
+  license_family: BSD
+  size: 246457
+  timestamp: 1626374695070
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://repo.anaconda.com/pkgs/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
+  sha256: 2b09b3a4920393833a5963dd702757152b425d2712acfc3fe0b59ceec6e315bd
+  md5: f00776a58646c5ae1644fc52029a5b66
+  depends:
+  - python
+  - six >=1.7.0
+  license: Apache 2.0
+  license_family: Apache
+  size: 14955
+  timestamp: 1629465474976
+- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
+  md5: 41db68b96e114e367c4f120a3b379e59
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19391
+  timestamp: 1632406728844
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 4e47f6c49ce84509f1466e8a4d728447bf4bcd9bce7b456431a789a262547067
+  md5: 4cad993b0f80bc23fb66a97592299cbb
+  depends:
+  - python >=2.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 26504
+  timestamp: 1623949147884
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+  sha256: ca2be6c7810a37cfc6db1f5383937b5d35c6d73c1fad8a9104de85f069b1df1c
+  md5: 9ccb2fb33edb152403d6ef32bf758a9d
+  depends:
+  - python
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 15614
+  timestamp: 1629402049497
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+  sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
+  md5: a815d3bdb160bcc71687f2dda70d3ca4
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 122218
+  timestamp: 1680170368293
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/abseil-cpp-20230802.0-h61975a4_2.tar.bz2
+  sha256: dc40cfc393c2acdb97ce54289d3124bdff35ffd4a6c203abb6f3f5598f49c115
+  md5: 64a761d3c1af045bf01d84d3fc4302a2
+  depends:
+  - gtest >=1.14.0,<1.14.1.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 1336618
+  timestamp: 1698327954026
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
+  md5: 447a49f7bad119faa80d7f14aa296c95
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162176
+  timestamp: 1644481750133
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+  sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
+  md5: 8810f48fe4a4792de0fd3520b502d08b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10019
+  timestamp: 1606859473259
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+  sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
+  md5: 00a446b6dfc61af223df4de29fe8ad94
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 34305
+  timestamp: 1644569782044
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-11.0.0-h89a8245_2.tar.bz2
+  sha256: 3f0d7b6fbf5d2943a91ee86d0d15b7aaaa4365c51d0a33a72cfec7f532cf90fd
+  md5: 7febd435dfd791eb86f989800a80d313
+  depends:
+  - aws-sdk-cpp >=1.8.185,<1.8.186.0a0
+  - brotli
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.5.0,<0.6.0a0
+  - grpc-cpp >=1.48.2,<1.49.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.10,<4.0a0
+  - orc >=1.7.4,<1.7.5.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.9,<2.0a0
+  - utf8proc <2.9.0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8832880
+  timestamp: 1693263543885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
+  md5: bd92dd8bd5b9d24e632b62a075426e50
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133634
+  timestamp: 1695718025321
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.6.8-h6c40b1e_1.tar.bz2
+  sha256: 20e070a2eec6c61d4410abea0cf5e61f7730dbc4d716f1bb479c2c4f9e2374d1
+  md5: 8907c29e3a313a6145b0a8383bb1831e
+  license: Apache-2.0
+  license_family: Apache
+  size: 155893
+  timestamp: 1685977853820
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.1.6-hcec6c5f_6.tar.bz2
+  sha256: 49941bebf4656e482ef1d022ad27ad7870e424acb48479e5b0fde0b455fad98e
+  md5: f73d13a717d451d006d48f6c69f46e94
+  depends:
+  - aws-c-common >=0.6.8,<0.6.9.0a0
+  - aws-checksums >=0.1.11,<0.1.12.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 23697
+  timestamp: 1685999036808
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.11-h6c40b1e_2.tar.bz2
+  sha256: 8d8baf5a4039a44b86469bcb757e0626ffbe7762f8c0e7568eaf87c574171fbb
+  md5: f9e03ecf8af230286698067c86d0680a
+  depends:
+  - aws-c-common >=0.6.8,<0.6.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 50927
+  timestamp: 1685994666563
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.8.185-h1a8d504_1.tar.bz2
+  sha256: b4ddcf4c5b69d10ed21928583b5bac81de9908a3a581f3f372219deb6e49c6e5
+  md5: b3831cfdab0b99263da510ff3e065a96
+  depends:
+  - aws-c-common >=0.6.8,<0.6.9.0a0
+  - aws-c-event-stream >=0.1.6,<0.1.7.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2112655
+  timestamp: 1686057600290
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+  sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
+  md5: f8ae051b591a9027adc16de1be9748f4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206198
+  timestamp: 1681493096349
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
+  sha256: 65ababd5e7812c35a97ac7d22b0ebe52c144121a3d49528b7d5c19e8453cce4a
+  md5: d85c13c017a37e406f6c1e00c1ea4f4f
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6480601
+  timestamp: 1690546287900
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+  sha256: 81102f2762d8eb2f07c69fbf7ca7dad879a257a053085492d4c1b4006eb35fb8
+  md5: 3c42777bc9330fe91177ea813b9ec252
+  depends:
+  - libboost 1.82.0 hf53b9f2_2
+  - libcxx >=14.0.6
+  license: BSL-1.0
+  license_family: OTHER
+  size: 11744
+  timestamp: 1696762233693
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+  sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
+  md5: 0d79760d544d0bd8acb4adc4ef813418
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 137075
+  timestamp: 1657175654487
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
+  md5: 31d6d04cd2388d8f19004501271b3545
+  depends:
+  - brotli-bin 1.0.9 hca72f7f_7
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18982
+  timestamp: 1659616229395
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
+  md5: caf1073dc2ca5aeb832a2877394eae12
+  depends:
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18233
+  timestamp: 1659616216769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+  sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
+  md5: aa1ed20c38af535c8d6a955314759d7b
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 394588
+  timestamp: 1659616312678
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
+  sha256: 4574ffa241157e108d19ece60107a3a689cefaaca43578e6c4a6b344c7330278
+  md5: ab3b4e83407001e7f1603ca1fa0f4873
+  license: bzip2
+  license_family: BSD
+  size: 106284
+  timestamp: 1563219666100
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+  sha256: f913b61ba3c1651b36688415cc163a5d575475f7573b543f48a80e7a5002e4bb
+  md5: f11d165eaa532ce04a35382841284298
+  license: MIT
+  license_family: MIT
+  size: 107047
+  timestamp: 1693902034820
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+  sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
+  md5: ce3588e31faa79f546e0fc6a36c5543c
+  license: MPL-2.0
+  license_family: Other
+  size: 133884
+  timestamp: 1694009771475
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+  sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
+  md5: 21eb7f53076d0a69513cfd258f6ef63c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159756
+  timestamp: 1690232346868
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+  sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
+  md5: a40a04d9cda1e665565bc6c832d598b6
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225258
+  timestamp: 1670423337502
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
+  sha256: b860f45bce9fbb40d024dcd3306e66a52010641091ca8d1fcdde6c4238717c73
+  md5: 3c38f3af9c23b26efc2b11d82c95922a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 153013
+  timestamp: 1698129937688
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
+  sha256: c368e11dc241d1b79b4bb0d9333b353dc1b966b49d145163a0590d88ad88fef2
+  md5: 1e62044b8a32d1452e51773ba7a4319c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41392
+  timestamp: 1683040146991
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+  sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
+  md5: b2cc5f37f7bb069d061306e7eac2a011
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1913396
+  timestamp: 1668084575248
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
+  md5: 103d8c039e342115720a84d59c119d46
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13774
+  timestamp: 1671231190250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+  sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
+  md5: f69f09e0346172f225390d2b3b0d7873
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 246628
+  timestamp: 1663827484947
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+  sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
+  md5: cb80c7ac65b48a737654f371fe31c460
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1307228
+  timestamp: 1694212041712
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.0-py39hca72f7f_0.tar.bz2
+  sha256: 68200788e4f482730df10be66e73ea32ae9031bb76551108e6ad8bfb197c653e
+  md5: d0548e07d136d23cfc9202312a325f34
+  depends:
+  - python >=3.9,<3.10.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 363755
+  timestamp: 1667466068228
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-2023.6.0-py39hecd8cb5_0.tar.bz2
+  sha256: f613b7aa5f154521396c0e691ea563f6623a304610a99696788f67790ed9cf27
+  md5: 10fdef72e0ea52f6f66130e7d2de55f1
+  depends:
+  - bokeh >=2.4.2
+  - cytoolz >=0.12.0
+  - dask-core 2023.6.0.*
+  - distributed 2023.6.0.*
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.21,<2.0a0
+  - pandas >=1.3
+  - pyarrow >=7.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6127
+  timestamp: 1687285007545
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
+  sha256: e80ce32bc86af3e0b67d44bc2c774dde7490443bf6ae4bed7d9c666e3631965f
+  md5: ba47d3bdf582bf15e9250bff6b2f6dbd
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2125677
+  timestamp: 1686783049768
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
+  sha256: 7717c1f0af2af4b28b6d787b32c5e1740f391915c78707d8643e0d516088dbd0
+  md5: d7ae4c5cb253fa85c0ce268d2bf9a191
+  depends:
+  - colorcet
+  - dask-core
+  - datashape
+  - numba
+  - numpy <2.0a0
+  - pandas
+  - param <2.0.0a0
+  - pillow
+  - pyct
+  - python >=3.9,<3.10.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17679970
+  timestamp: 1692372465872
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
+  sha256: 40bbbe2ed223829f4a3f91024fa409f1a665ad94294bec2c9e930989bb2b8911
+  md5: 4add00dc619c12370af0ed18c76b71f6
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 103370
+  timestamp: 1613390236788
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+  sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
+  md5: 04cbe8f4bc62c34fac9d42d1124059bf
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2052734
+  timestamp: 1690905361158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2023.6.0-py39hecd8cb5_0.tar.bz2
+  sha256: cae6f0cdca229423df948658c1b83258671e388f958f5ed141ba5811ce030fbe
+  md5: 1b5c10d7094410bbd1c93431739fd538
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - dask-core 2023.6.0.*
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.0
+  - packaging >=20.0
+  - psutil >=5.7.2
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=5.3.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.10.0
+  - tornado >=6.0.4
+  - urllib3 >=1.24.3
+  - zict >=2.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1387898
+  timestamp: 1686866140802
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
+  md5: ef0e825982f242085574f502dfff4f6b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16594
+  timestamp: 1649926538106
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
+  md5: 24747a300246c016b3a7f04dabd02d4a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27709
+  timestamp: 1668714497209
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
+  sha256: 95e9a45812b1b4059b973e5e6e131c7c1a8b2ce2dafc5117e7806b1c8f30de27
+  md5: bc889aaa846ed177fc5f495c24041acc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 262430
+  timestamp: 1695734574609
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-h0a44026_0.tar.bz2
+  sha256: 36f939c2123f7baef087a46e6a831d42a52a728093c46ffff9945d5d461a0c41
+  md5: 481275c7cd308738942b6cc02b625804
+  depends:
+  - libcxx >=4.0.1
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 139043
+  timestamp: 1542388670387
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+  sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
+  md5: e4a732941f74b8062c8bcbfe5c5c2b56
+  license: MIT
+  license_family: MIT
+  size: 80252
+  timestamp: 1676983220161
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-h23ab428_0.tar.bz2
+  sha256: 17b526435dc8d509e682414cfec291ce5b56e24b9bf6c7a7e4b366b2cfacda26
+  md5: 797484a4ab5d2a8cc1e5cf5026af9ee1
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=10.0.0
+  license: BSD-3-Clause
+  size: 96479
+  timestamp: 1620732938755
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/grpc-cpp-1.48.2-hbe2b35a_3.tar.bz2
+  sha256: 429778798ecd14755d6550f9fdeec8855e99e40cbe6128a87592958bd8fd95a1
+  md5: 155ac9a36f0be7fd310556c6a0381850
+  depends:
+  - abseil-cpp >=20230802.0,<20230802.1.0a0
+  - c-ares >=1.19.1,<2.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.20.4.0a0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - openssl 3.*
+  - openssl >=3.0.11,<4.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4020362
+  timestamp: 1698063432993
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/gtest-1.14.0-ha357a0b_0.tar.bz2
+  sha256: edfb65219af41d5037b6371c6b074c8372db90b17d25f85f55e36523c01949ec
+  md5: f21a88869091d6d4d88b9b5f064a3157
+  depends:
+  - libcxx >=14.0.6
+  constrains:
+  - gmock 1.14.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 400287
+  timestamp: 1692633607623
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+  sha256: 5c36d43cadbbf944d9255e79df85c2e9e6155a1d6f9158e06fcd8ffd458b7663
+  md5: a5a2cff387403ccf9cf58aac7a6dde55
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4573879
+  timestamp: 1698866750755
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+  sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
+  md5: f3ce6fe6eb760c236e5f7d04df5faa81
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28138484
+  timestamp: 1692293212596
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+  sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
+  md5: 6dd72c43fea25b748ec7a9f6c0407e15
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111810
+  timestamp: 1666125671024
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
+  md5: 03cdb7e679924b329ecab8f12cb8fc67
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38813
+  timestamp: 1678997212422
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
+  md5: e113c4e6e758dd68faf196586bf5564d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51873
+  timestamp: 1698254765815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+  sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
+  md5: 78baea934985ccd9514a366cc7e80ed4
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 727499
+  timestamp: 1681801225190
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+  sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
+  md5: da9b63e42f281f7e77b289f4b654b83b
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 218436
+  timestamp: 1691121840155
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+  sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
+  md5: 6a7cb9b49593b29933fa2b503d533a08
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1257205
+  timestamp: 1694181720454
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+  sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
+  md5: d861ef66f5c0a282d60b65778a9de2f3
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1048450
+  timestamp: 1644315332508
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
+  md5: f7e603c965052deed8b789c35855a42f
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213537
+  timestamp: 1666908270815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
+  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
+  license: IJG
+  license_family: Other
+  size: 278924
+  timestamp: 1677849185191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+  sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
+  md5: a82a17e78f725dcbd71ff8dac6db05c7
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133134
+  timestamp: 1676558895333
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+  sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
+  md5: ee9270379a9ebdb6297e4b6849b3f7f0
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 195479
+  timestamp: 1676329410154
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: ede34881321808fbb967885dde9b0b6c9c8ef1f3eb192fa514058c4f14201c4f
+  md5: 07d24f5332ca5d0e76aa0df051a1f05d
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 79901
+  timestamp: 1698937699237
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+  sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
+  md5: 7e60995b3119417213e5faedda147499
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 403165
+  timestamp: 1671707664990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+  sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
+  md5: cd470bdb28bb0e8b3535c93a3a6dad07
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65431
+  timestamp: 1672387389172
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
+  sha256: a3a24cd84c291f7c9e28842ccfc2107d149f0aa8e676b85d9104eda77622e603
+  md5: 99ba4367783596d1bb0c7766ea6706ea
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - openssl >=3.0.8,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1290758
+  timestamp: 1686931137388
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+  sha256: 127dbf93874f1bb3493b312fecb5ffedb8f2a41d2470e2cbeb889eb58d89ebf7
+  md5: 07502b61e43a2039e4312b40d53c1db1
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 22584954
+  timestamp: 1696762195023
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
+  md5: 7dba7aa5b971febb55281659843586ba
+  license: MIT
+  size: 65470
+  timestamp: 1659616172703
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
+  md5: f78a158983f0bbaba56f34b976bc6dae
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 34189
+  timestamp: 1659616189313
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
+  md5: 36a1d885725d3ab4d1fadc5a29f978d2
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 327737
+  timestamp: 1659616202869
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.4.0-hf20ceda_0.tar.bz2
+  sha256: 5501e46f0f145d8fdd72dbc99523caf51c77a814c3531e200beefa811ff4b5ce
+  md5: ac8738061571d853de74a590f48e42b6
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.57.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: curl
+  license_family: MIT
+  size: 369487
+  timestamp: 1697023549088
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20221030-h6c40b1e_0.tar.bz2
+  sha256: 67e38ccc55c2d996a8a0949080949c9803ddff84a96c4e34bc4c48fa95e5f35b
+  md5: b549aa024097c9f2790ba6eb89bc53fd
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 168786
+  timestamp: 1670840154554
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+  sha256: 4786264321edbff780633a5b752995eb3193ca4bce11b0fda179577f6cf1102c
+  md5: 849fdd014c201a9d2c2aa7c7db38a778
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 103993
+  timestamp: 1632891571494
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+  sha256: a60941a0365ee3e8b9ff721f75b0608c234b5652f53337a918b787839de4bb53
+  md5: 4d61f019594ebccfb3f4fb87ee778416
+  depends:
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 414942
+  timestamp: 1685052318462
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+  sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
+  md5: 817848d0e2b2808acdc9b3fbbf581726
+  license: MIT
+  license_family: MIT
+  size: 133887
+  timestamp: 1683716590737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+  sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
+  md5: e458587c87e3f2d20192f4e0738f2c63
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 149419
+  timestamp: 1665498987619
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+  sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
+  md5: 1058b661ec829b2ee3716ee2a5520641
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1917987
+  timestamp: 1665498925405
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+  sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
+  md5: c90372428e1e4eed4fdcd790979d06b4
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1409377
+  timestamp: 1650983531933
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+  sha256: 8176dd9a68815301a24ed51e72f3506f5f77c67a112efa0dd14971f2f3b3c8c1
+  md5: b5e470c224000a6bda6f655c155b53e7
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 27861431
+  timestamp: 1683292881730
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+  sha256: 7bfcf69c31a4eb15dfab661c93463ce8dfb7b3de4356945fa5c1ca50a5ae0cb0
+  md5: 4934bb34818fa3d99b32b9cb59fed205
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - c-ares >=1.7.5
+  - libcxx >=14.0.6
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 784918
+  timestamp: 1697018436251
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
+  sha256: 1884de5207f5a1210217d7132348b4944ec4b09a91085b7b47a19dfdd9b6dbba
+  md5: aa960ea0133deec4637a8d05700cc3c4
+  depends:
+  - libcxx >=14.0.6
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2412437
+  timestamp: 1675278748544
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-h04015c4_2.tar.bz2
+  sha256: ea67e176a2142813dc19481cd83fd7c17fda32a96cbdd72c78e29b59030eb5fa
+  md5: 13a0cba33faf8074613ca460a6ddae19
+  depends:
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338575
+  timestamp: 1686931283039
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+  sha256: 21ba71cdc65b56c6daefeeab55959e5a7edadfd697cfa8b2ed5c1b3e2a98586b
+  md5: cbbd369ee87aba597c942727bada4eee
+  depends:
+  - boost-cpp >=1.73
+  - libcxx >=14.0.6
+  - libevent >=2.1.12,<2.1.13.0a0
+  - openssl >=3.0.9,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 364326
+  timestamp: 1687975317748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+  sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
+  md5: c0b99f8e1c7475f23b1c7b4250b06e1c
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88021
+  timestamp: 1694778290062
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+  sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
+  md5: 06866415ef22d5322f9bdc9956b59c4d
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 678174
+  timestamp: 1692970318885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+  sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
+  md5: 2edc6c894d6d0321304396e9bd40df94
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241774
+  timestamp: 1692973618934
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 0190d3b8d2939f28aa017711cf4147c51a1139da2922cc8420a71562dd99f844
+  md5: 454a7f2c4426453f17e995382a4235e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 36036
+  timestamp: 1659783508187
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+  sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
+  md5: 5c740b4a18a558de0ccfe601703c423c
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 338738
+  timestamp: 1662635677689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
+  sha256: fbf3c01a0834c151485b1b2ddf0c83d43703cbea051c6dbcb0d8d41946107670
+  md5: 12137025daee35f5c708ca10d0c96e3c
+  depends:
+  - libcxx >=14.0.6
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - python >=3.9,<3.10.0a0
+  - zlib
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 318622
+  timestamp: 1697031357874
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1dab4daa56408915de3ec270c8b887e7221d48633ea83b0afff61041fc197972
+  md5: 1519f9b766f9f894282db8353066e3b2
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11883
+  timestamp: 1652903144294
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+  sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
+  md5: 8bbd981ca0129d7beeacd3cd7623f714
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1491074
+  timestamp: 1695058597986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-4.3.2-py39h6c40b1e_0.tar.bz2
+  sha256: 90e49c636ba91bbe7c31dfa8e9ce584fe952482a6aaa7353a0502dbe337c9aaa
+  md5: 4d8212ad094f39d06bcc61b6f388d3a0
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35180
+  timestamp: 1686057959850
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+  sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
+  md5: d5f58d056b4bfc67aec30c77035ba889
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 182491
+  timestamp: 1670944720979
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+  sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
+  md5: 1affd16b166571a91feae04baf5fd3da
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123431
+  timestamp: 1671542016019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+  sha256: e5fc51472fa0f36abd78baa5b3c9245d6627b0da11188e6a954d73f3f2bca210
+  md5: df7c519447affffb594f8c56b028ed33
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 107035
+  timestamp: 1684279974102
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+  sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
+  md5: 3681ebf029211ceab26af6f5d35abf39
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22254
+  timestamp: 1654598220251
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+  sha256: 2fd179efa024c92d0d71179a981a781d16c70f5d8c6305e0d678b0c7ae1275ab
+  md5: addda7f015d1673f794a23fdb18a3e09
+  depends:
+  - __osx >=10.12
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8182219
+  timestamp: 1698692361219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+  sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
+  md5: 6eb64ecfcd754502e271db0bb51d2cfd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17374
+  timestamp: 1662014643620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 2312ee5a6343e8495802698d7181f1b619aad7479d96ee253407b324ac884417
+  md5: 866960fa48a7ca335941786d4869802a
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53542
+  timestamp: 1659721365599
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: 37f455814ce242eb65ff80a0402f1bd231a388e6823e6c1e65f60b705c032a2d
+  md5: 4c9246c492a64729225aa5b04e12c2d1
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19573
+  timestamp: 1659716100178
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+  sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
+  md5: 2a4d604717a647ad21af766289cbbfc3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58057
+  timestamp: 1607364912348
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+  sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
+  md5: 25051fe272624544652dc6d814c2943a
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224420228
+  timestamp: 1691503125614
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+  sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
+  md5: 37d8cf85a63f7aa9af1624894a7d606d
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48590
+  timestamp: 1682969183093
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+  sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
+  md5: 0b2aee6666135bbd36b46d6ac66160f7
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 210705
+  timestamp: 1695058433223
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+  sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
+  md5: e22fb55ce380d0ebd44cce3f20d5349e
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296614
+  timestamp: 1695060155673
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py39haf03e11_0.tar.bz2
+  sha256: e3ac58a4520466ecb759590759c86e81dcddf1c36fd25d081dd9064d9e850c48
+  md5: d184127ffc4131fdef14724d5f480c99
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 84981
+  timestamp: 1652362789251
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
+  sha256: 5f60ca253f1fea0a1d765f535ff9ca2cf7efba90aea4c9a290d8f50ad11d4f6f
+  md5: 97d6ec94e2300030bddf0e5289cd2a84
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 24240
+  timestamp: 1607574265505
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+  sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
+  md5: 1a5d4004e64e3cfb7a2a297b9117c285
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8213832
+  timestamp: 1681756573646
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py39hecd8cb5_0.tar.bz2
+  sha256: 59acf22956f295ed429624a1560bceffbbf536ea93ca63a5f1a48975a0afdbcb
+  md5: a7a6344327960940bad23e783a4d6bce
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100813
+  timestamp: 1698934262550
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+  sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
+  md5: e572c1264a7af20b486f64ac8c9e1f57
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 573356
+  timestamp: 1668450732828
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+  sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
+  md5: b67569a7c30af9ffa5cde6e4b52ac68b
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148342
+  timestamp: 1694616917184
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+  sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
+  md5: 97b81f34efbe86c5220fe82eb584fd62
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387288528
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+  sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
+  md5: d77862975a9a1cf50acb803be26e83a1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 575365
+  timestamp: 1690985052739
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+  sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
+  md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22858
+  timestamp: 1668160618784
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
+  sha256: 249efa747726ad61bc1093f33f155f0b7a0fa5b728cb1a6a6bd126458f279c96
+  md5: 1cced9a92d68307846cf59c238a42f13
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.41.0,<0.42.0a0
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.26
+  - python >=3.9,<3.10.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - libopenblas !=0.3.6
+  - tbb >=2021.6,<2022
+  - scipy >=1.0
+  - cuda-python >=11.6
+  - cudatoolkit >=10.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4431283
+  timestamp: 1697057424792
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+  sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
+  md5: 185e9c41abb88ee59b52ec0f5f65d506
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 138305
+  timestamp: 1696515469702
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
+  sha256: 361754aae186c6f4f8e5ceadf02b95ae74b47a97eaf1aa37538a7c410fb3ec88
+  md5: 02e4a556e3eb2375ec5a75795dd32372
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.25.2 py39ha186be2_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12847
+  timestamp: 1691166007881
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
+  sha256: 94d69c58f79dea6d155debef3237f02397ab6c3d042b519ad89fc64d204507d2
+  md5: 891a8850c69fd11971e58dfba0c40fcd
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.25.2 py39h827a554_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7529822
+  timestamp: 1691165972737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
+  md5: 93f5d7b66976154adeda219bea02ba45
+  depends:
+  - libcxx >=10.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 484257
+  timestamp: 1630093862501
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.12-hca72f7f_0.tar.bz2
+  sha256: a40b753094bc68bda7364443e3fba9b9f6d00a25e147c5286226b75b940829d4
+  md5: 0fde5da60eba23ea5ca611395d5309fa
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4974949
+  timestamp: 1699012522706
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-1.7.4-h995b336_1.tar.bz2
+  sha256: 281d5a10e7a0a25bd6ee20d1d0f03530dd90fe5b4e3490ad3f33f0367df36f7c
+  md5: 062f9bba1d43123d02c60d23a29831a1
+  depends:
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.9,<2.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 425422
+  timestamp: 1676482778334
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+  sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
+  md5: 4154929ace2ad6ee16aea815635a6d1f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73598
+  timestamp: 1693575307570
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+  sha256: aff5acedef9da91b77851e1a163b8319d72bc4152c98ac87703a2eac1e5d575b
+  md5: 7df4c76aa8c52fedce5346748d56459e
+  depends:
+  - bottleneck >=1.3.4
+  - libcxx >=14.0.6
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - tabulate >=0.8.10
+  - blosc >=1.21.0
+  - fsspec >=2022.05.0
+  - beautifulsoup4 >=4.11.1
+  - pyreadstat >=1.1.5
+  - pyqt >=5.15.6,<6
+  - s3fs >=2022.05.0
+  - numba >=0.55.2
+  - xlrd >=2.0.1
+  - qtpy >=2.2.0
+  - xarray >=2022.03.0
+  - psycopg2 >=2.9.3
+  - lxml >=4.8.0
+  - zstandard >=0.17.0
+  - pyarrow >=7.0.0
+  - pytables >=3.7.0
+  - xlsxwriter >=3.0.3
+  - gcsfs >=2022.05.0
+  - fastparquet >=0.8.1
+  - scipy >=1.8.1
+  - pymysql >=1.0.2
+  - odfpy>=1.4.1
+  - pandas-gbq >=0.17.5
+  - pyxlsb >=1.0.9
+  - matplotlib-base >=3.6.1
+  - openpyxl >=3.0.10
+  - jinja2 >=3.1.2
+  - html5lib >=1.1
+  - dataframe-api-compat >=0.1.7
+  - sqlalchemy >=1.4.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13388063
+  timestamp: 1697477404222
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
+  sha256: 1928d1f3aa777c6fe0b279f400fa417b293527531bbdd3d918cc8e987a680f86
+  md5: e8d7a163f2f9dd0f1972e126ee87b586
+  depends:
+  - bleach
+  - bokeh >=3.1.1,<3.3
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.16.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17076156
+  timestamp: 1695146369755
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+  sha256: 914f1ec8d911083c006c4c2d3b4c0c528e79abba3ae5f1dad825bd896870270d
+  md5: 949e0e4c0ce43c92eb52241892230873
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142949
+  timestamp: 1684915417020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
+  sha256: ddcb56e35d537f7a748b242c7c44368f112471973a52ae022945f597b7a83c7c
+  md5: 94bac4f8fbfaf821ace161b9f1f58716
+  depends:
+  - locket
+  - python >=3.9,<3.10.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36756
+  timestamp: 1698702713944
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+  sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
+  md5: be0a90921f3bf4f0d6950fb786093de7
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND
+  license_family: Other
+  size: 719901
+  timestamp: 1696580194417
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+  sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
+  md5: 81ae9ec2d7fcf6934847bff558b619f5
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2672987
+  timestamp: 1697548890181
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+  sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
+  md5: 1a822c206e2abddc5d6d821721af227f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33013
+  timestamp: 1692205801265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+  sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
+  md5: 1604d33dbdb2446c642970f8b354bedb
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91266
+  timestamp: 1659455269141
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+  sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
+  md5: d1b3bcc35655a3123acb1fa2ad1a8511
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580828
+  timestamp: 1672387372015
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+  sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
+  md5: 7540555d1fb192236db9a7c5c9d3601c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365765
+  timestamp: 1656431373327
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-11.0.0-py39he65a03e_1.tar.bz2
+  sha256: 9ca66e703bb0302a32d318eeb14fcd6d78676fcf15a4533879712365030e8646
+  md5: 213e1dd8e05ab7bff06fdab423df6f1e
+  depends:
+  - arrow-cpp >=11.0.0,<11.0.1.0a0
+  - boost-cpp
+  - gflags
+  - libcxx >=14.0.6
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4391192
+  timestamp: 1693273411611
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
+  md5: 0a73533fb6e0dc717ab906a537bc747d
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30803
+  timestamp: 1675441638631
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+  sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
+  md5: 0a959fbad46ab38ade48dbd358002674
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1864757
+  timestamp: 1684280094736
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+  sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
+  md5: ea24b5076ef79e4567c5a3f0cb22b470
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95330
+  timestamp: 1690223465114
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+  sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
+  md5: bcaea6d4a47e9c874becaa700c78dcf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157216
+  timestamp: 1661452617825
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+  sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
+  md5: 707110d1b49cb1864acb0bbaa103591e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 95016
+  timestamp: 1636111184034
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
+  md5: 113a443b9c706f9f9c6187c0eaa3de27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31178
+  timestamp: 1605305861851
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+  sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
+  md5: 85a8d0001db70e52a479155228cb1fe0
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13324979
+  timestamp: 1694439878265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+  sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
+  md5: 47c5e22e31ec05a7bc0ce90065a53afd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 265348
+  timestamp: 1661368839620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py39hcec6c5f_0.tar.bz2
+  sha256: fa3f9b9aa7e0a71e0a7237adf0fdede90808fda954bebd4d10b4bea97ab7f62f
+  md5: dc1fb278f98f80996a6642a03a007f34
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 136975
+  timestamp: 1682522551539
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+  sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
+  md5: ce9a69e1668aa1e133f2aa6d4e8d346f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 254958
+  timestamp: 1695131709704
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 9ee098c09f31fad7ff1856e5ce2619172eaf979997e7a427d1e05cce32c2af00
+  md5: cac1d1898b69ae9646dfbf082910635d
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40946
+  timestamp: 1685030787453
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+  sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
+  md5: 637f08b19dd8fd87347d8c44f9e3e202
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 170776
+  timestamp: 1698096100056
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+  sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
+  md5: 8ce3ac7d8a04e469b566f1b090d01140
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 470617
+  timestamp: 1657724324011
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+  sha256: c69f556df9a27328c56943f3b5918cbb953cfbca987e20394d823a6174781202
+  md5: ab294ae71ecdfaa307a961cc71dd890d
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-3-Clause
+  size: 205638
+  timestamp: 1652449553607
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
+  md5: 6f2d41dd76a03b7f85a1ed49af1763d6
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95100
+  timestamp: 1690400262627
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+  sha256: a9755ecbfd42c708945027facfa11a3dc3119778326a0ae5df79f80d7b72afa5
+  md5: 839ffa4e775fee9a8bdddabf4a14da43
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<1.28
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24331914
+  timestamp: 1696545397632
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
+  md5: b0321e6f14e139fc15b1f8b4acb35d2f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093966
+  timestamp: 1690290944588
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.1.9-he9d5cce_0.tar.bz2
+  sha256: c7af3280189c023d0c7380a7c1bdda2f2f09b036aa507c2650503b041037bf55
+  md5: 58260ae8dcdaf2ec4a07bb1bdb451b34
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 1357241
+  timestamp: 1649923925096
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+  sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
+  md5: 62b64576a0aa5f6c3fb05f56650d25e1
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15535
+  timestamp: 1614030509324
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+  sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
+  md5: 15b5595b31e39f08eaacbe2e502d8fb3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67292
+  timestamp: 1696347733587
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/spatialpandas-0.4.9-py39hecd8cb5_0.tar.bz2
+  sha256: 4974e2ec8fb3c03cd5b6555b558dadfef640b6b7f2a2984f8dd593f44d464d3f
+  md5: 0aa7edd6b36bbcaa30f0ded56c88e7e3
+  depends:
+  - dask-core
+  - fsspec
+  - numba
+  - pandas
+  - param
+  - pyarrow >=1.0
+  - python >=3.9,<3.10.0a0
+  - retrying
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 149386
+  timestamp: 1695247229147
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+  sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
+  md5: 82e4db6a498480a75d53c55bd35b6478
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1801397
+  timestamp: 1681394807900
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+  sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
+  md5: 63b957927b9949ccb19da28ec4612706
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30902
+  timestamp: 1671751919031
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+  sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
+  md5: e346257a2fa8e2cb48c762138a5d009b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39915
+  timestamp: 1668168959656
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+  sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
+  md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
+  depends:
+  - zlib >=1.2.12,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3536231
+  timestamp: 1654088937695
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
+  sha256: 74fc3a9e308602b3710f8fa671f24f5492571d0c8f7c1b3071dac72671262d45
+  md5: e08ead92568f5bd72d5ac7f08f087fee
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102258
+  timestamp: 1667464155001
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+  sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
+  md5: a1bbf0abfb8c45541122c0eb2feee317
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680464
+  timestamp: 1696937112175
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+  sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
+  md5: d689f6203c0a9d04fb229c73d7e80a7a
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125145
+  timestamp: 1679561909274
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
+  md5: 8a292c1ee22489bef2e84bc3aaf4098e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193141
+  timestamp: 1671143985219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
+  md5: 8bf0bfffc11ad06a1c94e145941b0ad4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9651
+  timestamp: 1690297655669
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
+  md5: 343514a174b3485fde55a73f56398dd7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58456
+  timestamp: 1690297648002
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+  sha256: 11e7401cb6805db7ce22b1f9dd6ba5b7941c92225ce440bed1da0af284bfcad4
+  md5: 5c10d68fa5616cdd82ee93ef6e0f038c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11615
+  timestamp: 1659769478980
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+  sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
+  md5: c2242e8fd24003a74ddf37416661e06d
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188757
+  timestamp: 1698257668273
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h9ed2024_0.tar.bz2
+  sha256: 99d4feafeeb067f60215951b6090aa8a7efe06283d4b39b077d54f579acf1925
+  md5: 8a87bb430755d203382a9802ad4def21
+  license: MIT
+  license_family: MIT
+  size: 309534
+  timestamp: 1611836061631
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+  sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
+  md5: 41f445e36b6b6722a9444508eef069f8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20583
+  timestamp: 1607365395045
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+  sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
+  md5: 409ee46ed24267b6da6fb32d13e1f21e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70730
+  timestamp: 1614804271285
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+  sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
+  md5: eb74e74d8e4fd533c55eb98b7b5e83bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102637
+  timestamp: 1695742077778
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
+  sha256: 9f5a34bef727052f97b1cc387c3a99a60754de99d6e4ab0b2de770d76b64dc0f
+  md5: b5ce0421037c626cfcec5b43d83ec420
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1787999
+  timestamp: 1689041573350
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+  sha256: cb007615819fd240ea4e343835dfbda3c508a92b5b7158219d30a22d0e67b57c
+  md5: bf215e781ac81e0fc433eedee330c54b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49462
+  timestamp: 1675159191191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+  sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
+  md5: e243baa546432c8394a8059a44a5a3e4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 419227
+  timestamp: 1683113010463
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+  sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
+  md5: fe4ac85ee86d3a94ea3a4ebea3779763
+  depends:
+  - libcxx >=10.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 321797
+  timestamp: 1616055526986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 16e64fb88aec5586d199cf317f4e10cfd4cb84bc2ffa51254b44c569f7834d3f
+  md5: 57b7c150445badc2b718691e67468091
+  depends:
+  - heapdict
+  - python >=3.9,<3.10.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 77666
+  timestamp: 1695833024405
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
+  md5: bc7073d9d4c0211cc4a1207c98fb765a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19091
+  timestamp: 1672387204865
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+  sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
+  md5: 8e495591e369ac161857a72011c0a296
+  license: Zlib
+  license_family: Other
+  size: 120272
+  timestamp: 1666595024203
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+  sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
+  md5: f1465fbd810b3746c6de6babfd4fe28a
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1023573
+  timestamp: 1681304595869
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/abseil-cpp-20230802.0-h313beb8_2.tar.bz2
+  sha256: d42422c15e115f76aec2f71e25887104359d5140af3cc6f19e358af011dc7ba9
+  md5: 9996619edfa02accc1fb7912d5ecc5fb
+  depends:
+  - gtest >=1.14.0,<1.14.1.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 1372151
+  timestamp: 1698327835928
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+  sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
+  md5: cf55cb8d7031b30c70c56fc7c782b5c7
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 156104
+  timestamp: 1644482799136
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+  sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
+  md5: 84fce327d9f0d594e86f565e5c21962e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10183
+  timestamp: 1629146082730
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+  sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
+  md5: 84b8b998a741b37abf5312c1c03696ef
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33979
+  timestamp: 1644845817952
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-11.0.0-hc7aafb3_2.tar.bz2
+  sha256: 35366c72df504648f1ad0f5392d6dc094f468b923f7a81334dabe9b6e08ddedf
+  md5: ba2924efa4743344ec29a9f001a4ff58
+  depends:
+  - aws-sdk-cpp >=1.8.185,<1.8.186.0a0
+  - brotli
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.5.0,<0.6.0a0
+  - grpc-cpp >=1.48.2,<1.49.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.10,<4.0a0
+  - orc >=1.7.4,<1.7.5.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.9,<2.0a0
+  - utf8proc <2.9.0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8073021
+  timestamp: 1693263207600
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+  sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
+  md5: 77b746931c8f31c3ae393ccb5819d43d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133628
+  timestamp: 1695717890677
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.6.8-h80987f9_1.tar.bz2
+  sha256: 4d63ff9d0b424c5dc2e20bb8324a348869dee0340511effadfd1d622842a8322
+  md5: 3137a10d16bb223ae981d566d60d984b
+  license: Apache-2.0
+  license_family: Apache
+  size: 153917
+  timestamp: 1685977852438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.1.6-h313beb8_6.tar.bz2
+  sha256: f41918089bd42945e10d71aaf30eacede92db2b57193c2c931a710c314a39730
+  md5: b0a63224a995df6e07fdebba41a3c1a6
+  depends:
+  - aws-c-common >=0.6.8,<0.6.9.0a0
+  - aws-checksums >=0.1.11,<0.1.12.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 24245
+  timestamp: 1686021087869
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.11-h80987f9_2.tar.bz2
+  sha256: 5068b5773e8ce07dfc34718fb6c4be364a4c79d821138d68c3d246873bd562b9
+  md5: 1efb7da0ab9ee77370640b77f74f9c7c
+  depends:
+  - aws-c-common >=0.6.8,<0.6.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51725
+  timestamp: 1685998294585
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.8.185-ha71a6ea_1.tar.bz2
+  sha256: 233e5de862c76724dadec694df81405812be33dbbbe6ca14b6e5d586885acfc7
+  md5: 0a776ce91b4d11b4fd86b01f9e9e4ec8
+  depends:
+  - aws-c-common >=0.6.8,<0.6.9.0a0
+  - aws-c-event-stream >=0.1.6,<0.1.7.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - libcxx >=14.0.6
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2159308
+  timestamp: 1686057541094
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+  sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
+  md5: 3df6e8ba34208dea068890e5d5318cc0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206759
+  timestamp: 1681493095987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
+  sha256: 4edfceca9958378015a2d5ff705aecb977fa329fdd0caf51cf6a1b6b5506e5ab
+  md5: 7404ddc0add9157338d7d4822ac13cb3
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6462121
+  timestamp: 1690546176434
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
+  sha256: f1660ecfb8687d74e81a7b00699a8bb4677cbd791d14f50ba517de98e2f187ca
+  md5: 1636fc4b725da8c5e967952a55f3fd80
+  depends:
+  - libboost 1.82.0 h0bc93f9_2
+  - libcxx >=14.0.6
+  license: BSL-1.0
+  license_family: OTHER
+  size: 11780
+  timestamp: 1696762172661
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+  sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
+  md5: bb55f81435cb6e11d264242274fccd1a
+  depends:
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 115947
+  timestamp: 1657175645380
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
+  md5: f860193e14afc7ef3f5b990a2ac003d2
+  depends:
+  - brotli-bin 1.0.9 h1a28f6b_7
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18936
+  timestamp: 1659616204016
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
+  md5: ad53130f3fd1f8d3c2fcbb7496e5585d
+  depends:
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18715
+  timestamp: 1659616188888
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+  sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
+  md5: 0982c046fb976e9f9fb19e7510187a18
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 366983
+  timestamp: 1659616245272
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
+  sha256: 019469288da4767fd021f488b907e2f4f3b34db686fa12055d52d9bb7bb4d872
+  md5: 9f63c782a4d20150ae9a664ee87cce16
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 150682
+  timestamp: 1624215191959
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+  sha256: b0be79290b1df1cf1d07a1a9c3f3a92ae262643a6df3dc10dfbac22a82874dd4
+  md5: 8fdcf1c08eee91fec7eefc22863c816a
+  license: MIT
+  license_family: MIT
+  size: 106550
+  timestamp: 1693902036526
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+  sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
+  md5: 31ac2f5596cb7a44adf073c930641c54
+  license: MPL-2.0
+  license_family: Other
+  size: 133817
+  timestamp: 1694009762858
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+  sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
+  md5: cf1f6c3c34a1e1b9ab22b04233d860f6
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159783
+  timestamp: 1690232303987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+  sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
+  md5: 0eb268e38b5174d471a6e87d9d6102b1
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225355
+  timestamp: 1670423312966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
+  sha256: 41e76ba21b1279278a039245275eb4ee1f81b38b33cba00ca3575f06be5dc570
+  md5: c5170bf12e308fb7f2d1b4b9065f3df7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 153036
+  timestamp: 1698129857856
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
+  sha256: 36240dde0a1546469f35f3b5509b55384dfd894beb56b3ca929da4b96a2a5f24
+  md5: 844539636e4c20ee99e8ceeff5e902bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41376
+  timestamp: 1683040042906
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+  sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
+  md5: e68c94666cd60221b575c3814c89bac0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1946451
+  timestamp: 1668084573824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+  sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
+  md5: 1773ae2b080cdd55827e27673351551e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13646
+  timestamp: 1671231171682
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+  sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
+  md5: 53bfd99ad1b09164d537209cffd98161
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 244040
+  timestamp: 1663827469853
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+  sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
+  md5: b62455043c8eb2434466885b19fed2de
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1399573
+  timestamp: 1694211828228
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.0-py39h1a28f6b_0.tar.bz2
+  sha256: 25f89dccae875d5f73e6bb41ab8bf5b39972715a304e8ce64cee93585d129825
+  md5: a7c6f8274e12b068638fac6e43e9d10e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 361259
+  timestamp: 1667466038174
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-2023.6.0-py39hca03da5_0.tar.bz2
+  sha256: 664bffc07c01bca0732405b0683dbb24af7edd888e110e1a12252f14fa0819d0
+  md5: ac3b1564712149abe6620718b4faef0a
+  depends:
+  - bokeh >=2.4.2
+  - cytoolz >=0.12.0
+  - dask-core 2023.6.0.*
+  - distributed 2023.6.0.*
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.21,<2.0a0
+  - pandas >=1.3
+  - pyarrow >=7.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6102
+  timestamp: 1687285030179
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
+  sha256: fb7d12350372a70daa9f476647d04fc213ef9d8f73cbddaf30b40b1b45beef0f
+  md5: 34595eb00802934d092b3086d7b4344d
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2124926
+  timestamp: 1686783028732
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
+  sha256: d366da723fc8baf4d9de0d25688619efe4d1c7abe5407dfb28654c4c9e2ef019
+  md5: d4c923ceedacd8d5d18f994feed8dbb8
+  depends:
+  - colorcet
+  - dask-core
+  - datashape
+  - numba
+  - numpy <2.0a0
+  - pandas
+  - param <2.0.0a0
+  - pillow
+  - pyct
+  - python >=3.9,<3.10.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17708209
+  timestamp: 1692372524993
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
+  sha256: 83dbf9755ea887576e3f34adb1c26d418db9aaf3c77dc07f30b58c2221b81c72
+  md5: 36246697d07d6709de78abe36b6beae5
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 103201
+  timestamp: 1629793063728
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+  sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
+  md5: eb3cdc0fc210838b9271512a6a1b7c85
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2067708
+  timestamp: 1690905319109
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2023.6.0-py39hca03da5_0.tar.bz2
+  sha256: 57934600ce752c7ae44d5a773da4bc6c35c024235673d1c80522c2533ebaa219
+  md5: 5f4de12f8691fc4a7ecca67e32099c7b
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - dask-core 2023.6.0.*
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.0
+  - packaging >=20.0
+  - psutil >=5.7.2
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=5.3.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.10.0
+  - tornado >=6.0.4
+  - urllib3 >=1.24.3
+  - zict >=2.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1390444
+  timestamp: 1686866076457
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+  sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
+  md5: f44b80b9405410e5bde6bfe0b31d5b3f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 15135
+  timestamp: 1650293774207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+  sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
+  md5: f87027ccce1361d0f82c0edf1a10d53b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27677
+  timestamp: 1668714367519
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
+  sha256: 296371685a5dcd98f5128f11f413e63aa59c1eba60543faf3baaebd445964c5d
+  md5: 9817e8ffd3669484c9a7de99a8aceffb
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 257844
+  timestamp: 1695734566410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-hc377ac9_0.tar.bz2
+  sha256: 30919078dc8497553981ed8436990832698e933340e0192e25d04e1c8ab00dff
+  md5: d5bcb4ec3322b0d7aa466c71b87d7775
+  depends:
+  - libcxx >=12.0.0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 146150
+  timestamp: 1628725106681
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+  sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
+  md5: 1d0bd7e576c64c059ef781dd319ad82a
+  license: MIT
+  license_family: MIT
+  size: 77591
+  timestamp: 1676983230102
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-hc377ac9_0.tar.bz2
+  sha256: 4fa13d0426ff6652fc41a19e8a7658aacc6fb6c8bfba2e2334d6884137cfbb0b
+  md5: d69680d281636c7cb3b22f404e0b8764
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=12.0.0
+  license: BSD-3-Clause
+  size: 94695
+  timestamp: 1628726581042
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpc-cpp-1.48.2-hc60591f_3.tar.bz2
+  sha256: 8d4269fb53b83f7dd6ae0932e5528df78d81bf1aa8510fc19b90780d0e9109b0
+  md5: 6426f96b576b853b08187ded60796a43
+  depends:
+  - abseil-cpp >=20230802.0,<20230802.1.0a0
+  - c-ares >=1.19.1,<2.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.20.4.0a0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - openssl 3.*
+  - openssl >=3.0.11,<4.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3910982
+  timestamp: 1698063335516
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gtest-1.14.0-h48ca7d4_0.tar.bz2
+  sha256: 064fc752345ef3973d3ebf2145029eaa308c17e12abe72a732255db9cdea6a40
+  md5: 37ace38cf07143b39ae9b89feb204d3d
+  depends:
+  - libcxx >=14.0.6
+  constrains:
+  - gmock 1.14.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 399378
+  timestamp: 1692633568295
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+  sha256: 3e480af22e98246c056bbd91d6be5352df34ff2b8451d9c7f614baeafb450d39
+  md5: 695fe7ccaf6935d3117533d1e6737320
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4542265
+  timestamp: 1698866834303
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+  sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
+  md5: 69eb3b03765627b6159ed23cdde78396
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28399065
+  timestamp: 1692293207812
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+  sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
+  md5: 83366cbd3beb073112f4644a613b6bca
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111933
+  timestamp: 1666125627512
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+  sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
+  md5: 647c1a2f8460ffa8c670a1915bbdb494
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38790
+  timestamp: 1678997152549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+  sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
+  md5: 35e541905426c686ef2ff010a0e502fd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51860
+  timestamp: 1698254731870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+  sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
+  md5: 187d7720aedf38759d122cccb4576f2c
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 219976
+  timestamp: 1691121991680
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+  sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
+  md5: e8e7f10741f9cfa737b310b334940441
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1255894
+  timestamp: 1694181494549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+  sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
+  md5: ff209e75aee17af2e358b0008fbe8c88
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1022945
+  timestamp: 1644315931223
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+  sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
+  md5: d3e78ef296b3c74910d003bd10b475d6
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213972
+  timestamp: 1666908195870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
+  md5: 055e12390b844ea6c6e956ee08a618e8
+  license: IJG
+  license_family: Other
+  size: 273479
+  timestamp: 1677849171867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+  sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
+  md5: 783e2ad3d36472648c5ccc9f3051db3c
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133077
+  timestamp: 1676558732505
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+  sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
+  md5: 0677598f673f9729b5990316170a999d
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 197129
+  timestamp: 1676329661580
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py39hca03da5_0.tar.bz2
+  sha256: cee2cc791937b240be796561ae67e5a7c57b014826fa087fd75b02acf82135ba
+  md5: 141af9befcd79a876ded744de7d1fa8f
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 79928
+  timestamp: 1698937338528
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+  sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
+  md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 401319
+  timestamp: 1671707682572
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+  sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
+  md5: 247558a0aecf1ef7e77a4343761353d6
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64600
+  timestamp: 1672387273585
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
+  sha256: 789402b67398d3d936ac4486df01869d59b0e1ba298cbd06407d059aced871e4
+  md5: a0f50a38705d0507bbf57ee49a1d9c29
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - openssl >=3.0.8,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1308175
+  timestamp: 1686931157327
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
+  sha256: c1f104bc84ee46a3d3beafb5e35236c64e6b4fd6cceabfb420e1838171b1d9c1
+  md5: 4f95903a1be48bbee1f9a818ec810b89
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 22243663
+  timestamp: 1696762144385
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
+  md5: a0f206782751dfffed0dd51302a1bf26
+  license: MIT
+  size: 68012
+  timestamp: 1659616138077
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
+  md5: 4c6667cdd061d28e9bc4e4300e4d115e
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 31173
+  timestamp: 1659616155596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
+  md5: 637e9430e258ddf050623ef2360184d8
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 298430
+  timestamp: 1659616172209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.4.0-h3e2b118_0.tar.bz2
+  sha256: 452d4f604f22619ef7a154680fbacbbced4bb221e1756a4d0b9dd0846514c25a
+  md5: aaf5235cf4bb69c1d87e779511a52dea
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.57.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 355802
+  timestamp: 1697023465826
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20221030-h80987f9_0.tar.bz2
+  sha256: 6304be2cb816e57ac178068d49befffba4354847f9ee1cfd0ec6acf9ba4ad94a
+  md5: af25d1cc1334d44d2b96eb8133c1dac9
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 167428
+  timestamp: 1670840153090
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+  sha256: 6fc572025852b210ecddcca3ab9ff3f1d5f6bd91f1933c6e296de6bb331f6b5d
+  md5: 6dd7d9c5737bbd2a27d18f15318dc3e6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 102059
+  timestamp: 1628961869728
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+  sha256: 9e7b9bb9367d8725a751cdfa0b2d270434d303ea196cfaacc605ee26be09874a
+  md5: 44d1843cc2f17eb2674f35b95468f551
+  depends:
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 415467
+  timestamp: 1685052299052
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+  sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
+  md5: 55c615026c0869f8d3ba657f3bd38c43
+  license: MIT
+  license_family: MIT
+  size: 120389
+  timestamp: 1683716579036
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+  sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
+  md5: a41117710dafe569c9cc4e83f6f29fe3
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1411339
+  timestamp: 1650982753977
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+  sha256: d654027daea13ac9db36ab5fd5eff3ad398ec97c1777bf399f3ec680d2c145b9
+  md5: baabb1f905054bfea3af8f5768572a34
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 26579907
+  timestamp: 1683291669565
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
+  sha256: b7cd58ddb892ed9d3983bdde8fc2530f0653a58818c87e08659f3795f04d8aff
+  md5: cf519f7233951d00a30c3b969c4cd161
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - c-ares >=1.7.5
+  - libcxx >=14.0.6
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 728977
+  timestamp: 1697018415626
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
+  sha256: 239ec46c06c477e722230159971bac8d9eb14793a2e75f6e3d3a7a04ed5d5ebd
+  md5: 50e9c501f39bb262703c764789099f24
+  depends:
+  - libcxx >=14.0.6
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2338901
+  timestamp: 1675278555141
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h02f6b3c_2.tar.bz2
+  sha256: c16b9310ccbfef25d8cc35d53acaf40af838170f7fdb87df5178baaf096a9045
+  md5: 41dce58413afe3226a5c8c66fea6db05
+  depends:
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 334603
+  timestamp: 1686931243969
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
+  sha256: 82a73882a31e7a4f4edcdb0c21562e123da913d03b90b19396bd6dd4fcd9a7fc
+  md5: b5e5199892949d1e7e2db7bf0ee4dfe9
+  depends:
+  - boost-cpp >=1.73
+  - libcxx >=14.0.6
+  - libevent >=2.1.12,<2.1.13.0a0
+  - openssl >=3.0.9,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 361781
+  timestamp: 1687975246139
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+  sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
+  md5: 98d22e0124d55fae3c37c608dab1dcc9
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 89825
+  timestamp: 1694778225280
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+  sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
+  md5: 0ba499df6755eae5d2d23aa4ab004553
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 642657
+  timestamp: 1692970217410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+  sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
+  md5: c73101971e5ab6a8e8688239884eac81
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241607
+  timestamp: 1692973585084
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+  sha256: ac50f846e93e68d50bfdd5589ea8272b987243a64eba8e2e358ef311d7734001
+  md5: f19270ff954a41dabbfe36ff0656935b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 36040
+  timestamp: 1659783399073
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
+  sha256: 124d9d4f865f0f66c4e5e7f99dc1110330c9415cc51effc0a5aad4261880c2f0
+  md5: c08c14e55ba470513eb6c87206fb7b30
+  depends:
+  - libcxx >=14.0.6
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - python >=3.9,<3.10.0a0
+  - zlib
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 322413
+  timestamp: 1697031210019
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
+  sha256: 83e1c11fb14ec2767e833b540a6a0fdbd8641523b5673273914007008e6666da
+  md5: 64adbf70a0d4ab82aca039e972821537
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11877
+  timestamp: 1652903192510
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+  sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
+  md5: 353dff9d5d996c2a260f66381b2ce3e8
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1470815
+  timestamp: 1695058433965
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.3.2-py39h80987f9_0.tar.bz2
+  sha256: 8e438ac9008003c616c931ff83a29bec61eb93ff338bbd4b485a0c3ff24129a6
+  md5: c2c34ba302a09b8ad0493372f93d5443
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37178
+  timestamp: 1686063992475
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+  sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
+  md5: c99006da802a97c9aae30da8c16b4820
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176131
+  timestamp: 1670944706815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+  sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
+  md5: 60bd1e037cda86205526f77405d78129
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123361
+  timestamp: 1671541992772
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+  sha256: 2fd690fa3c54a40f0426874ea12e12aad2718263a75708ddd1fa6052a4ad7fb3
+  md5: 81388724babfe9c32ea5cdd93633c342
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 107072
+  timestamp: 1684280007887
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+  sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
+  md5: 34dfd76da78de2eae95bbda390d746d6
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23092
+  timestamp: 1654598007056
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+  sha256: bf0eeef3c3c713515766ab8b0dc7863413de5b4b227deede97e24d90ca342345
+  md5: a7bba1857eb84fb50caea377e60d2050
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8066509
+  timestamp: 1698692266161
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+  sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
+  md5: eb79dabbeedee7da85dfbfb145bb8a26
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17342
+  timestamp: 1662014601345
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+  sha256: f400ad75dd2890627dc948f3e2e6b19732d02c124723eaf22272026993a94d52
+  md5: 4a4ffc7365e30b18f4443281839e2718
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53505
+  timestamp: 1659721313693
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+  sha256: 20fb26a7ac748ce288cf8483a837b0c33f1348ae738bcdb69cdc2763c7bbf7e1
+  md5: a0aebbc6c170ebd8d4710fd70b3db503
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19562
+  timestamp: 1659716131839
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+  sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
+  md5: 56db7bd3ff511cd839bda081523b3edd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 55683
+  timestamp: 1629356128780
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py39h525c30c_0.tar.bz2
+  sha256: 20021076eaf466a3bd28a11a5fa28d1cec5fefcaa37d01de8e34c29bc560f8e3
+  md5: 48de2033df7f3739fa92f9e9e150e2d5
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 85401
+  timestamp: 1652362790532
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
+  sha256: ee936ba5fd196c15c3cb538aef721e54bb4486110ae3ebbfcf78e95e8380efa4
+  md5: dde1d9e040e04cbfbc0138898240a660
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 23003
+  timestamp: 1629282780853
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+  sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
+  md5: 176e0dcaeb28393881bacf69941e3889
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8289638
+  timestamp: 1681756329011
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py39hca03da5_0.tar.bz2
+  sha256: d34fcad560dcc7b8e7df2a0250be9694a02e072aa7f7d4992ebd427665575a8e
+  md5: 5972b5a5fbac5cea54ee0ff2cef85897
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100843
+  timestamp: 1698934268054
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+  sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
+  md5: 150ea9fadddf21993d3328d3e48a18b7
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 557688
+  timestamp: 1668450759059
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+  sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
+  md5: 37163b32508f9f589b3e6462a3a47546
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148426
+  timestamp: 1694616771736
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+  sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
+  md5: 6cdf7cbc43bf40e92b056a5576bd0086
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387216468
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+  sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
+  md5: 0f05853a139b6cda9c73e9d2707a4976
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 590288
+  timestamp: 1690984971741
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+  sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
+  md5: 7de782e4fb34bfa95ef2fc79d27d727d
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22840
+  timestamp: 1668160634885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
+  sha256: 0a5a7295f055d2f175528cc895dcb07533df5f0b87f05ac7839ec1af15988218
+  md5: 3d8e6925b26ca29486d0b58b30f1f663
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.41.0,<0.42.0a0
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.26
+  - python >=3.9,<3.10.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - cuda-python >=11.6
+  - tbb >=2021.6,<2022
+  - libopenblas >=0.3.18, !=0.3.20
+  - scipy >=1.0
+  - cudatoolkit >=10.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4428704
+  timestamp: 1697061454581
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+  sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
+  md5: 1a7b23113372c5667dbfe45976b9cc5c
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 126357
+  timestamp: 1696515322390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
+  sha256: 5332b3635fbc1a800b0fe58db7a0e57bb5ef75cbc56a0512c76f01ac7fc7139f
+  md5: ab7fbf394a301d25d1bf8cfa76fd917b
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.25.2 py39ha9811e2_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12847
+  timestamp: 1691092401334
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
+  sha256: 114b5aa7ef0990a615e27116e05dba0e7e78df750e3592aa4b732438f391a394
+  md5: 3284c63e9251227322ef9fd9c997f2c7
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.25.2 py39h3b2db8e_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6338710
+  timestamp: 1691092386069
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
+  md5: 371358a54bbdd307603888348d1a2c6f
+  depends:
+  - libcxx >=12.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD 2-Clause
+  size: 412248
+  timestamp: 1628861367714
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.12-h1a28f6b_0.tar.bz2
+  sha256: 8da09e2669c8217fa915cc35cac6994fbf81ef45d52776bbcd44aa107ad2eafa
+  md5: 35199a35c3aca5d373116843d377ca47
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4762670
+  timestamp: 1699012560527
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
+  sha256: c4135710b5536fb859a6672c055bbc2cff0426e0655e75c7fdf808f7f3344ada
+  md5: 483605a01fccba850b7f0cbdeff29858
+  depends:
+  - libcxx >=14.0.6
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.9,<2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 421604
+  timestamp: 1676482754496
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+  sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
+  md5: d73db95f07a282021efdf8bc09713261
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73620
+  timestamp: 1693575195999
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+  sha256: 247b5e4d81b6d5d013a9c27e1f30c41fff896fed98a68ebda26b19b4062a6828
+  md5: 354a1d65300b4309d53dfa648014e8fe
+  depends:
+  - bottleneck >=1.3.4
+  - libcxx >=14.0.6
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - lxml >=4.8.0
+  - matplotlib-base >=3.6.1
+  - tabulate >=0.8.10
+  - pyqt >=5.15.6,<6
+  - openpyxl >=3.0.10
+  - s3fs >=2022.05.0
+  - pymysql >=1.0.2
+  - beautifulsoup4 >=4.11.1
+  - scipy >=1.8.1
+  - xlsxwriter >=3.0.3
+  - fastparquet >=0.8.1
+  - xlrd >=2.0.1
+  - blosc >=1.21.0
+  - zstandard >=0.17.0
+  - psycopg2 >=2.9.3
+  - pyarrow >=7.0.0
+  - pandas-gbq >=0.17.5
+  - pytables >=3.7.0
+  - sqlalchemy >=1.4.36
+  - odfpy>=1.4.1
+  - numba >=0.55.2
+  - jinja2 >=3.1.2
+  - pyreadstat >=1.1.5
+  - gcsfs >=2022.05.0
+  - qtpy >=2.2.0
+  - html5lib >=1.1
+  - xarray >=2022.03.0
+  - fsspec >=2022.05.0
+  - dataframe-api-compat >=0.1.7
+  - pyxlsb >=1.0.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13257999
+  timestamp: 1697478739906
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
+  sha256: 4548d2a1bc58cd61e9c9f475a77bac68d9e49d4996c4c891d5ca8ba5ea7552b0
+  md5: b4ed079246a55ac8f91b8f8abb713b3b
+  depends:
+  - bleach
+  - bokeh >=3.1.1,<3.3
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.16.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17115516
+  timestamp: 1695146000246
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+  sha256: 0d64f2438be25524bbfeb8646e4fb3c18499d747398a03ed15d41b350b03e001
+  md5: 6a4908a5c9f7b3f17f09ebc34b1b691c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142857
+  timestamp: 1684915417403
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
+  sha256: 3a6450282f56265e800500b62cd1bbe39cd5a6a09c4747c6dc3e8aab10bfa8a0
+  md5: 9b01b16f9c5a033ee8b92683d66b184e
+  depends:
+  - locket
+  - python >=3.9,<3.10.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36731
+  timestamp: 1698702611592
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+  sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
+  md5: 6e01c592ae3b8ff2d12cae76f2f4276b
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 715239
+  timestamp: 1696580071596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+  sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
+  md5: 9fb8f460c130d56caf33c6bbe46fbe8a
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2678841
+  timestamp: 1697548790931
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+  sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
+  md5: 390b8c3cd74281abecdbfd51476922f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33033
+  timestamp: 1692205747301
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+  sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
+  md5: 7896828fb3565fefad43f980d50c8723
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91190
+  timestamp: 1659455206354
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+  sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
+  md5: d934c74eb66d01af0f45f0881f4bab77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580588
+  timestamp: 1672387390426
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+  sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
+  md5: 9858166e5ffb624c8b9d281f4000d725
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 367167
+  timestamp: 1656431368885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-11.0.0-py39hbfed03b_1.tar.bz2
+  sha256: a5ea3a518a33ea96e544f134d96ea2d967c796172169a253e1c987d05a3342ee
+  md5: eced623c20b50303d6248e05f48092e0
+  depends:
+  - arrow-cpp >=11.0.0,<11.0.1.0a0
+  - boost-cpp
+  - gflags
+  - libcxx >=14.0.6
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4374629
+  timestamp: 1693273159579
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+  sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
+  md5: 4d2b45c6be8221e6a3e44c2d5838426f
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30843
+  timestamp: 1675441531640
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+  sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
+  md5: 02521df4e2e79f75faa9cbb3560ab1dd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1861763
+  timestamp: 1684280026169
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+  sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
+  md5: bdebe59bffc7adbad83fdcd9d429a5f5
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95234
+  timestamp: 1690223494699
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+  sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
+  md5: d716e5c9b5eec45ce1df8eb52cab817a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157408
+  timestamp: 1661452601692
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+  sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
+  md5: 1907629863ed8e7c35ead232dae7693f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 91636
+  timestamp: 1628941083263
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+  sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
+  md5: 847b9bddf2a86e1609c0d53bbc23ea79
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 27378
+  timestamp: 1626781391140
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+  sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
+  md5: 18aa18bd0d260605923877921d26cc74
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13194025
+  timestamp: 1694438901368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+  sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
+  md5: 45642a99c83e7aed74d1ffab1f20145b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 266647
+  timestamp: 1661368655993
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py39h313beb8_0.tar.bz2
+  sha256: 120745bd4e38c1ad20fbaa6a43b932e4233c349959f12c71e8dc85bc4dbd78e7
+  md5: 35ffa41c6c93dc92534cd1a1ed18be5b
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 133586
+  timestamp: 1682522585527
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+  sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
+  md5: fec748525144049a2fc7f52f9755232c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257235
+  timestamp: 1695131702047
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+  sha256: 960192a143672e9c1d6fe4027af448512d91eee7501e5c245c21b865cf8bf429
+  md5: 76d491244218505f071ba56a308673df
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40950
+  timestamp: 1685030774581
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+  sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
+  md5: 3445d25415998c807efbe64d3a7e03c8
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 167068
+  timestamp: 1698096118071
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+  sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
+  md5: e6e92da28e9b0e428ed4b7df417bec25
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 472418
+  timestamp: 1657724315435
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+  sha256: 089c6b9bebfa690f380710f219ab0fcc1acec9f2e187d4174a08222c45f58afc
+  md5: 11b832c6c10a6d2b0e687a20c3037c97
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-3-Clause
+  size: 194532
+  timestamp: 1652449531448
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+  sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
+  md5: dba22515f36d3c266de5896350813ea2
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95103
+  timestamp: 1690400315537
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+  sha256: c35449c0ca64d0d6a23c019b6eba188f546e42379857cbc4240bbdddee1159d3
+  md5: 61cb82346e21710f3e0645096cda4e12
+  depends:
+  - blas * openblas
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.21.5,<1.28
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22859180
+  timestamp: 1696543469561
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+  sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
+  md5: 3cd7eb43e285faba76faf67667e26b00
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093916
+  timestamp: 1690290951258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.1.9-hc377ac9_0.tar.bz2
+  sha256: 1a0eb8133498944a69d432b79b3edae63d64b2ccd92aa508b89b3fa83dc7983a
+  md5: c9acd31658bb93735e401406ae43089d
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 1304256
+  timestamp: 1650293949317
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+  sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
+  md5: c5e9aef0d6895de1c927e9d796cd7cd3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15691
+  timestamp: 1629145910454
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+  sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
+  md5: 0f7c229e774146ffc4e29dedf75372bf
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67279
+  timestamp: 1696347632563
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/spatialpandas-0.4.9-py39hca03da5_0.tar.bz2
+  sha256: b0ddb0fe25fd6be7f5619eea067e92a789f39e458a971366ee8da540773cf6ea
+  md5: 7255da059b6190a750c2c2d5f404e9ad
+  depends:
+  - dask-core
+  - fsspec
+  - numba
+  - pandas
+  - param
+  - pyarrow >=1.0
+  - python >=3.9,<3.10.0a0
+  - retrying
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 149377
+  timestamp: 1695247383366
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+  sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
+  md5: 2302a79a045f152e183a52a81adfba62
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1674163
+  timestamp: 1681394762218
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+  sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
+  md5: ae58720a18a2ed15eae214ad7a10d1b5
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 140125
+  timestamp: 1680167256603
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+  sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
+  md5: 4ae67163d55cf9df83d4027ebc38c501
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30894
+  timestamp: 1671751931536
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+  sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
+  md5: dbb5c0cddb6661a89afee647fd3dc01e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39875
+  timestamp: 1668168874870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+  sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
+  md5: 667e60c8b407d73cbba40f44901f4f00
+  depends:
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3412693
+  timestamp: 1654088929697
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
+  sha256: 065cf1b08faf1d28aa348d569f2266d8b33b22ba424312c7ec959be95f217646
+  md5: 20370dbc92a9262e6fc8c82208f74ff2
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102259
+  timestamp: 1667464137769
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+  sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
+  md5: 884f788a5f6a664c9b79f7a4a60362d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680561
+  timestamp: 1696937004165
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+  sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
+  md5: 639a4f489af172c866c18442948e5874
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - slack-sdk
+  - requests
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125170
+  timestamp: 1679561942932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+  sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
+  md5: e5b90eba83fddba6d7aa6072b5bf7c91
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193017
+  timestamp: 1671143921826
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
+  md5: 644ef8830437070f60efcfcd6a987198
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9670
+  timestamp: 1690297532002
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
+  md5: a902a833bb186a2f1a4b2b89b1195136
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58466
+  timestamp: 1690297524418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+  sha256: 536045a8a172c651fd306c285a6d7409775f018dac944f2124c538ccfb195e28
+  md5: d4dc6cdf0812191b9ec78b35b4fdf3e0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11593
+  timestamp: 1659769477205
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+  sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
+  md5: f3f1d2c1028dad2f11ff950a15c99dbf
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188640
+  timestamp: 1698257577209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h1a28f6b_0.tar.bz2
+  sha256: 51736bc20b585261902ea83590782b4ac6e54a2b5723cf8e819f33a1013af690
+  md5: 34e8baed182ea45eb7e72d387e6f7fa5
+  license: MIT
+  license_family: MIT
+  size: 101295
+  timestamp: 1628694426801
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+  sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
+  md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20091
+  timestamp: 1629144441130
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+  sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
+  md5: 3089c63bf8f4d0423e1a287da286d83e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70923
+  timestamp: 1629357115820
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+  sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
+  md5: 5886b30b312445471268444f41f39dc7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102583
+  timestamp: 1695741976083
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
+  sha256: 300b9e4cfc9d01fa4d537060b2867f3cb89f22f932992fc2427e00dda050d55b
+  md5: 768c174577b786b99f8b46c4789b36a2
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1800646
+  timestamp: 1689041569828
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+  sha256: 105e39d3eb51b47c7244b3379c0133ab7051966664f52835453b14509215b159
+  md5: ed20012c2cd99ffd04cca9929e0bc061
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49775
+  timestamp: 1675159079039
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+  sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
+  md5: 2e75ad6a09c308268192efe03cc9ebf4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 411778
+  timestamp: 1683113019715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+  sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
+  md5: 30f666bf97c26587c5d2f68cc5f330ab
+  depends:
+  - libcxx >=12.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 316901
+  timestamp: 1629287855861
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py39hca03da5_0.tar.bz2
+  sha256: 8d31a7e9356948fd3d715faa6111e78dec6ffb6981819dd182aed7f765ec97c1
+  md5: 869dc425508ac78b9031bde17f568cd8
+  depends:
+  - heapdict
+  - python >=3.9,<3.10.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 77665
+  timestamp: 1695832985587
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+  sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
+  md5: 584e591d36dcd5ba5c45404f0f7ebb2d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19076
+  timestamp: 1672387153578
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+  sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
+  md5: 467ae28215d1aa1c5688bc0c8a184269
+  license: Zlib
+  license_family: Other
+  size: 103525
+  timestamp: 1666595022664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+  sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
+  md5: 7cfbed15f1feee1422810f7830075f53
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 779464
+  timestamp: 1681304594848
+- conda: https://repo.anaconda.com/pkgs/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
+  sha256: c5a4f98a90713f799a73195cc159571c4bd373bfa43640dc0c1707608e582945
+  md5: 537f198da93942d8ef7008606edae551
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2363136
+  timestamp: 1652426285158
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+  sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
+  md5: ed14f9bc6e55220483f1a5a388625a08
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162772
+  timestamp: 1644481986085
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+  sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
+  md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 39253
+  timestamp: 1644551767970
+- conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-11.0.0-ha81ea56_2.tar.bz2
+  sha256: d039fa7a61ba39f73007c9600827bb73ffcbe0e53f1b505ec90aadad9f03a7d1
+  md5: 29b4ee3013059cb3bfc7ea3615bf48c1
+  depends:
+  - abseil-cpp >=20211102.0,<20211102.1.0a0
+  - aws-sdk-cpp >=1.8.185,<1.8.186.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-ares
+  - glog >=0.5.0,<0.6.0a0
+  - grpc-cpp >=1.48.2,<1.49.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.10,<4.0a0
+  - orc >=1.7.4,<1.7.5.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.9,<2.0a0
+  - utf8proc <2.9.0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8320742
+  timestamp: 1693265580715
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+  sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
+  md5: b24d13c443a26f65a0778b475a5726bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132830
+  timestamp: 1695717959996
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.6.8-h2bbff1b_1.tar.bz2
+  sha256: bddd29eeda0582b60f9acf79e56cf2921fe1a01fe64207fb6db1a243c1604339
+  md5: 6598ca0318ff021ec7279d011a314c60
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 164184
+  timestamp: 1685977910402
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.1.6-hd77b12b_6.tar.bz2
+  sha256: 7d55f521fac0d4ae8dca1233fbde41321e67aa8ae683b41b506012809af48191
+  md5: 126c485741a00fa9e688e5f138510cfa
+  depends:
+  - aws-c-common >=0.6.8,<0.6.9.0a0
+  - aws-checksums >=0.1.11,<0.1.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 27553
+  timestamp: 1685999081313
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.11-h2bbff1b_2.tar.bz2
+  sha256: 7f66a409f02718870deaf43bcaf1a997ea43c8657861a902ae01bd570ed7a82d
+  md5: e23c359b77a20d7a9cf422dcdadec3c8
+  depends:
+  - aws-c-common >=0.6.8,<0.6.9.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 53376
+  timestamp: 1685994712130
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.8.185-hd77b12b_1.tar.bz2
+  sha256: b6c0b47023b13b944705f1c9701d9fceba59278ebe21ddba2dd9774a6d0b8551
+  md5: 3b2b3baf0bc96d73a5ae315840529ed4
+  depends:
+  - aws-c-common >=0.6.8,<0.6.9.0a0
+  - aws-c-event-stream >=0.1.6,<0.1.7.0a0
+  - libcurl >=7.88.1,<9.0a0
+  - openssl 3.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3231175
+  timestamp: 1686057995042
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+  sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
+  md5: 302c3c0696e17eaa62e140e3892644ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 199723
+  timestamp: 1681493196911
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
+  sha256: 29e914b68f261dd564de357888d32ec1511a6fcac9477fe68797289aba4d3e75
+  md5: 288585e412638a51e0288caf690d543b
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6485148
+  timestamp: 1690546982849
+- conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+  sha256: 68ef338b27c035add89c0812ad469dd8c9e94f27130f770345ea20deb049d50b
+  md5: 9ec19b145f655329532b608963cf32f4
+  depends:
+  - libboost 1.82.0 h3399ecb_2
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 11334
+  timestamp: 1696764270626
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+  sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
+  md5: bf930260f679bc74227bbb18bc36ae82
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 119700
+  timestamp: 1657176150595
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
+  md5: 507dfe693ef429f466d964b599f4af21
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_7
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 18650
+  timestamp: 1659616328001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
+  md5: d0bf43e8df60baae3b3105aa5c42a791
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 21153
+  timestamp: 1659616312367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+  sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
+  md5: 7bd24bf94c24e810aecaaf84a0978e6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 343204
+  timestamp: 1659616543542
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
+  sha256: 3a26c397d4e0d546b0c2f433074c20813c5f3ae98bcf07a165c648f369a850b9
+  md5: 8f8069ce8c9eff1b0f124de2c0a63b86
+  depends:
+  - vc >=14.1,<15.0a0
+  license: bzip2
+  license_family: BSD
+  size: 154105
+  timestamp: 1563219293348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+  sha256: 41a6c5a90b88ec7010bb6dd89390754e476b52c3ab2d519bdab9556da8829479
+  md5: b047426a545e287f45e8abfbfcb0de55
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 118041
+  timestamp: 1693902191485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+  sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
+  md5: 092b417c11edcbe6bb9b765ab4a55d23
+  license: MPL-2.0
+  license_family: Other
+  size: 164999
+  timestamp: 1694009822357
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+  sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
+  md5: 708a750d370b9d6875651021e21c4446
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159322
+  timestamp: 1690232335307
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+  sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
+  md5: c35736da3ea26782425e78061268cf5e
+  depends:
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 228713
+  timestamp: 1670423312743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
+  sha256: 9577ff772035cd30e72323edff379dd3df877de00f7f690fd33c8720a5a4bbc9
+  md5: 1130fd979d4f97f511f10b36ff09513d
+  depends:
+  - colorama
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 152728
+  timestamp: 1698129962390
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
+  sha256: e5babe79f8132c4bd44bc05307976f2c5485014ae3129655dddbd3baa8e75e46
+  md5: 093223df00c6ef9db4e7e5aa7bfec00a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40844
+  timestamp: 1683040252786
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+  sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
+  md5: 457a4339a53c033d48ce0c72e5038d2e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30330
+  timestamp: 1672387265402
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+  sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
+  md5: 59ec65fd9e06b81a65cc12986c67d5da
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1939614
+  timestamp: 1668084794027
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+  sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
+  md5: 3489c1a2b73fc957b5a62cc59349e25b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13438
+  timestamp: 1671231196438
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+  sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
+  md5: 3492b96083c1e904cc32d26ea7f1e1d8
+  depends:
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184280
+  timestamp: 1663827558327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+  sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
+  md5: f46d904bc6f220327e70474971341f52
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1220835
+  timestamp: 1694445639066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.0-py39h2bbff1b_0.tar.bz2
+  sha256: 28c350d12caf11ba087e033289e5152ea9b9dc4abbf0229299a3e5d20759f47e
+  md5: 4bac24daf8224ea465812ad92c30ad47
+  depends:
+  - python >=3.9,<3.10.0a0
+  - toolz >=0.10.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 311754
+  timestamp: 1667466298939
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-2023.6.0-py39haa95532_0.tar.bz2
+  sha256: 4a76fc5f38fa806fe29278cfa5541b6efa60062123854998fab7fba629490f4f
+  md5: 6ee30cfc076adeffa3b70ef987603f52
+  depends:
+  - bokeh >=2.4.2
+  - cytoolz >=0.12.0
+  - dask-core 2023.6.0.*
+  - distributed 2023.6.0.*
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.21,<2.0a0
+  - pandas >=1.3
+  - pyarrow >=7.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5634
+  timestamp: 1687285077691
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
+  sha256: 78d66bcb1c979647e9c5473825d4a5e35afa2a0dfeef71cb0d9d9a72fea3c102
+  md5: f2875875bb22ab4704a77bc368a9dc00
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.2.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2180195
+  timestamp: 1686783294287
+- conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
+  sha256: 882a0fb257fb07bb47e8127b9ce1f556e319ce4941b74adc94f9849093e11d0d
+  md5: b6ef3c0b6e49ff3d497785c744ce44cc
+  depends:
+  - colorcet
+  - dask-core
+  - datashape
+  - numba
+  - numpy <2.0a0
+  - pandas
+  - param <2.0.0a0
+  - pillow
+  - pyct
+  - python >=3.9,<3.10.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17688679
+  timestamp: 1692373093225
+- conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
+  sha256: a6c8b5d32c52ce71d41c7702265e0bb064c960ab67b88ecbea967595c5e02bc3
+  md5: 112f2f9c7055656ec156fe287c97c0e9
+  depends:
+  - multipledispatch >=0.4.7
+  - numpy >=1.7,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 104432
+  timestamp: 1613390539244
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+  sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
+  md5: 2ff4fb509788b0e47ac684ba151394d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3289966
+  timestamp: 1690907040646
+- conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2023.6.0-py39haa95532_0.tar.bz2
+  sha256: 630642c70be3bcc7c4dcbebd42700b0d24e10e008cf2910a6da0ff547415b513
+  md5: 30640e2f388681e0bc2d0819c393e3c1
+  depends:
+  - click >=8.0
+  - cloudpickle >=1.5.0
+  - dask-core 2023.6.0.*
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.0
+  - packaging >=20.0
+  - psutil >=5.7.2
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=5.3.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.10.0
+  - tornado >=6.0.4
+  - urllib3 >=1.24.3
+  - zict >=2.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1417000
+  timestamp: 1686866407042
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+  sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
+  md5: 0f166c3e70541d8bee6e9d0cb60fb66e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16979
+  timestamp: 1649926678161
+- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+  sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
+  md5: ea93d413944ca6a8677eb1b284b136ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27388
+  timestamp: 1668714577678
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
+  sha256: 6b724886465fea70d2ca843fea1d01bcc24d496601587b87c0cb8f2626b259c2
+  md5: 6c11d9242869d6c3b01698f728bd409b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 260567
+  timestamp: 1695734829130
+- conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-ha925a31_0.tar.bz2
+  sha256: ad0e4798638530f78c8f36ab21ca05c229d0dba4111327a2c8fdc7d1c4d91912
+  md5: 9e22a730deccc88b398abac59752760e
+  depends:
+  - vc >=14.1,<15.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 328927
+  timestamp: 1542388617060
+- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+  sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
+  md5: 9f167d3e45441bc3633c1974b1b0ce8c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 88421
+  timestamp: 1676983264486
+- conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_0.tar.bz2
+  sha256: 203032374cdb03d0b443f9a9fa600ce3fb0b76bff7e8d92d2254e199fc878e03
+  md5: 6b6f718cb8ece69c73e3798105b5340b
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  size: 92876
+  timestamp: 1620733126207
+- conda: https://repo.anaconda.com/pkgs/main/win-64/grpc-cpp-1.48.2-hfe90ff0_1.tar.bz2
+  sha256: 0c6223208742064a2829f8dd658e04b72f5176e357a1320c0b0398b91abfd292
+  md5: 19c77d6709407253582fae939434016c
+  depends:
+  - libprotobuf >=3.20.3,<3.20.4.0a0
+  - openssl 3.*
+  - re2
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 31002375
+  timestamp: 1685747992041
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+  sha256: fa8f868e49721ca19912f816a6da221172758f9e3d28d8b31d53249fb14dc25f
+  md5: 09f9a2cea9425d76dccf9b026afe5bb2
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4576915
+  timestamp: 1698866895838
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+  sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
+  md5: 582d2c1135a89da757a038de831e7f39
+  license: Intel proprietary
+  size: 11086648
+  timestamp: 1664812389803
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+  sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
+  md5: 30fdefd1541c789c163751291a8faa88
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111448
+  timestamp: 1666125667599
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+  sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
+  md5: a10f07c7a3510272a296f9fed458a4ed
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38098
+  timestamp: 1678997241511
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+  sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
+  md5: fad9cf2023d807da8d44996e9d4399a0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51490
+  timestamp: 1698254721864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+  sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
+  md5: 9834848bd7c7759acf12e78d09388563
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3891030
+  timestamp: 1681801474383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+  sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
+  md5: 1285c8c628bc912c54d0968574c9f4c9
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217232
+  timestamp: 1691122695748
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+  sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
+  md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
+  depends:
+  - backcall
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1279433
+  timestamp: 1694181820978
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+  sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
+  md5: f5fcce35d3f21cdfc5893c5a7a86c651
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1035394
+  timestamp: 1644315567034
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+  sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
+  md5: f67fe3337528e2886f1ac3ab8ac37985
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213110
+  timestamp: 1666908350218
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
+  md5: 81f2c343dc4c65eea39c45383272068f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 407861
+  timestamp: 1677849239400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+  sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
+  md5: bd9526d38a145fe311a8aa36bc11e071
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 152006
+  timestamp: 1676558783570
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+  sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
+  md5: a00e6a62956fde3c4135464353ee8a53
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229158
+  timestamp: 1676330909084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py39haa95532_0.tar.bz2
+  sha256: e840d6b322faa7d5fee2c54ed6074e3a6b7fe38a9356020a4027d9e09c40a1a1
+  md5: 038bb985c0d43bf77a8e772f4c4ad22a
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 103854
+  timestamp: 1698937448209
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+  sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
+  md5: 5efa1332f7c0a8d9638eda02170c4ce5
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pywinpty
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 413653
+  timestamp: 1671707957673
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+  sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
+  md5: 891fe66a24d8714737b2874985ee1303
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62298
+  timestamp: 1672388166096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+  sha256: 4184dd040fc38cb123a98588a8344aa8d1ba1932df5fcc6c188f6b21f5a0c306
+  md5: da58cfa83f3d6c31ae12d8777cd1b64d
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 29803292
+  timestamp: 1696764164248
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
+  md5: c345f51706eef530454f66b794e5e574
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 68189
+  timestamp: 1659616216976
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
+  md5: a7400cfb72042977bc047909ed504ce8
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 33743
+  timestamp: 1659616248209
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
+  md5: 6307f6854754ab5bd7c84e6998385bb1
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 733177
+  timestamp: 1659616279453
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.1.1-h86230a5_0.tar.bz2
+  sha256: 5763d2c3cbb615b6560e91b91b13116229dd38c3e18ee952a1861aec56e8e99c
+  md5: cc1f82beb7d4c258263c12785caae23e
+  depends:
+  - libssh2 >=1.10.0
+  - libssh2 >=1.10.0,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: curl
+  license_family: MIT
+  size: 326718
+  timestamp: 1685433002097
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
+  sha256: 6458c7a370c4e3366b3b208c5b2834a7acfb17981e47fe3fb861f225d7cefbc3
+  md5: ecabf4acab5b604856d8c7c4278c2c2c
+  depends:
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 446380
+  timestamp: 1685052520132
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+  sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
+  md5: b812bc5d9c76242e2bb2ac87afe7d39b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 730280
+  timestamp: 1650983734373
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
+  sha256: f7368e611e349b91315ce4ba4dbf9116d996a48f98eed425f4d5c3d5b9fcfa5e
+  md5: 77eb9daff9052f1fbf24d91c5bba1d74
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2543079
+  timestamp: 1675278760037
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-he2ea4bf_2.tar.bz2
+  sha256: 07e45cd4e2e791528d099791f1664983b880566c836e73925211e45c9e28096b
+  md5: 5f67893563dfc1dd0e45d3b2abf2e3f4
+  depends:
+  - openssl >=3.0.8,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 230596
+  timestamp: 1686933095919
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
+  sha256: 238e486a0d62264e7ab35098bdc0390fb9a4649921b18827228c811ae8252c88
+  md5: f1ebe453c5a955a25e4b00f73279fc42
+  depends:
+  - boost-cpp >=1.73
+  - libevent
+  - openssl >=3.0.9,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 894777
+  timestamp: 1687975823684
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+  sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
+  md5: ba9418df9288a2f031a02fa35b774ce0
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78524
+  timestamp: 1694778314659
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+  sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
+  md5: 6ece7f1a3248169837714d05d7f6ef0a
+  depends:
+  - libiconv >=1.16,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 3513910
+  timestamp: 1692971505729
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+  sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
+  md5: bd7ec244935e83e850a4ff34e8e2e64f
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 513971
+  timestamp: 1692973657152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+  sha256: e1c0e745d9ba36a80773e841d96bf514ad1ceda419e4188aad3c22782af00234
+  md5: f226532e9bb308f20e874c56be6ceefb
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 35788
+  timestamp: 1659783414586
+- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
+  sha256: 2f610fc98b674e4eceeceaadbb94b4153759ee9249759dd27ca48bfdeeef82cf
+  md5: c24005244a08cbfb665f89d8858e0187
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 20824879
+  timestamp: 1697031479623
+- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
+  sha256: 5d4cf89313147e44530dbb3cc6a93247aaded0701bbf8ba3a382ef710abf4cfa
+  md5: 137deeca51202f6b4ac786472a00be55
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 12894
+  timestamp: 1652904101694
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+  sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
+  md5: fb7881e74b59262df0fa4ec981964efc
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1244887
+  timestamp: 1695058550693
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.3.2-py39h2bbff1b_0.tar.bz2
+  sha256: 249bedcd46393c1f7506c1087e6a7da1927e28bc73778843575bb1bf9f495962
+  md5: 392b06ffe7c8d92097b07e60f8d5efa5
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 83368
+  timestamp: 1686058138081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+  sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
+  md5: 6970c7f46b0164cad1d210e7a1419959
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143434
+  timestamp: 1670944902624
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+  sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
+  md5: 1015298551c040c6d5e26eebbae12ef5
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142316
+  timestamp: 1671542240512
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+  sha256: ab5c246c2b271acc1cdd0b9343989c0166681536e569cdbe71618f55d34c7292
+  md5: 7ce68d771cd94c9ff5efefe69d327c9a
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 125122
+  timestamp: 1684280210213
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+  sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
+  md5: 466da740fafef3d6bce114220f0be306
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28510
+  timestamp: 1654508162239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+  sha256: 1687ae122ee7d8b583141fc5014b76d494841dc8083b854449e3d6e0f6bb7019
+  md5: 3697ac26ee3c2d49338dd5b9c6551152
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8080067
+  timestamp: 1698692812610
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+  sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
+  md5: a9fa43e694b25cd49b8b08a9eefd696e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18054
+  timestamp: 1661915903969
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+  sha256: 8aa14047fac6ef8b326900c4bf1a960eaa7a1699c18fdf1e75a59101b610b6df
+  md5: 7e1d4d4700fbea6171d30f1d5ad24226
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53362
+  timestamp: 1659721308586
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+  sha256: 2017814a7cc93dd51c6b7c016e3cdf8fbc32fa20f985638aaff6a6377e9ee086
+  md5: a1a285c56b001c3b5c591bf21eec3149
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19326
+  timestamp: 1659716205153
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+  sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
+  md5: 248c468abced874f0231d3cc23177c77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58488
+  timestamp: 1607359497934
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+  sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
+  md5: 5e763c995ff0c549f68a10bce70fede4
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187489950
+  timestamp: 1691503804820
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+  sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
+  md5: dd0c2ece6a743c373c9b5a5919b4818f
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49744
+  timestamp: 1682975040154
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+  sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
+  md5: 57cea8df7ab85f2a98f64d23afcb1f90
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184956
+  timestamp: 1695058491736
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+  sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
+  md5: 8769cdd201d905069800488fe31574e5
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 256221
+  timestamp: 1695060152521
+- conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py39h59b6b97_0.tar.bz2
+  sha256: ed64d0a3331cc40479962ed066a833243ca36035bd4cefee4fb5e42a9214f64b
+  md5: 6b7d9b4724303c0159086d28e9ef4901
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 82755
+  timestamp: 1652329408426
+- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
+  sha256: b75f28f29d60f2a8726fb0f036e5d01489942abbf77ff1e1cc8e12d7f372b8f3
+  md5: 7a1d29477873480809fd3860f2e69f01
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 24734
+  timestamp: 1607574381373
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+  sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
+  md5: d9781492332e6326f9fca87f3a8efacd
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8135792
+  timestamp: 1681756491399
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py39haa95532_0.tar.bz2
+  sha256: 49715dd545469a4458cdf0d0d55c9a7af7cb7a2da8a6504a60dd3089714015ae
+  md5: 4257087772bed974078f56673ca50d99
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119351
+  timestamp: 1698934436390
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+  sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
+  md5: f1d8ce412e115986c403f223b3b47d0f
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 596314
+  timestamp: 1668451106600
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+  sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
+  md5: f96bbef0985d7e66ebf00c0d55e30e23
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 167045
+  timestamp: 1694617078743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+  sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
+  md5: 6e6ba64c8dc5025aeac606404a8df36a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13786
+  timestamp: 1672387480065
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+  sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
+  md5: 4a7a3286484766741f627696697c362c
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 609425
+  timestamp: 1690985686105
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+  sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
+  md5: 4269a1f93882205b90d4b2ae78fc82d5
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22417
+  timestamp: 1668160717305
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
+  sha256: 39b52f5a3e0f71a07358f2bd07a67b950170eabc3398ae968ef523cc0854141a
+  md5: 4baee3e5d96aed7d5d3e28051d6214e5
+  depends:
+  - llvmlite >=0.41.0,<0.42.0a0
+  - numpy >=1.21,!=1.22.0,!=1.22.1,!=1.22.2,<1.26
+  - python >=3.9,<3.10.0a0
+  - tbb >=2021.8.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - tbb >=2021.6,<2022
+  - scipy >=1.0
+  - cudatoolkit >=10.2
+  - cuda-python >=11.6
+  - libopenblas !=0.3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4472762
+  timestamp: 1697063760024
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+  sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
+  md5: a18a576b7024cfd6f905c526a786a916
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 135285
+  timestamp: 1696515698492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
+  sha256: 410f3a13eaddcfcfc65cb077dd0b85b7c66853a2447161b9022eed7d9fe472f9
+  md5: c4aae7ab3842a3decd05c5c1d8b916d3
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.25.2 py39h65a83cf_0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12296
+  timestamp: 1691098390179
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
+  sha256: 5a81ff60cc876951905995ea52d3815e38a0d757c6c674acbef1144d8dc746fb
+  md5: 72413d41fe97de5da9b1ce325e544e05
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.25.2 py39h055cbcc_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6857794
+  timestamp: 1691098356763
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
+  md5: ab07e2a27ac08afe3d0b4c0890b8486a
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 2-Clause
+  size: 249316
+  timestamp: 1630094024143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.12-h2bbff1b_0.tar.bz2
+  sha256: 8ef9303c90033dfd6ffac174ec7c47c93c2adc840ef164a7841ce8b7aca33e6d
+  md5: ff1c3deee94b20c5d06d6d2cb91a4af3
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8048086
+  timestamp: 1699014079653
+- conda: https://repo.anaconda.com/pkgs/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
+  sha256: 417cf23716f17b6daf2b717bbd69240aa9440845dfa415f59a97961794632ce5
+  md5: 36d709d47c43a3e9b43f23cf4edb6438
+  depends:
+  - libprotobuf >=3.20.3,<3.21.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.9,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 877890
+  timestamp: 1676482911485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+  sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
+  md5: df1d746ba8d5d6ba01ac1373b9b71e1a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73016
+  timestamp: 1693575484990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+  sha256: 1994e5831fd421bd6cf85916073d4012dec53e673b672b3985efaf771f0a7bf8
+  md5: c486a5b51e3227f6ea564a9dd3125e45
+  depends:
+  - bottleneck >=1.3.4
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - openpyxl >=3.0.10
+  - jinja2 >=3.1.2
+  - qtpy >=2.2.0
+  - numba >=0.55.2
+  - pyreadstat >=1.1.5
+  - zstandard >=0.17.0
+  - xlrd >=2.0.1
+  - tabulate >=0.8.10
+  - fsspec >=2022.05.0
+  - pyqt >=5.15.6,<6
+  - xarray >=2022.03.0
+  - xlsxwriter >=3.0.3
+  - beautifulsoup4 >=4.11.1
+  - html5lib >=1.1
+  - fastparquet >=0.8.1
+  - pyarrow >=7.0.0
+  - pyxlsb >=1.0.9
+  - matplotlib-base >=3.6.1
+  - odfpy>=1.4.1
+  - pytables >=3.7.0
+  - sqlalchemy >=1.4.36
+  - psycopg2 >=2.9.3
+  - blosc >=1.21.0
+  - lxml >=4.8.0
+  - pymysql >=1.0.2
+  - gcsfs >=2022.05.0
+  - pandas-gbq >=0.17.5
+  - dataframe-api-compat >=0.1.7
+  - s3fs >=2022.05.0
+  - scipy >=1.8.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12629931
+  timestamp: 1697479885371
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
+  sha256: 0044e1cc04f3cb7c48209276c35c59c05b87e852c0ac01be468b99f3656445fb
+  md5: ee81d2a2b2c558b43a48fd68c2de1dbf
+  depends:
+  - bleach
+  - bokeh >=3.1.1,<3.3
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.16.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17009718
+  timestamp: 1695148093102
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+  sha256: 2773f47b2d745ab483cf7fcbd5b5e2f7020d45462d32d2ccd5cf232ca13c6f67
+  md5: ca16cd208037bd58d2da267c338da4a4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142229
+  timestamp: 1684915524241
+- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
+  sha256: 5738f61dae392c171b4f699a6973e736198e4d4a63fa22dcf957afaf1de150af
+  md5: cba721e73156d62fc4ff23159e96ad41
+  depends:
+  - locket
+  - python >=3.9,<3.10.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.9.0
+  - pandas >=0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36452
+  timestamp: 1698702686971
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+  sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
+  md5: 427c1450bebb632f43bbc8c83006e4cd
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 806931
+  timestamp: 1696580240310
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+  sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
+  md5: 21790cd3e2b8a45c4104aff0a68330d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3001751
+  timestamp: 1697549357662
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+  sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
+  md5: 56f44a1054da2d10777e375838191070
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 32355
+  timestamp: 1692205784293
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+  sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
+  md5: 8a35ad65651086575ce55371f22feda8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91045
+  timestamp: 1659455316472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+  sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
+  md5: 186eb95f816a2eff80c3c7f7d964c7b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 578514
+  timestamp: 1672388155359
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+  sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
+  md5: 47b6cbe6ce9289e47d16900b03596a91
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372807
+  timestamp: 1656431445633
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-11.0.0-py39h790e06d_1.tar.bz2
+  sha256: 5b6ad360ec3b29619cd455bde021aa306fa193e86ae00cecd34a2852fd03417d
+  md5: 15298793035b738648140239b6d2a295
+  depends:
+  - arrow-cpp >=11.0.0,<11.0.1.0a0
+  - boost-cpp
+  - gflags
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3673822
+  timestamp: 1693273731311
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+  sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
+  md5: 07165c444adc7c7ccc8a345875adc5ef
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48408
+  timestamp: 1675450623287
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+  sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
+  md5: d58e76a31e2f6e7410ba4afd7f385b0d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1877445
+  timestamp: 1684280183367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+  sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
+  md5: 0e5b0fe7debbf558ce97090f6b67cdae
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94633
+  timestamp: 1690225630423
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+  sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
+  md5: 0fde797653e4ab589506121fb1e37555
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157119
+  timestamp: 1661452591647
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+  sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
+  md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 92679
+  timestamp: 1636093365041
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+  sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
+  md5: f870859d4dc7a8d82cf3546bd9035f33
+  depends:
+  - python >=3.9,<3.10.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 54520
+  timestamp: 1605307564142
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+  sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
+  md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
+  depends:
+  - openssl >=3.0.10,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 21172845
+  timestamp: 1694442462066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+  sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
+  md5: 9d99075052265ae3d718582d3b875038
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269964
+  timestamp: 1661376543480
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py39hd77b12b_0.tar.bz2
+  sha256: 8b6a4065775dced4e05e655b2cc3a59e5dd70f3c081e0d37e6f65073cb2e2b43
+  md5: 7c7beb23a7b73c5797a1ab69ab124cd7
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 135726
+  timestamp: 1682522544682
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+  sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
+  md5: fa9074d94236c9b768bfd2c858875b27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 264836
+  timestamp: 1695131770282
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+  sha256: 97243a31c39f4990c0e9d4f2307f2f7fb9421553303923bc105067ec4340bdff
+  md5: 8078c5760f27398eaf1082226647d137
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40145
+  timestamp: 1685031143383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+  sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
+  md5: 3d2841085778006c2e79f9c7300f8b9d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13565975
+  timestamp: 1669937633869
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+  sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
+  md5: 54a4bc0724041dd173088419d6ede2af
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 239062
+  timestamp: 1677611495106
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+  sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
+  md5: f39f84115e228bad4bceaefdd637f022
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 158558
+  timestamp: 1698096358091
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+  sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
+  md5: df398a3a1668fd2a22061764e20ea91d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.4,<4.3.5.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 460913
+  timestamp: 1657616061604
+- conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+  sha256: 720f3dd1f933d035b1393951ffd1b6437fc5e19b1999e74096044514a46053fb
+  md5: add2dfb15b518144663fc3b897d66da7
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  size: 493391
+  timestamp: 1652432364793
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+  sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
+  md5: 38db77ece9dc76feffb9ef7638e38258
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94397
+  timestamp: 1690400496655
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+  sha256: 3a9a680173f731d515e0587d5b74583cc986b5c1ff62f4cf9e4f7ec268cbb62a
+  md5: 3387bf809e3d32dde3f5cbc3ef49bf47
+  depends:
+  - blas 1.0 mkl
+  - icc_rt >=2022.1.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<1.28
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22779707
+  timestamp: 1696550432358
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+  sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
+  md5: 3e284ae6b48ee30c364ffdc5601610b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1099842
+  timestamp: 1690291374842
+- conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.1.9-h6c2663c_0.tar.bz2
+  sha256: 25c1b4224f5d7d767d4adfe0384d585e9b3935464be3efff3120059308d9747c
+  md5: faac387845d33d194eeb7d5a3d962ea5
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 6506572
+  timestamp: 1649924235781
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+  sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
+  md5: 993b3886b334bd1f49d34206f21997b4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15998
+  timestamp: 1614030572433
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+  sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
+  md5: 7ac9604ad7564ac0c71bff5db198656f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67012
+  timestamp: 1696347795139
+- conda: https://repo.anaconda.com/pkgs/main/win-64/spatialpandas-0.4.9-py39haa95532_0.tar.bz2
+  sha256: dc8df02a3e1f24da2488db1ef7b51acd9fef6095b6a72448f6be6c255e56c7df
+  md5: a0c2b87355560c900494debb9e2fe4d8
+  depends:
+  - dask-core
+  - fsspec
+  - numba
+  - pandas
+  - param
+  - pyarrow >=1.0
+  - python >=3.9,<3.10.0a0
+  - retrying
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 148206
+  timestamp: 1695247775159
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+  sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
+  md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1311308
+  timestamp: 1681402905668
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+  sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
+  md5: 28b9869d8d3a839918fac4a08f38cbc2
+  depends:
+  - python >=3.9,<3.10.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30546
+  timestamp: 1671752127904
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+  sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
+  md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39590
+  timestamp: 1668168880994
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+  sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
+  md5: 52cdcdb96383c010ca833a7c24b3935b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Tcl/Tk
+  license_family: BSD
+  size: 3690152
+  timestamp: 1654036853710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
+  sha256: 1ee791ecc17e11a31d6cf1553845e7279d9d9a2c7383a2a3e1ae131ddd024b6f
+  md5: b32030d310e0437dc631e5719369004c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102033
+  timestamp: 1667464306003
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+  sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
+  md5: 0e054ab29119cf4c1f778613acf972f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 681780
+  timestamp: 1696937326924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+  sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
+  md5: b6ad839ebba536ad1c3cc58d0e2123f0
+  depends:
+  - colorama
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 143681
+  timestamp: 1679562248929
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+  sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
+  md5: fe78de10019085146f1cc6c94fdc2620
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192822
+  timestamp: 1671143999327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
+  md5: ca5fc3fbdb09b6de068a8b7a8869369f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9208
+  timestamp: 1690298120549
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
+  md5: a86e87a10e5fdff486265e0c675fb99f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57922
+  timestamp: 1690298106990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+  sha256: 8057d3d2a0acd44496de33c5b222063c3f7d06b90c74fbbda45bd18b0b324219
+  md5: 398f8db5bd8cab84b3d85a9d85fa4889
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11362
+  timestamp: 1659769459206
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+  sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
+  md5: 0d31859e0a097aedbcc1627db33b3d92
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188367
+  timestamp: 1698257883295
+- conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_0.tar.bz2
+  sha256: 3090678ff796558a51d0d7628d07d792f0d7364a863e57e716d9d05dbf3032eb
+  md5: 150c8148017ae3461951cc919e317f92
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 315993
+  timestamp: 1611836198527
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+  sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
+  md5: 45ef24c486a484f079faf1dc90e4c7e9
+  depends:
+  - vs2015_runtime >=14.27.29016
+  license: Modified BSD License (3-clause)
+  license_family: BSD
+  size: 8277
+  timestamp: 1605602889180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+  sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
+  md5: 4daaceb6cfc1af6274509081d8018ef1
+  size: 2316783
+  timestamp: 1605602872095
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+  sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
+  md5: 916c16904615c7af3b5d37cb6694f45e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21084
+  timestamp: 1607347371925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+  sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
+  md5: da69e6987fcc757e83a358ceaa13f62b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73391
+  timestamp: 1614804425587
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+  sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
+  md5: 23b9f4634b2e5450be617114f62c74f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 120873
+  timestamp: 1695742300539
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+  sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
+  md5: 120f0b088290fc17bd6618fc10a2f0c4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PUBLIC-DOMAIN
+  size: 34293
+  timestamp: 1605306211299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
+  sha256: 6bdb88cd45b22246e84b7400159ca90faf98ab4e8c1fa2d38d031cfc73c4dc13
+  md5: d6e10641ece06f67561c5f6a676a4b7e
+  depends:
+  - numpy >=1.21,<2.0a0
+  - packaging >=21.3
+  - pandas >=1.4
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1794729
+  timestamp: 1689041580510
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+  sha256: a5d2a216d052105fdaad7256f23da3b29f95100d1dc0f29b6ab1f3bbc75e17a9
+  md5: a558f681ebc243f86cde2515c065b62e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48805
+  timestamp: 1675159123654
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+  sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
+  md5: c3f7871e9a33adeccee1b1e8e216918e
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 1332571
+  timestamp: 1683113347814
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+  sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
+  md5: 1ab55f8c4b5292ec360c572120bf823e
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-3.0-or-later
+  size: 9430705
+  timestamp: 1616055773485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py39haa95532_0.tar.bz2
+  sha256: 556bdf23786b69d1699aa1313fac43589cd33f8c62b701259e0f71c52343b59a
+  md5: 7bbafad85b6da7514e895923f3af7f5a
+  depends:
+  - heapdict
+  - python >=3.9,<3.10.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 76800
+  timestamp: 1695832961240
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+  sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
+  md5: 6875e0bf3828707dc9165d694c0d0a7d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18725
+  timestamp: 1672387612937
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+  sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
+  md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 148931
+  timestamp: 1666595229032
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+  sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
+  md5: 8d6a1e767775fe0eb617cd6e22edc2ff
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1871867
+  timestamp: 1681304638261

--- a/ship_traffic/pixi.lock
+++ b/ship_traffic/pixi.lock
@@ -7,875 +7,875 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-11.0.0-h374c478_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.6.8-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.1.6-h6a678d5_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.11-h5eee18b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.8.185-h721c034_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.2.1-py39h2f386ee_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39hdda0065_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.0-py39h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-2023.6.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2023.6.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-he6710b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h2531618_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/grpc-cpp-1.48.2-he1ff14a_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.4.0-h251f7ec_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20221030-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-hdbd6064_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.10.4-hf1b16e4_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.37-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.41.0-py39he621ea3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.9.3-py39hdbbb534_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py39h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py39hd09550d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.58.0-py39h1128e8f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.25.2-py39h5f9d8c6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.25.2-py39hb5e798b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.12-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.1.1-py39h1128e8f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.2.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-11.0.0-py39h468efa6_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.18-h955ad1f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py39h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.11.3-py39h5f9d8c6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.1.9-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/spatialpandas-0.4.9-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h27cfd23_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/arrow-cpp-11.0.0-h374c478_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-common-0.6.8-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-event-stream-0.1.6-h6a678d5_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-checksums-0.1.11-h5eee18b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-sdk-cpp-1.8.185-h721c034_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-3.2.1-py39h2f386ee_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39hdda0065_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cytoolz-0.12.0-py39h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dask-2023.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/distributed-2023.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gflags-2.2.2-he6710b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/glog-0.5.0-h2531618_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/grpc-cpp-1.48.2-he1ff14a_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.18.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libcurl-8.4.0-h251f7ec_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20221030-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libssh2-1.10.0-hdbd6064_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxml2-2.10.4-hf1b16e4_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.37-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.41.0-py39he621ea3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lxml-4.9.3-py39hdbbb534_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-4.3.2-py39h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/msgpack-python-1.0.3-py39hd09550d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numba-0.58.0-py39h1128e8f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.25.2-py39h5f9d8c6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.25.2-py39hb5e798b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.12-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-2.1.1-py39h1128e8f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-1.2.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyarrow-11.0.0-py39h468efa6_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.9.18-h955ad1f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-lmdb-1.4.1-py39h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scipy-1.11.3-py39h5f9d8c6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/snappy-1.1.9-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/spatialpandas-0.4.9-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/utf8proc-2.6.1-h27cfd23_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zict-3.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/abseil-cpp-20230802.0-h61975a4_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-11.0.0-h89a8245_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.6.8-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.1.6-hcec6c5f_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.11-h6c40b1e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.8.185-h1a8d504_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-2023.6.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2023.6.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-h0a44026_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/grpc-cpp-1.48.2-hbe2b35a_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gtest-1.14.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.4.0-hf20ceda_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20221030-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-h04015c4_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-4.3.2-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py39haf03e11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.12-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-1.7.4-h995b336_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-11.0.0-py39he65a03e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.1.9-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/spatialpandas-0.4.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h9ed2024_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/abseil-cpp-20230802.0-h61975a4_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/arrow-cpp-11.0.0-h89a8245_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-common-0.6.8-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-event-stream-0.1.6-hcec6c5f_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-checksums-0.1.11-h6c40b1e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-sdk-cpp-1.8.185-h1a8d504_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cytoolz-0.12.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/dask-2023.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/distributed-2023.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/gflags-2.2.2-h0a44026_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/glog-0.5.0-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/grpc-cpp-1.48.2-hbe2b35a_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/gtest-1.14.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcurl-8.4.0-hf20ceda_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libedit-3.1.20221030-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libssh2-1.10.0-h04015c4_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-4.3.2-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/msgpack-python-1.0.3-py39haf03e11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.12-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/orc-1.7.4-h995b336_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyarrow-11.0.0-py39he65a03e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-lmdb-1.4.1-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/snappy-1.1.9-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/spatialpandas-0.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/utf8proc-2.6.1-h9ed2024_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zict-3.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/abseil-cpp-20230802.0-h313beb8_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-11.0.0-hc7aafb3_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.6.8-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.1.6-h313beb8_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.11-h80987f9_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.8.185-ha71a6ea_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-2023.6.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2023.6.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpc-cpp-1.48.2-hc60591f_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gtest-1.14.0-h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.4.0-h3e2b118_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20221030-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h02f6b3c_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.3.2-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py39h525c30c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.12-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-11.0.0-py39hbfed03b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.1.9-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/spatialpandas-0.4.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/abseil-cpp-20230802.0-h313beb8_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/arrow-cpp-11.0.0-hc7aafb3_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-common-0.6.8-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-event-stream-0.1.6-h313beb8_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-checksums-0.1.11-h80987f9_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-sdk-cpp-1.8.185-ha71a6ea_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cytoolz-0.12.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/dask-2023.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/distributed-2023.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/gflags-2.2.2-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/glog-0.5.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/grpc-cpp-1.48.2-hc60591f_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/gtest-1.14.0-h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcurl-8.4.0-h3e2b118_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libedit-3.1.20221030-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libssh2-1.10.0-h02f6b3c_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-4.3.2-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/msgpack-python-1.0.3-py39h525c30c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.12-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyarrow-11.0.0-py39hbfed03b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-lmdb-1.4.1-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/snappy-1.1.9-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/spatialpandas-0.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/utf8proc-2.6.1-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zict-3.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-11.0.0-ha81ea56_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.6.8-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.1.6-hd77b12b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.11-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.8.185-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-2023.6.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2023.6.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-ha925a31_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/grpc-cpp-1.48.2-hfe90ff0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.1.1-h86230a5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-he2ea4bf_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.3.2-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.12-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-11.0.0-py39h790e06d_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.1.9-h6c2663c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/spatialpandas-0.4.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/arrow-cpp-11.0.0-ha81ea56_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-common-0.6.8-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-event-stream-0.1.6-hd77b12b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-checksums-0.1.11-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-sdk-cpp-1.8.185-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cytoolz-0.12.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/dask-2023.6.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/distributed-2023.6.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/gflags-2.2.2-ha925a31_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/glog-0.5.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/grpc-cpp-1.48.2-hfe90ff0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libcurl-8.1.1-h86230a5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libssh2-1.10.0-he2ea4bf_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-4.3.2-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/msgpack-python-1.0.3-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.12-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyarrow-11.0.0-py39h790e06d_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-lmdb-1.4.1-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/snappy-1.1.9-h6c2663c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/spatialpandas-0.4.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/utf8proc-2.6.1-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zict-3.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
   sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
   md5: 613805add1c05b538ff06d217252feb7
   depends:
@@ -886,7 +886,7 @@ packages:
   license: BSD-3-Clause
   size: 20810
   timestamp: 1652859733309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/abseil-cpp-20211102.0-hd4dd3e8_0.tar.bz2
   sha256: 8762f481244fb151a200f01dd70e69c77171a3ee0f7f4c130e8e95b6a1626a68
   md5: c3707fcd2efa582afc5c7e1986c6ce48
   depends:
@@ -896,7 +896,7 @@ packages:
   license_family: Apache
   size: 1135866
   timestamp: 1652382888447
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
   sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
   md5: 2cf39d906cc321896ffe3e5d33d80c5c
   depends:
@@ -909,7 +909,7 @@ packages:
   license_family: MIT
   size: 162166
   timestamp: 1644463608931
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
   sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
   md5: 2972a84e0e22ae3244bbd2f1eebcf536
   depends:
@@ -920,7 +920,7 @@ packages:
   license_family: MIT
   size: 35352
   timestamp: 1644569715988
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-11.0.0-h374c478_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/arrow-cpp-11.0.0-h374c478_2.tar.bz2
   sha256: d4800b8aedf8fbd9b2ea0d8326144a8dfc6f54a20b0fe8cf4c07b09b931b7c7c
   md5: c907d45aa4355477499984b4afaf1ea6
   depends:
@@ -949,7 +949,7 @@ packages:
   license_family: Apache
   size: 11652427
   timestamp: 1693264125605
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
   sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
   md5: a68016b4b06460def24cb69d932986f3
   depends:
@@ -958,7 +958,7 @@ packages:
   license_family: MIT
   size: 132486
   timestamp: 1695717963702
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.6.8-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-common-0.6.8-h5eee18b_1.tar.bz2
   sha256: 1ce66314d08e9e942891e9de722b0881ae366eddda92ce5531dd405b61a0c66f
   md5: e9c686e865033b3258219d863b17d318
   depends:
@@ -967,7 +967,7 @@ packages:
   license_family: Apache
   size: 172946
   timestamp: 1685977805041
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.1.6-h6a678d5_6.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-event-stream-0.1.6-h6a678d5_6.tar.bz2
   sha256: e6b4b9a4d81eb8c6050a08000df32f9158811e5b4a4379f3c3c14c1db9b94ba3
   md5: 3943c28b998aa149a38724f9ce8c3f41
   depends:
@@ -979,7 +979,7 @@ packages:
   license_family: Apache
   size: 25977
   timestamp: 1685999011516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.11-h5eee18b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-checksums-0.1.11-h5eee18b_2.tar.bz2
   sha256: 4b5623e05f4b9756739c109bcbcdd95c4fa3888fe3402e5cc9e15d40f37d7881
   md5: fa9ebd6fddf05d571aba2ee50266cbcb
   depends:
@@ -989,7 +989,7 @@ packages:
   license_family: Apache
   size: 51973
   timestamp: 1685994640393
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.8.185-h721c034_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-sdk-cpp-1.8.185-h721c034_1.tar.bz2
   sha256: 703ed4542bb40bb4daac768505521395605ac32b1b383c43d7e59c224ae010ad
   md5: 2b02ca97a26097b453f8ef956081fc43
   depends:
@@ -1004,7 +1004,7 @@ packages:
   license_family: Apache
   size: 2528606
   timestamp: 1686057539519
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
   sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
   md5: 2f6356a2f530314b4059c08c79a3d8bc
   depends:
@@ -1014,12 +1014,12 @@ packages:
   license_family: MIT
   size: 205868
   timestamp: 1681493113570
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.2.1-py39h2f386ee_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-3.2.1-py39h2f386ee_0.tar.bz2
   sha256: e6f5db63551cd4edaaeb2e7b9e8eb0ceec1e2370d5e1c469bffbcd2584ecea4e
   md5: 4854bd2f4f65a8f30a5127a07d44cbe0
   depends:
@@ -1037,7 +1037,7 @@ packages:
   license_family: BSD
   size: 6483397
   timestamp: 1690546140960
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
   sha256: 3606c8607c29229222667f66421f79df167d33043fe9245cdd4e2c4520ecc721
   md5: eca33dcef14fa044193e43492dca8585
   depends:
@@ -1048,7 +1048,7 @@ packages:
   license_family: OTHER
   size: 10768
   timestamp: 1696762269985
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
   sha256: 20e381c665853131fc5c9a397b1d4b05bb05859a2bdfbb0559e85ec445ee9e7c
   md5: 14dc3c2e8eb68b1111a08de9a3ce8a00
   depends:
@@ -1059,7 +1059,7 @@ packages:
   license_family: BSD
   size: 128656
   timestamp: 1657175966755
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
   sha256: 11df9b719339bb40e4af8eb124a094def217f64e2440af973d7342da19c030b0
   md5: 712827b1699cc71e6240626c413408f3
   depends:
@@ -1070,7 +1070,7 @@ packages:
   license: MIT
   size: 18907
   timestamp: 1659616178155
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
   sha256: 6408b6849347ef01f5ed170f4b35fb4bdfed2d9cf9da4912a4b104a810518a80
   md5: d9d570587ccfd7158b66feb823c990c6
   depends:
@@ -1080,7 +1080,7 @@ packages:
   license: MIT
   size: 19933
   timestamp: 1659616170430
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
   sha256: 8507df3357958556aff2dea8788a3f7ddad6172fd9fe5d1bdb6c3afe9686d2f8
   md5: f0204f72bcd9ef836218cc74345e69f2
   depends:
@@ -1090,7 +1090,7 @@ packages:
   license: MIT
   size: 362180
   timestamp: 1659616255400
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h7b6447c_0.tar.bz2
   sha256: 168c2fc4d5899ee70e85fadc998e00827e1b856a6fc4a402ed465cd7c320d19f
   md5: f52e60deb7f4c82821be9a868e889348
   depends:
@@ -1099,7 +1099,7 @@ packages:
   license_family: BSD
   size: 107105
   timestamp: 1563219611337
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
   sha256: 5b4c80587ae4ec915505469f79d866f27c80456156667c8548d31c67c2c1653e
   md5: c3d6bfae757760082261779c406a880d
   depends:
@@ -1108,14 +1108,14 @@ packages:
   license_family: MIT
   size: 116270
   timestamp: 1693902021950
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
   sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
   md5: 3ef00f4c5278b688552efc259c463dc8
   license: MPL-2.0
   license_family: Other
   size: 132731
   timestamp: 1694009767372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
   sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
   md5: d5cb3d97cf5e85ffe5e94037ed8a1169
   depends:
@@ -1124,7 +1124,7 @@ packages:
   license_family: Other
   size: 159077
   timestamp: 1690232254640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
   sha256: e99314f8809d65195dcab68a9783f70fbe990113a66c98c9b0a7ffea01226b71
   md5: fff69f95079191a10e099b21a5fd4bc3
   depends:
@@ -1136,7 +1136,7 @@ packages:
   license_family: MIT
   size: 234749
   timestamp: 1670423281079
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py39h06a4308_0.tar.bz2
   sha256: 762f4506c3e12b2332bd9abea3a2a1966f307b2673be7fd661dc6e316602d18b
   md5: 4b8df5459d1762495428323753438641
   depends:
@@ -1145,7 +1145,7 @@ packages:
   license_family: BSD
   size: 151844
   timestamp: 1698129872673
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cloudpickle-2.2.1-py39h06a4308_0.tar.bz2
   sha256: 4fd0207b930fbc936d4b8206117cfa9792aa19bfb320eb08aab6bba10002f9ee
   md5: 7082a1ce8fa314cc2761d2f689c6bb9e
   depends:
@@ -1154,7 +1154,7 @@ packages:
   license_family: BSD
   size: 40456
   timestamp: 1683040035572
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
   sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
   md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
   depends:
@@ -1164,7 +1164,7 @@ packages:
   license_family: CC
   size: 1917831
   timestamp: 1668084545510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
   sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
   md5: 13702d3b4b744784e5bd559c7050dd6f
   depends:
@@ -1174,7 +1174,7 @@ packages:
   license_family: BSD
   size: 12719
   timestamp: 1671231205875
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
   sha256: 0b1a9a25ddfc6631390c53d6ee95706eaab0805c5a9a8d748c08120a1f421256
   md5: a93581f810ef522bd23c148195591157
   depends:
@@ -1186,7 +1186,7 @@ packages:
   license_family: BSD
   size: 234846
   timestamp: 1663827645102
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39hdda0065_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39hdda0065_0.tar.bz2
   sha256: 6a08c501a310e5e482df8e917a7b0cd438e83f33a44aaec49c2ab53eeda5ebf1
   md5: 3f8c39c0ce002faf6719b8d2d5f31941
   depends:
@@ -1200,7 +1200,7 @@ packages:
   license_family: BSD
   size: 2181966
   timestamp: 1694444647708
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-0.12.0-py39h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cytoolz-0.12.0-py39h5eee18b_0.tar.bz2
   sha256: aac94702b3d4e4767f0bbbe3f1acfa811e18a2abb66f3afac74a51ddc3d046d9
   md5: 4c34345079d18b1203746067dcd15042
   depends:
@@ -1211,7 +1211,7 @@ packages:
   license_family: BSD
   size: 394960
   timestamp: 1667466037849
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-2023.6.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dask-2023.6.0-py39h06a4308_0.tar.bz2
   sha256: f17cae7cee82184f8ecdb8f1b42bd0dc9d1d76fb19ea4febdabcfcb1397ad025
   md5: 2fe097998562477a3131010972f1d649
   depends:
@@ -1229,7 +1229,7 @@ packages:
   license_family: BSD
   size: 5234
   timestamp: 1687284923315
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dask-core-2023.6.0-py39h06a4308_0.tar.bz2
   sha256: 2084ad037e4b67a158facc0d1b21d1de16df7fe758e2bf08f6e48c6b75626cb8
   md5: 8bb8a915dda236f7a2cf790490983445
   depends:
@@ -1246,7 +1246,7 @@ packages:
   license_family: BSD
   size: 2121644
   timestamp: 1686782977519
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/datashader-0.15.2-py39h06a4308_0.tar.bz2
   sha256: 161644f5f183f5632806cb2cb31890d06a1a575bed7949fe11bc59d3d4344e9d
   md5: 96baa11147a42b64dcaa233a1733b8ee
   depends:
@@ -1268,7 +1268,7 @@ packages:
   license_family: BSD
   size: 17667549
   timestamp: 1692372404139
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/datashape-0.5.4-py39h06a4308_1.tar.bz2
   sha256: 80188a9729a26e36b027e673f5f30395798eb68f9fe4721f3f33b4d4d2e58285
   md5: 686db307602cbbdc30ca7d62b765578b
   depends:
@@ -1280,7 +1280,7 @@ packages:
   license_family: BSD
   size: 103488
   timestamp: 1613390248313
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
   sha256: 96b5d4c87d8467ae6ba92f9c17eaa9e059b6f7e9b8ee57aee788885c7413078b
   md5: 9868912fd269f4d9d6423cfe69560131
   depends:
@@ -1291,7 +1291,7 @@ packages:
   license_family: MIT
   size: 2164334
   timestamp: 1690905228819
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2023.6.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/distributed-2023.6.0-py39h06a4308_0.tar.bz2
   sha256: 5223d52058a7f4de043e7f8d3b03163626a4da7a8b0b7f3ab1403c23ad20173c
   md5: 1d6b6b067820cf7078380495d5b8cbe9
   depends:
@@ -1315,7 +1315,7 @@ packages:
   license_family: BSD
   size: 1390378
   timestamp: 1686866113775
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
   sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
   md5: 2e6ec51066d825ef3c317abe78d6049e
   depends:
@@ -1324,7 +1324,7 @@ packages:
   license_family: MIT
   size: 16413
   timestamp: 1649926472708
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
   sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
   md5: b4d923222d45314856b5378cb115214d
   depends:
@@ -1333,7 +1333,7 @@ packages:
   license_family: BSD
   size: 26728
   timestamp: 1668714462023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
   sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
   md5: a5dc8677d891dff2393b63189a3ad42f
   depends:
@@ -1344,7 +1344,7 @@ packages:
   license_family: Other
   size: 971975
   timestamp: 1666798278693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fsspec-2023.9.2-py39h06a4308_0.tar.bz2
   sha256: cfef2f1f3f1aa159f87806b7fa2b65c02c0d6f9bd24ccda833b43246c5095be6
   md5: 394ec1374a92c6fd5f772343934337e4
   depends:
@@ -1353,7 +1353,7 @@ packages:
   license_family: BSD
   size: 260575
   timestamp: 1695734561396
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-he6710b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/gflags-2.2.2-he6710b0_0.tar.bz2
   sha256: bb154050063e427d00f261baa1e7884a0a2db54d57791322048296439147a89a
   md5: bcb2fff3ff80e0466eb2dafc93f88fa1
   depends:
@@ -1363,7 +1363,7 @@ packages:
   license_family: BSD
   size: 164178
   timestamp: 1542388351673
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
   sha256: c323a9800a358c178f6f3b8860bbb77c373fbc3be981bb6420175fbb5431adf5
   md5: 6485f51176cf651b3b28c3548cef10ad
   depends:
@@ -1372,7 +1372,7 @@ packages:
   license_family: MIT
   size: 78533
   timestamp: 1676983203797
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h2531618_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/glog-0.5.0-h2531618_0.tar.bz2
   sha256: cb4410750b5d94bd1a75e6dff662e4192481d0f5fd53dcbfa5853e21d20b20c8
   md5: bfbf6dcde0288f43857e8371087e81da
   depends:
@@ -1382,7 +1382,7 @@ packages:
   license: BSD-3-Clause
   size: 108274
   timestamp: 1620732909459
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/grpc-cpp-1.48.2-he1ff14a_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/grpc-cpp-1.48.2-he1ff14a_1.tar.bz2
   sha256: 32657e2d11dd813e5649f714c7f58115cff3387f27cf0904cee873bd0d82d2a4
   md5: bdfb8214247977e4ededa4aeb3291ea3
   depends:
@@ -1400,7 +1400,7 @@ packages:
   license_family: APACHE
   size: 5391101
   timestamp: 1685747457305
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.18.0-py39h06a4308_0.tar.bz2
   sha256: 6d934b1d532f644e148bcf51f9c8d0c7623e832fd29282bc6c4cb64b9e027884
   md5: b18725efd77d3fb6c9addf81dac09081
   depends:
@@ -1417,7 +1417,7 @@ packages:
   license_family: BSD
   size: 4576699
   timestamp: 1698866790345
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
   sha256: b35b281dbf69b826c6ae04fcd7b6a2d1f098277a669a199906a1f23b4b0931a5
   md5: 2a793fe24f85aa5819fe69c450cba6f7
   depends:
@@ -1427,7 +1427,7 @@ packages:
   license_family: MIT
   size: 29021241
   timestamp: 1692293243228
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
   sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
   md5: 1eb52f9f45cea2fb9ce27b19f990160e
   depends:
@@ -1436,7 +1436,7 @@ packages:
   license_family: BSD
   size: 110793
   timestamp: 1666125606878
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
   sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
   md5: 126b3c1933b7364ff03f67455b687e99
   depends:
@@ -1446,7 +1446,7 @@ packages:
   license_family: APACHE
   size: 37588
   timestamp: 1678997134023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
   sha256: b6d5f6098903e5edfbc2200282efa186d446442d47ab75f51ff22c30ae0c4da4
   md5: e53a806995cedc9e5d8a96e03c9e79ac
   depends:
@@ -1456,7 +1456,7 @@ packages:
   license_family: Apache
   size: 50699
   timestamp: 1698254665788
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
   sha256: bddc8de31272a509510cc87e5ac0cdb0e7765d393ca7bdfddbfe4123979a9413
   md5: bc8a501970aadad3373edbce996b5fdf
   depends:
@@ -1472,7 +1472,7 @@ packages:
   license_family: Proprietary
   size: 19286333
   timestamp: 1681801301379
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
   sha256: c0d0714c68ed953740812688ac1b3c3e286de33b55d49f02953d705fb00c30d0
   md5: 8b65eea396159a3b59278f77c81ddd1b
   depends:
@@ -1493,7 +1493,7 @@ packages:
   license_family: BSD
   size: 217268
   timestamp: 1691122070319
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
   sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
   md5: ff47e0be879e817713ce2a9daa76e2b0
   depends:
@@ -1514,7 +1514,7 @@ packages:
   license_family: BSD
   size: 1261116
   timestamp: 1694181530670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
   sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
   md5: 5ef6c6a0d1ac79143c7359d305155167
   depends:
@@ -1524,7 +1524,7 @@ packages:
   license_family: MIT
   size: 1021637
   timestamp: 1644297140650
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
   sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
   md5: eaeb023688f781e7dd89e74310c38195
   depends:
@@ -1534,7 +1534,7 @@ packages:
   license_family: BSD
   size: 211775
   timestamp: 1666908212136
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
   sha256: c21f8f407266d039e819c27fe9eb4fb26587e974f3bd059b37cbaec5073722d0
   md5: ba1f47411e9e07876c7a3e9d3be6a98e
   depends:
@@ -1543,7 +1543,7 @@ packages:
   license_family: Other
   size: 281400
   timestamp: 1677849152168
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
   sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
   md5: 0d2c3c5edf671b575532d5a3e8bf15fc
   depends:
@@ -1554,7 +1554,7 @@ packages:
   license_family: MIT
   size: 131510
   timestamp: 1676558716852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
   sha256: 4ba1f5698f0b483af397021b2047554afb3129790cac3a1502c79693154331d2
   md5: 8e9c0ef4b0b57caa87c146892e56a313
   depends:
@@ -1570,7 +1570,7 @@ packages:
   license_family: BSD
   size: 192921
   timestamp: 1676329415827
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.5.0-py39h06a4308_0.tar.bz2
   sha256: b791f2f86fe1993ddfcd10a80a92fb098c2b4792f0ce13da9269cac6b3647d0b
   md5: ac7c5e38691312d195fdd1f23b33f779
   depends:
@@ -1581,7 +1581,7 @@ packages:
   license_family: BSD
   size: 78853
   timestamp: 1698937381669
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
   sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
   md5: a4beb461f0a60998a090d760b5c6c907
   depends:
@@ -1605,7 +1605,7 @@ packages:
   license_family: BSD
   size: 411564
   timestamp: 1671707702849
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
   sha256: 6d6c384c9c65e33d5d047e01131e0687eb2bc1e5a4a67f80af3c0b773c1bba82
   md5: 07957e1d2fb6a407f7d7293b84938e1e
   depends:
@@ -1616,7 +1616,7 @@ packages:
   license_family: BSD
   size: 77689
   timestamp: 1672387301020
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
   sha256: 01bae3dd44469e34f043e0416f5f5e658429bf4031745399d9968d10b899e2c4
   md5: 10171cca67e3d73c3646c6dc5a321460
   depends:
@@ -1628,7 +1628,7 @@ packages:
   license_family: MIT
   size: 1427115
   timestamp: 1686931095252
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -1639,7 +1639,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
   sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
   md5: 9508af80612e4fa1b5d1abb43ca7e63c
   constrains:
@@ -1647,7 +1647,7 @@ packages:
   license: GPL-3.0-only
   size: 749072
   timestamp: 1652971360657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
   sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
   md5: 88199c75f2ac211728febced7785c24e
   depends:
@@ -1657,7 +1657,7 @@ packages:
   license_family: Apache
   size: 228278
   timestamp: 1635523146417
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
   sha256: e2754627e8aeb98777318939e6773b9eadbdc219dd8961aca946354d9d30f481
   md5: 4ed89646229bee3e594cd2cc8f6060f9
   depends:
@@ -1672,7 +1672,7 @@ packages:
   license_family: OTHER
   size: 23778916
   timestamp: 1696762223408
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
   sha256: 472cf888db65d00451fcd5fccd5244d55c061e8d7efe43f70220414ef64521a5
   md5: 787927eff72e62c270f614cbcba9479c
   depends:
@@ -1680,7 +1680,7 @@ packages:
   license: MIT
   size: 67109
   timestamp: 1659616145972
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
   sha256: 19a43182ca343510ba51baa0fce91d64c840a19cdf13c6dde4e03e819c70897e
   md5: c0608d376a30b5aa4d2f2c22978135db
   depends:
@@ -1689,7 +1689,7 @@ packages:
   license: MIT
   size: 34691
   timestamp: 1659616154057
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
   sha256: 158c401aa0bab05aa5f4134aea798085e4e3849209946f896cca352930d2225d
   md5: cc6a6d362912a2d112310bd3f8acd44e
   depends:
@@ -1698,7 +1698,7 @@ packages:
   license: MIT
   size: 295287
   timestamp: 1659616162282
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.4.0-h251f7ec_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libcurl-8.4.0-h251f7ec_0.tar.bz2
   sha256: ba5af576db57611030cfcfaca376b08c417ef7ee5dbe065710d64aaca30748f5
   md5: 1a56ed5ad456aa2d140fc69dc862cfe0
   depends:
@@ -1714,7 +1714,7 @@ packages:
   license_family: MIT
   size: 396955
   timestamp: 1697023405523
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
   sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
   md5: 55dde57e63a36b202e388a39dcee9a66
   depends:
@@ -1723,7 +1723,7 @@ packages:
   license_family: MIT
   size: 74096
   timestamp: 1695996494461
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20221030-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20221030-h5eee18b_0.tar.bz2
   sha256: 5d66a60672f8e7dd0c048b5f158b5d406f16133b260ffde95a93eb453a1e7af9
   md5: af7584851084abae8eaa8cee2ed288b4
   depends:
@@ -1733,7 +1733,7 @@ packages:
   license_family: BSD
   size: 195621
   timestamp: 1670840131081
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
   sha256: efdab884c85fda4461f7a393aa6d4e0e50d03cb59fb9c8a980b1307b8379ebe0
   md5: eeca774c6154c49340dd403b1928d5e9
   depends:
@@ -1742,7 +1742,7 @@ packages:
   license_family: BSD
   size: 108906
   timestamp: 1632891483341
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
   sha256: 4b2518a1aa3859031a531cd1077e8a60d5b3a0dc7c83210ef27ff9ce2c78c3e3
   md5: 49f152ee4045544c10799d32bba85c07
   depends:
@@ -1753,7 +1753,7 @@ packages:
   license_family: BSD
   size: 480247
   timestamp: 1685052130829
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
   sha256: ec1c6341cf0091b55be05285037cb3fbba90573e00257f383ab274d8b8e6d46f
   md5: 32ac65d639d6c155ea7276cadf1fd2b6
   depends:
@@ -1763,7 +1763,7 @@ packages:
   license_family: MIT
   size: 147907
   timestamp: 1683716564178
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
   sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
   md5: 641e72e5067bd6d5454405879e1cd2a7
   depends:
@@ -1778,7 +1778,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 8895144
   timestamp: 1654090827491
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
   sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
   md5: 27082517590f3b9fbffecc68513b461b
   depends:
@@ -1787,7 +1787,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 19860
   timestamp: 1654090819660
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
   sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
   md5: 0202c3c8ae4735cac6c7f3d1e1685964
   constrains:
@@ -1795,7 +1795,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 5228750
   timestamp: 1654090762569
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
   sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
   md5: 3080c2813e6e1d0f8a100a38b5b3456d
   depends:
@@ -1803,7 +1803,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 573231
   timestamp: 1654090775721
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
   sha256: 512fac06ddd97b4383503d4fbd8145102966055b29ccf86841a930dbb4ef3ab8
   md5: 833c0e514ff9c8ae0511630b024d60e0
   depends:
@@ -1816,7 +1816,7 @@ packages:
   license_family: Apache
   size: 37179832
   timestamp: 1683292829131
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
   sha256: 6c67d781d3c074ae46b18567f230bce4a4afa209e8b914dc2cb448502774886e
   md5: c9627c386bbc8a1a1a0a2e736ea44501
   depends:
@@ -1832,7 +1832,7 @@ packages:
   license_family: MIT
   size: 722387
   timestamp: 1697018420830
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
   sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
   md5: 1bffe1481ed4f88827248fb9001f8923
   depends:
@@ -1842,7 +1842,7 @@ packages:
   license_family: Other
   size: 362561
   timestamp: 1677841789536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libprotobuf-3.20.3-he621ea3_0.tar.bz2
   sha256: a24f7d1cdb5e18466a61860a5a66baffd608e212bbfed2935350e83d4d8659c0
   md5: b32a43de76bc9be9c71f9a12edec8a1e
   depends:
@@ -1853,7 +1853,7 @@ packages:
   license_family: BSD
   size: 2706964
   timestamp: 1675278653314
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -1861,7 +1861,7 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.10.0-hdbd6064_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libssh2-1.10.0-hdbd6064_2.tar.bz2
   sha256: d011fe14e4b5752feb7f1d6b7c1a7913cb153f8759b4befdf53ed7a5d846cd52
   md5: c29b0f58de6585e5220e10eb5ac2f9e2
   depends:
@@ -1871,7 +1871,7 @@ packages:
   license_family: BSD
   size: 311498
   timestamp: 1686931236351
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
   sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
   md5: 8c195584a5f5471b600ee180e4052773
   depends:
@@ -1879,7 +1879,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 6410287
   timestamp: 1654090800863
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
   sha256: 974e4035c5d51cd41fa7a7f02fadc1980069c00526c1646fa18ea94e667fb137
   md5: 188de945b4279a812953011e8c4580c2
   depends:
@@ -1893,7 +1893,7 @@ packages:
   license_family: Apache
   size: 4630795
   timestamp: 1687975185557
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
   sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
   md5: ef78eebd98289aceacdfa29182426adf
   depends:
@@ -1911,7 +1911,7 @@ packages:
   license_family: Other
   size: 664034
   timestamp: 1693575237924
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
   sha256: c6aecee300c8e84a99056307ed3bdc047edd5366e55230a4eabe3ee5e8082bb8
   md5: 3a6ebf9895b1085a23783cd95460a629
   depends:
@@ -1926,7 +1926,7 @@ packages:
   license_family: BSD
   size: 88424
   timestamp: 1694778218406
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
   sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
   md5: 9cdeef1d044c7e035c006890f11569d3
   depends:
@@ -1937,7 +1937,7 @@ packages:
   license_family: BSD
   size: 436056
   timestamp: 1694776944891
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.10.4-hf1b16e4_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxml2-2.10.4-hf1b16e4_1.tar.bz2
   sha256: 93b155c0472d424dce940921ff368a3e4fd70fa41f5f934e58a4b7ec24722f95
   md5: 2d7bb4d2ef09d62843f8be03b55fce18
   depends:
@@ -1949,7 +1949,7 @@ packages:
   license_family: MIT
   size: 744988
   timestamp: 1692970212537
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.37-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.37-h5eee18b_1.tar.bz2
   sha256: e4e42cc28f7d509980afa2b1e76266d997628c9ff5d194c8460228279c0b6cdc
   md5: ff861c432be5a684783732ad1eb4c39f
   depends:
@@ -1960,7 +1960,7 @@ packages:
   license_family: MIT
   size: 258682
   timestamp: 1692973520375
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py39h06a4308_0.tar.bz2
   sha256: 0e4d61ed508712fc16117fc41f0f5bfedd319cfefd114749689db5f78242b0a5
   md5: d40d6b6ea51683b29a9e210831db4a13
   depends:
@@ -1970,7 +1970,7 @@ packages:
   license_family: MIT
   size: 35171
   timestamp: 1659783489143
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.41.0-py39he621ea3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.41.0-py39he621ea3_0.tar.bz2
   sha256: 2246a2cfd4902904e047c598f3860e592ca2d4779d01c231149a73933e6e5921
   md5: fc49dbd83aa5e65e5c1e90a79baf663e
   depends:
@@ -1983,7 +1983,7 @@ packages:
   license_family: BSD
   size: 4040718
   timestamp: 1697031344309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py39h06a4308_0.tar.bz2
   sha256: d8cd22ac7f033507549f6a0d078cd273607cb6e8246b0383375a33941969c12c
   md5: 78c7a3a437536ae24d2d7ce15ec400d2
   depends:
@@ -1992,7 +1992,7 @@ packages:
   license_family: BSD
   size: 11065
   timestamp: 1652903210940
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.9.3-py39hdbbb534_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lxml-4.9.3-py39hdbbb534_0.tar.bz2
   sha256: b961c12e78000995cfcc5769c64b1c146f917e640e999e290bb2b36468bd7dbe
   md5: a3a5039a19997b8cee4ddf538472358c
   depends:
@@ -2004,7 +2004,7 @@ packages:
   license_family: Other
   size: 1616363
   timestamp: 1695058577405
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py39h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-4.3.2-py39h5eee18b_0.tar.bz2
   sha256: 2af4de285aede9dfaa53b4c542ba500b01420156aa6fabfd0fdc426dd3110e51
   md5: a7a6a481ac90c173785513e0b28d0ed3
   depends:
@@ -2015,7 +2015,7 @@ packages:
   license_family: BSD
   size: 37668
   timestamp: 1686057919336
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
   sha256: 36b23ab8d8aa22d70a2f733462cabe95e5b27ca919ec7a75a5592bc39c5f7d16
   md5: f24adbfdfe16b0bac0d14640bb5ce616
   depends:
@@ -2025,7 +2025,7 @@ packages:
   license_family: BSD
   size: 163649
   timestamp: 1670944701605
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
   sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
   md5: 421f82c8274b44660dba629134faa6af
   depends:
@@ -2035,7 +2035,7 @@ packages:
   license_family: BSD
   size: 122221
   timestamp: 1671541990505
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py39h06a4308_1.tar.bz2
   sha256: 9332b39039a52ecc802ddc2c4a3bde95a3141aff0ccab19a7591ec6ef72bfe07
   md5: 622bb5a6eeeadeb8731e5e1bf4f0d7a2
   depends:
@@ -2045,7 +2045,7 @@ packages:
   license_family: MIT
   size: 105637
   timestamp: 1684279960746
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
   sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
   md5: feb0e452205b44ac45d9b5e55c21a3b1
   depends:
@@ -2057,7 +2057,7 @@ packages:
   license_family: BSD
   size: 22819
   timestamp: 1654597913064
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
   sha256: 10701d3065424bbef89c03a30c4adecd67308cd2f76e0d873aad6a180d9fe097
   md5: e196f6bace29ef34f0a996ef1c99f193
   depends:
@@ -2080,7 +2080,7 @@ packages:
   license_family: PSF
   size: 8129476
   timestamp: 1698692330174
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
   sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
   md5: c04ef34af33da4c71bcc99b7ec24d210
   depends:
@@ -2090,7 +2090,7 @@ packages:
   license_family: BSD
   size: 16391
   timestamp: 1662014553452
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py39h06a4308_0.tar.bz2
   sha256: 0dd0157d3d6c591a1087f7b96993412ac9194b7ea0ee2d667b1dc1c587eb0e33
   md5: 975a78ae464b1cd9541c498fd8299858
   depends:
@@ -2100,7 +2100,7 @@ packages:
   license_family: MIT
   size: 52857
   timestamp: 1659721312521
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py39h06a4308_0.tar.bz2
   sha256: cae67d22945f16e1034fc53144eea8bb67f2fecf6d60b22c43822094b6ca2b49
   md5: 19932cd4f64628bf6db1accebdaf7eac
   depends:
@@ -2109,7 +2109,7 @@ packages:
   license_family: MIT
   size: 18689
   timestamp: 1659716096534
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
   sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
   md5: f6c734d73e6e3dbc1b62766cf18ff3e4
   depends:
@@ -2119,7 +2119,7 @@ packages:
   license_family: BSD
   size: 58153
   timestamp: 1607364912263
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
   sha256: c7dedf41acbb2a065364f949ba24479449387d54c095220ff89346d266b25347
   md5: c5f96c8ff7102e1d673829bbeb8bed84
   depends:
@@ -2133,7 +2133,7 @@ packages:
   license_family: Proprietary
   size: 206706869
   timestamp: 1691503234180
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
   sha256: 984f547627b0af8358fa83b2396e0b2c014f9bc281304b6b8d3ff139a3f04b40
   md5: 724d2559e0ed50aa0eee97c919134ded
   depends:
@@ -2144,7 +2144,7 @@ packages:
   license_family: BSD
   size: 58512
   timestamp: 1682948511810
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
   sha256: 650419991b99b810e79221e35e5a6c3e49240ed30ff3e5324eecf1cefd276110
   md5: a14b8155afdb15f3bce72e67925c0ceb
   depends:
@@ -2158,7 +2158,7 @@ packages:
   license_family: BSD
   size: 227382
   timestamp: 1695058347376
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
   sha256: 7b0eeb8acc4c6b9f45b214fbc991a4073a59a8f7b798a4cc86515b97f7af6355
   md5: eb48e45fd8d61762290e4289a52be3f7
   depends:
@@ -2173,7 +2173,7 @@ packages:
   license_family: BSD
   size: 329190
   timestamp: 1695059874042
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py39hd09550d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/msgpack-python-1.0.3-py39hd09550d_0.tar.bz2
   sha256: a138d682379358886f9d8c1e81da8d126c5cb1f0eff50e236ed471ea5b0b9d24
   md5: 5b2574b896f022cf33ed9a871aacabb3
   depends:
@@ -2184,7 +2184,7 @@ packages:
   license_family: Apache
   size: 90177
   timestamp: 1652362815706
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py39h06a4308_0.tar.bz2
   sha256: 305313d215116fbf13a38f8a321eb635b83294871801ac63e543a59ba7de642c
   md5: e0db8ae050bd0db74f47edc370dbc287
   depends:
@@ -2194,7 +2194,7 @@ packages:
   license_family: BSD
   size: 24480
   timestamp: 1607574279743
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
   sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
   md5: 95c83d71814c504b5504df4f14548f1a
   depends:
@@ -2220,7 +2220,7 @@ packages:
   license_family: BSD
   size: 8257558
   timestamp: 1681756322140
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py39h06a4308_0.tar.bz2
   sha256: 79e10dc933d22aa99de3543071f1beaaf0ff24df9fed7d2ef5e765f3ed766064
   md5: ea6ebe4e8d6af98128d32606da618a29
   depends:
@@ -2233,7 +2233,7 @@ packages:
   license_family: BSD
   size: 99555
   timestamp: 1698934242626
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
   sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
   md5: 1710a25086c8098367eb36b9d441448b
   depends:
@@ -2261,7 +2261,7 @@ packages:
   license_family: BSD
   size: 569683
   timestamp: 1668450704669
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
   sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
   md5: 385cc9e53404776782502c0fdb08820f
   depends:
@@ -2274,7 +2274,7 @@ packages:
   license_family: BSD
   size: 147046
   timestamp: 1694616899309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
   sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
   md5: 57ea097dc15f8d9f9eb90e1d919143b0
   depends:
@@ -2283,7 +2283,7 @@ packages:
   license_family: MIT
   size: 1157733
   timestamp: 1674734069410
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
   sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
   md5: bbbcbebc20a4fdcadce398d0ca04f95e
   depends:
@@ -2292,7 +2292,7 @@ packages:
   license_family: BSD
   size: 13109
   timestamp: 1672387143252
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
   sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
   md5: 248ce515640465371927d46f389ed555
   depends:
@@ -2317,7 +2317,7 @@ packages:
   license_family: BSD
   size: 594054
   timestamp: 1690985006481
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
   sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
   md5: 70db71df4ee1cdd38090c0f7b80ba61f
   depends:
@@ -2327,7 +2327,7 @@ packages:
   license_family: BSD
   size: 21944
   timestamp: 1668160644514
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.58.0-py39h1128e8f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numba-0.58.0-py39h1128e8f_0.tar.bz2
   sha256: f8dd4d134d271bd5c598a751a97bd762af9d521da397c3d7c9bf27f075766786
   md5: 1b6b9a910a63651d7b0730fb8efb715d
   depends:
@@ -2349,7 +2349,7 @@ packages:
   license_family: BSD
   size: 4454092
   timestamp: 1697065406496
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
   sha256: e61fc626f7131f1857c703ad3bb4dcacfc6b1fd6d5da545aa8f600b840315aca
   md5: 6b689e52e3ba1fa7caaab3e6be31860c
   depends:
@@ -2364,7 +2364,7 @@ packages:
   license_family: MIT
   size: 141434
   timestamp: 1696515497148
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.25.2-py39h5f9d8c6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.25.2-py39h5f9d8c6_0.tar.bz2
   sha256: 546e81b24b7718627a403582cdfd604df8c250373afc65620df65e9d7bc52209
   md5: abfffef48047ff2b9e1aa14435b3b51f
   depends:
@@ -2381,7 +2381,7 @@ packages:
   license_family: BSD
   size: 11965
   timestamp: 1691097038493
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.25.2-py39hb5e798b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.25.2-py39hb5e798b_0.tar.bz2
   sha256: f822485f35430e652cd400ddc551991a02cff7f41823733536d74431b48454d8
   md5: 7fa1afb4996b13c22a2c4f0ee0800bfc
   depends:
@@ -2397,7 +2397,7 @@ packages:
   license_family: BSD
   size: 7863917
   timestamp: 1691097022810
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
   sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
   md5: b0afe23033c8c5344640bc25225fa579
   depends:
@@ -2408,7 +2408,7 @@ packages:
   license: BSD 2-Clause
   size: 516994
   timestamp: 1630084830020
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.12-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.12-h7f8727e_0.tar.bz2
   sha256: f29899dc427cc09b2668b1e6db7718574809497c73bd725c682088053852aa16
   md5: bbd867a77bbde74015a8db1b3f3a01a8
   depends:
@@ -2418,7 +2418,7 @@ packages:
   license_family: Apache
   size: 5486812
   timestamp: 1699012426314
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/orc-1.7.4-hb3bc3d3_1.tar.bz2
   sha256: 9618addfc1b940c048372ffb2c8500d4b44d02455a9bd1f411e530ed5e09b8d5
   md5: 56057ed323f733bdcf262468682d0358
   depends:
@@ -2433,7 +2433,7 @@ packages:
   license_family: Apache
   size: 1132661
   timestamp: 1676482768554
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
   sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
   md5: 77a22ed6d0d448c5288d0f695bc9ac49
   depends:
@@ -2442,7 +2442,7 @@ packages:
   license_family: Apache
   size: 72527
   timestamp: 1693575234886
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.1.1-py39h1128e8f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-2.1.1-py39h1128e8f_0.tar.bz2
   sha256: 525a877de379651efc20862a77deb470c9c4ff3cfa470d3643c5036de0ec5d17
   md5: dd9fcd456d8fb03daad201cf130d28bd
   depends:
@@ -2490,7 +2490,7 @@ packages:
   license_family: BSD
   size: 14140649
   timestamp: 1697477421901
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.2.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-1.2.3-py39h06a4308_0.tar.bz2
   sha256: ef7397640e2220170a3bb0a65afe9e9093d2072d5aeb15a50cbd7ec0b90aee67
   md5: 2b592717e374c813b8fba0022e83b5b7
   depends:
@@ -2514,7 +2514,7 @@ packages:
   license_family: BSD
   size: 16953995
   timestamp: 1695146143065
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
   sha256: 64a732ce2661cdb6bd8f9d1484ac10afeb73082b1c2b44728d212e0117d2860e
   md5: ada303f0cf43a4e99cfa7f243b23b681
   depends:
@@ -2523,7 +2523,7 @@ packages:
   license_family: BSD
   size: 141832
   timestamp: 1684915385689
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/partd-1.4.1-py39h06a4308_0.tar.bz2
   sha256: 9c699bd495cbf23db7dea986deeb75183571b83adc14b3e4a36cc6cfd2a198a8
   md5: 39ed6f683307cca54ac666b2d1f849ff
   depends:
@@ -2537,7 +2537,7 @@ packages:
   license_family: BSD
   size: 35706
   timestamp: 1698702632637
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
   sha256: db8122fcb6316fb86c2ff6d4dd47154a650ac26d270183a316f14004adf27525
   md5: 33ad46d04664fc8b65a545110e4fe099
   depends:
@@ -2557,7 +2557,7 @@ packages:
   license_family: Other
   size: 764331
   timestamp: 1696580179855
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
   sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
   md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
   depends:
@@ -2568,7 +2568,7 @@ packages:
   license_family: MIT
   size: 2674850
   timestamp: 1697548887851
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
   sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
   md5: fe56f0479dd414c846191116366262c3
   depends:
@@ -2577,7 +2577,7 @@ packages:
   license_family: MIT
   size: 31999
   timestamp: 1692205535111
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
   sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
   md5: 44d2a857d13bdf9d99aaac039a249d47
   depends:
@@ -2586,7 +2586,7 @@ packages:
   license_family: Apache
   size: 91137
   timestamp: 1659455142164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
   sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
   md5: eb899a739d9b58dd747f1f6bd52d4cf3
   depends:
@@ -2598,7 +2598,7 @@ packages:
   license_family: BSD
   size: 579771
   timestamp: 1672387338600
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
   sha256: a760d6c9fca08c09ff0bc9a33946188e2ea5deed2443d4acb360ce55ce36ee43
   md5: 2cb2ad8315f68f4339b9416bd9ab115e
   depends:
@@ -2608,7 +2608,7 @@ packages:
   license_family: BSD
   size: 353437
   timestamp: 1656431352923
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-11.0.0-py39h468efa6_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyarrow-11.0.0-py39h468efa6_1.tar.bz2
   sha256: 2bcd948dd7720e29dc17e1a71bcd97a990b392cbbaa0714dd15befb8126fc37b
   md5: 57791bf3248bd3092cf3ca737445f934
   depends:
@@ -2623,7 +2623,7 @@ packages:
   license_family: Apache
   size: 4814185
   timestamp: 1693273169679
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
   sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
   md5: f36ecb722522cbe2e3737424edf1b5e1
   depends:
@@ -2635,7 +2635,7 @@ packages:
   license_family: BSD
   size: 29312
   timestamp: 1675441510984
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
   sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
   md5: 6d03295e544251e608a28c8d7c48115e
   depends:
@@ -2644,7 +2644,7 @@ packages:
   license_family: BSD
   size: 1862058
   timestamp: 1684280096752
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
   sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
   md5: 1f09617aecd6f3c2f2e20692c0759f34
   depends:
@@ -2654,7 +2654,7 @@ packages:
   license_family: Apache
   size: 94434
   timestamp: 1690223520097
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
   sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
   md5: ffceed627867508d73af1636ab5ebf42
   depends:
@@ -2663,7 +2663,7 @@ packages:
   license_family: MIT
   size: 156324
   timestamp: 1661452578573
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
   sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
   md5: 0e3341a4fe434167bf74b613eb6afd81
   depends:
@@ -2673,7 +2673,7 @@ packages:
   license_family: MIT
   size: 97194
   timestamp: 1636110999719
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
   sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
   md5: c5f3f7f10ad30f0945e75252615ab6e5
   depends:
@@ -2682,7 +2682,7 @@ packages:
   license_family: BSD
   size: 31331
   timestamp: 1605305847037
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.18-h955ad1f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.9.18-h955ad1f_0.tar.bz2
   sha256: e9cc8f89dc327997339bedd9961428a13dda3893e3dba46358e73b1fd1ffa37a
   md5: e99f4c3215771cd11de42d30ac8ada47
   depends:
@@ -2703,7 +2703,7 @@ packages:
   license_family: PSF
   size: 26811973
   timestamp: 1694440290734
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
   sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
   md5: 0caa188a695319bdb13f53b0a2b3accc
   depends:
@@ -2712,7 +2712,7 @@ packages:
   license_family: BSD
   size: 264864
   timestamp: 1661371117920
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.4.1-py39h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-lmdb-1.4.1-py39h6a678d5_0.tar.bz2
   sha256: 3d4ebba2cd88a8e2b514c061d107b33057c67d54620a2975146d51444887b543
   md5: 9ae7c3b89bdccb939936e2f087c4f761
   depends:
@@ -2723,7 +2723,7 @@ packages:
   license_family: Other
   size: 139001
   timestamp: 1682522498995
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
   sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
   md5: bcb44ecbea441ee0d4659133d060d71f
   depends:
@@ -2732,7 +2732,7 @@ packages:
   license_family: MIT
   size: 257904
   timestamp: 1695131670290
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
   sha256: e937081facacb141dc2c9cdcced92baa9a2662e4a56100b6041df0b6b7692570
   md5: f3ac39b2349258198a9b3316636fe5d5
   depends:
@@ -2742,7 +2742,7 @@ packages:
   license_family: BSD
   size: 39972
   timestamp: 1685030752528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
   sha256: 2a535f9fdda20b536bd76dfa286fb67a7685ed2be4ad51e2860c44e144c0b457
   md5: 797c263fd5bff62987fc1da076eef0f9
   depends:
@@ -2753,7 +2753,7 @@ packages:
   license_family: MIT
   size: 184040
   timestamp: 1698096132905
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
   sha256: 70ee4fc614dd3337ad542c7c961428930160ab8c7da27775faed5ffddbd362d7
   md5: bf2a4feb20647c569f7ce5a8f63094fa
   depends:
@@ -2765,7 +2765,7 @@ packages:
   license_family: BSD
   size: 515650
   timestamp: 1657724431309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
   sha256: 8a640736bef635346409582dbfe2b7d0ecc9da215c90173ff8a9a5fe22569107
   md5: 6b583dce61c6feb352ef0f49f413af1e
   depends:
@@ -2774,7 +2774,7 @@ packages:
   license: BSD-3-Clause
   size: 235004
   timestamp: 1652449537852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
   sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
   md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
   depends:
@@ -2784,7 +2784,7 @@ packages:
   license_family: GPL
   size: 467661
   timestamp: 1666648052561
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
   sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
   md5: c7de00b4ac2778c4e5a7816320d75391
   depends:
@@ -2800,7 +2800,7 @@ packages:
   license_family: Apache
   size: 94028
   timestamp: 1690400356879
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.11.3-py39h5f9d8c6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/scipy-1.11.3-py39h5f9d8c6_0.tar.bz2
   sha256: 8ddacf409396338156d1a09da3f8f0f3b3b473c679bcfefd2de154f7d8f91344
   md5: 6d6d7ca3d32075d8a57131d589851dd2
   depends:
@@ -2817,7 +2817,7 @@ packages:
   license_family: BSD
   size: 23630389
   timestamp: 1696544992719
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
   sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
   md5: 1581cafc84708ed9aafaaee1cbbf6065
   depends:
@@ -2826,7 +2826,7 @@ packages:
   license_family: MIT
   size: 1089416
   timestamp: 1690290900608
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.1.9-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/snappy-1.1.9-h295c915_0.tar.bz2
   sha256: 0f5809564b323f020dec2633dc274bbc96dc13d54888bb115938d3d7f6a717bb
   md5: 71b25fd79c57bcf6bd2ba8ccf1e18506
   depends:
@@ -2836,7 +2836,7 @@ packages:
   license_family: BSD
   size: 891170
   timestamp: 1649923859475
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
   sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
   md5: e19ffbfb24b990275d24fcea2bd1699b
   depends:
@@ -2845,7 +2845,7 @@ packages:
   license_family: Apache
   size: 15702
   timestamp: 1614030498860
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
   sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
   md5: ca061ce25c0f58628643abec8d6a8244
   depends:
@@ -2854,7 +2854,7 @@ packages:
   license_family: MIT
   size: 66330
   timestamp: 1696347637947
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/spatialpandas-0.4.9-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/spatialpandas-0.4.9-py39h06a4308_0.tar.bz2
   sha256: b88b9369baba9167eb3df4193de695f3f7fb605ca3a6dcfa6ee3b46db5ccb6f2
   md5: 34a3e041868a5667eb24bcc5f73adc8b
   depends:
@@ -2870,7 +2870,7 @@ packages:
   license_family: BSD
   size: 147839
   timestamp: 1695247335265
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
   sha256: 8b45ba506984fe9c061b4acde6f5243d52dda8c1eae4992f8d80c03f425214fe
   md5: 68c24a824d36a16bbb28d80d70cee8d2
   depends:
@@ -2883,7 +2883,7 @@ packages:
   license_family: Other
   size: 1640317
   timestamp: 1681394746811
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
   sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
   md5: 041a3caf09dc9ce8fc6c10925c4fe050
   depends:
@@ -2893,7 +2893,7 @@ packages:
   license_family: Apache
   size: 1888016
   timestamp: 1680167274961
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
   sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
   md5: 0e76eab58fe488e91f0aee73f46de031
   depends:
@@ -2904,7 +2904,7 @@ packages:
   license_family: BSD
   size: 29816
   timestamp: 1671751864131
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
   sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
   md5: b413a210eca82fe867e991eed085201b
   depends:
@@ -2914,7 +2914,7 @@ packages:
   license_family: BSD
   size: 38882
   timestamp: 1668168876032
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
   sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
   md5: 5b8375e2092012db69d2123dc0c68630
   depends:
@@ -2924,7 +2924,7 @@ packages:
   license_family: BSD
   size: 3485432
   timestamp: 1654088939579
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/toolz-0.12.0-py39h06a4308_0.tar.bz2
   sha256: 57983e3eb698a3b08b570d5f398d9550cf50b9bf54b2b4728c731ecbc0c89138
   md5: 3ce956b1e1a7f77af6e6127dca987b95
   depends:
@@ -2933,7 +2933,7 @@ packages:
   license_family: BSD
   size: 101246
   timestamp: 1667464172523
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
   sha256: bd06f7b49d9c04c51c1e825bab446ec3cdde2bce39af00bf113a05c1009595e2
   md5: 587c3f3c891901f4305653e50c18d6c0
   depends:
@@ -2943,7 +2943,7 @@ packages:
   license_family: Apache
   size: 679739
   timestamp: 1696937022519
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
   sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
   md5: 67a8320961ff24e92eebb661536e5cf7
   depends:
@@ -2956,7 +2956,7 @@ packages:
   license_family: MOZILLA
   size: 123763
   timestamp: 1679561904852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
   sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
   md5: 0f0b91a158dd3692cbb7a7763b657bfe
   depends:
@@ -2965,7 +2965,7 @@ packages:
   license_family: BSD
   size: 192032
   timestamp: 1671143995098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
   md5: 8515e64a3de7581360d713fe4c0a094e
   depends:
@@ -2975,7 +2975,7 @@ packages:
   license_family: PSF
   size: 8789
   timestamp: 1690297588156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
   md5: 60170012374b2a5007842fa5870d78c5
   depends:
@@ -2984,7 +2984,7 @@ packages:
   license_family: PSF
   size: 57479
   timestamp: 1690297581658
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py39h06a4308_0.tar.bz2
   sha256: bdafa637d91ee2986a37cc82eb18c7b9b6e467eddd2eac3f510ad878a5b45da2
   md5: 89e6a047e97aa6b06c8a217e64182646
   depends:
@@ -2993,7 +2993,7 @@ packages:
   license_family: MIT
   size: 10729
   timestamp: 1659769510353
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
   sha256: 2f4a5979aaf22660fe9fb8c4ffd41e5a9dc012e20f78e1dbf4ad9c67e0fd28be
   md5: 0be10051dd3d6f31ba52b7c08ba3ba0a
   depends:
@@ -3008,7 +3008,7 @@ packages:
   license_family: MIT
   size: 187469
   timestamp: 1698257600264
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h27cfd23_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/utf8proc-2.6.1-h27cfd23_0.tar.bz2
   sha256: 3573b5d63801189ea8a1cbaffce73171f2c4c3b77c5c4952bf2b709694e140ff
   md5: b45754c4fa24c5b4ce9d504c5b6cc4f1
   depends:
@@ -3017,7 +3017,7 @@ packages:
   license_family: MIT
   size: 309353
   timestamp: 1611836033971
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
   sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
   md5: f8d03a15b974fc7810d9f54ae849fc8e
   depends:
@@ -3026,7 +3026,7 @@ packages:
   license_family: BSD
   size: 20781
   timestamp: 1607365390528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
   sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
   md5: d7db5d6ce1db80eade8a082ff78bf479
   depends:
@@ -3036,7 +3036,7 @@ packages:
   license_family: BSD
   size: 71044
   timestamp: 1614804011510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
   sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
   md5: b3899f8bda32734727bd5a73df1d7d17
   depends:
@@ -3045,7 +3045,7 @@ packages:
   license_family: MIT
   size: 101520
   timestamp: 1695742037911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xarray-2023.6.0-py39h06a4308_0.tar.bz2
   sha256: d88bdc49a883a944cf1562ebb0a30d0451e28ab05521fc882615e357b105f414
   md5: c150cf16071597fa3977fb81ebb83760
   depends:
@@ -3057,7 +3057,7 @@ packages:
   license_family: Apache
   size: 1787638
   timestamp: 1689041557651
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py39h06a4308_1.tar.bz2
   sha256: 8e8d728472d26c1a42345003d69bf381c062db8050d3444a6ccced7e5dcc3524
   md5: dd9bda05830964c550a69b70178ee6f9
   depends:
@@ -3066,7 +3066,7 @@ packages:
   license_family: BSD
   size: 48001
   timestamp: 1675159114742
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
   sha256: 93ca87e697bb9e045fc9cda13b05fe27e1a99f3ed143b75bbcaf4dcb745aa06f
   md5: 3eebbb22c5ca63987db36e1f19cbe872
   depends:
@@ -3075,7 +3075,7 @@ packages:
   license_family: GPL2
   size: 763941
   timestamp: 1683112966413
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -3083,7 +3083,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
   sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
   md5: 567b68192c387b5fc88178425577a0fe
   depends:
@@ -3093,7 +3093,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 366479
   timestamp: 1616055552392
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zict-3.0.0-py39h06a4308_0.tar.bz2
   sha256: 859398823a40ead7079055f01ad23f7f5a03ffa11ad672fa26bea38badd8ec01
   md5: b733cbb9875966a2017e7c386fb98076
   depends:
@@ -3104,7 +3104,7 @@ packages:
   license_family: BSD
   size: 76469
   timestamp: 1695832872162
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
   sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
   md5: 3818a9531fe74433c3b7d5144c9a58cc
   depends:
@@ -3113,7 +3113,7 @@ packages:
   license_family: MIT
   size: 18021
   timestamp: 1672387231268
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
   sha256: 2dc9150a95704d83efd39bb9dfb44bdf8419022f4fb0fc416380a922a27c130d
   md5: 4f315d7551f4bbeb06b6fc28342a9aa5
   depends:
@@ -3122,7 +3122,7 @@ packages:
   license_family: Other
   size: 127528
   timestamp: 1666595012798
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
   sha256: aa6aa291bec6aa66e1f063cfa75a9e0fc6bd459fcb45c372aacac9006a073900
   md5: 4e99328768f538f33aecebdae9472744
   depends:
@@ -3135,7 +3135,7 @@ packages:
   license_family: BSD
   size: 1055426
   timestamp: 1681304602537
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -3148,7 +3148,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -3158,7 +3158,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
   md5: b2aa5503875aba2f1d88cae9df9a96d5
   depends:
@@ -3167,7 +3167,7 @@ packages:
   license_family: BSD
   size: 13636
   timestamp: 1611930018941
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -3179,7 +3179,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
   sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
   md5: 544adf2677c47c9b9c891aea720678f1
   depends:
@@ -3187,7 +3187,7 @@ packages:
   license: MIT
   size: 33999
   timestamp: 1630003259346
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -3196,7 +3196,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -3205,7 +3205,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -3214,7 +3214,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -3223,7 +3223,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
   sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
   md5: 9eff1a842dbda8d1bae9a2c008b599bc
   depends:
@@ -3234,7 +3234,7 @@ packages:
   license_family: MIT
   size: 690443
   timestamp: 1625743217109
-- conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
   sha256: 9de8666e5b70aa2437737128eaa14ffe80a7b5235c2a6b7d3f39ccefd7816ba0
   md5: bb52e50c5ab1a5c7778c11376404dfdb
   depends:
@@ -3242,7 +3242,7 @@ packages:
   license: BSD 3-Clause
   size: 7933
   timestamp: 1630598543551
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -3250,7 +3250,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
   sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
   md5: 33624a42ee387bf9918ea98b4e7b31fc
   depends:
@@ -3260,7 +3260,7 @@ packages:
   license_family: BSD
   size: 8173
   timestamp: 1601490751973
-- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
   sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
   md5: 67857cc5e9044770d2b15f9d94a4521d
   depends:
@@ -3269,7 +3269,7 @@ packages:
   license_family: Apache
   size: 12810
   timestamp: 1600445183315
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -3278,7 +3278,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -3287,7 +3287,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -3297,7 +3297,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
   sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
   md5: e68a6f315f41a8d814d833652bf38b9b
   depends:
@@ -3305,7 +3305,7 @@ packages:
   license: MIT
   size: 13374
   timestamp: 1606932077143
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -3313,7 +3313,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -3322,7 +3322,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -3331,7 +3331,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
   sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
   md5: 2eb923cc014094f4acf7f849d67d73f8
   depends:
@@ -3341,7 +3341,7 @@ packages:
   license_family: BSD
   size: 246457
   timestamp: 1626374695070
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
   sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
   md5: 02caf3f47f1d06256068053297355740
   depends:
@@ -3350,7 +3350,7 @@ packages:
   license_family: Apache
   size: 152292
   timestamp: 1690578151230
-- conda: https://repo.anaconda.com/pkgs/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/retrying-1.3.3-pyhd3eb1b0_2.tar.bz2
   sha256: 2b09b3a4920393833a5963dd702757152b425d2712acfc3fe0b59ceec6e315bd
   md5: f00776a58646c5ae1644fc52029a5b66
   depends:
@@ -3360,7 +3360,7 @@ packages:
   license_family: Apache
   size: 14955
   timestamp: 1629465474976
-- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
   sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
   md5: 41db68b96e114e367c4f120a3b379e59
   depends:
@@ -3369,7 +3369,7 @@ packages:
   license_family: BSD
   size: 19391
   timestamp: 1632406728844
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -3378,7 +3378,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
   sha256: 4e47f6c49ce84509f1466e8a4d728447bf4bcd9bce7b456431a789a262547067
   md5: 4cad993b0f80bc23fb66a97592299cbb
   depends:
@@ -3387,7 +3387,7 @@ packages:
   license_family: Apache
   size: 26504
   timestamp: 1623949147884
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -3399,7 +3399,7 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
   sha256: ca2be6c7810a37cfc6db1f5383937b5d35c6d73c1fad8a9104de85f069b1df1c
   md5: 9ccb2fb33edb152403d6ef32bf758a9d
   depends:
@@ -3408,14 +3408,14 @@ packages:
   license_family: BSD
   size: 15614
   timestamp: 1629402049497
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
   sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
   md5: a815d3bdb160bcc71687f2dda70d3ca4
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 122218
   timestamp: 1680170368293
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -3423,7 +3423,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/abseil-cpp-20230802.0-h61975a4_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/abseil-cpp-20230802.0-h61975a4_2.tar.bz2
   sha256: dc40cfc393c2acdb97ce54289d3124bdff35ffd4a6c203abb6f3f5598f49c115
   md5: 64a761d3c1af045bf01d84d3fc4302a2
   depends:
@@ -3433,7 +3433,7 @@ packages:
   license_family: Apache
   size: 1336618
   timestamp: 1698327954026
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
   sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
   md5: 447a49f7bad119faa80d7f14aa296c95
   depends:
@@ -3446,7 +3446,7 @@ packages:
   license_family: MIT
   size: 162176
   timestamp: 1644481750133
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
   sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
   md5: 8810f48fe4a4792de0fd3520b502d08b
   depends:
@@ -3455,7 +3455,7 @@ packages:
   license_family: BSD
   size: 10019
   timestamp: 1606859473259
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
   sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
   md5: 00a446b6dfc61af223df4de29fe8ad94
   depends:
@@ -3465,7 +3465,7 @@ packages:
   license_family: MIT
   size: 34305
   timestamp: 1644569782044
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-11.0.0-h89a8245_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/arrow-cpp-11.0.0-h89a8245_2.tar.bz2
   sha256: 3f0d7b6fbf5d2943a91ee86d0d15b7aaaa4365c51d0a33a72cfec7f532cf90fd
   md5: 7febd435dfd791eb86f989800a80d313
   depends:
@@ -3493,7 +3493,7 @@ packages:
   license_family: Apache
   size: 8832880
   timestamp: 1693263543885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
   sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
   md5: bd92dd8bd5b9d24e632b62a075426e50
   depends:
@@ -3502,14 +3502,14 @@ packages:
   license_family: MIT
   size: 133634
   timestamp: 1695718025321
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.6.8-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-common-0.6.8-h6c40b1e_1.tar.bz2
   sha256: 20e070a2eec6c61d4410abea0cf5e61f7730dbc4d716f1bb479c2c4f9e2374d1
   md5: 8907c29e3a313a6145b0a8383bb1831e
   license: Apache-2.0
   license_family: Apache
   size: 155893
   timestamp: 1685977853820
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.1.6-hcec6c5f_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-event-stream-0.1.6-hcec6c5f_6.tar.bz2
   sha256: 49941bebf4656e482ef1d022ad27ad7870e424acb48479e5b0fde0b455fad98e
   md5: f73d13a717d451d006d48f6c69f46e94
   depends:
@@ -3520,7 +3520,7 @@ packages:
   license_family: Apache
   size: 23697
   timestamp: 1685999036808
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.11-h6c40b1e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-checksums-0.1.11-h6c40b1e_2.tar.bz2
   sha256: 8d8baf5a4039a44b86469bcb757e0626ffbe7762f8c0e7568eaf87c574171fbb
   md5: f9e03ecf8af230286698067c86d0680a
   depends:
@@ -3529,7 +3529,7 @@ packages:
   license_family: Apache
   size: 50927
   timestamp: 1685994666563
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.8.185-h1a8d504_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-sdk-cpp-1.8.185-h1a8d504_1.tar.bz2
   sha256: b4ddcf4c5b69d10ed21928583b5bac81de9908a3a581f3f372219deb6e49c6e5
   md5: b3831cfdab0b99263da510ff3e065a96
   depends:
@@ -3543,7 +3543,7 @@ packages:
   license_family: Apache
   size: 2112655
   timestamp: 1686057600290
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
   sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
   md5: f8ae051b591a9027adc16de1be9748f4
   depends:
@@ -3553,12 +3553,12 @@ packages:
   license_family: MIT
   size: 206198
   timestamp: 1681493096349
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
   sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
   md5: e2f3248e2a5009a02f7b8e54f83314ef
   size: 5620
   timestamp: 1528121955725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-3.2.1-py39h20db666_0.tar.bz2
   sha256: 65ababd5e7812c35a97ac7d22b0ebe52c144121a3d49528b7d5c19e8453cce4a
   md5: d85c13c017a37e406f6c1e00c1ea4f4f
   depends:
@@ -3576,7 +3576,7 @@ packages:
   license_family: BSD
   size: 6480601
   timestamp: 1690546287900
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
   sha256: 81102f2762d8eb2f07c69fbf7ca7dad879a257a053085492d4c1b4006eb35fb8
   md5: 3c42777bc9330fe91177ea813b9ec252
   depends:
@@ -3586,7 +3586,7 @@ packages:
   license_family: OTHER
   size: 11744
   timestamp: 1696762233693
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
   sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
   md5: 0d79760d544d0bd8acb4adc4ef813418
   depends:
@@ -3596,7 +3596,7 @@ packages:
   license_family: BSD
   size: 137075
   timestamp: 1657175654487
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
   sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
   md5: 31d6d04cd2388d8f19004501271b3545
   depends:
@@ -3606,7 +3606,7 @@ packages:
   license: MIT
   size: 18982
   timestamp: 1659616229395
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
   sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
   md5: caf1073dc2ca5aeb832a2877394eae12
   depends:
@@ -3615,7 +3615,7 @@ packages:
   license: MIT
   size: 18233
   timestamp: 1659616216769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
   sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
   md5: aa1ed20c38af535c8d6a955314759d7b
   depends:
@@ -3624,28 +3624,28 @@ packages:
   license: MIT
   size: 394588
   timestamp: 1659616312678
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h1de35cc_0.tar.bz2
   sha256: 4574ffa241157e108d19ece60107a3a689cefaaca43578e6c4a6b344c7330278
   md5: ab3b4e83407001e7f1603ca1fa0f4873
   license: bzip2
   license_family: BSD
   size: 106284
   timestamp: 1563219666100
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
   sha256: f913b61ba3c1651b36688415cc163a5d575475f7573b543f48a80e7a5002e4bb
   md5: f11d165eaa532ce04a35382841284298
   license: MIT
   license_family: MIT
   size: 107047
   timestamp: 1693902034820
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
   sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
   md5: ce3588e31faa79f546e0fc6a36c5543c
   license: MPL-2.0
   license_family: Other
   size: 133884
   timestamp: 1694009771475
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
   sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
   md5: 21eb7f53076d0a69513cfd258f6ef63c
   depends:
@@ -3654,7 +3654,7 @@ packages:
   license_family: Other
   size: 159756
   timestamp: 1690232346868
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
   sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
   md5: a40a04d9cda1e665565bc6c832d598b6
   depends:
@@ -3665,7 +3665,7 @@ packages:
   license_family: MIT
   size: 225258
   timestamp: 1670423337502
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py39hecd8cb5_0.tar.bz2
   sha256: b860f45bce9fbb40d024dcd3306e66a52010641091ca8d1fcdde6c4238717c73
   md5: 3c38f3af9c23b26efc2b11d82c95922a
   depends:
@@ -3674,7 +3674,7 @@ packages:
   license_family: BSD
   size: 153013
   timestamp: 1698129937688
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cloudpickle-2.2.1-py39hecd8cb5_0.tar.bz2
   sha256: c368e11dc241d1b79b4bb0d9333b353dc1b966b49d145163a0590d88ad88fef2
   md5: 1e62044b8a32d1452e51773ba7a4319c
   depends:
@@ -3683,7 +3683,7 @@ packages:
   license_family: BSD
   size: 41392
   timestamp: 1683040146991
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
   sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
   md5: b2cc5f37f7bb069d061306e7eac2a011
   depends:
@@ -3693,7 +3693,7 @@ packages:
   license_family: CC
   size: 1913396
   timestamp: 1668084575248
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
   sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
   md5: 103d8c039e342115720a84d59c119d46
   depends:
@@ -3703,7 +3703,7 @@ packages:
   license_family: BSD
   size: 13774
   timestamp: 1671231190250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
   sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
   md5: f69f09e0346172f225390d2b3b0d7873
   depends:
@@ -3714,7 +3714,7 @@ packages:
   license_family: BSD
   size: 246628
   timestamp: 1663827484947
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
   sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
   md5: cb80c7ac65b48a737654f371fe31c460
   depends:
@@ -3727,7 +3727,7 @@ packages:
   license_family: BSD
   size: 1307228
   timestamp: 1694212041712
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-0.12.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cytoolz-0.12.0-py39hca72f7f_0.tar.bz2
   sha256: 68200788e4f482730df10be66e73ea32ae9031bb76551108e6ad8bfb197c653e
   md5: d0548e07d136d23cfc9202312a325f34
   depends:
@@ -3737,7 +3737,7 @@ packages:
   license_family: BSD
   size: 363755
   timestamp: 1667466068228
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-2023.6.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/dask-2023.6.0-py39hecd8cb5_0.tar.bz2
   sha256: f613b7aa5f154521396c0e691ea563f6623a304610a99696788f67790ed9cf27
   md5: 10fdef72e0ea52f6f66130e7d2de55f1
   depends:
@@ -3755,7 +3755,7 @@ packages:
   license_family: BSD
   size: 6127
   timestamp: 1687285007545
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/dask-core-2023.6.0-py39hecd8cb5_0.tar.bz2
   sha256: e80ce32bc86af3e0b67d44bc2c774dde7490443bf6ae4bed7d9c666e3631965f
   md5: ba47d3bdf582bf15e9250bff6b2f6dbd
   depends:
@@ -3772,7 +3772,7 @@ packages:
   license_family: BSD
   size: 2125677
   timestamp: 1686783049768
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/datashader-0.15.2-py39hecd8cb5_0.tar.bz2
   sha256: 7717c1f0af2af4b28b6d787b32c5e1740f391915c78707d8643e0d516088dbd0
   md5: d7ae4c5cb253fa85c0ce268d2bf9a191
   depends:
@@ -3794,7 +3794,7 @@ packages:
   license_family: BSD
   size: 17679970
   timestamp: 1692372465872
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/datashape-0.5.4-py39hecd8cb5_1.tar.bz2
   sha256: 40bbbe2ed223829f4a3f91024fa409f1a665ad94294bec2c9e930989bb2b8911
   md5: 4add00dc619c12370af0ed18c76b71f6
   depends:
@@ -3806,7 +3806,7 @@ packages:
   license_family: BSD
   size: 103370
   timestamp: 1613390236788
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
   sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
   md5: 04cbe8f4bc62c34fac9d42d1124059bf
   depends:
@@ -3816,7 +3816,7 @@ packages:
   license_family: MIT
   size: 2052734
   timestamp: 1690905361158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2023.6.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/distributed-2023.6.0-py39hecd8cb5_0.tar.bz2
   sha256: cae6f0cdca229423df948658c1b83258671e388f958f5ed141ba5811ce030fbe
   md5: 1b5c10d7094410bbd1c93431739fd538
   depends:
@@ -3840,7 +3840,7 @@ packages:
   license_family: BSD
   size: 1387898
   timestamp: 1686866140802
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
   sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
   md5: ef0e825982f242085574f502dfff4f6b
   depends:
@@ -3849,7 +3849,7 @@ packages:
   license_family: MIT
   size: 16594
   timestamp: 1649926538106
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
   sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
   md5: 24747a300246c016b3a7f04dabd02d4a
   depends:
@@ -3858,7 +3858,7 @@ packages:
   license_family: BSD
   size: 27709
   timestamp: 1668714497209
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -3868,7 +3868,7 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fsspec-2023.9.2-py39hecd8cb5_0.tar.bz2
   sha256: 95e9a45812b1b4059b973e5e6e131c7c1a8b2ce2dafc5117e7806b1c8f30de27
   md5: bc889aaa846ed177fc5f495c24041acc
   depends:
@@ -3877,7 +3877,7 @@ packages:
   license_family: BSD
   size: 262430
   timestamp: 1695734574609
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-h0a44026_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/gflags-2.2.2-h0a44026_0.tar.bz2
   sha256: 36f939c2123f7baef087a46e6a831d42a52a728093c46ffff9945d5d461a0c41
   md5: 481275c7cd308738942b6cc02b625804
   depends:
@@ -3886,14 +3886,14 @@ packages:
   license_family: BSD
   size: 139043
   timestamp: 1542388670387
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
   sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
   md5: e4a732941f74b8062c8bcbfe5c5c2b56
   license: MIT
   license_family: MIT
   size: 80252
   timestamp: 1676983220161
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/glog-0.5.0-h23ab428_0.tar.bz2
   sha256: 17b526435dc8d509e682414cfec291ce5b56e24b9bf6c7a7e4b366b2cfacda26
   md5: 797484a4ab5d2a8cc1e5cf5026af9ee1
   depends:
@@ -3902,7 +3902,7 @@ packages:
   license: BSD-3-Clause
   size: 96479
   timestamp: 1620732938755
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/grpc-cpp-1.48.2-hbe2b35a_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/grpc-cpp-1.48.2-hbe2b35a_3.tar.bz2
   sha256: 429778798ecd14755d6550f9fdeec8855e99e40cbe6128a87592958bd8fd95a1
   md5: 155ac9a36f0be7fd310556c6a0381850
   depends:
@@ -3919,7 +3919,7 @@ packages:
   license_family: APACHE
   size: 4020362
   timestamp: 1698063432993
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/gtest-1.14.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/gtest-1.14.0-ha357a0b_0.tar.bz2
   sha256: edfb65219af41d5037b6371c6b074c8372db90b17d25f85f55e36523c01949ec
   md5: f21a88869091d6d4d88b9b5f064a3157
   depends:
@@ -3930,7 +3930,7 @@ packages:
   license_family: BSD
   size: 400287
   timestamp: 1692633607623
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
   sha256: 5c36d43cadbbf944d9255e79df85c2e9e6155a1d6f9158e06fcd8ffd458b7663
   md5: a5a2cff387403ccf9cf58aac7a6dde55
   depends:
@@ -3947,7 +3947,7 @@ packages:
   license_family: BSD
   size: 4573879
   timestamp: 1698866750755
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
   sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
   md5: f3ce6fe6eb760c236e5f7d04df5faa81
   depends:
@@ -3956,7 +3956,7 @@ packages:
   license_family: MIT
   size: 28138484
   timestamp: 1692293212596
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
   sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
   md5: 6dd72c43fea25b748ec7a9f6c0407e15
   depends:
@@ -3965,7 +3965,7 @@ packages:
   license_family: BSD
   size: 111810
   timestamp: 1666125671024
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
   sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
   md5: 03cdb7e679924b329ecab8f12cb8fc67
   depends:
@@ -3975,7 +3975,7 @@ packages:
   license_family: APACHE
   size: 38813
   timestamp: 1678997212422
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
   sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
   md5: e113c4e6e758dd68faf196586bf5564d
   depends:
@@ -3985,7 +3985,7 @@ packages:
   license_family: Apache
   size: 51873
   timestamp: 1698254765815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
   sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
   md5: 78baea934985ccd9514a366cc7e80ed4
   depends:
@@ -3994,7 +3994,7 @@ packages:
   license_family: Proprietary
   size: 727499
   timestamp: 1681801225190
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
   sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
   md5: da9b63e42f281f7e77b289f4b654b83b
   depends:
@@ -4016,7 +4016,7 @@ packages:
   license_family: BSD
   size: 218436
   timestamp: 1691121840155
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
   sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
   md5: 6a7cb9b49593b29933fa2b503d533a08
   depends:
@@ -4038,7 +4038,7 @@ packages:
   license_family: BSD
   size: 1257205
   timestamp: 1694181720454
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
   sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
   md5: d861ef66f5c0a282d60b65778a9de2f3
   depends:
@@ -4048,7 +4048,7 @@ packages:
   license_family: MIT
   size: 1048450
   timestamp: 1644315332508
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
   sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
   md5: f7e603c965052deed8b789c35855a42f
   depends:
@@ -4058,14 +4058,14 @@ packages:
   license_family: BSD
   size: 213537
   timestamp: 1666908270815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
   sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
   md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
   license: IJG
   license_family: Other
   size: 278924
   timestamp: 1677849185191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
   sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
   md5: a82a17e78f725dcbd71ff8dac6db05c7
   depends:
@@ -4076,7 +4076,7 @@ packages:
   license_family: MIT
   size: 133134
   timestamp: 1676558895333
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
   sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
   md5: ee9270379a9ebdb6297e4b6849b3f7f0
   depends:
@@ -4092,7 +4092,7 @@ packages:
   license_family: BSD
   size: 195479
   timestamp: 1676329410154
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.5.0-py39hecd8cb5_0.tar.bz2
   sha256: ede34881321808fbb967885dde9b0b6c9c8ef1f3eb192fa514058c4f14201c4f
   md5: 07d24f5332ca5d0e76aa0df051a1f05d
   depends:
@@ -4103,7 +4103,7 @@ packages:
   license_family: BSD
   size: 79901
   timestamp: 1698937699237
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
   sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
   md5: 7e60995b3119417213e5faedda147499
   depends:
@@ -4127,7 +4127,7 @@ packages:
   license_family: BSD
   size: 403165
   timestamp: 1671707664990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
   sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
   md5: cd470bdb28bb0e8b3535c93a3a6dad07
   depends:
@@ -4137,7 +4137,7 @@ packages:
   license_family: BSD
   size: 65431
   timestamp: 1672387389172
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
   sha256: a3a24cd84c291f7c9e28842ccfc2107d149f0aa8e676b85d9104eda77622e603
   md5: 99ba4367783596d1bb0c7766ea6706ea
   depends:
@@ -4148,7 +4148,7 @@ packages:
   license_family: MIT
   size: 1290758
   timestamp: 1686931137388
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -4158,7 +4158,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -4167,7 +4167,7 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
   sha256: 127dbf93874f1bb3493b312fecb5ffedb8f2a41d2470e2cbeb889eb58d89ebf7
   md5: 07502b61e43a2039e4312b40d53c1db1
   depends:
@@ -4182,13 +4182,13 @@ packages:
   license_family: OTHER
   size: 22584954
   timestamp: 1696762195023
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
   sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
   md5: 7dba7aa5b971febb55281659843586ba
   license: MIT
   size: 65470
   timestamp: 1659616172703
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
   sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
   md5: f78a158983f0bbaba56f34b976bc6dae
   depends:
@@ -4196,7 +4196,7 @@ packages:
   license: MIT
   size: 34189
   timestamp: 1659616189313
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
   sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
   md5: 36a1d885725d3ab4d1fadc5a29f978d2
   depends:
@@ -4204,7 +4204,7 @@ packages:
   license: MIT
   size: 327737
   timestamp: 1659616202869
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.4.0-hf20ceda_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcurl-8.4.0-hf20ceda_0.tar.bz2
   sha256: 5501e46f0f145d8fdd72dbc99523caf51c77a814c3531e200beefa811ff4b5ce
   md5: ac8738061571d853de74a590f48e42b6
   depends:
@@ -4219,21 +4219,21 @@ packages:
   license_family: MIT
   size: 369487
   timestamp: 1697023549088
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20221030-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libedit-3.1.20221030-h6c40b1e_0.tar.bz2
   sha256: 67e38ccc55c2d996a8a0949080949c9803ddff84a96c4e34bc4c48fa95e5f35b
   md5: b549aa024097c9f2790ba6eb89bc53fd
   depends:
@@ -4242,14 +4242,14 @@ packages:
   license_family: BSD
   size: 168786
   timestamp: 1670840154554
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
   sha256: 4786264321edbff780633a5b752995eb3193ca4bce11b0fda179577f6cf1102c
   md5: 849fdd014c201a9d2c2aa7c7db38a778
   license: BSD-2-Clause
   license_family: BSD
   size: 103993
   timestamp: 1632891571494
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
   sha256: a60941a0365ee3e8b9ff721f75b0608c234b5652f53337a918b787839de4bb53
   md5: 4d61f019594ebccfb3f4fb87ee778416
   depends:
@@ -4259,14 +4259,14 @@ packages:
   license_family: BSD
   size: 414942
   timestamp: 1685052318462
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
   sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
   md5: 817848d0e2b2808acdc9b3fbbf581726
   license: MIT
   license_family: MIT
   size: 133887
   timestamp: 1683716590737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
   sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
   md5: e458587c87e3f2d20192f4e0738f2c63
   depends:
@@ -4275,7 +4275,7 @@ packages:
   license_family: GPL
   size: 149419
   timestamp: 1665498987619
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
   sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
   md5: 1058b661ec829b2ee3716ee2a5520641
   depends:
@@ -4286,14 +4286,14 @@ packages:
   license_family: GPL
   size: 1917987
   timestamp: 1665498925405
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
   sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
   md5: c90372428e1e4eed4fdcd790979d06b4
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1409377
   timestamp: 1650983531933
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libllvm14-14.0.6-h91fad77_3.tar.bz2
   sha256: 8176dd9a68815301a24ed51e72f3506f5f77c67a112efa0dd14971f2f3b3c8c1
   md5: b5e470c224000a6bda6f655c155b53e7
   depends:
@@ -4305,7 +4305,7 @@ packages:
   license_family: Apache
   size: 27861431
   timestamp: 1683292881730
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
   sha256: 7bfcf69c31a4eb15dfab661c93463ce8dfb7b3de4356945fa5c1ca50a5ae0cb0
   md5: 4934bb34818fa3d99b32b9cb59fed205
   depends:
@@ -4320,7 +4320,7 @@ packages:
   license_family: MIT
   size: 784918
   timestamp: 1697018436251
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -4329,7 +4329,7 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libprotobuf-3.20.3-hfff2838_0.tar.bz2
   sha256: 1884de5207f5a1210217d7132348b4944ec4b09a91085b7b47a19dfdd9b6dbba
   md5: aa960ea0133deec4637a8d05700cc3c4
   depends:
@@ -4339,13 +4339,13 @@ packages:
   license_family: BSD
   size: 2412437
   timestamp: 1675278748544
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.10.0-h04015c4_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libssh2-1.10.0-h04015c4_2.tar.bz2
   sha256: ea67e176a2142813dc19481cd83fd7c17fda32a96cbdd72c78e29b59030eb5fa
   md5: 13a0cba33faf8074613ca460a6ddae19
   depends:
@@ -4354,7 +4354,7 @@ packages:
   license_family: BSD
   size: 338575
   timestamp: 1686931283039
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
   sha256: 21ba71cdc65b56c6daefeeab55959e5a7edadfd697cfa8b2ed5c1b3e2a98586b
   md5: cbbd369ee87aba597c942727bada4eee
   depends:
@@ -4367,7 +4367,7 @@ packages:
   license_family: Apache
   size: 364326
   timestamp: 1687975317748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -4384,7 +4384,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
   sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
   md5: c0b99f8e1c7475f23b1c7b4250b06e1c
   depends:
@@ -4398,7 +4398,7 @@ packages:
   license_family: BSD
   size: 88021
   timestamp: 1694778290062
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
   sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
   md5: 46a65d1fc24013217e06aaf6d65ffcad
   constrains:
@@ -4407,7 +4407,7 @@ packages:
   license_family: BSD
   size: 425478
   timestamp: 1694776947990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
   sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
   md5: 06866415ef22d5322f9bdc9956b59c4d
   depends:
@@ -4419,7 +4419,7 @@ packages:
   license_family: MIT
   size: 678174
   timestamp: 1692970318885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
   sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
   md5: 2edc6c894d6d0321304396e9bd40df94
   depends:
@@ -4429,7 +4429,7 @@ packages:
   license_family: MIT
   size: 241774
   timestamp: 1692973618934
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 0190d3b8d2939f28aa017711cf4147c51a1139da2922cc8420a71562dd99f844
   md5: 454a7f2c4426453f17e995382a4235e4
   depends:
@@ -4439,7 +4439,7 @@ packages:
   license_family: MIT
   size: 36036
   timestamp: 1659783508187
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
   sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
   md5: 5c740b4a18a558de0ccfe601703c423c
   constrains:
@@ -4448,7 +4448,7 @@ packages:
   license_family: Apache
   size: 338738
   timestamp: 1662635677689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.41.0-py39hfff2838_0.tar.bz2
   sha256: fbf3c01a0834c151485b1b2ddf0c83d43703cbea051c6dbcb0d8d41946107670
   md5: 12137025daee35f5c708ca10d0c96e3c
   depends:
@@ -4460,7 +4460,7 @@ packages:
   license_family: BSD
   size: 318622
   timestamp: 1697031357874
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 1dab4daa56408915de3ec270c8b887e7221d48633ea83b0afff61041fc197972
   md5: 1519f9b766f9f894282db8353066e3b2
   depends:
@@ -4469,7 +4469,7 @@ packages:
   license_family: BSD
   size: 11883
   timestamp: 1652903144294
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
   sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
   md5: 8bbd981ca0129d7beeacd3cd7623f714
   depends:
@@ -4480,7 +4480,7 @@ packages:
   license_family: Other
   size: 1491074
   timestamp: 1695058597986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-4.3.2-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-4.3.2-py39h6c40b1e_0.tar.bz2
   sha256: 90e49c636ba91bbe7c31dfa8e9ce584fe952482a6aaa7353a0502dbe337c9aaa
   md5: 4d8212ad094f39d06bcc61b6f388d3a0
   depends:
@@ -4490,7 +4490,7 @@ packages:
   license_family: BSD
   size: 35180
   timestamp: 1686057959850
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
   sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
   md5: d5f58d056b4bfc67aec30c77035ba889
   depends:
@@ -4499,7 +4499,7 @@ packages:
   license_family: BSD
   size: 182491
   timestamp: 1670944720979
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
   sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
   md5: 1affd16b166571a91feae04baf5fd3da
   depends:
@@ -4509,7 +4509,7 @@ packages:
   license_family: BSD
   size: 123431
   timestamp: 1671542016019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
   sha256: e5fc51472fa0f36abd78baa5b3c9245d6627b0da11188e6a954d73f3f2bca210
   md5: df7c519447affffb594f8c56b028ed33
   depends:
@@ -4519,7 +4519,7 @@ packages:
   license_family: MIT
   size: 107035
   timestamp: 1684279974102
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
   sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
   md5: 3681ebf029211ceab26af6f5d35abf39
   depends:
@@ -4530,7 +4530,7 @@ packages:
   license_family: BSD
   size: 22254
   timestamp: 1654598220251
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
   sha256: 2fd179efa024c92d0d71179a981a781d16c70f5d8c6305e0d678b0c7ae1275ab
   md5: addda7f015d1673f794a23fdb18a3e09
   depends:
@@ -4553,7 +4553,7 @@ packages:
   license_family: PSF
   size: 8182219
   timestamp: 1698692361219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
   sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
   md5: 6eb64ecfcd754502e271db0bb51d2cfd
   depends:
@@ -4563,7 +4563,7 @@ packages:
   license_family: BSD
   size: 17374
   timestamp: 1662014643620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 2312ee5a6343e8495802698d7181f1b619aad7479d96ee253407b324ac884417
   md5: 866960fa48a7ca335941786d4869802a
   depends:
@@ -4573,7 +4573,7 @@ packages:
   license_family: MIT
   size: 53542
   timestamp: 1659721365599
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
   sha256: 37f455814ce242eb65ff80a0402f1bd231a388e6823e6c1e65f60b705c032a2d
   md5: 4c9246c492a64729225aa5b04e12c2d1
   depends:
@@ -4582,7 +4582,7 @@ packages:
   license_family: MIT
   size: 19573
   timestamp: 1659716100178
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
   sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
   md5: 2a4d604717a647ad21af766289cbbfc3
   depends:
@@ -4591,7 +4591,7 @@ packages:
   license_family: BSD
   size: 58057
   timestamp: 1607364912348
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
   sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
   md5: 25051fe272624544652dc6d814c2943a
   depends:
@@ -4604,7 +4604,7 @@ packages:
   license_family: Proprietary
   size: 224420228
   timestamp: 1691503125614
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
   sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
   md5: 37d8cf85a63f7aa9af1624894a7d606d
   depends:
@@ -4614,7 +4614,7 @@ packages:
   license_family: BSD
   size: 48590
   timestamp: 1682969183093
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
   sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
   md5: 0b2aee6666135bbd36b46d6ac66160f7
   depends:
@@ -4627,7 +4627,7 @@ packages:
   license_family: BSD
   size: 210705
   timestamp: 1695058433223
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
   sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
   md5: e22fb55ce380d0ebd44cce3f20d5349e
   depends:
@@ -4641,7 +4641,7 @@ packages:
   license_family: BSD
   size: 296614
   timestamp: 1695060155673
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py39haf03e11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/msgpack-python-1.0.3-py39haf03e11_0.tar.bz2
   sha256: e3ac58a4520466ecb759590759c86e81dcddf1c36fd25d081dd9064d9e850c48
   md5: d184127ffc4131fdef14724d5f480c99
   depends:
@@ -4651,7 +4651,7 @@ packages:
   license_family: Apache
   size: 84981
   timestamp: 1652362789251
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py39hecd8cb5_0.tar.bz2
   sha256: 5f60ca253f1fea0a1d765f535ff9ca2cf7efba90aea4c9a290d8f50ad11d4f6f
   md5: 97d6ec94e2300030bddf0e5289cd2a84
   depends:
@@ -4661,7 +4661,7 @@ packages:
   license_family: BSD
   size: 24240
   timestamp: 1607574265505
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
   sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
   md5: 1a5d4004e64e3cfb7a2a297b9117c285
   depends:
@@ -4687,7 +4687,7 @@ packages:
   license_family: BSD
   size: 8213832
   timestamp: 1681756573646
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py39hecd8cb5_0.tar.bz2
   sha256: 59acf22956f295ed429624a1560bceffbbf536ea93ca63a5f1a48975a0afdbcb
   md5: a7a6344327960940bad23e783a4d6bce
   depends:
@@ -4700,7 +4700,7 @@ packages:
   license_family: BSD
   size: 100813
   timestamp: 1698934262550
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
   sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
   md5: e572c1264a7af20b486f64ac8c9e1f57
   depends:
@@ -4728,7 +4728,7 @@ packages:
   license_family: BSD
   size: 573356
   timestamp: 1668450732828
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
   sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
   md5: b67569a7c30af9ffa5cde6e4b52ac68b
   depends:
@@ -4741,14 +4741,14 @@ packages:
   license_family: BSD
   size: 148342
   timestamp: 1694616917184
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
   sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
   md5: 97b81f34efbe86c5220fe82eb584fd62
   depends:
@@ -4757,7 +4757,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387288528
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
   sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
   md5: d77862975a9a1cf50acb803be26e83a1
   depends:
@@ -4782,7 +4782,7 @@ packages:
   license_family: BSD
   size: 575365
   timestamp: 1690985052739
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
   sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
   md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
   depends:
@@ -4792,7 +4792,7 @@ packages:
   license_family: BSD
   size: 22858
   timestamp: 1668160618784
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numba-0.58.0-py39h3ea8b11_0.tar.bz2
   sha256: 249efa747726ad61bc1093f33f155f0b7a0fa5b728cb1a6a6bd126458f279c96
   md5: 1cced9a92d68307846cf59c238a42f13
   depends:
@@ -4812,7 +4812,7 @@ packages:
   license_family: BSD
   size: 4431283
   timestamp: 1697057424792
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
   sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
   md5: 185e9c41abb88ee59b52ec0f5f65d506
   depends:
@@ -4826,7 +4826,7 @@ packages:
   license_family: MIT
   size: 138305
   timestamp: 1696515469702
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.25.2-py39h827a554_0.tar.bz2
   sha256: 361754aae186c6f4f8e5ceadf02b95ae74b47a97eaf1aa37538a7c410fb3ec88
   md5: 02e4a556e3eb2375ec5a75795dd32372
   depends:
@@ -4842,7 +4842,7 @@ packages:
   license_family: BSD
   size: 12847
   timestamp: 1691166007881
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.25.2-py39ha186be2_0.tar.bz2
   sha256: 94d69c58f79dea6d155debef3237f02397ab6c3d042b519ad89fc64d204507d2
   md5: 891a8850c69fd11971e58dfba0c40fcd
   depends:
@@ -4857,7 +4857,7 @@ packages:
   license_family: BSD
   size: 7529822
   timestamp: 1691165972737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
   sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
   md5: 93f5d7b66976154adeda219bea02ba45
   depends:
@@ -4867,7 +4867,7 @@ packages:
   license: BSD 2-Clause
   size: 484257
   timestamp: 1630093862501
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.12-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.12-hca72f7f_0.tar.bz2
   sha256: a40b753094bc68bda7364443e3fba9b9f6d00a25e147c5286226b75b940829d4
   md5: 0fde5da60eba23ea5ca611395d5309fa
   depends:
@@ -4876,7 +4876,7 @@ packages:
   license_family: Apache
   size: 4974949
   timestamp: 1699012522706
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-1.7.4-h995b336_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/orc-1.7.4-h995b336_1.tar.bz2
   sha256: 281d5a10e7a0a25bd6ee20d1d0f03530dd90fe5b4e3490ad3f33f0367df36f7c
   md5: 062f9bba1d43123d02c60d23a29831a1
   depends:
@@ -4890,7 +4890,7 @@ packages:
   license_family: Apache
   size: 425422
   timestamp: 1676482778334
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
   sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
   md5: 4154929ace2ad6ee16aea815635a6d1f
   depends:
@@ -4899,7 +4899,7 @@ packages:
   license_family: Apache
   size: 73598
   timestamp: 1693575307570
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
   sha256: aff5acedef9da91b77851e1a163b8319d72bc4152c98ac87703a2eac1e5d575b
   md5: 7df4c76aa8c52fedce5346748d56459e
   depends:
@@ -4946,7 +4946,7 @@ packages:
   license_family: BSD
   size: 13388063
   timestamp: 1697477404222
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-1.2.3-py39hecd8cb5_0.tar.bz2
   sha256: 1928d1f3aa777c6fe0b279f400fa417b293527531bbdd3d918cc8e987a680f86
   md5: e8d7a163f2f9dd0f1972e126ee87b586
   depends:
@@ -4970,7 +4970,7 @@ packages:
   license_family: BSD
   size: 17076156
   timestamp: 1695146369755
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-1.13.0-py39hecd8cb5_0.tar.bz2
   sha256: 914f1ec8d911083c006c4c2d3b4c0c528e79abba3ae5f1dad825bd896870270d
   md5: 949e0e4c0ce43c92eb52241892230873
   depends:
@@ -4979,7 +4979,7 @@ packages:
   license_family: BSD
   size: 142949
   timestamp: 1684915417020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/partd-1.4.1-py39hecd8cb5_0.tar.bz2
   sha256: ddcb56e35d537f7a748b242c7c44368f112471973a52ae022945f597b7a83c7c
   md5: 94bac4f8fbfaf821ace161b9f1f58716
   depends:
@@ -4993,7 +4993,7 @@ packages:
   license_family: BSD
   size: 36756
   timestamp: 1698702713944
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
   sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
   md5: be0a90921f3bf4f0d6950fb786093de7
   depends:
@@ -5012,7 +5012,7 @@ packages:
   license_family: Other
   size: 719901
   timestamp: 1696580194417
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
   sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
   md5: 81ae9ec2d7fcf6934847bff558b619f5
   depends:
@@ -5023,7 +5023,7 @@ packages:
   license_family: MIT
   size: 2672987
   timestamp: 1697548890181
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
   sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
   md5: 1a822c206e2abddc5d6d821721af227f
   depends:
@@ -5032,7 +5032,7 @@ packages:
   license_family: MIT
   size: 33013
   timestamp: 1692205801265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
   sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
   md5: 1604d33dbdb2446c642970f8b354bedb
   depends:
@@ -5041,7 +5041,7 @@ packages:
   license_family: Apache
   size: 91266
   timestamp: 1659455269141
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
   sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
   md5: d1b3bcc35655a3123acb1fa2ad1a8511
   depends:
@@ -5053,7 +5053,7 @@ packages:
   license_family: BSD
   size: 580828
   timestamp: 1672387372015
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
   sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
   md5: 7540555d1fb192236db9a7c5c9d3601c
   depends:
@@ -5062,7 +5062,7 @@ packages:
   license_family: BSD
   size: 365765
   timestamp: 1656431373327
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-11.0.0-py39he65a03e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyarrow-11.0.0-py39he65a03e_1.tar.bz2
   sha256: 9ca66e703bb0302a32d318eeb14fcd6d78676fcf15a4533879712365030e8646
   md5: 213e1dd8e05ab7bff06fdab423df6f1e
   depends:
@@ -5076,7 +5076,7 @@ packages:
   license_family: Apache
   size: 4391192
   timestamp: 1693273411611
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
   sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
   md5: 0a73533fb6e0dc717ab906a537bc747d
   depends:
@@ -5088,7 +5088,7 @@ packages:
   license_family: BSD
   size: 30803
   timestamp: 1675441638631
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
   sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
   md5: 0a959fbad46ab38ade48dbd358002674
   depends:
@@ -5097,7 +5097,7 @@ packages:
   license_family: BSD
   size: 1864757
   timestamp: 1684280094736
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
   sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
   md5: ea24b5076ef79e4567c5a3f0cb22b470
   depends:
@@ -5107,7 +5107,7 @@ packages:
   license_family: Apache
   size: 95330
   timestamp: 1690223465114
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
   sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
   md5: bcaea6d4a47e9c874becaa700c78dcf7
   depends:
@@ -5116,7 +5116,7 @@ packages:
   license_family: MIT
   size: 157216
   timestamp: 1661452617825
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
   sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
   md5: 707110d1b49cb1864acb0bbaa103591e
   depends:
@@ -5125,7 +5125,7 @@ packages:
   license_family: MIT
   size: 95016
   timestamp: 1636111184034
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
   sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
   md5: 113a443b9c706f9f9c6187c0eaa3de27
   depends:
@@ -5134,7 +5134,7 @@ packages:
   license_family: BSD
   size: 31178
   timestamp: 1605305861851
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
   sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
   md5: 85a8d0001db70e52a479155228cb1fe0
   depends:
@@ -5153,7 +5153,7 @@ packages:
   license_family: PSF
   size: 13324979
   timestamp: 1694439878265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
   sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
   md5: 47c5e22e31ec05a7bc0ce90065a53afd
   depends:
@@ -5162,7 +5162,7 @@ packages:
   license_family: BSD
   size: 265348
   timestamp: 1661368839620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.4.1-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-lmdb-1.4.1-py39hcec6c5f_0.tar.bz2
   sha256: fa3f9b9aa7e0a71e0a7237adf0fdede90808fda954bebd4d10b4bea97ab7f62f
   md5: dc1fb278f98f80996a6642a03a007f34
   depends:
@@ -5172,7 +5172,7 @@ packages:
   license_family: Other
   size: 136975
   timestamp: 1682522551539
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
   sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
   md5: ce9a69e1668aa1e133f2aa6d4e8d346f
   depends:
@@ -5181,7 +5181,7 @@ packages:
   license_family: MIT
   size: 254958
   timestamp: 1695131709704
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 9ee098c09f31fad7ff1856e5ce2619172eaf979997e7a427d1e05cce32c2af00
   md5: cac1d1898b69ae9646dfbf082910635d
   depends:
@@ -5191,7 +5191,7 @@ packages:
   license_family: BSD
   size: 40946
   timestamp: 1685030787453
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
   sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
   md5: 637f08b19dd8fd87347d8c44f9e3e202
   depends:
@@ -5201,7 +5201,7 @@ packages:
   license_family: MIT
   size: 170776
   timestamp: 1698096100056
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
   sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
   md5: 8ce3ac7d8a04e469b566f1b090d01140
   depends:
@@ -5212,7 +5212,7 @@ packages:
   license_family: BSD
   size: 470617
   timestamp: 1657724324011
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
   sha256: c69f556df9a27328c56943f3b5918cbb953cfbca987e20394d823a6174781202
   md5: ab294ae71ecdfaa307a961cc71dd890d
   depends:
@@ -5220,7 +5220,7 @@ packages:
   license: BSD-3-Clause
   size: 205638
   timestamp: 1652449553607
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -5229,7 +5229,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
   sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
   md5: 6f2d41dd76a03b7f85a1ed49af1763d6
   depends:
@@ -5245,7 +5245,7 @@ packages:
   license_family: Apache
   size: 95100
   timestamp: 1690400262627
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
   sha256: a9755ecbfd42c708945027facfa11a3dc3119778326a0ae5df79f80d7b72afa5
   md5: 839ffa4e775fee9a8bdddabf4a14da43
   depends:
@@ -5262,7 +5262,7 @@ packages:
   license_family: BSD
   size: 24331914
   timestamp: 1696545397632
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
   md5: b0321e6f14e139fc15b1f8b4acb35d2f
   depends:
@@ -5271,7 +5271,7 @@ packages:
   license_family: MIT
   size: 1093966
   timestamp: 1690290944588
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.1.9-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/snappy-1.1.9-he9d5cce_0.tar.bz2
   sha256: c7af3280189c023d0c7380a7c1bdda2f2f09b036aa507c2650503b041037bf55
   md5: 58260ae8dcdaf2ec4a07bb1bdb451b34
   depends:
@@ -5280,7 +5280,7 @@ packages:
   license_family: BSD
   size: 1357241
   timestamp: 1649923925096
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
   sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
   md5: 62b64576a0aa5f6c3fb05f56650d25e1
   depends:
@@ -5289,7 +5289,7 @@ packages:
   license_family: Apache
   size: 15535
   timestamp: 1614030509324
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
   sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
   md5: 15b5595b31e39f08eaacbe2e502d8fb3
   depends:
@@ -5298,7 +5298,7 @@ packages:
   license_family: MIT
   size: 67292
   timestamp: 1696347733587
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/spatialpandas-0.4.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/spatialpandas-0.4.9-py39hecd8cb5_0.tar.bz2
   sha256: 4974e2ec8fb3c03cd5b6555b558dadfef640b6b7f2a2984f8dd593f44d464d3f
   md5: 0aa7edd6b36bbcaa30f0ded56c88e7e3
   depends:
@@ -5314,7 +5314,7 @@ packages:
   license_family: BSD
   size: 149386
   timestamp: 1695247229147
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
   sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
   md5: 82e4db6a498480a75d53c55bd35b6478
   depends:
@@ -5326,7 +5326,7 @@ packages:
   license_family: Other
   size: 1801397
   timestamp: 1681394807900
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -5335,7 +5335,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
   sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
   md5: 63b957927b9949ccb19da28ec4612706
   depends:
@@ -5346,7 +5346,7 @@ packages:
   license_family: BSD
   size: 30902
   timestamp: 1671751919031
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
   sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
   md5: e346257a2fa8e2cb48c762138a5d009b
   depends:
@@ -5356,7 +5356,7 @@ packages:
   license_family: BSD
   size: 39915
   timestamp: 1668168959656
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
   sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
   md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
   depends:
@@ -5365,7 +5365,7 @@ packages:
   license_family: BSD
   size: 3536231
   timestamp: 1654088937695
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/toolz-0.12.0-py39hecd8cb5_0.tar.bz2
   sha256: 74fc3a9e308602b3710f8fa671f24f5492571d0c8f7c1b3071dac72671262d45
   md5: e08ead92568f5bd72d5ac7f08f087fee
   depends:
@@ -5374,7 +5374,7 @@ packages:
   license_family: BSD
   size: 102258
   timestamp: 1667464155001
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
   sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
   md5: a1bbf0abfb8c45541122c0eb2feee317
   depends:
@@ -5383,7 +5383,7 @@ packages:
   license_family: Apache
   size: 680464
   timestamp: 1696937112175
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
   sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
   md5: d689f6203c0a9d04fb229c73d7e80a7a
   depends:
@@ -5396,7 +5396,7 @@ packages:
   license_family: MOZILLA
   size: 125145
   timestamp: 1679561909274
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
   md5: 8a292c1ee22489bef2e84bc3aaf4098e
   depends:
@@ -5405,7 +5405,7 @@ packages:
   license_family: BSD
   size: 193141
   timestamp: 1671143985219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
   md5: 8bf0bfffc11ad06a1c94e145941b0ad4
   depends:
@@ -5415,7 +5415,7 @@ packages:
   license_family: PSF
   size: 9651
   timestamp: 1690297655669
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
   md5: 343514a174b3485fde55a73f56398dd7
   depends:
@@ -5424,7 +5424,7 @@ packages:
   license_family: PSF
   size: 58456
   timestamp: 1690297648002
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
   sha256: 11e7401cb6805db7ce22b1f9dd6ba5b7941c92225ce440bed1da0af284bfcad4
   md5: 5c10d68fa5616cdd82ee93ef6e0f038c
   depends:
@@ -5433,7 +5433,7 @@ packages:
   license_family: MIT
   size: 11615
   timestamp: 1659769478980
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
   sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
   md5: c2242e8fd24003a74ddf37416661e06d
   depends:
@@ -5448,14 +5448,14 @@ packages:
   license_family: MIT
   size: 188757
   timestamp: 1698257668273
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h9ed2024_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/utf8proc-2.6.1-h9ed2024_0.tar.bz2
   sha256: 99d4feafeeb067f60215951b6090aa8a7efe06283d4b39b077d54f579acf1925
   md5: 8a87bb430755d203382a9802ad4def21
   license: MIT
   license_family: MIT
   size: 309534
   timestamp: 1611836061631
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
   sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
   md5: 41f445e36b6b6722a9444508eef069f8
   depends:
@@ -5464,7 +5464,7 @@ packages:
   license_family: BSD
   size: 20583
   timestamp: 1607365395045
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
   sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
   md5: 409ee46ed24267b6da6fb32d13e1f21e
   depends:
@@ -5474,7 +5474,7 @@ packages:
   license_family: BSD
   size: 70730
   timestamp: 1614804271285
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
   sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
   md5: eb74e74d8e4fd533c55eb98b7b5e83bc
   depends:
@@ -5483,7 +5483,7 @@ packages:
   license_family: MIT
   size: 102637
   timestamp: 1695742077778
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xarray-2023.6.0-py39hecd8cb5_0.tar.bz2
   sha256: 9f5a34bef727052f97b1cc387c3a99a60754de99d6e4ab0b2de770d76b64dc0f
   md5: b5ce0421037c626cfcec5b43d83ec420
   depends:
@@ -5495,7 +5495,7 @@ packages:
   license_family: Apache
   size: 1787999
   timestamp: 1689041573350
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
   sha256: cb007615819fd240ea4e343835dfbda3c508a92b5b7158219d30a22d0e67b57c
   md5: bf215e781ac81e0fc433eedee330c54b
   depends:
@@ -5504,20 +5504,20 @@ packages:
   license_family: BSD
   size: 49462
   timestamp: 1675159191191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
   sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
   md5: e243baa546432c8394a8059a44a5a3e4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 419227
   timestamp: 1683113010463
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
   sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
   md5: fe4ac85ee86d3a94ea3a4ebea3779763
   depends:
@@ -5526,7 +5526,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 321797
   timestamp: 1616055526986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zict-3.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 16e64fb88aec5586d199cf317f4e10cfd4cb84bc2ffa51254b44c569f7834d3f
   md5: 57b7c150445badc2b718691e67468091
   depends:
@@ -5537,7 +5537,7 @@ packages:
   license_family: BSD
   size: 77666
   timestamp: 1695833024405
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
   sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
   md5: bc7073d9d4c0211cc4a1207c98fb765a
   depends:
@@ -5546,14 +5546,14 @@ packages:
   license_family: MIT
   size: 19091
   timestamp: 1672387204865
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
   sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
   md5: 8e495591e369ac161857a72011c0a296
   license: Zlib
   license_family: Other
   size: 120272
   timestamp: 1666595024203
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
   sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
   md5: f1465fbd810b3746c6de6babfd4fe28a
   depends:
@@ -5565,7 +5565,7 @@ packages:
   license_family: BSD
   size: 1023573
   timestamp: 1681304595869
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/abseil-cpp-20230802.0-h313beb8_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/abseil-cpp-20230802.0-h313beb8_2.tar.bz2
   sha256: d42422c15e115f76aec2f71e25887104359d5140af3cc6f19e358af011dc7ba9
   md5: 9996619edfa02accc1fb7912d5ecc5fb
   depends:
@@ -5575,7 +5575,7 @@ packages:
   license_family: Apache
   size: 1372151
   timestamp: 1698327835928
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
   sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
   md5: cf55cb8d7031b30c70c56fc7c782b5c7
   depends:
@@ -5588,7 +5588,7 @@ packages:
   license_family: MIT
   size: 156104
   timestamp: 1644482799136
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
   sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
   md5: 84fce327d9f0d594e86f565e5c21962e
   depends:
@@ -5597,7 +5597,7 @@ packages:
   license_family: BSD
   size: 10183
   timestamp: 1629146082730
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
   sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
   md5: 84b8b998a741b37abf5312c1c03696ef
   depends:
@@ -5607,7 +5607,7 @@ packages:
   license_family: MIT
   size: 33979
   timestamp: 1644845817952
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-11.0.0-hc7aafb3_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/arrow-cpp-11.0.0-hc7aafb3_2.tar.bz2
   sha256: 35366c72df504648f1ad0f5392d6dc094f468b923f7a81334dabe9b6e08ddedf
   md5: ba2924efa4743344ec29a9f001a4ff58
   depends:
@@ -5635,7 +5635,7 @@ packages:
   license_family: Apache
   size: 8073021
   timestamp: 1693263207600
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
   sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
   md5: 77b746931c8f31c3ae393ccb5819d43d
   depends:
@@ -5644,14 +5644,14 @@ packages:
   license_family: MIT
   size: 133628
   timestamp: 1695717890677
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.6.8-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-common-0.6.8-h80987f9_1.tar.bz2
   sha256: 4d63ff9d0b424c5dc2e20bb8324a348869dee0340511effadfd1d622842a8322
   md5: 3137a10d16bb223ae981d566d60d984b
   license: Apache-2.0
   license_family: Apache
   size: 153917
   timestamp: 1685977852438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.1.6-h313beb8_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-event-stream-0.1.6-h313beb8_6.tar.bz2
   sha256: f41918089bd42945e10d71aaf30eacede92db2b57193c2c931a710c314a39730
   md5: b0a63224a995df6e07fdebba41a3c1a6
   depends:
@@ -5662,7 +5662,7 @@ packages:
   license_family: Apache
   size: 24245
   timestamp: 1686021087869
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.11-h80987f9_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-checksums-0.1.11-h80987f9_2.tar.bz2
   sha256: 5068b5773e8ce07dfc34718fb6c4be364a4c79d821138d68c3d246873bd562b9
   md5: 1efb7da0ab9ee77370640b77f74f9c7c
   depends:
@@ -5671,7 +5671,7 @@ packages:
   license_family: Apache
   size: 51725
   timestamp: 1685998294585
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.8.185-ha71a6ea_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-sdk-cpp-1.8.185-ha71a6ea_1.tar.bz2
   sha256: 233e5de862c76724dadec694df81405812be33dbbbe6ca14b6e5d586885acfc7
   md5: 0a776ce91b4d11b4fd86b01f9e9e4ec8
   depends:
@@ -5685,7 +5685,7 @@ packages:
   license_family: Apache
   size: 2159308
   timestamp: 1686057541094
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
   sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
   md5: 3df6e8ba34208dea068890e5d5318cc0
   depends:
@@ -5695,12 +5695,12 @@ packages:
   license_family: MIT
   size: 206759
   timestamp: 1681493095987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.2.1-py39h33ce5c2_0.tar.bz2
   sha256: 4edfceca9958378015a2d5ff705aecb977fa329fdd0caf51cf6a1b6b5506e5ab
   md5: 7404ddc0add9157338d7d4822ac13cb3
   depends:
@@ -5718,7 +5718,7 @@ packages:
   license_family: BSD
   size: 6462121
   timestamp: 1690546176434
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
   sha256: f1660ecfb8687d74e81a7b00699a8bb4677cbd791d14f50ba517de98e2f187ca
   md5: 1636fc4b725da8c5e967952a55f3fd80
   depends:
@@ -5728,7 +5728,7 @@ packages:
   license_family: OTHER
   size: 11780
   timestamp: 1696762172661
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
   sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
   md5: bb55f81435cb6e11d264242274fccd1a
   depends:
@@ -5738,7 +5738,7 @@ packages:
   license_family: BSD
   size: 115947
   timestamp: 1657175645380
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
   md5: f860193e14afc7ef3f5b990a2ac003d2
   depends:
@@ -5748,7 +5748,7 @@ packages:
   license: MIT
   size: 18936
   timestamp: 1659616204016
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
   sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
   md5: ad53130f3fd1f8d3c2fcbb7496e5585d
   depends:
@@ -5757,7 +5757,7 @@ packages:
   license: MIT
   size: 18715
   timestamp: 1659616188888
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
   sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
   md5: 0982c046fb976e9f9fb19e7510187a18
   depends:
@@ -5766,28 +5766,28 @@ packages:
   license: MIT
   size: 366983
   timestamp: 1659616245272
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h620ffc9_4.tar.bz2
   sha256: 019469288da4767fd021f488b907e2f4f3b34db686fa12055d52d9bb7bb4d872
   md5: 9f63c782a4d20150ae9a664ee87cce16
   license: bzip2-1.0.6
   license_family: BSD
   size: 150682
   timestamp: 1624215191959
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
   sha256: b0be79290b1df1cf1d07a1a9c3f3a92ae262643a6df3dc10dfbac22a82874dd4
   md5: 8fdcf1c08eee91fec7eefc22863c816a
   license: MIT
   license_family: MIT
   size: 106550
   timestamp: 1693902036526
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
   sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
   md5: 31ac2f5596cb7a44adf073c930641c54
   license: MPL-2.0
   license_family: Other
   size: 133817
   timestamp: 1694009762858
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
   sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
   md5: cf1f6c3c34a1e1b9ab22b04233d860f6
   depends:
@@ -5796,7 +5796,7 @@ packages:
   license_family: Other
   size: 159783
   timestamp: 1690232303987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
   sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
   md5: 0eb268e38b5174d471a6e87d9d6102b1
   depends:
@@ -5807,7 +5807,7 @@ packages:
   license_family: MIT
   size: 225355
   timestamp: 1670423312966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py39hca03da5_0.tar.bz2
   sha256: 41e76ba21b1279278a039245275eb4ee1f81b38b33cba00ca3575f06be5dc570
   md5: c5170bf12e308fb7f2d1b4b9065f3df7
   depends:
@@ -5816,7 +5816,7 @@ packages:
   license_family: BSD
   size: 153036
   timestamp: 1698129857856
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-2.2.1-py39hca03da5_0.tar.bz2
   sha256: 36240dde0a1546469f35f3b5509b55384dfd894beb56b3ca929da4b96a2a5f24
   md5: 844539636e4c20ee99e8ceeff5e902bc
   depends:
@@ -5825,7 +5825,7 @@ packages:
   license_family: BSD
   size: 41376
   timestamp: 1683040042906
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
   sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
   md5: e68c94666cd60221b575c3814c89bac0
   depends:
@@ -5835,7 +5835,7 @@ packages:
   license_family: CC
   size: 1946451
   timestamp: 1668084573824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
   sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
   md5: 1773ae2b080cdd55827e27673351551e
   depends:
@@ -5845,7 +5845,7 @@ packages:
   license_family: BSD
   size: 13646
   timestamp: 1671231171682
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
   sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
   md5: 53bfd99ad1b09164d537209cffd98161
   depends:
@@ -5856,7 +5856,7 @@ packages:
   license_family: BSD
   size: 244040
   timestamp: 1663827469853
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
   sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
   md5: b62455043c8eb2434466885b19fed2de
   depends:
@@ -5869,7 +5869,7 @@ packages:
   license_family: BSD
   size: 1399573
   timestamp: 1694211828228
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-0.12.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cytoolz-0.12.0-py39h1a28f6b_0.tar.bz2
   sha256: 25f89dccae875d5f73e6bb41ab8bf5b39972715a304e8ce64cee93585d129825
   md5: a7c6f8274e12b068638fac6e43e9d10e
   depends:
@@ -5879,7 +5879,7 @@ packages:
   license_family: BSD
   size: 361259
   timestamp: 1667466038174
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-2023.6.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/dask-2023.6.0-py39hca03da5_0.tar.bz2
   sha256: 664bffc07c01bca0732405b0683dbb24af7edd888e110e1a12252f14fa0819d0
   md5: ac3b1564712149abe6620718b4faef0a
   depends:
@@ -5897,7 +5897,7 @@ packages:
   license_family: BSD
   size: 6102
   timestamp: 1687285030179
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2023.6.0-py39hca03da5_0.tar.bz2
   sha256: fb7d12350372a70daa9f476647d04fc213ef9d8f73cbddaf30b40b1b45beef0f
   md5: 34595eb00802934d092b3086d7b4344d
   depends:
@@ -5914,7 +5914,7 @@ packages:
   license_family: BSD
   size: 2124926
   timestamp: 1686783028732
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/datashader-0.15.2-py39hca03da5_0.tar.bz2
   sha256: d366da723fc8baf4d9de0d25688619efe4d1c7abe5407dfb28654c4c9e2ef019
   md5: d4c923ceedacd8d5d18f994feed8dbb8
   depends:
@@ -5936,7 +5936,7 @@ packages:
   license_family: BSD
   size: 17708209
   timestamp: 1692372524993
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/datashape-0.5.4-py39hca03da5_1.tar.bz2
   sha256: 83dbf9755ea887576e3f34adb1c26d418db9aaf3c77dc07f30b58c2221b81c72
   md5: 36246697d07d6709de78abe36b6beae5
   depends:
@@ -5948,7 +5948,7 @@ packages:
   license_family: BSD
   size: 103201
   timestamp: 1629793063728
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
   sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
   md5: eb3cdc0fc210838b9271512a6a1b7c85
   depends:
@@ -5958,7 +5958,7 @@ packages:
   license_family: MIT
   size: 2067708
   timestamp: 1690905319109
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2023.6.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/distributed-2023.6.0-py39hca03da5_0.tar.bz2
   sha256: 57934600ce752c7ae44d5a773da4bc6c35c024235673d1c80522c2533ebaa219
   md5: 5f4de12f8691fc4a7ecca67e32099c7b
   depends:
@@ -5982,7 +5982,7 @@ packages:
   license_family: BSD
   size: 1390444
   timestamp: 1686866076457
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
   sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
   md5: f44b80b9405410e5bde6bfe0b31d5b3f
   depends:
@@ -5991,7 +5991,7 @@ packages:
   license_family: MIT
   size: 15135
   timestamp: 1650293774207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
   sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
   md5: f87027ccce1361d0f82c0edf1a10d53b
   depends:
@@ -6000,7 +6000,7 @@ packages:
   license_family: BSD
   size: 27677
   timestamp: 1668714367519
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -6010,7 +6010,7 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2023.9.2-py39hca03da5_0.tar.bz2
   sha256: 296371685a5dcd98f5128f11f413e63aa59c1eba60543faf3baaebd445964c5d
   md5: 9817e8ffd3669484c9a7de99a8aceffb
   depends:
@@ -6019,7 +6019,7 @@ packages:
   license_family: BSD
   size: 257844
   timestamp: 1695734566410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/gflags-2.2.2-hc377ac9_0.tar.bz2
   sha256: 30919078dc8497553981ed8436990832698e933340e0192e25d04e1c8ab00dff
   md5: d5bcb4ec3322b0d7aa466c71b87d7775
   depends:
@@ -6028,14 +6028,14 @@ packages:
   license_family: BSD
   size: 146150
   timestamp: 1628725106681
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
   sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
   md5: 1d0bd7e576c64c059ef781dd319ad82a
   license: MIT
   license_family: MIT
   size: 77591
   timestamp: 1676983230102
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/glog-0.5.0-hc377ac9_0.tar.bz2
   sha256: 4fa13d0426ff6652fc41a19e8a7658aacc6fb6c8bfba2e2334d6884137cfbb0b
   md5: d69680d281636c7cb3b22f404e0b8764
   depends:
@@ -6044,7 +6044,7 @@ packages:
   license: BSD-3-Clause
   size: 94695
   timestamp: 1628726581042
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/grpc-cpp-1.48.2-hc60591f_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/grpc-cpp-1.48.2-hc60591f_3.tar.bz2
   sha256: 8d4269fb53b83f7dd6ae0932e5528df78d81bf1aa8510fc19b90780d0e9109b0
   md5: 6426f96b576b853b08187ded60796a43
   depends:
@@ -6061,7 +6061,7 @@ packages:
   license_family: APACHE
   size: 3910982
   timestamp: 1698063335516
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gtest-1.14.0-h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/gtest-1.14.0-h48ca7d4_0.tar.bz2
   sha256: 064fc752345ef3973d3ebf2145029eaa308c17e12abe72a732255db9cdea6a40
   md5: 37ace38cf07143b39ae9b89feb204d3d
   depends:
@@ -6072,7 +6072,7 @@ packages:
   license_family: BSD
   size: 399378
   timestamp: 1692633568295
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
   sha256: 3e480af22e98246c056bbd91d6be5352df34ff2b8451d9c7f614baeafb450d39
   md5: 695fe7ccaf6935d3117533d1e6737320
   depends:
@@ -6089,7 +6089,7 @@ packages:
   license_family: BSD
   size: 4542265
   timestamp: 1698866834303
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
   sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
   md5: 69eb3b03765627b6159ed23cdde78396
   depends:
@@ -6098,7 +6098,7 @@ packages:
   license_family: MIT
   size: 28399065
   timestamp: 1692293207812
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
   sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
   md5: 83366cbd3beb073112f4644a613b6bca
   depends:
@@ -6107,7 +6107,7 @@ packages:
   license_family: BSD
   size: 111933
   timestamp: 1666125627512
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
   sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
   md5: 647c1a2f8460ffa8c670a1915bbdb494
   depends:
@@ -6117,7 +6117,7 @@ packages:
   license_family: APACHE
   size: 38790
   timestamp: 1678997152549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
   sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
   md5: 35e541905426c686ef2ff010a0e502fd
   depends:
@@ -6127,7 +6127,7 @@ packages:
   license_family: Apache
   size: 51860
   timestamp: 1698254731870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
   sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
   md5: 187d7720aedf38759d122cccb4576f2c
   depends:
@@ -6149,7 +6149,7 @@ packages:
   license_family: BSD
   size: 219976
   timestamp: 1691121991680
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
   sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
   md5: e8e7f10741f9cfa737b310b334940441
   depends:
@@ -6171,7 +6171,7 @@ packages:
   license_family: BSD
   size: 1255894
   timestamp: 1694181494549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
   sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
   md5: ff209e75aee17af2e358b0008fbe8c88
   depends:
@@ -6181,7 +6181,7 @@ packages:
   license_family: MIT
   size: 1022945
   timestamp: 1644315931223
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
   sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
   md5: d3e78ef296b3c74910d003bd10b475d6
   depends:
@@ -6191,14 +6191,14 @@ packages:
   license_family: BSD
   size: 213972
   timestamp: 1666908195870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
   sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
   md5: 055e12390b844ea6c6e956ee08a618e8
   license: IJG
   license_family: Other
   size: 273479
   timestamp: 1677849171867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
   sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
   md5: 783e2ad3d36472648c5ccc9f3051db3c
   depends:
@@ -6209,7 +6209,7 @@ packages:
   license_family: MIT
   size: 133077
   timestamp: 1676558732505
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
   sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
   md5: 0677598f673f9729b5990316170a999d
   depends:
@@ -6225,7 +6225,7 @@ packages:
   license_family: BSD
   size: 197129
   timestamp: 1676329661580
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.5.0-py39hca03da5_0.tar.bz2
   sha256: cee2cc791937b240be796561ae67e5a7c57b014826fa087fd75b02acf82135ba
   md5: 141af9befcd79a876ded744de7d1fa8f
   depends:
@@ -6236,7 +6236,7 @@ packages:
   license_family: BSD
   size: 79928
   timestamp: 1698937338528
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
   sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
   md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
   depends:
@@ -6260,7 +6260,7 @@ packages:
   license_family: BSD
   size: 401319
   timestamp: 1671707682572
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
   sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
   md5: 247558a0aecf1ef7e77a4343761353d6
   depends:
@@ -6270,7 +6270,7 @@ packages:
   license_family: BSD
   size: 64600
   timestamp: 1672387273585
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
   sha256: 789402b67398d3d936ac4486df01869d59b0e1ba298cbd06407d059aced871e4
   md5: a0f50a38705d0507bbf57ee49a1d9c29
   depends:
@@ -6281,7 +6281,7 @@ packages:
   license_family: MIT
   size: 1308175
   timestamp: 1686931157327
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -6291,7 +6291,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -6300,7 +6300,7 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
   sha256: c1f104bc84ee46a3d3beafb5e35236c64e6b4fd6cceabfb420e1838171b1d9c1
   md5: 4f95903a1be48bbee1f9a818ec810b89
   depends:
@@ -6315,13 +6315,13 @@ packages:
   license_family: OTHER
   size: 22243663
   timestamp: 1696762144385
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
   md5: a0f206782751dfffed0dd51302a1bf26
   license: MIT
   size: 68012
   timestamp: 1659616138077
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
   md5: 4c6667cdd061d28e9bc4e4300e4d115e
   depends:
@@ -6329,7 +6329,7 @@ packages:
   license: MIT
   size: 31173
   timestamp: 1659616155596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
   md5: 637e9430e258ddf050623ef2360184d8
   depends:
@@ -6337,7 +6337,7 @@ packages:
   license: MIT
   size: 298430
   timestamp: 1659616172209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.4.0-h3e2b118_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcurl-8.4.0-h3e2b118_0.tar.bz2
   sha256: 452d4f604f22619ef7a154680fbacbbced4bb221e1756a4d0b9dd0846514c25a
   md5: aaf5235cf4bb69c1d87e779511a52dea
   depends:
@@ -6352,21 +6352,21 @@ packages:
   license_family: MIT
   size: 355802
   timestamp: 1697023465826
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20221030-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libedit-3.1.20221030-h80987f9_0.tar.bz2
   sha256: 6304be2cb816e57ac178068d49befffba4354847f9ee1cfd0ec6acf9ba4ad94a
   md5: af25d1cc1334d44d2b96eb8133c1dac9
   depends:
@@ -6375,14 +6375,14 @@ packages:
   license_family: BSD
   size: 167428
   timestamp: 1670840153090
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
   sha256: 6fc572025852b210ecddcca3ab9ff3f1d5f6bd91f1933c6e296de6bb331f6b5d
   md5: 6dd7d9c5737bbd2a27d18f15318dc3e6
   license: BSD-2-Clause
   license_family: BSD
   size: 102059
   timestamp: 1628961869728
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
   sha256: 9e7b9bb9367d8725a751cdfa0b2d270434d303ea196cfaacc605ee26be09874a
   md5: 44d1843cc2f17eb2674f35b95468f551
   depends:
@@ -6392,14 +6392,14 @@ packages:
   license_family: BSD
   size: 415467
   timestamp: 1685052299052
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
   sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
   md5: 55c615026c0869f8d3ba657f3bd38c43
   license: MIT
   license_family: MIT
   size: 120389
   timestamp: 1683716579036
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -6408,7 +6408,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -6419,14 +6419,14 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
   sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
   md5: a41117710dafe569c9cc4e83f6f29fe3
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1411339
   timestamp: 1650982753977
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libllvm14-14.0.6-h7ec7a93_3.tar.bz2
   sha256: d654027daea13ac9db36ab5fd5eff3ad398ec97c1777bf399f3ec680d2c145b9
   md5: baabb1f905054bfea3af8f5768572a34
   depends:
@@ -6438,7 +6438,7 @@ packages:
   license_family: Apache
   size: 26579907
   timestamp: 1683291669565
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
   sha256: b7cd58ddb892ed9d3983bdde8fc2530f0653a58818c87e08659f3795f04d8aff
   md5: cf519f7233951d00a30c3b969c4cd161
   depends:
@@ -6453,7 +6453,7 @@ packages:
   license_family: MIT
   size: 728977
   timestamp: 1697018415626
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -6464,7 +6464,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -6473,7 +6473,7 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libprotobuf-3.20.3-h514c7bf_0.tar.bz2
   sha256: 239ec46c06c477e722230159971bac8d9eb14793a2e75f6e3d3a7a04ed5d5ebd
   md5: 50e9c501f39bb262703c764789099f24
   depends:
@@ -6483,13 +6483,13 @@ packages:
   license_family: BSD
   size: 2338901
   timestamp: 1675278555141
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.10.0-h02f6b3c_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libssh2-1.10.0-h02f6b3c_2.tar.bz2
   sha256: c16b9310ccbfef25d8cc35d53acaf40af838170f7fdb87df5178baaf096a9045
   md5: 41dce58413afe3226a5c8c66fea6db05
   depends:
@@ -6498,7 +6498,7 @@ packages:
   license_family: BSD
   size: 334603
   timestamp: 1686931243969
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
   sha256: 82a73882a31e7a4f4edcdb0c21562e123da913d03b90b19396bd6dd4fcd9a7fc
   md5: b5e5199892949d1e7e2db7bf0ee4dfe9
   depends:
@@ -6511,7 +6511,7 @@ packages:
   license_family: Apache
   size: 361781
   timestamp: 1687975246139
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -6528,7 +6528,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
   sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
   md5: 98d22e0124d55fae3c37c608dab1dcc9
   depends:
@@ -6542,7 +6542,7 @@ packages:
   license_family: BSD
   size: 89825
   timestamp: 1694778225280
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
   sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
   md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
   constrains:
@@ -6551,7 +6551,7 @@ packages:
   license_family: BSD
   size: 331675
   timestamp: 1694776939192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
   sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
   md5: 0ba499df6755eae5d2d23aa4ab004553
   depends:
@@ -6563,7 +6563,7 @@ packages:
   license_family: MIT
   size: 642657
   timestamp: 1692970217410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
   sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
   md5: c73101971e5ab6a8e8688239884eac81
   depends:
@@ -6573,7 +6573,7 @@ packages:
   license_family: MIT
   size: 241607
   timestamp: 1692973585084
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
   sha256: ac50f846e93e68d50bfdd5589ea8272b987243a64eba8e2e358ef311d7734001
   md5: f19270ff954a41dabbfe36ff0656935b
   depends:
@@ -6583,7 +6583,7 @@ packages:
   license_family: MIT
   size: 36040
   timestamp: 1659783399073
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -6592,7 +6592,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.41.0-py39h514c7bf_0.tar.bz2
   sha256: 124d9d4f865f0f66c4e5e7f99dc1110330c9415cc51effc0a5aad4261880c2f0
   md5: c08c14e55ba470513eb6c87206fb7b30
   depends:
@@ -6604,7 +6604,7 @@ packages:
   license_family: BSD
   size: 322413
   timestamp: 1697031210019
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py39hca03da5_0.tar.bz2
   sha256: 83e1c11fb14ec2767e833b540a6a0fdbd8641523b5673273914007008e6666da
   md5: 64adbf70a0d4ab82aca039e972821537
   depends:
@@ -6613,7 +6613,7 @@ packages:
   license_family: BSD
   size: 11877
   timestamp: 1652903192510
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
   sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
   md5: 353dff9d5d996c2a260f66381b2ce3e8
   depends:
@@ -6624,7 +6624,7 @@ packages:
   license_family: Other
   size: 1470815
   timestamp: 1695058433965
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.3.2-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-4.3.2-py39h80987f9_0.tar.bz2
   sha256: 8e438ac9008003c616c931ff83a29bec61eb93ff338bbd4b485a0c3ff24129a6
   md5: c2c34ba302a09b8ad0493372f93d5443
   depends:
@@ -6634,7 +6634,7 @@ packages:
   license_family: BSD
   size: 37178
   timestamp: 1686063992475
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
   sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
   md5: c99006da802a97c9aae30da8c16b4820
   depends:
@@ -6643,7 +6643,7 @@ packages:
   license_family: BSD
   size: 176131
   timestamp: 1670944706815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
   sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
   md5: 60bd1e037cda86205526f77405d78129
   depends:
@@ -6653,7 +6653,7 @@ packages:
   license_family: BSD
   size: 123361
   timestamp: 1671541992772
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
   sha256: 2fd690fa3c54a40f0426874ea12e12aad2718263a75708ddd1fa6052a4ad7fb3
   md5: 81388724babfe9c32ea5cdd93633c342
   depends:
@@ -6663,7 +6663,7 @@ packages:
   license_family: MIT
   size: 107072
   timestamp: 1684280007887
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
   sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
   md5: 34dfd76da78de2eae95bbda390d746d6
   depends:
@@ -6674,7 +6674,7 @@ packages:
   license_family: BSD
   size: 23092
   timestamp: 1654598007056
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
   sha256: bf0eeef3c3c713515766ab8b0dc7863413de5b4b227deede97e24d90ca342345
   md5: a7bba1857eb84fb50caea377e60d2050
   depends:
@@ -6696,7 +6696,7 @@ packages:
   license_family: PSF
   size: 8066509
   timestamp: 1698692266161
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
   sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
   md5: eb79dabbeedee7da85dfbfb145bb8a26
   depends:
@@ -6706,7 +6706,7 @@ packages:
   license_family: BSD
   size: 17342
   timestamp: 1662014601345
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
   sha256: f400ad75dd2890627dc948f3e2e6b19732d02c124723eaf22272026993a94d52
   md5: 4a4ffc7365e30b18f4443281839e2718
   depends:
@@ -6716,7 +6716,7 @@ packages:
   license_family: MIT
   size: 53505
   timestamp: 1659721313693
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
   sha256: 20fb26a7ac748ce288cf8483a837b0c33f1348ae738bcdb69cdc2763c7bbf7e1
   md5: a0aebbc6c170ebd8d4710fd70b3db503
   depends:
@@ -6725,7 +6725,7 @@ packages:
   license_family: MIT
   size: 19562
   timestamp: 1659716131839
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
   sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
   md5: 56db7bd3ff511cd839bda081523b3edd
   depends:
@@ -6734,7 +6734,7 @@ packages:
   license_family: BSD
   size: 55683
   timestamp: 1629356128780
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py39h525c30c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/msgpack-python-1.0.3-py39h525c30c_0.tar.bz2
   sha256: 20021076eaf466a3bd28a11a5fa28d1cec5fefcaa37d01de8e34c29bc560f8e3
   md5: 48de2033df7f3739fa92f9e9e150e2d5
   depends:
@@ -6744,7 +6744,7 @@ packages:
   license_family: Apache
   size: 85401
   timestamp: 1652362790532
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py39hca03da5_0.tar.bz2
   sha256: ee936ba5fd196c15c3cb538aef721e54bb4486110ae3ebbfcf78e95e8380efa4
   md5: dde1d9e040e04cbfbc0138898240a660
   depends:
@@ -6754,7 +6754,7 @@ packages:
   license_family: BSD
   size: 23003
   timestamp: 1629282780853
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
   sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
   md5: 176e0dcaeb28393881bacf69941e3889
   depends:
@@ -6780,7 +6780,7 @@ packages:
   license_family: BSD
   size: 8289638
   timestamp: 1681756329011
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py39hca03da5_0.tar.bz2
   sha256: d34fcad560dcc7b8e7df2a0250be9694a02e072aa7f7d4992ebd427665575a8e
   md5: 5972b5a5fbac5cea54ee0ff2cef85897
   depends:
@@ -6793,7 +6793,7 @@ packages:
   license_family: BSD
   size: 100843
   timestamp: 1698934268054
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
   sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
   md5: 150ea9fadddf21993d3328d3e48a18b7
   depends:
@@ -6821,7 +6821,7 @@ packages:
   license_family: BSD
   size: 557688
   timestamp: 1668450759059
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
   sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
   md5: 37163b32508f9f589b3e6462a3a47546
   depends:
@@ -6834,14 +6834,14 @@ packages:
   license_family: BSD
   size: 148426
   timestamp: 1694616771736
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
   sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
   md5: 6cdf7cbc43bf40e92b056a5576bd0086
   depends:
@@ -6850,7 +6850,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387216468
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
   sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
   md5: 0f05853a139b6cda9c73e9d2707a4976
   depends:
@@ -6875,7 +6875,7 @@ packages:
   license_family: BSD
   size: 590288
   timestamp: 1690984971741
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
   sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
   md5: 7de782e4fb34bfa95ef2fc79d27d727d
   depends:
@@ -6885,7 +6885,7 @@ packages:
   license_family: BSD
   size: 22840
   timestamp: 1668160634885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numba-0.58.0-py39h46d7db6_0.tar.bz2
   sha256: 0a5a7295f055d2f175528cc895dcb07533df5f0b87f05ac7839ec1af15988218
   md5: 3d8e6925b26ca29486d0b58b30f1f663
   depends:
@@ -6905,7 +6905,7 @@ packages:
   license_family: BSD
   size: 4428704
   timestamp: 1697061454581
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
   sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
   md5: 1a7b23113372c5667dbfe45976b9cc5c
   depends:
@@ -6916,7 +6916,7 @@ packages:
   license_family: MIT
   size: 126357
   timestamp: 1696515322390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.25.2-py39h3b2db8e_0.tar.bz2
   sha256: 5332b3635fbc1a800b0fe58db7a0e57bb5ef75cbc56a0512c76f01ac7fc7139f
   md5: ab7fbf394a301d25d1bf8cfa76fd917b
   depends:
@@ -6929,7 +6929,7 @@ packages:
   license_family: BSD
   size: 12847
   timestamp: 1691092401334
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.25.2-py39ha9811e2_0.tar.bz2
   sha256: 114b5aa7ef0990a615e27116e05dba0e7e78df750e3592aa4b732438f391a394
   md5: 3284c63e9251227322ef9fd9c997f2c7
   depends:
@@ -6943,7 +6943,7 @@ packages:
   license_family: BSD
   size: 6338710
   timestamp: 1691092386069
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
   sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
   md5: 371358a54bbdd307603888348d1a2c6f
   depends:
@@ -6953,7 +6953,7 @@ packages:
   license: BSD 2-Clause
   size: 412248
   timestamp: 1628861367714
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.12-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.12-h1a28f6b_0.tar.bz2
   sha256: 8da09e2669c8217fa915cc35cac6994fbf81ef45d52776bbcd44aa107ad2eafa
   md5: 35199a35c3aca5d373116843d377ca47
   depends:
@@ -6962,7 +6962,7 @@ packages:
   license_family: Apache
   size: 4762670
   timestamp: 1699012560527
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/orc-1.7.4-hdca1487_1.tar.bz2
   sha256: c4135710b5536fb859a6672c055bbc2cff0426e0655e75c7fdf808f7f3344ada
   md5: 483605a01fccba850b7f0cbdeff29858
   depends:
@@ -6976,7 +6976,7 @@ packages:
   license_family: Apache
   size: 421604
   timestamp: 1676482754496
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
   sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
   md5: d73db95f07a282021efdf8bc09713261
   depends:
@@ -6985,7 +6985,7 @@ packages:
   license_family: Apache
   size: 73620
   timestamp: 1693575195999
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
   sha256: 247b5e4d81b6d5d013a9c27e1f30c41fff896fed98a68ebda26b19b4062a6828
   md5: 354a1d65300b4309d53dfa648014e8fe
   depends:
@@ -7032,7 +7032,7 @@ packages:
   license_family: BSD
   size: 13257999
   timestamp: 1697478739906
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-1.2.3-py39hca03da5_0.tar.bz2
   sha256: 4548d2a1bc58cd61e9c9f475a77bac68d9e49d4996c4c891d5ca8ba5ea7552b0
   md5: b4ed079246a55ac8f91b8f8abb713b3b
   depends:
@@ -7056,7 +7056,7 @@ packages:
   license_family: BSD
   size: 17115516
   timestamp: 1695146000246
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-1.13.0-py39hca03da5_0.tar.bz2
   sha256: 0d64f2438be25524bbfeb8646e4fb3c18499d747398a03ed15d41b350b03e001
   md5: 6a4908a5c9f7b3f17f09ebc34b1b691c
   depends:
@@ -7065,7 +7065,7 @@ packages:
   license_family: BSD
   size: 142857
   timestamp: 1684915417403
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.1-py39hca03da5_0.tar.bz2
   sha256: 3a6450282f56265e800500b62cd1bbe39cd5a6a09c4747c6dc3e8aab10bfa8a0
   md5: 9b01b16f9c5a033ee8b92683d66b184e
   depends:
@@ -7079,7 +7079,7 @@ packages:
   license_family: BSD
   size: 36731
   timestamp: 1698702611592
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
   sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
   md5: 6e01c592ae3b8ff2d12cae76f2f4276b
   depends:
@@ -7098,7 +7098,7 @@ packages:
   license_family: Other
   size: 715239
   timestamp: 1696580071596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
   sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
   md5: 9fb8f460c130d56caf33c6bbe46fbe8a
   depends:
@@ -7109,7 +7109,7 @@ packages:
   license_family: MIT
   size: 2678841
   timestamp: 1697548790931
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
   sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
   md5: 390b8c3cd74281abecdbfd51476922f9
   depends:
@@ -7118,7 +7118,7 @@ packages:
   license_family: MIT
   size: 33033
   timestamp: 1692205747301
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
   sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
   md5: 7896828fb3565fefad43f980d50c8723
   depends:
@@ -7127,7 +7127,7 @@ packages:
   license_family: Apache
   size: 91190
   timestamp: 1659455206354
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
   sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
   md5: d934c74eb66d01af0f45f0881f4bab77
   depends:
@@ -7139,7 +7139,7 @@ packages:
   license_family: BSD
   size: 580588
   timestamp: 1672387390426
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
   sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
   md5: 9858166e5ffb624c8b9d281f4000d725
   depends:
@@ -7148,7 +7148,7 @@ packages:
   license_family: BSD
   size: 367167
   timestamp: 1656431368885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-11.0.0-py39hbfed03b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyarrow-11.0.0-py39hbfed03b_1.tar.bz2
   sha256: a5ea3a518a33ea96e544f134d96ea2d967c796172169a253e1c987d05a3342ee
   md5: eced623c20b50303d6248e05f48092e0
   depends:
@@ -7162,7 +7162,7 @@ packages:
   license_family: Apache
   size: 4374629
   timestamp: 1693273159579
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
   sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
   md5: 4d2b45c6be8221e6a3e44c2d5838426f
   depends:
@@ -7174,7 +7174,7 @@ packages:
   license_family: BSD
   size: 30843
   timestamp: 1675441531640
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
   sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
   md5: 02521df4e2e79f75faa9cbb3560ab1dd
   depends:
@@ -7183,7 +7183,7 @@ packages:
   license_family: BSD
   size: 1861763
   timestamp: 1684280026169
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
   sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
   md5: bdebe59bffc7adbad83fdcd9d429a5f5
   depends:
@@ -7193,7 +7193,7 @@ packages:
   license_family: Apache
   size: 95234
   timestamp: 1690223494699
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
   sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
   md5: d716e5c9b5eec45ce1df8eb52cab817a
   depends:
@@ -7202,7 +7202,7 @@ packages:
   license_family: MIT
   size: 157408
   timestamp: 1661452601692
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
   sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
   md5: 1907629863ed8e7c35ead232dae7693f
   depends:
@@ -7211,7 +7211,7 @@ packages:
   license_family: MIT
   size: 91636
   timestamp: 1628941083263
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
   sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
   md5: 847b9bddf2a86e1609c0d53bbc23ea79
   depends:
@@ -7220,7 +7220,7 @@ packages:
   license_family: BSD
   size: 27378
   timestamp: 1626781391140
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
   sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
   md5: 18aa18bd0d260605923877921d26cc74
   depends:
@@ -7239,7 +7239,7 @@ packages:
   license_family: PSF
   size: 13194025
   timestamp: 1694438901368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
   sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
   md5: 45642a99c83e7aed74d1ffab1f20145b
   depends:
@@ -7248,7 +7248,7 @@ packages:
   license_family: BSD
   size: 266647
   timestamp: 1661368655993
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.4.1-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-lmdb-1.4.1-py39h313beb8_0.tar.bz2
   sha256: 120745bd4e38c1ad20fbaa6a43b932e4233c349959f12c71e8dc85bc4dbd78e7
   md5: 35ffa41c6c93dc92534cd1a1ed18be5b
   depends:
@@ -7258,7 +7258,7 @@ packages:
   license_family: Other
   size: 133586
   timestamp: 1682522585527
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
   sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
   md5: fec748525144049a2fc7f52f9755232c
   depends:
@@ -7267,7 +7267,7 @@ packages:
   license_family: MIT
   size: 257235
   timestamp: 1695131702047
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
   sha256: 960192a143672e9c1d6fe4027af448512d91eee7501e5c245c21b865cf8bf429
   md5: 76d491244218505f071ba56a308673df
   depends:
@@ -7277,7 +7277,7 @@ packages:
   license_family: BSD
   size: 40950
   timestamp: 1685030774581
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
   sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
   md5: 3445d25415998c807efbe64d3a7e03c8
   depends:
@@ -7287,7 +7287,7 @@ packages:
   license_family: MIT
   size: 167068
   timestamp: 1698096118071
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
   sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
   md5: e6e92da28e9b0e428ed4b7df417bec25
   depends:
@@ -7298,7 +7298,7 @@ packages:
   license_family: BSD
   size: 472418
   timestamp: 1657724315435
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
   sha256: 089c6b9bebfa690f380710f219ab0fcc1acec9f2e187d4174a08222c45f58afc
   md5: 11b832c6c10a6d2b0e687a20c3037c97
   depends:
@@ -7306,7 +7306,7 @@ packages:
   license: BSD-3-Clause
   size: 194532
   timestamp: 1652449531448
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -7315,7 +7315,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
   sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
   md5: dba22515f36d3c266de5896350813ea2
   depends:
@@ -7331,7 +7331,7 @@ packages:
   license_family: Apache
   size: 95103
   timestamp: 1690400315537
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
   sha256: c35449c0ca64d0d6a23c019b6eba188f546e42379857cbc4240bbdddee1159d3
   md5: 61cb82346e21710f3e0645096cda4e12
   depends:
@@ -7347,7 +7347,7 @@ packages:
   license_family: BSD
   size: 22859180
   timestamp: 1696543469561
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
   sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
   md5: 3cd7eb43e285faba76faf67667e26b00
   depends:
@@ -7356,7 +7356,7 @@ packages:
   license_family: MIT
   size: 1093916
   timestamp: 1690290951258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.1.9-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/snappy-1.1.9-hc377ac9_0.tar.bz2
   sha256: 1a0eb8133498944a69d432b79b3edae63d64b2ccd92aa508b89b3fa83dc7983a
   md5: c9acd31658bb93735e401406ae43089d
   depends:
@@ -7365,7 +7365,7 @@ packages:
   license_family: BSD
   size: 1304256
   timestamp: 1650293949317
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
   sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
   md5: c5e9aef0d6895de1c927e9d796cd7cd3
   depends:
@@ -7374,7 +7374,7 @@ packages:
   license_family: Apache
   size: 15691
   timestamp: 1629145910454
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
   sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
   md5: 0f7c229e774146ffc4e29dedf75372bf
   depends:
@@ -7383,7 +7383,7 @@ packages:
   license_family: MIT
   size: 67279
   timestamp: 1696347632563
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/spatialpandas-0.4.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/spatialpandas-0.4.9-py39hca03da5_0.tar.bz2
   sha256: b0ddb0fe25fd6be7f5619eea067e92a789f39e458a971366ee8da540773cf6ea
   md5: 7255da059b6190a750c2c2d5f404e9ad
   depends:
@@ -7399,7 +7399,7 @@ packages:
   license_family: BSD
   size: 149377
   timestamp: 1695247383366
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
   sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
   md5: 2302a79a045f152e183a52a81adfba62
   depends:
@@ -7411,7 +7411,7 @@ packages:
   license_family: Other
   size: 1674163
   timestamp: 1681394762218
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
   sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
   md5: ae58720a18a2ed15eae214ad7a10d1b5
   depends:
@@ -7420,7 +7420,7 @@ packages:
   license_family: Apache
   size: 140125
   timestamp: 1680167256603
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
   sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
   md5: 4ae67163d55cf9df83d4027ebc38c501
   depends:
@@ -7431,7 +7431,7 @@ packages:
   license_family: BSD
   size: 30894
   timestamp: 1671751931536
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
   sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
   md5: dbb5c0cddb6661a89afee647fd3dc01e
   depends:
@@ -7441,7 +7441,7 @@ packages:
   license_family: BSD
   size: 39875
   timestamp: 1668168874870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
   sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
   md5: 667e60c8b407d73cbba40f44901f4f00
   depends:
@@ -7450,7 +7450,7 @@ packages:
   license_family: BSD
   size: 3412693
   timestamp: 1654088929697
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/toolz-0.12.0-py39hca03da5_0.tar.bz2
   sha256: 065cf1b08faf1d28aa348d569f2266d8b33b22ba424312c7ec959be95f217646
   md5: 20370dbc92a9262e6fc8c82208f74ff2
   depends:
@@ -7459,7 +7459,7 @@ packages:
   license_family: BSD
   size: 102259
   timestamp: 1667464137769
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
   sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
   md5: 884f788a5f6a664c9b79f7a4a60362d0
   depends:
@@ -7468,7 +7468,7 @@ packages:
   license_family: Apache
   size: 680561
   timestamp: 1696937004165
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
   sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
   md5: 639a4f489af172c866c18442948e5874
   depends:
@@ -7481,7 +7481,7 @@ packages:
   license_family: MOZILLA
   size: 125170
   timestamp: 1679561942932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
   sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
   md5: e5b90eba83fddba6d7aa6072b5bf7c91
   depends:
@@ -7490,7 +7490,7 @@ packages:
   license_family: BSD
   size: 193017
   timestamp: 1671143921826
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
   md5: 644ef8830437070f60efcfcd6a987198
   depends:
@@ -7500,7 +7500,7 @@ packages:
   license_family: PSF
   size: 9670
   timestamp: 1690297532002
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
   md5: a902a833bb186a2f1a4b2b89b1195136
   depends:
@@ -7509,7 +7509,7 @@ packages:
   license_family: PSF
   size: 58466
   timestamp: 1690297524418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
   sha256: 536045a8a172c651fd306c285a6d7409775f018dac944f2124c538ccfb195e28
   md5: d4dc6cdf0812191b9ec78b35b4fdf3e0
   depends:
@@ -7518,7 +7518,7 @@ packages:
   license_family: MIT
   size: 11593
   timestamp: 1659769477205
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
   sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
   md5: f3f1d2c1028dad2f11ff950a15c99dbf
   depends:
@@ -7533,14 +7533,14 @@ packages:
   license_family: MIT
   size: 188640
   timestamp: 1698257577209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/utf8proc-2.6.1-h1a28f6b_0.tar.bz2
   sha256: 51736bc20b585261902ea83590782b4ac6e54a2b5723cf8e819f33a1013af690
   md5: 34e8baed182ea45eb7e72d387e6f7fa5
   license: MIT
   license_family: MIT
   size: 101295
   timestamp: 1628694426801
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
   sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
   md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
   depends:
@@ -7549,7 +7549,7 @@ packages:
   license_family: BSD
   size: 20091
   timestamp: 1629144441130
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
   sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
   md5: 3089c63bf8f4d0423e1a287da286d83e
   depends:
@@ -7559,7 +7559,7 @@ packages:
   license_family: BSD
   size: 70923
   timestamp: 1629357115820
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
   sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
   md5: 5886b30b312445471268444f41f39dc7
   depends:
@@ -7568,7 +7568,7 @@ packages:
   license_family: MIT
   size: 102583
   timestamp: 1695741976083
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xarray-2023.6.0-py39hca03da5_0.tar.bz2
   sha256: 300b9e4cfc9d01fa4d537060b2867f3cb89f22f932992fc2427e00dda050d55b
   md5: 768c174577b786b99f8b46c4789b36a2
   depends:
@@ -7580,7 +7580,7 @@ packages:
   license_family: Apache
   size: 1800646
   timestamp: 1689041569828
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
   sha256: 105e39d3eb51b47c7244b3379c0133ab7051966664f52835453b14509215b159
   md5: ed20012c2cd99ffd04cca9929e0bc061
   depends:
@@ -7589,20 +7589,20 @@ packages:
   license_family: BSD
   size: 49775
   timestamp: 1675159079039
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
   sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
   md5: 2e75ad6a09c308268192efe03cc9ebf4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 411778
   timestamp: 1683113019715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
   sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
   md5: 30f666bf97c26587c5d2f68cc5f330ab
   depends:
@@ -7611,7 +7611,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 316901
   timestamp: 1629287855861
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zict-3.0.0-py39hca03da5_0.tar.bz2
   sha256: 8d31a7e9356948fd3d715faa6111e78dec6ffb6981819dd182aed7f765ec97c1
   md5: 869dc425508ac78b9031bde17f568cd8
   depends:
@@ -7622,7 +7622,7 @@ packages:
   license_family: BSD
   size: 77665
   timestamp: 1695832985587
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
   sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
   md5: 584e591d36dcd5ba5c45404f0f7ebb2d
   depends:
@@ -7631,14 +7631,14 @@ packages:
   license_family: MIT
   size: 19076
   timestamp: 1672387153578
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
   sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
   md5: 467ae28215d1aa1c5688bc0c8a184269
   license: Zlib
   license_family: Other
   size: 103525
   timestamp: 1666595022664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
   sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
   md5: 7cfbed15f1feee1422810f7830075f53
   depends:
@@ -7650,7 +7650,7 @@ packages:
   license_family: BSD
   size: 779464
   timestamp: 1681304594848
-- conda: https://repo.anaconda.com/pkgs/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/abseil-cpp-20211102.0-hd77b12b_0.tar.bz2
   sha256: c5a4f98a90713f799a73195cc159571c4bd373bfa43640dc0c1707608e582945
   md5: 537f198da93942d8ef7008606edae551
   depends:
@@ -7660,7 +7660,7 @@ packages:
   license_family: Apache
   size: 2363136
   timestamp: 1652426285158
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
   sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
   md5: ed14f9bc6e55220483f1a5a388625a08
   depends:
@@ -7673,7 +7673,7 @@ packages:
   license_family: MIT
   size: 162772
   timestamp: 1644481986085
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
   sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
   md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
   depends:
@@ -7685,7 +7685,7 @@ packages:
   license_family: MIT
   size: 39253
   timestamp: 1644551767970
-- conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-11.0.0-ha81ea56_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/arrow-cpp-11.0.0-ha81ea56_2.tar.bz2
   sha256: d039fa7a61ba39f73007c9600827bb73ffcbe0e53f1b505ec90aadad9f03a7d1
   md5: 29b4ee3013059cb3bfc7ea3615bf48c1
   depends:
@@ -7714,7 +7714,7 @@ packages:
   license_family: Apache
   size: 8320742
   timestamp: 1693265580715
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
   sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
   md5: b24d13c443a26f65a0778b475a5726bc
   depends:
@@ -7723,7 +7723,7 @@ packages:
   license_family: MIT
   size: 132830
   timestamp: 1695717959996
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.6.8-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-common-0.6.8-h2bbff1b_1.tar.bz2
   sha256: bddd29eeda0582b60f9acf79e56cf2921fe1a01fe64207fb6db1a243c1604339
   md5: 6598ca0318ff021ec7279d011a314c60
   depends:
@@ -7733,7 +7733,7 @@ packages:
   license_family: Apache
   size: 164184
   timestamp: 1685977910402
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.1.6-hd77b12b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-event-stream-0.1.6-hd77b12b_6.tar.bz2
   sha256: 7d55f521fac0d4ae8dca1233fbde41321e67aa8ae683b41b506012809af48191
   md5: 126c485741a00fa9e688e5f138510cfa
   depends:
@@ -7745,7 +7745,7 @@ packages:
   license_family: Apache
   size: 27553
   timestamp: 1685999081313
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.11-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-checksums-0.1.11-h2bbff1b_2.tar.bz2
   sha256: 7f66a409f02718870deaf43bcaf1a997ea43c8657861a902ae01bd570ed7a82d
   md5: e23c359b77a20d7a9cf422dcdadec3c8
   depends:
@@ -7756,7 +7756,7 @@ packages:
   license_family: Apache
   size: 53376
   timestamp: 1685994712130
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.8.185-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-sdk-cpp-1.8.185-hd77b12b_1.tar.bz2
   sha256: b6c0b47023b13b944705f1c9701d9fceba59278ebe21ddba2dd9774a6d0b8551
   md5: 3b2b3baf0bc96d73a5ae315840529ed4
   depends:
@@ -7770,7 +7770,7 @@ packages:
   license_family: Apache
   size: 3231175
   timestamp: 1686057995042
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
   sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
   md5: 302c3c0696e17eaa62e140e3892644ae
   depends:
@@ -7780,12 +7780,12 @@ packages:
   license_family: MIT
   size: 199723
   timestamp: 1681493196911
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-3.2.1-py39h9909e9c_0.tar.bz2
   sha256: 29e914b68f261dd564de357888d32ec1511a6fcac9477fe68797289aba4d3e75
   md5: 288585e412638a51e0288caf690d543b
   depends:
@@ -7803,7 +7803,7 @@ packages:
   license_family: BSD
   size: 6485148
   timestamp: 1690546982849
-- conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
   sha256: 68ef338b27c035add89c0812ad469dd8c9e94f27130f770345ea20deb049d50b
   md5: 9ec19b145f655329532b608963cf32f4
   depends:
@@ -7814,7 +7814,7 @@ packages:
   license_family: OTHER
   size: 11334
   timestamp: 1696764270626
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
   sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
   md5: bf930260f679bc74227bbb18bc36ae82
   depends:
@@ -7826,7 +7826,7 @@ packages:
   license_family: BSD
   size: 119700
   timestamp: 1657176150595
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
   md5: 507dfe693ef429f466d964b599f4af21
   depends:
@@ -7838,7 +7838,7 @@ packages:
   license: MIT
   size: 18650
   timestamp: 1659616328001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
   md5: d0bf43e8df60baae3b3105aa5c42a791
   depends:
@@ -7849,7 +7849,7 @@ packages:
   license: MIT
   size: 21153
   timestamp: 1659616312367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
   sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
   md5: 7bd24bf94c24e810aecaaf84a0978e6f
   depends:
@@ -7859,7 +7859,7 @@ packages:
   license: MIT
   size: 343204
   timestamp: 1659616543542
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-he774522_0.tar.bz2
   sha256: 3a26c397d4e0d546b0c2f433074c20813c5f3ae98bcf07a165c648f369a850b9
   md5: 8f8069ce8c9eff1b0f124de2c0a63b86
   depends:
@@ -7868,7 +7868,7 @@ packages:
   license_family: BSD
   size: 154105
   timestamp: 1563219293348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
   sha256: 41a6c5a90b88ec7010bb6dd89390754e476b52c3ab2d519bdab9556da8829479
   md5: b047426a545e287f45e8abfbfcb0de55
   depends:
@@ -7878,14 +7878,14 @@ packages:
   license_family: MIT
   size: 118041
   timestamp: 1693902191485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
   sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
   md5: 092b417c11edcbe6bb9b765ab4a55d23
   license: MPL-2.0
   license_family: Other
   size: 164999
   timestamp: 1694009822357
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
   sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
   md5: 708a750d370b9d6875651021e21c4446
   depends:
@@ -7894,7 +7894,7 @@ packages:
   license_family: Other
   size: 159322
   timestamp: 1690232335307
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
   sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
   md5: c35736da3ea26782425e78061268cf5e
   depends:
@@ -7906,7 +7906,7 @@ packages:
   license_family: MIT
   size: 228713
   timestamp: 1670423312743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py39haa95532_0.tar.bz2
   sha256: 9577ff772035cd30e72323edff379dd3df877de00f7f690fd33c8720a5a4bbc9
   md5: 1130fd979d4f97f511f10b36ff09513d
   depends:
@@ -7916,7 +7916,7 @@ packages:
   license_family: BSD
   size: 152728
   timestamp: 1698129962390
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cloudpickle-2.2.1-py39haa95532_0.tar.bz2
   sha256: e5babe79f8132c4bd44bc05307976f2c5485014ae3129655dddbd3baa8e75e46
   md5: 093223df00c6ef9db4e7e5aa7bfec00a
   depends:
@@ -7925,7 +7925,7 @@ packages:
   license_family: BSD
   size: 40844
   timestamp: 1683040252786
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
   sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
   md5: 457a4339a53c033d48ce0c72e5038d2e
   depends:
@@ -7934,7 +7934,7 @@ packages:
   license_family: BSD
   size: 30330
   timestamp: 1672387265402
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
   sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
   md5: 59ec65fd9e06b81a65cc12986c67d5da
   depends:
@@ -7944,7 +7944,7 @@ packages:
   license_family: CC
   size: 1939614
   timestamp: 1668084794027
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
   sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
   md5: 3489c1a2b73fc957b5a62cc59349e25b
   depends:
@@ -7954,7 +7954,7 @@ packages:
   license_family: BSD
   size: 13438
   timestamp: 1671231196438
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
   sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
   md5: 3492b96083c1e904cc32d26ea7f1e1d8
   depends:
@@ -7966,7 +7966,7 @@ packages:
   license_family: BSD
   size: 184280
   timestamp: 1663827558327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
   sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
   md5: f46d904bc6f220327e70474971341f52
   depends:
@@ -7981,7 +7981,7 @@ packages:
   license_family: BSD
   size: 1220835
   timestamp: 1694445639066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-0.12.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cytoolz-0.12.0-py39h2bbff1b_0.tar.bz2
   sha256: 28c350d12caf11ba087e033289e5152ea9b9dc4abbf0229299a3e5d20759f47e
   md5: 4bac24daf8224ea465812ad92c30ad47
   depends:
@@ -7993,7 +7993,7 @@ packages:
   license_family: BSD
   size: 311754
   timestamp: 1667466298939
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-2023.6.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/dask-2023.6.0-py39haa95532_0.tar.bz2
   sha256: 4a76fc5f38fa806fe29278cfa5541b6efa60062123854998fab7fba629490f4f
   md5: 6ee30cfc076adeffa3b70ef987603f52
   depends:
@@ -8011,7 +8011,7 @@ packages:
   license_family: BSD
   size: 5634
   timestamp: 1687285077691
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/dask-core-2023.6.0-py39haa95532_0.tar.bz2
   sha256: 78d66bcb1c979647e9c5473825d4a5e35afa2a0dfeef71cb0d9d9a72fea3c102
   md5: f2875875bb22ab4704a77bc368a9dc00
   depends:
@@ -8028,7 +8028,7 @@ packages:
   license_family: BSD
   size: 2180195
   timestamp: 1686783294287
-- conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/datashader-0.15.2-py39haa95532_0.tar.bz2
   sha256: 882a0fb257fb07bb47e8127b9ce1f556e319ce4941b74adc94f9849093e11d0d
   md5: b6ef3c0b6e49ff3d497785c744ce44cc
   depends:
@@ -8050,7 +8050,7 @@ packages:
   license_family: BSD
   size: 17688679
   timestamp: 1692373093225
-- conda: https://repo.anaconda.com/pkgs/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/datashape-0.5.4-py39haa95532_1.tar.bz2
   sha256: a6c8b5d32c52ce71d41c7702265e0bb064c960ab67b88ecbea967595c5e02bc3
   md5: 112f2f9c7055656ec156fe287c97c0e9
   depends:
@@ -8062,7 +8062,7 @@ packages:
   license_family: BSD
   size: 104432
   timestamp: 1613390539244
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
   sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
   md5: 2ff4fb509788b0e47ac684ba151394d0
   depends:
@@ -8073,7 +8073,7 @@ packages:
   license_family: MIT
   size: 3289966
   timestamp: 1690907040646
-- conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2023.6.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/distributed-2023.6.0-py39haa95532_0.tar.bz2
   sha256: 630642c70be3bcc7c4dcbebd42700b0d24e10e008cf2910a6da0ff547415b513
   md5: 30640e2f388681e0bc2d0819c393e3c1
   depends:
@@ -8097,7 +8097,7 @@ packages:
   license_family: BSD
   size: 1417000
   timestamp: 1686866407042
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
   sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
   md5: 0f166c3e70541d8bee6e9d0cb60fb66e
   depends:
@@ -8106,7 +8106,7 @@ packages:
   license_family: MIT
   size: 16979
   timestamp: 1649926678161
-- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
   sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
   md5: ea93d413944ca6a8677eb1b284b136ae
   depends:
@@ -8115,7 +8115,7 @@ packages:
   license_family: BSD
   size: 27388
   timestamp: 1668714577678
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -8127,7 +8127,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fsspec-2023.9.2-py39haa95532_0.tar.bz2
   sha256: 6b724886465fea70d2ca843fea1d01bcc24d496601587b87c0cb8f2626b259c2
   md5: 6c11d9242869d6c3b01698f728bd409b
   depends:
@@ -8136,7 +8136,7 @@ packages:
   license_family: BSD
   size: 260567
   timestamp: 1695734829130
-- conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-ha925a31_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/gflags-2.2.2-ha925a31_0.tar.bz2
   sha256: ad0e4798638530f78c8f36ab21ca05c229d0dba4111327a2c8fdc7d1c4d91912
   md5: 9e22a730deccc88b398abac59752760e
   depends:
@@ -8145,7 +8145,7 @@ packages:
   license_family: BSD
   size: 328927
   timestamp: 1542388617060
-- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
   sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
   md5: 9f167d3e45441bc3633c1974b1b0ce8c
   depends:
@@ -8155,7 +8155,7 @@ packages:
   license_family: MIT
   size: 88421
   timestamp: 1676983264486
-- conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/glog-0.5.0-hd77b12b_0.tar.bz2
   sha256: 203032374cdb03d0b443f9a9fa600ce3fb0b76bff7e8d92d2254e199fc878e03
   md5: 6b6f718cb8ece69c73e3798105b5340b
   depends:
@@ -8165,7 +8165,7 @@ packages:
   license: BSD-3-Clause
   size: 92876
   timestamp: 1620733126207
-- conda: https://repo.anaconda.com/pkgs/main/win-64/grpc-cpp-1.48.2-hfe90ff0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/grpc-cpp-1.48.2-hfe90ff0_1.tar.bz2
   sha256: 0c6223208742064a2829f8dd658e04b72f5176e357a1320c0b0398b91abfd292
   md5: 19c77d6709407253582fae939434016c
   depends:
@@ -8179,7 +8179,7 @@ packages:
   license_family: APACHE
   size: 31002375
   timestamp: 1685747992041
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
   sha256: fa8f868e49721ca19912f816a6da221172758f9e3d28d8b31d53249fb14dc25f
   md5: 09f9a2cea9425d76dccf9b026afe5bb2
   depends:
@@ -8196,13 +8196,13 @@ packages:
   license_family: BSD
   size: 4576915
   timestamp: 1698866895838
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
   sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
   md5: 582d2c1135a89da757a038de831e7f39
   license: Intel proprietary
   size: 11086648
   timestamp: 1664812389803
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
   sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
   md5: 30fdefd1541c789c163751291a8faa88
   depends:
@@ -8211,7 +8211,7 @@ packages:
   license_family: BSD
   size: 111448
   timestamp: 1666125667599
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
   sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
   md5: a10f07c7a3510272a296f9fed458a4ed
   depends:
@@ -8221,7 +8221,7 @@ packages:
   license_family: APACHE
   size: 38098
   timestamp: 1678997241511
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
   sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
   md5: fad9cf2023d807da8d44996e9d4399a0
   depends:
@@ -8231,7 +8231,7 @@ packages:
   license_family: Apache
   size: 51490
   timestamp: 1698254721864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
   sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
   md5: 9834848bd7c7759acf12e78d09388563
   depends:
@@ -8241,7 +8241,7 @@ packages:
   license_family: Proprietary
   size: 3891030
   timestamp: 1681801474383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
   sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
   md5: 1285c8c628bc912c54d0968574c9f4c9
   depends:
@@ -8262,7 +8262,7 @@ packages:
   license_family: BSD
   size: 217232
   timestamp: 1691122695748
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
   sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
   md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
   depends:
@@ -8283,7 +8283,7 @@ packages:
   license_family: BSD
   size: 1279433
   timestamp: 1694181820978
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
   sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
   md5: f5fcce35d3f21cdfc5893c5a7a86c651
   depends:
@@ -8293,7 +8293,7 @@ packages:
   license_family: MIT
   size: 1035394
   timestamp: 1644315567034
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
   sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
   md5: f67fe3337528e2886f1ac3ab8ac37985
   depends:
@@ -8303,7 +8303,7 @@ packages:
   license_family: BSD
   size: 213110
   timestamp: 1666908350218
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
   sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
   md5: 81f2c343dc4c65eea39c45383272068f
   depends:
@@ -8313,7 +8313,7 @@ packages:
   license_family: Other
   size: 407861
   timestamp: 1677849239400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
   sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
   md5: bd9526d38a145fe311a8aa36bc11e071
   depends:
@@ -8324,7 +8324,7 @@ packages:
   license_family: MIT
   size: 152006
   timestamp: 1676558783570
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
   sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
   md5: a00e6a62956fde3c4135464353ee8a53
   depends:
@@ -8340,7 +8340,7 @@ packages:
   license_family: BSD
   size: 229158
   timestamp: 1676330909084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.5.0-py39haa95532_0.tar.bz2
   sha256: e840d6b322faa7d5fee2c54ed6074e3a6b7fe38a9356020a4027d9e09c40a1a1
   md5: 038bb985c0d43bf77a8e772f4c4ad22a
   depends:
@@ -8352,7 +8352,7 @@ packages:
   license_family: BSD
   size: 103854
   timestamp: 1698937448209
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
   sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
   md5: 5efa1332f7c0a8d9638eda02170c4ce5
   depends:
@@ -8377,7 +8377,7 @@ packages:
   license_family: BSD
   size: 413653
   timestamp: 1671707957673
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
   sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
   md5: 891fe66a24d8714737b2874985ee1303
   depends:
@@ -8388,7 +8388,7 @@ packages:
   license_family: BSD
   size: 62298
   timestamp: 1672388166096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -8398,7 +8398,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
   sha256: 4184dd040fc38cb123a98588a8344aa8d1ba1932df5fcc6c188f6b21f5a0c306
   md5: da58cfa83f3d6c31ae12d8777cd1b64d
   depends:
@@ -8411,7 +8411,7 @@ packages:
   license_family: OTHER
   size: 29803292
   timestamp: 1696764164248
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
   sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
   md5: c345f51706eef530454f66b794e5e574
   depends:
@@ -8420,7 +8420,7 @@ packages:
   license: MIT
   size: 68189
   timestamp: 1659616216976
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
   md5: a7400cfb72042977bc047909ed504ce8
   depends:
@@ -8430,7 +8430,7 @@ packages:
   license: MIT
   size: 33743
   timestamp: 1659616248209
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
   md5: 6307f6854754ab5bd7c84e6998385bb1
   depends:
@@ -8440,7 +8440,7 @@ packages:
   license: MIT
   size: 733177
   timestamp: 1659616279453
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.1.1-h86230a5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libcurl-8.1.1-h86230a5_0.tar.bz2
   sha256: 5763d2c3cbb615b6560e91b91b13116229dd38c3e18ee952a1861aec56e8e99c
   md5: cc1f82beb7d4c258263c12785caae23e
   depends:
@@ -8453,7 +8453,7 @@ packages:
   license_family: MIT
   size: 326718
   timestamp: 1685433002097
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -8463,7 +8463,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
   sha256: 6458c7a370c4e3366b3b208c5b2834a7acfb17981e47fe3fb861f225d7cefbc3
   md5: ecabf4acab5b604856d8c7c4278c2c2c
   depends:
@@ -8475,7 +8475,7 @@ packages:
   license_family: BSD
   size: 446380
   timestamp: 1685052520132
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
   sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
   md5: b812bc5d9c76242e2bb2ac87afe7d39b
   depends:
@@ -8485,7 +8485,7 @@ packages:
   license_family: GPL3
   size: 730280
   timestamp: 1650983734373
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -8496,7 +8496,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libprotobuf-3.20.3-h23ce68f_0.tar.bz2
   sha256: f7368e611e349b91315ce4ba4dbf9116d996a48f98eed425f4d5c3d5b9fcfa5e
   md5: 77eb9daff9052f1fbf24d91c5bba1d74
   depends:
@@ -8507,7 +8507,7 @@ packages:
   license_family: BSD
   size: 2543079
   timestamp: 1675278760037
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -8516,7 +8516,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.10.0-he2ea4bf_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libssh2-1.10.0-he2ea4bf_2.tar.bz2
   sha256: 07e45cd4e2e791528d099791f1664983b880566c836e73925211e45c9e28096b
   md5: 5f67893563dfc1dd0e45d3b2abf2e3f4
   depends:
@@ -8527,7 +8527,7 @@ packages:
   license_family: BSD
   size: 230596
   timestamp: 1686933095919
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
   sha256: 238e486a0d62264e7ab35098bdc0390fb9a4649921b18827228c811ae8252c88
   md5: f1ebe453c5a955a25e4b00f73279fc42
   depends:
@@ -8541,7 +8541,7 @@ packages:
   license_family: Apache
   size: 894777
   timestamp: 1687975823684
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -8558,7 +8558,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
   sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
   md5: ba9418df9288a2f031a02fa35b774ce0
   depends:
@@ -8574,7 +8574,7 @@ packages:
   license_family: BSD
   size: 78524
   timestamp: 1694778314659
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
   sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
   md5: b1781519a200ccbfcb4a1194005aa3ef
   depends:
@@ -8586,7 +8586,7 @@ packages:
   license_family: BSD
   size: 338459
   timestamp: 1694777084290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
   sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
   md5: 6ece7f1a3248169837714d05d7f6ef0a
   depends:
@@ -8598,7 +8598,7 @@ packages:
   license_family: MIT
   size: 3513910
   timestamp: 1692971505729
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
   sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
   md5: bd7ec244935e83e850a4ff34e8e2e64f
   depends:
@@ -8609,7 +8609,7 @@ packages:
   license_family: MIT
   size: 513971
   timestamp: 1692973657152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
   sha256: e1c0e745d9ba36a80773e841d96bf514ad1ceda419e4188aad3c22782af00234
   md5: f226532e9bb308f20e874c56be6ceefb
   depends:
@@ -8619,7 +8619,7 @@ packages:
   license_family: MIT
   size: 35788
   timestamp: 1659783414586
-- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/llvmlite-0.41.0-py39hf2fb9eb_0.tar.bz2
   sha256: 2f610fc98b674e4eceeceaadbb94b4153759ee9249759dd27ca48bfdeeef82cf
   md5: c24005244a08cbfb665f89d8858e0187
   depends:
@@ -8631,7 +8631,7 @@ packages:
   license_family: BSD
   size: 20824879
   timestamp: 1697031479623
-- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py39haa95532_0.tar.bz2
   sha256: 5d4cf89313147e44530dbb3cc6a93247aaded0701bbf8ba3a382ef710abf4cfa
   md5: 137deeca51202f6b4ac786472a00be55
   depends:
@@ -8640,7 +8640,7 @@ packages:
   license_family: BSD
   size: 12894
   timestamp: 1652904101694
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
   sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
   md5: fb7881e74b59262df0fa4ec981964efc
   depends:
@@ -8653,7 +8653,7 @@ packages:
   license_family: Other
   size: 1244887
   timestamp: 1695058550693
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.3.2-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-4.3.2-py39h2bbff1b_0.tar.bz2
   sha256: 249bedcd46393c1f7506c1087e6a7da1927e28bc73778843575bb1bf9f495962
   md5: 392b06ffe7c8d92097b07e60f8d5efa5
   depends:
@@ -8665,7 +8665,7 @@ packages:
   license_family: BSD
   size: 83368
   timestamp: 1686058138081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
   sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
   md5: 6970c7f46b0164cad1d210e7a1419959
   depends:
@@ -8675,7 +8675,7 @@ packages:
   license_family: BSD
   size: 143434
   timestamp: 1670944902624
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
   sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
   md5: 1015298551c040c6d5e26eebbae12ef5
   depends:
@@ -8685,7 +8685,7 @@ packages:
   license_family: BSD
   size: 142316
   timestamp: 1671542240512
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
   sha256: ab5c246c2b271acc1cdd0b9343989c0166681536e569cdbe71618f55d34c7292
   md5: 7ce68d771cd94c9ff5efefe69d327c9a
   depends:
@@ -8695,7 +8695,7 @@ packages:
   license_family: MIT
   size: 125122
   timestamp: 1684280210213
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
   sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
   md5: 466da740fafef3d6bce114220f0be306
   depends:
@@ -8708,7 +8708,7 @@ packages:
   license_family: BSD
   size: 28510
   timestamp: 1654508162239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
   sha256: 1687ae122ee7d8b583141fc5014b76d494841dc8083b854449e3d6e0f6bb7019
   md5: 3697ac26ee3c2d49338dd5b9c6551152
   depends:
@@ -8731,7 +8731,7 @@ packages:
   license_family: PSF
   size: 8080067
   timestamp: 1698692812610
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
   sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
   md5: a9fa43e694b25cd49b8b08a9eefd696e
   depends:
@@ -8741,7 +8741,7 @@ packages:
   license_family: BSD
   size: 18054
   timestamp: 1661915903969
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
   sha256: 8aa14047fac6ef8b326900c4bf1a960eaa7a1699c18fdf1e75a59101b610b6df
   md5: 7e1d4d4700fbea6171d30f1d5ad24226
   depends:
@@ -8751,7 +8751,7 @@ packages:
   license_family: MIT
   size: 53362
   timestamp: 1659721308586
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
   sha256: 2017814a7cc93dd51c6b7c016e3cdf8fbc32fa20f985638aaff6a6377e9ee086
   md5: a1a285c56b001c3b5c591bf21eec3149
   depends:
@@ -8760,7 +8760,7 @@ packages:
   license_family: MIT
   size: 19326
   timestamp: 1659716205153
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
   sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
   md5: 248c468abced874f0231d3cc23177c77
   depends:
@@ -8771,7 +8771,7 @@ packages:
   license_family: BSD
   size: 58488
   timestamp: 1607359497934
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
   sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
   md5: 5e763c995ff0c549f68a10bce70fede4
   depends:
@@ -8783,7 +8783,7 @@ packages:
   license_family: Proprietary
   size: 187489950
   timestamp: 1691503804820
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
   sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
   md5: dd0c2ece6a743c373c9b5a5919b4818f
   depends:
@@ -8795,7 +8795,7 @@ packages:
   license_family: BSD
   size: 49744
   timestamp: 1682975040154
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
   sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
   md5: 57cea8df7ab85f2a98f64d23afcb1f90
   depends:
@@ -8810,7 +8810,7 @@ packages:
   license_family: BSD
   size: 184956
   timestamp: 1695058491736
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
   sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
   md5: 8769cdd201d905069800488fe31574e5
   depends:
@@ -8825,7 +8825,7 @@ packages:
   license_family: BSD
   size: 256221
   timestamp: 1695060152521
-- conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/msgpack-python-1.0.3-py39h59b6b97_0.tar.bz2
   sha256: ed64d0a3331cc40479962ed066a833243ca36035bd4cefee4fb5e42a9214f64b
   md5: 6b7d9b4724303c0159086d28e9ef4901
   depends:
@@ -8836,7 +8836,7 @@ packages:
   license_family: Apache
   size: 82755
   timestamp: 1652329408426
-- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py39haa95532_0.tar.bz2
   sha256: b75f28f29d60f2a8726fb0f036e5d01489942abbf77ff1e1cc8e12d7f372b8f3
   md5: 7a1d29477873480809fd3860f2e69f01
   depends:
@@ -8846,7 +8846,7 @@ packages:
   license_family: BSD
   size: 24734
   timestamp: 1607574381373
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
   sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
   md5: d9781492332e6326f9fca87f3a8efacd
   depends:
@@ -8872,7 +8872,7 @@ packages:
   license_family: BSD
   size: 8135792
   timestamp: 1681756491399
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py39haa95532_0.tar.bz2
   sha256: 49715dd545469a4458cdf0d0d55c9a7af7cb7a2da8a6504a60dd3089714015ae
   md5: 4257087772bed974078f56673ca50d99
   depends:
@@ -8885,7 +8885,7 @@ packages:
   license_family: BSD
   size: 119351
   timestamp: 1698934436390
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
   sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
   md5: f1d8ce412e115986c403f223b3b47d0f
   depends:
@@ -8913,7 +8913,7 @@ packages:
   license_family: BSD
   size: 596314
   timestamp: 1668451106600
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
   sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
   md5: f96bbef0985d7e66ebf00c0d55e30e23
   depends:
@@ -8926,7 +8926,7 @@ packages:
   license_family: BSD
   size: 167045
   timestamp: 1694617078743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
   sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
   md5: 6e6ba64c8dc5025aeac606404a8df36a
   depends:
@@ -8935,7 +8935,7 @@ packages:
   license_family: BSD
   size: 13786
   timestamp: 1672387480065
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
   sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
   md5: 4a7a3286484766741f627696697c362c
   depends:
@@ -8960,7 +8960,7 @@ packages:
   license_family: BSD
   size: 609425
   timestamp: 1690985686105
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
   sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
   md5: 4269a1f93882205b90d4b2ae78fc82d5
   depends:
@@ -8970,7 +8970,7 @@ packages:
   license_family: BSD
   size: 22417
   timestamp: 1668160717305
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numba-0.58.0-py39h4ed8f06_0.tar.bz2
   sha256: 39b52f5a3e0f71a07358f2bd07a67b950170eabc3398ae968ef523cc0854141a
   md5: 4baee3e5d96aed7d5d3e28051d6214e5
   depends:
@@ -8990,7 +8990,7 @@ packages:
   license_family: BSD
   size: 4472762
   timestamp: 1697063760024
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
   sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
   md5: a18a576b7024cfd6f905c526a786a916
   depends:
@@ -9005,7 +9005,7 @@ packages:
   license_family: MIT
   size: 135285
   timestamp: 1696515698492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.25.2-py39h055cbcc_0.tar.bz2
   sha256: 410f3a13eaddcfcfc65cb077dd0b85b7c66853a2447161b9022eed7d9fe472f9
   md5: c4aae7ab3842a3decd05c5c1d8b916d3
   depends:
@@ -9022,7 +9022,7 @@ packages:
   license_family: BSD
   size: 12296
   timestamp: 1691098390179
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.25.2-py39h65a83cf_0.tar.bz2
   sha256: 5a81ff60cc876951905995ea52d3815e38a0d757c6c674acbef1144d8dc746fb
   md5: 72413d41fe97de5da9b1ce325e544e05
   depends:
@@ -9038,7 +9038,7 @@ packages:
   license_family: BSD
   size: 6857794
   timestamp: 1691098356763
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
   sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
   md5: ab07e2a27ac08afe3d0b4c0890b8486a
   depends:
@@ -9049,7 +9049,7 @@ packages:
   license: BSD 2-Clause
   size: 249316
   timestamp: 1630094024143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.12-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.12-h2bbff1b_0.tar.bz2
   sha256: 8ef9303c90033dfd6ffac174ec7c47c93c2adc840ef164a7841ce8b7aca33e6d
   md5: ff1c3deee94b20c5d06d6d2cb91a4af3
   depends:
@@ -9060,7 +9060,7 @@ packages:
   license_family: Apache
   size: 8048086
   timestamp: 1699014079653
-- conda: https://repo.anaconda.com/pkgs/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/orc-1.7.4-h623e30f_1.tar.bz2
   sha256: 417cf23716f17b6daf2b717bbd69240aa9440845dfa415f59a97961794632ce5
   md5: 36d709d47c43a3e9b43f23cf4edb6438
   depends:
@@ -9075,7 +9075,7 @@ packages:
   license_family: Apache
   size: 877890
   timestamp: 1676482911485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
   sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
   md5: df1d746ba8d5d6ba01ac1373b9b71e1a
   depends:
@@ -9084,7 +9084,7 @@ packages:
   license_family: Apache
   size: 73016
   timestamp: 1693575484990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
   sha256: 1994e5831fd421bd6cf85916073d4012dec53e673b672b3985efaf771f0a7bf8
   md5: c486a5b51e3227f6ea564a9dd3125e45
   depends:
@@ -9132,7 +9132,7 @@ packages:
   license_family: BSD
   size: 12629931
   timestamp: 1697479885371
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-1.2.3-py39haa95532_0.tar.bz2
   sha256: 0044e1cc04f3cb7c48209276c35c59c05b87e852c0ac01be468b99f3656445fb
   md5: ee81d2a2b2c558b43a48fd68c2de1dbf
   depends:
@@ -9156,7 +9156,7 @@ packages:
   license_family: BSD
   size: 17009718
   timestamp: 1695148093102
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-1.13.0-py39haa95532_0.tar.bz2
   sha256: 2773f47b2d745ab483cf7fcbd5b5e2f7020d45462d32d2ccd5cf232ca13c6f67
   md5: ca16cd208037bd58d2da267c338da4a4
   depends:
@@ -9165,7 +9165,7 @@ packages:
   license_family: BSD
   size: 142229
   timestamp: 1684915524241
-- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/partd-1.4.1-py39haa95532_0.tar.bz2
   sha256: 5738f61dae392c171b4f699a6973e736198e4d4a63fa22dcf957afaf1de150af
   md5: cba721e73156d62fc4ff23159e96ad41
   depends:
@@ -9179,7 +9179,7 @@ packages:
   license_family: BSD
   size: 36452
   timestamp: 1698702686971
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
   sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
   md5: 427c1450bebb632f43bbc8c83006e4cd
   depends:
@@ -9198,7 +9198,7 @@ packages:
   license_family: Other
   size: 806931
   timestamp: 1696580240310
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
   sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
   md5: 21790cd3e2b8a45c4104aff0a68330d0
   depends:
@@ -9209,7 +9209,7 @@ packages:
   license_family: MIT
   size: 3001751
   timestamp: 1697549357662
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
   sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
   md5: 56f44a1054da2d10777e375838191070
   depends:
@@ -9218,7 +9218,7 @@ packages:
   license_family: MIT
   size: 32355
   timestamp: 1692205784293
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
   sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
   md5: 8a35ad65651086575ce55371f22feda8
   depends:
@@ -9227,7 +9227,7 @@ packages:
   license_family: Apache
   size: 91045
   timestamp: 1659455316472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
   sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
   md5: 186eb95f816a2eff80c3c7f7d964c7b0
   depends:
@@ -9239,7 +9239,7 @@ packages:
   license_family: BSD
   size: 578514
   timestamp: 1672388155359
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
   sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
   md5: 47b6cbe6ce9289e47d16900b03596a91
   depends:
@@ -9250,7 +9250,7 @@ packages:
   license_family: BSD
   size: 372807
   timestamp: 1656431445633
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-11.0.0-py39h790e06d_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyarrow-11.0.0-py39h790e06d_1.tar.bz2
   sha256: 5b6ad360ec3b29619cd455bde021aa306fa193e86ae00cecd34a2852fd03417d
   md5: 15298793035b738648140239b6d2a295
   depends:
@@ -9265,7 +9265,7 @@ packages:
   license_family: Apache
   size: 3673822
   timestamp: 1693273731311
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
   sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
   md5: 07165c444adc7c7ccc8a345875adc5ef
   depends:
@@ -9277,7 +9277,7 @@ packages:
   license_family: BSD
   size: 48408
   timestamp: 1675450623287
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
   sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
   md5: d58e76a31e2f6e7410ba4afd7f385b0d
   depends:
@@ -9286,7 +9286,7 @@ packages:
   license_family: BSD
   size: 1877445
   timestamp: 1684280183367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
   sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
   md5: 0e5b0fe7debbf558ce97090f6b67cdae
   depends:
@@ -9296,7 +9296,7 @@ packages:
   license_family: Apache
   size: 94633
   timestamp: 1690225630423
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
   sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
   md5: 0fde797653e4ab589506121fb1e37555
   depends:
@@ -9305,7 +9305,7 @@ packages:
   license_family: MIT
   size: 157119
   timestamp: 1661452591647
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
   sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
   md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
   depends:
@@ -9316,7 +9316,7 @@ packages:
   license_family: MIT
   size: 92679
   timestamp: 1636093365041
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
   sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
   md5: f870859d4dc7a8d82cf3546bd9035f33
   depends:
@@ -9326,7 +9326,7 @@ packages:
   license_family: BSD
   size: 54520
   timestamp: 1605307564142
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
   sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
   md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
   depends:
@@ -9339,7 +9339,7 @@ packages:
   license_family: PSF
   size: 21172845
   timestamp: 1694442462066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
   sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
   md5: 9d99075052265ae3d718582d3b875038
   depends:
@@ -9348,7 +9348,7 @@ packages:
   license_family: BSD
   size: 269964
   timestamp: 1661376543480
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.4.1-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-lmdb-1.4.1-py39hd77b12b_0.tar.bz2
   sha256: 8b6a4065775dced4e05e655b2cc3a59e5dd70f3c081e0d37e6f65073cb2e2b43
   md5: 7c7beb23a7b73c5797a1ab69ab124cd7
   depends:
@@ -9359,7 +9359,7 @@ packages:
   license_family: Other
   size: 135726
   timestamp: 1682522544682
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
   sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
   md5: fa9074d94236c9b768bfd2c858875b27
   depends:
@@ -9368,7 +9368,7 @@ packages:
   license_family: MIT
   size: 264836
   timestamp: 1695131770282
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
   sha256: 97243a31c39f4990c0e9d4f2307f2f7fb9421553303923bc105067ec4340bdff
   md5: 8078c5760f27398eaf1082226647d137
   depends:
@@ -9378,7 +9378,7 @@ packages:
   license_family: BSD
   size: 40145
   timestamp: 1685031143383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
   sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
   md5: 3d2841085778006c2e79f9c7300f8b9d
   depends:
@@ -9388,7 +9388,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13565975
   timestamp: 1669937633869
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
   sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
   md5: 54a4bc0724041dd173088419d6ede2af
   depends:
@@ -9400,7 +9400,7 @@ packages:
   license_family: MIT
   size: 239062
   timestamp: 1677611495106
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
   sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
   md5: f39f84115e228bad4bceaefdd637f022
   depends:
@@ -9412,7 +9412,7 @@ packages:
   license_family: MIT
   size: 158558
   timestamp: 1698096358091
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
   sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
   md5: df398a3a1668fd2a22061764e20ea91d
   depends:
@@ -9424,7 +9424,7 @@ packages:
   license_family: BSD
   size: 460913
   timestamp: 1657616061604
-- conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
   sha256: 720f3dd1f933d035b1393951ffd1b6437fc5e19b1999e74096044514a46053fb
   md5: add2dfb15b518144663fc3b897d66da7
   depends:
@@ -9433,7 +9433,7 @@ packages:
   license: BSD-3-Clause
   size: 493391
   timestamp: 1652432364793
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
   sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
   md5: 38db77ece9dc76feffb9ef7638e38258
   depends:
@@ -9449,7 +9449,7 @@ packages:
   license_family: Apache
   size: 94397
   timestamp: 1690400496655
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
   sha256: 3a9a680173f731d515e0587d5b74583cc986b5c1ff62f4cf9e4f7ec268cbb62a
   md5: 3387bf809e3d32dde3f5cbc3ef49bf47
   depends:
@@ -9467,7 +9467,7 @@ packages:
   license_family: BSD
   size: 22779707
   timestamp: 1696550432358
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
   sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
   md5: 3e284ae6b48ee30c364ffdc5601610b0
   depends:
@@ -9476,7 +9476,7 @@ packages:
   license_family: MIT
   size: 1099842
   timestamp: 1690291374842
-- conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.1.9-h6c2663c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/snappy-1.1.9-h6c2663c_0.tar.bz2
   sha256: 25c1b4224f5d7d767d4adfe0384d585e9b3935464be3efff3120059308d9747c
   md5: faac387845d33d194eeb7d5a3d962ea5
   depends:
@@ -9486,7 +9486,7 @@ packages:
   license_family: BSD
   size: 6506572
   timestamp: 1649924235781
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
   sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
   md5: 993b3886b334bd1f49d34206f21997b4
   depends:
@@ -9495,7 +9495,7 @@ packages:
   license_family: Apache
   size: 15998
   timestamp: 1614030572433
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
   sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
   md5: 7ac9604ad7564ac0c71bff5db198656f
   depends:
@@ -9504,7 +9504,7 @@ packages:
   license_family: MIT
   size: 67012
   timestamp: 1696347795139
-- conda: https://repo.anaconda.com/pkgs/main/win-64/spatialpandas-0.4.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/spatialpandas-0.4.9-py39haa95532_0.tar.bz2
   sha256: dc8df02a3e1f24da2488db1ef7b51acd9fef6095b6a72448f6be6c255e56c7df
   md5: a0c2b87355560c900494debb9e2fe4d8
   depends:
@@ -9520,7 +9520,7 @@ packages:
   license_family: BSD
   size: 148206
   timestamp: 1695247775159
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
   sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
   md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
   depends:
@@ -9530,7 +9530,7 @@ packages:
   license_family: Other
   size: 1311308
   timestamp: 1681402905668
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -9540,7 +9540,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
   sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
   md5: 28b9869d8d3a839918fac4a08f38cbc2
   depends:
@@ -9551,7 +9551,7 @@ packages:
   license_family: BSD
   size: 30546
   timestamp: 1671752127904
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
   sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
   md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
   depends:
@@ -9561,7 +9561,7 @@ packages:
   license_family: BSD
   size: 39590
   timestamp: 1668168880994
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
   sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
   md5: 52cdcdb96383c010ca833a7c24b3935b
   depends:
@@ -9571,7 +9571,7 @@ packages:
   license_family: BSD
   size: 3690152
   timestamp: 1654036853710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/toolz-0.12.0-py39haa95532_0.tar.bz2
   sha256: 1ee791ecc17e11a31d6cf1553845e7279d9d9a2c7383a2a3e1ae131ddd024b6f
   md5: b32030d310e0437dc631e5719369004c
   depends:
@@ -9580,7 +9580,7 @@ packages:
   license_family: BSD
   size: 102033
   timestamp: 1667464306003
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
   sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
   md5: 0e054ab29119cf4c1f778613acf972f9
   depends:
@@ -9591,7 +9591,7 @@ packages:
   license_family: Apache
   size: 681780
   timestamp: 1696937326924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
   sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
   md5: b6ad839ebba536ad1c3cc58d0e2123f0
   depends:
@@ -9605,7 +9605,7 @@ packages:
   license_family: MOZILLA
   size: 143681
   timestamp: 1679562248929
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
   sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
   md5: fe78de10019085146f1cc6c94fdc2620
   depends:
@@ -9614,7 +9614,7 @@ packages:
   license_family: BSD
   size: 192822
   timestamp: 1671143999327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
   md5: ca5fc3fbdb09b6de068a8b7a8869369f
   depends:
@@ -9624,7 +9624,7 @@ packages:
   license_family: PSF
   size: 9208
   timestamp: 1690298120549
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
   md5: a86e87a10e5fdff486265e0c675fb99f
   depends:
@@ -9633,7 +9633,7 @@ packages:
   license_family: PSF
   size: 57922
   timestamp: 1690298106990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
   sha256: 8057d3d2a0acd44496de33c5b222063c3f7d06b90c74fbbda45bd18b0b324219
   md5: 398f8db5bd8cab84b3d85a9d85fa4889
   depends:
@@ -9642,7 +9642,7 @@ packages:
   license_family: MIT
   size: 11362
   timestamp: 1659769459206
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
   sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
   md5: 0d31859e0a097aedbcc1627db33b3d92
   depends:
@@ -9657,7 +9657,7 @@ packages:
   license_family: MIT
   size: 188367
   timestamp: 1698257883295
-- conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/utf8proc-2.6.1-h2bbff1b_0.tar.bz2
   sha256: 3090678ff796558a51d0d7628d07d792f0d7364a863e57e716d9d05dbf3032eb
   md5: 150c8148017ae3461951cc919e317f92
   depends:
@@ -9667,7 +9667,7 @@ packages:
   license_family: MIT
   size: 315993
   timestamp: 1611836198527
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
   sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
   md5: 45ef24c486a484f079faf1dc90e4c7e9
   depends:
@@ -9676,12 +9676,12 @@ packages:
   license_family: BSD
   size: 8277
   timestamp: 1605602889180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
   sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
   md5: 4daaceb6cfc1af6274509081d8018ef1
   size: 2316783
   timestamp: 1605602872095
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
   sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
   md5: 916c16904615c7af3b5d37cb6694f45e
   depends:
@@ -9690,7 +9690,7 @@ packages:
   license_family: BSD
   size: 21084
   timestamp: 1607347371925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
   sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
   md5: da69e6987fcc757e83a358ceaa13f62b
   depends:
@@ -9700,7 +9700,7 @@ packages:
   license_family: BSD
   size: 73391
   timestamp: 1614804425587
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
   sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
   md5: 23b9f4634b2e5450be617114f62c74f9
   depends:
@@ -9709,7 +9709,7 @@ packages:
   license_family: MIT
   size: 120873
   timestamp: 1695742300539
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
   sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
   md5: 120f0b088290fc17bd6618fc10a2f0c4
   depends:
@@ -9717,13 +9717,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 34293
   timestamp: 1605306211299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xarray-2023.6.0-py39haa95532_0.tar.bz2
   sha256: 6bdb88cd45b22246e84b7400159ca90faf98ab4e8c1fa2d38d031cfc73c4dc13
   md5: d6e10641ece06f67561c5f6a676a4b7e
   depends:
@@ -9735,7 +9735,7 @@ packages:
   license_family: Apache
   size: 1794729
   timestamp: 1689041580510
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
   sha256: a5d2a216d052105fdaad7256f23da3b29f95100d1dc0f29b6ab1f3bbc75e17a9
   md5: a558f681ebc243f86cde2515c065b62e
   depends:
@@ -9744,7 +9744,7 @@ packages:
   license_family: BSD
   size: 48805
   timestamp: 1675159123654
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
   sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
   md5: c3f7871e9a33adeccee1b1e8e216918e
   depends:
@@ -9754,7 +9754,7 @@ packages:
   license_family: GPL2
   size: 1332571
   timestamp: 1683113347814
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -9763,7 +9763,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
   sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
   md5: 1ab55f8c4b5292ec360c572120bf823e
   depends:
@@ -9773,7 +9773,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 9430705
   timestamp: 1616055773485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zict-3.0.0-py39haa95532_0.tar.bz2
   sha256: 556bdf23786b69d1699aa1313fac43589cd33f8c62b701259e0f71c52343b59a
   md5: 7bbafad85b6da7514e895923f3af7f5a
   depends:
@@ -9784,7 +9784,7 @@ packages:
   license_family: BSD
   size: 76800
   timestamp: 1695832961240
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
   sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
   md5: 6875e0bf3828707dc9165d694c0d0a7d
   depends:
@@ -9793,7 +9793,7 @@ packages:
   license_family: MIT
   size: 18725
   timestamp: 1672387612937
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
   sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
   md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
   depends:
@@ -9803,7 +9803,7 @@ packages:
   license_family: Other
   size: 148931
   timestamp: 1666595229032
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
   sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
   md5: 8d6a1e767775fe0eb617cd6e22edc2ff
   depends:

--- a/ship_traffic/pixi.toml
+++ b/ship_traffic/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "ship_traffic"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/ship_traffic/pixi.toml
+++ b/ship_traffic/pixi.toml
@@ -25,15 +25,15 @@ panel = "*"
 spatialpandas = "*"
 xarray = "*"
 pyarrow = "*"
-pip = "*"
-setuptools = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+setuptools = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks.dashboard]
 cmd = "panel serve --rest-session-info --session-history -1 ship_traffic.ipynb"

--- a/ship_traffic/pixi.toml
+++ b/ship_traffic/pixi.toml
@@ -1,0 +1,49 @@
+[workspace]
+name = "ship_traffic"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2021-01-27"
+maintainers = ["jbednar", "jlstevens"]
+categories = ["Geospatial", "Featured"]
+labels = ["datashader", "holoviews", "bokeh", "panel", "dask", "spatialpandas"]
+description = "Visualizing AIS location tracking data for marine vessels near the USA"
+
+[dependencies]
+python = "3.9.*"
+bokeh = "*"
+colorcet = "*"
+dask = "*"
+datashader = "*"
+holoviews = "*"
+notebook = "*"
+numba = "*"
+numexpr = "*"
+pandas = "*"
+panel = "*"
+spatialpandas = "*"
+xarray = "*"
+pyarrow = "*"
+pip = "*"
+setuptools = "*"
+wheel = "*"
+
+[target.osx-64.dependencies]
+libgfortran = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks.dashboard]
+cmd = "panel serve --rest-session-info --session-history -1 ship_traffic.ipynb"
+depends-on = ["download"]
+
+[tasks.notebook]
+cmd = "jupyter notebook ship_traffic.ipynb"
+depends-on = ["download"]
+
+[tasks.download]
+env = { FILENAME = "data/AIS_2020_01_broadcast.parq" }
+cmd = "mkdir -p $FILENAME && curl -fsSL -o .DATA.zip http://s3.amazonaws.com/datashader-data/ship_traffic.zip && python -m zipfile -e .DATA.zip $FILENAME && rm .DATA.zip"
+outputs = ["data/AIS_2020_01_broadcast.parq"]

--- a/square_limit/pixi.lock
+++ b/square_limit/pixi.lock
@@ -7,663 +7,663 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.0-h8213a91_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.0-h28cd5cc_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.5.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.9.2-py39h2531618_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-5.9.7-h5867ecd_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-4.19.13-py39h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gst-plugins-base-1.14.0-h8213a91_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gstreamer-1.14.0-h28cd5cc_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-3.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyqt-5.9.2-py39h2531618_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/qt-5.9.7-h5867ecd_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sip-4.19.13-py39h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.8.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-3.8.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.8.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-3.8.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.8.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-3.8.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
   sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
   md5: 2cf39d906cc321896ffe3e5d33d80c5c
   depends:
@@ -676,7 +676,7 @@ packages:
   license_family: MIT
   size: 162166
   timestamp: 1644463608931
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
   sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
   md5: 2972a84e0e22ae3244bbd2f1eebcf536
   depends:
@@ -687,7 +687,7 @@ packages:
   license_family: MIT
   size: 35352
   timestamp: 1644569715988
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
   sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
   md5: a68016b4b06460def24cb69d932986f3
   depends:
@@ -696,7 +696,7 @@ packages:
   license_family: MIT
   size: 132486
   timestamp: 1695717963702
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
   sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
   md5: 2f6356a2f530314b4059c08c79a3d8bc
   depends:
@@ -706,12 +706,12 @@ packages:
   license_family: MIT
   size: 205868
   timestamp: 1681493113570
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
   sha256: 2d8e75f31f75ea5eb8b9021b4c21eb2846a254a097e06eb68e66fc36a82e1bed
   md5: ae374a11c789a55555f70b29b9eff1f9
   depends:
@@ -727,7 +727,7 @@ packages:
   license_family: BSD
   size: 14430294
   timestamp: 1658136783940
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
   sha256: f84f9caa7eb9d489fd9634419fdf766d39293a5df1104b840fa0cdc5823a5c60
   md5: 922555c0435d6b2537cf8ced534b048c
   depends:
@@ -738,7 +738,7 @@ packages:
   license_family: BSD
   size: 141903
   timestamp: 1648028958291
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
   sha256: 0bbcb6f78eac530c6a084459ffab3238647b266d0c74d695e6e6387dd119cc67
   md5: bdc971e2a9affb5125b68ad708172dab
   depends:
@@ -747,7 +747,7 @@ packages:
   license: MIT
   size: 411301
   timestamp: 1602517685375
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
   sha256: 8c2071f706c2b445dabb781f7f8f008b23a29957468ec6894f050bfb3a2d5bf4
   md5: c203ffc7bbba991c7089d4b383cfd92c
   depends:
@@ -758,14 +758,14 @@ packages:
   license_family: MIT
   size: 357797
   timestamp: 1605539534667
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
   sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
   md5: 3ef00f4c5278b688552efc259c463dc8
   license: MPL-2.0
   license_family: Other
   size: 132731
   timestamp: 1694009767372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
   sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
   md5: d5cb3d97cf5e85ffe5e94037ed8a1169
   depends:
@@ -774,7 +774,7 @@ packages:
   license_family: Other
   size: 159077
   timestamp: 1690232254640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
   sha256: 674707b9c42e65c903c9786ee5a56b4d42aa054f1e75b328db8a2c1bfa368739
   md5: 76ae217198b014b89b267cf41b8251dd
   depends:
@@ -786,7 +786,7 @@ packages:
   license_family: MIT
   size: 231920
   timestamp: 1642701209740
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
   sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
   md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
   depends:
@@ -796,7 +796,7 @@ packages:
   license_family: CC
   size: 1917831
   timestamp: 1668084545510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
   sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
   md5: 13702d3b4b744784e5bd559c7050dd6f
   depends:
@@ -806,7 +806,7 @@ packages:
   license_family: BSD
   size: 12719
   timestamp: 1671231205875
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
   sha256: 821af57c20a85b4e92268fbf65fbaec2f273da5bb21889d9643756ef6e473237
   md5: f57e0f502500ffebdbec081ef61ad1d4
   depends:
@@ -820,7 +820,7 @@ packages:
   license_family: BSD
   size: 2179774
   timestamp: 1694445209134
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
   sha256: 469debfa966d24b8372aaf909ecbe27dc6fde186f6f0d5b9e0a8427e38053364
   md5: 498d0788982ec4c5d13a44359b9c7afb
   depends:
@@ -830,7 +830,7 @@ packages:
   license: GPL2
   size: 600218
   timestamp: 1602701107852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
   sha256: 3a39a2d6f161080c706292e3bf480f62d2444b1d6d67b3d7db50458202ee31f1
   md5: 0524ffca60f845eb392bbb56d56f0ce5
   depends:
@@ -841,7 +841,7 @@ packages:
   license_family: MIT
   size: 2094615
   timestamp: 1637091869922
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
   sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
   md5: 2e6ec51066d825ef3c317abe78d6049e
   depends:
@@ -850,7 +850,7 @@ packages:
   license_family: MIT
   size: 16413
   timestamp: 1649926472708
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
   sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
   md5: b4d923222d45314856b5378cb115214d
   depends:
@@ -859,7 +859,7 @@ packages:
   license_family: BSD
   size: 26728
   timestamp: 1668714462023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
   sha256: 27cde2cf0b1e10c2315bc1384fcb56537b424f6c2c872ca4662bc971e41910da
   md5: c12e8c75f3c7c4f5867827c5dc02dc2c
   depends:
@@ -869,7 +869,7 @@ packages:
   license_family: MIT
   size: 216001
   timestamp: 1644418571578
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
   sha256: f80526def98864c9560dd3f6754d1c905edc001d18279f6e169913ee8f26a6a2
   md5: e2fda4383ff9a690a6ac174553e10414
   depends:
@@ -880,7 +880,7 @@ packages:
   license: MIT
   size: 306671
   timestamp: 1612452969808
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
   sha256: 8a121233d0b2cbb2463b67e798739ad2946f38933430a6a7fd1197cc6eab1c99
   md5: d2b24736491290a6c6d0138932111150
   depends:
@@ -890,7 +890,7 @@ packages:
   license: GPL-2.0-only and LicenseRef-FreeType
   size: 965280
   timestamp: 1635422707211
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
   sha256: 3c8ece1a7257b1d45f8fa25f46504bb709a1923d7175f2996e891366ec434b9d
   md5: 299bf4271d710651a1d71d3795580c2d
   depends:
@@ -898,7 +898,7 @@ packages:
   license: MIT
   size: 83592
   timestamp: 1603192039050
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
   sha256: bb98f022743e5df14d73db0edae49eb95a11abcc41c973fe2f30c3810bc5021e
   md5: 858d4f13f1b0e54ee8cc3dd7c67cf0de
   depends:
@@ -912,7 +912,7 @@ packages:
   license_family: LGPL
   size: 2021087
   timestamp: 1642701448286
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.0-h8213a91_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/gst-plugins-base-1.14.0-h8213a91_2.tar.bz2
   sha256: c85c664066c685b606df768d23eac08e1b824e391eb59f61a9ef608f4f46c5b6
   md5: df2e0695e2edbd91b719da5b15249c5a
   depends:
@@ -924,7 +924,7 @@ packages:
   - zlib >=1.2.11,<2.0.0a0
   size: 6651032
   timestamp: 1609866747525
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.0-h28cd5cc_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/gstreamer-1.14.0-h28cd5cc_2.tar.bz2
   sha256: dc1af8ae3b38b8d81c00b54dac851618dba87ea8d4083af84dcb60c3070039ad
   md5: 83453eb716b94c66fb64391760c0eeb1
   depends:
@@ -932,7 +932,7 @@ packages:
   - libgcc-ng >=7.3.0
   size: 4178090
   timestamp: 1609866593800
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
   sha256: 2d727f8335c59314b521b66d437ca4d51904134473ae503b7b097e239635f209
   md5: 6991e520f353d995023404f6f524d192
   depends:
@@ -949,7 +949,7 @@ packages:
   license_family: BSD
   size: 4507274
   timestamp: 1693378095165
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
   sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
   md5: 9213e0336e3a5216c989cfe52648412e
   depends:
@@ -958,7 +958,7 @@ packages:
   license: MIT
   size: 23805906
   timestamp: 1588026213084
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
   sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
   md5: 1eb52f9f45cea2fb9ce27b19f990160e
   depends:
@@ -967,7 +967,7 @@ packages:
   license_family: BSD
   size: 110793
   timestamp: 1666125606878
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
   sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
   md5: 126b3c1933b7364ff03f67455b687e99
   depends:
@@ -977,7 +977,7 @@ packages:
   license_family: APACHE
   size: 37588
   timestamp: 1678997134023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
   sha256: 1b424413f28b840fc6d4bf467f37e9e405823b1e3b899005df80152d48936d64
   md5: 4aa8bcf74c81cd3600978f791191692a
   constrains:
@@ -986,7 +986,7 @@ packages:
   license_family: Proprietary
   size: 9246735
   timestamp: 1634546760713
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
   sha256: b51b2e0dd37a74784ba19db22aded3f4c843b6fddb4a74399f65f36fc018aaa2
   md5: 0d56ab1950f952284b895ac0f78284a7
   depends:
@@ -1006,7 +1006,7 @@ packages:
   license_family: BSD
   size: 203541
   timestamp: 1671488675347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
   sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
   md5: ff47e0be879e817713ce2a9daa76e2b0
   depends:
@@ -1027,7 +1027,7 @@ packages:
   license_family: BSD
   size: 1261116
   timestamp: 1694181530670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
   sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
   md5: 5ef6c6a0d1ac79143c7359d305155167
   depends:
@@ -1037,7 +1037,7 @@ packages:
   license_family: MIT
   size: 1021637
   timestamp: 1644297140650
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
   sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
   md5: eaeb023688f781e7dd89e74310c38195
   depends:
@@ -1047,7 +1047,7 @@ packages:
   license_family: BSD
   size: 211775
   timestamp: 1666908212136
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
   sha256: 85348bfb14db4fea84078d703e766a3c978c5a592a06e41266748826dd59d8ae
   md5: 6e1c0fb5260c590f7ef5235cb3d05863
   depends:
@@ -1056,7 +1056,7 @@ packages:
   license_family: Other
   size: 279884
   timestamp: 1651065953960
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
   sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
   md5: 0d2c3c5edf671b575532d5a3e8bf15fc
   depends:
@@ -1067,7 +1067,7 @@ packages:
   license_family: MIT
   size: 131510
   timestamp: 1676558716852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
   sha256: 92bc012f9eb4ad71158cf4826fd3e125fcebff53b529276a81224acda48be547
   md5: c5fd100e3062e831cbdf33331042f627
   depends:
@@ -1083,7 +1083,7 @@ packages:
   license_family: BSD
   size: 190884
   timestamp: 1650622553813
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.5.0-py39h06a4308_0.tar.bz2
   sha256: b791f2f86fe1993ddfcd10a80a92fb098c2b4792f0ce13da9269cac6b3647d0b
   md5: ac7c5e38691312d195fdd1f23b33f779
   depends:
@@ -1094,7 +1094,7 @@ packages:
   license_family: BSD
   size: 78853
   timestamp: 1698937381669
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
   sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
   md5: a4beb461f0a60998a090d760b5c6c907
   depends:
@@ -1118,7 +1118,7 @@ packages:
   license_family: BSD
   size: 411564
   timestamp: 1671707702849
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
   sha256: 974df3dc76089be57b327acd6634384def84249003f58678ca1142bb274a75d9
   md5: 81b969d1a00153759b30554a1f11ddfd
   depends:
@@ -1129,7 +1129,7 @@ packages:
   license_family: BSD
   size: 92144
   timestamp: 1653292217019
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -1140,7 +1140,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
   sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
   md5: 9508af80612e4fa1b5d1abb43ca7e63c
   constrains:
@@ -1148,7 +1148,7 @@ packages:
   license: GPL-3.0-only
   size: 749072
   timestamp: 1652971360657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
   sha256: 3b4afe7665dcdb99bd4586a888b85b2e0325f8faecdd31c7780792080ee97872
   md5: 822b5201dde61bc838072dc5b670c88c
   depends:
@@ -1157,7 +1157,7 @@ packages:
   license: Custom
   size: 55183
   timestamp: 1594054267890
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
   sha256: c6fafbe73d2f93b91b6f4b65829f925f52a8f84746a57abd216b39da9ce8c494
   md5: 238f19c803a6ba7bd6dbd6989e03cbf1
   depends:
@@ -1165,7 +1165,7 @@ packages:
   license: GPL
   size: 8496776
   timestamp: 1560112207081
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
   sha256: bc3e6e79c32ff0ecea601aa108ae9cf4068f69703580e40e266ad4bcc52cff54
   md5: 9cb85601944ca7383b1769bff74b94e8
   depends:
@@ -1174,7 +1174,7 @@ packages:
   license: zlib/libpng
   size: 372914
   timestamp: 1556041895170
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -1182,13 +1182,13 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
   sha256: 43b0bd205f539583c088feb5b8d77b60c83d1df80c2a93dac9f2a1127001b2cf
   md5: 53fa39fdae936e9d07c4b2f5ef361993
   license: GPL3 with runtime exception
   size: 4246257
   timestamp: 1560112223556
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
   sha256: 711ea05b4c35bdafc762a172b01db896b17942f474c2b1a519f91370964bf9bc
   md5: b25d56d33596623a6a4a9d9baaa4f602
   depends:
@@ -1202,7 +1202,7 @@ packages:
   license: HPND
   size: 592974
   timestamp: 1653047881023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
   sha256: 4e1dce80f23551a69761ad48b2372e35f58292ec9cc0ce061312330366a1a223
   md5: fda36b99463bad87974196da2d5bed08
   depends:
@@ -1210,7 +1210,7 @@ packages:
   license: BSD 3-Clause
   size: 18725
   timestamp: 1633507857274
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
   sha256: 146dbb1e4dbccdd57819e5102a8ca00970b8e33d6c6180e8007db89b184da569
   md5: c566a384259c1d2769852c3bddd81a67
   depends:
@@ -1224,7 +1224,7 @@ packages:
   license_family: BSD
   size: 90150
   timestamp: 1645441199289
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
   sha256: cffb5a063111f7a99a99c74770b23db5dde52325e25a7a46d1903d5ff4a82c88
   md5: eeb1bd66f28bed1956ab989d6eff7ae5
   depends:
@@ -1235,14 +1235,14 @@ packages:
   license_family: BSD
   size: 889956
   timestamp: 1645089138421
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
   sha256: 5d68e69709ae10bd6c4b58b6af447ad2f2bd24955994f3ec77103d1a6bf5e1f5
   md5: 49e523de8d364b7fabc3850eccbe9bda
   depends:
   - libgcc-ng >=7.5.0
   size: 623492
   timestamp: 1652448233146
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
   sha256: 71f6c4a97014d745c58df52b4dd60ddd75a8508d54fe5b97f42bd1f31cb1c067
   md5: 686e77514ec9f1ef0a6feed374f14d37
   depends:
@@ -1254,7 +1254,7 @@ packages:
   license_family: MIT
   size: 789469
   timestamp: 1653546418059
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
   sha256: ea3355a67c5173f3944f09861043ca66eb7dbeff8f385d13528b3aabc0801d0c
   md5: 66e2aa12181bb2911485bdbe125d24c5
   depends:
@@ -1264,7 +1264,7 @@ packages:
   license: MIT
   size: 584199
   timestamp: 1654075843119
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
   sha256: 64b022d706b76c33965a250fdc8c6008443c41bff8ab27bb1df3cb70419576fd
   md5: ec4f05846aacf634df15c389235725cc
   depends:
@@ -1276,7 +1276,7 @@ packages:
   license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
   size: 1538261
   timestamp: 1646624639995
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
   sha256: 2c6a5dda7c510a961bc78e31d4232be5e8e0760c93454f5fd200c379355e0f5e
   md5: f35d4bf2fbb39e334992f6dd39f8721e
   depends:
@@ -1286,7 +1286,7 @@ packages:
   license_family: BSD
   size: 220865
   timestamp: 1627657046002
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
   sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
   md5: 421f82c8274b44660dba629134faa6af
   depends:
@@ -1296,7 +1296,7 @@ packages:
   license_family: BSD
   size: 122221
   timestamp: 1671541990505
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
   sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
   md5: feb0e452205b44ac45d9b5e55c21a3b1
   depends:
@@ -1308,7 +1308,7 @@ packages:
   license_family: BSD
   size: 22819
   timestamp: 1654597913064
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.5.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-3.5.1-py39h06a4308_1.tar.bz2
   sha256: 62fb0d06224e15528540718debebeaebbfdbd7f03106fad52a7002fb96c6b8bd
   md5: 364c1e3dddefa27741e540496c38b694
   depends:
@@ -1320,7 +1320,7 @@ packages:
   license_family: PSF
   size: 28294
   timestamp: 1647442129989
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
   sha256: dc51b316ef5dcfb82a9c0afdc40879146ae59516f6cea7db776077783dfd2d76
   md5: b0b6b57c140f026b8806051107336576
   depends:
@@ -1342,7 +1342,7 @@ packages:
   license_family: PSF
   size: 7729454
   timestamp: 1647442028622
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
   sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
   md5: c04ef34af33da4c71bcc99b7ec24d210
   depends:
@@ -1352,7 +1352,7 @@ packages:
   license_family: BSD
   size: 16391
   timestamp: 1662014553452
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
   sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
   md5: f6c734d73e6e3dbc1b62766cf18ff3e4
   depends:
@@ -1362,7 +1362,7 @@ packages:
   license_family: BSD
   size: 58153
   timestamp: 1607364912263
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
   sha256: 7c4ded8b2ef036839f988560848d2c32e1aa4627fd37a32710e42c39f5c61ac2
   md5: bd20f4410b81f327e35ffa0657961146
   depends:
@@ -1373,7 +1373,7 @@ packages:
   license_family: Proprietary
   size: 229783051
   timestamp: 1634547157986
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
   sha256: 5394f5efd53afb2c1b0abf571ce3d9cb684b6c7e255f140ba2acaa703d6113be
   md5: d3cb2bfa63e30153f5527797dcc87280
   depends:
@@ -1385,7 +1385,7 @@ packages:
   license_family: BSD
   size: 63551
   timestamp: 1626176932911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
   sha256: c244d23da2749857a993f84969fd35ffd183ab8f462986df6d33ae0f705fe034
   md5: 9b1f8ccc2488d0e04eb73211e2987483
   depends:
@@ -1399,7 +1399,7 @@ packages:
   license: BSD 3-Clause
   size: 204136
   timestamp: 1634566416657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
   sha256: f81f426f8ef306d636664bc49e7cdd70e2b4306d7c6bcb9c75fe35a45ab2087a
   md5: 77aa1d7f958d36bf227e6ff4a34d2e3d
   depends:
@@ -1413,7 +1413,7 @@ packages:
   license: BSD-3-Clause
   size: 365386
   timestamp: 1626186165897
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
   sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
   md5: 95c83d71814c504b5504df4f14548f1a
   depends:
@@ -1439,7 +1439,7 @@ packages:
   license_family: BSD
   size: 8257558
   timestamp: 1681756322140
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py39h06a4308_0.tar.bz2
   sha256: 79e10dc933d22aa99de3543071f1beaaf0ff24df9fed7d2ef5e765f3ed766064
   md5: ea6ebe4e8d6af98128d32606da618a29
   depends:
@@ -1452,7 +1452,7 @@ packages:
   license_family: BSD
   size: 99555
   timestamp: 1698934242626
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
   sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
   md5: 1710a25086c8098367eb36b9d441448b
   depends:
@@ -1480,7 +1480,7 @@ packages:
   license_family: BSD
   size: 569683
   timestamp: 1668450704669
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
   sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
   md5: 385cc9e53404776782502c0fdb08820f
   depends:
@@ -1493,7 +1493,7 @@ packages:
   license_family: BSD
   size: 147046
   timestamp: 1694616899309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
   sha256: 0807371380965e421cb5f3f2a30d790fd5c41db11dbb6d318e14294c3b1741ed
   md5: fca4bd4e3891aebf4fd7daf9b6d0ccfa
   depends:
@@ -1501,7 +1501,7 @@ packages:
   license: Free software (MIT-like)
   size: 1083412
   timestamp: 1636570020698
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
   sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
   md5: bbbcbebc20a4fdcadce398d0ca04f95e
   depends:
@@ -1510,7 +1510,7 @@ packages:
   license_family: BSD
   size: 13109
   timestamp: 1672387143252
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
   sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
   md5: 248ce515640465371927d46f389ed555
   depends:
@@ -1535,7 +1535,7 @@ packages:
   license_family: BSD
   size: 594054
   timestamp: 1690985006481
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
   sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
   md5: 70db71df4ee1cdd38090c0f7b80ba61f
   depends:
@@ -1545,7 +1545,7 @@ packages:
   license_family: BSD
   size: 21944
   timestamp: 1668160644514
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
   sha256: 15a12c8bebcda45c577e61cea412d9aafaa433e39f9e91fd61bbfab66fcee3ab
   md5: 5239d8330e8bd34972fb80918dce79e7
   depends:
@@ -1561,7 +1561,7 @@ packages:
   license_family: MIT
   size: 136437
   timestamp: 1640689905588
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
   sha256: ff8d0426c7096e086db818265c3edf4a820accbfb15afae0407ca578de151fa9
   md5: d7bcf0b9ba2d85cf532059ec119d2750
   depends:
@@ -1577,7 +1577,7 @@ packages:
   license: BSD-3-Clause
   size: 9965
   timestamp: 1652801901707
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
   sha256: abfdeda143b6b667d50a82ea119043fc1469ee02f094a41a2402433ff408099e
   md5: e8dc29adc0282f4658e0e2f25ff207a2
   depends:
@@ -1592,7 +1592,7 @@ packages:
   license: BSD-3-Clause
   size: 7095882
   timestamp: 1652801886819
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
   sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
   md5: 5ad4571eba2479f77a9f849a6ae7724c
   depends:
@@ -1602,7 +1602,7 @@ packages:
   license_family: Apache
   size: 3998613
   timestamp: 1694465071784
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
   sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
   md5: 77a22ed6d0d448c5288d0f695bc9ac49
   depends:
@@ -1611,7 +1611,7 @@ packages:
   license_family: Apache
   size: 72527
   timestamp: 1693575234886
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
   sha256: e7a0abb0f00a94000876f2095f0cf531ad3803ffbd868a780b3f06816b54492c
   md5: 97ef7e1fe923d22a8e2307f3f39a92d5
   depends:
@@ -1627,7 +1627,7 @@ packages:
   license_family: BSD
   size: 13221005
   timestamp: 1650622404234
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
   sha256: 49fdb57b2ed2ce4d6bb7a2c5adec36ba59522518a41fb941f9e39a9f43750cc5
   md5: 871b65444733b7da5823ee0dc9826722
   depends:
@@ -1648,7 +1648,7 @@ packages:
   license_family: BSD
   size: 14712394
   timestamp: 1676379803902
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
   sha256: 64a732ce2661cdb6bd8f9d1484ac10afeb73082b1c2b44728d212e0117d2860e
   md5: ada303f0cf43a4e99cfa7f243b23b681
   depends:
@@ -1657,7 +1657,7 @@ packages:
   license_family: BSD
   size: 141832
   timestamp: 1684915385689
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
   sha256: 4881cc5e0d5b20335bcfba4eaf29fdc95dedf2607903aabecdacffb64d3407d4
   md5: 4bac8a874e62f41ebab8345ca6076eb6
   depends:
@@ -1667,7 +1667,7 @@ packages:
   license_family: BSD
   size: 263308
   timestamp: 1624477853289
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
   sha256: 8bcb1c67693f42a3170eb77ef4cdbb81b605fdf40816953e69a33a065c101638
   md5: b7689507fb5f879dc766aaa8a4c37351
   depends:
@@ -1686,7 +1686,7 @@ packages:
   license_family: Other
   size: 734566
   timestamp: 1646325095608
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
   sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
   md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
   depends:
@@ -1697,7 +1697,7 @@ packages:
   license_family: MIT
   size: 2674850
   timestamp: 1697548887851
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
   sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
   md5: fe56f0479dd414c846191116366262c3
   depends:
@@ -1706,7 +1706,7 @@ packages:
   license_family: MIT
   size: 31999
   timestamp: 1692205535111
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
   sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
   md5: 44d2a857d13bdf9d99aaac039a249d47
   depends:
@@ -1715,7 +1715,7 @@ packages:
   license_family: Apache
   size: 91137
   timestamp: 1659455142164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
   sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
   md5: eb899a739d9b58dd747f1f6bd52d4cf3
   depends:
@@ -1727,7 +1727,7 @@ packages:
   license_family: BSD
   size: 579771
   timestamp: 1672387338600
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
   sha256: 6973cfe0565ba3b5ad6d1de9e34848fbbadd78b507b2e23e1c079636b8f8f317
   md5: a924535045fb356e23e7a3cc8116b638
   depends:
@@ -1737,7 +1737,7 @@ packages:
   license_family: BSD
   size: 350026
   timestamp: 1612298042840
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
   sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
   md5: f36ecb722522cbe2e3737424edf1b5e1
   depends:
@@ -1749,7 +1749,7 @@ packages:
   license_family: BSD
   size: 29312
   timestamp: 1675441510984
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
   sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
   md5: 6d03295e544251e608a28c8d7c48115e
   depends:
@@ -1758,7 +1758,7 @@ packages:
   license_family: BSD
   size: 1862058
   timestamp: 1684280096752
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
   sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
   md5: 1f09617aecd6f3c2f2e20692c0759f34
   depends:
@@ -1768,7 +1768,7 @@ packages:
   license_family: Apache
   size: 94434
   timestamp: 1690223520097
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
   sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
   md5: ffceed627867508d73af1636ab5ebf42
   depends:
@@ -1777,7 +1777,7 @@ packages:
   license_family: MIT
   size: 156324
   timestamp: 1661452578573
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.9.2-py39h2531618_6.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyqt-5.9.2-py39h2531618_6.tar.bz2
   sha256: c96502aca0df082c457f31d9e6202419aa86f24e1c699c3a34d02602f7a42812
   md5: 3eda4bcc31b66fd5002817def97cd129
   depends:
@@ -1791,7 +1791,7 @@ packages:
   license_family: GPL
   size: 6010734
   timestamp: 1607697278482
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
   sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
   md5: 0e3341a4fe434167bf74b613eb6afd81
   depends:
@@ -1801,7 +1801,7 @@ packages:
   license_family: MIT
   size: 97194
   timestamp: 1636110999719
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
   sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
   md5: c5f3f7f10ad30f0945e75252615ab6e5
   depends:
@@ -1810,7 +1810,7 @@ packages:
   license_family: BSD
   size: 31331
   timestamp: 1605305847037
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
   sha256: c4b9e332a6f2b7524e8c88e2b39a2568a48e556fd9a44c30759c43611d4d023d
   md5: bb118745c9b08fc5028f45e77f371e68
   depends:
@@ -1830,7 +1830,7 @@ packages:
   license_family: PSF
   size: 24553777
   timestamp: 1654084160832
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
   sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
   md5: 0caa188a695319bdb13f53b0a2b3accc
   depends:
@@ -1839,7 +1839,7 @@ packages:
   license_family: BSD
   size: 264864
   timestamp: 1661371117920
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
   sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
   md5: bcb44ecbea441ee0d4659133d060d71f
   depends:
@@ -1848,7 +1848,7 @@ packages:
   license_family: MIT
   size: 257904
   timestamp: 1695131670290
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
   sha256: e937081facacb141dc2c9cdcced92baa9a2662e4a56100b6041df0b6b7692570
   md5: f3ac39b2349258198a9b3316636fe5d5
   depends:
@@ -1858,7 +1858,7 @@ packages:
   license_family: BSD
   size: 39972
   timestamp: 1685030752528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
   sha256: 3da9cbbd49fac566433748bd245d09d7d5fcd28b04c0397cbbf6d5bb92f5c4a5
   md5: df73a5d2f6e089d51e71e91935a82c65
   depends:
@@ -1869,7 +1869,7 @@ packages:
   license_family: MIT
   size: 183753
   timestamp: 1635775763162
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
   sha256: 26005d191bb15070aad70707ed6493f32678a67978bd3b83d4c9679cab44e717
   md5: 2dc75d5a4ccb64310939c3a72d34ae20
   depends:
@@ -1880,7 +1880,7 @@ packages:
   license_family: BSD
   size: 521583
   timestamp: 1638435042256
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-5.9.7-h5867ecd_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/qt-5.9.7-h5867ecd_1.tar.bz2
   sha256: 5881ffba2ab8ed28112e80dd3f17ced0832b75615b9f8aab6bf171575c812b88
   md5: 50da300935a335f7605d3f96fa045111
   depends:
@@ -1904,7 +1904,7 @@ packages:
   license: LGPL-3.0
   size: 90037659
   timestamp: 1544604609235
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
   sha256: 8c950c69bee969e2c66f88f0dc247b3ab75a753672a88009779d5f5dba193532
   md5: 150ac0eb929bab9dec912797bdfc7b95
   depends:
@@ -1914,7 +1914,7 @@ packages:
   license_family: GPL
   size: 433182
   timestamp: 1642022402894
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
   sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
   md5: c7de00b4ac2778c4e5a7816320d75391
   depends:
@@ -1930,7 +1930,7 @@ packages:
   license_family: Apache
   size: 94028
   timestamp: 1690400356879
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
   sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
   md5: 1581cafc84708ed9aafaaee1cbbf6065
   depends:
@@ -1939,7 +1939,7 @@ packages:
   license_family: MIT
   size: 1089416
   timestamp: 1690290900608
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-4.19.13-py39h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sip-4.19.13-py39h295c915_0.tar.bz2
   sha256: 9f2d68b41365097a380979014b3cabf5f1f9f07e5554eb215eef4801f640922e
   md5: 3ec6ce8f2eae0969b341e5702fb029c6
   depends:
@@ -1949,7 +1949,7 @@ packages:
   license: GPL-3.0
   size: 302624
   timestamp: 1643114723175
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
   sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
   md5: e19ffbfb24b990275d24fcea2bd1699b
   depends:
@@ -1958,7 +1958,7 @@ packages:
   license_family: Apache
   size: 15702
   timestamp: 1614030498860
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
   sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
   md5: ca061ce25c0f58628643abec8d6a8244
   depends:
@@ -1967,7 +1967,7 @@ packages:
   license_family: MIT
   size: 66330
   timestamp: 1696347637947
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
   sha256: 87965b7b46d93866d31696a1045216d64f077a06b2900c356aba87e8559c6188
   md5: fa334030245135b37027a882f3c468bf
   depends:
@@ -1978,7 +1978,7 @@ packages:
   license_family: Other
   size: 1561908
   timestamp: 1655328608308
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
   sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
   md5: 0e76eab58fe488e91f0aee73f46de031
   depends:
@@ -1989,7 +1989,7 @@ packages:
   license_family: BSD
   size: 29816
   timestamp: 1671751864131
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
   sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
   md5: b413a210eca82fe867e991eed085201b
   depends:
@@ -1999,7 +1999,7 @@ packages:
   license_family: BSD
   size: 38882
   timestamp: 1668168876032
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
   sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
   md5: 5b8375e2092012db69d2123dc0c68630
   depends:
@@ -2009,7 +2009,7 @@ packages:
   license_family: BSD
   size: 3485432
   timestamp: 1654088939579
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
   sha256: b746e39272888b9cc1a2a711b7b8836f2e26f4457850e43ad18bf0765e21dc3d
   md5: 200e86f8d53aeebf4b7dcfc944fd7920
   depends:
@@ -2019,7 +2019,7 @@ packages:
   license_family: Apache
   size: 661662
   timestamp: 1606942359431
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
   sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
   md5: 67a8320961ff24e92eebb661536e5cf7
   depends:
@@ -2032,7 +2032,7 @@ packages:
   license_family: MOZILLA
   size: 123763
   timestamp: 1679561904852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
   sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
   md5: 0f0b91a158dd3692cbb7a7763b657bfe
   depends:
@@ -2041,7 +2041,7 @@ packages:
   license_family: BSD
   size: 192032
   timestamp: 1671143995098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
   md5: 8515e64a3de7581360d713fe4c0a094e
   depends:
@@ -2051,7 +2051,7 @@ packages:
   license_family: PSF
   size: 8789
   timestamp: 1690297588156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
   md5: 60170012374b2a5007842fa5870d78c5
   depends:
@@ -2060,7 +2060,7 @@ packages:
   license_family: PSF
   size: 57479
   timestamp: 1690297581658
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
   sha256: 870f20a3c006a74b291910f69c3469a409bd21437142864b29cfafeb89ca7c34
   md5: 1b2f1589e3ebc3e0c6ecb38dba93e4ae
   depends:
@@ -2075,7 +2075,7 @@ packages:
   license_family: MIT
   size: 186761
   timestamp: 1686163186447
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
   sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
   md5: f8d03a15b974fc7810d9f54ae849fc8e
   depends:
@@ -2084,7 +2084,7 @@ packages:
   license_family: BSD
   size: 20781
   timestamp: 1607365390528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
   sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
   md5: d7db5d6ce1db80eade8a082ff78bf479
   depends:
@@ -2094,7 +2094,7 @@ packages:
   license_family: BSD
   size: 71044
   timestamp: 1614804011510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
   sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
   md5: b3899f8bda32734727bd5a73df1d7d17
   depends:
@@ -2103,7 +2103,7 @@ packages:
   license_family: MIT
   size: 101520
   timestamp: 1695742037911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
   sha256: 2ce360ff98c0ca4537d70c19266b5700810196c54ce2fbaff3b94a969846ee37
   md5: 94cb94dc47405b24b1b5bd0a3275ab59
   depends:
@@ -2112,7 +2112,7 @@ packages:
   license_family: GPL2
   size: 398058
   timestamp: 1651602137803
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -2120,7 +2120,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
   sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
   md5: 567b68192c387b5fc88178425577a0fe
   depends:
@@ -2130,7 +2130,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 366479
   timestamp: 1616055552392
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
   sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
   md5: 3818a9531fe74433c3b7d5144c9a58cc
   depends:
@@ -2139,7 +2139,7 @@ packages:
   license_family: MIT
   size: 18021
   timestamp: 1672387231268
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
   sha256: 513444d83ac2405e898531492ea59f3a95641e357cc39c1048d6fffc1791a16b
   md5: 601d9449c280b9b145dc8c83b6f06119
   depends:
@@ -2148,7 +2148,7 @@ packages:
   license_family: Other
   size: 133595
   timestamp: 1650637720646
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
   sha256: 1c049c23788a00b6f38bdc801245e0e60af98718d4db4c958658bcc67ff158c7
   md5: b1737dfd2e06ad69ec5cfec341e207c6
   depends:
@@ -2161,7 +2161,7 @@ packages:
   license_family: BSD
   size: 827172
   timestamp: 1650622223170
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -2174,7 +2174,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -2184,7 +2184,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
   md5: b2aa5503875aba2f1d88cae9df9a96d5
   depends:
@@ -2193,7 +2193,7 @@ packages:
   license_family: BSD
   size: 13636
   timestamp: 1611930018941
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -2205,7 +2205,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
   sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
   md5: 544adf2677c47c9b9c891aea720678f1
   depends:
@@ -2213,7 +2213,7 @@ packages:
   license: MIT
   size: 33999
   timestamp: 1630003259346
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -2222,7 +2222,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -2231,7 +2231,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -2240,7 +2240,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -2249,7 +2249,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
   sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
   md5: 9eff1a842dbda8d1bae9a2c008b599bc
   depends:
@@ -2260,7 +2260,7 @@ packages:
   license_family: MIT
   size: 690443
   timestamp: 1625743217109
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -2268,7 +2268,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
   sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
   md5: 33624a42ee387bf9918ea98b4e7b31fc
   depends:
@@ -2278,7 +2278,7 @@ packages:
   license_family: BSD
   size: 8173
   timestamp: 1601490751973
-- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
   sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
   md5: 67857cc5e9044770d2b15f9d94a4521d
   depends:
@@ -2287,7 +2287,7 @@ packages:
   license_family: Apache
   size: 12810
   timestamp: 1600445183315
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -2296,7 +2296,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -2305,7 +2305,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -2315,7 +2315,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
   sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
   md5: e68a6f315f41a8d814d833652bf38b9b
   depends:
@@ -2323,7 +2323,7 @@ packages:
   license: MIT
   size: 13374
   timestamp: 1606932077143
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -2331,7 +2331,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -2340,7 +2340,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -2349,7 +2349,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
   sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
   md5: 2eb923cc014094f4acf7f849d67d73f8
   depends:
@@ -2359,7 +2359,7 @@ packages:
   license_family: BSD
   size: 246457
   timestamp: 1626374695070
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
   sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
   md5: 02caf3f47f1d06256068053297355740
   depends:
@@ -2368,7 +2368,7 @@ packages:
   license_family: Apache
   size: 152292
   timestamp: 1690578151230
-- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
   sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
   md5: 41db68b96e114e367c4f120a3b379e59
   depends:
@@ -2377,7 +2377,7 @@ packages:
   license_family: BSD
   size: 19391
   timestamp: 1632406728844
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -2386,7 +2386,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -2398,14 +2398,14 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
   sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
   md5: a815d3bdb160bcc71687f2dda70d3ca4
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 122218
   timestamp: 1680170368293
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -2413,7 +2413,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
   sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
   md5: 447a49f7bad119faa80d7f14aa296c95
   depends:
@@ -2426,7 +2426,7 @@ packages:
   license_family: MIT
   size: 162176
   timestamp: 1644481750133
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
   sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
   md5: 8810f48fe4a4792de0fd3520b502d08b
   depends:
@@ -2435,7 +2435,7 @@ packages:
   license_family: BSD
   size: 10019
   timestamp: 1606859473259
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
   sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
   md5: 00a446b6dfc61af223df4de29fe8ad94
   depends:
@@ -2445,7 +2445,7 @@ packages:
   license_family: MIT
   size: 34305
   timestamp: 1644569782044
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
   sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
   md5: bd92dd8bd5b9d24e632b62a075426e50
   depends:
@@ -2454,7 +2454,7 @@ packages:
   license_family: MIT
   size: 133634
   timestamp: 1695718025321
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
   sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
   md5: f8ae051b591a9027adc16de1be9748f4
   depends:
@@ -2464,12 +2464,12 @@ packages:
   license_family: MIT
   size: 206198
   timestamp: 1681493096349
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
   sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
   md5: e2f3248e2a5009a02f7b8e54f83314ef
   size: 5620
   timestamp: 1528121955725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
   sha256: 2936241747f6cc0f0b3afa53bb28ad6f658b53a0fc2e67a5ed34d1d5e2cce117
   md5: bdca1b691340964271d9cfec6baaf8d0
   depends:
@@ -2487,7 +2487,7 @@ packages:
   license_family: BSD
   size: 5719952
   timestamp: 1697490515691
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
   sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
   md5: 0d79760d544d0bd8acb4adc4ef813418
   depends:
@@ -2497,7 +2497,7 @@ packages:
   license_family: BSD
   size: 137075
   timestamp: 1657175654487
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
   sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
   md5: 31d6d04cd2388d8f19004501271b3545
   depends:
@@ -2507,7 +2507,7 @@ packages:
   license: MIT
   size: 18982
   timestamp: 1659616229395
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
   sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
   md5: caf1073dc2ca5aeb832a2877394eae12
   depends:
@@ -2516,7 +2516,7 @@ packages:
   license: MIT
   size: 18233
   timestamp: 1659616216769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
   sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
   md5: aa1ed20c38af535c8d6a955314759d7b
   depends:
@@ -2525,14 +2525,14 @@ packages:
   license: MIT
   size: 394588
   timestamp: 1659616312678
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
   sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
   md5: ce3588e31faa79f546e0fc6a36c5543c
   license: MPL-2.0
   license_family: Other
   size: 133884
   timestamp: 1694009771475
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
   sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
   md5: 21eb7f53076d0a69513cfd258f6ef63c
   depends:
@@ -2541,7 +2541,7 @@ packages:
   license_family: Other
   size: 159756
   timestamp: 1690232346868
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
   sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
   md5: a40a04d9cda1e665565bc6c832d598b6
   depends:
@@ -2552,7 +2552,7 @@ packages:
   license_family: MIT
   size: 225258
   timestamp: 1670423337502
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
   sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
   md5: b2cc5f37f7bb069d061306e7eac2a011
   depends:
@@ -2562,7 +2562,7 @@ packages:
   license_family: CC
   size: 1913396
   timestamp: 1668084575248
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
   sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
   md5: 103d8c039e342115720a84d59c119d46
   depends:
@@ -2572,7 +2572,7 @@ packages:
   license_family: BSD
   size: 13774
   timestamp: 1671231190250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
   sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
   md5: f69f09e0346172f225390d2b3b0d7873
   depends:
@@ -2583,7 +2583,7 @@ packages:
   license_family: BSD
   size: 246628
   timestamp: 1663827484947
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
   sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
   md5: cb80c7ac65b48a737654f371fe31c460
   depends:
@@ -2596,7 +2596,7 @@ packages:
   license_family: BSD
   size: 1307228
   timestamp: 1694212041712
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
   sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
   md5: 04cbe8f4bc62c34fac9d42d1124059bf
   depends:
@@ -2606,7 +2606,7 @@ packages:
   license_family: MIT
   size: 2052734
   timestamp: 1690905361158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
   sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
   md5: ef0e825982f242085574f502dfff4f6b
   depends:
@@ -2615,7 +2615,7 @@ packages:
   license_family: MIT
   size: 16594
   timestamp: 1649926538106
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
   sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
   md5: 24747a300246c016b3a7f04dabd02d4a
   depends:
@@ -2624,7 +2624,7 @@ packages:
   license_family: BSD
   size: 27709
   timestamp: 1668714497209
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -2634,14 +2634,14 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
   sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
   md5: e4a732941f74b8062c8bcbfe5c5c2b56
   license: MIT
   license_family: MIT
   size: 80252
   timestamp: 1676983220161
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
   sha256: 5c36d43cadbbf944d9255e79df85c2e9e6155a1d6f9158e06fcd8ffd458b7663
   md5: a5a2cff387403ccf9cf58aac7a6dde55
   depends:
@@ -2658,7 +2658,7 @@ packages:
   license_family: BSD
   size: 4573879
   timestamp: 1698866750755
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
   sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
   md5: f3ce6fe6eb760c236e5f7d04df5faa81
   depends:
@@ -2667,7 +2667,7 @@ packages:
   license_family: MIT
   size: 28138484
   timestamp: 1692293212596
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
   sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
   md5: 6dd72c43fea25b748ec7a9f6c0407e15
   depends:
@@ -2676,7 +2676,7 @@ packages:
   license_family: BSD
   size: 111810
   timestamp: 1666125671024
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
   sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
   md5: 03cdb7e679924b329ecab8f12cb8fc67
   depends:
@@ -2686,7 +2686,7 @@ packages:
   license_family: APACHE
   size: 38813
   timestamp: 1678997212422
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
   sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
   md5: e113c4e6e758dd68faf196586bf5564d
   depends:
@@ -2696,7 +2696,7 @@ packages:
   license_family: Apache
   size: 51873
   timestamp: 1698254765815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
   sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
   md5: 78baea934985ccd9514a366cc7e80ed4
   depends:
@@ -2705,7 +2705,7 @@ packages:
   license_family: Proprietary
   size: 727499
   timestamp: 1681801225190
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
   sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
   md5: da9b63e42f281f7e77b289f4b654b83b
   depends:
@@ -2727,7 +2727,7 @@ packages:
   license_family: BSD
   size: 218436
   timestamp: 1691121840155
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
   sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
   md5: 6a7cb9b49593b29933fa2b503d533a08
   depends:
@@ -2749,7 +2749,7 @@ packages:
   license_family: BSD
   size: 1257205
   timestamp: 1694181720454
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
   sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
   md5: d861ef66f5c0a282d60b65778a9de2f3
   depends:
@@ -2759,7 +2759,7 @@ packages:
   license_family: MIT
   size: 1048450
   timestamp: 1644315332508
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
   sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
   md5: f7e603c965052deed8b789c35855a42f
   depends:
@@ -2769,14 +2769,14 @@ packages:
   license_family: BSD
   size: 213537
   timestamp: 1666908270815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
   sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
   md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
   license: IJG
   license_family: Other
   size: 278924
   timestamp: 1677849185191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
   sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
   md5: a82a17e78f725dcbd71ff8dac6db05c7
   depends:
@@ -2787,7 +2787,7 @@ packages:
   license_family: MIT
   size: 133134
   timestamp: 1676558895333
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
   sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
   md5: ee9270379a9ebdb6297e4b6849b3f7f0
   depends:
@@ -2803,7 +2803,7 @@ packages:
   license_family: BSD
   size: 195479
   timestamp: 1676329410154
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.5.0-py39hecd8cb5_0.tar.bz2
   sha256: ede34881321808fbb967885dde9b0b6c9c8ef1f3eb192fa514058c4f14201c4f
   md5: 07d24f5332ca5d0e76aa0df051a1f05d
   depends:
@@ -2814,7 +2814,7 @@ packages:
   license_family: BSD
   size: 79901
   timestamp: 1698937699237
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
   sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
   md5: 7e60995b3119417213e5faedda147499
   depends:
@@ -2838,7 +2838,7 @@ packages:
   license_family: BSD
   size: 403165
   timestamp: 1671707664990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
   sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
   md5: cd470bdb28bb0e8b3535c93a3a6dad07
   depends:
@@ -2848,7 +2848,7 @@ packages:
   license_family: BSD
   size: 65431
   timestamp: 1672387389172
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -2858,7 +2858,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -2867,13 +2867,13 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
   sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
   md5: 7dba7aa5b971febb55281659843586ba
   license: MIT
   size: 65470
   timestamp: 1659616172703
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
   sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
   md5: f78a158983f0bbaba56f34b976bc6dae
   depends:
@@ -2881,7 +2881,7 @@ packages:
   license: MIT
   size: 34189
   timestamp: 1659616189313
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
   sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
   md5: 36a1d885725d3ab4d1fadc5a29f978d2
   depends:
@@ -2889,35 +2889,35 @@ packages:
   license: MIT
   size: 327737
   timestamp: 1659616202869
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
   sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
   md5: 817848d0e2b2808acdc9b3fbbf581726
   license: MIT
   license_family: MIT
   size: 133887
   timestamp: 1683716590737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
   sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
   md5: c90372428e1e4eed4fdcd790979d06b4
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1409377
   timestamp: 1650983531933
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -2926,13 +2926,13 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -2949,7 +2949,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
   sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
   md5: c0b99f8e1c7475f23b1c7b4250b06e1c
   depends:
@@ -2963,7 +2963,7 @@ packages:
   license_family: BSD
   size: 88021
   timestamp: 1694778290062
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
   sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
   md5: 46a65d1fc24013217e06aaf6d65ffcad
   constrains:
@@ -2972,7 +2972,7 @@ packages:
   license_family: BSD
   size: 425478
   timestamp: 1694776947990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
   sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
   md5: 06866415ef22d5322f9bdc9956b59c4d
   depends:
@@ -2984,7 +2984,7 @@ packages:
   license_family: MIT
   size: 678174
   timestamp: 1692970318885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
   sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
   md5: 2edc6c894d6d0321304396e9bd40df94
   depends:
@@ -2994,7 +2994,7 @@ packages:
   license_family: MIT
   size: 241774
   timestamp: 1692973618934
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 0190d3b8d2939f28aa017711cf4147c51a1139da2922cc8420a71562dd99f844
   md5: 454a7f2c4426453f17e995382a4235e4
   depends:
@@ -3004,7 +3004,7 @@ packages:
   license_family: MIT
   size: 36036
   timestamp: 1659783508187
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
   sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
   md5: 8bbd981ca0129d7beeacd3cd7623f714
   depends:
@@ -3015,7 +3015,7 @@ packages:
   license_family: Other
   size: 1491074
   timestamp: 1695058597986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
   sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
   md5: d5f58d056b4bfc67aec30c77035ba889
   depends:
@@ -3024,7 +3024,7 @@ packages:
   license_family: BSD
   size: 182491
   timestamp: 1670944720979
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
   sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
   md5: 1affd16b166571a91feae04baf5fd3da
   depends:
@@ -3034,7 +3034,7 @@ packages:
   license_family: BSD
   size: 123431
   timestamp: 1671542016019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
   sha256: e5fc51472fa0f36abd78baa5b3c9245d6627b0da11188e6a954d73f3f2bca210
   md5: df7c519447affffb594f8c56b028ed33
   depends:
@@ -3044,7 +3044,7 @@ packages:
   license_family: MIT
   size: 107035
   timestamp: 1684279974102
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
   sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
   md5: 3681ebf029211ceab26af6f5d35abf39
   depends:
@@ -3055,7 +3055,7 @@ packages:
   license_family: BSD
   size: 22254
   timestamp: 1654598220251
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.8.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-3.8.0-py39hecd8cb5_0.tar.bz2
   sha256: 40aa972e605bdc8305ebdc4b8e891ae8b65382be12d221e002ec31cfe830ac22
   md5: 07b2a24fd3dcb5cb0af22e137cd43408
   depends:
@@ -3066,7 +3066,7 @@ packages:
   license_family: PSF
   size: 8754
   timestamp: 1698692468088
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
   sha256: 2fd179efa024c92d0d71179a981a781d16c70f5d8c6305e0d678b0c7ae1275ab
   md5: addda7f015d1673f794a23fdb18a3e09
   depends:
@@ -3089,7 +3089,7 @@ packages:
   license_family: PSF
   size: 8182219
   timestamp: 1698692361219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
   sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
   md5: 6eb64ecfcd754502e271db0bb51d2cfd
   depends:
@@ -3099,7 +3099,7 @@ packages:
   license_family: BSD
   size: 17374
   timestamp: 1662014643620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 2312ee5a6343e8495802698d7181f1b619aad7479d96ee253407b324ac884417
   md5: 866960fa48a7ca335941786d4869802a
   depends:
@@ -3109,7 +3109,7 @@ packages:
   license_family: MIT
   size: 53542
   timestamp: 1659721365599
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
   sha256: 37f455814ce242eb65ff80a0402f1bd231a388e6823e6c1e65f60b705c032a2d
   md5: 4c9246c492a64729225aa5b04e12c2d1
   depends:
@@ -3118,7 +3118,7 @@ packages:
   license_family: MIT
   size: 19573
   timestamp: 1659716100178
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
   sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
   md5: 2a4d604717a647ad21af766289cbbfc3
   depends:
@@ -3127,7 +3127,7 @@ packages:
   license_family: BSD
   size: 58057
   timestamp: 1607364912348
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
   sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
   md5: 25051fe272624544652dc6d814c2943a
   depends:
@@ -3140,7 +3140,7 @@ packages:
   license_family: Proprietary
   size: 224420228
   timestamp: 1691503125614
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
   sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
   md5: 37d8cf85a63f7aa9af1624894a7d606d
   depends:
@@ -3150,7 +3150,7 @@ packages:
   license_family: BSD
   size: 48590
   timestamp: 1682969183093
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
   sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
   md5: 0b2aee6666135bbd36b46d6ac66160f7
   depends:
@@ -3163,7 +3163,7 @@ packages:
   license_family: BSD
   size: 210705
   timestamp: 1695058433223
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
   sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
   md5: e22fb55ce380d0ebd44cce3f20d5349e
   depends:
@@ -3177,7 +3177,7 @@ packages:
   license_family: BSD
   size: 296614
   timestamp: 1695060155673
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
   sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
   md5: 1a5d4004e64e3cfb7a2a297b9117c285
   depends:
@@ -3203,7 +3203,7 @@ packages:
   license_family: BSD
   size: 8213832
   timestamp: 1681756573646
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py39hecd8cb5_0.tar.bz2
   sha256: 59acf22956f295ed429624a1560bceffbbf536ea93ca63a5f1a48975a0afdbcb
   md5: a7a6344327960940bad23e783a4d6bce
   depends:
@@ -3216,7 +3216,7 @@ packages:
   license_family: BSD
   size: 100813
   timestamp: 1698934262550
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
   sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
   md5: e572c1264a7af20b486f64ac8c9e1f57
   depends:
@@ -3244,7 +3244,7 @@ packages:
   license_family: BSD
   size: 573356
   timestamp: 1668450732828
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
   sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
   md5: b67569a7c30af9ffa5cde6e4b52ac68b
   depends:
@@ -3257,14 +3257,14 @@ packages:
   license_family: BSD
   size: 148342
   timestamp: 1694616917184
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
   sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
   md5: 97b81f34efbe86c5220fe82eb584fd62
   depends:
@@ -3273,7 +3273,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387288528
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
   sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
   md5: d77862975a9a1cf50acb803be26e83a1
   depends:
@@ -3298,7 +3298,7 @@ packages:
   license_family: BSD
   size: 575365
   timestamp: 1690985052739
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
   sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
   md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
   depends:
@@ -3308,7 +3308,7 @@ packages:
   license_family: BSD
   size: 22858
   timestamp: 1668160618784
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
   sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
   md5: 185e9c41abb88ee59b52ec0f5f65d506
   depends:
@@ -3322,7 +3322,7 @@ packages:
   license_family: MIT
   size: 138305
   timestamp: 1696515469702
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
   sha256: 82a2dd0c2ff6e20a275e5447dd03088f79694f7bfa5055a25c54bebf31aac4ca
   md5: c157e6ab469a95b06fa822ba075978b3
   depends:
@@ -3338,7 +3338,7 @@ packages:
   license_family: BSD
   size: 10376
   timestamp: 1695831243158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
   sha256: b3a003b41cec2751210e542911e99437db0321542f6812c1b88608ef720ba7ef
   md5: 56400dfe88c427cdf1854e47666b8a99
   depends:
@@ -3353,7 +3353,7 @@ packages:
   license_family: BSD
   size: 7570900
   timestamp: 1695831208653
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
   sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
   md5: 93f5d7b66976154adeda219bea02ba45
   depends:
@@ -3363,7 +3363,7 @@ packages:
   license: BSD 2-Clause
   size: 484257
   timestamp: 1630093862501
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
   sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
   md5: 5e8713ef1215406254988163eaf34020
   depends:
@@ -3372,7 +3372,7 @@ packages:
   license_family: Apache
   size: 4965606
   timestamp: 1695323060401
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
   sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
   md5: 4154929ace2ad6ee16aea815635a6d1f
   depends:
@@ -3381,7 +3381,7 @@ packages:
   license_family: Apache
   size: 73598
   timestamp: 1693575307570
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
   sha256: aff5acedef9da91b77851e1a163b8319d72bc4152c98ac87703a2eac1e5d575b
   md5: 7df4c76aa8c52fedce5346748d56459e
   depends:
@@ -3428,7 +3428,7 @@ packages:
   license_family: BSD
   size: 13388063
   timestamp: 1697477404222
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
   sha256: 42d83288119306089a06e853a37045fbb9860548b05a1e79d223f7ecf1cb349d
   md5: 8daced11264159ff57df7bba4d0b2ec7
   depends:
@@ -3452,7 +3452,7 @@ packages:
   license_family: BSD
   size: 17075803
   timestamp: 1698867397009
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
   sha256: ad7ca92e5c83a8e2181677025509ed7b8f566ec23b24f28316fa087bb591c11f
   md5: a4ccd0fbcfb26de868f2fb4836940d7a
   depends:
@@ -3461,7 +3461,7 @@ packages:
   license_family: BSD
   size: 189263
   timestamp: 1698263570990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
   sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
   md5: be0a90921f3bf4f0d6950fb786093de7
   depends:
@@ -3480,7 +3480,7 @@ packages:
   license_family: Other
   size: 719901
   timestamp: 1696580194417
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
   sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
   md5: 81ae9ec2d7fcf6934847bff558b619f5
   depends:
@@ -3491,7 +3491,7 @@ packages:
   license_family: MIT
   size: 2672987
   timestamp: 1697548890181
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
   sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
   md5: 1a822c206e2abddc5d6d821721af227f
   depends:
@@ -3500,7 +3500,7 @@ packages:
   license_family: MIT
   size: 33013
   timestamp: 1692205801265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
   sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
   md5: 1604d33dbdb2446c642970f8b354bedb
   depends:
@@ -3509,7 +3509,7 @@ packages:
   license_family: Apache
   size: 91266
   timestamp: 1659455269141
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
   sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
   md5: d1b3bcc35655a3123acb1fa2ad1a8511
   depends:
@@ -3521,7 +3521,7 @@ packages:
   license_family: BSD
   size: 580828
   timestamp: 1672387372015
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
   sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
   md5: 7540555d1fb192236db9a7c5c9d3601c
   depends:
@@ -3530,7 +3530,7 @@ packages:
   license_family: BSD
   size: 365765
   timestamp: 1656431373327
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
   sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
   md5: 0a73533fb6e0dc717ab906a537bc747d
   depends:
@@ -3542,7 +3542,7 @@ packages:
   license_family: BSD
   size: 30803
   timestamp: 1675441638631
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
   sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
   md5: 0a959fbad46ab38ade48dbd358002674
   depends:
@@ -3551,7 +3551,7 @@ packages:
   license_family: BSD
   size: 1864757
   timestamp: 1684280094736
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
   sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
   md5: ea24b5076ef79e4567c5a3f0cb22b470
   depends:
@@ -3561,7 +3561,7 @@ packages:
   license_family: Apache
   size: 95330
   timestamp: 1690223465114
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
   sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
   md5: bcaea6d4a47e9c874becaa700c78dcf7
   depends:
@@ -3570,7 +3570,7 @@ packages:
   license_family: MIT
   size: 157216
   timestamp: 1661452617825
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
   sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
   md5: 707110d1b49cb1864acb0bbaa103591e
   depends:
@@ -3579,7 +3579,7 @@ packages:
   license_family: MIT
   size: 95016
   timestamp: 1636111184034
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
   sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
   md5: 113a443b9c706f9f9c6187c0eaa3de27
   depends:
@@ -3588,7 +3588,7 @@ packages:
   license_family: BSD
   size: 31178
   timestamp: 1605305861851
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
   sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
   md5: 85a8d0001db70e52a479155228cb1fe0
   depends:
@@ -3607,7 +3607,7 @@ packages:
   license_family: PSF
   size: 13324979
   timestamp: 1694439878265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
   sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
   md5: 47c5e22e31ec05a7bc0ce90065a53afd
   depends:
@@ -3616,7 +3616,7 @@ packages:
   license_family: BSD
   size: 265348
   timestamp: 1661368839620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
   sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
   md5: ce9a69e1668aa1e133f2aa6d4e8d346f
   depends:
@@ -3625,7 +3625,7 @@ packages:
   license_family: MIT
   size: 254958
   timestamp: 1695131709704
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 9ee098c09f31fad7ff1856e5ce2619172eaf979997e7a427d1e05cce32c2af00
   md5: cac1d1898b69ae9646dfbf082910635d
   depends:
@@ -3635,7 +3635,7 @@ packages:
   license_family: BSD
   size: 40946
   timestamp: 1685030787453
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
   sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
   md5: 637f08b19dd8fd87347d8c44f9e3e202
   depends:
@@ -3645,7 +3645,7 @@ packages:
   license_family: MIT
   size: 170776
   timestamp: 1698096100056
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
   sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
   md5: 8ce3ac7d8a04e469b566f1b090d01140
   depends:
@@ -3656,7 +3656,7 @@ packages:
   license_family: BSD
   size: 470617
   timestamp: 1657724324011
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -3665,7 +3665,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
   sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
   md5: 6f2d41dd76a03b7f85a1ed49af1763d6
   depends:
@@ -3681,7 +3681,7 @@ packages:
   license_family: Apache
   size: 95100
   timestamp: 1690400262627
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
   md5: b0321e6f14e139fc15b1f8b4acb35d2f
   depends:
@@ -3690,7 +3690,7 @@ packages:
   license_family: MIT
   size: 1093966
   timestamp: 1690290944588
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
   sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
   md5: 62b64576a0aa5f6c3fb05f56650d25e1
   depends:
@@ -3699,7 +3699,7 @@ packages:
   license_family: Apache
   size: 15535
   timestamp: 1614030509324
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
   sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
   md5: 15b5595b31e39f08eaacbe2e502d8fb3
   depends:
@@ -3708,7 +3708,7 @@ packages:
   license_family: MIT
   size: 67292
   timestamp: 1696347733587
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
   sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
   md5: 82e4db6a498480a75d53c55bd35b6478
   depends:
@@ -3720,7 +3720,7 @@ packages:
   license_family: Other
   size: 1801397
   timestamp: 1681394807900
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -3729,7 +3729,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
   sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
   md5: 63b957927b9949ccb19da28ec4612706
   depends:
@@ -3740,7 +3740,7 @@ packages:
   license_family: BSD
   size: 30902
   timestamp: 1671751919031
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
   sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
   md5: e346257a2fa8e2cb48c762138a5d009b
   depends:
@@ -3750,7 +3750,7 @@ packages:
   license_family: BSD
   size: 39915
   timestamp: 1668168959656
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
   sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
   md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
   depends:
@@ -3759,7 +3759,7 @@ packages:
   license_family: BSD
   size: 3536231
   timestamp: 1654088937695
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
   sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
   md5: a1bbf0abfb8c45541122c0eb2feee317
   depends:
@@ -3768,7 +3768,7 @@ packages:
   license_family: Apache
   size: 680464
   timestamp: 1696937112175
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
   sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
   md5: d689f6203c0a9d04fb229c73d7e80a7a
   depends:
@@ -3781,7 +3781,7 @@ packages:
   license_family: MOZILLA
   size: 125145
   timestamp: 1679561909274
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
   md5: 8a292c1ee22489bef2e84bc3aaf4098e
   depends:
@@ -3790,7 +3790,7 @@ packages:
   license_family: BSD
   size: 193141
   timestamp: 1671143985219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
   md5: 8bf0bfffc11ad06a1c94e145941b0ad4
   depends:
@@ -3800,7 +3800,7 @@ packages:
   license_family: PSF
   size: 9651
   timestamp: 1690297655669
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
   md5: 343514a174b3485fde55a73f56398dd7
   depends:
@@ -3809,7 +3809,7 @@ packages:
   license_family: PSF
   size: 58456
   timestamp: 1690297648002
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
   sha256: 11e7401cb6805db7ce22b1f9dd6ba5b7941c92225ce440bed1da0af284bfcad4
   md5: 5c10d68fa5616cdd82ee93ef6e0f038c
   depends:
@@ -3818,7 +3818,7 @@ packages:
   license_family: MIT
   size: 11615
   timestamp: 1659769478980
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
   sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
   md5: c2242e8fd24003a74ddf37416661e06d
   depends:
@@ -3833,7 +3833,7 @@ packages:
   license_family: MIT
   size: 188757
   timestamp: 1698257668273
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
   sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
   md5: 41f445e36b6b6722a9444508eef069f8
   depends:
@@ -3842,7 +3842,7 @@ packages:
   license_family: BSD
   size: 20583
   timestamp: 1607365395045
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
   sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
   md5: 409ee46ed24267b6da6fb32d13e1f21e
   depends:
@@ -3852,7 +3852,7 @@ packages:
   license_family: BSD
   size: 70730
   timestamp: 1614804271285
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
   sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
   md5: eb74e74d8e4fd533c55eb98b7b5e83bc
   depends:
@@ -3861,7 +3861,7 @@ packages:
   license_family: MIT
   size: 102637
   timestamp: 1695742077778
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
   sha256: cb007615819fd240ea4e343835dfbda3c508a92b5b7158219d30a22d0e67b57c
   md5: bf215e781ac81e0fc433eedee330c54b
   depends:
@@ -3870,20 +3870,20 @@ packages:
   license_family: BSD
   size: 49462
   timestamp: 1675159191191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
   sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
   md5: e243baa546432c8394a8059a44a5a3e4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 419227
   timestamp: 1683113010463
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
   sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
   md5: fe4ac85ee86d3a94ea3a4ebea3779763
   depends:
@@ -3892,7 +3892,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 321797
   timestamp: 1616055526986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
   sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
   md5: bc7073d9d4c0211cc4a1207c98fb765a
   depends:
@@ -3901,14 +3901,14 @@ packages:
   license_family: MIT
   size: 19091
   timestamp: 1672387204865
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
   sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
   md5: 8e495591e369ac161857a72011c0a296
   license: Zlib
   license_family: Other
   size: 120272
   timestamp: 1666595024203
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
   sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
   md5: f1465fbd810b3746c6de6babfd4fe28a
   depends:
@@ -3920,7 +3920,7 @@ packages:
   license_family: BSD
   size: 1023573
   timestamp: 1681304595869
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
   sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
   md5: cf55cb8d7031b30c70c56fc7c782b5c7
   depends:
@@ -3933,7 +3933,7 @@ packages:
   license_family: MIT
   size: 156104
   timestamp: 1644482799136
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
   sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
   md5: 84fce327d9f0d594e86f565e5c21962e
   depends:
@@ -3942,7 +3942,7 @@ packages:
   license_family: BSD
   size: 10183
   timestamp: 1629146082730
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
   sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
   md5: 84b8b998a741b37abf5312c1c03696ef
   depends:
@@ -3952,7 +3952,7 @@ packages:
   license_family: MIT
   size: 33979
   timestamp: 1644845817952
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
   sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
   md5: 77b746931c8f31c3ae393ccb5819d43d
   depends:
@@ -3961,7 +3961,7 @@ packages:
   license_family: MIT
   size: 133628
   timestamp: 1695717890677
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
   sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
   md5: 3df6e8ba34208dea068890e5d5318cc0
   depends:
@@ -3971,12 +3971,12 @@ packages:
   license_family: MIT
   size: 206759
   timestamp: 1681493095987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
   sha256: 8c31e7ede4b9a3ec6e1342f02bcff4d7113e5b25f12b91d108616a08eb8eb34f
   md5: de3ce22af040eb01db773fcab23ef413
   depends:
@@ -3994,7 +3994,7 @@ packages:
   license_family: BSD
   size: 5722206
   timestamp: 1697490482051
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
   sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
   md5: bb55f81435cb6e11d264242274fccd1a
   depends:
@@ -4004,7 +4004,7 @@ packages:
   license_family: BSD
   size: 115947
   timestamp: 1657175645380
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
   md5: f860193e14afc7ef3f5b990a2ac003d2
   depends:
@@ -4014,7 +4014,7 @@ packages:
   license: MIT
   size: 18936
   timestamp: 1659616204016
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
   sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
   md5: ad53130f3fd1f8d3c2fcbb7496e5585d
   depends:
@@ -4023,7 +4023,7 @@ packages:
   license: MIT
   size: 18715
   timestamp: 1659616188888
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
   sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
   md5: 0982c046fb976e9f9fb19e7510187a18
   depends:
@@ -4032,14 +4032,14 @@ packages:
   license: MIT
   size: 366983
   timestamp: 1659616245272
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
   sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
   md5: 31ac2f5596cb7a44adf073c930641c54
   license: MPL-2.0
   license_family: Other
   size: 133817
   timestamp: 1694009762858
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
   sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
   md5: cf1f6c3c34a1e1b9ab22b04233d860f6
   depends:
@@ -4048,7 +4048,7 @@ packages:
   license_family: Other
   size: 159783
   timestamp: 1690232303987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
   sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
   md5: 0eb268e38b5174d471a6e87d9d6102b1
   depends:
@@ -4059,7 +4059,7 @@ packages:
   license_family: MIT
   size: 225355
   timestamp: 1670423312966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
   sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
   md5: e68c94666cd60221b575c3814c89bac0
   depends:
@@ -4069,7 +4069,7 @@ packages:
   license_family: CC
   size: 1946451
   timestamp: 1668084573824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
   sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
   md5: 1773ae2b080cdd55827e27673351551e
   depends:
@@ -4079,7 +4079,7 @@ packages:
   license_family: BSD
   size: 13646
   timestamp: 1671231171682
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
   sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
   md5: 53bfd99ad1b09164d537209cffd98161
   depends:
@@ -4090,7 +4090,7 @@ packages:
   license_family: BSD
   size: 244040
   timestamp: 1663827469853
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
   sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
   md5: b62455043c8eb2434466885b19fed2de
   depends:
@@ -4103,7 +4103,7 @@ packages:
   license_family: BSD
   size: 1399573
   timestamp: 1694211828228
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
   sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
   md5: eb3cdc0fc210838b9271512a6a1b7c85
   depends:
@@ -4113,7 +4113,7 @@ packages:
   license_family: MIT
   size: 2067708
   timestamp: 1690905319109
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
   sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
   md5: f44b80b9405410e5bde6bfe0b31d5b3f
   depends:
@@ -4122,7 +4122,7 @@ packages:
   license_family: MIT
   size: 15135
   timestamp: 1650293774207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
   sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
   md5: f87027ccce1361d0f82c0edf1a10d53b
   depends:
@@ -4131,7 +4131,7 @@ packages:
   license_family: BSD
   size: 27677
   timestamp: 1668714367519
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -4141,14 +4141,14 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
   sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
   md5: 1d0bd7e576c64c059ef781dd319ad82a
   license: MIT
   license_family: MIT
   size: 77591
   timestamp: 1676983230102
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
   sha256: 3e480af22e98246c056bbd91d6be5352df34ff2b8451d9c7f614baeafb450d39
   md5: 695fe7ccaf6935d3117533d1e6737320
   depends:
@@ -4165,7 +4165,7 @@ packages:
   license_family: BSD
   size: 4542265
   timestamp: 1698866834303
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
   sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
   md5: 69eb3b03765627b6159ed23cdde78396
   depends:
@@ -4174,7 +4174,7 @@ packages:
   license_family: MIT
   size: 28399065
   timestamp: 1692293207812
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
   sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
   md5: 83366cbd3beb073112f4644a613b6bca
   depends:
@@ -4183,7 +4183,7 @@ packages:
   license_family: BSD
   size: 111933
   timestamp: 1666125627512
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
   sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
   md5: 647c1a2f8460ffa8c670a1915bbdb494
   depends:
@@ -4193,7 +4193,7 @@ packages:
   license_family: APACHE
   size: 38790
   timestamp: 1678997152549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
   sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
   md5: 35e541905426c686ef2ff010a0e502fd
   depends:
@@ -4203,7 +4203,7 @@ packages:
   license_family: Apache
   size: 51860
   timestamp: 1698254731870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
   sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
   md5: 187d7720aedf38759d122cccb4576f2c
   depends:
@@ -4225,7 +4225,7 @@ packages:
   license_family: BSD
   size: 219976
   timestamp: 1691121991680
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
   sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
   md5: e8e7f10741f9cfa737b310b334940441
   depends:
@@ -4247,7 +4247,7 @@ packages:
   license_family: BSD
   size: 1255894
   timestamp: 1694181494549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
   sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
   md5: ff209e75aee17af2e358b0008fbe8c88
   depends:
@@ -4257,7 +4257,7 @@ packages:
   license_family: MIT
   size: 1022945
   timestamp: 1644315931223
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
   sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
   md5: d3e78ef296b3c74910d003bd10b475d6
   depends:
@@ -4267,14 +4267,14 @@ packages:
   license_family: BSD
   size: 213972
   timestamp: 1666908195870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
   sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
   md5: 055e12390b844ea6c6e956ee08a618e8
   license: IJG
   license_family: Other
   size: 273479
   timestamp: 1677849171867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
   sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
   md5: 783e2ad3d36472648c5ccc9f3051db3c
   depends:
@@ -4285,7 +4285,7 @@ packages:
   license_family: MIT
   size: 133077
   timestamp: 1676558732505
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
   sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
   md5: 0677598f673f9729b5990316170a999d
   depends:
@@ -4301,7 +4301,7 @@ packages:
   license_family: BSD
   size: 197129
   timestamp: 1676329661580
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.5.0-py39hca03da5_0.tar.bz2
   sha256: cee2cc791937b240be796561ae67e5a7c57b014826fa087fd75b02acf82135ba
   md5: 141af9befcd79a876ded744de7d1fa8f
   depends:
@@ -4312,7 +4312,7 @@ packages:
   license_family: BSD
   size: 79928
   timestamp: 1698937338528
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
   sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
   md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
   depends:
@@ -4336,7 +4336,7 @@ packages:
   license_family: BSD
   size: 401319
   timestamp: 1671707682572
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
   sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
   md5: 247558a0aecf1ef7e77a4343761353d6
   depends:
@@ -4346,7 +4346,7 @@ packages:
   license_family: BSD
   size: 64600
   timestamp: 1672387273585
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -4356,7 +4356,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -4365,13 +4365,13 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
   md5: a0f206782751dfffed0dd51302a1bf26
   license: MIT
   size: 68012
   timestamp: 1659616138077
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
   md5: 4c6667cdd061d28e9bc4e4300e4d115e
   depends:
@@ -4379,7 +4379,7 @@ packages:
   license: MIT
   size: 31173
   timestamp: 1659616155596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
   md5: 637e9430e258ddf050623ef2360184d8
   depends:
@@ -4387,28 +4387,28 @@ packages:
   license: MIT
   size: 298430
   timestamp: 1659616172209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
   sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
   md5: 55c615026c0869f8d3ba657f3bd38c43
   license: MIT
   license_family: MIT
   size: 120389
   timestamp: 1683716579036
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -4417,7 +4417,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -4428,14 +4428,14 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
   sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
   md5: a41117710dafe569c9cc4e83f6f29fe3
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1411339
   timestamp: 1650982753977
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -4446,7 +4446,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -4455,13 +4455,13 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -4478,7 +4478,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
   sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
   md5: 98d22e0124d55fae3c37c608dab1dcc9
   depends:
@@ -4492,7 +4492,7 @@ packages:
   license_family: BSD
   size: 89825
   timestamp: 1694778225280
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
   sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
   md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
   constrains:
@@ -4501,7 +4501,7 @@ packages:
   license_family: BSD
   size: 331675
   timestamp: 1694776939192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
   sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
   md5: 0ba499df6755eae5d2d23aa4ab004553
   depends:
@@ -4513,7 +4513,7 @@ packages:
   license_family: MIT
   size: 642657
   timestamp: 1692970217410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
   sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
   md5: c73101971e5ab6a8e8688239884eac81
   depends:
@@ -4523,7 +4523,7 @@ packages:
   license_family: MIT
   size: 241607
   timestamp: 1692973585084
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
   sha256: ac50f846e93e68d50bfdd5589ea8272b987243a64eba8e2e358ef311d7734001
   md5: f19270ff954a41dabbfe36ff0656935b
   depends:
@@ -4533,7 +4533,7 @@ packages:
   license_family: MIT
   size: 36040
   timestamp: 1659783399073
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -4542,7 +4542,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
   sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
   md5: 353dff9d5d996c2a260f66381b2ce3e8
   depends:
@@ -4553,7 +4553,7 @@ packages:
   license_family: Other
   size: 1470815
   timestamp: 1695058433965
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
   sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
   md5: c99006da802a97c9aae30da8c16b4820
   depends:
@@ -4562,7 +4562,7 @@ packages:
   license_family: BSD
   size: 176131
   timestamp: 1670944706815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
   sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
   md5: 60bd1e037cda86205526f77405d78129
   depends:
@@ -4572,7 +4572,7 @@ packages:
   license_family: BSD
   size: 123361
   timestamp: 1671541992772
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
   sha256: 2fd690fa3c54a40f0426874ea12e12aad2718263a75708ddd1fa6052a4ad7fb3
   md5: 81388724babfe9c32ea5cdd93633c342
   depends:
@@ -4582,7 +4582,7 @@ packages:
   license_family: MIT
   size: 107072
   timestamp: 1684280007887
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
   sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
   md5: 34dfd76da78de2eae95bbda390d746d6
   depends:
@@ -4593,7 +4593,7 @@ packages:
   license_family: BSD
   size: 23092
   timestamp: 1654598007056
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.8.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-3.8.0-py39hca03da5_0.tar.bz2
   sha256: f6d7d0f791face4d911f5907df48e093cebcd1da188ba3d3267bf858d6dcacaf
   md5: 6a55e97ce33cd40a280f538dd5437eff
   depends:
@@ -4604,7 +4604,7 @@ packages:
   license_family: PSF
   size: 8725
   timestamp: 1698692342704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
   sha256: bf0eeef3c3c713515766ab8b0dc7863413de5b4b227deede97e24d90ca342345
   md5: a7bba1857eb84fb50caea377e60d2050
   depends:
@@ -4626,7 +4626,7 @@ packages:
   license_family: PSF
   size: 8066509
   timestamp: 1698692266161
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
   sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
   md5: eb79dabbeedee7da85dfbfb145bb8a26
   depends:
@@ -4636,7 +4636,7 @@ packages:
   license_family: BSD
   size: 17342
   timestamp: 1662014601345
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
   sha256: f400ad75dd2890627dc948f3e2e6b19732d02c124723eaf22272026993a94d52
   md5: 4a4ffc7365e30b18f4443281839e2718
   depends:
@@ -4646,7 +4646,7 @@ packages:
   license_family: MIT
   size: 53505
   timestamp: 1659721313693
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
   sha256: 20fb26a7ac748ce288cf8483a837b0c33f1348ae738bcdb69cdc2763c7bbf7e1
   md5: a0aebbc6c170ebd8d4710fd70b3db503
   depends:
@@ -4655,7 +4655,7 @@ packages:
   license_family: MIT
   size: 19562
   timestamp: 1659716131839
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
   sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
   md5: 56db7bd3ff511cd839bda081523b3edd
   depends:
@@ -4664,7 +4664,7 @@ packages:
   license_family: BSD
   size: 55683
   timestamp: 1629356128780
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
   sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
   md5: 176e0dcaeb28393881bacf69941e3889
   depends:
@@ -4690,7 +4690,7 @@ packages:
   license_family: BSD
   size: 8289638
   timestamp: 1681756329011
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py39hca03da5_0.tar.bz2
   sha256: d34fcad560dcc7b8e7df2a0250be9694a02e072aa7f7d4992ebd427665575a8e
   md5: 5972b5a5fbac5cea54ee0ff2cef85897
   depends:
@@ -4703,7 +4703,7 @@ packages:
   license_family: BSD
   size: 100843
   timestamp: 1698934268054
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
   sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
   md5: 150ea9fadddf21993d3328d3e48a18b7
   depends:
@@ -4731,7 +4731,7 @@ packages:
   license_family: BSD
   size: 557688
   timestamp: 1668450759059
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
   sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
   md5: 37163b32508f9f589b3e6462a3a47546
   depends:
@@ -4744,14 +4744,14 @@ packages:
   license_family: BSD
   size: 148426
   timestamp: 1694616771736
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
   sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
   md5: 6cdf7cbc43bf40e92b056a5576bd0086
   depends:
@@ -4760,7 +4760,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387216468
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
   sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
   md5: 0f05853a139b6cda9c73e9d2707a4976
   depends:
@@ -4785,7 +4785,7 @@ packages:
   license_family: BSD
   size: 590288
   timestamp: 1690984971741
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
   sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
   md5: 7de782e4fb34bfa95ef2fc79d27d727d
   depends:
@@ -4795,7 +4795,7 @@ packages:
   license_family: BSD
   size: 22840
   timestamp: 1668160634885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
   sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
   md5: 1a7b23113372c5667dbfe45976b9cc5c
   depends:
@@ -4806,7 +4806,7 @@ packages:
   license_family: MIT
   size: 126357
   timestamp: 1696515322390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
   sha256: 3cd1161558704176560843586b1b1f9b257fd68c0ca53a2fc09e61267f47514c
   md5: dd162b2716dc9daf732240a343862d4a
   depends:
@@ -4819,7 +4819,7 @@ packages:
   license_family: BSD
   size: 10388
   timestamp: 1695830584640
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
   sha256: 5f35d8c0e1768fa3a9d2e75659cd2096bea6b4e021afea114f573e95f4943fb2
   md5: 958f78b1e2299537996f98da7a930198
   depends:
@@ -4833,7 +4833,7 @@ packages:
   license_family: BSD
   size: 6313331
   timestamp: 1695830570878
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
   sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
   md5: 371358a54bbdd307603888348d1a2c6f
   depends:
@@ -4843,7 +4843,7 @@ packages:
   license: BSD 2-Clause
   size: 412248
   timestamp: 1628861367714
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
   sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
   md5: fa15d3b44ae1360ac9b640bbd5b6923c
   depends:
@@ -4852,7 +4852,7 @@ packages:
   license_family: Apache
   size: 4746123
   timestamp: 1695322833432
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
   sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
   md5: d73db95f07a282021efdf8bc09713261
   depends:
@@ -4861,7 +4861,7 @@ packages:
   license_family: Apache
   size: 73620
   timestamp: 1693575195999
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
   sha256: 247b5e4d81b6d5d013a9c27e1f30c41fff896fed98a68ebda26b19b4062a6828
   md5: 354a1d65300b4309d53dfa648014e8fe
   depends:
@@ -4908,7 +4908,7 @@ packages:
   license_family: BSD
   size: 13257999
   timestamp: 1697478739906
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
   sha256: 90a1889cd0004bfc5e12ac94b4ea92718a473373033bb0ba5259804ed67bf2bc
   md5: e89f615737385fee88150ab4adf037e6
   depends:
@@ -4932,7 +4932,7 @@ packages:
   license_family: BSD
   size: 17147015
   timestamp: 1698866800249
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
   sha256: 0ae09c974297767a707642344c40f484281f0a3000251a6234e46ef19f00c10e
   md5: 64a0eaf3381e9f6aa971229501710798
   depends:
@@ -4941,7 +4941,7 @@ packages:
   license_family: BSD
   size: 189313
   timestamp: 1698263486159
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
   sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
   md5: 6e01c592ae3b8ff2d12cae76f2f4276b
   depends:
@@ -4960,7 +4960,7 @@ packages:
   license_family: Other
   size: 715239
   timestamp: 1696580071596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
   sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
   md5: 9fb8f460c130d56caf33c6bbe46fbe8a
   depends:
@@ -4971,7 +4971,7 @@ packages:
   license_family: MIT
   size: 2678841
   timestamp: 1697548790931
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
   sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
   md5: 390b8c3cd74281abecdbfd51476922f9
   depends:
@@ -4980,7 +4980,7 @@ packages:
   license_family: MIT
   size: 33033
   timestamp: 1692205747301
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
   sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
   md5: 7896828fb3565fefad43f980d50c8723
   depends:
@@ -4989,7 +4989,7 @@ packages:
   license_family: Apache
   size: 91190
   timestamp: 1659455206354
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
   sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
   md5: d934c74eb66d01af0f45f0881f4bab77
   depends:
@@ -5001,7 +5001,7 @@ packages:
   license_family: BSD
   size: 580588
   timestamp: 1672387390426
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
   sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
   md5: 9858166e5ffb624c8b9d281f4000d725
   depends:
@@ -5010,7 +5010,7 @@ packages:
   license_family: BSD
   size: 367167
   timestamp: 1656431368885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
   sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
   md5: 4d2b45c6be8221e6a3e44c2d5838426f
   depends:
@@ -5022,7 +5022,7 @@ packages:
   license_family: BSD
   size: 30843
   timestamp: 1675441531640
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
   sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
   md5: 02521df4e2e79f75faa9cbb3560ab1dd
   depends:
@@ -5031,7 +5031,7 @@ packages:
   license_family: BSD
   size: 1861763
   timestamp: 1684280026169
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
   sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
   md5: bdebe59bffc7adbad83fdcd9d429a5f5
   depends:
@@ -5041,7 +5041,7 @@ packages:
   license_family: Apache
   size: 95234
   timestamp: 1690223494699
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
   sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
   md5: d716e5c9b5eec45ce1df8eb52cab817a
   depends:
@@ -5050,7 +5050,7 @@ packages:
   license_family: MIT
   size: 157408
   timestamp: 1661452601692
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
   sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
   md5: 1907629863ed8e7c35ead232dae7693f
   depends:
@@ -5059,7 +5059,7 @@ packages:
   license_family: MIT
   size: 91636
   timestamp: 1628941083263
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
   sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
   md5: 847b9bddf2a86e1609c0d53bbc23ea79
   depends:
@@ -5068,7 +5068,7 @@ packages:
   license_family: BSD
   size: 27378
   timestamp: 1626781391140
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
   sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
   md5: 18aa18bd0d260605923877921d26cc74
   depends:
@@ -5087,7 +5087,7 @@ packages:
   license_family: PSF
   size: 13194025
   timestamp: 1694438901368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
   sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
   md5: 45642a99c83e7aed74d1ffab1f20145b
   depends:
@@ -5096,7 +5096,7 @@ packages:
   license_family: BSD
   size: 266647
   timestamp: 1661368655993
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
   sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
   md5: fec748525144049a2fc7f52f9755232c
   depends:
@@ -5105,7 +5105,7 @@ packages:
   license_family: MIT
   size: 257235
   timestamp: 1695131702047
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
   sha256: 960192a143672e9c1d6fe4027af448512d91eee7501e5c245c21b865cf8bf429
   md5: 76d491244218505f071ba56a308673df
   depends:
@@ -5115,7 +5115,7 @@ packages:
   license_family: BSD
   size: 40950
   timestamp: 1685030774581
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
   sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
   md5: 3445d25415998c807efbe64d3a7e03c8
   depends:
@@ -5125,7 +5125,7 @@ packages:
   license_family: MIT
   size: 167068
   timestamp: 1698096118071
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
   sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
   md5: e6e92da28e9b0e428ed4b7df417bec25
   depends:
@@ -5136,7 +5136,7 @@ packages:
   license_family: BSD
   size: 472418
   timestamp: 1657724315435
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -5145,7 +5145,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
   sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
   md5: dba22515f36d3c266de5896350813ea2
   depends:
@@ -5161,7 +5161,7 @@ packages:
   license_family: Apache
   size: 95103
   timestamp: 1690400315537
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
   sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
   md5: 3cd7eb43e285faba76faf67667e26b00
   depends:
@@ -5170,7 +5170,7 @@ packages:
   license_family: MIT
   size: 1093916
   timestamp: 1690290951258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
   sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
   md5: c5e9aef0d6895de1c927e9d796cd7cd3
   depends:
@@ -5179,7 +5179,7 @@ packages:
   license_family: Apache
   size: 15691
   timestamp: 1629145910454
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
   sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
   md5: 0f7c229e774146ffc4e29dedf75372bf
   depends:
@@ -5188,7 +5188,7 @@ packages:
   license_family: MIT
   size: 67279
   timestamp: 1696347632563
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
   sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
   md5: 2302a79a045f152e183a52a81adfba62
   depends:
@@ -5200,7 +5200,7 @@ packages:
   license_family: Other
   size: 1674163
   timestamp: 1681394762218
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
   sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
   md5: 4ae67163d55cf9df83d4027ebc38c501
   depends:
@@ -5211,7 +5211,7 @@ packages:
   license_family: BSD
   size: 30894
   timestamp: 1671751931536
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
   sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
   md5: dbb5c0cddb6661a89afee647fd3dc01e
   depends:
@@ -5221,7 +5221,7 @@ packages:
   license_family: BSD
   size: 39875
   timestamp: 1668168874870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
   sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
   md5: 667e60c8b407d73cbba40f44901f4f00
   depends:
@@ -5230,7 +5230,7 @@ packages:
   license_family: BSD
   size: 3412693
   timestamp: 1654088929697
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
   sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
   md5: 884f788a5f6a664c9b79f7a4a60362d0
   depends:
@@ -5239,7 +5239,7 @@ packages:
   license_family: Apache
   size: 680561
   timestamp: 1696937004165
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
   sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
   md5: 639a4f489af172c866c18442948e5874
   depends:
@@ -5252,7 +5252,7 @@ packages:
   license_family: MOZILLA
   size: 125170
   timestamp: 1679561942932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
   sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
   md5: e5b90eba83fddba6d7aa6072b5bf7c91
   depends:
@@ -5261,7 +5261,7 @@ packages:
   license_family: BSD
   size: 193017
   timestamp: 1671143921826
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
   md5: 644ef8830437070f60efcfcd6a987198
   depends:
@@ -5271,7 +5271,7 @@ packages:
   license_family: PSF
   size: 9670
   timestamp: 1690297532002
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
   md5: a902a833bb186a2f1a4b2b89b1195136
   depends:
@@ -5280,7 +5280,7 @@ packages:
   license_family: PSF
   size: 58466
   timestamp: 1690297524418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
   sha256: 536045a8a172c651fd306c285a6d7409775f018dac944f2124c538ccfb195e28
   md5: d4dc6cdf0812191b9ec78b35b4fdf3e0
   depends:
@@ -5289,7 +5289,7 @@ packages:
   license_family: MIT
   size: 11593
   timestamp: 1659769477205
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
   sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
   md5: f3f1d2c1028dad2f11ff950a15c99dbf
   depends:
@@ -5304,7 +5304,7 @@ packages:
   license_family: MIT
   size: 188640
   timestamp: 1698257577209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
   sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
   md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
   depends:
@@ -5313,7 +5313,7 @@ packages:
   license_family: BSD
   size: 20091
   timestamp: 1629144441130
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
   sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
   md5: 3089c63bf8f4d0423e1a287da286d83e
   depends:
@@ -5323,7 +5323,7 @@ packages:
   license_family: BSD
   size: 70923
   timestamp: 1629357115820
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
   sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
   md5: 5886b30b312445471268444f41f39dc7
   depends:
@@ -5332,7 +5332,7 @@ packages:
   license_family: MIT
   size: 102583
   timestamp: 1695741976083
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
   sha256: 105e39d3eb51b47c7244b3379c0133ab7051966664f52835453b14509215b159
   md5: ed20012c2cd99ffd04cca9929e0bc061
   depends:
@@ -5341,20 +5341,20 @@ packages:
   license_family: BSD
   size: 49775
   timestamp: 1675159079039
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
   sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
   md5: 2e75ad6a09c308268192efe03cc9ebf4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 411778
   timestamp: 1683113019715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
   sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
   md5: 30f666bf97c26587c5d2f68cc5f330ab
   depends:
@@ -5363,7 +5363,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 316901
   timestamp: 1629287855861
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
   sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
   md5: 584e591d36dcd5ba5c45404f0f7ebb2d
   depends:
@@ -5372,14 +5372,14 @@ packages:
   license_family: MIT
   size: 19076
   timestamp: 1672387153578
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
   sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
   md5: 467ae28215d1aa1c5688bc0c8a184269
   license: Zlib
   license_family: Other
   size: 103525
   timestamp: 1666595022664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
   sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
   md5: 7cfbed15f1feee1422810f7830075f53
   depends:
@@ -5391,7 +5391,7 @@ packages:
   license_family: BSD
   size: 779464
   timestamp: 1681304594848
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
   sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
   md5: ed14f9bc6e55220483f1a5a388625a08
   depends:
@@ -5404,7 +5404,7 @@ packages:
   license_family: MIT
   size: 162772
   timestamp: 1644481986085
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
   sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
   md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
   depends:
@@ -5416,7 +5416,7 @@ packages:
   license_family: MIT
   size: 39253
   timestamp: 1644551767970
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
   sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
   md5: b24d13c443a26f65a0778b475a5726bc
   depends:
@@ -5425,7 +5425,7 @@ packages:
   license_family: MIT
   size: 132830
   timestamp: 1695717959996
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
   sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
   md5: 302c3c0696e17eaa62e140e3892644ae
   depends:
@@ -5435,12 +5435,12 @@ packages:
   license_family: MIT
   size: 199723
   timestamp: 1681493196911
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
   sha256: 812f268862208c2518b5187809a8571adb488de3604d512721035e65458dde76
   md5: 97ce620b7dd3ee743d0ca28ed66ace74
   depends:
@@ -5458,7 +5458,7 @@ packages:
   license_family: BSD
   size: 5721832
   timestamp: 1697491241383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
   sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
   md5: bf930260f679bc74227bbb18bc36ae82
   depends:
@@ -5470,7 +5470,7 @@ packages:
   license_family: BSD
   size: 119700
   timestamp: 1657176150595
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
   md5: 507dfe693ef429f466d964b599f4af21
   depends:
@@ -5482,7 +5482,7 @@ packages:
   license: MIT
   size: 18650
   timestamp: 1659616328001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
   md5: d0bf43e8df60baae3b3105aa5c42a791
   depends:
@@ -5493,7 +5493,7 @@ packages:
   license: MIT
   size: 21153
   timestamp: 1659616312367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
   sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
   md5: 7bd24bf94c24e810aecaaf84a0978e6f
   depends:
@@ -5503,14 +5503,14 @@ packages:
   license: MIT
   size: 343204
   timestamp: 1659616543542
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
   sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
   md5: 092b417c11edcbe6bb9b765ab4a55d23
   license: MPL-2.0
   license_family: Other
   size: 164999
   timestamp: 1694009822357
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
   sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
   md5: 708a750d370b9d6875651021e21c4446
   depends:
@@ -5519,7 +5519,7 @@ packages:
   license_family: Other
   size: 159322
   timestamp: 1690232335307
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
   sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
   md5: c35736da3ea26782425e78061268cf5e
   depends:
@@ -5531,7 +5531,7 @@ packages:
   license_family: MIT
   size: 228713
   timestamp: 1670423312743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
   sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
   md5: 457a4339a53c033d48ce0c72e5038d2e
   depends:
@@ -5540,7 +5540,7 @@ packages:
   license_family: BSD
   size: 30330
   timestamp: 1672387265402
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
   sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
   md5: 59ec65fd9e06b81a65cc12986c67d5da
   depends:
@@ -5550,7 +5550,7 @@ packages:
   license_family: CC
   size: 1939614
   timestamp: 1668084794027
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
   sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
   md5: 3489c1a2b73fc957b5a62cc59349e25b
   depends:
@@ -5560,7 +5560,7 @@ packages:
   license_family: BSD
   size: 13438
   timestamp: 1671231196438
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
   sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
   md5: 3492b96083c1e904cc32d26ea7f1e1d8
   depends:
@@ -5572,7 +5572,7 @@ packages:
   license_family: BSD
   size: 184280
   timestamp: 1663827558327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
   sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
   md5: f46d904bc6f220327e70474971341f52
   depends:
@@ -5587,7 +5587,7 @@ packages:
   license_family: BSD
   size: 1220835
   timestamp: 1694445639066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
   sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
   md5: 2ff4fb509788b0e47ac684ba151394d0
   depends:
@@ -5598,7 +5598,7 @@ packages:
   license_family: MIT
   size: 3289966
   timestamp: 1690907040646
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
   sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
   md5: 0f166c3e70541d8bee6e9d0cb60fb66e
   depends:
@@ -5607,7 +5607,7 @@ packages:
   license_family: MIT
   size: 16979
   timestamp: 1649926678161
-- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
   sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
   md5: ea93d413944ca6a8677eb1b284b136ae
   depends:
@@ -5616,7 +5616,7 @@ packages:
   license_family: BSD
   size: 27388
   timestamp: 1668714577678
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -5628,7 +5628,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
   sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
   md5: 9f167d3e45441bc3633c1974b1b0ce8c
   depends:
@@ -5638,7 +5638,7 @@ packages:
   license_family: MIT
   size: 88421
   timestamp: 1676983264486
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
   sha256: fa8f868e49721ca19912f816a6da221172758f9e3d28d8b31d53249fb14dc25f
   md5: 09f9a2cea9425d76dccf9b026afe5bb2
   depends:
@@ -5655,7 +5655,7 @@ packages:
   license_family: BSD
   size: 4576915
   timestamp: 1698866895838
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
   sha256: 945f4521793d7d279532d1ccd5157201c5cbf64f846bfe60249d01e1b4edf295
   md5: 0accae23d095c165ac731f4a1f3ca497
   depends:
@@ -5665,7 +5665,7 @@ packages:
   license_family: MIT
   size: 37021132
   timestamp: 1692294548916
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
   sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
   md5: 30fdefd1541c789c163751291a8faa88
   depends:
@@ -5674,7 +5674,7 @@ packages:
   license_family: BSD
   size: 111448
   timestamp: 1666125667599
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
   sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
   md5: a10f07c7a3510272a296f9fed458a4ed
   depends:
@@ -5684,7 +5684,7 @@ packages:
   license_family: APACHE
   size: 38098
   timestamp: 1678997241511
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
   sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
   md5: fad9cf2023d807da8d44996e9d4399a0
   depends:
@@ -5694,7 +5694,7 @@ packages:
   license_family: Apache
   size: 51490
   timestamp: 1698254721864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
   sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
   md5: 9834848bd7c7759acf12e78d09388563
   depends:
@@ -5704,7 +5704,7 @@ packages:
   license_family: Proprietary
   size: 3891030
   timestamp: 1681801474383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
   sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
   md5: 1285c8c628bc912c54d0968574c9f4c9
   depends:
@@ -5725,7 +5725,7 @@ packages:
   license_family: BSD
   size: 217232
   timestamp: 1691122695748
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
   sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
   md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
   depends:
@@ -5746,7 +5746,7 @@ packages:
   license_family: BSD
   size: 1279433
   timestamp: 1694181820978
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
   sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
   md5: f5fcce35d3f21cdfc5893c5a7a86c651
   depends:
@@ -5756,7 +5756,7 @@ packages:
   license_family: MIT
   size: 1035394
   timestamp: 1644315567034
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
   sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
   md5: f67fe3337528e2886f1ac3ab8ac37985
   depends:
@@ -5766,7 +5766,7 @@ packages:
   license_family: BSD
   size: 213110
   timestamp: 1666908350218
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
   sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
   md5: 81f2c343dc4c65eea39c45383272068f
   depends:
@@ -5776,7 +5776,7 @@ packages:
   license_family: Other
   size: 407861
   timestamp: 1677849239400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
   sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
   md5: bd9526d38a145fe311a8aa36bc11e071
   depends:
@@ -5787,7 +5787,7 @@ packages:
   license_family: MIT
   size: 152006
   timestamp: 1676558783570
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
   sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
   md5: a00e6a62956fde3c4135464353ee8a53
   depends:
@@ -5803,7 +5803,7 @@ packages:
   license_family: BSD
   size: 229158
   timestamp: 1676330909084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.5.0-py39haa95532_0.tar.bz2
   sha256: e840d6b322faa7d5fee2c54ed6074e3a6b7fe38a9356020a4027d9e09c40a1a1
   md5: 038bb985c0d43bf77a8e772f4c4ad22a
   depends:
@@ -5815,7 +5815,7 @@ packages:
   license_family: BSD
   size: 103854
   timestamp: 1698937448209
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
   sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
   md5: 5efa1332f7c0a8d9638eda02170c4ce5
   depends:
@@ -5840,7 +5840,7 @@ packages:
   license_family: BSD
   size: 413653
   timestamp: 1671707957673
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
   sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
   md5: 891fe66a24d8714737b2874985ee1303
   depends:
@@ -5851,7 +5851,7 @@ packages:
   license_family: BSD
   size: 62298
   timestamp: 1672388166096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
   sha256: ef6b0347ae565dd648a2bb40bc8b0b30f2e4f8387778fefced1d581b7d5a3e16
   md5: 8ef1d5919aa55fe56ef34d9a7969dca7
   depends:
@@ -5862,7 +5862,7 @@ packages:
   license_family: MIT
   size: 861982
   timestamp: 1684424430941
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -5872,7 +5872,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
   sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
   md5: c345f51706eef530454f66b794e5e574
   depends:
@@ -5881,7 +5881,7 @@ packages:
   license: MIT
   size: 68189
   timestamp: 1659616216976
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
   md5: a7400cfb72042977bc047909ed504ce8
   depends:
@@ -5891,7 +5891,7 @@ packages:
   license: MIT
   size: 33743
   timestamp: 1659616248209
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
   md5: 6307f6854754ab5bd7c84e6998385bb1
   depends:
@@ -5901,7 +5901,7 @@ packages:
   license: MIT
   size: 733177
   timestamp: 1659616279453
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
   sha256: bb17beae8860a83d081d57273825b46bf8fe9903f3b4182ab41a7ae2c7274859
   md5: 94182f4ab8beb4eddfd8167b2e2b0380
   depends:
@@ -5913,7 +5913,7 @@ packages:
   license_family: Apache
   size: 147804
   timestamp: 1681225547009
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
   sha256: 01b84a38c9069e7b8e6fa2a07707e785df7d40b8f01d76a504e98e5a5cd58539
   md5: 22c9f7e59174c49f06e3c5c9384401ce
   depends:
@@ -5924,7 +5924,7 @@ packages:
   license_family: Apache
   size: 25699299
   timestamp: 1681225463612
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -5934,7 +5934,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
   sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
   md5: b812bc5d9c76242e2bb2ac87afe7d39b
   depends:
@@ -5944,7 +5944,7 @@ packages:
   license_family: GPL3
   size: 730280
   timestamp: 1650983734373
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -5955,7 +5955,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
   sha256: a36ea5c77075e90f47d3f5c1e2081c0c1c78c5c0a5135bf9a6448fca67bbc79d
   md5: a0a02817a7def0563d1635035c26451b
   depends:
@@ -5966,7 +5966,7 @@ packages:
   - zlib >=1.2.13,<2.0.0a0
   size: 3827890
   timestamp: 1687382140999
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -5975,7 +5975,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -5992,7 +5992,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
   sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
   md5: ba9418df9288a2f031a02fa35b774ce0
   depends:
@@ -6008,7 +6008,7 @@ packages:
   license_family: BSD
   size: 78524
   timestamp: 1694778314659
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
   sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
   md5: b1781519a200ccbfcb4a1194005aa3ef
   depends:
@@ -6020,7 +6020,7 @@ packages:
   license_family: BSD
   size: 338459
   timestamp: 1694777084290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
   sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
   md5: 6ece7f1a3248169837714d05d7f6ef0a
   depends:
@@ -6032,7 +6032,7 @@ packages:
   license_family: MIT
   size: 3513910
   timestamp: 1692971505729
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
   sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
   md5: bd7ec244935e83e850a4ff34e8e2e64f
   depends:
@@ -6043,7 +6043,7 @@ packages:
   license_family: MIT
   size: 513971
   timestamp: 1692973657152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
   sha256: e1c0e745d9ba36a80773e841d96bf514ad1ceda419e4188aad3c22782af00234
   md5: f226532e9bb308f20e874c56be6ceefb
   depends:
@@ -6053,7 +6053,7 @@ packages:
   license_family: MIT
   size: 35788
   timestamp: 1659783414586
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
   sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
   md5: fb7881e74b59262df0fa4ec981964efc
   depends:
@@ -6066,7 +6066,7 @@ packages:
   license_family: Other
   size: 1244887
   timestamp: 1695058550693
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
   sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
   md5: 6970c7f46b0164cad1d210e7a1419959
   depends:
@@ -6076,7 +6076,7 @@ packages:
   license_family: BSD
   size: 143434
   timestamp: 1670944902624
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
   sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
   md5: 1015298551c040c6d5e26eebbae12ef5
   depends:
@@ -6086,7 +6086,7 @@ packages:
   license_family: BSD
   size: 142316
   timestamp: 1671542240512
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
   sha256: ab5c246c2b271acc1cdd0b9343989c0166681536e569cdbe71618f55d34c7292
   md5: 7ce68d771cd94c9ff5efefe69d327c9a
   depends:
@@ -6096,7 +6096,7 @@ packages:
   license_family: MIT
   size: 125122
   timestamp: 1684280210213
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
   sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
   md5: 466da740fafef3d6bce114220f0be306
   depends:
@@ -6109,7 +6109,7 @@ packages:
   license_family: BSD
   size: 28510
   timestamp: 1654508162239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.8.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-3.8.0-py39haa95532_0.tar.bz2
   sha256: 3ee1e0b89c9a16ed21af80d9883d7638227028cac76ab24b5dcb4aa25dcd5536
   md5: 0ec5d4cee9f74324b4bf0a653e53681b
   depends:
@@ -6121,7 +6121,7 @@ packages:
   license_family: PSF
   size: 8485
   timestamp: 1698692858409
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
   sha256: 1687ae122ee7d8b583141fc5014b76d494841dc8083b854449e3d6e0f6bb7019
   md5: 3697ac26ee3c2d49338dd5b9c6551152
   depends:
@@ -6144,7 +6144,7 @@ packages:
   license_family: PSF
   size: 8080067
   timestamp: 1698692812610
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
   sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
   md5: a9fa43e694b25cd49b8b08a9eefd696e
   depends:
@@ -6154,7 +6154,7 @@ packages:
   license_family: BSD
   size: 18054
   timestamp: 1661915903969
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
   sha256: 8aa14047fac6ef8b326900c4bf1a960eaa7a1699c18fdf1e75a59101b610b6df
   md5: 7e1d4d4700fbea6171d30f1d5ad24226
   depends:
@@ -6164,7 +6164,7 @@ packages:
   license_family: MIT
   size: 53362
   timestamp: 1659721308586
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
   sha256: 2017814a7cc93dd51c6b7c016e3cdf8fbc32fa20f985638aaff6a6377e9ee086
   md5: a1a285c56b001c3b5c591bf21eec3149
   depends:
@@ -6173,7 +6173,7 @@ packages:
   license_family: MIT
   size: 19326
   timestamp: 1659716205153
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
   sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
   md5: 248c468abced874f0231d3cc23177c77
   depends:
@@ -6184,7 +6184,7 @@ packages:
   license_family: BSD
   size: 58488
   timestamp: 1607359497934
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
   sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
   md5: 5e763c995ff0c549f68a10bce70fede4
   depends:
@@ -6196,7 +6196,7 @@ packages:
   license_family: Proprietary
   size: 187489950
   timestamp: 1691503804820
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
   sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
   md5: dd0c2ece6a743c373c9b5a5919b4818f
   depends:
@@ -6208,7 +6208,7 @@ packages:
   license_family: BSD
   size: 49744
   timestamp: 1682975040154
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
   sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
   md5: 57cea8df7ab85f2a98f64d23afcb1f90
   depends:
@@ -6223,7 +6223,7 @@ packages:
   license_family: BSD
   size: 184956
   timestamp: 1695058491736
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
   sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
   md5: 8769cdd201d905069800488fe31574e5
   depends:
@@ -6238,7 +6238,7 @@ packages:
   license_family: BSD
   size: 256221
   timestamp: 1695060152521
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
   sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
   md5: d9781492332e6326f9fca87f3a8efacd
   depends:
@@ -6264,7 +6264,7 @@ packages:
   license_family: BSD
   size: 8135792
   timestamp: 1681756491399
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py39haa95532_0.tar.bz2
   sha256: 49715dd545469a4458cdf0d0d55c9a7af7cb7a2da8a6504a60dd3089714015ae
   md5: 4257087772bed974078f56673ca50d99
   depends:
@@ -6277,7 +6277,7 @@ packages:
   license_family: BSD
   size: 119351
   timestamp: 1698934436390
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
   sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
   md5: f1d8ce412e115986c403f223b3b47d0f
   depends:
@@ -6305,7 +6305,7 @@ packages:
   license_family: BSD
   size: 596314
   timestamp: 1668451106600
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
   sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
   md5: f96bbef0985d7e66ebf00c0d55e30e23
   depends:
@@ -6318,7 +6318,7 @@ packages:
   license_family: BSD
   size: 167045
   timestamp: 1694617078743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
   sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
   md5: 6e6ba64c8dc5025aeac606404a8df36a
   depends:
@@ -6327,7 +6327,7 @@ packages:
   license_family: BSD
   size: 13786
   timestamp: 1672387480065
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
   sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
   md5: 4a7a3286484766741f627696697c362c
   depends:
@@ -6352,7 +6352,7 @@ packages:
   license_family: BSD
   size: 609425
   timestamp: 1690985686105
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
   sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
   md5: 4269a1f93882205b90d4b2ae78fc82d5
   depends:
@@ -6362,7 +6362,7 @@ packages:
   license_family: BSD
   size: 22417
   timestamp: 1668160717305
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
   sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
   md5: a18a576b7024cfd6f905c526a786a916
   depends:
@@ -6377,7 +6377,7 @@ packages:
   license_family: MIT
   size: 135285
   timestamp: 1696515698492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
   sha256: e5e11f9b42d770ee46ac24d1cdf7aa4e9c49a60a607c8c28e7729131a99eadd5
   md5: 4274d06db8a9a381c072d226d0322dc0
   depends:
@@ -6394,7 +6394,7 @@ packages:
   license_family: BSD
   size: 9835
   timestamp: 1695830845329
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
   sha256: dcaa1607ce40a0ed610dd5398e125c8e5b08e738e50b6037a8c72b49ca561ff2
   md5: d99d990a60644b97ba1ff9bb8da0e66f
   depends:
@@ -6410,7 +6410,7 @@ packages:
   license_family: BSD
   size: 6778113
   timestamp: 1695830816710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
   sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
   md5: ab07e2a27ac08afe3d0b4c0890b8486a
   depends:
@@ -6421,7 +6421,7 @@ packages:
   license: BSD 2-Clause
   size: 249316
   timestamp: 1630094024143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
   sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
   md5: 73b17037d87b5a58feb34dafc0538f7f
   depends:
@@ -6432,7 +6432,7 @@ packages:
   license_family: Apache
   size: 8058396
   timestamp: 1695324589828
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
   sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
   md5: df1d746ba8d5d6ba01ac1373b9b71e1a
   depends:
@@ -6441,7 +6441,7 @@ packages:
   license_family: Apache
   size: 73016
   timestamp: 1693575484990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
   sha256: 1994e5831fd421bd6cf85916073d4012dec53e673b672b3985efaf771f0a7bf8
   md5: c486a5b51e3227f6ea564a9dd3125e45
   depends:
@@ -6489,7 +6489,7 @@ packages:
   license_family: BSD
   size: 12629931
   timestamp: 1697479885371
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
   sha256: 270e4c3ab0f0c8d8f31fa0e45bc516c1e41be618a5c66e1c86dc39ce76cb2372
   md5: cad52ba9eb391416112f0994b6c35249
   depends:
@@ -6513,7 +6513,7 @@ packages:
   license_family: BSD
   size: 17162886
   timestamp: 1698867967809
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
   sha256: 56eaf7f4b1bb81e3deed55711dd2ee78f244a3cc0ad4bb7a1f09d97e46f9793f
   md5: c24a3daed1e85ba7a100fa6966c5bb48
   depends:
@@ -6522,7 +6522,7 @@ packages:
   license_family: BSD
   size: 189021
   timestamp: 1698263520538
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
   sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
   md5: 427c1450bebb632f43bbc8c83006e4cd
   depends:
@@ -6541,7 +6541,7 @@ packages:
   license_family: Other
   size: 806931
   timestamp: 1696580240310
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
   sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
   md5: 21790cd3e2b8a45c4104aff0a68330d0
   depends:
@@ -6552,7 +6552,7 @@ packages:
   license_family: MIT
   size: 3001751
   timestamp: 1697549357662
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
   sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
   md5: 56f44a1054da2d10777e375838191070
   depends:
@@ -6561,7 +6561,7 @@ packages:
   license_family: MIT
   size: 32355
   timestamp: 1692205784293
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
   sha256: bbcef9bbf4ccd051becaa7d8aa88cb5f46ff64570cc395b6a471332d8b900e11
   md5: 0daf62b71923d157544576122b0fa79d
   depends:
@@ -6570,7 +6570,7 @@ packages:
   license_family: BSD
   size: 82560
   timestamp: 1607021261834
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
   sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
   md5: 8a35ad65651086575ce55371f22feda8
   depends:
@@ -6579,7 +6579,7 @@ packages:
   license_family: Apache
   size: 91045
   timestamp: 1659455316472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
   sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
   md5: 186eb95f816a2eff80c3c7f7d964c7b0
   depends:
@@ -6591,7 +6591,7 @@ packages:
   license_family: BSD
   size: 578514
   timestamp: 1672388155359
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
   sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
   md5: 47b6cbe6ce9289e47d16900b03596a91
   depends:
@@ -6602,7 +6602,7 @@ packages:
   license_family: BSD
   size: 372807
   timestamp: 1656431445633
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
   sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
   md5: 07165c444adc7c7ccc8a345875adc5ef
   depends:
@@ -6614,7 +6614,7 @@ packages:
   license_family: BSD
   size: 48408
   timestamp: 1675450623287
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
   sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
   md5: d58e76a31e2f6e7410ba4afd7f385b0d
   depends:
@@ -6623,7 +6623,7 @@ packages:
   license_family: BSD
   size: 1877445
   timestamp: 1684280183367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
   sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
   md5: 0e5b0fe7debbf558ce97090f6b67cdae
   depends:
@@ -6633,7 +6633,7 @@ packages:
   license_family: Apache
   size: 94633
   timestamp: 1690225630423
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
   sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
   md5: 0fde797653e4ab589506121fb1e37555
   depends:
@@ -6642,7 +6642,7 @@ packages:
   license_family: MIT
   size: 157119
   timestamp: 1661452591647
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
   sha256: e70028d0250602c01feac17e60fafd371daee5d731917732b7eced4ab47b3243
   md5: 72a51c0d49711d22a39aefc04fa0c328
   depends:
@@ -6657,7 +6657,7 @@ packages:
   license_family: GPL
   size: 5007361
   timestamp: 1698781683371
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
   sha256: 6eb0c4f2e8acaa6dfaf1fb5b4b34f13d366ebf11d77e14a674a26d7fabbc7981
   md5: 9354d98a97abd4715cdf63d4a28f7645
   depends:
@@ -6668,7 +6668,7 @@ packages:
   license_family: GPL
   size: 84071
   timestamp: 1698769559444
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
   sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
   md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
   depends:
@@ -6679,7 +6679,7 @@ packages:
   license_family: MIT
   size: 92679
   timestamp: 1636093365041
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
   sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
   md5: f870859d4dc7a8d82cf3546bd9035f33
   depends:
@@ -6689,7 +6689,7 @@ packages:
   license_family: BSD
   size: 54520
   timestamp: 1605307564142
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
   sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
   md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
   depends:
@@ -6702,7 +6702,7 @@ packages:
   license_family: PSF
   size: 21172845
   timestamp: 1694442462066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
   sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
   md5: 9d99075052265ae3d718582d3b875038
   depends:
@@ -6711,7 +6711,7 @@ packages:
   license_family: BSD
   size: 269964
   timestamp: 1661376543480
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
   sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
   md5: fa9074d94236c9b768bfd2c858875b27
   depends:
@@ -6720,7 +6720,7 @@ packages:
   license_family: MIT
   size: 264836
   timestamp: 1695131770282
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
   sha256: 97243a31c39f4990c0e9d4f2307f2f7fb9421553303923bc105067ec4340bdff
   md5: 8078c5760f27398eaf1082226647d137
   depends:
@@ -6730,7 +6730,7 @@ packages:
   license_family: BSD
   size: 40145
   timestamp: 1685031143383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
   sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
   md5: 3d2841085778006c2e79f9c7300f8b9d
   depends:
@@ -6740,7 +6740,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13565975
   timestamp: 1669937633869
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
   sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
   md5: 54a4bc0724041dd173088419d6ede2af
   depends:
@@ -6752,7 +6752,7 @@ packages:
   license_family: MIT
   size: 239062
   timestamp: 1677611495106
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
   sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
   md5: f39f84115e228bad4bceaefdd637f022
   depends:
@@ -6764,7 +6764,7 @@ packages:
   license_family: MIT
   size: 158558
   timestamp: 1698096358091
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
   sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
   md5: df398a3a1668fd2a22061764e20ea91d
   depends:
@@ -6776,7 +6776,7 @@ packages:
   license_family: BSD
   size: 460913
   timestamp: 1657616061604
-- conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
   sha256: 409f9fad42cbae8d915d1703d87db6af9f951b150517daa4e1c0220cc5eb7b0f
   md5: 2b17abf94b02a6c5ba6b7623dba97ff9
   depends:
@@ -6799,7 +6799,7 @@ packages:
   license_family: LGPL
   size: 69829482
   timestamp: 1693228189080
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
   sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
   md5: 38db77ece9dc76feffb9ef7638e38258
   depends:
@@ -6815,7 +6815,7 @@ packages:
   license_family: Apache
   size: 94397
   timestamp: 1690400496655
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
   sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
   md5: 3e284ae6b48ee30c364ffdc5601610b0
   depends:
@@ -6824,7 +6824,7 @@ packages:
   license_family: MIT
   size: 1099842
   timestamp: 1690291374842
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
   sha256: ed2b75ca1bb075901550bf892aa18a46a563e512e28ad5fe1b36e7ed3c6708d0
   md5: 22779fae19f454e13656af8b737f8bd3
   depends:
@@ -6839,7 +6839,7 @@ packages:
   license_family: GPL
   size: 602624
   timestamp: 1698676202396
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
   sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
   md5: 993b3886b334bd1f49d34206f21997b4
   depends:
@@ -6848,7 +6848,7 @@ packages:
   license_family: Apache
   size: 15998
   timestamp: 1614030572433
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
   sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
   md5: 7ac9604ad7564ac0c71bff5db198656f
   depends:
@@ -6857,7 +6857,7 @@ packages:
   license_family: MIT
   size: 67012
   timestamp: 1696347795139
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
   sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
   md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
   depends:
@@ -6867,7 +6867,7 @@ packages:
   license_family: Other
   size: 1311308
   timestamp: 1681402905668
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -6877,7 +6877,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
   sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
   md5: 28b9869d8d3a839918fac4a08f38cbc2
   depends:
@@ -6888,7 +6888,7 @@ packages:
   license_family: BSD
   size: 30546
   timestamp: 1671752127904
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
   sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
   md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
   depends:
@@ -6898,7 +6898,7 @@ packages:
   license_family: BSD
   size: 39590
   timestamp: 1668168880994
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
   sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
   md5: 52cdcdb96383c010ca833a7c24b3935b
   depends:
@@ -6908,7 +6908,7 @@ packages:
   license_family: BSD
   size: 3690152
   timestamp: 1654036853710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
   sha256: 86a1b449d27205327a5de0f81d18d9ad768e68d915b91b1d5b82be2d8f524e94
   md5: 78a8a9f8c638df9a2db80964c97ff43f
   depends:
@@ -6917,7 +6917,7 @@ packages:
   license_family: MIT
   size: 25476
   timestamp: 1657175730463
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
   sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
   md5: 0e054ab29119cf4c1f778613acf972f9
   depends:
@@ -6928,7 +6928,7 @@ packages:
   license_family: Apache
   size: 681780
   timestamp: 1696937326924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
   sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
   md5: b6ad839ebba536ad1c3cc58d0e2123f0
   depends:
@@ -6942,7 +6942,7 @@ packages:
   license_family: MOZILLA
   size: 143681
   timestamp: 1679562248929
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
   sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
   md5: fe78de10019085146f1cc6c94fdc2620
   depends:
@@ -6951,7 +6951,7 @@ packages:
   license_family: BSD
   size: 192822
   timestamp: 1671143999327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
   md5: ca5fc3fbdb09b6de068a8b7a8869369f
   depends:
@@ -6961,7 +6961,7 @@ packages:
   license_family: PSF
   size: 9208
   timestamp: 1690298120549
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
   md5: a86e87a10e5fdff486265e0c675fb99f
   depends:
@@ -6970,7 +6970,7 @@ packages:
   license_family: PSF
   size: 57922
   timestamp: 1690298106990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
   sha256: 8057d3d2a0acd44496de33c5b222063c3f7d06b90c74fbbda45bd18b0b324219
   md5: 398f8db5bd8cab84b3d85a9d85fa4889
   depends:
@@ -6979,7 +6979,7 @@ packages:
   license_family: MIT
   size: 11362
   timestamp: 1659769459206
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
   sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
   md5: 0d31859e0a097aedbcc1627db33b3d92
   depends:
@@ -6994,7 +6994,7 @@ packages:
   license_family: MIT
   size: 188367
   timestamp: 1698257883295
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
   sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
   md5: 45ef24c486a484f079faf1dc90e4c7e9
   depends:
@@ -7003,12 +7003,12 @@ packages:
   license_family: BSD
   size: 8277
   timestamp: 1605602889180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
   sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
   md5: 4daaceb6cfc1af6274509081d8018ef1
   size: 2316783
   timestamp: 1605602872095
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
   sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
   md5: 916c16904615c7af3b5d37cb6694f45e
   depends:
@@ -7017,7 +7017,7 @@ packages:
   license_family: BSD
   size: 21084
   timestamp: 1607347371925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
   sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
   md5: da69e6987fcc757e83a358ceaa13f62b
   depends:
@@ -7027,7 +7027,7 @@ packages:
   license_family: BSD
   size: 73391
   timestamp: 1614804425587
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
   sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
   md5: 23b9f4634b2e5450be617114f62c74f9
   depends:
@@ -7036,7 +7036,7 @@ packages:
   license_family: MIT
   size: 120873
   timestamp: 1695742300539
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
   sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
   md5: 120f0b088290fc17bd6618fc10a2f0c4
   depends:
@@ -7044,13 +7044,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 34293
   timestamp: 1605306211299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
   sha256: a5d2a216d052105fdaad7256f23da3b29f95100d1dc0f29b6ab1f3bbc75e17a9
   md5: a558f681ebc243f86cde2515c065b62e
   depends:
@@ -7059,7 +7059,7 @@ packages:
   license_family: BSD
   size: 48805
   timestamp: 1675159123654
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
   sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
   md5: c3f7871e9a33adeccee1b1e8e216918e
   depends:
@@ -7069,7 +7069,7 @@ packages:
   license_family: GPL2
   size: 1332571
   timestamp: 1683113347814
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -7078,7 +7078,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
   sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
   md5: 1ab55f8c4b5292ec360c572120bf823e
   depends:
@@ -7088,7 +7088,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 9430705
   timestamp: 1616055773485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
   sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
   md5: 6875e0bf3828707dc9165d694c0d0a7d
   depends:
@@ -7097,7 +7097,7 @@ packages:
   license_family: MIT
   size: 18725
   timestamp: 1672387612937
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
   sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
   md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
   depends:
@@ -7107,7 +7107,7 @@ packages:
   license_family: Other
   size: 148931
   timestamp: 1666595229032
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
   sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
   md5: 8d6a1e767775fe0eb617cd6e22edc2ff
   depends:

--- a/square_limit/pixi.lock
+++ b/square_limit/pixi.lock
@@ -1,0 +1,7122 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.0-h8213a91_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.0-h28cd5cc_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.9.2-py39h2531618_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-5.9.7-h5867ecd_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-4.19.13-py39h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.8.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.8.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.8.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+  sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
+  md5: 2cf39d906cc321896ffe3e5d33d80c5c
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162166
+  timestamp: 1644463608931
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+  sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
+  md5: 2972a84e0e22ae3244bbd2f1eebcf536
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 35352
+  timestamp: 1644569715988
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+  sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
+  md5: a68016b4b06460def24cb69d932986f3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132486
+  timestamp: 1695717963702
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+  sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
+  md5: 2f6356a2f530314b4059c08c79a3d8bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 205868
+  timestamp: 1681493113570
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-2.4.3-py39h06a4308_0.tar.bz2
+  sha256: 2d8e75f31f75ea5eb8b9021b4c21eb2846a254a097e06eb68e66fc36a82e1bed
+  md5: ae374a11c789a55555f70b29b9eff1f9
+  depends:
+  - jinja2 >=2.9
+  - numpy >=1.11.3,<2.0a0
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - typing_extensions >=3.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14430294
+  timestamp: 1658136783940
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.4-py39hce1f21e_0.tar.bz2
+  sha256: f84f9caa7eb9d489fd9634419fdf766d39293a5df1104b840fa0cdc5823a5c60
+  md5: 922555c0435d6b2537cf8ced534b048c
+  depends:
+  - libgcc-ng >=7.5.0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 141903
+  timestamp: 1648028958291
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-he6710b0_2.tar.bz2
+  sha256: 0bbcb6f78eac530c6a084459ffab3238647b266d0c74d695e6e6387dd119cc67
+  md5: bdc971e2a9affb5125b68ad708172dab
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 411301
+  timestamp: 1602517685375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py39h27cfd23_1003.tar.bz2
+  sha256: 8c2071f706c2b445dabb781f7f8f008b23a29957468ec6894f050bfb3a2d5bf4
+  md5: c203ffc7bbba991c7089d4b383cfd92c
+  depends:
+  - cffi >=1.0.0
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 357797
+  timestamp: 1605539534667
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+  sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
+  md5: 3ef00f4c5278b688552efc259c463dc8
+  license: MPL-2.0
+  license_family: Other
+  size: 132731
+  timestamp: 1694009767372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+  sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
+  md5: d5cb3d97cf5e85ffe5e94037ed8a1169
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159077
+  timestamp: 1690232254640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.0-py39hd667e15_1.tar.bz2
+  sha256: 674707b9c42e65c903c9786ee5a56b4d42aa054f1e75b328db8a2c1bfa368739
+  md5: 76ae217198b014b89b267cf41b8251dd
+  depends:
+  - libffi >=3.3
+  - libgcc-ng >=7.5.0
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 231920
+  timestamp: 1642701209740
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+  sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
+  md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1917831
+  timestamp: 1668084545510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+  sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
+  md5: 13702d3b4b744784e5bd559c7050dd6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12719
+  timestamp: 1671231205875
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39h130f0dd_0.tar.bz2
+  sha256: 821af57c20a85b4e92268fbf65fbaec2f273da5bb21889d9643756ef6e473237
+  md5: f57e0f502500ffebdbec081ef61ad1d4
+  depends:
+  - cffi >=1.12
+  - libgcc-ng
+  - openssl >=1.1.1v,<1.1.2a
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 2179774
+  timestamp: 1694445209134
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+  sha256: 469debfa966d24b8372aaf909ecbe27dc6fde186f6f0d5b9e0a8427e38053364
+  md5: 498d0788982ec4c5d13a44359b9c7afb
+  depends:
+  - expat >=2.2.10,<3.0a0
+  - glib
+  - libgcc-ng >=7.3.0
+  license: GPL2
+  size: 600218
+  timestamp: 1602701107852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.5.1-py39h295c915_0.tar.bz2
+  sha256: 3a39a2d6f161080c706292e3bf480f62d2444b1d6d67b3d7db50458202ee31f1
+  md5: 0524ffca60f845eb392bbb56d56f0ce5
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2094615
+  timestamp: 1637091869922
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+  sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
+  md5: 2e6ec51066d825ef3c317abe78d6049e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16413
+  timestamp: 1649926472708
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+  sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
+  md5: b4d923222d45314856b5378cb115214d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26728
+  timestamp: 1668714462023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.4.4-h295c915_0.tar.bz2
+  sha256: 27cde2cf0b1e10c2315bc1384fcb56537b424f6c2c872ca4662bc971e41910da
+  md5: c12e8c75f3c7c4f5867827c5dc02dc2c
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: MIT
+  license_family: MIT
+  size: 216001
+  timestamp: 1644418571578
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.13.1-h6c09931_0.tar.bz2
+  sha256: f80526def98864c9560dd3f6754d1c905edc001d18279f6e169913ee8f26a6a2
+  md5: e2fda4383ff9a690a6ac174553e10414
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - libgcc-ng >=7.3.0
+  - libuuid >=1.0.3,<2.0a0
+  - libxml2 >=2.9.10,<2.10.0a0
+  license: MIT
+  size: 306671
+  timestamp: 1612452969808
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.11.0-h70c0345_0.tar.bz2
+  sha256: 8a121233d0b2cbb2463b67e798739ad2946f38933430a6a7fd1197cc6eab1c99
+  md5: d2b24736491290a6c6d0138932111150
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: GPL-2.0-only and LicenseRef-FreeType
+  size: 965280
+  timestamp: 1635422707211
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h7b6447c_0.tar.bz2
+  sha256: 3c8ece1a7257b1d45f8fa25f46504bb709a1923d7175f2996e891366ec434b9d
+  md5: 299bf4271d710651a1d71d3795580c2d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 83592
+  timestamp: 1603192039050
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.69.1-h4ff587b_1.tar.bz2
+  sha256: bb98f022743e5df14d73db0edae49eb95a11abcc41c973fe2f30c3810bc5021e
+  md5: 858d4f13f1b0e54ee8cc3dd7c67cf0de
+  depends:
+  - libffi >=3.3
+  - libffi >=3.3,<3.4.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - pcre >=8.45,<9.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 2021087
+  timestamp: 1642701448286
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.0-h8213a91_2.tar.bz2
+  sha256: c85c664066c685b606df768d23eac08e1b824e391eb59f61a9ef608f4f46c5b6
+  md5: df2e0695e2edbd91b719da5b15249c5a
+  depends:
+  - glib >=2.66.1,<3.0a0
+  - gstreamer >=1.14.0,<2.0a0
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - libxcb >=1.14,<2.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  size: 6651032
+  timestamp: 1609866747525
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.0-h28cd5cc_2.tar.bz2
+  sha256: dc1af8ae3b38b8d81c00b54dac851618dba87ea8d4083af84dcb60c3070039ad
+  md5: 83453eb716b94c66fb64391760c0eeb1
+  depends:
+  - glib >=2.66.1,<3.0a0
+  - libgcc-ng >=7.3.0
+  size: 4178090
+  timestamp: 1609866593800
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.17.1-py39h06a4308_0.tar.bz2
+  sha256: 2d727f8335c59314b521b66d437ca4d51904134473ae503b7b097e239635f209
+  md5: 6991e520f353d995023404f6f524d192
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=0.13.1
+  - param >=1.12.0,<2.0.0a0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4507274
+  timestamp: 1693378095165
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-58.2-he6710b0_3.tar.bz2
+  sha256: bc2f45de45fba5aeb97e55cbbf68c1b4bdc49ac9982db27a7e871aaab66ca107
+  md5: 9213e0336e3a5216c989cfe52648412e
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: MIT
+  size: 23805906
+  timestamp: 1588026213084
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+  sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
+  md5: 1eb52f9f45cea2fb9ce27b19f990160e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110793
+  timestamp: 1666125606878
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+  sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
+  md5: 126b3c1933b7364ff03f67455b687e99
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 37588
+  timestamp: 1678997134023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2021.4.0-h06a4308_3561.tar.bz2
+  sha256: 1b424413f28b840fc6d4bf467f37e9e405823b1e3b899005df80152d48936d64
+  md5: 4aa8bcf74c81cd3600978f791191692a
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 9246735
+  timestamp: 1634546760713
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.19.2-py39hb070fc8_0.tar.bz2
+  sha256: b51b2e0dd37a74784ba19db22aded3f4c843b6fddb4a74399f65f36fc018aaa2
+  md5: 0d56ab1950f952284b895ac0f78284a7
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.0
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203541
+  timestamp: 1671488675347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+  sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
+  md5: ff47e0be879e817713ce2a9daa76e2b0
+  depends:
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1261116
+  timestamp: 1694181530670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+  sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
+  md5: 5ef6c6a0d1ac79143c7359d305155167
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1021637
+  timestamp: 1644297140650
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+  sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
+  md5: eaeb023688f781e7dd89e74310c38195
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 211775
+  timestamp: 1666908212136
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h7f8727e_0.tar.bz2
+  sha256: 85348bfb14db4fea84078d703e766a3c978c5a592a06e41266748826dd59d8ae
+  md5: 6e1c0fb5260c590f7ef5235cb3d05863
+  depends:
+  - libgcc-ng >=7.5.0
+  license: IJG
+  license_family: Other
+  size: 279884
+  timestamp: 1651065953960
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+  sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
+  md5: 0d2c3c5edf671b575532d5a3e8bf15fc
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 131510
+  timestamp: 1676558716852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.2.2-py39h06a4308_0.tar.bz2
+  sha256: 92bc012f9eb4ad71158cf4826fd3e125fcebff53b529276a81224acda48be547
+  md5: c5fd100e3062e831cbdf33331042f627
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=22.3
+  - tornado >=6.0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 190884
+  timestamp: 1650622553813
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py39h06a4308_0.tar.bz2
+  sha256: b791f2f86fe1993ddfcd10a80a92fb098c2b4792f0ce13da9269cac6b3647d0b
+  md5: ac7c5e38691312d195fdd1f23b33f779
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78853
+  timestamp: 1698937381669
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+  sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
+  md5: a4beb461f0a60998a090d760b5c6c907
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411564
+  timestamp: 1671707702849
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.2-py39h295c915_0.tar.bz2
+  sha256: 974df3dc76089be57b327acd6634384def84249003f58678ca1142bb274a75d9
+  md5: 81b969d1a00153759b30554a1f11ddfd
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 92144
+  timestamp: 1653292217019
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.tar.bz2
+  sha256: 3b4afe7665dcdb99bd4586a888b85b2e0325f8faecdd31c7780792080ee97872
+  md5: 822b5201dde61bc838072dc5b670c88c
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  license: Custom
+  size: 55183
+  timestamp: 1594054267890
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.tar.bz2
+  sha256: c6fafbe73d2f93b91b6f4b65829f925f52a8f84746a57abd216b39da9ce8c494
+  md5: 238f19c803a6ba7bd6dbd6989e03cbf1
+  depends:
+  - _libgcc_mutex * main
+  license: GPL
+  size: 8496776
+  timestamp: 1560112207081
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.37-hbc83047_0.tar.bz2
+  sha256: bc3e6e79c32ff0ecea601aa108ae9cf4068f69703580e40e266ad4bcc52cff54
+  md5: 9cb85601944ca7383b1769bff74b94e8
+  depends:
+  - libgcc-ng >=7.3.0
+  - zlib >=1.2.11,<2.0.0a0
+  license: zlib/libpng
+  size: 372914
+  timestamp: 1556041895170
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.tar.bz2
+  sha256: 43b0bd205f539583c088feb5b8d77b60c83d1df80c2a93dac9f2a1127001b2cf
+  md5: 53fa39fdae936e9d07c4b2f5ef361993
+  license: GPL3 with runtime exception
+  size: 4246257
+  timestamp: 1560112223556
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.2.0-h2818925_1.tar.bz2
+  sha256: 711ea05b4c35bdafc762a172b01db896b17942f474c2b1a519f91370964bf9bc
+  md5: b25d56d33596623a6a4a9d9baaa4f602
+  depends:
+  - jpeg >=9e,<10a
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libwebp-base
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  size: 592974
+  timestamp: 1653047881023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.0.3-h7f8727e_2.tar.bz2
+  sha256: 4e1dce80f23551a69761ad48b2372e35f58292ec9cc0ce061312330366a1a223
+  md5: fda36b99463bad87974196da2d5bed08
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD 3-Clause
+  size: 18725
+  timestamp: 1633507857274
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.2.2-h55f646e_0.tar.bz2
+  sha256: 146dbb1e4dbccdd57819e5102a8ca00970b8e33d6c6180e8007db89b184da569
+  md5: c566a384259c1d2769852c3bddd81a67
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9d,<10a
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 90150
+  timestamp: 1645441199289
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.2.2-h7f8727e_0.tar.bz2
+  sha256: cffb5a063111f7a99a99c74770b23db5dde52325e25a7a46d1903d5ff4a82c88
+  md5: eeb1bd66f28bed1956ab989d6eff7ae5
+  depends:
+  - libgcc-ng >=7.5.0
+  constrains:
+  - libwebp 1.2.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 889956
+  timestamp: 1645089138421
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+  sha256: 5d68e69709ae10bd6c4b58b6af447ad2f2bd24955994f3ec77103d1a6bf5e1f5
+  md5: 49e523de8d364b7fabc3850eccbe9bda
+  depends:
+  - libgcc-ng >=7.5.0
+  size: 623492
+  timestamp: 1652448233146
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.tar.bz2
+  sha256: 71f6c4a97014d745c58df52b4dd60ddd75a8508d54fe5b97f42bd1f31cb1c067
+  md5: 686e77514ec9f1ef0a6feed374f14d37
+  depends:
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.5.0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 789469
+  timestamp: 1653546418059
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.tar.bz2
+  sha256: ea3355a67c5173f3944f09861043ca66eb7dbeff8f385d13528b3aabc0801d0c
+  md5: 66e2aa12181bb2911485bdbe125d24c5
+  depends:
+  - icu >=58.2,<59.0a0
+  - libgcc-ng >=7.5.0
+  - libxml2 >=2.9.14,<2.10.0a0
+  license: MIT
+  size: 584199
+  timestamp: 1654075843119
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.8.0-py39h1f438cf_0.tar.bz2
+  sha256: 64b022d706b76c33965a250fdc8c6008443c41bff8ab27bb1df3cb70419576fd
+  md5: ec4f05846aacf634df15c389235725cc
+  depends:
+  - libgcc-ng >=7.5.0
+  - libxml2 >=2.9.12,<2.10.0a0
+  - libxslt >=1.1.28
+  - libxslt >=1.1.34,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  size: 1538261
+  timestamp: 1646624639995
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.3-h295c915_1.tar.bz2
+  sha256: 2c6a5dda7c510a961bc78e31d4232be5e8e0760c93454f5fd200c379355e0f5e
+  md5: f35d4bf2fbb39e334992f6dd39f8721e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 220865
+  timestamp: 1627657046002
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+  sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
+  md5: 421f82c8274b44660dba629134faa6af
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 122221
+  timestamp: 1671541990505
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+  sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
+  md5: feb0e452205b44ac45d9b5e55c21a3b1
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22819
+  timestamp: 1654597913064
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.5.1-py39h06a4308_1.tar.bz2
+  sha256: 62fb0d06224e15528540718debebeaebbfdbd7f03106fad52a7002fb96c6b8bd
+  md5: 364c1e3dddefa27741e540496c38b694
+  depends:
+  - matplotlib-base >=3.5.1,<3.5.2.0a0
+  - pyqt
+  - python >=3.9,<3.10.0a0
+  - tornado
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 28294
+  timestamp: 1647442129989
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.5.1-py39ha18d171_1.tar.bz2
+  sha256: dc51b316ef5dcfb82a9c0afdc40879146ae59516f6cea7db776077783dfd2d76
+  md5: b0b6b57c140f026b8806051107336576
+  depends:
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.11.0,<3.0a0
+  - freetype >=2.3
+  - kiwisolver >=1.0.1
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - numpy >=1.19.2,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.2.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  - tk
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7729454
+  timestamp: 1647442028622
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+  sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
+  md5: c04ef34af33da4c71bcc99b7ec24d210
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16391
+  timestamp: 1662014553452
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+  sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
+  md5: f6c734d73e6e3dbc1b62766cf18ff3e4
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58153
+  timestamp: 1607364912263
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2021.4.0-h06a4308_640.tar.bz2
+  sha256: 7c4ded8b2ef036839f988560848d2c32e1aa4627fd37a32710e42c39f5c61ac2
+  md5: bd20f4410b81f327e35ffa0657961146
+  depends:
+  - intel-openmp 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 229783051
+  timestamp: 1634547157986
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h7f8727e_0.tar.bz2
+  sha256: 5394f5efd53afb2c1b0abf571ce3d9cb684b6c7e255f140ba2acaa703d6113be
+  md5: d3cb2bfa63e30153f5527797dcc87280
+  depends:
+  - libgcc-ng >=7.5.0
+  - mkl >=2021.2.0,<2022.0a0
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 63551
+  timestamp: 1626176932911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.1-py39hd3c417c_0.tar.bz2
+  sha256: c244d23da2749857a993f84969fd35ffd183ab8f462986df6d33ae0f705fe034
+  md5: 9b1f8ccc2488d0e04eb73211e2987483
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.3.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  size: 204136
+  timestamp: 1634566416657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.2-py39h51133e4_0.tar.bz2
+  sha256: f81f426f8ef306d636664bc49e7cdd70e2b4306d7c6bcb9c75fe35a45ab2087a
+  md5: 77aa1d7f958d36bf227e6ff4a34d2e3d
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.2.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  size: 365386
+  timestamp: 1626186165897
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+  sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
+  md5: 95c83d71814c504b5504df4f14548f1a
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8257558
+  timestamp: 1681756322140
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py39h06a4308_0.tar.bz2
+  sha256: 79e10dc933d22aa99de3543071f1beaaf0ff24df9fed7d2ef5e765f3ed766064
+  md5: ea6ebe4e8d6af98128d32606da618a29
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99555
+  timestamp: 1698934242626
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+  sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
+  md5: 1710a25086c8098367eb36b9d441448b
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 569683
+  timestamp: 1668450704669
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+  sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
+  md5: 385cc9e53404776782502c0fdb08820f
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147046
+  timestamp: 1694616899309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.3-h7f8727e_2.tar.bz2
+  sha256: 0807371380965e421cb5f3f2a30d790fd5c41db11dbb6d318e14294c3b1741ed
+  md5: fca4bd4e3891aebf4fd7daf9b6d0ccfa
+  depends:
+  - libgcc-ng >=7.5.0
+  license: Free software (MIT-like)
+  size: 1083412
+  timestamp: 1636570020698
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+  sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
+  md5: bbbcbebc20a4fdcadce398d0ca04f95e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13109
+  timestamp: 1672387143252
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+  sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
+  md5: 248ce515640465371927d46f389ed555
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 594054
+  timestamp: 1690985006481
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+  sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
+  md5: 70db71df4ee1cdd38090c0f7b80ba61f
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21944
+  timestamp: 1668160644514
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.1-py39h6abb31d_0.tar.bz2
+  sha256: 15a12c8bebcda45c577e61cea412d9aafaa433e39f9e91fd61bbfab66fcee3ab
+  md5: 5239d8330e8bd34972fb80918dce79e7
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16.6,<2.0a0
+  - packaging
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 136437
+  timestamp: 1640689905588
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.22.3-py39he7a7128_0.tar.bz2
+  sha256: ff8d0426c7096e086db818265c3edf4a820accbfb15afae0407ca578de151fa9
+  md5: d7bcf0b9ba2d85cf532059ec119d2750
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.22.3 py39hf524024_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  size: 9965
+  timestamp: 1652801901707
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.22.3-py39hf524024_0.tar.bz2
+  sha256: abfdeda143b6b667d50a82ea119043fc1469ee02f094a41a2402433ff408099e
+  md5: e8dc29adc0282f4658e0e2f25ff207a2
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - mkl >=2021.4.0,<2022.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.22.3 py39he7a7128_0
+  license: BSD-3-Clause
+  size: 7095882
+  timestamp: 1652801886819
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1w-h7f8727e_0.tar.bz2
+  sha256: dff9c10efc7a4c5d1ba05309cfda77de4453d3681edc432d1f229d96f2dcc7a4
+  md5: 5ad4571eba2479f77a9f849a6ae7724c
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: OpenSSL
+  license_family: Apache
+  size: 3998613
+  timestamp: 1694465071784
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+  sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
+  md5: 77a22ed6d0d448c5288d0f695bc9ac49
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 72527
+  timestamp: 1693575234886
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-1.4.2-py39h295c915_0.tar.bz2
+  sha256: e7a0abb0f00a94000876f2095f0cf531ad3803ffbd868a780b3f06816b54492c
+  md5: 97ef7e1fe923d22a8e2307f3f39a92d5
+  depends:
+  - bottleneck >=1.3.1
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - numexpr >=2.7.1
+  - numpy >=1.19.2,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.1
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13221005
+  timestamp: 1650622404234
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-0.14.3-py39h06a4308_0.tar.bz2
+  sha256: 49fdb57b2ed2ce4d6bb7a2c5adec36ba59522518a41fb941f9e39a9f43750cc5
+  md5: 871b65444733b7da5823ee0dc9826722
+  depends:
+  - bleach
+  - bokeh >=2.4.0,<2.5.0
+  - markdown
+  - param >=1.12.0,<2.0.0a0
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - setuptools >=42
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >1.14.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14712394
+  timestamp: 1676379803902
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-1.13.0-py39h06a4308_0.tar.bz2
+  sha256: 64a732ce2661cdb6bd8f9d1484ac10afeb73082b1c2b44728d212e0117d2860e
+  md5: ada303f0cf43a4e99cfa7f243b23b681
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141832
+  timestamp: 1684915385689
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
+  sha256: 4881cc5e0d5b20335bcfba4eaf29fdc95dedf2607903aabecdacffb64d3407d4
+  md5: 4bac8a874e62f41ebab8345ca6076eb6
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 263308
+  timestamp: 1624477853289
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-9.0.1-py39h22f2fdc_0.tar.bz2
+  sha256: 8bcb1c67693f42a3170eb77ef4cdbb81b605fdf40816953e69a33a065c101638
+  md5: b7689507fb5f879dc766aaa8a4c37351
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp >=0.3.0
+  - libwebp >=1.2.0,<1.3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk
+  - zlib >=1.2.11,<2.0.0a0
+  license: LicenseRef-PIL
+  license_family: Other
+  size: 734566
+  timestamp: 1646325095608
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+  sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
+  md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2674850
+  timestamp: 1697548887851
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+  sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
+  md5: fe56f0479dd414c846191116366262c3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 31999
+  timestamp: 1692205535111
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+  sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
+  md5: 44d2a857d13bdf9d99aaac039a249d47
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91137
+  timestamp: 1659455142164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+  sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
+  md5: eb899a739d9b58dd747f1f6bd52d4cf3
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 579771
+  timestamp: 1672387338600
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.8.0-py39h27cfd23_1.tar.bz2
+  sha256: 6973cfe0565ba3b5ad6d1de9e34848fbbadd78b507b2e23e1c079636b8f8f317
+  md5: a924535045fb356e23e7a3cc8116b638
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 350026
+  timestamp: 1612298042840
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+  sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
+  md5: f36ecb722522cbe2e3737424edf1b5e1
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29312
+  timestamp: 1675441510984
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+  sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
+  md5: 6d03295e544251e608a28c8d7c48115e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1862058
+  timestamp: 1684280096752
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+  sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
+  md5: 1f09617aecd6f3c2f2e20692c0759f34
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94434
+  timestamp: 1690223520097
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+  sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
+  md5: ffceed627867508d73af1636ab5ebf42
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 156324
+  timestamp: 1661452578573
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.9.2-py39h2531618_6.tar.bz2
+  sha256: c96502aca0df082c457f31d9e6202419aa86f24e1c699c3a34d02602f7a42812
+  md5: 3eda4bcc31b66fd5002817def97cd129
+  depends:
+  - libgcc-ng >=7.3.0
+  - libstdcxx-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  - qt 5.9.*
+  - qt >=5.9.7,<5.10.0a0
+  - sip 4.19.13.*
+  license: Commercial, GPL-2.0, GPL-3.0
+  license_family: GPL
+  size: 6010734
+  timestamp: 1607697278482
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+  sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
+  md5: 0e3341a4fe434167bf74b613eb6afd81
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 97194
+  timestamp: 1636110999719
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+  sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
+  md5: c5f3f7f10ad30f0945e75252615ab6e5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31331
+  timestamp: 1605305847037
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.12-h12debd9_1.tar.bz2
+  sha256: c4b9e332a6f2b7524e8c88e2b39a2568a48e556fd9a44c30759c43611d4d023d
+  md5: bb118745c9b08fc5028f45e77f371e68
+  depends:
+  - ld_impl_linux-64
+  - libffi >=3.3,<3.4.0a0
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - ncurses >=6.3,<7.0a0
+  - openssl >=1.1.1o,<1.1.2a
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.38.3,<4.0a0
+  - tk >=8.6.11,<8.7.0a0
+  - tzdata
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 24553777
+  timestamp: 1654084160832
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+  sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
+  md5: 0caa188a695319bdb13f53b0a2b3accc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264864
+  timestamp: 1661371117920
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+  sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
+  md5: bcb44ecbea441ee0d4659133d060d71f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257904
+  timestamp: 1695131670290
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+  sha256: e937081facacb141dc2c9cdcced92baa9a2662e4a56100b6041df0b6b7692570
+  md5: f3ac39b2349258198a9b3316636fe5d5
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39972
+  timestamp: 1685030752528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0-py39h7f8727e_1.tar.bz2
+  sha256: 3da9cbbd49fac566433748bd245d09d7d5fcd28b04c0397cbbf6d5bb92f5c4a5
+  md5: df73a5d2f6e089d51e71e91935a82c65
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 183753
+  timestamp: 1635775763162
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-22.3.0-py39h295c915_2.tar.bz2
+  sha256: 26005d191bb15070aad70707ed6493f32678a67978bd3b83d4c9679cab44e717
+  md5: 2dc75d5a4ccb64310939c3a72d34ae20
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-clause
+  license_family: BSD
+  size: 521583
+  timestamp: 1638435042256
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-5.9.7-h5867ecd_1.tar.bz2
+  sha256: 5881ffba2ab8ed28112e80dd3f17ced0832b75615b9f8aab6bf171575c812b88
+  md5: 50da300935a335f7605d3f96fa045111
+  depends:
+  - dbus >=1.13.2,<2.0a0
+  - expat >=2.2.6,<3.0a0
+  - fontconfig >=2.13.0,<3.0a0
+  - freetype >=2.9.1,<3.0a0
+  - glib >=2.56.2,<3.0a0
+  - gst-plugins-base >=1.14.0,<1.15.0a0
+  - gstreamer >=1.14.0,<1.15.0a0
+  - icu >=58.2,<59.0a0
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libpng >=1.6.35,<1.7.0a0
+  - libstdcxx-ng >=7.3.0
+  - libxcb >=1.13,<2.0a0
+  - libxml2 >=2.9.8,<2.10.0a0
+  - openssl 1.1.*
+  - sqlite >=3.25.3,<4.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  license: LGPL-3.0
+  size: 90037659
+  timestamp: 1544604609235
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.1.2-h7f8727e_1.tar.bz2
+  sha256: 8c950c69bee969e2c66f88f0dc247b3ab75a753672a88009779d5f5dba193532
+  md5: 150ac0eb929bab9dec912797bdfc7b95
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 433182
+  timestamp: 1642022402894
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+  sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
+  md5: c7de00b4ac2778c4e5a7816320d75391
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94028
+  timestamp: 1690400356879
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+  sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
+  md5: 1581cafc84708ed9aafaaee1cbbf6065
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1089416
+  timestamp: 1690290900608
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-4.19.13-py39h295c915_0.tar.bz2
+  sha256: 9f2d68b41365097a380979014b3cabf5f1f9f07e5554eb215eef4801f640922e
+  md5: 3ec6ce8f2eae0969b341e5702fb029c6
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: GPL-3.0
+  size: 302624
+  timestamp: 1643114723175
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+  sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
+  md5: e19ffbfb24b990275d24fcea2bd1699b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15702
+  timestamp: 1614030498860
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+  sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
+  md5: ca061ce25c0f58628643abec8d6a8244
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 66330
+  timestamp: 1696347637947
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.38.5-hc218d9a_0.tar.bz2
+  sha256: 87965b7b46d93866d31696a1045216d64f077a06b2900c356aba87e8559c6188
+  md5: fa334030245135b37027a882f3c468bf
+  depends:
+  - libgcc-ng >=7.5.0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: blessing
+  license_family: Other
+  size: 1561908
+  timestamp: 1655328608308
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+  sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
+  md5: 0e76eab58fe488e91f0aee73f46de031
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29816
+  timestamp: 1671751864131
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+  sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
+  md5: b413a210eca82fe867e991eed085201b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38882
+  timestamp: 1668168876032
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+  sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
+  md5: 5b8375e2092012db69d2123dc0c68630
+  depends:
+  - libgcc-ng >=7.5.0
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3485432
+  timestamp: 1654088939579
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.1-py39h27cfd23_0.tar.bz2
+  sha256: b746e39272888b9cc1a2a711b7b8836f2e26f4457850e43ad18bf0765e21dc3d
+  md5: 200e86f8d53aeebf4b7dcfc944fd7920
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 661662
+  timestamp: 1606942359431
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+  sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
+  md5: 67a8320961ff24e92eebb661536e5cf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - requests
+  - slack-sdk
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 123763
+  timestamp: 1679561904852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+  sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
+  md5: 0f0b91a158dd3692cbb7a7763b657bfe
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192032
+  timestamp: 1671143995098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
+  md5: 8515e64a3de7581360d713fe4c0a094e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8789
+  timestamp: 1690297588156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
+  md5: 60170012374b2a5007842fa5870d78c5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57479
+  timestamp: 1690297581658
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py39h06a4308_0.tar.bz2
+  sha256: 870f20a3c006a74b291910f69c3469a409bd21437142864b29cfafeb89ca7c34
+  md5: 1b2f1589e3ebc3e0c6ecb38dba93e4ae
+  depends:
+  - brotlipy >=0.6.0
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 186761
+  timestamp: 1686163186447
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+  sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
+  md5: f8d03a15b974fc7810d9f54ae849fc8e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20781
+  timestamp: 1607365390528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+  sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
+  md5: d7db5d6ce1db80eade8a082ff78bf479
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 71044
+  timestamp: 1614804011510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+  sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
+  md5: b3899f8bda32734727bd5a73df1d7d17
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 101520
+  timestamp: 1695742037911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7f8727e_1.tar.bz2
+  sha256: 2ce360ff98c0ca4537d70c19266b5700810196c54ce2fbaff3b94a969846ee37
+  md5: 94cb94dc47405b24b1b5bd0a3275ab59
+  depends:
+  - libgcc-ng >=7.5.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 398058
+  timestamp: 1651602137803
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+  sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
+  md5: 567b68192c387b5fc88178425577a0fe
+  depends:
+  - libgcc-ng >=7.3.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=7.3.0
+  license: LGPL-3.0-or-later
+  size: 366479
+  timestamp: 1616055552392
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+  sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
+  md5: 3818a9531fe74433c3b7d5144c9a58cc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18021
+  timestamp: 1672387231268
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.12-h7f8727e_2.tar.bz2
+  sha256: 513444d83ac2405e898531492ea59f3a95641e357cc39c1048d6fffc1791a16b
+  md5: 601d9449c280b9b145dc8c83b6f06119
+  depends:
+  - libgcc-ng >=7.5.0
+  license: Zlib
+  license_family: Other
+  size: 133595
+  timestamp: 1650637720646
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.2-ha4553b6_0.tar.bz2
+  sha256: 1c049c23788a00b6f38bdc801245e0e60af98718d4db4c958658bcc67ff158c7
+  md5: b1737dfd2e06ad69ec5cfec341e207c6
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - xz >=5.2.5,<6.0a0
+  - zlib >=1.2.12,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 827172
+  timestamp: 1650622223170
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
+  md5: b2aa5503875aba2f1d88cae9df9a96d5
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13636
+  timestamp: 1611930018941
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
+  md5: 544adf2677c47c9b9c891aea720678f1
+  depends:
+  - python >=3.5
+  license: MIT
+  size: 33999
+  timestamp: 1630003259346
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+  sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
+  md5: 9eff1a842dbda8d1bae9a2c008b599bc
+  depends:
+  - brotli >=1.0.1
+  - munkres
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 690443
+  timestamp: 1625743217109
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+  sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
+  md5: 33624a42ee387bf9918ea98b4e7b31fc
+  depends:
+  - pygments >=2.4.1,<3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8173
+  timestamp: 1601490751973
+- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+  sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
+  md5: 67857cc5e9044770d2b15f9d94a4521d
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12810
+  timestamp: 1600445183315
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+  sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
+  md5: e68a6f315f41a8d814d833652bf38b9b
+  depends:
+  - python >=3
+  license: MIT
+  size: 13374
+  timestamp: 1606932077143
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
+  md5: 2eb923cc014094f4acf7f849d67d73f8
+  depends:
+  - python
+  - six >=1.5
+  license: BSD-3-Clause and Apache
+  license_family: BSD
+  size: 246457
+  timestamp: 1626374695070
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
+  md5: 41db68b96e114e367c4f120a3b379e59
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19391
+  timestamp: 1632406728844
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+  sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
+  md5: a815d3bdb160bcc71687f2dda70d3ca4
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 122218
+  timestamp: 1680170368293
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
+  md5: 447a49f7bad119faa80d7f14aa296c95
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162176
+  timestamp: 1644481750133
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+  sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
+  md5: 8810f48fe4a4792de0fd3520b502d08b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10019
+  timestamp: 1606859473259
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+  sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
+  md5: 00a446b6dfc61af223df4de29fe8ad94
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 34305
+  timestamp: 1644569782044
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
+  md5: bd92dd8bd5b9d24e632b62a075426e50
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133634
+  timestamp: 1695718025321
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+  sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
+  md5: f8ae051b591a9027adc16de1be9748f4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206198
+  timestamp: 1681493096349
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
+  sha256: 2936241747f6cc0f0b3afa53bb28ad6f658b53a0fc2e67a5ed34d1d5e2cce117
+  md5: bdca1b691340964271d9cfec6baaf8d0
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5719952
+  timestamp: 1697490515691
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+  sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
+  md5: 0d79760d544d0bd8acb4adc4ef813418
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 137075
+  timestamp: 1657175654487
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
+  md5: 31d6d04cd2388d8f19004501271b3545
+  depends:
+  - brotli-bin 1.0.9 hca72f7f_7
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18982
+  timestamp: 1659616229395
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
+  md5: caf1073dc2ca5aeb832a2877394eae12
+  depends:
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18233
+  timestamp: 1659616216769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+  sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
+  md5: aa1ed20c38af535c8d6a955314759d7b
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 394588
+  timestamp: 1659616312678
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+  sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
+  md5: ce3588e31faa79f546e0fc6a36c5543c
+  license: MPL-2.0
+  license_family: Other
+  size: 133884
+  timestamp: 1694009771475
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+  sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
+  md5: 21eb7f53076d0a69513cfd258f6ef63c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159756
+  timestamp: 1690232346868
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+  sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
+  md5: a40a04d9cda1e665565bc6c832d598b6
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225258
+  timestamp: 1670423337502
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+  sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
+  md5: b2cc5f37f7bb069d061306e7eac2a011
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1913396
+  timestamp: 1668084575248
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
+  md5: 103d8c039e342115720a84d59c119d46
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13774
+  timestamp: 1671231190250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+  sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
+  md5: f69f09e0346172f225390d2b3b0d7873
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 246628
+  timestamp: 1663827484947
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+  sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
+  md5: cb80c7ac65b48a737654f371fe31c460
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1307228
+  timestamp: 1694212041712
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+  sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
+  md5: 04cbe8f4bc62c34fac9d42d1124059bf
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2052734
+  timestamp: 1690905361158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
+  md5: ef0e825982f242085574f502dfff4f6b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16594
+  timestamp: 1649926538106
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
+  md5: 24747a300246c016b3a7f04dabd02d4a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27709
+  timestamp: 1668714497209
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+  sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
+  md5: e4a732941f74b8062c8bcbfe5c5c2b56
+  license: MIT
+  license_family: MIT
+  size: 80252
+  timestamp: 1676983220161
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+  sha256: 5c36d43cadbbf944d9255e79df85c2e9e6155a1d6f9158e06fcd8ffd458b7663
+  md5: a5a2cff387403ccf9cf58aac7a6dde55
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4573879
+  timestamp: 1698866750755
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+  sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
+  md5: f3ce6fe6eb760c236e5f7d04df5faa81
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28138484
+  timestamp: 1692293212596
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+  sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
+  md5: 6dd72c43fea25b748ec7a9f6c0407e15
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111810
+  timestamp: 1666125671024
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
+  md5: 03cdb7e679924b329ecab8f12cb8fc67
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38813
+  timestamp: 1678997212422
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
+  md5: e113c4e6e758dd68faf196586bf5564d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51873
+  timestamp: 1698254765815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+  sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
+  md5: 78baea934985ccd9514a366cc7e80ed4
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 727499
+  timestamp: 1681801225190
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+  sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
+  md5: da9b63e42f281f7e77b289f4b654b83b
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 218436
+  timestamp: 1691121840155
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+  sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
+  md5: 6a7cb9b49593b29933fa2b503d533a08
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1257205
+  timestamp: 1694181720454
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+  sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
+  md5: d861ef66f5c0a282d60b65778a9de2f3
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1048450
+  timestamp: 1644315332508
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
+  md5: f7e603c965052deed8b789c35855a42f
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213537
+  timestamp: 1666908270815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
+  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
+  license: IJG
+  license_family: Other
+  size: 278924
+  timestamp: 1677849185191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+  sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
+  md5: a82a17e78f725dcbd71ff8dac6db05c7
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133134
+  timestamp: 1676558895333
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+  sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
+  md5: ee9270379a9ebdb6297e4b6849b3f7f0
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 195479
+  timestamp: 1676329410154
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: ede34881321808fbb967885dde9b0b6c9c8ef1f3eb192fa514058c4f14201c4f
+  md5: 07d24f5332ca5d0e76aa0df051a1f05d
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 79901
+  timestamp: 1698937699237
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+  sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
+  md5: 7e60995b3119417213e5faedda147499
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 403165
+  timestamp: 1671707664990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+  sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
+  md5: cd470bdb28bb0e8b3535c93a3a6dad07
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65431
+  timestamp: 1672387389172
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
+  md5: 7dba7aa5b971febb55281659843586ba
+  license: MIT
+  size: 65470
+  timestamp: 1659616172703
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
+  md5: f78a158983f0bbaba56f34b976bc6dae
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 34189
+  timestamp: 1659616189313
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
+  md5: 36a1d885725d3ab4d1fadc5a29f978d2
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 327737
+  timestamp: 1659616202869
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+  sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
+  md5: 817848d0e2b2808acdc9b3fbbf581726
+  license: MIT
+  license_family: MIT
+  size: 133887
+  timestamp: 1683716590737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+  sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
+  md5: c90372428e1e4eed4fdcd790979d06b4
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1409377
+  timestamp: 1650983531933
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+  sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
+  md5: c0b99f8e1c7475f23b1c7b4250b06e1c
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88021
+  timestamp: 1694778290062
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+  sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
+  md5: 06866415ef22d5322f9bdc9956b59c4d
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 678174
+  timestamp: 1692970318885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+  sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
+  md5: 2edc6c894d6d0321304396e9bd40df94
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241774
+  timestamp: 1692973618934
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 0190d3b8d2939f28aa017711cf4147c51a1139da2922cc8420a71562dd99f844
+  md5: 454a7f2c4426453f17e995382a4235e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 36036
+  timestamp: 1659783508187
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+  sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
+  md5: 8bbd981ca0129d7beeacd3cd7623f714
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1491074
+  timestamp: 1695058597986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+  sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
+  md5: d5f58d056b4bfc67aec30c77035ba889
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 182491
+  timestamp: 1670944720979
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+  sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
+  md5: 1affd16b166571a91feae04baf5fd3da
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123431
+  timestamp: 1671542016019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+  sha256: e5fc51472fa0f36abd78baa5b3c9245d6627b0da11188e6a954d73f3f2bca210
+  md5: df7c519447affffb594f8c56b028ed33
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 107035
+  timestamp: 1684279974102
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+  sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
+  md5: 3681ebf029211ceab26af6f5d35abf39
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22254
+  timestamp: 1654598220251
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.8.0-py39hecd8cb5_0.tar.bz2
+  sha256: 40aa972e605bdc8305ebdc4b8e891ae8b65382be12d221e002ec31cfe830ac22
+  md5: 07b2a24fd3dcb5cb0af22e137cd43408
+  depends:
+  - matplotlib-base >=3.8.0,<3.8.1.0a0
+  - python >=3.9,<3.10.0a0
+  - tornado >=5
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8754
+  timestamp: 1698692468088
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+  sha256: 2fd179efa024c92d0d71179a981a781d16c70f5d8c6305e0d678b0c7ae1275ab
+  md5: addda7f015d1673f794a23fdb18a3e09
+  depends:
+  - __osx >=10.12
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8182219
+  timestamp: 1698692361219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+  sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
+  md5: 6eb64ecfcd754502e271db0bb51d2cfd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17374
+  timestamp: 1662014643620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 2312ee5a6343e8495802698d7181f1b619aad7479d96ee253407b324ac884417
+  md5: 866960fa48a7ca335941786d4869802a
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53542
+  timestamp: 1659721365599
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: 37f455814ce242eb65ff80a0402f1bd231a388e6823e6c1e65f60b705c032a2d
+  md5: 4c9246c492a64729225aa5b04e12c2d1
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19573
+  timestamp: 1659716100178
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+  sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
+  md5: 2a4d604717a647ad21af766289cbbfc3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58057
+  timestamp: 1607364912348
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+  sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
+  md5: 25051fe272624544652dc6d814c2943a
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224420228
+  timestamp: 1691503125614
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+  sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
+  md5: 37d8cf85a63f7aa9af1624894a7d606d
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48590
+  timestamp: 1682969183093
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+  sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
+  md5: 0b2aee6666135bbd36b46d6ac66160f7
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 210705
+  timestamp: 1695058433223
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+  sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
+  md5: e22fb55ce380d0ebd44cce3f20d5349e
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296614
+  timestamp: 1695060155673
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+  sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
+  md5: 1a5d4004e64e3cfb7a2a297b9117c285
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8213832
+  timestamp: 1681756573646
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py39hecd8cb5_0.tar.bz2
+  sha256: 59acf22956f295ed429624a1560bceffbbf536ea93ca63a5f1a48975a0afdbcb
+  md5: a7a6344327960940bad23e783a4d6bce
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100813
+  timestamp: 1698934262550
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+  sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
+  md5: e572c1264a7af20b486f64ac8c9e1f57
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 573356
+  timestamp: 1668450732828
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+  sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
+  md5: b67569a7c30af9ffa5cde6e4b52ac68b
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148342
+  timestamp: 1694616917184
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+  sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
+  md5: 97b81f34efbe86c5220fe82eb584fd62
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387288528
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+  sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
+  md5: d77862975a9a1cf50acb803be26e83a1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 575365
+  timestamp: 1690985052739
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+  sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
+  md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22858
+  timestamp: 1668160618784
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+  sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
+  md5: 185e9c41abb88ee59b52ec0f5f65d506
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 138305
+  timestamp: 1696515469702
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+  sha256: 82a2dd0c2ff6e20a275e5447dd03088f79694f7bfa5055a25c54bebf31aac4ca
+  md5: c157e6ab469a95b06fa822ba075978b3
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.0 py39ha186be2_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10376
+  timestamp: 1695831243158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+  sha256: b3a003b41cec2751210e542911e99437db0321542f6812c1b88608ef720ba7ef
+  md5: 56400dfe88c427cdf1854e47666b8a99
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.26.0 py39h827a554_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7570900
+  timestamp: 1695831208653
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
+  md5: 93f5d7b66976154adeda219bea02ba45
+  depends:
+  - libcxx >=10.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 484257
+  timestamp: 1630093862501
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+  sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
+  md5: 5e8713ef1215406254988163eaf34020
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4965606
+  timestamp: 1695323060401
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+  sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
+  md5: 4154929ace2ad6ee16aea815635a6d1f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73598
+  timestamp: 1693575307570
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+  sha256: aff5acedef9da91b77851e1a163b8319d72bc4152c98ac87703a2eac1e5d575b
+  md5: 7df4c76aa8c52fedce5346748d56459e
+  depends:
+  - bottleneck >=1.3.4
+  - libcxx >=14.0.6
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - tabulate >=0.8.10
+  - blosc >=1.21.0
+  - fsspec >=2022.05.0
+  - beautifulsoup4 >=4.11.1
+  - pyreadstat >=1.1.5
+  - pyqt >=5.15.6,<6
+  - s3fs >=2022.05.0
+  - numba >=0.55.2
+  - xlrd >=2.0.1
+  - qtpy >=2.2.0
+  - xarray >=2022.03.0
+  - psycopg2 >=2.9.3
+  - lxml >=4.8.0
+  - zstandard >=0.17.0
+  - pyarrow >=7.0.0
+  - pytables >=3.7.0
+  - xlsxwriter >=3.0.3
+  - gcsfs >=2022.05.0
+  - fastparquet >=0.8.1
+  - scipy >=1.8.1
+  - pymysql >=1.0.2
+  - odfpy>=1.4.1
+  - pandas-gbq >=0.17.5
+  - pyxlsb >=1.0.9
+  - matplotlib-base >=3.6.1
+  - openpyxl >=3.0.10
+  - jinja2 >=3.1.2
+  - html5lib >=1.1
+  - dataframe-api-compat >=0.1.7
+  - sqlalchemy >=1.4.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13388063
+  timestamp: 1697477404222
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
+  sha256: 42d83288119306089a06e853a37045fbb9860548b05a1e79d223f7ecf1cb349d
+  md5: 8daced11264159ff57df7bba4d0b2ec7
+  depends:
+  - bleach
+  - bokeh >=3.2.0,<3.4
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.0.0,<3
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.17.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17075803
+  timestamp: 1698867397009
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: ad7ca92e5c83a8e2181677025509ed7b8f566ec23b24f28316fa087bb591c11f
+  md5: a4ccd0fbcfb26de868f2fb4836940d7a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189263
+  timestamp: 1698263570990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+  sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
+  md5: be0a90921f3bf4f0d6950fb786093de7
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND
+  license_family: Other
+  size: 719901
+  timestamp: 1696580194417
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+  sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
+  md5: 81ae9ec2d7fcf6934847bff558b619f5
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2672987
+  timestamp: 1697548890181
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+  sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
+  md5: 1a822c206e2abddc5d6d821721af227f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33013
+  timestamp: 1692205801265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+  sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
+  md5: 1604d33dbdb2446c642970f8b354bedb
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91266
+  timestamp: 1659455269141
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+  sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
+  md5: d1b3bcc35655a3123acb1fa2ad1a8511
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580828
+  timestamp: 1672387372015
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+  sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
+  md5: 7540555d1fb192236db9a7c5c9d3601c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365765
+  timestamp: 1656431373327
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
+  md5: 0a73533fb6e0dc717ab906a537bc747d
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30803
+  timestamp: 1675441638631
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+  sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
+  md5: 0a959fbad46ab38ade48dbd358002674
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1864757
+  timestamp: 1684280094736
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+  sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
+  md5: ea24b5076ef79e4567c5a3f0cb22b470
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95330
+  timestamp: 1690223465114
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+  sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
+  md5: bcaea6d4a47e9c874becaa700c78dcf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157216
+  timestamp: 1661452617825
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+  sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
+  md5: 707110d1b49cb1864acb0bbaa103591e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 95016
+  timestamp: 1636111184034
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
+  md5: 113a443b9c706f9f9c6187c0eaa3de27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31178
+  timestamp: 1605305861851
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+  sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
+  md5: 85a8d0001db70e52a479155228cb1fe0
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13324979
+  timestamp: 1694439878265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+  sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
+  md5: 47c5e22e31ec05a7bc0ce90065a53afd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 265348
+  timestamp: 1661368839620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+  sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
+  md5: ce9a69e1668aa1e133f2aa6d4e8d346f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 254958
+  timestamp: 1695131709704
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 9ee098c09f31fad7ff1856e5ce2619172eaf979997e7a427d1e05cce32c2af00
+  md5: cac1d1898b69ae9646dfbf082910635d
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40946
+  timestamp: 1685030787453
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+  sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
+  md5: 637f08b19dd8fd87347d8c44f9e3e202
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 170776
+  timestamp: 1698096100056
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+  sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
+  md5: 8ce3ac7d8a04e469b566f1b090d01140
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 470617
+  timestamp: 1657724324011
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
+  md5: 6f2d41dd76a03b7f85a1ed49af1763d6
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95100
+  timestamp: 1690400262627
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
+  md5: b0321e6f14e139fc15b1f8b4acb35d2f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093966
+  timestamp: 1690290944588
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+  sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
+  md5: 62b64576a0aa5f6c3fb05f56650d25e1
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15535
+  timestamp: 1614030509324
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+  sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
+  md5: 15b5595b31e39f08eaacbe2e502d8fb3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67292
+  timestamp: 1696347733587
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+  sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
+  md5: 82e4db6a498480a75d53c55bd35b6478
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1801397
+  timestamp: 1681394807900
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+  sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
+  md5: 63b957927b9949ccb19da28ec4612706
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30902
+  timestamp: 1671751919031
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+  sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
+  md5: e346257a2fa8e2cb48c762138a5d009b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39915
+  timestamp: 1668168959656
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+  sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
+  md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
+  depends:
+  - zlib >=1.2.12,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3536231
+  timestamp: 1654088937695
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+  sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
+  md5: a1bbf0abfb8c45541122c0eb2feee317
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680464
+  timestamp: 1696937112175
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+  sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
+  md5: d689f6203c0a9d04fb229c73d7e80a7a
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125145
+  timestamp: 1679561909274
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
+  md5: 8a292c1ee22489bef2e84bc3aaf4098e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193141
+  timestamp: 1671143985219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
+  md5: 8bf0bfffc11ad06a1c94e145941b0ad4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9651
+  timestamp: 1690297655669
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
+  md5: 343514a174b3485fde55a73f56398dd7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58456
+  timestamp: 1690297648002
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+  sha256: 11e7401cb6805db7ce22b1f9dd6ba5b7941c92225ce440bed1da0af284bfcad4
+  md5: 5c10d68fa5616cdd82ee93ef6e0f038c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11615
+  timestamp: 1659769478980
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+  sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
+  md5: c2242e8fd24003a74ddf37416661e06d
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188757
+  timestamp: 1698257668273
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+  sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
+  md5: 41f445e36b6b6722a9444508eef069f8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20583
+  timestamp: 1607365395045
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+  sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
+  md5: 409ee46ed24267b6da6fb32d13e1f21e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70730
+  timestamp: 1614804271285
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+  sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
+  md5: eb74e74d8e4fd533c55eb98b7b5e83bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102637
+  timestamp: 1695742077778
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+  sha256: cb007615819fd240ea4e343835dfbda3c508a92b5b7158219d30a22d0e67b57c
+  md5: bf215e781ac81e0fc433eedee330c54b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49462
+  timestamp: 1675159191191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+  sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
+  md5: e243baa546432c8394a8059a44a5a3e4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 419227
+  timestamp: 1683113010463
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+  sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
+  md5: fe4ac85ee86d3a94ea3a4ebea3779763
+  depends:
+  - libcxx >=10.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 321797
+  timestamp: 1616055526986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
+  md5: bc7073d9d4c0211cc4a1207c98fb765a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19091
+  timestamp: 1672387204865
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+  sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
+  md5: 8e495591e369ac161857a72011c0a296
+  license: Zlib
+  license_family: Other
+  size: 120272
+  timestamp: 1666595024203
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+  sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
+  md5: f1465fbd810b3746c6de6babfd4fe28a
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1023573
+  timestamp: 1681304595869
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+  sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
+  md5: cf55cb8d7031b30c70c56fc7c782b5c7
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 156104
+  timestamp: 1644482799136
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+  sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
+  md5: 84fce327d9f0d594e86f565e5c21962e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10183
+  timestamp: 1629146082730
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+  sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
+  md5: 84b8b998a741b37abf5312c1c03696ef
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33979
+  timestamp: 1644845817952
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+  sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
+  md5: 77b746931c8f31c3ae393ccb5819d43d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133628
+  timestamp: 1695717890677
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+  sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
+  md5: 3df6e8ba34208dea068890e5d5318cc0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206759
+  timestamp: 1681493095987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
+  sha256: 8c31e7ede4b9a3ec6e1342f02bcff4d7113e5b25f12b91d108616a08eb8eb34f
+  md5: de3ce22af040eb01db773fcab23ef413
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5722206
+  timestamp: 1697490482051
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+  sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
+  md5: bb55f81435cb6e11d264242274fccd1a
+  depends:
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 115947
+  timestamp: 1657175645380
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
+  md5: f860193e14afc7ef3f5b990a2ac003d2
+  depends:
+  - brotli-bin 1.0.9 h1a28f6b_7
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18936
+  timestamp: 1659616204016
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
+  md5: ad53130f3fd1f8d3c2fcbb7496e5585d
+  depends:
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18715
+  timestamp: 1659616188888
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+  sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
+  md5: 0982c046fb976e9f9fb19e7510187a18
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 366983
+  timestamp: 1659616245272
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+  sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
+  md5: 31ac2f5596cb7a44adf073c930641c54
+  license: MPL-2.0
+  license_family: Other
+  size: 133817
+  timestamp: 1694009762858
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+  sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
+  md5: cf1f6c3c34a1e1b9ab22b04233d860f6
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159783
+  timestamp: 1690232303987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+  sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
+  md5: 0eb268e38b5174d471a6e87d9d6102b1
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225355
+  timestamp: 1670423312966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+  sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
+  md5: e68c94666cd60221b575c3814c89bac0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1946451
+  timestamp: 1668084573824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+  sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
+  md5: 1773ae2b080cdd55827e27673351551e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13646
+  timestamp: 1671231171682
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+  sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
+  md5: 53bfd99ad1b09164d537209cffd98161
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 244040
+  timestamp: 1663827469853
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+  sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
+  md5: b62455043c8eb2434466885b19fed2de
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1399573
+  timestamp: 1694211828228
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+  sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
+  md5: eb3cdc0fc210838b9271512a6a1b7c85
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2067708
+  timestamp: 1690905319109
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+  sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
+  md5: f44b80b9405410e5bde6bfe0b31d5b3f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 15135
+  timestamp: 1650293774207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+  sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
+  md5: f87027ccce1361d0f82c0edf1a10d53b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27677
+  timestamp: 1668714367519
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+  sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
+  md5: 1d0bd7e576c64c059ef781dd319ad82a
+  license: MIT
+  license_family: MIT
+  size: 77591
+  timestamp: 1676983230102
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+  sha256: 3e480af22e98246c056bbd91d6be5352df34ff2b8451d9c7f614baeafb450d39
+  md5: 695fe7ccaf6935d3117533d1e6737320
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4542265
+  timestamp: 1698866834303
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+  sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
+  md5: 69eb3b03765627b6159ed23cdde78396
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28399065
+  timestamp: 1692293207812
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+  sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
+  md5: 83366cbd3beb073112f4644a613b6bca
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111933
+  timestamp: 1666125627512
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+  sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
+  md5: 647c1a2f8460ffa8c670a1915bbdb494
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38790
+  timestamp: 1678997152549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+  sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
+  md5: 35e541905426c686ef2ff010a0e502fd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51860
+  timestamp: 1698254731870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+  sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
+  md5: 187d7720aedf38759d122cccb4576f2c
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 219976
+  timestamp: 1691121991680
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+  sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
+  md5: e8e7f10741f9cfa737b310b334940441
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1255894
+  timestamp: 1694181494549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+  sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
+  md5: ff209e75aee17af2e358b0008fbe8c88
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1022945
+  timestamp: 1644315931223
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+  sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
+  md5: d3e78ef296b3c74910d003bd10b475d6
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213972
+  timestamp: 1666908195870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
+  md5: 055e12390b844ea6c6e956ee08a618e8
+  license: IJG
+  license_family: Other
+  size: 273479
+  timestamp: 1677849171867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+  sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
+  md5: 783e2ad3d36472648c5ccc9f3051db3c
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133077
+  timestamp: 1676558732505
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+  sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
+  md5: 0677598f673f9729b5990316170a999d
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 197129
+  timestamp: 1676329661580
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py39hca03da5_0.tar.bz2
+  sha256: cee2cc791937b240be796561ae67e5a7c57b014826fa087fd75b02acf82135ba
+  md5: 141af9befcd79a876ded744de7d1fa8f
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 79928
+  timestamp: 1698937338528
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+  sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
+  md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 401319
+  timestamp: 1671707682572
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+  sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
+  md5: 247558a0aecf1ef7e77a4343761353d6
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64600
+  timestamp: 1672387273585
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
+  md5: a0f206782751dfffed0dd51302a1bf26
+  license: MIT
+  size: 68012
+  timestamp: 1659616138077
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
+  md5: 4c6667cdd061d28e9bc4e4300e4d115e
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 31173
+  timestamp: 1659616155596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
+  md5: 637e9430e258ddf050623ef2360184d8
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 298430
+  timestamp: 1659616172209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+  sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
+  md5: 55c615026c0869f8d3ba657f3bd38c43
+  license: MIT
+  license_family: MIT
+  size: 120389
+  timestamp: 1683716579036
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+  sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
+  md5: a41117710dafe569c9cc4e83f6f29fe3
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1411339
+  timestamp: 1650982753977
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+  sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
+  md5: 98d22e0124d55fae3c37c608dab1dcc9
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 89825
+  timestamp: 1694778225280
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+  sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
+  md5: 0ba499df6755eae5d2d23aa4ab004553
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 642657
+  timestamp: 1692970217410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+  sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
+  md5: c73101971e5ab6a8e8688239884eac81
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241607
+  timestamp: 1692973585084
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+  sha256: ac50f846e93e68d50bfdd5589ea8272b987243a64eba8e2e358ef311d7734001
+  md5: f19270ff954a41dabbfe36ff0656935b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 36040
+  timestamp: 1659783399073
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+  sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
+  md5: 353dff9d5d996c2a260f66381b2ce3e8
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1470815
+  timestamp: 1695058433965
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+  sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
+  md5: c99006da802a97c9aae30da8c16b4820
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176131
+  timestamp: 1670944706815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+  sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
+  md5: 60bd1e037cda86205526f77405d78129
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123361
+  timestamp: 1671541992772
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+  sha256: 2fd690fa3c54a40f0426874ea12e12aad2718263a75708ddd1fa6052a4ad7fb3
+  md5: 81388724babfe9c32ea5cdd93633c342
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 107072
+  timestamp: 1684280007887
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+  sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
+  md5: 34dfd76da78de2eae95bbda390d746d6
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23092
+  timestamp: 1654598007056
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.8.0-py39hca03da5_0.tar.bz2
+  sha256: f6d7d0f791face4d911f5907df48e093cebcd1da188ba3d3267bf858d6dcacaf
+  md5: 6a55e97ce33cd40a280f538dd5437eff
+  depends:
+  - matplotlib-base >=3.8.0,<3.8.1.0a0
+  - python >=3.9,<3.10.0a0
+  - tornado >=5
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8725
+  timestamp: 1698692342704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+  sha256: bf0eeef3c3c713515766ab8b0dc7863413de5b4b227deede97e24d90ca342345
+  md5: a7bba1857eb84fb50caea377e60d2050
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8066509
+  timestamp: 1698692266161
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+  sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
+  md5: eb79dabbeedee7da85dfbfb145bb8a26
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17342
+  timestamp: 1662014601345
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+  sha256: f400ad75dd2890627dc948f3e2e6b19732d02c124723eaf22272026993a94d52
+  md5: 4a4ffc7365e30b18f4443281839e2718
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53505
+  timestamp: 1659721313693
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+  sha256: 20fb26a7ac748ce288cf8483a837b0c33f1348ae738bcdb69cdc2763c7bbf7e1
+  md5: a0aebbc6c170ebd8d4710fd70b3db503
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19562
+  timestamp: 1659716131839
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+  sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
+  md5: 56db7bd3ff511cd839bda081523b3edd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 55683
+  timestamp: 1629356128780
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+  sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
+  md5: 176e0dcaeb28393881bacf69941e3889
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8289638
+  timestamp: 1681756329011
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py39hca03da5_0.tar.bz2
+  sha256: d34fcad560dcc7b8e7df2a0250be9694a02e072aa7f7d4992ebd427665575a8e
+  md5: 5972b5a5fbac5cea54ee0ff2cef85897
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100843
+  timestamp: 1698934268054
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+  sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
+  md5: 150ea9fadddf21993d3328d3e48a18b7
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 557688
+  timestamp: 1668450759059
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+  sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
+  md5: 37163b32508f9f589b3e6462a3a47546
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148426
+  timestamp: 1694616771736
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+  sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
+  md5: 6cdf7cbc43bf40e92b056a5576bd0086
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387216468
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+  sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
+  md5: 0f05853a139b6cda9c73e9d2707a4976
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 590288
+  timestamp: 1690984971741
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+  sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
+  md5: 7de782e4fb34bfa95ef2fc79d27d727d
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22840
+  timestamp: 1668160634885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+  sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
+  md5: 1a7b23113372c5667dbfe45976b9cc5c
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 126357
+  timestamp: 1696515322390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+  sha256: 3cd1161558704176560843586b1b1f9b257fd68c0ca53a2fc09e61267f47514c
+  md5: dd162b2716dc9daf732240a343862d4a
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.26.0 py39ha9811e2_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10388
+  timestamp: 1695830584640
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+  sha256: 5f35d8c0e1768fa3a9d2e75659cd2096bea6b4e021afea114f573e95f4943fb2
+  md5: 958f78b1e2299537996f98da7a930198
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.26.0 py39h3b2db8e_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6313331
+  timestamp: 1695830570878
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
+  md5: 371358a54bbdd307603888348d1a2c6f
+  depends:
+  - libcxx >=12.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD 2-Clause
+  size: 412248
+  timestamp: 1628861367714
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+  sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
+  md5: fa15d3b44ae1360ac9b640bbd5b6923c
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4746123
+  timestamp: 1695322833432
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+  sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
+  md5: d73db95f07a282021efdf8bc09713261
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73620
+  timestamp: 1693575195999
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+  sha256: 247b5e4d81b6d5d013a9c27e1f30c41fff896fed98a68ebda26b19b4062a6828
+  md5: 354a1d65300b4309d53dfa648014e8fe
+  depends:
+  - bottleneck >=1.3.4
+  - libcxx >=14.0.6
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - lxml >=4.8.0
+  - matplotlib-base >=3.6.1
+  - tabulate >=0.8.10
+  - pyqt >=5.15.6,<6
+  - openpyxl >=3.0.10
+  - s3fs >=2022.05.0
+  - pymysql >=1.0.2
+  - beautifulsoup4 >=4.11.1
+  - scipy >=1.8.1
+  - xlsxwriter >=3.0.3
+  - fastparquet >=0.8.1
+  - xlrd >=2.0.1
+  - blosc >=1.21.0
+  - zstandard >=0.17.0
+  - psycopg2 >=2.9.3
+  - pyarrow >=7.0.0
+  - pandas-gbq >=0.17.5
+  - pytables >=3.7.0
+  - sqlalchemy >=1.4.36
+  - odfpy>=1.4.1
+  - numba >=0.55.2
+  - jinja2 >=3.1.2
+  - pyreadstat >=1.1.5
+  - gcsfs >=2022.05.0
+  - qtpy >=2.2.0
+  - html5lib >=1.1
+  - xarray >=2022.03.0
+  - fsspec >=2022.05.0
+  - dataframe-api-compat >=0.1.7
+  - pyxlsb >=1.0.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13257999
+  timestamp: 1697478739906
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
+  sha256: 90a1889cd0004bfc5e12ac94b4ea92718a473373033bb0ba5259804ed67bf2bc
+  md5: e89f615737385fee88150ab4adf037e6
+  depends:
+  - bleach
+  - bokeh >=3.2.0,<3.4
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.0.0,<3
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.17.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17147015
+  timestamp: 1698866800249
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
+  sha256: 0ae09c974297767a707642344c40f484281f0a3000251a6234e46ef19f00c10e
+  md5: 64a0eaf3381e9f6aa971229501710798
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189313
+  timestamp: 1698263486159
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+  sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
+  md5: 6e01c592ae3b8ff2d12cae76f2f4276b
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 715239
+  timestamp: 1696580071596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+  sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
+  md5: 9fb8f460c130d56caf33c6bbe46fbe8a
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2678841
+  timestamp: 1697548790931
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+  sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
+  md5: 390b8c3cd74281abecdbfd51476922f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33033
+  timestamp: 1692205747301
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+  sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
+  md5: 7896828fb3565fefad43f980d50c8723
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91190
+  timestamp: 1659455206354
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+  sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
+  md5: d934c74eb66d01af0f45f0881f4bab77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580588
+  timestamp: 1672387390426
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+  sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
+  md5: 9858166e5ffb624c8b9d281f4000d725
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 367167
+  timestamp: 1656431368885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+  sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
+  md5: 4d2b45c6be8221e6a3e44c2d5838426f
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30843
+  timestamp: 1675441531640
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+  sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
+  md5: 02521df4e2e79f75faa9cbb3560ab1dd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1861763
+  timestamp: 1684280026169
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+  sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
+  md5: bdebe59bffc7adbad83fdcd9d429a5f5
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95234
+  timestamp: 1690223494699
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+  sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
+  md5: d716e5c9b5eec45ce1df8eb52cab817a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157408
+  timestamp: 1661452601692
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+  sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
+  md5: 1907629863ed8e7c35ead232dae7693f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 91636
+  timestamp: 1628941083263
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+  sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
+  md5: 847b9bddf2a86e1609c0d53bbc23ea79
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 27378
+  timestamp: 1626781391140
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+  sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
+  md5: 18aa18bd0d260605923877921d26cc74
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13194025
+  timestamp: 1694438901368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+  sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
+  md5: 45642a99c83e7aed74d1ffab1f20145b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 266647
+  timestamp: 1661368655993
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+  sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
+  md5: fec748525144049a2fc7f52f9755232c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257235
+  timestamp: 1695131702047
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+  sha256: 960192a143672e9c1d6fe4027af448512d91eee7501e5c245c21b865cf8bf429
+  md5: 76d491244218505f071ba56a308673df
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40950
+  timestamp: 1685030774581
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+  sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
+  md5: 3445d25415998c807efbe64d3a7e03c8
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 167068
+  timestamp: 1698096118071
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+  sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
+  md5: e6e92da28e9b0e428ed4b7df417bec25
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 472418
+  timestamp: 1657724315435
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+  sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
+  md5: dba22515f36d3c266de5896350813ea2
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95103
+  timestamp: 1690400315537
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+  sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
+  md5: 3cd7eb43e285faba76faf67667e26b00
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093916
+  timestamp: 1690290951258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+  sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
+  md5: c5e9aef0d6895de1c927e9d796cd7cd3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15691
+  timestamp: 1629145910454
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+  sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
+  md5: 0f7c229e774146ffc4e29dedf75372bf
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67279
+  timestamp: 1696347632563
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+  sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
+  md5: 2302a79a045f152e183a52a81adfba62
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1674163
+  timestamp: 1681394762218
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+  sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
+  md5: 4ae67163d55cf9df83d4027ebc38c501
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30894
+  timestamp: 1671751931536
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+  sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
+  md5: dbb5c0cddb6661a89afee647fd3dc01e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39875
+  timestamp: 1668168874870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+  sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
+  md5: 667e60c8b407d73cbba40f44901f4f00
+  depends:
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3412693
+  timestamp: 1654088929697
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+  sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
+  md5: 884f788a5f6a664c9b79f7a4a60362d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680561
+  timestamp: 1696937004165
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+  sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
+  md5: 639a4f489af172c866c18442948e5874
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - slack-sdk
+  - requests
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125170
+  timestamp: 1679561942932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+  sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
+  md5: e5b90eba83fddba6d7aa6072b5bf7c91
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193017
+  timestamp: 1671143921826
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
+  md5: 644ef8830437070f60efcfcd6a987198
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9670
+  timestamp: 1690297532002
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
+  md5: a902a833bb186a2f1a4b2b89b1195136
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58466
+  timestamp: 1690297524418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+  sha256: 536045a8a172c651fd306c285a6d7409775f018dac944f2124c538ccfb195e28
+  md5: d4dc6cdf0812191b9ec78b35b4fdf3e0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11593
+  timestamp: 1659769477205
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+  sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
+  md5: f3f1d2c1028dad2f11ff950a15c99dbf
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188640
+  timestamp: 1698257577209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+  sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
+  md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20091
+  timestamp: 1629144441130
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+  sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
+  md5: 3089c63bf8f4d0423e1a287da286d83e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70923
+  timestamp: 1629357115820
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+  sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
+  md5: 5886b30b312445471268444f41f39dc7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102583
+  timestamp: 1695741976083
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+  sha256: 105e39d3eb51b47c7244b3379c0133ab7051966664f52835453b14509215b159
+  md5: ed20012c2cd99ffd04cca9929e0bc061
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49775
+  timestamp: 1675159079039
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+  sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
+  md5: 2e75ad6a09c308268192efe03cc9ebf4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 411778
+  timestamp: 1683113019715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+  sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
+  md5: 30f666bf97c26587c5d2f68cc5f330ab
+  depends:
+  - libcxx >=12.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 316901
+  timestamp: 1629287855861
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+  sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
+  md5: 584e591d36dcd5ba5c45404f0f7ebb2d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19076
+  timestamp: 1672387153578
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+  sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
+  md5: 467ae28215d1aa1c5688bc0c8a184269
+  license: Zlib
+  license_family: Other
+  size: 103525
+  timestamp: 1666595022664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+  sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
+  md5: 7cfbed15f1feee1422810f7830075f53
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 779464
+  timestamp: 1681304594848
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+  sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
+  md5: ed14f9bc6e55220483f1a5a388625a08
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162772
+  timestamp: 1644481986085
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+  sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
+  md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 39253
+  timestamp: 1644551767970
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+  sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
+  md5: b24d13c443a26f65a0778b475a5726bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132830
+  timestamp: 1695717959996
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+  sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
+  md5: 302c3c0696e17eaa62e140e3892644ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 199723
+  timestamp: 1681493196911
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
+  sha256: 812f268862208c2518b5187809a8571adb488de3604d512721035e65458dde76
+  md5: 97ce620b7dd3ee743d0ca28ed66ace74
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5721832
+  timestamp: 1697491241383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+  sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
+  md5: bf930260f679bc74227bbb18bc36ae82
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 119700
+  timestamp: 1657176150595
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
+  md5: 507dfe693ef429f466d964b599f4af21
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_7
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 18650
+  timestamp: 1659616328001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
+  md5: d0bf43e8df60baae3b3105aa5c42a791
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 21153
+  timestamp: 1659616312367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+  sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
+  md5: 7bd24bf94c24e810aecaaf84a0978e6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 343204
+  timestamp: 1659616543542
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+  sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
+  md5: 092b417c11edcbe6bb9b765ab4a55d23
+  license: MPL-2.0
+  license_family: Other
+  size: 164999
+  timestamp: 1694009822357
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+  sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
+  md5: 708a750d370b9d6875651021e21c4446
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159322
+  timestamp: 1690232335307
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+  sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
+  md5: c35736da3ea26782425e78061268cf5e
+  depends:
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 228713
+  timestamp: 1670423312743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+  sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
+  md5: 457a4339a53c033d48ce0c72e5038d2e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30330
+  timestamp: 1672387265402
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+  sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
+  md5: 59ec65fd9e06b81a65cc12986c67d5da
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1939614
+  timestamp: 1668084794027
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+  sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
+  md5: 3489c1a2b73fc957b5a62cc59349e25b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13438
+  timestamp: 1671231196438
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+  sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
+  md5: 3492b96083c1e904cc32d26ea7f1e1d8
+  depends:
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184280
+  timestamp: 1663827558327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+  sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
+  md5: f46d904bc6f220327e70474971341f52
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1220835
+  timestamp: 1694445639066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+  sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
+  md5: 2ff4fb509788b0e47ac684ba151394d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3289966
+  timestamp: 1690907040646
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+  sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
+  md5: 0f166c3e70541d8bee6e9d0cb60fb66e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16979
+  timestamp: 1649926678161
+- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+  sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
+  md5: ea93d413944ca6a8677eb1b284b136ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27388
+  timestamp: 1668714577678
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+  sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
+  md5: 9f167d3e45441bc3633c1974b1b0ce8c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 88421
+  timestamp: 1676983264486
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+  sha256: fa8f868e49721ca19912f816a6da221172758f9e3d28d8b31d53249fb14dc25f
+  md5: 09f9a2cea9425d76dccf9b026afe5bb2
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4576915
+  timestamp: 1698866895838
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+  sha256: 945f4521793d7d279532d1ccd5157201c5cbf64f846bfe60249d01e1b4edf295
+  md5: 0accae23d095c165ac731f4a1f3ca497
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 37021132
+  timestamp: 1692294548916
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+  sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
+  md5: 30fdefd1541c789c163751291a8faa88
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111448
+  timestamp: 1666125667599
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+  sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
+  md5: a10f07c7a3510272a296f9fed458a4ed
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38098
+  timestamp: 1678997241511
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+  sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
+  md5: fad9cf2023d807da8d44996e9d4399a0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51490
+  timestamp: 1698254721864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+  sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
+  md5: 9834848bd7c7759acf12e78d09388563
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3891030
+  timestamp: 1681801474383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+  sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
+  md5: 1285c8c628bc912c54d0968574c9f4c9
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217232
+  timestamp: 1691122695748
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+  sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
+  md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
+  depends:
+  - backcall
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1279433
+  timestamp: 1694181820978
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+  sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
+  md5: f5fcce35d3f21cdfc5893c5a7a86c651
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1035394
+  timestamp: 1644315567034
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+  sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
+  md5: f67fe3337528e2886f1ac3ab8ac37985
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213110
+  timestamp: 1666908350218
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
+  md5: 81f2c343dc4c65eea39c45383272068f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 407861
+  timestamp: 1677849239400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+  sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
+  md5: bd9526d38a145fe311a8aa36bc11e071
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 152006
+  timestamp: 1676558783570
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+  sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
+  md5: a00e6a62956fde3c4135464353ee8a53
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229158
+  timestamp: 1676330909084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py39haa95532_0.tar.bz2
+  sha256: e840d6b322faa7d5fee2c54ed6074e3a6b7fe38a9356020a4027d9e09c40a1a1
+  md5: 038bb985c0d43bf77a8e772f4c4ad22a
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 103854
+  timestamp: 1698937448209
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+  sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
+  md5: 5efa1332f7c0a8d9638eda02170c4ce5
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pywinpty
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 413653
+  timestamp: 1671707957673
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+  sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
+  md5: 891fe66a24d8714737b2874985ee1303
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62298
+  timestamp: 1672388166096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+  sha256: ef6b0347ae565dd648a2bb40bc8b0b30f2e4f8387778fefced1d581b7d5a3e16
+  md5: 8ef1d5919aa55fe56ef34d9a7969dca7
+  depends:
+  - openssl 3.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 861982
+  timestamp: 1684424430941
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
+  md5: c345f51706eef530454f66b794e5e574
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 68189
+  timestamp: 1659616216976
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
+  md5: a7400cfb72042977bc047909ed504ce8
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 33743
+  timestamp: 1659616248209
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
+  md5: 6307f6854754ab5bd7c84e6998385bb1
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 733177
+  timestamp: 1659616279453
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+  sha256: bb17beae8860a83d081d57273825b46bf8fe9903f3b4182ab41a7ae2c7274859
+  md5: 94182f4ab8beb4eddfd8167b2e2b0380
+  depends:
+  - libclang13 14.0.6 default_h8e68704_1
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 147804
+  timestamp: 1681225547009
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+  sha256: 01b84a38c9069e7b8e6fa2a07707e785df7d40b8f01d76a504e98e5a5cd58539
+  md5: 22c9f7e59174c49f06e3c5c9384401ce
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 25699299
+  timestamp: 1681225463612
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+  sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
+  md5: b812bc5d9c76242e2bb2ac87afe7d39b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 730280
+  timestamp: 1650983734373
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
+  sha256: a36ea5c77075e90f47d3f5c1e2081c0c1c78c5c0a5135bf9a6448fca67bbc79d
+  md5: a0a02817a7def0563d1635035c26451b
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - openssl >=3.0.8,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  size: 3827890
+  timestamp: 1687382140999
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+  sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
+  md5: ba9418df9288a2f031a02fa35b774ce0
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78524
+  timestamp: 1694778314659
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+  sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
+  md5: 6ece7f1a3248169837714d05d7f6ef0a
+  depends:
+  - libiconv >=1.16,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 3513910
+  timestamp: 1692971505729
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+  sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
+  md5: bd7ec244935e83e850a4ff34e8e2e64f
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 513971
+  timestamp: 1692973657152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+  sha256: e1c0e745d9ba36a80773e841d96bf514ad1ceda419e4188aad3c22782af00234
+  md5: f226532e9bb308f20e874c56be6ceefb
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 35788
+  timestamp: 1659783414586
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+  sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
+  md5: fb7881e74b59262df0fa4ec981964efc
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1244887
+  timestamp: 1695058550693
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+  sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
+  md5: 6970c7f46b0164cad1d210e7a1419959
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143434
+  timestamp: 1670944902624
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+  sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
+  md5: 1015298551c040c6d5e26eebbae12ef5
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142316
+  timestamp: 1671542240512
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+  sha256: ab5c246c2b271acc1cdd0b9343989c0166681536e569cdbe71618f55d34c7292
+  md5: 7ce68d771cd94c9ff5efefe69d327c9a
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 125122
+  timestamp: 1684280210213
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+  sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
+  md5: 466da740fafef3d6bce114220f0be306
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28510
+  timestamp: 1654508162239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.8.0-py39haa95532_0.tar.bz2
+  sha256: 3ee1e0b89c9a16ed21af80d9883d7638227028cac76ab24b5dcb4aa25dcd5536
+  md5: 0ec5d4cee9f74324b4bf0a653e53681b
+  depends:
+  - matplotlib-base >=3.8.0,<3.8.1.0a0
+  - pyqt >=5
+  - python >=3.9,<3.10.0a0
+  - tornado >=5
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8485
+  timestamp: 1698692858409
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+  sha256: 1687ae122ee7d8b583141fc5014b76d494841dc8083b854449e3d6e0f6bb7019
+  md5: 3697ac26ee3c2d49338dd5b9c6551152
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8080067
+  timestamp: 1698692812610
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+  sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
+  md5: a9fa43e694b25cd49b8b08a9eefd696e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18054
+  timestamp: 1661915903969
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+  sha256: 8aa14047fac6ef8b326900c4bf1a960eaa7a1699c18fdf1e75a59101b610b6df
+  md5: 7e1d4d4700fbea6171d30f1d5ad24226
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53362
+  timestamp: 1659721308586
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+  sha256: 2017814a7cc93dd51c6b7c016e3cdf8fbc32fa20f985638aaff6a6377e9ee086
+  md5: a1a285c56b001c3b5c591bf21eec3149
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19326
+  timestamp: 1659716205153
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+  sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
+  md5: 248c468abced874f0231d3cc23177c77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58488
+  timestamp: 1607359497934
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+  sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
+  md5: 5e763c995ff0c549f68a10bce70fede4
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187489950
+  timestamp: 1691503804820
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+  sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
+  md5: dd0c2ece6a743c373c9b5a5919b4818f
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49744
+  timestamp: 1682975040154
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+  sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
+  md5: 57cea8df7ab85f2a98f64d23afcb1f90
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184956
+  timestamp: 1695058491736
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+  sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
+  md5: 8769cdd201d905069800488fe31574e5
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 256221
+  timestamp: 1695060152521
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+  sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
+  md5: d9781492332e6326f9fca87f3a8efacd
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8135792
+  timestamp: 1681756491399
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py39haa95532_0.tar.bz2
+  sha256: 49715dd545469a4458cdf0d0d55c9a7af7cb7a2da8a6504a60dd3089714015ae
+  md5: 4257087772bed974078f56673ca50d99
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119351
+  timestamp: 1698934436390
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+  sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
+  md5: f1d8ce412e115986c403f223b3b47d0f
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 596314
+  timestamp: 1668451106600
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+  sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
+  md5: f96bbef0985d7e66ebf00c0d55e30e23
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 167045
+  timestamp: 1694617078743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+  sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
+  md5: 6e6ba64c8dc5025aeac606404a8df36a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13786
+  timestamp: 1672387480065
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+  sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
+  md5: 4a7a3286484766741f627696697c362c
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 609425
+  timestamp: 1690985686105
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+  sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
+  md5: 4269a1f93882205b90d4b2ae78fc82d5
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22417
+  timestamp: 1668160717305
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+  sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
+  md5: a18a576b7024cfd6f905c526a786a916
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 135285
+  timestamp: 1696515698492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+  sha256: e5e11f9b42d770ee46ac24d1cdf7aa4e9c49a60a607c8c28e7729131a99eadd5
+  md5: 4274d06db8a9a381c072d226d0322dc0
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.0 py39h65a83cf_0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9835
+  timestamp: 1695830845329
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+  sha256: dcaa1607ce40a0ed610dd5398e125c8e5b08e738e50b6037a8c72b49ca561ff2
+  md5: d99d990a60644b97ba1ff9bb8da0e66f
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.26.0 py39h055cbcc_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6778113
+  timestamp: 1695830816710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
+  md5: ab07e2a27ac08afe3d0b4c0890b8486a
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 2-Clause
+  size: 249316
+  timestamp: 1630094024143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+  sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
+  md5: 73b17037d87b5a58feb34dafc0538f7f
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8058396
+  timestamp: 1695324589828
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+  sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
+  md5: df1d746ba8d5d6ba01ac1373b9b71e1a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73016
+  timestamp: 1693575484990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+  sha256: 1994e5831fd421bd6cf85916073d4012dec53e673b672b3985efaf771f0a7bf8
+  md5: c486a5b51e3227f6ea564a9dd3125e45
+  depends:
+  - bottleneck >=1.3.4
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - openpyxl >=3.0.10
+  - jinja2 >=3.1.2
+  - qtpy >=2.2.0
+  - numba >=0.55.2
+  - pyreadstat >=1.1.5
+  - zstandard >=0.17.0
+  - xlrd >=2.0.1
+  - tabulate >=0.8.10
+  - fsspec >=2022.05.0
+  - pyqt >=5.15.6,<6
+  - xarray >=2022.03.0
+  - xlsxwriter >=3.0.3
+  - beautifulsoup4 >=4.11.1
+  - html5lib >=1.1
+  - fastparquet >=0.8.1
+  - pyarrow >=7.0.0
+  - pyxlsb >=1.0.9
+  - matplotlib-base >=3.6.1
+  - odfpy>=1.4.1
+  - pytables >=3.7.0
+  - sqlalchemy >=1.4.36
+  - psycopg2 >=2.9.3
+  - blosc >=1.21.0
+  - lxml >=4.8.0
+  - pymysql >=1.0.2
+  - gcsfs >=2022.05.0
+  - pandas-gbq >=0.17.5
+  - dataframe-api-compat >=0.1.7
+  - s3fs >=2022.05.0
+  - scipy >=1.8.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12629931
+  timestamp: 1697479885371
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
+  sha256: 270e4c3ab0f0c8d8f31fa0e45bc516c1e41be618a5c66e1c86dc39ce76cb2372
+  md5: cad52ba9eb391416112f0994b6c35249
+  depends:
+  - bleach
+  - bokeh >=3.2.0,<3.4
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.0.0,<3
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.17.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17162886
+  timestamp: 1698867967809
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
+  sha256: 56eaf7f4b1bb81e3deed55711dd2ee78f244a3cc0ad4bb7a1f09d97e46f9793f
+  md5: c24a3daed1e85ba7a100fa6966c5bb48
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189021
+  timestamp: 1698263520538
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+  sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
+  md5: 427c1450bebb632f43bbc8c83006e4cd
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 806931
+  timestamp: 1696580240310
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+  sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
+  md5: 21790cd3e2b8a45c4104aff0a68330d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3001751
+  timestamp: 1697549357662
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+  sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
+  md5: 56f44a1054da2d10777e375838191070
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 32355
+  timestamp: 1692205784293
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
+  sha256: bbcef9bbf4ccd051becaa7d8aa88cb5f46ff64570cc395b6a471332d8b900e11
+  md5: 0daf62b71923d157544576122b0fa79d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-clause
+  license_family: BSD
+  size: 82560
+  timestamp: 1607021261834
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+  sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
+  md5: 8a35ad65651086575ce55371f22feda8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91045
+  timestamp: 1659455316472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+  sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
+  md5: 186eb95f816a2eff80c3c7f7d964c7b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 578514
+  timestamp: 1672388155359
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+  sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
+  md5: 47b6cbe6ce9289e47d16900b03596a91
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372807
+  timestamp: 1656431445633
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+  sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
+  md5: 07165c444adc7c7ccc8a345875adc5ef
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48408
+  timestamp: 1675450623287
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+  sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
+  md5: d58e76a31e2f6e7410ba4afd7f385b0d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1877445
+  timestamp: 1684280183367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+  sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
+  md5: 0e5b0fe7debbf558ce97090f6b67cdae
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94633
+  timestamp: 1690225630423
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+  sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
+  md5: 0fde797653e4ab589506121fb1e37555
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157119
+  timestamp: 1661452591647
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
+  sha256: e70028d0250602c01feac17e60fafd371daee5d731917732b7eced4ab47b3243
+  md5: 72a51c0d49711d22a39aefc04fa0c328
+  depends:
+  - pyqt5-sip 12.13.0 py39h2bbff1b_0
+  - python >=3.9,<3.10.0a0
+  - qt-main 5.15.*
+  - qt-main >=5.15.2,<5.16.0a0
+  - sip >=6.7.12,<6.8.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 5007361
+  timestamp: 1698781683371
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
+  sha256: 6eb0c4f2e8acaa6dfaf1fb5b4b34f13d366ebf11d77e14a674a26d7fabbc7981
+  md5: 9354d98a97abd4715cdf63d4a28f7645
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 84071
+  timestamp: 1698769559444
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+  sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
+  md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 92679
+  timestamp: 1636093365041
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+  sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
+  md5: f870859d4dc7a8d82cf3546bd9035f33
+  depends:
+  - python >=3.9,<3.10.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 54520
+  timestamp: 1605307564142
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+  sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
+  md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
+  depends:
+  - openssl >=3.0.10,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 21172845
+  timestamp: 1694442462066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+  sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
+  md5: 9d99075052265ae3d718582d3b875038
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269964
+  timestamp: 1661376543480
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+  sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
+  md5: fa9074d94236c9b768bfd2c858875b27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 264836
+  timestamp: 1695131770282
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+  sha256: 97243a31c39f4990c0e9d4f2307f2f7fb9421553303923bc105067ec4340bdff
+  md5: 8078c5760f27398eaf1082226647d137
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40145
+  timestamp: 1685031143383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+  sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
+  md5: 3d2841085778006c2e79f9c7300f8b9d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13565975
+  timestamp: 1669937633869
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+  sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
+  md5: 54a4bc0724041dd173088419d6ede2af
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 239062
+  timestamp: 1677611495106
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+  sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
+  md5: f39f84115e228bad4bceaefdd637f022
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 158558
+  timestamp: 1698096358091
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+  sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
+  md5: df398a3a1668fd2a22061764e20ea91d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.4,<4.3.5.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 460913
+  timestamp: 1657616061604
+- conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
+  sha256: 409f9fad42cbae8d915d1703d87db6af9f951b150517daa4e1c0220cc5eb7b0f
+  md5: 2b17abf94b02a6c5ba6b7623dba97ff9
+  depends:
+  - icu >=73.1,<74.0a0
+  - jpeg >=9e,<10a
+  - krb5 >=1.20.1,<1.21.0a0
+  - libclang >=14.0.6,<15.0a0
+  - libclang13 >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=12.15,<13.0a0
+  - openssl >=3.0.10,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  constrains:
+  - qt >=5.15.2,<6
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 69829482
+  timestamp: 1693228189080
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+  sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
+  md5: 38db77ece9dc76feffb9ef7638e38258
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94397
+  timestamp: 1690400496655
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+  sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
+  md5: 3e284ae6b48ee30c364ffdc5601610b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1099842
+  timestamp: 1690291374842
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
+  sha256: ed2b75ca1bb075901550bf892aa18a46a563e512e28ad5fe1b36e7ed3c6708d0
+  md5: 22779fae19f454e13656af8b737f8bd3
+  depends:
+  - packaging
+  - ply
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - tomli
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-SIP_License OR GPL-2.0-or-later OR GPL-3.0-or-later
+  license_family: GPL
+  size: 602624
+  timestamp: 1698676202396
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+  sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
+  md5: 993b3886b334bd1f49d34206f21997b4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15998
+  timestamp: 1614030572433
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+  sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
+  md5: 7ac9604ad7564ac0c71bff5db198656f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67012
+  timestamp: 1696347795139
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+  sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
+  md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1311308
+  timestamp: 1681402905668
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+  sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
+  md5: 28b9869d8d3a839918fac4a08f38cbc2
+  depends:
+  - python >=3.9,<3.10.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30546
+  timestamp: 1671752127904
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+  sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
+  md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39590
+  timestamp: 1668168880994
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+  sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
+  md5: 52cdcdb96383c010ca833a7c24b3935b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Tcl/Tk
+  license_family: BSD
+  size: 3690152
+  timestamp: 1654036853710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
+  sha256: 86a1b449d27205327a5de0f81d18d9ad768e68d915b91b1d5b82be2d8f524e94
+  md5: 78a8a9f8c638df9a2db80964c97ff43f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 25476
+  timestamp: 1657175730463
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+  sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
+  md5: 0e054ab29119cf4c1f778613acf972f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 681780
+  timestamp: 1696937326924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+  sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
+  md5: b6ad839ebba536ad1c3cc58d0e2123f0
+  depends:
+  - colorama
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 143681
+  timestamp: 1679562248929
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+  sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
+  md5: fe78de10019085146f1cc6c94fdc2620
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192822
+  timestamp: 1671143999327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
+  md5: ca5fc3fbdb09b6de068a8b7a8869369f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9208
+  timestamp: 1690298120549
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
+  md5: a86e87a10e5fdff486265e0c675fb99f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57922
+  timestamp: 1690298106990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+  sha256: 8057d3d2a0acd44496de33c5b222063c3f7d06b90c74fbbda45bd18b0b324219
+  md5: 398f8db5bd8cab84b3d85a9d85fa4889
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11362
+  timestamp: 1659769459206
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+  sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
+  md5: 0d31859e0a097aedbcc1627db33b3d92
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188367
+  timestamp: 1698257883295
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+  sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
+  md5: 45ef24c486a484f079faf1dc90e4c7e9
+  depends:
+  - vs2015_runtime >=14.27.29016
+  license: Modified BSD License (3-clause)
+  license_family: BSD
+  size: 8277
+  timestamp: 1605602889180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+  sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
+  md5: 4daaceb6cfc1af6274509081d8018ef1
+  size: 2316783
+  timestamp: 1605602872095
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+  sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
+  md5: 916c16904615c7af3b5d37cb6694f45e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21084
+  timestamp: 1607347371925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+  sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
+  md5: da69e6987fcc757e83a358ceaa13f62b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73391
+  timestamp: 1614804425587
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+  sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
+  md5: 23b9f4634b2e5450be617114f62c74f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 120873
+  timestamp: 1695742300539
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+  sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
+  md5: 120f0b088290fc17bd6618fc10a2f0c4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PUBLIC-DOMAIN
+  size: 34293
+  timestamp: 1605306211299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+  sha256: a5d2a216d052105fdaad7256f23da3b29f95100d1dc0f29b6ab1f3bbc75e17a9
+  md5: a558f681ebc243f86cde2515c065b62e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48805
+  timestamp: 1675159123654
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+  sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
+  md5: c3f7871e9a33adeccee1b1e8e216918e
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 1332571
+  timestamp: 1683113347814
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+  sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
+  md5: 1ab55f8c4b5292ec360c572120bf823e
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-3.0-or-later
+  size: 9430705
+  timestamp: 1616055773485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+  sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
+  md5: 6875e0bf3828707dc9165d694c0d0a7d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18725
+  timestamp: 1672387612937
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+  sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
+  md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 148931
+  timestamp: 1666595229032
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+  sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
+  md5: 8d6a1e767775fe0eb617cd6e22edc2ff
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1871867
+  timestamp: 1681304638261

--- a/square_limit/pixi.toml
+++ b/square_limit/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "square_limit"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/square_limit/pixi.toml
+++ b/square_limit/pixi.toml
@@ -1,0 +1,30 @@
+[workspace]
+name = "square_limit"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2019-06-10"
+maintainers = ["jlstevens", "jbednar"]
+categories = ["Mathematics"]
+labels = ["holoviews", "matplotlib"]
+description = "Recreating the Square Limit woodcut by M.C. Escher using Holoviews Spline"
+no_data_ingestion = true
+
+[dependencies]
+python = "3.9.*"
+notebook = "*"
+holoviews = "*"
+matplotlib = "*"
+numpy = "*"
+pandas = "*"
+param = "*"
+pip = "*"
+setuptools = "*"
+wheel = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks]
+notebook = "jupyter notebook square_limit.ipynb"

--- a/square_limit/pixi.toml
+++ b/square_limit/pixi.toml
@@ -19,12 +19,12 @@ matplotlib = "*"
 numpy = "*"
 pandas = "*"
 param = "*"
-pip = "*"
-setuptools = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+setuptools = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks]
 notebook = "jupyter notebook square_limit.ipynb"

--- a/sri_model/pixi.lock
+++ b/sri_model/pixi.lock
@@ -7,709 +7,709 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.3.0-py39h2f386ee_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39hdda0065_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cyrus-sasl-2.1.28-h52b45da_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.5.0-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.14.1-h4c34cd2_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.69.1-he621ea3_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.1-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.1-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang-14.0.6-default_hc6dbbc7_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang13-14.0.6-default_he11475f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcups-2.4.2-h2d74bed_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20221030-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpq-12.15-hdbd6064_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxkbcommon-1.0.1-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.10.4-hf1b16e4_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.37-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.9.3-py39hdbbb534_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.8.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mysql-5.7.24-h721c034_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.0-py39h5f9d8c6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.0-py39hb5e798b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.11-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.1.1-py39h1128e8f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.3.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ply-3.11-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.15.10-py39h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt5-sip-12.13.0-py39h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.18-h955ad1f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-main-5.15.2-h53bd1ea_10.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.11.3-py39h5f9d8c6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-6.7.12-py39h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tomli-2.0.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py39h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-3.3.0-py39h2f386ee_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39hdda0065_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cyrus-sasl-2.1.28-h52b45da_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/expat-2.5.0-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fontconfig-2.14.1-h4c34cd2_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/glib-2.69.1-he621ea3_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gst-plugins-base-1.14.1-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gstreamer-1.14.1-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.18.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libclang-14.0.6-default_hc6dbbc7_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libclang13-14.0.6-default_he11475f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libcups-2.4.2-h2d74bed_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20221030-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpq-12.15-hdbd6064_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxkbcommon-1.0.1-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxml2-2.10.4-hf1b16e4_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.37-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lxml-4.9.3-py39hdbbb534_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-3.8.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mysql-5.7.24-h721c034_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/networkx-3.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.0-py39h5f9d8c6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.0-py39hb5e798b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.11-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-2.1.1-py39h1128e8f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-1.3.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-2.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ply-3.11-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyqt-5.15.10-py39h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyqt5-sip-12.13.0-py39h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.9.18-h955ad1f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/qt-main-5.15.2-h53bd1ea_10.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scipy-1.11.3-py39h5f9d8c6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sip-6.7.12-py39h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tomli-2.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py39h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.8.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-3.8.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/networkx-3.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.8.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-3.8.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/networkx-3.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.8.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-3.8.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/networkx-3.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
   sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
   md5: 613805add1c05b538ff06d217252feb7
   depends:
@@ -720,7 +720,7 @@ packages:
   license: BSD-3-Clause
   size: 20810
   timestamp: 1652859733309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
   sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
   md5: 2cf39d906cc321896ffe3e5d33d80c5c
   depends:
@@ -733,7 +733,7 @@ packages:
   license_family: MIT
   size: 162166
   timestamp: 1644463608931
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
   sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
   md5: 2972a84e0e22ae3244bbd2f1eebcf536
   depends:
@@ -744,7 +744,7 @@ packages:
   license_family: MIT
   size: 35352
   timestamp: 1644569715988
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
   sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
   md5: a68016b4b06460def24cb69d932986f3
   depends:
@@ -753,7 +753,7 @@ packages:
   license_family: MIT
   size: 132486
   timestamp: 1695717963702
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
   sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
   md5: 2f6356a2f530314b4059c08c79a3d8bc
   depends:
@@ -763,12 +763,12 @@ packages:
   license_family: MIT
   size: 205868
   timestamp: 1681493113570
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.3.0-py39h2f386ee_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-3.3.0-py39h2f386ee_0.tar.bz2
   sha256: f2a4f2dbea826cfaf59d09e53a4bb951ffd77becb2f53f5b4ddb6ef63cdd5210
   md5: 1d420e8258cf81e6cebc7320e5cf6a0a
   depends:
@@ -786,7 +786,7 @@ packages:
   license_family: BSD
   size: 5706055
   timestamp: 1697490557655
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
   sha256: 20e381c665853131fc5c9a397b1d4b05bb05859a2bdfbb0559e85ec445ee9e7c
   md5: 14dc3c2e8eb68b1111a08de9a3ce8a00
   depends:
@@ -797,7 +797,7 @@ packages:
   license_family: BSD
   size: 128656
   timestamp: 1657175966755
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
   sha256: 11df9b719339bb40e4af8eb124a094def217f64e2440af973d7342da19c030b0
   md5: 712827b1699cc71e6240626c413408f3
   depends:
@@ -808,7 +808,7 @@ packages:
   license: MIT
   size: 18907
   timestamp: 1659616178155
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
   sha256: 6408b6849347ef01f5ed170f4b35fb4bdfed2d9cf9da4912a4b104a810518a80
   md5: d9d570587ccfd7158b66feb823c990c6
   depends:
@@ -818,7 +818,7 @@ packages:
   license: MIT
   size: 19933
   timestamp: 1659616170430
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
   sha256: 8507df3357958556aff2dea8788a3f7ddad6172fd9fe5d1bdb6c3afe9686d2f8
   md5: f0204f72bcd9ef836218cc74345e69f2
   depends:
@@ -828,14 +828,14 @@ packages:
   license: MIT
   size: 362180
   timestamp: 1659616255400
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
   sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
   md5: 3ef00f4c5278b688552efc259c463dc8
   license: MPL-2.0
   license_family: Other
   size: 132731
   timestamp: 1694009767372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
   sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
   md5: d5cb3d97cf5e85ffe5e94037ed8a1169
   depends:
@@ -844,7 +844,7 @@ packages:
   license_family: Other
   size: 159077
   timestamp: 1690232254640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
   sha256: e99314f8809d65195dcab68a9783f70fbe990113a66c98c9b0a7ffea01226b71
   md5: fff69f95079191a10e099b21a5fd4bc3
   depends:
@@ -856,7 +856,7 @@ packages:
   license_family: MIT
   size: 234749
   timestamp: 1670423281079
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
   sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
   md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
   depends:
@@ -866,7 +866,7 @@ packages:
   license_family: CC
   size: 1917831
   timestamp: 1668084545510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
   sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
   md5: 13702d3b4b744784e5bd559c7050dd6f
   depends:
@@ -876,7 +876,7 @@ packages:
   license_family: BSD
   size: 12719
   timestamp: 1671231205875
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
   sha256: 0b1a9a25ddfc6631390c53d6ee95706eaab0805c5a9a8d748c08120a1f421256
   md5: a93581f810ef522bd23c148195591157
   depends:
@@ -888,7 +888,7 @@ packages:
   license_family: BSD
   size: 234846
   timestamp: 1663827645102
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39hdda0065_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cryptography-41.0.3-py39hdda0065_0.tar.bz2
   sha256: 6a08c501a310e5e482df8e917a7b0cd438e83f33a44aaec49c2ab53eeda5ebf1
   md5: 3f8c39c0ce002faf6719b8d2d5f31941
   depends:
@@ -902,7 +902,7 @@ packages:
   license_family: BSD
   size: 2181966
   timestamp: 1694444647708
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cyrus-sasl-2.1.28-h52b45da_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cyrus-sasl-2.1.28-h52b45da_1.tar.bz2
   sha256: 4e7eb5911636f3cac2bb22c85d56a8edf946cfd6379e8b7be6136ffdaf669c22
   md5: dcabb2d653147fd807cf6edeb2c3522b
   depends:
@@ -914,7 +914,7 @@ packages:
   license_family: BSD
   size: 239169
   timestamp: 1688045783866
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
   sha256: 469debfa966d24b8372aaf909ecbe27dc6fde186f6f0d5b9e0a8427e38053364
   md5: 498d0788982ec4c5d13a44359b9c7afb
   depends:
@@ -924,7 +924,7 @@ packages:
   license: GPL2
   size: 600218
   timestamp: 1602701107852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
   sha256: 96b5d4c87d8467ae6ba92f9c17eaa9e059b6f7e9b8ee57aee788885c7413078b
   md5: 9868912fd269f4d9d6423cfe69560131
   depends:
@@ -935,7 +935,7 @@ packages:
   license_family: MIT
   size: 2164334
   timestamp: 1690905228819
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
   sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
   md5: 2e6ec51066d825ef3c317abe78d6049e
   depends:
@@ -944,7 +944,7 @@ packages:
   license_family: MIT
   size: 16413
   timestamp: 1649926472708
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
   sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
   md5: b4d923222d45314856b5378cb115214d
   depends:
@@ -953,7 +953,7 @@ packages:
   license_family: BSD
   size: 26728
   timestamp: 1668714462023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.5.0-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/expat-2.5.0-h6a678d5_0.tar.bz2
   sha256: 3afaaa4f71028c9ea0cb94681eb679b751c1f65dc3b692fb0d8a36ae0d3f0fed
   md5: 42d5d947fb3bebc9465ddeaf0093a1cb
   depends:
@@ -963,7 +963,7 @@ packages:
   license_family: MIT
   size: 192956
   timestamp: 1693497362098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.14.1-h4c34cd2_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fontconfig-2.14.1-h4c34cd2_2.tar.bz2
   sha256: 4a623c7f73f4531a16271ded00c80e7dce65aa35b5105015fc4d0ceb37c9fa0d
   md5: c9dc79248f887050dc89e19670dcbd66
   depends:
@@ -977,7 +977,7 @@ packages:
   license_family: MIT
   size: 383064
   timestamp: 1679578197653
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
   sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
   md5: a5dc8677d891dff2393b63189a3ad42f
   depends:
@@ -988,7 +988,7 @@ packages:
   license_family: Other
   size: 971975
   timestamp: 1666798278693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
   sha256: c323a9800a358c178f6f3b8860bbb77c373fbc3be981bb6420175fbb5431adf5
   md5: 6485f51176cf651b3b28c3548cef10ad
   depends:
@@ -997,7 +997,7 @@ packages:
   license_family: MIT
   size: 78533
   timestamp: 1676983203797
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.69.1-he621ea3_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/glib-2.69.1-he621ea3_2.tar.bz2
   sha256: e5e0b6a6c7bdd8a2453bce4b5045e022c6df3ad5a5a4d3085eb59ac4e1ded452
   md5: 0223c02d020cf3ff6637210d99000b5a
   depends:
@@ -1011,7 +1011,7 @@ packages:
   license_family: LGPL
   size: 1989267
   timestamp: 1669364519815
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.1-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/gst-plugins-base-1.14.1-h6a678d5_1.tar.bz2
   sha256: 833208211f0ecb52198f5fae585f937be3c337c15b4569d8f1a28638545250d5
   md5: 2fa837925e0633ceae4ec826f6daa93f
   depends:
@@ -1023,7 +1023,7 @@ packages:
   - zlib >=1.2.11,<2.0.0a0
   size: 2253949
   timestamp: 1677171916164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.1-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/gstreamer-1.14.1-h5eee18b_1.tar.bz2
   sha256: 8257a1c1c967d48561f62adb649fe21c467f0a37c41f783ba6e2c6d79fa1cc4f
   md5: 5cd8e1f16b1ce869d0c3a98b9f0897fb
   depends:
@@ -1031,7 +1031,7 @@ packages:
   - libgcc-ng >=11.2.0
   size: 1690003
   timestamp: 1677171850557
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.18.0-py39h06a4308_0.tar.bz2
   sha256: 6d934b1d532f644e148bcf51f9c8d0c7623e832fd29282bc6c4cb64b9e027884
   md5: b18725efd77d3fb6c9addf81dac09081
   depends:
@@ -1048,7 +1048,7 @@ packages:
   license_family: BSD
   size: 4576699
   timestamp: 1698866790345
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
   sha256: b35b281dbf69b826c6ae04fcd7b6a2d1f098277a669a199906a1f23b4b0931a5
   md5: 2a793fe24f85aa5819fe69c450cba6f7
   depends:
@@ -1058,7 +1058,7 @@ packages:
   license_family: MIT
   size: 29021241
   timestamp: 1692293243228
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
   sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
   md5: 1eb52f9f45cea2fb9ce27b19f990160e
   depends:
@@ -1067,7 +1067,7 @@ packages:
   license_family: BSD
   size: 110793
   timestamp: 1666125606878
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
   sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
   md5: 126b3c1933b7364ff03f67455b687e99
   depends:
@@ -1077,7 +1077,7 @@ packages:
   license_family: APACHE
   size: 37588
   timestamp: 1678997134023
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
   sha256: b6d5f6098903e5edfbc2200282efa186d446442d47ab75f51ff22c30ae0c4da4
   md5: e53a806995cedc9e5d8a96e03c9e79ac
   depends:
@@ -1087,7 +1087,7 @@ packages:
   license_family: Apache
   size: 50699
   timestamp: 1698254665788
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
   sha256: bddc8de31272a509510cc87e5ac0cdb0e7765d393ca7bdfddbfe4123979a9413
   md5: bc8a501970aadad3373edbce996b5fdf
   depends:
@@ -1103,7 +1103,7 @@ packages:
   license_family: Proprietary
   size: 19286333
   timestamp: 1681801301379
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
   sha256: c0d0714c68ed953740812688ac1b3c3e286de33b55d49f02953d705fb00c30d0
   md5: 8b65eea396159a3b59278f77c81ddd1b
   depends:
@@ -1124,7 +1124,7 @@ packages:
   license_family: BSD
   size: 217268
   timestamp: 1691122070319
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
   sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
   md5: ff47e0be879e817713ce2a9daa76e2b0
   depends:
@@ -1145,7 +1145,7 @@ packages:
   license_family: BSD
   size: 1261116
   timestamp: 1694181530670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
   sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
   md5: 5ef6c6a0d1ac79143c7359d305155167
   depends:
@@ -1155,7 +1155,7 @@ packages:
   license_family: MIT
   size: 1021637
   timestamp: 1644297140650
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
   sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
   md5: eaeb023688f781e7dd89e74310c38195
   depends:
@@ -1165,7 +1165,7 @@ packages:
   license_family: BSD
   size: 211775
   timestamp: 1666908212136
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
   sha256: c21f8f407266d039e819c27fe9eb4fb26587e974f3bd059b37cbaec5073722d0
   md5: ba1f47411e9e07876c7a3e9d3be6a98e
   depends:
@@ -1174,7 +1174,7 @@ packages:
   license_family: Other
   size: 281400
   timestamp: 1677849152168
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
   sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
   md5: 0d2c3c5edf671b575532d5a3e8bf15fc
   depends:
@@ -1185,7 +1185,7 @@ packages:
   license_family: MIT
   size: 131510
   timestamp: 1676558716852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
   sha256: 4ba1f5698f0b483af397021b2047554afb3129790cac3a1502c79693154331d2
   md5: 8e9c0ef4b0b57caa87c146892e56a313
   depends:
@@ -1201,7 +1201,7 @@ packages:
   license_family: BSD
   size: 192921
   timestamp: 1676329415827
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.5.0-py39h06a4308_0.tar.bz2
   sha256: b791f2f86fe1993ddfcd10a80a92fb098c2b4792f0ce13da9269cac6b3647d0b
   md5: ac7c5e38691312d195fdd1f23b33f779
   depends:
@@ -1212,7 +1212,7 @@ packages:
   license_family: BSD
   size: 78853
   timestamp: 1698937381669
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
   sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
   md5: a4beb461f0a60998a090d760b5c6c907
   depends:
@@ -1236,7 +1236,7 @@ packages:
   license_family: BSD
   size: 411564
   timestamp: 1671707702849
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
   sha256: 6d6c384c9c65e33d5d047e01131e0687eb2bc1e5a4a67f80af3c0b773c1bba82
   md5: 07957e1d2fb6a407f7d7293b84938e1e
   depends:
@@ -1247,7 +1247,7 @@ packages:
   license_family: BSD
   size: 77689
   timestamp: 1672387301020
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
   sha256: 01bae3dd44469e34f043e0416f5f5e658429bf4031745399d9968d10b899e2c4
   md5: 10171cca67e3d73c3646c6dc5a321460
   depends:
@@ -1259,7 +1259,7 @@ packages:
   license_family: MIT
   size: 1427115
   timestamp: 1686931095252
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -1270,7 +1270,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
   sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
   md5: 9508af80612e4fa1b5d1abb43ca7e63c
   constrains:
@@ -1278,7 +1278,7 @@ packages:
   license: GPL-3.0-only
   size: 749072
   timestamp: 1652971360657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
   sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
   md5: 88199c75f2ac211728febced7785c24e
   depends:
@@ -1288,7 +1288,7 @@ packages:
   license_family: Apache
   size: 228278
   timestamp: 1635523146417
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
   sha256: 472cf888db65d00451fcd5fccd5244d55c061e8d7efe43f70220414ef64521a5
   md5: 787927eff72e62c270f614cbcba9479c
   depends:
@@ -1296,7 +1296,7 @@ packages:
   license: MIT
   size: 67109
   timestamp: 1659616145972
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
   sha256: 19a43182ca343510ba51baa0fce91d64c840a19cdf13c6dde4e03e819c70897e
   md5: c0608d376a30b5aa4d2f2c22978135db
   depends:
@@ -1305,7 +1305,7 @@ packages:
   license: MIT
   size: 34691
   timestamp: 1659616154057
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
   sha256: 158c401aa0bab05aa5f4134aea798085e4e3849209946f896cca352930d2225d
   md5: cc6a6d362912a2d112310bd3f8acd44e
   depends:
@@ -1314,7 +1314,7 @@ packages:
   license: MIT
   size: 295287
   timestamp: 1659616162282
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang-14.0.6-default_hc6dbbc7_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libclang-14.0.6-default_hc6dbbc7_1.tar.bz2
   sha256: 46646ce93dafb4922f4597c34c4fec106b4ff3b9707a202387f7964601e47876
   md5: 5eaf417727302b441025661154fc4587
   depends:
@@ -1327,7 +1327,7 @@ packages:
   license_family: Apache
   size: 130632
   timestamp: 1681222907766
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang13-14.0.6-default_he11475f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libclang13-14.0.6-default_he11475f_1.tar.bz2
   sha256: 24d638d8577a3332a2e6cd77a5178054ca9cf7e14f71353b5b0a655155ab5c19
   md5: 230f394424c6cc26ebbee96176b65ece
   depends:
@@ -1339,7 +1339,7 @@ packages:
   license_family: Apache
   size: 11152969
   timestamp: 1681222877667
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcups-2.4.2-h2d74bed_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libcups-2.4.2-h2d74bed_1.tar.bz2
   sha256: f465c8f00b075660362d8e7fba8702b1c11e56fb2c305da78b9ee69898609be7
   md5: 8a2e46dc8bd62528a6f4d9092f2f6911
   depends:
@@ -1352,7 +1352,7 @@ packages:
   license_family: Apache
   size: 4901408
   timestamp: 1685057846629
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
   sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
   md5: 55dde57e63a36b202e388a39dcee9a66
   depends:
@@ -1361,7 +1361,7 @@ packages:
   license_family: MIT
   size: 74096
   timestamp: 1695996494461
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20221030-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20221030-h5eee18b_0.tar.bz2
   sha256: 5d66a60672f8e7dd0c048b5f158b5d406f16133b260ffde95a93eb453a1e7af9
   md5: af7584851084abae8eaa8cee2ed288b4
   depends:
@@ -1371,7 +1371,7 @@ packages:
   license_family: BSD
   size: 195621
   timestamp: 1670840131081
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
   sha256: ec1c6341cf0091b55be05285037cb3fbba90573e00257f383ab274d8b8e6d46f
   md5: 32ac65d639d6c155ea7276cadf1fd2b6
   depends:
@@ -1381,7 +1381,7 @@ packages:
   license_family: MIT
   size: 147907
   timestamp: 1683716564178
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
   sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
   md5: 641e72e5067bd6d5454405879e1cd2a7
   depends:
@@ -1396,7 +1396,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 8895144
   timestamp: 1654090827491
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
   sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
   md5: 27082517590f3b9fbffecc68513b461b
   depends:
@@ -1405,7 +1405,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 19860
   timestamp: 1654090819660
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
   sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
   md5: 0202c3c8ae4735cac6c7f3d1e1685964
   constrains:
@@ -1413,7 +1413,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 5228750
   timestamp: 1654090762569
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
   sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
   md5: 3080c2813e6e1d0f8a100a38b5b3456d
   depends:
@@ -1421,7 +1421,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 573231
   timestamp: 1654090775721
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
   sha256: 512fac06ddd97b4383503d4fbd8145102966055b29ccf86841a930dbb4ef3ab8
   md5: 833c0e514ff9c8ae0511630b024d60e0
   depends:
@@ -1434,7 +1434,7 @@ packages:
   license_family: Apache
   size: 37179832
   timestamp: 1683292829131
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
   sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
   md5: 1bffe1481ed4f88827248fb9001f8923
   depends:
@@ -1444,7 +1444,7 @@ packages:
   license_family: Other
   size: 362561
   timestamp: 1677841789536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpq-12.15-hdbd6064_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpq-12.15-hdbd6064_1.tar.bz2
   sha256: 3c143d73ce3eb1286de076843d56158b3d33ad76126c4df404720b881ad8ec64
   md5: 85fdca62d65ed23546961c5ecd4dc68a
   depends:
@@ -1453,7 +1453,7 @@ packages:
   - openssl >=3.0.8,<4.0a0
   size: 2989276
   timestamp: 1687380039119
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -1461,7 +1461,7 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
   sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
   md5: 8c195584a5f5471b600ee180e4052773
   depends:
@@ -1469,7 +1469,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 6410287
   timestamp: 1654090800863
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
   sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
   md5: ef78eebd98289aceacdfa29182426adf
   depends:
@@ -1487,7 +1487,7 @@ packages:
   license_family: Other
   size: 664034
   timestamp: 1693575237924
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
   sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
   md5: 292768ec77416ae257cfdd44ea2071c8
   depends:
@@ -1496,7 +1496,7 @@ packages:
   license_family: BSD
   size: 29197
   timestamp: 1668082729834
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
   sha256: c6aecee300c8e84a99056307ed3bdc047edd5366e55230a4eabe3ee5e8082bb8
   md5: 3a6ebf9895b1085a23783cd95460a629
   depends:
@@ -1511,7 +1511,7 @@ packages:
   license_family: BSD
   size: 88424
   timestamp: 1694778218406
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
   sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
   md5: 9cdeef1d044c7e035c006890f11569d3
   depends:
@@ -1522,14 +1522,14 @@ packages:
   license_family: BSD
   size: 436056
   timestamp: 1694776944891
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
   sha256: 5d68e69709ae10bd6c4b58b6af447ad2f2bd24955994f3ec77103d1a6bf5e1f5
   md5: 49e523de8d364b7fabc3850eccbe9bda
   depends:
   - libgcc-ng >=7.5.0
   size: 623492
   timestamp: 1652448233146
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxkbcommon-1.0.1-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxkbcommon-1.0.1-h5eee18b_1.tar.bz2
   sha256: 114853749b375d54347f18b472456eb7d66beba26238c984403bdd5ff8831947
   md5: 6225f107993ddf5e1f61111b3df025bd
   depends:
@@ -1540,7 +1540,7 @@ packages:
   license_family: MIT
   size: 640985
   timestamp: 1679578328295
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.10.4-hf1b16e4_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxml2-2.10.4-hf1b16e4_1.tar.bz2
   sha256: 93b155c0472d424dce940921ff368a3e4fd70fa41f5f934e58a4b7ec24722f95
   md5: 2d7bb4d2ef09d62843f8be03b55fce18
   depends:
@@ -1552,7 +1552,7 @@ packages:
   license_family: MIT
   size: 744988
   timestamp: 1692970212537
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.37-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxslt-1.1.37-h5eee18b_1.tar.bz2
   sha256: e4e42cc28f7d509980afa2b1e76266d997628c9ff5d194c8460228279c0b6cdc
   md5: ff861c432be5a684783732ad1eb4c39f
   depends:
@@ -1563,7 +1563,7 @@ packages:
   license_family: MIT
   size: 258682
   timestamp: 1692973520375
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py39h06a4308_0.tar.bz2
   sha256: 0e4d61ed508712fc16117fc41f0f5bfedd319cfefd114749689db5f78242b0a5
   md5: d40d6b6ea51683b29a9e210831db4a13
   depends:
@@ -1573,7 +1573,7 @@ packages:
   license_family: MIT
   size: 35171
   timestamp: 1659783489143
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.9.3-py39hdbbb534_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lxml-4.9.3-py39hdbbb534_0.tar.bz2
   sha256: b961c12e78000995cfcc5769c64b1c146f917e640e999e290bb2b36468bd7dbe
   md5: a3a5039a19997b8cee4ddf538472358c
   depends:
@@ -1585,7 +1585,7 @@ packages:
   license_family: Other
   size: 1616363
   timestamp: 1695058577405
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
   sha256: 36b23ab8d8aa22d70a2f733462cabe95e5b27ca919ec7a75a5592bc39c5f7d16
   md5: f24adbfdfe16b0bac0d14640bb5ce616
   depends:
@@ -1595,7 +1595,7 @@ packages:
   license_family: BSD
   size: 163649
   timestamp: 1670944701605
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
   sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
   md5: 421f82c8274b44660dba629134faa6af
   depends:
@@ -1605,7 +1605,7 @@ packages:
   license_family: BSD
   size: 122221
   timestamp: 1671541990505
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py39h06a4308_1.tar.bz2
   sha256: 9332b39039a52ecc802ddc2c4a3bde95a3141aff0ccab19a7591ec6ef72bfe07
   md5: 622bb5a6eeeadeb8731e5e1bf4f0d7a2
   depends:
@@ -1615,7 +1615,7 @@ packages:
   license_family: MIT
   size: 105637
   timestamp: 1684279960746
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
   sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
   md5: feb0e452205b44ac45d9b5e55c21a3b1
   depends:
@@ -1627,7 +1627,7 @@ packages:
   license_family: BSD
   size: 22819
   timestamp: 1654597913064
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.8.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-3.8.0-py39h06a4308_0.tar.bz2
   sha256: 7769380101bde07e1631d530110b75d7871a1069ba27a2b3984b92c499c28f95
   md5: 2b244d4ee70f0c1bc1b61ae17af9816e
   depends:
@@ -1639,7 +1639,7 @@ packages:
   license_family: PSF
   size: 7881
   timestamp: 1698692415570
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
   sha256: 10701d3065424bbef89c03a30c4adecd67308cd2f76e0d873aad6a180d9fe097
   md5: e196f6bace29ef34f0a996ef1c99f193
   depends:
@@ -1662,7 +1662,7 @@ packages:
   license_family: PSF
   size: 8129476
   timestamp: 1698692330174
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
   sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
   md5: c04ef34af33da4c71bcc99b7ec24d210
   depends:
@@ -1672,7 +1672,7 @@ packages:
   license_family: BSD
   size: 16391
   timestamp: 1662014553452
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py39h06a4308_0.tar.bz2
   sha256: 0dd0157d3d6c591a1087f7b96993412ac9194b7ea0ee2d667b1dc1c587eb0e33
   md5: 975a78ae464b1cd9541c498fd8299858
   depends:
@@ -1682,7 +1682,7 @@ packages:
   license_family: MIT
   size: 52857
   timestamp: 1659721312521
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py39h06a4308_0.tar.bz2
   sha256: cae67d22945f16e1034fc53144eea8bb67f2fecf6d60b22c43822094b6ca2b49
   md5: 19932cd4f64628bf6db1accebdaf7eac
   depends:
@@ -1691,7 +1691,7 @@ packages:
   license_family: MIT
   size: 18689
   timestamp: 1659716096534
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
   sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
   md5: f6c734d73e6e3dbc1b62766cf18ff3e4
   depends:
@@ -1701,7 +1701,7 @@ packages:
   license_family: BSD
   size: 58153
   timestamp: 1607364912263
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
   sha256: c7dedf41acbb2a065364f949ba24479449387d54c095220ff89346d266b25347
   md5: c5f96c8ff7102e1d673829bbeb8bed84
   depends:
@@ -1715,7 +1715,7 @@ packages:
   license_family: Proprietary
   size: 206706869
   timestamp: 1691503234180
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
   sha256: 984f547627b0af8358fa83b2396e0b2c014f9bc281304b6b8d3ff139a3f04b40
   md5: 724d2559e0ed50aa0eee97c919134ded
   depends:
@@ -1726,7 +1726,7 @@ packages:
   license_family: BSD
   size: 58512
   timestamp: 1682948511810
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
   sha256: 650419991b99b810e79221e35e5a6c3e49240ed30ff3e5324eecf1cefd276110
   md5: a14b8155afdb15f3bce72e67925c0ceb
   depends:
@@ -1740,7 +1740,7 @@ packages:
   license_family: BSD
   size: 227382
   timestamp: 1695058347376
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
   sha256: 7b0eeb8acc4c6b9f45b214fbc991a4073a59a8f7b798a4cc86515b97f7af6355
   md5: eb48e45fd8d61762290e4289a52be3f7
   depends:
@@ -1755,7 +1755,7 @@ packages:
   license_family: BSD
   size: 329190
   timestamp: 1695059874042
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mysql-5.7.24-h721c034_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mysql-5.7.24-h721c034_2.tar.bz2
   sha256: 1127b7dbb0a740f3de8931a4af5b70b3dac6dc3de162a2d8f8760335db5e6669
   md5: b4ab7fa3430324358189ca5ff9fc8e42
   depends:
@@ -1768,7 +1768,7 @@ packages:
   license_family: GPL
   size: 82391019
   timestamp: 1688563074905
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
   sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
   md5: 95c83d71814c504b5504df4f14548f1a
   depends:
@@ -1794,7 +1794,7 @@ packages:
   license_family: BSD
   size: 8257558
   timestamp: 1681756322140
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py39h06a4308_0.tar.bz2
   sha256: 79e10dc933d22aa99de3543071f1beaaf0ff24df9fed7d2ef5e765f3ed766064
   md5: ea6ebe4e8d6af98128d32606da618a29
   depends:
@@ -1807,7 +1807,7 @@ packages:
   license_family: BSD
   size: 99555
   timestamp: 1698934242626
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
   sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
   md5: 1710a25086c8098367eb36b9d441448b
   depends:
@@ -1835,7 +1835,7 @@ packages:
   license_family: BSD
   size: 569683
   timestamp: 1668450704669
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
   sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
   md5: 385cc9e53404776782502c0fdb08820f
   depends:
@@ -1848,7 +1848,7 @@ packages:
   license_family: BSD
   size: 147046
   timestamp: 1694616899309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
   sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
   md5: 57ea097dc15f8d9f9eb90e1d919143b0
   depends:
@@ -1857,7 +1857,7 @@ packages:
   license_family: MIT
   size: 1157733
   timestamp: 1674734069410
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
   sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
   md5: bbbcbebc20a4fdcadce398d0ca04f95e
   depends:
@@ -1866,7 +1866,7 @@ packages:
   license_family: BSD
   size: 13109
   timestamp: 1672387143252
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/networkx-3.1-py39h06a4308_0.tar.bz2
   sha256: 75a4858adf42d03e1ef52ea0083d7665bf3426607367cad661077199951b18a4
   md5: 357296e49c55733ecc879ffe5d612116
   depends:
@@ -1875,7 +1875,7 @@ packages:
   license_family: BSD
   size: 2955832
   timestamp: 1690562037565
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
   sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
   md5: 248ce515640465371927d46f389ed555
   depends:
@@ -1900,7 +1900,7 @@ packages:
   license_family: BSD
   size: 594054
   timestamp: 1690985006481
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
   sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
   md5: 70db71df4ee1cdd38090c0f7b80ba61f
   depends:
@@ -1910,7 +1910,7 @@ packages:
   license_family: BSD
   size: 21944
   timestamp: 1668160644514
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
   sha256: e61fc626f7131f1857c703ad3bb4dcacfc6b1fd6d5da545aa8f600b840315aca
   md5: 6b689e52e3ba1fa7caaab3e6be31860c
   depends:
@@ -1925,7 +1925,7 @@ packages:
   license_family: MIT
   size: 141434
   timestamp: 1696515497148
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.0-py39h5f9d8c6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.0-py39h5f9d8c6_0.tar.bz2
   sha256: de22d445f66249c5bf5fbef2f4bba81baa0eb13e5050036da9ffacd46b3ee1ea
   md5: 0c454790ce9011e27e597f8b1ce5e769
   depends:
@@ -1942,7 +1942,7 @@ packages:
   license_family: BSD
   size: 9526
   timestamp: 1695832867641
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.0-py39hb5e798b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.0-py39hb5e798b_0.tar.bz2
   sha256: 0f8233bca839fed724ee08cf5cb1bafffd72bd3f588401adb3bf126990d8bf19
   md5: 068fb4b40cd349a7db1d9ed214178ca6
   depends:
@@ -1958,7 +1958,7 @@ packages:
   license_family: BSD
   size: 7858953
   timestamp: 1695832851373
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
   sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
   md5: b0afe23033c8c5344640bc25225fa579
   depends:
@@ -1969,7 +1969,7 @@ packages:
   license: BSD 2-Clause
   size: 516994
   timestamp: 1630084830020
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.11-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.11-h7f8727e_2.tar.bz2
   sha256: 3a01ea7f58c487ee5d30251c089137ad9600dc305a82e09231dd112e19824e71
   md5: 39ef8bbb036d537b1deb7f7ac32ea87e
   depends:
@@ -1979,7 +1979,7 @@ packages:
   license_family: Apache
   size: 5493777
   timestamp: 1695322649929
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
   sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
   md5: 77a22ed6d0d448c5288d0f695bc9ac49
   depends:
@@ -1988,7 +1988,7 @@ packages:
   license_family: Apache
   size: 72527
   timestamp: 1693575234886
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.1.1-py39h1128e8f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-2.1.1-py39h1128e8f_0.tar.bz2
   sha256: 525a877de379651efc20862a77deb470c9c4ff3cfa470d3643c5036de0ec5d17
   md5: dd9fcd456d8fb03daad201cf130d28bd
   depends:
@@ -2036,7 +2036,7 @@ packages:
   license_family: BSD
   size: 14140649
   timestamp: 1697477421901
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.3.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-1.3.1-py39h06a4308_0.tar.bz2
   sha256: a521bbf5ace95000eefefc5b4e6ff599f7607aea6878a5bf61cd58e9232850fc
   md5: 76e793d8f5634ca4d10cbc6c15a84e65
   depends:
@@ -2060,7 +2060,7 @@ packages:
   license_family: BSD
   size: 17121173
   timestamp: 1698867093476
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-2.0.0-py39h06a4308_0.tar.bz2
   sha256: 5ee99045a6225d67f275d2b934e0c406aa18e78606933d3e180884e85ab07755
   md5: e9f0d25cb34c847f93a8269f2b8cc674
   depends:
@@ -2069,7 +2069,7 @@ packages:
   license_family: BSD
   size: 188223
   timestamp: 1698263473172
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
   sha256: 4881cc5e0d5b20335bcfba4eaf29fdc95dedf2607903aabecdacffb64d3407d4
   md5: 4bac8a874e62f41ebab8345ca6076eb6
   depends:
@@ -2079,7 +2079,7 @@ packages:
   license_family: BSD
   size: 263308
   timestamp: 1624477853289
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
   sha256: db8122fcb6316fb86c2ff6d4dd47154a650ac26d270183a316f14004adf27525
   md5: 33ad46d04664fc8b65a545110e4fe099
   depends:
@@ -2099,7 +2099,7 @@ packages:
   license_family: Other
   size: 764331
   timestamp: 1696580179855
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
   sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
   md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
   depends:
@@ -2110,7 +2110,7 @@ packages:
   license_family: MIT
   size: 2674850
   timestamp: 1697548887851
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
   sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
   md5: fe56f0479dd414c846191116366262c3
   depends:
@@ -2119,7 +2119,7 @@ packages:
   license_family: MIT
   size: 31999
   timestamp: 1692205535111
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ply-3.11-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ply-3.11-py39h06a4308_0.tar.bz2
   sha256: a38e6d2ba251c6456849a7e2529a7d30150d7345abc8ee6d0afeba6c7173ac7a
   md5: 290fd05d75d8e816a9b0f29e10ea4063
   depends:
@@ -2128,7 +2128,7 @@ packages:
   license_family: BSD
   size: 82191
   timestamp: 1607029370982
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
   sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
   md5: 44d2a857d13bdf9d99aaac039a249d47
   depends:
@@ -2137,7 +2137,7 @@ packages:
   license_family: Apache
   size: 91137
   timestamp: 1659455142164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
   sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
   md5: eb899a739d9b58dd747f1f6bd52d4cf3
   depends:
@@ -2149,7 +2149,7 @@ packages:
   license_family: BSD
   size: 579771
   timestamp: 1672387338600
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
   sha256: a760d6c9fca08c09ff0bc9a33946188e2ea5deed2443d4acb360ce55ce36ee43
   md5: 2cb2ad8315f68f4339b9416bd9ab115e
   depends:
@@ -2159,7 +2159,7 @@ packages:
   license_family: BSD
   size: 353437
   timestamp: 1656431352923
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
   sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
   md5: f36ecb722522cbe2e3737424edf1b5e1
   depends:
@@ -2171,7 +2171,7 @@ packages:
   license_family: BSD
   size: 29312
   timestamp: 1675441510984
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
   sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
   md5: 6d03295e544251e608a28c8d7c48115e
   depends:
@@ -2180,7 +2180,7 @@ packages:
   license_family: BSD
   size: 1862058
   timestamp: 1684280096752
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
   sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
   md5: 1f09617aecd6f3c2f2e20692c0759f34
   depends:
@@ -2190,7 +2190,7 @@ packages:
   license_family: Apache
   size: 94434
   timestamp: 1690223520097
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
   sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
   md5: ffceed627867508d73af1636ab5ebf42
   depends:
@@ -2199,7 +2199,7 @@ packages:
   license_family: MIT
   size: 156324
   timestamp: 1661452578573
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.15.10-py39h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyqt-5.15.10-py39h6a678d5_0.tar.bz2
   sha256: ee433aa91ace3663610cfb0bae64c2493607983307a8c4ae659058a71fced498
   md5: 36fa923ae045804756daaa637c50a34e
   depends:
@@ -2214,7 +2214,7 @@ packages:
   license_family: GPL
   size: 6514297
   timestamp: 1698772741413
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt5-sip-12.13.0-py39h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyqt5-sip-12.13.0-py39h5eee18b_0.tar.bz2
   sha256: 3d8beba15e78e1015b290a54d02ead66310149fa4382f8a590f2346f10629d24
   md5: 340faa81b485b2b79bb30575e39818e7
   depends:
@@ -2224,7 +2224,7 @@ packages:
   license_family: GPL
   size: 97026
   timestamp: 1698769334601
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
   sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
   md5: 0e3341a4fe434167bf74b613eb6afd81
   depends:
@@ -2234,7 +2234,7 @@ packages:
   license_family: MIT
   size: 97194
   timestamp: 1636110999719
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
   sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
   md5: c5f3f7f10ad30f0945e75252615ab6e5
   depends:
@@ -2243,7 +2243,7 @@ packages:
   license_family: BSD
   size: 31331
   timestamp: 1605305847037
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.18-h955ad1f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.9.18-h955ad1f_0.tar.bz2
   sha256: e9cc8f89dc327997339bedd9961428a13dda3893e3dba46358e73b1fd1ffa37a
   md5: e99f4c3215771cd11de42d30ac8ada47
   depends:
@@ -2264,7 +2264,7 @@ packages:
   license_family: PSF
   size: 26811973
   timestamp: 1694440290734
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
   sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
   md5: 0caa188a695319bdb13f53b0a2b3accc
   depends:
@@ -2273,7 +2273,7 @@ packages:
   license_family: BSD
   size: 264864
   timestamp: 1661371117920
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
   sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
   md5: bcb44ecbea441ee0d4659133d060d71f
   depends:
@@ -2282,7 +2282,7 @@ packages:
   license_family: MIT
   size: 257904
   timestamp: 1695131670290
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
   sha256: e937081facacb141dc2c9cdcced92baa9a2662e4a56100b6041df0b6b7692570
   md5: f3ac39b2349258198a9b3316636fe5d5
   depends:
@@ -2292,7 +2292,7 @@ packages:
   license_family: BSD
   size: 39972
   timestamp: 1685030752528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
   sha256: 2a535f9fdda20b536bd76dfa286fb67a7685ed2be4ad51e2860c44e144c0b457
   md5: 797c263fd5bff62987fc1da076eef0f9
   depends:
@@ -2303,7 +2303,7 @@ packages:
   license_family: MIT
   size: 184040
   timestamp: 1698096132905
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
   sha256: 70ee4fc614dd3337ad542c7c961428930160ab8c7da27775faed5ffddbd362d7
   md5: bf2a4feb20647c569f7ce5a8f63094fa
   depends:
@@ -2315,7 +2315,7 @@ packages:
   license_family: BSD
   size: 515650
   timestamp: 1657724431309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-main-5.15.2-h53bd1ea_10.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/qt-main-5.15.2-h53bd1ea_10.tar.bz2
   sha256: 34fca7030324880c741f8b2030673229883cb7a11429f8e4bd2664d7d0f07ae1
   md5: ccbd6faf6b49454aec690b72d21666dd
   depends:
@@ -2349,7 +2349,7 @@ packages:
   license_family: LGPL
   size: 62392312
   timestamp: 1693222657819
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
   sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
   md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
   depends:
@@ -2359,7 +2359,7 @@ packages:
   license_family: GPL
   size: 467661
   timestamp: 1666648052561
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
   sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
   md5: c7de00b4ac2778c4e5a7816320d75391
   depends:
@@ -2375,7 +2375,7 @@ packages:
   license_family: Apache
   size: 94028
   timestamp: 1690400356879
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.11.3-py39h5f9d8c6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/scipy-1.11.3-py39h5f9d8c6_0.tar.bz2
   sha256: 8ddacf409396338156d1a09da3f8f0f3b3b473c679bcfefd2de154f7d8f91344
   md5: 6d6d7ca3d32075d8a57131d589851dd2
   depends:
@@ -2392,7 +2392,7 @@ packages:
   license_family: BSD
   size: 23630389
   timestamp: 1696544992719
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
   sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
   md5: 1581cafc84708ed9aafaaee1cbbf6065
   depends:
@@ -2401,7 +2401,7 @@ packages:
   license_family: MIT
   size: 1089416
   timestamp: 1690290900608
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-6.7.12-py39h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sip-6.7.12-py39h6a678d5_0.tar.bz2
   sha256: 5c834b081a5d4092b980506b8ca135bceed171cefe12a6670439447415fe8512
   md5: 52a9ac7b6afc89a7d854a91a7755bc26
   depends:
@@ -2415,7 +2415,7 @@ packages:
   license_family: GPL
   size: 565139
   timestamp: 1698676107812
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
   sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
   md5: e19ffbfb24b990275d24fcea2bd1699b
   depends:
@@ -2424,7 +2424,7 @@ packages:
   license_family: Apache
   size: 15702
   timestamp: 1614030498860
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
   sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
   md5: ca061ce25c0f58628643abec8d6a8244
   depends:
@@ -2433,7 +2433,7 @@ packages:
   license_family: MIT
   size: 66330
   timestamp: 1696347637947
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
   sha256: 8b45ba506984fe9c061b4acde6f5243d52dda8c1eae4992f8d80c03f425214fe
   md5: 68c24a824d36a16bbb28d80d70cee8d2
   depends:
@@ -2446,7 +2446,7 @@ packages:
   license_family: Other
   size: 1640317
   timestamp: 1681394746811
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
   sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
   md5: 041a3caf09dc9ce8fc6c10925c4fe050
   depends:
@@ -2456,7 +2456,7 @@ packages:
   license_family: Apache
   size: 1888016
   timestamp: 1680167274961
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
   sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
   md5: 0e76eab58fe488e91f0aee73f46de031
   depends:
@@ -2467,7 +2467,7 @@ packages:
   license_family: BSD
   size: 29816
   timestamp: 1671751864131
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
   sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
   md5: b413a210eca82fe867e991eed085201b
   depends:
@@ -2477,7 +2477,7 @@ packages:
   license_family: BSD
   size: 38882
   timestamp: 1668168876032
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
   sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
   md5: 5b8375e2092012db69d2123dc0c68630
   depends:
@@ -2487,7 +2487,7 @@ packages:
   license_family: BSD
   size: 3485432
   timestamp: 1654088939579
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tomli-2.0.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tomli-2.0.1-py39h06a4308_0.tar.bz2
   sha256: b91bd44ade7b16900ce08a0697abf363e04606f891df593c459d062c8fcf5478
   md5: 3c925f0e6cbc92a445946470f9d3732e
   depends:
@@ -2496,7 +2496,7 @@ packages:
   license_family: MIT
   size: 24854
   timestamp: 1657175588674
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
   sha256: bd06f7b49d9c04c51c1e825bab446ec3cdde2bce39af00bf113a05c1009595e2
   md5: 587c3f3c891901f4305653e50c18d6c0
   depends:
@@ -2506,7 +2506,7 @@ packages:
   license_family: Apache
   size: 679739
   timestamp: 1696937022519
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
   sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
   md5: 67a8320961ff24e92eebb661536e5cf7
   depends:
@@ -2519,7 +2519,7 @@ packages:
   license_family: MOZILLA
   size: 123763
   timestamp: 1679561904852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
   sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
   md5: 0f0b91a158dd3692cbb7a7763b657bfe
   depends:
@@ -2528,7 +2528,7 @@ packages:
   license_family: BSD
   size: 192032
   timestamp: 1671143995098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
   md5: 8515e64a3de7581360d713fe4c0a094e
   depends:
@@ -2538,7 +2538,7 @@ packages:
   license_family: PSF
   size: 8789
   timestamp: 1690297588156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
   sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
   md5: 60170012374b2a5007842fa5870d78c5
   depends:
@@ -2547,7 +2547,7 @@ packages:
   license_family: PSF
   size: 57479
   timestamp: 1690297581658
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py39h06a4308_0.tar.bz2
   sha256: bdafa637d91ee2986a37cc82eb18c7b9b6e467eddd2eac3f510ad878a5b45da2
   md5: 89e6a047e97aa6b06c8a217e64182646
   depends:
@@ -2556,7 +2556,7 @@ packages:
   license_family: MIT
   size: 10729
   timestamp: 1659769510353
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
   sha256: 2f4a5979aaf22660fe9fb8c4ffd41e5a9dc012e20f78e1dbf4ad9c67e0fd28be
   md5: 0be10051dd3d6f31ba52b7c08ba3ba0a
   depends:
@@ -2571,7 +2571,7 @@ packages:
   license_family: MIT
   size: 187469
   timestamp: 1698257600264
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
   sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
   md5: f8d03a15b974fc7810d9f54ae849fc8e
   depends:
@@ -2580,7 +2580,7 @@ packages:
   license_family: BSD
   size: 20781
   timestamp: 1607365390528
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
   sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
   md5: d7db5d6ce1db80eade8a082ff78bf479
   depends:
@@ -2590,7 +2590,7 @@ packages:
   license_family: BSD
   size: 71044
   timestamp: 1614804011510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
   sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
   md5: b3899f8bda32734727bd5a73df1d7d17
   depends:
@@ -2599,7 +2599,7 @@ packages:
   license_family: MIT
   size: 101520
   timestamp: 1695742037911
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py39h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py39h06a4308_1.tar.bz2
   sha256: 8e8d728472d26c1a42345003d69bf381c062db8050d3444a6ccced7e5dcc3524
   md5: dd9bda05830964c550a69b70178ee6f9
   depends:
@@ -2608,7 +2608,7 @@ packages:
   license_family: BSD
   size: 48001
   timestamp: 1675159114742
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
   sha256: 93ca87e697bb9e045fc9cda13b05fe27e1a99f3ed143b75bbcaf4dcb745aa06f
   md5: 3eebbb22c5ca63987db36e1f19cbe872
   depends:
@@ -2617,7 +2617,7 @@ packages:
   license_family: GPL2
   size: 763941
   timestamp: 1683112966413
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -2625,7 +2625,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
   sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
   md5: 567b68192c387b5fc88178425577a0fe
   depends:
@@ -2635,7 +2635,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 366479
   timestamp: 1616055552392
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
   sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
   md5: 3818a9531fe74433c3b7d5144c9a58cc
   depends:
@@ -2644,7 +2644,7 @@ packages:
   license_family: MIT
   size: 18021
   timestamp: 1672387231268
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
   sha256: 2dc9150a95704d83efd39bb9dfb44bdf8419022f4fb0fc416380a922a27c130d
   md5: 4f315d7551f4bbeb06b6fc28342a9aa5
   depends:
@@ -2653,7 +2653,7 @@ packages:
   license_family: Other
   size: 127528
   timestamp: 1666595012798
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
   sha256: aa6aa291bec6aa66e1f063cfa75a9e0fc6bd459fcb45c372aacac9006a073900
   md5: 4e99328768f538f33aecebdae9472744
   depends:
@@ -2666,7 +2666,7 @@ packages:
   license_family: BSD
   size: 1055426
   timestamp: 1681304602537
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -2679,7 +2679,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -2689,7 +2689,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
   md5: b2aa5503875aba2f1d88cae9df9a96d5
   depends:
@@ -2698,7 +2698,7 @@ packages:
   license_family: BSD
   size: 13636
   timestamp: 1611930018941
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -2710,7 +2710,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
   sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
   md5: 544adf2677c47c9b9c891aea720678f1
   depends:
@@ -2718,7 +2718,7 @@ packages:
   license: MIT
   size: 33999
   timestamp: 1630003259346
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -2727,7 +2727,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -2736,7 +2736,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -2745,7 +2745,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -2754,7 +2754,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
   sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
   md5: 9eff1a842dbda8d1bae9a2c008b599bc
   depends:
@@ -2765,7 +2765,7 @@ packages:
   license_family: MIT
   size: 690443
   timestamp: 1625743217109
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -2773,7 +2773,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
   sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
   md5: 33624a42ee387bf9918ea98b4e7b31fc
   depends:
@@ -2783,7 +2783,7 @@ packages:
   license_family: BSD
   size: 8173
   timestamp: 1601490751973
-- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/munkres-1.1.4-py_0.tar.bz2
   sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
   md5: 67857cc5e9044770d2b15f9d94a4521d
   depends:
@@ -2792,7 +2792,7 @@ packages:
   license_family: Apache
   size: 12810
   timestamp: 1600445183315
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -2801,7 +2801,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -2810,7 +2810,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -2820,7 +2820,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
   sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
   md5: e68a6f315f41a8d814d833652bf38b9b
   depends:
@@ -2828,7 +2828,7 @@ packages:
   license: MIT
   size: 13374
   timestamp: 1606932077143
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -2836,7 +2836,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -2845,7 +2845,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -2854,7 +2854,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
   sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
   md5: 2eb923cc014094f4acf7f849d67d73f8
   depends:
@@ -2864,7 +2864,7 @@ packages:
   license_family: BSD
   size: 246457
   timestamp: 1626374695070
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
   sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
   md5: 02caf3f47f1d06256068053297355740
   depends:
@@ -2873,7 +2873,7 @@ packages:
   license_family: Apache
   size: 152292
   timestamp: 1690578151230
-- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
   sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
   md5: 41db68b96e114e367c4f120a3b379e59
   depends:
@@ -2882,7 +2882,7 @@ packages:
   license_family: BSD
   size: 19391
   timestamp: 1632406728844
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -2891,7 +2891,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -2903,14 +2903,14 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
   sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
   md5: a815d3bdb160bcc71687f2dda70d3ca4
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 122218
   timestamp: 1680170368293
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -2918,7 +2918,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
   sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
   md5: 447a49f7bad119faa80d7f14aa296c95
   depends:
@@ -2931,7 +2931,7 @@ packages:
   license_family: MIT
   size: 162176
   timestamp: 1644481750133
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
   sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
   md5: 8810f48fe4a4792de0fd3520b502d08b
   depends:
@@ -2940,7 +2940,7 @@ packages:
   license_family: BSD
   size: 10019
   timestamp: 1606859473259
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
   sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
   md5: 00a446b6dfc61af223df4de29fe8ad94
   depends:
@@ -2950,7 +2950,7 @@ packages:
   license_family: MIT
   size: 34305
   timestamp: 1644569782044
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
   sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
   md5: bd92dd8bd5b9d24e632b62a075426e50
   depends:
@@ -2959,7 +2959,7 @@ packages:
   license_family: MIT
   size: 133634
   timestamp: 1695718025321
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
   sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
   md5: f8ae051b591a9027adc16de1be9748f4
   depends:
@@ -2969,12 +2969,12 @@ packages:
   license_family: MIT
   size: 206198
   timestamp: 1681493096349
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
   sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
   md5: e2f3248e2a5009a02f7b8e54f83314ef
   size: 5620
   timestamp: 1528121955725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
   sha256: 2936241747f6cc0f0b3afa53bb28ad6f658b53a0fc2e67a5ed34d1d5e2cce117
   md5: bdca1b691340964271d9cfec6baaf8d0
   depends:
@@ -2992,7 +2992,7 @@ packages:
   license_family: BSD
   size: 5719952
   timestamp: 1697490515691
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
   sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
   md5: 0d79760d544d0bd8acb4adc4ef813418
   depends:
@@ -3002,7 +3002,7 @@ packages:
   license_family: BSD
   size: 137075
   timestamp: 1657175654487
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
   sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
   md5: 31d6d04cd2388d8f19004501271b3545
   depends:
@@ -3012,7 +3012,7 @@ packages:
   license: MIT
   size: 18982
   timestamp: 1659616229395
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
   sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
   md5: caf1073dc2ca5aeb832a2877394eae12
   depends:
@@ -3021,7 +3021,7 @@ packages:
   license: MIT
   size: 18233
   timestamp: 1659616216769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
   sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
   md5: aa1ed20c38af535c8d6a955314759d7b
   depends:
@@ -3030,14 +3030,14 @@ packages:
   license: MIT
   size: 394588
   timestamp: 1659616312678
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
   sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
   md5: ce3588e31faa79f546e0fc6a36c5543c
   license: MPL-2.0
   license_family: Other
   size: 133884
   timestamp: 1694009771475
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
   sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
   md5: 21eb7f53076d0a69513cfd258f6ef63c
   depends:
@@ -3046,7 +3046,7 @@ packages:
   license_family: Other
   size: 159756
   timestamp: 1690232346868
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
   sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
   md5: a40a04d9cda1e665565bc6c832d598b6
   depends:
@@ -3057,7 +3057,7 @@ packages:
   license_family: MIT
   size: 225258
   timestamp: 1670423337502
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
   sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
   md5: b2cc5f37f7bb069d061306e7eac2a011
   depends:
@@ -3067,7 +3067,7 @@ packages:
   license_family: CC
   size: 1913396
   timestamp: 1668084575248
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
   sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
   md5: 103d8c039e342115720a84d59c119d46
   depends:
@@ -3077,7 +3077,7 @@ packages:
   license_family: BSD
   size: 13774
   timestamp: 1671231190250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
   sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
   md5: f69f09e0346172f225390d2b3b0d7873
   depends:
@@ -3088,7 +3088,7 @@ packages:
   license_family: BSD
   size: 246628
   timestamp: 1663827484947
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
   sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
   md5: cb80c7ac65b48a737654f371fe31c460
   depends:
@@ -3101,7 +3101,7 @@ packages:
   license_family: BSD
   size: 1307228
   timestamp: 1694212041712
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
   sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
   md5: 04cbe8f4bc62c34fac9d42d1124059bf
   depends:
@@ -3111,7 +3111,7 @@ packages:
   license_family: MIT
   size: 2052734
   timestamp: 1690905361158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
   sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
   md5: ef0e825982f242085574f502dfff4f6b
   depends:
@@ -3120,7 +3120,7 @@ packages:
   license_family: MIT
   size: 16594
   timestamp: 1649926538106
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
   sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
   md5: 24747a300246c016b3a7f04dabd02d4a
   depends:
@@ -3129,7 +3129,7 @@ packages:
   license_family: BSD
   size: 27709
   timestamp: 1668714497209
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -3139,14 +3139,14 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
   sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
   md5: e4a732941f74b8062c8bcbfe5c5c2b56
   license: MIT
   license_family: MIT
   size: 80252
   timestamp: 1676983220161
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
   sha256: 5c36d43cadbbf944d9255e79df85c2e9e6155a1d6f9158e06fcd8ffd458b7663
   md5: a5a2cff387403ccf9cf58aac7a6dde55
   depends:
@@ -3163,7 +3163,7 @@ packages:
   license_family: BSD
   size: 4573879
   timestamp: 1698866750755
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
   sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
   md5: f3ce6fe6eb760c236e5f7d04df5faa81
   depends:
@@ -3172,7 +3172,7 @@ packages:
   license_family: MIT
   size: 28138484
   timestamp: 1692293212596
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
   sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
   md5: 6dd72c43fea25b748ec7a9f6c0407e15
   depends:
@@ -3181,7 +3181,7 @@ packages:
   license_family: BSD
   size: 111810
   timestamp: 1666125671024
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
   sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
   md5: 03cdb7e679924b329ecab8f12cb8fc67
   depends:
@@ -3191,7 +3191,7 @@ packages:
   license_family: APACHE
   size: 38813
   timestamp: 1678997212422
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
   sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
   md5: e113c4e6e758dd68faf196586bf5564d
   depends:
@@ -3201,7 +3201,7 @@ packages:
   license_family: Apache
   size: 51873
   timestamp: 1698254765815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
   sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
   md5: 78baea934985ccd9514a366cc7e80ed4
   depends:
@@ -3210,7 +3210,7 @@ packages:
   license_family: Proprietary
   size: 727499
   timestamp: 1681801225190
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
   sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
   md5: da9b63e42f281f7e77b289f4b654b83b
   depends:
@@ -3232,7 +3232,7 @@ packages:
   license_family: BSD
   size: 218436
   timestamp: 1691121840155
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
   sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
   md5: 6a7cb9b49593b29933fa2b503d533a08
   depends:
@@ -3254,7 +3254,7 @@ packages:
   license_family: BSD
   size: 1257205
   timestamp: 1694181720454
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
   sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
   md5: d861ef66f5c0a282d60b65778a9de2f3
   depends:
@@ -3264,7 +3264,7 @@ packages:
   license_family: MIT
   size: 1048450
   timestamp: 1644315332508
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
   sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
   md5: f7e603c965052deed8b789c35855a42f
   depends:
@@ -3274,14 +3274,14 @@ packages:
   license_family: BSD
   size: 213537
   timestamp: 1666908270815
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
   sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
   md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
   license: IJG
   license_family: Other
   size: 278924
   timestamp: 1677849185191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
   sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
   md5: a82a17e78f725dcbd71ff8dac6db05c7
   depends:
@@ -3292,7 +3292,7 @@ packages:
   license_family: MIT
   size: 133134
   timestamp: 1676558895333
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
   sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
   md5: ee9270379a9ebdb6297e4b6849b3f7f0
   depends:
@@ -3308,7 +3308,7 @@ packages:
   license_family: BSD
   size: 195479
   timestamp: 1676329410154
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.5.0-py39hecd8cb5_0.tar.bz2
   sha256: ede34881321808fbb967885dde9b0b6c9c8ef1f3eb192fa514058c4f14201c4f
   md5: 07d24f5332ca5d0e76aa0df051a1f05d
   depends:
@@ -3319,7 +3319,7 @@ packages:
   license_family: BSD
   size: 79901
   timestamp: 1698937699237
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
   sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
   md5: 7e60995b3119417213e5faedda147499
   depends:
@@ -3343,7 +3343,7 @@ packages:
   license_family: BSD
   size: 403165
   timestamp: 1671707664990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
   sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
   md5: cd470bdb28bb0e8b3535c93a3a6dad07
   depends:
@@ -3353,7 +3353,7 @@ packages:
   license_family: BSD
   size: 65431
   timestamp: 1672387389172
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -3363,7 +3363,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -3372,13 +3372,13 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
   sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
   md5: 7dba7aa5b971febb55281659843586ba
   license: MIT
   size: 65470
   timestamp: 1659616172703
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
   sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
   md5: f78a158983f0bbaba56f34b976bc6dae
   depends:
@@ -3386,7 +3386,7 @@ packages:
   license: MIT
   size: 34189
   timestamp: 1659616189313
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
   sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
   md5: 36a1d885725d3ab4d1fadc5a29f978d2
   depends:
@@ -3394,28 +3394,28 @@ packages:
   license: MIT
   size: 327737
   timestamp: 1659616202869
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
   sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
   md5: 817848d0e2b2808acdc9b3fbbf581726
   license: MIT
   license_family: MIT
   size: 133887
   timestamp: 1683716590737
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
   sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
   md5: e458587c87e3f2d20192f4e0738f2c63
   depends:
@@ -3424,7 +3424,7 @@ packages:
   license_family: GPL
   size: 149419
   timestamp: 1665498987619
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
   sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
   md5: 1058b661ec829b2ee3716ee2a5520641
   depends:
@@ -3435,14 +3435,14 @@ packages:
   license_family: GPL
   size: 1917987
   timestamp: 1665498925405
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
   sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
   md5: c90372428e1e4eed4fdcd790979d06b4
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1409377
   timestamp: 1650983531933
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -3451,13 +3451,13 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -3474,7 +3474,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
   sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
   md5: c0b99f8e1c7475f23b1c7b4250b06e1c
   depends:
@@ -3488,7 +3488,7 @@ packages:
   license_family: BSD
   size: 88021
   timestamp: 1694778290062
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
   sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
   md5: 46a65d1fc24013217e06aaf6d65ffcad
   constrains:
@@ -3497,7 +3497,7 @@ packages:
   license_family: BSD
   size: 425478
   timestamp: 1694776947990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
   sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
   md5: 06866415ef22d5322f9bdc9956b59c4d
   depends:
@@ -3509,7 +3509,7 @@ packages:
   license_family: MIT
   size: 678174
   timestamp: 1692970318885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
   sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
   md5: 2edc6c894d6d0321304396e9bd40df94
   depends:
@@ -3519,7 +3519,7 @@ packages:
   license_family: MIT
   size: 241774
   timestamp: 1692973618934
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 0190d3b8d2939f28aa017711cf4147c51a1139da2922cc8420a71562dd99f844
   md5: 454a7f2c4426453f17e995382a4235e4
   depends:
@@ -3529,7 +3529,7 @@ packages:
   license_family: MIT
   size: 36036
   timestamp: 1659783508187
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
   sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
   md5: 5c740b4a18a558de0ccfe601703c423c
   constrains:
@@ -3538,7 +3538,7 @@ packages:
   license_family: Apache
   size: 338738
   timestamp: 1662635677689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
   sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
   md5: 8bbd981ca0129d7beeacd3cd7623f714
   depends:
@@ -3549,7 +3549,7 @@ packages:
   license_family: Other
   size: 1491074
   timestamp: 1695058597986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
   sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
   md5: d5f58d056b4bfc67aec30c77035ba889
   depends:
@@ -3558,7 +3558,7 @@ packages:
   license_family: BSD
   size: 182491
   timestamp: 1670944720979
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
   sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
   md5: 1affd16b166571a91feae04baf5fd3da
   depends:
@@ -3568,7 +3568,7 @@ packages:
   license_family: BSD
   size: 123431
   timestamp: 1671542016019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
   sha256: e5fc51472fa0f36abd78baa5b3c9245d6627b0da11188e6a954d73f3f2bca210
   md5: df7c519447affffb594f8c56b028ed33
   depends:
@@ -3578,7 +3578,7 @@ packages:
   license_family: MIT
   size: 107035
   timestamp: 1684279974102
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
   sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
   md5: 3681ebf029211ceab26af6f5d35abf39
   depends:
@@ -3589,7 +3589,7 @@ packages:
   license_family: BSD
   size: 22254
   timestamp: 1654598220251
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.8.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-3.8.0-py39hecd8cb5_0.tar.bz2
   sha256: 40aa972e605bdc8305ebdc4b8e891ae8b65382be12d221e002ec31cfe830ac22
   md5: 07b2a24fd3dcb5cb0af22e137cd43408
   depends:
@@ -3600,7 +3600,7 @@ packages:
   license_family: PSF
   size: 8754
   timestamp: 1698692468088
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
   sha256: 2fd179efa024c92d0d71179a981a781d16c70f5d8c6305e0d678b0c7ae1275ab
   md5: addda7f015d1673f794a23fdb18a3e09
   depends:
@@ -3623,7 +3623,7 @@ packages:
   license_family: PSF
   size: 8182219
   timestamp: 1698692361219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
   sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
   md5: 6eb64ecfcd754502e271db0bb51d2cfd
   depends:
@@ -3633,7 +3633,7 @@ packages:
   license_family: BSD
   size: 17374
   timestamp: 1662014643620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 2312ee5a6343e8495802698d7181f1b619aad7479d96ee253407b324ac884417
   md5: 866960fa48a7ca335941786d4869802a
   depends:
@@ -3643,7 +3643,7 @@ packages:
   license_family: MIT
   size: 53542
   timestamp: 1659721365599
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
   sha256: 37f455814ce242eb65ff80a0402f1bd231a388e6823e6c1e65f60b705c032a2d
   md5: 4c9246c492a64729225aa5b04e12c2d1
   depends:
@@ -3652,7 +3652,7 @@ packages:
   license_family: MIT
   size: 19573
   timestamp: 1659716100178
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
   sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
   md5: 2a4d604717a647ad21af766289cbbfc3
   depends:
@@ -3661,7 +3661,7 @@ packages:
   license_family: BSD
   size: 58057
   timestamp: 1607364912348
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
   sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
   md5: 25051fe272624544652dc6d814c2943a
   depends:
@@ -3674,7 +3674,7 @@ packages:
   license_family: Proprietary
   size: 224420228
   timestamp: 1691503125614
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
   sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
   md5: 37d8cf85a63f7aa9af1624894a7d606d
   depends:
@@ -3684,7 +3684,7 @@ packages:
   license_family: BSD
   size: 48590
   timestamp: 1682969183093
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
   sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
   md5: 0b2aee6666135bbd36b46d6ac66160f7
   depends:
@@ -3697,7 +3697,7 @@ packages:
   license_family: BSD
   size: 210705
   timestamp: 1695058433223
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
   sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
   md5: e22fb55ce380d0ebd44cce3f20d5349e
   depends:
@@ -3711,7 +3711,7 @@ packages:
   license_family: BSD
   size: 296614
   timestamp: 1695060155673
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
   sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
   md5: 1a5d4004e64e3cfb7a2a297b9117c285
   depends:
@@ -3737,7 +3737,7 @@ packages:
   license_family: BSD
   size: 8213832
   timestamp: 1681756573646
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py39hecd8cb5_0.tar.bz2
   sha256: 59acf22956f295ed429624a1560bceffbbf536ea93ca63a5f1a48975a0afdbcb
   md5: a7a6344327960940bad23e783a4d6bce
   depends:
@@ -3750,7 +3750,7 @@ packages:
   license_family: BSD
   size: 100813
   timestamp: 1698934262550
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
   sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
   md5: e572c1264a7af20b486f64ac8c9e1f57
   depends:
@@ -3778,7 +3778,7 @@ packages:
   license_family: BSD
   size: 573356
   timestamp: 1668450732828
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
   sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
   md5: b67569a7c30af9ffa5cde6e4b52ac68b
   depends:
@@ -3791,14 +3791,14 @@ packages:
   license_family: BSD
   size: 148342
   timestamp: 1694616917184
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
   sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
   md5: 97b81f34efbe86c5220fe82eb584fd62
   depends:
@@ -3807,7 +3807,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387288528
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/networkx-3.1-py39hecd8cb5_0.tar.bz2
   sha256: e108c2df53ee3b3218067fd50fedcd417d5ec12d1d1247a46f0018942efd2c08
   md5: f2b02e342efea3f93ab8eee6033a332a
   depends:
@@ -3816,7 +3816,7 @@ packages:
   license_family: BSD
   size: 2958243
   timestamp: 1690562148988
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
   sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
   md5: d77862975a9a1cf50acb803be26e83a1
   depends:
@@ -3841,7 +3841,7 @@ packages:
   license_family: BSD
   size: 575365
   timestamp: 1690985052739
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
   sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
   md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
   depends:
@@ -3851,7 +3851,7 @@ packages:
   license_family: BSD
   size: 22858
   timestamp: 1668160618784
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
   sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
   md5: 185e9c41abb88ee59b52ec0f5f65d506
   depends:
@@ -3865,7 +3865,7 @@ packages:
   license_family: MIT
   size: 138305
   timestamp: 1696515469702
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
   sha256: 82a2dd0c2ff6e20a275e5447dd03088f79694f7bfa5055a25c54bebf31aac4ca
   md5: c157e6ab469a95b06fa822ba075978b3
   depends:
@@ -3881,7 +3881,7 @@ packages:
   license_family: BSD
   size: 10376
   timestamp: 1695831243158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
   sha256: b3a003b41cec2751210e542911e99437db0321542f6812c1b88608ef720ba7ef
   md5: 56400dfe88c427cdf1854e47666b8a99
   depends:
@@ -3896,7 +3896,7 @@ packages:
   license_family: BSD
   size: 7570900
   timestamp: 1695831208653
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
   sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
   md5: 93f5d7b66976154adeda219bea02ba45
   depends:
@@ -3906,7 +3906,7 @@ packages:
   license: BSD 2-Clause
   size: 484257
   timestamp: 1630093862501
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
   sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
   md5: 5e8713ef1215406254988163eaf34020
   depends:
@@ -3915,7 +3915,7 @@ packages:
   license_family: Apache
   size: 4965606
   timestamp: 1695323060401
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
   sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
   md5: 4154929ace2ad6ee16aea815635a6d1f
   depends:
@@ -3924,7 +3924,7 @@ packages:
   license_family: Apache
   size: 73598
   timestamp: 1693575307570
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
   sha256: aff5acedef9da91b77851e1a163b8319d72bc4152c98ac87703a2eac1e5d575b
   md5: 7df4c76aa8c52fedce5346748d56459e
   depends:
@@ -3971,7 +3971,7 @@ packages:
   license_family: BSD
   size: 13388063
   timestamp: 1697477404222
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
   sha256: 42d83288119306089a06e853a37045fbb9860548b05a1e79d223f7ecf1cb349d
   md5: 8daced11264159ff57df7bba4d0b2ec7
   depends:
@@ -3995,7 +3995,7 @@ packages:
   license_family: BSD
   size: 17075803
   timestamp: 1698867397009
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
   sha256: ad7ca92e5c83a8e2181677025509ed7b8f566ec23b24f28316fa087bb591c11f
   md5: a4ccd0fbcfb26de868f2fb4836940d7a
   depends:
@@ -4004,7 +4004,7 @@ packages:
   license_family: BSD
   size: 189263
   timestamp: 1698263570990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
   sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
   md5: be0a90921f3bf4f0d6950fb786093de7
   depends:
@@ -4023,7 +4023,7 @@ packages:
   license_family: Other
   size: 719901
   timestamp: 1696580194417
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
   sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
   md5: 81ae9ec2d7fcf6934847bff558b619f5
   depends:
@@ -4034,7 +4034,7 @@ packages:
   license_family: MIT
   size: 2672987
   timestamp: 1697548890181
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
   sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
   md5: 1a822c206e2abddc5d6d821721af227f
   depends:
@@ -4043,7 +4043,7 @@ packages:
   license_family: MIT
   size: 33013
   timestamp: 1692205801265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
   sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
   md5: 1604d33dbdb2446c642970f8b354bedb
   depends:
@@ -4052,7 +4052,7 @@ packages:
   license_family: Apache
   size: 91266
   timestamp: 1659455269141
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
   sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
   md5: d1b3bcc35655a3123acb1fa2ad1a8511
   depends:
@@ -4064,7 +4064,7 @@ packages:
   license_family: BSD
   size: 580828
   timestamp: 1672387372015
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
   sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
   md5: 7540555d1fb192236db9a7c5c9d3601c
   depends:
@@ -4073,7 +4073,7 @@ packages:
   license_family: BSD
   size: 365765
   timestamp: 1656431373327
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
   sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
   md5: 0a73533fb6e0dc717ab906a537bc747d
   depends:
@@ -4085,7 +4085,7 @@ packages:
   license_family: BSD
   size: 30803
   timestamp: 1675441638631
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
   sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
   md5: 0a959fbad46ab38ade48dbd358002674
   depends:
@@ -4094,7 +4094,7 @@ packages:
   license_family: BSD
   size: 1864757
   timestamp: 1684280094736
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
   sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
   md5: ea24b5076ef79e4567c5a3f0cb22b470
   depends:
@@ -4104,7 +4104,7 @@ packages:
   license_family: Apache
   size: 95330
   timestamp: 1690223465114
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
   sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
   md5: bcaea6d4a47e9c874becaa700c78dcf7
   depends:
@@ -4113,7 +4113,7 @@ packages:
   license_family: MIT
   size: 157216
   timestamp: 1661452617825
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
   sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
   md5: 707110d1b49cb1864acb0bbaa103591e
   depends:
@@ -4122,7 +4122,7 @@ packages:
   license_family: MIT
   size: 95016
   timestamp: 1636111184034
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
   sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
   md5: 113a443b9c706f9f9c6187c0eaa3de27
   depends:
@@ -4131,7 +4131,7 @@ packages:
   license_family: BSD
   size: 31178
   timestamp: 1605305861851
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
   sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
   md5: 85a8d0001db70e52a479155228cb1fe0
   depends:
@@ -4150,7 +4150,7 @@ packages:
   license_family: PSF
   size: 13324979
   timestamp: 1694439878265
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
   sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
   md5: 47c5e22e31ec05a7bc0ce90065a53afd
   depends:
@@ -4159,7 +4159,7 @@ packages:
   license_family: BSD
   size: 265348
   timestamp: 1661368839620
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
   sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
   md5: ce9a69e1668aa1e133f2aa6d4e8d346f
   depends:
@@ -4168,7 +4168,7 @@ packages:
   license_family: MIT
   size: 254958
   timestamp: 1695131709704
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
   sha256: 9ee098c09f31fad7ff1856e5ce2619172eaf979997e7a427d1e05cce32c2af00
   md5: cac1d1898b69ae9646dfbf082910635d
   depends:
@@ -4178,7 +4178,7 @@ packages:
   license_family: BSD
   size: 40946
   timestamp: 1685030787453
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
   sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
   md5: 637f08b19dd8fd87347d8c44f9e3e202
   depends:
@@ -4188,7 +4188,7 @@ packages:
   license_family: MIT
   size: 170776
   timestamp: 1698096100056
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
   sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
   md5: 8ce3ac7d8a04e469b566f1b090d01140
   depends:
@@ -4199,7 +4199,7 @@ packages:
   license_family: BSD
   size: 470617
   timestamp: 1657724324011
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -4208,7 +4208,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
   sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
   md5: 6f2d41dd76a03b7f85a1ed49af1763d6
   depends:
@@ -4224,7 +4224,7 @@ packages:
   license_family: Apache
   size: 95100
   timestamp: 1690400262627
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
   sha256: a9755ecbfd42c708945027facfa11a3dc3119778326a0ae5df79f80d7b72afa5
   md5: 839ffa4e775fee9a8bdddabf4a14da43
   depends:
@@ -4241,7 +4241,7 @@ packages:
   license_family: BSD
   size: 24331914
   timestamp: 1696545397632
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
   sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
   md5: b0321e6f14e139fc15b1f8b4acb35d2f
   depends:
@@ -4250,7 +4250,7 @@ packages:
   license_family: MIT
   size: 1093966
   timestamp: 1690290944588
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
   sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
   md5: 62b64576a0aa5f6c3fb05f56650d25e1
   depends:
@@ -4259,7 +4259,7 @@ packages:
   license_family: Apache
   size: 15535
   timestamp: 1614030509324
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
   sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
   md5: 15b5595b31e39f08eaacbe2e502d8fb3
   depends:
@@ -4268,7 +4268,7 @@ packages:
   license_family: MIT
   size: 67292
   timestamp: 1696347733587
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
   sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
   md5: 82e4db6a498480a75d53c55bd35b6478
   depends:
@@ -4280,7 +4280,7 @@ packages:
   license_family: Other
   size: 1801397
   timestamp: 1681394807900
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -4289,7 +4289,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
   sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
   md5: 63b957927b9949ccb19da28ec4612706
   depends:
@@ -4300,7 +4300,7 @@ packages:
   license_family: BSD
   size: 30902
   timestamp: 1671751919031
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
   sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
   md5: e346257a2fa8e2cb48c762138a5d009b
   depends:
@@ -4310,7 +4310,7 @@ packages:
   license_family: BSD
   size: 39915
   timestamp: 1668168959656
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
   sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
   md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
   depends:
@@ -4319,7 +4319,7 @@ packages:
   license_family: BSD
   size: 3536231
   timestamp: 1654088937695
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
   sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
   md5: a1bbf0abfb8c45541122c0eb2feee317
   depends:
@@ -4328,7 +4328,7 @@ packages:
   license_family: Apache
   size: 680464
   timestamp: 1696937112175
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
   sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
   md5: d689f6203c0a9d04fb229c73d7e80a7a
   depends:
@@ -4341,7 +4341,7 @@ packages:
   license_family: MOZILLA
   size: 125145
   timestamp: 1679561909274
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
   md5: 8a292c1ee22489bef2e84bc3aaf4098e
   depends:
@@ -4350,7 +4350,7 @@ packages:
   license_family: BSD
   size: 193141
   timestamp: 1671143985219
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
   md5: 8bf0bfffc11ad06a1c94e145941b0ad4
   depends:
@@ -4360,7 +4360,7 @@ packages:
   license_family: PSF
   size: 9651
   timestamp: 1690297655669
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
   sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
   md5: 343514a174b3485fde55a73f56398dd7
   depends:
@@ -4369,7 +4369,7 @@ packages:
   license_family: PSF
   size: 58456
   timestamp: 1690297648002
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
   sha256: 11e7401cb6805db7ce22b1f9dd6ba5b7941c92225ce440bed1da0af284bfcad4
   md5: 5c10d68fa5616cdd82ee93ef6e0f038c
   depends:
@@ -4378,7 +4378,7 @@ packages:
   license_family: MIT
   size: 11615
   timestamp: 1659769478980
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
   sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
   md5: c2242e8fd24003a74ddf37416661e06d
   depends:
@@ -4393,7 +4393,7 @@ packages:
   license_family: MIT
   size: 188757
   timestamp: 1698257668273
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
   sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
   md5: 41f445e36b6b6722a9444508eef069f8
   depends:
@@ -4402,7 +4402,7 @@ packages:
   license_family: BSD
   size: 20583
   timestamp: 1607365395045
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
   sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
   md5: 409ee46ed24267b6da6fb32d13e1f21e
   depends:
@@ -4412,7 +4412,7 @@ packages:
   license_family: BSD
   size: 70730
   timestamp: 1614804271285
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
   sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
   md5: eb74e74d8e4fd533c55eb98b7b5e83bc
   depends:
@@ -4421,7 +4421,7 @@ packages:
   license_family: MIT
   size: 102637
   timestamp: 1695742077778
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
   sha256: cb007615819fd240ea4e343835dfbda3c508a92b5b7158219d30a22d0e67b57c
   md5: bf215e781ac81e0fc433eedee330c54b
   depends:
@@ -4430,20 +4430,20 @@ packages:
   license_family: BSD
   size: 49462
   timestamp: 1675159191191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
   sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
   md5: e243baa546432c8394a8059a44a5a3e4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 419227
   timestamp: 1683113010463
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
   sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
   md5: fe4ac85ee86d3a94ea3a4ebea3779763
   depends:
@@ -4452,7 +4452,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 321797
   timestamp: 1616055526986
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
   sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
   md5: bc7073d9d4c0211cc4a1207c98fb765a
   depends:
@@ -4461,14 +4461,14 @@ packages:
   license_family: MIT
   size: 19091
   timestamp: 1672387204865
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
   sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
   md5: 8e495591e369ac161857a72011c0a296
   license: Zlib
   license_family: Other
   size: 120272
   timestamp: 1666595024203
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
   sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
   md5: f1465fbd810b3746c6de6babfd4fe28a
   depends:
@@ -4480,7 +4480,7 @@ packages:
   license_family: BSD
   size: 1023573
   timestamp: 1681304595869
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
   sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
   md5: cf55cb8d7031b30c70c56fc7c782b5c7
   depends:
@@ -4493,7 +4493,7 @@ packages:
   license_family: MIT
   size: 156104
   timestamp: 1644482799136
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
   sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
   md5: 84fce327d9f0d594e86f565e5c21962e
   depends:
@@ -4502,7 +4502,7 @@ packages:
   license_family: BSD
   size: 10183
   timestamp: 1629146082730
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
   sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
   md5: 84b8b998a741b37abf5312c1c03696ef
   depends:
@@ -4512,7 +4512,7 @@ packages:
   license_family: MIT
   size: 33979
   timestamp: 1644845817952
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
   sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
   md5: 77b746931c8f31c3ae393ccb5819d43d
   depends:
@@ -4521,7 +4521,7 @@ packages:
   license_family: MIT
   size: 133628
   timestamp: 1695717890677
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
   sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
   md5: 3df6e8ba34208dea068890e5d5318cc0
   depends:
@@ -4531,12 +4531,12 @@ packages:
   license_family: MIT
   size: 206759
   timestamp: 1681493095987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
   sha256: 8c31e7ede4b9a3ec6e1342f02bcff4d7113e5b25f12b91d108616a08eb8eb34f
   md5: de3ce22af040eb01db773fcab23ef413
   depends:
@@ -4554,7 +4554,7 @@ packages:
   license_family: BSD
   size: 5722206
   timestamp: 1697490482051
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
   sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
   md5: bb55f81435cb6e11d264242274fccd1a
   depends:
@@ -4564,7 +4564,7 @@ packages:
   license_family: BSD
   size: 115947
   timestamp: 1657175645380
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
   md5: f860193e14afc7ef3f5b990a2ac003d2
   depends:
@@ -4574,7 +4574,7 @@ packages:
   license: MIT
   size: 18936
   timestamp: 1659616204016
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
   sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
   md5: ad53130f3fd1f8d3c2fcbb7496e5585d
   depends:
@@ -4583,7 +4583,7 @@ packages:
   license: MIT
   size: 18715
   timestamp: 1659616188888
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
   sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
   md5: 0982c046fb976e9f9fb19e7510187a18
   depends:
@@ -4592,14 +4592,14 @@ packages:
   license: MIT
   size: 366983
   timestamp: 1659616245272
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
   sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
   md5: 31ac2f5596cb7a44adf073c930641c54
   license: MPL-2.0
   license_family: Other
   size: 133817
   timestamp: 1694009762858
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
   sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
   md5: cf1f6c3c34a1e1b9ab22b04233d860f6
   depends:
@@ -4608,7 +4608,7 @@ packages:
   license_family: Other
   size: 159783
   timestamp: 1690232303987
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
   sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
   md5: 0eb268e38b5174d471a6e87d9d6102b1
   depends:
@@ -4619,7 +4619,7 @@ packages:
   license_family: MIT
   size: 225355
   timestamp: 1670423312966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
   sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
   md5: e68c94666cd60221b575c3814c89bac0
   depends:
@@ -4629,7 +4629,7 @@ packages:
   license_family: CC
   size: 1946451
   timestamp: 1668084573824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
   sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
   md5: 1773ae2b080cdd55827e27673351551e
   depends:
@@ -4639,7 +4639,7 @@ packages:
   license_family: BSD
   size: 13646
   timestamp: 1671231171682
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
   sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
   md5: 53bfd99ad1b09164d537209cffd98161
   depends:
@@ -4650,7 +4650,7 @@ packages:
   license_family: BSD
   size: 244040
   timestamp: 1663827469853
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
   sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
   md5: b62455043c8eb2434466885b19fed2de
   depends:
@@ -4663,7 +4663,7 @@ packages:
   license_family: BSD
   size: 1399573
   timestamp: 1694211828228
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
   sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
   md5: eb3cdc0fc210838b9271512a6a1b7c85
   depends:
@@ -4673,7 +4673,7 @@ packages:
   license_family: MIT
   size: 2067708
   timestamp: 1690905319109
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
   sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
   md5: f44b80b9405410e5bde6bfe0b31d5b3f
   depends:
@@ -4682,7 +4682,7 @@ packages:
   license_family: MIT
   size: 15135
   timestamp: 1650293774207
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
   sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
   md5: f87027ccce1361d0f82c0edf1a10d53b
   depends:
@@ -4691,7 +4691,7 @@ packages:
   license_family: BSD
   size: 27677
   timestamp: 1668714367519
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -4701,14 +4701,14 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
   sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
   md5: 1d0bd7e576c64c059ef781dd319ad82a
   license: MIT
   license_family: MIT
   size: 77591
   timestamp: 1676983230102
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
   sha256: 3e480af22e98246c056bbd91d6be5352df34ff2b8451d9c7f614baeafb450d39
   md5: 695fe7ccaf6935d3117533d1e6737320
   depends:
@@ -4725,7 +4725,7 @@ packages:
   license_family: BSD
   size: 4542265
   timestamp: 1698866834303
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
   sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
   md5: 69eb3b03765627b6159ed23cdde78396
   depends:
@@ -4734,7 +4734,7 @@ packages:
   license_family: MIT
   size: 28399065
   timestamp: 1692293207812
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
   sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
   md5: 83366cbd3beb073112f4644a613b6bca
   depends:
@@ -4743,7 +4743,7 @@ packages:
   license_family: BSD
   size: 111933
   timestamp: 1666125627512
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
   sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
   md5: 647c1a2f8460ffa8c670a1915bbdb494
   depends:
@@ -4753,7 +4753,7 @@ packages:
   license_family: APACHE
   size: 38790
   timestamp: 1678997152549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
   sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
   md5: 35e541905426c686ef2ff010a0e502fd
   depends:
@@ -4763,7 +4763,7 @@ packages:
   license_family: Apache
   size: 51860
   timestamp: 1698254731870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
   sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
   md5: 187d7720aedf38759d122cccb4576f2c
   depends:
@@ -4785,7 +4785,7 @@ packages:
   license_family: BSD
   size: 219976
   timestamp: 1691121991680
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
   sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
   md5: e8e7f10741f9cfa737b310b334940441
   depends:
@@ -4807,7 +4807,7 @@ packages:
   license_family: BSD
   size: 1255894
   timestamp: 1694181494549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
   sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
   md5: ff209e75aee17af2e358b0008fbe8c88
   depends:
@@ -4817,7 +4817,7 @@ packages:
   license_family: MIT
   size: 1022945
   timestamp: 1644315931223
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
   sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
   md5: d3e78ef296b3c74910d003bd10b475d6
   depends:
@@ -4827,14 +4827,14 @@ packages:
   license_family: BSD
   size: 213972
   timestamp: 1666908195870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
   sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
   md5: 055e12390b844ea6c6e956ee08a618e8
   license: IJG
   license_family: Other
   size: 273479
   timestamp: 1677849171867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
   sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
   md5: 783e2ad3d36472648c5ccc9f3051db3c
   depends:
@@ -4845,7 +4845,7 @@ packages:
   license_family: MIT
   size: 133077
   timestamp: 1676558732505
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
   sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
   md5: 0677598f673f9729b5990316170a999d
   depends:
@@ -4861,7 +4861,7 @@ packages:
   license_family: BSD
   size: 197129
   timestamp: 1676329661580
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.5.0-py39hca03da5_0.tar.bz2
   sha256: cee2cc791937b240be796561ae67e5a7c57b014826fa087fd75b02acf82135ba
   md5: 141af9befcd79a876ded744de7d1fa8f
   depends:
@@ -4872,7 +4872,7 @@ packages:
   license_family: BSD
   size: 79928
   timestamp: 1698937338528
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
   sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
   md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
   depends:
@@ -4896,7 +4896,7 @@ packages:
   license_family: BSD
   size: 401319
   timestamp: 1671707682572
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
   sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
   md5: 247558a0aecf1ef7e77a4343761353d6
   depends:
@@ -4906,7 +4906,7 @@ packages:
   license_family: BSD
   size: 64600
   timestamp: 1672387273585
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -4916,7 +4916,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -4925,13 +4925,13 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
   md5: a0f206782751dfffed0dd51302a1bf26
   license: MIT
   size: 68012
   timestamp: 1659616138077
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
   md5: 4c6667cdd061d28e9bc4e4300e4d115e
   depends:
@@ -4939,7 +4939,7 @@ packages:
   license: MIT
   size: 31173
   timestamp: 1659616155596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
   sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
   md5: 637e9430e258ddf050623ef2360184d8
   depends:
@@ -4947,28 +4947,28 @@ packages:
   license: MIT
   size: 298430
   timestamp: 1659616172209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
   sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
   md5: 55c615026c0869f8d3ba657f3bd38c43
   license: MIT
   license_family: MIT
   size: 120389
   timestamp: 1683716579036
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -4977,7 +4977,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -4988,14 +4988,14 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
   sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
   md5: a41117710dafe569c9cc4e83f6f29fe3
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1411339
   timestamp: 1650982753977
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -5006,7 +5006,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -5015,13 +5015,13 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -5038,7 +5038,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
   sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
   md5: 98d22e0124d55fae3c37c608dab1dcc9
   depends:
@@ -5052,7 +5052,7 @@ packages:
   license_family: BSD
   size: 89825
   timestamp: 1694778225280
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
   sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
   md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
   constrains:
@@ -5061,7 +5061,7 @@ packages:
   license_family: BSD
   size: 331675
   timestamp: 1694776939192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
   sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
   md5: 0ba499df6755eae5d2d23aa4ab004553
   depends:
@@ -5073,7 +5073,7 @@ packages:
   license_family: MIT
   size: 642657
   timestamp: 1692970217410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
   sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
   md5: c73101971e5ab6a8e8688239884eac81
   depends:
@@ -5083,7 +5083,7 @@ packages:
   license_family: MIT
   size: 241607
   timestamp: 1692973585084
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
   sha256: ac50f846e93e68d50bfdd5589ea8272b987243a64eba8e2e358ef311d7734001
   md5: f19270ff954a41dabbfe36ff0656935b
   depends:
@@ -5093,7 +5093,7 @@ packages:
   license_family: MIT
   size: 36040
   timestamp: 1659783399073
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -5102,7 +5102,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
   sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
   md5: 353dff9d5d996c2a260f66381b2ce3e8
   depends:
@@ -5113,7 +5113,7 @@ packages:
   license_family: Other
   size: 1470815
   timestamp: 1695058433965
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
   sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
   md5: c99006da802a97c9aae30da8c16b4820
   depends:
@@ -5122,7 +5122,7 @@ packages:
   license_family: BSD
   size: 176131
   timestamp: 1670944706815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
   sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
   md5: 60bd1e037cda86205526f77405d78129
   depends:
@@ -5132,7 +5132,7 @@ packages:
   license_family: BSD
   size: 123361
   timestamp: 1671541992772
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
   sha256: 2fd690fa3c54a40f0426874ea12e12aad2718263a75708ddd1fa6052a4ad7fb3
   md5: 81388724babfe9c32ea5cdd93633c342
   depends:
@@ -5142,7 +5142,7 @@ packages:
   license_family: MIT
   size: 107072
   timestamp: 1684280007887
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
   sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
   md5: 34dfd76da78de2eae95bbda390d746d6
   depends:
@@ -5153,7 +5153,7 @@ packages:
   license_family: BSD
   size: 23092
   timestamp: 1654598007056
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.8.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-3.8.0-py39hca03da5_0.tar.bz2
   sha256: f6d7d0f791face4d911f5907df48e093cebcd1da188ba3d3267bf858d6dcacaf
   md5: 6a55e97ce33cd40a280f538dd5437eff
   depends:
@@ -5164,7 +5164,7 @@ packages:
   license_family: PSF
   size: 8725
   timestamp: 1698692342704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
   sha256: bf0eeef3c3c713515766ab8b0dc7863413de5b4b227deede97e24d90ca342345
   md5: a7bba1857eb84fb50caea377e60d2050
   depends:
@@ -5186,7 +5186,7 @@ packages:
   license_family: PSF
   size: 8066509
   timestamp: 1698692266161
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
   sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
   md5: eb79dabbeedee7da85dfbfb145bb8a26
   depends:
@@ -5196,7 +5196,7 @@ packages:
   license_family: BSD
   size: 17342
   timestamp: 1662014601345
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
   sha256: f400ad75dd2890627dc948f3e2e6b19732d02c124723eaf22272026993a94d52
   md5: 4a4ffc7365e30b18f4443281839e2718
   depends:
@@ -5206,7 +5206,7 @@ packages:
   license_family: MIT
   size: 53505
   timestamp: 1659721313693
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
   sha256: 20fb26a7ac748ce288cf8483a837b0c33f1348ae738bcdb69cdc2763c7bbf7e1
   md5: a0aebbc6c170ebd8d4710fd70b3db503
   depends:
@@ -5215,7 +5215,7 @@ packages:
   license_family: MIT
   size: 19562
   timestamp: 1659716131839
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
   sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
   md5: 56db7bd3ff511cd839bda081523b3edd
   depends:
@@ -5224,7 +5224,7 @@ packages:
   license_family: BSD
   size: 55683
   timestamp: 1629356128780
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
   sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
   md5: 176e0dcaeb28393881bacf69941e3889
   depends:
@@ -5250,7 +5250,7 @@ packages:
   license_family: BSD
   size: 8289638
   timestamp: 1681756329011
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py39hca03da5_0.tar.bz2
   sha256: d34fcad560dcc7b8e7df2a0250be9694a02e072aa7f7d4992ebd427665575a8e
   md5: 5972b5a5fbac5cea54ee0ff2cef85897
   depends:
@@ -5263,7 +5263,7 @@ packages:
   license_family: BSD
   size: 100843
   timestamp: 1698934268054
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
   sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
   md5: 150ea9fadddf21993d3328d3e48a18b7
   depends:
@@ -5291,7 +5291,7 @@ packages:
   license_family: BSD
   size: 557688
   timestamp: 1668450759059
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
   sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
   md5: 37163b32508f9f589b3e6462a3a47546
   depends:
@@ -5304,14 +5304,14 @@ packages:
   license_family: BSD
   size: 148426
   timestamp: 1694616771736
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
   sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
   md5: 6cdf7cbc43bf40e92b056a5576bd0086
   depends:
@@ -5320,7 +5320,7 @@ packages:
   license_family: BSD
   size: 14163
   timestamp: 1672387216468
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/networkx-3.1-py39hca03da5_0.tar.bz2
   sha256: 05a45d181b83b1eb136e35faf77bcd916adbdb49e178dd563da44f8227594956
   md5: cdded8a3b2576bf9a2f103d396c47889
   depends:
@@ -5329,7 +5329,7 @@ packages:
   license_family: BSD
   size: 2964776
   timestamp: 1690562172192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
   sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
   md5: 0f05853a139b6cda9c73e9d2707a4976
   depends:
@@ -5354,7 +5354,7 @@ packages:
   license_family: BSD
   size: 590288
   timestamp: 1690984971741
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
   sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
   md5: 7de782e4fb34bfa95ef2fc79d27d727d
   depends:
@@ -5364,7 +5364,7 @@ packages:
   license_family: BSD
   size: 22840
   timestamp: 1668160634885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
   sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
   md5: 1a7b23113372c5667dbfe45976b9cc5c
   depends:
@@ -5375,7 +5375,7 @@ packages:
   license_family: MIT
   size: 126357
   timestamp: 1696515322390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
   sha256: 3cd1161558704176560843586b1b1f9b257fd68c0ca53a2fc09e61267f47514c
   md5: dd162b2716dc9daf732240a343862d4a
   depends:
@@ -5388,7 +5388,7 @@ packages:
   license_family: BSD
   size: 10388
   timestamp: 1695830584640
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
   sha256: 5f35d8c0e1768fa3a9d2e75659cd2096bea6b4e021afea114f573e95f4943fb2
   md5: 958f78b1e2299537996f98da7a930198
   depends:
@@ -5402,7 +5402,7 @@ packages:
   license_family: BSD
   size: 6313331
   timestamp: 1695830570878
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
   sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
   md5: 371358a54bbdd307603888348d1a2c6f
   depends:
@@ -5412,7 +5412,7 @@ packages:
   license: BSD 2-Clause
   size: 412248
   timestamp: 1628861367714
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
   sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
   md5: fa15d3b44ae1360ac9b640bbd5b6923c
   depends:
@@ -5421,7 +5421,7 @@ packages:
   license_family: Apache
   size: 4746123
   timestamp: 1695322833432
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
   sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
   md5: d73db95f07a282021efdf8bc09713261
   depends:
@@ -5430,7 +5430,7 @@ packages:
   license_family: Apache
   size: 73620
   timestamp: 1693575195999
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
   sha256: 247b5e4d81b6d5d013a9c27e1f30c41fff896fed98a68ebda26b19b4062a6828
   md5: 354a1d65300b4309d53dfa648014e8fe
   depends:
@@ -5477,7 +5477,7 @@ packages:
   license_family: BSD
   size: 13257999
   timestamp: 1697478739906
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
   sha256: 90a1889cd0004bfc5e12ac94b4ea92718a473373033bb0ba5259804ed67bf2bc
   md5: e89f615737385fee88150ab4adf037e6
   depends:
@@ -5501,7 +5501,7 @@ packages:
   license_family: BSD
   size: 17147015
   timestamp: 1698866800249
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
   sha256: 0ae09c974297767a707642344c40f484281f0a3000251a6234e46ef19f00c10e
   md5: 64a0eaf3381e9f6aa971229501710798
   depends:
@@ -5510,7 +5510,7 @@ packages:
   license_family: BSD
   size: 189313
   timestamp: 1698263486159
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
   sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
   md5: 6e01c592ae3b8ff2d12cae76f2f4276b
   depends:
@@ -5529,7 +5529,7 @@ packages:
   license_family: Other
   size: 715239
   timestamp: 1696580071596
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
   sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
   md5: 9fb8f460c130d56caf33c6bbe46fbe8a
   depends:
@@ -5540,7 +5540,7 @@ packages:
   license_family: MIT
   size: 2678841
   timestamp: 1697548790931
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
   sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
   md5: 390b8c3cd74281abecdbfd51476922f9
   depends:
@@ -5549,7 +5549,7 @@ packages:
   license_family: MIT
   size: 33033
   timestamp: 1692205747301
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
   sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
   md5: 7896828fb3565fefad43f980d50c8723
   depends:
@@ -5558,7 +5558,7 @@ packages:
   license_family: Apache
   size: 91190
   timestamp: 1659455206354
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
   sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
   md5: d934c74eb66d01af0f45f0881f4bab77
   depends:
@@ -5570,7 +5570,7 @@ packages:
   license_family: BSD
   size: 580588
   timestamp: 1672387390426
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
   sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
   md5: 9858166e5ffb624c8b9d281f4000d725
   depends:
@@ -5579,7 +5579,7 @@ packages:
   license_family: BSD
   size: 367167
   timestamp: 1656431368885
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
   sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
   md5: 4d2b45c6be8221e6a3e44c2d5838426f
   depends:
@@ -5591,7 +5591,7 @@ packages:
   license_family: BSD
   size: 30843
   timestamp: 1675441531640
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
   sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
   md5: 02521df4e2e79f75faa9cbb3560ab1dd
   depends:
@@ -5600,7 +5600,7 @@ packages:
   license_family: BSD
   size: 1861763
   timestamp: 1684280026169
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
   sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
   md5: bdebe59bffc7adbad83fdcd9d429a5f5
   depends:
@@ -5610,7 +5610,7 @@ packages:
   license_family: Apache
   size: 95234
   timestamp: 1690223494699
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
   sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
   md5: d716e5c9b5eec45ce1df8eb52cab817a
   depends:
@@ -5619,7 +5619,7 @@ packages:
   license_family: MIT
   size: 157408
   timestamp: 1661452601692
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
   sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
   md5: 1907629863ed8e7c35ead232dae7693f
   depends:
@@ -5628,7 +5628,7 @@ packages:
   license_family: MIT
   size: 91636
   timestamp: 1628941083263
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
   sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
   md5: 847b9bddf2a86e1609c0d53bbc23ea79
   depends:
@@ -5637,7 +5637,7 @@ packages:
   license_family: BSD
   size: 27378
   timestamp: 1626781391140
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
   sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
   md5: 18aa18bd0d260605923877921d26cc74
   depends:
@@ -5656,7 +5656,7 @@ packages:
   license_family: PSF
   size: 13194025
   timestamp: 1694438901368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
   sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
   md5: 45642a99c83e7aed74d1ffab1f20145b
   depends:
@@ -5665,7 +5665,7 @@ packages:
   license_family: BSD
   size: 266647
   timestamp: 1661368655993
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
   sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
   md5: fec748525144049a2fc7f52f9755232c
   depends:
@@ -5674,7 +5674,7 @@ packages:
   license_family: MIT
   size: 257235
   timestamp: 1695131702047
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
   sha256: 960192a143672e9c1d6fe4027af448512d91eee7501e5c245c21b865cf8bf429
   md5: 76d491244218505f071ba56a308673df
   depends:
@@ -5684,7 +5684,7 @@ packages:
   license_family: BSD
   size: 40950
   timestamp: 1685030774581
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
   sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
   md5: 3445d25415998c807efbe64d3a7e03c8
   depends:
@@ -5694,7 +5694,7 @@ packages:
   license_family: MIT
   size: 167068
   timestamp: 1698096118071
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
   sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
   md5: e6e92da28e9b0e428ed4b7df417bec25
   depends:
@@ -5705,7 +5705,7 @@ packages:
   license_family: BSD
   size: 472418
   timestamp: 1657724315435
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -5714,7 +5714,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
   sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
   md5: dba22515f36d3c266de5896350813ea2
   depends:
@@ -5730,7 +5730,7 @@ packages:
   license_family: Apache
   size: 95103
   timestamp: 1690400315537
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
   sha256: c35449c0ca64d0d6a23c019b6eba188f546e42379857cbc4240bbdddee1159d3
   md5: 61cb82346e21710f3e0645096cda4e12
   depends:
@@ -5746,7 +5746,7 @@ packages:
   license_family: BSD
   size: 22859180
   timestamp: 1696543469561
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
   sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
   md5: 3cd7eb43e285faba76faf67667e26b00
   depends:
@@ -5755,7 +5755,7 @@ packages:
   license_family: MIT
   size: 1093916
   timestamp: 1690290951258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
   sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
   md5: c5e9aef0d6895de1c927e9d796cd7cd3
   depends:
@@ -5764,7 +5764,7 @@ packages:
   license_family: Apache
   size: 15691
   timestamp: 1629145910454
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
   sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
   md5: 0f7c229e774146ffc4e29dedf75372bf
   depends:
@@ -5773,7 +5773,7 @@ packages:
   license_family: MIT
   size: 67279
   timestamp: 1696347632563
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
   sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
   md5: 2302a79a045f152e183a52a81adfba62
   depends:
@@ -5785,7 +5785,7 @@ packages:
   license_family: Other
   size: 1674163
   timestamp: 1681394762218
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
   sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
   md5: 4ae67163d55cf9df83d4027ebc38c501
   depends:
@@ -5796,7 +5796,7 @@ packages:
   license_family: BSD
   size: 30894
   timestamp: 1671751931536
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
   sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
   md5: dbb5c0cddb6661a89afee647fd3dc01e
   depends:
@@ -5806,7 +5806,7 @@ packages:
   license_family: BSD
   size: 39875
   timestamp: 1668168874870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
   sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
   md5: 667e60c8b407d73cbba40f44901f4f00
   depends:
@@ -5815,7 +5815,7 @@ packages:
   license_family: BSD
   size: 3412693
   timestamp: 1654088929697
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
   sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
   md5: 884f788a5f6a664c9b79f7a4a60362d0
   depends:
@@ -5824,7 +5824,7 @@ packages:
   license_family: Apache
   size: 680561
   timestamp: 1696937004165
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
   sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
   md5: 639a4f489af172c866c18442948e5874
   depends:
@@ -5837,7 +5837,7 @@ packages:
   license_family: MOZILLA
   size: 125170
   timestamp: 1679561942932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
   sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
   md5: e5b90eba83fddba6d7aa6072b5bf7c91
   depends:
@@ -5846,7 +5846,7 @@ packages:
   license_family: BSD
   size: 193017
   timestamp: 1671143921826
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
   md5: 644ef8830437070f60efcfcd6a987198
   depends:
@@ -5856,7 +5856,7 @@ packages:
   license_family: PSF
   size: 9670
   timestamp: 1690297532002
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
   sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
   md5: a902a833bb186a2f1a4b2b89b1195136
   depends:
@@ -5865,7 +5865,7 @@ packages:
   license_family: PSF
   size: 58466
   timestamp: 1690297524418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
   sha256: 536045a8a172c651fd306c285a6d7409775f018dac944f2124c538ccfb195e28
   md5: d4dc6cdf0812191b9ec78b35b4fdf3e0
   depends:
@@ -5874,7 +5874,7 @@ packages:
   license_family: MIT
   size: 11593
   timestamp: 1659769477205
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
   sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
   md5: f3f1d2c1028dad2f11ff950a15c99dbf
   depends:
@@ -5889,7 +5889,7 @@ packages:
   license_family: MIT
   size: 188640
   timestamp: 1698257577209
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
   sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
   md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
   depends:
@@ -5898,7 +5898,7 @@ packages:
   license_family: BSD
   size: 20091
   timestamp: 1629144441130
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
   sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
   md5: 3089c63bf8f4d0423e1a287da286d83e
   depends:
@@ -5908,7 +5908,7 @@ packages:
   license_family: BSD
   size: 70923
   timestamp: 1629357115820
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
   sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
   md5: 5886b30b312445471268444f41f39dc7
   depends:
@@ -5917,7 +5917,7 @@ packages:
   license_family: MIT
   size: 102583
   timestamp: 1695741976083
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
   sha256: 105e39d3eb51b47c7244b3379c0133ab7051966664f52835453b14509215b159
   md5: ed20012c2cd99ffd04cca9929e0bc061
   depends:
@@ -5926,20 +5926,20 @@ packages:
   license_family: BSD
   size: 49775
   timestamp: 1675159079039
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
   sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
   md5: 2e75ad6a09c308268192efe03cc9ebf4
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_family: GPL2
   size: 411778
   timestamp: 1683113019715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
   sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
   md5: 30f666bf97c26587c5d2f68cc5f330ab
   depends:
@@ -5948,7 +5948,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 316901
   timestamp: 1629287855861
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
   sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
   md5: 584e591d36dcd5ba5c45404f0f7ebb2d
   depends:
@@ -5957,14 +5957,14 @@ packages:
   license_family: MIT
   size: 19076
   timestamp: 1672387153578
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
   sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
   md5: 467ae28215d1aa1c5688bc0c8a184269
   license: Zlib
   license_family: Other
   size: 103525
   timestamp: 1666595022664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
   sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
   md5: 7cfbed15f1feee1422810f7830075f53
   depends:
@@ -5976,7 +5976,7 @@ packages:
   license_family: BSD
   size: 779464
   timestamp: 1681304594848
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
   sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
   md5: ed14f9bc6e55220483f1a5a388625a08
   depends:
@@ -5989,7 +5989,7 @@ packages:
   license_family: MIT
   size: 162772
   timestamp: 1644481986085
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
   sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
   md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
   depends:
@@ -6001,7 +6001,7 @@ packages:
   license_family: MIT
   size: 39253
   timestamp: 1644551767970
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
   sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
   md5: b24d13c443a26f65a0778b475a5726bc
   depends:
@@ -6010,7 +6010,7 @@ packages:
   license_family: MIT
   size: 132830
   timestamp: 1695717959996
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
   sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
   md5: 302c3c0696e17eaa62e140e3892644ae
   depends:
@@ -6020,12 +6020,12 @@ packages:
   license_family: MIT
   size: 199723
   timestamp: 1681493196911
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
   sha256: 812f268862208c2518b5187809a8571adb488de3604d512721035e65458dde76
   md5: 97ce620b7dd3ee743d0ca28ed66ace74
   depends:
@@ -6043,7 +6043,7 @@ packages:
   license_family: BSD
   size: 5721832
   timestamp: 1697491241383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
   sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
   md5: bf930260f679bc74227bbb18bc36ae82
   depends:
@@ -6055,7 +6055,7 @@ packages:
   license_family: BSD
   size: 119700
   timestamp: 1657176150595
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
   md5: 507dfe693ef429f466d964b599f4af21
   depends:
@@ -6067,7 +6067,7 @@ packages:
   license: MIT
   size: 18650
   timestamp: 1659616328001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
   md5: d0bf43e8df60baae3b3105aa5c42a791
   depends:
@@ -6078,7 +6078,7 @@ packages:
   license: MIT
   size: 21153
   timestamp: 1659616312367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
   sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
   md5: 7bd24bf94c24e810aecaaf84a0978e6f
   depends:
@@ -6088,14 +6088,14 @@ packages:
   license: MIT
   size: 343204
   timestamp: 1659616543542
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
   sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
   md5: 092b417c11edcbe6bb9b765ab4a55d23
   license: MPL-2.0
   license_family: Other
   size: 164999
   timestamp: 1694009822357
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
   sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
   md5: 708a750d370b9d6875651021e21c4446
   depends:
@@ -6104,7 +6104,7 @@ packages:
   license_family: Other
   size: 159322
   timestamp: 1690232335307
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
   sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
   md5: c35736da3ea26782425e78061268cf5e
   depends:
@@ -6116,7 +6116,7 @@ packages:
   license_family: MIT
   size: 228713
   timestamp: 1670423312743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
   sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
   md5: 457a4339a53c033d48ce0c72e5038d2e
   depends:
@@ -6125,7 +6125,7 @@ packages:
   license_family: BSD
   size: 30330
   timestamp: 1672387265402
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
   sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
   md5: 59ec65fd9e06b81a65cc12986c67d5da
   depends:
@@ -6135,7 +6135,7 @@ packages:
   license_family: CC
   size: 1939614
   timestamp: 1668084794027
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
   sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
   md5: 3489c1a2b73fc957b5a62cc59349e25b
   depends:
@@ -6145,7 +6145,7 @@ packages:
   license_family: BSD
   size: 13438
   timestamp: 1671231196438
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
   sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
   md5: 3492b96083c1e904cc32d26ea7f1e1d8
   depends:
@@ -6157,7 +6157,7 @@ packages:
   license_family: BSD
   size: 184280
   timestamp: 1663827558327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
   sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
   md5: f46d904bc6f220327e70474971341f52
   depends:
@@ -6172,7 +6172,7 @@ packages:
   license_family: BSD
   size: 1220835
   timestamp: 1694445639066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
   sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
   md5: 2ff4fb509788b0e47ac684ba151394d0
   depends:
@@ -6183,7 +6183,7 @@ packages:
   license_family: MIT
   size: 3289966
   timestamp: 1690907040646
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
   sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
   md5: 0f166c3e70541d8bee6e9d0cb60fb66e
   depends:
@@ -6192,7 +6192,7 @@ packages:
   license_family: MIT
   size: 16979
   timestamp: 1649926678161
-- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
   sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
   md5: ea93d413944ca6a8677eb1b284b136ae
   depends:
@@ -6201,7 +6201,7 @@ packages:
   license_family: BSD
   size: 27388
   timestamp: 1668714577678
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -6213,7 +6213,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
   sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
   md5: 9f167d3e45441bc3633c1974b1b0ce8c
   depends:
@@ -6223,7 +6223,7 @@ packages:
   license_family: MIT
   size: 88421
   timestamp: 1676983264486
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
   sha256: fa8f868e49721ca19912f816a6da221172758f9e3d28d8b31d53249fb14dc25f
   md5: 09f9a2cea9425d76dccf9b026afe5bb2
   depends:
@@ -6240,13 +6240,13 @@ packages:
   license_family: BSD
   size: 4576915
   timestamp: 1698866895838
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
   sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
   md5: 582d2c1135a89da757a038de831e7f39
   license: Intel proprietary
   size: 11086648
   timestamp: 1664812389803
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
   sha256: 945f4521793d7d279532d1ccd5157201c5cbf64f846bfe60249d01e1b4edf295
   md5: 0accae23d095c165ac731f4a1f3ca497
   depends:
@@ -6256,7 +6256,7 @@ packages:
   license_family: MIT
   size: 37021132
   timestamp: 1692294548916
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
   sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
   md5: 30fdefd1541c789c163751291a8faa88
   depends:
@@ -6265,7 +6265,7 @@ packages:
   license_family: BSD
   size: 111448
   timestamp: 1666125667599
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
   sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
   md5: a10f07c7a3510272a296f9fed458a4ed
   depends:
@@ -6275,7 +6275,7 @@ packages:
   license_family: APACHE
   size: 38098
   timestamp: 1678997241511
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
   sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
   md5: fad9cf2023d807da8d44996e9d4399a0
   depends:
@@ -6285,7 +6285,7 @@ packages:
   license_family: Apache
   size: 51490
   timestamp: 1698254721864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
   sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
   md5: 9834848bd7c7759acf12e78d09388563
   depends:
@@ -6295,7 +6295,7 @@ packages:
   license_family: Proprietary
   size: 3891030
   timestamp: 1681801474383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
   sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
   md5: 1285c8c628bc912c54d0968574c9f4c9
   depends:
@@ -6316,7 +6316,7 @@ packages:
   license_family: BSD
   size: 217232
   timestamp: 1691122695748
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
   sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
   md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
   depends:
@@ -6337,7 +6337,7 @@ packages:
   license_family: BSD
   size: 1279433
   timestamp: 1694181820978
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
   sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
   md5: f5fcce35d3f21cdfc5893c5a7a86c651
   depends:
@@ -6347,7 +6347,7 @@ packages:
   license_family: MIT
   size: 1035394
   timestamp: 1644315567034
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
   sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
   md5: f67fe3337528e2886f1ac3ab8ac37985
   depends:
@@ -6357,7 +6357,7 @@ packages:
   license_family: BSD
   size: 213110
   timestamp: 1666908350218
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
   sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
   md5: 81f2c343dc4c65eea39c45383272068f
   depends:
@@ -6367,7 +6367,7 @@ packages:
   license_family: Other
   size: 407861
   timestamp: 1677849239400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
   sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
   md5: bd9526d38a145fe311a8aa36bc11e071
   depends:
@@ -6378,7 +6378,7 @@ packages:
   license_family: MIT
   size: 152006
   timestamp: 1676558783570
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
   sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
   md5: a00e6a62956fde3c4135464353ee8a53
   depends:
@@ -6394,7 +6394,7 @@ packages:
   license_family: BSD
   size: 229158
   timestamp: 1676330909084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.5.0-py39haa95532_0.tar.bz2
   sha256: e840d6b322faa7d5fee2c54ed6074e3a6b7fe38a9356020a4027d9e09c40a1a1
   md5: 038bb985c0d43bf77a8e772f4c4ad22a
   depends:
@@ -6406,7 +6406,7 @@ packages:
   license_family: BSD
   size: 103854
   timestamp: 1698937448209
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
   sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
   md5: 5efa1332f7c0a8d9638eda02170c4ce5
   depends:
@@ -6431,7 +6431,7 @@ packages:
   license_family: BSD
   size: 413653
   timestamp: 1671707957673
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
   sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
   md5: 891fe66a24d8714737b2874985ee1303
   depends:
@@ -6442,7 +6442,7 @@ packages:
   license_family: BSD
   size: 62298
   timestamp: 1672388166096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
   sha256: ef6b0347ae565dd648a2bb40bc8b0b30f2e4f8387778fefced1d581b7d5a3e16
   md5: 8ef1d5919aa55fe56ef34d9a7969dca7
   depends:
@@ -6453,7 +6453,7 @@ packages:
   license_family: MIT
   size: 861982
   timestamp: 1684424430941
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -6463,7 +6463,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
   sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
   md5: c345f51706eef530454f66b794e5e574
   depends:
@@ -6472,7 +6472,7 @@ packages:
   license: MIT
   size: 68189
   timestamp: 1659616216976
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
   md5: a7400cfb72042977bc047909ed504ce8
   depends:
@@ -6482,7 +6482,7 @@ packages:
   license: MIT
   size: 33743
   timestamp: 1659616248209
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
   sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
   md5: 6307f6854754ab5bd7c84e6998385bb1
   depends:
@@ -6492,7 +6492,7 @@ packages:
   license: MIT
   size: 733177
   timestamp: 1659616279453
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
   sha256: bb17beae8860a83d081d57273825b46bf8fe9903f3b4182ab41a7ae2c7274859
   md5: 94182f4ab8beb4eddfd8167b2e2b0380
   depends:
@@ -6504,7 +6504,7 @@ packages:
   license_family: Apache
   size: 147804
   timestamp: 1681225547009
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
   sha256: 01b84a38c9069e7b8e6fa2a07707e785df7d40b8f01d76a504e98e5a5cd58539
   md5: 22c9f7e59174c49f06e3c5c9384401ce
   depends:
@@ -6515,7 +6515,7 @@ packages:
   license_family: Apache
   size: 25699299
   timestamp: 1681225463612
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -6525,7 +6525,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
   sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
   md5: b812bc5d9c76242e2bb2ac87afe7d39b
   depends:
@@ -6535,7 +6535,7 @@ packages:
   license_family: GPL3
   size: 730280
   timestamp: 1650983734373
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -6546,7 +6546,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
   sha256: a36ea5c77075e90f47d3f5c1e2081c0c1c78c5c0a5135bf9a6448fca67bbc79d
   md5: a0a02817a7def0563d1635035c26451b
   depends:
@@ -6557,7 +6557,7 @@ packages:
   - zlib >=1.2.13,<2.0.0a0
   size: 3827890
   timestamp: 1687382140999
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -6566,7 +6566,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -6583,7 +6583,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
   sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
   md5: ba9418df9288a2f031a02fa35b774ce0
   depends:
@@ -6599,7 +6599,7 @@ packages:
   license_family: BSD
   size: 78524
   timestamp: 1694778314659
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
   sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
   md5: b1781519a200ccbfcb4a1194005aa3ef
   depends:
@@ -6611,7 +6611,7 @@ packages:
   license_family: BSD
   size: 338459
   timestamp: 1694777084290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
   sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
   md5: 6ece7f1a3248169837714d05d7f6ef0a
   depends:
@@ -6623,7 +6623,7 @@ packages:
   license_family: MIT
   size: 3513910
   timestamp: 1692971505729
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
   sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
   md5: bd7ec244935e83e850a4ff34e8e2e64f
   depends:
@@ -6634,7 +6634,7 @@ packages:
   license_family: MIT
   size: 513971
   timestamp: 1692973657152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
   sha256: e1c0e745d9ba36a80773e841d96bf514ad1ceda419e4188aad3c22782af00234
   md5: f226532e9bb308f20e874c56be6ceefb
   depends:
@@ -6644,7 +6644,7 @@ packages:
   license_family: MIT
   size: 35788
   timestamp: 1659783414586
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
   sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
   md5: fb7881e74b59262df0fa4ec981964efc
   depends:
@@ -6657,7 +6657,7 @@ packages:
   license_family: Other
   size: 1244887
   timestamp: 1695058550693
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
   sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
   md5: 6970c7f46b0164cad1d210e7a1419959
   depends:
@@ -6667,7 +6667,7 @@ packages:
   license_family: BSD
   size: 143434
   timestamp: 1670944902624
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
   sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
   md5: 1015298551c040c6d5e26eebbae12ef5
   depends:
@@ -6677,7 +6677,7 @@ packages:
   license_family: BSD
   size: 142316
   timestamp: 1671542240512
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
   sha256: ab5c246c2b271acc1cdd0b9343989c0166681536e569cdbe71618f55d34c7292
   md5: 7ce68d771cd94c9ff5efefe69d327c9a
   depends:
@@ -6687,7 +6687,7 @@ packages:
   license_family: MIT
   size: 125122
   timestamp: 1684280210213
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
   sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
   md5: 466da740fafef3d6bce114220f0be306
   depends:
@@ -6700,7 +6700,7 @@ packages:
   license_family: BSD
   size: 28510
   timestamp: 1654508162239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.8.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-3.8.0-py39haa95532_0.tar.bz2
   sha256: 3ee1e0b89c9a16ed21af80d9883d7638227028cac76ab24b5dcb4aa25dcd5536
   md5: 0ec5d4cee9f74324b4bf0a653e53681b
   depends:
@@ -6712,7 +6712,7 @@ packages:
   license_family: PSF
   size: 8485
   timestamp: 1698692858409
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
   sha256: 1687ae122ee7d8b583141fc5014b76d494841dc8083b854449e3d6e0f6bb7019
   md5: 3697ac26ee3c2d49338dd5b9c6551152
   depends:
@@ -6735,7 +6735,7 @@ packages:
   license_family: PSF
   size: 8080067
   timestamp: 1698692812610
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
   sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
   md5: a9fa43e694b25cd49b8b08a9eefd696e
   depends:
@@ -6745,7 +6745,7 @@ packages:
   license_family: BSD
   size: 18054
   timestamp: 1661915903969
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
   sha256: 8aa14047fac6ef8b326900c4bf1a960eaa7a1699c18fdf1e75a59101b610b6df
   md5: 7e1d4d4700fbea6171d30f1d5ad24226
   depends:
@@ -6755,7 +6755,7 @@ packages:
   license_family: MIT
   size: 53362
   timestamp: 1659721308586
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
   sha256: 2017814a7cc93dd51c6b7c016e3cdf8fbc32fa20f985638aaff6a6377e9ee086
   md5: a1a285c56b001c3b5c591bf21eec3149
   depends:
@@ -6764,7 +6764,7 @@ packages:
   license_family: MIT
   size: 19326
   timestamp: 1659716205153
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
   sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
   md5: 248c468abced874f0231d3cc23177c77
   depends:
@@ -6775,7 +6775,7 @@ packages:
   license_family: BSD
   size: 58488
   timestamp: 1607359497934
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
   sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
   md5: 5e763c995ff0c549f68a10bce70fede4
   depends:
@@ -6787,7 +6787,7 @@ packages:
   license_family: Proprietary
   size: 187489950
   timestamp: 1691503804820
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
   sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
   md5: dd0c2ece6a743c373c9b5a5919b4818f
   depends:
@@ -6799,7 +6799,7 @@ packages:
   license_family: BSD
   size: 49744
   timestamp: 1682975040154
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
   sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
   md5: 57cea8df7ab85f2a98f64d23afcb1f90
   depends:
@@ -6814,7 +6814,7 @@ packages:
   license_family: BSD
   size: 184956
   timestamp: 1695058491736
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
   sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
   md5: 8769cdd201d905069800488fe31574e5
   depends:
@@ -6829,7 +6829,7 @@ packages:
   license_family: BSD
   size: 256221
   timestamp: 1695060152521
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
   sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
   md5: d9781492332e6326f9fca87f3a8efacd
   depends:
@@ -6855,7 +6855,7 @@ packages:
   license_family: BSD
   size: 8135792
   timestamp: 1681756491399
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py39haa95532_0.tar.bz2
   sha256: 49715dd545469a4458cdf0d0d55c9a7af7cb7a2da8a6504a60dd3089714015ae
   md5: 4257087772bed974078f56673ca50d99
   depends:
@@ -6868,7 +6868,7 @@ packages:
   license_family: BSD
   size: 119351
   timestamp: 1698934436390
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
   sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
   md5: f1d8ce412e115986c403f223b3b47d0f
   depends:
@@ -6896,7 +6896,7 @@ packages:
   license_family: BSD
   size: 596314
   timestamp: 1668451106600
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
   sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
   md5: f96bbef0985d7e66ebf00c0d55e30e23
   depends:
@@ -6909,7 +6909,7 @@ packages:
   license_family: BSD
   size: 167045
   timestamp: 1694617078743
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
   sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
   md5: 6e6ba64c8dc5025aeac606404a8df36a
   depends:
@@ -6918,7 +6918,7 @@ packages:
   license_family: BSD
   size: 13786
   timestamp: 1672387480065
-- conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/networkx-3.1-py39haa95532_0.tar.bz2
   sha256: 55847705e1cb4c384a61611e15a0beb52d745b30e0fced2d9a3daa877b3d712f
   md5: 5082bfa6e6400284e8e3833a7874b789
   depends:
@@ -6927,7 +6927,7 @@ packages:
   license_family: BSD
   size: 2928272
   timestamp: 1690562181595
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
   sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
   md5: 4a7a3286484766741f627696697c362c
   depends:
@@ -6952,7 +6952,7 @@ packages:
   license_family: BSD
   size: 609425
   timestamp: 1690985686105
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
   sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
   md5: 4269a1f93882205b90d4b2ae78fc82d5
   depends:
@@ -6962,7 +6962,7 @@ packages:
   license_family: BSD
   size: 22417
   timestamp: 1668160717305
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
   sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
   md5: a18a576b7024cfd6f905c526a786a916
   depends:
@@ -6977,7 +6977,7 @@ packages:
   license_family: MIT
   size: 135285
   timestamp: 1696515698492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
   sha256: e5e11f9b42d770ee46ac24d1cdf7aa4e9c49a60a607c8c28e7729131a99eadd5
   md5: 4274d06db8a9a381c072d226d0322dc0
   depends:
@@ -6994,7 +6994,7 @@ packages:
   license_family: BSD
   size: 9835
   timestamp: 1695830845329
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
   sha256: dcaa1607ce40a0ed610dd5398e125c8e5b08e738e50b6037a8c72b49ca561ff2
   md5: d99d990a60644b97ba1ff9bb8da0e66f
   depends:
@@ -7010,7 +7010,7 @@ packages:
   license_family: BSD
   size: 6778113
   timestamp: 1695830816710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
   sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
   md5: ab07e2a27ac08afe3d0b4c0890b8486a
   depends:
@@ -7021,7 +7021,7 @@ packages:
   license: BSD 2-Clause
   size: 249316
   timestamp: 1630094024143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
   sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
   md5: 73b17037d87b5a58feb34dafc0538f7f
   depends:
@@ -7032,7 +7032,7 @@ packages:
   license_family: Apache
   size: 8058396
   timestamp: 1695324589828
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
   sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
   md5: df1d746ba8d5d6ba01ac1373b9b71e1a
   depends:
@@ -7041,7 +7041,7 @@ packages:
   license_family: Apache
   size: 73016
   timestamp: 1693575484990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
   sha256: 1994e5831fd421bd6cf85916073d4012dec53e673b672b3985efaf771f0a7bf8
   md5: c486a5b51e3227f6ea564a9dd3125e45
   depends:
@@ -7089,7 +7089,7 @@ packages:
   license_family: BSD
   size: 12629931
   timestamp: 1697479885371
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
   sha256: 270e4c3ab0f0c8d8f31fa0e45bc516c1e41be618a5c66e1c86dc39ce76cb2372
   md5: cad52ba9eb391416112f0994b6c35249
   depends:
@@ -7113,7 +7113,7 @@ packages:
   license_family: BSD
   size: 17162886
   timestamp: 1698867967809
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
   sha256: 56eaf7f4b1bb81e3deed55711dd2ee78f244a3cc0ad4bb7a1f09d97e46f9793f
   md5: c24a3daed1e85ba7a100fa6966c5bb48
   depends:
@@ -7122,7 +7122,7 @@ packages:
   license_family: BSD
   size: 189021
   timestamp: 1698263520538
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
   sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
   md5: 427c1450bebb632f43bbc8c83006e4cd
   depends:
@@ -7141,7 +7141,7 @@ packages:
   license_family: Other
   size: 806931
   timestamp: 1696580240310
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
   sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
   md5: 21790cd3e2b8a45c4104aff0a68330d0
   depends:
@@ -7152,7 +7152,7 @@ packages:
   license_family: MIT
   size: 3001751
   timestamp: 1697549357662
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
   sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
   md5: 56f44a1054da2d10777e375838191070
   depends:
@@ -7161,7 +7161,7 @@ packages:
   license_family: MIT
   size: 32355
   timestamp: 1692205784293
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
   sha256: bbcef9bbf4ccd051becaa7d8aa88cb5f46ff64570cc395b6a471332d8b900e11
   md5: 0daf62b71923d157544576122b0fa79d
   depends:
@@ -7170,7 +7170,7 @@ packages:
   license_family: BSD
   size: 82560
   timestamp: 1607021261834
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
   sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
   md5: 8a35ad65651086575ce55371f22feda8
   depends:
@@ -7179,7 +7179,7 @@ packages:
   license_family: Apache
   size: 91045
   timestamp: 1659455316472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
   sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
   md5: 186eb95f816a2eff80c3c7f7d964c7b0
   depends:
@@ -7191,7 +7191,7 @@ packages:
   license_family: BSD
   size: 578514
   timestamp: 1672388155359
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
   sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
   md5: 47b6cbe6ce9289e47d16900b03596a91
   depends:
@@ -7202,7 +7202,7 @@ packages:
   license_family: BSD
   size: 372807
   timestamp: 1656431445633
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
   sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
   md5: 07165c444adc7c7ccc8a345875adc5ef
   depends:
@@ -7214,7 +7214,7 @@ packages:
   license_family: BSD
   size: 48408
   timestamp: 1675450623287
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
   sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
   md5: d58e76a31e2f6e7410ba4afd7f385b0d
   depends:
@@ -7223,7 +7223,7 @@ packages:
   license_family: BSD
   size: 1877445
   timestamp: 1684280183367
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
   sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
   md5: 0e5b0fe7debbf558ce97090f6b67cdae
   depends:
@@ -7233,7 +7233,7 @@ packages:
   license_family: Apache
   size: 94633
   timestamp: 1690225630423
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
   sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
   md5: 0fde797653e4ab589506121fb1e37555
   depends:
@@ -7242,7 +7242,7 @@ packages:
   license_family: MIT
   size: 157119
   timestamp: 1661452591647
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
   sha256: e70028d0250602c01feac17e60fafd371daee5d731917732b7eced4ab47b3243
   md5: 72a51c0d49711d22a39aefc04fa0c328
   depends:
@@ -7257,7 +7257,7 @@ packages:
   license_family: GPL
   size: 5007361
   timestamp: 1698781683371
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
   sha256: 6eb0c4f2e8acaa6dfaf1fb5b4b34f13d366ebf11d77e14a674a26d7fabbc7981
   md5: 9354d98a97abd4715cdf63d4a28f7645
   depends:
@@ -7268,7 +7268,7 @@ packages:
   license_family: GPL
   size: 84071
   timestamp: 1698769559444
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
   sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
   md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
   depends:
@@ -7279,7 +7279,7 @@ packages:
   license_family: MIT
   size: 92679
   timestamp: 1636093365041
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
   sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
   md5: f870859d4dc7a8d82cf3546bd9035f33
   depends:
@@ -7289,7 +7289,7 @@ packages:
   license_family: BSD
   size: 54520
   timestamp: 1605307564142
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
   sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
   md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
   depends:
@@ -7302,7 +7302,7 @@ packages:
   license_family: PSF
   size: 21172845
   timestamp: 1694442462066
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
   sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
   md5: 9d99075052265ae3d718582d3b875038
   depends:
@@ -7311,7 +7311,7 @@ packages:
   license_family: BSD
   size: 269964
   timestamp: 1661376543480
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
   sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
   md5: fa9074d94236c9b768bfd2c858875b27
   depends:
@@ -7320,7 +7320,7 @@ packages:
   license_family: MIT
   size: 264836
   timestamp: 1695131770282
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
   sha256: 97243a31c39f4990c0e9d4f2307f2f7fb9421553303923bc105067ec4340bdff
   md5: 8078c5760f27398eaf1082226647d137
   depends:
@@ -7330,7 +7330,7 @@ packages:
   license_family: BSD
   size: 40145
   timestamp: 1685031143383
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
   sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
   md5: 3d2841085778006c2e79f9c7300f8b9d
   depends:
@@ -7340,7 +7340,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13565975
   timestamp: 1669937633869
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
   sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
   md5: 54a4bc0724041dd173088419d6ede2af
   depends:
@@ -7352,7 +7352,7 @@ packages:
   license_family: MIT
   size: 239062
   timestamp: 1677611495106
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
   sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
   md5: f39f84115e228bad4bceaefdd637f022
   depends:
@@ -7364,7 +7364,7 @@ packages:
   license_family: MIT
   size: 158558
   timestamp: 1698096358091
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
   sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
   md5: df398a3a1668fd2a22061764e20ea91d
   depends:
@@ -7376,7 +7376,7 @@ packages:
   license_family: BSD
   size: 460913
   timestamp: 1657616061604
-- conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
   sha256: 409f9fad42cbae8d915d1703d87db6af9f951b150517daa4e1c0220cc5eb7b0f
   md5: 2b17abf94b02a6c5ba6b7623dba97ff9
   depends:
@@ -7399,7 +7399,7 @@ packages:
   license_family: LGPL
   size: 69829482
   timestamp: 1693228189080
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
   sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
   md5: 38db77ece9dc76feffb9ef7638e38258
   depends:
@@ -7415,7 +7415,7 @@ packages:
   license_family: Apache
   size: 94397
   timestamp: 1690400496655
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
   sha256: 3a9a680173f731d515e0587d5b74583cc986b5c1ff62f4cf9e4f7ec268cbb62a
   md5: 3387bf809e3d32dde3f5cbc3ef49bf47
   depends:
@@ -7433,7 +7433,7 @@ packages:
   license_family: BSD
   size: 22779707
   timestamp: 1696550432358
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
   sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
   md5: 3e284ae6b48ee30c364ffdc5601610b0
   depends:
@@ -7442,7 +7442,7 @@ packages:
   license_family: MIT
   size: 1099842
   timestamp: 1690291374842
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
   sha256: ed2b75ca1bb075901550bf892aa18a46a563e512e28ad5fe1b36e7ed3c6708d0
   md5: 22779fae19f454e13656af8b737f8bd3
   depends:
@@ -7457,7 +7457,7 @@ packages:
   license_family: GPL
   size: 602624
   timestamp: 1698676202396
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
   sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
   md5: 993b3886b334bd1f49d34206f21997b4
   depends:
@@ -7466,7 +7466,7 @@ packages:
   license_family: Apache
   size: 15998
   timestamp: 1614030572433
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
   sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
   md5: 7ac9604ad7564ac0c71bff5db198656f
   depends:
@@ -7475,7 +7475,7 @@ packages:
   license_family: MIT
   size: 67012
   timestamp: 1696347795139
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
   sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
   md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
   depends:
@@ -7485,7 +7485,7 @@ packages:
   license_family: Other
   size: 1311308
   timestamp: 1681402905668
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -7495,7 +7495,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
   sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
   md5: 28b9869d8d3a839918fac4a08f38cbc2
   depends:
@@ -7506,7 +7506,7 @@ packages:
   license_family: BSD
   size: 30546
   timestamp: 1671752127904
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
   sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
   md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
   depends:
@@ -7516,7 +7516,7 @@ packages:
   license_family: BSD
   size: 39590
   timestamp: 1668168880994
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
   sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
   md5: 52cdcdb96383c010ca833a7c24b3935b
   depends:
@@ -7526,7 +7526,7 @@ packages:
   license_family: BSD
   size: 3690152
   timestamp: 1654036853710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
   sha256: 86a1b449d27205327a5de0f81d18d9ad768e68d915b91b1d5b82be2d8f524e94
   md5: 78a8a9f8c638df9a2db80964c97ff43f
   depends:
@@ -7535,7 +7535,7 @@ packages:
   license_family: MIT
   size: 25476
   timestamp: 1657175730463
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
   sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
   md5: 0e054ab29119cf4c1f778613acf972f9
   depends:
@@ -7546,7 +7546,7 @@ packages:
   license_family: Apache
   size: 681780
   timestamp: 1696937326924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
   sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
   md5: b6ad839ebba536ad1c3cc58d0e2123f0
   depends:
@@ -7560,7 +7560,7 @@ packages:
   license_family: MOZILLA
   size: 143681
   timestamp: 1679562248929
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
   sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
   md5: fe78de10019085146f1cc6c94fdc2620
   depends:
@@ -7569,7 +7569,7 @@ packages:
   license_family: BSD
   size: 192822
   timestamp: 1671143999327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
   md5: ca5fc3fbdb09b6de068a8b7a8869369f
   depends:
@@ -7579,7 +7579,7 @@ packages:
   license_family: PSF
   size: 9208
   timestamp: 1690298120549
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
   sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
   md5: a86e87a10e5fdff486265e0c675fb99f
   depends:
@@ -7588,7 +7588,7 @@ packages:
   license_family: PSF
   size: 57922
   timestamp: 1690298106990
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
   sha256: 8057d3d2a0acd44496de33c5b222063c3f7d06b90c74fbbda45bd18b0b324219
   md5: 398f8db5bd8cab84b3d85a9d85fa4889
   depends:
@@ -7597,7 +7597,7 @@ packages:
   license_family: MIT
   size: 11362
   timestamp: 1659769459206
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
   sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
   md5: 0d31859e0a097aedbcc1627db33b3d92
   depends:
@@ -7612,7 +7612,7 @@ packages:
   license_family: MIT
   size: 188367
   timestamp: 1698257883295
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.2-h21ff451_1.tar.bz2
   sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
   md5: 45ef24c486a484f079faf1dc90e4c7e9
   depends:
@@ -7621,12 +7621,12 @@ packages:
   license_family: BSD
   size: 8277
   timestamp: 1605602889180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
   sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
   md5: 4daaceb6cfc1af6274509081d8018ef1
   size: 2316783
   timestamp: 1605602872095
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
   sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
   md5: 916c16904615c7af3b5d37cb6694f45e
   depends:
@@ -7635,7 +7635,7 @@ packages:
   license_family: BSD
   size: 21084
   timestamp: 1607347371925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
   sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
   md5: da69e6987fcc757e83a358ceaa13f62b
   depends:
@@ -7645,7 +7645,7 @@ packages:
   license_family: BSD
   size: 73391
   timestamp: 1614804425587
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
   sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
   md5: 23b9f4634b2e5450be617114f62c74f9
   depends:
@@ -7654,7 +7654,7 @@ packages:
   license_family: MIT
   size: 120873
   timestamp: 1695742300539
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
   sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
   md5: 120f0b088290fc17bd6618fc10a2f0c4
   depends:
@@ -7662,13 +7662,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 34293
   timestamp: 1605306211299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
   sha256: a5d2a216d052105fdaad7256f23da3b29f95100d1dc0f29b6ab1f3bbc75e17a9
   md5: a558f681ebc243f86cde2515c065b62e
   depends:
@@ -7677,7 +7677,7 @@ packages:
   license_family: BSD
   size: 48805
   timestamp: 1675159123654
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
   sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
   md5: c3f7871e9a33adeccee1b1e8e216918e
   depends:
@@ -7687,7 +7687,7 @@ packages:
   license_family: GPL2
   size: 1332571
   timestamp: 1683113347814
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -7696,7 +7696,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
   sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
   md5: 1ab55f8c4b5292ec360c572120bf823e
   depends:
@@ -7706,7 +7706,7 @@ packages:
   license: LGPL-3.0-or-later
   size: 9430705
   timestamp: 1616055773485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
   sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
   md5: 6875e0bf3828707dc9165d694c0d0a7d
   depends:
@@ -7715,7 +7715,7 @@ packages:
   license_family: MIT
   size: 18725
   timestamp: 1672387612937
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
   sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
   md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
   depends:
@@ -7725,7 +7725,7 @@ packages:
   license_family: Other
   size: 148931
   timestamp: 1666595229032
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
   sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
   md5: 8d6a1e767775fe0eb617cd6e22edc2ff
   depends:

--- a/sri_model/pixi.lock
+++ b/sri_model/pixi.lock
@@ -1,0 +1,7740 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.3.0-py39h2f386ee_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39hdda0065_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cyrus-sasl-2.1.28-h52b45da_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.5.0-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.14.1-h4c34cd2_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.69.1-he621ea3_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.1-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.1-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang-14.0.6-default_hc6dbbc7_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang13-14.0.6-default_he11475f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcups-2.4.2-h2d74bed_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20221030-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpq-12.15-hdbd6064_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxkbcommon-1.0.1-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.10.4-hf1b16e4_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.37-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.9.3-py39hdbbb534_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.8.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mysql-5.7.24-h721c034_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.0-py39h5f9d8c6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.0-py39hb5e798b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.11-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.1.1-py39h1128e8f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.3.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ply-3.11-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.15.10-py39h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt5-sip-12.13.0-py39h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.18-h955ad1f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-main-5.15.2-h53bd1ea_10.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.11.3-py39h5f9d8c6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-6.7.12-py39h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tomli-2.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py39h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.8.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.8.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.8.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+  sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
+  md5: 613805add1c05b538ff06d217252feb7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 20810
+  timestamp: 1652859733309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-3.5.0-py39h06a4308_0.tar.bz2
+  sha256: 1e383e4d196ea09008d70acb793217fba86597e0ff44725b3d1e4aad0797d525
+  md5: 2cf39d906cc321896ffe3e5d33d80c5c
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162166
+  timestamp: 1644463608931
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py39h7f8727e_0.tar.bz2
+  sha256: 8e115035314cadb1ce373fd96cdcbc4e14df922d094c8403ea9e80ca35f5873a
+  md5: 2972a84e0e22ae3244bbd2f1eebcf536
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 35352
+  timestamp: 1644569715988
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py39h06a4308_0.tar.bz2
+  sha256: 61c887d15f104b549b0ec3875ceb51905bbdb82a237e40e9b32401d9c2361f8b
+  md5: a68016b4b06460def24cb69d932986f3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132486
+  timestamp: 1695717963702
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py39h06a4308_0.tar.bz2
+  sha256: c030281abd8f56407afb23d435aa5744db88c681184d1c4252d7a7c954d68e9f
+  md5: 2f6356a2f530314b4059c08c79a3d8bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 205868
+  timestamp: 1681493113570
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.3.0-py39h2f386ee_0.tar.bz2
+  sha256: f2a4f2dbea826cfaf59d09e53a4bb951ffd77becb2f53f5b4ddb6ef63cdd5210
+  md5: 1d420e8258cf81e6cebc7320e5cf6a0a
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5706055
+  timestamp: 1697490557655
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.5-py39h7deecbd_0.tar.bz2
+  sha256: 20e381c665853131fc5c9a397b1d4b05bb05859a2bdfbb0559e85ec445ee9e7c
+  md5: 14dc3c2e8eb68b1111a08de9a3ce8a00
+  depends:
+  - libgcc-ng >=11.2.0
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 128656
+  timestamp: 1657175966755
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 11df9b719339bb40e4af8eb124a094def217f64e2440af973d7342da19c030b0
+  md5: 712827b1699cc71e6240626c413408f3
+  depends:
+  - brotli-bin 1.0.9 h5eee18b_7
+  - libbrotlidec 1.0.9 h5eee18b_7
+  - libbrotlienc 1.0.9 h5eee18b_7
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 18907
+  timestamp: 1659616178155
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 6408b6849347ef01f5ed170f4b35fb4bdfed2d9cf9da4912a4b104a810518a80
+  md5: d9d570587ccfd7158b66feb823c990c6
+  depends:
+  - libbrotlidec 1.0.9 h5eee18b_7
+  - libbrotlienc 1.0.9 h5eee18b_7
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 19933
+  timestamp: 1659616170430
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py39h6a678d5_7.tar.bz2
+  sha256: 8507df3357958556aff2dea8788a3f7ddad6172fd9fe5d1bdb6c3afe9686d2f8
+  md5: f0204f72bcd9ef836218cc74345e69f2
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 362180
+  timestamp: 1659616255400
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2023.08.22-h06a4308_0.tar.bz2
+  sha256: 25f0a879b58fe2859b7928854cce5cf7ff1b547b1c26a0f05734a31f68dc10a7
+  md5: 3ef00f4c5278b688552efc259c463dc8
+  license: MPL-2.0
+  license_family: Other
+  size: 132731
+  timestamp: 1694009767372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2023.7.22-py39h06a4308_0.tar.bz2
+  sha256: 81b7babb8ac16394b990932a40595a0c22065c060ccec20017235cc2cc1c7f6b
+  md5: d5cb3d97cf5e85ffe5e94037ed8a1169
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159077
+  timestamp: 1690232254640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.15.1-py39h5eee18b_3.tar.bz2
+  sha256: e99314f8809d65195dcab68a9783f70fbe990113a66c98c9b0a7ffea01226b71
+  md5: fff69f95079191a10e099b21a5fd4bc3
+  depends:
+  - libffi >=3.4,<3.5
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 234749
+  timestamp: 1670423281079
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.0.1-py39h06a4308_0.tar.bz2
+  sha256: c54f2ff08c13471922e8f3043e47898aaec39956373808b3eb053273860fe303
+  md5: 10bd31b22cd7efc4cff2b9503ef6d3e0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1917831
+  timestamp: 1668084545510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.1.2-py39h06a4308_0.tar.bz2
+  sha256: 9127732de58afa6a03a8c5009d7f918bc7cf0307ba5e1a5afb6f917fe75c2151
+  md5: 13702d3b4b744784e5bd559c7050dd6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12719
+  timestamp: 1671231205875
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.0.5-py39hdb19cb5_0.tar.bz2
+  sha256: 0b1a9a25ddfc6631390c53d6ee95706eaab0805c5a9a8d748c08120a1f421256
+  md5: a93581f810ef522bd23c148195591157
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 234846
+  timestamp: 1663827645102
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cryptography-41.0.3-py39hdda0065_0.tar.bz2
+  sha256: 6a08c501a310e5e482df8e917a7b0cd438e83f33a44aaec49c2ab53eeda5ebf1
+  md5: 3f8c39c0ce002faf6719b8d2d5f31941
+  depends:
+  - cffi >=1.12
+  - libgcc-ng
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 2181966
+  timestamp: 1694444647708
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cyrus-sasl-2.1.28-h52b45da_1.tar.bz2
+  sha256: 4e7eb5911636f3cac2bb22c85d56a8edf946cfd6379e8b7be6136ffdaf669c22
+  md5: dcabb2d653147fd807cf6edeb2c3522b
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.9,<4.0a0
+  license: BSD-3-Clause-Attribution
+  license_family: BSD
+  size: 239169
+  timestamp: 1688045783866
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dbus-1.13.18-hb2f20db_0.tar.bz2
+  sha256: 469debfa966d24b8372aaf909ecbe27dc6fde186f6f0d5b9e0a8427e38053364
+  md5: 498d0788982ec4c5d13a44359b9c7afb
+  depends:
+  - expat >=2.2.10,<3.0a0
+  - glib
+  - libgcc-ng >=7.3.0
+  license: GPL2
+  size: 600218
+  timestamp: 1602701107852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py39h6a678d5_0.tar.bz2
+  sha256: 96b5d4c87d8467ae6ba92f9c17eaa9e059b6f7e9b8ee57aee788885c7413078b
+  md5: 9868912fd269f4d9d6423cfe69560131
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2164334
+  timestamp: 1690905228819
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py39h06a4308_0.tar.bz2
+  sha256: 96289b0fa3e06e1e2093680248f19e01ead264cda209267c113f7910fb2b975b
+  md5: 2e6ec51066d825ef3c317abe78d6049e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16413
+  timestamp: 1649926472708
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/exceptiongroup-1.0.4-py39h06a4308_0.tar.bz2
+  sha256: e3fa60df94ad383173fa0d565afbe74070fa0765ca1e423720c0f08f525bcb20
+  md5: b4d923222d45314856b5378cb115214d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26728
+  timestamp: 1668714462023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/expat-2.5.0-h6a678d5_0.tar.bz2
+  sha256: 3afaaa4f71028c9ea0cb94681eb679b751c1f65dc3b692fb0d8a36ae0d3f0fed
+  md5: 42d5d947fb3bebc9465ddeaf0093a1cb
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 192956
+  timestamp: 1693497362098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.14.1-h4c34cd2_2.tar.bz2
+  sha256: 4a623c7f73f4531a16271ded00c80e7dce65aa35b5105015fc4d0ceb37c9fa0d
+  md5: c9dc79248f887050dc89e19670dcbd66
+  depends:
+  - expat >=2.4.9,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - libxml2 >=2.10.3,<2.11.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 383064
+  timestamp: 1679578197653
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+  sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
+  md5: a5dc8677d891dff2393b63189a3ad42f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 971975
+  timestamp: 1666798278693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/giflib-5.2.1-h5eee18b_3.tar.bz2
+  sha256: c323a9800a358c178f6f3b8860bbb77c373fbc3be981bb6420175fbb5431adf5
+  md5: 6485f51176cf651b3b28c3548cef10ad
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 78533
+  timestamp: 1676983203797
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/glib-2.69.1-he621ea3_2.tar.bz2
+  sha256: e5e0b6a6c7bdd8a2453bce4b5045e022c6df3ad5a5a4d3085eb59ac4e1ded452
+  md5: 0223c02d020cf3ff6637210d99000b5a
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - pcre >=8.45,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 1989267
+  timestamp: 1669364519815
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.1-h6a678d5_1.tar.bz2
+  sha256: 833208211f0ecb52198f5fae585f937be3c337c15b4569d8f1a28638545250d5
+  md5: 2fa837925e0633ceae4ec826f6daa93f
+  depends:
+  - glib >=2.69.1,<3.0a0
+  - gstreamer >=1.14.1,<2.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libxcb >=1.14,<2.0a0
+  - zlib >=1.2.11,<2.0.0a0
+  size: 2253949
+  timestamp: 1677171916164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gstreamer-1.14.1-h5eee18b_1.tar.bz2
+  sha256: 8257a1c1c967d48561f62adb649fe21c467f0a37c41f783ba6e2c6d79fa1cc4f
+  md5: 5cd8e1f16b1ce869d0c3a98b9f0897fb
+  depends:
+  - glib >=2.69.1,<3.0a0
+  - libgcc-ng >=11.2.0
+  size: 1690003
+  timestamp: 1677171850557
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.0-py39h06a4308_0.tar.bz2
+  sha256: 6d934b1d532f644e148bcf51f9c8d0c7623e832fd29282bc6c4cb64b9e027884
+  md5: b18725efd77d3fb6c9addf81dac09081
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4576699
+  timestamp: 1698866790345
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+  sha256: b35b281dbf69b826c6ae04fcd7b6a2d1f098277a669a199906a1f23b4b0931a5
+  md5: 2a793fe24f85aa5819fe69c450cba6f7
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 29021241
+  timestamp: 1692293243228
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.4-py39h06a4308_0.tar.bz2
+  sha256: 4ef0e1d11cf14da72ed8388d7e6d094e306889cb538dcd6aa02e9dd08ff10dbf
+  md5: 1eb52f9f45cea2fb9ce27b19f990160e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110793
+  timestamp: 1666125606878
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-6.0.0-py39h06a4308_0.tar.bz2
+  sha256: a9fe83b3aa6ffb8fc2a1cf767a0fd1a2633375f77b0f28aa6336c745880d4299
+  md5: 126b3c1933b7364ff03f67455b687e99
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 37588
+  timestamp: 1678997134023
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib_resources-6.1.0-py39h06a4308_0.tar.bz2
+  sha256: b6d5f6098903e5edfbc2200282efa186d446442d47ab75f51ff22c30ae0c4da4
+  md5: e53a806995cedc9e5d8a96e03c9e79ac
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 50699
+  timestamp: 1698254665788
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46305.tar.bz2
+  sha256: bddc8de31272a509510cc87e5ac0cdb0e7765d393ca7bdfddbfe4123979a9413
+  md5: bc8a501970aadad3373edbce996b5fdf
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<1.2.14
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 19286333
+  timestamp: 1681801301379
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.25.0-py39h2f386ee_0.tar.bz2
+  sha256: c0d0714c68ed953740812688ac1b3c3e286de33b55d49f02953d705fb00c30d0
+  md5: 8b65eea396159a3b59278f77c81ddd1b
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217268
+  timestamp: 1691122070319
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.15.0-py39h06a4308_0.tar.bz2
+  sha256: 1103ff58d14a5dbd58a81352070c2482fd2cf12e7e57bde56f2e9160e2ae353f
+  md5: ff47e0be879e817713ce2a9daa76e2b0
+  depends:
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1261116
+  timestamp: 1694181530670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py39h06a4308_1.tar.bz2
+  sha256: 6feb2896156814ddfe0cf4f5d2fd41c419b3ce7f6cdfcec9a7a40a260bda3dff
+  md5: 5ef6c6a0d1ac79143c7359d305155167
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1021637
+  timestamp: 1644297140650
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.2-py39h06a4308_0.tar.bz2
+  sha256: ac5842abf82b3a86091a3e46881ef74891d40442c53254b885e9c29f53af4d0f
+  md5: eaeb023688f781e7dd89e74310c38195
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 211775
+  timestamp: 1666908212136
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+  sha256: c21f8f407266d039e819c27fe9eb4fb26587e974f3bd059b37cbaec5073722d0
+  md5: ba1f47411e9e07876c7a3e9d3be6a98e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: IJG
+  license_family: Other
+  size: 281400
+  timestamp: 1677849152168
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.17.3-py39h06a4308_0.tar.bz2
+  sha256: fd552c9fe7779219844ea9d67e1abc27cd6549307087960d422ece8dbe5a4951
+  md5: 0d2c3c5edf671b575532d5a3e8bf15fc
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 131510
+  timestamp: 1676558716852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py39h06a4308_0.tar.bz2
+  sha256: 4ba1f5698f0b483af397021b2047554afb3129790cac3a1502c79693154331d2
+  md5: 8e9c0ef4b0b57caa87c146892e56a313
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192921
+  timestamp: 1676329415827
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py39h06a4308_0.tar.bz2
+  sha256: b791f2f86fe1993ddfcd10a80a92fb098c2b4792f0ce13da9269cac6b3647d0b
+  md5: ac7c5e38691312d195fdd1f23b33f779
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78853
+  timestamp: 1698937381669
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-1.23.4-py39h06a4308_0.tar.bz2
+  sha256: 69ddf26162941898630d1505442660bd16ed08a58112ae1ad7e0829c9d82bb44
+  md5: a4beb461f0a60998a090d760b5c6c907
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411564
+  timestamp: 1671707702849
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py39h6a678d5_0.tar.bz2
+  sha256: 6d6c384c9c65e33d5d047e01131e0687eb2bc1e5a4a67f80af3c0b773c1bba82
+  md5: 07957e1d2fb6a407f7d7293b84938e1e
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 77689
+  timestamp: 1672387301020
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+  sha256: 01bae3dd44469e34f043e0416f5f5e658429bf4031745399d9968d10b899e2c4
+  md5: 10171cca67e3d73c3646c6dc5a321460
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.8,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1427115
+  timestamp: 1686931095252
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+  sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
+  md5: 88199c75f2ac211728febced7785c24e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 228278
+  timestamp: 1635523146417
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 472cf888db65d00451fcd5fccd5244d55c061e8d7efe43f70220414ef64521a5
+  md5: 787927eff72e62c270f614cbcba9479c
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 67109
+  timestamp: 1659616145972
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 19a43182ca343510ba51baa0fce91d64c840a19cdf13c6dde4e03e819c70897e
+  md5: c0608d376a30b5aa4d2f2c22978135db
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_7
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 34691
+  timestamp: 1659616154057
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_7.tar.bz2
+  sha256: 158c401aa0bab05aa5f4134aea798085e4e3849209946f896cca352930d2225d
+  md5: cc6a6d362912a2d112310bd3f8acd44e
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_7
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 295287
+  timestamp: 1659616162282
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang-14.0.6-default_hc6dbbc7_1.tar.bz2
+  sha256: 46646ce93dafb4922f4597c34c4fec106b4ff3b9707a202387f7964601e47876
+  md5: 5eaf417727302b441025661154fc4587
+  depends:
+  - libclang13 14.0.6 default_he11475f_1
+  - libgcc-ng >=11.2.0
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 130632
+  timestamp: 1681222907766
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libclang13-14.0.6-default_he11475f_1.tar.bz2
+  sha256: 24d638d8577a3332a2e6cd77a5178054ca9cf7e14f71353b5b0a655155ab5c19
+  md5: 230f394424c6cc26ebbee96176b65ece
+  depends:
+  - libgcc-ng >=11.2.0
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 11152969
+  timestamp: 1681222877667
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcups-2.4.2-h2d74bed_1.tar.bz2
+  sha256: f465c8f00b075660362d8e7fba8702b1c11e56fb2c305da78b9ee69898609be7
+  md5: 8a2e46dc8bd62528a6f4d9092f2f6911
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4901408
+  timestamp: 1685057846629
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+  sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
+  md5: 55dde57e63a36b202e388a39dcee9a66
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 74096
+  timestamp: 1695996494461
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20221030-h5eee18b_0.tar.bz2
+  sha256: 5d66a60672f8e7dd0c048b5f158b5d406f16133b260ffde95a93eb453a1e7af9
+  md5: af7584851084abae8eaa8cee2ed288b4
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.3,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 195621
+  timestamp: 1670840131081
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_0.tar.bz2
+  sha256: ec1c6341cf0091b55be05285037cb3fbba90573e00257f383ab274d8b8e6d46f
+  md5: 32ac65d639d6c155ea7276cadf1fd2b6
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 147907
+  timestamp: 1683716564178
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
+  md5: 641e72e5067bd6d5454405879e1cd2a7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - _libgcc_mutex * main
+  - __glibc >=2.17
+  constrains:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - libgomp 11.2.0 h1234567_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 8895144
+  timestamp: 1654090827491
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+  sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
+  md5: 27082517590f3b9fbffecc68513b461b
+  depends:
+  - libgfortran5 11.2.0.*
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 19860
+  timestamp: 1654090819660
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+  sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
+  md5: 0202c3c8ae4735cac6c7f3d1e1685964
+  constrains:
+  - libgfortran-ng 11.2.0 *_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 5228750
+  timestamp: 1654090762569
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+  sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
+  md5: 3080c2813e6e1d0f8a100a38b5b3456d
+  depends:
+  - _libgcc_mutex 0.1 main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 573231
+  timestamp: 1654090775721
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm14-14.0.6-hdb19cb5_3.tar.bz2
+  sha256: 512fac06ddd97b4383503d4fbd8145102966055b29ccf86841a930dbb4ef3ab8
+  md5: 833c0e514ff9c8ae0511630b024d60e0
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 37179832
+  timestamp: 1683292829131
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+  sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
+  md5: 1bffe1481ed4f88827248fb9001f8923
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 362561
+  timestamp: 1677841789536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpq-12.15-hdbd6064_1.tar.bz2
+  sha256: 3c143d73ce3eb1286de076843d56158b3d33ad76126c4df404720b881ad8ec64
+  md5: 85fdca62d65ed23546961c5ecd4dc68a
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.8,<4.0a0
+  size: 2989276
+  timestamp: 1687380039119
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
+  md5: 8c195584a5f5471b600ee180e4052773
+  depends:
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 6410287
+  timestamp: 1654090800863
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+  sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
+  md5: ef78eebd98289aceacdfa29182426adf
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 664034
+  timestamp: 1693575237924
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+  sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
+  md5: 292768ec77416ae257cfdd44ea2071c8
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29197
+  timestamp: 1668082729834
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-1.3.2-h11a3e52_0.tar.bz2
+  sha256: c6aecee300c8e84a99056307ed3bdc047edd5366e55230a4eabe3ee5e8082bb8
+  md5: 3a6ebf9895b1085a23783cd95460a629
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88424
+  timestamp: 1694778218406
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+  sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
+  md5: 9cdeef1d044c7e035c006890f11569d3
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 436056
+  timestamp: 1694776944891
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxcb-1.15-h7f8727e_0.tar.bz2
+  sha256: 5d68e69709ae10bd6c4b58b6af447ad2f2bd24955994f3ec77103d1a6bf5e1f5
+  md5: 49e523de8d364b7fabc3850eccbe9bda
+  depends:
+  - libgcc-ng >=7.5.0
+  size: 623492
+  timestamp: 1652448233146
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxkbcommon-1.0.1-h5eee18b_1.tar.bz2
+  sha256: 114853749b375d54347f18b472456eb7d66beba26238c984403bdd5ff8831947
+  md5: 6225f107993ddf5e1f61111b3df025bd
+  depends:
+  - libgcc-ng >=11.2.0
+  - libxcb >=1.15,<2.0a0
+  - libxml2 >=2.10.3,<2.11.0a0
+  license: MIT/X11 Derivative
+  license_family: MIT
+  size: 640985
+  timestamp: 1679578328295
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.10.4-hf1b16e4_1.tar.bz2
+  sha256: 93b155c0472d424dce940921ff368a3e4fd70fa41f5f934e58a4b7ec24722f95
+  md5: 2d7bb4d2ef09d62843f8be03b55fce18
+  depends:
+  - icu >=73.1,<74.0a0
+  - libgcc-ng >=11.2.0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 744988
+  timestamp: 1692970212537
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.37-h5eee18b_1.tar.bz2
+  sha256: e4e42cc28f7d509980afa2b1e76266d997628c9ff5d194c8460228279c0b6cdc
+  md5: ff861c432be5a684783732ad1eb4c39f
+  depends:
+  - icu >=73.1,<74.0a0
+  - libgcc-ng >=11.2.0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 258682
+  timestamp: 1692973520375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py39h06a4308_0.tar.bz2
+  sha256: 0e4d61ed508712fc16117fc41f0f5bfedd319cfefd114749689db5f78242b0a5
+  md5: d40d6b6ea51683b29a9e210831db4a13
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 35171
+  timestamp: 1659783489143
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lxml-4.9.3-py39hdbbb534_0.tar.bz2
+  sha256: b961c12e78000995cfcc5769c64b1c146f917e640e999e290bb2b36468bd7dbe
+  md5: a3a5039a19997b8cee4ddf538472358c
+  depends:
+  - libgcc-ng >=11.2.0
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1616363
+  timestamp: 1695058577405
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_0.tar.bz2
+  sha256: 36b23ab8d8aa22d70a2f733462cabe95e5b27ca919ec7a75a5592bc39c5f7d16
+  md5: f24adbfdfe16b0bac0d14640bb5ce616
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 163649
+  timestamp: 1670944701605
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py39h06a4308_0.tar.bz2
+  sha256: f5d4aae9bb975b3baae421e6bcfdb7fa4f364d89f123ceb73225cf069516e48b
+  md5: 421f82c8274b44660dba629134faa6af
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 122221
+  timestamp: 1671541990505
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py39h06a4308_1.tar.bz2
+  sha256: 9332b39039a52ecc802ddc2c4a3bde95a3141aff0ccab19a7591ec6ef72bfe07
+  md5: 622bb5a6eeeadeb8731e5e1bf4f0d7a2
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 105637
+  timestamp: 1684279960746
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.1-py39h7f8727e_0.tar.bz2
+  sha256: b253d11efce2f5e65ffaccf2b87bab23ae53d5bf2663ba394187047ca6374405
+  md5: feb0e452205b44ac45d9b5e55c21a3b1
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22819
+  timestamp: 1654597913064
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-3.8.0-py39h06a4308_0.tar.bz2
+  sha256: 7769380101bde07e1631d530110b75d7871a1069ba27a2b3984b92c499c28f95
+  md5: 2b244d4ee70f0c1bc1b61ae17af9816e
+  depends:
+  - matplotlib-base >=3.8.0,<3.8.1.0a0
+  - pyqt >=5
+  - python >=3.9,<3.10.0a0
+  - tornado >=5
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 7881
+  timestamp: 1698692415570
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.0-py39h1128e8f_0.tar.bz2
+  sha256: 10701d3065424bbef89c03a30c4adecd67308cd2f76e0d873aad6a180d9fe097
+  md5: e196f6bace29ef34f0a996ef1c99f193
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8129476
+  timestamp: 1698692330174
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py39h06a4308_0.tar.bz2
+  sha256: 2cce821c755c782aec4fa1713dfa3a1e4f6639c532fefe4eaaba10297df6c546
+  md5: c04ef34af33da4c71bcc99b7ec24d210
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16391
+  timestamp: 1662014553452
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py39h06a4308_0.tar.bz2
+  sha256: 0dd0157d3d6c591a1087f7b96993412ac9194b7ea0ee2d667b1dc1c587eb0e33
+  md5: 975a78ae464b1cd9541c498fd8299858
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 52857
+  timestamp: 1659721312521
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py39h06a4308_0.tar.bz2
+  sha256: cae67d22945f16e1034fc53144eea8bb67f2fecf6d60b22c43822094b6ca2b49
+  md5: 19932cd4f64628bf6db1accebdaf7eac
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18689
+  timestamp: 1659716096534
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-0.8.4-py39h27cfd23_1000.tar.bz2
+  sha256: 91720216312a88348bc20083c47f7e9232d34e929e08c8762e62611543acdadc
+  md5: f6c734d73e6e3dbc1b62766cf18ff3e4
+  depends:
+  - libgcc-ng >=7.3.0
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58153
+  timestamp: 1607364912263
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46343.tar.bz2
+  sha256: c7dedf41acbb2a065364f949ba24479449387d54c095220ff89346d266b25347
+  md5: c5f96c8ff7102e1d673829bbeb8bed84
+  depends:
+  - intel-openmp 2023.*
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - tbb 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 206706869
+  timestamp: 1691503234180
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py39h5eee18b_1.tar.bz2
+  sha256: 984f547627b0af8358fa83b2396e0b2c014f9bc281304b6b8d3ff139a3f04b40
+  md5: 724d2559e0ed50aa0eee97c919134ded
+  depends:
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 58512
+  timestamp: 1682948511810
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py39h5eee18b_0.tar.bz2
+  sha256: 650419991b99b810e79221e35e5a6c3e49240ed30ff3e5324eecf1cefd276110
+  md5: a14b8155afdb15f3bce72e67925c0ceb
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 227382
+  timestamp: 1695058347376
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py39hdb19cb5_0.tar.bz2
+  sha256: 7b0eeb8acc4c6b9f45b214fbc991a4073a59a8f7b798a4cc86515b97f7af6355
+  md5: eb48e45fd8d61762290e4289a52be3f7
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 329190
+  timestamp: 1695059874042
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mysql-5.7.24-h721c034_2.tar.bz2
+  sha256: 1127b7dbb0a740f3de8931a4af5b70b3dac6dc3de162a2d8f8760335db5e6669
+  md5: b4ab7fa3430324358189ca5ff9fc8e42
+  depends:
+  - cyrus-sasl >=2.1.28,<3.0a0
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.9,<4.0a0
+  license: GPL-2.0
+  license_family: GPL
+  size: 82391019
+  timestamp: 1688563074905
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-0.5.5-py39h06a4308_0.tar.bz2
+  sha256: 2a002317d25e023763a362135b18c5754be62a016658ecc873ea2b8fcb3d2dfa
+  md5: 95c83d71814c504b5504df4f14548f1a
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8257558
+  timestamp: 1681756322140
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py39h06a4308_0.tar.bz2
+  sha256: 79e10dc933d22aa99de3543071f1beaaf0ff24df9fed7d2ef5e765f3ed766064
+  md5: ea6ebe4e8d6af98128d32606da618a29
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99555
+  timestamp: 1698934242626
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-6.5.4-py39h06a4308_0.tar.bz2
+  sha256: 8f42419638dbfa40606e63df51232ef21f26cc674e23181eb9b6123d1eda4bf4
+  md5: 1710a25086c8098367eb36b9d441448b
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 569683
+  timestamp: 1668450704669
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py39h06a4308_0.tar.bz2
+  sha256: 196c8a97148367e7fb4e51989d21b64659ca4d0c80f5c2b6731363bb3ef0ec59
+  md5: 385cc9e53404776782502c0fdb08820f
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147046
+  timestamp: 1694616899309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+  sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
+  md5: 57ea097dc15f8d9f9eb90e1d919143b0
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1157733
+  timestamp: 1674734069410
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.5.6-py39h06a4308_0.tar.bz2
+  sha256: c1bf379f6530ea323debe819bd4fd1f9ddf8c70c4f514890d42e01a77af1f812
+  md5: bbbcbebc20a4fdcadce398d0ca04f95e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13109
+  timestamp: 1672387143252
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.1-py39h06a4308_0.tar.bz2
+  sha256: 75a4858adf42d03e1ef52ea0083d7665bf3426607367cad661077199951b18a4
+  md5: 357296e49c55733ecc879ffe5d612116
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2955832
+  timestamp: 1690562037565
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py39h06a4308_1.tar.bz2
+  sha256: 0db83a4101de756aeaa65ebc62b19cbf8f59f78a9b056e58c495df5280b021c3
+  md5: 248ce515640465371927d46f389ed555
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 594054
+  timestamp: 1690985006481
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.2-py39h06a4308_0.tar.bz2
+  sha256: c1d8ceadd7700fc60239c2791a8ae746b3c5e37e524e0663e8933fc71dc0d5db
+  md5: 70db71df4ee1cdd38090c0f7b80ba61f
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21944
+  timestamp: 1668160644514
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py39h85018f9_0.tar.bz2
+  sha256: e61fc626f7131f1857c703ad3bb4dcacfc6b1fd6d5da545aa8f600b840315aca
+  md5: 6b689e52e3ba1fa7caaab3e6be31860c
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 141434
+  timestamp: 1696515497148
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.0-py39h5f9d8c6_0.tar.bz2
+  sha256: de22d445f66249c5bf5fbef2f4bba81baa0eb13e5050036da9ffacd46b3ee1ea
+  md5: 0c454790ce9011e27e597f8b1ce5e769
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.0 py39hb5e798b_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9526
+  timestamp: 1695832867641
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.0-py39hb5e798b_0.tar.bz2
+  sha256: 0f8233bca839fed724ee08cf5cb1bafffd72bd3f588401adb3bf126990d8bf19
+  md5: 068fb4b40cd349a7db1d9ed214178ca6
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.26.0 py39h5f9d8c6_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7858953
+  timestamp: 1695832851373
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+  sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
+  md5: b0afe23033c8c5344640bc25225fa579
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 516994
+  timestamp: 1630084830020
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.11-h7f8727e_2.tar.bz2
+  sha256: 3a01ea7f58c487ee5d30251c089137ad9600dc305a82e09231dd112e19824e71
+  md5: 39ef8bbb036d537b1deb7f7ac32ea87e
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 5493777
+  timestamp: 1695322649929
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.1-py39h06a4308_0.tar.bz2
+  sha256: b9d3e911f4c7d9c732c36422046a0d32170cec1803ba5c7f7c33544ed97deadc
+  md5: 77a22ed6d0d448c5288d0f695bc9ac49
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 72527
+  timestamp: 1693575234886
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.1.1-py39h1128e8f_0.tar.bz2
+  sha256: 525a877de379651efc20862a77deb470c9c4ff3cfa470d3643c5036de0ec5d17
+  md5: dd9fcd456d8fb03daad201cf130d28bd
+  depends:
+  - bottleneck >=1.3.4
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - pyreadstat >=1.1.5
+  - zstandard >=0.17.0
+  - pyqt >=5.15.6,<6
+  - qtpy >=2.2.0
+  - gcsfs >=2022.05.0
+  - blosc >=1.21.0
+  - lxml >=4.8.0
+  - odfpy>=1.4.1
+  - xlrd >=2.0.1
+  - jinja2 >=3.1.2
+  - matplotlib-base >=3.6.1
+  - fastparquet >=0.8.1
+  - numba >=0.55.2
+  - pyxlsb >=1.0.9
+  - xarray >=2022.03.0
+  - pyarrow >=7.0.0
+  - s3fs >=2022.05.0
+  - tabulate >=0.8.10
+  - pandas-gbq >=0.17.5
+  - psycopg2 >=2.9.3
+  - openpyxl >=3.0.10
+  - xlsxwriter >=3.0.3
+  - scipy >=1.8.1
+  - dataframe-api-compat >=0.1.7
+  - sqlalchemy >=1.4.36
+  - fsspec >=2022.05.0
+  - beautifulsoup4 >=4.11.1
+  - pymysql >=1.0.2
+  - html5lib >=1.1
+  - pytables >=3.7.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14140649
+  timestamp: 1697477421901
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.3.1-py39h06a4308_0.tar.bz2
+  sha256: a521bbf5ace95000eefefc5b4e6ff599f7607aea6878a5bf61cd58e9232850fc
+  md5: 76e793d8f5634ca4d10cbc6c15a84e65
+  depends:
+  - bleach
+  - bokeh >=3.2.0,<3.4
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.0.0,<3
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.17.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17121173
+  timestamp: 1698867093476
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.0.0-py39h06a4308_0.tar.bz2
+  sha256: 5ee99045a6225d67f275d2b934e0c406aa18e78606933d3e180884e85ab07755
+  md5: e9f0d25cb34c847f93a8269f2b8cc674
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 188223
+  timestamp: 1698263473172
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pcre-8.45-h295c915_0.tar.bz2
+  sha256: 4881cc5e0d5b20335bcfba4eaf29fdc95dedf2607903aabecdacffb64d3407d4
+  md5: 4bac8a874e62f41ebab8345ca6076eb6
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 263308
+  timestamp: 1624477853289
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.0.1-py39ha6cbd5a_0.tar.bz2
+  sha256: db8122fcb6316fb86c2ff6d4dd47154a650ac26d270183a316f14004adf27525
+  md5: 33ad46d04664fc8b65a545110e4fe099
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 764331
+  timestamp: 1696580179855
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-23.3-py39h06a4308_0.tar.bz2
+  sha256: defc7f41fa33b1ec2cb3fa0eda9a1e3787fb266e05e58ba1df3fd9ed7dde63d6
+  md5: a33c5f7c8c5f64d6e6cdc9effa1116d9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2674850
+  timestamp: 1697548887851
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py39h06a4308_0.tar.bz2
+  sha256: 831b91a33502abdf6c11b0edd6e01d1c6168c7cc1368b25aedcf154b78fcb562
+  md5: fe56f0479dd414c846191116366262c3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 31999
+  timestamp: 1692205535111
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ply-3.11-py39h06a4308_0.tar.bz2
+  sha256: a38e6d2ba251c6456849a7e2529a7d30150d7345abc8ee6d0afeba6c7173ac7a
+  md5: 290fd05d75d8e816a9b0f29e10ea4063
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-clause
+  license_family: BSD
+  size: 82191
+  timestamp: 1607029370982
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py39h06a4308_0.tar.bz2
+  sha256: 88ae4ca590c895606bfed52b57baf531d858f3bee7374965485e3788bf0c894d
+  md5: 44d2a857d13bdf9d99aaac039a249d47
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91137
+  timestamp: 1659455142164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.36-py39h06a4308_0.tar.bz2
+  sha256: 385b2ac10ea3f96df9afb5088f8e773885c1e88a34831e42a083927049ac6511
+  md5: eb899a739d9b58dd747f1f6bd52d4cf3
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 579771
+  timestamp: 1672387338600
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py39h5eee18b_0.tar.bz2
+  sha256: a760d6c9fca08c09ff0bc9a33946188e2ea5deed2443d4acb360ce55ce36ee43
+  md5: 2cb2ad8315f68f4339b9416bd9ab115e
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353437
+  timestamp: 1656431352923
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py39h06a4308_0.tar.bz2
+  sha256: 53fa6ed14cb22b8cb879f0ecf45cca8f3013b8ebcfa89456c85b3947ce4ab109
+  md5: f36ecb722522cbe2e3737424edf1b5e1
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29312
+  timestamp: 1675441510984
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py39h06a4308_1.tar.bz2
+  sha256: 4fcc8915549df7e56dbd8e85a5290d60800240387a7f3fde5292c29a8d6c1897
+  md5: 6d03295e544251e608a28c8d7c48115e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1862058
+  timestamp: 1684280096752
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyopenssl-23.2.0-py39h06a4308_0.tar.bz2
+  sha256: 95e66848dbe3f8177db8f07be183add3ba73b7e2e3c93d302028862b233a46b3
+  md5: 1f09617aecd6f3c2f2e20692c0759f34
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94434
+  timestamp: 1690223520097
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py39h06a4308_0.tar.bz2
+  sha256: a26d077b2439153277868702c690ae2f61a9bac7254a39c70094d522fafc329d
+  md5: ffceed627867508d73af1636ab5ebf42
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 156324
+  timestamp: 1661452578573
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt-5.15.10-py39h6a678d5_0.tar.bz2
+  sha256: ee433aa91ace3663610cfb0bae64c2493607983307a8c4ae659058a71fced498
+  md5: 36fa923ae045804756daaa637c50a34e
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - pyqt5-sip 12.13.0 py39h5eee18b_0
+  - python >=3.9,<3.10.0a0
+  - qt-main 5.15.*
+  - qt-main >=5.15.2,<5.16.0a0
+  - sip >=6.7.12,<6.8.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 6514297
+  timestamp: 1698772741413
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyqt5-sip-12.13.0-py39h5eee18b_0.tar.bz2
+  sha256: 3d8beba15e78e1015b290a54d02ead66310149fa4382f8a590f2346f10629d24
+  md5: 340faa81b485b2b79bb30575e39818e7
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 97026
+  timestamp: 1698769334601
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyrsistent-0.18.0-py39heee7806_0.tar.bz2
+  sha256: 1eefce8974d25a42d989e1ca817b0f829192fcb0cfc72f921e7d2c3075d7c06f
+  md5: 0e3341a4fe434167bf74b613eb6afd81
+  depends:
+  - libgcc-ng >=7.5.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 97194
+  timestamp: 1636110999719
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py39h06a4308_0.tar.bz2
+  sha256: 5eb7130d2f345d4a4fd7ccfc10bc9ba5f1235eaabc22536b9a20736087be106e
+  md5: c5f3f7f10ad30f0945e75252615ab6e5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31331
+  timestamp: 1605305847037
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.18-h955ad1f_0.tar.bz2
+  sha256: e9cc8f89dc327997339bedd9961428a13dda3893e3dba46358e73b1fd1ffa37a
+  md5: e99f4c3215771cd11de42d30ac8ada47
+  depends:
+  - ld_impl_linux-64
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 26811973
+  timestamp: 1694440290734
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py39h06a4308_0.tar.bz2
+  sha256: a7ab4852e35549608b391e96c2e0e35f2cb2035733d9a801f4a039549b770bcb
+  md5: 0caa188a695319bdb13f53b0a2b3accc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264864
+  timestamp: 1661371117920
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2023.3.post1-py39h06a4308_0.tar.bz2
+  sha256: 9bf1d89b747b64e8ad7f7ba08caed51a51b7f3009dd6d99261014f66f9eedaa0
+  md5: bcb44ecbea441ee0d4659133d060d71f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257904
+  timestamp: 1695131670290
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-2.3.0-py39h06a4308_0.tar.bz2
+  sha256: e937081facacb141dc2c9cdcced92baa9a2662e4a56100b6041df0b6b7692570
+  md5: f3ac39b2349258198a9b3316636fe5d5
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39972
+  timestamp: 1685030752528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py39h5eee18b_0.tar.bz2
+  sha256: 2a535f9fdda20b536bd76dfa286fb67a7685ed2be4ad51e2860c44e144c0b457
+  md5: 797c263fd5bff62987fc1da076eef0f9
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 184040
+  timestamp: 1698096132905
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-23.2.0-py39h6a678d5_0.tar.bz2
+  sha256: 70ee4fc614dd3337ad542c7c961428930160ab8c7da27775faed5ffddbd362d7
+  md5: bf2a4feb20647c569f7ce5a8f63094fa
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 515650
+  timestamp: 1657724431309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/qt-main-5.15.2-h53bd1ea_10.tar.bz2
+  sha256: 34fca7030324880c741f8b2030673229883cb7a11429f8e4bd2664d7d0f07ae1
+  md5: ccbd6faf6b49454aec690b72d21666dd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - dbus >=1.13.18,<2.0a0
+  - fontconfig >=2.14.1,<3.0a0
+  - freetype >=2.10.4,<3.0a0
+  - glib >=2.69.1,<3.0a0
+  - gst-plugins-base >=1.14.1,<1.15.0a0
+  - gstreamer >=1.14.1,<1.15.0a0
+  - icu >=73.1,<74.0a0
+  - jpeg >=9e,<10a
+  - krb5 >=1.20.1,<1.21.0a0
+  - libclang >=14.0.6,<15.0a0
+  - libclang13 >=14.0.6
+  - libcups 2.*
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=12.15,<13.0a0
+  - libstdcxx-ng >=11.2.0
+  - libxcb >=1.15,<2.0a0
+  - libxkbcommon >=1.0.1,<2.0a0
+  - mysql 5.7.*
+  - openssl >=3.0.10,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  constrains:
+  - qt >=5.15.2,<6
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 62392312
+  timestamp: 1693222657819
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+  sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
+  md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 467661
+  timestamp: 1666648052561
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py39h06a4308_0.tar.bz2
+  sha256: d75944ee54223866870a0ffffdcea3d116b8d010af38813944ea4971f0c3376a
+  md5: c7de00b4ac2778c4e5a7816320d75391
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94028
+  timestamp: 1690400356879
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.11.3-py39h5f9d8c6_0.tar.bz2
+  sha256: 8ddacf409396338156d1a09da3f8f0f3b3b473c679bcfefd2de154f7d8f91344
+  md5: 6d6d7ca3d32075d8a57131d589851dd2
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libgfortran-ng
+  - libgfortran5 >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<1.28
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23630389
+  timestamp: 1696544992719
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-68.0.0-py39h06a4308_0.tar.bz2
+  sha256: 8f376d3a9e9fd16fa25e4aae3a662ea7311601e2e7020b0ca1fa076ad0dd2c5e
+  md5: 1581cafc84708ed9aafaaee1cbbf6065
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1089416
+  timestamp: 1690290900608
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sip-6.7.12-py39h6a678d5_0.tar.bz2
+  sha256: 5c834b081a5d4092b980506b8ca135bceed171cefe12a6670439447415fe8512
+  md5: 52a9ac7b6afc89a7d854a91a7755bc26
+  depends:
+  - libgcc-ng >=11.2.0
+  - packaging
+  - ply
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - tomli
+  license: LicenseRef-SIP_License OR GPL-2.0-or-later OR GPL-3.0-or-later
+  license_family: GPL
+  size: 565139
+  timestamp: 1698676107812
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.2.0-py39h06a4308_1.tar.bz2
+  sha256: 58bea49efb19cf0af5399d369a9c9b4cd0fc1b3bb1c3542d09f313050823576f
+  md5: e19ffbfb24b990275d24fcea2bd1699b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15702
+  timestamp: 1614030498860
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py39h06a4308_0.tar.bz2
+  sha256: f7699224e82be39ba67438972a1db182bb9e8a2ebe2c7426d862c5f5548bc862
+  md5: ca061ce25c0f58628643abec8d6a8244
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 66330
+  timestamp: 1696347637947
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.41.2-h5eee18b_0.tar.bz2
+  sha256: 8b45ba506984fe9c061b4acde6f5243d52dda8c1eae4992f8d80c03f425214fe
+  md5: 68c24a824d36a16bbb28d80d70cee8d2
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1640317
+  timestamp: 1681394746811
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+  sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
+  md5: 041a3caf09dc9ce8fc6c10925c4fe050
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1888016
+  timestamp: 1680167274961
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py39h06a4308_0.tar.bz2
+  sha256: b2727fb9c674d7ae7786f322ae4e00673edff6c87ce016871f492026a26a0f5e
+  md5: 0e76eab58fe488e91f0aee73f46de031
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29816
+  timestamp: 1671751864131
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py39h06a4308_0.tar.bz2
+  sha256: 6ac6003ae10a377e9c2e8953f00aba524b166484252069f19670c6c3792cb5ca
+  md5: b413a210eca82fe867e991eed085201b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38882
+  timestamp: 1668168876032
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.tar.bz2
+  sha256: 4a822e705b349b3ba698cc1845397977aa17a0b853e9ea63d1b228e3fc60ba9b
+  md5: 5b8375e2092012db69d2123dc0c68630
+  depends:
+  - libgcc-ng >=7.5.0
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3485432
+  timestamp: 1654088939579
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tomli-2.0.1-py39h06a4308_0.tar.bz2
+  sha256: b91bd44ade7b16900ce08a0697abf363e04606f891df593c459d062c8fcf5478
+  md5: 3c925f0e6cbc92a445946470f9d3732e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 24854
+  timestamp: 1657175588674
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py39h5eee18b_0.tar.bz2
+  sha256: bd06f7b49d9c04c51c1e825bab446ec3cdde2bce39af00bf113a05c1009595e2
+  md5: 587c3f3c891901f4305653e50c18d6c0
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 679739
+  timestamp: 1696937022519
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.65.0-py39hb070fc8_0.tar.bz2
+  sha256: 89473ae25cda1917882fdf204887ab7138ac7ea72c2519248425872f422c5971
+  md5: 67a8320961ff24e92eebb661536e5cf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - requests
+  - slack-sdk
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 123763
+  timestamp: 1679561904852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py39h06a4308_0.tar.bz2
+  sha256: cf64b9ca6e05ac898d0a14973a4492e6bfbf02023d3bb0971335e3e73888e37f
+  md5: 0f0b91a158dd3692cbb7a7763b657bfe
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192032
+  timestamp: 1671143995098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 3f9d710c8256451458427b037bb0bb049688fef74b3a60f9874984b1269e07c2
+  md5: 8515e64a3de7581360d713fe4c0a094e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8789
+  timestamp: 1690297588156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.7.1-py39h06a4308_0.tar.bz2
+  sha256: 7126b8672977b98a2ceee2504eab8b83ba65ba48ee7c67786b771b79ea189168
+  md5: 60170012374b2a5007842fa5870d78c5
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57479
+  timestamp: 1690297581658
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py39h06a4308_0.tar.bz2
+  sha256: bdafa637d91ee2986a37cc82eb18c7b9b6e467eddd2eac3f510ad878a5b45da2
+  md5: 89e6a047e97aa6b06c8a217e64182646
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 10729
+  timestamp: 1659769510353
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.18-py39h06a4308_0.tar.bz2
+  sha256: 2f4a5979aaf22660fe9fb8c4ffd41e5a9dc012e20f78e1dbf4ad9c67e0fd28be
+  md5: 0be10051dd3d6f31ba52b7c08ba3ba0a
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 187469
+  timestamp: 1698257600264
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py39h06a4308_1.tar.bz2
+  sha256: a32a1aa28f8927a9e6b9057fdf8426b83ee5d415ab005038b07ad4f3d1945173
+  md5: f8d03a15b974fc7810d9f54ae849fc8e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20781
+  timestamp: 1607365390528
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-0.58.0-py39h06a4308_4.tar.bz2
+  sha256: 3f3ed61beaf5939afe7ec80af940b5d4dc316f90e32b1528f53e49546378d389
+  md5: d7db5d6ce1db80eade8a082ff78bf479
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 71044
+  timestamp: 1614804011510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.41.2-py39h06a4308_0.tar.bz2
+  sha256: bd2c8689bf29bb3e4588970f6bba11161da201ffcb15dbd55ce66c0cb53d3e81
+  md5: b3899f8bda32734727bd5a73df1d7d17
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 101520
+  timestamp: 1695742037911
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py39h06a4308_1.tar.bz2
+  sha256: 8e8d728472d26c1a42345003d69bf381c062db8050d3444a6ccced7e5dcc3524
+  md5: dd9bda05830964c550a69b70178ee6f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48001
+  timestamp: 1675159114742
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.2-h5eee18b_0.tar.bz2
+  sha256: 93ca87e697bb9e045fc9cda13b05fe27e1a99f3ed143b75bbcaf4dcb745aa06f
+  md5: 3eebbb22c5ca63987db36e1f19cbe872
+  depends:
+  - libgcc-ng >=11.2.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 763941
+  timestamp: 1683112966413
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.4-h2531618_0.tar.bz2
+  sha256: 95c82f0f889e8cbd0abe00cdc1ef22591293f741055179dcb973cf0830e63ee3
+  md5: 567b68192c387b5fc88178425577a0fe
+  depends:
+  - libgcc-ng >=7.3.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=7.3.0
+  license: LGPL-3.0-or-later
+  size: 366479
+  timestamp: 1616055552392
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.11.0-py39h06a4308_0.tar.bz2
+  sha256: d15085ade33b9eb9adf8f3b8dad240688ee10ab49e7d7c33015c6d4f51202b72
+  md5: 3818a9531fe74433c3b7d5144c9a58cc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18021
+  timestamp: 1672387231268
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_0.tar.bz2
+  sha256: 2dc9150a95704d83efd39bb9dfb44bdf8419022f4fb0fc416380a922a27c130d
+  md5: 4f315d7551f4bbeb06b6fc28342a9aa5
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Zlib
+  license_family: Other
+  size: 127528
+  timestamp: 1666595012798
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_0.tar.bz2
+  sha256: aa6aa291bec6aa66e1f063cfa75a9e0fc6bd459fcb45c372aacac9006a073900
+  md5: 4e99328768f538f33aecebdae9472744
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1055426
+  timestamp: 1681304602537
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/backcall-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 09f2cf5b30825a39257320204b08146367f4346655197515b2cabcd363736488
+  md5: b2aa5503875aba2f1d88cae9df9a96d5
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13636
+  timestamp: 1611930018941
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
+  md5: 544adf2677c47c9b9c891aea720678f1
+  depends:
+  - python >=3.5
+  license: MIT
+  size: 33999
+  timestamp: 1630003259346
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/fonttools-4.25.0-pyhd3eb1b0_0.tar.bz2
+  sha256: dc52779857921d283bad3eb24071aed6fd4d593bedd2dcfa847d097e04f2cc06
+  md5: 9eff1a842dbda8d1bae9a2c008b599bc
+  depends:
+  - brotli >=1.0.1
+  - munkres
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 690443
+  timestamp: 1625743217109
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/jupyterlab_pygments-0.1.2-py_0.tar.bz2
+  sha256: 3cf088eceac1016e2dd2164e52d23ccf6687ea0d57a6afa295a19b24fb049201
+  md5: 33624a42ee387bf9918ea98b4e7b31fc
+  depends:
+  - pygments >=2.4.1,<3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8173
+  timestamp: 1601490751973
+- conda: https://repo.anaconda.com/pkgs/main/noarch/munkres-1.1.4-py_0.tar.bz2
+  sha256: 8e1aa5421845a3e66dda9eeb1b9f9250d39a41ab971cf910c07f60528882b6de
+  md5: 67857cc5e9044770d2b15f9d94a4521d
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12810
+  timestamp: 1600445183315
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pickleshare-0.7.5-pyhd3eb1b0_1003.tar.bz2
+  sha256: ba9b23dea09b8fb44c49c1eed16163bd0f1cb64bb19c9e2591825738a6fa5918
+  md5: e68a6f315f41a8d814d833652bf38b9b
+  depends:
+  - python >=3
+  license: MIT
+  size: 13374
+  timestamp: 1606932077143
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 2745290a16cda0ae986b70c21f77ca43112c7be15f26041bec436f9f76aa3faf
+  md5: 2eb923cc014094f4acf7f849d67d73f8
+  depends:
+  - python
+  - six >=1.5
+  license: BSD-3-Clause and Apache
+  license_family: BSD
+  size: 246457
+  timestamp: 1626374695070
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://repo.anaconda.com/pkgs/main/noarch/send2trash-1.8.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 751cec8fcd920c628b77c444a6451bdefb317560fb2d0d86b902dd196e4b1909
+  md5: 41db68b96e114e367c4f120a3b379e59
+  depends:
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19391
+  timestamp: 1632406728844
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2023c-h04d1e81_0.tar.bz2
+  sha256: a5ddaa6108bf5e1f95d9d8287cdf1d24cbef3ef8bea206a79cc8ff520d6db1d8
+  md5: a815d3bdb160bcc71687f2dda70d3ca4
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 122218
+  timestamp: 1680170368293
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-3.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: 13e73c428772cd9ffb84d7d9962e452be3e7184a4805a5ba538a1208bab385bb
+  md5: 447a49f7bad119faa80d7f14aa296c95
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162176
+  timestamp: 1644481750133
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py39hecd8cb5_1001.tar.bz2
+  sha256: c8d0079391f4ff14590bd1bcf31a4e4f0a6b7a057f438851ea2cdf9bb03c9dfa
+  md5: 8810f48fe4a4792de0fd3520b502d08b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10019
+  timestamp: 1606859473259
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py39hca72f7f_0.tar.bz2
+  sha256: 1a88bfa500ab8ed7ea509db9de0c0d7a8504c3d769f4b6981d73123957bbbfc5
+  md5: 00a446b6dfc61af223df4de29fe8ad94
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 34305
+  timestamp: 1644569782044
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: 41c811cf48a20445df4c42c1640379f05fb0fb4ce40398f37caafec46065bc91
+  md5: bd92dd8bd5b9d24e632b62a075426e50
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133634
+  timestamp: 1695718025321
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py39hecd8cb5_0.tar.bz2
+  sha256: becae4817ceb5d01199a4ee849d9a1df2c6722d326ce7bee9809ae7ee9f8718f
+  md5: f8ae051b591a9027adc16de1be9748f4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206198
+  timestamp: 1681493096349
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.3.0-py39h20db666_0.tar.bz2
+  sha256: 2936241747f6cc0f0b3afa53bb28ad6f658b53a0fc2e67a5ed34d1d5e2cce117
+  md5: bdca1b691340964271d9cfec6baaf8d0
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5719952
+  timestamp: 1697490515691
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.5-py39h67323c0_0.tar.bz2
+  sha256: 1a973c14603815f3beb62585b8bfcbdb389b3bfea7af0f2785848d0f2a8c82a4
+  md5: 0d79760d544d0bd8acb4adc4ef813418
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 137075
+  timestamp: 1657175654487
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 9809d9e13225a5c7a296dcbd4a6cce514a6c593bb94317e80c0eb6be2197e3d0
+  md5: 31d6d04cd2388d8f19004501271b3545
+  depends:
+  - brotli-bin 1.0.9 hca72f7f_7
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18982
+  timestamp: 1659616229395
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 68d6028e850916c7de1db7e7cc843f9be3bd6f3b199db24a1163f07173703f60
+  md5: caf1073dc2ca5aeb832a2877394eae12
+  depends:
+  - libbrotlidec 1.0.9 hca72f7f_7
+  - libbrotlienc 1.0.9 hca72f7f_7
+  license: MIT
+  size: 18233
+  timestamp: 1659616216769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py39he9d5cce_7.tar.bz2
+  sha256: 53c32e5a8db87ffafa361a1b26ebf840ae0a74d8b034a960f905c58cd36c5b2d
+  md5: aa1ed20c38af535c8d6a955314759d7b
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 394588
+  timestamp: 1659616312678
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2023.08.22-hecd8cb5_0.tar.bz2
+  sha256: 9656b4585ba25c89f4968134378e8792a6075a890198bad7053cc19bda8f0960
+  md5: ce3588e31faa79f546e0fc6a36c5543c
+  license: MPL-2.0
+  license_family: Other
+  size: 133884
+  timestamp: 1694009771475
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2023.7.22-py39hecd8cb5_0.tar.bz2
+  sha256: 50240ce92cf2d838c4397da50052ee5a855880966a39ec102a50a71494e4c5f4
+  md5: 21eb7f53076d0a69513cfd258f6ef63c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159756
+  timestamp: 1690232346868
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.15.1-py39h6c40b1e_3.tar.bz2
+  sha256: 06efdf42cb61264a74fd632d20ca583eef928552345ce8d28f0ff7cc7b6a1a71
+  md5: a40a04d9cda1e665565bc6c832d598b6
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225258
+  timestamp: 1670423337502
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.0.1-py39hecd8cb5_0.tar.bz2
+  sha256: 8087b804aa944e4a59c568ff652a7d684e821a34e2b2d3180bca34853243e2c8
+  md5: b2cc5f37f7bb069d061306e7eac2a011
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1913396
+  timestamp: 1668084575248
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: d864bfa44d8d2f7f41295021e38ab8e85333765571f1ff28bb8b218222f2b278
+  md5: 103d8c039e342115720a84d59c119d46
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13774
+  timestamp: 1671231190250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.0.5-py39haf03e11_0.tar.bz2
+  sha256: bdeb0fb4f5ef8d18ee9d37694238028533956ad7b89147a8b77004b4a6cb30ee
+  md5: f69f09e0346172f225390d2b3b0d7873
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 246628
+  timestamp: 1663827484947
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cryptography-41.0.3-py39h30e54ef_0.tar.bz2
+  sha256: c0e9f17a21a3cd9f70a69b123c58b3ab4a5a2c96d899340310b5712e35bf05c1
+  md5: cb80c7ac65b48a737654f371fe31c460
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1307228
+  timestamp: 1694212041712
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py39hcec6c5f_0.tar.bz2
+  sha256: f5d18b4cccb512beb948a3033dbcba3d51750adf1c8796cc3258b48e5cba2393
+  md5: 04cbe8f4bc62c34fac9d42d1124059bf
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2052734
+  timestamp: 1690905361158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 3888d879bfa7f6d4c4b576bf0e7f96dec35090795f4140c96b7fa63041138ea9
+  md5: ef0e825982f242085574f502dfff4f6b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16594
+  timestamp: 1649926538106
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/exceptiongroup-1.0.4-py39hecd8cb5_0.tar.bz2
+  sha256: 76da764d5bc6be29bc9d0be59036eeb7e5ae74292d481c16c1c7ad1f71d7ec31
+  md5: 24747a300246c016b3a7f04dabd02d4a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27709
+  timestamp: 1668714497209
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/giflib-5.2.1-h6c40b1e_3.tar.bz2
+  sha256: 918fd55f78dd12ab63217486ee7b4c13fa78f8b00f6c5fecd0b7d60ae5f20281
+  md5: e4a732941f74b8062c8bcbfe5c5c2b56
+  license: MIT
+  license_family: MIT
+  size: 80252
+  timestamp: 1676983220161
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.0-py39hecd8cb5_0.tar.bz2
+  sha256: 5c36d43cadbbf944d9255e79df85c2e9e6155a1d6f9158e06fcd8ffd458b7663
+  md5: a5a2cff387403ccf9cf58aac7a6dde55
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4573879
+  timestamp: 1698866750755
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+  sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
+  md5: f3ce6fe6eb760c236e5f7d04df5faa81
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28138484
+  timestamp: 1692293212596
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.4-py39hecd8cb5_0.tar.bz2
+  sha256: fc3613caf99038e240e1a3277f035ee8cbdad0ca7238736fe80a91756d7eef9c
+  md5: 6dd72c43fea25b748ec7a9f6c0407e15
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111810
+  timestamp: 1666125671024
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-6.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: e8418fe1e46ad56f67c5e9e731d15017b89e145c774867ba73282a6bea52afa4
+  md5: 03cdb7e679924b329ecab8f12cb8fc67
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38813
+  timestamp: 1678997212422
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib_resources-6.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: a56484deb6f2ff9ccedb9c7e8783e2fbf40c7964eb4e5e475ef83c12b2af6ae6
+  md5: e113c4e6e758dd68faf196586bf5564d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51873
+  timestamp: 1698254765815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43547.tar.bz2
+  sha256: e476fcbf12b0d12c86e46938238563f210c9e827a48973cb82bcd5f8973a5e72
+  md5: 78baea934985ccd9514a366cc7e80ed4
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 727499
+  timestamp: 1681801225190
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.25.0-py39h20db666_0.tar.bz2
+  sha256: 71ef033d5da0ee1ef05a847f7d7bd4887ecb59866a02687831c5c101c19994a1
+  md5: da9b63e42f281f7e77b289f4b654b83b
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 218436
+  timestamp: 1691121840155
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.15.0-py39hecd8cb5_0.tar.bz2
+  sha256: ed62cd5ffa084a868fbfeb847c97660be6d9b38b1dbbba94b90e86c9f4536d25
+  md5: 6a7cb9b49593b29933fa2b503d533a08
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1257205
+  timestamp: 1694181720454
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py39hecd8cb5_1.tar.bz2
+  sha256: ffab0a8329a4c3a806f3f0ef927d4f04ad29bcd7c66ebbaae037c8ef6310864a
+  md5: d861ef66f5c0a282d60b65778a9de2f3
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1048450
+  timestamp: 1644315332508
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.2-py39hecd8cb5_0.tar.bz2
+  sha256: 9ae5c34fbae69cbe97bacb3aa6c5ea94a0fb5bc0d65e2f58ba2d1a0cd89029da
+  md5: f7e603c965052deed8b789c35855a42f
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213537
+  timestamp: 1666908270815
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
+  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
+  license: IJG
+  license_family: Other
+  size: 278924
+  timestamp: 1677849185191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.17.3-py39hecd8cb5_0.tar.bz2
+  sha256: 4448d1505b0229a771f6c49871cf0aaffeb24a32f293f572e63a9a87802d3c64
+  md5: a82a17e78f725dcbd71ff8dac6db05c7
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133134
+  timestamp: 1676558895333
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py39hecd8cb5_0.tar.bz2
+  sha256: f901fa95783b6790540b8107a400004b17726e5175d686f20d40c6704d8a89ba
+  md5: ee9270379a9ebdb6297e4b6849b3f7f0
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 195479
+  timestamp: 1676329410154
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: ede34881321808fbb967885dde9b0b6c9c8ef1f3eb192fa514058c4f14201c4f
+  md5: 07d24f5332ca5d0e76aa0df051a1f05d
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 79901
+  timestamp: 1698937699237
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-1.23.4-py39hecd8cb5_0.tar.bz2
+  sha256: 8d4d5ecb6a3e28f7d6070ecc266e3c8ff54d1c61d2f6b7bf6729d366aa5dae43
+  md5: 7e60995b3119417213e5faedda147499
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 403165
+  timestamp: 1671707664990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py39hcec6c5f_0.tar.bz2
+  sha256: ad1c4b66c49c6f6e874e37e5e9a19d341308a1fa95fea54a9e61d5a72ee7cdb0
+  md5: cd470bdb28bb0e8b3535c93a3a6dad07
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65431
+  timestamp: 1672387389172
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 0c94d2dbc5dc4e7e1d663728b7e759c6643667e1532a87f8a2296ee2fc3fd51e
+  md5: 7dba7aa5b971febb55281659843586ba
+  license: MIT
+  size: 65470
+  timestamp: 1659616172703
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 7fe12989dfecbd6a47b370bda2298b6408b433dab3beab1783553df1cb7c10fd
+  md5: f78a158983f0bbaba56f34b976bc6dae
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 34189
+  timestamp: 1659616189313
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-hca72f7f_7.tar.bz2
+  sha256: 8a099bbab7dac20061c998e532dec2e08b50dd96899c680dd0519d8aa84bdc4e
+  md5: 36a1d885725d3ab4d1fadc5a29f978d2
+  depends:
+  - libbrotlicommon 1.0.9 hca72f7f_7
+  license: MIT
+  size: 327737
+  timestamp: 1659616202869
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_0.tar.bz2
+  sha256: 5d97bdc320e4c9cecf4510517c33764387163e25c36d94785da93d1e936c48c1
+  md5: 817848d0e2b2808acdc9b3fbbf581726
+  license: MIT
+  license_family: MIT
+  size: 133887
+  timestamp: 1683716590737
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+  sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
+  md5: e458587c87e3f2d20192f4e0738f2c63
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 149419
+  timestamp: 1665498987619
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+  sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
+  md5: 1058b661ec829b2ee3716ee2a5520641
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1917987
+  timestamp: 1665498925405
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-hca72f7f_2.tar.bz2
+  sha256: f3456f50b3b9cdd989ecc308bad441cd21dcc246c574243eb8f6895f5f3eb9ed
+  md5: c90372428e1e4eed4fdcd790979d06b4
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1409377
+  timestamp: 1650983531933
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-1.3.2-hf6ce154_0.tar.bz2
+  sha256: 87c7a8de961ed23a37da39abfeda82e0239b5f2cda2c60649773f918daef7167
+  md5: c0b99f8e1c7475f23b1c7b4250b06e1c
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88021
+  timestamp: 1694778290062
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.10.4-h1bd7e62_1.tar.bz2
+  sha256: 56c105d4b7503982b2e29a910ea5035189eea7878d5eb2239256ed61a8949cf3
+  md5: 06866415ef22d5322f9bdc9956b59c4d
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 678174
+  timestamp: 1692970318885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxslt-1.1.37-h6c40b1e_1.tar.bz2
+  sha256: 30f881918bca97822c7e7cc39b95cd0146986b3bd8094514dac2cf421541f6c6
+  md5: 2edc6c894d6d0321304396e9bd40df94
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241774
+  timestamp: 1692973618934
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 0190d3b8d2939f28aa017711cf4147c51a1139da2922cc8420a71562dd99f844
+  md5: 454a7f2c4426453f17e995382a4235e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 36036
+  timestamp: 1659783508187
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+  sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
+  md5: 5c740b4a18a558de0ccfe601703c423c
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 338738
+  timestamp: 1662635677689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lxml-4.9.3-py39h946e0e5_0.tar.bz2
+  sha256: f7d92d43cdf72eeca1c9288362f26cf83d739ba5a428ce5716d206d972296ba3
+  md5: 8bbd981ca0129d7beeacd3cd7623f714
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1491074
+  timestamp: 1695058597986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_0.tar.bz2
+  sha256: 74e263365ae950da52900518d6e7d7e0b0a28e9aca03187bc8bc2cae031db46a
+  md5: d5f58d056b4bfc67aec30c77035ba889
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 182491
+  timestamp: 1670944720979
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py39hecd8cb5_0.tar.bz2
+  sha256: 9fe68c8eb9b0a3aa41eb5531fcf0e9ec2c9115fa65c46213d5adc00116aff596
+  md5: 1affd16b166571a91feae04baf5fd3da
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123431
+  timestamp: 1671542016019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py39hecd8cb5_1.tar.bz2
+  sha256: e5fc51472fa0f36abd78baa5b3c9245d6627b0da11188e6a954d73f3f2bca210
+  md5: df7c519447affffb594f8c56b028ed33
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 107035
+  timestamp: 1684279974102
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.1-py39hca72f7f_0.tar.bz2
+  sha256: 2b6a228a76493d54d885c3239c05fa8c00d6fd94d5db18542f5c653fc8fbb798
+  md5: 3681ebf029211ceab26af6f5d35abf39
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22254
+  timestamp: 1654598220251
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-3.8.0-py39hecd8cb5_0.tar.bz2
+  sha256: 40aa972e605bdc8305ebdc4b8e891ae8b65382be12d221e002ec31cfe830ac22
+  md5: 07b2a24fd3dcb5cb0af22e137cd43408
+  depends:
+  - matplotlib-base >=3.8.0,<3.8.1.0a0
+  - python >=3.9,<3.10.0a0
+  - tornado >=5
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8754
+  timestamp: 1698692468088
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.0-py39hb47e01b_0.tar.bz2
+  sha256: 2fd179efa024c92d0d71179a981a781d16c70f5d8c6305e0d678b0c7ae1275ab
+  md5: addda7f015d1673f794a23fdb18a3e09
+  depends:
+  - __osx >=10.12
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8182219
+  timestamp: 1698692361219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py39hecd8cb5_0.tar.bz2
+  sha256: b07b19f15381e20d1b95e86c5958b13ecba68cf6e2987e6917611391b7077860
+  md5: 6eb64ecfcd754502e271db0bb51d2cfd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17374
+  timestamp: 1662014643620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 2312ee5a6343e8495802698d7181f1b619aad7479d96ee253407b324ac884417
+  md5: 866960fa48a7ca335941786d4869802a
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53542
+  timestamp: 1659721365599
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py39hecd8cb5_0.tar.bz2
+  sha256: 37f455814ce242eb65ff80a0402f1bd231a388e6823e6c1e65f60b705c032a2d
+  md5: 4c9246c492a64729225aa5b04e12c2d1
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19573
+  timestamp: 1659716100178
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-0.8.4-py39h9ed2024_1000.tar.bz2
+  sha256: bce8438ce1029525e3af4243925f6fead97dafe776d55321f88d696653b499a4
+  md5: 2a4d604717a647ad21af766289cbbfc3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58057
+  timestamp: 1607364912348
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43559.tar.bz2
+  sha256: a2f4ba3f6e5e1d72bf8c7a2b540bfaad9a54796aa590c618a27687fcfabe7583
+  md5: 25051fe272624544652dc6d814c2943a
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224420228
+  timestamp: 1691503125614
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py39h6c40b1e_1.tar.bz2
+  sha256: e8ab7e085c27403d813961828f36b27475b8272aeb93d0daa6edde3a34602723
+  md5: 37d8cf85a63f7aa9af1624894a7d606d
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48590
+  timestamp: 1682969183093
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py39h6c40b1e_0.tar.bz2
+  sha256: 7d605f37e905f3eed934ba8ee3263b0f4f43f23205867016caed9e7b064f1656
+  md5: 0b2aee6666135bbd36b46d6ac66160f7
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 210705
+  timestamp: 1695058433223
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py39ha357a0b_0.tar.bz2
+  sha256: d79d993bf520cb947e984207989b692f47ef8a573cdcc58b482d9a00096eb68a
+  md5: e22fb55ce380d0ebd44cce3f20d5349e
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296614
+  timestamp: 1695060155673
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-0.5.5-py39hecd8cb5_0.tar.bz2
+  sha256: a8d6ff7ef8999e22470f425a4bf1b7e06b308fdcc6f5639e9a14ec4452e7bc0c
+  md5: 1a5d4004e64e3cfb7a2a297b9117c285
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8213832
+  timestamp: 1681756573646
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py39hecd8cb5_0.tar.bz2
+  sha256: 59acf22956f295ed429624a1560bceffbbf536ea93ca63a5f1a48975a0afdbcb
+  md5: a7a6344327960940bad23e783a4d6bce
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100813
+  timestamp: 1698934262550
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-6.5.4-py39hecd8cb5_0.tar.bz2
+  sha256: f1c58c9f3081bd46d3acddfe4312a6d487e96d0d961d60902002744bfa5b35af
+  md5: e572c1264a7af20b486f64ac8c9e1f57
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 573356
+  timestamp: 1668450732828
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py39hecd8cb5_0.tar.bz2
+  sha256: ba23f4869ac472f95547a3909a62a9a1c654e449f6ff12b77e1afe4d08be657b
+  md5: b67569a7c30af9ffa5cde6e4b52ac68b
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148342
+  timestamp: 1694616917184
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.5.6-py39hecd8cb5_0.tar.bz2
+  sha256: 608735a47b74fbb8ea8945c72cd2982a9f326d00a3832c78d5cb17dcdc02c2d1
+  md5: 97b81f34efbe86c5220fe82eb584fd62
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387288528
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.1-py39hecd8cb5_0.tar.bz2
+  sha256: e108c2df53ee3b3218067fd50fedcd417d5ec12d1d1247a46f0018942efd2c08
+  md5: f2b02e342efea3f93ab8eee6033a332a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2958243
+  timestamp: 1690562148988
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py39hecd8cb5_1.tar.bz2
+  sha256: f683696cee85e299fa639cb8035b9db30822f6783be02c356f254a20e6a843f0
+  md5: d77862975a9a1cf50acb803be26e83a1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 575365
+  timestamp: 1690985052739
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.2-py39hecd8cb5_0.tar.bz2
+  sha256: 56734e1f514439c1d89eb70f85e7488acd0fa8870d245b643144419236595b9e
+  md5: fcf427f8b0b0b2dc8b9cd83ba26c6177
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22858
+  timestamp: 1668160618784
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py39h827a554_0.tar.bz2
+  sha256: 8c39424eb35933dd22754260ad49fb774e423c55dc5aaed66bef64c5864ed0ca
+  md5: 185e9c41abb88ee59b52ec0f5f65d506
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 138305
+  timestamp: 1696515469702
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.0-py39h827a554_0.tar.bz2
+  sha256: 82a2dd0c2ff6e20a275e5447dd03088f79694f7bfa5055a25c54bebf31aac4ca
+  md5: c157e6ab469a95b06fa822ba075978b3
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.0 py39ha186be2_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10376
+  timestamp: 1695831243158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.0-py39ha186be2_0.tar.bz2
+  sha256: b3a003b41cec2751210e542911e99437db0321542f6812c1b88608ef720ba7ef
+  md5: 56400dfe88c427cdf1854e47666b8a99
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.26.0 py39h827a554_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7570900
+  timestamp: 1695831208653
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
+  md5: 93f5d7b66976154adeda219bea02ba45
+  depends:
+  - libcxx >=10.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 484257
+  timestamp: 1630093862501
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.11-hca72f7f_2.tar.bz2
+  sha256: 2ebbbe328e24efdfc4ec32aae27b18998bfe0f1be5328d4ea511afb043a77cdd
+  md5: 5e8713ef1215406254988163eaf34020
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4965606
+  timestamp: 1695323060401
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.1-py39hecd8cb5_0.tar.bz2
+  sha256: 7609426af4d66d174df6129457fd0f52de7fb7652dd08eae161185a7a9da8bad
+  md5: 4154929ace2ad6ee16aea815635a6d1f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73598
+  timestamp: 1693575307570
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.1.1-py39h3ea8b11_0.tar.bz2
+  sha256: aff5acedef9da91b77851e1a163b8319d72bc4152c98ac87703a2eac1e5d575b
+  md5: 7df4c76aa8c52fedce5346748d56459e
+  depends:
+  - bottleneck >=1.3.4
+  - libcxx >=14.0.6
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - tabulate >=0.8.10
+  - blosc >=1.21.0
+  - fsspec >=2022.05.0
+  - beautifulsoup4 >=4.11.1
+  - pyreadstat >=1.1.5
+  - pyqt >=5.15.6,<6
+  - s3fs >=2022.05.0
+  - numba >=0.55.2
+  - xlrd >=2.0.1
+  - qtpy >=2.2.0
+  - xarray >=2022.03.0
+  - psycopg2 >=2.9.3
+  - lxml >=4.8.0
+  - zstandard >=0.17.0
+  - pyarrow >=7.0.0
+  - pytables >=3.7.0
+  - xlsxwriter >=3.0.3
+  - gcsfs >=2022.05.0
+  - fastparquet >=0.8.1
+  - scipy >=1.8.1
+  - pymysql >=1.0.2
+  - odfpy>=1.4.1
+  - pandas-gbq >=0.17.5
+  - pyxlsb >=1.0.9
+  - matplotlib-base >=3.6.1
+  - openpyxl >=3.0.10
+  - jinja2 >=3.1.2
+  - html5lib >=1.1
+  - dataframe-api-compat >=0.1.7
+  - sqlalchemy >=1.4.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13388063
+  timestamp: 1697477404222
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.3.1-py39hecd8cb5_0.tar.bz2
+  sha256: 42d83288119306089a06e853a37045fbb9860548b05a1e79d223f7ecf1cb349d
+  md5: 8daced11264159ff57df7bba4d0b2ec7
+  depends:
+  - bleach
+  - bokeh >=3.2.0,<3.4
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.0.0,<3
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.17.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17075803
+  timestamp: 1698867397009
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: ad7ca92e5c83a8e2181677025509ed7b8f566ec23b24f28316fa087bb591c11f
+  md5: a4ccd0fbcfb26de868f2fb4836940d7a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189263
+  timestamp: 1698263570990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.0.1-py39h7d39338_0.tar.bz2
+  sha256: fa650c98237dfcf3391428d9e46db662955ee91d4142ce8d9d32ad978b738c4f
+  md5: be0a90921f3bf4f0d6950fb786093de7
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND
+  license_family: Other
+  size: 719901
+  timestamp: 1696580194417
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-23.3-py39hecd8cb5_0.tar.bz2
+  sha256: d3b44e98f14aa1924c47456ed8a198c31f626815d6038f4567406476d29c2e65
+  md5: 81ae9ec2d7fcf6934847bff558b619f5
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2672987
+  timestamp: 1697548890181
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py39hecd8cb5_0.tar.bz2
+  sha256: 96026f097d82064a488391c8d86708fb4312103e1cf4aa3a671c83f0cc7c84b0
+  md5: 1a822c206e2abddc5d6d821721af227f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33013
+  timestamp: 1692205801265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py39hecd8cb5_0.tar.bz2
+  sha256: 288d9c47f2213c47156d88373f18bfd9b62dd0376e2838c8f350a20cb5102e2f
+  md5: 1604d33dbdb2446c642970f8b354bedb
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91266
+  timestamp: 1659455269141
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.36-py39hecd8cb5_0.tar.bz2
+  sha256: 1498de7a4be4812d5488c1c7b50b51b52dd5a73ddcfe2889668394ebbd1e7974
+  md5: d1b3bcc35655a3123acb1fa2ad1a8511
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580828
+  timestamp: 1672387372015
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py39hca72f7f_0.tar.bz2
+  sha256: 6b4438a3e8b3d06b226a83546c85fb98da1ed7c4577520db13a83b50a6bfe50b
+  md5: 7540555d1fb192236db9a7c5c9d3601c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365765
+  timestamp: 1656431373327
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py39hecd8cb5_0.tar.bz2
+  sha256: df526309cf3f059b7da0da73074228a292bc52d905cabd986988dde32d71f248
+  md5: 0a73533fb6e0dc717ab906a537bc747d
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30803
+  timestamp: 1675441638631
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py39hecd8cb5_1.tar.bz2
+  sha256: 8062832de6e28794629c5f9a1d9af9a3623f615ad9ebae8408f477397806fa57
+  md5: 0a959fbad46ab38ade48dbd358002674
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1864757
+  timestamp: 1684280094736
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyopenssl-23.2.0-py39hecd8cb5_0.tar.bz2
+  sha256: 2f1120a15405a82b13955d5cb53a0380a8e48f2458f3b70cc1094be5a192189d
+  md5: ea24b5076ef79e4567c5a3f0cb22b470
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95330
+  timestamp: 1690223465114
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py39hecd8cb5_0.tar.bz2
+  sha256: 807b3fe850a0e7fe04e0e1735ecde845b1942be1e122e505ef1ad44b265d5f50
+  md5: bcaea6d4a47e9c874becaa700c78dcf7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157216
+  timestamp: 1661452617825
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyrsistent-0.18.0-py39hca72f7f_0.tar.bz2
+  sha256: e186265981010995002b3a5ce4457b097172de7d24309035817f286245e5ac02
+  md5: 707110d1b49cb1864acb0bbaa103591e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 95016
+  timestamp: 1636111184034
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: fe7df2db41ba51c33c10a58038dd945adcab91edf897728a0918df9e1fb1ed9f
+  md5: 113a443b9c706f9f9c6187c0eaa3de27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 31178
+  timestamp: 1605305861851
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.9.18-h5ee71fb_0.tar.bz2
+  sha256: 82f6eafe240a48b71e0f51968a72ea093bd4146a224b8a6c1816fab7fd2286f5
+  md5: 85a8d0001db70e52a479155228cb1fe0
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13324979
+  timestamp: 1694439878265
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py39hecd8cb5_0.tar.bz2
+  sha256: ad967f8f6ec77ad4ab5e9a6ab6f6134b5c1e5aa560b09f73f20780b61bb61c96
+  md5: 47c5e22e31ec05a7bc0ce90065a53afd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 265348
+  timestamp: 1661368839620
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2023.3.post1-py39hecd8cb5_0.tar.bz2
+  sha256: ff492de397d67da4a19d24fd4a16572fc995ed568356e44470987da2c23004f2
+  md5: ce9a69e1668aa1e133f2aa6d4e8d346f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 254958
+  timestamp: 1695131709704
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-2.3.0-py39hecd8cb5_0.tar.bz2
+  sha256: 9ee098c09f31fad7ff1856e5ce2619172eaf979997e7a427d1e05cce32c2af00
+  md5: cac1d1898b69ae9646dfbf082910635d
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40946
+  timestamp: 1685030787453
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py39h6c40b1e_0.tar.bz2
+  sha256: c455f800af7f7abff59f25dc5b03d4ab169ebcd1fa872abd5f5dc59beb258e4a
+  md5: 637f08b19dd8fd87347d8c44f9e3e202
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 170776
+  timestamp: 1698096100056
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-23.2.0-py39he9d5cce_0.tar.bz2
+  sha256: 58ace4d18ecc09b0c888f7bb658c3c4a575ae9a4994ba35dcbffcd581470e508
+  md5: 8ce3ac7d8a04e469b566f1b090d01140
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 470617
+  timestamp: 1657724324011
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1c69d7342707e854da0df111a28f2b4499306a9b940f2782cfe795eae1588fd2
+  md5: 6f2d41dd76a03b7f85a1ed49af1763d6
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95100
+  timestamp: 1690400262627
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.11.3-py39hdb2ea58_0.tar.bz2
+  sha256: a9755ecbfd42c708945027facfa11a3dc3119778326a0ae5df79f80d7b72afa5
+  md5: 839ffa4e775fee9a8bdddabf4a14da43
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<1.28
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24331914
+  timestamp: 1696545397632
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-68.0.0-py39hecd8cb5_0.tar.bz2
+  sha256: 8fe13f7fff0db29402bd454503e8e179e56a422d08b9fc41cf9e064257e59481
+  md5: b0321e6f14e139fc15b1f8b4acb35d2f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093966
+  timestamp: 1690290944588
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.2.0-py39hecd8cb5_1.tar.bz2
+  sha256: 456c22c0e2c5c406ce7cea447b11b06203498c5ca8abe5604c7c29d38d70fe1d
+  md5: 62b64576a0aa5f6c3fb05f56650d25e1
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15535
+  timestamp: 1614030509324
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py39hecd8cb5_0.tar.bz2
+  sha256: 32017eb9274b53048d99b093c62dcc6fd2e4514521d3690d29dc2d3fe2adcd29
+  md5: 15b5595b31e39f08eaacbe2e502d8fb3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67292
+  timestamp: 1696347733587
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.41.2-h6c40b1e_0.tar.bz2
+  sha256: 47d38e4651870afa01557e1de4fe29e6e2dfbfdba4a0a68109750cb0be6dbf68
+  md5: 82e4db6a498480a75d53c55bd35b6478
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1801397
+  timestamp: 1681394807900
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py39hecd8cb5_0.tar.bz2
+  sha256: c11d2706092b88d1c373d89111a4dc8095f0e270c3cde254f288c973cb736489
+  md5: 63b957927b9949ccb19da28ec4612706
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30902
+  timestamp: 1671751919031
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py39hecd8cb5_0.tar.bz2
+  sha256: 5dd02cc3a62436c8a2eaae0d318ef9925276bc2e08faa0542d67acd9005d22b5
+  md5: e346257a2fa8e2cb48c762138a5d009b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39915
+  timestamp: 1668168959656
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.tar.bz2
+  sha256: b0c2866ed3b190b0d84024a08273846c335644bcbfe23a8521a418f2be98044c
+  md5: d5b05e38d3bc8fe6d9bcdd91029db1c7
+  depends:
+  - zlib >=1.2.12,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3536231
+  timestamp: 1654088937695
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py39h6c40b1e_0.tar.bz2
+  sha256: 0257b9a4d7d64737f786549f4732b3ea9e500230f697fbe997f2fc9e639865ca
+  md5: a1bbf0abfb8c45541122c0eb2feee317
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680464
+  timestamp: 1696937112175
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.65.0-py39h01d92e1_0.tar.bz2
+  sha256: 614ca06aa21ffba5fa6adf1cb7f39c767c0e084abbe81c547802ffd453c915e2
+  md5: d689f6203c0a9d04fb229c73d7e80a7a
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125145
+  timestamp: 1679561909274
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 1c781a8ea669e5912a5ee630dcd2066a41ded5e14bd27e5c5459b438d89e8791
+  md5: 8a292c1ee22489bef2e84bc3aaf4098e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193141
+  timestamp: 1671143985219
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 307f89c83e0ceb4f821127406056b0561623b9eb7b5e71dcbfb867bd0a2a316a
+  md5: 8bf0bfffc11ad06a1c94e145941b0ad4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9651
+  timestamp: 1690297655669
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.7.1-py39hecd8cb5_0.tar.bz2
+  sha256: 4125e44641ad8e94f2a77c686bfb9b713ebc4dac3985641e36e6b2e4504fa687
+  md5: 343514a174b3485fde55a73f56398dd7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58456
+  timestamp: 1690297648002
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py39hecd8cb5_0.tar.bz2
+  sha256: 11e7401cb6805db7ce22b1f9dd6ba5b7941c92225ce440bed1da0af284bfcad4
+  md5: 5c10d68fa5616cdd82ee93ef6e0f038c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11615
+  timestamp: 1659769478980
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-1.26.18-py39hecd8cb5_0.tar.bz2
+  sha256: c75602c6c7069745a4a9594ea845115d80025258d2573635958698a419e33a11
+  md5: c2242e8fd24003a74ddf37416661e06d
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188757
+  timestamp: 1698257668273
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py39hecd8cb5_1.tar.bz2
+  sha256: f2e6cb758673bf4662142c4aabd55b9282ad7e4bb57183145da178c88b7d2769
+  md5: 41f445e36b6b6722a9444508eef069f8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20583
+  timestamp: 1607365395045
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-0.58.0-py39hecd8cb5_4.tar.bz2
+  sha256: 413a872a33671284832b2261e0b54f2974fb65b6b9f9e80449cb51483ca8845e
+  md5: 409ee46ed24267b6da6fb32d13e1f21e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70730
+  timestamp: 1614804271285
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.41.2-py39hecd8cb5_0.tar.bz2
+  sha256: bcb39e5015db21509d797c9ffba67c6eff15f97783ae4f898801f9cd69837c82
+  md5: eb74e74d8e4fd533c55eb98b7b5e83bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102637
+  timestamp: 1695742077778
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py39hecd8cb5_1.tar.bz2
+  sha256: cb007615819fd240ea4e343835dfbda3c508a92b5b7158219d30a22d0e67b57c
+  md5: bf215e781ac81e0fc433eedee330c54b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49462
+  timestamp: 1675159191191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.2-h6c40b1e_0.tar.bz2
+  sha256: a727e09581e94d07e431fb5cb4ae21a741ffa957e5093c2a2d0cc9860c958643
+  md5: e243baa546432c8394a8059a44a5a3e4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 419227
+  timestamp: 1683113010463
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.4-h23ab428_0.tar.bz2
+  sha256: dcc28f346501e3d6bbeee265a3160b4dff4e0f37ed9fa5a743e30e91fa51c854
+  md5: fe4ac85ee86d3a94ea3a4ebea3779763
+  depends:
+  - libcxx >=10.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 321797
+  timestamp: 1616055526986
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.11.0-py39hecd8cb5_0.tar.bz2
+  sha256: 1e7fc9922f53b42460b6acd9bc4a38ab028bba442fcd9ee6037da1981e804360
+  md5: bc7073d9d4c0211cc4a1207c98fb765a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19091
+  timestamp: 1672387204865
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4dc903c_0.tar.bz2
+  sha256: 656a87c551a958f974ee409319b30ca29a205957ece617dbb21405b59bd66604
+  md5: 8e495591e369ac161857a72011c0a296
+  license: Zlib
+  license_family: Other
+  size: 120272
+  timestamp: 1666595024203
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_0.tar.bz2
+  sha256: efbbe6fdf136f73f17f2918810b53412bde1f203e979c8ada973d931ca47e1d4
+  md5: f1465fbd810b3746c6de6babfd4fe28a
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1023573
+  timestamp: 1681304595869
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-3.5.0-py39hca03da5_0.tar.bz2
+  sha256: a4b4024680fb60e12ec8c4bb8069461f96999ade6d2f082fb2beb3bc26484b4a
+  md5: cf55cb8d7031b30c70c56fc7c782b5c7
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 156104
+  timestamp: 1644482799136
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py39hca03da5_1001.tar.bz2
+  sha256: 855756b61b1b97c4e5a6f98695d4d61e20fe3265263acc61ae8fcd465a135d72
+  md5: 84fce327d9f0d594e86f565e5c21962e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 10183
+  timestamp: 1629146082730
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py39h1a28f6b_0.tar.bz2
+  sha256: 48c11abf9e8ebb8662f9f0f597c833675c392c064ce31f965248da291ee48d56
+  md5: 84b8b998a741b37abf5312c1c03696ef
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33979
+  timestamp: 1644845817952
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py39hca03da5_0.tar.bz2
+  sha256: b5f2b7ff9183402fed51a3ce3709915a62bafefad9b9c79f47646d9b4ef426f5
+  md5: 77b746931c8f31c3ae393ccb5819d43d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133628
+  timestamp: 1695717890677
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py39hca03da5_0.tar.bz2
+  sha256: 3ce1c2f370704ec8650f2cc3a911c4aebe7484f4e0263d7feecf9cc6b9295dc4
+  md5: 3df6e8ba34208dea068890e5d5318cc0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 206759
+  timestamp: 1681493095987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.3.0-py39h33ce5c2_0.tar.bz2
+  sha256: 8c31e7ede4b9a3ec6e1342f02bcff4d7113e5b25f12b91d108616a08eb8eb34f
+  md5: de3ce22af040eb01db773fcab23ef413
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5722206
+  timestamp: 1697490482051
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.5-py39heec5a64_0.tar.bz2
+  sha256: c884185ef2ea3fa8fd096a1560d522cd384052ac52efa2eef089510e96dfeb1c
+  md5: bb55f81435cb6e11d264242274fccd1a
+  depends:
+  - numpy >=1.19.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 115947
+  timestamp: 1657175645380
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 16c01b91abd74e592b26ca9143beae8bb1da1e2dd3f68efa8744b634a5b002b8
+  md5: f860193e14afc7ef3f5b990a2ac003d2
+  depends:
+  - brotli-bin 1.0.9 h1a28f6b_7
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18936
+  timestamp: 1659616204016
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: c79b34274531bedb3b46e7f23088f28bb1adb302e3dfafb0e4d2265c2363765d
+  md5: ad53130f3fd1f8d3c2fcbb7496e5585d
+  depends:
+  - libbrotlidec 1.0.9 h1a28f6b_7
+  - libbrotlienc 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 18715
+  timestamp: 1659616188888
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py39hc377ac9_7.tar.bz2
+  sha256: fab22e936c0eb27da21db8663d12d84c2a6005006bda21236ecd3615e69c9857
+  md5: 0982c046fb976e9f9fb19e7510187a18
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  size: 366983
+  timestamp: 1659616245272
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2023.08.22-hca03da5_0.tar.bz2
+  sha256: f299673a0f55432f93763f90b66f50f57595370db8269d921d825c8e0c17c812
+  md5: 31ac2f5596cb7a44adf073c930641c54
+  license: MPL-2.0
+  license_family: Other
+  size: 133817
+  timestamp: 1694009762858
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2023.7.22-py39hca03da5_0.tar.bz2
+  sha256: 613103fc4cae963cfbfce45dece3c3f828e75a8768858f6e0b00db37e57fd99c
+  md5: cf1f6c3c34a1e1b9ab22b04233d860f6
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159783
+  timestamp: 1690232303987
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.15.1-py39h80987f9_3.tar.bz2
+  sha256: 3d9ae6d354cf671a470940a8041c318da8c13be5ddfec8ea18b3b926cd6299b2
+  md5: 0eb268e38b5174d471a6e87d9d6102b1
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 225355
+  timestamp: 1670423312966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.0.1-py39hca03da5_0.tar.bz2
+  sha256: 8e9ccc31e507e308e02d242a8e10a2a23f5eddd089db05c724ce408e58df35a4
+  md5: e68c94666cd60221b575c3814c89bac0
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1946451
+  timestamp: 1668084573824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.1.2-py39hca03da5_0.tar.bz2
+  sha256: a4981dffa3f0eb65b42d567e2d50199a80ffb9e157066290f09a2f171fc80aff
+  md5: 1773ae2b080cdd55827e27673351551e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13646
+  timestamp: 1671231171682
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.0.5-py39h525c30c_0.tar.bz2
+  sha256: f86351143e43ebd6cc68c05cc36ceedd1c3cad64a1f110271509e977a3840650
+  md5: 53bfd99ad1b09164d537209cffd98161
+  depends:
+  - libcxx >=12.0.0
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 244040
+  timestamp: 1663827469853
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cryptography-41.0.3-py39hd4332d6_0.tar.bz2
+  sha256: d0d78c36d5fd799dee5d7daa96d125fe06a5b75efe380a70fc8641b89b894ceb
+  md5: b62455043c8eb2434466885b19fed2de
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1399573
+  timestamp: 1694211828228
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py39h313beb8_0.tar.bz2
+  sha256: dac771c99e91329d0c0da332305cab9bb34ff967f37ac3417943718c5dcc3f6f
+  md5: eb3cdc0fc210838b9271512a6a1b7c85
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 2067708
+  timestamp: 1690905319109
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py39hca03da5_0.tar.bz2
+  sha256: dcc7bf00bf0dec6e3d1f15d20a37609f010fa3a2780e453e704275edb46f0ab1
+  md5: f44b80b9405410e5bde6bfe0b31d5b3f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 15135
+  timestamp: 1650293774207
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/exceptiongroup-1.0.4-py39hca03da5_0.tar.bz2
+  sha256: aa7762baaa4717dcc69676772d484fe2c9df25363459284fbc76dedf6ad0e24b
+  md5: f87027ccce1361d0f82c0edf1a10d53b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27677
+  timestamp: 1668714367519
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/giflib-5.2.1-h80987f9_3.tar.bz2
+  sha256: 6aaf5f0995392ee23f8c840523733c1d5647f576c695914a209233d79d1e7449
+  md5: 1d0bd7e576c64c059ef781dd319ad82a
+  license: MIT
+  license_family: MIT
+  size: 77591
+  timestamp: 1676983230102
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.0-py39hca03da5_0.tar.bz2
+  sha256: 3e480af22e98246c056bbd91d6be5352df34ff2b8451d9c7f614baeafb450d39
+  md5: 695fe7ccaf6935d3117533d1e6737320
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4542265
+  timestamp: 1698866834303
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+  sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
+  md5: 69eb3b03765627b6159ed23cdde78396
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28399065
+  timestamp: 1692293207812
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.4-py39hca03da5_0.tar.bz2
+  sha256: 445762c3564bbec8a246b6115b8fcdc77bd3a40fe6b1398ecf8dc7865e832af8
+  md5: 83366cbd3beb073112f4644a613b6bca
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111933
+  timestamp: 1666125627512
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-6.0.0-py39hca03da5_0.tar.bz2
+  sha256: 6b46a3f39d41b5fc7ad81b7ced3f48124b9ef1650b3fa5ef7e5f8a93b3d91a5e
+  md5: 647c1a2f8460ffa8c670a1915bbdb494
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38790
+  timestamp: 1678997152549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib_resources-6.1.0-py39hca03da5_0.tar.bz2
+  sha256: 111b0b68eb7166f62d151f3efba930f91a85c6ece024fc3ba7e9b005781b992d
+  md5: 35e541905426c686ef2ff010a0e502fd
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51860
+  timestamp: 1698254731870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.25.0-py39h33ce5c2_0.tar.bz2
+  sha256: 3a3913e40c4d3376211bd56c1b91b6deb5b12249ccdbac67868c2f3ab0c854fb
+  md5: 187d7720aedf38759d122cccb4576f2c
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 219976
+  timestamp: 1691121991680
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.15.0-py39hca03da5_0.tar.bz2
+  sha256: 1745d4f5b994361ad207e9a08015c134752dc535a3630cbea82cb65aef427e7f
+  md5: e8e7f10741f9cfa737b310b334940441
+  depends:
+  - appnope
+  - backcall
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1255894
+  timestamp: 1694181494549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py39hca03da5_1.tar.bz2
+  sha256: e55e2db33b7c53946e6f5abae59a40f219ff406dcd9274f84533a9840c47b495
+  md5: ff209e75aee17af2e358b0008fbe8c88
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1022945
+  timestamp: 1644315931223
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.2-py39hca03da5_0.tar.bz2
+  sha256: 6237e7752bf55e5f0b52a8676ad317d2b88d920a615fa37d30e9fb0da88601c2
+  md5: d3e78ef296b3c74910d003bd10b475d6
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213972
+  timestamp: 1666908195870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
+  md5: 055e12390b844ea6c6e956ee08a618e8
+  license: IJG
+  license_family: Other
+  size: 273479
+  timestamp: 1677849171867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.17.3-py39hca03da5_0.tar.bz2
+  sha256: 8787a63d625e0771b8e20b69861fbf5c25c64b52bb51f7c1fa3a1226c0b73b50
+  md5: 783e2ad3d36472648c5ccc9f3051db3c
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 133077
+  timestamp: 1676558732505
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py39hca03da5_0.tar.bz2
+  sha256: feba85f7f24c5a57c29ed8a5edea873627e5eedde3810efeb815398fd581c7df
+  md5: 0677598f673f9729b5990316170a999d
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 197129
+  timestamp: 1676329661580
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py39hca03da5_0.tar.bz2
+  sha256: cee2cc791937b240be796561ae67e5a7c57b014826fa087fd75b02acf82135ba
+  md5: 141af9befcd79a876ded744de7d1fa8f
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 79928
+  timestamp: 1698937338528
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-1.23.4-py39hca03da5_0.tar.bz2
+  sha256: 7be718b3daa0b2bf6fe911cd17d73529229d372baa0b38935b441895b64c549c
+  md5: 637d0a4dd0e70dc716d4fce6d7d59cf8
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 401319
+  timestamp: 1671707682572
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py39h313beb8_0.tar.bz2
+  sha256: 50f7bd6c28018b17e2602d7551316a9bf413475e841c93866298a8180d75fe6e
+  md5: 247558a0aecf1ef7e77a4343761353d6
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64600
+  timestamp: 1672387273585
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 342a8269bcbdfde01a8a57b9ba0a73be31c836ac4d0e49ddc08ea38644f4f985
+  md5: a0f206782751dfffed0dd51302a1bf26
+  license: MIT
+  size: 68012
+  timestamp: 1659616138077
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 8acb80f58afe65b95fdeb7c16f34774dd1f3e8257d356e2990ffe4120e2311e1
+  md5: 4c6667cdd061d28e9bc4e4300e4d115e
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 31173
+  timestamp: 1659616155596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h1a28f6b_7.tar.bz2
+  sha256: 40377c6a2853452a918f9e0defb1c8214e558e7757f115195fc8cb63b473631a
+  md5: 637e9430e258ddf050623ef2360184d8
+  depends:
+  - libbrotlicommon 1.0.9 h1a28f6b_7
+  license: MIT
+  size: 298430
+  timestamp: 1659616172209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_0.tar.bz2
+  sha256: 4b755258de5901748d8eaca5e8ee051486ca1d52ca9c4cdb1082e0ea24118da7
+  md5: 55c615026c0869f8d3ba657f3bd38c43
+  license: MIT
+  license_family: MIT
+  size: 120389
+  timestamp: 1683716579036
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h1a28f6b_2.tar.bz2
+  sha256: b7c38fcc281d1be382884e7d9ec7cd4bd705b6c2e2f59401717415c9c8e20a79
+  md5: a41117710dafe569c9cc4e83f6f29fe3
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1411339
+  timestamp: 1650982753977
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-1.3.2-ha3663a8_0.tar.bz2
+  sha256: 776f64e220bb8f3391bd52630da244f9cc269d20feb4cf7eea5e14baeebbf37c
+  md5: 98d22e0124d55fae3c37c608dab1dcc9
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 89825
+  timestamp: 1694778225280
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.10.4-h0dcf63f_1.tar.bz2
+  sha256: c99bc270f21964410621fe61474dc192d8571799da33bc264cfd501f81eed8f1
+  md5: 0ba499df6755eae5d2d23aa4ab004553
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 642657
+  timestamp: 1692970217410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxslt-1.1.37-h80987f9_1.tar.bz2
+  sha256: f3ae0f05b7c2551232add880de33c8b1c4f78b6d56478cea6a0e2d5d403e961e
+  md5: c73101971e5ab6a8e8688239884eac81
+  depends:
+  - icu >=73.1,<74.0a0
+  - libxml2 >=2.10.4,<2.11.0a0
+  license: MIT
+  license_family: MIT
+  size: 241607
+  timestamp: 1692973585084
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py39hca03da5_0.tar.bz2
+  sha256: ac50f846e93e68d50bfdd5589ea8272b987243a64eba8e2e358ef311d7734001
+  md5: f19270ff954a41dabbfe36ff0656935b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 36040
+  timestamp: 1659783399073
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lxml-4.9.3-py39h50ffb84_0.tar.bz2
+  sha256: f65d34be7976518611b298735620ac960f302f65059c4d4c39a6bae1f87cc4b1
+  md5: 353dff9d5d996c2a260f66381b2ce3e8
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1470815
+  timestamp: 1695058433965
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_0.tar.bz2
+  sha256: 9fb7cb211eaefdbe8fb438440a60203da4b1174cae582b13fb0bd5fda68caf2f
+  md5: c99006da802a97c9aae30da8c16b4820
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176131
+  timestamp: 1670944706815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py39hca03da5_0.tar.bz2
+  sha256: e8a606d11d3cbfa2bd2cae849fd4709d4e361b42129d6008e00b095d5595f02e
+  md5: 60bd1e037cda86205526f77405d78129
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123361
+  timestamp: 1671541992772
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py39hca03da5_1.tar.bz2
+  sha256: 2fd690fa3c54a40f0426874ea12e12aad2718263a75708ddd1fa6052a4ad7fb3
+  md5: 81388724babfe9c32ea5cdd93633c342
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 107072
+  timestamp: 1684280007887
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.1-py39h1a28f6b_0.tar.bz2
+  sha256: ea26c75e4e8df3867948f7f5622e093352b653a51a8838c5acc13e2630cab32c
+  md5: 34dfd76da78de2eae95bbda390d746d6
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23092
+  timestamp: 1654598007056
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-3.8.0-py39hca03da5_0.tar.bz2
+  sha256: f6d7d0f791face4d911f5907df48e093cebcd1da188ba3d3267bf858d6dcacaf
+  md5: 6a55e97ce33cd40a280f538dd5437eff
+  depends:
+  - matplotlib-base >=3.8.0,<3.8.1.0a0
+  - python >=3.9,<3.10.0a0
+  - tornado >=5
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8725
+  timestamp: 1698692342704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.0-py39h46d7db6_0.tar.bz2
+  sha256: bf0eeef3c3c713515766ab8b0dc7863413de5b4b227deede97e24d90ca342345
+  md5: a7bba1857eb84fb50caea377e60d2050
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8066509
+  timestamp: 1698692266161
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py39hca03da5_0.tar.bz2
+  sha256: a90bf92dfef4a1a29f14d2268390fe54512f8c796355b7df5b5d35b7f9f92ccf
+  md5: eb79dabbeedee7da85dfbfb145bb8a26
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17342
+  timestamp: 1662014601345
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py39hca03da5_0.tar.bz2
+  sha256: f400ad75dd2890627dc948f3e2e6b19732d02c124723eaf22272026993a94d52
+  md5: 4a4ffc7365e30b18f4443281839e2718
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53505
+  timestamp: 1659721313693
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py39hca03da5_0.tar.bz2
+  sha256: 20fb26a7ac748ce288cf8483a837b0c33f1348ae738bcdb69cdc2763c7bbf7e1
+  md5: a0aebbc6c170ebd8d4710fd70b3db503
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19562
+  timestamp: 1659716131839
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-0.8.4-py39h1a28f6b_1000.tar.bz2
+  sha256: f69b05138e6dd0da424f49196b0f0c3dc81483c6f60c5eeb8ad4bf07ce816792
+  md5: 56db7bd3ff511cd839bda081523b3edd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 55683
+  timestamp: 1629356128780
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-0.5.5-py39hca03da5_0.tar.bz2
+  sha256: c8379ce4247d39b6ef1c75d6f93e6be8c4b15dc70cc9976cbca624cb25101850
+  md5: 176e0dcaeb28393881bacf69941e3889
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8289638
+  timestamp: 1681756329011
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py39hca03da5_0.tar.bz2
+  sha256: d34fcad560dcc7b8e7df2a0250be9694a02e072aa7f7d4992ebd427665575a8e
+  md5: 5972b5a5fbac5cea54ee0ff2cef85897
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100843
+  timestamp: 1698934268054
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-6.5.4-py39hca03da5_0.tar.bz2
+  sha256: fab416102da6016d0ba5435c9d2ae78a83e305a953ada122708aed252f0bb095
+  md5: 150ea9fadddf21993d3328d3e48a18b7
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 557688
+  timestamp: 1668450759059
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py39hca03da5_0.tar.bz2
+  sha256: 7c93fcdb583ac4079c96ee1c09f7891690bf1ae4a2746f1fd81b623ec1ccb319
+  md5: 37163b32508f9f589b3e6462a3a47546
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148426
+  timestamp: 1694616771736
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.5.6-py39hca03da5_0.tar.bz2
+  sha256: 33962997fdddf4d02fb3c8bfc79f6807af1d22f8f1b11043c52558a001350228
+  md5: 6cdf7cbc43bf40e92b056a5576bd0086
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14163
+  timestamp: 1672387216468
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.1-py39hca03da5_0.tar.bz2
+  sha256: 05a45d181b83b1eb136e35faf77bcd916adbdb49e178dd563da44f8227594956
+  md5: cdded8a3b2576bf9a2f103d396c47889
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2964776
+  timestamp: 1690562172192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py39hca03da5_1.tar.bz2
+  sha256: 4072996691ed61d7044ed10cbc580bb90fa982b5d63ef23144382c6fc99c5ca3
+  md5: 0f05853a139b6cda9c73e9d2707a4976
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 590288
+  timestamp: 1690984971741
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.2-py39hca03da5_0.tar.bz2
+  sha256: 86fd8395b7a91a2c1407a79362de718c7cfc64db0537d644bbc8fe956d28c162
+  md5: 7de782e4fb34bfa95ef2fc79d27d727d
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22840
+  timestamp: 1668160634885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py39hecc3335_0.tar.bz2
+  sha256: e86c77e58b56ab77835cfc621f615f88c2794188001fd1a2592a9f11d75ebb31
+  md5: 1a7b23113372c5667dbfe45976b9cc5c
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 126357
+  timestamp: 1696515322390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.0-py39h3b2db8e_0.tar.bz2
+  sha256: 3cd1161558704176560843586b1b1f9b257fd68c0ca53a2fc09e61267f47514c
+  md5: dd162b2716dc9daf732240a343862d4a
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.26.0 py39ha9811e2_0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10388
+  timestamp: 1695830584640
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.0-py39ha9811e2_0.tar.bz2
+  sha256: 5f35d8c0e1768fa3a9d2e75659cd2096bea6b4e021afea114f573e95f4943fb2
+  md5: 958f78b1e2299537996f98da7a930198
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - numpy 1.26.0 py39h3b2db8e_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6313331
+  timestamp: 1695830570878
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
+  md5: 371358a54bbdd307603888348d1a2c6f
+  depends:
+  - libcxx >=12.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD 2-Clause
+  size: 412248
+  timestamp: 1628861367714
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.11-h1a28f6b_2.tar.bz2
+  sha256: 23510e9db153d8119d80fb3e92af4f4a3736440e965c68e4ef29a4c1e186088f
+  md5: fa15d3b44ae1360ac9b640bbd5b6923c
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4746123
+  timestamp: 1695322833432
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.1-py39hca03da5_0.tar.bz2
+  sha256: 510f250b3f5fc77d63e02fc1a4c931068e5640b7c6163d44c532bca42ba72d77
+  md5: d73db95f07a282021efdf8bc09713261
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73620
+  timestamp: 1693575195999
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.1.1-py39h46d7db6_0.tar.bz2
+  sha256: 247b5e4d81b6d5d013a9c27e1f30c41fff896fed98a68ebda26b19b4062a6828
+  md5: 354a1d65300b4309d53dfa648014e8fe
+  depends:
+  - bottleneck >=1.3.4
+  - libcxx >=14.0.6
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  constrains:
+  - lxml >=4.8.0
+  - matplotlib-base >=3.6.1
+  - tabulate >=0.8.10
+  - pyqt >=5.15.6,<6
+  - openpyxl >=3.0.10
+  - s3fs >=2022.05.0
+  - pymysql >=1.0.2
+  - beautifulsoup4 >=4.11.1
+  - scipy >=1.8.1
+  - xlsxwriter >=3.0.3
+  - fastparquet >=0.8.1
+  - xlrd >=2.0.1
+  - blosc >=1.21.0
+  - zstandard >=0.17.0
+  - psycopg2 >=2.9.3
+  - pyarrow >=7.0.0
+  - pandas-gbq >=0.17.5
+  - pytables >=3.7.0
+  - sqlalchemy >=1.4.36
+  - odfpy>=1.4.1
+  - numba >=0.55.2
+  - jinja2 >=3.1.2
+  - pyreadstat >=1.1.5
+  - gcsfs >=2022.05.0
+  - qtpy >=2.2.0
+  - html5lib >=1.1
+  - xarray >=2022.03.0
+  - fsspec >=2022.05.0
+  - dataframe-api-compat >=0.1.7
+  - pyxlsb >=1.0.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13257999
+  timestamp: 1697478739906
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.3.1-py39hca03da5_0.tar.bz2
+  sha256: 90a1889cd0004bfc5e12ac94b4ea92718a473373033bb0ba5259804ed67bf2bc
+  md5: e89f615737385fee88150ab4adf037e6
+  depends:
+  - bleach
+  - bokeh >=3.2.0,<3.4
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.0.0,<3
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.17.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17147015
+  timestamp: 1698866800249
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.0.0-py39hca03da5_0.tar.bz2
+  sha256: 0ae09c974297767a707642344c40f484281f0a3000251a6234e46ef19f00c10e
+  md5: 64a0eaf3381e9f6aa971229501710798
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189313
+  timestamp: 1698263486159
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.0.1-py39h3b245a6_0.tar.bz2
+  sha256: 3a06355ba58d456b7dc46bae87b63d15257da1c2e1a157ca5972530c722178f8
+  md5: 6e01c592ae3b8ff2d12cae76f2f4276b
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libcxx >=14.0.6
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 715239
+  timestamp: 1696580071596
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-23.3-py39hca03da5_0.tar.bz2
+  sha256: d1d96643acdb1e9c0295f9d8470a63705d7a2f919218e7d05e87281fd0332d4a
+  md5: 9fb8f460c130d56caf33c6bbe46fbe8a
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2678841
+  timestamp: 1697548790931
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py39hca03da5_0.tar.bz2
+  sha256: 942cd41d561bb1d5ac7ff9b18e22e0d5153d12c340266ed8d8f9e00bbdcc89cb
+  md5: 390b8c3cd74281abecdbfd51476922f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 33033
+  timestamp: 1692205747301
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py39hca03da5_0.tar.bz2
+  sha256: aacdd5156fcf109f949a284d28be879dded6ef994dd0c2fbb9dd44637e027a4d
+  md5: 7896828fb3565fefad43f980d50c8723
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91190
+  timestamp: 1659455206354
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.36-py39hca03da5_0.tar.bz2
+  sha256: 801bdb59391fb4bcde8eec8ab6d3267a7ff13440edd4d600dc7a0c8e09cda97a
+  md5: d934c74eb66d01af0f45f0881f4bab77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 580588
+  timestamp: 1672387390426
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py39h1a28f6b_0.tar.bz2
+  sha256: d522bb13d07c916addfa928dcd83b2b65534b672d839bbdd3a9b5ebeeba5dbf9
+  md5: 9858166e5ffb624c8b9d281f4000d725
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 367167
+  timestamp: 1656431368885
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py39hca03da5_0.tar.bz2
+  sha256: a708e29728d4b9822a5cf2bf225da27f8fd358ea0f00b498cb6eb6cf4ccab465
+  md5: 4d2b45c6be8221e6a3e44c2d5838426f
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30843
+  timestamp: 1675441531640
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py39hca03da5_1.tar.bz2
+  sha256: 3475411b79ab74ffdcd97bdbcb9c36061dcd358740f6de2e89e53f6912e32cb5
+  md5: 02521df4e2e79f75faa9cbb3560ab1dd
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1861763
+  timestamp: 1684280026169
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyopenssl-23.2.0-py39hca03da5_0.tar.bz2
+  sha256: efae9d8f90857e4b3ab6ff4322bf90decf966a029a052b72798565b7c03c8906
+  md5: bdebe59bffc7adbad83fdcd9d429a5f5
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 95234
+  timestamp: 1690223494699
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py39hca03da5_0.tar.bz2
+  sha256: 20b0c23a186d4d1b905b5e0b56cbff4d5621061f2901a2c729a96c97e2448016
+  md5: d716e5c9b5eec45ce1df8eb52cab817a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157408
+  timestamp: 1661452601692
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyrsistent-0.18.0-py39h1a28f6b_0.tar.bz2
+  sha256: 57637b44cd3e7797b3d1f6be6f711b6e87414bb8128b6eef63a45a1460c53389
+  md5: 1907629863ed8e7c35ead232dae7693f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 91636
+  timestamp: 1628941083263
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py39hca03da5_0.tar.bz2
+  sha256: fe49f23b73c0ed64dd828c4e9e67a9b33998fc2511a796dfcf6fe2b13e67376a
+  md5: 847b9bddf2a86e1609c0d53bbc23ea79
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 27378
+  timestamp: 1626781391140
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.9.18-hb885b13_0.tar.bz2
+  sha256: 7e4a3c7a7f0122e72e84463bdab49abcb05ac5750fb2fd12ad5c5d036309633b
+  md5: 18aa18bd0d260605923877921d26cc74
+  depends:
+  - libcxx >=14.0.6
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.10,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 13194025
+  timestamp: 1694438901368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py39hca03da5_0.tar.bz2
+  sha256: 49a84cb62b495d84e713baa271fbed4360e9fc069597f4d112356e18e4720c6c
+  md5: 45642a99c83e7aed74d1ffab1f20145b
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 266647
+  timestamp: 1661368655993
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2023.3.post1-py39hca03da5_0.tar.bz2
+  sha256: 6f7289856ff0e2fd52dd539a7d585c756bfb350bcd32d5d809872a7e7dc7395f
+  md5: fec748525144049a2fc7f52f9755232c
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 257235
+  timestamp: 1695131702047
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-2.3.0-py39hca03da5_0.tar.bz2
+  sha256: 960192a143672e9c1d6fe4027af448512d91eee7501e5c245c21b865cf8bf429
+  md5: 76d491244218505f071ba56a308673df
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40950
+  timestamp: 1685030774581
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py39h80987f9_0.tar.bz2
+  sha256: b5e84d32c49ceac7c24e27dcc8c9a6dd6bb5606f2ccab70e96d5848265615cf0
+  md5: 3445d25415998c807efbe64d3a7e03c8
+  depends:
+  - python >=3.9,<3.10.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 167068
+  timestamp: 1698096118071
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-23.2.0-py39hc377ac9_0.tar.bz2
+  sha256: 752438e90623e3193fd589c821e09284adbe8ab0e13560d00c366cf7173262c4
+  md5: e6e92da28e9b0e428ed4b7df417bec25
+  depends:
+  - libcxx >=12.0.0
+  - python >=3.9,<3.10.0a0
+  - zeromq >=4.3.4,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 472418
+  timestamp: 1657724315435
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py39hca03da5_0.tar.bz2
+  sha256: 170608200d9e70e5887f4e1514a3de574731388eec171c98904381ff0a1137e1
+  md5: dba22515f36d3c266de5896350813ea2
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 95103
+  timestamp: 1690400315537
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.11.3-py39h20cbe94_0.tar.bz2
+  sha256: c35449c0ca64d0d6a23c019b6eba188f546e42379857cbc4240bbdddee1159d3
+  md5: 61cb82346e21710f3e0645096cda4e12
+  depends:
+  - blas * openblas
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.21.5,<1.28
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22859180
+  timestamp: 1696543469561
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-68.0.0-py39hca03da5_0.tar.bz2
+  sha256: 0d7e78ef025140d4dc24f759a9a6b7613886ad6951c314ad05162ccd2d2c59e9
+  md5: 3cd7eb43e285faba76faf67667e26b00
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1093916
+  timestamp: 1690290951258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.2.0-py39hca03da5_1.tar.bz2
+  sha256: ceb4d0e599808b596b99dcad41582b0fc42eb14bfa5115958aff6b5fa85468cf
+  md5: c5e9aef0d6895de1c927e9d796cd7cd3
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15691
+  timestamp: 1629145910454
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py39hca03da5_0.tar.bz2
+  sha256: 9aaae5db2174accb4bf38f2318e83253c578c186edaf46d4f8803faba8ba229b
+  md5: 0f7c229e774146ffc4e29dedf75372bf
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67279
+  timestamp: 1696347632563
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.41.2-h80987f9_0.tar.bz2
+  sha256: 51ff668c345919a3009ce15728f1778c9ef7ec7b62755782557a315ea3ddb787
+  md5: 2302a79a045f152e183a52a81adfba62
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1674163
+  timestamp: 1681394762218
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py39hca03da5_0.tar.bz2
+  sha256: 84390122622a8e362e89a63761715a1d534da76380a80cf2a76fedc92bae2bc6
+  md5: 4ae67163d55cf9df83d4027ebc38c501
+  depends:
+  - ptyprocess
+  - python >=3.9,<3.10.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30894
+  timestamp: 1671751931536
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py39hca03da5_0.tar.bz2
+  sha256: 2c258fe508e59073ac904a5b13594323dd681eadd9779123bb7e6f667d283281
+  md5: dbb5c0cddb6661a89afee647fd3dc01e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39875
+  timestamp: 1668168874870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.12-hb8d0fd4_0.tar.bz2
+  sha256: 8e6803c22b8d4ee598a62dfec76f3d750a9d5c46a007f500736e01879c083f85
+  md5: 667e60c8b407d73cbba40f44901f4f00
+  depends:
+  - zlib >=1.2.12,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3412693
+  timestamp: 1654088929697
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py39h80987f9_0.tar.bz2
+  sha256: fda5f95dd023e4df722dd5ad0c27c4aaa6dd66d75325aa11fa7b068cf0be47b1
+  md5: 884f788a5f6a664c9b79f7a4a60362d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 680561
+  timestamp: 1696937004165
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.65.0-py39h86d0a89_0.tar.bz2
+  sha256: 4ba846205cb1ee04298dfa4dfda856543ab3206fcdb1803df0820b5a29daa552
+  md5: 639a4f489af172c866c18442948e5874
+  depends:
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - ipywidgets >=6
+  - slack-sdk
+  - requests
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 125170
+  timestamp: 1679561942932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py39hca03da5_0.tar.bz2
+  sha256: aa0f7d72209aace43b716f0d37648ebcf12ac803bd35f4f2a746bbc77ec31d52
+  md5: e5b90eba83fddba6d7aa6072b5bf7c91
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193017
+  timestamp: 1671143921826
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 1b72d760904617794789fc6acc406b0b560ca5a586f1e67e69e85ae5d1f2cfe6
+  md5: 644ef8830437070f60efcfcd6a987198
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9670
+  timestamp: 1690297532002
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.7.1-py39hca03da5_0.tar.bz2
+  sha256: 8c6a81b7a82278ed11ac68aad9cec2431d28a01638d4d4be72054ff9abbe7488
+  md5: a902a833bb186a2f1a4b2b89b1195136
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 58466
+  timestamp: 1690297524418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py39hca03da5_0.tar.bz2
+  sha256: 536045a8a172c651fd306c285a6d7409775f018dac944f2124c538ccfb195e28
+  md5: d4dc6cdf0812191b9ec78b35b4fdf3e0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11593
+  timestamp: 1659769477205
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-1.26.18-py39hca03da5_0.tar.bz2
+  sha256: 3a9491b6749e61fc534ec4470b1b0656da0e0187759bf67ed11cc38e8ccb8e71
+  md5: f3f1d2c1028dad2f11ff950a15c99dbf
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188640
+  timestamp: 1698257577209
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py39hca03da5_1.tar.bz2
+  sha256: 1a052bc9f2289815f1c3bad81b739f99b97a2ed7a947537e478f5d6454694441
+  md5: ea7e83bcae1f0a39cb61f94f5a45d4e4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 20091
+  timestamp: 1629144441130
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-0.58.0-py39hca03da5_4.tar.bz2
+  sha256: dc37ef100b4ce1627bcd127d14c80428d5a8726f96b2041624da76c6e8fcd695
+  md5: 3089c63bf8f4d0423e1a287da286d83e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 70923
+  timestamp: 1629357115820
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.41.2-py39hca03da5_0.tar.bz2
+  sha256: 4d36ec6d9b8407353ccaa687951453e5af5d6b4e8e5eb52ccfdb9af2c4707850
+  md5: 5886b30b312445471268444f41f39dc7
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 102583
+  timestamp: 1695741976083
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py39hca03da5_1.tar.bz2
+  sha256: 105e39d3eb51b47c7244b3379c0133ab7051966664f52835453b14509215b159
+  md5: ed20012c2cd99ffd04cca9929e0bc061
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49775
+  timestamp: 1675159079039
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.2-h80987f9_0.tar.bz2
+  sha256: 3da79de8313250d87f9a69481c38a268f713ca94eb2e112a2384e29c9af7a7e6
+  md5: 2e75ad6a09c308268192efe03cc9ebf4
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 411778
+  timestamp: 1683113019715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.4-hc377ac9_0.tar.bz2
+  sha256: f0995c4ecbd6745dc44b99060587c3d924b9a17c97e9c67d0ae63370f3b3ed8b
+  md5: 30f666bf97c26587c5d2f68cc5f330ab
+  depends:
+  - libcxx >=12.0.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: LGPL-3.0-or-later
+  size: 316901
+  timestamp: 1629287855861
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.11.0-py39hca03da5_0.tar.bz2
+  sha256: 24c42da59e4fb45be7af343be3e33e5140d74cdd26204733bf48514e2fee94ab
+  md5: 584e591d36dcd5ba5c45404f0f7ebb2d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19076
+  timestamp: 1672387153578
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h5a0b063_0.tar.bz2
+  sha256: 6b8e4581c1ac4fcfc47d4fc6d00732f9cf373144fcaa7262c402ce55fbdae7fd
+  md5: 467ae28215d1aa1c5688bc0c8a184269
+  license: Zlib
+  license_family: Other
+  size: 103525
+  timestamp: 1666595022664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_0.tar.bz2
+  sha256: 3160f549baffb2773187928eb946b2b73d12934730900bbee7fca6f7c2fc97a0
+  md5: 7cfbed15f1feee1422810f7830075f53
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 779464
+  timestamp: 1681304594848
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-3.5.0-py39haa95532_0.tar.bz2
+  sha256: c4735331dbd77ac45438dc20031a8b9fb05e7612246d25bad7f2f2c08cab411f
+  md5: ed14f9bc6e55220483f1a5a388625a08
+  depends:
+  - idna >=2.8
+  - python >=3.9,<3.10.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.16
+  license: MIT
+  license_family: MIT
+  size: 162772
+  timestamp: 1644481986085
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py39h2bbff1b_0.tar.bz2
+  sha256: 1d39f23ab38411cf291c2d718aa256a4133398ffb23cbf26a3ad7ffac9245d04
+  md5: 60c8bfaea0d0ebe28c09f538a0f9f72a
+  depends:
+  - cffi >=1.0.1
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 39253
+  timestamp: 1644551767970
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py39haa95532_0.tar.bz2
+  sha256: 47a81644d0c76a1864c1dacd11a11d897ea8a49975dc9d5543d69e0c613269ef
+  md5: b24d13c443a26f65a0778b475a5726bc
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 132830
+  timestamp: 1695717959996
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py39haa95532_0.tar.bz2
+  sha256: 0712b18411e07e140d2293f0659f13d5048ab54488e569bfa40d3f3a40ef15fd
+  md5: 302c3c0696e17eaa62e140e3892644ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 199723
+  timestamp: 1681493196911
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.3.0-py39h9909e9c_0.tar.bz2
+  sha256: 812f268862208c2518b5187809a8571adb488de3604d512721035e65458dde76
+  md5: 97ce620b7dd3ee743d0ca28ed66ace74
+  depends:
+  - contourpy >=1
+  - jinja2 >=2.9
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml >=3.10
+  - tornado >=5.1
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5721832
+  timestamp: 1697491241383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.5-py39h080aedc_0.tar.bz2
+  sha256: 10dcfa166cde7a14a278f530a354ac46856655bf81b164b16861d9cc1875e912
+  md5: bf930260f679bc74227bbb18bc36ae82
+  depends:
+  - numpy >=1.16.6,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 119700
+  timestamp: 1657176150595
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 46e865df3b8a31694e7320b6104ba08792aa6356341411b20b17af8626ebd8b0
+  md5: 507dfe693ef429f466d964b599f4af21
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_7
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 18650
+  timestamp: 1659616328001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 5207157f89190f508db6acd4b6dfe5d3b97a91ed68393c83f56f54f331e38a44
+  md5: d0bf43e8df60baae3b3105aa5c42a791
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_7
+  - libbrotlienc 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 21153
+  timestamp: 1659616312367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py39hd77b12b_7.tar.bz2
+  sha256: 8a71f463d4fe0f005920ee8b00e5c6649b3fc22b9dd66bebaf4db6ecc1ac75fa
+  md5: 7bd24bf94c24e810aecaaf84a0978e6f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 343204
+  timestamp: 1659616543542
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2023.08.22-haa95532_0.tar.bz2
+  sha256: ae754ea5cae6c6d8cb65f67faab445c1a58dc696ed31b769d1bc5cb5e65ad9c1
+  md5: 092b417c11edcbe6bb9b765ab4a55d23
+  license: MPL-2.0
+  license_family: Other
+  size: 164999
+  timestamp: 1694009822357
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2023.7.22-py39haa95532_0.tar.bz2
+  sha256: d89da74a8d67e0fe3c7a15f65569bac16ab05142b3be051f4ab8e3b664d50edc
+  md5: 708a750d370b9d6875651021e21c4446
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 159322
+  timestamp: 1690232335307
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.15.1-py39h2bbff1b_3.tar.bz2
+  sha256: af4f03c361f114297d13d171748f3b7ef58bfd622b25759cd92bb651ea608e16
+  md5: c35736da3ea26782425e78061268cf5e
+  depends:
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 228713
+  timestamp: 1670423312743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py39haa95532_0.tar.bz2
+  sha256: 87e89c03e67e00aa759fae3ee3da12ac3fbb83ddad004fe81120a6deec97e2a5
+  md5: 457a4339a53c033d48ce0c72e5038d2e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30330
+  timestamp: 1672387265402
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.0.1-py39haa95532_0.tar.bz2
+  sha256: ded97214c6d09f4fa9899bdc27b3a1023f98656ce34e652f7a91490e86592ff6
+  md5: 59ec65fd9e06b81a65cc12986c67d5da
+  depends:
+  - pyct >=0.4.4
+  - python >=3.9,<3.10.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 1939614
+  timestamp: 1668084794027
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.1.2-py39haa95532_0.tar.bz2
+  sha256: eb9b4a3d169ff629d40f1c54566585ff09d0f56aab96c59ebcbdc657b504f7e5
+  md5: 3489c1a2b73fc957b5a62cc59349e25b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13438
+  timestamp: 1671231196438
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.0.5-py39h59b6b97_0.tar.bz2
+  sha256: 494544436a5fcac339208dcbe2a8532f7112ac089c2e457f6dfc052884499ba7
+  md5: 3492b96083c1e904cc32d26ea7f1e1d8
+  depends:
+  - numpy >=1.16,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184280
+  timestamp: 1663827558327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cryptography-41.0.3-py39h89fc84f_0.tar.bz2
+  sha256: e971c2e7b015f0276aba71db06ea6795f619c49b8728239d17a0d206329b980b
+  md5: f46d904bc6f220327e70474971341f52
+  depends:
+  - cffi >=1.12
+  - openssl >=3.0.10,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - pyopenssl >=23.0.0
+  license: (BSD-3-Clause OR Apache-2.0) AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1220835
+  timestamp: 1694445639066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py39hd77b12b_0.tar.bz2
+  sha256: e0763376e71916df4c0f317fa0278b05bd647fa151d4a1eda51b012c867430ec
+  md5: 2ff4fb509788b0e47ac684ba151394d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3289966
+  timestamp: 1690907040646
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py39haa95532_0.tar.bz2
+  sha256: 584ac94bc8141d9566cbc190604c5affdbd5362e280ebaa56dc59aa48f2f83b0
+  md5: 0f166c3e70541d8bee6e9d0cb60fb66e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT License
+  license_family: MIT
+  size: 16979
+  timestamp: 1649926678161
+- conda: https://repo.anaconda.com/pkgs/main/win-64/exceptiongroup-1.0.4-py39haa95532_0.tar.bz2
+  sha256: 2cc43763881cd76fa18de2cf8446fd70255dc6fa2afdfdcef01964cb62a4f5ce
+  md5: ea93d413944ca6a8677eb1b284b136ae
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27388
+  timestamp: 1668714577678
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/giflib-5.2.1-h8cc25b3_3.tar.bz2
+  sha256: 2965ee2f3b9e6ed1dedf75982672d2598f11b8eb336547ae184d9f5882a7c9f1
+  md5: 9f167d3e45441bc3633c1974b1b0ce8c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 88421
+  timestamp: 1676983264486
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.0-py39haa95532_0.tar.bz2
+  sha256: fa8f868e49721ca19912f816a6da221172758f9e3d28d8b31d53249fb14dc25f
+  md5: 09f9a2cea9425d76dccf9b026afe5bb2
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4576915
+  timestamp: 1698866895838
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+  sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
+  md5: 582d2c1135a89da757a038de831e7f39
+  license: Intel proprietary
+  size: 11086648
+  timestamp: 1664812389803
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icu-73.1-h6c2663c_0.tar.bz2
+  sha256: 945f4521793d7d279532d1ccd5157201c5cbf64f846bfe60249d01e1b4edf295
+  md5: 0accae23d095c165ac731f4a1f3ca497
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 37021132
+  timestamp: 1692294548916
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.4-py39haa95532_0.tar.bz2
+  sha256: 49d7860665b41fc4c304e3ffd813436ea9adfcd4df67eba2bd14843a2f5d82b4
+  md5: 30fdefd1541c789c163751291a8faa88
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111448
+  timestamp: 1666125667599
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-6.0.0-py39haa95532_0.tar.bz2
+  sha256: 868ef1d23c681e39253a6be586ac25f12c7fe0f5a057b583069f7b5d8ef78e1b
+  md5: a10f07c7a3510272a296f9fed458a4ed
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38098
+  timestamp: 1678997241511
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib_resources-6.1.0-py39haa95532_0.tar.bz2
+  sha256: 6e0dc76dac7919e6b2be05ad7b1b2f35ca1cf05b6ab2c9af2707fc1102767320
+  md5: fad9cf2023d807da8d44996e9d4399a0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - zipp >=3.1.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51490
+  timestamp: 1698254721864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46319.tar.bz2
+  sha256: cae1893b8ba0235653ad1f8069f90264194d06c11ac04162e7e6705a5037c111
+  md5: 9834848bd7c7759acf12e78d09388563
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3891030
+  timestamp: 1681801474383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.25.0-py39h9909e9c_0.tar.bz2
+  sha256: 6f499f0dd64a5cb1cf2aa73528424ae4bc0b6fde4f491381cc751fdeebe0076e
+  md5: 1285c8c628bc912c54d0968574c9f4c9
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=20
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 217232
+  timestamp: 1691122695748
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.15.0-py39haa95532_0.tar.bz2
+  sha256: d06b9e1d7946f0b993db05709592d3d4fa157f710bf1a0988ee869f36a0bfd1a
+  md5: 53ea4c3fe6462b0ecd526eaa71bb43d5
+  depends:
+  - backcall
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >3.0.30,<3.1.0,!=3.0.37
+  - pygments >=2.4.0
+  - python >=3.9,<3.10.0a0
+  - stack_data
+  - traitlets >=5
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1279433
+  timestamp: 1694181820978
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py39haa95532_1.tar.bz2
+  sha256: b57ffe58b8f25011aa76997387ab5f70e93744bdce660f2f3fb97e4fc5a83c7e
+  md5: f5fcce35d3f21cdfc5893c5a7a86c651
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1035394
+  timestamp: 1644315567034
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.2-py39haa95532_0.tar.bz2
+  sha256: ac614f76ad829b11df46da5aabaac341e8e4969c8c0d5dc7c532ad0d4ba88f13
+  md5: f67fe3337528e2886f1ac3ab8ac37985
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 213110
+  timestamp: 1666908350218
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
+  md5: 81f2c343dc4c65eea39c45383272068f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 407861
+  timestamp: 1677849239400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.17.3-py39haa95532_0.tar.bz2
+  sha256: 702ca74d18d82646dcc6e8abaa3850f04ecb156bb191b092777def5f196fb731
+  md5: bd9526d38a145fe311a8aa36bc11e071
+  depends:
+  - attrs >=17.4.0
+  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 152006
+  timestamp: 1676558783570
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py39haa95532_0.tar.bz2
+  sha256: eab501d361da478e406e454b7883d6d5bb6f947e8ab473c67515e83af084e061
+  md5: a00e6a62956fde3c4135464353ee8a53
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229158
+  timestamp: 1676330909084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py39haa95532_0.tar.bz2
+  sha256: e840d6b322faa7d5fee2c54ed6074e3a6b7fe38a9356020a4027d9e09c40a1a1
+  md5: 038bb985c0d43bf77a8e772f4c4ad22a
+  depends:
+  - platformdirs >=2.5
+  - python >=3.9,<3.10.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 103854
+  timestamp: 1698937448209
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-1.23.4-py39haa95532_0.tar.bz2
+  sha256: b2884608a7bdfcf00434a276a587a0adc76d32712ec43f6bd3d15914ad3dc395
+  md5: 5efa1332f7c0a8d9638eda02170c4ce5
+  depends:
+  - anyio >=3.1.0,<4
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.7.0
+  - nbconvert >=6.4.4
+  - nbformat >=5.2.0
+  - packaging
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pywinpty
+  - pyzmq >=17
+  - send2trash
+  - terminado >=0.8.3
+  - tornado >=6.1.0
+  - traitlets >=5.1
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 413653
+  timestamp: 1671707957673
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py39hd77b12b_0.tar.bz2
+  sha256: 836acb55fe4fbe0a706ce65fad035b96680948acea3c7f5b7a2266cd3dd574a2
+  md5: 891fe66a24d8714737b2874985ee1303
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62298
+  timestamp: 1672388166096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/krb5-1.20.1-h5b6d351_0.tar.bz2
+  sha256: ef6b0347ae565dd648a2bb40bc8b0b30f2e4f8387778fefced1d581b7d5a3e16
+  md5: 8ef1d5919aa55fe56ef34d9a7969dca7
+  depends:
+  - openssl 3.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 861982
+  timestamp: 1684424430941
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: a45ea688d6a869a39d38a74c7cc6f0c7619dd46faa0fa4df4421a97dff1f3019
+  md5: c345f51706eef530454f66b794e5e574
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 68189
+  timestamp: 1659616216976
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 87850562db1079e88e56aab880d43bea9cf80c2646da4607b6bc19c6f740b179
+  md5: a7400cfb72042977bc047909ed504ce8
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 33743
+  timestamp: 1659616248209
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_7.tar.bz2
+  sha256: 24e0c7d46dce8cdd1e51e566bb03183915ebc8a8cffb22bf7dfad9e03aca322e
+  md5: 6307f6854754ab5bd7c84e6998385bb1
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 733177
+  timestamp: 1659616279453
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang-14.0.6-default_hb5a9fac_1.tar.bz2
+  sha256: bb17beae8860a83d081d57273825b46bf8fe9903f3b4182ab41a7ae2c7274859
+  md5: 94182f4ab8beb4eddfd8167b2e2b0380
+  depends:
+  - libclang13 14.0.6 default_h8e68704_1
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 147804
+  timestamp: 1681225547009
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libclang13-14.0.6-default_h8e68704_1.tar.bz2
+  sha256: 01b84a38c9069e7b8e6fa2a07707e785df7d40b8f01d76a504e98e5a5cd58539
+  md5: 22c9f7e59174c49f06e3c5c9384401ce
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 25699299
+  timestamp: 1681225463612
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libiconv-1.16-h2bbff1b_2.tar.bz2
+  sha256: 0d7bbecd06847ffbfd1fd0a9cbb7bc631cb6be192f9ce9f9d9d6f66838405a83
+  md5: b812bc5d9c76242e2bb2ac87afe7d39b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 730280
+  timestamp: 1650983734373
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpq-12.15-h906ac69_1.tar.bz2
+  sha256: a36ea5c77075e90f47d3f5c1e2081c0c1c78c5c0a5135bf9a6448fca67bbc79d
+  md5: a0a02817a7def0563d1635035c26451b
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - openssl >=3.0.8,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  size: 3827890
+  timestamp: 1687382140999
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-1.3.2-hbc33d0d_0.tar.bz2
+  sha256: 892eeac94c67c547fcbf8920a9f9c1565bccca12f1f37a3258a019011d31f799
+  md5: ba9418df9288a2f031a02fa35b774ce0
+  depends:
+  - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - libwebp-base 1.3.2.*
+  - libwebp-base >=1.3.2,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78524
+  timestamp: 1694778314659
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxml2-2.10.4-h0ad7f3c_1.tar.bz2
+  sha256: 97ae143eb7325d9c289f2804aef9d47f20be7358854d2a04d0943aff19a7f692
+  md5: 6ece7f1a3248169837714d05d7f6ef0a
+  depends:
+  - libiconv >=1.16,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 3513910
+  timestamp: 1692971505729
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libxslt-1.1.37-h2bbff1b_1.tar.bz2
+  sha256: 2a09e93a9446b5c97fec5d15481201c3db81acc9f88362ca541eaf87e4b9190d
+  md5: bd7ec244935e83e850a4ff34e8e2e64f
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 513971
+  timestamp: 1692973657152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py39haa95532_0.tar.bz2
+  sha256: e1c0e745d9ba36a80773e841d96bf514ad1ceda419e4188aad3c22782af00234
+  md5: f226532e9bb308f20e874c56be6ceefb
+  depends:
+  - python >=3.9,<3.10.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 35788
+  timestamp: 1659783414586
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lxml-4.9.3-py39h09808a7_0.tar.bz2
+  sha256: 5e806fbfbb4f6d24c54bcbf18db1ac8c99398fa0e2dc90eaa2b535b5307a0e79
+  md5: fb7881e74b59262df0fa4ec981964efc
+  depends:
+  - libxml2 >=2.10.4,<2.11.0a0
+  - libxslt >=1.1.37,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause and GPL-2.0-only and ZPL-2.0 and LicenseRef-ElementTree
+  license_family: Other
+  size: 1244887
+  timestamp: 1695058550693
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_0.tar.bz2
+  sha256: f8cf680d5cbbeb1d73e0d4deef8c00127c69f625c3441d857fbe56948a30dcc6
+  md5: 6970c7f46b0164cad1d210e7a1419959
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143434
+  timestamp: 1670944902624
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py39haa95532_0.tar.bz2
+  sha256: cfd1081e47c02f044da097b4d7646fea1d0adc28341113d963edf6a92c14fe9c
+  md5: 1015298551c040c6d5e26eebbae12ef5
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 142316
+  timestamp: 1671542240512
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py39haa95532_1.tar.bz2
+  sha256: ab5c246c2b271acc1cdd0b9343989c0166681536e569cdbe71618f55d34c7292
+  md5: 7ce68d771cd94c9ff5efefe69d327c9a
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 125122
+  timestamp: 1684280210213
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.1-py39h2bbff1b_0.tar.bz2
+  sha256: 3573157bc9271afe38aab4d3e2fcf3c745756bfe6020f66b5685a02b2ec6e713
+  md5: 466da740fafef3d6bce114220f0be306
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28510
+  timestamp: 1654508162239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-3.8.0-py39haa95532_0.tar.bz2
+  sha256: 3ee1e0b89c9a16ed21af80d9883d7638227028cac76ab24b5dcb4aa25dcd5536
+  md5: 0ec5d4cee9f74324b4bf0a653e53681b
+  depends:
+  - matplotlib-base >=3.8.0,<3.8.1.0a0
+  - pyqt >=5
+  - python >=3.9,<3.10.0a0
+  - tornado >=5
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8485
+  timestamp: 1698692858409
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.0-py39h4ed8f06_0.tar.bz2
+  sha256: 1687ae122ee7d8b583141fc5014b76d494841dc8083b854449e3d6e0f6bb7019
+  md5: 3697ac26ee3c2d49338dd5b9c6551152
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - importlib_resources >=3.2.0
+  - kiwisolver >=1.0.1
+  - numpy >=1.21.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=6.2.0
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 8080067
+  timestamp: 1698692812610
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py39haa95532_0.tar.bz2
+  sha256: 85fe20a86996a078398b9e0348e6c68aafc233af06b89fa9e632f3c62d874e59
+  md5: a9fa43e694b25cd49b8b08a9eefd696e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18054
+  timestamp: 1661915903969
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py39haa95532_0.tar.bz2
+  sha256: 8aa14047fac6ef8b326900c4bf1a960eaa7a1699c18fdf1e75a59101b610b6df
+  md5: 7e1d4d4700fbea6171d30f1d5ad24226
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 53362
+  timestamp: 1659721308586
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py39haa95532_0.tar.bz2
+  sha256: 2017814a7cc93dd51c6b7c016e3cdf8fbc32fa20f985638aaff6a6377e9ee086
+  md5: a1a285c56b001c3b5c591bf21eec3149
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 19326
+  timestamp: 1659716205153
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-0.8.4-py39h2bbff1b_1000.tar.bz2
+  sha256: 9f82f5b75ba6de389453ea2ed67a7fe80b07962119c0ca7ead3c5e574649151e
+  md5: 248c468abced874f0231d3cc23177c77
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 58488
+  timestamp: 1607359497934
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46357.tar.bz2
+  sha256: dbbe88906e263dcb79c38c10477ac83d8ef8a3a4645fc6c56ea524ddb2adbf17
+  md5: 5e763c995ff0c549f68a10bce70fede4
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187489950
+  timestamp: 1691503804820
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py39h2bbff1b_1.tar.bz2
+  sha256: 6dddd7e13832a8a91b6c1b8ab8bfb446ee62bebfab661aad4de5c52ba62aa25d
+  md5: dd0c2ece6a743c373c9b5a5919b4818f
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49744
+  timestamp: 1682975040154
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py39h2bbff1b_0.tar.bz2
+  sha256: 637897894d98eff959bebf605eab283a7e224fab836725f41e8016a956081433
+  md5: 57cea8df7ab85f2a98f64d23afcb1f90
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 184956
+  timestamp: 1695058491736
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py39h59b6b97_0.tar.bz2
+  sha256: e1ec087b63a20aee9bb57e06c51abe8049a60b1f43d0cdd99cdbf7dea963fd78
+  md5: 8769cdd201d905069800488fe31574e5
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 256221
+  timestamp: 1695060152521
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-0.5.5-py39haa95532_0.tar.bz2
+  sha256: e2e362930800d5441580b0109dd1de43873aea655908e8d4affc11f2e95ef59c
+  md5: d9781492332e6326f9fca87f3a8efacd
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.1.0
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8135792
+  timestamp: 1681756491399
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py39haa95532_0.tar.bz2
+  sha256: 49715dd545469a4458cdf0d0d55c9a7af7cb7a2da8a6504a60dd3089714015ae
+  md5: 4257087772bed974078f56673ca50d99
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.9,<3.10.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119351
+  timestamp: 1698934436390
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-6.5.4-py39haa95532_0.tar.bz2
+  sha256: 6c127332e060b4cbfeed79af965a99f80894994cf4cb38886be907dc4ce47e34
+  md5: f1d8ce412e115986c403f223b3b47d0f
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - lxml
+  - markupsafe >=2.0
+  - mistune >=0.8.1,<2
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.9,<3.10.0a0
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - pyppeteer >=1,<1.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 596314
+  timestamp: 1668451106600
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py39haa95532_0.tar.bz2
+  sha256: 2b62132891ac9fb1a556e3624892ecebf3d281218dbce32f0784ba0e238eca33
+  md5: f96bbef0985d7e66ebf00c0d55e30e23
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.9,<3.10.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 167045
+  timestamp: 1694617078743
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.5.6-py39haa95532_0.tar.bz2
+  sha256: 1d7ba454910413aece7b2de276c5017dbbecd0c0d2cc5a57de38840d0e67d324
+  md5: 6e6ba64c8dc5025aeac606404a8df36a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13786
+  timestamp: 1672387480065
+- conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.1-py39haa95532_0.tar.bz2
+  sha256: 55847705e1cb4c384a61611e15a0beb52d745b30e0fced2d9a3daa877b3d712f
+  md5: 5082bfa6e6400284e8e3833a7874b789
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2928272
+  timestamp: 1690562181595
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py39haa95532_1.tar.bz2
+  sha256: 5c17c23b931f8b88189de64c8fc92d42f144e51ad20d376952c4bc77613be8ac
+  md5: 4a7a3286484766741f627696697c362c
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.9,<3.10.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 609425
+  timestamp: 1690985686105
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.2-py39haa95532_0.tar.bz2
+  sha256: 59552c619118f9b09fe5def7cbb43952edcd32caffa35420d7e7bf2e34651eef
+  md5: 4269a1f93882205b90d4b2ae78fc82d5
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22417
+  timestamp: 1668160717305
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py39h2cd9be0_0.tar.bz2
+  sha256: 8e499b5cc522168ad517865ab98cb3b3019446aec79c0f1ef3895359aff4c9ca
+  md5: a18a576b7024cfd6f905c526a786a916
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 135285
+  timestamp: 1696515698492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.0-py39h055cbcc_0.tar.bz2
+  sha256: e5e11f9b42d770ee46ac24d1cdf7aa4e9c49a60a607c8c28e7729131a99eadd5
+  md5: 4274d06db8a9a381c072d226d0322dc0
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.0 py39h65a83cf_0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9835
+  timestamp: 1695830845329
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.0-py39h65a83cf_0.tar.bz2
+  sha256: dcaa1607ce40a0ed610dd5398e125c8e5b08e738e50b6037a8c72b49ca561ff2
+  md5: d99d990a60644b97ba1ff9bb8da0e66f
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.26.0 py39h055cbcc_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6778113
+  timestamp: 1695830816710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
+  md5: ab07e2a27ac08afe3d0b4c0890b8486a
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 2-Clause
+  size: 249316
+  timestamp: 1630094024143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.11-h2bbff1b_2.tar.bz2
+  sha256: d6bcab0ffa3ef14739cf07adb3e1ef18dcbf99de399ea49fdc6f505a1565927e
+  md5: 73b17037d87b5a58feb34dafc0538f7f
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8058396
+  timestamp: 1695324589828
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.1-py39haa95532_0.tar.bz2
+  sha256: 96374fdbcb0495a50c72e01f55fa6a0a991e78704da0c62fa2dd5548d76ba25b
+  md5: df1d746ba8d5d6ba01ac1373b9b71e1a
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 73016
+  timestamp: 1693575484990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.1.1-py39h4ed8f06_0.tar.bz2
+  sha256: 1994e5831fd421bd6cf85916073d4012dec53e673b672b3985efaf771f0a7bf8
+  md5: c486a5b51e3227f6ea564a9dd3125e45
+  depends:
+  - bottleneck >=1.3.4
+  - numexpr >=2.8.0
+  - numpy >=1.21.5,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.1
+  - pytz >=2020.1
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - openpyxl >=3.0.10
+  - jinja2 >=3.1.2
+  - qtpy >=2.2.0
+  - numba >=0.55.2
+  - pyreadstat >=1.1.5
+  - zstandard >=0.17.0
+  - xlrd >=2.0.1
+  - tabulate >=0.8.10
+  - fsspec >=2022.05.0
+  - pyqt >=5.15.6,<6
+  - xarray >=2022.03.0
+  - xlsxwriter >=3.0.3
+  - beautifulsoup4 >=4.11.1
+  - html5lib >=1.1
+  - fastparquet >=0.8.1
+  - pyarrow >=7.0.0
+  - pyxlsb >=1.0.9
+  - matplotlib-base >=3.6.1
+  - odfpy>=1.4.1
+  - pytables >=3.7.0
+  - sqlalchemy >=1.4.36
+  - psycopg2 >=2.9.3
+  - blosc >=1.21.0
+  - lxml >=4.8.0
+  - pymysql >=1.0.2
+  - gcsfs >=2022.05.0
+  - pandas-gbq >=0.17.5
+  - dataframe-api-compat >=0.1.7
+  - s3fs >=2022.05.0
+  - scipy >=1.8.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12629931
+  timestamp: 1697479885371
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.3.1-py39haa95532_0.tar.bz2
+  sha256: 270e4c3ab0f0c8d8f31fa0e45bc516c1e41be618a5c66e1c86dc39ce76cb2372
+  md5: cad52ba9eb391416112f0994b6c35249
+  depends:
+  - bleach
+  - bokeh >=3.2.0,<3.4
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.0.0,<3
+  - python >=3.9,<3.10.0a0
+  - pyviz_comms >=0.7.4
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.17.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17162886
+  timestamp: 1698867967809
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.0.0-py39haa95532_0.tar.bz2
+  sha256: 56eaf7f4b1bb81e3deed55711dd2ee78f244a3cc0ad4bb7a1f09d97e46f9793f
+  md5: c24a3daed1e85ba7a100fa6966c5bb48
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189021
+  timestamp: 1698263520538
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.0.1-py39h045eedc_0.tar.bz2
+  sha256: 11f7165aed535d482fa3e5b5dc9d116adae5ca01b3a3e15197af88bca833f5fc
+  md5: 427c1450bebb632f43bbc8c83006e4cd
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp >=1.3.2,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND
+  license_family: Other
+  size: 806931
+  timestamp: 1696580240310
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-23.3-py39haa95532_0.tar.bz2
+  sha256: e6193767920746be9970d4fa091638a83e27595c8da2d3a189ce54b7ef70c2eb
+  md5: 21790cd3e2b8a45c4104aff0a68330d0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3001751
+  timestamp: 1697549357662
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py39haa95532_0.tar.bz2
+  sha256: 003d13e980cbb3ff50f136d0e19e6933366b59a048e4581f92ca139bc2c39efd
+  md5: 56f44a1054da2d10777e375838191070
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 32355
+  timestamp: 1692205784293
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ply-3.11-py39haa95532_0.tar.bz2
+  sha256: bbcef9bbf4ccd051becaa7d8aa88cb5f46ff64570cc395b6a471332d8b900e11
+  md5: 0daf62b71923d157544576122b0fa79d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-clause
+  license_family: BSD
+  size: 82560
+  timestamp: 1607021261834
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py39haa95532_0.tar.bz2
+  sha256: 289ad56bbd7d80dfdce577654f3750cd58ea0310e3088cf39b13bcb577b9b0c3
+  md5: 8a35ad65651086575ce55371f22feda8
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 91045
+  timestamp: 1659455316472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.36-py39haa95532_0.tar.bz2
+  sha256: 5225e8d80aa62a2c764ca8943d7a799ddc9896a80434f7ec02e1bc799a746b74
+  md5: 186eb95f816a2eff80c3c7f7d964c7b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.36
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 578514
+  timestamp: 1672388155359
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py39h2bbff1b_0.tar.bz2
+  sha256: 2ac7d64c8a0876fa99897e8543cd192537a94c9fafc605e3c31fe893984f15b8
+  md5: 47b6cbe6ce9289e47d16900b03596a91
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372807
+  timestamp: 1656431445633
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py39haa95532_0.tar.bz2
+  sha256: 2c4ad837ea236465adbd03a534d14fcc61cb1b00c7cb02fd21e0a4f1d84bf8d5
+  md5: 07165c444adc7c7ccc8a345875adc5ef
+  depends:
+  - param >=1.7.0
+  - python >=3.9,<3.10.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48408
+  timestamp: 1675450623287
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py39haa95532_1.tar.bz2
+  sha256: 5db80d4c8d37d6bac184d6b4a8f698eeec3e25324f50b0f6d81006a8c076020c
+  md5: d58e76a31e2f6e7410ba4afd7f385b0d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1877445
+  timestamp: 1684280183367
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyopenssl-23.2.0-py39haa95532_0.tar.bz2
+  sha256: 7789733bfc3d3ddccbd8b0ecab103544a4934d0ab775792c963387ac614e72e2
+  md5: 0e5b0fe7debbf558ce97090f6b67cdae
+  depends:
+  - cryptography >=38.0.0,<42,!=40.0.0,!=40.0.1
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94633
+  timestamp: 1690225630423
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py39haa95532_0.tar.bz2
+  sha256: 10fc0695db96dc0a68ad9fda22a9e896bc2f4b0c66fd5d4ce60d7865585fef39
+  md5: 0fde797653e4ab589506121fb1e37555
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 157119
+  timestamp: 1661452591647
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt-5.15.10-py39hd77b12b_0.tar.bz2
+  sha256: e70028d0250602c01feac17e60fafd371daee5d731917732b7eced4ab47b3243
+  md5: 72a51c0d49711d22a39aefc04fa0c328
+  depends:
+  - pyqt5-sip 12.13.0 py39h2bbff1b_0
+  - python >=3.9,<3.10.0a0
+  - qt-main 5.15.*
+  - qt-main >=5.15.2,<5.16.0a0
+  - sip >=6.7.12,<6.8.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 5007361
+  timestamp: 1698781683371
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyqt5-sip-12.13.0-py39h2bbff1b_0.tar.bz2
+  sha256: 6eb0c4f2e8acaa6dfaf1fb5b4b34f13d366ebf11d77e14a674a26d7fabbc7981
+  md5: 9354d98a97abd4715cdf63d4a28f7645
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 84071
+  timestamp: 1698769559444
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyrsistent-0.18.0-py39h196d8e1_0.tar.bz2
+  sha256: 4d1122bff4fad0e77ae4031cc51344bd98f7d6b101d29b92a43fa1c04ba22826
+  md5: bb79af9a1ef5aef4be0e5f7e22b5eea4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 92679
+  timestamp: 1636093365041
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py39haa95532_0.tar.bz2
+  sha256: 2a4dc2b1e89cda887094dafb3359a5c468585902f6a8b8f030e9647bc3eac65f
+  md5: f870859d4dc7a8d82cf3546bd9035f33
+  depends:
+  - python >=3.9,<3.10.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 54520
+  timestamp: 1605307564142
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.9.18-h1aa4202_0.tar.bz2
+  sha256: fb0d4afd031b8997fa5ade56cd2a1e4bfea765c092a10ea01d4135b1449a8915
+  md5: 46a5dc5f79f6de6eb5ecfa895e1cc840
+  depends:
+  - openssl >=3.0.10,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 21172845
+  timestamp: 1694442462066
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py39haa95532_0.tar.bz2
+  sha256: 8690b9aaf0457ae170e1cac0bfd338d088e9b35ee4e82913ab44f53867d80fb0
+  md5: 9d99075052265ae3d718582d3b875038
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269964
+  timestamp: 1661376543480
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2023.3.post1-py39haa95532_0.tar.bz2
+  sha256: b539d27de9c6b90ed2b535a94c8109cc33e8b085e6dcc2c451b4f0e8d52f5cc4
+  md5: fa9074d94236c9b768bfd2c858875b27
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 264836
+  timestamp: 1695131770282
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-2.3.0-py39haa95532_0.tar.bz2
+  sha256: 97243a31c39f4990c0e9d4f2307f2f7fb9421553303923bc105067ec4340bdff
+  md5: 8078c5760f27398eaf1082226647d137
+  depends:
+  - param
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40145
+  timestamp: 1685031143383
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py39h2bbff1b_0.tar.bz2
+  sha256: f1903495af81ef6d4b81ce6dd96302bca95db2d10e463f0ecfca9591010ad68e
+  md5: 3d2841085778006c2e79f9c7300f8b9d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13565975
+  timestamp: 1669937633869
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py39h5da7b33_0.tar.bz2
+  sha256: fc65ceebc52b6886c5824acd24a70f24c7fd0fe6f0a302928f07f0d41c5b3037
+  md5: 54a4bc0724041dd173088419d6ede2af
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 239062
+  timestamp: 1677611495106
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py39h2bbff1b_0.tar.bz2
+  sha256: 5e4420df4f9aef61acc18aff9bc6c10add9c5bb42ee723de074706ca77615573
+  md5: f39f84115e228bad4bceaefdd637f022
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 158558
+  timestamp: 1698096358091
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-23.2.0-py39hd77b12b_0.tar.bz2
+  sha256: d0aa8d2f6029f6c55e2b65a8c7580f64fb1e4ab323160264b10d2ac4f9c22f8e
+  md5: df398a3a1668fd2a22061764e20ea91d
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.4,<4.3.5.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: BSD
+  size: 460913
+  timestamp: 1657616061604
+- conda: https://repo.anaconda.com/pkgs/main/win-64/qt-main-5.15.2-h19c9488_10.tar.bz2
+  sha256: 409f9fad42cbae8d915d1703d87db6af9f951b150517daa4e1c0220cc5eb7b0f
+  md5: 2b17abf94b02a6c5ba6b7623dba97ff9
+  depends:
+  - icu >=73.1,<74.0a0
+  - jpeg >=9e,<10a
+  - krb5 >=1.20.1,<1.21.0a0
+  - libclang >=14.0.6,<15.0a0
+  - libclang13 >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=12.15,<13.0a0
+  - openssl >=3.0.10,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  constrains:
+  - qt >=5.15.2,<6
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 69829482
+  timestamp: 1693228189080
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py39haa95532_0.tar.bz2
+  sha256: 86e7fb5c7f60b943eb9fa38edfc489130a9e286600b78029509716f8a2fa7755
+  md5: 38db77ece9dc76feffb9ef7638e38258
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9,<3.10.0a0
+  - urllib3 >=1.21.1,<2
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6, !=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 94397
+  timestamp: 1690400496655
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.11.3-py39h309d312_0.tar.bz2
+  sha256: 3a9a680173f731d515e0587d5b74583cc986b5c1ff62f4cf9e4f7ec268cbb62a
+  md5: 3387bf809e3d32dde3f5cbc3ef49bf47
+  depends:
+  - blas 1.0 mkl
+  - icc_rt >=2022.1.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21.5,<1.28
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22779707
+  timestamp: 1696550432358
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-68.0.0-py39haa95532_0.tar.bz2
+  sha256: a23bb2149caa59bb455b60ea0ec851eedaff4d57dd369215b303e9bb3de81df5
+  md5: 3e284ae6b48ee30c364ffdc5601610b0
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 1099842
+  timestamp: 1690291374842
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sip-6.7.12-py39hd77b12b_0.tar.bz2
+  sha256: ed2b75ca1bb075901550bf892aa18a46a563e512e28ad5fe1b36e7ed3c6708d0
+  md5: 22779fae19f454e13656af8b737f8bd3
+  depends:
+  - packaging
+  - ply
+  - python >=3.9,<3.10.0a0
+  - setuptools
+  - tomli
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-SIP_License OR GPL-2.0-or-later OR GPL-3.0-or-later
+  license_family: GPL
+  size: 602624
+  timestamp: 1698676202396
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.2.0-py39haa95532_1.tar.bz2
+  sha256: 8d646483c7490dddc96e6add533bc7cd61c00aa3df9785d7c4a23a55cae4e0b8
+  md5: 993b3886b334bd1f49d34206f21997b4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 15998
+  timestamp: 1614030572433
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py39haa95532_0.tar.bz2
+  sha256: a6ad7d179909edc66e5646f646f0d8c3ec86a0679135dfc858df3b9cfaf39c06
+  md5: 7ac9604ad7564ac0c71bff5db198656f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 67012
+  timestamp: 1696347795139
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.41.2-h2bbff1b_0.tar.bz2
+  sha256: 2050ce6672c53b888dd58dda0a3f76b0cf8573577540fd86427a904ea0158352
+  md5: 32f95c4ef7dfbf22fd35292ff8bd51a5
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1311308
+  timestamp: 1681402905668
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py39haa95532_0.tar.bz2
+  sha256: dde349e4212d3fedc2573c5086f2843f43bac1d6b138cae3a5bfa84cd45ab046
+  md5: 28b9869d8d3a839918fac4a08f38cbc2
+  depends:
+  - python >=3.9,<3.10.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30546
+  timestamp: 1671752127904
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py39haa95532_0.tar.bz2
+  sha256: d55050c77a8c3b005b47e38525085a29a5e9843158846bd48749232de7a208e1
+  md5: 694bfc0ab6a0a4614eb4ceb111bc29d4
+  depends:
+  - python >=3.9,<3.10.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39590
+  timestamp: 1668168880994
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.12-h2bbff1b_0.tar.bz2
+  sha256: 95e7b0ac7780147defd47242ef2e28b31719a8e40c077db2b302dd951335feca
+  md5: 52cdcdb96383c010ca833a7c24b3935b
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Tcl/Tk
+  license_family: BSD
+  size: 3690152
+  timestamp: 1654036853710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tomli-2.0.1-py39haa95532_0.tar.bz2
+  sha256: 86a1b449d27205327a5de0f81d18d9ad768e68d915b91b1d5b82be2d8f524e94
+  md5: 78a8a9f8c638df9a2db80964c97ff43f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 25476
+  timestamp: 1657175730463
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py39h2bbff1b_0.tar.bz2
+  sha256: 1528da271520b8a50a71e36b3374e7709649d5ca64745e46eae6550ff8229afd
+  md5: 0e054ab29119cf4c1f778613acf972f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 681780
+  timestamp: 1696937326924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.65.0-py39hd4e2768_0.tar.bz2
+  sha256: 156fae007e611a622751b7c683b85feee11d178c36581493bab5dcf2e7bc8f91
+  md5: b6ad839ebba536ad1c3cc58d0e2123f0
+  depends:
+  - colorama
+  - python >=3.9,<3.10.0a0
+  constrains:
+  - slack-sdk
+  - requests
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 143681
+  timestamp: 1679562248929
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py39haa95532_0.tar.bz2
+  sha256: acd4a18da3a3ad0b440f2548be813e1a090a086448fa962a43009b8c8dbc47da
+  md5: fe78de10019085146f1cc6c94fdc2620
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 192822
+  timestamp: 1671143999327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: b2458f6a550ad81fbd57cf12218dbd757cdd5c7548b4ccbac377c9f15e1baf80
+  md5: ca5fc3fbdb09b6de068a8b7a8869369f
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions 4.7.1 py39haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9208
+  timestamp: 1690298120549
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.7.1-py39haa95532_0.tar.bz2
+  sha256: 9a85899de7761e864d29f96b8a6be34b71935dd1521d4464ef840928105b66d9
+  md5: a86e87a10e5fdff486265e0c675fb99f
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 57922
+  timestamp: 1690298106990
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py39haa95532_0.tar.bz2
+  sha256: 8057d3d2a0acd44496de33c5b222063c3f7d06b90c74fbbda45bd18b0b324219
+  md5: 398f8db5bd8cab84b3d85a9d85fa4889
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 11362
+  timestamp: 1659769459206
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-1.26.18-py39haa95532_0.tar.bz2
+  sha256: 29fcb6f8ca17fe5c5962a87ee0717b7c2afd9683685859cd49499886f7d6fa62
+  md5: 0d31859e0a097aedbcc1627db33b3d92
+  depends:
+  - brotli-python >=1.0.9
+  - certifi
+  - cryptography >=1.3.4
+  - idna >=2.0.0
+  - pyopenssl >=0.14
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 188367
+  timestamp: 1698257883295
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h21ff451_1.tar.bz2
+  sha256: dd86ecdc7a11af2624841b0670b7de722078e050f2a91bcd4bdc3df1871f45b1
+  md5: 45ef24c486a484f079faf1dc90e4c7e9
+  depends:
+  - vs2015_runtime >=14.27.29016
+  license: Modified BSD License (3-clause)
+  license_family: BSD
+  size: 8277
+  timestamp: 1605602889180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.27.29016-h5e58377_2.tar.bz2
+  sha256: cf1dbd738c479b1fd6668629a3fe4485b4935a1cd01951f92a4e741e8b6a9501
+  md5: 4daaceb6cfc1af6274509081d8018ef1
+  size: 2316783
+  timestamp: 1605602872095
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py39haa95532_1.tar.bz2
+  sha256: a984ed63e13d22cf08e50a94c98cd25442616363eb3c78fcefcf141da2a248a0
+  md5: 916c16904615c7af3b5d37cb6694f45e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 21084
+  timestamp: 1607347371925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-0.58.0-py39haa95532_4.tar.bz2
+  sha256: 96b1acfbff69fbdffa849a81f95cdd59da75b0221c483055e014c7e6e71222cd
+  md5: da69e6987fcc757e83a358ceaa13f62b
+  depends:
+  - python >=3.9,<3.10.0a0
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73391
+  timestamp: 1614804425587
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.41.2-py39haa95532_0.tar.bz2
+  sha256: 0d2e96a5461ab172628e3507c27396e0672264658941a80fbbd5ea777ed5b73e
+  md5: 23b9f4634b2e5450be617114f62c74f9
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 120873
+  timestamp: 1695742300539
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py39haa95532_0.tar.bz2
+  sha256: 216ba3dafee051e051acd6a967c2d7f3b68037f4b4b0f0beefcf715652b34eab
+  md5: 120f0b088290fc17bd6618fc10a2f0c4
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: PUBLIC-DOMAIN
+  size: 34293
+  timestamp: 1605306211299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py39haa95532_1.tar.bz2
+  sha256: a5d2a216d052105fdaad7256f23da3b29f95100d1dc0f29b6ab1f3bbc75e17a9
+  md5: a558f681ebc243f86cde2515c065b62e
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48805
+  timestamp: 1675159123654
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.2-h8cc25b3_0.tar.bz2
+  sha256: 8adf016ebb7f919b8056aca7e36c3b79aac4361d75cbc40d00826fd0daf012e7
+  md5: c3f7871e9a33adeccee1b1e8e216918e
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license_family: GPL2
+  size: 1332571
+  timestamp: 1683113347814
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.4-hd77b12b_0.tar.bz2
+  sha256: fd8e6a0fcf36c191c5c2bb6cc0bd9dde7ad98cb1d936062a923e75d99c793114
+  md5: 1ab55f8c4b5292ec360c572120bf823e
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-3.0-or-later
+  size: 9430705
+  timestamp: 1616055773485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.11.0-py39haa95532_0.tar.bz2
+  sha256: b0d39e1373f052c6428566566870622e5bfe9721b445e6baee4322637b50328b
+  md5: 6875e0bf3828707dc9165d694c0d0a7d
+  depends:
+  - python >=3.9,<3.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 18725
+  timestamp: 1672387612937
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_0.tar.bz2
+  sha256: 174b1b82719c185e17104b504ca50d322a28e996b20fd547de0d2f2ce39f1fd9
+  md5: 05f29aa81cd3a3b38ebaccfa5a0d0e17
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 148931
+  timestamp: 1666595229032
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_0.tar.bz2
+  sha256: 1d736c895c8de273f101b72180436b1c0376238fa8706315b2684db5975166b5
+  md5: 8d6a1e767775fe0eb617cd6e22edc2ff
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1871867
+  timestamp: 1681304638261

--- a/sri_model/pixi.toml
+++ b/sri_model/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "sri_model"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/sri_model/pixi.toml
+++ b/sri_model/pixi.toml
@@ -1,0 +1,35 @@
+[workspace]
+name = "sri_model"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2015-01-01"
+maintainers = ["philippjfr"]
+categories = ["Other Sciences"]
+labels = ["holoviews", "bokeh", "matplotlib", "param", "networkx"]
+description = "Agent based modelling in epidemiology using HoloViews"
+no_data_ingestion = true
+
+[dependencies]
+python = "3.9.*"
+notebook = "*"
+scipy = "*"
+holoviews = "*"
+matplotlib = "*"
+networkx = "*"
+numpy = "*"
+pandas = "*"
+param = "*"
+pip = "*"
+setuptools = "*"
+wheel = "*"
+
+[target.osx-64.dependencies]
+libgfortran = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks]
+notebook = "jupyter notebook sri_model.ipynb"

--- a/sri_model/pixi.toml
+++ b/sri_model/pixi.toml
@@ -21,15 +21,15 @@ networkx = "*"
 numpy = "*"
 pandas = "*"
 param = "*"
-pip = "*"
-setuptools = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+setuptools = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks]
 notebook = "jupyter notebook sri_model.ipynb"

--- a/streaming_timeseries/pixi.lock
+++ b/streaming_timeseries/pixi.lock
@@ -1,0 +1,6682 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/nodefaults/
+    indexes:
+    - https://pypi.org/simple
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311h9ecbd09_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hfdbb021_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.3-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.1-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.9-py311hfdbb021_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.55.1-py311h2dc5d0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.12.1-nompi_py311hb639ac4_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_h2d575fe_107.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.7-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.6.3-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hf672d98_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-hc4654cb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py311h2dc5d0c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.3-py311h2b939e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mne-lsl-1.8.0-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.3-py311h71ddf71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py311h7db5c69_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.0.0-py311h49e9ac3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.5.1-h0054346_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.6.1-py311h0f98d5a_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.11-h9e4cc4f_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py311h7deb3e3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.22.3-py311h9e33e62_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py311he9a78e4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.47.0-h9eae976_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.2-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py311hbc35293_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.10.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lazy_loader-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mne-base-1.8.0-pyh694c41f_200.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhff2d567_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyqtgraph-0.13.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/qtpy-2.4.2-pyhdecd6ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - pypi: https://files.pythonhosted.org/packages/07/51/e0f59b86f93e31d5c813dffbc31cf65b512a427849438189f3be8a156394/tsdownsample-0.1.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/20/8a/767a70e04e4532c05f2b60dc817672e5bfec4911ca6655e8943eadf80670/h5io-0.2.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/c7/56f50f023e19b0abd3ac93b86d64afdb58a16cca197441be9201bae367b7/pymatreader-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/45/fc303eb433e8a2a271739c98e953728422fa61a3c1f36077a49e395c972e/xmltodict-0.14.2-py2.py3-none-any.whl
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.10.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lazy_loader-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mne-base-1.8.0-pyh694c41f_200.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhff2d567_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyqtgraph-0.13.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/qtpy-2.4.2-pyhdecd6ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h3336109_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hd89902b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.3-hf13058a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.8.30-h8857fd0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.1-py311h137bacd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.1-py311h4e34fa0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.9-py311hc356e98_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.55.1-py311ha3cf9ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.12.1-nompi_py311h82f1de1_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.3-nompi_h1607680_107.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.7-py311hf2f7c97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-25_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-25_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.10.1-h58e7537_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.5-hf95d169_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.22-h00291cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.4-h240833e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-25_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.6.3-hd471939_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.64.0-hc7306c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_hbf64a52_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.44-h4b8f8c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.0-h2f8c449_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-h3dc7d44_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-hf4bdac2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.5-ha54dae1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.2-py311ha3cf9ac_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.3-py311h19a4563_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/mne-lsl-1.8.0-py311h4e34fa0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.1.3-py311h14ed71f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hd471939_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.3-py311haeb46be_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.0.0-py311h1f68098_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.5.1-h5273da6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.0-py311h1314207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.3.2-py311hfbc4093_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.3.2-py311hfbc4093_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.6.1-py311h50e4d0a_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.11-h9ccd52b_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311h3336109_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.2.0-py311h4d3da15_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.22.3-py311h3b9c2be_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.1-py311hed734c1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.47.0-h6285a30_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.2-py311h4d7f069_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-15.1.0-py311h1314207_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h00291cd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h7130eaa_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py311hdf6fcd6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
+      - pypi: https://files.pythonhosted.org/packages/1d/d4/9189084a953dbb83deceb1c43f4b834986b4137f0d83059e8cb049012d74/tsdownsample-0.1.3-cp311-cp311-macosx_10_12_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/20/8a/767a70e04e4532c05f2b60dc817672e5bfec4911ca6655e8943eadf80670/h5io-0.2.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/c7/56f50f023e19b0abd3ac93b86d64afdb58a16cca197441be9201bae367b7/pymatreader-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/45/fc303eb433e8a2a271739c98e953728422fa61a3c1f36077a49e395c972e/xmltodict-0.14.2-py2.py3-none-any.whl
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.10.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lazy_loader-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mne-base-1.8.0-pyh694c41f_200.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhff2d567_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyqtgraph-0.13.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/qtpy-2.4.2-pyhdecd6ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311h460d6c5_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311h3f08180_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.3-h5505292_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py311h3a79f62_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.1-py311h210dab8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.9-py311h155a34a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.55.1-py311h4921393_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.12.1-nompi_py311h0fa3d65_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.3-nompi_ha698983_107.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py311h267d04e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.7-py311h2c37856_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-25_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-25_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.10.1-h13a7ad3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.5-ha82da77_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.22-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-25_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.6.3-h39f12f2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.47.0-hbaaea75_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h9cc3647_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-ha962b0a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.5-hdb05f8b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py311h4921393_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.9.3-py311h031da69_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mne-lsl-1.8.0-py311h210dab8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.3-py311h649a571_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h39f12f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py311h9cb3ce9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.0.0-py311h3894ae9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.5.1-h1318a7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py311hae2e1ce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.3.2-py311hab620ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.3.2-py311hab620ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.6.1-py311hb4b81e0_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.11-hc22306f_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h460d6c5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.0-py311h730b646_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.22.3-py311h3ff9189_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.1-py311hf1db568_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.47.0-hcd14bea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.2-py311h917b07b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-15.1.0-py311hae2e1ce_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-hc1bb282_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py311ha60cc69_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+      - pypi: https://files.pythonhosted.org/packages/20/8a/767a70e04e4532c05f2b60dc817672e5bfec4911ca6655e8943eadf80670/h5io-0.2.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/50/53/20e415e48ebd7fb7f39b369dd25734b82eae7217ff58bbf49b2a0c677743/tsdownsample-0.1.3-cp311-cp311-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/c7/56f50f023e19b0abd3ac93b86d64afdb58a16cca197441be9201bae367b7/pymatreader-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/45/fc303eb433e8a2a271739c98e953728422fa61a3c1f36077a49e395c972e/xmltodict-0.14.2-py2.py3-none-any.whl
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.11-py311hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.10.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh5737063_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lazy_loader-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mne-base-1.8.0-pyh694c41f_200.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhff2d567_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyqtgraph-0.13.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/qtpy-2.4.2-pyhdecd6ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311he736701_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311hda3d55a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.1-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.9-py311hda3d55a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.55.1-py311h5082efb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.12.1-nompi_py311h67016bb_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_hd5d9e70_107.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.7-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.22-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.4-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-14.2.0-h1383e82_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-14.2.0-h1383e82_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.2-default_ha69328c_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.6.3-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.0-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-he619c9f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hdefb170_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.5-he286e8c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py311h5082efb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.3-py311h8f1b1e4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mne-lsl-1.8.0-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.3-py311h35ffc71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.4.0-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py311hcf9f919_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.0.0-py311h4fbf6a9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.5.1-h4f671f6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.6.1-py311h90dcb63_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.11-h3f84c4b_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-307-py311hda3d55a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.14-py311hda3d55a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.2.0-py311h484c95c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.22.3-py311h533ab2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py311hf16d85f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.47.0-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-h62715c5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.2-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-15.1.0-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34433-he29a5d6_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hdffcdeb_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-h0e40799_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.5-h0e40799_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py311h53056dc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+      - pypi: https://files.pythonhosted.org/packages/20/8a/767a70e04e4532c05f2b60dc817672e5bfec4911ca6655e8943eadf80670/h5io-0.2.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/66/ac/58ab1f1c86422cea13df0bf62dc0beb3d96f2c7831a4adcd49278df1f9fe/tsdownsample-0.1.3-cp311-none-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/c7/56f50f023e19b0abd3ac93b86d64afdb58a16cca197441be9201bae367b7/pymatreader-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/45/fc303eb433e8a2a271739c98e953728422fa61a3c1f36077a49e395c972e/xmltodict-0.14.2-py2.py3-none-any.whl
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  license: None
+  size: 2562
+  timestamp: 1578324546067
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23621
+  timestamp: 1650670423406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311h9ecbd09_5.conda
+  sha256: d1af1fbcb698c2e07b0d1d2b98384dd6021fa55c8bcb920e3652e0b0c393881b
+  md5: 18143eab7fcd6662c604b85850f0db1e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.0.1
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 35025
+  timestamp: 1725356735679
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_2.conda
+  sha256: fcb0b5b28ba7492093e54f3184435144e074dfceab27ac8e6a9457e736565b0b
+  md5: 98514fe74548d768907ce7a13f680e8f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli-bin 1.1.0 hb9d3cd8_2
+  - libbrotlidec 1.1.0 hb9d3cd8_2
+  - libbrotlienc 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 19264
+  timestamp: 1725267697072
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_2.conda
+  sha256: 261364d7445513b9a4debc345650fad13c627029bfc800655a266bf1e375bc65
+  md5: c63b5e52939e795ba8d26e35d767a843
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlidec 1.1.0 hb9d3cd8_2
+  - libbrotlienc 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 18881
+  timestamp: 1725267688731
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hfdbb021_2.conda
+  sha256: 949913bbd1f74d1af202d3e4bff2e0a4e792ec00271dc4dd08641d4221aa2e12
+  md5: d21daab070d76490cb39a8f1d1729d79
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  license: MIT
+  license_family: MIT
+  size: 350367
+  timestamp: 1725267768486
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+  sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
+  md5: 62ee74e96c5ebb0af99386de58cf9553
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 252783
+  timestamp: 1720974456583
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.3-hb9d3cd8_1.conda
+  sha256: 732571ba6286dbccbf4c6450078a581b7a5620204faf876ff0ef282d77a6bfa8
+  md5: ee228789a85f961d14567252a03e725f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 204857
+  timestamp: 1732447031823
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
+  sha256: afee721baa6d988e27fef1832f68d6f32ac8cc99cdf6015732224c2841a09cea
+  md5: c27d1c142233b5bc9ca570c6e2e0c244
+  license: ISC
+  size: 159003
+  timestamp: 1725018903918
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
+  sha256: bc47aa39c8254e9e487b8bcd74cfa3b4a3de3648869eb1a0b89905986b668e35
+  md5: 55553ecd5328336368db611f350b7039
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 302115
+  timestamp: 1725560701719
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.1-py311hd18a35c_0.conda
+  sha256: 08be6120dc9369f07858677dde2a8474644cc7ec2ae146b39a6953aadc536dfd
+  md5: 351cb68d2081e249069748b6e60b3cd2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 278209
+  timestamp: 1731428493722
+- conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.9-py311hfdbb021_0.conda
+  sha256: cc2e120f53571e19ee6ea062e85e256fce6550ee139d8127cfb24d7ba015f2ae
+  md5: e1d95dce136e7d0f6a9d7cd9b6dca985
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2567811
+  timestamp: 1732236803227
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.55.1-py311h2dc5d0c_0.conda
+  sha256: 1d130b501942bd43e9d2e47fee0321eb861853fc171e98bb3a7c6cfe2b7f7131
+  md5: 7e891abfe80fe852757e3c92d314a245
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli
+  - libgcc >=13
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2877377
+  timestamp: 1733242455265
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+  sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
+  md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 634972
+  timestamp: 1694615932610
+- conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.12.1-nompi_py311hb639ac4_102.conda
+  sha256: a21932ada1e7a9f95433e4b29980316dac72428bedd738e1af73cb269ed36e2a
+  md5: c2438b0f0016fbd7ea93e872c9b93309
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cached-property
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libgcc >=13
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1391677
+  timestamp: 1729617884282
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_h2d575fe_107.conda
+  sha256: 84d9427b4700ba438064e48cd3c829f83974b7d78c2b477f88685a00348eb06e
+  md5: e370421dfe789ad5177452d377d96f8a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3903048
+  timestamp: 1733018614782
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_1.conda
+  sha256: 2f082f7b12a7c6824e051321c1029452562ad6d496ad2e8c8b7b3dea1c8feb92
+  md5: 5ca76f61b00a15a9be0612d4d883badc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17645
+  timestamp: 1725303065473
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+  sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
+  md5: 30186d27e2c9fa62b45fb1476b7200e3
+  depends:
+  - libgcc-ng >=10.3.0
+  license: LGPL-2.1-or-later
+  size: 117831
+  timestamp: 1646151697040
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.7-py311hd18a35c_0.conda
+  sha256: 4af11cbc063096a284fe1689b33424e7e49732a27fd396d74c7dee03d1e788ee
+  md5: be34c90cce87090d24da64a7c239ca96
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 72393
+  timestamp: 1725459421768
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+  sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
+  md5: 3f43953b7d3fb3aaa1d0d0723d91e368
+  depends:
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1370023
+  timestamp: 1719463201255
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+  sha256: 5c878d104b461b7ef922abe6320711c0d01772f4cd55de18b674f88547870041
+  md5: 51bb7010fc86f70eee639b4bb7a894f5
+  depends:
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 245247
+  timestamp: 1701647787198
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+  sha256: 7c91cea91b13f4314d125d1bedb9d03a29ebbd5080ccdea70260363424646dbe
+  md5: 048b02e3962f066da18efe3a21b77672
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - binutils_impl_linux-64 2.43
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 669211
+  timestamp: 1729655358674
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+  sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
+  md5: 76bbff344f0134279f225174e9064c8f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 281798
+  timestamp: 1657977462600
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
+  sha256: 2ef420a655528bca9d269086cf33b7e90d2f54ad941b437fb1ed5eca87cee017
+  md5: 5e97e271911b8b2001a8b71860c32faa
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 35446
+  timestamp: 1711021212685
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
+  sha256: d6d12dc437d060f838820e9e61bf73baab651f91935ac594cf10beb9ef1b4450
+  md5: 8ea26d42ca88ec5258802715fe1ee10b
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - liblapack 3.9.0 25_linux64_openblas
+  - libcblas 3.9.0 25_linux64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 25_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15677
+  timestamp: 1729642900350
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
+  sha256: d9db2de60ea917298e658143354a530e9ca5f9c63471c65cf47ab39fd2f429e3
+  md5: 41b599ed2b02abcfdd84302bff174b23
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 68851
+  timestamp: 1725267660471
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
+  sha256: 2892d512cad096cb03f1b66361deeab58b64e15ba525d6592bb6d609e7045edf
+  md5: 9566f0bd264fbd463002e759b8a82401
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 32696
+  timestamp: 1725267669305
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
+  sha256: 779f58174e99de3600e939fa46eddb453ec5d3c60bb46cdaa8b4c127224dbf29
+  md5: 06f70867945ea6a84d35836af780f1de
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 281750
+  timestamp: 1725267679782
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
+  sha256: ab87b0477078837c91d9cda62a9faca18fba7c57cc77aa779ae24b3ac783b5dd
+  md5: 5dbd1b0fc0d01ec5e0e1fbe667281a11
+  depends:
+  - libblas 3.9.0 25_linux64_openblas
+  constrains:
+  - liblapack 3.9.0 25_linux64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 25_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15613
+  timestamp: 1729642905619
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
+  sha256: 54e6114dfce566c3a22ad3b7b309657e3600cdb668398e95f1301360d5d52c99
+  md5: 6e801c50a40301f6978c53976917b277
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 424900
+  timestamp: 1726659794676
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
+  sha256: 780f0530a3adfc1497ba49d626931c6afc978c540e1abfde6ccd57128ded6ad6
+  md5: b422943d5d772b7cc858b36ad2a92db5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 72242
+  timestamp: 1728177071251
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+  sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
+  md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 123878
+  timestamp: 1597616541093
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+  md5: 172bf1cd1ff8629f2b1179945ed45055
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 112766
+  timestamp: 1702146165126
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
+  sha256: 56541b98447b58e52d824bd59d6382d609e11de1f8adf20b23143e353d2b8d26
+  md5: db833e03127376d461e1e13e76f09b6c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 73304
+  timestamp: 1730967041968
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+  sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+  md5: d645c6d2ac96843a2bfaccd2d62b3ac3
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 58292
+  timestamp: 1636488182923
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
+  sha256: 53eb8a79365e58849e7b1a068d31f4f9e718dc938d6f2c03e960345739a03569
+  md5: 3cb76c3f10d3bc7f1105b2fc9db984df
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 14.2.0 h77fa898_1
+  - libgcc-ng ==14.2.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 848745
+  timestamp: 1729027721139
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+  sha256: 3a76969c80e9af8b6e7a55090088bc41da4cffcde9e2c71b17f44d37b7cb87f7
+  md5: e39480b9ca41323497b05492a63bc35b
+  depends:
+  - libgcc 14.2.0 h77fa898_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54142
+  timestamp: 1729027726517
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+  sha256: fc9e7f22a17faf74da904ebfc4d88699013d2992e55505e4aa0eb01770290977
+  md5: f1fd30127802683586f768875127a987
+  depends:
+  - libgfortran5 14.2.0 hd5240d6_1
+  constrains:
+  - libgfortran-ng ==14.2.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 53997
+  timestamp: 1729027752995
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
+  sha256: d149a37ca73611e425041f33b9d8dbed6e52ec506fe8cc1fc0ee054bddeb6d5d
+  md5: 9822b874ea29af082e5d36098d25427d
+  depends:
+  - libgcc >=14.2.0
+  constrains:
+  - libgfortran 14.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1462645
+  timestamp: 1729027735353
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+  sha256: 1911c29975ec99b6b906904040c855772ccb265a1c79d5d75c8ceec4ed89cd63
+  md5: cc3573974587f12dda90d96e3e55a702
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 460992
+  timestamp: 1729027639220
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+  sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
+  md5: ea25936bb4080d843790b586850f82b8
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 618575
+  timestamp: 1694474974816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
+  sha256: 9d1ff017714edb2d84868f0f931a4a0e7c289a971062b2ac66cfc8145df7e20e
+  md5: 4dc03a53fc69371a6158d0ed37214cd3
+  depends:
+  - libblas 3.9.0 25_linux64_openblas
+  constrains:
+  - liblapacke 3.9.0 25_linux64_openblas
+  - libcblas 3.9.0 25_linux64_openblas
+  - blas * openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15608
+  timestamp: 1729642910812
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.6.3-hb9d3cd8_1.conda
+  sha256: e6e425252f3839e2756e4af1ea2074dffd3396c161bf460629f9dfd6a65f15c6
+  md5: 2ecf2f1c7e4e21fcfe6423a51a992d84
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - xz ==5.6.3=*_1
+  license: 0BSD
+  size: 111132
+  timestamp: 1733407410083
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+  sha256: b0f2b3695b13a989f75d8fd7f4778e1c7aabe3b36db83f0fe80b2cd812c0e975
+  md5: 19e57602824042dfd0446292ef90488b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - c-ares >=1.32.3,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 647599
+  timestamp: 1729571887612
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+  sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+  md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  license_family: GPL
+  size: 33408
+  timestamp: 1697359010159
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
+  sha256: 99ba271d8a80a1af2723f2e124ffd91d850074c0389c067e6d96d72a2dbfeabe
+  md5: 62857b389e42b36b686331bec0922050
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.2.0
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5578513
+  timestamp: 1730772671118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
+  sha256: e5b14f7a01c2db4362d8591f42f82f336ed48d5e4079e4d1f65d0c2a3637ea78
+  md5: f4cc49d7aa68316213e4b12be35308d1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 290661
+  timestamp: 1726234747153
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
+  sha256: 0105bd108f19ea8e6a78d2d994a6d4a8db16d19a41212070d2d1d48a63c34161
+  md5: a587892d3c13b6621a6091be690dbca2
+  depends:
+  - libgcc-ng >=12
+  license: ISC
+  size: 205978
+  timestamp: 1716828628198
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_1.conda
+  sha256: 8a9aadf996a2399f65b679c6e7f29139d5059f699c63e6d7b50e20db10c00508
+  md5: b6f02b52a174e612e89548f4663ce56a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 875349
+  timestamp: 1730208050020
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hf672d98_0.conda
+  sha256: 0407ac9fda2bb67e11e357066eff144c845801d00b5f664efbc48813af1e7bb9
+  md5: be2de152d8073ef1c01b7728475f2fe7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 304278
+  timestamp: 1732349402869
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+  sha256: 4661af0eb9bdcbb5fb33e5d0023b001ad4be828fccdcc56500059d56f9869462
+  md5: 234a5554c53625688d51062645337328
+  depends:
+  - libgcc 14.2.0 h77fa898_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3893695
+  timestamp: 1729027746910
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+  sha256: 25bb30b827d4f6d6f0522cc0579e431695503822f144043b93c50237017fffd8
+  md5: 8371ac6457591af2cf6159439c1fd051
+  depends:
+  - libstdcxx 14.2.0 hc0a3c3a_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54105
+  timestamp: 1729027780628
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-hc4654cb_2.conda
+  sha256: 18653b4a5c73e19c5e86ff72dab9bf59f5cc43d7f404a6be705d152dfd5e0660
+  md5: be54fb40ea32e8fe9dbaa94d4528b57e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.22,<1.26.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libstdcxx >=13
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 429018
+  timestamp: 1733443013288
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33601
+  timestamp: 1680112270483
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+  sha256: 49bc5f6b1e11cb2babf2a2a731d1a680a5e08a858280876a779dbda06c78c35f
+  md5: b26e8aa824079e1be0294e7152ca4559
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 438953
+  timestamp: 1713199854503
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+  sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
+  md5: 92ed62436b625154323d40d5f2f11dd7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 395888
+  timestamp: 1727278577118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
+  md5: 5aa797f8787fe7a17d1b0821485b5adc
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 100393
+  timestamp: 1702724383534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
+  md5: edb0dca6bc32e4f4789199455a1dbeb8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 60963
+  timestamp: 1727963148474
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py311h2dc5d0c_1.conda
+  sha256: 0291d90706ac6d3eea73e66cd290ef6d805da3fad388d1d476b8536ec92ca9a8
+  md5: 6565a715337ae279e351d0abd8ffe88a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25354
+  timestamp: 1733219879408
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.3-py311h2b939e6_0.conda
+  sha256: d31ebd77324b3ea74fa946043402f3bc59efd39c760835ad5f67b2b9e3c54eac
+  md5: 22a5583349cc89b5c9159b15746f27e2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  - tk >=8.6.13,<8.7.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 7980027
+  timestamp: 1733176210238
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mne-lsl-1.8.0-py311hd18a35c_0.conda
+  sha256: 733d05f75ba76d482e0523d6f8f96430063ea96c544b835e0a289ef1cef798b2
+  md5: d9706c105c010fea0051a6a0b7eb33cb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - click >=8.1
+  - libgcc >=13
+  - libstdcxx >=13
+  - mne-base >=1.4.2
+  - numpy >=1.21
+  - packaging
+  - pooch
+  - psutil
+  - pyqtgraph
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - qtpy
+  - scipy
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 592814
+  timestamp: 1732896088289
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+  sha256: 6a1d5d8634c1a07913f1c525db6455918cbc589d745fac46d9d6e30340c8731a
+  md5: 70caf8bb6cf39a0b6b7efc885f51c0fe
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: X11 AND BSD-3-Clause
+  size: 889086
+  timestamp: 1724658547447
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.3-py311h71ddf71_0.conda
+  sha256: d2fdae6b0e80c23248f0f6bf7b5e3b6e0f56f69f420e9f5da5a6aae2c95b1493
+  md5: 1b3c543b0cc96310bcf0b825d5a68cb1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8978113
+  timestamp: 1730588531967
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
+  sha256: 5600a0b82df042bd27d01e4e687187411561dfc11cc05143a08ce29b64bf2af2
+  md5: 7f2e286780f072ed750df46dc2631138
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.43,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 341592
+  timestamp: 1709159244431
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
+  sha256: 814b9dff1847b132c676ee6cc1a8cb2d427320779b93e1b6d76552275c128705
+  md5: 23cc74f77eb99315c0360ec3533147a9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 2947466
+  timestamp: 1731377666602
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py311h7db5c69_1.conda
+  sha256: dce121d3838996b77b810ca9097cc17068552075c761408a9b2eb788cf8fd1b0
+  md5: 643f8cb35133eb1be4919fb953f0a25f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15695466
+  timestamp: 1726879158862
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.0.0-py311h49e9ac3_0.conda
+  sha256: f0f792596ae99cba01f829d064058b1e99ca84080fc89f72d925bfe473cfc1b6
+  md5: 2bd3d0f839ec0d1eaca817c9d1feb7c2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 42421065
+  timestamp: 1729065780130
+- conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.5.1-h0054346_0.conda
+  sha256: 835afb9c8198895ec1ce2916320503d47bb0c25b75c228d744c44e505f1f4e3b
+  md5: 398cabfd9bd75e90d0901db95224f25f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libsqlite >=3.47.0,<4.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 3108751
+  timestamp: 1733138115896
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py311h9ecbd09_0.conda
+  sha256: 2ac3f1ed6e6a2a0c67a3922f4b5faf382855ad02cc0c85c5d56291c7a94296d0
+  md5: 0ffc1f53106a38f059b151c465891ed3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 505408
+  timestamp: 1729847169876
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+  sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
+  md5: b3c17d95b5a10c6e64a21fa17573e70e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 8252
+  timestamp: 1726802366959
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.6.1-py311h0f98d5a_10.conda
+  sha256: bd03c94e159e5935116d959f5595ea4ba38910d5c05e6919b3ad28d7e4a3df20
+  md5: 37f7e40c0afe09d0f15f0da92bbde054
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - certifi
+  - libgcc >=13
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 561770
+  timestamp: 1726679886387
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.11-h9e4cc4f_1_cpython.conda
+  sha256: b29ce0836fce55bdff8d5c5b71c4921a23f87d3b950aea89a9e75784120b06b0
+  md5: 8387070aa413ce9a8cc35a509fae938b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.6.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - liblzma >=5.6.3,<6.0a0
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.4.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 30624804
+  timestamp: 1733409665928
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
+  sha256: 2660b8059b3ee854bc5d3c6b1fce946e5bd2fe8fbca7827de2c5885ead6209de
+  md5: 139a8d40c8a2f430df31048949e450de
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6211
+  timestamp: 1723823324668
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h9ecbd09_1.conda
+  sha256: e721e5ff389a7b2135917c04b27391be3d3382e261bb60a369b1620655365c3d
+  md5: abeb54d40f439b86f75ea57045ab8496
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 212644
+  timestamp: 1725456264282
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py311h7deb3e3_3.conda
+  sha256: 3fdef7b3c43474b7225868776a373289a8fd92787ffdf8bed11cf7f39b4ac741
+  md5: e0897de1d8979a3bb20ef031ae1f7d28
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 389074
+  timestamp: 1728642373938
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+  sha256: 776363493bad83308ba30bcb88c2552632581b143e8ee25b1982c8c743e73abc
+  md5: 353823361b1d27eb3960efb076dfcaf6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-Qhull
+  size: 552937
+  timestamp: 1720813982144
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+  sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
+  md5: 47d31b792659ce70f470b5c82fdfb7a4
+  depends:
+  - libgcc-ng >=12
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 281456
+  timestamp: 1679532220005
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.22.3-py311h9e33e62_0.conda
+  sha256: 0908ac4acb1a10fe63046e947a96c77cea0d392619ef965944da86c3574b68ec
+  md5: b1f5799ae0cc22198928f09879da01f5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  size: 351650
+  timestamp: 1733366766805
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py311he9a78e4_1.conda
+  sha256: 59482b974c36c375fdfd0bc3e5a3003ea2d2ae72b64b8f3deaeef5a851dbc91d
+  md5: 49ba89bf4d8a995efb99517d1c7aeb1e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=13
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17592106
+  timestamp: 1729481734425
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.47.0-h9eae976_1.conda
+  sha256: 8ea1a085fa95d806301aeec0df6985c3ad0852a9a46aa62dd737d228c7862f9f
+  md5: 53abf1ef70b9ae213b22caa5350f97a9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libsqlite 3.47.0 hadc24fc_1
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 883666
+  timestamp: 1730208056779
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+  sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
+  md5: d453b98d9c83e71da0741bb0ff4d76bc
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3318875
+  timestamp: 1699202167581
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.2-py311h9ecbd09_0.conda
+  sha256: afa3489113154b5cb0724b0bf120b62df91f426dabfe5d02f2ba09e90d346b28
+  md5: df3aee9c3e44489257a840b8354e77b9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 855653
+  timestamp: 1732616048886
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py311h9ecbd09_1.conda
+  sha256: 5f277c801ca392512de9aa497fd8be3e168950600c438778dfc4234943c474fc
+  md5: 00895577e2b4c24dca76675ab1862551
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 368413
+  timestamp: 1729704640193
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
+  sha256: 532a046fee0b3a402db867b6ec55c84ba4cdedb91d817147c8feeae9766be3d6
+  md5: 77cbc488235ebbaab2b6e912d3934bae
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 14679
+  timestamp: 1727034741045
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+  sha256: 6b250f3e59db07c2514057944a3ea2044d6a8cdde8a47b6497c254520fade1ee
+  md5: 8035c64cb77ed555e3f150b7b3972480
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 19901
+  timestamp: 1727794976192
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+  sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
+  md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 89141
+  timestamp: 1641346969816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_7.conda
+  sha256: a4dc72c96848f764bb5a5176aa93dd1e9b9e52804137b99daeebba277b31ea10
+  md5: 3947a35e916fcc6b9825449affbf4214
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - libstdcxx >=13
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 335400
+  timestamp: 1731585026517
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py311hbc35293_1.conda
+  sha256: a5cf0eef1ffce0d710eb3dffcb07d9d5922d4f7a141abc96f6476b98600f718f
+  md5: aec590674ba365e50ae83aa2d6e1efae
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.11
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 417923
+  timestamp: 1725305669690
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+  sha256: c558b9cc01d9c1444031bd1ce4b9cff86f9085765f17627a6cd85fc623c8a02b
+  md5: 4d056880988120e29d75bfff282e0f45
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 554846
+  timestamp: 1714722996770
+- conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+  sha256: 4b54b7ce79d818e3cce54ae4d552dba51b7afac160ceecdefd04b3917a37c502
+  md5: 688697ec5e9588bdded167d19577625b
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.9
+  - sniffio >=1.1
+  - typing_extensions >=4.1
+  constrains:
+  - uvloop >=0.21.0b1
+  - trio >=0.26.1
+  license: MIT
+  license_family: MIT
+  size: 109864
+  timestamp: 1728935803440
+- conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
+  sha256: 8f032b140ea4159806e4969a68b4a3c0a7cab1ad936eb958a2b5ffe5335e19bf
+  md5: 54898d0f524c9dee622d44bbb081a8ab
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 10076
+  timestamp: 1733332433806
+- conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
+  sha256: 7af62339394986bc470a7a231c7f37ad0173ffb41f6bc0e8e31b0be9e3b9d20f
+  md5: a7ee488b71c30ada51c48468337b85ba
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.9
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 18594
+  timestamp: 1733311166338
+- conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+  sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
+  md5: b77d8c2313158e6e461ca0efb1c2c508
+  depends:
+  - python >=3.8
+  - python-dateutil >=2.7.0
+  - types-python-dateutil >=2.8.10
+  license: Apache-2.0
+  license_family: Apache
+  size: 100096
+  timestamp: 1696129131844
+- conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+  sha256: 93b14414b3b3ed91e286e1cbe4e7a60c4e1b1c730b0814d1e452a8ac4b9af593
+  md5: 8f587de4bcf981e26228f268df374a9b
+  depends:
+  - python >=3.9
+  constrains:
+  - astroid >=2,<4
+  license: Apache-2.0
+  license_family: Apache
+  size: 28206
+  timestamp: 1733250564754
+- conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+  sha256: 7ed83731979fe5b046c157730e50af0e24454468bbba1ed8fc1a3107db5d7518
+  md5: 3d081de3a6ea9f894bbb585e8e3a4dcb
+  depends:
+  - python >=3.8
+  - typing_extensions >=4.0.0
+  license: MIT
+  license_family: MIT
+  size: 15342
+  timestamp: 1690563152778
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+  sha256: 28dba85a7e0f7fb57d7315e13f603d1e41b83c5b88aa2a602596b52c833a2ff8
+  md5: 6732fa52eb8e66e5afeb32db8701a791
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 56048
+  timestamp: 1722977241383
+- conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_1.conda
+  sha256: f6205d3a62e87447e06e98d911559be0208d824976d77ab092796c9176611fcb
+  md5: 3e23f7db93ec14c80525257d8affac28
+  depends:
+  - python >=3.9
+  - pytz >=2015.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6551057
+  timestamp: 1733236466015
+- conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_1.conda
+  sha256: fca842ab7be052eea1037ebee17ac25cc79c626382dd2187b5c6e007b9d9f65f
+  md5: d48f7e9fdec44baf6d1da416fe402b04
+  depends:
+  - python >=3.9
+  - soupsieve >=1.2
+  license: MIT
+  license_family: MIT
+  size: 118042
+  timestamp: 1733230951790
+- conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_1.conda
+  sha256: ffc8e4e53cd92aec0f0ea0bc9e28f5fd1b1e67bde46b0b298170e6fb78eecce1
+  md5: 707af59db75b066217403a8f00c1d826
+  depends:
+  - python >=3.9
+  - webencodings
+  license: Apache-2.0 AND MIT
+  license_family: Apache
+  size: 132933
+  timestamp: 1733302409510
+- conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.2-pyhd8ed1ab_0.conda
+  sha256: e8307f1ea9306a48c4d872f7499b4a5e6f4137c440b46554897d8c08ca2a743b
+  md5: b3335e258c6113c8a355c32dd91e954f
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.10
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4774564
+  timestamp: 1733256001780
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+  sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
+  md5: 9b347a7ec10940d3f7941ff6c460b551
+  depends:
+  - cached_property >=1.5.2,<1.5.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4134
+  timestamp: 1615209571450
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+  sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+  md5: 576d629e47797577ab0f1b351297ef4a
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11065
+  timestamp: 1615209567874
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+  sha256: 7020770df338c45ac6b560185956c32f0a5abf4b76179c037f115fc7d687819f
+  md5: 12f7d00853807b0531775e9be891cb11
+  depends:
+  - python >=3.7
+  license: ISC
+  size: 163752
+  timestamp: 1725278204397
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+  sha256: 63022ee2c6a157a9f980250a66f54bdcdf5abee817348d0f9a74c2441a6fbf0e
+  md5: 6581a17bba6b948bb60130026404a9d6
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 47533
+  timestamp: 1733218182393
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_1.conda
+  sha256: 1cd5fc6ccdd5141378e51252a7a3810b07fd5a7e6934a5b4a7eccba66566224b
+  md5: cb8e52f28f5e592598190c562e7b5bf1
+  depends:
+  - __unix
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84513
+  timestamp: 1733221925078
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_1.conda
+  sha256: 98eeb47687c0a3260c7ea1e29f41057b8e57481b834d3bf5902b7a62e194f88f
+  md5: e2afd3b7e37a5363e292a8b33dbef65c
+  depends:
+  - __win
+  - colorama
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 85069
+  timestamp: 1733222030187
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
+  md5: 962b9857ee8e7018c22f2776ffa0b2d7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27011
+  timestamp: 1733218222191
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+  sha256: 79a6b4fff545e0b18f86ad93276a1797eb6ac3f7e1851e03f02d63b19655731b
+  md5: 4d155b600b63bc6ba89d91fab74238f8
+  depends:
+  - python >=3.7
+  license: CC-BY-4.0
+  size: 173517
+  timestamp: 1709713413736
+- conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+  sha256: e923acf02708a8a0b591f3bce4bdc11c8e63b73198b99b35fe6cd96bfb6a0dbe
+  md5: 948d84721b578d426294e17a02e24cbb
+  depends:
+  - python >=3.6
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12134
+  timestamp: 1710320435158
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.11-py311hd8ed1ab_1.conda
+  sha256: b9bb4486ba7b81d7264e92f346c9fa2d4a6c9678c28b33fb5d1652ecc7f82e26
+  md5: 6aab9c45010dc5ed92215f89cdafa201
+  depends:
+  - python 3.11.11.*
+  - python_abi * *_cp311
+  license: Python-2.0
+  size: 46068
+  timestamp: 1733407866862
+- conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+  sha256: 9827efa891e507a91a8a2acf64e210d2aff394e1cde432ad08e1f8c66b12293c
+  md5: 44600c4667a319d67dbe0681fc0bc833
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13399
+  timestamp: 1733332563512
+- conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+  sha256: 84e5120c97502a3785e8c3241c3bf51f64b4d445f13b4d2445db00d9816fe479
+  md5: d622d8d7ee8868870f9cbe259f381181
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14068
+  timestamp: 1733236549190
+- conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
+  md5: 961b3a227b437d82ad7054484cfa71b2
+  depends:
+  - python >=3.6
+  license: PSF-2.0
+  license_family: PSF
+  size: 24062
+  timestamp: 1615232388757
+- conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+  sha256: 80f579bfc71b3dab5bef74114b89e26c85cb0df8caf4c27ab5ffc16363d57ee7
+  md5: 3366592d3c219f2731721f11bc93755c
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 11259
+  timestamp: 1733327239578
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+  sha256: cbde2c64ec317118fc06b223c5fd87c8a680255e7348dd60e7b292d2e103e701
+  md5: a16662747cdeb9abbac74d0057cc976e
+  depends:
+  - python >=3.9
+  license: MIT and PSF-2.0
+  size: 20486
+  timestamp: 1733208916977
+- conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+  sha256: a52d7516e2e11d3eb10908e10d3eb3f8ef267fea99ed9b09d52d96c4db3441b8
+  md5: d0441db20c827c11721889a241df1220
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 28337
+  timestamp: 1725214501850
+- conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+  sha256: 2509992ec2fd38ab27c7cdb42cf6cadc566a1cc0d1021a2673475d9fa87c6276
+  md5: d3549fd50d450b6d9e7dddff25dd2110
+  depends:
+  - cached-property >=1.3.0
+  - python >=3.9,<4
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 16705
+  timestamp: 1733327494780
+- conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
+  sha256: 622516185a7c740d5c7f27016d0c15b45782c1501e5611deec63fd70344ce7c8
+  md5: 7ee49e89531c0dcbba9466f6d115d585
+  depends:
+  - python >=3.9
+  - typing_extensions
+  license: MIT
+  license_family: MIT
+  size: 51846
+  timestamp: 1733327599467
+- conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
+  sha256: 843ddad410c370672a8250470697027618f104153612439076d4d7b91eeb7b5c
+  md5: 825927dc7b0f287ef8d4d0011bb113b1
+  depends:
+  - hpack >=4.0,<5
+  - hyperframe >=6.0,<7
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 52000
+  timestamp: 1733298867359
+- conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+  sha256: 369d234fb83fb37e0e8abe7a78981a533cec37053c5c15177ad6caade729118d
+  md5: a765e03fa67caf58525b08bbbd5b4f76
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.9
+  - pyviz_comms >=2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4037867
+  timestamp: 1730736003074
+- conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyhd8ed1ab_1.conda
+  sha256: ec89b7e5b8aa2f0219f666084446e1fb7b54545861e9caa892acb24d125761b5
+  md5: 2aa5ff7fa34a81b9196532c84c10d865
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 29412
+  timestamp: 1733299296857
+- conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+  sha256: c84d012a245171f3ed666a8bf9319580c269b7843ffa79f26468842da3abd5df
+  md5: 2ca8e6dbc86525c8b95e3c0ffa26442e
+  depends:
+  - python >=3.8
+  - h11 >=0.13,<0.15
+  - h2 >=3,<5
+  - sniffio 1.*
+  - anyio >=3.0,<5.0
+  - certifi
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48959
+  timestamp: 1731707562362
+- conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.0-pyhd8ed1ab_0.conda
+  sha256: cb7895446cd93091300accea6afbc8d9811a3c5899922ccfeeff97d9b55909dc
+  md5: 22878824a87f1af2ad48665f9d5bfcc8
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 63183
+  timestamp: 1732831049776
+- conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+  sha256: a0fb47776b6816990b94eab6e1a27025f643fa94646b845277d3aa8bce8fb2f1
+  md5: dbc57da07daee81a9cd76586217c7cbb
+  depends:
+  - bokeh >=3.1
+  - colorcet >=2
+  - holoviews >=1.19.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 246908
+  timestamp: 1729160766015
+- conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_1.conda
+  sha256: e91c6ef09d076e1d9a02819cd00fa7ee18ecf30cdd667605c853980216584d1b
+  md5: 566e75c90c1d0c8c459eb0ad9833dc7a
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 17239
+  timestamp: 1733298862681
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+  sha256: d7a472c9fd479e2e8dcb83fb8d433fce971ea369d704ece380e876f9c3494e87
+  md5: 39a4f67be3286c86d696df570b1201b7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49765
+  timestamp: 1733211921194
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+  sha256: 13766b88fc5b23581530d3a0287c0c58ad82f60401afefab283bf158d2be55a9
+  md5: 315607a3030ad5d5227e76e0733798ff
+  depends:
+  - python >=3.9
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 28623
+  timestamp: 1733223207185
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
+  sha256: 461199e429a3db01f0a673f8beaac5e0be75b88895952fb9183f2ab01c5c3c24
+  md5: 15798fa69312d433af690c8c42b3fb36
+  depends:
+  - python >=3.9
+  - zipp >=3.1.0
+  constrains:
+  - importlib-resources >=6.4.5,<6.4.6.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 32701
+  timestamp: 1733231441973
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+  sha256: 33cfd339bb4efac56edf93474b37ddc049e08b1b4930cf036c893cc1f5a1f32a
+  md5: b40131ab6a36ac2c09b7c57d4d3fbf99
+  depends:
+  - __linux
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119084
+  timestamp: 1719845605084
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+  sha256: dc569094125127c0078aa536f78733f383dd7e09507277ef8bcd1789786e7086
+  md5: 18df5fc4944a679e085e0e8f31775fc8
+  depends:
+  - __win
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119853
+  timestamp: 1719845858082
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+  sha256: 072534d4d379225b2c3a4e38bc7730b65ae171ac7f0c2d401141043336e97980
+  md5: 9eb15d654daa0ef5a98802f586bb4ffc
+  depends:
+  - __osx
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119568
+  timestamp: 1719845667420
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
+  sha256: 65cdc105e5effea2943d3979cc1592590c923a589009b484d07672faaf047af1
+  md5: 5d6e5cb3a4b820f61b2073f0ad5431f1
+  depends:
+  - __unix
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.10
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 600248
+  timestamp: 1732897026255
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh7428d3b_0.conda
+  sha256: 94ee8215bd1f614c9c984437b184e8dbe61a4014eb5813c276e3dcb18aaa7f46
+  md5: 6cdaebbc9e3feb2811eb9f52ed0b89e1
+  depends:
+  - __win
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.10
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 600466
+  timestamp: 1732897444811
+- conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
+  md5: 4cb68948e0b8429534380243d063a27a
+  depends:
+  - arrow >=0.15.0
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 17189
+  timestamp: 1638811664194
+- conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+  sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+  md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.9
+  license: Apache-2.0 AND MIT
+  size: 843646
+  timestamp: 1733300981994
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+  sha256: 85a7169c078b8065bd9d121b0e7b99c8b88c42a411314b6ae5fcd81c48c4710a
+  md5: 08cce3151bde4ecad7885bd9fb647532
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110963
+  timestamp: 1733217424408
+- conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.10.0-pyhd8ed1ab_1.conda
+  sha256: 61bca2dac194c44603446944745566d7b4e55407280f6f6cea8bbe4de26b558f
+  md5: cd170f82d8e5b355dfdea6adab23e4af
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 31573
+  timestamp: 1733272196759
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+  sha256: 7d0c4c0346b26be9f220682b7c5c0d84606d48c6dbc36fc238e4452dda733aff
+  md5: da304c192ad59975202859b367d0f6a2
+  depends:
+  - attrs >=22.2.0
+  - importlib_resources >=1.4.0
+  - jsonschema-specifications >=2023.03.6
+  - pkgutil-resolve-name >=1.3.10
+  - python >=3.8
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 74323
+  timestamp: 1720529611305
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+  sha256: 82f8bed0f21dc0b3aff40dd4e39d77e85b93b0417bc5659b001e0109341b8b98
+  md5: 720745920222587ef942acfbc578b584
+  depends:
+  - python >=3.8
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 16165
+  timestamp: 1728418976382
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+  sha256: 007a0a506a0d1805b099629cb0ee743ad0afe7d9749e57339f32c168119e0139
+  md5: 16b37612b3a2fd77f409329e213b530c
+  depends:
+  - fqdn
+  - idna
+  - isoduration
+  - jsonpointer >1.13
+  - jsonschema >=4.23.0,<4.23.1.0a0
+  - rfc3339-validator
+  - rfc3986-validator >0.1.0
+  - uri-template
+  - webcolors >=24.6.0
+  license: MIT
+  license_family: MIT
+  size: 7143
+  timestamp: 1720529619500
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+  sha256: 2151c2c63e0442a4c69ee0ad8a634195eedab10b7b74c0ec8266471842239a93
+  md5: 885867f6adab3d7ecdf8ab6ca0785f51
+  depends:
+  - importlib-metadata >=4.8.3
+  - jupyter_server >=1.1.2
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55539
+  timestamp: 1712707521811
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
+  sha256: 19d8bd5bb2fde910ec59e081eeb59529491995ce0d653a5209366611023a0b3a
+  md5: 4ebae00eae9705b0c3d6d1018a81d047
+  depends:
+  - importlib-metadata >=4.8.3
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.9
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 106342
+  timestamp: 1733441040958
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+  sha256: 732b1e8536bc22a5a174baa79842d79db2f4956d90293dd82dc1b3f6099bcccd
+  md5: 0a2980dada0dd7fd0998f0342308b1b1
+  depends:
+  - __unix
+  - platformdirs >=2.5
+  - python >=3.8
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 57671
+  timestamp: 1727163547058
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh5737063_1.conda
+  sha256: 7c903b2d62414c3e8da1f78db21f45b98de387aae195f8ca959794113ba4b3fd
+  md5: 46d87d1c0ea5da0aae36f77fa406e20d
+  depends:
+  - __win
+  - cpython
+  - platformdirs >=2.5
+  - python >=3.8
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 58269
+  timestamp: 1727164026641
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_1.conda
+  sha256: d7fa4c627d56ce8dc02f09f358757f8fd49eb6137216dc99340a6b4efc7e0491
+  md5: 62186e6383f38cc6a3466f0fadde3f2e
+  depends:
+  - jsonschema-with-format-nongpl >=4.18.0
+  - python >=3.9
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21434
+  timestamp: 1733441420606
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_1.conda
+  sha256: 082d3517455339c8baea245a257af249758ccec26b8832d969ac928901c234cc
+  md5: 81ea84b3212287f926e35b9036192963
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert-core >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.9
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 324289
+  timestamp: 1733428731329
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+  sha256: 0890fc79422191bc29edf17d7b42cff44ba254aa225d31eb30819f8772b775b8
+  md5: 2d983ff1b82a1ccb6f2e9d8784bdd6bd
+  depends:
+  - python >=3.9
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19711
+  timestamp: 1733428049134
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.2-pyhd8ed1ab_0.conda
+  sha256: e806f753fe91faaffbad3d1d3aab7ceee785ae01bf0d758a82f1466164d727d6
+  md5: 5f0d3b774cae26dd785e443a0e1623ae
+  depends:
+  - async-lru >=1.0.0
+  - httpx >=0.28.0,<0.29.0
+  - importlib-metadata >=4.8.3
+  - ipykernel >=6.5.0
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.27.1,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.9
+  - setuptools >=40.8.0
+  - tomli >=1.2.2
+  - tornado >=6.2.0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7396800
+  timestamp: 1733261150800
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+  sha256: dc24b900742fdaf1e077d9a3458fd865711de80bca95fe3c6d46610c532c6ef0
+  md5: fd312693df06da3578383232528c468d
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.9
+  constrains:
+  - jupyterlab >=4.0.8,<5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18711
+  timestamp: 1733328194037
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+  sha256: a23b26d1a35bccdb91b9232119e5f402624e1e1a252b0e64cc20c6eb5b87cefb
+  md5: af8239bf1ba7e8c69b689f780f653488
+  depends:
+  - babel >=2.10
+  - importlib-metadata >=4.8.3
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.8
+  - requests >=2.31
+  constrains:
+  - openapi-core >=0.18.0,<0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49355
+  timestamp: 1721163412436
+- conda: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_1.conda
+  sha256: c1ca8dc910d7c32d431d8ef4acdea8da2e876c62f096b99591f712fd62cf7269
+  md5: 4809b9f4c6ce106d443c3f90b8e10db2
+  depends:
+  - importlib-metadata
+  - packaging
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16193
+  timestamp: 1723774444381
+- conda: https://conda.anaconda.org/conda-forge/noarch/lazy_loader-0.4-pyhd8ed1ab_1.conda
+  sha256: bf5a563f4e7d2bd5d3ec0644c0cb452b1e9e4ee68a221f6c9718872a22d4fa7a
+  md5: ec6f70b8a5242936567d4f886726a372
+  depends:
+  - lazy-loader 0.4 pyhd8ed1ab_1
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6513
+  timestamp: 1723774453792
+- conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+  sha256: aa99d44e8c83865026575a8af253141c53e0b3ab05f053befaa7757c8525064f
+  md5: f1b64ca4faf563605cf6f6ca93f9ff3f
+  depends:
+  - python >=3.7
+  - uc-micro-py
+  license: MIT
+  license_family: MIT
+  size: 24035
+  timestamp: 1707129321841
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+  sha256: fce1fde00359696983989699c00f9891194c4ebafea647a8d21b7e2e3329b56e
+  md5: 06e9bebf748a0dea03ecbe1f0e27e909
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78331
+  timestamp: 1710435316163
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+  sha256: 0fbacdfb31e55964152b24d5567e9a9996e1e7902fb08eb7d91b5fd6ce60803a
+  md5: fee3164ac23dfca50cfcc8b85ddefb81
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 64430
+  timestamp: 1733250550053
+- conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+  sha256: 69b7dc7131703d3d60da9b0faa6dd8acbf6f6c396224cf6aef3e855b8c0c41c6
+  md5: af6ab708897df59bd6e7283ceab1b56b
+  depends:
+  - python >=3.9
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14467
+  timestamp: 1733417051523
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+  sha256: 5cedc99412278b37e9596f1f991d49f5a1663fe79767cf814a288134a1400ba9
+  md5: 5387f2cfa28f8a3afa3368bb4ba201e8
+  depends:
+  - markdown-it-py >=1.0.0,<4.0.0
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 42126
+  timestamp: 1725995333692
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+  sha256: 78c1bbe1723449c52b7a9df1af2ee5f005209f67e40b6e1d3c7619127c43b1c7
+  md5: 592132998493b3ff25fd7479396e8351
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 14465
+  timestamp: 1733255681319
+- conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_1.conda
+  sha256: 0a9faaf1692b74f321cedbd37a44f108a1ec3f5d9638bc5bbf860cb3b6ff6db4
+  md5: c46df05cae629e55426773ac1f85d68f
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65901
+  timestamp: 1733258822603
+- conda: https://conda.anaconda.org/conda-forge/noarch/mne-base-1.8.0-pyh694c41f_200.conda
+  sha256: a777fcde8b0299a8a00e67bbe058f0f48295368ca24185efc2806449987310bf
+  md5: baa925d0e4fd05b33a430913c235bd4e
+  depends:
+  - decorator
+  - jinja2
+  - lazy_loader >=0.3
+  - matplotlib-base >=3.5.0
+  - numpy >=1.21.2
+  - packaging
+  - pooch >=1.5
+  - python >=3.9
+  - scipy >=1.7.1
+  - tqdm
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7210433
+  timestamp: 1724034836971
+  purls:
+  - pkg:pypi/mne?source=hash-mapping
+- conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+  sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
+  md5: 2ba8498c1018c1e9c61eb99b973dfe19
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12452
+  timestamp: 1600387789153
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+  sha256: 564e22c4048f2f00c7ee79417dea364f95cf069a1f2565dc26d5ece1fc3fd779
+  md5: 3ee79082e59a28e1db11e2a9c3bcd85a
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.8
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27878
+  timestamp: 1732882434219
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhff2d567_2.conda
+  sha256: 03a1303ce135a8214b450e751d93c9048f55edb37f3f9f06c5e9d78ba3ef2a89
+  md5: 0457fdf55c88e52e0e7b63691eafcc48
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<3.1
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.8
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - nbconvert =7.16.4=*_2
+  - pandoc >=2.9.2,<4.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 188505
+  timestamp: 1733405603619
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+  sha256: 7a5bd30a2e7ddd7b85031a5e2e14f290898098dc85bea5b3a5bf147c25122838
+  md5: bbe1963f1e47f594070ffe87cdf612ea
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.9
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100945
+  timestamp: 1733402844974
+- conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+  sha256: bb7b21d7fd0445ddc0631f64e66d91a179de4ba920b8381f29b9d006a42788c0
+  md5: 598fd7d4d0de2455fb74f56063969a97
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11543
+  timestamp: 1733325673691
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.3.1-pyhd8ed1ab_0.conda
+  sha256: d5bd4e3c27b2fd234c5d79f3749cd6139d5b13a88cb7320f93c239aabc28e576
+  md5: f663ab5bcc9a28364b7b80aa976ed00f
+  depends:
+  - importlib_resources >=5.0
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab >=4.3.2,<4.4
+  - jupyterlab_server >=2.27.1,<3
+  - notebook-shim >=0.2,<0.3
+  - python >=3.9
+  - tornado >=6.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9415854
+  timestamp: 1733367221274
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+  sha256: 7b920e46b9f7a2d2aa6434222e5c8d739021dbc5cc75f32d124a8191d86f9056
+  md5: e7f89ea5f7ea9401642758ff50a2d9c1
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16817
+  timestamp: 1733408419340
+- conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+  sha256: 5e238e5e646414d517a13f6786c7227206ace58271e3ef63f6adca4d6a4c2839
+  md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
+  depends:
+  - python >=3.6
+  - typing_utils
+  license: Apache-2.0
+  license_family: APACHE
+  size: 30232
+  timestamp: 1706394723472
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+  sha256: da157b19bcd398b9804c5c52fc000fcb8ab0525bdb9c70f95beaa0bb42f85af1
+  md5: 3bfed7e6228ebf2f7b9eaa47f1b4e2aa
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: APACHE
+  size: 60164
+  timestamp: 1733203368787
+- conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
+  md5: 457c2c8c08e54905d6954e79cb5b5db9
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11627
+  timestamp: 1631603397334
+- conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+  sha256: 5a05f572a610cada2fcccef8d555fddf2d01bef80da32411150735e6177d1eab
+  md5: 41c7413071c2bae37472214a3525e6bf
+  depends:
+  - bleach
+  - bokeh >=3.5.0,<3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.1.0,<3.0
+  - python >=3.10
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20670374
+  timestamp: 1731497809631
+- conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+  sha256: db644c81c1f47e1fa8134d5de935ec4269d765fbef8d44bd454eb187c7524472
+  md5: bd991333d5bc659bb82bfb5a5d4c1576
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 103339
+  timestamp: 1719325288387
+- conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
+  sha256: 17131120c10401a99205fc6fe436e7903c0fa092f1b3e80452927ab377239bcc
+  md5: 5c092057b6badd30f75b06244ecd01c9
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 75295
+  timestamp: 1733271352153
+- conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+  sha256: 202af1de83b585d36445dc1fda94266697341994d1a3328fabde4989e1b3d07a
+  md5: d0d408b1f18883a944376da5cf8101ea
+  depends:
+  - ptyprocess >=0.5
+  - python >=3.9
+  license: ISC
+  size: 53561
+  timestamp: 1733302019362
+- conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+  sha256: e2ac3d66c367dada209fc6da43e645672364b9fd5f9d28b9f016e24b81af475b
+  md5: 11a9d1d09a3615fc07c3faf79bc0b943
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 11748
+  timestamp: 1733327448200
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+  sha256: 499313e72e20225f84c2e9690bbaf5b952c8d7e0bf34b728278538f766b81628
+  md5: 5dd546fe99b44fda83963d15f84263b7
+  depends:
+  - python >=3.8,<3.13.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 1243168
+  timestamp: 1730203795600
+- conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+  sha256: adb2dde5b4f7da70ae81309cce6188ed3286ff280355cf1931b45d91164d2ad8
+  md5: 5a5870a74432aa332f7d32180633ad05
+  depends:
+  - python >=3.9
+  license: MIT AND PSF-2.0
+  size: 10693
+  timestamp: 1733344619659
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+  sha256: bb50f6499e8bc1d1a26f17716c97984671121608dc0c3ecd34858112bce59a27
+  md5: 577852c7e53901ddccc7e6a9959ddebe
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 20448
+  timestamp: 1733232756001
+- conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_1.conda
+  sha256: bedda6b36e8e42b0255179446699a0cf08051e6d9d358dd0dd0e787254a3620e
+  md5: b3e783e8e8ed7577cf0b6dee37d1fbac
+  depends:
+  - packaging >=20.0
+  - platformdirs >=2.5.0
+  - python >=3.9
+  - requests >=2.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54116
+  timestamp: 1733421432357
+- conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.1-pyhd8ed1ab_0.conda
+  sha256: bc8f00d5155deb7b47702cb8370f233935704100dbc23e30747c161d1b6cf3ab
+  md5: 3e01e386307acc60b2f89af0b2e161aa
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  size: 49002
+  timestamp: 1733327434163
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_1.conda
+  sha256: 79fb7d1eeb490d4cc1b79f781bb59fe302ae38cf0a30907ecde75a7d399796cc
+  md5: 368d4aa48358439e07a97ae237491785
+  depends:
+  - python >=3.9
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.48
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269848
+  timestamp: 1733302634979
+- conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+  sha256: a7713dfe30faf17508ec359e0bc7e0983f5d94682492469bd462cdaae9c64d83
+  md5: 7d9daffbb8d8e0af0f769dbbcd173a54
+  depends:
+  - python >=3.9
+  license: ISC
+  size: 19457
+  timestamp: 1733302371990
+- conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+  sha256: dcfcb3cee1ae0a89729601582cc3edea20ba13c9493967a03a693c67567af0c8
+  md5: 0f051f09d992e0d08941706ad519ee0e
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 16551
+  timestamp: 1721585805256
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+  sha256: 79db7928d13fab2d892592223d7570f5061c192f27b9febd1a418427b719acc6
+  md5: 12c566707c80111f9799308d9e265aef
+  depends:
+  - python >=3.9
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110100
+  timestamp: 1733195786147
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+  sha256: 0d6133545f268b2b89c2617c196fc791f365b538d4057ecd636d658c3b1e885d
+  md5: b38dc0206e2a530e5c2cf11dc086b31a
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 876700
+  timestamp: 1733221731178
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_2.conda
+  sha256: 09a5484532e24a33649ab612674fd0857bbdcfd6640a79d13a6690fb742a36e1
+  md5: 4c05a2bcf87bb495512374143b57cf28
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 92319
+  timestamp: 1733222687746
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyqtgraph-0.13.7-pyhd8ed1ab_0.conda
+  sha256: e0ab6d9b69bde1febba187f88c4743cb36063c3edbf3642ac0e604979bf6f126
+  md5: d31a6f00bd89ff46a5e457c935578c33
+  depends:
+  - numpy >=1.22
+  - python >=3.9
+  constrains:
+  - pyqt >=5.15
+  - pyside2 >=5.15
+  license: MIT
+  license_family: MIT
+  size: 1443102
+  timestamp: 1714681228438
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
+  sha256: d016e04b0e12063fbee4a2d5fbb9b39a8d191b5a0042f0b8459188aedeabb0ca
+  md5: e2fd202833c4a981ce8a65974fe4abd1
+  depends:
+  - __win
+  - python >=3.9
+  - win_inet_pton
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21784
+  timestamp: 1733217448189
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+  sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
+  md5: 461219d1a5bd61342293efa2c0c90eac
+  depends:
+  - __unix
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21085
+  timestamp: 1733217331982
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+  sha256: a50052536f1ef8516ed11a844f9413661829aa083304dc624c5925298d078d79
+  md5: 5ba79d7c71f03c678c8ead841f347d6e
+  depends:
+  - python >=3.9
+  - six >=1.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 222505
+  timestamp: 1733215763718
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+  sha256: 1b09a28093071c1874862422696429d0d35bd0b8420698003ac004746c5e82a2
+  md5: 38e34d2d1d9dca4fb2b9a0a04f604e2c
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 226259
+  timestamp: 1733236073335
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+  sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
+  md5: a61bf9ec79426938ff785eb69dbb1960
+  depends:
+  - python >=3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13383
+  timestamp: 1677079727691
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+  sha256: 57c9a02ec25926fb48edca59b9ede107823e5d5c473b94a0e05cc0b9a193a642
+  md5: c0def296b2f6d2dd7b030c2a7f66bb1f
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 142235
+  timestamp: 1733235414217
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+  sha256: 1a7d6b233f7e6e3bbcbad054c8fd51e690a67b129a899a056a5e45dd9f00cb41
+  md5: 3eeeeb9e4827ace8c0c1419c85d590ad
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 188538
+  timestamp: 1706886944988
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+  sha256: a7979e8e4936c430f5fe3d04fc2d67b42dab84fb4a502c4961a17dcb2327fec0
+  md5: 02b4e3a3014c1ac490ee4a4316f2d229
+  depends:
+  - param
+  - python >=3.6
+  constrains:
+  - jupyterlab >=4.0,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48061
+  timestamp: 1722535734510
+- conda: https://conda.anaconda.org/conda-forge/noarch/qtpy-2.4.2-pyhdecd6ff_0.conda
+  sha256: b1b148dfcdd9f343729f39e68851600b13c6e16c041d6cb13aaf37fb86033da3
+  md5: 5060d07c9a66612192a3f6f0609fa36f
+  depends:
+  - packaging
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 62425
+  timestamp: 1730763884592
+- conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_1.conda
+  sha256: f972eecb4dc8e06257af37642f92b0f2df04a7fe4c950f2e1045505e5e93985f
+  md5: 8c9083612c1bfe6878715ed5732605f8
+  depends:
+  - attrs >=22.2.0
+  - python >=3.9
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 42201
+  timestamp: 1733366868091
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+  sha256: d701ca1136197aa121bbbe0e8c18db6b5c94acbd041c2b43c70e5ae104e1d8ad
+  md5: a9b9368f3701a417eac9edbcae7cb737
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 58723
+  timestamp: 1733217126197
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
+  md5: fed45fc5ea0813240707998abe49f520
+  depends:
+  - python >=3.5
+  - six
+  license: MIT
+  license_family: MIT
+  size: 8064
+  timestamp: 1638811838081
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+  sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
+  md5: 912a71cc01012ee38e6b90ddd561e36f
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 7818
+  timestamp: 1598024297745
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_1.conda
+  sha256: 00926652bbb8924e265caefdb1db100f86a479e8f1066efe395d5552dde54d02
+  md5: 938c8de6b9de091997145b3bf25cdbf9
+  depends:
+  - __linux
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22736
+  timestamp: 1733322148326
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_1.conda
+  sha256: 5282eb5b462502c38df8cb37cd1542c5bbe26af2453a18a0a0602d084ca39f53
+  md5: e67b1b1fa7a79ff9e8e326d0caf55854
+  depends:
+  - __osx
+  - pyobjc-framework-cocoa
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23100
+  timestamp: 1733322309409
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_1.conda
+  sha256: ba8b93df52e0d625177907852340d735026c81118ac197f61f1f5baea19071ad
+  md5: e6a4e906051565caf5fdae5b0415b654
+  depends:
+  - __win
+  - python >=3.9
+  - pywin32
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23359
+  timestamp: 1733322590167
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+  sha256: abb12e1dd515b13660aacb5d0fd43835bc2186cab472df25b7716cd65e095111
+  md5: fc80f7995e396cbaeabd23cf46c413dc
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 774252
+  timestamp: 1732632769210
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+  sha256: 41db0180680cc67c3fa76544ffd48d6a5679d96f4b71d7498a759e94edc9a2db
+  md5: a451d576819089b0d672f18768be0f65
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 16385
+  timestamp: 1733381032766
+- conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+  sha256: c2248418c310bdd1719b186796ae50a8a77ce555228b6acd32768e2543a15012
+  md5: bf7a226e58dfb8346c70df36065d86c9
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  size: 15019
+  timestamp: 1733244175724
+- conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+  sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
+  md5: 3f144b2c34f8cb5a9abd9ed23a39c561
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 36754
+  timestamp: 1693929424267
+- conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+  sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
+  md5: e7df0fdd404616638df5ece6e69ba7af
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 26205
+  timestamp: 1669632203115
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+  sha256: b300557c0382478cf661ddb520263508e4b3b5871b471410450ef2846e8c352c
+  md5: efba281bbdae5f6b0a1d53c6d4a97c93
+  depends:
+  - __linux
+  - ptyprocess
+  - python >=3.8
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22452
+  timestamp: 1710262728753
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+  sha256: 4daae56fc8da17784578fbdd064f17e3b3076b394730a14119e571707568dc8a
+  md5: 00b54981b923f5aefcd5e8547de056d5
+  depends:
+  - __osx
+  - ptyprocess
+  - python >=3.8
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22717
+  timestamp: 1710265922593
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
+  sha256: 8cb078291fd7882904e3de594d299c8de16dd3af7405787fce6919a385cfc238
+  md5: 4abd500577430a942a995fd0d09b76a2
+  depends:
+  - __win
+  - python >=3.8
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22883
+  timestamp: 1710262943966
+- conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+  sha256: cad582d6f978276522f84bd209a5ddac824742fe2d452af6acf900f8650a73a2
+  md5: f1acf5fdefa8300de697982bcb1761c9
+  depends:
+  - python >=3.5
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28285
+  timestamp: 1729802975370
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+  sha256: 18636339a79656962723077df9a56c0ac7b8a864329eb8f847ee3d38495b863e
+  md5: ac944244f1fed2eb49bae07193ae8215
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 19167
+  timestamp: 1733256819729
+- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+  sha256: 5673b7104350a6998cb86cccf1d0058217d86950e8d6c927d8530606028edb1d
+  md5: 4085c9db273a148e149c03627350e22c
+  depends:
+  - colorama
+  - python >=3.7
+  license: MPL-2.0 or MIT
+  size: 89484
+  timestamp: 1732497312317
+- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+  sha256: f39a5620c6e8e9e98357507262a7869de2ae8cc07da8b7f84e517c9fd6c2b959
+  md5: 019a7385be9af33791c989871317e1ed
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110051
+  timestamp: 1733367480074
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhd8ed1ab_1.conda
+  sha256: 78538b566f1f1cd1e309bba8361875523c69db1a25db292a54977603c5ea1421
+  md5: cb0e8ce6fe1198a058040619a09bc424
+  depends:
+  - python >=3.9
+  license: Apache-2.0 AND MIT
+  size: 21850
+  timestamp: 1733279726734
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+  sha256: c8e9c1c467b5f960b627d7adc1c65fece8e929a3de89967e91ef0f726422fd32
+  md5: b6a408c64b78ec7b779a3e5c7a902433
+  depends:
+  - typing_extensions 4.12.2 pyha770c72_1
+  license: PSF-2.0
+  license_family: PSF
+  size: 10075
+  timestamp: 1733188758872
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+  sha256: 337be7af5af8b2817f115b3b68870208b30c31d3439bec07bfb2d8f4823e3568
+  md5: d17f13df8b65464ca316cbc000a3cb64
+  depends:
+  - python >=3.9
+  license: PSF-2.0
+  license_family: PSF
+  size: 39637
+  timestamp: 1733188758212
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+  sha256: 3088d5d873411a56bf988eee774559335749aed6f6c28e07bf933256afb9eb6c
+  md5: f6d7aa696c67756a650e91e15e88223c
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 15183
+  timestamp: 1733331395943
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+  sha256: 4fde5c3008bf5d2db82f2b50204464314cc3c91c1d953652f7bd01d9e52aefdf
+  md5: 8ac3367aafb1cc0a068483c580af8015
+  license: LicenseRef-Public-Domain
+  size: 122354
+  timestamp: 1728047496079
+- conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+  sha256: 54293cd94da3a6b978b353eb7897555055d925ad0008bc73e85cca19e2587ed0
+  md5: 3b7fc78d7be7b450952aaa916fb78877
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 11162
+  timestamp: 1707507514699
+- conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+  sha256: e0eb6c8daf892b3056f08416a96d68b0a358b7c46b99c8a50481b22631a4dfc0
+  md5: e7cb0f5745e4c5035a460248334af7eb
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 23990
+  timestamp: 1733323714454
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+  sha256: 416e30a1c3262275f01a3e22e783118d9e9d2872a739a9ed860d06fa9c7593d5
+  md5: 4a2d8ef7c37b8808c5b9b750501fffce
+  depends:
+  - brotli-python >=1.0.9
+  - h2 >=4,<5
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 98077
+  timestamp: 1733206968917
+- conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+  sha256: f21e63e8f7346f9074fd00ca3b079bd3d2fa4d71f1f89d5b6934bf31446dc2a5
+  md5: b68980f2495d096e71c7fd9d7ccf63e6
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 32581
+  timestamp: 1733231433877
+- conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+  sha256: 08315dc2e61766a39219b2d82685fc25a56b2817acf84d5b390176080eaacf99
+  md5: b49f7b291e15494aafb0a7d74806f337
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18431
+  timestamp: 1733359823938
+- conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+  sha256: 19ff205e138bb056a46f9e3839935a2e60bd1cf01c8241a5e172a422fed4f9c6
+  md5: 2841eb5bfc75ce15e9a0054b98dcd64d
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15496
+  timestamp: 1733236131358
+- conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+  sha256: 1dd84764424ffc82030c19ad70607e6f9e3b9cb8e633970766d697185652053e
+  md5: 84f8f77f0a9c6ef401ee96611745da8f
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 46718
+  timestamp: 1733157432924
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+  sha256: 1b34021e815ff89a4d902d879c3bd2040bc1bd6169b32e9427497fa05c55f1ce
+  md5: 75cb7132eb58d97896e173ef12ac9986
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 62931
+  timestamp: 1733130309598
+- conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+  sha256: 93807369ab91f230cf9e6e2a237eaa812492fe00face5b38068735858fba954f
+  md5: 46e441ba871f524e2b067929da3051c2
+  depends:
+  - __win
+  - python >=3.9
+  license: LicenseRef-Public-Domain
+  size: 9555
+  timestamp: 1733130678956
+- conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_1.conda
+  sha256: 5f8757092fc985d7586f2659505ec28757c05fd65d8d6ae549a5cec7e3376977
+  md5: c79cea50b258f652010cb6c8d81591b5
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 46860
+  timestamp: 1733143536777
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+  sha256: 567c04f124525c97a096b65769834b7acb047db24b15a56888a322bf3966c3e1
+  md5: 0c3cc595284c5e8f0f9900a9b228a332
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 21809
+  timestamp: 1732827613585
+- conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h3336109_5.conda
+  sha256: fa5eb633b320e10fc2138f3d842d8a8ca72815f106acbab49a68ec9783e4d70d
+  md5: 29b46bd410067f668c4cef7fdc78fe25
+  depends:
+  - __osx >=10.13
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 32275
+  timestamp: 1725356815696
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h00291cd_2.conda
+  sha256: 624954bc08b3d7885a58c7d547282cfb9a201ce79b748b358f801de53e20f523
+  md5: 2db0c38a7f2321c5bdaf32b181e832c7
+  depends:
+  - __osx >=10.13
+  - brotli-bin 1.1.0 h00291cd_2
+  - libbrotlidec 1.1.0 h00291cd_2
+  - libbrotlienc 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 19450
+  timestamp: 1725267851605
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h00291cd_2.conda
+  sha256: 642a8492491109fd8270c1e2c33b18126712df0cedb94aaa2b1c6b02505a4bfa
+  md5: 049933ecbf552479a12c7917f0a4ce59
+  depends:
+  - __osx >=10.13
+  - libbrotlidec 1.1.0 h00291cd_2
+  - libbrotlienc 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 16643
+  timestamp: 1725267837325
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hd89902b_2.conda
+  sha256: 004cefbd18f581636a8dcb1964fb73478f15d496769226ec896c1d4a0161b7d8
+  md5: d75f06ee06001794aa83a05e885f1520
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 363793
+  timestamp: 1725267947069
+- conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+  sha256: cad153608b81fb24fc8c509357daa9ae4e49dfc535b2cb49b91e23dbd68fc3c5
+  md5: 7ed4301d437b59045be7e051a0308211
+  depends:
+  - __osx >=10.13
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 134188
+  timestamp: 1720974491916
+- conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.3-hf13058a_1.conda
+  sha256: 37c031f91bb4c7ebec248e283c453b24840764fb53b640768780dcd904093f17
+  md5: 7d8083876d71fe1316fc18369ee0dc58
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 184403
+  timestamp: 1732447223773
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.8.30-h8857fd0_0.conda
+  sha256: 593f302d0f44c2c771e1614ee6d56fffdc7d616e6f187669c8b0e34ffce3e1ae
+  md5: b7e5424e7f06547a903d28e4651dbb21
+  license: ISC
+  size: 158665
+  timestamp: 1725019059295
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.1-py311h137bacd_0.conda
+  sha256: 012ee7b1ed4f9b0490d6e90c72decf148d7575173c7eaf851cd87fd434d2cacc
+  md5: a4b0f531064fa3dd5e3afbb782ea2cd5
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 288762
+  timestamp: 1725560945833
+- conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.1-py311h4e34fa0_0.conda
+  sha256: 373e17f22bca3e13aac2245bb0c8a15c4a54d1ffa4c3278308eeb8d3c9435c0e
+  md5: 6bc3882064e277827934e2c6e5281661
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 255123
+  timestamp: 1731428577146
+- conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.9-py311hc356e98_0.conda
+  sha256: 12b1bcdbc226966ad328fbfc48c605e82e7f8e28f58905611a4789cbcc33a41d
+  md5: fb00506b224d15fdc3851a8c9985d4e1
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2499942
+  timestamp: 1732237016874
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.55.1-py311ha3cf9ac_0.conda
+  sha256: 65f05b0cabfa14486baef6f267ecea2c2fed56725cabe3767406c38349946000
+  md5: d482e362ac39ce9d0747e8f12968d3b8
+  depends:
+  - __osx >=10.13
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2835530
+  timestamp: 1733242278548
+- conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+  sha256: b292cf5a25f094eeb4b66e37d99a97894aafd04a5683980852a8cbddccdc8e4e
+  md5: 25152fce119320c980e5470e64834b50
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 599300
+  timestamp: 1694616137838
+- conda: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.12.1-nompi_py311h82f1de1_102.conda
+  sha256: f535bfbb313c98e6ad53c55bc7c52963f00a336625100d03967aace09d327f42
+  md5: b4470b6cac2328d45982637ae5db107e
+  depends:
+  - __osx >=10.13
+  - cached-property
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1190158
+  timestamp: 1729618122263
+- conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.3-nompi_h1607680_107.conda
+  sha256: c4bc53e88257e8e15c9966e76b890469d431a5ae44be391043e041890d5dbc3d
+  md5: 76e77282dc7b1f5ba08a4f1fb72c5208
+  depends:
+  - __osx >=10.13
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3750574
+  timestamp: 1733018945955
+- conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_1.conda
+  sha256: 2499e5ebb3efa4186d6922122224d16bac791a5c0adad5b48b2bcd1e1e2afc8d
+  md5: b6c1710105dad14d47001a339cd14da6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17727
+  timestamp: 1725302991176
+- conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.7-py311hf2f7c97_0.conda
+  sha256: 00b477bff9138ca51edd94f7b31ce9fe2cd13a1dc8768abcf037a22eccf26940
+  md5: 24b0e3e3444be9fabcc8457c409e297f
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 60398
+  timestamp: 1725459431458
+- conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+  sha256: 83b52685a4ce542772f0892a0f05764ac69d57187975579a0835ff255ae3ef9c
+  md5: d4765c524b1d91567886bde656fb514b
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1185323
+  timestamp: 1719463492984
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
+  sha256: 222ebc0a55544b9922f61e75015d02861e65b48f12113af41d48ba0814e14e4e
+  md5: 1442db8f03517834843666c422238c9b
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 224432
+  timestamp: 1701648089496
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+  sha256: e41790fc0f4089726369b3c7f813117bbc14b533e0ed8b94cf75aba252e82497
+  md5: f9d6a4c82889d5ecedec1d90eb673c55
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 290319
+  timestamp: 1657977526749
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
+  sha256: dae5921339c5d89f4bf58a95fd4e9c76270dbf7f6a94f3c5081b574905fcccf8
+  md5: 66d3c1f6dd4636216b4fca7a748d50eb
+  depends:
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 28602
+  timestamp: 1711021419744
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-25_osx64_openblas.conda
+  sha256: 1b22b5322a311a775bca637b26317645cf07e35f125cede9278c6c45db6e7105
+  md5: da0a6f87958893e1d2e2bbc7e7a6541f
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - liblapack 3.9.0 25_osx64_openblas
+  - liblapacke 3.9.0 25_osx64_openblas
+  - blas * openblas
+  - libcblas 3.9.0 25_osx64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15952
+  timestamp: 1729643159199
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h00291cd_2.conda
+  sha256: b377056470a9fb4a100aa3c51b3581aab6496ba84d21cd99bcc1d5ef0359b1b6
+  md5: 58f2c4bdd56c46cc7451596e4ae68e0b
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 67267
+  timestamp: 1725267768667
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h00291cd_2.conda
+  sha256: 4d49ea72e2f44d2d7a8be5472e4bd0bc2c6b89c55569de2c43576363a0685c0c
+  md5: 34709a1f5df44e054c4a12ab536c5459
+  depends:
+  - __osx >=10.13
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 29872
+  timestamp: 1725267807289
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h00291cd_2.conda
+  sha256: 477d236d389473413a1ccd2bec1b66b2f1d2d7d1b4a57bb56421b7b611a56cd1
+  md5: 691f0dcb36f1ae67f5c489f20ae987ea
+  depends:
+  - __osx >=10.13
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 296353
+  timestamp: 1725267822076
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-25_osx64_openblas.conda
+  sha256: b04ae297aa5396df3135514866db72845b111c92524570f923625473f11cfbe2
+  md5: ab304b75ea67f850cf7adf9156e3f62f
+  depends:
+  - libblas 3.9.0 25_osx64_openblas
+  constrains:
+  - liblapack 3.9.0 25_osx64_openblas
+  - liblapacke 3.9.0 25_osx64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15842
+  timestamp: 1729643166929
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.10.1-h58e7537_0.conda
+  sha256: 662fe145459ed58dee882e525588d1da4dcc4cbd10cfca0725d1fc3840461798
+  md5: 6c8669d8228a2bbd0283911cc6d6726e
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 402588
+  timestamp: 1726660264675
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.5-hf95d169_0.conda
+  sha256: 57e80908add715a2198559001087de014156c4b44a722add46253465ae9daa0c
+  md5: a20d4ea6839510372d1eeb8532b09acf
+  depends:
+  - __osx >=10.13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 529401
+  timestamp: 1733291621685
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.22-h00291cd_0.conda
+  sha256: 681035346974c3315685dc40898e26f65f1c00cbb0b5fd80cc2599e207a34b31
+  md5: a15785ccc62ae2a8febd299424081efb
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 70407
+  timestamp: 1728177128525
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+  sha256: dbd3c3f2eca1d21c52e4c03b21930bbce414c4592f8ce805801575b9e9256095
+  md5: 6016a8a1d0e63cac3de2c352cd40208b
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 105382
+  timestamp: 1597616576726
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+  sha256: 0d238488564a7992942aa165ff994eca540f687753b4f0998b29b4e4d030ff43
+  md5: 899db79329439820b7e8f8de41bca902
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 106663
+  timestamp: 1702146352558
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.4-h240833e_0.conda
+  sha256: d10f43d0c5df6c8cf55259bce0fe14d2377eed625956cddce06f58827d288c59
+  md5: 20307f4049a735a78a29073be1be2626
+  depends:
+  - __osx >=10.13
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 70758
+  timestamp: 1730967204736
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+  sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
+  md5: ccb34fb14960ad8b125962d3d79b31a9
+  license: MIT
+  license_family: MIT
+  size: 51348
+  timestamp: 1636488394370
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+  sha256: 4874422e567b68334705c135c17e5acdca1404de8255673ce30ad3510e00be0d
+  md5: 0b6e23a012ee7a9a5f6b244f5a92c1d5
+  depends:
+  - libgfortran5 13.2.0 h2873a65_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110106
+  timestamp: 1707328956438
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+  sha256: da3db4b947e30aec7596a3ef92200d17e774cccbbf7efc47802529a4ca5ca31b
+  md5: e4fb4d23ec2870ff3c40d10afe305aec
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1571379
+  timestamp: 1707328880361
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+  sha256: d9572fd1024adc374aae7c247d0f29fdf4b122f1e3586fe62acc18067f40d02f
+  md5: 72507f8e3961bc968af17435060b6dd6
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 579748
+  timestamp: 1694475265912
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-25_osx64_openblas.conda
+  sha256: 2a9a6143d103e7e21511cbf439521645bdd506bfabfcac9d6398dd0562c6905c
+  md5: dda0e24b4605ebbd381e48606a107bed
+  depends:
+  - libblas 3.9.0 25_osx64_openblas
+  constrains:
+  - liblapacke 3.9.0 25_osx64_openblas
+  - blas * openblas
+  - libcblas 3.9.0 25_osx64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15852
+  timestamp: 1729643174413
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.6.3-hd471939_1.conda
+  sha256: c70639ff3cb034a8e31cb081c907879b6a639bb12b0e090069a68eb69125b10e
+  md5: f9e9205fed9c664421c1c09f0b90ce6d
+  depends:
+  - __osx >=10.13
+  constrains:
+  - xz ==5.6.3=*_1
+  license: 0BSD
+  size: 103745
+  timestamp: 1733407504892
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.64.0-hc7306c3_0.conda
+  sha256: 0dcfdcf3a445d2d7de4f3b186ab0a794dc872f4ea21622f9b997be72712c027f
+  md5: ab21007194b97beade22ceb7a3f6fee5
+  depends:
+  - __osx >=10.13
+  - c-ares >=1.34.2,<2.0a0
+  - libcxx >=17
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 606663
+  timestamp: 1729572019083
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_hbf64a52_1.conda
+  sha256: cef5856952688ce9303f85f5bc62c99e8c2256b4c679f63afdfb381f222e90c7
+  md5: cd2c572c02a73b88c4d378eb31110e85
+  depends:
+  - __osx >=10.13
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - llvm-openmp >=18.1.8
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6165715
+  timestamp: 1730773348340
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.44-h4b8f8c9_0.conda
+  sha256: 12b44e58f8832798d7a5c0a7480c95e905dbd6c3558dec09739062411f9e08d1
+  md5: f32ac2c8dd390dbf169f550887ed09d9
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 268073
+  timestamp: 1726234803010
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
+  sha256: d3975cfe60e81072666da8c76b993af018cf2e73fe55acba2b5ba0928efaccf5
+  md5: 6af4b059e26492da6013e79cbcb4d069
+  depends:
+  - __osx >=10.13
+  license: ISC
+  size: 210249
+  timestamp: 1716828641383
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.0-h2f8c449_1.conda
+  sha256: a0f7381c867898a45018b1e5cf1aca68659d292d58252e8f489a4270b010fed8
+  md5: af445c495253a871c3d809e1199bb12b
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 915300
+  timestamp: 1730208101739
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-h3dc7d44_0.conda
+  sha256: ef2a81c9a15080b996a37f0e1712881da90a710b234e63d8539d69892353de90
+  md5: b1caec4561059e43a5d056684c5a2de0
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 283874
+  timestamp: 1732349525684
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-hf4bdac2_2.conda
+  sha256: dba23d6c9c1df6092e894b69d53fcdb78cdd10eab8e1b57f040de91a8beed908
+  md5: 99a4153a4ee19d4902c0c08bfae4cdb4
+  depends:
+  - __osx >=10.13
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=18
+  - libdeflate >=1.22,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 399202
+  timestamp: 1733443156315
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
+  sha256: 7bafd8f4c637778cd0aa390bf3a894feef0e1fcf6ea6000c7ffc25c4c5a65538
+  md5: b2c0047ea73819d992484faacbbe1c24
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 355099
+  timestamp: 1713200298965
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+  sha256: 8896cd5deff6f57d102734f3e672bc17120613647288f9122bec69098e839af7
+  md5: bbeca862892e2898bdb45792a61c4afc
+  depends:
+  - __osx >=10.13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 323770
+  timestamp: 1727278927545
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+  sha256: 8412f96504fc5993a63edf1e211d042a1fd5b1d51dedec755d2058948fcced09
+  md5: 003a54a4e32b02f7355b50a837e699da
+  depends:
+  - __osx >=10.13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 57133
+  timestamp: 1727963183990
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.5-ha54dae1_0.conda
+  sha256: e4966acfed5d3358eeec2c30b9f0f51b6c3d05bca680e87a5db210963511dadb
+  md5: fc0cec628a431e2f87d09e83a3a579e1
+  depends:
+  - __osx >=10.13
+  constrains:
+  - openmp 19.1.5|19.1.5.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 305285
+  timestamp: 1733376049594
+- conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.2-py311ha3cf9ac_1.conda
+  sha256: e9965b5d4c29b17b1512035b24a7c126ed7bdb6b39103b52cae099d5bb4194a9
+  md5: 1d6596ca7c7b66215c5c0d58b3cb0dd3
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24688
+  timestamp: 1733219887972
+- conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.3-py311h19a4563_0.conda
+  sha256: bbcf29f1850cc8ab9d70d526cfa5515a2e6d4a4c259c0a04f72ffd38aadc4548
+  md5: 8c0cd76938ca846fda82d1fa9039e63a
+  depends:
+  - __osx >=10.13
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=18
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 7852415
+  timestamp: 1733176358042
+- conda: https://conda.anaconda.org/conda-forge/osx-64/mne-lsl-1.8.0-py311h4e34fa0_0.conda
+  sha256: ebb428a67edc5407d9e7c073afdbc0527e8c4aa64efb6b4a4ecf71ef594dde76
+  md5: 7b9bb186aa3d991a9c7efed6fa29b59a
+  depends:
+  - __osx >=10.13
+  - click >=8.1
+  - libcxx >=18
+  - mne-base >=1.4.2
+  - numpy >=1.21
+  - packaging
+  - pooch
+  - psutil
+  - pyqtgraph
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - qtpy
+  - scipy
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 513661
+  timestamp: 1732896193984
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
+  sha256: b0b3180039ef19502525a2abd5833c00f9624af830fd391f851934d57bffb9af
+  md5: e102bbf8a6ceeaf429deab8032fc8977
+  depends:
+  - __osx >=10.13
+  license: X11 AND BSD-3-Clause
+  size: 822066
+  timestamp: 1724658603042
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.1.3-py311h14ed71f_0.conda
+  sha256: 2ddc0acaf8602eda5e555435a37641439aa7876425fe7b40214f15dab182e5e3
+  md5: 220e4e917b6133e0cbb879c48c058adc
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8262782
+  timestamp: 1730588525361
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
+  sha256: dc9c405119b9b54f8ca5984da27ba498bd848ab4f0f580da6f293009ca5adc13
+  md5: 05a14cc9d725dd74995927968d6547e3
+  depends:
+  - libcxx >=16
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 331273
+  timestamp: 1709159538792
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hd471939_0.conda
+  sha256: ba7e068ed469d6625e32ae60e6ad893e655b6695280dadf7e065ed0b6f3b885c
+  md5: ec99d2ce0b3033a75cbad01bbc7c5b71
+  depends:
+  - __osx >=10.13
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2590683
+  timestamp: 1731378034404
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.3-py311haeb46be_1.conda
+  sha256: ad35c52521f0946caf06e19fd3dfad55f7b30e46648f96214f59d8ca2dac95ad
+  md5: ca32a9963a1b5c636b5131831ded81f3
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14864168
+  timestamp: 1726879042435
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.0.0-py311h1f68098_0.conda
+  sha256: 3826fe546e711787ce5b42e2f9176589846631945a528176da0fb61e751d3749
+  md5: ab73babea5e9a94d4f0f3c8fead83459
+  depends:
+  - __osx >=10.13
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 42126861
+  timestamp: 1729065932260
+- conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.5.1-h5273da6_0.conda
+  sha256: 5d35d13994abdc6a7dd1801f37db98e9efca5983f0479e380844264343ec8096
+  md5: 523c87f13b2f99a96295993ede863b87
+  depends:
+  - __osx >=10.13
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libsqlite >=3.47.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2840582
+  timestamp: 1733138585653
+- conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.0-py311h1314207_0.conda
+  sha256: 340d19b16a2f5b663b4f000188467831b107dcaa5b15522e172d6a27820d3b01
+  md5: 446e328d89429c077ccd74d7e9d8853e
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 512211
+  timestamp: 1729847190327
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+  sha256: 05944ca3445f31614f8c674c560bca02ff05cb51637a96f665cb2bbe496099e5
+  md5: 8bcf980d2c6b17094961198284b8e862
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 8364
+  timestamp: 1726802331537
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.3.2-py311hfbc4093_0.conda
+  sha256: 4b6729088cc2b5461b5f1cf080a400921538b52854b3ef3ef55dc3382d3dd365
+  md5: b7ae34cfc2cbd83ec8fb9783bc00df1c
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 490751
+  timestamp: 1732987367396
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.3.2-py311hfbc4093_0.conda
+  sha256: c3ceda073b0164655f16b080d9c9b9d027021e4e0142c04a029663adc8eda0ee
+  md5: 6f2fc8232ec4b6da3b7f4aac21eaaa3b
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 10.3.2.*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 381731
+  timestamp: 1733168922676
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.6.1-py311h50e4d0a_10.conda
+  sha256: dde6b51b0b6093573a16034daedf8d908c1181ecc4c1fbec7479ab61401a5c19
+  md5: 7b1a044902592d7925924b587aef244b
+  depends:
+  - __osx >=10.13
+  - certifi
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 498830
+  timestamp: 1726679935783
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.11-h9ccd52b_1_cpython.conda
+  sha256: 4c53c4c48a0f42577ae405553ab899b3ef5ee23b2a1bf4fbbc694c46f884f6fc
+  md5: 9b20fb7c571405d29f33ae2fc5990d8d
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.4.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 14221518
+  timestamp: 1733409959819
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
+  sha256: 9b092850a268aca99600b724bae849f51209ecd5628e609b4699debc59ff1945
+  md5: e6d62858c06df0be0e6255c753d74787
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6303
+  timestamp: 1723823062672
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311h3336109_1.conda
+  sha256: d8f4513c53a7c0be9f1cdb9d1af31ac85cf8a6f0e4194715e36e915c03104662
+  md5: b0132bec7165a53403dcc393ff761a9e
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 193941
+  timestamp: 1725456465818
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.2.0-py311h4d3da15_3.conda
+  sha256: 6aa664170031e36302616978404175c6ada3bd4a14c71bac826fa6a7ec15f815
+  md5: 48a614f384285254a3224d086dc84ce3
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 366412
+  timestamp: 1728642446264
+- conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+  sha256: 79d804fa6af9c750e8b09482559814ae18cd8df549ecb80a4873537a5a31e06e
+  md5: dd1ea9ff27c93db7c01a7b7656bd4ad4
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: LicenseRef-Qhull
+  size: 528122
+  timestamp: 1720814002588
+- conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+  sha256: 41e7d30a097d9b060037f0c6a2b1d4c4ae7e942c06c943d23f9d481548478568
+  md5: f17f77f2acf4d344734bda76829ce14e
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 255870
+  timestamp: 1679532707590
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.22.3-py311h3b9c2be_0.conda
+  sha256: 435d6ddb0a1625b91e83573b17fcd543ebedffc81d912cacb53d48a8cb59a861
+  md5: 19f12b2368042654dbc26036f036483b
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 329432
+  timestamp: 1733367026508
+- conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.1-py311hed734c1_1.conda
+  sha256: 2515954fe9f8202c35e9b2df6d65650f8ffcfa7dc99ed068b25968e8af5f1b23
+  md5: 22812381ffcab544161a257666f1c203
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16391177
+  timestamp: 1729481689967
+- conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.47.0-h6285a30_1.conda
+  sha256: 34eaf24c2d0b034374d7a85026650fe28e17321fa471e5c5f654b48c5cbd3c2a
+  md5: c1d1f4d014063068fd6c402cf741e317
+  depends:
+  - __osx >=10.13
+  - libsqlite 3.47.0 h2f8c449_1
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 929527
+  timestamp: 1730208118175
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+  sha256: 30412b2e9de4ff82d8c2a7e5d06a15f4f4fef1809a72138b6ccb53a33b26faf5
+  md5: bf830ba5afc507c6232d4ef0fb1a882d
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3270220
+  timestamp: 1699202389792
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.2-py311h4d7f069_0.conda
+  sha256: 5273ba307489570df61d82a6b3365b2a27862765099cf4ef3830569fa4a30f27
+  md5: 073c42a2b6b7e4219325b1f5983c7579
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 858750
+  timestamp: 1732616082798
+- conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-15.1.0-py311h1314207_1.conda
+  sha256: c0be0b59fa67c3f9915d3dcd77d972656b9966b4516b3c044efe350860f7e054
+  md5: 574fd9b8168c1b109003c3c431c0bb7e
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 363667
+  timestamp: 1729704694220
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h00291cd_1.conda
+  sha256: 96177823ec38336b0f4b7e7c2413da61f8d008d800cc4a5b8ad21f9128fb7de0
+  md5: c6cc91149a08402bbb313c5dc0142567
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 13176
+  timestamp: 1727034772877
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
+  sha256: bb4d1ef9cafef535494adf9296130b6193b3a44375883185b5167de03eb1ac7f
+  md5: 9f438e1b6f4e73fd9e6d78bfe7c36743
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 18465
+  timestamp: 1727794980957
+- conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+  sha256: 5301417e2c8dea45b401ffee8df3957d2447d4ce80c83c5ff151fc6bfe1c4148
+  md5: d7e08fcf8259d742156188e8762b4d20
+  license: MIT
+  license_family: MIT
+  size: 84237
+  timestamp: 1641347062780
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h7130eaa_7.conda
+  sha256: b932dce8c9de9a8ffbf0db0365d29677636e599f7763ca51e554c43a0c5f8389
+  md5: 6a0a76cd2b3d575e1b7aaeb283b9c3ed
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.3,<1.22.0a0
+  - libcxx >=18
+  - libsodium >=1.0.20,<1.0.21.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 292112
+  timestamp: 1731585246902
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py311hdf6fcd6_1.conda
+  sha256: d9bf977b620750049eb60fffca299a701342a2df59bcc2586a79b2f7c5783fa1
+  md5: 4fc42d6f85a21b09ee6477f456554df3
+  depends:
+  - __osx >=10.13
+  - cffi >=1.11
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411350
+  timestamp: 1725305723486
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
+  sha256: efa04a98cb149643fa54c4dad5a0179e36a5fbc88427ea0eec88ceed87fd0f96
+  md5: 4cb2cd56f039b129bb0e491c1164167e
+  depends:
+  - __osx >=10.9
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 498900
+  timestamp: 1714723303098
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311h460d6c5_5.conda
+  sha256: 6eabd1bcefc235b7943688d865519577d7668a2f4dc3a24ee34d81eb4bfe77d1
+  md5: 1e8260965552c6ec86453b7d15a598de
+  depends:
+  - __osx >=11.0
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 33008
+  timestamp: 1725356833036
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hd74edd7_2.conda
+  sha256: a086f36ff68d6e30da625e910547f6211385246fb2474b144ac8c47c32254576
+  md5: 215e3dc8f2f837906d066e7f01aa77c0
+  depends:
+  - __osx >=11.0
+  - brotli-bin 1.1.0 hd74edd7_2
+  - libbrotlidec 1.1.0 hd74edd7_2
+  - libbrotlienc 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 19588
+  timestamp: 1725268044856
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hd74edd7_2.conda
+  sha256: 28f1af63b49fddf58084fb94e5512ad46e9c453eb4be1d97449c67059e5b0680
+  md5: b8512db2145dc3ae8d86cdc21a8d421e
+  depends:
+  - __osx >=11.0
+  - libbrotlidec 1.1.0 hd74edd7_2
+  - libbrotlienc 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 16772
+  timestamp: 1725268026061
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311h3f08180_2.conda
+  sha256: f507d65e740777a629ceacb062c768829ab76fde01446b191699a734521ecaad
+  md5: c8793a23206344faa25f4e0b5d0e7908
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 339584
+  timestamp: 1725268241628
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+  sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
+  md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
+  depends:
+  - __osx >=11.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 122909
+  timestamp: 1720974522888
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.3-h5505292_1.conda
+  sha256: 6dfa83cbd9acc8671d439fe9c745a5716faf6cbadf2f1e18c841bcf86cbba5f2
+  md5: fb72102e8a8f9bcd38e40af09ff41c42
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 179318
+  timestamp: 1732447193278
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
+  sha256: 2db1733f4b644575dbbdd7994a8f338e6ef937f5ebdb74acd557e9dda0211709
+  md5: 40dec13fd8348dbe303e57be74bd3d35
+  license: ISC
+  size: 158482
+  timestamp: 1725019034582
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py311h3a79f62_0.conda
+  sha256: 253605b305cc4548b8f97eb7c2e146697e0c7672b099c4862ec5ca7e8e995307
+  md5: a42272c5dbb6ffbc1a5af70f24c7b448
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 288211
+  timestamp: 1725560745212
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.1-py311h210dab8_0.conda
+  sha256: 8e755206b38a6e14861c79a74b51af76124bdf5c266dd6a584305e03d37c2e0c
+  md5: 7f9e9df2d62cf69aed450f6957a23e61
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 247202
+  timestamp: 1731428753912
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.9-py311h155a34a_0.conda
+  sha256: 880c3de00402d6c5d61d3f64af9ecad8022f272225e3ae62fa8e9c4885b7f0e5
+  md5: d619288803d5935f771f64a7924a6aad
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2531409
+  timestamp: 1732237062084
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.55.1-py311h4921393_0.conda
+  sha256: 49f1ac7c79c546437311bbe18f075d3ad19714cd627131cb2a02ca9c660debc1
+  md5: 545ea87f1c719d9d26a4c265bcd1d7d9
+  depends:
+  - __osx >=11.0
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2803365
+  timestamp: 1733242276864
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+  sha256: 791673127e037a2dc0eebe122dc4f904cb3f6e635bb888f42cbe1a76b48748d9
+  md5: e6085e516a3e304ce41a8ee08b9b89ad
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 596430
+  timestamp: 1694616332835
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.12.1-nompi_py311h0fa3d65_102.conda
+  sha256: 2e4a5673bfb6750c503edeb9dfc11bcb4fe7313a2c44377ba1dafbb7527ebe48
+  md5: 679929d14a50b8ef5efafdecc52e163e
+  depends:
+  - __osx >=11.0
+  - cached-property
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1216231
+  timestamp: 1729618649075
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.3-nompi_ha698983_107.conda
+  sha256: cf36f8853e81b2742258c7f702d3498853466edd6dfd77c3dae6569f86f4eac5
+  md5: af446c2d7aff6a664828d0c1cb3bc6b7
+  depends:
+  - __osx >=11.0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3478702
+  timestamp: 1733017931067
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py311h267d04e_1.conda
+  sha256: 736304347653ed421b13c56ba6f4f87c1d78d24cd3fa74db0db6fb70c814fa65
+  md5: 5bce88ac1bef7d47c62cb574b25891ae
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18253
+  timestamp: 1725303181400
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.7-py311h2c37856_0.conda
+  sha256: 8ffc46f6e99c95c48426cf34c033d16cde3bcf100cd74d1d74a33943a85a6ec8
+  md5: ee572d19da1346db8e78cb8e7d5d2330
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59357
+  timestamp: 1725459504453
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+  sha256: 4442f957c3c77d69d9da3521268cad5d54c9033f1a73f99cde0a3658937b159b
+  md5: c6dc8a0fdec13a0565936655c33069a1
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1155530
+  timestamp: 1719463474401
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
+  sha256: 151e0c84feb7e0747fabcc85006b8973b22f5abbc3af76a9add0b0ef0320ebe4
+  md5: 66f6c134e76fe13cce8a9ea5814b5dd5
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 211959
+  timestamp: 1701647962657
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+  sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
+  md5: de462d5aacda3b30721b512c5da4e742
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 215721
+  timestamp: 1657977558796
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
+  sha256: 896189b7b48a194c46a3556ea04943ef81cbe0498521231f8eb25816a68bc8ed
+  md5: 6f0b8e56d2e7bae12a18fc5b2cd9f310
+  depends:
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 28451
+  timestamp: 1711021498493
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-25_osxarm64_openblas.conda
+  sha256: f1fb9a11af0b2878bd8804b4c77d3733c40076218bcbdb35f575b1c0c9fddf11
+  md5: f8cf4d920ff36ce471619010eff59cac
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - blas * openblas
+  - liblapack 3.9.0 25_osxarm64_openblas
+  - liblapacke 3.9.0 25_osxarm64_openblas
+  - libcblas 3.9.0 25_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15913
+  timestamp: 1729643265495
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hd74edd7_2.conda
+  sha256: 839dacb741bdbb25e58f42088a2001b649f4f12195aeb700b5ddfca3267749e5
+  md5: d0bf1dff146b799b319ea0434b93f779
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 68426
+  timestamp: 1725267943211
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hd74edd7_2.conda
+  sha256: 6c6862eb274f21a7c0b60e5345467a12e6dda8b9af4438c66d496a2c1a538264
+  md5: 55e66e68ce55523a6811633dd1ac74e2
+  depends:
+  - __osx >=11.0
+  - libbrotlicommon 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 28378
+  timestamp: 1725267980316
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hd74edd7_2.conda
+  sha256: eeb1eb0d58b9d02bc1b98dc0a058f104ab168eb2f7d1c7bfa0570a12cfcdb7b7
+  md5: 4f3a434504c67b2c42565c0b85c1885c
+  depends:
+  - __osx >=11.0
+  - libbrotlicommon 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 279644
+  timestamp: 1725268003553
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-25_osxarm64_openblas.conda
+  sha256: d9fa5b6b11252132a3383bbf87bd2f1b9d6248bef1b7e113c2a8ae41b0376218
+  md5: 4df0fae81f0b5bf47d48c882b086da11
+  depends:
+  - libblas 3.9.0 25_osxarm64_openblas
+  constrains:
+  - blas * openblas
+  - liblapack 3.9.0 25_osxarm64_openblas
+  - liblapacke 3.9.0 25_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15837
+  timestamp: 1729643270793
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.10.1-h13a7ad3_0.conda
+  sha256: 983a977c5627f975a930542c8aabb46089ec6ea72f28d9c4d3ee8eafaf2fc25a
+  md5: d84030d0863ffe7dea00b9a807fee961
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 379948
+  timestamp: 1726660033582
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.5-ha82da77_0.conda
+  sha256: 7918cc0bb7a6554cdd3eee634c3dc414a1ab8ec49faeca1567367bb92118f9d7
+  md5: 3c7be0df28ccda1d193ea6de56dcb5ff
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 519819
+  timestamp: 1733291654212
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.22-hd74edd7_0.conda
+  sha256: 3552894ca62bebc33d05982937cda25a4fa19e56a82af2ff20944ff4c2532fda
+  md5: 2d3e3f3d8ab315748420ef58d5a3ae0f
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 54089
+  timestamp: 1728177149927
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+  sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
+  md5: 30e4362988a2623e9eb34337b83e01f9
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 96607
+  timestamp: 1597616630749
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+  sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
+  md5: 36d33e440c31857372a72137f78bacf5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 107458
+  timestamp: 1702146414478
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
+  sha256: e42ab5ace927ee7c84e3f0f7d813671e1cf3529f5f06ee5899606630498c2745
+  md5: 38d2656dd914feb0cab8c629370768bf
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 64693
+  timestamp: 1730967175868
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+  md5: 086914b672be056eb70fd4285b6783b6
+  license: MIT
+  license_family: MIT
+  size: 39020
+  timestamp: 1636488587153
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+  sha256: 44e541b4821c96b28b27fef5630883a60ce4fee91fd9c79f25a199f8f73f337b
+  md5: 4a55d9e169114b2b90d3ec4604cd7bbf
+  depends:
+  - libgfortran5 13.2.0 hf226fd6_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110233
+  timestamp: 1707330749033
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+  sha256: bafc679eedb468a86aa4636061c55966186399ee0a04b605920d208d97ac579a
+  md5: 66ac81d54e95c534ae488726c1f698ea
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 997381
+  timestamp: 1707330687590
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+  sha256: a42054eaa38e84fc1e5ab443facac4bbc9d1b6b6f23f54b7bf4f1eb687e1d993
+  md5: 3ff1e053dc3a2b8e36b9bfa4256a58d1
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 547541
+  timestamp: 1694475104253
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-25_osxarm64_openblas.conda
+  sha256: fdd742407672a9af20e70764550cf18b3ab67f12e48bf04163b90492fbc401e7
+  md5: 19bbddfec972d401838330453186108d
+  depends:
+  - libblas 3.9.0 25_osxarm64_openblas
+  constrains:
+  - blas * openblas
+  - liblapacke 3.9.0 25_osxarm64_openblas
+  - libcblas 3.9.0 25_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15823
+  timestamp: 1729643275943
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.6.3-h39f12f2_1.conda
+  sha256: d863b8257406918ffdc50ae65502f2b2d6cede29404d09a094f59509d6a0aaf1
+  md5: b2553114a7f5e20ccd02378a77d836aa
+  depends:
+  - __osx >=11.0
+  constrains:
+  - xz ==5.6.3=*_1
+  license: 0BSD
+  size: 99129
+  timestamp: 1733407496073
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
+  sha256: 00cc685824f39f51be5233b54e19f45abd60de5d8847f1a56906f8936648b72f
+  md5: 3408c02539cee5f1141f9f11450b6a51
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.34.2,<2.0a0
+  - libcxx >=17
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 566719
+  timestamp: 1729572385640
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
+  sha256: 62bb669c37a845129096f73d446cdb6bb170e4927f2fea2b661329680dbbc373
+  md5: 40803a48d947c8639da6704e9a44d3ce
+  depends:
+  - __osx >=11.0
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - llvm-openmp >=18.1.8
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4165774
+  timestamp: 1730772154295
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
+  sha256: 38f8759a3eb8060deabd4db41f0f023514d853e46ddcbd0ba21768fc4e563bb1
+  md5: fb36e93f0ea6a6f5d2b99984f34b049e
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 263385
+  timestamp: 1726234714421
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
+  sha256: fade8223e1e1004367d7101dd17261003b60aa576df6d7802191f8972f7470b1
+  md5: a7ce36e284c5faaf93c220dfc39e3abd
+  depends:
+  - __osx >=11.0
+  license: ISC
+  size: 164972
+  timestamp: 1716828607917
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.47.0-hbaaea75_1.conda
+  sha256: 5a96caa566c11e5a5ebdcdb86a0759a7fb27d3c5f42e6a0fd0d6023c1e935d9e
+  md5: 07a14fbe439eef078cc479deca321161
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 837683
+  timestamp: 1730208293578
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h9cc3647_0.conda
+  sha256: f7047c6ed44bcaeb04432e8c74da87591940d091b0a3940c0d884b7faa8062e9
+  md5: ddc7194676c285513706e5fc64f214d7
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279028
+  timestamp: 1732349599461
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-ha962b0a_2.conda
+  sha256: d9e6835fd189b85eb90dbfdcc51f5375decbf5bb53130042f49bbd6bfb0b24be
+  md5: 8e14b5225c593f099a21971568e6d7b4
+  depends:
+  - __osx >=11.0
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=18
+  - libdeflate >=1.22,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 370387
+  timestamp: 1733443310502
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+  sha256: 0d4bad713a512d79bfeb4d61821f447afab8b0792aca823f505ce6b195e9fde5
+  md5: c0af0edfebe780b19940e94871f1a765
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 287750
+  timestamp: 1713200194013
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+  sha256: bd3816218924b1e43b275863e21a3e13a5db4a6da74cca8e60bc3c213eb62f71
+  md5: af523aae2eca6dfa1c8eec693f5b9a79
+  depends:
+  - __osx >=11.0
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 323658
+  timestamp: 1727278733917
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
+  md5: 369964e85dc26bfe78f41399b366c435
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 46438
+  timestamp: 1727963202283
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.5-hdb05f8b_0.conda
+  sha256: e7ba0d8b718925efdcf1309f5e776e3264cc172d3af8d4048b39627c50a1abc0
+  md5: f2c2e187a1d2637d282e34dc92021a70
+  depends:
+  - __osx >=11.0
+  constrains:
+  - openmp 19.1.5|19.1.5.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 281120
+  timestamp: 1733376089600
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py311h4921393_1.conda
+  sha256: 4f738a7c80e34e5e5d558e946b06d08e7c40e3cc4bdf08140bf782c359845501
+  md5: 249e2f6f5393bb6b36b3d3a3eebdcdf9
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24976
+  timestamp: 1733219849253
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.9.3-py311h031da69_0.conda
+  sha256: cc8a4f695d1679d55c39ed917d5ca6dc1b8a86ddb801b339c1f91e71d5f3cfe4
+  md5: 7def9f5bdc783a319c7b1304bd6144b7
+  depends:
+  - __osx >=11.0
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=18
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 7821688
+  timestamp: 1733176518004
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mne-lsl-1.8.0-py311h210dab8_0.conda
+  sha256: e391223659079c9a1dd997165f83b7f7bfd9f368b0ba0554e55464c16f82d211
+  md5: 80c914d4d7ea1c5f2fc10d8015416d81
+  depends:
+  - __osx >=11.0
+  - click >=8.1
+  - libcxx >=18
+  - mne-base >=1.4.2
+  - numpy >=1.21
+  - packaging
+  - pooch
+  - psutil
+  - pyqtgraph
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - qtpy
+  - scipy
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 500365
+  timestamp: 1732896373122
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+  sha256: 27d0b9ff78ad46e1f3a6c96c479ab44beda5f96def88e2fe626e0a49429d8afc
+  md5: cb2b0ea909b97b3d70cd3921d1445e1a
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  size: 802321
+  timestamp: 1724658775723
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.3-py311h649a571_0.conda
+  sha256: 5a95da4a8de64fb44b0045c92f579d3529b2cccbd5a38ec7901e03ee10f707d5
+  md5: 3205b87adf34406ae1a83e8bf46cd987
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7041966
+  timestamp: 1730588523973
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
+  sha256: 472d6eaffc1996e6af35ec8e91c967f472a536a470079bfa56383cc0dbf4d463
+  md5: 5029846003f0bc14414b9128a1f7c84b
+  depends:
+  - libcxx >=16
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 316603
+  timestamp: 1709159627299
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h39f12f2_0.conda
+  sha256: bd1d58ced46e75efa3b842c61642fd12272c69e9fe4d7261078bc082153a1d53
+  md5: df307bbc703324722df0293c9ca2e418
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2935176
+  timestamp: 1731377561525
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py311h9cb3ce9_1.conda
+  sha256: 0a08027b25e4f6034d7733c7366f44283246d61cb82d1721f8789d50ebfef287
+  md5: 9ffa9dee175c76e68ea5de5aa1168d83
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14807397
+  timestamp: 1726879116250
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.0.0-py311h3894ae9_0.conda
+  sha256: 6d5307fed000e6b72b98d54dd1fea7b155f9a6453476a937522b89dde7b3d673
+  md5: a9a4adae1c4178f50ac3d1fd5d64bb85
+  depends:
+  - __osx >=11.0
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 41856994
+  timestamp: 1729066060042
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.5.1-h1318a7e_0.conda
+  sha256: c6289d6f1a13f28ff3754ac0cb2553f7e7bc4a3102291115f62a04995d0421eb
+  md5: 5eb42e77ae79b46fabcb0f6f6d130763
+  depends:
+  - __osx >=11.0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libsqlite >=3.47.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2673401
+  timestamp: 1733138376056
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py311hae2e1ce_0.conda
+  sha256: 6237f04371995fa8e8f16481dcd4e01d2733a82750180a362a9f4953ffbb3cde
+  md5: e226eba0c52ecd6786e73c8ad7f41e79
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 514316
+  timestamp: 1729847396776
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+  sha256: 8ed65e17fbb0ca944bfb8093b60086e3f9dd678c3448b5de212017394c247ee3
+  md5: 415816daf82e0b23a736a069a75e9da7
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 8381
+  timestamp: 1726802424786
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.3.2-py311hab620ed_0.conda
+  sha256: b3990d45325f4d2716d933b1fff821b69b530889d138d6caa246a3ef3d5aaf51
+  md5: 6968e48654cd85960526f4e6ed24996c
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 479023
+  timestamp: 1732987380000
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.3.2-py311hab620ed_0.conda
+  sha256: eaa25ed388d010b298baa11dc62aebf37bb2d8e655b2f8ad0d5df0d1dde25dfd
+  md5: b8302e3047685d0c0721fb65e50039da
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 10.3.2.*
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 384939
+  timestamp: 1733168978481
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.6.1-py311hb4b81e0_10.conda
+  sha256: 8091e5c23915e65d79b3cefcd71deae71c984eb91e46375720a9e09e5ed4e15e
+  md5: 4ef8c617785e130180c0b980b864bb46
+  depends:
+  - __osx >=11.0
+  - certifi
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 503136
+  timestamp: 1726679978805
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.11-hc22306f_1_cpython.conda
+  sha256: 94e198f6a5affa1431401fca7e3b27fda68c59f5ee726083288bff1f6bed8c7f
+  md5: 8d81dcd0be5bdcdd98e0f2482bf63784
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.4.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 14647146
+  timestamp: 1733409012105
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
+  sha256: adc05729b7e0aca7b436e60a86f10822a92185dfcb48d66d6444e3629d3a1f6a
+  md5: 3b855e3734344134cb56c410f729c340
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6308
+  timestamp: 1723823096865
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h460d6c5_1.conda
+  sha256: 9ae182eef4e96a7c2f46cc9add19496276612663e17429500432631dce31a831
+  md5: d32590e7bd388f18b036c6fc402a0cb1
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 192321
+  timestamp: 1725456528007
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.0-py311h730b646_3.conda
+  sha256: 7e75589d9c3723ecf314435f15a7b486cebafa89ebf00bb616354e37587dc7ae
+  md5: b6f3e527de0c0384cd78cfa779bd6ddf
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365841
+  timestamp: 1728642472021
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+  sha256: 873ac689484262a51fd79bc6103c1a1bedbf524924d7f0088fb80703042805e4
+  md5: 6483b1f59526e05d7d894e466b5b6924
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: LicenseRef-Qhull
+  size: 516376
+  timestamp: 1720814307311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+  sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
+  md5: 8cbb776a2f641b943d413b3e19df71f4
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 250351
+  timestamp: 1679532511311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.22.3-py311h3ff9189_0.conda
+  sha256: 8b1e693f3bb84f1152858bba9e15a6717cad02f70b45df3538078c22e67f5a06
+  md5: 16669f8098b2f4a8560727efb9e65afd
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 324661
+  timestamp: 1733366968758
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.1-py311hf1db568_1.conda
+  sha256: 082a72e5f197aefb59e9f40176df835407e5f71ec832541ba14d4326d3686552
+  md5: 1163490da89fd85d00d29b4d4be7cf0c
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15242433
+  timestamp: 1729481958579
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.47.0-hcd14bea_1.conda
+  sha256: f9975914a78d600182ec68c963a98c6c0a07eda9b9eee7d6e8bdac9310858ad2
+  md5: ca42c22ab1d212895e58fee9ba32875f
+  depends:
+  - __osx >=11.0
+  - libsqlite 3.47.0 hbaaea75_1
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 840459
+  timestamp: 1730208324005
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+  sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
+  md5: b50a57ba89c32b62428b71a875291c9b
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3145523
+  timestamp: 1699202432999
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.2-py311h917b07b_0.conda
+  sha256: 80b79a7d4ed8e16019b8c634cca66935d18fc98be358c76a6ead8c611306ee14
+  md5: 183b74c576dc7f920dae168997dbd1dd
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 858954
+  timestamp: 1732616142626
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-15.1.0-py311hae2e1ce_1.conda
+  sha256: e4b1dcf79f4d4656e538ba24c845350b147d0d9f066771f8b3f396bea828b965
+  md5: ade7687026adce6296650b21e7463758
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 372655
+  timestamp: 1729704815727
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
+  sha256: 7113618021cf6c80831a429b2ebb9d639f3c43cf7fe2257d235dc6ae0ab43289
+  md5: 7e0125f8fb619620a0011dc9297e2493
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 13515
+  timestamp: 1727034783560
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+  sha256: 9939a166d780700d81023546759102b33fdc2c5f11ef09f5f66c77210fd334c8
+  md5: 77c447f48cab5d3a15ac224edb86a968
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 18487
+  timestamp: 1727795205022
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+  sha256: 93181a04ba8cfecfdfb162fc958436d868cc37db504c58078eab4c1a3e57fbb7
+  md5: 4bb3f014845110883a3c5ee811fd84b4
+  license: MIT
+  license_family: MIT
+  size: 88016
+  timestamp: 1641347076660
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-hc1bb282_7.conda
+  sha256: 9e585569fe2e7d3bea71972cd4b9f06b1a7ab8fa7c5139f92a31cbceecf25a8a
+  md5: f7e6b65943cb73bce0143737fded08f1
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libcxx >=18
+  - libsodium >=1.0.20,<1.0.21.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 281565
+  timestamp: 1731585108039
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py311ha60cc69_1.conda
+  sha256: d2f2f1a408e2353fc61d2bf064313270be2260ee212fe827dcf3cfd3754f1354
+  md5: 29d320d6450b2948740a9be3761b2e9d
+  depends:
+  - __osx >=11.0
+  - cffi >=1.11
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 332271
+  timestamp: 1725305847224
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+  sha256: 2d4fd1ff7ee79cd954ca8e81abf11d9d49954dd1fef80f27289e2402ae9c2e09
+  md5: d96942c06c3e84bfcc5efb038724a7fd
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 405089
+  timestamp: 1714723101397
+- conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
+  sha256: 1a62cd1f215fe0902e7004089693a78347a30ad687781dfda2289cab000e652d
+  md5: 37e16618af5c4851a3f3d66dd0e11141
+  depends:
+  - libgomp >=7.5.0
+  - libwinpthread >=12.0.0.r2.ggc561118da
+  constrains:
+  - openmp_impl 9999
+  - msys2-conda-epoch <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49468
+  timestamp: 1718213032772
+- conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311he736701_5.conda
+  sha256: 8bbce5e61e012a06e248f58bb675fdc82ba2900c78590696d185150fb9cea91f
+  md5: 8917bf795c40ec1839ed9d0ab3ad9735
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 34883
+  timestamp: 1725357113431
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-h2466b09_2.conda
+  sha256: d8fd7d1b446706776117d2dcad1c0289b9f5e1521cb13405173bad38568dd252
+  md5: 378f1c9421775dfe644731cb121c8979
+  depends:
+  - brotli-bin 1.1.0 h2466b09_2
+  - libbrotlidec 1.1.0 h2466b09_2
+  - libbrotlienc 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 19697
+  timestamp: 1725268293988
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-h2466b09_2.conda
+  sha256: f3bf2893613540ac256c68f211861c4de618d96291719e32178d894114ac2bc2
+  md5: d22534a9be5771fc58eb7564947f669d
+  depends:
+  - libbrotlidec 1.1.0 h2466b09_2
+  - libbrotlienc 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 20837
+  timestamp: 1725268270219
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311hda3d55a_2.conda
+  sha256: aa3ac5dbf63db2f145235708973c626c2189ee4040d769fdf0076286fa45dc26
+  md5: a0ea2839841a06740a1c110ba3317b42
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  license: MIT
+  license_family: MIT
+  size: 322114
+  timestamp: 1725268368720
+- conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+  sha256: 35a5dad92e88fdd7fc405e864ec239486f4f31eec229e31686e61a140a8e573b
+  md5: 276e7ffe9ffe39688abc665ef0f45596
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 54927
+  timestamp: 1720974860185
+- conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
+  sha256: 0fcac3a7ffcc556649e034a1802aedf795e64227eaa7194d207b01eaf26454c4
+  md5: 4c4fd67c18619be5aa65dc5b6c72e490
+  license: ISC
+  size: 158773
+  timestamp: 1725019107649
+- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py311he736701_0.conda
+  sha256: 9689fbd8a31fdf273f826601e90146006f6631619767a67955048c7ad7798a1d
+  md5: e1c69be23bd05471a6c623e91680ad59
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 297627
+  timestamp: 1725561079708
+- conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.1-py311h3257749_0.conda
+  sha256: dbb0c161dd75e72e66c13f31715941adb094a45471016f89d6a1cfab30967ba8
+  md5: 91d8504588e1b3c77e605503e5a1bc11
+  depends:
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 216693
+  timestamp: 1731429286140
+- conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.9-py311hda3d55a_0.conda
+  sha256: 04db57c1b8fa22d17399c8df03e0d62b365a1315318b59009980672762a6ed87
+  md5: 0f21eefbe9b04632c4e0e17636be84d3
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 3623627
+  timestamp: 1732237179740
+- conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.55.1-py311h5082efb_0.conda
+  sha256: 8b8b119d0e33998326d0cd67ff191ed61ab34e17937970fc40cd23156a88b8d1
+  md5: 4d05b5fd390be4220d5820e1d98bd870
+  depends:
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - unicodedata2 >=15.1.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 2504673
+  timestamp: 1733242460211
+- conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+  sha256: 2c53ee8879e05e149a9e525481d36adfd660a6abda26fd731376fa64ff03e728
+  md5: 3761b23693f768dc75a8fd0a73ca053f
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-only OR FTL
+  size: 510306
+  timestamp: 1694616398888
+- conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.12.1-nompi_py311h67016bb_102.conda
+  sha256: 5ca110b4264f7b9567662d11fd17bb11909a012dc2da8b3fe36b255df9aac824
+  md5: cc84ef5211329e067d485f3e36bc54be
+  depends:
+  - cached-property
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1115485
+  timestamp: 1729618324428
+- conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_hd5d9e70_107.conda
+  sha256: bc06fa5d7c6e272b0d03632be2b69509705c72632fbcc4cd86017e8edcfa6af3
+  md5: 2fe16003742cbb2765462fdadadfe9d1
+  depends:
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2045376
+  timestamp: 1733017969370
+- conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+  sha256: 0fd2b0b84c854029041b0ede8f4c2369242ee92acc0092f8407b1fe9238a8209
+  md5: 2d89243bfb53652c182a7c73182cce4f
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 1852356
+  timestamp: 1723739573141
+- conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_1.conda
+  sha256: 9a667eeae67936e710ff69ee7ce0e784d6052eeba9670b268c565a55178098c4
+  md5: 943f7fab631e12750641efd7279a268c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42891
+  timestamp: 1725303340467
+- conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.7-py311h3257749_0.conda
+  sha256: a2079e13d1345a5dd61df6be933e828e805051256e7260009ba93fce55aebd75
+  md5: 18fd1ac3d79a8d6550eaea5ceaa00036
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55867
+  timestamp: 1725459681416
+- conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+  sha256: 18e8b3430d7d232dad132f574268f56b3eb1a19431d6d5de8c53c29e6c18fa81
+  md5: 31aec030344e962fbd7dbbbbd68e60a9
+  depends:
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 712034
+  timestamp: 1719463874284
+- conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
+  sha256: f9fd9e80e46358a57d9bb97b1e37a03da4022143b019aa3c4476d8a7795de290
+  md5: d3592435917b62a8becff3a60db674f6
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 507632
+  timestamp: 1701648249706
+- conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+  sha256: f4f39d7f6a2f9b407f8fb567a6c25755270421731d70f0ff331f5de4fa367488
+  md5: 1900cb3cab5055833cfddb0ba233b074
+  depends:
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30037
+  license: Apache-2.0
+  license_family: Apache
+  size: 194365
+  timestamp: 1657977692274
+- conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
+  sha256: f5c293d3cfc00f71dfdb64bd65ab53625565f8778fc2d5790575bef238976ebf
+  md5: 8723000f6ffdbdaef16025f0a01b64c5
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 32567
+  timestamp: 1711021603471
+- conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_mkl.conda
+  sha256: 5468bb91c44b41ce060bbd997c797b2f91e2b7ce91a7cbf4ddf7e7b734a8dc98
+  md5: 499208e81242efb6e5abc7366c91c816
+  depends:
+  - mkl 2024.2.2 h66d3029_14
+  constrains:
+  - blas * mkl
+  - libcblas 3.9.0 25_win64_mkl
+  - liblapack 3.9.0 25_win64_mkl
+  - liblapacke 3.9.0 25_win64_mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3736641
+  timestamp: 1729643534444
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-h2466b09_2.conda
+  sha256: 33e8851c6cc8e2d93059792cd65445bfe6be47e4782f826f01593898ec95764c
+  md5: f7dc9a8f21d74eab46456df301da2972
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 70526
+  timestamp: 1725268159739
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-h2466b09_2.conda
+  sha256: 234fc92f4c4f1cf22f6464b2b15bfc872fa583c74bf3ab9539ff38892c43612f
+  md5: 9bae75ce723fa34e98e239d21d752a7e
+  depends:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 32685
+  timestamp: 1725268208844
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-h2466b09_2.conda
+  sha256: 3d0dd7ef505962f107b7ea8f894e0b3dd01bf46852b362c8a7fc136b039bc9e1
+  md5: 85741a24d97954a991e55e34bc55990b
+  depends:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 245929
+  timestamp: 1725268238259
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_mkl.conda
+  sha256: 21528cdfe67dafdb2d21925515a167f13963e002c2b6d06d68984767f731850c
+  md5: 3ed189ba03a9888a8013aaee0d67c49d
+  depends:
+  - libblas 3.9.0 25_win64_mkl
+  constrains:
+  - blas * mkl
+  - liblapack 3.9.0 25_win64_mkl
+  - liblapacke 3.9.0 25_win64_mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3732258
+  timestamp: 1729643561581
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
+  sha256: dfbac497c4fee74f67391f9c4a40cab559468b7d04ff9fad4b404a26b5e1d5b8
+  md5: 7ead800e22ff7b4bccb73e42a8f7a0f4
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: curl
+  license_family: MIT
+  size: 342388
+  timestamp: 1726660508261
+- conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.22-h2466b09_0.conda
+  sha256: 579c634b7de8869cb1d76eccd4c032dc275d5a017212128502ea4dc828a5b361
+  md5: a3439ce12d4e3cd887270d9436f9a4c8
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 155506
+  timestamp: 1728177485361
+- conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.4-he0c23c2_0.conda
+  sha256: 0c0447bf20d1013d5603499de93a16b6faa92d7ead870d96305c0f065b6a5a12
+  md5: eb383771c680aa792feb529eaf9df82f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 139068
+  timestamp: 1730967442102
+- conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+  sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
+  md5: 2c96d1b6915b408893f9472569dee135
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 42063
+  timestamp: 1636489106777
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-14.2.0-h1383e82_1.conda
+  sha256: ef840e797714440bb10b69446d815966fff41fdac79f79c4e19c475d81cd375d
+  md5: 75fdd34824997a0f9950a703b15d8ac5
+  depends:
+  - _openmp_mutex >=4.5
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - libgcc-ng ==14.2.0=*_1
+  - libgomp 14.2.0 h1383e82_1
+  - msys2-conda-epoch <0.0a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 666386
+  timestamp: 1729089506769
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-14.2.0-h1383e82_1.conda
+  sha256: d8739b834608f35775209b032f0c2be752ef187863c7ec847afcebe2f681be4e
+  md5: 9e2d4d1214df6f21cba12f6eff4972f9
+  depends:
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - msys2-conda-epoch <0.0a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 524249
+  timestamp: 1729089441747
+- conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.2-default_ha69328c_1001.conda
+  sha256: 850e255997f538d5fb6ed651321141155a33bb781d43d326fc4ff62114dd2842
+  md5: b87a0ac5ab6495d8225db5dc72dd21cd
+  depends:
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - libxml2 >=2.13.4,<2.14.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2390021
+  timestamp: 1731375651179
+- conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+  sha256: 5f844dd19b046d43174ad80c6ea75b5d504020e3b63cfbc4ace97b8730d35c7b
+  md5: e1eb10b1cca179f2baa3601e4efc8712
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-only
+  size: 636146
+  timestamp: 1702682547199
+- conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+  sha256: 4e7808e3098b4b4ed7e287f63bb24f9045cc4d95bfd39f0db870fc2837d74dff
+  md5: 3f1b948619c45b1ca714d60c7389092c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 822966
+  timestamp: 1694475223854
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_mkl.conda
+  sha256: 98c13a28596389539abe3f608c6fbd2826df47671f77c58a331df878c6140c53
+  md5: f716ef84564c574e8e74ae725f5d5f93
+  depends:
+  - libblas 3.9.0 25_win64_mkl
+  constrains:
+  - blas * mkl
+  - libcblas 3.9.0 25_win64_mkl
+  - liblapacke 3.9.0 25_win64_mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3736560
+  timestamp: 1729643588182
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.6.3-h2466b09_1.conda
+  sha256: 24d04bd55adfa44c421c99ce169df38cb1ad2bba5f43151bc847fc802496a1fa
+  md5: 015b9c0bd1eef60729ab577a38aaf0b5
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - xz ==5.6.3=*_1
+  license: 0BSD
+  size: 104332
+  timestamp: 1733407872569
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
+  sha256: 0d3d6ff9225f6918ac225e3839c0d91e5af1da08a4ebf59cac1bfd86018db945
+  md5: 639ac6b55a40aa5de7b8c1b4d78f9e81
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: zlib-acknowledgement
+  size: 348933
+  timestamp: 1726235196095
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+  sha256: 7bcb3edccea30f711b6be9601e083ecf4f435b9407d70fc48fbcf9e5d69a0fc6
+  md5: 198bb594f202b205c7d18b936fa4524f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: ISC
+  size: 202344
+  timestamp: 1716828757533
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.0-h2466b09_1.conda
+  sha256: 3342d6fe787f5830f7e8466d9c65c914bfd8d67220fb5673041b338cbba47afe
+  md5: 5b1f36012cc3d09c4eb9f24ad0e2c379
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 892175
+  timestamp: 1730208431651
+- conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-he619c9f_0.conda
+  sha256: 4b3256bd2b4e4b3183005d3bd8826d651eccd1a4740b70625afa2b7e7123d191
+  md5: af0cbf037dd614c34399b3b3e568c557
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 291889
+  timestamp: 1732349796504
+- conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hdefb170_2.conda
+  sha256: e297d10f0a1019e71e52fc53ceaa61b0a376bf7e0e3813318dc842e9c25de140
+  md5: 49434938b99a5ba78c9afe573d158c1e
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.22,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 979557
+  timestamp: 1733443394289
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+  sha256: d0ca51cb1de9192be9a3238e71fbcca5a535619c499c4f4c9b2ed41c14d36770
+  md5: abd61d0ab127ec5cd68f62c2969e6f34
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 274359
+  timestamp: 1713200524021
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_8.conda
+  sha256: 6d5e158813ab8d553fbb0fedd0abe7bf92970b0be3a9ddf12da0f6cbad78f506
+  md5: 03cccbba200ee0523bde1f3dad60b1f3
+  depends:
+  - ucrt
+  constrains:
+  - pthreads-win32 <0.0a0
+  - msys2-conda-epoch <0.0a0
+  license: MIT AND BSD-3-Clause-Clear
+  size: 35433
+  timestamp: 1724681489463
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
+  sha256: 08dec73df0e161c96765468847298a420933a36bc4f09b50e062df8793290737
+  md5: a69bbf778a462da324489976c84cfc8c
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - pthread-stubs
+  - ucrt >=10.0.20348.0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 1208687
+  timestamp: 1727279378819
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.5-he286e8c_1.conda
+  sha256: 084dd4dde342f13c43ee418d153ac5b2610f95be029073a15fa9dda22b130d06
+  md5: 77eaa84f90fc90643c5a0be0aa9bdd1b
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1612294
+  timestamp: 1733443909984
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+  sha256: ba945c6493449bed0e6e29883c4943817f7c79cbff52b83360f7b341277c6402
+  md5: 41fbfac52c601159df6c01f875de31b9
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 55476
+  timestamp: 1727963768015
+- conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py311h5082efb_1.conda
+  sha256: 6f756e13ccf1a521d3960bd3cadddf564e013e210eaeced411c5259f070da08e
+  md5: c1f2ddad665323278952a453912dc3bd
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28238
+  timestamp: 1733220208800
+- conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.3-py311h8f1b1e4_0.conda
+  sha256: 624ca657eea90a7cbb19c49b8bbb8d8e4d6e233f6e59fd10f7032623e2a7bb21
+  md5: c6e27df155392af0f22217192f8aebdd
+  depends:
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 7841204
+  timestamp: 1733177818555
+- conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_14.conda
+  sha256: 098ba4a3cb82f627bc79dc0ab1111b44859c9ef4aaa8d75ce043bce107770cb3
+  md5: f011e7cc21918dc9d1efe0209e27fa16
+  depends:
+  - intel-openmp 2024.*
+  - tbb 2021.*
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 103019089
+  timestamp: 1727378392081
+- conda: https://conda.anaconda.org/conda-forge/win-64/mne-lsl-1.8.0-py311h3257749_0.conda
+  sha256: a4b0a080a8b1716b93cfb720d5c02b7fa98ab821d7faddad1af8e3281adfe5e1
+  md5: 57ee873271707392620be179267aded4
+  depends:
+  - click >=8.1
+  - mne-base >=1.4.2
+  - numpy >=1.21
+  - packaging
+  - pooch
+  - psutil
+  - pyqtgraph
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - qtpy
+  - scipy
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 479468
+  timestamp: 1732896583315
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.3-py311h35ffc71_0.conda
+  sha256: 09b0b580e5c4e2eb5dd1b5c44487a274a444d7cc44caced61324a65a8cfa2741
+  md5: aa627d29d5d1ed4192e70cd5a6cb1f4f
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7659216
+  timestamp: 1730588918527
+- conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
+  sha256: dda71cbe094234ab208f3552dec1f4ca6f2e614175d010808d6cb66ecf0bc753
+  md5: 7e7099ad94ac3b599808950cec30ad4e
+  depends:
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 237974
+  timestamp: 1709159764160
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.4.0-h2466b09_0.conda
+  sha256: e03045a0837e01ff5c75e9273a572553e7522290799807f918c917a9826a6484
+  md5: d0d805d9b5524a14efb51b3bff965e83
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 8491156
+  timestamp: 1731379715927
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py311hcf9f919_1.conda
+  sha256: f5477bf3a2b7919481009ce87212d7bbd16c61a5bb05c692a7c336fb45646534
+  md5: 5965b8926efba14e6fde98cc8713c083
+  depends:
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14587131
+  timestamp: 1726879538736
+- conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.0.0-py311h4fbf6a9_0.conda
+  sha256: 0d38ec638a5b266adb894f6fe4c874b46b98180a984007bf40cb030a22e8cc1e
+  md5: 44897ebc5704d3de316af26740325513
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: HPND
+  size: 42185657
+  timestamp: 1729066269713
+- conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.5.1-h4f671f6_0.conda
+  sha256: ddd0be6172e3903bc6602a93394e8051826235377c1ce8c6ba2435869794e726
+  md5: 7303dac2aa92318f319508aedab6a127
+  depends:
+  - libcurl >=8.10.1,<9.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - sqlite
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2740461
+  timestamp: 1733138695290
+- conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py311he736701_0.conda
+  sha256: 303c988247c4b1638f1cc90cd40465f5c74ca0ecfd83114033af637654dc2b6b
+  md5: 307267e6a028bca3382d98e06a372ebf
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 521434
+  timestamp: 1729847606018
+- conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
+  sha256: 7e446bafb4d692792310ed022fe284e848c6a868c861655a92435af7368bae7b
+  md5: 3c8f2573569bb816483e5cf57efbbe29
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 9389
+  timestamp: 1726802555076
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.6.1-py311h90dcb63_10.conda
+  sha256: 1211a1df2461daf499943e2f298113ab0fd72179148320609492cc5bf43bab3a
+  md5: 1105032aa8fc4803164484d2a60b3d18
+  depends:
+  - certifi
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 755087
+  timestamp: 1726680254645
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.11-h3f84c4b_1_cpython.conda
+  sha256: 5be6181ab6d655ad761490b7808584c5e78e5d7139846685b1850a8b7ef6c5df
+  md5: 4d490a426481298bdd89a502253a7fd4
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 18161635
+  timestamp: 1733408064601
+- conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-5_cp311.conda
+  sha256: 9b210e5807dd9c9ed71ff192a95f1872da597ddd10e7cefec93a922fe22e598a
+  md5: 895b873644c11ccc0ab7dba2d8513ae6
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6707
+  timestamp: 1723823225752
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-307-py311hda3d55a_3.conda
+  sha256: 78a4ede098bbc122a3dff4e0e27255e30b236101818e8f499779c89670c58cd6
+  md5: 1bc10dbe3b8d03071070c962a2bdf65f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 6023110
+  timestamp: 1728636767562
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.14-py311hda3d55a_0.conda
+  sha256: 337097e3f3b71f782c43fb702893f86f080e140da467415dcaf039a7fbb8e551
+  md5: 64553b300529aa8987f6ca92c914c844
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 210973
+  timestamp: 1729202625177
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311he736701_1.conda
+  sha256: 86608f1b4f6b1819a74b6b1344c34304745fd7e84bfc9900269f57cf28178d31
+  md5: d0c5f3c595039890be0c9af47d23b9ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 187901
+  timestamp: 1725456808581
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.2.0-py311h484c95c_3.conda
+  sha256: 4d3fc4cfac284efb83a903601586cc6ee18fb556d4bf84d3bd66af76517c463e
+  md5: 4836b00658e11b466b823216f6df2424
+  depends:
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 371084
+  timestamp: 1728642713666
+- conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+  sha256: 887d53486a37bd870da62b8fa2ebe3993f912ad04bd755e7ed7c47ced97cbaa8
+  md5: 854fbdff64b572b5c0b470f334d34c11
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LicenseRef-Qhull
+  size: 1377020
+  timestamp: 1720814433486
+- conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.22.3-py311h533ab2d_0.conda
+  sha256: c74b3a4430706dfb63176429cc31410dcb86a15e1d35463aae04733c4700b8d8
+  md5: 40c964a32833f3ad13ba4183cd180577
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 222035
+  timestamp: 1733367148577
+- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py311hf16d85f_1.conda
+  sha256: bd3c3ec5ba203143818fa3ca300060a459d78da566049b49ed2ef20e04ea5b96
+  md5: b7c132408b0ee7408dcfa998ef6f7939
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15858505
+  timestamp: 1729482598163
+- conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.47.0-h2466b09_1.conda
+  sha256: bc2a5ab86dbe2352790d1742265b3b6ae9a7aa5cf80345a37f26ec3e04cf9b4a
+  md5: 93084a590e8b7d2b62b7d5b1763d5bde
+  depends:
+  - libsqlite 3.47.0 h2466b09_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 914686
+  timestamp: 1730208443157
+- conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-h62715c5_1.conda
+  sha256: 03cc5442046485b03dd1120d0f49d35a7e522930a2ab82f275e938e17b07b302
+  md5: 9190dd0a23d925f7602f9628b3aed511
+  depends:
+  - libhwloc >=2.11.2,<2.11.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 151460
+  timestamp: 1732982860332
+- conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+  sha256: 2c4e914f521ccb2718946645108c9bd3fc3216ba69aea20c2c3cedbd8db32bb1
+  md5: fc048363eb8f03cd1737600a5d08aafe
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: TCL
+  license_family: BSD
+  size: 3503410
+  timestamp: 1699202577803
+- conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.2-py311he736701_0.conda
+  sha256: 7e313f1724e5eb7d13f7a1ebd6026a378f3f58a638ba7cdc3bd452c01323bb29
+  md5: 7e33077ce1bc0bf45c45a92e37432f16
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 859456
+  timestamp: 1732616376731
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+  sha256: db8dead3dd30fb1a032737554ce91e2819b43496a0db09927edf01c32b577450
+  md5: 6797b005cd0f439c4c5c9ac565783700
+  constrains:
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-MicrosoftWindowsSDK10
+  size: 559710
+  timestamp: 1728377334097
+- conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-15.1.0-py311he736701_1.conda
+  sha256: 07d55566e05bbadc32e989bbe50853e579fea0f8809503719d7d1438302d27be
+  md5: 6230613721d6d805d0276025ee4d7b2b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 365349
+  timestamp: 1729705070270
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_23.conda
+  sha256: 986ddaf8feec2904eac9535a7ddb7acda1a1dfb9482088fdb8129f1595181663
+  md5: 7c10ec3158d1eb4ddff7007c9101adb0
+  depends:
+  - vc14_runtime >=14.38.33135
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17479
+  timestamp: 1731710827215
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34433-he29a5d6_23.conda
+  sha256: c483b090c4251a260aba6ff3e83a307bcfb5fb24ad7ced872ab5d02971bd3a49
+  md5: 32b37d0cfa80da34548501cdc913a832
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.42.34433.* *_23
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  size: 754247
+  timestamp: 1731710681163
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hdffcdeb_23.conda
+  sha256: 568ce8151eaae256f1cef752fc78651ad7a86ff05153cc7a4740b52ae6536118
+  md5: 5c176975ca2b8366abad3c97b3cd1e83
+  depends:
+  - vc14_runtime >=14.42.34433
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17572
+  timestamp: 1731710685291
+- conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: 9df10c5b607dd30e05ba08cbd940009305c75db242476f4e845ea06008b0a283
+  md5: 1cee351bf20b830d991dbe0bc8cd7dfe
+  license: MIT
+  license_family: MIT
+  size: 1176306
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-h0e40799_1.conda
+  sha256: f44bc6f568a9697b7e1eadc2d00ef5de0fe62efcf5e27e5ecc46f81046082faf
+  md5: ca66d6f8fe86dd53664e8de5087ef6b1
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 107925
+  timestamp: 1727035280560
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.5-h0e40799_0.conda
+  sha256: 9075f98dcaa8e9957e4a3d9d30db05c7578a536950a31c200854c5c34e1edb2c
+  md5: 8393c0f7e7870b4eb45553326f81f0ff
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 69920
+  timestamp: 1727795651979
+- conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+  sha256: 4e2246383003acbad9682c7c63178e2e715ad0eb84f03a8df1fbfba455dfedc5
+  md5: adbfb9f45d1004a26763652246a33764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 63274
+  timestamp: 1641347623319
+- conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_7.conda
+  sha256: 15cc8e2162d0a33ffeb3f7b7c7883fd830c54a4b1be6a4b8c7ee1f4fef0088fb
+  md5: e03f2c245a5ee6055752465519363b1c
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 2527503
+  timestamp: 1731585151036
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py311h53056dc_1.conda
+  sha256: a93584e6167c3598854a47f3bf8276fa646a3bb4d12fcfc23a54e37d5879f35c
+  md5: 7d4c123cbb5e6293dd4dd2f8d30f0de4
+  depends:
+  - cffi >=1.11
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 321357
+  timestamp: 1725305930669
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+  sha256: 768e30dc513568491818fb068ee867c57c514b553915536da09e5d10b4ebf3c3
+  md5: 9a17230f95733c04dc40a2b1e5491d74
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 349143
+  timestamp: 1714723445995
+- pypi: https://files.pythonhosted.org/packages/07/51/e0f59b86f93e31d5c813dffbc31cf65b512a427849438189f3be8a156394/tsdownsample-0.1.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: tsdownsample
+  version: 0.1.3
+  sha256: 08ed25561d504aad77ba815e4d176efe80a37b8761a53bf77bb087e08ae8f54b
+  requires_dist: &id001
+  - numpy
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/1d/d4/9189084a953dbb83deceb1c43f4b834986b4137f0d83059e8cb049012d74/tsdownsample-0.1.3-cp311-cp311-macosx_10_12_x86_64.whl
+  name: tsdownsample
+  version: 0.1.3
+  sha256: 539bae2e1675af94c26c8eed67f1bb8ebfc72fe44fa17965fb324ef38cb9e70d
+  requires_dist: *id001
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/20/8a/767a70e04e4532c05f2b60dc817672e5bfec4911ca6655e8943eadf80670/h5io-0.2.4-py3-none-any.whl
+  name: h5io
+  version: 0.2.4
+  sha256: 5e05bf687b5ff13e431752167caf29a40c31f8f5bca73044b32d5bc8ef18b12e
+  requires_dist:
+  - numpy
+  - h5py
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/50/53/20e415e48ebd7fb7f39b369dd25734b82eae7217ff58bbf49b2a0c677743/tsdownsample-0.1.3-cp311-cp311-macosx_11_0_arm64.whl
+  name: tsdownsample
+  version: 0.1.3
+  sha256: f547ad4b796097d314fdc5538c50db8b073b110aae13e540cd8db4802b0317f6
+  requires_dist: *id001
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/66/ac/58ab1f1c86422cea13df0bf62dc0beb3d96f2c7831a4adcd49278df1f9fe/tsdownsample-0.1.3-cp311-none-win_amd64.whl
+  name: tsdownsample
+  version: 0.1.3
+  sha256: f97a858a855d7d84c96d3b89daa2237c80da8da12ff7a3a3d13e029d6c15e69d
+  requires_dist: *id001
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/bd/c7/56f50f023e19b0abd3ac93b86d64afdb58a16cca197441be9201bae367b7/pymatreader-1.0.0-py3-none-any.whl
+  name: pymatreader
+  version: 1.0.0
+  sha256: 32de9a3b25a8eee9eed5aeef2d2f8321f0a6d952620679415aeea8b0b53e0c5c
+  requires_dist:
+  - h5py
+  - numpy
+  - scipy>=1.7.1
+  - xmltodict
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/d6/45/fc303eb433e8a2a271739c98e953728422fa61a3c1f36077a49e395c972e/xmltodict-0.14.2-py2.py3-none-any.whl
+  name: xmltodict
+  version: 0.14.2
+  sha256: 20cc7d723ed729276e808f26fb6b3599f786cbc37e06c65e192ba77c40f20aac
+  requires_python: '>=3.6'

--- a/streaming_timeseries/pixi.lock
+++ b/streaming_timeseries/pixi.lock
@@ -8,7 +8,6 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
-    - url: https://conda.anaconda.org/nodefaults/
     indexes:
     - https://pypi.org/simple
     packages:

--- a/streaming_timeseries/pixi.toml
+++ b/streaming_timeseries/pixi.toml
@@ -29,9 +29,9 @@ pip = "*"
 [pypi-dependencies]
 tsdownsample = ">=0.1.3"
 mne = { version = ">=1.8.0", extras = ["hdf5"] }
-h5io = "*"
-pymatreader = "*"
-xmltodict = "*"
+h5io = "*"  # promoted from anaconda-project lock
+pymatreader = "*"  # promoted from anaconda-project lock
+xmltodict = "*"  # promoted from anaconda-project lock
 
 [tasks.lab]
 cmd = "jupyter lab streaming_timeseries.ipynb"

--- a/streaming_timeseries/pixi.toml
+++ b/streaming_timeseries/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "streaming_timeseries"
-channels = ["conda-forge", "nodefaults"]
+channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/streaming_timeseries/pixi.toml
+++ b/streaming_timeseries/pixi.toml
@@ -1,0 +1,51 @@
+[workspace]
+name = "streaming_timeseries"
+channels = ["conda-forge", "nodefaults"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2024-12-06"
+maintainers = ["droumis"]
+categories = ["Neuroscience"]
+labels = ["panel", "holoviews", "bokeh"]
+title = "Streaming Timeseries"
+description = "Streaming display of multichannel timeseries data."
+
+[dependencies]
+notebook = ">=6.5.2"
+python = "3.11.*"
+numpy = ">=2.1.3"
+panel = ">=1.4.2"
+hvplot = ">=0.10.0"
+pandas = ">=2.2.1"
+holoviews = ">=1.19.0"
+h5py = ">=3.12.1"
+mne-lsl = ">=1.8.0"
+jupyterlab = ">=4.3.2"
+pyproj = "==3.6.1"
+bokeh = ">=3.6.2"
+pip = "*"
+
+[pypi-dependencies]
+tsdownsample = ">=0.1.3"
+mne = { version = ">=1.8.0", extras = ["hdf5"] }
+h5io = "*"
+pymatreader = "*"
+xmltodict = "*"
+
+[tasks.lab]
+cmd = "jupyter lab streaming_timeseries.ipynb"
+depends-on = ["download"]
+
+[tasks.notebook]
+cmd = "jupyter notebook streaming_timeseries.ipynb"
+depends-on = ["download"]
+
+[tasks.dashboard]
+cmd = "panel serve --rest-session-info --session-history -1 streaming_timeseries.ipynb --show"
+depends-on = ["download"]
+
+[tasks.download]
+env = { FILENAME = "data/sample-ant-raw.fif" }
+cmd = "mkdir -p data && curl -fsSL -o $FILENAME https://datasets.holoviz.org/eeg_ant/v1/sample-ant-raw.fif"
+outputs = ["data/sample-ant-raw.fif"]

--- a/template/pixi.lock
+++ b/template/pixi.lock
@@ -7,640 +7,640 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
   sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
   md5: 613805add1c05b538ff06d217252feb7
   depends:
@@ -651,7 +651,7 @@ packages:
   license: BSD-3-Clause
   size: 20810
   timestamp: 1652859733309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
   sha256: 250f50edf43a786a32942e9ae67ce807e9b3ac4cb6b58b1170cb541fb24e391f
   md5: b48058294499d292ddf9a3b966dc9cc5
   depends:
@@ -665,7 +665,7 @@ packages:
   license_family: MIT
   size: 228473
   timestamp: 1706220559474
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
   sha256: 0d4f5274503916e1c683dcc16e8a7c4186557afa3f62399cd628e4eb535fe77a
   md5: 062acdb0f9ae976c25c2d15d589dc1d6
   depends:
@@ -676,7 +676,7 @@ packages:
   license_family: MIT
   size: 35809
   timestamp: 1676823571351
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
   sha256: 567dfdd5b986012421a736a5f1c1d5874d8d691dd483c838b55e1ab06c0b217d
   md5: 4e0aa1543f546b898523382ee8405e84
   depends:
@@ -685,7 +685,7 @@ packages:
   license_family: MIT
   size: 152577
   timestamp: 1695717917074
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
   sha256: 894fceb5b4f8740bcd146de8bd0f6eabf14e2407b149b790b4983b8432681e6b
   md5: 2f0ef211bf628cd22bbfa44c3f9bc035
   depends:
@@ -695,12 +695,12 @@ packages:
   license_family: MIT
   size: 271600
   timestamp: 1681493103694
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
   sha256: 9f027f156744dcbf28945aad6e422ef030c84c2a5d40116d3e40407c66853bf8
   md5: 7b52489e04f9a5585643d5578835fc68
   depends:
@@ -718,7 +718,7 @@ packages:
   license_family: BSD
   size: 6059952
   timestamp: 1712084450899
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
   sha256: 8e2b2073ff5c61d35714e8a36ce657a8ac741b7bedc2852a238c7f1625142705
   md5: d951ab54a682b6328327fec53b1e5e72
   depends:
@@ -729,7 +729,7 @@ packages:
   license_family: BSD
   size: 147642
   timestamp: 1707864274452
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
   sha256: 5d15605858771290fdaaae41a43941623757a25cb1292080d69d6d3857807935
   md5: 7f517469aa5380c52e55db9f37df104f
   depends:
@@ -740,7 +740,7 @@ packages:
   license: MIT
   size: 18652
   timestamp: 1714483267080
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
   sha256: a5094f078584e27c7cced4a9564ae904a329f5c1702a7c1ba092d581ba1544f1
   md5: 6ddf45dd8a21a9512481de9bc0e5a03f
   depends:
@@ -750,7 +750,7 @@ packages:
   license: MIT
   size: 19711
   timestamp: 1714483255915
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
   sha256: 93180c973816246f068b742d0bf64840f0ea48e31d4f9b0747ea2ffc34d8855d
   md5: f3a00096965a5ba1eb41d2c99a4662a2
   depends:
@@ -760,7 +760,7 @@ packages:
   license: MIT
   size: 361574
   timestamp: 1714483400014
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
   sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
   md5: f5058c8d5b2994b7334f18e022105a14
   depends:
@@ -769,14 +769,14 @@ packages:
   license_family: BSD
   size: 427542
   timestamp: 1714510571510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
   sha256: 394f74202c2efc8fcfd02b8953f508eb6a2961d224a2f9d15091caf5cbe1be67
   md5: 1202b4ed32215c6405bb42fbff355316
   license: MPL-2.0
   license_family: Other
   size: 137411
   timestamp: 1710764808838
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
   sha256: 6dc29d20180f6e002f37b251efa639716d3444e129a754dabf751f816aada7ef
   md5: 5dbfa083e6ab6318fac58fe0e0c94445
   depends:
@@ -785,7 +785,7 @@ packages:
   license_family: Other
   size: 165152
   timestamp: 1707229213375
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
   sha256: d138cc3fde270eba783baf1e2ba17c89800b2cbbf20976d0eb425b3436a4a184
   md5: 1875e89c1a939e4e7c5e7b731c72b838
   depends:
@@ -797,7 +797,7 @@ packages:
   license_family: MIT
   size: 302401
   timestamp: 1714483186060
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
   sha256: d9c102b9ec7f3a635936b6f73d4db126d748a25f65407353bd76b260dc7d1cd6
   md5: eec48dbdf5dac0ea26750cc26b58c1d9
   depends:
@@ -806,7 +806,7 @@ packages:
   license_family: CC
   size: 554986
   timestamp: 1709758392744
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
   sha256: 882481e441b9b93cbdfb32fbe32a6ad9f26197472f186a08fddb921f61346c02
   md5: 443c79196064f57c98199e9990544b2f
   depends:
@@ -816,7 +816,7 @@ packages:
   license_family: BSD
   size: 16902
   timestamp: 1709322958614
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
   sha256: e4877b41553e31b9f9f090dffab77a654255c63776e8b30fc91ec1f60afadbf1
   md5: c34d3f1520f1e8c9957eb236710058c4
   depends:
@@ -828,7 +828,7 @@ packages:
   license_family: BSD
   size: 281162
   timestamp: 1700583651472
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
   sha256: 3b4cd8dc60572086f1a1cbb97e2712e0ffd55317ce8f0309d552eee7367855eb
   md5: 70a1263b6e19bf2d77c020a2e77277c9
   depends:
@@ -839,7 +839,7 @@ packages:
   license_family: MIT
   size: 2556575
   timestamp: 1690905285843
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
   sha256: 4b589e3265c74159130230c164ff2d8d381be65899a249def0b53f93ce83fd47
   md5: 245cb7173dcdba21cf368031cd87f706
   depends:
@@ -848,7 +848,7 @@ packages:
   license_family: MIT
   size: 17434
   timestamp: 1676823330845
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
   sha256: b75d12e85274660bb675a3e53d47a929872f2daa2ff5a76e98885ee3f2d19ad1
   md5: f2119d0885334060d0d7fe59e5220287
   depends:
@@ -867,7 +867,7 @@ packages:
   license_family: MIT
   size: 3237908
   timestamp: 1713551660998
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
   sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
   md5: a5dc8677d891dff2393b63189a3ad42f
   depends:
@@ -878,7 +878,7 @@ packages:
   license_family: Other
   size: 971975
   timestamp: 1666798278693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
   sha256: f48ccfb4214e2af41e73a3904e343ecd1eb1ae06578c26f55a5dd247771b2c86
   md5: d58e9eb09817935eb7342ceff889f481
   depends:
@@ -895,7 +895,7 @@ packages:
   license_family: BSD
   size: 5335524
   timestamp: 1707836581350
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
   sha256: a0ae6c5a6b615d73d9a243331f3f7d749b4feafdf2f334337fda8abd6c8355ed
   md5: e61d8dcd4dfd6d165e6e480cee846bf5
   depends:
@@ -912,7 +912,7 @@ packages:
   license_family: BSD
   size: 357992
   timestamp: 1715090462763
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
   sha256: e08e27531775de40f46b6ac7bf71856963baa0c008bd2b4d112e6341cd3e8f4c
   md5: bfc7682613c861cbcb4ac01485c05657
   depends:
@@ -921,7 +921,7 @@ packages:
   license_family: BSD
   size: 147174
   timestamp: 1714398938840
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
   sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
   md5: 3add2ce56858a1b8f6a37342f82773d3
   depends:
@@ -937,7 +937,7 @@ packages:
   license_family: Proprietary
   size: 19310769
   timestamp: 1699647799237
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
   sha256: 0b670ab17ed2e1b592079bd64386dadc249ddc892e5ae1dd99f142a918ffc75d
   md5: 632575b9e442c1e5c146cf78424da610
   depends:
@@ -958,7 +958,7 @@ packages:
   license_family: BSD
   size: 227791
   timestamp: 1705934138566
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
   sha256: 65228eb868c3ec8aa71f958e60a675a919f016c2057392e02fd422fc841858f9
   md5: 68e23f14cd222c233e6b37262bc61c23
   depends:
@@ -975,7 +975,7 @@ packages:
   license_family: BSD
   size: 1612840
   timestamp: 1704833066871
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
   sha256: a2918ea8a3e2c56fc6d91191e84b2f35500c392b16ab687a0c03ded2e2e51239
   md5: 84fadd6b7fef393cccc0d123dae6cae8
   depends:
@@ -985,7 +985,7 @@ packages:
   license_family: MIT
   size: 1162207
   timestamp: 1679336523618
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
   sha256: 4520b83e425883981f97191986a08122fbaebc3f16b898368796314136779028
   md5: 42a8f32c4d842d3e5410b2bc1cc2fb57
   depends:
@@ -995,7 +995,7 @@ packages:
   license_family: BSD
   size: 352284
   timestamp: 1706733655761
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
   sha256: c21f8f407266d039e819c27fe9eb4fb26587e974f3bd059b37cbaec5073722d0
   md5: ba1f47411e9e07876c7a3e9d3be6a98e
   depends:
@@ -1004,7 +1004,7 @@ packages:
   license_family: Other
   size: 281400
   timestamp: 1677849152168
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
   sha256: 06b729aee6dd2a1e545f3ad64179cc0d4ef8a15e33db3be2995dd3e0868465ca
   md5: 8bb3215912588e47e2eeb4e7a09ad64f
   depends:
@@ -1017,7 +1017,7 @@ packages:
   license_family: MIT
   size: 180858
   timestamp: 1699041715847
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
   sha256: 9e3bac2d41bd432b721b009e7de981766fba396e6f238e923f304112bd88655a
   md5: 84ae4cf3f2d01fbebdac374971192be9
   depends:
@@ -1027,7 +1027,7 @@ packages:
   license_family: MIT
   size: 15525
   timestamp: 1699032521315
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
   sha256: 79ce6dff3d93649a2555b1d2a4ae9eb77175a1c00664cb8eb0e6f848d5cdd1b9
   md5: db395b0efd7018fcf3a4af879170c2a8
   depends:
@@ -1043,7 +1043,7 @@ packages:
   license_family: BSD
   size: 276856
   timestamp: 1676823504812
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
   sha256: fedc7e5560252af44b0dfbe6f7acfe20ab17a6a08e758f670a1cd820551afc7a
   md5: bd28d36963087f53a79b23fee697d665
   depends:
@@ -1054,7 +1054,7 @@ packages:
   license_family: BSD
   size: 93898
   timestamp: 1698937453304
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
   sha256: 2b896fe8b2187b7df824041826e14379476eb2e61d607d8cb38ac2b3df40aaa4
   md5: 8fc7e517da96c2c482331f6b08d07a17
   depends:
@@ -1070,7 +1070,7 @@ packages:
   license_family: BSD
   size: 41459
   timestamp: 1699282616532
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
   sha256: 87d372f5b23bcc2410e43b40b4ad059ea1625178b8a2b484fc63805ce517e594
   md5: 50204f372b1672871d6ab3db6a876374
   depends:
@@ -1097,7 +1097,7 @@ packages:
   license_family: BSD
   size: 594177
   timestamp: 1699467208489
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
   sha256: ddfee06ba9b149222c65d1d4270272840533aa63b56fe36363c84a891c71d328
   md5: ee128e5c0d8d9e1952e2387b66a5b8cb
   depends:
@@ -1107,7 +1107,7 @@ packages:
   license_family: BSD
   size: 27239
   timestamp: 1686870958829
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
   sha256: 0c6a074272ed58677ec17e4dbfceaffd2108841a61af92b32f156c5763108d1d
   md5: dd3d37841d0d20c70a60e8c939923894
   depends:
@@ -1119,7 +1119,7 @@ packages:
   license_family: BSD
   size: 19144
   timestamp: 1700168632051
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
   sha256: b040f0d0ee4588188ab6b83a93738b3ff6e6d1775424be97995bd0df0f4fb904
   md5: eae62735d710cf5ff6d51e6f59fcd999
   depends:
@@ -1130,7 +1130,7 @@ packages:
   license_family: BSD
   size: 78148
   timestamp: 1676827253282
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
   sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
   md5: 653b4f425f6d4a21f04619b1f5f8aa43
   depends:
@@ -1141,7 +1141,7 @@ packages:
   license_family: MIT
   size: 405739
   timestamp: 1617648674152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
   sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
   md5: 9508af80612e4fa1b5d1abb43ca7e63c
   constrains:
@@ -1149,7 +1149,7 @@ packages:
   license: GPL-3.0-only
   size: 749072
   timestamp: 1652971360657
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
   sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
   md5: 88199c75f2ac211728febced7785c24e
   depends:
@@ -1159,7 +1159,7 @@ packages:
   license_family: Apache
   size: 228278
   timestamp: 1635523146417
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
   sha256: bb990ea068c3b3dafd9c807e0e19570320cb2fe7d69cc326f1f0b5319b0654b2
   md5: 3ff70744e396b1af69656c574b05c3b9
   depends:
@@ -1167,7 +1167,7 @@ packages:
   license: MIT
   size: 66940
   timestamp: 1714483221853
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
   sha256: 3b87a816f72a00e1f0022a160e7eda70af89d3de2a2e08a72be1c17b31d759f3
   md5: 4f57d3a0a13ddaf1c06efb586b702f46
   depends:
@@ -1176,7 +1176,7 @@ packages:
   license: MIT
   size: 34446
   timestamp: 1714483232430
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
   sha256: 2cf15e89f910600f468edfde8d0f9b80a14fa2319ed89160dc7375dfd3764fdb
   md5: 463adc13f2feea3570d1eccac368d9e4
   depends:
@@ -1185,7 +1185,7 @@ packages:
   license: MIT
   size: 295090
   timestamp: 1714483244460
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
   sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
   md5: 55dde57e63a36b202e388a39dcee9a66
   depends:
@@ -1194,7 +1194,7 @@ packages:
   license_family: MIT
   size: 74096
   timestamp: 1695996494461
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
   sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
   md5: 1af9b4d62c708924417f2640ef22a68f
   depends:
@@ -1204,7 +1204,7 @@ packages:
   license_family: MIT
   size: 154016
   timestamp: 1714483282916
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
   sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
   md5: 641e72e5067bd6d5454405879e1cd2a7
   depends:
@@ -1219,7 +1219,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 8895144
   timestamp: 1654090827491
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
   sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
   md5: 3080c2813e6e1d0f8a100a38b5b3456d
   depends:
@@ -1227,7 +1227,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 573231
   timestamp: 1654090775721
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
   sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
   md5: 1bffe1481ed4f88827248fb9001f8923
   depends:
@@ -1237,7 +1237,7 @@ packages:
   license_family: Other
   size: 362561
   timestamp: 1677841789536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -1245,7 +1245,7 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
   sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
   md5: 8c195584a5f5471b600ee180e4052773
   depends:
@@ -1253,7 +1253,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 6410287
   timestamp: 1654090800863
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
   sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
   md5: ef78eebd98289aceacdfa29182426adf
   depends:
@@ -1271,7 +1271,7 @@ packages:
   license_family: Other
   size: 664034
   timestamp: 1693575237924
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
   sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
   md5: 292768ec77416ae257cfdd44ea2071c8
   depends:
@@ -1280,7 +1280,7 @@ packages:
   license_family: BSD
   size: 29197
   timestamp: 1668082729834
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
   sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
   md5: 9cdeef1d044c7e035c006890f11569d3
   depends:
@@ -1291,7 +1291,7 @@ packages:
   license_family: BSD
   size: 436056
   timestamp: 1694776944891
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
   sha256: fd8e30beb8c9442f16e6617fac92dd0c89ec823e98f06e60f712147380ead35f
   md5: 7ed7caf2816c8b85b67b6f4e8833cbd5
   depends:
@@ -1301,7 +1301,7 @@ packages:
   license_family: MIT
   size: 41155
   timestamp: 1676837080881
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
   sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
   md5: 76f089e76ec67583bb38428b51008097
   depends:
@@ -1311,7 +1311,7 @@ packages:
   license_family: BSD
   size: 164494
   timestamp: 1714510587156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
   sha256: 260e26dd509834c1b225ab7bdb97b9a86e00054fbdd5dfa49e68fa4dcf85a661
   md5: 8f5d7ddc69cc6f7d44c80d2251dea5d1
   depends:
@@ -1320,7 +1320,7 @@ packages:
   license_family: BSD
   size: 162339
   timestamp: 1676837095436
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
   sha256: 7f5b0804d0768619b7bd93b10488067d80bf42ec29f443f00b53ba11758a1241
   md5: 8afb45e45c0d93bfd142e682d4b021ef
   depends:
@@ -1330,7 +1330,7 @@ packages:
   license_family: MIT
   size: 134438
   timestamp: 1684280014220
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
   sha256: cb03570c99c983d7bfda94bc47d8eb00d4059b8548a171130775acc998004195
   md5: 5b1abbbf1e4f9b350b16fc9caf9e889b
   depends:
@@ -1342,7 +1342,7 @@ packages:
   license_family: BSD
   size: 26919
   timestamp: 1704206397615
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
   sha256: 85fea48bea278a77d102781a1cbb6bf69307207d741251e38a6515c5fd7e3523
   md5: d6ddba94f7c33c88c9825be8409991bf
   depends:
@@ -1364,7 +1364,7 @@ packages:
   license_family: PSF
   size: 9150942
   timestamp: 1713336680714
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
   sha256: 7ac07ea180b5928086075900afbc332fb1d3c81ddfacb54c891693c284056f14
   md5: fc83dd1b3d2ec3c0a297ead0c3405907
   depends:
@@ -1374,7 +1374,7 @@ packages:
   license_family: BSD
   size: 19573
   timestamp: 1676823852670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
   sha256: c9ba2f9c83820712dd97d6a1b54a1215b9820a0be02ac82380b4c50911b9400c
   md5: e5dc6b4a5b8e02733ce3bc9e9198a8d2
   depends:
@@ -1384,7 +1384,7 @@ packages:
   license_family: MIT
   size: 67750
   timestamp: 1676837123613
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
   sha256: 1a5141ef0de1cbff816f96bb4b212a40606e2fc11301a4c1358c8d63a6b2b027
   md5: 22ac3bc22b68fef4c1f3f6ab3c7bfe0b
   depends:
@@ -1393,7 +1393,7 @@ packages:
   license_family: MIT
   size: 23040
   timestamp: 1676827301164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
   sha256: 9aacfbbe6f638c58a4e8ff31374d1438d78b7db25d6ea6fd0c50ca2109f225d4
   md5: e602057e3b3d80da88c61d66e8851c5b
   depends:
@@ -1404,7 +1404,7 @@ packages:
   license_family: BSD
   size: 104681
   timestamp: 1676823696152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
   sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
   md5: ce77d0f05f846da4a6b9e23fe7f21d9b
   depends:
@@ -1418,7 +1418,7 @@ packages:
   license_family: Proprietary
   size: 206738176
   timestamp: 1699648006088
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
   sha256: 2aef0876d0df033f7fae8cddbd25d95fc1bfc067e60dd143bd8000fec0768b21
   md5: d6cdc670327bd1675bbea642849f04e1
   depends:
@@ -1429,7 +1429,7 @@ packages:
   license_family: BSD
   size: 59569
   timestamp: 1682948560323
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
   sha256: 691c4b2b47cf3fac55b4949d7c0f547246ef19cb3510749142cee4bd01ffb055
   md5: bbd69efa3f24ee747410f83118640d92
   depends:
@@ -1443,7 +1443,7 @@ packages:
   license_family: BSD
   size: 240723
   timestamp: 1695058405382
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
   sha256: 71f5c7beca4e81b465ecfc6ed51cb3d39f51dd88df0b29eff5def3d1f12969eb
   md5: 61d58663b7277cf4cc3cb8d9873d3ee8
   depends:
@@ -1458,7 +1458,7 @@ packages:
   license_family: BSD
   size: 331105
   timestamp: 1695059935112
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
   sha256: 20d832ce714465ae1685d29e2f913fd105d385d003fe1bef71ef472e6f3489e6
   md5: ad76299b0c33b7a5c0d45905271165c1
   depends:
@@ -1484,7 +1484,7 @@ packages:
   license_family: BSD
   size: 8303422
   timestamp: 1699542957307
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
   sha256: bb45fb0a3973caa74fd8f845e0a519895f6a378807626e15ecf72c02f2eed794
   md5: 185f658ba8a74e326b7231c8fd0d62bf
   depends:
@@ -1497,7 +1497,7 @@ packages:
   license_family: BSD
   size: 121834
   timestamp: 1698934274227
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
   sha256: 8b2fc372a6655fd5b277d07b994ce43643553fbc37e63a60e9fe527a9026ec06
   md5: ed6ac14aed5a796b153d757862398997
   depends:
@@ -1524,7 +1524,7 @@ packages:
   license_family: BSD
   size: 523905
   timestamp: 1699022906468
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
   sha256: 7908ff6c516b15e8fb677be4071145e18adea7d4c13b8485a70a5ee2f573f8cb
   md5: 50c0e38207a131a5de6a14ef919ffcdc
   depends:
@@ -1537,7 +1537,7 @@ packages:
   license_family: BSD
   size: 169629
   timestamp: 1694616826002
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
   sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
   md5: 57ea097dc15f8d9f9eb90e1d919143b0
   depends:
@@ -1546,7 +1546,7 @@ packages:
   license_family: MIT
   size: 1157733
   timestamp: 1674734069410
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
   sha256: 266199dd4efde0ad342a9c500f4bc4299c5622219aea623b46315a9b4f6b8959
   md5: 2b21844d2b0024d0ffad0e6450cf0855
   depends:
@@ -1555,7 +1555,7 @@ packages:
   license_family: BSD
   size: 15860
   timestamp: 1708532713870
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
   sha256: 13d6c640710895e9732225cdedbe47fcd756887fffeb0cf9bc149ee7234dfc27
   md5: a87d55e3d071f2c435b10db49a9911af
   depends:
@@ -1580,7 +1580,7 @@ packages:
   license_family: BSD
   size: 730963
   timestamp: 1690984942516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
   sha256: ef2857e6d3d7eb246b3abddfbd3aa2d124dd8565391ace3876b77339babc50bb
   md5: d276d1b1774107987963135c78ca7390
   depends:
@@ -1590,7 +1590,7 @@ packages:
   license_family: BSD
   size: 26607
   timestamp: 1699455972519
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
   sha256: 2f89f38a665ece47e8868b391fc70602fcee588e989bc1ca6f17f6094892a94e
   md5: b788c80b2d571531ea4f3f8335ae5423
   depends:
@@ -1605,7 +1605,7 @@ packages:
   license_family: MIT
   size: 168827
   timestamp: 1696515597877
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
   sha256: e09e1aff2c12d4ef3fec58fb627744e4b5c7d9eaede7175e293f77272d8b8bfd
   md5: fe8242cfd54d238507493612ae697ad4
   depends:
@@ -1622,7 +1622,7 @@ packages:
   license_family: BSD
   size: 10270
   timestamp: 1708639794640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
   sha256: a53ad723826651041a5057a1cf31bc8689b24d335ce61b196df5124974b05a8e
   md5: 7b29e7191c4170189d6080e61229f030
   depends:
@@ -1638,7 +1638,7 @@ packages:
   license_family: BSD
   size: 9163911
   timestamp: 1708639777712
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
   sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
   md5: b0afe23033c8c5344640bc25225fa579
   depends:
@@ -1649,7 +1649,7 @@ packages:
   license: BSD 2-Clause
   size: 516994
   timestamp: 1630084830020
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
   sha256: 6c7cb4097e4f3655b54a119304e50f0edbc4bd52f36c84629b64674cf8d468b8
   md5: f1e48c973646ded3c2e1a189a9d8b8c9
   depends:
@@ -1659,7 +1659,7 @@ packages:
   license_family: Apache
   size: 5498991
   timestamp: 1716318104769
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
   sha256: 280225061aeba00d7b85f46e55d7d79cd92c92f662dc749d9c53187978e8d083
   md5: c51c21da68080d89300703ad818c824a
   depends:
@@ -1668,7 +1668,7 @@ packages:
   license_family: APACHE
   size: 38606
   timestamp: 1699371264464
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
   sha256: bd3eacd22e85f88bedd9c7e97a59eacfb3c8bb80eb59be244825d6895a0e7ac1
   md5: 08ceb294ba8a9ae13630da789884736e
   depends:
@@ -1677,7 +1677,7 @@ packages:
   license_family: Apache
   size: 157904
   timestamp: 1710807470578
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
   sha256: a2ee3a6aaf54929b82b851b2eb5436e14e5a294303ef429d6dccd33bcdfc8002
   md5: b467a5c7ad672ccc2d498a67b9eeeaaa
   depends:
@@ -1728,7 +1728,7 @@ packages:
   license_family: BSD
   size: 17970687
   timestamp: 1709593080388
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
   sha256: aa05415302a27a82105e9d0800151f09fd1bb896b90854dc23989f9aecd9200b
   md5: 4974b1ae5f1a3b6d9fb26e7eb2c26733
   depends:
@@ -1752,7 +1752,7 @@ packages:
   license_family: BSD
   size: 21869200
   timestamp: 1714071532259
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
   sha256: c6c782537b96ab9caf3e25f5a33799c727e84664cdbab37a8d3359a221e2d2e3
   md5: 8f56d0f63e0589dd7e4a004678307813
   depends:
@@ -1761,7 +1761,7 @@ packages:
   license_family: BSD
   size: 263438
   timestamp: 1711136934516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
   sha256: 28ed719669260a20bec78971edaffb91ec917d2a3f0fac1cf9a8ba21590baa43
   md5: 0481d078fcd64f7f981532a514d9d50d
   depends:
@@ -1778,7 +1778,7 @@ packages:
   license_family: Other
   size: 960727
   timestamp: 1714399060039
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
   sha256: d527189038b376a982c18613df808f25dc40314b0dc8fe5549f3ae9f4288e497
   md5: 68dad015e796cc26364b55f92f61faa7
   depends:
@@ -1789,7 +1789,7 @@ packages:
   license_family: MIT
   size: 3451714
   timestamp: 1715097126399
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
   sha256: d2bbab8bfc57c7f46ca8994bc87df7e744d3f036b867bc4be1145ba6d8d7e091
   md5: de41707272a8e3ccab764f0b7010a27d
   depends:
@@ -1798,7 +1798,7 @@ packages:
   license_family: MIT
   size: 37394
   timestamp: 1692205565974
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
   sha256: e2a0e2a618aa33f0beff9583c7dc510b8d0737b023117346676aacbad33970d8
   md5: 66a6818307261b1a28ab12d1b7776fdf
   depends:
@@ -1807,7 +1807,7 @@ packages:
   license_family: Apache
   size: 121454
   timestamp: 1679340540306
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
   sha256: b7f591c19b10bf0daa7e6e3b45a9f4a0a0e83188e1f8a58037caea79e60f8d91
   md5: d945b4ccc135005839c504cc29df1745
   depends:
@@ -1819,7 +1819,7 @@ packages:
   license_family: BSD
   size: 749608
   timestamp: 1704404477511
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
   sha256: 96482b49191fdac59580a95e69508367083e1f7600145e11d7c2db634337eb26
   md5: 2d57bf8eacf3f291db845928241f724c
   depends:
@@ -1829,7 +1829,7 @@ packages:
   license_family: BSD
   size: 490805
   timestamp: 1679337420563
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
   sha256: ed927e4d058a8f4ea73edc7a43ed74877d93b88fdfa240b3b2777244386ced70
   md5: a1f0e05fc7e49712f81ad5478ec9d51e
   depends:
@@ -1838,7 +1838,7 @@ packages:
   license_family: BSD
   size: 2121496
   timestamp: 1684280065800
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
   sha256: ad219924e362ce7af458fa6547660181579e9a50e5aed1ffd9268cbe7c2650e3
   md5: 2b1ac40e0df3673d33b7f4c4f93ae1ef
   depends:
@@ -1847,7 +1847,7 @@ packages:
   license_family: MIT
   size: 207338
   timestamp: 1677811584327
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
   sha256: 114b55e00f4622c90fd2b404b21ad5f94a10283fcaaf86a42174b8d39b0a3e98
   md5: 2458e92683cc68671a6c8e1b86ce8817
   depends:
@@ -1856,7 +1856,7 @@ packages:
   license_family: BSD
   size: 35850
   timestamp: 1676822725516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
   sha256: ef622eb34669f3518d2f855cb333c56b106d02cdeac9d58e5a1a5a3097e4978d
   md5: 9d4f211d050d511b0b84c2e57e7fb1d7
   depends:
@@ -1878,7 +1878,7 @@ packages:
   license_family: PSF
   size: 36072860
   timestamp: 1713546307595
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
   sha256: a0f008717fab060ccd003dfebc09156d90b9afd14ac3626566aa1a8f3d3b7e2f
   md5: 357bf4fe94496cbae72ab4d780184b31
   depends:
@@ -1888,7 +1888,7 @@ packages:
   license_family: BSD
   size: 330924
   timestamp: 1716495762901
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
   sha256: aadc4078311c059265706a56265f0a57ceb538d36179d5203dd487d80d0e8f16
   md5: 59ec670fcd172447dbd9591b8fbfdd56
   depends:
@@ -1897,7 +1897,7 @@ packages:
   license_family: BSD
   size: 278741
   timestamp: 1679340144625
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
   sha256: d5058d0ecc3973316c1d5f1bfb03dd119e0dade85f4c2d21b412c8db4e1636f2
   md5: 93000e4d3603342779a2afda66fa91b8
   depends:
@@ -1906,7 +1906,7 @@ packages:
   license_family: BSD
   size: 17607
   timestamp: 1683823841946
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
   sha256: b85acb933fff864bfa89d034e8e3d85b1a9c2e69cbfc0d68c1d66ffd1443e67d
   md5: 0cdb92d2d684ee1095310f992ed0d9b2
   depends:
@@ -1915,7 +1915,7 @@ packages:
   license_family: MIT
   size: 266796
   timestamp: 1713974338678
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
   sha256: 511e8206a15445715b80be76493300930686b3fe1e512ae942d6ccca36df392a
   md5: 35a6e46ae970f8b71d78fb5a810f2e80
   depends:
@@ -1927,7 +1927,7 @@ packages:
   license_family: BSD
   size: 64013
   timestamp: 1711136926372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
   sha256: b2a1f649669f4336b74f6f20df711959bcd8024f8f8b94199dc0e040b06bd37a
   md5: f9e8e3f7068f717f75e555dc04545d8d
   depends:
@@ -1938,7 +1938,7 @@ packages:
   license_family: MIT
   size: 206433
   timestamp: 1698096204677
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
   sha256: 7c74db4292f31619606180f86f3c1e2d913495c2c9d1195c5d51681a6a841625
   md5: be1c05fae57d194924b9400f9b5ad3c6
   depends:
@@ -1949,7 +1949,7 @@ packages:
   license_family: Other
   size: 613277
   timestamp: 1709318516682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
   sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
   md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
   depends:
@@ -1959,7 +1959,7 @@ packages:
   license_family: GPL
   size: 467661
   timestamp: 1666648052561
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
   sha256: 89c2f4235277b9825cc805c5c44f0b1afcb683d7b5a3f513bc4bf243b643bb0c
   md5: db70eb57e33adf7b8bbdadd72214d48d
   depends:
@@ -1970,7 +1970,7 @@ packages:
   license_family: MIT
   size: 73679
   timestamp: 1699012111499
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
   sha256: 684037527327839d734e7eac2ee09ef5ddb4f77df22daf40c79e51db29d09543
   md5: 57c5bcb9eae9f1d93ccfd38025660de2
   depends:
@@ -1986,7 +1986,7 @@ packages:
   license_family: Apache
   size: 119414
   timestamp: 1707355661872
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
   sha256: fdae3f68ea84b99561aee6c566ab1c287d8f2ae2668424e9283a8ed86af8f1d2
   md5: cde5b71ccbb3630053340b2c8c7dbf10
   depends:
@@ -1996,7 +1996,7 @@ packages:
   license_family: MIT
   size: 9333
   timestamp: 1683077183576
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
   sha256: 0bf859b06a07857099fd4f524fe5e0875fda70029e9485d95c7efa97134fbc14
   md5: fd5815cc592fdbd4c831901541eadaba
   depends:
@@ -2005,7 +2005,7 @@ packages:
   license_family: MIT
   size: 9735
   timestamp: 1683059096795
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
   sha256: 474553d01aea57214a54a7443f227da84a58e29c49eb7605ba0043c55b7d167a
   md5: f01333e9f0a908e435db650f42fbd2db
   depends:
@@ -2015,7 +2015,7 @@ packages:
   license_family: MIT
   size: 1096668
   timestamp: 1698946168635
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
   sha256: 51bcea0e575a626f6ffbd16d1153330fda93dbe3dd31dcd3a8f469ff61dd1e4e
   md5: 41d531c90be8c82bf79635ff3d409476
   depends:
@@ -2024,7 +2024,7 @@ packages:
   license_family: BSD
   size: 32295
   timestamp: 1699371262818
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
   sha256: 0a95988ea269c96354626dcab255b65b54bb5c503d24cdeb6ef2e1c42818bd59
   md5: 8bfb9f42492b3b53b8151d77e51c75d8
   depends:
@@ -2033,7 +2033,7 @@ packages:
   license_family: MIT
   size: 1594974
   timestamp: 1715024182643
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
   sha256: 1a84b00944bc5588e14a097460175f97df49acb4f1ff2498ffd9a1893068ed81
   md5: a456513471b2ecbed60430c21dd1ccc7
   depends:
@@ -2042,7 +2042,7 @@ packages:
   license_family: Other
   size: 17880
   timestamp: 1705431390054
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
   sha256: adcafd297d60af64107c113bb7b8b92160d0268a44ef9a3b79e56a88a0358ea7
   md5: 28ed704ed26b06d32662e3a6a87e59b0
   depends:
@@ -2051,7 +2051,7 @@ packages:
   license_family: MIT
   size: 88799
   timestamp: 1696347581401
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
   sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
   md5: f86119b3243fe3508160aa0406245738
   depends:
@@ -2064,7 +2064,7 @@ packages:
   license_family: Other
   size: 1723866
   timestamp: 1714488309729
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
   sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
   md5: 041a3caf09dc9ce8fc6c10925c4fe050
   depends:
@@ -2074,7 +2074,7 @@ packages:
   license_family: Apache
   size: 1888016
   timestamp: 1680167274961
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
   sha256: 856a8ab8c350c50247b79966c6cb80fb6d4de36eef49ddf75aebbbcaf854c82d
   md5: 442dde204d14d171aab9ee40e8de4de8
   depends:
@@ -2085,7 +2085,7 @@ packages:
   license_family: BSD
   size: 37456
   timestamp: 1677696176157
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
   sha256: f0a026ddc0ed041bfc60c8a1ca0b70b7a69232775b3181bfb35a39fda42d6994
   md5: 2902d5a5854865baaaf58dc59cf06b3c
   depends:
@@ -2095,7 +2095,7 @@ packages:
   license_family: BSD
   size: 49185
   timestamp: 1676823769869
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
   sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
   md5: e2512d57c8a1e91e7b20e265c6906546
   depends:
@@ -2105,7 +2105,7 @@ packages:
   license_family: BSD
   size: 3588922
   timestamp: 1714770676475
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
   sha256: 1bf522ade750cf0b70d61e71916ff00569e2908db1e9dedb223fda2608ed8bde
   md5: 6793c74fe94211c0bfe6766c6dd490af
   depends:
@@ -2115,7 +2115,7 @@ packages:
   license_family: Apache
   size: 893808
   timestamp: 1696937055591
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
   sha256: 54f41afbea1c01a10e5703e64645de145f34ad6d89cf245fbc5cfaaff58a8743
   md5: 15b6c8bee4c28c6efb3e388178b37145
   depends:
@@ -2126,7 +2126,7 @@ packages:
   license_family: MOZILLA
   size: 154276
   timestamp: 1716395957568
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
   sha256: 0575785f6553e61cc6138abfd5de52305fac6f85971642fa1f056a76c66a52b2
   md5: f2c25e5dfdd23f70b83776a8832893cf
   depends:
@@ -2135,7 +2135,7 @@ packages:
   license_family: BSD
   size: 270865
   timestamp: 1676823316868
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
   sha256: 8c06c291c76e8c2022ffbb9fea4727a4bf1f9b03e498bafc56ba8ac4e7604ab9
   md5: 5adb7baf1091d09026a372cac930ce6c
   depends:
@@ -2145,7 +2145,7 @@ packages:
   license_family: PSF
   size: 8869
   timestamp: 1715268966416
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
   sha256: 118b0801167264c401e84bbf19175546092a5569cc098146f7362bbf890dc8d9
   md5: b3c2aa56d53b459f8365d8385f48d0c3
   depends:
@@ -2154,7 +2154,7 @@ packages:
   license_family: PSF
   size: 74489
   timestamp: 1715268960737
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
   sha256: 509b962773f0fe44a93a7f6196b254670a030eac8ea7f90727312e3ccd9294b2
   md5: 6c402d5bf4e01c8c3895c9ef41707b6e
   depends:
@@ -2163,7 +2163,7 @@ packages:
   license_family: MIT
   size: 11371
   timestamp: 1676828901104
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
   sha256: bbe7629e8ce52c82f13ed0d1fb919f3659ef466b274a7c74aa925a9bc7aee450
   md5: 7da527bbcf71270c1abed8ea52e7d44c
   depends:
@@ -2173,7 +2173,7 @@ packages:
   license_family: Apache
   size: 509031
   timestamp: 1713213062098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
   sha256: 5c6afad310db12b3658a652efc5de45c182164a0b537cb2cdae5885428b30d22
   md5: 89ea2fed160a633e0a6d152b61cb0dd2
   depends:
@@ -2189,7 +2189,7 @@ packages:
   license_family: MIT
   size: 209068
   timestamp: 1715635972793
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
   sha256: c3a5e0b855dc2de6c162708dfcf170a23eb9e7525d4252d8dce553369af4a330
   md5: a4c77e204b7787f820955166a1283168
   depends:
@@ -2198,7 +2198,7 @@ packages:
   license_family: BSD
   size: 25890
   timestamp: 1676823132898
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
   sha256: 42989f9970a8466cc4edb73463dfa194594dd1a5d42c9f820a1f86296d4af140
   md5: 655dfd4d2f17977cb81caa1c082d2b25
   depends:
@@ -2207,7 +2207,7 @@ packages:
   license_family: Apache
   size: 113505
   timestamp: 1715878346465
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
   sha256: eec0d2e0bce4b62278cacd7b0bee053160845e86507051a5434d2069bd290f36
   md5: a069e5aef64a6dac076cc9a3d28a17c9
   depends:
@@ -2216,7 +2216,7 @@ packages:
   license_family: MIT
   size: 136022
   timestamp: 1714717059748
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
   sha256: d18cdca154bf668826f869117ea996c4f9e8ef7d27b7c528332a7d17e5a8602c
   md5: 9f7353d72046b16dd6ef6b5689ac9bfd
   depends:
@@ -2225,7 +2225,7 @@ packages:
   license_family: BSD
   size: 54731
   timestamp: 1676828934954
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
   sha256: 9122d6e9dabb7a47f2bcb15d86b97c96c49a9048da3f8ae59675351710c14cc5
   md5: 660b2aead2ec87b751c86cd33934f44e
   depends:
@@ -2234,7 +2234,7 @@ packages:
   license_family: GPL2
   size: 716926
   timestamp: 1714510796277
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -2242,7 +2242,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
   sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
   md5: 943f1247a22b6b64171363bcee1eec27
   depends:
@@ -2253,7 +2253,7 @@ packages:
   license_family: Other
   size: 371663
   timestamp: 1705602144682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
   sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
   md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
   depends:
@@ -2262,7 +2262,7 @@ packages:
   license_family: Other
   size: 127143
   timestamp: 1714510716441
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
   sha256: af3c032f06352e87c450739cb8aafe1ff34ad28bf074b214ea98b3d29259a85d
   md5: 51fa34bd0e016ed7c5371cf6cb13ef6c
   depends:
@@ -2275,7 +2275,7 @@ packages:
   license_family: BSD
   size: 1044463
   timestamp: 1714678445052
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -2288,7 +2288,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -2298,7 +2298,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
   sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
   md5: d78a456773bd4df323a2dfb4d8710b90
   depends:
@@ -2310,7 +2310,7 @@ packages:
   license_family: Apache
   size: 124095
   timestamp: 1641577596378
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
   sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
   md5: 544adf2677c47c9b9c891aea720678f1
   depends:
@@ -2318,7 +2318,7 @@ packages:
   license: MIT
   size: 33999
   timestamp: 1630003259346
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -2327,7 +2327,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -2336,7 +2336,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -2345,7 +2345,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -2354,7 +2354,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -2362,7 +2362,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -2371,7 +2371,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
   md5: 19dd0314629d343382a76a309cb7d183
   depends:
@@ -2380,7 +2380,7 @@ packages:
   license_family: MIT
   size: 70876
   timestamp: 1641458670141
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -2390,7 +2390,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
   sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
   md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
   depends:
@@ -2399,7 +2399,7 @@ packages:
   license_family: BSD
   size: 5106
   timestamp: 1704404390460
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -2407,7 +2407,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -2416,7 +2416,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -2425,7 +2425,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
   sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
   md5: 02caf3f47f1d06256068053297355740
   depends:
@@ -2434,7 +2434,7 @@ packages:
   license_family: Apache
   size: 152292
   timestamp: 1690578151230
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -2443,7 +2443,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -2455,14 +2455,14 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
   sha256: dc9f709bacbaf08a0941d2622d82f91f18b355e82c55348ec29f1391215ca7e0
   md5: ece0f5837a4de2d4d5f1abf8347cd10a
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 124922
   timestamp: 1708711884650
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -2470,7 +2470,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
   sha256: 5800a2466734dd1ef372bec0dd3f0880c5072fa1e8b0668f5054f834285e991c
   md5: 18194e51d4420ac08f29f3f86581b52e
   depends:
@@ -2484,7 +2484,7 @@ packages:
   license_family: MIT
   size: 229003
   timestamp: 1706220302459
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
   sha256: ab7672364f1fa55ec5d8311d85d40e5b57cbd3517b17670557b6fb822bcf759c
   md5: 6e0159a5865cb7e96a748bd8560035ee
   depends:
@@ -2493,7 +2493,7 @@ packages:
   license_family: BSD
   size: 11579
   timestamp: 1678317458652
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
   sha256: 51556902e09436d46878ef772805d06416ca96ffaa66340b5565c0245574aaf5
   md5: 4cb1b20635cf5431d34cc96ca1e8a751
   depends:
@@ -2503,7 +2503,7 @@ packages:
   license_family: MIT
   size: 33355
   timestamp: 1678317111825
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
   sha256: 188b74f717e3ce3595da404c0e027b8ccafa9c186e88325e8f02c29d7b4c0744
   md5: 04ad90eead5812a0263b42321056ab33
   depends:
@@ -2512,7 +2512,7 @@ packages:
   license_family: MIT
   size: 153694
   timestamp: 1695717975427
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
   sha256: bf3c60386619f08cf5105b4b903bbc109b3252c3b923fe055aa445908a01969c
   md5: 3f84a301921ec6400b7f1f1c4ba3260d
   depends:
@@ -2522,12 +2522,12 @@ packages:
   license_family: MIT
   size: 270017
   timestamp: 1681493109562
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-mkl.tar.bz2
   sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
   md5: e2f3248e2a5009a02f7b8e54f83314ef
   size: 5620
   timestamp: 1528121955725
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
   sha256: 126ae8e30b8464fb2dc94ce9163dcb2d5482f7214c7d8a48340c3f09f1409d5e
   md5: d5e0c054042910b4394a14c7eb4d8131
   depends:
@@ -2545,7 +2545,7 @@ packages:
   license_family: BSD
   size: 6080356
   timestamp: 1712084675745
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
   sha256: 9acafafcaebd653c2372ddc864525722e1c55b884b5eba22e28e2b2d946b853c
   md5: 22375cc3c2edada31b85af56c8e6dee6
   depends:
@@ -2555,7 +2555,7 @@ packages:
   license_family: BSD
   size: 155829
   timestamp: 1707864406086
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
   sha256: d8b1ccb15297dcfb3f9ebb8139c3e28a13d6c2e73c37612cb214ab6cc58b15fa
   md5: e5dec9f13de061640ad2697562a99b54
   depends:
@@ -2565,7 +2565,7 @@ packages:
   license: MIT
   size: 19732
   timestamp: 1714483415038
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
   sha256: e9fda4393edd0234c88efc2b88e0edf42c94eb49ea5b189a80afd733058be8fb
   md5: 13ceed558eb174d6b77ed1b0035f1785
   depends:
@@ -2574,7 +2574,7 @@ packages:
   license: MIT
   size: 18400
   timestamp: 1714483395748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
   sha256: a323af3251e426962ad16edf8f46a696ef502731faf12aee32ca289c40b11342
   md5: 658ce49e9f07dba7a1afe70fa2666e0a
   depends:
@@ -2583,21 +2583,21 @@ packages:
   license: MIT
   size: 393858
   timestamp: 1714483549536
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
   sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
   md5: c5a600d81b1b48578863af2973c743ac
   license: bzip2-1.0.8
   license_family: BSD
   size: 187637
   timestamp: 1714510590009
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
   sha256: 0c5f9766aa2dcc08ae71b6c0102046a56b30297d0bedc3039b7f72d1658baa43
   md5: 34583b436e62a2ce55d6a7e8eb818e33
   license: MPL-2.0
   license_family: Other
   size: 138712
   timestamp: 1710764814844
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
   sha256: 20b1fc398e925e6c8cea6a06d3bb614e2c0de886e3f14f85b0ba26e57ff40b7e
   md5: ac95cfe373c7fef7820e93189041b0cc
   depends:
@@ -2606,7 +2606,7 @@ packages:
   license_family: Other
   size: 166856
   timestamp: 1707229213510
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
   sha256: 6b5bebc13755b0a5ef423219eeecd1c25b97dbe83afad6e2552635387547d9f7
   md5: b7bc4192fcfed7fc7df1ce00bce97b02
   depends:
@@ -2617,7 +2617,7 @@ packages:
   license_family: MIT
   size: 291802
   timestamp: 1714483319125
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
   sha256: 9270668e34b00a2605584a2db5130c83826855cd05b896ce949f3156fa197429
   md5: 2586aa55677e822e8285d777f9039ca9
   depends:
@@ -2626,7 +2626,7 @@ packages:
   license_family: CC
   size: 543487
   timestamp: 1709758497949
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
   sha256: 389c63a84b92a6254c9d361ebe970d537d0b88733efd5ac5c3ee58196fd2c5a9
   md5: c7bc5b3cbe76be83a27f00b7e4740727
   depends:
@@ -2636,7 +2636,7 @@ packages:
   license_family: BSD
   size: 17974
   timestamp: 1709323004148
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
   sha256: bebfc5aa6be12e61a134b580b07b67f7d8c045d6b113fca5b21fa1e83a2f03ce
   md5: 239df72a3921c951059fa8afc09643f6
   depends:
@@ -2647,7 +2647,7 @@ packages:
   license_family: BSD
   size: 287736
   timestamp: 1700583644534
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
   sha256: e0e30590a78d99d51445ac4f668aefe1bf20025a35bdbac00f04647b95c9f152
   md5: bd0db635eefeea82a0c567b39c9a0e3d
   depends:
@@ -2657,7 +2657,7 @@ packages:
   license_family: MIT
   size: 2485698
   timestamp: 1690905283575
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
   sha256: d48b47b86b09dac1fa4542ec13e1bd4e23093638e684fa66ec3afdd9ce9337c1
   md5: 5a2d1828ab7c8eccd3c2610d13672977
   depends:
@@ -2666,7 +2666,7 @@ packages:
   license_family: MIT
   size: 17336
   timestamp: 1678316187749
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
   sha256: 54645c22fabc25b632114d1d3c403a6fad9149b51ab36719b2690a084f14a072
   md5: a8ad2f4abfb2e17ecf6e596342528156
   depends:
@@ -2684,7 +2684,7 @@ packages:
   license_family: MIT
   size: 3180691
   timestamp: 1713551771692
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -2694,7 +2694,7 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
   sha256: 4120472ee1c5d31efffeb045892bece27b9a15a30d77c35212f6508221635918
   md5: 9561a225b5171285250c9071f8cab074
   depends:
@@ -2711,7 +2711,7 @@ packages:
   license_family: BSD
   size: 5368257
   timestamp: 1707836808668
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 50dee40e4a9ea7a035baeecc85770c88d63d4e6b0c3c2519c1429e881171150c
   md5: 4d465f453dca5c65224dccbe953f600c
   depends:
@@ -2728,7 +2728,7 @@ packages:
   license_family: BSD
   size: 359293
   timestamp: 1715090716440
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
   sha256: 5c2458964157fe493ca18c513c693b70cb622087e5fa0c93e65fc45217edd811
   md5: 15629e52625221b51a443cefd9501d12
   depends:
@@ -2737,7 +2737,7 @@ packages:
   license_family: BSD
   size: 148522
   timestamp: 1714398885844
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
   sha256: e0127f50d444bf4474e8df07d602c7f6dd38690e8bb3fb28817c164940ffcde1
   md5: 583fcd7060cad6a77074d00d9ef62f44
   depends:
@@ -2746,7 +2746,7 @@ packages:
   license_family: Proprietary
   size: 731417
   timestamp: 1699647668990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
   sha256: eb58fa29b1ce9aa5fc774d4c466696457695dec3b206456614b4c9cac0a94e42
   md5: 3d3291ff58dff83dcd40ec54b435f4d2
   depends:
@@ -2768,7 +2768,7 @@ packages:
   license_family: BSD
   size: 229910
   timestamp: 1705934029588
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
   sha256: 73aa7662c00c73bab2dafefefc87a1b524961d2687410af624ecbd6703e483f3
   md5: 7e71e99766107a553752ed8f22b61cf0
   depends:
@@ -2785,7 +2785,7 @@ packages:
   license_family: BSD
   size: 1611976
   timestamp: 1704833049616
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
   sha256: e08cda2bcbdec124c63e951eb248c503bb1467c2a6000010c6bdc0726e0e00b7
   md5: 22c24f43b82da8b3920a913bbf452421
   depends:
@@ -2795,7 +2795,7 @@ packages:
   license_family: MIT
   size: 1168968
   timestamp: 1679336359851
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
   sha256: 3b262312f1fc76e490c067408771da0a12c7691379cddc3c86121255cda7a41d
   md5: cbf00a1bc151243cb6a33524b62f3663
   depends:
@@ -2805,14 +2805,14 @@ packages:
   license_family: BSD
   size: 353280
   timestamp: 1706733664000
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
   sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
   md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
   license: IJG
   license_family: Other
   size: 278924
   timestamp: 1677849185191
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
   sha256: 99fc6ac82c56eb2a580f96db24a5b887f8abc8c24af445d3313d5ebb48598478
   md5: 71892160908a6daedb5fb7c404079ae4
   depends:
@@ -2825,7 +2825,7 @@ packages:
   license_family: MIT
   size: 182073
   timestamp: 1699041732321
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 0ea44d0c8044e70ab0eaf4d6f5f3e4753838dee106b5cbd36561e21a65cbac77
   md5: 1d045016dca889d702f1caf3a16162fc
   depends:
@@ -2835,7 +2835,7 @@ packages:
   license_family: MIT
   size: 16528
   timestamp: 1699032525791
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
   sha256: 70442ec4b0b7ebbdcf150963f61f797b861001092124f4ea39a16eb92a4d176e
   md5: 63d1503915a15ae4f9ad1c46112ca374
   depends:
@@ -2851,7 +2851,7 @@ packages:
   license_family: BSD
   size: 272720
   timestamp: 1678316970740
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
   sha256: 8601c674f4779900f6a949e47b814be68b722b0b3d394433bec9d197924ebd69
   md5: b8423f8caff3041a251fc3681f43496a
   depends:
@@ -2862,7 +2862,7 @@ packages:
   license_family: BSD
   size: 94990
   timestamp: 1698937583196
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
   sha256: 6a430c812ce0415a04d9cfe6c66d9012eced2d91c04960c88bc8ec1e9f1b5d6d
   md5: 30b3d5d6a8cf5d1604e5f5fb177917b5
   depends:
@@ -2878,7 +2878,7 @@ packages:
   license_family: BSD
   size: 42513
   timestamp: 1699282637015
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
   sha256: c2d206db117f7161e77236ebd6b0051fc73e1731c242d1e08597d736a0376c92
   md5: bdb61de2e20e02c93423d9de091c74ad
   depends:
@@ -2905,7 +2905,7 @@ packages:
   license_family: BSD
   size: 601837
   timestamp: 1699466514455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
   sha256: fd7964657f0a8fe8b167ba860b1f960e8b7b45309eb6c7c850d50ec283fe03b5
   md5: 2967bb345bc75f53182e263ff4743ca6
   depends:
@@ -2915,7 +2915,7 @@ packages:
   license_family: BSD
   size: 28223
   timestamp: 1686870845224
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
   sha256: 64cf59f0f74b0329b5069bc6135b4f40593f1dac52d85ad574d4b8e0a4b2cf16
   md5: 35e8b80eaa03a904fc7f1da39e7f654d
   depends:
@@ -2927,7 +2927,7 @@ packages:
   license_family: BSD
   size: 20234
   timestamp: 1700168776500
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
   sha256: a12382b50416803f559a03fb384ba492c1dafa351e1191a3f8dc361bee6c4f37
   md5: f2ae846b663bbb642f4b1e90eaad38a3
   depends:
@@ -2937,7 +2937,7 @@ packages:
   license_family: BSD
   size: 64817
   timestamp: 1678322501509
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
   sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
   md5: 819762fdace9397c0e14a9ed2dcdb829
   depends:
@@ -2947,7 +2947,7 @@ packages:
   license_family: MIT
   size: 419188
   timestamp: 1617648628608
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
   sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
   md5: d9e7e12a2bc017897a1a866e972a04de
   depends:
@@ -2956,13 +2956,13 @@ packages:
   license_family: Apache
   size: 203852
   timestamp: 1635523161861
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 685c3bc9068bd485604b80bf03789e4dca95c410d33871bc1b882e47649fabed
   md5: 6cf8e55271e150ca0961d0ddedaa61bb
   license: MIT
   size: 66237
   timestamp: 1714483284541
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 69826cee54db9955f0120af21ec36d13f9211877fd67364f2068d0a54c6c97cd
   md5: 0851917257f490d35e1f73da8a1c723c
   depends:
@@ -2970,7 +2970,7 @@ packages:
   license: MIT
   size: 34042
   timestamp: 1714483343147
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
   sha256: 3f5a1f03b50b90b397a0ee432ad0cba13354abdaf7e5652c0fc60164b26a08b6
   md5: a50bdc871ef4bf14deb088d888b92b5e
   depends:
@@ -2978,28 +2978,28 @@ packages:
   license: MIT
   size: 311597
   timestamp: 1714483371586
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
   sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
   md5: 891b155ceb619a35ae6abb1fc4225aa1
   license: MIT
   license_family: MIT
   size: 77959
   timestamp: 1695996522382
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
   sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
   md5: 822a5b76117e56d3912f1f2153307528
   license: MIT
   license_family: MIT
   size: 136045
   timestamp: 1714483561919
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -3008,13 +3008,13 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
   sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
   md5: 3438422a7b72a28655ce0c2cc9c2a5b6
   depends:
@@ -3031,7 +3031,7 @@ packages:
   license_family: Other
   size: 642076
   timestamp: 1693575343250
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
   sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
   md5: 46a65d1fc24013217e06aaf6d65ffcad
   constrains:
@@ -3040,7 +3040,7 @@ packages:
   license_family: BSD
   size: 425478
   timestamp: 1694776947990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
   sha256: d28c465ec6d5f8d4962c597b249b58998300c8b4e3c937c578c3d15294ea863d
   md5: dcaed6ddd0723c7cce6bfad917be98b2
   depends:
@@ -3050,7 +3050,7 @@ packages:
   license_family: MIT
   size: 41176
   timestamp: 1678413498410
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
   sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
   md5: 8f57dc3a3327bb6f7e1cba908856ac7f
   depends:
@@ -3059,7 +3059,7 @@ packages:
   license_family: BSD
   size: 183138
   timestamp: 1714510756758
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
   sha256: 6fb2953e169ee1ae38f24d29752051501992f19b96b5ebcea9af75737bdbcb42
   md5: 7f410cdae838c5030108d1b98a8c78f6
   depends:
@@ -3068,7 +3068,7 @@ packages:
   license_family: BSD
   size: 162478
   timestamp: 1678377892595
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
   sha256: cd97e09a12ffb49b2a30a782fa8c7933b28f5ffdbfc5c73a9ebaa95fc9447370
   md5: d1fb6ebc1e5728aa6377cfc71da08942
   depends:
@@ -3078,7 +3078,7 @@ packages:
   license_family: MIT
   size: 135859
   timestamp: 1684280005320
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
   sha256: 30c3b189462a9d0f4794d229adadf34b5f5a5f56f95c30d5afc17ef524579290
   md5: d4e9421243129d1d57c472dab045f3dc
   depends:
@@ -3089,7 +3089,7 @@ packages:
   license_family: BSD
   size: 26639
   timestamp: 1704206159955
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
   sha256: 080000a28b3ceca54eec6de0748c690ea5a4c390e358283eac03fe7a6dd87065
   md5: 51344eca57d7940fb01eb5e8914509e3
   depends:
@@ -3111,7 +3111,7 @@ packages:
   license_family: PSF
   size: 9099909
   timestamp: 1713336790553
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
   sha256: 07e7fd5bd64e55328b4b99d92e2e2600d791f1095bf905daab4cfc59f0f0a45b
   md5: cf53321779f4ca7e986c1468719b93f1
   depends:
@@ -3121,7 +3121,7 @@ packages:
   license_family: BSD
   size: 19500
   timestamp: 1678317565001
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
   sha256: 0770e02be1ea1216af493cfc03d5b8a702e14606fa93b0692bcdab1fed1b898c
   md5: ca6f06ceaf66a32bbf5dfdb6e373a5cf
   depends:
@@ -3131,7 +3131,7 @@ packages:
   license_family: MIT
   size: 67892
   timestamp: 1678417734353
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
   sha256: fbe95ed0501bb0f137048476fe41bc718dd659e8ecb066bc67ac17d6a50f4318
   md5: ec162bde8d1c8a107b257df218b17035
   depends:
@@ -3140,7 +3140,7 @@ packages:
   license_family: MIT
   size: 23030
   timestamp: 1678381838497
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
   sha256: c20dd678655e582129a858a1c5162bdc254082d3a3c035b0f72629d9276e5b75
   md5: 800a0738c728796e02d0386ce7d457aa
   depends:
@@ -3151,7 +3151,7 @@ packages:
   license_family: BSD
   size: 104585
   timestamp: 1678317269407
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
   sha256: c825bc3070f73318ffff88a7a0b7fc6d1858b058ced735efd1789053f1583918
   md5: dea5f96459c9a6df6b026ca57d387936
   depends:
@@ -3164,7 +3164,7 @@ packages:
   license_family: Proprietary
   size: 224299920
   timestamp: 1699647835748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
   sha256: a76c134ec258612ff7d55cb2a19b9e3461cbbd375a744bd29390af9cfcd283b2
   md5: 1c736f58992009f53f014aef163bae31
   depends:
@@ -3174,7 +3174,7 @@ packages:
   license_family: BSD
   size: 48442
   timestamp: 1682969160267
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
   sha256: bcfb0d1e075d043bcf05fa1a7ce3c142bf222d29693366af49a5a346c770812f
   md5: 59e4820b34049cbc6619a8ac97290abc
   depends:
@@ -3187,7 +3187,7 @@ packages:
   license_family: BSD
   size: 222137
   timestamp: 1695058350477
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
   sha256: 114e408c40b332393cf2792393e4d1ede3465abcb3d345fe647ee519565346c8
   md5: 86b13271578e1fa5e664edcf6fcb3ce4
   depends:
@@ -3201,7 +3201,7 @@ packages:
   license_family: BSD
   size: 296860
   timestamp: 1695059990370
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
   sha256: a58960e88525a202ba193b4dd8227c4d9c3dd98b8b43edea34b05a9a9fd1121c
   md5: 71a37f987c3df6657548d098bd2a58e7
   depends:
@@ -3227,7 +3227,7 @@ packages:
   license_family: BSD
   size: 8286383
   timestamp: 1699543227340
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
   sha256: e08cb3ee6df01f4c1e1ac8bc4ed1a06e549ffcc8774fe2e2842c644bb8f74a86
   md5: 6ba0ae0fb14cbea1e3197707701dc180
   depends:
@@ -3240,7 +3240,7 @@ packages:
   license_family: BSD
   size: 123077
   timestamp: 1698934356774
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 2f946b5042eaac97206b5217fb203f3604ab3a60aecd99bdfc684925e3136c18
   md5: b24026076c381ff2009e7acb9e0a6e87
   depends:
@@ -3267,7 +3267,7 @@ packages:
   license_family: BSD
   size: 534650
   timestamp: 1699022791300
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
   sha256: ba368605a0af6f1dcbdcb6fddab9ce63224a85dd11bfb2b1acace1dc17899411
   md5: 91f3ea3fe44d619ee95a6ed3773a0814
   depends:
@@ -3280,14 +3280,14 @@ packages:
   license_family: BSD
   size: 170926
   timestamp: 1694616830121
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
   sha256: 42d803e1d8b54748db5d989ecd503826f564132df7cddc20f520460f55e523a1
   md5: cd3fa71626ebc098da4625fc6be79752
   depends:
@@ -3296,7 +3296,7 @@ packages:
   license_family: BSD
   size: 16952
   timestamp: 1708532805951
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
   sha256: 92d50872fad0d1fecfea42cbfdb69887def80927c169a88204d163c2d3c7d035
   md5: fe6780b8659ff5d6061268708a7b2032
   depends:
@@ -3321,7 +3321,7 @@ packages:
   license_family: BSD
   size: 716120
   timestamp: 1690984968401
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
   sha256: ed5608feb37a083d47b04203195260e801b64b5380f292cf18bb61e7ad827a2a
   md5: daa9c1c233673b727528548454aea664
   depends:
@@ -3331,7 +3331,7 @@ packages:
   license_family: BSD
   size: 27607
   timestamp: 1699456006797
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
   sha256: cacba45c1eebf7d86748737717883a98cf40664231460fa41391c79f98d06f45
   md5: 3dbfae0d5b90e77f9358564ad442ac9d
   depends:
@@ -3345,7 +3345,7 @@ packages:
   license_family: MIT
   size: 165572
   timestamp: 1696515553184
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
   sha256: 1466c3af380b949612c79940124e426eccd59e335c205da0c00383a69358d1c0
   md5: df6be53592d40ba7e03d6ffe349760bf
   depends:
@@ -3361,7 +3361,7 @@ packages:
   license_family: BSD
   size: 11330
   timestamp: 1708639985606
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
   sha256: ace67d704fa7eea1480eb463f2d91bfc161be2ee20263c5a9939805ae3c2a9da
   md5: ec124589478fa12fba4f35f31c3a0692
   depends:
@@ -3376,7 +3376,7 @@ packages:
   license_family: BSD
   size: 8783230
   timestamp: 1708639945646
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
   sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
   md5: 93f5d7b66976154adeda219bea02ba45
   depends:
@@ -3386,7 +3386,7 @@ packages:
   license: BSD 2-Clause
   size: 484257
   timestamp: 1630093862501
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
   sha256: 891ffe9826f6f9ec9a4fc5d1bbb9a64f9de23f27705c2202f7d475b7cd14dd83
   md5: ab0d447c9eb4fcada05d853bd13a24ac
   depends:
@@ -3395,7 +3395,7 @@ packages:
   license_family: Apache
   size: 4970613
   timestamp: 1716319014066
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
   sha256: 8a0809f419065e014cb8e2c8a516cadca6088fb71fd1ef3ae2287d91e3360d59
   md5: 4dc0b9bc88476fcc5246d823ff1c289a
   depends:
@@ -3404,7 +3404,7 @@ packages:
   license_family: APACHE
   size: 39645
   timestamp: 1699371213055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
   sha256: 64fbbb03570788298d8b04d4ea6cb254fef5d5eec73265aeecd72cb565617f4d
   md5: 4b1195028bc26257df43fdd943638266
   depends:
@@ -3413,7 +3413,7 @@ packages:
   license_family: Apache
   size: 159450
   timestamp: 1710811009212
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
   sha256: 6abb7e0aeda0130f54925421900772e1bc46d1f04ae69ce1376524457686d49f
   md5: 232a6370c3fab0c41c6d4c7339e778ca
   depends:
@@ -3463,7 +3463,7 @@ packages:
   license_family: BSD
   size: 17296294
   timestamp: 1709591285369
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
   sha256: 10a5eb185aa5dcfecfa854c2e66b3779cb6d2dee85f1b2236f43234a1c1ba9e0
   md5: 2200abcb857e6bb8cb46b861cb4d2fd7
   depends:
@@ -3487,7 +3487,7 @@ packages:
   license_family: BSD
   size: 22071486
   timestamp: 1714072093679
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
   sha256: daf01c56a3c44555ecb61e9a0e899a7b58872c6b7631f00a04ee8d3199e9e568
   md5: 2163ed8005a14ecda15efe5586582cce
   depends:
@@ -3496,7 +3496,7 @@ packages:
   license_family: BSD
   size: 267508
   timestamp: 1711137004592
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
   sha256: 90efc71d35ab62d5b8d7b648e016444e1c4c8b83238b6dc9f2c6c3db4b14c599
   md5: 6b6eeb0a14c5479db1dd39aa8d338150
   depends:
@@ -3512,7 +3512,7 @@ packages:
   license_family: Other
   size: 939480
   timestamp: 1714399174883
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
   sha256: f6b0ded7010706431f2a6d9776aa6033dfd19d2264b3cebf28072629160090a8
   md5: 02de6d0d9cc23fafe2e3597ed0e52693
   depends:
@@ -3523,7 +3523,7 @@ packages:
   license_family: MIT
   size: 3444268
   timestamp: 1715097155645
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 81719c31101d6c019150cedcc7b08adb3bdb357e8b2952e428dadaabc4dc985d
   md5: 105825168e0a17fb007f60b5f314e311
   depends:
@@ -3532,7 +3532,7 @@ packages:
   license_family: MIT
   size: 38405
   timestamp: 1692205731769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
   sha256: c0982f688127129e026d2b4cdacdd5684d00796ea7bdadd7d26b1101b095d723
   md5: 0d6910c74729fede645c010110f1c89e
   depends:
@@ -3541,7 +3541,7 @@ packages:
   license_family: Apache
   size: 121796
   timestamp: 1679340253537
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
   sha256: e32843723b10ecd9badde28e1085419c0b59ed8a96c7cacce6395e39e3a874f9
   md5: 5af0280a817d2c273304cd22328124af
   depends:
@@ -3553,7 +3553,7 @@ packages:
   license_family: BSD
   size: 763044
   timestamp: 1704404460779
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
   sha256: 117a435c2473e2a20cc81eaacb2b45ea5e7fe3c946eec2915936d344913ede44
   md5: 0f459ee59fda20e2077fdc2c777edfc8
   depends:
@@ -3562,7 +3562,7 @@ packages:
   license_family: BSD
   size: 497470
   timestamp: 1679337286052
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
   sha256: dfb403f367c57327a4d080109df88383ecff18464de287a1ce936a7274e3656b
   md5: 997b674bad89963af875b93b06807f51
   depends:
@@ -3571,7 +3571,7 @@ packages:
   license_family: BSD
   size: 2120413
   timestamp: 1684280057020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
   sha256: 9d2c0f373ac1c5db329581793dd517092cdf9a59140f2516ed8c3a1f483c0bbd
   md5: ee10503a159e819abdc586666bdf0952
   depends:
@@ -3580,7 +3580,7 @@ packages:
   license_family: MIT
   size: 207552
   timestamp: 1678322848766
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 717e038567506ca58ce1cd4a3416892d02f4ebfdd332077cc3d110cfe3d36c58
   md5: 53bbfb400668f798eef6f8c7cf938e1f
   depends:
@@ -3589,7 +3589,7 @@ packages:
   license_family: BSD
   size: 35751
   timestamp: 1678315886516
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
   sha256: 092dea8d520acff3e64c71155e666b0b6074d37a71d5eb32f3cd485b0d185d0b
   md5: 9fbaf2d9534c26e76aa14b11b23de332
   depends:
@@ -3608,7 +3608,7 @@ packages:
   license_family: PSF
   size: 16852220
   timestamp: 1713545835789
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
   sha256: 04e100d0a1ea9722e24972657ec5935ad34c7c58957dabb821333e5eac80f717
   md5: 2b6de49ad07b26e1f7084f0fda958eb1
   depends:
@@ -3618,7 +3618,7 @@ packages:
   license_family: BSD
   size: 332276
   timestamp: 1716495830117
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
   sha256: 514249897265f66f6ecca0a4427eb02a43c33b3c24974db16d05db6bbe97881d
   md5: c9ea1437e5a3ba6a52ec2322505203e6
   depends:
@@ -3627,7 +3627,7 @@ packages:
   license_family: BSD
   size: 279116
   timestamp: 1679338758489
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
   sha256: 78b785b9b6ed46c86b0d3a32bdceea49f816672227fb63e726b2d46eadbdba0b
   md5: 79d783f74359141e0b06a848db33823b
   depends:
@@ -3636,7 +3636,7 @@ packages:
   license_family: BSD
   size: 18563
   timestamp: 1683823935261
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
   sha256: e358fe679e83ccdc8c433746ae6468e8e96d90d97d99530f8476ef5630b2c121
   md5: ce30a0a31d891e69dc9b7bf8b7f0c39c
   depends:
@@ -3645,7 +3645,7 @@ packages:
   license_family: MIT
   size: 268876
   timestamp: 1713974360942
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
   sha256: eeb5a5eed93b8e311ad4d3f4389e050f11bba2eaec9536e1c3ed2f849c6c999b
   md5: c18bd3e12de797d52a470c21a150dffe
   depends:
@@ -3657,7 +3657,7 @@ packages:
   license_family: BSD
   size: 65270
   timestamp: 1711136914884
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
   sha256: c3e11ed944da69c11b949bb918341a0d79ef603ee34a632d6a45fbf89ff924a1
   md5: fee7ff4d291f530b4cecb575f29807a0
   depends:
@@ -3667,7 +3667,7 @@ packages:
   license_family: MIT
   size: 197996
   timestamp: 1698096137432
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
   sha256: aa07b90a7ee65f76c8cba1ff99a5cdeb95cbe41881ae951f64ffff06674a1b2d
   md5: 58621e3d244137885f7dfbb35e50340a
   depends:
@@ -3677,7 +3677,7 @@ packages:
   license_family: Other
   size: 594801
   timestamp: 1709318510622
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -3686,7 +3686,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
   sha256: d784dc26c5de8e41845350a899e5779250b71f45d39e2aece62e739e9add7308
   md5: 7b077b7f46112bb31dc066396c51d3fa
   depends:
@@ -3697,7 +3697,7 @@ packages:
   license_family: MIT
   size: 74776
   timestamp: 1699012164201
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
   sha256: 3357b6b327b3d0a2cc0f02934a60bbd6df38f4ea7bbb3f50cb8e21332c9f5786
   md5: bf5e48b646e36ef2b788be9665c0e5ae
   depends:
@@ -3713,7 +3713,7 @@ packages:
   license_family: Apache
   size: 120768
   timestamp: 1707355762747
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
   sha256: 727fb8d957e02d03b928d049ffbc712316f176a2c331391766d646621b45655a
   md5: 7e0e416c642f3ee4ddfb084a811fb4df
   depends:
@@ -3723,7 +3723,7 @@ packages:
   license_family: MIT
   size: 10236
   timestamp: 1683077214314
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
   sha256: a8a67143ccb65cfd6f50055176b6c26179a83130a45d0a12e79dd2de68d8db63
   md5: a2065790f41e3eeb6efe0ef6daa75377
   depends:
@@ -3732,7 +3732,7 @@ packages:
   license_family: MIT
   size: 10600
   timestamp: 1683059285216
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
   sha256: 6aba582338faa0c26fe336bdb10c65b8f7808a6e383bd8f80f3e6b612ca209ec
   md5: a7486349b5f7370f6902c2050a23d268
   depends:
@@ -3741,7 +3741,7 @@ packages:
   license_family: MIT
   size: 319197
   timestamp: 1698946203341
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
   sha256: beba0555707dac1e8484d73cee9e4128ac4b10e2a0d4209357481179022e8fdc
   md5: baa8b304607b3a9ae8a3d9acb354c31c
   depends:
@@ -3750,7 +3750,7 @@ packages:
   license_family: BSD
   size: 33343
   timestamp: 1699371216044
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
   sha256: c1df29188e321abe23651c73712a6d8ed3abdc89ad38a42c33f1835b3ab77abe
   md5: 6c984ea85326858942f7b635e0cc9ff8
   depends:
@@ -3759,7 +3759,7 @@ packages:
   license_family: MIT
   size: 1597325
   timestamp: 1715025837032
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
   sha256: 0eb44a16ef74a13ef7839209899d009cd94974fbc406a417d958c7bc8d955245
   md5: 41f239a5b67b1daf819849023aa5d12f
   depends:
@@ -3768,7 +3768,7 @@ packages:
   license_family: Other
   size: 19056
   timestamp: 1705431379885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
   sha256: 14775231982e1ea150189c956927ccfb1ad01a8c9395cdeea4d5a48b9b8ce664
   md5: 729badc4bf7ba8ccc70e0f9e58075c99
   depends:
@@ -3777,7 +3777,7 @@ packages:
   license_family: MIT
   size: 89812
   timestamp: 1696347694075
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
   sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
   md5: 6bef1694163a68ac4c37e5857b8da4f5
   depends:
@@ -3789,7 +3789,7 @@ packages:
   license_family: Other
   size: 1900191
   timestamp: 1714488351925
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -3798,7 +3798,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
   sha256: 3d5c2968f581006437df3932cd5d3c1c4afa78f0e13757b958440245d3248856
   md5: 605ea221d225ad8e79284dbcfdab0715
   depends:
@@ -3809,7 +3809,7 @@ packages:
   license_family: BSD
   size: 37699
   timestamp: 1678317755913
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
   sha256: ed059e32ce5a1c0511575f29d2fb6da12c54a37000bfa80f9e5aa9dfd9e04101
   md5: 4d2261a92d25136a68b8d01d101119f5
   depends:
@@ -3819,7 +3819,7 @@ packages:
   license_family: BSD
   size: 49145
   timestamp: 1678317386284
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
   sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
   md5: 523c006cc67c011383678c762015479b
   depends:
@@ -3828,7 +3828,7 @@ packages:
   license_family: BSD
   size: 3594448
   timestamp: 1714770737885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
   sha256: 6ab71b48d145c69007cfb5b4a21def2cc83bba972b7cc91c7d52d0d7eeb055bf
   md5: f8970b0ad5c8b452b8722ceb4e5c17f7
   depends:
@@ -3837,7 +3837,7 @@ packages:
   license_family: Apache
   size: 895379
   timestamp: 1696937269468
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
   sha256: 3df84b9897f05a104c99e297dc29ad8f718982fc64c61b5a2204c19c578f47e5
   md5: deab971930d242221ed86bfd768dde40
   depends:
@@ -3848,7 +3848,7 @@ packages:
   license_family: MOZILLA
   size: 155545
   timestamp: 1716396266697
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 9e8dbede0bc54c77b974210be66503e7e8e45e0f1c71dc5c16cc9a9674d54259
   md5: b4fcab9e63bd7b3cdf458c953904807c
   depends:
@@ -3857,7 +3857,7 @@ packages:
   license_family: BSD
   size: 270874
   timestamp: 1678316116954
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
   sha256: 17e5688d09ffbcb8b71b34b86edc7374fa0b04d60a4d729d405ffc22ef63726c
   md5: e4bf44ddbbcb136332ccb47ac2b879a0
   depends:
@@ -3867,7 +3867,7 @@ packages:
   license_family: PSF
   size: 9890
   timestamp: 1715269046804
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
   sha256: 7d369ec970d1d5411e457c79f94197756c7088deff8183806ea71e633b26edf9
   md5: 9ffa197b26373667f50b21876862398e
   depends:
@@ -3876,7 +3876,7 @@ packages:
   license_family: PSF
   size: 75595
   timestamp: 1715269030928
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
   sha256: a9960485ced319ac91afe69eaaf703c7e6b3049f1e06a4a8c2818b64155943f0
   md5: 0a9c8ea92a14330a07edabac249e32a9
   depends:
@@ -3885,7 +3885,7 @@ packages:
   license_family: MIT
   size: 11399
   timestamp: 1678394892923
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
   sha256: d42ae57366d05e12f10074583568355752436d66ad018ffbcfa24135f593810a
   md5: 1a98e48aa0bd8b3ec09e2cbdbb236575
   depends:
@@ -3894,7 +3894,7 @@ packages:
   license_family: Apache
   size: 498952
   timestamp: 1713213079520
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
   sha256: 5dc693f0e0aeb30cb6033015b13e75c8a21c56b1262d9652788c3e73a5c5c4a5
   md5: 6b5cc9b43aa34431f8c30b5cdc22004b
   depends:
@@ -3910,7 +3910,7 @@ packages:
   license_family: MIT
   size: 210522
   timestamp: 1715636148762
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
   sha256: 597015e8a038a111f03ffbc9a217fcda549d75230c86ce53c1f23c53d6f1a0cb
   md5: 62e98aac883bccc1c87ca0d2ce2f08e0
   depends:
@@ -3919,7 +3919,7 @@ packages:
   license_family: BSD
   size: 25798
   timestamp: 1678317074170
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
   sha256: 1430e6f4b4dd9354b7bb88f7f7bc9cdbab26a034ad1ae5c278de0f5a99329372
   md5: be0832862b29bf5767a707ac6bd53b93
   depends:
@@ -3928,7 +3928,7 @@ packages:
   license_family: Apache
   size: 114834
   timestamp: 1715878445060
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
   sha256: 885a9b6046e76f7dc1a346b14c63b4083046137bfae036362c854458e20e4fc8
   md5: 3b279447ca282d065e681e567055b582
   depends:
@@ -3937,7 +3937,7 @@ packages:
   license_family: MIT
   size: 137340
   timestamp: 1714717062907
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
   sha256: 5b6d5246955b5f9480ff7027eb002442a7ade24f5c354da54ed513042f76cedc
   md5: f32aa8a37d5e65a8dc30f9a1f46bc63d
   depends:
@@ -3946,20 +3946,20 @@ packages:
   license_family: BSD
   size: 54719
   timestamp: 1678325412288
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
   sha256: ed0152ad6b87ffd9e01f4a62bc358e805ad59637f898a801b0a9cf903ae8e1fb
   md5: 8a92f8c663608f24e14d8a2068b9d83a
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 415323
   timestamp: 1714511993944
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
   sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
   md5: c25b6d40f834647d0bbe767f6c776031
   depends:
@@ -3969,14 +3969,14 @@ packages:
   license_family: Other
   size: 329449
   timestamp: 1705602140856
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
   sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
   md5: f2519b551f99765d9d98950c5e2b4713
   license: Zlib
   license_family: Other
   size: 119782
   timestamp: 1714511811597
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
   sha256: 7feb73e79bdbd45404ddc7a30c43bf4cc68eced8ce448ce7c31f5db134276fc5
   md5: 48313bc6570c705cadbba3c356e0dc8e
   depends:
@@ -3988,7 +3988,7 @@ packages:
   license_family: BSD
   size: 1014151
   timestamp: 1714678461080
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
   sha256: 9ca3f0dfc2bdbc109e359ba7ab246e6ae952a14819148ad069454b52f2bda802
   md5: 51fb05873a644cac52f0d1e10cb7969a
   depends:
@@ -4002,7 +4002,7 @@ packages:
   license_family: MIT
   size: 228856
   timestamp: 1706220385566
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
   sha256: 43405cc7341ce3efb2e24013ad62c64f26a69926635adceaa5459ccbcafb3776
   md5: effa6d22f497e164cc8455f7f329c304
   depends:
@@ -4011,7 +4011,7 @@ packages:
   license_family: BSD
   size: 12510
   timestamp: 1677917870614
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
   sha256: 947efe1c50b3280e9a67cbb18636bdade53a40960fff3056850ff81ab87acbe3
   md5: 7d2d384ee32ccc12dcb0dc099e421482
   depends:
@@ -4021,7 +4021,7 @@ packages:
   license_family: MIT
   size: 35091
   timestamp: 1677915945226
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
   sha256: 8259b4a0973c825ac81f581afcbe86640bd0a94b33caa996167309241877635a
   md5: 49b8ddacfd3927bcaae139eadfb72ce1
   depends:
@@ -4030,7 +4030,7 @@ packages:
   license_family: MIT
   size: 153557
   timestamp: 1695717951839
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
   sha256: 11159a30daae77cfc1abe5e60c19261f65c005e6fbc460aecf72318514d737ad
   md5: 0c5002654a9cb21db1fdf8c1d2017df5
   depends:
@@ -4040,12 +4040,12 @@ packages:
   license_family: MIT
   size: 269772
   timestamp: 1681493072129
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
   sha256: 90439f37ede74ef464e76093e173a8e94a20ee4ad79c68c9e7570fbc67fc13cc
   md5: bb3b906307dd679fc3276be7581494f9
   depends:
@@ -4063,7 +4063,7 @@ packages:
   license_family: BSD
   size: 6073834
   timestamp: 1712084392983
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
   sha256: 688a071ba370f51b457cd32d70b7b38921ce9551203d06fa7fc2c30c4b79891d
   md5: b2353077a39ab997463768154dd58fec
   depends:
@@ -4073,7 +4073,7 @@ packages:
   license_family: BSD
   size: 134711
   timestamp: 1707864978809
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
   sha256: 048264434c33fdb53862cdd69b2e2bc4ce6f8a70b3211ad6d686d066eac2aa91
   md5: d55696ccaf6755931cd662dfb929aa0b
   depends:
@@ -4083,7 +4083,7 @@ packages:
   license: MIT
   size: 19737
   timestamp: 1714483270447
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
   sha256: 13627293296fcc231d8dc12d803dfc9621108c60df38b0e3c64e9e02ed55e564
   md5: 86efd4ad08cd80d3eab77873db84a255
   depends:
@@ -4092,7 +4092,7 @@ packages:
   license: MIT
   size: 19083
   timestamp: 1714483255364
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
   sha256: 2e542b2bb27f8379da3efcb83ef084cb26e6a9ab576c50487c2dd996afd5ccb1
   md5: e8cab9d1ef58a450f971690fcdb2ede2
   depends:
@@ -4101,21 +4101,21 @@ packages:
   license: MIT
   size: 380182
   timestamp: 1714483330655
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
   sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
   md5: 56d1386c7f1f338f0d18f82af6525273
   license: bzip2-1.0.8
   license_family: BSD
   size: 158748
   timestamp: 1714510571033
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
   sha256: bbfc668f445f3584936b326dcfe92bf71971ce16241f4f79db8aeb88d7aab41c
   md5: 10cc05ed51482e1dfcc31dbd13bb34c6
   license: MPL-2.0
   license_family: Other
   size: 138641
   timestamp: 1710764806818
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
   sha256: 512969f339a9a7b347cdb7b88f439819168089867f04732279f02759d8caf24e
   md5: 2009c2ee465fdd74dbd046de73726234
   depends:
@@ -4124,7 +4124,7 @@ packages:
   license_family: Other
   size: 166501
   timestamp: 1707229221324
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
   sha256: 8d26cd4d16545ad8afddd5521bc6894a50d5b8faff3abbe600bb9b062f3c3a0a
   md5: 66eb734b7d7008eb5fb537900767c7ae
   depends:
@@ -4135,7 +4135,7 @@ packages:
   license_family: MIT
   size: 286807
   timestamp: 1714483190838
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
   sha256: 808e56fb70f3d38599ee7a54c2a707b282ba9a401fa69a1f54cdc26425d9ce01
   md5: fc37321833175bda4fc5c21afe32db49
   depends:
@@ -4144,7 +4144,7 @@ packages:
   license_family: CC
   size: 539588
   timestamp: 1709758479776
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
   sha256: d9c126d8bcd1c89ea37186c172d6b1f73f45ada60e3ae1790a017b530baa0147
   md5: f0223aae3d622547f6accb212579c58e
   depends:
@@ -4154,7 +4154,7 @@ packages:
   license_family: BSD
   size: 17967
   timestamp: 1709322909223
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
   sha256: 1f908c688e47d03d92ac09d9541a1f1c773ac2ca485dd1d77441b1aaefc032db
   md5: 444c330471496a39a97e87f41ed70c96
   depends:
@@ -4165,7 +4165,7 @@ packages:
   license_family: BSD
   size: 281104
   timestamp: 1700583698464
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
   sha256: b9356e3ada4872c7c950d2ac7e0f107c4786775191efdfda3a469dffb18f2714
   md5: 07ddd96675caf30ea77cafb1ea5662a4
   depends:
@@ -4175,7 +4175,7 @@ packages:
   license_family: MIT
   size: 2490144
   timestamp: 1690905181398
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
   sha256: b1481ffa475c65200626f051d5dcbdb264730b533e928dde608a79ce7a5b4e48
   md5: aada2761547a291d68f4c016a1a9bc7b
   depends:
@@ -4184,7 +4184,7 @@ packages:
   license_family: MIT
   size: 18265
   timestamp: 1677911915719
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
   sha256: eb82a0e2ca36d0973b5f6642e27609554edad4b72696f989776d5db8cd4a6a42
   md5: fa8d9dd8a2fabba964c6bb75ace8c572
   depends:
@@ -4202,7 +4202,7 @@ packages:
   license_family: MIT
   size: 3201601
   timestamp: 1713551611540
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -4212,7 +4212,7 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
   sha256: 898d10bc1ededb43b7339ccf57fef404d96184de8ebaa788dba0b36a8c8a282d
   md5: a1925e4ff9f6124ca7d439430bc110fb
   depends:
@@ -4229,7 +4229,7 @@ packages:
   license_family: BSD
   size: 5399311
   timestamp: 1707836657705
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
   sha256: 765d5b7ef75ed7f52a110504cd88e9b0c9977b841f1beaeeabb17e629b462908
   md5: 0af9cd26a7c9eb8b77d3cbacb93a118b
   depends:
@@ -4246,7 +4246,7 @@ packages:
   license_family: BSD
   size: 360105
   timestamp: 1715090588763
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
   sha256: 4d4ab70ae0ce008c1cc96a4edfbf3866d5e636acc4799a545ea93acee51635f7
   md5: 86a085a440729020d1d7b0b74d6a0c6c
   depends:
@@ -4255,7 +4255,7 @@ packages:
   license_family: BSD
   size: 148448
   timestamp: 1714398923507
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
   sha256: 63670c8f31770e1746016f645ca6b42b35f92d1c37e8025793d9490fed9998c0
   md5: 9cb417b9fdf02b4e007a5b5781e5a8cc
   depends:
@@ -4277,7 +4277,7 @@ packages:
   license_family: BSD
   size: 229932
   timestamp: 1705934202146
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
   sha256: a40c76c412ec793ca26b97a9b5c496d253768438e1f7d4a0ee5f63ea79eed355
   md5: f609e4fe044318211cf0e37e289beebd
   depends:
@@ -4294,7 +4294,7 @@ packages:
   license_family: BSD
   size: 1614299
   timestamp: 1704833142734
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
   sha256: e57d10579b52a3cde45aa17e1bdd95dcb9d3346aa00eb02c51e38a42db83e18d
   md5: 05153120787fb09159b6e1ad902c6e10
   depends:
@@ -4304,7 +4304,7 @@ packages:
   license_family: MIT
   size: 1180481
   timestamp: 1678994989550
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
   sha256: 06512ef9a910fa72bf5697fe89e88c605d61f8478a9d8dd233c13f40e30f8446
   md5: cfa00c9ffd3407e29507525c020e5526
   depends:
@@ -4314,14 +4314,14 @@ packages:
   license_family: BSD
   size: 355730
   timestamp: 1706733720706
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
   sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
   md5: 055e12390b844ea6c6e956ee08a618e8
   license: IJG
   license_family: Other
   size: 273479
   timestamp: 1677849171867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
   sha256: 62025ce4a2b9244b9816c9e02487e0dda567600692b5f9ca71f425d084961c7e
   md5: d57b7063122e5bf25cdfc2a5ea7330a8
   depends:
@@ -4334,7 +4334,7 @@ packages:
   license_family: MIT
   size: 181872
   timestamp: 1699041739097
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
   sha256: 404b0847029f77bedd7902a170a046219e0dc5c0ec2be19ff45361cff25b2181
   md5: 3a02bbe8d45fdbcb2350f672be74c9f5
   depends:
@@ -4344,7 +4344,7 @@ packages:
   license_family: MIT
   size: 16524
   timestamp: 1699032463763
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
   sha256: 7deb8ad28c34c369573754304a03ea2acda8ee39102a56526ec689a4d9210109
   md5: 675ea1a746a78ff6bf8fc4b39139efff
   depends:
@@ -4360,7 +4360,7 @@ packages:
   license_family: BSD
   size: 277400
   timestamp: 1677914250715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
   sha256: 8220b1bbdde5e800810f7bf183a992af1a95825a837edf975fa8c4b51c5d806f
   md5: 3a06ddad06e04d5f0211c22cd81ca75a
   depends:
@@ -4371,7 +4371,7 @@ packages:
   license_family: BSD
   size: 94950
   timestamp: 1698937436979
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
   sha256: 8a9a9f9ddbf1b7744ef04a8c862438499a41d81a4beb4a49860156c273bb7497
   md5: 051355801f09eefe850ee8145151f934
   depends:
@@ -4387,7 +4387,7 @@ packages:
   license_family: BSD
   size: 42497
   timestamp: 1699282590553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
   sha256: 65c703cc996a705d0ee350070e313b1cae865f9d6e6490ebf1164c0f3ce22d93
   md5: 305ad8bcaad3e352d61b1e594093b467
   depends:
@@ -4414,7 +4414,7 @@ packages:
   license_family: BSD
   size: 596801
   timestamp: 1699466743685
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
   sha256: 501e929d345aaa9079c965552b942b4e8bde35b87ae89faef003687a40bab3a4
   md5: 54c7b8554a405acd7c8326c41ba93e63
   depends:
@@ -4424,7 +4424,7 @@ packages:
   license_family: BSD
   size: 28237
   timestamp: 1686870817418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
   sha256: 773e7c4571f482a744dfb18ae26fb22635f5d3f51389c838bd97f9044ea55cc4
   md5: 5161546aba5597318cb5653390cdecd8
   depends:
@@ -4436,7 +4436,7 @@ packages:
   license_family: BSD
   size: 20235
   timestamp: 1700168681687
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
   sha256: 8c1c64d51be73aad381992a9df19d8336910bdfc40f19940231df86e177d17cc
   md5: b1f786f96684a143cf30d1f6b8aebdb3
   depends:
@@ -4446,7 +4446,7 @@ packages:
   license_family: BSD
   size: 65045
   timestamp: 1677925371836
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
   sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
   md5: 7b5fd4df2a76303132c964bdc5e9c799
   depends:
@@ -4456,7 +4456,7 @@ packages:
   license_family: MIT
   size: 381078
   timestamp: 1628858598062
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
   sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
   md5: 255cac6bbe51bc940f6be144ce03bccf
   depends:
@@ -4465,13 +4465,13 @@ packages:
   license_family: Apache
   size: 150335
   timestamp: 1635523422442
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
   sha256: 199042b87451abaf14546af124ae3380194cddda928e0d30ccb341e93084854c
   md5: eaa0442887994a82486c65d87f6b71e6
   license: MIT
   size: 68806
   timestamp: 1714483212137
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
   sha256: bd9a8a17fb14086446b710fa029d238e69274b83ee2e7e09093496f190de82b5
   md5: 66615d6a0cb5dcca3e20c019cde0ed2d
   depends:
@@ -4479,7 +4479,7 @@ packages:
   license: MIT
   size: 32975
   timestamp: 1714483225840
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
   sha256: e1bf77e8b975c30a69b08a08410622e27c8cff6f592ccfa590466b83d9e6d104
   md5: 8af86bdac01fe303d693d9b76c071059
   depends:
@@ -4487,28 +4487,28 @@ packages:
   license: MIT
   size: 310266
   timestamp: 1714483239194
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
   sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
   md5: d7ab3e05dd4a208d00eb99f98157073e
   license: MIT
   license_family: MIT
   size: 57736
   timestamp: 1695996497021
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
   sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
   md5: f31e4eb9cd6447cc2f5ef0243a76540c
   license: MIT
   license_family: MIT
   size: 120460
   timestamp: 1714483461787
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -4517,7 +4517,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -4528,7 +4528,7 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -4539,7 +4539,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -4548,13 +4548,13 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
   sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
   md5: 72f5fa7b7f8ee7310e6c34fe115dd843
   depends:
@@ -4571,7 +4571,7 @@ packages:
   license_family: Other
   size: 637627
   timestamp: 1693575264127
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
   sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
   md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
   constrains:
@@ -4580,7 +4580,7 @@ packages:
   license_family: BSD
   size: 331675
   timestamp: 1694776939192
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
   sha256: 41c62a460bb81a1a272aa28b219fab9c26510adac177ff1528b1980eabc6e868
   md5: 8d312c5628dc7ea833e9b4dcb73e9c45
   depends:
@@ -4590,7 +4590,7 @@ packages:
   license_family: MIT
   size: 42346
   timestamp: 1677973051421
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -4599,7 +4599,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
   sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
   md5: f5f7e6e7541d8dc3d3df270d488d2e24
   depends:
@@ -4608,7 +4608,7 @@ packages:
   license_family: BSD
   size: 176990
   timestamp: 1714510588159
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
   sha256: d024f5142416961a5e66e424d4d14aec652f9e9dd738b41a97f45674c2ffc9d5
   md5: 0e2d94b125d802f7b006cf19c71655a1
   depends:
@@ -4617,7 +4617,7 @@ packages:
   license_family: BSD
   size: 163084
   timestamp: 1677932947966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
   sha256: acfd84e29ff4dc2d85543bb973a07f22b4ba53c5d00bca84608ee7f13b2a8676
   md5: 5ca161cd51e2db358e768453b3ee485e
   depends:
@@ -4627,7 +4627,7 @@ packages:
   license_family: MIT
   size: 135871
   timestamp: 1684279980293
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
   sha256: b1bed54c7bfb7304cde9e8e6f798543d08e808e81286a5a48296fc94d621f9da
   md5: 774358285c9e496c9f5c121cc546c823
   depends:
@@ -4638,7 +4638,7 @@ packages:
   license_family: BSD
   size: 27438
   timestamp: 1704206026910
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
   sha256: 9229a6e15abf3147cfcffad4ca389dad940e45779963b4fc3fd56dfdcfca3234
   md5: 4e1897f3cb4923de48c016468c01c051
   depends:
@@ -4659,7 +4659,7 @@ packages:
   license_family: PSF
   size: 9100733
   timestamp: 1713336457304
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
   sha256: 3276d61fc353c537bb09d4b7473d7abe12be38806f42c8cc383b62f40850a5cc
   md5: 6e9c9d47f264b77d9a8461f0899848a7
   depends:
@@ -4669,7 +4669,7 @@ packages:
   license_family: BSD
   size: 20446
   timestamp: 1677918370379
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
   sha256: 43c96d30775b61b4968422a47f9605049428120669f0742bbb9e5ba145c7d11e
   md5: a31ca0d9284860adf5463cf45a5e3145
   depends:
@@ -4679,7 +4679,7 @@ packages:
   license_family: MIT
   size: 69243
   timestamp: 1677995336989
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
   sha256: 96d8c9f42a38651b7bafe5f3cb132601db76cd1e28fa58e2eaf090e634292fff
   md5: 5ebc793a17b6aa84d13f19433545ffa5
   depends:
@@ -4688,7 +4688,7 @@ packages:
   license_family: MIT
   size: 23895
   timestamp: 1677942274932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
   sha256: db9bd659ada23f1ded443d2db00dd13b5d5c0b30f5062544b1ee2c2b88d63d29
   md5: 03c48121614cf12abfe30eced9b34717
   depends:
@@ -4699,7 +4699,7 @@ packages:
   license_family: BSD
   size: 105333
   timestamp: 1677916687032
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
   sha256: a8b3d349481dc694eb9a507f55c91e8981e2a3bc41743023ca01248c8a6d779a
   md5: 71e6e29ec3b98fb282c01b012a5df236
   depends:
@@ -4725,7 +4725,7 @@ packages:
   license_family: BSD
   size: 8294656
   timestamp: 1699543119360
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
   sha256: e8eee27fb667aa10b26f3bc4b93f449b7d991ded27b9cb457effee394ce05f6f
   md5: 6a3e5cd0e1141c01ffb91285bdccfe83
   depends:
@@ -4738,7 +4738,7 @@ packages:
   license_family: BSD
   size: 123043
   timestamp: 1698934328890
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
   sha256: 40230434aa2fbb33ece13632e8d4b7cd1ad68fdb8d1b00263af4a010795d25f8
   md5: f12ce7dad3620d6d53a442fa9d36a0b0
   depends:
@@ -4765,7 +4765,7 @@ packages:
   license_family: BSD
   size: 538067
   timestamp: 1699022954841
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
   sha256: a492acec8ceadc0911a75966ffa630a8eb15b2da8c7a8d544a645ba47771a2d1
   md5: 4002b1b88b2ecfdfc769036f43b0a895
   depends:
@@ -4778,14 +4778,14 @@ packages:
   license_family: BSD
   size: 170964
   timestamp: 1694616845237
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
   sha256: 417ace1ce51e81f3f92ddc26e0e3a83c1e19c9ebb7af7104452002a5573da534
   md5: 3e11de6cef096091bb733e07802f00b0
   depends:
@@ -4794,7 +4794,7 @@ packages:
   license_family: BSD
   size: 16979
   timestamp: 1708532698253
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
   sha256: 2e09ae8d10d7e5651727aab66a1e89b59e716295267a8295eaa53760c4c38533
   md5: 8d52be8699bf030546811bb69fbeb2b1
   depends:
@@ -4819,7 +4819,7 @@ packages:
   license_family: BSD
   size: 728383
   timestamp: 1690985022565
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
   sha256: b0cc542e2a6f42ba716e7e4ccf29eddcb155ad167fcdbc72d2db9c7873eb5639
   md5: 7acf81b17d2c4ceb3cd39dc9f173855c
   depends:
@@ -4829,7 +4829,7 @@ packages:
   license_family: BSD
   size: 27539
   timestamp: 1699455954000
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
   sha256: 151a3eb68d1189e69764ece1d8fb3544d31a22f5bbbc3e19d846de8dece304d2
   md5: eb6609e6bdc9c82d70df3f8c4c2de95b
   depends:
@@ -4840,7 +4840,7 @@ packages:
   license_family: MIT
   size: 153313
   timestamp: 1696515415712
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
   sha256: d3bb1d4be88320a5861cd3a0f086e9709f9b64c96c032cb9039cc4f17ec66a85
   md5: 0a7b97665c06fcd34a70e34abc177280
   depends:
@@ -4853,7 +4853,7 @@ packages:
   license_family: BSD
   size: 11288
   timestamp: 1708639168951
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
   sha256: 3e70248a7069ca12ccf56252869bfdb72211fd4e4c327e6994756496df786c79
   md5: ce4846006d98638cd86a532a72f8dfe4
   depends:
@@ -4867,7 +4867,7 @@ packages:
   license_family: BSD
   size: 7536860
   timestamp: 1708639153133
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
   sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
   md5: 371358a54bbdd307603888348d1a2c6f
   depends:
@@ -4877,7 +4877,7 @@ packages:
   license: BSD 2-Clause
   size: 412248
   timestamp: 1628861367714
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
   sha256: da78bd65c91881856baadf977534832f68db3938c1b5b713c8797be70b83c98c
   md5: f728656890f860eec5ad2899e657df3a
   depends:
@@ -4886,7 +4886,7 @@ packages:
   license_family: Apache
   size: 4763426
   timestamp: 1716318333548
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
   sha256: 77b0c0a0fb14d817390244ebd93c36d44a7867239963f211f7c0a72a3f98d382
   md5: b90336feb8a50d2eff880e89acb02f40
   depends:
@@ -4895,7 +4895,7 @@ packages:
   license_family: APACHE
   size: 39617
   timestamp: 1699371253760
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
   sha256: 4f6c3e8d8fc4c57975cab837ef109b9ee7af4f18aac72668334ac656e53c6edf
   md5: fbf1b507f9a80c5de3c957e8152124da
   depends:
@@ -4904,7 +4904,7 @@ packages:
   license_family: Apache
   size: 159289
   timestamp: 1710807498427
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
   sha256: 3af823879c340838c1040e99f653c3438ccce8dc559bd91c3f4ab2579282a002
   md5: 5b3df01fda0281dab4196bc36d1ca367
   depends:
@@ -4954,7 +4954,7 @@ packages:
   license_family: BSD
   size: 17082645
   timestamp: 1709591689205
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
   sha256: 8bf772501cf4b49a939de17bf378d3e395f452d3070d05871354bd2bc915d012
   md5: 753d2070a2aea47934ecf6ac1ea0bc04
   depends:
@@ -4978,7 +4978,7 @@ packages:
   license_family: BSD
   size: 21901817
   timestamp: 1714071405089
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
   sha256: 67feb8232961ad9d7672a49f6f86f0b86764f62a97d86d58b90ca7e8345bab76
   md5: 3afb6e6747bd29e9483d35dbf8b24f74
   depends:
@@ -4987,7 +4987,7 @@ packages:
   license_family: BSD
   size: 264413
   timestamp: 1711136882294
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
   sha256: 174b680f4bb041e8146aae80f92390122459e0ef8c911cab22d01e2e92d44ab1
   md5: cfffc94779cd26a349bd409b5590b098
   depends:
@@ -5003,7 +5003,7 @@ packages:
   license_family: Other
   size: 916496
   timestamp: 1714399019350
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
   sha256: 102c3c35a9dfa0f10ec8f4a040a24295f9c736443ccae2f685348a44f62a4d68
   md5: 027b347e79e252aa17b534e1a02bccd6
   depends:
@@ -5014,7 +5014,7 @@ packages:
   license_family: MIT
   size: 3447682
   timestamp: 1715097070362
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
   sha256: b6200816d65673aa1707c20a768c9cff87dd8dbe1335f9c1478e5931dfa08ee0
   md5: 14b1e0fa73eb33f9c83048482dcce57b
   depends:
@@ -5023,7 +5023,7 @@ packages:
   license_family: MIT
   size: 38423
   timestamp: 1692205689597
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
   sha256: ebdf211edd98d88a23778551c7a9702106edd0695d4fc48e87c21f77521c1ffe
   md5: d8c505081a468f1b99c62466e2309417
   depends:
@@ -5032,7 +5032,7 @@ packages:
   license_family: Apache
   size: 123084
   timestamp: 1678996822234
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
   sha256: 07cfba50d9e94364bde077731a824ca4f537138b35ee6b66d07aee16ac9850f1
   md5: 919bf486280a11e6acb3c2c3a82f7473
   depends:
@@ -5044,7 +5044,7 @@ packages:
   license_family: BSD
   size: 763225
   timestamp: 1704404463402
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
   sha256: 8094436b2c44e68e72569c704633802aad82e977b1e16026848218679c8becf4
   md5: 2360e46d3e598dd5e2abed781fe166c5
   depends:
@@ -5053,7 +5053,7 @@ packages:
   license_family: BSD
   size: 502115
   timestamp: 1678995719872
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
   sha256: 121b5b66721760c05f1d4eee91626229d1814663d3fb5f23126ef870aa496e26
   md5: 0c588c2ca790a05d422c06e8568201ad
   depends:
@@ -5062,7 +5062,7 @@ packages:
   license_family: BSD
   size: 2124200
   timestamp: 1684280082141
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
   sha256: 44b694db8e81d61960d28d60f9e9b573f03f7827881d302da334378881db4889
   md5: 6c94ba7caa599ff533e0ab55d898be8a
   depends:
@@ -5071,7 +5071,7 @@ packages:
   license_family: MIT
   size: 208454
   timestamp: 1677910948527
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
   sha256: 0bb3d2a57b332c5cf73ea40ea13c850ae24a1f9a3a41ed9267832d9e3c767572
   md5: 45a7fcf1641980d5114999736428502d
   depends:
@@ -5080,7 +5080,7 @@ packages:
   license_family: BSD
   size: 36755
   timestamp: 1677906514270
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
   sha256: 960c343b7b8569dfe4e71a395f7bede1e749da7b02c17506b590c9e1839e6fd7
   md5: 722c4b4386af73cf1562974a00c880a4
   depends:
@@ -5099,7 +5099,7 @@ packages:
   license_family: PSF
   size: 16494386
   timestamp: 1713545544909
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
   sha256: c3cbf5bd237b0a7458640191016b2701fe120c547df9afc835da76663a9c17f7
   md5: 843568c76b6b9384635b7fca74c79792
   depends:
@@ -5109,7 +5109,7 @@ packages:
   license_family: BSD
   size: 332222
   timestamp: 1716495881101
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
   sha256: f94b3cfea6f76ea9983e16d3c4c7e0a64f02c40cc2c3ad57189bca2e67030bd9
   md5: 0d100990ade57a02b60d1e8085db0bdf
   depends:
@@ -5118,7 +5118,7 @@ packages:
   license_family: BSD
   size: 280263
   timestamp: 1678996927464
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
   sha256: 252c86f5aef7f8dfce99a260c24cbb35a9adfea144a2acfabb224f516341544f
   md5: 745b888e19a644f48800799f82c01c21
   depends:
@@ -5127,7 +5127,7 @@ packages:
   license_family: BSD
   size: 18539
   timestamp: 1683823925189
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
   sha256: d945744eb133f19ca61325cac5128bdb053ae04de4a0ba6f69c061449cac8af7
   md5: 34baa81490d667381bc7021435b0e1f2
   depends:
@@ -5136,7 +5136,7 @@ packages:
   license_family: MIT
   size: 275858
   timestamp: 1713974457562
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
   sha256: 012585bdb5ae54c2cded50be703734e6dbf418b003635b6f6d7c1e36e7020c30
   md5: da7e99a707bd0cfa20db651b5c068bfd
   depends:
@@ -5148,7 +5148,7 @@ packages:
   license_family: BSD
   size: 65556
   timestamp: 1711136890180
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
   sha256: 4f04a43cbd612ab09cefbdc2e48ee61b51967dad59d859ce0502cc2c46c88fc5
   md5: c68bf65433b2151b51b2e699bc22c501
   depends:
@@ -5158,7 +5158,7 @@ packages:
   license_family: MIT
   size: 194632
   timestamp: 1698096151085
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
   sha256: ae8cdd5be5a7ad19ff82925a035859fafcc5942cd3899d127a508dbb9a235090
   md5: 252a7b997d08bf72f10b3bc2dc68333e
   depends:
@@ -5168,7 +5168,7 @@ packages:
   license_family: Other
   size: 580346
   timestamp: 1709318480624
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -5177,7 +5177,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
   sha256: 7a208abc002a2fc208ae25cb2cf932999a3e4980aa4c9edff315cb9ac62b12ce
   md5: bd22ebd3cff811577ea61f115ba7f4f2
   depends:
@@ -5188,7 +5188,7 @@ packages:
   license_family: MIT
   size: 74744
   timestamp: 1699012126255
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
   sha256: cc8d055a068fe5a7484284c3360d81db61656dd6118c743c740fcc47cd3da379
   md5: e5fad71ef3b99077b79052576e51bf9f
   depends:
@@ -5204,7 +5204,7 @@ packages:
   license_family: Apache
   size: 120672
   timestamp: 1707355664440
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
   sha256: 52368d9b557b8f54ef5ca4bf6cd5a3ec665171f2b2d2082cdd410bab88f4829c
   md5: ac76fb4d2eef3ecdd491cf5d3fb8620d
   depends:
@@ -5214,7 +5214,7 @@ packages:
   license_family: MIT
   size: 10204
   timestamp: 1683077239143
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
   sha256: 491d116c5f54ef340e3bce631835f7138cd1923d7b63e6ca9aa01b48110cb8f9
   md5: 9b81bd8ea808704f5433884b567f1f15
   depends:
@@ -5223,7 +5223,7 @@ packages:
   license_family: MIT
   size: 10557
   timestamp: 1683059079547
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
   sha256: b53a5f6119173d62e4e68a37ea8511c7fc87a00af72953e0048d075a799c7a7a
   md5: 76a16cf4edb9b12b2b96a2d323f060dc
   depends:
@@ -5232,7 +5232,7 @@ packages:
   license_family: MIT
   size: 342535
   timestamp: 1698945991201
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
   sha256: c80d52567084b1caaed2862b77b70065ca17afaf0b020733e9d6c273b4a63e78
   md5: ddf7d88c1967f3f7a4ce1c975fd47e0d
   depends:
@@ -5241,7 +5241,7 @@ packages:
   license_family: BSD
   size: 33321
   timestamp: 1699371225235
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
   sha256: 6d38d171ef87340cf0fbbf4c70217df4826c65400c9290774f5cb35e381e3315
   md5: b9529a812f9862fc89461b6b90f184ba
   depends:
@@ -5250,7 +5250,7 @@ packages:
   license_family: MIT
   size: 1599110
   timestamp: 1715024190898
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
   sha256: cd71091a234874d2826fa063ec5222b3191c9f47e1b5281c352d9df3f31a06bf
   md5: 0db8e29016c6bff026c083d9923a7566
   depends:
@@ -5259,7 +5259,7 @@ packages:
   license_family: Other
   size: 19073
   timestamp: 1705431415504
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
   sha256: 3e18cdafc607c6d7623b1c8f041cbfbb50a27e298f961abdcce7e36834ac39e1
   md5: 9ee0da74c55d0b8d83edf246fd717f20
   depends:
@@ -5268,7 +5268,7 @@ packages:
   license_family: MIT
   size: 89862
   timestamp: 1696347657368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
   sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
   md5: d8c1e9910392d0bcb22a173f9ce30fa6
   depends:
@@ -5280,7 +5280,7 @@ packages:
   license_family: Other
   size: 1758290
   timestamp: 1714488307689
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
   sha256: b5c265e9ed9a1ff2238a09b83bdc1826950faa87fd6b685debe60888de6e7a50
   md5: 5827c8a32317894ce18576e334daba47
   depends:
@@ -5291,7 +5291,7 @@ packages:
   license_family: BSD
   size: 38559
   timestamp: 1677918962258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
   sha256: cfefd86d0f4981d22b7611b3dc60359b8698bf39f2b743cb90b7005aaca88e1e
   md5: a04dbcd6095f6b8f3ad195a78d48b262
   depends:
@@ -5301,7 +5301,7 @@ packages:
   license_family: BSD
   size: 50058
   timestamp: 1677917499177
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
   sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
   md5: 3c25b4f4768ccda28b20a03ba27e7759
   depends:
@@ -5310,7 +5310,7 @@ packages:
   license_family: BSD
   size: 3484151
   timestamp: 1714770744982
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
   sha256: 177246487449f87567fe56c8f20011a4350a132d1556c9f87474d7b2e8c1374f
   md5: d465118217b9f27d47dceff89c2e9f95
   depends:
@@ -5319,7 +5319,7 @@ packages:
   license_family: Apache
   size: 896655
   timestamp: 1696937042980
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
   sha256: 81efb240a49cede5ece3a8ad48f1d9dfdeb56260bf1a20e25ec53cdb202f7c3e
   md5: 81a17d13c75596841b95340a34bbe929
   depends:
@@ -5330,7 +5330,7 @@ packages:
   license_family: MOZILLA
   size: 155516
   timestamp: 1716396017482
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
   sha256: 65e760119352cd85c63d365d2576c09a9ddb060e5b029a265d50bc268eed9290
   md5: 14c241871b12dc3be52e6cd681267caf
   depends:
@@ -5339,7 +5339,7 @@ packages:
   license_family: BSD
   size: 271445
   timestamp: 1677911758960
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
   sha256: 96071e07e807414b7ae5a2fe958ac171e5795576b3a4c2f5e8c643fba43d760f
   md5: a34f2b216e35a37f966883dacda229e2
   depends:
@@ -5349,7 +5349,7 @@ packages:
   license_family: PSF
   size: 9902
   timestamp: 1715268985387
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
   sha256: b20e48aff4c781a52b6be66d77418e768527a621f5fc272ecb34ea03475b2bd7
   md5: 707738432f16f5e63909fcaa6e65850d
   depends:
@@ -5358,7 +5358,7 @@ packages:
   license_family: PSF
   size: 75604
   timestamp: 1715268976065
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
   sha256: 2ea2d0520b330d381a2ab241bdb9ae146ef815ee7c96ee52a9773fb9ae85f4fd
   md5: 66f7f8979cfb2cccffac972d70482130
   depends:
@@ -5367,7 +5367,7 @@ packages:
   license_family: MIT
   size: 12614
   timestamp: 1677963554857
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
   sha256: df7fe7740bd853b641d624e2ec97f1aacb2b82691936a8c04ef18fa9768539c2
   md5: d5c7626d45fd03b22797c18e47812beb
   depends:
@@ -5376,7 +5376,7 @@ packages:
   license_family: Apache
   size: 518048
   timestamp: 1713213046424
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
   sha256: 3fbcccceb4d7d99f60a6e6e013ab84c4532244c42ab9d65b6fdaab6bd30f7269
   md5: 6a7e05872852d4bcde959f7cc8407672
   depends:
@@ -5392,7 +5392,7 @@ packages:
   license_family: MIT
   size: 210307
   timestamp: 1715635933070
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
   sha256: 09738b7f9075386bf062b12ddb6fb72a06450d2481f6b5ca2026c811cd849569
   md5: 9afdec076c95746ac21235f971190e40
   depends:
@@ -5401,7 +5401,7 @@ packages:
   license_family: BSD
   size: 26727
   timestamp: 1677910175964
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
   sha256: b4ced7366de8eb7258f31d516616e70c62ed4a798780e57e208509d2b52ab435
   md5: 65a9a05a726734c1da667f9bd3c78c14
   depends:
@@ -5410,7 +5410,7 @@ packages:
   license_family: Apache
   size: 114733
   timestamp: 1715878377412
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
   sha256: aa301d9e42aadbe3dd5f301ccbf17fbadc347fd37d413c0cbcbd24403892a936
   md5: 77097d17d835a137af7950c628b66150
   depends:
@@ -5419,7 +5419,7 @@ packages:
   license_family: MIT
   size: 137260
   timestamp: 1714717037687
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
   sha256: 2cd108896df65636769e3804ecc2ca421ad9b54e64fa21922bbabe40c90c247a
   md5: b3a1e5077b28f71298d891fbfb5ff03e
   depends:
@@ -5428,20 +5428,20 @@ packages:
   license_family: BSD
   size: 55645
   timestamp: 1677927459979
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
   sha256: 5be8c968f2da5c4bf14f28d63e31b4c1b6993d980023769732c7f58f396c2e0b
   md5: 3f5f62d4e85e3bdd48d39189b01805a6
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 459197
   timestamp: 1714510992914
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
   sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
   md5: 3d57d1adadca9388aaaa1c529b65ba65
   depends:
@@ -5451,14 +5451,14 @@ packages:
   license_family: Other
   size: 322790
   timestamp: 1705602163804
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
   sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
   md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
   license: Zlib
   license_family: Other
   size: 104928
   timestamp: 1714510936868
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
   sha256: a3f3eaf240991b6bd7b0596a78d0abb3321cc79db52fa24f6f559189778871c6
   md5: 71f035b4716322539e2461cb6667e946
   depends:
@@ -5470,7 +5470,7 @@ packages:
   license_family: BSD
   size: 825339
   timestamp: 1714678419523
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
   sha256: 6e6787755de0cf2fd776c9681a7b0fd0fb23e35e679a463cc2005b991c413910
   md5: ccad42ec9a2ad48939f089c528abc8f0
   depends:
@@ -5484,7 +5484,7 @@ packages:
   license_family: MIT
   size: 229694
   timestamp: 1706220431719
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
   sha256: f715f7c2e06149bd6d43258e41479d3171efe5e9d56050a0a5f5652ed9d05fff
   md5: 11a8ca43d69881b88f95ae681478866d
   depends:
@@ -5496,7 +5496,7 @@ packages:
   license_family: MIT
   size: 36089
   timestamp: 1676424516042
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
   sha256: 9adabcdd2a10f73fa5ba56adc901eeea2e379991a0d4cb9737eec7aa6b9fc5d8
   md5: fc80b572be85601706d425b21a58d497
   depends:
@@ -5505,7 +5505,7 @@ packages:
   license_family: MIT
   size: 153102
   timestamp: 1695718054194
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
   sha256: 38ccda1553733326d99a75436b4b0f7640bafbbfcdbc33838b0e59cf017de687
   md5: 3f6812578c5e0b3ba0d2a651cc766c15
   depends:
@@ -5515,12 +5515,12 @@ packages:
   license_family: MIT
   size: 266405
   timestamp: 1681493141116
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
   sha256: fe765d810e1612af7a42f34223077f0adc05dbd386b257be24661913d067fe30
   md5: 82e988aba03c8afa03fce78f7442806e
   depends:
@@ -5538,7 +5538,7 @@ packages:
   license_family: BSD
   size: 6086137
   timestamp: 1712084583317
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
   sha256: 5c12a5d7856d9977447360b3a99a5b99818707fe79781ba1779037f11b3fef53
   md5: 6a125ae352306a944aabc635a5fe13a3
   depends:
@@ -5550,7 +5550,7 @@ packages:
   license_family: BSD
   size: 139230
   timestamp: 1707864402762
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 751071782f597f87ed7f67437ef6cc669213902461b9795dd6eb0f4897eddc83
   md5: 5ad8fe62aad5e16cfdf2c5a7d1327fe7
   depends:
@@ -5562,7 +5562,7 @@ packages:
   license: MIT
   size: 19418
   timestamp: 1714483531456
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 9bd62d810867549b9c967c5915f3fa3f66cfbd6ede28b1cc152efd1261285c0a
   md5: 64cc76de3662b62bc8f0e42befd92c5d
   depends:
@@ -5573,7 +5573,7 @@ packages:
   license: MIT
   size: 32178
   timestamp: 1714483513837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
   sha256: 1547fa52134cf06b8d01bdf52114db7db60a89bf35c9c95be5b5a03b13dbd565
   md5: deb765cb7c4b7edc4d126f864f31747c
   depends:
@@ -5583,7 +5583,7 @@ packages:
   license: MIT
   size: 356401
   timestamp: 1714483740924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
   sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
   md5: 11e0af09a31e2d5df51c65a342032b85
   depends:
@@ -5593,14 +5593,14 @@ packages:
   license_family: BSD
   size: 112994
   timestamp: 1714511182837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
   sha256: 73391a74a5300ad3fb063ea0f0c3491d220128a0611a84036da2e23c1e93dc0e
   md5: 501ded4f9b5ed895077802defee912cf
   license: MPL-2.0
   license_family: Other
   size: 171644
   timestamp: 1710764856021
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
   sha256: cd6545642e380b13700f2f2a7a1fb54a273365047bd23108dbd03b197f5c0c9c
   md5: 929edc1c553d2da4d6c6c0745b033cc3
   depends:
@@ -5609,7 +5609,7 @@ packages:
   license_family: Other
   size: 166377
   timestamp: 1707229328635
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
   sha256: 5cb6ac90ad234248f3795945f69b0382397714a52712337b2f86339526b822d8
   md5: b90f3126f6315ea2e8ab242533062557
   depends:
@@ -5621,7 +5621,7 @@ packages:
   license_family: MIT
   size: 302693
   timestamp: 1714483562551
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
   sha256: 4099898f02e1f6119fcda65e747c3cbfef0bf563c8855b79a0245160709d5b45
   md5: ab9705c34e67fb8c8faec69d63ff4064
   depends:
@@ -5630,7 +5630,7 @@ packages:
   license_family: BSD
   size: 36410
   timestamp: 1676422341506
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
   sha256: c722f50980d7416ffb2cfc7bf72649307a0bb78c5a24eccefcd049cb61d6b355
   md5: c7c9ff0513ff3c99700919293b702410
   depends:
@@ -5639,7 +5639,7 @@ packages:
   license_family: CC
   size: 543258
   timestamp: 1709758602437
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
   sha256: 8fb3e816a5ad1da05125462dbc9e2a7e933b001a871aa65703802c0a894c6277
   md5: ee4b2fa9fce130496d5c7c86c35a1a05
   depends:
@@ -5649,7 +5649,7 @@ packages:
   license_family: BSD
   size: 17723
   timestamp: 1709323150229
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
   sha256: eeb49cd151ecdccd40062e8123a3b7a9a8a1eda6567dd33ce909ff8ee1a97c89
   md5: b7fe1f7ead1ec2ac642d022942282fc8
   depends:
@@ -5661,7 +5661,7 @@ packages:
   license_family: BSD
   size: 232451
   timestamp: 1700583772701
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
   sha256: 5c73f86e575f2ad683ee4a1c2df11020e270edd89d12f11199483d57b0b51826
   md5: e96a12895ce374476277b1b196ba24bd
   depends:
@@ -5672,7 +5672,7 @@ packages:
   license_family: MIT
   size: 3719519
   timestamp: 1690907216785
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
   sha256: 5d5fc8a24c804010b8cb5963227230352ea3ccf56bea9e8116e34f77223218f2
   md5: 8f989a72eed6293dfe0533c83057980d
   depends:
@@ -5681,7 +5681,7 @@ packages:
   license_family: MIT
   size: 17688
   timestamp: 1676423357100
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
   sha256: 27fb03eb57d25711a15e145f47a64320a9955b585efc9fd0a1a51cdd71b9fde3
   md5: eb3869e98f6f53dfec76e2eff4d6b61e
   depends:
@@ -5701,7 +5701,7 @@ packages:
   license_family: MIT
   size: 2732423
   timestamp: 1713552175344
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -5713,7 +5713,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
   sha256: 68d59a361a93a5ae36542f667138b4ab072e1abff15b3aa2dc55575baf86a3e9
   md5: 383239566d9506b743c7bc65d709b7e1
   depends:
@@ -5730,7 +5730,7 @@ packages:
   license_family: BSD
   size: 5374020
   timestamp: 1707836834797
-- conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
   sha256: dee3fc68ed81398d232b3afe9a032837bdbef98c1b2478604d6abd397e3e7d64
   md5: 3f75535ca6dfee0745b221922f21f6de
   depends:
@@ -5747,7 +5747,7 @@ packages:
   license_family: BSD
   size: 353312
   timestamp: 1715090519918
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
   sha256: 102c803186db6d62eaf41a906f6c563ff0d62b53c1eaede8a381e18c0d005ed9
   md5: 9d30dec03058758a428cf152e0ae28b5
   depends:
@@ -5756,7 +5756,7 @@ packages:
   license_family: BSD
   size: 148193
   timestamp: 1714399061601
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
   sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
   md5: d215cc8ee7ca2cc83cc250cc5d822fe0
   depends:
@@ -5766,7 +5766,7 @@ packages:
   license_family: Proprietary
   size: 3929136
   timestamp: 1699647939158
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
   sha256: 864e9598f64105769b4ec02cc404fb507bc59e217324daf1686c00cfd12c0055
   md5: 6bb1c3be1f85799a3988afc2c3c5a4f0
   depends:
@@ -5787,7 +5787,7 @@ packages:
   license_family: BSD
   size: 229621
   timestamp: 1705934494547
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
   sha256: e0b44f0c3a4ead0fb8e58033c0be25524ee9ecf7f4cc632f03e9f6fac3484baa
   md5: 50cbc18d0c7b42a4553b52d0cef2c857
   depends:
@@ -5804,7 +5804,7 @@ packages:
   license_family: BSD
   size: 1637367
   timestamp: 1704834149957
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
   sha256: d81566367c79a28d4717157fc74293e846a47af99387ed479eb001a425dd398e
   md5: 28c76079c96ad7f8b1a5ed32b438c79a
   depends:
@@ -5814,7 +5814,7 @@ packages:
   license_family: MIT
   size: 1147434
   timestamp: 1679427525584
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
   sha256: f766a445df8e81447f27c830e162566b221fa1bfc41296a6c5e0789586ca1fbf
   md5: 55bc50633414fc8616ccbf4140a42d5f
   depends:
@@ -5824,7 +5824,7 @@ packages:
   license_family: BSD
   size: 353715
   timestamp: 1706733949898
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
   sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
   md5: 81f2c343dc4c65eea39c45383272068f
   depends:
@@ -5834,7 +5834,7 @@ packages:
   license_family: Other
   size: 407861
   timestamp: 1677849239400
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
   sha256: 5e6698015a3b048093f5737f0e54bcbae415d0f9682dfdfeae3a8cfb4ea275e2
   md5: 0093a4214131046c4f68af0739dfbea4
   depends:
@@ -5847,7 +5847,7 @@ packages:
   license_family: MIT
   size: 201456
   timestamp: 1699041872445
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
   sha256: 9581be54128954080d7cef448b1728874c2ebbe5064f55adece422cf12eafa5a
   md5: 3adc105f87d5c7f0b1248bc3423f5b48
   depends:
@@ -5857,7 +5857,7 @@ packages:
   license_family: MIT
   size: 16187
   timestamp: 1699032556953
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
   sha256: ad8343bad7c8f0448cbcfbaf872cc94b56da81c52e5cdcee2a5d6b89f029eb75
   md5: addceff8d46c9d1d322618a9ce9e5b39
   depends:
@@ -5873,7 +5873,7 @@ packages:
   license_family: BSD
   size: 300354
   timestamp: 1676424060532
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
   sha256: 851ae576c2b72bf3172cd460feec4f5577dc06476a043e185279071b67549fab
   md5: fae4d214d00de6604738f39acbbb197e
   depends:
@@ -5885,7 +5885,7 @@ packages:
   license_family: BSD
   size: 119710
   timestamp: 1698937651636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
   sha256: d97ad90f9121ecf7f8d3af773b222c0bd244204ee73a3e44185491fa16d83104
   md5: 73ac0fa3c67e5eb283173d74a2771752
   depends:
@@ -5901,7 +5901,7 @@ packages:
   license_family: BSD
   size: 60625
   timestamp: 1699282918176
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
   sha256: 257e1102d2dc3f8b0c1708585c819e86f41abd101084cd0569e8e31652480875
   md5: 2128c6806bba6953e1a275f37e7a295b
   depends:
@@ -5929,7 +5929,7 @@ packages:
   license_family: BSD
   size: 614705
   timestamp: 1699467242943
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
   sha256: 90420847230e72a648417f5f77cebcf7f17b89f70788652c276acc0c440e135f
   md5: ef3d8dee197aa37897bf6d39d2dd878f
   depends:
@@ -5940,7 +5940,7 @@ packages:
   license_family: BSD
   size: 27639
   timestamp: 1686871052174
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
   sha256: 97faaf26ce5254ec3649a8ee7f480b1556e4e8e6e4356d2fab1e6a5532631a0f
   md5: da23bd831c50c877f63038b7e16720ad
   depends:
@@ -5952,7 +5952,7 @@ packages:
   license_family: BSD
   size: 20163
   timestamp: 1700168785472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
   sha256: 8a2f0909fad0387e57cb0e9ee30db2b20761a9106e794381ffeac387a298fb07
   md5: 6058b2efc3284e27aacec2e6e6280433
   depends:
@@ -5963,7 +5963,7 @@ packages:
   license_family: BSD
   size: 62334
   timestamp: 1676432044242
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
   sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
   md5: f5f73266281ab12377d5d47bdf07500a
   depends:
@@ -5975,7 +5975,7 @@ packages:
   license_family: MIT
   size: 905072
   timestamp: 1617648814933
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
   sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
   md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
   depends:
@@ -5985,7 +5985,7 @@ packages:
   license_family: Apache
   size: 145864
   timestamp: 1635523278997
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 7c906c94a4d46ea963080a6ba5bd12c1274da66159877a544fbc70291eeed98d
   md5: 45a3d52534fac8aa54a55ee92211a918
   depends:
@@ -5994,7 +5994,7 @@ packages:
   license: MIT
   size: 80216
   timestamp: 1714483371043
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
   sha256: daad7edc6d56abf3e176479e8628162dbf1c56b3d24db30d708aebae694a5214
   md5: e8ecf229f7fcb4c0b76d8613627948f5
   depends:
@@ -6004,7 +6004,7 @@ packages:
   license: MIT
   size: 45189
   timestamp: 1714483420152
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
   sha256: 84320217abffa9386186ec8d03b4651bb4b1900d3871adc965a9a9e1d3799907
   md5: 651312fa22168f71f9aec5f9ee2c2fcf
   depends:
@@ -6014,7 +6014,7 @@ packages:
   license: MIT
   size: 756116
   timestamp: 1714483464368
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
   sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
   md5: 2539073f9c3b4126f8fef179e4a2697a
   depends:
@@ -6024,7 +6024,7 @@ packages:
   license_family: MIT
   size: 187095
   timestamp: 1695996637011
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
   sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
   md5: cf949d76148be1e2a534218d9c57df86
   depends:
@@ -6034,7 +6034,7 @@ packages:
   license_family: MIT
   size: 155435
   timestamp: 1714484319443
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -6045,7 +6045,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -6054,7 +6054,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
   sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
   md5: 169f1c9be4b9af46ce5dfab2dab660b4
   depends:
@@ -6071,7 +6071,7 @@ packages:
   license_family: Other
   size: 1460728
   timestamp: 1693575386348
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
   sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
   md5: b1781519a200ccbfcb4a1194005aa3ef
   depends:
@@ -6083,7 +6083,7 @@ packages:
   license_family: BSD
   size: 338459
   timestamp: 1694777084290
-- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
   sha256: 4534c822511a052a72c2b070a05e5d8d6f3550f18ea00a33f9d8a9a92b4382cc
   md5: 82f24e7660831445a2183216e280a6a4
   depends:
@@ -6093,7 +6093,7 @@ packages:
   license_family: MIT
   size: 41464
   timestamp: 1676474474981
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
   sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
   md5: 320f40b75d93f3b96931c6d13c23946c
   depends:
@@ -6103,7 +6103,7 @@ packages:
   license_family: BSD
   size: 158902
   timestamp: 1714512129889
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
   sha256: e0dc6e119b224bb31ef34b6ba270ffadc181d38b698c5318de8df7a5d2c4ccbd
   md5: 992ccd756f09408f0b74dfb9852a8b7f
   depends:
@@ -6112,7 +6112,7 @@ packages:
   license_family: BSD
   size: 182381
   timestamp: 1676437963591
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
   sha256: 050b5fd4b28132d8102a7e6b40179894dc7f5e41f7ad9ee19211e67446c5740f
   md5: 3ae0b2f6baec708554648ddafa81b756
   depends:
@@ -6122,7 +6122,7 @@ packages:
   license_family: MIT
   size: 154386
   timestamp: 1684279992864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
   sha256: 8269c73b7a9c03b95a121e318d0468f35eecc016093620b0560f35238cc5df51
   md5: 2914bea0ae29315f998e1abac79ccaa8
   depends:
@@ -6135,7 +6135,7 @@ packages:
   license_family: BSD
   size: 30214
   timestamp: 1704206218108
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
   sha256: 68fb7d113dbf185b571343847e3dbefdbe7d0b9b5902f1f390bc2a6e33a3f8ee
   md5: a72ff718390a1fde0b208a43e6b9b655
   depends:
@@ -6157,7 +6157,7 @@ packages:
   license_family: PSF
   size: 11366001
   timestamp: 1713336740870
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
   sha256: 43279276850eb6e621812448cddc1093524cee0b7f8ed58b4600b68a4fb659f2
   md5: 5968b2b5c1f3cf5c8c8c9aaa4d8d66a2
   depends:
@@ -6167,7 +6167,7 @@ packages:
   license_family: BSD
   size: 19886
   timestamp: 1676425829787
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
   sha256: 3062a8254ca351b54f15bea85cc928a3ba4d879bb98ce97ece39a9f7eca215a5
   md5: 8f1565663abb34ad7fdd512e76da5532
   depends:
@@ -6177,7 +6177,7 @@ packages:
   license_family: MIT
   size: 68031
   timestamp: 1676481862508
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
   sha256: cdff5215c292fe59649ca40ca72f5d26da352760c1d6a56feba14eb13f7bbf61
   md5: e0f3f32b22135dfeaec277bc87183ca9
   depends:
@@ -6186,7 +6186,7 @@ packages:
   license_family: MIT
   size: 23328
   timestamp: 1676442709081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
   sha256: 3b173a25605d2aaacc57ec0e425f1d1c51327eb2521c8742a736e2c76069bc8d
   md5: 169f1c93a443f95a88665f3008623ce1
   depends:
@@ -6197,7 +6197,7 @@ packages:
   license_family: BSD
   size: 104882
   timestamp: 1676425142412
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
   sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
   md5: 527155127b9fada5e5c5c69a624674b9
   depends:
@@ -6209,7 +6209,7 @@ packages:
   license_family: Proprietary
   size: 187498166
   timestamp: 1699648376430
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
   sha256: cea59ae60da314caecf08edb9bcb03126c6dd35837c8184bceaa194decca3341
   md5: 30936b7263cf0171f7c86400f12ef184
   depends:
@@ -6221,7 +6221,7 @@ packages:
   license_family: BSD
   size: 49080
   timestamp: 1682975093455
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
   sha256: 5070ceb0a406b1b8b99e2ec58f5d224cbe16ec78109c46720bd182b509e05c6e
   md5: 34de1af5c639f2d06c6c8d99488e4226
   depends:
@@ -6236,7 +6236,7 @@ packages:
   license_family: BSD
   size: 196201
   timestamp: 1695058367111
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
   sha256: 6b4b27302e458fa527321c59be7c335d61f86da7501c4d141db20a72fad68b55
   md5: 7db9b12da1290bb2c2fc6ee52a945905
   depends:
@@ -6251,7 +6251,7 @@ packages:
   license_family: BSD
   size: 256371
   timestamp: 1695060425702
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
   sha256: 5422fc4dc6708279223027e45dd1ccffe4dc2feb93c60c8a683946a398c60a1c
   md5: 62d16437707dd382c21a9ed1d8b375dc
   depends:
@@ -6277,7 +6277,7 @@ packages:
   license_family: BSD
   size: 8304222
   timestamp: 1699543942441
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
   sha256: e940f9178ee2fa0a7c12873ae35ebea0074371653e5cfa1be8aa8d9271fd343b
   md5: 355d0835215911738a28010dfa6aa382
   depends:
@@ -6290,7 +6290,7 @@ packages:
   license_family: BSD
   size: 141785
   timestamp: 1698934346590
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
   sha256: 47dd00c0179f4eb29c70d0453d340f7f5332af326b3d51c64ca3bf6a14be8e7e
   md5: f66afe718bdb57667b03ebda4cb2ac7e
   depends:
@@ -6317,7 +6317,7 @@ packages:
   license_family: BSD
   size: 561655
   timestamp: 1699023338436
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
   sha256: 4ee863a1ff697274c642b3101f82b279a354e3f033a87505655039f89127bb41
   md5: bfaf19be6644ad2344e118aa0acccb13
   depends:
@@ -6330,7 +6330,7 @@ packages:
   license_family: BSD
   size: 189809
   timestamp: 1694617194065
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
   sha256: 90fb3f14c49da1397982eae21cd09e8d60d491d76f94c57590c56723fe6dc172
   md5: 46a523661fe5c1bce7b4213fd428c3de
   depends:
@@ -6339,7 +6339,7 @@ packages:
   license_family: BSD
   size: 16732
   timestamp: 1708532795328
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
   sha256: 5db3fd8b4d97e2a6232e2f7c62f1ce82ae3876326aed9f8c3ea656eda83e55da
   md5: 39c36df9dac13398e8a54497dcc14611
   depends:
@@ -6364,7 +6364,7 @@ packages:
   license_family: BSD
   size: 755697
   timestamp: 1690986137327
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
   sha256: e040ebcab948325fbe17e4ab15be62e1fafa7bad225457e59764adb60eb40db5
   md5: 4d40a09df8cb74a9f044eab317436d67
   depends:
@@ -6374,7 +6374,7 @@ packages:
   license_family: BSD
   size: 27282
   timestamp: 1699456187703
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
   sha256: d3bd2a6614bb7e7f5ce3348d6674e71cce45cbde236beff32f0f08cd95a64ef0
   md5: e70f15643164f432d1df68635e7c322b
   depends:
@@ -6389,7 +6389,7 @@ packages:
   license_family: MIT
   size: 162691
   timestamp: 1696515822068
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
   sha256: 470fe9a0b3e196fa60d5550d8188f6074a207572fa0d353a4448d580872e7804
   md5: 6fdb8df0613fb2fb9f1732d335fa25f1
   depends:
@@ -6406,7 +6406,7 @@ packages:
   license_family: BSD
   size: 11053
   timestamp: 1708641901110
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
   sha256: 222c1711e7cf151e29077c7d4d86a865c9fd39615812d58a1daca6fd1b6bdfb5
   md5: 585bcd8bc3940a8a859f38ebafdcd77d
   depends:
@@ -6422,7 +6422,7 @@ packages:
   license_family: BSD
   size: 10723862
   timestamp: 1708641867155
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
   sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
   md5: ab07e2a27ac08afe3d0b4c0890b8486a
   depends:
@@ -6433,7 +6433,7 @@ packages:
   license: BSD 2-Clause
   size: 249316
   timestamp: 1630094024143
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
   sha256: c8e066c2cb547914401ec29b7356914ca3cdf6ac37eead248fe0c41236a7838c
   md5: 5879739cc77497a518b2ebd55857183b
   depends:
@@ -6444,7 +6444,7 @@ packages:
   license_family: Apache
   size: 8118619
   timestamp: 1716319803768
-- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
   sha256: b2f5f50a1ddf811102636f3acebd76716c88ebb628754b91eda7a3a962adf26c
   md5: 712527b4d84c350dca4b67f511c04414
   depends:
@@ -6453,7 +6453,7 @@ packages:
   license_family: APACHE
   size: 39421
   timestamp: 1699371341381
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
   sha256: 432b8b7c4671878cbbe361e518544203f97bd2e4f24fa08cf65e8be583f25529
   md5: e62e7c668b080e0f6ce09fd548f69f7f
   depends:
@@ -6462,7 +6462,7 @@ packages:
   license_family: Apache
   size: 159066
   timestamp: 1710809127954
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
   sha256: 3ae55d8148580fc3f171c0fcc420488fbba05517cefd358fe013b45ec3594371
   md5: bfb42ed6826a1c8cded9539fc6e07029
   depends:
@@ -6513,7 +6513,7 @@ packages:
   license_family: BSD
   size: 16924671
   timestamp: 1709591125871
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
   sha256: b529eac4abff05f13760c51ad37adf24e744109a6fb30471b26dc1f6a1c23847
   md5: b690cc140a7866280131762a26c05f39
   depends:
@@ -6537,7 +6537,7 @@ packages:
   license_family: BSD
   size: 21902721
   timestamp: 1714073654508
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
   sha256: e77795e1af9bc27d45841d6b9c51e0e7da31e0eabaaffa99162245adc55d13a3
   md5: 14046398ac44f496bc9df300285ec586
   depends:
@@ -6546,7 +6546,7 @@ packages:
   license_family: BSD
   size: 267222
   timestamp: 1711137058994
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
   sha256: 6ca54ba8ce430caa8a1838b19869814d0b7fa3592a77f75298130983e635387b
   md5: e56c194e56d19dd8fd76f75a77f92c33
   depends:
@@ -6564,7 +6564,7 @@ packages:
   license_family: Other
   size: 1070844
   timestamp: 1714399290671
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
   sha256: 15001c7ee6cf6e0ef7afc2f313114f6103e7b6f641fac9a6899ee02d6537c822
   md5: 250ba95e77f5fcb3fe2aefa85157e859
   depends:
@@ -6575,7 +6575,7 @@ packages:
   license_family: MIT
   size: 3759346
   timestamp: 1715097175495
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
   sha256: e5f8cbfb5fc25d460a9117bfc5511959c5e86ccb193316033f87bd516e0c8881
   md5: 9f7e8b5eb651539386bb92c14e5c321b
   depends:
@@ -6584,7 +6584,7 @@ packages:
   license_family: MIT
   size: 37730
   timestamp: 1692205554840
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
   sha256: 6c5b53831273674361437fb546e08315fc11ca9275a174bca3887987e86ced5a
   md5: f8d91daf5173eb03157f484389adcdd4
   depends:
@@ -6593,7 +6593,7 @@ packages:
   license_family: Apache
   size: 122178
   timestamp: 1679591983138
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
   sha256: 546819d922b03f3a25ca9f98fd069d0588d481fc0603c6d74bd598fb6a93687f
   md5: 86c18e3e0b67ee099457475ed6caf2e6
   depends:
@@ -6605,7 +6605,7 @@ packages:
   license_family: BSD
   size: 751763
   timestamp: 1704404627180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
   sha256: ae06f0dfa2cfae51404afc6d6ad3a474a93015b5ba9a7d3ea24224b8e7547987
   md5: 3e19794c806cc3e84a3080a97c359b75
   depends:
@@ -6616,7 +6616,7 @@ packages:
   license_family: BSD
   size: 510466
   timestamp: 1679005998612
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
   sha256: d95c88d06f4f3f667bd9a39e5f18179e83b3cd4c115c06ce0fff390ff6d3a700
   md5: c6d00a8a4d89b1be99bfa3aff19d96b4
   depends:
@@ -6625,7 +6625,7 @@ packages:
   license_family: BSD
   size: 2134881
   timestamp: 1684280285492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
   sha256: 643a9a0eba1e2bd5980d21623d3b35188c24781ec251acc4d15714bd1ccb4c17
   md5: b3cda0394db05be6f0f6176abacb13f3
   depends:
@@ -6634,7 +6634,7 @@ packages:
   license_family: MIT
   size: 207985
   timestamp: 1678721438358
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
   sha256: 974c22de09078bf07c5db31fe12d8d89d6433508defc8237cbe52e08c69ed56b
   md5: 9cf10bfd49140a527cf4b1d912097e6d
   depends:
@@ -6644,7 +6644,7 @@ packages:
   license_family: BSD
   size: 36072
   timestamp: 1676426019064
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
   sha256: f43aca7a222c983c25c3e15f79c7e7e3c4909bb7839a1dd0ee327def81aa476e
   md5: 2b61f1cb7fec068c76ef0ff97c2c62b5
   depends:
@@ -6665,7 +6665,7 @@ packages:
   license_family: PSF
   size: 19811751
   timestamp: 1713545124922
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
   sha256: 2c61639b3bb56fc864c86558bceb7845b1731ac44bf1a94894172ea47a995bd4
   md5: 404805e547b4d50b5cd17e16bca87527
   depends:
@@ -6675,7 +6675,7 @@ packages:
   license_family: BSD
   size: 332043
   timestamp: 1716495838826
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
   sha256: 9acb33db60d9319595f52337cae3b88c2a2338cd66f1f9d8ae86d0a993c2067a
   md5: f4af8cf94d042b4dde487241bba1c457
   depends:
@@ -6684,7 +6684,7 @@ packages:
   license_family: BSD
   size: 279780
   timestamp: 1679500609851
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
   sha256: 48fe7373b012b51134b6b6ff67f18d2b4aae3a5c7700e4560ce002af7172f064
   md5: 0379cd17692152c12b662b0e4ea46b88
   depends:
@@ -6693,7 +6693,7 @@ packages:
   license_family: BSD
   size: 18008
   timestamp: 1683824373128
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
   sha256: 803274d986d0c4e3b5ec1018747ede86ef57137455b3e44a60e834717eafb92b
   md5: c9f134ddeff6fdf0373a45534ddb7079
   depends:
@@ -6702,7 +6702,7 @@ packages:
   license_family: MIT
   size: 273009
   timestamp: 1713974722039
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
   sha256: 6fbcba97c1dcb5157afd23f264c3cff069c7e4be5ea55980fc349eb8dc2cb49e
   md5: 8153e3f8b3283926bcf9403804a365f5
   depends:
@@ -6714,7 +6714,7 @@ packages:
   license_family: BSD
   size: 65050
   timestamp: 1711137009299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
   sha256: cd33dfee104dfbba4af38d06a09ccbae6a32e7c543afedab523303319ebb283d
   md5: 3dfc19af0306d80921e1403f1f551bba
   depends:
@@ -6724,7 +6724,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13679916
   timestamp: 1676423267293
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
   sha256: 102ff1d958209e3648bb49da3503cf752abab822011fdc4e12e88145c9e73772
   md5: 0553c2c381b6f5c836b23edc8c6db2ba
   depends:
@@ -6736,7 +6736,7 @@ packages:
   license_family: MIT
   size: 246689
   timestamp: 1677708371873
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
   sha256: bee5c4d0f41f06a9c0aac636885e36e8b81116aafde980f9ea48fdb64abb5567
   md5: 6c05a053240cb90765d6f8c2efdf905e
   depends:
@@ -6748,7 +6748,7 @@ packages:
   license_family: MIT
   size: 182228
   timestamp: 1698096268270
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
   sha256: ea39db411361d96545a04fb976940e9590147acb4ca9caacf7e8264780379347
   md5: b411b8be8e53e5059949dde02dd07faf
   depends:
@@ -6760,7 +6760,7 @@ packages:
   license_family: Other
   size: 565148
   timestamp: 1709319072176
-- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
   sha256: 47653b45a5f2d97b5bf0dbf0e620908880f9078da427eef69012effe3f19af67
   md5: 44e709ae67d89bccee2d4d46d358fee3
   depends:
@@ -6771,7 +6771,7 @@ packages:
   license_family: MIT
   size: 74493
   timestamp: 1699012356534
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
   sha256: d7bcba5262df162756885a773c3bf2dace27311bbbb1830a0f97aa60ac7c1239
   md5: daeb99ccfe39f725278203412aac0873
   depends:
@@ -6787,7 +6787,7 @@ packages:
   license_family: Apache
   size: 120468
   timestamp: 1707355917958
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
   sha256: d6daaa6b45272819176e4aeb467ae00e3db43386548464a9993688f292709d40
   md5: 9fe721d7f7420c259df4f07d4503f654
   depends:
@@ -6797,7 +6797,7 @@ packages:
   license_family: MIT
   size: 9683
   timestamp: 1683077110211
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
   sha256: 6051860575f9448aea5799d74469c928cd7cdeeca1eb53657872262a77b1a7a8
   md5: 60e193eca497130034facd5fed168249
   depends:
@@ -6806,7 +6806,7 @@ packages:
   license_family: MIT
   size: 10094
   timestamp: 1683059114376
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
   sha256: ecd310461c1b45ab92ddf15539cea5a6e837860561c974d2d7393f9a7933f116
   md5: 1762fec2838763e904141167e18b0389
   depends:
@@ -6817,7 +6817,7 @@ packages:
   license_family: MIT
   size: 215600
   timestamp: 1698947891859
-- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
   sha256: 6fd52bae6360fbc8135d72e0c1e4fd407769fa4d0f4b59356e7aed3e000eb339
   md5: 49fd52885250da8aab17ed72e2e18b81
   depends:
@@ -6826,7 +6826,7 @@ packages:
   license_family: BSD
   size: 88901
   timestamp: 1699371435766
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
   sha256: a2ec4690bc07be9e7f3ad8e3003803eb4304a434d3f139633e2817318a9f7b20
   md5: dd2d225219924fc5c36598c919541271
   depends:
@@ -6835,7 +6835,7 @@ packages:
   license_family: MIT
   size: 1593050
   timestamp: 1715025622141
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
   sha256: 5d1b7e14dc04816692de0f8518ea8fcbefb26ab61cec83f96f2c44c1bee67fab
   md5: 505d2a70a875b5082dc857aa4dfab0d4
   depends:
@@ -6844,7 +6844,7 @@ packages:
   license_family: Other
   size: 18830
   timestamp: 1705431395254
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
   sha256: 5ff3b4ac3fbce4dd67a87856c04698d0397deb0ac288ff4e7eb02fbab57f1253
   md5: 0ca650a7001c6650809d3361de8cb005
   depends:
@@ -6853,7 +6853,7 @@ packages:
   license_family: MIT
   size: 89590
   timestamp: 1696347858925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
   sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
   md5: 833b93a2daade3407898f15588945d83
   depends:
@@ -6863,7 +6863,7 @@ packages:
   license_family: Other
   size: 1440481
   timestamp: 1714488344682
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -6873,7 +6873,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
   sha256: 78d89b50a29fbeb19a562f5dad95615e3f192bb4f3b86cd6ea75f2f825418232
   md5: 4a4040df560ea47704e0898c4c015808
   depends:
@@ -6884,7 +6884,7 @@ packages:
   license_family: BSD
   size: 38069
   timestamp: 1678228553220
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
   sha256: 70a3cc4a4e81a6421bc19cd410d1d6064aadb2b1cce38b020f85e5346716d8e7
   md5: 32a9a2539579a3d522dce3b5cb4f987b
   depends:
@@ -6894,7 +6894,7 @@ packages:
   license_family: BSD
   size: 49495
   timestamp: 1676425411739
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
   sha256: 0a95736cfd0bb25fc201cd6be4a2450ea8fc30eeb349d861812675b84c94fa74
   md5: a8a9fb30c6dd8e7a16d5dcd2333c3c49
   depends:
@@ -6905,7 +6905,7 @@ packages:
   license_family: BSD
   size: 3844176
   timestamp: 1714770894235
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
   sha256: 4febf30c11674711b86c8c10da46a5e1613071388da999210912a31508864add
   md5: 1c109fc1112ea1f5f377bdf0d18ba75f
   depends:
@@ -6916,7 +6916,7 @@ packages:
   license_family: Apache
   size: 895633
   timestamp: 1696937216859
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
   sha256: 973dc7991dd5976ce2d27a94739712cac4d31f2d2958fbf23adb844f5ac999c8
   md5: ca74b36907b3f4f8a51bd5b2e4d8220b
   depends:
@@ -6928,7 +6928,7 @@ packages:
   license_family: MOZILLA
   size: 186541
   timestamp: 1716396206048
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
   sha256: e8c77efe880546252f244f995cbed5967809555127b4f818b97455d434b23415
   md5: 7397ac07045115960ebd8dec95326a7a
   depends:
@@ -6937,7 +6937,7 @@ packages:
   license_family: BSD
   size: 270819
   timestamp: 1676423321499
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
   sha256: ab3cce654f1e94793fff0cb03b750d9b20cdbf099263b1906c3c5eaf8b347ab6
   md5: c68ffc771312afb6f88b94c24d2bb689
   depends:
@@ -6947,7 +6947,7 @@ packages:
   license_family: PSF
   size: 9706
   timestamp: 1715268972001
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
   sha256: 4089efea1753ebe2f6617b46cc368738f285b1d816d4a4f01ba71524f46851b4
   md5: 7f610528ecd0b317180efa2058c32323
   depends:
@@ -6956,7 +6956,7 @@ packages:
   license_family: PSF
   size: 75414
   timestamp: 1715268958140
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
   sha256: d091897f05318c22ca31028370f25355065999078f7db6f88ab27bf4cb030ec8
   md5: 1776502c1cfb351554eeda6cddaf255f
   depends:
@@ -6965,7 +6965,7 @@ packages:
   license_family: MIT
   size: 11588
   timestamp: 1676457729096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
   sha256: c16498f8238cc331618720d078b87995eceb6bbf20268a7a4e8efbf7b5859a9a
   md5: 770432c0ca1ab9d99ffe95e51d3a3e74
   depends:
@@ -6976,7 +6976,7 @@ packages:
   license_family: Apache
   size: 517433
   timestamp: 1713213261710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
   sha256: 3009bd4e7e8126309e606c81cb75d4b8d4fbb2bceac10ec43f7eb6eaaf717ac2
   md5: ee6e87af42008a762d3531771c1a2b18
   depends:
@@ -6992,7 +6992,7 @@ packages:
   license_family: MIT
   size: 210034
   timestamp: 1715636431813
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
   sha256: 906048f3b1dc326b367a08edc91816ff523b5f06cd45d985b4dbb7cfe8017559
   md5: e509c495aaa92d767d554cd43a990ee5
   depends:
@@ -7001,12 +7001,12 @@ packages:
   license_family: BSD
   size: 8900
   timestamp: 1715797316229
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
   sha256: ab224d078734a23527716388ddffc034d18254843881d0fc068c2efa35bacfe1
   md5: 73f5831d017e5572330d2459844718f3
   size: 2246565
   timestamp: 1715797302913
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
   sha256: 24ea3d3e0cb98d0d246338dbb4562b67967bb32002e3704e495a5c863476e831
   md5: c7b9cdbe87b3c9720aeca1164a0fd6df
   depends:
@@ -7015,7 +7015,7 @@ packages:
   license_family: BSD
   size: 26181
   timestamp: 1676424437003
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
   sha256: 92d27e41ce34387e59acb47572fcb2e92c4defaeadafd11ce190226022023e69
   md5: f1bf142d852987acbe4b0bc94e87d958
   depends:
@@ -7024,7 +7024,7 @@ packages:
   license_family: Apache
   size: 145306
   timestamp: 1715878654770
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
   sha256: 1b086d1b079fdb2f148c7dd82658f2b7f283c88f286e1216c0f1237319039b0f
   md5: 299e87f151a549d86a48bf24df15c607
   depends:
@@ -7033,7 +7033,7 @@ packages:
   license_family: MIT
   size: 168041
   timestamp: 1714717238470
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
   sha256: 17fadf35aa8917c107e7b369e9364ac7c09537776e7943d37e225e14b7026c94
   md5: 0e67c3b9624540581b894b11267a837b
   depends:
@@ -7041,13 +7041,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 10197
   timestamp: 1676425485716
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
   sha256: b849b368e27920838fe40a512b102879693a55cb187dd1c8d3a83fa8c05a8054
   md5: 7b1f6e9c71906a93039b3446b99a5498
   depends:
@@ -7056,7 +7056,7 @@ packages:
   license_family: BSD
   size: 55114
   timestamp: 1676434863173
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
   sha256: 344a5276a9928638dcde054dfe4e87c8cb40bd2d4d356378b9ab2f863ca62e4b
   md5: fe471fd8b5a3d77be6fa5dbf9b99dafb
   depends:
@@ -7066,7 +7066,7 @@ packages:
   license_family: GPL2
   size: 1432281
   timestamp: 1714515119689
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -7075,7 +7075,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
   sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
   md5: e5aed81295b61b6d1eb62830799a0297
   depends:
@@ -7086,7 +7086,7 @@ packages:
   license_family: Other
   size: 9125184
   timestamp: 1705602328351
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
   sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
   md5: f295b54ab59f5b8658e2a322ac6aa721
   depends:
@@ -7096,7 +7096,7 @@ packages:
   license_family: Other
   size: 162161
   timestamp: 1714514792081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
   sha256: b2ff66b7f6efa0831f939e57e562c244332b690af08818a540d1a97fa07d8525
   md5: e548d528873d9a0006a36714cf36462a
   depends:

--- a/template/pixi.lock
+++ b/template/pixi.lock
@@ -1,0 +1,7111 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+  sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
+  md5: 613805add1c05b538ff06d217252feb7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 20810
+  timestamp: 1652859733309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.2.0-py311h06a4308_0.tar.bz2
+  sha256: 250f50edf43a786a32942e9ae67ce807e9b3ac4cb6b58b1170cb541fb24e391f
+  md5: b48058294499d292ddf9a3b966dc9cc5
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 228473
+  timestamp: 1706220559474
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_0.tar.bz2
+  sha256: 0d4f5274503916e1c683dcc16e8a7c4186557afa3f62399cd628e4eb535fe77a
+  md5: 062acdb0f9ae976c25c2d15d589dc1d6
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 35809
+  timestamp: 1676823571351
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-23.1.0-py311h06a4308_0.tar.bz2
+  sha256: 567dfdd5b986012421a736a5f1c1d5874d8d691dd483c838b55e1ab06c0b217d
+  md5: 4e0aa1543f546b898523382ee8405e84
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 152577
+  timestamp: 1695717917074
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.2-py311h06a4308_0.tar.bz2
+  sha256: 894fceb5b4f8740bcd146de8bd0f6eabf14e2407b149b790b4983b8432681e6b
+  md5: 2f0ef211bf628cd22bbfa44c3f9bc035
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 271600
+  timestamp: 1681493103694
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.4.0-py311h92b7b1e_1.tar.bz2
+  sha256: 9f027f156744dcbf28945aad6e422ef030c84c2a5d40116d3e40407c66853bf8
+  md5: 7b52489e04f9a5585643d5578835fc68
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6059952
+  timestamp: 1712084450899
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.3.7-py311hf4808d0_0.tar.bz2
+  sha256: 8e2b2073ff5c61d35714e8a36ce657a8ac741b7bedc2852a238c7f1625142705
+  md5: d951ab54a682b6328327fec53b1e5e72
+  depends:
+  - libgcc-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 147642
+  timestamp: 1707864274452
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 5d15605858771290fdaaae41a43941623757a25cb1292080d69d6d3857807935
+  md5: 7f517469aa5380c52e55db9f37df104f
+  depends:
+  - brotli-bin 1.0.9 h5eee18b_8
+  - libbrotlidec 1.0.9 h5eee18b_8
+  - libbrotlienc 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 18652
+  timestamp: 1714483267080
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_8.tar.bz2
+  sha256: a5094f078584e27c7cced4a9564ae904a329f5c1702a7c1ba092d581ba1544f1
+  md5: 6ddf45dd8a21a9512481de9bc0e5a03f
+  depends:
+  - libbrotlidec 1.0.9 h5eee18b_8
+  - libbrotlienc 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 19711
+  timestamp: 1714483255915
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_8.tar.bz2
+  sha256: 93180c973816246f068b742d0bf64840f0ea48e31d4f9b0747ea2ffc34d8855d
+  md5: f3a00096965a5ba1eb41d2c99a4662a2
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 361574
+  timestamp: 1714483400014
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+  sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
+  md5: f5058c8d5b2994b7334f18e022105a14
+  depends:
+  - libgcc-ng >=11.2.0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 427542
+  timestamp: 1714510571510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.3.11-h06a4308_0.tar.bz2
+  sha256: 394f74202c2efc8fcfd02b8953f508eb6a2961d224a2f9d15091caf5cbe1be67
+  md5: 1202b4ed32215c6405bb42fbff355316
+  license: MPL-2.0
+  license_family: Other
+  size: 137411
+  timestamp: 1710764808838
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.2.2-py311h06a4308_0.tar.bz2
+  sha256: 6dc29d20180f6e002f37b251efa639716d3444e129a754dabf751f816aada7ef
+  md5: 5dbfa083e6ab6318fac58fe0e0c94445
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 165152
+  timestamp: 1707229213375
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.16.0-py311h5eee18b_1.tar.bz2
+  sha256: d138cc3fde270eba783baf1e2ba17c89800b2cbbf20976d0eb425b3436a4a184
+  md5: 1875e89c1a939e4e7c5e7b731c72b838
+  depends:
+  - libffi >=3.4,<3.5
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 302401
+  timestamp: 1714483186060
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+  sha256: d9c102b9ec7f3a635936b6f73d4db126d748a25f65407353bd76b260dc7d1cd6
+  md5: eec48dbdf5dac0ea26750cc26b58c1d9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 554986
+  timestamp: 1709758392744
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+  sha256: 882481e441b9b93cbdfb32fbe32a6ad9f26197472f186a08fddb921f61346c02
+  md5: 443c79196064f57c98199e9990544b2f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16902
+  timestamp: 1709322958614
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.2.0-py311hdb19cb5_0.tar.bz2
+  sha256: e4877b41553e31b9f9f090dffab77a654255c63776e8b30fc91ec1f60afadbf1
+  md5: c34d3f1520f1e8c9957eb236710058c4
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281162
+  timestamp: 1700583651472
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.6.7-py311h6a678d5_0.tar.bz2
+  sha256: 3b4cd8dc60572086f1a1cbb97e2712e0ffd55317ce8f0309d552eee7367855eb
+  md5: 70a1263b6e19bf2d77c020a2e77277c9
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2556575
+  timestamp: 1690905285843
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+  sha256: 4b589e3265c74159130230c164ff2d8d381be65899a249def0b53f93ce83fd47
+  md5: 245cb7173dcdba21cf368031cd87f706
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17434
+  timestamp: 1676823330845
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+  sha256: b75d12e85274660bb675a3e53d47a929872f2daa2ff5a76e98885ee3f2d19ad1
+  md5: f2119d0885334060d0d7fe59e5220287
+  depends:
+  - brotli >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - fs >=2.2.0,<3
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  - zopfli >=0.1.4
+  - lz4 >=1.7.4.2
+  license: MIT
+  license_family: MIT
+  size: 3237908
+  timestamp: 1713551660998
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+  sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
+  md5: a5dc8677d891dff2393b63189a3ad42f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 971975
+  timestamp: 1666798278693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.18.3-py311h06a4308_0.tar.bz2
+  sha256: f48ccfb4214e2af41e73a3904e343ecd1eb1ae06578c26f55a5dd247771b2c86
+  md5: d58e9eb09817935eb7342ceff889f481
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5335524
+  timestamp: 1707836581350
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.10.0-py311h06a4308_0.tar.bz2
+  sha256: a0ae6c5a6b615d73d9a243331f3f7d749b4feafdf2f334337fda8abd6c8355ed
+  md5: e61d8dcd4dfd6d165e6e480cee846bf5
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 357992
+  timestamp: 1715090462763
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+  sha256: e08e27531775de40f46b6ac7bf71856963baa0c008bd2b4d112e6341cd3e8f4c
+  md5: bfc7682613c861cbcb4ac01485c05657
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147174
+  timestamp: 1714398938840
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+  sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
+  md5: 3add2ce56858a1b8f6a37342f82773d3
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<1.2.14
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 19310769
+  timestamp: 1699647799237
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.28.0-py311h06a4308_0.tar.bz2
+  sha256: 0b670ab17ed2e1b592079bd64386dadc249ddc892e5ae1dd99f142a918ffc75d
+  md5: 632575b9e442c1e5c146cf78424da610
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 227791
+  timestamp: 1705934138566
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.20.0-py311h06a4308_0.tar.bz2
+  sha256: 65228eb868c3ec8aa71f958e60a675a919f016c2057392e02fd422fc841858f9
+  md5: 68e23f14cd222c233e6b37262bc61c23
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1612840
+  timestamp: 1704833066871
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.18.1-py311h06a4308_1.tar.bz2
+  sha256: a2918ea8a3e2c56fc6d91191e84b2f35500c392b16ab687a0c03ded2e2e51239
+  md5: 84fadd6b7fef393cccc0d123dae6cae8
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1162207
+  timestamp: 1679336523618
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.3-py311h06a4308_0.tar.bz2
+  sha256: 4520b83e425883981f97191986a08122fbaebc3f16b898368796314136779028
+  md5: 42a8f32c4d842d3e5410b2bc1cc2fb57
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 352284
+  timestamp: 1706733655761
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_1.tar.bz2
+  sha256: c21f8f407266d039e819c27fe9eb4fb26587e974f3bd059b37cbaec5073722d0
+  md5: ba1f47411e9e07876c7a3e9d3be6a98e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: IJG
+  license_family: Other
+  size: 281400
+  timestamp: 1677849152168
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.19.2-py311h06a4308_0.tar.bz2
+  sha256: 06b729aee6dd2a1e545f3ad64179cc0d4ef8a15e33db3be2995dd3e0868465ca
+  md5: 8bb3215912588e47e2eeb4e7a09ad64f
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 180858
+  timestamp: 1699041715847
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+  sha256: 9e3bac2d41bd432b721b009e7de981766fba396e6f238e923f304112bd88655a
+  md5: 84ae4cf3f2d01fbebdac374971192be9
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 15525
+  timestamp: 1699032521315
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+  sha256: 79ce6dff3d93649a2555b1d2a4ae9eb77175a1c00664cb8eb0e6f848d5cdd1b9
+  md5: db395b0efd7018fcf3a4af879170c2a8
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 276856
+  timestamp: 1676823504812
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.5.0-py311h06a4308_0.tar.bz2
+  sha256: fedc7e5560252af44b0dfbe6f7acfe20ab17a6a08e758f670a1cd820551afc7a
+  md5: bd28d36963087f53a79b23fee697d665
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 93898
+  timestamp: 1698937453304
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.8.0-py311h06a4308_0.tar.bz2
+  sha256: 2b896fe8b2187b7df824041826e14379476eb2e61d607d8cb38ac2b3df40aaa4
+  md5: 8fc7e517da96c2c482331f6b08d07a17
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41459
+  timestamp: 1699282616532
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.10.0-py311h06a4308_0.tar.bz2
+  sha256: 87d372f5b23bcc2410e43b40b4ad059ea1625178b8a2b484fc63805ce517e594
+  md5: 50204f372b1672871d6ab3db6a876374
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 594177
+  timestamp: 1699467208489
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+  sha256: ddfee06ba9b149222c65d1d4270272840533aa63b56fe36363c84a891c71d328
+  md5: ee128e5c0d8d9e1952e2387b66a5b8cb
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27239
+  timestamp: 1686870958829
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+  sha256: 0c6a074272ed58677ec17e4dbfceaffd2108841a61af92b32f156c5763108d1d
+  md5: dd3d37841d0d20c70a60e8c939923894
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19144
+  timestamp: 1700168632051
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+  sha256: b040f0d0ee4588188ab6b83a93738b3ff6e6d1775424be97995bd0df0f4fb904
+  md5: eae62735d710cf5ff6d51e6f59fcd999
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78148
+  timestamp: 1676827253282
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.tar.bz2
+  sha256: 415b837a89c718d1ae308611125e359b03907ccdebbec5240ebccff9c5c62356
+  md5: 653b4f425f6d4a21f04619b1f5f8aa43
+  depends:
+  - jpeg >=9b,<10a
+  - libgcc-ng >=7.3.0
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 405739
+  timestamp: 1617648674152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.38-h1181459_1.tar.bz2
+  sha256: 9efd56db85f14f597db9844207d0fa81cbdc5d7a163ca38a7c5dd6c08219db21
+  md5: 9508af80612e4fa1b5d1abb43ca7e63c
+  constrains:
+  - binutils_impl_linux-64 2.38
+  license: GPL-3.0-only
+  size: 749072
+  timestamp: 1652971360657
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-3.0-h295c915_0.tar.bz2
+  sha256: ba7fab6985a18b8e510041b9ba8e61f1fe3121ac1fe23bebaf283bd284a11df8
+  md5: 88199c75f2ac211728febced7785c24e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 228278
+  timestamp: 1635523146417
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_8.tar.bz2
+  sha256: bb990ea068c3b3dafd9c807e0e19570320cb2fe7d69cc326f1f0b5319b0654b2
+  md5: 3ff70744e396b1af69656c574b05c3b9
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 66940
+  timestamp: 1714483221853
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 3b87a816f72a00e1f0022a160e7eda70af89d3de2a2e08a72be1c17b31d759f3
+  md5: 4f57d3a0a13ddaf1c06efb586b702f46
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 34446
+  timestamp: 1714483232430
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_8.tar.bz2
+  sha256: 2cf15e89f910600f468edfde8d0f9b80a14fa2319ed89160dc7375dfd3764fdb
+  md5: 463adc13f2feea3570d1eccac368d9e4
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_8
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 295090
+  timestamp: 1714483244460
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.17-h5eee18b_1.tar.bz2
+  sha256: 4de0d1342ff01c217dc5bbcd5a29843dae77b092dff8b947db4772fc97b988fc
+  md5: 55dde57e63a36b202e388a39dcee9a66
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 74096
+  timestamp: 1695996494461
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+  sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
+  md5: 1af9b4d62c708924417f2640ef22a68f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 154016
+  timestamp: 1714483282916
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
+  md5: 641e72e5067bd6d5454405879e1cd2a7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - _libgcc_mutex * main
+  - __glibc >=2.17
+  constrains:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - libgomp 11.2.0 h1234567_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 8895144
+  timestamp: 1654090827491
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+  sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
+  md5: 3080c2813e6e1d0f8a100a38b5b3456d
+  depends:
+  - _libgcc_mutex 0.1 main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 573231
+  timestamp: 1654090775721
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+  sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
+  md5: 1bffe1481ed4f88827248fb9001f8923
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 362561
+  timestamp: 1677841789536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
+  md5: 8c195584a5f5471b600ee180e4052773
+  depends:
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 6410287
+  timestamp: 1654090800863
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-h6a678d5_0.tar.bz2
+  sha256: 99f6dc0ad282b7843da09daaa2564a777ed4355679547784c097f9b4267290ed
+  md5: ef78eebd98289aceacdfa29182426adf
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 664034
+  timestamp: 1693575237924
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+  sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
+  md5: 292768ec77416ae257cfdd44ea2071c8
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29197
+  timestamp: 1668082729834
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_0.tar.bz2
+  sha256: 359d32e792328cfe07680a8f9abccfc36bb9ef339860615f45c8e449a4c67d24
+  md5: 9cdeef1d044c7e035c006890f11569d3
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 436056
+  timestamp: 1694776944891
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+  sha256: fd8e30beb8c9442f16e6617fac92dd0c89ec823e98f06e60f712147380ead35f
+  md5: 7ed7caf2816c8b85b67b6f4e8833cbd5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41155
+  timestamp: 1676837080881
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+  sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
+  md5: 76f089e76ec67583bb38428b51008097
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 164494
+  timestamp: 1714510587156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+  sha256: 260e26dd509834c1b225ab7bdb97b9a86e00054fbdd5dfa49e68fa4dcf85a661
+  md5: 8f5d7ddc69cc6f7d44c80d2251dea5d1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162339
+  timestamp: 1676837095436
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+  sha256: 7f5b0804d0768619b7bd93b10488067d80bf42ec29f443f00b53ba11758a1241
+  md5: 8afb45e45c0d93bfd142e682d4b021ef
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 134438
+  timestamp: 1684280014220
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_0.tar.bz2
+  sha256: cb03570c99c983d7bfda94bc47d8eb00d4059b8548a171130775acc998004195
+  md5: 5b1abbbf1e4f9b350b16fc9caf9e889b
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26919
+  timestamp: 1704206397615
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.8.4-py311ha02d727_0.tar.bz2
+  sha256: 85fea48bea278a77d102781a1cbb6bf69307207d741251e38a6515c5fd7e3523
+  md5: d6ddba94f7c33c88c9825be8409991bf
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9150942
+  timestamp: 1713336680714
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+  sha256: 7ac07ea180b5928086075900afbc332fb1d3c81ddfacb54c891693c284056f14
+  md5: fc83dd1b3d2ec3c0a297ead0c3405907
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19573
+  timestamp: 1676823852670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+  sha256: c9ba2f9c83820712dd97d6a1b54a1215b9820a0be02ac82380b4c50911b9400c
+  md5: e5dc6b4a5b8e02733ce3bc9e9198a8d2
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67750
+  timestamp: 1676837123613
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+  sha256: 1a5141ef0de1cbff816f96bb4b212a40606e2fc11301a4c1358c8d63a6b2b027
+  md5: 22ac3bc22b68fef4c1f3f6ab3c7bfe0b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23040
+  timestamp: 1676827301164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+  sha256: 9aacfbbe6f638c58a4e8ff31374d1438d78b7db25d6ea6fd0c50ca2109f225d4
+  md5: e602057e3b3d80da88c61d66e8851c5b
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104681
+  timestamp: 1676823696152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+  sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
+  md5: ce77d0f05f846da4a6b9e23fe7f21d9b
+  depends:
+  - intel-openmp 2023.*
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - tbb 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 206738176
+  timestamp: 1699648006088
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_1.tar.bz2
+  sha256: 2aef0876d0df033f7fae8cddbd25d95fc1bfc067e60dd143bd8000fec0768b21
+  md5: d6cdc670327bd1675bbea642849f04e1
+  depends:
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59569
+  timestamp: 1682948560323
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.8-py311h5eee18b_0.tar.bz2
+  sha256: 691c4b2b47cf3fac55b4949d7c0f547246ef19cb3510749142cee4bd01ffb055
+  md5: bbd69efa3f24ee747410f83118640d92
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 240723
+  timestamp: 1695058405382
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.4-py311hdb19cb5_0.tar.bz2
+  sha256: 71f5c7beca4e81b465ecfc6ed51cb3d39f51dd88df0b29eff5def3d1f12969eb
+  md5: 61d58663b7277cf4cc3cb8d9873d3ee8
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331105
+  timestamp: 1695059935112
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.0.0-py311h06a4308_0.tar.bz2
+  sha256: 20d832ce714465ae1685d29e2f913fd105d385d003fe1bef71ef472e6f3489e6
+  md5: ad76299b0c33b7a5c0d45905271165c1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8303422
+  timestamp: 1699542957307
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+  sha256: bb45fb0a3973caa74fd8f845e0a519895f6a378807626e15ecf72c02f2eed794
+  md5: 185f658ba8a74e326b7231c8fd0d62bf
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 121834
+  timestamp: 1698934274227
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.10.0-py311h06a4308_0.tar.bz2
+  sha256: 8b2fc372a6655fd5b277d07b994ce43643553fbc37e63a60e9fe527a9026ec06
+  md5: ed6ac14aed5a796b153d757862398997
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 523905
+  timestamp: 1699022906468
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.9.2-py311h06a4308_0.tar.bz2
+  sha256: 7908ff6c516b15e8fb677be4071145e18adea7d4c13b8485a70a5ee2f573f8cb
+  md5: 50c0e38207a131a5de6a14ef919ffcdc
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 169629
+  timestamp: 1694616826002
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+  sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
+  md5: 57ea097dc15f8d9f9eb90e1d919143b0
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1157733
+  timestamp: 1674734069410
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+  sha256: 266199dd4efde0ad342a9c500f4bc4299c5622219aea623b46315a9b4f6b8959
+  md5: 2b21844d2b0024d0ffad0e6450cf0855
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 15860
+  timestamp: 1708532713870
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.4-py311h06a4308_1.tar.bz2
+  sha256: 13d6c640710895e9732225cdedbe47fcd756887fffeb0cf9bc149ee7234dfc27
+  md5: a87d55e3d071f2c435b10db49a9911af
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 730963
+  timestamp: 1690984942516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+  sha256: ef2857e6d3d7eb246b3abddfbd3aa2d124dd8565391ace3876b77339babc50bb
+  md5: d276d1b1774107987963135c78ca7390
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26607
+  timestamp: 1699455972519
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.8.7-py311h65dcdc2_0.tar.bz2
+  sha256: 2f89f38a665ece47e8868b391fc70602fcee588e989bc1ca6f17f6094892a94e
+  md5: b788c80b2d571531ea4f3f8335ae5423
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 168827
+  timestamp: 1696515597877
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+  sha256: e09e1aff2c12d4ef3fec58fb627744e4b5c7d9eaede7175e293f77272d8b8bfd
+  md5: fe8242cfd54d238507493612ae697ad4
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311hf175353_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10270
+  timestamp: 1708639794640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+  sha256: a53ad723826651041a5057a1cf31bc8689b24d335ce61b196df5124974b05a8e
+  md5: 7b29e7191c4170189d6080e61229f030
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311h08b1b3b_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9163911
+  timestamp: 1708639777712
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.4.0-h3ad879b_0.tar.bz2
+  sha256: 128890b4fc4124ba4221a0073187119d5f4824f150edf7b7647bd8c4eb566117
+  md5: b0afe23033c8c5344640bc25225fa579
+  depends:
+  - libgcc-ng >=7.5.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libstdcxx-ng >=7.5.0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 516994
+  timestamp: 1630084830020
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.13-h7f8727e_2.tar.bz2
+  sha256: 6c7cb4097e4f3655b54a119304e50f0edbc4bd52f36c84629b64674cf8d468b8
+  md5: f1e48c973646ded3c2e1a189a9d8b8c9
+  depends:
+  - ca-certificates
+  - libgcc-ng >=7.5.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 5498991
+  timestamp: 1716318104769
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+  sha256: 280225061aeba00d7b85f46e55d7d79cd92c92f662dc749d9c53187978e8d083
+  md5: c51c21da68080d89300703ad818c824a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38606
+  timestamp: 1699371264464
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-23.2-py311h06a4308_0.tar.bz2
+  sha256: bd3eacd22e85f88bedd9c7e97a59eacfb3c8bb80eb59be244825d6895a0e7ac1
+  md5: 08ceb294ba8a9ae13630da789884736e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 157904
+  timestamp: 1710807470578
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.1-py311ha02d727_0.tar.bz2
+  sha256: a2ee3a6aaf54929b82b851b2eb5436e14e5a294303ef429d6dccd33bcdfc8002
+  md5: b467a5c7ad672ccc2d498a67b9eeeaaa
+  depends:
+  - bottleneck >=1.3.6
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - fsspec >=2022.11.0
+  - matplotlib-base >=3.6.3
+  - tabulate >=0.9.0
+  - odfpy>=1.4.1
+  - pyreadstat >=1.2.0
+  - pyarrow >=10.0.1
+  - python-calamine >=0.1.7
+  - s3fs >=2022.11.0
+  - beautifulsoup4 >=4.11.2
+  - gcsfs >=2022.11.0
+  - xlrd >=2.0.1
+  - dataframe-api-compat >=0.1.7
+  - pyqt >=5.15.9
+  - adbc-driver-postgresql >=0.8.0
+  - fastparquet >=2022.12.0
+  - psycopg2 >=2.9.6
+  - qtpy >=2.3.0
+  - openpyxl >=3.1.0
+  - xarray >=2022.12.0
+  - html5lib >=1.1
+  - jinja2 >=3.1.2
+  - pyxlsb >=1.0.10
+  - sqlalchemy >=2.0.0
+  - zstandard >=0.19.0
+  - pymysql >=1.0.2
+  - pandas-gbq >=0.19.0
+  - lxml >=4.9.2
+  - numba >=0.56.4
+  - xlsxwriter >=3.0.5
+  - blosc >=1.21.3
+  - adbc-driver-sqlite >=0.8.0
+  - pytables >=3.8.0
+  - scipy >=1.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17970687
+  timestamp: 1709593080388
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.4.2-py311h06a4308_0.tar.bz2
+  sha256: aa05415302a27a82105e9d0800151f09fd1bb896b90854dc23989f9aecd9200b
+  md5: 4974b1ae5f1a3b6d9fb26e7eb2c26733
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.0.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21869200
+  timestamp: 1714071532259
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.1.0-py311h06a4308_0.tar.bz2
+  sha256: c6c782537b96ab9caf3e25f5a33799c727e84664cdbab37a8d3359a221e2d2e3
+  md5: 8f56d0f63e0589dd7e4a004678307813
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 263438
+  timestamp: 1711136934516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-10.3.0-py311h5eee18b_0.tar.bz2
+  sha256: 28ed719669260a20bec78971edaffb91ec917d2a3f0fac1cf9a8ba21590baa43
+  md5: 0481d078fcd64f7f981532a514d9d50d
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 960727
+  timestamp: 1714399060039
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.0-py311h06a4308_0.tar.bz2
+  sha256: d527189038b376a982c18613df808f25dc40314b0dc8fe5549f3ae9f4288e497
+  md5: 68dad015e796cc26364b55f92f61faa7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3451714
+  timestamp: 1715097126399
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+  sha256: d2bbab8bfc57c7f46ca8994bc87df7e744d3f036b867bc4be1145ba6d8d7e091
+  md5: de41707272a8e3ccab764f0b7010a27d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37394
+  timestamp: 1692205565974
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.14.1-py311h06a4308_0.tar.bz2
+  sha256: e2a0e2a618aa33f0beff9583c7dc510b8d0737b023117346676aacbad33970d8
+  md5: 66a6818307261b1a28ab12d1b7776fdf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 121454
+  timestamp: 1679340540306
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+  sha256: b7f591c19b10bf0daa7e6e3b45a9f4a0a0e83188e1f8a58037caea79e60f8d91
+  md5: d945b4ccc135005839c504cc29df1745
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 749608
+  timestamp: 1704404477511
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_0.tar.bz2
+  sha256: 96482b49191fdac59580a95e69508367083e1f7600145e11d7c2db634337eb26
+  md5: 2d57bf8eacf3f291db845928241f724c
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 490805
+  timestamp: 1679337420563
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+  sha256: ed927e4d058a8f4ea73edc7a43ed74877d93b88fdfa240b3b2777244386ced70
+  md5: a1f0e05fc7e49712f81ad5478ec9d51e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2121496
+  timestamp: 1684280065800
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.0.9-py311h06a4308_0.tar.bz2
+  sha256: ad219924e362ce7af458fa6547660181579e9a50e5aed1ffd9268cbe7c2650e3
+  md5: 2b1ac40e0df3673d33b7f4c4f93ae1ef
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207338
+  timestamp: 1677811584327
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+  sha256: 114b55e00f4622c90fd2b404b21ad5f94a10283fcaaf86a42174b8d39b0a3e98
+  md5: 2458e92683cc68671a6c8e1b86ce8817
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35850
+  timestamp: 1676822725516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.9-h955ad1f_0.tar.bz2
+  sha256: ef622eb34669f3518d2f855cb333c56b106d02cdeac9d58e5a1a5a3097e4978d
+  md5: 9d4f211d050d511b0b84c2e57e7fb1d7
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.35.1
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 36072860
+  timestamp: 1713546307595
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+  sha256: a0f008717fab060ccd003dfebc09156d90b9afd14ac3626566aa1a8f3d3b7e2f
+  md5: 357bf4fe94496cbae72ab4d780184b31
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 330924
+  timestamp: 1716495762901
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.16.2-py311h06a4308_0.tar.bz2
+  sha256: aadc4078311c059265706a56265f0a57ceb538d36179d5203dd487d80d0e8f16
+  md5: 59ec670fcd172447dbd9591b8fbfdd56
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 278741
+  timestamp: 1679340144625
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-2.0.7-py311h06a4308_0.tar.bz2
+  sha256: d5058d0ecc3973316c1d5f1bfb03dd119e0dade85f4c2d21b412c8db4e1636f2
+  md5: 93000e4d3603342779a2afda66fa91b8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17607
+  timestamp: 1683823841946
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+  sha256: b85acb933fff864bfa89d034e8e3d85b1a9c2e69cbfc0d68c1d66ffd1443e67d
+  md5: 0cdb92d2d684ee1095310f992ed0d9b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 266796
+  timestamp: 1713974338678
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+  sha256: 511e8206a15445715b80be76493300930686b3fe1e512ae942d6ccca36df392a
+  md5: 35a6e46ae970f8b71d78fb5a810f2e80
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64013
+  timestamp: 1711136926372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.1-py311h5eee18b_0.tar.bz2
+  sha256: b2a1f649669f4336b74f6f20df711959bcd8024f8f8b94199dc0e040b06bd37a
+  md5: f9e8e3f7068f717f75e555dc04545d8d
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 206433
+  timestamp: 1698096204677
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+  sha256: 7c74db4292f31619606180f86f3c1e2d913495c2c9d1195c5d51681a6a841625
+  md5: be1c05fae57d194924b9400f9b5ad3c6
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 613277
+  timestamp: 1709318516682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+  sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
+  md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 467661
+  timestamp: 1666648052561
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+  sha256: 89c2f4235277b9825cc805c5c44f0b1afcb683d7b5a3f513bc4bf243b643bb0c
+  md5: db70eb57e33adf7b8bbdadd72214d48d
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 73679
+  timestamp: 1699012111499
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.31.0-py311h06a4308_1.tar.bz2
+  sha256: 684037527327839d734e7eac2ee09ef5ddb4f77df22daf40c79e51db29d09543
+  md5: 57c5bcb9eae9f1d93ccfd38025660de2
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 119414
+  timestamp: 1707355661872
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+  sha256: fdae3f68ea84b99561aee6c566ab1c287d8f2ae2668424e9283a8ed86af8f1d2
+  md5: cde5b71ccbb3630053340b2c8c7dbf10
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9333
+  timestamp: 1683077183576
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+  sha256: 0bf859b06a07857099fd4f524fe5e0875fda70029e9485d95c7efa97134fbc14
+  md5: fd5815cc592fdbd4c831901541eadaba
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 9735
+  timestamp: 1683059096795
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311hb02cf49_0.tar.bz2
+  sha256: 474553d01aea57214a54a7443f227da84a58e29c49eb7605ba0043c55b7d167a
+  md5: f01333e9f0a908e435db650f42fbd2db
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1096668
+  timestamp: 1698946168635
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+  sha256: 51bcea0e575a626f6ffbd16d1153330fda93dbe3dd31dcd3a8f469ff61dd1e4e
+  md5: 41d531c90be8c82bf79635ff3d409476
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 32295
+  timestamp: 1699371262818
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-69.5.1-py311h06a4308_0.tar.bz2
+  sha256: 0a95988ea269c96354626dcab255b65b54bb5c503d24cdeb6ef2e1c42818bd59
+  md5: 8bfb9f42492b3b53b8151d77e51c75d8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1594974
+  timestamp: 1715024182643
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+  sha256: 1a84b00944bc5588e14a097460175f97df49acb4f1ff2498ffd9a1893068ed81
+  md5: a456513471b2ecbed60430c21dd1ccc7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17880
+  timestamp: 1705431390054
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+  sha256: adcafd297d60af64107c113bb7b8b92160d0268a44ef9a3b79e56a88a0358ea7
+  md5: 28ed704ed26b06d32662e3a6a87e59b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 88799
+  timestamp: 1696347581401
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+  sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
+  md5: f86119b3243fe3508160aa0406245738
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1723866
+  timestamp: 1714488309729
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+  sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
+  md5: 041a3caf09dc9ce8fc6c10925c4fe050
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1888016
+  timestamp: 1680167274961
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+  sha256: 856a8ab8c350c50247b79966c6cb80fb6d4de36eef49ddf75aebbbcaf854c82d
+  md5: 442dde204d14d171aab9ee40e8de4de8
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37456
+  timestamp: 1677696176157
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+  sha256: f0a026ddc0ed041bfc60c8a1ca0b70b7a69232775b3181bfb35a39fda42d6994
+  md5: 2902d5a5854865baaaf58dc59cf06b3c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49185
+  timestamp: 1676823769869
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+  sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
+  md5: e2512d57c8a1e91e7b20e265c6906546
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3588922
+  timestamp: 1714770676475
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.3.3-py311h5eee18b_0.tar.bz2
+  sha256: 1bf522ade750cf0b70d61e71916ff00569e2908db1e9dedb223fda2608ed8bde
+  md5: 6793c74fe94211c0bfe6766c6dd490af
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 893808
+  timestamp: 1696937055591
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.4-py311h92b7b1e_0.tar.bz2
+  sha256: 54f41afbea1c01a10e5703e64645de145f34ad6d89cf245fbc5cfaaff58a8743
+  md5: 15b6c8bee4c28c6efb3e388178b37145
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 154276
+  timestamp: 1716395957568
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.7.1-py311h06a4308_0.tar.bz2
+  sha256: 0575785f6553e61cc6138abfd5de52305fac6f85971642fa1f056a76c66a52b2
+  md5: f2c25e5dfdd23f70b83776a8832893cf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270865
+  timestamp: 1676823316868
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.11.0-py311h06a4308_0.tar.bz2
+  sha256: 8c06c291c76e8c2022ffbb9fea4727a4bf1f9b03e498bafc56ba8ac4e7604ab9
+  md5: 5adb7baf1091d09026a372cac930ce6c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8869
+  timestamp: 1715268966416
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.11.0-py311h06a4308_0.tar.bz2
+  sha256: 118b0801167264c401e84bbf19175546092a5569cc098146f7362bbf890dc8d9
+  md5: b3c2aa56d53b459f8365d8385f48d0c3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 74489
+  timestamp: 1715268960737
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+  sha256: 509b962773f0fe44a93a7f6196b254670a030eac8ea7f90727312e3ccd9294b2
+  md5: 6c402d5bf4e01c8c3895c9ef41707b6e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11371
+  timestamp: 1676828901104
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+  sha256: bbe7629e8ce52c82f13ed0d1fb919f3659ef466b274a7c74aa925a9bc7aee450
+  md5: 7da527bbcf71270c1abed8ea52e7d44c
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 509031
+  timestamp: 1713213062098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.1-py311h06a4308_0.tar.bz2
+  sha256: 5c6afad310db12b3658a652efc5de45c182164a0b537cb2cdae5885428b30d22
+  md5: 89ea2fed160a633e0a6d152b61cb0dd2
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - zstandard >=0.18.0
+  - requests >=2.26.0
+  - selenium >=4.4.3
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 209068
+  timestamp: 1715635972793
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+  sha256: c3a5e0b855dc2de6c162708dfcf170a23eb9e7525d4252d8dce553369af4a330
+  md5: a4c77e204b7787f820955166a1283168
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25890
+  timestamp: 1676823132898
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+  sha256: 42989f9970a8466cc4edb73463dfa194594dd1a5d42c9f820a1f86296d4af140
+  md5: 655dfd4d2f17977cb81caa1c082d2b25
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 113505
+  timestamp: 1715878346465
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.43.0-py311h06a4308_0.tar.bz2
+  sha256: eec0d2e0bce4b62278cacd7b0bee053160845e86507051a5434d2069bd290f36
+  md5: a069e5aef64a6dac076cc9a3d28a17c9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 136022
+  timestamp: 1714717059748
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+  sha256: d18cdca154bf668826f869117ea996c4f9e8ef7d27b7c528332a7d17e5a8602c
+  md5: 9f7353d72046b16dd6ef6b5689ac9bfd
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54731
+  timestamp: 1676828934954
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+  sha256: 9122d6e9dabb7a47f2bcb15d86b97c96c49a9048da3f8ae59675351710c14cc5
+  md5: 660b2aead2ec87b751c86cd33934f44e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 716926
+  timestamp: 1714510796277
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+  sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
+  md5: 943f1247a22b6b64171363bcee1eec27
+  depends:
+  - libgcc-ng >=11.2.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=11.2.0
+  license: MPL-2.0
+  license_family: Other
+  size: 371663
+  timestamp: 1705602144682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+  sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
+  md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Zlib
+  license_family: Other
+  size: 127143
+  timestamp: 1714510716441
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.5-hc292b87_2.tar.bz2
+  sha256: af3c032f06352e87c450739cb8aafe1ff34ad28bf074b214ea98b3d29259a85d
+  md5: 51fa34bd0e016ed7c5371cf6cb13ef6c
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1044463
+  timestamp: 1714678445052
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/bleach-4.1.0-pyhd3eb1b0_0.tar.bz2
+  sha256: c12c93294feedfb47faf1ad98050223d765245636bed70532db083603e443c66
+  md5: d78a456773bd4df323a2dfb4d8710b90
+  depends:
+  - packaging
+  - python >=3.6
+  - six >=1.9.0
+  - webencodings
+  license: Apache-2.0
+  license_family: Apache
+  size: 124095
+  timestamp: 1641577596378
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-2.0.4-pyhd3eb1b0_0.tar.bz2
+  sha256: 390e7731b21d7688bf8f01832f9bc79eb98ff8d619c2d275486c3643fdf3832c
+  md5: 544adf2677c47c9b9c891aea720678f1
+  depends:
+  - python >=3.5
+  license: MIT
+  size: 33999
+  timestamp: 1630003259346
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/parso-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 0343630fb79796c9055e4b5d03346e2b7b4a78956dd152dc84e3bb051f5f5dc2
+  md5: 19dd0314629d343382a76a309cb7d183
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 70876
+  timestamp: 1641458670141
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+  sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
+  md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
+  depends:
+  - prompt-toolkit >=3.0.43,<3.0.44.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5106
+  timestamp: 1704404390460
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024a-h04d1e81_0.tar.bz2
+  sha256: dc9f709bacbaf08a0941d2622d82f91f18b355e82c55348ec29f1391215ca7e0
+  md5: ece0f5837a4de2d4d5f1abf8347cd10a
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 124922
+  timestamp: 1708711884650
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.2.0-py311hecd8cb5_0.tar.bz2
+  sha256: 5800a2466734dd1ef372bec0dd3f0880c5072fa1e8b0668f5054f834285e991c
+  md5: 18194e51d4420ac08f29f3f86581b52e
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 229003
+  timestamp: 1706220302459
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+  sha256: ab7672364f1fa55ec5d8311d85d40e5b57cbd3517b17670557b6fb822bcf759c
+  md5: 6e0159a5865cb7e96a748bd8560035ee
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 11579
+  timestamp: 1678317458652
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h6c40b1e_0.tar.bz2
+  sha256: 51556902e09436d46878ef772805d06416ca96ffaa66340b5565c0245574aaf5
+  md5: 4cb1b20635cf5431d34cc96ca1e8a751
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 33355
+  timestamp: 1678317111825
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-23.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: 188b74f717e3ce3595da404c0e027b8ccafa9c186e88325e8f02c29d7b4c0744
+  md5: 04ad90eead5812a0263b42321056ab33
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153694
+  timestamp: 1695717975427
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.2-py311hecd8cb5_0.tar.bz2
+  sha256: bf3c60386619f08cf5105b4b903bbc109b3252c3b923fe055aa445908a01969c
+  md5: 3f84a301921ec6400b7f1f1c4ba3260d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 270017
+  timestamp: 1681493109562
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-mkl.tar.bz2
+  sha256: a2c116d511cc8fc0ba53a1e0b4c32ade562c128cc6b6cda4711f13e1a6c4a52c
+  md5: e2f3248e2a5009a02f7b8e54f83314ef
+  size: 5620
+  timestamp: 1528121955725
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.4.0-py311h85bffb1_1.tar.bz2
+  sha256: 126ae8e30b8464fb2dc94ce9163dcb2d5482f7214c7d8a48340c3f09f1409d5e
+  md5: d5e0c054042910b4394a14c7eb4d8131
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6080356
+  timestamp: 1712084675745
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.3.7-py311hb3a5e46_0.tar.bz2
+  sha256: 9acafafcaebd653c2372ddc864525722e1c55b884b5eba22e28e2b2d946b853c
+  md5: 22375cc3c2edada31b85af56c8e6dee6
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 155829
+  timestamp: 1707864406086
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: d8b1ccb15297dcfb3f9ebb8139c3e28a13d6c2e73c37612cb214ab6cc58b15fa
+  md5: e5dec9f13de061640ad2697562a99b54
+  depends:
+  - brotli-bin 1.0.9 h6c40b1e_8
+  - libbrotlidec 1.0.9 h6c40b1e_8
+  - libbrotlienc 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 19732
+  timestamp: 1714483415038
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: e9fda4393edd0234c88efc2b88e0edf42c94eb49ea5b189a80afd733058be8fb
+  md5: 13ceed558eb174d6b77ed1b0035f1785
+  depends:
+  - libbrotlidec 1.0.9 h6c40b1e_8
+  - libbrotlienc 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 18400
+  timestamp: 1714483395748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311hcec6c5f_8.tar.bz2
+  sha256: a323af3251e426962ad16edf8f46a696ef502731faf12aee32ca289c40b11342
+  md5: 658ce49e9f07dba7a1afe70fa2666e0a
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 393858
+  timestamp: 1714483549536
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+  sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
+  md5: c5a600d81b1b48578863af2973c743ac
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 187637
+  timestamp: 1714510590009
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.3.11-hecd8cb5_0.tar.bz2
+  sha256: 0c5f9766aa2dcc08ae71b6c0102046a56b30297d0bedc3039b7f72d1658baa43
+  md5: 34583b436e62a2ce55d6a7e8eb818e33
+  license: MPL-2.0
+  license_family: Other
+  size: 138712
+  timestamp: 1710764814844
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.2.2-py311hecd8cb5_0.tar.bz2
+  sha256: 20b1fc398e925e6c8cea6a06d3bb614e2c0de886e3f14f85b0ba26e57ff40b7e
+  md5: ac95cfe373c7fef7820e93189041b0cc
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 166856
+  timestamp: 1707229213510
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.16.0-py311h6c40b1e_1.tar.bz2
+  sha256: 6b5bebc13755b0a5ef423219eeecd1c25b97dbe83afad6e2552635387547d9f7
+  md5: b7bc4192fcfed7fc7df1ce00bce97b02
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 291802
+  timestamp: 1714483319125
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: 9270668e34b00a2605584a2db5130c83826855cd05b896ce949f3156fa197429
+  md5: 2586aa55677e822e8285d777f9039ca9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 543487
+  timestamp: 1709758497949
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: 389c63a84b92a6254c9d361ebe970d537d0b88733efd5ac5c3ee58196fd2c5a9
+  md5: c7bc5b3cbe76be83a27f00b7e4740727
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17974
+  timestamp: 1709323004148
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.2.0-py311ha357a0b_0.tar.bz2
+  sha256: bebfc5aa6be12e61a134b580b07b67f7d8c045d6b113fca5b21fa1e83a2f03ce
+  md5: 239df72a3921c951059fa8afc09643f6
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 287736
+  timestamp: 1700583644534
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.6.7-py311hcec6c5f_0.tar.bz2
+  sha256: e0e30590a78d99d51445ac4f668aefe1bf20025a35bdbac00f04647b95c9f152
+  md5: bd0db635eefeea82a0c567b39c9a0e3d
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2485698
+  timestamp: 1690905283575
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+  sha256: d48b47b86b09dac1fa4542ec13e1bd4e23093638e684fa66ec3afdd9ce9337c1
+  md5: 5a2d1828ab7c8eccd3c2610d13672977
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17336
+  timestamp: 1678316187749
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+  sha256: 54645c22fabc25b632114d1d3c403a6fad9149b51ab36719b2690a084f14a072
+  md5: a8ad2f4abfb2e17ecf6e596342528156
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lz4 >=1.7.4.2
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  license: MIT
+  license_family: MIT
+  size: 3180691
+  timestamp: 1713551771692
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.18.3-py311hecd8cb5_0.tar.bz2
+  sha256: 4120472ee1c5d31efffeb045892bece27b9a15a30d77c35212f6508221635918
+  md5: 9561a225b5171285250c9071f8cab074
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5368257
+  timestamp: 1707836808668
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 50dee40e4a9ea7a035baeecc85770c88d63d4e6b0c3c2519c1429e881171150c
+  md5: 4d465f453dca5c65224dccbe953f600c
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 359293
+  timestamp: 1715090716440
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+  sha256: 5c2458964157fe493ca18c513c693b70cb622087e5fa0c93e65fc45217edd811
+  md5: 15629e52625221b51a443cefd9501d12
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148522
+  timestamp: 1714398885844
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/intel-openmp-2023.1.0-ha357a0b_43548.tar.bz2
+  sha256: e0127f50d444bf4474e8df07d602c7f6dd38690e8bb3fb28817c164940ffcde1
+  md5: 583fcd7060cad6a77074d00d9ef62f44
+  depends:
+  - libcxx >=14.0.6
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 731417
+  timestamp: 1699647668990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.28.0-py311hecd8cb5_0.tar.bz2
+  sha256: eb58fa29b1ce9aa5fc774d4c466696457695dec3b206456614b4c9cac0a94e42
+  md5: 3d3291ff58dff83dcd40ec54b435f4d2
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229910
+  timestamp: 1705934029588
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.20.0-py311hecd8cb5_0.tar.bz2
+  sha256: 73aa7662c00c73bab2dafefefc87a1b524961d2687410af624ecbd6703e483f3
+  md5: 7e71e99766107a553752ed8f22b61cf0
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1611976
+  timestamp: 1704833049616
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.18.1-py311hecd8cb5_1.tar.bz2
+  sha256: e08cda2bcbdec124c63e951eb248c503bb1467c2a6000010c6bdc0726e0e00b7
+  md5: 22c24f43b82da8b3920a913bbf452421
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1168968
+  timestamp: 1679336359851
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.3-py311hecd8cb5_0.tar.bz2
+  sha256: 3b262312f1fc76e490c067408771da0a12c7691379cddc3c86121255cda7a41d
+  md5: cbf00a1bc151243cb6a33524b62f3663
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353280
+  timestamp: 1706733664000
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h6c40b1e_1.tar.bz2
+  sha256: d75253e027d26da1cd9705f162b2bff93ee50b6e7a00f0328a244d6cc170cb83
+  md5: 0d5b0c3bf5f1ac9a0fb97a23aec8a7b9
+  license: IJG
+  license_family: Other
+  size: 278924
+  timestamp: 1677849185191
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.19.2-py311hecd8cb5_0.tar.bz2
+  sha256: 99fc6ac82c56eb2a580f96db24a5b887f8abc8c24af445d3313d5ebb48598478
+  md5: 71892160908a6daedb5fb7c404079ae4
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 182073
+  timestamp: 1699041732321
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 0ea44d0c8044e70ab0eaf4d6f5f3e4753838dee106b5cbd36561e21a65cbac77
+  md5: 1d045016dca889d702f1caf3a16162fc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16528
+  timestamp: 1699032525791
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+  sha256: 70442ec4b0b7ebbdcf150963f61f797b861001092124f4ea39a16eb92a4d176e
+  md5: 63d1503915a15ae4f9ad1c46112ca374
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 272720
+  timestamp: 1678316970740
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.5.0-py311hecd8cb5_0.tar.bz2
+  sha256: 8601c674f4779900f6a949e47b814be68b722b0b3d394433bec9d197924ebd69
+  md5: b8423f8caff3041a251fc3681f43496a
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94990
+  timestamp: 1698937583196
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: 6a430c812ce0415a04d9cfe6c66d9012eced2d91c04960c88bc8ec1e9f1b5d6d
+  md5: 30b3d5d6a8cf5d1604e5f5fb177917b5
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42513
+  timestamp: 1699282637015
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: c2d206db117f7161e77236ebd6b0051fc73e1731c242d1e08597d736a0376c92
+  md5: bdb61de2e20e02c93423d9de091c74ad
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 601837
+  timestamp: 1699466514455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+  sha256: fd7964657f0a8fe8b167ba860b1f960e8b7b45309eb6c7c850d50ec283fe03b5
+  md5: 2967bb345bc75f53182e263ff4743ca6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28223
+  timestamp: 1686870845224
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+  sha256: 64cf59f0f74b0329b5069bc6135b4f40593f1dac52d85ad574d4b8e0a4b2cf16
+  md5: 35e8b80eaa03a904fc7f1da39e7f654d
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20234
+  timestamp: 1700168776500
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+  sha256: a12382b50416803f559a03fb384ba492c1dafa351e1191a3f8dc361bee6c4f37
+  md5: f2ae846b663bbb642f4b1e90eaad38a3
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64817
+  timestamp: 1678322501509
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.12-hf1fd2bf_0.tar.bz2
+  sha256: c8883857937fba182a1da0462663acceefb2e6f99b6f4979274d5ab36266c2f4
+  md5: 819762fdace9397c0e14a9ed2dcdb829
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 419188
+  timestamp: 1617648628608
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-3.0-he9d5cce_0.tar.bz2
+  sha256: 1bc6775157a53351800f1cc3de85f88a219fb98a09ac9bc8b9f056e394278035
+  md5: d9e7e12a2bc017897a1a866e972a04de
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 203852
+  timestamp: 1635523161861
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 685c3bc9068bd485604b80bf03789e4dca95c410d33871bc1b882e47649fabed
+  md5: 6cf8e55271e150ca0961d0ddedaa61bb
+  license: MIT
+  size: 66237
+  timestamp: 1714483284541
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 69826cee54db9955f0120af21ec36d13f9211877fd67364f2068d0a54c6c97cd
+  md5: 0851917257f490d35e1f73da8a1c723c
+  depends:
+  - libbrotlicommon 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 34042
+  timestamp: 1714483343147
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h6c40b1e_8.tar.bz2
+  sha256: 3f5a1f03b50b90b397a0ee432ad0cba13354abdaf7e5652c0fc60164b26a08b6
+  md5: a50bdc871ef4bf14deb088d888b92b5e
+  depends:
+  - libbrotlicommon 1.0.9 h6c40b1e_8
+  license: MIT
+  size: 311597
+  timestamp: 1714483371586
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.17-hb664fd8_1.tar.bz2
+  sha256: d049c6cf8f17122010ad9323383cd298204be30d19ccd6541cb5ff350bb2ec66
+  md5: 891b155ceb619a35ae6abb1fc4225aa1
+  license: MIT
+  license_family: MIT
+  size: 77959
+  timestamp: 1695996522382
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+  sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
+  md5: 822a5b76117e56d3912f1f2153307528
+  license: MIT
+  license_family: MIT
+  size: 136045
+  timestamp: 1714483561919
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-hcec6c5f_0.tar.bz2
+  sha256: 7a4b8c59ffcbe6fb7db18da0a6c69cdca4bbb040ef9ca5481fdc8018400853eb
+  md5: 3438422a7b72a28655ce0c2cc9c2a5b6
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 642076
+  timestamp: 1693575343250
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h6c40b1e_0.tar.bz2
+  sha256: fc845d32f640788e8308fff2d27d41b8cd97d61c5c6dcb50aec1d03bbc2c8db1
+  md5: 46a65d1fc24013217e06aaf6d65ffcad
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 425478
+  timestamp: 1694776947990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: d28c465ec6d5f8d4962c597b249b58998300c8b4e3c937c578c3d15294ea863d
+  md5: dcaed6ddd0723c7cce6bfad917be98b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41176
+  timestamp: 1678413498410
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+  sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
+  md5: 8f57dc3a3327bb6f7e1cba908856ac7f
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 183138
+  timestamp: 1714510756758
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+  sha256: 6fb2953e169ee1ae38f24d29752051501992f19b96b5ebcea9af75737bdbcb42
+  md5: 7f410cdae838c5030108d1b98a8c78f6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162478
+  timestamp: 1678377892595
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+  sha256: cd97e09a12ffb49b2a30a782fa8c7933b28f5ffdbfc5c73a9ebaa95fc9447370
+  md5: d1fb6ebc1e5728aa6377cfc71da08942
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135859
+  timestamp: 1684280005320
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h6c40b1e_0.tar.bz2
+  sha256: 30c3b189462a9d0f4794d229adadf34b5f5a5f56f95c30d5afc17ef524579290
+  md5: d4e9421243129d1d57c472dab045f3dc
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26639
+  timestamp: 1704206159955
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.8.4-py311h41a4f6b_0.tar.bz2
+  sha256: 080000a28b3ceca54eec6de0748c690ea5a4c390e358283eac03fe7a6dd87065
+  md5: 51344eca57d7940fb01eb5e8914509e3
+  depends:
+  - __osx >=10.12
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9099909
+  timestamp: 1713336790553
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+  sha256: 07e7fd5bd64e55328b4b99d92e2e2600d791f1095bf905daab4cfc59f0f0a45b
+  md5: cf53321779f4ca7e986c1468719b93f1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19500
+  timestamp: 1678317565001
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0770e02be1ea1216af493cfc03d5b8a702e14606fa93b0692bcdab1fed1b898c
+  md5: ca6f06ceaf66a32bbf5dfdb6e373a5cf
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67892
+  timestamp: 1678417734353
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: fbe95ed0501bb0f137048476fe41bc718dd659e8ecb066bc67ac17d6a50f4318
+  md5: ec162bde8d1c8a107b257df218b17035
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23030
+  timestamp: 1678381838497
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+  sha256: c20dd678655e582129a858a1c5162bdc254082d3a3c035b0f72629d9276e5b75
+  md5: 800a0738c728796e02d0386ce7d457aa
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104585
+  timestamp: 1678317269407
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-2023.1.0-h8e150cf_43560.tar.bz2
+  sha256: c825bc3070f73318ffff88a7a0b7fc6d1858b058ced735efd1789053f1583918
+  md5: dea5f96459c9a6df6b026ca57d387936
+  depends:
+  - intel-openmp 2023.*
+  - libcxx >=14.0.6
+  - tbb 2021.*
+  constrains:
+  - __osx >=10.13
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 224299920
+  timestamp: 1699647835748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl-service-2.4.0-py311h6c40b1e_1.tar.bz2
+  sha256: a76c134ec258612ff7d55cb2a19b9e3461cbbd375a744bd29390af9cfcd283b2
+  md5: 1c736f58992009f53f014aef163bae31
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48442
+  timestamp: 1682969160267
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_fft-1.3.8-py311h6c40b1e_0.tar.bz2
+  sha256: bcfb0d1e075d043bcf05fa1a7ce3c142bf222d29693366af49a5a346c770812f
+  md5: 59e4820b34049cbc6619a8ac97290abc
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 222137
+  timestamp: 1695058350477
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mkl_random-1.2.4-py311ha357a0b_0.tar.bz2
+  sha256: 114e408c40b332393cf2792393e4d1ede3465abcb3d345fe647ee519565346c8
+  md5: 86b13271578e1fa5e664edcf6fcb3ce4
+  depends:
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - blas * mkl
+  - numpy <2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 296860
+  timestamp: 1695059990370
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: a58960e88525a202ba193b4dd8227c4d9c3dd98b8b43edea34b05a9a9fd1121c
+  md5: 71a37f987c3df6657548d098bd2a58e7
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8286383
+  timestamp: 1699543227340
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: e08cb3ee6df01f4c1e1ac8bc4ed1a06e549ffcc8774fe2e2842c644bb8f74a86
+  md5: 6ba0ae0fb14cbea1e3197707701dc180
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123077
+  timestamp: 1698934356774
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 2f946b5042eaac97206b5217fb203f3604ab3a60aecd99bdfc684925e3136c18
+  md5: b24026076c381ff2009e7acb9e0a6e87
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 534650
+  timestamp: 1699022791300
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.9.2-py311hecd8cb5_0.tar.bz2
+  sha256: ba368605a0af6f1dcbdcb6fddab9ce63224a85dd11bfb2b1acace1dc17899411
+  md5: 91f3ea3fe44d619ee95a6ed3773a0814
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 170926
+  timestamp: 1694616830121
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 42d803e1d8b54748db5d989ecd503826f564132df7cddc20f520460f55e523a1
+  md5: cd3fa71626ebc098da4625fc6be79752
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16952
+  timestamp: 1708532805951
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.4-py311hecd8cb5_1.tar.bz2
+  sha256: 92d50872fad0d1fecfea42cbfdb69887def80927c169a88204d163c2d3c7d035
+  md5: fe6780b8659ff5d6061268708a7b2032
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 716120
+  timestamp: 1690984968401
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+  sha256: ed5608feb37a083d47b04203195260e801b64b5380f292cf18bb61e7ad827a2a
+  md5: daa9c1c233673b727528548454aea664
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27607
+  timestamp: 1699456006797
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.8.7-py311h728a8a3_0.tar.bz2
+  sha256: cacba45c1eebf7d86748737717883a98cf40664231460fa41391c79f98d06f45
+  md5: 3dbfae0d5b90e77f9358564ad442ac9d
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 165572
+  timestamp: 1696515553184
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h728a8a3_0.tar.bz2
+  sha256: 1466c3af380b949612c79940124e426eccd59e335c205da0c00383a69358d1c0
+  md5: df6be53592d40ba7e03d6ffe349760bf
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311h53bf9ac_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11330
+  timestamp: 1708639985606
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311h53bf9ac_0.tar.bz2
+  sha256: ace67d704fa7eea1480eb463f2d91bfc161be2ee20263c5a9939805ae3c2a9da
+  md5: ec124589478fa12fba4f35f31c3a0692
+  depends:
+  - blas 1.0 mkl
+  - libcxx >=14.0.6
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311h728a8a3_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8783230
+  timestamp: 1708639945646
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.4.0-h66ea3da_0.tar.bz2
+  sha256: 173bc3a2534e87100fc93326d716c3cb0b790894aa3a15f31fc4ab9a06f9143c
+  md5: 93f5d7b66976154adeda219bea02ba45
+  depends:
+  - libcxx >=10.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  license: BSD 2-Clause
+  size: 484257
+  timestamp: 1630093862501
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.13-hca72f7f_2.tar.bz2
+  sha256: 891ffe9826f6f9ec9a4fc5d1bbb9a64f9de23f27705c2202f7d475b7cd14dd83
+  md5: ab0d447c9eb4fcada05d853bd13a24ac
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4970613
+  timestamp: 1716319014066
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+  sha256: 8a0809f419065e014cb8e2c8a516cadca6088fb71fd1ef3ae2287d91e3360d59
+  md5: 4dc0b9bc88476fcc5246d823ff1c289a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39645
+  timestamp: 1699371213055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-23.2-py311hecd8cb5_0.tar.bz2
+  sha256: 64fbbb03570788298d8b04d4ea6cb254fef5d5eec73265aeecd72cb565617f4d
+  md5: 4b1195028bc26257df43fdd943638266
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 159450
+  timestamp: 1710811009212
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.1-py311hdb55bb0_0.tar.bz2
+  sha256: 6abb7e0aeda0130f54925421900772e1bc46d1f04ae69ce1376524457686d49f
+  md5: 232a6370c3fab0c41c6d4c7339e778ca
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - xarray >=2022.12.0
+  - xlrd >=2.0.1
+  - pytables >=3.8.0
+  - qtpy >=2.3.0
+  - scipy >=1.10.0
+  - adbc-driver-sqlite >=0.8.0
+  - pyqt >=5.15.9
+  - fastparquet >=2022.12.0
+  - pyxlsb >=1.0.10
+  - gcsfs >=2022.11.0
+  - matplotlib-base >=3.6.3
+  - tabulate >=0.9.0
+  - xlsxwriter >=3.0.5
+  - html5lib >=1.1
+  - python-calamine >=0.1.7
+  - pandas-gbq >=0.19.0
+  - odfpy>=1.4.1
+  - pyreadstat >=1.2.0
+  - dataframe-api-compat >=0.1.7
+  - beautifulsoup4 >=4.11.2
+  - lxml >=4.9.2
+  - sqlalchemy >=2.0.0
+  - jinja2 >=3.1.2
+  - s3fs >=2022.11.0
+  - psycopg2 >=2.9.6
+  - openpyxl >=3.1.0
+  - fsspec >=2022.11.0
+  - adbc-driver-postgresql >=0.8.0
+  - numba >=0.56.4
+  - blosc >=1.21.3
+  - pymysql >=1.0.2
+  - zstandard >=0.19.0
+  - pyarrow >=10.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17296294
+  timestamp: 1709591285369
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.4.2-py311hecd8cb5_0.tar.bz2
+  sha256: 10a5eb185aa5dcfecfa854c2e66b3779cb6d2dee85f1b2236f43234a1c1ba9e0
+  md5: 2200abcb857e6bb8cb46b861cb4d2fd7
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.0.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22071486
+  timestamp: 1714072093679
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: daf01c56a3c44555ecb61e9a0e899a7b58872c6b7631f00a04ee8d3199e9e568
+  md5: 2163ed8005a14ecda15efe5586582cce
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 267508
+  timestamp: 1711137004592
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-10.3.0-py311h6c40b1e_0.tar.bz2
+  sha256: 90efc71d35ab62d5b8d7b648e016444e1c4c8b83238b6dc9f2c6c3db4b14c599
+  md5: 6b6eeb0a14c5479db1dd39aa8d338150
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 939480
+  timestamp: 1714399174883
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.0-py311hecd8cb5_0.tar.bz2
+  sha256: f6b0ded7010706431f2a6d9776aa6033dfd19d2264b3cebf28072629160090a8
+  md5: 02de6d0d9cc23fafe2e3597ed0e52693
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3444268
+  timestamp: 1715097155645
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 81719c31101d6c019150cedcc7b08adb3bdb357e8b2952e428dadaabc4dc985d
+  md5: 105825168e0a17fb007f60b5f314e311
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38405
+  timestamp: 1692205731769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.14.1-py311hecd8cb5_0.tar.bz2
+  sha256: c0982f688127129e026d2b4cdacdd5684d00796ea7bdadd7d26b1101b095d723
+  md5: 0d6910c74729fede645c010110f1c89e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 121796
+  timestamp: 1679340253537
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+  sha256: e32843723b10ecd9badde28e1085419c0b59ed8a96c7cacce6395e39e3a874f9
+  md5: 5af0280a817d2c273304cd22328124af
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763044
+  timestamp: 1704404460779
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h6c40b1e_0.tar.bz2
+  sha256: 117a435c2473e2a20cc81eaacb2b45ea5e7fe3c946eec2915936d344913ede44
+  md5: 0f459ee59fda20e2077fdc2c777edfc8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 497470
+  timestamp: 1679337286052
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+  sha256: dfb403f367c57327a4d080109df88383ecff18464de287a1ce936a7274e3656b
+  md5: 997b674bad89963af875b93b06807f51
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2120413
+  timestamp: 1684280057020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.0.9-py311hecd8cb5_0.tar.bz2
+  sha256: 9d2c0f373ac1c5db329581793dd517092cdf9a59140f2516ed8c3a1f483c0bbd
+  md5: ee10503a159e819abdc586666bdf0952
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207552
+  timestamp: 1678322848766
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 717e038567506ca58ce1cd4a3416892d02f4ebfdd332077cc3d110cfe3d36c58
+  md5: 53bbfb400668f798eef6f8c7cf938e1f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35751
+  timestamp: 1678315886516
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.9-hf27a42d_0.tar.bz2
+  sha256: 092dea8d520acff3e64c71155e666b0b6074d37a71d5eb32f3cd485b0d185d0b
+  md5: 9fbaf2d9534c26e76aa14b11b23de332
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.0,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16852220
+  timestamp: 1713545835789
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+  sha256: 04e100d0a1ea9722e24972657ec5935ad34c7c58957dabb821333e5eac80f717
+  md5: 2b6de49ad07b26e1f7084f0fda958eb1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332276
+  timestamp: 1716495830117
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.16.2-py311hecd8cb5_0.tar.bz2
+  sha256: 514249897265f66f6ecca0a4427eb02a43c33b3c24974db16d05db6bbe97881d
+  md5: c9ea1437e5a3ba6a52ec2322505203e6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279116
+  timestamp: 1679338758489
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-2.0.7-py311hecd8cb5_0.tar.bz2
+  sha256: 78b785b9b6ed46c86b0d3a32bdceea49f816672227fb63e726b2d46eadbdba0b
+  md5: 79d783f74359141e0b06a848db33823b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18563
+  timestamp: 1683823935261
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+  sha256: e358fe679e83ccdc8c433746ae6468e8e96d90d97d99530f8476ef5630b2c121
+  md5: ce30a0a31d891e69dc9b7bf8b7f0c39c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 268876
+  timestamp: 1713974360942
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+  sha256: eeb5a5eed93b8e311ad4d3f4389e050f11bba2eaec9536e1c3ed2f849c6c999b
+  md5: c18bd3e12de797d52a470c21a150dffe
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65270
+  timestamp: 1711136914884
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.1-py311h6c40b1e_0.tar.bz2
+  sha256: c3e11ed944da69c11b949bb918341a0d79ef603ee34a632d6a45fbf89ff924a1
+  md5: fee7ff4d291f530b4cecb575f29807a0
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 197996
+  timestamp: 1698096137432
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+  sha256: aa07b90a7ee65f76c8cba1ff99a5cdeb95cbe41881ae951f64ffff06674a1b2d
+  md5: 58621e3d244137885f7dfbb35e50340a
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 594801
+  timestamp: 1709318510622
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+  sha256: d784dc26c5de8e41845350a899e5779250b71f45d39e2aece62e739e9add7308
+  md5: 7b077b7f46112bb31dc066396c51d3fa
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74776
+  timestamp: 1699012164201
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.31.0-py311hecd8cb5_1.tar.bz2
+  sha256: 3357b6b327b3d0a2cc0f02934a60bbd6df38f4ea7bbb3f50cb8e21332c9f5786
+  md5: bf5e48b646e36ef2b788be9665c0e5ae
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 120768
+  timestamp: 1707355762747
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+  sha256: 727fb8d957e02d03b928d049ffbc712316f176a2c331391766d646621b45655a
+  md5: 7e0e416c642f3ee4ddfb084a811fb4df
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10236
+  timestamp: 1683077214314
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+  sha256: a8a67143ccb65cfd6f50055176b6c26179a83130a45d0a12e79dd2de68d8db63
+  md5: a2065790f41e3eeb6efe0ef6daa75377
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10600
+  timestamp: 1683059285216
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311hf2ad997_0.tar.bz2
+  sha256: 6aba582338faa0c26fe336bdb10c65b8f7808a6e383bd8f80f3e6b612ca209ec
+  md5: a7486349b5f7370f6902c2050a23d268
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 319197
+  timestamp: 1698946203341
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+  sha256: beba0555707dac1e8484d73cee9e4128ac4b10e2a0d4209357481179022e8fdc
+  md5: baa8b304607b3a9ae8a3d9acb354c31c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33343
+  timestamp: 1699371216044
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-69.5.1-py311hecd8cb5_0.tar.bz2
+  sha256: c1df29188e321abe23651c73712a6d8ed3abdc89ad38a42c33f1835b3ab77abe
+  md5: 6c984ea85326858942f7b635e0cc9ff8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1597325
+  timestamp: 1715025837032
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0eb44a16ef74a13ef7839209899d009cd94974fbc406a417d958c7bc8d955245
+  md5: 41f239a5b67b1daf819849023aa5d12f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19056
+  timestamp: 1705431379885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+  sha256: 14775231982e1ea150189c956927ccfb1ad01a8c9395cdeea4d5a48b9b8ce664
+  md5: 729badc4bf7ba8ccc70e0f9e58075c99
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89812
+  timestamp: 1696347694075
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+  sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
+  md5: 6bef1694163a68ac4c37e5857b8da4f5
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1900191
+  timestamp: 1714488351925
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+  sha256: 3d5c2968f581006437df3932cd5d3c1c4afa78f0e13757b958440245d3248856
+  md5: 605ea221d225ad8e79284dbcfdab0715
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37699
+  timestamp: 1678317755913
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: ed059e32ce5a1c0511575f29d2fb6da12c54a37000bfa80f9e5aa9dfd9e04101
+  md5: 4d2261a92d25136a68b8d01d101119f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49145
+  timestamp: 1678317386284
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+  sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
+  md5: 523c006cc67c011383678c762015479b
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3594448
+  timestamp: 1714770737885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.3.3-py311h6c40b1e_0.tar.bz2
+  sha256: 6ab71b48d145c69007cfb5b4a21def2cc83bba972b7cc91c7d52d0d7eeb055bf
+  md5: f8970b0ad5c8b452b8722ceb4e5c17f7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 895379
+  timestamp: 1696937269468
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.4-py311h85bffb1_0.tar.bz2
+  sha256: 3df84b9897f05a104c99e297dc29ad8f718982fc64c61b5a2204c19c578f47e5
+  md5: deab971930d242221ed86bfd768dde40
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 155545
+  timestamp: 1716396266697
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 9e8dbede0bc54c77b974210be66503e7e8e45e0f1c71dc5c16cc9a9674d54259
+  md5: b4fcab9e63bd7b3cdf458c953904807c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270874
+  timestamp: 1678316116954
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: 17e5688d09ffbcb8b71b34b86edc7374fa0b04d60a4d729d405ffc22ef63726c
+  md5: e4bf44ddbbcb136332ccb47ac2b879a0
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9890
+  timestamp: 1715269046804
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: 7d369ec970d1d5411e457c79f94197756c7088deff8183806ea71e633b26edf9
+  md5: 9ffa197b26373667f50b21876862398e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 75595
+  timestamp: 1715269030928
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+  sha256: a9960485ced319ac91afe69eaaf703c7e6b3049f1e06a4a8c2818b64155943f0
+  md5: 0a9c8ea92a14330a07edabac249e32a9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11399
+  timestamp: 1678394892923
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+  sha256: d42ae57366d05e12f10074583568355752436d66ad018ffbcfa24135f593810a
+  md5: 1a98e48aa0bd8b3ec09e2cbdbb236575
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 498952
+  timestamp: 1713213079520
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: 5dc693f0e0aeb30cb6033015b13e75c8a21c56b1262d9652788c3e73a5c5c4a5
+  md5: 6b5cc9b43aa34431f8c30b5cdc22004b
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - selenium >=4.4.3
+  - h2 >=4,<5
+  - requests >=2.26.0
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 210522
+  timestamp: 1715636148762
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+  sha256: 597015e8a038a111f03ffbc9a217fcda549d75230c86ce53c1f23c53d6f1a0cb
+  md5: 62e98aac883bccc1c87ca0d2ce2f08e0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25798
+  timestamp: 1678317074170
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: 1430e6f4b4dd9354b7bb88f7f7bc9cdbab26a034ad1ae5c278de0f5a99329372
+  md5: be0832862b29bf5767a707ac6bd53b93
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 114834
+  timestamp: 1715878445060
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.43.0-py311hecd8cb5_0.tar.bz2
+  sha256: 885a9b6046e76f7dc1a346b14c63b4083046137bfae036362c854458e20e4fc8
+  md5: 3b279447ca282d065e681e567055b582
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 137340
+  timestamp: 1714717062907
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+  sha256: 5b6d5246955b5f9480ff7027eb002442a7ade24f5c354da54ed513042f76cedc
+  md5: f32aa8a37d5e65a8dc30f9a1f46bc63d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54719
+  timestamp: 1678325412288
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+  sha256: ed0152ad6b87ffd9e01f4a62bc358e805ad59637f898a801b0a9cf903ae8e1fb
+  md5: 8a92f8c663608f24e14d8a2068b9d83a
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 415323
+  timestamp: 1714511993944
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+  sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
+  md5: c25b6d40f834647d0bbe767f6c776031
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 329449
+  timestamp: 1705602140856
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+  sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
+  md5: f2519b551f99765d9d98950c5e2b4713
+  license: Zlib
+  license_family: Other
+  size: 119782
+  timestamp: 1714511811597
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.5-hc035e20_2.tar.bz2
+  sha256: 7feb73e79bdbd45404ddc7a30c43bf4cc68eced8ce448ce7c31f5db134276fc5
+  md5: 48313bc6570c705cadbba3c356e0dc8e
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1014151
+  timestamp: 1714678461080
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.2.0-py311hca03da5_0.tar.bz2
+  sha256: 9ca3f0dfc2bdbc109e359ba7ab246e6ae952a14819148ad069454b52f2bda802
+  md5: 51fb05873a644cac52f0d1e10cb7969a
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.23
+  - uvloop >=0.17
+  license: MIT
+  license_family: MIT
+  size: 228856
+  timestamp: 1706220385566
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+  sha256: 43405cc7341ce3efb2e24013ad62c64f26a69926635adceaa5459ccbcafb3776
+  md5: effa6d22f497e164cc8455f7f329c304
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 12510
+  timestamp: 1677917870614
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_0.tar.bz2
+  sha256: 947efe1c50b3280e9a67cbb18636bdade53a40960fff3056850ff81ab87acbe3
+  md5: 7d2d384ee32ccc12dcb0dc099e421482
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 35091
+  timestamp: 1677915945226
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-23.1.0-py311hca03da5_0.tar.bz2
+  sha256: 8259b4a0973c825ac81f581afcbe86640bd0a94b33caa996167309241877635a
+  md5: 49b8ddacfd3927bcaae139eadfb72ce1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153557
+  timestamp: 1695717951839
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.2-py311hca03da5_0.tar.bz2
+  sha256: 11159a30daae77cfc1abe5e60c19261f65c005e6fbc460aecf72318514d737ad
+  md5: 0c5002654a9cb21db1fdf8c1d2017df5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 269772
+  timestamp: 1681493072129
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.4.0-py311hb6e6a13_1.tar.bz2
+  sha256: 90439f37ede74ef464e76093e173a8e94a20ee4ad79c68c9e7570fbc67fc13cc
+  md5: bb3b906307dd679fc3276be7581494f9
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6073834
+  timestamp: 1712084392983
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.3.7-py311hb9f6ed7_0.tar.bz2
+  sha256: 688a071ba370f51b457cd32d70b7b38921ce9551203d06fa7fc2c30c4b79891d
+  md5: b2353077a39ab997463768154dd58fec
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134711
+  timestamp: 1707864978809
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_8.tar.bz2
+  sha256: 048264434c33fdb53862cdd69b2e2bc4ce6f8a70b3211ad6d686d066eac2aa91
+  md5: d55696ccaf6755931cd662dfb929aa0b
+  depends:
+  - brotli-bin 1.0.9 h80987f9_8
+  - libbrotlidec 1.0.9 h80987f9_8
+  - libbrotlienc 1.0.9 h80987f9_8
+  license: MIT
+  size: 19737
+  timestamp: 1714483270447
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_8.tar.bz2
+  sha256: 13627293296fcc231d8dc12d803dfc9621108c60df38b0e3c64e9e02ed55e564
+  md5: 86efd4ad08cd80d3eab77873db84a255
+  depends:
+  - libbrotlidec 1.0.9 h80987f9_8
+  - libbrotlienc 1.0.9 h80987f9_8
+  license: MIT
+  size: 19083
+  timestamp: 1714483255364
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_8.tar.bz2
+  sha256: 2e542b2bb27f8379da3efcb83ef084cb26e6a9ab576c50487c2dd996afd5ccb1
+  md5: e8cab9d1ef58a450f971690fcdb2ede2
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 380182
+  timestamp: 1714483330655
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+  sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
+  md5: 56d1386c7f1f338f0d18f82af6525273
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 158748
+  timestamp: 1714510571033
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.3.11-hca03da5_0.tar.bz2
+  sha256: bbfc668f445f3584936b326dcfe92bf71971ce16241f4f79db8aeb88d7aab41c
+  md5: 10cc05ed51482e1dfcc31dbd13bb34c6
+  license: MPL-2.0
+  license_family: Other
+  size: 138641
+  timestamp: 1710764806818
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.2.2-py311hca03da5_0.tar.bz2
+  sha256: 512969f339a9a7b347cdb7b88f439819168089867f04732279f02759d8caf24e
+  md5: 2009c2ee465fdd74dbd046de73726234
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 166501
+  timestamp: 1707229221324
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.16.0-py311h80987f9_1.tar.bz2
+  sha256: 8d26cd4d16545ad8afddd5521bc6894a50d5b8faff3abbe600bb9b062f3c3a0a
+  md5: 66eb734b7d7008eb5fb537900767c7ae
+  depends:
+  - libffi >=3.4,<3.5
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 286807
+  timestamp: 1714483190838
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+  sha256: 808e56fb70f3d38599ee7a54c2a707b282ba9a401fa69a1f54cdc26425d9ce01
+  md5: fc37321833175bda4fc5c21afe32db49
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 539588
+  timestamp: 1709758479776
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+  sha256: d9c126d8bcd1c89ea37186c172d6b1f73f45ada60e3ae1790a017b530baa0147
+  md5: f0223aae3d622547f6accb212579c58e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17967
+  timestamp: 1709322909223
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.2.0-py311h48ca7d4_0.tar.bz2
+  sha256: 1f908c688e47d03d92ac09d9541a1f1c773ac2ca485dd1d77441b1aaefc032db
+  md5: 444c330471496a39a97e87f41ed70c96
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281104
+  timestamp: 1700583698464
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.6.7-py311h313beb8_0.tar.bz2
+  sha256: b9356e3ada4872c7c950d2ac7e0f107c4786775191efdfda3a469dffb18f2714
+  md5: 07ddd96675caf30ea77cafb1ea5662a4
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2490144
+  timestamp: 1690905181398
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+  sha256: b1481ffa475c65200626f051d5dcbdb264730b533e928dde608a79ce7a5b4e48
+  md5: aada2761547a291d68f4c016a1a9bc7b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 18265
+  timestamp: 1677911915719
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+  sha256: eb82a0e2ca36d0973b5f6642e27609554edad4b72696f989776d5db8cd4a6a42
+  md5: fa8d9dd8a2fabba964c6bb75ace8c572
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 3201601
+  timestamp: 1713551611540
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.18.3-py311hca03da5_0.tar.bz2
+  sha256: 898d10bc1ededb43b7339ccf57fef404d96184de8ebaa788dba0b36a8c8a282d
+  md5: a1925e4ff9f6124ca7d439430bc110fb
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5399311
+  timestamp: 1707836657705
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.10.0-py311hca03da5_0.tar.bz2
+  sha256: 765d5b7ef75ed7f52a110504cd88e9b0c9977b841f1beaeeabb17e629b462908
+  md5: 0af9cd26a7c9eb8b77d3cbacb93a118b
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 360105
+  timestamp: 1715090588763
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+  sha256: 4d4ab70ae0ce008c1cc96a4edfbf3866d5e636acc4799a545ea93acee51635f7
+  md5: 86a085a440729020d1d7b0b74d6a0c6c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148448
+  timestamp: 1714398923507
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.28.0-py311hca03da5_0.tar.bz2
+  sha256: 63670c8f31770e1746016f645ca6b42b35f92d1c37e8025793d9490fed9998c0
+  md5: 9cb417b9fdf02b4e007a5b5781e5a8cc
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229932
+  timestamp: 1705934202146
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.20.0-py311hca03da5_0.tar.bz2
+  sha256: a40c76c412ec793ca26b97a9b5c496d253768438e1f7d4a0ee5f63ea79eed355
+  md5: f609e4fe044318211cf0e37e289beebd
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1614299
+  timestamp: 1704833142734
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.18.1-py311hca03da5_1.tar.bz2
+  sha256: e57d10579b52a3cde45aa17e1bdd95dcb9d3346aa00eb02c51e38a42db83e18d
+  md5: 05153120787fb09159b6e1ad902c6e10
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1180481
+  timestamp: 1678994989550
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.3-py311hca03da5_0.tar.bz2
+  sha256: 06512ef9a910fa72bf5697fe89e88c605d61f8478a9d8dd233c13f40e30f8446
+  md5: cfa00c9ffd3407e29507525c020e5526
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 355730
+  timestamp: 1706733720706
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_1.tar.bz2
+  sha256: d0c46242393d556d12c236f0d60d4f98b6eab1d32661ee5cb71a3bf862a4ee13
+  md5: 055e12390b844ea6c6e956ee08a618e8
+  license: IJG
+  license_family: Other
+  size: 273479
+  timestamp: 1677849171867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.19.2-py311hca03da5_0.tar.bz2
+  sha256: 62025ce4a2b9244b9816c9e02487e0dda567600692b5f9ca71f425d084961c7e
+  md5: d57b7063122e5bf25cdfc2a5ea7330a8
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 181872
+  timestamp: 1699041739097
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+  sha256: 404b0847029f77bedd7902a170a046219e0dc5c0ec2be19ff45361cff25b2181
+  md5: 3a02bbe8d45fdbcb2350f672be74c9f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16524
+  timestamp: 1699032463763
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+  sha256: 7deb8ad28c34c369573754304a03ea2acda8ee39102a56526ec689a4d9210109
+  md5: 675ea1a746a78ff6bf8fc4b39139efff
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 277400
+  timestamp: 1677914250715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.5.0-py311hca03da5_0.tar.bz2
+  sha256: 8220b1bbdde5e800810f7bf183a992af1a95825a837edf975fa8c4b51c5d806f
+  md5: 3a06ddad06e04d5f0211c22cd81ca75a
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94950
+  timestamp: 1698937436979
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.8.0-py311hca03da5_0.tar.bz2
+  sha256: 8a9a9f9ddbf1b7744ef04a8c862438499a41d81a4beb4a49860156c273bb7497
+  md5: 051355801f09eefe850ee8145151f934
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42497
+  timestamp: 1699282590553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.10.0-py311hca03da5_0.tar.bz2
+  sha256: 65c703cc996a705d0ee350070e313b1cae865f9d6e6490ebf1164c0f3ce22d93
+  md5: 305ad8bcaad3e352d61b1e594093b467
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 596801
+  timestamp: 1699466743685
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+  sha256: 501e929d345aaa9079c965552b942b4e8bde35b87ae89faef003687a40bab3a4
+  md5: 54c7b8554a405acd7c8326c41ba93e63
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28237
+  timestamp: 1686870817418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+  sha256: 773e7c4571f482a744dfb18ae26fb22635f5d3f51389c838bd97f9044ea55cc4
+  md5: 5161546aba5597318cb5653390cdecd8
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20235
+  timestamp: 1700168681687
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+  sha256: 8c1c64d51be73aad381992a9df19d8336910bdfc40f19940231df86e177d17cc
+  md5: b1f786f96684a143cf30d1f6b8aebdb3
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65045
+  timestamp: 1677925371836
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.12-hba8e193_0.tar.bz2
+  sha256: 51e7683549248b9dad3b7d897bf58ba6ac205ae0833ae2261d58746a30942d67
+  md5: 7b5fd4df2a76303132c964bdc5e9c799
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.2.0,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 381078
+  timestamp: 1628858598062
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-3.0-hc377ac9_0.tar.bz2
+  sha256: 273cfe6374fb924e4d829af4b03d0a8be33aad5a88ec05992b71b2bd6a1e8e8f
+  md5: 255cac6bbe51bc940f6be144ce03bccf
+  depends:
+  - libcxx >=12.0.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150335
+  timestamp: 1635523422442
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_8.tar.bz2
+  sha256: 199042b87451abaf14546af124ae3380194cddda928e0d30ccb341e93084854c
+  md5: eaa0442887994a82486c65d87f6b71e6
+  license: MIT
+  size: 68806
+  timestamp: 1714483212137
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_8.tar.bz2
+  sha256: bd9a8a17fb14086446b710fa029d238e69274b83ee2e7e09093496f190de82b5
+  md5: 66615d6a0cb5dcca3e20c019cde0ed2d
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_8
+  license: MIT
+  size: 32975
+  timestamp: 1714483225840
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_8.tar.bz2
+  sha256: e1bf77e8b975c30a69b08a08410622e27c8cff6f592ccfa590466b83d9e6d104
+  md5: 8af86bdac01fe303d693d9b76c071059
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_8
+  license: MIT
+  size: 310266
+  timestamp: 1714483239194
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.17-h80987f9_1.tar.bz2
+  sha256: 2d00050a7fc5606fde23d93f2026dd6c6e1631505ae1efb78b3a921f787cc9b5
+  md5: d7ab3e05dd4a208d00eb99f98157073e
+  license: MIT
+  license_family: MIT
+  size: 57736
+  timestamp: 1695996497021
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+  sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
+  md5: f31e4eb9cd6447cc2f5ef0243a76540c
+  license: MIT
+  license_family: MIT
+  size: 120460
+  timestamp: 1714483461787
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-h313beb8_0.tar.bz2
+  sha256: 51b2c39b911276b2b4aa7e02d1bc7f46349e357fd3e8e835de91d7419b25291b
+  md5: 72f5fa7b7f8ee7310e6c34fe115dd843
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 637627
+  timestamp: 1693575264127
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_0.tar.bz2
+  sha256: d3ea40f6440c4bce2efa9085ba3b371d38d5e5e329147b7a698460c873c3d6c7
+  md5: 6d1e9532bfd6cdf81d29bcfe5eadbece
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 331675
+  timestamp: 1694776939192
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+  sha256: 41c62a460bb81a1a272aa28b219fab9c26510adac177ff1528b1980eabc6e868
+  md5: 8d312c5628dc7ea833e9b4dcb73e9c45
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 42346
+  timestamp: 1677973051421
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+  sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
+  md5: f5f7e6e7541d8dc3d3df270d488d2e24
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176990
+  timestamp: 1714510588159
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+  sha256: d024f5142416961a5e66e424d4d14aec652f9e9dd738b41a97f45674c2ffc9d5
+  md5: 0e2d94b125d802f7b006cf19c71655a1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 163084
+  timestamp: 1677932947966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+  sha256: acfd84e29ff4dc2d85543bb973a07f22b4ba53c5d00bca84608ee7f13b2a8676
+  md5: 5ca161cd51e2db358e768453b3ee485e
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135871
+  timestamp: 1684279980293
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+  sha256: b1bed54c7bfb7304cde9e8e6f798543d08e808e81286a5a48296fc94d621f9da
+  md5: 774358285c9e496c9f5c121cc546c823
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27438
+  timestamp: 1704206026910
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.8.4-py311h7aedaa7_0.tar.bz2
+  sha256: 9229a6e15abf3147cfcffad4ca389dad940e45779963b4fc3fd56dfdcfca3234
+  md5: 4e1897f3cb4923de48c016468c01c051
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9100733
+  timestamp: 1713336457304
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+  sha256: 3276d61fc353c537bb09d4b7473d7abe12be38806f42c8cc383b62f40850a5cc
+  md5: 6e9c9d47f264b77d9a8461f0899848a7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20446
+  timestamp: 1677918370379
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+  sha256: 43c96d30775b61b4968422a47f9605049428120669f0742bbb9e5ba145c7d11e
+  md5: a31ca0d9284860adf5463cf45a5e3145
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 69243
+  timestamp: 1677995336989
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+  sha256: 96d8c9f42a38651b7bafe5f3cb132601db76cd1e28fa58e2eaf090e634292fff
+  md5: 5ebc793a17b6aa84d13f19433545ffa5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23895
+  timestamp: 1677942274932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+  sha256: db9bd659ada23f1ded443d2db00dd13b5d5c0b30f5062544b1ee2c2b88d63d29
+  md5: 03c48121614cf12abfe30eced9b34717
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105333
+  timestamp: 1677916687032
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.0.0-py311hca03da5_0.tar.bz2
+  sha256: a8b3d349481dc694eb9a507f55c91e8981e2a3bc41743023ca01248c8a6d779a
+  md5: 71e6e29ec3b98fb282c01b012a5df236
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8294656
+  timestamp: 1699543119360
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+  sha256: e8eee27fb667aa10b26f3bc4b93f449b7d991ded27b9cb457effee394ce05f6f
+  md5: 6a3e5cd0e1141c01ffb91285bdccfe83
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123043
+  timestamp: 1698934328890
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.10.0-py311hca03da5_0.tar.bz2
+  sha256: 40230434aa2fbb33ece13632e8d4b7cd1ad68fdb8d1b00263af4a010795d25f8
+  md5: f12ce7dad3620d6d53a442fa9d36a0b0
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - pyqtwebengine >=5.15
+  - tornado >=6.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 538067
+  timestamp: 1699022954841
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.9.2-py311hca03da5_0.tar.bz2
+  sha256: a492acec8ceadc0911a75966ffa630a8eb15b2da8c7a8d544a645ba47771a2d1
+  md5: 4002b1b88b2ecfdfc769036f43b0a895
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 170964
+  timestamp: 1694616845237
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+  sha256: 417ace1ce51e81f3f92ddc26e0e3a83c1e19c9ebb7af7104452002a5573da534
+  md5: 3e11de6cef096091bb733e07802f00b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16979
+  timestamp: 1708532698253
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.4-py311hca03da5_1.tar.bz2
+  sha256: 2e09ae8d10d7e5651727aab66a1e89b59e716295267a8295eaa53760c4c38533
+  md5: 8d52be8699bf030546811bb69fbeb2b1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 728383
+  timestamp: 1690985022565
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+  sha256: b0cc542e2a6f42ba716e7e4ccf29eddcb155ad167fcdbc72d2db9c7873eb5639
+  md5: 7acf81b17d2c4ceb3cd39dc9f173855c
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27539
+  timestamp: 1699455954000
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.8.7-py311h6dc990b_0.tar.bz2
+  sha256: 151a3eb68d1189e69764ece1d8fb3544d31a22f5bbbc3e19d846de8dece304d2
+  md5: eb6609e6bdc9c82d70df3f8c4c2de95b
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153313
+  timestamp: 1696515415712
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+  sha256: d3bb1d4be88320a5861cd3a0f086e9709f9b64c96c032cb9039cc4f17ec66a85
+  md5: 0a7b97665c06fcd34a70e34abc177280
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.26.4 py311hfbfe69c_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11288
+  timestamp: 1708639168951
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+  sha256: 3e70248a7069ca12ccf56252869bfdb72211fd4e4c327e6994756496df786c79
+  md5: ce4846006d98638cd86a532a72f8dfe4
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311he598dae_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7536860
+  timestamp: 1708639153133
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.3.0-h7a6adac_2.tar.bz2
+  sha256: 7ec782f65e7ea74f7c18a8659c42e64ff84b5549e9839c6d095a491eedde8fca
+  md5: 371358a54bbdd307603888348d1a2c6f
+  depends:
+  - libcxx >=12.0.0
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.2.0,<4.7.0
+  license: BSD 2-Clause
+  size: 412248
+  timestamp: 1628861367714
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.13-h1a28f6b_2.tar.bz2
+  sha256: da78bd65c91881856baadf977534832f68db3938c1b5b713c8797be70b83c98c
+  md5: f728656890f860eec5ad2899e657df3a
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4763426
+  timestamp: 1716318333548
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+  sha256: 77b0c0a0fb14d817390244ebd93c36d44a7867239963f211f7c0a72a3f98d382
+  md5: b90336feb8a50d2eff880e89acb02f40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39617
+  timestamp: 1699371253760
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-23.2-py311hca03da5_0.tar.bz2
+  sha256: 4f6c3e8d8fc4c57975cab837ef109b9ee7af4f18aac72668334ac656e53c6edf
+  md5: fbf1b507f9a80c5de3c957e8152124da
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 159289
+  timestamp: 1710807498427
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.1-py311h7aedaa7_0.tar.bz2
+  sha256: 3af823879c340838c1040e99f653c3438ccce8dc559bd91c3f4ab2579282a002
+  md5: 5b3df01fda0281dab4196bc36d1ca367
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - odfpy>=1.4.1
+  - adbc-driver-postgresql >=0.8.0
+  - scipy >=1.10.0
+  - fastparquet >=2022.12.0
+  - pyxlsb >=1.0.10
+  - pymysql >=1.0.2
+  - sqlalchemy >=2.0.0
+  - pyreadstat >=1.2.0
+  - beautifulsoup4 >=4.11.2
+  - fsspec >=2022.11.0
+  - openpyxl >=3.1.0
+  - xlsxwriter >=3.0.5
+  - jinja2 >=3.1.2
+  - zstandard >=0.19.0
+  - numba >=0.56.4
+  - matplotlib-base >=3.6.3
+  - psycopg2 >=2.9.6
+  - xlrd >=2.0.1
+  - pyarrow >=10.0.1
+  - pytables >=3.8.0
+  - html5lib >=1.1
+  - blosc >=1.21.3
+  - gcsfs >=2022.11.0
+  - dataframe-api-compat >=0.1.7
+  - qtpy >=2.3.0
+  - adbc-driver-sqlite >=0.8.0
+  - lxml >=4.9.2
+  - xarray >=2022.12.0
+  - s3fs >=2022.11.0
+  - pandas-gbq >=0.19.0
+  - pyqt >=5.15.9
+  - tabulate >=0.9.0
+  - python-calamine >=0.1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17082645
+  timestamp: 1709591689205
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.4.2-py311hca03da5_0.tar.bz2
+  sha256: 8bf772501cf4b49a939de17bf378d3e395f452d3070d05871354bd2bc915d012
+  md5: 753d2070a2aea47934ecf6ac1ea0bc04
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.0.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21901817
+  timestamp: 1714071405089
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.1.0-py311hca03da5_0.tar.bz2
+  sha256: 67feb8232961ad9d7672a49f6f86f0b86764f62a97d86d58b90ca7e8345bab76
+  md5: 3afb6e6747bd29e9483d35dbf8b24f74
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 264413
+  timestamp: 1711136882294
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-10.3.0-py311h80987f9_0.tar.bz2
+  sha256: 174b680f4bb041e8146aae80f92390122459e0ef8c911cab22d01e2e92d44ab1
+  md5: cfffc94779cd26a349bd409b5590b098
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 916496
+  timestamp: 1714399019350
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.0-py311hca03da5_0.tar.bz2
+  sha256: 102c3c35a9dfa0f10ec8f4a040a24295f9c736443ccae2f685348a44f62a4d68
+  md5: 027b347e79e252aa17b534e1a02bccd6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3447682
+  timestamp: 1715097070362
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+  sha256: b6200816d65673aa1707c20a768c9cff87dd8dbe1335f9c1478e5931dfa08ee0
+  md5: 14b1e0fa73eb33f9c83048482dcce57b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38423
+  timestamp: 1692205689597
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.14.1-py311hca03da5_0.tar.bz2
+  sha256: ebdf211edd98d88a23778551c7a9702106edd0695d4fc48e87c21f77521c1ffe
+  md5: d8c505081a468f1b99c62466e2309417
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 123084
+  timestamp: 1678996822234
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+  sha256: 07cfba50d9e94364bde077731a824ca4f537138b35ee6b66d07aee16ac9850f1
+  md5: 919bf486280a11e6acb3c2c3a82f7473
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763225
+  timestamp: 1704404463402
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_0.tar.bz2
+  sha256: 8094436b2c44e68e72569c704633802aad82e977b1e16026848218679c8becf4
+  md5: 2360e46d3e598dd5e2abed781fe166c5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 502115
+  timestamp: 1678995719872
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+  sha256: 121b5b66721760c05f1d4eee91626229d1814663d3fb5f23126ef870aa496e26
+  md5: 0c588c2ca790a05d422c06e8568201ad
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2124200
+  timestamp: 1684280082141
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.0.9-py311hca03da5_0.tar.bz2
+  sha256: 44b694db8e81d61960d28d60f9e9b573f03f7827881d302da334378881db4889
+  md5: 6c94ba7caa599ff533e0ab55d898be8a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 208454
+  timestamp: 1677910948527
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+  sha256: 0bb3d2a57b332c5cf73ea40ea13c850ae24a1f9a3a41ed9267832d9e3c767572
+  md5: 45a7fcf1641980d5114999736428502d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36755
+  timestamp: 1677906514270
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.9-hb885b13_0.tar.bz2
+  sha256: 960c343b7b8569dfe4e71a395f7bede1e749da7b02c17506b590c9e1839e6fd7
+  md5: 722c4b4386af73cf1562974a00c880a4
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.13,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16494386
+  timestamp: 1713545544909
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+  sha256: c3cbf5bd237b0a7458640191016b2701fe120c547df9afc835da76663a9c17f7
+  md5: 843568c76b6b9384635b7fca74c79792
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332222
+  timestamp: 1716495881101
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.16.2-py311hca03da5_0.tar.bz2
+  sha256: f94b3cfea6f76ea9983e16d3c4c7e0a64f02c40cc2c3ad57189bca2e67030bd9
+  md5: 0d100990ade57a02b60d1e8085db0bdf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 280263
+  timestamp: 1678996927464
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-2.0.7-py311hca03da5_0.tar.bz2
+  sha256: 252c86f5aef7f8dfce99a260c24cbb35a9adfea144a2acfabb224f516341544f
+  md5: 745b888e19a644f48800799f82c01c21
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18539
+  timestamp: 1683823925189
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+  sha256: d945744eb133f19ca61325cac5128bdb053ae04de4a0ba6f69c061449cac8af7
+  md5: 34baa81490d667381bc7021435b0e1f2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 275858
+  timestamp: 1713974457562
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+  sha256: 012585bdb5ae54c2cded50be703734e6dbf418b003635b6f6d7c1e36e7020c30
+  md5: da7e99a707bd0cfa20db651b5c068bfd
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65556
+  timestamp: 1711136890180
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.1-py311h80987f9_0.tar.bz2
+  sha256: 4f04a43cbd612ab09cefbdc2e48ee61b51967dad59d859ce0502cc2c46c88fc5
+  md5: c68bf65433b2151b51b2e699bc22c501
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 194632
+  timestamp: 1698096151085
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+  sha256: ae8cdd5be5a7ad19ff82925a035859fafcc5942cd3899d127a508dbb9a235090
+  md5: 252a7b997d08bf72f10b3bc2dc68333e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 580346
+  timestamp: 1709318480624
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+  sha256: 7a208abc002a2fc208ae25cb2cf932999a3e4980aa4c9edff315cb9ac62b12ce
+  md5: bd22ebd3cff811577ea61f115ba7f4f2
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74744
+  timestamp: 1699012126255
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.31.0-py311hca03da5_1.tar.bz2
+  sha256: cc8d055a068fe5a7484284c3360d81db61656dd6118c743c740fcc47cd3da379
+  md5: e5fad71ef3b99077b79052576e51bf9f
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 120672
+  timestamp: 1707355664440
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+  sha256: 52368d9b557b8f54ef5ca4bf6cd5a3ec665171f2b2d2082cdd410bab88f4829c
+  md5: ac76fb4d2eef3ecdd491cf5d3fb8620d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10204
+  timestamp: 1683077239143
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+  sha256: 491d116c5f54ef340e3bce631835f7138cd1923d7b63e6ca9aa01b48110cb8f9
+  md5: 9b81bd8ea808704f5433884b567f1f15
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10557
+  timestamp: 1683059079547
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311hf0e4da2_0.tar.bz2
+  sha256: b53a5f6119173d62e4e68a37ea8511c7fc87a00af72953e0048d075a799c7a7a
+  md5: 76a16cf4edb9b12b2b96a2d323f060dc
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 342535
+  timestamp: 1698945991201
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+  sha256: c80d52567084b1caaed2862b77b70065ca17afaf0b020733e9d6c273b4a63e78
+  md5: ddf7d88c1967f3f7a4ce1c975fd47e0d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33321
+  timestamp: 1699371225235
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-69.5.1-py311hca03da5_0.tar.bz2
+  sha256: 6d38d171ef87340cf0fbbf4c70217df4826c65400c9290774f5cb35e381e3315
+  md5: b9529a812f9862fc89461b6b90f184ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1599110
+  timestamp: 1715024190898
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+  sha256: cd71091a234874d2826fa063ec5222b3191c9f47e1b5281c352d9df3f31a06bf
+  md5: 0db8e29016c6bff026c083d9923a7566
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19073
+  timestamp: 1705431415504
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+  sha256: 3e18cdafc607c6d7623b1c8f041cbfbb50a27e298f961abdcce7e36834ac39e1
+  md5: 9ee0da74c55d0b8d83edf246fd717f20
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89862
+  timestamp: 1696347657368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+  sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
+  md5: d8c1e9910392d0bcb22a173f9ce30fa6
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1758290
+  timestamp: 1714488307689
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+  sha256: b5c265e9ed9a1ff2238a09b83bdc1826950faa87fd6b685debe60888de6e7a50
+  md5: 5827c8a32317894ce18576e334daba47
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38559
+  timestamp: 1677918962258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+  sha256: cfefd86d0f4981d22b7611b3dc60359b8698bf39f2b743cb90b7005aaca88e1e
+  md5: a04dbcd6095f6b8f3ad195a78d48b262
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50058
+  timestamp: 1677917499177
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+  sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
+  md5: 3c25b4f4768ccda28b20a03ba27e7759
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3484151
+  timestamp: 1714770744982
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.3.3-py311h80987f9_0.tar.bz2
+  sha256: 177246487449f87567fe56c8f20011a4350a132d1556c9f87474d7b2e8c1374f
+  md5: d465118217b9f27d47dceff89c2e9f95
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 896655
+  timestamp: 1696937042980
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.4-py311hb6e6a13_0.tar.bz2
+  sha256: 81efb240a49cede5ece3a8ad48f1d9dfdeb56260bf1a20e25ec53cdb202f7c3e
+  md5: 81a17d13c75596841b95340a34bbe929
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 155516
+  timestamp: 1716396017482
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.7.1-py311hca03da5_0.tar.bz2
+  sha256: 65e760119352cd85c63d365d2576c09a9ddb060e5b029a265d50bc268eed9290
+  md5: 14c241871b12dc3be52e6cd681267caf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 271445
+  timestamp: 1677911758960
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.11.0-py311hca03da5_0.tar.bz2
+  sha256: 96071e07e807414b7ae5a2fe958ac171e5795576b3a4c2f5e8c643fba43d760f
+  md5: a34f2b216e35a37f966883dacda229e2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9902
+  timestamp: 1715268985387
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.11.0-py311hca03da5_0.tar.bz2
+  sha256: b20e48aff4c781a52b6be66d77418e768527a621f5fc272ecb34ea03475b2bd7
+  md5: 707738432f16f5e63909fcaa6e65850d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 75604
+  timestamp: 1715268976065
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+  sha256: 2ea2d0520b330d381a2ab241bdb9ae146ef815ee7c96ee52a9773fb9ae85f4fd
+  md5: 66f7f8979cfb2cccffac972d70482130
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 12614
+  timestamp: 1677963554857
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+  sha256: df7fe7740bd853b641d624e2ec97f1aacb2b82691936a8c04ef18fa9768539c2
+  md5: d5c7626d45fd03b22797c18e47812beb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 518048
+  timestamp: 1713213046424
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.1-py311hca03da5_0.tar.bz2
+  sha256: 3fbcccceb4d7d99f60a6e6e013ab84c4532244c42ab9d65b6fdaab6bd30f7269
+  md5: 6a7e05872852d4bcde959f7cc8407672
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - requests >=2.26.0
+  - selenium >=4.4.3
+  - zstandard >=0.18.0
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 210307
+  timestamp: 1715635933070
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+  sha256: 09738b7f9075386bf062b12ddb6fb72a06450d2481f6b5ca2026c811cd849569
+  md5: 9afdec076c95746ac21235f971190e40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26727
+  timestamp: 1677910175964
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+  sha256: b4ced7366de8eb7258f31d516616e70c62ed4a798780e57e208509d2b52ab435
+  md5: 65a9a05a726734c1da667f9bd3c78c14
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 114733
+  timestamp: 1715878377412
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.43.0-py311hca03da5_0.tar.bz2
+  sha256: aa301d9e42aadbe3dd5f301ccbf17fbadc347fd37d413c0cbcbd24403892a936
+  md5: 77097d17d835a137af7950c628b66150
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 137260
+  timestamp: 1714717037687
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+  sha256: 2cd108896df65636769e3804ecc2ca421ad9b54e64fa21922bbabe40c90c247a
+  md5: b3a1e5077b28f71298d891fbfb5ff03e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55645
+  timestamp: 1677927459979
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+  sha256: 5be8c968f2da5c4bf14f28d63e31b4c1b6993d980023769732c7f58f396c2e0b
+  md5: 3f5f62d4e85e3bdd48d39189b01805a6
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 459197
+  timestamp: 1714510992914
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+  sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
+  md5: 3d57d1adadca9388aaaa1c529b65ba65
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 322790
+  timestamp: 1705602163804
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+  sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
+  md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
+  license: Zlib
+  license_family: Other
+  size: 104928
+  timestamp: 1714510936868
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.5-hd90d995_2.tar.bz2
+  sha256: a3f3eaf240991b6bd7b0596a78d0abb3321cc79db52fa24f6f559189778871c6
+  md5: 71f035b4716322539e2461cb6667e946
+  depends:
+  - libcxx >=14.0.6
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 825339
+  timestamp: 1714678419523
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.2.0-py311haa95532_0.tar.bz2
+  sha256: 6e6787755de0cf2fd776c9681a7b0fd0fb23e35e679a463cc2005b991c413910
+  md5: ccad42ec9a2ad48939f089c528abc8f0
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.17
+  - trio >=0.23
+  license: MIT
+  license_family: MIT
+  size: 229694
+  timestamp: 1706220431719
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h2bbff1b_0.tar.bz2
+  sha256: f715f7c2e06149bd6d43258e41479d3171efe5e9d56050a0a5f5652ed9d05fff
+  md5: 11a8ca43d69881b88f95ae681478866d
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 36089
+  timestamp: 1676424516042
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-23.1.0-py311haa95532_0.tar.bz2
+  sha256: 9adabcdd2a10f73fa5ba56adc901eeea2e379991a0d4cb9737eec7aa6b9fc5d8
+  md5: fc80b572be85601706d425b21a58d497
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 153102
+  timestamp: 1695718054194
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.2-py311haa95532_0.tar.bz2
+  sha256: 38ccda1553733326d99a75436b4b0f7640bafbbfcdbc33838b0e59cf017de687
+  md5: 3f6812578c5e0b3ba0d2a651cc766c15
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 266405
+  timestamp: 1681493141116
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.4.0-py311h746a85d_1.tar.bz2
+  sha256: fe765d810e1612af7a42f34223077f0adc05dbd386b257be24661913d067fe30
+  md5: 82e988aba03c8afa03fce78f7442806e
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6086137
+  timestamp: 1712084583317
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.3.7-py311hd7041d2_0.tar.bz2
+  sha256: 5c12a5d7856d9977447360b3a99a5b99818707fe79781ba1779037f11b3fef53
+  md5: 6a125ae352306a944aabc635a5fe13a3
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 139230
+  timestamp: 1707864402762
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 751071782f597f87ed7f67437ef6cc669213902461b9795dd6eb0f4897eddc83
+  md5: 5ad8fe62aad5e16cfdf2c5a7d1327fe7
+  depends:
+  - brotli-bin 1.0.9 h2bbff1b_8
+  - libbrotlidec 1.0.9 h2bbff1b_8
+  - libbrotlienc 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 19418
+  timestamp: 1714483531456
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 9bd62d810867549b9c967c5915f3fa3f66cfbd6ede28b1cc152efd1261285c0a
+  md5: 64cc76de3662b62bc8f0e42befd92c5d
+  depends:
+  - libbrotlidec 1.0.9 h2bbff1b_8
+  - libbrotlienc 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 32178
+  timestamp: 1714483513837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311hd77b12b_8.tar.bz2
+  sha256: 1547fa52134cf06b8d01bdf52114db7db60a89bf35c9c95be5b5a03b13dbd565
+  md5: deb765cb7c4b7edc4d126f864f31747c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 356401
+  timestamp: 1714483740924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+  sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
+  md5: 11e0af09a31e2d5df51c65a342032b85
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 112994
+  timestamp: 1714511182837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.3.11-haa95532_0.tar.bz2
+  sha256: 73391a74a5300ad3fb063ea0f0c3491d220128a0611a84036da2e23c1e93dc0e
+  md5: 501ded4f9b5ed895077802defee912cf
+  license: MPL-2.0
+  license_family: Other
+  size: 171644
+  timestamp: 1710764856021
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.2.2-py311haa95532_0.tar.bz2
+  sha256: cd6545642e380b13700f2f2a7a1fb54a273365047bd23108dbd03b197f5c0c9c
+  md5: 929edc1c553d2da4d6c6c0745b033cc3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 166377
+  timestamp: 1707229328635
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.16.0-py311h2bbff1b_1.tar.bz2
+  sha256: 5cb6ac90ad234248f3795945f69b0382397714a52712337b2f86339526b822d8
+  md5: b90f3126f6315ea2e8ab242533062557
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 302693
+  timestamp: 1714483562551
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+  sha256: 4099898f02e1f6119fcda65e747c3cbfef0bf563c8855b79a0245160709d5b45
+  md5: ab9705c34e67fb8c8faec69d63ff4064
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36410
+  timestamp: 1676422341506
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+  sha256: c722f50980d7416ffb2cfc7bf72649307a0bb78c5a24eccefcd049cb61d6b355
+  md5: c7c9ff0513ff3c99700919293b702410
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 543258
+  timestamp: 1709758602437
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+  sha256: 8fb3e816a5ad1da05125462dbc9e2a7e933b001a871aa65703802c0a894c6277
+  md5: ee4b2fa9fce130496d5c7c86c35a1a05
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17723
+  timestamp: 1709323150229
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.2.0-py311h59b6b97_0.tar.bz2
+  sha256: eeb49cd151ecdccd40062e8123a3b7a9a8a1eda6567dd33ce909ff8ee1a97c89
+  md5: b7fe1f7ead1ec2ac642d022942282fc8
+  depends:
+  - numpy >=1.20,<2
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 232451
+  timestamp: 1700583772701
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.6.7-py311hd77b12b_0.tar.bz2
+  sha256: 5c73f86e575f2ad683ee4a1c2df11020e270edd89d12f11199483d57b0b51826
+  md5: e96a12895ce374476277b1b196ba24bd
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 3719519
+  timestamp: 1690907216785
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+  sha256: 5d5fc8a24c804010b8cb5963227230352ea3ccf56bea9e8116e34f77223218f2
+  md5: 8f989a72eed6293dfe0533c83057980d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17688
+  timestamp: 1676423357100
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+  sha256: 27fb03eb57d25711a15e145f47a64320a9955b585efc9fd0a1a51cdd71b9fde3
+  md5: eb3869e98f6f53dfec76e2eff4d6b61e
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 2732423
+  timestamp: 1713552175344
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.18.3-py311haa95532_0.tar.bz2
+  sha256: 68d59a361a93a5ae36542f667138b4ab072e1abff15b3aa2dc55575baf86a3e9
+  md5: 383239566d9506b743c7bc65d709b7e1
+  depends:
+  - colorcet
+  - matplotlib-base >=3
+  - numpy >=1.0,<2.0a0
+  - packaging
+  - pandas >=0.20.0
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=0.7.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5374020
+  timestamp: 1707836834797
+- conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.10.0-py311haa95532_0.tar.bz2
+  sha256: dee3fc68ed81398d232b3afe9a032837bdbef98c1b2478604d6abd397e3e7d64
+  md5: 3f75535ca6dfee0745b221922f21f6de
+  depends:
+  - bokeh >=1.0.0
+  - colorcet >=2
+  - holoviews >=1.11.0
+  - numpy >=1.15,<2.0a0
+  - packaging
+  - pandas
+  - panel >=0.11.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353312
+  timestamp: 1715090519918
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+  sha256: 102c803186db6d62eaf41a906f6c563ff0d62b53c1eaede8a381e18c0d005ed9
+  md5: 9d30dec03058758a428cf152e0ae28b5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148193
+  timestamp: 1714399061601
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+  sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
+  md5: d215cc8ee7ca2cc83cc250cc5d822fe0
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3929136
+  timestamp: 1699647939158
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.28.0-py311haa95532_0.tar.bz2
+  sha256: 864e9598f64105769b4ec02cc404fb507bc59e217324daf1686c00cfd12c0055
+  md5: 6bb1c3be1f85799a3988afc2c3c5a4f0
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 229621
+  timestamp: 1705934494547
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.20.0-py311haa95532_0.tar.bz2
+  sha256: e0b44f0c3a4ead0fb8e58033c0be25524ee9ecf7f4cc632f03e9f6fac3484baa
+  md5: 50cbc18d0c7b42a4553b52d0cef2c857
+  depends:
+  - colorama
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1637367
+  timestamp: 1704834149957
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.18.1-py311haa95532_1.tar.bz2
+  sha256: d81566367c79a28d4717157fc74293e846a47af99387ed479eb001a425dd398e
+  md5: 28c76079c96ad7f8b1a5ed32b438c79a
+  depends:
+  - parso >=0.8.0,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1147434
+  timestamp: 1679427525584
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.3-py311haa95532_0.tar.bz2
+  sha256: f766a445df8e81447f27c830e162566b221fa1bfc41296a6c5e0789586ca1fbf
+  md5: 55bc50633414fc8616ccbf4140a42d5f
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 353715
+  timestamp: 1706733949898
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h2bbff1b_1.tar.bz2
+  sha256: 43439bef477a8fff322c365cfe6a38c5412140ec738292c4a31c3b19f28a328b
+  md5: 81f2c343dc4c65eea39c45383272068f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 407861
+  timestamp: 1677849239400
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.19.2-py311haa95532_0.tar.bz2
+  sha256: 5e6698015a3b048093f5737f0e54bcbae415d0f9682dfdfeae3a8cfb4ea275e2
+  md5: 0093a4214131046c4f68af0739dfbea4
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 201456
+  timestamp: 1699041872445
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+  sha256: 9581be54128954080d7cef448b1728874c2ebbe5064f55adece422cf12eafa5a
+  md5: 3adc105f87d5c7f0b1248bc3423f5b48
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16187
+  timestamp: 1699032556953
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+  sha256: ad8343bad7c8f0448cbcfbaf872cc94b56da81c52e5cdcee2a5d6b89f029eb75
+  md5: addceff8d46c9d1d322618a9ce9e5b39
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 300354
+  timestamp: 1676424060532
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.5.0-py311haa95532_0.tar.bz2
+  sha256: 851ae576c2b72bf3172cd460feec4f5577dc06476a043e185279071b67549fab
+  md5: fae4d214d00de6604738f39acbbb197e
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119710
+  timestamp: 1698937651636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.8.0-py311haa95532_0.tar.bz2
+  sha256: d97ad90f9121ecf7f8d3af773b222c0bd244204ee73a3e44185491fa16d83104
+  md5: 73ac0fa3c67e5eb283173d74a2771752
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 60625
+  timestamp: 1699282918176
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.10.0-py311haa95532_0.tar.bz2
+  sha256: 257e1102d2dc3f8b0c1708585c819e86f41abd101084cd0569e8e31652480875
+  md5: 2128c6806bba6953e1a275f37e7a295b
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi
+  - jinja2
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.6.0
+  - jupyter_server_terminals
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides
+  - packaging
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pywinpty
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 614705
+  timestamp: 1699467242943
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+  sha256: 90420847230e72a648417f5f77cebcf7f17b89f70788652c276acc0c440e135f
+  md5: ef3d8dee197aa37897bf6d39d2dd878f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=2.0.10
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27639
+  timestamp: 1686871052174
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+  sha256: 97faaf26ce5254ec3649a8ee7f480b1556e4e8e6e4356d2fab1e6a5532631a0f
+  md5: da23bd831c50c877f63038b7e16720ad
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20163
+  timestamp: 1700168785472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+  sha256: 8a2f0909fad0387e57cb0e9ee30db2b20761a9106e794381ffeac387a298fb07
+  md5: 6058b2efc3284e27aacec2e6e6280433
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62334
+  timestamp: 1676432044242
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.12-h83e58a3_0.tar.bz2
+  sha256: 8c735346a71edf114bfe55279b4262c3bcf13862e3e4fe3d4e00223c9d7003c2
+  md5: f5f73266281ab12377d5d47bdf07500a
+  depends:
+  - jpeg >=9b,<10a
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 905072
+  timestamp: 1617648814933
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-3.0-hd77b12b_0.tar.bz2
+  sha256: 20bfa0c43b6b47c372f1912cf76327b5b64af4bf1a7088ff934923b370807423
+  md5: c65e0fdc40ff5ec7ce4b22edee1a1bb3
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145864
+  timestamp: 1635523278997
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 7c906c94a4d46ea963080a6ba5bd12c1274da66159877a544fbc70291eeed98d
+  md5: 45a3d52534fac8aa54a55ee92211a918
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 80216
+  timestamp: 1714483371043
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: daad7edc6d56abf3e176479e8628162dbf1c56b3d24db30d708aebae694a5214
+  md5: e8ecf229f7fcb4c0b76d8613627948f5
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 45189
+  timestamp: 1714483420152
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h2bbff1b_8.tar.bz2
+  sha256: 84320217abffa9386186ec8d03b4651bb4b1900d3871adc965a9a9e1d3799907
+  md5: 651312fa22168f71f9aec5f9ee2c2fcf
+  depends:
+  - libbrotlicommon 1.0.9 h2bbff1b_8
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 756116
+  timestamp: 1714483464368
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.17-h2bbff1b_1.tar.bz2
+  sha256: 3dc4dbb11538d9d6a93a0e3e8334388bc274c95ac3a6158563c95d394299dcf8
+  md5: 2539073f9c3b4126f8fef179e4a2697a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 187095
+  timestamp: 1695996637011
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+  sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
+  md5: cf949d76148be1e2a534218d9c57df86
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 155435
+  timestamp: 1714484319443
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-hd77b12b_0.tar.bz2
+  sha256: d540759117ea88156a97075f2501c41ebc5e639314cfd9c1fbf273a7c6876921
+  md5: 169f1c9be4b9af46ce5dfab2dab660b4
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=3.0,<4.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - xz >=5.2.4,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1460728
+  timestamp: 1693575386348
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h2bbff1b_0.tar.bz2
+  sha256: a62e1fdb4b151cf3b1c37fde9287f0d20c20998edec46b37f9ebfb26068e90e6
+  md5: b1781519a200ccbfcb4a1194005aa3ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 338459
+  timestamp: 1694777084290
+- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+  sha256: 4534c822511a052a72c2b070a05e5d8d6f3550f18ea00a33f9d8a9a92b4382cc
+  md5: 82f24e7660831445a2183216e280a6a4
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41464
+  timestamp: 1676474474981
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+  sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
+  md5: 320f40b75d93f3b96931c6d13c23946c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 158902
+  timestamp: 1714512129889
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+  sha256: e0dc6e119b224bb31ef34b6ba270ffadc181d38b698c5318de8df7a5d2c4ccbd
+  md5: 992ccd756f09408f0b74dfb9852a8b7f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 182381
+  timestamp: 1676437963591
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+  sha256: 050b5fd4b28132d8102a7e6b40179894dc7f5e41f7ad9ee19211e67446c5740f
+  md5: 3ae0b2f6baec708554648ddafa81b756
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 154386
+  timestamp: 1684279992864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h2bbff1b_0.tar.bz2
+  sha256: 8269c73b7a9c03b95a121e318d0468f35eecc016093620b0560f35238cc5df51
+  md5: 2914bea0ae29315f998e1abac79ccaa8
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30214
+  timestamp: 1704206218108
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.8.4-py311hf62ec03_0.tar.bz2
+  sha256: 68fb7d113dbf185b571343847e3dbefdbe7d0b9b5902f1f390bc2a6e33a3f8ee
+  md5: a72ff718390a1fde0b208a43e6b9b655
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1,<3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 11366001
+  timestamp: 1713336740870
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+  sha256: 43279276850eb6e621812448cddc1093524cee0b7f8ed58b4600b68a4fb659f2
+  md5: 5968b2b5c1f3cf5c8c8c9aaa4d8d66a2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19886
+  timestamp: 1676425829787
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+  sha256: 3062a8254ca351b54f15bea85cc928a3ba4d879bb98ce97ece39a9f7eca215a5
+  md5: 8f1565663abb34ad7fdd512e76da5532
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 68031
+  timestamp: 1676481862508
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+  sha256: cdff5215c292fe59649ca40ca72f5d26da352760c1d6a56feba14eb13f7bbf61
+  md5: e0f3f32b22135dfeaec277bc87183ca9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23328
+  timestamp: 1676442709081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+  sha256: 3b173a25605d2aaacc57ec0e425f1d1c51327eb2521c8742a736e2c76069bc8d
+  md5: 169f1c93a443f95a88665f3008623ce1
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104882
+  timestamp: 1676425142412
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+  sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
+  md5: 527155127b9fada5e5c5c69a624674b9
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187498166
+  timestamp: 1699648376430
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h2bbff1b_1.tar.bz2
+  sha256: cea59ae60da314caecf08edb9bcb03126c6dd35837c8184bceaa194decca3341
+  md5: 30936b7263cf0171f7c86400f12ef184
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49080
+  timestamp: 1682975093455
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.8-py311h2bbff1b_0.tar.bz2
+  sha256: 5070ceb0a406b1b8b99e2ec58f5d224cbe16ec78109c46720bd182b509e05c6e
+  md5: 34de1af5c639f2d06c6c8d99488e4226
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 196201
+  timestamp: 1695058367111
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.4-py311h59b6b97_0.tar.bz2
+  sha256: 6b4b27302e458fa527321c59be7c335d61f86da7501c4d141db20a72fad68b55
+  md5: 7db9b12da1290bb2c2fc6ee52a945905
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy <2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 256371
+  timestamp: 1695060425702
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.0.0-py311haa95532_0.tar.bz2
+  sha256: 5422fc4dc6708279223027e45dd1ccffe4dc2feb93c60c8a683946a398c60a1c
+  md5: 62d16437707dd382c21a9ed1d8b375dc
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=6.1.1
+  - jupyter_core >=4.6.1
+  - jupyter_server >=1.8
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8304222
+  timestamp: 1699543942441
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+  sha256: e940f9178ee2fa0a7c12873ae35ebea0074371653e5cfa1be8aa8d9271fd343b
+  md5: 355d0835215911738a28010dfa6aa382
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141785
+  timestamp: 1698934346590
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.10.0-py311haa95532_0.tar.bz2
+  sha256: 47dd00c0179f4eb29c70d0453d340f7f5332af326b3d51c64ca3bf6a14be8e7e
+  md5: f66afe718bdb57667b03ebda4cb2ac7e
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 561655
+  timestamp: 1699023338436
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.9.2-py311haa95532_0.tar.bz2
+  sha256: 4ee863a1ff697274c642b3101f82b279a354e3f033a87505655039f89127bb41
+  md5: bfaf19be6644ad2344e118aa0acccb13
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189809
+  timestamp: 1694617194065
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+  sha256: 90fb3f14c49da1397982eae21cd09e8d60d491d76f94c57590c56723fe6dc172
+  md5: 46a523661fe5c1bce7b4213fd428c3de
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16732
+  timestamp: 1708532795328
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.4-py311haa95532_1.tar.bz2
+  sha256: 5db3fd8b4d97e2a6232e2f7c62f1ce82ae3876326aed9f8c3ea656eda83e55da
+  md5: 39c36df9dac13398e8a54497dcc14611
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 755697
+  timestamp: 1690986137327
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+  sha256: e040ebcab948325fbe17e4ab15be62e1fafa7bad225457e59764adb60eb40db5
+  md5: 4d40a09df8cb74a9f044eab317436d67
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27282
+  timestamp: 1699456187703
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.8.7-py311h1fcbade_0.tar.bz2
+  sha256: d3bd2a6614bb7e7f5ce3348d6674e71cce45cbde236beff32f0f08cd95a64ef0
+  md5: e70f15643164f432d1df68635e7c322b
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 162691
+  timestamp: 1696515822068
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+  sha256: 470fe9a0b3e196fa60d5550d8188f6074a207572fa0d353a4448d580872e7804
+  md5: 6fdb8df0613fb2fb9f1732d335fa25f1
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311hd01c5d8_0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11053
+  timestamp: 1708641901110
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+  sha256: 222c1711e7cf151e29077c7d4d86a865c9fd39615812d58a1daca6fd1b6bdfb5
+  md5: 585bcd8bc3940a8a859f38ebafdcd77d
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.26.4 py311hdab7c0b_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10723862
+  timestamp: 1708641867155
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.4.0-h4fc8c34_0.tar.bz2
+  sha256: c352710e3bd9724c6d8d7332be6863edd0026e0532989b8c2d2c3e254232037b
+  md5: ab07e2a27ac08afe3d0b4c0890b8486a
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - libtiff >=4.1.0,<4.7.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD 2-Clause
+  size: 249316
+  timestamp: 1630094024143
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.13-h2bbff1b_2.tar.bz2
+  sha256: c8e066c2cb547914401ec29b7356914ca3cdf6ac37eead248fe0c41236a7838c
+  md5: 5879739cc77497a518b2ebd55857183b
+  depends:
+  - ca-certificates
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8118619
+  timestamp: 1716319803768
+- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+  sha256: b2f5f50a1ddf811102636f3acebd76716c88ebb628754b91eda7a3a962adf26c
+  md5: 712527b4d84c350dca4b67f511c04414
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39421
+  timestamp: 1699371341381
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-23.2-py311haa95532_0.tar.bz2
+  sha256: 432b8b7c4671878cbbe361e518544203f97bd2e4f24fa08cf65e8be583f25529
+  md5: e62e7c668b080e0f6ce09fd548f69f7f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 159066
+  timestamp: 1710809127954
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.1-py311hea22821_0.tar.bz2
+  sha256: 3ae55d8148580fc3f171c0fcc420488fbba05517cefd358fe013b45ec3594371
+  md5: bfb42ed6826a1c8cded9539fc6e07029
+  depends:
+  - bottleneck >=1.3.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - python-calamine >=0.1.7
+  - xarray >=2022.12.0
+  - lxml >=4.9.2
+  - dataframe-api-compat >=0.1.7
+  - jinja2 >=3.1.2
+  - zstandard >=0.19.0
+  - blosc >=1.21.3
+  - matplotlib-base >=3.6.3
+  - adbc-driver-postgresql >=0.8.0
+  - xlrd >=2.0.1
+  - fastparquet >=2022.12.0
+  - pymysql >=1.0.2
+  - gcsfs >=2022.11.0
+  - pandas-gbq >=0.19.0
+  - xlsxwriter >=3.0.5
+  - pyarrow >=10.0.1
+  - html5lib >=1.1
+  - pyqt >=5.15.9
+  - psycopg2 >=2.9.6
+  - scipy >=1.10.0
+  - numba >=0.56.4
+  - qtpy >=2.3.0
+  - openpyxl >=3.1.0
+  - adbc-driver-sqlite >=0.8.0
+  - tabulate >=0.9.0
+  - pyreadstat >=1.2.0
+  - pytables >=3.8.0
+  - beautifulsoup4 >=4.11.2
+  - pyxlsb >=1.0.10
+  - sqlalchemy >=2.0.0
+  - s3fs >=2022.11.0
+  - fsspec >=2022.11.0
+  - odfpy>=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16924671
+  timestamp: 1709591125871
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.4.2-py311haa95532_0.tar.bz2
+  sha256: b529eac4abff05f13760c51ad37adf24e744109a6fb30471b26dc1f6a1c23847
+  md5: b690cc140a7866280131762a26c05f39
+  depends:
+  - bleach
+  - bokeh >=3.4.0,<3.5
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.0.0,<3
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm >=4.48.0
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21902721
+  timestamp: 1714073654508
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.1.0-py311haa95532_0.tar.bz2
+  sha256: e77795e1af9bc27d45841d6b9c51e0e7da31e0eabaaffa99162245adc55d13a3
+  md5: 14046398ac44f496bc9df300285ec586
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 267222
+  timestamp: 1711137058994
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-10.3.0-py311h2bbff1b_0.tar.bz2
+  sha256: 6ca54ba8ce430caa8a1838b19869814d0b7fa3592a77f75298130983e635387b
+  md5: e56c194e56d19dd8fd76f75a77f92c33
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.12,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 1070844
+  timestamp: 1714399290671
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.0-py311haa95532_0.tar.bz2
+  sha256: 15001c7ee6cf6e0ef7afc2f313114f6103e7b6f641fac9a6899ee02d6537c822
+  md5: 250ba95e77f5fcb3fe2aefa85157e859
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3759346
+  timestamp: 1715097175495
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+  sha256: e5f8cbfb5fc25d460a9117bfc5511959c5e86ccb193316033f87bd516e0c8881
+  md5: 9f7e8b5eb651539386bb92c14e5c321b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37730
+  timestamp: 1692205554840
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.14.1-py311haa95532_0.tar.bz2
+  sha256: 6c5b53831273674361437fb546e08315fc11ca9275a174bca3887987e86ced5a
+  md5: f8d91daf5173eb03157f484389adcdd4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 122178
+  timestamp: 1679591983138
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+  sha256: 546819d922b03f3a25ca9f98fd069d0588d481fc0603c6d74bd598fb6a93687f
+  md5: 86c18e3e0b67ee099457475ed6caf2e6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 751763
+  timestamp: 1704404627180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h2bbff1b_0.tar.bz2
+  sha256: ae06f0dfa2cfae51404afc6d6ad3a474a93015b5ba9a7d3ea24224b8e7547987
+  md5: 3e19794c806cc3e84a3080a97c359b75
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 510466
+  timestamp: 1679005998612
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+  sha256: d95c88d06f4f3f667bd9a39e5f18179e83b3cd4c115c06ce0fff390ff6d3a700
+  md5: c6d00a8a4d89b1be99bfa3aff19d96b4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2134881
+  timestamp: 1684280285492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.0.9-py311haa95532_0.tar.bz2
+  sha256: 643a9a0eba1e2bd5980d21623d3b35188c24781ec251acc4d15714bd1ccb4c17
+  md5: b3cda0394db05be6f0f6176abacb13f3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 207985
+  timestamp: 1678721438358
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+  sha256: 974c22de09078bf07c5db31fe12d8d89d6433508defc8237cbe52e08c69ed56b
+  md5: 9cf10bfd49140a527cf4b1d912097e6d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36072
+  timestamp: 1676426019064
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.9-he1021f5_0.tar.bz2
+  sha256: f43aca7a222c983c25c3e15f79c7e7e3c4909bb7839a1dd0ee327def81aa476e
+  md5: 2b61f1cb7fec068c76ef0ff97c2c62b5
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - openssl >=3.0.13,<4.0a0
+  - sqlite >=3.41.2,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - openssl <3.5.7
+  license: PSF-2.0
+  license_family: PSF
+  size: 19811751
+  timestamp: 1713545124922
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+  sha256: 2c61639b3bb56fc864c86558bceb7845b1731ac44bf1a94894172ea47a995bd4
+  md5: 404805e547b4d50b5cd17e16bca87527
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332043
+  timestamp: 1716495838826
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.16.2-py311haa95532_0.tar.bz2
+  sha256: 9acb33db60d9319595f52337cae3b88c2a2338cd66f1f9d8ae86d0a993c2067a
+  md5: f4af8cf94d042b4dde487241bba1c457
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279780
+  timestamp: 1679500609851
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-2.0.7-py311haa95532_0.tar.bz2
+  sha256: 48fe7373b012b51134b6b6ff67f18d2b4aae3a5c7700e4560ce002af7172f064
+  md5: 0379cd17692152c12b662b0e4ea46b88
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 18008
+  timestamp: 1683824373128
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+  sha256: 803274d986d0c4e3b5ec1018747ede86ef57137455b3e44a60e834717eafb92b
+  md5: c9f134ddeff6fdf0373a45534ddb7079
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 273009
+  timestamp: 1713974722039
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+  sha256: 6fbcba97c1dcb5157afd23f264c3cff069c7e4be5ea55980fc349eb8dc2cb49e
+  md5: 8153e3f8b3283926bcf9403804a365f5
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65050
+  timestamp: 1711137009299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-305-py311h2bbff1b_0.tar.bz2
+  sha256: cd33dfee104dfbba4af38d06a09ccbae6a32e7c543afedab523303319ebb283d
+  md5: 3dfc19af0306d80921e1403f1f551bba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13679916
+  timestamp: 1676423267293
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.10-py311h5da7b33_0.tar.bz2
+  sha256: 102ff1d958209e3648bb49da3503cf752abab822011fdc4e12e88145c9e73772
+  md5: 0553c2c381b6f5c836b23edc8c6db2ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 246689
+  timestamp: 1677708371873
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.1-py311h2bbff1b_0.tar.bz2
+  sha256: bee5c4d0f41f06a9c0aac636885e36e8b81116aafde980f9ea48fdb64abb5567
+  md5: 6c05a053240cb90765d6f8c2efdf905e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 182228
+  timestamp: 1698096268270
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+  sha256: ea39db411361d96545a04fb976940e9590147acb4ca9caacf7e8264780379347
+  md5: b411b8be8e53e5059949dde02dd07faf
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 565148
+  timestamp: 1709319072176
+- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+  sha256: 47653b45a5f2d97b5bf0dbf0e620908880f9078da427eef69012effe3f19af67
+  md5: 44e709ae67d89bccee2d4d46d358fee3
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74493
+  timestamp: 1699012356534
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.31.0-py311haa95532_1.tar.bz2
+  sha256: d7bcba5262df162756885a773c3bf2dace27311bbbb1830a0f97aa60ac7c1239
+  md5: daeb99ccfe39f725278203412aac0873
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 120468
+  timestamp: 1707355917958
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+  sha256: d6daaa6b45272819176e4aeb467ae00e3db43386548464a9993688f292709d40
+  md5: 9fe721d7f7420c259df4f07d4503f654
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9683
+  timestamp: 1683077110211
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+  sha256: 6051860575f9448aea5799d74469c928cd7cdeeca1eb53657872262a77b1a7a8
+  md5: 60e193eca497130034facd5fed168249
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10094
+  timestamp: 1683059114376
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h062c2fa_0.tar.bz2
+  sha256: ecd310461c1b45ab92ddf15539cea5a6e837860561c974d2d7393f9a7933f116
+  md5: 1762fec2838763e904141167e18b0389
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 215600
+  timestamp: 1698947891859
+- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+  sha256: 6fd52bae6360fbc8135d72e0c1e4fd407769fa4d0f4b59356e7aed3e000eb339
+  md5: 49fd52885250da8aab17ed72e2e18b81
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88901
+  timestamp: 1699371435766
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-69.5.1-py311haa95532_0.tar.bz2
+  sha256: a2ec4690bc07be9e7f3ad8e3003803eb4304a434d3f139633e2817318a9f7b20
+  md5: dd2d225219924fc5c36598c919541271
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1593050
+  timestamp: 1715025622141
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+  sha256: 5d1b7e14dc04816692de0f8518ea8fcbefb26ab61cec83f96f2c44c1bee67fab
+  md5: 505d2a70a875b5082dc857aa4dfab0d4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 18830
+  timestamp: 1705431395254
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+  sha256: 5ff3b4ac3fbce4dd67a87856c04698d0397deb0ac288ff4e7eb02fbab57f1253
+  md5: 0ca650a7001c6650809d3361de8cb005
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89590
+  timestamp: 1696347858925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+  sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
+  md5: 833b93a2daade3407898f15588945d83
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1440481
+  timestamp: 1714488344682
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+  sha256: 78d89b50a29fbeb19a562f5dad95615e3f192bb4f3b86cd6ea75f2f825418232
+  md5: 4a4040df560ea47704e0898c4c015808
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38069
+  timestamp: 1678228553220
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+  sha256: 70a3cc4a4e81a6421bc19cd410d1d6064aadb2b1cce38b020f85e5346716d8e7
+  md5: 32a9a2539579a3d522dce3b5cb4f987b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49495
+  timestamp: 1676425411739
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+  sha256: 0a95736cfd0bb25fc201cd6be4a2450ea8fc30eeb349d861812675b84c94fa74
+  md5: a8a9fb30c6dd8e7a16d5dcd2333c3c49
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3844176
+  timestamp: 1714770894235
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.3.3-py311h2bbff1b_0.tar.bz2
+  sha256: 4febf30c11674711b86c8c10da46a5e1613071388da999210912a31508864add
+  md5: 1c109fc1112ea1f5f377bdf0d18ba75f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 895633
+  timestamp: 1696937216859
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.4-py311h746a85d_0.tar.bz2
+  sha256: 973dc7991dd5976ce2d27a94739712cac4d31f2d2958fbf23adb844f5ac999c8
+  md5: ca74b36907b3f4f8a51bd5b2e4d8220b
+  depends:
+  - colorama
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 186541
+  timestamp: 1716396206048
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.7.1-py311haa95532_0.tar.bz2
+  sha256: e8c77efe880546252f244f995cbed5967809555127b4f818b97455d434b23415
+  md5: 7397ac07045115960ebd8dec95326a7a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270819
+  timestamp: 1676423321499
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.11.0-py311haa95532_0.tar.bz2
+  sha256: ab3cce654f1e94793fff0cb03b750d9b20cdbf099263b1906c3c5eaf8b347ab6
+  md5: c68ffc771312afb6f88b94c24d2bb689
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.11.0 py311haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9706
+  timestamp: 1715268972001
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.11.0-py311haa95532_0.tar.bz2
+  sha256: 4089efea1753ebe2f6617b46cc368738f285b1d816d4a4f01ba71524f46851b4
+  md5: 7f610528ecd0b317180efa2058c32323
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 75414
+  timestamp: 1715268958140
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+  sha256: d091897f05318c22ca31028370f25355065999078f7db6f88ab27bf4cb030ec8
+  md5: 1776502c1cfb351554eeda6cddaf255f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11588
+  timestamp: 1676457729096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+  sha256: c16498f8238cc331618720d078b87995eceb6bbf20268a7a4e8efbf7b5859a9a
+  md5: 770432c0ca1ab9d99ffe95e51d3a3e74
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 517433
+  timestamp: 1713213261710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.1-py311haa95532_0.tar.bz2
+  sha256: 3009bd4e7e8126309e606c81cb75d4b8d4fbb2bceac10ec43f7eb6eaaf717ac2
+  md5: ee6e87af42008a762d3531771c1a2b18
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - selenium >=4.4.3
+  - requests >=2.26.0
+  - h2 >=4,<5
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 210034
+  timestamp: 1715636431813
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.2-h2eaa2aa_1.tar.bz2
+  sha256: 906048f3b1dc326b367a08edc91816ff523b5f06cd45d985b4dbb7cfe8017559
+  md5: e509c495aaa92d767d554cd43a990ee5
+  depends:
+  - vs2015_runtime >=14.29.30133
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8900
+  timestamp: 1715797316229
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.29.30133-h43f2093_3.tar.bz2
+  sha256: ab224d078734a23527716388ddffc034d18254843881d0fc068c2efa35bacfe1
+  md5: 73f5831d017e5572330d2459844718f3
+  size: 2246565
+  timestamp: 1715797302913
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+  sha256: 24ea3d3e0cb98d0d246338dbb4562b67967bb32002e3704e495a5c863476e831
+  md5: c7b9cdbe87b3c9720aeca1164a0fd6df
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26181
+  timestamp: 1676424437003
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+  sha256: 92d27e41ce34387e59acb47572fcb2e92c4defaeadafd11ce190226022023e69
+  md5: f1bf142d852987acbe4b0bc94e87d958
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145306
+  timestamp: 1715878654770
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.43.0-py311haa95532_0.tar.bz2
+  sha256: 1b086d1b079fdb2f148c7dd82658f2b7f283c88f286e1216c0f1237319039b0f
+  md5: 299e87f151a549d86a48bf24df15c607
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 168041
+  timestamp: 1714717238470
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+  sha256: 17fadf35aa8917c107e7b369e9364ac7c09537776e7943d37e225e14b7026c94
+  md5: 0e67c3b9624540581b894b11267a837b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PUBLIC-DOMAIN
+  size: 10197
+  timestamp: 1676425485716
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+  sha256: b849b368e27920838fe40a512b102879693a55cb187dd1c8d3a83fa8c05a8054
+  md5: 7b1f6e9c71906a93039b3446b99a5498
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55114
+  timestamp: 1676434863173
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+  sha256: 344a5276a9928638dcde054dfe4e87c8cb40bd2d4d356378b9ab2f863ca62e4b
+  md5: fe471fd8b5a3d77be6fa5dbf9b99dafb
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 1432281
+  timestamp: 1714515119689
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+  sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
+  md5: e5aed81295b61b6d1eb62830799a0297
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 9125184
+  timestamp: 1705602328351
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+  sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
+  md5: f295b54ab59f5b8658e2a322ac6aa721
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 162161
+  timestamp: 1714514792081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.5-hd43e919_2.tar.bz2
+  sha256: b2ff66b7f6efa0831f939e57e562c244332b690af08818a540d1a97fa07d8525
+  md5: e548d528873d9a0006a36714cf36462a
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1933522
+  timestamp: 1714679197977

--- a/template/pixi.toml
+++ b/template/pixi.toml
@@ -21,12 +21,12 @@ python = "3.11.*"
 panel = ">=1.4.2"
 hvplot = ">=0.10.0"
 pandas = ">=2.2.1"
-pip = "*"
-setuptools = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+setuptools = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks.notebook]
 cmd = "jupyter notebook template.ipynb"

--- a/template/pixi.toml
+++ b/template/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "template"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/template/pixi.toml
+++ b/template/pixi.toml
@@ -1,0 +1,42 @@
+[workspace]
+name = "template"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2022-01-20"
+maintainers = ["maximlt", "jlstevens"]
+categories = ["Other Sciences"]
+labels = ["hvplot", "bokeh", "panel"]
+title = "Template"
+description = "This is the example project"
+no_data_ingestion = false
+skip_notebooks_evaluation = false
+notebooks_to_skip = []
+gh_runner = "ubuntu-latest"
+
+[dependencies]
+notebook = ">=6.5.2,<7"
+python = "3.11.*"
+panel = ">=1.4.2"
+hvplot = ">=0.10.0"
+pandas = ">=2.2.1"
+pip = "*"
+setuptools = "*"
+wheel = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks.notebook]
+cmd = "jupyter notebook template.ipynb"
+depends-on = ["download"]
+
+[tasks.dashboard]
+cmd = "panel serve --rest-session-info --session-history -1 template.ipynb"
+depends-on = ["download"]
+
+[tasks.download]
+env = { FILENAME = "data/penguins.csv" }
+cmd = "mkdir -p data && curl -fsSL -o $FILENAME https://datasets.holoviz.org/penguins/v1/penguins.csv"
+outputs = ["data/penguins.csv"]

--- a/timelapse_microscopy/pixi.lock
+++ b/timelapse_microscopy/pixi.lock
@@ -1,0 +1,9650 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/nodefaults/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.11.9-py311h2dc5d0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311h9ecbd09_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.8.0-hb88c0a9_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.8.0-hecf86a2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.10.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.0-hf42f96a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.0-h1ffe551_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.9.1-hab05fe4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.15.2-hdeadb07_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.11.0-h7bd072d_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.7.3-h3a84f74_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.1-hf42f96a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.2-hf42f96a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.29.6-hdec8b0f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.449-h5558e3c_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.14.0-h5cfcd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.10.0-h113e628_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.13.0-h3cf044e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.8.0-h736e048_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.12.0-ha633028_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hfdbb021_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.3-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.1-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.0.0-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.9-py311hfdbb021_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.55.1-py311h2dc5d0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.5.0-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.7-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_h5888daf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-18.1.0-he15abb1_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-18.1.0-h5888daf_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-18.1.0-h5888daf_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-18.1.0-h5c8f2c3_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.31.0-h804f50b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.31.0-h0121fbd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.67.1-hc2c308b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-18.1.0-h6bd9018_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hbbce691_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hf672d98_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.21.0-h0e7cc3e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-he137b08_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-hf23e847_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-h064dc61_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.43.0-py311h9c9ff8c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.3-py311h2cbdf9a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py311h2dc5d0c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.3-py311h2b939e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.0-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.1.0-py311h2dc5d0c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.60.0-py311h4bc866e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.14.1-py311h7db5c69_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.0.2-py311h71ddf71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.3-he039a57_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py311h7db5c69_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.0.0-py311h49e9ac3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.2.0-py311h9ecbd09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-18.1.0-py311h38be061_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-18.1.0-py311h4854187_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.10-hc5c86c4_3_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py311h7deb3e3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h77b4e00_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.22.0-py311h9e33e62_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.9-h0fd0ee4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py311he9a78e4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.2-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.18.0-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py311hbc35293_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holonote-0.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.18.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holonote-0.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.18.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.11.9-py311ha3cf9ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h3336109_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.8.0-hb1b2711_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.8.0-h1c3498a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.10.3-h6e16a3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.3.0-h1c3498a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.5.0-heedde58_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.9.1-h0c96e2d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.15.2-h789f5c1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.11.0-h00ab244_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.7.3-h704940e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.2.1-h1c3498a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.2.2-h1c3498a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.29.6-he19e5b3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.449-he3c0133_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.14.0-h9a36307_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.10.0-ha4e2ba9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.13.0-h3d2f5f1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.8.0-h1ccc5ac_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-files-datalake-cpp-12.12.0-h86941f0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hd89902b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.3-hf13058a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.8.30-h8857fd0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.1-py311h137bacd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.1-py311h4e34fa0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.0.0-py311h3336109_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.9-py311hc356e98_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.55.1-py311ha3cf9ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/frozenlist-1.5.0-py311h1314207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hac325c4_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h2790a97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.7-py311hf2f7c97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240722.0-cxx17_hac325c4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-18.1.0-h14b790f_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-18.1.0-he5ac762_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-18.1.0-he5ac762_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-18.1.0-h16335c3_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-25_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-25_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.10.1-h58e7537_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.4-hf95d169_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.22-h00291cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.4-h240833e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.31.0-hd00c612_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.31.0-h3f2b517_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.67.1-he6e0b18_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-25_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-hc8e404f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.64.0-hc7306c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_hbf64a52_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-18.1.0-h436316b_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.44-h4b8f8c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-5.28.2-h8b30cf6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2024.07.02-hd530cb8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.0-h2f8c449_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-h3dc7d44_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.21.0-h75589b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-h583c2ba_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.9.0-h6e16a3a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.5-h495214b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.4-ha54dae1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.43.0-py311h25b8078_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-4.3.3-py311h12b7ed1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.2-py311ha3cf9ac_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.3-py311h19a4563_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.1.0-py311hf2f7c97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/multidict-6.1.0-py311h1cc1194_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.60.0-py311h0e5bd6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numcodecs-0.14.1-py311hcf53e2f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.0.2-py311h14ed71f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hd471939_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.3-h5cd248e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.3-py311haeb46be_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.0.0-py311h1f68098_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/propcache-0.2.0-py311h3336109_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.0-py311h1314207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-18.1.0-py311h6eed73b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-18.1.0-py311he02522f_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.3.2-py311hfbc4093_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.3.2-py311hfbc4093_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.10-ha513fb2_3_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311h3336109_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.2.0-py311h4d3da15_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2024.07.02-h2fb0a26_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.22.0-py311h3b9c2be_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.1-py311hed734c1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-he1e6707_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.2-py311h4d7f069_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-15.1.0-py311h1314207_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h00291cd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yarl-1.18.0-py311h4d7f069_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h7130eaa_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py311hdf6fcd6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holonote-0.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.18.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.11.9-py311h4921393_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311h460d6c5_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.8.0-h9b725a8_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.8.0-h5d7ee29_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.10.3-h5505292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.0-h5d7ee29_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.5.0-h13ead76_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.9.1-hf483d09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.15.2-h39f8ad8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.11.0-h68a0d7e_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.7.3-h840aca7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.1-h5d7ee29_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.2-h5d7ee29_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.29.6-ha226bf8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.449-h3b64406_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.14.0-hd50102c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.10.0-hc602bab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.13.0-h7585a09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.8.0-h9ca1f76_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.12.0-hcdd55da_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311h3f08180_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.3-h5505292_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py311h3a79f62_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.1-py311h210dab8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.0.0-py311h460d6c5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.9-py311h155a34a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.55.1-py311h4921393_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.5.0-py311hae2e1ce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py311h267d04e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.7-py311h2c37856_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_hf9b8971_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-18.1.0-h654e1bb_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-18.1.0-h605b82c_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-18.1.0-h605b82c_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-18.1.0-h9b432b6_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-25_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-25_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.10.1-h13a7ad3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.4-ha82da77_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.22-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.31.0-h8d8be31_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.31.0-h7081f7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.67.1-hc70892a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-25_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-18.1.0-h5168bdf_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.28.2-h8f0b736_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2024.07.02-h2348fd5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.47.0-hbaaea75_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h9cc3647_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.21.0-h64651cc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-hfce79cd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.9.0-h5505292_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.13.5-h376fa9f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.4-hdb05f8b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.43.0-py311hc367efa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-4.3.3-py311hebe0b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py311h4921393_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.9.3-py311h031da69_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.0-py311h2c37856_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.1.0-py311h30e7462_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.60.0-py311h9506ed5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numcodecs-0.14.1-py311hca32420_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.0.2-py311h649a571_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h39f12f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.3-h121fd32_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py311h9cb3ce9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.0.0-py311h3894ae9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/propcache-0.2.0-py311h460d6c5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py311hae2e1ce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-18.1.0-py311ha1ab1f8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-18.1.0-py311he04fa90_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.3.2-py311hab620ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.3.2-py311hab620ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.10-hc51fdd5_3_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h460d6c5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.0-py311h730b646_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2024.07.02-hcd0e937_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.22.0-py311h3ff9189_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.1-py311hf1db568_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.2-py311h917b07b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-15.1.0-py311hae2e1ce_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.18.0-py311h917b07b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-hc1bb282_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py311ha60cc69_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.10-py311hd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holonote-0.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh5737063_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.18.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.11.9-py311h5082efb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311he736701_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.8.0-h6c5491b_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.8.0-hb414858_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.10.3-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.3.0-hb414858_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.5.0-hab6af6e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.9.1-hab0f966_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.15.2-hef77f12_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.11.0-hbfeb708_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.7.3-h6108ab3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.2.1-hb414858_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.2.2-hb414858_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.29.6-h94c4a24_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.449-h0ed5b37_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311hda3d55a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.34.3-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.1-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.0.0-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.9-py311hda3d55a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.55.1-py311h5082efb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.5.0-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.7-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_he0c23c2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-18.1.0-h0ea94f9_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-18.1.0-hb6457b2_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-18.1.0-hb6457b2_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-18.1.0-h30d554c_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.22-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.4-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-14.2.0-h1383e82_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-14.2.0-h1383e82_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.31.0-h07d40e7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.31.0-he5eb982_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.67.1-h7aa3b8a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.2-default_ha69328c_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-18.1.0-he61daf8_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.28.2-hcaed137_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2024.07.02-h4eb7d71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.0-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-he619c9f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.21.0-hbe90ef8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hfc51747_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.9.0-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.5-h442d1da_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.43.0-py311h7deaa30_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-4.3.3-py311h8b5e962_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py311h5082efb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.3-py311h8f1b1e4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.0-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.1.0-py311h5082efb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.60.0-py311h0673bce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numcodecs-0.14.1-py311hcf9f919_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.0.2-py311h35ffc71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.4.0-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.3-h34659fe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py311hcf9f919_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.0.0-py311h4fbf6a9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/propcache-0.2.0-py311he736701_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.1.0-py311h1ea47a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.1.0-py311hdea38fa_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.10-hce54a09_3_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-307-py311hda3d55a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.14-py311hda3d55a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.2.0-py311h484c95c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2024.07.02-hd3b24a8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.22.0-py311h533ab2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py311hf16d85f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-h62715c5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.2-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-15.1.0-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34433-he29a5d6_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hdffcdeb_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-h0e40799_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.5-h0e40799_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yarl-1.18.0-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py311h53056dc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  license: None
+  size: 2562
+  timestamp: 1578324546067
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23621
+  timestamp: 1650670423406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.11.9-py311h2dc5d0c_0.conda
+  sha256: 7ad0ca5ba77e058b442f0c39c708c88f2dac53b8769737701ee57964d51bdc46
+  md5: 2665cc7da1c554be586963d50d1ad612
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aiohappyeyeballs >=2.3.0
+  - aiosignal >=1.1.2
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - libgcc >=13
+  - multidict >=4.5,<7.0
+  - propcache >=0.2.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yarl >=1.17.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  size: 920988
+  timestamp: 1733124865570
+- conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311h9ecbd09_5.conda
+  sha256: d1af1fbcb698c2e07b0d1d2b98384dd6021fa55c8bcb920e3652e0b0c393881b
+  md5: 18143eab7fcd6662c604b85850f0db1e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.0.1
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 35025
+  timestamp: 1725356735679
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.8.0-hb88c0a9_10.conda
+  sha256: d2837a84e6bd7d993a83e79f9e240e1465e375f3d57149ea5b1927c6a4133bcc
+  md5: 409b7ee6d3473cc62bda7280f6ac20d0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 107163
+  timestamp: 1731733534767
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.8.0-hecf86a2_2.conda
+  sha256: 220a37955c120bf2f565fbd5320a82fc4c8b550b2449294bc0509c296cfcb9fa
+  md5: c54459d686ad9d0502823cacff7e8423
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - libgcc >=13
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 47477
+  timestamp: 1731678510949
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.10.3-hb9d3cd8_0.conda
+  sha256: 90bd2ff40b65acb62f11e2500ee7b7e85ac77d2e332429002f4c1da949bec27f
+  md5: ff3653946d34a6a6ba10babb139d96ef
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 237137
+  timestamp: 1731567278052
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.0-hf42f96a_2.conda
+  sha256: 210ba4fff1c9500fe02de1dae311ce723bfa313a2d21b72accd745f736f56fce
+  md5: 257f4ae92fe11bd8436315c86468c39b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 19034
+  timestamp: 1731678703956
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.0-h1ffe551_7.conda
+  sha256: 3b780d6483baa889e8df5aa66ab3c439a9c81331cf2a4799e373f4174768ddd9
+  md5: 7cce4dfab184f4bbdfc160789251b3c5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 53500
+  timestamp: 1731714597524
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.9.1-hab05fe4_2.conda
+  sha256: 90a325b6f5371dd2203b643de646967fe57a4bcbbee8c91086abbf9dd733d59a
+  md5: fb409f7053fa3dbbdf6eb41045a87795
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-compression >=0.3.0,<0.3.1.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 196945
+  timestamp: 1731714483279
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.15.2-hdeadb07_2.conda
+  sha256: 1636136a5d882b4aaa13ea8b7de8cf07038a6878872e3c434df9daf478cee594
+  md5: 461a1eaa075fd391add91bcffc9de0c1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - libgcc >=13
+  - s2n >=1.5.9,<1.5.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 159368
+  timestamp: 1731702542973
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.11.0-h7bd072d_8.conda
+  sha256: 51d3d87a47c642096e2ce389a169aec2e26958042e9130857552a12d65a19045
+  md5: 0e9d67838114c0dbd267a9311268b331
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 194447
+  timestamp: 1731734668760
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.7.3-h3a84f74_0.conda
+  sha256: db17a15e5e01f19700bf9be961e1c4e002ccf8dc4d9caa3a24a0ab54f00f2c2d
+  md5: 171850b890600458ae6c990e78f1fa23
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - libgcc >=13
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 113536
+  timestamp: 1733098705479
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.1-hf42f96a_1.conda
+  sha256: f6e38c79b124c34edb048c28ec58fdfc4ea8f7a218dc493195afbada48ba063b
+  md5: bbdd20fb1994a9f0ba98078fcb6c12ab
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 55738
+  timestamp: 1731687063424
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.2-hf42f96a_1.conda
+  sha256: da802ace5448481c968cfec7e7a4f79f686f42df9de8e3f78c09a925c2882a79
+  md5: d908d43d87429be24edfb20e96543c20
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 72744
+  timestamp: 1731687193373
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.29.6-hdec8b0f_1.conda
+  sha256: cd09f1d5d854607ce7acafc76c74e864f296d296e60b54054a10f757ecc3d2dd
+  md5: 40647232fad98f92be8c6050a7e0c2bd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-mqtt >=0.11.0,<0.11.1.0a0
+  - aws-c-s3 >=0.7.3,<0.7.4.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 354710
+  timestamp: 1733150818238
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.449-h5558e3c_4.conda
+  sha256: 4881f7b4f5e3c797332cffb990df246a422346b220a9c16014f274beb2a276f5
+  md5: ba7abdc93b0ade11d774b47aaab84737
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2945541
+  timestamp: 1732812288219
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.14.0-h5cfcd09_0.conda
+  sha256: fe07debdb089a3db17f40a7f20d283d75284bb4fc269ef727b8ba6fc93f7cb5a
+  md5: 0a8838771cc2e985cd295e01ae83baf1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 345117
+  timestamp: 1728053909574
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.10.0-h113e628_0.conda
+  sha256: 286b31616c191486626cb49e9ceb5920d29394b9e913c23adb7eb637629ba4de
+  md5: 73f73f60854f325a55f1d31459f2ab73
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 232351
+  timestamp: 1728486729511
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.13.0-h3cf044e_1.conda
+  sha256: 2606260e5379eed255bcdc6adc39b93fb31477337bcd911c121fc43cd29bf394
+  md5: 7eb66060455c7a47d9dcdbfa9f46579b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  size: 549342
+  timestamp: 1728578123088
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.8.0-h736e048_1.conda
+  sha256: 273475f002b091b66ce7366da04bf164c3732c03f8692ab2ee2d23335b6a82ba
+  md5: 13de36be8de3ae3f05ba127631599213
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.12.7,<2.14.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 149312
+  timestamp: 1728563338704
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.12.0-ha633028_1.conda
+  sha256: 5371e4f3f920933bb89b926a85a67f24388227419abd6e99f6086481e5e8d5f2
+  md5: 7c1980f89dd41b097549782121a73490
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  size: 287366
+  timestamp: 1728729530295
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_2.conda
+  sha256: fcb0b5b28ba7492093e54f3184435144e074dfceab27ac8e6a9457e736565b0b
+  md5: 98514fe74548d768907ce7a13f680e8f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli-bin 1.1.0 hb9d3cd8_2
+  - libbrotlidec 1.1.0 hb9d3cd8_2
+  - libbrotlienc 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 19264
+  timestamp: 1725267697072
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_2.conda
+  sha256: 261364d7445513b9a4debc345650fad13c627029bfc800655a266bf1e375bc65
+  md5: c63b5e52939e795ba8d26e35d767a843
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlidec 1.1.0 hb9d3cd8_2
+  - libbrotlienc 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 18881
+  timestamp: 1725267688731
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hfdbb021_2.conda
+  sha256: 949913bbd1f74d1af202d3e4bff2e0a4e792ec00271dc4dd08641d4221aa2e12
+  md5: d21daab070d76490cb39a8f1d1729d79
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  license: MIT
+  license_family: MIT
+  size: 350367
+  timestamp: 1725267768486
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+  sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
+  md5: 62ee74e96c5ebb0af99386de58cf9553
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 252783
+  timestamp: 1720974456583
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.3-hb9d3cd8_1.conda
+  sha256: 732571ba6286dbccbf4c6450078a581b7a5620204faf876ff0ef282d77a6bfa8
+  md5: ee228789a85f961d14567252a03e725f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 204857
+  timestamp: 1732447031823
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
+  sha256: afee721baa6d988e27fef1832f68d6f32ac8cc99cdf6015732224c2841a09cea
+  md5: c27d1c142233b5bc9ca570c6e2e0c244
+  license: ISC
+  size: 159003
+  timestamp: 1725018903918
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
+  sha256: bc47aa39c8254e9e487b8bcd74cfa3b4a3de3648869eb1a0b89905986b668e35
+  md5: 55553ecd5328336368db611f350b7039
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 302115
+  timestamp: 1725560701719
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.1-py311hd18a35c_0.conda
+  sha256: 08be6120dc9369f07858677dde2a8474644cc7ec2ae146b39a6953aadc536dfd
+  md5: 351cb68d2081e249069748b6e60b3cd2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 278209
+  timestamp: 1731428493722
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.0.0-py311h9ecbd09_1.conda
+  sha256: 42544e13dc4bb018cec0579ad7a6158c1f296e32fa0995ffd8abb116734dc427
+  md5: 765c19c0b6df9c143ac8f959d1a1a238
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 393854
+  timestamp: 1728335173137
+- conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.9-py311hfdbb021_0.conda
+  sha256: cc2e120f53571e19ee6ea062e85e256fce6550ee139d8127cfb24d7ba015f2ae
+  md5: e1d95dce136e7d0f6a9d7cd9b6dca985
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2567811
+  timestamp: 1732236803227
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.55.1-py311h2dc5d0c_0.conda
+  sha256: 1d130b501942bd43e9d2e47fee0321eb861853fc171e98bb3a7c6cfe2b7f7131
+  md5: 7e891abfe80fe852757e3c92d314a245
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli
+  - libgcc >=13
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2877377
+  timestamp: 1733242455265
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+  sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
+  md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 634972
+  timestamp: 1694615932610
+- conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.5.0-py311h9ecbd09_0.conda
+  sha256: 5bde4e41dd1bdf42488f1b86039f38914e87f4a6b46c15224c217651f964de8b
+  md5: 75424a18fb275a18b288c099b869c3bc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 60988
+  timestamp: 1729699558841
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
+  sha256: 6c33bf0c4d8f418546ba9c250db4e4221040936aef8956353bc764d4877bc39a
+  md5: d411fc29e338efb48c5fd4576d71d881
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119654
+  timestamp: 1726600001928
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
+  sha256: dc824dc1d0aa358e28da2ecbbb9f03d932d976c8dca11214aa1dcdfcbd054ba2
+  md5: ff862eebdfeb2fd048ae9dc92510baca
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 143452
+  timestamp: 1718284177264
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_1.conda
+  sha256: 2f082f7b12a7c6824e051321c1029452562ad6d496ad2e8c8b7b3dea1c8feb92
+  md5: 5ca76f61b00a15a9be0612d4d883badc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17645
+  timestamp: 1725303065473
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+  sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
+  md5: 30186d27e2c9fa62b45fb1476b7200e3
+  depends:
+  - libgcc-ng >=10.3.0
+  license: LGPL-2.1-or-later
+  size: 117831
+  timestamp: 1646151697040
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.7-py311hd18a35c_0.conda
+  sha256: 4af11cbc063096a284fe1689b33424e7e49732a27fd396d74c7dee03d1e788ee
+  md5: be34c90cce87090d24da64a7c239ca96
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 72393
+  timestamp: 1725459421768
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+  sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
+  md5: 3f43953b7d3fb3aaa1d0d0723d91e368
+  depends:
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1370023
+  timestamp: 1719463201255
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+  sha256: 5c878d104b461b7ef922abe6320711c0d01772f4cd55de18b674f88547870041
+  md5: 51bb7010fc86f70eee639b4bb7a894f5
+  depends:
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 245247
+  timestamp: 1701647787198
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+  sha256: 7c91cea91b13f4314d125d1bedb9d03a29ebbd5080ccdea70260363424646dbe
+  md5: 048b02e3962f066da18efe3a21b77672
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - binutils_impl_linux-64 2.43
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 669211
+  timestamp: 1729655358674
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+  sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
+  md5: 76bbff344f0134279f225174e9064c8f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 281798
+  timestamp: 1657977462600
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_h5888daf_1.conda
+  sha256: 8f91429091183c26950f1e7ffa730e8632f0627ba35d2fccd71df31628c9b4e5
+  md5: e1f604644fe8d78e22660e2fec6756bc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  constrains:
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1310521
+  timestamp: 1727295454064
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-18.1.0-he15abb1_1_cpu.conda
+  sha256: afc81af2e533cc35295aebae4fb382e770310d9b1ac31837456b440d35c54cf7
+  md5: bd3e35a6f3f869b4777488452f315008
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - aws-sdk-cpp >=1.11.449,<1.11.450.0a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-identity-cpp >=1.10.0,<1.10.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-files-datalake-cpp >=12.12.0,<12.12.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libgcc >=13
+  - libgoogle-cloud >=2.31.0,<2.32.0a0
+  - libgoogle-cloud-storage >=2.31.0,<2.32.0a0
+  - libre2-11 >=2024.7.2
+  - libstdcxx >=13
+  - libutf8proc >=2.8.0,<2.9.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.3,<2.0.4.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - parquet-cpp <0.0a0
+  - arrow-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 8780597
+  timestamp: 1732863546099
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-18.1.0-h5888daf_1_cpu.conda
+  sha256: 3de5719a7035baad7e665116dce7bb3d069f0c1916e163c553e2e491bbe8b614
+  md5: 6197dcb930f6254e9b2fdc416be56b71
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 18.1.0 he15abb1_1_cpu
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 611272
+  timestamp: 1732863586114
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-18.1.0-h5888daf_1_cpu.conda
+  sha256: 7b3db3d5a7e411f8897e8d74403c1d871f3054300f5009c4bdf75da011bc3f42
+  md5: 77501831a2aabbaabac55e8cb3b6900a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 18.1.0 he15abb1_1_cpu
+  - libarrow-acero 18.1.0 h5888daf_1_cpu
+  - libgcc >=13
+  - libparquet 18.1.0 h6bd9018_1_cpu
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 585458
+  timestamp: 1732863686753
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-18.1.0-h5c8f2c3_1_cpu.conda
+  sha256: e77a354bfc0ba7b04c856f1bb16e7b08950bcde54026087bafec46090380fcc1
+  md5: 5d47bd2674afd104dbe2f2f3534594b0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 18.1.0 he15abb1_1_cpu
+  - libarrow-acero 18.1.0 h5888daf_1_cpu
+  - libarrow-dataset 18.1.0 h5888daf_1_cpu
+  - libgcc >=13
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 520681
+  timestamp: 1732863726954
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
+  sha256: d6d12dc437d060f838820e9e61bf73baab651f91935ac594cf10beb9ef1b4450
+  md5: 8ea26d42ca88ec5258802715fe1ee10b
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - liblapack 3.9.0 25_linux64_openblas
+  - libcblas 3.9.0 25_linux64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 25_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15677
+  timestamp: 1729642900350
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
+  sha256: d9db2de60ea917298e658143354a530e9ca5f9c63471c65cf47ab39fd2f429e3
+  md5: 41b599ed2b02abcfdd84302bff174b23
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 68851
+  timestamp: 1725267660471
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
+  sha256: 2892d512cad096cb03f1b66361deeab58b64e15ba525d6592bb6d609e7045edf
+  md5: 9566f0bd264fbd463002e759b8a82401
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 32696
+  timestamp: 1725267669305
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
+  sha256: 779f58174e99de3600e939fa46eddb453ec5d3c60bb46cdaa8b4c127224dbf29
+  md5: 06f70867945ea6a84d35836af780f1de
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 281750
+  timestamp: 1725267679782
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
+  sha256: ab87b0477078837c91d9cda62a9faca18fba7c57cc77aa779ae24b3ac783b5dd
+  md5: 5dbd1b0fc0d01ec5e0e1fbe667281a11
+  depends:
+  - libblas 3.9.0 25_linux64_openblas
+  constrains:
+  - liblapack 3.9.0 25_linux64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 25_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15613
+  timestamp: 1729642905619
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+  sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
+  md5: c965a5aa0d5c1c37ffc62dff36e28400
+  depends:
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20440
+  timestamp: 1633683576494
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
+  sha256: 54e6114dfce566c3a22ad3b7b309657e3600cdb668398e95f1301360d5d52c99
+  md5: 6e801c50a40301f6978c53976917b277
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 424900
+  timestamp: 1726659794676
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
+  sha256: 780f0530a3adfc1497ba49d626931c6afc978c540e1abfde6ccd57128ded6ad6
+  md5: b422943d5d772b7cc858b36ad2a92db5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 72242
+  timestamp: 1728177071251
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+  sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
+  md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 123878
+  timestamp: 1597616541093
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+  md5: 172bf1cd1ff8629f2b1179945ed45055
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 112766
+  timestamp: 1702146165126
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+  sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
+  md5: a1cfcc585f0c42bf8d5546bb1dfb668d
+  depends:
+  - libgcc-ng >=12
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 427426
+  timestamp: 1685725977222
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
+  sha256: 56541b98447b58e52d824bd59d6382d609e11de1f8adf20b23143e353d2b8d26
+  md5: db833e03127376d461e1e13e76f09b6c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 73304
+  timestamp: 1730967041968
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+  sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+  md5: d645c6d2ac96843a2bfaccd2d62b3ac3
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 58292
+  timestamp: 1636488182923
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
+  sha256: 53eb8a79365e58849e7b1a068d31f4f9e718dc938d6f2c03e960345739a03569
+  md5: 3cb76c3f10d3bc7f1105b2fc9db984df
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 14.2.0 h77fa898_1
+  - libgcc-ng ==14.2.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 848745
+  timestamp: 1729027721139
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+  sha256: 3a76969c80e9af8b6e7a55090088bc41da4cffcde9e2c71b17f44d37b7cb87f7
+  md5: e39480b9ca41323497b05492a63bc35b
+  depends:
+  - libgcc 14.2.0 h77fa898_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54142
+  timestamp: 1729027726517
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+  sha256: fc9e7f22a17faf74da904ebfc4d88699013d2992e55505e4aa0eb01770290977
+  md5: f1fd30127802683586f768875127a987
+  depends:
+  - libgfortran5 14.2.0 hd5240d6_1
+  constrains:
+  - libgfortran-ng ==14.2.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 53997
+  timestamp: 1729027752995
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
+  sha256: d149a37ca73611e425041f33b9d8dbed6e52ec506fe8cc1fc0ee054bddeb6d5d
+  md5: 9822b874ea29af082e5d36098d25427d
+  depends:
+  - libgcc >=14.2.0
+  constrains:
+  - libgfortran 14.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1462645
+  timestamp: 1729027735353
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+  sha256: 1911c29975ec99b6b906904040c855772ccb265a1c79d5d75c8ceec4ed89cd63
+  md5: cc3573974587f12dda90d96e3e55a702
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 460992
+  timestamp: 1729027639220
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.31.0-h804f50b_0.conda
+  sha256: b2de99c83516236ff591d30436779f8345bcc11bb0ec76a7ca3a38a3b23b6423
+  md5: 35ab838423b60f233391eb86d324a830
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  - openssl >=3.3.2,<4.0a0
+  constrains:
+  - libgoogle-cloud 2.31.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1248705
+  timestamp: 1731122589027
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.31.0-h0121fbd_0.conda
+  sha256: 3c38b0a80441f82323dc5a72b96c0dd7476bd5184fbfcdf825a8e15249c849af
+  md5: 568d6a09a6ed76337a7b97c84ae7c0f8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libgcc >=13
+  - libgoogle-cloud 2.31.0 h804f50b_0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  size: 782150
+  timestamp: 1731122728715
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.67.1-hc2c308b_0.conda
+  sha256: 870550c1faf524e9a695262cd4c31441b18ad542f16893bd3c5dbc93106705f7
+  md5: 4606a4647bfe857e3cfe21ca12ac3afb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - c-ares >=1.32.3,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libre2-11 >=2024.7.2
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.67.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 7362336
+  timestamp: 1730236333879
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+  sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
+  md5: d66573916ffcf376178462f1b61c941e
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  size: 705775
+  timestamp: 1702682170569
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+  sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
+  md5: ea25936bb4080d843790b586850f82b8
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 618575
+  timestamp: 1694474974816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
+  sha256: 9d1ff017714edb2d84868f0f931a4a0e7c289a971062b2ac66cfc8145df7e20e
+  md5: 4dc03a53fc69371a6158d0ed37214cd3
+  depends:
+  - libblas 3.9.0 25_linux64_openblas
+  constrains:
+  - liblapacke 3.9.0 25_linux64_openblas
+  - libcblas 3.9.0 25_linux64_openblas
+  - blas * openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15608
+  timestamp: 1729642910812
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
+  sha256: 225cc7c3b20ac1db1bdb37fa18c95bf8aecef4388e984ab2f7540a9f4382106a
+  md5: 73301c133ded2bf71906aa2104edae8b
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 31484415
+  timestamp: 1690557554081
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+  sha256: b0f2b3695b13a989f75d8fd7f4778e1c7aabe3b36db83f0fe80b2cd812c0e975
+  md5: 19e57602824042dfd0446292ef90488b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - c-ares >=1.32.3,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 647599
+  timestamp: 1729571887612
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+  sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+  md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  license_family: GPL
+  size: 33408
+  timestamp: 1697359010159
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
+  sha256: 99ba271d8a80a1af2723f2e124ffd91d850074c0389c067e6d96d72a2dbfeabe
+  md5: 62857b389e42b36b686331bec0922050
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.2.0
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5578513
+  timestamp: 1730772671118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-18.1.0-h6bd9018_1_cpu.conda
+  sha256: 0df119f4c1a2387d910e132c670b29ee5b29dd79384549de6f1a43067515c8ba
+  md5: 1054909202f86e38bbbb7ca1131b8471
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 18.1.0 he15abb1_1_cpu
+  - libgcc >=13
+  - libstdcxx >=13
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 1203523
+  timestamp: 1732863665743
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
+  sha256: e5b14f7a01c2db4362d8591f42f82f336ed48d5e4079e4d1f65d0c2a3637ea78
+  md5: f4cc49d7aa68316213e4b12be35308d1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 290661
+  timestamp: 1726234747153
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
+  sha256: 5e8fd4aa00193c85602ce6101dd28fe31306dff85c9725048f6dc828dfa7c421
+  md5: ab0bff36363bec94720275a681af8b83
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2945348
+  timestamp: 1728565355702
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hbbce691_1.conda
+  sha256: f8ad6a4f6d4fd54ebe3e5e712a01e663222fc57f49d16b6b8b10c30990dafb8f
+  md5: 2124de47357b7a516c0a3efd8f88c143
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 211096
+  timestamp: 1728778964655
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
+  sha256: 0105bd108f19ea8e6a78d2d994a6d4a8db16d19a41212070d2d1d48a63c34161
+  md5: a587892d3c13b6621a6091be690dbca2
+  depends:
+  - libgcc-ng >=12
+  license: ISC
+  size: 205978
+  timestamp: 1716828628198
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_1.conda
+  sha256: 8a9aadf996a2399f65b679c6e7f29139d5059f699c63e6d7b50e20db10c00508
+  md5: b6f02b52a174e612e89548f4663ce56a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 875349
+  timestamp: 1730208050020
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hf672d98_0.conda
+  sha256: 0407ac9fda2bb67e11e357066eff144c845801d00b5f664efbc48813af1e7bb9
+  md5: be2de152d8073ef1c01b7728475f2fe7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 304278
+  timestamp: 1732349402869
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+  sha256: 4661af0eb9bdcbb5fb33e5d0023b001ad4be828fccdcc56500059d56f9869462
+  md5: 234a5554c53625688d51062645337328
+  depends:
+  - libgcc 14.2.0 h77fa898_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3893695
+  timestamp: 1729027746910
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+  sha256: 25bb30b827d4f6d6f0522cc0579e431695503822f144043b93c50237017fffd8
+  md5: 8371ac6457591af2cf6159439c1fd051
+  depends:
+  - libstdcxx 14.2.0 hc0a3c3a_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54105
+  timestamp: 1729027780628
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.21.0-h0e7cc3e_0.conda
+  sha256: ebb395232973c18745b86c9a399a4725b2c39293c9a91b8e59251be013db42f0
+  md5: dcb95c0a98ba9ff737f7ae482aef7833
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 425773
+  timestamp: 1727205853307
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-he137b08_1.conda
+  sha256: 9890121db85f6ef463fe12eb04ef1471176e3ef3b5e2d62e8d6dac713df00df4
+  md5: 63872517c98aa305da58a757c443698e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.22,<1.26.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx >=13
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 428156
+  timestamp: 1728232228989
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-hf23e847_1.conda
+  sha256: 104cf5b427fc914fec63e55f685a39480abeb4beb34bdbc77dea084c8f5a55cb
+  md5: b1aa0faa95017bca11369bd080487ec4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 80852
+  timestamp: 1732829699583
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33601
+  timestamp: 1680112270483
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+  sha256: 49bc5f6b1e11cb2babf2a2a731d1a680a5e08a858280876a779dbda06c78c35f
+  md5: b26e8aa824079e1be0294e7152ca4559
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 438953
+  timestamp: 1713199854503
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+  sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
+  md5: 92ed62436b625154323d40d5f2f11dd7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 395888
+  timestamp: 1727278577118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
+  md5: 5aa797f8787fe7a17d1b0821485b5adc
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 100393
+  timestamp: 1702724383534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-h064dc61_0.conda
+  sha256: 7ab7fb45a0014981d35247cd5b09057fc8ed3c07378086a6c7ad552915928647
+  md5: fb16b85a5be1328ac1c44b098b74c570
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - icu <0.0a0
+  license: MIT
+  license_family: MIT
+  size: 689363
+  timestamp: 1731489619071
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
+  md5: edb0dca6bc32e4f4789199455a1dbeb8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 60963
+  timestamp: 1727963148474
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.43.0-py311h9c9ff8c_1.conda
+  sha256: fb8b3eeea19f1160343d2c84f3b3e888f8c45db563375660905e1e73a793fc74
+  md5: 9ab40f5700784bf16ff7cf8012a646e8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3471295
+  timestamp: 1725305248888
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.3-py311h2cbdf9a_1.conda
+  sha256: 83f560beb20f61bb8c6e43a0656f1e744934d41a48b8a19408e6596cf8ce99a8
+  md5: 867a4aa23ae6c0e9c84cf9aa4f2df0fe
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39383
+  timestamp: 1725089531914
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+  sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
+  md5: 318b08df404f9c9be5712aaa5a6f0bb0
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143402
+  timestamp: 1674727076728
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py311h2dc5d0c_1.conda
+  sha256: 0291d90706ac6d3eea73e66cd290ef6d805da3fad388d1d476b8536ec92ca9a8
+  md5: 6565a715337ae279e351d0abd8ffe88a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25354
+  timestamp: 1733219879408
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.3-py311h2b939e6_0.conda
+  sha256: d31ebd77324b3ea74fa946043402f3bc59efd39c760835ad5f67b2b9e3c54eac
+  md5: 22a5583349cc89b5c9159b15746f27e2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  - tk >=8.6.13,<8.7.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 7980027
+  timestamp: 1733176210238
+- conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.0-py311hd18a35c_0.conda
+  sha256: 9033fa7084cbfd10e1b7ed3b74cee17169a0731ec98244d05c372fc4a935d5c9
+  md5: 682f76920687f7d9283039eb542fdacf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 104809
+  timestamp: 1725975116412
+- conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.1.0-py311h2dc5d0c_1.conda
+  sha256: a7216675325306e3efe30d7036c53379eb391517792d051d738027bc3740aad5
+  md5: 5384f857bd8b0fc3a62ce1ece858c89f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 63150
+  timestamp: 1729065611493
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+  sha256: 6a1d5d8634c1a07913f1c525db6455918cbc589d745fac46d9d6e30340c8731a
+  md5: 70caf8bb6cf39a0b6b7efc885f51c0fe
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: X11 AND BSD-3-Clause
+  size: 889086
+  timestamp: 1724658547447
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.60.0-py311h4bc866e_0.conda
+  sha256: b48178613ba637b647c5738772d3efabfca502ea579b5ec10784a33d5acb0789
+  md5: e32a210e9caf97383c35685fd2343512
+  depends:
+  - _openmp_mutex >=4.5
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libopenblas !=0.3.6
+  - cuda-version >=11.2
+  - cuda-python >=11.6
+  - tbb >=2021.6.0
+  - scipy >=1.0
+  - cudatoolkit >=11.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5801568
+  timestamp: 1718888179690
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.14.1-py311h7db5c69_0.conda
+  sha256: 7a953d08194b108e68c176ebf58813df329bd40847bb92a912ea87b7d15fabbe
+  md5: a50abcda080c2a9e3c46a6985fec12c0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - msgpack-python
+  - numpy >=1.19,<3
+  - numpy >=1.24
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 848638
+  timestamp: 1732243709737
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.0.2-py311h71ddf71_1.conda
+  sha256: a922ec6947ad6953cb011b8f1a44779f6b55d62a14c5bcd25d19a8fb1629da30
+  md5: 04ce874aa54fc1d9c735a04e0c6d99c4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9148240
+  timestamp: 1732314901472
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
+  sha256: 5600a0b82df042bd27d01e4e687187411561dfc11cc05143a08ce29b64bf2af2
+  md5: 7f2e286780f072ed750df46dc2631138
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.43,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 341592
+  timestamp: 1709159244431
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
+  sha256: 814b9dff1847b132c676ee6cc1a8cb2d427320779b93e1b6d76552275c128705
+  md5: 23cc74f77eb99315c0360ec3533147a9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 2947466
+  timestamp: 1731377666602
+- conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.3-he039a57_0.conda
+  sha256: 9657ae19d6541fe67a61ef0c26ba1012ec508920b49afa897962c7d4b263ba35
+  md5: 052499acd6d6b79952197a13b23e2600
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1187593
+  timestamp: 1731664886527
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py311h7db5c69_1.conda
+  sha256: dce121d3838996b77b810ca9097cc17068552075c761408a9b2eb788cf8fd1b0
+  md5: 643f8cb35133eb1be4919fb953f0a25f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15695466
+  timestamp: 1726879158862
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.0.0-py311h49e9ac3_0.conda
+  sha256: f0f792596ae99cba01f829d064058b1e99ca84080fc89f72d925bfe473cfc1b6
+  md5: 2bd3d0f839ec0d1eaca817c9d1feb7c2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 42421065
+  timestamp: 1729065780130
+- conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.2.0-py311h9ecbd09_2.conda
+  sha256: bc2fbbc3f494884b62f288db2f6d53f57a9a1129cc95138780abdb783c487bc4
+  md5: 85a56dd3b692fb5435de1e901354b5b8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 53716
+  timestamp: 1728545855994
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py311h9ecbd09_0.conda
+  sha256: 2ac3f1ed6e6a2a0c67a3922f4b5faf382855ad02cc0c85c5d56291c7a94296d0
+  md5: 0ffc1f53106a38f059b151c465891ed3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 505408
+  timestamp: 1729847169876
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+  sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
+  md5: b3c17d95b5a10c6e64a21fa17573e70e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 8252
+  timestamp: 1726802366959
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-18.1.0-py311h38be061_0.conda
+  sha256: 9cfd158a1bb76c4af1a51237a5c5db4a36b2e83bad625ddf6c2b65ee232c16ba
+  md5: 47b8624012486e05e66f6acf7267aa22
+  depends:
+  - libarrow-acero 18.1.0.*
+  - libarrow-dataset 18.1.0.*
+  - libarrow-substrait 18.1.0.*
+  - libparquet 18.1.0.*
+  - pyarrow-core 18.1.0 *_0_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25199
+  timestamp: 1732610760700
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-18.1.0-py311h4854187_0_cpu.conda
+  sha256: db147a0cc22b55ea3c35553b39336eb0392c33371f6efd7f9fb4efed2b728e34
+  md5: 830a64ee7a65e588c7ea615be84db2e3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 18.1.0.* *cpu
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy >=1.21,<3
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4562010
+  timestamp: 1732610600424
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.10-hc5c86c4_3_cpython.conda
+  sha256: b7fa3bd48e3a3d30f65608e07759cefd27885c6388b3f612af85ce40282e6936
+  md5: 9e1ad55c87368e662177661a998feed5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 30543977
+  timestamp: 1729043512711
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
+  sha256: 2660b8059b3ee854bc5d3c6b1fce946e5bd2fe8fbca7827de2c5885ead6209de
+  md5: 139a8d40c8a2f430df31048949e450de
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6211
+  timestamp: 1723823324668
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h9ecbd09_1.conda
+  sha256: e721e5ff389a7b2135917c04b27391be3d3382e261bb60a369b1620655365c3d
+  md5: abeb54d40f439b86f75ea57045ab8496
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 212644
+  timestamp: 1725456264282
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py311h7deb3e3_3.conda
+  sha256: 3fdef7b3c43474b7225868776a373289a8fd92787ffdf8bed11cf7f39b4ac741
+  md5: e0897de1d8979a3bb20ef031ae1f7d28
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 389074
+  timestamp: 1728642373938
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+  sha256: 776363493bad83308ba30bcb88c2552632581b143e8ee25b1982c8c743e73abc
+  md5: 353823361b1d27eb3960efb076dfcaf6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-Qhull
+  size: 552937
+  timestamp: 1720813982144
+- conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h77b4e00_1.conda
+  sha256: c1721cb80f7201652fc9801f49c214c88aee835d957f2376e301bd40a8415742
+  md5: 01093ff37c1b5e6bf9f17c0116747d11
+  depends:
+  - libre2-11 2024.07.02 hbbce691_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26665
+  timestamp: 1728778975855
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+  sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
+  md5: 47d31b792659ce70f470b5c82fdfb7a4
+  depends:
+  - libgcc-ng >=12
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 281456
+  timestamp: 1679532220005
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.22.0-py311h9e33e62_0.conda
+  sha256: eb0776215fdc6405fde60520c2f17ddca9d971a13d91d6661192c0ccda4363d9
+  md5: 16366d652e4b14554c3f2eebfde6aed8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  size: 352425
+  timestamp: 1733232879970
+- conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.9-h0fd0ee4_0.conda
+  sha256: f2c8e55d6caa8d87a482b1f133963c184de1ccb2303b77cc8ca86c794253f151
+  md5: f472432f3753c5ca763d2497e2ea30bf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 355568
+  timestamp: 1731541963573
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py311he9a78e4_1.conda
+  sha256: 59482b974c36c375fdfd0bc3e5a3003ea2d2ae72b64b8f3deaeef5a851dbc91d
+  md5: 49ba89bf4d8a995efb99517d1c7aeb1e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=13
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17592106
+  timestamp: 1729481734425
+- conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
+  sha256: dc7c8e0e8c3e8702aae81c52d940bfaabe756953ee51b1f1757e891bab62cf7f
+  md5: 6b7dcc7349efd123d493d2dbe85a045f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42465
+  timestamp: 1720003704360
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+  sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
+  md5: d453b98d9c83e71da0741bb0ff4d76bc
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3318875
+  timestamp: 1699202167581
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.2-py311h9ecbd09_0.conda
+  sha256: afa3489113154b5cb0724b0bf120b62df91f426dabfe5d02f2ba09e90d346b28
+  md5: df3aee9c3e44489257a840b8354e77b9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 855653
+  timestamp: 1732616048886
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py311h9ecbd09_1.conda
+  sha256: 5f277c801ca392512de9aa497fd8be3e168950600c438778dfc4234943c474fc
+  md5: 00895577e2b4c24dca76675ab1862551
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 368413
+  timestamp: 1729704640193
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
+  sha256: 532a046fee0b3a402db867b6ec55c84ba4cdedb91d817147c8feeae9766be3d6
+  md5: 77cbc488235ebbaab2b6e912d3934bae
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 14679
+  timestamp: 1727034741045
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+  sha256: 6b250f3e59db07c2514057944a3ea2044d6a8cdde8a47b6497c254520fade1ee
+  md5: 8035c64cb77ed555e3f150b7b3972480
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 19901
+  timestamp: 1727794976192
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+  sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+  md5: 2161070d867d1b1204ea749c8eec4ef0
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1 and GPL-2.0
+  size: 418368
+  timestamp: 1660346797927
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+  sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
+  md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 89141
+  timestamp: 1641346969816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.18.0-py311h9ecbd09_0.conda
+  sha256: 6badcbdfa79e7d85898dadc3f3c8541aeb0328beaf52d8c324f9cfa03827e34b
+  md5: 6c53a0d074f60e75069133bfcdfdf76f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - idna >=2.0
+  - libgcc >=13
+  - multidict >=4.0
+  - propcache >=0.2.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 152353
+  timestamp: 1732220979792
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_7.conda
+  sha256: a4dc72c96848f764bb5a5176aa93dd1e9b9e52804137b99daeebba277b31ea10
+  md5: 3947a35e916fcc6b9825449affbf4214
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - libstdcxx >=13
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 335400
+  timestamp: 1731585026517
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py311hbc35293_1.conda
+  sha256: a5cf0eef1ffce0d710eb3dffcb07d9d5922d4f7a141abc96f6476b98600f718f
+  md5: aec590674ba365e50ae83aa2d6e1efae
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.11
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 417923
+  timestamp: 1725305669690
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+  sha256: c558b9cc01d9c1444031bd1ce4b9cff86f9085765f17627a6cd85fc623c8a02b
+  md5: 4d056880988120e29d75bfff282e0f45
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 554846
+  timestamp: 1714722996770
+- conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.4-pyhd8ed1ab_0.conda
+  sha256: 4282838f468f75f0c1746cbc6cdd3365b9f6d449bf5af8a74b234e396d847bf0
+  md5: 8d6f8a679aa0272ba8d6092ce4824870
+  depends:
+  - python >=3.9
+  license: PSF-2.0
+  license_family: PSF
+  size: 19310
+  timestamp: 1733135584059
+- conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 575c742e14c86575986dc867463582a970463da50b77264cdf54df74f5563783
+  md5: d1e1eb7e21a9e2c74279d87dafb68156
+  depends:
+  - frozenlist >=1.1.0
+  - python >=3.7
+  license: Apache-2.0
+  license_family: APACHE
+  size: 12730
+  timestamp: 1667935912504
+- conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+  sha256: 4b54b7ce79d818e3cce54ae4d552dba51b7afac160ceecdefd04b3917a37c502
+  md5: 688697ec5e9588bdded167d19577625b
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.9
+  - sniffio >=1.1
+  - typing_extensions >=4.1
+  constrains:
+  - uvloop >=0.21.0b1
+  - trio >=0.26.1
+  license: MIT
+  license_family: MIT
+  size: 109864
+  timestamp: 1728935803440
+- conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
+  sha256: 45ae2d41f4a4dcf8707633d3d7ae376fc62f0c09b1d063c3049c3f6f8c911670
+  md5: cc4834a9ee7cc49ce8d25177c47b10d8
+  depends:
+  - python >=3.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 10241
+  timestamp: 1707233195627
+- conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+  sha256: 130766446f5507bd44df957b6b5c898a8bd98f024bb426ed6cb9ff1ad67fc677
+  md5: 3afef1f55a1366b4d3b6a0d92e2235e4
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.7
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 18602
+  timestamp: 1692818472638
+- conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+  sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
+  md5: b77d8c2313158e6e461ca0efb1c2c508
+  depends:
+  - python >=3.8
+  - python-dateutil >=2.7.0
+  - types-python-dateutil >=2.8.10
+  license: Apache-2.0
+  license_family: Apache
+  size: 100096
+  timestamp: 1696129131844
+- conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
+  sha256: b3e9369529fe7d721b66f18680ff4b561e20dbf6507e209e1f60eac277c97560
+  md5: c0481c9de49f040272556e2cedf42816
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 6164
+  timestamp: 1531050741142
+- conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+  sha256: 93b14414b3b3ed91e286e1cbe4e7a60c4e1b1c730b0814d1e452a8ac4b9af593
+  md5: 8f587de4bcf981e26228f268df374a9b
+  depends:
+  - python >=3.9
+  constrains:
+  - astroid >=2,<4
+  license: Apache-2.0
+  license_family: Apache
+  size: 28206
+  timestamp: 1733250564754
+- conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+  sha256: 7ed83731979fe5b046c157730e50af0e24454468bbba1ed8fc1a3107db5d7518
+  md5: 3d081de3a6ea9f894bbb585e8e3a4dcb
+  depends:
+  - python >=3.8
+  - typing_extensions >=4.0.0
+  license: MIT
+  license_family: MIT
+  size: 15342
+  timestamp: 1690563152778
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+  sha256: 28dba85a7e0f7fb57d7315e13f603d1e41b83c5b88aa2a602596b52c833a2ff8
+  md5: 6732fa52eb8e66e5afeb32db8701a791
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 56048
+  timestamp: 1722977241383
+- conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_1.conda
+  sha256: f6205d3a62e87447e06e98d911559be0208d824976d77ab092796c9176611fcb
+  md5: 3e23f7db93ec14c80525257d8affac28
+  depends:
+  - python >=3.9
+  - pytz >=2015.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6551057
+  timestamp: 1733236466015
+- conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_1.conda
+  sha256: fca842ab7be052eea1037ebee17ac25cc79c626382dd2187b5c6e007b9d9f65f
+  md5: d48f7e9fdec44baf6d1da416fe402b04
+  depends:
+  - python >=3.9
+  - soupsieve >=1.2
+  license: MIT
+  license_family: MIT
+  size: 118042
+  timestamp: 1733230951790
+- conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
+  sha256: 01be7fb5163e7c31356a18c259ddc19a5431b8b974dc65e2427b88c2d30034f3
+  md5: 461bcfab8e65c166e297222ae919a2d4
+  depends:
+  - python >=3.9
+  - webencodings
+  license: Apache-2.0 AND MIT
+  license_family: Apache
+  size: 132652
+  timestamp: 1730286301829
+- conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.2-pyhd8ed1ab_0.conda
+  sha256: e8307f1ea9306a48c4d872f7499b4a5e6f4137c440b46554897d8c08ca2a743b
+  md5: b3335e258c6113c8a355c32dd91e954f
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.10
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4774564
+  timestamp: 1733256001780
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+  sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
+  md5: 9b347a7ec10940d3f7941ff6c460b551
+  depends:
+  - cached_property >=1.5.2,<1.5.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4134
+  timestamp: 1615209571450
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+  sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+  md5: 576d629e47797577ab0f1b351297ef4a
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11065
+  timestamp: 1615209567874
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+  sha256: 7020770df338c45ac6b560185956c32f0a5abf4b76179c037f115fc7d687819f
+  md5: 12f7d00853807b0531775e9be891cb11
+  depends:
+  - python >=3.7
+  license: ISC
+  size: 163752
+  timestamp: 1725278204397
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+  sha256: 63022ee2c6a157a9f980250a66f54bdcdf5abee817348d0f9a74c2441a6fbf0e
+  md5: 6581a17bba6b948bb60130026404a9d6
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 47533
+  timestamp: 1733218182393
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_1.conda
+  sha256: 1cd5fc6ccdd5141378e51252a7a3810b07fd5a7e6934a5b4a7eccba66566224b
+  md5: cb8e52f28f5e592598190c562e7b5bf1
+  depends:
+  - __unix
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84513
+  timestamp: 1733221925078
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_1.conda
+  sha256: 98eeb47687c0a3260c7ea1e29f41057b8e57481b834d3bf5902b7a62e194f88f
+  md5: e2afd3b7e37a5363e292a8b33dbef65c
+  depends:
+  - __win
+  - colorama
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 85069
+  timestamp: 1733222030187
+- conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+  sha256: 5a33d0d3ef33121c546eaf78b3dac2141fc4d30bbaeb3959bbc66fcd5e99ced6
+  md5: c88ca2bb7099167912e3b26463fff079
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25952
+  timestamp: 1729059365471
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
+  md5: 962b9857ee8e7018c22f2776ffa0b2d7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27011
+  timestamp: 1733218222191
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+  sha256: 79a6b4fff545e0b18f86ad93276a1797eb6ac3f7e1851e03f02d63b19655731b
+  md5: 4d155b600b63bc6ba89d91fab74238f8
+  depends:
+  - python >=3.7
+  license: CC-BY-4.0
+  size: 173517
+  timestamp: 1709713413736
+- conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+  sha256: e923acf02708a8a0b591f3bce4bdc11c8e63b73198b99b35fe6cd96bfb6a0dbe
+  md5: 948d84721b578d426294e17a02e24cbb
+  depends:
+  - python >=3.6
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12134
+  timestamp: 1710320435158
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.10-py311hd8ed1ab_3.conda
+  sha256: 3b2460b6cce53ce95f1f3aeb8ef7a50b356226dc48d45265ce5e585fc5e8cbed
+  md5: b6d1a583921c24bb45feef32262b10aa
+  depends:
+  - python 3.11.10.*
+  - python_abi * *_cp311
+  license: Python-2.0
+  size: 45741
+  timestamp: 1729041746101
+- conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+  sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
+  md5: 5cd86562580f274031ede6aa6aa24441
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13458
+  timestamp: 1696677888423
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.11.2-pyhff2d567_1.conda
+  sha256: 1f2c226bfb4e3ee24125185b0694ec73431ff95bc55d995abdb38b7a7e1838ca
+  md5: 4ea56955c9922ac99c35d0784cffeb96
+  depends:
+  - bokeh >=3.1.0
+  - cytoolz >=0.11.0
+  - dask-core >=2024.11.2,<2024.11.3.0a0
+  - dask-expr >=1.1,<1.2
+  - distributed >=2024.11.2,<2024.11.3.0a0
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.24
+  - pandas >=2.0
+  - pyarrow >=14.0.1
+  - python >=3.10
+  constrains:
+  - openssl !=1.1.1e
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7549
+  timestamp: 1731971053850
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.11.2-pyhff2d567_1.conda
+  sha256: b5e120fbcab57343aedbb312c22df8faa1a8444fb16b4d66879efbd7fd560d53
+  md5: ae2be36dab764e655a22f240837cef75
+  depends:
+  - click >=8.1
+  - cloudpickle >=3.0.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.4.0
+  - python >=3.10
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 903030
+  timestamp: 1731970891036
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.19-pyhd8ed1ab_0.conda
+  sha256: 5f2c9e8f49c016a249d07eb46bae5b4085f3750827d12aff8aa0db1be4665165
+  md5: 09ea33eb6525cc703ce1d39c88378320
+  depends:
+  - dask-core 2024.11.2
+  - pandas >=2
+  - pyarrow >=14.0.1
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 185913
+  timestamp: 1731515130979
+- conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+  sha256: 8f35e2d76173d300f5e5f504d67238097c16457267d421a8ab10d1e5bd9b734d
+  md5: 1316959270592fbf8e2278a336de3ab9
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy
+  - packaging
+  - pandas
+  - param
+  - pillow
+  - pyct
+  - python >=3.9
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17230062
+  timestamp: 1720435590279
+- conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+  sha256: 84e5120c97502a3785e8c3241c3bf51f64b4d445f13b4d2445db00d9816fe479
+  md5: d622d8d7ee8868870f9cbe259f381181
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14068
+  timestamp: 1733236549190
+- conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
+  md5: 961b3a227b437d82ad7054484cfa71b2
+  depends:
+  - python >=3.6
+  license: PSF-2.0
+  license_family: PSF
+  size: 24062
+  timestamp: 1615232388757
+- conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.11.2-pyhff2d567_1.conda
+  sha256: 67b4ef42db9f0fcfa2fb6274bd4ee530769bb84649cbb07da2b7d0a85f4cdfe2
+  md5: 171408408370e59126dc3e39352c6218
+  depends:
+  - click >=8.0
+  - cloudpickle >=3.0.0
+  - cytoolz >=0.11.2
+  - dask-core >=2024.11.2,<2024.11.3.0a0
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.2
+  - packaging >=20.0
+  - psutil >=5.8.0
+  - python >=3.10
+  - pyyaml >=5.4.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.11.2
+  - tornado >=6.2.0
+  - urllib3 >=1.26.5
+  - zict >=3.0.0
+  constrains:
+  - openssl !=1.1.1e
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 802347
+  timestamp: 1731970957315
+- conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
+  md5: 3cf04868fee0a029769bd41f4b2fbf2d
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 9199
+  timestamp: 1643888357950
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+  sha256: cbde2c64ec317118fc06b223c5fd87c8a680255e7348dd60e7b292d2e103e701
+  md5: a16662747cdeb9abbac74d0057cc976e
+  depends:
+  - python >=3.9
+  license: MIT and PSF-2.0
+  size: 20486
+  timestamp: 1733208916977
+- conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+  sha256: a52d7516e2e11d3eb10908e10d3eb3f8ef267fea99ed9b09d52d96c4db3441b8
+  md5: d0441db20c827c11721889a241df1220
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 28337
+  timestamp: 1725214501850
+- conda: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+  sha256: 42be6ac8478051b26751d778490d6a71de12e5c6443e145ff3eddbc577d9bcda
+  md5: 348e27e78a5e39090031448c72f66d5e
+  depends:
+  - python >=3.6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 19975
+  timestamp: 1643971626978
+- conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 6cfd1f9bcd2358a69fb571f4b3af049b630d52647d906822dbedac03e84e4f63
+  md5: 642d35437078749ef23a5dca2c9bb1f3
+  depends:
+  - cached-property >=1.3.0
+  - python >=2.7,<4
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 14395
+  timestamp: 1638810388635
+- conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+  sha256: 40bb76981dd49d5869b48925a8975bb7bbe4e33e1e40af4ec06f6bf4a62effd7
+  md5: 816dbc4679a64e4417cd1385d661bb31
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 134745
+  timestamp: 1729608972363
+- conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 817d2c77d53afe3f3d9cf7f6eb8745cdd8ea76c7adaa9d7ced75c455a2c2c085
+  md5: b21ed0883505ba1910994f1df031a428
+  depends:
+  - python >=3
+  - typing_extensions
+  license: MIT
+  license_family: MIT
+  size: 48251
+  timestamp: 1664132995560
+- conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+  sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
+  md5: b748fbf7060927a6e82df7cb5ee8f097
+  depends:
+  - hpack >=4.0,<5
+  - hyperframe >=6.0,<7
+  - python >=3.6.1
+  license: MIT
+  license_family: MIT
+  size: 46754
+  timestamp: 1634280590080
+- conda: https://conda.anaconda.org/conda-forge/noarch/holonote-0.2.1-pyhd8ed1ab_0.conda
+  sha256: 7f866a6590a1429ef931bafae66154745a68a5f189849152dd3a70f50bbcc125
+  md5: 5f67a58769a552a112e6c5146ef86ae4
+  depends:
+  - holoviews >=1.18.0
+  - pandas
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 45773
+  timestamp: 1726235911461
+- conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+  sha256: 369d234fb83fb37e0e8abe7a78981a533cec37053c5c15177ad6caade729118d
+  md5: a765e03fa67caf58525b08bbbd5b4f76
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.9
+  - pyviz_comms >=2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4037867
+  timestamp: 1730736003074
+- conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+  sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
+  md5: 914d6646c4dbb1fd3ff539830a12fd71
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 25341
+  timestamp: 1598856368685
+- conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+  sha256: c84d012a245171f3ed666a8bf9319580c269b7843ffa79f26468842da3abd5df
+  md5: 2ca8e6dbc86525c8b95e3c0ffa26442e
+  depends:
+  - python >=3.8
+  - h11 >=0.13,<0.15
+  - h2 >=3,<5
+  - sniffio 1.*
+  - anyio >=3.0,<5.0
+  - certifi
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48959
+  timestamp: 1731707562362
+- conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.0-pyhd8ed1ab_0.conda
+  sha256: cb7895446cd93091300accea6afbc8d9811a3c5899922ccfeeff97d9b55909dc
+  md5: 22878824a87f1af2ad48665f9d5bfcc8
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 63183
+  timestamp: 1732831049776
+- conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+  sha256: a0fb47776b6816990b94eab6e1a27025f643fa94646b845277d3aa8bce8fb2f1
+  md5: dbc57da07daee81a9cd76586217c7cbb
+  depends:
+  - bokeh >=3.1
+  - colorcet >=2
+  - holoviews >=1.19.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 246908
+  timestamp: 1729160766015
+- conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
+  md5: 9f765cbfab6870c8435b9eefecd7a1f4
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 14646
+  timestamp: 1619110249723
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+  sha256: d7a472c9fd479e2e8dcb83fb8d433fce971ea369d704ece380e876f9c3494e87
+  md5: 39a4f67be3286c86d696df570b1201b7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49765
+  timestamp: 1733211921194
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+  sha256: 13766b88fc5b23581530d3a0287c0c58ad82f60401afefab283bf158d2be55a9
+  md5: 315607a3030ad5d5227e76e0733798ff
+  depends:
+  - python >=3.9
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 28623
+  timestamp: 1733223207185
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
+  sha256: 461199e429a3db01f0a673f8beaac5e0be75b88895952fb9183f2ab01c5c3c24
+  md5: 15798fa69312d433af690c8c42b3fb36
+  depends:
+  - python >=3.9
+  - zipp >=3.1.0
+  constrains:
+  - importlib-resources >=6.4.5,<6.4.6.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 32701
+  timestamp: 1733231441973
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+  sha256: 33cfd339bb4efac56edf93474b37ddc049e08b1b4930cf036c893cc1f5a1f32a
+  md5: b40131ab6a36ac2c09b7c57d4d3fbf99
+  depends:
+  - __linux
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119084
+  timestamp: 1719845605084
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+  sha256: dc569094125127c0078aa536f78733f383dd7e09507277ef8bcd1789786e7086
+  md5: 18df5fc4944a679e085e0e8f31775fc8
+  depends:
+  - __win
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119853
+  timestamp: 1719845858082
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+  sha256: 072534d4d379225b2c3a4e38bc7730b65ae171ac7f0c2d401141043336e97980
+  md5: 9eb15d654daa0ef5a98802f586bb4ffc
+  depends:
+  - __osx
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119568
+  timestamp: 1719845667420
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
+  sha256: 65cdc105e5effea2943d3979cc1592590c923a589009b484d07672faaf047af1
+  md5: 5d6e5cb3a4b820f61b2073f0ad5431f1
+  depends:
+  - __unix
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.10
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 600248
+  timestamp: 1732897026255
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh7428d3b_0.conda
+  sha256: 94ee8215bd1f614c9c984437b184e8dbe61a4014eb5813c276e3dcb18aaa7f46
+  md5: 6cdaebbc9e3feb2811eb9f52ed0b89e1
+  depends:
+  - __win
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.10
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 600466
+  timestamp: 1732897444811
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_1.conda
+  sha256: 72fbbe8bc511f20268d347c1a06e279128237e096c4c174b2f9164a661c6b13e
+  md5: f8ed9f18dce81e4ee55c858cc2f8548a
+  depends:
+  - python >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28064
+  timestamp: 1716278507729
+- conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
+  md5: 4cb68948e0b8429534380243d063a27a
+  depends:
+  - arrow >=0.15.0
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 17189
+  timestamp: 1638811664194
+- conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhff2d567_0.conda
+  sha256: d37dad14c00d06d33bfb99c378d0abd7645224a9491c433af5028f24863341ab
+  md5: 11ead81b00e0f7cc901fceb7ccfb92c1
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.9
+  license: Apache-2.0 AND MIT
+  size: 842916
+  timestamp: 1731317305873
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+  sha256: 85a7169c078b8065bd9d121b0e7b99c8b88c42a411314b6ae5fcd81c48c4710a
+  md5: 08cce3151bde4ecad7885bd9fb647532
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110963
+  timestamp: 1733217424408
+- conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.10.0-pyhd8ed1ab_0.conda
+  sha256: df01c5253bb5f8c68526c8bad92b8e832ed58a0d4c40d08a65c81c51821bc23d
+  md5: 165cbd1d80be88dafadeabfaae6fa588
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 32030
+  timestamp: 1732666224221
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+  sha256: 7d0c4c0346b26be9f220682b7c5c0d84606d48c6dbc36fc238e4452dda733aff
+  md5: da304c192ad59975202859b367d0f6a2
+  depends:
+  - attrs >=22.2.0
+  - importlib_resources >=1.4.0
+  - jsonschema-specifications >=2023.03.6
+  - pkgutil-resolve-name >=1.3.10
+  - python >=3.8
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 74323
+  timestamp: 1720529611305
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+  sha256: 82f8bed0f21dc0b3aff40dd4e39d77e85b93b0417bc5659b001e0109341b8b98
+  md5: 720745920222587ef942acfbc578b584
+  depends:
+  - python >=3.8
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 16165
+  timestamp: 1728418976382
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+  sha256: 007a0a506a0d1805b099629cb0ee743ad0afe7d9749e57339f32c168119e0139
+  md5: 16b37612b3a2fd77f409329e213b530c
+  depends:
+  - fqdn
+  - idna
+  - isoduration
+  - jsonpointer >1.13
+  - jsonschema >=4.23.0,<4.23.1.0a0
+  - rfc3339-validator
+  - rfc3986-validator >0.1.0
+  - uri-template
+  - webcolors >=24.6.0
+  license: MIT
+  license_family: MIT
+  size: 7143
+  timestamp: 1720529619500
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+  sha256: 2151c2c63e0442a4c69ee0ad8a634195eedab10b7b74c0ec8266471842239a93
+  md5: 885867f6adab3d7ecdf8ab6ca0785f51
+  depends:
+  - importlib-metadata >=4.8.3
+  - jupyter_server >=1.1.2
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55539
+  timestamp: 1712707521811
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+  sha256: 38e67f3e0d631f4aeeab4bbd4062dcb6f4ae9dc35803053c995d02912a999b65
+  md5: 5cbf9a31a19d4ef9103adb7d71fd45fd
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.7
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99449
+  timestamp: 1673616104031
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+  sha256: 732b1e8536bc22a5a174baa79842d79db2f4956d90293dd82dc1b3f6099bcccd
+  md5: 0a2980dada0dd7fd0998f0342308b1b1
+  depends:
+  - __unix
+  - platformdirs >=2.5
+  - python >=3.8
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 57671
+  timestamp: 1727163547058
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh5737063_1.conda
+  sha256: 7c903b2d62414c3e8da1f78db21f45b98de387aae195f8ca959794113ba4b3fd
+  md5: 46d87d1c0ea5da0aae36f77fa406e20d
+  depends:
+  - __win
+  - cpython
+  - platformdirs >=2.5
+  - python >=3.8
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 58269
+  timestamp: 1727164026641
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+  sha256: cd3f41dc093162a41d4bae171e40a1b9b115c4d488e9bb837a8fa9d084931fb9
+  md5: ed45423c41b3da15ea1df39b1f80c2ca
+  depends:
+  - jsonschema-with-format-nongpl >=4.18.0
+  - python >=3.8
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21475
+  timestamp: 1710805759187
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+  sha256: edab71a05feceac54bdb90e755a257545af7832b9911607c1a70f09be44ba985
+  md5: ca23c71f70a7c7935b3d03f0f1a5801d
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert-core >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.8
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 323978
+  timestamp: 1720816754998
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+  sha256: 038efbc7e4b2e72d49ed193cfb2bbbe9fbab2459786ce9350301f466a32567db
+  md5: 219b3833aa8ed91d47d1be6ca03f30be
+  depends:
+  - python >=3.8
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19818
+  timestamp: 1710262791393
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.1-pyhff2d567_0.conda
+  sha256: ff1035eb0020dbaf4e332ef4b81a7068b595dfc57dde3313e9c4a37583772644
+  md5: b4f3d579fc21a44518d52c52507461b4
+  depends:
+  - async-lru >=1.0.0
+  - httpx >=0.25.0
+  - importlib-metadata >=4.8.3
+  - ipykernel >=6.5.0
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.27.1,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.9
+  - setuptools >=40.1.0
+  - tomli >=1.2.2
+  - tornado >=6.2.0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7101932
+  timestamp: 1731776859245
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+  sha256: 4aa622bbcf97e44cd1adf0100b7ff71b7e20268f043bdf6feae4d16152f1f242
+  md5: afcd1b53bcac8844540358e33f33d28f
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.7
+  constrains:
+  - jupyterlab >=4.0.8,<5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18776
+  timestamp: 1707149279640
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+  sha256: a23b26d1a35bccdb91b9232119e5f402624e1e1a252b0e64cc20c6eb5b87cefb
+  md5: af8239bf1ba7e8c69b689f780f653488
+  depends:
+  - babel >=2.10
+  - importlib-metadata >=4.8.3
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.8
+  - requests >=2.31
+  constrains:
+  - openapi-core >=0.18.0,<0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49355
+  timestamp: 1721163412436
+- conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+  sha256: aa99d44e8c83865026575a8af253141c53e0b3ab05f053befaa7757c8525064f
+  md5: f1b64ca4faf563605cf6f6ca93f9ff3f
+  depends:
+  - python >=3.7
+  - uc-micro-py
+  license: MIT
+  license_family: MIT
+  size: 24035
+  timestamp: 1707129321841
+- conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
+  md5: 91e27ef3d05cc772ce627e51cff111c4
+  depends:
+  - python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 8250
+  timestamp: 1650660473123
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+  sha256: fce1fde00359696983989699c00f9891194c4ebafea647a8d21b7e2e3329b56e
+  md5: 06e9bebf748a0dea03ecbe1f0e27e909
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78331
+  timestamp: 1710435316163
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+  sha256: 0fbacdfb31e55964152b24d5567e9a9996e1e7902fb08eb7d91b5fd6ce60803a
+  md5: fee3164ac23dfca50cfcc8b85ddefb81
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 64430
+  timestamp: 1733250550053
+- conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+  sha256: 7ea68676ea35fbb095420bbcc1c82c4767b8be7bb56abb6989b7f89d957a3bab
+  md5: 779345c95648be40d22aaa89de7d4254
+  depends:
+  - python >=3.6
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14599
+  timestamp: 1713250613726
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+  sha256: 5cedc99412278b37e9596f1f991d49f5a1663fe79767cf814a288134a1400ba9
+  md5: 5387f2cfa28f8a3afa3368bb4ba201e8
+  depends:
+  - markdown-it-py >=1.0.0,<4.0.0
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 42126
+  timestamp: 1725995333692
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+  sha256: 78c1bbe1723449c52b7a9df1af2ee5f005209f67e40b6e1d3c7619127c43b1c7
+  md5: 592132998493b3ff25fd7479396e8351
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 14465
+  timestamp: 1733255681319
+- conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_1.conda
+  sha256: 0a9faaf1692b74f321cedbd37a44f108a1ec3f5d9638bc5bbf860cb3b6ff6db4
+  md5: c46df05cae629e55426773ac1f85d68f
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65901
+  timestamp: 1733258822603
+- conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+  sha256: c6216a21154373b340c64f321f22fec51db4ee6156c2e642fa58368103ac5d09
+  md5: 121a57fce7fff0857ec70fa03200962f
+  depends:
+  - python >=3.6
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17254
+  timestamp: 1721907640382
+- conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+  sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
+  md5: 2ba8498c1018c1e9c61eb99b973dfe19
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12452
+  timestamp: 1600387789153
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_0.conda
+  sha256: da3330a8ffff1f5b15b558543fbec69e05a48750ed50b53369b93da788abedc5
+  md5: 6275b55edf34cfa1f01ba40b699dd915
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5493243
+  timestamp: 1716838925077
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+  sha256: 564e22c4048f2f00c7ee79417dea364f95cf069a1f2565dc26d5ece1fc3fd779
+  md5: 3ee79082e59a28e1db11e2a9c3bcd85a
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.8
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27878
+  timestamp: 1732882434219
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+  sha256: 074d858c5808e0a832acc0da37cd70de1565e8d6e17a62d5a11b3902b5e78319
+  md5: e2d2abb421c13456a9a9f80272fdf543
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<3.1
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.8
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - nbconvert =7.16.4=*_1
+  - pandoc >=2.9.2,<4.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189599
+  timestamp: 1718135529468
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+  sha256: 36fe73da4d37bc7ac2d1540526ecd294fbd09acda04e096181ab8f1ccd2b464c
+  md5: 0b57b5368ab7fc7cdc9e3511fa867214
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.8
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101232
+  timestamp: 1712239122969
+- conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+  sha256: 30db21d1f7e59b3408b831a7e0417b83b53ee6223afae56482c5f26da3ceb49a
+  md5: 6598c056f64dc8800d40add25e4e2c34
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11638
+  timestamp: 1705850780510
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+  sha256: e37db45223e432bcad809897177e05fff31828dfcfc3ef18f046ae44ec01286c
+  md5: f81a6fe643390df9347984644727d796
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert-core >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.7
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 308643
+  timestamp: 1715849037288
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+  sha256: 9b5fdef9ebe89222baa9da2796ebe7bc02ec6c5a1f61327b651d6b92cf9a0230
+  md5: 3d85618e2c97ab896b5b5e298d32b5b3
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16880
+  timestamp: 1707957948029
+- conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+  sha256: 5e238e5e646414d517a13f6786c7227206ace58271e3ef63f6adca4d6a4c2839
+  md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
+  depends:
+  - python >=3.6
+  - typing_utils
+  license: Apache-2.0
+  license_family: APACHE
+  size: 30232
+  timestamp: 1706394723472
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+  sha256: da157b19bcd398b9804c5c52fc000fcb8ab0525bdb9c70f95beaa0bb42f85af1
+  md5: 3bfed7e6228ebf2f7b9eaa47f1b4e2aa
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: APACHE
+  size: 60164
+  timestamp: 1733203368787
+- conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
+  md5: 457c2c8c08e54905d6954e79cb5b5db9
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11627
+  timestamp: 1631603397334
+- conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+  sha256: 5a05f572a610cada2fcccef8d555fddf2d01bef80da32411150735e6177d1eab
+  md5: 41c7413071c2bae37472214a3525e6bf
+  depends:
+  - bleach
+  - bokeh >=3.5.0,<3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.1.0,<3.0
+  - python >=3.10
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20670374
+  timestamp: 1731497809631
+- conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+  sha256: db644c81c1f47e1fa8134d5de935ec4269d765fbef8d44bd454eb187c7524472
+  md5: bd991333d5bc659bb82bfb5a5d4c1576
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 103339
+  timestamp: 1719325288387
+- conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+  sha256: bfe404eebb930cc41782d34f8fc04c0388ea692eeebe2c5fc28df8ec8d4d61ae
+  md5: 81534b420deb77da8833f2289b8d47ac
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 75191
+  timestamp: 1712320447201
+- conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+  sha256: 472fc587c63ec4f6eba0cc0b06008a6371e0a08a5986de3cf4e8024a47b4fe6c
+  md5: 0badf9c54e24cecfb0ad2f99d680c163
+  depends:
+  - locket
+  - python >=3.9
+  - toolz
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20884
+  timestamp: 1715026639309
+- conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+  sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
+  md5: 629f3203c99b32e0988910c93e77f3b6
+  depends:
+  - ptyprocess >=0.5
+  - python >=3.7
+  license: ISC
+  size: 53600
+  timestamp: 1706113273252
+- conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+  sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
+  md5: 415f0ebb6198cc2801c73438a9fb5761
+  depends:
+  - python >=3
+  license: MIT
+  license_family: MIT
+  size: 9332
+  timestamp: 1602536313357
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+  sha256: 499313e72e20225f84c2e9690bbaf5b952c8d7e0bf34b728278538f766b81628
+  md5: 5dd546fe99b44fda83963d15f84263b7
+  depends:
+  - python >=3.8,<3.13.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 1243168
+  timestamp: 1730203795600
+- conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+  sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
+  md5: 405678b942f2481cecdb3e010f4925d9
+  depends:
+  - python >=3.6
+  license: MIT AND PSF-2.0
+  size: 10778
+  timestamp: 1694617398467
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+  sha256: bb50f6499e8bc1d1a26f17716c97984671121608dc0c3ecd34858112bce59a27
+  md5: 577852c7e53901ddccc7e6a9959ddebe
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 20448
+  timestamp: 1733232756001
+- conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
+  sha256: 01f0c3dd00081637ed920a922b17bcc8ed49608404ee466ced806856e671f6b9
+  md5: 07e9550ddff45150bfc7da146268e165
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: Apache
+  size: 49024
+  timestamp: 1726902073034
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_0.conda
+  sha256: 44e4e6108d425a666856a52d1523e5d70890256a8920bb0dcd3d55cc750f3207
+  md5: 4c05134c48b6a74f33bbb9938e4a115e
+  depends:
+  - python >=3.7
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.48
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270271
+  timestamp: 1727341744544
+- conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+  sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+  md5: 359eeb6536da0e687af562ed265ec263
+  depends:
+  - python
+  license: ISC
+  size: 16546
+  timestamp: 1609419417991
+- conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+  sha256: dcfcb3cee1ae0a89729601582cc3edea20ba13c9493967a03a693c67567af0c8
+  md5: 0f051f09d992e0d08941706ad519ee0e
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 16551
+  timestamp: 1721585805256
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+  sha256: 79db7928d13fab2d892592223d7570f5061c192f27b9febd1a418427b719acc6
+  md5: 12c566707c80111f9799308d9e265aef
+  depends:
+  - python >=3.9
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110100
+  timestamp: 1733195786147
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+  sha256: 0e1e17a37d53be84c33b88218f10afb5f8137f19a727fdc56e45ae0b8b439a57
+  md5: 24c245c82396be3297c0aa26b69e18d8
+  depends:
+  - param >=1.7.0
+  - python >=3.7
+  - pyyaml
+  - requests
+  - setuptools >=61.0
+  constrains:
+  - pyct-core <0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20096
+  timestamp: 1701103924264
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+  sha256: 0d6133545f268b2b89c2617c196fc791f365b538d4057ecd636d658c3b1e885d
+  md5: b38dc0206e2a530e5c2cf11dc086b31a
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 876700
+  timestamp: 1733221731178
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_2.conda
+  sha256: 09a5484532e24a33649ab612674fd0857bbdcfd6640a79d13a6690fb742a36e1
+  md5: 4c05a2bcf87bb495512374143b57cf28
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 92319
+  timestamp: 1733222687746
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
+  sha256: d016e04b0e12063fbee4a2d5fbb9b39a8d191b5a0042f0b8459188aedeabb0ca
+  md5: e2fd202833c4a981ce8a65974fe4abd1
+  depends:
+  - __win
+  - python >=3.9
+  - win_inet_pton
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21784
+  timestamp: 1733217448189
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+  sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
+  md5: 461219d1a5bd61342293efa2c0c90eac
+  depends:
+  - __unix
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21085
+  timestamp: 1733217331982
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+  sha256: a50052536f1ef8516ed11a844f9413661829aa083304dc624c5925298d078d79
+  md5: 5ba79d7c71f03c678c8ead841f347d6e
+  depends:
+  - python >=3.9
+  - six >=1.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 222505
+  timestamp: 1733215763718
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+  sha256: 1b09a28093071c1874862422696429d0d35bd0b8420698003ac004746c5e82a2
+  md5: 38e34d2d1d9dca4fb2b9a0a04f604e2c
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 226259
+  timestamp: 1733236073335
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+  sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
+  md5: a61bf9ec79426938ff785eb69dbb1960
+  depends:
+  - python >=3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13383
+  timestamp: 1677079727691
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+  sha256: 57c9a02ec25926fb48edca59b9ede107823e5d5c473b94a0e05cc0b9a193a642
+  md5: c0def296b2f6d2dd7b030c2a7f66bb1f
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 142235
+  timestamp: 1733235414217
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+  sha256: 1a7d6b233f7e6e3bbcbad054c8fd51e690a67b129a899a056a5e45dd9f00cb41
+  md5: 3eeeeb9e4827ace8c0c1419c85d590ad
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 188538
+  timestamp: 1706886944988
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+  sha256: a7979e8e4936c430f5fe3d04fc2d67b42dab84fb4a502c4961a17dcb2327fec0
+  md5: 02b4e3a3014c1ac490ee4a4316f2d229
+  depends:
+  - param
+  - python >=3.6
+  constrains:
+  - jupyterlab >=4.0,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48061
+  timestamp: 1722535734510
+- conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+  sha256: be8d6d9e86b1a3fef5424127ff81782f8ca63d3058980859609f6f1ecdd34cb3
+  md5: 0fc8b52192a8898627c3efae1003e9f6
+  depends:
+  - attrs >=22.2.0
+  - python >=3.8
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 42210
+  timestamp: 1714619625532
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+  sha256: d701ca1136197aa121bbbe0e8c18db6b5c94acbd041c2b43c70e5ae104e1d8ad
+  md5: a9b9368f3701a417eac9edbcae7cb737
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 58723
+  timestamp: 1733217126197
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
+  md5: fed45fc5ea0813240707998abe49f520
+  depends:
+  - python >=3.5
+  - six
+  license: MIT
+  license_family: MIT
+  size: 8064
+  timestamp: 1638811838081
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+  sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
+  md5: 912a71cc01012ee38e6b90ddd561e36f
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 7818
+  timestamp: 1598024297745
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_0.conda
+  sha256: c4401b071e86ddfa0ea4f34b85308db2516b6aeca50053535996864cfdee7b3f
+  md5: 778594b20097b5a948c59e50ae42482a
+  depends:
+  - __linux
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22868
+  timestamp: 1712585140895
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
+  sha256: f911307db932c92510da6c3c15b461aef935720776643a1fbf3683f61001068b
+  md5: c3cb67fc72fb38020fe7923dbbcf69b0
+  depends:
+  - __osx
+  - pyobjc-framework-cocoa
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23165
+  timestamp: 1712585504123
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_0.conda
+  sha256: d8aa230501a33250af2deee03006a2579f0335e7240a9c7286834788dcdcfaa8
+  md5: 5a86a21050ca3831ec7f77fb302f1132
+  depends:
+  - __win
+  - python >=3.7
+  - pywin32
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23319
+  timestamp: 1712585816346
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+  sha256: abb12e1dd515b13660aacb5d0fd43835bc2186cab472df25b7716cd65e095111
+  md5: fc80f7995e396cbaeabd23cf46c413dc
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 774252
+  timestamp: 1732632769210
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyhd8ed1ab_1.conda
+  sha256: 761b96fe7bea080b9c35dd2f87f788eb94b61d462645bd16f361e80ae0ff017c
+  md5: a516da6cfe1ec0a55e49737f017b4965
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 16385
+  timestamp: 1733216901349
+- conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+  sha256: c2248418c310bdd1719b186796ae50a8a77ce555228b6acd32768e2543a15012
+  md5: bf7a226e58dfb8346c70df36065d86c9
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  size: 15019
+  timestamp: 1733244175724
+- conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
+  md5: 6d6552722448103793743dabfbda532d
+  depends:
+  - python >=2.7
+  license: Apache-2.0
+  license_family: APACHE
+  size: 26314
+  timestamp: 1621217159824
+- conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+  sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
+  md5: 3f144b2c34f8cb5a9abd9ed23a39c561
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 36754
+  timestamp: 1693929424267
+- conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+  sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
+  md5: e7df0fdd404616638df5ece6e69ba7af
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 26205
+  timestamp: 1669632203115
+- conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+  sha256: 2e2c255b6f24a6d75b9938cb184520e27db697db2c24f04e18342443ae847c0a
+  md5: 04eedddeb68ad39871c8127dd1c21f4f
+  depends:
+  - python >=3.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17386
+  timestamp: 1702066480361
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+  sha256: b300557c0382478cf661ddb520263508e4b3b5871b471410450ef2846e8c352c
+  md5: efba281bbdae5f6b0a1d53c6d4a97c93
+  depends:
+  - __linux
+  - ptyprocess
+  - python >=3.8
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22452
+  timestamp: 1710262728753
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+  sha256: 4daae56fc8da17784578fbdd064f17e3b3076b394730a14119e571707568dc8a
+  md5: 00b54981b923f5aefcd5e8547de056d5
+  depends:
+  - __osx
+  - ptyprocess
+  - python >=3.8
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22717
+  timestamp: 1710265922593
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
+  sha256: 8cb078291fd7882904e3de594d299c8de16dd3af7405787fce6919a385cfc238
+  md5: 4abd500577430a942a995fd0d09b76a2
+  depends:
+  - __win
+  - python >=3.8
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22883
+  timestamp: 1710262943966
+- conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+  sha256: cad582d6f978276522f84bd209a5ddac824742fe2d452af6acf900f8650a73a2
+  md5: f1acf5fdefa8300de697982bcb1761c9
+  depends:
+  - python >=3.5
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28285
+  timestamp: 1729802975370
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+  sha256: 18636339a79656962723077df9a56c0ac7b8a864329eb8f847ee3d38495b863e
+  md5: ac944244f1fed2eb49bae07193ae8215
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 19167
+  timestamp: 1733256819729
+- conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+  sha256: 6371cf3cf8292f2abdcc2bf783d6e70203d72f8ff0c1625f55a486711e276c75
+  md5: 34feccdd4177f2d3d53c73fc44fd9a37
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 52623
+  timestamp: 1728059623353
+- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+  sha256: 5673b7104350a6998cb86cccf1d0058217d86950e8d6c927d8530606028edb1d
+  md5: 4085c9db273a148e149c03627350e22c
+  depends:
+  - colorama
+  - python >=3.7
+  license: MPL-2.0 or MIT
+  size: 89484
+  timestamp: 1732497312317
+- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+  sha256: 8a64fa0f19022828513667c2c7176cfd125001f3f4b9bc00d33732e627dd2592
+  md5: 3df84416a021220d8b5700c613af2dc5
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110187
+  timestamp: 1713535244513
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
+  sha256: 8489af986daebfbcd13d3748ba55431259206e37f184ab42a57e107fecd85e02
+  md5: 3d326f8a2aa2d14d51d8c513426b5def
+  depends:
+  - python >=3.6
+  license: Apache-2.0 AND MIT
+  size: 21765
+  timestamp: 1727940339297
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+  sha256: c8e9c1c467b5f960b627d7adc1c65fece8e929a3de89967e91ef0f726422fd32
+  md5: b6a408c64b78ec7b779a3e5c7a902433
+  depends:
+  - typing_extensions 4.12.2 pyha770c72_1
+  license: PSF-2.0
+  license_family: PSF
+  size: 10075
+  timestamp: 1733188758872
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+  sha256: 337be7af5af8b2817f115b3b68870208b30c31d3439bec07bfb2d8f4823e3568
+  md5: d17f13df8b65464ca316cbc000a3cb64
+  depends:
+  - python >=3.9
+  license: PSF-2.0
+  license_family: PSF
+  size: 39637
+  timestamp: 1733188758212
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 9e3758b620397f56fb709f796969de436d63b7117897159619b87938e1f78739
+  md5: eb67e3cace64c66233e2d35949e20f92
+  depends:
+  - python >=3.6.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 13829
+  timestamp: 1622899345711
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+  sha256: 4fde5c3008bf5d2db82f2b50204464314cc3c91c1d953652f7bd01d9e52aefdf
+  md5: 8ac3367aafb1cc0a068483c580af8015
+  license: LicenseRef-Public-Domain
+  size: 122354
+  timestamp: 1728047496079
+- conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+  sha256: 54293cd94da3a6b978b353eb7897555055d925ad0008bc73e85cca19e2587ed0
+  md5: 3b7fc78d7be7b450952aaa916fb78877
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 11162
+  timestamp: 1707507514699
+- conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+  sha256: b76904b53721dc88a46352324c79d2b077c2f74a9f7208ad2c4249892669ae94
+  md5: 0944dc65cb4a9b5b68522c3bb585d41c
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 23999
+  timestamp: 1688655976471
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+  sha256: 416e30a1c3262275f01a3e22e783118d9e9d2872a739a9ed860d06fa9c7593d5
+  md5: 4a2d8ef7c37b8808c5b9b750501fffce
+  depends:
+  - brotli-python >=1.0.9
+  - h2 >=4,<5
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 98077
+  timestamp: 1733206968917
+- conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+  sha256: f21e63e8f7346f9074fd00ca3b079bd3d2fa4d71f1f89d5b6934bf31446dc2a5
+  md5: b68980f2495d096e71c7fd9d7ccf63e6
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 32581
+  timestamp: 1733231433877
+- conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
+  sha256: ec71f97c332a7d328ae038990b8090cbfa772f82845b5d2233defd167b7cc5ac
+  md5: eb48b812eb4fbb9ff238a6651fdbbcae
+  depends:
+  - python >=3.5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18378
+  timestamp: 1723294800217
+- conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+  sha256: 19ff205e138bb056a46f9e3839935a2e60bd1cf01c8241a5e172a422fed4f9c6
+  md5: 2841eb5bfc75ce15e9a0054b98dcd64d
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15496
+  timestamp: 1733236131358
+- conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+  sha256: 1dd84764424ffc82030c19ad70607e6f9e3b9cb8e633970766d697185652053e
+  md5: 84f8f77f0a9c6ef401ee96611745da8f
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 46718
+  timestamp: 1733157432924
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+  sha256: 1b34021e815ff89a4d902d879c3bd2040bc1bd6169b32e9427497fa05c55f1ce
+  md5: 75cb7132eb58d97896e173ef12ac9986
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 62931
+  timestamp: 1733130309598
+- conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+  sha256: 93807369ab91f230cf9e6e2a237eaa812492fe00face5b38068735858fba954f
+  md5: 46e441ba871f524e2b067929da3051c2
+  depends:
+  - __win
+  - python >=3.9
+  license: LicenseRef-Public-Domain
+  size: 9555
+  timestamp: 1733130678956
+- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.11.0-pyhd8ed1ab_0.conda
+  sha256: 1312af7bc507afdcf24df1599d6aa062ceb252d4c086d5b8e5a022bf8051d980
+  md5: 7358eeedbffd742549d372e0066999d3
+  depends:
+  - numpy >=1.24
+  - packaging >=23.2
+  - pandas >=2.1
+  - python >=3.10
+  constrains:
+  - cartopy >=0.22
+  - h5py >=3.8
+  - h5netcdf >=1.3
+  - sparse >=0.14
+  - dask-core >=2023.11
+  - cftime >=1.6
+  - bottleneck >=1.3
+  - netcdf4 >=1.6.0
+  - iris >=3.7
+  - zarr >=2.16
+  - seaborn-base >=0.13
+  - distributed >=2023.11
+  - matplotlib-base >=3.8
+  - nc-time-axis >=1.4
+  - scipy >=1.11
+  - toolz >=0.12
+  - flox >=0.7
+  - numba >=0.57
+  - pint >=0.22
+  - hdf5 >=1.12
+  license: Apache-2.0
+  license_family: APACHE
+  size: 826310
+  timestamp: 1732532972254
+- conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_1.conda
+  sha256: 5f8757092fc985d7586f2659505ec28757c05fd65d8d6ae549a5cec7e3376977
+  md5: c79cea50b258f652010cb6c8d81591b5
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 46860
+  timestamp: 1733143536777
+- conda: https://conda.anaconda.org/conda-forge/noarch/zarr-2.18.3-pyhd8ed1ab_1.conda
+  sha256: 02c045d3ab97bd5a713b0f35b05f017603d33bd728694ce3cf843c45c2906535
+  md5: 3e9a0fee25417c432c4780b9597fc312
+  depends:
+  - asciitree
+  - fasteners
+  - numcodecs >=0.10.0,<0.16.0a0
+  - numpy >=1.24,<3.0
+  - python >=3.10
+  constrains:
+  - notebook
+  - ipytree >=0.2.2
+  - ipywidgets >=8.0.0
+  license: MIT
+  license_family: MIT
+  size: 160013
+  timestamp: 1733237313723
+- conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+  sha256: 3d65c081514569ab3642ba7e6c2a6b4615778b596db6b1c82ee30a2d912539e5
+  md5: cf30c2c15b82aacb07f9c09e28ff2275
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36325
+  timestamp: 1681770298596
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+  sha256: 567c04f124525c97a096b65769834b7acb047db24b15a56888a322bf3966c3e1
+  md5: 0c3cc595284c5e8f0f9900a9b228a332
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 21809
+  timestamp: 1732827613585
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.11.9-py311ha3cf9ac_0.conda
+  sha256: 8f27d49937ef1d66cd894a9e00f4326722376750fef791154c002bdb9789a729
+  md5: ec60f95c2c05327235e9c7957bb5a3a9
+  depends:
+  - __osx >=10.13
+  - aiohappyeyeballs >=2.3.0
+  - aiosignal >=1.1.2
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - multidict >=4.5,<7.0
+  - propcache >=0.2.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yarl >=1.17.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  size: 877431
+  timestamp: 1733124993817
+- conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h3336109_5.conda
+  sha256: fa5eb633b320e10fc2138f3d842d8a8ca72815f106acbab49a68ec9783e4d70d
+  md5: 29b46bd410067f668c4cef7fdc78fe25
+  depends:
+  - __osx >=10.13
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 32275
+  timestamp: 1725356815696
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.8.0-hb1b2711_10.conda
+  sha256: 88731bee2b93e8bf5e6c0a692da9a28ac017de16880e72d6a26d4f48377a69ae
+  md5: cabb2823d1eaa138c1fa5ea3b68b9f8a
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94585
+  timestamp: 1731733610867
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.8.0-h1c3498a_2.conda
+  sha256: fa5cf06e1553198ef41d6aae29bfdf990053db185c492c27b116b2c91137e8c0
+  md5: b900b8d8f2d51c1b84ad1c8a1366c1e3
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 39373
+  timestamp: 1731678700352
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.10.3-h6e16a3a_0.conda
+  sha256: b31603e305c9a7b9f7dca010471ac2012a4c570da483737ec090db4812674fe8
+  md5: d1b72435b57b79fb97ba3ab6564db34c
+  depends:
+  - __osx >=10.13
+  license: Apache-2.0
+  license_family: Apache
+  size: 227079
+  timestamp: 1731567405398
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.3.0-h1c3498a_2.conda
+  sha256: 7cbb8cf79428c342518b2ba456361f89e48ec5ae6a974b2bb3bd8ceb84778c5c
+  md5: af56ad879a463b520989ddd774aa7695
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18023
+  timestamp: 1731678883009
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.5.0-heedde58_7.conda
+  sha256: 5fe9a5cc297d8c54536d7958738db35ae7ef561ad02494692b03c5c2b41f896e
+  md5: b1fa857b39304646770e3f0d70182ed3
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 46953
+  timestamp: 1731714670991
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.9.1-h0c96e2d_2.conda
+  sha256: dab3bc124acb36fd89839337b37fac40fcf47798a66934aa18e280a889646e8e
+  md5: e0596752aa1c4f748c88bce167ae003d
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-compression >=0.3.0,<0.3.1.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 164320
+  timestamp: 1731714564875
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.15.2-h789f5c1_2.conda
+  sha256: 57775bb51fbb45405575548d7452fc7702affac744fd6b80aebc82a28f5e2cba
+  md5: f85932994b14737e4ec6b6dc0bb66036
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 139362
+  timestamp: 1731702578455
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.11.0-h00ab244_8.conda
+  sha256: 5ba0cd019a01ca553784d18f6e4cc60a481eb88410ca689b6adbc1915cb85b89
+  md5: 0c2db3585e4c1865cdf4528720bab440
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 164288
+  timestamp: 1731734750092
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.7.3-h704940e_0.conda
+  sha256: 637c331a952139f505eea6792672562348dfc5160312b15561ccec6952cba7d4
+  md5: bae8175fd5c4e6dcc2eea2dccf3b77ba
+  depends:
+  - __osx >=10.13
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 98417
+  timestamp: 1733098790016
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.2.1-h1c3498a_1.conda
+  sha256: 59f47c5bea2ddc1c502999e6b2a4ebb81be7ddbf9d2b5818ff1cdc5ad58aa03d
+  md5: 70cd54aaaddb6efa4e5d41fa8f045a44
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51034
+  timestamp: 1731687124981
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.2.2-h1c3498a_1.conda
+  sha256: a52b53437bd274eeee1bdd1427686b2d3b4bed586a91f0ea5a4c45303805cd56
+  md5: a13de34c0c2224a8755ef3854f85c2a8
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 70940
+  timestamp: 1731687320283
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.29.6-he19e5b3_1.conda
+  sha256: 634531d5382dcf04bea027c2f3c53987012fcf96a5fb390af82cfd283e6a6ba5
+  md5: 66fd8bfe35b5542963261528f58123fe
+  depends:
+  - __osx >=10.13
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-mqtt >=0.11.0,<0.11.1.0a0
+  - aws-c-s3 >=0.7.3,<0.7.4.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 297150
+  timestamp: 1733150961814
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.449-he3c0133_4.conda
+  sha256: 17ab2acfbb32d82a4ebecf706c28ccb5b61329d5f95d2f9cb11459810b807f70
+  md5: 93a4b306f61300dac213d4433d34974c
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2784788
+  timestamp: 1732812562314
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.14.0-h9a36307_0.conda
+  sha256: c7694fc16b9aebeb6ee5e4f80019b477a181d961a3e4d9b6a66b77777eb754fe
+  md5: 1082a031824b12a2be731d600cfa5ccb
+  depends:
+  - __osx >=10.13
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 303166
+  timestamp: 1728053999891
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.10.0-ha4e2ba9_0.conda
+  sha256: b9899b9698a6c7353fc5078c449105aae58635d217befbc8ca9d5a527198019b
+  md5: ad56b6a4b8931d37a2cf5bc724a46f01
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 175344
+  timestamp: 1728487066445
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.13.0-h3d2f5f1_1.conda
+  sha256: 31984e52450230d04ca98d5232dbe256e5ef6e32b15d46124135c6e64790010d
+  md5: 3df4fb5d6d0e7b3fb28e071aff23787e
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 445040
+  timestamp: 1728578180436
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.8.0-h1ccc5ac_1.conda
+  sha256: 51fb67d2991d105b8f7b97b4810cd63bac4dc421a4a9c83c15a98ca520a42e1e
+  md5: 5b3e79eb148d6e30d6c697788bad9960
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - libxml2 >=2.12.7,<2.14.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 126229
+  timestamp: 1728563580392
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-files-datalake-cpp-12.12.0-h86941f0_1.conda
+  sha256: 12d95251a8793ea2e78f494e69353a930e9ea06bbaaaa4ccb6e5b3e35ee0744f
+  md5: 60452336e7f61f6fdaaff69264ee112e
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 200991
+  timestamp: 1728729588371
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h00291cd_2.conda
+  sha256: 624954bc08b3d7885a58c7d547282cfb9a201ce79b748b358f801de53e20f523
+  md5: 2db0c38a7f2321c5bdaf32b181e832c7
+  depends:
+  - __osx >=10.13
+  - brotli-bin 1.1.0 h00291cd_2
+  - libbrotlidec 1.1.0 h00291cd_2
+  - libbrotlienc 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 19450
+  timestamp: 1725267851605
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h00291cd_2.conda
+  sha256: 642a8492491109fd8270c1e2c33b18126712df0cedb94aaa2b1c6b02505a4bfa
+  md5: 049933ecbf552479a12c7917f0a4ce59
+  depends:
+  - __osx >=10.13
+  - libbrotlidec 1.1.0 h00291cd_2
+  - libbrotlienc 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 16643
+  timestamp: 1725267837325
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hd89902b_2.conda
+  sha256: 004cefbd18f581636a8dcb1964fb73478f15d496769226ec896c1d4a0161b7d8
+  md5: d75f06ee06001794aa83a05e885f1520
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 363793
+  timestamp: 1725267947069
+- conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+  sha256: cad153608b81fb24fc8c509357daa9ae4e49dfc535b2cb49b91e23dbd68fc3c5
+  md5: 7ed4301d437b59045be7e051a0308211
+  depends:
+  - __osx >=10.13
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 134188
+  timestamp: 1720974491916
+- conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.3-hf13058a_1.conda
+  sha256: 37c031f91bb4c7ebec248e283c453b24840764fb53b640768780dcd904093f17
+  md5: 7d8083876d71fe1316fc18369ee0dc58
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 184403
+  timestamp: 1732447223773
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.8.30-h8857fd0_0.conda
+  sha256: 593f302d0f44c2c771e1614ee6d56fffdc7d616e6f187669c8b0e34ffce3e1ae
+  md5: b7e5424e7f06547a903d28e4651dbb21
+  license: ISC
+  size: 158665
+  timestamp: 1725019059295
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.1-py311h137bacd_0.conda
+  sha256: 012ee7b1ed4f9b0490d6e90c72decf148d7575173c7eaf851cd87fd434d2cacc
+  md5: a4b0f531064fa3dd5e3afbb782ea2cd5
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 288762
+  timestamp: 1725560945833
+- conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.1-py311h4e34fa0_0.conda
+  sha256: 373e17f22bca3e13aac2245bb0c8a15c4a54d1ffa4c3278308eeb8d3c9435c0e
+  md5: 6bc3882064e277827934e2c6e5281661
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 255123
+  timestamp: 1731428577146
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.0.0-py311h3336109_1.conda
+  sha256: fd921e8aa9ec5d26b2aebaef91dd4bc1e6d4fd2114f2fc566578122ff95cdb3c
+  md5: d7a579f4ad0ad76e49fb62151ad6fd6f
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 344088
+  timestamp: 1728335202437
+- conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.9-py311hc356e98_0.conda
+  sha256: 12b1bcdbc226966ad328fbfc48c605e82e7f8e28f58905611a4789cbcc33a41d
+  md5: fb00506b224d15fdc3851a8c9985d4e1
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2499942
+  timestamp: 1732237016874
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.55.1-py311ha3cf9ac_0.conda
+  sha256: 65f05b0cabfa14486baef6f267ecea2c2fed56725cabe3767406c38349946000
+  md5: d482e362ac39ce9d0747e8f12968d3b8
+  depends:
+  - __osx >=10.13
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2835530
+  timestamp: 1733242278548
+- conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+  sha256: b292cf5a25f094eeb4b66e37d99a97894aafd04a5683980852a8cbddccdc8e4e
+  md5: 25152fce119320c980e5470e64834b50
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 599300
+  timestamp: 1694616137838
+- conda: https://conda.anaconda.org/conda-forge/osx-64/frozenlist-1.5.0-py311h1314207_0.conda
+  sha256: 36e430566ea33d33d4b6092e74b75a52d40bc15ea53534f3fad4f3fb971cf021
+  md5: 00c859c1395300f2679bc81e055f3dae
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 53479
+  timestamp: 1729699615503
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hac325c4_1005.conda
+  sha256: c0bea66f71a6f4baa8d4f0248e17f65033d558d9e882c0af571b38bcca3e4b46
+  md5: a26de8814083a6971f14f9c8c3cb36c2
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84946
+  timestamp: 1726600054963
+- conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h2790a97_0.conda
+  sha256: dd56547db8625eb5c91bb0a9fbe8bd6f5c7fbf5b6059d46365e94472c46b24f9
+  md5: 06cf91665775b0da395229cd4331b27d
+  depends:
+  - __osx >=10.13
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 117017
+  timestamp: 1718284325443
+- conda: https://conda.anaconda.org/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
+  sha256: 2e64307532f482a0929412976c8450c719d558ba20c0962832132fd0d07ba7a7
+  md5: d68d48a3060eb5abdc1cdc8e2a3a5966
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 11761697
+  timestamp: 1720853679409
+- conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_1.conda
+  sha256: 2499e5ebb3efa4186d6922122224d16bac791a5c0adad5b48b2bcd1e1e2afc8d
+  md5: b6c1710105dad14d47001a339cd14da6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17727
+  timestamp: 1725302991176
+- conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.7-py311hf2f7c97_0.conda
+  sha256: 00b477bff9138ca51edd94f7b31ce9fe2cd13a1dc8768abcf037a22eccf26940
+  md5: 24b0e3e3444be9fabcc8457c409e297f
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 60398
+  timestamp: 1725459431458
+- conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+  sha256: 83b52685a4ce542772f0892a0f05764ac69d57187975579a0835ff255ae3ef9c
+  md5: d4765c524b1d91567886bde656fb514b
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1185323
+  timestamp: 1719463492984
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
+  sha256: 222ebc0a55544b9922f61e75015d02861e65b48f12113af41d48ba0814e14e4e
+  md5: 1442db8f03517834843666c422238c9b
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 224432
+  timestamp: 1701648089496
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+  sha256: e41790fc0f4089726369b3c7f813117bbc14b533e0ed8b94cf75aba252e82497
+  md5: f9d6a4c82889d5ecedec1d90eb673c55
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 290319
+  timestamp: 1657977526749
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240722.0-cxx17_hac325c4_1.conda
+  sha256: b548e80280242ad1d93d8d7fb48a30af7e4124959ba2031c65c9675b98163652
+  md5: 40373920232a6ac0404eee9cf39a9f09
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  constrains:
+  - abseil-cpp =20240722.0
+  - libabseil-static =20240722.0=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1170354
+  timestamp: 1727295597292
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-18.1.0-h14b790f_2_cpu.conda
+  sha256: 76e55b03da834e0f52f3c98d688fe09c80de54e86d73353c0f1f3ea41f038c52
+  md5: 28163b6ae1cadbfefa19a86bce1ea860
+  depends:
+  - __osx >=10.13
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - aws-sdk-cpp >=1.11.449,<1.11.450.0a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-identity-cpp >=1.10.0,<1.10.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-files-datalake-cpp >=12.12.0,<12.12.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=18
+  - libgoogle-cloud >=2.31.0,<2.32.0a0
+  - libgoogle-cloud-storage >=2.31.0,<2.32.0a0
+  - libre2-11 >=2024.7.2
+  - libutf8proc >=2.9.0,<2.10.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.3,<2.0.4.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - arrow-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  - parquet-cpp <0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 6143357
+  timestamp: 1732948790584
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-18.1.0-he5ac762_2_cpu.conda
+  sha256: 88d352e07507dc21f2dc55e073f1a98199fff1af8ab6a266182f8c369e3cf5df
+  md5: 6fdd737c49d4ab4c96228e5f1af507d7
+  depends:
+  - __osx >=10.13
+  - libarrow 18.1.0 h14b790f_2_cpu
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: APACHE
+  size: 522755
+  timestamp: 1732949132535
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-18.1.0-he5ac762_2_cpu.conda
+  sha256: 1bcdf49f9344de5c23165ca2e0ec0948e084b58ded41f8f9c9228809feea0a35
+  md5: fd9e6210ddd2541de392716ff89f4cc2
+  depends:
+  - __osx >=10.13
+  - libarrow 18.1.0 h14b790f_2_cpu
+  - libarrow-acero 18.1.0 he5ac762_2_cpu
+  - libcxx >=18
+  - libparquet 18.1.0 h436316b_2_cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 514877
+  timestamp: 1732951748681
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-18.1.0-h16335c3_2_cpu.conda
+  sha256: d304956dfc4304494f89175854069273776a0345c41b6aceaf991552f0b7c75f
+  md5: eb34cb397b31b3318503c8907101955d
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 18.1.0 h14b790f_2_cpu
+  - libarrow-acero 18.1.0 he5ac762_2_cpu
+  - libarrow-dataset 18.1.0 he5ac762_2_cpu
+  - libcxx >=18
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 465386
+  timestamp: 1732952465558
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-25_osx64_openblas.conda
+  sha256: 1b22b5322a311a775bca637b26317645cf07e35f125cede9278c6c45db6e7105
+  md5: da0a6f87958893e1d2e2bbc7e7a6541f
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - liblapack 3.9.0 25_osx64_openblas
+  - liblapacke 3.9.0 25_osx64_openblas
+  - blas * openblas
+  - libcblas 3.9.0 25_osx64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15952
+  timestamp: 1729643159199
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h00291cd_2.conda
+  sha256: b377056470a9fb4a100aa3c51b3581aab6496ba84d21cd99bcc1d5ef0359b1b6
+  md5: 58f2c4bdd56c46cc7451596e4ae68e0b
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 67267
+  timestamp: 1725267768667
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h00291cd_2.conda
+  sha256: 4d49ea72e2f44d2d7a8be5472e4bd0bc2c6b89c55569de2c43576363a0685c0c
+  md5: 34709a1f5df44e054c4a12ab536c5459
+  depends:
+  - __osx >=10.13
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 29872
+  timestamp: 1725267807289
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h00291cd_2.conda
+  sha256: 477d236d389473413a1ccd2bec1b66b2f1d2d7d1b4a57bb56421b7b611a56cd1
+  md5: 691f0dcb36f1ae67f5c489f20ae987ea
+  depends:
+  - __osx >=10.13
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 296353
+  timestamp: 1725267822076
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-25_osx64_openblas.conda
+  sha256: b04ae297aa5396df3135514866db72845b111c92524570f923625473f11cfbe2
+  md5: ab304b75ea67f850cf7adf9156e3f62f
+  depends:
+  - libblas 3.9.0 25_osx64_openblas
+  constrains:
+  - liblapack 3.9.0 25_osx64_openblas
+  - liblapacke 3.9.0 25_osx64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15842
+  timestamp: 1729643166929
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+  sha256: 3043869ac1ee84554f177695e92f2f3c2c507b260edad38a0bf3981fce1632ff
+  md5: 23d6d5a69918a438355d7cbc4c3d54c9
+  depends:
+  - libcxx >=11.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20128
+  timestamp: 1633683906221
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.10.1-h58e7537_0.conda
+  sha256: 662fe145459ed58dee882e525588d1da4dcc4cbd10cfca0725d1fc3840461798
+  md5: 6c8669d8228a2bbd0283911cc6d6726e
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 402588
+  timestamp: 1726660264675
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.4-hf95d169_0.conda
+  sha256: 48c6d0ab9dd0c66693f79f4a032cd9ebb64fb88329dfa747aeac5299f9b3f33b
+  md5: 5f23923c08151687ff2fc3002b0a7234
+  depends:
+  - __osx >=10.13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 529010
+  timestamp: 1732060320836
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.22-h00291cd_0.conda
+  sha256: 681035346974c3315685dc40898e26f65f1c00cbb0b5fd80cc2599e207a34b31
+  md5: a15785ccc62ae2a8febd299424081efb
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 70407
+  timestamp: 1728177128525
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+  sha256: dbd3c3f2eca1d21c52e4c03b21930bbce414c4592f8ce805801575b9e9256095
+  md5: 6016a8a1d0e63cac3de2c352cd40208b
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 105382
+  timestamp: 1597616576726
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+  sha256: 0d238488564a7992942aa165ff994eca540f687753b4f0998b29b4e4d030ff43
+  md5: 899db79329439820b7e8f8de41bca902
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 106663
+  timestamp: 1702146352558
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+  sha256: e0bd9af2a29f8dd74309c0ae4f17a7c2b8c4b89f875ff1d6540c941eefbd07fb
+  md5: e38e467e577bd193a7d5de7c2c540b04
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372661
+  timestamp: 1685726378869
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.4-h240833e_0.conda
+  sha256: d10f43d0c5df6c8cf55259bce0fe14d2377eed625956cddce06f58827d288c59
+  md5: 20307f4049a735a78a29073be1be2626
+  depends:
+  - __osx >=10.13
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 70758
+  timestamp: 1730967204736
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+  sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
+  md5: ccb34fb14960ad8b125962d3d79b31a9
+  license: MIT
+  license_family: MIT
+  size: 51348
+  timestamp: 1636488394370
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+  sha256: 4874422e567b68334705c135c17e5acdca1404de8255673ce30ad3510e00be0d
+  md5: 0b6e23a012ee7a9a5f6b244f5a92c1d5
+  depends:
+  - libgfortran5 13.2.0 h2873a65_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110106
+  timestamp: 1707328956438
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+  sha256: da3db4b947e30aec7596a3ef92200d17e774cccbbf7efc47802529a4ca5ca31b
+  md5: e4fb4d23ec2870ff3c40d10afe305aec
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1571379
+  timestamp: 1707328880361
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.31.0-hd00c612_0.conda
+  sha256: 10df0003243d2ef5cca614351fa24efe42164912d358378a947c06167eba6b45
+  md5: 65d85eb999d66f8be20d3735a9ceaa7f
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - openssl >=3.3.2,<4.0a0
+  constrains:
+  - libgoogle-cloud 2.31.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 890808
+  timestamp: 1731121937109
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.31.0-h3f2b517_0.conda
+  sha256: e1f53309fe02143e1342ccb658466be015a1ee4249d306eed4158d75f680d992
+  md5: 3f8c6c99af88f5039869c24aea7024a6
+  depends:
+  - __osx >=10.13
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libcxx >=18
+  - libgoogle-cloud 2.31.0 hd00c612_0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  size: 541478
+  timestamp: 1731123018190
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.67.1-he6e0b18_0.conda
+  sha256: 0884aaa894617fac40c0e0d03a03d2ea6ea486fe9692a0ff854cbe4b080e4c6a
+  md5: 05ea1754e8da5d0e8faf9ec599505834
+  depends:
+  - __osx >=10.13
+  - c-ares >=1.34.2,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libre2-11 >=2024.7.2
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.67.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5335099
+  timestamp: 1730235623016
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
+  sha256: 23d4923baeca359423a7347c2ed7aaf48c68603df0cf8b87cc94a10b0d4e9a23
+  md5: 6c3628d047e151efba7cf08c5e54d1ca
+  license: LGPL-2.1-only
+  size: 666538
+  timestamp: 1702682713201
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+  sha256: d9572fd1024adc374aae7c247d0f29fdf4b122f1e3586fe62acc18067f40d02f
+  md5: 72507f8e3961bc968af17435060b6dd6
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 579748
+  timestamp: 1694475265912
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-25_osx64_openblas.conda
+  sha256: 2a9a6143d103e7e21511cbf439521645bdd506bfabfcac9d6398dd0562c6905c
+  md5: dda0e24b4605ebbd381e48606a107bed
+  depends:
+  - libblas 3.9.0 25_osx64_openblas
+  constrains:
+  - liblapacke 3.9.0 25_osx64_openblas
+  - blas * openblas
+  - libcblas 3.9.0 25_osx64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15852
+  timestamp: 1729643174413
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-hc8e404f_4.conda
+  sha256: 0df3902a300cfe092425f86144d5e00ef67be3cd1cc89fd63084d45262a772ad
+  md5: ed06753e2ba7c66ed0ca7f19578fcb68
+  depends:
+  - libcxx >=15
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 22467131
+  timestamp: 1690563140552
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.64.0-hc7306c3_0.conda
+  sha256: 0dcfdcf3a445d2d7de4f3b186ab0a794dc872f4ea21622f9b997be72712c027f
+  md5: ab21007194b97beade22ceb7a3f6fee5
+  depends:
+  - __osx >=10.13
+  - c-ares >=1.34.2,<2.0a0
+  - libcxx >=17
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 606663
+  timestamp: 1729572019083
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_hbf64a52_1.conda
+  sha256: cef5856952688ce9303f85f5bc62c99e8c2256b4c679f63afdfb381f222e90c7
+  md5: cd2c572c02a73b88c4d378eb31110e85
+  depends:
+  - __osx >=10.13
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - llvm-openmp >=18.1.8
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6165715
+  timestamp: 1730773348340
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-18.1.0-h436316b_2_cpu.conda
+  sha256: a882916a5b49f2be5e4efacd8158e58814ff4dc3ed4d06e12e9ce6264deee47b
+  md5: d2e2fc66fb64473c6ec878422d777f47
+  depends:
+  - __osx >=10.13
+  - libarrow 18.1.0 h14b790f_2_cpu
+  - libcxx >=18
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 940937
+  timestamp: 1732951273222
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.44-h4b8f8c9_0.conda
+  sha256: 12b44e58f8832798d7a5c0a7480c95e905dbd6c3558dec09739062411f9e08d1
+  md5: f32ac2c8dd390dbf169f550887ed09d9
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 268073
+  timestamp: 1726234803010
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-5.28.2-h8b30cf6_0.conda
+  sha256: e240c2003e301ede0a0f4af7688adb8456559ffaa4af2eed3fce879c22c80a0e
+  md5: 2302089e5bcb04ce891ce765c963befb
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2428926
+  timestamp: 1728565541606
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2024.07.02-hd530cb8_1.conda
+  sha256: 2fac39fb704ded9584d1a9e7511163830016803f83852a724c2ccef1cc16e17b
+  md5: 1e14c67a5e8a9273a98b83fbc0905b99
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 178580
+  timestamp: 1728779037721
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
+  sha256: d3975cfe60e81072666da8c76b993af018cf2e73fe55acba2b5ba0928efaccf5
+  md5: 6af4b059e26492da6013e79cbcb4d069
+  depends:
+  - __osx >=10.13
+  license: ISC
+  size: 210249
+  timestamp: 1716828641383
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.0-h2f8c449_1.conda
+  sha256: a0f7381c867898a45018b1e5cf1aca68659d292d58252e8f489a4270b010fed8
+  md5: af445c495253a871c3d809e1199bb12b
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 915300
+  timestamp: 1730208101739
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-h3dc7d44_0.conda
+  sha256: ef2a81c9a15080b996a37f0e1712881da90a710b234e63d8539d69892353de90
+  md5: b1caec4561059e43a5d056684c5a2de0
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 283874
+  timestamp: 1732349525684
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.21.0-h75589b3_0.conda
+  sha256: 3f82eddd6de435a408538ac81a7a2c0c155877534761ec9cd7a2906c005cece2
+  md5: 7a472cd20d9ae866aeb6e292b33381d6
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 332651
+  timestamp: 1727206546431
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-h583c2ba_1.conda
+  sha256: 4d58c695dfed6f308d0fd3ff552e0078bb98bc0be2ea0bf55820eb6e86fa5355
+  md5: 4b78bcdcc8780cede8b3d090deba874d
+  depends:
+  - __osx >=10.13
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=17
+  - libdeflate >=1.22,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 395980
+  timestamp: 1728232302162
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.9.0-h6e16a3a_1.conda
+  sha256: 2c2957a94cd6c950bcdde8a55ea40ddfc65bef393f0eb76be0f281c179327a55
+  md5: 2c6188e92dbde6515162a84329c54f13
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 79297
+  timestamp: 1732868560678
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
+  sha256: 7bafd8f4c637778cd0aa390bf3a894feef0e1fcf6ea6000c7ffc25c4c5a65538
+  md5: b2c0047ea73819d992484faacbbe1c24
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 355099
+  timestamp: 1713200298965
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+  sha256: 8896cd5deff6f57d102734f3e672bc17120613647288f9122bec69098e839af7
+  md5: bbeca862892e2898bdb45792a61c4afc
+  depends:
+  - __osx >=10.13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 323770
+  timestamp: 1727278927545
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.5-h495214b_0.conda
+  sha256: 66e1bf40699daf83b39e1281f06c64cf83499de3a9c05d59477fadded6d85b18
+  md5: 8711bc6fb054192dc432741dcd233ac3
+  depends:
+  - __osx >=10.13
+  - icu >=75.1,<76.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 608931
+  timestamp: 1731489767386
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+  sha256: 8412f96504fc5993a63edf1e211d042a1fd5b1d51dedec755d2058948fcced09
+  md5: 003a54a4e32b02f7355b50a837e699da
+  depends:
+  - __osx >=10.13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 57133
+  timestamp: 1727963183990
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.4-ha54dae1_0.conda
+  sha256: 69fca4a9318d7367ec3e0e7d6e6023a46ae1113dbd67da6d0f93fffa0ef54497
+  md5: 193715d512f648fe0865f6f13b1957e3
+  depends:
+  - __osx >=10.13
+  constrains:
+  - openmp 19.1.4|19.1.4.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 305132
+  timestamp: 1732102427054
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.43.0-py311h25b8078_1.conda
+  sha256: 8f47684beb89f6c03d10a06929365218cdf4454aee52f0bf83a97da4597c429c
+  md5: 19d1706a45751962b116123dcbc578f0
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 379249
+  timestamp: 1725305363038
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-4.3.3-py311h12b7ed1_1.conda
+  sha256: 47515c300a34c47be42b3196f6f5d400fd3f80f0ae25c73eb10ad367cef450cb
+  md5: ab30eba2d9fe565ff640369016e74fe5
+  depends:
+  - __osx >=10.13
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36652
+  timestamp: 1725089602246
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+  sha256: 39aa0c01696e4e202bf5e337413de09dfeec061d89acd5f28e9968b4e93c3f48
+  md5: aa04f7143228308662696ac24023f991
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 156415
+  timestamp: 1674727335352
+- conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.2-py311ha3cf9ac_1.conda
+  sha256: e9965b5d4c29b17b1512035b24a7c126ed7bdb6b39103b52cae099d5bb4194a9
+  md5: 1d6596ca7c7b66215c5c0d58b3cb0dd3
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24688
+  timestamp: 1733219887972
+- conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.3-py311h19a4563_0.conda
+  sha256: bbcf29f1850cc8ab9d70d526cfa5515a2e6d4a4c259c0a04f72ffd38aadc4548
+  md5: 8c0cd76938ca846fda82d1fa9039e63a
+  depends:
+  - __osx >=10.13
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=18
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 7852415
+  timestamp: 1733176358042
+- conda: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.1.0-py311hf2f7c97_0.conda
+  sha256: b56b1e7d156b88cc0c62734acf56d4ee809723614f659e4203028e7eeac16a78
+  md5: 6804cd42195bf94efd1b892688c96412
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 90868
+  timestamp: 1725975178961
+- conda: https://conda.anaconda.org/conda-forge/osx-64/multidict-6.1.0-py311h1cc1194_1.conda
+  sha256: 2a6125f3f0ead2acc2c3af744e3cf76317dade0f7eb57f21a7512f0e6ddcb8d4
+  md5: 4ab98d43b99358e7e068b52bafe462bf
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 55833
+  timestamp: 1729065694959
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
+  sha256: b0b3180039ef19502525a2abd5833c00f9624af830fd391f851934d57bffb9af
+  md5: e102bbf8a6ceeaf429deab8032fc8977
+  depends:
+  - __osx >=10.13
+  license: X11 AND BSD-3-Clause
+  size: 822066
+  timestamp: 1724658603042
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.60.0-py311h0e5bd6a_0.conda
+  sha256: 47fbc7925d5ee5ba9d841e542752288fc7059f44c0b95c34e11c609f4754e517
+  md5: 8bd1ff28924ea52b539528d85f70a1ac
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - llvm-openmp >=16.0.6
+  - llvm-openmp >=18.1.8
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libopenblas !=0.3.6
+  - cuda-python >=11.6
+  - scipy >=1.0
+  - tbb >=2021.6.0
+  - cudatoolkit >=11.2
+  - cuda-version >=11.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5773011
+  timestamp: 1718888442395
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numcodecs-0.14.1-py311hcf53e2f_0.conda
+  sha256: 418e2f485862e77743eef4ef4ce5f2b63438dd8af09211d15151d2561c53b3ef
+  md5: 3426451554e4cd5f2925e5e7f7caeda9
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - msgpack-python
+  - numpy >=1.19,<3
+  - numpy >=1.24
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 762194
+  timestamp: 1732243827399
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.0.2-py311h14ed71f_1.conda
+  sha256: 11b26503fbcc7215ba4ccb9d4f67540f9783fe1bd01d18c54f0cf8ab03ee7295
+  md5: 3162c97b53e0e3deeb4773e9b21cbde7
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8027046
+  timestamp: 1732314989218
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
+  sha256: dc9c405119b9b54f8ca5984da27ba498bd848ab4f0f580da6f293009ca5adc13
+  md5: 05a14cc9d725dd74995927968d6547e3
+  depends:
+  - libcxx >=16
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 331273
+  timestamp: 1709159538792
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hd471939_0.conda
+  sha256: ba7e068ed469d6625e32ae60e6ad893e655b6695280dadf7e065ed0b6f3b885c
+  md5: ec99d2ce0b3033a75cbad01bbc7c5b71
+  depends:
+  - __osx >=10.13
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2590683
+  timestamp: 1731378034404
+- conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.3-h5cd248e_0.conda
+  sha256: 5254a9e811e25595ffa029f131557adf0657efbb81d659afb5561af3ef4bbffa
+  md5: fe9651fd3413eb332537f7729cebc8e1
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 467056
+  timestamp: 1731665334947
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.3-py311haeb46be_1.conda
+  sha256: ad35c52521f0946caf06e19fd3dfad55f7b30e46648f96214f59d8ca2dac95ad
+  md5: ca32a9963a1b5c636b5131831ded81f3
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14864168
+  timestamp: 1726879042435
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.0.0-py311h1f68098_0.conda
+  sha256: 3826fe546e711787ce5b42e2f9176589846631945a528176da0fb61e751d3749
+  md5: ab73babea5e9a94d4f0f3c8fead83459
+  depends:
+  - __osx >=10.13
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 42126861
+  timestamp: 1729065932260
+- conda: https://conda.anaconda.org/conda-forge/osx-64/propcache-0.2.0-py311h3336109_2.conda
+  sha256: 34d5eba45fd4bc40d3e1e2eb39d1e3e418725d51406db4bce4c745689c4102e6
+  md5: 8d1662b4a3df11cef61afa54a2748f4d
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 47401
+  timestamp: 1728546044739
+- conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.0-py311h1314207_0.conda
+  sha256: 340d19b16a2f5b663b4f000188467831b107dcaa5b15522e172d6a27820d3b01
+  md5: 446e328d89429c077ccd74d7e9d8853e
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 512211
+  timestamp: 1729847190327
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+  sha256: 05944ca3445f31614f8c674c560bca02ff05cb51637a96f665cb2bbe496099e5
+  md5: 8bcf980d2c6b17094961198284b8e862
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 8364
+  timestamp: 1726802331537
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-18.1.0-py311h6eed73b_0.conda
+  sha256: a0a27fe54d19a42a900ed00a72a68758a14e742c8e22808be1240c24622a07fb
+  md5: c1de8a6883cbb9135fbbf1e1bdbebbdc
+  depends:
+  - libarrow-acero 18.1.0.*
+  - libarrow-dataset 18.1.0.*
+  - libarrow-substrait 18.1.0.*
+  - libparquet 18.1.0.*
+  - pyarrow-core 18.1.0 *_0_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25275
+  timestamp: 1732611267588
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-18.1.0-py311he02522f_0_cpu.conda
+  sha256: 960a5cb329b82118daab50be01faa541c3542e45d30e8eeff14d93619fc0af6b
+  md5: 995e6211e8d94b51466b7d0c8ccd475b
+  depends:
+  - __osx >=10.13
+  - libarrow 18.1.0.* *cpu
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - numpy >=1.21,<3
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4068983
+  timestamp: 1732611224743
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.3.2-py311hfbc4093_0.conda
+  sha256: 4b6729088cc2b5461b5f1cf080a400921538b52854b3ef3ef55dc3382d3dd365
+  md5: b7ae34cfc2cbd83ec8fb9783bc00df1c
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 490751
+  timestamp: 1732987367396
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.3.2-py311hfbc4093_0.conda
+  sha256: c3ceda073b0164655f16b080d9c9b9d027021e4e0142c04a029663adc8eda0ee
+  md5: 6f2fc8232ec4b6da3b7f4aac21eaaa3b
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 10.3.2.*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 381731
+  timestamp: 1733168922676
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.10-ha513fb2_3_cpython.conda
+  sha256: 670ba83b2aab2204f3254ed47ac0e4b8cad82478e5821727aeab69a2912aa1a0
+  md5: 1a88c32ab9e997380ba1f9306624f805
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 15442415
+  timestamp: 1729043110107
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
+  sha256: 9b092850a268aca99600b724bae849f51209ecd5628e609b4699debc59ff1945
+  md5: e6d62858c06df0be0e6255c753d74787
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6303
+  timestamp: 1723823062672
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311h3336109_1.conda
+  sha256: d8f4513c53a7c0be9f1cdb9d1af31ac85cf8a6f0e4194715e36e915c03104662
+  md5: b0132bec7165a53403dcc393ff761a9e
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 193941
+  timestamp: 1725456465818
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.2.0-py311h4d3da15_3.conda
+  sha256: 6aa664170031e36302616978404175c6ada3bd4a14c71bac826fa6a7ec15f815
+  md5: 48a614f384285254a3224d086dc84ce3
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 366412
+  timestamp: 1728642446264
+- conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+  sha256: 79d804fa6af9c750e8b09482559814ae18cd8df549ecb80a4873537a5a31e06e
+  md5: dd1ea9ff27c93db7c01a7b7656bd4ad4
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: LicenseRef-Qhull
+  size: 528122
+  timestamp: 1720814002588
+- conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2024.07.02-h2fb0a26_1.conda
+  sha256: 49ec4ed6249efe9cda173745e036137f8de1f0b22edf9b0ca4f9c6409b2b68f9
+  md5: aa8ea927cdbdf690efeae3e575716131
+  depends:
+  - libre2-11 2024.07.02 hd530cb8_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26864
+  timestamp: 1728779054104
+- conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+  sha256: 41e7d30a097d9b060037f0c6a2b1d4c4ae7e942c06c943d23f9d481548478568
+  md5: f17f77f2acf4d344734bda76829ce14e
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 255870
+  timestamp: 1679532707590
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.22.0-py311h3b9c2be_0.conda
+  sha256: 39ab6a55bb8099b2b2ca49e16ab42e3af3444c252aa5d110f176863b5e28f843
+  md5: fea4ef5405df200a0f109badb27debbc
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 330453
+  timestamp: 1733233074987
+- conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.1-py311hed734c1_1.conda
+  sha256: 2515954fe9f8202c35e9b2df6d65650f8ffcfa7dc99ed068b25968e8af5f1b23
+  md5: 22812381ffcab544161a257666f1c203
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16391177
+  timestamp: 1729481689967
+- conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-he1e6707_0.conda
+  sha256: a979319cd4916f0e7450aa92bb3cf4c2518afa80be50de99f31d075e693a6dd9
+  md5: ddceef5df973c8ff7d6b32353c0cb358
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37036
+  timestamp: 1720003862906
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+  sha256: 30412b2e9de4ff82d8c2a7e5d06a15f4f4fef1809a72138b6ccb53a33b26faf5
+  md5: bf830ba5afc507c6232d4ef0fb1a882d
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3270220
+  timestamp: 1699202389792
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.2-py311h4d7f069_0.conda
+  sha256: 5273ba307489570df61d82a6b3365b2a27862765099cf4ef3830569fa4a30f27
+  md5: 073c42a2b6b7e4219325b1f5983c7579
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 858750
+  timestamp: 1732616082798
+- conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-15.1.0-py311h1314207_1.conda
+  sha256: c0be0b59fa67c3f9915d3dcd77d972656b9966b4516b3c044efe350860f7e054
+  md5: 574fd9b8168c1b109003c3c431c0bb7e
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 363667
+  timestamp: 1729704694220
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h00291cd_1.conda
+  sha256: 96177823ec38336b0f4b7e7c2413da61f8d008d800cc4a5b8ad21f9128fb7de0
+  md5: c6cc91149a08402bbb313c5dc0142567
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 13176
+  timestamp: 1727034772877
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
+  sha256: bb4d1ef9cafef535494adf9296130b6193b3a44375883185b5167de03eb1ac7f
+  md5: 9f438e1b6f4e73fd9e6d78bfe7c36743
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 18465
+  timestamp: 1727794980957
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+  sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
+  md5: a72f9d4ea13d55d745ff1ed594747f10
+  license: LGPL-2.1 and GPL-2.0
+  size: 238119
+  timestamp: 1660346964847
+- conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+  sha256: 5301417e2c8dea45b401ffee8df3957d2447d4ce80c83c5ff151fc6bfe1c4148
+  md5: d7e08fcf8259d742156188e8762b4d20
+  license: MIT
+  license_family: MIT
+  size: 84237
+  timestamp: 1641347062780
+- conda: https://conda.anaconda.org/conda-forge/osx-64/yarl-1.18.0-py311h4d7f069_0.conda
+  sha256: 3bcd4186c08715e59da6d13eeb5dbdfba3d8438b39a9c2ddf7dfa4f4e250a5fa
+  md5: e62e3168b3d3fa6c40e86f9e0b0fbc4a
+  depends:
+  - __osx >=10.13
+  - idna >=2.0
+  - multidict >=4.0
+  - propcache >=0.2.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 141489
+  timestamp: 1732221153875
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h7130eaa_7.conda
+  sha256: b932dce8c9de9a8ffbf0db0365d29677636e599f7763ca51e554c43a0c5f8389
+  md5: 6a0a76cd2b3d575e1b7aaeb283b9c3ed
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.3,<1.22.0a0
+  - libcxx >=18
+  - libsodium >=1.0.20,<1.0.21.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 292112
+  timestamp: 1731585246902
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py311hdf6fcd6_1.conda
+  sha256: d9bf977b620750049eb60fffca299a701342a2df59bcc2586a79b2f7c5783fa1
+  md5: 4fc42d6f85a21b09ee6477f456554df3
+  depends:
+  - __osx >=10.13
+  - cffi >=1.11
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411350
+  timestamp: 1725305723486
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
+  sha256: efa04a98cb149643fa54c4dad5a0179e36a5fbc88427ea0eec88ceed87fd0f96
+  md5: 4cb2cd56f039b129bb0e491c1164167e
+  depends:
+  - __osx >=10.9
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 498900
+  timestamp: 1714723303098
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.11.9-py311h4921393_0.conda
+  sha256: 4e57bf5250304eec98769921788c7be76d146f21edf85ed890318991a8d9e2e7
+  md5: b7e219c251ece66ccd7058af6d6fda10
+  depends:
+  - __osx >=11.0
+  - aiohappyeyeballs >=2.3.0
+  - aiosignal >=1.1.2
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - multidict >=4.5,<7.0
+  - propcache >=0.2.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - yarl >=1.17.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  size: 880101
+  timestamp: 1733124988232
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311h460d6c5_5.conda
+  sha256: 6eabd1bcefc235b7943688d865519577d7668a2f4dc3a24ee34d81eb4bfe77d1
+  md5: 1e8260965552c6ec86453b7d15a598de
+  depends:
+  - __osx >=11.0
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 33008
+  timestamp: 1725356833036
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.8.0-h9b725a8_10.conda
+  sha256: 63cb8c25e0a26be4261d4271de525e7e33aefe9d9b001b8abfa5c9ac69c3dab3
+  md5: 17c90d9eb8c6842fd739dc5445ce9962
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 92355
+  timestamp: 1731733738919
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.8.0-h5d7ee29_2.conda
+  sha256: 2a8c09b33400cf2b7d658e63fd5a6f9b6e9626458f6213b904592fc15220bc92
+  md5: 92734dad83d22314205ba73b679710d2
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 39966
+  timestamp: 1731678721786
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.10.3-h5505292_0.conda
+  sha256: bb2c1038726d31ffd2d35a5764f80bcd670b6a1c753aadfd261aecb9f88db6d8
+  md5: 4150339e3b08db33fe4c436340b1d7f6
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 221524
+  timestamp: 1731567512057
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.0-h5d7ee29_2.conda
+  sha256: a52ea62bf08aed3af079e16d1738f3d2a7fcdd1d260289ae27ae96298e15d12a
+  md5: 15566c36b0cf5f314e3bee7f7cc796b5
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18204
+  timestamp: 1731678916439
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.5.0-h13ead76_7.conda
+  sha256: 386965fab5f0bed4a6109cdba32579f16bee1b0f76ce1db840ce6f7070188f9f
+  md5: 55a901b6d4fb9ce1bc8328925b229f0b
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 47528
+  timestamp: 1731714690911
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.9.1-hf483d09_2.conda
+  sha256: fca9ed0f0895bab9bf737c8d8a3314556cb893d45c40f0656f21a93502db3089
+  md5: d880c40b8fc7d07374c036f93f1359d2
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-compression >=0.3.0,<0.3.1.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 153315
+  timestamp: 1731714621306
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.15.2-h39f8ad8_2.conda
+  sha256: b14e32f024f6be1610dccfdb6371e101cba204d24f37c2a63d9b6380ac74ac17
+  md5: 3b49f1dd8f20bead8b222828cfdad585
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 137610
+  timestamp: 1731702839896
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.11.0-h68a0d7e_8.conda
+  sha256: 837c24c105624e16ace94b4b566ffe45231ff275339c523571ebd45946926156
+  md5: 9e3ac70d27e7591b1310a690768cfe27
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 134573
+  timestamp: 1731734281038
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.7.3-h840aca7_0.conda
+  sha256: 18972a91f32f6b0edb58eb71cb2f5b56654183fd6ba611b3b0d6cc484017aeff
+  md5: 893e668d99fa4b31eef9dc5b19c21b9a
+  depends:
+  - __osx >=11.0
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 97145
+  timestamp: 1733098874599
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.1-h5d7ee29_1.conda
+  sha256: ed3b272b9a345142e62f0cf9ab2a9fa909c92e09691f6a06e98ff500a1f8a303
+  md5: 0f1e5bc57d4567c9d9bec8d8982828ed
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 50276
+  timestamp: 1731687215375
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.2-h5d7ee29_1.conda
+  sha256: eb7ebe309b33a04329b3e51a7f10bb407815389dc37cc047f7d41f9c91f0d1b0
+  md5: db1ed95988a8fe6c1ce0d94abdfc8e72
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 70184
+  timestamp: 1731687342560
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.29.6-ha226bf8_1.conda
+  sha256: f645e2a8015d8e71ed785c81a14a202ebce2f5dcca8982cd7ec5f8000f9be5c3
+  md5: 81da0b5f65ab08e3919d6eadf08b5776
+  depends:
+  - __osx >=11.0
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-mqtt >=0.11.0,<0.11.1.0a0
+  - aws-c-s3 >=0.7.3,<0.7.4.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 236505
+  timestamp: 1733151090562
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.449-h3b64406_4.conda
+  sha256: 10ce9c203d31229432421a841d8d135d3e942637571aae4bb2d3c7d5242e7f05
+  md5: f9e46a4bb5a04cbca08355f166ce87c8
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2722689
+  timestamp: 1732812825640
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.14.0-hd50102c_0.conda
+  sha256: f5b91329ed59ffc0be8747784c6e4cc7e56250c54032883a83bc11808ef6a87e
+  md5: f093a11dcf3cdcca010b20a818fcc6dc
+  depends:
+  - __osx >=11.0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 294299
+  timestamp: 1728054014060
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.10.0-hc602bab_0.conda
+  sha256: bde446b916fff5150606f8ed3e6058ffc55a3aa72381e46f1ab346590b1ae40a
+  md5: d7b71593a937459f2d4b67e1a4727dc2
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 166907
+  timestamp: 1728486882502
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.13.0-h7585a09_1.conda
+  sha256: 08d52d130addc0fb55d5ba10d9fa483e39be25d69bac7f4c676c2c3069207590
+  md5: 704238ef05d46144dae2e6b5853df8bc
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 438636
+  timestamp: 1728578216193
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.8.0-h9ca1f76_1.conda
+  sha256: 77ab04e8fe5636a2de9c718f72a43645f7502cd208868c8a91ffba385547d585
+  md5: 7a187cd7b1445afc80253bb186a607cc
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - libxml2 >=2.12.7,<2.14.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 121278
+  timestamp: 1728563418777
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.12.0-hcdd55da_1.conda
+  sha256: f48523f8aa0b5b80f45a92f0556b388dd96f44ac2dc2f44a01d08c1822eec97d
+  md5: c49fbc5233fcbaa86391162ff1adef38
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 196032
+  timestamp: 1728729672889
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hd74edd7_2.conda
+  sha256: a086f36ff68d6e30da625e910547f6211385246fb2474b144ac8c47c32254576
+  md5: 215e3dc8f2f837906d066e7f01aa77c0
+  depends:
+  - __osx >=11.0
+  - brotli-bin 1.1.0 hd74edd7_2
+  - libbrotlidec 1.1.0 hd74edd7_2
+  - libbrotlienc 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 19588
+  timestamp: 1725268044856
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hd74edd7_2.conda
+  sha256: 28f1af63b49fddf58084fb94e5512ad46e9c453eb4be1d97449c67059e5b0680
+  md5: b8512db2145dc3ae8d86cdc21a8d421e
+  depends:
+  - __osx >=11.0
+  - libbrotlidec 1.1.0 hd74edd7_2
+  - libbrotlienc 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 16772
+  timestamp: 1725268026061
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311h3f08180_2.conda
+  sha256: f507d65e740777a629ceacb062c768829ab76fde01446b191699a734521ecaad
+  md5: c8793a23206344faa25f4e0b5d0e7908
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 339584
+  timestamp: 1725268241628
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+  sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
+  md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
+  depends:
+  - __osx >=11.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 122909
+  timestamp: 1720974522888
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.3-h5505292_1.conda
+  sha256: 6dfa83cbd9acc8671d439fe9c745a5716faf6cbadf2f1e18c841bcf86cbba5f2
+  md5: fb72102e8a8f9bcd38e40af09ff41c42
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 179318
+  timestamp: 1732447193278
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
+  sha256: 2db1733f4b644575dbbdd7994a8f338e6ef937f5ebdb74acd557e9dda0211709
+  md5: 40dec13fd8348dbe303e57be74bd3d35
+  license: ISC
+  size: 158482
+  timestamp: 1725019034582
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py311h3a79f62_0.conda
+  sha256: 253605b305cc4548b8f97eb7c2e146697e0c7672b099c4862ec5ca7e8e995307
+  md5: a42272c5dbb6ffbc1a5af70f24c7b448
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 288211
+  timestamp: 1725560745212
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.1-py311h210dab8_0.conda
+  sha256: 8e755206b38a6e14861c79a74b51af76124bdf5c266dd6a584305e03d37c2e0c
+  md5: 7f9e9df2d62cf69aed450f6957a23e61
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 247202
+  timestamp: 1731428753912
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.0.0-py311h460d6c5_1.conda
+  sha256: cff9cd6a8652a73d9e1d73c51bfd1bac6b526e705885b1ec8f0c159bd34046d2
+  md5: 72740cbbba07d1fb0f37448e1e1c7ef9
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 341441
+  timestamp: 1728335223644
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.9-py311h155a34a_0.conda
+  sha256: 880c3de00402d6c5d61d3f64af9ecad8022f272225e3ae62fa8e9c4885b7f0e5
+  md5: d619288803d5935f771f64a7924a6aad
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2531409
+  timestamp: 1732237062084
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.55.1-py311h4921393_0.conda
+  sha256: 49f1ac7c79c546437311bbe18f075d3ad19714cd627131cb2a02ca9c660debc1
+  md5: 545ea87f1c719d9d26a4c265bcd1d7d9
+  depends:
+  - __osx >=11.0
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2803365
+  timestamp: 1733242276864
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+  sha256: 791673127e037a2dc0eebe122dc4f904cb3f6e635bb888f42cbe1a76b48748d9
+  md5: e6085e516a3e304ce41a8ee08b9b89ad
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 596430
+  timestamp: 1694616332835
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.5.0-py311hae2e1ce_0.conda
+  sha256: 3df51bbf74052c5d29a33cf8c8c57302699937f883e0e4e9e506c7e0b09e45a5
+  md5: 7f28e6daf0b4963be1061291cbe10bfb
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 54023
+  timestamp: 1729699703032
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
+  sha256: fd56ed8a1dab72ab90d8a8929b6f916a6d9220ca297ff077f8f04c5ed3408e20
+  md5: 57a511a5905caa37540eb914dfcbf1fb
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 82090
+  timestamp: 1726600145480
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
+  sha256: 9fc77de416953aa959039db72bc41bfa4600ae3ff84acad04a7d0c1ab9552602
+  md5: fef68d0a95aa5b84b5c1a4f6f3bf40e1
+  depends:
+  - __osx >=11.0
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 112215
+  timestamp: 1718284365403
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py311h267d04e_1.conda
+  sha256: 736304347653ed421b13c56ba6f4f87c1d78d24cd3fa74db0db6fb70c814fa65
+  md5: 5bce88ac1bef7d47c62cb574b25891ae
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18253
+  timestamp: 1725303181400
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.7-py311h2c37856_0.conda
+  sha256: 8ffc46f6e99c95c48426cf34c033d16cde3bcf100cd74d1d74a33943a85a6ec8
+  md5: ee572d19da1346db8e78cb8e7d5d2330
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59357
+  timestamp: 1725459504453
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+  sha256: 4442f957c3c77d69d9da3521268cad5d54c9033f1a73f99cde0a3658937b159b
+  md5: c6dc8a0fdec13a0565936655c33069a1
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1155530
+  timestamp: 1719463474401
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
+  sha256: 151e0c84feb7e0747fabcc85006b8973b22f5abbc3af76a9add0b0ef0320ebe4
+  md5: 66f6c134e76fe13cce8a9ea5814b5dd5
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 211959
+  timestamp: 1701647962657
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+  sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
+  md5: de462d5aacda3b30721b512c5da4e742
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 215721
+  timestamp: 1657977558796
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_hf9b8971_1.conda
+  sha256: 90bf08a75506dfcf28a70977da8ab050bcf594cd02abd3a9d84a22c9e8161724
+  md5: 706da5e791c569a7b9814877098a6a0a
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  constrains:
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1179072
+  timestamp: 1727295571173
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-18.1.0-h654e1bb_2_cpu.conda
+  sha256: 925dcb034f36536eed21d9323f096bf2ebf1111d14c61e1ae0b90e5de131f1e1
+  md5: e69934ff9dd8745fea8927028d1603ee
+  depends:
+  - __osx >=11.0
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - aws-sdk-cpp >=1.11.449,<1.11.450.0a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-identity-cpp >=1.10.0,<1.10.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-files-datalake-cpp >=12.12.0,<12.12.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=18
+  - libgoogle-cloud >=2.31.0,<2.32.0a0
+  - libgoogle-cloud-storage >=2.31.0,<2.32.0a0
+  - libre2-11 >=2024.7.2
+  - libutf8proc >=2.9.0,<2.10.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.3,<2.0.4.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - arrow-cpp <0.0a0
+  - parquet-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5475725
+  timestamp: 1732947802614
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-18.1.0-h605b82c_2_cpu.conda
+  sha256: cfe32f1b0712b77d2c792a839fe4ea2790cabd99d47cd8e1b20ba2d3c8b113b2
+  md5: 60351279d7dfd7c254c46aabf9aa35a6
+  depends:
+  - __osx >=11.0
+  - libarrow 18.1.0 h654e1bb_2_cpu
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: APACHE
+  size: 483362
+  timestamp: 1732948000606
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-18.1.0-h605b82c_2_cpu.conda
+  sha256: eeae9e8d382c482076f4739455b53f16851d7f99be219b6f96dd4e765132b446
+  md5: b5fcaddabf47aa15e50feff072a55ada
+  depends:
+  - __osx >=11.0
+  - libarrow 18.1.0 h654e1bb_2_cpu
+  - libarrow-acero 18.1.0 h605b82c_2_cpu
+  - libcxx >=18
+  - libparquet 18.1.0 h5168bdf_2_cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 489769
+  timestamp: 1732949732423
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-18.1.0-h9b432b6_2_cpu.conda
+  sha256: 6dde802134bd2e78581eb838c049b2e7e378899706b471f7072222a6b1284b90
+  md5: 49e7c0460532a73f34bd127fff009224
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 18.1.0 h654e1bb_2_cpu
+  - libarrow-acero 18.1.0 h605b82c_2_cpu
+  - libarrow-dataset 18.1.0 h605b82c_2_cpu
+  - libcxx >=18
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 451127
+  timestamp: 1732950194322
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-25_osxarm64_openblas.conda
+  sha256: f1fb9a11af0b2878bd8804b4c77d3733c40076218bcbdb35f575b1c0c9fddf11
+  md5: f8cf4d920ff36ce471619010eff59cac
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - blas * openblas
+  - liblapack 3.9.0 25_osxarm64_openblas
+  - liblapacke 3.9.0 25_osxarm64_openblas
+  - libcblas 3.9.0 25_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15913
+  timestamp: 1729643265495
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hd74edd7_2.conda
+  sha256: 839dacb741bdbb25e58f42088a2001b649f4f12195aeb700b5ddfca3267749e5
+  md5: d0bf1dff146b799b319ea0434b93f779
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 68426
+  timestamp: 1725267943211
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hd74edd7_2.conda
+  sha256: 6c6862eb274f21a7c0b60e5345467a12e6dda8b9af4438c66d496a2c1a538264
+  md5: 55e66e68ce55523a6811633dd1ac74e2
+  depends:
+  - __osx >=11.0
+  - libbrotlicommon 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 28378
+  timestamp: 1725267980316
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hd74edd7_2.conda
+  sha256: eeb1eb0d58b9d02bc1b98dc0a058f104ab168eb2f7d1c7bfa0570a12cfcdb7b7
+  md5: 4f3a434504c67b2c42565c0b85c1885c
+  depends:
+  - __osx >=11.0
+  - libbrotlicommon 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 279644
+  timestamp: 1725268003553
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-25_osxarm64_openblas.conda
+  sha256: d9fa5b6b11252132a3383bbf87bd2f1b9d6248bef1b7e113c2a8ae41b0376218
+  md5: 4df0fae81f0b5bf47d48c882b086da11
+  depends:
+  - libblas 3.9.0 25_osxarm64_openblas
+  constrains:
+  - blas * openblas
+  - liblapack 3.9.0 25_osxarm64_openblas
+  - liblapacke 3.9.0 25_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15837
+  timestamp: 1729643270793
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+  sha256: 58477b67cc719060b5b069ba57161e20ba69b8695d154a719cb4b60caf577929
+  md5: 32bd82a6a625ea6ce090a81c3d34edeb
+  depends:
+  - libcxx >=11.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18765
+  timestamp: 1633683992603
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.10.1-h13a7ad3_0.conda
+  sha256: 983a977c5627f975a930542c8aabb46089ec6ea72f28d9c4d3ee8eafaf2fc25a
+  md5: d84030d0863ffe7dea00b9a807fee961
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 379948
+  timestamp: 1726660033582
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.4-ha82da77_0.conda
+  sha256: 342896ebc1d6acbf022ca6df006a936b9a472579e91e3c502cb1f52f218b78e9
+  md5: a2d3d484d95889fccdd09498d8f6bf9a
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 520678
+  timestamp: 1732060258949
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.22-hd74edd7_0.conda
+  sha256: 3552894ca62bebc33d05982937cda25a4fa19e56a82af2ff20944ff4c2532fda
+  md5: 2d3e3f3d8ab315748420ef58d5a3ae0f
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 54089
+  timestamp: 1728177149927
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+  sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
+  md5: 30e4362988a2623e9eb34337b83e01f9
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 96607
+  timestamp: 1597616630749
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+  sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
+  md5: 36d33e440c31857372a72137f78bacf5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 107458
+  timestamp: 1702146414478
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+  sha256: 8c136d7586259bb5c0d2b913aaadc5b9737787ae4f40e3ad1beaf96c80b919b7
+  md5: 1a109764bff3bdc7bdd84088347d71dc
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 368167
+  timestamp: 1685726248899
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
+  sha256: e42ab5ace927ee7c84e3f0f7d813671e1cf3529f5f06ee5899606630498c2745
+  md5: 38d2656dd914feb0cab8c629370768bf
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 64693
+  timestamp: 1730967175868
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+  md5: 086914b672be056eb70fd4285b6783b6
+  license: MIT
+  license_family: MIT
+  size: 39020
+  timestamp: 1636488587153
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+  sha256: 44e541b4821c96b28b27fef5630883a60ce4fee91fd9c79f25a199f8f73f337b
+  md5: 4a55d9e169114b2b90d3ec4604cd7bbf
+  depends:
+  - libgfortran5 13.2.0 hf226fd6_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110233
+  timestamp: 1707330749033
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+  sha256: bafc679eedb468a86aa4636061c55966186399ee0a04b605920d208d97ac579a
+  md5: 66ac81d54e95c534ae488726c1f698ea
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 997381
+  timestamp: 1707330687590
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.31.0-h8d8be31_0.conda
+  sha256: 184d650d55453a40935c128ea309088ae52e15a68cd87ab17ae7c77704251168
+  md5: a338736f1514e6f999db8726fe0965b1
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - openssl >=3.3.2,<4.0a0
+  constrains:
+  - libgoogle-cloud 2.31.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 873497
+  timestamp: 1731121684939
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.31.0-h7081f7f_0.conda
+  sha256: 01f5156584b816d34270a60a61f6b6561f2a01cb3b4eeb455a4e1808d763d486
+  md5: 548fd1d31741ee6b13df4124db4a9f5f
+  depends:
+  - __osx >=11.0
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libcxx >=18
+  - libgoogle-cloud 2.31.0 h8d8be31_0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  size: 526858
+  timestamp: 1731122580689
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.67.1-hc70892a_0.conda
+  sha256: d2393fcd3c3584e5d58da4122f48bcf297567d2f6f14b3d1fcbd34fdd5040694
+  md5: 624e27571fde34f8acc2afec840ac435
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.34.2,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libre2-11 >=2024.7.2
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.67.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4882208
+  timestamp: 1730236299095
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
+  sha256: bc7de5097b97bcafcf7deaaed505f7ce02f648aac8eccc0d5a47cc599a1d0304
+  md5: 69bda57310071cf6d2b86caf11573d2d
+  license: LGPL-2.1-only
+  size: 676469
+  timestamp: 1702682458114
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+  sha256: a42054eaa38e84fc1e5ab443facac4bbc9d1b6b6f23f54b7bf4f1eb687e1d993
+  md5: 3ff1e053dc3a2b8e36b9bfa4256a58d1
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 547541
+  timestamp: 1694475104253
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-25_osxarm64_openblas.conda
+  sha256: fdd742407672a9af20e70764550cf18b3ab67f12e48bf04163b90492fbc401e7
+  md5: 19bbddfec972d401838330453186108d
+  depends:
+  - libblas 3.9.0 25_osxarm64_openblas
+  constrains:
+  - blas * openblas
+  - liblapacke 3.9.0 25_osxarm64_openblas
+  - libcblas 3.9.0 25_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15823
+  timestamp: 1729643275943
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_4.conda
+  sha256: 6f603914fe8633a615f0d2f1383978eb279eeb552079a78449c9fbb43f22a349
+  md5: 9f3dce5d26ea56a9000cd74c034582bd
+  depends:
+  - libcxx >=15
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 20571387
+  timestamp: 1690559110016
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
+  sha256: 00cc685824f39f51be5233b54e19f45abd60de5d8847f1a56906f8936648b72f
+  md5: 3408c02539cee5f1141f9f11450b6a51
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.34.2,<2.0a0
+  - libcxx >=17
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 566719
+  timestamp: 1729572385640
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
+  sha256: 62bb669c37a845129096f73d446cdb6bb170e4927f2fea2b661329680dbbc373
+  md5: 40803a48d947c8639da6704e9a44d3ce
+  depends:
+  - __osx >=11.0
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - llvm-openmp >=18.1.8
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4165774
+  timestamp: 1730772154295
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-18.1.0-h5168bdf_2_cpu.conda
+  sha256: 454487d113974b923b4214a65aab780fd90c4914390d0b1f4640b1bf60537bff
+  md5: f995df7ee206617a3e858fd932d7bd2d
+  depends:
+  - __osx >=11.0
+  - libarrow 18.1.0 h654e1bb_2_cpu
+  - libcxx >=18
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 872333
+  timestamp: 1732949558028
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
+  sha256: 38f8759a3eb8060deabd4db41f0f023514d853e46ddcbd0ba21768fc4e563bb1
+  md5: fb36e93f0ea6a6f5d2b99984f34b049e
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 263385
+  timestamp: 1726234714421
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.28.2-h8f0b736_0.conda
+  sha256: f732a6fa918428e2d5ba61e78fe11bb44a002cc8f6bb74c94ee5b1297fefcfd8
+  md5: d2cb5991f2fb8eb079c80084435e9ce6
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2374965
+  timestamp: 1728565334796
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2024.07.02-h2348fd5_1.conda
+  sha256: 6facca42cfc85a05b33e484a8b0df7857cc092db34806946d022270098d8d20f
+  md5: 5a7065309a66097738be6a06fd04b7ef
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 165956
+  timestamp: 1728779107218
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
+  sha256: fade8223e1e1004367d7101dd17261003b60aa576df6d7802191f8972f7470b1
+  md5: a7ce36e284c5faaf93c220dfc39e3abd
+  depends:
+  - __osx >=11.0
+  license: ISC
+  size: 164972
+  timestamp: 1716828607917
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.47.0-hbaaea75_1.conda
+  sha256: 5a96caa566c11e5a5ebdcdb86a0759a7fb27d3c5f42e6a0fd0d6023c1e935d9e
+  md5: 07a14fbe439eef078cc479deca321161
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 837683
+  timestamp: 1730208293578
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h9cc3647_0.conda
+  sha256: f7047c6ed44bcaeb04432e8c74da87591940d091b0a3940c0d884b7faa8062e9
+  md5: ddc7194676c285513706e5fc64f214d7
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279028
+  timestamp: 1732349599461
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.21.0-h64651cc_0.conda
+  sha256: 7a6c7d5f58cbbc2ccd6493b4b821639fdb0701b9b04c737a949e8cb6adf1c9ad
+  md5: 7ce2bd2f650f8c31ad7ba4c7bfea61b7
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 324342
+  timestamp: 1727206096912
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-hfce79cd_1.conda
+  sha256: 97ba24c74750b6e731b3fe0d2a751cda6148b4937d2cc3f72d43bf7b3885c39d
+  md5: b9abf45f7c64caf3303725f1aa0e9a4d
+  depends:
+  - __osx >=11.0
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=17
+  - libdeflate >=1.22,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 366323
+  timestamp: 1728232400072
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.9.0-h5505292_1.conda
+  sha256: ea88f06e97ef8fa2490f7594f8885bb542577226edf8abba3144302d951a53c2
+  md5: f777470d31c78cd0abe1903a2fda436f
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 83000
+  timestamp: 1732868631531
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+  sha256: 0d4bad713a512d79bfeb4d61821f447afab8b0792aca823f505ce6b195e9fde5
+  md5: c0af0edfebe780b19940e94871f1a765
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 287750
+  timestamp: 1713200194013
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+  sha256: bd3816218924b1e43b275863e21a3e13a5db4a6da74cca8e60bc3c213eb62f71
+  md5: af523aae2eca6dfa1c8eec693f5b9a79
+  depends:
+  - __osx >=11.0
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 323658
+  timestamp: 1727278733917
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.13.5-h376fa9f_0.conda
+  sha256: d443703d324f3dbd628d58ea498ab0e474c06d5771e7f55baf215fdbc11ceb87
+  md5: adea92805465ed3dcf0776b428e34744
+  depends:
+  - __osx >=11.0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - icu <0.0a0
+  license: MIT
+  license_family: MIT
+  size: 582076
+  timestamp: 1731489850179
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
+  md5: 369964e85dc26bfe78f41399b366c435
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 46438
+  timestamp: 1727963202283
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.4-hdb05f8b_0.conda
+  sha256: dfdcd8de37899d984326f9734b28f46f80b88c068e44c562933a8b3117f2401a
+  md5: 76ca179ec970bea6e275e2fa477c2d3c
+  depends:
+  - __osx >=11.0
+  constrains:
+  - openmp 19.1.4|19.1.4.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 281554
+  timestamp: 1732102484807
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.43.0-py311hc367efa_1.conda
+  sha256: c352b894bb07ed59d1cdaed1a64e52b054f4ff02119600a97ccf39cce06dbe5f
+  md5: d14048893b6cc8aec00b4e0e6eb78de2
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 378145
+  timestamp: 1725305457011
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-4.3.3-py311hebe0b09_1.conda
+  sha256: d68fb0bf5d74c83432155406de87b50b8c10712d331bbbab616c52d945751981
+  md5: 74df239a2926df48e2543bb6754baf61
+  depends:
+  - __osx >=11.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 108602
+  timestamp: 1725089854895
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+  sha256: fc343b8c82efe40819b986e29ba748366514e5ab94a1e1138df195af5f45fa24
+  md5: 45505bec548634f7d05e02fb25262cb9
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 141188
+  timestamp: 1674727268278
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py311h4921393_1.conda
+  sha256: 4f738a7c80e34e5e5d558e946b06d08e7c40e3cc4bdf08140bf782c359845501
+  md5: 249e2f6f5393bb6b36b3d3a3eebdcdf9
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24976
+  timestamp: 1733219849253
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.9.3-py311h031da69_0.conda
+  sha256: cc8a4f695d1679d55c39ed917d5ca6dc1b8a86ddb801b339c1f91e71d5f3cfe4
+  md5: 7def9f5bdc783a319c7b1304bd6144b7
+  depends:
+  - __osx >=11.0
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=18
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 7821688
+  timestamp: 1733176518004
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.0-py311h2c37856_0.conda
+  sha256: aafa8572c72283801148845772fd9d494765bdcf1b8ae6f435e1caff4f1c97f3
+  md5: 6c826762702474fb0def6cedd2db5316
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 91131
+  timestamp: 1725975234150
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.1.0-py311h30e7462_1.conda
+  sha256: 9e7beeeef3c13e000e2e9dab38dff3a5284a8c8665019be149db50b4eff9a340
+  md5: ff4227ea49745aeddbf45edef09036bc
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 56769
+  timestamp: 1729065684471
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+  sha256: 27d0b9ff78ad46e1f3a6c96c479ab44beda5f96def88e2fe626e0a49429d8afc
+  md5: cb2b0ea909b97b3d70cd3921d1445e1a
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  size: 802321
+  timestamp: 1724658775723
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.60.0-py311h9506ed5_0.conda
+  sha256: 70435f94de8b5328b039ffff9dfdd00c8c0a503cb1a86f4b70ae9cbdd7e4ec1f
+  md5: 5e14ce0b9976d6d0370c9f5032c81bb7
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - llvm-openmp >=16.0.6
+  - llvm-openmp >=18.1.7
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - cuda-version >=11.2
+  - cudatoolkit >=11.2
+  - scipy >=1.0
+  - cuda-python >=11.6
+  - libopenblas >=0.3.18, !=0.3.20
+  - tbb >=2021.6.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5778831
+  timestamp: 1718888718616
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numcodecs-0.14.1-py311hca32420_0.conda
+  sha256: 3625553950c7ef362c291b78453023a47125ffaf3d9c0924a379bc23ec18c857
+  md5: 9d6892bb6ea4921e29259606bd6731e7
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - msgpack-python
+  - numpy >=1.19,<3
+  - numpy >=1.24
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 674849
+  timestamp: 1732243826721
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.0.2-py311h649a571_1.conda
+  sha256: 3d4c508041d17007a56f79b593a6d6a69d4f4e2453f1f7ee29ecb48992cc3acc
+  md5: 417c4c5c4a4693156f5b878cf94bf7a0
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6893464
+  timestamp: 1732314808608
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
+  sha256: 472d6eaffc1996e6af35ec8e91c967f472a536a470079bfa56383cc0dbf4d463
+  md5: 5029846003f0bc14414b9128a1f7c84b
+  depends:
+  - libcxx >=16
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 316603
+  timestamp: 1709159627299
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h39f12f2_0.conda
+  sha256: bd1d58ced46e75efa3b842c61642fd12272c69e9fe4d7261078bc082153a1d53
+  md5: df307bbc703324722df0293c9ca2e418
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2935176
+  timestamp: 1731377561525
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.3-h121fd32_0.conda
+  sha256: 4759fd0c3f06c035146100e22ee36a312c9a8226654bd2973e9ca9ac5de5cf1f
+  md5: 39995f7406b949c1bef74f0c7277afb3
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 438254
+  timestamp: 1731665228473
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py311h9cb3ce9_1.conda
+  sha256: 0a08027b25e4f6034d7733c7366f44283246d61cb82d1721f8789d50ebfef287
+  md5: 9ffa9dee175c76e68ea5de5aa1168d83
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14807397
+  timestamp: 1726879116250
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.0.0-py311h3894ae9_0.conda
+  sha256: 6d5307fed000e6b72b98d54dd1fea7b155f9a6453476a937522b89dde7b3d673
+  md5: a9a4adae1c4178f50ac3d1fd5d64bb85
+  depends:
+  - __osx >=11.0
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 41856994
+  timestamp: 1729066060042
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/propcache-0.2.0-py311h460d6c5_2.conda
+  sha256: 7e6a656b09d494f0623c8bd0969195d1cd3f62a2ab5a2474a667c88e21cca971
+  md5: 8fb75727dfbab541ece9542718cc30f4
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 48222
+  timestamp: 1728546126843
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py311hae2e1ce_0.conda
+  sha256: 6237f04371995fa8e8f16481dcd4e01d2733a82750180a362a9f4953ffbb3cde
+  md5: e226eba0c52ecd6786e73c8ad7f41e79
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 514316
+  timestamp: 1729847396776
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+  sha256: 8ed65e17fbb0ca944bfb8093b60086e3f9dd678c3448b5de212017394c247ee3
+  md5: 415816daf82e0b23a736a069a75e9da7
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 8381
+  timestamp: 1726802424786
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-18.1.0-py311ha1ab1f8_0.conda
+  sha256: c93f3ede66be0502b5b9afc5bc3fde50d6f8c3863d29b138ff5f536a116457f3
+  md5: 7a3b822fa6abb937651bee20878f087a
+  depends:
+  - libarrow-acero 18.1.0.*
+  - libarrow-dataset 18.1.0.*
+  - libarrow-substrait 18.1.0.*
+  - libparquet 18.1.0.*
+  - pyarrow-core 18.1.0 *_0_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25322
+  timestamp: 1732611121491
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-18.1.0-py311he04fa90_0_cpu.conda
+  sha256: 4563e2d4f41b3874b89e8e2bdebf42588c1c819bd050ae858200f60e30bae860
+  md5: 09b4a27f615d22f194466d8c274ef13e
+  depends:
+  - __osx >=11.0
+  - libarrow 18.1.0.* *cpu
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy >=1.21,<3
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3974075
+  timestamp: 1732611073316
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.3.2-py311hab620ed_0.conda
+  sha256: b3990d45325f4d2716d933b1fff821b69b530889d138d6caa246a3ef3d5aaf51
+  md5: 6968e48654cd85960526f4e6ed24996c
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 479023
+  timestamp: 1732987380000
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.3.2-py311hab620ed_0.conda
+  sha256: eaa25ed388d010b298baa11dc62aebf37bb2d8e655b2f8ad0d5df0d1dde25dfd
+  md5: b8302e3047685d0c0721fb65e50039da
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 10.3.2.*
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 384939
+  timestamp: 1733168978481
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.10-hc51fdd5_3_cpython.conda
+  sha256: 95a2c487176867ded825e23eab1e581398f75c5323da0cb7577c3cff3d2f955b
+  md5: 2a47a0061d7d3030e45b66d23f01d101
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 14598065
+  timestamp: 1729042279642
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
+  sha256: adc05729b7e0aca7b436e60a86f10822a92185dfcb48d66d6444e3629d3a1f6a
+  md5: 3b855e3734344134cb56c410f729c340
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6308
+  timestamp: 1723823096865
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h460d6c5_1.conda
+  sha256: 9ae182eef4e96a7c2f46cc9add19496276612663e17429500432631dce31a831
+  md5: d32590e7bd388f18b036c6fc402a0cb1
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 192321
+  timestamp: 1725456528007
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.0-py311h730b646_3.conda
+  sha256: 7e75589d9c3723ecf314435f15a7b486cebafa89ebf00bb616354e37587dc7ae
+  md5: b6f3e527de0c0384cd78cfa779bd6ddf
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365841
+  timestamp: 1728642472021
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+  sha256: 873ac689484262a51fd79bc6103c1a1bedbf524924d7f0088fb80703042805e4
+  md5: 6483b1f59526e05d7d894e466b5b6924
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: LicenseRef-Qhull
+  size: 516376
+  timestamp: 1720814307311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2024.07.02-hcd0e937_1.conda
+  sha256: eebddde6cb10b146507810b701ef6df122d5309cd5151a39d0828aa44dc53725
+  md5: 19e29f2ccc9168eb0a39dc40c04c0e21
+  depends:
+  - libre2-11 2024.07.02 h2348fd5_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26860
+  timestamp: 1728779123653
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+  sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
+  md5: 8cbb776a2f641b943d413b3e19df71f4
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 250351
+  timestamp: 1679532511311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.22.0-py311h3ff9189_0.conda
+  sha256: 7fe72c70456ca156560669b863190e0b517c67dc04cfd427c35df707ba456096
+  md5: 09e0e8ba0dc31299d3e2e35f8ab691c9
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 326061
+  timestamp: 1733233366821
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.1-py311hf1db568_1.conda
+  sha256: 082a72e5f197aefb59e9f40176df835407e5f71ec832541ba14d4326d3686552
+  md5: 1163490da89fd85d00d29b4d4be7cf0c
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15242433
+  timestamp: 1729481958579
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
+  sha256: cb7a9440241c6092e0f1c795fdca149c4767023e783eaf9cfebc501f906b4897
+  md5: 69d0f9694f3294418ee935da3d5f7272
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35708
+  timestamp: 1720003794374
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+  sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
+  md5: b50a57ba89c32b62428b71a875291c9b
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3145523
+  timestamp: 1699202432999
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.2-py311h917b07b_0.conda
+  sha256: 80b79a7d4ed8e16019b8c634cca66935d18fc98be358c76a6ead8c611306ee14
+  md5: 183b74c576dc7f920dae168997dbd1dd
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 858954
+  timestamp: 1732616142626
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-15.1.0-py311hae2e1ce_1.conda
+  sha256: e4b1dcf79f4d4656e538ba24c845350b147d0d9f066771f8b3f396bea828b965
+  md5: ade7687026adce6296650b21e7463758
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 372655
+  timestamp: 1729704815727
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
+  sha256: 7113618021cf6c80831a429b2ebb9d639f3c43cf7fe2257d235dc6ae0ab43289
+  md5: 7e0125f8fb619620a0011dc9297e2493
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 13515
+  timestamp: 1727034783560
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+  sha256: 9939a166d780700d81023546759102b33fdc2c5f11ef09f5f66c77210fd334c8
+  md5: 77c447f48cab5d3a15ac224edb86a968
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 18487
+  timestamp: 1727795205022
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+  sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
+  md5: 39c6b54e94014701dd157f4f576ed211
+  license: LGPL-2.1 and GPL-2.0
+  size: 235693
+  timestamp: 1660346961024
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+  sha256: 93181a04ba8cfecfdfb162fc958436d868cc37db504c58078eab4c1a3e57fbb7
+  md5: 4bb3f014845110883a3c5ee811fd84b4
+  license: MIT
+  license_family: MIT
+  size: 88016
+  timestamp: 1641347076660
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.18.0-py311h917b07b_0.conda
+  sha256: d21aeb264716c1f7bfb0f73f489621eebf8d28d951f3885a90ba97369eb2184d
+  md5: 93d15c4b23a94293511460afeda65445
+  depends:
+  - __osx >=11.0
+  - idna >=2.0
+  - multidict >=4.0
+  - propcache >=0.2.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 142545
+  timestamp: 1732221235765
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-hc1bb282_7.conda
+  sha256: 9e585569fe2e7d3bea71972cd4b9f06b1a7ab8fa7c5139f92a31cbceecf25a8a
+  md5: f7e6b65943cb73bce0143737fded08f1
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libcxx >=18
+  - libsodium >=1.0.20,<1.0.21.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 281565
+  timestamp: 1731585108039
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py311ha60cc69_1.conda
+  sha256: d2f2f1a408e2353fc61d2bf064313270be2260ee212fe827dcf3cfd3754f1354
+  md5: 29d320d6450b2948740a9be3761b2e9d
+  depends:
+  - __osx >=11.0
+  - cffi >=1.11
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 332271
+  timestamp: 1725305847224
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+  sha256: 2d4fd1ff7ee79cd954ca8e81abf11d9d49954dd1fef80f27289e2402ae9c2e09
+  md5: d96942c06c3e84bfcc5efb038724a7fd
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 405089
+  timestamp: 1714723101397
+- conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
+  sha256: 1a62cd1f215fe0902e7004089693a78347a30ad687781dfda2289cab000e652d
+  md5: 37e16618af5c4851a3f3d66dd0e11141
+  depends:
+  - libgomp >=7.5.0
+  - libwinpthread >=12.0.0.r2.ggc561118da
+  constrains:
+  - openmp_impl 9999
+  - msys2-conda-epoch <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49468
+  timestamp: 1718213032772
+- conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.11.9-py311h5082efb_0.conda
+  sha256: 200f43e3823f62ec75f1ecb31074a087bc70e1333bce648f677c4965d70ca75e
+  md5: 4f285d6694c650fd5b0d354166488d2a
+  depends:
+  - aiohappyeyeballs >=2.3.0
+  - aiosignal >=1.1.2
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - multidict >=4.5,<7.0
+  - propcache >=0.2.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yarl >=1.17.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  size: 862685
+  timestamp: 1733125213743
+- conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311he736701_5.conda
+  sha256: 8bbce5e61e012a06e248f58bb675fdc82ba2900c78590696d185150fb9cea91f
+  md5: 8917bf795c40ec1839ed9d0ab3ad9735
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 34883
+  timestamp: 1725357113431
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.8.0-h6c5491b_10.conda
+  sha256: f92d43e36d271194f027a49c5bd91c7f3eab0406a83734b0a2fee75e0c914546
+  md5: 78eef4154032e557c81bcd12640ee048
+  depends:
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 103029
+  timestamp: 1731733929676
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.8.0-hb414858_2.conda
+  sha256: d2327c924931550a05ab902b4aedbcf5105b581839bade4db7fba6e73dd63214
+  md5: fd898cb8119bf3ad009762df2d8068b0
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 46852
+  timestamp: 1731679007675
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.10.3-h2466b09_0.conda
+  sha256: 27c094c554a84389f0f2430e7397a1b33d558b035bbaf188877f635dbb9b26e6
+  md5: 49b50b5f5074259e9a62c0c271a24d98
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 234894
+  timestamp: 1731567453718
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.3.0-hb414858_2.conda
+  sha256: 2f8c79b24a1396ed2754379bfbe1595b50e7cf306962060b80084b46b682887f
+  md5: beb319c4aeb7de9f6cacf533ebbae94c
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 22528
+  timestamp: 1731679090015
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.5.0-hab6af6e_7.conda
+  sha256: 39fe165d6616e09d25c07a85560ec414a0b0b19c1880e0df52283196cf44896f
+  md5: 1e81f2ecfb25d4a84b4d8fa6067924e5
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 54641
+  timestamp: 1731714676039
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.9.1-hab0f966_2.conda
+  sha256: 81c93d2b8c951c18509ff1359505d01740f77865c9bef46c457607f0ca8c76ad
+  md5: e715a008f534917e93ed2238546b68b0
+  depends:
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-compression >=0.3.0,<0.3.1.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 182315
+  timestamp: 1731714924335
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.15.2-hef77f12_2.conda
+  sha256: 8c02308ad64dcccb85ea55b6fdfb6b6de4b5710a564d24faf64655c4029f4008
+  md5: ac3ab925a1345a6957d5d217fd2d9469
+  depends:
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 160495
+  timestamp: 1731702920182
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.11.0-hbfeb708_8.conda
+  sha256: c1462d6b1de9bdaf6b3233e70cdf2e49b481da9bdf91c0c3f5fcf5ed55f3ca18
+  md5: e125209fbb06e56a208a75f8aae48c00
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 186691
+  timestamp: 1731735208782
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.7.3-h6108ab3_0.conda
+  sha256: 42409678927e0089543d4639ada00c1c166d77e6135a3b3c552b6a491512af8e
+  md5: 9090f1226825b89de99e2be2f929060b
+  depends:
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 109177
+  timestamp: 1733099183920
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.2.1-hb414858_1.conda
+  sha256: 6130e79950efe49460dcedc8a4845a274ed572e55667b66c815dc771f63f9eca
+  md5: 0e3318644bfcc9c42cbde728d7bb8e08
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 55188
+  timestamp: 1731687352327
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.2.2-hb414858_1.conda
+  sha256: f7d0c5c9bd65cca937ed53425800d7376e89bdac9f82fcef44698e6707784cae
+  md5: 0cb03655a7cf5b4ad9e0cd8d5a18b21d
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 91905
+  timestamp: 1731687613902
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.29.6-h94c4a24_1.conda
+  sha256: c7c20548632a2473d6671e5f316d43f09b4b12a3680e4fade8ac6e0a8980c3e8
+  md5: 4ca522ecc81d38d5a79148eed7911d9d
+  depends:
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-mqtt >=0.11.0,<0.11.1.0a0
+  - aws-c-s3 >=0.7.3,<0.7.4.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 262336
+  timestamp: 1733151403513
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.449-h0ed5b37_4.conda
+  sha256: 0057120a9a651d5a50f9fbd4a6404a5aec22885f298ec4da61a1bc1468891f0e
+  md5: da1b9b48262754a5ecf1cf494bb6c4d9
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 2845768
+  timestamp: 1732813377812
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-h2466b09_2.conda
+  sha256: d8fd7d1b446706776117d2dcad1c0289b9f5e1521cb13405173bad38568dd252
+  md5: 378f1c9421775dfe644731cb121c8979
+  depends:
+  - brotli-bin 1.1.0 h2466b09_2
+  - libbrotlidec 1.1.0 h2466b09_2
+  - libbrotlienc 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 19697
+  timestamp: 1725268293988
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-h2466b09_2.conda
+  sha256: f3bf2893613540ac256c68f211861c4de618d96291719e32178d894114ac2bc2
+  md5: d22534a9be5771fc58eb7564947f669d
+  depends:
+  - libbrotlidec 1.1.0 h2466b09_2
+  - libbrotlienc 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 20837
+  timestamp: 1725268270219
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311hda3d55a_2.conda
+  sha256: aa3ac5dbf63db2f145235708973c626c2189ee4040d769fdf0076286fa45dc26
+  md5: a0ea2839841a06740a1c110ba3317b42
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  license: MIT
+  license_family: MIT
+  size: 322114
+  timestamp: 1725268368720
+- conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+  sha256: 35a5dad92e88fdd7fc405e864ec239486f4f31eec229e31686e61a140a8e573b
+  md5: 276e7ffe9ffe39688abc665ef0f45596
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 54927
+  timestamp: 1720974860185
+- conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.34.3-h2466b09_1.conda
+  sha256: 535b9dd013b8726b5147ca202f509308960ef0d050bce4872e16c0d76962147c
+  md5: f8413bb7fb62f7bdc2545c9a06937790
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 192376
+  timestamp: 1732447407728
+- conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
+  sha256: 0fcac3a7ffcc556649e034a1802aedf795e64227eaa7194d207b01eaf26454c4
+  md5: 4c4fd67c18619be5aa65dc5b6c72e490
+  license: ISC
+  size: 158773
+  timestamp: 1725019107649
+- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py311he736701_0.conda
+  sha256: 9689fbd8a31fdf273f826601e90146006f6631619767a67955048c7ad7798a1d
+  md5: e1c69be23bd05471a6c623e91680ad59
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 297627
+  timestamp: 1725561079708
+- conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.1-py311h3257749_0.conda
+  sha256: dbb0c161dd75e72e66c13f31715941adb094a45471016f89d6a1cfab30967ba8
+  md5: 91d8504588e1b3c77e605503e5a1bc11
+  depends:
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 216693
+  timestamp: 1731429286140
+- conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.0.0-py311he736701_1.conda
+  sha256: e8f2027af0cf22feebad76ccbbb3139437fd07b5c6c35497b45e8de2d1f636ea
+  md5: b0845b4087a24616d2fecc716397b3f6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 322558
+  timestamp: 1728335601937
+- conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.9-py311hda3d55a_0.conda
+  sha256: 04db57c1b8fa22d17399c8df03e0d62b365a1315318b59009980672762a6ed87
+  md5: 0f21eefbe9b04632c4e0e17636be84d3
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 3623627
+  timestamp: 1732237179740
+- conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.55.1-py311h5082efb_0.conda
+  sha256: 8b8b119d0e33998326d0cd67ff191ed61ab34e17937970fc40cd23156a88b8d1
+  md5: 4d05b5fd390be4220d5820e1d98bd870
+  depends:
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - unicodedata2 >=15.1.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 2504673
+  timestamp: 1733242460211
+- conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+  sha256: 2c53ee8879e05e149a9e525481d36adfd660a6abda26fd731376fa64ff03e728
+  md5: 3761b23693f768dc75a8fd0a73ca053f
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-only OR FTL
+  size: 510306
+  timestamp: 1694616398888
+- conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.5.0-py311he736701_0.conda
+  sha256: 2a3975f8a179d3b58ea1818753a4920ae6e1188c6e8239107f076bde149be569
+  md5: 228d16664f7938586d813a1df2637934
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 54934
+  timestamp: 1729699828246
+- conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+  sha256: 0fd2b0b84c854029041b0ede8f4c2369242ee92acc0092f8407b1fe9238a8209
+  md5: 2d89243bfb53652c182a7c73182cce4f
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 1852356
+  timestamp: 1723739573141
+- conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_1.conda
+  sha256: 9a667eeae67936e710ff69ee7ce0e784d6052eeba9670b268c565a55178098c4
+  md5: 943f7fab631e12750641efd7279a268c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42891
+  timestamp: 1725303340467
+- conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.7-py311h3257749_0.conda
+  sha256: a2079e13d1345a5dd61df6be933e828e805051256e7260009ba93fce55aebd75
+  md5: 18fd1ac3d79a8d6550eaea5ceaa00036
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55867
+  timestamp: 1725459681416
+- conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+  sha256: 18e8b3430d7d232dad132f574268f56b3eb1a19431d6d5de8c53c29e6c18fa81
+  md5: 31aec030344e962fbd7dbbbbd68e60a9
+  depends:
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 712034
+  timestamp: 1719463874284
+- conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
+  sha256: f9fd9e80e46358a57d9bb97b1e37a03da4022143b019aa3c4476d8a7795de290
+  md5: d3592435917b62a8becff3a60db674f6
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 507632
+  timestamp: 1701648249706
+- conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+  sha256: f4f39d7f6a2f9b407f8fb567a6c25755270421731d70f0ff331f5de4fa367488
+  md5: 1900cb3cab5055833cfddb0ba233b074
+  depends:
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30037
+  license: Apache-2.0
+  license_family: Apache
+  size: 194365
+  timestamp: 1657977692274
+- conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_he0c23c2_1.conda
+  sha256: 52ff148dee1871ef1d5c298bae20309707e866b44714a0a333a5ed2cf9a38832
+  md5: 3f59a73b07a05530b252ecb07dd882b9
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1777570
+  timestamp: 1727296115119
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-18.1.0-h0ea94f9_2_cpu.conda
+  sha256: 212996b0a7efe74c01f9a045f4db2253175ad95dee088fc2cb8c2944f8df9ab0
+  md5: 0fc0ae2ddd001a52d6715ba88c651e8e
+  depends:
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - aws-sdk-cpp >=1.11.449,<1.11.450.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgoogle-cloud >=2.31.0,<2.32.0a0
+  - libgoogle-cloud-storage >=2.31.0,<2.32.0a0
+  - libre2-11 >=2024.7.2
+  - libutf8proc >=2.9.0,<2.10.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.3,<2.0.4.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - parquet-cpp <0.0a0
+  - arrow-cpp <0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5248470
+  timestamp: 1732950405896
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-18.1.0-hb6457b2_2_cpu.conda
+  sha256: e17750b6fe6c863b1f2496e5ebf5c181416a0a40526efd9072cd200b44e7d587
+  md5: b21ccd9073c96c689db3e620ffa15cc4
+  depends:
+  - libarrow 18.1.0 h0ea94f9_2_cpu
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  license: Apache-2.0
+  license_family: APACHE
+  size: 446442
+  timestamp: 1732950538361
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-18.1.0-hb6457b2_2_cpu.conda
+  sha256: 6fece2e5e0480839ce1408769ec1dbb72ba7220388a65b37ba4cdc8cc0430f31
+  md5: a33883871abd3033d5ad4096d977131a
+  depends:
+  - libarrow 18.1.0 h0ea94f9_2_cpu
+  - libarrow-acero 18.1.0 hb6457b2_2_cpu
+  - libparquet 18.1.0 he61daf8_2_cpu
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  license: Apache-2.0
+  license_family: APACHE
+  size: 433194
+  timestamp: 1732951105863
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-18.1.0-h30d554c_2_cpu.conda
+  sha256: c936be773ff3c3d87a521e8e53ff2f631474c3a9714a981027236853003c984f
+  md5: ee7c83f7afe66b6ce158632e70c36be2
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 18.1.0 h0ea94f9_2_cpu
+  - libarrow-acero 18.1.0 hb6457b2_2_cpu
+  - libarrow-dataset 18.1.0 hb6457b2_2_cpu
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  license: Apache-2.0
+  license_family: APACHE
+  size: 364194
+  timestamp: 1732951352741
+- conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_mkl.conda
+  sha256: 5468bb91c44b41ce060bbd997c797b2f91e2b7ce91a7cbf4ddf7e7b734a8dc98
+  md5: 499208e81242efb6e5abc7366c91c816
+  depends:
+  - mkl 2024.2.2 h66d3029_14
+  constrains:
+  - blas * mkl
+  - libcblas 3.9.0 25_win64_mkl
+  - liblapack 3.9.0 25_win64_mkl
+  - liblapacke 3.9.0 25_win64_mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3736641
+  timestamp: 1729643534444
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-h2466b09_2.conda
+  sha256: 33e8851c6cc8e2d93059792cd65445bfe6be47e4782f826f01593898ec95764c
+  md5: f7dc9a8f21d74eab46456df301da2972
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 70526
+  timestamp: 1725268159739
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-h2466b09_2.conda
+  sha256: 234fc92f4c4f1cf22f6464b2b15bfc872fa583c74bf3ab9539ff38892c43612f
+  md5: 9bae75ce723fa34e98e239d21d752a7e
+  depends:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 32685
+  timestamp: 1725268208844
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-h2466b09_2.conda
+  sha256: 3d0dd7ef505962f107b7ea8f894e0b3dd01bf46852b362c8a7fc136b039bc9e1
+  md5: 85741a24d97954a991e55e34bc55990b
+  depends:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 245929
+  timestamp: 1725268238259
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_mkl.conda
+  sha256: 21528cdfe67dafdb2d21925515a167f13963e002c2b6d06d68984767f731850c
+  md5: 3ed189ba03a9888a8013aaee0d67c49d
+  depends:
+  - libblas 3.9.0 25_win64_mkl
+  constrains:
+  - blas * mkl
+  - liblapack 3.9.0 25_win64_mkl
+  - liblapacke 3.9.0 25_win64_mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3732258
+  timestamp: 1729643561581
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+  sha256: 75e60fbe436ba8a11c170c89af5213e8bec0418f88b7771ab7e3d9710b70c54e
+  md5: cd4cc2d0c610c8cb5419ccc979f2d6ce
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25694
+  timestamp: 1633684287072
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
+  sha256: dfbac497c4fee74f67391f9c4a40cab559468b7d04ff9fad4b404a26b5e1d5b8
+  md5: 7ead800e22ff7b4bccb73e42a8f7a0f4
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: curl
+  license_family: MIT
+  size: 342388
+  timestamp: 1726660508261
+- conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.22-h2466b09_0.conda
+  sha256: 579c634b7de8869cb1d76eccd4c032dc275d5a017212128502ea4dc828a5b361
+  md5: a3439ce12d4e3cd887270d9436f9a4c8
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 155506
+  timestamp: 1728177485361
+- conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+  sha256: af03882afb7a7135288becf340c2f0cf8aa8221138a9a7b108aaeb308a486da1
+  md5: 25efbd786caceef438be46da78a7b5ef
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 410555
+  timestamp: 1685726568668
+- conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.4-he0c23c2_0.conda
+  sha256: 0c0447bf20d1013d5603499de93a16b6faa92d7ead870d96305c0f065b6a5a12
+  md5: eb383771c680aa792feb529eaf9df82f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 139068
+  timestamp: 1730967442102
+- conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+  sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
+  md5: 2c96d1b6915b408893f9472569dee135
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 42063
+  timestamp: 1636489106777
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-14.2.0-h1383e82_1.conda
+  sha256: ef840e797714440bb10b69446d815966fff41fdac79f79c4e19c475d81cd375d
+  md5: 75fdd34824997a0f9950a703b15d8ac5
+  depends:
+  - _openmp_mutex >=4.5
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - libgcc-ng ==14.2.0=*_1
+  - libgomp 14.2.0 h1383e82_1
+  - msys2-conda-epoch <0.0a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 666386
+  timestamp: 1729089506769
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-14.2.0-h1383e82_1.conda
+  sha256: d8739b834608f35775209b032f0c2be752ef187863c7ec847afcebe2f681be4e
+  md5: 9e2d4d1214df6f21cba12f6eff4972f9
+  depends:
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - msys2-conda-epoch <0.0a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 524249
+  timestamp: 1729089441747
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.31.0-h07d40e7_0.conda
+  sha256: 40d5aa338c0aca8e619c777cc552d19f5810f1408b695c9de8f1dc7e279d8550
+  md5: 94320a551af951938e22e9b5dbd60b50
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libgoogle-cloud 2.31.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 14474
+  timestamp: 1731122599862
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.31.0-he5eb982_0.conda
+  sha256: 0deaba4051d1caec99f2e76bad65979007a01e912eecf8bdd895b5bddb96a085
+  md5: 5de1d1089bc7d21b2cbc7273a0c2022d
+  depends:
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libgoogle-cloud 2.31.0 h07d40e7_0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 14355
+  timestamp: 1731122772886
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.67.1-h7aa3b8a_0.conda
+  sha256: 986dafe9c3219e88a82389e679a2804d4256aa9ddaead193f91b7d6b4ef89ea1
+  md5: daad5d4a1c24c1afe748afbb83377e43
+  depends:
+  - c-ares >=1.34.2,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libre2-11 >=2024.7.2
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - re2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - grpc-cpp =1.67.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 17167461
+  timestamp: 1730236510917
+- conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.2-default_ha69328c_1001.conda
+  sha256: 850e255997f538d5fb6ed651321141155a33bb781d43d326fc4ff62114dd2842
+  md5: b87a0ac5ab6495d8225db5dc72dd21cd
+  depends:
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - libxml2 >=2.13.4,<2.14.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2390021
+  timestamp: 1731375651179
+- conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+  sha256: 5f844dd19b046d43174ad80c6ea75b5d504020e3b63cfbc4ace97b8730d35c7b
+  md5: e1eb10b1cca179f2baa3601e4efc8712
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-only
+  size: 636146
+  timestamp: 1702682547199
+- conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+  sha256: 4e7808e3098b4b4ed7e287f63bb24f9045cc4d95bfd39f0db870fc2837d74dff
+  md5: 3f1b948619c45b1ca714d60c7389092c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 822966
+  timestamp: 1694475223854
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_mkl.conda
+  sha256: 98c13a28596389539abe3f608c6fbd2826df47671f77c58a331df878c6140c53
+  md5: f716ef84564c574e8e74ae725f5d5f93
+  depends:
+  - libblas 3.9.0 25_win64_mkl
+  constrains:
+  - blas * mkl
+  - libcblas 3.9.0 25_win64_mkl
+  - liblapacke 3.9.0 25_win64_mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3736560
+  timestamp: 1729643588182
+- conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-18.1.0-he61daf8_2_cpu.conda
+  sha256: 22f314491e7f9fa3241e2ed721184c722f8b7c3bc404927385e1e30cba3d66ee
+  md5: a0b4b350dba8924ced639a629c5e3cb4
+  depends:
+  - libarrow 18.1.0 h0ea94f9_2_cpu
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.4.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  license: Apache-2.0
+  license_family: APACHE
+  size: 811713
+  timestamp: 1732950983570
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
+  sha256: 0d3d6ff9225f6918ac225e3839c0d91e5af1da08a4ebf59cac1bfd86018db945
+  md5: 639ac6b55a40aa5de7b8c1b4d78f9e81
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: zlib-acknowledgement
+  size: 348933
+  timestamp: 1726235196095
+- conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.28.2-hcaed137_0.conda
+  sha256: 798c6675fb709ceaa6a9bd83e9cffe06bc98e83f519c7d7d881243d2e6d0c34d
+  md5: 97c6d2f83edd7b400a22660e2a4d1488
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6033581
+  timestamp: 1728565880841
+- conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2024.07.02-h4eb7d71_1.conda
+  sha256: 39908d18620d48406ea3492bf111eface5b3a88c1a2d166c6d513b03f450df5d
+  md5: d8dbfb066c8e3e85439687613d32057d
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 260860
+  timestamp: 1728779502416
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+  sha256: 7bcb3edccea30f711b6be9601e083ecf4f435b9407d70fc48fbcf9e5d69a0fc6
+  md5: 198bb594f202b205c7d18b936fa4524f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: ISC
+  size: 202344
+  timestamp: 1716828757533
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.0-h2466b09_1.conda
+  sha256: 3342d6fe787f5830f7e8466d9c65c914bfd8d67220fb5673041b338cbba47afe
+  md5: 5b1f36012cc3d09c4eb9f24ad0e2c379
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 892175
+  timestamp: 1730208431651
+- conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-he619c9f_0.conda
+  sha256: 4b3256bd2b4e4b3183005d3bd8826d651eccd1a4740b70625afa2b7e7123d191
+  md5: af0cbf037dd614c34399b3b3e568c557
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 291889
+  timestamp: 1732349796504
+- conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.21.0-hbe90ef8_0.conda
+  sha256: 81ca4873ba09055c307f8777fb7d967b5c26291f38095785ae52caed75946488
+  md5: 7699570e1f97de7001a7107aabf2d677
+  depends:
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 633857
+  timestamp: 1727206429954
+- conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hfc51747_1.conda
+  sha256: 902cb9f7f54d17dcfd54ce050b1ce2bc944b9bbd1748913342c2ea1e1140f8bb
+  md5: eac317ed1cc6b9c0af0c27297e364665
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.22,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 978865
+  timestamp: 1728232594877
+- conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.9.0-h2466b09_1.conda
+  sha256: 19386d93341d8fa3800033a7555ab00b9fef1db1dbd0a50b6e547b532860b603
+  md5: 6f35a14d54f6fe4d013005cf56031842
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 84392
+  timestamp: 1732868780863
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+  sha256: d0ca51cb1de9192be9a3238e71fbcca5a535619c499c4f4c9b2ed41c14d36770
+  md5: abd61d0ab127ec5cd68f62c2969e6f34
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 274359
+  timestamp: 1713200524021
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_8.conda
+  sha256: 6d5e158813ab8d553fbb0fedd0abe7bf92970b0be3a9ddf12da0f6cbad78f506
+  md5: 03cccbba200ee0523bde1f3dad60b1f3
+  depends:
+  - ucrt
+  constrains:
+  - pthreads-win32 <0.0a0
+  - msys2-conda-epoch <0.0a0
+  license: MIT AND BSD-3-Clause-Clear
+  size: 35433
+  timestamp: 1724681489463
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
+  sha256: 08dec73df0e161c96765468847298a420933a36bc4f09b50e062df8793290737
+  md5: a69bbf778a462da324489976c84cfc8c
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - pthread-stubs
+  - ucrt >=10.0.20348.0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 1208687
+  timestamp: 1727279378819
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.5-h442d1da_0.conda
+  sha256: 020466b17c143190bd5a6540be2ceef4c1f8d514408bd5f0adaafcd9d0057b5c
+  md5: 1fbabbec60a3c7c519a5973b06c3b2f4
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1511585
+  timestamp: 1731489892312
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+  sha256: ba945c6493449bed0e6e29883c4943817f7c79cbff52b83360f7b341277c6402
+  md5: 41fbfac52c601159df6c01f875de31b9
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 55476
+  timestamp: 1727963768015
+- conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.43.0-py311h7deaa30_1.conda
+  sha256: 7df8480fc6c32b6f5e0b6f928332759559e9c2d6c43f94e6b51ea5d2129442a9
+  md5: c59d60615d5c5a9e9539a106478d332c
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - vs2015_runtime
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17126019
+  timestamp: 1725305442517
+- conda: https://conda.anaconda.org/conda-forge/win-64/lz4-4.3.3-py311h8b5e962_1.conda
+  sha256: 24bb321c5da9660f56759000001a6f227780348a21098164f55049b58ac78a11
+  md5: 8672eca07a3b500a9aa0483c43742f82
+  depends:
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 76663
+  timestamp: 1725090098178
+- conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+  sha256: a0954b4b1590735ea5f3d0f4579c3883f8ac837387afd5b398b241fda85124ab
+  md5: e34720eb20a33fc3bfb8451dd837ab7a
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134235
+  timestamp: 1674728465431
+- conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py311h5082efb_1.conda
+  sha256: 6f756e13ccf1a521d3960bd3cadddf564e013e210eaeced411c5259f070da08e
+  md5: c1f2ddad665323278952a453912dc3bd
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28238
+  timestamp: 1733220208800
+- conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.3-py311h8f1b1e4_0.conda
+  sha256: 624ca657eea90a7cbb19c49b8bbb8d8e4d6e233f6e59fd10f7032623e2a7bb21
+  md5: c6e27df155392af0f22217192f8aebdd
+  depends:
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 7841204
+  timestamp: 1733177818555
+- conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_14.conda
+  sha256: 098ba4a3cb82f627bc79dc0ab1111b44859c9ef4aaa8d75ce043bce107770cb3
+  md5: f011e7cc21918dc9d1efe0209e27fa16
+  depends:
+  - intel-openmp 2024.*
+  - tbb 2021.*
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 103019089
+  timestamp: 1727378392081
+- conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.0-py311h3257749_0.conda
+  sha256: 4e6a7979b434308ce5588970cb613952e3340bb2f9e63aaad7e5069ef1f08d1d
+  md5: 36562593204b081d0da8a8bfabfb278b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 89472
+  timestamp: 1725975909671
+- conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.1.0-py311h5082efb_1.conda
+  sha256: 2e56ad9c72a9a757dc192b16efdc36681a5a963ca2bc4b798b5ddc4a271dbe7e
+  md5: 43817f67897069a44137321949264aab
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 57534
+  timestamp: 1729066160777
+- conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.60.0-py311h0673bce_0.conda
+  sha256: b3359607051ec34c3eeb90447ece326822b6883882cf0e425cb1108dbcaebdc9
+  md5: 5d6eb2107dd921d651e46d059a82ab95
+  depends:
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - cudatoolkit >=11.2
+  - libopenblas !=0.3.6
+  - cuda-version >=11.2
+  - tbb >=2021.6.0
+  - scipy >=1.0
+  - cuda-python >=11.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5807308
+  timestamp: 1718888792863
+- conda: https://conda.anaconda.org/conda-forge/win-64/numcodecs-0.14.1-py311hcf9f919_0.conda
+  sha256: 50dc848841027218ccb52e87948e06087e434fff867cfd5ea19a31b3aebd61c8
+  md5: 2213faefca7125f0cd8f6bca9a835032
+  depends:
+  - msgpack-python
+  - numpy >=1.19,<3
+  - numpy >=1.24
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 552380
+  timestamp: 1732244009988
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.0.2-py311h35ffc71_1.conda
+  sha256: 22d8f73e0fd6477f425e6b22a2db15af73f0ce4775ae7acb1ce1b06d666256a7
+  md5: 4bb6bca8e8c20873b9036643fff8af3b
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7501226
+  timestamp: 1732315481415
+- conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
+  sha256: dda71cbe094234ab208f3552dec1f4ca6f2e614175d010808d6cb66ecf0bc753
+  md5: 7e7099ad94ac3b599808950cec30ad4e
+  depends:
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 237974
+  timestamp: 1709159764160
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.4.0-h2466b09_0.conda
+  sha256: e03045a0837e01ff5c75e9273a572553e7522290799807f918c917a9826a6484
+  md5: d0d805d9b5524a14efb51b3bff965e83
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 8491156
+  timestamp: 1731379715927
+- conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.3-h34659fe_0.conda
+  sha256: 8baa71790c9899bd7bc0d028ec0dab8180330cb12ecd6600d2b7e0cb78a79a2c
+  md5: 7d0f9831258c59c73b1dcf00b05e8785
+  depends:
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 896875
+  timestamp: 1731665181736
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py311hcf9f919_1.conda
+  sha256: f5477bf3a2b7919481009ce87212d7bbd16c61a5bb05c692a7c336fb45646534
+  md5: 5965b8926efba14e6fde98cc8713c083
+  depends:
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14587131
+  timestamp: 1726879538736
+- conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.0.0-py311h4fbf6a9_0.conda
+  sha256: 0d38ec638a5b266adb894f6fe4c874b46b98180a984007bf40cb030a22e8cc1e
+  md5: 44897ebc5704d3de316af26740325513
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: HPND
+  size: 42185657
+  timestamp: 1729066269713
+- conda: https://conda.anaconda.org/conda-forge/win-64/propcache-0.2.0-py311he736701_2.conda
+  sha256: a9e90e6fd386ad9effc8e7c7e119ef15a913acc9c65897f649f32f61464ebcc9
+  md5: cf6d45e5a2054bc666c0d7f9a124ee20
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 50352
+  timestamp: 1728546232937
+- conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py311he736701_0.conda
+  sha256: 303c988247c4b1638f1cc90cd40465f5c74ca0ecfd83114033af637654dc2b6b
+  md5: 307267e6a028bca3382d98e06a372ebf
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 521434
+  timestamp: 1729847606018
+- conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
+  sha256: 7e446bafb4d692792310ed022fe284e848c6a868c861655a92435af7368bae7b
+  md5: 3c8f2573569bb816483e5cf57efbbe29
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 9389
+  timestamp: 1726802555076
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.1.0-py311h1ea47a8_0.conda
+  sha256: 78e88b5ee2d80622091e24ba74d35f425060648735f5156ac388b1fd87169958
+  md5: 3577ae265ed894dc105829e4e0a4f40c
+  depends:
+  - libarrow-acero 18.1.0.*
+  - libarrow-dataset 18.1.0.*
+  - libarrow-substrait 18.1.0.*
+  - libparquet 18.1.0.*
+  - pyarrow-core 18.1.0 *_0_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25662
+  timestamp: 1732651904499
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.1.0-py311hdea38fa_0_cpu.conda
+  sha256: 436fc748241421e39ea72c8fcfebdad20c5c39a7dfc1d9c16dda03b97b7c317d
+  md5: 3603acae16694ed5cd689e6980eb0703
+  depends:
+  - libarrow 18.1.0.* *cpu
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy >=1.21,<3
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3498372
+  timestamp: 1732651886220
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.10-hce54a09_3_cpython.conda
+  sha256: 3931c546219d069918389e4dbe12057af4cc68a1060577a04014c6b5fc618aa0
+  md5: 5d54d429c0eb2273d1cc69763de6edaf
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 18206702
+  timestamp: 1729041779073
+- conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-5_cp311.conda
+  sha256: 9b210e5807dd9c9ed71ff192a95f1872da597ddd10e7cefec93a922fe22e598a
+  md5: 895b873644c11ccc0ab7dba2d8513ae6
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6707
+  timestamp: 1723823225752
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-307-py311hda3d55a_3.conda
+  sha256: 78a4ede098bbc122a3dff4e0e27255e30b236101818e8f499779c89670c58cd6
+  md5: 1bc10dbe3b8d03071070c962a2bdf65f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 6023110
+  timestamp: 1728636767562
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.14-py311hda3d55a_0.conda
+  sha256: 337097e3f3b71f782c43fb702893f86f080e140da467415dcaf039a7fbb8e551
+  md5: 64553b300529aa8987f6ca92c914c844
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 210973
+  timestamp: 1729202625177
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311he736701_1.conda
+  sha256: 86608f1b4f6b1819a74b6b1344c34304745fd7e84bfc9900269f57cf28178d31
+  md5: d0c5f3c595039890be0c9af47d23b9ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 187901
+  timestamp: 1725456808581
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.2.0-py311h484c95c_3.conda
+  sha256: 4d3fc4cfac284efb83a903601586cc6ee18fb556d4bf84d3bd66af76517c463e
+  md5: 4836b00658e11b466b823216f6df2424
+  depends:
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 371084
+  timestamp: 1728642713666
+- conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+  sha256: 887d53486a37bd870da62b8fa2ebe3993f912ad04bd755e7ed7c47ced97cbaa8
+  md5: 854fbdff64b572b5c0b470f334d34c11
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LicenseRef-Qhull
+  size: 1377020
+  timestamp: 1720814433486
+- conda: https://conda.anaconda.org/conda-forge/win-64/re2-2024.07.02-hd3b24a8_1.conda
+  sha256: 5ac1c50d731c323bb52c78113792a71c5f8f060e5767c0a202120a948e0fc85b
+  md5: b4abdc84c969587219e7e759116a3e8b
+  depends:
+  - libre2-11 2024.07.02 h4eb7d71_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 214858
+  timestamp: 1728779526745
+- conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.22.0-py311h533ab2d_0.conda
+  sha256: 015090a6fa3426e0226b8f4e7f1eaa4f568034b87767efd236ff3b6c2dad8cbd
+  md5: 087ac071acf52b17734136fd526aab98
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 222047
+  timestamp: 1733233453828
+- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py311hf16d85f_1.conda
+  sha256: bd3c3ec5ba203143818fa3ca300060a459d78da566049b49ed2ef20e04ea5b96
+  md5: b7c132408b0ee7408dcfa998ef6f7939
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15858505
+  timestamp: 1729482598163
+- conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
+  sha256: 5b9450f619aabcfbf3d284a272964250b2e1971ab0f7a7ef9143dda0ecc537b8
+  md5: 7635a408509e20dcfc7653ca305ad799
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59350
+  timestamp: 1720004197144
+- conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-h62715c5_1.conda
+  sha256: 03cc5442046485b03dd1120d0f49d35a7e522930a2ab82f275e938e17b07b302
+  md5: 9190dd0a23d925f7602f9628b3aed511
+  depends:
+  - libhwloc >=2.11.2,<2.11.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 151460
+  timestamp: 1732982860332
+- conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+  sha256: 2c4e914f521ccb2718946645108c9bd3fc3216ba69aea20c2c3cedbd8db32bb1
+  md5: fc048363eb8f03cd1737600a5d08aafe
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: TCL
+  license_family: BSD
+  size: 3503410
+  timestamp: 1699202577803
+- conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.2-py311he736701_0.conda
+  sha256: 7e313f1724e5eb7d13f7a1ebd6026a378f3f58a638ba7cdc3bd452c01323bb29
+  md5: 7e33077ce1bc0bf45c45a92e37432f16
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 859456
+  timestamp: 1732616376731
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+  sha256: db8dead3dd30fb1a032737554ce91e2819b43496a0db09927edf01c32b577450
+  md5: 6797b005cd0f439c4c5c9ac565783700
+  constrains:
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-MicrosoftWindowsSDK10
+  size: 559710
+  timestamp: 1728377334097
+- conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-15.1.0-py311he736701_1.conda
+  sha256: 07d55566e05bbadc32e989bbe50853e579fea0f8809503719d7d1438302d27be
+  md5: 6230613721d6d805d0276025ee4d7b2b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 365349
+  timestamp: 1729705070270
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_23.conda
+  sha256: 986ddaf8feec2904eac9535a7ddb7acda1a1dfb9482088fdb8129f1595181663
+  md5: 7c10ec3158d1eb4ddff7007c9101adb0
+  depends:
+  - vc14_runtime >=14.38.33135
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17479
+  timestamp: 1731710827215
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34433-he29a5d6_23.conda
+  sha256: c483b090c4251a260aba6ff3e83a307bcfb5fb24ad7ced872ab5d02971bd3a49
+  md5: 32b37d0cfa80da34548501cdc913a832
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.42.34433.* *_23
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  size: 754247
+  timestamp: 1731710681163
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hdffcdeb_23.conda
+  sha256: 568ce8151eaae256f1cef752fc78651ad7a86ff05153cc7a4740b52ae6536118
+  md5: 5c176975ca2b8366abad3c97b3cd1e83
+  depends:
+  - vc14_runtime >=14.42.34433
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17572
+  timestamp: 1731710685291
+- conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: 9df10c5b607dd30e05ba08cbd940009305c75db242476f4e845ea06008b0a283
+  md5: 1cee351bf20b830d991dbe0bc8cd7dfe
+  license: MIT
+  license_family: MIT
+  size: 1176306
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-h0e40799_1.conda
+  sha256: f44bc6f568a9697b7e1eadc2d00ef5de0fe62efcf5e27e5ecc46f81046082faf
+  md5: ca66d6f8fe86dd53664e8de5087ef6b1
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 107925
+  timestamp: 1727035280560
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.5-h0e40799_0.conda
+  sha256: 9075f98dcaa8e9957e4a3d9d30db05c7578a536950a31c200854c5c34e1edb2c
+  md5: 8393c0f7e7870b4eb45553326f81f0ff
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 69920
+  timestamp: 1727795651979
+- conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+  sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
+  md5: 515d77642eaa3639413c6b1bc3f94219
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: LGPL-2.1 and GPL-2.0
+  size: 217804
+  timestamp: 1660346976440
+- conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+  sha256: 4e2246383003acbad9682c7c63178e2e715ad0eb84f03a8df1fbfba455dfedc5
+  md5: adbfb9f45d1004a26763652246a33764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 63274
+  timestamp: 1641347623319
+- conda: https://conda.anaconda.org/conda-forge/win-64/yarl-1.18.0-py311he736701_0.conda
+  sha256: 65bbf6486a913990e07581930b7a49c72ce8b21b5541242302d684f26e3b184d
+  md5: ce3089b5e70ce57190001f9b9648dacb
+  depends:
+  - idna >=2.0
+  - multidict >=4.0
+  - propcache >=0.2.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 142764
+  timestamp: 1732221338560
+- conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_7.conda
+  sha256: 15cc8e2162d0a33ffeb3f7b7c7883fd830c54a4b1be6a4b8c7ee1f4fef0088fb
+  md5: e03f2c245a5ee6055752465519363b1c
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 2527503
+  timestamp: 1731585151036
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py311h53056dc_1.conda
+  sha256: a93584e6167c3598854a47f3bf8276fa646a3bb4d12fcfc23a54e37d5879f35c
+  md5: 7d4c123cbb5e6293dd4dd2f8d30f0de4
+  depends:
+  - cffi >=1.11
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 321357
+  timestamp: 1725305930669
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+  sha256: 768e30dc513568491818fb068ee867c57c514b553915536da09e5d10b4ebf3c3
+  md5: 9a17230f95733c04dc40a2b1e5491d74
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 349143
+  timestamp: 1714723445995

--- a/timelapse_microscopy/pixi.lock
+++ b/timelapse_microscopy/pixi.lock
@@ -8,7 +8,6 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
-    - url: https://conda.anaconda.org/nodefaults/
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2

--- a/timelapse_microscopy/pixi.toml
+++ b/timelapse_microscopy/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "timelapse_microscopy"
-channels = ["conda-forge", "nodefaults"]
+channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/timelapse_microscopy/pixi.toml
+++ b/timelapse_microscopy/pixi.toml
@@ -1,0 +1,51 @@
+[workspace]
+name = "timelapse_microscopy"
+channels = ["conda-forge", "nodefaults"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2024-11-21"
+maintainers = ["droumis"]
+categories = ["Neuroscience"]
+labels = ["hvplot", "panel", "holoviews", "bokeh", "datashader", "holonote", "xarray", "dask"]
+title = "Time-lapse Microscopy"
+description = "Display and annotate time-lapse microscopy in Neuroscience"
+
+[dependencies]
+notebook = ">=6.5.2,<7"
+python = "3.11.*"
+numpy = ">=2.0.2"
+panel = ">=1.4.2"
+hvplot = ">=0.10.0"
+pandas = ">=2.2.3"
+holoviews = ">=1.19.0"
+datashader = ">=0.16.3"
+dask = ">=2024.11.2"
+xarray = ">=2024.5.0"
+zarr = ">=2.18.3"
+pyarrow = ">=18.0.0"
+jupyterlab = ">=4.3.1"
+holonote = ">=0.2.1"
+bokeh = ">=3.6.2"
+requests = ">=2.32.3"
+aiohttp = ">=3.11.6"
+fsspec = ">=2024.10.0"
+pip = "*"
+wheel = "*"
+
+[tasks.lab]
+cmd = "jupyter lab timelapse_microscopy.ipynb"
+depends-on = ["download"]
+
+[tasks.notebook]
+cmd = "jupyter notebook timelapse_microscopy.ipynb"
+depends-on = ["download"]
+
+[tasks.dashboard]
+cmd = "panel serve --rest-session-info --session-history -1 timelapse_microscopy.ipynb --show"
+depends-on = ["download"]
+
+[tasks.download]
+env = { FILENAME = "data/real_miniscope_uint8.zarr" }
+cmd = "mkdir -p $FILENAME && curl -fsSL -o .miniscope_data.zip https://s3.eu-west-1.amazonaws.com/datasets.holoviz.org/miniscope/v1/miniscope.zip && python -m zipfile -e .miniscope_data.zip $FILENAME && rm .miniscope_data.zip"
+outputs = ["data/real_miniscope_uint8.zarr"]

--- a/timelapse_microscopy/pixi.toml
+++ b/timelapse_microscopy/pixi.toml
@@ -30,8 +30,8 @@ bokeh = ">=3.6.2"
 requests = ">=2.32.3"
 aiohttp = ">=3.11.6"
 fsspec = ">=2024.10.0"
-pip = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [tasks.lab]
 cmd = "jupyter lab timelapse_microscopy.ipynb"

--- a/uk_researchers/pixi.lock
+++ b/uk_researchers/pixi.lock
@@ -7,925 +7,925 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.6.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-19.0.0-h865e1df_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-24.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.11.212-hecad206_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bleach-6.2.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.6.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.4.2-py311hf4808d0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2025.2.25-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2025.1.31-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py311h1fdaa30_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.3.1-py311hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cramjam-2.7.0-py311h24d97f6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-1.0.1-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-2024.12.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.12.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-expr-1.1.21-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.17.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.8.11-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2024.12.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-2024.2.0-py311hf4808d0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.55.3-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.12.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.20.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/imageio-2.37.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-8.5.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.30.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.5-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.23.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.8-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lazy_loader-0.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.16-hb9589c4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-4.0.0-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libabseil-20240116.2-cxx17_h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.12.1-hc9e6f67_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.22-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgrpc-1.62.2-h2d74bed_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm15-15.0.7-he89c38a_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-4.25.3-he621ea3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.11.1-h251f7ec_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-hffd6297_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.13.5-hfdd30dd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.44.0-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py311h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-3.0.2-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.10.0-py311hbfdbfaf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.11-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.8-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py311hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.16.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.4.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.61.0-py311h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.10.1-py311h3c60e43_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.16-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-2.0.1-h2d29ad5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.3-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.2.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/parso-0.8.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-11.1.0-py311hcea889d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-25.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.21.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-19.0.0-py311h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.2.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.11-he870216_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.20.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-3.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.6.2-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-snappy-0.6.1-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.22.3-py311h4aa5aa6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scikit-image-0.25.0-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.15.1-py311h08b1b3b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-75.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tifffile-2024.12.12-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.4.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-1.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.2-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.67.1-py311h92b7b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.12.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.12.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.45.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2024.11.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.6.4-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.21.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2025a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-4.6.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/arrow-cpp-19.0.0-h865e1df_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-24.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/aws-sdk-cpp-1.11.212-hecad206_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bleach-6.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-3.6.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.4.2-py311hf4808d0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py311h6a678d5_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2025.2.25-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2025.1.31-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.17.1-py311h1fdaa30_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cloudpickle-3.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/contourpy-1.3.1-py311hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cramjam-2.7.0-py311h24d97f6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cytoolz-1.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dask-2024.12.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dask-core-2024.12.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/dask-expr-1.1.21-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/datashader-0.17.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.8.11-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/distributed-2024.12.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fastparquet-2024.2.0-py311hf4808d0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fonttools-4.55.3-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fsspec-2024.12.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.20.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/imageio-2.37.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-8.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.29.5-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.30.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.19.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.5-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.23.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.8-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lazy_loader-0.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.16-hb9589c4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lerc-4.0.0-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libabseil-20240116.2-cxx17_h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libcurl-8.12.1-hc9e6f67_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.22-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgrpc-1.62.2-h2d74bed_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libllvm15-15.0.7-he89c38a_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libprotobuf-4.25.3-he621ea3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libssh2-1.11.1-h251f7ec_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-hffd6297_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libxml2-2.13.5-hfdd30dd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.44.0-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-4.3.2-py311h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-3.0.2-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.10.0-py311hbfdbfaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py311h5eee18b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.11-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.8-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/msgpack-python-1.0.3-py311hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.16.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.10.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/networkx-3.4.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numba-0.61.0-py311h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.10.1-py311h3c60e43_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.16-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/orc-2.0.1-h2d29ad5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-24.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-2.2.3-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-2.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/parso-0.8.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/partd-1.4.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-11.1.0-py311hcea889d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-25.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.21.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py311h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyarrow-19.0.0-py311h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.11.11-he870216_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.20.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-json-logger-3.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-lmdb-1.6.2-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-snappy-0.6.1-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.2-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.32.3-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.22.3-py311h4aa5aa6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scikit-image-0.25.0-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/scipy-1.15.1-py311h08b1b3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-75.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tifffile-2024.12.12-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/toolz-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.4.2-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.67.1-py311h92b7b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.12.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.12.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-2.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.45.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xarray-2024.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.6.4-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zict-3.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zipp-3.21.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2025a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2025a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.6.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h46256e1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-19.0.0-hdba8a65_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.11.212-h9475118_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bleach-6.2.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.6.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.4.2-py311h9b7fc35_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311h6d0c2b6_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2025.2.25-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2025.1.31-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py311h9205ec4_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.3.1-py311h1962661_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cramjam-2.7.0-py311h9c86198_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-1.0.1-py311h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-2024.12.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2024.12.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-expr-1.1.21-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.17.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.8.11-py311h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2024.12.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-2024.2.0-py311hb3a5e46_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.55.3-py311h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.12.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.20.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/imageio-2.37.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-8.5.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.30.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.5-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.23.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.8-py311h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lazy_loader-0.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.16-h4f63f0c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-4.0.0-h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libabseil-20240116.2-cxx17_h548131f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h46256e1_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h46256e1_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h46256e1_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.12.1-h9bcc28a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.22-h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgrpc-1.62.2-hf2926fd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm15-15.0.7-h1357083_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-4.25.3-h34eed0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.11.1-h3a17b82_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-h6fa9cd1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.13.5-h6070cd6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.44.0-py311h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-4.3.2-py311h46256e1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-3.0.2-py311h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.10.0-py311h919b35b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py311ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.4.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.61.0-py311h6d0c2b6_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.10.1-py311hc59c7be_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h91b6869_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311hb3ec012_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.16-h184c1cd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-2.0.1-h5747287_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.3-py311h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.2.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/parso-0.8.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-11.1.0-py311h47bf62f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-25.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.21.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h46256e1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-19.0.0-py311h6d0c2b6_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.2.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.11-h4d6d9e5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.20.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-3.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.6.2-py311h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-snappy-0.6.1-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py311h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.22.3-py311h83de92b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scikit-image-0.25.0-py311h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.15.1-py311hedc7b93_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-75.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tifffile-2024.12.12-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.4.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-1.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.2-py311h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.67.1-py311h85bffb1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.12.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.12.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h46256e1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.45.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2024.11.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.6.4-h46256e1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.21.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2025a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-4.6.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py311h46256e1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/arrow-cpp-19.0.0-hdba8a65_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-24.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/aws-sdk-cpp-1.11.212-h9475118_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bleach-6.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-3.6.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.4.2-py311h9b7fc35_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py311h6d0c2b6_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2025.2.25-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2025.1.31-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.17.1-py311h9205ec4_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cloudpickle-3.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.3.1-py311h1962661_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cramjam-2.7.0-py311h9c86198_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cytoolz-1.0.1-py311h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/dask-2024.12.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/dask-core-2024.12.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/dask-expr-1.1.21-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/datashader-0.17.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.8.11-py311h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/distributed-2024.12.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fastparquet-2024.2.0-py311hb3a5e46_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fonttools-4.55.3-py311h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fsspec-2024.12.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.20.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/imageio-2.37.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-8.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.29.5-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.30.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.19.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.23.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.8-py311h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lazy_loader-0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.16-h4f63f0c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-4.0.0-h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libabseil-20240116.2-cxx17_h548131f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h46256e1_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h46256e1_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h46256e1_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcurl-8.12.1-h9bcc28a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.22-h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgrpc-1.62.2-hf2926fd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libllvm15-15.0.7-h1357083_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libprotobuf-4.25.3-h34eed0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libssh2-1.11.1-h3a17b82_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-h6fa9cd1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libxml2-2.13.5-h6070cd6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.44.0-py311h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-4.3.2-py311h46256e1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-3.0.2-py311h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.10.0-py311h919b35b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/msgpack-python-1.0.3-py311ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.16.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.10.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/networkx-3.4.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numba-0.61.0-py311h6d0c2b6_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.10.1-py311hc59c7be_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.4-py311h91b6869_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.4-py311hb3ec012_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.16-h184c1cd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/orc-2.0.1-h5747287_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-24.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-2.2.3-py311h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-2.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/parso-0.8.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/partd-1.4.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-11.1.0-py311h47bf62f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-25.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.21.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py311h46256e1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyarrow-19.0.0-py311h6d0c2b6_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.11.11-h4d6d9e5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.20.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-json-logger-3.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-lmdb-1.6.2-py311h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-snappy-0.6.1-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.2-py311h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.32.3-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.22.3-py311h83de92b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scikit-image-0.25.0-py311h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/scipy-1.15.1-py311hedc7b93_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-75.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tifffile-2024.12.12-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/toolz-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.4.2-py311h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.67.1-py311h85bffb1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.12.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.12.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py311h46256e1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-2.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.45.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xarray-2024.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.6.4-h46256e1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zict-3.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zipp-3.21.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2025a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.6.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-19.0.0-h0b7d223_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-24.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.11.212-hdd7fb2f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bleach-6.2.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.6.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.4.2-py311hb9f6ed7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2025.2.25-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2025.1.31-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.3.1-py311h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cramjam-2.7.0-py311h62f922a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-1.0.1-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-2024.12.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.12.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-expr-1.1.21-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.17.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.8.11-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2024.12.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-2024.2.0-py311hb9f6ed7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.55.3-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.12.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.20.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/imageio-2.37.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-8.5.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.30.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.5-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.23.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.8-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lazy_loader-0.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.16-he93ba84_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-4.0.0-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libabseil-20240116.2-cxx17_h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.12.1-hde089ae_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.22-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgrpc-1.62.2-h62f6fdd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm15-15.0.7-h97a1cf3_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-4.25.3-h514c7bf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.11.1-h3e2b118_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-hc9ead59_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.13.5-h0b34f26_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.44.0-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.3.2-py311h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-3.0.2-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.10.0-py311h7ef442a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py311h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.4.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.61.0-py311h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.10.1-py311h5d9532f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.16-h02f6b3c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-2.0.1-h937ddfc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.3-py311hcf29cfe_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.2.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/parso-0.8.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-11.1.0-py311h84e58ab_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-25.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.21.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-19.0.0-py311h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.2.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.11-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.20.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-3.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.6.2-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-snappy-0.6.1-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.2-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.22.3-py311h2aea54e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scikit-image-0.25.0-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.15.1-py311hac8794a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-75.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tifffile-2024.12.12-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.4.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-1.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.2-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.67.1-py311hb6e6a13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.12.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.12.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.45.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2024.11.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.6.4-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.21.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2025a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.6.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/arrow-cpp-19.0.0-h0b7d223_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-24.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/aws-sdk-cpp-1.11.212-hdd7fb2f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bleach-6.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.6.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.4.2-py311hb9f6ed7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2025.2.25-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2025.1.31-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-3.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.3.1-py311h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cramjam-2.7.0-py311h62f922a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cytoolz-1.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/dask-2024.12.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2024.12.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/dask-expr-1.1.21-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/datashader-0.17.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.8.11-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/distributed-2024.12.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fastparquet-2024.2.0-py311hb9f6ed7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.55.3-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2024.12.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.20.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/imageio-2.37.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-8.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.29.5-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.30.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.19.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.5-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.23.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.8-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lazy_loader-0.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.16-he93ba84_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-4.0.0-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libabseil-20240116.2-cxx17_h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcurl-8.12.1-hde089ae_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.22-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgrpc-1.62.2-h62f6fdd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libllvm15-15.0.7-h97a1cf3_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libprotobuf-4.25.3-h514c7bf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libssh2-1.11.1-h3e2b118_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-hc9ead59_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.13.5-h0b34f26_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.44.0-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-4.3.2-py311h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-3.0.2-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.10.0-py311h7ef442a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/msgpack-python-1.0.3-py311h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.16.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.10.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/networkx-3.4.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numba-0.61.0-py311h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.10.1-py311h5d9532f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.16-h02f6b3c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/orc-2.0.1-h937ddfc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-24.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.2.3-py311hcf29cfe_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-2.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/parso-0.8.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-11.1.0-py311h84e58ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-25.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.21.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py311h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyarrow-19.0.0-py311h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.11.11-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.20.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-3.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-lmdb-1.6.2-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-snappy-0.6.1-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.2-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.32.3-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.22.3-py311h2aea54e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scikit-image-0.25.0-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.15.1-py311hac8794a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-75.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tifffile-2024.12.12-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/toolz-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.4.2-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.67.1-py311hb6e6a13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.12.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.12.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.45.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xarray-2024.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.6.4-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zict-3.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.21.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2025a-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.6.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h827c3e9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-19.0.0-h33d5241_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-24.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.11.212-h6a15179_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bleach-6.2.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.6.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.4.2-py311h57dcf0c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311h5da7b33_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2025.2.25-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2025.1.31-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py311h827c3e9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.3.1-py311h214f63a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cramjam-2.7.0-py311h005caf5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-1.0.1-py311h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-2024.12.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.12.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-expr-1.1.21-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.17.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.8.11-py311h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2024.12.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-2024.2.0-py311hd7041d2_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.55.3-py311h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.12.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.20.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/imageio-2.37.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-8.5.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.30.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.5-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.23.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.8-py311h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lazy_loader-0.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.16-hb4a4139_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-4.0.0-h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libabseil-20240116.2-cxx17_h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h827c3e9_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h827c3e9_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h827c3e9_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.12.1-h9da9810_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.22-h5bf469e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libgrpc-1.62.2-hf25190f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-4.25.3-hf2fb9eb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.11.1-h2addb87_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-h44ae7cf_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.44.0-py311hf2fb9eb_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.3.2-py311h827c3e9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-3.0.2-py311h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.10.0-py311he19b0ae_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h827c3e9_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.11-py311h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.8-py311hea22821_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py311h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.4.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.61.0-py311h5da7b33_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.10.1-py311h4cd664f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.16-h3f729d1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/orc-2.0.1-hd8d391b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.3-py311h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.2.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/parso-0.8.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-11.1.0-py311h096bfcc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-25.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.21.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h827c3e9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-19.0.0-py311h5da7b33_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.2.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.11-h4607a30_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.20.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-3.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.6.2-py311h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-snappy-0.6.1-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-308-py311h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.14-py311h72d21ff_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.2-py311h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.22.3-py311h636fa0f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scikit-image-0.25.0-py311h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.15.1-py311h9f229c6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-75.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tifffile-2024.12.12-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.4.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-1.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.2-py311h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.67.1-py311h746a85d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.12.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.12.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h827c3e9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.42-haa95532_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.42.34433-he0abc0d_4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.45.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2024.11.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.6.4-h4754444_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.21.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gmp-6.1.0-2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2025a-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-4.6.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py311h827c3e9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/arrow-cpp-19.0.0-h33d5241_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-24.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/aws-sdk-cpp-1.11.212-h6a15179_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bleach-6.2.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-3.6.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.4.2-py311h57dcf0c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py311h5da7b33_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2025.2.25-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2025.1.31-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.17.1-py311h827c3e9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cloudpickle-3.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.3.1-py311h214f63a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cramjam-2.7.0-py311h005caf5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cytoolz-1.0.1-py311h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/dask-2024.12.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/dask-core-2024.12.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/dask-expr-1.1.21-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/datashader-0.17.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.8.11-py311h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/distributed-2024.12.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fastparquet-2024.2.0-py311hd7041d2_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fonttools-4.55.3-py311h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fsspec-2024.12.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.20.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/imageio-2.37.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/importlib-metadata-8.5.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.29.5-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.30.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.19.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.5-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.23.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.8-py311h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lazy_loader-0.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lcms2-2.16-hb4a4139_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-4.0.0-h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libabseil-20240116.2-cxx17_h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h827c3e9_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h827c3e9_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h827c3e9_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libcurl-8.12.1-h9da9810_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.22-h5bf469e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libgrpc-1.62.2-hf25190f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libprotobuf-4.25.3-hf2fb9eb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libssh2-1.11.1-h2addb87_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-h44ae7cf_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/llvmlite-0.44.0-py311hf2fb9eb_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-4.3.2-py311h827c3e9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-3.0.2-py311h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.10.0-py311he19b0ae_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py311h827c3e9_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.11-py311h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.8-py311hea22821_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/msgpack-python-1.0.3-py311h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-7.16.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.10.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/networkx-3.4.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numba-0.61.0-py311h5da7b33_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.10.1-py311h4cd664f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.16-h3f729d1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/orc-2.0.1-hd8d391b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-24.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-2.2.3-py311h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-2.2.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/parso-0.8.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/partd-1.4.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-11.1.0-py311h096bfcc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-25.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.21.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py311h827c3e9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyarrow-19.0.0-py311h5da7b33_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.2.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.11.11-h4607a30_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.20.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-json-logger-3.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-lmdb-1.6.2-py311h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-snappy-0.6.1-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-308-py311h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.14-py311h72d21ff_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.2-py311h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.32.3-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rpds-py-0.22.3-py311h636fa0f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scikit-image-0.25.0-py311h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/scipy-1.15.1-py311h9f229c6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-75.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tifffile-2024.12.12-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.4.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/toolz-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.4.2-py311h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.67.1-py311h746a85d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.12.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.12.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py311h827c3e9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-2.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.42-haa95532_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.42.34433-he0abc0d_4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.45.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xarray-2024.11.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.6.4-h4754444_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zict-3.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zipp-3.21.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
+      - conda: https://conda.anaconda.org/msys2/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+      - conda: https://conda.anaconda.org/msys2/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+      - conda: https://conda.anaconda.org/msys2/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+      - conda: https://conda.anaconda.org/msys2/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+      - conda: https://conda.anaconda.org/msys2/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+      - conda: https://conda.anaconda.org/msys2/win-64/msys2-conda-epoch-20160418-1.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
   sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
   md5: 613805add1c05b538ff06d217252feb7
   depends:
@@ -936,7 +936,7 @@ packages:
   license: BSD-3-Clause
   size: 20810
   timestamp: 1652859733309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.6.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-4.6.2-py311h06a4308_0.tar.bz2
   sha256: d58b068fe1b9c195394e77a6fba4d152c6934e97df7757dd6b921498f8aa72f8
   md5: 09de3b2d5519a680bda3c3771380c3da
   depends:
@@ -950,7 +950,7 @@ packages:
   license_family: MIT
   size: 243587
   timestamp: 1729121303719
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_1.tar.bz2
   sha256: b7eb9612c200994d8126caa0c36561a586c6a8a57066609febae6ff4d61da35a
   md5: 6181c14ad55e754ce7327ec32e7a2bf9
   depends:
@@ -961,7 +961,7 @@ packages:
   license_family: MIT
   size: 36032
   timestamp: 1736182558607
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-19.0.0-h865e1df_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/arrow-cpp-19.0.0-h865e1df_0.tar.bz2
   sha256: 19075e5fc1ff6c49540fa30bb683abb9c6b6561d863748b07867489eb9625fd7
   md5: dd136dfcc2378b121024766923f45cb7
   depends:
@@ -992,7 +992,7 @@ packages:
   license_family: Apache
   size: 14402129
   timestamp: 1738050893917
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-24.3.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-24.3.0-py311h06a4308_0.tar.bz2
   sha256: 9c40ad73b2f2f2a6ea5ae3919a9a538518b0eb92baef29f07fd006fca09a5e90
   md5: b6fca842c8ea8530e4d1751c277e8ba2
   depends:
@@ -1001,7 +1001,7 @@ packages:
   license_family: MIT
   size: 162429
   timestamp: 1734533126936
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
   sha256: 432e4fb45ae24789afdaeca800862aad03f8ebed5af908f01eed2a09283915e5
   md5: a88c0e111e1f47ee83f1b6f329a149ef
   depends:
@@ -1015,7 +1015,7 @@ packages:
   license_family: Apache
   size: 97643
   timestamp: 1706746168671
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
   sha256: edb54d1554aefb65ff5a3969085dd8695e1e3218a2987ac30a96901f0bbf887a
   md5: 5f131e63f8d80f2b7ac505054204a9e3
   depends:
@@ -1026,7 +1026,7 @@ packages:
   license_family: Apache
   size: 44722
   timestamp: 1706690912333
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
   sha256: 2afbfb546992e5954748d039ea15405f99018f6de78ec2f32bc7ff9bfc428a9c
   md5: 489017af35cf8bdb976e6fef020a4ac7
   depends:
@@ -1035,7 +1035,7 @@ packages:
   license_family: Apache
   size: 202658
   timestamp: 1706189913451
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
   sha256: 5f81f5a3ea27bd29bf32a6987290de8c7b2da6612676aa8e606a7003519cbf47
   md5: c11e7ceff3ca45bf580d1c944d93bd1f
   depends:
@@ -1045,7 +1045,7 @@ packages:
   license_family: Apache
   size: 17839
   timestamp: 1706690843204
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
   sha256: 348ced323311d36344a0fa9e88d299b361bad1f628dfbdd34bcea8662b3ab44b
   md5: 19a11cdc9727c5981d96983a29b93ce4
   depends:
@@ -1058,7 +1058,7 @@ packages:
   license_family: Apache
   size: 52025
   timestamp: 1706697274091
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
   sha256: 14e2843a218cb01bfc499a22537eb345f6e222b8496cfda2050c73ad98f09cda
   md5: 44cba75d1bb5122aeadcaf8bb7da5e2a
   depends:
@@ -1071,7 +1071,7 @@ packages:
   license_family: Apache
   size: 192985
   timestamp: 1706744140260
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
   sha256: a0f6916d60c0e1bac6ba548bf05a491b8db048a94e13da2f1cfa51b4ca879fb8
   md5: 1f010db4f5ef1b3d705ee04dd1d473c9
   depends:
@@ -1083,7 +1083,7 @@ packages:
   license_family: Apache
   size: 143623
   timestamp: 1706696185335
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
   sha256: 596945a39d772056e57bb357202a17e02508f2594da9c00e00ad767b8213e998
   md5: 98cccbcc56a28ec7339e393816f4bdf7
   depends:
@@ -1095,7 +1095,7 @@ packages:
   license_family: Apache
   size: 70139
   timestamp: 1706746744249
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
   sha256: 12bf86ab848e3311f4eed4e93734a84064dc84580ad6dd4bb823b4ab6ef09698
   md5: 4a8c2dcf0ede655609a9fc5632a5227b
   depends:
@@ -1111,7 +1111,7 @@ packages:
   license_family: Apache
   size: 74700
   timestamp: 1706747582638
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
   sha256: f05ce64fee77518a6deb45f187fcee415328e90ea8f2bf6031bd5b8273a1028f
   md5: b8ebb4b892d9b80d513b4ca62a8d6de2
   depends:
@@ -1121,7 +1121,7 @@ packages:
   license_family: Apache
   size: 53042
   timestamp: 1706690818718
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
   sha256: 52bb367fc367ee3923353927226299a2b8b1be6a1993c11e19b20cafe6c6db0f
   md5: 4715508fd5f8b39e902cb2afebc13c93
   depends:
@@ -1131,7 +1131,7 @@ packages:
   license_family: Apache
   size: 52138
   timestamp: 1706192048702
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
   sha256: 0d13fbdace8ab4fbfcc015cf83bead69560a3dfadc6e0ce8441001629d725834
   md5: a02c72bff71848705e70cd6f075a28f3
   depends:
@@ -1150,7 +1150,7 @@ packages:
   license_family: Apache
   size: 211559
   timestamp: 1706827608038
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.11.212-hecad206_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/aws-sdk-cpp-1.11.212-hecad206_0.tar.bz2
   sha256: 9a1de443175997ba4ce5ff7990c8bfbd75af2d2cf9a4d5f6c178f0f90779f772
   md5: 4fcc20f27dbbc8c81c0a1eb81b481695
   depends:
@@ -1167,7 +1167,7 @@ packages:
   license_family: Apache
   size: 4657506
   timestamp: 1733148711180
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
   sha256: 5bb9bfe025d9a49af272f194278f63cea7366e83bdf3f99d25f97b820d522089
   md5: 100d3161d97332fe38945afec8d36935
   depends:
@@ -1177,12 +1177,12 @@ packages:
   license_family: MIT
   size: 276381
   timestamp: 1718029864701
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bleach-6.2.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bleach-6.2.0-py311h06a4308_0.tar.bz2
   sha256: 46d4caa9b996615e6d367282d5ba3a4a11f23052fac305cf52fc067e4f766ed7
   md5: 5f923de750f6d8a2a9faa8cf90da6311
   depends:
@@ -1194,7 +1194,7 @@ packages:
   license_family: Apache
   size: 367370
   timestamp: 1732290516590
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.6.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-3.6.2-py311h06a4308_0.tar.bz2
   sha256: cc28ef20fc2443761fbb79da152803ecb35aee02110db896f5f07137fce231db
   md5: c45ba96af7be3ebfc9947bd7f26ba888
   depends:
@@ -1212,7 +1212,7 @@ packages:
   license_family: BSD
   size: 5877128
   timestamp: 1737999314705
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
   sha256: 3606c8607c29229222667f66421f79df167d33043fe9245cdd4e2c4520ecc721
   md5: eca33dcef14fa044193e43492dca8585
   depends:
@@ -1223,7 +1223,7 @@ packages:
   license_family: OTHER
   size: 10768
   timestamp: 1696762269985
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.4.2-py311hf4808d0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.4.2-py311hf4808d0_0.tar.bz2
   sha256: de78a7f35a57c21d8986c1084f308c98477747d6a92a0b23b5d4855333eee0c9
   md5: 85399e523becae3ca29054b3d579b8e7
   depends:
@@ -1234,7 +1234,7 @@ packages:
   license_family: BSD
   size: 148890
   timestamp: 1731058903578
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_9.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py311h6a678d5_9.tar.bz2
   sha256: b7ff9535237880e6fb540d58ce2b904e9407904c92579260b92be12a4451281a
   md5: f229f321f52804bfa696fed56b11b5d1
   depends:
@@ -1244,7 +1244,7 @@ packages:
   license: MIT
   size: 361254
   timestamp: 1736182674347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
   sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
   md5: f5058c8d5b2994b7334f18e022105a14
   depends:
@@ -1253,7 +1253,7 @@ packages:
   license_family: BSD
   size: 427542
   timestamp: 1714510571510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
   sha256: 5b4c80587ae4ec915505469f79d866f27c80456156667c8548d31c67c2c1653e
   md5: c3d6bfae757760082261779c406a880d
   depends:
@@ -1262,14 +1262,14 @@ packages:
   license_family: MIT
   size: 116270
   timestamp: 1693902021950
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2025.2.25-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2025.2.25-h06a4308_0.tar.bz2
   sha256: 3b93acbbf19f6720aa1b8b4e4e2a9c2580af5d635384cf310586411efbb364e9
   md5: ba2f1a3a29243f13c6898395f2c2dab7
   license: MPL-2.0
   license_family: Other
   size: 139245
   timestamp: 1740582453836
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2025.1.31-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2025.1.31-py311h06a4308_0.tar.bz2
   sha256: b3d1c50537d3de350bc0a42947aac47037441bdb07fefcf1991c72012c8b6c68
   md5: 7ad703949235c3f0dcc99996989d5a90
   depends:
@@ -1278,7 +1278,7 @@ packages:
   license_family: Other
   size: 168016
   timestamp: 1738623830569
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py311h1fdaa30_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.17.1-py311h1fdaa30_1.tar.bz2
   sha256: a73bd99651100ddd118806e62f20b2b6fac0098e0615580314fb8cc983467d4e
   md5: b8f1ba0cf72321301cd1d840fd286731
   depends:
@@ -1290,7 +1290,7 @@ packages:
   license_family: MIT
   size: 308046
   timestamp: 1736182517693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
   sha256: 9ddbf05887c7d7926418520cc7848e57f6d2431bc4ec6d30e090b02dbf865041
   md5: 57ae1141ad9a048fb2a75d7a3ef7430a
   depends:
@@ -1299,7 +1299,7 @@ packages:
   license_family: BSD
   size: 203190
   timestamp: 1698129926216
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cloudpickle-3.0.0-py311h06a4308_0.tar.bz2
   sha256: 017b35122f533e4ffc48bb3e0c6fd1f16e8cbb2a67d40b3f6572b77511ffe26d
   md5: 75eb58b2cdb0ddf4e93293cf973a0829
   depends:
@@ -1308,7 +1308,7 @@ packages:
   license_family: BSD
   size: 41983
   timestamp: 1721657369906
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
   sha256: d9c102b9ec7f3a635936b6f73d4db126d748a25f65407353bd76b260dc7d1cd6
   md5: eec48dbdf5dac0ea26750cc26b58c1d9
   depends:
@@ -1317,7 +1317,7 @@ packages:
   license_family: CC
   size: 554986
   timestamp: 1709758392744
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
   sha256: 882481e441b9b93cbdfb32fbe32a6ad9f26197472f186a08fddb921f61346c02
   md5: 443c79196064f57c98199e9990544b2f
   depends:
@@ -1327,7 +1327,7 @@ packages:
   license_family: BSD
   size: 16902
   timestamp: 1709322958614
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.3.1-py311hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/contourpy-1.3.1-py311hdb19cb5_0.tar.bz2
   sha256: 214cc9e08edf0430b1dca7d7a5407f19c16e9ad0684bb972a4a836e044196719
   md5: db381e74b7730d0b8b54a05d2716c28c
   depends:
@@ -1339,7 +1339,7 @@ packages:
   license_family: BSD
   size: 299819
   timestamp: 1732540101238
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cramjam-2.7.0-py311h24d97f6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cramjam-2.7.0-py311h24d97f6_0.tar.bz2
   sha256: 7bb1fd85aaba31403b00722d6f142220031788e391fdaad899c816595cb3ae5d
   md5: 6673633f2374304790bfdcaa334b14ae
   depends:
@@ -1349,7 +1349,7 @@ packages:
   license_family: MIT
   size: 1528662
   timestamp: 1702651329660
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-1.0.1-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cytoolz-1.0.1-py311h5eee18b_0.tar.bz2
   sha256: e74069c0543df0eb9437c59abb170cb74b4d00ed8b840fad1ffb841d47139dbc
   md5: 26f8aecb6684b5c74a2118071c528d9f
   depends:
@@ -1360,7 +1360,7 @@ packages:
   license_family: BSD
   size: 436017
   timestamp: 1736803911833
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-2024.12.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dask-2024.12.1-py311h06a4308_0.tar.bz2
   sha256: c43d26fdf93c0fafb0b5d5861891eddd2c12867a24fe7d34a7f850d8225f5265
   md5: f7bb330f7fc1dab73a580b7bb0d25f1c
   depends:
@@ -1379,7 +1379,7 @@ packages:
   license_family: BSD
   size: 5357
   timestamp: 1736873436192
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.12.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dask-core-2024.12.1-py311h06a4308_0.tar.bz2
   sha256: 541570cc3a626034a66cabb0e3831c6fd380a780c2d27e02a1dc000022ec123b
   md5: 0e5baa13350a14b6381123242c0746b3
   depends:
@@ -1396,7 +1396,7 @@ packages:
   license_family: BSD
   size: 3202802
   timestamp: 1736807571954
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-expr-1.1.21-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/dask-expr-1.1.21-py311h06a4308_0.tar.bz2
   sha256: 02176f6cb5966f28f1258659ad3529f3fd579bb52c2bb7e39219f8de4ecaa316
   md5: 3a74962f2142df53f5003c3c8b5af692
   depends:
@@ -1408,7 +1408,7 @@ packages:
   license_family: BSD
   size: 568612
   timestamp: 1736810427516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.17.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/datashader-0.17.0-py311h06a4308_0.tar.bz2
   sha256: 4c5ea17c9aa9f47a597312aee142eac20db3963f0bf4aaf9f973f5b5f226f0c0
   md5: 7fa0742a8942e0568d2cc5c78e8740cd
   depends:
@@ -1429,7 +1429,7 @@ packages:
   license_family: BSD
   size: 18006100
   timestamp: 1738336791055
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.8.11-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.8.11-py311h6a678d5_0.tar.bz2
   sha256: 69c3214beb1e7f398f82a10c245af788304bbff2e1a12d0e15672f68ba00d974
   md5: d3c168f99c3d8bb146f89b3032f3ebaf
   depends:
@@ -1440,7 +1440,7 @@ packages:
   license_family: MIT
   size: 2844636
   timestamp: 1736267672061
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2024.12.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/distributed-2024.12.1-py311h06a4308_0.tar.bz2
   sha256: 0aed2ca7ba2852533118858fc2d91bf3096e6b4838f3d1193e8147acd24f9721
   md5: 5d6374b10e491c5136612fcffed907f0
   depends:
@@ -1464,7 +1464,7 @@ packages:
   license_family: BSD
   size: 1826844
   timestamp: 1736870807534
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
   sha256: 4b589e3265c74159130230c164ff2d8d381be65899a249def0b53f93ce83fd47
   md5: 245cb7173dcdba21cf368031cd87f706
   depends:
@@ -1473,7 +1473,7 @@ packages:
   license_family: MIT
   size: 17434
   timestamp: 1676823330845
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-2024.2.0-py311hf4808d0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fastparquet-2024.2.0-py311hf4808d0_0.tar.bz2
   sha256: b7f0f6cc1213a6f36d1ca1844b6fa918833a737703f54e719bd71cd3b39eba9e
   md5: 9aa84ee8cddc8aaa057295e1853c3ad2
   depends:
@@ -1488,7 +1488,7 @@ packages:
   license_family: Apache
   size: 683044
   timestamp: 1715262508371
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.55.3-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fonttools-4.55.3-py311h5eee18b_0.tar.bz2
   sha256: a26c56f941d50242db192dcb73fdcf195e0a3ad38919bda027d21d32c47a8d5c
   md5: d3090d6cf0c24c8ce35091cdfb4f85be
   depends:
@@ -1507,7 +1507,7 @@ packages:
   license_family: MIT
   size: 3312570
   timestamp: 1737039356330
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
   sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
   md5: a5dc8677d891dff2393b63189a3ad42f
   depends:
@@ -1518,7 +1518,7 @@ packages:
   license_family: Other
   size: 971975
   timestamp: 1666798278693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.12.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fsspec-2024.12.0-py311h06a4308_0.tar.bz2
   sha256: 4a20bf26e48e997957f09c47b68b18ddfd0ba9326e43767b1066a9c1a5a872db
   md5: c256cee55d0b5c19eb4883ce0a6ef8c8
   depends:
@@ -1529,7 +1529,7 @@ packages:
   license_family: BSD
   size: 391598
   timestamp: 1736274697928
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
   sha256: 2fc1136056f41fe92de719fb821550346704965dd12a5fa35069cdb4948d5c17
   md5: fd089b0fba2b03aafe3adb6cdaa9ac3b
   depends:
@@ -1539,7 +1539,7 @@ packages:
   license_family: BSD
   size: 203421
   timestamp: 1706888218007
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
   sha256: f1e190d4ee766add8131a2b011723c472284de2bbb5e07c8f895f30e3c591df7
   md5: 82029e0758feac811afec2a6ef9e6155
   depends:
@@ -1550,7 +1550,7 @@ packages:
   license_family: BSD
   size: 108438
   timestamp: 1706895276199
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.20.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.20.1-py311h06a4308_0.tar.bz2
   sha256: d2d94eb25aa4ab4d7ba21e40350ec6f4930013f62040a9b5b86f429b4a11ad1c
   md5: 89c07e7d38ff95e603bcb70186f0204b
   depends:
@@ -1570,7 +1570,7 @@ packages:
   license_family: BSD
   size: 6127969
   timestamp: 1740582781565
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
   sha256: b35b281dbf69b826c6ae04fcd7b6a2d1f098277a669a199906a1f23b4b0931a5
   md5: 2a793fe24f85aa5819fe69c450cba6f7
   depends:
@@ -1580,7 +1580,7 @@ packages:
   license_family: MIT
   size: 29021241
   timestamp: 1692293243228
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
   sha256: e08e27531775de40f46b6ac7bf71856963baa0c008bd2b4d112e6341cd3e8f4c
   md5: bfc7682613c861cbcb4ac01485c05657
   depends:
@@ -1589,7 +1589,7 @@ packages:
   license_family: BSD
   size: 147174
   timestamp: 1714398938840
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/imageio-2.37.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/imageio-2.37.0-py311h06a4308_0.tar.bz2
   sha256: 67fa968580722a3f4c5ebfeab2748daa58518e2bb005d5214962e39021329751
   md5: 813d87f2c2922f553bdbd29d1cca7592
   depends:
@@ -1600,7 +1600,7 @@ packages:
   license_family: BSD
   size: 665720
   timestamp: 1738160075021
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-8.5.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/importlib-metadata-8.5.0-py311h06a4308_0.tar.bz2
   sha256: 0b292de5578240518ff0e3e829a836e29b75fede7dd6b77d87e635680b3cd970
   md5: 6a34f99c9b49a106851598516cb2ee9f
   depends:
@@ -1610,7 +1610,7 @@ packages:
   license_family: APACHE
   size: 54269
   timestamp: 1732633524542
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
   sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
   md5: 3add2ce56858a1b8f6a37342f82773d3
   depends:
@@ -1626,7 +1626,7 @@ packages:
   license_family: Proprietary
   size: 19310769
   timestamp: 1699647799237
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.29.5-py311h06a4308_1.tar.bz2
   sha256: 582a57ce666b49fe02ebc6f8bebe8b48938833968b58be98e4efefd73d7ad226
   md5: 61267bc76e930917150fcba755e607dc
   depends:
@@ -1647,7 +1647,7 @@ packages:
   license_family: BSD
   size: 238192
   timestamp: 1737660819687
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.30.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.30.0-py311h06a4308_0.tar.bz2
   sha256: 8d16ed1f5ff00f096b360ce1d7f9b4a4878ddcc8c866c4e5da1d2d9c2cd98d5b
   md5: 7bfea7a1bfd1c08fddd95dc471270519
   depends:
@@ -1665,7 +1665,7 @@ packages:
   license_family: BSD
   size: 1634301
   timestamp: 1734548199842
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.19.2-py311h06a4308_0.tar.bz2
   sha256: 61d1e8ff671b50ee001b1702b12f44572f6963157964c825c7358ecd2e62bc16
   md5: f4040af0e38070f691bf43c120e8744f
   depends:
@@ -1675,7 +1675,7 @@ packages:
   license_family: MIT
   size: 1172008
   timestamp: 1733987427312
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.5-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.5-py311h06a4308_0.tar.bz2
   sha256: 59c96b9acaf6b0f497e7900ca5d37049fe34be53e6efcb818183563a89e5f674
   md5: c0187cdffb26e981be0c64ec8b4fb70d
   depends:
@@ -1687,7 +1687,7 @@ packages:
   license_family: BSD
   size: 357212
   timestamp: 1737760133539
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
   sha256: 8316ae3abee25edab89788ee6e9eef79c398aba192559f514674a04ee1860bca
   md5: 112209aed451545a622ab217c70f6972
   depends:
@@ -1696,7 +1696,7 @@ packages:
   license_family: Other
   size: 283506
   timestamp: 1722872662693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.23.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.23.0-py311h06a4308_0.tar.bz2
   sha256: caafff289b6a96f7f13668faa72e7a85346f410b1f97dc34163f70746bb98f1b
   md5: 27d1820c6bd6185aa888ee994d290bf1
   depends:
@@ -1709,7 +1709,7 @@ packages:
   license_family: MIT
   size: 192447
   timestamp: 1728486794980
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
   sha256: 9e3bac2d41bd432b721b009e7de981766fba396e6f238e923f304112bd88655a
   md5: 84ae4cf3f2d01fbebdac374971192be9
   depends:
@@ -1719,7 +1719,7 @@ packages:
   license_family: MIT
   size: 15525
   timestamp: 1699032521315
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
   sha256: 79ce6dff3d93649a2555b1d2a4ae9eb77175a1c00664cb8eb0e6f848d5cdd1b9
   md5: db395b0efd7018fcf3a4af879170c2a8
   depends:
@@ -1735,7 +1735,7 @@ packages:
   license_family: BSD
   size: 276856
   timestamp: 1676823504812
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
   sha256: 91cca0ba49accdc9e97463bee087244a27ad107eb3af9ccb91634239f8b10f72
   md5: a185824bfc55bd90e1cf9330b417b74c
   depends:
@@ -1746,7 +1746,7 @@ packages:
   license_family: BSD
   size: 97359
   timestamp: 1718818381635
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
   sha256: 540f8dfb7cdc3877b4e24d6af65696d0bc7eae5de1c307229f86b3fe601a2286
   md5: f650f8c007471f6ef6c1a292918d2e1f
   depends:
@@ -1762,7 +1762,7 @@ packages:
   license_family: BSD
   size: 41920
   timestamp: 1718738122846
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
   sha256: 398387b6f1ee1691b04a31fedd1320225e5553aa921b06bc013f010a0008621e
   md5: bac66634a9133c633ddc879e14e83f23
   depends:
@@ -1789,7 +1789,7 @@ packages:
   license_family: BSD
   size: 610854
   timestamp: 1718827113534
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
   sha256: ddfee06ba9b149222c65d1d4270272840533aa63b56fe36363c84a891c71d328
   md5: ee128e5c0d8d9e1952e2387b66a5b8cb
   depends:
@@ -1799,7 +1799,7 @@ packages:
   license_family: BSD
   size: 27239
   timestamp: 1686870958829
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
   sha256: 0c6a074272ed58677ec17e4dbfceaffd2108841a61af92b32f156c5763108d1d
   md5: dd3d37841d0d20c70a60e8c939923894
   depends:
@@ -1811,7 +1811,7 @@ packages:
   license_family: BSD
   size: 19144
   timestamp: 1700168632051
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.8-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.8-py311h6a678d5_0.tar.bz2
   sha256: 83282f813347516f402cc0f0ac95ba07e59128ee3b7c28cca9d49f8ef115a8a7
   md5: 0326b3398754ac5583370fc797f5e8c4
   depends:
@@ -1822,7 +1822,7 @@ packages:
   license_family: BSD
   size: 79276
   timestamp: 1737039252672
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
   sha256: 01bae3dd44469e34f043e0416f5f5e658429bf4031745399d9968d10b899e2c4
   md5: 10171cca67e3d73c3646c6dc5a321460
   depends:
@@ -1834,7 +1834,7 @@ packages:
   license_family: MIT
   size: 1427115
   timestamp: 1686931095252
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lazy_loader-0.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lazy_loader-0.4-py311h06a4308_0.tar.bz2
   sha256: 3127b107ca08f3c374302d55b38d6b5255f7ae3775f1bfc0f596ec9e22222009
   md5: 1f2c186a765f44c14181d872345797e4
   depends:
@@ -1844,7 +1844,7 @@ packages:
   license_family: BSD
   size: 24758
   timestamp: 1718176785266
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.16-hb9589c4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.16-hb9589c4_0.tar.bz2
   sha256: 1b6b432a7ef79b3c29ab84e9fa1fb159837dd65b3997e9a6605896f3517dcfcf
   md5: ed981583bbc6e6ac7707895204653e0d
   depends:
@@ -1855,7 +1855,7 @@ packages:
   license_family: MIT
   size: 271236
   timestamp: 1734428496317
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
   sha256: 069d33aebaf4db4ae410d4acb4851860a69d2c8f326fd45ab2a67b67fe276e6d
   md5: 61689da52cf1fcebda8c9fb2872f94bf
   constrains:
@@ -1863,7 +1863,7 @@ packages:
   license: GPL-3.0-only
   size: 723073
   timestamp: 1727336193185
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-4.0.0-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lerc-4.0.0-h6a678d5_0.tar.bz2
   sha256: 3b35e98ab9e27e3c6ce1a4988087410c4f10f8f2dc7b32e5fd0597ae3330a6f0
   md5: 2a9cf942ef9eac2d34261363e6fbacad
   depends:
@@ -1873,7 +1873,7 @@ packages:
   license_family: Apache
   size: 283535
   timestamp: 1734423401417
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libabseil-20240116.2-cxx17_h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libabseil-20240116.2-cxx17_h6a678d5_0.tar.bz2
   sha256: 799f5e019772d5d774c07dbb8b8d633e0b559921c8ab16ab2276aca1ca4f2fa2
   md5: fe4de116b00c2c7eb7d307a58eef7429
   depends:
@@ -1886,7 +1886,7 @@ packages:
   license_family: Apache
   size: 1316915
   timestamp: 1716563364037
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
   sha256: e2754627e8aeb98777318939e6773b9eadbdc219dd8961aca946354d9d30f481
   md5: 4ed89646229bee3e594cd2cc8f6060f9
   depends:
@@ -1901,7 +1901,7 @@ packages:
   license_family: OTHER
   size: 23778916
   timestamp: 1696762223408
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_9.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_9.tar.bz2
   sha256: f4443a37d6eb1f35aed3b36d67ee10df39dccde535f3a6761fad44c0a516843d
   md5: 69b08a79ab20702c6bd5f77cc4063267
   depends:
@@ -1909,7 +1909,7 @@ packages:
   license: MIT
   size: 67000
   timestamp: 1736182526370
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_9.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_9.tar.bz2
   sha256: 51a57fc34ce6d44b35d76562b945a55efdcd663880bb1a153c44fe176fbc5c1a
   md5: 72d59a9872154e939d5759c7eb2c5db1
   depends:
@@ -1918,7 +1918,7 @@ packages:
   license: MIT
   size: 34506
   timestamp: 1736182538544
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_9.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_9.tar.bz2
   sha256: 5a43fa99f57fe609b374888359cecef39556ebf9c5fb6fd35eb9694f054b65eb
   md5: 3c5dbc154e879dcfd5e71c8cd56202ff
   depends:
@@ -1927,7 +1927,7 @@ packages:
   license: MIT
   size: 295241
   timestamp: 1736182548938
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.12.1-hc9e6f67_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libcurl-8.12.1-hc9e6f67_0.tar.bz2
   sha256: 66d224610f31352ed42cd1b7fd8c3d8718d7774b32520f905b953e3044ed06c4
   md5: 79558711ab0e4fc10b49e2db2e868af7
   depends:
@@ -1944,7 +1944,7 @@ packages:
   license_family: MIT
   size: 457077
   timestamp: 1739986326232
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.22-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.22-h5eee18b_0.tar.bz2
   sha256: 99b22a8ac9907bf834b06bc1d4c046a46e0d1fe8f044e03b287ca80490ffd7b3
   md5: c75f9e8e2f44baf9a36b4d7ac80eb2bc
   depends:
@@ -1953,7 +1953,7 @@ packages:
   license_family: MIT
   size: 78335
   timestamp: 1734423317784
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
   sha256: 5bd3af246b6a93ea0912179ae66e0ad9157ca0142263010d84b65724e6db0bec
   md5: 5cb0cc0e1783419cf8fc1c65fee0f62f
   depends:
@@ -1963,7 +1963,7 @@ packages:
   license_family: BSD
   size: 195807
   timestamp: 1703006263489
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
   sha256: efdab884c85fda4461f7a393aa6d4e0e50d03cb59fb9c8a980b1307b8379ebe0
   md5: eeca774c6154c49340dd403b1928d5e9
   depends:
@@ -1972,7 +1972,7 @@ packages:
   license_family: BSD
   size: 108906
   timestamp: 1632891483341
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
   sha256: 4b2518a1aa3859031a531cd1077e8a60d5b3a0dc7c83210ef27ff9ce2c78c3e3
   md5: 49f152ee4045544c10799d32bba85c07
   depends:
@@ -1983,7 +1983,7 @@ packages:
   license_family: BSD
   size: 480247
   timestamp: 1685052130829
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
   sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
   md5: 1af9b4d62c708924417f2640ef22a68f
   depends:
@@ -1993,7 +1993,7 @@ packages:
   license_family: MIT
   size: 154016
   timestamp: 1714483282916
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
   sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
   md5: 641e72e5067bd6d5454405879e1cd2a7
   depends:
@@ -2008,7 +2008,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 8895144
   timestamp: 1654090827491
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
   sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
   md5: 27082517590f3b9fbffecc68513b461b
   depends:
@@ -2017,7 +2017,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 19860
   timestamp: 1654090819660
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
   sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
   md5: 0202c3c8ae4735cac6c7f3d1e1685964
   constrains:
@@ -2025,7 +2025,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 5228750
   timestamp: 1654090762569
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
   sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
   md5: 3080c2813e6e1d0f8a100a38b5b3456d
   depends:
@@ -2033,7 +2033,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 573231
   timestamp: 1654090775721
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgrpc-1.62.2-h2d74bed_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgrpc-1.62.2-h2d74bed_0.tar.bz2
   sha256: 498fafb5df2311ce582cbdfd9262f060a484ad8577030298deed948a3c491cd7
   md5: 3065951fe45c36bb91009a61776f5e9a
   depends:
@@ -2052,7 +2052,7 @@ packages:
   license_family: APACHE
   size: 9018521
   timestamp: 1716835817873
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm15-15.0.7-he89c38a_4.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libllvm15-15.0.7-he89c38a_4.tar.bz2
   sha256: c8138d6c8b3ffb43748b898c03c375c486455f5625011584ef955c596587519f
   md5: 2b261a273c1a14918d47243633cecc1d
   depends:
@@ -2066,7 +2066,7 @@ packages:
   license_family: Apache
   size: 39428816
   timestamp: 1730400002494
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
   sha256: 6c67d781d3c074ae46b18567f230bce4a4afa209e8b914dc2cb448502774886e
   md5: c9627c386bbc8a1a1a0a2e736ea44501
   depends:
@@ -2082,7 +2082,7 @@ packages:
   license_family: MIT
   size: 722387
   timestamp: 1697018420830
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
   sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
   md5: 1bffe1481ed4f88827248fb9001f8923
   depends:
@@ -2092,7 +2092,7 @@ packages:
   license_family: Other
   size: 362561
   timestamp: 1677841789536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-4.25.3-he621ea3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libprotobuf-4.25.3-he621ea3_0.tar.bz2
   sha256: c070317f268dfcf77d5ff50c286bf430419fa9267eeea67d622f85c25fc6de9d
   md5: 1672198ffdc6aabb8750c51496719e19
   depends:
@@ -2105,7 +2105,7 @@ packages:
   license_family: BSD
   size: 3242840
   timestamp: 1716568319462
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -2113,7 +2113,7 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.11.1-h251f7ec_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libssh2-1.11.1-h251f7ec_0.tar.bz2
   sha256: 2fee5719b7bcaac278f03d4e5c15f17cf5840ed563de6730b4778c0fd62b8d9f
   md5: 162db824b70ea49175750d732102ec58
   depends:
@@ -2124,7 +2124,7 @@ packages:
   license_family: BSD
   size: 301096
   timestamp: 1732891131339
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
   sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
   md5: 8c195584a5f5471b600ee180e4052773
   depends:
@@ -2132,7 +2132,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 6410287
   timestamp: 1654090800863
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
   sha256: 974e4035c5d51cd41fa7a7f02fadc1980069c00526c1646fa18ea94e667fb137
   md5: 188de945b4279a812953011e8c4580c2
   depends:
@@ -2146,7 +2146,7 @@ packages:
   license_family: Apache
   size: 4630795
   timestamp: 1687975185557
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-hffd6297_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-hffd6297_1.tar.bz2
   sha256: 00c29474500c2db177d482b62dd42392327376823464961995d60ee5c7679c55
   md5: d26f4756467be40670835398528d1309
   depends:
@@ -2163,7 +2163,7 @@ packages:
   license_family: Other
   size: 663476
   timestamp: 1734425727361
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
   sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
   md5: 292768ec77416ae257cfdd44ea2071c8
   depends:
@@ -2172,7 +2172,7 @@ packages:
   license_family: BSD
   size: 29197
   timestamp: 1668082729834
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
   sha256: a062fad27450b94279d1688aabd11a95eedee7814462ef6364337d55412b4a7e
   md5: e0521f84b9770830e654432364ac930e
   depends:
@@ -2183,7 +2183,7 @@ packages:
   license_family: BSD
   size: 484011
   timestamp: 1729160032020
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.13.5-hfdd30dd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libxml2-2.13.5-hfdd30dd_0.tar.bz2
   sha256: ce666a7b5b6ce0e36b6e19014c30bf98c5c067ebe64cfa37d86c864ebbe04db5
   md5: 2d21c00fb7dc7a540e1a1aed30eef237
   depends:
@@ -2195,7 +2195,7 @@ packages:
   license_family: MIT
   size: 742705
   timestamp: 1732316075095
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
   sha256: fd8e30beb8c9442f16e6617fac92dd0c89ec823e98f06e60f712147380ead35f
   md5: 7ed7caf2816c8b85b67b6f4e8833cbd5
   depends:
@@ -2205,7 +2205,7 @@ packages:
   license_family: MIT
   size: 41155
   timestamp: 1676837080881
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.44.0-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/llvmlite-0.44.0-py311h6a678d5_0.tar.bz2
   sha256: eaf9b9a6be9b9086ae23b054d3dd3ac643316b8b27734b2168e52dd4c62278d9
   md5: f4f7eeab21c48d3cb6d6bde05bd98343
   depends:
@@ -2217,7 +2217,7 @@ packages:
   license_family: BSD
   size: 5297287
   timestamp: 1738678576396
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
   sha256: 95fe76d2691feb13203b55ad2aba535bb848cae21ffd05b13ff51c7a45fa2332
   md5: 6a04ec16e3abc1c7e2104be32cd6c418
   depends:
@@ -2226,7 +2226,7 @@ packages:
   license_family: BSD
   size: 13458
   timestamp: 1676827287432
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py311h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-4.3.2-py311h5eee18b_1.tar.bz2
   sha256: c5f6a345b9a8e8e3b7f5368b6732e2ea0123451b6519b22913def3e2d2eab795
   md5: 09b4afa08f1175ebb6fd23bd55f3d20c
   depends:
@@ -2237,7 +2237,7 @@ packages:
   license_family: BSD
   size: 40866
   timestamp: 1736366782736
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
   sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
   md5: 76f089e76ec67583bb38428b51008097
   depends:
@@ -2247,7 +2247,7 @@ packages:
   license_family: BSD
   size: 164494
   timestamp: 1714510587156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
   sha256: 260e26dd509834c1b225ab7bdb97b9a86e00054fbdd5dfa49e68fa4dcf85a661
   md5: 8f5d7ddc69cc6f7d44c80d2251dea5d1
   depends:
@@ -2256,7 +2256,7 @@ packages:
   license_family: BSD
   size: 162339
   timestamp: 1676837095436
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
   sha256: 7f5b0804d0768619b7bd93b10488067d80bf42ec29f443f00b53ba11758a1241
   md5: 8afb45e45c0d93bfd142e682d4b021ef
   depends:
@@ -2266,7 +2266,7 @@ packages:
   license_family: MIT
   size: 134438
   timestamp: 1684280014220
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-3.0.2-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-3.0.2-py311h5eee18b_0.tar.bz2
   sha256: a77bbb4f7a346d892137624387e6c61ae08528013eb5a7dccf1ff8106f4f7aee
   md5: 5aac92e1241121c99dc5ac5b866dc1d7
   depends:
@@ -2278,7 +2278,7 @@ packages:
   license_family: BSD
   size: 28215
   timestamp: 1738584091856
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.10.0-py311hbfdbfaf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.10.0-py311hbfdbfaf_0.tar.bz2
   sha256: 4a1053eb7d779473df2b6af99649e20af08b3bfadaba59009df756585e7bf107
   md5: 803563191e37b0fc9bf0ca62d13b2d10
   depends:
@@ -2299,7 +2299,7 @@ packages:
   license_family: PSF
   size: 9818267
   timestamp: 1736278428611
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
   sha256: 7ac07ea180b5928086075900afbc332fb1d3c81ddfacb54c891693c284056f14
   md5: fc83dd1b3d2ec3c0a297ead0c3405907
   depends:
@@ -2309,7 +2309,7 @@ packages:
   license_family: BSD
   size: 19573
   timestamp: 1676823852670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
   sha256: c9ba2f9c83820712dd97d6a1b54a1215b9820a0be02ac82380b4c50911b9400c
   md5: e5dc6b4a5b8e02733ce3bc9e9198a8d2
   depends:
@@ -2319,7 +2319,7 @@ packages:
   license_family: MIT
   size: 67750
   timestamp: 1676837123613
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
   sha256: 1a5141ef0de1cbff816f96bb4b212a40606e2fc11301a4c1358c8d63a6b2b027
   md5: 22ac3bc22b68fef4c1f3f6ab3c7bfe0b
   depends:
@@ -2328,7 +2328,7 @@ packages:
   license_family: MIT
   size: 23040
   timestamp: 1676827301164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
   sha256: 9aacfbbe6f638c58a4e8ff31374d1438d78b7db25d6ea6fd0c50ca2109f225d4
   md5: e602057e3b3d80da88c61d66e8851c5b
   depends:
@@ -2339,7 +2339,7 @@ packages:
   license_family: BSD
   size: 104681
   timestamp: 1676823696152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
   sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
   md5: ce77d0f05f846da4a6b9e23fe7f21d9b
   depends:
@@ -2353,7 +2353,7 @@ packages:
   license_family: Proprietary
   size: 206738176
   timestamp: 1699648006088
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py311h5eee18b_2.tar.bz2
   sha256: 2aa10f19199e2f594db9d292538611b60f9eb8604ac2e8ed5658360da0417fed
   md5: 1bb09282d58781f1886968ec437e1db9
   depends:
@@ -2364,7 +2364,7 @@ packages:
   license_family: BSD
   size: 76075
   timestamp: 1736367004456
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.11-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.11-py311h5eee18b_0.tar.bz2
   sha256: 26001bced97eaa8c3862686f48668a252b8f7fd6ed81329534bee0538ea39fe0
   md5: eb3e382c51549878d07e5c3e207c3845
   depends:
@@ -2378,7 +2378,7 @@ packages:
   license_family: BSD
   size: 241049
   timestamp: 1730824176185
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.8-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.8-py311ha02d727_0.tar.bz2
   sha256: afc57040e0c892e46b00ecb534100fcaf05d8c75592170b0ce9119f2e5630557
   md5: 5e47055fea53886417e9a62d4e89c7c9
   depends:
@@ -2393,7 +2393,7 @@ packages:
   license_family: BSD
   size: 411216
   timestamp: 1730824036145
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py311hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/msgpack-python-1.0.3-py311hdb19cb5_0.tar.bz2
   sha256: ee4db7daf8d5e41a547e7790dd62aa98e203f4f857cf6018b850e7df8e613a3c
   md5: 17145d1745996667614b52d2b27a1403
   depends:
@@ -2404,7 +2404,7 @@ packages:
   license_family: Apache
   size: 37588
   timestamp: 1676823053826
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
   sha256: b558b3f6c144652b5e0d26497b3ce24c318a6b9ff8ea2079113c95e5553b3cf9
   md5: 0b185969ac2b065c27cbcc9641d93678
   depends:
@@ -2414,7 +2414,7 @@ packages:
   license_family: BSD
   size: 29568
   timestamp: 1676841232463
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
   sha256: 6116c133fbed1e7ea0f5e69f900e93d7977cb715920d10b10642c191d00cc9a6
   md5: b842f7ebdc8b7b6a0dda4c5ebe12805b
   depends:
@@ -2427,7 +2427,7 @@ packages:
   license_family: BSD
   size: 8315206
   timestamp: 1717622768176
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
   sha256: bb45fb0a3973caa74fd8f845e0a519895f6a378807626e15ecf72c02f2eed794
   md5: 185f658ba8a74e326b7231c8fd0d62bf
   depends:
@@ -2440,7 +2440,7 @@ packages:
   license_family: BSD
   size: 121834
   timestamp: 1698934274227
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.16.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.16.4-py311h06a4308_0.tar.bz2
   sha256: 9361ab2f7b289e9fd33ef001035fbdca9735f1c5425bb8282ce053d152ffaa2c
   md5: f95894da2382644ab016e71dc0db3463
   depends:
@@ -2467,7 +2467,7 @@ packages:
   license_family: BSD
   size: 528660
   timestamp: 1728049573278
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.10.4-py311h06a4308_0.tar.bz2
   sha256: c7aa4facc9d03e5087f9b22a88373beb43633a2c558e895303f5accc3ce95142
   md5: 4b4927ae34aaf3ee6b008a4392afd2dd
   depends:
@@ -2480,7 +2480,7 @@ packages:
   license_family: BSD
   size: 169513
   timestamp: 1728049478168
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
   sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
   md5: 57ea097dc15f8d9f9eb90e1d919143b0
   depends:
@@ -2489,7 +2489,7 @@ packages:
   license_family: MIT
   size: 1157733
   timestamp: 1674734069410
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
   sha256: 266199dd4efde0ad342a9c500f4bc4299c5622219aea623b46315a9b4f6b8959
   md5: 2b21844d2b0024d0ffad0e6450cf0855
   depends:
@@ -2498,7 +2498,7 @@ packages:
   license_family: BSD
   size: 15860
   timestamp: 1708532713870
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.4.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/networkx-3.4.2-py311h06a4308_0.tar.bz2
   sha256: f54320cfc82be563199cafc28821cd5468c18d71d806e2f2ef353a309f91162d
   md5: 8a344fb902f2f8dccd67a77798d2f928
   depends:
@@ -2516,7 +2516,7 @@ packages:
   license_family: BSD
   size: 3404769
   timestamp: 1737039757951
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
   sha256: 59e169e036db0f2b98ed19f867d8ac708970214599efa0d57d3413fc1dbe8e3c
   md5: d0faf375bfc33811456d43fe549cb939
   depends:
@@ -2541,7 +2541,7 @@ packages:
   license_family: BSD
   size: 710152
   timestamp: 1717630833268
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
   sha256: ef2857e6d3d7eb246b3abddfbd3aa2d124dd8565391ace3876b77339babc50bb
   md5: d276d1b1774107987963135c78ca7390
   depends:
@@ -2551,7 +2551,7 @@ packages:
   license_family: BSD
   size: 26607
   timestamp: 1699455972519
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.61.0-py311h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numba-0.61.0-py311h6a678d5_1.tar.bz2
   sha256: 2f95537e4966bee197b435cdff1dbf2080822e3eb5c6f3fd5cbfee3122f31148
   md5: 43e6d6cf6df11282475ea663a3622b90
   depends:
@@ -2576,7 +2576,7 @@ packages:
   license_family: BSD
   size: 6321862
   timestamp: 1740752747545
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.10.1-py311h3c60e43_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.10.1-py311h3c60e43_0.tar.bz2
   sha256: c85ee5a0b557ed925a1709b7422f13e88545bd2392c63d8e65b8d4dd44bca713
   md5: 3ca48c350f813b2e11ed2312858098f7
   depends:
@@ -2592,7 +2592,7 @@ packages:
   license_family: MIT
   size: 204257
   timestamp: 1730216115069
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
   sha256: e09e1aff2c12d4ef3fec58fb627744e4b5c7d9eaede7175e293f77272d8b8bfd
   md5: fe8242cfd54d238507493612ae697ad4
   depends:
@@ -2609,7 +2609,7 @@ packages:
   license_family: BSD
   size: 10270
   timestamp: 1708639794640
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
   sha256: a53ad723826651041a5057a1cf31bc8689b24d335ce61b196df5124974b05a8e
   md5: 7b29e7191c4170189d6080e61229f030
   depends:
@@ -2625,7 +2625,7 @@ packages:
   license_family: BSD
   size: 9163911
   timestamp: 1708639777712
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
   sha256: 1c9f6902907a3d4a7e5c3cb02236491ea4c4e66a1a0ce51fa506dffb24ba89f6
   md5: 36d514eca3c87ab75a1d418607e26db2
   depends:
@@ -2637,7 +2637,7 @@ packages:
   license_family: BSD
   size: 528528
   timestamp: 1722872671997
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.16-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.16-h5eee18b_0.tar.bz2
   sha256: 3ddd6080b6f008c6270ada8aa125af76afb3bd4ea4fbc47acccc2dacae0af8ee
   md5: a659f1ac2ace6e5c8bf4a5074c3b7788
   depends:
@@ -2647,7 +2647,7 @@ packages:
   license_family: Apache
   size: 5513682
   timestamp: 1740989825289
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-2.0.1-h2d29ad5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/orc-2.0.1-h2d29ad5_0.tar.bz2
   sha256: b29f46d834ef22a9cb4a05cb241cb6881a69be8eb96fb643fa7edc192b46669e
   md5: 68b0e862640c31c5f82def14794015b5
   depends:
@@ -2663,7 +2663,7 @@ packages:
   license_family: Apache
   size: 1341122
   timestamp: 1717104644619
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
   sha256: 280225061aeba00d7b85f46e55d7d79cd92c92f662dc749d9c53187978e8d083
   md5: c51c21da68080d89300703ad818c824a
   depends:
@@ -2672,7 +2672,7 @@ packages:
   license_family: APACHE
   size: 38606
   timestamp: 1699371264464
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-24.2-py311h06a4308_0.tar.bz2
   sha256: 288da6ac31a1aebbd0571fe1d273c6095a0c049c6be93db899dfe45fc57c7936
   md5: 684139274d664e9d0458b11e8a46d55e
   depends:
@@ -2681,7 +2681,7 @@ packages:
   license_family: Apache
   size: 188806
   timestamp: 1734472196649
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.3-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-2.2.3-py311h6a678d5_0.tar.bz2
   sha256: f9c6066d840b6a7db19eb969637e9ae26b22a64f4c63e7d34639c5638d71bc2b
   md5: 5f21a0ac71dd61bb78501815e23e1117
   depends:
@@ -2732,7 +2732,7 @@ packages:
   license_family: BSD
   size: 17990544
   timestamp: 1732738272325
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-1.6.0-py311h06a4308_0.tar.bz2
   sha256: 97fb5715b3e6bd925f9ce7239085ce4479c9c451301fe5a5ab91d201e2f20fd7
   md5: 641fd555bafec41ede9bf09c3f327fac
   depends:
@@ -2757,7 +2757,7 @@ packages:
   license_family: BSD
   size: 24391130
   timestamp: 1738685172659
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.2.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-2.2.0-py311h06a4308_0.tar.bz2
   sha256: d137c487271bef84a7d0a7497439db4d0a07b6b4a9e30036b19bfd264828b728
   md5: 80cb61dac081768a5d5d2d925a61896d
   depends:
@@ -2766,7 +2766,7 @@ packages:
   license_family: BSD
   size: 268099
   timestamp: 1734618713828
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/parso-0.8.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/parso-0.8.4-py311h06a4308_0.tar.bz2
   sha256: e40e60301997a3b5ff53b7ed7365db536f1b492a829ce2946ac61f6f7321c1a3
   md5: d9f873bfc00a48198c960c9ba56f9e93
   depends:
@@ -2775,7 +2775,7 @@ packages:
   license_family: MIT
   size: 222615
   timestamp: 1733963432742
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/partd-1.4.2-py311h06a4308_0.tar.bz2
   sha256: b96acd51c903ff9b5611255f16c27ef589fc39a05ae4d61c9224850b4eeb6fe4
   md5: eb0b306fec6e0beabe0080e4122a9c8c
   depends:
@@ -2789,7 +2789,7 @@ packages:
   license_family: BSD
   size: 47364
   timestamp: 1736803437262
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-11.1.0-py311hcea889d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-11.1.0-py311hcea889d_0.tar.bz2
   sha256: 630ef38f47357fe4ed046a3b71ebe382aa253b59793840775a186c9c63dc6e57
   md5: 60bf75f54f265640a5c80a65d77103d5
   depends:
@@ -2807,7 +2807,7 @@ packages:
   license_family: Other
   size: 1000438
   timestamp: 1738010435246
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-25.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-25.0-py311h06a4308_0.tar.bz2
   sha256: 64f16503d8799c8ed3031e8c81d429353406504e98cefed97080fc35e2b55fc0
   md5: de0f3617ef38333a13b7aebb17b761a0
   depends:
@@ -2818,7 +2818,7 @@ packages:
   license_family: MIT
   size: 2971886
   timestamp: 1737992037529
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
   sha256: d2bbab8bfc57c7f46ca8994bc87df7e744d3f036b867bc4be1145ba6d8d7e091
   md5: de41707272a8e3ccab764f0b7010a27d
   depends:
@@ -2827,7 +2827,7 @@ packages:
   license_family: MIT
   size: 37394
   timestamp: 1692205565974
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.21.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.21.0-py311h06a4308_0.tar.bz2
   sha256: ef83087f0474cbc11bf6ab7c318a56a7677c6dcc57c75d5ed52a0a2a6bda30a2
   md5: 25de2c05534f16c0e2b61429c7c2d3bb
   depends:
@@ -2836,7 +2836,7 @@ packages:
   license_family: Apache
   size: 121560
   timestamp: 1731953225009
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
   sha256: b7f591c19b10bf0daa7e6e3b45a9f4a0a0e83188e1f8a58037caea79e60f8d91
   md5: d945b4ccc135005839c504cc29df1745
   depends:
@@ -2848,7 +2848,7 @@ packages:
   license_family: BSD
   size: 749608
   timestamp: 1704404477511
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py311h5eee18b_1.tar.bz2
   sha256: 675e161cff8bc0f660b3f7ea5692207de372730d9ea2d5410a1e76c8e3cb24d5
   md5: 924cb59384b001ea5e9e37d1638820cc
   depends:
@@ -2858,7 +2858,7 @@ packages:
   license_family: BSD
   size: 495241
   timestamp: 1736367238095
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-19.0.0-py311h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyarrow-19.0.0-py311h6a678d5_1.tar.bz2
   sha256: edcfdcaba5832487d9b52a4d18b9e8a53b62e3a0ba5be7fe2998d83bdae011f0
   md5: 4bd50f981e639a6e4750d05600b5522c
   depends:
@@ -2872,7 +2872,7 @@ packages:
   license_family: Apache
   size: 8956536
   timestamp: 1738231250212
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
   sha256: eb75b4417565d25e2d1006db75aa8bd9da6b6c72a929954b01a31b9bf5f8b42e
   md5: bb56c0358b65665f4dd509a4635f6f3c
   depends:
@@ -2884,7 +2884,7 @@ packages:
   license_family: BSD
   size: 37802
   timestamp: 1676838557935
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
   sha256: ed927e4d058a8f4ea73edc7a43ed74877d93b88fdfa240b3b2777244386ced70
   md5: a1f0e05fc7e49712f81ad5478ec9d51e
   depends:
@@ -2893,7 +2893,7 @@ packages:
   license_family: BSD
   size: 2121496
   timestamp: 1684280065800
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.2.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.2.0-py311h06a4308_0.tar.bz2
   sha256: b5d27b938ed374a24fcb18a66c3f1a94e28bbe01b4ac156cd26c7be1ca756622
   md5: 244cfad440c898146039cb986864017e
   depends:
@@ -2902,7 +2902,7 @@ packages:
   license_family: MIT
   size: 486387
   timestamp: 1731445563066
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
   sha256: 114b55e00f4622c90fd2b404b21ad5f94a10283fcaaf86a42174b8d39b0a3e98
   md5: 2458e92683cc68671a6c8e1b86ce8817
   depends:
@@ -2911,7 +2911,7 @@ packages:
   license_family: BSD
   size: 35850
   timestamp: 1676822725516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.11-he870216_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.11.11-he870216_0.tar.bz2
   sha256: aced5b9158e4839247dcf76bd5197650803f9db116ccdc451a79d1c0da5f2354
   md5: bc33687df04e0cfeebd12f682bec6b22
   depends:
@@ -2933,7 +2933,7 @@ packages:
   license_family: PSF
   size: 36116799
   timestamp: 1733935613200
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
   sha256: a0f008717fab060ccd003dfebc09156d90b9afd14ac3626566aa1a8f3d3b7e2f
   md5: 357bf4fe94496cbae72ab4d780184b31
   depends:
@@ -2943,7 +2943,7 @@ packages:
   license_family: BSD
   size: 330924
   timestamp: 1716495762901
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.20.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.20.0-py311h06a4308_0.tar.bz2
   sha256: 8e42421bb620d1e12ab455da3594c2129b0a6d994a0be6a1e4519d1d3ead360f
   md5: 99293d1a98a94e2b11c5d598ea2d80a8
   depends:
@@ -2952,7 +2952,7 @@ packages:
   license_family: BSD
   size: 281088
   timestamp: 1731939500285
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-3.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-json-logger-3.2.1-py311h06a4308_0.tar.bz2
   sha256: 0cb8b14ce460a6927a4b1e9c2b2737b8668f7bae47998c56d2e307706f72076f
   md5: eb0b1081560d413b713603a3bdb9b0dd
   depends:
@@ -2961,7 +2961,7 @@ packages:
   license_family: BSD
   size: 28481
   timestamp: 1734370110052
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.6.2-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-lmdb-1.6.2-py311h6a678d5_0.tar.bz2
   sha256: bdd5c8398e306eec5a30c9cd6ea3181cb453c89d42cd81cc40e581334381d136
   md5: bb38a06afd93970d169f58d9f379334b
   depends:
@@ -2972,7 +2972,7 @@ packages:
   license_family: Other
   size: 154000
   timestamp: 1736540736166
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-snappy-0.6.1-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-snappy-0.6.1-py311h6a678d5_0.tar.bz2
   sha256: 68ecfb1ece016cb4610ddc746022ba892d30efbe12ec0858c605ca18c363098d
   md5: ef7c3d6a2becca7997b00e1ff9444dbb
   depends:
@@ -2984,7 +2984,7 @@ packages:
   license_family: BSD
   size: 36679
   timestamp: 1676842382142
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
   sha256: b85acb933fff864bfa89d034e8e3d85b1a9c2e69cbfc0d68c1d66ffd1443e67d
   md5: 0cdb92d2d684ee1095310f992ed0d9b2
   depends:
@@ -2993,7 +2993,7 @@ packages:
   license_family: MIT
   size: 266796
   timestamp: 1713974338678
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
   sha256: 511e8206a15445715b80be76493300930686b3fe1e512ae942d6ccca36df392a
   md5: 35a6e46ae970f8b71d78fb5a810f2e80
   depends:
@@ -3005,7 +3005,7 @@ packages:
   license_family: BSD
   size: 64013
   timestamp: 1711136926372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.2-py311h5eee18b_0.tar.bz2
   sha256: 132aa25ee904333ef338eb1935dd8e5ccffb27cacf33fdb58c1358ec22424933
   md5: 92ce34b6f4f7a6e64c80c2ba0a96edf4
   depends:
@@ -3016,7 +3016,7 @@ packages:
   license_family: MIT
   size: 222337
   timestamp: 1728658052191
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
   sha256: 7c74db4292f31619606180f86f3c1e2d913495c2c9d1195c5d51681a6a841625
   md5: be1c05fae57d194924b9400f9b5ad3c6
   depends:
@@ -3027,7 +3027,7 @@ packages:
   license_family: Other
   size: 613277
   timestamp: 1709318516682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
   sha256: 8a640736bef635346409582dbfe2b7d0ecc9da215c90173ff8a9a5fe22569107
   md5: 6b583dce61c6feb352ef0f49f413af1e
   depends:
@@ -3036,7 +3036,7 @@ packages:
   license: BSD-3-Clause
   size: 235004
   timestamp: 1652449537852
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
   sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
   md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
   depends:
@@ -3046,7 +3046,7 @@ packages:
   license_family: GPL
   size: 467661
   timestamp: 1666648052561
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
   sha256: 89c2f4235277b9825cc805c5c44f0b1afcb683d7b5a3f513bc4bf243b643bb0c
   md5: db70eb57e33adf7b8bbdadd72214d48d
   depends:
@@ -3057,7 +3057,7 @@ packages:
   license_family: MIT
   size: 73679
   timestamp: 1699012111499
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.32.3-py311h06a4308_1.tar.bz2
   sha256: 1ac5ee93110e2f7f1d68b6c985e4adcc3710f537c388ae3ff4f85059288070a1
   md5: 4385913efbeb323430797aa3b3506525
   depends:
@@ -3073,7 +3073,7 @@ packages:
   license_family: Apache
   size: 123440
   timestamp: 1730999231468
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
   sha256: fdae3f68ea84b99561aee6c566ab1c287d8f2ae2668424e9283a8ed86af8f1d2
   md5: cde5b71ccbb3630053340b2c8c7dbf10
   depends:
@@ -3083,7 +3083,7 @@ packages:
   license_family: MIT
   size: 9333
   timestamp: 1683077183576
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
   sha256: 0bf859b06a07857099fd4f524fe5e0875fda70029e9485d95c7efa97134fbc14
   md5: fd5815cc592fdbd4c831901541eadaba
   depends:
@@ -3092,7 +3092,7 @@ packages:
   license_family: MIT
   size: 9735
   timestamp: 1683059096795
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.22.3-py311h4aa5aa6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.22.3-py311h4aa5aa6_0.tar.bz2
   sha256: 04dfe4c37981aa83a527943d1b8b97fc1114e5d8451f8a7419b82723cadf9ef9
   md5: 0077518e6e8f5086934b83c719e833fc
   depends:
@@ -3102,7 +3102,7 @@ packages:
   license_family: MIT
   size: 387461
   timestamp: 1736541527247
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
   sha256: 8c8aa1eb7e215984f46c8e1c7cfa6e5e6b233993d92b835a9b1b5491a4b970ab
   md5: 6e145b179adde03f8aa8a066c58d4e31
   depends:
@@ -3112,7 +3112,7 @@ packages:
   license_family: Apache
   size: 380702
   timestamp: 1706563445897
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scikit-image-0.25.0-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/scikit-image-0.25.0-py311h6a678d5_0.tar.bz2
   sha256: 74e2fb1d93c7088be9d830eb7b7a29fb8d4c63eba244439a11732594c3a0fa60
   md5: e7f65054b8f8bd918b017c68f204d54f
   depends:
@@ -3142,7 +3142,7 @@ packages:
   license_family: Other
   size: 13099498
   timestamp: 1737478036440
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.15.1-py311h08b1b3b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/scipy-1.15.1-py311h08b1b3b_0.tar.bz2
   sha256: 862b4557695d2e2b7b73dd644ed39b5b85bd9568b317a81f47becaa39e42ab38
   md5: 3ee39110782b4be9e58c7aefa3873d8e
   depends:
@@ -3160,7 +3160,7 @@ packages:
   license_family: BSD
   size: 30618018
   timestamp: 1737124439345
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py311h06a4308_1.tar.bz2
   sha256: e63e86fe0d0850be9875933c62bb6db688851aace1d9189bc1a47d469afd22b1
   md5: cca758835477ebeaa86f1baaad9e5072
   depends:
@@ -3169,7 +3169,7 @@ packages:
   license_family: BSD
   size: 32439
   timestamp: 1736540840590
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-75.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-75.8.0-py311h06a4308_0.tar.bz2
   sha256: e2b971b957b1bed5e0cc8921515c0013cfe657dc4c4a3a4e3f0ef475d5a3f768
   md5: 1aa6863387e163b749cd1df4a017af08
   depends:
@@ -3178,7 +3178,7 @@ packages:
   license_family: MIT
   size: 2303858
   timestamp: 1738045951501
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
   sha256: 8fd98235b37194986a5eb663c95a4a6db8c9e20a627f5c79ff8d9be3fd0e36f7
   md5: 25ac00d957eda056675f8fa3eafdf6df
   depends:
@@ -3188,7 +3188,7 @@ packages:
   license_family: BSD
   size: 52749
   timestamp: 1723557449203
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
   sha256: 1a84b00944bc5588e14a097460175f97df49acb4f1ff2498ffd9a1893068ed81
   md5: a456513471b2ecbed60430c21dd1ccc7
   depends:
@@ -3197,7 +3197,7 @@ packages:
   license_family: Other
   size: 17880
   timestamp: 1705431390054
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
   sha256: adcafd297d60af64107c113bb7b8b92160d0268a44ef9a3b79e56a88a0358ea7
   md5: 28ed704ed26b06d32662e3a6a87e59b0
   depends:
@@ -3206,7 +3206,7 @@ packages:
   license_family: MIT
   size: 88799
   timestamp: 1696347581401
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
   sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
   md5: f86119b3243fe3508160aa0406245738
   depends:
@@ -3219,7 +3219,7 @@ packages:
   license_family: Other
   size: 1723866
   timestamp: 1714488309729
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
   sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
   md5: 041a3caf09dc9ce8fc6c10925c4fe050
   depends:
@@ -3229,7 +3229,7 @@ packages:
   license_family: Apache
   size: 1888016
   timestamp: 1680167274961
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
   sha256: 856a8ab8c350c50247b79966c6cb80fb6d4de36eef49ddf75aebbbcaf854c82d
   md5: 442dde204d14d171aab9ee40e8de4de8
   depends:
@@ -3240,7 +3240,7 @@ packages:
   license_family: BSD
   size: 37456
   timestamp: 1677696176157
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tifffile-2024.12.12-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tifffile-2024.12.12-py311h06a4308_0.tar.bz2
   sha256: 5a301135c6e772da6b14b2468d957e9e7a9d9b28fd53f1fe4cd60a3614b561a1
   md5: f419995451f73f6ca2ab526f12f15110
   depends:
@@ -3254,7 +3254,7 @@ packages:
   license_family: BSD
   size: 520349
   timestamp: 1734340960378
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.4.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.4.0-py311h06a4308_0.tar.bz2
   sha256: c26644ab8c3641ee3e8a1f8b2c956ea4962f28766e63045d04830895a77ab4ef
   md5: dc03c456f163e2ee825ef58d7bda260e
   depends:
@@ -3264,7 +3264,7 @@ packages:
   license_family: BSD
   size: 105144
   timestamp: 1738337726955
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
   sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
   md5: e2512d57c8a1e91e7b20e265c6906546
   depends:
@@ -3274,7 +3274,7 @@ packages:
   license_family: BSD
   size: 3588922
   timestamp: 1714770676475
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-1.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/toolz-1.0.0-py311h06a4308_0.tar.bz2
   sha256: 122195bef57aa4b2f306fb9da598f624e7484cd68e12b153423163625d103e82
   md5: ce627ee2768dd9164e9dd38dbbfe493e
   depends:
@@ -3283,7 +3283,7 @@ packages:
   license_family: BSD
   size: 137395
   timestamp: 1736796348932
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.2-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.4.2-py311h5eee18b_0.tar.bz2
   sha256: 780986d79652f3f4eec28d8d9cdda134a1eed4aee302a66483ebfb8c5dbef877
   md5: 5c580c8870055c1a563959f98142f836
   depends:
@@ -3293,7 +3293,7 @@ packages:
   license_family: Apache
   size: 915944
   timestamp: 1733960601134
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.67.1-py311h92b7b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.67.1-py311h92b7b1e_0.tar.bz2
   sha256: ec9e26c23d9ecbf2659baf0bdb494fe7c8c1adfc2652f498e8a4c86e5c7d52cf
   md5: ad166b83ace6eccc6aece01e99b76df9
   depends:
@@ -3304,7 +3304,7 @@ packages:
   license_family: MOZILLA
   size: 154942
   timestamp: 1738943559030
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
   sha256: 2091b17ae4fa46ed98fd6bfe9ca1aff3b0b81d73045e0cc55774b6516b8704b3
   md5: 183ae7b837c1c68ec1a8011011fadea7
   depends:
@@ -3313,7 +3313,7 @@ packages:
   license_family: BSD
   size: 206924
   timestamp: 1718227183177
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.12.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.12.2-py311h06a4308_0.tar.bz2
   sha256: 48850864a536279a44c8e4b5eaf5d7d0b424df752374fb5624f2c3ecc8b8bc6d
   md5: 0f1d42f3ecfa42bbfe56e32d902fb88e
   depends:
@@ -3323,7 +3323,7 @@ packages:
   license_family: PSF
   size: 8924
   timestamp: 1734714943753
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.12.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.12.2-py311h06a4308_0.tar.bz2
   sha256: 613ddfe5f4e9f2cb37f63a58a2c1d8527e4f19b5758429752733ecb919ffd2c2
   md5: db0f11a0de3083f9288c7d3a054f3887
   depends:
@@ -3332,7 +3332,7 @@ packages:
   license_family: PSF
   size: 81460
   timestamp: 1734714938116
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
   sha256: 509b962773f0fe44a93a7f6196b254670a030eac8ea7f90727312e3ccd9294b2
   md5: 6c402d5bf4e01c8c3895c9ef41707b6e
   depends:
@@ -3341,7 +3341,7 @@ packages:
   license_family: MIT
   size: 11371
   timestamp: 1676828901104
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_1.tar.bz2
   sha256: 6156af1c5328402d038a8149b032afee72772ae42f41b7afb64b647b2f493072
   md5: ce769642bd2a2fc532a61d5d9ad75340
   depends:
@@ -3351,7 +3351,7 @@ packages:
   license_family: Apache
   size: 512446
   timestamp: 1736541055872
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.3.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-2.3.0-py311h06a4308_0.tar.bz2
   sha256: 3ecf92bcd85bddb047ae10562f5813cddb6308c82404041e38a2feecee84dff9
   md5: bc4a1212360e17741c57d46915763eae
   depends:
@@ -3367,7 +3367,7 @@ packages:
   license_family: MIT
   size: 221784
   timestamp: 1737133656065
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
   sha256: a8d11b0f08217607b99ba560edf66423ca1e36f4ffbb6e2377e61670e2b5f36b
   md5: 431e82b081b08aef0259df0437e04c75
   depends:
@@ -3376,7 +3376,7 @@ packages:
   license_family: MIT
   size: 97535
   timestamp: 1706894675990
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
   sha256: c3a5e0b855dc2de6c162708dfcf170a23eb9e7525d4252d8dce553369af4a330
   md5: a4c77e204b7787f820955166a1283168
   depends:
@@ -3385,7 +3385,7 @@ packages:
   license_family: BSD
   size: 25890
   timestamp: 1676823132898
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
   sha256: 42989f9970a8466cc4edb73463dfa194594dd1a5d42c9f820a1f86296d4af140
   md5: 655dfd4d2f17977cb81caa1c082d2b25
   depends:
@@ -3394,7 +3394,7 @@ packages:
   license_family: Apache
   size: 113505
   timestamp: 1715878346465
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.45.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.45.1-py311h06a4308_0.tar.bz2
   sha256: 4cde08f71cfbbfe04c2db531f02bbe41e59f4c8106035bf6879a60aa9b3be72a
   md5: 7f83df7c72bc54e8ea629254b604e996
   depends:
@@ -3403,7 +3403,7 @@ packages:
   license_family: MIT
   size: 144053
   timestamp: 1737990272462
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2024.11.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xarray-2024.11.0-py311h06a4308_0.tar.bz2
   sha256: a61dae57de0024ae96377788cf549c00f4d3b45e878e70f53f44388e9c608ad0
   md5: d453ecf0fc6e2d4367421b0ffadb0f1a
   depends:
@@ -3415,7 +3415,7 @@ packages:
   license_family: Apache
   size: 3005438
   timestamp: 1734535848338
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
   sha256: d18cdca154bf668826f869117ea996c4f9e8ef7d27b7c528332a7d17e5a8602c
   md5: 9f7353d72046b16dd6ef6b5689ac9bfd
   depends:
@@ -3424,7 +3424,7 @@ packages:
   license_family: BSD
   size: 54731
   timestamp: 1676828934954
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.6.4-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.6.4-h5eee18b_1.tar.bz2
   sha256: bcebbfa8a53efd5eaa77a0cd7f120b2e3a397e67aa78ebe907f1b35ae7148b0f
   md5: c924da317917a16d9d8551701b53ef7b
   depends:
@@ -3433,7 +3433,7 @@ packages:
   license_family: GPL2
   size: 580712
   timestamp: 1739468299256
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -3441,7 +3441,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
   sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
   md5: 943f1247a22b6b64171363bcee1eec27
   depends:
@@ -3452,7 +3452,7 @@ packages:
   license_family: Other
   size: 371663
   timestamp: 1705602144682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zict-3.0.0-py311h06a4308_0.tar.bz2
   sha256: f33ed759a551e2cd64115a3b01af0fc9822b1a5a1a5c798aa0ee14292792d7c1
   md5: 7feb38e587b3352efca77df1447858d2
   depends:
@@ -3463,7 +3463,7 @@ packages:
   license_family: BSD
   size: 102106
   timestamp: 1695832995689
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.21.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zipp-3.21.0-py311h06a4308_0.tar.bz2
   sha256: e46271d373c7df35529f3679fc35075ef0673e1f93cc43f388ecd50c3892ba47
   md5: efa61cd508fe869102963c235c0d91b7
   depends:
@@ -3472,7 +3472,7 @@ packages:
   license_family: MIT
   size: 29517
   timestamp: 1732630842012
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
   sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
   md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
   depends:
@@ -3481,7 +3481,7 @@ packages:
   license_family: Other
   size: 127143
   timestamp: 1714510716441
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
   sha256: a65c6277a3045e4ea72f617f977134c18366d8142ce51512f5a3cf325226a8bf
   md5: d941bb6fdc55cc1b3f67b3beb23d1795
   depends:
@@ -3494,7 +3494,7 @@ packages:
   license_family: BSD
   size: 1081416
   timestamp: 1728487031624
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -3507,7 +3507,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -3517,7 +3517,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
   sha256: c0dd89ffac001588171152a285ddbbaea209ebe4116010f985f898b7e87c2f35
   md5: 731ae7d446633bc729f3493a52d4365b
   depends:
@@ -3526,7 +3526,7 @@ packages:
   license_family: MIT
   size: 43502
   timestamp: 1721748373551
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -3535,7 +3535,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -3544,7 +3544,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -3553,7 +3553,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -3562,7 +3562,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
   sha256: 9de8666e5b70aa2437737128eaa14ffe80a7b5235c2a6b7d3f39ccefd7816ba0
   md5: bb52e50c5ab1a5c7778c11376404dfdb
   depends:
@@ -3570,7 +3570,7 @@ packages:
   license: BSD 3-Clause
   size: 7933
   timestamp: 1630598543551
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -3578,7 +3578,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -3587,7 +3587,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -3597,7 +3597,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
   sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
   md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
   depends:
@@ -3606,7 +3606,7 @@ packages:
   license_family: BSD
   size: 5106
   timestamp: 1704404390460
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -3614,7 +3614,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -3623,7 +3623,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -3632,7 +3632,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
   sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
   md5: 02caf3f47f1d06256068053297355740
   depends:
@@ -3641,7 +3641,7 @@ packages:
   license_family: Apache
   size: 152292
   timestamp: 1690578151230
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -3650,7 +3650,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
   sha256: 4e47f6c49ce84509f1466e8a4d728447bf4bcd9bce7b456431a789a262547067
   md5: 4cad993b0f80bc23fb66a97592299cbb
   depends:
@@ -3659,7 +3659,7 @@ packages:
   license_family: Apache
   size: 26504
   timestamp: 1623949147884
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -3671,7 +3671,7 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
   sha256: ca2be6c7810a37cfc6db1f5383937b5d35c6d73c1fad8a9104de85f069b1df1c
   md5: 9ccb2fb33edb152403d6ef32bf758a9d
   depends:
@@ -3680,14 +3680,14 @@ packages:
   license_family: BSD
   size: 15614
   timestamp: 1629402049497
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2025a-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2025a-h04d1e81_0.tar.bz2
   sha256: 3c9af6c00f75f5fbcad55fef878e67ea5db5bec590b928d4b1ba47aaa0f3d8d7
   md5: 200a475b8b5b4e72e8b5ceddf3d0f24a
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 126234
   timestamp: 1737549203664
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -3695,7 +3695,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.6.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-4.6.2-py311hecd8cb5_0.tar.bz2
   sha256: 10c81c3952bdf1073713a33f65f538082b2f6de47c4dff3cf173a18e4f014e7a
   md5: 87d1d76e942262c2c7c39370e30d7b3b
   depends:
@@ -3709,7 +3709,7 @@ packages:
   license_family: MIT
   size: 244917
   timestamp: 1729121433463
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
   sha256: ab7672364f1fa55ec5d8311d85d40e5b57cbd3517b17670557b6fb822bcf759c
   md5: 6e0159a5865cb7e96a748bd8560035ee
   depends:
@@ -3718,7 +3718,7 @@ packages:
   license_family: BSD
   size: 11579
   timestamp: 1678317458652
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h46256e1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py311h46256e1_1.tar.bz2
   sha256: 3f2344b378e912596a7b66e66e35833e7c20544446f7b19f25f4b500e5441a3d
   md5: c7914de4b54fc22e1b419b5c5426281e
   depends:
@@ -3728,7 +3728,7 @@ packages:
   license_family: MIT
   size: 34877
   timestamp: 1736182638965
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-19.0.0-hdba8a65_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/arrow-cpp-19.0.0-hdba8a65_0.tar.bz2
   sha256: eb59b3e6d30c9964959c8ac3f2be4b5bf0ff703ba982412825f08b95d859b8f2
   md5: bdeab8cabb00d64d2e85e14c2e4ad665
   depends:
@@ -3760,7 +3760,7 @@ packages:
   license_family: Apache
   size: 11032164
   timestamp: 1738050731377
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.3.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-24.3.0-py311hecd8cb5_0.tar.bz2
   sha256: 5543d56ca11cc3aef4c889d8824a798bc4418b82265f43bca53077724c7ed1e9
   md5: fe9dd468243c6b0fbd5d55cc5c2a60cb
   depends:
@@ -3769,7 +3769,7 @@ packages:
   license_family: MIT
   size: 163936
   timestamp: 1734533359828
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
   sha256: a153eee37b30ca5c25c5c95463a8852f1cf62a8f45f73349e68f1e3b22eec6da
   md5: 4bf760fad0e938618391f0db249d00e1
   depends:
@@ -3782,7 +3782,7 @@ packages:
   license_family: Apache
   size: 87236
   timestamp: 1706746160841
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
   sha256: 04ec5908b1dc2979ed50923af90d02da8a60434658efbc4f35fc61e7e9cafa0b
   md5: 6ba283b7f902226f232fe8a32fa83ee4
   depends:
@@ -3791,14 +3791,14 @@ packages:
   license_family: Apache
   size: 37547
   timestamp: 1706690917050
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
   sha256: 08431c5ec5f0a9e95819b6a76c9cc870d2154e46b229431fd0b3dad25bb70b04
   md5: 78b4b4225fdefef0b9b0d56b6e51e4a0
   license: Apache-2.0
   license_family: Apache
   size: 184146
   timestamp: 1706189913777
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
   sha256: 6a78705375d837a0eeeff9e914aae53a0d2cd44e9760075bdd8711a05f94ff3f
   md5: 931b0654ae05bcd1acc760dc830b89d3
   depends:
@@ -3807,7 +3807,7 @@ packages:
   license_family: Apache
   size: 17410
   timestamp: 1706690854689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
   sha256: 1d468f7c085b73cc40f813885d77a74270f94dd973b4285546d8873030fcada7
   md5: 3a61760bb61f85b3a0ffe7b14058801f
   depends:
@@ -3819,7 +3819,7 @@ packages:
   license_family: Apache
   size: 46197
   timestamp: 1706697276616
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
   sha256: b53432aadb2ffe2f1c584c6994b665f3620f29c51b200b03282065a480cf021e
   md5: 9686f32b210a009048c0877ac39fe88c
   depends:
@@ -3831,7 +3831,7 @@ packages:
   license_family: Apache
   size: 164397
   timestamp: 1706744140750
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
   sha256: 2ff9632eb2e2c7a70b8d64988e530d842fe5fa7fa529d34cda19f76fb40582e2
   md5: ffbd1ff65fe9fb52d833af5d396b006d
   depends:
@@ -3841,7 +3841,7 @@ packages:
   license_family: Apache
   size: 125589
   timestamp: 1706696187075
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
   sha256: fa57f1d2b2eb56db72e4b54348452af67a1222bd4266b3d68c7b7ff00399743b
   md5: ae9e78f6b1fef841fc0ffc7ef7c78d26
   depends:
@@ -3852,7 +3852,7 @@ packages:
   license_family: Apache
   size: 61379
   timestamp: 1706746740037
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
   sha256: 00834bd876756f1f13333c31623c2bdfa7d901b40aec161cf0343548fcd96187
   md5: 4ef080b5a91e260d51d563218396d0f6
   depends:
@@ -3866,7 +3866,7 @@ packages:
   license_family: Apache
   size: 67408
   timestamp: 1706747579372
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
   sha256: fb3198a05c96030d8498a5c4873e56ae28a5b04fb904a5c696a2192e9ee6c45b
   md5: 48efeda1471a50b9481c3943a0300e86
   depends:
@@ -3875,7 +3875,7 @@ packages:
   license_family: Apache
   size: 48055
   timestamp: 1706690833951
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
   sha256: f05fb72b1a5f25fab65ef416ff0d1966e3ff84f8a08c56bf809fb602028c66ec
   md5: 86cda3f774047ff6b40eb14aab83215d
   depends:
@@ -3884,7 +3884,7 @@ packages:
   license_family: Apache
   size: 51354
   timestamp: 1706192066535
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
   sha256: b8cb5f96e9eab47419622795fcdb42ad414481db9b84bbb50fcf8251a1314b59
   md5: 335265dfe12cb6adcacf39b411cf9d7a
   depends:
@@ -3902,7 +3902,7 @@ packages:
   license_family: Apache
   size: 210312
   timestamp: 1706827788950
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.11.212-h9475118_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/aws-sdk-cpp-1.11.212-h9475118_0.tar.bz2
   sha256: 51078459008a3618fbd15c4277487188c3cf7f9c5c8987f4bb0594b77032adb8
   md5: 6629a63506ad22cce3d8a2f89ef089ea
   depends:
@@ -3917,7 +3917,7 @@ packages:
   license_family: Apache
   size: 4299803
   timestamp: 1733148774517
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
   sha256: 365824e639808e52809f97b70b65da94a5eeb87e29dd97c8926aa72707a5a1c7
   md5: db7813418dfe42d59363fed4a68d5c36
   depends:
@@ -3927,12 +3927,12 @@ packages:
   license_family: MIT
   size: 278195
   timestamp: 1718029905185
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-openblas.tar.bz2
   sha256: 695ac69739e73351dfebfb01ea39c5e1dbfdcfb475590d6560ae318bfbad3a97
   md5: 38fd73cba341639c45d8c747b08c9cc1
   size: 49130
   timestamp: 1528225884020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bleach-6.2.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bleach-6.2.0-py311hecd8cb5_0.tar.bz2
   sha256: 7c36e9cb426d000a95c25bfbe5bfe627bf7c7954bb6726b2480e825ec6c41164
   md5: f97fe0299b63520bab00b5bdf52272fc
   depends:
@@ -3944,7 +3944,7 @@ packages:
   license_family: Apache
   size: 371442
   timestamp: 1732291870573
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.6.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-3.6.2-py311hecd8cb5_0.tar.bz2
   sha256: c8f2a98fb20810d9f6a1a93c0960558956ceeed9ab0ee8ff29e29f8db3024c01
   md5: f4955f95a41cda37d6a5f7ca853a2d3c
   depends:
@@ -3962,7 +3962,7 @@ packages:
   license_family: BSD
   size: 5890372
   timestamp: 1737999241552
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
   sha256: 81102f2762d8eb2f07c69fbf7ca7dad879a257a053085492d4c1b4006eb35fb8
   md5: 3c42777bc9330fe91177ea813b9ec252
   depends:
@@ -3972,7 +3972,7 @@ packages:
   license_family: OTHER
   size: 11744
   timestamp: 1696762233693
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.4.2-py311h9b7fc35_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.4.2-py311h9b7fc35_0.tar.bz2
   sha256: 2db3c754dcd7b5f87f8e9384509f539b3c9a80e7c26279c050814258e712a223
   md5: 24af5157264705bc3358ec195490de59
   depends:
@@ -3982,7 +3982,7 @@ packages:
   license_family: BSD
   size: 156491
   timestamp: 1731059250255
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311h6d0c2b6_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py311h6d0c2b6_9.tar.bz2
   sha256: c6ff30f54a4448526a1f2c9e5e4835e0416104c41e5b61bdbf6ff310a675641e
   md5: ac04cd8733681fabf6202b9d12a28235
   depends:
@@ -3991,28 +3991,28 @@ packages:
   license: MIT
   size: 394189
   timestamp: 1736182987784
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
   sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
   md5: c5a600d81b1b48578863af2973c743ac
   license: bzip2-1.0.8
   license_family: BSD
   size: 187637
   timestamp: 1714510590009
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
   sha256: f913b61ba3c1651b36688415cc163a5d575475f7573b543f48a80e7a5002e4bb
   md5: f11d165eaa532ce04a35382841284298
   license: MIT
   license_family: MIT
   size: 107047
   timestamp: 1693902034820
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2025.2.25-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2025.2.25-hecd8cb5_0.tar.bz2
   sha256: eed2df4a7eb4ad975ad60ffd3aa9e28a8461042abaa49c8da0ac69a0d3778c7e
   md5: 2b7e8362bb4cc2e7fde27d2a80af9dfc
   license: MPL-2.0
   license_family: Other
   size: 140713
   timestamp: 1740582484873
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2025.1.31-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2025.1.31-py311hecd8cb5_0.tar.bz2
   sha256: 7e80e0b7e83da0fb269ba10c393bffe2259bd236fec5ce9a2fa9070a7fe54d1e
   md5: ce18ce529baa9178f4edaddc95b27912
   depends:
@@ -4021,7 +4021,7 @@ packages:
   license_family: Other
   size: 169256
   timestamp: 1738623783634
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py311h9205ec4_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.17.1-py311h9205ec4_1.tar.bz2
   sha256: d93f07c0baebe21d32298a5e4e6d59ec01aa8730628d3e586a099aa75baec0dd
   md5: dffa026d960d5042574e76c406c7b319
   depends:
@@ -4032,7 +4032,7 @@ packages:
   license_family: MIT
   size: 293192
   timestamp: 1736183432113
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
   sha256: aceaa74365b0d8e69c817639393df3a713a802f40645ac0bd2f39adc871acf54
   md5: 52191c9d4f4fcaeea39574819ab2f14f
   depends:
@@ -4041,7 +4041,7 @@ packages:
   license_family: BSD
   size: 204365
   timestamp: 1698129979494
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cloudpickle-3.0.0-py311hecd8cb5_0.tar.bz2
   sha256: 6289468ac6d509d11f928e80005c27fcc169be379c9714f839c305949fbc22af
   md5: 851f577d81bce100ddf9c11ded38da06
   depends:
@@ -4050,7 +4050,7 @@ packages:
   license_family: BSD
   size: 43158
   timestamp: 1721657395305
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
   sha256: 9270668e34b00a2605584a2db5130c83826855cd05b896ce949f3156fa197429
   md5: 2586aa55677e822e8285d777f9039ca9
   depends:
@@ -4059,7 +4059,7 @@ packages:
   license_family: CC
   size: 543487
   timestamp: 1709758497949
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
   sha256: 389c63a84b92a6254c9d361ebe970d537d0b88733efd5ac5c3ee58196fd2c5a9
   md5: c7bc5b3cbe76be83a27f00b7e4740727
   depends:
@@ -4069,7 +4069,7 @@ packages:
   license_family: BSD
   size: 17974
   timestamp: 1709323004148
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.3.1-py311h1962661_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.3.1-py311h1962661_0.tar.bz2
   sha256: a8433ccc2ae0f5a69a2795cc9a124678bc25dd99d23c697280394febd0ce1683
   md5: 9dd4588e1973ae233a3d227182e6c709
   depends:
@@ -4080,7 +4080,7 @@ packages:
   license_family: BSD
   size: 301973
   timestamp: 1732540462617
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cramjam-2.7.0-py311h9c86198_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cramjam-2.7.0-py311h9c86198_0.tar.bz2
   sha256: f480b0ed7a98e682d8cbdaeef697116a0d839cee08ec8b5f39078c4e056ec29b
   md5: 7712882f644fca2ccd169ce2dee2b4d9
   depends:
@@ -4089,7 +4089,7 @@ packages:
   license_family: MIT
   size: 1473015
   timestamp: 1702651642047
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-1.0.1-py311h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cytoolz-1.0.1-py311h46256e1_0.tar.bz2
   sha256: cd7ad139df45050de901127e004b7f19dd7b47fda18b9a0e8c0f1b0eb6132baf
   md5: c4acf42375dc4b5ea1144ec77d8bd18c
   depends:
@@ -4099,7 +4099,7 @@ packages:
   license_family: BSD
   size: 408736
   timestamp: 1736804008505
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-2024.12.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/dask-2024.12.1-py311hecd8cb5_0.tar.bz2
   sha256: 95b1a49058aaa455e947587e89a458c3035da0b42edb7b35ce2daa6610ab32dc
   md5: a7c93b2edbcf975ba6c66c7553c5fef8
   depends:
@@ -4118,7 +4118,7 @@ packages:
   license_family: BSD
   size: 6369
   timestamp: 1736874124933
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2024.12.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/dask-core-2024.12.1-py311hecd8cb5_0.tar.bz2
   sha256: 196f447909e5cde96573418ef2b17b4d9f28954ae568a872d9f553befe0e9745
   md5: 5917e5d751a4fab35df14c598bd6626c
   depends:
@@ -4135,7 +4135,7 @@ packages:
   license_family: BSD
   size: 3196324
   timestamp: 1736807879069
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-expr-1.1.21-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/dask-expr-1.1.21-py311hecd8cb5_0.tar.bz2
   sha256: 675f3486427b9b1a14e7caf7d745d6d3016f1e0cc11c9a0bc395bd66596c9cc3
   md5: b894c290307c8dadb88e60fcc17a0a64
   depends:
@@ -4147,7 +4147,7 @@ packages:
   license_family: BSD
   size: 570430
   timestamp: 1736810627837
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.17.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/datashader-0.17.0-py311hecd8cb5_0.tar.bz2
   sha256: 2e3dddcfc333657c0331c063c133e42729d4afc0f17bd44b784d3db4f784f630
   md5: 7a5173b979dca48c186dc2cb847105f4
   depends:
@@ -4168,7 +4168,7 @@ packages:
   license_family: BSD
   size: 18010111
   timestamp: 1738338208258
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.8.11-py311h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.8.11-py311h6d0c2b6_0.tar.bz2
   sha256: ca52a2c3bc6ade8a458b1d0f0e5f0637cb715add74480c6061df52658765fa25
   md5: 7728392984085b5bd2550360b608df0d
   depends:
@@ -4178,7 +4178,7 @@ packages:
   license_family: MIT
   size: 2786928
   timestamp: 1736267811270
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2024.12.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/distributed-2024.12.1-py311hecd8cb5_0.tar.bz2
   sha256: 98a6ca0bf3ce8fb5d28a77080c2abbb4525454699e673fc624381a60cdec019c
   md5: a729ef49c8a66fa723bb98bc906c1fba
   depends:
@@ -4202,7 +4202,7 @@ packages:
   license_family: BSD
   size: 1824097
   timestamp: 1736870891276
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
   sha256: d48b47b86b09dac1fa4542ec13e1bd4e23093638e684fa66ec3afdd9ce9337c1
   md5: 5a2d1828ab7c8eccd3c2610d13672977
   depends:
@@ -4211,7 +4211,7 @@ packages:
   license_family: MIT
   size: 17336
   timestamp: 1678316187749
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-2024.2.0-py311hb3a5e46_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fastparquet-2024.2.0-py311hb3a5e46_0.tar.bz2
   sha256: 3a4f25b0833b1e459e03b22ad6f0fa21b489ca5aa9559bd18e1ed6659509766e
   md5: f35dfe533aa5ab48ea2f7064b6b6353d
   depends:
@@ -4225,7 +4225,7 @@ packages:
   license_family: Apache
   size: 661944
   timestamp: 1715262849492
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.55.3-py311h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fonttools-4.55.3-py311h46256e1_0.tar.bz2
   sha256: 890ef82419af3c013b4abb8ef38290e3582df16115c28d63d4048a3ec7c6c7b4
   md5: 86f1888844cb0c0e74d0917374fccb26
   depends:
@@ -4243,7 +4243,7 @@ packages:
   license_family: MIT
   size: 3240690
   timestamp: 1737040198351
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -4253,7 +4253,7 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.12.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fsspec-2024.12.0-py311hecd8cb5_0.tar.bz2
   sha256: e483157d3adcb67e1ab4a7548884d32fe54df6856001217f34a9c38afe3a3efc
   md5: 6f10c4ece49e70fa78b1bfce333ae06c
   depends:
@@ -4264,7 +4264,7 @@ packages:
   license_family: BSD
   size: 397391
   timestamp: 1736275074073
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
   sha256: 3c7aa54548409f9343e891820ea43c195b5e4e4dce6b761bc3ae9f6c8be0fc86
   md5: ed9629d6dc1612ec425eb8d27478b0f6
   depends:
@@ -4273,7 +4273,7 @@ packages:
   license_family: BSD
   size: 140316
   timestamp: 1706888243476
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
   sha256: aed47f9ca4dd140b9c8a183e53d4b89eba84a20041d2038983cdfea8096104ef
   md5: c0d981d7d43eaad55950ff5e57206e70
   depends:
@@ -4283,7 +4283,7 @@ packages:
   license_family: BSD
   size: 97828
   timestamp: 1706895273858
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.20.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.20.1-py311hecd8cb5_0.tar.bz2
   sha256: 6ce4e0816edc5bd019217ecd47c98607ccdfa3f488741f4ec0e7f2cb0c6af971
   md5: ed3fddc0df1d0a15720b6d07130a7e49
   depends:
@@ -4303,7 +4303,7 @@ packages:
   license_family: BSD
   size: 6200029
   timestamp: 1740583330876
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
   sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
   md5: f3ce6fe6eb760c236e5f7d04df5faa81
   depends:
@@ -4312,7 +4312,7 @@ packages:
   license_family: MIT
   size: 28138484
   timestamp: 1692293212596
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
   sha256: 5c2458964157fe493ca18c513c693b70cb622087e5fa0c93e65fc45217edd811
   md5: 15629e52625221b51a443cefd9501d12
   depends:
@@ -4321,7 +4321,7 @@ packages:
   license_family: BSD
   size: 148522
   timestamp: 1714398885844
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/imageio-2.37.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/imageio-2.37.0-py311hecd8cb5_0.tar.bz2
   sha256: 906bf47c416726871147f56e4b8d75f4dfeb75a91ccecb05a0f32179b9562f3a
   md5: b149364a17be4799847816671d4e044b
   depends:
@@ -4332,7 +4332,7 @@ packages:
   license_family: BSD
   size: 666913
   timestamp: 1738160330852
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-8.5.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/importlib-metadata-8.5.0-py311hecd8cb5_0.tar.bz2
   sha256: 93a3ba81d845710e74bc76f0439758bb91b015fd3e271fc4b6349c55972b4ab1
   md5: f82a0ed701e03576df6faa7181a8d81f
   depends:
@@ -4342,7 +4342,7 @@ packages:
   license_family: APACHE
   size: 55466
   timestamp: 1732633660153
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.29.5-py311hecd8cb5_1.tar.bz2
   sha256: 6c4b4d5da2f4936a69e980ce34103da715211d01de342c44d6c64d9270db7e15
   md5: 7d06beefeea6694f9de075c32ce3b1f3
   depends:
@@ -4364,7 +4364,7 @@ packages:
   license_family: BSD
   size: 240904
   timestamp: 1737662538368
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.30.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.30.0-py311hecd8cb5_0.tar.bz2
   sha256: 69fe2c100148f65f721bc791004000aa1e6a96cce9271f2c52c6b273f626d208
   md5: e82a62e5327d2ad85d2456e675487b6a
   depends:
@@ -4382,7 +4382,7 @@ packages:
   license_family: BSD
   size: 1640008
   timestamp: 1734551073802
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.19.2-py311hecd8cb5_0.tar.bz2
   sha256: 40f655b062710295113369c5c236ca3f0b281fd2b91959cffd02f20aa9dbfd57
   md5: c6e3b63c5b90d3a422ca100f5a233a10
   depends:
@@ -4392,7 +4392,7 @@ packages:
   license_family: MIT
   size: 1193759
   timestamp: 1733987587898
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.5-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.5-py311hecd8cb5_0.tar.bz2
   sha256: 4f7339b035a2e6c092b403fa0baf3d4b4b1a320801e1589d51181d3d245c092d
   md5: 810d409cef85a1896ae1fb8502675957
   depends:
@@ -4404,14 +4404,14 @@ packages:
   license_family: BSD
   size: 361525
   timestamp: 1737760340792
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
   sha256: 855982a798d9af8e70635a250528a5da3b2b0cf7095e2804858caf139c8a239b
   md5: 112a5602fe42a84a5bafa038abeddf4f
   license: IJG
   license_family: Other
   size: 279686
   timestamp: 1722872676718
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.23.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.23.0-py311hecd8cb5_0.tar.bz2
   sha256: a899e7bdac6b9b734882ee44a8065d7006dd669fde9b0fb0a88ed2e2f77ec357
   md5: 14a0abb1c37f2e37c0e55b8feec8d564
   depends:
@@ -4424,7 +4424,7 @@ packages:
   license_family: MIT
   size: 193788
   timestamp: 1728487044949
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 0ea44d0c8044e70ab0eaf4d6f5f3e4753838dee106b5cbd36561e21a65cbac77
   md5: 1d045016dca889d702f1caf3a16162fc
   depends:
@@ -4434,7 +4434,7 @@ packages:
   license_family: MIT
   size: 16528
   timestamp: 1699032525791
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
   sha256: 70442ec4b0b7ebbdcf150963f61f797b861001092124f4ea39a16eb92a4d176e
   md5: 63d1503915a15ae4f9ad1c46112ca374
   depends:
@@ -4450,7 +4450,7 @@ packages:
   license_family: BSD
   size: 272720
   timestamp: 1678316970740
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
   sha256: e657ec0667481d957827be1ce825b0a971aa3a211b07c1274d2c1099ded3129c
   md5: 5e317fd45011a0003c29331a8002cb75
   depends:
@@ -4461,7 +4461,7 @@ packages:
   license_family: BSD
   size: 98632
   timestamp: 1718818439542
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 2634d721123ea1e41b6e1cfe4a67552ec520ea9b5154c9e788ccb09d4745b732
   md5: e874eba19b493b7a68161429f24b8f51
   depends:
@@ -4477,7 +4477,7 @@ packages:
   license_family: BSD
   size: 43102
   timestamp: 1718738272613
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
   sha256: c353480ed4744c2a16aaccc1649bab38144436ad6d16ac2937e3e333d32fdccc
   md5: 7de25bdf4cfd3f5485d790d9cddf427f
   depends:
@@ -4504,7 +4504,7 @@ packages:
   license_family: BSD
   size: 619935
   timestamp: 1718828240904
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
   sha256: fd7964657f0a8fe8b167ba860b1f960e8b7b45309eb6c7c850d50ec283fe03b5
   md5: 2967bb345bc75f53182e263ff4743ca6
   depends:
@@ -4514,7 +4514,7 @@ packages:
   license_family: BSD
   size: 28223
   timestamp: 1686870845224
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
   sha256: 64cf59f0f74b0329b5069bc6135b4f40593f1dac52d85ad574d4b8e0a4b2cf16
   md5: 35e8b80eaa03a904fc7f1da39e7f654d
   depends:
@@ -4526,7 +4526,7 @@ packages:
   license_family: BSD
   size: 20234
   timestamp: 1700168776500
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.8-py311h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.8-py311h6d0c2b6_0.tar.bz2
   sha256: d3417c81f287fc04e11f4d2605c5650d8e14352fced97257ee8078707978c455
   md5: 8cf9a8648f02789ccd93f5f3900b611e
   depends:
@@ -4536,7 +4536,7 @@ packages:
   license_family: BSD
   size: 69231
   timestamp: 1737040352794
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
   sha256: a3a24cd84c291f7c9e28842ccfc2107d149f0aa8e676b85d9104eda77622e603
   md5: 99ba4367783596d1bb0c7766ea6706ea
   depends:
@@ -4547,7 +4547,7 @@ packages:
   license_family: MIT
   size: 1290758
   timestamp: 1686931137388
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lazy_loader-0.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lazy_loader-0.4-py311hecd8cb5_0.tar.bz2
   sha256: bf3268d74374fbcd6c09b200096e0e6bbc9e199cf6c84c2dfa798109d6c72fb0
   md5: e0ee3bff8409a917c94237125092eb58
   depends:
@@ -4557,7 +4557,7 @@ packages:
   license_family: BSD
   size: 25930
   timestamp: 1718176930919
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.16-h4f63f0c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.16-h4f63f0c_0.tar.bz2
   sha256: ca7970616a49595aa2ada83fd1ab5f5318fc3254d21f66e946cfd9f1c6b5188b
   md5: 851fa57e5675397c0e724987f17a3f3d
   depends:
@@ -4567,7 +4567,7 @@ packages:
   license_family: MIT
   size: 264025
   timestamp: 1734428532705
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-4.0.0-h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-4.0.0-h6d0c2b6_0.tar.bz2
   sha256: 50da46ac4a032a38d2d9e714e945079e05a46ae451437a52ad09b4cd5d925f5b
   md5: 234c885b9f326ecf78b5294fb709ddee
   depends:
@@ -4576,7 +4576,7 @@ packages:
   license_family: Apache
   size: 295348
   timestamp: 1734423413199
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libabseil-20240116.2-cxx17_h548131f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libabseil-20240116.2-cxx17_h548131f_0.tar.bz2
   sha256: 8973f292fbdc61fb9a0f97746e6e4d2ad7a777e54400e7800de9b14f229a7999
   md5: 5524c45ff980ff65c2aa4bd106e7299a
   depends:
@@ -4589,7 +4589,7 @@ packages:
   license_family: Apache
   size: 1199721
   timestamp: 1716563412628
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
   sha256: 127dbf93874f1bb3493b312fecb5ffedb8f2a41d2470e2cbeb889eb58d89ebf7
   md5: 07502b61e43a2039e4312b40d53c1db1
   depends:
@@ -4604,13 +4604,13 @@ packages:
   license_family: OTHER
   size: 22584954
   timestamp: 1696762195023
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h46256e1_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h46256e1_9.tar.bz2
   sha256: 8f058b4b23c8d56f8411c8f6eec834ea30e8a2ce7a98685ad9c2a4817aabae4a
   md5: b64809b5c2030ac3e571c9f6b5b34335
   license: MIT
   size: 66530
   timestamp: 1736182753663
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h46256e1_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h46256e1_9.tar.bz2
   sha256: 6269fa97423611d7310bb23d6929e1fee3246a10440cd931718d4d447f6d4215
   md5: 23d3558e675675ea0281bbfcac49453a
   depends:
@@ -4618,7 +4618,7 @@ packages:
   license: MIT
   size: 34461
   timestamp: 1736182772158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h46256e1_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h46256e1_9.tar.bz2
   sha256: 738524a5398e731ba9c74b799bf5e972721af4a4dc6a5425d2e17780e3e15912
   md5: b562c3b15ef8b86391171d2f1b85cae6
   depends:
@@ -4626,7 +4626,7 @@ packages:
   license: MIT
   size: 311811
   timestamp: 1736182791956
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.12.1-h9bcc28a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcurl-8.12.1-h9bcc28a_0.tar.bz2
   sha256: 4140204da287f719fa989576b8c1f79b907e710c453ff7718bea05d5ad99b780
   md5: 1ed8bb7105c17dd7c0d7d4a599179aee
   depends:
@@ -4642,21 +4642,21 @@ packages:
   license_family: MIT
   size: 425499
   timestamp: 1739986491449
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.22-h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.22-h46256e1_0.tar.bz2
   sha256: 5267b5015a03aa90883f57b3cc5dda014082e5ab88e2d3b30fe809c37b96094c
   md5: a6bdcc6561a095bc0ac11482e84c37c8
   license: MIT
   license_family: MIT
   size: 84141
   timestamp: 1734423352364
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
   sha256: e84e6cbacb12de6fe86955449502d3956696ae583060d0d4911ea6f503cfb9ad
   md5: 1d200c536be4172db41c49e81a3e6350
   depends:
@@ -4665,14 +4665,14 @@ packages:
   license_family: BSD
   size: 169586
   timestamp: 1703006265367
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
   sha256: 4786264321edbff780633a5b752995eb3193ca4bce11b0fda179577f6cf1102c
   md5: 849fdd014c201a9d2c2aa7c7db38a778
   license: BSD-2-Clause
   license_family: BSD
   size: 103993
   timestamp: 1632891571494
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
   sha256: a60941a0365ee3e8b9ff721f75b0608c234b5652f53337a918b787839de4bb53
   md5: 4d61f019594ebccfb3f4fb87ee778416
   depends:
@@ -4682,14 +4682,14 @@ packages:
   license_family: BSD
   size: 414942
   timestamp: 1685052318462
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
   sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
   md5: 822a5b76117e56d3912f1f2153307528
   license: MIT
   license_family: MIT
   size: 136045
   timestamp: 1714483561919
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
   sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
   md5: e458587c87e3f2d20192f4e0738f2c63
   depends:
@@ -4698,7 +4698,7 @@ packages:
   license_family: GPL
   size: 149419
   timestamp: 1665498987619
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
   sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
   md5: 1058b661ec829b2ee3716ee2a5520641
   depends:
@@ -4709,7 +4709,7 @@ packages:
   license_family: GPL
   size: 1917987
   timestamp: 1665498925405
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgrpc-1.62.2-hf2926fd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgrpc-1.62.2-hf2926fd_0.tar.bz2
   sha256: 451a1bafa405093889dfcc3669f0a679d300bd8c8770901be300832f72e0d359
   md5: b27400d99678fc64f10b5908ea05daed
   depends:
@@ -4729,14 +4729,14 @@ packages:
   license_family: APACHE
   size: 6917286
   timestamp: 1716835073567
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
   sha256: 9ff6ed0f0b9f9f27f449e95d11aa1c4e9e80028fd9d2a8caca5a15d8df88f435
   md5: 7b4b557afc66aba367da14d97d71934c
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1409885
   timestamp: 1714483704680
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm15-15.0.7-h1357083_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libllvm15-15.0.7-h1357083_4.tar.bz2
   sha256: f90e26d7559b18aeee0a3b43a4864b5c19ea1313b2e61dfed93d77c21c02357f
   md5: ea6d65b67c795598481f5c419d086a7f
   depends:
@@ -4749,7 +4749,7 @@ packages:
   license_family: Apache
   size: 29644059
   timestamp: 1730401127883
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
   sha256: 7bfcf69c31a4eb15dfab661c93463ce8dfb7b3de4356945fa5c1ca50a5ae0cb0
   md5: 4934bb34818fa3d99b32b9cb59fed205
   depends:
@@ -4764,7 +4764,7 @@ packages:
   license_family: MIT
   size: 784918
   timestamp: 1697018436251
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
   sha256: 499ebc9000c8e810081b5d7f7524b45dc99f6914096ea9e145366033514938b4
   md5: ce5c24f93932e1a53d7d89e502f28783
   depends:
@@ -4775,7 +4775,7 @@ packages:
   license_family: BSD
   size: 10123989
   timestamp: 1664896966769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -4784,7 +4784,7 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-4.25.3-h34eed0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libprotobuf-4.25.3-h34eed0b_0.tar.bz2
   sha256: 22fddb84e3f771ee2a550da0dbe4caa334ac53b8a633ea566ec5b2e4cbb261cf
   md5: 1922ae6303e44e99aa04f54291240e1b
   depends:
@@ -4798,13 +4798,13 @@ packages:
   license_family: BSD
   size: 2688858
   timestamp: 1716567854254
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.11.1-h3a17b82_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libssh2-1.11.1-h3a17b82_0.tar.bz2
   sha256: 1107001cf2ab50223d97fe24d4747262f52883abe47263e301a506b195485017
   md5: a42788d25cc9b4a03d4434e231db7445
   depends:
@@ -4814,7 +4814,7 @@ packages:
   license_family: BSD
   size: 292312
   timestamp: 1732891162787
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
   sha256: 21ba71cdc65b56c6daefeeab55959e5a7edadfd697cfa8b2ed5c1b3e2a98586b
   md5: cbbd369ee87aba597c942727bada4eee
   depends:
@@ -4827,7 +4827,7 @@ packages:
   license_family: Apache
   size: 364326
   timestamp: 1687975317748
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-h6fa9cd1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-h6fa9cd1_1.tar.bz2
   sha256: 82d2f89ec9f2b0769c0368f7f0734a405e3fb12bbdbefd3ec13b478bf6b2b699
   md5: 2a4899f52b1a65d18dfc2af0ea3d5177
   depends:
@@ -4843,7 +4843,7 @@ packages:
   license_family: Other
   size: 668404
   timestamp: 1734425846576
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
   sha256: 246c0d82766042c1a9194eecc71690918c68afa3528ff0c2c82796ce901df40b
   md5: f33be4ed3bff89ed8f68df6c75158510
   constrains:
@@ -4852,7 +4852,7 @@ packages:
   license_family: BSD
   size: 449215
   timestamp: 1729160070984
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.13.5-h6070cd6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libxml2-2.13.5-h6070cd6_0.tar.bz2
   sha256: 791ce310409e586df33c86fb3b6def35db2c7bf3c4a9c0fba41856ab7f408bf7
   md5: 5aef8bf269c4f9f3e2de64907da8a9b4
   depends:
@@ -4864,7 +4864,7 @@ packages:
   license_family: MIT
   size: 647442
   timestamp: 1732316131363
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
   sha256: d28c465ec6d5f8d4962c597b249b58998300c8b4e3c937c578c3d15294ea863d
   md5: dcaed6ddd0723c7cce6bfad917be98b2
   depends:
@@ -4874,7 +4874,7 @@ packages:
   license_family: MIT
   size: 41176
   timestamp: 1678413498410
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
   sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
   md5: 5c740b4a18a558de0ccfe601703c423c
   constrains:
@@ -4883,7 +4883,7 @@ packages:
   license_family: Apache
   size: 338738
   timestamp: 1662635677689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.44.0-py311h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvmlite-0.44.0-py311h6d0c2b6_0.tar.bz2
   sha256: 932c4ef3e1166188c9a93a27a16fab98a4f9989b96c3d700b9c04b373166031f
   md5: ac6e3f7baa60a087a9235773c9cd4fcb
   depends:
@@ -4894,7 +4894,7 @@ packages:
   license_family: BSD
   size: 456612
   timestamp: 1738678581789
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
   sha256: 716a654df2e55052193150015bd5c9856b847893fc5a229fa8669725b1c56ff2
   md5: 687ba6c11de38ad7cc597f7188b491e7
   depends:
@@ -4903,7 +4903,7 @@ packages:
   license_family: BSD
   size: 13357
   timestamp: 1678322560230
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-4.3.2-py311h46256e1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-4.3.2-py311h46256e1_1.tar.bz2
   sha256: 29a411b215312f6d31c80bcd94d1a85ceb257e041e963728928db23c3c770021
   md5: 7f811f40d3548a64de5cfa23ab72e7b1
   depends:
@@ -4913,7 +4913,7 @@ packages:
   license_family: BSD
   size: 38660
   timestamp: 1736368024365
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
   sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
   md5: 8f57dc3a3327bb6f7e1cba908856ac7f
   depends:
@@ -4922,7 +4922,7 @@ packages:
   license_family: BSD
   size: 183138
   timestamp: 1714510756758
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
   sha256: 6fb2953e169ee1ae38f24d29752051501992f19b96b5ebcea9af75737bdbcb42
   md5: 7f410cdae838c5030108d1b98a8c78f6
   depends:
@@ -4931,7 +4931,7 @@ packages:
   license_family: BSD
   size: 162478
   timestamp: 1678377892595
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
   sha256: cd97e09a12ffb49b2a30a782fa8c7933b28f5ffdbfc5c73a9ebaa95fc9447370
   md5: d1fb6ebc1e5728aa6377cfc71da08942
   depends:
@@ -4941,7 +4941,7 @@ packages:
   license_family: MIT
   size: 135859
   timestamp: 1684280005320
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-3.0.2-py311h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-3.0.2-py311h46256e1_0.tar.bz2
   sha256: 077282e1acac6c4805ac9459dee02815041755d129f1ec016ac0cc40a9e9fc48
   md5: 195e14d7a296482d77a1475541bb7da9
   depends:
@@ -4952,7 +4952,7 @@ packages:
   license_family: BSD
   size: 28349
   timestamp: 1738584403932
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.10.0-py311h919b35b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.10.0-py311h919b35b_0.tar.bz2
   sha256: a02829868777ce746dafb37da1a234c212d11ed8609c13e8fb837e5cc0b82116
   md5: 4d13f50eb1cda9f81858fd11ded08720
   depends:
@@ -4972,7 +4972,7 @@ packages:
   license_family: PSF
   size: 9826780
   timestamp: 1736279748306
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
   sha256: 07e7fd5bd64e55328b4b99d92e2e2600d791f1095bf905daab4cfc59f0f0a45b
   md5: cf53321779f4ca7e986c1468719b93f1
   depends:
@@ -4982,7 +4982,7 @@ packages:
   license_family: BSD
   size: 19500
   timestamp: 1678317565001
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
   sha256: 0770e02be1ea1216af493cfc03d5b8a702e14606fa93b0692bcdab1fed1b898c
   md5: ca6f06ceaf66a32bbf5dfdb6e373a5cf
   depends:
@@ -4992,7 +4992,7 @@ packages:
   license_family: MIT
   size: 67892
   timestamp: 1678417734353
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
   sha256: fbe95ed0501bb0f137048476fe41bc718dd659e8ecb066bc67ac17d6a50f4318
   md5: ec162bde8d1c8a107b257df218b17035
   depends:
@@ -5001,7 +5001,7 @@ packages:
   license_family: MIT
   size: 23030
   timestamp: 1678381838497
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
   sha256: c20dd678655e582129a858a1c5162bdc254082d3a3c035b0f72629d9276e5b75
   md5: 800a0738c728796e02d0386ce7d457aa
   depends:
@@ -5012,7 +5012,7 @@ packages:
   license_family: BSD
   size: 104585
   timestamp: 1678317269407
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py311ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/msgpack-python-1.0.3-py311ha357a0b_0.tar.bz2
   sha256: 7517bb3a1337287e71ba182e23654f49275048389a1a3c6d750dc580caf4aaed
   md5: 5466d265b312c4ff0ff4969ebf15c0ce
   depends:
@@ -5022,7 +5022,7 @@ packages:
   license_family: Apache
   size: 37529
   timestamp: 1678318290205
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
   sha256: 638450a7ccb5f438ac65aa1c8d871fb5bb664e7261ec7e663d0302485c219a67
   md5: 574875bbeabff85b5d9cfdb62066aece
   depends:
@@ -5032,7 +5032,7 @@ packages:
   license_family: BSD
   size: 29473
   timestamp: 1678392919304
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
   sha256: f961b1322b6b02fee53ff9bd0f56bb73886eb59debd3f3666669593de7f48894
   md5: a1e74ccd2f341d1d672e33d79e60d200
   depends:
@@ -5045,7 +5045,7 @@ packages:
   license_family: BSD
   size: 8183400
   timestamp: 1717623127275
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
   sha256: e08cb3ee6df01f4c1e1ac8bc4ed1a06e549ffcc8774fe2e2842c644bb8f74a86
   md5: 6ba0ae0fb14cbea1e3197707701dc180
   depends:
@@ -5058,7 +5058,7 @@ packages:
   license_family: BSD
   size: 123077
   timestamp: 1698934356774
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.16.4-py311hecd8cb5_0.tar.bz2
   sha256: 098d35939d62073df7fc42fadde9d9f7f646e4727382c363c02c136820555e80
   md5: 25b1cce018e6c1b19146f117690d2b5b
   depends:
@@ -5085,7 +5085,7 @@ packages:
   license_family: BSD
   size: 533595
   timestamp: 1728050041209
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.10.4-py311hecd8cb5_0.tar.bz2
   sha256: 3175bd2b744191da1c7477be8162a0f8d7f68363de8c2ab6df989908211ba17c
   md5: 2508c1c6fc84c712ce0419470f60b5fb
   depends:
@@ -5098,14 +5098,14 @@ packages:
   license_family: BSD
   size: 171386
   timestamp: 1728050190296
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
   sha256: 42d803e1d8b54748db5d989ecd503826f564132df7cddc20f520460f55e523a1
   md5: cd3fa71626ebc098da4625fc6be79752
   depends:
@@ -5114,7 +5114,7 @@ packages:
   license_family: BSD
   size: 16952
   timestamp: 1708532805951
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.4.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/networkx-3.4.2-py311hecd8cb5_0.tar.bz2
   sha256: 0d9fda495e414a519f8f038f7c98b1c88a27a1a37183017b70c6aad326be861b
   md5: dd80e14433e8439b6cad21d4518fc81b
   depends:
@@ -5132,7 +5132,7 @@ packages:
   license_family: BSD
   size: 3424359
   timestamp: 1737043448460
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
   sha256: 09d88f1eb19a90dfe737f0e5b4dce7629f6076a2d91d572cbb0a41be5220a4e8
   md5: ac8c26d949a04f478b560b7d8a2358a4
   depends:
@@ -5157,7 +5157,7 @@ packages:
   license_family: BSD
   size: 707187
   timestamp: 1717630829258
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
   sha256: ed5608feb37a083d47b04203195260e801b64b5380f292cf18bb61e7ad827a2a
   md5: daa9c1c233673b727528548454aea664
   depends:
@@ -5167,7 +5167,7 @@ packages:
   license_family: BSD
   size: 27607
   timestamp: 1699456006797
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.61.0-py311h6d0c2b6_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numba-0.61.0-py311h6d0c2b6_1.tar.bz2
   sha256: a09f6dd503ea180dfbd1719d7a3a9130bf2278d6e85db1fd36b726d48f73db89
   md5: e742c3f123cb46423ddd20e669c44618
   depends:
@@ -5190,7 +5190,7 @@ packages:
   license_family: BSD
   size: 6339136
   timestamp: 1740697415775
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.10.1-py311hc59c7be_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.10.1-py311hc59c7be_0.tar.bz2
   sha256: 4b784353c86d73f10d714c039c29ca73508203cb86a7ce455f71ee52b940edb3
   md5: a8c1b6256e1d5743bb92d9c467736aa8
   depends:
@@ -5204,7 +5204,7 @@ packages:
   license_family: MIT
   size: 202114
   timestamp: 1730216207054
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h91b6869_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-1.26.4-py311h91b6869_0.tar.bz2
   sha256: 85aa18f7f372d263f1b9a6eed279e0fa048387520bf71b9c409e13801a0568d4
   md5: c077c784069f04cc487620bcdc7707ea
   depends:
@@ -5217,7 +5217,7 @@ packages:
   license_family: BSD
   size: 11321
   timestamp: 1708642350281
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311hb3ec012_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-1.26.4-py311hb3ec012_0.tar.bz2
   sha256: bc050bacb16826ee23329eed65b63c2625884e2af1853f901f7e09870c7dbd1f
   md5: 96b8308a1bdb2f1e77698ea9fdf96bf3
   depends:
@@ -5231,7 +5231,7 @@ packages:
   license_family: BSD
   size: 8784964
   timestamp: 1708642301649
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
   sha256: 401214a4763c79c2355b012b9f29e3cee097a598bb53e933acb6b98a2bb6614f
   md5: 3216c5f433643ee62a8d0672c3500320
   depends:
@@ -5242,7 +5242,7 @@ packages:
   license_family: BSD
   size: 535252
   timestamp: 1722872704730
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.16-h184c1cd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.16-h184c1cd_0.tar.bz2
   sha256: abf49ca62b98e297aaef845a9e46b5b634a463a6f89f9a98507bce1c153e37c4
   md5: ece825c671d4857e0556de45e5a7903f
   depends:
@@ -5251,7 +5251,7 @@ packages:
   license_family: Apache
   size: 4970204
   timestamp: 1740990032144
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-2.0.1-h5747287_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/orc-2.0.1-h5747287_0.tar.bz2
   sha256: ca2972eb0d95b834238106df2b3bbb6efdb07ea2e9080a718669d8a1dc65f4cd
   md5: 2fe36bccf7d2d86be813bda00878a7f0
   depends:
@@ -5268,7 +5268,7 @@ packages:
   license_family: Apache
   size: 526130
   timestamp: 1717104747125
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
   sha256: 8a0809f419065e014cb8e2c8a516cadca6088fb71fd1ef3ae2287d91e3360d59
   md5: 4dc0b9bc88476fcc5246d823ff1c289a
   depends:
@@ -5277,7 +5277,7 @@ packages:
   license_family: APACHE
   size: 39645
   timestamp: 1699371213055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-24.2-py311hecd8cb5_0.tar.bz2
   sha256: 81f1c12808d6db7c1b26bace7b719fdfd45d7a683e46223c5d4b3843da957c39
   md5: ec1eed2e438db9d3e9906d30d2ad55d6
   depends:
@@ -5286,7 +5286,7 @@ packages:
   license_family: Apache
   size: 189794
   timestamp: 1734472374591
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.3-py311h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-2.2.3-py311h6d0c2b6_0.tar.bz2
   sha256: 320127675235a15f36cd445ad7366ba64acd939ecd5bec5b6888ef365aed27a7
   md5: c283b35da322fcba5fe94e69da4df242
   depends:
@@ -5336,7 +5336,7 @@ packages:
   license_family: BSD
   size: 17297833
   timestamp: 1732736229906
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-1.6.0-py311hecd8cb5_0.tar.bz2
   sha256: b3d97ca6739fa4f1766d26e5a7312a98d5b7a501d5b7167885ff9d0e15d09ab4
   md5: 006b944d84ff0e35a5979f0a98408069
   depends:
@@ -5361,7 +5361,7 @@ packages:
   license_family: BSD
   size: 24631464
   timestamp: 1738685246317
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.2.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-2.2.0-py311hecd8cb5_0.tar.bz2
   sha256: 0639a95fc20308a04d5b1d67b7f8770013a0fb46d2fc605466036f7acbb22061
   md5: 2c90142d5c3066fe79194fe084808bf6
   depends:
@@ -5370,7 +5370,7 @@ packages:
   license_family: BSD
   size: 272394
   timestamp: 1734618667545
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/parso-0.8.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/parso-0.8.4-py311hecd8cb5_0.tar.bz2
   sha256: c204c097bc991a8ba9f459b710a690259c4c3fd44a8550b0f65f2f0a11a80cb4
   md5: 5ce9f46a387e05dff118a050152880f5
   depends:
@@ -5379,7 +5379,7 @@ packages:
   license_family: MIT
   size: 225040
   timestamp: 1733963549046
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/partd-1.4.2-py311hecd8cb5_0.tar.bz2
   sha256: 51cb5a4d03b12ea21baf31310a8e6b864021951050b63fb7cdc96f72f5c9b3be
   md5: 662bb6a1b3eac5da9a075b34d3d218ca
   depends:
@@ -5393,7 +5393,7 @@ packages:
   license_family: BSD
   size: 48653
   timestamp: 1736803596752
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-11.1.0-py311h47bf62f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-11.1.0-py311h47bf62f_0.tar.bz2
   sha256: 34843745b2373e67faf2894f1c36e53c12142a3b07f89eb6178eedef4ca73f70
   md5: 02f725d8200b6558615e5deb6b0a5331
   depends:
@@ -5410,7 +5410,7 @@ packages:
   license_family: Other
   size: 973663
   timestamp: 1738010491802
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-25.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-25.0-py311hecd8cb5_0.tar.bz2
   sha256: d21c0d266e4b68d84517f05a575dd67e49e9a7bcf0f1e6572946a4ffb510fb14
   md5: a116be2009053c0bc87cd860b332c0c2
   depends:
@@ -5421,7 +5421,7 @@ packages:
   license_family: MIT
   size: 2962980
   timestamp: 1737992964499
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 81719c31101d6c019150cedcc7b08adb3bdb357e8b2952e428dadaabc4dc985d
   md5: 105825168e0a17fb007f60b5f314e311
   depends:
@@ -5430,7 +5430,7 @@ packages:
   license_family: MIT
   size: 38405
   timestamp: 1692205731769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.21.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.21.0-py311hecd8cb5_0.tar.bz2
   sha256: 74d50e1d381add9e02e4d4c9b0ae247f1c90bcc544cb622d6bf6c420ad17408d
   md5: 3059b89ad8f6ed91166c87ef25349ca5
   depends:
@@ -5439,7 +5439,7 @@ packages:
   license_family: Apache
   size: 122986
   timestamp: 1731958894994
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
   sha256: e32843723b10ecd9badde28e1085419c0b59ed8a96c7cacce6395e39e3a874f9
   md5: 5af0280a817d2c273304cd22328124af
   depends:
@@ -5451,7 +5451,7 @@ packages:
   license_family: BSD
   size: 763044
   timestamp: 1704404460779
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h46256e1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py311h46256e1_1.tar.bz2
   sha256: d4711400167a76a91b3067d0982d135546e6479a5dcabe4a8087d4f16729b081
   md5: 8b89db6f3680b3ceddfb37d3489a96e0
   depends:
@@ -5460,7 +5460,7 @@ packages:
   license_family: BSD
   size: 503499
   timestamp: 1736369694493
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-19.0.0-py311h6d0c2b6_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyarrow-19.0.0-py311h6d0c2b6_1.tar.bz2
   sha256: 3f4f8e83aa4d9f5587c8cf6dbbe65d7e3d9b47a647c2ec26f837d5302b4f905e
   md5: 22bc3b8bbdff643e7face011b21d0610
   depends:
@@ -5473,7 +5473,7 @@ packages:
   license_family: Apache
   size: 8220961
   timestamp: 1738240552396
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
   sha256: 667b5cf00d31293dede2ddadcc30ab967103d585d40647f34d6d830af97ee51f
   md5: 81d3876fa502fca91ba4136a5f3fc3d3
   depends:
@@ -5485,7 +5485,7 @@ packages:
   license_family: BSD
   size: 37821
   timestamp: 1678378977816
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
   sha256: dfb403f367c57327a4d080109df88383ecff18464de287a1ce936a7274e3656b
   md5: 997b674bad89963af875b93b06807f51
   depends:
@@ -5494,7 +5494,7 @@ packages:
   license_family: BSD
   size: 2120413
   timestamp: 1684280057020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.2.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.2.0-py311hecd8cb5_0.tar.bz2
   sha256: d91145c8170d70c3343e3c72de9bbd65f18dd868699d5865cfd378027ed1d1e6
   md5: be4e175b2ddfdde750cdf6f83fb694d0
   depends:
@@ -5503,7 +5503,7 @@ packages:
   license_family: MIT
   size: 487468
   timestamp: 1731445595709
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 717e038567506ca58ce1cd4a3416892d02f4ebfdd332077cc3d110cfe3d36c58
   md5: 53bbfb400668f798eef6f8c7cf938e1f
   depends:
@@ -5512,7 +5512,7 @@ packages:
   license_family: BSD
   size: 35751
   timestamp: 1678315886516
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.11-h4d6d9e5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.11.11-h4d6d9e5_0.tar.bz2
   sha256: 250c9769e378c2bc583c3c89351d3ea20e363825aa0c72e98a5c6ea3a1934a50
   md5: bf4aaf980dd4941ab9a2a6e413d36c57
   depends:
@@ -5531,7 +5531,7 @@ packages:
   license_family: PSF
   size: 16867465
   timestamp: 1733935409990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
   sha256: 04e100d0a1ea9722e24972657ec5935ad34c7c58957dabb821333e5eac80f717
   md5: 2b6de49ad07b26e1f7084f0fda958eb1
   depends:
@@ -5541,7 +5541,7 @@ packages:
   license_family: BSD
   size: 332276
   timestamp: 1716495830117
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.20.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.20.0-py311hecd8cb5_0.tar.bz2
   sha256: 5f0b041239a0ad2b3888b944efd9cad94e92bcbc91f25eae80a7065c7446379b
   md5: 0e26c390904343d308b6677403d8a8e5
   depends:
@@ -5550,7 +5550,7 @@ packages:
   license_family: BSD
   size: 282407
   timestamp: 1731939768586
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-3.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-json-logger-3.2.1-py311hecd8cb5_0.tar.bz2
   sha256: 2aaaf300f4f747bd82cfb52e2ea8c581fe7a9548384b22e862625a1489f6263c
   md5: eceb46e8d6370a13fcc8443feb798d47
   depends:
@@ -5559,7 +5559,7 @@ packages:
   license_family: BSD
   size: 29626
   timestamp: 1734370318805
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.6.2-py311h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-lmdb-1.6.2-py311h6d0c2b6_0.tar.bz2
   sha256: 950159e48a7d2dfbbea0df7c72b64495acaed0be8b56eafb7b54533c71019d2f
   md5: 468e79c134e447de88fed8f994b1afae
   depends:
@@ -5569,7 +5569,7 @@ packages:
   license_family: Other
   size: 150740
   timestamp: 1736542444375
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-snappy-0.6.1-py311hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-snappy-0.6.1-py311hcec6c5f_0.tar.bz2
   sha256: 1f9837d4c967b68a8fd468d3ea1491406ccc1bc85e0704ff04e9130e763c2c7b
   md5: 5dc10776026d472cf660771f9f1d6b8d
   depends:
@@ -5580,7 +5580,7 @@ packages:
   license_family: BSD
   size: 35255
   timestamp: 1678388804985
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
   sha256: e358fe679e83ccdc8c433746ae6468e8e96d90d97d99530f8476ef5630b2c121
   md5: ce30a0a31d891e69dc9b7bf8b7f0c39c
   depends:
@@ -5589,7 +5589,7 @@ packages:
   license_family: MIT
   size: 268876
   timestamp: 1713974360942
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
   sha256: eeb5a5eed93b8e311ad4d3f4389e050f11bba2eaec9536e1c3ed2f849c6c999b
   md5: c18bd3e12de797d52a470c21a150dffe
   depends:
@@ -5601,7 +5601,7 @@ packages:
   license_family: BSD
   size: 65270
   timestamp: 1711136914884
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py311h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.2-py311h46256e1_0.tar.bz2
   sha256: eaba8d555ca65df57c5c1dfa320c6b222ddb2c428609a29765ea89179ff05a98
   md5: 9a926091b8beee27d251241d227a646d
   depends:
@@ -5611,7 +5611,7 @@ packages:
   license_family: MIT
   size: 208392
   timestamp: 1728659514546
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
   sha256: aa07b90a7ee65f76c8cba1ff99a5cdeb95cbe41881ae951f64ffff06674a1b2d
   md5: 58621e3d244137885f7dfbb35e50340a
   depends:
@@ -5621,7 +5621,7 @@ packages:
   license_family: Other
   size: 594801
   timestamp: 1709318510622
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
   sha256: c69f556df9a27328c56943f3b5918cbb953cfbca987e20394d823a6174781202
   md5: ab294ae71ecdfaa307a961cc71dd890d
   depends:
@@ -5629,7 +5629,7 @@ packages:
   license: BSD-3-Clause
   size: 205638
   timestamp: 1652449553607
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -5638,7 +5638,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
   sha256: d784dc26c5de8e41845350a899e5779250b71f45d39e2aece62e739e9add7308
   md5: 7b077b7f46112bb31dc066396c51d3fa
   depends:
@@ -5649,7 +5649,7 @@ packages:
   license_family: MIT
   size: 74776
   timestamp: 1699012164201
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.32.3-py311hecd8cb5_1.tar.bz2
   sha256: 022bc34ef458cf0f26cb2e94f3238618e72ca59489efb074d25e5a4700e53707
   md5: 4f1d626c702cbb79e25aa92375049279
   depends:
@@ -5665,7 +5665,7 @@ packages:
   license_family: Apache
   size: 124655
   timestamp: 1730999183404
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
   sha256: 727fb8d957e02d03b928d049ffbc712316f176a2c331391766d646621b45655a
   md5: 7e0e416c642f3ee4ddfb084a811fb4df
   depends:
@@ -5675,7 +5675,7 @@ packages:
   license_family: MIT
   size: 10236
   timestamp: 1683077214314
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
   sha256: a8a67143ccb65cfd6f50055176b6c26179a83130a45d0a12e79dd2de68d8db63
   md5: a2065790f41e3eeb6efe0ef6daa75377
   depends:
@@ -5684,7 +5684,7 @@ packages:
   license_family: MIT
   size: 10600
   timestamp: 1683059285216
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.22.3-py311h83de92b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.22.3-py311h83de92b_0.tar.bz2
   sha256: e1d5536de94bb0cd3b5d63044e00425b75de36cddde773178f4b96fa223698b9
   md5: eae729d4ea22b7b1780cdeb7ba1943a0
   depends:
@@ -5695,7 +5695,7 @@ packages:
   license_family: MIT
   size: 370287
   timestamp: 1736547107420
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scikit-image-0.25.0-py311h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/scikit-image-0.25.0-py311h6d0c2b6_0.tar.bz2
   sha256: 549c4710d24f61a263ac4f77df946f5ba9edd802422ca67540290537d080bb42
   md5: b8ff67585be2a82ec56311dc5a84e088
   depends:
@@ -5723,7 +5723,7 @@ packages:
   license_family: Other
   size: 12484786
   timestamp: 1737474697990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.15.1-py311hedc7b93_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/scipy-1.15.1-py311hedc7b93_0.tar.bz2
   sha256: d9997badc7003cd27cde365f1f0cb4534ba28ce8a3c610857e1157f1958e660f
   md5: 0c089148a1ad3abbc3be7d6052732a61
   depends:
@@ -5740,7 +5740,7 @@ packages:
   license_family: BSD
   size: 29902677
   timestamp: 1737126721017
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py311hecd8cb5_1.tar.bz2
   sha256: b5591b76d1ede877894fecb0f624ab7622ee576e4495d4fbc5cf4698b0e58caa
   md5: 516af2e9aee8f913abb2d03400b7d010
   depends:
@@ -5749,7 +5749,7 @@ packages:
   license_family: BSD
   size: 33671
   timestamp: 1736543483460
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-75.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-75.8.0-py311hecd8cb5_0.tar.bz2
   sha256: 7f97e1031cee1f0c13c604c5c1ab591d7458a12aaedeb12857c0768716f70cdc
   md5: ff42104b98748eeb2ffeaef42c94a2d6
   depends:
@@ -5758,7 +5758,7 @@ packages:
   license_family: MIT
   size: 2306558
   timestamp: 1738046028518
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
   sha256: 9eaab5afd89c87ca139915589626785039fac30f05f8fb19e9eefe27eb935ce6
   md5: babdcd3370f85ded3d313902dcebecfb
   depends:
@@ -5767,7 +5767,7 @@ packages:
   license_family: BSD
   size: 46224
   timestamp: 1723557464934
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
   sha256: 0eb44a16ef74a13ef7839209899d009cd94974fbc406a417d958c7bc8d955245
   md5: 41f239a5b67b1daf819849023aa5d12f
   depends:
@@ -5776,7 +5776,7 @@ packages:
   license_family: Other
   size: 19056
   timestamp: 1705431379885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
   sha256: 14775231982e1ea150189c956927ccfb1ad01a8c9395cdeea4d5a48b9b8ce664
   md5: 729badc4bf7ba8ccc70e0f9e58075c99
   depends:
@@ -5785,7 +5785,7 @@ packages:
   license_family: MIT
   size: 89812
   timestamp: 1696347694075
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
   sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
   md5: 6bef1694163a68ac4c37e5857b8da4f5
   depends:
@@ -5797,7 +5797,7 @@ packages:
   license_family: Other
   size: 1900191
   timestamp: 1714488351925
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
   sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
   md5: 61d6251c7fd58a353ebe33d95b8ada33
   depends:
@@ -5806,7 +5806,7 @@ packages:
   license_family: Apache
   size: 180099
   timestamp: 1680167277796
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
   sha256: 3d5c2968f581006437df3932cd5d3c1c4afa78f0e13757b958440245d3248856
   md5: 605ea221d225ad8e79284dbcfdab0715
   depends:
@@ -5817,7 +5817,7 @@ packages:
   license_family: BSD
   size: 37699
   timestamp: 1678317755913
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tifffile-2024.12.12-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tifffile-2024.12.12-py311hecd8cb5_0.tar.bz2
   sha256: a3d0f4673d35a9f67c18f8352118055cba2a8d63210112a451ee817090e2d24b
   md5: f893539321e682129018db29bc0e3319
   depends:
@@ -5831,7 +5831,7 @@ packages:
   license_family: BSD
   size: 522194
   timestamp: 1734341101049
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.4.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.4.0-py311hecd8cb5_0.tar.bz2
   sha256: 67eb32c950198f88cfd1ab0041a70cadf36c7a9c6256f3351cf5b15be8d1eec3
   md5: e1ba1b42d2443fab4fb2471b70061529
   depends:
@@ -5841,7 +5841,7 @@ packages:
   license_family: BSD
   size: 106377
   timestamp: 1738340071227
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
   sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
   md5: 523c006cc67c011383678c762015479b
   depends:
@@ -5850,7 +5850,7 @@ packages:
   license_family: BSD
   size: 3594448
   timestamp: 1714770737885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-1.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/toolz-1.0.0-py311hecd8cb5_0.tar.bz2
   sha256: 10c8ad5f4d84e77b854d2e0f30c20628b47d2233c949011219ffbcc6eaf0c928
   md5: 7450c3c21275ec3864469064e2db96b9
   depends:
@@ -5859,7 +5859,7 @@ packages:
   license_family: BSD
   size: 138845
   timestamp: 1736796304528
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.2-py311h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.4.2-py311h46256e1_0.tar.bz2
   sha256: 926f89ddb422d2868f65532d07637474578c27ddc90ef9202410f075fe310b95
   md5: 1c4aad6b2e2e721689e4b7f0d24bbd9a
   depends:
@@ -5868,7 +5868,7 @@ packages:
   license_family: Apache
   size: 916363
   timestamp: 1733960657634
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.67.1-py311h85bffb1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.67.1-py311h85bffb1_0.tar.bz2
   sha256: c4bccdf0892c9f8fffe5a968d6e7f73157bd6682d0253b6dc2143db5e60ce094
   md5: 4397f5d8e2796595937de38fe33be974
   depends:
@@ -5879,7 +5879,7 @@ packages:
   license_family: MOZILLA
   size: 156244
   timestamp: 1738946121505
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
   sha256: 5283f2b23a6e9d888b2834cba2bbf284f551e199d2c1b4add176b1cbafb19ee0
   md5: 58bf7871ca100fbda0492bb5a3363c80
   depends:
@@ -5888,7 +5888,7 @@ packages:
   license_family: BSD
   size: 208200
   timestamp: 1718227205760
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.12.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.12.2-py311hecd8cb5_0.tar.bz2
   sha256: 8022de54a1fbd9c3477536d96ac53f7fd5a32d8746f3993c2bc2bf5c5bcd82ae
   md5: 3134d7e75b5c6cb1b98c1220bfc2924e
   depends:
@@ -5898,7 +5898,7 @@ packages:
   license_family: PSF
   size: 10063
   timestamp: 1734714948797
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.12.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.12.2-py311hecd8cb5_0.tar.bz2
   sha256: 1a33aba353b4c72ee219540fbaf361f575c7c6fe0259bfb8c453b9c61320beec
   md5: b71aa2fc23e5979b7443d52ee91265ee
   depends:
@@ -5907,7 +5907,7 @@ packages:
   license_family: PSF
   size: 82779
   timestamp: 1734714943158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
   sha256: a9960485ced319ac91afe69eaaf703c7e6b3049f1e06a4a8c2818b64155943f0
   md5: 0a9c8ea92a14330a07edabac249e32a9
   depends:
@@ -5916,7 +5916,7 @@ packages:
   license_family: MIT
   size: 11399
   timestamp: 1678394892923
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h46256e1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py311h46256e1_1.tar.bz2
   sha256: 413998bdde08eaa50c14a0c8094e3869b6eafdfd81d988ce2674f0df19eaafd3
   md5: c14444bb7c690c8340ab103941c8486d
   depends:
@@ -5925,7 +5925,7 @@ packages:
   license_family: Apache
   size: 495952
   timestamp: 1736544621517
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.3.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-2.3.0-py311hecd8cb5_0.tar.bz2
   sha256: 758bd260523cdf34cb3da3ed57c0855fb9c01af8cd8bfe14a16d7072bc1e6df9
   md5: 9456f00a26b310b0ca789e0c8441a9c0
   depends:
@@ -5941,14 +5941,14 @@ packages:
   license_family: MIT
   size: 223280
   timestamp: 1737133805231
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
   sha256: 0f8c3eb254be9c1957e748e385e20e62509d11052990c4755012be62434c9129
   md5: 53229ba93f6e38308ae42ecfc6eaad9d
   license: MIT
   license_family: MIT
   size: 96768
   timestamp: 1706894705048
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
   sha256: 597015e8a038a111f03ffbc9a217fcda549d75230c86ce53c1f23c53d6f1a0cb
   md5: 62e98aac883bccc1c87ca0d2ce2f08e0
   depends:
@@ -5957,7 +5957,7 @@ packages:
   license_family: BSD
   size: 25798
   timestamp: 1678317074170
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
   sha256: 1430e6f4b4dd9354b7bb88f7f7bc9cdbab26a034ad1ae5c278de0f5a99329372
   md5: be0832862b29bf5767a707ac6bd53b93
   depends:
@@ -5966,7 +5966,7 @@ packages:
   license_family: Apache
   size: 114834
   timestamp: 1715878445060
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.45.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.45.1-py311hecd8cb5_0.tar.bz2
   sha256: 2bcf41c4bd1ad308f98a3b87181f730e617beb578a3322dbdce60adb51ae385e
   md5: 3d56b8c9c337b4597b474fa423cb704d
   depends:
@@ -5975,7 +5975,7 @@ packages:
   license_family: MIT
   size: 145560
   timestamp: 1737991669288
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2024.11.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xarray-2024.11.0-py311hecd8cb5_0.tar.bz2
   sha256: 36a035c94ec8a72e730b43a16b92e3eedfe1d27bb27d13f363df70abe13d9fbf
   md5: bec65eada309349b7b99f96f01b34c38
   depends:
@@ -5987,7 +5987,7 @@ packages:
   license_family: Apache
   size: 3015266
   timestamp: 1734536001064
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
   sha256: 5b6d5246955b5f9480ff7027eb002442a7ade24f5c354da54ed513042f76cedc
   md5: f32aa8a37d5e65a8dc30f9a1f46bc63d
   depends:
@@ -5996,20 +5996,20 @@ packages:
   license_family: BSD
   size: 54719
   timestamp: 1678325412288
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.6.4-h46256e1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.6.4-h46256e1_1.tar.bz2
   sha256: c46b5b4e5159739c03830541c7261691d556a897ddabdf1a4024fe40d22bdefe
   md5: 5a0422426246e10734acfb8dd2b9fac6
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 286200
   timestamp: 1739468347605
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
   sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
   md5: c25b6d40f834647d0bbe767f6c776031
   depends:
@@ -6019,7 +6019,7 @@ packages:
   license_family: Other
   size: 329449
   timestamp: 1705602140856
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zict-3.0.0-py311hecd8cb5_0.tar.bz2
   sha256: e5fd1f8b8e5cc1221e85355ade7b69f0df640dbdc016b7f9ea0b0b6eda5bf9b6
   md5: 11c4cb55382be5ab89b5c4085510db3b
   depends:
@@ -6030,7 +6030,7 @@ packages:
   license_family: BSD
   size: 103266
   timestamp: 1695833080541
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.21.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zipp-3.21.0-py311hecd8cb5_0.tar.bz2
   sha256: f2a900ccc2ed67c2a969c0707b58043d2e556c222d22e596611f1549067975b4
   md5: 1eb3ce37ce16e3db13cad3a7c133878f
   depends:
@@ -6039,14 +6039,14 @@ packages:
   license_family: MIT
   size: 30625
   timestamp: 1732630910322
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
   sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
   md5: f2519b551f99765d9d98950c5e2b4713
   license: Zlib
   license_family: Other
   size: 119782
   timestamp: 1714511811597
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
   sha256: a1f470eabe211500d2ec7866ecf421c067f159045f0245f19e9ba8272c5a177e
   md5: f8bd5fb9fac17a47c64ae56355faba24
   depends:
@@ -6057,7 +6057,7 @@ packages:
   license_family: BSD
   size: 1033188
   timestamp: 1728487057684
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.6.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.6.2-py311hca03da5_0.tar.bz2
   sha256: 8d925b1438e14479c33257054daaf3acab8db996d49fc1f57f9a675569a90493
   md5: 7277b32d35b11efb43245178c3f99fb4
   depends:
@@ -6071,7 +6071,7 @@ packages:
   license_family: MIT
   size: 245764
   timestamp: 1729121361882
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
   sha256: 43405cc7341ce3efb2e24013ad62c64f26a69926635adceaa5459ccbcafb3776
   md5: effa6d22f497e164cc8455f7f329c304
   depends:
@@ -6080,7 +6080,7 @@ packages:
   license_family: BSD
   size: 12510
   timestamp: 1677917870614
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_1.tar.bz2
   sha256: 34eff2dd23f43b16903603d5a629e65d0da4f4c3556bbdc4e81c54ca4f2287b4
   md5: 1f421ad5db9e7301fb935e6f0328dea2
   depends:
@@ -6090,7 +6090,7 @@ packages:
   license_family: MIT
   size: 35693
   timestamp: 1736182683157
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-19.0.0-h0b7d223_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/arrow-cpp-19.0.0-h0b7d223_0.tar.bz2
   sha256: 095aba3e60c6868f97cac85a92b9167eaa10a1486d94c72486790314fb25d9ab
   md5: 246ea5eadafa4642efa434b67b080d8d
   depends:
@@ -6120,7 +6120,7 @@ packages:
   license_family: Apache
   size: 10182859
   timestamp: 1738050558936
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-24.3.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-24.3.0-py311hca03da5_0.tar.bz2
   sha256: b21a439235347e2b0ca4fc059c7be459ef3597a141138dd8ca5004877a1dd86d
   md5: b5c410a1799c550d53e5f11219819850
   depends:
@@ -6129,7 +6129,7 @@ packages:
   license_family: MIT
   size: 163887
   timestamp: 1734533146293
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
   sha256: f536e8b60bdc895063ca0e0155d2041993caed5f932c232f2a0d8e52798da2f1
   md5: daacfabaacebe1d1e53426ec3e385d14
   depends:
@@ -6142,7 +6142,7 @@ packages:
   license_family: Apache
   size: 86757
   timestamp: 1706746162173
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
   sha256: c356ce4cbd638a41fd3db59aa3559850e38c6b41188b8ffab32bdcbd9a55fe03
   md5: e9dc8c248dda95e92533cae6815a0a8b
   depends:
@@ -6151,14 +6151,14 @@ packages:
   license_family: Apache
   size: 39456
   timestamp: 1706690903374
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
   sha256: 117825fcff2a68136a6e5183e05542c2654d73322e70daee3c50c0ecb3aec703
   md5: b115d3f733fe8bae79b9d416754b260e
   license: Apache-2.0
   license_family: Apache
   size: 182078
   timestamp: 1706189905050
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
   sha256: 241c19574abcaf91a47fc5c36f38e58c86732be5e06f5170063406098a58639f
   md5: 3cfc3d38b8fdb25cc2e10e3e370d4106
   depends:
@@ -6167,7 +6167,7 @@ packages:
   license_family: Apache
   size: 18039
   timestamp: 1706690838125
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
   sha256: d4c60f610e57b35a2962b8cea9911358d1642e0449468fa4967706af88bf5da9
   md5: fc23856f141fe548afcfc4823881ee19
   depends:
@@ -6179,7 +6179,7 @@ packages:
   license_family: Apache
   size: 47155
   timestamp: 1706697259456
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
   sha256: c43ed35f4a64818ae39ca2c3c3652428c15da5e287f6e94254c3df4d6c759fb3
   md5: 06366f5f8762447babf69804a04b1a69
   depends:
@@ -6191,7 +6191,7 @@ packages:
   license_family: Apache
   size: 162746
   timestamp: 1706744122437
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
   sha256: 14e2ee7339c88089d1ff68f7144b3fb4f9e34fe538a9462f8de31dd6fdd1d42b
   md5: 59ab0e7ffd73966ec6a2fa83a5df5c47
   depends:
@@ -6201,7 +6201,7 @@ packages:
   license_family: Apache
   size: 127084
   timestamp: 1706696174505
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
   sha256: 601baf006d0545ec65566701d99c601cba843e8ac03d80819d4b8bed23d1e5c4
   md5: 2c98a19d57362cf1fbfec3dda3ea283b
   depends:
@@ -6212,7 +6212,7 @@ packages:
   license_family: Apache
   size: 61914
   timestamp: 1706746732665
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
   sha256: 16809db73ddc3c374ead2c2e9f2221894e2014d3e07ba62d79375cb4de4dfc9d
   md5: c03f5e3b42bc59bd92db813522cce1aa
   depends:
@@ -6226,7 +6226,7 @@ packages:
   license_family: Apache
   size: 67560
   timestamp: 1706747573116
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
   sha256: 293cf6b9dfa727d0e65b383b0e434f8fb26480abd011516171b8652fd363c98e
   md5: 2df2dd6c43a3b413b438a9ef834d78b0
   depends:
@@ -6235,7 +6235,7 @@ packages:
   license_family: Apache
   size: 48454
   timestamp: 1706690816205
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
   sha256: 773f7ff1a91af373d27f5c57833aff8912870108ddd94a5280bfdc608effe5e3
   md5: fad8b095c03774c9d4901db7eda09002
   depends:
@@ -6244,7 +6244,7 @@ packages:
   license_family: Apache
   size: 52142
   timestamp: 1706192041205
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
   sha256: 4efabe18fc312e65a5aac9b2ebe423296cfe702756891978244287ab47881927
   md5: 5786a8ac037fd0e81e25f52dbc6dc72d
   depends:
@@ -6262,7 +6262,7 @@ packages:
   license_family: Apache
   size: 210683
   timestamp: 1706827608490
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.11.212-hdd7fb2f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/aws-sdk-cpp-1.11.212-hdd7fb2f_0.tar.bz2
   sha256: 68b693d97f567999d4bc9ac6bf82576f633f9a4c021fdeee239b39a3db2aacd3
   md5: 11e3300b8aac284f019e064ef4be1dbd
   depends:
@@ -6277,7 +6277,7 @@ packages:
   license_family: Apache
   size: 4304517
   timestamp: 1733148748698
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
   sha256: ae3c6633ed84bac16592b3b756f96ffc577414971014ca9efa498a162588757f
   md5: ea600f99d012d734f831d1bc00a17661
   depends:
@@ -6287,12 +6287,12 @@ packages:
   license_family: MIT
   size: 281227
   timestamp: 1718029919645
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bleach-6.2.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bleach-6.2.0-py311hca03da5_0.tar.bz2
   sha256: 557a8b96a55bd208098771332ba46454d76f4a864679d1d4cfe9f7533db4eaca
   md5: c0e11382888896052023f0f8b4ac242a
   depends:
@@ -6304,7 +6304,7 @@ packages:
   license_family: Apache
   size: 370511
   timestamp: 1732292237553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.6.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.6.2-py311hca03da5_0.tar.bz2
   sha256: 03c113e9729743913e0d13d2d61e4642578664e252f8534f94b48dd96a8fe4a0
   md5: 494a9098b5705582fcab49deb98142f5
   depends:
@@ -6322,7 +6322,7 @@ packages:
   license_family: BSD
   size: 5891982
   timestamp: 1737999258476
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
   sha256: f1660ecfb8687d74e81a7b00699a8bb4677cbd791d14f50ba517de98e2f187ca
   md5: 1636fc4b725da8c5e967952a55f3fd80
   depends:
@@ -6332,7 +6332,7 @@ packages:
   license_family: OTHER
   size: 11780
   timestamp: 1696762172661
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.4.2-py311hb9f6ed7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.4.2-py311hb9f6ed7_0.tar.bz2
   sha256: db1a051d5329611e3e0fab1ea11b2ec06ae511e6c34935738a701ac2ae2fcf86
   md5: 14b2ca28694689fa950ae434e4390224
   depends:
@@ -6342,7 +6342,7 @@ packages:
   license_family: BSD
   size: 135731
   timestamp: 1731058941306
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_9.tar.bz2
   sha256: 5c439398dfaf525e3183dd04df18dede76ee247feffe3ca0103d8506b3785cd4
   md5: 316001829060774b502831c8abf6b634
   depends:
@@ -6351,28 +6351,28 @@ packages:
   license: MIT
   size: 380565
   timestamp: 1736182939936
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
   sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
   md5: 56d1386c7f1f338f0d18f82af6525273
   license: bzip2-1.0.8
   license_family: BSD
   size: 158748
   timestamp: 1714510571033
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
   sha256: b0be79290b1df1cf1d07a1a9c3f3a92ae262643a6df3dc10dfbac22a82874dd4
   md5: 8fdcf1c08eee91fec7eefc22863c816a
   license: MIT
   license_family: MIT
   size: 106550
   timestamp: 1693902036526
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2025.2.25-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2025.2.25-hca03da5_0.tar.bz2
   sha256: ae2f9e468cb736fe9b014ed4fc781a46246877372aa47819795504fb333041fb
   md5: 021feaf22d802c1ff4fd173e0358b36a
   license: MPL-2.0
   license_family: Other
   size: 140976
   timestamp: 1740582468706
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2025.1.31-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2025.1.31-py311hca03da5_0.tar.bz2
   sha256: 9926704e09bc74e44bd40d9cd97b22307db3206139facabb8f6a4d142738bcf7
   md5: c7d785ff3ed172470942f4047e65592f
   depends:
@@ -6381,7 +6381,7 @@ packages:
   license_family: Other
   size: 169691
   timestamp: 1738624007099
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_1.tar.bz2
   sha256: 7f00d92fcfb1a24b4c8fcbe695ce117d985ed44a58b294cd9d4d5d2cf513bba1
   md5: 93179889226fd770fec62ff555acce5f
   depends:
@@ -6392,7 +6392,7 @@ packages:
   license_family: MIT
   size: 292644
   timestamp: 1736182914702
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
   sha256: df81a27f221d11af4a709f272dc8ba3fd3f6d5ab4ffd883c40567bcf04f0cfd3
   md5: e49333e3ffe1fe2e701f50a6e6dccc52
   depends:
@@ -6401,7 +6401,7 @@ packages:
   license_family: BSD
   size: 204179
   timestamp: 1698129906257
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cloudpickle-3.0.0-py311hca03da5_0.tar.bz2
   sha256: 340739a06e25afcd23ec4c5e5d45ac940feb16bee5122e1d14d261a2c80b5617
   md5: bd85d021206472f6a6615575f126ed65
   depends:
@@ -6410,7 +6410,7 @@ packages:
   license_family: BSD
   size: 43128
   timestamp: 1721657439520
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
   sha256: 808e56fb70f3d38599ee7a54c2a707b282ba9a401fa69a1f54cdc26425d9ce01
   md5: fc37321833175bda4fc5c21afe32db49
   depends:
@@ -6419,7 +6419,7 @@ packages:
   license_family: CC
   size: 539588
   timestamp: 1709758479776
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
   sha256: d9c126d8bcd1c89ea37186c172d6b1f73f45ada60e3ae1790a017b530baa0147
   md5: f0223aae3d622547f6accb212579c58e
   depends:
@@ -6429,7 +6429,7 @@ packages:
   license_family: BSD
   size: 17967
   timestamp: 1709322909223
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.3.1-py311h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.3.1-py311h48ca7d4_0.tar.bz2
   sha256: d76cf29e53f303a799da85cd45c5dc65e9d52f050acf9c42ae448b32cb19e3b9
   md5: 1bd0fdf6a0fcf98ed2e968c7359ddc4d
   depends:
@@ -6440,7 +6440,7 @@ packages:
   license_family: BSD
   size: 299096
   timestamp: 1732540161576
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cramjam-2.7.0-py311h62f922a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cramjam-2.7.0-py311h62f922a_0.tar.bz2
   sha256: 1a71c2e15872edff275f419bd1b827c2e37a4cfaf997cd30104cadb2da285a5b
   md5: e97551b1be62a8bc30eb69e1dfe39191
   depends:
@@ -6449,7 +6449,7 @@ packages:
   license_family: MIT
   size: 1531706
   timestamp: 1702651054879
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-1.0.1-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cytoolz-1.0.1-py311h80987f9_0.tar.bz2
   sha256: 25e3dbcb94956d69c436962f946cb8bd967065553d5457c0e48819beb5e543ac
   md5: 335939572c2dd4ae231452304f2916fc
   depends:
@@ -6459,7 +6459,7 @@ packages:
   license_family: BSD
   size: 407595
   timestamp: 1736804012870
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-2024.12.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/dask-2024.12.1-py311hca03da5_0.tar.bz2
   sha256: 90c6b9f147495cff3c6a867db922fcf4a2932e955c8e9738e63a09e7af82fae1
   md5: c70893ab03d926e9a214fc2add1e32cf
   depends:
@@ -6478,7 +6478,7 @@ packages:
   license_family: BSD
   size: 6497
   timestamp: 1736873361214
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.12.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/dask-core-2024.12.1-py311hca03da5_0.tar.bz2
   sha256: d2f314a158b163bf063de34bed4113aeb67b5d1851a696835fed2ba541ce58b7
   md5: f03ff65ee99d66e0e2c8de7d6a08a6ec
   depends:
@@ -6495,7 +6495,7 @@ packages:
   license_family: BSD
   size: 3197873
   timestamp: 1736807559091
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-expr-1.1.21-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/dask-expr-1.1.21-py311hca03da5_0.tar.bz2
   sha256: d00e6b836745b3419ec725db7e375b8845a1c965bbb5bc6311a17766773835f4
   md5: aa62a70ef798893dcc04855ebc5b2c18
   depends:
@@ -6507,7 +6507,7 @@ packages:
   license_family: BSD
   size: 570918
   timestamp: 1736810460236
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.17.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/datashader-0.17.0-py311hca03da5_0.tar.bz2
   sha256: c046e4f03dd3d60adbd6c83339f727feb6a95fde65f07b6a076d6e28903c19d3
   md5: 700624c5f2fffff42dc6d22910045ff3
   depends:
@@ -6528,7 +6528,7 @@ packages:
   license_family: BSD
   size: 18021016
   timestamp: 1738336846678
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.8.11-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.8.11-py311h313beb8_0.tar.bz2
   sha256: a694b8a82ab88f241d100b86586ee802c1d6874e42da4e1bc4fc154df95637f2
   md5: 39b58c0525acb9a7014bb007aa34ddd1
   depends:
@@ -6538,7 +6538,7 @@ packages:
   license_family: MIT
   size: 2793877
   timestamp: 1736267724300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2024.12.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/distributed-2024.12.1-py311hca03da5_0.tar.bz2
   sha256: 18ca8d7be5bd680716b4a15513e88bc0457245baa91a34573bfe8d191e27c385
   md5: 75616a67cdd9413f1e11f010f382d82b
   depends:
@@ -6562,7 +6562,7 @@ packages:
   license_family: BSD
   size: 1820407
   timestamp: 1736870865648
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
   sha256: b1481ffa475c65200626f051d5dcbdb264730b533e928dde608a79ce7a5b4e48
   md5: aada2761547a291d68f4c016a1a9bc7b
   depends:
@@ -6571,7 +6571,7 @@ packages:
   license_family: MIT
   size: 18265
   timestamp: 1677911915719
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-2024.2.0-py311hb9f6ed7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fastparquet-2024.2.0-py311hb9f6ed7_0.tar.bz2
   sha256: 9fc5d69d32d7220004d221f730c50fedfb9d92b12751ed2992ab168dadc85864
   md5: 5d5095c56297f7a7d0d324b496b23b98
   depends:
@@ -6585,7 +6585,7 @@ packages:
   license_family: Apache
   size: 646867
   timestamp: 1715262347984
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.55.3-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.55.3-py311h80987f9_0.tar.bz2
   sha256: 4ade3182f23e3fa0f020a64de5b72069c47ea712d63ce7766dd34ffa79bbc84e
   md5: a03e83b30ffe4ad197dba8c2e24db857
   depends:
@@ -6603,7 +6603,7 @@ packages:
   license_family: MIT
   size: 3245536
   timestamp: 1737039544546
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -6613,7 +6613,7 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.12.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fsspec-2024.12.0-py311hca03da5_0.tar.bz2
   sha256: a5a88a3643a7c41154fe2377afbd65962617712a2d1bb667451526b373558969
   md5: a8421c47d9cea24f66d6032c8a12c29b
   depends:
@@ -6624,7 +6624,7 @@ packages:
   license_family: BSD
   size: 393768
   timestamp: 1736274786703
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
   sha256: 25e05b93a99914a5fd1a298a2c5b25479fbd571b0db9caa7c6ad4336f060f62c
   md5: e213b68bb0274e0e54c610a041e059f5
   depends:
@@ -6633,7 +6633,7 @@ packages:
   license_family: BSD
   size: 150168
   timestamp: 1706888198288
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
   sha256: bbbcf47ef9249635b5199be1414b0b59687cc04ea9630d50ecc609dc200c095e
   md5: 5820c373d6847a68551cadb8984a8277
   depends:
@@ -6643,7 +6643,7 @@ packages:
   license_family: BSD
   size: 95638
   timestamp: 1706895270850
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.20.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.20.1-py311hca03da5_0.tar.bz2
   sha256: 89972f3fc0e9cadbbc57018e9f91f5519593461aff3a26f868cafe3ecbecaa17
   md5: c64fab64771a1dc6c6538d467932798c
   depends:
@@ -6663,7 +6663,7 @@ packages:
   license_family: BSD
   size: 6132281
   timestamp: 1740582883549
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
   sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
   md5: 69eb3b03765627b6159ed23cdde78396
   depends:
@@ -6672,7 +6672,7 @@ packages:
   license_family: MIT
   size: 28399065
   timestamp: 1692293207812
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
   sha256: 4d4ab70ae0ce008c1cc96a4edfbf3866d5e636acc4799a545ea93acee51635f7
   md5: 86a085a440729020d1d7b0b74d6a0c6c
   depends:
@@ -6681,7 +6681,7 @@ packages:
   license_family: BSD
   size: 148448
   timestamp: 1714398923507
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/imageio-2.37.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/imageio-2.37.0-py311hca03da5_0.tar.bz2
   sha256: 059f09774e28cdd37bf51f6410a1cde8b497ec6cca172dc4f22ebbb0e25943d9
   md5: 0356fc829cf5c3446da583357f7c2627
   depends:
@@ -6692,7 +6692,7 @@ packages:
   license_family: BSD
   size: 668629
   timestamp: 1738160418012
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-8.5.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/importlib-metadata-8.5.0-py311hca03da5_0.tar.bz2
   sha256: a8d59a001bbf14fc1efc7554f026feb8f2ca68aab06146d8fff17b860e38e773
   md5: 481d195c5f4458e6035fedde8df02dd3
   depends:
@@ -6702,7 +6702,7 @@ packages:
   license_family: APACHE
   size: 55400
   timestamp: 1732633785459
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.29.5-py311hca03da5_1.tar.bz2
   sha256: efd30bd378cf4f9c93cf38b00baf432e3ae454106bc8be43ac1b86679489aefc
   md5: d8bca2c17b359f33f3752f1a6a7042c5
   depends:
@@ -6724,7 +6724,7 @@ packages:
   license_family: BSD
   size: 238706
   timestamp: 1737660744568
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.30.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.30.0-py311hca03da5_0.tar.bz2
   sha256: 6520fa19784d319996b26b76afa58631ba1c947941b0b3140cfe812421c99924
   md5: afdd96e6adde92b303856588dd9562a3
   depends:
@@ -6742,7 +6742,7 @@ packages:
   license_family: BSD
   size: 1639167
   timestamp: 1734548338159
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.19.2-py311hca03da5_0.tar.bz2
   sha256: bc8c88ebbfe7a0a575e5546ca9b02bc6629cf8ed04467d74b921328918852b4a
   md5: a73b1ed92ff1b9528898c3d09f34889a
   depends:
@@ -6752,7 +6752,7 @@ packages:
   license_family: MIT
   size: 1192471
   timestamp: 1733987575145
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.5-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.5-py311hca03da5_0.tar.bz2
   sha256: b011d9c5a510a5952def06c7dbdcb0f943f26088555d854b3578260b85d3ccb1
   md5: d50f9f0031dc0a710a641919a66bf7a6
   depends:
@@ -6764,14 +6764,14 @@ packages:
   license_family: BSD
   size: 358998
   timestamp: 1737760292134
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
   sha256: 9d5cbffa98f3a4391f66b0c5ce1f411f0bfb0eb83137dc7146fb7bae23cb3570
   md5: 95c92318023482e4e8c698ae6c4597fe
   license: IJG
   license_family: Other
   size: 274078
   timestamp: 1722872672311
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.23.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.23.0-py311hca03da5_0.tar.bz2
   sha256: 5e1400c72584b88b0ea13d2e66110eb7571f155f8b8d62ede4ca61b8279b8bdc
   md5: 6924a112e8115ffdb74a5c8840903b84
   depends:
@@ -6784,7 +6784,7 @@ packages:
   license_family: MIT
   size: 193322
   timestamp: 1728486773537
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
   sha256: 404b0847029f77bedd7902a170a046219e0dc5c0ec2be19ff45361cff25b2181
   md5: 3a02bbe8d45fdbcb2350f672be74c9f5
   depends:
@@ -6794,7 +6794,7 @@ packages:
   license_family: MIT
   size: 16524
   timestamp: 1699032463763
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
   sha256: 7deb8ad28c34c369573754304a03ea2acda8ee39102a56526ec689a4d9210109
   md5: 675ea1a746a78ff6bf8fc4b39139efff
   depends:
@@ -6810,7 +6810,7 @@ packages:
   license_family: BSD
   size: 277400
   timestamp: 1677914250715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
   sha256: ceec15c84f5c699b8055d01e046be04ccb7cfd7c8bd090fc18959f2a4d9f8cf8
   md5: f85c11f7068312e1e84505efef9d55e3
   depends:
@@ -6821,7 +6821,7 @@ packages:
   license_family: BSD
   size: 98520
   timestamp: 1718818476094
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
   sha256: b2f1ee2a297e001a2e70bc218f60deb08c50b9b727668913ed5a106640413d2e
   md5: fc4e797a17ff5dccadfb5d19346b7800
   depends:
@@ -6837,7 +6837,7 @@ packages:
   license_family: BSD
   size: 43099
   timestamp: 1718738212629
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
   sha256: 2d96618ab2e9b3de870a713d7e5b19f6cde936291f3c87972f945b6e27024e77
   md5: 534159d29d9aba9c7e70ee52c27b326b
   depends:
@@ -6864,7 +6864,7 @@ packages:
   license_family: BSD
   size: 614003
   timestamp: 1718827110867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
   sha256: 501e929d345aaa9079c965552b942b4e8bde35b87ae89faef003687a40bab3a4
   md5: 54c7b8554a405acd7c8326c41ba93e63
   depends:
@@ -6874,7 +6874,7 @@ packages:
   license_family: BSD
   size: 28237
   timestamp: 1686870817418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
   sha256: 773e7c4571f482a744dfb18ae26fb22635f5d3f51389c838bd97f9044ea55cc4
   md5: 5161546aba5597318cb5653390cdecd8
   depends:
@@ -6886,7 +6886,7 @@ packages:
   license_family: BSD
   size: 20235
   timestamp: 1700168681687
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.8-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.8-py311h313beb8_0.tar.bz2
   sha256: 74a9386951df51a0f237e2138ab3823f9256664dc6974ec9b53fd5159355fc67
   md5: 166d5e5085ac1b21ba04ad7be3054e0e
   depends:
@@ -6896,7 +6896,7 @@ packages:
   license_family: BSD
   size: 69162
   timestamp: 1737039690391
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
   sha256: 789402b67398d3d936ac4486df01869d59b0e1ba298cbd06407d059aced871e4
   md5: a0f50a38705d0507bbf57ee49a1d9c29
   depends:
@@ -6907,7 +6907,7 @@ packages:
   license_family: MIT
   size: 1308175
   timestamp: 1686931157327
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lazy_loader-0.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lazy_loader-0.4-py311hca03da5_0.tar.bz2
   sha256: 94f99abc0091e89711698b25275839eb264e370691980d9e37e3a88ccb391f32
   md5: bc285b4a7c86f2eb254c16bbccf2838d
   depends:
@@ -6917,7 +6917,7 @@ packages:
   license_family: BSD
   size: 25872
   timestamp: 1718176805871
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.16-he93ba84_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.16-he93ba84_0.tar.bz2
   sha256: 4b45c39ed7c4267baa88eee55413830c87863c9dee6e8af40e0261aa0fcd9469
   md5: dfd7325cb25e3e7d0d2c3f77209d12b3
   depends:
@@ -6927,7 +6927,7 @@ packages:
   license_family: MIT
   size: 246476
   timestamp: 1734428527302
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-4.0.0-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-4.0.0-h313beb8_0.tar.bz2
   sha256: f123fe7eb47ac10d174364902a64c311b1875f4863b1b3791e6b3fca8e0ab272
   md5: b62145f1eeed0a89b5d76c3bb9b409d5
   depends:
@@ -6936,7 +6936,7 @@ packages:
   license_family: Apache
   size: 222115
   timestamp: 1734423410079
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libabseil-20240116.2-cxx17_h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libabseil-20240116.2-cxx17_h313beb8_0.tar.bz2
   sha256: 34390ba05b3d56366a2252f095f8bdf2527371854d981550db7485fc8290c10f
   md5: c8055bc73af0ac231a8b507edc1ff116
   depends:
@@ -6948,7 +6948,7 @@ packages:
   license_family: Apache
   size: 1246977
   timestamp: 1716563341094
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
   sha256: c1f104bc84ee46a3d3beafb5e35236c64e6b4fd6cceabfb420e1838171b1d9c1
   md5: 4f95903a1be48bbee1f9a818ec810b89
   depends:
@@ -6963,13 +6963,13 @@ packages:
   license_family: OTHER
   size: 22243663
   timestamp: 1696762144385
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_9.tar.bz2
   sha256: bc3732d108e184da32b682c94421173529842f8b429fd693592575b637707b9b
   md5: 0e753a927e7ef21b248c739b7846903a
   license: MIT
   size: 69063
   timestamp: 1736182580217
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_9.tar.bz2
   sha256: cd3149e7fb36e67ae496ff37827870c6822619d09b235e2adc7ba5ce9b33f938
   md5: ae813d7d06d4672d06fad704b7bd4077
   depends:
@@ -6977,7 +6977,7 @@ packages:
   license: MIT
   size: 33265
   timestamp: 1736182639925
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_9.tar.bz2
   sha256: e3a1bd31d21200c8841e7305cf4ac1ed21ef75c72acbdb0412747be7b27069c1
   md5: 86fd5a04180dbcf27c012d9fe8b01a94
   depends:
@@ -6985,7 +6985,7 @@ packages:
   license: MIT
   size: 310515
   timestamp: 1736182663109
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.12.1-hde089ae_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcurl-8.12.1-hde089ae_0.tar.bz2
   sha256: e86c7acc2608c4989908a0fb9da8482d1fa4b8c3172bca6154d61f892a706d21
   md5: a534f1f1c0eadee0eb4348e183255831
   depends:
@@ -7001,21 +7001,21 @@ packages:
   license_family: MIT
   size: 412777
   timestamp: 1739986400565
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.22-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.22-h80987f9_0.tar.bz2
   sha256: 695c939431f7fd074d175e62944daca33ff51f3abfe1ee5c51d92d89ad663da8
   md5: 8985f8e47c5bd81416ed08c28d7f305a
   license: MIT
   license_family: MIT
   size: 60900
   timestamp: 1734423344642
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
   sha256: 9597df5344a718d37837966aa05091faf210260898fad5e7a64b87f17de9e90d
   md5: 678a1f87940ef6cc421a092301b8c3fe
   depends:
@@ -7024,14 +7024,14 @@ packages:
   license_family: BSD
   size: 167208
   timestamp: 1703006281321
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
   sha256: 6fc572025852b210ecddcca3ab9ff3f1d5f6bd91f1933c6e296de6bb331f6b5d
   md5: 6dd7d9c5737bbd2a27d18f15318dc3e6
   license: BSD-2-Clause
   license_family: BSD
   size: 102059
   timestamp: 1628961869728
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
   sha256: 9e7b9bb9367d8725a751cdfa0b2d270434d303ea196cfaacc605ee26be09874a
   md5: 44d1843cc2f17eb2674f35b95468f551
   depends:
@@ -7041,14 +7041,14 @@ packages:
   license_family: BSD
   size: 415467
   timestamp: 1685052299052
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
   sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
   md5: f31e4eb9cd6447cc2f5ef0243a76540c
   license: MIT
   license_family: MIT
   size: 120460
   timestamp: 1714483461787
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -7057,7 +7057,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -7068,7 +7068,7 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgrpc-1.62.2-h62f6fdd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgrpc-1.62.2-h62f6fdd_0.tar.bz2
   sha256: e6e4e402ba9350955e9472f33ae7ce4ed712b6ad38b9b5c532e68bfb02646390
   md5: f5f2fdfe7750c7757efab6848e873b0c
   depends:
@@ -7086,14 +7086,14 @@ packages:
   license_family: APACHE
   size: 6756803
   timestamp: 1716834849823
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
   sha256: 72d242814b990900c9410d4738cc685f70ea71231742293cffbb475d8df100f8
   md5: f9976688992b7ac4b56f5600ee15b5c4
   license: GPL-3.0-or-later
   license_family: GPL3
   size: 1407202
   timestamp: 1714483550601
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm15-15.0.7-h97a1cf3_4.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libllvm15-15.0.7-h97a1cf3_4.tar.bz2
   sha256: 44965fabbd722807018a5769455c38d552020cd2ebf5a6bf4044d103aded3808
   md5: 3a217481817fbceaef19d096550cf567
   depends:
@@ -7106,7 +7106,7 @@ packages:
   license_family: Apache
   size: 28303254
   timestamp: 1730396980888
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
   sha256: b7cd58ddb892ed9d3983bdde8fc2530f0653a58818c87e08659f3795f04d8aff
   md5: cf519f7233951d00a30c3b969c4cd161
   depends:
@@ -7121,7 +7121,7 @@ packages:
   license_family: MIT
   size: 728977
   timestamp: 1697018415626
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -7132,7 +7132,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -7141,7 +7141,7 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-4.25.3-h514c7bf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libprotobuf-4.25.3-h514c7bf_0.tar.bz2
   sha256: b628e7b726fc1d77b9b3f8d3078757de8cbc20399a4b0fbdaff6526ba82c4cec
   md5: a92f039187d790f9d8d507549ef61914
   depends:
@@ -7153,13 +7153,13 @@ packages:
   license_family: BSD
   size: 2665938
   timestamp: 1716567699253
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.11.1-h3e2b118_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libssh2-1.11.1-h3e2b118_0.tar.bz2
   sha256: 7a4a378fd967c667ec1ed6db98eb697a92838bbb2a0058d592f4615f70fbc1c7
   md5: e65d37b5b4b531889526b0995b8589d2
   depends:
@@ -7169,7 +7169,7 @@ packages:
   license_family: BSD
   size: 287605
   timestamp: 1732891144732
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
   sha256: 82a73882a31e7a4f4edcdb0c21562e123da913d03b90b19396bd6dd4fcd9a7fc
   md5: b5e5199892949d1e7e2db7bf0ee4dfe9
   depends:
@@ -7182,7 +7182,7 @@ packages:
   license_family: Apache
   size: 361781
   timestamp: 1687975246139
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-hc9ead59_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-hc9ead59_1.tar.bz2
   sha256: 209b3214c150026e4de2a962e4a9c26457c3d4f3f113bcb115bd7a5373422827
   md5: 5624e697d929ac1b10bc3b3a89c1a8be
   depends:
@@ -7198,7 +7198,7 @@ packages:
   license_family: Other
   size: 607843
   timestamp: 1734425782308
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
   sha256: 479cf759232c2361af87493ecd124e7d3a8940030e42e1931234c35bea73c3bd
   md5: cd8fe2c981594a457c6af3a0d5de0bd5
   constrains:
@@ -7207,7 +7207,7 @@ packages:
   license_family: BSD
   size: 341817
   timestamp: 1729160040909
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.13.5-h0b34f26_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libxml2-2.13.5-h0b34f26_0.tar.bz2
   sha256: 3206ddc0d980175fb1a9d0ed98dbf796d772b8b86420bfb9607fd45fbbd64967
   md5: a7a5c90bb4bdd73eb73bae909eb019a1
   depends:
@@ -7219,7 +7219,7 @@ packages:
   license_family: MIT
   size: 620378
   timestamp: 1732316106513
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
   sha256: 41c62a460bb81a1a272aa28b219fab9c26510adac177ff1528b1980eabc6e868
   md5: 8d312c5628dc7ea833e9b4dcb73e9c45
   depends:
@@ -7229,7 +7229,7 @@ packages:
   license_family: MIT
   size: 42346
   timestamp: 1677973051421
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -7238,7 +7238,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.44.0-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvmlite-0.44.0-py311h313beb8_0.tar.bz2
   sha256: 41c772afe07d7b30984e86a8dc2ef96090912274c6151f9cbc705a496c2a1520
   md5: eac34b484107dda971b34bcf76cf25bd
   depends:
@@ -7249,7 +7249,7 @@ packages:
   license_family: BSD
   size: 466619
   timestamp: 1738678667984
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
   sha256: 5777bbef827f72975a36f3da80ab4af718dc781264f74ad7e3864755d620c0f0
   md5: 4240f1a79b812387919cc710a0469556
   depends:
@@ -7258,7 +7258,7 @@ packages:
   license_family: BSD
   size: 14318
   timestamp: 1677925438733
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.3.2-py311h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-4.3.2-py311h80987f9_1.tar.bz2
   sha256: 67dc10bca7950eb27c053102e172d8ffe13d647f9d2830a29ceb8ccd5a885787
   md5: c8c425327e5ba64d2782abf7b2e31ae6
   depends:
@@ -7268,7 +7268,7 @@ packages:
   license_family: BSD
   size: 40689
   timestamp: 1736367162985
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
   sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
   md5: f5f7e6e7541d8dc3d3df270d488d2e24
   depends:
@@ -7277,7 +7277,7 @@ packages:
   license_family: BSD
   size: 176990
   timestamp: 1714510588159
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
   sha256: d024f5142416961a5e66e424d4d14aec652f9e9dd738b41a97f45674c2ffc9d5
   md5: 0e2d94b125d802f7b006cf19c71655a1
   depends:
@@ -7286,7 +7286,7 @@ packages:
   license_family: BSD
   size: 163084
   timestamp: 1677932947966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
   sha256: acfd84e29ff4dc2d85543bb973a07f22b4ba53c5d00bca84608ee7f13b2a8676
   md5: 5ca161cd51e2db358e768453b3ee485e
   depends:
@@ -7296,7 +7296,7 @@ packages:
   license_family: MIT
   size: 135871
   timestamp: 1684279980293
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-3.0.2-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-3.0.2-py311h80987f9_0.tar.bz2
   sha256: c7dbf6b43ddc196da705430e42fb2902e72ab90584ccd93ca6610d1023812daf
   md5: 36587635282a895de9aeb24a85b22621
   depends:
@@ -7307,7 +7307,7 @@ packages:
   license_family: BSD
   size: 29283
   timestamp: 1738584124483
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.10.0-py311h7ef442a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.10.0-py311h7ef442a_0.tar.bz2
   sha256: 012a1113fd728eaca513b2f71d3be101e8b5a600b8c749822f323eb2675ba3d8
   md5: 9dddca88e71c2b941a6555b09e4b0a67
   depends:
@@ -7327,7 +7327,7 @@ packages:
   license_family: PSF
   size: 9718053
   timestamp: 1736278806782
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
   sha256: 3276d61fc353c537bb09d4b7473d7abe12be38806f42c8cc383b62f40850a5cc
   md5: 6e9c9d47f264b77d9a8461f0899848a7
   depends:
@@ -7337,7 +7337,7 @@ packages:
   license_family: BSD
   size: 20446
   timestamp: 1677918370379
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
   sha256: 43c96d30775b61b4968422a47f9605049428120669f0742bbb9e5ba145c7d11e
   md5: a31ca0d9284860adf5463cf45a5e3145
   depends:
@@ -7347,7 +7347,7 @@ packages:
   license_family: MIT
   size: 69243
   timestamp: 1677995336989
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
   sha256: 96d8c9f42a38651b7bafe5f3cb132601db76cd1e28fa58e2eaf090e634292fff
   md5: 5ebc793a17b6aa84d13f19433545ffa5
   depends:
@@ -7356,7 +7356,7 @@ packages:
   license_family: MIT
   size: 23895
   timestamp: 1677942274932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
   sha256: db9bd659ada23f1ded443d2db00dd13b5d5c0b30f5062544b1ee2c2b88d63d29
   md5: 03c48121614cf12abfe30eced9b34717
   depends:
@@ -7367,7 +7367,7 @@ packages:
   license_family: BSD
   size: 105333
   timestamp: 1677916687032
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py311h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/msgpack-python-1.0.3-py311h48ca7d4_0.tar.bz2
   sha256: 3e370e88a51671f87fa0c0e241569950f8c5a38d5e8743c33b0193f54d73d10d
   md5: dd70eac354c92710ce4e2be9d4b02043
   depends:
@@ -7377,7 +7377,7 @@ packages:
   license_family: Apache
   size: 38448
   timestamp: 1677909415759
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
   sha256: 8b05894fdcbe5cfcdee94812b043de4cd7b4fa51d3e2aad25fc7cff50c8f82ab
   md5: c970d49137dce1c77f782ee5725950c1
   depends:
@@ -7387,7 +7387,7 @@ packages:
   license_family: BSD
   size: 30745
   timestamp: 1677960816849
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
   sha256: b6fa12e4bde747bf288bda31ce8ec5e24292dbf74fde67f18f9c9c100b845a38
   md5: 2eddc760c15171a1e8aa838d9d162e18
   depends:
@@ -7400,7 +7400,7 @@ packages:
   license_family: BSD
   size: 8291605
   timestamp: 1717622676584
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
   sha256: e8eee27fb667aa10b26f3bc4b93f449b7d991ded27b9cb457effee394ce05f6f
   md5: 6a3e5cd0e1141c01ffb91285bdccfe83
   depends:
@@ -7413,7 +7413,7 @@ packages:
   license_family: BSD
   size: 123043
   timestamp: 1698934328890
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.16.4-py311hca03da5_0.tar.bz2
   sha256: 1f6d171443b30990cd724ef1e5fa287311d1cf9064c0f5984e6acb2225a0197c
   md5: 9a8675276a35db6cc6649f0bddecf53d
   depends:
@@ -7440,7 +7440,7 @@ packages:
   license_family: BSD
   size: 531141
   timestamp: 1728049778343
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.10.4-py311hca03da5_0.tar.bz2
   sha256: ae983360f1f69987f0fb3a8de9767b362dc903a9b0b130d87fcfcca445dddc4b
   md5: f56cbcd18632f7f669a28363c6d3fe4e
   depends:
@@ -7453,14 +7453,14 @@ packages:
   license_family: BSD
   size: 171380
   timestamp: 1728049515633
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
   sha256: 417ace1ce51e81f3f92ddc26e0e3a83c1e19c9ebb7af7104452002a5573da534
   md5: 3e11de6cef096091bb733e07802f00b0
   depends:
@@ -7469,7 +7469,7 @@ packages:
   license_family: BSD
   size: 16979
   timestamp: 1708532698253
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.4.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/networkx-3.4.2-py311hca03da5_0.tar.bz2
   sha256: 001df280146368c5498b90d291370d577125e7bb7e0de4407fd6dba7ffe49e80
   md5: b9f8846ccd65ab0933991dba4bac2300
   depends:
@@ -7487,7 +7487,7 @@ packages:
   license_family: BSD
   size: 3411023
   timestamp: 1737040521924
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
   sha256: 8ea1be4285e2e7d361cbcc1daf9c220f87ceaab2308bf7b339d2513d6ea22184
   md5: 774ce02efa90f212023541c0b24e92c1
   depends:
@@ -7512,7 +7512,7 @@ packages:
   license_family: BSD
   size: 726598
   timestamp: 1717630964815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
   sha256: b0cc542e2a6f42ba716e7e4ccf29eddcb155ad167fcdbc72d2db9c7873eb5639
   md5: 7acf81b17d2c4ceb3cd39dc9f173855c
   depends:
@@ -7522,7 +7522,7 @@ packages:
   license_family: BSD
   size: 27539
   timestamp: 1699455954000
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.61.0-py311h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numba-0.61.0-py311h313beb8_1.tar.bz2
   sha256: 633930dd9cc4a30518cd826e3eeee7e4f12ca59089d830831ee8a13526361d04
   md5: 774e0cdb37128a0298deb43880eb0e90
   depends:
@@ -7545,7 +7545,7 @@ packages:
   license_family: BSD
   size: 6294931
   timestamp: 1740669484935
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.10.1-py311h5d9532f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.10.1-py311h5d9532f_0.tar.bz2
   sha256: e7085ecdcbb7814ab5b588399963d6877083cbcbce27407b5ded3c099af1e6a9
   md5: b656e9369b00f6f0eec85203e35eaa42
   depends:
@@ -7557,7 +7557,7 @@ packages:
   license_family: MIT
   size: 189479
   timestamp: 1730216150682
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
   sha256: d3bb1d4be88320a5861cd3a0f086e9709f9b64c96c032cb9039cc4f17ec66a85
   md5: 0a7b97665c06fcd34a70e34abc177280
   depends:
@@ -7570,7 +7570,7 @@ packages:
   license_family: BSD
   size: 11288
   timestamp: 1708639168951
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
   sha256: 3e70248a7069ca12ccf56252869bfdb72211fd4e4c327e6994756496df786c79
   md5: ce4846006d98638cd86a532a72f8dfe4
   depends:
@@ -7584,7 +7584,7 @@ packages:
   license_family: BSD
   size: 7536860
   timestamp: 1708639153133
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
   sha256: b9f781280f49644ca05e18aacbdde1c57cc5107e7cc2471b843ea8461672aa7f
   md5: 9125d30e4e105b45f7f7d9c20acafa10
   depends:
@@ -7595,7 +7595,7 @@ packages:
   license_family: BSD
   size: 450131
   timestamp: 1722872679313
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.16-h02f6b3c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.16-h02f6b3c_0.tar.bz2
   sha256: 0e5520f848ed0192a5d7320fd57bcb7f4a3281dbb55f80c2642855c86b865d6f
   md5: 145f3f48ff6d4d0811ea4737b6156c57
   depends:
@@ -7604,7 +7604,7 @@ packages:
   license_family: Apache
   size: 4772692
   timestamp: 1740990210047
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-2.0.1-h937ddfc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/orc-2.0.1-h937ddfc_0.tar.bz2
   sha256: 504f44b8b91a085a34fc2674ecfc8e617108cf1fa3484a2e24bed7e16e40679a
   md5: 837ad487be774903686ba041dfad8795
   depends:
@@ -7619,7 +7619,7 @@ packages:
   license_family: Apache
   size: 505018
   timestamp: 1717104635074
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
   sha256: 77b0c0a0fb14d817390244ebd93c36d44a7867239963f211f7c0a72a3f98d382
   md5: b90336feb8a50d2eff880e89acb02f40
   depends:
@@ -7628,7 +7628,7 @@ packages:
   license_family: APACHE
   size: 39617
   timestamp: 1699371253760
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-24.2-py311hca03da5_0.tar.bz2
   sha256: 7e81c844126506e5e9a3245f094bfb83d7a7e8b108757551ba2cdc9c81602357
   md5: 40ead0e0477f2925e2a333f79f5d8511
   depends:
@@ -7637,7 +7637,7 @@ packages:
   license_family: Apache
   size: 190184
   timestamp: 1734472332475
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.3-py311hcf29cfe_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.2.3-py311hcf29cfe_0.tar.bz2
   sha256: 9d1b4942a2e900c2ce21b4c5d1b7cbb352aad96480b8a5e54c8de3f3ef158143
   md5: 174139c81708a96f152437fcdc06fca8
   depends:
@@ -7687,7 +7687,7 @@ packages:
   license_family: BSD
   size: 17075464
   timestamp: 1732735585667
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-1.6.0-py311hca03da5_0.tar.bz2
   sha256: 062ec8cc22edcc5ec5e826b12b931b3b9957796adb10cca5df4b6318f6d0d30c
   md5: bbb5a8cf9e15cfa329ac40c6047a51ca
   depends:
@@ -7712,7 +7712,7 @@ packages:
   license_family: BSD
   size: 24523710
   timestamp: 1738685269734
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.2.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-2.2.0-py311hca03da5_0.tar.bz2
   sha256: 00a71c24e865b2a60d7aac81508c1c7144a73d7611961214c562eaf270286ff8
   md5: 0fbf4531ff5194c1df47533fcafeec6a
   depends:
@@ -7721,7 +7721,7 @@ packages:
   license_family: BSD
   size: 269736
   timestamp: 1734618675560
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/parso-0.8.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/parso-0.8.4-py311hca03da5_0.tar.bz2
   sha256: d4507aa0fe135a06d918e4217eb89bf2de87574b36ae0fbcc5e0568e10daf1f9
   md5: 379218d52b3715c7664153dd035ebc8a
   depends:
@@ -7730,7 +7730,7 @@ packages:
   license_family: MIT
   size: 224689
   timestamp: 1733963346031
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/partd-1.4.2-py311hca03da5_0.tar.bz2
   sha256: 08be6374b43337eb2fc2967ff857c0eadf3d1f9011a3600c91358c5981e12eba
   md5: 01ae0890cb887eb40cf7b0afb801c9d2
   depends:
@@ -7744,7 +7744,7 @@ packages:
   license_family: BSD
   size: 48726
   timestamp: 1736803522790
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-11.1.0-py311h84e58ab_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-11.1.0-py311h84e58ab_0.tar.bz2
   sha256: 268d62303973a28dba8c3f157b2d0c40eecb96f44f6f5ec06de80cfd3e953df8
   md5: f68870d51e021bcccbd4a9b73e5fde75
   depends:
@@ -7761,7 +7761,7 @@ packages:
   license_family: Other
   size: 949008
   timestamp: 1738010498978
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-25.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-25.0-py311hca03da5_0.tar.bz2
   sha256: cae74ef635708b34f06499fc6cc7902167bc20c98877d754cb67e2039e477f5a
   md5: 12f0b64141739b5d08e0cd17017e9c0a
   depends:
@@ -7772,7 +7772,7 @@ packages:
   license_family: MIT
   size: 2978195
   timestamp: 1737992144489
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
   sha256: b6200816d65673aa1707c20a768c9cff87dd8dbe1335f9c1478e5931dfa08ee0
   md5: 14b1e0fa73eb33f9c83048482dcce57b
   depends:
@@ -7781,7 +7781,7 @@ packages:
   license_family: MIT
   size: 38423
   timestamp: 1692205689597
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.21.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.21.0-py311hca03da5_0.tar.bz2
   sha256: 16e6ef97591f7833c9cd8f2f369812ac62a13e9241b1e8d605932a8da92c2df1
   md5: fa273fbe5dbea433b860c4b89dad0184
   depends:
@@ -7790,7 +7790,7 @@ packages:
   license_family: Apache
   size: 123030
   timestamp: 1731958853048
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
   sha256: 07cfba50d9e94364bde077731a824ca4f537138b35ee6b66d07aee16ac9850f1
   md5: 919bf486280a11e6acb3c2c3a82f7473
   depends:
@@ -7802,7 +7802,7 @@ packages:
   license_family: BSD
   size: 763225
   timestamp: 1704404463402
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py311h80987f9_1.tar.bz2
   sha256: a6d24cb3a6a50bcb52a37548ce3d4d2ee58b8d23403bc7f63018b184263c5968
   md5: d8201518af79a2d79e517846e9f68872
   depends:
@@ -7811,7 +7811,7 @@ packages:
   license_family: BSD
   size: 500255
   timestamp: 1736367725875
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-19.0.0-py311h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyarrow-19.0.0-py311h313beb8_1.tar.bz2
   sha256: 45b8c541a82ec173a7f9b31c8726220e703c7d5b119007a9029c37df10f1df01
   md5: 18dc5e5c8728ee4a7a63fe6b4344ce78
   depends:
@@ -7824,7 +7824,7 @@ packages:
   license_family: Apache
   size: 8059807
   timestamp: 1738233813674
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
   sha256: 4f17f70658e32a9a86661184cace6be3bb7bd61f9b55b513092beddf44552679
   md5: 0aa95279688b0433badea0b660ac8146
   depends:
@@ -7836,7 +7836,7 @@ packages:
   license_family: BSD
   size: 38653
   timestamp: 1677933613643
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
   sha256: 121b5b66721760c05f1d4eee91626229d1814663d3fb5f23126ef870aa496e26
   md5: 0c588c2ca790a05d422c06e8568201ad
   depends:
@@ -7845,7 +7845,7 @@ packages:
   license_family: BSD
   size: 2124200
   timestamp: 1684280082141
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.2.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.2.0-py311hca03da5_0.tar.bz2
   sha256: 86cd1c9d1c73f7dac9f3038d16ac2d6952d42bda57d4da52b18c8561d2901082
   md5: fe581970af66b493353b9dcdb6bf572f
   depends:
@@ -7854,7 +7854,7 @@ packages:
   license_family: MIT
   size: 487783
   timestamp: 1731445552436
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
   sha256: 0bb3d2a57b332c5cf73ea40ea13c850ae24a1f9a3a41ed9267832d9e3c767572
   md5: 45a7fcf1641980d5114999736428502d
   depends:
@@ -7863,7 +7863,7 @@ packages:
   license_family: BSD
   size: 36755
   timestamp: 1677906514270
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.11-hb885b13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.11.11-hb885b13_0.tar.bz2
   sha256: 8359c229ad74991a35ad4e9cd24223a8102b10e2647624965b29a0bce4f88a31
   md5: 70344859c29c4298141767a093918a61
   depends:
@@ -7882,7 +7882,7 @@ packages:
   license_family: PSF
   size: 16479225
   timestamp: 1733934794096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
   sha256: c3cbf5bd237b0a7458640191016b2701fe120c547df9afc835da76663a9c17f7
   md5: 843568c76b6b9384635b7fca74c79792
   depends:
@@ -7892,7 +7892,7 @@ packages:
   license_family: BSD
   size: 332222
   timestamp: 1716495881101
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.20.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.20.0-py311hca03da5_0.tar.bz2
   sha256: 9c37d0d46f2e1930d0efc33f5ae7f9b6ba72f835a1b8b4311ec76953a796fe8f
   md5: 59292a5980e93058c2b8700c4680fb62
   depends:
@@ -7901,7 +7901,7 @@ packages:
   license_family: BSD
   size: 282469
   timestamp: 1731939575445
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-3.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-3.2.1-py311hca03da5_0.tar.bz2
   sha256: e836037601159fe5cd5cf2fa5b818bb4b9a9465f8b0753e78c1b5e809b052627
   md5: fcdab3a23d5db6e00399f5f66dd2bb27
   depends:
@@ -7910,7 +7910,7 @@ packages:
   license_family: BSD
   size: 29575
   timestamp: 1734370349925
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.6.2-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-lmdb-1.6.2-py311h313beb8_0.tar.bz2
   sha256: 75827145ef7b39aa197dbe00569a7966b8cb3e5fa3b93069c734f6e73aad79d1
   md5: d0185d9b609dde82f3c9cc5a9d7e919c
   depends:
@@ -7920,7 +7920,7 @@ packages:
   license_family: Other
   size: 147887
   timestamp: 1736541232523
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-snappy-0.6.1-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-snappy-0.6.1-py311h313beb8_0.tar.bz2
   sha256: 34f174914e9854c27ae0bd904bf848f50b9760eca6cc8c3ec70666eb3a6e69ad
   md5: 898e47ec7bd4461989be61181d1e7b1a
   depends:
@@ -7931,7 +7931,7 @@ packages:
   license_family: BSD
   size: 37310
   timestamp: 1677954185139
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
   sha256: d945744eb133f19ca61325cac5128bdb053ae04de4a0ba6f69c061449cac8af7
   md5: 34baa81490d667381bc7021435b0e1f2
   depends:
@@ -7940,7 +7940,7 @@ packages:
   license_family: MIT
   size: 275858
   timestamp: 1713974457562
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
   sha256: 012585bdb5ae54c2cded50be703734e6dbf418b003635b6f6d7c1e36e7020c30
   md5: da7e99a707bd0cfa20db651b5c068bfd
   depends:
@@ -7952,7 +7952,7 @@ packages:
   license_family: BSD
   size: 65556
   timestamp: 1711136890180
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.2-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.2-py311h80987f9_0.tar.bz2
   sha256: 8d6910a02d0a30dabb40104565c0c74531aafd4c959431ddbfde47ef52f4c83c
   md5: b1619588c95cb65375af1d2eb448ecc8
   depends:
@@ -7962,7 +7962,7 @@ packages:
   license_family: MIT
   size: 205890
   timestamp: 1728658038659
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
   sha256: ae8cdd5be5a7ad19ff82925a035859fafcc5942cd3899d127a508dbb9a235090
   md5: 252a7b997d08bf72f10b3bc2dc68333e
   depends:
@@ -7972,7 +7972,7 @@ packages:
   license_family: Other
   size: 580346
   timestamp: 1709318480624
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
   sha256: 089c6b9bebfa690f380710f219ab0fcc1acec9f2e187d4174a08222c45f58afc
   md5: 11b832c6c10a6d2b0e687a20c3037c97
   depends:
@@ -7980,7 +7980,7 @@ packages:
   license: BSD-3-Clause
   size: 194532
   timestamp: 1652449531448
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -7989,7 +7989,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
   sha256: 7a208abc002a2fc208ae25cb2cf932999a3e4980aa4c9edff315cb9ac62b12ce
   md5: bd22ebd3cff811577ea61f115ba7f4f2
   depends:
@@ -8000,7 +8000,7 @@ packages:
   license_family: MIT
   size: 74744
   timestamp: 1699012126255
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.32.3-py311hca03da5_1.tar.bz2
   sha256: 4cefdf48ebab7544252ce5f4274b5b86f8107e5af556bf387445a2eb4d42449c
   md5: 482973b9a55bd1a4cdc33c557a6afb29
   depends:
@@ -8016,7 +8016,7 @@ packages:
   license_family: Apache
   size: 124539
   timestamp: 1730999249799
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
   sha256: 52368d9b557b8f54ef5ca4bf6cd5a3ec665171f2b2d2082cdd410bab88f4829c
   md5: ac76fb4d2eef3ecdd491cf5d3fb8620d
   depends:
@@ -8026,7 +8026,7 @@ packages:
   license_family: MIT
   size: 10204
   timestamp: 1683077239143
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
   sha256: 491d116c5f54ef340e3bce631835f7138cd1923d7b63e6ca9aa01b48110cb8f9
   md5: 9b81bd8ea808704f5433884b567f1f15
   depends:
@@ -8035,7 +8035,7 @@ packages:
   license_family: MIT
   size: 10557
   timestamp: 1683059079547
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.22.3-py311h2aea54e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.22.3-py311h2aea54e_0.tar.bz2
   sha256: 0ff3bdce4c3932f756e3ac0b5a1e458ad61f20111c96087e3066f3d166d12290
   md5: cc04229f5e9e579cff0945419b4ca798
   depends:
@@ -8044,7 +8044,7 @@ packages:
   license_family: MIT
   size: 376794
   timestamp: 1736542667988
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scikit-image-0.25.0-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/scikit-image-0.25.0-py311h313beb8_0.tar.bz2
   sha256: 0ad857cd9489c8c73fd3fcbd861076672f1950393af51e0bb3523ad5195c1774
   md5: 7a552bb46ab2be010e71856e3cf45e18
   depends:
@@ -8072,7 +8072,7 @@ packages:
   license_family: Other
   size: 12365296
   timestamp: 1737474705666
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.15.1-py311hac8794a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/scipy-1.15.1-py311hac8794a_0.tar.bz2
   sha256: cc0c2c076f95d897365d87658e1cc396707316a48beeccafc5f726d839fb6204
   md5: 3195a0e3a04449f0c084262144766126
   depends:
@@ -8089,7 +8089,7 @@ packages:
   license_family: BSD
   size: 28080933
   timestamp: 1737123647830
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py311hca03da5_1.tar.bz2
   sha256: f3abf394e08b2ba5707fe3795a0c2d961eef72adcbd3ce09950549adf21adbc3
   md5: d833b8f097cdfd5cd0c1854799a28e2c
   depends:
@@ -8098,7 +8098,7 @@ packages:
   license_family: BSD
   size: 33750
   timestamp: 1736541523525
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-75.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-75.8.0-py311hca03da5_0.tar.bz2
   sha256: e70923770836d29267082fd2a2be124e970ef3ef2c0ecf8a30ec40ffcbc060cb
   md5: 48e0878b5cd23e17f09d0c3022c93464
   depends:
@@ -8107,7 +8107,7 @@ packages:
   license_family: MIT
   size: 2295198
   timestamp: 1738046002051
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
   sha256: 499623019bea7cd167924f7fa841237b11b81a1e9cafe9b8ffde47d329275167
   md5: 290d04cffc69bf26a4ed9f1aa9ad42e4
   depends:
@@ -8116,7 +8116,7 @@ packages:
   license_family: BSD
   size: 46038
   timestamp: 1723557442909
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
   sha256: cd71091a234874d2826fa063ec5222b3191c9f47e1b5281c352d9df3f31a06bf
   md5: 0db8e29016c6bff026c083d9923a7566
   depends:
@@ -8125,7 +8125,7 @@ packages:
   license_family: Other
   size: 19073
   timestamp: 1705431415504
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
   sha256: 3e18cdafc607c6d7623b1c8f041cbfbb50a27e298f961abdcce7e36834ac39e1
   md5: 9ee0da74c55d0b8d83edf246fd717f20
   depends:
@@ -8134,7 +8134,7 @@ packages:
   license_family: MIT
   size: 89862
   timestamp: 1696347657368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
   sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
   md5: d8c1e9910392d0bcb22a173f9ce30fa6
   depends:
@@ -8146,7 +8146,7 @@ packages:
   license_family: Other
   size: 1758290
   timestamp: 1714488307689
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
   sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
   md5: ae58720a18a2ed15eae214ad7a10d1b5
   depends:
@@ -8155,7 +8155,7 @@ packages:
   license_family: Apache
   size: 140125
   timestamp: 1680167256603
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
   sha256: b5c265e9ed9a1ff2238a09b83bdc1826950faa87fd6b685debe60888de6e7a50
   md5: 5827c8a32317894ce18576e334daba47
   depends:
@@ -8166,7 +8166,7 @@ packages:
   license_family: BSD
   size: 38559
   timestamp: 1677918962258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tifffile-2024.12.12-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tifffile-2024.12.12-py311hca03da5_0.tar.bz2
   sha256: 3c2272c779e109914cde5b210d1aae99726882836143a4d84892efd27e93647f
   md5: 5deb1e0e6300c71dcb0f59bcd80ab553
   depends:
@@ -8180,7 +8180,7 @@ packages:
   license_family: BSD
   size: 532469
   timestamp: 1734340979736
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.4.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.4.0-py311hca03da5_0.tar.bz2
   sha256: 27c47f3396dda92e5d3fee80e8acdb5d4fbc29a92aedb86a5829b298ee28aab6
   md5: 62dfbd4be598cd4de58d60e287e07f0d
   depends:
@@ -8190,7 +8190,7 @@ packages:
   license_family: BSD
   size: 106596
   timestamp: 1738338664624
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
   sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
   md5: 3c25b4f4768ccda28b20a03ba27e7759
   depends:
@@ -8199,7 +8199,7 @@ packages:
   license_family: BSD
   size: 3484151
   timestamp: 1714770744982
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-1.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/toolz-1.0.0-py311hca03da5_0.tar.bz2
   sha256: 6eaff36e2bab2334f333300606d86016ec407e9f93992e5ce358110a40c6e9a5
   md5: 879b2084cd1fc57ba22ee032a78258b6
   depends:
@@ -8208,7 +8208,7 @@ packages:
   license_family: BSD
   size: 138878
   timestamp: 1736796390598
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.2-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.4.2-py311h80987f9_0.tar.bz2
   sha256: cf80ec43ca8cd5066bb4b673815b3ee0d81cba428d8cde5fdad2b275e8e2a192
   md5: d481b72f67890c155e69c27b0e723391
   depends:
@@ -8217,7 +8217,7 @@ packages:
   license_family: Apache
   size: 915674
   timestamp: 1733960659590
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.67.1-py311hb6e6a13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.67.1-py311hb6e6a13_0.tar.bz2
   sha256: 3dc5b1bd8c934d0ad1c42b396ab657e1a57b3a3fac66c3920ae86015f252e6a4
   md5: 274eade660e7298d61514b9ce5d01b4d
   depends:
@@ -8228,7 +8228,7 @@ packages:
   license_family: MOZILLA
   size: 156442
   timestamp: 1738943824585
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
   sha256: 707e5dfdb9116f31bc1ad7f497f6e8416683add460258fdc2a4c16eec85226be
   md5: ffb602322a388ec8e1f385edaca3ce12
   depends:
@@ -8237,7 +8237,7 @@ packages:
   license_family: BSD
   size: 208171
   timestamp: 1718227091374
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.12.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.12.2-py311hca03da5_0.tar.bz2
   sha256: 76bfd11a14fed1c680f48ab1d85cfab450f28798b393949c7be3932fb124d6a0
   md5: e2d3691e6d2d812b68b13c7ac3086a67
   depends:
@@ -8247,7 +8247,7 @@ packages:
   license_family: PSF
   size: 9928
   timestamp: 1734715032666
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.12.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.12.2-py311hca03da5_0.tar.bz2
   sha256: 6ed1e28c504268da2e42490301a1c0bad8b7f9261693d457233f675b3f5d9387
   md5: a25a484145929656f3e0c6acda51117a
   depends:
@@ -8256,7 +8256,7 @@ packages:
   license_family: PSF
   size: 82601
   timestamp: 1734715026245
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
   sha256: 2ea2d0520b330d381a2ab241bdb9ae146ef815ee7c96ee52a9773fb9ae85f4fd
   md5: 66f7f8979cfb2cccffac972d70482130
   depends:
@@ -8265,7 +8265,7 @@ packages:
   license_family: MIT
   size: 12614
   timestamp: 1677963554857
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_1.tar.bz2
   sha256: 56850724b394276c479065dd01d3923d3b1dc97079338d1d1ef860383aa87cc4
   md5: 17ccacc9e9c00ab86010677b96eebd8b
   depends:
@@ -8274,7 +8274,7 @@ packages:
   license_family: Apache
   size: 518188
   timestamp: 1736541828170
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.3.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.3.0-py311hca03da5_0.tar.bz2
   sha256: b156de384e10e5bab7ecb95aec2ef4e0887ed1b5ed1891f1157e6824848169d7
   md5: baf5f98abd611c5f5d9eadd590633111
   depends:
@@ -8290,14 +8290,14 @@ packages:
   license_family: MIT
   size: 223300
   timestamp: 1737133804463
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
   sha256: 20ae100fd04de16356f26e7c9dab514015e57a9d54fb78767aa5ed97de7846fb
   md5: f620d98b3d0072945948310c86f0f1c5
   license: MIT
   license_family: MIT
   size: 157385
   timestamp: 1706894678643
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
   sha256: 09738b7f9075386bf062b12ddb6fb72a06450d2481f6b5ca2026c811cd849569
   md5: 9afdec076c95746ac21235f971190e40
   depends:
@@ -8306,7 +8306,7 @@ packages:
   license_family: BSD
   size: 26727
   timestamp: 1677910175964
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
   sha256: b4ced7366de8eb7258f31d516616e70c62ed4a798780e57e208509d2b52ab435
   md5: 65a9a05a726734c1da667f9bd3c78c14
   depends:
@@ -8315,7 +8315,7 @@ packages:
   license_family: Apache
   size: 114733
   timestamp: 1715878377412
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.45.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.45.1-py311hca03da5_0.tar.bz2
   sha256: 44c924d2a032a0672d84aefb68b407fa52912555fc15fb7724ed651804aa5471
   md5: 9ab5e101cd19fdec87c3e527ea1d181c
   depends:
@@ -8324,7 +8324,7 @@ packages:
   license_family: MIT
   size: 145595
   timestamp: 1737990528158
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2024.11.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xarray-2024.11.0-py311hca03da5_0.tar.bz2
   sha256: 9552f12a85ea98f23169aceed20685ef94095113ea08e3263f1593ffd444956f
   md5: 766697fe41abe6e6cca6d5f25d7b09b2
   depends:
@@ -8336,7 +8336,7 @@ packages:
   license_family: Apache
   size: 3027679
   timestamp: 1734535815327
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
   sha256: 2cd108896df65636769e3804ecc2ca421ad9b54e64fa21922bbabe40c90c247a
   md5: b3a1e5077b28f71298d891fbfb5ff03e
   depends:
@@ -8345,20 +8345,20 @@ packages:
   license_family: BSD
   size: 55645
   timestamp: 1677927459979
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.6.4-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.6.4-h80987f9_1.tar.bz2
   sha256: e2d31c8ee56686f97a58dd6d924f7901c974e67bb14678c53784160f088d77ec
   md5: d0c14075bc4b6014b3158d434d57820b
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 285627
   timestamp: 1739468310111
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
   sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
   md5: 3d57d1adadca9388aaaa1c529b65ba65
   depends:
@@ -8368,7 +8368,7 @@ packages:
   license_family: Other
   size: 322790
   timestamp: 1705602163804
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zict-3.0.0-py311hca03da5_0.tar.bz2
   sha256: db7fb95af4702cb2ce5281333fa769006f532bc39e8e5bd580a2eb9970a7a38d
   md5: 2c13d5a0b62ff7a644a6957829dc54a6
   depends:
@@ -8379,7 +8379,7 @@ packages:
   license_family: BSD
   size: 103248
   timestamp: 1695832909752
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.21.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zipp-3.21.0-py311hca03da5_0.tar.bz2
   sha256: 5a0b82126f14ccd93001175781c4f95b58aa201395652ee5af6a73ccbc380d0f
   md5: 386dfaab7f4727fef089e98e07935f25
   depends:
@@ -8388,14 +8388,14 @@ packages:
   license_family: MIT
   size: 30617
   timestamp: 1732630794687
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
   sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
   md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
   license: Zlib
   license_family: Other
   size: 104928
   timestamp: 1714510936868
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
   sha256: 43667132ec8fa4c34ba438e13a01b08073e3e3e8a648ecdb6afe4141a7c197e2
   md5: fb8c3f5683b19dd3743d125797b8e2dd
   depends:
@@ -8406,7 +8406,7 @@ packages:
   license_family: BSD
   size: 817614
   timestamp: 1728486986031
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.6.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-4.6.2-py311haa95532_0.tar.bz2
   sha256: 6fbb6b2aa38cb576b17299bf2fdc3779ca090059bfd35e92127f692f2b912aef
   md5: 403069f811c54afaf3d6e3be619bbab8
   depends:
@@ -8419,7 +8419,7 @@ packages:
   license_family: MIT
   size: 244161
   timestamp: 1729121358016
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h827c3e9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py311h827c3e9_1.tar.bz2
   sha256: c6ca6f120f5e09524f2e6bf0db3d88f765e1700b2a5ae115028e5536dbc6d596
   md5: afdf42981074a40b5f08bc6af82670a9
   depends:
@@ -8431,7 +8431,7 @@ packages:
   license_family: MIT
   size: 47000
   timestamp: 1736183077470
-- conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-19.0.0-h33d5241_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/arrow-cpp-19.0.0-h33d5241_0.tar.bz2
   sha256: a1f7dffa83660b5ca33a36b6d3d47fab1a6d1c31dd8a717da73ca834fd04d0d1
   md5: 092c8cf13e8c7312b00c2ede97576836
   depends:
@@ -8463,7 +8463,7 @@ packages:
   license_family: Apache
   size: 9028129
   timestamp: 1738052113637
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-24.3.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-24.3.0-py311haa95532_0.tar.bz2
   sha256: 530abbccadda1fcb2cc52ef46c1615cc64f81932a9565f28e4d0684dae754265
   md5: b630c6316defef2d31cf5e31a74ee656
   depends:
@@ -8472,7 +8472,7 @@ packages:
   license_family: MIT
   size: 163897
   timestamp: 1734533441204
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
   sha256: a11741c5aaa360b4772d0fb7eea606edb5266a4e2806b22f0b8b65b69b7a7273
   md5: 9a54285c5e75ab5e6bfcb3b5590f9449
   depends:
@@ -8487,7 +8487,7 @@ packages:
   license_family: Apache
   size: 93395
   timestamp: 1706746331576
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
   sha256: 32b4da68dd0edbf0c8d7a8a18ba400b26775faabaccbc2cb3e9d2ab7c65e7714
   md5: 48f0a7a7f739d8be4c9dd061be217619
   depends:
@@ -8498,7 +8498,7 @@ packages:
   license_family: Apache
   size: 45714
   timestamp: 1706691182873
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
   sha256: d2710c7f5b4bb8f94a964996387fbd6396f9881d163affeb7ffb050a39e58c1c
   md5: 1a8a2f82798a94d1b272ec2d307cc5ef
   depends:
@@ -8508,7 +8508,7 @@ packages:
   license_family: Apache
   size: 195487
   timestamp: 1706190077309
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
   sha256: 0a5ea74ebcf9bdccfad972add8ff83a47992ab28370cebc34fc4594c1c7cf03a
   md5: 2f90d407ca685c124ddb5fc4d79f4517
   depends:
@@ -8519,7 +8519,7 @@ packages:
   license_family: Apache
   size: 21804
   timestamp: 1706690937014
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
   sha256: 334d2d9c4181c9955256485f66bf4e48ae9b1dc03044aa0424bf1fda292b3151
   md5: 9ab57953af3164d3d94001eeca0e6359
   depends:
@@ -8532,7 +8532,7 @@ packages:
   license_family: Apache
   size: 52661
   timestamp: 1706697357084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
   sha256: 59155d1258b4e29c0046e5ab14b1e2cb3ccfca069982fe9dd4cd751b1ed67492
   md5: 28bd7c351db93c3b8520cc1598eddf66
   depends:
@@ -8546,7 +8546,7 @@ packages:
   license_family: Apache
   size: 177605
   timestamp: 1706744253596
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
   sha256: 3aa9b1c2c508a5dcfb482083cb986498f6df460e652cc7557d3c2d122d559ebe
   md5: b8bf7ae26d234b6738fc37b7c172b3c5
   depends:
@@ -8558,7 +8558,7 @@ packages:
   license_family: Apache
   size: 145865
   timestamp: 1706696287610
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
   sha256: 68564155186523ec8b97b892d0a6b62b3e6f75e4e2b80fac5684011e070295d6
   md5: ba2fa531a69a5a7e4966eba6d7891c8b
   depends:
@@ -8571,7 +8571,7 @@ packages:
   license_family: Apache
   size: 69542
   timestamp: 1706746839018
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
   sha256: 9c0f2f18f8b7e10e940d2438d70a2a03893421f25fd50461b8b2979f3a310a15
   md5: da0f3ce6d8f71a71e6cae01832d853f5
   depends:
@@ -8587,7 +8587,7 @@ packages:
   license_family: Apache
   size: 72614
   timestamp: 1706747680710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
   sha256: bcee1da236f6f5f88322979daddc89e8555648593f6282ad3073a68eb22a68d2
   md5: bf4c19b0db5049930d8b2fcc3b9172fa
   depends:
@@ -8598,7 +8598,7 @@ packages:
   license_family: Apache
   size: 51027
   timestamp: 1706690972693
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
   sha256: 32561df1e664cb320f79c26c5af23dd55953924e66824e2d6372a44687147bdc
   md5: 05f4c6715180a992468035c0a86e734c
   depends:
@@ -8609,7 +8609,7 @@ packages:
   license_family: Apache
   size: 54300
   timestamp: 1706192197648
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
   sha256: 94d2fff3facfd248968d39a3fd7d3b1f7270df32a87dd567c33d60da1a5eb064
   md5: 64fed6e7c73d88bfbfc39e838022f948
   depends:
@@ -8628,7 +8628,7 @@ packages:
   license_family: Apache
   size: 199877
   timestamp: 1706827970924
-- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.11.212-h6a15179_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/aws-sdk-cpp-1.11.212-h6a15179_0.tar.bz2
   sha256: e02bc15ace74eee253c8287e9531c1ccf527a9ebd9babefb84b7c742a123125d
   md5: a35d4c87d9b8d6392f90a55c605a016d
   depends:
@@ -8644,7 +8644,7 @@ packages:
   license_family: Apache
   size: 4395881
   timestamp: 1733149195598
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
   sha256: f1eb2a5aeb25efa0b38fc1dd94a36d431bc80d654f11a052f67a899dcc471f57
   md5: 9db5a441c7cbcf4dc617f8c722e4310d
   depends:
@@ -8654,12 +8654,12 @@ packages:
   license_family: MIT
   size: 276663
   timestamp: 1718029990621
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bleach-6.2.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bleach-6.2.0-py311haa95532_0.tar.bz2
   sha256: 0837002d1a1cd03ff18ec4328ad308859cfeb02e9ebb56c7565f2540a410c207
   md5: 89be604fc06ac9ec44500f933bab9ca9
   depends:
@@ -8671,7 +8671,7 @@ packages:
   license_family: Apache
   size: 371219
   timestamp: 1732292957244
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.6.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-3.6.2-py311haa95532_0.tar.bz2
   sha256: fabd25a04e244b54c39f4500d41bdb59c5c6da2b3aa935e20d340c5778fb2473
   md5: 4f4a3d7246e9cfee285d5185ec88d68e
   depends:
@@ -8689,7 +8689,7 @@ packages:
   license_family: BSD
   size: 5911839
   timestamp: 1737999415426
-- conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
   sha256: 68ef338b27c035add89c0812ad469dd8c9e94f27130f770345ea20deb049d50b
   md5: 9ec19b145f655329532b608963cf32f4
   depends:
@@ -8700,7 +8700,7 @@ packages:
   license_family: OTHER
   size: 11334
   timestamp: 1696764270626
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.4.2-py311h57dcf0c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.4.2-py311h57dcf0c_0.tar.bz2
   sha256: 42f1a2eb775091e9aec87f3f08ba76891e45032c980b9c00c108437df6b5fc56
   md5: 327b522b59ec41d6e5d4a100c228415b
   depends:
@@ -8712,7 +8712,7 @@ packages:
   license_family: BSD
   size: 160724
   timestamp: 1731059089575
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311h5da7b33_9.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py311h5da7b33_9.tar.bz2
   sha256: 1d1267a7b0eb3de746900b4c6dd06ca141085fd12b076b6ae38e8800e8b6d305
   md5: 7e55ca44341f40eea68607d12479f367
   depends:
@@ -8722,7 +8722,7 @@ packages:
   license: MIT
   size: 356583
   timestamp: 1736183647928
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
   sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
   md5: 11e0af09a31e2d5df51c65a342032b85
   depends:
@@ -8732,7 +8732,7 @@ packages:
   license_family: BSD
   size: 112994
   timestamp: 1714511182837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
   sha256: 41a6c5a90b88ec7010bb6dd89390754e476b52c3ab2d519bdab9556da8829479
   md5: b047426a545e287f45e8abfbfcb0de55
   depends:
@@ -8742,14 +8742,14 @@ packages:
   license_family: MIT
   size: 118041
   timestamp: 1693902191485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2025.2.25-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2025.2.25-haa95532_0.tar.bz2
   sha256: 6e64cd794a42471c64e0971deb5ab21497217fcef9f4504900e1ac95b003db79
   md5: e3b5a74405c1f5f34df64c1263147d0b
   license: MPL-2.0
   license_family: Other
   size: 174706
   timestamp: 1740582512824
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2025.1.31-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2025.1.31-py311haa95532_0.tar.bz2
   sha256: 316422bef7d3a948b7f6fcfe2830fb9bdd6a301efccc121a358adc691967f431
   md5: 997bf2a46a4a7addc95bdc5757111d2d
   depends:
@@ -8758,7 +8758,7 @@ packages:
   license_family: Other
   size: 169824
   timestamp: 1738623814920
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py311h827c3e9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.17.1-py311h827c3e9_1.tar.bz2
   sha256: 14cb2182124ca010739f78e856e5d4ee50cc1b1da55550c9d2fc817f2c67dbbe
   md5: d8ee3acca8b6a61a3f58b83f820e8900
   depends:
@@ -8770,7 +8770,7 @@ packages:
   license_family: MIT
   size: 317912
   timestamp: 1736184391679
-- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
   sha256: 7153817dd49ec317b519802c7c22c836602e00cbd96d68385e83eaf4c9f5ba6a
   md5: cd829e5997611a602e29fa2fd5882635
   depends:
@@ -8780,7 +8780,7 @@ packages:
   license_family: BSD
   size: 204113
   timestamp: 1698130080270
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cloudpickle-3.0.0-py311haa95532_0.tar.bz2
   sha256: 364512f6fbda47a7683831e49d94cede5ea91ed57c0bcb27c4c1a95b067c7717
   md5: c4c87a947b2f0594d0eda7d852140845
   depends:
@@ -8789,7 +8789,7 @@ packages:
   license_family: BSD
   size: 42936
   timestamp: 1721657516663
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
   sha256: 4099898f02e1f6119fcda65e747c3cbfef0bf563c8855b79a0245160709d5b45
   md5: ab9705c34e67fb8c8faec69d63ff4064
   depends:
@@ -8798,7 +8798,7 @@ packages:
   license_family: BSD
   size: 36410
   timestamp: 1676422341506
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
   sha256: c722f50980d7416ffb2cfc7bf72649307a0bb78c5a24eccefcd049cb61d6b355
   md5: c7c9ff0513ff3c99700919293b702410
   depends:
@@ -8807,7 +8807,7 @@ packages:
   license_family: CC
   size: 543258
   timestamp: 1709758602437
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
   sha256: 8fb3e816a5ad1da05125462dbc9e2a7e933b001a871aa65703802c0a894c6277
   md5: ee4b2fa9fce130496d5c7c86c35a1a05
   depends:
@@ -8817,7 +8817,7 @@ packages:
   license_family: BSD
   size: 17723
   timestamp: 1709323150229
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.3.1-py311h214f63a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.3.1-py311h214f63a_0.tar.bz2
   sha256: f78afa9b88ee6210adc2619ba09e20b1ef1fbe97505958a6291d8cdfee9f42b7
   md5: c9d405de1665e2d6e8cef51450f2a7a4
   depends:
@@ -8829,7 +8829,7 @@ packages:
   license_family: BSD
   size: 248779
   timestamp: 1732540644947
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cramjam-2.7.0-py311h005caf5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cramjam-2.7.0-py311h005caf5_0.tar.bz2
   sha256: 97def042390c467aaaa3f4c33276b0c134c40eb426695332673ed1173f999258
   md5: 13d97f9f5f7b1f8808e4a694b3305f15
   depends:
@@ -8839,7 +8839,7 @@ packages:
   license_family: MIT
   size: 1384742
   timestamp: 1702664451643
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-1.0.1-py311h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cytoolz-1.0.1-py311h827c3e9_0.tar.bz2
   sha256: d0c2e1f02e0f57fc2c13eb78c4f3fcb1d65aa3f5c38f2e8f64e5dcad85c7a404
   md5: 21fce512896bf8903242034f1592b33d
   depends:
@@ -8851,7 +8851,7 @@ packages:
   license_family: BSD
   size: 414374
   timestamp: 1736804071255
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-2024.12.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/dask-2024.12.1-py311haa95532_0.tar.bz2
   sha256: ec83b54a5fda90b6c97070c09f9aadc7b9da198c5f00ca5bd6dc39c9341adf50
   md5: 3958754ea4f24a2f277602388df087b2
   depends:
@@ -8870,7 +8870,7 @@ packages:
   license_family: BSD
   size: 6407
   timestamp: 1736873629289
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.12.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/dask-core-2024.12.1-py311haa95532_0.tar.bz2
   sha256: ffc2591312374b651faa688a0ceadbb4df2a55f1159a28dba075d578a5b64fc9
   md5: a44f2e793eb5f4ca4deb7413bb42af55
   depends:
@@ -8887,7 +8887,7 @@ packages:
   license_family: BSD
   size: 3268096
   timestamp: 1736807954804
-- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-expr-1.1.21-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/dask-expr-1.1.21-py311haa95532_0.tar.bz2
   sha256: 65d6d9fae6dff5a180fe455835af2c2d577df7af7a2820260c33d321aed2daf3
   md5: bd86876b2096dc4d9c8bf229705177b6
   depends:
@@ -8899,7 +8899,7 @@ packages:
   license_family: BSD
   size: 570643
   timestamp: 1736810554291
-- conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.17.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/datashader-0.17.0-py311haa95532_0.tar.bz2
   sha256: b42dbd308a689be8da71780257580759af832c33138854760ffb7bd49008aa32
   md5: 144db31a92581c2d1235bf263ee3918f
   depends:
@@ -8920,7 +8920,7 @@ packages:
   license_family: BSD
   size: 18031143
   timestamp: 1738337442786
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.8.11-py311h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.8.11-py311h5da7b33_0.tar.bz2
   sha256: 6f2f0fa6cd6b041d5dd3dfc6beeb0528b563f1d138e0c1937dda07b3ef243846
   md5: 47eb9e788ad8380d20fcdf8b40ea08a1
   depends:
@@ -8931,7 +8931,7 @@ packages:
   license_family: MIT
   size: 4034402
   timestamp: 1736269847465
-- conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2024.12.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/distributed-2024.12.1-py311haa95532_0.tar.bz2
   sha256: ef1a8013c323d631da194440f2956fda52e1f096b7638fe483c744e1c239bdc2
   md5: 2160b00d35aeeff8ebc806c290e5a95f
   depends:
@@ -8955,7 +8955,7 @@ packages:
   license_family: BSD
   size: 1861618
   timestamp: 1736871289693
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
   sha256: 5d5fc8a24c804010b8cb5963227230352ea3ccf56bea9e8116e34f77223218f2
   md5: 8f989a72eed6293dfe0533c83057980d
   depends:
@@ -8964,7 +8964,7 @@ packages:
   license_family: MIT
   size: 17688
   timestamp: 1676423357100
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-2024.2.0-py311hd7041d2_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fastparquet-2024.2.0-py311hd7041d2_0.tar.bz2
   sha256: d3a95af9b825eb25c78876ca08bf53372e1d5dc11fae2b0469ee2d1dcba1e77c
   md5: 1f736c03b7e7e7cb54ba193a90aef21f
   depends:
@@ -8980,7 +8980,7 @@ packages:
   license_family: Apache
   size: 677268
   timestamp: 1715262878219
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.55.3-py311h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fonttools-4.55.3-py311h827c3e9_0.tar.bz2
   sha256: c70c37156388dba6236fcf5905cc9b671d6d0d73eccdc7c4197676c02b8356ed
   md5: d09af197d693ad449c0481a2729ed46f
   depends:
@@ -9000,7 +9000,7 @@ packages:
   license_family: MIT
   size: 2826042
   timestamp: 1737041124866
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -9012,7 +9012,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.12.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fsspec-2024.12.0-py311haa95532_0.tar.bz2
   sha256: c11c3d2ad55faa4718cf68c779fc2c9721e58a7926dcc07630cd7865ee5dfeec
   md5: c795095832a830914b47fb65672d043e
   depends:
@@ -9023,7 +9023,7 @@ packages:
   license_family: BSD
   size: 397468
   timestamp: 1736274967762
-- conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
   sha256: 7cb0df7aa62796b0081e1708003529c02411aca6a540bae97beaec919aa64e74
   md5: ea81fd813e10055553a8d7597c8be98f
   depends:
@@ -9033,7 +9033,7 @@ packages:
   license_family: BSD
   size: 322778
   timestamp: 1706888324269
-- conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
   sha256: ed1fa1a40c6739b48ff3a2d51c3df20e4983b59684b04d93e1337c5f2e93a954
   md5: 1797f64343a42395207cd452e6a6a751
   depends:
@@ -9044,7 +9044,7 @@ packages:
   license_family: BSD
   size: 94476
   timestamp: 1706895442146
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.20.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.20.1-py311haa95532_0.tar.bz2
   sha256: c9be6ad5f8d8088f73205ca977146a3dca20f90f286770a87ec8ebea8d34872f
   md5: c93ced75faf6a951d095b7a291379183
   depends:
@@ -9064,13 +9064,13 @@ packages:
   license_family: BSD
   size: 6141475
   timestamp: 1740583429941
-- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
   sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
   md5: 582d2c1135a89da757a038de831e7f39
   license: Intel proprietary
   size: 11086648
   timestamp: 1664812389803
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
   sha256: 102c803186db6d62eaf41a906f6c563ff0d62b53c1eaede8a381e18c0d005ed9
   md5: 9d30dec03058758a428cf152e0ae28b5
   depends:
@@ -9079,7 +9079,7 @@ packages:
   license_family: BSD
   size: 148193
   timestamp: 1714399061601
-- conda: https://repo.anaconda.com/pkgs/main/win-64/imageio-2.37.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/imageio-2.37.0-py311haa95532_0.tar.bz2
   sha256: e88c34e7e4eaa942efa89c84df74dccf91c39c58752ac09e9e455793cc38d887
   md5: 1caa9f6da3b317477c08109cb424ef11
   depends:
@@ -9090,7 +9090,7 @@ packages:
   license_family: BSD
   size: 703019
   timestamp: 1738161011503
-- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-8.5.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/importlib-metadata-8.5.0-py311haa95532_0.tar.bz2
   sha256: aac5e9b4e949192c4818db0cff953988afa024e59c966202e193574d5d15f2a4
   md5: 5431ec6e2ab12e9e9e60f4557c5b0550
   depends:
@@ -9100,7 +9100,7 @@ packages:
   license_family: APACHE
   size: 55311
   timestamp: 1732633664589
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
   sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
   md5: d215cc8ee7ca2cc83cc250cc5d822fe0
   depends:
@@ -9110,7 +9110,7 @@ packages:
   license_family: Proprietary
   size: 3929136
   timestamp: 1699647939158
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.29.5-py311haa95532_1.tar.bz2
   sha256: 24ac6b6e64a2bad2bb8b43b694a8717700c1f1b89af06af677ebf8f96fff75a8
   md5: 181a1aa67aa6f8a82008adbb22bc95f7
   depends:
@@ -9131,7 +9131,7 @@ packages:
   license_family: BSD
   size: 239732
   timestamp: 1737661471714
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.30.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.30.0-py311haa95532_0.tar.bz2
   sha256: 849c5c284c450d0a254fdb09872a56bc36736fad80b5602d51034cd3c5e1f244
   md5: 85c6796b362a934aefccd96c6f4e84c9
   depends:
@@ -9149,7 +9149,7 @@ packages:
   license_family: BSD
   size: 1677847
   timestamp: 1734548277969
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.19.2-py311haa95532_0.tar.bz2
   sha256: 47280ad8a680828014eceff93c5c587c0c290579486377e696c78d8461a172a1
   md5: d38c4583143de20b5c9c8571889e1980
   depends:
@@ -9159,7 +9159,7 @@ packages:
   license_family: MIT
   size: 1189371
   timestamp: 1733987881391
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.5-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.5-py311haa95532_0.tar.bz2
   sha256: d0c47772a48d2dfe474eb13195b8d505156be94e6e139667a423575ed432f30f
   md5: 3af6d96bb74c1fe0c3281a47069a5e70
   depends:
@@ -9171,7 +9171,7 @@ packages:
   license_family: BSD
   size: 361687
   timestamp: 1737760321623
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
   sha256: 0238fb10912d9345a9d327ff314a179de38369f8e1d0de0b5f4fab04defab0e4
   md5: 16a420ea83811cfa0c7cadba8f9f0995
   depends:
@@ -9181,7 +9181,7 @@ packages:
   license_family: Other
   size: 409932
   timestamp: 1722872751697
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.23.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.23.0-py311haa95532_0.tar.bz2
   sha256: 99f6618c5969b13451072defdcf3441b83f710010ef10b7a620b42e156ed919e
   md5: 501a297479b97960e249bdb117f7cda7
   depends:
@@ -9194,7 +9194,7 @@ packages:
   license_family: MIT
   size: 224348
   timestamp: 1728486919376
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
   sha256: 9581be54128954080d7cef448b1728874c2ebbe5064f55adece422cf12eafa5a
   md5: 3adc105f87d5c7f0b1248bc3423f5b48
   depends:
@@ -9204,7 +9204,7 @@ packages:
   license_family: MIT
   size: 16187
   timestamp: 1699032556953
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
   sha256: ad8343bad7c8f0448cbcfbaf872cc94b56da81c52e5cdcee2a5d6b89f029eb75
   md5: addceff8d46c9d1d322618a9ce9e5b39
   depends:
@@ -9220,7 +9220,7 @@ packages:
   license_family: BSD
   size: 300354
   timestamp: 1676424060532
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
   sha256: fe0bf805dfa60d8b5d61670900442d0cda12523135176f60e1ebafb797e521d8
   md5: c8cf5ea3d4b0bc57dfe6b189b47e69e9
   depends:
@@ -9232,7 +9232,7 @@ packages:
   license_family: BSD
   size: 136783
   timestamp: 1718818384444
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
   sha256: 262c35a28d0af4d73ea1c010ce0c022005512a26d5c27064c8e009c0b7b789d9
   md5: 8367c61552aa274c0843201d88e461c8
   depends:
@@ -9248,7 +9248,7 @@ packages:
   license_family: BSD
   size: 72131
   timestamp: 1718738283200
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
   sha256: 00bf8449a37eb10c91ebfaa14b231905fde9493740cbda7ec89a8d3d8d9d1ff3
   md5: 1f3abe3cbf365249ebae7465a57e4cae
   depends:
@@ -9276,7 +9276,7 @@ packages:
   license_family: BSD
   size: 655133
   timestamp: 1718827724346
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
   sha256: 90420847230e72a648417f5f77cebcf7f17b89f70788652c276acc0c440e135f
   md5: ef3d8dee197aa37897bf6d39d2dd878f
   depends:
@@ -9287,7 +9287,7 @@ packages:
   license_family: BSD
   size: 27639
   timestamp: 1686871052174
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
   sha256: 97faaf26ce5254ec3649a8ee7f480b1556e4e8e6e4356d2fab1e6a5532631a0f
   md5: da23bd831c50c877f63038b7e16720ad
   depends:
@@ -9299,7 +9299,7 @@ packages:
   license_family: BSD
   size: 20163
   timestamp: 1700168785472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.8-py311h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.8-py311h5da7b33_0.tar.bz2
   sha256: 57b39cf2915a010c60378dfae2914e6e70df28b85a45084d26b3484ecb77af7a
   md5: 69f4bd7904b46d0040209518a69256a1
   depends:
@@ -9310,7 +9310,7 @@ packages:
   license_family: BSD
   size: 73206
   timestamp: 1737041022655
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lazy_loader-0.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lazy_loader-0.4-py311haa95532_0.tar.bz2
   sha256: ba82d5012d3c43591406b2156eaef0d3671f1a5d9c92d1673f0188cc8bebded5
   md5: 5ef812a5a293188d1ffe6fe7418d83a4
   depends:
@@ -9320,7 +9320,7 @@ packages:
   license_family: BSD
   size: 25695
   timestamp: 1718177014000
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.16-hb4a4139_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lcms2-2.16-hb4a4139_0.tar.bz2
   sha256: ef4d7e1443c7c510b6e690e344392075bc4d89b5818907f544ce98fd967d029a
   md5: 6541897ab2fd34b35519b95c922b3192
   depends:
@@ -9332,7 +9332,7 @@ packages:
   license_family: MIT
   size: 1089573
   timestamp: 1734428606761
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-4.0.0-h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-4.0.0-h5da7b33_0.tar.bz2
   sha256: 3a915692cf3e21e7cc4259faea2e17535530515acb3bc8fa00832d646bdeecf0
   md5: eda551db9b747f0606eddd001343ed36
   depends:
@@ -9342,7 +9342,7 @@ packages:
   license_family: Apache
   size: 207263
   timestamp: 1734423494890
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libabseil-20240116.2-cxx17_h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libabseil-20240116.2-cxx17_h5da7b33_0.tar.bz2
   sha256: 0e20a85132c711cb36bc33f1c329eec57f9b8b5a52fe8b16e39ccf2181c3e585
   md5: 2056c0ad87951b65e50a809d539a1903
   depends:
@@ -9355,7 +9355,7 @@ packages:
   license_family: Apache
   size: 2192360
   timestamp: 1716563477680
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
   sha256: 4184dd040fc38cb123a98588a8344aa8d1ba1932df5fcc6c188f6b21f5a0c306
   md5: da58cfa83f3d6c31ae12d8777cd1b64d
   depends:
@@ -9368,7 +9368,7 @@ packages:
   license_family: OTHER
   size: 29803292
   timestamp: 1696764164248
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h827c3e9_9.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h827c3e9_9.tar.bz2
   sha256: 5c51b1860e91be66584f6932b86de344a7158894e98b59ed5f973c39e3d77fbc
   md5: 4273c278acae05def47ce1bbf4a604bc
   depends:
@@ -9377,7 +9377,7 @@ packages:
   license: MIT
   size: 80775
   timestamp: 1736183139175
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h827c3e9_9.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h827c3e9_9.tar.bz2
   sha256: c34366f1af8c499501c660caed188191869198af323f28f9fdf36cdc3bd9b983
   md5: 17978e34dd336c03b45064a092e24b2c
   depends:
@@ -9387,7 +9387,7 @@ packages:
   license: MIT
   size: 45764
   timestamp: 1736183205643
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h827c3e9_9.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h827c3e9_9.tar.bz2
   sha256: 3db56a17b192f502d1658eff34ed0d3d4ca137c9611e22c5ea866d217004d939
   md5: 4b5c2afa55286a51a06fb2e7f2ffa135
   depends:
@@ -9397,7 +9397,7 @@ packages:
   license: MIT
   size: 755218
   timestamp: 1736183274598
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.12.1-h9da9810_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libcurl-8.12.1-h9da9810_0.tar.bz2
   sha256: 2146af071794793754a13c3831642f18e61a237aa39cc903b0c7bf42aa1a3feb
   md5: 8e1c91dacbc168acf20f675848dc6fd1
   depends:
@@ -9411,7 +9411,7 @@ packages:
   license_family: MIT
   size: 380931
   timestamp: 1739986497455
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.22-h5bf469e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.22-h5bf469e_0.tar.bz2
   sha256: 46c58457ec8c074d5af22fe36a182d5c29e76f6248e7d1d5cb76c66beefe52aa
   md5: 5bd6c216dd03f3ccf9d108b7c8a29367
   depends:
@@ -9421,7 +9421,7 @@ packages:
   license_family: MIT
   size: 223776
   timestamp: 1734423384478
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
   sha256: 6458c7a370c4e3366b3b208c5b2834a7acfb17981e47fe3fb861f225d7cefbc3
   md5: ecabf4acab5b604856d8c7c4278c2c2c
   depends:
@@ -9433,7 +9433,7 @@ packages:
   license_family: BSD
   size: 446380
   timestamp: 1685052520132
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
   sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
   md5: cf949d76148be1e2a534218d9c57df86
   depends:
@@ -9443,7 +9443,7 @@ packages:
   license_family: MIT
   size: 155435
   timestamp: 1714484319443
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libgrpc-1.62.2-hf25190f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libgrpc-1.62.2-hf25190f_0.tar.bz2
   sha256: 1d933ff3c15bbd21e2463392eb8b84c19f5e7e8116757a5456d53edd182f8aa3
   md5: eb54ebe53747695597188890f99c2aad
   depends:
@@ -9462,7 +9462,7 @@ packages:
   license_family: APACHE
   size: 19177715
   timestamp: 1716836854929
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -9473,7 +9473,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-4.25.3-hf2fb9eb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libprotobuf-4.25.3-hf2fb9eb_0.tar.bz2
   sha256: 189a48ba963858b5adf13f200a36ee566bcd823b8fbc1a0372d4605f465989ae
   md5: 310f4bf562072517c58e700471d52999
   depends:
@@ -9486,7 +9486,7 @@ packages:
   license_family: BSD
   size: 6407565
   timestamp: 1716568643819
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -9495,7 +9495,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.11.1-h2addb87_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libssh2-1.11.1-h2addb87_0.tar.bz2
   sha256: c63c4909596a8fe198b94f8cccd91dd8445b92b1b3951a15fb836d88115f93af
   md5: 2ded634970ea802078cc2b68f903d45f
   depends:
@@ -9507,7 +9507,7 @@ packages:
   license_family: BSD
   size: 310776
   timestamp: 1732891385479
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
   sha256: 238e486a0d62264e7ab35098bdc0390fb9a4649921b18827228c811ae8252c88
   md5: f1ebe453c5a955a25e4b00f73279fc42
   depends:
@@ -9521,7 +9521,7 @@ packages:
   license_family: Apache
   size: 894777
   timestamp: 1687975823684
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-h44ae7cf_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-h44ae7cf_1.tar.bz2
   sha256: 224c9ee15d52fd10544bdae6738e8d8ad12a04a6c48692574d51426d0ea421f2
   md5: ba5f521d36280d34950fc5d99a58676b
   depends:
@@ -9537,7 +9537,7 @@ packages:
   license_family: Other
   size: 1213382
   timestamp: 1734425893191
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
   sha256: e54ee28f6ba01b3addf61ee9dfbdedc16eac8654fc334f713b5f181cf037d0f2
   md5: 47aa151852fc9b07e7573d22f0af945d
   depends:
@@ -9549,7 +9549,7 @@ packages:
   license_family: BSD
   size: 339944
   timestamp: 1729160123353
-- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
   sha256: 4534c822511a052a72c2b070a05e5d8d6f3550f18ea00a33f9d8a9a92b4382cc
   md5: 82f24e7660831445a2183216e280a6a4
   depends:
@@ -9559,7 +9559,7 @@ packages:
   license_family: MIT
   size: 41464
   timestamp: 1676474474981
-- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.44.0-py311hf2fb9eb_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/llvmlite-0.44.0-py311hf2fb9eb_0.tar.bz2
   sha256: 4ed71969f70f21b139eef63796e36bc097f40a4b85f0bb03099c3a8f4cd54b3e
   md5: a7559fa32b5b83f3a2c027cfb821f8e3
   depends:
@@ -9571,7 +9571,7 @@ packages:
   license_family: BSD
   size: 22183942
   timestamp: 1738678710240
-- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
   sha256: 896b7a39bd4ad3621312130122b4fe84dcb67d7355166255c58ea9bc562eb0ae
   md5: 640b852a56296f48cf073e61a59c5256
   depends:
@@ -9580,7 +9580,7 @@ packages:
   license_family: BSD
   size: 13751
   timestamp: 1676428354074
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.3.2-py311h827c3e9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-4.3.2-py311h827c3e9_1.tar.bz2
   sha256: c32634e77ad79376714e9fc1c46c393a820ee13ac06270dece8d98c645bdda89
   md5: 00b7603f9c73ce9f188a3bcccc6c0d07
   depends:
@@ -9592,7 +9592,7 @@ packages:
   license_family: BSD
   size: 106672
   timestamp: 1736370127321
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
   sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
   md5: 320f40b75d93f3b96931c6d13c23946c
   depends:
@@ -9602,7 +9602,7 @@ packages:
   license_family: BSD
   size: 158902
   timestamp: 1714512129889
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
   sha256: e0dc6e119b224bb31ef34b6ba270ffadc181d38b698c5318de8df7a5d2c4ccbd
   md5: 992ccd756f09408f0b74dfb9852a8b7f
   depends:
@@ -9611,7 +9611,7 @@ packages:
   license_family: BSD
   size: 182381
   timestamp: 1676437963591
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
   sha256: 050b5fd4b28132d8102a7e6b40179894dc7f5e41f7ad9ee19211e67446c5740f
   md5: 3ae0b2f6baec708554648ddafa81b756
   depends:
@@ -9621,7 +9621,7 @@ packages:
   license_family: MIT
   size: 154386
   timestamp: 1684279992864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-3.0.2-py311h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-3.0.2-py311h827c3e9_0.tar.bz2
   sha256: f5bb2877837f996624d59e52d7bc4fa95b8d80c2972d758dfdc817b6a06aac05
   md5: 2c8805cff2f45459eb69566abfbebbfa
   depends:
@@ -9634,7 +9634,7 @@ packages:
   license_family: BSD
   size: 42282
   timestamp: 1738584229532
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.10.0-py311he19b0ae_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.10.0-py311he19b0ae_0.tar.bz2
   sha256: 35078ccb78b0b35ea07ccff575a056166fe32df8c2e4a2265c3aca75e00a482b
   md5: 3d61e9d9826f4a3664bc102588ab2fa4
   depends:
@@ -9655,7 +9655,7 @@ packages:
   license_family: PSF
   size: 12369480
   timestamp: 1736279003945
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
   sha256: 43279276850eb6e621812448cddc1093524cee0b7f8ed58b4600b68a4fb659f2
   md5: 5968b2b5c1f3cf5c8c8c9aaa4d8d66a2
   depends:
@@ -9665,7 +9665,7 @@ packages:
   license_family: BSD
   size: 19886
   timestamp: 1676425829787
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
   sha256: 3062a8254ca351b54f15bea85cc928a3ba4d879bb98ce97ece39a9f7eca215a5
   md5: 8f1565663abb34ad7fdd512e76da5532
   depends:
@@ -9675,7 +9675,7 @@ packages:
   license_family: MIT
   size: 68031
   timestamp: 1676481862508
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
   sha256: cdff5215c292fe59649ca40ca72f5d26da352760c1d6a56feba14eb13f7bbf61
   md5: e0f3f32b22135dfeaec277bc87183ca9
   depends:
@@ -9684,7 +9684,7 @@ packages:
   license_family: MIT
   size: 23328
   timestamp: 1676442709081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
   sha256: 3b173a25605d2aaacc57ec0e425f1d1c51327eb2521c8742a736e2c76069bc8d
   md5: 169f1c93a443f95a88665f3008623ce1
   depends:
@@ -9695,7 +9695,7 @@ packages:
   license_family: BSD
   size: 104882
   timestamp: 1676425142412
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
   sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
   md5: 527155127b9fada5e5c5c69a624674b9
   depends:
@@ -9707,7 +9707,7 @@ packages:
   license_family: Proprietary
   size: 187498166
   timestamp: 1699648376430
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h827c3e9_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py311h827c3e9_2.tar.bz2
   sha256: d05715a691b223d6c7f592c21032f9bee1e7cad6834c942eec1f2d5bf2da100d
   md5: 04bd233faebb0a8c2841e648ea39e801
   depends:
@@ -9719,7 +9719,7 @@ packages:
   license_family: BSD
   size: 80594
   timestamp: 1736370888084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.11-py311h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.11-py311h827c3e9_0.tar.bz2
   sha256: 513b8fe5da01b8460084688d99c977d173b19d7d58ad2aa6b27a961665ae25f4
   md5: c07115b0a05892c721b7324ef8598c2f
   depends:
@@ -9734,7 +9734,7 @@ packages:
   license_family: BSD
   size: 212966
   timestamp: 1730823150084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.8-py311hea22821_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.8-py311hea22821_0.tar.bz2
   sha256: f8ea6da83e88b353bf66ae609d0377e45fe0d4dcdba2c920ca7b600559f49679
   md5: 98805ec361a795613a97773fab63653b
   depends:
@@ -9749,7 +9749,7 @@ packages:
   license_family: BSD
   size: 345997
   timestamp: 1730822892388
-- conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py311h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/msgpack-python-1.0.3-py311h59b6b97_0.tar.bz2
   sha256: c09c5ed3f07731091958ea6ed06a1eaeaca1f7e1361d341fb06b344d51074ca2
   md5: 520c04235cf0980e1ce908e893b4dc71
   depends:
@@ -9760,7 +9760,7 @@ packages:
   license_family: Apache
   size: 37775
   timestamp: 1676427521514
-- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
   sha256: 39f09c1bc57b4800ebda331eddb462928435498705351b0432d51a4293294ad8
   md5: 5565984a02f41e97cb9a4c9126ced14b
   depends:
@@ -9770,7 +9770,7 @@ packages:
   license_family: BSD
   size: 29808
   timestamp: 1676442800892
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
   sha256: 636f369607118a6ee3d0b63b7edb925d8081fd3fc829a7699136ce0dedbde067
   md5: b7e49c9cea50d8406cac81cd720dd80a
   depends:
@@ -9783,7 +9783,7 @@ packages:
   license_family: BSD
   size: 8323655
   timestamp: 1717622931223
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
   sha256: e940f9178ee2fa0a7c12873ae35ebea0074371653e5cfa1be8aa8d9271fd343b
   md5: 355d0835215911738a28010dfa6aa382
   depends:
@@ -9796,7 +9796,7 @@ packages:
   license_family: BSD
   size: 141785
   timestamp: 1698934346590
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-7.16.4-py311haa95532_0.tar.bz2
   sha256: d5a6346c8d081061777b5327284f3836342ad3e4869c3584a8bf1b7abac56466
   md5: 0d00b9e90c3df8cb479490dc136f0577
   depends:
@@ -9823,7 +9823,7 @@ packages:
   license_family: BSD
   size: 573057
   timestamp: 1728052469536
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.10.4-py311haa95532_0.tar.bz2
   sha256: 952df0af8037fd3131a3f64481660272040fc30816c5b6a5377fa2357d3bcede
   md5: e0f63c7653d679b5ec3f50b14424ad1d
   depends:
@@ -9836,7 +9836,7 @@ packages:
   license_family: BSD
   size: 202609
   timestamp: 1728050720194
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
   sha256: 90fb3f14c49da1397982eae21cd09e8d60d491d76f94c57590c56723fe6dc172
   md5: 46a523661fe5c1bce7b4213fd428c3de
   depends:
@@ -9845,7 +9845,7 @@ packages:
   license_family: BSD
   size: 16732
   timestamp: 1708532795328
-- conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.4.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/networkx-3.4.2-py311haa95532_0.tar.bz2
   sha256: b34f73b420b25b789139a69cec271592e1ed8cfb716a19ec62bc9f4a5ad65d87
   md5: 0007af7a310c8541dc22c49fbeddf9ae
   depends:
@@ -9863,7 +9863,7 @@ packages:
   license_family: BSD
   size: 3410161
   timestamp: 1737044326163
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
   sha256: 62732e34b2cdcb73846cfdf53284067d32113aae0f6d736ca30ce2b0073bce27
   md5: ec7191b2ea4e65b5eed6f7fdd9271d28
   depends:
@@ -9888,7 +9888,7 @@ packages:
   license_family: BSD
   size: 769732
   timestamp: 1717630919732
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
   sha256: e040ebcab948325fbe17e4ab15be62e1fafa7bad225457e59764adb60eb40db5
   md5: 4d40a09df8cb74a9f044eab317436d67
   depends:
@@ -9898,7 +9898,7 @@ packages:
   license_family: BSD
   size: 27282
   timestamp: 1699456187703
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.61.0-py311h5da7b33_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numba-0.61.0-py311h5da7b33_1.tar.bz2
   sha256: 10ac4c6d3888b01c0231a637b1756d5699fa69cf44e67f7fb6ecec9f158ec395
   md5: 0de6cc471167996a4eb7e366424baf38
   depends:
@@ -9921,7 +9921,7 @@ packages:
   license_family: BSD
   size: 6349470
   timestamp: 1740679736335
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.10.1-py311h4cd664f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.10.1-py311h4cd664f_0.tar.bz2
   sha256: 7bf058d86876ca3d1f23b21ca8f3d9340e7f26fef9366eca092302c4fdc04e8b
   md5: 7492afa4cb19e783c400ae35b90753cc
   depends:
@@ -9937,7 +9937,7 @@ packages:
   license_family: MIT
   size: 210960
   timestamp: 1730216100891
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
   sha256: 470fe9a0b3e196fa60d5550d8188f6074a207572fa0d353a4448d580872e7804
   md5: 6fdb8df0613fb2fb9f1732d335fa25f1
   depends:
@@ -9954,7 +9954,7 @@ packages:
   license_family: BSD
   size: 11053
   timestamp: 1708641901110
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
   sha256: 222c1711e7cf151e29077c7d4d86a865c9fd39615812d58a1daca6fd1b6bdfb5
   md5: 585bcd8bc3940a8a859f38ebafdcd77d
   depends:
@@ -9970,7 +9970,7 @@ packages:
   license_family: BSD
   size: 10723862
   timestamp: 1708641867155
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
   sha256: e2afce0548808d27293a03661ee5f7ac3e18f82a92c9fb23f420eb5e92126fc6
   md5: 9dd921a785844abe0aa842c3800d405a
   depends:
@@ -9982,7 +9982,7 @@ packages:
   license_family: BSD
   size: 286986
   timestamp: 1722872761369
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.16-h3f729d1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.16-h3f729d1_0.tar.bz2
   sha256: 09a7f7d538b0ea0686699d70ee5ad3b3de0f949c3826c3f3ae25d4286cb3bc00
   md5: e071cd2b74e888dd3aef739ee4060bc0
   depends:
@@ -9993,7 +9993,7 @@ packages:
   license_family: Apache
   size: 8351528
   timestamp: 1740991970485
-- conda: https://repo.anaconda.com/pkgs/main/win-64/orc-2.0.1-hd8d391b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/orc-2.0.1-hd8d391b_0.tar.bz2
   sha256: af8a9ad457ebc4c4aa800676ffbfd5cf830e1da697672ea6412bf041fd61cedd
   md5: 584d733dc81492d46a926660353b361a
   depends:
@@ -10011,7 +10011,7 @@ packages:
   license_family: Apache
   size: 1235996
   timestamp: 1717104791454
-- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
   sha256: b2f5f50a1ddf811102636f3acebd76716c88ebb628754b91eda7a3a962adf26c
   md5: 712527b4d84c350dca4b67f511c04414
   depends:
@@ -10020,7 +10020,7 @@ packages:
   license_family: APACHE
   size: 39421
   timestamp: 1699371341381
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-24.2-py311haa95532_0.tar.bz2
   sha256: 55ead6073f34770ba6ab735643411f2219ecd820d186ca3af266954d05e09487
   md5: 6bae6e1982c2e8a4eb1c66df62521fa3
   depends:
@@ -10029,7 +10029,7 @@ packages:
   license_family: Apache
   size: 189953
   timestamp: 1734472735678
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.3-py311h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-2.2.3-py311h5da7b33_0.tar.bz2
   sha256: 82cc56df413c3875ccc7c811d3268a1404c6ed2b8d02bf7980f2c87a88918168
   md5: e109a06ad54fcea29bdaa01596179a8b
   depends:
@@ -10080,7 +10080,7 @@ packages:
   license_family: BSD
   size: 17254708
   timestamp: 1732738447404
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-1.6.0-py311haa95532_0.tar.bz2
   sha256: 192831c7bc433ee523b155de842db7d5f6db9a1e78b70545dbc75a6fef5354cf
   md5: 28120336ff966ebb49f3331fe2eee795
   depends:
@@ -10105,7 +10105,7 @@ packages:
   license_family: BSD
   size: 24698103
   timestamp: 1738687060117
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.2.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-2.2.0-py311haa95532_0.tar.bz2
   sha256: 4086a9512de16e81900140f66ed8e693f05f333f298a83b39a11d5c887fb2434
   md5: 1314cc7bad5784cd7bee147f44ec9947
   depends:
@@ -10114,7 +10114,7 @@ packages:
   license_family: BSD
   size: 273134
   timestamp: 1734618723915
-- conda: https://repo.anaconda.com/pkgs/main/win-64/parso-0.8.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/parso-0.8.4-py311haa95532_0.tar.bz2
   sha256: d9548c1a2c3292e37ff5d8a4b8f10785f3718b445a64b3e259cbed4ec17700e7
   md5: 59cb810d1a41684238817cb875734af2
   depends:
@@ -10123,7 +10123,7 @@ packages:
   license_family: MIT
   size: 224906
   timestamp: 1733963496420
-- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/partd-1.4.2-py311haa95532_0.tar.bz2
   sha256: c02fed71b4aab0ebe6a200b1b062e9b30cc990c572ab75546b9aabf8e2c036b9
   md5: 8e6a93fa140a70f7706241067ec5e508
   depends:
@@ -10137,7 +10137,7 @@ packages:
   license_family: BSD
   size: 48516
   timestamp: 1736803518887
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-11.1.0-py311h096bfcc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-11.1.0-py311h096bfcc_0.tar.bz2
   sha256: e8bfe7a79be1549fb5c2f4950d07c91d174d0177051481f7d78257712716ec66
   md5: 4f7c73093a936a7c53a81d5e7191bdcd
   depends:
@@ -10156,7 +10156,7 @@ packages:
   license_family: Other
   size: 977993
   timestamp: 1738010898913
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-25.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-25.0-py311haa95532_0.tar.bz2
   sha256: 99c969667a50b21694dea15b4082b25ceea53baca4ed40fbce245eb4262588f0
   md5: b6dfc09ba17209049e317cfd4e9a140d
   depends:
@@ -10167,7 +10167,7 @@ packages:
   license_family: MIT
   size: 3277696
   timestamp: 1737992380415
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
   sha256: e5f8cbfb5fc25d460a9117bfc5511959c5e86ccb193316033f87bd516e0c8881
   md5: 9f7e8b5eb651539386bb92c14e5c321b
   depends:
@@ -10176,7 +10176,7 @@ packages:
   license_family: MIT
   size: 37730
   timestamp: 1692205554840
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.21.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.21.0-py311haa95532_0.tar.bz2
   sha256: 98674172e2820965291e63eab571fde1fd26cbbad3856be6f86f415e7e1037b8
   md5: 30ffc1f7b25ca073001fb641f9724520
   depends:
@@ -10185,7 +10185,7 @@ packages:
   license_family: Apache
   size: 122618
   timestamp: 1731961709745
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
   sha256: 546819d922b03f3a25ca9f98fd069d0588d481fc0603c6d74bd598fb6a93687f
   md5: 86c18e3e0b67ee099457475ed6caf2e6
   depends:
@@ -10197,7 +10197,7 @@ packages:
   license_family: BSD
   size: 751763
   timestamp: 1704404627180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h827c3e9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py311h827c3e9_1.tar.bz2
   sha256: ac23609428982448c7d8e4457b4c7ad3cf0373fd33cf12767b6b064ebca729bc
   md5: ce75fc6d561dbe9fc629b7a7c4359af3
   depends:
@@ -10208,7 +10208,7 @@ packages:
   license_family: BSD
   size: 523851
   timestamp: 1736372163558
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-19.0.0-py311h5da7b33_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyarrow-19.0.0-py311h5da7b33_1.tar.bz2
   sha256: 3544ce70fd62e4accf73b9c935ea014a5957e3c39ca6a1d350b1faa7987e8f25
   md5: db9b5bc1be1314775aa71a47651ef149
   depends:
@@ -10221,7 +10221,7 @@ packages:
   license_family: Apache
   size: 6679808
   timestamp: 1738230946393
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
   sha256: e2af1efb1a5094a5962d93fa949ecab479a2ae7570e030f52eeac6761383c208
   md5: 4cb1359e22ddf8f3996afddce5f6205c
   depends:
@@ -10233,7 +10233,7 @@ packages:
   license_family: BSD
   size: 56638
   timestamp: 1676438592117
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
   sha256: d95c88d06f4f3f667bd9a39e5f18179e83b3cd4c115c06ce0fff390ff6d3a700
   md5: c6d00a8a4d89b1be99bfa3aff19d96b4
   depends:
@@ -10242,7 +10242,7 @@ packages:
   license_family: BSD
   size: 2134881
   timestamp: 1684280285492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.2.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.2.0-py311haa95532_0.tar.bz2
   sha256: 30ed42a98c68d6c98d48f871197c5c9c745e7545a12818a21d36689fe1a3a856
   md5: dfd92ad9c788e9c687ca8adc3f541ce0
   depends:
@@ -10251,7 +10251,7 @@ packages:
   license_family: MIT
   size: 486618
   timestamp: 1731445794006
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
   sha256: 974c22de09078bf07c5db31fe12d8d89d6433508defc8237cbe52e08c69ed56b
   md5: 9cf10bfd49140a527cf4b1d912097e6d
   depends:
@@ -10261,7 +10261,7 @@ packages:
   license_family: BSD
   size: 36072
   timestamp: 1676426019064
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.11-h4607a30_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.11.11-h4607a30_0.tar.bz2
   sha256: a53f9aa74ecbe1f97a4956425ad1636d8c936750636dd7de0ac8d35ae14b105b
   md5: b3717cd05b5595bd3c839f202df46e74
   depends:
@@ -10282,7 +10282,7 @@ packages:
   license_family: PSF
   size: 20212416
   timestamp: 1733935177242
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
   sha256: 2c61639b3bb56fc864c86558bceb7845b1731ac44bf1a94894172ea47a995bd4
   md5: 404805e547b4d50b5cd17e16bca87527
   depends:
@@ -10292,7 +10292,7 @@ packages:
   license_family: BSD
   size: 332043
   timestamp: 1716495838826
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.20.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.20.0-py311haa95532_0.tar.bz2
   sha256: dbd986e65f63d73389c7ecf060c0954905f3dba4b2f9f33bf930ca4cb0875310
   md5: c2604164bf8765f3281c1f65ef5eac92
   depends:
@@ -10301,7 +10301,7 @@ packages:
   license_family: BSD
   size: 282101
   timestamp: 1731939443247
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-3.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-json-logger-3.2.1-py311haa95532_0.tar.bz2
   sha256: 68389376bdfc521ad3b3f264267420b4c1f99356e90fb0f894128f40f5975ab3
   md5: 65408c0fbd3705ce3fcd630e19effa73
   depends:
@@ -10310,7 +10310,7 @@ packages:
   license_family: BSD
   size: 29508
   timestamp: 1734370229403
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.6.2-py311h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-lmdb-1.6.2-py311h5da7b33_0.tar.bz2
   sha256: ee2593e8fba1e0bd17d06993cc10db78564ffffc474ef7544c4159fdf636f082
   md5: 6cc36bf13acaeccb0c8de698d33e050c
   depends:
@@ -10321,7 +10321,7 @@ packages:
   license_family: Other
   size: 166314
   timestamp: 1736541891612
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-snappy-0.6.1-py311hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-snappy-0.6.1-py311hd77b12b_0.tar.bz2
   sha256: d58b4c81e37e7332851e6b19db7511389bfec89d6dac69382c503e6a25968254
   md5: 907db7a86a727b8d7062e3b9853e80a3
   depends:
@@ -10333,7 +10333,7 @@ packages:
   license_family: BSD
   size: 38764
   timestamp: 1676446120675
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
   sha256: 803274d986d0c4e3b5ec1018747ede86ef57137455b3e44a60e834717eafb92b
   md5: c9f134ddeff6fdf0373a45534ddb7079
   depends:
@@ -10342,7 +10342,7 @@ packages:
   license_family: MIT
   size: 273009
   timestamp: 1713974722039
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
   sha256: 6fbcba97c1dcb5157afd23f264c3cff069c7e4be5ea55980fc349eb8dc2cb49e
   md5: 8153e3f8b3283926bcf9403804a365f5
   depends:
@@ -10354,7 +10354,7 @@ packages:
   license_family: BSD
   size: 65050
   timestamp: 1711137009299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-308-py311h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-308-py311h5da7b33_0.tar.bz2
   sha256: 6b6a583ddae1f7fdf8b3923bd2b8c56382b2c77d0d08ed536e3237c8b82f9f02
   md5: 01baaaa03f7066e272de93b25539c834
   depends:
@@ -10363,7 +10363,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13813074
   timestamp: 1732201761313
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.14-py311h72d21ff_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.14-py311h72d21ff_0.tar.bz2
   sha256: dd0c35a9a5a0e35033b3a5a4c1a98b121670b9e9c795ee8dcf400534760af267
   md5: 2addb0793c3e949f71e415943db41e70
   depends:
@@ -10375,7 +10375,7 @@ packages:
   license_family: MIT
   size: 250185
   timestamp: 1733515229618
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.2-py311h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.2-py311h827c3e9_0.tar.bz2
   sha256: b54065893111c3bf4ab784feb9a0b7b58bd829c414adda935624790d6541885f
   md5: 1d84022dd238ec68d7c0499885d18c86
   depends:
@@ -10387,7 +10387,7 @@ packages:
   license_family: MIT
   size: 209408
   timestamp: 1728658205944
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
   sha256: ea39db411361d96545a04fb976940e9590147acb4ca9caacf7e8264780379347
   md5: b411b8be8e53e5059949dde02dd07faf
   depends:
@@ -10399,7 +10399,7 @@ packages:
   license_family: Other
   size: 565148
   timestamp: 1709319072176
-- conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
   sha256: 720f3dd1f933d035b1393951ffd1b6437fc5e19b1999e74096044514a46053fb
   md5: add2dfb15b518144663fc3b897d66da7
   depends:
@@ -10408,7 +10408,7 @@ packages:
   license: BSD-3-Clause
   size: 493391
   timestamp: 1652432364793
-- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
   sha256: 47653b45a5f2d97b5bf0dbf0e620908880f9078da427eef69012effe3f19af67
   md5: 44e709ae67d89bccee2d4d46d358fee3
   depends:
@@ -10419,7 +10419,7 @@ packages:
   license_family: MIT
   size: 74493
   timestamp: 1699012356534
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.32.3-py311haa95532_1.tar.bz2
   sha256: a225c1d6a873991bed5c9e93806f0ef0af35830cd6ce09a849e20084a8372200
   md5: 321bb6bf4f0afb4e9175bcb75ab57976
   depends:
@@ -10435,7 +10435,7 @@ packages:
   license_family: Apache
   size: 124386
   timestamp: 1731000647310
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
   sha256: d6daaa6b45272819176e4aeb467ae00e3db43386548464a9993688f292709d40
   md5: 9fe721d7f7420c259df4f07d4503f654
   depends:
@@ -10445,7 +10445,7 @@ packages:
   license_family: MIT
   size: 9683
   timestamp: 1683077110211
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
   sha256: 6051860575f9448aea5799d74469c928cd7cdeeca1eb53657872262a77b1a7a8
   md5: 60e193eca497130034facd5fed168249
   depends:
@@ -10454,7 +10454,7 @@ packages:
   license_family: MIT
   size: 10094
   timestamp: 1683059114376
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.22.3-py311h636fa0f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rpds-py-0.22.3-py311h636fa0f_0.tar.bz2
   sha256: 134ac16033c85372d7ce578b15930adabc6a070f87352bdc0a06820a191b36eb
   md5: 8bb82907b584f6fe7b68d3dc429ad311
   depends:
@@ -10465,7 +10465,7 @@ packages:
   license_family: MIT
   size: 268477
   timestamp: 1736545733061
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scikit-image-0.25.0-py311h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/scikit-image-0.25.0-py311h5da7b33_0.tar.bz2
   sha256: 99bc4402b40cc5b062ae1e3a127fc446171c63784b4c280266178f89c93abb2f
   md5: 9f6eebf64ab95a1aef8c200aff249163
   depends:
@@ -10494,7 +10494,7 @@ packages:
   license_family: Other
   size: 13274470
   timestamp: 1737476259877
-- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.15.1-py311h9f229c6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/scipy-1.15.1-py311h9f229c6_0.tar.bz2
   sha256: 9838e7ac943e722c03afd1c7550084680ee900837c66aa5f5d09c88c0bac3fa7
   md5: 4eefcf949ac2baca2f696611d440e684
   depends:
@@ -10511,7 +10511,7 @@ packages:
   license_family: BSD
   size: 37176316
   timestamp: 1737133797753
-- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py311haa95532_1.tar.bz2
   sha256: 62bfeda88ac74e49d274b705b6483a4f1fd241f5c354f04ab02025a9a15f93ed
   md5: 5d0ca57d369b424403de8830d5a638da
   depends:
@@ -10520,7 +10520,7 @@ packages:
   license_family: BSD
   size: 99986
   timestamp: 1736542872085
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-75.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-75.8.0-py311haa95532_0.tar.bz2
   sha256: 94a1d4bdfaf7f327e218ddb0cd9d564872fa6a24ea52e8bc945dd850b8f20dc3
   md5: 2c65061f62f8df0f81ebed0efe387602
   depends:
@@ -10529,7 +10529,7 @@ packages:
   license_family: MIT
   size: 2307476
   timestamp: 1738046308078
-- conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
   sha256: 5e5f855a70cf4c9dc6f2ac8d9fa51a3f095bf4db8e2ee3ff213ef5432556d7cd
   md5: 9c1f7331a4116e5c27d8af7453f8ee47
   depends:
@@ -10539,7 +10539,7 @@ packages:
   license_family: BSD
   size: 119274
   timestamp: 1723557526373
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
   sha256: 5d1b7e14dc04816692de0f8518ea8fcbefb26ab61cec83f96f2c44c1bee67fab
   md5: 505d2a70a875b5082dc857aa4dfab0d4
   depends:
@@ -10548,7 +10548,7 @@ packages:
   license_family: Other
   size: 18830
   timestamp: 1705431395254
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
   sha256: 5ff3b4ac3fbce4dd67a87856c04698d0397deb0ac288ff4e7eb02fbab57f1253
   md5: 0ca650a7001c6650809d3361de8cb005
   depends:
@@ -10557,7 +10557,7 @@ packages:
   license_family: MIT
   size: 89590
   timestamp: 1696347858925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
   sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
   md5: 833b93a2daade3407898f15588945d83
   depends:
@@ -10567,7 +10567,7 @@ packages:
   license_family: Other
   size: 1440481
   timestamp: 1714488344682
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -10577,7 +10577,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
   sha256: 78d89b50a29fbeb19a562f5dad95615e3f192bb4f3b86cd6ea75f2f825418232
   md5: 4a4040df560ea47704e0898c4c015808
   depends:
@@ -10588,7 +10588,7 @@ packages:
   license_family: BSD
   size: 38069
   timestamp: 1678228553220
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tifffile-2024.12.12-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tifffile-2024.12.12-py311haa95532_0.tar.bz2
   sha256: d3a1426c67e568097b45ea81f798af98982b2acf5ada09da4ebca4eb088dd9b0
   md5: c0306a2d78b25b8ceb4c46168a464f89
   depends:
@@ -10602,7 +10602,7 @@ packages:
   license_family: BSD
   size: 575304
   timestamp: 1734341325379
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.4.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.4.0-py311haa95532_0.tar.bz2
   sha256: bf353c0c858f16699eb830b7738b6654cef6a47b6de3c3b497fe843a3c389a11
   md5: 9b3a79bdeba3acd6c8051eea4a0fdd72
   depends:
@@ -10612,7 +10612,7 @@ packages:
   license_family: BSD
   size: 106345
   timestamp: 1738337778545
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
   sha256: 0a95736cfd0bb25fc201cd6be4a2450ea8fc30eeb349d861812675b84c94fa74
   md5: a8a9fb30c6dd8e7a16d5dcd2333c3c49
   depends:
@@ -10623,7 +10623,7 @@ packages:
   license_family: BSD
   size: 3844176
   timestamp: 1714770894235
-- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-1.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/toolz-1.0.0-py311haa95532_0.tar.bz2
   sha256: 40cf1210dfc0eefa3711b085dd5c2d9a03e8e7a315813e13c0f36120ef46ca5f
   md5: 06449223ec7c8953845149c2010ddc33
   depends:
@@ -10632,7 +10632,7 @@ packages:
   license_family: BSD
   size: 138855
   timestamp: 1736796480727
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.2-py311h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.4.2-py311h827c3e9_0.tar.bz2
   sha256: 04c7dd95fc472792fd29e76a8a5a0d1e9f87dd2569c3db59c36253f2f7fb420f
   md5: c24e1d36c566681be5bba111e5883c0d
   depends:
@@ -10643,7 +10643,7 @@ packages:
   license_family: Apache
   size: 933447
   timestamp: 1733960990402
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.67.1-py311h746a85d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.67.1-py311h746a85d_0.tar.bz2
   sha256: 2bf8527a85db2c43c45437d33e1ed3b8baf511bd4dd5b304a933e89c4d89fe21
   md5: cb788bffc1a7a8c8c30a27dbb4472772
   depends:
@@ -10655,7 +10655,7 @@ packages:
   license_family: MOZILLA
   size: 187524
   timestamp: 1738946539403
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
   sha256: a724711191ac1226bf228eab49718eed7b5c7394f539294eb0f88baf8e7bb24d
   md5: c78482e07d0aa6df9fcfa5b366dd87e3
   depends:
@@ -10664,7 +10664,7 @@ packages:
   license_family: BSD
   size: 207744
   timestamp: 1718227224929
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.12.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.12.2-py311haa95532_0.tar.bz2
   sha256: 81ba8633c9266a47ccf6c13e675548ac10b3a6e6a7bfa978c1fa1c3bac078909
   md5: 15f63d935470581900fb5cb5a77bddfa
   depends:
@@ -10674,7 +10674,7 @@ packages:
   license_family: PSF
   size: 9887
   timestamp: 1734714947897
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.12.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.12.2-py311haa95532_0.tar.bz2
   sha256: d348f55f9646a6d564dddbc3b2fcdcb6972bb1da9d9ad38941399cafc2d35f21
   md5: 8f78d5a156c9f79284c5d191e091101c
   depends:
@@ -10683,7 +10683,7 @@ packages:
   license_family: PSF
   size: 82553
   timestamp: 1734714936074
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
   sha256: d091897f05318c22ca31028370f25355065999078f7db6f88ab27bf4cb030ec8
   md5: 1776502c1cfb351554eeda6cddaf255f
   depends:
@@ -10692,7 +10692,7 @@ packages:
   license_family: MIT
   size: 11588
   timestamp: 1676457729096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h827c3e9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py311h827c3e9_1.tar.bz2
   sha256: 359246beab1c7d0112123fccc72e4e82fa05ac644a0387064fe11d34e709aaec
   md5: 96fe5cc02d327dc03fa4980b4d7b650c
   depends:
@@ -10703,7 +10703,7 @@ packages:
   license_family: Apache
   size: 513756
   timestamp: 1736544133041
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.3.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-2.3.0-py311haa95532_0.tar.bz2
   sha256: f97a7938ce2eada94759732420c5000b69eff58c8d82833b41ca2809552593a8
   md5: d7a502daadc1d11db6acd637d7b2577c
   depends:
@@ -10719,7 +10719,7 @@ packages:
   license_family: MIT
   size: 223213
   timestamp: 1737133924756
-- conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
   sha256: 2ef16d0252e04063d44d0683831d55b485f713fe5af2c2efd61753fb4f27d7e4
   md5: 256ab1d5dce70111a1f4807a5a9fc322
   depends:
@@ -10729,7 +10729,7 @@ packages:
   license_family: MIT
   size: 100982
   timestamp: 1706894771410
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.42-haa95532_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.42-haa95532_4.tar.bz2
   sha256: e1893bcf9543c44dc71d8d869b3adb1c3b117004b06f1bb065db2f5778a8f81c
   md5: 9ade3f0dfabff28bb61973afd2b50e13
   depends:
@@ -10738,12 +10738,12 @@ packages:
   license_family: BSD
   size: 9751
   timestamp: 1739202647759
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.42.34433-he0abc0d_4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.42.34433-he0abc0d_4.tar.bz2
   sha256: 4a432ec177be39d70164d04b13759b5532d2818cbe84123179cd195fe8ede102
   md5: 4c0af6c22468d1a5ad1654d895128006
   size: 2462862
   timestamp: 1739202634559
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
   sha256: 24ea3d3e0cb98d0d246338dbb4562b67967bb32002e3704e495a5c863476e831
   md5: c7b9cdbe87b3c9720aeca1164a0fd6df
   depends:
@@ -10752,7 +10752,7 @@ packages:
   license_family: BSD
   size: 26181
   timestamp: 1676424437003
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
   sha256: 92d27e41ce34387e59acb47572fcb2e92c4defaeadafd11ce190226022023e69
   md5: f1bf142d852987acbe4b0bc94e87d958
   depends:
@@ -10761,7 +10761,7 @@ packages:
   license_family: Apache
   size: 145306
   timestamp: 1715878654770
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.45.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.45.1-py311haa95532_0.tar.bz2
   sha256: b42f0df89a608d5579738bb8c44cd6871b0a73b731cb91d64e7b72bf03a164aa
   md5: eb0b68c2d661763d490a911b52a108c0
   depends:
@@ -10770,7 +10770,7 @@ packages:
   license_family: MIT
   size: 176574
   timestamp: 1737990578192
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
   sha256: 17fadf35aa8917c107e7b369e9364ac7c09537776e7943d37e225e14b7026c94
   md5: 0e67c3b9624540581b894b11267a837b
   depends:
@@ -10778,13 +10778,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 10197
   timestamp: 1676425485716
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2024.11.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xarray-2024.11.0-py311haa95532_0.tar.bz2
   sha256: a6dcae6604a3e67e1db1a536ed1280ac5d7316bef8f0199ac707f534c25c4231
   md5: c1d227561f8b2ead88d3e1107a640145
   depends:
@@ -10796,7 +10796,7 @@ packages:
   license_family: Apache
   size: 3026676
   timestamp: 1734536084028
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
   sha256: b849b368e27920838fe40a512b102879693a55cb187dd1c8d3a83fa8c05a8054
   md5: 7b1f6e9c71906a93039b3446b99a5498
   depends:
@@ -10805,7 +10805,7 @@ packages:
   license_family: BSD
   size: 55114
   timestamp: 1676434863173
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.6.4-h4754444_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.6.4-h4754444_1.tar.bz2
   sha256: d3458fa18024725ca330e84a0f63b531133a781b33e360b35c50cd278cc66ec4
   md5: 3f6d85e0ee495eb5fdae370f7f456e4c
   depends:
@@ -10815,7 +10815,7 @@ packages:
   license_family: GPL2
   size: 290014
   timestamp: 1739468425589
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -10824,7 +10824,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
   sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
   md5: e5aed81295b61b6d1eb62830799a0297
   depends:
@@ -10835,7 +10835,7 @@ packages:
   license_family: Other
   size: 9125184
   timestamp: 1705602328351
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zict-3.0.0-py311haa95532_0.tar.bz2
   sha256: 478892109d9dc82c90f82d269d3796f4f812f6cba5d3d1f9178a20bd7f583a1f
   md5: df02873bda6c5de6331b00fb1591abac
   depends:
@@ -10846,7 +10846,7 @@ packages:
   license_family: BSD
   size: 102456
   timestamp: 1695833422458
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.21.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zipp-3.21.0-py311haa95532_0.tar.bz2
   sha256: 51af770b59e46a11f079a36e2c56ccbd793afbc5a6a3f9bce04a509f0a3b343f
   md5: b4e7673adc5af56b8752142313d017db
   depends:
@@ -10855,7 +10855,7 @@ packages:
   license_family: MIT
   size: 30531
   timestamp: 1732630914792
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
   sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
   md5: f295b54ab59f5b8658e2a322ac6aa721
   depends:
@@ -10865,7 +10865,7 @@ packages:
   license_family: Other
   size: 162161
   timestamp: 1714514792081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
   sha256: 1f68cd378c6cdec34a5a3a21c56c9b8422b0f037b868b3db72065c0a2ca27921
   md5: d455a04486eddfb94c280974c0c33ae3
   depends:
@@ -10878,16 +10878,14 @@ packages:
   license_family: BSD
   size: 1971698
   timestamp: 1728487049972
-- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
-  sha256: 98f3bae3caff4c52615ddb56405dc51b39d9d2c47a9bccd130a5a19d10304245
+- conda: https://conda.anaconda.org/msys2/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
   md5: de1b7f7c8221028f6bbe103df4c53bed
   depends:
   - m2w64-gcc-libs-core
   - msys2-conda-epoch >=20160418
   license: GPL, LGPL, FDL, custom
   size: 348607
-- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
-  sha256: 2fb6488298a659c781f9294a743b0b376d9998a6b06aa2a3b85b49c38a85ea16
+- conda: https://conda.anaconda.org/msys2/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
   md5: 0b9caac6747002340b057a222af705b2
   depends:
   - m2w64-gcc-libgfortran
@@ -10897,8 +10895,7 @@ packages:
   - msys2-conda-epoch >=20160418
   license: GPL3+, partial:GCCRLE, partial:LGPL2+
   size: 530578
-- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
-  sha256: 449df9debaf202928e3a0db1f059ef35b1bcb3973fa92e217ca2775f82415111
+- conda: https://conda.anaconda.org/msys2/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
   md5: 276d396bfe8d958f71173b7134f739fa
   depends:
   - m2w64-gmp
@@ -10906,21 +10903,18 @@ packages:
   - msys2-conda-epoch >=20160418
   license: GPL3+, partial:GCCRLE, partial:LGPL2+
   size: 217686
-- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gmp-6.1.0-2.tar.bz2
-  sha256: 5cf23439eef17ae158d63ff3f85f77d1dca9a45b19324fdeda9e3e48ae298d18
+- conda: https://conda.anaconda.org/msys2/win-64/m2w64-gmp-6.1.0-2.tar.bz2
   md5: fec04371463ec68eb8f5752a22c5b030
   depends:
   - msys2-conda-epoch >=20160418
   license: LGPL3
   size: 705647
-- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
-  sha256: 9373b0157e08cbea09298f461d2816833281b3e22a8c9f6c5a38d7109c8a281e
+- conda: https://conda.anaconda.org/msys2/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
   md5: 67e61e700eb27424979778fae9293f13
   depends:
   - msys2-conda-epoch >=20160418
   license: MIT, BSD
   size: 30543
-- conda: https://repo.anaconda.com/pkgs/msys2/win-64/msys2-conda-epoch-20160418-1.tar.bz2
-  sha256: d6a55d779052bca9accd534398b4e147d0a3dfc8f4b6528391ee9c15843784bc
+- conda: https://conda.anaconda.org/msys2/win-64/msys2-conda-epoch-20160418-1.tar.bz2
   md5: 6eaef3074f65f715ed1ca6b8a08be3aa
   size: 2065

--- a/uk_researchers/pixi.lock
+++ b/uk_researchers/pixi.lock
@@ -1,0 +1,10926 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.6.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-19.0.0-h865e1df_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-24.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.11.212-hecad206_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bleach-6.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.6.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.4.2-py311hf4808d0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2025.2.25-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2025.1.31-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py311h1fdaa30_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.3.1-py311hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cramjam-2.7.0-py311h24d97f6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-1.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-2024.12.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.12.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-expr-1.1.21-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.17.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.8.11-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2024.12.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-2024.2.0-py311hf4808d0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.55.3-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.12.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.20.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/imageio-2.37.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-8.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.30.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.5-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.23.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.8-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lazy_loader-0.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.16-hb9589c4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-4.0.0-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libabseil-20240116.2-cxx17_h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.12.1-hc9e6f67_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.22-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgrpc-1.62.2-h2d74bed_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm15-15.0.7-he89c38a_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-4.25.3-he621ea3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.11.1-h251f7ec_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-hffd6297_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.13.5-hfdd30dd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.44.0-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py311h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-3.0.2-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.10.0-py311hbfdbfaf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.11-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.8-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py311hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.16.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.4.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.61.0-py311h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.10.1-py311h3c60e43_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.16-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-2.0.1-h2d29ad5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.3-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/parso-0.8.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-11.1.0-py311hcea889d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-25.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.21.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-19.0.0-py311h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.11-he870216_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.20.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-3.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.6.2-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-snappy-0.6.1-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.22.3-py311h4aa5aa6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scikit-image-0.25.0-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.15.1-py311h08b1b3b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-75.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tifffile-2024.12.12-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-1.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.2-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.67.1-py311h92b7b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.12.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.12.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.45.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2024.11.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.6.4-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.21.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2025a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2025a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.6.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h46256e1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-19.0.0-hdba8a65_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.11.212-h9475118_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bleach-6.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.6.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.4.2-py311h9b7fc35_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311h6d0c2b6_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2025.2.25-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2025.1.31-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py311h9205ec4_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.3.1-py311h1962661_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cramjam-2.7.0-py311h9c86198_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-1.0.1-py311h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-2024.12.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2024.12.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-expr-1.1.21-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.17.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.8.11-py311h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2024.12.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-2024.2.0-py311hb3a5e46_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.55.3-py311h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.12.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.20.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/imageio-2.37.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-8.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.30.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.23.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.8-py311h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lazy_loader-0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.16-h4f63f0c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-4.0.0-h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libabseil-20240116.2-cxx17_h548131f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h46256e1_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h46256e1_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h46256e1_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.12.1-h9bcc28a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.22-h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgrpc-1.62.2-hf2926fd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm15-15.0.7-h1357083_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-4.25.3-h34eed0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.11.1-h3a17b82_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-h6fa9cd1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.13.5-h6070cd6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.44.0-py311h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-4.3.2-py311h46256e1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-3.0.2-py311h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.10.0-py311h919b35b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py311ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.4.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.61.0-py311h6d0c2b6_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.10.1-py311hc59c7be_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h91b6869_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311hb3ec012_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.16-h184c1cd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-2.0.1-h5747287_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.3-py311h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/parso-0.8.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-11.1.0-py311h47bf62f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-25.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.21.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h46256e1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-19.0.0-py311h6d0c2b6_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.11-h4d6d9e5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.20.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-3.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.6.2-py311h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-snappy-0.6.1-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py311h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.22.3-py311h83de92b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scikit-image-0.25.0-py311h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.15.1-py311hedc7b93_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-75.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tifffile-2024.12.12-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-1.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.2-py311h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.67.1-py311h85bffb1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.12.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.12.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h46256e1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.45.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2024.11.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.6.4-h46256e1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.21.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2025a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.6.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-19.0.0-h0b7d223_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-24.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.11.212-hdd7fb2f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bleach-6.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.6.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.4.2-py311hb9f6ed7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2025.2.25-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2025.1.31-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.3.1-py311h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cramjam-2.7.0-py311h62f922a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-1.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-2024.12.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.12.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-expr-1.1.21-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.17.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.8.11-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2024.12.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-2024.2.0-py311hb9f6ed7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.55.3-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.12.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.20.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/imageio-2.37.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-8.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.30.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.5-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.23.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.8-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lazy_loader-0.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.16-he93ba84_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-4.0.0-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libabseil-20240116.2-cxx17_h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.12.1-hde089ae_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.22-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgrpc-1.62.2-h62f6fdd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm15-15.0.7-h97a1cf3_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-4.25.3-h514c7bf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.11.1-h3e2b118_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-hc9ead59_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.13.5-h0b34f26_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.44.0-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.3.2-py311h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-3.0.2-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.10.0-py311h7ef442a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py311h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.4.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.61.0-py311h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.10.1-py311h5d9532f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.16-h02f6b3c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-2.0.1-h937ddfc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.3-py311hcf29cfe_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/parso-0.8.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-11.1.0-py311h84e58ab_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-25.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.21.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-19.0.0-py311h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.11-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.20.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-3.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.6.2-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-snappy-0.6.1-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.2-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.22.3-py311h2aea54e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scikit-image-0.25.0-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.15.1-py311hac8794a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-75.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tifffile-2024.12.12-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-1.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.2-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.67.1-py311hb6e6a13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.12.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.12.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.45.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2024.11.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.6.4-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.21.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2025a-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.6.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h827c3e9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-19.0.0-h33d5241_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-24.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.11.212-h6a15179_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bleach-6.2.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.6.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.4.2-py311h57dcf0c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311h5da7b33_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2025.2.25-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2025.1.31-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py311h827c3e9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.3.1-py311h214f63a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cramjam-2.7.0-py311h005caf5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-1.0.1-py311h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-2024.12.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.12.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/dask-expr-1.1.21-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.17.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.8.11-py311h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2024.12.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-2024.2.0-py311hd7041d2_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.55.3-py311h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.12.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.20.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/imageio-2.37.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-8.5.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.30.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.5-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.23.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.8-py311h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lazy_loader-0.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.16-hb4a4139_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-4.0.0-h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libabseil-20240116.2-cxx17_h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h827c3e9_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h827c3e9_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h827c3e9_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.12.1-h9da9810_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.22-h5bf469e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libgrpc-1.62.2-hf25190f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-4.25.3-hf2fb9eb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.11.1-h2addb87_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-h44ae7cf_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.44.0-py311hf2fb9eb_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.3.2-py311h827c3e9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-3.0.2-py311h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.10.0-py311he19b0ae_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h827c3e9_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.11-py311h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.8-py311hea22821_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py311h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.4.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.61.0-py311h5da7b33_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.10.1-py311h4cd664f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.16-h3f729d1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/orc-2.0.1-hd8d391b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.3-py311h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.2.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/parso-0.8.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-11.1.0-py311h096bfcc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-25.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.21.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h827c3e9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-19.0.0-py311h5da7b33_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.2.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.11-h4607a30_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.20.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-3.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.6.2-py311h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-snappy-0.6.1-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-308-py311h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.14-py311h72d21ff_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.2-py311h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.22.3-py311h636fa0f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scikit-image-0.25.0-py311h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.15.1-py311h9f229c6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-75.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tifffile-2024.12.12-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.4.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-1.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.2-py311h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.67.1-py311h746a85d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.12.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.12.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h827c3e9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.42-haa95532_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.42.34433-he0abc0d_4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.45.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2024.11.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.6.4-h4754444_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.21.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/msys2/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+  sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
+  md5: 613805add1c05b538ff06d217252feb7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 20810
+  timestamp: 1652859733309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.6.2-py311h06a4308_0.tar.bz2
+  sha256: d58b068fe1b9c195394e77a6fba4d152c6934e97df7757dd6b921498f8aa72f8
+  md5: 09de3b2d5519a680bda3c3771380c3da
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.26.1
+  - uvloop >=0.21
+  license: MIT
+  license_family: MIT
+  size: 243587
+  timestamp: 1729121303719
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_1.tar.bz2
+  sha256: b7eb9612c200994d8126caa0c36561a586c6a8a57066609febae6ff4d61da35a
+  md5: 6181c14ad55e754ce7327ec32e7a2bf9
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 36032
+  timestamp: 1736182558607
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/arrow-cpp-19.0.0-h865e1df_0.tar.bz2
+  sha256: 19075e5fc1ff6c49540fa30bb683abb9c6b6561d863748b07867489eb9625fd7
+  md5: dd136dfcc2378b121024766923f45cb7
+  depends:
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - aws-sdk-cpp >=1.11.212,<1.11.213.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.5.0,<0.6.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libgcc-ng >=11.2.0
+  - libgrpc >=1.62.2,<1.63.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx-ng >=11.2.0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.15,<4.0a0
+  - orc >=2.0.1,<2.0.2.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.10,<2.0a0
+  - utf8proc >=2.6.1,<2.9.0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 14402129
+  timestamp: 1738050893917
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-24.3.0-py311h06a4308_0.tar.bz2
+  sha256: 9c40ad73b2f2f2a6ea5ae3919a9a538518b0eb92baef29f07fd006fca09a5e90
+  md5: b6fca842c8ea8530e4d1751c277e8ba2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 162429
+  timestamp: 1734533126936
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-auth-0.6.19-h5eee18b_0.tar.bz2
+  sha256: 432e4fb45ae24789afdaeca800862aad03f8ebed5af908f01eed2a09283915e5
+  md5: a88c0e111e1f47ee83f1b6f329a149ef
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 97643
+  timestamp: 1706746168671
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-cal-0.5.20-hdbd6064_0.tar.bz2
+  sha256: edb54d1554aefb65ff5a3969085dd8695e1e3218a2987ac30a96901f0bbf887a
+  md5: 5f131e63f8d80f2b7ac505054204a9e3
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.12,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 44722
+  timestamp: 1706690912333
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-common-0.8.5-h5eee18b_0.tar.bz2
+  sha256: 2afbfb546992e5954748d039ea15405f99018f6de78ec2f32bc7ff9bfc428a9c
+  md5: 489017af35cf8bdb976e6fef020a4ac7
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 202658
+  timestamp: 1706189913451
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-compression-0.2.16-h5eee18b_0.tar.bz2
+  sha256: 5f81f5a3ea27bd29bf32a6987290de8c7b2da6612676aa8e606a7003519cbf47
+  md5: c11e7ceff3ca45bf580d1c944d93bd1f
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 17839
+  timestamp: 1706690843204
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-event-stream-0.2.15-h6a678d5_0.tar.bz2
+  sha256: 348ced323311d36344a0fa9e88d299b361bad1f628dfbdd34bcea8662b3ab44b
+  md5: 19a11cdc9727c5981d96983a29b93ce4
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52025
+  timestamp: 1706697274091
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-http-0.6.25-h5eee18b_0.tar.bz2
+  sha256: 14e2843a218cb01bfc499a22537eb345f6e222b8496cfda2050c73ad98f09cda
+  md5: 44cba75d1bb5122aeadcaf8bb7da5e2a
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-compression >=0.2.16,<0.2.17.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 192985
+  timestamp: 1706744140260
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-io-0.13.10-h5eee18b_0.tar.bz2
+  sha256: a0f6916d60c0e1bac6ba548bf05a491b8db048a94e13da2f1cfa51b4ca879fb8
+  md5: 1f010db4f5ef1b3d705ee04dd1d473c9
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  - s2n >=1.3.27,<1.3.28.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 143623
+  timestamp: 1706696185335
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-mqtt-0.7.13-h5eee18b_0.tar.bz2
+  sha256: 596945a39d772056e57bb357202a17e02508f2594da9c00e00ad767b8213e998
+  md5: 98cccbcc56a28ec7339e393816f4bdf7
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 70139
+  timestamp: 1706746744249
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-s3-0.1.51-hdbd6064_0.tar.bz2
+  sha256: 12bf86ab848e3311f4eed4e93734a84064dc84580ad6dd4bb823b4ab6ef09698
+  md5: 4a8c2dcf0ede655609a9fc5632a5227b
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.12,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 74700
+  timestamp: 1706747582638
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-c-sdkutils-0.1.6-h5eee18b_0.tar.bz2
+  sha256: f05ce64fee77518a6deb45f187fcee415328e90ea8f2bf6031bd5b8273a1028f
+  md5: b8ebb4b892d9b80d513b4ca62a8d6de2
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 53042
+  timestamp: 1706690818718
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-checksums-0.1.13-h5eee18b_0.tar.bz2
+  sha256: 52bb367fc367ee3923353927226299a2b8b1be6a1993c11e19b20cafe6c6db0f
+  md5: 4715508fd5f8b39e902cb2afebc13c93
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52138
+  timestamp: 1706192048702
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-crt-cpp-0.18.16-h6a678d5_0.tar.bz2
+  sha256: 0d13fbdace8ab4fbfcc015cf83bead69560a3dfadc6e0ce8441001629d725834
+  md5: a02c72bff71848705e70cd6f075a28f3
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
+  - aws-c-s3 >=0.1.51,<0.1.52.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 211559
+  timestamp: 1706827608038
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/aws-sdk-cpp-1.11.212-hecad206_0.tar.bz2
+  sha256: 9a1de443175997ba4ce5ff7990c8bfbd75af2d2cf9a4d5f6c178f0f90779f772
+  md5: 4fcc20f27dbbc8c81c0a1eb81b481695
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - libcurl >=8.1.1,<9.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.15,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4657506
+  timestamp: 1733148711180
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
+  sha256: 5bb9bfe025d9a49af272f194278f63cea7366e83bdf3f99d25f97b820d522089
+  md5: 100d3161d97332fe38945afec8d36935
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 276381
+  timestamp: 1718029864701
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bleach-6.2.0-py311h06a4308_0.tar.bz2
+  sha256: 46d4caa9b996615e6d367282d5ba3a4a11f23052fac305cf52fc067e4f766ed7
+  md5: 5f923de750f6d8a2a9faa8cf90da6311
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings
+  constrains:
+  - tinycss2 >=1.1.0,<1.5
+  license: Apache-2.0
+  license_family: Apache
+  size: 367370
+  timestamp: 1732290516590
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.6.2-py311h06a4308_0.tar.bz2
+  sha256: cc28ef20fc2443761fbb79da152803ecb35aee02110db896f5f07137fce231db
+  md5: c45ba96af7be3ebfc9947bd7f26ba888
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5877128
+  timestamp: 1737999314705
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/boost-cpp-1.82.0-hdb19cb5_2.tar.bz2
+  sha256: 3606c8607c29229222667f66421f79df167d33043fe9245cdd4e2c4520ecc721
+  md5: eca33dcef14fa044193e43492dca8585
+  depends:
+  - libboost 1.82.0 h109eef0_2
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 10768
+  timestamp: 1696762269985
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.4.2-py311hf4808d0_0.tar.bz2
+  sha256: de78a7f35a57c21d8986c1084f308c98477747d6a92a0b23b5d4855333eee0c9
+  md5: 85399e523becae3ca29054b3d579b8e7
+  depends:
+  - libgcc-ng >=11.2.0
+  - numpy >=1.21,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 148890
+  timestamp: 1731058903578
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_9.tar.bz2
+  sha256: b7ff9535237880e6fb540d58ce2b904e9407904c92579260b92be12a4451281a
+  md5: f229f321f52804bfa696fed56b11b5d1
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 361254
+  timestamp: 1736182674347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+  sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
+  md5: f5058c8d5b2994b7334f18e022105a14
+  depends:
+  - libgcc-ng >=11.2.0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 427542
+  timestamp: 1714510571510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/c-ares-1.19.1-h5eee18b_0.tar.bz2
+  sha256: 5b4c80587ae4ec915505469f79d866f27c80456156667c8548d31c67c2c1653e
+  md5: c3d6bfae757760082261779c406a880d
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 116270
+  timestamp: 1693902021950
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2025.2.25-h06a4308_0.tar.bz2
+  sha256: 3b93acbbf19f6720aa1b8b4e4e2a9c2580af5d635384cf310586411efbb364e9
+  md5: ba2f1a3a29243f13c6898395f2c2dab7
+  license: MPL-2.0
+  license_family: Other
+  size: 139245
+  timestamp: 1740582453836
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2025.1.31-py311h06a4308_0.tar.bz2
+  sha256: b3d1c50537d3de350bc0a42947aac47037441bdb07fefcf1991c72012c8b6c68
+  md5: 7ad703949235c3f0dcc99996989d5a90
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 168016
+  timestamp: 1738623830569
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py311h1fdaa30_1.tar.bz2
+  sha256: a73bd99651100ddd118806e62f20b2b6fac0098e0615580314fb8cc983467d4e
+  md5: b8f1ba0cf72321301cd1d840fd286731
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 308046
+  timestamp: 1736182517693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/click-8.1.7-py311h06a4308_0.tar.bz2
+  sha256: 9ddbf05887c7d7926418520cc7848e57f6d2431bc4ec6d30e090b02dbf865041
+  md5: 57ae1141ad9a048fb2a75d7a3ef7430a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203190
+  timestamp: 1698129926216
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cloudpickle-3.0.0-py311h06a4308_0.tar.bz2
+  sha256: 017b35122f533e4ffc48bb3e0c6fd1f16e8cbb2a67d40b3f6572b77511ffe26d
+  md5: 75eb58b2cdb0ddf4e93293cf973a0829
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41983
+  timestamp: 1721657369906
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+  sha256: d9c102b9ec7f3a635936b6f73d4db126d748a25f65407353bd76b260dc7d1cd6
+  md5: eec48dbdf5dac0ea26750cc26b58c1d9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 554986
+  timestamp: 1709758392744
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+  sha256: 882481e441b9b93cbdfb32fbe32a6ad9f26197472f186a08fddb921f61346c02
+  md5: 443c79196064f57c98199e9990544b2f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16902
+  timestamp: 1709322958614
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.3.1-py311hdb19cb5_0.tar.bz2
+  sha256: 214cc9e08edf0430b1dca7d7a5407f19c16e9ad0684bb972a4a836e044196719
+  md5: db381e74b7730d0b8b54a05d2716c28c
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 299819
+  timestamp: 1732540101238
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cramjam-2.7.0-py311h24d97f6_0.tar.bz2
+  sha256: 7bb1fd85aaba31403b00722d6f142220031788e391fdaad899c816595cb3ae5d
+  md5: 6673633f2374304790bfdcaa334b14ae
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1528662
+  timestamp: 1702651329660
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cytoolz-1.0.1-py311h5eee18b_0.tar.bz2
+  sha256: e74069c0543df0eb9437c59abb170cb74b4d00ed8b840fad1ffb841d47139dbc
+  md5: 26f8aecb6684b5c74a2118071c528d9f
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - toolz >=0.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 436017
+  timestamp: 1736803911833
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-2024.12.1-py311h06a4308_0.tar.bz2
+  sha256: c43d26fdf93c0fafb0b5d5861891eddd2c12867a24fe7d34a7f850d8225f5265
+  md5: f7bb330f7fc1dab73a580b7bb0d25f1c
+  depends:
+  - bokeh >=3.1.0
+  - cytoolz >=0.12.0
+  - dask-core 2024.12.1
+  - dask-expr >=1.1,<1.2
+  - distributed 2024.12.1
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.24
+  - pandas >=2.0
+  - pyarrow >=14.0.1
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5357
+  timestamp: 1736873436192
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-core-2024.12.1-py311h06a4308_0.tar.bz2
+  sha256: 541570cc3a626034a66cabb0e3831c6fd380a780c2d27e02a1dc000022ec123b
+  md5: 0e5baa13350a14b6381123242c0746b3
+  depends:
+  - click >=8.1
+  - cloudpickle >=3.0.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.4.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3202802
+  timestamp: 1736807571954
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/dask-expr-1.1.21-py311h06a4308_0.tar.bz2
+  sha256: 02176f6cb5966f28f1258659ad3529f3fd579bb52c2bb7e39219f8de4ecaa316
+  md5: 3a74962f2142df53f5003c3c8b5af692
+  depends:
+  - dask-core 2024.12.1
+  - pandas >=2
+  - pyarrow >=14.0.1
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 568612
+  timestamp: 1736810427516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/datashader-0.17.0-py311h06a4308_0.tar.bz2
+  sha256: 4c5ea17c9aa9f47a597312aee142eac20db3963f0bf4aaf9f973f5b5f226f0c0
+  md5: 7fa0742a8942e0568d2cc5c78e8740cd
+  depends:
+  - colorcet
+  - multipledispatch
+  - numba
+  - numpy
+  - packaging
+  - pandas <3.0.0
+  - param
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18006100
+  timestamp: 1738336791055
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.8.11-py311h6a678d5_0.tar.bz2
+  sha256: 69c3214beb1e7f398f82a10c245af788304bbff2e1a12d0e15672f68ba00d974
+  md5: d3c168f99c3d8bb146f89b3032f3ebaf
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2844636
+  timestamp: 1736267672061
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/distributed-2024.12.1-py311h06a4308_0.tar.bz2
+  sha256: 0aed2ca7ba2852533118858fc2d91bf3096e6b4838f3d1193e8147acd24f9721
+  md5: 5d6374b10e491c5136612fcffed907f0
+  depends:
+  - click >=8.0
+  - cloudpickle >=3.0.0
+  - dask-core 2024.12.1
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.2
+  - packaging >=20.0
+  - psutil >=5.8.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.4.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.11.2
+  - tornado >=6.2.0
+  - urllib3 >=1.26.5
+  - zict >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1826844
+  timestamp: 1736870807534
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+  sha256: 4b589e3265c74159130230c164ff2d8d381be65899a249def0b53f93ce83fd47
+  md5: 245cb7173dcdba21cf368031cd87f706
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17434
+  timestamp: 1676823330845
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fastparquet-2024.2.0-py311hf4808d0_0.tar.bz2
+  sha256: b7f0f6cc1213a6f36d1ca1844b6fa918833a737703f54e719bd71cd3b39eba9e
+  md5: 9aa84ee8cddc8aaa057295e1853c3ad2
+  depends:
+  - cramjam >=2.3.0
+  - fsspec
+  - libgcc-ng >=11.2.0
+  - numpy >=1.23.5,<2.0a0
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 683044
+  timestamp: 1715262508371
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.55.3-py311h5eee18b_0.tar.bz2
+  sha256: a26c56f941d50242db192dcb73fdcf195e0a3ad38919bda027d21d32c47a8d5c
+  md5: d3090d6cf0c24c8ce35091cdfb4f85be
+  depends:
+  - brotli-python >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - uharfbuzz >=0.23.0
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 3312570
+  timestamp: 1737039356330
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+  sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
+  md5: a5dc8677d891dff2393b63189a3ad42f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 971975
+  timestamp: 1666798278693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fsspec-2024.12.0-py311h06a4308_0.tar.bz2
+  sha256: 4a20bf26e48e997957f09c47b68b18ddfd0ba9326e43767b1066a9c1a5a872db
+  md5: c256cee55d0b5c19eb4883ce0a6ef8c8
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - pyarrow >=1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 391598
+  timestamp: 1736274697928
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/gflags-2.2.2-h6a678d5_1.tar.bz2
+  sha256: 2fc1136056f41fe92de719fb821550346704965dd12a5fa35069cdb4948d5c17
+  md5: fd089b0fba2b03aafe3adb6cdaa9ac3b
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203421
+  timestamp: 1706888218007
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/glog-0.5.0-h6a678d5_1.tar.bz2
+  sha256: f1e190d4ee766add8131a2b011723c472284de2bbb5e07c8f895f30e3c591df7
+  md5: 82029e0758feac811afec2a6ef9e6155
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 108438
+  timestamp: 1706895276199
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.20.1-py311h06a4308_0.tar.bz2
+  sha256: d2d94eb25aa4ab4d7ba21e40350ec6f4930013f62040a9b5b86f429b4a11ad1c
+  md5: 89c07e7d38ff95e603bcb70186f0204b
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.1
+  constrains:
+  - plotly >=4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6127969
+  timestamp: 1740582781565
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/icu-73.1-h6a678d5_0.tar.bz2
+  sha256: b35b281dbf69b826c6ae04fcd7b6a2d1f098277a669a199906a1f23b4b0931a5
+  md5: 2a793fe24f85aa5819fe69c450cba6f7
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 29021241
+  timestamp: 1692293243228
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+  sha256: e08e27531775de40f46b6ac7bf71856963baa0c008bd2b4d112e6341cd3e8f4c
+  md5: bfc7682613c861cbcb4ac01485c05657
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147174
+  timestamp: 1714398938840
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/imageio-2.37.0-py311h06a4308_0.tar.bz2
+  sha256: 67fa968580722a3f4c5ebfeab2748daa58518e2bb005d5214962e39021329751
+  md5: 813d87f2c2922f553bdbd29d1cca7592
+  depends:
+  - numpy
+  - pillow >=8.3.2
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 665720
+  timestamp: 1738160075021
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/importlib-metadata-8.5.0-py311h06a4308_0.tar.bz2
+  sha256: 0b292de5578240518ff0e3e829a836e29b75fede7dd6b77d87e635680b3cd970
+  md5: 6a34f99c9b49a106851598516cb2ee9f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=3.20
+  license: Apache-2.0
+  license_family: APACHE
+  size: 54269
+  timestamp: 1732633524542
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+  sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
+  md5: 3add2ce56858a1b8f6a37342f82773d3
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<1.2.14
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 19310769
+  timestamp: 1699647799237
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py311h06a4308_1.tar.bz2
+  sha256: 582a57ce666b49fe02ebc6f8bebe8b48938833968b58be98e4efefd73d7ad226
+  md5: 61267bc76e930917150fcba755e607dc
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 238192
+  timestamp: 1737660819687
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.30.0-py311h06a4308_0.tar.bz2
+  sha256: 8d16ed1f5ff00f096b360ce1d7f9b4a4878ddcc8c866c4e5da1d2d9c2cd98d5b
+  md5: 7bfea7a1bfd1c08fddd95dc471270519
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1634301
+  timestamp: 1734548199842
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.2-py311h06a4308_0.tar.bz2
+  sha256: 61d1e8ff671b50ee001b1702b12f44572f6963157964c825c7358ecd2e62bc16
+  md5: f4040af0e38070f691bf43c120e8744f
+  depends:
+  - parso >=0.8.4,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1172008
+  timestamp: 1733987427312
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.5-py311h06a4308_0.tar.bz2
+  sha256: 59c96b9acaf6b0f497e7900ca5d37049fe34be53e6efcb818183563a89e5f674
+  md5: c0187cdffb26e981be0c64ec8b4fb70d
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 357212
+  timestamp: 1737760133539
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+  sha256: 8316ae3abee25edab89788ee6e9eef79c398aba192559f514674a04ee1860bca
+  md5: 112209aed451545a622ab217c70f6972
+  depends:
+  - libgcc-ng >=11.2.0
+  license: IJG
+  license_family: Other
+  size: 283506
+  timestamp: 1722872662693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.23.0-py311h06a4308_0.tar.bz2
+  sha256: caafff289b6a96f7f13668faa72e7a85346f410b1f97dc34163f70746bb98f1b
+  md5: 27d1820c6bd6185aa888ee994d290bf1
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 192447
+  timestamp: 1728486794980
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+  sha256: 9e3bac2d41bd432b721b009e7de981766fba396e6f238e923f304112bd88655a
+  md5: 84ae4cf3f2d01fbebdac374971192be9
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 15525
+  timestamp: 1699032521315
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+  sha256: 79ce6dff3d93649a2555b1d2a4ae9eb77175a1c00664cb8eb0e6f848d5cdd1b9
+  md5: db395b0efd7018fcf3a4af879170c2a8
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 276856
+  timestamp: 1676823504812
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
+  sha256: 91cca0ba49accdc9e97463bee087244a27ad107eb3af9ccb91634239f8b10f72
+  md5: a185824bfc55bd90e1cf9330b417b74c
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 97359
+  timestamp: 1718818381635
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
+  sha256: 540f8dfb7cdc3877b4e24d6af65696d0bc7eae5de1c307229f86b3fe601a2286
+  md5: f650f8c007471f6ef6c1a292918d2e1f
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41920
+  timestamp: 1718738122846
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
+  sha256: 398387b6f1ee1691b04a31fedd1320225e5553aa921b06bc013f010a0008621e
+  md5: bac66634a9133c633ddc879e14e83f23
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 610854
+  timestamp: 1718827113534
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+  sha256: ddfee06ba9b149222c65d1d4270272840533aa63b56fe36363c84a891c71d328
+  md5: ee128e5c0d8d9e1952e2387b66a5b8cb
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27239
+  timestamp: 1686870958829
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+  sha256: 0c6a074272ed58677ec17e4dbfceaffd2108841a61af92b32f156c5763108d1d
+  md5: dd3d37841d0d20c70a60e8c939923894
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19144
+  timestamp: 1700168632051
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.8-py311h6a678d5_0.tar.bz2
+  sha256: 83282f813347516f402cc0f0ac95ba07e59128ee3b7c28cca9d49f8ef115a8a7
+  md5: 0326b3398754ac5583370fc797f5e8c4
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 79276
+  timestamp: 1737039252672
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/krb5-1.20.1-h143b758_1.tar.bz2
+  sha256: 01bae3dd44469e34f043e0416f5f5e658429bf4031745399d9968d10b899e2c4
+  md5: 10171cca67e3d73c3646c6dc5a321460
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.8,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1427115
+  timestamp: 1686931095252
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lazy_loader-0.4-py311h06a4308_0.tar.bz2
+  sha256: 3127b107ca08f3c374302d55b38d6b5255f7ae3775f1bfc0f596ec9e22222009
+  md5: 1f2c186a765f44c14181d872345797e4
+  depends:
+  - packaging
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24758
+  timestamp: 1718176785266
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.16-hb9589c4_0.tar.bz2
+  sha256: 1b6b432a7ef79b3c29ab84e9fa1fb159837dd65b3997e9a6605896f3517dcfcf
+  md5: ed981583bbc6e6ac7707895204653e0d
+  depends:
+  - jpeg >=9e,<10a
+  - libgcc-ng >=11.2.0
+  - libtiff >=4.5.1,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 271236
+  timestamp: 1734428496317
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+  sha256: 069d33aebaf4db4ae410d4acb4851860a69d2c8f326fd45ab2a67b67fe276e6d
+  md5: 61689da52cf1fcebda8c9fb2872f94bf
+  constrains:
+  - binutils_impl_linux-64 2.40
+  license: GPL-3.0-only
+  size: 723073
+  timestamp: 1727336193185
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-4.0.0-h6a678d5_0.tar.bz2
+  sha256: 3b35e98ab9e27e3c6ce1a4988087410c4f10f8f2dc7b32e5fd0597ae3330a6f0
+  md5: 2a9cf942ef9eac2d34261363e6fbacad
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 283535
+  timestamp: 1734423401417
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libabseil-20240116.2-cxx17_h6a678d5_0.tar.bz2
+  sha256: 799f5e019772d5d774c07dbb8b8d633e0b559921c8ab16ab2276aca1ca4f2fa2
+  md5: fe4de116b00c2c7eb7d307a58eef7429
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  constrains:
+  - abseil-cpp =20240116.2
+  - libabseil-static =20240116.2=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1316915
+  timestamp: 1716563364037
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libboost-1.82.0-h109eef0_2.tar.bz2
+  sha256: e2754627e8aeb98777318939e6773b9eadbdc219dd8961aca946354d9d30f481
+  md5: 4ed89646229bee3e594cd2cc8f6060f9
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 23778916
+  timestamp: 1696762223408
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_9.tar.bz2
+  sha256: f4443a37d6eb1f35aed3b36d67ee10df39dccde535f3a6761fad44c0a516843d
+  md5: 69b08a79ab20702c6bd5f77cc4063267
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 67000
+  timestamp: 1736182526370
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_9.tar.bz2
+  sha256: 51a57fc34ce6d44b35d76562b945a55efdcd663880bb1a153c44fe176fbc5c1a
+  md5: 72d59a9872154e939d5759c7eb2c5db1
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_9
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 34506
+  timestamp: 1736182538544
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_9.tar.bz2
+  sha256: 5a43fa99f57fe609b374888359cecef39556ebf9c5fb6fd35eb9694f054b65eb
+  md5: 3c5dbc154e879dcfd5e71c8cd56202ff
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_9
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 295241
+  timestamp: 1736182548938
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libcurl-8.12.1-hc9e6f67_0.tar.bz2
+  sha256: 66d224610f31352ed42cd1b7fd8c3d8718d7774b32520f905b953e3044ed06c4
+  md5: 79558711ab0e4fc10b49e2db2e868af7
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libgcc-ng >=11.2.0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.57.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.11.1,<2.0a0
+  - openssl >=3.0.15,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 457077
+  timestamp: 1739986326232
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.22-h5eee18b_0.tar.bz2
+  sha256: 99b22a8ac9907bf834b06bc1d4c046a46e0d1fe8f044e03b287ca80490ffd7b3
+  md5: c75f9e8e2f44baf9a36b4d7ac80eb2bc
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 78335
+  timestamp: 1734423317784
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20230828-h5eee18b_0.tar.bz2
+  sha256: 5bd3af246b6a93ea0912179ae66e0ad9157ca0142263010d84b65724e6db0bec
+  md5: 5cb0cc0e1783419cf8fc1c65fee0f62f
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 195807
+  timestamp: 1703006263489
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libev-4.33-h7f8727e_1.tar.bz2
+  sha256: efdab884c85fda4461f7a393aa6d4e0e50d03cb59fb9c8a980b1307b8379ebe0
+  md5: eeca774c6154c49340dd403b1928d5e9
+  depends:
+  - libgcc-ng >=7.5.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 108906
+  timestamp: 1632891483341
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libevent-2.1.12-hdbd6064_1.tar.bz2
+  sha256: 4b2518a1aa3859031a531cd1077e8a60d5b3a0dc7c83210ef27ff9ce2c78c3e3
+  md5: 49f152ee4045544c10799d32bba85c07
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 480247
+  timestamp: 1685052130829
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+  sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
+  md5: 1af9b4d62c708924417f2640ef22a68f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 154016
+  timestamp: 1714483282916
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
+  md5: 641e72e5067bd6d5454405879e1cd2a7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - _libgcc_mutex * main
+  - __glibc >=2.17
+  constrains:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - libgomp 11.2.0 h1234567_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 8895144
+  timestamp: 1654090827491
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran-ng-11.2.0-h00389a5_1.tar.bz2
+  sha256: 2a24dd54fee86551eb2b03b6ef78433d0cbab3915ed538ecee28af123394137b
+  md5: 27082517590f3b9fbffecc68513b461b
+  depends:
+  - libgfortran5 11.2.0.*
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 19860
+  timestamp: 1654090819660
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgfortran5-11.2.0-h1234567_1.tar.bz2
+  sha256: b170f2d1dc4c33c525261b2b61f9efffb6eb3dbb0a3e9966dd4c5ed0b33069f2
+  md5: 0202c3c8ae4735cac6c7f3d1e1685964
+  constrains:
+  - libgfortran-ng 11.2.0 *_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 5228750
+  timestamp: 1654090762569
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+  sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
+  md5: 3080c2813e6e1d0f8a100a38b5b3456d
+  depends:
+  - _libgcc_mutex 0.1 main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 573231
+  timestamp: 1654090775721
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgrpc-1.62.2-h2d74bed_0.tar.bz2
+  sha256: 498fafb5df2311ce582cbdfd9262f060a484ad8577030298deed948a3c491cd7
+  md5: 3065951fe45c36bb91009a61776f5e9a
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libgcc-ng >=11.2.0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.13,<4.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - grpc-cpp =1.62.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 9018521
+  timestamp: 1716835817873
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libllvm15-15.0.7-he89c38a_4.tar.bz2
+  sha256: c8138d6c8b3ffb43748b898c03c375c486455f5625011584ef955c596587519f
+  md5: 2b261a273c1a14918d47243633cecc1d
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libxml2 >=2.13.1,<2.14.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 39428816
+  timestamp: 1730400002494
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libnghttp2-1.57.0-h2d74bed_0.tar.bz2
+  sha256: 6c67d781d3c074ae46b18567f230bce4a4afa209e8b914dc2cb448502774886e
+  md5: c9627c386bbc8a1a1a0a2e736ea44501
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - c-ares >=1.7.5
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 722387
+  timestamp: 1697018420830
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+  sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
+  md5: 1bffe1481ed4f88827248fb9001f8923
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 362561
+  timestamp: 1677841789536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libprotobuf-4.25.3-he621ea3_0.tar.bz2
+  sha256: c070317f268dfcf77d5ff50c286bf430419fa9267eeea67d622f85c25fc6de9d
+  md5: 1672198ffdc6aabb8750c51496719e19
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3242840
+  timestamp: 1716568319462
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libssh2-1.11.1-h251f7ec_0.tar.bz2
+  sha256: 2fee5719b7bcaac278f03d4e5c15f17cf5840ed563de6730b4778c0fd62b8d9f
+  md5: 162db824b70ea49175750d732102ec58
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.15,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 301096
+  timestamp: 1732891131339
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
+  md5: 8c195584a5f5471b600ee180e4052773
+  depends:
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 6410287
+  timestamp: 1654090800863
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libthrift-0.15.0-h1795dd8_2.tar.bz2
+  sha256: 974e4035c5d51cd41fa7a7f02fadc1980069c00526c1646fa18ea94e667fb137
+  md5: 188de945b4279a812953011e8c4580c2
+  depends:
+  - boost-cpp >=1.73
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - openssl >=3.0.9,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4630795
+  timestamp: 1687975185557
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-hffd6297_1.tar.bz2
+  sha256: 00c29474500c2db177d482b62dd42392327376823464961995d60ee5c7679c55
+  md5: d26f4756467be40670835398528d1309
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.22,<1.23.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 663476
+  timestamp: 1734425727361
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+  sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
+  md5: 292768ec77416ae257cfdd44ea2071c8
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29197
+  timestamp: 1668082729834
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+  sha256: a062fad27450b94279d1688aabd11a95eedee7814462ef6364337d55412b4a7e
+  md5: e0521f84b9770830e654432364ac930e
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 484011
+  timestamp: 1729160032020
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.13.5-hfdd30dd_0.tar.bz2
+  sha256: ce666a7b5b6ce0e36b6e19014c30bf98c5c067ebe64cfa37d86c864ebbe04db5
+  md5: 2d21c00fb7dc7a540e1a1aed30eef237
+  depends:
+  - icu >=73.1,<74.0a0
+  - libgcc-ng >=11.2.0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 742705
+  timestamp: 1732316075095
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+  sha256: fd8e30beb8c9442f16e6617fac92dd0c89ec823e98f06e60f712147380ead35f
+  md5: 7ed7caf2816c8b85b67b6f4e8833cbd5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41155
+  timestamp: 1676837080881
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/llvmlite-0.44.0-py311h6a678d5_0.tar.bz2
+  sha256: eaf9b9a6be9b9086ae23b054d3dd3ac643316b8b27734b2168e52dd4c62278d9
+  md5: f4f7eeab21c48d3cb6d6bde05bd98343
+  depends:
+  - libgcc-ng >=11.2.0
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5297287
+  timestamp: 1738678576396
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/locket-1.0.0-py311h06a4308_0.tar.bz2
+  sha256: 95fe76d2691feb13203b55ad2aba535bb848cae21ffd05b13ff51c7a45fa2332
+  md5: 6a04ec16e3abc1c7e2104be32cd6c418
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13458
+  timestamp: 1676827287432
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-4.3.2-py311h5eee18b_1.tar.bz2
+  sha256: c5f6a345b9a8e8e3b7f5368b6732e2ea0123451b6519b22913def3e2d2eab795
+  md5: 09b4afa08f1175ebb6fd23bd55f3d20c
+  depends:
+  - libgcc-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40866
+  timestamp: 1736366782736
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+  sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
+  md5: 76f089e76ec67583bb38428b51008097
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 164494
+  timestamp: 1714510587156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+  sha256: 260e26dd509834c1b225ab7bdb97b9a86e00054fbdd5dfa49e68fa4dcf85a661
+  md5: 8f5d7ddc69cc6f7d44c80d2251dea5d1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162339
+  timestamp: 1676837095436
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+  sha256: 7f5b0804d0768619b7bd93b10488067d80bf42ec29f443f00b53ba11758a1241
+  md5: 8afb45e45c0d93bfd142e682d4b021ef
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 134438
+  timestamp: 1684280014220
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-3.0.2-py311h5eee18b_0.tar.bz2
+  sha256: a77bbb4f7a346d892137624387e6c61ae08528013eb5a7dccf1ff8106f4f7aee
+  md5: 5aac92e1241121c99dc5ac5b866dc1d7
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28215
+  timestamp: 1738584091856
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.10.0-py311hbfdbfaf_0.tar.bz2
+  sha256: 4a1053eb7d779473df2b6af99649e20af08b3bfadaba59009df756585e7bf107
+  md5: 803563191e37b0fc9bf0ca62d13b2d10
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.23,<3.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9818267
+  timestamp: 1736278428611
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+  sha256: 7ac07ea180b5928086075900afbc332fb1d3c81ddfacb54c891693c284056f14
+  md5: fc83dd1b3d2ec3c0a297ead0c3405907
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19573
+  timestamp: 1676823852670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+  sha256: c9ba2f9c83820712dd97d6a1b54a1215b9820a0be02ac82380b4c50911b9400c
+  md5: e5dc6b4a5b8e02733ce3bc9e9198a8d2
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67750
+  timestamp: 1676837123613
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+  sha256: 1a5141ef0de1cbff816f96bb4b212a40606e2fc11301a4c1358c8d63a6b2b027
+  md5: 22ac3bc22b68fef4c1f3f6ab3c7bfe0b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23040
+  timestamp: 1676827301164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+  sha256: 9aacfbbe6f638c58a4e8ff31374d1438d78b7db25d6ea6fd0c50ca2109f225d4
+  md5: e602057e3b3d80da88c61d66e8851c5b
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104681
+  timestamp: 1676823696152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+  sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
+  md5: ce77d0f05f846da4a6b9e23fe7f21d9b
+  depends:
+  - intel-openmp 2023.*
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - tbb 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 206738176
+  timestamp: 1699648006088
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_2.tar.bz2
+  sha256: 2aa10f19199e2f594db9d292538611b60f9eb8604ac2e8ed5658360da0417fed
+  md5: 1bb09282d58781f1886968ec437e1db9
+  depends:
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 76075
+  timestamp: 1736367004456
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.11-py311h5eee18b_0.tar.bz2
+  sha256: 26001bced97eaa8c3862686f48668a252b8f7fd6ed81329534bee0538ea39fe0
+  md5: eb3e382c51549878d07e5c3e207c3845
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 241049
+  timestamp: 1730824176185
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.8-py311ha02d727_0.tar.bz2
+  sha256: afc57040e0c892e46b00ecb534100fcaf05d8c75592170b0ce9119f2e5630557
+  md5: 5e47055fea53886417e9a62d4e89c7c9
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16
+  - python >=3.11,<3.12.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411216
+  timestamp: 1730824036145
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.3-py311hdb19cb5_0.tar.bz2
+  sha256: ee4db7daf8d5e41a547e7790dd62aa98e203f4f857cf6018b850e7df8e613a3c
+  md5: 17145d1745996667614b52d2b27a1403
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 37588
+  timestamp: 1676823053826
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/multipledispatch-0.6.0-py311h06a4308_0.tar.bz2
+  sha256: b558b3f6c144652b5e0d26497b3ce24c318a6b9ff8ea2079113c95e5553b3cf9
+  md5: 0b185969ac2b065c27cbcc9641d93678
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29568
+  timestamp: 1676841232463
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
+  sha256: 6116c133fbed1e7ea0f5e69f900e93d7977cb715920d10b10642c191d00cc9a6
+  md5: b842f7ebdc8b7b6a0dda4c5ebe12805b
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8315206
+  timestamp: 1717622768176
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+  sha256: bb45fb0a3973caa74fd8f845e0a519895f6a378807626e15ecf72c02f2eed794
+  md5: 185f658ba8a74e326b7231c8fd0d62bf
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 121834
+  timestamp: 1698934274227
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.16.4-py311h06a4308_0.tar.bz2
+  sha256: 9361ab2f7b289e9fd33ef001035fbdca9735f1c5425bb8282ce053d152ffaa2c
+  md5: f95894da2382644ab016e71dc0db3463
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 528660
+  timestamp: 1728049573278
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py311h06a4308_0.tar.bz2
+  sha256: c7aa4facc9d03e5087f9b22a88373beb43633a2c558e895303f5accc3ce95142
+  md5: 4b4927ae34aaf3ee6b008a4392afd2dd
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 169513
+  timestamp: 1728049478168
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+  sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
+  md5: 57ea097dc15f8d9f9eb90e1d919143b0
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1157733
+  timestamp: 1674734069410
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+  sha256: 266199dd4efde0ad342a9c500f4bc4299c5622219aea623b46315a9b4f6b8959
+  md5: 2b21844d2b0024d0ffad0e6450cf0855
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 15860
+  timestamp: 1708532713870
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/networkx-3.4.2-py311h06a4308_0.tar.bz2
+  sha256: f54320cfc82be563199cafc28821cd5468c18d71d806e2f2ef353a309f91162d
+  md5: 8a344fb902f2f8dccd67a77798d2f928
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - matplotlib-base >=3.7
+  - pygraphviz >=1.14
+  - pydot >=3.0.1
+  - sympy >=1.10
+  - numpy >=1.24
+  - scipy >=1.10,!=1.11.0,!=1.11.1
+  - lxml >=4.6
+  - pandas >=2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3404769
+  timestamp: 1737039757951
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
+  sha256: 59e169e036db0f2b98ed19f867d8ac708970214599efa0d57d3413fc1dbe8e3c
+  md5: d0faf375bfc33811456d43fe549cb939
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 710152
+  timestamp: 1717630833268
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+  sha256: ef2857e6d3d7eb246b3abddfbd3aa2d124dd8565391ace3876b77339babc50bb
+  md5: d276d1b1774107987963135c78ca7390
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26607
+  timestamp: 1699455972519
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numba-0.61.0-py311h6a678d5_1.tar.bz2
+  sha256: 2f95537e4966bee197b435cdff1dbf2080822e3eb5c6f3fd5cbfee3122f31148
+  md5: 43e6d6cf6df11282475ea663a3622b90
+  depends:
+  - _openmp_mutex >=5.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - llvmlite >=0.44.0,<0.45.0a0
+  - numpy >=1.21,<3
+  - numpy >=1.24,<2.2,!=2.0.1
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  - libgomp
+  constrains:
+  - cuda-version >=11.2
+  - cuda-python >=11.6
+  - libopenblas !=0.3.6
+  - cudatoolkit >=11.2
+  - scipy >=1.0
+  - tbb >=2021.6,<2022
+  - numba-rvsdg 0.0.*
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6321862
+  timestamp: 1740752747545
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.10.1-py311h3c60e43_0.tar.bz2
+  sha256: c85ee5a0b557ed925a1709b7422f13e88545bd2392c63d8e65b8d4dd44bca713
+  md5: 3ca48c350f813b2e11ed2312858098f7
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21,<3
+  - numpy >=1.23.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 204257
+  timestamp: 1730216115069
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-1.26.4-py311h08b1b3b_0.tar.bz2
+  sha256: e09e1aff2c12d4ef3fec58fb627744e4b5c7d9eaede7175e293f77272d8b8bfd
+  md5: fe8242cfd54d238507493612ae697ad4
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311hf175353_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10270
+  timestamp: 1708639794640
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-1.26.4-py311hf175353_0.tar.bz2
+  sha256: a53ad723826651041a5057a1cf31bc8689b24d335ce61b196df5124974b05a8e
+  md5: 7b29e7191c4170189d6080e61229f030
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311h08b1b3b_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9163911
+  timestamp: 1708639777712
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
+  sha256: 1c9f6902907a3d4a7e5c3cb02236491ea4c4e66a1a0ce51fa506dffb24ba89f6
+  md5: 36d514eca3c87ab75a1d418607e26db2
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=11.2.0
+  - libtiff >=4.5.0,<4.7.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 528528
+  timestamp: 1722872671997
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.16-h5eee18b_0.tar.bz2
+  sha256: 3ddd6080b6f008c6270ada8aa125af76afb3bd4ea4fbc47acccc2dacae0af8ee
+  md5: a659f1ac2ace6e5c8bf4a5074c3b7788
+  depends:
+  - ca-certificates
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 5513682
+  timestamp: 1740989825289
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/orc-2.0.1-h2d29ad5_0.tar.bz2
+  sha256: b29f46d834ef22a9cb4a05cb241cb6881a69be8eb96fb643fa7edc192b46669e
+  md5: 68b0e862640c31c5f82def14794015b5
+  depends:
+  - libgcc-ng >=11.2.0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.10,<2.0a0
+  - tzdata
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1341122
+  timestamp: 1717104644619
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+  sha256: 280225061aeba00d7b85f46e55d7d79cd92c92f662dc749d9c53187978e8d083
+  md5: c51c21da68080d89300703ad818c824a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38606
+  timestamp: 1699371264464
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.2-py311h06a4308_0.tar.bz2
+  sha256: 288da6ac31a1aebbd0571fe1d273c6095a0c049c6be93db899dfe45fc57c7936
+  md5: 684139274d664e9d0458b11e8a46d55e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 188806
+  timestamp: 1734472196649
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.3-py311h6a678d5_0.tar.bz2
+  sha256: f9c6066d840b6a7db19eb969637e9ae26b22a64f4c63e7d34639c5638d71bc2b
+  md5: 5f21a0ac71dd61bb78501815e23e1117
+  depends:
+  - bottleneck >=1.3.6
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numexpr >=2.8.4
+  - numpy >=1.23.2,<3
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - pyxlsb >=1.0.10
+  - beautifulsoup4 >=4.11.2
+  - jinja2 >=3.1.2
+  - dataframe-api-compat >=0.1.7
+  - pyarrow >=10.0.1
+  - pytables >=3.8.0
+  - pandas-gbq >=0.19.0
+  - zstandard >=0.19.0
+  - numba >=0.56.4
+  - html5lib >=1.1
+  - psycopg2 >=2.9.6
+  - blosc >=1.21.3
+  - adbc-driver-postgresql >=0.8.0
+  - pymysql >=1.0.2
+  - qtpy >=2.3.0
+  - scipy >=1.10.0
+  - lxml >=4.9.2
+  - fastparquet >=2022.12.0
+  - xlrd >=2.0.1
+  - s3fs >=2022.11.0
+  - xlsxwriter >=3.0.5
+  - gcsfs >=2022.11.0
+  - sqlalchemy >=2.0.0
+  - adbc-driver-sqlite >=0.8.0
+  - python-calamine >=0.1.7
+  - odfpy>=1.4.1
+  - pyqt >=5.15.9
+  - openpyxl >=3.1.0
+  - fsspec >=2022.11.0
+  - matplotlib-base >=3.6.3
+  - tabulate >=0.9.0
+  - pyreadstat >=1.2.0
+  - xarray >=2022.12.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17990544
+  timestamp: 1732738272325
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.6.0-py311h06a4308_0.tar.bz2
+  sha256: 97fb5715b3e6bd925f9ce7239085ce4479c9c451301fe5a5ab91d201e2f20fd7
+  md5: 641fd555bafec41ede9bf09c3f327fac
+  depends:
+  - bleach
+  - bokeh >=3.5.0,<3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.1.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing-extensions
+  constrains:
+  - holoviews >=1.18.0
+  - bokeh-fastapi >=0.1.2,<0.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24391130
+  timestamp: 1738685172659
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.2.0-py311h06a4308_0.tar.bz2
+  sha256: d137c487271bef84a7d0a7497439db4d0a07b6b4a9e30036b19bfd264828b728
+  md5: 80cb61dac081768a5d5d2d925a61896d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 268099
+  timestamp: 1734618713828
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/parso-0.8.4-py311h06a4308_0.tar.bz2
+  sha256: e40e60301997a3b5ff53b7ed7365db536f1b492a829ce2946ac61f6f7321c1a3
+  md5: d9f873bfc00a48198c960c9ba56f9e93
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 222615
+  timestamp: 1733963432742
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/partd-1.4.2-py311h06a4308_0.tar.bz2
+  sha256: b96acd51c903ff9b5611255f16c27ef589fc39a05ae4d61c9224850b4eeb6fe4
+  md5: eb0b306fec6e0beabe0080e4122a9c8c
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - pandas >=1.3.0
+  - numpy >= 1.20.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 47364
+  timestamp: 1736803437262
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-11.1.0-py311hcea889d_0.tar.bz2
+  sha256: 630ef38f47357fe4ed046a3b71ebe382aa253b59793840775a186c9c63dc6e57
+  md5: 60bf75f54f265640a5c80a65d77103d5
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.16,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libtiff >=4.2.0,<4.7.0
+  - libtiff >=4.5.1,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 1000438
+  timestamp: 1738010435246
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-25.0-py311h06a4308_0.tar.bz2
+  sha256: 64f16503d8799c8ed3031e8c81d429353406504e98cefed97080fc35e2b55fc0
+  md5: de0f3617ef38333a13b7aebb17b761a0
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2971886
+  timestamp: 1737992037529
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+  sha256: d2bbab8bfc57c7f46ca8994bc87df7e744d3f036b867bc4be1145ba6d8d7e091
+  md5: de41707272a8e3ccab764f0b7010a27d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37394
+  timestamp: 1692205565974
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.21.0-py311h06a4308_0.tar.bz2
+  sha256: ef83087f0474cbc11bf6ab7c318a56a7677c6dcc57c75d5ed52a0a2a6bda30a2
+  md5: 25de2c05534f16c0e2b61429c7c2d3bb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 121560
+  timestamp: 1731953225009
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+  sha256: b7f591c19b10bf0daa7e6e3b45a9f4a0a0e83188e1f8a58037caea79e60f8d91
+  md5: d945b4ccc135005839c504cc29df1745
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 749608
+  timestamp: 1704404477511
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_1.tar.bz2
+  sha256: 675e161cff8bc0f660b3f7ea5692207de372730d9ea2d5410a1e76c8e3cb24d5
+  md5: 924cb59384b001ea5e9e37d1638820cc
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 495241
+  timestamp: 1736367238095
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyarrow-19.0.0-py311h6a678d5_1.tar.bz2
+  sha256: edcfdcaba5832487d9b52a4d18b9e8a53b62e3a0ba5be7fe2998d83bdae011f0
+  md5: 4bd50f981e639a6e4750d05600b5522c
+  depends:
+  - arrow-cpp >=19.0.0,<19.0.1.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.19,<3
+  - numpy >=1.23.5,<3
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8956536
+  timestamp: 1738231250212
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyct-0.5.0-py311h06a4308_0.tar.bz2
+  sha256: eb75b4417565d25e2d1006db75aa8bd9da6b6c72a929954b01a31b9bf5f8b42e
+  md5: bb56c0358b65665f4dd509a4635f6f3c
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37802
+  timestamp: 1676838557935
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+  sha256: ed927e4d058a8f4ea73edc7a43ed74877d93b88fdfa240b3b2777244386ced70
+  md5: a1f0e05fc7e49712f81ad5478ec9d51e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2121496
+  timestamp: 1684280065800
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.2.0-py311h06a4308_0.tar.bz2
+  sha256: b5d27b938ed374a24fcb18a66c3f1a94e28bbe01b4ac156cd26c7be1ca756622
+  md5: 244cfad440c898146039cb986864017e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 486387
+  timestamp: 1731445563066
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+  sha256: 114b55e00f4622c90fd2b404b21ad5f94a10283fcaaf86a42174b8d39b0a3e98
+  md5: 2458e92683cc68671a6c8e1b86ce8817
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35850
+  timestamp: 1676822725516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.11-he870216_0.tar.bz2
+  sha256: aced5b9158e4839247dcf76bd5197650803f9db116ccdc451a79d1c0da5f2354
+  md5: bc33687df04e0cfeebd12f682bec6b22
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.35.1
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.15,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.45.3,<4.0a0
+  - tk >=8.6.14,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 36116799
+  timestamp: 1733935613200
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+  sha256: a0f008717fab060ccd003dfebc09156d90b9afd14ac3626566aa1a8f3d3b7e2f
+  md5: 357bf4fe94496cbae72ab4d780184b31
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 330924
+  timestamp: 1716495762901
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.20.0-py311h06a4308_0.tar.bz2
+  sha256: 8e42421bb620d1e12ab455da3594c2129b0a6d994a0be6a1e4519d1d3ead360f
+  md5: 99293d1a98a94e2b11c5d598ea2d80a8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281088
+  timestamp: 1731939500285
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-3.2.1-py311h06a4308_0.tar.bz2
+  sha256: 0cb8b14ce460a6927a4b1e9c2b2737b8668f7bae47998c56d2e307706f72076f
+  md5: eb0b1081560d413b713603a3bdb9b0dd
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 28481
+  timestamp: 1734370110052
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-lmdb-1.6.2-py311h6a678d5_0.tar.bz2
+  sha256: bdd5c8398e306eec5a30c9cd6ea3181cb453c89d42cd81cc40e581334381d136
+  md5: bb38a06afd93970d169f58d9f379334b
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 154000
+  timestamp: 1736540736166
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-snappy-0.6.1-py311h6a678d5_0.tar.bz2
+  sha256: 68ecfb1ece016cb4610ddc746022ba892d30efbe12ec0858c605ca18c363098d
+  md5: ef7c3d6a2becca7997b00e1ff9444dbb
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - snappy >=1.1.9,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36679
+  timestamp: 1676842382142
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+  sha256: b85acb933fff864bfa89d034e8e3d85b1a9c2e69cbfc0d68c1d66ffd1443e67d
+  md5: 0cdb92d2d684ee1095310f992ed0d9b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 266796
+  timestamp: 1713974338678
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+  sha256: 511e8206a15445715b80be76493300930686b3fe1e512ae942d6ccca36df392a
+  md5: 35a6e46ae970f8b71d78fb5a810f2e80
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64013
+  timestamp: 1711136926372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py311h5eee18b_0.tar.bz2
+  sha256: 132aa25ee904333ef338eb1935dd8e5ccffb27cacf33fdb58c1358ec22424933
+  md5: 92ce34b6f4f7a6e64c80c2ba0a96edf4
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 222337
+  timestamp: 1728658052191
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+  sha256: 7c74db4292f31619606180f86f3c1e2d913495c2c9d1195c5d51681a6a841625
+  md5: be1c05fae57d194924b9400f9b5ad3c6
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 613277
+  timestamp: 1709318516682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/re2-2022.04.01-h295c915_0.tar.bz2
+  sha256: 8a640736bef635346409582dbfe2b7d0ecc9da215c90173ff8a9a5fe22569107
+  md5: 6b583dce61c6feb352ef0f49f413af1e
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  license: BSD-3-Clause
+  size: 235004
+  timestamp: 1652449537852
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+  sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
+  md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 467661
+  timestamp: 1666648052561
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+  sha256: 89c2f4235277b9825cc805c5c44f0b1afcb683d7b5a3f513bc4bf243b643bb0c
+  md5: db70eb57e33adf7b8bbdadd72214d48d
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 73679
+  timestamp: 1699012111499
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py311h06a4308_1.tar.bz2
+  sha256: 1ac5ee93110e2f7f1d68b6c985e4adcc3710f537c388ae3ff4f85059288070a1
+  md5: 4385913efbeb323430797aa3b3506525
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 123440
+  timestamp: 1730999231468
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+  sha256: fdae3f68ea84b99561aee6c566ab1c287d8f2ae2668424e9283a8ed86af8f1d2
+  md5: cde5b71ccbb3630053340b2c8c7dbf10
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9333
+  timestamp: 1683077183576
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+  sha256: 0bf859b06a07857099fd4f524fe5e0875fda70029e9485d95c7efa97134fbc14
+  md5: fd5815cc592fdbd4c831901541eadaba
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 9735
+  timestamp: 1683059096795
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.22.3-py311h4aa5aa6_0.tar.bz2
+  sha256: 04dfe4c37981aa83a527943d1b8b97fc1114e5d8451f8a7419b82723cadf9ef9
+  md5: 0077518e6e8f5086934b83c719e833fc
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 387461
+  timestamp: 1736541527247
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/s2n-1.3.27-hdbd6064_0.tar.bz2
+  sha256: 8c8aa1eb7e215984f46c8e1c7cfa6e5e6b233993d92b835a9b1b5491a4b970ab
+  md5: 6e145b179adde03f8aa8a066c58d4e31
+  depends:
+  - libgcc-ng >=11.2.0
+  - openssl >=3.0.12,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 380702
+  timestamp: 1706563445897
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scikit-image-0.25.0-py311h6a678d5_0.tar.bz2
+  sha256: 74e2fb1d93c7088be9d830eb7b7a29fb8d4c63eba244439a11732594c3a0fa60
+  md5: e7f65054b8f8bd918b017c68f204d54f
+  depends:
+  - _openmp_mutex
+  - imageio >=2.33,!=2.35.0
+  - lazy_loader >=0.4
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - networkx >=3.0
+  - numpy >=1.21,<3
+  - numpy >=1.24,<3
+  - packaging >=21
+  - pillow >=10.1
+  - python >=3.11,<3.12.0a0
+  - scipy >=1.11.2
+  - tifffile >=2022.8.12
+  constrains:
+  - pooch >=1.6.0
+  - scikit-learn >=1.2
+  - matplotlib-base >=3.7
+  - cloudpickle >=0.2.1
+  - dask-core >=2021.1.0,!=2024.8.0
+  - pywavelets >=1.6
+  - pyamg >=5.2
+  - astropy >=5.0
+  license: BSD-3-Clause AND MIT AND BSD-2-Clause
+  license_family: Other
+  size: 13099498
+  timestamp: 1737478036440
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/scipy-1.15.1-py311h08b1b3b_0.tar.bz2
+  sha256: 862b4557695d2e2b7b73dd644ed39b5b85bd9568b317a81f47becaa39e42ab38
+  md5: 3ee39110782b4be9e58c7aefa3873d8e
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libgfortran-ng
+  - libgfortran5 >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.5
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 30618018
+  timestamp: 1737124439345
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_1.tar.bz2
+  sha256: e63e86fe0d0850be9875933c62bb6db688851aace1d9189bc1a47d469afd22b1
+  md5: cca758835477ebeaa86f1baaad9e5072
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 32439
+  timestamp: 1736540840590
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-75.8.0-py311h06a4308_0.tar.bz2
+  sha256: e2b971b957b1bed5e0cc8921515c0013cfe657dc4c4a3a4e3f0ef475d5a3f768
+  md5: 1aa6863387e163b749cd1df4a017af08
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2303858
+  timestamp: 1738045951501
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/snappy-1.2.1-h6a678d5_0.tar.bz2
+  sha256: 8fd98235b37194986a5eb663c95a4a6db8c9e20a627f5c79ff8d9be3fd0e36f7
+  md5: 25ac00d957eda056675f8fa3eafdf6df
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 52749
+  timestamp: 1723557449203
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+  sha256: 1a84b00944bc5588e14a097460175f97df49acb4f1ff2498ffd9a1893068ed81
+  md5: a456513471b2ecbed60430c21dd1ccc7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17880
+  timestamp: 1705431390054
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+  sha256: adcafd297d60af64107c113bb7b8b92160d0268a44ef9a3b79e56a88a0358ea7
+  md5: 28ed704ed26b06d32662e3a6a87e59b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 88799
+  timestamp: 1696347581401
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+  sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
+  md5: f86119b3243fe3508160aa0406245738
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1723866
+  timestamp: 1714488309729
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+  sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
+  md5: 041a3caf09dc9ce8fc6c10925c4fe050
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1888016
+  timestamp: 1680167274961
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+  sha256: 856a8ab8c350c50247b79966c6cb80fb6d4de36eef49ddf75aebbbcaf854c82d
+  md5: 442dde204d14d171aab9ee40e8de4de8
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37456
+  timestamp: 1677696176157
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tifffile-2024.12.12-py311h06a4308_0.tar.bz2
+  sha256: 5a301135c6e772da6b14b2468d957e9e7a9d9b28fd53f1fe4cd60a3614b561a1
+  md5: f419995451f73f6ca2ab526f12f15110
+  depends:
+  - numpy
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - matplotlib-base >=3.3
+  - imagecodecs >=2023.8.12
+  - zarr <3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 520349
+  timestamp: 1734340960378
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.4.0-py311h06a4308_0.tar.bz2
+  sha256: c26644ab8c3641ee3e8a1f8b2c956ea4962f28766e63045d04830895a77ab4ef
+  md5: dc03c456f163e2ee825ef58d7bda260e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105144
+  timestamp: 1738337726955
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+  sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
+  md5: e2512d57c8a1e91e7b20e265c6906546
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3588922
+  timestamp: 1714770676475
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/toolz-1.0.0-py311h06a4308_0.tar.bz2
+  sha256: 122195bef57aa4b2f306fb9da598f624e7484cd68e12b153423163625d103e82
+  md5: ce627ee2768dd9164e9dd38dbbfe493e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 137395
+  timestamp: 1736796348932
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.2-py311h5eee18b_0.tar.bz2
+  sha256: 780986d79652f3f4eec28d8d9cdda134a1eed4aee302a66483ebfb8c5dbef877
+  md5: 5c580c8870055c1a563959f98142f836
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 915944
+  timestamp: 1733960601134
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.67.1-py311h92b7b1e_0.tar.bz2
+  sha256: ec9e26c23d9ecbf2659baf0bdb494fe7c8c1adfc2652f498e8a4c86e5c7d52cf
+  md5: ad166b83ace6eccc6aece01e99b76df9
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 154942
+  timestamp: 1738943559030
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
+  sha256: 2091b17ae4fa46ed98fd6bfe9ca1aff3b0b81d73045e0cc55774b6516b8704b3
+  md5: 183ae7b837c1c68ec1a8011011fadea7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 206924
+  timestamp: 1718227183177
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.12.2-py311h06a4308_0.tar.bz2
+  sha256: 48850864a536279a44c8e4b5eaf5d7d0b424df752374fb5624f2c3ecc8b8bc6d
+  md5: 0f1d42f3ecfa42bbfe56e32d902fb88e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.12.2 py311h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8924
+  timestamp: 1734714943753
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.12.2-py311h06a4308_0.tar.bz2
+  sha256: 613ddfe5f4e9f2cb37f63a58a2c1d8527e4f19b5758429752733ecb919ffd2c2
+  md5: db0f11a0de3083f9288c7d3a054f3887
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 81460
+  timestamp: 1734714938116
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+  sha256: 509b962773f0fe44a93a7f6196b254670a030eac8ea7f90727312e3ccd9294b2
+  md5: 6c402d5bf4e01c8c3895c9ef41707b6e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11371
+  timestamp: 1676828901104
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_1.tar.bz2
+  sha256: 6156af1c5328402d038a8149b032afee72772ae42f41b7afb64b647b2f493072
+  md5: ce769642bd2a2fc532a61d5d9ad75340
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 512446
+  timestamp: 1736541055872
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.3.0-py311h06a4308_0.tar.bz2
+  sha256: 3ecf92bcd85bddb047ae10562f5813cddb6308c82404041e38a2feecee84dff9
+  md5: bc4a1212360e17741c57d46915763eae
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - requests >=2.26.0
+  - zstandard >=0.18.0
+  - h2 >=4,<5
+  - selenium >=4.4.3
+  license: MIT
+  license_family: MIT
+  size: 221784
+  timestamp: 1737133656065
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/utf8proc-2.6.1-h5eee18b_1.tar.bz2
+  sha256: a8d11b0f08217607b99ba560edf66423ca1e36f4ffbb6e2377e61670e2b5f36b
+  md5: 431e82b081b08aef0259df0437e04c75
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 97535
+  timestamp: 1706894675990
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+  sha256: c3a5e0b855dc2de6c162708dfcf170a23eb9e7525d4252d8dce553369af4a330
+  md5: a4c77e204b7787f820955166a1283168
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25890
+  timestamp: 1676823132898
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+  sha256: 42989f9970a8466cc4edb73463dfa194594dd1a5d42c9f820a1f86296d4af140
+  md5: 655dfd4d2f17977cb81caa1c082d2b25
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 113505
+  timestamp: 1715878346465
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.45.1-py311h06a4308_0.tar.bz2
+  sha256: 4cde08f71cfbbfe04c2db531f02bbe41e59f4c8106035bf6879a60aa9b3be72a
+  md5: 7f83df7c72bc54e8ea629254b604e996
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 144053
+  timestamp: 1737990272462
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xarray-2024.11.0-py311h06a4308_0.tar.bz2
+  sha256: a61dae57de0024ae96377788cf549c00f4d3b45e878e70f53f44388e9c608ad0
+  md5: d453ecf0fc6e2d4367421b0ffadb0f1a
+  depends:
+  - numpy >=1.24
+  - packaging >=23.2
+  - pandas >=2.1
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3005438
+  timestamp: 1734535848338
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+  sha256: d18cdca154bf668826f869117ea996c4f9e8ef7d27b7c528332a7d17e5a8602c
+  md5: 9f7353d72046b16dd6ef6b5689ac9bfd
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54731
+  timestamp: 1676828934954
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.6.4-h5eee18b_1.tar.bz2
+  sha256: bcebbfa8a53efd5eaa77a0cd7f120b2e3a397e67aa78ebe907f1b35ae7148b0f
+  md5: c924da317917a16d9d8551701b53ef7b
+  depends:
+  - libgcc-ng >=11.2.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 580712
+  timestamp: 1739468299256
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+  sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
+  md5: 943f1247a22b6b64171363bcee1eec27
+  depends:
+  - libgcc-ng >=11.2.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=11.2.0
+  license: MPL-2.0
+  license_family: Other
+  size: 371663
+  timestamp: 1705602144682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zict-3.0.0-py311h06a4308_0.tar.bz2
+  sha256: f33ed759a551e2cd64115a3b01af0fc9822b1a5a1a5c798aa0ee14292792d7c1
+  md5: 7feb38e587b3352efca77df1447858d2
+  depends:
+  - heapdict
+  - python >=3.11,<3.12.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102106
+  timestamp: 1695832995689
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zipp-3.21.0-py311h06a4308_0.tar.bz2
+  sha256: e46271d373c7df35529f3679fc35075ef0673e1f93cc43f388ecd50c3892ba47
+  md5: efa61cd508fe869102963c235c0d91b7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 29517
+  timestamp: 1732630842012
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+  sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
+  md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Zlib
+  license_family: Other
+  size: 127143
+  timestamp: 1714510716441
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
+  sha256: a65c6277a3045e4ea72f617f977134c18366d8142ce51512f5a3cf325226a8bf
+  md5: d941bb6fdc55cc1b3f67b3beb23d1795
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1081416
+  timestamp: 1728487031624
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+  sha256: c0dd89ffac001588171152a285ddbbaea209ebe4116010f985f898b7e87c2f35
+  md5: 731ae7d446633bc729f3493a52d4365b
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 43502
+  timestamp: 1721748373551
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/heapdict-1.0.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 9de8666e5b70aa2437737128eaa14ffe80a7b5235c2a6b7d3f39ccefd7816ba0
+  md5: bb52e50c5ab1a5c7778c11376404dfdb
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 7933
+  timestamp: 1630598543551
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+  sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
+  md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
+  depends:
+  - prompt-toolkit >=3.0.43,<3.0.44.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5106
+  timestamp: 1704404390460
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/sortedcontainers-2.4.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 4e47f6c49ce84509f1466e8a4d728447bf4bcd9bce7b456431a789a262547067
+  md5: 4cad993b0f80bc23fb66a97592299cbb
+  depends:
+  - python >=2.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 26504
+  timestamp: 1623949147884
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tblib-1.7.0-pyhd3eb1b0_0.tar.bz2
+  sha256: ca2be6c7810a37cfc6db1f5383937b5d35c6d73c1fad8a9104de85f069b1df1c
+  md5: 9ccb2fb33edb152403d6ef32bf758a9d
+  depends:
+  - python
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 15614
+  timestamp: 1629402049497
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2025a-h04d1e81_0.tar.bz2
+  sha256: 3c9af6c00f75f5fbcad55fef878e67ea5db5bec590b928d4b1ba47aaa0f3d8d7
+  md5: 200a475b8b5b4e72e8b5ceddf3d0f24a
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 126234
+  timestamp: 1737549203664
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.6.2-py311hecd8cb5_0.tar.bz2
+  sha256: 10c81c3952bdf1073713a33f65f538082b2f6de47c4dff3cf173a18e4f014e7a
+  md5: 87d1d76e942262c2c7c39370e30d7b3b
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.21
+  - trio >=0.26.1
+  license: MIT
+  license_family: MIT
+  size: 244917
+  timestamp: 1729121433463
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+  sha256: ab7672364f1fa55ec5d8311d85d40e5b57cbd3517b17670557b6fb822bcf759c
+  md5: 6e0159a5865cb7e96a748bd8560035ee
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 11579
+  timestamp: 1678317458652
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h46256e1_1.tar.bz2
+  sha256: 3f2344b378e912596a7b66e66e35833e7c20544446f7b19f25f4b500e5441a3d
+  md5: c7914de4b54fc22e1b419b5c5426281e
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 34877
+  timestamp: 1736182638965
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/arrow-cpp-19.0.0-hdba8a65_0.tar.bz2
+  sha256: eb59b3e6d30c9964959c8ac3f2be4b5bf0ff703ba982412825f08b95d859b8f2
+  md5: bdeab8cabb00d64d2e85e14c2e4ad665
+  depends:
+  - __osx >=10.13
+  - __osx >=10.15
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - aws-sdk-cpp >=1.11.212,<1.11.213.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.5.0,<0.6.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libcxx >=14.0.6
+  - libgrpc >=1.62.2,<1.63.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.15,<4.0a0
+  - orc >=2.0.1,<2.0.2.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.10,<2.0a0
+  - utf8proc >=2.6.1,<2.9.0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 11032164
+  timestamp: 1738050731377
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 5543d56ca11cc3aef4c889d8824a798bc4418b82265f43bca53077724c7ed1e9
+  md5: fe9dd468243c6b0fbd5d55cc5c2a60cb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 163936
+  timestamp: 1734533359828
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-auth-0.6.19-h6c40b1e_0.tar.bz2
+  sha256: a153eee37b30ca5c25c5c95463a8852f1cf62a8f45f73349e68f1e3b22eec6da
+  md5: 4bf760fad0e938618391f0db249d00e1
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 87236
+  timestamp: 1706746160841
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-cal-0.5.20-h3333b6a_0.tar.bz2
+  sha256: 04ec5908b1dc2979ed50923af90d02da8a60434658efbc4f35fc61e7e9cafa0b
+  md5: 6ba283b7f902226f232fe8a32fa83ee4
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 37547
+  timestamp: 1706690917050
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-common-0.8.5-h6c40b1e_0.tar.bz2
+  sha256: 08431c5ec5f0a9e95819b6a76c9cc870d2154e46b229431fd0b3dad25bb70b04
+  md5: 78b4b4225fdefef0b9b0d56b6e51e4a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 184146
+  timestamp: 1706189913777
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-compression-0.2.16-h6c40b1e_0.tar.bz2
+  sha256: 6a78705375d837a0eeeff9e914aae53a0d2cd44e9760075bdd8711a05f94ff3f
+  md5: 931b0654ae05bcd1acc760dc830b89d3
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 17410
+  timestamp: 1706690854689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-event-stream-0.2.15-hcec6c5f_0.tar.bz2
+  sha256: 1d468f7c085b73cc40f813885d77a74270f94dd973b4285546d8873030fcada7
+  md5: 3a61760bb61f85b3a0ffe7b14058801f
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 46197
+  timestamp: 1706697276616
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-http-0.6.25-h6c40b1e_0.tar.bz2
+  sha256: b53432aadb2ffe2f1c584c6994b665f3620f29c51b200b03282065a480cf021e
+  md5: 9686f32b210a009048c0877ac39fe88c
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-compression >=0.2.16,<0.2.17.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 164397
+  timestamp: 1706744140750
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-io-0.13.10-h6c40b1e_0.tar.bz2
+  sha256: 2ff9632eb2e2c7a70b8d64988e530d842fe5fa7fa529d34cda19f76fb40582e2
+  md5: ffbd1ff65fe9fb52d833af5d396b006d
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 125589
+  timestamp: 1706696187075
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-mqtt-0.7.13-h6c40b1e_0.tar.bz2
+  sha256: fa57f1d2b2eb56db72e4b54348452af67a1222bd4266b3d68c7b7ff00399743b
+  md5: ae9e78f6b1fef841fc0ffc7ef7c78d26
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 61379
+  timestamp: 1706746740037
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-s3-0.1.51-h6c40b1e_0.tar.bz2
+  sha256: 00834bd876756f1f13333c31623c2bdfa7d901b40aec161cf0343548fcd96187
+  md5: 4ef080b5a91e260d51d563218396d0f6
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 67408
+  timestamp: 1706747579372
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-c-sdkutils-0.1.6-h6c40b1e_0.tar.bz2
+  sha256: fb3198a05c96030d8498a5c4873e56ae28a5b04fb904a5c696a2192e9ee6c45b
+  md5: 48efeda1471a50b9481c3943a0300e86
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 48055
+  timestamp: 1706690833951
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-checksums-0.1.13-h6c40b1e_0.tar.bz2
+  sha256: f05fb72b1a5f25fab65ef416ff0d1966e3ff84f8a08c56bf809fb602028c66ec
+  md5: 86cda3f774047ff6b40eb14aab83215d
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51354
+  timestamp: 1706192066535
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-crt-cpp-0.18.16-hcec6c5f_0.tar.bz2
+  sha256: b8cb5f96e9eab47419622795fcdb42ad414481db9b84bbb50fcf8251a1314b59
+  md5: 335265dfe12cb6adcacf39b411cf9d7a
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
+  - aws-c-s3 >=0.1.51,<0.1.52.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 210312
+  timestamp: 1706827788950
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/aws-sdk-cpp-1.11.212-h9475118_0.tar.bz2
+  sha256: 51078459008a3618fbd15c4277487188c3cf7f9c5c8987f4bb0594b77032adb8
+  md5: 6629a63506ad22cce3d8a2f89ef089ea
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - libcurl >=8.1.1,<9.0a0
+  - libcxx >=14.0.6
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4299803
+  timestamp: 1733148774517
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
+  sha256: 365824e639808e52809f97b70b65da94a5eeb87e29dd97c8926aa72707a5a1c7
+  md5: db7813418dfe42d59363fed4a68d5c36
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 278195
+  timestamp: 1718029905185
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
+  sha256: 695ac69739e73351dfebfb01ea39c5e1dbfdcfb475590d6560ae318bfbad3a97
+  md5: 38fd73cba341639c45d8c747b08c9cc1
+  size: 49130
+  timestamp: 1528225884020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bleach-6.2.0-py311hecd8cb5_0.tar.bz2
+  sha256: 7c36e9cb426d000a95c25bfbe5bfe627bf7c7954bb6726b2480e825ec6c41164
+  md5: f97fe0299b63520bab00b5bdf52272fc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings
+  constrains:
+  - tinycss2 >=1.1.0,<1.5
+  license: Apache-2.0
+  license_family: Apache
+  size: 371442
+  timestamp: 1732291870573
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.6.2-py311hecd8cb5_0.tar.bz2
+  sha256: c8f2a98fb20810d9f6a1a93c0960558956ceeed9ab0ee8ff29e29f8db3024c01
+  md5: f4955f95a41cda37d6a5f7ca853a2d3c
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5890372
+  timestamp: 1737999241552
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/boost-cpp-1.82.0-ha357a0b_2.tar.bz2
+  sha256: 81102f2762d8eb2f07c69fbf7ca7dad879a257a053085492d4c1b4006eb35fb8
+  md5: 3c42777bc9330fe91177ea813b9ec252
+  depends:
+  - libboost 1.82.0 hf53b9f2_2
+  - libcxx >=14.0.6
+  license: BSL-1.0
+  license_family: OTHER
+  size: 11744
+  timestamp: 1696762233693
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.4.2-py311h9b7fc35_0.tar.bz2
+  sha256: 2db3c754dcd7b5f87f8e9384509f539b3c9a80e7c26279c050814258e712a223
+  md5: 24af5157264705bc3358ec195490de59
+  depends:
+  - numpy >=1.21,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 156491
+  timestamp: 1731059250255
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311h6d0c2b6_9.tar.bz2
+  sha256: c6ff30f54a4448526a1f2c9e5e4835e0416104c41e5b61bdbf6ff310a675641e
+  md5: ac04cd8733681fabf6202b9d12a28235
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 394189
+  timestamp: 1736182987784
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+  sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
+  md5: c5a600d81b1b48578863af2973c743ac
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 187637
+  timestamp: 1714510590009
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/c-ares-1.19.1-h6c40b1e_0.tar.bz2
+  sha256: f913b61ba3c1651b36688415cc163a5d575475f7573b543f48a80e7a5002e4bb
+  md5: f11d165eaa532ce04a35382841284298
+  license: MIT
+  license_family: MIT
+  size: 107047
+  timestamp: 1693902034820
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2025.2.25-hecd8cb5_0.tar.bz2
+  sha256: eed2df4a7eb4ad975ad60ffd3aa9e28a8461042abaa49c8da0ac69a0d3778c7e
+  md5: 2b7e8362bb4cc2e7fde27d2a80af9dfc
+  license: MPL-2.0
+  license_family: Other
+  size: 140713
+  timestamp: 1740582484873
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2025.1.31-py311hecd8cb5_0.tar.bz2
+  sha256: 7e80e0b7e83da0fb269ba10c393bffe2259bd236fec5ce9a2fa9070a7fe54d1e
+  md5: ce18ce529baa9178f4edaddc95b27912
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 169256
+  timestamp: 1738623783634
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py311h9205ec4_1.tar.bz2
+  sha256: d93f07c0baebe21d32298a5e4e6d59ec01aa8730628d3e586a099aa75baec0dd
+  md5: dffa026d960d5042574e76c406c7b319
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 293192
+  timestamp: 1736183432113
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/click-8.1.7-py311hecd8cb5_0.tar.bz2
+  sha256: aceaa74365b0d8e69c817639393df3a713a802f40645ac0bd2f39adc871acf54
+  md5: 52191c9d4f4fcaeea39574819ab2f14f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204365
+  timestamp: 1698129979494
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cloudpickle-3.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: 6289468ac6d509d11f928e80005c27fcc169be379c9714f839c305949fbc22af
+  md5: 851f577d81bce100ddf9c11ded38da06
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43158
+  timestamp: 1721657395305
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: 9270668e34b00a2605584a2db5130c83826855cd05b896ce949f3156fa197429
+  md5: 2586aa55677e822e8285d777f9039ca9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 543487
+  timestamp: 1709758497949
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: 389c63a84b92a6254c9d361ebe970d537d0b88733efd5ac5c3ee58196fd2c5a9
+  md5: c7bc5b3cbe76be83a27f00b7e4740727
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17974
+  timestamp: 1709323004148
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.3.1-py311h1962661_0.tar.bz2
+  sha256: a8433ccc2ae0f5a69a2795cc9a124678bc25dd99d23c697280394febd0ce1683
+  md5: 9dd4588e1973ae233a3d227182e6c709
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 301973
+  timestamp: 1732540462617
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cramjam-2.7.0-py311h9c86198_0.tar.bz2
+  sha256: f480b0ed7a98e682d8cbdaeef697116a0d839cee08ec8b5f39078c4e056ec29b
+  md5: 7712882f644fca2ccd169ce2dee2b4d9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1473015
+  timestamp: 1702651642047
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cytoolz-1.0.1-py311h46256e1_0.tar.bz2
+  sha256: cd7ad139df45050de901127e004b7f19dd7b47fda18b9a0e8c0f1b0eb6132baf
+  md5: c4acf42375dc4b5ea1144ec77d8bd18c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - toolz >=0.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 408736
+  timestamp: 1736804008505
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-2024.12.1-py311hecd8cb5_0.tar.bz2
+  sha256: 95b1a49058aaa455e947587e89a458c3035da0b42edb7b35ce2daa6610ab32dc
+  md5: a7c93b2edbcf975ba6c66c7553c5fef8
+  depends:
+  - bokeh >=3.1.0
+  - cytoolz >=0.12.0
+  - dask-core 2024.12.1
+  - dask-expr >=1.1,<1.2
+  - distributed 2024.12.1
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.24
+  - pandas >=2.0
+  - pyarrow >=14.0.1
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6369
+  timestamp: 1736874124933
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-core-2024.12.1-py311hecd8cb5_0.tar.bz2
+  sha256: 196f447909e5cde96573418ef2b17b4d9f28954ae568a872d9f553befe0e9745
+  md5: 5917e5d751a4fab35df14c598bd6626c
+  depends:
+  - click >=8.1
+  - cloudpickle >=3.0.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.4.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3196324
+  timestamp: 1736807879069
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/dask-expr-1.1.21-py311hecd8cb5_0.tar.bz2
+  sha256: 675f3486427b9b1a14e7caf7d745d6d3016f1e0cc11c9a0bc395bd66596c9cc3
+  md5: b894c290307c8dadb88e60fcc17a0a64
+  depends:
+  - dask-core 2024.12.1
+  - pandas >=2
+  - pyarrow >=14.0.1
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 570430
+  timestamp: 1736810627837
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/datashader-0.17.0-py311hecd8cb5_0.tar.bz2
+  sha256: 2e3dddcfc333657c0331c063c133e42729d4afc0f17bd44b784d3db4f784f630
+  md5: 7a5173b979dca48c186dc2cb847105f4
+  depends:
+  - colorcet
+  - multipledispatch
+  - numba
+  - numpy
+  - packaging
+  - pandas <3.0.0
+  - param
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18010111
+  timestamp: 1738338208258
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.8.11-py311h6d0c2b6_0.tar.bz2
+  sha256: ca52a2c3bc6ade8a458b1d0f0e5f0637cb715add74480c6061df52658765fa25
+  md5: 7728392984085b5bd2550360b608df0d
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2786928
+  timestamp: 1736267811270
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/distributed-2024.12.1-py311hecd8cb5_0.tar.bz2
+  sha256: 98a6ca0bf3ce8fb5d28a77080c2abbb4525454699e673fc624381a60cdec019c
+  md5: a729ef49c8a66fa723bb98bc906c1fba
+  depends:
+  - click >=8.0
+  - cloudpickle >=3.0.0
+  - dask-core 2024.12.1
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.2
+  - packaging >=20.0
+  - psutil >=5.8.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.4.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.11.2
+  - tornado >=6.2.0
+  - urllib3 >=1.26.5
+  - zict >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1824097
+  timestamp: 1736870891276
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+  sha256: d48b47b86b09dac1fa4542ec13e1bd4e23093638e684fa66ec3afdd9ce9337c1
+  md5: 5a2d1828ab7c8eccd3c2610d13672977
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17336
+  timestamp: 1678316187749
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fastparquet-2024.2.0-py311hb3a5e46_0.tar.bz2
+  sha256: 3a4f25b0833b1e459e03b22ad6f0fa21b489ca5aa9559bd18e1ed6659509766e
+  md5: f35dfe533aa5ab48ea2f7064b6b6353d
+  depends:
+  - cramjam >=2.3.0
+  - fsspec
+  - numpy >=1.23.5,<2.0a0
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 661944
+  timestamp: 1715262849492
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.55.3-py311h46256e1_0.tar.bz2
+  sha256: 890ef82419af3c013b4abb8ef38290e3582df16115c28d63d4048a3ec7c6c7b4
+  md5: 86f1888844cb0c0e74d0917374fccb26
+  depends:
+  - brotli-python >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - lxml >=4.0
+  - fs >=2.2.0,<3
+  - uharfbuzz >=0.23.0
+  license: MIT
+  license_family: MIT
+  size: 3240690
+  timestamp: 1737040198351
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fsspec-2024.12.0-py311hecd8cb5_0.tar.bz2
+  sha256: e483157d3adcb67e1ab4a7548884d32fe54df6856001217f34a9c38afe3a3efc
+  md5: 6f10c4ece49e70fa78b1bfce333ae06c
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - pyarrow >=1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 397391
+  timestamp: 1736275074073
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/gflags-2.2.2-hcec6c5f_1.tar.bz2
+  sha256: 3c7aa54548409f9343e891820ea43c195b5e4e4dce6b761bc3ae9f6c8be0fc86
+  md5: ed9629d6dc1612ec425eb8d27478b0f6
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 140316
+  timestamp: 1706888243476
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/glog-0.5.0-hcec6c5f_1.tar.bz2
+  sha256: aed47f9ca4dd140b9c8a183e53d4b89eba84a20041d2038983cdfea8096104ef
+  md5: c0d981d7d43eaad55950ff5e57206e70
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 97828
+  timestamp: 1706895273858
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.20.1-py311hecd8cb5_0.tar.bz2
+  sha256: 6ce4e0816edc5bd019217ecd47c98607ccdfa3f488741f4ec0e7f2cb0c6af971
+  md5: ed3fddc0df1d0a15720b6d07130a7e49
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.1
+  constrains:
+  - plotly >=4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6200029
+  timestamp: 1740583330876
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/icu-73.1-hcec6c5f_0.tar.bz2
+  sha256: fd87b109deef638ca91abf3972516ed588f6d63a32b809943018dd206d3cf2f1
+  md5: f3ce6fe6eb760c236e5f7d04df5faa81
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28138484
+  timestamp: 1692293212596
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+  sha256: 5c2458964157fe493ca18c513c693b70cb622087e5fa0c93e65fc45217edd811
+  md5: 15629e52625221b51a443cefd9501d12
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148522
+  timestamp: 1714398885844
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/imageio-2.37.0-py311hecd8cb5_0.tar.bz2
+  sha256: 906bf47c416726871147f56e4b8d75f4dfeb75a91ccecb05a0f32179b9562f3a
+  md5: b149364a17be4799847816671d4e044b
+  depends:
+  - numpy
+  - pillow >=8.3.2
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 666913
+  timestamp: 1738160330852
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/importlib-metadata-8.5.0-py311hecd8cb5_0.tar.bz2
+  sha256: 93a3ba81d845710e74bc76f0439758bb91b015fd3e271fc4b6349c55972b4ab1
+  md5: f82a0ed701e03576df6faa7181a8d81f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=3.20
+  license: Apache-2.0
+  license_family: APACHE
+  size: 55466
+  timestamp: 1732633660153
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py311hecd8cb5_1.tar.bz2
+  sha256: 6c4b4d5da2f4936a69e980ce34103da715211d01de342c44d6c64d9270db7e15
+  md5: 7d06beefeea6694f9de075c32ce3b1f3
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 240904
+  timestamp: 1737662538368
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.30.0-py311hecd8cb5_0.tar.bz2
+  sha256: 69fe2c100148f65f721bc791004000aa1e6a96cce9271f2c52c6b273f626d208
+  md5: e82a62e5327d2ad85d2456e675487b6a
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1640008
+  timestamp: 1734551073802
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.2-py311hecd8cb5_0.tar.bz2
+  sha256: 40f655b062710295113369c5c236ca3f0b281fd2b91959cffd02f20aa9dbfd57
+  md5: c6e3b63c5b90d3a422ca100f5a233a10
+  depends:
+  - parso >=0.8.4,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1193759
+  timestamp: 1733987587898
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.5-py311hecd8cb5_0.tar.bz2
+  sha256: 4f7339b035a2e6c092b403fa0baf3d4b4b1a320801e1589d51181d3d245c092d
+  md5: 810d409cef85a1896ae1fb8502675957
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 361525
+  timestamp: 1737760340792
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+  sha256: 855982a798d9af8e70635a250528a5da3b2b0cf7095e2804858caf139c8a239b
+  md5: 112a5602fe42a84a5bafa038abeddf4f
+  license: IJG
+  license_family: Other
+  size: 279686
+  timestamp: 1722872676718
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.23.0-py311hecd8cb5_0.tar.bz2
+  sha256: a899e7bdac6b9b734882ee44a8065d7006dd669fde9b0fb0a88ed2e2f77ec357
+  md5: 14a0abb1c37f2e37c0e55b8feec8d564
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 193788
+  timestamp: 1728487044949
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 0ea44d0c8044e70ab0eaf4d6f5f3e4753838dee106b5cbd36561e21a65cbac77
+  md5: 1d045016dca889d702f1caf3a16162fc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16528
+  timestamp: 1699032525791
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+  sha256: 70442ec4b0b7ebbdcf150963f61f797b861001092124f4ea39a16eb92a4d176e
+  md5: 63d1503915a15ae4f9ad1c46112ca374
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 272720
+  timestamp: 1678316970740
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
+  sha256: e657ec0667481d957827be1ce825b0a971aa3a211b07c1274d2c1099ded3129c
+  md5: 5e317fd45011a0003c29331a8002cb75
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 98632
+  timestamp: 1718818439542
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 2634d721123ea1e41b6e1cfe4a67552ec520ea9b5154c9e788ccb09d4745b732
+  md5: e874eba19b493b7a68161429f24b8f51
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43102
+  timestamp: 1718738272613
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
+  sha256: c353480ed4744c2a16aaccc1649bab38144436ad6d16ac2937e3e333d32fdccc
+  md5: 7de25bdf4cfd3f5485d790d9cddf427f
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 619935
+  timestamp: 1718828240904
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+  sha256: fd7964657f0a8fe8b167ba860b1f960e8b7b45309eb6c7c850d50ec283fe03b5
+  md5: 2967bb345bc75f53182e263ff4743ca6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28223
+  timestamp: 1686870845224
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+  sha256: 64cf59f0f74b0329b5069bc6135b4f40593f1dac52d85ad574d4b8e0a4b2cf16
+  md5: 35e8b80eaa03a904fc7f1da39e7f654d
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20234
+  timestamp: 1700168776500
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.8-py311h6d0c2b6_0.tar.bz2
+  sha256: d3417c81f287fc04e11f4d2605c5650d8e14352fced97257ee8078707978c455
+  md5: 8cf9a8648f02789ccd93f5f3900b611e
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 69231
+  timestamp: 1737040352794
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/krb5-1.20.1-h428f121_1.tar.bz2
+  sha256: a3a24cd84c291f7c9e28842ccfc2107d149f0aa8e676b85d9104eda77622e603
+  md5: 99ba4367783596d1bb0c7766ea6706ea
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - openssl >=3.0.8,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1290758
+  timestamp: 1686931137388
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lazy_loader-0.4-py311hecd8cb5_0.tar.bz2
+  sha256: bf3268d74374fbcd6c09b200096e0e6bbc9e199cf6c84c2dfa798109d6c72fb0
+  md5: e0ee3bff8409a917c94237125092eb58
+  depends:
+  - packaging
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25930
+  timestamp: 1718176930919
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.16-h4f63f0c_0.tar.bz2
+  sha256: ca7970616a49595aa2ada83fd1ab5f5318fc3254d21f66e946cfd9f1c6b5188b
+  md5: 851fa57e5675397c0e724987f17a3f3d
+  depends:
+  - jpeg >=9e,<10a
+  - libtiff >=4.5.1,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 264025
+  timestamp: 1734428532705
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-4.0.0-h6d0c2b6_0.tar.bz2
+  sha256: 50da46ac4a032a38d2d9e714e945079e05a46ae451437a52ad09b4cd5d925f5b
+  md5: 234c885b9f326ecf78b5294fb709ddee
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 295348
+  timestamp: 1734423413199
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libabseil-20240116.2-cxx17_h548131f_0.tar.bz2
+  sha256: 8973f292fbdc61fb9a0f97746e6e4d2ad7a777e54400e7800de9b14f229a7999
+  md5: 5524c45ff980ff65c2aa4bd106e7299a
+  depends:
+  - libcxx >=14.0.6
+  constrains:
+  - __osx >=10.15
+  - libabseil-static =20240116.2=cxx17*
+  - abseil-cpp =20240116.2
+  license: Apache-2.0
+  license_family: Apache
+  size: 1199721
+  timestamp: 1716563412628
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libboost-1.82.0-hf53b9f2_2.tar.bz2
+  sha256: 127dbf93874f1bb3493b312fecb5ffedb8f2a41d2470e2cbeb889eb58d89ebf7
+  md5: 07502b61e43a2039e4312b40d53c1db1
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 22584954
+  timestamp: 1696762195023
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h46256e1_9.tar.bz2
+  sha256: 8f058b4b23c8d56f8411c8f6eec834ea30e8a2ce7a98685ad9c2a4817aabae4a
+  md5: b64809b5c2030ac3e571c9f6b5b34335
+  license: MIT
+  size: 66530
+  timestamp: 1736182753663
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h46256e1_9.tar.bz2
+  sha256: 6269fa97423611d7310bb23d6929e1fee3246a10440cd931718d4d447f6d4215
+  md5: 23d3558e675675ea0281bbfcac49453a
+  depends:
+  - libbrotlicommon 1.0.9 h46256e1_9
+  license: MIT
+  size: 34461
+  timestamp: 1736182772158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h46256e1_9.tar.bz2
+  sha256: 738524a5398e731ba9c74b799bf5e972721af4a4dc6a5425d2e17780e3e15912
+  md5: b562c3b15ef8b86391171d2f1b85cae6
+  depends:
+  - libbrotlicommon 1.0.9 h46256e1_9
+  license: MIT
+  size: 311811
+  timestamp: 1736182791956
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcurl-8.12.1-h9bcc28a_0.tar.bz2
+  sha256: 4140204da287f719fa989576b8c1f79b907e710c453ff7718bea05d5ad99b780
+  md5: 1ed8bb7105c17dd7c0d7d4a599179aee
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.57.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.11.1,<2.0a0
+  - openssl >=3.0.15,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 425499
+  timestamp: 1739986491449
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.22-h46256e1_0.tar.bz2
+  sha256: 5267b5015a03aa90883f57b3cc5dda014082e5ab88e2d3b30fe809c37b96094c
+  md5: a6bdcc6561a095bc0ac11482e84c37c8
+  license: MIT
+  license_family: MIT
+  size: 84141
+  timestamp: 1734423352364
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libedit-3.1.20230828-h6c40b1e_0.tar.bz2
+  sha256: e84e6cbacb12de6fe86955449502d3956696ae583060d0d4911ea6f503cfb9ad
+  md5: 1d200c536be4172db41c49e81a3e6350
+  depends:
+  - ncurses >=6.4,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 169586
+  timestamp: 1703006265367
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libev-4.33-h9ed2024_1.tar.bz2
+  sha256: 4786264321edbff780633a5b752995eb3193ca4bce11b0fda179577f6cf1102c
+  md5: 849fdd014c201a9d2c2aa7c7db38a778
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 103993
+  timestamp: 1632891571494
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libevent-2.1.12-h04015c4_1.tar.bz2
+  sha256: a60941a0365ee3e8b9ff721f75b0608c234b5652f53337a918b787839de4bb53
+  md5: 4d61f019594ebccfb3f4fb87ee778416
+  depends:
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 414942
+  timestamp: 1685052318462
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+  sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
+  md5: 822a5b76117e56d3912f1f2153307528
+  license: MIT
+  license_family: MIT
+  size: 136045
+  timestamp: 1714483561919
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+  sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
+  md5: e458587c87e3f2d20192f4e0738f2c63
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 149419
+  timestamp: 1665498987619
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+  sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
+  md5: 1058b661ec829b2ee3716ee2a5520641
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1917987
+  timestamp: 1665498925405
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgrpc-1.62.2-hf2926fd_0.tar.bz2
+  sha256: 451a1bafa405093889dfcc3669f0a679d300bd8c8770901be300832f72e0d359
+  md5: b27400d99678fc64f10b5908ea05daed
+  depends:
+  - __osx >=10.13
+  - __osx >=10.15
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - openssl >=3.0.13,<4.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  constrains:
+  - grpc-cpp =1.62.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 6917286
+  timestamp: 1716835073567
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libiconv-1.16-h6c40b1e_3.tar.bz2
+  sha256: 9ff6ed0f0b9f9f27f449e95d11aa1c4e9e80028fd9d2a8caca5a15d8df88f435
+  md5: 7b4b557afc66aba367da14d97d71934c
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1409885
+  timestamp: 1714483704680
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libllvm15-15.0.7-h1357083_4.tar.bz2
+  sha256: f90e26d7559b18aeee0a3b43a4864b5c19ea1313b2e61dfed93d77c21c02357f
+  md5: ea6d65b67c795598481f5c419d086a7f
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<4.0a0
+  - libxml2 >=2.13.1,<2.14.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 29644059
+  timestamp: 1730401127883
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libnghttp2-1.57.0-h9beae6a_0.tar.bz2
+  sha256: 7bfcf69c31a4eb15dfab661c93463ce8dfb7b3de4356945fa5c1ca50a5ae0cb0
+  md5: 4934bb34818fa3d99b32b9cb59fed205
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - c-ares >=1.7.5
+  - libcxx >=14.0.6
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 784918
+  timestamp: 1697018436251
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
+  sha256: 499ebc9000c8e810081b5d7f7524b45dc99f6914096ea9e145366033514938b4
+  md5: ce5c24f93932e1a53d7d89e502f28783
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10123989
+  timestamp: 1664896966769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libprotobuf-4.25.3-h34eed0b_0.tar.bz2
+  sha256: 22fddb84e3f771ee2a550da0dbe4caa334ac53b8a633ea566ec5b2e4cbb261cf
+  md5: 1922ae6303e44e99aa04f54291240e1b
+  depends:
+  - __osx >=10.13
+  - __osx >=10.15
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libcxx >=14.0.6
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2688858
+  timestamp: 1716567854254
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libssh2-1.11.1-h3a17b82_0.tar.bz2
+  sha256: 1107001cf2ab50223d97fe24d4747262f52883abe47263e301a506b195485017
+  md5: a42788d25cc9b4a03d4434e231db7445
+  depends:
+  - openssl >=3.0.15,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 292312
+  timestamp: 1732891162787
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libthrift-0.15.0-h70b4b81_2.tar.bz2
+  sha256: 21ba71cdc65b56c6daefeeab55959e5a7edadfd697cfa8b2ed5c1b3e2a98586b
+  md5: cbbd369ee87aba597c942727bada4eee
+  depends:
+  - boost-cpp >=1.73
+  - libcxx >=14.0.6
+  - libevent >=2.1.12,<2.1.13.0a0
+  - openssl >=3.0.9,<4.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 364326
+  timestamp: 1687975317748
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-h6fa9cd1_1.tar.bz2
+  sha256: 82d2f89ec9f2b0769c0368f7f0734a405e3fb12bbdbefd3ec13b478bf6b2b699
+  md5: 2a4899f52b1a65d18dfc2af0ea3d5177
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.22,<1.23.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 668404
+  timestamp: 1734425846576
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+  sha256: 246c0d82766042c1a9194eecc71690918c68afa3528ff0c2c82796ce901df40b
+  md5: f33be4ed3bff89ed8f68df6c75158510
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 449215
+  timestamp: 1729160070984
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libxml2-2.13.5-h6070cd6_0.tar.bz2
+  sha256: 791ce310409e586df33c86fb3b6def35db2c7bf3c4a9c0fba41856ab7f408bf7
+  md5: 5aef8bf269c4f9f3e2de64907da8a9b4
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 647442
+  timestamp: 1732316131363
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: d28c465ec6d5f8d4962c597b249b58998300c8b4e3c937c578c3d15294ea863d
+  md5: dcaed6ddd0723c7cce6bfad917be98b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41176
+  timestamp: 1678413498410
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+  sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
+  md5: 5c740b4a18a558de0ccfe601703c423c
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 338738
+  timestamp: 1662635677689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvmlite-0.44.0-py311h6d0c2b6_0.tar.bz2
+  sha256: 932c4ef3e1166188c9a93a27a16fab98a4f9989b96c3d700b9c04b373166031f
+  md5: ac6e3f7baa60a087a9235773c9cd4fcb
+  depends:
+  - libcxx >=14.0.6
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 456612
+  timestamp: 1738678581789
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/locket-1.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: 716a654df2e55052193150015bd5c9856b847893fc5a229fa8669725b1c56ff2
+  md5: 687ba6c11de38ad7cc597f7188b491e7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13357
+  timestamp: 1678322560230
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-4.3.2-py311h46256e1_1.tar.bz2
+  sha256: 29a411b215312f6d31c80bcd94d1a85ceb257e041e963728928db23c3c770021
+  md5: 7f811f40d3548a64de5cfa23ab72e7b1
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38660
+  timestamp: 1736368024365
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+  sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
+  md5: 8f57dc3a3327bb6f7e1cba908856ac7f
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 183138
+  timestamp: 1714510756758
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+  sha256: 6fb2953e169ee1ae38f24d29752051501992f19b96b5ebcea9af75737bdbcb42
+  md5: 7f410cdae838c5030108d1b98a8c78f6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162478
+  timestamp: 1678377892595
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+  sha256: cd97e09a12ffb49b2a30a782fa8c7933b28f5ffdbfc5c73a9ebaa95fc9447370
+  md5: d1fb6ebc1e5728aa6377cfc71da08942
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135859
+  timestamp: 1684280005320
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-3.0.2-py311h46256e1_0.tar.bz2
+  sha256: 077282e1acac6c4805ac9459dee02815041755d129f1ec016ac0cc40a9e9fc48
+  md5: 195e14d7a296482d77a1475541bb7da9
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28349
+  timestamp: 1738584403932
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.10.0-py311h919b35b_0.tar.bz2
+  sha256: a02829868777ce746dafb37da1a234c212d11ed8609c13e8fb837e5cc0b82116
+  md5: 4d13f50eb1cda9f81858fd11ded08720
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23,<3.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9826780
+  timestamp: 1736279748306
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+  sha256: 07e7fd5bd64e55328b4b99d92e2e2600d791f1095bf905daab4cfc59f0f0a45b
+  md5: cf53321779f4ca7e986c1468719b93f1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19500
+  timestamp: 1678317565001
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0770e02be1ea1216af493cfc03d5b8a702e14606fa93b0692bcdab1fed1b898c
+  md5: ca6f06ceaf66a32bbf5dfdb6e373a5cf
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67892
+  timestamp: 1678417734353
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: fbe95ed0501bb0f137048476fe41bc718dd659e8ecb066bc67ac17d6a50f4318
+  md5: ec162bde8d1c8a107b257df218b17035
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23030
+  timestamp: 1678381838497
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+  sha256: c20dd678655e582129a858a1c5162bdc254082d3a3c035b0f72629d9276e5b75
+  md5: 800a0738c728796e02d0386ce7d457aa
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104585
+  timestamp: 1678317269407
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/msgpack-python-1.0.3-py311ha357a0b_0.tar.bz2
+  sha256: 7517bb3a1337287e71ba182e23654f49275048389a1a3c6d750dc580caf4aaed
+  md5: 5466d265b312c4ff0ff4969ebf15c0ce
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 37529
+  timestamp: 1678318290205
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/multipledispatch-0.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 638450a7ccb5f438ac65aa1c8d871fb5bb664e7261ec7e663d0302485c219a67
+  md5: 574875bbeabff85b5d9cfdb62066aece
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29473
+  timestamp: 1678392919304
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: f961b1322b6b02fee53ff9bd0f56bb73886eb59debd3f3666669593de7f48894
+  md5: a1e74ccd2f341d1d672e33d79e60d200
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8183400
+  timestamp: 1717623127275
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: e08cb3ee6df01f4c1e1ac8bc4ed1a06e549ffcc8774fe2e2842c644bb8f74a86
+  md5: 6ba0ae0fb14cbea1e3197707701dc180
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123077
+  timestamp: 1698934356774
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.4-py311hecd8cb5_0.tar.bz2
+  sha256: 098d35939d62073df7fc42fadde9d9f7f646e4727382c363c02c136820555e80
+  md5: 25b1cce018e6c1b19146f117690d2b5b
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - pyqtwebengine >=5.15
+  - tornado >=6.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 533595
+  timestamp: 1728050041209
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py311hecd8cb5_0.tar.bz2
+  sha256: 3175bd2b744191da1c7477be8162a0f8d7f68363de8c2ab6df989908211ba17c
+  md5: 2508c1c6fc84c712ce0419470f60b5fb
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 171386
+  timestamp: 1728050190296
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 42d803e1d8b54748db5d989ecd503826f564132df7cddc20f520460f55e523a1
+  md5: cd3fa71626ebc098da4625fc6be79752
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16952
+  timestamp: 1708532805951
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/networkx-3.4.2-py311hecd8cb5_0.tar.bz2
+  sha256: 0d9fda495e414a519f8f038f7c98b1c88a27a1a37183017b70c6aad326be861b
+  md5: dd80e14433e8439b6cad21d4518fc81b
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - lxml >=4.6
+  - pydot >=3.0.1
+  - pygraphviz >=1.14
+  - scipy >=1.10,!=1.11.0,!=1.11.1
+  - matplotlib-base >=3.7
+  - pandas >=2.0
+  - sympy >=1.10
+  - numpy >=1.24
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3424359
+  timestamp: 1737043448460
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
+  sha256: 09d88f1eb19a90dfe737f0e5b4dce7629f6076a2d91d572cbb0a41be5220a4e8
+  md5: ac8c26d949a04f478b560b7d8a2358a4
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 707187
+  timestamp: 1717630829258
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+  sha256: ed5608feb37a083d47b04203195260e801b64b5380f292cf18bb61e7ad827a2a
+  md5: daa9c1c233673b727528548454aea664
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27607
+  timestamp: 1699456006797
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numba-0.61.0-py311h6d0c2b6_1.tar.bz2
+  sha256: a09f6dd503ea180dfbd1719d7a3a9130bf2278d6e85db1fd36b726d48f73db89
+  md5: e742c3f123cb46423ddd20e669c44618
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.44.0,<0.45.0a0
+  - numpy >=1.21,<3
+  - numpy >=1.24,<2.2,!=2.0.1
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - cuda-python >=11.6
+  - tbb >=2021.6,<2022
+  - numba-rvsdg 0.0.*
+  - libopenblas !=0.3.6
+  - cuda-version >=11.2
+  - scipy >=1.0
+  - cudatoolkit >=11.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6339136
+  timestamp: 1740697415775
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.10.1-py311hc59c7be_0.tar.bz2
+  sha256: 4b784353c86d73f10d714c039c29ca73508203cb86a7ce455f71ee52b940edb3
+  md5: a8c1b6256e1d5743bb92d9c467736aa8
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.21,<3
+  - numpy >=1.23.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 202114
+  timestamp: 1730216207054
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-1.26.4-py311h91b6869_0.tar.bz2
+  sha256: 85aa18f7f372d263f1b9a6eed279e0fa048387520bf71b9c409e13801a0568d4
+  md5: c077c784069f04cc487620bcdc7707ea
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.26.4 py311hb3ec012_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11321
+  timestamp: 1708642350281
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-1.26.4-py311hb3ec012_0.tar.bz2
+  sha256: bc050bacb16826ee23329eed65b63c2625884e2af1853f901f7e09870c7dbd1f
+  md5: 96b8308a1bdb2f1e77698ea9fdf96bf3
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311h91b6869_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8784964
+  timestamp: 1708642301649
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
+  sha256: 401214a4763c79c2355b012b9f29e3cee097a598bb53e933acb6b98a2bb6614f
+  md5: 3216c5f433643ee62a8d0672c3500320
+  depends:
+  - libcxx >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.7.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 535252
+  timestamp: 1722872704730
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.16-h184c1cd_0.tar.bz2
+  sha256: abf49ca62b98e297aaef845a9e46b5b634a463a6f89f9a98507bce1c153e37c4
+  md5: ece825c671d4857e0556de45e5a7903f
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4970204
+  timestamp: 1740990032144
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/orc-2.0.1-h5747287_0.tar.bz2
+  sha256: ca2972eb0d95b834238106df2b3bbb6efdb07ea2e9080a718669d8a1dc65f4cd
+  md5: 2fe36bccf7d2d86be813bda00878a7f0
+  depends:
+  - __osx >=10.13
+  - __osx >=10.15
+  - libcxx >=14.0.6
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.10,<2.0a0
+  - tzdata
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 526130
+  timestamp: 1717104747125
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+  sha256: 8a0809f419065e014cb8e2c8a516cadca6088fb71fd1ef3ae2287d91e3360d59
+  md5: 4dc0b9bc88476fcc5246d823ff1c289a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39645
+  timestamp: 1699371213055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.2-py311hecd8cb5_0.tar.bz2
+  sha256: 81f1c12808d6db7c1b26bace7b719fdfd45d7a683e46223c5d4b3843da957c39
+  md5: ec1eed2e438db9d3e9906d30d2ad55d6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 189794
+  timestamp: 1734472374591
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.3-py311h6d0c2b6_0.tar.bz2
+  sha256: 320127675235a15f36cd445ad7366ba64acd939ecd5bec5b6888ef365aed27a7
+  md5: c283b35da322fcba5fe94e69da4df242
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.2,<3
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - matplotlib-base >=3.6.3
+  - html5lib >=1.1
+  - tabulate >=0.9.0
+  - beautifulsoup4 >=4.11.2
+  - sqlalchemy >=2.0.0
+  - python-calamine >=0.1.7
+  - xlrd >=2.0.1
+  - pyqt >=5.15.9
+  - blosc >=1.21.3
+  - xarray >=2022.12.0
+  - pytables >=3.8.0
+  - zstandard >=0.19.0
+  - openpyxl >=3.1.0
+  - s3fs >=2022.11.0
+  - odfpy>=1.4.1
+  - pymysql >=1.0.2
+  - numba >=0.56.4
+  - xlsxwriter >=3.0.5
+  - lxml >=4.9.2
+  - jinja2 >=3.1.2
+  - adbc-driver-postgresql >=0.8.0
+  - adbc-driver-sqlite >=0.8.0
+  - pyarrow >=10.0.1
+  - pyxlsb >=1.0.10
+  - qtpy >=2.3.0
+  - fsspec >=2022.11.0
+  - fastparquet >=2022.12.0
+  - psycopg2 >=2.9.6
+  - scipy >=1.10.0
+  - pyreadstat >=1.2.0
+  - pandas-gbq >=0.19.0
+  - gcsfs >=2022.11.0
+  - dataframe-api-compat >=0.1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17297833
+  timestamp: 1732736229906
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: b3d97ca6739fa4f1766d26e5a7312a98d5b7a501d5b7167885ff9d0e15d09ab4
+  md5: 006b944d84ff0e35a5979f0a98408069
+  depends:
+  - bleach
+  - bokeh >=3.5.0,<3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.1.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing-extensions
+  constrains:
+  - bokeh-fastapi >=0.1.2,<0.2
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24631464
+  timestamp: 1738685246317
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.2.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0639a95fc20308a04d5b1d67b7f8770013a0fb46d2fc605466036f7acbb22061
+  md5: 2c90142d5c3066fe79194fe084808bf6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 272394
+  timestamp: 1734618667545
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/parso-0.8.4-py311hecd8cb5_0.tar.bz2
+  sha256: c204c097bc991a8ba9f459b710a690259c4c3fd44a8550b0f65f2f0a11a80cb4
+  md5: 5ce9f46a387e05dff118a050152880f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 225040
+  timestamp: 1733963549046
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/partd-1.4.2-py311hecd8cb5_0.tar.bz2
+  sha256: 51cb5a4d03b12ea21baf31310a8e6b864021951050b63fb7cdc96f72f5c9b3be
+  md5: 662bb6a1b3eac5da9a075b34d3d218ca
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - pandas >=1.3.0
+  - numpy >= 1.20.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48653
+  timestamp: 1736803596752
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-11.1.0-py311h47bf62f_0.tar.bz2
+  sha256: 34843745b2373e67faf2894f1c36e53c12142a3b07f89eb6178eedef4ca73f70
+  md5: 02f725d8200b6558615e5deb6b0a5331
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.16,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libtiff >=4.5.1,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 973663
+  timestamp: 1738010491802
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-25.0-py311hecd8cb5_0.tar.bz2
+  sha256: d21c0d266e4b68d84517f05a575dd67e49e9a7bcf0f1e6572946a4ffb510fb14
+  md5: a116be2009053c0bc87cd860b332c0c2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2962980
+  timestamp: 1737992964499
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 81719c31101d6c019150cedcc7b08adb3bdb357e8b2952e428dadaabc4dc985d
+  md5: 105825168e0a17fb007f60b5f314e311
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38405
+  timestamp: 1692205731769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.21.0-py311hecd8cb5_0.tar.bz2
+  sha256: 74d50e1d381add9e02e4d4c9b0ae247f1c90bcc544cb622d6bf6c420ad17408d
+  md5: 3059b89ad8f6ed91166c87ef25349ca5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 122986
+  timestamp: 1731958894994
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+  sha256: e32843723b10ecd9badde28e1085419c0b59ed8a96c7cacce6395e39e3a874f9
+  md5: 5af0280a817d2c273304cd22328124af
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763044
+  timestamp: 1704404460779
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h46256e1_1.tar.bz2
+  sha256: d4711400167a76a91b3067d0982d135546e6479a5dcabe4a8087d4f16729b081
+  md5: 8b89db6f3680b3ceddfb37d3489a96e0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 503499
+  timestamp: 1736369694493
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyarrow-19.0.0-py311h6d0c2b6_1.tar.bz2
+  sha256: 3f4f8e83aa4d9f5587c8cf6dbbe65d7e3d9b47a647c2ec26f837d5302b4f905e
+  md5: 22bc3b8bbdff643e7face011b21d0610
+  depends:
+  - arrow-cpp >=19.0.0,<19.0.1.0a0
+  - libcxx >=14.0.6
+  - numpy >=1.19,<3
+  - numpy >=1.23.5,<3
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8220961
+  timestamp: 1738240552396
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyct-0.5.0-py311hecd8cb5_0.tar.bz2
+  sha256: 667b5cf00d31293dede2ddadcc30ab967103d585d40647f34d6d830af97ee51f
+  md5: 81d3876fa502fca91ba4136a5f3fc3d3
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37821
+  timestamp: 1678378977816
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+  sha256: dfb403f367c57327a4d080109df88383ecff18464de287a1ce936a7274e3656b
+  md5: 997b674bad89963af875b93b06807f51
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2120413
+  timestamp: 1684280057020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.2.0-py311hecd8cb5_0.tar.bz2
+  sha256: d91145c8170d70c3343e3c72de9bbd65f18dd868699d5865cfd378027ed1d1e6
+  md5: be4e175b2ddfdde750cdf6f83fb694d0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 487468
+  timestamp: 1731445595709
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 717e038567506ca58ce1cd4a3416892d02f4ebfdd332077cc3d110cfe3d36c58
+  md5: 53bbfb400668f798eef6f8c7cf938e1f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35751
+  timestamp: 1678315886516
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.11-h4d6d9e5_0.tar.bz2
+  sha256: 250c9769e378c2bc583c3c89351d3ea20e363825aa0c72e98a5c6ea3a1934a50
+  md5: bf4aaf980dd4941ab9a2a6e413d36c57
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.15,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.45.3,<4.0a0
+  - tk >=8.6.14,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16867465
+  timestamp: 1733935409990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+  sha256: 04e100d0a1ea9722e24972657ec5935ad34c7c58957dabb821333e5eac80f717
+  md5: 2b6de49ad07b26e1f7084f0fda958eb1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332276
+  timestamp: 1716495830117
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.20.0-py311hecd8cb5_0.tar.bz2
+  sha256: 5f0b041239a0ad2b3888b944efd9cad94e92bcbc91f25eae80a7065c7446379b
+  md5: 0e26c390904343d308b6677403d8a8e5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 282407
+  timestamp: 1731939768586
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-3.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: 2aaaf300f4f747bd82cfb52e2ea8c581fe7a9548384b22e862625a1489f6263c
+  md5: eceb46e8d6370a13fcc8443feb798d47
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29626
+  timestamp: 1734370318805
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-lmdb-1.6.2-py311h6d0c2b6_0.tar.bz2
+  sha256: 950159e48a7d2dfbbea0df7c72b64495acaed0be8b56eafb7b54533c71019d2f
+  md5: 468e79c134e447de88fed8f994b1afae
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 150740
+  timestamp: 1736542444375
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-snappy-0.6.1-py311hcec6c5f_0.tar.bz2
+  sha256: 1f9837d4c967b68a8fd468d3ea1491406ccc1bc85e0704ff04e9130e763c2c7b
+  md5: 5dc10776026d472cf660771f9f1d6b8d
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  - snappy >=1.1.9,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35255
+  timestamp: 1678388804985
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+  sha256: e358fe679e83ccdc8c433746ae6468e8e96d90d97d99530f8476ef5630b2c121
+  md5: ce30a0a31d891e69dc9b7bf8b7f0c39c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 268876
+  timestamp: 1713974360942
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+  sha256: eeb5a5eed93b8e311ad4d3f4389e050f11bba2eaec9536e1c3ed2f849c6c999b
+  md5: c18bd3e12de797d52a470c21a150dffe
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65270
+  timestamp: 1711136914884
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py311h46256e1_0.tar.bz2
+  sha256: eaba8d555ca65df57c5c1dfa320c6b222ddb2c428609a29765ea89179ff05a98
+  md5: 9a926091b8beee27d251241d227a646d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 208392
+  timestamp: 1728659514546
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+  sha256: aa07b90a7ee65f76c8cba1ff99a5cdeb95cbe41881ae951f64ffff06674a1b2d
+  md5: 58621e3d244137885f7dfbb35e50340a
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 594801
+  timestamp: 1709318510622
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/re2-2022.04.01-he9d5cce_0.tar.bz2
+  sha256: c69f556df9a27328c56943f3b5918cbb953cfbca987e20394d823a6174781202
+  md5: ab294ae71ecdfaa307a961cc71dd890d
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-3-Clause
+  size: 205638
+  timestamp: 1652449553607
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+  sha256: d784dc26c5de8e41845350a899e5779250b71f45d39e2aece62e739e9add7308
+  md5: 7b077b7f46112bb31dc066396c51d3fa
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74776
+  timestamp: 1699012164201
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py311hecd8cb5_1.tar.bz2
+  sha256: 022bc34ef458cf0f26cb2e94f3238618e72ca59489efb074d25e5a4700e53707
+  md5: 4f1d626c702cbb79e25aa92375049279
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 124655
+  timestamp: 1730999183404
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+  sha256: 727fb8d957e02d03b928d049ffbc712316f176a2c331391766d646621b45655a
+  md5: 7e0e416c642f3ee4ddfb084a811fb4df
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10236
+  timestamp: 1683077214314
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+  sha256: a8a67143ccb65cfd6f50055176b6c26179a83130a45d0a12e79dd2de68d8db63
+  md5: a2065790f41e3eeb6efe0ef6daa75377
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10600
+  timestamp: 1683059285216
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.22.3-py311h83de92b_0.tar.bz2
+  sha256: e1d5536de94bb0cd3b5d63044e00425b75de36cddde773178f4b96fa223698b9
+  md5: eae729d4ea22b7b1780cdeb7ba1943a0
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - __osx >=10.12
+  license: MIT
+  license_family: MIT
+  size: 370287
+  timestamp: 1736547107420
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scikit-image-0.25.0-py311h6d0c2b6_0.tar.bz2
+  sha256: 549c4710d24f61a263ac4f77df946f5ba9edd802422ca67540290537d080bb42
+  md5: b8ff67585be2a82ec56311dc5a84e088
+  depends:
+  - imageio >=2.33,!=2.35.0
+  - lazy_loader >=0.4
+  - libcxx >=14.0.6
+  - networkx >=3.0
+  - numpy >=1.21,<3
+  - numpy >=1.24,<3
+  - packaging >=21
+  - pillow >=10.1
+  - python >=3.11,<3.12.0a0
+  - scipy >=1.11.2
+  - tifffile >=2022.8.12
+  constrains:
+  - pywavelets >=1.6
+  - dask-core >=2021.1.0,!=2024.8.0
+  - astropy >=5.0
+  - matplotlib-base >=3.7
+  - scikit-learn >=1.2
+  - cloudpickle >=0.2.1
+  - pyamg >=5.2
+  - pooch >=1.6.0
+  license: BSD-3-Clause AND MIT AND BSD-2-Clause
+  license_family: Other
+  size: 12484786
+  timestamp: 1737474697990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/scipy-1.15.1-py311hedc7b93_0.tar.bz2
+  sha256: d9997badc7003cd27cde365f1f0cb4534ba28ce8a3c610857e1157f1958e660f
+  md5: 0c089148a1ad3abbc3be7d6052732a61
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.23.5,<2.5
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 29902677
+  timestamp: 1737126721017
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_1.tar.bz2
+  sha256: b5591b76d1ede877894fecb0f624ab7622ee576e4495d4fbc5cf4698b0e58caa
+  md5: 516af2e9aee8f913abb2d03400b7d010
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33671
+  timestamp: 1736543483460
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-75.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: 7f97e1031cee1f0c13c604c5c1ab591d7458a12aaedeb12857c0768716f70cdc
+  md5: ff42104b98748eeb2ffeaef42c94a2d6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2306558
+  timestamp: 1738046028518
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/snappy-1.2.1-h6d0c2b6_0.tar.bz2
+  sha256: 9eaab5afd89c87ca139915589626785039fac30f05f8fb19e9eefe27eb935ce6
+  md5: babdcd3370f85ded3d313902dcebecfb
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 46224
+  timestamp: 1723557464934
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0eb44a16ef74a13ef7839209899d009cd94974fbc406a417d958c7bc8d955245
+  md5: 41f239a5b67b1daf819849023aa5d12f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19056
+  timestamp: 1705431379885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+  sha256: 14775231982e1ea150189c956927ccfb1ad01a8c9395cdeea4d5a48b9b8ce664
+  md5: 729badc4bf7ba8ccc70e0f9e58075c99
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89812
+  timestamp: 1696347694075
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+  sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
+  md5: 6bef1694163a68ac4c37e5857b8da4f5
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1900191
+  timestamp: 1714488351925
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tbb-2021.8.0-ha357a0b_0.tar.bz2
+  sha256: 6aa547778b31b10db75749c6e7aa380fca6f989c6f05e9435280afd7ab84ac83
+  md5: 61d6251c7fd58a353ebe33d95b8ada33
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 180099
+  timestamp: 1680167277796
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+  sha256: 3d5c2968f581006437df3932cd5d3c1c4afa78f0e13757b958440245d3248856
+  md5: 605ea221d225ad8e79284dbcfdab0715
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37699
+  timestamp: 1678317755913
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tifffile-2024.12.12-py311hecd8cb5_0.tar.bz2
+  sha256: a3d0f4673d35a9f67c18f8352118055cba2a8d63210112a451ee817090e2d24b
+  md5: f893539321e682129018db29bc0e3319
+  depends:
+  - numpy
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - imagecodecs >=2023.8.12
+  - matplotlib-base >=3.3
+  - zarr <3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 522194
+  timestamp: 1734341101049
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.4.0-py311hecd8cb5_0.tar.bz2
+  sha256: 67eb32c950198f88cfd1ab0041a70cadf36c7a9c6256f3351cf5b15be8d1eec3
+  md5: e1ba1b42d2443fab4fb2471b70061529
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 106377
+  timestamp: 1738340071227
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+  sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
+  md5: 523c006cc67c011383678c762015479b
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3594448
+  timestamp: 1714770737885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/toolz-1.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: 10c8ad5f4d84e77b854d2e0f30c20628b47d2233c949011219ffbcc6eaf0c928
+  md5: 7450c3c21275ec3864469064e2db96b9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 138845
+  timestamp: 1736796304528
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.2-py311h46256e1_0.tar.bz2
+  sha256: 926f89ddb422d2868f65532d07637474578c27ddc90ef9202410f075fe310b95
+  md5: 1c4aad6b2e2e721689e4b7f0d24bbd9a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 916363
+  timestamp: 1733960657634
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.67.1-py311h85bffb1_0.tar.bz2
+  sha256: c4bccdf0892c9f8fffe5a968d6e7f73157bd6682d0253b6dc2143db5e60ce094
+  md5: 4397f5d8e2796595937de38fe33be974
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 156244
+  timestamp: 1738946121505
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
+  sha256: 5283f2b23a6e9d888b2834cba2bbf284f551e199d2c1b4add176b1cbafb19ee0
+  md5: 58bf7871ca100fbda0492bb5a3363c80
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 208200
+  timestamp: 1718227205760
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.12.2-py311hecd8cb5_0.tar.bz2
+  sha256: 8022de54a1fbd9c3477536d96ac53f7fd5a32d8746f3993c2bc2bf5c5bcd82ae
+  md5: 3134d7e75b5c6cb1b98c1220bfc2924e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.12.2 py311hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 10063
+  timestamp: 1734714948797
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.12.2-py311hecd8cb5_0.tar.bz2
+  sha256: 1a33aba353b4c72ee219540fbaf361f575c7c6fe0259bfb8c453b9c61320beec
+  md5: b71aa2fc23e5979b7443d52ee91265ee
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 82779
+  timestamp: 1734714943158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+  sha256: a9960485ced319ac91afe69eaaf703c7e6b3049f1e06a4a8c2818b64155943f0
+  md5: 0a9c8ea92a14330a07edabac249e32a9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11399
+  timestamp: 1678394892923
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h46256e1_1.tar.bz2
+  sha256: 413998bdde08eaa50c14a0c8094e3869b6eafdfd81d988ce2674f0df19eaafd3
+  md5: c14444bb7c690c8340ab103941c8486d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 495952
+  timestamp: 1736544621517
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 758bd260523cdf34cb3da3ed57c0855fb9c01af8cd8bfe14a16d7072bc1e6df9
+  md5: 9456f00a26b310b0ca789e0c8441a9c0
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - requests >=2.26.0
+  - zstandard >=0.18.0
+  - selenium >=4.4.3
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 223280
+  timestamp: 1737133805231
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/utf8proc-2.6.1-h6c40b1e_1.tar.bz2
+  sha256: 0f8c3eb254be9c1957e748e385e20e62509d11052990c4755012be62434c9129
+  md5: 53229ba93f6e38308ae42ecfc6eaad9d
+  license: MIT
+  license_family: MIT
+  size: 96768
+  timestamp: 1706894705048
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+  sha256: 597015e8a038a111f03ffbc9a217fcda549d75230c86ce53c1f23c53d6f1a0cb
+  md5: 62e98aac883bccc1c87ca0d2ce2f08e0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25798
+  timestamp: 1678317074170
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: 1430e6f4b4dd9354b7bb88f7f7bc9cdbab26a034ad1ae5c278de0f5a99329372
+  md5: be0832862b29bf5767a707ac6bd53b93
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 114834
+  timestamp: 1715878445060
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.45.1-py311hecd8cb5_0.tar.bz2
+  sha256: 2bcf41c4bd1ad308f98a3b87181f730e617beb578a3322dbdce60adb51ae385e
+  md5: 3d56b8c9c337b4597b474fa423cb704d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 145560
+  timestamp: 1737991669288
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xarray-2024.11.0-py311hecd8cb5_0.tar.bz2
+  sha256: 36a035c94ec8a72e730b43a16b92e3eedfe1d27bb27d13f363df70abe13d9fbf
+  md5: bec65eada309349b7b99f96f01b34c38
+  depends:
+  - numpy >=1.24
+  - packaging >=23.2
+  - pandas >=2.1
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3015266
+  timestamp: 1734536001064
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+  sha256: 5b6d5246955b5f9480ff7027eb002442a7ade24f5c354da54ed513042f76cedc
+  md5: f32aa8a37d5e65a8dc30f9a1f46bc63d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54719
+  timestamp: 1678325412288
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.6.4-h46256e1_1.tar.bz2
+  sha256: c46b5b4e5159739c03830541c7261691d556a897ddabdf1a4024fe40d22bdefe
+  md5: 5a0422426246e10734acfb8dd2b9fac6
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 286200
+  timestamp: 1739468347605
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+  sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
+  md5: c25b6d40f834647d0bbe767f6c776031
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 329449
+  timestamp: 1705602140856
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zict-3.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: e5fd1f8b8e5cc1221e85355ade7b69f0df640dbdc016b7f9ea0b0b6eda5bf9b6
+  md5: 11c4cb55382be5ab89b5c4085510db3b
+  depends:
+  - heapdict
+  - python >=3.11,<3.12.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 103266
+  timestamp: 1695833080541
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zipp-3.21.0-py311hecd8cb5_0.tar.bz2
+  sha256: f2a900ccc2ed67c2a969c0707b58043d2e556c222d22e596611f1549067975b4
+  md5: 1eb3ce37ce16e3db13cad3a7c133878f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 30625
+  timestamp: 1732630910322
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+  sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
+  md5: f2519b551f99765d9d98950c5e2b4713
+  license: Zlib
+  license_family: Other
+  size: 119782
+  timestamp: 1714511811597
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
+  sha256: a1f470eabe211500d2ec7866ecf421c067f159045f0245f19e9ba8272c5a177e
+  md5: f8bd5fb9fac17a47c64ae56355faba24
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1033188
+  timestamp: 1728487057684
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.6.2-py311hca03da5_0.tar.bz2
+  sha256: 8d925b1438e14479c33257054daaf3acab8db996d49fc1f57f9a675569a90493
+  md5: 7277b32d35b11efb43245178c3f99fb4
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.21
+  - trio >=0.26.1
+  license: MIT
+  license_family: MIT
+  size: 245764
+  timestamp: 1729121361882
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+  sha256: 43405cc7341ce3efb2e24013ad62c64f26a69926635adceaa5459ccbcafb3776
+  md5: effa6d22f497e164cc8455f7f329c304
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 12510
+  timestamp: 1677917870614
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_1.tar.bz2
+  sha256: 34eff2dd23f43b16903603d5a629e65d0da4f4c3556bbdc4e81c54ca4f2287b4
+  md5: 1f421ad5db9e7301fb935e6f0328dea2
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 35693
+  timestamp: 1736182683157
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/arrow-cpp-19.0.0-h0b7d223_0.tar.bz2
+  sha256: 095aba3e60c6868f97cac85a92b9167eaa10a1486d94c72486790314fb25d9ab
+  md5: 246ea5eadafa4642efa434b67b080d8d
+  depends:
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - aws-sdk-cpp >=1.11.212,<1.11.213.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.5.0,<0.6.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libcxx >=14.0.6
+  - libgrpc >=1.62.2,<1.63.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.15,<4.0a0
+  - orc >=2.0.1,<2.0.2.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.10,<2.0a0
+  - utf8proc >=2.6.1,<2.9.0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 10182859
+  timestamp: 1738050558936
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-24.3.0-py311hca03da5_0.tar.bz2
+  sha256: b21a439235347e2b0ca4fc059c7be459ef3597a141138dd8ca5004877a1dd86d
+  md5: b5c410a1799c550d53e5f11219819850
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 163887
+  timestamp: 1734533146293
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-auth-0.6.19-h80987f9_0.tar.bz2
+  sha256: f536e8b60bdc895063ca0e0155d2041993caed5f932c232f2a0d8e52798da2f1
+  md5: daacfabaacebe1d1e53426ec3e385d14
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 86757
+  timestamp: 1706746162173
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-cal-0.5.20-h80987f9_0.tar.bz2
+  sha256: c356ce4cbd638a41fd3db59aa3559850e38c6b41188b8ffab32bdcbd9a55fe03
+  md5: e9dc8c248dda95e92533cae6815a0a8b
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 39456
+  timestamp: 1706690903374
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-common-0.8.5-h80987f9_0.tar.bz2
+  sha256: 117825fcff2a68136a6e5183e05542c2654d73322e70daee3c50c0ecb3aec703
+  md5: b115d3f733fe8bae79b9d416754b260e
+  license: Apache-2.0
+  license_family: Apache
+  size: 182078
+  timestamp: 1706189905050
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-compression-0.2.16-h80987f9_0.tar.bz2
+  sha256: 241c19574abcaf91a47fc5c36f38e58c86732be5e06f5170063406098a58639f
+  md5: 3cfc3d38b8fdb25cc2e10e3e370d4106
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18039
+  timestamp: 1706690838125
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-event-stream-0.2.15-h313beb8_0.tar.bz2
+  sha256: d4c60f610e57b35a2962b8cea9911358d1642e0449468fa4967706af88bf5da9
+  md5: fc23856f141fe548afcfc4823881ee19
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 47155
+  timestamp: 1706697259456
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-http-0.6.25-h80987f9_0.tar.bz2
+  sha256: c43ed35f4a64818ae39ca2c3c3652428c15da5e287f6e94254c3df4d6c759fb3
+  md5: 06366f5f8762447babf69804a04b1a69
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-compression >=0.2.16,<0.2.17.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 162746
+  timestamp: 1706744122437
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-io-0.13.10-h80987f9_0.tar.bz2
+  sha256: 14e2ee7339c88089d1ff68f7144b3fb4f9e34fe538a9462f8de31dd6fdd1d42b
+  md5: 59ab0e7ffd73966ec6a2fa83a5df5c47
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 127084
+  timestamp: 1706696174505
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-mqtt-0.7.13-h80987f9_0.tar.bz2
+  sha256: 601baf006d0545ec65566701d99c601cba843e8ac03d80819d4b8bed23d1e5c4
+  md5: 2c98a19d57362cf1fbfec3dda3ea283b
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 61914
+  timestamp: 1706746732665
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-s3-0.1.51-h80987f9_0.tar.bz2
+  sha256: 16809db73ddc3c374ead2c2e9f2221894e2014d3e07ba62d79375cb4de4dfc9d
+  md5: c03f5e3b42bc59bd92db813522cce1aa
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 67560
+  timestamp: 1706747573116
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-c-sdkutils-0.1.6-h80987f9_0.tar.bz2
+  sha256: 293cf6b9dfa727d0e65b383b0e434f8fb26480abd011516171b8652fd363c98e
+  md5: 2df2dd6c43a3b413b438a9ef834d78b0
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 48454
+  timestamp: 1706690816205
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-checksums-0.1.13-h80987f9_0.tar.bz2
+  sha256: 773f7ff1a91af373d27f5c57833aff8912870108ddd94a5280bfdc608effe5e3
+  md5: fad8b095c03774c9d4901db7eda09002
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52142
+  timestamp: 1706192041205
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-crt-cpp-0.18.16-h313beb8_0.tar.bz2
+  sha256: 4efabe18fc312e65a5aac9b2ebe423296cfe702756891978244287ab47881927
+  md5: 5786a8ac037fd0e81e25f52dbc6dc72d
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
+  - aws-c-s3 >=0.1.51,<0.1.52.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 210683
+  timestamp: 1706827608490
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/aws-sdk-cpp-1.11.212-hdd7fb2f_0.tar.bz2
+  sha256: 68b693d97f567999d4bc9ac6bf82576f633f9a4c021fdeee239b39a3db2aacd3
+  md5: 11e3300b8aac284f019e064ef4be1dbd
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - libcurl >=8.1.1,<9.0a0
+  - libcxx >=14.0.6
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4304517
+  timestamp: 1733148748698
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
+  sha256: ae3c6633ed84bac16592b3b756f96ffc577414971014ca9efa498a162588757f
+  md5: ea600f99d012d734f831d1bc00a17661
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 281227
+  timestamp: 1718029919645
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bleach-6.2.0-py311hca03da5_0.tar.bz2
+  sha256: 557a8b96a55bd208098771332ba46454d76f4a864679d1d4cfe9f7533db4eaca
+  md5: c0e11382888896052023f0f8b4ac242a
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings
+  constrains:
+  - tinycss2 >=1.1.0,<1.5
+  license: Apache-2.0
+  license_family: Apache
+  size: 370511
+  timestamp: 1732292237553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.6.2-py311hca03da5_0.tar.bz2
+  sha256: 03c113e9729743913e0d13d2d61e4642578664e252f8534f94b48dd96a8fe4a0
+  md5: 494a9098b5705582fcab49deb98142f5
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5891982
+  timestamp: 1737999258476
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/boost-cpp-1.82.0-h48ca7d4_2.tar.bz2
+  sha256: f1660ecfb8687d74e81a7b00699a8bb4677cbd791d14f50ba517de98e2f187ca
+  md5: 1636fc4b725da8c5e967952a55f3fd80
+  depends:
+  - libboost 1.82.0 h0bc93f9_2
+  - libcxx >=14.0.6
+  license: BSL-1.0
+  license_family: OTHER
+  size: 11780
+  timestamp: 1696762172661
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.4.2-py311hb9f6ed7_0.tar.bz2
+  sha256: db1a051d5329611e3e0fab1ea11b2ec06ae511e6c34935738a701ac2ae2fcf86
+  md5: 14b2ca28694689fa950ae434e4390224
+  depends:
+  - numpy >=1.21,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 135731
+  timestamp: 1731058941306
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_9.tar.bz2
+  sha256: 5c439398dfaf525e3183dd04df18dede76ee247feffe3ca0103d8506b3785cd4
+  md5: 316001829060774b502831c8abf6b634
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 380565
+  timestamp: 1736182939936
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+  sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
+  md5: 56d1386c7f1f338f0d18f82af6525273
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 158748
+  timestamp: 1714510571033
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/c-ares-1.19.1-h80987f9_0.tar.bz2
+  sha256: b0be79290b1df1cf1d07a1a9c3f3a92ae262643a6df3dc10dfbac22a82874dd4
+  md5: 8fdcf1c08eee91fec7eefc22863c816a
+  license: MIT
+  license_family: MIT
+  size: 106550
+  timestamp: 1693902036526
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2025.2.25-hca03da5_0.tar.bz2
+  sha256: ae2f9e468cb736fe9b014ed4fc781a46246877372aa47819795504fb333041fb
+  md5: 021feaf22d802c1ff4fd173e0358b36a
+  license: MPL-2.0
+  license_family: Other
+  size: 140976
+  timestamp: 1740582468706
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2025.1.31-py311hca03da5_0.tar.bz2
+  sha256: 9926704e09bc74e44bd40d9cd97b22307db3206139facabb8f6a4d142738bcf7
+  md5: c7d785ff3ed172470942f4047e65592f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 169691
+  timestamp: 1738624007099
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_1.tar.bz2
+  sha256: 7f00d92fcfb1a24b4c8fcbe695ce117d985ed44a58b294cd9d4d5d2cf513bba1
+  md5: 93179889226fd770fec62ff555acce5f
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 292644
+  timestamp: 1736182914702
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/click-8.1.7-py311hca03da5_0.tar.bz2
+  sha256: df81a27f221d11af4a709f272dc8ba3fd3f6d5ab4ffd883c40567bcf04f0cfd3
+  md5: e49333e3ffe1fe2e701f50a6e6dccc52
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204179
+  timestamp: 1698129906257
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cloudpickle-3.0.0-py311hca03da5_0.tar.bz2
+  sha256: 340739a06e25afcd23ec4c5e5d45ac940feb16bee5122e1d14d261a2c80b5617
+  md5: bd85d021206472f6a6615575f126ed65
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43128
+  timestamp: 1721657439520
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+  sha256: 808e56fb70f3d38599ee7a54c2a707b282ba9a401fa69a1f54cdc26425d9ce01
+  md5: fc37321833175bda4fc5c21afe32db49
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 539588
+  timestamp: 1709758479776
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+  sha256: d9c126d8bcd1c89ea37186c172d6b1f73f45ada60e3ae1790a017b530baa0147
+  md5: f0223aae3d622547f6accb212579c58e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17967
+  timestamp: 1709322909223
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.3.1-py311h48ca7d4_0.tar.bz2
+  sha256: d76cf29e53f303a799da85cd45c5dc65e9d52f050acf9c42ae448b32cb19e3b9
+  md5: 1bd0fdf6a0fcf98ed2e968c7359ddc4d
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 299096
+  timestamp: 1732540161576
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cramjam-2.7.0-py311h62f922a_0.tar.bz2
+  sha256: 1a71c2e15872edff275f419bd1b827c2e37a4cfaf997cd30104cadb2da285a5b
+  md5: e97551b1be62a8bc30eb69e1dfe39191
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1531706
+  timestamp: 1702651054879
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cytoolz-1.0.1-py311h80987f9_0.tar.bz2
+  sha256: 25e3dbcb94956d69c436962f946cb8bd967065553d5457c0e48819beb5e543ac
+  md5: 335939572c2dd4ae231452304f2916fc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - toolz >=0.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 407595
+  timestamp: 1736804012870
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-2024.12.1-py311hca03da5_0.tar.bz2
+  sha256: 90c6b9f147495cff3c6a867db922fcf4a2932e955c8e9738e63a09e7af82fae1
+  md5: c70893ab03d926e9a214fc2add1e32cf
+  depends:
+  - bokeh >=3.1.0
+  - cytoolz >=0.12.0
+  - dask-core 2024.12.1
+  - dask-expr >=1.1,<1.2
+  - distributed 2024.12.1
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.24
+  - pandas >=2.0
+  - pyarrow >=14.0.1
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6497
+  timestamp: 1736873361214
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-core-2024.12.1-py311hca03da5_0.tar.bz2
+  sha256: d2f314a158b163bf063de34bed4113aeb67b5d1851a696835fed2ba541ce58b7
+  md5: f03ff65ee99d66e0e2c8de7d6a08a6ec
+  depends:
+  - click >=8.1
+  - cloudpickle >=3.0.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.4.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3197873
+  timestamp: 1736807559091
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/dask-expr-1.1.21-py311hca03da5_0.tar.bz2
+  sha256: d00e6b836745b3419ec725db7e375b8845a1c965bbb5bc6311a17766773835f4
+  md5: aa62a70ef798893dcc04855ebc5b2c18
+  depends:
+  - dask-core 2024.12.1
+  - pandas >=2
+  - pyarrow >=14.0.1
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 570918
+  timestamp: 1736810460236
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/datashader-0.17.0-py311hca03da5_0.tar.bz2
+  sha256: c046e4f03dd3d60adbd6c83339f727feb6a95fde65f07b6a076d6e28903c19d3
+  md5: 700624c5f2fffff42dc6d22910045ff3
+  depends:
+  - colorcet
+  - multipledispatch
+  - numba
+  - numpy
+  - packaging
+  - pandas <3.0.0
+  - param
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18021016
+  timestamp: 1738336846678
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.8.11-py311h313beb8_0.tar.bz2
+  sha256: a694b8a82ab88f241d100b86586ee802c1d6874e42da4e1bc4fc154df95637f2
+  md5: 39b58c0525acb9a7014bb007aa34ddd1
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2793877
+  timestamp: 1736267724300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/distributed-2024.12.1-py311hca03da5_0.tar.bz2
+  sha256: 18ca8d7be5bd680716b4a15513e88bc0457245baa91a34573bfe8d191e27c385
+  md5: 75616a67cdd9413f1e11f010f382d82b
+  depends:
+  - click >=8.0
+  - cloudpickle >=3.0.0
+  - dask-core 2024.12.1
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.2
+  - packaging >=20.0
+  - psutil >=5.8.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.4.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.11.2
+  - tornado >=6.2.0
+  - urllib3 >=1.26.5
+  - zict >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1820407
+  timestamp: 1736870865648
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+  sha256: b1481ffa475c65200626f051d5dcbdb264730b533e928dde608a79ce7a5b4e48
+  md5: aada2761547a291d68f4c016a1a9bc7b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 18265
+  timestamp: 1677911915719
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fastparquet-2024.2.0-py311hb9f6ed7_0.tar.bz2
+  sha256: 9fc5d69d32d7220004d221f730c50fedfb9d92b12751ed2992ab168dadc85864
+  md5: 5d5095c56297f7a7d0d324b496b23b98
+  depends:
+  - cramjam >=2.3.0
+  - fsspec
+  - numpy >=1.23.5,<2.0a0
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 646867
+  timestamp: 1715262347984
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.55.3-py311h80987f9_0.tar.bz2
+  sha256: 4ade3182f23e3fa0f020a64de5b72069c47ea712d63ce7766dd34ffa79bbc84e
+  md5: a03e83b30ffe4ad197dba8c2e24db857
+  depends:
+  - brotli-python >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - lz4 >=1.7.4.2
+  - fs >=2.2.0,<3
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - zopfli >=0.1.4
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 3245536
+  timestamp: 1737039544546
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fsspec-2024.12.0-py311hca03da5_0.tar.bz2
+  sha256: a5a88a3643a7c41154fe2377afbd65962617712a2d1bb667451526b373558969
+  md5: a8421c47d9cea24f66d6032c8a12c29b
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - pyarrow >=1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 393768
+  timestamp: 1736274786703
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/gflags-2.2.2-h313beb8_1.tar.bz2
+  sha256: 25e05b93a99914a5fd1a298a2c5b25479fbd571b0db9caa7c6ad4336f060f62c
+  md5: e213b68bb0274e0e54c610a041e059f5
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 150168
+  timestamp: 1706888198288
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/glog-0.5.0-h313beb8_1.tar.bz2
+  sha256: bbbcf47ef9249635b5199be1414b0b59687cc04ea9630d50ecc609dc200c095e
+  md5: 5820c373d6847a68551cadb8984a8277
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=14.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 95638
+  timestamp: 1706895270850
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.20.1-py311hca03da5_0.tar.bz2
+  sha256: 89972f3fc0e9cadbbc57018e9f91f5519593461aff3a26f868cafe3ecbecaa17
+  md5: c64fab64771a1dc6c6538d467932798c
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.1
+  constrains:
+  - plotly >=4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6132281
+  timestamp: 1740582883549
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/icu-73.1-h313beb8_0.tar.bz2
+  sha256: ad7719d2bcd4060cc985339d8f17ba2afe0e55fd111e14ea9210aa8ba97b27d3
+  md5: 69eb3b03765627b6159ed23cdde78396
+  depends:
+  - libcxx >=14.0.6
+  license: MIT
+  license_family: MIT
+  size: 28399065
+  timestamp: 1692293207812
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+  sha256: 4d4ab70ae0ce008c1cc96a4edfbf3866d5e636acc4799a545ea93acee51635f7
+  md5: 86a085a440729020d1d7b0b74d6a0c6c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148448
+  timestamp: 1714398923507
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/imageio-2.37.0-py311hca03da5_0.tar.bz2
+  sha256: 059f09774e28cdd37bf51f6410a1cde8b497ec6cca172dc4f22ebbb0e25943d9
+  md5: 0356fc829cf5c3446da583357f7c2627
+  depends:
+  - numpy
+  - pillow >=8.3.2
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 668629
+  timestamp: 1738160418012
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/importlib-metadata-8.5.0-py311hca03da5_0.tar.bz2
+  sha256: a8d59a001bbf14fc1efc7554f026feb8f2ca68aab06146d8fff17b860e38e773
+  md5: 481d195c5f4458e6035fedde8df02dd3
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=3.20
+  license: Apache-2.0
+  license_family: APACHE
+  size: 55400
+  timestamp: 1732633785459
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py311hca03da5_1.tar.bz2
+  sha256: efd30bd378cf4f9c93cf38b00baf432e3ae454106bc8be43ac1b86679489aefc
+  md5: d8bca2c17b359f33f3752f1a6a7042c5
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 238706
+  timestamp: 1737660744568
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.30.0-py311hca03da5_0.tar.bz2
+  sha256: 6520fa19784d319996b26b76afa58631ba1c947941b0b3140cfe812421c99924
+  md5: afdd96e6adde92b303856588dd9562a3
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1639167
+  timestamp: 1734548338159
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.2-py311hca03da5_0.tar.bz2
+  sha256: bc8c88ebbfe7a0a575e5546ca9b02bc6629cf8ed04467d74b921328918852b4a
+  md5: a73b1ed92ff1b9528898c3d09f34889a
+  depends:
+  - parso >=0.8.4,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1192471
+  timestamp: 1733987575145
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.5-py311hca03da5_0.tar.bz2
+  sha256: b011d9c5a510a5952def06c7dbdcb0f943f26088555d854b3578260b85d3ccb1
+  md5: d50f9f0031dc0a710a641919a66bf7a6
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 358998
+  timestamp: 1737760292134
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+  sha256: 9d5cbffa98f3a4391f66b0c5ce1f411f0bfb0eb83137dc7146fb7bae23cb3570
+  md5: 95c92318023482e4e8c698ae6c4597fe
+  license: IJG
+  license_family: Other
+  size: 274078
+  timestamp: 1722872672311
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.23.0-py311hca03da5_0.tar.bz2
+  sha256: 5e1400c72584b88b0ea13d2e66110eb7571f155f8b8d62ede4ca61b8279b8bdc
+  md5: 6924a112e8115ffdb74a5c8840903b84
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 193322
+  timestamp: 1728486773537
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+  sha256: 404b0847029f77bedd7902a170a046219e0dc5c0ec2be19ff45361cff25b2181
+  md5: 3a02bbe8d45fdbcb2350f672be74c9f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16524
+  timestamp: 1699032463763
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+  sha256: 7deb8ad28c34c369573754304a03ea2acda8ee39102a56526ec689a4d9210109
+  md5: 675ea1a746a78ff6bf8fc4b39139efff
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 277400
+  timestamp: 1677914250715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
+  sha256: ceec15c84f5c699b8055d01e046be04ccb7cfd7c8bd090fc18959f2a4d9f8cf8
+  md5: f85c11f7068312e1e84505efef9d55e3
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 98520
+  timestamp: 1718818476094
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
+  sha256: b2f1ee2a297e001a2e70bc218f60deb08c50b9b727668913ed5a106640413d2e
+  md5: fc4e797a17ff5dccadfb5d19346b7800
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43099
+  timestamp: 1718738212629
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
+  sha256: 2d96618ab2e9b3de870a713d7e5b19f6cde936291f3c87972f945b6e27024e77
+  md5: 534159d29d9aba9c7e70ee52c27b326b
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 614003
+  timestamp: 1718827110867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+  sha256: 501e929d345aaa9079c965552b942b4e8bde35b87ae89faef003687a40bab3a4
+  md5: 54c7b8554a405acd7c8326c41ba93e63
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28237
+  timestamp: 1686870817418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+  sha256: 773e7c4571f482a744dfb18ae26fb22635f5d3f51389c838bd97f9044ea55cc4
+  md5: 5161546aba5597318cb5653390cdecd8
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20235
+  timestamp: 1700168681687
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.8-py311h313beb8_0.tar.bz2
+  sha256: 74a9386951df51a0f237e2138ab3823f9256664dc6974ec9b53fd5159355fc67
+  md5: 166d5e5085ac1b21ba04ad7be3054e0e
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 69162
+  timestamp: 1737039690391
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/krb5-1.20.1-hf3e1bf2_1.tar.bz2
+  sha256: 789402b67398d3d936ac4486df01869d59b0e1ba298cbd06407d059aced871e4
+  md5: a0f50a38705d0507bbf57ee49a1d9c29
+  depends:
+  - libedit >=3.1.20221030,<3.2.0a0
+  - libedit >=3.1.20221030,<4.0a0
+  - openssl >=3.0.8,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1308175
+  timestamp: 1686931157327
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lazy_loader-0.4-py311hca03da5_0.tar.bz2
+  sha256: 94f99abc0091e89711698b25275839eb264e370691980d9e37e3a88ccb391f32
+  md5: bc285b4a7c86f2eb254c16bbccf2838d
+  depends:
+  - packaging
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25872
+  timestamp: 1718176805871
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.16-he93ba84_0.tar.bz2
+  sha256: 4b45c39ed7c4267baa88eee55413830c87863c9dee6e8af40e0261aa0fcd9469
+  md5: dfd7325cb25e3e7d0d2c3f77209d12b3
+  depends:
+  - jpeg >=9e,<10a
+  - libtiff >=4.5.1,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 246476
+  timestamp: 1734428527302
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-4.0.0-h313beb8_0.tar.bz2
+  sha256: f123fe7eb47ac10d174364902a64c311b1875f4863b1b3791e6b3fca8e0ab272
+  md5: b62145f1eeed0a89b5d76c3bb9b409d5
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 222115
+  timestamp: 1734423410079
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libabseil-20240116.2-cxx17_h313beb8_0.tar.bz2
+  sha256: 34390ba05b3d56366a2252f095f8bdf2527371854d981550db7485fc8290c10f
+  md5: c8055bc73af0ac231a8b507edc1ff116
+  depends:
+  - libcxx >=14.0.6
+  constrains:
+  - libabseil-static =20240116.2=cxx17*
+  - abseil-cpp =20240116.2
+  license: Apache-2.0
+  license_family: Apache
+  size: 1246977
+  timestamp: 1716563341094
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libboost-1.82.0-h0bc93f9_2.tar.bz2
+  sha256: c1f104bc84ee46a3d3beafb5e35236c64e6b4fd6cceabfb420e1838171b1d9c1
+  md5: 4f95903a1be48bbee1f9a818ec810b89
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=73.1,<74.0a0
+  - libcxx >=14.0.6
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 22243663
+  timestamp: 1696762144385
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_9.tar.bz2
+  sha256: bc3732d108e184da32b682c94421173529842f8b429fd693592575b637707b9b
+  md5: 0e753a927e7ef21b248c739b7846903a
+  license: MIT
+  size: 69063
+  timestamp: 1736182580217
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_9.tar.bz2
+  sha256: cd3149e7fb36e67ae496ff37827870c6822619d09b235e2adc7ba5ce9b33f938
+  md5: ae813d7d06d4672d06fad704b7bd4077
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_9
+  license: MIT
+  size: 33265
+  timestamp: 1736182639925
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_9.tar.bz2
+  sha256: e3a1bd31d21200c8841e7305cf4ac1ed21ef75c72acbdb0412747be7b27069c1
+  md5: 86fd5a04180dbcf27c012d9fe8b01a94
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_9
+  license: MIT
+  size: 310515
+  timestamp: 1736182663109
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcurl-8.12.1-hde089ae_0.tar.bz2
+  sha256: e86c7acc2608c4989908a0fb9da8482d1fa4b8c3172bca6154d61f892a706d21
+  md5: a534f1f1c0eadee0eb4348e183255831
+  depends:
+  - krb5 >=1.20.1,<1.21.0a0
+  - libnghttp2 >=1.57.0
+  - libnghttp2 >=1.57.0,<2.0a0
+  - libssh2 >=1.10.0
+  - libssh2 >=1.11.1,<2.0a0
+  - openssl >=3.0.15,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 412777
+  timestamp: 1739986400565
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.22-h80987f9_0.tar.bz2
+  sha256: 695c939431f7fd074d175e62944daca33ff51f3abfe1ee5c51d92d89ad663da8
+  md5: 8985f8e47c5bd81416ed08c28d7f305a
+  license: MIT
+  license_family: MIT
+  size: 60900
+  timestamp: 1734423344642
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libedit-3.1.20230828-h80987f9_0.tar.bz2
+  sha256: 9597df5344a718d37837966aa05091faf210260898fad5e7a64b87f17de9e90d
+  md5: 678a1f87940ef6cc421a092301b8c3fe
+  depends:
+  - ncurses >=6.4,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 167208
+  timestamp: 1703006281321
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libev-4.33-h1a28f6b_1.tar.bz2
+  sha256: 6fc572025852b210ecddcca3ab9ff3f1d5f6bd91f1933c6e296de6bb331f6b5d
+  md5: 6dd7d9c5737bbd2a27d18f15318dc3e6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 102059
+  timestamp: 1628961869728
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libevent-2.1.12-h02f6b3c_1.tar.bz2
+  sha256: 9e7b9bb9367d8725a751cdfa0b2d270434d303ea196cfaacc605ee26be09874a
+  md5: 44d1843cc2f17eb2674f35b95468f551
+  depends:
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 415467
+  timestamp: 1685052299052
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+  sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
+  md5: f31e4eb9cd6447cc2f5ef0243a76540c
+  license: MIT
+  license_family: MIT
+  size: 120460
+  timestamp: 1714483461787
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgrpc-1.62.2-h62f6fdd_0.tar.bz2
+  sha256: e6e4e402ba9350955e9472f33ae7ce4ed712b6ad38b9b5c532e68bfb02646390
+  md5: f5f2fdfe7750c7757efab6848e873b0c
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libcxx >=14.0.6
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - openssl >=3.0.13,<4.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - grpc-cpp =1.62.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 6756803
+  timestamp: 1716834849823
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libiconv-1.16-h80987f9_3.tar.bz2
+  sha256: 72d242814b990900c9410d4738cc685f70ea71231742293cffbb475d8df100f8
+  md5: f9976688992b7ac4b56f5600ee15b5c4
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  size: 1407202
+  timestamp: 1714483550601
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libllvm15-15.0.7-h97a1cf3_4.tar.bz2
+  sha256: 44965fabbd722807018a5769455c38d552020cd2ebf5a6bf4044d103aded3808
+  md5: 3a217481817fbceaef19d096550cf567
+  depends:
+  - libcxx >=14
+  - libffi >=3.4,<4.0a0
+  - libxml2 >=2.13.1,<2.14.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 28303254
+  timestamp: 1730396980888
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libnghttp2-1.57.0-h62f6fdd_0.tar.bz2
+  sha256: b7cd58ddb892ed9d3983bdde8fc2530f0653a58818c87e08659f3795f04d8aff
+  md5: cf519f7233951d00a30c3b969c4cd161
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - c-ares >=1.7.5
+  - libcxx >=14.0.6
+  - libev >=4.11
+  - libev >=4.33,<4.34.0a0
+  - openssl >=3.0.11,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 728977
+  timestamp: 1697018415626
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libprotobuf-4.25.3-h514c7bf_0.tar.bz2
+  sha256: b628e7b726fc1d77b9b3f8d3078757de8cbc20399a4b0fbdaff6526ba82c4cec
+  md5: a92f039187d790f9d8d507549ef61914
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libcxx >=14.0.6
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2665938
+  timestamp: 1716567699253
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libssh2-1.11.1-h3e2b118_0.tar.bz2
+  sha256: 7a4a378fd967c667ec1ed6db98eb697a92838bbb2a0058d592f4615f70fbc1c7
+  md5: e65d37b5b4b531889526b0995b8589d2
+  depends:
+  - openssl >=3.0.15,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 287605
+  timestamp: 1732891144732
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libthrift-0.15.0-h73c2103_2.tar.bz2
+  sha256: 82a73882a31e7a4f4edcdb0c21562e123da913d03b90b19396bd6dd4fcd9a7fc
+  md5: b5e5199892949d1e7e2db7bf0ee4dfe9
+  depends:
+  - boost-cpp >=1.73
+  - libcxx >=14.0.6
+  - libevent >=2.1.12,<2.1.13.0a0
+  - openssl >=3.0.9,<4.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 361781
+  timestamp: 1687975246139
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-hc9ead59_1.tar.bz2
+  sha256: 209b3214c150026e4de2a962e4a9c26457c3d4f3f113bcb115bd7a5373422827
+  md5: 5624e697d929ac1b10bc3b3a89c1a8be
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.22,<1.23.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 607843
+  timestamp: 1734425782308
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
+  sha256: 479cf759232c2361af87493ecd124e7d3a8940030e42e1931234c35bea73c3bd
+  md5: cd8fe2c981594a457c6af3a0d5de0bd5
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 341817
+  timestamp: 1729160040909
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libxml2-2.13.5-h0b34f26_0.tar.bz2
+  sha256: 3206ddc0d980175fb1a9d0ed98dbf796d772b8b86420bfb9607fd45fbbd64967
+  md5: a7a5c90bb4bdd73eb73bae909eb019a1
+  depends:
+  - icu >=73.1,<74.0a0
+  - libiconv >=1.16,<2.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 620378
+  timestamp: 1732316106513
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+  sha256: 41c62a460bb81a1a272aa28b219fab9c26510adac177ff1528b1980eabc6e868
+  md5: 8d312c5628dc7ea833e9b4dcb73e9c45
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 42346
+  timestamp: 1677973051421
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvmlite-0.44.0-py311h313beb8_0.tar.bz2
+  sha256: 41c772afe07d7b30984e86a8dc2ef96090912274c6151f9cbc705a496c2a1520
+  md5: eac34b484107dda971b34bcf76cf25bd
+  depends:
+  - libcxx >=14.0.6
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 466619
+  timestamp: 1738678667984
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/locket-1.0.0-py311hca03da5_0.tar.bz2
+  sha256: 5777bbef827f72975a36f3da80ab4af718dc781264f74ad7e3864755d620c0f0
+  md5: 4240f1a79b812387919cc710a0469556
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14318
+  timestamp: 1677925438733
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-4.3.2-py311h80987f9_1.tar.bz2
+  sha256: 67dc10bca7950eb27c053102e172d8ffe13d647f9d2830a29ceb8ccd5a885787
+  md5: c8c425327e5ba64d2782abf7b2e31ae6
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40689
+  timestamp: 1736367162985
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+  sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
+  md5: f5f7e6e7541d8dc3d3df270d488d2e24
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176990
+  timestamp: 1714510588159
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+  sha256: d024f5142416961a5e66e424d4d14aec652f9e9dd738b41a97f45674c2ffc9d5
+  md5: 0e2d94b125d802f7b006cf19c71655a1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 163084
+  timestamp: 1677932947966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+  sha256: acfd84e29ff4dc2d85543bb973a07f22b4ba53c5d00bca84608ee7f13b2a8676
+  md5: 5ca161cd51e2db358e768453b3ee485e
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135871
+  timestamp: 1684279980293
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-3.0.2-py311h80987f9_0.tar.bz2
+  sha256: c7dbf6b43ddc196da705430e42fb2902e72ab90584ccd93ca6610d1023812daf
+  md5: 36587635282a895de9aeb24a85b22621
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29283
+  timestamp: 1738584124483
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.10.0-py311h7ef442a_0.tar.bz2
+  sha256: 012a1113fd728eaca513b2f71d3be101e8b5a600b8c749822f323eb2675ba3d8
+  md5: 9dddca88e71c2b941a6555b09e4b0a67
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23,<3.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9718053
+  timestamp: 1736278806782
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+  sha256: 3276d61fc353c537bb09d4b7473d7abe12be38806f42c8cc383b62f40850a5cc
+  md5: 6e9c9d47f264b77d9a8461f0899848a7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20446
+  timestamp: 1677918370379
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+  sha256: 43c96d30775b61b4968422a47f9605049428120669f0742bbb9e5ba145c7d11e
+  md5: a31ca0d9284860adf5463cf45a5e3145
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 69243
+  timestamp: 1677995336989
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+  sha256: 96d8c9f42a38651b7bafe5f3cb132601db76cd1e28fa58e2eaf090e634292fff
+  md5: 5ebc793a17b6aa84d13f19433545ffa5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23895
+  timestamp: 1677942274932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+  sha256: db9bd659ada23f1ded443d2db00dd13b5d5c0b30f5062544b1ee2c2b88d63d29
+  md5: 03c48121614cf12abfe30eced9b34717
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105333
+  timestamp: 1677916687032
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/msgpack-python-1.0.3-py311h48ca7d4_0.tar.bz2
+  sha256: 3e370e88a51671f87fa0c0e241569950f8c5a38d5e8743c33b0193f54d73d10d
+  md5: dd70eac354c92710ce4e2be9d4b02043
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 38448
+  timestamp: 1677909415759
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/multipledispatch-0.6.0-py311hca03da5_0.tar.bz2
+  sha256: 8b05894fdcbe5cfcdee94812b043de4cd7b4fa51d3e2aad25fc7cff50c8f82ab
+  md5: c970d49137dce1c77f782ee5725950c1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 30745
+  timestamp: 1677960816849
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
+  sha256: b6fa12e4bde747bf288bda31ce8ec5e24292dbf74fde67f18f9c9c100b845a38
+  md5: 2eddc760c15171a1e8aa838d9d162e18
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8291605
+  timestamp: 1717622676584
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+  sha256: e8eee27fb667aa10b26f3bc4b93f449b7d991ded27b9cb457effee394ce05f6f
+  md5: 6a3e5cd0e1141c01ffb91285bdccfe83
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123043
+  timestamp: 1698934328890
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.4-py311hca03da5_0.tar.bz2
+  sha256: 1f6d171443b30990cd724ef1e5fa287311d1cf9064c0f5984e6acb2225a0197c
+  md5: 9a8675276a35db6cc6649f0bddecf53d
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - pyqtwebengine >=5.15
+  - tornado >=6.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 531141
+  timestamp: 1728049778343
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py311hca03da5_0.tar.bz2
+  sha256: ae983360f1f69987f0fb3a8de9767b362dc903a9b0b130d87fcfcca445dddc4b
+  md5: f56cbcd18632f7f669a28363c6d3fe4e
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 171380
+  timestamp: 1728049515633
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+  sha256: 417ace1ce51e81f3f92ddc26e0e3a83c1e19c9ebb7af7104452002a5573da534
+  md5: 3e11de6cef096091bb733e07802f00b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16979
+  timestamp: 1708532698253
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/networkx-3.4.2-py311hca03da5_0.tar.bz2
+  sha256: 001df280146368c5498b90d291370d577125e7bb7e0de4407fd6dba7ffe49e80
+  md5: b9f8846ccd65ab0933991dba4bac2300
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - pydot >=3.0.1
+  - pandas >=2.0
+  - pygraphviz >=1.14
+  - numpy >=1.24
+  - sympy >=1.10
+  - lxml >=4.6
+  - scipy >=1.10,!=1.11.0,!=1.11.1
+  - matplotlib-base >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3411023
+  timestamp: 1737040521924
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
+  sha256: 8ea1be4285e2e7d361cbcc1daf9c220f87ceaab2308bf7b339d2513d6ea22184
+  md5: 774ce02efa90f212023541c0b24e92c1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 726598
+  timestamp: 1717630964815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+  sha256: b0cc542e2a6f42ba716e7e4ccf29eddcb155ad167fcdbc72d2db9c7873eb5639
+  md5: 7acf81b17d2c4ceb3cd39dc9f173855c
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27539
+  timestamp: 1699455954000
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numba-0.61.0-py311h313beb8_1.tar.bz2
+  sha256: 633930dd9cc4a30518cd826e3eeee7e4f12ca59089d830831ee8a13526361d04
+  md5: 774e0cdb37128a0298deb43880eb0e90
+  depends:
+  - libcxx >=14.0.6
+  - llvm-openmp >=14.0.6
+  - llvmlite >=0.44.0,<0.45.0a0
+  - numpy >=1.21,<3
+  - numpy >=1.24,<2.2,!=2.0.1
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  constrains:
+  - cudatoolkit >=11.2
+  - cuda-version >=11.2
+  - tbb >=2021.6,<2022
+  - scipy >=1.0
+  - cuda-python >=11.6
+  - numba-rvsdg 0.0.*
+  - libopenblas >=0.3.18, !=0.3.20
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6294931
+  timestamp: 1740669484935
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.10.1-py311h5d9532f_0.tar.bz2
+  sha256: e7085ecdcbb7814ab5b588399963d6877083cbcbce27407b5ded3c099af1e6a9
+  md5: b656e9369b00f6f0eec85203e35eaa42
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.21,<3
+  - numpy >=1.23.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 189479
+  timestamp: 1730216150682
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-1.26.4-py311he598dae_0.tar.bz2
+  sha256: d3bb1d4be88320a5861cd3a0f086e9709f9b64c96c032cb9039cc4f17ec66a85
+  md5: 0a7b97665c06fcd34a70e34abc177280
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 1.26.4 py311hfbfe69c_0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11288
+  timestamp: 1708639168951
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-1.26.4-py311hfbfe69c_0.tar.bz2
+  sha256: 3e70248a7069ca12ccf56252869bfdb72211fd4e4c327e6994756496df786c79
+  md5: ce4846006d98638cd86a532a72f8dfe4
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - numpy 1.26.4 py311he598dae_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7536860
+  timestamp: 1708639153133
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
+  sha256: b9f781280f49644ca05e18aacbdde1c57cc5107e7cc2471b843ea8461672aa7f
+  md5: 9125d30e4e105b45f7f7d9c20acafa10
+  depends:
+  - libcxx >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.7.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 450131
+  timestamp: 1722872679313
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.16-h02f6b3c_0.tar.bz2
+  sha256: 0e5520f848ed0192a5d7320fd57bcb7f4a3281dbb55f80c2642855c86b865d6f
+  md5: 145f3f48ff6d4d0811ea4737b6156c57
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4772692
+  timestamp: 1740990210047
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/orc-2.0.1-h937ddfc_0.tar.bz2
+  sha256: 504f44b8b91a085a34fc2674ecfc8e617108cf1fa3484a2e24bed7e16e40679a
+  md5: 837ad487be774903686ba041dfad8795
+  depends:
+  - libcxx >=14.0.6
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.10,<2.0a0
+  - tzdata
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 505018
+  timestamp: 1717104635074
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+  sha256: 77b0c0a0fb14d817390244ebd93c36d44a7867239963f211f7c0a72a3f98d382
+  md5: b90336feb8a50d2eff880e89acb02f40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39617
+  timestamp: 1699371253760
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.2-py311hca03da5_0.tar.bz2
+  sha256: 7e81c844126506e5e9a3245f094bfb83d7a7e8b108757551ba2cdc9c81602357
+  md5: 40ead0e0477f2925e2a333f79f5d8511
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 190184
+  timestamp: 1734472332475
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.3-py311hcf29cfe_0.tar.bz2
+  sha256: 9d1b4942a2e900c2ce21b4c5d1b7cbb352aad96480b8a5e54c8de3f3ef158143
+  md5: 174139c81708a96f152437fcdc06fca8
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.2,<3
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - pyreadstat >=1.2.0
+  - scipy >=1.10.0
+  - fsspec >=2022.11.0
+  - adbc-driver-postgresql >=0.8.0
+  - pymysql >=1.0.2
+  - openpyxl >=3.1.0
+  - jinja2 >=3.1.2
+  - numba >=0.56.4
+  - pyqt >=5.15.9
+  - sqlalchemy >=2.0.0
+  - zstandard >=0.19.0
+  - dataframe-api-compat >=0.1.7
+  - s3fs >=2022.11.0
+  - adbc-driver-sqlite >=0.8.0
+  - html5lib >=1.1
+  - fastparquet >=2022.12.0
+  - odfpy>=1.4.1
+  - xarray >=2022.12.0
+  - psycopg2 >=2.9.6
+  - xlrd >=2.0.1
+  - matplotlib-base >=3.6.3
+  - python-calamine >=0.1.7
+  - blosc >=1.21.3
+  - lxml >=4.9.2
+  - gcsfs >=2022.11.0
+  - tabulate >=0.9.0
+  - xlsxwriter >=3.0.5
+  - qtpy >=2.3.0
+  - pyxlsb >=1.0.10
+  - pandas-gbq >=0.19.0
+  - pyarrow >=10.0.1
+  - beautifulsoup4 >=4.11.2
+  - pytables >=3.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17075464
+  timestamp: 1732735585667
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.6.0-py311hca03da5_0.tar.bz2
+  sha256: 062ec8cc22edcc5ec5e826b12b931b3b9957796adb10cca5df4b6318f6d0d30c
+  md5: bbb5a8cf9e15cfa329ac40c6047a51ca
+  depends:
+  - bleach
+  - bokeh >=3.5.0,<3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.1.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing-extensions
+  constrains:
+  - holoviews >=1.18.0
+  - bokeh-fastapi >=0.1.2,<0.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24523710
+  timestamp: 1738685269734
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.2.0-py311hca03da5_0.tar.bz2
+  sha256: 00a71c24e865b2a60d7aac81508c1c7144a73d7611961214c562eaf270286ff8
+  md5: 0fbf4531ff5194c1df47533fcafeec6a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269736
+  timestamp: 1734618675560
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/parso-0.8.4-py311hca03da5_0.tar.bz2
+  sha256: d4507aa0fe135a06d918e4217eb89bf2de87574b36ae0fbcc5e0568e10daf1f9
+  md5: 379218d52b3715c7664153dd035ebc8a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 224689
+  timestamp: 1733963346031
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/partd-1.4.2-py311hca03da5_0.tar.bz2
+  sha256: 08be6374b43337eb2fc2967ff857c0eadf3d1f9011a3600c91358c5981e12eba
+  md5: 01ae0890cb887eb40cf7b0afb801c9d2
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.20.0
+  - pandas >=1.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48726
+  timestamp: 1736803522790
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-11.1.0-py311h84e58ab_0.tar.bz2
+  sha256: 268d62303973a28dba8c3f157b2d0c40eecb96f44f6f5ec06de80cfd3e953df8
+  md5: f68870d51e021bcccbd4a9b73e5fde75
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.16,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libtiff >=4.5.1,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 949008
+  timestamp: 1738010498978
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-25.0-py311hca03da5_0.tar.bz2
+  sha256: cae74ef635708b34f06499fc6cc7902167bc20c98877d754cb67e2039e477f5a
+  md5: 12f0b64141739b5d08e0cd17017e9c0a
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2978195
+  timestamp: 1737992144489
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+  sha256: b6200816d65673aa1707c20a768c9cff87dd8dbe1335f9c1478e5931dfa08ee0
+  md5: 14b1e0fa73eb33f9c83048482dcce57b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38423
+  timestamp: 1692205689597
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.21.0-py311hca03da5_0.tar.bz2
+  sha256: 16e6ef97591f7833c9cd8f2f369812ac62a13e9241b1e8d605932a8da92c2df1
+  md5: fa273fbe5dbea433b860c4b89dad0184
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 123030
+  timestamp: 1731958853048
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+  sha256: 07cfba50d9e94364bde077731a824ca4f537138b35ee6b66d07aee16ac9850f1
+  md5: 919bf486280a11e6acb3c2c3a82f7473
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763225
+  timestamp: 1704404463402
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_1.tar.bz2
+  sha256: a6d24cb3a6a50bcb52a37548ce3d4d2ee58b8d23403bc7f63018b184263c5968
+  md5: d8201518af79a2d79e517846e9f68872
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 500255
+  timestamp: 1736367725875
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyarrow-19.0.0-py311h313beb8_1.tar.bz2
+  sha256: 45b8c541a82ec173a7f9b31c8726220e703c7d5b119007a9029c37df10f1df01
+  md5: 18dc5e5c8728ee4a7a63fe6b4344ce78
+  depends:
+  - arrow-cpp >=19.0.0,<19.0.1.0a0
+  - libcxx >=14.0.6
+  - numpy >=1.19,<3
+  - numpy >=1.23.5,<3
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8059807
+  timestamp: 1738233813674
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyct-0.5.0-py311hca03da5_0.tar.bz2
+  sha256: 4f17f70658e32a9a86661184cace6be3bb7bd61f9b55b513092beddf44552679
+  md5: 0aa95279688b0433badea0b660ac8146
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38653
+  timestamp: 1677933613643
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+  sha256: 121b5b66721760c05f1d4eee91626229d1814663d3fb5f23126ef870aa496e26
+  md5: 0c588c2ca790a05d422c06e8568201ad
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2124200
+  timestamp: 1684280082141
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.2.0-py311hca03da5_0.tar.bz2
+  sha256: 86cd1c9d1c73f7dac9f3038d16ac2d6952d42bda57d4da52b18c8561d2901082
+  md5: fe581970af66b493353b9dcdb6bf572f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 487783
+  timestamp: 1731445552436
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+  sha256: 0bb3d2a57b332c5cf73ea40ea13c850ae24a1f9a3a41ed9267832d9e3c767572
+  md5: 45a7fcf1641980d5114999736428502d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36755
+  timestamp: 1677906514270
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.11-hb885b13_0.tar.bz2
+  sha256: 8359c229ad74991a35ad4e9cd24223a8102b10e2647624965b29a0bce4f88a31
+  md5: 70344859c29c4298141767a093918a61
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.15,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.45.3,<4.0a0
+  - tk >=8.6.14,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16479225
+  timestamp: 1733934794096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+  sha256: c3cbf5bd237b0a7458640191016b2701fe120c547df9afc835da76663a9c17f7
+  md5: 843568c76b6b9384635b7fca74c79792
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332222
+  timestamp: 1716495881101
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.20.0-py311hca03da5_0.tar.bz2
+  sha256: 9c37d0d46f2e1930d0efc33f5ae7f9b6ba72f835a1b8b4311ec76953a796fe8f
+  md5: 59292a5980e93058c2b8700c4680fb62
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 282469
+  timestamp: 1731939575445
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-3.2.1-py311hca03da5_0.tar.bz2
+  sha256: e836037601159fe5cd5cf2fa5b818bb4b9a9465f8b0753e78c1b5e809b052627
+  md5: fcdab3a23d5db6e00399f5f66dd2bb27
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29575
+  timestamp: 1734370349925
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-lmdb-1.6.2-py311h313beb8_0.tar.bz2
+  sha256: 75827145ef7b39aa197dbe00569a7966b8cb3e5fa3b93069c734f6e73aad79d1
+  md5: d0185d9b609dde82f3c9cc5a9d7e919c
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 147887
+  timestamp: 1736541232523
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-snappy-0.6.1-py311h313beb8_0.tar.bz2
+  sha256: 34f174914e9854c27ae0bd904bf848f50b9760eca6cc8c3ec70666eb3a6e69ad
+  md5: 898e47ec7bd4461989be61181d1e7b1a
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  - snappy >=1.1.9,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37310
+  timestamp: 1677954185139
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+  sha256: d945744eb133f19ca61325cac5128bdb053ae04de4a0ba6f69c061449cac8af7
+  md5: 34baa81490d667381bc7021435b0e1f2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 275858
+  timestamp: 1713974457562
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+  sha256: 012585bdb5ae54c2cded50be703734e6dbf418b003635b6f6d7c1e36e7020c30
+  md5: da7e99a707bd0cfa20db651b5c068bfd
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65556
+  timestamp: 1711136890180
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.2-py311h80987f9_0.tar.bz2
+  sha256: 8d6910a02d0a30dabb40104565c0c74531aafd4c959431ddbfde47ef52f4c83c
+  md5: b1619588c95cb65375af1d2eb448ecc8
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 205890
+  timestamp: 1728658038659
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+  sha256: ae8cdd5be5a7ad19ff82925a035859fafcc5942cd3899d127a508dbb9a235090
+  md5: 252a7b997d08bf72f10b3bc2dc68333e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 580346
+  timestamp: 1709318480624
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/re2-2022.04.01-hc377ac9_0.tar.bz2
+  sha256: 089c6b9bebfa690f380710f219ab0fcc1acec9f2e187d4174a08222c45f58afc
+  md5: 11b832c6c10a6d2b0e687a20c3037c97
+  depends:
+  - libcxx >=12.0.0
+  license: BSD-3-Clause
+  size: 194532
+  timestamp: 1652449531448
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+  sha256: 7a208abc002a2fc208ae25cb2cf932999a3e4980aa4c9edff315cb9ac62b12ce
+  md5: bd22ebd3cff811577ea61f115ba7f4f2
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74744
+  timestamp: 1699012126255
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py311hca03da5_1.tar.bz2
+  sha256: 4cefdf48ebab7544252ce5f4274b5b86f8107e5af556bf387445a2eb4d42449c
+  md5: 482973b9a55bd1a4cdc33c557a6afb29
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 124539
+  timestamp: 1730999249799
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+  sha256: 52368d9b557b8f54ef5ca4bf6cd5a3ec665171f2b2d2082cdd410bab88f4829c
+  md5: ac76fb4d2eef3ecdd491cf5d3fb8620d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10204
+  timestamp: 1683077239143
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+  sha256: 491d116c5f54ef340e3bce631835f7138cd1923d7b63e6ca9aa01b48110cb8f9
+  md5: 9b81bd8ea808704f5433884b567f1f15
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10557
+  timestamp: 1683059079547
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.22.3-py311h2aea54e_0.tar.bz2
+  sha256: 0ff3bdce4c3932f756e3ac0b5a1e458ad61f20111c96087e3066f3d166d12290
+  md5: cc04229f5e9e579cff0945419b4ca798
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 376794
+  timestamp: 1736542667988
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scikit-image-0.25.0-py311h313beb8_0.tar.bz2
+  sha256: 0ad857cd9489c8c73fd3fcbd861076672f1950393af51e0bb3523ad5195c1774
+  md5: 7a552bb46ab2be010e71856e3cf45e18
+  depends:
+  - imageio >=2.33,!=2.35.0
+  - lazy_loader >=0.4
+  - libcxx >=14.0.6
+  - networkx >=3.0
+  - numpy >=1.21,<3
+  - numpy >=1.24,<3
+  - packaging >=21
+  - pillow >=10.1
+  - python >=3.11,<3.12.0a0
+  - scipy >=1.11.2
+  - tifffile >=2022.8.12
+  constrains:
+  - pyamg >=5.2
+  - pooch >=1.6.0
+  - dask-core >=2021.1.0,!=2024.8.0
+  - pywavelets >=1.6
+  - matplotlib-base >=3.7
+  - scikit-learn >=1.2
+  - cloudpickle >=0.2.1
+  - astropy >=5.0
+  license: BSD-3-Clause AND MIT AND BSD-2-Clause
+  license_family: Other
+  size: 12365296
+  timestamp: 1737474705666
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/scipy-1.15.1-py311hac8794a_0.tar.bz2
+  sha256: cc0c2c076f95d897365d87658e1cc396707316a48beeccafc5f726d839fb6204
+  md5: 3195a0e3a04449f0c084262144766126
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  - libgfortran5 >=11.3.0
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.23.5,<2.5
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 28080933
+  timestamp: 1737123647830
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_1.tar.bz2
+  sha256: f3abf394e08b2ba5707fe3795a0c2d961eef72adcbd3ce09950549adf21adbc3
+  md5: d833b8f097cdfd5cd0c1854799a28e2c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33750
+  timestamp: 1736541523525
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-75.8.0-py311hca03da5_0.tar.bz2
+  sha256: e70923770836d29267082fd2a2be124e970ef3ef2c0ecf8a30ec40ffcbc060cb
+  md5: 48e0878b5cd23e17f09d0c3022c93464
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2295198
+  timestamp: 1738046002051
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/snappy-1.2.1-h313beb8_0.tar.bz2
+  sha256: 499623019bea7cd167924f7fa841237b11b81a1e9cafe9b8ffde47d329275167
+  md5: 290d04cffc69bf26a4ed9f1aa9ad42e4
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 46038
+  timestamp: 1723557442909
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+  sha256: cd71091a234874d2826fa063ec5222b3191c9f47e1b5281c352d9df3f31a06bf
+  md5: 0db8e29016c6bff026c083d9923a7566
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19073
+  timestamp: 1705431415504
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+  sha256: 3e18cdafc607c6d7623b1c8f041cbfbb50a27e298f961abdcce7e36834ac39e1
+  md5: 9ee0da74c55d0b8d83edf246fd717f20
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89862
+  timestamp: 1696347657368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+  sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
+  md5: d8c1e9910392d0bcb22a173f9ce30fa6
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1758290
+  timestamp: 1714488307689
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tbb-2021.8.0-h48ca7d4_0.tar.bz2
+  sha256: f0fd1997d10353ebfd4da51796404c37acd69a5da353f275557cdb895b4d98cd
+  md5: ae58720a18a2ed15eae214ad7a10d1b5
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 140125
+  timestamp: 1680167256603
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+  sha256: b5c265e9ed9a1ff2238a09b83bdc1826950faa87fd6b685debe60888de6e7a50
+  md5: 5827c8a32317894ce18576e334daba47
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38559
+  timestamp: 1677918962258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tifffile-2024.12.12-py311hca03da5_0.tar.bz2
+  sha256: 3c2272c779e109914cde5b210d1aae99726882836143a4d84892efd27e93647f
+  md5: 5deb1e0e6300c71dcb0f59bcd80ab553
+  depends:
+  - numpy
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - matplotlib-base >=3.3
+  - imagecodecs >=2023.8.12
+  - zarr <3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 532469
+  timestamp: 1734340979736
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.4.0-py311hca03da5_0.tar.bz2
+  sha256: 27c47f3396dda92e5d3fee80e8acdb5d4fbc29a92aedb86a5829b298ee28aab6
+  md5: 62dfbd4be598cd4de58d60e287e07f0d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 106596
+  timestamp: 1738338664624
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+  sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
+  md5: 3c25b4f4768ccda28b20a03ba27e7759
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3484151
+  timestamp: 1714770744982
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/toolz-1.0.0-py311hca03da5_0.tar.bz2
+  sha256: 6eaff36e2bab2334f333300606d86016ec407e9f93992e5ce358110a40c6e9a5
+  md5: 879b2084cd1fc57ba22ee032a78258b6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 138878
+  timestamp: 1736796390598
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.2-py311h80987f9_0.tar.bz2
+  sha256: cf80ec43ca8cd5066bb4b673815b3ee0d81cba428d8cde5fdad2b275e8e2a192
+  md5: d481b72f67890c155e69c27b0e723391
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 915674
+  timestamp: 1733960659590
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.67.1-py311hb6e6a13_0.tar.bz2
+  sha256: 3dc5b1bd8c934d0ad1c42b396ab657e1a57b3a3fac66c3920ae86015f252e6a4
+  md5: 274eade660e7298d61514b9ce5d01b4d
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 156442
+  timestamp: 1738943824585
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
+  sha256: 707e5dfdb9116f31bc1ad7f497f6e8416683add460258fdc2a4c16eec85226be
+  md5: ffb602322a388ec8e1f385edaca3ce12
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 208171
+  timestamp: 1718227091374
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.12.2-py311hca03da5_0.tar.bz2
+  sha256: 76bfd11a14fed1c680f48ab1d85cfab450f28798b393949c7be3932fb124d6a0
+  md5: e2d3691e6d2d812b68b13c7ac3086a67
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.12.2 py311hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9928
+  timestamp: 1734715032666
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.12.2-py311hca03da5_0.tar.bz2
+  sha256: 6ed1e28c504268da2e42490301a1c0bad8b7f9261693d457233f675b3f5d9387
+  md5: a25a484145929656f3e0c6acda51117a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 82601
+  timestamp: 1734715026245
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+  sha256: 2ea2d0520b330d381a2ab241bdb9ae146ef815ee7c96ee52a9773fb9ae85f4fd
+  md5: 66f7f8979cfb2cccffac972d70482130
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 12614
+  timestamp: 1677963554857
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_1.tar.bz2
+  sha256: 56850724b394276c479065dd01d3923d3b1dc97079338d1d1ef860383aa87cc4
+  md5: 17ccacc9e9c00ab86010677b96eebd8b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 518188
+  timestamp: 1736541828170
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.3.0-py311hca03da5_0.tar.bz2
+  sha256: b156de384e10e5bab7ecb95aec2ef4e0887ed1b5ed1891f1157e6824848169d7
+  md5: baf5f98abd611c5f5d9eadd590633111
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - requests >=2.26.0
+  - h2 >=4,<5
+  - selenium >=4.4.3
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 223300
+  timestamp: 1737133804463
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/utf8proc-2.6.1-h80987f9_1.tar.bz2
+  sha256: 20ae100fd04de16356f26e7c9dab514015e57a9d54fb78767aa5ed97de7846fb
+  md5: f620d98b3d0072945948310c86f0f1c5
+  license: MIT
+  license_family: MIT
+  size: 157385
+  timestamp: 1706894678643
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+  sha256: 09738b7f9075386bf062b12ddb6fb72a06450d2481f6b5ca2026c811cd849569
+  md5: 9afdec076c95746ac21235f971190e40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26727
+  timestamp: 1677910175964
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+  sha256: b4ced7366de8eb7258f31d516616e70c62ed4a798780e57e208509d2b52ab435
+  md5: 65a9a05a726734c1da667f9bd3c78c14
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 114733
+  timestamp: 1715878377412
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.45.1-py311hca03da5_0.tar.bz2
+  sha256: 44c924d2a032a0672d84aefb68b407fa52912555fc15fb7724ed651804aa5471
+  md5: 9ab5e101cd19fdec87c3e527ea1d181c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 145595
+  timestamp: 1737990528158
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xarray-2024.11.0-py311hca03da5_0.tar.bz2
+  sha256: 9552f12a85ea98f23169aceed20685ef94095113ea08e3263f1593ffd444956f
+  md5: 766697fe41abe6e6cca6d5f25d7b09b2
+  depends:
+  - numpy >=1.24
+  - packaging >=23.2
+  - pandas >=2.1
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3027679
+  timestamp: 1734535815327
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+  sha256: 2cd108896df65636769e3804ecc2ca421ad9b54e64fa21922bbabe40c90c247a
+  md5: b3a1e5077b28f71298d891fbfb5ff03e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55645
+  timestamp: 1677927459979
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.6.4-h80987f9_1.tar.bz2
+  sha256: e2d31c8ee56686f97a58dd6d924f7901c974e67bb14678c53784160f088d77ec
+  md5: d0c14075bc4b6014b3158d434d57820b
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 285627
+  timestamp: 1739468310111
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+  sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
+  md5: 3d57d1adadca9388aaaa1c529b65ba65
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 322790
+  timestamp: 1705602163804
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zict-3.0.0-py311hca03da5_0.tar.bz2
+  sha256: db7fb95af4702cb2ce5281333fa769006f532bc39e8e5bd580a2eb9970a7a38d
+  md5: 2c13d5a0b62ff7a644a6957829dc54a6
+  depends:
+  - heapdict
+  - python >=3.11,<3.12.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 103248
+  timestamp: 1695832909752
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zipp-3.21.0-py311hca03da5_0.tar.bz2
+  sha256: 5a0b82126f14ccd93001175781c4f95b58aa201395652ee5af6a73ccbc380d0f
+  md5: 386dfaab7f4727fef089e98e07935f25
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 30617
+  timestamp: 1732630794687
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+  sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
+  md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
+  license: Zlib
+  license_family: Other
+  size: 104928
+  timestamp: 1714510936868
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
+  sha256: 43667132ec8fa4c34ba438e13a01b08073e3e3e8a648ecdb6afe4141a7c197e2
+  md5: fb8c3f5683b19dd3743d125797b8e2dd
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 817614
+  timestamp: 1728486986031
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.6.2-py311haa95532_0.tar.bz2
+  sha256: 6fbb6b2aa38cb576b17299bf2fdc3779ca090059bfd35e92127f692f2b912aef
+  md5: 403069f811c54afaf3d6e3be619bbab8
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.26.1
+  license: MIT
+  license_family: MIT
+  size: 244161
+  timestamp: 1729121358016
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h827c3e9_1.tar.bz2
+  sha256: c6ca6f120f5e09524f2e6bf0db3d88f765e1700b2a5ae115028e5536dbc6d596
+  md5: afdf42981074a40b5f08bc6af82670a9
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 47000
+  timestamp: 1736183077470
+- conda: https://repo.anaconda.com/pkgs/main/win-64/arrow-cpp-19.0.0-h33d5241_0.tar.bz2
+  sha256: a1f7dffa83660b5ca33a36b6d3d47fab1a6d1c31dd8a717da73ca834fd04d0d1
+  md5: 092c8cf13e8c7312b00c2ede97576836
+  depends:
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - aws-sdk-cpp >=1.11.212,<1.11.213.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-ares >=1.19.1,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.5.0,<0.6.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libgrpc >=1.62.2,<1.63.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libthrift >=0.15.0,<0.16.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - openssl >=3.0.15,<4.0a0
+  - orc >=2.0.1,<2.0.2.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - snappy >=1.1.10,<2.0a0
+  - utf8proc >=2.6.1,<2.9.0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 9028129
+  timestamp: 1738052113637
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-24.3.0-py311haa95532_0.tar.bz2
+  sha256: 530abbccadda1fcb2cc52ef46c1615cc64f81932a9565f28e4d0684dae754265
+  md5: b630c6316defef2d31cf5e31a74ee656
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 163897
+  timestamp: 1734533441204
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-auth-0.6.19-h2bbff1b_0.tar.bz2
+  sha256: a11741c5aaa360b4772d0fb7eea606edb5266a4e2806b22f0b8b65b69b7a7273
+  md5: 9a54285c5e75ab5e6bfcb3b5590f9449
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 93395
+  timestamp: 1706746331576
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-cal-0.5.20-h2bbff1b_0.tar.bz2
+  sha256: 32b4da68dd0edbf0c8d7a8a18ba400b26775faabaccbc2cb3e9d2ab7c65e7714
+  md5: 48f0a7a7f739d8be4c9dd061be217619
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 45714
+  timestamp: 1706691182873
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-common-0.8.5-h2bbff1b_0.tar.bz2
+  sha256: d2710c7f5b4bb8f94a964996387fbd6396f9881d163affeb7ffb050a39e58c1c
+  md5: 1a8a2f82798a94d1b272ec2d307cc5ef
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 195487
+  timestamp: 1706190077309
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-compression-0.2.16-h2bbff1b_0.tar.bz2
+  sha256: 0a5ea74ebcf9bdccfad972add8ff83a47992ab28370cebc34fc4594c1c7cf03a
+  md5: 2f90d407ca685c124ddb5fc4d79f4517
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 21804
+  timestamp: 1706690937014
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-event-stream-0.2.15-hd77b12b_0.tar.bz2
+  sha256: 334d2d9c4181c9955256485f66bf4e48ae9b1dc03044aa0424bf1fda292b3151
+  md5: 9ab57953af3164d3d94001eeca0e6359
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 52661
+  timestamp: 1706697357084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-http-0.6.25-h2bbff1b_0.tar.bz2
+  sha256: 59155d1258b4e29c0046e5ab14b1e2cb3ccfca069982fe9dd4cd751b1ed67492
+  md5: 28bd7c351db93c3b8520cc1598eddf66
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-compression >=0.2.16,<0.2.17.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 177605
+  timestamp: 1706744253596
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-io-0.13.10-h2bbff1b_0.tar.bz2
+  sha256: 3aa9b1c2c508a5dcfb482083cb986498f6df460e652cc7557d3c2d122d559ebe
+  md5: b8bf7ae26d234b6738fc37b7c172b3c5
+  depends:
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145865
+  timestamp: 1706696287610
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-mqtt-0.7.13-h2bbff1b_0.tar.bz2
+  sha256: 68564155186523ec8b97b892d0a6b62b3e6f75e4e2b80fac5684011e070295d6
+  md5: ba2fa531a69a5a7e4966eba6d7891c8b
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 69542
+  timestamp: 1706746839018
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-s3-0.1.51-h2bbff1b_0.tar.bz2
+  sha256: 9c0f2f18f8b7e10e940d2438d70a2a03893421f25fd50461b8b2979f3a310a15
+  md5: da0f3ce6d8f71a71e6cae01832d853f5
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 72614
+  timestamp: 1706747680710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-c-sdkutils-0.1.6-h2bbff1b_0.tar.bz2
+  sha256: bcee1da236f6f5f88322979daddc89e8555648593f6282ad3073a68eb22a68d2
+  md5: bf4c19b0db5049930d8b2fcc3b9172fa
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51027
+  timestamp: 1706690972693
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-checksums-0.1.13-h2bbff1b_0.tar.bz2
+  sha256: 32561df1e664cb320f79c26c5af23dd55953924e66824e2d6372a44687147bdc
+  md5: 05f4c6715180a992468035c0a86e734c
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 54300
+  timestamp: 1706192197648
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-crt-cpp-0.18.16-hd77b12b_0.tar.bz2
+  sha256: 94d2fff3facfd248968d39a3fd7d3b1f7270df32a87dd567c33d60da1a5eb064
+  md5: 64fed6e7c73d88bfbfc39e838022f948
+  depends:
+  - aws-c-auth >=0.6.19,<0.6.20.0a0
+  - aws-c-cal >=0.5.20,<0.5.21.0a0
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-c-http >=0.6.25,<0.6.26.0a0
+  - aws-c-io >=0.13.10,<0.13.11.0a0
+  - aws-c-mqtt >=0.7.13,<0.7.14.0a0
+  - aws-c-s3 >=0.1.51,<0.1.52.0a0
+  - aws-c-sdkutils >=0.1.6,<0.1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 199877
+  timestamp: 1706827970924
+- conda: https://repo.anaconda.com/pkgs/main/win-64/aws-sdk-cpp-1.11.212-h6a15179_0.tar.bz2
+  sha256: e02bc15ace74eee253c8287e9531c1ccf527a9ebd9babefb84b7c742a123125d
+  md5: a35d4c87d9b8d6392f90a55c605a016d
+  depends:
+  - aws-c-common >=0.8.5,<0.8.6.0a0
+  - aws-c-event-stream >=0.2.15,<0.2.16.0a0
+  - aws-checksums >=0.1.13,<0.1.14.0a0
+  - aws-crt-cpp >=0.18.16,<0.18.17.0a0
+  - libcurl >=8.1.1,<9.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4395881
+  timestamp: 1733149195598
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
+  sha256: f1eb2a5aeb25efa0b38fc1dd94a36d431bc80d654f11a052f67a899dcc471f57
+  md5: 9db5a441c7cbcf4dc617f8c722e4310d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 276663
+  timestamp: 1718029990621
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bleach-6.2.0-py311haa95532_0.tar.bz2
+  sha256: 0837002d1a1cd03ff18ec4328ad308859cfeb02e9ebb56c7565f2540a410c207
+  md5: 89be604fc06ac9ec44500f933bab9ca9
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings
+  constrains:
+  - tinycss2 >=1.1.0,<1.5
+  license: Apache-2.0
+  license_family: Apache
+  size: 371219
+  timestamp: 1732292957244
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.6.2-py311haa95532_0.tar.bz2
+  sha256: fabd25a04e244b54c39f4500d41bdb59c5c6da2b3aa935e20d340c5778fb2473
+  md5: 4f4a3d7246e9cfee285d5185ec88d68e
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5911839
+  timestamp: 1737999415426
+- conda: https://repo.anaconda.com/pkgs/main/win-64/boost-cpp-1.82.0-h59b6b97_2.tar.bz2
+  sha256: 68ef338b27c035add89c0812ad469dd8c9e94f27130f770345ea20deb049d50b
+  md5: 9ec19b145f655329532b608963cf32f4
+  depends:
+  - libboost 1.82.0 h3399ecb_2
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 11334
+  timestamp: 1696764270626
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.4.2-py311h57dcf0c_0.tar.bz2
+  sha256: 42f1a2eb775091e9aec87f3f08ba76891e45032c980b9c00c108437df6b5fc56
+  md5: 327b522b59ec41d6e5d4a100c228415b
+  depends:
+  - numpy >=1.21,<3
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 160724
+  timestamp: 1731059089575
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311h5da7b33_9.tar.bz2
+  sha256: 1d1267a7b0eb3de746900b4c6dd06ca141085fd12b076b6ae38e8800e8b6d305
+  md5: 7e55ca44341f40eea68607d12479f367
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  size: 356583
+  timestamp: 1736183647928
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+  sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
+  md5: 11e0af09a31e2d5df51c65a342032b85
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 112994
+  timestamp: 1714511182837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/c-ares-1.19.1-h2bbff1b_0.tar.bz2
+  sha256: 41a6c5a90b88ec7010bb6dd89390754e476b52c3ab2d519bdab9556da8829479
+  md5: b047426a545e287f45e8abfbfcb0de55
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 118041
+  timestamp: 1693902191485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2025.2.25-haa95532_0.tar.bz2
+  sha256: 6e64cd794a42471c64e0971deb5ab21497217fcef9f4504900e1ac95b003db79
+  md5: e3b5a74405c1f5f34df64c1263147d0b
+  license: MPL-2.0
+  license_family: Other
+  size: 174706
+  timestamp: 1740582512824
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2025.1.31-py311haa95532_0.tar.bz2
+  sha256: 316422bef7d3a948b7f6fcfe2830fb9bdd6a301efccc121a358adc691967f431
+  md5: 997bf2a46a4a7addc95bdc5757111d2d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 169824
+  timestamp: 1738623814920
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py311h827c3e9_1.tar.bz2
+  sha256: 14cb2182124ca010739f78e856e5d4ee50cc1b1da55550c9d2fc817f2c67dbbe
+  md5: d8ee3acca8b6a61a3f58b83f820e8900
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 317912
+  timestamp: 1736184391679
+- conda: https://repo.anaconda.com/pkgs/main/win-64/click-8.1.7-py311haa95532_0.tar.bz2
+  sha256: 7153817dd49ec317b519802c7c22c836602e00cbd96d68385e83eaf4c9f5ba6a
+  md5: cd829e5997611a602e29fa2fd5882635
+  depends:
+  - colorama
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 204113
+  timestamp: 1698130080270
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cloudpickle-3.0.0-py311haa95532_0.tar.bz2
+  sha256: 364512f6fbda47a7683831e49d94cede5ea91ed57c0bcb27c4c1a95b067c7717
+  md5: c4c87a947b2f0594d0eda7d852140845
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42936
+  timestamp: 1721657516663
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+  sha256: 4099898f02e1f6119fcda65e747c3cbfef0bf563c8855b79a0245160709d5b45
+  md5: ab9705c34e67fb8c8faec69d63ff4064
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36410
+  timestamp: 1676422341506
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+  sha256: c722f50980d7416ffb2cfc7bf72649307a0bb78c5a24eccefcd049cb61d6b355
+  md5: c7c9ff0513ff3c99700919293b702410
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 543258
+  timestamp: 1709758602437
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+  sha256: 8fb3e816a5ad1da05125462dbc9e2a7e933b001a871aa65703802c0a894c6277
+  md5: ee4b2fa9fce130496d5c7c86c35a1a05
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17723
+  timestamp: 1709323150229
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.3.1-py311h214f63a_0.tar.bz2
+  sha256: f78afa9b88ee6210adc2619ba09e20b1ef1fbe97505958a6291d8cdfee9f42b7
+  md5: c9d405de1665e2d6e8cef51450f2a7a4
+  depends:
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 248779
+  timestamp: 1732540644947
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cramjam-2.7.0-py311h005caf5_0.tar.bz2
+  sha256: 97def042390c467aaaa3f4c33276b0c134c40eb426695332673ed1173f999258
+  md5: 13d97f9f5f7b1f8808e4a694b3305f15
+  depends:
+  - m2w64-gcc-libs
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1384742
+  timestamp: 1702664451643
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cytoolz-1.0.1-py311h827c3e9_0.tar.bz2
+  sha256: d0c2e1f02e0f57fc2c13eb78c4f3fcb1d65aa3f5c38f2e8f64e5dcad85c7a404
+  md5: 21fce512896bf8903242034f1592b33d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - toolz >=0.8.0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 414374
+  timestamp: 1736804071255
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-2024.12.1-py311haa95532_0.tar.bz2
+  sha256: ec83b54a5fda90b6c97070c09f9aadc7b9da198c5f00ca5bd6dc39c9341adf50
+  md5: 3958754ea4f24a2f277602388df087b2
+  depends:
+  - bokeh >=3.1.0
+  - cytoolz >=0.12.0
+  - dask-core 2024.12.1
+  - dask-expr >=1.1,<1.2
+  - distributed 2024.12.1
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.24
+  - pandas >=2.0
+  - pyarrow >=14.0.1
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6407
+  timestamp: 1736873629289
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-core-2024.12.1-py311haa95532_0.tar.bz2
+  sha256: ffc2591312374b651faa688a0ceadbb4df2a55f1159a28dba075d578a5b64fc9
+  md5: a44f2e793eb5f4ca4deb7413bb42af55
+  depends:
+  - click >=8.1
+  - cloudpickle >=3.0.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.4.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3268096
+  timestamp: 1736807954804
+- conda: https://repo.anaconda.com/pkgs/main/win-64/dask-expr-1.1.21-py311haa95532_0.tar.bz2
+  sha256: 65d6d9fae6dff5a180fe455835af2c2d577df7af7a2820260c33d321aed2daf3
+  md5: bd86876b2096dc4d9c8bf229705177b6
+  depends:
+  - dask-core 2024.12.1
+  - pandas >=2
+  - pyarrow >=14.0.1
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 570643
+  timestamp: 1736810554291
+- conda: https://repo.anaconda.com/pkgs/main/win-64/datashader-0.17.0-py311haa95532_0.tar.bz2
+  sha256: b42dbd308a689be8da71780257580759af832c33138854760ffb7bd49008aa32
+  md5: 144db31a92581c2d1235bf263ee3918f
+  depends:
+  - colorcet
+  - multipledispatch
+  - numba
+  - numpy
+  - packaging
+  - pandas <3.0.0
+  - param
+  - pyct
+  - python >=3.11,<3.12.0a0
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18031143
+  timestamp: 1738337442786
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.8.11-py311h5da7b33_0.tar.bz2
+  sha256: 6f2f0fa6cd6b041d5dd3dfc6beeb0528b563f1d138e0c1937dda07b3ef243846
+  md5: 47eb9e788ad8380d20fcdf8b40ea08a1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 4034402
+  timestamp: 1736269847465
+- conda: https://repo.anaconda.com/pkgs/main/win-64/distributed-2024.12.1-py311haa95532_0.tar.bz2
+  sha256: ef1a8013c323d631da194440f2956fda52e1f096b7638fe483c744e1c239bdc2
+  md5: 2160b00d35aeeff8ebc806c290e5a95f
+  depends:
+  - click >=8.0
+  - cloudpickle >=3.0.0
+  - dask-core 2024.12.1
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.2
+  - packaging >=20.0
+  - psutil >=5.8.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=5.4.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.11.2
+  - tornado >=6.2.0
+  - urllib3 >=1.26.5
+  - zict >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1861618
+  timestamp: 1736871289693
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+  sha256: 5d5fc8a24c804010b8cb5963227230352ea3ccf56bea9e8116e34f77223218f2
+  md5: 8f989a72eed6293dfe0533c83057980d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17688
+  timestamp: 1676423357100
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fastparquet-2024.2.0-py311hd7041d2_0.tar.bz2
+  sha256: d3a95af9b825eb25c78876ca08bf53372e1d5dc11fae2b0469ee2d1dcba1e77c
+  md5: 1f736c03b7e7e7cb54ba193a90aef21f
+  depends:
+  - cramjam >=2.3.0
+  - fsspec
+  - numpy >=1.23.5,<2.0a0
+  - packaging
+  - pandas >=1.5.0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 677268
+  timestamp: 1715262878219
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.55.3-py311h827c3e9_0.tar.bz2
+  sha256: c70c37156388dba6236fcf5905cc9b671d6d0d73eccdc7c4197676c02b8356ed
+  md5: d09af197d693ad449c0481a2729ed46f
+  depends:
+  - brotli-python >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - lxml >=4.0
+  - zopfli >=0.1.4
+  - uharfbuzz >=0.23.0
+  - fs >=2.2.0,<3
+  - lz4 >=1.7.4.2
+  - skia-pathops >=0.5.0
+  license: MIT
+  license_family: MIT
+  size: 2826042
+  timestamp: 1737041124866
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fsspec-2024.12.0-py311haa95532_0.tar.bz2
+  sha256: c11c3d2ad55faa4718cf68c779fc2c9721e58a7926dcc07630cd7865ee5dfeec
+  md5: c795095832a830914b47fb65672d043e
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - pyarrow >=1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 397468
+  timestamp: 1736274967762
+- conda: https://repo.anaconda.com/pkgs/main/win-64/gflags-2.2.2-hd77b12b_1.tar.bz2
+  sha256: 7cb0df7aa62796b0081e1708003529c02411aca6a540bae97beaec919aa64e74
+  md5: ea81fd813e10055553a8d7597c8be98f
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 322778
+  timestamp: 1706888324269
+- conda: https://repo.anaconda.com/pkgs/main/win-64/glog-0.5.0-hd77b12b_1.tar.bz2
+  sha256: ed1fa1a40c6739b48ff3a2d51c3df20e4983b59684b04d93e1337c5f2e93a954
+  md5: 1797f64343a42395207cd452e6a6a751
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94476
+  timestamp: 1706895442146
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.20.1-py311haa95532_0.tar.bz2
+  sha256: c9be6ad5f8d8088f73205ca977146a3dca20f90f286770a87ec8ebea8d34872f
+  md5: c93ced75faf6a951d095b7a291379183
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.1
+  constrains:
+  - plotly >=4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6141475
+  timestamp: 1740583429941
+- conda: https://repo.anaconda.com/pkgs/main/win-64/icc_rt-2022.1.0-h6049295_2.tar.bz2
+  sha256: a20ee960a7cfccc2e32c635398d3ecefadb4c1220e15da0fd452d33796fafe48
+  md5: 582d2c1135a89da757a038de831e7f39
+  license: Intel proprietary
+  size: 11086648
+  timestamp: 1664812389803
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+  sha256: 102c803186db6d62eaf41a906f6c563ff0d62b53c1eaede8a381e18c0d005ed9
+  md5: 9d30dec03058758a428cf152e0ae28b5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148193
+  timestamp: 1714399061601
+- conda: https://repo.anaconda.com/pkgs/main/win-64/imageio-2.37.0-py311haa95532_0.tar.bz2
+  sha256: e88c34e7e4eaa942efa89c84df74dccf91c39c58752ac09e9e455793cc38d887
+  md5: 1caa9f6da3b317477c08109cb424ef11
+  depends:
+  - numpy
+  - pillow >=8.3.2
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 703019
+  timestamp: 1738161011503
+- conda: https://repo.anaconda.com/pkgs/main/win-64/importlib-metadata-8.5.0-py311haa95532_0.tar.bz2
+  sha256: aac5e9b4e949192c4818db0cff953988afa024e59c966202e193574d5d15f2a4
+  md5: 5431ec6e2ab12e9e9e60f4557c5b0550
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zipp >=3.20
+  license: Apache-2.0
+  license_family: APACHE
+  size: 55311
+  timestamp: 1732633664589
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+  sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
+  md5: d215cc8ee7ca2cc83cc250cc5d822fe0
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3929136
+  timestamp: 1699647939158
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py311haa95532_1.tar.bz2
+  sha256: 24ac6b6e64a2bad2bb8b43b694a8717700c1f1b89af06af677ebf8f96fff75a8
+  md5: 181a1aa67aa6f8a82008adbb22bc95f7
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 239732
+  timestamp: 1737661471714
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.30.0-py311haa95532_0.tar.bz2
+  sha256: 849c5c284c450d0a254fdb09872a56bc36736fad80b5602d51034cd3c5e1f244
+  md5: 85c6796b362a934aefccd96c6f4e84c9
+  depends:
+  - colorama
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1677847
+  timestamp: 1734548277969
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.2-py311haa95532_0.tar.bz2
+  sha256: 47280ad8a680828014eceff93c5c587c0c290579486377e696c78d8461a172a1
+  md5: d38c4583143de20b5c9c8571889e1980
+  depends:
+  - parso >=0.8.4,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1189371
+  timestamp: 1733987881391
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.5-py311haa95532_0.tar.bz2
+  sha256: d0c47772a48d2dfe474eb13195b8d505156be94e6e139667a423575ed432f30f
+  md5: 3af6d96bb74c1fe0c3281a47069a5e70
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 361687
+  timestamp: 1737760321623
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+  sha256: 0238fb10912d9345a9d327ff314a179de38369f8e1d0de0b5f4fab04defab0e4
+  md5: 16a420ea83811cfa0c7cadba8f9f0995
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 409932
+  timestamp: 1722872751697
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.23.0-py311haa95532_0.tar.bz2
+  sha256: 99f6618c5969b13451072defdcf3441b83f710010ef10b7a620b42e156ed919e
+  md5: 501a297479b97960e249bdb117f7cda7
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 224348
+  timestamp: 1728486919376
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+  sha256: 9581be54128954080d7cef448b1728874c2ebbe5064f55adece422cf12eafa5a
+  md5: 3adc105f87d5c7f0b1248bc3423f5b48
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16187
+  timestamp: 1699032556953
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+  sha256: ad8343bad7c8f0448cbcfbaf872cc94b56da81c52e5cdcee2a5d6b89f029eb75
+  md5: addceff8d46c9d1d322618a9ce9e5b39
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 300354
+  timestamp: 1676424060532
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
+  sha256: fe0bf805dfa60d8b5d61670900442d0cda12523135176f60e1ebafb797e521d8
+  md5: c8cf5ea3d4b0bc57dfe6b189b47e69e9
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 136783
+  timestamp: 1718818384444
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
+  sha256: 262c35a28d0af4d73ea1c010ce0c022005512a26d5c27064c8e009c0b7b789d9
+  md5: 8367c61552aa274c0843201d88e461c8
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 72131
+  timestamp: 1718738283200
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
+  sha256: 00bf8449a37eb10c91ebfaa14b231905fde9493740cbda7ec89a8d3d8d9d1ff3
+  md5: 1f3abe3cbf365249ebae7465a57e4cae
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=2.0.1
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 655133
+  timestamp: 1718827724346
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+  sha256: 90420847230e72a648417f5f77cebcf7f17b89f70788652c276acc0c440e135f
+  md5: ef3d8dee197aa37897bf6d39d2dd878f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=2.0.10
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27639
+  timestamp: 1686871052174
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+  sha256: 97faaf26ce5254ec3649a8ee7f480b1556e4e8e6e4356d2fab1e6a5532631a0f
+  md5: da23bd831c50c877f63038b7e16720ad
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20163
+  timestamp: 1700168785472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.8-py311h5da7b33_0.tar.bz2
+  sha256: 57b39cf2915a010c60378dfae2914e6e70df28b85a45084d26b3484ecb77af7a
+  md5: 69f4bd7904b46d0040209518a69256a1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73206
+  timestamp: 1737041022655
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lazy_loader-0.4-py311haa95532_0.tar.bz2
+  sha256: ba82d5012d3c43591406b2156eaef0d3671f1a5d9c92d1673f0188cc8bebded5
+  md5: 5ef812a5a293188d1ffe6fe7418d83a4
+  depends:
+  - packaging
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25695
+  timestamp: 1718177014000
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.16-hb4a4139_0.tar.bz2
+  sha256: ef4d7e1443c7c510b6e690e344392075bc4d89b5818907f544ce98fd967d029a
+  md5: 6541897ab2fd34b35519b95c922b3192
+  depends:
+  - jpeg >=9e,<10a
+  - libtiff >=4.5.1,<4.7.0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 1089573
+  timestamp: 1734428606761
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-4.0.0-h5da7b33_0.tar.bz2
+  sha256: 3a915692cf3e21e7cc4259faea2e17535530515acb3bc8fa00832d646bdeecf0
+  md5: eda551db9b747f0606eddd001343ed36
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 207263
+  timestamp: 1734423494890
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libabseil-20240116.2-cxx17_h5da7b33_0.tar.bz2
+  sha256: 0e20a85132c711cb36bc33f1c329eec57f9b8b5a52fe8b16e39ccf2181c3e585
+  md5: 2056c0ad87951b65e50a809d539a1903
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - abseil-cpp =20240116.2
+  - libabseil-static =20240116.2=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 2192360
+  timestamp: 1716563477680
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libboost-1.82.0-h3399ecb_2.tar.bz2
+  sha256: 4184dd040fc38cb123a98588a8344aa8d1ba1932df5fcc6c188f6b21f5a0c306
+  md5: da58cfa83f3d6c31ae12d8777cd1b64d
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - xz >=5.4.2,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSL-1.0
+  license_family: OTHER
+  size: 29803292
+  timestamp: 1696764164248
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h827c3e9_9.tar.bz2
+  sha256: 5c51b1860e91be66584f6932b86de344a7158894e98b59ed5f973c39e3d77fbc
+  md5: 4273c278acae05def47ce1bbf4a604bc
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  size: 80775
+  timestamp: 1736183139175
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h827c3e9_9.tar.bz2
+  sha256: c34366f1af8c499501c660caed188191869198af323f28f9fdf36cdc3bd9b983
+  md5: 17978e34dd336c03b45064a092e24b2c
+  depends:
+  - libbrotlicommon 1.0.9 h827c3e9_9
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  size: 45764
+  timestamp: 1736183205643
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h827c3e9_9.tar.bz2
+  sha256: 3db56a17b192f502d1658eff34ed0d3d4ca137c9611e22c5ea866d217004d939
+  md5: 4b5c2afa55286a51a06fb2e7f2ffa135
+  depends:
+  - libbrotlicommon 1.0.9 h827c3e9_9
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  size: 755218
+  timestamp: 1736183274598
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.12.1-h9da9810_0.tar.bz2
+  sha256: 2146af071794793754a13c3831642f18e61a237aa39cc903b0c7bf42aa1a3feb
+  md5: 8e1c91dacbc168acf20f675848dc6fd1
+  depends:
+  - libssh2 >=1.10.0
+  - libssh2 >=1.11.1,<2.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 380931
+  timestamp: 1739986497455
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.22-h5bf469e_0.tar.bz2
+  sha256: 46c58457ec8c074d5af22fe36a182d5c29e76f6248e7d1d5cb76c66beefe52aa
+  md5: 5bd6c216dd03f3ccf9d108b7c8a29367
+  depends:
+  - vc >=14.40,<15.0a0
+  - vs2015_runtime >=14.42.34433,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 223776
+  timestamp: 1734423384478
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libevent-2.1.12-h56d1f94_1.tar.bz2
+  sha256: 6458c7a370c4e3366b3b208c5b2834a7acfb17981e47fe3fb861f225d7cefbc3
+  md5: ecabf4acab5b604856d8c7c4278c2c2c
+  depends:
+  - openssl 3.*
+  - openssl >=3.0.8,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 446380
+  timestamp: 1685052520132
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+  sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
+  md5: cf949d76148be1e2a534218d9c57df86
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 155435
+  timestamp: 1714484319443
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libgrpc-1.62.2-hf25190f_0.tar.bz2
+  sha256: 1d933ff3c15bbd21e2463392eb8b84c19f5e7e8116757a5456d53edd182f8aa3
+  md5: eb54ebe53747695597188890f99c2aad
+  depends:
+  - c-ares >=1.19.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - openssl >=3.0.13,<4.0a0
+  - re2 >=2022.4.1,<2022.4.2.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - grpc-cpp =1.62.2
+  license: Apache-2.0
+  license_family: APACHE
+  size: 19177715
+  timestamp: 1716836854929
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libprotobuf-4.25.3-hf2fb9eb_0.tar.bz2
+  sha256: 189a48ba963858b5adf13f200a36ee566bcd823b8fbc1a0372d4605f465989ae
+  md5: 310f4bf562072517c58e700471d52999
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6407565
+  timestamp: 1716568643819
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libssh2-1.11.1-h2addb87_0.tar.bz2
+  sha256: c63c4909596a8fe198b94f8cccd91dd8445b92b1b3951a15fb836d88115f93af
+  md5: 2ded634970ea802078cc2b68f903d45f
+  depends:
+  - openssl >=3.0.15,<4.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 310776
+  timestamp: 1732891385479
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libthrift-0.15.0-h4364b78_2.tar.bz2
+  sha256: 238e486a0d62264e7ab35098bdc0390fb9a4649921b18827228c811ae8252c88
+  md5: f1ebe453c5a955a25e4b00f73279fc42
+  depends:
+  - boost-cpp >=1.73
+  - libevent
+  - openssl >=3.0.9,<4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 894777
+  timestamp: 1687975823684
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-h44ae7cf_1.tar.bz2
+  sha256: 224c9ee15d52fd10544bdae6738e8d8ad12a04a6c48692574d51426d0ea421f2
+  md5: ba5f521d36280d34950fc5d99a58676b
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.22,<1.23.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1213382
+  timestamp: 1734425893191
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
+  sha256: e54ee28f6ba01b3addf61ee9dfbdedc16eac8654fc334f713b5f181cf037d0f2
+  md5: 47aa151852fc9b07e7573d22f0af945d
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 339944
+  timestamp: 1729160123353
+- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+  sha256: 4534c822511a052a72c2b070a05e5d8d6f3550f18ea00a33f9d8a9a92b4382cc
+  md5: 82f24e7660831445a2183216e280a6a4
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41464
+  timestamp: 1676474474981
+- conda: https://repo.anaconda.com/pkgs/main/win-64/llvmlite-0.44.0-py311hf2fb9eb_0.tar.bz2
+  sha256: 4ed71969f70f21b139eef63796e36bc097f40a4b85f0bb03099c3a8f4cd54b3e
+  md5: a7559fa32b5b83f3a2c027cfb821f8e3
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22183942
+  timestamp: 1738678710240
+- conda: https://repo.anaconda.com/pkgs/main/win-64/locket-1.0.0-py311haa95532_0.tar.bz2
+  sha256: 896b7a39bd4ad3621312130122b4fe84dcb67d7355166255c58ea9bc562eb0ae
+  md5: 640b852a56296f48cf073e61a59c5256
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13751
+  timestamp: 1676428354074
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-4.3.2-py311h827c3e9_1.tar.bz2
+  sha256: c32634e77ad79376714e9fc1c46c393a820ee13ac06270dece8d98c645bdda89
+  md5: 00b7603f9c73ce9f188a3bcccc6c0d07
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 106672
+  timestamp: 1736370127321
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+  sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
+  md5: 320f40b75d93f3b96931c6d13c23946c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 158902
+  timestamp: 1714512129889
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+  sha256: e0dc6e119b224bb31ef34b6ba270ffadc181d38b698c5318de8df7a5d2c4ccbd
+  md5: 992ccd756f09408f0b74dfb9852a8b7f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 182381
+  timestamp: 1676437963591
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+  sha256: 050b5fd4b28132d8102a7e6b40179894dc7f5e41f7ad9ee19211e67446c5740f
+  md5: 3ae0b2f6baec708554648ddafa81b756
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 154386
+  timestamp: 1684279992864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-3.0.2-py311h827c3e9_0.tar.bz2
+  sha256: f5bb2877837f996624d59e52d7bc4fa95b8d80c2972d758dfdc817b6a06aac05
+  md5: 2c8805cff2f45459eb69566abfbebbfa
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42282
+  timestamp: 1738584229532
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.10.0-py311he19b0ae_0.tar.bz2
+  sha256: 35078ccb78b0b35ea07ccff575a056166fe32df8c2e4a2265c3aca75e00a482b
+  md5: 3d61e9d9826f4a3664bc102588ab2fa4
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.23,<3.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 12369480
+  timestamp: 1736279003945
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+  sha256: 43279276850eb6e621812448cddc1093524cee0b7f8ed58b4600b68a4fb659f2
+  md5: 5968b2b5c1f3cf5c8c8c9aaa4d8d66a2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19886
+  timestamp: 1676425829787
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+  sha256: 3062a8254ca351b54f15bea85cc928a3ba4d879bb98ce97ece39a9f7eca215a5
+  md5: 8f1565663abb34ad7fdd512e76da5532
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 68031
+  timestamp: 1676481862508
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+  sha256: cdff5215c292fe59649ca40ca72f5d26da352760c1d6a56feba14eb13f7bbf61
+  md5: e0f3f32b22135dfeaec277bc87183ca9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23328
+  timestamp: 1676442709081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+  sha256: 3b173a25605d2aaacc57ec0e425f1d1c51327eb2521c8742a736e2c76069bc8d
+  md5: 169f1c93a443f95a88665f3008623ce1
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104882
+  timestamp: 1676425142412
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+  sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
+  md5: 527155127b9fada5e5c5c69a624674b9
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187498166
+  timestamp: 1699648376430
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h827c3e9_2.tar.bz2
+  sha256: d05715a691b223d6c7f592c21032f9bee1e7cad6834c942eec1f2d5bf2da100d
+  md5: 04bd233faebb0a8c2841e648ea39e801
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 80594
+  timestamp: 1736370888084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.11-py311h827c3e9_0.tar.bz2
+  sha256: 513b8fe5da01b8460084688d99c977d173b19d7d58ad2aa6b27a961665ae25f4
+  md5: c07115b0a05892c721b7324ef8598c2f
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 212966
+  timestamp: 1730823150084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.8-py311hea22821_0.tar.bz2
+  sha256: f8ea6da83e88b353bf66ae609d0377e45fe0d4dcdba2c920ca7b600559f49679
+  md5: 98805ec361a795613a97773fab63653b
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 345997
+  timestamp: 1730822892388
+- conda: https://repo.anaconda.com/pkgs/main/win-64/msgpack-python-1.0.3-py311h59b6b97_0.tar.bz2
+  sha256: c09c5ed3f07731091958ea6ed06a1eaeaca1f7e1361d341fb06b344d51074ca2
+  md5: 520c04235cf0980e1ce908e893b4dc71
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 37775
+  timestamp: 1676427521514
+- conda: https://repo.anaconda.com/pkgs/main/win-64/multipledispatch-0.6.0-py311haa95532_0.tar.bz2
+  sha256: 39f09c1bc57b4800ebda331eddb462928435498705351b0432d51a4293294ad8
+  md5: 5565984a02f41e97cb9a4c9126ced14b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 29808
+  timestamp: 1676442800892
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
+  sha256: 636f369607118a6ee3d0b63b7edb925d8081fd3fc829a7699136ce0dedbde067
+  md5: b7e49c9cea50d8406cac81cd720dd80a
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8323655
+  timestamp: 1717622931223
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+  sha256: e940f9178ee2fa0a7c12873ae35ebea0074371653e5cfa1be8aa8d9271fd343b
+  md5: 355d0835215911738a28010dfa6aa382
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141785
+  timestamp: 1698934346590
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.4-py311haa95532_0.tar.bz2
+  sha256: d5a6346c8d081061777b5327284f3836342ad3e4869c3584a8bf1b7abac56466
+  md5: 0d00b9e90c3df8cb479490dc136f0577
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 573057
+  timestamp: 1728052469536
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py311haa95532_0.tar.bz2
+  sha256: 952df0af8037fd3131a3f64481660272040fc30816c5b6a5377fa2357d3bcede
+  md5: e0f63c7653d679b5ec3f50b14424ad1d
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 202609
+  timestamp: 1728050720194
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+  sha256: 90fb3f14c49da1397982eae21cd09e8d60d491d76f94c57590c56723fe6dc172
+  md5: 46a523661fe5c1bce7b4213fd428c3de
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16732
+  timestamp: 1708532795328
+- conda: https://repo.anaconda.com/pkgs/main/win-64/networkx-3.4.2-py311haa95532_0.tar.bz2
+  sha256: b34f73b420b25b789139a69cec271592e1ed8cfb716a19ec62bc9f4a5ad65d87
+  md5: 0007af7a310c8541dc22c49fbeddf9ae
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - scipy >=1.10,!=1.11.0,!=1.11.1
+  - matplotlib-base >=3.7
+  - sympy >=1.10
+  - pandas >=2.0
+  - pygraphviz >=1.14
+  - numpy >=1.24
+  - pydot >=3.0.1
+  - lxml >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3410161
+  timestamp: 1737044326163
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
+  sha256: 62732e34b2cdcb73846cfdf53284067d32113aae0f6d736ca30ce2b0073bce27
+  md5: ec7191b2ea4e65b5eed6f7fdd9271d28
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 769732
+  timestamp: 1717630919732
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+  sha256: e040ebcab948325fbe17e4ab15be62e1fafa7bad225457e59764adb60eb40db5
+  md5: 4d40a09df8cb74a9f044eab317436d67
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27282
+  timestamp: 1699456187703
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numba-0.61.0-py311h5da7b33_1.tar.bz2
+  sha256: 10ac4c6d3888b01c0231a637b1756d5699fa69cf44e67f7fb6ecec9f158ec395
+  md5: 0de6cc471167996a4eb7e366424baf38
+  depends:
+  - llvmlite >=0.44.0,<0.45.0a0
+  - numpy >=1.21,<3
+  - numpy >=1.24,<2.2,!=2.0.1
+  - python >=3.11,<3.12.0a0
+  - tbb >=2021.8.0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - numba-rvsdg 0.0.*
+  - cudatoolkit >=11.2
+  - cuda-python >=11.6
+  - scipy >=1.0
+  - libopenblas !=0.3.6
+  - cuda-version >=11.2
+  - tbb >=2021.6,<2022
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 6349470
+  timestamp: 1740679736335
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.10.1-py311h4cd664f_0.tar.bz2
+  sha256: 7bf058d86876ca3d1f23b21ca8f3d9340e7f26fef9366eca092302c4fdc04e8b
+  md5: 7492afa4cb19e783c400ae35b90753cc
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21,<3
+  - numpy >=1.23.0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 210960
+  timestamp: 1730216100891
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-1.26.4-py311hdab7c0b_0.tar.bz2
+  sha256: 470fe9a0b3e196fa60d5550d8188f6074a207572fa0d353a4448d580872e7804
+  md5: 6fdb8df0613fb2fb9f1732d335fa25f1
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 1.26.4 py311hd01c5d8_0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11053
+  timestamp: 1708641901110
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-1.26.4-py311hd01c5d8_0.tar.bz2
+  sha256: 222c1711e7cf151e29077c7d4d86a865c9fd39615812d58a1daca6fd1b6bdfb5
+  md5: 585bcd8bc3940a8a859f38ebafdcd77d
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  constrains:
+  - numpy 1.26.4 py311hdab7c0b_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10723862
+  timestamp: 1708641867155
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+  sha256: e2afce0548808d27293a03661ee5f7ac3e18f82a92c9fb23f420eb5e92126fc6
+  md5: 9dd921a785844abe0aa842c3800d405a
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.7.0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 286986
+  timestamp: 1722872761369
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.16-h3f729d1_0.tar.bz2
+  sha256: 09a7f7d538b0ea0686699d70ee5ad3b3de0f949c3826c3f3ae25d4286cb3bc00
+  md5: e071cd2b74e888dd3aef739ee4060bc0
+  depends:
+  - ca-certificates
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8351528
+  timestamp: 1740991970485
+- conda: https://repo.anaconda.com/pkgs/main/win-64/orc-2.0.1-hd8d391b_0.tar.bz2
+  sha256: af8a9ad457ebc4c4aa800676ffbfd5cf830e1da697672ea6412bf041fd61cedd
+  md5: 584d733dc81492d46a926660353b361a
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240116.3.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - snappy >=1.1.10,<2.0a0
+  - tzdata
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1235996
+  timestamp: 1717104791454
+- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+  sha256: b2f5f50a1ddf811102636f3acebd76716c88ebb628754b91eda7a3a962adf26c
+  md5: 712527b4d84c350dca4b67f511c04414
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39421
+  timestamp: 1699371341381
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.2-py311haa95532_0.tar.bz2
+  sha256: 55ead6073f34770ba6ab735643411f2219ecd820d186ca3af266954d05e09487
+  md5: 6bae6e1982c2e8a4eb1c66df62521fa3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 189953
+  timestamp: 1734472735678
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.3-py311h5da7b33_0.tar.bz2
+  sha256: 82cc56df413c3875ccc7c811d3268a1404c6ed2b8d02bf7980f2c87a88918168
+  md5: e109a06ad54fcea29bdaa01596179a8b
+  depends:
+  - bottleneck >=1.3.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.2,<3
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - lxml >=4.9.2
+  - pyreadstat >=1.2.0
+  - psycopg2 >=2.9.6
+  - pyqt >=5.15.9
+  - python-calamine >=0.1.7
+  - dataframe-api-compat >=0.1.7
+  - scipy >=1.10.0
+  - gcsfs >=2022.11.0
+  - zstandard >=0.19.0
+  - numba >=0.56.4
+  - pymysql >=1.0.2
+  - xlsxwriter >=3.0.5
+  - sqlalchemy >=2.0.0
+  - beautifulsoup4 >=4.11.2
+  - xlrd >=2.0.1
+  - openpyxl >=3.1.0
+  - s3fs >=2022.11.0
+  - jinja2 >=3.1.2
+  - fsspec >=2022.11.0
+  - html5lib >=1.1
+  - pytables >=3.8.0
+  - blosc >=1.21.3
+  - adbc-driver-postgresql >=0.8.0
+  - pandas-gbq >=0.19.0
+  - matplotlib-base >=3.6.3
+  - qtpy >=2.3.0
+  - fastparquet >=2022.12.0
+  - odfpy>=1.4.1
+  - pyarrow >=10.0.1
+  - tabulate >=0.9.0
+  - pyxlsb >=1.0.10
+  - xarray >=2022.12.0
+  - adbc-driver-sqlite >=0.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17254708
+  timestamp: 1732738447404
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.6.0-py311haa95532_0.tar.bz2
+  sha256: 192831c7bc433ee523b155de842db7d5f6db9a1e78b70545dbc75a6fef5354cf
+  md5: 28120336ff966ebb49f3331fe2eee795
+  depends:
+  - bleach
+  - bokeh >=3.5.0,<3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.1.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing-extensions
+  constrains:
+  - bokeh-fastapi >=0.1.2,<0.2
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24698103
+  timestamp: 1738687060117
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.2.0-py311haa95532_0.tar.bz2
+  sha256: 4086a9512de16e81900140f66ed8e693f05f333f298a83b39a11d5c887fb2434
+  md5: 1314cc7bad5784cd7bee147f44ec9947
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 273134
+  timestamp: 1734618723915
+- conda: https://repo.anaconda.com/pkgs/main/win-64/parso-0.8.4-py311haa95532_0.tar.bz2
+  sha256: d9548c1a2c3292e37ff5d8a4b8f10785f3718b445a64b3e259cbed4ec17700e7
+  md5: 59cb810d1a41684238817cb875734af2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 224906
+  timestamp: 1733963496420
+- conda: https://repo.anaconda.com/pkgs/main/win-64/partd-1.4.2-py311haa95532_0.tar.bz2
+  sha256: c02fed71b4aab0ebe6a200b1b062e9b30cc990c572ab75546b9aabf8e2c036b9
+  md5: 8e6a93fa140a70f7706241067ec5e508
+  depends:
+  - locket
+  - python >=3.11,<3.12.0a0
+  - toolz
+  constrains:
+  - numpy >= 1.20.0
+  - pandas >=1.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48516
+  timestamp: 1736803518887
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-11.1.0-py311h096bfcc_0.tar.bz2
+  sha256: e8bfe7a79be1549fb5c2f4950d07c91d174d0177051481f7d78257712716ec66
+  md5: 4f7c73093a936a7c53a81d5e7191bdcd
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.16,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libtiff >=4.5.1,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 977993
+  timestamp: 1738010898913
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-25.0-py311haa95532_0.tar.bz2
+  sha256: 99c969667a50b21694dea15b4082b25ceea53baca4ed40fbce245eb4262588f0
+  md5: b6dfc09ba17209049e317cfd4e9a140d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3277696
+  timestamp: 1737992380415
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+  sha256: e5f8cbfb5fc25d460a9117bfc5511959c5e86ccb193316033f87bd516e0c8881
+  md5: 9f7e8b5eb651539386bb92c14e5c321b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37730
+  timestamp: 1692205554840
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.21.0-py311haa95532_0.tar.bz2
+  sha256: 98674172e2820965291e63eab571fde1fd26cbbad3856be6f86f415e7e1037b8
+  md5: 30ffc1f7b25ca073001fb641f9724520
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 122618
+  timestamp: 1731961709745
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+  sha256: 546819d922b03f3a25ca9f98fd069d0588d481fc0603c6d74bd598fb6a93687f
+  md5: 86c18e3e0b67ee099457475ed6caf2e6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 751763
+  timestamp: 1704404627180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h827c3e9_1.tar.bz2
+  sha256: ac23609428982448c7d8e4457b4c7ad3cf0373fd33cf12767b6b064ebca729bc
+  md5: ce75fc6d561dbe9fc629b7a7c4359af3
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 523851
+  timestamp: 1736372163558
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyarrow-19.0.0-py311h5da7b33_1.tar.bz2
+  sha256: 3544ce70fd62e4accf73b9c935ea014a5957e3c39ca6a1d350b1faa7987e8f25
+  md5: db9b5bc1be1314775aa71a47651ef149
+  depends:
+  - arrow-cpp >=19.0.0,<19.0.1.0a0
+  - numpy >=1.23.5,<3
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 6679808
+  timestamp: 1738230946393
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyct-0.5.0-py311haa95532_0.tar.bz2
+  sha256: e2af1efb1a5094a5962d93fa949ecab479a2ae7570e030f52eeac6761383c208
+  md5: 4cb1359e22ddf8f3996afddce5f6205c
+  depends:
+  - param >=1.7.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 56638
+  timestamp: 1676438592117
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+  sha256: d95c88d06f4f3f667bd9a39e5f18179e83b3cd4c115c06ce0fff390ff6d3a700
+  md5: c6d00a8a4d89b1be99bfa3aff19d96b4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2134881
+  timestamp: 1684280285492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.2.0-py311haa95532_0.tar.bz2
+  sha256: 30ed42a98c68d6c98d48f871197c5c9c745e7545a12818a21d36689fe1a3a856
+  md5: dfd92ad9c788e9c687ca8adc3f541ce0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 486618
+  timestamp: 1731445794006
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+  sha256: 974c22de09078bf07c5db31fe12d8d89d6433508defc8237cbe52e08c69ed56b
+  md5: 9cf10bfd49140a527cf4b1d912097e6d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36072
+  timestamp: 1676426019064
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.11-h4607a30_0.tar.bz2
+  sha256: a53f9aa74ecbe1f97a4956425ad1636d8c936750636dd7de0ac8d35ae14b105b
+  md5: b3717cd05b5595bd3c839f202df46e74
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - openssl >=3.0.15,<4.0a0
+  - sqlite >=3.45.3,<4.0a0
+  - tk >=8.6.14,<8.7.0a0
+  - tzdata
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - openssl <3.5.7
+  license: PSF-2.0
+  license_family: PSF
+  size: 20212416
+  timestamp: 1733935177242
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+  sha256: 2c61639b3bb56fc864c86558bceb7845b1731ac44bf1a94894172ea47a995bd4
+  md5: 404805e547b4d50b5cd17e16bca87527
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332043
+  timestamp: 1716495838826
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.20.0-py311haa95532_0.tar.bz2
+  sha256: dbd986e65f63d73389c7ecf060c0954905f3dba4b2f9f33bf930ca4cb0875310
+  md5: c2604164bf8765f3281c1f65ef5eac92
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 282101
+  timestamp: 1731939443247
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-3.2.1-py311haa95532_0.tar.bz2
+  sha256: 68389376bdfc521ad3b3f264267420b4c1f99356e90fb0f894128f40f5975ab3
+  md5: 65408c0fbd3705ce3fcd630e19effa73
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29508
+  timestamp: 1734370229403
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-lmdb-1.6.2-py311h5da7b33_0.tar.bz2
+  sha256: ee2593e8fba1e0bd17d06993cc10db78564ffffc474ef7544c4159fdf636f082
+  md5: 6cc36bf13acaeccb0c8de698d33e050c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: OLDAP-2.8
+  license_family: Other
+  size: 166314
+  timestamp: 1736541891612
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-snappy-0.6.1-py311hd77b12b_0.tar.bz2
+  sha256: d58b4c81e37e7332851e6b19db7511389bfec89d6dac69382c503e6a25968254
+  md5: 907db7a86a727b8d7062e3b9853e80a3
+  depends:
+  - python >=3.11,<3.12.0a0
+  - snappy >=1.1.9,<2.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 38764
+  timestamp: 1676446120675
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+  sha256: 803274d986d0c4e3b5ec1018747ede86ef57137455b3e44a60e834717eafb92b
+  md5: c9f134ddeff6fdf0373a45534ddb7079
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 273009
+  timestamp: 1713974722039
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+  sha256: 6fbcba97c1dcb5157afd23f264c3cff069c7e4be5ea55980fc349eb8dc2cb49e
+  md5: 8153e3f8b3283926bcf9403804a365f5
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65050
+  timestamp: 1711137009299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-308-py311h5da7b33_0.tar.bz2
+  sha256: 6b6a583ddae1f7fdf8b3923bd2b8c56382b2c77d0d08ed536e3237c8b82f9f02
+  md5: 01baaaa03f7066e272de93b25539c834
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13813074
+  timestamp: 1732201761313
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.14-py311h72d21ff_0.tar.bz2
+  sha256: dd0c35a9a5a0e35033b3a5a4c1a98b121670b9e9c795ee8dcf400534760af267
+  md5: 2addb0793c3e949f71e415943db41e70
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - winpty >=0.4.3,<1.0a0
+  license: MIT
+  license_family: MIT
+  size: 250185
+  timestamp: 1733515229618
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.2-py311h827c3e9_0.tar.bz2
+  sha256: b54065893111c3bf4ab784feb9a0b7b58bd829c414adda935624790d6541885f
+  md5: 1d84022dd238ec68d7c0499885d18c86
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 209408
+  timestamp: 1728658205944
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+  sha256: ea39db411361d96545a04fb976940e9590147acb4ca9caacf7e8264780379347
+  md5: b411b8be8e53e5059949dde02dd07faf
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 565148
+  timestamp: 1709319072176
+- conda: https://repo.anaconda.com/pkgs/main/win-64/re2-2022.04.01-hd77b12b_0.tar.bz2
+  sha256: 720f3dd1f933d035b1393951ffd1b6437fc5e19b1999e74096044514a46053fb
+  md5: add2dfb15b518144663fc3b897d66da7
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  size: 493391
+  timestamp: 1652432364793
+- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+  sha256: 47653b45a5f2d97b5bf0dbf0e620908880f9078da427eef69012effe3f19af67
+  md5: 44e709ae67d89bccee2d4d46d358fee3
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74493
+  timestamp: 1699012356534
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py311haa95532_1.tar.bz2
+  sha256: a225c1d6a873991bed5c9e93806f0ef0af35830cd6ce09a849e20084a8372200
+  md5: 321bb6bf4f0afb4e9175bcb75ab57976
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 124386
+  timestamp: 1731000647310
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+  sha256: d6daaa6b45272819176e4aeb467ae00e3db43386548464a9993688f292709d40
+  md5: 9fe721d7f7420c259df4f07d4503f654
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9683
+  timestamp: 1683077110211
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+  sha256: 6051860575f9448aea5799d74469c928cd7cdeeca1eb53657872262a77b1a7a8
+  md5: 60e193eca497130034facd5fed168249
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10094
+  timestamp: 1683059114376
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.22.3-py311h636fa0f_0.tar.bz2
+  sha256: 134ac16033c85372d7ce578b15930adabc6a070f87352bdc0a06820a191b36eb
+  md5: 8bb82907b584f6fe7b68d3dc429ad311
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 268477
+  timestamp: 1736545733061
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scikit-image-0.25.0-py311h5da7b33_0.tar.bz2
+  sha256: 99bc4402b40cc5b062ae1e3a127fc446171c63784b4c280266178f89c93abb2f
+  md5: 9f6eebf64ab95a1aef8c200aff249163
+  depends:
+  - imageio >=2.33,!=2.35.0
+  - lazy_loader >=0.4
+  - networkx >=3.0
+  - numpy >=1.21,<3
+  - numpy >=1.24,<3
+  - packaging >=21
+  - pillow >=10.1
+  - python >=3.11,<3.12.0a0
+  - scipy >=1.11.2
+  - tifffile >=2022.8.12
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - scikit-learn >=1.2
+  - cloudpickle >=0.2.1
+  - pywavelets >=1.6
+  - astropy >=5.0
+  - matplotlib-base >=3.7
+  - pooch >=1.6.0
+  - dask-core >=2021.1.0,!=2024.8.0
+  - pyamg >=5.2
+  license: BSD-3-Clause AND MIT AND BSD-2-Clause
+  license_family: Other
+  size: 13274470
+  timestamp: 1737476259877
+- conda: https://repo.anaconda.com/pkgs/main/win-64/scipy-1.15.1-py311h9f229c6_0.tar.bz2
+  sha256: 9838e7ac943e722c03afd1c7550084680ee900837c66aa5f5d09c88c0bac3fa7
+  md5: 4eefcf949ac2baca2f696611d440e684
+  depends:
+  - blas 1.0 mkl
+  - icc_rt >=2022.1.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.23.5,<2.5
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-Clause AND MIT AND BSD-3-Clause-Attribution AND BSD-2-Clause AND
+    BSL-1.0
+  license_family: BSD
+  size: 37176316
+  timestamp: 1737133797753
+- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_1.tar.bz2
+  sha256: 62bfeda88ac74e49d274b705b6483a4f1fd241f5c354f04ab02025a9a15f93ed
+  md5: 5d0ca57d369b424403de8830d5a638da
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99986
+  timestamp: 1736542872085
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-75.8.0-py311haa95532_0.tar.bz2
+  sha256: 94a1d4bdfaf7f327e218ddb0cd9d564872fa6a24ea52e8bc945dd850b8f20dc3
+  md5: 2c65061f62f8df0f81ebed0efe387602
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2307476
+  timestamp: 1738046308078
+- conda: https://repo.anaconda.com/pkgs/main/win-64/snappy-1.2.1-hcdb6601_0.tar.bz2
+  sha256: 5e5f855a70cf4c9dc6f2ac8d9fa51a3f095bf4db8e2ee3ff213ef5432556d7cd
+  md5: 9c1f7331a4116e5c27d8af7453f8ee47
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
+  license_family: BSD
+  size: 119274
+  timestamp: 1723557526373
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+  sha256: 5d1b7e14dc04816692de0f8518ea8fcbefb26ab61cec83f96f2c44c1bee67fab
+  md5: 505d2a70a875b5082dc857aa4dfab0d4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 18830
+  timestamp: 1705431395254
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+  sha256: 5ff3b4ac3fbce4dd67a87856c04698d0397deb0ac288ff4e7eb02fbab57f1253
+  md5: 0ca650a7001c6650809d3361de8cb005
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89590
+  timestamp: 1696347858925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+  sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
+  md5: 833b93a2daade3407898f15588945d83
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1440481
+  timestamp: 1714488344682
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+  sha256: 78d89b50a29fbeb19a562f5dad95615e3f192bb4f3b86cd6ea75f2f825418232
+  md5: 4a4040df560ea47704e0898c4c015808
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38069
+  timestamp: 1678228553220
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tifffile-2024.12.12-py311haa95532_0.tar.bz2
+  sha256: d3a1426c67e568097b45ea81f798af98982b2acf5ada09da4ebca4eb088dd9b0
+  md5: c0306a2d78b25b8ceb4c46168a464f89
+  depends:
+  - numpy
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - zarr <3
+  - imagecodecs >=2023.8.12
+  - matplotlib-base >=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 575304
+  timestamp: 1734341325379
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.4.0-py311haa95532_0.tar.bz2
+  sha256: bf353c0c858f16699eb830b7738b6654cef6a47b6de3c3b497fe843a3c389a11
+  md5: 9b3a79bdeba3acd6c8051eea4a0fdd72
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 106345
+  timestamp: 1738337778545
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+  sha256: 0a95736cfd0bb25fc201cd6be4a2450ea8fc30eeb349d861812675b84c94fa74
+  md5: a8a9fb30c6dd8e7a16d5dcd2333c3c49
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3844176
+  timestamp: 1714770894235
+- conda: https://repo.anaconda.com/pkgs/main/win-64/toolz-1.0.0-py311haa95532_0.tar.bz2
+  sha256: 40cf1210dfc0eefa3711b085dd5c2d9a03e8e7a315813e13c0f36120ef46ca5f
+  md5: 06449223ec7c8953845149c2010ddc33
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 138855
+  timestamp: 1736796480727
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.2-py311h827c3e9_0.tar.bz2
+  sha256: 04c7dd95fc472792fd29e76a8a5a0d1e9f87dd2569c3db59c36253f2f7fb420f
+  md5: c24e1d36c566681be5bba111e5883c0d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 933447
+  timestamp: 1733960990402
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.67.1-py311h746a85d_0.tar.bz2
+  sha256: 2bf8527a85db2c43c45437d33e1ed3b8baf511bd4dd5b304a933e89c4d89fe21
+  md5: cb788bffc1a7a8c8c30a27dbb4472772
+  depends:
+  - colorama
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 187524
+  timestamp: 1738946539403
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
+  sha256: a724711191ac1226bf228eab49718eed7b5c7394f539294eb0f88baf8e7bb24d
+  md5: c78482e07d0aa6df9fcfa5b366dd87e3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 207744
+  timestamp: 1718227224929
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.12.2-py311haa95532_0.tar.bz2
+  sha256: 81ba8633c9266a47ccf6c13e675548ac10b3a6e6a7bfa978c1fa1c3bac078909
+  md5: 15f63d935470581900fb5cb5a77bddfa
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.12.2 py311haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9887
+  timestamp: 1734714947897
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.12.2-py311haa95532_0.tar.bz2
+  sha256: d348f55f9646a6d564dddbc3b2fcdcb6972bb1da9d9ad38941399cafc2d35f21
+  md5: 8f78d5a156c9f79284c5d191e091101c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 82553
+  timestamp: 1734714936074
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+  sha256: d091897f05318c22ca31028370f25355065999078f7db6f88ab27bf4cb030ec8
+  md5: 1776502c1cfb351554eeda6cddaf255f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11588
+  timestamp: 1676457729096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h827c3e9_1.tar.bz2
+  sha256: 359246beab1c7d0112123fccc72e4e82fa05ac644a0387064fe11d34e709aaec
+  md5: 96fe5cc02d327dc03fa4980b4d7b650c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 513756
+  timestamp: 1736544133041
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.3.0-py311haa95532_0.tar.bz2
+  sha256: f97a7938ce2eada94759732420c5000b69eff58c8d82833b41ca2809552593a8
+  md5: d7a502daadc1d11db6acd637d7b2577c
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - zstandard >=0.18.0
+  - requests >=2.26.0
+  - h2 >=4,<5
+  - selenium >=4.4.3
+  license: MIT
+  license_family: MIT
+  size: 223213
+  timestamp: 1737133924756
+- conda: https://repo.anaconda.com/pkgs/main/win-64/utf8proc-2.6.1-h2bbff1b_1.tar.bz2
+  sha256: 2ef16d0252e04063d44d0683831d55b485f713fe5af2c2efd61753fb4f27d7e4
+  md5: 256ab1d5dce70111a1f4807a5a9fc322
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 100982
+  timestamp: 1706894771410
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.42-haa95532_4.tar.bz2
+  sha256: e1893bcf9543c44dc71d8d869b3adb1c3b117004b06f1bb065db2f5778a8f81c
+  md5: 9ade3f0dfabff28bb61973afd2b50e13
+  depends:
+  - vs2015_runtime >=14.42.34433
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9751
+  timestamp: 1739202647759
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.42.34433-he0abc0d_4.tar.bz2
+  sha256: 4a432ec177be39d70164d04b13759b5532d2818cbe84123179cd195fe8ede102
+  md5: 4c0af6c22468d1a5ad1654d895128006
+  size: 2462862
+  timestamp: 1739202634559
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+  sha256: 24ea3d3e0cb98d0d246338dbb4562b67967bb32002e3704e495a5c863476e831
+  md5: c7b9cdbe87b3c9720aeca1164a0fd6df
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26181
+  timestamp: 1676424437003
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+  sha256: 92d27e41ce34387e59acb47572fcb2e92c4defaeadafd11ce190226022023e69
+  md5: f1bf142d852987acbe4b0bc94e87d958
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145306
+  timestamp: 1715878654770
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.45.1-py311haa95532_0.tar.bz2
+  sha256: b42f0df89a608d5579738bb8c44cd6871b0a73b731cb91d64e7b72bf03a164aa
+  md5: eb0b68c2d661763d490a911b52a108c0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 176574
+  timestamp: 1737990578192
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+  sha256: 17fadf35aa8917c107e7b369e9364ac7c09537776e7943d37e225e14b7026c94
+  md5: 0e67c3b9624540581b894b11267a837b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PUBLIC-DOMAIN
+  size: 10197
+  timestamp: 1676425485716
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xarray-2024.11.0-py311haa95532_0.tar.bz2
+  sha256: a6dcae6604a3e67e1db1a536ed1280ac5d7316bef8f0199ac707f534c25c4231
+  md5: c1d227561f8b2ead88d3e1107a640145
+  depends:
+  - numpy >=1.24
+  - packaging >=23.2
+  - pandas >=2.1
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3026676
+  timestamp: 1734536084028
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+  sha256: b849b368e27920838fe40a512b102879693a55cb187dd1c8d3a83fa8c05a8054
+  md5: 7b1f6e9c71906a93039b3446b99a5498
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55114
+  timestamp: 1676434863173
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.6.4-h4754444_1.tar.bz2
+  sha256: d3458fa18024725ca330e84a0f63b531133a781b33e360b35c50cd278cc66ec4
+  md5: 3f6d85e0ee495eb5fdae370f7f456e4c
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 290014
+  timestamp: 1739468425589
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+  sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
+  md5: e5aed81295b61b6d1eb62830799a0297
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 9125184
+  timestamp: 1705602328351
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zict-3.0.0-py311haa95532_0.tar.bz2
+  sha256: 478892109d9dc82c90f82d269d3796f4f812f6cba5d3d1f9178a20bd7f583a1f
+  md5: df02873bda6c5de6331b00fb1591abac
+  depends:
+  - heapdict
+  - python >=3.11,<3.12.0a0
+  - python-lmdb
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 102456
+  timestamp: 1695833422458
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zipp-3.21.0-py311haa95532_0.tar.bz2
+  sha256: 51af770b59e46a11f079a36e2c56ccbd793afbc5a6a3f9bce04a509f0a3b343f
+  md5: b4e7673adc5af56b8752142313d017db
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 30531
+  timestamp: 1732630914792
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+  sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
+  md5: f295b54ab59f5b8658e2a322ac6aa721
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 162161
+  timestamp: 1714514792081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
+  sha256: 1f68cd378c6cdec34a5a3a21c56c9b8422b0f037b868b3db72065c0a2ca27921
+  md5: d455a04486eddfb94c280974c0c33ae3
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1971698
+  timestamp: 1728487049972
+- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+  sha256: 98f3bae3caff4c52615ddb56405dc51b39d9d2c47a9bccd130a5a19d10304245
+  md5: de1b7f7c8221028f6bbe103df4c53bed
+  depends:
+  - m2w64-gcc-libs-core
+  - msys2-conda-epoch >=20160418
+  license: GPL, LGPL, FDL, custom
+  size: 348607
+- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+  sha256: 2fb6488298a659c781f9294a743b0b376d9998a6b06aa2a3b85b49c38a85ea16
+  md5: 0b9caac6747002340b057a222af705b2
+  depends:
+  - m2w64-gcc-libgfortran
+  - m2w64-gcc-libs-core
+  - m2w64-gmp
+  - m2w64-libwinpthread-git
+  - msys2-conda-epoch >=20160418
+  license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  size: 530578
+- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+  sha256: 449df9debaf202928e3a0db1f059ef35b1bcb3973fa92e217ca2775f82415111
+  md5: 276d396bfe8d958f71173b7134f739fa
+  depends:
+  - m2w64-gmp
+  - m2w64-libwinpthread-git
+  - msys2-conda-epoch >=20160418
+  license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  size: 217686
+- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+  sha256: 5cf23439eef17ae158d63ff3f85f77d1dca9a45b19324fdeda9e3e48ae298d18
+  md5: fec04371463ec68eb8f5752a22c5b030
+  depends:
+  - msys2-conda-epoch >=20160418
+  license: LGPL3
+  size: 705647
+- conda: https://repo.anaconda.com/pkgs/msys2/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+  sha256: 9373b0157e08cbea09298f461d2816833281b3e22a8c9f6c5a38d7109c8a281e
+  md5: 67e61e700eb27424979778fae9293f13
+  depends:
+  - msys2-conda-epoch >=20160418
+  license: MIT, BSD
+  size: 30543
+- conda: https://repo.anaconda.com/pkgs/msys2/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+  sha256: d6a55d779052bca9accd534398b4e147d0a3dfc8f4b6528391ee9c15843784bc
+  md5: 6eaef3074f65f715ed1ca6b8a08be3aa
+  size: 2065

--- a/uk_researchers/pixi.toml
+++ b/uk_researchers/pixi.toml
@@ -1,0 +1,50 @@
+[workspace]
+name = "uk_researchers"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2017-06-07"
+maintainers = ["philippjfr", "jbednar"]
+categories = ["Networks"]
+labels = ["datashader", "holoviews", "bokeh"]
+description = "UK research networks with HoloViews, Bokeh, and Datashader"
+
+[dependencies]
+python = "3.11.*"
+notebook = "<7"
+colorcet = "*"
+dask = "*"
+datashader = "*"
+fastparquet = "*"
+holoviews = "*"
+param = "*"
+pandas = "*"
+python-snappy = "*"
+scikit-image = "*"
+pip = "*"
+setuptools = "*"
+wheel = "*"
+
+[target.osx-64.dependencies]
+libgfortran = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks.notebook]
+cmd = "jupyter notebook uk_researchers.ipynb"
+depends-on = ["download"]
+
+[tasks.download]
+depends-on = ["download-DATA", "download-METADATA"]
+
+[tasks.download-DATA]
+env = { FILENAME = "data/graph" }
+cmd = "mkdir -p $FILENAME && curl -fsSL -o .DATA.zip http://s3.amazonaws.com/datashader-data/calvert_uk_research2017.snappy.parq.zip && python -m zipfile -e .DATA.zip $FILENAME && rm .DATA.zip"
+outputs = ["data/graph"]
+
+[tasks.download-METADATA]
+env = { FILENAME = "data/institutions" }
+cmd = "mkdir -p $FILENAME && curl -fsSL -o .METADATA.zip http://s3.amazonaws.com/datashader-data/calvert_uk_research2017_nodes.zip && python -m zipfile -e .METADATA.zip $FILENAME && rm .METADATA.zip"
+outputs = ["data/institutions"]

--- a/uk_researchers/pixi.toml
+++ b/uk_researchers/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "uk_researchers"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/uk_researchers/pixi.toml
+++ b/uk_researchers/pixi.toml
@@ -22,15 +22,15 @@ param = "*"
 pandas = "*"
 python-snappy = "*"
 scikit-image = "*"
-pip = "*"
-setuptools = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+setuptools = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks.notebook]
 cmd = "jupyter notebook uk_researchers.ipynb"

--- a/volumetric_imaging/pixi.lock
+++ b/volumetric_imaging/pixi.lock
@@ -8,7 +8,6 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
-    - url: https://conda.anaconda.org/nodefaults/
     indexes:
     - https://pypi.org/simple
     packages:

--- a/volumetric_imaging/pixi.lock
+++ b/volumetric_imaging/pixi.lock
@@ -1,0 +1,5268 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/nodefaults/
+    indexes:
+    - https://pypi.org/simple
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311h9ecbd09_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hfdbb021_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.12.14-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.1-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.11-py311hfdbb021_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-26_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-26_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.23-h4ddbbb0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-26_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.6.3-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.2-hee588c1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-hd9ff511_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py311h2dc5d0c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.2.0-py311hf916aec_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.3-h5fbd93e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py311h7db5c69_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.0.0-py311h49e9ac3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.11-h9e4cc4f_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py311h7deb3e3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.22.3-py311h9e33e62_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.2-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py311hbc35293_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.3.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.12.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.10.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhff2d567_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241206-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - pypi: https://files.pythonhosted.org/packages/2f/a2/e0e01c70d7a6804eb00faeb901af341ca5518b9d58c444c133d300c48b83/neuroglancer-2.40.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/49/97/fa78e3d2f65c02c8e1268b9aba606569fe97f6c8f7c2d74394553347c145/rsa-4.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5e/cb/cb0311f2ec371c83d6510847476c665edc9cc97564a51923557bc8f0b680/google_apitools-0.5.32-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/61/bf/fd60001b3abc5222d8eaa4a204cd8c0ae78e75adc688f33ce4bf25b7fafa/fasteners-0.19-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/77/89/bc88a6711935ba795a679ea6ebee07e128050d6382eaa35a0a47c8032bdc/pyasn1_modules-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7d/6c/f78174aeafa8918ac93d86b45837b661ae60a42cda68ce3c591387646560/panel_neuroglancer-0.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/87/c6/53da25344e3e3a9c01095a89f16dbcda021c609ddb42dd6d7c0528236fb2/atomicwrites-1.4.1.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/8d/8d/4d5d5f9f500499f7bd4c93903b43e8d6976f3fc6f064637ded1a85d09b07/google_auth-2.37.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/95/a9/4f25a14d23f0786b64875b91784607c2277eff25d48f915e39ff0cff505a/oauth2client-4.1.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/07/14f8ad37f2d12a5ce41206c21820d8cb6561b728e51fad4530dff0552a67/cachetools-5.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a8/6c/d2fbdaaa5959339d53ba38e94c123e4e84b8fbc4b84beb0e70d7c1608486/httplib2-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/be/ec/2eb3cd785efd67806c46c13a17339708ddc346cbb684eade7a6e6f79536a/pyparsing-3.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.3.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.12.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.10.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhff2d567_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241206-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h3336109_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hd89902b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.12.14-h8857fd0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.1-py311h137bacd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.1-py311h4e34fa0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.11-py311hc356e98_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-26_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-26_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.6-hf95d169_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.23-he65b83e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.4-h240833e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-26_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.6.3-hd471939_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_hbf64a52_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.44-h4b8f8c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.2-hdb6dae5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-hb77a491_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.6-ha54dae1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.2-py311ha3cf9ac_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.2.0-py311h4632d39_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.3-h7fd6d84_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hd471939_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.3-py311haeb46be_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.0.0-py311h1f68098_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.0-py311h1314207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.3.2-py311hfbc4093_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.3.2-py311hfbc4093_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.11-h9ccd52b_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311h3336109_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.2.0-py311h4d3da15_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.22.3-py311h3b9c2be_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.2-py311h4d7f069_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.12-h6e16a3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h7130eaa_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py311hdf6fcd6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
+      - pypi: https://files.pythonhosted.org/packages/49/97/fa78e3d2f65c02c8e1268b9aba606569fe97f6c8f7c2d74394553347c145/rsa-4.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/59/52/3890bdc3345a1885a6eac6d4b982124d4820c11b706ce179b76c26b3eaea/neuroglancer-2.40.1-cp39-abi3-macosx_10_9_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/5e/cb/cb0311f2ec371c83d6510847476c665edc9cc97564a51923557bc8f0b680/google_apitools-0.5.32-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/61/bf/fd60001b3abc5222d8eaa4a204cd8c0ae78e75adc688f33ce4bf25b7fafa/fasteners-0.19-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/77/89/bc88a6711935ba795a679ea6ebee07e128050d6382eaa35a0a47c8032bdc/pyasn1_modules-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7d/6c/f78174aeafa8918ac93d86b45837b661ae60a42cda68ce3c591387646560/panel_neuroglancer-0.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/87/c6/53da25344e3e3a9c01095a89f16dbcda021c609ddb42dd6d7c0528236fb2/atomicwrites-1.4.1.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/8d/8d/4d5d5f9f500499f7bd4c93903b43e8d6976f3fc6f064637ded1a85d09b07/google_auth-2.37.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/95/a9/4f25a14d23f0786b64875b91784607c2277eff25d48f915e39ff0cff505a/oauth2client-4.1.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/07/14f8ad37f2d12a5ce41206c21820d8cb6561b728e51fad4530dff0552a67/cachetools-5.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a8/6c/d2fbdaaa5959339d53ba38e94c123e4e84b8fbc4b84beb0e70d7c1608486/httplib2-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/be/ec/2eb3cd785efd67806c46c13a17339708ddc346cbb684eade7a6e6f79536a/pyparsing-3.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.3.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.12.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.10.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhff2d567_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241206-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311h460d6c5_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311h3f08180_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.12.14-hf0a4a13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py311h3a79f62_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.1-py311h210dab8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.11-py311h155a34a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py311h267d04e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-26_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-26_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.6-ha82da77_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.23-hec38601_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-26_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.6.3-h39f12f2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.47.2-h3f77e49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-h551f018_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.6-hdb05f8b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py311h4921393_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.2.0-py311h4b914e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.3-h8a3d83b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h39f12f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py311h9cb3ce9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.0.0-py311h3894ae9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py311hae2e1ce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.3.2-py311hab620ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.3.2-py311hab620ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.11-hc22306f_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h460d6c5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.0-py311h730b646_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.22.3-py311h3ff9189_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.2-py311h917b07b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-h5505292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-hc1bb282_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py311ha60cc69_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+      - pypi: https://files.pythonhosted.org/packages/49/97/fa78e3d2f65c02c8e1268b9aba606569fe97f6c8f7c2d74394553347c145/rsa-4.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5e/cb/cb0311f2ec371c83d6510847476c665edc9cc97564a51923557bc8f0b680/google_apitools-0.5.32-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/61/bf/fd60001b3abc5222d8eaa4a204cd8c0ae78e75adc688f33ce4bf25b7fafa/fasteners-0.19-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/77/89/bc88a6711935ba795a679ea6ebee07e128050d6382eaa35a0a47c8032bdc/pyasn1_modules-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7d/6c/f78174aeafa8918ac93d86b45837b661ae60a42cda68ce3c591387646560/panel_neuroglancer-0.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/87/c6/53da25344e3e3a9c01095a89f16dbcda021c609ddb42dd6d7c0528236fb2/atomicwrites-1.4.1.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/8d/8d/4d5d5f9f500499f7bd4c93903b43e8d6976f3fc6f064637ded1a85d09b07/google_auth-2.37.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/95/a9/4f25a14d23f0786b64875b91784607c2277eff25d48f915e39ff0cff505a/oauth2client-4.1.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/07/14f8ad37f2d12a5ce41206c21820d8cb6561b728e51fad4530dff0552a67/cachetools-5.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a7/37/214037aec09f43e1854173fc338eb5f20f2b2f6d57ccf9dfc9f4032b1567/neuroglancer-2.40.1-cp39-abi3-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/a8/6c/d2fbdaaa5959339d53ba38e94c123e4e84b8fbc4b84beb0e70d7c1608486/httplib2-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/be/ec/2eb3cd785efd67806c46c13a17339708ddc346cbb684eade7a6e6f79536a/pyparsing-3.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.3.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.12.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.11-py311hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.10.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh5737063_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhff2d567_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241206-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311he736701_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311hda3d55a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.12.14-h56e8100_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.1-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.11-py311hda3d55a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-26_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-26_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.23-h9062f6e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.4-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-14.2.0-h1383e82_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-14.2.0-h1383e82_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.2-default_ha69328c_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-26_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.6.3-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.2-h67fdade_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-h797046b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.5-he286e8c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py311h5082efb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.2.0-py311hc213d13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.3-h4d64b90_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.4.0-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py311hcf9f919_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.0.0-py311h4fbf6a9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.11-h3f84c4b_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-307-py311hda3d55a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.14-py311hda3d55a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.2.0-py311h484c95c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.22.3-py311h533ab2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-h62715c5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.2-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34433-he29a5d6_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hdffcdeb_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.12-h0e40799_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.5-h0e40799_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py311h53056dc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+      - pypi: https://files.pythonhosted.org/packages/23/d9/29ae513f60f0d972789453f14b22753d9becc303f0ad7e797cf6b4878580/neuroglancer-2.40.1-cp39-abi3-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/49/97/fa78e3d2f65c02c8e1268b9aba606569fe97f6c8f7c2d74394553347c145/rsa-4.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5e/cb/cb0311f2ec371c83d6510847476c665edc9cc97564a51923557bc8f0b680/google_apitools-0.5.32-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/61/bf/fd60001b3abc5222d8eaa4a204cd8c0ae78e75adc688f33ce4bf25b7fafa/fasteners-0.19-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/77/89/bc88a6711935ba795a679ea6ebee07e128050d6382eaa35a0a47c8032bdc/pyasn1_modules-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7d/6c/f78174aeafa8918ac93d86b45837b661ae60a42cda68ce3c591387646560/panel_neuroglancer-0.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/87/c6/53da25344e3e3a9c01095a89f16dbcda021c609ddb42dd6d7c0528236fb2/atomicwrites-1.4.1.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/8d/8d/4d5d5f9f500499f7bd4c93903b43e8d6976f3fc6f064637ded1a85d09b07/google_auth-2.37.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/95/a9/4f25a14d23f0786b64875b91784607c2277eff25d48f915e39ff0cff505a/oauth2client-4.1.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/07/14f8ad37f2d12a5ce41206c21820d8cb6561b728e51fad4530dff0552a67/cachetools-5.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a8/6c/d2fbdaaa5959339d53ba38e94c123e4e84b8fbc4b84beb0e70d7c1608486/httplib2-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/be/ec/2eb3cd785efd67806c46c13a17339708ddc346cbb684eade7a6e6f79536a/pyparsing-3.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  license: None
+  size: 2562
+  timestamp: 1578324546067
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23621
+  timestamp: 1650670423406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311h9ecbd09_5.conda
+  sha256: d1af1fbcb698c2e07b0d1d2b98384dd6021fa55c8bcb920e3652e0b0c393881b
+  md5: 18143eab7fcd6662c604b85850f0db1e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.0.1
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 35025
+  timestamp: 1725356735679
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hfdbb021_2.conda
+  sha256: 949913bbd1f74d1af202d3e4bff2e0a4e792ec00271dc4dd08641d4221aa2e12
+  md5: d21daab070d76490cb39a8f1d1729d79
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  license: MIT
+  license_family: MIT
+  size: 350367
+  timestamp: 1725267768486
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+  sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
+  md5: 62ee74e96c5ebb0af99386de58cf9553
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 252783
+  timestamp: 1720974456583
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.12.14-hbcca054_0.conda
+  sha256: 1afd7274cbc9a334d6d0bc62fa760acc7afdaceb0b91a8df370ec01fd75dc7dd
+  md5: 720523eb0d6a9b0f6120c16b2aa4e7de
+  license: ISC
+  size: 157088
+  timestamp: 1734208393264
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
+  sha256: bc47aa39c8254e9e487b8bcd74cfa3b4a3de3648869eb1a0b89905986b668e35
+  md5: 55553ecd5328336368db611f350b7039
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 302115
+  timestamp: 1725560701719
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.1-py311hd18a35c_0.conda
+  sha256: 08be6120dc9369f07858677dde2a8474644cc7ec2ae146b39a6953aadc536dfd
+  md5: 351cb68d2081e249069748b6e60b3cd2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 278209
+  timestamp: 1731428493722
+- conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.11-py311hfdbb021_0.conda
+  sha256: 4b9f89967fdb6a97ad946746f1852083ad49a50327818bd558d7d37084217590
+  md5: 7243087876dfd44a22d62e01cc0a3551
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2542323
+  timestamp: 1734159109444
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+  sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
+  md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 634972
+  timestamp: 1694615932610
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_1.conda
+  sha256: 2f082f7b12a7c6824e051321c1029452562ad6d496ad2e8c8b7b3dea1c8feb92
+  md5: 5ca76f61b00a15a9be0612d4d883badc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17645
+  timestamp: 1725303065473
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+  sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
+  md5: 30186d27e2c9fa62b45fb1476b7200e3
+  depends:
+  - libgcc-ng >=10.3.0
+  license: LGPL-2.1-or-later
+  size: 117831
+  timestamp: 1646151697040
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+  sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
+  md5: 3f43953b7d3fb3aaa1d0d0723d91e368
+  depends:
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1370023
+  timestamp: 1719463201255
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+  sha256: 5c878d104b461b7ef922abe6320711c0d01772f4cd55de18b674f88547870041
+  md5: 51bb7010fc86f70eee639b4bb7a894f5
+  depends:
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 245247
+  timestamp: 1701647787198
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+  sha256: 7c91cea91b13f4314d125d1bedb9d03a29ebbd5080ccdea70260363424646dbe
+  md5: 048b02e3962f066da18efe3a21b77672
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - binutils_impl_linux-64 2.43
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 669211
+  timestamp: 1729655358674
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+  sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
+  md5: 76bbff344f0134279f225174e9064c8f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 281798
+  timestamp: 1657977462600
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-26_linux64_openblas.conda
+  sha256: 30bd658682b124243f8e52d8edf8a19e7be1bc31e4fe4baec30a64002dc8cd0c
+  md5: ac52800af2e0c0e7dac770b435ce768a
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - libcblas 3.9.0 26_linux64_openblas
+  - liblapack 3.9.0 26_linux64_openblas
+  - liblapacke 3.9.0 26_linux64_openblas
+  - blas * openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16393
+  timestamp: 1734432564346
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-26_linux64_openblas.conda
+  sha256: 9c74e536c9bc868e356ffd43f81c2cb398aec84b40fcadc312315b164a5500ee
+  md5: ebcc5f37a435aa3c19640533c82f8d76
+  depends:
+  - libblas 3.9.0 26_linux64_openblas
+  constrains:
+  - liblapack 3.9.0 26_linux64_openblas
+  - liblapacke 3.9.0 26_linux64_openblas
+  - blas * openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16336
+  timestamp: 1734432570482
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.23-h4ddbbb0_0.conda
+  sha256: 511d801626d02f4247a04fff957cc6e9ec4cc7e8622bd9acd076bcdc5de5fe66
+  md5: 8dfae1d2e74767e9ce36d5fa0d8605db
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 72255
+  timestamp: 1734373823254
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+  sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
+  md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 123878
+  timestamp: 1597616541093
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
+  sha256: 56541b98447b58e52d824bd59d6382d609e11de1f8adf20b23143e353d2b8d26
+  md5: db833e03127376d461e1e13e76f09b6c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 73304
+  timestamp: 1730967041968
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+  sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+  md5: d645c6d2ac96843a2bfaccd2d62b3ac3
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 58292
+  timestamp: 1636488182923
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
+  sha256: 53eb8a79365e58849e7b1a068d31f4f9e718dc938d6f2c03e960345739a03569
+  md5: 3cb76c3f10d3bc7f1105b2fc9db984df
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 14.2.0 h77fa898_1
+  - libgcc-ng ==14.2.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 848745
+  timestamp: 1729027721139
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+  sha256: 3a76969c80e9af8b6e7a55090088bc41da4cffcde9e2c71b17f44d37b7cb87f7
+  md5: e39480b9ca41323497b05492a63bc35b
+  depends:
+  - libgcc 14.2.0 h77fa898_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54142
+  timestamp: 1729027726517
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+  sha256: fc9e7f22a17faf74da904ebfc4d88699013d2992e55505e4aa0eb01770290977
+  md5: f1fd30127802683586f768875127a987
+  depends:
+  - libgfortran5 14.2.0 hd5240d6_1
+  constrains:
+  - libgfortran-ng ==14.2.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 53997
+  timestamp: 1729027752995
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
+  sha256: d149a37ca73611e425041f33b9d8dbed6e52ec506fe8cc1fc0ee054bddeb6d5d
+  md5: 9822b874ea29af082e5d36098d25427d
+  depends:
+  - libgcc >=14.2.0
+  constrains:
+  - libgfortran 14.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1462645
+  timestamp: 1729027735353
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+  sha256: 1911c29975ec99b6b906904040c855772ccb265a1c79d5d75c8ceec4ed89cd63
+  md5: cc3573974587f12dda90d96e3e55a702
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 460992
+  timestamp: 1729027639220
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+  sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
+  md5: ea25936bb4080d843790b586850f82b8
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 618575
+  timestamp: 1694474974816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-26_linux64_openblas.conda
+  sha256: b76458c36331376911e0f98fa68109e02f4d5e5ebfffa79587ac69cef748bba1
+  md5: 3792604c43695d6a273bc5faaac47d48
+  depends:
+  - libblas 3.9.0 26_linux64_openblas
+  constrains:
+  - libcblas 3.9.0 26_linux64_openblas
+  - liblapacke 3.9.0 26_linux64_openblas
+  - blas * openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16338
+  timestamp: 1734432576650
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.6.3-hb9d3cd8_1.conda
+  sha256: e6e425252f3839e2756e4af1ea2074dffd3396c161bf460629f9dfd6a65f15c6
+  md5: 2ecf2f1c7e4e21fcfe6423a51a992d84
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - xz ==5.6.3=*_1
+  license: 0BSD
+  size: 111132
+  timestamp: 1733407410083
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+  sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+  md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  license_family: GPL
+  size: 33408
+  timestamp: 1697359010159
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
+  sha256: 99ba271d8a80a1af2723f2e124ffd91d850074c0389c067e6d96d72a2dbfeabe
+  md5: 62857b389e42b36b686331bec0922050
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.2.0
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5578513
+  timestamp: 1730772671118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
+  sha256: e5b14f7a01c2db4362d8591f42f82f336ed48d5e4079e4d1f65d0c2a3637ea78
+  md5: f4cc49d7aa68316213e4b12be35308d1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 290661
+  timestamp: 1726234747153
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
+  sha256: 0105bd108f19ea8e6a78d2d994a6d4a8db16d19a41212070d2d1d48a63c34161
+  md5: a587892d3c13b6621a6091be690dbca2
+  depends:
+  - libgcc-ng >=12
+  license: ISC
+  size: 205978
+  timestamp: 1716828628198
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.2-hee588c1_0.conda
+  sha256: 48af21ebc2cbf358976f1e0f4a0ab9e91dfc83d0ef337cf3837c6f5bc22fb352
+  md5: b58da17db24b6e08bcbf8fed2fb8c915
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 873551
+  timestamp: 1733761824646
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+  sha256: 4661af0eb9bdcbb5fb33e5d0023b001ad4be828fccdcc56500059d56f9869462
+  md5: 234a5554c53625688d51062645337328
+  depends:
+  - libgcc 14.2.0 h77fa898_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3893695
+  timestamp: 1729027746910
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+  sha256: 25bb30b827d4f6d6f0522cc0579e431695503822f144043b93c50237017fffd8
+  md5: 8371ac6457591af2cf6159439c1fd051
+  depends:
+  - libstdcxx 14.2.0 hc0a3c3a_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54105
+  timestamp: 1729027780628
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-hd9ff511_3.conda
+  sha256: b224e16b88d76ea95e4af56e2bc638c603bd26a770b98d117d04541d3aafa002
+  md5: 0ea6510969e1296cc19966fad481f6de
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.23,<1.26.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libstdcxx >=13
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 428173
+  timestamp: 1734398813264
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33601
+  timestamp: 1680112270483
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+  sha256: 49bc5f6b1e11cb2babf2a2a731d1a680a5e08a858280876a779dbda06c78c35f
+  md5: b26e8aa824079e1be0294e7152ca4559
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 438953
+  timestamp: 1713199854503
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+  sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
+  md5: 92ed62436b625154323d40d5f2f11dd7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 395888
+  timestamp: 1727278577118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
+  md5: 5aa797f8787fe7a17d1b0821485b5adc
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 100393
+  timestamp: 1702724383534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
+  md5: edb0dca6bc32e4f4789199455a1dbeb8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 60963
+  timestamp: 1727963148474
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py311h2dc5d0c_1.conda
+  sha256: 0291d90706ac6d3eea73e66cd290ef6d805da3fad388d1d476b8536ec92ca9a8
+  md5: 6565a715337ae279e351d0abd8ffe88a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25354
+  timestamp: 1733219879408
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+  sha256: 6a1d5d8634c1a07913f1c525db6455918cbc589d745fac46d9d6e30340c8731a
+  md5: 70caf8bb6cf39a0b6b7efc885f51c0fe
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: X11 AND BSD-3-Clause
+  size: 889086
+  timestamp: 1724658547447
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.2.0-py311hf916aec_0.conda
+  sha256: 96bacc2948ef680d88d038200e1c744e989bf960bc59d59e2ba27f9f295b0b26
+  md5: 82c097817ff68e7b6f5db63cdcb593d2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8973279
+  timestamp: 1733688742678
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.3-h5fbd93e_0.conda
+  sha256: 5bee706ea5ba453ed7fd9da7da8380dd88b865c8d30b5aaec14d2b6dd32dbc39
+  md5: 9e5816bc95d285c115a3ebc2f8563564
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libpng >=1.6.44,<1.7.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 342988
+  timestamp: 1733816638720
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
+  sha256: 814b9dff1847b132c676ee6cc1a8cb2d427320779b93e1b6d76552275c128705
+  md5: 23cc74f77eb99315c0360ec3533147a9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 2947466
+  timestamp: 1731377666602
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py311h7db5c69_1.conda
+  sha256: dce121d3838996b77b810ca9097cc17068552075c761408a9b2eb788cf8fd1b0
+  md5: 643f8cb35133eb1be4919fb953f0a25f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15695466
+  timestamp: 1726879158862
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.0.0-py311h49e9ac3_0.conda
+  sha256: f0f792596ae99cba01f829d064058b1e99ca84080fc89f72d925bfe473cfc1b6
+  md5: 2bd3d0f839ec0d1eaca817c9d1feb7c2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 42421065
+  timestamp: 1729065780130
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py311h9ecbd09_0.conda
+  sha256: 2ac3f1ed6e6a2a0c67a3922f4b5faf382855ad02cc0c85c5d56291c7a94296d0
+  md5: 0ffc1f53106a38f059b151c465891ed3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 505408
+  timestamp: 1729847169876
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+  sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
+  md5: b3c17d95b5a10c6e64a21fa17573e70e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 8252
+  timestamp: 1726802366959
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.11-h9e4cc4f_1_cpython.conda
+  sha256: b29ce0836fce55bdff8d5c5b71c4921a23f87d3b950aea89a9e75784120b06b0
+  md5: 8387070aa413ce9a8cc35a509fae938b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.6.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - liblzma >=5.6.3,<6.0a0
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.4.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 30624804
+  timestamp: 1733409665928
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
+  sha256: 2660b8059b3ee854bc5d3c6b1fce946e5bd2fe8fbca7827de2c5885ead6209de
+  md5: 139a8d40c8a2f430df31048949e450de
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6211
+  timestamp: 1723823324668
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h9ecbd09_1.conda
+  sha256: e721e5ff389a7b2135917c04b27391be3d3382e261bb60a369b1620655365c3d
+  md5: abeb54d40f439b86f75ea57045ab8496
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 212644
+  timestamp: 1725456264282
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py311h7deb3e3_3.conda
+  sha256: 3fdef7b3c43474b7225868776a373289a8fd92787ffdf8bed11cf7f39b4ac741
+  md5: e0897de1d8979a3bb20ef031ae1f7d28
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 389074
+  timestamp: 1728642373938
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+  sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
+  md5: 47d31b792659ce70f470b5c82fdfb7a4
+  depends:
+  - libgcc-ng >=12
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 281456
+  timestamp: 1679532220005
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.22.3-py311h9e33e62_0.conda
+  sha256: 0908ac4acb1a10fe63046e947a96c77cea0d392619ef965944da86c3574b68ec
+  md5: b1f5799ae0cc22198928f09879da01f5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  size: 351650
+  timestamp: 1733366766805
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+  sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
+  md5: d453b98d9c83e71da0741bb0ff4d76bc
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3318875
+  timestamp: 1699202167581
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.2-py311h9ecbd09_0.conda
+  sha256: afa3489113154b5cb0724b0bf120b62df91f426dabfe5d02f2ba09e90d346b28
+  md5: df3aee9c3e44489257a840b8354e77b9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 855653
+  timestamp: 1732616048886
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb9d3cd8_0.conda
+  sha256: ed10c9283974d311855ae08a16dfd7e56241fac632aec3b92e3cfe73cff31038
+  md5: f6ebe2cb3f82ba6c057dde5d9debe4f7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 14780
+  timestamp: 1734229004433
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+  sha256: 6b250f3e59db07c2514057944a3ea2044d6a8cdde8a47b6497c254520fade1ee
+  md5: 8035c64cb77ed555e3f150b7b3972480
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 19901
+  timestamp: 1727794976192
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+  sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
+  md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 89141
+  timestamp: 1641346969816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_7.conda
+  sha256: a4dc72c96848f764bb5a5176aa93dd1e9b9e52804137b99daeebba277b31ea10
+  md5: 3947a35e916fcc6b9825449affbf4214
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - libstdcxx >=13
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 335400
+  timestamp: 1731585026517
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py311hbc35293_1.conda
+  sha256: a5cf0eef1ffce0d710eb3dffcb07d9d5922d4f7a141abc96f6476b98600f718f
+  md5: aec590674ba365e50ae83aa2d6e1efae
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.11
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 417923
+  timestamp: 1725305669690
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+  sha256: c558b9cc01d9c1444031bd1ce4b9cff86f9085765f17627a6cd85fc623c8a02b
+  md5: 4d056880988120e29d75bfff282e0f45
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 554846
+  timestamp: 1714722996770
+- conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.7.0-pyhd8ed1ab_0.conda
+  sha256: 687537ee3af30f8784986bf40cac30e88138770b16e51ca9850c9c23c09aeba1
+  md5: c88107912954a983c2caf25f7fd55158
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.9
+  - sniffio >=1.1
+  - typing_extensions >=4.5
+  constrains:
+  - trio >=0.26.1
+  - uvloop >=0.21
+  license: MIT
+  license_family: MIT
+  size: 112730
+  timestamp: 1733532678437
+- conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
+  sha256: 8f032b140ea4159806e4969a68b4a3c0a7cab1ad936eb958a2b5ffe5335e19bf
+  md5: 54898d0f524c9dee622d44bbb081a8ab
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 10076
+  timestamp: 1733332433806
+- conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
+  sha256: 7af62339394986bc470a7a231c7f37ad0173ffb41f6bc0e8e31b0be9e3b9d20f
+  md5: a7ee488b71c30ada51c48468337b85ba
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.9
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 18594
+  timestamp: 1733311166338
+- conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_1.conda
+  sha256: c4b0bdb3d5dee50b60db92f99da3e4c524d5240aafc0a5fcc15e45ae2d1a3cd1
+  md5: 46b53236fdd990271b03c3978d4218a9
+  depends:
+  - python >=3.9
+  - python-dateutil >=2.7.0
+  - types-python-dateutil >=2.8.10
+  license: Apache-2.0
+  license_family: Apache
+  size: 99951
+  timestamp: 1733584345583
+- conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
+  sha256: 93b14414b3b3ed91e286e1cbe4e7a60c4e1b1c730b0814d1e452a8ac4b9af593
+  md5: 8f587de4bcf981e26228f268df374a9b
+  depends:
+  - python >=3.9
+  constrains:
+  - astroid >=2,<4
+  license: Apache-2.0
+  license_family: Apache
+  size: 28206
+  timestamp: 1733250564754
+- conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_1.conda
+  sha256: 344157f396dfdc929d1dff8fe010abe173cd168d22a56648583e616495f2929e
+  md5: 40c673c7d585623b8f1ee650c8734eb6
+  depends:
+  - python >=3.9
+  - typing_extensions >=4.0.0
+  license: MIT
+  license_family: MIT
+  size: 15318
+  timestamp: 1733584388228
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.3.0-pyh71513ae_0.conda
+  sha256: 750186af694a7130eaf7119fbb56db0d2326d8995ad5b8eae23c622b85fea29a
+  md5: 356927ace43302bf6f5926e2a58dae6a
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 56354
+  timestamp: 1734348889193
+- conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_1.conda
+  sha256: f6205d3a62e87447e06e98d911559be0208d824976d77ab092796c9176611fcb
+  md5: 3e23f7db93ec14c80525257d8affac28
+  depends:
+  - python >=3.9
+  - pytz >=2015.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6551057
+  timestamp: 1733236466015
+- conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_1.conda
+  sha256: fca842ab7be052eea1037ebee17ac25cc79c626382dd2187b5c6e007b9d9f65f
+  md5: d48f7e9fdec44baf6d1da416fe402b04
+  depends:
+  - python >=3.9
+  - soupsieve >=1.2
+  license: MIT
+  license_family: MIT
+  size: 118042
+  timestamp: 1733230951790
+- conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_1.conda
+  sha256: ffc8e4e53cd92aec0f0ea0bc9e28f5fd1b1e67bde46b0b298170e6fb78eecce1
+  md5: 707af59db75b066217403a8f00c1d826
+  depends:
+  - python >=3.9
+  - webencodings
+  license: Apache-2.0 AND MIT
+  license_family: Apache
+  size: 132933
+  timestamp: 1733302409510
+- conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.2-pyhd8ed1ab_1.conda
+  sha256: 66d2649b8b8f1ec58c83a9ff948aed4a3a86465ca6ccda686741797cae54b264
+  md5: 976ff24762f1f991b08f7a7a41875086
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.10
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4838239
+  timestamp: 1733754831166
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+  sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
+  md5: 9b347a7ec10940d3f7941ff6c460b551
+  depends:
+  - cached_property >=1.5.2,<1.5.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4134
+  timestamp: 1615209571450
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+  sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+  md5: 576d629e47797577ab0f1b351297ef4a
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11065
+  timestamp: 1615209567874
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.12.14-pyhd8ed1ab_0.conda
+  sha256: 048c16a9cbcb1fbad02083414d3bc7c1d0eea4b39aee6aa6bf8d1d5089ca8bad
+  md5: 6feb87357ecd66733be3279f16a8c400
+  depends:
+  - python >=3.9
+  license: ISC
+  size: 161642
+  timestamp: 1734380604767
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+  sha256: 63022ee2c6a157a9f980250a66f54bdcdf5abee817348d0f9a74c2441a6fbf0e
+  md5: 6581a17bba6b948bb60130026404a9d6
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 47533
+  timestamp: 1733218182393
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
+  md5: 962b9857ee8e7018c22f2776ffa0b2d7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27011
+  timestamp: 1733218222191
+- conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_1.conda
+  sha256: 7e87ef7c91574d9fac19faedaaee328a70f718c9b4ddadfdc0ba9ac021bd64af
+  md5: 74673132601ec2b7fc592755605f4c1b
+  depends:
+  - python >=3.9
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12103
+  timestamp: 1733503053903
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.11-py311hd8ed1ab_1.conda
+  sha256: b9bb4486ba7b81d7264e92f346c9fa2d4a6c9678c28b33fb5d1652ecc7f82e26
+  md5: 6aab9c45010dc5ed92215f89cdafa201
+  depends:
+  - python 3.11.11.*
+  - python_abi * *_cp311
+  license: Python-2.0
+  size: 46068
+  timestamp: 1733407866862
+- conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+  sha256: 84e5120c97502a3785e8c3241c3bf51f64b4d445f13b4d2445db00d9816fe479
+  md5: d622d8d7ee8868870f9cbe259f381181
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 14068
+  timestamp: 1733236549190
+- conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
+  md5: 961b3a227b437d82ad7054484cfa71b2
+  depends:
+  - python >=3.6
+  license: PSF-2.0
+  license_family: PSF
+  size: 24062
+  timestamp: 1615232388757
+- conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
+  sha256: 80f579bfc71b3dab5bef74114b89e26c85cb0df8caf4c27ab5ffc16363d57ee7
+  md5: 3366592d3c219f2731721f11bc93755c
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 11259
+  timestamp: 1733327239578
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+  sha256: cbde2c64ec317118fc06b223c5fd87c8a680255e7348dd60e7b292d2e103e701
+  md5: a16662747cdeb9abbac74d0057cc976e
+  depends:
+  - python >=3.9
+  license: MIT and PSF-2.0
+  size: 20486
+  timestamp: 1733208916977
+- conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_1.conda
+  sha256: 28d25ea375ebab4bf7479228f8430db20986187b04999136ff5c722ebd32eb60
+  md5: ef8b5fca76806159fc25b4f48d8737eb
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 28348
+  timestamp: 1733569440265
+- conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+  sha256: 2509992ec2fd38ab27c7cdb42cf6cadc566a1cc0d1021a2673475d9fa87c6276
+  md5: d3549fd50d450b6d9e7dddff25dd2110
+  depends:
+  - cached-property >=1.3.0
+  - python >=3.9,<4
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 16705
+  timestamp: 1733327494780
+- conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
+  sha256: 622516185a7c740d5c7f27016d0c15b45782c1501e5611deec63fd70344ce7c8
+  md5: 7ee49e89531c0dcbba9466f6d115d585
+  depends:
+  - python >=3.9
+  - typing_extensions
+  license: MIT
+  license_family: MIT
+  size: 51846
+  timestamp: 1733327599467
+- conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
+  sha256: 843ddad410c370672a8250470697027618f104153612439076d4d7b91eeb7b5c
+  md5: 825927dc7b0f287ef8d4d0011bb113b1
+  depends:
+  - hpack >=4.0,<5
+  - hyperframe >=6.0,<7
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 52000
+  timestamp: 1733298867359
+- conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyhd8ed1ab_1.conda
+  sha256: ec89b7e5b8aa2f0219f666084446e1fb7b54545861e9caa892acb24d125761b5
+  md5: 2aa5ff7fa34a81b9196532c84c10d865
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 29412
+  timestamp: 1733299296857
+- conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+  sha256: c84d012a245171f3ed666a8bf9319580c269b7843ffa79f26468842da3abd5df
+  md5: 2ca8e6dbc86525c8b95e3c0ffa26442e
+  depends:
+  - python >=3.8
+  - h11 >=0.13,<0.15
+  - h2 >=3,<5
+  - sniffio 1.*
+  - anyio >=3.0,<5.0
+  - certifi
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48959
+  timestamp: 1731707562362
+- conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+  sha256: cd0f1de3697b252df95f98383e9edb1d00386bfdd03fdf607fa42fe5fcb09950
+  md5: d6989ead454181f4f9bc987d3dc4e285
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 63082
+  timestamp: 1733663449209
+- conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_1.conda
+  sha256: e91c6ef09d076e1d9a02819cd00fa7ee18ecf30cdd667605c853980216584d1b
+  md5: 566e75c90c1d0c8c459eb0ad9833dc7a
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 17239
+  timestamp: 1733298862681
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+  sha256: d7a472c9fd479e2e8dcb83fb8d433fce971ea369d704ece380e876f9c3494e87
+  md5: 39a4f67be3286c86d696df570b1201b7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49765
+  timestamp: 1733211921194
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+  sha256: 13766b88fc5b23581530d3a0287c0c58ad82f60401afefab283bf158d2be55a9
+  md5: 315607a3030ad5d5227e76e0733798ff
+  depends:
+  - python >=3.9
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 28623
+  timestamp: 1733223207185
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
+  sha256: 461199e429a3db01f0a673f8beaac5e0be75b88895952fb9183f2ab01c5c3c24
+  md5: 15798fa69312d433af690c8c42b3fb36
+  depends:
+  - python >=3.9
+  - zipp >=3.1.0
+  constrains:
+  - importlib-resources >=6.4.5,<6.4.6.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 32701
+  timestamp: 1733231441973
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+  sha256: 33cfd339bb4efac56edf93474b37ddc049e08b1b4930cf036c893cc1f5a1f32a
+  md5: b40131ab6a36ac2c09b7c57d4d3fbf99
+  depends:
+  - __linux
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119084
+  timestamp: 1719845605084
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+  sha256: dc569094125127c0078aa536f78733f383dd7e09507277ef8bcd1789786e7086
+  md5: 18df5fc4944a679e085e0e8f31775fc8
+  depends:
+  - __win
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119853
+  timestamp: 1719845858082
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+  sha256: 072534d4d379225b2c3a4e38bc7730b65ae171ac7f0c2d401141043336e97980
+  md5: 9eb15d654daa0ef5a98802f586bb4ffc
+  depends:
+  - __osx
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119568
+  timestamp: 1719845667420
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
+  sha256: 65cdc105e5effea2943d3979cc1592590c923a589009b484d07672faaf047af1
+  md5: 5d6e5cb3a4b820f61b2073f0ad5431f1
+  depends:
+  - __unix
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.10
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 600248
+  timestamp: 1732897026255
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh7428d3b_0.conda
+  sha256: 94ee8215bd1f614c9c984437b184e8dbe61a4014eb5813c276e3dcb18aaa7f46
+  md5: 6cdaebbc9e3feb2811eb9f52ed0b89e1
+  depends:
+  - __win
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.10
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 600466
+  timestamp: 1732897444811
+- conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+  sha256: 08e838d29c134a7684bca0468401d26840f41c92267c4126d7b43a6b533b0aed
+  md5: 0b0154421989637d424ccf0f104be51a
+  depends:
+  - arrow >=0.15.0
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 19832
+  timestamp: 1733493720346
+- conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
+  sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
+  md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.9
+  license: Apache-2.0 AND MIT
+  size: 843646
+  timestamp: 1733300981994
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+  sha256: 85a7169c078b8065bd9d121b0e7b99c8b88c42a411314b6ae5fcd81c48c4710a
+  md5: 08cce3151bde4ecad7885bd9fb647532
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110963
+  timestamp: 1733217424408
+- conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.10.0-pyhd8ed1ab_1.conda
+  sha256: 61bca2dac194c44603446944745566d7b4e55407280f6f6cea8bbe4de26b558f
+  md5: cd170f82d8e5b355dfdea6adab23e4af
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 31573
+  timestamp: 1733272196759
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_1.conda
+  sha256: be992a99e589146f229c58fe5083e0b60551d774511c494f91fe011931bd7893
+  md5: a3cead9264b331b32fe8f0aabc967522
+  depends:
+  - attrs >=22.2.0
+  - importlib_resources >=1.4.0
+  - jsonschema-specifications >=2023.03.6
+  - pkgutil-resolve-name >=1.3.10
+  - python >=3.9
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 74256
+  timestamp: 1733472818764
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_1.conda
+  sha256: 37127133837444cf0e6d1a95ff5a505f8214ed4e89e8e9343284840e674c6891
+  md5: 3b519bc21bc80e60b456f1e62962a766
+  depends:
+  - python >=3.9
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 16170
+  timestamp: 1733493624968
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_1.conda
+  sha256: 6e0184530011961a0802fda100ecdfd4b0eca634ed94c37e553b72e21c26627d
+  md5: a5b1a8065857cc4bd8b7a38d063bb728
+  depends:
+  - fqdn
+  - idna
+  - isoduration
+  - jsonpointer >1.13
+  - jsonschema >=4.23.0,<4.23.1.0a0
+  - rfc3339-validator
+  - rfc3986-validator >0.1.0
+  - uri-template
+  - webcolors >=24.6.0
+  license: MIT
+  license_family: MIT
+  size: 7135
+  timestamp: 1733472820035
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_1.conda
+  sha256: 1565c8b1423a37fca00fe0ab2a17cd8992c2ecf23e7867a1c9f6f86a9831c196
+  md5: 0b4c3908e5a38ea22ebb98ee5888c768
+  depends:
+  - importlib-metadata >=4.8.3
+  - jupyter_server >=1.1.2
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55221
+  timestamp: 1733493006611
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
+  sha256: 19d8bd5bb2fde910ec59e081eeb59529491995ce0d653a5209366611023a0b3a
+  md5: 4ebae00eae9705b0c3d6d1018a81d047
+  depends:
+  - importlib-metadata >=4.8.3
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.9
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 106342
+  timestamp: 1733441040958
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+  sha256: 732b1e8536bc22a5a174baa79842d79db2f4956d90293dd82dc1b3f6099bcccd
+  md5: 0a2980dada0dd7fd0998f0342308b1b1
+  depends:
+  - __unix
+  - platformdirs >=2.5
+  - python >=3.8
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 57671
+  timestamp: 1727163547058
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh5737063_1.conda
+  sha256: 7c903b2d62414c3e8da1f78db21f45b98de387aae195f8ca959794113ba4b3fd
+  md5: 46d87d1c0ea5da0aae36f77fa406e20d
+  depends:
+  - __win
+  - cpython
+  - platformdirs >=2.5
+  - python >=3.8
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 58269
+  timestamp: 1727164026641
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.11.0-pyhd8ed1ab_0.conda
+  sha256: eeb32aa58d37b130387628d5c151092f6d3fcf0a6964294bef06d6bac117f3c4
+  md5: 2d8876ca6bda213622dfbc3d1da56ecb
+  depends:
+  - jsonschema-with-format-nongpl >=4.18.0
+  - packaging
+  - python >=3.9
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22160
+  timestamp: 1734531779868
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_1.conda
+  sha256: 082d3517455339c8baea245a257af249758ccec26b8832d969ac928901c234cc
+  md5: 81ea84b3212287f926e35b9036192963
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert-core >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.9
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 324289
+  timestamp: 1733428731329
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
+  sha256: 0890fc79422191bc29edf17d7b42cff44ba254aa225d31eb30819f8772b775b8
+  md5: 2d983ff1b82a1ccb6f2e9d8784bdd6bd
+  depends:
+  - python >=3.9
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19711
+  timestamp: 1733428049134
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.4-pyhd8ed1ab_0.conda
+  sha256: bcf9fc0ea4bd6cf06a7a23b7f8b7bb7d8520eea8d0cdd6d3b975ede7793ed69b
+  md5: edc13687180382b4444d9f143a2e1ef7
+  depends:
+  - async-lru >=1.0.0
+  - httpx >=0.25.0
+  - importlib-metadata >=4.8.3
+  - ipykernel >=6.5.0
+  - jinja2 >=3.0.3
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab_server >=2.27.1,<3
+  - notebook-shim >=0.2
+  - packaging
+  - python >=3.9
+  - setuptools >=40.8.0
+  - tomli >=1.2.2
+  - tornado >=6.2.0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7257751
+  timestamp: 1734539283837
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+  sha256: dc24b900742fdaf1e077d9a3458fd865711de80bca95fe3c6d46610c532c6ef0
+  md5: fd312693df06da3578383232528c468d
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.9
+  constrains:
+  - jupyterlab >=4.0.8,<5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18711
+  timestamp: 1733328194037
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_1.conda
+  sha256: d03d0b7e23fa56d322993bc9786b3a43b88ccc26e58b77c756619a921ab30e86
+  md5: 9dc4b2b0f41f0de41d27f3293e319357
+  depends:
+  - babel >=2.10
+  - importlib-metadata >=4.8.3
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.9
+  - requests >=2.31
+  constrains:
+  - openapi-core >=0.18.0,<0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49449
+  timestamp: 1733599666357
+- conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_1.conda
+  sha256: d975a2015803d4fdaaae3f53e21f64996577d7a069eb61c6d2792504f16eb57b
+  md5: b02fe519b5dc0dc55e7299810fcdfb8e
+  depends:
+  - python >=3.9
+  - uc-micro-py
+  license: MIT
+  license_family: MIT
+  size: 24154
+  timestamp: 1733781296133
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+  sha256: fce1fde00359696983989699c00f9891194c4ebafea647a8d21b7e2e3329b56e
+  md5: 06e9bebf748a0dea03ecbe1f0e27e909
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78331
+  timestamp: 1710435316163
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+  sha256: 0fbacdfb31e55964152b24d5567e9a9996e1e7902fb08eb7d91b5fd6ce60803a
+  md5: fee3164ac23dfca50cfcc8b85ddefb81
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 64430
+  timestamp: 1733250550053
+- conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
+  sha256: 69b7dc7131703d3d60da9b0faa6dd8acbf6f6c396224cf6aef3e855b8c0c41c6
+  md5: af6ab708897df59bd6e7283ceab1b56b
+  depends:
+  - python >=3.9
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14467
+  timestamp: 1733417051523
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_1.conda
+  sha256: c63ed79d9745109c0a70397713b0c07f06e7d3561abcb122cfc80a141ab3b449
+  md5: af2060041d4f3250a7eb6ab3ec0e549b
+  depends:
+  - markdown-it-py >=1.0.0,<4.0.0
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 42180
+  timestamp: 1733854816517
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+  sha256: 78c1bbe1723449c52b7a9df1af2ee5f005209f67e40b6e1d3c7619127c43b1c7
+  md5: 592132998493b3ff25fd7479396e8351
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 14465
+  timestamp: 1733255681319
+- conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_1.conda
+  sha256: 0a9faaf1692b74f321cedbd37a44f108a1ec3f5d9638bc5bbf860cb3b6ff6db4
+  md5: c46df05cae629e55426773ac1f85d68f
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65901
+  timestamp: 1733258822603
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+  sha256: 564e22c4048f2f00c7ee79417dea364f95cf069a1f2565dc26d5ece1fc3fd779
+  md5: 3ee79082e59a28e1db11e2a9c3bcd85a
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.8
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27878
+  timestamp: 1732882434219
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhff2d567_2.conda
+  sha256: 03a1303ce135a8214b450e751d93c9048f55edb37f3f9f06c5e9d78ba3ef2a89
+  md5: 0457fdf55c88e52e0e7b63691eafcc48
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<3.1
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.8
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - nbconvert =7.16.4=*_2
+  - pandoc >=2.9.2,<4.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 188505
+  timestamp: 1733405603619
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+  sha256: 7a5bd30a2e7ddd7b85031a5e2e14f290898098dc85bea5b3a5bf147c25122838
+  md5: bbe1963f1e47f594070ffe87cdf612ea
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.9
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100945
+  timestamp: 1733402844974
+- conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+  sha256: bb7b21d7fd0445ddc0631f64e66d91a179de4ba920b8381f29b9d006a42788c0
+  md5: 598fd7d4d0de2455fb74f56063969a97
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11543
+  timestamp: 1733325673691
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.3.1-pyhd8ed1ab_0.conda
+  sha256: d5bd4e3c27b2fd234c5d79f3749cd6139d5b13a88cb7320f93c239aabc28e576
+  md5: f663ab5bcc9a28364b7b80aa976ed00f
+  depends:
+  - importlib_resources >=5.0
+  - jupyter_server >=2.4.0,<3
+  - jupyterlab >=4.3.2,<4.4
+  - jupyterlab_server >=2.27.1,<3
+  - notebook-shim >=0.2,<0.3
+  - python >=3.9
+  - tornado >=6.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9415854
+  timestamp: 1733367221274
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+  sha256: 7b920e46b9f7a2d2aa6434222e5c8d739021dbc5cc75f32d124a8191d86f9056
+  md5: e7f89ea5f7ea9401642758ff50a2d9c1
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16817
+  timestamp: 1733408419340
+- conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+  sha256: 1840bd90d25d4930d60f57b4f38d4e0ae3f5b8db2819638709c36098c6ba770c
+  md5: e51f1e4089cad105b6cac64bd8166587
+  depends:
+  - python >=3.9
+  - typing_utils
+  license: Apache-2.0
+  license_family: APACHE
+  size: 30139
+  timestamp: 1734587755455
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+  sha256: da157b19bcd398b9804c5c52fc000fcb8ab0525bdb9c70f95beaa0bb42f85af1
+  md5: 3bfed7e6228ebf2f7b9eaa47f1b4e2aa
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: APACHE
+  size: 60164
+  timestamp: 1733203368787
+- conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
+  md5: 457c2c8c08e54905d6954e79cb5b5db9
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11627
+  timestamp: 1631603397334
+- conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+  sha256: 5a05f572a610cada2fcccef8d555fddf2d01bef80da32411150735e6177d1eab
+  md5: 41c7413071c2bae37472214a3525e6bf
+  depends:
+  - bleach
+  - bokeh >=3.5.0,<3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.1.0,<3.0
+  - python >=3.10
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20670374
+  timestamp: 1731497809631
+- conda: https://conda.anaconda.org/conda-forge/noarch/param-2.2.0-pyhd8ed1ab_0.conda
+  sha256: 857c0e09b51d5c81d5a2144d4a5bd3dc15f81a52f1bf3da9290baff3deae6b5d
+  md5: 8bd46aebe85bd9c5f30affd520ab441f
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104754
+  timestamp: 1734441144421
+- conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
+  sha256: 17131120c10401a99205fc6fe436e7903c0fa092f1b3e80452927ab377239bcc
+  md5: 5c092057b6badd30f75b06244ecd01c9
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 75295
+  timestamp: 1733271352153
+- conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+  sha256: 202af1de83b585d36445dc1fda94266697341994d1a3328fabde4989e1b3d07a
+  md5: d0d408b1f18883a944376da5cf8101ea
+  depends:
+  - ptyprocess >=0.5
+  - python >=3.9
+  license: ISC
+  size: 53561
+  timestamp: 1733302019362
+- conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+  sha256: e2ac3d66c367dada209fc6da43e645672364b9fd5f9d28b9f016e24b81af475b
+  md5: 11a9d1d09a3615fc07c3faf79bc0b943
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 11748
+  timestamp: 1733327448200
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_2.conda
+  sha256: da8c8888de10c1e4234ebcaa1550ac2b4b5408ac20f093fe641e4bc8c9c9f3eb
+  md5: 04e691b9fadd93a8a9fad87a81d4fd8f
+  depends:
+  - python >=3.9,<3.13.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 1245116
+  timestamp: 1734466348103
+- conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+  sha256: adb2dde5b4f7da70ae81309cce6188ed3286ff280355cf1931b45d91164d2ad8
+  md5: 5a5870a74432aa332f7d32180633ad05
+  depends:
+  - python >=3.9
+  license: MIT AND PSF-2.0
+  size: 10693
+  timestamp: 1733344619659
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+  sha256: bb50f6499e8bc1d1a26f17716c97984671121608dc0c3ecd34858112bce59a27
+  md5: 577852c7e53901ddccc7e6a9959ddebe
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 20448
+  timestamp: 1733232756001
+- conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.1-pyhd8ed1ab_0.conda
+  sha256: bc8f00d5155deb7b47702cb8370f233935704100dbc23e30747c161d1b6cf3ab
+  md5: 3e01e386307acc60b2f89af0b2e161aa
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  size: 49002
+  timestamp: 1733327434163
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_1.conda
+  sha256: 79fb7d1eeb490d4cc1b79f781bb59fe302ae38cf0a30907ecde75a7d399796cc
+  md5: 368d4aa48358439e07a97ae237491785
+  depends:
+  - python >=3.9
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.48
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269848
+  timestamp: 1733302634979
+- conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+  sha256: a7713dfe30faf17508ec359e0bc7e0983f5d94682492469bd462cdaae9c64d83
+  md5: 7d9daffbb8d8e0af0f769dbbcd173a54
+  depends:
+  - python >=3.9
+  license: ISC
+  size: 19457
+  timestamp: 1733302371990
+- conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+  sha256: 71bd24600d14bb171a6321d523486f6a06f855e75e547fa0cb2a0953b02047f0
+  md5: 3bfdfb8dbcdc4af1ae3f9a8eb3948f04
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 16668
+  timestamp: 1733569518868
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+  sha256: 79db7928d13fab2d892592223d7570f5061c192f27b9febd1a418427b719acc6
+  md5: 12c566707c80111f9799308d9e265aef
+  depends:
+  - python >=3.9
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110100
+  timestamp: 1733195786147
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+  sha256: 0d6133545f268b2b89c2617c196fc791f365b538d4057ecd636d658c3b1e885d
+  md5: b38dc0206e2a530e5c2cf11dc086b31a
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 876700
+  timestamp: 1733221731178
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
+  sha256: d016e04b0e12063fbee4a2d5fbb9b39a8d191b5a0042f0b8459188aedeabb0ca
+  md5: e2fd202833c4a981ce8a65974fe4abd1
+  depends:
+  - __win
+  - python >=3.9
+  - win_inet_pton
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21784
+  timestamp: 1733217448189
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+  sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
+  md5: 461219d1a5bd61342293efa2c0c90eac
+  depends:
+  - __unix
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21085
+  timestamp: 1733217331982
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+  sha256: a50052536f1ef8516ed11a844f9413661829aa083304dc624c5925298d078d79
+  md5: 5ba79d7c71f03c678c8ead841f347d6e
+  depends:
+  - python >=3.9
+  - six >=1.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 222505
+  timestamp: 1733215763718
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
+  sha256: 1b09a28093071c1874862422696429d0d35bd0b8420698003ac004746c5e82a2
+  md5: 38e34d2d1d9dca4fb2b9a0a04f604e2c
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 226259
+  timestamp: 1733236073335
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+  sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
+  md5: a61bf9ec79426938ff785eb69dbb1960
+  depends:
+  - python >=3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13383
+  timestamp: 1677079727691
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+  sha256: 57c9a02ec25926fb48edca59b9ede107823e5d5c473b94a0e05cc0b9a193a642
+  md5: c0def296b2f6d2dd7b030c2a7f66bb1f
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 142235
+  timestamp: 1733235414217
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+  sha256: 1a7d6b233f7e6e3bbcbad054c8fd51e690a67b129a899a056a5e45dd9f00cb41
+  md5: 3eeeeb9e4827ace8c0c1419c85d590ad
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 188538
+  timestamp: 1706886944988
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+  sha256: a7979e8e4936c430f5fe3d04fc2d67b42dab84fb4a502c4961a17dcb2327fec0
+  md5: 02b4e3a3014c1ac490ee4a4316f2d229
+  depends:
+  - param
+  - python >=3.6
+  constrains:
+  - jupyterlab >=4.0,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48061
+  timestamp: 1722535734510
+- conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_1.conda
+  sha256: f972eecb4dc8e06257af37642f92b0f2df04a7fe4c950f2e1045505e5e93985f
+  md5: 8c9083612c1bfe6878715ed5732605f8
+  depends:
+  - attrs >=22.2.0
+  - python >=3.9
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 42201
+  timestamp: 1733366868091
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+  sha256: d701ca1136197aa121bbbe0e8c18db6b5c94acbd041c2b43c70e5ae104e1d8ad
+  md5: a9b9368f3701a417eac9edbcae7cb737
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.9
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 58723
+  timestamp: 1733217126197
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+  sha256: 2e4372f600490a6e0b3bac60717278448e323cab1c0fecd5f43f7c56535a99c5
+  md5: 36de09a8d3e5d5e6f4ee63af49e59706
+  depends:
+  - python >=3.9
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10209
+  timestamp: 1733600040800
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+  sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
+  md5: 912a71cc01012ee38e6b90ddd561e36f
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 7818
+  timestamp: 1598024297745
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_1.conda
+  sha256: 00926652bbb8924e265caefdb1db100f86a479e8f1066efe395d5552dde54d02
+  md5: 938c8de6b9de091997145b3bf25cdbf9
+  depends:
+  - __linux
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22736
+  timestamp: 1733322148326
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_1.conda
+  sha256: 5282eb5b462502c38df8cb37cd1542c5bbe26af2453a18a0a0602d084ca39f53
+  md5: e67b1b1fa7a79ff9e8e326d0caf55854
+  depends:
+  - __osx
+  - pyobjc-framework-cocoa
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23100
+  timestamp: 1733322309409
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_1.conda
+  sha256: ba8b93df52e0d625177907852340d735026c81118ac197f61f1f5baea19071ad
+  md5: e6a4e906051565caf5fdae5b0415b654
+  depends:
+  - __win
+  - python >=3.9
+  - pywin32
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23359
+  timestamp: 1733322590167
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+  sha256: abb12e1dd515b13660aacb5d0fd43835bc2186cab472df25b7716cd65e095111
+  md5: fc80f7995e396cbaeabd23cf46c413dc
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 774252
+  timestamp: 1732632769210
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+  sha256: 41db0180680cc67c3fa76544ffd48d6a5679d96f4b71d7498a759e94edc9a2db
+  md5: a451d576819089b0d672f18768be0f65
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 16385
+  timestamp: 1733381032766
+- conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+  sha256: c2248418c310bdd1719b186796ae50a8a77ce555228b6acd32768e2543a15012
+  md5: bf7a226e58dfb8346c70df36065d86c9
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  size: 15019
+  timestamp: 1733244175724
+- conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+  sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
+  md5: 3f144b2c34f8cb5a9abd9ed23a39c561
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 36754
+  timestamp: 1693929424267
+- conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+  sha256: 570da295d421661af487f1595045760526964f41471021056e993e73089e9c41
+  md5: b1b505328da7a6b246787df4b5a49fbc
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 26988
+  timestamp: 1733569565672
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+  sha256: b300557c0382478cf661ddb520263508e4b3b5871b471410450ef2846e8c352c
+  md5: efba281bbdae5f6b0a1d53c6d4a97c93
+  depends:
+  - __linux
+  - ptyprocess
+  - python >=3.8
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22452
+  timestamp: 1710262728753
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+  sha256: 4daae56fc8da17784578fbdd064f17e3b3076b394730a14119e571707568dc8a
+  md5: 00b54981b923f5aefcd5e8547de056d5
+  depends:
+  - __osx
+  - ptyprocess
+  - python >=3.8
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22717
+  timestamp: 1710265922593
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
+  sha256: 8cb078291fd7882904e3de594d299c8de16dd3af7405787fce6919a385cfc238
+  md5: 4abd500577430a942a995fd0d09b76a2
+  depends:
+  - __win
+  - python >=3.8
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22883
+  timestamp: 1710262943966
+- conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+  sha256: cad582d6f978276522f84bd209a5ddac824742fe2d452af6acf900f8650a73a2
+  md5: f1acf5fdefa8300de697982bcb1761c9
+  depends:
+  - python >=3.5
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28285
+  timestamp: 1729802975370
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+  sha256: 18636339a79656962723077df9a56c0ac7b8a864329eb8f847ee3d38495b863e
+  md5: ac944244f1fed2eb49bae07193ae8215
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 19167
+  timestamp: 1733256819729
+- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+  sha256: 5673b7104350a6998cb86cccf1d0058217d86950e8d6c927d8530606028edb1d
+  md5: 4085c9db273a148e149c03627350e22c
+  depends:
+  - colorama
+  - python >=3.7
+  license: MPL-2.0 or MIT
+  size: 89484
+  timestamp: 1732497312317
+- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+  sha256: f39a5620c6e8e9e98357507262a7869de2ae8cc07da8b7f84e517c9fd6c2b959
+  md5: 019a7385be9af33791c989871317e1ed
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110051
+  timestamp: 1733367480074
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241206-pyhd8ed1ab_0.conda
+  sha256: 8b98cd9464837174ab58aaa912fc95d5831879864676650a383994033533b8d1
+  md5: 1dbc4a115e2ad9fb7f9d5b68397f66f9
+  depends:
+  - python >=3.9
+  license: Apache-2.0 AND MIT
+  size: 22104
+  timestamp: 1733612458611
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
+  sha256: c8e9c1c467b5f960b627d7adc1c65fece8e929a3de89967e91ef0f726422fd32
+  md5: b6a408c64b78ec7b779a3e5c7a902433
+  depends:
+  - typing_extensions 4.12.2 pyha770c72_1
+  license: PSF-2.0
+  license_family: PSF
+  size: 10075
+  timestamp: 1733188758872
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+  sha256: 337be7af5af8b2817f115b3b68870208b30c31d3439bec07bfb2d8f4823e3568
+  md5: d17f13df8b65464ca316cbc000a3cb64
+  depends:
+  - python >=3.9
+  license: PSF-2.0
+  license_family: PSF
+  size: 39637
+  timestamp: 1733188758212
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+  sha256: 3088d5d873411a56bf988eee774559335749aed6f6c28e07bf933256afb9eb6c
+  md5: f6d7aa696c67756a650e91e15e88223c
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 15183
+  timestamp: 1733331395943
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+  sha256: 4fde5c3008bf5d2db82f2b50204464314cc3c91c1d953652f7bd01d9e52aefdf
+  md5: 8ac3367aafb1cc0a068483c580af8015
+  license: LicenseRef-Public-Domain
+  size: 122354
+  timestamp: 1728047496079
+- conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_1.conda
+  sha256: a2f837780af450d633efc052219c31378bcad31356766663fb88a99e8e4c817b
+  md5: 9c96c9876ba45368a03056ddd0f20431
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 11199
+  timestamp: 1733784280160
+- conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+  sha256: e0eb6c8daf892b3056f08416a96d68b0a358b7c46b99c8a50481b22631a4dfc0
+  md5: e7cb0f5745e4c5035a460248334af7eb
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 23990
+  timestamp: 1733323714454
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+  sha256: 416e30a1c3262275f01a3e22e783118d9e9d2872a739a9ed860d06fa9c7593d5
+  md5: 4a2d8ef7c37b8808c5b9b750501fffce
+  depends:
+  - brotli-python >=1.0.9
+  - h2 >=4,<5
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 98077
+  timestamp: 1733206968917
+- conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
+  sha256: f21e63e8f7346f9074fd00ca3b079bd3d2fa4d71f1f89d5b6934bf31446dc2a5
+  md5: b68980f2495d096e71c7fd9d7ccf63e6
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 32581
+  timestamp: 1733231433877
+- conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
+  sha256: 08315dc2e61766a39219b2d82685fc25a56b2817acf84d5b390176080eaacf99
+  md5: b49f7b291e15494aafb0a7d74806f337
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18431
+  timestamp: 1733359823938
+- conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+  sha256: 19ff205e138bb056a46f9e3839935a2e60bd1cf01c8241a5e172a422fed4f9c6
+  md5: 2841eb5bfc75ce15e9a0054b98dcd64d
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15496
+  timestamp: 1733236131358
+- conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
+  sha256: 1dd84764424ffc82030c19ad70607e6f9e3b9cb8e633970766d697185652053e
+  md5: 84f8f77f0a9c6ef401ee96611745da8f
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 46718
+  timestamp: 1733157432924
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+  sha256: 1b34021e815ff89a4d902d879c3bd2040bc1bd6169b32e9427497fa05c55f1ce
+  md5: 75cb7132eb58d97896e173ef12ac9986
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 62931
+  timestamp: 1733130309598
+- conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+  sha256: 93807369ab91f230cf9e6e2a237eaa812492fe00face5b38068735858fba954f
+  md5: 46e441ba871f524e2b067929da3051c2
+  depends:
+  - __win
+  - python >=3.9
+  license: LicenseRef-Public-Domain
+  size: 9555
+  timestamp: 1733130678956
+- conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_1.conda
+  sha256: 5f8757092fc985d7586f2659505ec28757c05fd65d8d6ae549a5cec7e3376977
+  md5: c79cea50b258f652010cb6c8d81591b5
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 46860
+  timestamp: 1733143536777
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+  sha256: 567c04f124525c97a096b65769834b7acb047db24b15a56888a322bf3966c3e1
+  md5: 0c3cc595284c5e8f0f9900a9b228a332
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 21809
+  timestamp: 1732827613585
+- conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h3336109_5.conda
+  sha256: fa5eb633b320e10fc2138f3d842d8a8ca72815f106acbab49a68ec9783e4d70d
+  md5: 29b46bd410067f668c4cef7fdc78fe25
+  depends:
+  - __osx >=10.13
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 32275
+  timestamp: 1725356815696
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hd89902b_2.conda
+  sha256: 004cefbd18f581636a8dcb1964fb73478f15d496769226ec896c1d4a0161b7d8
+  md5: d75f06ee06001794aa83a05e885f1520
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 363793
+  timestamp: 1725267947069
+- conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+  sha256: cad153608b81fb24fc8c509357daa9ae4e49dfc535b2cb49b91e23dbd68fc3c5
+  md5: 7ed4301d437b59045be7e051a0308211
+  depends:
+  - __osx >=10.13
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 134188
+  timestamp: 1720974491916
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.12.14-h8857fd0_0.conda
+  sha256: ddaafdcd1b8ace6ffeea22b6824ca9db8a64cf0a2652a11d7554ece54935fa06
+  md5: b7b887091c99ed2e74845e75e9128410
+  license: ISC
+  size: 156925
+  timestamp: 1734208413176
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.1-py311h137bacd_0.conda
+  sha256: 012ee7b1ed4f9b0490d6e90c72decf148d7575173c7eaf851cd87fd434d2cacc
+  md5: a4b0f531064fa3dd5e3afbb782ea2cd5
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 288762
+  timestamp: 1725560945833
+- conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.1-py311h4e34fa0_0.conda
+  sha256: 373e17f22bca3e13aac2245bb0c8a15c4a54d1ffa4c3278308eeb8d3c9435c0e
+  md5: 6bc3882064e277827934e2c6e5281661
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 255123
+  timestamp: 1731428577146
+- conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.11-py311hc356e98_0.conda
+  sha256: 21eb9fba357931a236762be29e8cac46a31dadc7c9331fc6dab12fdb76a436dc
+  md5: 8a01667a3ede4f50226273c585cb7454
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2483345
+  timestamp: 1734159136244
+- conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+  sha256: b292cf5a25f094eeb4b66e37d99a97894aafd04a5683980852a8cbddccdc8e4e
+  md5: 25152fce119320c980e5470e64834b50
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 599300
+  timestamp: 1694616137838
+- conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_1.conda
+  sha256: 2499e5ebb3efa4186d6922122224d16bac791a5c0adad5b48b2bcd1e1e2afc8d
+  md5: b6c1710105dad14d47001a339cd14da6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17727
+  timestamp: 1725302991176
+- conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+  sha256: 83b52685a4ce542772f0892a0f05764ac69d57187975579a0835ff255ae3ef9c
+  md5: d4765c524b1d91567886bde656fb514b
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1185323
+  timestamp: 1719463492984
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
+  sha256: 222ebc0a55544b9922f61e75015d02861e65b48f12113af41d48ba0814e14e4e
+  md5: 1442db8f03517834843666c422238c9b
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 224432
+  timestamp: 1701648089496
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+  sha256: e41790fc0f4089726369b3c7f813117bbc14b533e0ed8b94cf75aba252e82497
+  md5: f9d6a4c82889d5ecedec1d90eb673c55
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 290319
+  timestamp: 1657977526749
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-26_osx64_openblas.conda
+  sha256: 4e860b60c06be04f2c37c45def870e4ea5268f568547b80a8f69ad6ecddb6f31
+  md5: 2f03da7a6d52d98bbea1f7390d6997bf
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - libcblas 3.9.0 26_osx64_openblas
+  - liblapack 3.9.0 26_osx64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 26_osx64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16611
+  timestamp: 1734432938741
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-26_osx64_openblas.conda
+  sha256: 4d5dd9aeca2fa37f01d6c0bdbafba0e4f8b6601758239fa85d0640d012a151d6
+  md5: 8726a2949c303b23da89be658a19675c
+  depends:
+  - libblas 3.9.0 26_osx64_openblas
+  constrains:
+  - liblapack 3.9.0 26_osx64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 26_osx64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16579
+  timestamp: 1734432954376
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.6-hf95d169_1.conda
+  sha256: c40661648c34c08e21b69e0eec021ccaf090ffff070d2a9cbcb1519e1b310568
+  md5: 1bad6c181a0799298aad42fc5a7e98b7
+  depends:
+  - __osx >=10.13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 527370
+  timestamp: 1734494305140
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.23-he65b83e_0.conda
+  sha256: 20c1e685e7409bb82c819ba55b9f7d9a654e8e6d597081581493badb7464520e
+  md5: 120f8f7ba6a8defb59f4253447db4bb4
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 69309
+  timestamp: 1734374105905
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+  sha256: dbd3c3f2eca1d21c52e4c03b21930bbce414c4592f8ce805801575b9e9256095
+  md5: 6016a8a1d0e63cac3de2c352cd40208b
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 105382
+  timestamp: 1597616576726
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.4-h240833e_0.conda
+  sha256: d10f43d0c5df6c8cf55259bce0fe14d2377eed625956cddce06f58827d288c59
+  md5: 20307f4049a735a78a29073be1be2626
+  depends:
+  - __osx >=10.13
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 70758
+  timestamp: 1730967204736
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+  sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
+  md5: ccb34fb14960ad8b125962d3d79b31a9
+  license: MIT
+  license_family: MIT
+  size: 51348
+  timestamp: 1636488394370
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+  sha256: 4874422e567b68334705c135c17e5acdca1404de8255673ce30ad3510e00be0d
+  md5: 0b6e23a012ee7a9a5f6b244f5a92c1d5
+  depends:
+  - libgfortran5 13.2.0 h2873a65_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110106
+  timestamp: 1707328956438
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+  sha256: da3db4b947e30aec7596a3ef92200d17e774cccbbf7efc47802529a4ca5ca31b
+  md5: e4fb4d23ec2870ff3c40d10afe305aec
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1571379
+  timestamp: 1707328880361
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+  sha256: d9572fd1024adc374aae7c247d0f29fdf4b122f1e3586fe62acc18067f40d02f
+  md5: 72507f8e3961bc968af17435060b6dd6
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 579748
+  timestamp: 1694475265912
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-26_osx64_openblas.conda
+  sha256: 166b07a129d122dbe90b06b582b5c29fbe5b958547fb474ca497cb084846810d
+  md5: c0c54bb6382ff1e52bf08f1da539e9b4
+  depends:
+  - libblas 3.9.0 26_osx64_openblas
+  constrains:
+  - libcblas 3.9.0 26_osx64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 26_osx64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16588
+  timestamp: 1734432968940
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.6.3-hd471939_1.conda
+  sha256: c70639ff3cb034a8e31cb081c907879b6a639bb12b0e090069a68eb69125b10e
+  md5: f9e9205fed9c664421c1c09f0b90ce6d
+  depends:
+  - __osx >=10.13
+  constrains:
+  - xz ==5.6.3=*_1
+  license: 0BSD
+  size: 103745
+  timestamp: 1733407504892
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_hbf64a52_1.conda
+  sha256: cef5856952688ce9303f85f5bc62c99e8c2256b4c679f63afdfb381f222e90c7
+  md5: cd2c572c02a73b88c4d378eb31110e85
+  depends:
+  - __osx >=10.13
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - llvm-openmp >=18.1.8
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6165715
+  timestamp: 1730773348340
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.44-h4b8f8c9_0.conda
+  sha256: 12b44e58f8832798d7a5c0a7480c95e905dbd6c3558dec09739062411f9e08d1
+  md5: f32ac2c8dd390dbf169f550887ed09d9
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 268073
+  timestamp: 1726234803010
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
+  sha256: d3975cfe60e81072666da8c76b993af018cf2e73fe55acba2b5ba0928efaccf5
+  md5: 6af4b059e26492da6013e79cbcb4d069
+  depends:
+  - __osx >=10.13
+  license: ISC
+  size: 210249
+  timestamp: 1716828641383
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.2-hdb6dae5_0.conda
+  sha256: 4d5e188d921f93c97ce172fc8c4341e8171670ec98d76f9961f65f6306fcda77
+  md5: 44d9799fda97eb34f6d88ac1e3eb0ea6
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 923167
+  timestamp: 1733761860127
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-hb77a491_3.conda
+  sha256: bb50df7cfc1acb11eae63c5f4fdc251d381cda96bf02c086c3202c83a5200032
+  md5: 6f2f9df7b093d6b33bc0c334acc7d2d9
+  depends:
+  - __osx >=10.13
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=18
+  - libdeflate >=1.23,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 400099
+  timestamp: 1734398943635
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
+  sha256: 7bafd8f4c637778cd0aa390bf3a894feef0e1fcf6ea6000c7ffc25c4c5a65538
+  md5: b2c0047ea73819d992484faacbbe1c24
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 355099
+  timestamp: 1713200298965
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+  sha256: 8896cd5deff6f57d102734f3e672bc17120613647288f9122bec69098e839af7
+  md5: bbeca862892e2898bdb45792a61c4afc
+  depends:
+  - __osx >=10.13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 323770
+  timestamp: 1727278927545
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+  sha256: 8412f96504fc5993a63edf1e211d042a1fd5b1d51dedec755d2058948fcced09
+  md5: 003a54a4e32b02f7355b50a837e699da
+  depends:
+  - __osx >=10.13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 57133
+  timestamp: 1727963183990
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.6-ha54dae1_0.conda
+  sha256: f79a1d6f8b2f6044eda1b1251c9bf49f4e11ae644e609e47486561a7eca437fd
+  md5: 4fe4d62071f8a3322ffb6588b49ccbb8
+  depends:
+  - __osx >=10.13
+  constrains:
+  - openmp 19.1.6|19.1.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 305048
+  timestamp: 1734520356844
+- conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.2-py311ha3cf9ac_1.conda
+  sha256: e9965b5d4c29b17b1512035b24a7c126ed7bdb6b39103b52cae099d5bb4194a9
+  md5: 1d6596ca7c7b66215c5c0d58b3cb0dd3
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24688
+  timestamp: 1733219887972
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
+  sha256: b0b3180039ef19502525a2abd5833c00f9624af830fd391f851934d57bffb9af
+  md5: e102bbf8a6ceeaf429deab8032fc8977
+  depends:
+  - __osx >=10.13
+  license: X11 AND BSD-3-Clause
+  size: 822066
+  timestamp: 1724658603042
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.2.0-py311h4632d39_0.conda
+  sha256: 7a9d6139763fab55c4ed8f88abe951d915d166ca8b0a03a0aec52628338243de
+  md5: d9afff186ad4267cabc94392fa4c1e93
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8254574
+  timestamp: 1733688667280
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.3-h7fd6d84_0.conda
+  sha256: faea03f36c9aa3524c911213b116da41695ff64b952d880551edee2843fe115b
+  md5: 025c711177fc3309228ca1a32374458d
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - libpng >=1.6.44,<1.7.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 332320
+  timestamp: 1733816828284
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hd471939_0.conda
+  sha256: ba7e068ed469d6625e32ae60e6ad893e655b6695280dadf7e065ed0b6f3b885c
+  md5: ec99d2ce0b3033a75cbad01bbc7c5b71
+  depends:
+  - __osx >=10.13
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2590683
+  timestamp: 1731378034404
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.3-py311haeb46be_1.conda
+  sha256: ad35c52521f0946caf06e19fd3dfad55f7b30e46648f96214f59d8ca2dac95ad
+  md5: ca32a9963a1b5c636b5131831ded81f3
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14864168
+  timestamp: 1726879042435
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.0.0-py311h1f68098_0.conda
+  sha256: 3826fe546e711787ce5b42e2f9176589846631945a528176da0fb61e751d3749
+  md5: ab73babea5e9a94d4f0f3c8fead83459
+  depends:
+  - __osx >=10.13
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 42126861
+  timestamp: 1729065932260
+- conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.0-py311h1314207_0.conda
+  sha256: 340d19b16a2f5b663b4f000188467831b107dcaa5b15522e172d6a27820d3b01
+  md5: 446e328d89429c077ccd74d7e9d8853e
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 512211
+  timestamp: 1729847190327
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+  sha256: 05944ca3445f31614f8c674c560bca02ff05cb51637a96f665cb2bbe496099e5
+  md5: 8bcf980d2c6b17094961198284b8e862
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 8364
+  timestamp: 1726802331537
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.3.2-py311hfbc4093_0.conda
+  sha256: 4b6729088cc2b5461b5f1cf080a400921538b52854b3ef3ef55dc3382d3dd365
+  md5: b7ae34cfc2cbd83ec8fb9783bc00df1c
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 490751
+  timestamp: 1732987367396
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.3.2-py311hfbc4093_0.conda
+  sha256: c3ceda073b0164655f16b080d9c9b9d027021e4e0142c04a029663adc8eda0ee
+  md5: 6f2fc8232ec4b6da3b7f4aac21eaaa3b
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 10.3.2.*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 381731
+  timestamp: 1733168922676
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.11-h9ccd52b_1_cpython.conda
+  sha256: 4c53c4c48a0f42577ae405553ab899b3ef5ee23b2a1bf4fbbc694c46f884f6fc
+  md5: 9b20fb7c571405d29f33ae2fc5990d8d
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.4.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 14221518
+  timestamp: 1733409959819
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
+  sha256: 9b092850a268aca99600b724bae849f51209ecd5628e609b4699debc59ff1945
+  md5: e6d62858c06df0be0e6255c753d74787
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6303
+  timestamp: 1723823062672
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311h3336109_1.conda
+  sha256: d8f4513c53a7c0be9f1cdb9d1af31ac85cf8a6f0e4194715e36e915c03104662
+  md5: b0132bec7165a53403dcc393ff761a9e
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 193941
+  timestamp: 1725456465818
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.2.0-py311h4d3da15_3.conda
+  sha256: 6aa664170031e36302616978404175c6ada3bd4a14c71bac826fa6a7ec15f815
+  md5: 48a614f384285254a3224d086dc84ce3
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 366412
+  timestamp: 1728642446264
+- conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+  sha256: 41e7d30a097d9b060037f0c6a2b1d4c4ae7e942c06c943d23f9d481548478568
+  md5: f17f77f2acf4d344734bda76829ce14e
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 255870
+  timestamp: 1679532707590
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.22.3-py311h3b9c2be_0.conda
+  sha256: 435d6ddb0a1625b91e83573b17fcd543ebedffc81d912cacb53d48a8cb59a861
+  md5: 19f12b2368042654dbc26036f036483b
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 329432
+  timestamp: 1733367026508
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+  sha256: 30412b2e9de4ff82d8c2a7e5d06a15f4f4fef1809a72138b6ccb53a33b26faf5
+  md5: bf830ba5afc507c6232d4ef0fb1a882d
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3270220
+  timestamp: 1699202389792
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.2-py311h4d7f069_0.conda
+  sha256: 5273ba307489570df61d82a6b3365b2a27862765099cf4ef3830569fa4a30f27
+  md5: 073c42a2b6b7e4219325b1f5983c7579
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 858750
+  timestamp: 1732616082798
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.12-h6e16a3a_0.conda
+  sha256: b4d2225135aa44e551576c4f3cf999b3252da6ffe7b92f0ad45bb44b887976fc
+  md5: 4cf40e60b444d56512a64f39d12c20bd
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 13290
+  timestamp: 1734229077182
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
+  sha256: bb4d1ef9cafef535494adf9296130b6193b3a44375883185b5167de03eb1ac7f
+  md5: 9f438e1b6f4e73fd9e6d78bfe7c36743
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 18465
+  timestamp: 1727794980957
+- conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+  sha256: 5301417e2c8dea45b401ffee8df3957d2447d4ce80c83c5ff151fc6bfe1c4148
+  md5: d7e08fcf8259d742156188e8762b4d20
+  license: MIT
+  license_family: MIT
+  size: 84237
+  timestamp: 1641347062780
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h7130eaa_7.conda
+  sha256: b932dce8c9de9a8ffbf0db0365d29677636e599f7763ca51e554c43a0c5f8389
+  md5: 6a0a76cd2b3d575e1b7aaeb283b9c3ed
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.3,<1.22.0a0
+  - libcxx >=18
+  - libsodium >=1.0.20,<1.0.21.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 292112
+  timestamp: 1731585246902
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py311hdf6fcd6_1.conda
+  sha256: d9bf977b620750049eb60fffca299a701342a2df59bcc2586a79b2f7c5783fa1
+  md5: 4fc42d6f85a21b09ee6477f456554df3
+  depends:
+  - __osx >=10.13
+  - cffi >=1.11
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411350
+  timestamp: 1725305723486
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
+  sha256: efa04a98cb149643fa54c4dad5a0179e36a5fbc88427ea0eec88ceed87fd0f96
+  md5: 4cb2cd56f039b129bb0e491c1164167e
+  depends:
+  - __osx >=10.9
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 498900
+  timestamp: 1714723303098
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311h460d6c5_5.conda
+  sha256: 6eabd1bcefc235b7943688d865519577d7668a2f4dc3a24ee34d81eb4bfe77d1
+  md5: 1e8260965552c6ec86453b7d15a598de
+  depends:
+  - __osx >=11.0
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 33008
+  timestamp: 1725356833036
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311h3f08180_2.conda
+  sha256: f507d65e740777a629ceacb062c768829ab76fde01446b191699a734521ecaad
+  md5: c8793a23206344faa25f4e0b5d0e7908
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 339584
+  timestamp: 1725268241628
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+  sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
+  md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
+  depends:
+  - __osx >=11.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 122909
+  timestamp: 1720974522888
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.12.14-hf0a4a13_0.conda
+  sha256: 256be633fd0882ccc1a7a32bc278547e1703f85082c0789a87a603ee3ab8fb82
+  md5: 7cb381a6783d91902638e4ed1ebd478e
+  license: ISC
+  size: 157091
+  timestamp: 1734208344343
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py311h3a79f62_0.conda
+  sha256: 253605b305cc4548b8f97eb7c2e146697e0c7672b099c4862ec5ca7e8e995307
+  md5: a42272c5dbb6ffbc1a5af70f24c7b448
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 288211
+  timestamp: 1725560745212
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.1-py311h210dab8_0.conda
+  sha256: 8e755206b38a6e14861c79a74b51af76124bdf5c266dd6a584305e03d37c2e0c
+  md5: 7f9e9df2d62cf69aed450f6957a23e61
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 247202
+  timestamp: 1731428753912
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.11-py311h155a34a_0.conda
+  sha256: cfefc76046aa13ae7f8e8ca81fe4c0d36800a3b1111670a50358372d20a074c9
+  md5: bf27c8f7c67b84d79f17d0c5ec4a8034
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2448440
+  timestamp: 1734159188959
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+  sha256: 791673127e037a2dc0eebe122dc4f904cb3f6e635bb888f42cbe1a76b48748d9
+  md5: e6085e516a3e304ce41a8ee08b9b89ad
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 596430
+  timestamp: 1694616332835
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py311h267d04e_1.conda
+  sha256: 736304347653ed421b13c56ba6f4f87c1d78d24cd3fa74db0db6fb70c814fa65
+  md5: 5bce88ac1bef7d47c62cb574b25891ae
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18253
+  timestamp: 1725303181400
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+  sha256: 4442f957c3c77d69d9da3521268cad5d54c9033f1a73f99cde0a3658937b159b
+  md5: c6dc8a0fdec13a0565936655c33069a1
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1155530
+  timestamp: 1719463474401
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
+  sha256: 151e0c84feb7e0747fabcc85006b8973b22f5abbc3af76a9add0b0ef0320ebe4
+  md5: 66f6c134e76fe13cce8a9ea5814b5dd5
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 211959
+  timestamp: 1701647962657
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+  sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
+  md5: de462d5aacda3b30721b512c5da4e742
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 215721
+  timestamp: 1657977558796
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-26_osxarm64_openblas.conda
+  sha256: 597f9c3779caa979c8c6abbb3ba8c7191b84e1a910d6b0d10e5faf35284c450c
+  md5: 21be102c9ae80a67ba7de23b129aa7f6
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - liblapack 3.9.0 26_osxarm64_openblas
+  - liblapacke 3.9.0 26_osxarm64_openblas
+  - libcblas 3.9.0 26_osxarm64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16714
+  timestamp: 1734433054681
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-26_osxarm64_openblas.conda
+  sha256: 27a29ef6b2fd2179bc3a0bb9db351f078ba140ca10485dca147c399639f84c93
+  md5: a0e9980fe12d42f6d0c0ec009f67e948
+  depends:
+  - libblas 3.9.0 26_osxarm64_openblas
+  constrains:
+  - liblapack 3.9.0 26_osxarm64_openblas
+  - liblapacke 3.9.0 26_osxarm64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16628
+  timestamp: 1734433061517
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.6-ha82da77_1.conda
+  sha256: 2b2443404503cd862385fd2f2a2c73f9624686fd1e5a45050b4034cfc06904ec
+  md5: ce5252d8db110cdb4ae4173d0a63c7c5
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 520992
+  timestamp: 1734494699681
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.23-hec38601_0.conda
+  sha256: 887c02deaed6d583459eba6367023e36d8761085b2f7126e389424f57155da53
+  md5: 1d8b9588be14e71df38c525767a1ac30
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 54132
+  timestamp: 1734373971372
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+  sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
+  md5: 30e4362988a2623e9eb34337b83e01f9
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 96607
+  timestamp: 1597616630749
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
+  sha256: e42ab5ace927ee7c84e3f0f7d813671e1cf3529f5f06ee5899606630498c2745
+  md5: 38d2656dd914feb0cab8c629370768bf
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 64693
+  timestamp: 1730967175868
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+  md5: 086914b672be056eb70fd4285b6783b6
+  license: MIT
+  license_family: MIT
+  size: 39020
+  timestamp: 1636488587153
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+  sha256: 44e541b4821c96b28b27fef5630883a60ce4fee91fd9c79f25a199f8f73f337b
+  md5: 4a55d9e169114b2b90d3ec4604cd7bbf
+  depends:
+  - libgfortran5 13.2.0 hf226fd6_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110233
+  timestamp: 1707330749033
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+  sha256: bafc679eedb468a86aa4636061c55966186399ee0a04b605920d208d97ac579a
+  md5: 66ac81d54e95c534ae488726c1f698ea
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 997381
+  timestamp: 1707330687590
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+  sha256: a42054eaa38e84fc1e5ab443facac4bbc9d1b6b6f23f54b7bf4f1eb687e1d993
+  md5: 3ff1e053dc3a2b8e36b9bfa4256a58d1
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 547541
+  timestamp: 1694475104253
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-26_osxarm64_openblas.conda
+  sha256: dd6d9a21e672aee4332f019c8229ce70cf5eaf6c2f4cbd1443b105fb66c00dc5
+  md5: cebad79038a75cfd28fa90d147a2d34d
+  depends:
+  - libblas 3.9.0 26_osxarm64_openblas
+  constrains:
+  - liblapacke 3.9.0 26_osxarm64_openblas
+  - libcblas 3.9.0 26_osxarm64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16624
+  timestamp: 1734433068120
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.6.3-h39f12f2_1.conda
+  sha256: d863b8257406918ffdc50ae65502f2b2d6cede29404d09a094f59509d6a0aaf1
+  md5: b2553114a7f5e20ccd02378a77d836aa
+  depends:
+  - __osx >=11.0
+  constrains:
+  - xz ==5.6.3=*_1
+  license: 0BSD
+  size: 99129
+  timestamp: 1733407496073
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
+  sha256: 62bb669c37a845129096f73d446cdb6bb170e4927f2fea2b661329680dbbc373
+  md5: 40803a48d947c8639da6704e9a44d3ce
+  depends:
+  - __osx >=11.0
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - llvm-openmp >=18.1.8
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4165774
+  timestamp: 1730772154295
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
+  sha256: 38f8759a3eb8060deabd4db41f0f023514d853e46ddcbd0ba21768fc4e563bb1
+  md5: fb36e93f0ea6a6f5d2b99984f34b049e
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 263385
+  timestamp: 1726234714421
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
+  sha256: fade8223e1e1004367d7101dd17261003b60aa576df6d7802191f8972f7470b1
+  md5: a7ce36e284c5faaf93c220dfc39e3abd
+  depends:
+  - __osx >=11.0
+  license: ISC
+  size: 164972
+  timestamp: 1716828607917
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.47.2-h3f77e49_0.conda
+  sha256: f192f3c8973de9ec4c214990715f13b781965247a5cedf9162e7f9e699cfc3c4
+  md5: 122d6f29470f1a991e85608e77e56a8a
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 850553
+  timestamp: 1733762057506
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-h551f018_3.conda
+  sha256: 91417846157e04992801438a496b151df89604b2e7c6775d6f701fcd0cbed5ae
+  md5: a5d084a957563e614ec0c0196d890654
+  depends:
+  - __osx >=11.0
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=18
+  - libdeflate >=1.23,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 370600
+  timestamp: 1734398863052
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+  sha256: 0d4bad713a512d79bfeb4d61821f447afab8b0792aca823f505ce6b195e9fde5
+  md5: c0af0edfebe780b19940e94871f1a765
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 287750
+  timestamp: 1713200194013
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+  sha256: bd3816218924b1e43b275863e21a3e13a5db4a6da74cca8e60bc3c213eb62f71
+  md5: af523aae2eca6dfa1c8eec693f5b9a79
+  depends:
+  - __osx >=11.0
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 323658
+  timestamp: 1727278733917
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
+  md5: 369964e85dc26bfe78f41399b366c435
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 46438
+  timestamp: 1727963202283
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.6-hdb05f8b_0.conda
+  sha256: a0f3e9139ab16f0a67b9d2bbabc15b78977168f4a5b5503fed4962dcb9a96102
+  md5: 34fdeffa0555a1a56f38839415cc066c
+  depends:
+  - __osx >=11.0
+  constrains:
+  - openmp 19.1.6|19.1.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 281251
+  timestamp: 1734520462311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py311h4921393_1.conda
+  sha256: 4f738a7c80e34e5e5d558e946b06d08e7c40e3cc4bdf08140bf782c359845501
+  md5: 249e2f6f5393bb6b36b3d3a3eebdcdf9
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24976
+  timestamp: 1733219849253
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+  sha256: 27d0b9ff78ad46e1f3a6c96c479ab44beda5f96def88e2fe626e0a49429d8afc
+  md5: cb2b0ea909b97b3d70cd3921d1445e1a
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  size: 802321
+  timestamp: 1724658775723
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.2.0-py311h4b914e2_0.conda
+  sha256: 00426f06605117e30f6b51c4214dbbaae583daebc7181537da22d0375172fd60
+  md5: 87da5b6268827d1e71346a5bdd86ad77
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7050174
+  timestamp: 1733688720325
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.3-h8a3d83b_0.conda
+  sha256: 1d59bc72ca7faac06d349c1a280f5cfb8a57ee5896f1e24225a997189d7418c7
+  md5: 4b71d78648dbcf68ce8bf22bb07ff838
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - libpng >=1.6.44,<1.7.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 319362
+  timestamp: 1733816781741
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h39f12f2_0.conda
+  sha256: bd1d58ced46e75efa3b842c61642fd12272c69e9fe4d7261078bc082153a1d53
+  md5: df307bbc703324722df0293c9ca2e418
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2935176
+  timestamp: 1731377561525
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py311h9cb3ce9_1.conda
+  sha256: 0a08027b25e4f6034d7733c7366f44283246d61cb82d1721f8789d50ebfef287
+  md5: 9ffa9dee175c76e68ea5de5aa1168d83
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14807397
+  timestamp: 1726879116250
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.0.0-py311h3894ae9_0.conda
+  sha256: 6d5307fed000e6b72b98d54dd1fea7b155f9a6453476a937522b89dde7b3d673
+  md5: a9a4adae1c4178f50ac3d1fd5d64bb85
+  depends:
+  - __osx >=11.0
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 41856994
+  timestamp: 1729066060042
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py311hae2e1ce_0.conda
+  sha256: 6237f04371995fa8e8f16481dcd4e01d2733a82750180a362a9f4953ffbb3cde
+  md5: e226eba0c52ecd6786e73c8ad7f41e79
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 514316
+  timestamp: 1729847396776
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+  sha256: 8ed65e17fbb0ca944bfb8093b60086e3f9dd678c3448b5de212017394c247ee3
+  md5: 415816daf82e0b23a736a069a75e9da7
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 8381
+  timestamp: 1726802424786
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.3.2-py311hab620ed_0.conda
+  sha256: b3990d45325f4d2716d933b1fff821b69b530889d138d6caa246a3ef3d5aaf51
+  md5: 6968e48654cd85960526f4e6ed24996c
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 479023
+  timestamp: 1732987380000
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.3.2-py311hab620ed_0.conda
+  sha256: eaa25ed388d010b298baa11dc62aebf37bb2d8e655b2f8ad0d5df0d1dde25dfd
+  md5: b8302e3047685d0c0721fb65e50039da
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 10.3.2.*
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 384939
+  timestamp: 1733168978481
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.11-hc22306f_1_cpython.conda
+  sha256: 94e198f6a5affa1431401fca7e3b27fda68c59f5ee726083288bff1f6bed8c7f
+  md5: 8d81dcd0be5bdcdd98e0f2482bf63784
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.4.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 14647146
+  timestamp: 1733409012105
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
+  sha256: adc05729b7e0aca7b436e60a86f10822a92185dfcb48d66d6444e3629d3a1f6a
+  md5: 3b855e3734344134cb56c410f729c340
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6308
+  timestamp: 1723823096865
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h460d6c5_1.conda
+  sha256: 9ae182eef4e96a7c2f46cc9add19496276612663e17429500432631dce31a831
+  md5: d32590e7bd388f18b036c6fc402a0cb1
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 192321
+  timestamp: 1725456528007
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.0-py311h730b646_3.conda
+  sha256: 7e75589d9c3723ecf314435f15a7b486cebafa89ebf00bb616354e37587dc7ae
+  md5: b6f3e527de0c0384cd78cfa779bd6ddf
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365841
+  timestamp: 1728642472021
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+  sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
+  md5: 8cbb776a2f641b943d413b3e19df71f4
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 250351
+  timestamp: 1679532511311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.22.3-py311h3ff9189_0.conda
+  sha256: 8b1e693f3bb84f1152858bba9e15a6717cad02f70b45df3538078c22e67f5a06
+  md5: 16669f8098b2f4a8560727efb9e65afd
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 324661
+  timestamp: 1733366968758
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+  sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
+  md5: b50a57ba89c32b62428b71a875291c9b
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3145523
+  timestamp: 1699202432999
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.2-py311h917b07b_0.conda
+  sha256: 80b79a7d4ed8e16019b8c634cca66935d18fc98be358c76a6ead8c611306ee14
+  md5: 183b74c576dc7f920dae168997dbd1dd
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 858954
+  timestamp: 1732616142626
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-h5505292_0.conda
+  sha256: f33e6f013fc36ebc200f09ddead83468544cb5c353a3b50499b07b8c34e28a8d
+  md5: 50901e0764b7701d8ed7343496f4f301
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 13593
+  timestamp: 1734229104321
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+  sha256: 9939a166d780700d81023546759102b33fdc2c5f11ef09f5f66c77210fd334c8
+  md5: 77c447f48cab5d3a15ac224edb86a968
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 18487
+  timestamp: 1727795205022
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+  sha256: 93181a04ba8cfecfdfb162fc958436d868cc37db504c58078eab4c1a3e57fbb7
+  md5: 4bb3f014845110883a3c5ee811fd84b4
+  license: MIT
+  license_family: MIT
+  size: 88016
+  timestamp: 1641347076660
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-hc1bb282_7.conda
+  sha256: 9e585569fe2e7d3bea71972cd4b9f06b1a7ab8fa7c5139f92a31cbceecf25a8a
+  md5: f7e6b65943cb73bce0143737fded08f1
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libcxx >=18
+  - libsodium >=1.0.20,<1.0.21.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 281565
+  timestamp: 1731585108039
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py311ha60cc69_1.conda
+  sha256: d2f2f1a408e2353fc61d2bf064313270be2260ee212fe827dcf3cfd3754f1354
+  md5: 29d320d6450b2948740a9be3761b2e9d
+  depends:
+  - __osx >=11.0
+  - cffi >=1.11
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 332271
+  timestamp: 1725305847224
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+  sha256: 2d4fd1ff7ee79cd954ca8e81abf11d9d49954dd1fef80f27289e2402ae9c2e09
+  md5: d96942c06c3e84bfcc5efb038724a7fd
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 405089
+  timestamp: 1714723101397
+- conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
+  sha256: 1a62cd1f215fe0902e7004089693a78347a30ad687781dfda2289cab000e652d
+  md5: 37e16618af5c4851a3f3d66dd0e11141
+  depends:
+  - libgomp >=7.5.0
+  - libwinpthread >=12.0.0.r2.ggc561118da
+  constrains:
+  - openmp_impl 9999
+  - msys2-conda-epoch <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49468
+  timestamp: 1718213032772
+- conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311he736701_5.conda
+  sha256: 8bbce5e61e012a06e248f58bb675fdc82ba2900c78590696d185150fb9cea91f
+  md5: 8917bf795c40ec1839ed9d0ab3ad9735
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 34883
+  timestamp: 1725357113431
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311hda3d55a_2.conda
+  sha256: aa3ac5dbf63db2f145235708973c626c2189ee4040d769fdf0076286fa45dc26
+  md5: a0ea2839841a06740a1c110ba3317b42
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  license: MIT
+  license_family: MIT
+  size: 322114
+  timestamp: 1725268368720
+- conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+  sha256: 35a5dad92e88fdd7fc405e864ec239486f4f31eec229e31686e61a140a8e573b
+  md5: 276e7ffe9ffe39688abc665ef0f45596
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 54927
+  timestamp: 1720974860185
+- conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.12.14-h56e8100_0.conda
+  sha256: 424d82db36cd26234bc4772426170efd60e888c2aed0099a257a95e131683a5e
+  md5: cb2eaeb88549ddb27af533eccf9a45c1
+  license: ISC
+  size: 157422
+  timestamp: 1734208404685
+- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py311he736701_0.conda
+  sha256: 9689fbd8a31fdf273f826601e90146006f6631619767a67955048c7ad7798a1d
+  md5: e1c69be23bd05471a6c623e91680ad59
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 297627
+  timestamp: 1725561079708
+- conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.1-py311h3257749_0.conda
+  sha256: dbb0c161dd75e72e66c13f31715941adb094a45471016f89d6a1cfab30967ba8
+  md5: 91d8504588e1b3c77e605503e5a1bc11
+  depends:
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 216693
+  timestamp: 1731429286140
+- conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.11-py311hda3d55a_0.conda
+  sha256: b4a4b2d6d40e681353d84669e861c369e3d9eca3cb6fdf0a50277f4702c42ba9
+  md5: d9fa2f0451b21409364946424896a14d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 3510571
+  timestamp: 1734159369511
+- conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+  sha256: 2c53ee8879e05e149a9e525481d36adfd660a6abda26fd731376fa64ff03e728
+  md5: 3761b23693f768dc75a8fd0a73ca053f
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-only OR FTL
+  size: 510306
+  timestamp: 1694616398888
+- conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+  sha256: 0fd2b0b84c854029041b0ede8f4c2369242ee92acc0092f8407b1fe9238a8209
+  md5: 2d89243bfb53652c182a7c73182cce4f
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 1852356
+  timestamp: 1723739573141
+- conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_1.conda
+  sha256: 9a667eeae67936e710ff69ee7ce0e784d6052eeba9670b268c565a55178098c4
+  md5: 943f7fab631e12750641efd7279a268c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42891
+  timestamp: 1725303340467
+- conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+  sha256: 18e8b3430d7d232dad132f574268f56b3eb1a19431d6d5de8c53c29e6c18fa81
+  md5: 31aec030344e962fbd7dbbbbd68e60a9
+  depends:
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 712034
+  timestamp: 1719463874284
+- conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
+  sha256: f9fd9e80e46358a57d9bb97b1e37a03da4022143b019aa3c4476d8a7795de290
+  md5: d3592435917b62a8becff3a60db674f6
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 507632
+  timestamp: 1701648249706
+- conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+  sha256: f4f39d7f6a2f9b407f8fb567a6c25755270421731d70f0ff331f5de4fa367488
+  md5: 1900cb3cab5055833cfddb0ba233b074
+  depends:
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30037
+  license: Apache-2.0
+  license_family: Apache
+  size: 194365
+  timestamp: 1657977692274
+- conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-26_win64_mkl.conda
+  sha256: d631993a5cf5b8d3201f881084fce7ff6a26cd49883e189bf582cd0b7975c80a
+  md5: ecfe732dbad1be001826fdb7e5e891b5
+  depends:
+  - mkl 2024.2.2 h66d3029_15
+  constrains:
+  - liblapacke 3.9.0 26_win64_mkl
+  - liblapack 3.9.0 26_win64_mkl
+  - blas * mkl
+  - libcblas 3.9.0 26_win64_mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3733122
+  timestamp: 1734432745507
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-26_win64_mkl.conda
+  sha256: 66699c4f84fd36b67a34a7ac59fb86e73ee0c5b3c3502441041c8dd51f0a7d49
+  md5: 652f3adcb9d329050a325416edb14246
+  depends:
+  - libblas 3.9.0 26_win64_mkl
+  constrains:
+  - liblapacke 3.9.0 26_win64_mkl
+  - liblapack 3.9.0 26_win64_mkl
+  - blas * mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3732146
+  timestamp: 1734432785653
+- conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.23-h9062f6e_0.conda
+  sha256: 96c47725a8258159295996ea2758fa0ff9bea330e72b59641642e16be8427ce8
+  md5: a9624935147a25b06013099d3038e467
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 155723
+  timestamp: 1734374084110
+- conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.4-he0c23c2_0.conda
+  sha256: 0c0447bf20d1013d5603499de93a16b6faa92d7ead870d96305c0f065b6a5a12
+  md5: eb383771c680aa792feb529eaf9df82f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 139068
+  timestamp: 1730967442102
+- conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+  sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
+  md5: 2c96d1b6915b408893f9472569dee135
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 42063
+  timestamp: 1636489106777
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-14.2.0-h1383e82_1.conda
+  sha256: ef840e797714440bb10b69446d815966fff41fdac79f79c4e19c475d81cd375d
+  md5: 75fdd34824997a0f9950a703b15d8ac5
+  depends:
+  - _openmp_mutex >=4.5
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - libgcc-ng ==14.2.0=*_1
+  - libgomp 14.2.0 h1383e82_1
+  - msys2-conda-epoch <0.0a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 666386
+  timestamp: 1729089506769
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-14.2.0-h1383e82_1.conda
+  sha256: d8739b834608f35775209b032f0c2be752ef187863c7ec847afcebe2f681be4e
+  md5: 9e2d4d1214df6f21cba12f6eff4972f9
+  depends:
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - msys2-conda-epoch <0.0a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 524249
+  timestamp: 1729089441747
+- conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.2-default_ha69328c_1001.conda
+  sha256: 850e255997f538d5fb6ed651321141155a33bb781d43d326fc4ff62114dd2842
+  md5: b87a0ac5ab6495d8225db5dc72dd21cd
+  depends:
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - libxml2 >=2.13.4,<2.14.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2390021
+  timestamp: 1731375651179
+- conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+  sha256: 5f844dd19b046d43174ad80c6ea75b5d504020e3b63cfbc4ace97b8730d35c7b
+  md5: e1eb10b1cca179f2baa3601e4efc8712
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-only
+  size: 636146
+  timestamp: 1702682547199
+- conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+  sha256: 4e7808e3098b4b4ed7e287f63bb24f9045cc4d95bfd39f0db870fc2837d74dff
+  md5: 3f1b948619c45b1ca714d60c7389092c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 822966
+  timestamp: 1694475223854
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-26_win64_mkl.conda
+  sha256: 6701bd162d105531b75d05acf82b4ad9fbc5a24ffbccf8c66efa9e72c386b33c
+  md5: 0a717f5fda7279b77bcce671b324408a
+  depends:
+  - libblas 3.9.0 26_win64_mkl
+  constrains:
+  - liblapacke 3.9.0 26_win64_mkl
+  - blas * mkl
+  - libcblas 3.9.0 26_win64_mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3732160
+  timestamp: 1734432822278
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.6.3-h2466b09_1.conda
+  sha256: 24d04bd55adfa44c421c99ce169df38cb1ad2bba5f43151bc847fc802496a1fa
+  md5: 015b9c0bd1eef60729ab577a38aaf0b5
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - xz ==5.6.3=*_1
+  license: 0BSD
+  size: 104332
+  timestamp: 1733407872569
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
+  sha256: 0d3d6ff9225f6918ac225e3839c0d91e5af1da08a4ebf59cac1bfd86018db945
+  md5: 639ac6b55a40aa5de7b8c1b4d78f9e81
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: zlib-acknowledgement
+  size: 348933
+  timestamp: 1726235196095
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+  sha256: 7bcb3edccea30f711b6be9601e083ecf4f435b9407d70fc48fbcf9e5d69a0fc6
+  md5: 198bb594f202b205c7d18b936fa4524f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: ISC
+  size: 202344
+  timestamp: 1716828757533
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.2-h67fdade_0.conda
+  sha256: ecfc0182c3b2e63c870581be1fa0e4dbdfec70d2011cb4f5bde416ece26c41df
+  md5: ff00095330e0d35a16bd3bdbd1a2d3e7
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 891292
+  timestamp: 1733762116902
+- conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-h797046b_3.conda
+  sha256: c363a8baba4ce12b8f01f0ab74fe8b0dc83facd89c6604f4a191084923682768
+  md5: defed79ff7a9164ad40320e3f116a138
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.23,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 978878
+  timestamp: 1734399004259
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+  sha256: d0ca51cb1de9192be9a3238e71fbcca5a535619c499c4f4c9b2ed41c14d36770
+  md5: abd61d0ab127ec5cd68f62c2969e6f34
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 274359
+  timestamp: 1713200524021
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_8.conda
+  sha256: 6d5e158813ab8d553fbb0fedd0abe7bf92970b0be3a9ddf12da0f6cbad78f506
+  md5: 03cccbba200ee0523bde1f3dad60b1f3
+  depends:
+  - ucrt
+  constrains:
+  - pthreads-win32 <0.0a0
+  - msys2-conda-epoch <0.0a0
+  license: MIT AND BSD-3-Clause-Clear
+  size: 35433
+  timestamp: 1724681489463
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
+  sha256: 08dec73df0e161c96765468847298a420933a36bc4f09b50e062df8793290737
+  md5: a69bbf778a462da324489976c84cfc8c
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - pthread-stubs
+  - ucrt >=10.0.20348.0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 1208687
+  timestamp: 1727279378819
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.5-he286e8c_1.conda
+  sha256: 084dd4dde342f13c43ee418d153ac5b2610f95be029073a15fa9dda22b130d06
+  md5: 77eaa84f90fc90643c5a0be0aa9bdd1b
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1612294
+  timestamp: 1733443909984
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+  sha256: ba945c6493449bed0e6e29883c4943817f7c79cbff52b83360f7b341277c6402
+  md5: 41fbfac52c601159df6c01f875de31b9
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 55476
+  timestamp: 1727963768015
+- conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py311h5082efb_1.conda
+  sha256: 6f756e13ccf1a521d3960bd3cadddf564e013e210eaeced411c5259f070da08e
+  md5: c1f2ddad665323278952a453912dc3bd
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28238
+  timestamp: 1733220208800
+- conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_15.conda
+  sha256: 20e52b0389586d0b914a49cd286c5ccc9c47949bed60ca6df004d1d295f2edbd
+  md5: 302dff2807f2927b3e9e0d19d60121de
+  depends:
+  - intel-openmp 2024.*
+  - tbb 2021.*
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 103106385
+  timestamp: 1730232843711
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.2.0-py311hc213d13_0.conda
+  sha256: 5ac23004df8d24a8b1ca1891a0c7f87d3053b1e2fff9f3c046e210584541b873
+  md5: 16284446a9c7a4b65dacde3cd380708d
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7647608
+  timestamp: 1733689217835
+- conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.3-h4d64b90_0.conda
+  sha256: 410175815df192f57a07c29a6b3fdd4231937173face9e63f0830c1234272ce3
+  md5: fc050366dd0b8313eb797ed1ffef3a29
+  depends:
+  - libpng >=1.6.44,<1.7.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 240148
+  timestamp: 1733817010335
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.4.0-h2466b09_0.conda
+  sha256: e03045a0837e01ff5c75e9273a572553e7522290799807f918c917a9826a6484
+  md5: d0d805d9b5524a14efb51b3bff965e83
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 8491156
+  timestamp: 1731379715927
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py311hcf9f919_1.conda
+  sha256: f5477bf3a2b7919481009ce87212d7bbd16c61a5bb05c692a7c336fb45646534
+  md5: 5965b8926efba14e6fde98cc8713c083
+  depends:
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14587131
+  timestamp: 1726879538736
+- conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.0.0-py311h4fbf6a9_0.conda
+  sha256: 0d38ec638a5b266adb894f6fe4c874b46b98180a984007bf40cb030a22e8cc1e
+  md5: 44897ebc5704d3de316af26740325513
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: HPND
+  size: 42185657
+  timestamp: 1729066269713
+- conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py311he736701_0.conda
+  sha256: 303c988247c4b1638f1cc90cd40465f5c74ca0ecfd83114033af637654dc2b6b
+  md5: 307267e6a028bca3382d98e06a372ebf
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 521434
+  timestamp: 1729847606018
+- conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
+  sha256: 7e446bafb4d692792310ed022fe284e848c6a868c861655a92435af7368bae7b
+  md5: 3c8f2573569bb816483e5cf57efbbe29
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 9389
+  timestamp: 1726802555076
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.11-h3f84c4b_1_cpython.conda
+  sha256: 5be6181ab6d655ad761490b7808584c5e78e5d7139846685b1850a8b7ef6c5df
+  md5: 4d490a426481298bdd89a502253a7fd4
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 18161635
+  timestamp: 1733408064601
+- conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-5_cp311.conda
+  sha256: 9b210e5807dd9c9ed71ff192a95f1872da597ddd10e7cefec93a922fe22e598a
+  md5: 895b873644c11ccc0ab7dba2d8513ae6
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6707
+  timestamp: 1723823225752
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-307-py311hda3d55a_3.conda
+  sha256: 78a4ede098bbc122a3dff4e0e27255e30b236101818e8f499779c89670c58cd6
+  md5: 1bc10dbe3b8d03071070c962a2bdf65f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 6023110
+  timestamp: 1728636767562
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.14-py311hda3d55a_0.conda
+  sha256: 337097e3f3b71f782c43fb702893f86f080e140da467415dcaf039a7fbb8e551
+  md5: 64553b300529aa8987f6ca92c914c844
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 210973
+  timestamp: 1729202625177
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311he736701_1.conda
+  sha256: 86608f1b4f6b1819a74b6b1344c34304745fd7e84bfc9900269f57cf28178d31
+  md5: d0c5f3c595039890be0c9af47d23b9ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 187901
+  timestamp: 1725456808581
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.2.0-py311h484c95c_3.conda
+  sha256: 4d3fc4cfac284efb83a903601586cc6ee18fb556d4bf84d3bd66af76517c463e
+  md5: 4836b00658e11b466b823216f6df2424
+  depends:
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 371084
+  timestamp: 1728642713666
+- conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.22.3-py311h533ab2d_0.conda
+  sha256: c74b3a4430706dfb63176429cc31410dcb86a15e1d35463aae04733c4700b8d8
+  md5: 40c964a32833f3ad13ba4183cd180577
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 222035
+  timestamp: 1733367148577
+- conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-h62715c5_1.conda
+  sha256: 03cc5442046485b03dd1120d0f49d35a7e522930a2ab82f275e938e17b07b302
+  md5: 9190dd0a23d925f7602f9628b3aed511
+  depends:
+  - libhwloc >=2.11.2,<2.11.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 151460
+  timestamp: 1732982860332
+- conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+  sha256: 2c4e914f521ccb2718946645108c9bd3fc3216ba69aea20c2c3cedbd8db32bb1
+  md5: fc048363eb8f03cd1737600a5d08aafe
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: TCL
+  license_family: BSD
+  size: 3503410
+  timestamp: 1699202577803
+- conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.2-py311he736701_0.conda
+  sha256: 7e313f1724e5eb7d13f7a1ebd6026a378f3f58a638ba7cdc3bd452c01323bb29
+  md5: 7e33077ce1bc0bf45c45a92e37432f16
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 859456
+  timestamp: 1732616376731
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+  sha256: db8dead3dd30fb1a032737554ce91e2819b43496a0db09927edf01c32b577450
+  md5: 6797b005cd0f439c4c5c9ac565783700
+  constrains:
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-MicrosoftWindowsSDK10
+  size: 559710
+  timestamp: 1728377334097
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_23.conda
+  sha256: 986ddaf8feec2904eac9535a7ddb7acda1a1dfb9482088fdb8129f1595181663
+  md5: 7c10ec3158d1eb4ddff7007c9101adb0
+  depends:
+  - vc14_runtime >=14.38.33135
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17479
+  timestamp: 1731710827215
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34433-he29a5d6_23.conda
+  sha256: c483b090c4251a260aba6ff3e83a307bcfb5fb24ad7ced872ab5d02971bd3a49
+  md5: 32b37d0cfa80da34548501cdc913a832
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.42.34433.* *_23
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  size: 754247
+  timestamp: 1731710681163
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hdffcdeb_23.conda
+  sha256: 568ce8151eaae256f1cef752fc78651ad7a86ff05153cc7a4740b52ae6536118
+  md5: 5c176975ca2b8366abad3c97b3cd1e83
+  depends:
+  - vc14_runtime >=14.42.34433
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17572
+  timestamp: 1731710685291
+- conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: 9df10c5b607dd30e05ba08cbd940009305c75db242476f4e845ea06008b0a283
+  md5: 1cee351bf20b830d991dbe0bc8cd7dfe
+  license: MIT
+  license_family: MIT
+  size: 1176306
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.12-h0e40799_0.conda
+  sha256: 047836241b2712aab1e29474a6f728647bff3ab57de2806b0bb0a6cf9a2d2634
+  md5: 2ffbfae4548098297c033228256eb96e
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 108013
+  timestamp: 1734229474049
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.5-h0e40799_0.conda
+  sha256: 9075f98dcaa8e9957e4a3d9d30db05c7578a536950a31c200854c5c34e1edb2c
+  md5: 8393c0f7e7870b4eb45553326f81f0ff
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 69920
+  timestamp: 1727795651979
+- conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+  sha256: 4e2246383003acbad9682c7c63178e2e715ad0eb84f03a8df1fbfba455dfedc5
+  md5: adbfb9f45d1004a26763652246a33764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 63274
+  timestamp: 1641347623319
+- conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_7.conda
+  sha256: 15cc8e2162d0a33ffeb3f7b7c7883fd830c54a4b1be6a4b8c7ee1f4fef0088fb
+  md5: e03f2c245a5ee6055752465519363b1c
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 2527503
+  timestamp: 1731585151036
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py311h53056dc_1.conda
+  sha256: a93584e6167c3598854a47f3bf8276fa646a3bb4d12fcfc23a54e37d5879f35c
+  md5: 7d4c123cbb5e6293dd4dd2f8d30f0de4
+  depends:
+  - cffi >=1.11
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 321357
+  timestamp: 1725305930669
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+  sha256: 768e30dc513568491818fb068ee867c57c514b553915536da09e5d10b4ebf3c3
+  md5: 9a17230f95733c04dc40a2b1e5491d74
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 349143
+  timestamp: 1714723445995
+- pypi: https://files.pythonhosted.org/packages/23/d9/29ae513f60f0d972789453f14b22753d9becc303f0ad7e797cf6b4878580/neuroglancer-2.40.1-cp39-abi3-win_amd64.whl
+  name: neuroglancer
+  version: 2.40.1
+  sha256: dc70a9dcd438c763515a2ca36135d10a49bd3261ac3fcf0b9183c03411554295
+  requires_dist: &id001
+  - Pillow>=3.2.0
+  - numpy>=1.11.0
+  - requests
+  - tornado
+  - google-apitools
+  - google-auth
+  - atomicwrites
+  - selenium>=4; extra == "webdriver"
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/2f/a2/e0e01c70d7a6804eb00faeb901af341ca5518b9d58c444c133d300c48b83/neuroglancer-2.40.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: neuroglancer
+  version: 2.40.1
+  sha256: b5cb9583b1668aad49c092bb047d6e74959bb3b5b343d5a624f084d82f3ede60
+  requires_dist: *id001
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/49/97/fa78e3d2f65c02c8e1268b9aba606569fe97f6c8f7c2d74394553347c145/rsa-4.9-py3-none-any.whl
+  name: rsa
+  version: '4.9'
+  sha256: 90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7
+  requires_dist:
+  - pyasn1 (>=0.1.3)
+  requires_python: '>=3.6,<4'
+- pypi: https://files.pythonhosted.org/packages/59/52/3890bdc3345a1885a6eac6d4b982124d4820c11b706ce179b76c26b3eaea/neuroglancer-2.40.1-cp39-abi3-macosx_10_9_x86_64.whl
+  name: neuroglancer
+  version: 2.40.1
+  sha256: 73b214772263005e2531dab6051ed1f4d5cd4c4f1c6eb181b9baf704ecb6f3f3
+  requires_dist: *id001
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/5e/cb/cb0311f2ec371c83d6510847476c665edc9cc97564a51923557bc8f0b680/google_apitools-0.5.32-py3-none-any.whl
+  name: google-apitools
+  version: 0.5.32
+  sha256: b78f74116558e0476e19501b5b4b2ac7c93261a69c5449c861ea95cbc853c688
+  requires_dist:
+  - httplib2 (>=0.8)
+  - fasteners (>=0.14)
+  - oauth2client (>=1.4.12)
+  - six (>=1.12.0)
+  - python-gflags (>=3.0.6) ; extra == 'cli'
+  - mock (>=1.0.1) ; extra == 'testing'
+  requires_python: '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*'
+- pypi: https://files.pythonhosted.org/packages/61/bf/fd60001b3abc5222d8eaa4a204cd8c0ae78e75adc688f33ce4bf25b7fafa/fasteners-0.19-py3-none-any.whl
+  name: fasteners
+  version: '0.19'
+  sha256: 758819cb5d94cdedf4e836988b74de396ceacb8e2794d21f82d131fd9ee77237
+  requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/77/89/bc88a6711935ba795a679ea6ebee07e128050d6382eaa35a0a47c8032bdc/pyasn1_modules-0.4.1-py3-none-any.whl
+  name: pyasn1-modules
+  version: 0.4.1
+  sha256: 49bfa96b45a292b711e986f222502c1c9a5e1f4e568fc30e2574a6c7d07838fd
+  requires_dist:
+  - pyasn1<0.7.0,>=0.4.6
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/7d/6c/f78174aeafa8918ac93d86b45837b661ae60a42cda68ce3c591387646560/panel_neuroglancer-0.1.0-py3-none-any.whl
+  name: panel-neuroglancer
+  version: 0.1.0
+  sha256: c02849bfab3feebad55b3f9804d32d0c492dad7b6ac7e707edda815e5581975e
+  requires_dist:
+  - neuroglancer>=2.40.1
+  - panel>=1.5.4
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/87/c6/53da25344e3e3a9c01095a89f16dbcda021c609ddb42dd6d7c0528236fb2/atomicwrites-1.4.1.tar.gz
+  name: atomicwrites
+  version: 1.4.1
+  sha256: 81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11
+- pypi: https://files.pythonhosted.org/packages/8d/8d/4d5d5f9f500499f7bd4c93903b43e8d6976f3fc6f064637ded1a85d09b07/google_auth-2.37.0-py2.py3-none-any.whl
+  name: google-auth
+  version: 2.37.0
+  sha256: 42664f18290a6be591be5329a96fe30184be1a1badb7292a7f686a9659de9ca0
+  requires_dist:
+  - cachetools<6.0,>=2.0.0
+  - pyasn1-modules>=0.2.1
+  - rsa<5,>=3.1.4
+  - aiohttp<4.0.0.dev0,>=3.6.2; extra == "aiohttp"
+  - requests<3.0.0.dev0,>=2.20.0; extra == "aiohttp"
+  - cryptography; extra == "enterprise-cert"
+  - pyopenssl; extra == "enterprise-cert"
+  - pyjwt>=2.0; extra == "pyjwt"
+  - cryptography>=38.0.3; extra == "pyjwt"
+  - pyopenssl>=20.0.0; extra == "pyopenssl"
+  - cryptography>=38.0.3; extra == "pyopenssl"
+  - pyu2f>=0.1.5; extra == "reauth"
+  - requests<3.0.0.dev0,>=2.20.0; extra == "requests"
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/95/a9/4f25a14d23f0786b64875b91784607c2277eff25d48f915e39ff0cff505a/oauth2client-4.1.3-py2.py3-none-any.whl
+  name: oauth2client
+  version: 4.1.3
+  sha256: b8a81cc5d60e2d364f0b1b98f958dbd472887acaf1a5b05e21c28c31a2d6d3ac
+  requires_dist:
+  - httplib2 (>=0.9.1)
+  - pyasn1 (>=0.1.7)
+  - pyasn1-modules (>=0.0.5)
+  - rsa (>=3.1.4)
+  - six (>=1.6.1)
+- pypi: https://files.pythonhosted.org/packages/a4/07/14f8ad37f2d12a5ce41206c21820d8cb6561b728e51fad4530dff0552a67/cachetools-5.5.0-py3-none-any.whl
+  name: cachetools
+  version: 5.5.0
+  sha256: 02134e8439cdc2ffb62023ce1debca2944c3f289d66bb17ead3ab3dede74b292
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/a7/37/214037aec09f43e1854173fc338eb5f20f2b2f6d57ccf9dfc9f4032b1567/neuroglancer-2.40.1-cp39-abi3-macosx_11_0_arm64.whl
+  name: neuroglancer
+  version: 2.40.1
+  sha256: 7466279b2cad28465edc727b994949599d2f0ece9ca22cee05bfa30c1d63a1ac
+  requires_dist: *id001
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/a8/6c/d2fbdaaa5959339d53ba38e94c123e4e84b8fbc4b84beb0e70d7c1608486/httplib2-0.22.0-py3-none-any.whl
+  name: httplib2
+  version: 0.22.0
+  sha256: 14ae0a53c1ba8f3d37e9e27cf37eabb0fb9980f435ba405d546948b009dd64dc
+  requires_dist:
+  - pyparsing (<3,>=2.4.2) ; python_version < "3.0"
+  - pyparsing (!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3,<4,>=2.4.2) ; python_version > "3.0"
+  requires_python: '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*'
+- pypi: https://files.pythonhosted.org/packages/be/ec/2eb3cd785efd67806c46c13a17339708ddc346cbb684eade7a6e6f79536a/pyparsing-3.2.0-py3-none-any.whl
+  name: pyparsing
+  version: 3.2.0
+  sha256: 93d9577b88da0bbea8cc8334ee8b918ed014968fd2ec383e868fb8afb1ccef84
+  requires_dist:
+  - railroad-diagrams; extra == "diagrams"
+  - jinja2; extra == "diagrams"
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl
+  name: pyasn1
+  version: 0.6.1
+  sha256: 0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629
+  requires_python: '>=3.8'

--- a/volumetric_imaging/pixi.toml
+++ b/volumetric_imaging/pixi.toml
@@ -1,0 +1,29 @@
+[workspace]
+name = "volumetric_imaging"
+channels = ["conda-forge", "nodefaults"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2024-11-22"
+maintainers = ["droumis"]
+categories = ["Neuroscience"]
+labels = ["panel", "param"]
+title = "Volumetric Imaging"
+description = "Display 3D image and segmentation data in a Jupyter notebook."
+no_data_ingestion = true
+
+[dependencies]
+notebook = ">=6.5.2"
+python = "3.11.*"
+panel = ">=1.5.4"
+jupyterlab = ">=4.3.1"
+pip = "*"
+
+[pypi-dependencies]
+neuroglancer = ">=2.40.1"
+panel-neuroglancer = ">=0.1.0"
+
+[tasks]
+lab = "jupyter lab volumetric_imaging.ipynb"
+notebook = "jupyter notebook volumetric_imaging.ipynb"
+dashboard = "panel serve --rest-session-info --session-history -1 volumetric_imaging.ipynb --show"

--- a/volumetric_imaging/pixi.toml
+++ b/volumetric_imaging/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "volumetric_imaging"
-channels = ["conda-forge", "nodefaults"]
+channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/walker_lake/pixi.lock
+++ b/walker_lake/pixi.lock
@@ -8,7 +8,6 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
-    - url: https://conda.anaconda.org/nodefaults/
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2

--- a/walker_lake/pixi.lock
+++ b/walker_lake/pixi.lock
@@ -1,0 +1,11416 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/nodefaults/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311h9ecbd09_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.8.0-hb88c0a9_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.8.0-hecf86a2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.10.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.0-hf42f96a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.0-h1ffe551_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.9.1-hab05fe4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.15.2-hdeadb07_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.11.0-h7bd072d_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.7.2-h3a84f74_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.1-hf42f96a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.2-hf42f96a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.29.6-h0e61686_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.449-h5558e3c_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.14.0-h5cfcd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.10.0-h113e628_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.13.0-h3cf044e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.8.0-h736e048_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.12.0-ha633028_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-hef167b5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hfdbb021_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.3-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.24.0-py311h7db5c69_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.4-py311h9f3472d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.1-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.0.0-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.9-py311hfdbb021_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.55.0-py311h2dc5d0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h743c826_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.13.0-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.3-h77b800c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.4-nompi_h2d575fe_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.18-h6688a6e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.7-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_h5888daf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.7-hadbb8c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-18.1.0-he15abb1_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-18.1.0-h5888daf_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-18.1.0-h5888daf_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-18.1.0-h5c8f2c3_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.1.1-h1909e37_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libde265-1.0.15-h00ab1b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.10.0-hef9eae6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.31.0-h804f50b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.31.0-h0121fbd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.67.1-hc2c308b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libheif-1.18.2-gpl_hffcb242_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-hf539b9f_1021.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h2564987_115.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-18.1.0-h6bd9018_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hbbce691_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h97f6797_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h1b4f908_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hf672d98_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.21.0-h0e7cc3e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-he137b08_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-hf23e847_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-hb346dea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.11.2-h6991a6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.43.0-py311h9c9ff8c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.3-py311h2cbdf9a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hd590300_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py311h2dc5d0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.2-py311h2b939e6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.7-h401b404_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.0-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.2-nompi_py311h7c29e4f_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.60.0-py311h4bc866e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.0.2-py311h71ddf71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.3-he039a57_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py311h7db5c69_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.0.0-py311h49e9ac3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.5.0-h12925eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-18.1.0-py311h38be061_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-18.1.0-py311h4854187_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.0-py311h0f98d5a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.10-hc5c86c4_3_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py311h7deb3e3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.4.2-py311h5394301_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.6.6-he8a937b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h77b4e00_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.21.0-py311h9e33e62_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.9-h0fd0ee4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py311he9a78e4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.6-py311h2fdb869_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.47.0-h9eae976_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-2.3.0-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.2-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.5-h988505b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py311hbc35293_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.13.1-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.13.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.13.1-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.13.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.9.1-hf036a51_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h3336109_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.8.0-hb1b2711_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.8.0-h1c3498a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.10.3-h6e16a3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.3.0-h1c3498a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.5.0-heedde58_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.9.1-h0c96e2d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.15.2-h789f5c1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.11.0-h00ab244_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.7.2-h704940e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.2.1-h1c3498a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.2.2-h1c3498a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.29.6-hd535841_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.449-he3c0133_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.14.0-h9a36307_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.10.0-ha4e2ba9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.13.0-h3d2f5f1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.8.0-h1ccc5ac_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-files-datalake-cpp-12.12.0-h86941f0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.6-h7d75f6d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hd89902b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.3-hf13058a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.8.30-h8857fd0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cartopy-0.24.0-py311haeb46be_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.1-py311h137bacd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cftime-1.6.4-py311h0034819_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.1-py311h4e34fa0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.0.0-py311h3336109_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/dav1d-1.2.1-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.9-py311hc356e98_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.55.0-py311ha3cf9ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3ec172f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.13.0-hac325c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/geotiff-1.7.3-h2b6e260_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hac325c4_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h2790a97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.4-nompi_h1607680_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/json-c-0.18-hc62ec3d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.7-py311hf2f7c97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240722.0-cxx17_hac325c4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.7.7-h7988bea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-18.1.0-h9cd44c2_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-18.1.0-h8bbd7dd_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-18.1.0-h8bbd7dd_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-18.1.0-h3d48b7c_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libavif16-1.1.1-h71406da_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-25_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h00291cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-25_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.10.1-h58e7537_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.4-hf95d169_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libde265-1.0.15-h7728843_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.22-h00291cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.4-h240833e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.10.0-h9b17b65_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.31.0-hd00c612_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.31.0-h3f2b517_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.67.1-he6e0b18_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libheif-1.18.2-gpl_h57a3ca0_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libkml-1.3.0-h9ee1731_1021.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-25_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-hc8e404f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.2-nompi_h976d569_115.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.64.0-hc7306c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_hbf64a52_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-18.1.0-h19ef8e7_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.44-h4b8f8c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-5.28.2-h8b30cf6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2024.07.02-hd530cb8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/librttopo-1.1.0-hdfb80b9_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libspatialite-5.1.0-hc43c327_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.0-h2f8c449_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-h3dc7d44_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.21.0-h75589b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-h583c2ba_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-he670073_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.5-h495214b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzip-1.11.2-h31df5bb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.4-ha54dae1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.43.0-py311h25b8078_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-4.3.3-py311h12b7ed1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lzo-2.10-h10d778d_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.2-py311h8b4e8a7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.2-py311h8b21175_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.0.7-h62b0c8d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.1.0-py311hf2f7c97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/netcdf4-1.7.2-nompi_py311h62486fc_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.60.0-py311h0e5bd6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.0.2-py311h14ed71f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hd471939_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.3-h5cd248e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.3-py311haeb46be_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.44-h7634a1b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.0.0-py311h1f68098_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.5.0-h70d2bda_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.0-py311h1314207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-18.1.0-py311h6eed73b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-18.1.0-py311he02522f_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.3.1-py311hd6939f8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.3.1-py311hd6939f8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.7.0-py311h50e4d0a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.10-ha513fb2_3_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311h3336109_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.2.0-py311h4d3da15_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rasterio-1.4.2-py311h7ab2778_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rav1e-0.6.6-h7205ca4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2024.07.02-h2fb0a26_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.21.0-py311h3b9c2be_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.1-py311hed734c1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.6-py311h9a2ae1f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-he1e6707_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.47.0-h6285a30_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/svt-av1-2.3.0-h97d8b74_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.2-py311h4d7f069_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-15.1.0-py311h1314207_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/uriparser-0.9.8-h6aefe2f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/x265-3.5-hbb4e6a2_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xerces-c-3.2.5-h197e74d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h00291cd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h7130eaa_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-hd23fc13_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py311hdf6fcd6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.13.1-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.13.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.9.1-h7bae524_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311h460d6c5_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.8.0-h9b725a8_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.8.0-h5d7ee29_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.10.3-h5505292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.0-h5d7ee29_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.5.0-h13ead76_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.9.1-hf483d09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.15.2-h39f8ad8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.11.0-h68a0d7e_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.7.2-h840aca7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.1-h5d7ee29_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.2-h5d7ee29_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.29.6-h8bcca62_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.449-h3b64406_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.14.0-hd50102c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.10.0-hc602bab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.13.0-h7585a09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.8.0-h9ca1f76_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.12.0-hcdd55da_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h5499902_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311h3f08180_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.3-h5505292_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cartopy-0.24.0-py311h9cb3ce9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py311h3a79f62_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.4-py311h0f07fe1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.1-py311h210dab8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.0.0-py311h460d6c5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.9-py311h155a34a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.55.0-py311h4921393_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-hfbad9fb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.13.0-hf9b8971_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geotiff-1.7.3-h82bf549_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.4-nompi_ha698983_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/json-c-0.18-he4178ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py311h267d04e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.7-py311h2c37856_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_hf9b8971_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.7.7-h7c07d2a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-18.1.0-hacc6a60_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-18.1.0-h1dc2043_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-18.1.0-h1dc2043_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-18.1.0-hf3d3107_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libavif16-1.1.1-h45b7238_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-25_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hd74edd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-25_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.10.1-h13a7ad3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.4-ha82da77_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libde265-1.0.15-h2ffa867_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.22-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.10.0-h1476194_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.31.0-h8d8be31_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.31.0-h7081f7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.67.1-hc70892a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libheif-1.18.2-gpl_he913df3_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libkml-1.3.0-he250239_1021.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-25_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnetcdf-4.9.2-nompi_h853a48d_115.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-18.1.0-hf4cc9e7_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.28.2-h8f0b736_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2024.07.02-h2348fd5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/librttopo-1.1.0-ha2cf0f4_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libspatialite-5.1.0-hffd3212_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.47.0-hbaaea75_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h9cc3647_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.21.0-h64651cc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-hfce79cd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-hc098a78_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.13.5-hbbdcc80_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzip-1.11.2-h1336266_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.4-hdb05f8b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.43.0-py311hc367efa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-4.3.3-py311hebe0b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h93a5062_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py311h56c23cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.9.2-py311hbe3227e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/minizip-4.0.7-h27ee973_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.0-py311h2c37856_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/netcdf4-1.7.2-nompi_py311hd13e3db_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.60.0-py311h9506ed5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.0.2-py311h649a571_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h39f12f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.3-h121fd32_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py311h9cb3ce9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-h297a79d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.0.0-py311h3894ae9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.5.0-h61a8e3e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py311hae2e1ce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-18.1.0-py311ha1ab1f8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-18.1.0-py311he04fa90_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.3.1-py311h09e6bbd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.3.1-py311h09e6bbd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.0-py311hb4b81e0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.10-hc51fdd5_3_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h460d6c5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.0-py311h730b646_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rasterio-1.4.2-py311h09e72dc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rav1e-0.6.6-h69fbcac_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2024.07.02-hcd0e937_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.21.0-py311h3ff9189_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.1-py311hf1db568_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.6-py311hac502b4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.47.0-hcd14bea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-2.3.0-hf24288c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.2-py311h917b07b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-15.1.0-py311hae2e1ce_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uriparser-0.9.8-h00cdb27_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xerces-c-3.2.5-h92fc2f4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-hc1bb282_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py311ha60cc69_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.10-py311hd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.11.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.13.1-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.13.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh5737063_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/_libavif_api-1.1.1-h57928b3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311he736701_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.8.0-h6c5491b_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.8.0-hb414858_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.10.3-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.3.0-hb414858_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.5.0-hab6af6e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.9.1-hab0f966_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.15.2-hef77f12_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.11.0-hbfeb708_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.7.2-h6108ab3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.2.1-hb414858_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.2.2-hb414858_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.29.6-h2d7cec8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.449-h0ed5b37_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.6-h85f69ea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311hda3d55a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.34.3-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cartopy-0.24.0-py311hcf9f919_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cftime-1.6.4-py311h0a17f05_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.1-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.0.0-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.9-py311hda3d55a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.55.0-py311h5082efb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-h8276f4a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.13.0-h5a68840_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.3-h496ac4d_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.4-nompi_hd5d9e70_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.7-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_he0c23c2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.7.7-h88ece9c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-18.1.0-h58c5d25_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-18.1.0-hf0642a6_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-18.1.0-hf0642a6_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-18.1.0-h322cffe_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libavif16-1.1.1-h4d049a7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libde265-1.0.15-h91493d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.22-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.4-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-14.2.0-h1383e82_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.10.0-hce5bd25_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-14.2.0-h1383e82_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.31.0-h07d40e7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.31.0-he5eb982_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.67.1-h7aa3b8a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libheif-1.18.2-gpl_hc631cee_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-h538826c_1021.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_he239ae6_115.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-18.1.0-hbdea95a_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.28.2-hcaed137_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2024.07.02-h4eb7d71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-hd4c2148_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-h939089a_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.0-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-he619c9f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.21.0-hbe90ef8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hfc51747_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-hb602f4b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.5-h442d1da_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzip-1.11.2-h3135430_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.43.0-py311h7deaa30_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-4.3.3-py311h8b5e962_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lzo-2.10-hcfcfb64_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py311h5082efb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.2-py311h8f1b1e4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/minizip-4.0.6-hb638d1e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.0-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/netcdf4-1.7.2-nompi_py311hc43f1c8_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.60.0-py311h0673bce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.0.2-py311h35ffc71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.4.0-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.3-h34659fe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py311hcf9f919_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.0.0-py311h4fbf6a9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.5.0-hd9569ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.1.0-py311h1ea47a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.1.0-py311hdea38fa_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.7.0-py311h90dcb63_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.10-hce54a09_3_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-5_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-307-py311hda3d55a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.14-py311hda3d55a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.2.0-py311h484c95c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rasterio-1.4.2-py311hf418590_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rav1e-0.6.6-h975169c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2024.07.02-hd3b24a8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.21.0-py311h533ab2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py311hf16d85f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.6-py311hd54bd37_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.47.0-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/svt-av1-2.3.0-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.7.0-h91493d7_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.2-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-15.1.0-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34433-he29a5d6_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hdffcdeb_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.2.5-he0c23c2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-h0e40799_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.5-h0e40799_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py311h53056dc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  license: None
+  size: 2562
+  timestamp: 1578324546067
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23621
+  timestamp: 1650670423406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
+  sha256: b08ef033817b5f9f76ce62dfcac7694e7b6b4006420372de22494503decac855
+  md5: 346722a0be40f6edc53f12640d301338
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2706396
+  timestamp: 1718551242397
+- conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311h9ecbd09_5.conda
+  sha256: d1af1fbcb698c2e07b0d1d2b98384dd6021fa55c8bcb920e3652e0b0c393881b
+  md5: 18143eab7fcd6662c604b85850f0db1e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.0.1
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 35025
+  timestamp: 1725356735679
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.8.0-hb88c0a9_10.conda
+  sha256: d2837a84e6bd7d993a83e79f9e240e1465e375f3d57149ea5b1927c6a4133bcc
+  md5: 409b7ee6d3473cc62bda7280f6ac20d0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 107163
+  timestamp: 1731733534767
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.8.0-hecf86a2_2.conda
+  sha256: 220a37955c120bf2f565fbd5320a82fc4c8b550b2449294bc0509c296cfcb9fa
+  md5: c54459d686ad9d0502823cacff7e8423
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - libgcc >=13
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 47477
+  timestamp: 1731678510949
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.10.3-hb9d3cd8_0.conda
+  sha256: 90bd2ff40b65acb62f11e2500ee7b7e85ac77d2e332429002f4c1da949bec27f
+  md5: ff3653946d34a6a6ba10babb139d96ef
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 237137
+  timestamp: 1731567278052
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.0-hf42f96a_2.conda
+  sha256: 210ba4fff1c9500fe02de1dae311ce723bfa313a2d21b72accd745f736f56fce
+  md5: 257f4ae92fe11bd8436315c86468c39b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 19034
+  timestamp: 1731678703956
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.0-h1ffe551_7.conda
+  sha256: 3b780d6483baa889e8df5aa66ab3c439a9c81331cf2a4799e373f4174768ddd9
+  md5: 7cce4dfab184f4bbdfc160789251b3c5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 53500
+  timestamp: 1731714597524
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.9.1-hab05fe4_2.conda
+  sha256: 90a325b6f5371dd2203b643de646967fe57a4bcbbee8c91086abbf9dd733d59a
+  md5: fb409f7053fa3dbbdf6eb41045a87795
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-compression >=0.3.0,<0.3.1.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 196945
+  timestamp: 1731714483279
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.15.2-hdeadb07_2.conda
+  sha256: 1636136a5d882b4aaa13ea8b7de8cf07038a6878872e3c434df9daf478cee594
+  md5: 461a1eaa075fd391add91bcffc9de0c1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - libgcc >=13
+  - s2n >=1.5.9,<1.5.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 159368
+  timestamp: 1731702542973
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.11.0-h7bd072d_8.conda
+  sha256: 51d3d87a47c642096e2ce389a169aec2e26958042e9130857552a12d65a19045
+  md5: 0e9d67838114c0dbd267a9311268b331
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 194447
+  timestamp: 1731734668760
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.7.2-h3a84f74_0.conda
+  sha256: c0ae38eb1f878157323afdd002229e9eeb739f622e028447330805c030c50a9f
+  md5: a5f883ce16928e898856b5bd8d1bee57
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - libgcc >=13
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 113549
+  timestamp: 1732679091663
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.1-hf42f96a_1.conda
+  sha256: f6e38c79b124c34edb048c28ec58fdfc4ea8f7a218dc493195afbada48ba063b
+  md5: bbdd20fb1994a9f0ba98078fcb6c12ab
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 55738
+  timestamp: 1731687063424
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.2-hf42f96a_1.conda
+  sha256: da802ace5448481c968cfec7e7a4f79f686f42df9de8e3f78c09a925c2882a79
+  md5: d908d43d87429be24edfb20e96543c20
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 72744
+  timestamp: 1731687193373
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.29.6-h0e61686_0.conda
+  sha256: b821d0125f8fcb589b880bf3a5e0e1667e285b3006ceb19d96e6d92d049ab787
+  md5: 651a6500e5fded51bb7572f4eebcfd7b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-mqtt >=0.11.0,<0.11.1.0a0
+  - aws-c-s3 >=0.7.2,<0.7.3.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 355169
+  timestamp: 1732769507038
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.449-h5558e3c_4.conda
+  sha256: 4881f7b4f5e3c797332cffb990df246a422346b220a9c16014f274beb2a276f5
+  md5: ba7abdc93b0ade11d774b47aaab84737
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2945541
+  timestamp: 1732812288219
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.14.0-h5cfcd09_0.conda
+  sha256: fe07debdb089a3db17f40a7f20d283d75284bb4fc269ef727b8ba6fc93f7cb5a
+  md5: 0a8838771cc2e985cd295e01ae83baf1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 345117
+  timestamp: 1728053909574
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.10.0-h113e628_0.conda
+  sha256: 286b31616c191486626cb49e9ceb5920d29394b9e913c23adb7eb637629ba4de
+  md5: 73f73f60854f325a55f1d31459f2ab73
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 232351
+  timestamp: 1728486729511
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.13.0-h3cf044e_1.conda
+  sha256: 2606260e5379eed255bcdc6adc39b93fb31477337bcd911c121fc43cd29bf394
+  md5: 7eb66060455c7a47d9dcdbfa9f46579b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  size: 549342
+  timestamp: 1728578123088
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.8.0-h736e048_1.conda
+  sha256: 273475f002b091b66ce7366da04bf164c3732c03f8692ab2ee2d23335b6a82ba
+  md5: 13de36be8de3ae3f05ba127631599213
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.12.7,<2.14.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 149312
+  timestamp: 1728563338704
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.12.0-ha633028_1.conda
+  sha256: 5371e4f3f920933bb89b926a85a67f24388227419abd6e99f6086481e5e8d5f2
+  md5: 7c1980f89dd41b097549782121a73490
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  size: 287366
+  timestamp: 1728729530295
+- conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-hef167b5_0.conda
+  sha256: 6cc260f9c6d32c5e728a2099a52fdd7ee69a782fff7b400d0606fcd32e0f5fd1
+  md5: 54fe76ab3d0189acaef95156874db7f9
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48842
+  timestamp: 1719266029046
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_2.conda
+  sha256: fcb0b5b28ba7492093e54f3184435144e074dfceab27ac8e6a9457e736565b0b
+  md5: 98514fe74548d768907ce7a13f680e8f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli-bin 1.1.0 hb9d3cd8_2
+  - libbrotlidec 1.1.0 hb9d3cd8_2
+  - libbrotlienc 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 19264
+  timestamp: 1725267697072
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_2.conda
+  sha256: 261364d7445513b9a4debc345650fad13c627029bfc800655a266bf1e375bc65
+  md5: c63b5e52939e795ba8d26e35d767a843
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlidec 1.1.0 hb9d3cd8_2
+  - libbrotlienc 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 18881
+  timestamp: 1725267688731
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hfdbb021_2.conda
+  sha256: 949913bbd1f74d1af202d3e4bff2e0a4e792ec00271dc4dd08641d4221aa2e12
+  md5: d21daab070d76490cb39a8f1d1729d79
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  license: MIT
+  license_family: MIT
+  size: 350367
+  timestamp: 1725267768486
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+  sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
+  md5: 62ee74e96c5ebb0af99386de58cf9553
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 252783
+  timestamp: 1720974456583
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.3-hb9d3cd8_1.conda
+  sha256: 732571ba6286dbccbf4c6450078a581b7a5620204faf876ff0ef282d77a6bfa8
+  md5: ee228789a85f961d14567252a03e725f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 204857
+  timestamp: 1732447031823
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
+  sha256: afee721baa6d988e27fef1832f68d6f32ac8cc99cdf6015732224c2841a09cea
+  md5: c27d1c142233b5bc9ca570c6e2e0c244
+  license: ISC
+  size: 159003
+  timestamp: 1725018903918
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.24.0-py311h7db5c69_0.conda
+  sha256: 992dd015dcb428c7bbd92f1de18fa3eb1f2cb084625ccf676a91727172361f2d
+  md5: 20ba399d57a2b5de789a5b24341481a1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - matplotlib-base >=3.6
+  - numpy >=1.19,<3
+  - packaging >=21
+  - pyproj >=3.3.1
+  - pyshp >=2.3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - shapely >=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1534682
+  timestamp: 1728342432383
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
+  sha256: bc47aa39c8254e9e487b8bcd74cfa3b4a3de3648869eb1a0b89905986b668e35
+  md5: 55553ecd5328336368db611f350b7039
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 302115
+  timestamp: 1725560701719
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.4-py311h9f3472d_1.conda
+  sha256: 8fa32d106c8757eac936105a5a14eb2eac0c66398cfa954855cb0bd220f003a5
+  md5: 2c3c4f115d28ed9e001a271d5d8585aa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 249930
+  timestamp: 1725400597307
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.1-py311hd18a35c_0.conda
+  sha256: 08be6120dc9369f07858677dde2a8474644cc7ec2ae146b39a6953aadc536dfd
+  md5: 351cb68d2081e249069748b6e60b3cd2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 278209
+  timestamp: 1731428493722
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.0.0-py311h9ecbd09_1.conda
+  sha256: 42544e13dc4bb018cec0579ad7a6158c1f296e32fa0995ffd8abb116734dc427
+  md5: 765c19c0b6df9c143ac8f959d1a1a238
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 393854
+  timestamp: 1728335173137
+- conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+  sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
+  md5: 418c6ca5929a611cbd69204907a83995
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 760229
+  timestamp: 1685695754230
+- conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.9-py311hfdbb021_0.conda
+  sha256: cc2e120f53571e19ee6ea062e85e256fce6550ee139d8127cfb24d7ba015f2ae
+  md5: e1d95dce136e7d0f6a9d7cd9b6dca985
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2567811
+  timestamp: 1732236803227
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.55.0-py311h2dc5d0c_0.conda
+  sha256: b959bbe11eda7f4443e635a95347de40d834484f7ad971a0d0953f327d2d86f8
+  md5: 8b056dbb53df32a9dbf1718a04dc4138
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli
+  - libgcc >=13
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2885790
+  timestamp: 1731643615522
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+  sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
+  md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 634972
+  timestamp: 1694615932610
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h743c826_0.conda
+  sha256: 9213f60ba710ecfd3632ce47e036775c9f15ce80a6682ff63cbf12d9dddd5382
+  md5: 12e6988845706b2cfbc3bc35c9a61a95
+  depends:
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - minizip >=4.0.1,<5.0a0
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 59769
+  timestamp: 1694952692595
+- conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.13.0-h5888daf_0.conda
+  sha256: 5c70d6d16e044859edca85feb9d4f1c3c6062aaf88d650826f5ccdf8c44336de
+  md5: 40b4ab956c90390e407bb177f8a58bab
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: LGPL-2.1-only
+  size: 1869233
+  timestamp: 1725676083126
+- conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.3-h77b800c_3.conda
+  sha256: 94c7d002c70a4802a78ac2925ad6b36327cff85e0af6af2825b11a968c81ec20
+  md5: 4eb52aecb43e7c72f8e4fca0c386354e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx >=13
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 131394
+  timestamp: 1726602918349
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
+  sha256: 6c33bf0c4d8f418546ba9c250db4e4221040936aef8956353bc764d4877bc39a
+  md5: d411fc29e338efb48c5fd4576d71d881
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119654
+  timestamp: 1726600001928
+- conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+  sha256: aac402a8298f0c0cc528664249170372ef6b37ac39fdc92b40601a6aed1e32ff
+  md5: 3bf7b9fd5a7136126e0234db4b87c8b6
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 77248
+  timestamp: 1712692454246
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
+  sha256: dc824dc1d0aa358e28da2ecbbb9f03d932d976c8dca11214aa1dcdfcbd054ba2
+  md5: ff862eebdfeb2fd048ae9dc92510baca
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 143452
+  timestamp: 1718284177264
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
+  sha256: 0d09b6dc1ce5c4005ae1c6a19dc10767932ef9a5e9c755cfdbb5189ac8fb0684
+  md5: bd77f8da987968ec3927990495dc22e4
+  depends:
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 756742
+  timestamp: 1695661547874
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.4-nompi_h2d575fe_103.conda
+  sha256: 50bcd6cd6e8853321e87d359571d187f8e18fa1c73b711074e551417c2163483
+  md5: f8416d7ff13707bd8eb75d6b8235857e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3940636
+  timestamp: 1730830832687
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+  sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
+  md5: 8b189310083baabfb622af68fd9d3ae3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 12129203
+  timestamp: 1720853576813
+- conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.18-h6688a6e_0.conda
+  sha256: 09e706cb388d3ea977fabcee8e28384bdaad8ce1fc49340df5f868a2bd95a7da
+  md5: 38f5dbc9ac808e31c00650f7be1db93f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 82709
+  timestamp: 1726487116178
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_1.conda
+  sha256: 2f082f7b12a7c6824e051321c1029452562ad6d496ad2e8c8b7b3dea1c8feb92
+  md5: 5ca76f61b00a15a9be0612d4d883badc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17645
+  timestamp: 1725303065473
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+  sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
+  md5: 30186d27e2c9fa62b45fb1476b7200e3
+  depends:
+  - libgcc-ng >=10.3.0
+  license: LGPL-2.1-or-later
+  size: 117831
+  timestamp: 1646151697040
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.7-py311hd18a35c_0.conda
+  sha256: 4af11cbc063096a284fe1689b33424e7e49732a27fd396d74c7dee03d1e788ee
+  md5: be34c90cce87090d24da64a7c239ca96
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 72393
+  timestamp: 1725459421768
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+  sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
+  md5: 3f43953b7d3fb3aaa1d0d0723d91e368
+  depends:
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1370023
+  timestamp: 1719463201255
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+  sha256: 5c878d104b461b7ef922abe6320711c0d01772f4cd55de18b674f88547870041
+  md5: 51bb7010fc86f70eee639b4bb7a894f5
+  depends:
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 245247
+  timestamp: 1701647787198
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+  sha256: 7c91cea91b13f4314d125d1bedb9d03a29ebbd5080ccdea70260363424646dbe
+  md5: 048b02e3962f066da18efe3a21b77672
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - binutils_impl_linux-64 2.43
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 669211
+  timestamp: 1729655358674
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+  sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
+  md5: 76bbff344f0134279f225174e9064c8f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 281798
+  timestamp: 1657977462600
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_h5888daf_1.conda
+  sha256: 8f91429091183c26950f1e7ffa730e8632f0627ba35d2fccd71df31628c9b4e5
+  md5: e1f604644fe8d78e22660e2fec6756bc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  constrains:
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1310521
+  timestamp: 1727295454064
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
+  sha256: 2ef420a655528bca9d269086cf33b7e90d2f54ad941b437fb1ed5eca87cee017
+  md5: 5e97e271911b8b2001a8b71860c32faa
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 35446
+  timestamp: 1711021212685
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.7-hadbb8c3_0.conda
+  sha256: 68afcb4519d08cebf71845aff6038e7273f021efc04ef48246f8d41e4e462a61
+  md5: 4a099677417658748239616b6ca96bb6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=13
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - lzo >=2.10,<3.0a0
+  - openssl >=3.4.0,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 874221
+  timestamp: 1732614239458
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-18.1.0-he15abb1_1_cpu.conda
+  sha256: afc81af2e533cc35295aebae4fb382e770310d9b1ac31837456b440d35c54cf7
+  md5: bd3e35a6f3f869b4777488452f315008
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - aws-sdk-cpp >=1.11.449,<1.11.450.0a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-identity-cpp >=1.10.0,<1.10.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-files-datalake-cpp >=12.12.0,<12.12.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libgcc >=13
+  - libgoogle-cloud >=2.31.0,<2.32.0a0
+  - libgoogle-cloud-storage >=2.31.0,<2.32.0a0
+  - libre2-11 >=2024.7.2
+  - libstdcxx >=13
+  - libutf8proc >=2.8.0,<2.9.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.3,<2.0.4.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - parquet-cpp <0.0a0
+  - arrow-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 8780597
+  timestamp: 1732863546099
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-18.1.0-h5888daf_1_cpu.conda
+  sha256: 3de5719a7035baad7e665116dce7bb3d069f0c1916e163c553e2e491bbe8b614
+  md5: 6197dcb930f6254e9b2fdc416be56b71
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 18.1.0 he15abb1_1_cpu
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 611272
+  timestamp: 1732863586114
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-18.1.0-h5888daf_1_cpu.conda
+  sha256: 7b3db3d5a7e411f8897e8d74403c1d871f3054300f5009c4bdf75da011bc3f42
+  md5: 77501831a2aabbaabac55e8cb3b6900a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 18.1.0 he15abb1_1_cpu
+  - libarrow-acero 18.1.0 h5888daf_1_cpu
+  - libgcc >=13
+  - libparquet 18.1.0 h6bd9018_1_cpu
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 585458
+  timestamp: 1732863686753
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-18.1.0-h5c8f2c3_1_cpu.conda
+  sha256: e77a354bfc0ba7b04c856f1bb16e7b08950bcde54026087bafec46090380fcc1
+  md5: 5d47bd2674afd104dbe2f2f3534594b0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 18.1.0 he15abb1_1_cpu
+  - libarrow-acero 18.1.0 h5888daf_1_cpu
+  - libarrow-dataset 18.1.0 h5888daf_1_cpu
+  - libgcc >=13
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 520681
+  timestamp: 1732863726954
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.1.1-h1909e37_2.conda
+  sha256: e06da844b007a64a9ac35d4e3dc4dbc66583f79b57d08166cf58f2f08723a6e8
+  md5: 21e468ed3786ebcb2124b123aa2484b7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aom >=3.9.1,<3.10.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - libgcc >=13
+  - rav1e >=0.6.6,<0.7.0a0
+  - svt-av1 >=2.3.0,<2.3.1.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 116202
+  timestamp: 1730268687453
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
+  sha256: d6d12dc437d060f838820e9e61bf73baab651f91935ac594cf10beb9ef1b4450
+  md5: 8ea26d42ca88ec5258802715fe1ee10b
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - liblapack 3.9.0 25_linux64_openblas
+  - libcblas 3.9.0 25_linux64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 25_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15677
+  timestamp: 1729642900350
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
+  sha256: d9db2de60ea917298e658143354a530e9ca5f9c63471c65cf47ab39fd2f429e3
+  md5: 41b599ed2b02abcfdd84302bff174b23
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 68851
+  timestamp: 1725267660471
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
+  sha256: 2892d512cad096cb03f1b66361deeab58b64e15ba525d6592bb6d609e7045edf
+  md5: 9566f0bd264fbd463002e759b8a82401
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 32696
+  timestamp: 1725267669305
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
+  sha256: 779f58174e99de3600e939fa46eddb453ec5d3c60bb46cdaa8b4c127224dbf29
+  md5: 06f70867945ea6a84d35836af780f1de
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 281750
+  timestamp: 1725267679782
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
+  sha256: ab87b0477078837c91d9cda62a9faca18fba7c57cc77aa779ae24b3ac783b5dd
+  md5: 5dbd1b0fc0d01ec5e0e1fbe667281a11
+  depends:
+  - libblas 3.9.0 25_linux64_openblas
+  constrains:
+  - liblapack 3.9.0 25_linux64_openblas
+  - blas * openblas
+  - liblapacke 3.9.0 25_linux64_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15613
+  timestamp: 1729642905619
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+  sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
+  md5: c965a5aa0d5c1c37ffc62dff36e28400
+  depends:
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20440
+  timestamp: 1633683576494
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
+  sha256: 54e6114dfce566c3a22ad3b7b309657e3600cdb668398e95f1301360d5d52c99
+  md5: 6e801c50a40301f6978c53976917b277
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 424900
+  timestamp: 1726659794676
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libde265-1.0.15-h00ab1b0_0.conda
+  sha256: 7cf7e294e1a7c8219065885e186d8f52002fb900bf384d815f159b5874204e3d
+  md5: 407fee7a5d7ab2dca12c9ca7f62310ad
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 411814
+  timestamp: 1703088639063
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
+  sha256: 780f0530a3adfc1497ba49d626931c6afc978c540e1abfde6ccd57128ded6ad6
+  md5: b422943d5d772b7cc858b36ad2a92db5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 72242
+  timestamp: 1728177071251
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+  sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
+  md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
+  depends:
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 123878
+  timestamp: 1597616541093
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+  md5: 172bf1cd1ff8629f2b1179945ed45055
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 112766
+  timestamp: 1702146165126
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+  sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
+  md5: a1cfcc585f0c42bf8d5546bb1dfb668d
+  depends:
+  - libgcc-ng >=12
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 427426
+  timestamp: 1685725977222
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
+  sha256: 56541b98447b58e52d824bd59d6382d609e11de1f8adf20b23143e353d2b8d26
+  md5: db833e03127376d461e1e13e76f09b6c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 73304
+  timestamp: 1730967041968
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+  sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+  md5: d645c6d2ac96843a2bfaccd2d62b3ac3
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 58292
+  timestamp: 1636488182923
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
+  sha256: 53eb8a79365e58849e7b1a068d31f4f9e718dc938d6f2c03e960345739a03569
+  md5: 3cb76c3f10d3bc7f1105b2fc9db984df
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 14.2.0 h77fa898_1
+  - libgcc-ng ==14.2.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 848745
+  timestamp: 1729027721139
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+  sha256: 3a76969c80e9af8b6e7a55090088bc41da4cffcde9e2c71b17f44d37b7cb87f7
+  md5: e39480b9ca41323497b05492a63bc35b
+  depends:
+  - libgcc 14.2.0 h77fa898_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54142
+  timestamp: 1729027726517
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.10.0-hef9eae6_2.conda
+  sha256: dc8c61317e5235be3e9ee96064cc6f6ca73fdefa27da9afbb65730129a74cd84
+  md5: 94ad74bce06086606cfa60c1595bf3bb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - geotiff >=1.7.3,<1.8.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - json-c >=0.18,<0.19.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libarchive >=3.7.7,<3.8.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libdeflate >=1.22,<1.26.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libheif >=1.18.2,<1.19.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.4.0,<4.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - xerces-c >=3.2.5,<3.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - libgdal 3.10.0.*
+  license: MIT
+  license_family: MIT
+  size: 10818538
+  timestamp: 1732731493346
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+  sha256: fc9e7f22a17faf74da904ebfc4d88699013d2992e55505e4aa0eb01770290977
+  md5: f1fd30127802683586f768875127a987
+  depends:
+  - libgfortran5 14.2.0 hd5240d6_1
+  constrains:
+  - libgfortran-ng ==14.2.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 53997
+  timestamp: 1729027752995
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
+  sha256: d149a37ca73611e425041f33b9d8dbed6e52ec506fe8cc1fc0ee054bddeb6d5d
+  md5: 9822b874ea29af082e5d36098d25427d
+  depends:
+  - libgcc >=14.2.0
+  constrains:
+  - libgfortran 14.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1462645
+  timestamp: 1729027735353
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+  sha256: 1911c29975ec99b6b906904040c855772ccb265a1c79d5d75c8ceec4ed89cd63
+  md5: cc3573974587f12dda90d96e3e55a702
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 460992
+  timestamp: 1729027639220
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.31.0-h804f50b_0.conda
+  sha256: b2de99c83516236ff591d30436779f8345bcc11bb0ec76a7ca3a38a3b23b6423
+  md5: 35ab838423b60f233391eb86d324a830
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  - openssl >=3.3.2,<4.0a0
+  constrains:
+  - libgoogle-cloud 2.31.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1248705
+  timestamp: 1731122589027
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.31.0-h0121fbd_0.conda
+  sha256: 3c38b0a80441f82323dc5a72b96c0dd7476bd5184fbfcdf825a8e15249c849af
+  md5: 568d6a09a6ed76337a7b97c84ae7c0f8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libgcc >=13
+  - libgoogle-cloud 2.31.0 h804f50b_0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  size: 782150
+  timestamp: 1731122728715
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.67.1-hc2c308b_0.conda
+  sha256: 870550c1faf524e9a695262cd4c31441b18ad542f16893bd3c5dbc93106705f7
+  md5: 4606a4647bfe857e3cfe21ca12ac3afb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - c-ares >=1.32.3,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libre2-11 >=2024.7.2
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.67.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 7362336
+  timestamp: 1730236333879
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libheif-1.18.2-gpl_hffcb242_100.conda
+  sha256: 82af131dc112f4f36ca9226f30a7b1b3e05ed4fb3f85003e8f1af72b6a8e44bc
+  md5: 76ac2c07b62d45c192940f010eea11fa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aom >=3.9.1,<3.10.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - libavif16 >=1.1.1,<2.0a0
+  - libde265 >=1.0.15,<1.0.16.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - x265 >=3.5,<3.6.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 428886
+  timestamp: 1723121455966
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+  sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
+  md5: d66573916ffcf376178462f1b61c941e
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  size: 705775
+  timestamp: 1702682170569
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+  sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
+  md5: ea25936bb4080d843790b586850f82b8
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 618575
+  timestamp: 1694474974816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-hf539b9f_1021.conda
+  sha256: 721c3916d41e052ffd8b60e77f2da6ee47ff0d18babfca48ccf93606f1e0656a
+  md5: e8c7620cc49de0c6a2349b6dd6e39beb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libexpat >=2.6.2,<3.0a0
+  - libgcc-ng >=13
+  - libstdcxx-ng >=13
+  - libzlib >=1.3.1,<2.0a0
+  - uriparser >=0.9.8,<1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 402219
+  timestamp: 1724667059411
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
+  sha256: 9d1ff017714edb2d84868f0f931a4a0e7c289a971062b2ac66cfc8145df7e20e
+  md5: 4dc03a53fc69371a6158d0ed37214cd3
+  depends:
+  - libblas 3.9.0 25_linux64_openblas
+  constrains:
+  - liblapacke 3.9.0 25_linux64_openblas
+  - libcblas 3.9.0 25_linux64_openblas
+  - blas * openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15608
+  timestamp: 1729642910812
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
+  sha256: 225cc7c3b20ac1db1bdb37fa18c95bf8aecef4388e984ab2f7540a9f4382106a
+  md5: 73301c133ded2bf71906aa2104edae8b
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 31484415
+  timestamp: 1690557554081
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h2564987_115.conda
+  sha256: 77d9536095a076414b787a0c2497bb35fcd72f71eb899fae5acb9853a64b4ec4
+  md5: c5ce70b76c77a6c9a3107be8d8e8ab0b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - blosc >=1.21.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzip >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zlib
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 835104
+  timestamp: 1728055792846
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+  sha256: b0f2b3695b13a989f75d8fd7f4778e1c7aabe3b36db83f0fe80b2cd812c0e975
+  md5: 19e57602824042dfd0446292ef90488b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - c-ares >=1.32.3,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 647599
+  timestamp: 1729571887612
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+  sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+  md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  license_family: GPL
+  size: 33408
+  timestamp: 1697359010159
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
+  sha256: 99ba271d8a80a1af2723f2e124ffd91d850074c0389c067e6d96d72a2dbfeabe
+  md5: 62857b389e42b36b686331bec0922050
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.2.0
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5578513
+  timestamp: 1730772671118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-18.1.0-h6bd9018_1_cpu.conda
+  sha256: 0df119f4c1a2387d910e132c670b29ee5b29dd79384549de6f1a43067515c8ba
+  md5: 1054909202f86e38bbbb7ca1131b8471
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 18.1.0 he15abb1_1_cpu
+  - libgcc >=13
+  - libstdcxx >=13
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 1203523
+  timestamp: 1732863665743
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
+  sha256: e5b14f7a01c2db4362d8591f42f82f336ed48d5e4079e4d1f65d0c2a3637ea78
+  md5: f4cc49d7aa68316213e4b12be35308d1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 290661
+  timestamp: 1726234747153
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
+  sha256: 5e8fd4aa00193c85602ce6101dd28fe31306dff85c9725048f6dc828dfa7c421
+  md5: ab0bff36363bec94720275a681af8b83
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2945348
+  timestamp: 1728565355702
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hbbce691_1.conda
+  sha256: f8ad6a4f6d4fd54ebe3e5e712a01e663222fc57f49d16b6b8b10c30990dafb8f
+  md5: 2124de47357b7a516c0a3efd8f88c143
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 211096
+  timestamp: 1728778964655
+- conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h97f6797_17.conda
+  sha256: 1fb8a71bdbc236b8e74f0475887786735d5fa6f5d76d9a4135021279c7ff54b8
+  md5: e16e9b1333385c502bf915195f421934
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 231770
+  timestamp: 1727338518657
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
+  sha256: 0105bd108f19ea8e6a78d2d994a6d4a8db16d19a41212070d2d1d48a63c34161
+  md5: a587892d3c13b6621a6091be690dbca2
+  depends:
+  - libgcc-ng >=12
+  license: ISC
+  size: 205978
+  timestamp: 1716828628198
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h1b4f908_11.conda
+  sha256: 11d8537d472c5fc25176fda7af6b9aa47f37ba98d0467b77cb713be18ed847ea
+  md5: 43a7f3df7d100e8fc280e6636680a870
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freexl >=2
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - libgcc >=13
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libstdcxx >=13
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - sqlite
+  - zlib
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 4045908
+  timestamp: 1727341751247
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_1.conda
+  sha256: 8a9aadf996a2399f65b679c6e7f29139d5059f699c63e6d7b50e20db10c00508
+  md5: b6f02b52a174e612e89548f4663ce56a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 875349
+  timestamp: 1730208050020
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hf672d98_0.conda
+  sha256: 0407ac9fda2bb67e11e357066eff144c845801d00b5f664efbc48813af1e7bb9
+  md5: be2de152d8073ef1c01b7728475f2fe7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 304278
+  timestamp: 1732349402869
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+  sha256: 4661af0eb9bdcbb5fb33e5d0023b001ad4be828fccdcc56500059d56f9869462
+  md5: 234a5554c53625688d51062645337328
+  depends:
+  - libgcc 14.2.0 h77fa898_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3893695
+  timestamp: 1729027746910
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+  sha256: 25bb30b827d4f6d6f0522cc0579e431695503822f144043b93c50237017fffd8
+  md5: 8371ac6457591af2cf6159439c1fd051
+  depends:
+  - libstdcxx 14.2.0 hc0a3c3a_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 54105
+  timestamp: 1729027780628
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.21.0-h0e7cc3e_0.conda
+  sha256: ebb395232973c18745b86c9a399a4725b2c39293c9a91b8e59251be013db42f0
+  md5: dcb95c0a98ba9ff737f7ae482aef7833
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 425773
+  timestamp: 1727205853307
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-he137b08_1.conda
+  sha256: 9890121db85f6ef463fe12eb04ef1471176e3ef3b5e2d62e8d6dac713df00df4
+  md5: 63872517c98aa305da58a757c443698e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.22,<1.26.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx >=13
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 428156
+  timestamp: 1728232228989
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-hf23e847_1.conda
+  sha256: 104cf5b427fc914fec63e55f685a39480abeb4beb34bdbc77dea084c8f5a55cb
+  md5: b1aa0faa95017bca11369bd080487ec4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 80852
+  timestamp: 1732829699583
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33601
+  timestamp: 1680112270483
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+  sha256: 49bc5f6b1e11cb2babf2a2a731d1a680a5e08a858280876a779dbda06c78c35f
+  md5: b26e8aa824079e1be0294e7152ca4559
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 438953
+  timestamp: 1713199854503
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+  sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
+  md5: 92ed62436b625154323d40d5f2f11dd7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 395888
+  timestamp: 1727278577118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
+  md5: 5aa797f8787fe7a17d1b0821485b5adc
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 100393
+  timestamp: 1702724383534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-hb346dea_0.conda
+  sha256: 8c9d6a3a421ac5bf965af495d1b0a08c6fb2245ba156550bc064a7b4f8fc7bd8
+  md5: c81a9f1118541aaa418ccb22190c817e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=13
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 689626
+  timestamp: 1731489608971
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.11.2-h6991a6a_0.conda
+  sha256: 991e7348b0f650d495fb6d8aa9f8c727bdf52dabf5853c0cc671439b160dce48
+  md5: a7b27c075c9b7f459f1c022090697cba
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 109043
+  timestamp: 1730442108429
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
+  md5: edb0dca6bc32e4f4789199455a1dbeb8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 60963
+  timestamp: 1727963148474
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.43.0-py311h9c9ff8c_1.conda
+  sha256: fb8b3eeea19f1160343d2c84f3b3e888f8c45db563375660905e1e73a793fc74
+  md5: 9ab40f5700784bf16ff7cf8012a646e8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3471295
+  timestamp: 1725305248888
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.3-py311h2cbdf9a_1.conda
+  sha256: 83f560beb20f61bb8c6e43a0656f1e744934d41a48b8a19408e6596cf8ce99a8
+  md5: 867a4aa23ae6c0e9c84cf9aa4f2df0fe
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 39383
+  timestamp: 1725089531914
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+  sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
+  md5: 318b08df404f9c9be5712aaa5a6f0bb0
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 143402
+  timestamp: 1674727076728
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hd590300_1001.conda
+  sha256: 88433b98a9dd9da315400e7fb9cd5f70804cb17dca8b1c85163a64f90f584126
+  md5: ec7398d21e2651e0dcb0044d03b9a339
+  depends:
+  - libgcc-ng >=12
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  size: 171416
+  timestamp: 1713515738503
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py311h2dc5d0c_0.conda
+  sha256: 364a0d55abc4c60bc575c81a4acc9e98ea27565147d4d4dc672bad4b2d069710
+  md5: 15e4dadd59e93baad7275249f10b9472
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25591
+  timestamp: 1729351519326
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.2-py311h2b939e6_2.conda
+  sha256: 92fd9a8c19130064daba8b95bde172c77cbb6105cd7bc928bb0b1174c4a1faec
+  md5: 2e8401a7780e33e9ca76034d0ed24c3c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  - tk >=8.6.13,<8.7.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8014605
+  timestamp: 1731025323671
+- conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.7-h401b404_0.conda
+  sha256: 6315ea87d094418e744deb79a22331718b36a0e6e107cd7fc3c52c7922bc8133
+  md5: 4474532a312b2245c5c77f1176989b46
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 91409
+  timestamp: 1718483022284
+- conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.0-py311hd18a35c_0.conda
+  sha256: 9033fa7084cbfd10e1b7ed3b74cee17169a0731ec98244d05c372fc4a935d5c9
+  md5: 682f76920687f7d9283039eb542fdacf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 104809
+  timestamp: 1725975116412
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+  sha256: 6a1d5d8634c1a07913f1c525db6455918cbc589d745fac46d9d6e30340c8731a
+  md5: 70caf8bb6cf39a0b6b7efc885f51c0fe
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: X11 AND BSD-3-Clause
+  size: 889086
+  timestamp: 1724658547447
+- conda: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.2-nompi_py311h7c29e4f_100.conda
+  sha256: bc94802624f241fdb7999d414a7bd5e4a6d3a0e6ae5454bdf428819c07261754
+  md5: 11395670c4eeda7a60c13c313a83727f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - certifi
+  - cftime
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libgcc >=13
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 1154059
+  timestamp: 1729667693885
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.60.0-py311h4bc866e_0.conda
+  sha256: b48178613ba637b647c5738772d3efabfca502ea579b5ec10784a33d5acb0789
+  md5: e32a210e9caf97383c35685fd2343512
+  depends:
+  - _openmp_mutex >=4.5
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libopenblas !=0.3.6
+  - cuda-version >=11.2
+  - cuda-python >=11.6
+  - tbb >=2021.6.0
+  - scipy >=1.0
+  - cudatoolkit >=11.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5801568
+  timestamp: 1718888179690
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.0.2-py311h71ddf71_1.conda
+  sha256: a922ec6947ad6953cb011b8f1a44779f6b55d62a14c5bcd25d19a8fb1629da30
+  md5: 04ce874aa54fc1d9c735a04e0c6d99c4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9148240
+  timestamp: 1732314901472
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
+  sha256: 5600a0b82df042bd27d01e4e687187411561dfc11cc05143a08ce29b64bf2af2
+  md5: 7f2e286780f072ed750df46dc2631138
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.43,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 341592
+  timestamp: 1709159244431
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
+  sha256: 814b9dff1847b132c676ee6cc1a8cb2d427320779b93e1b6d76552275c128705
+  md5: 23cc74f77eb99315c0360ec3533147a9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 2947466
+  timestamp: 1731377666602
+- conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.3-he039a57_0.conda
+  sha256: 9657ae19d6541fe67a61ef0c26ba1012ec508920b49afa897962c7d4b263ba35
+  md5: 052499acd6d6b79952197a13b23e2600
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1187593
+  timestamp: 1731664886527
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py311h7db5c69_1.conda
+  sha256: dce121d3838996b77b810ca9097cc17068552075c761408a9b2eb788cf8fd1b0
+  md5: 643f8cb35133eb1be4919fb953f0a25f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15695466
+  timestamp: 1726879158862
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
+  sha256: 1087716b399dab91cc9511d6499036ccdc53eb29a288bebcb19cf465c51d7c0d
+  md5: df359c09c41cd186fffb93a2d87aa6f5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 952308
+  timestamp: 1723488734144
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.0.0-py311h49e9ac3_0.conda
+  sha256: f0f792596ae99cba01f829d064058b1e99ca84080fc89f72d925bfe473cfc1b6
+  md5: 2bd3d0f839ec0d1eaca817c9d1feb7c2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 42421065
+  timestamp: 1729065780130
+- conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.5.0-h12925eb_0.conda
+  sha256: 936de8754054d97223e87cc87b72641d2c7582d536ee9eee4b0443fa66e2733f
+  md5: 8c29983ebe50cc7e0998c34bc7614222
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcurl >=8.10.0,<9.0a0
+  - libgcc >=13
+  - libsqlite >=3.46.1,<4.0a0
+  - libstdcxx >=13
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 3093445
+  timestamp: 1726489083290
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py311h9ecbd09_0.conda
+  sha256: 2ac3f1ed6e6a2a0c67a3922f4b5faf382855ad02cc0c85c5d56291c7a94296d0
+  md5: 0ffc1f53106a38f059b151c465891ed3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 505408
+  timestamp: 1729847169876
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+  sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
+  md5: b3c17d95b5a10c6e64a21fa17573e70e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 8252
+  timestamp: 1726802366959
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-18.1.0-py311h38be061_0.conda
+  sha256: 9cfd158a1bb76c4af1a51237a5c5db4a36b2e83bad625ddf6c2b65ee232c16ba
+  md5: 47b8624012486e05e66f6acf7267aa22
+  depends:
+  - libarrow-acero 18.1.0.*
+  - libarrow-dataset 18.1.0.*
+  - libarrow-substrait 18.1.0.*
+  - libparquet 18.1.0.*
+  - pyarrow-core 18.1.0 *_0_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25199
+  timestamp: 1732610760700
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-18.1.0-py311h4854187_0_cpu.conda
+  sha256: db147a0cc22b55ea3c35553b39336eb0392c33371f6efd7f9fb4efed2b728e34
+  md5: 830a64ee7a65e588c7ea615be84db2e3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 18.1.0.* *cpu
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy >=1.21,<3
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4562010
+  timestamp: 1732610600424
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.0-py311h0f98d5a_0.conda
+  sha256: 194440401fba9fb3903aa921abcf3da468172700b5b5c9b21f98fb7be469a54f
+  md5: 22531205a97c116251713008d65dfefd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - certifi
+  - libgcc >=13
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 562000
+  timestamp: 1727795513365
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.10-hc5c86c4_3_cpython.conda
+  sha256: b7fa3bd48e3a3d30f65608e07759cefd27885c6388b3f612af85ce40282e6936
+  md5: 9e1ad55c87368e662177661a998feed5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 30543977
+  timestamp: 1729043512711
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
+  sha256: 2660b8059b3ee854bc5d3c6b1fce946e5bd2fe8fbca7827de2c5885ead6209de
+  md5: 139a8d40c8a2f430df31048949e450de
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6211
+  timestamp: 1723823324668
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h9ecbd09_1.conda
+  sha256: e721e5ff389a7b2135917c04b27391be3d3382e261bb60a369b1620655365c3d
+  md5: abeb54d40f439b86f75ea57045ab8496
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 212644
+  timestamp: 1725456264282
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py311h7deb3e3_3.conda
+  sha256: 3fdef7b3c43474b7225868776a373289a8fd92787ffdf8bed11cf7f39b4ac741
+  md5: e0897de1d8979a3bb20ef031ae1f7d28
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 389074
+  timestamp: 1728642373938
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+  sha256: 776363493bad83308ba30bcb88c2552632581b143e8ee25b1982c8c743e73abc
+  md5: 353823361b1d27eb3960efb076dfcaf6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-Qhull
+  size: 552937
+  timestamp: 1720813982144
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.4.2-py311h5394301_1.conda
+  sha256: c40f18b3aa3e09803fb601168fbd13a623ecc2457baab2c7139f1bc37e342eef
+  md5: 11abe0f15275f15814d8d738a17319df
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - affine
+  - attrs
+  - certifi
+  - click >=4
+  - click-plugins
+  - cligj >=0.5
+  - libgcc >=13
+  - libgdal-core >=3.10.0,<3.11.0a0
+  - libstdcxx >=13
+  - numpy >=1.21,<3
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8182817
+  timestamp: 1731967205107
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.6.6-he8a937b_2.conda
+  sha256: 91b3c1ced90d04ee2eded1f72cf3cbc19ff05a25e41876ef0758266a5bab009f
+  md5: 77d9955b4abddb811cb8ab1aa7d743e4
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 15423721
+  timestamp: 1694329261357
+- conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h77b4e00_1.conda
+  sha256: c1721cb80f7201652fc9801f49c214c88aee835d957f2376e301bd40a8415742
+  md5: 01093ff37c1b5e6bf9f17c0116747d11
+  depends:
+  - libre2-11 2024.07.02 hbbce691_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26665
+  timestamp: 1728778975855
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+  sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
+  md5: 47d31b792659ce70f470b5c82fdfb7a4
+  depends:
+  - libgcc-ng >=12
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 281456
+  timestamp: 1679532220005
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.21.0-py311h9e33e62_0.conda
+  sha256: 41b1c00f08d2b09243ca184af6f4fe8ca9fee418a62aec1cf1555bfd0b1b2eac
+  md5: befdb32741d8686b860232ca80178d63
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  size: 334025
+  timestamp: 1730922823065
+- conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.9-h0fd0ee4_0.conda
+  sha256: f2c8e55d6caa8d87a482b1f133963c184de1ccb2303b77cc8ca86c794253f151
+  md5: f472432f3753c5ca763d2497e2ea30bf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 355568
+  timestamp: 1731541963573
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py311he9a78e4_1.conda
+  sha256: 59482b974c36c375fdfd0bc3e5a3003ea2d2ae72b64b8f3deaeef5a851dbc91d
+  md5: 49ba89bf4d8a995efb99517d1c7aeb1e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=13
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17592106
+  timestamp: 1729481734425
+- conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.6-py311h2fdb869_2.conda
+  sha256: c09f263d503aa59d9bb31425c175bd202917669d1047f830942407b23de231ab
+  md5: 4c78235905053663d1c9e23df3f11b65
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - libgcc >=13
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 581316
+  timestamp: 1727273591182
+- conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
+  sha256: dc7c8e0e8c3e8702aae81c52d940bfaabe756953ee51b1f1757e891bab62cf7f
+  md5: 6b7dcc7349efd123d493d2dbe85a045f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42465
+  timestamp: 1720003704360
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.47.0-h9eae976_1.conda
+  sha256: 8ea1a085fa95d806301aeec0df6985c3ad0852a9a46aa62dd737d228c7862f9f
+  md5: 53abf1ef70b9ae213b22caa5350f97a9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libsqlite 3.47.0 hadc24fc_1
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 883666
+  timestamp: 1730208056779
+- conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-2.3.0-h5888daf_0.conda
+  sha256: df30a9be29f1a8b5a2e314dd5b16ccfbcbd1cc6a4f659340e8bc2bd4de37bc6f
+  md5: 355898d24394b2af353eb96358db9fdd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2746291
+  timestamp: 1730246036363
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+  sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
+  md5: d453b98d9c83e71da0741bb0ff4d76bc
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3318875
+  timestamp: 1699202167581
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.2-py311h9ecbd09_0.conda
+  sha256: afa3489113154b5cb0724b0bf120b62df91f426dabfe5d02f2ba09e90d346b28
+  md5: df3aee9c3e44489257a840b8354e77b9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 855653
+  timestamp: 1732616048886
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py311h9ecbd09_1.conda
+  sha256: 5f277c801ca392512de9aa497fd8be3e168950600c438778dfc4234943c474fc
+  md5: 00895577e2b4c24dca76675ab1862551
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 368413
+  timestamp: 1729704640193
+- conda: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda
+  sha256: 2aad2aeff7c69a2d7eecd7b662eef756b27d6a6b96f3e2c2a7071340ce14543e
+  md5: d71d3a66528853c0a1ac2c02d79a0284
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48270
+  timestamp: 1715010035325
+- conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+  sha256: 76c7405bcf2af639971150f342550484efac18219c0203c5ee2e38b8956fe2a0
+  md5: e7f6ed84d4623d52ee581325c1587a6b
+  depends:
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 3357188
+  timestamp: 1646609687141
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.5-h988505b_2.conda
+  sha256: 339ab0ff05170a295e59133cd0fa9a9c4ba32b6941c8a2a73484cc13f81e248a
+  md5: 9dda9667feba914e0e80b95b82f7402b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=13
+  - libnsl >=2.0.1,<2.1.0a0
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 1648243
+  timestamp: 1727733890754
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
+  sha256: 532a046fee0b3a402db867b6ec55c84ba4cdedb91d817147c8feeae9766be3d6
+  md5: 77cbc488235ebbaab2b6e912d3934bae
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 14679
+  timestamp: 1727034741045
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+  sha256: 6b250f3e59db07c2514057944a3ea2044d6a8cdde8a47b6497c254520fade1ee
+  md5: 8035c64cb77ed555e3f150b7b3972480
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 19901
+  timestamp: 1727794976192
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+  sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+  md5: 2161070d867d1b1204ea749c8eec4ef0
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1 and GPL-2.0
+  size: 418368
+  timestamp: 1660346797927
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+  sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
+  md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 89141
+  timestamp: 1641346969816
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_7.conda
+  sha256: a4dc72c96848f764bb5a5176aa93dd1e9b9e52804137b99daeebba277b31ea10
+  md5: 3947a35e916fcc6b9825449affbf4214
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - libstdcxx >=13
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 335400
+  timestamp: 1731585026517
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+  sha256: 5d7c0e5f0005f74112a34a7425179f4eb6e73c92f5d109e6af4ddeca407c92ab
+  md5: c9f075ab2f33b3bbee9e62d4ad0a6cd8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib 1.3.1 hb9d3cd8_2
+  license: Zlib
+  license_family: Other
+  size: 92286
+  timestamp: 1727963153079
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py311hbc35293_1.conda
+  sha256: a5cf0eef1ffce0d710eb3dffcb07d9d5922d4f7a141abc96f6476b98600f718f
+  md5: aec590674ba365e50ae83aa2d6e1efae
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.11
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 417923
+  timestamp: 1725305669690
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+  sha256: c558b9cc01d9c1444031bd1ce4b9cff86f9085765f17627a6cd85fc623c8a02b
+  md5: 4d056880988120e29d75bfff282e0f45
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 554846
+  timestamp: 1714722996770
+- conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+  sha256: fbf0288cae7c6e5005280436ff73c95a36c5a4c978ba50175cc8e3eb22abc5f9
+  md5: ae5f4ad87126c55ba3f690ef07f81d64
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18726
+  timestamp: 1674245215155
+- conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+  sha256: 4b54b7ce79d818e3cce54ae4d552dba51b7afac160ceecdefd04b3917a37c502
+  md5: 688697ec5e9588bdded167d19577625b
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.9
+  - sniffio >=1.1
+  - typing_extensions >=4.1
+  constrains:
+  - uvloop >=0.21.0b1
+  - trio >=0.26.1
+  license: MIT
+  license_family: MIT
+  size: 109864
+  timestamp: 1728935803440
+- conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
+  sha256: 45ae2d41f4a4dcf8707633d3d7ae376fc62f0c09b1d063c3049c3f6f8c911670
+  md5: cc4834a9ee7cc49ce8d25177c47b10d8
+  depends:
+  - python >=3.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 10241
+  timestamp: 1707233195627
+- conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+  sha256: 130766446f5507bd44df957b6b5c898a8bd98f024bb426ed6cb9ff1ad67fc677
+  md5: 3afef1f55a1366b4d3b6a0d92e2235e4
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.7
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 18602
+  timestamp: 1692818472638
+- conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+  sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
+  md5: b77d8c2313158e6e461ca0efb1c2c508
+  depends:
+  - python >=3.8
+  - python-dateutil >=2.7.0
+  - types-python-dateutil >=2.8.10
+  license: Apache-2.0
+  license_family: Apache
+  size: 100096
+  timestamp: 1696129131844
+- conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+  sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
+  md5: 5f25798dcefd8252ce5f9dc494d5f571
+  depends:
+  - python >=3.5
+  - six >=1.12.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 28922
+  timestamp: 1698341257884
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+  sha256: 28dba85a7e0f7fb57d7315e13f603d1e41b83c5b88aa2a602596b52c833a2ff8
+  md5: 6732fa52eb8e66e5afeb32db8701a791
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 56048
+  timestamp: 1722977241383
+- conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+  sha256: 7b05b2d0669029326c623b9df7a29fa49d1982a9e7e31b2fea34b4c9a4a72317
+  md5: 332493000404d8411859539a5a630865
+  depends:
+  - python >=3.6
+  - soupsieve >=1.2
+  license: MIT
+  license_family: MIT
+  size: 118200
+  timestamp: 1705564819537
+- conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
+  sha256: 01be7fb5163e7c31356a18c259ddc19a5431b8b974dc65e2427b88c2d30034f3
+  md5: 461bcfab8e65c166e297222ae919a2d4
+  depends:
+  - python >=3.9
+  - webencodings
+  license: Apache-2.0 AND MIT
+  license_family: Apache
+  size: 132652
+  timestamp: 1730286301829
+- conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.5.2-pyhd8ed1ab_0.conda
+  sha256: 8af284264eb1cb9c08586ac8c212dcafc929ef1de3db9d0d7f8ca75190a30f4b
+  md5: 38d785787ec83d0431b3855328395113
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.10
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4798991
+  timestamp: 1724417639170
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+  sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
+  md5: 9b347a7ec10940d3f7941ff6c460b551
+  depends:
+  - cached_property >=1.5.2,<1.5.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4134
+  timestamp: 1615209571450
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+  sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+  md5: 576d629e47797577ab0f1b351297ef4a
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11065
+  timestamp: 1615209567874
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+  sha256: 7020770df338c45ac6b560185956c32f0a5abf4b76179c037f115fc7d687819f
+  md5: 12f7d00853807b0531775e9be891cb11
+  depends:
+  - python >=3.7
+  license: ISC
+  size: 163752
+  timestamp: 1725278204397
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_0.conda
+  sha256: 1873ac45ea61f95750cb0b4e5e675d1c5b3def937e80c7eebb19297f76810be8
+  md5: a374efa97290b8799046df7c5ca17164
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 47314
+  timestamp: 1728479405343
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+  sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
+  md5: f3ad426304898027fc619827ff428eca
+  depends:
+  - __unix
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84437
+  timestamp: 1692311973840
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
+  sha256: 90236b113b9a20041736e80b80ee965167f9aac0468315c55e2bad902d673fb0
+  md5: 3549ecbceb6cd77b91a105511b7d0786
+  depends:
+  - __win
+  - colorama
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 85051
+  timestamp: 1692312207348
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+  sha256: ddef6e559dde6673ee504b0e29dd814d36e22b6b9b1f519fa856ee268905bf92
+  md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
+  depends:
+  - click >=3.0
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8992
+  timestamp: 1554588104889
+- conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+  sha256: 97bd58f0cfcff56a0bcda101e26f7d936625599325beba3e3a1fa512dd7fc174
+  md5: a29b7c141d6b2de4bb67788a5f107734
+  depends:
+  - click >=4.0
+  - python <4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10255
+  timestamp: 1633637895378
+- conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.0-pyhd8ed1ab_1.conda
+  sha256: 5a33d0d3ef33121c546eaf78b3dac2141fc4d30bbaeb3959bbc66fcd5e99ced6
+  md5: c88ca2bb7099167912e3b26463fff079
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25952
+  timestamp: 1729059365471
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+  sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+  md5: 3faab06a954c2a04039983f2c4a50d99
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25170
+  timestamp: 1666700778190
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+  sha256: 79a6b4fff545e0b18f86ad93276a1797eb6ac3f7e1851e03f02d63b19655731b
+  md5: 4d155b600b63bc6ba89d91fab74238f8
+  depends:
+  - python >=3.7
+  license: CC-BY-4.0
+  size: 173517
+  timestamp: 1709713413736
+- conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+  sha256: e923acf02708a8a0b591f3bce4bdc11c8e63b73198b99b35fe6cd96bfb6a0dbe
+  md5: 948d84721b578d426294e17a02e24cbb
+  depends:
+  - python >=3.6
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12134
+  timestamp: 1710320435158
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.10-py311hd8ed1ab_3.conda
+  sha256: 3b2460b6cce53ce95f1f3aeb8ef7a50b356226dc48d45265ce5e585fc5e8cbed
+  md5: b6d1a583921c24bb45feef32262b10aa
+  depends:
+  - python 3.11.10.*
+  - python_abi * *_cp311
+  license: Python-2.0
+  size: 45741
+  timestamp: 1729041746101
+- conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+  sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
+  md5: 5cd86562580f274031ede6aa6aa24441
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13458
+  timestamp: 1696677888423
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.11.2-pyhff2d567_1.conda
+  sha256: 1f2c226bfb4e3ee24125185b0694ec73431ff95bc55d995abdb38b7a7e1838ca
+  md5: 4ea56955c9922ac99c35d0784cffeb96
+  depends:
+  - bokeh >=3.1.0
+  - cytoolz >=0.11.0
+  - dask-core >=2024.11.2,<2024.11.3.0a0
+  - dask-expr >=1.1,<1.2
+  - distributed >=2024.11.2,<2024.11.3.0a0
+  - jinja2 >=2.10.3
+  - lz4 >=4.3.2
+  - numpy >=1.24
+  - pandas >=2.0
+  - pyarrow >=14.0.1
+  - python >=3.10
+  constrains:
+  - openssl !=1.1.1e
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7549
+  timestamp: 1731971053850
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.11.2-pyhff2d567_1.conda
+  sha256: b5e120fbcab57343aedbb312c22df8faa1a8444fb16b4d66879efbd7fd560d53
+  md5: ae2be36dab764e655a22f240837cef75
+  depends:
+  - click >=8.1
+  - cloudpickle >=3.0.0
+  - fsspec >=2021.09.0
+  - importlib-metadata >=4.13.0
+  - packaging >=20.0
+  - partd >=1.4.0
+  - python >=3.10
+  - pyyaml >=5.3.1
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 903030
+  timestamp: 1731970891036
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.19-pyhd8ed1ab_0.conda
+  sha256: 5f2c9e8f49c016a249d07eb46bae5b4085f3750827d12aff8aa0db1be4665165
+  md5: 09ea33eb6525cc703ce1d39c88378320
+  depends:
+  - dask-core 2024.11.2
+  - pandas >=2
+  - pyarrow >=14.0.1
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 185913
+  timestamp: 1731515130979
+- conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+  sha256: 8f35e2d76173d300f5e5f504d67238097c16457267d421a8ab10d1e5bd9b734d
+  md5: 1316959270592fbf8e2278a336de3ab9
+  depends:
+  - colorcet
+  - dask-core
+  - multipledispatch
+  - numba
+  - numpy
+  - packaging
+  - pandas
+  - param
+  - pillow
+  - pyct
+  - python >=3.9
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17230062
+  timestamp: 1720435590279
+- conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+  md5: 43afe5ab04e35e17ba28649471dd7364
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 12072
+  timestamp: 1641555714315
+- conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
+  md5: 961b3a227b437d82ad7054484cfa71b2
+  depends:
+  - python >=3.6
+  license: PSF-2.0
+  license_family: PSF
+  size: 24062
+  timestamp: 1615232388757
+- conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.11.2-pyhff2d567_1.conda
+  sha256: 67b4ef42db9f0fcfa2fb6274bd4ee530769bb84649cbb07da2b7d0a85f4cdfe2
+  md5: 171408408370e59126dc3e39352c6218
+  depends:
+  - click >=8.0
+  - cloudpickle >=3.0.0
+  - cytoolz >=0.11.2
+  - dask-core >=2024.11.2,<2024.11.3.0a0
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.2
+  - packaging >=20.0
+  - psutil >=5.8.0
+  - python >=3.10
+  - pyyaml >=5.4.1
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0
+  - toolz >=0.11.2
+  - tornado >=6.2.0
+  - urllib3 >=1.26.5
+  - zict >=3.0.0
+  constrains:
+  - openssl !=1.1.1e
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 802347
+  timestamp: 1731970957315
+- conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
+  md5: 3cf04868fee0a029769bd41f4b2fbf2d
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 9199
+  timestamp: 1643888357950
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+  sha256: e0edd30c4b7144406bb4da975e6bb97d6bc9c0e999aa4efe66ae108cada5d5b5
+  md5: d02ae936e42063ca46af6cdad2dbd1e0
+  depends:
+  - python >=3.7
+  license: MIT and PSF-2.0
+  size: 20418
+  timestamp: 1720869435725
+- conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+  sha256: a52d7516e2e11d3eb10908e10d3eb3f8ef267fea99ed9b09d52d96c4db3441b8
+  md5: d0441db20c827c11721889a241df1220
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 28337
+  timestamp: 1725214501850
+- conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 6cfd1f9bcd2358a69fb571f4b3af049b630d52647d906822dbedac03e84e4f63
+  md5: 642d35437078749ef23a5dca2c9bb1f3
+  depends:
+  - cached-property >=1.3.0
+  - python >=2.7,<4
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 14395
+  timestamp: 1638810388635
+- conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+  sha256: 40bb76981dd49d5869b48925a8975bb7bbe4e33e1e40af4ec06f6bf4a62effd7
+  md5: 816dbc4679a64e4417cd1385d661bb31
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 134745
+  timestamp: 1729608972363
+- conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_1.conda
+  sha256: 1b0853491a299e95d57ccf3f3c9053a1b7e49fc9b2ad959f321b0717e567e249
+  md5: cad8d8e1583463e7642adc72a76dc3c5
+  depends:
+  - numpy >=1.22
+  - packaging
+  - pandas >=1.4.0
+  - python >=3.9
+  - shapely >=2.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 239539
+  timestamp: 1726898022361
+- conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.13.1-hd8ed1ab_0.conda
+  sha256: b5913fab2f72974a8e38beced5c863179ad9e5a01f9783415a598a4665e80af9
+  md5: d2256176e09650d9a33bfd2d7c942dbc
+  depends:
+  - datashader
+  - geopandas-base
+  - geoviews-core 1.13.1 pyha770c72_0
+  - netcdf4
+  - pandas
+  - pyct
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7882
+  timestamp: 1732869193766
+- conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.13.1-pyha770c72_0.conda
+  sha256: a0739e9c34ca4637d389bd31d8e6974b563d4053523d0f6e9a568b0f37425f4d
+  md5: 438e7e8553527288b7e6e9ebc70010a7
+  depends:
+  - bokeh >=3.5.0,<3.6.0
+  - cartopy >=0.18.0
+  - holoviews >=1.16.0
+  - numpy >=1.0
+  - packaging
+  - panel >=1.0.0
+  - param >=1.9.3,<3.0
+  - pyproj
+  - python >=3.10
+  - shapely
+  - xyzservices
+  constrains:
+  - geoviews 1.13.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 404625
+  timestamp: 1732869147532
+- conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+  sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
+  md5: b748fbf7060927a6e82df7cb5ee8f097
+  depends:
+  - hpack >=4.0,<5
+  - hyperframe >=6.0,<7
+  - python >=3.6.1
+  license: MIT
+  license_family: MIT
+  size: 46754
+  timestamp: 1634280590080
+- conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+  sha256: 369d234fb83fb37e0e8abe7a78981a533cec37053c5c15177ad6caade729118d
+  md5: a765e03fa67caf58525b08bbbd5b4f76
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.9
+  - pyviz_comms >=2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4037867
+  timestamp: 1730736003074
+- conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+  sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
+  md5: 914d6646c4dbb1fd3ff539830a12fd71
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 25341
+  timestamp: 1598856368685
+- conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
+  md5: 9f765cbfab6870c8435b9eefecd7a1f4
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 14646
+  timestamp: 1619110249723
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
+  sha256: 8c57fd68e6be5eecba4462e983aed7e85761a519aab80e834bbd7794d4b545b2
+  md5: 7ba2ede0e7c795ff95088daf0dc59753
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49837
+  timestamp: 1726459583613
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
+  sha256: 7194700ce1a5ad2621fd68e894dd8c1ceaff9a38723e6e0e5298fdef13017b1c
+  md5: 54198435fce4d64d8a89af22573012a8
+  depends:
+  - python >=3.8
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 28646
+  timestamp: 1726082927916
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_0.conda
+  sha256: 2cb9db3e40033c3df72d3defc678a012840378fd55a67e4351363d4b321a0dc1
+  md5: c808991d29b9838fb4d96ce8267ec9ec
+  depends:
+  - python >=3.8
+  - zipp >=3.1.0
+  constrains:
+  - importlib-resources >=6.4.5,<6.4.6.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 32725
+  timestamp: 1725921462405
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+  sha256: 33cfd339bb4efac56edf93474b37ddc049e08b1b4930cf036c893cc1f5a1f32a
+  md5: b40131ab6a36ac2c09b7c57d4d3fbf99
+  depends:
+  - __linux
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119084
+  timestamp: 1719845605084
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+  sha256: dc569094125127c0078aa536f78733f383dd7e09507277ef8bcd1789786e7086
+  md5: 18df5fc4944a679e085e0e8f31775fc8
+  depends:
+  - __win
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119853
+  timestamp: 1719845858082
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+  sha256: 072534d4d379225b2c3a4e38bc7730b65ae171ac7f0c2d401141043336e97980
+  md5: 9eb15d654daa0ef5a98802f586bb4ffc
+  depends:
+  - __osx
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119568
+  timestamp: 1719845667420
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh707e725_0.conda
+  sha256: 65cdc105e5effea2943d3979cc1592590c923a589009b484d07672faaf047af1
+  md5: 5d6e5cb3a4b820f61b2073f0ad5431f1
+  depends:
+  - __unix
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - pickleshare
+  - prompt-toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.10
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 600248
+  timestamp: 1732897026255
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.30.0-pyh7428d3b_0.conda
+  sha256: 94ee8215bd1f614c9c984437b184e8dbe61a4014eb5813c276e3dcb18aaa7f46
+  md5: 6cdaebbc9e3feb2811eb9f52ed0b89e1
+  depends:
+  - __win
+  - colorama
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.10
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 600466
+  timestamp: 1732897444811
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-pyhd8ed1ab_1.conda
+  sha256: 72fbbe8bc511f20268d347c1a06e279128237e096c4c174b2f9164a661c6b13e
+  md5: f8ed9f18dce81e4ee55c858cc2f8548a
+  depends:
+  - python >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28064
+  timestamp: 1716278507729
+- conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
+  md5: 4cb68948e0b8429534380243d063a27a
+  depends:
+  - arrow >=0.15.0
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 17189
+  timestamp: 1638811664194
+- conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhff2d567_0.conda
+  sha256: d37dad14c00d06d33bfb99c378d0abd7645224a9491c433af5028f24863341ab
+  md5: 11ead81b00e0f7cc901fceb7ccfb92c1
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.9
+  license: Apache-2.0 AND MIT
+  size: 842916
+  timestamp: 1731317305873
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+  sha256: 27380d870d42d00350d2d52598cddaf02f9505fb24be09488da0c9b8d1428f2d
+  md5: 7b86ecb7d3557821c649b3c31e3eb9f2
+  depends:
+  - markupsafe >=2.0
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 111565
+  timestamp: 1715127275924
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+  sha256: 7d0c4c0346b26be9f220682b7c5c0d84606d48c6dbc36fc238e4452dda733aff
+  md5: da304c192ad59975202859b367d0f6a2
+  depends:
+  - attrs >=22.2.0
+  - importlib_resources >=1.4.0
+  - jsonschema-specifications >=2023.03.6
+  - pkgutil-resolve-name >=1.3.10
+  - python >=3.8
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 74323
+  timestamp: 1720529611305
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+  sha256: 82f8bed0f21dc0b3aff40dd4e39d77e85b93b0417bc5659b001e0109341b8b98
+  md5: 720745920222587ef942acfbc578b584
+  depends:
+  - python >=3.8
+  - referencing >=0.31.0
+  license: MIT
+  license_family: MIT
+  size: 16165
+  timestamp: 1728418976382
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+  sha256: 007a0a506a0d1805b099629cb0ee743ad0afe7d9749e57339f32c168119e0139
+  md5: 16b37612b3a2fd77f409329e213b530c
+  depends:
+  - fqdn
+  - idna
+  - isoduration
+  - jsonpointer >1.13
+  - jsonschema >=4.23.0,<4.23.1.0a0
+  - rfc3339-validator
+  - rfc3986-validator >0.1.0
+  - uri-template
+  - webcolors >=24.6.0
+  license: MIT
+  license_family: MIT
+  size: 7143
+  timestamp: 1720529619500
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.4.9-pyhd8ed1ab_0.conda
+  sha256: 38e67f3e0d631f4aeeab4bbd4062dcb6f4ae9dc35803053c995d02912a999b65
+  md5: 5cbf9a31a19d4ef9103adb7d71fd45fd
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.7
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 99449
+  timestamp: 1673616104031
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+  sha256: 732b1e8536bc22a5a174baa79842d79db2f4956d90293dd82dc1b3f6099bcccd
+  md5: 0a2980dada0dd7fd0998f0342308b1b1
+  depends:
+  - __unix
+  - platformdirs >=2.5
+  - python >=3.8
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 57671
+  timestamp: 1727163547058
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh5737063_1.conda
+  sha256: 7c903b2d62414c3e8da1f78db21f45b98de387aae195f8ca959794113ba4b3fd
+  md5: 46d87d1c0ea5da0aae36f77fa406e20d
+  depends:
+  - __win
+  - cpython
+  - platformdirs >=2.5
+  - python >=3.8
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 58269
+  timestamp: 1727164026641
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+  sha256: cd3f41dc093162a41d4bae171e40a1b9b115c4d488e9bb837a8fa9d084931fb9
+  md5: ed45423c41b3da15ea1df39b1f80c2ca
+  depends:
+  - jsonschema-with-format-nongpl >=4.18.0
+  - python >=3.8
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21475
+  timestamp: 1710805759187
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+  sha256: edab71a05feceac54bdb90e755a257545af7832b9911607c1a70f09be44ba985
+  md5: ca23c71f70a7c7935b3d03f0f1a5801d
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert-core >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.8
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 323978
+  timestamp: 1720816754998
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+  sha256: 038efbc7e4b2e72d49ed193cfb2bbbe9fbab2459786ce9350301f466a32567db
+  md5: 219b3833aa8ed91d47d1be6ca03f30be
+  depends:
+  - python >=3.8
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19818
+  timestamp: 1710262791393
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+  sha256: 4aa622bbcf97e44cd1adf0100b7ff71b7e20268f043bdf6feae4d16152f1f242
+  md5: afcd1b53bcac8844540358e33f33d28f
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.7
+  constrains:
+  - jupyterlab >=4.0.8,<5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18776
+  timestamp: 1707149279640
+- conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+  sha256: aa99d44e8c83865026575a8af253141c53e0b3ab05f053befaa7757c8525064f
+  md5: f1b64ca4faf563605cf6f6ca93f9ff3f
+  depends:
+  - python >=3.7
+  - uc-micro-py
+  license: MIT
+  license_family: MIT
+  size: 24035
+  timestamp: 1707129321841
+- conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
+  md5: 91e27ef3d05cc772ce627e51cff111c4
+  depends:
+  - python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 8250
+  timestamp: 1650660473123
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
+  sha256: fce1fde00359696983989699c00f9891194c4ebafea647a8d21b7e2e3329b56e
+  md5: 06e9bebf748a0dea03ecbe1f0e27e909
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78331
+  timestamp: 1710435316163
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+  sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
+  md5: 93a8e71256479c62074356ef6ebf501b
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 64356
+  timestamp: 1686175179621
+- conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+  sha256: 7ea68676ea35fbb095420bbcc1c82c4767b8be7bb56abb6989b7f89d957a3bab
+  md5: 779345c95648be40d22aaa89de7d4254
+  depends:
+  - python >=3.6
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14599
+  timestamp: 1713250613726
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+  sha256: 5cedc99412278b37e9596f1f991d49f5a1663fe79767cf814a288134a1400ba9
+  md5: 5387f2cfa28f8a3afa3368bb4ba201e8
+  depends:
+  - markdown-it-py >=1.0.0,<4.0.0
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 42126
+  timestamp: 1725995333692
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+  sha256: 64073dfb6bb429d52fff30891877b48c7ec0f89625b1bf844905b66a81cce6e1
+  md5: 776a8dd9e824f77abac30e6ef43a8f7a
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 14680
+  timestamp: 1704317789138
+- conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+  sha256: f95cb70007e3cc2ba44e17c29a056b499e6dadf08746706d0c817c8e2f47e05c
+  md5: 5cbee699846772cc939bef23a0d524ed
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 66022
+  timestamp: 1698947249750
+- conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+  sha256: c6216a21154373b340c64f321f22fec51db4ee6156c2e642fa58368103ac5d09
+  md5: 121a57fce7fff0857ec70fa03200962f
+  depends:
+  - python >=3.6
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17254
+  timestamp: 1721907640382
+- conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+  sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
+  md5: 2ba8498c1018c1e9c61eb99b973dfe19
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 12452
+  timestamp: 1600387789153
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclassic-1.1.0-pyhd8ed1ab_0.conda
+  sha256: da3330a8ffff1f5b15b558543fbec69e05a48750ed50b53369b93da788abedc5
+  md5: 6275b55edf34cfa1f01ba40b699dd915
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5493243
+  timestamp: 1716838925077
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.1-pyhd8ed1ab_0.conda
+  sha256: 564e22c4048f2f00c7ee79417dea364f95cf069a1f2565dc26d5ece1fc3fd779
+  md5: 3ee79082e59a28e1db11e2a9c3bcd85a
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.8
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27878
+  timestamp: 1732882434219
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+  sha256: 074d858c5808e0a832acc0da37cd70de1565e8d6e17a62d5a11b3902b5e78319
+  md5: e2d2abb421c13456a9a9f80272fdf543
+  depends:
+  - beautifulsoup4
+  - bleach
+  - defusedxml
+  - entrypoints >=0.2.2
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<3.1
+  - nbclient >=0.5.0
+  - nbformat >=5.1
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.8
+  - tinycss2
+  - traitlets >=5.0
+  constrains:
+  - nbconvert =7.16.4=*_1
+  - pandoc >=2.9.2,<4.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 189599
+  timestamp: 1718135529468
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+  sha256: 36fe73da4d37bc7ac2d1540526ecd294fbd09acda04e096181ab8f1ccd2b464c
+  md5: 0b57b5368ab7fc7cdc9e3511fa867214
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.8
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 101232
+  timestamp: 1712239122969
+- conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+  sha256: 30db21d1f7e59b3408b831a7e0417b83b53ee6223afae56482c5f26da3ceb49a
+  md5: 6598c056f64dc8800d40add25e4e2c34
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11638
+  timestamp: 1705850780510
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-6.5.7-pyha770c72_0.conda
+  sha256: e37db45223e432bcad809897177e05fff31828dfcfc3ef18f046ae44ec01286c
+  md5: f81a6fe643390df9347984644727d796
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert-core >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.7
+  - pyzmq >=17
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 308643
+  timestamp: 1715849037288
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+  sha256: 9b5fdef9ebe89222baa9da2796ebe7bc02ec6c5a1f61327b651d6b92cf9a0230
+  md5: 3d85618e2c97ab896b5b5e298d32b5b3
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16880
+  timestamp: 1707957948029
+- conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+  sha256: 5e238e5e646414d517a13f6786c7227206ace58271e3ef63f6adca4d6a4c2839
+  md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
+  depends:
+  - python >=3.6
+  - typing_utils
+  license: Apache-2.0
+  license_family: APACHE
+  size: 30232
+  timestamp: 1706394723472
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhff2d567_1.conda
+  sha256: 74843f871e5cd8a1baf5ed8c406c571139c287141efe532f8ffbdafa3664d244
+  md5: 8508b703977f4c4ada34d657d051972c
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: APACHE
+  size: 60380
+  timestamp: 1731802602808
+- conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
+  md5: 457c2c8c08e54905d6954e79cb5b5db9
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11627
+  timestamp: 1631603397334
+- conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.4-pyhd8ed1ab_0.conda
+  sha256: 5a05f572a610cada2fcccef8d555fddf2d01bef80da32411150735e6177d1eab
+  md5: 41c7413071c2bae37472214a3525e6bf
+  depends:
+  - bleach
+  - bokeh >=3.5.0,<3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2
+  - param >=2.1.0,<3.0
+  - python >=3.10
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20670374
+  timestamp: 1731497809631
+- conda: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+  sha256: db644c81c1f47e1fa8134d5de935ec4269d765fbef8d44bd454eb187c7524472
+  md5: bd991333d5bc659bb82bfb5a5d4c1576
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 103339
+  timestamp: 1719325288387
+- conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+  sha256: bfe404eebb930cc41782d34f8fc04c0388ea692eeebe2c5fc28df8ec8d4d61ae
+  md5: 81534b420deb77da8833f2289b8d47ac
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 75191
+  timestamp: 1712320447201
+- conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+  sha256: 472fc587c63ec4f6eba0cc0b06008a6371e0a08a5986de3cf4e8024a47b4fe6c
+  md5: 0badf9c54e24cecfb0ad2f99d680c163
+  depends:
+  - locket
+  - python >=3.9
+  - toolz
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20884
+  timestamp: 1715026639309
+- conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+  sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
+  md5: 629f3203c99b32e0988910c93e77f3b6
+  depends:
+  - ptyprocess >=0.5
+  - python >=3.7
+  license: ISC
+  size: 53600
+  timestamp: 1706113273252
+- conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+  sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
+  md5: 415f0ebb6198cc2801c73438a9fb5761
+  depends:
+  - python >=3
+  license: MIT
+  license_family: MIT
+  size: 9332
+  timestamp: 1602536313357
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+  sha256: 499313e72e20225f84c2e9690bbaf5b952c8d7e0bf34b728278538f766b81628
+  md5: 5dd546fe99b44fda83963d15f84263b7
+  depends:
+  - python >=3.8,<3.13.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 1243168
+  timestamp: 1730203795600
+- conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+  sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
+  md5: 405678b942f2481cecdb3e010f4925d9
+  depends:
+  - python >=3.6
+  license: MIT AND PSF-2.0
+  size: 10778
+  timestamp: 1694617398467
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
+  sha256: c81bdeadc4adcda216b2c7b373f0335f5c78cc480d1d55d10f21823590d7e46f
+  md5: fd8f2b18b65bbf62e8f653100690c8d2
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 20625
+  timestamp: 1726613611845
+- conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
+  sha256: 01f0c3dd00081637ed920a922b17bcc8ed49608404ee466ced806856e671f6b9
+  md5: 07e9550ddff45150bfc7da146268e165
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: Apache
+  size: 49024
+  timestamp: 1726902073034
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_0.conda
+  sha256: 44e4e6108d425a666856a52d1523e5d70890256a8920bb0dcd3d55cc750f3207
+  md5: 4c05134c48b6a74f33bbb9938e4a115e
+  depends:
+  - python >=3.7
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.48
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 270271
+  timestamp: 1727341744544
+- conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+  sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+  md5: 359eeb6536da0e687af562ed265ec263
+  depends:
+  - python
+  license: ISC
+  size: 16546
+  timestamp: 1609419417991
+- conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+  sha256: dcfcb3cee1ae0a89729601582cc3edea20ba13c9493967a03a693c67567af0c8
+  md5: 0f051f09d992e0d08941706ad519ee0e
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 16551
+  timestamp: 1721585805256
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+  sha256: 406001ebf017688b1a1554b49127ca3a4ac4626ec0fd51dc75ffa4415b720b64
+  md5: 844d9eb3b43095b031874477f7d70088
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105098
+  timestamp: 1711811634025
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+  sha256: 0e1e17a37d53be84c33b88218f10afb5f8137f19a727fdc56e45ae0b8b439a57
+  md5: 24c245c82396be3297c0aa26b69e18d8
+  depends:
+  - param >=1.7.0
+  - python >=3.7
+  - pyyaml
+  - requests
+  - setuptools >=61.0
+  constrains:
+  - pyct-core <0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20096
+  timestamp: 1701103924264
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+  sha256: 78267adf4e76d0d64ea2ffab008c501156c108bb08fecb703816fb63e279780b
+  md5: b7f5c092b8f9800150d998a71b76d5a1
+  depends:
+  - python >=3.8
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 879295
+  timestamp: 1714846885370
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_1.conda
+  sha256: b846e3965cd106438cf0b9dc0de8d519670ac065f822a7d66862e9423e0229cb
+  md5: 035c17fbf099f50ff60bf2eb303b0a83
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 92444
+  timestamp: 1728880549923
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 41eced0d5e855bc52018f200b239d627daa38ad78a655ffa2f1efd95b07b6bce
+  md5: 92a889dc236a5197612bc85bee6d7174
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 964060
+  timestamp: 1659003065197
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
+  sha256: b3a612bc887f3dd0fb7c4199ad8e342bd148cf69a9b74fd9468a18cf2bef07b7
+  md5: 56cd9fe388baac0e90c7149cfac95b60
+  depends:
+  - __win
+  - python >=3.8
+  - win_inet_pton
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19348
+  timestamp: 1661605138291
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+  sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+  md5: 2a7de29fb590ca14b5243c4c812c8025
+  depends:
+  - __unix
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18981
+  timestamp: 1661604969727
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_0.conda
+  sha256: 3888012c5916efaef45d503e3e544bbcc571b84426c1bb9577799ada9efefb54
+  md5: b6dfd90a2141e573e4b6a81630b56df5
+  depends:
+  - python >=3.9
+  - six >=1.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 221925
+  timestamp: 1731919374686
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.0-pyhd8ed1ab_0.conda
+  sha256: 09ae0acccbfc325b9b65946795c0055e0a40374e4e73b264f3b7e8cd8ae0a95a
+  md5: 4c849126120d1b3d61cf0eac8120ea70
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 225949
+  timestamp: 1732805566866
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+  sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
+  md5: a61bf9ec79426938ff785eb69dbb1960
+  depends:
+  - python >=3.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 13383
+  timestamp: 1677079727691
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_0.conda
+  sha256: fe3f62ce2bc714bdaa222ab3f0344a2815ad9e853c6df38d15c9f25de8a3a6d4
+  md5: 986287f89929b2d629bd6ef6497dc307
+  depends:
+  - python >=3.6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 142527
+  timestamp: 1727140688093
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
+  sha256: 1a7d6b233f7e6e3bbcbad054c8fd51e690a67b129a899a056a5e45dd9f00cb41
+  md5: 3eeeeb9e4827ace8c0c1419c85d590ad
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 188538
+  timestamp: 1706886944988
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+  sha256: a7979e8e4936c430f5fe3d04fc2d67b42dab84fb4a502c4961a17dcb2327fec0
+  md5: 02b4e3a3014c1ac490ee4a4316f2d229
+  depends:
+  - param
+  - python >=3.6
+  constrains:
+  - jupyterlab >=4.0,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48061
+  timestamp: 1722535734510
+- conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+  sha256: be8d6d9e86b1a3fef5424127ff81782f8ca63d3058980859609f6f1ecdd34cb3
+  md5: 0fc8b52192a8898627c3efae1003e9f6
+  depends:
+  - attrs >=22.2.0
+  - python >=3.8
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 42210
+  timestamp: 1714619625532
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+  sha256: 5845ffe82a6fa4d437a2eae1e32a1ad308d7ad349f61e337c0a890fe04c513cc
+  md5: 5ede4753180c7a550a443c430dc8ab52
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.8
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 58810
+  timestamp: 1717057174842
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+  sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
+  md5: fed45fc5ea0813240707998abe49f520
+  depends:
+  - python >=3.5
+  - six
+  license: MIT
+  license_family: MIT
+  size: 8064
+  timestamp: 1638811838081
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+  sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
+  md5: 912a71cc01012ee38e6b90ddd561e36f
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 7818
+  timestamp: 1598024297745
+- conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.17.0-pyhd8ed1ab_0.conda
+  sha256: 992ce1a2667dd2beac45157dcb9058775e0522ebf1a70f1563c0fd0608f9480a
+  md5: 160464c6f979eb68e9a9ea31dd6b5aa6
+  depends:
+  - numpy >=1.23
+  - packaging
+  - pyproj >=3.3
+  - python >=3.10
+  - rasterio >=1.3
+  - scipy
+  - xarray >=2022.3.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51306
+  timestamp: 1721412091165
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_0.conda
+  sha256: c4401b071e86ddfa0ea4f34b85308db2516b6aeca50053535996864cfdee7b3f
+  md5: 778594b20097b5a948c59e50ae42482a
+  depends:
+  - __linux
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22868
+  timestamp: 1712585140895
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
+  sha256: f911307db932c92510da6c3c15b461aef935720776643a1fbf3683f61001068b
+  md5: c3cb67fc72fb38020fe7923dbbcf69b0
+  depends:
+  - __osx
+  - pyobjc-framework-cocoa
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23165
+  timestamp: 1712585504123
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_0.conda
+  sha256: d8aa230501a33250af2deee03006a2579f0335e7240a9c7286834788dcdcfaa8
+  md5: 5a86a21050ca3831ec7f77fb302f1132
+  depends:
+  - __win
+  - python >=3.7
+  - pywin32
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23319
+  timestamp: 1712585816346
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+  sha256: abb12e1dd515b13660aacb5d0fd43835bc2186cab472df25b7716cd65e095111
+  md5: fc80f7995e396cbaeabd23cf46c413dc
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 774252
+  timestamp: 1732632769210
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+  sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
+  md5: e5f25f8dbc060e9a8d912e432202afc2
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 14259
+  timestamp: 1620240338595
+- conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+  sha256: bc12100b2d8836b93c55068b463190505b8064d0fc7d025e89f20ebf22fe6c2b
+  md5: 490730480d76cf9c8f8f2849719c6e2b
+  depends:
+  - python >=3.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 15064
+  timestamp: 1708953086199
+- conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_1.conda
+  sha256: 4c2281d61c325f9208ce18e030efc94e44c9a4f0d28a6c5737ff79740e1db2d4
+  md5: 5abeaa41ec50d4d1421a8bc8fbc93054
+  depends:
+  - numpy
+  - pyparsing >=2.1.6
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 11131
+  timestamp: 1722610712753
+- conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
+  md5: 6d6552722448103793743dabfbda532d
+  depends:
+  - python >=2.7
+  license: Apache-2.0
+  license_family: APACHE
+  size: 26314
+  timestamp: 1621217159824
+- conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+  sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
+  md5: 3f144b2c34f8cb5a9abd9ed23a39c561
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 36754
+  timestamp: 1693929424267
+- conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+  sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
+  md5: e7df0fdd404616638df5ece6e69ba7af
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 26205
+  timestamp: 1669632203115
+- conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+  sha256: 2e2c255b6f24a6d75b9938cb184520e27db697db2c24f04e18342443ae847c0a
+  md5: 04eedddeb68ad39871c8127dd1c21f4f
+  depends:
+  - python >=3.7
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17386
+  timestamp: 1702066480361
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
+  sha256: b300557c0382478cf661ddb520263508e4b3b5871b471410450ef2846e8c352c
+  md5: efba281bbdae5f6b0a1d53c6d4a97c93
+  depends:
+  - __linux
+  - ptyprocess
+  - python >=3.8
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22452
+  timestamp: 1710262728753
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
+  sha256: 4daae56fc8da17784578fbdd064f17e3b3076b394730a14119e571707568dc8a
+  md5: 00b54981b923f5aefcd5e8547de056d5
+  depends:
+  - __osx
+  - ptyprocess
+  - python >=3.8
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22717
+  timestamp: 1710265922593
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
+  sha256: 8cb078291fd7882904e3de594d299c8de16dd3af7405787fce6919a385cfc238
+  md5: 4abd500577430a942a995fd0d09b76a2
+  depends:
+  - __win
+  - python >=3.8
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 22883
+  timestamp: 1710262943966
+- conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+  sha256: cad582d6f978276522f84bd209a5ddac824742fe2d452af6acf900f8650a73a2
+  md5: f1acf5fdefa8300de697982bcb1761c9
+  depends:
+  - python >=3.5
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28285
+  timestamp: 1729802975370
+- conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+  sha256: 6371cf3cf8292f2abdcc2bf783d6e70203d72f8ff0c1625f55a486711e276c75
+  md5: 34feccdd4177f2d3d53c73fc44fd9a37
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 52623
+  timestamp: 1728059623353
+- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+  sha256: 5673b7104350a6998cb86cccf1d0058217d86950e8d6c927d8530606028edb1d
+  md5: 4085c9db273a148e149c03627350e22c
+  depends:
+  - colorama
+  - python >=3.7
+  license: MPL-2.0 or MIT
+  size: 89484
+  timestamp: 1732497312317
+- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+  sha256: 8a64fa0f19022828513667c2c7176cfd125001f3f4b9bc00d33732e627dd2592
+  md5: 3df84416a021220d8b5700c613af2dc5
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110187
+  timestamp: 1713535244513
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
+  sha256: 8489af986daebfbcd13d3748ba55431259206e37f184ab42a57e107fecd85e02
+  md5: 3d326f8a2aa2d14d51d8c513426b5def
+  depends:
+  - python >=3.6
+  license: Apache-2.0 AND MIT
+  size: 21765
+  timestamp: 1727940339297
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+  sha256: d3b9a8ed6da7c9f9553c5fd8a4fca9c3e0ab712fa5f497859f82337d67533b73
+  md5: 52d648bd608f5737b123f510bb5514b5
+  depends:
+  - typing_extensions 4.12.2 pyha770c72_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 10097
+  timestamp: 1717802659025
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+  sha256: 0fce54f8ec3e59f5ef3bb7641863be4e1bf1279623e5af3d3fa726e8f7628ddb
+  md5: ebe6952715e1d5eb567eeebf25250fa7
+  depends:
+  - python >=3.8
+  license: PSF-2.0
+  license_family: PSF
+  size: 39888
+  timestamp: 1717802653893
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 9e3758b620397f56fb709f796969de436d63b7117897159619b87938e1f78739
+  md5: eb67e3cace64c66233e2d35949e20f92
+  depends:
+  - python >=3.6.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 13829
+  timestamp: 1622899345711
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+  sha256: 4fde5c3008bf5d2db82f2b50204464314cc3c91c1d953652f7bd01d9e52aefdf
+  md5: 8ac3367aafb1cc0a068483c580af8015
+  license: LicenseRef-Public-Domain
+  size: 122354
+  timestamp: 1728047496079
+- conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+  sha256: 54293cd94da3a6b978b353eb7897555055d925ad0008bc73e85cca19e2587ed0
+  md5: 3b7fc78d7be7b450952aaa916fb78877
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 11162
+  timestamp: 1707507514699
+- conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+  sha256: b76904b53721dc88a46352324c79d2b077c2f74a9f7208ad2c4249892669ae94
+  md5: 0944dc65cb4a9b5b68522c3bb585d41c
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 23999
+  timestamp: 1688655976471
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
+  sha256: b6bb34ce41cd93956ad6eeee275ed52390fb3788d6c75e753172ea7ac60b66e5
+  md5: 6b55867f385dd762ed99ea687af32a69
+  depends:
+  - brotli-python >=1.0.9
+  - h2 >=4,<5
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.8
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 98076
+  timestamp: 1726496531769
+- conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+  sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
+  md5: 68f0738df502a14213624b288c60c9ad
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 32709
+  timestamp: 1704731373922
+- conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
+  sha256: ec71f97c332a7d328ae038990b8090cbfa772f82845b5d2233defd167b7cc5ac
+  md5: eb48b812eb4fbb9ff238a6651fdbbcae
+  depends:
+  - python >=3.5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18378
+  timestamp: 1723294800217
+- conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+  sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
+  md5: daf5160ff9cde3a468556965329085b9
+  depends:
+  - python >=2.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15600
+  timestamp: 1694681458271
+- conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+  sha256: 44a5e3b97feef24cd719f7851cca9af9799dc9c17d3e0298d5856baab2d682f5
+  md5: f372c576b8774922da83cda2b12f9d29
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: APACHE
+  size: 47066
+  timestamp: 1713923494501
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_0.conda
+  sha256: 24f6851a336a50c53d6b50b142c1654872494a62528d57c3ff40240cbd8b13be
+  md5: bdb2f437ce62fd2f1fef9119a37a12d9
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 62998
+  timestamp: 1732339880578
+- conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_7.conda
+  sha256: c5297692ab34aade5e21107abaf623d6f93847662e25f655320038d2bfa1a812
+  md5: c998c13b2f998af57c3b88c7a47979e0
+  depends:
+  - __win
+  - python >=3.6
+  license: LicenseRef-Public-Domain
+  size: 9602
+  timestamp: 1727796413384
+- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.11.0-pyhd8ed1ab_0.conda
+  sha256: 1312af7bc507afdcf24df1599d6aa062ceb252d4c086d5b8e5a022bf8051d980
+  md5: 7358eeedbffd742549d372e0066999d3
+  depends:
+  - numpy >=1.24
+  - packaging >=23.2
+  - pandas >=2.1
+  - python >=3.10
+  constrains:
+  - cartopy >=0.22
+  - h5py >=3.8
+  - h5netcdf >=1.3
+  - sparse >=0.14
+  - dask-core >=2023.11
+  - cftime >=1.6
+  - bottleneck >=1.3
+  - netcdf4 >=1.6.0
+  - iris >=3.7
+  - zarr >=2.16
+  - seaborn-base >=0.13
+  - distributed >=2023.11
+  - matplotlib-base >=3.8
+  - nc-time-axis >=1.4
+  - scipy >=1.11
+  - toolz >=0.12
+  - flox >=0.7
+  - numba >=0.57
+  - pint >=0.22
+  - hdf5 >=1.12
+  license: Apache-2.0
+  license_family: APACHE
+  size: 826310
+  timestamp: 1732532972254
+- conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_0.conda
+  sha256: 2dd2825b5a246461a95a0affaf7e1d459f7cc0ae68ad2dd8aab360c2e5859488
+  md5: 156c91e778c1d4d57b709f8c5333fd06
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 46887
+  timestamp: 1725366457240
+- conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+  sha256: 3d65c081514569ab3642ba7e6c2a6b4615778b596db6b1c82ee30a2d912539e5
+  md5: cf30c2c15b82aacb07f9c09e28ff2275
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36325
+  timestamp: 1681770298596
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+  sha256: 567c04f124525c97a096b65769834b7acb047db24b15a56888a322bf3966c3e1
+  md5: 0c3cc595284c5e8f0f9900a9b228a332
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 21809
+  timestamp: 1732827613585
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.9.1-hf036a51_0.conda
+  sha256: 3032f2f55d6eceb10d53217c2a7f43e1eac83603d91e21ce502e8179e63a75f5
+  md5: 3f17bc32cb7fcb2b4bf3d8d37f656eb8
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2749186
+  timestamp: 1718551450314
+- conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h3336109_5.conda
+  sha256: fa5eb633b320e10fc2138f3d842d8a8ca72815f106acbab49a68ec9783e4d70d
+  md5: 29b46bd410067f668c4cef7fdc78fe25
+  depends:
+  - __osx >=10.13
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 32275
+  timestamp: 1725356815696
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.8.0-hb1b2711_10.conda
+  sha256: 88731bee2b93e8bf5e6c0a692da9a28ac017de16880e72d6a26d4f48377a69ae
+  md5: cabb2823d1eaa138c1fa5ea3b68b9f8a
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 94585
+  timestamp: 1731733610867
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.8.0-h1c3498a_2.conda
+  sha256: fa5cf06e1553198ef41d6aae29bfdf990053db185c492c27b116b2c91137e8c0
+  md5: b900b8d8f2d51c1b84ad1c8a1366c1e3
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 39373
+  timestamp: 1731678700352
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.10.3-h6e16a3a_0.conda
+  sha256: b31603e305c9a7b9f7dca010471ac2012a4c570da483737ec090db4812674fe8
+  md5: d1b72435b57b79fb97ba3ab6564db34c
+  depends:
+  - __osx >=10.13
+  license: Apache-2.0
+  license_family: Apache
+  size: 227079
+  timestamp: 1731567405398
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.3.0-h1c3498a_2.conda
+  sha256: 7cbb8cf79428c342518b2ba456361f89e48ec5ae6a974b2bb3bd8ceb84778c5c
+  md5: af56ad879a463b520989ddd774aa7695
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18023
+  timestamp: 1731678883009
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.5.0-heedde58_7.conda
+  sha256: 5fe9a5cc297d8c54536d7958738db35ae7ef561ad02494692b03c5c2b41f896e
+  md5: b1fa857b39304646770e3f0d70182ed3
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 46953
+  timestamp: 1731714670991
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.9.1-h0c96e2d_2.conda
+  sha256: dab3bc124acb36fd89839337b37fac40fcf47798a66934aa18e280a889646e8e
+  md5: e0596752aa1c4f748c88bce167ae003d
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-compression >=0.3.0,<0.3.1.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 164320
+  timestamp: 1731714564875
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.15.2-h789f5c1_2.conda
+  sha256: 57775bb51fbb45405575548d7452fc7702affac744fd6b80aebc82a28f5e2cba
+  md5: f85932994b14737e4ec6b6dc0bb66036
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 139362
+  timestamp: 1731702578455
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.11.0-h00ab244_8.conda
+  sha256: 5ba0cd019a01ca553784d18f6e4cc60a481eb88410ca689b6adbc1915cb85b89
+  md5: 0c2db3585e4c1865cdf4528720bab440
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 164288
+  timestamp: 1731734750092
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.7.2-h704940e_0.conda
+  sha256: 27874af00427b939bb34fa0e71c84859927912dc7236c3afb492a314acc89abe
+  md5: 227849429ccc4d3f80e647ccf76da6c0
+  depends:
+  - __osx >=10.13
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 97856
+  timestamp: 1732679210985
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.2.1-h1c3498a_1.conda
+  sha256: 59f47c5bea2ddc1c502999e6b2a4ebb81be7ddbf9d2b5818ff1cdc5ad58aa03d
+  md5: 70cd54aaaddb6efa4e5d41fa8f045a44
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 51034
+  timestamp: 1731687124981
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.2.2-h1c3498a_1.conda
+  sha256: a52b53437bd274eeee1bdd1427686b2d3b4bed586a91f0ea5a4c45303805cd56
+  md5: a13de34c0c2224a8755ef3854f85c2a8
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 70940
+  timestamp: 1731687320283
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.29.6-hd535841_0.conda
+  sha256: c6d55992dd56ba348b8e1fae3e98c68d6bb8e6d8b23c80d0fa4e83cc401eefca
+  md5: dbc22cbc851c2de54d74b8570ef90806
+  depends:
+  - __osx >=10.13
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-mqtt >=0.11.0,<0.11.1.0a0
+  - aws-c-s3 >=0.7.2,<0.7.3.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 297934
+  timestamp: 1732769669203
+- conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.449-he3c0133_4.conda
+  sha256: 17ab2acfbb32d82a4ebecf706c28ccb5b61329d5f95d2f9cb11459810b807f70
+  md5: 93a4b306f61300dac213d4433d34974c
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2784788
+  timestamp: 1732812562314
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.14.0-h9a36307_0.conda
+  sha256: c7694fc16b9aebeb6ee5e4f80019b477a181d961a3e4d9b6a66b77777eb754fe
+  md5: 1082a031824b12a2be731d600cfa5ccb
+  depends:
+  - __osx >=10.13
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 303166
+  timestamp: 1728053999891
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.10.0-ha4e2ba9_0.conda
+  sha256: b9899b9698a6c7353fc5078c449105aae58635d217befbc8ca9d5a527198019b
+  md5: ad56b6a4b8931d37a2cf5bc724a46f01
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 175344
+  timestamp: 1728487066445
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.13.0-h3d2f5f1_1.conda
+  sha256: 31984e52450230d04ca98d5232dbe256e5ef6e32b15d46124135c6e64790010d
+  md5: 3df4fb5d6d0e7b3fb28e071aff23787e
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 445040
+  timestamp: 1728578180436
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.8.0-h1ccc5ac_1.conda
+  sha256: 51fb67d2991d105b8f7b97b4810cd63bac4dc421a4a9c83c15a98ca520a42e1e
+  md5: 5b3e79eb148d6e30d6c697788bad9960
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - libxml2 >=2.12.7,<2.14.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 126229
+  timestamp: 1728563580392
+- conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-files-datalake-cpp-12.12.0-h86941f0_1.conda
+  sha256: 12d95251a8793ea2e78f494e69353a930e9ea06bbaaaa4ccb6e5b3e35ee0744f
+  md5: 60452336e7f61f6fdaaff69264ee112e
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 200991
+  timestamp: 1728729588371
+- conda: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.6-h7d75f6d_0.conda
+  sha256: 65e5f5dd3d68ed0d9d35e79d64f8141283cad2b55dcd9a04480ceea0e436aca8
+  md5: 3e5669e51737d04f4806dd3e8c424663
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 47051
+  timestamp: 1719266142315
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h00291cd_2.conda
+  sha256: 624954bc08b3d7885a58c7d547282cfb9a201ce79b748b358f801de53e20f523
+  md5: 2db0c38a7f2321c5bdaf32b181e832c7
+  depends:
+  - __osx >=10.13
+  - brotli-bin 1.1.0 h00291cd_2
+  - libbrotlidec 1.1.0 h00291cd_2
+  - libbrotlienc 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 19450
+  timestamp: 1725267851605
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h00291cd_2.conda
+  sha256: 642a8492491109fd8270c1e2c33b18126712df0cedb94aaa2b1c6b02505a4bfa
+  md5: 049933ecbf552479a12c7917f0a4ce59
+  depends:
+  - __osx >=10.13
+  - libbrotlidec 1.1.0 h00291cd_2
+  - libbrotlienc 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 16643
+  timestamp: 1725267837325
+- conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hd89902b_2.conda
+  sha256: 004cefbd18f581636a8dcb1964fb73478f15d496769226ec896c1d4a0161b7d8
+  md5: d75f06ee06001794aa83a05e885f1520
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 363793
+  timestamp: 1725267947069
+- conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+  sha256: cad153608b81fb24fc8c509357daa9ae4e49dfc535b2cb49b91e23dbd68fc3c5
+  md5: 7ed4301d437b59045be7e051a0308211
+  depends:
+  - __osx >=10.13
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 134188
+  timestamp: 1720974491916
+- conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.3-hf13058a_1.conda
+  sha256: 37c031f91bb4c7ebec248e283c453b24840764fb53b640768780dcd904093f17
+  md5: 7d8083876d71fe1316fc18369ee0dc58
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 184403
+  timestamp: 1732447223773
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.8.30-h8857fd0_0.conda
+  sha256: 593f302d0f44c2c771e1614ee6d56fffdc7d616e6f187669c8b0e34ffce3e1ae
+  md5: b7e5424e7f06547a903d28e4651dbb21
+  license: ISC
+  size: 158665
+  timestamp: 1725019059295
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cartopy-0.24.0-py311haeb46be_0.conda
+  sha256: 5de8435aff6492d4f6aac711be102d121ebdc4bf4ef12602943cd7ed670435ef
+  md5: e9759395bf751096605fbf4a21627650
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - matplotlib-base >=3.6
+  - numpy >=1.19,<3
+  - packaging >=21
+  - pyproj >=3.3.1
+  - pyshp >=2.3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - shapely >=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1518753
+  timestamp: 1728342398327
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.1-py311h137bacd_0.conda
+  sha256: 012ee7b1ed4f9b0490d6e90c72decf148d7575173c7eaf851cd87fd434d2cacc
+  md5: a4b0f531064fa3dd5e3afbb782ea2cd5
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 288762
+  timestamp: 1725560945833
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cftime-1.6.4-py311h0034819_1.conda
+  sha256: 025d33877c4e3558bd3d8c8d11bcd11760d61634d1b1be819203c5b00b770132
+  md5: cda3610885501f18aec020da7f92cf25
+  depends:
+  - __osx >=10.13
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 211019
+  timestamp: 1725400678395
+- conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.1-py311h4e34fa0_0.conda
+  sha256: 373e17f22bca3e13aac2245bb0c8a15c4a54d1ffa4c3278308eeb8d3c9435c0e
+  md5: 6bc3882064e277827934e2c6e5281661
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 255123
+  timestamp: 1731428577146
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.0.0-py311h3336109_1.conda
+  sha256: fd921e8aa9ec5d26b2aebaef91dd4bc1e6d4fd2114f2fc566578122ff95cdb3c
+  md5: d7a579f4ad0ad76e49fb62151ad6fd6f
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 344088
+  timestamp: 1728335202437
+- conda: https://conda.anaconda.org/conda-forge/osx-64/dav1d-1.2.1-h0dc2134_0.conda
+  sha256: ec71a835866b42e946cd2039a5f7a6458851a21890d315476f5e66790ac11c96
+  md5: 9d88733c715300a39f8ca2e936b7808d
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 668439
+  timestamp: 1685696184631
+- conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.9-py311hc356e98_0.conda
+  sha256: 12b1bcdbc226966ad328fbfc48c605e82e7f8e28f58905611a4789cbcc33a41d
+  md5: fb00506b224d15fdc3851a8c9985d4e1
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2499942
+  timestamp: 1732237016874
+- conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.55.0-py311ha3cf9ac_0.conda
+  sha256: 14c8fe864b2b0df5f74e9f5079cbbbd614bf35135746473276fc40e82128f364
+  md5: 57ae8d06b0d70028a20d2e87b3ea8724
+  depends:
+  - __osx >=10.13
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2808934
+  timestamp: 1731643652637
+- conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+  sha256: b292cf5a25f094eeb4b66e37d99a97894aafd04a5683980852a8cbddccdc8e4e
+  md5: 25152fce119320c980e5470e64834b50
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 599300
+  timestamp: 1694616137838
+- conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3ec172f_0.conda
+  sha256: 9d59f1894c3b526e6806e376e979b81d0df23a836415122b86458aef72cda24a
+  md5: 640c34a8084e2a812bcee5b804597fc9
+  depends:
+  - libexpat >=2.5.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - minizip >=4.0.1,<5.0a0
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 54007
+  timestamp: 1694952882265
+- conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.13.0-hac325c4_0.conda
+  sha256: 7e3201780fda37f23623e384557eb66047942db1c2fe0a7453c0caf301ec8bbb
+  md5: 905fbe84dd83254e4e0db610123dd32d
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  license: LGPL-2.1-only
+  size: 1577166
+  timestamp: 1725676182968
+- conda: https://conda.anaconda.org/conda-forge/osx-64/geotiff-1.7.3-h2b6e260_3.conda
+  sha256: 7e58d94340a499c3c62022ba070231f1dcc7c55a98f8f2a7e982d2071dfd421c
+  md5: bbc58a544b03990b3bc8c2139cc6c34f
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 115513
+  timestamp: 1726603109733
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hac325c4_1005.conda
+  sha256: c0bea66f71a6f4baa8d4f0248e17f65033d558d9e882c0af571b38bcca3e4b46
+  md5: a26de8814083a6971f14f9c8c3cb36c2
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84946
+  timestamp: 1726600054963
+- conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h10d778d_0.conda
+  sha256: 2c825df829097536314a195ae5cacaa8695209da6b4400135a65d8e23c008ff8
+  md5: 03e8c9b4d3da5f3d6eabdd020c2d63ac
+  license: MIT
+  license_family: MIT
+  size: 74516
+  timestamp: 1712692686914
+- conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h2790a97_0.conda
+  sha256: dd56547db8625eb5c91bb0a9fbe8bd6f5c7fbf5b6059d46365e94472c46b24f9
+  md5: 06cf91665775b0da395229cd4331b27d
+  depends:
+  - __osx >=10.13
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 117017
+  timestamp: 1718284325443
+- conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
+  sha256: 8c767cc71226e9eb62649c903c68ba73c5f5e7e3696ec0319d1f90586cebec7d
+  md5: 7ce543bf38dbfae0de9af112ee178af2
+  depends:
+  - libcxx >=15.0.7
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 724103
+  timestamp: 1695661907511
+- conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.4-nompi_h1607680_103.conda
+  sha256: bcec9cfa16cd8a3562255d3a97930716cf7c788aad6338baf6bd7bd7c803aa32
+  md5: 23eb36be1235e5986845d9f7d1acedc0
+  depends:
+  - __osx >=10.13
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3733556
+  timestamp: 1730831490461
+- conda: https://conda.anaconda.org/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
+  sha256: 2e64307532f482a0929412976c8450c719d558ba20c0962832132fd0d07ba7a7
+  md5: d68d48a3060eb5abdc1cdc8e2a3a5966
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 11761697
+  timestamp: 1720853679409
+- conda: https://conda.anaconda.org/conda-forge/osx-64/json-c-0.18-hc62ec3d_0.conda
+  sha256: b58f8002318d6b880a98e1b0aa943789b3b0f49334a3bdb9c19b463a0b799cad
+  md5: 2c5a3c42de607dda0cfa0edd541fd279
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 71514
+  timestamp: 1726487153769
+- conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_1.conda
+  sha256: 2499e5ebb3efa4186d6922122224d16bac791a5c0adad5b48b2bcd1e1e2afc8d
+  md5: b6c1710105dad14d47001a339cd14da6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17727
+  timestamp: 1725302991176
+- conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.7-py311hf2f7c97_0.conda
+  sha256: 00b477bff9138ca51edd94f7b31ce9fe2cd13a1dc8768abcf037a22eccf26940
+  md5: 24b0e3e3444be9fabcc8457c409e297f
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 60398
+  timestamp: 1725459431458
+- conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+  sha256: 83b52685a4ce542772f0892a0f05764ac69d57187975579a0835ff255ae3ef9c
+  md5: d4765c524b1d91567886bde656fb514b
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1185323
+  timestamp: 1719463492984
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
+  sha256: 222ebc0a55544b9922f61e75015d02861e65b48f12113af41d48ba0814e14e4e
+  md5: 1442db8f03517834843666c422238c9b
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 224432
+  timestamp: 1701648089496
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+  sha256: e41790fc0f4089726369b3c7f813117bbc14b533e0ed8b94cf75aba252e82497
+  md5: f9d6a4c82889d5ecedec1d90eb673c55
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 290319
+  timestamp: 1657977526749
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240722.0-cxx17_hac325c4_1.conda
+  sha256: b548e80280242ad1d93d8d7fb48a30af7e4124959ba2031c65c9675b98163652
+  md5: 40373920232a6ac0404eee9cf39a9f09
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  constrains:
+  - abseil-cpp =20240722.0
+  - libabseil-static =20240722.0=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1170354
+  timestamp: 1727295597292
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
+  sha256: dae5921339c5d89f4bf58a95fd4e9c76270dbf7f6a94f3c5081b574905fcccf8
+  md5: 66d3c1f6dd4636216b4fca7a748d50eb
+  depends:
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 28602
+  timestamp: 1711021419744
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.7.7-h7988bea_0.conda
+  sha256: 50a5ffeeef306c9f29e2872aa011c28f546a364a8e50350bd05ff0055ad8c599
+  md5: 5af9f38826ccc57545a5c55c54cbfd92
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libiconv >=1.17,<2.0a0
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - lzo >=2.10,<3.0a0
+  - openssl >=3.4.0,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 752482
+  timestamp: 1732614525711
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-18.1.0-h9cd44c2_1_cpu.conda
+  sha256: 3e34440e55e57057e27673d133dabed96bfba3556967468511de07d762e1a192
+  md5: b4ed19dbad676acbf5c4a2d8bc428f6f
+  depends:
+  - __osx >=10.13
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - aws-sdk-cpp >=1.11.449,<1.11.450.0a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-identity-cpp >=1.10.0,<1.10.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-files-datalake-cpp >=12.12.0,<12.12.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=18
+  - libgoogle-cloud >=2.31.0,<2.32.0a0
+  - libgoogle-cloud-storage >=2.31.0,<2.32.0a0
+  - libre2-11 >=2024.7.2
+  - libutf8proc >=2.8.0,<2.9.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.3,<2.0.4.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - parquet-cpp <0.0a0
+  - arrow-cpp <0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 6130675
+  timestamp: 1732863122113
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-18.1.0-h8bbd7dd_1_cpu.conda
+  sha256: 4fcbd1b6bcd7dfb24c9a5e345c4fd2912cbb45fa6c69ec0a3569c1a505952d32
+  md5: d4d4f410990ca5621c1561c84fd76d4c
+  depends:
+  - __osx >=10.13
+  - libarrow 18.1.0 h9cd44c2_1_cpu
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: APACHE
+  size: 522792
+  timestamp: 1732863504703
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-18.1.0-h8bbd7dd_1_cpu.conda
+  sha256: d950ddc6ce6453614a051295eb325d81717799de02741c7fc9b471c69d23b8aa
+  md5: 94160706e163f8e8023c1fc5f07bcb7b
+  depends:
+  - __osx >=10.13
+  - libarrow 18.1.0 h9cd44c2_1_cpu
+  - libarrow-acero 18.1.0 h8bbd7dd_1_cpu
+  - libcxx >=18
+  - libparquet 18.1.0 h19ef8e7_1_cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 515756
+  timestamp: 1732865570745
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-18.1.0-h3d48b7c_1_cpu.conda
+  sha256: c264d3ff28a3be04980ea6cb045c418fa581ade5e62908aba33c3c8a3eda1dae
+  md5: 72cf98a703ac14eed5655741fcf34583
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 18.1.0 h9cd44c2_1_cpu
+  - libarrow-acero 18.1.0 h8bbd7dd_1_cpu
+  - libarrow-dataset 18.1.0 h8bbd7dd_1_cpu
+  - libcxx >=18
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 465404
+  timestamp: 1732866353681
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libavif16-1.1.1-h71406da_2.conda
+  sha256: 8e3d479f13a85ee73c3152704c1d9e0430065f4824bae625f2f35c463c172831
+  md5: 804f440fd71e1a903215710826cf98aa
+  depends:
+  - __osx >=10.13
+  - aom >=3.9.1,<3.10.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - rav1e >=0.6.6,<0.7.0a0
+  - svt-av1 >=2.3.0,<2.3.1.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 108913
+  timestamp: 1730268731759
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-25_osx64_openblas.conda
+  sha256: 1b22b5322a311a775bca637b26317645cf07e35f125cede9278c6c45db6e7105
+  md5: da0a6f87958893e1d2e2bbc7e7a6541f
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - liblapack 3.9.0 25_osx64_openblas
+  - liblapacke 3.9.0 25_osx64_openblas
+  - blas * openblas
+  - libcblas 3.9.0 25_osx64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15952
+  timestamp: 1729643159199
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h00291cd_2.conda
+  sha256: b377056470a9fb4a100aa3c51b3581aab6496ba84d21cd99bcc1d5ef0359b1b6
+  md5: 58f2c4bdd56c46cc7451596e4ae68e0b
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 67267
+  timestamp: 1725267768667
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h00291cd_2.conda
+  sha256: 4d49ea72e2f44d2d7a8be5472e4bd0bc2c6b89c55569de2c43576363a0685c0c
+  md5: 34709a1f5df44e054c4a12ab536c5459
+  depends:
+  - __osx >=10.13
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 29872
+  timestamp: 1725267807289
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h00291cd_2.conda
+  sha256: 477d236d389473413a1ccd2bec1b66b2f1d2d7d1b4a57bb56421b7b611a56cd1
+  md5: 691f0dcb36f1ae67f5c489f20ae987ea
+  depends:
+  - __osx >=10.13
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 296353
+  timestamp: 1725267822076
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-25_osx64_openblas.conda
+  sha256: b04ae297aa5396df3135514866db72845b111c92524570f923625473f11cfbe2
+  md5: ab304b75ea67f850cf7adf9156e3f62f
+  depends:
+  - libblas 3.9.0 25_osx64_openblas
+  constrains:
+  - liblapack 3.9.0 25_osx64_openblas
+  - liblapacke 3.9.0 25_osx64_openblas
+  - blas * openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15842
+  timestamp: 1729643166929
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+  sha256: 3043869ac1ee84554f177695e92f2f3c2c507b260edad38a0bf3981fce1632ff
+  md5: 23d6d5a69918a438355d7cbc4c3d54c9
+  depends:
+  - libcxx >=11.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20128
+  timestamp: 1633683906221
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.10.1-h58e7537_0.conda
+  sha256: 662fe145459ed58dee882e525588d1da4dcc4cbd10cfca0725d1fc3840461798
+  md5: 6c8669d8228a2bbd0283911cc6d6726e
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 402588
+  timestamp: 1726660264675
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.4-hf95d169_0.conda
+  sha256: 48c6d0ab9dd0c66693f79f4a032cd9ebb64fb88329dfa747aeac5299f9b3f33b
+  md5: 5f23923c08151687ff2fc3002b0a7234
+  depends:
+  - __osx >=10.13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 529010
+  timestamp: 1732060320836
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libde265-1.0.15-h7728843_0.conda
+  sha256: a67544ca45a082da0c868fbcd1a0f49fc6f92281aa9aedd20bdce9e7c7e45817
+  md5: a270b0e1a2a3326cc21eee82c42efffc
+  depends:
+  - libcxx >=15
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 331376
+  timestamp: 1703088831061
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.22-h00291cd_0.conda
+  sha256: 681035346974c3315685dc40898e26f65f1c00cbb0b5fd80cc2599e207a34b31
+  md5: a15785ccc62ae2a8febd299424081efb
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 70407
+  timestamp: 1728177128525
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+  sha256: dbd3c3f2eca1d21c52e4c03b21930bbce414c4592f8ce805801575b9e9256095
+  md5: 6016a8a1d0e63cac3de2c352cd40208b
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 105382
+  timestamp: 1597616576726
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+  sha256: 0d238488564a7992942aa165ff994eca540f687753b4f0998b29b4e4d030ff43
+  md5: 899db79329439820b7e8f8de41bca902
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 106663
+  timestamp: 1702146352558
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+  sha256: e0bd9af2a29f8dd74309c0ae4f17a7c2b8c4b89f875ff1d6540c941eefbd07fb
+  md5: e38e467e577bd193a7d5de7c2c540b04
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372661
+  timestamp: 1685726378869
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.4-h240833e_0.conda
+  sha256: d10f43d0c5df6c8cf55259bce0fe14d2377eed625956cddce06f58827d288c59
+  md5: 20307f4049a735a78a29073be1be2626
+  depends:
+  - __osx >=10.13
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 70758
+  timestamp: 1730967204736
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+  sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
+  md5: ccb34fb14960ad8b125962d3d79b31a9
+  license: MIT
+  license_family: MIT
+  size: 51348
+  timestamp: 1636488394370
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.10.0-h9b17b65_2.conda
+  sha256: 4eaebc39b4cbf39f36b23376f99f773174d9c862c31ed20c32cafe2799bc25c7
+  md5: 1ceacde7d91a7b413a0969a3565841df
+  depends:
+  - __osx >=10.13
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - geotiff >=1.7.3,<1.8.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - json-c >=0.18,<0.19.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libarchive >=3.7.7,<3.8.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libdeflate >=1.22,<1.26.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libheif >=1.18.2,<1.19.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.4.0,<4.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - xerces-c >=3.2.5,<3.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - libgdal 3.10.0.*
+  license: MIT
+  license_family: MIT
+  size: 9222770
+  timestamp: 1732732585467
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+  sha256: 4874422e567b68334705c135c17e5acdca1404de8255673ce30ad3510e00be0d
+  md5: 0b6e23a012ee7a9a5f6b244f5a92c1d5
+  depends:
+  - libgfortran5 13.2.0 h2873a65_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110106
+  timestamp: 1707328956438
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+  sha256: da3db4b947e30aec7596a3ef92200d17e774cccbbf7efc47802529a4ca5ca31b
+  md5: e4fb4d23ec2870ff3c40d10afe305aec
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1571379
+  timestamp: 1707328880361
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.31.0-hd00c612_0.conda
+  sha256: 10df0003243d2ef5cca614351fa24efe42164912d358378a947c06167eba6b45
+  md5: 65d85eb999d66f8be20d3735a9ceaa7f
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - openssl >=3.3.2,<4.0a0
+  constrains:
+  - libgoogle-cloud 2.31.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 890808
+  timestamp: 1731121937109
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.31.0-h3f2b517_0.conda
+  sha256: e1f53309fe02143e1342ccb658466be015a1ee4249d306eed4158d75f680d992
+  md5: 3f8c6c99af88f5039869c24aea7024a6
+  depends:
+  - __osx >=10.13
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libcxx >=18
+  - libgoogle-cloud 2.31.0 hd00c612_0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  size: 541478
+  timestamp: 1731123018190
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.67.1-he6e0b18_0.conda
+  sha256: 0884aaa894617fac40c0e0d03a03d2ea6ea486fe9692a0ff854cbe4b080e4c6a
+  md5: 05ea1754e8da5d0e8faf9ec599505834
+  depends:
+  - __osx >=10.13
+  - c-ares >=1.34.2,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libre2-11 >=2024.7.2
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.67.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5335099
+  timestamp: 1730235623016
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libheif-1.18.2-gpl_h57a3ca0_100.conda
+  sha256: e3aaa419f3d7ff2e21710991c1dd4484ed301942dcbcb5052e6835ddfd08abed
+  md5: b08c6fdf99e131e906935a01b63e113c
+  depends:
+  - __osx >=10.13
+  - aom >=3.9.1,<3.10.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - libavif16 >=1.1.1,<2.0a0
+  - libcxx >=16
+  - libde265 >=1.0.15,<1.0.16.0a0
+  - x265 >=3.5,<3.6.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 385347
+  timestamp: 1723121606492
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
+  sha256: 23d4923baeca359423a7347c2ed7aaf48c68603df0cf8b87cc94a10b0d4e9a23
+  md5: 6c3628d047e151efba7cf08c5e54d1ca
+  license: LGPL-2.1-only
+  size: 666538
+  timestamp: 1702682713201
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+  sha256: d9572fd1024adc374aae7c247d0f29fdf4b122f1e3586fe62acc18067f40d02f
+  md5: 72507f8e3961bc968af17435060b6dd6
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 579748
+  timestamp: 1694475265912
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libkml-1.3.0-h9ee1731_1021.conda
+  sha256: dba3732e9a3b204e5af01c5ddba8630f4a337693b1c5375c2981a88b580116bd
+  md5: b098eeacf7e78f09c8771f5088b97bbb
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libexpat >=2.6.2,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - uriparser >=0.9.8,<1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 286877
+  timestamp: 1724667518323
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-25_osx64_openblas.conda
+  sha256: 2a9a6143d103e7e21511cbf439521645bdd506bfabfcac9d6398dd0562c6905c
+  md5: dda0e24b4605ebbd381e48606a107bed
+  depends:
+  - libblas 3.9.0 25_osx64_openblas
+  constrains:
+  - liblapacke 3.9.0 25_osx64_openblas
+  - blas * openblas
+  - libcblas 3.9.0 25_osx64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15852
+  timestamp: 1729643174413
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-hc8e404f_4.conda
+  sha256: 0df3902a300cfe092425f86144d5e00ef67be3cd1cc89fd63084d45262a772ad
+  md5: ed06753e2ba7c66ed0ca7f19578fcb68
+  depends:
+  - libcxx >=15
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 22467131
+  timestamp: 1690563140552
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.2-nompi_h976d569_115.conda
+  sha256: 90fbe85be42ce31b4d41b54fe2d686049435c08ffbc60f8b6a9c39de51102031
+  md5: cece37517cf646a6a710080f8fc1528d
+  depends:
+  - __osx >=10.13
+  - blosc >=1.21.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzip >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zlib
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 724239
+  timestamp: 1728056183743
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.64.0-hc7306c3_0.conda
+  sha256: 0dcfdcf3a445d2d7de4f3b186ab0a794dc872f4ea21622f9b997be72712c027f
+  md5: ab21007194b97beade22ceb7a3f6fee5
+  depends:
+  - __osx >=10.13
+  - c-ares >=1.34.2,<2.0a0
+  - libcxx >=17
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 606663
+  timestamp: 1729572019083
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_hbf64a52_1.conda
+  sha256: cef5856952688ce9303f85f5bc62c99e8c2256b4c679f63afdfb381f222e90c7
+  md5: cd2c572c02a73b88c4d378eb31110e85
+  depends:
+  - __osx >=10.13
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - llvm-openmp >=18.1.8
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6165715
+  timestamp: 1730773348340
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-18.1.0-h19ef8e7_1_cpu.conda
+  sha256: 88814e05529015176eb9004c7ed2019400197d2613dbb2951acdba260e273c9f
+  md5: 34b9145e15470e29dd6c3fb439651df4
+  depends:
+  - __osx >=10.13
+  - libarrow 18.1.0 h9cd44c2_1_cpu
+  - libcxx >=18
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 941094
+  timestamp: 1732865230960
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.44-h4b8f8c9_0.conda
+  sha256: 12b44e58f8832798d7a5c0a7480c95e905dbd6c3558dec09739062411f9e08d1
+  md5: f32ac2c8dd390dbf169f550887ed09d9
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 268073
+  timestamp: 1726234803010
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-5.28.2-h8b30cf6_0.conda
+  sha256: e240c2003e301ede0a0f4af7688adb8456559ffaa4af2eed3fce879c22c80a0e
+  md5: 2302089e5bcb04ce891ce765c963befb
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2428926
+  timestamp: 1728565541606
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2024.07.02-hd530cb8_1.conda
+  sha256: 2fac39fb704ded9584d1a9e7511163830016803f83852a724c2ccef1cc16e17b
+  md5: 1e14c67a5e8a9273a98b83fbc0905b99
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 178580
+  timestamp: 1728779037721
+- conda: https://conda.anaconda.org/conda-forge/osx-64/librttopo-1.1.0-hdfb80b9_17.conda
+  sha256: 683ec76fcc035f3803aedbffdc4e8ab62fbde360bfaa73f3693eeb429c48b029
+  md5: 627b89a9764485ebace5ebe42b6e6ab4
+  depends:
+  - __osx >=10.13
+  - geos >=3.13.0,<3.13.1.0a0
+  - libcxx >=17
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 213348
+  timestamp: 1727265795635
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
+  sha256: d3975cfe60e81072666da8c76b993af018cf2e73fe55acba2b5ba0928efaccf5
+  md5: 6af4b059e26492da6013e79cbcb4d069
+  depends:
+  - __osx >=10.13
+  license: ISC
+  size: 210249
+  timestamp: 1716828641383
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libspatialite-5.1.0-hc43c327_11.conda
+  sha256: 1e392f1f5544ffeb9ce724d06602a8f8062529824954d11b63d4ae01f45a9b49
+  md5: 59c3e269e76ec0e03802ddea2b4e44a0
+  depends:
+  - __osx >=10.13
+  - freexl >=2
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - libcxx >=17
+  - libiconv >=1.17,<2.0a0
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - sqlite
+  - zlib
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 3315985
+  timestamp: 1727341824716
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.47.0-h2f8c449_1.conda
+  sha256: a0f7381c867898a45018b1e5cf1aca68659d292d58252e8f489a4270b010fed8
+  md5: af445c495253a871c3d809e1199bb12b
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 915300
+  timestamp: 1730208101739
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-h3dc7d44_0.conda
+  sha256: ef2a81c9a15080b996a37f0e1712881da90a710b234e63d8539d69892353de90
+  md5: b1caec4561059e43a5d056684c5a2de0
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 283874
+  timestamp: 1732349525684
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.21.0-h75589b3_0.conda
+  sha256: 3f82eddd6de435a408538ac81a7a2c0c155877534761ec9cd7a2906c005cece2
+  md5: 7a472cd20d9ae866aeb6e292b33381d6
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 332651
+  timestamp: 1727206546431
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-h583c2ba_1.conda
+  sha256: 4d58c695dfed6f308d0fd3ff552e0078bb98bc0be2ea0bf55820eb6e86fa5355
+  md5: 4b78bcdcc8780cede8b3d090deba874d
+  depends:
+  - __osx >=10.13
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=17
+  - libdeflate >=1.22,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 395980
+  timestamp: 1728232302162
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-he670073_1.conda
+  sha256: 2b4c4c2a6051433e5c39943b8886a89fc74543f3b5d8286e5a39c7373f5f6cec
+  md5: a7ce895b33370269f03650fa30b7c53d
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 79479
+  timestamp: 1732829757644
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
+  sha256: 7bafd8f4c637778cd0aa390bf3a894feef0e1fcf6ea6000c7ffc25c4c5a65538
+  md5: b2c0047ea73819d992484faacbbe1c24
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 355099
+  timestamp: 1713200298965
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+  sha256: 8896cd5deff6f57d102734f3e672bc17120613647288f9122bec69098e839af7
+  md5: bbeca862892e2898bdb45792a61c4afc
+  depends:
+  - __osx >=10.13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 323770
+  timestamp: 1727278927545
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.5-h495214b_0.conda
+  sha256: 66e1bf40699daf83b39e1281f06c64cf83499de3a9c05d59477fadded6d85b18
+  md5: 8711bc6fb054192dc432741dcd233ac3
+  depends:
+  - __osx >=10.13
+  - icu >=75.1,<76.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 608931
+  timestamp: 1731489767386
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzip-1.11.2-h31df5bb_0.conda
+  sha256: 434a4d1ad23c1c8deb7ec2da94aca05e22bc29dee445b4f7642e1c2f20fc0b0b
+  md5: 3cf12c97a18312c9243a895580bf5be6
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 129542
+  timestamp: 1730442392952
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+  sha256: 8412f96504fc5993a63edf1e211d042a1fd5b1d51dedec755d2058948fcced09
+  md5: 003a54a4e32b02f7355b50a837e699da
+  depends:
+  - __osx >=10.13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 57133
+  timestamp: 1727963183990
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.4-ha54dae1_0.conda
+  sha256: 69fca4a9318d7367ec3e0e7d6e6023a46ae1113dbd67da6d0f93fffa0ef54497
+  md5: 193715d512f648fe0865f6f13b1957e3
+  depends:
+  - __osx >=10.13
+  constrains:
+  - openmp 19.1.4|19.1.4.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 305132
+  timestamp: 1732102427054
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.43.0-py311h25b8078_1.conda
+  sha256: 8f47684beb89f6c03d10a06929365218cdf4454aee52f0bf83a97da4597c429c
+  md5: 19d1706a45751962b116123dcbc578f0
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 379249
+  timestamp: 1725305363038
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-4.3.3-py311h12b7ed1_1.conda
+  sha256: 47515c300a34c47be42b3196f6f5d400fd3f80f0ae25c73eb10ad367cef450cb
+  md5: ab30eba2d9fe565ff640369016e74fe5
+  depends:
+  - __osx >=10.13
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36652
+  timestamp: 1725089602246
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+  sha256: 39aa0c01696e4e202bf5e337413de09dfeec061d89acd5f28e9968b4e93c3f48
+  md5: aa04f7143228308662696ac24023f991
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 156415
+  timestamp: 1674727335352
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lzo-2.10-h10d778d_1001.conda
+  sha256: 4006c57f805ca6aec72ee0eb7166b2fd648dd1bf3721b9de4b909cd374196643
+  md5: bfecd73e4a2dc18ffd5288acf8a212ab
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  size: 146405
+  timestamp: 1713516112292
+- conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.2-py311h8b4e8a7_0.conda
+  sha256: dd3554cee0aedc19a0cd56b52555c26fb0392e97749ceb202ddac7de55e3acf2
+  md5: 87074906abc091b40ac46e7881b7e45d
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24409
+  timestamp: 1729351443593
+- conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.2-py311h8b21175_2.conda
+  sha256: 26efe199ae6d1cadd2cab43d75f05b6b9b9236db731d605c4a079fe3706b7ea7
+  md5: baafa77537c20f3b575f5729de00d487
+  depends:
+  - __osx >=10.13
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8100228
+  timestamp: 1731025375118
+- conda: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.0.7-h62b0c8d_0.conda
+  sha256: e02a6e1a43b0ff44bb9460d46d3f7687a1876d435fb3c2c6cf9e19bab60901f6
+  md5: 9cb19284d7d835918241acf8180099db
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libcxx >=16
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 78595
+  timestamp: 1718483214061
+- conda: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.1.0-py311hf2f7c97_0.conda
+  sha256: b56b1e7d156b88cc0c62734acf56d4ee809723614f659e4203028e7eeac16a78
+  md5: 6804cd42195bf94efd1b892688c96412
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 90868
+  timestamp: 1725975178961
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
+  sha256: b0b3180039ef19502525a2abd5833c00f9624af830fd391f851934d57bffb9af
+  md5: e102bbf8a6ceeaf429deab8032fc8977
+  depends:
+  - __osx >=10.13
+  license: X11 AND BSD-3-Clause
+  size: 822066
+  timestamp: 1724658603042
+- conda: https://conda.anaconda.org/conda-forge/osx-64/netcdf4-1.7.2-nompi_py311h62486fc_100.conda
+  sha256: 9980fad2c45510c6e7311825566fb9b9e5fe526e14b14d7f69d51abde6b55717
+  md5: 2c509bde20d3dd0a0d1f1283aa2d434a
+  depends:
+  - __osx >=10.13
+  - certifi
+  - cftime
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 1055069
+  timestamp: 1729662554732
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.60.0-py311h0e5bd6a_0.conda
+  sha256: 47fbc7925d5ee5ba9d841e542752288fc7059f44c0b95c34e11c609f4754e517
+  md5: 8bd1ff28924ea52b539528d85f70a1ac
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - llvm-openmp >=16.0.6
+  - llvm-openmp >=18.1.8
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libopenblas !=0.3.6
+  - cuda-python >=11.6
+  - scipy >=1.0
+  - tbb >=2021.6.0
+  - cudatoolkit >=11.2
+  - cuda-version >=11.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5773011
+  timestamp: 1718888442395
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.0.2-py311h14ed71f_1.conda
+  sha256: 11b26503fbcc7215ba4ccb9d4f67540f9783fe1bd01d18c54f0cf8ab03ee7295
+  md5: 3162c97b53e0e3deeb4773e9b21cbde7
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8027046
+  timestamp: 1732314989218
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
+  sha256: dc9c405119b9b54f8ca5984da27ba498bd848ab4f0f580da6f293009ca5adc13
+  md5: 05a14cc9d725dd74995927968d6547e3
+  depends:
+  - libcxx >=16
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 331273
+  timestamp: 1709159538792
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hd471939_0.conda
+  sha256: ba7e068ed469d6625e32ae60e6ad893e655b6695280dadf7e065ed0b6f3b885c
+  md5: ec99d2ce0b3033a75cbad01bbc7c5b71
+  depends:
+  - __osx >=10.13
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2590683
+  timestamp: 1731378034404
+- conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.3-h5cd248e_0.conda
+  sha256: 5254a9e811e25595ffa029f131557adf0657efbb81d659afb5561af3ef4bbffa
+  md5: fe9651fd3413eb332537f7729cebc8e1
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 467056
+  timestamp: 1731665334947
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.3-py311haeb46be_1.conda
+  sha256: ad35c52521f0946caf06e19fd3dfad55f7b30e46648f96214f59d8ca2dac95ad
+  md5: ca32a9963a1b5c636b5131831ded81f3
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14864168
+  timestamp: 1726879042435
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.44-h7634a1b_2.conda
+  sha256: 336057fce69d45e1059f138beb38d60eb87ba858c3ad729ed49d9ecafd23669f
+  md5: 58cde0663f487778bcd7a0c8daf50293
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 854306
+  timestamp: 1723488807216
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.0.0-py311h1f68098_0.conda
+  sha256: 3826fe546e711787ce5b42e2f9176589846631945a528176da0fb61e751d3749
+  md5: ab73babea5e9a94d4f0f3c8fead83459
+  depends:
+  - __osx >=10.13
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 42126861
+  timestamp: 1729065932260
+- conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.5.0-h70d2bda_0.conda
+  sha256: 9530508868971b9866486c6cb370a18ca97d6960ccb010f9ca0eaeb539b16910
+  md5: bc2d54e486a633b5f6c3f18c1fe734fb
+  depends:
+  - __osx >=10.13
+  - libcurl >=8.10.0,<9.0a0
+  - libcxx >=17
+  - libsqlite >=3.46.1,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2790379
+  timestamp: 1726489327240
+- conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.0-py311h1314207_0.conda
+  sha256: 340d19b16a2f5b663b4f000188467831b107dcaa5b15522e172d6a27820d3b01
+  md5: 446e328d89429c077ccd74d7e9d8853e
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 512211
+  timestamp: 1729847190327
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
+  sha256: 05944ca3445f31614f8c674c560bca02ff05cb51637a96f665cb2bbe496099e5
+  md5: 8bcf980d2c6b17094961198284b8e862
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 8364
+  timestamp: 1726802331537
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-18.1.0-py311h6eed73b_0.conda
+  sha256: a0a27fe54d19a42a900ed00a72a68758a14e742c8e22808be1240c24622a07fb
+  md5: c1de8a6883cbb9135fbbf1e1bdbebbdc
+  depends:
+  - libarrow-acero 18.1.0.*
+  - libarrow-dataset 18.1.0.*
+  - libarrow-substrait 18.1.0.*
+  - libparquet 18.1.0.*
+  - pyarrow-core 18.1.0 *_0_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25275
+  timestamp: 1732611267588
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-18.1.0-py311he02522f_0_cpu.conda
+  sha256: 960a5cb329b82118daab50be01faa541c3542e45d30e8eeff14d93619fc0af6b
+  md5: 995e6211e8d94b51466b7d0c8ccd475b
+  depends:
+  - __osx >=10.13
+  - libarrow 18.1.0.* *cpu
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - numpy >=1.21,<3
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4068983
+  timestamp: 1732611224743
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.3.1-py311hd6939f8_1.conda
+  sha256: 48de2a78d71e6c1a2681c1fbcf1f1503a29c58cc42cfc0fafa5c1b59a10eda94
+  md5: c8e529b8f6a408dfc6a2bc0c607e2338
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 491149
+  timestamp: 1725739585987
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.3.1-py311hd6939f8_1.conda
+  sha256: bf6179d71edb920cedf7ce4395f4447d5ae96a9deb5a44dcc1a6abffea0de4aa
+  md5: f3f565f99289de1cd140bdbea51b94eb
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 10.3.1.*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 381020
+  timestamp: 1725875173947
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.7.0-py311h50e4d0a_0.conda
+  sha256: a269c953b5c7d789e330db13cb693d6aec6f176cc249cd36607850e826f3deae
+  md5: 53d4a946f02d1b811035310cf575990c
+  depends:
+  - __osx >=10.13
+  - certifi
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 498197
+  timestamp: 1727795466468
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.10-ha513fb2_3_cpython.conda
+  sha256: 670ba83b2aab2204f3254ed47ac0e4b8cad82478e5821727aeab69a2912aa1a0
+  md5: 1a88c32ab9e997380ba1f9306624f805
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 15442415
+  timestamp: 1729043110107
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
+  sha256: 9b092850a268aca99600b724bae849f51209ecd5628e609b4699debc59ff1945
+  md5: e6d62858c06df0be0e6255c753d74787
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6303
+  timestamp: 1723823062672
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311h3336109_1.conda
+  sha256: d8f4513c53a7c0be9f1cdb9d1af31ac85cf8a6f0e4194715e36e915c03104662
+  md5: b0132bec7165a53403dcc393ff761a9e
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 193941
+  timestamp: 1725456465818
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.2.0-py311h4d3da15_3.conda
+  sha256: 6aa664170031e36302616978404175c6ada3bd4a14c71bac826fa6a7ec15f815
+  md5: 48a614f384285254a3224d086dc84ce3
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 366412
+  timestamp: 1728642446264
+- conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+  sha256: 79d804fa6af9c750e8b09482559814ae18cd8df549ecb80a4873537a5a31e06e
+  md5: dd1ea9ff27c93db7c01a7b7656bd4ad4
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: LicenseRef-Qhull
+  size: 528122
+  timestamp: 1720814002588
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rasterio-1.4.2-py311h7ab2778_1.conda
+  sha256: c2d6a98cd0bd690a79ef447a8aeb0a6a765d5cc1ee39483078e4be9897cec39d
+  md5: 0c37f9875ec280ac84b7ace5e450a882
+  depends:
+  - __osx >=10.13
+  - affine
+  - attrs
+  - certifi
+  - click >=4
+  - click-plugins
+  - cligj >=0.5
+  - libcxx >=18
+  - libgdal-core >=3.10.0,<3.11.0a0
+  - numpy >=1.21,<3
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7599422
+  timestamp: 1731967297400
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rav1e-0.6.6-h7205ca4_2.conda
+  sha256: 046ac50530590cd2a5d9bcb1e581bdd168e06049230ad3afd8cce2fa71b429d9
+  md5: ab03527926f8ce85f84a91fd35520ef2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1767853
+  timestamp: 1694329738983
+- conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2024.07.02-h2fb0a26_1.conda
+  sha256: 49ec4ed6249efe9cda173745e036137f8de1f0b22edf9b0ca4f9c6409b2b68f9
+  md5: aa8ea927cdbdf690efeae3e575716131
+  depends:
+  - libre2-11 2024.07.02 hd530cb8_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26864
+  timestamp: 1728779054104
+- conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+  sha256: 41e7d30a097d9b060037f0c6a2b1d4c4ae7e942c06c943d23f9d481548478568
+  md5: f17f77f2acf4d344734bda76829ce14e
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 255870
+  timestamp: 1679532707590
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.21.0-py311h3b9c2be_0.conda
+  sha256: 234429609e71e568d1dcd7113e9a3c53c231079166ec89364b7c1158ea989776
+  md5: 230b5b87921887039af74b783d8ff095
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 301356
+  timestamp: 1730922990073
+- conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.1-py311hed734c1_1.conda
+  sha256: 2515954fe9f8202c35e9b2df6d65650f8ffcfa7dc99ed068b25968e8af5f1b23
+  md5: 22812381ffcab544161a257666f1c203
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16391177
+  timestamp: 1729481689967
+- conda: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.6-py311h9a2ae1f_2.conda
+  sha256: 6bc887207108f5757da724c139c2c9026094a136b0f0004f9624905b4fb69f65
+  md5: b43481859216598390d3b6610ab42e40
+  depends:
+  - __osx >=10.13
+  - geos >=3.13.0,<3.13.1.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 548018
+  timestamp: 1727273592519
+- conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-he1e6707_0.conda
+  sha256: a979319cd4916f0e7450aa92bb3cf4c2518afa80be50de99f31d075e693a6dd9
+  md5: ddceef5df973c8ff7d6b32353c0cb358
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 37036
+  timestamp: 1720003862906
+- conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.47.0-h6285a30_1.conda
+  sha256: 34eaf24c2d0b034374d7a85026650fe28e17321fa471e5c5f654b48c5cbd3c2a
+  md5: c1d1f4d014063068fd6c402cf741e317
+  depends:
+  - __osx >=10.13
+  - libsqlite 3.47.0 h2f8c449_1
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 929527
+  timestamp: 1730208118175
+- conda: https://conda.anaconda.org/conda-forge/osx-64/svt-av1-2.3.0-h97d8b74_0.conda
+  sha256: 8cd3878eb1d31ecf21fe982e6d2ca557787100aed2f0c7fd44d01d504e704e30
+  md5: c54053b3d1752308a38a9a8c48ce10da
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2413474
+  timestamp: 1730246540736
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+  sha256: 30412b2e9de4ff82d8c2a7e5d06a15f4f4fef1809a72138b6ccb53a33b26faf5
+  md5: bf830ba5afc507c6232d4ef0fb1a882d
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3270220
+  timestamp: 1699202389792
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.2-py311h4d7f069_0.conda
+  sha256: 5273ba307489570df61d82a6b3365b2a27862765099cf4ef3830569fa4a30f27
+  md5: 073c42a2b6b7e4219325b1f5983c7579
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 858750
+  timestamp: 1732616082798
+- conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-15.1.0-py311h1314207_1.conda
+  sha256: c0be0b59fa67c3f9915d3dcd77d972656b9966b4516b3c044efe350860f7e054
+  md5: 574fd9b8168c1b109003c3c431c0bb7e
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 363667
+  timestamp: 1729704694220
+- conda: https://conda.anaconda.org/conda-forge/osx-64/uriparser-0.9.8-h6aefe2f_0.conda
+  sha256: fec8e52955fc314580a93dee665349bf430ce6df19019cea3fae7ec60f732bdd
+  md5: 649890a63cc818b24fbbf0572db221a5
+  depends:
+  - __osx >=10.9
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43396
+  timestamp: 1715010079800
+- conda: https://conda.anaconda.org/conda-forge/osx-64/x265-3.5-hbb4e6a2_3.tar.bz2
+  sha256: 6b6a57710192764d0538f72ea1ccecf2c6174a092e0bc76d790f8ca36bbe90e4
+  md5: a3bf3e95b7795871a6734a784400fcea
+  depends:
+  - libcxx >=12.0.1
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 3433205
+  timestamp: 1646610148268
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xerces-c-3.2.5-h197e74d_2.conda
+  sha256: 6218762b3ecff8e365f2880bb6a762b195e350159510d3f2dba58fa53f90a1bf
+  md5: 559e2c3fb2fe4bfc985e8486bad8ecaa
+  depends:
+  - __osx >=10.13
+  - icu >=75.1,<76.0a0
+  - libcxx >=17
+  license: Apache-2.0
+  license_family: Apache
+  size: 1352475
+  timestamp: 1727734320281
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h00291cd_1.conda
+  sha256: 96177823ec38336b0f4b7e7c2413da61f8d008d800cc4a5b8ad21f9128fb7de0
+  md5: c6cc91149a08402bbb313c5dc0142567
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 13176
+  timestamp: 1727034772877
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
+  sha256: bb4d1ef9cafef535494adf9296130b6193b3a44375883185b5167de03eb1ac7f
+  md5: 9f438e1b6f4e73fd9e6d78bfe7c36743
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 18465
+  timestamp: 1727794980957
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+  sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
+  md5: a72f9d4ea13d55d745ff1ed594747f10
+  license: LGPL-2.1 and GPL-2.0
+  size: 238119
+  timestamp: 1660346964847
+- conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+  sha256: 5301417e2c8dea45b401ffee8df3957d2447d4ce80c83c5ff151fc6bfe1c4148
+  md5: d7e08fcf8259d742156188e8762b4d20
+  license: MIT
+  license_family: MIT
+  size: 84237
+  timestamp: 1641347062780
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h7130eaa_7.conda
+  sha256: b932dce8c9de9a8ffbf0db0365d29677636e599f7763ca51e554c43a0c5f8389
+  md5: 6a0a76cd2b3d575e1b7aaeb283b9c3ed
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.3,<1.22.0a0
+  - libcxx >=18
+  - libsodium >=1.0.20,<1.0.21.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 292112
+  timestamp: 1731585246902
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-hd23fc13_2.conda
+  sha256: 219edbdfe7f073564375819732cbf7cc0d7c7c18d3f546a09c2dfaf26e4d69f3
+  md5: c989e0295dcbdc08106fe5d9e935f0b9
+  depends:
+  - __osx >=10.13
+  - libzlib 1.3.1 hd23fc13_2
+  license: Zlib
+  license_family: Other
+  size: 88544
+  timestamp: 1727963189976
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py311hdf6fcd6_1.conda
+  sha256: d9bf977b620750049eb60fffca299a701342a2df59bcc2586a79b2f7c5783fa1
+  md5: 4fc42d6f85a21b09ee6477f456554df3
+  depends:
+  - __osx >=10.13
+  - cffi >=1.11
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411350
+  timestamp: 1725305723486
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
+  sha256: efa04a98cb149643fa54c4dad5a0179e36a5fbc88427ea0eec88ceed87fd0f96
+  md5: 4cb2cd56f039b129bb0e491c1164167e
+  depends:
+  - __osx >=10.9
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 498900
+  timestamp: 1714723303098
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.9.1-h7bae524_0.conda
+  sha256: ec238f18ce8140485645252351a0eca9ef4f7a1c568a420f240a585229bc12ef
+  md5: 7adba36492a1bb22d98ffffe4f6fc6de
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2235747
+  timestamp: 1718551382432
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311h460d6c5_5.conda
+  sha256: 6eabd1bcefc235b7943688d865519577d7668a2f4dc3a24ee34d81eb4bfe77d1
+  md5: 1e8260965552c6ec86453b7d15a598de
+  depends:
+  - __osx >=11.0
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 33008
+  timestamp: 1725356833036
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.8.0-h9b725a8_10.conda
+  sha256: 63cb8c25e0a26be4261d4271de525e7e33aefe9d9b001b8abfa5c9ac69c3dab3
+  md5: 17c90d9eb8c6842fd739dc5445ce9962
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 92355
+  timestamp: 1731733738919
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.8.0-h5d7ee29_2.conda
+  sha256: 2a8c09b33400cf2b7d658e63fd5a6f9b6e9626458f6213b904592fc15220bc92
+  md5: 92734dad83d22314205ba73b679710d2
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 39966
+  timestamp: 1731678721786
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.10.3-h5505292_0.conda
+  sha256: bb2c1038726d31ffd2d35a5764f80bcd670b6a1c753aadfd261aecb9f88db6d8
+  md5: 4150339e3b08db33fe4c436340b1d7f6
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 221524
+  timestamp: 1731567512057
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.0-h5d7ee29_2.conda
+  sha256: a52ea62bf08aed3af079e16d1738f3d2a7fcdd1d260289ae27ae96298e15d12a
+  md5: 15566c36b0cf5f314e3bee7f7cc796b5
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18204
+  timestamp: 1731678916439
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.5.0-h13ead76_7.conda
+  sha256: 386965fab5f0bed4a6109cdba32579f16bee1b0f76ce1db840ce6f7070188f9f
+  md5: 55a901b6d4fb9ce1bc8328925b229f0b
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 47528
+  timestamp: 1731714690911
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.9.1-hf483d09_2.conda
+  sha256: fca9ed0f0895bab9bf737c8d8a3314556cb893d45c40f0656f21a93502db3089
+  md5: d880c40b8fc7d07374c036f93f1359d2
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-compression >=0.3.0,<0.3.1.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 153315
+  timestamp: 1731714621306
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.15.2-h39f8ad8_2.conda
+  sha256: b14e32f024f6be1610dccfdb6371e101cba204d24f37c2a63d9b6380ac74ac17
+  md5: 3b49f1dd8f20bead8b222828cfdad585
+  depends:
+  - __osx >=11.0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 137610
+  timestamp: 1731702839896
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.11.0-h68a0d7e_8.conda
+  sha256: 837c24c105624e16ace94b4b566ffe45231ff275339c523571ebd45946926156
+  md5: 9e3ac70d27e7591b1310a690768cfe27
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 134573
+  timestamp: 1731734281038
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.7.2-h840aca7_0.conda
+  sha256: 30e4bed9d008fb79f5e84ecbea0f21030ad5d60cb5c55a962df90721aa98fc42
+  md5: 63100ff62fdff4a6afcea38841036027
+  depends:
+  - __osx >=11.0
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 97042
+  timestamp: 1732679268030
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.1-h5d7ee29_1.conda
+  sha256: ed3b272b9a345142e62f0cf9ab2a9fa909c92e09691f6a06e98ff500a1f8a303
+  md5: 0f1e5bc57d4567c9d9bec8d8982828ed
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 50276
+  timestamp: 1731687215375
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.2-h5d7ee29_1.conda
+  sha256: eb7ebe309b33a04329b3e51a7f10bb407815389dc37cc047f7d41f9c91f0d1b0
+  md5: db1ed95988a8fe6c1ce0d94abdfc8e72
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 70184
+  timestamp: 1731687342560
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.29.6-h8bcca62_0.conda
+  sha256: b6d2ff238a712137afd9b46842235b32a04cac580734873bf86876da6e71dd03
+  md5: 8e49f5e86a3e39699b24035fa6d1ad40
+  depends:
+  - __osx >=11.0
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-mqtt >=0.11.0,<0.11.1.0a0
+  - aws-c-s3 >=0.7.2,<0.7.3.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: Apache
+  size: 236490
+  timestamp: 1732769764315
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.449-h3b64406_4.conda
+  sha256: 10ce9c203d31229432421a841d8d135d3e942637571aae4bb2d3c7d5242e7f05
+  md5: f9e46a4bb5a04cbca08355f166ce87c8
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2722689
+  timestamp: 1732812825640
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.14.0-hd50102c_0.conda
+  sha256: f5b91329ed59ffc0be8747784c6e4cc7e56250c54032883a83bc11808ef6a87e
+  md5: f093a11dcf3cdcca010b20a818fcc6dc
+  depends:
+  - __osx >=11.0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 294299
+  timestamp: 1728054014060
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.10.0-hc602bab_0.conda
+  sha256: bde446b916fff5150606f8ed3e6058ffc55a3aa72381e46f1ab346590b1ae40a
+  md5: d7b71593a937459f2d4b67e1a4727dc2
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 166907
+  timestamp: 1728486882502
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.13.0-h7585a09_1.conda
+  sha256: 08d52d130addc0fb55d5ba10d9fa483e39be25d69bac7f4c676c2c3069207590
+  md5: 704238ef05d46144dae2e6b5853df8bc
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 438636
+  timestamp: 1728578216193
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.8.0-h9ca1f76_1.conda
+  sha256: 77ab04e8fe5636a2de9c718f72a43645f7502cd208868c8a91ffba385547d585
+  md5: 7a187cd7b1445afc80253bb186a607cc
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - libcxx >=17
+  - libxml2 >=2.12.7,<2.14.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 121278
+  timestamp: 1728563418777
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.12.0-hcdd55da_1.conda
+  sha256: f48523f8aa0b5b80f45a92f0556b388dd96f44ac2dc2f44a01d08c1822eec97d
+  md5: c49fbc5233fcbaa86391162ff1adef38
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
+  - libcxx >=17
+  license: MIT
+  license_family: MIT
+  size: 196032
+  timestamp: 1728729672889
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h5499902_0.conda
+  sha256: 5a1e635a371449a750b776cab64ad83f5218b58b3f137ebd33ad3ec17f1ce92e
+  md5: e94ca7aec8544f700d45b24aff2dd4d7
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33201
+  timestamp: 1719266149627
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hd74edd7_2.conda
+  sha256: a086f36ff68d6e30da625e910547f6211385246fb2474b144ac8c47c32254576
+  md5: 215e3dc8f2f837906d066e7f01aa77c0
+  depends:
+  - __osx >=11.0
+  - brotli-bin 1.1.0 hd74edd7_2
+  - libbrotlidec 1.1.0 hd74edd7_2
+  - libbrotlienc 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 19588
+  timestamp: 1725268044856
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hd74edd7_2.conda
+  sha256: 28f1af63b49fddf58084fb94e5512ad46e9c453eb4be1d97449c67059e5b0680
+  md5: b8512db2145dc3ae8d86cdc21a8d421e
+  depends:
+  - __osx >=11.0
+  - libbrotlidec 1.1.0 hd74edd7_2
+  - libbrotlienc 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 16772
+  timestamp: 1725268026061
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311h3f08180_2.conda
+  sha256: f507d65e740777a629ceacb062c768829ab76fde01446b191699a734521ecaad
+  md5: c8793a23206344faa25f4e0b5d0e7908
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 339584
+  timestamp: 1725268241628
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+  sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
+  md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
+  depends:
+  - __osx >=11.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 122909
+  timestamp: 1720974522888
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.3-h5505292_1.conda
+  sha256: 6dfa83cbd9acc8671d439fe9c745a5716faf6cbadf2f1e18c841bcf86cbba5f2
+  md5: fb72102e8a8f9bcd38e40af09ff41c42
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 179318
+  timestamp: 1732447193278
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
+  sha256: 2db1733f4b644575dbbdd7994a8f338e6ef937f5ebdb74acd557e9dda0211709
+  md5: 40dec13fd8348dbe303e57be74bd3d35
+  license: ISC
+  size: 158482
+  timestamp: 1725019034582
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cartopy-0.24.0-py311h9cb3ce9_0.conda
+  sha256: f48faa9de55ee315c9d3f6ecad6949e1f0e18ebafa9e86f5f723dde6aa0915aa
+  md5: 27811d1c187c3f00ba249abcbee8f1bd
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - matplotlib-base >=3.6
+  - numpy >=1.19,<3
+  - packaging >=21
+  - pyproj >=3.3.1
+  - pyshp >=2.3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - shapely >=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1515694
+  timestamp: 1728342455991
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py311h3a79f62_0.conda
+  sha256: 253605b305cc4548b8f97eb7c2e146697e0c7672b099c4862ec5ca7e8e995307
+  md5: a42272c5dbb6ffbc1a5af70f24c7b448
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 288211
+  timestamp: 1725560745212
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.4-py311h0f07fe1_1.conda
+  sha256: a77f11a4e202e7e856b368e7bae7a463d4193d5263927ca8c6e02eee6e5a0703
+  md5: f239945e88a60c79f705944b22ab56d3
+  depends:
+  - __osx >=11.0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 206517
+  timestamp: 1725400747908
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.1-py311h210dab8_0.conda
+  sha256: 8e755206b38a6e14861c79a74b51af76124bdf5c266dd6a584305e03d37c2e0c
+  md5: 7f9e9df2d62cf69aed450f6957a23e61
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 247202
+  timestamp: 1731428753912
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.0.0-py311h460d6c5_1.conda
+  sha256: cff9cd6a8652a73d9e1d73c51bfd1bac6b526e705885b1ec8f0c159bd34046d2
+  md5: 72740cbbba07d1fb0f37448e1e1c7ef9
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 341441
+  timestamp: 1728335223644
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
+  sha256: 93e077b880a85baec8227e8c72199220c7f87849ad32d02c14fb3807368260b8
+  md5: 5a74cdee497e6b65173e10d94582fae6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 316394
+  timestamp: 1685695959391
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.9-py311h155a34a_0.conda
+  sha256: 880c3de00402d6c5d61d3f64af9ecad8022f272225e3ae62fa8e9c4885b7f0e5
+  md5: d619288803d5935f771f64a7924a6aad
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2531409
+  timestamp: 1732237062084
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.55.0-py311h4921393_0.conda
+  sha256: d4a66eafaaa94618f9218881d24fd60f4b93c2d629cab14ddb98216e1cf83fda
+  md5: 9dbec219c6180471bada3b40199f2239
+  depends:
+  - __osx >=11.0
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2781319
+  timestamp: 1731643650622
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+  sha256: 791673127e037a2dc0eebe122dc4f904cb3f6e635bb888f42cbe1a76b48748d9
+  md5: e6085e516a3e304ce41a8ee08b9b89ad
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  size: 596430
+  timestamp: 1694616332835
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-hfbad9fb_0.conda
+  sha256: 9cb4957d1431bc57bc95b1e99a50669d91ac3441226a78f69fa030d52f2bda77
+  md5: 40722e5f48287567cda6fb2ec1f7891b
+  depends:
+  - libexpat >=2.5.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - minizip >=4.0.1,<5.0a0
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 55132
+  timestamp: 1694952828719
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.13.0-hf9b8971_0.conda
+  sha256: 273381020b72bde1597d4e07e855ed50ffac083512e61ccbdd99d93f03c6cbf2
+  md5: 45b2e9adb9663644b1eefa5300b9eef3
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: LGPL-2.1-only
+  size: 1481430
+  timestamp: 1725676193541
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/geotiff-1.7.3-h82bf549_3.conda
+  sha256: 7ce4d6dced3cd313ea170db69d6929b88d77ebd40715f9f38c3bcba3633d6c65
+  md5: cb84033d7c167a16c4577272b4493bc5
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 113739
+  timestamp: 1726603324989
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
+  sha256: fd56ed8a1dab72ab90d8a8929b6f916a6d9220ca297ff077f8f04c5ed3408e20
+  md5: 57a511a5905caa37540eb914dfcbf1fb
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 82090
+  timestamp: 1726600145480
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-h93a5062_0.conda
+  sha256: 843b3f364ff844137e37d5c0a181f11f6d51adcedd216f019d074e5aa5d7e09c
+  md5: 95fa1486c77505330c20f7202492b913
+  license: MIT
+  license_family: MIT
+  size: 71613
+  timestamp: 1712692611426
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
+  sha256: 9fc77de416953aa959039db72bc41bfa4600ae3ff84acad04a7d0c1ab9552602
+  md5: fef68d0a95aa5b84b5c1a4f6f3bf40e1
+  depends:
+  - __osx >=11.0
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 112215
+  timestamp: 1718284365403
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
+  sha256: c3b01e3c3fe4ca1c4d28c287eaa5168a4f2fd3ffd76690082ac919244c22fa90
+  md5: ff5d749fd711dc7759e127db38005924
+  depends:
+  - libcxx >=15.0.7
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 762257
+  timestamp: 1695661864625
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.4-nompi_ha698983_103.conda
+  sha256: 01c2792588db2ac16e758a2898e4ec40955a2abcbc30f0212b7a669e1d094cae
+  md5: b779eb51bbfdf8d1b4539199b76839b4
+  depends:
+  - __osx >=11.0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3495866
+  timestamp: 1730831045992
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+  sha256: 9ba12c93406f3df5ab0a43db8a4b4ef67a5871dfd401010fbe29b218b2cbe620
+  md5: 5eb22c1d7b3fc4abb50d92d621583137
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 11857802
+  timestamp: 1720853997952
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/json-c-0.18-he4178ee_0.conda
+  sha256: 73179a1cd0b45c09d4f631cb359d9e755e6e573c5d908df42006728e0bf8297c
+  md5: 94f14ef6157687c30feb44e1abecd577
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 73715
+  timestamp: 1726487214495
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py311h267d04e_1.conda
+  sha256: 736304347653ed421b13c56ba6f4f87c1d78d24cd3fa74db0db6fb70c814fa65
+  md5: 5bce88ac1bef7d47c62cb574b25891ae
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18253
+  timestamp: 1725303181400
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.7-py311h2c37856_0.conda
+  sha256: 8ffc46f6e99c95c48426cf34c033d16cde3bcf100cd74d1d74a33943a85a6ec8
+  md5: ee572d19da1346db8e78cb8e7d5d2330
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59357
+  timestamp: 1725459504453
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+  sha256: 4442f957c3c77d69d9da3521268cad5d54c9033f1a73f99cde0a3658937b159b
+  md5: c6dc8a0fdec13a0565936655c33069a1
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1155530
+  timestamp: 1719463474401
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
+  sha256: 151e0c84feb7e0747fabcc85006b8973b22f5abbc3af76a9add0b0ef0320ebe4
+  md5: 66f6c134e76fe13cce8a9ea5814b5dd5
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 211959
+  timestamp: 1701647962657
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+  sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
+  md5: de462d5aacda3b30721b512c5da4e742
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 215721
+  timestamp: 1657977558796
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_hf9b8971_1.conda
+  sha256: 90bf08a75506dfcf28a70977da8ab050bcf594cd02abd3a9d84a22c9e8161724
+  md5: 706da5e791c569a7b9814877098a6a0a
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  constrains:
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1179072
+  timestamp: 1727295571173
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
+  sha256: 896189b7b48a194c46a3556ea04943ef81cbe0498521231f8eb25816a68bc8ed
+  md5: 6f0b8e56d2e7bae12a18fc5b2cd9f310
+  depends:
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 28451
+  timestamp: 1711021498493
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.7.7-h7c07d2a_0.conda
+  sha256: 10d5c755761c6823d20c6ddbd42292ef91f34e271b6ba3e78d0c5fa81c22b3ed
+  md5: 49b28e291693b70cf8a7e70f290834d8
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libiconv >=1.17,<2.0a0
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - lzo >=2.10,<3.0a0
+  - openssl >=3.4.0,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 777074
+  timestamp: 1732614642044
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-18.1.0-hacc6a60_1_cpu.conda
+  sha256: c06d055a3b1fdc1a670481345a11ab7d2225074d0a98e448419e5cd828c070f4
+  md5: 4957a938ab42181d6c9748920f13a027
+  depends:
+  - __osx >=11.0
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - aws-sdk-cpp >=1.11.449,<1.11.450.0a0
+  - azure-core-cpp >=1.14.0,<1.14.1.0a0
+  - azure-identity-cpp >=1.10.0,<1.10.1.0a0
+  - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
+  - azure-storage-files-datalake-cpp >=12.12.0,<12.12.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=18
+  - libgoogle-cloud >=2.31.0,<2.32.0a0
+  - libgoogle-cloud-storage >=2.31.0,<2.32.0a0
+  - libre2-11 >=2024.7.2
+  - libutf8proc >=2.8.0,<2.9.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.3,<2.0.4.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - arrow-cpp <0.0a0
+  - parquet-cpp <0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5470388
+  timestamp: 1732863147130
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-18.1.0-h1dc2043_1_cpu.conda
+  sha256: 54709d2e29fe13167bb2b5e7755382723684197b32188ea18c9c48f5a911af46
+  md5: 8a7dfd6c38ecc940e8edbf341819b2fe
+  depends:
+  - __osx >=11.0
+  - libarrow 18.1.0 hacc6a60_1_cpu
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: APACHE
+  size: 484158
+  timestamp: 1732863376127
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-18.1.0-h1dc2043_1_cpu.conda
+  sha256: 7b5b462c709c2269af5dfec695028c6efe67dc7eb90b485e0e71fae6ecce6f6d
+  md5: 27c23281c2e2b56fec1b6d7dd1df439a
+  depends:
+  - __osx >=11.0
+  - libarrow 18.1.0 hacc6a60_1_cpu
+  - libarrow-acero 18.1.0 h1dc2043_1_cpu
+  - libcxx >=18
+  - libparquet 18.1.0 hf4cc9e7_1_cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 489630
+  timestamp: 1732865758291
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-18.1.0-hf3d3107_1_cpu.conda
+  sha256: 725aa1db6b91068613c1effdf8f23d592dd1e6c95722e27eb63ad94c98d47c1b
+  md5: 72ec5bcfc66b3cc5e865c7c90b24c43e
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 18.1.0 hacc6a60_1_cpu
+  - libarrow-acero 18.1.0 h1dc2043_1_cpu
+  - libarrow-dataset 18.1.0 h1dc2043_1_cpu
+  - libcxx >=18
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 451765
+  timestamp: 1732866475770
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libavif16-1.1.1-h45b7238_2.conda
+  sha256: c671365e8c822d29b53f20c4573fdbc70f18b50ff9a4b5b2b6b3c8f7ad2ac2a9
+  md5: 7571064a60bc193ff5c25f36ed23394a
+  depends:
+  - __osx >=11.0
+  - aom >=3.9.1,<3.10.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - rav1e >=0.6.6,<0.7.0a0
+  - svt-av1 >=2.3.0,<2.3.1.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 96781
+  timestamp: 1730268761553
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-25_osxarm64_openblas.conda
+  sha256: f1fb9a11af0b2878bd8804b4c77d3733c40076218bcbdb35f575b1c0c9fddf11
+  md5: f8cf4d920ff36ce471619010eff59cac
+  depends:
+  - libopenblas >=0.3.28,<0.3.29.0a0
+  - libopenblas >=0.3.28,<1.0a0
+  constrains:
+  - blas * openblas
+  - liblapack 3.9.0 25_osxarm64_openblas
+  - liblapacke 3.9.0 25_osxarm64_openblas
+  - libcblas 3.9.0 25_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15913
+  timestamp: 1729643265495
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hd74edd7_2.conda
+  sha256: 839dacb741bdbb25e58f42088a2001b649f4f12195aeb700b5ddfca3267749e5
+  md5: d0bf1dff146b799b319ea0434b93f779
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 68426
+  timestamp: 1725267943211
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hd74edd7_2.conda
+  sha256: 6c6862eb274f21a7c0b60e5345467a12e6dda8b9af4438c66d496a2c1a538264
+  md5: 55e66e68ce55523a6811633dd1ac74e2
+  depends:
+  - __osx >=11.0
+  - libbrotlicommon 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 28378
+  timestamp: 1725267980316
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hd74edd7_2.conda
+  sha256: eeb1eb0d58b9d02bc1b98dc0a058f104ab168eb2f7d1c7bfa0570a12cfcdb7b7
+  md5: 4f3a434504c67b2c42565c0b85c1885c
+  depends:
+  - __osx >=11.0
+  - libbrotlicommon 1.1.0 hd74edd7_2
+  license: MIT
+  license_family: MIT
+  size: 279644
+  timestamp: 1725268003553
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-25_osxarm64_openblas.conda
+  sha256: d9fa5b6b11252132a3383bbf87bd2f1b9d6248bef1b7e113c2a8ae41b0376218
+  md5: 4df0fae81f0b5bf47d48c882b086da11
+  depends:
+  - libblas 3.9.0 25_osxarm64_openblas
+  constrains:
+  - blas * openblas
+  - liblapack 3.9.0 25_osxarm64_openblas
+  - liblapacke 3.9.0 25_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15837
+  timestamp: 1729643270793
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+  sha256: 58477b67cc719060b5b069ba57161e20ba69b8695d154a719cb4b60caf577929
+  md5: 32bd82a6a625ea6ce090a81c3d34edeb
+  depends:
+  - libcxx >=11.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18765
+  timestamp: 1633683992603
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.10.1-h13a7ad3_0.conda
+  sha256: 983a977c5627f975a930542c8aabb46089ec6ea72f28d9c4d3ee8eafaf2fc25a
+  md5: d84030d0863ffe7dea00b9a807fee961
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 379948
+  timestamp: 1726660033582
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.4-ha82da77_0.conda
+  sha256: 342896ebc1d6acbf022ca6df006a936b9a472579e91e3c502cb1f52f218b78e9
+  md5: a2d3d484d95889fccdd09498d8f6bf9a
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 520678
+  timestamp: 1732060258949
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libde265-1.0.15-h2ffa867_0.conda
+  sha256: 13747fa634f7f16d7f222b7d3869e3c1aab9d3a2791edeb2fc632a87663950e0
+  md5: 7c718ee6d8497702145612fa0898a12d
+  depends:
+  - libcxx >=15
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 277861
+  timestamp: 1703089176970
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.22-hd74edd7_0.conda
+  sha256: 3552894ca62bebc33d05982937cda25a4fa19e56a82af2ff20944ff4c2532fda
+  md5: 2d3e3f3d8ab315748420ef58d5a3ae0f
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 54089
+  timestamp: 1728177149927
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+  sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
+  md5: 30e4362988a2623e9eb34337b83e01f9
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 96607
+  timestamp: 1597616630749
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+  sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
+  md5: 36d33e440c31857372a72137f78bacf5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 107458
+  timestamp: 1702146414478
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+  sha256: 8c136d7586259bb5c0d2b913aaadc5b9737787ae4f40e3ad1beaf96c80b919b7
+  md5: 1a109764bff3bdc7bdd84088347d71dc
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 368167
+  timestamp: 1685726248899
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
+  sha256: e42ab5ace927ee7c84e3f0f7d813671e1cf3529f5f06ee5899606630498c2745
+  md5: 38d2656dd914feb0cab8c629370768bf
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 64693
+  timestamp: 1730967175868
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+  md5: 086914b672be056eb70fd4285b6783b6
+  license: MIT
+  license_family: MIT
+  size: 39020
+  timestamp: 1636488587153
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.10.0-h1476194_2.conda
+  sha256: bc64d2a1baeb66985aff69e0ea0f4a1441ef9ef8d0c3a2ecd548003c74c506b4
+  md5: e79854bb7cddc78aa8d09a15a06da166
+  depends:
+  - __osx >=11.0
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - geotiff >=1.7.3,<1.8.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - json-c >=0.18,<0.19.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libarchive >=3.7.7,<3.8.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libdeflate >=1.22,<1.26.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libheif >=1.18.2,<1.19.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.4.0,<4.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - xerces-c >=3.2.5,<3.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - libgdal 3.10.0.*
+  license: MIT
+  license_family: MIT
+  size: 8481363
+  timestamp: 1732732439438
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+  sha256: 44e541b4821c96b28b27fef5630883a60ce4fee91fd9c79f25a199f8f73f337b
+  md5: 4a55d9e169114b2b90d3ec4604cd7bbf
+  depends:
+  - libgfortran5 13.2.0 hf226fd6_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 110233
+  timestamp: 1707330749033
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+  sha256: bafc679eedb468a86aa4636061c55966186399ee0a04b605920d208d97ac579a
+  md5: 66ac81d54e95c534ae488726c1f698ea
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 997381
+  timestamp: 1707330687590
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.31.0-h8d8be31_0.conda
+  sha256: 184d650d55453a40935c128ea309088ae52e15a68cd87ab17ae7c77704251168
+  md5: a338736f1514e6f999db8726fe0965b1
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - openssl >=3.3.2,<4.0a0
+  constrains:
+  - libgoogle-cloud 2.31.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 873497
+  timestamp: 1731121684939
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.31.0-h7081f7f_0.conda
+  sha256: 01f5156584b816d34270a60a61f6b6561f2a01cb3b4eeb455a4e1808d763d486
+  md5: 548fd1d31741ee6b13df4124db4a9f5f
+  depends:
+  - __osx >=11.0
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libcxx >=18
+  - libgoogle-cloud 2.31.0 h8d8be31_0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  size: 526858
+  timestamp: 1731122580689
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.67.1-hc70892a_0.conda
+  sha256: d2393fcd3c3584e5d58da4122f48bcf297567d2f6f14b3d1fcbd34fdd5040694
+  md5: 624e27571fde34f8acc2afec840ac435
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.34.2,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libre2-11 >=2024.7.2
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.67.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4882208
+  timestamp: 1730236299095
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libheif-1.18.2-gpl_he913df3_100.conda
+  sha256: 34a70c5889989013b199c6266a30362539af9e24211a6963a0cb0d7ba786f12d
+  md5: 29911afbc2ec42a42914d5255dea52e6
+  depends:
+  - __osx >=11.0
+  - aom >=3.9.1,<3.10.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - libavif16 >=1.1.1,<2.0a0
+  - libcxx >=16
+  - libde265 >=1.0.15,<1.0.16.0a0
+  - x265 >=3.5,<3.6.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 351064
+  timestamp: 1723121589940
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
+  sha256: bc7de5097b97bcafcf7deaaed505f7ce02f648aac8eccc0d5a47cc599a1d0304
+  md5: 69bda57310071cf6d2b86caf11573d2d
+  license: LGPL-2.1-only
+  size: 676469
+  timestamp: 1702682458114
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+  sha256: a42054eaa38e84fc1e5ab443facac4bbc9d1b6b6f23f54b7bf4f1eb687e1d993
+  md5: 3ff1e053dc3a2b8e36b9bfa4256a58d1
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 547541
+  timestamp: 1694475104253
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libkml-1.3.0-he250239_1021.conda
+  sha256: e578ba448489465b8fea743e214272a9fcfccb0d152ba1ff57657aaa76a0cd7d
+  md5: 891bb2a18eaef684f37bd4fb942cd8b2
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libexpat >=2.6.2,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - uriparser >=0.9.8,<1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281362
+  timestamp: 1724667138089
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-25_osxarm64_openblas.conda
+  sha256: fdd742407672a9af20e70764550cf18b3ab67f12e48bf04163b90492fbc401e7
+  md5: 19bbddfec972d401838330453186108d
+  depends:
+  - libblas 3.9.0 25_osxarm64_openblas
+  constrains:
+  - blas * openblas
+  - liblapacke 3.9.0 25_osxarm64_openblas
+  - libcblas 3.9.0 25_osxarm64_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15823
+  timestamp: 1729643275943
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_4.conda
+  sha256: 6f603914fe8633a615f0d2f1383978eb279eeb552079a78449c9fbb43f22a349
+  md5: 9f3dce5d26ea56a9000cd74c034582bd
+  depends:
+  - libcxx >=15
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 20571387
+  timestamp: 1690559110016
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnetcdf-4.9.2-nompi_h853a48d_115.conda
+  sha256: 8d7c9ede65241de34aa5aa4c1cf04964fd6e027e2a7d4e8cce654b2350c0f2d3
+  md5: 94b3a12456a4e257e65c6b962c785190
+  depends:
+  - __osx >=11.0
+  - blosc >=1.21.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=17
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzip >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zlib
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 678786
+  timestamp: 1728055979264
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
+  sha256: 00cc685824f39f51be5233b54e19f45abd60de5d8847f1a56906f8936648b72f
+  md5: 3408c02539cee5f1141f9f11450b6a51
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.34.2,<2.0a0
+  - libcxx >=17
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 566719
+  timestamp: 1729572385640
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
+  sha256: 62bb669c37a845129096f73d446cdb6bb170e4927f2fea2b661329680dbbc373
+  md5: 40803a48d947c8639da6704e9a44d3ce
+  depends:
+  - __osx >=11.0
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - llvm-openmp >=18.1.8
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4165774
+  timestamp: 1730772154295
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-18.1.0-hf4cc9e7_1_cpu.conda
+  sha256: 974b773c8a000b27ef3283b8744cfda9e46afff7d66c708b90971cc4d681805e
+  md5: 1d41143609ae6961de983182053fbdf2
+  depends:
+  - __osx >=11.0
+  - libarrow 18.1.0 hacc6a60_1_cpu
+  - libcxx >=18
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 874294
+  timestamp: 1732865555683
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
+  sha256: 38f8759a3eb8060deabd4db41f0f023514d853e46ddcbd0ba21768fc4e563bb1
+  md5: fb36e93f0ea6a6f5d2b99984f34b049e
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 263385
+  timestamp: 1726234714421
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.28.2-h8f0b736_0.conda
+  sha256: f732a6fa918428e2d5ba61e78fe11bb44a002cc8f6bb74c94ee5b1297fefcfd8
+  md5: d2cb5991f2fb8eb079c80084435e9ce6
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2374965
+  timestamp: 1728565334796
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2024.07.02-h2348fd5_1.conda
+  sha256: 6facca42cfc85a05b33e484a8b0df7857cc092db34806946d022270098d8d20f
+  md5: 5a7065309a66097738be6a06fd04b7ef
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 165956
+  timestamp: 1728779107218
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/librttopo-1.1.0-ha2cf0f4_17.conda
+  sha256: 9ff3162d035a1d9022f6145755a70d0c0ce6c9152792402bc42294354c871a17
+  md5: ba729f000ea379b76ed2190119d21e13
+  depends:
+  - __osx >=11.0
+  - geos >=3.13.0,<3.13.1.0a0
+  - libcxx >=17
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 191064
+  timestamp: 1727265842691
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
+  sha256: fade8223e1e1004367d7101dd17261003b60aa576df6d7802191f8972f7470b1
+  md5: a7ce36e284c5faaf93c220dfc39e3abd
+  depends:
+  - __osx >=11.0
+  license: ISC
+  size: 164972
+  timestamp: 1716828607917
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libspatialite-5.1.0-hffd3212_11.conda
+  sha256: 593f50ff3828a2760e7aa131233d9ca410bf5bca764e6eac563a4c5b4a57b2d9
+  md5: b8e9d3018a9bb0ddf92d68f19e543604
+  depends:
+  - __osx >=11.0
+  - freexl >=2
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - libcxx >=17
+  - libiconv >=1.17,<2.0a0
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - sqlite
+  - zlib
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 2984267
+  timestamp: 1727341782874
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.47.0-hbaaea75_1.conda
+  sha256: 5a96caa566c11e5a5ebdcdb86a0759a7fb27d3c5f42e6a0fd0d6023c1e935d9e
+  md5: 07a14fbe439eef078cc479deca321161
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 837683
+  timestamp: 1730208293578
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h9cc3647_0.conda
+  sha256: f7047c6ed44bcaeb04432e8c74da87591940d091b0a3940c0d884b7faa8062e9
+  md5: ddc7194676c285513706e5fc64f214d7
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 279028
+  timestamp: 1732349599461
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.21.0-h64651cc_0.conda
+  sha256: 7a6c7d5f58cbbc2ccd6493b4b821639fdb0701b9b04c737a949e8cb6adf1c9ad
+  md5: 7ce2bd2f650f8c31ad7ba4c7bfea61b7
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 324342
+  timestamp: 1727206096912
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-hfce79cd_1.conda
+  sha256: 97ba24c74750b6e731b3fe0d2a751cda6148b4937d2cc3f72d43bf7b3885c39d
+  md5: b9abf45f7c64caf3303725f1aa0e9a4d
+  depends:
+  - __osx >=11.0
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=17
+  - libdeflate >=1.22,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 366323
+  timestamp: 1728232400072
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-hc098a78_1.conda
+  sha256: 7807a98522477a8bf12460402845224f607ab6e1e73ac316b667169f5143cfe5
+  md5: ed89b8bf0d74d23ce47bcf566dd36608
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 82462
+  timestamp: 1732829832932
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+  sha256: 0d4bad713a512d79bfeb4d61821f447afab8b0792aca823f505ce6b195e9fde5
+  md5: c0af0edfebe780b19940e94871f1a765
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 287750
+  timestamp: 1713200194013
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+  sha256: bd3816218924b1e43b275863e21a3e13a5db4a6da74cca8e60bc3c213eb62f71
+  md5: af523aae2eca6dfa1c8eec693f5b9a79
+  depends:
+  - __osx >=11.0
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 323658
+  timestamp: 1727278733917
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.13.5-hbbdcc80_0.conda
+  sha256: 936de9c0e91cb6f178c48ea14313cf6c79bdb1f474c785c117c41492b0407a98
+  md5: 967d4a9dadd710415ee008d862a07c99
+  depends:
+  - __osx >=11.0
+  - icu >=75.1,<76.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 583082
+  timestamp: 1731489765442
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzip-1.11.2-h1336266_0.conda
+  sha256: 507599a77c1ce823c2d3acaefaae4ead0686f183f3980467a4c4b8ba209eff40
+  md5: 7177414f275db66735a17d316b0a81d6
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 125507
+  timestamp: 1730442214849
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
+  md5: 369964e85dc26bfe78f41399b366c435
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 46438
+  timestamp: 1727963202283
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.4-hdb05f8b_0.conda
+  sha256: dfdcd8de37899d984326f9734b28f46f80b88c068e44c562933a8b3117f2401a
+  md5: 76ca179ec970bea6e275e2fa477c2d3c
+  depends:
+  - __osx >=11.0
+  constrains:
+  - openmp 19.1.4|19.1.4.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 281554
+  timestamp: 1732102484807
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.43.0-py311hc367efa_1.conda
+  sha256: c352b894bb07ed59d1cdaed1a64e52b054f4ff02119600a97ccf39cce06dbe5f
+  md5: d14048893b6cc8aec00b4e0e6eb78de2
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libllvm14 >=14.0.6,<14.1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 378145
+  timestamp: 1725305457011
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-4.3.3-py311hebe0b09_1.conda
+  sha256: d68fb0bf5d74c83432155406de87b50b8c10712d331bbbab616c52d945751981
+  md5: 74df239a2926df48e2543bb6754baf61
+  depends:
+  - __osx >=11.0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 108602
+  timestamp: 1725089854895
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+  sha256: fc343b8c82efe40819b986e29ba748366514e5ab94a1e1138df195af5f45fa24
+  md5: 45505bec548634f7d05e02fb25262cb9
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 141188
+  timestamp: 1674727268278
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h93a5062_1001.conda
+  sha256: b68160b0a8ec374cea12de7afb954ca47419cdc300358232e19cec666d60b929
+  md5: 915996063a7380c652f83609e970c2a7
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  size: 131447
+  timestamp: 1713516009610
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py311h56c23cb_0.conda
+  sha256: 74bbdf6dbfe561026fed5c7d5c1a123e6dff0fedc5bc7ed0c6e9037c95ca96d7
+  md5: be48a4cc178a91af3b1ccd58c14efde2
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25180
+  timestamp: 1729351536390
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.9.2-py311hbe3227e_2.conda
+  sha256: bf2f04ad5d57b2042eb58fe1f969e4b263e8edcee971396005aa4dbb39ceab14
+  md5: 2c4e7ee255a37a3dc2ab9ee684b407f4
+  depends:
+  - __osx >=11.0
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 7902037
+  timestamp: 1731025458642
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/minizip-4.0.7-h27ee973_0.conda
+  sha256: 8216190bed8462758d1fea34964f4f46e6314e92696d8b6607bde588895663ad
+  md5: 73dcdab1f21da49048a4f26d648c87a9
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libcxx >=16
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 77944
+  timestamp: 1718483144234
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.0-py311h2c37856_0.conda
+  sha256: aafa8572c72283801148845772fd9d494765bdcf1b8ae6f435e1caff4f1c97f3
+  md5: 6c826762702474fb0def6cedd2db5316
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 91131
+  timestamp: 1725975234150
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+  sha256: 27d0b9ff78ad46e1f3a6c96c479ab44beda5f96def88e2fe626e0a49429d8afc
+  md5: cb2b0ea909b97b3d70cd3921d1445e1a
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  size: 802321
+  timestamp: 1724658775723
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/netcdf4-1.7.2-nompi_py311hd13e3db_100.conda
+  sha256: deaffc773f838f2677791aedf3bfd4dc72e3f4bc1b5e46c831734aa11ef32101
+  md5: e4c8b38c12de3bb2be288862acd8e5ca
+  depends:
+  - __osx >=11.0
+  - certifi
+  - cftime
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 1048689
+  timestamp: 1729663101204
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.60.0-py311h9506ed5_0.conda
+  sha256: 70435f94de8b5328b039ffff9dfdd00c8c0a503cb1a86f4b70ae9cbdd7e4ec1f
+  md5: 5e14ce0b9976d6d0370c9f5032c81bb7
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - llvm-openmp >=16.0.6
+  - llvm-openmp >=18.1.7
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - cuda-version >=11.2
+  - cudatoolkit >=11.2
+  - scipy >=1.0
+  - cuda-python >=11.6
+  - libopenblas >=0.3.18, !=0.3.20
+  - tbb >=2021.6.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5778831
+  timestamp: 1718888718616
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.0.2-py311h649a571_1.conda
+  sha256: 3d4c508041d17007a56f79b593a6d6a69d4f4e2453f1f7ee29ecb48992cc3acc
+  md5: 417c4c5c4a4693156f5b878cf94bf7a0
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6893464
+  timestamp: 1732314808608
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
+  sha256: 472d6eaffc1996e6af35ec8e91c967f472a536a470079bfa56383cc0dbf4d463
+  md5: 5029846003f0bc14414b9128a1f7c84b
+  depends:
+  - libcxx >=16
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 316603
+  timestamp: 1709159627299
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h39f12f2_0.conda
+  sha256: bd1d58ced46e75efa3b842c61642fd12272c69e9fe4d7261078bc082153a1d53
+  md5: df307bbc703324722df0293c9ca2e418
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2935176
+  timestamp: 1731377561525
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.3-h121fd32_0.conda
+  sha256: 4759fd0c3f06c035146100e22ee36a312c9a8226654bd2973e9ca9ac5de5cf1f
+  md5: 39995f7406b949c1bef74f0c7277afb3
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 438254
+  timestamp: 1731665228473
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py311h9cb3ce9_1.conda
+  sha256: 0a08027b25e4f6034d7733c7366f44283246d61cb82d1721f8789d50ebfef287
+  md5: 9ffa9dee175c76e68ea5de5aa1168d83
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14807397
+  timestamp: 1726879116250
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-h297a79d_2.conda
+  sha256: 83153c7d8fd99cab33c92ce820aa7bfed0f1c94fc57010cf227b6e3c50cb7796
+  md5: 147c83e5e44780c7492998acbacddf52
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 618973
+  timestamp: 1723488853807
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.0.0-py311h3894ae9_0.conda
+  sha256: 6d5307fed000e6b72b98d54dd1fea7b155f9a6453476a937522b89dde7b3d673
+  md5: a9a4adae1c4178f50ac3d1fd5d64bb85
+  depends:
+  - __osx >=11.0
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 41856994
+  timestamp: 1729066060042
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.5.0-h61a8e3e_0.conda
+  sha256: df44f24dc325fff7480f20fb404dad03015b9e646aa25e0eb24d1edd3930164e
+  md5: 7b9888f46634eb49eece8fa6e16406d6
+  depends:
+  - __osx >=11.0
+  - libcurl >=8.10.0,<9.0a0
+  - libcxx >=17
+  - libsqlite >=3.46.1,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2732379
+  timestamp: 1726489115567
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py311hae2e1ce_0.conda
+  sha256: 6237f04371995fa8e8f16481dcd4e01d2733a82750180a362a9f4953ffbb3cde
+  md5: e226eba0c52ecd6786e73c8ad7f41e79
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 514316
+  timestamp: 1729847396776
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+  sha256: 8ed65e17fbb0ca944bfb8093b60086e3f9dd678c3448b5de212017394c247ee3
+  md5: 415816daf82e0b23a736a069a75e9da7
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 8381
+  timestamp: 1726802424786
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-18.1.0-py311ha1ab1f8_0.conda
+  sha256: c93f3ede66be0502b5b9afc5bc3fde50d6f8c3863d29b138ff5f536a116457f3
+  md5: 7a3b822fa6abb937651bee20878f087a
+  depends:
+  - libarrow-acero 18.1.0.*
+  - libarrow-dataset 18.1.0.*
+  - libarrow-substrait 18.1.0.*
+  - libparquet 18.1.0.*
+  - pyarrow-core 18.1.0 *_0_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25322
+  timestamp: 1732611121491
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-18.1.0-py311he04fa90_0_cpu.conda
+  sha256: 4563e2d4f41b3874b89e8e2bdebf42588c1c819bd050ae858200f60e30bae860
+  md5: 09b4a27f615d22f194466d8c274ef13e
+  depends:
+  - __osx >=11.0
+  - libarrow 18.1.0.* *cpu
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy >=1.21,<3
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3974075
+  timestamp: 1732611073316
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.3.1-py311h09e6bbd_1.conda
+  sha256: 698b08ca54169a744a1a087130ece9528f18da5e3be33ff6799ac6337d2a5e7f
+  md5: a0a43da9ec3ffb6195e7621fd959f430
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 485377
+  timestamp: 1725739643057
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.3.1-py311h09e6bbd_1.conda
+  sha256: 1d9f2c68ba6c7812f0c1e4a9bf9a5ad0a691b7b7b7694cb7ec0f05f1c24906f1
+  md5: 9c3fc1bf9718d8340f41b0fab06ecdaa
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 10.3.1.*
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 384333
+  timestamp: 1725875205492
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.0-py311hb4b81e0_0.conda
+  sha256: c2c06cca4ce9fd72f1bf8d69703a8c5c2252efd497619d09f47d95d18d3cccf9
+  md5: e3c2e5ded5b6e4b3c2600d033929645c
+  depends:
+  - __osx >=11.0
+  - certifi
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 501267
+  timestamp: 1727795522741
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.10-hc51fdd5_3_cpython.conda
+  sha256: 95a2c487176867ded825e23eab1e581398f75c5323da0cb7577c3cff3d2f955b
+  md5: 2a47a0061d7d3030e45b66d23f01d101
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 14598065
+  timestamp: 1729042279642
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
+  sha256: adc05729b7e0aca7b436e60a86f10822a92185dfcb48d66d6444e3629d3a1f6a
+  md5: 3b855e3734344134cb56c410f729c340
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6308
+  timestamp: 1723823096865
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h460d6c5_1.conda
+  sha256: 9ae182eef4e96a7c2f46cc9add19496276612663e17429500432631dce31a831
+  md5: d32590e7bd388f18b036c6fc402a0cb1
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 192321
+  timestamp: 1725456528007
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.0-py311h730b646_3.conda
+  sha256: 7e75589d9c3723ecf314435f15a7b486cebafa89ebf00bb616354e37587dc7ae
+  md5: b6f3e527de0c0384cd78cfa779bd6ddf
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 365841
+  timestamp: 1728642472021
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+  sha256: 873ac689484262a51fd79bc6103c1a1bedbf524924d7f0088fb80703042805e4
+  md5: 6483b1f59526e05d7d894e466b5b6924
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: LicenseRef-Qhull
+  size: 516376
+  timestamp: 1720814307311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rasterio-1.4.2-py311h09e72dc_1.conda
+  sha256: 04f16340c6ace57f411aa0bb3bfc6dcbd06d3053a89dae900c7861f1676b4708
+  md5: 6c6c2f41ef3efd99af5e5490f89cbc10
+  depends:
+  - __osx >=11.0
+  - affine
+  - attrs
+  - certifi
+  - click >=4
+  - click-plugins
+  - cligj >=0.5
+  - libcxx >=18
+  - libgdal-core >=3.10.0,<3.11.0a0
+  - numpy >=1.21,<3
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7893753
+  timestamp: 1731967443302
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rav1e-0.6.6-h69fbcac_2.conda
+  sha256: be6174970193cb4d0ffa7d731a93a4c9542881dbc7ab24e74b460ef312161169
+  md5: e309ae86569b1cd55a0285fa4e939844
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1526706
+  timestamp: 1694329743011
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2024.07.02-hcd0e937_1.conda
+  sha256: eebddde6cb10b146507810b701ef6df122d5309cd5151a39d0828aa44dc53725
+  md5: 19e29f2ccc9168eb0a39dc40c04c0e21
+  depends:
+  - libre2-11 2024.07.02 h2348fd5_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26860
+  timestamp: 1728779123653
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+  sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
+  md5: 8cbb776a2f641b943d413b3e19df71f4
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 250351
+  timestamp: 1679532511311
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.21.0-py311h3ff9189_0.conda
+  sha256: 309be68ba0cac227dbc288576b1b35a4f57cea85ca8891689399c384ac04b254
+  md5: ae72e9942de84200f16d91a1c3418116
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 294014
+  timestamp: 1730923248201
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.1-py311hf1db568_1.conda
+  sha256: 082a72e5f197aefb59e9f40176df835407e5f71ec832541ba14d4326d3686552
+  md5: 1163490da89fd85d00d29b4d4be7cf0c
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15242433
+  timestamp: 1729481958579
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.6-py311hac502b4_2.conda
+  sha256: ce20ddfb0c8c96eebf3123d5c56e6d32c56b01650eb4b0da86603dad7b0bbf32
+  md5: b3088a6bbd05fb8481257a97cbc65b48
+  depends:
+  - __osx >=11.0
+  - geos >=3.13.0,<3.13.1.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 543087
+  timestamp: 1727273733033
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
+  sha256: cb7a9440241c6092e0f1c795fdca149c4767023e783eaf9cfebc501f906b4897
+  md5: 69d0f9694f3294418ee935da3d5f7272
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35708
+  timestamp: 1720003794374
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.47.0-hcd14bea_1.conda
+  sha256: f9975914a78d600182ec68c963a98c6c0a07eda9b9eee7d6e8bdac9310858ad2
+  md5: ca42c22ab1d212895e58fee9ba32875f
+  depends:
+  - __osx >=11.0
+  - libsqlite 3.47.0 hbaaea75_1
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 840459
+  timestamp: 1730208324005
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-2.3.0-hf24288c_0.conda
+  sha256: ab876ed8bdd20e22a868dcb8d03e9ce9bbba7762d7e652d49bfff6af768a5b8f
+  md5: 114c33e9eec335a379c9ee6c498bb807
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1387330
+  timestamp: 1730246134730
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+  sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
+  md5: b50a57ba89c32b62428b71a875291c9b
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3145523
+  timestamp: 1699202432999
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.2-py311h917b07b_0.conda
+  sha256: 80b79a7d4ed8e16019b8c634cca66935d18fc98be358c76a6ead8c611306ee14
+  md5: 183b74c576dc7f920dae168997dbd1dd
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 858954
+  timestamp: 1732616142626
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-15.1.0-py311hae2e1ce_1.conda
+  sha256: e4b1dcf79f4d4656e538ba24c845350b147d0d9f066771f8b3f396bea828b965
+  md5: ade7687026adce6296650b21e7463758
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 372655
+  timestamp: 1729704815727
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/uriparser-0.9.8-h00cdb27_0.conda
+  sha256: fa0bcbfb20a508ca9bf482236fe799581cbd0eab016e47a865e9fa44dbe3c512
+  md5: e8ff9e11babbc8cd77af5a4258dc2802
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40625
+  timestamp: 1715010029254
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
+  sha256: 2fed6987dba7dee07bd9adc1a6f8e6c699efb851431bcb6ebad7de196e87841d
+  md5: b1f7f2780feffe310b068c021e8ff9b2
+  depends:
+  - libcxx >=12.0.1
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1832744
+  timestamp: 1646609481185
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xerces-c-3.2.5-h92fc2f4_2.conda
+  sha256: 863a7c2a991a4399d362d42c285ebc20748a4ea417647ebd3a171e2220c7457d
+  md5: 50b7325437ef0901fe25dc5c9e743b88
+  depends:
+  - __osx >=11.0
+  - icu >=75.1,<76.0a0
+  - libcxx >=17
+  license: Apache-2.0
+  license_family: Apache
+  size: 1277884
+  timestamp: 1727733870250
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
+  sha256: 7113618021cf6c80831a429b2ebb9d639f3c43cf7fe2257d235dc6ae0ab43289
+  md5: 7e0125f8fb619620a0011dc9297e2493
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 13515
+  timestamp: 1727034783560
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+  sha256: 9939a166d780700d81023546759102b33fdc2c5f11ef09f5f66c77210fd334c8
+  md5: 77c447f48cab5d3a15ac224edb86a968
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 18487
+  timestamp: 1727795205022
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+  sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
+  md5: 39c6b54e94014701dd157f4f576ed211
+  license: LGPL-2.1 and GPL-2.0
+  size: 235693
+  timestamp: 1660346961024
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+  sha256: 93181a04ba8cfecfdfb162fc958436d868cc37db504c58078eab4c1a3e57fbb7
+  md5: 4bb3f014845110883a3c5ee811fd84b4
+  license: MIT
+  license_family: MIT
+  size: 88016
+  timestamp: 1641347076660
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-hc1bb282_7.conda
+  sha256: 9e585569fe2e7d3bea71972cd4b9f06b1a7ab8fa7c5139f92a31cbceecf25a8a
+  md5: f7e6b65943cb73bce0143737fded08f1
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libcxx >=18
+  - libsodium >=1.0.20,<1.0.21.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 281565
+  timestamp: 1731585108039
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
+  sha256: 58f8860756680a4831c1bf4f294e2354d187f2e999791d53b1941834c4b37430
+  md5: e3170d898ca6cb48f1bb567afb92f775
+  depends:
+  - __osx >=11.0
+  - libzlib 1.3.1 h8359307_2
+  license: Zlib
+  license_family: Other
+  size: 77606
+  timestamp: 1727963209370
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py311ha60cc69_1.conda
+  sha256: d2f2f1a408e2353fc61d2bf064313270be2260ee212fe827dcf3cfd3754f1354
+  md5: 29d320d6450b2948740a9be3761b2e9d
+  depends:
+  - __osx >=11.0
+  - cffi >=1.11
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 332271
+  timestamp: 1725305847224
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+  sha256: 2d4fd1ff7ee79cd954ca8e81abf11d9d49954dd1fef80f27289e2402ae9c2e09
+  md5: d96942c06c3e84bfcc5efb038724a7fd
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 405089
+  timestamp: 1714723101397
+- conda: https://conda.anaconda.org/conda-forge/win-64/_libavif_api-1.1.1-h57928b3_2.conda
+  sha256: b99b8948a170ff721ea958ee04a4431797070e85dd6942cb27b73ac3102e5145
+  md5: 76cf1f62c9a62d6b8f44339483e0f016
+  size: 9286
+  timestamp: 1730268773319
+- conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
+  sha256: 1a62cd1f215fe0902e7004089693a78347a30ad687781dfda2289cab000e652d
+  md5: 37e16618af5c4851a3f3d66dd0e11141
+  depends:
+  - libgomp >=7.5.0
+  - libwinpthread >=12.0.0.r2.ggc561118da
+  constrains:
+  - openmp_impl 9999
+  - msys2-conda-epoch <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49468
+  timestamp: 1718213032772
+- conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
+  sha256: 0524d0c0b61dacd0c22ac7a8067f977b1d52380210933b04141f5099c5b6fec7
+  md5: 3d7c14285d3eb3239a76ff79063f27a5
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1958151
+  timestamp: 1718551737234
+- conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311he736701_5.conda
+  sha256: 8bbce5e61e012a06e248f58bb675fdc82ba2900c78590696d185150fb9cea91f
+  md5: 8917bf795c40ec1839ed9d0ab3ad9735
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 34883
+  timestamp: 1725357113431
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.8.0-h6c5491b_10.conda
+  sha256: f92d43e36d271194f027a49c5bd91c7f3eab0406a83734b0a2fee75e0c914546
+  md5: 78eef4154032e557c81bcd12640ee048
+  depends:
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 103029
+  timestamp: 1731733929676
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.8.0-hb414858_2.conda
+  sha256: d2327c924931550a05ab902b4aedbcf5105b581839bade4db7fba6e73dd63214
+  md5: fd898cb8119bf3ad009762df2d8068b0
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 46852
+  timestamp: 1731679007675
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.10.3-h2466b09_0.conda
+  sha256: 27c094c554a84389f0f2430e7397a1b33d558b035bbaf188877f635dbb9b26e6
+  md5: 49b50b5f5074259e9a62c0c271a24d98
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 234894
+  timestamp: 1731567453718
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.3.0-hb414858_2.conda
+  sha256: 2f8c79b24a1396ed2754379bfbe1595b50e7cf306962060b80084b46b682887f
+  md5: beb319c4aeb7de9f6cacf533ebbae94c
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 22528
+  timestamp: 1731679090015
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.5.0-hab6af6e_7.conda
+  sha256: 39fe165d6616e09d25c07a85560ec414a0b0b19c1880e0df52283196cf44896f
+  md5: 1e81f2ecfb25d4a84b4d8fa6067924e5
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 54641
+  timestamp: 1731714676039
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.9.1-hab0f966_2.conda
+  sha256: 81c93d2b8c951c18509ff1359505d01740f77865c9bef46c457607f0ca8c76ad
+  md5: e715a008f534917e93ed2238546b68b0
+  depends:
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-compression >=0.3.0,<0.3.1.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 182315
+  timestamp: 1731714924335
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.15.2-hef77f12_2.conda
+  sha256: 8c02308ad64dcccb85ea55b6fdfb6b6de4b5710a564d24faf64655c4029f4008
+  md5: ac3ab925a1345a6957d5d217fd2d9469
+  depends:
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 160495
+  timestamp: 1731702920182
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.11.0-hbfeb708_8.conda
+  sha256: c1462d6b1de9bdaf6b3233e70cdf2e49b481da9bdf91c0c3f5fcf5ed55f3ca18
+  md5: e125209fbb06e56a208a75f8aae48c00
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 186691
+  timestamp: 1731735208782
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.7.2-h6108ab3_0.conda
+  sha256: b85c36390bfde675fd7fcebfd44bd60d09919d2c7fd2c983d9a5504db3cef6c3
+  md5: dd13817144d595f8309f08cd61578fba
+  depends:
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 108777
+  timestamp: 1732679249162
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.2.1-hb414858_1.conda
+  sha256: 6130e79950efe49460dcedc8a4845a274ed572e55667b66c815dc771f63f9eca
+  md5: 0e3318644bfcc9c42cbde728d7bb8e08
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 55188
+  timestamp: 1731687352327
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.2.2-hb414858_1.conda
+  sha256: f7d0c5c9bd65cca937ed53425800d7376e89bdac9f82fcef44698e6707784cae
+  md5: 0cb03655a7cf5b4ad9e0cd8d5a18b21d
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 91905
+  timestamp: 1731687613902
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.29.6-h2d7cec8_0.conda
+  sha256: 171f1096285af8ba584940420762f083a3476728ced00f0d84fc5984856b52e3
+  md5: a08b5df4fe1f5b8247ed98e0f25391e0
+  depends:
+  - aws-c-auth >=0.8.0,<0.8.1.0a0
+  - aws-c-cal >=0.8.0,<0.8.1.0a0
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-c-http >=0.9.1,<0.9.2.0a0
+  - aws-c-io >=0.15.2,<0.15.3.0a0
+  - aws-c-mqtt >=0.11.0,<0.11.1.0a0
+  - aws-c-s3 >=0.7.2,<0.7.3.0a0
+  - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 261909
+  timestamp: 1732769680432
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.449-h0ed5b37_4.conda
+  sha256: 0057120a9a651d5a50f9fbd4a6404a5aec22885f298ec4da61a1bc1468891f0e
+  md5: da1b9b48262754a5ecf1cf494bb6c4d9
+  depends:
+  - aws-c-common >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.5.0,<0.5.1.0a0
+  - aws-checksums >=0.2.2,<0.2.3.0a0
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 2845768
+  timestamp: 1732813377812
+- conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.6-h85f69ea_0.conda
+  sha256: 1289853b41df5355f45664f1cb015c868df1f570cf743e9e4a5bda8efe8c42fa
+  md5: 2390269374fded230fcbca8332a4adc0
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50135
+  timestamp: 1719266616208
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-h2466b09_2.conda
+  sha256: d8fd7d1b446706776117d2dcad1c0289b9f5e1521cb13405173bad38568dd252
+  md5: 378f1c9421775dfe644731cb121c8979
+  depends:
+  - brotli-bin 1.1.0 h2466b09_2
+  - libbrotlidec 1.1.0 h2466b09_2
+  - libbrotlienc 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 19697
+  timestamp: 1725268293988
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-h2466b09_2.conda
+  sha256: f3bf2893613540ac256c68f211861c4de618d96291719e32178d894114ac2bc2
+  md5: d22534a9be5771fc58eb7564947f669d
+  depends:
+  - libbrotlidec 1.1.0 h2466b09_2
+  - libbrotlienc 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 20837
+  timestamp: 1725268270219
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311hda3d55a_2.conda
+  sha256: aa3ac5dbf63db2f145235708973c626c2189ee4040d769fdf0076286fa45dc26
+  md5: a0ea2839841a06740a1c110ba3317b42
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  license: MIT
+  license_family: MIT
+  size: 322114
+  timestamp: 1725268368720
+- conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+  sha256: 35a5dad92e88fdd7fc405e864ec239486f4f31eec229e31686e61a140a8e573b
+  md5: 276e7ffe9ffe39688abc665ef0f45596
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 54927
+  timestamp: 1720974860185
+- conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.34.3-h2466b09_1.conda
+  sha256: 535b9dd013b8726b5147ca202f509308960ef0d050bce4872e16c0d76962147c
+  md5: f8413bb7fb62f7bdc2545c9a06937790
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 192376
+  timestamp: 1732447407728
+- conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
+  sha256: 0fcac3a7ffcc556649e034a1802aedf795e64227eaa7194d207b01eaf26454c4
+  md5: 4c4fd67c18619be5aa65dc5b6c72e490
+  license: ISC
+  size: 158773
+  timestamp: 1725019107649
+- conda: https://conda.anaconda.org/conda-forge/win-64/cartopy-0.24.0-py311hcf9f919_0.conda
+  sha256: 5ee7140b550932896f416f3765d3ff4acd326fe8b50909eda6186dd3ce34f320
+  md5: 38e9d8fdeccfc01fa09f0bf6d30e3da2
+  depends:
+  - matplotlib-base >=3.6
+  - numpy >=1.19,<3
+  - packaging >=21
+  - pyproj >=3.3.1
+  - pyshp >=2.3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - shapely >=1.8
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1584457
+  timestamp: 1728342837436
+- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py311he736701_0.conda
+  sha256: 9689fbd8a31fdf273f826601e90146006f6631619767a67955048c7ad7798a1d
+  md5: e1c69be23bd05471a6c623e91680ad59
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 297627
+  timestamp: 1725561079708
+- conda: https://conda.anaconda.org/conda-forge/win-64/cftime-1.6.4-py311h0a17f05_1.conda
+  sha256: 1ab7b1dd6e6610042b48adc47dd85f4b0bdfe19230585a75fdec2d1bb4c64f3a
+  md5: a46fb98d896ccf723aa9f1bba8ccdef1
+  depends:
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 187832
+  timestamp: 1725401239339
+- conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.1-py311h3257749_0.conda
+  sha256: dbb0c161dd75e72e66c13f31715941adb094a45471016f89d6a1cfab30967ba8
+  md5: 91d8504588e1b3c77e605503e5a1bc11
+  depends:
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 216693
+  timestamp: 1731429286140
+- conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.0.0-py311he736701_1.conda
+  sha256: e8f2027af0cf22feebad76ccbbb3139437fd07b5c6c35497b45e8de2d1f636ea
+  md5: b0845b4087a24616d2fecc716397b3f6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - toolz >=0.10.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 322558
+  timestamp: 1728335601937
+- conda: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
+  sha256: 2aa2083c9c186da7d6f975ccfbef654ed54fff27f4bc321dbcd12cee932ec2c4
+  md5: ed2c27bda330e3f0ab41577cf8b9b585
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 618643
+  timestamp: 1685696352968
+- conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.9-py311hda3d55a_0.conda
+  sha256: 04db57c1b8fa22d17399c8df03e0d62b365a1315318b59009980672762a6ed87
+  md5: 0f21eefbe9b04632c4e0e17636be84d3
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 3623627
+  timestamp: 1732237179740
+- conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.55.0-py311h5082efb_0.conda
+  sha256: 3a031bac21b8057a9e337ecb586eda89ebdfd3f8ccb46b59b5df4883bdd6cb35
+  md5: 9c27840f1f26f6abe84d9b41ff1dcc03
+  depends:
+  - brotli
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - unicodedata2 >=15.1.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 2478943
+  timestamp: 1731643729545
+- conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+  sha256: 2c53ee8879e05e149a9e525481d36adfd660a6abda26fd731376fa64ff03e728
+  md5: 3761b23693f768dc75a8fd0a73ca053f
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-only OR FTL
+  size: 510306
+  timestamp: 1694616398888
+- conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-h8276f4a_0.conda
+  sha256: 9ef2fcf3b35703bf61a8359038c4b707382f3d5f0c4020f3f8ffb2f665daabae
+  md5: 8e02e06229c677cbc9f5dc69ba49052c
+  depends:
+  - libexpat >=2.5.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - minizip >=4.0.1,<5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 77439
+  timestamp: 1694953013560
+- conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.13.0-h5a68840_0.conda
+  sha256: 2b46d6f304f70dfca304169299908b558bd1e83992acb5077766eefa3d3fe35f
+  md5: 08a30fe29a645fc5c768c0968db116d3
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-only
+  size: 1665961
+  timestamp: 1725676536384
+- conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.3-h496ac4d_3.conda
+  sha256: 116120a2f4411618800c2a5ce246dfc313298e545ce1ffaa85f28cc3ac2236ac
+  md5: fb20f424102030f3952532cc7aebdbd8
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 123087
+  timestamp: 1726603487099
+- conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
+  sha256: 52fa5dde69758c19c69ab68a3d7ebfb2c9042e3a55d405c29a59d3b0584fd790
+  md5: 84344a916a73727c1326841007b52ca8
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 779637
+  timestamp: 1695662145568
+- conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.4-nompi_hd5d9e70_103.conda
+  sha256: c7fefe41464651e807f61d42803a670f25dbe0cb59677af97b9dda3e8cb675fd
+  md5: 6d72be86cae448cfc7bf93d51cd642bb
+  depends:
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2049966
+  timestamp: 1730830694091
+- conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+  sha256: 0fd2b0b84c854029041b0ede8f4c2369242ee92acc0092f8407b1fe9238a8209
+  md5: 2d89243bfb53652c182a7c73182cce4f
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 1852356
+  timestamp: 1723739573141
+- conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_1.conda
+  sha256: 9a667eeae67936e710ff69ee7ce0e784d6052eeba9670b268c565a55178098c4
+  md5: 943f7fab631e12750641efd7279a268c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42891
+  timestamp: 1725303340467
+- conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.7-py311h3257749_0.conda
+  sha256: a2079e13d1345a5dd61df6be933e828e805051256e7260009ba93fce55aebd75
+  md5: 18fd1ac3d79a8d6550eaea5ceaa00036
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55867
+  timestamp: 1725459681416
+- conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+  sha256: 18e8b3430d7d232dad132f574268f56b3eb1a19431d6d5de8c53c29e6c18fa81
+  md5: 31aec030344e962fbd7dbbbbd68e60a9
+  depends:
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 712034
+  timestamp: 1719463874284
+- conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
+  sha256: f9fd9e80e46358a57d9bb97b1e37a03da4022143b019aa3c4476d8a7795de290
+  md5: d3592435917b62a8becff3a60db674f6
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 507632
+  timestamp: 1701648249706
+- conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+  sha256: f4f39d7f6a2f9b407f8fb567a6c25755270421731d70f0ff331f5de4fa367488
+  md5: 1900cb3cab5055833cfddb0ba233b074
+  depends:
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30037
+  license: Apache-2.0
+  license_family: Apache
+  size: 194365
+  timestamp: 1657977692274
+- conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_he0c23c2_1.conda
+  sha256: 52ff148dee1871ef1d5c298bae20309707e866b44714a0a333a5ed2cf9a38832
+  md5: 3f59a73b07a05530b252ecb07dd882b9
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1777570
+  timestamp: 1727296115119
+- conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
+  sha256: f5c293d3cfc00f71dfdb64bd65ab53625565f8778fc2d5790575bef238976ebf
+  md5: 8723000f6ffdbdaef16025f0a01b64c5
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 32567
+  timestamp: 1711021603471
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.7.7-h88ece9c_0.conda
+  sha256: afc496c826ec21cb898018695a7785baced3ebb66a90e39a1c2604dfaa1546be
+  md5: 37c6e11d9f2e69789198ef2bfc661392
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - lzo >=2.10,<3.0a0
+  - openssl >=3.4.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 977329
+  timestamp: 1732614920501
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-18.1.0-h58c5d25_1_cpu.conda
+  sha256: ccf28b3c1a611c77ccfb29adaa7c719a7392cffae21df0a1902abdbf0239fff9
+  md5: 6ba3dfb9b424bbc0b1470a23d74f4cb5
+  depends:
+  - aws-crt-cpp >=0.29.6,<0.29.7.0a0
+  - aws-sdk-cpp >=1.11.449,<1.11.450.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgoogle-cloud >=2.31.0,<2.32.0a0
+  - libgoogle-cloud-storage >=2.31.0,<2.32.0a0
+  - libre2-11 >=2024.7.2
+  - libutf8proc >=2.8.0,<2.9.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.3,<2.0.4.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - arrow-cpp <0.0a0
+  - parquet-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 5264645
+  timestamp: 1732864775612
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-18.1.0-hf0642a6_1_cpu.conda
+  sha256: 9eee20f7d541437aa3f08928d65cf504dd290853516a5ce89f17a1ec5a272219
+  md5: 0e2e09c462e475fcde0aeb85cc241688
+  depends:
+  - libarrow 18.1.0 h58c5d25_1_cpu
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  license: Apache-2.0
+  license_family: APACHE
+  size: 446372
+  timestamp: 1732864908687
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-18.1.0-hf0642a6_1_cpu.conda
+  sha256: f3b129c0872c82718f03df4aec57bd7f5a309e4e176063d6522e647a9fedfd36
+  md5: 0020a3503814d19d7e587cfdf99ffddf
+  depends:
+  - libarrow 18.1.0 h58c5d25_1_cpu
+  - libarrow-acero 18.1.0 hf0642a6_1_cpu
+  - libparquet 18.1.0 hbdea95a_1_cpu
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  license: Apache-2.0
+  license_family: APACHE
+  size: 433995
+  timestamp: 1732865460414
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-18.1.0-h322cffe_1_cpu.conda
+  sha256: ec8969a9f64510221144ab5c2e450e9b225ffbeee4515383f25474ac302b9526
+  md5: 16e4488c02ec050a81d4f0a6bcd69d97
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libarrow 18.1.0 h58c5d25_1_cpu
+  - libarrow-acero 18.1.0 hf0642a6_1_cpu
+  - libarrow-dataset 18.1.0 hf0642a6_1_cpu
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  license: Apache-2.0
+  license_family: APACHE
+  size: 364438
+  timestamp: 1732865698281
+- conda: https://conda.anaconda.org/conda-forge/win-64/libavif16-1.1.1-h4d049a7_2.conda
+  sha256: f74662ac8325dedbc786bf4f3faef39ad4981739cf0239c2ea2d80c791b04de5
+  md5: e7e7405d962ebcb6803f29dc4eabae69
+  depends:
+  - _libavif_api >=1.1.1,<1.1.2.0a0
+  - aom >=3.9.1,<3.10.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - rav1e >=0.6.6,<0.7.0a0
+  - svt-av1 >=2.3.0,<2.3.1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 97828
+  timestamp: 1730269135854
+- conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_mkl.conda
+  sha256: 5468bb91c44b41ce060bbd997c797b2f91e2b7ce91a7cbf4ddf7e7b734a8dc98
+  md5: 499208e81242efb6e5abc7366c91c816
+  depends:
+  - mkl 2024.2.2 h66d3029_14
+  constrains:
+  - blas * mkl
+  - libcblas 3.9.0 25_win64_mkl
+  - liblapack 3.9.0 25_win64_mkl
+  - liblapacke 3.9.0 25_win64_mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3736641
+  timestamp: 1729643534444
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-h2466b09_2.conda
+  sha256: 33e8851c6cc8e2d93059792cd65445bfe6be47e4782f826f01593898ec95764c
+  md5: f7dc9a8f21d74eab46456df301da2972
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 70526
+  timestamp: 1725268159739
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-h2466b09_2.conda
+  sha256: 234fc92f4c4f1cf22f6464b2b15bfc872fa583c74bf3ab9539ff38892c43612f
+  md5: 9bae75ce723fa34e98e239d21d752a7e
+  depends:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 32685
+  timestamp: 1725268208844
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-h2466b09_2.conda
+  sha256: 3d0dd7ef505962f107b7ea8f894e0b3dd01bf46852b362c8a7fc136b039bc9e1
+  md5: 85741a24d97954a991e55e34bc55990b
+  depends:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 245929
+  timestamp: 1725268238259
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_mkl.conda
+  sha256: 21528cdfe67dafdb2d21925515a167f13963e002c2b6d06d68984767f731850c
+  md5: 3ed189ba03a9888a8013aaee0d67c49d
+  depends:
+  - libblas 3.9.0 25_win64_mkl
+  constrains:
+  - blas * mkl
+  - liblapack 3.9.0 25_win64_mkl
+  - liblapacke 3.9.0 25_win64_mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3732258
+  timestamp: 1729643561581
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+  sha256: 75e60fbe436ba8a11c170c89af5213e8bec0418f88b7771ab7e3d9710b70c54e
+  md5: cd4cc2d0c610c8cb5419ccc979f2d6ce
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25694
+  timestamp: 1633684287072
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
+  sha256: dfbac497c4fee74f67391f9c4a40cab559468b7d04ff9fad4b404a26b5e1d5b8
+  md5: 7ead800e22ff7b4bccb73e42a8f7a0f4
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: curl
+  license_family: MIT
+  size: 342388
+  timestamp: 1726660508261
+- conda: https://conda.anaconda.org/conda-forge/win-64/libde265-1.0.15-h91493d7_0.conda
+  sha256: f52c603151743486d2faec37e161c60731001d9c955e0f12ac9ad334c1119116
+  md5: 9dc3c1fbc1c7bc6204e8a603f45e156b
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 252968
+  timestamp: 1703089151021
+- conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.22-h2466b09_0.conda
+  sha256: 579c634b7de8869cb1d76eccd4c032dc275d5a017212128502ea4dc828a5b361
+  md5: a3439ce12d4e3cd887270d9436f9a4c8
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 155506
+  timestamp: 1728177485361
+- conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+  sha256: af03882afb7a7135288becf340c2f0cf8aa8221138a9a7b108aaeb308a486da1
+  md5: 25efbd786caceef438be46da78a7b5ef
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 410555
+  timestamp: 1685726568668
+- conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.4-he0c23c2_0.conda
+  sha256: 0c0447bf20d1013d5603499de93a16b6faa92d7ead870d96305c0f065b6a5a12
+  md5: eb383771c680aa792feb529eaf9df82f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  size: 139068
+  timestamp: 1730967442102
+- conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+  sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
+  md5: 2c96d1b6915b408893f9472569dee135
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 42063
+  timestamp: 1636489106777
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-14.2.0-h1383e82_1.conda
+  sha256: ef840e797714440bb10b69446d815966fff41fdac79f79c4e19c475d81cd375d
+  md5: 75fdd34824997a0f9950a703b15d8ac5
+  depends:
+  - _openmp_mutex >=4.5
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - libgcc-ng ==14.2.0=*_1
+  - libgomp 14.2.0 h1383e82_1
+  - msys2-conda-epoch <0.0a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 666386
+  timestamp: 1729089506769
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.10.0-hce5bd25_2.conda
+  sha256: 576eabc93657dddecd4442b38df4ad1f92661621da31ab22f058e60d437b321c
+  md5: 686c90266552d6b201ffb7f91f82a6f6
+  depends:
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - geotiff >=1.7.3,<1.8.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libarchive >=3.7.7,<3.8.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libdeflate >=1.22,<1.26.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libheif >=1.18.2,<1.19.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.4.0,<4.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xerces-c >=3.2.5,<3.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - libgdal 3.10.0.*
+  license: MIT
+  license_family: MIT
+  size: 8423813
+  timestamp: 1732732742395
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-14.2.0-h1383e82_1.conda
+  sha256: d8739b834608f35775209b032f0c2be752ef187863c7ec847afcebe2f681be4e
+  md5: 9e2d4d1214df6f21cba12f6eff4972f9
+  depends:
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - msys2-conda-epoch <0.0a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 524249
+  timestamp: 1729089441747
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.31.0-h07d40e7_0.conda
+  sha256: 40d5aa338c0aca8e619c777cc552d19f5810f1408b695c9de8f1dc7e279d8550
+  md5: 94320a551af951938e22e9b5dbd60b50
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgrpc >=1.67.1,<1.68.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libgoogle-cloud 2.31.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  size: 14474
+  timestamp: 1731122599862
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.31.0-he5eb982_0.conda
+  sha256: 0deaba4051d1caec99f2e76bad65979007a01e912eecf8bdd895b5bddb96a085
+  md5: 5de1d1089bc7d21b2cbc7273a0c2022d
+  depends:
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libgoogle-cloud 2.31.0 h07d40e7_0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 14355
+  timestamp: 1731122772886
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.67.1-h7aa3b8a_0.conda
+  sha256: 986dafe9c3219e88a82389e679a2804d4256aa9ddaead193f91b7d6b4ef89ea1
+  md5: daad5d4a1c24c1afe748afbb83377e43
+  depends:
+  - c-ares >=1.34.2,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libre2-11 >=2024.7.2
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - re2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - grpc-cpp =1.67.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 17167461
+  timestamp: 1730236510917
+- conda: https://conda.anaconda.org/conda-forge/win-64/libheif-1.18.2-gpl_hc631cee_100.conda
+  sha256: 8d7f1a2015d826a14728ddc1c1bb3a5619d15063d6189acb564e4e264f9255ee
+  md5: 4e127b124dcddec36018c97129720671
+  depends:
+  - aom >=3.9.1,<3.10.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - libavif16 >=1.1.1,<2.0a0
+  - libde265 >=1.0.15,<1.0.16.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - x265 >=3.5,<3.6.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 330638
+  timestamp: 1723121942820
+- conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+  sha256: 5f844dd19b046d43174ad80c6ea75b5d504020e3b63cfbc4ace97b8730d35c7b
+  md5: e1eb10b1cca179f2baa3601e4efc8712
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-only
+  size: 636146
+  timestamp: 1702682547199
+- conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+  sha256: 4e7808e3098b4b4ed7e287f63bb24f9045cc4d95bfd39f0db870fc2837d74dff
+  md5: 3f1b948619c45b1ca714d60c7389092c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 822966
+  timestamp: 1694475223854
+- conda: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-h538826c_1021.conda
+  sha256: 81a6096a2db500f0c3527ae59398eacca0634c3381559713ab28022d711dd3bd
+  md5: 431ec3b40b041576811641e2d643954e
+  depends:
+  - libexpat >=2.6.2,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - uriparser >=0.9.8,<1.0a0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1651104
+  timestamp: 1724667610262
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_mkl.conda
+  sha256: 98c13a28596389539abe3f608c6fbd2826df47671f77c58a331df878c6140c53
+  md5: f716ef84564c574e8e74ae725f5d5f93
+  depends:
+  - libblas 3.9.0 25_win64_mkl
+  constrains:
+  - blas * mkl
+  - libcblas 3.9.0 25_win64_mkl
+  - liblapacke 3.9.0 25_win64_mkl
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3736560
+  timestamp: 1729643588182
+- conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_he239ae6_115.conda
+  sha256: bdf67732b92836287bdf6618093dada2ec20f2be4102d031a80f736e082cc410
+  md5: 582fd971ca8f54b59f007f2c1f1a113e
+  depends:
+  - blosc >=1.21.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzip >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 625327
+  timestamp: 1728056291410
+- conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-18.1.0-hbdea95a_1_cpu.conda
+  sha256: bf5b18ec852a8535e073ebdf5f064c7db9a1147cb0250845439e8b65fae0dbb5
+  md5: d301459fbcd8dec306460110a1e8af37
+  depends:
+  - libarrow 18.1.0 h58c5d25_1_cpu
+  - libthrift >=0.21.0,<0.21.1.0a0
+  - openssl >=3.4.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34433
+  license: Apache-2.0
+  license_family: APACHE
+  size: 810953
+  timestamp: 1732865341099
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
+  sha256: 0d3d6ff9225f6918ac225e3839c0d91e5af1da08a4ebf59cac1bfd86018db945
+  md5: 639ac6b55a40aa5de7b8c1b4d78f9e81
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: zlib-acknowledgement
+  size: 348933
+  timestamp: 1726235196095
+- conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.28.2-hcaed137_0.conda
+  sha256: 798c6675fb709ceaa6a9bd83e9cffe06bc98e83f519c7d7d881243d2e6d0c34d
+  md5: 97c6d2f83edd7b400a22660e2a4d1488
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6033581
+  timestamp: 1728565880841
+- conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2024.07.02-h4eb7d71_1.conda
+  sha256: 39908d18620d48406ea3492bf111eface5b3a88c1a2d166c6d513b03f450df5d
+  md5: d8dbfb066c8e3e85439687613d32057d
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - re2 2024.07.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 260860
+  timestamp: 1728779502416
+- conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-hd4c2148_17.conda
+  sha256: 0f4a1c8ed579f96ccb73245b4002d7152a2a8ecd05a01d49901c5d280561f766
+  md5: 06ea16b8c60b4ce1970c06191f8639d4
+  depends:
+  - geos >=3.13.0,<3.13.1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 404515
+  timestamp: 1727265928370
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+  sha256: 7bcb3edccea30f711b6be9601e083ecf4f435b9407d70fc48fbcf9e5d69a0fc6
+  md5: 198bb594f202b205c7d18b936fa4524f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: ISC
+  size: 202344
+  timestamp: 1716828757533
+- conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-h939089a_11.conda
+  sha256: 76da01457b92be57ac0635cec2681c5423a46252713b144391c14aa0dffe61ba
+  md5: 3ff7b70e2c517f3a43f0b3f87475915a
+  depends:
+  - freexl >=2
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.13.0,<3.13.1.0a0
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libxml2 >=2.12.7,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.5.0,<9.6.0a0
+  - sqlite
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 8293459
+  timestamp: 1727341947641
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.0-h2466b09_1.conda
+  sha256: 3342d6fe787f5830f7e8466d9c65c914bfd8d67220fb5673041b338cbba47afe
+  md5: 5b1f36012cc3d09c4eb9f24ad0e2c379
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 892175
+  timestamp: 1730208431651
+- conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-he619c9f_0.conda
+  sha256: 4b3256bd2b4e4b3183005d3bd8826d651eccd1a4740b70625afa2b7e7123d191
+  md5: af0cbf037dd614c34399b3b3e568c557
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 291889
+  timestamp: 1732349796504
+- conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.21.0-hbe90ef8_0.conda
+  sha256: 81ca4873ba09055c307f8777fb7d967b5c26291f38095785ae52caed75946488
+  md5: 7699570e1f97de7001a7107aabf2d677
+  depends:
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 633857
+  timestamp: 1727206429954
+- conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hfc51747_1.conda
+  sha256: 902cb9f7f54d17dcfd54ce050b1ce2bc944b9bbd1748913342c2ea1e1140f8bb
+  md5: eac317ed1cc6b9c0af0c27297e364665
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.22,<1.26.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  size: 978865
+  timestamp: 1728232594877
+- conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-hb602f4b_1.conda
+  sha256: b9e55f0be8ea5bee960565fd18c232a0ef62af7f007d1d102a3b66c496489d68
+  md5: 4dce7215af5e642fe84a07321c0628f6
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 83847
+  timestamp: 1732830082137
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+  sha256: d0ca51cb1de9192be9a3238e71fbcca5a535619c499c4f4c9b2ed41c14d36770
+  md5: abd61d0ab127ec5cd68f62c2969e6f34
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 274359
+  timestamp: 1713200524021
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_8.conda
+  sha256: 6d5e158813ab8d553fbb0fedd0abe7bf92970b0be3a9ddf12da0f6cbad78f506
+  md5: 03cccbba200ee0523bde1f3dad60b1f3
+  depends:
+  - ucrt
+  constrains:
+  - pthreads-win32 <0.0a0
+  - msys2-conda-epoch <0.0a0
+  license: MIT AND BSD-3-Clause-Clear
+  size: 35433
+  timestamp: 1724681489463
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h0e4246c_0.conda
+  sha256: 08dec73df0e161c96765468847298a420933a36bc4f09b50e062df8793290737
+  md5: a69bbf778a462da324489976c84cfc8c
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - pthread-stubs
+  - ucrt >=10.0.20348.0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 1208687
+  timestamp: 1727279378819
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.5-h442d1da_0.conda
+  sha256: 020466b17c143190bd5a6540be2ceef4c1f8d514408bd5f0adaafcd9d0057b5c
+  md5: 1fbabbec60a3c7c519a5973b06c3b2f4
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1511585
+  timestamp: 1731489892312
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzip-1.11.2-h3135430_0.conda
+  sha256: 8ed49d8aa0ff908e16c82f92154174027c8906429e8b63d71f0b27ecc987b43e
+  md5: 09066edc7810e4bd1b41ad01a6cc4706
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 146856
+  timestamp: 1730442305774
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+  sha256: ba945c6493449bed0e6e29883c4943817f7c79cbff52b83360f7b341277c6402
+  md5: 41fbfac52c601159df6c01f875de31b9
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 55476
+  timestamp: 1727963768015
+- conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.43.0-py311h7deaa30_1.conda
+  sha256: 7df8480fc6c32b6f5e0b6f928332759559e9c2d6c43f94e6b51ea5d2129442a9
+  md5: c59d60615d5c5a9e9539a106478d332c
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - vs2015_runtime
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17126019
+  timestamp: 1725305442517
+- conda: https://conda.anaconda.org/conda-forge/win-64/lz4-4.3.3-py311h8b5e962_1.conda
+  sha256: 24bb321c5da9660f56759000001a6f227780348a21098164f55049b58ac78a11
+  md5: 8672eca07a3b500a9aa0483c43742f82
+  depends:
+  - lz4-c >=1.9.3,<1.10.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 76663
+  timestamp: 1725090098178
+- conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+  sha256: a0954b4b1590735ea5f3d0f4579c3883f8ac837387afd5b398b241fda85124ab
+  md5: e34720eb20a33fc3bfb8451dd837ab7a
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134235
+  timestamp: 1674728465431
+- conda: https://conda.anaconda.org/conda-forge/win-64/lzo-2.10-hcfcfb64_1001.conda
+  sha256: 39e176b8cc8fe878d87594fae0504c649d1c2c6d5476dd7238237d19eb825751
+  md5: 629f4f4e874cf096eb93a23240910cee
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  size: 142771
+  timestamp: 1713516312465
+- conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.2-py311h5082efb_0.conda
+  sha256: 8a2022af5237e0fdf7e646856f1122735b71e4cdeaf42684b533ec4bad5a885f
+  md5: 84e78e335b0f9292060f1ac6d8ce0e3e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28244
+  timestamp: 1729351760960
+- conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.2-py311h8f1b1e4_2.conda
+  sha256: 45d3c5e41275b8333d0622a8f7642d049d9cbbe6c80cf7beb1aa371f1e79dffe
+  md5: f7d8036f3808253ae132500eaa8d65d9
+  depends:
+  - certifi >=2020.06.20
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.12.1,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 7939436
+  timestamp: 1731026260055
+- conda: https://conda.anaconda.org/conda-forge/win-64/minizip-4.0.6-hb638d1e_0.conda
+  sha256: b334446aa40fe368ea816f5ee47145aea4408812a5a8d016db51923d7c465835
+  md5: 43e2b972e258a25a1e01790ad0e3287a
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 85324
+  timestamp: 1717296997985
+- conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_14.conda
+  sha256: 098ba4a3cb82f627bc79dc0ab1111b44859c9ef4aaa8d75ce043bce107770cb3
+  md5: f011e7cc21918dc9d1efe0209e27fa16
+  depends:
+  - intel-openmp 2024.*
+  - tbb 2021.*
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 103019089
+  timestamp: 1727378392081
+- conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.0-py311h3257749_0.conda
+  sha256: 4e6a7979b434308ce5588970cb613952e3340bb2f9e63aaad7e5069ef1f08d1d
+  md5: 36562593204b081d0da8a8bfabfb278b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 89472
+  timestamp: 1725975909671
+- conda: https://conda.anaconda.org/conda-forge/win-64/netcdf4-1.7.2-nompi_py311hc43f1c8_100.conda
+  sha256: 83089e3b03bdfc048a1e2a0b860e6882031a72eac8c7aecd13b0e9402745f07c
+  md5: 5871f94c855c953ca3abc768f1420f3c
+  depends:
+  - certifi
+  - cftime
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1013027
+  timestamp: 1729662815776
+- conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.60.0-py311h0673bce_0.conda
+  sha256: b3359607051ec34c3eeb90447ece326822b6883882cf0e425cb1108dbcaebdc9
+  md5: 5d6eb2107dd921d651e46d059a82ab95
+  depends:
+  - llvmlite >=0.43.0,<0.44.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.22.3,<2.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - cudatoolkit >=11.2
+  - libopenblas !=0.3.6
+  - cuda-version >=11.2
+  - tbb >=2021.6.0
+  - scipy >=1.0
+  - cuda-python >=11.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 5807308
+  timestamp: 1718888792863
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.0.2-py311h35ffc71_1.conda
+  sha256: 22d8f73e0fd6477f425e6b22a2db15af73f0ce4775ae7acb1ce1b06d666256a7
+  md5: 4bb6bca8e8c20873b9036643fff8af3b
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7501226
+  timestamp: 1732315481415
+- conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
+  sha256: dda71cbe094234ab208f3552dec1f4ca6f2e614175d010808d6cb66ecf0bc753
+  md5: 7e7099ad94ac3b599808950cec30ad4e
+  depends:
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 237974
+  timestamp: 1709159764160
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.4.0-h2466b09_0.conda
+  sha256: e03045a0837e01ff5c75e9273a572553e7522290799807f918c917a9826a6484
+  md5: d0d805d9b5524a14efb51b3bff965e83
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 8491156
+  timestamp: 1731379715927
+- conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.3-h34659fe_0.conda
+  sha256: 8baa71790c9899bd7bc0d028ec0dab8180330cb12ecd6600d2b7e0cb78a79a2c
+  md5: 7d0f9831258c59c73b1dcf00b05e8785
+  depends:
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 896875
+  timestamp: 1731665181736
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py311hcf9f919_1.conda
+  sha256: f5477bf3a2b7919481009ce87212d7bbd16c61a5bb05c692a7c336fb45646534
+  md5: 5965b8926efba14e6fde98cc8713c083
+  depends:
+  - numpy >=1.19,<3
+  - numpy >=1.22.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1,<2024.2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14587131
+  timestamp: 1726879538736
+- conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_2.conda
+  sha256: f4a12cbf8a7c5bfa2592b9dc92b492c438781898e5b02f397979b0be6e1b5851
+  md5: a3a3baddcfb8c80db84bec3cb7746fb8
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 820831
+  timestamp: 1723489427046
+- conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.0.0-py311h4fbf6a9_0.conda
+  sha256: 0d38ec638a5b266adb894f6fe4c874b46b98180a984007bf40cb030a22e8cc1e
+  md5: 44897ebc5704d3de316af26740325513
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: HPND
+  size: 42185657
+  timestamp: 1729066269713
+- conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.5.0-hd9569ee_0.conda
+  sha256: ebd1fee2834cf5971a08dfb665606f775302aa22e98d5d893d35323805311419
+  md5: 4cfbffd1cd2bbff30e975a71b1769597
+  depends:
+  - libcurl >=8.10.0,<9.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - sqlite
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 2709612
+  timestamp: 1726489723807
+- conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py311he736701_0.conda
+  sha256: 303c988247c4b1638f1cc90cd40465f5c74ca0ecfd83114033af637654dc2b6b
+  md5: 307267e6a028bca3382d98e06a372ebf
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 521434
+  timestamp: 1729847606018
+- conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
+  sha256: 7e446bafb4d692792310ed022fe284e848c6a868c861655a92435af7368bae7b
+  md5: 3c8f2573569bb816483e5cf57efbbe29
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 9389
+  timestamp: 1726802555076
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.1.0-py311h1ea47a8_0.conda
+  sha256: 78e88b5ee2d80622091e24ba74d35f425060648735f5156ac388b1fd87169958
+  md5: 3577ae265ed894dc105829e4e0a4f40c
+  depends:
+  - libarrow-acero 18.1.0.*
+  - libarrow-dataset 18.1.0.*
+  - libarrow-substrait 18.1.0.*
+  - libparquet 18.1.0.*
+  - pyarrow-core 18.1.0 *_0_*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25662
+  timestamp: 1732651904499
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.1.0-py311hdea38fa_0_cpu.conda
+  sha256: 436fc748241421e39ea72c8fcfebdad20c5c39a7dfc1d9c16dda03b97b7c317d
+  md5: 3603acae16694ed5cd689e6980eb0703
+  depends:
+  - libarrow 18.1.0.* *cpu
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy >=1.21,<3
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3498372
+  timestamp: 1732651886220
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.7.0-py311h90dcb63_0.conda
+  sha256: 36644db864de2ae57573d61bff0c46f3e5cb1efc86bd43756fdec9365ee8b5b3
+  md5: 423256766e9b9ba6c01c39b0ea992f1e
+  depends:
+  - certifi
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 760981
+  timestamp: 1727796239898
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.10-hce54a09_3_cpython.conda
+  sha256: 3931c546219d069918389e4dbe12057af4cc68a1060577a04014c6b5fc618aa0
+  md5: 5d54d429c0eb2273d1cc69763de6edaf
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 18206702
+  timestamp: 1729041779073
+- conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-5_cp311.conda
+  sha256: 9b210e5807dd9c9ed71ff192a95f1872da597ddd10e7cefec93a922fe22e598a
+  md5: 895b873644c11ccc0ab7dba2d8513ae6
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6707
+  timestamp: 1723823225752
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-307-py311hda3d55a_3.conda
+  sha256: 78a4ede098bbc122a3dff4e0e27255e30b236101818e8f499779c89670c58cd6
+  md5: 1bc10dbe3b8d03071070c962a2bdf65f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  size: 6023110
+  timestamp: 1728636767562
+- conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.14-py311hda3d55a_0.conda
+  sha256: 337097e3f3b71f782c43fb702893f86f080e140da467415dcaf039a7fbb8e551
+  md5: 64553b300529aa8987f6ca92c914c844
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - winpty
+  license: MIT
+  license_family: MIT
+  size: 210973
+  timestamp: 1729202625177
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311he736701_1.conda
+  sha256: 86608f1b4f6b1819a74b6b1344c34304745fd7e84bfc9900269f57cf28178d31
+  md5: d0c5f3c595039890be0c9af47d23b9ba
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 187901
+  timestamp: 1725456808581
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.2.0-py311h484c95c_3.conda
+  sha256: 4d3fc4cfac284efb83a903601586cc6ee18fb556d4bf84d3bd66af76517c463e
+  md5: 4836b00658e11b466b823216f6df2424
+  depends:
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 371084
+  timestamp: 1728642713666
+- conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+  sha256: 887d53486a37bd870da62b8fa2ebe3993f912ad04bd755e7ed7c47ced97cbaa8
+  md5: 854fbdff64b572b5c0b470f334d34c11
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LicenseRef-Qhull
+  size: 1377020
+  timestamp: 1720814433486
+- conda: https://conda.anaconda.org/conda-forge/win-64/rasterio-1.4.2-py311hf418590_1.conda
+  sha256: a7731c1b83c02a88edc10dbdb9b469d70708ffb79c1658aa52a8194fdf1b578b
+  md5: 4b9e8abb782da65ab3acbf3084e6aedd
+  depends:
+  - affine
+  - attrs
+  - certifi
+  - click >=4
+  - click-plugins
+  - cligj >=0.5
+  - libgdal-core >=3.10.0,<3.11.0a0
+  - numpy >=1.21,<3
+  - proj >=9.5.0,<9.6.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7641540
+  timestamp: 1731967463170
+- conda: https://conda.anaconda.org/conda-forge/win-64/rav1e-0.6.6-h975169c_2.conda
+  sha256: 3193451440e5ac737b7d5d2a79f9e012d426c0c53e41e60df4992150bfc39565
+  md5: bd32cc2ed62374932f9d57a2e3eb2863
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1523119
+  timestamp: 1694330157594
+- conda: https://conda.anaconda.org/conda-forge/win-64/re2-2024.07.02-hd3b24a8_1.conda
+  sha256: 5ac1c50d731c323bb52c78113792a71c5f8f060e5767c0a202120a948e0fc85b
+  md5: b4abdc84c969587219e7e759116a3e8b
+  depends:
+  - libre2-11 2024.07.02 h4eb7d71_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 214858
+  timestamp: 1728779526745
+- conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.21.0-py311h533ab2d_0.conda
+  sha256: 217c9ce9bcb50ea55ba1148a7b85ae945015c68ecae914707eff0fce5c175cdf
+  md5: 56ff25ebb744a6aa97ff02b8c263c892
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 211208
+  timestamp: 1730923228503
+- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py311hf16d85f_1.conda
+  sha256: bd3c3ec5ba203143818fa3ca300060a459d78da566049b49ed2ef20e04ea5b96
+  md5: b7c132408b0ee7408dcfa998ef6f7939
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15858505
+  timestamp: 1729482598163
+- conda: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.6-py311hd54bd37_2.conda
+  sha256: 7861137aee7b42c15fdbfed908e25285b2672a5c060b40891624d036bdbc1ec2
+  md5: b38f0e907cf3431ea635f1a5d871a85e
+  depends:
+  - geos >=3.13.0,<3.13.1.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 548238
+  timestamp: 1727274233608
+- conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
+  sha256: 5b9450f619aabcfbf3d284a272964250b2e1971ab0f7a7ef9143dda0ecc537b8
+  md5: 7635a408509e20dcfc7653ca305ad799
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 59350
+  timestamp: 1720004197144
+- conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.47.0-h2466b09_1.conda
+  sha256: bc2a5ab86dbe2352790d1742265b3b6ae9a7aa5cf80345a37f26ec3e04cf9b4a
+  md5: 93084a590e8b7d2b62b7d5b1763d5bde
+  depends:
+  - libsqlite 3.47.0 h2466b09_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 914686
+  timestamp: 1730208443157
+- conda: https://conda.anaconda.org/conda-forge/win-64/svt-av1-2.3.0-he0c23c2_0.conda
+  sha256: c25bf68ef411d41ee29f353acc698c482fdd087426a77398b7b41ce9d968519e
+  md5: ac11ae1da661e573b71870b1191ce079
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1845727
+  timestamp: 1730246453216
+- conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.7.0-h91493d7_0.tar.bz2
+  sha256: c3d607499a6e097f4b8b27048ee7166319fd3dfe98aea9e69a69a3d087b986e3
+  md5: f57be598137919e4f7e7d159960d66a1
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 178574
+  timestamp: 1668617991077
+- conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+  sha256: 2c4e914f521ccb2718946645108c9bd3fc3216ba69aea20c2c3cedbd8db32bb1
+  md5: fc048363eb8f03cd1737600a5d08aafe
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: TCL
+  license_family: BSD
+  size: 3503410
+  timestamp: 1699202577803
+- conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.2-py311he736701_0.conda
+  sha256: 7e313f1724e5eb7d13f7a1ebd6026a378f3f58a638ba7cdc3bd452c01323bb29
+  md5: 7e33077ce1bc0bf45c45a92e37432f16
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 859456
+  timestamp: 1732616376731
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+  sha256: db8dead3dd30fb1a032737554ce91e2819b43496a0db09927edf01c32b577450
+  md5: 6797b005cd0f439c4c5c9ac565783700
+  constrains:
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-MicrosoftWindowsSDK10
+  size: 559710
+  timestamp: 1728377334097
+- conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-15.1.0-py311he736701_1.conda
+  sha256: 07d55566e05bbadc32e989bbe50853e579fea0f8809503719d7d1438302d27be
+  md5: 6230613721d6d805d0276025ee4d7b2b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 365349
+  timestamp: 1729705070270
+- conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
+  sha256: ed0eed8ed0343d29cdbfaeb1bfd141f090af696547d69f91c18f46350299f00d
+  md5: 28b4cf9065681f43cc567410edf8243d
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49181
+  timestamp: 1715010467661
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_23.conda
+  sha256: 986ddaf8feec2904eac9535a7ddb7acda1a1dfb9482088fdb8129f1595181663
+  md5: 7c10ec3158d1eb4ddff7007c9101adb0
+  depends:
+  - vc14_runtime >=14.38.33135
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17479
+  timestamp: 1731710827215
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34433-he29a5d6_23.conda
+  sha256: c483b090c4251a260aba6ff3e83a307bcfb5fb24ad7ced872ab5d02971bd3a49
+  md5: 32b37d0cfa80da34548501cdc913a832
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.42.34433.* *_23
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  size: 754247
+  timestamp: 1731710681163
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hdffcdeb_23.conda
+  sha256: 568ce8151eaae256f1cef752fc78651ad7a86ff05153cc7a4740b52ae6536118
+  md5: 5c176975ca2b8366abad3c97b3cd1e83
+  depends:
+  - vc14_runtime >=14.42.34433
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17572
+  timestamp: 1731710685291
+- conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: 9df10c5b607dd30e05ba08cbd940009305c75db242476f4e845ea06008b0a283
+  md5: 1cee351bf20b830d991dbe0bc8cd7dfe
+  license: MIT
+  license_family: MIT
+  size: 1176306
+- conda: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
+  sha256: 02b9874049112f2b7335c9a3e880ac05d99a08d9a98160c5a98898b2b3ac42b2
+  md5: ca7129a334198f08347fb19ac98a2de9
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 5517425
+  timestamp: 1646611941216
+- conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.2.5-he0c23c2_2.conda
+  sha256: 759ae22a0a221dc1c0ba39684b0dcf696aab4132478e17e56a0366ded519e54e
+  md5: 82b6eac3c198271e98b48d52d79726d8
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 3574017
+  timestamp: 1727734520239
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-h0e40799_1.conda
+  sha256: f44bc6f568a9697b7e1eadc2d00ef5de0fe62efcf5e27e5ecc46f81046082faf
+  md5: ca66d6f8fe86dd53664e8de5087ef6b1
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 107925
+  timestamp: 1727035280560
+- conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.5-h0e40799_0.conda
+  sha256: 9075f98dcaa8e9957e4a3d9d30db05c7578a536950a31c200854c5c34e1edb2c
+  md5: 8393c0f7e7870b4eb45553326f81f0ff
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  size: 69920
+  timestamp: 1727795651979
+- conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+  sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
+  md5: 515d77642eaa3639413c6b1bc3f94219
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: LGPL-2.1 and GPL-2.0
+  size: 217804
+  timestamp: 1660346976440
+- conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+  sha256: 4e2246383003acbad9682c7c63178e2e715ad0eb84f03a8df1fbfba455dfedc5
+  md5: adbfb9f45d1004a26763652246a33764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  size: 63274
+  timestamp: 1641347623319
+- conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_7.conda
+  sha256: 15cc8e2162d0a33ffeb3f7b7c7883fd830c54a4b1be6a4b8c7ee1f4fef0088fb
+  md5: e03f2c245a5ee6055752465519363b1c
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 2527503
+  timestamp: 1731585151036
+- conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
+  sha256: 8c688797ba23b9ab50cef404eca4d004a948941b6ee533ead0ff3bf52012528c
+  md5: be60c4e8efa55fddc17b4131aa47acbd
+  depends:
+  - libzlib 1.3.1 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Zlib
+  license_family: Other
+  size: 107439
+  timestamp: 1727963788936
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py311h53056dc_1.conda
+  sha256: a93584e6167c3598854a47f3bf8276fa646a3bb4d12fcfc23a54e37d5879f35c
+  md5: 7d4c123cbb5e6293dd4dd2f8d30f0de4
+  depends:
+  - cffi >=1.11
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 321357
+  timestamp: 1725305930669
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+  sha256: 768e30dc513568491818fb068ee867c57c514b553915536da09e5d10b4ebf3c3
+  md5: 9a17230f95733c04dc40a2b1e5491d74
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 349143
+  timestamp: 1714723445995

--- a/walker_lake/pixi.toml
+++ b/walker_lake/pixi.toml
@@ -19,8 +19,8 @@ holoviews = ">=1.20.0"
 rioxarray = ">=0.17.0"
 dask = ">=2024.11.2"
 distributed = ">=2024.11.2"
-pip = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [tasks.notebook]
 cmd = "jupyter notebook walker_lake.ipynb"

--- a/walker_lake/pixi.toml
+++ b/walker_lake/pixi.toml
@@ -1,0 +1,50 @@
+[workspace]
+name = "walker_lake"
+channels = ["conda-forge", "nodefaults"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2018-10-11"
+maintainers = ["jlstevens", "jbednar"]
+categories = ["Geospatial"]
+labels = ["datashader", "geoviews", "bokeh", "xarray", "dask"]
+description = "Analysis of NDVI over time of Walker Lake, Nevada"
+
+[dependencies]
+python = "3.11.*"
+notebook = ">=6,<7"
+datashader = ">=0.16.3"
+geoviews = ">=1.13.1"
+holoviews = ">=1.20.0"
+rioxarray = ">=0.17.0"
+dask = ">=2024.11.2"
+distributed = ">=2024.11.2"
+pip = "*"
+wheel = "*"
+
+[tasks.notebook]
+cmd = "jupyter notebook walker_lake.ipynb"
+depends-on = ["download"]
+
+[tasks.download]
+depends-on = ["download-LANDSAT8_B4", "download-LANDSAT8_B5", "download-LANDSAT5_B4", "download-LANDSAT5_B5"]
+
+[tasks.download-LANDSAT8_B4]
+env = { FILENAME = "data/LC08_L1TP_042033_20171022_20171107_01_T1_sr_band4.tif" }
+cmd = "mkdir -p data && curl -fsSL -o $FILENAME https://earth-data.s3.us-east-1.amazonaws.com/landsat/LC08_L1TP_042033_20171022_20171107_01_T1_sr_band4.tif"
+outputs = ["data/LC08_L1TP_042033_20171022_20171107_01_T1_sr_band4.tif"]
+
+[tasks.download-LANDSAT8_B5]
+env = { FILENAME = "data/LC08_L1TP_042033_20171022_20171107_01_T1_sr_band5.tif" }
+cmd = "mkdir -p data && curl -fsSL -o $FILENAME https://earth-data.s3.us-east-1.amazonaws.com/landsat/LC08_L1TP_042033_20171022_20171107_01_T1_sr_band5.tif"
+outputs = ["data/LC08_L1TP_042033_20171022_20171107_01_T1_sr_band5.tif"]
+
+[tasks.download-LANDSAT5_B4]
+env = { FILENAME = "data/LT05_L1TP_042033_19881022_20161001_01_T1_sr_band4.tif" }
+cmd = "mkdir -p data && curl -fsSL -o $FILENAME https://earth-data.s3.us-east-1.amazonaws.com/landsat/LT05_L1TP_042033_19881022_20161001_01_T1_sr_band4.tif"
+outputs = ["data/LT05_L1TP_042033_19881022_20161001_01_T1_sr_band4.tif"]
+
+[tasks.download-LANDSAT5_B5]
+env = { FILENAME = "data/LT05_L1TP_042033_19881022_20161001_01_T1_sr_band5.tif" }
+cmd = "mkdir -p data && curl -fsSL -o $FILENAME https://earth-data.s3.us-east-1.amazonaws.com/landsat/LT05_L1TP_042033_19881022_20161001_01_T1_sr_band5.tif"
+outputs = ["data/LT05_L1TP_042033_19881022_20161001_01_T1_sr_band5.tif"]

--- a/walker_lake/pixi.toml
+++ b/walker_lake/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "walker_lake"
-channels = ["conda-forge", "nodefaults"]
+channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]

--- a/world_cup/pixi.lock
+++ b/world_cup/pixi.lock
@@ -1,0 +1,7125 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  default:
+    channels:
+    - url: https://repo.anaconda.com/pkgs/main/
+    - url: https://repo.anaconda.com/pkgs/msys2/
+    packages:
+      linux-64:
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.6.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-24.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bleach-6.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.4.2-py311hf4808d0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.12.31-h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.12.14-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py311h1fdaa30_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.3.1-py311hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.8.11-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.20.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.11.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.30.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.23.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.16-hb9589c4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-4.0.0-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.22-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-hffd6297_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.10.0-py311hbfdbfaf_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.11-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.8-py311ha02d727_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.16.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.10.1-py311h3c60e43_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-2.2.1-py311h08b1b3b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-2.2.1-py311hf175353_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.15-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.3-py311h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.5.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/parso-0.8.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-11.0.0-py311hcea889d_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.21.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.11-he870216_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.20.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-3.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311h4aa5aa6_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-72.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.2-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.5-py311h92b7b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.12.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.12.2-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.44.0-py311h06a4308_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      osx-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.6.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h46256e1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bleach-6.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.4.2-py311h9b7fc35_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h46256e1_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h46256e1_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311h6d0c2b6_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.12.31-hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.12.14-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py311h9205ec4_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.3.1-py311h1962661_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.8.11-py311h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.20.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.11.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.30.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.23.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.16-h4f63f0c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-4.0.0-h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h46256e1_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h46256e1_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h46256e1_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.22-h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-h6fa9cd1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h46256e1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.10.0-py311h919b35b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.10.1-py311hc59c7be_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-2.1.3-py311h13f252e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-2.1.3-py311ha745260_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.15-h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.3-py311h6d0c2b6_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.5.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/parso-0.8.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-11.0.0-py311h47bf62f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.21.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h46256e1_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.11-h4d6d9e5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.20.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-3.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py311h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311h83de92b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-72.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.2-py311h46256e1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.5-py311h85bffb1_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.12.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.12.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.44.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
+      osx-arm64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.6.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-24.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bleach-6.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.4.2-py311hb9f6ed7_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.12.31-hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.12.14-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.3.1-py311h48ca7d4_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.8.11-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.20.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.11.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.30.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.23.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.16-he93ba84_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-4.0.0-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.22-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-hc9ead59_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.10.0-py311h7ef442a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.10.1-py311h5d9532f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-2.2.1-py311he598dae_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-2.2.1-py311hfbfe69c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.15-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.3-py311hcf29cfe_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.5.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/parso-0.8.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-11.0.0-py311h84e58ab_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.21.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.11-hb885b13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.20.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-3.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.2-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311h2aea54e_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-72.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.2-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.5-py311hb6e6a13_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.12.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.12.2-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.44.0-py311hca03da5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
+      win-64:
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.6.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h827c3e9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-24.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bleach-6.2.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.4.2-py311h57dcf0c_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h827c3e9_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h827c3e9_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311h5da7b33_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.12.31-haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.12.14-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py311h827c3e9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.3.1-py311h214f63a_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.8.11-py311h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.20.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.11.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.30.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.23.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.16-hb4a4139_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-4.0.0-h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h827c3e9_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h827c3e9_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h827c3e9_9.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.22-h5bf469e_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-h44ae7cf_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h827c3e9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.10.0-py311he19b0ae_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h827c3e9_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.11-py311h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.8-py311hea22821_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.10.1-py311h4cd664f_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-2.2.1-py311hdab7c0b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-2.2.1-py311hd01c5d8_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.15-h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.3-py311h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.5.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.2.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/parso-0.8.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-11.0.0-py311h096bfcc_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.21.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h827c3e9_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.2.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.11-h4607a30_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.20.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-3.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-308-py311h5da7b33_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.14-py311h72d21ff_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.2-py311h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h636fa0f_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-72.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.2-py311h827c3e9_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.5-py311h746a85d_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.12.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.12.2-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.3-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.40-haa95532_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.42.34433-h9531ae6_2.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.44.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
+packages:
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+  sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
+  md5: 013d3f22cd3b87f71224bd936765bcad
+  size: 3121
+  timestamp: 1562011674792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+  sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
+  md5: 613805add1c05b538ff06d217252feb7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  size: 20810
+  timestamp: 1652859733309
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.6.2-py311h06a4308_0.tar.bz2
+  sha256: d58b068fe1b9c195394e77a6fba4d152c6934e97df7757dd6b921498f8aa72f8
+  md5: 09de3b2d5519a680bda3c3771380c3da
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.26.1
+  - uvloop >=0.21
+  license: MIT
+  license_family: MIT
+  size: 243587
+  timestamp: 1729121303719
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_1.tar.bz2
+  sha256: b7eb9612c200994d8126caa0c36561a586c6a8a57066609febae6ff4d61da35a
+  md5: 6181c14ad55e754ce7327ec32e7a2bf9
+  depends:
+  - cffi >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 36032
+  timestamp: 1736182558607
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-24.3.0-py311h06a4308_0.tar.bz2
+  sha256: 9c40ad73b2f2f2a6ea5ae3919a9a538518b0eb92baef29f07fd006fca09a5e90
+  md5: b6fca842c8ea8530e4d1751c277e8ba2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 162429
+  timestamp: 1734533126936
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
+  sha256: 5bb9bfe025d9a49af272f194278f63cea7366e83bdf3f99d25f97b820d522089
+  md5: 100d3161d97332fe38945afec8d36935
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 276381
+  timestamp: 1718029864701
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+  sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
+  md5: 751c2c5b239a728db05f91374aaac3a1
+  size: 5838
+  timestamp: 1528122042945
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bleach-6.2.0-py311h06a4308_0.tar.bz2
+  sha256: 46d4caa9b996615e6d367282d5ba3a4a11f23052fac305cf52fc067e4f766ed7
+  md5: 5f923de750f6d8a2a9faa8cf90da6311
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings
+  constrains:
+  - tinycss2 >=1.1.0,<1.5
+  license: Apache-2.0
+  license_family: Apache
+  size: 367370
+  timestamp: 1732290516590
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.6.0-py311h06a4308_0.tar.bz2
+  sha256: 30dedc2bed0aa72523531f5e22fff96c948bb2f68addb625161ef50b07484fb9
+  md5: 1571b1a2aded9cbd3c0c7656e9a9ebbe
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5853990
+  timestamp: 1727914619438
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.4.2-py311hf4808d0_0.tar.bz2
+  sha256: de78a7f35a57c21d8986c1084f308c98477747d6a92a0b23b5d4855333eee0c9
+  md5: 85399e523becae3ca29054b3d579b8e7
+  depends:
+  - libgcc-ng >=11.2.0
+  - numpy >=1.21,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 148890
+  timestamp: 1731058903578
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_9.tar.bz2
+  sha256: b59efa2904ae9978739d8ace23f3f27c6a45d478d8a1b280946aa232e70f3cfd
+  md5: 055fcc9955965c288132fa36c5ce3053
+  depends:
+  - brotli-bin 1.0.9 h5eee18b_9
+  - libbrotlidec 1.0.9 h5eee18b_9
+  - libbrotlienc 1.0.9 h5eee18b_9
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 18722
+  timestamp: 1736182569595
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_9.tar.bz2
+  sha256: 1f6dcd77e302c8a468764a1b2302828dacb87aafe55d2e2374b8e00fca9b62c0
+  md5: 77d68ab5e96a98bfde1a74670999fb90
+  depends:
+  - libbrotlidec 1.0.9 h5eee18b_9
+  - libbrotlienc 1.0.9 h5eee18b_9
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 19800
+  timestamp: 1736182559439
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_9.tar.bz2
+  sha256: b7ff9535237880e6fb540d58ce2b904e9407904c92579260b92be12a4451281a
+  md5: f229f321f52804bfa696fed56b11b5d1
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 361254
+  timestamp: 1736182674347
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+  sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
+  md5: f5058c8d5b2994b7334f18e022105a14
+  depends:
+  - libgcc-ng >=11.2.0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 427542
+  timestamp: 1714510571510
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.12.31-h06a4308_0.tar.bz2
+  sha256: c4937657ed853c9c65270ed0f2a0cf6f52fa12f79d34a80fb865b99af32dee06
+  md5: 514df5b057d22088c8ae4e340803fe53
+  license: MPL-2.0
+  license_family: Other
+  size: 137958
+  timestamp: 1736360393668
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.12.14-py311h06a4308_0.tar.bz2
+  sha256: 47947a1e2c41071780fca3cce3fea9de888c47e06c456fc84f1cff80eace0109
+  md5: 2253b0553985a10579b262cb6ea2f718
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 166554
+  timestamp: 1734473301827
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py311h1fdaa30_1.tar.bz2
+  sha256: a73bd99651100ddd118806e62f20b2b6fac0098e0615580314fb8cc983467d4e
+  md5: b8f1ba0cf72321301cd1d840fd286731
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 308046
+  timestamp: 1736182517693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+  sha256: d9c102b9ec7f3a635936b6f73d4db126d748a25f65407353bd76b260dc7d1cd6
+  md5: eec48dbdf5dac0ea26750cc26b58c1d9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 554986
+  timestamp: 1709758392744
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+  sha256: 882481e441b9b93cbdfb32fbe32a6ad9f26197472f186a08fddb921f61346c02
+  md5: 443c79196064f57c98199e9990544b2f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16902
+  timestamp: 1709322958614
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.3.1-py311hdb19cb5_0.tar.bz2
+  sha256: 214cc9e08edf0430b1dca7d7a5407f19c16e9ad0684bb972a4a836e044196719
+  md5: db381e74b7730d0b8b54a05d2716c28c
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 299819
+  timestamp: 1732540101238
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.8.11-py311h6a678d5_0.tar.bz2
+  sha256: 69c3214beb1e7f398f82a10c245af788304bbff2e1a12d0e15672f68ba00d974
+  md5: d3c168f99c3d8bb146f89b3032f3ebaf
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2844636
+  timestamp: 1736267672061
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+  sha256: 4b589e3265c74159130230c164ff2d8d381be65899a249def0b53f93ce83fd47
+  md5: 245cb7173dcdba21cf368031cd87f706
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17434
+  timestamp: 1676823330845
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+  sha256: b75d12e85274660bb675a3e53d47a929872f2daa2ff5a76e98885ee3f2d19ad1
+  md5: f2119d0885334060d0d7fe59e5220287
+  depends:
+  - brotli >=1.0.1
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - fs >=2.2.0,<3
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  - zopfli >=0.1.4
+  - lz4 >=1.7.4.2
+  license: MIT
+  license_family: MIT
+  size: 3237908
+  timestamp: 1713551660998
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+  sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
+  md5: a5dc8677d891dff2393b63189a3ad42f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 971975
+  timestamp: 1666798278693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.20.0-py311h06a4308_0.tar.bz2
+  sha256: 97633f085c543505ab0ed53de62bbe516ffdef26f11449a5a361ef6303b3142d
+  md5: 8b2ed66ea48b7e6fef1018404ddf93f1
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.1
+  constrains:
+  - plotly >=4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6141733
+  timestamp: 1730827820330
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.11.2-py311h06a4308_0.tar.bz2
+  sha256: 0fadbb65eaa9e384ad80257f86b1acb2b4c9796d29aa13bb83d81e2d658b3073
+  md5: bffdd73242bda84226e6f28a852368bf
+  depends:
+  - bokeh >=3.1
+  - colorcet >=2
+  - holoviews >=1.19.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 371661
+  timestamp: 1734469525165
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+  sha256: e08e27531775de40f46b6ac7bf71856963baa0c008bd2b4d112e6341cd3e8f4c
+  md5: bfc7682613c861cbcb4ac01485c05657
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 147174
+  timestamp: 1714398938840
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+  sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
+  md5: 3add2ce56858a1b8f6a37342f82773d3
+  depends:
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - zlib >=1.2.13,<1.2.14
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 19310769
+  timestamp: 1699647799237
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py311h06a4308_0.tar.bz2
+  sha256: fe68041ab6344e8f2a6dd8e42032bc1332e22bc8c268e74b81e00fe10e35b822
+  md5: 382be07ff80150df0b66abae64059a40
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 238033
+  timestamp: 1728665623948
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.30.0-py311h06a4308_0.tar.bz2
+  sha256: 8d16ed1f5ff00f096b360ce1d7f9b4a4878ddcc8c866c4e5da1d2d9c2cd98d5b
+  md5: 7bfea7a1bfd1c08fddd95dc471270519
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1634301
+  timestamp: 1734548199842
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.2-py311h06a4308_0.tar.bz2
+  sha256: 61d1e8ff671b50ee001b1702b12f44572f6963157964c825c7358ecd2e62bc16
+  md5: f4040af0e38070f691bf43c120e8744f
+  depends:
+  - parso >=0.8.4,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1172008
+  timestamp: 1733987427312
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py311h06a4308_1.tar.bz2
+  sha256: 1cf0f40f4bbb90b1280c32ddfa7e9a7b36b82e88a467c994b4c698c3d41ce5f2
+  md5: 0731cad6883721022d93fbd62ffe1edc
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 356018
+  timestamp: 1730903056980
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+  sha256: 8316ae3abee25edab89788ee6e9eef79c398aba192559f514674a04ee1860bca
+  md5: 112209aed451545a622ab217c70f6972
+  depends:
+  - libgcc-ng >=11.2.0
+  license: IJG
+  license_family: Other
+  size: 283506
+  timestamp: 1722872662693
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.23.0-py311h06a4308_0.tar.bz2
+  sha256: caafff289b6a96f7f13668faa72e7a85346f410b1f97dc34163f70746bb98f1b
+  md5: 27d1820c6bd6185aa888ee994d290bf1
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 192447
+  timestamp: 1728486794980
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+  sha256: 9e3bac2d41bd432b721b009e7de981766fba396e6f238e923f304112bd88655a
+  md5: 84ae4cf3f2d01fbebdac374971192be9
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 15525
+  timestamp: 1699032521315
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+  sha256: 79ce6dff3d93649a2555b1d2a4ae9eb77175a1c00664cb8eb0e6f848d5cdd1b9
+  md5: db395b0efd7018fcf3a4af879170c2a8
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 276856
+  timestamp: 1676823504812
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
+  sha256: 91cca0ba49accdc9e97463bee087244a27ad107eb3af9ccb91634239f8b10f72
+  md5: a185824bfc55bd90e1cf9330b417b74c
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 97359
+  timestamp: 1718818381635
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
+  sha256: 540f8dfb7cdc3877b4e24d6af65696d0bc7eae5de1c307229f86b3fe601a2286
+  md5: f650f8c007471f6ef6c1a292918d2e1f
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 41920
+  timestamp: 1718738122846
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
+  sha256: 398387b6f1ee1691b04a31fedd1320225e5553aa921b06bc013f010a0008621e
+  md5: bac66634a9133c633ddc879e14e83f23
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 610854
+  timestamp: 1718827113534
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+  sha256: ddfee06ba9b149222c65d1d4270272840533aa63b56fe36363c84a891c71d328
+  md5: ee128e5c0d8d9e1952e2387b66a5b8cb
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27239
+  timestamp: 1686870958829
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+  sha256: 0c6a074272ed58677ec17e4dbfceaffd2108841a61af92b32f156c5763108d1d
+  md5: dd3d37841d0d20c70a60e8c939923894
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19144
+  timestamp: 1700168632051
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+  sha256: b040f0d0ee4588188ab6b83a93738b3ff6e6d1775424be97995bd0df0f4fb904
+  md5: eae62735d710cf5ff6d51e6f59fcd999
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 78148
+  timestamp: 1676827253282
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.16-hb9589c4_0.tar.bz2
+  sha256: 1b6b432a7ef79b3c29ab84e9fa1fb159837dd65b3997e9a6605896f3517dcfcf
+  md5: ed981583bbc6e6ac7707895204653e0d
+  depends:
+  - jpeg >=9e,<10a
+  - libgcc-ng >=11.2.0
+  - libtiff >=4.5.1,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 271236
+  timestamp: 1734428496317
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+  sha256: 069d33aebaf4db4ae410d4acb4851860a69d2c8f326fd45ab2a67b67fe276e6d
+  md5: 61689da52cf1fcebda8c9fb2872f94bf
+  constrains:
+  - binutils_impl_linux-64 2.40
+  license: GPL-3.0-only
+  size: 723073
+  timestamp: 1727336193185
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-4.0.0-h6a678d5_0.tar.bz2
+  sha256: 3b35e98ab9e27e3c6ce1a4988087410c4f10f8f2dc7b32e5fd0597ae3330a6f0
+  md5: 2a9cf942ef9eac2d34261363e6fbacad
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 283535
+  timestamp: 1734423401417
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_9.tar.bz2
+  sha256: f4443a37d6eb1f35aed3b36d67ee10df39dccde535f3a6761fad44c0a516843d
+  md5: 69b08a79ab20702c6bd5f77cc4063267
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 67000
+  timestamp: 1736182526370
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_9.tar.bz2
+  sha256: 51a57fc34ce6d44b35d76562b945a55efdcd663880bb1a153c44fe176fbc5c1a
+  md5: 72d59a9872154e939d5759c7eb2c5db1
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_9
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 34506
+  timestamp: 1736182538544
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_9.tar.bz2
+  sha256: 5a43fa99f57fe609b374888359cecef39556ebf9c5fb6fd35eb9694f054b65eb
+  md5: 3c5dbc154e879dcfd5e71c8cd56202ff
+  depends:
+  - libbrotlicommon 1.0.9 h5eee18b_9
+  - libgcc-ng >=11.2.0
+  license: MIT
+  size: 295241
+  timestamp: 1736182548938
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.22-h5eee18b_0.tar.bz2
+  sha256: 99b22a8ac9907bf834b06bc1d4c046a46e0d1fe8f044e03b287ca80490ffd7b3
+  md5: c75f9e8e2f44baf9a36b4d7ac80eb2bc
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 78335
+  timestamp: 1734423317784
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+  sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
+  md5: 1af9b4d62c708924417f2640ef22a68f
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: MIT
+  license_family: MIT
+  size: 154016
+  timestamp: 1714483282916
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
+  md5: 641e72e5067bd6d5454405879e1cd2a7
+  depends:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - _libgcc_mutex * main
+  - __glibc >=2.17
+  constrains:
+  - _libgcc_mutex 0.1 main
+  - _openmp_mutex
+  - libgomp 11.2.0 h1234567_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 8895144
+  timestamp: 1654090827491
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+  sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
+  md5: 3080c2813e6e1d0f8a100a38b5b3456d
+  depends:
+  - _libgcc_mutex 0.1 main
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 573231
+  timestamp: 1654090775721
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+  sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
+  md5: 1bffe1481ed4f88827248fb9001f8923
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 362561
+  timestamp: 1677841789536
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+  sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
+  md5: 6f662c6b244a444869f0c537da106d6d
+  depends:
+  - libgcc-ng >=7.3.0
+  license: ISC
+  size: 396743
+  timestamp: 1581700759428
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+  sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
+  md5: 8c195584a5f5471b600ee180e4052773
+  depends:
+  - __glibc >=2.17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 6410287
+  timestamp: 1654090800863
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-hffd6297_1.tar.bz2
+  sha256: 00c29474500c2db177d482b62dd42392327376823464961995d60ee5c7679c55
+  md5: d26f4756467be40670835398528d1309
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.22,<1.23.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 663476
+  timestamp: 1734425727361
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+  sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
+  md5: 292768ec77416ae257cfdd44ea2071c8
+  depends:
+  - libgcc-ng >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29197
+  timestamp: 1668082729834
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+  sha256: a062fad27450b94279d1688aabd11a95eedee7814462ef6364337d55412b4a7e
+  md5: e0521f84b9770830e654432364ac930e
+  depends:
+  - libgcc-ng >=11.2.0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 484011
+  timestamp: 1729160032020
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+  sha256: fd8e30beb8c9442f16e6617fac92dd0c89ec823e98f06e60f712147380ead35f
+  md5: 7ed7caf2816c8b85b67b6f4e8833cbd5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41155
+  timestamp: 1676837080881
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+  sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
+  md5: 76f089e76ec67583bb38428b51008097
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 164494
+  timestamp: 1714510587156
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+  sha256: 260e26dd509834c1b225ab7bdb97b9a86e00054fbdd5dfa49e68fa4dcf85a661
+  md5: 8f5d7ddc69cc6f7d44c80d2251dea5d1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162339
+  timestamp: 1676837095436
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+  sha256: 7f5b0804d0768619b7bd93b10488067d80bf42ec29f443f00b53ba11758a1241
+  md5: 8afb45e45c0d93bfd142e682d4b021ef
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 134438
+  timestamp: 1684280014220
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_1.tar.bz2
+  sha256: 4cb3c7482521d58234f9696167809e55bde8fa3df547d11b9fd238adc360abec
+  md5: e39f68d06a1f03ee3c6361abc0806092
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27074
+  timestamp: 1736367601790
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.10.0-py311hbfdbfaf_0.tar.bz2
+  sha256: 4a1053eb7d779473df2b6af99649e20af08b3bfadaba59009df756585e7bf107
+  md5: 803563191e37b0fc9bf0ca62d13b2d10
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numpy >=1.23,<3.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9818267
+  timestamp: 1736278428611
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+  sha256: 7ac07ea180b5928086075900afbc332fb1d3c81ddfacb54c891693c284056f14
+  md5: fc83dd1b3d2ec3c0a297ead0c3405907
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19573
+  timestamp: 1676823852670
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+  sha256: c9ba2f9c83820712dd97d6a1b54a1215b9820a0be02ac82380b4c50911b9400c
+  md5: e5dc6b4a5b8e02733ce3bc9e9198a8d2
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67750
+  timestamp: 1676837123613
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+  sha256: 1a5141ef0de1cbff816f96bb4b212a40606e2fc11301a4c1358c8d63a6b2b027
+  md5: 22ac3bc22b68fef4c1f3f6ab3c7bfe0b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23040
+  timestamp: 1676827301164
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+  sha256: 9aacfbbe6f638c58a4e8ff31374d1438d78b7db25d6ea6fd0c50ca2109f225d4
+  md5: e602057e3b3d80da88c61d66e8851c5b
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104681
+  timestamp: 1676823696152
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+  sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
+  md5: ce77d0f05f846da4a6b9e23fe7f21d9b
+  depends:
+  - intel-openmp 2023.*
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - tbb 2021.*
+  constrains:
+  - __glibc >=2.17
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 206738176
+  timestamp: 1699648006088
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_2.tar.bz2
+  sha256: 2aa10f19199e2f594db9d292538611b60f9eb8604ac2e8ed5658360da0417fed
+  md5: 1bb09282d58781f1886968ec437e1db9
+  depends:
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 76075
+  timestamp: 1736367004456
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.11-py311h5eee18b_0.tar.bz2
+  sha256: 26001bced97eaa8c3862686f48668a252b8f7fd6ed81329534bee0538ea39fe0
+  md5: eb3e382c51549878d07e5c3e207c3845
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 241049
+  timestamp: 1730824176185
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.8-py311ha02d727_0.tar.bz2
+  sha256: afc57040e0c892e46b00ecb534100fcaf05d8c75592170b0ce9119f2e5630557
+  md5: 5e47055fea53886417e9a62d4e89c7c9
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16
+  - python >=3.11,<3.12.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 411216
+  timestamp: 1730824036145
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
+  sha256: 6116c133fbed1e7ea0f5e69f900e93d7977cb715920d10b10642c191d00cc9a6
+  md5: b842f7ebdc8b7b6a0dda4c5ebe12805b
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8315206
+  timestamp: 1717622768176
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+  sha256: bb45fb0a3973caa74fd8f845e0a519895f6a378807626e15ecf72c02f2eed794
+  md5: 185f658ba8a74e326b7231c8fd0d62bf
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 121834
+  timestamp: 1698934274227
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.16.4-py311h06a4308_0.tar.bz2
+  sha256: 9361ab2f7b289e9fd33ef001035fbdca9735f1c5425bb8282ce053d152ffaa2c
+  md5: f95894da2382644ab016e71dc0db3463
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 528660
+  timestamp: 1728049573278
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py311h06a4308_0.tar.bz2
+  sha256: c7aa4facc9d03e5087f9b22a88373beb43633a2c558e895303f5accc3ce95142
+  md5: 4b4927ae34aaf3ee6b008a4392afd2dd
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 169513
+  timestamp: 1728049478168
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+  sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
+  md5: 57ea097dc15f8d9f9eb90e1d919143b0
+  depends:
+  - libgcc-ng >=11.2.0
+  license: MIT AND X11
+  license_family: MIT
+  size: 1157733
+  timestamp: 1674734069410
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+  sha256: 266199dd4efde0ad342a9c500f4bc4299c5622219aea623b46315a9b4f6b8959
+  md5: 2b21844d2b0024d0ffad0e6450cf0855
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 15860
+  timestamp: 1708532713870
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
+  sha256: 59e169e036db0f2b98ed19f867d8ac708970214599efa0d57d3413fc1dbe8e3c
+  md5: d0faf375bfc33811456d43fe549cb939
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 710152
+  timestamp: 1717630833268
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+  sha256: ef2857e6d3d7eb246b3abddfbd3aa2d124dd8565391ace3876b77339babc50bb
+  md5: d276d1b1774107987963135c78ca7390
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26607
+  timestamp: 1699455972519
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.10.1-py311h3c60e43_0.tar.bz2
+  sha256: c85ee5a0b557ed925a1709b7422f13e88545bd2392c63d8e65b8d4dd44bca713
+  md5: 3ca48c350f813b2e11ed2312858098f7
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21,<3
+  - numpy >=1.23.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 204257
+  timestamp: 1730216115069
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-2.2.1-py311h08b1b3b_0.tar.bz2
+  sha256: 4d1f6b92a77f75f8cfcb4577c2a82943f609891d525535cca3d89f7a8e3a09f8
+  md5: ac149ca5e00bf0467516b56d03ab6ff9
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 2.2.1 py311hf175353_0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - setuptools <74
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10756
+  timestamp: 1736502859104
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-2.2.1-py311hf175353_0.tar.bz2
+  sha256: a62122e67910125e92f3c23907631aeddfbc88dc09531c05e2fa1d3711cfacef
+  md5: 6689e6e4f931e8a93c78141865615650
+  depends:
+  - blas 1.0 mkl
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - setuptools <74
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10118433
+  timestamp: 1736502843447
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
+  sha256: 1c9f6902907a3d4a7e5c3cb02236491ea4c4e66a1a0ce51fa506dffb24ba89f6
+  md5: 36d514eca3c87ab75a1d418607e26db2
+  depends:
+  - libgcc-ng >=11.2.0
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=11.2.0
+  - libtiff >=4.5.0,<4.7.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 528528
+  timestamp: 1722872671997
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.15-h5eee18b_0.tar.bz2
+  sha256: f8a3dbcdabfad712311fdbec1fd49d44340818d348df5d90f420de133a4daeb1
+  md5: 4084456e619e7c2ab269f3cf2ff831f2
+  depends:
+  - ca-certificates
+  - libgcc-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 5499760
+  timestamp: 1725545717819
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+  sha256: 280225061aeba00d7b85f46e55d7d79cd92c92f662dc749d9c53187978e8d083
+  md5: c51c21da68080d89300703ad818c824a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 38606
+  timestamp: 1699371264464
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.2-py311h06a4308_0.tar.bz2
+  sha256: 288da6ac31a1aebbd0571fe1d273c6095a0c049c6be93db899dfe45fc57c7936
+  md5: 684139274d664e9d0458b11e8a46d55e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 188806
+  timestamp: 1734472196649
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.3-py311h6a678d5_0.tar.bz2
+  sha256: f9c6066d840b6a7db19eb969637e9ae26b22a64f4c63e7d34639c5638d71bc2b
+  md5: 5f21a0ac71dd61bb78501815e23e1117
+  depends:
+  - bottleneck >=1.3.6
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - numexpr >=2.8.4
+  - numpy >=1.23.2,<3
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - pyxlsb >=1.0.10
+  - beautifulsoup4 >=4.11.2
+  - jinja2 >=3.1.2
+  - dataframe-api-compat >=0.1.7
+  - pyarrow >=10.0.1
+  - pytables >=3.8.0
+  - pandas-gbq >=0.19.0
+  - zstandard >=0.19.0
+  - numba >=0.56.4
+  - html5lib >=1.1
+  - psycopg2 >=2.9.6
+  - blosc >=1.21.3
+  - adbc-driver-postgresql >=0.8.0
+  - pymysql >=1.0.2
+  - qtpy >=2.3.0
+  - scipy >=1.10.0
+  - lxml >=4.9.2
+  - fastparquet >=2022.12.0
+  - xlrd >=2.0.1
+  - s3fs >=2022.11.0
+  - xlsxwriter >=3.0.5
+  - gcsfs >=2022.11.0
+  - sqlalchemy >=2.0.0
+  - adbc-driver-sqlite >=0.8.0
+  - python-calamine >=0.1.7
+  - odfpy>=1.4.1
+  - pyqt >=5.15.9
+  - openpyxl >=3.1.0
+  - fsspec >=2022.11.0
+  - matplotlib-base >=3.6.3
+  - tabulate >=0.9.0
+  - pyreadstat >=1.2.0
+  - xarray >=2022.12.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17990544
+  timestamp: 1732738272325
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.5.3-py311h06a4308_0.tar.bz2
+  sha256: edabd666746acfb045c1dd922835172ea94c00d33bf03337740db2af93551911
+  md5: 486d3afb94115451198410b69e3fa0b5
+  depends:
+  - bleach
+  - bokeh >=3.5.0,<3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.1.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing-extensions
+  constrains:
+  - holoviews >=1.18.0
+  - bokeh-fastapi >=0.1.2,<0.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24210987
+  timestamp: 1730381005745
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.2.0-py311h06a4308_0.tar.bz2
+  sha256: d137c487271bef84a7d0a7497439db4d0a07b6b4a9e30036b19bfd264828b728
+  md5: 80cb61dac081768a5d5d2d925a61896d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 268099
+  timestamp: 1734618713828
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/parso-0.8.4-py311h06a4308_0.tar.bz2
+  sha256: e40e60301997a3b5ff53b7ed7365db536f1b492a829ce2946ac61f6f7321c1a3
+  md5: d9f873bfc00a48198c960c9ba56f9e93
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 222615
+  timestamp: 1733963432742
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-11.0.0-py311hcea889d_1.tar.bz2
+  sha256: 5a6d206a72dea0ba519847e03cebfc149070eef747082d3d00677beac3fd4ed5
+  md5: 47344fee0c1f75f06a9c3f7df3a5918e
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.16,<3.0a0
+  - libgcc-ng >=11.2.0
+  - libtiff >=4.2.0,<4.7.0
+  - libtiff >=4.5.1,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 1011464
+  timestamp: 1734430724792
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.2-py311h06a4308_0.tar.bz2
+  sha256: 87422d1d2592abe99ee9a6c06f6653030567e88571a21edca9f4c1f2cd22ae07
+  md5: 806984470b5328d7fdb721b37ec2d73f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2913778
+  timestamp: 1723484664306
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+  sha256: d2bbab8bfc57c7f46ca8994bc87df7e744d3f036b867bc4be1145ba6d8d7e091
+  md5: de41707272a8e3ccab764f0b7010a27d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37394
+  timestamp: 1692205565974
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.21.0-py311h06a4308_0.tar.bz2
+  sha256: ef83087f0474cbc11bf6ab7c318a56a7677c6dcc57c75d5ed52a0a2a6bda30a2
+  md5: 25de2c05534f16c0e2b61429c7c2d3bb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 121560
+  timestamp: 1731953225009
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+  sha256: b7f591c19b10bf0daa7e6e3b45a9f4a0a0e83188e1f8a58037caea79e60f8d91
+  md5: d945b4ccc135005839c504cc29df1745
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 749608
+  timestamp: 1704404477511
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_1.tar.bz2
+  sha256: 675e161cff8bc0f660b3f7ea5692207de372730d9ea2d5410a1e76c8e3cb24d5
+  md5: 924cb59384b001ea5e9e37d1638820cc
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 495241
+  timestamp: 1736367238095
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+  sha256: ed927e4d058a8f4ea73edc7a43ed74877d93b88fdfa240b3b2777244386ced70
+  md5: a1f0e05fc7e49712f81ad5478ec9d51e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2121496
+  timestamp: 1684280065800
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.2.0-py311h06a4308_0.tar.bz2
+  sha256: b5d27b938ed374a24fcb18a66c3f1a94e28bbe01b4ac156cd26c7be1ca756622
+  md5: 244cfad440c898146039cb986864017e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 486387
+  timestamp: 1731445563066
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+  sha256: 114b55e00f4622c90fd2b404b21ad5f94a10283fcaaf86a42174b8d39b0a3e98
+  md5: 2458e92683cc68671a6c8e1b86ce8817
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35850
+  timestamp: 1676822725516
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.11-he870216_0.tar.bz2
+  sha256: aced5b9158e4839247dcf76bd5197650803f9db116ccdc451a79d1c0da5f2354
+  md5: bc33687df04e0cfeebd12f682bec6b22
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.35.1
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=11.2.0
+  - libuuid >=1.41.5,<2.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.15,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.45.3,<4.0a0
+  - tk >=8.6.14,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 36116799
+  timestamp: 1733935613200
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+  sha256: a0f008717fab060ccd003dfebc09156d90b9afd14ac3626566aa1a8f3d3b7e2f
+  md5: 357bf4fe94496cbae72ab4d780184b31
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 330924
+  timestamp: 1716495762901
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.20.0-py311h06a4308_0.tar.bz2
+  sha256: 8e42421bb620d1e12ab455da3594c2129b0a6d994a0be6a1e4519d1d3ead360f
+  md5: 99293d1a98a94e2b11c5d598ea2d80a8
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 281088
+  timestamp: 1731939500285
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-3.2.1-py311h06a4308_0.tar.bz2
+  sha256: 0cb8b14ce460a6927a4b1e9c2b2737b8668f7bae47998c56d2e307706f72076f
+  md5: eb0b1081560d413b713603a3bdb9b0dd
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 28481
+  timestamp: 1734370110052
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+  sha256: b85acb933fff864bfa89d034e8e3d85b1a9c2e69cbfc0d68c1d66ffd1443e67d
+  md5: 0cdb92d2d684ee1095310f992ed0d9b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 266796
+  timestamp: 1713974338678
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+  sha256: 511e8206a15445715b80be76493300930686b3fe1e512ae942d6ccca36df392a
+  md5: 35a6e46ae970f8b71d78fb5a810f2e80
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64013
+  timestamp: 1711136926372
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py311h5eee18b_0.tar.bz2
+  sha256: 132aa25ee904333ef338eb1935dd8e5ccffb27cacf33fdb58c1358ec22424933
+  md5: 92ce34b6f4f7a6e64c80c2ba0a96edf4
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 222337
+  timestamp: 1728658052191
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+  sha256: 7c74db4292f31619606180f86f3c1e2d913495c2c9d1195c5d51681a6a841625
+  md5: be1c05fae57d194924b9400f9b5ad3c6
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 613277
+  timestamp: 1709318516682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+  sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
+  md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 467661
+  timestamp: 1666648052561
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+  sha256: 89c2f4235277b9825cc805c5c44f0b1afcb683d7b5a3f513bc4bf243b643bb0c
+  md5: db70eb57e33adf7b8bbdadd72214d48d
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 73679
+  timestamp: 1699012111499
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py311h06a4308_1.tar.bz2
+  sha256: 1ac5ee93110e2f7f1d68b6c985e4adcc3710f537c388ae3ff4f85059288070a1
+  md5: 4385913efbeb323430797aa3b3506525
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 123440
+  timestamp: 1730999231468
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+  sha256: fdae3f68ea84b99561aee6c566ab1c287d8f2ae2668424e9283a8ed86af8f1d2
+  md5: cde5b71ccbb3630053340b2c8c7dbf10
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9333
+  timestamp: 1683077183576
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+  sha256: 0bf859b06a07857099fd4f524fe5e0875fda70029e9485d95c7efa97134fbc14
+  md5: fd5815cc592fdbd4c831901541eadaba
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 9735
+  timestamp: 1683059096795
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311h4aa5aa6_1.tar.bz2
+  sha256: e65d6513d86339932493ba017a6108b64a6051c7a2ae4d920b98d4eaf8872b53
+  md5: 73dd6ee25b6b39940f80a90ef7cd87d7
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 340692
+  timestamp: 1732227820782
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+  sha256: 51bcea0e575a626f6ffbd16d1153330fda93dbe3dd31dcd3a8f469ff61dd1e4e
+  md5: 41d531c90be8c82bf79635ff3d409476
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 32295
+  timestamp: 1699371262818
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-72.1.0-py311h06a4308_0.tar.bz2
+  sha256: ba9fef2940e2737e5f351f2817d918ea1688138e19a6dadbf17f6961d481dd74
+  md5: e19eae321026b92ff3a27208430735c4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 3308302
+  timestamp: 1722860116537
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+  sha256: 1a84b00944bc5588e14a097460175f97df49acb4f1ff2498ffd9a1893068ed81
+  md5: a456513471b2ecbed60430c21dd1ccc7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 17880
+  timestamp: 1705431390054
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+  sha256: adcafd297d60af64107c113bb7b8b92160d0268a44ef9a3b79e56a88a0358ea7
+  md5: 28ed704ed26b06d32662e3a6a87e59b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 88799
+  timestamp: 1696347581401
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+  sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
+  md5: f86119b3243fe3508160aa0406245738
+  depends:
+  - libgcc-ng >=11.2.0
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1723866
+  timestamp: 1714488309729
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+  sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
+  md5: 041a3caf09dc9ce8fc6c10925c4fe050
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1888016
+  timestamp: 1680167274961
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+  sha256: 856a8ab8c350c50247b79966c6cb80fb6d4de36eef49ddf75aebbbcaf854c82d
+  md5: 442dde204d14d171aab9ee40e8de4de8
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37456
+  timestamp: 1677696176157
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+  sha256: f0a026ddc0ed041bfc60c8a1ca0b70b7a69232775b3181bfb35a39fda42d6994
+  md5: 2902d5a5854865baaaf58dc59cf06b3c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49185
+  timestamp: 1676823769869
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+  sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
+  md5: e2512d57c8a1e91e7b20e265c6906546
+  depends:
+  - libgcc-ng >=11.2.0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3588922
+  timestamp: 1714770676475
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.2-py311h5eee18b_0.tar.bz2
+  sha256: 780986d79652f3f4eec28d8d9cdda134a1eed4aee302a66483ebfb8c5dbef877
+  md5: 5c580c8870055c1a563959f98142f836
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 915944
+  timestamp: 1733960601134
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.5-py311h92b7b1e_0.tar.bz2
+  sha256: dab820faa313d62b44014841409cef89a49dbda9a7697689ce37b3032ec3276e
+  md5: 1d6513a5b915465291fdb2041815bdc6
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 154437
+  timestamp: 1724854032868
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
+  sha256: 2091b17ae4fa46ed98fd6bfe9ca1aff3b0b81d73045e0cc55774b6516b8704b3
+  md5: 183ae7b837c1c68ec1a8011011fadea7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 206924
+  timestamp: 1718227183177
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.12.2-py311h06a4308_0.tar.bz2
+  sha256: 48850864a536279a44c8e4b5eaf5d7d0b424df752374fb5624f2c3ecc8b8bc6d
+  md5: 0f1d42f3ecfa42bbfe56e32d902fb88e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.12.2 py311h06a4308_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8924
+  timestamp: 1734714943753
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.12.2-py311h06a4308_0.tar.bz2
+  sha256: 613ddfe5f4e9f2cb37f63a58a2c1d8527e4f19b5758429752733ecb919ffd2c2
+  md5: db0f11a0de3083f9288c7d3a054f3887
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 81460
+  timestamp: 1734714938116
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+  sha256: 509b962773f0fe44a93a7f6196b254670a030eac8ea7f90727312e3ccd9294b2
+  md5: 6c402d5bf4e01c8c3895c9ef41707b6e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11371
+  timestamp: 1676828901104
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+  sha256: bbe7629e8ce52c82f13ed0d1fb919f3659ef466b274a7c74aa925a9bc7aee450
+  md5: 7da527bbcf71270c1abed8ea52e7d44c
+  depends:
+  - libgcc-ng >=11.2.0
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 509031
+  timestamp: 1713213062098
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.3-py311h06a4308_0.tar.bz2
+  sha256: 42eaf6a7ea875b236796f58e9f06919fda206ef6a4884ce943d94aa7747ad290
+  md5: d1a78c6d9003bf2ff1cda53bde67c1f5
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - requests >=2.26.0
+  - selenium >=4.4.3
+  - zstandard >=0.18.0
+  - h2 >=4,<5
+  license: MIT
+  license_family: MIT
+  size: 217451
+  timestamp: 1727769856880
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+  sha256: c3a5e0b855dc2de6c162708dfcf170a23eb9e7525d4252d8dce553369af4a330
+  md5: a4c77e204b7787f820955166a1283168
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25890
+  timestamp: 1676823132898
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+  sha256: 42989f9970a8466cc4edb73463dfa194594dd1a5d42c9f820a1f86296d4af140
+  md5: 655dfd4d2f17977cb81caa1c082d2b25
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 113505
+  timestamp: 1715878346465
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.44.0-py311h06a4308_0.tar.bz2
+  sha256: 3b258ad0db82572157a72303bbd5c20399d0c7f3b48abc1435ef96e4517e59f7
+  md5: e11eb90c0ee1084a95cffe231196d98d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 138218
+  timestamp: 1726165052578
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+  sha256: d18cdca154bf668826f869117ea996c4f9e8ef7d27b7c528332a7d17e5a8602c
+  md5: 9f7353d72046b16dd6ef6b5689ac9bfd
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54731
+  timestamp: 1676828934954
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+  sha256: 9122d6e9dabb7a47f2bcb15d86b97c96c49a9048da3f8ae59675351710c14cc5
+  md5: 660b2aead2ec87b751c86cd33934f44e
+  depends:
+  - libgcc-ng >=11.2.0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 716926
+  timestamp: 1714510796277
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+  sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
+  md5: fcff4f33bb4e3fa91f8d5c3168807abb
+  depends:
+  - libgcc-ng >=7.3.0
+  license: MIT
+  size: 88839
+  timestamp: 1593116114710
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+  sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
+  md5: 943f1247a22b6b64171363bcee1eec27
+  depends:
+  - libgcc-ng >=11.2.0
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=11.2.0
+  license: MPL-2.0
+  license_family: Other
+  size: 371663
+  timestamp: 1705602144682
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+  sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
+  md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
+  depends:
+  - libgcc-ng >=11.2.0
+  license: Zlib
+  license_family: Other
+  size: 127143
+  timestamp: 1714510716441
+- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
+  sha256: a65c6277a3045e4ea72f617f977134c18366d8142ce51512f5a3cf325226a8bf
+  md5: d941bb6fdc55cc1b3f67b3beb23d1795
+  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1081416
+  timestamp: 1728487031624
+- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
+  md5: 32685aa840f6868407a3150184ebbf90
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.6
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 15512
+  timestamp: 1645000255221
+- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
+  md5: d9c6faf4f1a52c664ef1343f464e45b5
+  depends:
+  - python >=3.5
+  - six
+  license: Apache-2.0
+  license_family: Apache
+  size: 21573
+  timestamp: 1646925670610
+- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+  sha256: c0dd89ffac001588171152a285ddbbaea209ebe4116010f985f898b7e87c2f35
+  md5: 731ae7d446633bc729f3493a52d4365b
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  size: 43502
+  timestamp: 1721748373551
+- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
+  md5: dfb0ca8055c9a72aaca7b845a6edea17
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12592
+  timestamp: 1637851583560
+- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+  sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
+  md5: 6072a09eeab81c07c98065234e46af1e
+  depends:
+  - python >=3.5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 11936
+  timestamp: 1643638345485
+- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+  sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
+  md5: b9280feeee8d845ba495a701bae72de9
+  depends:
+  - python
+  license: PSF 2.0
+  license_family: PSF
+  size: 24190
+  timestamp: 1615228158573
+- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+  sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
+  md5: 1bdd5a02233d229e76081a73659e9405
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 18210
+  timestamp: 1646925120076
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+  sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
+  md5: 2b7ea8318bc62d9e504ea43409ecd7c1
+  depends:
+  - python
+  license: BSD 3-Clause
+  size: 27342
+  timestamp: 1606773472974
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
+  md5: 0cb9961d77df143d6d65580d713aade1
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11684
+  timestamp: 1643405489166
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+  sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
+  md5: 5122a68ef2c53409eda11f07f1c3d7c7
+  depends:
+  - ptyprocess >=0.5
+  - python
+  license: ISC
+  license_family: Other
+  size: 52491
+  timestamp: 1605563236879
+- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+  sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
+  md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
+  depends:
+  - prompt-toolkit >=3.0.43,<3.0.44.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5106
+  timestamp: 1704404390460
+- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+  sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
+  md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
+  depends:
+  - python
+  license: ISC
+  size: 16774
+  timestamp: 1609355038155
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+  sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
+  md5: 8be7529b5e573e3cbc6df277b9950109
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 14248
+  timestamp: 1646925118814
+- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+  sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
+  md5: e70944ff53d19af4f65073a4f21c7b05
+  depends:
+  - python >=3.6
+  license: BSD-3-clause
+  license_family: BSD
+  size: 96720
+  timestamp: 1636541382349
+- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+  sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
+  md5: 02caf3f47f1d06256068053297355740
+  depends:
+  - python
+  license: Apache-2.0
+  license_family: Apache
+  size: 152292
+  timestamp: 1690578151230
+- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+  sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
+  md5: 0a3ab834ba49016e183e715bff48a2b6
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 19160
+  timestamp: 1644875974931
+- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+  sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
+  md5: fa3edcfd4c2c0d744bc177cbfcd77626
+  depends:
+  - asttokens
+  - executing
+  - pure_eval
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 21658
+  timestamp: 1646927641146
+- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+  sha256: bf3130b8c44a7e9bcd496f515d0ee4b2e788610f468bafd708d16d007cb47332
+  md5: 48f856789d224eae8d1979c212205fde
+  license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
+  size: 123651
+  timestamp: 1728062827250
+- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+  sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
+  md5: 98982290b7b7eff532ec6dead415172b
+  depends:
+  - python
+  license: MIT
+  size: 34378
+  timestamp: 1629357209371
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.6.2-py311hecd8cb5_0.tar.bz2
+  sha256: 10c81c3952bdf1073713a33f65f538082b2f6de47c4dff3cf173a18e4f014e7a
+  md5: 87d1d76e942262c2c7c39370e30d7b3b
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.21
+  - trio >=0.26.1
+  license: MIT
+  license_family: MIT
+  size: 244917
+  timestamp: 1729121433463
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+  sha256: ab7672364f1fa55ec5d8311d85d40e5b57cbd3517b17670557b6fb822bcf759c
+  md5: 6e0159a5865cb7e96a748bd8560035ee
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 11579
+  timestamp: 1678317458652
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h46256e1_1.tar.bz2
+  sha256: 3f2344b378e912596a7b66e66e35833e7c20544446f7b19f25f4b500e5441a3d
+  md5: c7914de4b54fc22e1b419b5c5426281e
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 34877
+  timestamp: 1736182638965
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 5543d56ca11cc3aef4c889d8824a798bc4418b82265f43bca53077724c7ed1e9
+  md5: fe9dd468243c6b0fbd5d55cc5c2a60cb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 163936
+  timestamp: 1734533359828
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
+  sha256: 365824e639808e52809f97b70b65da94a5eeb87e29dd97c8926aa72707a5a1c7
+  md5: db7813418dfe42d59363fed4a68d5c36
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 278195
+  timestamp: 1718029905185
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
+  sha256: 695ac69739e73351dfebfb01ea39c5e1dbfdcfb475590d6560ae318bfbad3a97
+  md5: 38fd73cba341639c45d8c747b08c9cc1
+  size: 49130
+  timestamp: 1528225884020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bleach-6.2.0-py311hecd8cb5_0.tar.bz2
+  sha256: 7c36e9cb426d000a95c25bfbe5bfe627bf7c7954bb6726b2480e825ec6c41164
+  md5: f97fe0299b63520bab00b5bdf52272fc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings
+  constrains:
+  - tinycss2 >=1.1.0,<1.5
+  license: Apache-2.0
+  license_family: Apache
+  size: 371442
+  timestamp: 1732291870573
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: fb5f53ec43d4ca92f433a556602a0347038856b5cdbcb2f0014b5445caa1b7a8
+  md5: 48f6989f8490bacc7ef44814c3ab7635
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5869515
+  timestamp: 1727914551902
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.4.2-py311h9b7fc35_0.tar.bz2
+  sha256: 2db3c754dcd7b5f87f8e9384509f539b3c9a80e7c26279c050814258e712a223
+  md5: 24af5157264705bc3358ec195490de59
+  depends:
+  - numpy >=1.21,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 156491
+  timestamp: 1731059250255
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h46256e1_9.tar.bz2
+  sha256: 80e274edf9502558321d8688a99dc6ce2a05c6b291ebe37324459465d8d6e229
+  md5: 4701bdd9441b09ad3cc9c0b766762940
+  depends:
+  - brotli-bin 1.0.9 h46256e1_9
+  - libbrotlidec 1.0.9 h46256e1_9
+  - libbrotlienc 1.0.9 h46256e1_9
+  license: MIT
+  size: 19944
+  timestamp: 1736182824280
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h46256e1_9.tar.bz2
+  sha256: 19b2438beebdfe5f70587f50aadf01ae7c4650d241a07e26f6806b39834f329d
+  md5: 26e4981d811569c9d4b66758366e0516
+  depends:
+  - libbrotlidec 1.0.9 h46256e1_9
+  - libbrotlienc 1.0.9 h46256e1_9
+  license: MIT
+  size: 18691
+  timestamp: 1736182810077
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311h6d0c2b6_9.tar.bz2
+  sha256: c6ff30f54a4448526a1f2c9e5e4835e0416104c41e5b61bdbf6ff310a675641e
+  md5: ac04cd8733681fabf6202b9d12a28235
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 394189
+  timestamp: 1736182987784
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+  sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
+  md5: c5a600d81b1b48578863af2973c743ac
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 187637
+  timestamp: 1714510590009
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.12.31-hecd8cb5_0.tar.bz2
+  sha256: 651569faa1282d4fe48fcbfa8776c49f671b6e36e856050007bd56dd0401abb8
+  md5: f23596dcfc737eb88e15a1113e092a7d
+  license: MPL-2.0
+  license_family: Other
+  size: 139293
+  timestamp: 1736360403971
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.12.14-py311hecd8cb5_0.tar.bz2
+  sha256: 738ee1189e5b0b7e21bd24de15a7332d733abc1d22f46257cbd89dcb453a26a4
+  md5: 1a4b3a732f4250b5c03ded46d7d30357
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 168308
+  timestamp: 1734473349417
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py311h9205ec4_1.tar.bz2
+  sha256: d93f07c0baebe21d32298a5e4e6d59ec01aa8730628d3e586a099aa75baec0dd
+  md5: dffa026d960d5042574e76c406c7b319
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 293192
+  timestamp: 1736183432113
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: 9270668e34b00a2605584a2db5130c83826855cd05b896ce949f3156fa197429
+  md5: 2586aa55677e822e8285d777f9039ca9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 543487
+  timestamp: 1709758497949
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: 389c63a84b92a6254c9d361ebe970d537d0b88733efd5ac5c3ee58196fd2c5a9
+  md5: c7bc5b3cbe76be83a27f00b7e4740727
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17974
+  timestamp: 1709323004148
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.3.1-py311h1962661_0.tar.bz2
+  sha256: a8433ccc2ae0f5a69a2795cc9a124678bc25dd99d23c697280394febd0ce1683
+  md5: 9dd4588e1973ae233a3d227182e6c709
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 301973
+  timestamp: 1732540462617
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.8.11-py311h6d0c2b6_0.tar.bz2
+  sha256: ca52a2c3bc6ade8a458b1d0f0e5f0637cb715add74480c6061df52658765fa25
+  md5: 7728392984085b5bd2550360b608df0d
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2786928
+  timestamp: 1736267811270
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+  sha256: d48b47b86b09dac1fa4542ec13e1bd4e23093638e684fa66ec3afdd9ce9337c1
+  md5: 5a2d1828ab7c8eccd3c2610d13672977
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17336
+  timestamp: 1678316187749
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+  sha256: 54645c22fabc25b632114d1d3c403a6fad9149b51ab36719b2690a084f14a072
+  md5: a8ad2f4abfb2e17ecf6e596342528156
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lz4 >=1.7.4.2
+  - uharfbuzz >=0.23.0
+  - lxml >=4.0
+  - skia-pathops >=0.5.0
+  license: MIT
+  license_family: MIT
+  size: 3180691
+  timestamp: 1713551771692
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+  sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
+  md5: 9a52880a01116b72d3e7b98d685abf67
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 924929
+  timestamp: 1666798304003
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.20.0-py311hecd8cb5_0.tar.bz2
+  sha256: 60fbaec8c8ddc4ac235a4c8143a1d734e34c0543ba20985973cb43a9220262c9
+  md5: f781135af3dde8699b5b3cf9bfe83b3f
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.1
+  constrains:
+  - plotly >=4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6129648
+  timestamp: 1730828256779
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.11.2-py311hecd8cb5_0.tar.bz2
+  sha256: e411b00b35edd4c57b15aa55807c1edbf0ef26e8c7452827364b50ea40798052
+  md5: 6696a322de6d7ac72287c210100fe2ad
+  depends:
+  - bokeh >=3.1
+  - colorcet >=2
+  - holoviews >=1.19.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372947
+  timestamp: 1734469892069
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+  sha256: 5c2458964157fe493ca18c513c693b70cb622087e5fa0c93e65fc45217edd811
+  md5: 15629e52625221b51a443cefd9501d12
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148522
+  timestamp: 1714398885844
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py311hecd8cb5_0.tar.bz2
+  sha256: 4772db5a35dfbdabf55b01943916d0a5b451db757aa38372571bb3e03948527a
+  md5: f6b4cd61684c3ec067cbda883fca865d
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 240267
+  timestamp: 1728665688908
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.30.0-py311hecd8cb5_0.tar.bz2
+  sha256: 69fe2c100148f65f721bc791004000aa1e6a96cce9271f2c52c6b273f626d208
+  md5: e82a62e5327d2ad85d2456e675487b6a
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1640008
+  timestamp: 1734551073802
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.2-py311hecd8cb5_0.tar.bz2
+  sha256: 40f655b062710295113369c5c236ca3f0b281fd2b91959cffd02f20aa9dbfd57
+  md5: c6e3b63c5b90d3a422ca100f5a233a10
+  depends:
+  - parso >=0.8.4,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1193759
+  timestamp: 1733987587898
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py311hecd8cb5_1.tar.bz2
+  sha256: f0610ceaac87ce39266f4dee8185244668ac9345143c9eb22c4cb201b79aab00
+  md5: 2d4759abb2b7a3de114fdef7bb241474
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 354673
+  timestamp: 1730902923439
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+  sha256: 855982a798d9af8e70635a250528a5da3b2b0cf7095e2804858caf139c8a239b
+  md5: 112a5602fe42a84a5bafa038abeddf4f
+  license: IJG
+  license_family: Other
+  size: 279686
+  timestamp: 1722872676718
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.23.0-py311hecd8cb5_0.tar.bz2
+  sha256: a899e7bdac6b9b734882ee44a8065d7006dd669fde9b0fb0a88ed2e2f77ec357
+  md5: 14a0abb1c37f2e37c0e55b8feec8d564
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 193788
+  timestamp: 1728487044949
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 0ea44d0c8044e70ab0eaf4d6f5f3e4753838dee106b5cbd36561e21a65cbac77
+  md5: 1d045016dca889d702f1caf3a16162fc
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16528
+  timestamp: 1699032525791
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+  sha256: 70442ec4b0b7ebbdcf150963f61f797b861001092124f4ea39a16eb92a4d176e
+  md5: 63d1503915a15ae4f9ad1c46112ca374
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 272720
+  timestamp: 1678316970740
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
+  sha256: e657ec0667481d957827be1ce825b0a971aa3a211b07c1274d2c1099ded3129c
+  md5: 5e317fd45011a0003c29331a8002cb75
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 98632
+  timestamp: 1718818439542
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 2634d721123ea1e41b6e1cfe4a67552ec520ea9b5154c9e788ccb09d4745b732
+  md5: e874eba19b493b7a68161429f24b8f51
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43102
+  timestamp: 1718738272613
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
+  sha256: c353480ed4744c2a16aaccc1649bab38144436ad6d16ac2937e3e333d32fdccc
+  md5: 7de25bdf4cfd3f5485d790d9cddf427f
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 619935
+  timestamp: 1718828240904
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+  sha256: fd7964657f0a8fe8b167ba860b1f960e8b7b45309eb6c7c850d50ec283fe03b5
+  md5: 2967bb345bc75f53182e263ff4743ca6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28223
+  timestamp: 1686870845224
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+  sha256: 64cf59f0f74b0329b5069bc6135b4f40593f1dac52d85ad574d4b8e0a4b2cf16
+  md5: 35e8b80eaa03a904fc7f1da39e7f654d
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20234
+  timestamp: 1700168776500
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+  sha256: a12382b50416803f559a03fb384ba492c1dafa351e1191a3f8dc361bee6c4f37
+  md5: f2ae846b663bbb642f4b1e90eaad38a3
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 64817
+  timestamp: 1678322501509
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.16-h4f63f0c_0.tar.bz2
+  sha256: ca7970616a49595aa2ada83fd1ab5f5318fc3254d21f66e946cfd9f1c6b5188b
+  md5: 851fa57e5675397c0e724987f17a3f3d
+  depends:
+  - jpeg >=9e,<10a
+  - libtiff >=4.5.1,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 264025
+  timestamp: 1734428532705
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-4.0.0-h6d0c2b6_0.tar.bz2
+  sha256: 50da46ac4a032a38d2d9e714e945079e05a46ae451437a52ad09b4cd5d925f5b
+  md5: 234c885b9f326ecf78b5294fb709ddee
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 295348
+  timestamp: 1734423413199
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h46256e1_9.tar.bz2
+  sha256: 8f058b4b23c8d56f8411c8f6eec834ea30e8a2ce7a98685ad9c2a4817aabae4a
+  md5: b64809b5c2030ac3e571c9f6b5b34335
+  license: MIT
+  size: 66530
+  timestamp: 1736182753663
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h46256e1_9.tar.bz2
+  sha256: 6269fa97423611d7310bb23d6929e1fee3246a10440cd931718d4d447f6d4215
+  md5: 23d3558e675675ea0281bbfcac49453a
+  depends:
+  - libbrotlicommon 1.0.9 h46256e1_9
+  license: MIT
+  size: 34461
+  timestamp: 1736182772158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h46256e1_9.tar.bz2
+  sha256: 738524a5398e731ba9c74b799bf5e972721af4a4dc6a5425d2e17780e3e15912
+  md5: b562c3b15ef8b86391171d2f1b85cae6
+  depends:
+  - libbrotlicommon 1.0.9 h46256e1_9
+  license: MIT
+  size: 311811
+  timestamp: 1736182791956
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+  sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
+  md5: af92f506156c9defc9b4dff41ecea1f9
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1391293
+  timestamp: 1662620489455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.22-h46256e1_0.tar.bz2
+  sha256: 5267b5015a03aa90883f57b3cc5dda014082e5ab88e2d3b30fe809c37b96094c
+  md5: a6bdcc6561a095bc0ac11482e84c37c8
+  license: MIT
+  license_family: MIT
+  size: 84141
+  timestamp: 1734423352364
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+  sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
+  md5: 822a5b76117e56d3912f1f2153307528
+  license: MIT
+  license_family: MIT
+  size: 136045
+  timestamp: 1714483561919
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+  sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
+  md5: e458587c87e3f2d20192f4e0738f2c63
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 149419
+  timestamp: 1665498987619
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+  sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
+  md5: 1058b661ec829b2ee3716ee2a5520641
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1917987
+  timestamp: 1665498925405
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
+  sha256: 499ebc9000c8e810081b5d7f7524b45dc99f6914096ea9e145366033514938b4
+  md5: ce5c24f93932e1a53d7d89e502f28783
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran 5.*
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10123989
+  timestamp: 1664896966769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+  sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
+  md5: cc2688c4d0b91033ee4d9064bebfcf3d
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: Zlib
+  license_family: Other
+  size: 318453
+  timestamp: 1677841804115
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+  sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
+  md5: b622efec408361995816c7ded7b5625a
+  license: ISC
+  size: 365163
+  timestamp: 1581701250028
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-h6fa9cd1_1.tar.bz2
+  sha256: 82d2f89ec9f2b0769c0368f7f0734a405e3fb12bbdbefd3ec13b478bf6b2b699
+  md5: 2a4899f52b1a65d18dfc2af0ea3d5177
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.22,<1.23.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 668404
+  timestamp: 1734425846576
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+  sha256: 246c0d82766042c1a9194eecc71690918c68afa3528ff0c2c82796ce901df40b
+  md5: f33be4ed3bff89ed8f68df6c75158510
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 449215
+  timestamp: 1729160070984
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+  sha256: d28c465ec6d5f8d4962c597b249b58998300c8b4e3c937c578c3d15294ea863d
+  md5: dcaed6ddd0723c7cce6bfad917be98b2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41176
+  timestamp: 1678413498410
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+  sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
+  md5: 5c740b4a18a558de0ccfe601703c423c
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 338738
+  timestamp: 1662635677689
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+  sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
+  md5: 8f57dc3a3327bb6f7e1cba908856ac7f
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 183138
+  timestamp: 1714510756758
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+  sha256: 6fb2953e169ee1ae38f24d29752051501992f19b96b5ebcea9af75737bdbcb42
+  md5: 7f410cdae838c5030108d1b98a8c78f6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 162478
+  timestamp: 1678377892595
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+  sha256: cd97e09a12ffb49b2a30a782fa8c7933b28f5ffdbfc5c73a9ebaa95fc9447370
+  md5: d1fb6ebc1e5728aa6377cfc71da08942
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135859
+  timestamp: 1684280005320
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h46256e1_1.tar.bz2
+  sha256: b266e4d6161bae908a36e9c0ed5e1be0fe468a661a4fb83a35cd7dcfeb17b787
+  md5: a81fab1a743f220322e1317d42590780
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26841
+  timestamp: 1736368702229
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.10.0-py311h919b35b_0.tar.bz2
+  sha256: a02829868777ce746dafb37da1a234c212d11ed8609c13e8fb837e5cc0b82116
+  md5: 4d13f50eb1cda9f81858fd11ded08720
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23,<3.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9826780
+  timestamp: 1736279748306
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+  sha256: 07e7fd5bd64e55328b4b99d92e2e2600d791f1095bf905daab4cfc59f0f0a45b
+  md5: cf53321779f4ca7e986c1468719b93f1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19500
+  timestamp: 1678317565001
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0770e02be1ea1216af493cfc03d5b8a702e14606fa93b0692bcdab1fed1b898c
+  md5: ca6f06ceaf66a32bbf5dfdb6e373a5cf
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 67892
+  timestamp: 1678417734353
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: fbe95ed0501bb0f137048476fe41bc718dd659e8ecb066bc67ac17d6a50f4318
+  md5: ec162bde8d1c8a107b257df218b17035
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23030
+  timestamp: 1678381838497
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+  sha256: c20dd678655e582129a858a1c5162bdc254082d3a3c035b0f72629d9276e5b75
+  md5: 800a0738c728796e02d0386ce7d457aa
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104585
+  timestamp: 1678317269407
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: f961b1322b6b02fee53ff9bd0f56bb73886eb59debd3f3666669593de7f48894
+  md5: a1e74ccd2f341d1d672e33d79e60d200
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8183400
+  timestamp: 1717623127275
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: e08cb3ee6df01f4c1e1ac8bc4ed1a06e549ffcc8774fe2e2842c644bb8f74a86
+  md5: 6ba0ae0fb14cbea1e3197707701dc180
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123077
+  timestamp: 1698934356774
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.4-py311hecd8cb5_0.tar.bz2
+  sha256: 098d35939d62073df7fc42fadde9d9f7f646e4727382c363c02c136820555e80
+  md5: 25b1cce018e6c1b19146f117690d2b5b
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - pyqtwebengine >=5.15
+  - tornado >=6.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 533595
+  timestamp: 1728050041209
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py311hecd8cb5_0.tar.bz2
+  sha256: 3175bd2b744191da1c7477be8162a0f8d7f68363de8c2ab6df989908211ba17c
+  md5: 2508c1c6fc84c712ce0419470f60b5fb
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 171386
+  timestamp: 1728050190296
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+  sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
+  md5: 20344bea303e2aff2796ee9963c12c7d
+  license: MIT AND X11
+  license_family: MIT
+  size: 1100911
+  timestamp: 1674734102055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+  sha256: 42d803e1d8b54748db5d989ecd503826f564132df7cddc20f520460f55e523a1
+  md5: cd3fa71626ebc098da4625fc6be79752
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16952
+  timestamp: 1708532805951
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
+  sha256: 09d88f1eb19a90dfe737f0e5b4dce7629f6076a2d91d572cbb0a41be5220a4e8
+  md5: ac8c26d949a04f478b560b7d8a2358a4
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 707187
+  timestamp: 1717630829258
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+  sha256: ed5608feb37a083d47b04203195260e801b64b5380f292cf18bb61e7ad827a2a
+  md5: daa9c1c233673b727528548454aea664
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27607
+  timestamp: 1699456006797
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.10.1-py311hc59c7be_0.tar.bz2
+  sha256: 4b784353c86d73f10d714c039c29ca73508203cb86a7ce455f71ee52b940edb3
+  md5: a8c1b6256e1d5743bb92d9c467736aa8
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy >=1.21,<3
+  - numpy >=1.23.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 202114
+  timestamp: 1730216207054
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-2.1.3-py311h13f252e_0.tar.bz2
+  sha256: 139ecaa09c2daf21f93ea5a049b3e43fc11ae876e9ae143d0b7183446ae7fe1b
+  md5: 3a1c27218d2c14e703b8b77b12d444c2
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 2.1.3 py311ha745260_0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - setuptools <74
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11745
+  timestamp: 1730840497938
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-2.1.3-py311ha745260_0.tar.bz2
+  sha256: 6d0b66a3ec1ed61691d5a509e536eb93f90a64ed3d6633dfe2edec4368597563
+  md5: 40ac4bb60e0b39827f523dd5a6a732bd
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - setuptools <74
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9520946
+  timestamp: 1730840459245
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
+  sha256: 401214a4763c79c2355b012b9f29e3cee097a598bb53e933acb6b98a2bb6614f
+  md5: 3216c5f433643ee62a8d0672c3500320
+  depends:
+  - libcxx >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.7.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 535252
+  timestamp: 1722872704730
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.15-h46256e1_0.tar.bz2
+  sha256: 8cc69ca3f77c9dc8bed662100046085536c6a95b77b2a964ba79fc81ba3f698a
+  md5: 270474613701d2371d5c5cc220a78825
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4961721
+  timestamp: 1725545867722
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+  sha256: 8a0809f419065e014cb8e2c8a516cadca6088fb71fd1ef3ae2287d91e3360d59
+  md5: 4dc0b9bc88476fcc5246d823ff1c289a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39645
+  timestamp: 1699371213055
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.2-py311hecd8cb5_0.tar.bz2
+  sha256: 81f1c12808d6db7c1b26bace7b719fdfd45d7a683e46223c5d4b3843da957c39
+  md5: ec1eed2e438db9d3e9906d30d2ad55d6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 189794
+  timestamp: 1734472374591
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.3-py311h6d0c2b6_0.tar.bz2
+  sha256: 320127675235a15f36cd445ad7366ba64acd939ecd5bec5b6888ef365aed27a7
+  md5: c283b35da322fcba5fe94e69da4df242
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.2,<3
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - matplotlib-base >=3.6.3
+  - html5lib >=1.1
+  - tabulate >=0.9.0
+  - beautifulsoup4 >=4.11.2
+  - sqlalchemy >=2.0.0
+  - python-calamine >=0.1.7
+  - xlrd >=2.0.1
+  - pyqt >=5.15.9
+  - blosc >=1.21.3
+  - xarray >=2022.12.0
+  - pytables >=3.8.0
+  - zstandard >=0.19.0
+  - openpyxl >=3.1.0
+  - s3fs >=2022.11.0
+  - odfpy>=1.4.1
+  - pymysql >=1.0.2
+  - numba >=0.56.4
+  - xlsxwriter >=3.0.5
+  - lxml >=4.9.2
+  - jinja2 >=3.1.2
+  - adbc-driver-postgresql >=0.8.0
+  - adbc-driver-sqlite >=0.8.0
+  - pyarrow >=10.0.1
+  - pyxlsb >=1.0.10
+  - qtpy >=2.3.0
+  - fsspec >=2022.11.0
+  - fastparquet >=2022.12.0
+  - psycopg2 >=2.9.6
+  - scipy >=1.10.0
+  - pyreadstat >=1.2.0
+  - pandas-gbq >=0.19.0
+  - gcsfs >=2022.11.0
+  - dataframe-api-compat >=0.1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17297833
+  timestamp: 1732736229906
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.5.3-py311hecd8cb5_0.tar.bz2
+  sha256: da4c642c2c4d0265063a50cfc3e5437b422bb8e807934823f98e0ab23dafab40
+  md5: 7aade1ab52d00e6df57919c6cfeeb2e9
+  depends:
+  - bleach
+  - bokeh >=3.5.0,<3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.1.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing-extensions
+  constrains:
+  - holoviews >=1.18.0
+  - bokeh-fastapi >=0.1.2,<0.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24103145
+  timestamp: 1730381703387
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.2.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0639a95fc20308a04d5b1d67b7f8770013a0fb46d2fc605466036f7acbb22061
+  md5: 2c90142d5c3066fe79194fe084808bf6
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 272394
+  timestamp: 1734618667545
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/parso-0.8.4-py311hecd8cb5_0.tar.bz2
+  sha256: c204c097bc991a8ba9f459b710a690259c4c3fd44a8550b0f65f2f0a11a80cb4
+  md5: 5ce9f46a387e05dff118a050152880f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 225040
+  timestamp: 1733963549046
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-11.0.0-py311h47bf62f_1.tar.bz2
+  sha256: 326dcf1882d0d06b61afc4eed062baf300a98f8df73f01e51d06548d4f040a63
+  md5: 96764a87a531506df69ba564467394ee
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.16,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libtiff >=4.5.1,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 970786
+  timestamp: 1734430869385
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.2-py311hecd8cb5_0.tar.bz2
+  sha256: 492ea4d1c5a4f860f3312c7729f1e33b706007578c25c031241d7497a115dd79
+  md5: 835f4767cdb9d80338e0bba649c1ce3c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2923519
+  timestamp: 1723484652903
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+  sha256: 81719c31101d6c019150cedcc7b08adb3bdb357e8b2952e428dadaabc4dc985d
+  md5: 105825168e0a17fb007f60b5f314e311
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38405
+  timestamp: 1692205731769
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.21.0-py311hecd8cb5_0.tar.bz2
+  sha256: 74d50e1d381add9e02e4d4c9b0ae247f1c90bcc544cb622d6bf6c420ad17408d
+  md5: 3059b89ad8f6ed91166c87ef25349ca5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 122986
+  timestamp: 1731958894994
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+  sha256: e32843723b10ecd9badde28e1085419c0b59ed8a96c7cacce6395e39e3a874f9
+  md5: 5af0280a817d2c273304cd22328124af
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763044
+  timestamp: 1704404460779
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h46256e1_1.tar.bz2
+  sha256: d4711400167a76a91b3067d0982d135546e6479a5dcabe4a8087d4f16729b081
+  md5: 8b89db6f3680b3ceddfb37d3489a96e0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 503499
+  timestamp: 1736369694493
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+  sha256: dfb403f367c57327a4d080109df88383ecff18464de287a1ce936a7274e3656b
+  md5: 997b674bad89963af875b93b06807f51
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2120413
+  timestamp: 1684280057020
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.2.0-py311hecd8cb5_0.tar.bz2
+  sha256: d91145c8170d70c3343e3c72de9bbd65f18dd868699d5865cfd378027ed1d1e6
+  md5: be4e175b2ddfdde750cdf6f83fb694d0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 487468
+  timestamp: 1731445595709
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+  sha256: 717e038567506ca58ce1cd4a3416892d02f4ebfdd332077cc3d110cfe3d36c58
+  md5: 53bbfb400668f798eef6f8c7cf938e1f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 35751
+  timestamp: 1678315886516
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.11-h4d6d9e5_0.tar.bz2
+  sha256: 250c9769e378c2bc583c3c89351d3ea20e363825aa0c72e98a5c6ea3a1934a50
+  md5: bf4aaf980dd4941ab9a2a6e413d36c57
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.15,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.45.3,<4.0a0
+  - tk >=8.6.14,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16867465
+  timestamp: 1733935409990
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+  sha256: 04e100d0a1ea9722e24972657ec5935ad34c7c58957dabb821333e5eac80f717
+  md5: 2b6de49ad07b26e1f7084f0fda958eb1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332276
+  timestamp: 1716495830117
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.20.0-py311hecd8cb5_0.tar.bz2
+  sha256: 5f0b041239a0ad2b3888b944efd9cad94e92bcbc91f25eae80a7065c7446379b
+  md5: 0e26c390904343d308b6677403d8a8e5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 282407
+  timestamp: 1731939768586
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-3.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: 2aaaf300f4f747bd82cfb52e2ea8c581fe7a9548384b22e862625a1489f6263c
+  md5: eceb46e8d6370a13fcc8443feb798d47
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29626
+  timestamp: 1734370318805
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+  sha256: e358fe679e83ccdc8c433746ae6468e8e96d90d97d99530f8476ef5630b2c121
+  md5: ce30a0a31d891e69dc9b7bf8b7f0c39c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 268876
+  timestamp: 1713974360942
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+  sha256: eeb5a5eed93b8e311ad4d3f4389e050f11bba2eaec9536e1c3ed2f849c6c999b
+  md5: c18bd3e12de797d52a470c21a150dffe
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65270
+  timestamp: 1711136914884
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py311h46256e1_0.tar.bz2
+  sha256: eaba8d555ca65df57c5c1dfa320c6b222ddb2c428609a29765ea89179ff05a98
+  md5: 9a926091b8beee27d251241d227a646d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 208392
+  timestamp: 1728659514546
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+  sha256: aa07b90a7ee65f76c8cba1ff99a5cdeb95cbe41881ae951f64ffff06674a1b2d
+  md5: 58621e3d244137885f7dfbb35e50340a
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 594801
+  timestamp: 1709318510622
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+  sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
+  md5: e8977fc2e69cb52f8dbb1b676d04cc45
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 386061
+  timestamp: 1666648077019
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+  sha256: d784dc26c5de8e41845350a899e5779250b71f45d39e2aece62e739e9add7308
+  md5: 7b077b7f46112bb31dc066396c51d3fa
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74776
+  timestamp: 1699012164201
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py311hecd8cb5_1.tar.bz2
+  sha256: 022bc34ef458cf0f26cb2e94f3238618e72ca59489efb074d25e5a4700e53707
+  md5: 4f1d626c702cbb79e25aa92375049279
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - pysocks >=1.5.6,!=1.5.7
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: Apache
+  size: 124655
+  timestamp: 1730999183404
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+  sha256: 727fb8d957e02d03b928d049ffbc712316f176a2c331391766d646621b45655a
+  md5: 7e0e416c642f3ee4ddfb084a811fb4df
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10236
+  timestamp: 1683077214314
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+  sha256: a8a67143ccb65cfd6f50055176b6c26179a83130a45d0a12e79dd2de68d8db63
+  md5: a2065790f41e3eeb6efe0ef6daa75377
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10600
+  timestamp: 1683059285216
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311h83de92b_1.tar.bz2
+  sha256: ff1effe1a0558882611efd943822ca2d60dab801b6d643519a8a956fdd7f0424
+  md5: eb5880cb36e5b133f17a899acde434ad
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - __osx >=10.12
+  license: MIT
+  license_family: MIT
+  size: 308653
+  timestamp: 1732231060164
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+  sha256: beba0555707dac1e8484d73cee9e4128ac4b10e2a0d4209357481179022e8fdc
+  md5: baa8b304607b3a9ae8a3d9acb354c31c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33343
+  timestamp: 1699371216044
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-72.1.0-py311hecd8cb5_0.tar.bz2
+  sha256: e8ae4e9fd18d355497c67165d57ab11205c87a29a3f1ca3e183f999383dccf52
+  md5: c12aca7f16288ed88f100109dd6035e7
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 3292002
+  timestamp: 1722860295070
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+  sha256: 0eb44a16ef74a13ef7839209899d009cd94974fbc406a417d958c7bc8d955245
+  md5: 41f239a5b67b1daf819849023aa5d12f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19056
+  timestamp: 1705431379885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+  sha256: 14775231982e1ea150189c956927ccfb1ad01a8c9395cdeea4d5a48b9b8ce664
+  md5: 729badc4bf7ba8ccc70e0f9e58075c99
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89812
+  timestamp: 1696347694075
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+  sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
+  md5: 6bef1694163a68ac4c37e5857b8da4f5
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.0,<9.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1900191
+  timestamp: 1714488351925
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+  sha256: 3d5c2968f581006437df3932cd5d3c1c4afa78f0e13757b958440245d3248856
+  md5: 605ea221d225ad8e79284dbcfdab0715
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 37699
+  timestamp: 1678317755913
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+  sha256: ed059e32ce5a1c0511575f29d2fb6da12c54a37000bfa80f9e5aa9dfd9e04101
+  md5: 4d2261a92d25136a68b8d01d101119f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49145
+  timestamp: 1678317386284
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+  sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
+  md5: 523c006cc67c011383678c762015479b
+  depends:
+  - zlib >=1.2.13,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3594448
+  timestamp: 1714770737885
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.2-py311h46256e1_0.tar.bz2
+  sha256: 926f89ddb422d2868f65532d07637474578c27ddc90ef9202410f075fe310b95
+  md5: 1c4aad6b2e2e721689e4b7f0d24bbd9a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 916363
+  timestamp: 1733960657634
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.5-py311h85bffb1_0.tar.bz2
+  sha256: ec67885e979483932bf0ce9e720841d6f9d44bbc5a049f2e4a15232803f8362a
+  md5: 044460e02becd58190c03e794461acee
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 155741
+  timestamp: 1724854618448
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
+  sha256: 5283f2b23a6e9d888b2834cba2bbf284f551e199d2c1b4add176b1cbafb19ee0
+  md5: 58bf7871ca100fbda0492bb5a3363c80
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 208200
+  timestamp: 1718227205760
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.12.2-py311hecd8cb5_0.tar.bz2
+  sha256: 8022de54a1fbd9c3477536d96ac53f7fd5a32d8746f3993c2bc2bf5c5bcd82ae
+  md5: 3134d7e75b5c6cb1b98c1220bfc2924e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.12.2 py311hecd8cb5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 10063
+  timestamp: 1734714948797
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.12.2-py311hecd8cb5_0.tar.bz2
+  sha256: 1a33aba353b4c72ee219540fbaf361f575c7c6fe0259bfb8c453b9c61320beec
+  md5: b71aa2fc23e5979b7443d52ee91265ee
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 82779
+  timestamp: 1734714943158
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+  sha256: a9960485ced319ac91afe69eaaf703c7e6b3049f1e06a4a8c2818b64155943f0
+  md5: 0a9c8ea92a14330a07edabac249e32a9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11399
+  timestamp: 1678394892923
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+  sha256: d42ae57366d05e12f10074583568355752436d66ad018ffbcfa24135f593810a
+  md5: 1a98e48aa0bd8b3ec09e2cbdbb236575
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 498952
+  timestamp: 1713213079520
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.3-py311hecd8cb5_0.tar.bz2
+  sha256: 89314728453fa65647c24a1991a18f1105ed5da67c69dc42231d26a6bc96c42c
+  md5: 3c07406e5e9575d136d225c57159cec3
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - requests >=2.26.0
+  - selenium >=4.4.3
+  - h2 >=4,<5
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 218673
+  timestamp: 1727770118330
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+  sha256: 597015e8a038a111f03ffbc9a217fcda549d75230c86ce53c1f23c53d6f1a0cb
+  md5: 62e98aac883bccc1c87ca0d2ce2f08e0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 25798
+  timestamp: 1678317074170
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+  sha256: 1430e6f4b4dd9354b7bb88f7f7bc9cdbab26a034ad1ae5c278de0f5a99329372
+  md5: be0832862b29bf5767a707ac6bd53b93
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 114834
+  timestamp: 1715878445060
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.44.0-py311hecd8cb5_0.tar.bz2
+  sha256: 907fd39137318473d447c56d77f775c9d3fef5b4e840f8c43f50f8f9c016710f
+  md5: 2106db0f651f613ca1971e60afe3f5f2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 139423
+  timestamp: 1726165218455
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+  sha256: 5b6d5246955b5f9480ff7027eb002442a7ade24f5c354da54ed513042f76cedc
+  md5: f32aa8a37d5e65a8dc30f9a1f46bc63d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54719
+  timestamp: 1678325412288
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+  sha256: ed0152ad6b87ffd9e01f4a62bc358e805ad59637f898a801b0a9cf903ae8e1fb
+  md5: 8a92f8c663608f24e14d8a2068b9d83a
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 415323
+  timestamp: 1714511993944
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+  sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
+  md5: cbfabc8518e50cc4726b86d1d8b6400a
+  license: MIT
+  size: 87049
+  timestamp: 1593116269220
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+  sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
+  md5: c25b6d40f834647d0bbe767f6c776031
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 329449
+  timestamp: 1705602140856
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+  sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
+  md5: f2519b551f99765d9d98950c5e2b4713
+  license: Zlib
+  license_family: Other
+  size: 119782
+  timestamp: 1714511811597
+- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
+  sha256: a1f470eabe211500d2ec7866ecf421c067f159045f0245f19e9ba8272c5a177e
+  md5: f8bd5fb9fac17a47c64ae56355faba24
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1033188
+  timestamp: 1728487057684
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.6.2-py311hca03da5_0.tar.bz2
+  sha256: 8d925b1438e14479c33257054daaf3acab8db996d49fc1f57f9a675569a90493
+  md5: 7277b32d35b11efb43245178c3f99fb4
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - uvloop >=0.21
+  - trio >=0.26.1
+  license: MIT
+  license_family: MIT
+  size: 245764
+  timestamp: 1729121361882
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+  sha256: 43405cc7341ce3efb2e24013ad62c64f26a69926635adceaa5459ccbcafb3776
+  md5: effa6d22f497e164cc8455f7f329c304
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 2-Clause
+  license_family: BSD
+  size: 12510
+  timestamp: 1677917870614
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_1.tar.bz2
+  sha256: 34eff2dd23f43b16903603d5a629e65d0da4f4c3556bbdc4e81c54ca4f2287b4
+  md5: 1f421ad5db9e7301fb935e6f0328dea2
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 35693
+  timestamp: 1736182683157
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-24.3.0-py311hca03da5_0.tar.bz2
+  sha256: b21a439235347e2b0ca4fc059c7be459ef3597a141138dd8ca5004877a1dd86d
+  md5: b5c410a1799c550d53e5f11219819850
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 163887
+  timestamp: 1734533146293
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
+  sha256: ae3c6633ed84bac16592b3b756f96ffc577414971014ca9efa498a162588757f
+  md5: ea600f99d012d734f831d1bc00a17661
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 281227
+  timestamp: 1718029919645
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+  sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
+  md5: 9a229bd94ce6f3045c9ffa953c602fd7
+  size: 10252
+  timestamp: 1628529248300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bleach-6.2.0-py311hca03da5_0.tar.bz2
+  sha256: 557a8b96a55bd208098771332ba46454d76f4a864679d1d4cfe9f7533db4eaca
+  md5: c0e11382888896052023f0f8b4ac242a
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings
+  constrains:
+  - tinycss2 >=1.1.0,<1.5
+  license: Apache-2.0
+  license_family: Apache
+  size: 370511
+  timestamp: 1732292237553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.6.0-py311hca03da5_0.tar.bz2
+  sha256: 2504fa4295015f621e607dde7a42efba5fec71bf691785ba8e2f86e72df19e88
+  md5: c961dda50ad88ee093645de69e768a4c
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5908154
+  timestamp: 1727914592573
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.4.2-py311hb9f6ed7_0.tar.bz2
+  sha256: db1a051d5329611e3e0fab1ea11b2ec06ae511e6c34935738a701ac2ae2fcf86
+  md5: 14b2ca28694689fa950ae434e4390224
+  depends:
+  - numpy >=1.21,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 135731
+  timestamp: 1731058941306
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_9.tar.bz2
+  sha256: 590fa74213a250f8ab4e3249cdb214c34f93121d249c413b201ff92b10c70ff6
+  md5: 9de7e158b8e00fbc39af88efd56be8ee
+  depends:
+  - brotli-bin 1.0.9 h80987f9_9
+  - libbrotlidec 1.0.9 h80987f9_9
+  - libbrotlienc 1.0.9 h80987f9_9
+  license: MIT
+  size: 19988
+  timestamp: 1736182733370
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_9.tar.bz2
+  sha256: 6e11a01df09bb5213eeb65c3347b45567a972c2557a27c2d8f76c7fa792a5c45
+  md5: 6b9fd6a4720fdbd87280ccfb063b9684
+  depends:
+  - libbrotlidec 1.0.9 h80987f9_9
+  - libbrotlienc 1.0.9 h80987f9_9
+  license: MIT
+  size: 19371
+  timestamp: 1736182689529
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_9.tar.bz2
+  sha256: 5c439398dfaf525e3183dd04df18dede76ee247feffe3ca0103d8506b3785cd4
+  md5: 316001829060774b502831c8abf6b634
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  size: 380565
+  timestamp: 1736182939936
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+  sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
+  md5: 56d1386c7f1f338f0d18f82af6525273
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 158748
+  timestamp: 1714510571033
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.12.31-hca03da5_0.tar.bz2
+  sha256: 45e4b0988896cdeb75f075f3be015d833de761b869bde21794447b6569ad6398
+  md5: 6615c8afe0cb6026dfc8ccbe87feed35
+  license: MPL-2.0
+  license_family: Other
+  size: 139547
+  timestamp: 1736360393211
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.12.14-py311hca03da5_0.tar.bz2
+  sha256: 752f20f65febccd832d3a64029abaaadf3ea01a6cdfa26d48cef2b5462ee3bc4
+  md5: c2bd26697a5a4ff7e6a49e9926e72419
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 168121
+  timestamp: 1734473316071
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_1.tar.bz2
+  sha256: 7f00d92fcfb1a24b4c8fcbe695ce117d985ed44a58b294cd9d4d5d2cf513bba1
+  md5: 93179889226fd770fec62ff555acce5f
+  depends:
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 292644
+  timestamp: 1736182914702
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+  sha256: 808e56fb70f3d38599ee7a54c2a707b282ba9a401fa69a1f54cdc26425d9ce01
+  md5: fc37321833175bda4fc5c21afe32db49
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 539588
+  timestamp: 1709758479776
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+  sha256: d9c126d8bcd1c89ea37186c172d6b1f73f45ada60e3ae1790a017b530baa0147
+  md5: f0223aae3d622547f6accb212579c58e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17967
+  timestamp: 1709322909223
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.3.1-py311h48ca7d4_0.tar.bz2
+  sha256: d76cf29e53f303a799da85cd45c5dc65e9d52f050acf9c42ae448b32cb19e3b9
+  md5: 1bd0fdf6a0fcf98ed2e968c7359ddc4d
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 299096
+  timestamp: 1732540161576
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.8.11-py311h313beb8_0.tar.bz2
+  sha256: a694b8a82ab88f241d100b86586ee802c1d6874e42da4e1bc4fc154df95637f2
+  md5: 39b58c0525acb9a7014bb007aa34ddd1
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 2793877
+  timestamp: 1736267724300
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+  sha256: b1481ffa475c65200626f051d5dcbdb264730b533e928dde608a79ce7a5b4e48
+  md5: aada2761547a291d68f4c016a1a9bc7b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 18265
+  timestamp: 1677911915719
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+  sha256: eb82a0e2ca36d0973b5f6642e27609554edad4b72696f989776d5db8cd4a6a42
+  md5: fa8d9dd8a2fabba964c6bb75ace8c572
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  constrains:
+  - zopfli >=0.1.4
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 3201601
+  timestamp: 1713551611540
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+  sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
+  md5: 44de39124e1b0f5f731c11631eac18ac
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 914169
+  timestamp: 1666798307824
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.20.0-py311hca03da5_0.tar.bz2
+  sha256: 1fc120c7bb3c245be0b2805ffaba6518b56e32ca510439b592172138e02e8700
+  md5: be7cf3596496c3d91885749d37e71362
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.1
+  constrains:
+  - plotly >=4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6103533
+  timestamp: 1730827873611
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.11.2-py311hca03da5_0.tar.bz2
+  sha256: 496491093dc391b9358f7fc3ff92846144e9e25e7d7e2bc8304bc3babf59ddcc
+  md5: 4b3be5c46e52fd21a5a3a3ce1964b24b
+  depends:
+  - bokeh >=3.1
+  - colorcet >=2
+  - holoviews >=1.19.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 373148
+  timestamp: 1734469778843
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+  sha256: 4d4ab70ae0ce008c1cc96a4edfbf3866d5e636acc4799a545ea93acee51635f7
+  md5: 86a085a440729020d1d7b0b74d6a0c6c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148448
+  timestamp: 1714398923507
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py311hca03da5_0.tar.bz2
+  sha256: 12ecf9e8614e4d864a3a82d1244b35bd93a3625c7521f44d75c1fb198501e3b5
+  md5: 6c05e1ef68be71ffae5bc818f393c6fa
+  depends:
+  - appnope
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 238518
+  timestamp: 1728665670755
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.30.0-py311hca03da5_0.tar.bz2
+  sha256: 6520fa19784d319996b26b76afa58631ba1c947941b0b3140cfe812421c99924
+  md5: afdd96e6adde92b303856588dd9562a3
+  depends:
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - pexpect >4.3
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1639167
+  timestamp: 1734548338159
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.2-py311hca03da5_0.tar.bz2
+  sha256: bc8c88ebbfe7a0a575e5546ca9b02bc6629cf8ed04467d74b921328918852b4a
+  md5: a73b1ed92ff1b9528898c3d09f34889a
+  depends:
+  - parso >=0.8.4,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1192471
+  timestamp: 1733987575145
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py311hca03da5_1.tar.bz2
+  sha256: 5057f548fb76e0afa997f69dd08a0c1a1d0b13382ca58e909fd378f1ff74de57
+  md5: 329e65306aa67a099eb34e39f80ef912
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 357841
+  timestamp: 1730902943889
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+  sha256: 9d5cbffa98f3a4391f66b0c5ce1f411f0bfb0eb83137dc7146fb7bae23cb3570
+  md5: 95c92318023482e4e8c698ae6c4597fe
+  license: IJG
+  license_family: Other
+  size: 274078
+  timestamp: 1722872672311
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.23.0-py311hca03da5_0.tar.bz2
+  sha256: 5e1400c72584b88b0ea13d2e66110eb7571f155f8b8d62ede4ca61b8279b8bdc
+  md5: 6924a112e8115ffdb74a5c8840903b84
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 193322
+  timestamp: 1728486773537
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+  sha256: 404b0847029f77bedd7902a170a046219e0dc5c0ec2be19ff45361cff25b2181
+  md5: 3a02bbe8d45fdbcb2350f672be74c9f5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16524
+  timestamp: 1699032463763
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+  sha256: 7deb8ad28c34c369573754304a03ea2acda8ee39102a56526ec689a4d9210109
+  md5: 675ea1a746a78ff6bf8fc4b39139efff
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 277400
+  timestamp: 1677914250715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
+  sha256: ceec15c84f5c699b8055d01e046be04ccb7cfd7c8bd090fc18959f2a4d9f8cf8
+  md5: f85c11f7068312e1e84505efef9d55e3
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 98520
+  timestamp: 1718818476094
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
+  sha256: b2f1ee2a297e001a2e70bc218f60deb08c50b9b727668913ed5a106640413d2e
+  md5: fc4e797a17ff5dccadfb5d19346b7800
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43099
+  timestamp: 1718738212629
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
+  sha256: 2d96618ab2e9b3de870a713d7e5b19f6cde936291f3c87972f945b6e27024e77
+  md5: 534159d29d9aba9c7e70ee52c27b326b
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 614003
+  timestamp: 1718827110867
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+  sha256: 501e929d345aaa9079c965552b942b4e8bde35b87ae89faef003687a40bab3a4
+  md5: 54c7b8554a405acd7c8326c41ba93e63
+  depends:
+  - python >=3.11,<3.12.0a0
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28237
+  timestamp: 1686870817418
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+  sha256: 773e7c4571f482a744dfb18ae26fb22635f5d3f51389c838bd97f9044ea55cc4
+  md5: 5161546aba5597318cb5653390cdecd8
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20235
+  timestamp: 1700168681687
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+  sha256: 8c1c64d51be73aad381992a9df19d8336910bdfc40f19940231df86e177d17cc
+  md5: b1f786f96684a143cf30d1f6b8aebdb3
+  depends:
+  - libcxx >=14.0.6
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65045
+  timestamp: 1677925371836
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.16-he93ba84_0.tar.bz2
+  sha256: 4b45c39ed7c4267baa88eee55413830c87863c9dee6e8af40e0261aa0fcd9469
+  md5: dfd7325cb25e3e7d0d2c3f77209d12b3
+  depends:
+  - jpeg >=9e,<10a
+  - libtiff >=4.5.1,<4.7.0
+  license: MIT
+  license_family: MIT
+  size: 246476
+  timestamp: 1734428527302
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-4.0.0-h313beb8_0.tar.bz2
+  sha256: f123fe7eb47ac10d174364902a64c311b1875f4863b1b3791e6b3fca8e0ab272
+  md5: b62145f1eeed0a89b5d76c3bb9b409d5
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 222115
+  timestamp: 1734423410079
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_9.tar.bz2
+  sha256: bc3732d108e184da32b682c94421173529842f8b429fd693592575b637707b9b
+  md5: 0e753a927e7ef21b248c739b7846903a
+  license: MIT
+  size: 69063
+  timestamp: 1736182580217
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_9.tar.bz2
+  sha256: cd3149e7fb36e67ae496ff37827870c6822619d09b235e2adc7ba5ce9b33f938
+  md5: ae813d7d06d4672d06fad704b7bd4077
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_9
+  license: MIT
+  size: 33265
+  timestamp: 1736182639925
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_9.tar.bz2
+  sha256: e3a1bd31d21200c8841e7305cf4ac1ed21ef75c72acbdb0412747be7b27069c1
+  md5: 86fd5a04180dbcf27c012d9fe8b01a94
+  depends:
+  - libbrotlicommon 1.0.9 h80987f9_9
+  license: MIT
+  size: 310515
+  timestamp: 1736182663109
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+  sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
+  md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 1387034
+  timestamp: 1662620483620
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.22-h80987f9_0.tar.bz2
+  sha256: 695c939431f7fd074d175e62944daca33ff51f3abfe1ee5c51d92d89ad663da8
+  md5: 8985f8e47c5bd81416ed08c28d7f305a
+  license: MIT
+  license_family: MIT
+  size: 60900
+  timestamp: 1734423344642
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+  sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
+  md5: f31e4eb9cd6447cc2f5ef0243a76540c
+  license: MIT
+  license_family: MIT
+  size: 120460
+  timestamp: 1714483461787
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+  sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
+  md5: 9a6698e6a01e492ef22889e4ec340e99
+  depends:
+  - libgfortran5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 151487
+  timestamp: 1665499021664
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+  sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
+  md5: 8f9dde854442b1597ec249e512b88673
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 *_28
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1387621
+  timestamp: 1665498967410
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+  sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
+  md5: 0ba7c7444f2cbc64396d3873b874ec63
+  depends:
+  - libcxx >=12.0.0
+  - libgfortran5
+  - libgfortran5 >=11.2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13307698
+  timestamp: 1664897510704
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+  sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
+  md5: 54add4e3b9ad35f25d34f3c2955abc7d
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 320926
+  timestamp: 1677841799096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+  sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
+  md5: 189d927763e0d79f379df224726e3611
+  license: ISC
+  size: 287344
+  timestamp: 1629287561438
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-hc9ead59_1.tar.bz2
+  sha256: 209b3214c150026e4de2a962e4a9c26457c3d4f3f113bcb115bd7a5373422827
+  md5: 5624e697d929ac1b10bc3b3a89c1a8be
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.22,<1.23.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 607843
+  timestamp: 1734425782308
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
+  sha256: 479cf759232c2361af87493ecd124e7d3a8940030e42e1931234c35bea73c3bd
+  md5: cd8fe2c981594a457c6af3a0d5de0bd5
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 341817
+  timestamp: 1729160040909
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+  sha256: 41c62a460bb81a1a272aa28b219fab9c26510adac177ff1528b1980eabc6e868
+  md5: 8d312c5628dc7ea833e9b4dcb73e9c45
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 42346
+  timestamp: 1677973051421
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+  sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
+  md5: 56eac4019124c7ae17dc2ae5bffce909
+  constrains:
+  - openmp 14.0.6|14.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 302507
+  timestamp: 1662635703553
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+  sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
+  md5: f5f7e6e7541d8dc3d3df270d488d2e24
+  depends:
+  - libcxx >=14.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 176990
+  timestamp: 1714510588159
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+  sha256: d024f5142416961a5e66e424d4d14aec652f9e9dd738b41a97f45674c2ffc9d5
+  md5: 0e2d94b125d802f7b006cf19c71655a1
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 163084
+  timestamp: 1677932947966
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+  sha256: acfd84e29ff4dc2d85543bb973a07f22b4ba53c5d00bca84608ee7f13b2a8676
+  md5: 5ca161cd51e2db358e768453b3ee485e
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 135871
+  timestamp: 1684279980293
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+  sha256: b1bed54c7bfb7304cde9e8e6f798543d08e808e81286a5a48296fc94d621f9da
+  md5: 774358285c9e496c9f5c121cc546c823
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27438
+  timestamp: 1704206026910
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.10.0-py311h7ef442a_0.tar.bz2
+  sha256: 012a1113fd728eaca513b2f71d3be101e8b5a600b8c749822f323eb2675ba3d8
+  md5: 9dddca88e71c2b941a6555b09e4b0a67
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - libcxx >=14.0.6
+  - numpy >=1.23,<3.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 9718053
+  timestamp: 1736278806782
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+  sha256: 3276d61fc353c537bb09d4b7473d7abe12be38806f42c8cc383b62f40850a5cc
+  md5: 6e9c9d47f264b77d9a8461f0899848a7
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20446
+  timestamp: 1677918370379
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+  sha256: 43c96d30775b61b4968422a47f9605049428120669f0742bbb9e5ba145c7d11e
+  md5: a31ca0d9284860adf5463cf45a5e3145
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 69243
+  timestamp: 1677995336989
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+  sha256: 96d8c9f42a38651b7bafe5f3cb132601db76cd1e28fa58e2eaf090e634292fff
+  md5: 5ebc793a17b6aa84d13f19433545ffa5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23895
+  timestamp: 1677942274932
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+  sha256: db9bd659ada23f1ded443d2db00dd13b5d5c0b30f5062544b1ee2c2b88d63d29
+  md5: 03c48121614cf12abfe30eced9b34717
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 105333
+  timestamp: 1677916687032
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
+  sha256: b6fa12e4bde747bf288bda31ce8ec5e24292dbf74fde67f18f9c9c100b845a38
+  md5: 2eddc760c15171a1e8aa838d9d162e18
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8291605
+  timestamp: 1717622676584
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+  sha256: e8eee27fb667aa10b26f3bc4b93f449b7d991ded27b9cb457effee394ce05f6f
+  md5: 6a3e5cd0e1141c01ffb91285bdccfe83
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 123043
+  timestamp: 1698934328890
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.4-py311hca03da5_0.tar.bz2
+  sha256: 1f6d171443b30990cd724ef1e5fa287311d1cf9064c0f5984e6acb2225a0197c
+  md5: 9a8675276a35db6cc6649f0bddecf53d
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - pyqtwebengine >=5.15
+  - tornado >=6.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 531141
+  timestamp: 1728049778343
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py311hca03da5_0.tar.bz2
+  sha256: ae983360f1f69987f0fb3a8de9767b362dc903a9b0b130d87fcfcca445dddc4b
+  md5: f56cbcd18632f7f669a28363c6d3fe4e
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 171380
+  timestamp: 1728049515633
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+  sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
+  md5: 43568079a90f14ee6d763f2c1cdd3cfa
+  license: MIT AND X11
+  license_family: MIT
+  size: 1078472
+  timestamp: 1674734099883
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+  sha256: 417ace1ce51e81f3f92ddc26e0e3a83c1e19c9ebb7af7104452002a5573da534
+  md5: 3e11de6cef096091bb733e07802f00b0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16979
+  timestamp: 1708532698253
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
+  sha256: 8ea1be4285e2e7d361cbcc1daf9c220f87ceaab2308bf7b339d2513d6ea22184
+  md5: 774ce02efa90f212023541c0b24e92c1
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 726598
+  timestamp: 1717630964815
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+  sha256: b0cc542e2a6f42ba716e7e4ccf29eddcb155ad167fcdbc72d2db9c7873eb5639
+  md5: 7acf81b17d2c4ceb3cd39dc9f173855c
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27539
+  timestamp: 1699455954000
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.10.1-py311h5d9532f_0.tar.bz2
+  sha256: e7085ecdcbb7814ab5b588399963d6877083cbcbce27407b5ded3c099af1e6a9
+  md5: b656e9369b00f6f0eec85203e35eaa42
+  depends:
+  - libcxx >=14.0.6
+  - numpy >=1.21,<3
+  - numpy >=1.23.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 189479
+  timestamp: 1730216150682
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-2.2.1-py311he598dae_0.tar.bz2
+  sha256: 6797ddf1604569b26af1846a8c75470af5c78759a2d2543fe9fa561b94ce6aea
+  md5: 2b410acdc298c586eef78e0ac23ab977
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - numpy-base 2.2.1 py311hfbfe69c_0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - setuptools <74
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11900
+  timestamp: 1736500573879
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-2.2.1-py311hfbfe69c_0.tar.bz2
+  sha256: 7eb1f398489cee9312cb1f8cafed9e3e06838918726715e54ea3bda3a5ff9d19
+  md5: e5a12ca1488317bb1e1977370a6e052d
+  depends:
+  - blas * openblas
+  - libcxx >=14.0.6
+  - libopenblas >=0.3.21,<1.0a0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - setuptools <74
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8018207
+  timestamp: 1736500561675
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
+  sha256: b9f781280f49644ca05e18aacbdde1c57cc5107e7cc2471b843ea8461672aa7f
+  md5: 9125d30e4e105b45f7f7d9c20acafa10
+  depends:
+  - libcxx >=14.0.6
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.7.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 450131
+  timestamp: 1722872679313
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.15-h80987f9_0.tar.bz2
+  sha256: 503def27e5229dc31eb3eea4c86ecabcd46a27b6711a968bafeaf7facfc8eeb1
+  md5: 2261823151398e7df6ee94c234f21f11
+  depends:
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 4762637
+  timestamp: 1725545955868
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+  sha256: 77b0c0a0fb14d817390244ebd93c36d44a7867239963f211f7c0a72a3f98d382
+  md5: b90336feb8a50d2eff880e89acb02f40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39617
+  timestamp: 1699371253760
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.2-py311hca03da5_0.tar.bz2
+  sha256: 7e81c844126506e5e9a3245f094bfb83d7a7e8b108757551ba2cdc9c81602357
+  md5: 40ead0e0477f2925e2a333f79f5d8511
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 190184
+  timestamp: 1734472332475
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.3-py311hcf29cfe_0.tar.bz2
+  sha256: 9d1b4942a2e900c2ce21b4c5d1b7cbb352aad96480b8a5e54c8de3f3ef158143
+  md5: 174139c81708a96f152437fcdc06fca8
+  depends:
+  - bottleneck >=1.3.6
+  - libcxx >=14.0.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.2,<3
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  constrains:
+  - pyreadstat >=1.2.0
+  - scipy >=1.10.0
+  - fsspec >=2022.11.0
+  - adbc-driver-postgresql >=0.8.0
+  - pymysql >=1.0.2
+  - openpyxl >=3.1.0
+  - jinja2 >=3.1.2
+  - numba >=0.56.4
+  - pyqt >=5.15.9
+  - sqlalchemy >=2.0.0
+  - zstandard >=0.19.0
+  - dataframe-api-compat >=0.1.7
+  - s3fs >=2022.11.0
+  - adbc-driver-sqlite >=0.8.0
+  - html5lib >=1.1
+  - fastparquet >=2022.12.0
+  - odfpy>=1.4.1
+  - xarray >=2022.12.0
+  - psycopg2 >=2.9.6
+  - xlrd >=2.0.1
+  - matplotlib-base >=3.6.3
+  - python-calamine >=0.1.7
+  - blosc >=1.21.3
+  - lxml >=4.9.2
+  - gcsfs >=2022.11.0
+  - tabulate >=0.9.0
+  - xlsxwriter >=3.0.5
+  - qtpy >=2.3.0
+  - pyxlsb >=1.0.10
+  - pandas-gbq >=0.19.0
+  - pyarrow >=10.0.1
+  - beautifulsoup4 >=4.11.2
+  - pytables >=3.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17075464
+  timestamp: 1732735585667
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.5.3-py311hca03da5_0.tar.bz2
+  sha256: aecb0fe7cd9004af633b8f2beef0f2c0eefce35f206d2ff4de80501fcb37f2dc
+  md5: b2e3ca6dd4a306e635ebd2119d58b448
+  depends:
+  - bleach
+  - bokeh >=3.5.0,<3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.1.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing-extensions
+  constrains:
+  - holoviews >=1.18.0
+  - bokeh-fastapi >=0.1.2,<0.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24200241
+  timestamp: 1730381212320
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.2.0-py311hca03da5_0.tar.bz2
+  sha256: 00a71c24e865b2a60d7aac81508c1c7144a73d7611961214c562eaf270286ff8
+  md5: 0fbf4531ff5194c1df47533fcafeec6a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269736
+  timestamp: 1734618675560
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/parso-0.8.4-py311hca03da5_0.tar.bz2
+  sha256: d4507aa0fe135a06d918e4217eb89bf2de87574b36ae0fbcc5e0568e10daf1f9
+  md5: 379218d52b3715c7664153dd035ebc8a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 224689
+  timestamp: 1733963346031
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-11.0.0-py311h84e58ab_1.tar.bz2
+  sha256: 44fe7a39cfaf817e2ddfacf7473e8cd300111df36a9b762ab939651fcdacddae
+  md5: 73c9669bf1fdaca9cfcd755cca8c8477
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.16,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libtiff >=4.5.1,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 950716
+  timestamp: 1734430712715
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.2-py311hca03da5_0.tar.bz2
+  sha256: 4f82ab7dc13317069ec808da81c472668e6ab85f5d74d5b385b6d86b4ef32bad
+  md5: f9c03ed21097422236806938a7b7dd64
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 2918476
+  timestamp: 1723484709578
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+  sha256: b6200816d65673aa1707c20a768c9cff87dd8dbe1335f9c1478e5931dfa08ee0
+  md5: 14b1e0fa73eb33f9c83048482dcce57b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 38423
+  timestamp: 1692205689597
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.21.0-py311hca03da5_0.tar.bz2
+  sha256: 16e6ef97591f7833c9cd8f2f369812ac62a13e9241b1e8d605932a8da92c2df1
+  md5: fa273fbe5dbea433b860c4b89dad0184
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 123030
+  timestamp: 1731958853048
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+  sha256: 07cfba50d9e94364bde077731a824ca4f537138b35ee6b66d07aee16ac9850f1
+  md5: 919bf486280a11e6acb3c2c3a82f7473
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 763225
+  timestamp: 1704404463402
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_1.tar.bz2
+  sha256: a6d24cb3a6a50bcb52a37548ce3d4d2ee58b8d23403bc7f63018b184263c5968
+  md5: d8201518af79a2d79e517846e9f68872
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 500255
+  timestamp: 1736367725875
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+  sha256: 121b5b66721760c05f1d4eee91626229d1814663d3fb5f23126ef870aa496e26
+  md5: 0c588c2ca790a05d422c06e8568201ad
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2124200
+  timestamp: 1684280082141
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.2.0-py311hca03da5_0.tar.bz2
+  sha256: 86cd1c9d1c73f7dac9f3038d16ac2d6952d42bda57d4da52b18c8561d2901082
+  md5: fe581970af66b493353b9dcdb6bf572f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 487783
+  timestamp: 1731445552436
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+  sha256: 0bb3d2a57b332c5cf73ea40ea13c850ae24a1f9a3a41ed9267832d9e3c767572
+  md5: 45a7fcf1641980d5114999736428502d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36755
+  timestamp: 1677906514270
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.11-hb885b13_0.tar.bz2
+  sha256: 8359c229ad74991a35ad4e9cd24223a8102b10e2647624965b29a0bce4f88a31
+  md5: 70344859c29c4298141767a093918a61
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.0.15,<4.0a0
+  - readline >=8.1.2,<9.0a0
+  - sqlite >=3.45.3,<4.0a0
+  - tk >=8.6.14,<8.7.0a0
+  - tzdata
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 16479225
+  timestamp: 1733934794096
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+  sha256: c3cbf5bd237b0a7458640191016b2701fe120c547df9afc835da76663a9c17f7
+  md5: 843568c76b6b9384635b7fca74c79792
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332222
+  timestamp: 1716495881101
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.20.0-py311hca03da5_0.tar.bz2
+  sha256: 9c37d0d46f2e1930d0efc33f5ae7f9b6ba72f835a1b8b4311ec76953a796fe8f
+  md5: 59292a5980e93058c2b8700c4680fb62
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 282469
+  timestamp: 1731939575445
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-3.2.1-py311hca03da5_0.tar.bz2
+  sha256: e836037601159fe5cd5cf2fa5b818bb4b9a9465f8b0753e78c1b5e809b052627
+  md5: fcdab3a23d5db6e00399f5f66dd2bb27
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29575
+  timestamp: 1734370349925
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+  sha256: d945744eb133f19ca61325cac5128bdb053ae04de4a0ba6f69c061449cac8af7
+  md5: 34baa81490d667381bc7021435b0e1f2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 275858
+  timestamp: 1713974457562
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+  sha256: 012585bdb5ae54c2cded50be703734e6dbf418b003635b6f6d7c1e36e7020c30
+  md5: da7e99a707bd0cfa20db651b5c068bfd
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65556
+  timestamp: 1711136890180
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.2-py311h80987f9_0.tar.bz2
+  sha256: 8d6910a02d0a30dabb40104565c0c74531aafd4c959431ddbfde47ef52f4c83c
+  md5: b1619588c95cb65375af1d2eb448ecc8
+  depends:
+  - python >=3.11,<3.12.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 205890
+  timestamp: 1728658038659
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+  sha256: ae8cdd5be5a7ad19ff82925a035859fafcc5942cd3899d127a508dbb9a235090
+  md5: 252a7b997d08bf72f10b3bc2dc68333e
+  depends:
+  - python >=3.11,<3.12.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 580346
+  timestamp: 1709318480624
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+  sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
+  md5: a276a37815f1f5e0af0d6445e4f33e0d
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 463867
+  timestamp: 1666648067390
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+  sha256: 7a208abc002a2fc208ae25cb2cf932999a3e4980aa4c9edff315cb9ac62b12ce
+  md5: bd22ebd3cff811577ea61f115ba7f4f2
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74744
+  timestamp: 1699012126255
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py311hca03da5_1.tar.bz2
+  sha256: 4cefdf48ebab7544252ce5f4274b5b86f8107e5af556bf387445a2eb4d42449c
+  md5: 482973b9a55bd1a4cdc33c557a6afb29
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 124539
+  timestamp: 1730999249799
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+  sha256: 52368d9b557b8f54ef5ca4bf6cd5a3ec665171f2b2d2082cdd410bab88f4829c
+  md5: ac76fb4d2eef3ecdd491cf5d3fb8620d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10204
+  timestamp: 1683077239143
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+  sha256: 491d116c5f54ef340e3bce631835f7138cd1923d7b63e6ca9aa01b48110cb8f9
+  md5: 9b81bd8ea808704f5433884b567f1f15
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10557
+  timestamp: 1683059079547
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311h2aea54e_1.tar.bz2
+  sha256: dafe2192ec46eed9702b6e5a221ffac2c916249c01f6772a4adf3bec7486cf94
+  md5: 06d7e1fce00afef0b290df51f259bab5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 317991
+  timestamp: 1732229174647
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+  sha256: c80d52567084b1caaed2862b77b70065ca17afaf0b020733e9d6c273b4a63e78
+  md5: ddf7d88c1967f3f7a4ce1c975fd47e0d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33321
+  timestamp: 1699371225235
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-72.1.0-py311hca03da5_0.tar.bz2
+  sha256: dc1b284c230e143ee75b7f93662a1c5c5cc8407e7328e358e7698bfc6d2a9740
+  md5: 71ce2e23600829422b23461f0fd1d98a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 3318492
+  timestamp: 1722860227978
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+  sha256: cd71091a234874d2826fa063ec5222b3191c9f47e1b5281c352d9df3f31a06bf
+  md5: 0db8e29016c6bff026c083d9923a7566
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 19073
+  timestamp: 1705431415504
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+  sha256: 3e18cdafc607c6d7623b1c8f041cbfbb50a27e298f961abdcce7e36834ac39e1
+  md5: 9ee0da74c55d0b8d83edf246fd717f20
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89862
+  timestamp: 1696347657368
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+  sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
+  md5: d8c1e9910392d0bcb22a173f9ce30fa6
+  depends:
+  - ncurses >=6.4,<7.0a0
+  - readline >=8.1.2,<9.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zlib >=1.2.13,<2.0a0
+  license: blessing
+  license_family: Other
+  size: 1758290
+  timestamp: 1714488307689
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+  sha256: b5c265e9ed9a1ff2238a09b83bdc1826950faa87fd6b685debe60888de6e7a50
+  md5: 5827c8a32317894ce18576e334daba47
+  depends:
+  - ptyprocess
+  - python >=3.11,<3.12.0a0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38559
+  timestamp: 1677918962258
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+  sha256: cfefd86d0f4981d22b7611b3dc60359b8698bf39f2b743cb90b7005aaca88e1e
+  md5: a04dbcd6095f6b8f3ad195a78d48b262
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50058
+  timestamp: 1677917499177
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+  sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
+  md5: 3c25b4f4768ccda28b20a03ba27e7759
+  depends:
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3484151
+  timestamp: 1714770744982
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.2-py311h80987f9_0.tar.bz2
+  sha256: cf80ec43ca8cd5066bb4b673815b3ee0d81cba428d8cde5fdad2b275e8e2a192
+  md5: d481b72f67890c155e69c27b0e723391
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 915674
+  timestamp: 1733960659590
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.5-py311hb6e6a13_0.tar.bz2
+  sha256: f6cda770cbe84b10f2d78d41bab43e1a1386e9722569c9b2b235083947fe90cc
+  md5: f5306a7b16da13a7258a20cecb62cdd5
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 155732
+  timestamp: 1724854273737
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
+  sha256: 707e5dfdb9116f31bc1ad7f497f6e8416683add460258fdc2a4c16eec85226be
+  md5: ffb602322a388ec8e1f385edaca3ce12
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 208171
+  timestamp: 1718227091374
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.12.2-py311hca03da5_0.tar.bz2
+  sha256: 76bfd11a14fed1c680f48ab1d85cfab450f28798b393949c7be3932fb124d6a0
+  md5: e2d3691e6d2d812b68b13c7ac3086a67
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.12.2 py311hca03da5_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9928
+  timestamp: 1734715032666
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.12.2-py311hca03da5_0.tar.bz2
+  sha256: 6ed1e28c504268da2e42490301a1c0bad8b7f9261693d457233f675b3f5d9387
+  md5: a25a484145929656f3e0c6acda51117a
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 82601
+  timestamp: 1734715026245
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+  sha256: 2ea2d0520b330d381a2ab241bdb9ae146ef815ee7c96ee52a9773fb9ae85f4fd
+  md5: 66f7f8979cfb2cccffac972d70482130
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 12614
+  timestamp: 1677963554857
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+  sha256: df7fe7740bd853b641d624e2ec97f1aacb2b82691936a8c04ef18fa9768539c2
+  md5: d5c7626d45fd03b22797c18e47812beb
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 518048
+  timestamp: 1713213046424
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.3-py311hca03da5_0.tar.bz2
+  sha256: 428c7365b106ed161342704298d14101e12cdd778caee3d167587fc2807e483d
+  md5: 86cd9cef3c89a98a98548f18c621e61e
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - h2 >=4,<5
+  - selenium >=4.4.3
+  - requests >=2.26.0
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  size: 218842
+  timestamp: 1727769914621
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+  sha256: 09738b7f9075386bf062b12ddb6fb72a06450d2481f6b5ca2026c811cd849569
+  md5: 9afdec076c95746ac21235f971190e40
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26727
+  timestamp: 1677910175964
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+  sha256: b4ced7366de8eb7258f31d516616e70c62ed4a798780e57e208509d2b52ab435
+  md5: 65a9a05a726734c1da667f9bd3c78c14
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 114733
+  timestamp: 1715878377412
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.44.0-py311hca03da5_0.tar.bz2
+  sha256: 088f397ff8a4a7e178415dd7e2ff987c02b3674c7b6885972fb6c669978aff40
+  md5: a87f4be160e50ea022588aab7c7322bf
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 139304
+  timestamp: 1726165038360
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+  sha256: 2cd108896df65636769e3804ecc2ca421ad9b54e64fa21922bbabe40c90c247a
+  md5: b3a1e5077b28f71298d891fbfb5ff03e
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55645
+  timestamp: 1677927459979
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+  sha256: 5be8c968f2da5c4bf14f28d63e31b4c1b6993d980023769732c7f58f396c2e0b
+  md5: 3f5f62d4e85e3bdd48d39189b01805a6
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 459197
+  timestamp: 1714510992914
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+  sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
+  md5: 990ccbdae7ddeea76e2bf0546d4c6369
+  license: MIT
+  size: 88367
+  timestamp: 1629137313522
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+  sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
+  md5: 3d57d1adadca9388aaaa1c529b65ba65
+  depends:
+  - libcxx >=14.0.6
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 322790
+  timestamp: 1705602163804
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+  sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
+  md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
+  license: Zlib
+  license_family: Other
+  size: 104928
+  timestamp: 1714510936868
+- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
+  sha256: 43667132ec8fa4c34ba438e13a01b08073e3e3e8a648ecdb6afe4141a7c197e2
+  md5: fb8c3f5683b19dd3743d125797b8e2dd
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 817614
+  timestamp: 1728486986031
+- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.6.2-py311haa95532_0.tar.bz2
+  sha256: 6fbb6b2aa38cb576b17299bf2fdc3779ca090059bfd35e92127f692f2b912aef
+  md5: 403069f811c54afaf3d6e3be619bbab8
+  depends:
+  - idna >=2.8
+  - python >=3.11,<3.12.0a0
+  - sniffio >=1.1
+  constrains:
+  - trio >=0.26.1
+  license: MIT
+  license_family: MIT
+  size: 244161
+  timestamp: 1729121358016
+- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h827c3e9_1.tar.bz2
+  sha256: c6ca6f120f5e09524f2e6bf0db3d88f765e1700b2a5ae115028e5536dbc6d596
+  md5: afdf42981074a40b5f08bc6af82670a9
+  depends:
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 47000
+  timestamp: 1736183077470
+- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-24.3.0-py311haa95532_0.tar.bz2
+  sha256: 530abbccadda1fcb2cc52ef46c1615cc64f81932a9565f28e4d0684dae754265
+  md5: b630c6316defef2d31cf5e31a74ee656
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 163897
+  timestamp: 1734533441204
+- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
+  sha256: f1eb2a5aeb25efa0b38fc1dd94a36d431bc80d654f11a052f67a899dcc471f57
+  md5: 9db5a441c7cbcf4dc617f8c722e4310d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - soupsieve >1.2
+  license: MIT
+  license_family: MIT
+  size: 276663
+  timestamp: 1718029990621
+- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+  sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
+  md5: e8aa6b7daaf0925245c148aaeaa0722e
+  size: 6183
+  timestamp: 1528122357636
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bleach-6.2.0-py311haa95532_0.tar.bz2
+  sha256: 0837002d1a1cd03ff18ec4328ad308859cfeb02e9ebb56c7565f2540a410c207
+  md5: 89be604fc06ac9ec44500f933bab9ca9
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings
+  constrains:
+  - tinycss2 >=1.1.0,<1.5
+  license: Apache-2.0
+  license_family: Apache
+  size: 371219
+  timestamp: 1732292957244
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.6.0-py311haa95532_0.tar.bz2
+  sha256: d6077bf47e0740168accab42135139ebb4bdd5cf1111f81881b148777468100e
+  md5: 7281ca887bccf048f735eb5acb1e5118
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - numpy >=1.16
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=7.1.0
+  - python >=3.11,<3.12.0a0
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5918010
+  timestamp: 1727915199711
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.4.2-py311h57dcf0c_0.tar.bz2
+  sha256: 42f1a2eb775091e9aec87f3f08ba76891e45032c980b9c00c108437df6b5fc56
+  md5: 327b522b59ec41d6e5d4a100c228415b
+  depends:
+  - numpy >=1.21,<3
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 160724
+  timestamp: 1731059089575
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h827c3e9_9.tar.bz2
+  sha256: 7b77dcc19206868494e1b0595d2f575bc7222a000825f0142409d4f7689dd2a8
+  md5: 87a9ff016a169e488858bd6b6876bbc2
+  depends:
+  - brotli-bin 1.0.9 h827c3e9_9
+  - libbrotlidec 1.0.9 h827c3e9_9
+  - libbrotlienc 1.0.9 h827c3e9_9
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  size: 19711
+  timestamp: 1736183369640
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h827c3e9_9.tar.bz2
+  sha256: 5e0ebd9da1061b360f75d51da7cb12f54f485e9669f93f431028c234f2e81dd5
+  md5: a3019a2306b44dd386bc06e8fe013c83
+  depends:
+  - libbrotlidec 1.0.9 h827c3e9_9
+  - libbrotlienc 1.0.9 h827c3e9_9
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  size: 33689
+  timestamp: 1736183347666
+- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311h5da7b33_9.tar.bz2
+  sha256: 1d1267a7b0eb3de746900b4c6dd06ca141085fd12b076b6ae38e8800e8b6d305
+  md5: 7e55ca44341f40eea68607d12479f367
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  size: 356583
+  timestamp: 1736183647928
+- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+  sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
+  md5: 11e0af09a31e2d5df51c65a342032b85
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: bzip2-1.0.8
+  license_family: BSD
+  size: 112994
+  timestamp: 1714511182837
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.12.31-haa95532_0.tar.bz2
+  sha256: c705fdedd20c3e3dbd1f2dca0bcfe75528c0892d0ce0325dc1969b049579ede5
+  md5: e59f75f1c0aa213d91dbc683155c562f
+  license: MPL-2.0
+  license_family: Other
+  size: 173115
+  timestamp: 1736360411856
+- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.12.14-py311haa95532_0.tar.bz2
+  sha256: 20d5658001133d159efd12aa8f12cd4f4092840015f7664fb6b210b239c72de1
+  md5: 6a8975d5b0a4ca161ca92071b51d85ec
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 167825
+  timestamp: 1734473486300
+- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py311h827c3e9_1.tar.bz2
+  sha256: 14cb2182124ca010739f78e856e5d4ee50cc1b1da55550c9d2fc817f2c67dbbe
+  md5: d8ee3acca8b6a61a3f58b83f820e8900
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 317912
+  timestamp: 1736184391679
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+  sha256: 4099898f02e1f6119fcda65e747c3cbfef0bf563c8855b79a0245160709d5b45
+  md5: ab9705c34e67fb8c8faec69d63ff4064
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36410
+  timestamp: 1676422341506
+- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+  sha256: c722f50980d7416ffb2cfc7bf72649307a0bb78c5a24eccefcd049cb61d6b355
+  md5: c7c9ff0513ff3c99700919293b702410
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: CC-BY-4.0
+  license_family: CC
+  size: 543258
+  timestamp: 1709758602437
+- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+  sha256: 8fb3e816a5ad1da05125462dbc9e2a7e933b001a871aa65703802c0a894c6277
+  md5: ee4b2fa9fce130496d5c7c86c35a1a05
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets >=4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17723
+  timestamp: 1709323150229
+- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.3.1-py311h214f63a_0.tar.bz2
+  sha256: f78afa9b88ee6210adc2619ba09e20b1ef1fbe97505958a6291d8cdfee9f42b7
+  md5: c9d405de1665e2d6e8cef51450f2a7a4
+  depends:
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 248779
+  timestamp: 1732540644947
+- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.8.11-py311h5da7b33_0.tar.bz2
+  sha256: 6f2f0fa6cd6b041d5dd3dfc6beeb0528b563f1d138e0c1937dda07b3ef243846
+  md5: 47eb9e788ad8380d20fcdf8b40ea08a1
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 4034402
+  timestamp: 1736269847465
+- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+  sha256: 5d5fc8a24c804010b8cb5963227230352ea3ccf56bea9e8116e34f77223218f2
+  md5: 8f989a72eed6293dfe0533c83057980d
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT License
+  license_family: MIT
+  size: 17688
+  timestamp: 1676423357100
+- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+  sha256: 27fb03eb57d25711a15e145f47a64320a9955b585efc9fd0a1a51cdd71b9fde3
+  md5: eb3869e98f6f53dfec76e2eff4d6b61e
+  depends:
+  - brotli >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - unicodedata2 >=15.1.0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  constrains:
+  - uharfbuzz >=0.23.0
+  - skia-pathops >=0.5.0
+  - lz4 >=1.7.4.2
+  - zopfli >=0.1.4
+  - fs >=2.2.0,<3
+  - lxml >=4.0
+  license: MIT
+  license_family: MIT
+  size: 2732423
+  timestamp: 1713552175344
+- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+  sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
+  md5: ef1b830ffb28c46ec812362318ea7ec3
+  depends:
+  - libpng >=1.6.37,<1.7.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: GPL-2-only and LicenseRef-FreeType
+  license_family: Other
+  size: 527643
+  timestamp: 1666798364378
+- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.20.0-py311haa95532_0.tar.bz2
+  sha256: d991c3ed55771bd642ffebbef209c4d94b9db7c206fb7ef52d8013baadfb6005
+  md5: 4ec4007efb1e5167568de53a8b03ac43
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.1
+  constrains:
+  - plotly >=4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6147331
+  timestamp: 1730827981525
+- conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.11.2-py311haa95532_0.tar.bz2
+  sha256: 4760ed2d77621477f47cdd4d96bc0c26cdba9fe93308df92c01d20d812b129ac
+  md5: 990ecc3db2641f58e3541e4b0a05c875
+  depends:
+  - bokeh >=3.1
+  - colorcet >=2
+  - holoviews >=1.19.0
+  - numpy >=1.21
+  - packaging
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=1.12.0,<3.0
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 368606
+  timestamp: 1734470082250
+- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+  sha256: 102c803186db6d62eaf41a906f6c563ff0d62b53c1eaede8a381e18c0d005ed9
+  md5: 9d30dec03058758a428cf152e0ae28b5
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 148193
+  timestamp: 1714399061601
+- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+  sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
+  md5: d215cc8ee7ca2cc83cc250cc5d822fe0
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 3929136
+  timestamp: 1699647939158
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py311haa95532_0.tar.bz2
+  sha256: 6f702a1b807648373dff43ba42e92978b52cfe392ca426dfb9ebf556a1189a70
+  md5: db5be371e83b27b4c763d1b1c3777df0
+  depends:
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 237277
+  timestamp: 1728665671824
+- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.30.0-py311haa95532_0.tar.bz2
+  sha256: 849c5c284c450d0a254fdb09872a56bc36736fad80b5602d51034cd3c5e1f244
+  md5: 85c6796b362a934aefccd96c6f4e84c9
+  depends:
+  - colorama
+  - decorator
+  - jedi >=0.16
+  - matplotlib-inline
+  - prompt_toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.11,<3.12.0a0
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1677847
+  timestamp: 1734548277969
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.2-py311haa95532_0.tar.bz2
+  sha256: 47280ad8a680828014eceff93c5c587c0c290579486377e696c78d8461a172a1
+  md5: d38c4583143de20b5c9c8571889e1980
+  depends:
+  - parso >=0.8.4,<0.9.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 1189371
+  timestamp: 1733987881391
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py311haa95532_1.tar.bz2
+  sha256: 8694788240bbdddbc5d111ee8d0ef11106ddadb13d56cd4c46b8140b88ab6277
+  md5: 64856a8473ebc5effe17f370b4e91016
+  depends:
+  - markupsafe >=2.0
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - babel >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 357167
+  timestamp: 1730903506013
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+  sha256: 0238fb10912d9345a9d327ff314a179de38369f8e1d0de0b5f4fab04defab0e4
+  md5: 16a420ea83811cfa0c7cadba8f9f0995
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: IJG
+  license_family: Other
+  size: 409932
+  timestamp: 1722872751697
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.23.0-py311haa95532_0.tar.bz2
+  sha256: 99f6618c5969b13451072defdcf3441b83f710010ef10b7a620b42e156ed919e
+  md5: 501a297479b97960e249bdb117f7cda7
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.03.6
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  license: MIT
+  license_family: MIT
+  size: 224348
+  timestamp: 1728486919376
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+  sha256: 9581be54128954080d7cef448b1728874c2ebbe5064f55adece422cf12eafa5a
+  md5: 3adc105f87d5c7f0b1248bc3423f5b48
+  depends:
+  - python >=3.11,<3.12.0a0
+  - referencing >=0.28.0
+  license: MIT
+  license_family: MIT
+  size: 16187
+  timestamp: 1699032556953
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+  sha256: ad8343bad7c8f0448cbcfbaf872cc94b56da81c52e5cdcee2a5d6b89f029eb75
+  md5: addceff8d46c9d1d322618a9ce9e5b39
+  depends:
+  - entrypoints
+  - jupyter_core >=4.9.2
+  - nest-asyncio >=1.5.4
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 300354
+  timestamp: 1676424060532
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
+  sha256: fe0bf805dfa60d8b5d61670900442d0cda12523135176f60e1ebafb797e521d8
+  md5: c8cf5ea3d4b0bc57dfe6b189b47e69e9
+  depends:
+  - platformdirs >=2.5
+  - python >=3.11,<3.12.0a0
+  - pywin32 >=300
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 136783
+  timestamp: 1718818384444
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
+  sha256: 262c35a28d0af4d73ea1c010ce0c022005512a26d5c27064c8e009c0b7b789d9
+  md5: 8367c61552aa274c0843201d88e461c8
+  depends:
+  - jsonschema >=4.18.0
+  - python >=3.11,<3.12.0a0
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 72131
+  timestamp: 1718738283200
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
+  sha256: 00bf8449a37eb10c91ebfaa14b231905fde9493740cbda7ec89a8d3d8d9d1ff3
+  md5: 1f3abe3cbf365249ebae7465a57e4cae
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.9.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=2.0.1
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 655133
+  timestamp: 1718827724346
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+  sha256: 90420847230e72a648417f5f77cebcf7f17b89f70788652c276acc0c440e135f
+  md5: ef3d8dee197aa37897bf6d39d2dd878f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=2.0.10
+  - terminado >=0.8.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27639
+  timestamp: 1686871052174
+- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+  sha256: 97faaf26ce5254ec3649a8ee7f480b1556e4e8e6e4356d2fab1e6a5532631a0f
+  md5: da23bd831c50c877f63038b7e16720ad
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=3.1,<4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20163
+  timestamp: 1700168785472
+- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+  sha256: 8a2f0909fad0387e57cb0e9ee30db2b20761a9106e794381ffeac387a298fb07
+  md5: 6058b2efc3284e27aacec2e6e6280433
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 62334
+  timestamp: 1676432044242
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.16-hb4a4139_0.tar.bz2
+  sha256: ef4d7e1443c7c510b6e690e344392075bc4d89b5818907f544ce98fd967d029a
+  md5: 6541897ab2fd34b35519b95c922b3192
+  depends:
+  - jpeg >=9e,<10a
+  - libtiff >=4.5.1,<4.7.0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 1089573
+  timestamp: 1734428606761
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-4.0.0-h5da7b33_0.tar.bz2
+  sha256: 3a915692cf3e21e7cc4259faea2e17535530515acb3bc8fa00832d646bdeecf0
+  md5: eda551db9b747f0606eddd001343ed36
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 207263
+  timestamp: 1734423494890
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h827c3e9_9.tar.bz2
+  sha256: 5c51b1860e91be66584f6932b86de344a7158894e98b59ed5f973c39e3d77fbc
+  md5: 4273c278acae05def47ce1bbf4a604bc
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  size: 80775
+  timestamp: 1736183139175
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h827c3e9_9.tar.bz2
+  sha256: c34366f1af8c499501c660caed188191869198af323f28f9fdf36cdc3bd9b983
+  md5: 17978e34dd336c03b45064a092e24b2c
+  depends:
+  - libbrotlicommon 1.0.9 h827c3e9_9
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  size: 45764
+  timestamp: 1736183205643
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h827c3e9_9.tar.bz2
+  sha256: 3db56a17b192f502d1658eff34ed0d3d4ca137c9611e22c5ea866d217004d939
+  md5: 4b5c2afa55286a51a06fb2e7f2ffa135
+  depends:
+  - libbrotlicommon 1.0.9 h827c3e9_9
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  size: 755218
+  timestamp: 1736183274598
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.22-h5bf469e_0.tar.bz2
+  sha256: 46c58457ec8c074d5af22fe36a182d5c29e76f6248e7d1d5cb76c66beefe52aa
+  md5: 5bd6c216dd03f3ccf9d108b7c8a29367
+  depends:
+  - vc >=14.40,<15.0a0
+  - vs2015_runtime >=14.42.34433,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 223776
+  timestamp: 1734423384478
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+  sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
+  md5: cf949d76148be1e2a534218d9c57df86
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 155435
+  timestamp: 1714484319443
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+  sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
+  md5: 78315f89b8550030dc574d04bc69c115
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: Zlib
+  license_family: Other
+  size: 707959
+  timestamp: 1677841899214
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+  sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
+  md5: 3151bf6860a305eeb17df6f0e7a4658a
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: ISC
+  size: 681655
+  timestamp: 1581697249749
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-h44ae7cf_1.tar.bz2
+  sha256: 224c9ee15d52fd10544bdae6738e8d8ad12a04a6c48692574d51426d0ea421f2
+  md5: ba5f521d36280d34950fc5d99a58676b
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.22,<1.23.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - xz >=5.2.10,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  license_family: Other
+  size: 1213382
+  timestamp: 1734425893191
+- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
+  sha256: e54ee28f6ba01b3addf61ee9dfbdedc16eac8654fc334f713b5f181cf037d0f2
+  md5: 47aa151852fc9b07e7573d22f0af945d
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - libwebp 1.3.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 339944
+  timestamp: 1729160123353
+- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+  sha256: 4534c822511a052a72c2b070a05e5d8d6f3550f18ea00a33f9d8a9a92b4382cc
+  md5: 82f24e7660831445a2183216e280a6a4
+  depends:
+  - python >=3.11,<3.12.0a0
+  - uc-micro-py >=1.0.1,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 41464
+  timestamp: 1676474474981
+- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+  sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
+  md5: 320f40b75d93f3b96931c6d13c23946c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 158902
+  timestamp: 1714512129889
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+  sha256: e0dc6e119b224bb31ef34b6ba270ffadc181d38b698c5318de8df7a5d2c4ccbd
+  md5: 992ccd756f09408f0b74dfb9852a8b7f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 182381
+  timestamp: 1676437963591
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+  sha256: 050b5fd4b28132d8102a7e6b40179894dc7f5e41f7ad9ee19211e67446c5740f
+  md5: 3ae0b2f6baec708554648ddafa81b756
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 154386
+  timestamp: 1684279992864
+- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h827c3e9_1.tar.bz2
+  sha256: e02c539068d82ac6a709a4bb33b18a181afdfa78f43c97451209c5903af7e4f7
+  md5: d9678fcceae215a8b3fb4639a77f818c
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40937
+  timestamp: 1736370643775
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.10.0-py311he19b0ae_0.tar.bz2
+  sha256: 35078ccb78b0b35ea07ccff575a056166fe32df8c2e4a2265c3aca75e00a482b
+  md5: 3d61e9d9826f4a3664bc102588ab2fa4
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype >=2.10.4,<3.0a0
+  - kiwisolver >=1.3.1
+  - numpy >=1.23,<3.0a0
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: LicenseRef-PSF-based
+  license_family: PSF
+  size: 12369480
+  timestamp: 1736279003945
+- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+  sha256: 43279276850eb6e621812448cddc1093524cee0b7f8ed58b4600b68a4fb659f2
+  md5: 5968b2b5c1f3cf5c8c8c9aaa4d8d66a2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19886
+  timestamp: 1676425829787
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+  sha256: 3062a8254ca351b54f15bea85cc928a3ba4d879bb98ce97ece39a9f7eca215a5
+  md5: 8f1565663abb34ad7fdd512e76da5532
+  depends:
+  - markdown-it-py >=1.0.0,<3.0.0
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 68031
+  timestamp: 1676481862508
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+  sha256: cdff5215c292fe59649ca40ca72f5d26da352760c1d6a56feba14eb13f7bbf61
+  md5: e0f3f32b22135dfeaec277bc87183ca9
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 23328
+  timestamp: 1676442709081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+  sha256: 3b173a25605d2aaacc57ec0e425f1d1c51327eb2521c8742a736e2c76069bc8d
+  md5: 169f1c93a443f95a88665f3008623ce1
+  depends:
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - nbconvert >6.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104882
+  timestamp: 1676425142412
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+  sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
+  md5: 527155127b9fada5e5c5c69a624674b9
+  depends:
+  - intel-openmp 2023.*
+  - tbb 2021.*
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  size: 187498166
+  timestamp: 1699648376430
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h827c3e9_2.tar.bz2
+  sha256: d05715a691b223d6c7f592c21032f9bee1e7cad6834c942eec1f2d5bf2da100d
+  md5: 04bd233faebb0a8c2841e648ea39e801
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 80594
+  timestamp: 1736370888084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.11-py311h827c3e9_0.tar.bz2
+  sha256: 513b8fe5da01b8460084688d99c977d173b19d7d58ad2aa6b27a961665ae25f4
+  md5: c07115b0a05892c721b7324ef8598c2f
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 212966
+  timestamp: 1730823150084
+- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.8-py311hea22821_0.tar.bz2
+  sha256: f8ea6da83e88b353bf66ae609d0377e45fe0d4dcdba2c920ca7b600559f49679
+  md5: 98805ec361a795613a97773fab63653b
+  depends:
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.16
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - blas * mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 345997
+  timestamp: 1730822892388
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
+  sha256: 636f369607118a6ee3d0b63b7edb925d8081fd3fc829a7699136ce0dedbde067
+  md5: b7e49c9cea50d8406cac81cd720dd80a
+  depends:
+  - ipykernel
+  - ipython_genutils
+  - nest-asyncio >=1.5
+  - notebook-shim >=0.2.3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8323655
+  timestamp: 1717622931223
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+  sha256: e940f9178ee2fa0a7c12873ae35ebea0074371653e5cfa1be8aa8d9271fd343b
+  md5: 355d0835215911738a28010dfa6aa382
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.11,<3.12.0a0
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 141785
+  timestamp: 1698934346590
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.4-py311haa95532_0.tar.bz2
+  sha256: d5a6346c8d081061777b5327284f3836342ad3e4869c3584a8bf1b7abac56466
+  md5: 0d00b9e90c3df8cb479490dc136f0577
+  depends:
+  - beautifulsoup4
+  - bleach !=5.0.0
+  - defusedxml
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.11,<3.12.0a0
+  - tinycss2
+  - traitlets >=5.1
+  constrains:
+  - tornado >=6.1
+  - pyqtwebengine >=5.15
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 573057
+  timestamp: 1728052469536
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py311haa95532_0.tar.bz2
+  sha256: 952df0af8037fd3131a3f64481660272040fc30816c5b6a5377fa2357d3bcede
+  md5: e0f63c7653d679b5ec3f50b14424ad1d
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.11,<3.12.0a0
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 202609
+  timestamp: 1728050720194
+- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+  sha256: 90fb3f14c49da1397982eae21cd09e8d60d491d76f94c57590c56723fe6dc172
+  md5: 46a523661fe5c1bce7b4213fd428c3de
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16732
+  timestamp: 1708532795328
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
+  sha256: 62732e34b2cdcb73846cfdf53284067d32113aae0f6d736ca30ce2b0073bce27
+  md5: ec7191b2ea4e65b5eed6f7fdd9271d28
+  depends:
+  - argon2-cffi
+  - ipykernel
+  - ipython_genutils
+  - jinja2
+  - jupyter_client >=5.3.4,<8
+  - jupyter_core >=4.6.1
+  - nbclassic >=0.4.7
+  - nbconvert >=5
+  - nbformat
+  - nest-asyncio >=1.5
+  - prometheus_client
+  - python >=3.11,<3.12.0a0
+  - pyzmq >=17,<25
+  - send2trash >=1.8.0
+  - terminado >=0.8.3
+  - tornado >=6.1
+  - traitlets >=4.2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 769732
+  timestamp: 1717630919732
+- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+  sha256: e040ebcab948325fbe17e4ab15be62e1fafa7bad225457e59764adb60eb40db5
+  md5: 4d40a09df8cb74a9f044eab317436d67
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27282
+  timestamp: 1699456187703
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.10.1-py311h4cd664f_0.tar.bz2
+  sha256: 7bf058d86876ca3d1f23b21ca8f3d9340e7f26fef9366eca092302c4fdc04e8b
+  md5: 7492afa4cb19e783c400ae35b90753cc
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - numpy >=1.21,<3
+  - numpy >=1.23.0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 210960
+  timestamp: 1730216100891
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-2.2.1-py311hdab7c0b_0.tar.bz2
+  sha256: da5a7e7f64c68b2c77eac97fda013ef6d16b79e6a9110e98939fdb693695483d
+  md5: ed1db38fa6cf50302eb6b9a25f0b6daa
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - mkl_fft
+  - mkl_random
+  - numpy-base 2.2.1 py311hd01c5d8_0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - setuptools <74
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11696
+  timestamp: 1736506710332
+- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-2.2.1-py311hd01c5d8_0.tar.bz2
+  sha256: 0ba9563d76efa6cda7e29c6d5d6b8e243d64837b9fb9ddebcd51cccf3ebf4aa7
+  md5: 60fd1362aba347e454a23f9863847eec
+  depends:
+  - blas 1.0 mkl
+  - mkl >=2023.1.0,<2024.0a0
+  - mkl-service >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - setuptools <74
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11894274
+  timestamp: 1736506680884
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+  sha256: e2afce0548808d27293a03661ee5f7ac3e18f82a92c9fb23f420eb5e92126fc6
+  md5: 9dd921a785844abe0aa842c3800d405a
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.7.0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 286986
+  timestamp: 1722872761369
+- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.15-h827c3e9_0.tar.bz2
+  sha256: a72f51f69a6893797b51345f9fd6b6a3b12764b435bb50e247e9e05d75711bd0
+  md5: c05007cfd519c5097f50d9c830ad897f
+  depends:
+  - ca-certificates
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 8396971
+  timestamp: 1725547066793
+- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+  sha256: b2f5f50a1ddf811102636f3acebd76716c88ebb628754b91eda7a3a962adf26c
+  md5: 712527b4d84c350dca4b67f511c04414
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39421
+  timestamp: 1699371341381
+- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.2-py311haa95532_0.tar.bz2
+  sha256: 55ead6073f34770ba6ab735643411f2219ecd820d186ca3af266954d05e09487
+  md5: 6bae6e1982c2e8a4eb1c66df62521fa3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0 or BSD-2-Clause
+  license_family: Apache
+  size: 189953
+  timestamp: 1734472735678
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.3-py311h5da7b33_0.tar.bz2
+  sha256: 82cc56df413c3875ccc7c811d3268a1404c6ed2b8d02bf7980f2c87a88918168
+  md5: e109a06ad54fcea29bdaa01596179a8b
+  depends:
+  - bottleneck >=1.3.6
+  - numexpr >=2.8.4
+  - numpy >=1.23.2,<3
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - pytz >=2020.1
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  constrains:
+  - lxml >=4.9.2
+  - pyreadstat >=1.2.0
+  - psycopg2 >=2.9.6
+  - pyqt >=5.15.9
+  - python-calamine >=0.1.7
+  - dataframe-api-compat >=0.1.7
+  - scipy >=1.10.0
+  - gcsfs >=2022.11.0
+  - zstandard >=0.19.0
+  - numba >=0.56.4
+  - pymysql >=1.0.2
+  - xlsxwriter >=3.0.5
+  - sqlalchemy >=2.0.0
+  - beautifulsoup4 >=4.11.2
+  - xlrd >=2.0.1
+  - openpyxl >=3.1.0
+  - s3fs >=2022.11.0
+  - jinja2 >=3.1.2
+  - fsspec >=2022.11.0
+  - html5lib >=1.1
+  - pytables >=3.8.0
+  - blosc >=1.21.3
+  - adbc-driver-postgresql >=0.8.0
+  - pandas-gbq >=0.19.0
+  - matplotlib-base >=3.6.3
+  - qtpy >=2.3.0
+  - fastparquet >=2022.12.0
+  - odfpy>=1.4.1
+  - pyarrow >=10.0.1
+  - tabulate >=0.9.0
+  - pyxlsb >=1.0.10
+  - xarray >=2022.12.0
+  - adbc-driver-sqlite >=0.8.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17254708
+  timestamp: 1732738447404
+- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.5.3-py311haa95532_0.tar.bz2
+  sha256: b0200b6e41271d9e8d37a423315190d4e0932c9f7fbc49895bfb6dd3af815b32
+  md5: 6e9c63ef2b4e4705c1df990034b685cb
+  depends:
+  - bleach
+  - bokeh >=3.5.0,<3.7.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - packaging
+  - pandas >=1.2,<3.0.0
+  - param >=2.1.0,<3.0
+  - python >=3.11,<3.12.0a0
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing-extensions
+  constrains:
+  - holoviews >=1.18.0
+  - bokeh-fastapi >=0.1.2,<0.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24127520
+  timestamp: 1730381316612
+- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.2.0-py311haa95532_0.tar.bz2
+  sha256: 4086a9512de16e81900140f66ed8e693f05f333f298a83b39a11d5c887fb2434
+  md5: 1314cc7bad5784cd7bee147f44ec9947
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 273134
+  timestamp: 1734618723915
+- conda: https://repo.anaconda.com/pkgs/main/win-64/parso-0.8.4-py311haa95532_0.tar.bz2
+  sha256: d9548c1a2c3292e37ff5d8a4b8f10785f3718b445a64b3e259cbed4ec17700e7
+  md5: 59cb810d1a41684238817cb875734af2
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 224906
+  timestamp: 1733963496420
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-11.0.0-py311h096bfcc_1.tar.bz2
+  sha256: 55f0d0c9b64311a8514632574e27e05476366459253db82694fa6c36566ebf3d
+  md5: f852ef4aa5f61e08da8afcfb6ea75f83
+  depends:
+  - freetype >=2.10.4,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.16,<3.0a0
+  - libtiff >=4.2.0,<4.7.0
+  - libtiff >=4.5.1,<4.7.0
+  - libwebp-base >=1.3.2,<2.0a0
+  - openjpeg >=2.3.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: HPND AND TCL
+  license_family: Other
+  size: 990296
+  timestamp: 1734431204885
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.2-py311haa95532_0.tar.bz2
+  sha256: 9c0dc12161f77b43137dad2e520ed7a343c5d8d8fd545492336e84201d1bb74c
+  md5: 22cda044cb24e1db8fbaa5864feb4261
+  depends:
+  - python >=3.11,<3.12.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 3199019
+  timestamp: 1723485404416
+- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+  sha256: e5f8cbfb5fc25d460a9117bfc5511959c5e86ccb193316033f87bd516e0c8881
+  md5: 9f7e8b5eb651539386bb92c14e5c321b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 37730
+  timestamp: 1692205554840
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.21.0-py311haa95532_0.tar.bz2
+  sha256: 98674172e2820965291e63eab571fde1fd26cbbad3856be6f86f415e7e1037b8
+  md5: 30ffc1f7b25ca073001fb641f9724520
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 122618
+  timestamp: 1731961709745
+- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+  sha256: 546819d922b03f3a25ca9f98fd069d0588d481fc0603c6d74bd598fb6a93687f
+  md5: 86c18e3e0b67ee099457475ed6caf2e6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.43
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 751763
+  timestamp: 1704404627180
+- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h827c3e9_1.tar.bz2
+  sha256: ac23609428982448c7d8e4457b4c7ad3cf0373fd33cf12767b6b064ebca729bc
+  md5: ce75fc6d561dbe9fc629b7a7c4359af3
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 523851
+  timestamp: 1736372163558
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+  sha256: d95c88d06f4f3f667bd9a39e5f18179e83b3cd4c115c06ce0fff390ff6d3a700
+  md5: c6d00a8a4d89b1be99bfa3aff19d96b4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2134881
+  timestamp: 1684280285492
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.2.0-py311haa95532_0.tar.bz2
+  sha256: 30ed42a98c68d6c98d48f871197c5c9c745e7545a12818a21d36689fe1a3a856
+  md5: dfd92ad9c788e9c687ca8adc3f541ce0
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 486618
+  timestamp: 1731445794006
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+  sha256: 974c22de09078bf07c5db31fe12d8d89d6433508defc8237cbe52e08c69ed56b
+  md5: 9cf10bfd49140a527cf4b1d912097e6d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - win_inet_pton
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 36072
+  timestamp: 1676426019064
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.11-h4607a30_0.tar.bz2
+  sha256: a53f9aa74ecbe1f97a4956425ad1636d8c936750636dd7de0ac8d35ae14b105b
+  md5: b3717cd05b5595bd3c839f202df46e74
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<3.5
+  - libffi >=3.4,<4.0a0
+  - openssl >=3.0.15,<4.0a0
+  - sqlite >=3.45.3,<4.0a0
+  - tk >=8.6.14,<8.7.0a0
+  - tzdata
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  constrains:
+  - openssl <3.5.7
+  license: PSF-2.0
+  license_family: PSF
+  size: 20212416
+  timestamp: 1733935177242
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+  sha256: 2c61639b3bb56fc864c86558bceb7845b1731ac44bf1a94894172ea47a995bd4
+  md5: 404805e547b4d50b5cd17e16bca87527
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six >=1.5
+  license: BSD-3-Clause and Apache-2.0
+  license_family: BSD
+  size: 332043
+  timestamp: 1716495838826
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.20.0-py311haa95532_0.tar.bz2
+  sha256: dbd986e65f63d73389c7ecf060c0954905f3dba4b2f9f33bf930ca4cb0875310
+  md5: c2604164bf8765f3281c1f65ef5eac92
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 282101
+  timestamp: 1731939443247
+- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-3.2.1-py311haa95532_0.tar.bz2
+  sha256: 68389376bdfc521ad3b3f264267420b4c1f99356e90fb0f894128f40f5975ab3
+  md5: 65408c0fbd3705ce3fcd630e19effa73
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29508
+  timestamp: 1734370229403
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+  sha256: 803274d986d0c4e3b5ec1018747ede86ef57137455b3e44a60e834717eafb92b
+  md5: c9f134ddeff6fdf0373a45534ddb7079
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 273009
+  timestamp: 1713974722039
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+  sha256: 6fbcba97c1dcb5157afd23f264c3cff069c7e4be5ea55980fc349eb8dc2cb49e
+  md5: 8153e3f8b3283926bcf9403804a365f5
+  depends:
+  - param
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65050
+  timestamp: 1711137009299
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-308-py311h5da7b33_0.tar.bz2
+  sha256: 6b6a583ddae1f7fdf8b3923bd2b8c56382b2c77d0d08ed536e3237c8b82f9f02
+  md5: 01baaaa03f7066e272de93b25539c834
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
+  size: 13813074
+  timestamp: 1732201761313
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.14-py311h72d21ff_0.tar.bz2
+  sha256: dd0c35a9a5a0e35033b3a5a4c1a98b121670b9e9c795ee8dcf400534760af267
+  md5: 2addb0793c3e949f71e415943db41e70
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - winpty >=0.4.3,<1.0a0
+  license: MIT
+  license_family: MIT
+  size: 250185
+  timestamp: 1733515229618
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.2-py311h827c3e9_0.tar.bz2
+  sha256: b54065893111c3bf4ab784feb9a0b7b58bd829c414adda935624790d6541885f
+  md5: 1d84022dd238ec68d7c0499885d18c86
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 209408
+  timestamp: 1728658205944
+- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+  sha256: ea39db411361d96545a04fb976940e9590147acb4ca9caacf7e8264780379347
+  md5: b411b8be8e53e5059949dde02dd07faf
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  - zeromq >=4.3.5,<4.3.6.0a0
+  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license_family: Other
+  size: 565148
+  timestamp: 1709319072176
+- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+  sha256: 47653b45a5f2d97b5bf0dbf0e620908880f9078da427eef69012effe3f19af67
+  md5: 44e709ae67d89bccee2d4d46d358fee3
+  depends:
+  - attrs >=22.2.0
+  - python >=3.11,<3.12.0a0
+  - rpds-py >=0.7.0
+  license: MIT
+  license_family: MIT
+  size: 74493
+  timestamp: 1699012356534
+- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py311haa95532_1.tar.bz2
+  sha256: a225c1d6a873991bed5c9e93806f0ef0af35830cd6ce09a849e20084a8372200
+  md5: 321bb6bf4f0afb4e9175bcb75ab57976
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.11,<3.12.0a0
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  - pysocks >=1.5.6,!=1.5.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 124386
+  timestamp: 1731000647310
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+  sha256: d6daaa6b45272819176e4aeb467ae00e3db43386548464a9993688f292709d40
+  md5: 9fe721d7f7420c259df4f07d4503f654
+  depends:
+  - python >=3.11,<3.12.0a0
+  - six
+  license: MIT
+  license_family: MIT
+  size: 9683
+  timestamp: 1683077110211
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+  sha256: 6051860575f9448aea5799d74469c928cd7cdeeca1eb53657872262a77b1a7a8
+  md5: 60e193eca497130034facd5fed168249
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 10094
+  timestamp: 1683059114376
+- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h636fa0f_1.tar.bz2
+  sha256: f97f61e82acb6b6481684fc7b48a5ceeda7dec8ad47dad1d2a5889e89a2f8330
+  md5: 48c238f5dc664b9d53cb375f3ecad8f6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: MIT
+  license_family: MIT
+  size: 222327
+  timestamp: 1732234798230
+- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+  sha256: 6fd52bae6360fbc8135d72e0c1e4fd407769fa4d0f4b59356e7aed3e000eb339
+  md5: 49fd52885250da8aab17ed72e2e18b81
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 88901
+  timestamp: 1699371435766
+- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-72.1.0-py311haa95532_0.tar.bz2
+  sha256: 9b5fdd849cbbf043c586ec778e225b2ed6f47f933a668f5a3969173254ae41e6
+  md5: 833f99fc56cb5e9c31ce0a4eba51b796
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 3307874
+  timestamp: 1722860376387
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+  sha256: 5d1b7e14dc04816692de0f8518ea8fcbefb26ab61cec83f96f2c44c1bee67fab
+  md5: 505d2a70a875b5082dc857aa4dfab0d4
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT OR Apache-2.0
+  license_family: Other
+  size: 18830
+  timestamp: 1705431395254
+- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+  sha256: 5ff3b4ac3fbce4dd67a87856c04698d0397deb0ac288ff4e7eb02fbab57f1253
+  md5: 0ca650a7001c6650809d3361de8cb005
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 89590
+  timestamp: 1696347858925
+- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+  sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
+  md5: 833b93a2daade3407898f15588945d83
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: blessing
+  license_family: Other
+  size: 1440481
+  timestamp: 1714488344682
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+  sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
+  md5: 2d00fccaf04f00047d71d21d309cf764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 152822
+  timestamp: 1680167347239
+- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+  sha256: 78d89b50a29fbeb19a562f5dad95615e3f192bb4f3b86cd6ea75f2f825418232
+  md5: 4a4040df560ea47704e0898c4c015808
+  depends:
+  - python >=3.11,<3.12.0a0
+  - pywinpty >=1.1.0
+  - tornado >=6.1.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 38069
+  timestamp: 1678228553220
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+  sha256: 70a3cc4a4e81a6421bc19cd410d1d6064aadb2b1cce38b020f85e5346716d8e7
+  md5: 32a9a2539579a3d522dce3b5cb4f987b
+  depends:
+  - python >=3.11,<3.12.0a0
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49495
+  timestamp: 1676425411739
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+  sha256: 0a95736cfd0bb25fc201cd6be4a2450ea8fc30eeb349d861812675b84c94fa74
+  md5: a8a9fb30c6dd8e7a16d5dcd2333c3c49
+  depends:
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.27.29016,<15.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  size: 3844176
+  timestamp: 1714770894235
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.2-py311h827c3e9_0.tar.bz2
+  sha256: 04c7dd95fc472792fd29e76a8a5a0d1e9f87dd2569c3db59c36253f2f7fb420f
+  md5: c24e1d36c566681be5bba111e5883c0d
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 933447
+  timestamp: 1733960990402
+- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.5-py311h746a85d_0.tar.bz2
+  sha256: 283f31f5ef79657b27b9a6d82b5366b869744b553f90bad219714f2771b0088f
+  md5: cea2f913161c630749f8e8ac190c99f3
+  depends:
+  - colorama
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - ipywidgets >=6
+  license: MPL-2.0 AND MIT
+  license_family: MOZILLA
+  size: 186694
+  timestamp: 1724854118410
+- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
+  sha256: a724711191ac1226bf228eab49718eed7b5c7394f539294eb0f88baf8e7bb24d
+  md5: c78482e07d0aa6df9fcfa5b366dd87e3
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 207744
+  timestamp: 1718227224929
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.12.2-py311haa95532_0.tar.bz2
+  sha256: 81ba8633c9266a47ccf6c13e675548ac10b3a6e6a7bfa978c1fa1c3bac078909
+  md5: 15f63d935470581900fb5cb5a77bddfa
+  depends:
+  - python >=3.11,<3.12.0a0
+  - typing_extensions 4.12.2 py311haa95532_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 9887
+  timestamp: 1734714947897
+- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.12.2-py311haa95532_0.tar.bz2
+  sha256: d348f55f9646a6d564dddbc3b2fcdcb6972bb1da9d9ad38941399cafc2d35f21
+  md5: 8f78d5a156c9f79284c5d191e091101c
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 82553
+  timestamp: 1734714936074
+- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+  sha256: d091897f05318c22ca31028370f25355065999078f7db6f88ab27bf4cb030ec8
+  md5: 1776502c1cfb351554eeda6cddaf255f
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 11588
+  timestamp: 1676457729096
+- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+  sha256: c16498f8238cc331618720d078b87995eceb6bbf20268a7a4e8efbf7b5859a9a
+  md5: 770432c0ca1ab9d99ffe95e51d3a3e74
+  depends:
+  - python >=3.11,<3.12.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 517433
+  timestamp: 1713213261710
+- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.3-py311haa95532_0.tar.bz2
+  sha256: de79b019200fdeb430ce7971edaa7af403cbfc1b52e1bdca6e496c6eeaf6b37f
+  md5: ba54713eec74d8c2636f137608ad8959
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.11,<3.12.0a0
+  constrains:
+  - selenium >=4.4.3
+  - zstandard >=0.18.0
+  - h2 >=4,<5
+  - requests >=2.26.0
+  license: MIT
+  license_family: MIT
+  size: 218619
+  timestamp: 1727770119876
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.40-haa95532_2.tar.bz2
+  sha256: 2347a1c63da77846cb2161daaca7a7918fd1f2f8fc6c482b1da15f2c81ff9401
+  md5: 82f790121c5a4b129df23a0c264a5371
+  depends:
+  - vs2015_runtime >=14.42.34433
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9297
+  timestamp: 1733348498082
+- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.42.34433-h9531ae6_2.tar.bz2
+  sha256: e5a9bb7ea0534170f6cd52021dd2c9cdd2048eb7cf30bd983ce12caf7fdcdb21
+  md5: 8a633c6afbd406dcec4a824949408c1a
+  size: 2461182
+  timestamp: 1733348487481
+- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+  sha256: 24ea3d3e0cb98d0d246338dbb4562b67967bb32002e3704e495a5c863476e831
+  md5: c7b9cdbe87b3c9720aeca1164a0fd6df
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD 3-Clause
+  license_family: BSD
+  size: 26181
+  timestamp: 1676424437003
+- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+  sha256: 92d27e41ce34387e59acb47572fcb2e92c4defaeadafd11ce190226022023e69
+  md5: f1bf142d852987acbe4b0bc94e87d958
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 145306
+  timestamp: 1715878654770
+- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.44.0-py311haa95532_0.tar.bz2
+  sha256: 2eb16eafe8322ad10c73b19be8f2c8b6135561bead6f73f48c069417f5db8928
+  md5: b28ec461da7eac99523f146ae752529b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: MIT
+  license_family: MIT
+  size: 170318
+  timestamp: 1726165294131
+- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+  sha256: 17fadf35aa8917c107e7b369e9364ac7c09537776e7943d37e225e14b7026c94
+  md5: 0e67c3b9624540581b894b11267a837b
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: PUBLIC-DOMAIN
+  size: 10197
+  timestamp: 1676425485716
+- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+  sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
+  md5: c5bdb727945bad906d23e44199144746
+  license: MIT
+  size: 1177536
+  timestamp: 1517593466234
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+  sha256: b849b368e27920838fe40a512b102879693a55cb187dd1c8d3a83fa8c05a8054
+  md5: 7b1f6e9c71906a93039b3446b99a5498
+  depends:
+  - python >=3.11,<3.12.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55114
+  timestamp: 1676434863173
+- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+  sha256: 344a5276a9928638dcde054dfe4e87c8cb40bd2d4d356378b9ab2f863ca62e4b
+  md5: fe471fd8b5a3d77be6fa5dbf9b99dafb
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
+  license_family: GPL2
+  size: 1432281
+  timestamp: 1714515119689
+- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+  sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
+  md5: daa42ad494a780c2f433596651132c1c
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MIT
+  size: 66759
+  timestamp: 1593116189318
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+  sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
+  md5: e5aed81295b61b6d1eb62830799a0297
+  depends:
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: MPL-2.0
+  license_family: Other
+  size: 9125184
+  timestamp: 1705602328351
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+  sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
+  md5: f295b54ab59f5b8658e2a322ac6aa721
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012,<15.0a0
+  license: Zlib
+  license_family: Other
+  size: 162161
+  timestamp: 1714514792081
+- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
+  sha256: 1f68cd378c6cdec34a5a3a21c56c9b8422b0f037b868b3db72065c0a2ca27921
+  md5: d455a04486eddfb94c280974c0c33ae3
+  depends:
+  - lz4-c >=1.9.4,<1.10.0a0
+  - vc >=14.2,<15.0a0
+  - vs2015_runtime >=14.29.30133,<15.0a0
+  - xz >=5.4.6,<6.0a0
+  - zlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause AND GPL-2.0-or-later
+  license_family: BSD
+  size: 1971698
+  timestamp: 1728487049972

--- a/world_cup/pixi.lock
+++ b/world_cup/pixi.lock
@@ -7,638 +7,638 @@ platforms:
 environments:
   default:
     channels:
-    - url: https://repo.anaconda.com/pkgs/main/
-    - url: https://repo.anaconda.com/pkgs/msys2/
+    - url: https://conda.anaconda.org/main/
+    - url: https://conda.anaconda.org/msys2/
     packages:
       linux-64:
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.6.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-24.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bleach-6.2.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.4.2-py311hf4808d0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.12.31-h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.12.14-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py311h1fdaa30_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.3.1-py311hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.8.11-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.20.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.11.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.30.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.23.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.16-hb9589c4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-4.0.0-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.22-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-hffd6297_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.10.0-py311hbfdbfaf_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.11-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.8-py311ha02d727_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.16.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.10.1-py311h3c60e43_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-2.2.1-py311h08b1b3b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-2.2.1-py311hf175353_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.15-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.3-py311h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.5.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.2.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/parso-0.8.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-11.0.0-py311hcea889d_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.21.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.2.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.11-he870216_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.20.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-3.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311h4aa5aa6_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-72.1.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.2-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.5-py311h92b7b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.12.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.12.2-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.3-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.44.0-py311h06a4308_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/anyio-4.6.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/attrs-24.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bleach-6.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bokeh-3.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.4.2-py311hf4808d0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py311h6a678d5_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2024.12.31-h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/certifi-2024.12.14-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/cffi-1.17.1-py311h1fdaa30_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/contourpy-1.3.1-py311hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/debugpy-1.8.11-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/holoviews-1.20.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/hvplot-0.11.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.29.5-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ipython-8.30.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jedi-0.19.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.4-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.23.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lcms2-2.16-hb9589c4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lerc-4.0.0-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.22-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-hffd6297_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py311h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.10.0-py311hbfdbfaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py311h5eee18b_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.11-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.8-py311ha02d727_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.16.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nbformat-5.10.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numexpr-2.10.1-py311h3c60e43_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-2.2.1-py311h08b1b3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/numpy-base-2.2.1-py311hf175353_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.15-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/packaging-24.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pandas-2.2.3-py311h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/panel-1.5.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/param-2.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/parso-0.8.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pillow-11.0.0-py311hcea889d_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pip-24.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.21.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py311h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.2.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-3.11.11-he870216_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.20.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/python-json-logger-3.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.2-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/requests-2.32.3-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py311h4aa5aa6_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/setuptools-72.1.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tornado-6.4.2-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/tqdm-4.66.5-py311h92b7b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.12.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.12.2-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/urllib3-2.2.3-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/wheel-0.44.0-py311h06a4308_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
       osx-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.6.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h46256e1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bleach-6.2.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.4.2-py311h9b7fc35_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h46256e1_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h46256e1_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311h6d0c2b6_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.12.31-hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.12.14-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py311h9205ec4_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.3.1-py311h1962661_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.8.11-py311h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.20.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.11.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.30.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.23.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.16-h4f63f0c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-4.0.0-h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h46256e1_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h46256e1_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h46256e1_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.22-h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-h6fa9cd1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h46256e1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.10.0-py311h919b35b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.10.1-py311hc59c7be_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-2.1.3-py311h13f252e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-2.1.3-py311ha745260_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.15-h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.3-py311h6d0c2b6_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.5.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.2.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/parso-0.8.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-11.0.0-py311h47bf62f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.21.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h46256e1_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.2.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.11-h4d6d9e5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.20.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-3.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py311h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311h83de92b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-72.1.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.2-py311h46256e1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.5-py311h85bffb1_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.12.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.12.2-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.3-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.44.0-py311hecd8cb5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/anyio-4.6.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py311h46256e1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/attrs-24.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bleach-6.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bokeh-3.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.4.2-py311h9b7fc35_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-h46256e1_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-h46256e1_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py311h6d0c2b6_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2024.12.31-hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/certifi-2024.12.14-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/cffi-1.17.1-py311h9205ec4_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/contourpy-1.3.1-py311h1962661_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/debugpy-1.8.11-py311h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/holoviews-1.20.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/hvplot-0.11.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.29.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ipython-8.30.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jedi-0.19.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.23.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lcms2-2.16-h4f63f0c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lerc-4.0.0-h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h46256e1_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h46256e1_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h46256e1_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.22-h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-h6fa9cd1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py311h46256e1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.10.0-py311h919b35b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.16.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nbformat-5.10.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numexpr-2.10.1-py311hc59c7be_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-2.1.3-py311h13f252e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/numpy-base-2.1.3-py311ha745260_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.15-h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/packaging-24.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pandas-2.2.3-py311h6d0c2b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/panel-1.5.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/param-2.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/parso-0.8.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pillow-11.0.0-py311h47bf62f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pip-24.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.21.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py311h46256e1_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.2.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-3.11.11-h4d6d9e5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.20.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/python-json-logger-3.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.2-py311h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/requests-2.32.3-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py311h83de92b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/setuptools-72.1.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tornado-6.4.2-py311h46256e1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/tqdm-4.66.5-py311h85bffb1_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.12.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.12.2-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/urllib3-2.2.3-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/wheel-0.44.0-py311hecd8cb5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
       osx-arm64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.6.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-24.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bleach-6.2.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.4.2-py311hb9f6ed7_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.12.31-hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.12.14-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.3.1-py311h48ca7d4_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.8.11-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.20.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.11.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.30.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.23.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.16-he93ba84_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-4.0.0-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.22-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-hc9ead59_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.10.0-py311h7ef442a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.10.1-py311h5d9532f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-2.2.1-py311he598dae_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-2.2.1-py311hfbfe69c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.15-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.3-py311hcf29cfe_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.5.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.2.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/parso-0.8.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-11.0.0-py311h84e58ab_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.21.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.2.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.11-hb885b13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.20.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-3.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.2-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311h2aea54e_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-72.1.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.2-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.5-py311hb6e6a13_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.12.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.12.2-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.3-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.44.0-py311hca03da5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.6.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/attrs-24.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bleach-6.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.4.2-py311hb9f6ed7_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h80987f9_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h80987f9_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2024.12.31-hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.12.14-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.3.1-py311h48ca7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.8.11-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.20.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/hvplot-0.11.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.29.5-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.30.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.19.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.4-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.23.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.16-he93ba84_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lerc-4.0.0-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.22-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-hc9ead59_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.10.0-py311h7ef442a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.16.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.10.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.10.1-py311h5d9532f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-2.2.1-py311he598dae_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-2.2.1-py311hfbfe69c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.15-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/packaging-24.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.2.3-py311hcf29cfe_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/panel-1.5.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/param-2.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/parso-0.8.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pillow-11.0.0-py311h84e58ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pip-24.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.21.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py311h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.2.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-3.11.11-hb885b13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.20.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-3.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.2-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/requests-2.32.3-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py311h2aea54e_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/setuptools-72.1.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.4.2-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.66.5-py311hb6e6a13_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.12.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.12.2-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.2.3-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.44.0-py311hca03da5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
       win-64:
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.6.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h827c3e9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-24.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bleach-6.2.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.4.2-py311h57dcf0c_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h827c3e9_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h827c3e9_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311h5da7b33_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.12.31-haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.12.14-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py311h827c3e9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.3.1-py311h214f63a_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.8.11-py311h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.20.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.11.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.30.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.23.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.16-hb4a4139_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-4.0.0-h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h827c3e9_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h827c3e9_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h827c3e9_9.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.22-h5bf469e_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-h44ae7cf_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h827c3e9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.10.0-py311he19b0ae_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h827c3e9_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.11-py311h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.8-py311hea22821_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.10.1-py311h4cd664f_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-2.2.1-py311hdab7c0b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-2.2.1-py311hd01c5d8_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.15-h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.3-py311h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.5.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.2.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/parso-0.8.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-11.0.0-py311h096bfcc_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.21.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h827c3e9_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.2.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.11-h4607a30_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.20.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-3.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-308-py311h5da7b33_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.14-py311h72d21ff_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.2-py311h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h636fa0f_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-72.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.2-py311h827c3e9_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.5-py311h746a85d_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.12.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.12.2-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.3-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.40-haa95532_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.42.34433-h9531ae6_2.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.44.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
-      - conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/anyio-4.6.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py311h827c3e9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/attrs-24.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bleach-6.2.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bokeh-3.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bottleneck-1.4.2-py311h57dcf0c_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h827c3e9_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h827c3e9_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py311h5da7b33_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ca-certificates-2024.12.31-haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/certifi-2024.12.14-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/cffi-1.17.1-py311h827c3e9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/contourpy-1.3.1-py311h214f63a_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/debugpy-1.8.11-py311h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/holoviews-1.20.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/hvplot-0.11.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipykernel-6.29.5-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/ipython-8.30.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jedi-0.19.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.4-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-4.23.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lcms2-2.16-hb4a4139_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lerc-4.0.0-h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h827c3e9_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h827c3e9_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h827c3e9_9.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libdeflate-1.22-h5bf469e_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-h44ae7cf_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py311h827c3e9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.10.0-py311he19b0ae_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py311h827c3e9_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.11-py311h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.8-py311hea22821_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbconvert-7.16.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nbformat-5.10.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numexpr-2.10.1-py311h4cd664f_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-2.2.1-py311hdab7c0b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/numpy-base-2.2.1-py311hd01c5d8_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/openssl-3.0.15-h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/packaging-24.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pandas-2.2.3-py311h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/panel-1.5.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/param-2.2.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/parso-0.8.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pillow-11.0.0-py311h096bfcc_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pip-24.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.21.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py311h827c3e9_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyparsing-3.2.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-3.11.11-h4607a30_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.20.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/python-json-logger-3.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywin32-308-py311h5da7b33_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.14-py311h72d21ff_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.2-py311h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/requests-2.32.3-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py311h636fa0f_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/setuptools-72.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tornado-6.4.2-py311h827c3e9_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/tqdm-4.66.5-py311h746a85d_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.12.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.12.2-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/urllib3-2.2.3-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vc-14.40-haa95532_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.42.34433-h9531ae6_2.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/wheel-0.44.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+      - conda: https://conda.anaconda.org/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
 packages:
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_libgcc_mutex-0.1-main.tar.bz2
   sha256: bd36a740479053a94d9c2a92bc55333a7a1a3e63ec0341d4cde6b7825bae0ee3
   md5: 013d3f22cd3b87f71224bd936765bcad
   size: 3121
   timestamp: 1562011674792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/_openmp_mutex-5.1-1_gnu.tar.bz2
   sha256: 9e1391519971e7ce527b3f268900d079bedf0eff3fb70cdb4844cd0f64dfe086
   md5: 613805add1c05b538ff06d217252feb7
   depends:
@@ -649,7 +649,7 @@ packages:
   license: BSD-3-Clause
   size: 20810
   timestamp: 1652859733309
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/anyio-4.6.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/anyio-4.6.2-py311h06a4308_0.tar.bz2
   sha256: d58b068fe1b9c195394e77a6fba4d152c6934e97df7757dd6b921498f8aa72f8
   md5: 09de3b2d5519a680bda3c3771380c3da
   depends:
@@ -663,7 +663,7 @@ packages:
   license_family: MIT
   size: 243587
   timestamp: 1729121303719
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/argon2-cffi-bindings-21.2.0-py311h5eee18b_1.tar.bz2
   sha256: b7eb9612c200994d8126caa0c36561a586c6a8a57066609febae6ff4d61da35a
   md5: 6181c14ad55e754ce7327ec32e7a2bf9
   depends:
@@ -674,7 +674,7 @@ packages:
   license_family: MIT
   size: 36032
   timestamp: 1736182558607
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/attrs-24.3.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/attrs-24.3.0-py311h06a4308_0.tar.bz2
   sha256: 9c40ad73b2f2f2a6ea5ae3919a9a538518b0eb92baef29f07fd006fca09a5e90
   md5: b6fca842c8ea8530e4d1751c277e8ba2
   depends:
@@ -683,7 +683,7 @@ packages:
   license_family: MIT
   size: 162429
   timestamp: 1734533126936
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/beautifulsoup4-4.12.3-py311h06a4308_0.tar.bz2
   sha256: 5bb9bfe025d9a49af272f194278f63cea7366e83bdf3f99d25f97b820d522089
   md5: 100d3161d97332fe38945afec8d36935
   depends:
@@ -693,12 +693,12 @@ packages:
   license_family: MIT
   size: 276381
   timestamp: 1718029864701
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/blas-1.0-mkl.tar.bz2
   sha256: 122379250785e89e0f47bad413928341643360563eb95fde4767c45262939f36
   md5: 751c2c5b239a728db05f91374aaac3a1
   size: 5838
   timestamp: 1528122042945
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bleach-6.2.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bleach-6.2.0-py311h06a4308_0.tar.bz2
   sha256: 46d4caa9b996615e6d367282d5ba3a4a11f23052fac305cf52fc067e4f766ed7
   md5: 5f923de750f6d8a2a9faa8cf90da6311
   depends:
@@ -710,7 +710,7 @@ packages:
   license_family: Apache
   size: 367370
   timestamp: 1732290516590
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bokeh-3.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bokeh-3.6.0-py311h06a4308_0.tar.bz2
   sha256: 30dedc2bed0aa72523531f5e22fff96c948bb2f68addb625161ef50b07484fb9
   md5: 1571b1a2aded9cbd3c0c7656e9a9ebbe
   depends:
@@ -728,7 +728,7 @@ packages:
   license_family: BSD
   size: 5853990
   timestamp: 1727914619438
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bottleneck-1.4.2-py311hf4808d0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bottleneck-1.4.2-py311hf4808d0_0.tar.bz2
   sha256: de78a7f35a57c21d8986c1084f308c98477747d6a92a0b23b5d4855333eee0c9
   md5: 85399e523becae3ca29054b3d579b8e7
   depends:
@@ -739,7 +739,7 @@ packages:
   license_family: BSD
   size: 148890
   timestamp: 1731058903578
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-1.0.9-h5eee18b_9.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-1.0.9-h5eee18b_9.tar.bz2
   sha256: b59efa2904ae9978739d8ace23f3f27c6a45d478d8a1b280946aa232e70f3cfd
   md5: 055fcc9955965c288132fa36c5ce3053
   depends:
@@ -750,7 +750,7 @@ packages:
   license: MIT
   size: 18722
   timestamp: 1736182569595
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-bin-1.0.9-h5eee18b_9.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-bin-1.0.9-h5eee18b_9.tar.bz2
   sha256: 1f6dcd77e302c8a468764a1b2302828dacb87aafe55d2e2374b8e00fca9b62c0
   md5: 77d68ab5e96a98bfde1a74670999fb90
   depends:
@@ -760,7 +760,7 @@ packages:
   license: MIT
   size: 19800
   timestamp: 1736182559439
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/brotli-python-1.0.9-py311h6a678d5_9.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/brotli-python-1.0.9-py311h6a678d5_9.tar.bz2
   sha256: b7ff9535237880e6fb540d58ce2b904e9407904c92579260b92be12a4451281a
   md5: f229f321f52804bfa696fed56b11b5d1
   depends:
@@ -770,7 +770,7 @@ packages:
   license: MIT
   size: 361254
   timestamp: 1736182674347
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/bzip2-1.0.8-h5eee18b_6.tar.bz2
   sha256: 8ed99913fcd4b28f85ff176583115f9673a920f58fe4b0c59cf2c76e8046aee3
   md5: f5058c8d5b2994b7334f18e022105a14
   depends:
@@ -779,14 +779,14 @@ packages:
   license_family: BSD
   size: 427542
   timestamp: 1714510571510
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ca-certificates-2024.12.31-h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ca-certificates-2024.12.31-h06a4308_0.tar.bz2
   sha256: c4937657ed853c9c65270ed0f2a0cf6f52fa12f79d34a80fb865b99af32dee06
   md5: 514df5b057d22088c8ae4e340803fe53
   license: MPL-2.0
   license_family: Other
   size: 137958
   timestamp: 1736360393668
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/certifi-2024.12.14-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/certifi-2024.12.14-py311h06a4308_0.tar.bz2
   sha256: 47947a1e2c41071780fca3cce3fea9de888c47e06c456fc84f1cff80eace0109
   md5: 2253b0553985a10579b262cb6ea2f718
   depends:
@@ -795,7 +795,7 @@ packages:
   license_family: Other
   size: 166554
   timestamp: 1734473301827
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.17.1-py311h1fdaa30_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/cffi-1.17.1-py311h1fdaa30_1.tar.bz2
   sha256: a73bd99651100ddd118806e62f20b2b6fac0098e0615580314fb8cc983467d4e
   md5: b8f1ba0cf72321301cd1d840fd286731
   depends:
@@ -807,7 +807,7 @@ packages:
   license_family: MIT
   size: 308046
   timestamp: 1736182517693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/colorcet-3.1.0-py311h06a4308_0.tar.bz2
   sha256: d9c102b9ec7f3a635936b6f73d4db126d748a25f65407353bd76b260dc7d1cd6
   md5: eec48dbdf5dac0ea26750cc26b58c1d9
   depends:
@@ -816,7 +816,7 @@ packages:
   license_family: CC
   size: 554986
   timestamp: 1709758392744
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/comm-0.2.1-py311h06a4308_0.tar.bz2
   sha256: 882481e441b9b93cbdfb32fbe32a6ad9f26197472f186a08fddb921f61346c02
   md5: 443c79196064f57c98199e9990544b2f
   depends:
@@ -826,7 +826,7 @@ packages:
   license_family: BSD
   size: 16902
   timestamp: 1709322958614
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/contourpy-1.3.1-py311hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/contourpy-1.3.1-py311hdb19cb5_0.tar.bz2
   sha256: 214cc9e08edf0430b1dca7d7a5407f19c16e9ad0684bb972a4a836e044196719
   md5: db381e74b7730d0b8b54a05d2716c28c
   depends:
@@ -838,7 +838,7 @@ packages:
   license_family: BSD
   size: 299819
   timestamp: 1732540101238
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/debugpy-1.8.11-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/debugpy-1.8.11-py311h6a678d5_0.tar.bz2
   sha256: 69c3214beb1e7f398f82a10c245af788304bbff2e1a12d0e15672f68ba00d974
   md5: d3c168f99c3d8bb146f89b3032f3ebaf
   depends:
@@ -849,7 +849,7 @@ packages:
   license_family: MIT
   size: 2844636
   timestamp: 1736267672061
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/entrypoints-0.4-py311h06a4308_0.tar.bz2
   sha256: 4b589e3265c74159130230c164ff2d8d381be65899a249def0b53f93ce83fd47
   md5: 245cb7173dcdba21cf368031cd87f706
   depends:
@@ -858,7 +858,7 @@ packages:
   license_family: MIT
   size: 17434
   timestamp: 1676823330845
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/fonttools-4.51.0-py311h5eee18b_0.tar.bz2
   sha256: b75d12e85274660bb675a3e53d47a929872f2daa2ff5a76e98885ee3f2d19ad1
   md5: f2119d0885334060d0d7fe59e5220287
   depends:
@@ -877,7 +877,7 @@ packages:
   license_family: MIT
   size: 3237908
   timestamp: 1713551660998
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/freetype-2.12.1-h4a9f257_0.tar.bz2
   sha256: 171f80eb26f00426bf47a361236cf0cc4cc0fb04769252b6f1d88a3bdb1f03cd
   md5: a5dc8677d891dff2393b63189a3ad42f
   depends:
@@ -888,7 +888,7 @@ packages:
   license_family: Other
   size: 971975
   timestamp: 1666798278693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/holoviews-1.20.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/holoviews-1.20.0-py311h06a4308_0.tar.bz2
   sha256: 97633f085c543505ab0ed53de62bbe516ffdef26f11449a5a361ef6303b3142d
   md5: 8b2ed66ea48b7e6fef1018404ddf93f1
   depends:
@@ -908,7 +908,7 @@ packages:
   license_family: BSD
   size: 6141733
   timestamp: 1730827820330
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/hvplot-0.11.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/hvplot-0.11.2-py311h06a4308_0.tar.bz2
   sha256: 0fadbb65eaa9e384ad80257f86b1acb2b4c9796d29aa13bb83d81e2d658b3073
   md5: bffdd73242bda84226e6f28a852368bf
   depends:
@@ -925,7 +925,7 @@ packages:
   license_family: BSD
   size: 371661
   timestamp: 1734469525165
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/idna-3.7-py311h06a4308_0.tar.bz2
   sha256: e08e27531775de40f46b6ac7bf71856963baa0c008bd2b4d112e6341cd3e8f4c
   md5: bfc7682613c861cbcb4ac01485c05657
   depends:
@@ -934,7 +934,7 @@ packages:
   license_family: BSD
   size: 147174
   timestamp: 1714398938840
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/intel-openmp-2023.1.0-hdb19cb5_46306.tar.bz2
   sha256: a437a24619632648df5051f7428b76a48e68f9e6b2fe3601243e6c93499bcb80
   md5: 3add2ce56858a1b8f6a37342f82773d3
   depends:
@@ -950,7 +950,7 @@ packages:
   license_family: Proprietary
   size: 19310769
   timestamp: 1699647799237
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipykernel-6.29.5-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipykernel-6.29.5-py311h06a4308_0.tar.bz2
   sha256: fe68041ab6344e8f2a6dd8e42032bc1332e22bc8c268e74b81e00fe10e35b822
   md5: 382be07ff80150df0b66abae64059a40
   depends:
@@ -971,7 +971,7 @@ packages:
   license_family: BSD
   size: 238033
   timestamp: 1728665623948
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ipython-8.30.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ipython-8.30.0-py311h06a4308_0.tar.bz2
   sha256: 8d16ed1f5ff00f096b360ce1d7f9b4a4878ddcc8c866c4e5da1d2d9c2cd98d5b
   md5: 7bfea7a1bfd1c08fddd95dc471270519
   depends:
@@ -989,7 +989,7 @@ packages:
   license_family: BSD
   size: 1634301
   timestamp: 1734548199842
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jedi-0.19.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jedi-0.19.2-py311h06a4308_0.tar.bz2
   sha256: 61d1e8ff671b50ee001b1702b12f44572f6963157964c825c7358ecd2e62bc16
   md5: f4040af0e38070f691bf43c120e8744f
   depends:
@@ -999,7 +999,7 @@ packages:
   license_family: MIT
   size: 1172008
   timestamp: 1733987427312
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jinja2-3.1.4-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jinja2-3.1.4-py311h06a4308_1.tar.bz2
   sha256: 1cf0f40f4bbb90b1280c32ddfa7e9a7b36b82e88a467c994b4c698c3d41ce5f2
   md5: 0731cad6883721022d93fbd62ffe1edc
   depends:
@@ -1011,7 +1011,7 @@ packages:
   license_family: BSD
   size: 356018
   timestamp: 1730903056980
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jpeg-9e-h5eee18b_3.tar.bz2
   sha256: 8316ae3abee25edab89788ee6e9eef79c398aba192559f514674a04ee1860bca
   md5: 112209aed451545a622ab217c70f6972
   depends:
@@ -1020,7 +1020,7 @@ packages:
   license_family: Other
   size: 283506
   timestamp: 1722872662693
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-4.23.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-4.23.0-py311h06a4308_0.tar.bz2
   sha256: caafff289b6a96f7f13668faa72e7a85346f410b1f97dc34163f70746bb98f1b
   md5: 27d1820c6bd6185aa888ee994d290bf1
   depends:
@@ -1033,7 +1033,7 @@ packages:
   license_family: MIT
   size: 192447
   timestamp: 1728486794980
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jsonschema-specifications-2023.7.1-py311h06a4308_0.tar.bz2
   sha256: 9e3bac2d41bd432b721b009e7de981766fba396e6f238e923f304112bd88655a
   md5: 84ae4cf3f2d01fbebdac374971192be9
   depends:
@@ -1043,7 +1043,7 @@ packages:
   license_family: MIT
   size: 15525
   timestamp: 1699032521315
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_client-7.4.9-py311h06a4308_0.tar.bz2
   sha256: 79ce6dff3d93649a2555b1d2a4ae9eb77175a1c00664cb8eb0e6f848d5cdd1b9
   md5: db395b0efd7018fcf3a4af879170c2a8
   depends:
@@ -1059,7 +1059,7 @@ packages:
   license_family: BSD
   size: 276856
   timestamp: 1676823504812
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_core-5.7.2-py311h06a4308_0.tar.bz2
   sha256: 91cca0ba49accdc9e97463bee087244a27ad107eb3af9ccb91634239f8b10f72
   md5: a185824bfc55bd90e1cf9330b417b74c
   depends:
@@ -1070,7 +1070,7 @@ packages:
   license_family: BSD
   size: 97359
   timestamp: 1718818381635
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_events-0.10.0-py311h06a4308_0.tar.bz2
   sha256: 540f8dfb7cdc3877b4e24d6af65696d0bc7eae5de1c307229f86b3fe601a2286
   md5: f650f8c007471f6ef6c1a292918d2e1f
   depends:
@@ -1086,7 +1086,7 @@ packages:
   license_family: BSD
   size: 41920
   timestamp: 1718738122846
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server-2.14.1-py311h06a4308_0.tar.bz2
   sha256: 398387b6f1ee1691b04a31fedd1320225e5553aa921b06bc013f010a0008621e
   md5: bac66634a9133c633ddc879e14e83f23
   depends:
@@ -1113,7 +1113,7 @@ packages:
   license_family: BSD
   size: 610854
   timestamp: 1718827113534
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyter_server_terminals-0.4.4-py311h06a4308_1.tar.bz2
   sha256: ddfee06ba9b149222c65d1d4270272840533aa63b56fe36363c84a891c71d328
   md5: ee128e5c0d8d9e1952e2387b66a5b8cb
   depends:
@@ -1123,7 +1123,7 @@ packages:
   license_family: BSD
   size: 27239
   timestamp: 1686870958829
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/jupyterlab_pygments-0.2.2-py311h06a4308_0.tar.bz2
   sha256: 0c6a074272ed58677ec17e4dbfceaffd2108841a61af92b32f156c5763108d1d
   md5: dd3d37841d0d20c70a60e8c939923894
   depends:
@@ -1135,7 +1135,7 @@ packages:
   license_family: BSD
   size: 19144
   timestamp: 1700168632051
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/kiwisolver-1.4.4-py311h6a678d5_0.tar.bz2
   sha256: b040f0d0ee4588188ab6b83a93738b3ff6e6d1775424be97995bd0df0f4fb904
   md5: eae62735d710cf5ff6d51e6f59fcd999
   depends:
@@ -1146,7 +1146,7 @@ packages:
   license_family: BSD
   size: 78148
   timestamp: 1676827253282
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.16-hb9589c4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lcms2-2.16-hb9589c4_0.tar.bz2
   sha256: 1b6b432a7ef79b3c29ab84e9fa1fb159837dd65b3997e9a6605896f3517dcfcf
   md5: ed981583bbc6e6ac7707895204653e0d
   depends:
@@ -1157,7 +1157,7 @@ packages:
   license_family: MIT
   size: 271236
   timestamp: 1734428496317
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ld_impl_linux-64-2.40-h12ee557_0.tar.bz2
   sha256: 069d33aebaf4db4ae410d4acb4851860a69d2c8f326fd45ab2a67b67fe276e6d
   md5: 61689da52cf1fcebda8c9fb2872f94bf
   constrains:
@@ -1165,7 +1165,7 @@ packages:
   license: GPL-3.0-only
   size: 723073
   timestamp: 1727336193185
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lerc-4.0.0-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lerc-4.0.0-h6a678d5_0.tar.bz2
   sha256: 3b35e98ab9e27e3c6ce1a4988087410c4f10f8f2dc7b32e5fd0597ae3330a6f0
   md5: 2a9cf942ef9eac2d34261363e6fbacad
   depends:
@@ -1175,7 +1175,7 @@ packages:
   license_family: Apache
   size: 283535
   timestamp: 1734423401417
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_9.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlicommon-1.0.9-h5eee18b_9.tar.bz2
   sha256: f4443a37d6eb1f35aed3b36d67ee10df39dccde535f3a6761fad44c0a516843d
   md5: 69b08a79ab20702c6bd5f77cc4063267
   depends:
@@ -1183,7 +1183,7 @@ packages:
   license: MIT
   size: 67000
   timestamp: 1736182526370
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlidec-1.0.9-h5eee18b_9.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlidec-1.0.9-h5eee18b_9.tar.bz2
   sha256: 51a57fc34ce6d44b35d76562b945a55efdcd663880bb1a153c44fe176fbc5c1a
   md5: 72d59a9872154e939d5759c7eb2c5db1
   depends:
@@ -1192,7 +1192,7 @@ packages:
   license: MIT
   size: 34506
   timestamp: 1736182538544
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libbrotlienc-1.0.9-h5eee18b_9.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libbrotlienc-1.0.9-h5eee18b_9.tar.bz2
   sha256: 5a43fa99f57fe609b374888359cecef39556ebf9c5fb6fd35eb9694f054b65eb
   md5: 3c5dbc154e879dcfd5e71c8cd56202ff
   depends:
@@ -1201,7 +1201,7 @@ packages:
   license: MIT
   size: 295241
   timestamp: 1736182548938
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libdeflate-1.22-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libdeflate-1.22-h5eee18b_0.tar.bz2
   sha256: 99b22a8ac9907bf834b06bc1d4c046a46e0d1fe8f044e03b287ca80490ffd7b3
   md5: c75f9e8e2f44baf9a36b4d7ac80eb2bc
   depends:
@@ -1210,7 +1210,7 @@ packages:
   license_family: MIT
   size: 78335
   timestamp: 1734423317784
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libffi-3.4.4-h6a678d5_1.tar.bz2
   sha256: 0b12a316bdf13ae98f00e3fb04c077176e0f27d22575855f9e548e7b2605494e
   md5: 1af9b4d62c708924417f2640ef22a68f
   depends:
@@ -1220,7 +1220,7 @@ packages:
   license_family: MIT
   size: 154016
   timestamp: 1714483282916
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgcc-ng-11.2.0-h1234567_1.tar.bz2
   sha256: f52d33d9c7cccf09b429a341d0bf803c8365a02a73a77b7ff887ec88f25d1c1a
   md5: 641e72e5067bd6d5454405879e1cd2a7
   depends:
@@ -1235,7 +1235,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 8895144
   timestamp: 1654090827491
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libgomp-11.2.0-h1234567_1.tar.bz2
   sha256: 118665c3af6392704fe608da9b98dbf815304537bb80ae99fb9fd59fc81f8b8e
   md5: 3080c2813e6e1d0f8a100a38b5b3456d
   depends:
@@ -1243,7 +1243,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 573231
   timestamp: 1654090775721
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libpng-1.6.39-h5eee18b_0.tar.bz2
   sha256: e57061a1f4d0f69b774fc0050c7799ca75e241113f8b68f1504ce967f3a73c2e
   md5: 1bffe1481ed4f88827248fb9001f8923
   depends:
@@ -1253,7 +1253,7 @@ packages:
   license_family: Other
   size: 362561
   timestamp: 1677841789536
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libsodium-1.0.18-h7b6447c_0.tar.bz2
   sha256: e31aa60464b87c49b12d3baa2f95f92486238246810845365b10d53aab0809ff
   md5: 6f662c6b244a444869f0c537da106d6d
   depends:
@@ -1261,7 +1261,7 @@ packages:
   license: ISC
   size: 396743
   timestamp: 1581700759428
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libstdcxx-ng-11.2.0-h1234567_1.tar.bz2
   sha256: 112ea187f09c690a87d419450d64f49d6cb3163206fcba38d2fdd8f2c7b5388e
   md5: 8c195584a5f5471b600ee180e4052773
   depends:
@@ -1269,7 +1269,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 6410287
   timestamp: 1654090800863
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.5.1-hffd6297_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libtiff-4.5.1-hffd6297_1.tar.bz2
   sha256: 00c29474500c2db177d482b62dd42392327376823464961995d60ee5c7679c55
   md5: d26f4756467be40670835398528d1309
   depends:
@@ -1286,7 +1286,7 @@ packages:
   license_family: Other
   size: 663476
   timestamp: 1734425727361
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libuuid-1.41.5-h5eee18b_0.tar.bz2
   sha256: bf310692ee3f3f9aa4a62c5ab334fa8068c1a1add4cf5c741492ca97a172d112
   md5: 292768ec77416ae257cfdd44ea2071c8
   depends:
@@ -1295,7 +1295,7 @@ packages:
   license_family: BSD
   size: 29197
   timestamp: 1668082729834
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/libwebp-base-1.3.2-h5eee18b_1.tar.bz2
   sha256: a062fad27450b94279d1688aabd11a95eedee7814462ef6364337d55412b4a7e
   md5: e0521f84b9770830e654432364ac930e
   depends:
@@ -1306,7 +1306,7 @@ packages:
   license_family: BSD
   size: 484011
   timestamp: 1729160032020
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/linkify-it-py-2.0.0-py311h06a4308_0.tar.bz2
   sha256: fd8e30beb8c9442f16e6617fac92dd0c89ec823e98f06e60f712147380ead35f
   md5: 7ed7caf2816c8b85b67b6f4e8833cbd5
   depends:
@@ -1316,7 +1316,7 @@ packages:
   license_family: MIT
   size: 41155
   timestamp: 1676837080881
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/lz4-c-1.9.4-h6a678d5_1.tar.bz2
   sha256: 500f73a55c66d92b34d174a28763b90dc1b3ef27daf2aedd0a4f6ac462596bc1
   md5: 76f089e76ec67583bb38428b51008097
   depends:
@@ -1326,7 +1326,7 @@ packages:
   license_family: BSD
   size: 164494
   timestamp: 1714510587156
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-3.4.1-py311h06a4308_0.tar.bz2
   sha256: 260e26dd509834c1b225ab7bdb97b9a86e00054fbdd5dfa49e68fa4dcf85a661
   md5: 8f5d7ddc69cc6f7d44c80d2251dea5d1
   depends:
@@ -1335,7 +1335,7 @@ packages:
   license_family: BSD
   size: 162339
   timestamp: 1676837095436
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markdown-it-py-2.2.0-py311h06a4308_1.tar.bz2
   sha256: 7f5b0804d0768619b7bd93b10488067d80bf42ec29f443f00b53ba11758a1241
   md5: 8afb45e45c0d93bfd142e682d4b021ef
   depends:
@@ -1345,7 +1345,7 @@ packages:
   license_family: MIT
   size: 134438
   timestamp: 1684280014220
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/markupsafe-2.1.3-py311h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/markupsafe-2.1.3-py311h5eee18b_1.tar.bz2
   sha256: 4cb3c7482521d58234f9696167809e55bde8fa3df547d11b9fd238adc360abec
   md5: e39f68d06a1f03ee3c6361abc0806092
   depends:
@@ -1357,7 +1357,7 @@ packages:
   license_family: BSD
   size: 27074
   timestamp: 1736367601790
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-base-3.10.0-py311hbfdbfaf_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-base-3.10.0-py311hbfdbfaf_0.tar.bz2
   sha256: 4a1053eb7d779473df2b6af99649e20af08b3bfadaba59009df756585e7bf107
   md5: 803563191e37b0fc9bf0ca62d13b2d10
   depends:
@@ -1378,7 +1378,7 @@ packages:
   license_family: PSF
   size: 9818267
   timestamp: 1736278428611
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/matplotlib-inline-0.1.6-py311h06a4308_0.tar.bz2
   sha256: 7ac07ea180b5928086075900afbc332fb1d3c81ddfacb54c891693c284056f14
   md5: fc83dd1b3d2ec3c0a297ead0c3405907
   depends:
@@ -1388,7 +1388,7 @@ packages:
   license_family: BSD
   size: 19573
   timestamp: 1676823852670
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdit-py-plugins-0.3.0-py311h06a4308_0.tar.bz2
   sha256: c9ba2f9c83820712dd97d6a1b54a1215b9820a0be02ac82380b4c50911b9400c
   md5: e5dc6b4a5b8e02733ce3bc9e9198a8d2
   depends:
@@ -1398,7 +1398,7 @@ packages:
   license_family: MIT
   size: 67750
   timestamp: 1676837123613
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mdurl-0.1.0-py311h06a4308_0.tar.bz2
   sha256: 1a5141ef0de1cbff816f96bb4b212a40606e2fc11301a4c1358c8d63a6b2b027
   md5: 22ac3bc22b68fef4c1f3f6ab3c7bfe0b
   depends:
@@ -1407,7 +1407,7 @@ packages:
   license_family: MIT
   size: 23040
   timestamp: 1676827301164
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mistune-2.0.4-py311h06a4308_0.tar.bz2
   sha256: 9aacfbbe6f638c58a4e8ff31374d1438d78b7db25d6ea6fd0c50ca2109f225d4
   md5: e602057e3b3d80da88c61d66e8851c5b
   depends:
@@ -1418,7 +1418,7 @@ packages:
   license_family: BSD
   size: 104681
   timestamp: 1676823696152
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-2023.1.0-h213fc3f_46344.tar.bz2
   sha256: 9813a7b6c2d4ff02b223fbc01d0c85cfab9d85584d19826fedd7d784a4a4e922
   md5: ce77d0f05f846da4a6b9e23fe7f21d9b
   depends:
@@ -1432,7 +1432,7 @@ packages:
   license_family: Proprietary
   size: 206738176
   timestamp: 1699648006088
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl-service-2.4.0-py311h5eee18b_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl-service-2.4.0-py311h5eee18b_2.tar.bz2
   sha256: 2aa10f19199e2f594db9d292538611b60f9eb8604ac2e8ed5658360da0417fed
   md5: 1bb09282d58781f1886968ec437e1db9
   depends:
@@ -1443,7 +1443,7 @@ packages:
   license_family: BSD
   size: 76075
   timestamp: 1736367004456
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_fft-1.3.11-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_fft-1.3.11-py311h5eee18b_0.tar.bz2
   sha256: 26001bced97eaa8c3862686f48668a252b8f7fd6ed81329534bee0538ea39fe0
   md5: eb3e382c51549878d07e5c3e207c3845
   depends:
@@ -1457,7 +1457,7 @@ packages:
   license_family: BSD
   size: 241049
   timestamp: 1730824176185
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/mkl_random-1.2.8-py311ha02d727_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/mkl_random-1.2.8-py311ha02d727_0.tar.bz2
   sha256: afc57040e0c892e46b00ecb534100fcaf05d8c75592170b0ce9119f2e5630557
   md5: 5e47055fea53886417e9a62d4e89c7c9
   depends:
@@ -1472,7 +1472,7 @@ packages:
   license_family: BSD
   size: 411216
   timestamp: 1730824036145
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclassic-1.1.0-py311h06a4308_0.tar.bz2
   sha256: 6116c133fbed1e7ea0f5e69f900e93d7977cb715920d10b10642c191d00cc9a6
   md5: b842f7ebdc8b7b6a0dda4c5ebe12805b
   depends:
@@ -1485,7 +1485,7 @@ packages:
   license_family: BSD
   size: 8315206
   timestamp: 1717622768176
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbclient-0.8.0-py311h06a4308_0.tar.bz2
   sha256: bb45fb0a3973caa74fd8f845e0a519895f6a378807626e15ecf72c02f2eed794
   md5: 185f658ba8a74e326b7231c8fd0d62bf
   depends:
@@ -1498,7 +1498,7 @@ packages:
   license_family: BSD
   size: 121834
   timestamp: 1698934274227
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbconvert-7.16.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbconvert-7.16.4-py311h06a4308_0.tar.bz2
   sha256: 9361ab2f7b289e9fd33ef001035fbdca9735f1c5425bb8282ce053d152ffaa2c
   md5: f95894da2382644ab016e71dc0db3463
   depends:
@@ -1525,7 +1525,7 @@ packages:
   license_family: BSD
   size: 528660
   timestamp: 1728049573278
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nbformat-5.10.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nbformat-5.10.4-py311h06a4308_0.tar.bz2
   sha256: c7aa4facc9d03e5087f9b22a88373beb43633a2c558e895303f5accc3ce95142
   md5: 4b4927ae34aaf3ee6b008a4392afd2dd
   depends:
@@ -1538,7 +1538,7 @@ packages:
   license_family: BSD
   size: 169513
   timestamp: 1728049478168
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/ncurses-6.4-h6a678d5_0.tar.bz2
   sha256: 1a04f65c955ea5e7c8fc2f79c80f918d7ba21e9c248757217710e48b882d9820
   md5: 57ea097dc15f8d9f9eb90e1d919143b0
   depends:
@@ -1547,7 +1547,7 @@ packages:
   license_family: MIT
   size: 1157733
   timestamp: 1674734069410
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/nest-asyncio-1.6.0-py311h06a4308_0.tar.bz2
   sha256: 266199dd4efde0ad342a9c500f4bc4299c5622219aea623b46315a9b4f6b8959
   md5: 2b21844d2b0024d0ffad0e6450cf0855
   depends:
@@ -1556,7 +1556,7 @@ packages:
   license_family: BSD
   size: 15860
   timestamp: 1708532713870
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-6.5.7-py311h06a4308_0.tar.bz2
   sha256: 59e169e036db0f2b98ed19f867d8ac708970214599efa0d57d3413fc1dbe8e3c
   md5: d0faf375bfc33811456d43fe549cb939
   depends:
@@ -1581,7 +1581,7 @@ packages:
   license_family: BSD
   size: 710152
   timestamp: 1717630833268
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/notebook-shim-0.2.3-py311h06a4308_0.tar.bz2
   sha256: ef2857e6d3d7eb246b3abddfbd3aa2d124dd8565391ace3876b77339babc50bb
   md5: d276d1b1774107987963135c78ca7390
   depends:
@@ -1591,7 +1591,7 @@ packages:
   license_family: BSD
   size: 26607
   timestamp: 1699455972519
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numexpr-2.10.1-py311h3c60e43_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numexpr-2.10.1-py311h3c60e43_0.tar.bz2
   sha256: c85ee5a0b557ed925a1709b7422f13e88545bd2392c63d8e65b8d4dd44bca713
   md5: 3ca48c350f813b2e11ed2312858098f7
   depends:
@@ -1607,7 +1607,7 @@ packages:
   license_family: MIT
   size: 204257
   timestamp: 1730216115069
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-2.2.1-py311h08b1b3b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-2.2.1-py311h08b1b3b_0.tar.bz2
   sha256: 4d1f6b92a77f75f8cfcb4577c2a82943f609891d525535cca3d89f7a8e3a09f8
   md5: ac149ca5e00bf0467516b56d03ab6ff9
   depends:
@@ -1626,7 +1626,7 @@ packages:
   license_family: BSD
   size: 10756
   timestamp: 1736502859104
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/numpy-base-2.2.1-py311hf175353_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/numpy-base-2.2.1-py311hf175353_0.tar.bz2
   sha256: a62122e67910125e92f3c23907631aeddfbc88dc09531c05e2fa1d3711cfacef
   md5: 6689e6e4f931e8a93c78141865615650
   depends:
@@ -1642,7 +1642,7 @@ packages:
   license_family: BSD
   size: 10118433
   timestamp: 1736502843447
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openjpeg-2.5.2-he7f1fd0_0.tar.bz2
   sha256: 1c9f6902907a3d4a7e5c3cb02236491ea4c4e66a1a0ce51fa506dffb24ba89f6
   md5: 36d514eca3c87ab75a1d418607e26db2
   depends:
@@ -1654,7 +1654,7 @@ packages:
   license_family: BSD
   size: 528528
   timestamp: 1722872671997
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/openssl-3.0.15-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/openssl-3.0.15-h5eee18b_0.tar.bz2
   sha256: f8a3dbcdabfad712311fdbec1fd49d44340818d348df5d90f420de133a4daeb1
   md5: 4084456e619e7c2ab269f3cf2ff831f2
   depends:
@@ -1664,7 +1664,7 @@ packages:
   license_family: Apache
   size: 5499760
   timestamp: 1725545717819
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/overrides-7.4.0-py311h06a4308_0.tar.bz2
   sha256: 280225061aeba00d7b85f46e55d7d79cd92c92f662dc749d9c53187978e8d083
   md5: c51c21da68080d89300703ad818c824a
   depends:
@@ -1673,7 +1673,7 @@ packages:
   license_family: APACHE
   size: 38606
   timestamp: 1699371264464
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/packaging-24.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/packaging-24.2-py311h06a4308_0.tar.bz2
   sha256: 288da6ac31a1aebbd0571fe1d273c6095a0c049c6be93db899dfe45fc57c7936
   md5: 684139274d664e9d0458b11e8a46d55e
   depends:
@@ -1682,7 +1682,7 @@ packages:
   license_family: Apache
   size: 188806
   timestamp: 1734472196649
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pandas-2.2.3-py311h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pandas-2.2.3-py311h6a678d5_0.tar.bz2
   sha256: f9c6066d840b6a7db19eb969637e9ae26b22a64f4c63e7d34639c5638d71bc2b
   md5: 5f21a0ac71dd61bb78501815e23e1117
   depends:
@@ -1733,7 +1733,7 @@ packages:
   license_family: BSD
   size: 17990544
   timestamp: 1732738272325
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/panel-1.5.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/panel-1.5.3-py311h06a4308_0.tar.bz2
   sha256: edabd666746acfb045c1dd922835172ea94c00d33bf03337740db2af93551911
   md5: 486d3afb94115451198410b69e3fa0b5
   depends:
@@ -1758,7 +1758,7 @@ packages:
   license_family: BSD
   size: 24210987
   timestamp: 1730381005745
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/param-2.2.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/param-2.2.0-py311h06a4308_0.tar.bz2
   sha256: d137c487271bef84a7d0a7497439db4d0a07b6b4a9e30036b19bfd264828b728
   md5: 80cb61dac081768a5d5d2d925a61896d
   depends:
@@ -1767,7 +1767,7 @@ packages:
   license_family: BSD
   size: 268099
   timestamp: 1734618713828
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/parso-0.8.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/parso-0.8.4-py311h06a4308_0.tar.bz2
   sha256: e40e60301997a3b5ff53b7ed7365db536f1b492a829ce2946ac61f6f7321c1a3
   md5: d9f873bfc00a48198c960c9ba56f9e93
   depends:
@@ -1776,7 +1776,7 @@ packages:
   license_family: MIT
   size: 222615
   timestamp: 1733963432742
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pillow-11.0.0-py311hcea889d_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pillow-11.0.0-py311hcea889d_1.tar.bz2
   sha256: 5a6d206a72dea0ba519847e03cebfc149070eef747082d3d00677beac3fd4ed5
   md5: 47344fee0c1f75f06a9c3f7df3a5918e
   depends:
@@ -1794,7 +1794,7 @@ packages:
   license_family: Other
   size: 1011464
   timestamp: 1734430724792
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pip-24.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pip-24.2-py311h06a4308_0.tar.bz2
   sha256: 87422d1d2592abe99ee9a6c06f6653030567e88571a21edca9f4c1f2cd22ae07
   md5: 806984470b5328d7fdb721b37ec2d73f
   depends:
@@ -1805,7 +1805,7 @@ packages:
   license_family: MIT
   size: 2913778
   timestamp: 1723484664306
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/platformdirs-3.10.0-py311h06a4308_0.tar.bz2
   sha256: d2bbab8bfc57c7f46ca8994bc87df7e744d3f036b867bc4be1145ba6d8d7e091
   md5: de41707272a8e3ccab764f0b7010a27d
   depends:
@@ -1814,7 +1814,7 @@ packages:
   license_family: MIT
   size: 37394
   timestamp: 1692205565974
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prometheus_client-0.21.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prometheus_client-0.21.0-py311h06a4308_0.tar.bz2
   sha256: ef83087f0474cbc11bf6ab7c318a56a7677c6dcc57c75d5ed52a0a2a6bda30a2
   md5: 25de2c05534f16c0e2b61429c7c2d3bb
   depends:
@@ -1823,7 +1823,7 @@ packages:
   license_family: Apache
   size: 121560
   timestamp: 1731953225009
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/prompt-toolkit-3.0.43-py311h06a4308_0.tar.bz2
   sha256: b7f591c19b10bf0daa7e6e3b45a9f4a0a0e83188e1f8a58037caea79e60f8d91
   md5: d945b4ccc135005839c504cc29df1745
   depends:
@@ -1835,7 +1835,7 @@ packages:
   license_family: BSD
   size: 749608
   timestamp: 1704404477511
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.9.0-py311h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/psutil-5.9.0-py311h5eee18b_1.tar.bz2
   sha256: 675e161cff8bc0f660b3f7ea5692207de372730d9ea2d5410a1e76c8e3cb24d5
   md5: 924cb59384b001ea5e9e37d1638820cc
   depends:
@@ -1845,7 +1845,7 @@ packages:
   license_family: BSD
   size: 495241
   timestamp: 1736367238095
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pygments-2.15.1-py311h06a4308_1.tar.bz2
   sha256: ed927e4d058a8f4ea73edc7a43ed74877d93b88fdfa240b3b2777244386ced70
   md5: a1f0e05fc7e49712f81ad5478ec9d51e
   depends:
@@ -1854,7 +1854,7 @@ packages:
   license_family: BSD
   size: 2121496
   timestamp: 1684280065800
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyparsing-3.2.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyparsing-3.2.0-py311h06a4308_0.tar.bz2
   sha256: b5d27b938ed374a24fcb18a66c3f1a94e28bbe01b4ac156cd26c7be1ca756622
   md5: 244cfad440c898146039cb986864017e
   depends:
@@ -1863,7 +1863,7 @@ packages:
   license_family: MIT
   size: 486387
   timestamp: 1731445563066
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pysocks-1.7.1-py311h06a4308_0.tar.bz2
   sha256: 114b55e00f4622c90fd2b404b21ad5f94a10283fcaaf86a42174b8d39b0a3e98
   md5: 2458e92683cc68671a6c8e1b86ce8817
   depends:
@@ -1872,7 +1872,7 @@ packages:
   license_family: BSD
   size: 35850
   timestamp: 1676822725516
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-3.11.11-he870216_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-3.11.11-he870216_0.tar.bz2
   sha256: aced5b9158e4839247dcf76bd5197650803f9db116ccdc451a79d1c0da5f2354
   md5: bc33687df04e0cfeebd12f682bec6b22
   depends:
@@ -1894,7 +1894,7 @@ packages:
   license_family: PSF
   size: 36116799
   timestamp: 1733935613200
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-dateutil-2.9.0post0-py311h06a4308_2.tar.bz2
   sha256: a0f008717fab060ccd003dfebc09156d90b9afd14ac3626566aa1a8f3d3b7e2f
   md5: 357bf4fe94496cbae72ab4d780184b31
   depends:
@@ -1904,7 +1904,7 @@ packages:
   license_family: BSD
   size: 330924
   timestamp: 1716495762901
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-fastjsonschema-2.20.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-fastjsonschema-2.20.0-py311h06a4308_0.tar.bz2
   sha256: 8e42421bb620d1e12ab455da3594c2129b0a6d994a0be6a1e4519d1d3ead360f
   md5: 99293d1a98a94e2b11c5d598ea2d80a8
   depends:
@@ -1913,7 +1913,7 @@ packages:
   license_family: BSD
   size: 281088
   timestamp: 1731939500285
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/python-json-logger-3.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/python-json-logger-3.2.1-py311h06a4308_0.tar.bz2
   sha256: 0cb8b14ce460a6927a4b1e9c2b2737b8668f7bae47998c56d2e307706f72076f
   md5: eb0b1081560d413b713603a3bdb9b0dd
   depends:
@@ -1922,7 +1922,7 @@ packages:
   license_family: BSD
   size: 28481
   timestamp: 1734370110052
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pytz-2024.1-py311h06a4308_0.tar.bz2
   sha256: b85acb933fff864bfa89d034e8e3d85b1a9c2e69cbfc0d68c1d66ffd1443e67d
   md5: 0cdb92d2d684ee1095310f992ed0d9b2
   depends:
@@ -1931,7 +1931,7 @@ packages:
   license_family: MIT
   size: 266796
   timestamp: 1713974338678
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyviz_comms-3.0.2-py311h06a4308_0.tar.bz2
   sha256: 511e8206a15445715b80be76493300930686b3fe1e512ae942d6ccca36df392a
   md5: 35a6e46ae970f8b71d78fb5a810f2e80
   depends:
@@ -1943,7 +1943,7 @@ packages:
   license_family: BSD
   size: 64013
   timestamp: 1711136926372
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyyaml-6.0.2-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyyaml-6.0.2-py311h5eee18b_0.tar.bz2
   sha256: 132aa25ee904333ef338eb1935dd8e5ccffb27cacf33fdb58c1358ec22424933
   md5: 92ce34b6f4f7a6e64c80c2ba0a96edf4
   depends:
@@ -1954,7 +1954,7 @@ packages:
   license_family: MIT
   size: 222337
   timestamp: 1728658052191
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/pyzmq-24.0.1-py311h5eee18b_0.tar.bz2
   sha256: 7c74db4292f31619606180f86f3c1e2d913495c2c9d1195c5d51681a6a841625
   md5: be1c05fae57d194924b9400f9b5ad3c6
   depends:
@@ -1965,7 +1965,7 @@ packages:
   license_family: Other
   size: 613277
   timestamp: 1709318516682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/readline-8.2-h5eee18b_0.tar.bz2
   sha256: 8a665f0160013939ee6b0c048d4d8f034b6d6feb7feec6844994322b7aaaa6e4
   md5: 960bf00d81e7bbdeff2c7d01ed78eaeb
   depends:
@@ -1975,7 +1975,7 @@ packages:
   license_family: GPL
   size: 467661
   timestamp: 1666648052561
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/referencing-0.30.2-py311h06a4308_0.tar.bz2
   sha256: 89c2f4235277b9825cc805c5c44f0b1afcb683d7b5a3f513bc4bf243b643bb0c
   md5: db70eb57e33adf7b8bbdadd72214d48d
   depends:
@@ -1986,7 +1986,7 @@ packages:
   license_family: MIT
   size: 73679
   timestamp: 1699012111499
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/requests-2.32.3-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/requests-2.32.3-py311h06a4308_1.tar.bz2
   sha256: 1ac5ee93110e2f7f1d68b6c985e4adcc3710f537c388ae3ff4f85059288070a1
   md5: 4385913efbeb323430797aa3b3506525
   depends:
@@ -2002,7 +2002,7 @@ packages:
   license_family: Apache
   size: 123440
   timestamp: 1730999231468
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3339-validator-0.1.4-py311h06a4308_0.tar.bz2
   sha256: fdae3f68ea84b99561aee6c566ab1c287d8f2ae2668424e9283a8ed86af8f1d2
   md5: cde5b71ccbb3630053340b2c8c7dbf10
   depends:
@@ -2012,7 +2012,7 @@ packages:
   license_family: MIT
   size: 9333
   timestamp: 1683077183576
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rfc3986-validator-0.1.1-py311h06a4308_0.tar.bz2
   sha256: 0bf859b06a07857099fd4f524fe5e0875fda70029e9485d95c7efa97134fbc14
   md5: fd5815cc592fdbd4c831901541eadaba
   depends:
@@ -2021,7 +2021,7 @@ packages:
   license_family: MIT
   size: 9735
   timestamp: 1683059096795
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/rpds-py-0.10.6-py311h4aa5aa6_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/rpds-py-0.10.6-py311h4aa5aa6_1.tar.bz2
   sha256: e65d6513d86339932493ba017a6108b64a6051c7a2ae4d920b98d4eaf8872b53
   md5: 73dd6ee25b6b39940f80a90ef7cd87d7
   depends:
@@ -2031,7 +2031,7 @@ packages:
   license_family: MIT
   size: 340692
   timestamp: 1732227820782
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/send2trash-1.8.2-py311h06a4308_0.tar.bz2
   sha256: 51bcea0e575a626f6ffbd16d1153330fda93dbe3dd31dcd3a8f469ff61dd1e4e
   md5: 41d531c90be8c82bf79635ff3d409476
   depends:
@@ -2040,7 +2040,7 @@ packages:
   license_family: BSD
   size: 32295
   timestamp: 1699371262818
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/setuptools-72.1.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/setuptools-72.1.0-py311h06a4308_0.tar.bz2
   sha256: ba9fef2940e2737e5f351f2817d918ea1688138e19a6dadbf17f6961d481dd74
   md5: e19eae321026b92ff3a27208430735c4
   depends:
@@ -2049,7 +2049,7 @@ packages:
   license_family: MIT
   size: 3308302
   timestamp: 1722860116537
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sniffio-1.3.0-py311h06a4308_0.tar.bz2
   sha256: 1a84b00944bc5588e14a097460175f97df49acb4f1ff2498ffd9a1893068ed81
   md5: a456513471b2ecbed60430c21dd1ccc7
   depends:
@@ -2058,7 +2058,7 @@ packages:
   license_family: Other
   size: 17880
   timestamp: 1705431390054
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/soupsieve-2.5-py311h06a4308_0.tar.bz2
   sha256: adcafd297d60af64107c113bb7b8b92160d0268a44ef9a3b79e56a88a0358ea7
   md5: 28ed704ed26b06d32662e3a6a87e59b0
   depends:
@@ -2067,7 +2067,7 @@ packages:
   license_family: MIT
   size: 88799
   timestamp: 1696347581401
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/sqlite-3.45.3-h5eee18b_0.tar.bz2
   sha256: b39511a1c3a59873eaa5da71edc7a458ab76746b75c6a9db6bfc7326a69451fb
   md5: f86119b3243fe3508160aa0406245738
   depends:
@@ -2080,7 +2080,7 @@ packages:
   license_family: Other
   size: 1723866
   timestamp: 1714488309729
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tbb-2021.8.0-hdb19cb5_0.tar.bz2
   sha256: fad05a7c749760b7d18d897a41fa4a00d83d137cdb90a76ddde4ee0b7e07d3ea
   md5: 041a3caf09dc9ce8fc6c10925c4fe050
   depends:
@@ -2090,7 +2090,7 @@ packages:
   license_family: Apache
   size: 1888016
   timestamp: 1680167274961
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/terminado-0.17.1-py311h06a4308_0.tar.bz2
   sha256: 856a8ab8c350c50247b79966c6cb80fb6d4de36eef49ddf75aebbbcaf854c82d
   md5: 442dde204d14d171aab9ee40e8de4de8
   depends:
@@ -2101,7 +2101,7 @@ packages:
   license_family: BSD
   size: 37456
   timestamp: 1677696176157
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tinycss2-1.2.1-py311h06a4308_0.tar.bz2
   sha256: f0a026ddc0ed041bfc60c8a1ca0b70b7a69232775b3181bfb35a39fda42d6994
   md5: 2902d5a5854865baaaf58dc59cf06b3c
   depends:
@@ -2111,7 +2111,7 @@ packages:
   license_family: BSD
   size: 49185
   timestamp: 1676823769869
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tk-8.6.14-h39e8969_0.tar.bz2
   sha256: a6d432c0b741a157f4403b3bd0f15637b8533db675085ec4f62a3ba62baf8fc8
   md5: e2512d57c8a1e91e7b20e265c6906546
   depends:
@@ -2121,7 +2121,7 @@ packages:
   license_family: BSD
   size: 3588922
   timestamp: 1714770676475
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tornado-6.4.2-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tornado-6.4.2-py311h5eee18b_0.tar.bz2
   sha256: 780986d79652f3f4eec28d8d9cdda134a1eed4aee302a66483ebfb8c5dbef877
   md5: 5c580c8870055c1a563959f98142f836
   depends:
@@ -2131,7 +2131,7 @@ packages:
   license_family: Apache
   size: 915944
   timestamp: 1733960601134
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/tqdm-4.66.5-py311h92b7b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/tqdm-4.66.5-py311h92b7b1e_0.tar.bz2
   sha256: dab820faa313d62b44014841409cef89a49dbda9a7697689ce37b3032ec3276e
   md5: 1d6513a5b915465291fdb2041815bdc6
   depends:
@@ -2142,7 +2142,7 @@ packages:
   license_family: MOZILLA
   size: 154437
   timestamp: 1724854032868
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/traitlets-5.14.3-py311h06a4308_0.tar.bz2
   sha256: 2091b17ae4fa46ed98fd6bfe9ca1aff3b0b81d73045e0cc55774b6516b8704b3
   md5: 183ae7b837c1c68ec1a8011011fadea7
   depends:
@@ -2151,7 +2151,7 @@ packages:
   license_family: BSD
   size: 206924
   timestamp: 1718227183177
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing-extensions-4.12.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing-extensions-4.12.2-py311h06a4308_0.tar.bz2
   sha256: 48850864a536279a44c8e4b5eaf5d7d0b424df752374fb5624f2c3ecc8b8bc6d
   md5: 0f1d42f3ecfa42bbfe56e32d902fb88e
   depends:
@@ -2161,7 +2161,7 @@ packages:
   license_family: PSF
   size: 8924
   timestamp: 1734714943753
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/typing_extensions-4.12.2-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/typing_extensions-4.12.2-py311h06a4308_0.tar.bz2
   sha256: 613ddfe5f4e9f2cb37f63a58a2c1d8527e4f19b5758429752733ecb919ffd2c2
   md5: db0f11a0de3083f9288c7d3a054f3887
   depends:
@@ -2170,7 +2170,7 @@ packages:
   license_family: PSF
   size: 81460
   timestamp: 1734714938116
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/uc-micro-py-1.0.1-py311h06a4308_0.tar.bz2
   sha256: 509b962773f0fe44a93a7f6196b254670a030eac8ea7f90727312e3ccd9294b2
   md5: 6c402d5bf4e01c8c3895c9ef41707b6e
   depends:
@@ -2179,7 +2179,7 @@ packages:
   license_family: MIT
   size: 11371
   timestamp: 1676828901104
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/unicodedata2-15.1.0-py311h5eee18b_0.tar.bz2
   sha256: bbe7629e8ce52c82f13ed0d1fb919f3659ef466b274a7c74aa925a9bc7aee450
   md5: 7da527bbcf71270c1abed8ea52e7d44c
   depends:
@@ -2189,7 +2189,7 @@ packages:
   license_family: Apache
   size: 509031
   timestamp: 1713213062098
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/urllib3-2.2.3-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/urllib3-2.2.3-py311h06a4308_0.tar.bz2
   sha256: 42eaf6a7ea875b236796f58e9f06919fda206ef6a4884ce943d94aa7747ad290
   md5: d1a78c6d9003bf2ff1cda53bde67c1f5
   depends:
@@ -2205,7 +2205,7 @@ packages:
   license_family: MIT
   size: 217451
   timestamp: 1727769856880
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/webencodings-0.5.1-py311h06a4308_1.tar.bz2
   sha256: c3a5e0b855dc2de6c162708dfcf170a23eb9e7525d4252d8dce553369af4a330
   md5: a4c77e204b7787f820955166a1283168
   depends:
@@ -2214,7 +2214,7 @@ packages:
   license_family: BSD
   size: 25890
   timestamp: 1676823132898
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/websocket-client-1.8.0-py311h06a4308_0.tar.bz2
   sha256: 42989f9970a8466cc4edb73463dfa194594dd1a5d42c9f820a1f86296d4af140
   md5: 655dfd4d2f17977cb81caa1c082d2b25
   depends:
@@ -2223,7 +2223,7 @@ packages:
   license_family: Apache
   size: 113505
   timestamp: 1715878346465
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.44.0-py311h06a4308_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/wheel-0.44.0-py311h06a4308_0.tar.bz2
   sha256: 3b258ad0db82572157a72303bbd5c20399d0c7f3b48abc1435ef96e4517e59f7
   md5: e11eb90c0ee1084a95cffe231196d98d
   depends:
@@ -2232,7 +2232,7 @@ packages:
   license_family: MIT
   size: 138218
   timestamp: 1726165052578
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xyzservices-2022.9.0-py311h06a4308_1.tar.bz2
   sha256: d18cdca154bf668826f869117ea996c4f9e8ef7d27b7c528332a7d17e5a8602c
   md5: 9f7353d72046b16dd6ef6b5689ac9bfd
   depends:
@@ -2241,7 +2241,7 @@ packages:
   license_family: BSD
   size: 54731
   timestamp: 1676828934954
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/xz-5.4.6-h5eee18b_1.tar.bz2
   sha256: 9122d6e9dabb7a47f2bcb15d86b97c96c49a9048da3f8ae59675351710c14cc5
   md5: 660b2aead2ec87b751c86cd33934f44e
   depends:
@@ -2250,7 +2250,7 @@ packages:
   license_family: GPL2
   size: 716926
   timestamp: 1714510796277
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/yaml-0.2.5-h7b6447c_0.tar.bz2
   sha256: 21957e347f97960435b5267baefe1014fe53e4e673b478dfe46b82e371bc0e2b
   md5: fcff4f33bb4e3fa91f8d5c3168807abb
   depends:
@@ -2258,7 +2258,7 @@ packages:
   license: MIT
   size: 88839
   timestamp: 1593116114710
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zeromq-4.3.5-h6a678d5_0.tar.bz2
   sha256: 893ffbb21c563f63220be0fd7cdd017f31ed3c7dc17606613f68da0e1c772fb6
   md5: 943f1247a22b6b64171363bcee1eec27
   depends:
@@ -2269,7 +2269,7 @@ packages:
   license_family: Other
   size: 371663
   timestamp: 1705602144682
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zlib-1.2.13-h5eee18b_1.tar.bz2
   sha256: 8299c6894c963a38eab3e1a7e7d3febc884841269c9d388152fad63a0d197e8f
   md5: 8e9cda0b8565c9dd6cfe917a1b3eb519
   depends:
@@ -2278,7 +2278,7 @@ packages:
   license_family: Other
   size: 127143
   timestamp: 1714510716441
-- conda: https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
+- conda: https://conda.anaconda.org/main/linux-64/zstd-1.5.6-hc292b87_0.tar.bz2
   sha256: a65c6277a3045e4ea72f617f977134c18366d8142ce51512f5a3cf325226a8bf
   md5: d941bb6fdc55cc1b3f67b3beb23d1795
   depends:
@@ -2291,7 +2291,7 @@ packages:
   license_family: BSD
   size: 1081416
   timestamp: 1728487031624
-- conda: https://repo.anaconda.com/pkgs/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/argon2-cffi-21.3.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1fcc454929849f704165f1c358a5c67da6d6055969106697940ee903dc189136
   md5: 32685aa840f6868407a3150184ebbf90
   depends:
@@ -2304,7 +2304,7 @@ packages:
   license_family: MIT
   size: 15512
   timestamp: 1645000255221
-- conda: https://repo.anaconda.com/pkgs/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/asttokens-2.0.5-pyhd3eb1b0_0.tar.bz2
   sha256: 5030ffb4c9a501359be889681081e5542725b0529b6119331a07aaa563e2f9f9
   md5: d9c6faf4f1a52c664ef1343f464e45b5
   depends:
@@ -2314,7 +2314,7 @@ packages:
   license_family: Apache
   size: 21573
   timestamp: 1646925670610
-- conda: https://repo.anaconda.com/pkgs/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/charset-normalizer-3.3.2-pyhd3eb1b0_0.tar.bz2
   sha256: c0dd89ffac001588171152a285ddbbaea209ebe4116010f985f898b7e87c2f35
   md5: 731ae7d446633bc729f3493a52d4365b
   depends:
@@ -2323,7 +2323,7 @@ packages:
   license_family: MIT
   size: 43502
   timestamp: 1721748373551
-- conda: https://repo.anaconda.com/pkgs/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/cycler-0.11.0-pyhd3eb1b0_0.tar.bz2
   sha256: 1f276b93525b372b75337e25fed10d47acfe9e7d3fc42783b7ea916af9a1b317
   md5: dfb0ca8055c9a72aaca7b845a6edea17
   depends:
@@ -2332,7 +2332,7 @@ packages:
   license_family: BSD
   size: 12592
   timestamp: 1637851583560
-- conda: https://repo.anaconda.com/pkgs/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/decorator-5.1.1-pyhd3eb1b0_0.tar.bz2
   sha256: a14463f2c25c4cb9eae1af565b6fef33c6b95dce387b36b5c2bc1eb91f00e1a4
   md5: 6072a09eeab81c07c98065234e46af1e
   depends:
@@ -2341,7 +2341,7 @@ packages:
   license_family: BSD
   size: 11936
   timestamp: 1643638345485
-- conda: https://repo.anaconda.com/pkgs/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/defusedxml-0.7.1-pyhd3eb1b0_0.tar.bz2
   sha256: 3b2984bb3edbe62e6fb161de43312df633ad74dcb3492a17bc1866f9f3e9f037
   md5: b9280feeee8d845ba495a701bae72de9
   depends:
@@ -2350,7 +2350,7 @@ packages:
   license_family: PSF
   size: 24190
   timestamp: 1615228158573
-- conda: https://repo.anaconda.com/pkgs/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/executing-0.8.3-pyhd3eb1b0_0.tar.bz2
   sha256: b67a5d4fdad35e881a497820699b2dc466a03aeff00a774ec412dba856a5895e
   md5: 1bdd5a02233d229e76081a73659e9405
   depends:
@@ -2359,7 +2359,7 @@ packages:
   license_family: MIT
   size: 18210
   timestamp: 1646925120076
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ipython_genutils-0.2.0-pyhd3eb1b0_1.tar.bz2
   sha256: ea821ba08e600790b068de794f7411a9c5a8a57afcdfb76696bd26470b2e5ca3
   md5: 2b7ea8318bc62d9e504ea43409ecd7c1
   depends:
@@ -2367,7 +2367,7 @@ packages:
   license: BSD 3-Clause
   size: 27342
   timestamp: 1606773472974
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pandocfilters-1.5.0-pyhd3eb1b0_0.tar.bz2
   sha256: 41ff03ca5d27e8d6667243ed280b86d28034112cdee3ab74091b28ee616c2f18
   md5: 0cb9961d77df143d6d65580d713aade1
   depends:
@@ -2376,7 +2376,7 @@ packages:
   license_family: BSD
   size: 11684
   timestamp: 1643405489166
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pexpect-4.8.0-pyhd3eb1b0_3.tar.bz2
   sha256: 543fe5710ecf50274fd6a8ac77c7e9058d15c9daee0aec04e85c2509e5cff9ed
   md5: 5122a68ef2c53409eda11f07f1c3d7c7
   depends:
@@ -2386,7 +2386,7 @@ packages:
   license_family: Other
   size: 52491
   timestamp: 1605563236879
-- conda: https://repo.anaconda.com/pkgs/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/prompt_toolkit-3.0.43-hd3eb1b0_0.tar.bz2
   sha256: 5ffd50c0d69c5bd368072c1bb7639073688f57e2e5b482bddf14fb2b218144e8
   md5: f824bca0e3a4f9dcc1eb5ea22b5e00a3
   depends:
@@ -2395,7 +2395,7 @@ packages:
   license_family: BSD
   size: 5106
   timestamp: 1704404390460
-- conda: https://repo.anaconda.com/pkgs/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/ptyprocess-0.7.0-pyhd3eb1b0_2.tar.bz2
   sha256: f661e9966229ec33ef4102771a12f6123fafe226337ad5531f6fd06820783eff
   md5: 62f3bb16b31fa9498a41fc4ad2b4f43c
   depends:
@@ -2403,7 +2403,7 @@ packages:
   license: ISC
   size: 16774
   timestamp: 1609355038155
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pure_eval-0.2.2-pyhd3eb1b0_0.tar.bz2
   sha256: 163e7d3545b6575c03c3ab8613e527e5359986360cc1a13b27c8534cfb3c5004
   md5: 8be7529b5e573e3cbc6df277b9950109
   depends:
@@ -2412,7 +2412,7 @@ packages:
   license_family: MIT
   size: 14248
   timestamp: 1646925118814
-- conda: https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/pycparser-2.21-pyhd3eb1b0_0.tar.bz2
   sha256: a87214cdef0b093e0b031cca176803dc04fbd948a44bf21503788ed37b42d1b7
   md5: e70944ff53d19af4f65073a4f21c7b05
   depends:
@@ -2421,7 +2421,7 @@ packages:
   license_family: BSD
   size: 96720
   timestamp: 1636541382349
-- conda: https://repo.anaconda.com/pkgs/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/python-tzdata-2023.3-pyhd3eb1b0_0.tar.bz2
   sha256: 554ca80900e3c5604c50a3fb73b359046d5d6c495b25909f7dff7db86234d67a
   md5: 02caf3f47f1d06256068053297355740
   depends:
@@ -2430,7 +2430,7 @@ packages:
   license_family: Apache
   size: 152292
   timestamp: 1690578151230
-- conda: https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2
   sha256: 5635e90c76aeac45a09f4ddb377ab215c01d0e17ecb18b43fad2c5447e351f6e
   md5: 0a3ab834ba49016e183e715bff48a2b6
   depends:
@@ -2439,7 +2439,7 @@ packages:
   license_family: MIT
   size: 19160
   timestamp: 1644875974931
-- conda: https://repo.anaconda.com/pkgs/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/stack_data-0.2.0-pyhd3eb1b0_0.tar.bz2
   sha256: 94e18c3bb250423255b00c9e3dd64880e076a1b8c2701c43492b2cc5e7cb91f3
   md5: fa3edcfd4c2c0d744bc177cbfcd77626
   depends:
@@ -2451,14 +2451,14 @@ packages:
   license_family: MIT
   size: 21658
   timestamp: 1646927641146
-- conda: https://repo.anaconda.com/pkgs/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/tzdata-2024b-h04d1e81_0.tar.bz2
   sha256: bf3130b8c44a7e9bcd496f515d0ee4b2e788610f468bafd708d16d007cb47332
   md5: 48f856789d224eae8d1979c212205fde
   license: CC-PDDC OR BSD-3-Clause
   license_family: BSD
   size: 123651
   timestamp: 1728062827250
-- conda: https://repo.anaconda.com/pkgs/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/noarch/wcwidth-0.2.5-pyhd3eb1b0_0.tar.bz2
   sha256: 2a886caffe9384c6ae32ee72f92d6c4bea0cbcc744682db1a1759d9b17b37af4
   md5: 98982290b7b7eff532ec6dead415172b
   depends:
@@ -2466,7 +2466,7 @@ packages:
   license: MIT
   size: 34378
   timestamp: 1629357209371
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/anyio-4.6.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/anyio-4.6.2-py311hecd8cb5_0.tar.bz2
   sha256: 10c81c3952bdf1073713a33f65f538082b2f6de47c4dff3cf173a18e4f014e7a
   md5: 87d1d76e942262c2c7c39370e30d7b3b
   depends:
@@ -2480,7 +2480,7 @@ packages:
   license_family: MIT
   size: 244917
   timestamp: 1729121433463
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/appnope-0.1.2-py311hecd8cb5_1001.tar.bz2
   sha256: ab7672364f1fa55ec5d8311d85d40e5b57cbd3517b17670557b6fb822bcf759c
   md5: 6e0159a5865cb7e96a748bd8560035ee
   depends:
@@ -2489,7 +2489,7 @@ packages:
   license_family: BSD
   size: 11579
   timestamp: 1678317458652
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/argon2-cffi-bindings-21.2.0-py311h46256e1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/argon2-cffi-bindings-21.2.0-py311h46256e1_1.tar.bz2
   sha256: 3f2344b378e912596a7b66e66e35833e7c20544446f7b19f25f4b500e5441a3d
   md5: c7914de4b54fc22e1b419b5c5426281e
   depends:
@@ -2499,7 +2499,7 @@ packages:
   license_family: MIT
   size: 34877
   timestamp: 1736182638965
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/attrs-24.3.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/attrs-24.3.0-py311hecd8cb5_0.tar.bz2
   sha256: 5543d56ca11cc3aef4c889d8824a798bc4418b82265f43bca53077724c7ed1e9
   md5: fe9dd468243c6b0fbd5d55cc5c2a60cb
   depends:
@@ -2508,7 +2508,7 @@ packages:
   license_family: MIT
   size: 163936
   timestamp: 1734533359828
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/beautifulsoup4-4.12.3-py311hecd8cb5_0.tar.bz2
   sha256: 365824e639808e52809f97b70b65da94a5eeb87e29dd97c8926aa72707a5a1c7
   md5: db7813418dfe42d59363fed4a68d5c36
   depends:
@@ -2518,12 +2518,12 @@ packages:
   license_family: MIT
   size: 278195
   timestamp: 1718029905185
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/blas-1.0-openblas.tar.bz2
   sha256: 695ac69739e73351dfebfb01ea39c5e1dbfdcfb475590d6560ae318bfbad3a97
   md5: 38fd73cba341639c45d8c747b08c9cc1
   size: 49130
   timestamp: 1528225884020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bleach-6.2.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bleach-6.2.0-py311hecd8cb5_0.tar.bz2
   sha256: 7c36e9cb426d000a95c25bfbe5bfe627bf7c7954bb6726b2480e825ec6c41164
   md5: f97fe0299b63520bab00b5bdf52272fc
   depends:
@@ -2535,7 +2535,7 @@ packages:
   license_family: Apache
   size: 371442
   timestamp: 1732291870573
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bokeh-3.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bokeh-3.6.0-py311hecd8cb5_0.tar.bz2
   sha256: fb5f53ec43d4ca92f433a556602a0347038856b5cdbcb2f0014b5445caa1b7a8
   md5: 48f6989f8490bacc7ef44814c3ab7635
   depends:
@@ -2553,7 +2553,7 @@ packages:
   license_family: BSD
   size: 5869515
   timestamp: 1727914551902
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bottleneck-1.4.2-py311h9b7fc35_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bottleneck-1.4.2-py311h9b7fc35_0.tar.bz2
   sha256: 2db3c754dcd7b5f87f8e9384509f539b3c9a80e7c26279c050814258e712a223
   md5: 24af5157264705bc3358ec195490de59
   depends:
@@ -2563,7 +2563,7 @@ packages:
   license_family: BSD
   size: 156491
   timestamp: 1731059250255
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-h46256e1_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-1.0.9-h46256e1_9.tar.bz2
   sha256: 80e274edf9502558321d8688a99dc6ce2a05c6b291ebe37324459465d8d6e229
   md5: 4701bdd9441b09ad3cc9c0b766762940
   depends:
@@ -2573,7 +2573,7 @@ packages:
   license: MIT
   size: 19944
   timestamp: 1736182824280
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-h46256e1_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-bin-1.0.9-h46256e1_9.tar.bz2
   sha256: 19b2438beebdfe5f70587f50aadf01ae7c4650d241a07e26f6806b39834f329d
   md5: 26e4981d811569c9d4b66758366e0516
   depends:
@@ -2582,7 +2582,7 @@ packages:
   license: MIT
   size: 18691
   timestamp: 1736182810077
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/brotli-python-1.0.9-py311h6d0c2b6_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/brotli-python-1.0.9-py311h6d0c2b6_9.tar.bz2
   sha256: c6ff30f54a4448526a1f2c9e5e4835e0416104c41e5b61bdbf6ff310a675641e
   md5: ac04cd8733681fabf6202b9d12a28235
   depends:
@@ -2591,21 +2591,21 @@ packages:
   license: MIT
   size: 394189
   timestamp: 1736182987784
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/bzip2-1.0.8-h6c40b1e_6.tar.bz2
   sha256: 438c40aa11178fe552d6c897b1df6dcee2ba366d27d45756c7fd7ece9c047a1c
   md5: c5a600d81b1b48578863af2973c743ac
   license: bzip2-1.0.8
   license_family: BSD
   size: 187637
   timestamp: 1714510590009
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ca-certificates-2024.12.31-hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ca-certificates-2024.12.31-hecd8cb5_0.tar.bz2
   sha256: 651569faa1282d4fe48fcbfa8776c49f671b6e36e856050007bd56dd0401abb8
   md5: f23596dcfc737eb88e15a1113e092a7d
   license: MPL-2.0
   license_family: Other
   size: 139293
   timestamp: 1736360403971
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/certifi-2024.12.14-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/certifi-2024.12.14-py311hecd8cb5_0.tar.bz2
   sha256: 738ee1189e5b0b7e21bd24de15a7332d733abc1d22f46257cbd89dcb453a26a4
   md5: 1a4b3a732f4250b5c03ded46d7d30357
   depends:
@@ -2614,7 +2614,7 @@ packages:
   license_family: Other
   size: 168308
   timestamp: 1734473349417
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/cffi-1.17.1-py311h9205ec4_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/cffi-1.17.1-py311h9205ec4_1.tar.bz2
   sha256: d93f07c0baebe21d32298a5e4e6d59ec01aa8730628d3e586a099aa75baec0dd
   md5: dffa026d960d5042574e76c406c7b319
   depends:
@@ -2625,7 +2625,7 @@ packages:
   license_family: MIT
   size: 293192
   timestamp: 1736183432113
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/colorcet-3.1.0-py311hecd8cb5_0.tar.bz2
   sha256: 9270668e34b00a2605584a2db5130c83826855cd05b896ce949f3156fa197429
   md5: 2586aa55677e822e8285d777f9039ca9
   depends:
@@ -2634,7 +2634,7 @@ packages:
   license_family: CC
   size: 543487
   timestamp: 1709758497949
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/comm-0.2.1-py311hecd8cb5_0.tar.bz2
   sha256: 389c63a84b92a6254c9d361ebe970d537d0b88733efd5ac5c3ee58196fd2c5a9
   md5: c7bc5b3cbe76be83a27f00b7e4740727
   depends:
@@ -2644,7 +2644,7 @@ packages:
   license_family: BSD
   size: 17974
   timestamp: 1709323004148
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/contourpy-1.3.1-py311h1962661_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/contourpy-1.3.1-py311h1962661_0.tar.bz2
   sha256: a8433ccc2ae0f5a69a2795cc9a124678bc25dd99d23c697280394febd0ce1683
   md5: 9dd4588e1973ae233a3d227182e6c709
   depends:
@@ -2655,7 +2655,7 @@ packages:
   license_family: BSD
   size: 301973
   timestamp: 1732540462617
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/debugpy-1.8.11-py311h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/debugpy-1.8.11-py311h6d0c2b6_0.tar.bz2
   sha256: ca52a2c3bc6ade8a458b1d0f0e5f0637cb715add74480c6061df52658765fa25
   md5: 7728392984085b5bd2550360b608df0d
   depends:
@@ -2665,7 +2665,7 @@ packages:
   license_family: MIT
   size: 2786928
   timestamp: 1736267811270
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/entrypoints-0.4-py311hecd8cb5_0.tar.bz2
   sha256: d48b47b86b09dac1fa4542ec13e1bd4e23093638e684fa66ec3afdd9ce9337c1
   md5: 5a2d1828ab7c8eccd3c2610d13672977
   depends:
@@ -2674,7 +2674,7 @@ packages:
   license_family: MIT
   size: 17336
   timestamp: 1678316187749
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/fonttools-4.51.0-py311h6c40b1e_0.tar.bz2
   sha256: 54645c22fabc25b632114d1d3c403a6fad9149b51ab36719b2690a084f14a072
   md5: a8ad2f4abfb2e17ecf6e596342528156
   depends:
@@ -2692,7 +2692,7 @@ packages:
   license_family: MIT
   size: 3180691
   timestamp: 1713551771692
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/freetype-2.12.1-hd8bbffd_0.tar.bz2
   sha256: 15e865111166f4a812a6ba3d629ae16c42ec9a2c6d10134d5a3809989c867eb8
   md5: 9a52880a01116b72d3e7b98d685abf67
   depends:
@@ -2702,7 +2702,7 @@ packages:
   license_family: Other
   size: 924929
   timestamp: 1666798304003
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/holoviews-1.20.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/holoviews-1.20.0-py311hecd8cb5_0.tar.bz2
   sha256: 60fbaec8c8ddc4ac235a4c8143a1d734e34c0543ba20985973cb43a9220262c9
   md5: f781135af3dde8699b5b3cf9bfe83b3f
   depends:
@@ -2722,7 +2722,7 @@ packages:
   license_family: BSD
   size: 6129648
   timestamp: 1730828256779
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/hvplot-0.11.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/hvplot-0.11.2-py311hecd8cb5_0.tar.bz2
   sha256: e411b00b35edd4c57b15aa55807c1edbf0ef26e8c7452827364b50ea40798052
   md5: 6696a322de6d7ac72287c210100fe2ad
   depends:
@@ -2739,7 +2739,7 @@ packages:
   license_family: BSD
   size: 372947
   timestamp: 1734469892069
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/idna-3.7-py311hecd8cb5_0.tar.bz2
   sha256: 5c2458964157fe493ca18c513c693b70cb622087e5fa0c93e65fc45217edd811
   md5: 15629e52625221b51a443cefd9501d12
   depends:
@@ -2748,7 +2748,7 @@ packages:
   license_family: BSD
   size: 148522
   timestamp: 1714398885844
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipykernel-6.29.5-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipykernel-6.29.5-py311hecd8cb5_0.tar.bz2
   sha256: 4772db5a35dfbdabf55b01943916d0a5b451db757aa38372571bb3e03948527a
   md5: f6b4cd61684c3ec067cbda883fca865d
   depends:
@@ -2770,7 +2770,7 @@ packages:
   license_family: BSD
   size: 240267
   timestamp: 1728665688908
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ipython-8.30.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ipython-8.30.0-py311hecd8cb5_0.tar.bz2
   sha256: 69fe2c100148f65f721bc791004000aa1e6a96cce9271f2c52c6b273f626d208
   md5: e82a62e5327d2ad85d2456e675487b6a
   depends:
@@ -2788,7 +2788,7 @@ packages:
   license_family: BSD
   size: 1640008
   timestamp: 1734551073802
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jedi-0.19.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jedi-0.19.2-py311hecd8cb5_0.tar.bz2
   sha256: 40f655b062710295113369c5c236ca3f0b281fd2b91959cffd02f20aa9dbfd57
   md5: c6e3b63c5b90d3a422ca100f5a233a10
   depends:
@@ -2798,7 +2798,7 @@ packages:
   license_family: MIT
   size: 1193759
   timestamp: 1733987587898
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jinja2-3.1.4-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jinja2-3.1.4-py311hecd8cb5_1.tar.bz2
   sha256: f0610ceaac87ce39266f4dee8185244668ac9345143c9eb22c4cb201b79aab00
   md5: 2d4759abb2b7a3de114fdef7bb241474
   depends:
@@ -2810,14 +2810,14 @@ packages:
   license_family: BSD
   size: 354673
   timestamp: 1730902923439
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jpeg-9e-h46256e1_3.tar.bz2
   sha256: 855982a798d9af8e70635a250528a5da3b2b0cf7095e2804858caf139c8a239b
   md5: 112a5602fe42a84a5bafa038abeddf4f
   license: IJG
   license_family: Other
   size: 279686
   timestamp: 1722872676718
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-4.23.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-4.23.0-py311hecd8cb5_0.tar.bz2
   sha256: a899e7bdac6b9b734882ee44a8065d7006dd669fde9b0fb0a88ed2e2f77ec357
   md5: 14a0abb1c37f2e37c0e55b8feec8d564
   depends:
@@ -2830,7 +2830,7 @@ packages:
   license_family: MIT
   size: 193788
   timestamp: 1728487044949
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jsonschema-specifications-2023.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 0ea44d0c8044e70ab0eaf4d6f5f3e4753838dee106b5cbd36561e21a65cbac77
   md5: 1d045016dca889d702f1caf3a16162fc
   depends:
@@ -2840,7 +2840,7 @@ packages:
   license_family: MIT
   size: 16528
   timestamp: 1699032525791
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_client-7.4.9-py311hecd8cb5_0.tar.bz2
   sha256: 70442ec4b0b7ebbdcf150963f61f797b861001092124f4ea39a16eb92a4d176e
   md5: 63d1503915a15ae4f9ad1c46112ca374
   depends:
@@ -2856,7 +2856,7 @@ packages:
   license_family: BSD
   size: 272720
   timestamp: 1678316970740
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_core-5.7.2-py311hecd8cb5_0.tar.bz2
   sha256: e657ec0667481d957827be1ce825b0a971aa3a211b07c1274d2c1099ded3129c
   md5: 5e317fd45011a0003c29331a8002cb75
   depends:
@@ -2867,7 +2867,7 @@ packages:
   license_family: BSD
   size: 98632
   timestamp: 1718818439542
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_events-0.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 2634d721123ea1e41b6e1cfe4a67552ec520ea9b5154c9e788ccb09d4745b732
   md5: e874eba19b493b7a68161429f24b8f51
   depends:
@@ -2883,7 +2883,7 @@ packages:
   license_family: BSD
   size: 43102
   timestamp: 1718738272613
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server-2.14.1-py311hecd8cb5_0.tar.bz2
   sha256: c353480ed4744c2a16aaccc1649bab38144436ad6d16ac2937e3e333d32fdccc
   md5: 7de25bdf4cfd3f5485d790d9cddf427f
   depends:
@@ -2910,7 +2910,7 @@ packages:
   license_family: BSD
   size: 619935
   timestamp: 1718828240904
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyter_server_terminals-0.4.4-py311hecd8cb5_1.tar.bz2
   sha256: fd7964657f0a8fe8b167ba860b1f960e8b7b45309eb6c7c850d50ec283fe03b5
   md5: 2967bb345bc75f53182e263ff4743ca6
   depends:
@@ -2920,7 +2920,7 @@ packages:
   license_family: BSD
   size: 28223
   timestamp: 1686870845224
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/jupyterlab_pygments-0.2.2-py311hecd8cb5_0.tar.bz2
   sha256: 64cf59f0f74b0329b5069bc6135b4f40593f1dac52d85ad574d4b8e0a4b2cf16
   md5: 35e8b80eaa03a904fc7f1da39e7f654d
   depends:
@@ -2932,7 +2932,7 @@ packages:
   license_family: BSD
   size: 20234
   timestamp: 1700168776500
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/kiwisolver-1.4.4-py311hcec6c5f_0.tar.bz2
   sha256: a12382b50416803f559a03fb384ba492c1dafa351e1191a3f8dc361bee6c4f37
   md5: f2ae846b663bbb642f4b1e90eaad38a3
   depends:
@@ -2942,7 +2942,7 @@ packages:
   license_family: BSD
   size: 64817
   timestamp: 1678322501509
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lcms2-2.16-h4f63f0c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lcms2-2.16-h4f63f0c_0.tar.bz2
   sha256: ca7970616a49595aa2ada83fd1ab5f5318fc3254d21f66e946cfd9f1c6b5188b
   md5: 851fa57e5675397c0e724987f17a3f3d
   depends:
@@ -2952,7 +2952,7 @@ packages:
   license_family: MIT
   size: 264025
   timestamp: 1734428532705
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lerc-4.0.0-h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lerc-4.0.0-h6d0c2b6_0.tar.bz2
   sha256: 50da46ac4a032a38d2d9e714e945079e05a46ae451437a52ad09b4cd5d925f5b
   md5: 234c885b9f326ecf78b5294fb709ddee
   depends:
@@ -2961,13 +2961,13 @@ packages:
   license_family: Apache
   size: 295348
   timestamp: 1734423413199
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlicommon-1.0.9-h46256e1_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlicommon-1.0.9-h46256e1_9.tar.bz2
   sha256: 8f058b4b23c8d56f8411c8f6eec834ea30e8a2ce7a98685ad9c2a4817aabae4a
   md5: b64809b5c2030ac3e571c9f6b5b34335
   license: MIT
   size: 66530
   timestamp: 1736182753663
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlidec-1.0.9-h46256e1_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlidec-1.0.9-h46256e1_9.tar.bz2
   sha256: 6269fa97423611d7310bb23d6929e1fee3246a10440cd931718d4d447f6d4215
   md5: 23d3558e675675ea0281bbfcac49453a
   depends:
@@ -2975,7 +2975,7 @@ packages:
   license: MIT
   size: 34461
   timestamp: 1736182772158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libbrotlienc-1.0.9-h46256e1_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libbrotlienc-1.0.9-h46256e1_9.tar.bz2
   sha256: 738524a5398e731ba9c74b799bf5e972721af4a4dc6a5425d2e17780e3e15912
   md5: b562c3b15ef8b86391171d2f1b85cae6
   depends:
@@ -2983,28 +2983,28 @@ packages:
   license: MIT
   size: 311811
   timestamp: 1736182791956
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libcxx-14.0.6-h9765a3e_0.tar.bz2
   sha256: 7bff6afa61f71c268279f70c7d23a27a97fcc4b7144c33c4de46f1cf4b8da16b
   md5: af92f506156c9defc9b4dff41ecea1f9
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1391293
   timestamp: 1662620489455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libdeflate-1.22-h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libdeflate-1.22-h46256e1_0.tar.bz2
   sha256: 5267b5015a03aa90883f57b3cc5dda014082e5ab88e2d3b30fe809c37b96094c
   md5: a6bdcc6561a095bc0ac11482e84c37c8
   license: MIT
   license_family: MIT
   size: 84141
   timestamp: 1734423352364
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libffi-3.4.4-hecd8cb5_1.tar.bz2
   sha256: 2c99b89a93497f81b323339d3a241a2437700d19ff17ca9ea8fc4899ad8cc9b9
   md5: 822a5b76117e56d3912f1f2153307528
   license: MIT
   license_family: MIT
   size: 136045
   timestamp: 1714483561919
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.tar.bz2
   sha256: ca94307d94c886dd4e48062dea64681fa6e703f1bea20cc8f90651fab87c17cb
   md5: e458587c87e3f2d20192f4e0738f2c63
   depends:
@@ -3013,7 +3013,7 @@ packages:
   license_family: GPL
   size: 149419
   timestamp: 1665498987619
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libgfortran5-11.3.0-h9dfd629_28.tar.bz2
   sha256: 2df0fd35a5eb6b0fc16d60ad26a3e097db4e48cf3c4d62b1ff8612588cda9b1b
   md5: 1058b661ec829b2ee3716ee2a5520641
   depends:
@@ -3024,7 +3024,7 @@ packages:
   license_family: GPL
   size: 1917987
   timestamp: 1665498925405
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libopenblas-0.3.21-h54e7dc3_0.tar.bz2
   sha256: 499ebc9000c8e810081b5d7f7524b45dc99f6914096ea9e145366033514938b4
   md5: ce5c24f93932e1a53d7d89e502f28783
   depends:
@@ -3035,7 +3035,7 @@ packages:
   license_family: BSD
   size: 10123989
   timestamp: 1664896966769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libpng-1.6.39-h6c40b1e_0.tar.bz2
   sha256: 060a686ecad744b62ca7afa4eb053466b1b566c88d4e52d1d40908dcfdfbfce9
   md5: cc2688c4d0b91033ee4d9064bebfcf3d
   depends:
@@ -3044,13 +3044,13 @@ packages:
   license_family: Other
   size: 318453
   timestamp: 1677841804115
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libsodium-1.0.18-h1de35cc_0.tar.bz2
   sha256: f1d7df37c9dad40e73be45c98f7e99b298e1db9d5fc8d884628ab1dbf5b1b86d
   md5: b622efec408361995816c7ded7b5625a
   license: ISC
   size: 365163
   timestamp: 1581701250028
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.5.1-h6fa9cd1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libtiff-4.5.1-h6fa9cd1_1.tar.bz2
   sha256: 82d2f89ec9f2b0769c0368f7f0734a405e3fb12bbdbefd3ec13b478bf6b2b699
   md5: 2a4899f52b1a65d18dfc2af0ea3d5177
   depends:
@@ -3066,7 +3066,7 @@ packages:
   license_family: Other
   size: 668404
   timestamp: 1734425846576
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/libwebp-base-1.3.2-h46256e1_1.tar.bz2
   sha256: 246c0d82766042c1a9194eecc71690918c68afa3528ff0c2c82796ce901df40b
   md5: f33be4ed3bff89ed8f68df6c75158510
   constrains:
@@ -3075,7 +3075,7 @@ packages:
   license_family: BSD
   size: 449215
   timestamp: 1729160070984
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/linkify-it-py-2.0.0-py311hecd8cb5_0.tar.bz2
   sha256: d28c465ec6d5f8d4962c597b249b58998300c8b4e3c937c578c3d15294ea863d
   md5: dcaed6ddd0723c7cce6bfad917be98b2
   depends:
@@ -3085,7 +3085,7 @@ packages:
   license_family: MIT
   size: 41176
   timestamp: 1678413498410
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/llvm-openmp-14.0.6-h0dcd299_0.tar.bz2
   sha256: e274916b0ecdba6dc87067a4f6ca8ff810602a3b1ebc4a25fb4d9bac3433c65c
   md5: 5c740b4a18a558de0ccfe601703c423c
   constrains:
@@ -3094,7 +3094,7 @@ packages:
   license_family: Apache
   size: 338738
   timestamp: 1662635677689
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/lz4-c-1.9.4-hcec6c5f_1.tar.bz2
   sha256: fc0e7e58f3b9ff542dd954825dba42373c98abc003d17a4abe59fbeba5cb2955
   md5: 8f57dc3a3327bb6f7e1cba908856ac7f
   depends:
@@ -3103,7 +3103,7 @@ packages:
   license_family: BSD
   size: 183138
   timestamp: 1714510756758
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-3.4.1-py311hecd8cb5_0.tar.bz2
   sha256: 6fb2953e169ee1ae38f24d29752051501992f19b96b5ebcea9af75737bdbcb42
   md5: 7f410cdae838c5030108d1b98a8c78f6
   depends:
@@ -3112,7 +3112,7 @@ packages:
   license_family: BSD
   size: 162478
   timestamp: 1678377892595
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markdown-it-py-2.2.0-py311hecd8cb5_1.tar.bz2
   sha256: cd97e09a12ffb49b2a30a782fa8c7933b28f5ffdbfc5c73a9ebaa95fc9447370
   md5: d1fb6ebc1e5728aa6377cfc71da08942
   depends:
@@ -3122,7 +3122,7 @@ packages:
   license_family: MIT
   size: 135859
   timestamp: 1684280005320
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/markupsafe-2.1.3-py311h46256e1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/markupsafe-2.1.3-py311h46256e1_1.tar.bz2
   sha256: b266e4d6161bae908a36e9c0ed5e1be0fe468a661a4fb83a35cd7dcfeb17b787
   md5: a81fab1a743f220322e1317d42590780
   depends:
@@ -3133,7 +3133,7 @@ packages:
   license_family: BSD
   size: 26841
   timestamp: 1736368702229
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-base-3.10.0-py311h919b35b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-base-3.10.0-py311h919b35b_0.tar.bz2
   sha256: a02829868777ce746dafb37da1a234c212d11ed8609c13e8fb837e5cc0b82116
   md5: 4d13f50eb1cda9f81858fd11ded08720
   depends:
@@ -3153,7 +3153,7 @@ packages:
   license_family: PSF
   size: 9826780
   timestamp: 1736279748306
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/matplotlib-inline-0.1.6-py311hecd8cb5_0.tar.bz2
   sha256: 07e7fd5bd64e55328b4b99d92e2e2600d791f1095bf905daab4cfc59f0f0a45b
   md5: cf53321779f4ca7e986c1468719b93f1
   depends:
@@ -3163,7 +3163,7 @@ packages:
   license_family: BSD
   size: 19500
   timestamp: 1678317565001
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdit-py-plugins-0.3.0-py311hecd8cb5_0.tar.bz2
   sha256: 0770e02be1ea1216af493cfc03d5b8a702e14606fa93b0692bcdab1fed1b898c
   md5: ca6f06ceaf66a32bbf5dfdb6e373a5cf
   depends:
@@ -3173,7 +3173,7 @@ packages:
   license_family: MIT
   size: 67892
   timestamp: 1678417734353
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mdurl-0.1.0-py311hecd8cb5_0.tar.bz2
   sha256: fbe95ed0501bb0f137048476fe41bc718dd659e8ecb066bc67ac17d6a50f4318
   md5: ec162bde8d1c8a107b257df218b17035
   depends:
@@ -3182,7 +3182,7 @@ packages:
   license_family: MIT
   size: 23030
   timestamp: 1678381838497
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/mistune-2.0.4-py311hecd8cb5_0.tar.bz2
   sha256: c20dd678655e582129a858a1c5162bdc254082d3a3c035b0f72629d9276e5b75
   md5: 800a0738c728796e02d0386ce7d457aa
   depends:
@@ -3193,7 +3193,7 @@ packages:
   license_family: BSD
   size: 104585
   timestamp: 1678317269407
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclassic-1.1.0-py311hecd8cb5_0.tar.bz2
   sha256: f961b1322b6b02fee53ff9bd0f56bb73886eb59debd3f3666669593de7f48894
   md5: a1e74ccd2f341d1d672e33d79e60d200
   depends:
@@ -3206,7 +3206,7 @@ packages:
   license_family: BSD
   size: 8183400
   timestamp: 1717623127275
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbclient-0.8.0-py311hecd8cb5_0.tar.bz2
   sha256: e08cb3ee6df01f4c1e1ac8bc4ed1a06e549ffcc8774fe2e2842c644bb8f74a86
   md5: 6ba0ae0fb14cbea1e3197707701dc180
   depends:
@@ -3219,7 +3219,7 @@ packages:
   license_family: BSD
   size: 123077
   timestamp: 1698934356774
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbconvert-7.16.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbconvert-7.16.4-py311hecd8cb5_0.tar.bz2
   sha256: 098d35939d62073df7fc42fadde9d9f7f646e4727382c363c02c136820555e80
   md5: 25b1cce018e6c1b19146f117690d2b5b
   depends:
@@ -3246,7 +3246,7 @@ packages:
   license_family: BSD
   size: 533595
   timestamp: 1728050041209
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nbformat-5.10.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nbformat-5.10.4-py311hecd8cb5_0.tar.bz2
   sha256: 3175bd2b744191da1c7477be8162a0f8d7f68363de8c2ab6df989908211ba17c
   md5: 2508c1c6fc84c712ce0419470f60b5fb
   depends:
@@ -3259,14 +3259,14 @@ packages:
   license_family: BSD
   size: 171386
   timestamp: 1728050190296
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/ncurses-6.4-hcec6c5f_0.tar.bz2
   sha256: 89766624cdd4de2e901400445ebcdccfbbd936e8dba040ea40e33c662a23a029
   md5: 20344bea303e2aff2796ee9963c12c7d
   license: MIT AND X11
   license_family: MIT
   size: 1100911
   timestamp: 1674734102055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/nest-asyncio-1.6.0-py311hecd8cb5_0.tar.bz2
   sha256: 42d803e1d8b54748db5d989ecd503826f564132df7cddc20f520460f55e523a1
   md5: cd3fa71626ebc098da4625fc6be79752
   depends:
@@ -3275,7 +3275,7 @@ packages:
   license_family: BSD
   size: 16952
   timestamp: 1708532805951
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-6.5.7-py311hecd8cb5_0.tar.bz2
   sha256: 09d88f1eb19a90dfe737f0e5b4dce7629f6076a2d91d572cbb0a41be5220a4e8
   md5: ac8c26d949a04f478b560b7d8a2358a4
   depends:
@@ -3300,7 +3300,7 @@ packages:
   license_family: BSD
   size: 707187
   timestamp: 1717630829258
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/notebook-shim-0.2.3-py311hecd8cb5_0.tar.bz2
   sha256: ed5608feb37a083d47b04203195260e801b64b5380f292cf18bb61e7ad827a2a
   md5: daa9c1c233673b727528548454aea664
   depends:
@@ -3310,7 +3310,7 @@ packages:
   license_family: BSD
   size: 27607
   timestamp: 1699456006797
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numexpr-2.10.1-py311hc59c7be_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numexpr-2.10.1-py311hc59c7be_0.tar.bz2
   sha256: 4b784353c86d73f10d714c039c29ca73508203cb86a7ce455f71ee52b940edb3
   md5: a8c1b6256e1d5743bb92d9c467736aa8
   depends:
@@ -3324,7 +3324,7 @@ packages:
   license_family: MIT
   size: 202114
   timestamp: 1730216207054
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-2.1.3-py311h13f252e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-2.1.3-py311h13f252e_0.tar.bz2
   sha256: 139ecaa09c2daf21f93ea5a049b3e43fc11ae876e9ae143d0b7183446ae7fe1b
   md5: 3a1c27218d2c14e703b8b77b12d444c2
   depends:
@@ -3339,7 +3339,7 @@ packages:
   license_family: BSD
   size: 11745
   timestamp: 1730840497938
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/numpy-base-2.1.3-py311ha745260_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/numpy-base-2.1.3-py311ha745260_0.tar.bz2
   sha256: 6d0b66a3ec1ed61691d5a509e536eb93f90a64ed3d6633dfe2edec4368597563
   md5: 40ac4bb60e0b39827f523dd5a6a732bd
   depends:
@@ -3353,7 +3353,7 @@ packages:
   license_family: BSD
   size: 9520946
   timestamp: 1730840459245
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openjpeg-2.5.2-hbf2204d_0.tar.bz2
   sha256: 401214a4763c79c2355b012b9f29e3cee097a598bb53e933acb6b98a2bb6614f
   md5: 3216c5f433643ee62a8d0672c3500320
   depends:
@@ -3364,7 +3364,7 @@ packages:
   license_family: BSD
   size: 535252
   timestamp: 1722872704730
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/openssl-3.0.15-h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/openssl-3.0.15-h46256e1_0.tar.bz2
   sha256: 8cc69ca3f77c9dc8bed662100046085536c6a95b77b2a964ba79fc81ba3f698a
   md5: 270474613701d2371d5c5cc220a78825
   depends:
@@ -3373,7 +3373,7 @@ packages:
   license_family: Apache
   size: 4961721
   timestamp: 1725545867722
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/overrides-7.4.0-py311hecd8cb5_0.tar.bz2
   sha256: 8a0809f419065e014cb8e2c8a516cadca6088fb71fd1ef3ae2287d91e3360d59
   md5: 4dc0b9bc88476fcc5246d823ff1c289a
   depends:
@@ -3382,7 +3382,7 @@ packages:
   license_family: APACHE
   size: 39645
   timestamp: 1699371213055
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/packaging-24.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/packaging-24.2-py311hecd8cb5_0.tar.bz2
   sha256: 81f1c12808d6db7c1b26bace7b719fdfd45d7a683e46223c5d4b3843da957c39
   md5: ec1eed2e438db9d3e9906d30d2ad55d6
   depends:
@@ -3391,7 +3391,7 @@ packages:
   license_family: Apache
   size: 189794
   timestamp: 1734472374591
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pandas-2.2.3-py311h6d0c2b6_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pandas-2.2.3-py311h6d0c2b6_0.tar.bz2
   sha256: 320127675235a15f36cd445ad7366ba64acd939ecd5bec5b6888ef365aed27a7
   md5: c283b35da322fcba5fe94e69da4df242
   depends:
@@ -3441,7 +3441,7 @@ packages:
   license_family: BSD
   size: 17297833
   timestamp: 1732736229906
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/panel-1.5.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/panel-1.5.3-py311hecd8cb5_0.tar.bz2
   sha256: da4c642c2c4d0265063a50cfc3e5437b422bb8e807934823f98e0ab23dafab40
   md5: 7aade1ab52d00e6df57919c6cfeeb2e9
   depends:
@@ -3466,7 +3466,7 @@ packages:
   license_family: BSD
   size: 24103145
   timestamp: 1730381703387
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/param-2.2.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/param-2.2.0-py311hecd8cb5_0.tar.bz2
   sha256: 0639a95fc20308a04d5b1d67b7f8770013a0fb46d2fc605466036f7acbb22061
   md5: 2c90142d5c3066fe79194fe084808bf6
   depends:
@@ -3475,7 +3475,7 @@ packages:
   license_family: BSD
   size: 272394
   timestamp: 1734618667545
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/parso-0.8.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/parso-0.8.4-py311hecd8cb5_0.tar.bz2
   sha256: c204c097bc991a8ba9f459b710a690259c4c3fd44a8550b0f65f2f0a11a80cb4
   md5: 5ce9f46a387e05dff118a050152880f5
   depends:
@@ -3484,7 +3484,7 @@ packages:
   license_family: MIT
   size: 225040
   timestamp: 1733963549046
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pillow-11.0.0-py311h47bf62f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pillow-11.0.0-py311h47bf62f_1.tar.bz2
   sha256: 326dcf1882d0d06b61afc4eed062baf300a98f8df73f01e51d06548d4f040a63
   md5: 96764a87a531506df69ba564467394ee
   depends:
@@ -3501,7 +3501,7 @@ packages:
   license_family: Other
   size: 970786
   timestamp: 1734430869385
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pip-24.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pip-24.2-py311hecd8cb5_0.tar.bz2
   sha256: 492ea4d1c5a4f860f3312c7729f1e33b706007578c25c031241d7497a115dd79
   md5: 835f4767cdb9d80338e0bba649c1ce3c
   depends:
@@ -3512,7 +3512,7 @@ packages:
   license_family: MIT
   size: 2923519
   timestamp: 1723484652903
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/platformdirs-3.10.0-py311hecd8cb5_0.tar.bz2
   sha256: 81719c31101d6c019150cedcc7b08adb3bdb357e8b2952e428dadaabc4dc985d
   md5: 105825168e0a17fb007f60b5f314e311
   depends:
@@ -3521,7 +3521,7 @@ packages:
   license_family: MIT
   size: 38405
   timestamp: 1692205731769
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prometheus_client-0.21.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prometheus_client-0.21.0-py311hecd8cb5_0.tar.bz2
   sha256: 74d50e1d381add9e02e4d4c9b0ae247f1c90bcc544cb622d6bf6c420ad17408d
   md5: 3059b89ad8f6ed91166c87ef25349ca5
   depends:
@@ -3530,7 +3530,7 @@ packages:
   license_family: Apache
   size: 122986
   timestamp: 1731958894994
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/prompt-toolkit-3.0.43-py311hecd8cb5_0.tar.bz2
   sha256: e32843723b10ecd9badde28e1085419c0b59ed8a96c7cacce6395e39e3a874f9
   md5: 5af0280a817d2c273304cd22328124af
   depends:
@@ -3542,7 +3542,7 @@ packages:
   license_family: BSD
   size: 763044
   timestamp: 1704404460779
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/psutil-5.9.0-py311h46256e1_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/psutil-5.9.0-py311h46256e1_1.tar.bz2
   sha256: d4711400167a76a91b3067d0982d135546e6479a5dcabe4a8087d4f16729b081
   md5: 8b89db6f3680b3ceddfb37d3489a96e0
   depends:
@@ -3551,7 +3551,7 @@ packages:
   license_family: BSD
   size: 503499
   timestamp: 1736369694493
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pygments-2.15.1-py311hecd8cb5_1.tar.bz2
   sha256: dfb403f367c57327a4d080109df88383ecff18464de287a1ce936a7274e3656b
   md5: 997b674bad89963af875b93b06807f51
   depends:
@@ -3560,7 +3560,7 @@ packages:
   license_family: BSD
   size: 2120413
   timestamp: 1684280057020
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyparsing-3.2.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyparsing-3.2.0-py311hecd8cb5_0.tar.bz2
   sha256: d91145c8170d70c3343e3c72de9bbd65f18dd868699d5865cfd378027ed1d1e6
   md5: be4e175b2ddfdde750cdf6f83fb694d0
   depends:
@@ -3569,7 +3569,7 @@ packages:
   license_family: MIT
   size: 487468
   timestamp: 1731445595709
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pysocks-1.7.1-py311hecd8cb5_0.tar.bz2
   sha256: 717e038567506ca58ce1cd4a3416892d02f4ebfdd332077cc3d110cfe3d36c58
   md5: 53bbfb400668f798eef6f8c7cf938e1f
   depends:
@@ -3578,7 +3578,7 @@ packages:
   license_family: BSD
   size: 35751
   timestamp: 1678315886516
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-3.11.11-h4d6d9e5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-3.11.11-h4d6d9e5_0.tar.bz2
   sha256: 250c9769e378c2bc583c3c89351d3ea20e363825aa0c72e98a5c6ea3a1934a50
   md5: bf4aaf980dd4941ab9a2a6e413d36c57
   depends:
@@ -3597,7 +3597,7 @@ packages:
   license_family: PSF
   size: 16867465
   timestamp: 1733935409990
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-dateutil-2.9.0post0-py311hecd8cb5_2.tar.bz2
   sha256: 04e100d0a1ea9722e24972657ec5935ad34c7c58957dabb821333e5eac80f717
   md5: 2b6de49ad07b26e1f7084f0fda958eb1
   depends:
@@ -3607,7 +3607,7 @@ packages:
   license_family: BSD
   size: 332276
   timestamp: 1716495830117
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-fastjsonschema-2.20.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-fastjsonschema-2.20.0-py311hecd8cb5_0.tar.bz2
   sha256: 5f0b041239a0ad2b3888b944efd9cad94e92bcbc91f25eae80a7065c7446379b
   md5: 0e26c390904343d308b6677403d8a8e5
   depends:
@@ -3616,7 +3616,7 @@ packages:
   license_family: BSD
   size: 282407
   timestamp: 1731939768586
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/python-json-logger-3.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/python-json-logger-3.2.1-py311hecd8cb5_0.tar.bz2
   sha256: 2aaaf300f4f747bd82cfb52e2ea8c581fe7a9548384b22e862625a1489f6263c
   md5: eceb46e8d6370a13fcc8443feb798d47
   depends:
@@ -3625,7 +3625,7 @@ packages:
   license_family: BSD
   size: 29626
   timestamp: 1734370318805
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pytz-2024.1-py311hecd8cb5_0.tar.bz2
   sha256: e358fe679e83ccdc8c433746ae6468e8e96d90d97d99530f8476ef5630b2c121
   md5: ce30a0a31d891e69dc9b7bf8b7f0c39c
   depends:
@@ -3634,7 +3634,7 @@ packages:
   license_family: MIT
   size: 268876
   timestamp: 1713974360942
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyviz_comms-3.0.2-py311hecd8cb5_0.tar.bz2
   sha256: eeb5a5eed93b8e311ad4d3f4389e050f11bba2eaec9536e1c3ed2f849c6c999b
   md5: c18bd3e12de797d52a470c21a150dffe
   depends:
@@ -3646,7 +3646,7 @@ packages:
   license_family: BSD
   size: 65270
   timestamp: 1711136914884
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyyaml-6.0.2-py311h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyyaml-6.0.2-py311h46256e1_0.tar.bz2
   sha256: eaba8d555ca65df57c5c1dfa320c6b222ddb2c428609a29765ea89179ff05a98
   md5: 9a926091b8beee27d251241d227a646d
   depends:
@@ -3656,7 +3656,7 @@ packages:
   license_family: MIT
   size: 208392
   timestamp: 1728659514546
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/pyzmq-24.0.1-py311h6c40b1e_0.tar.bz2
   sha256: aa07b90a7ee65f76c8cba1ff99a5cdeb95cbe41881ae951f64ffff06674a1b2d
   md5: 58621e3d244137885f7dfbb35e50340a
   depends:
@@ -3666,7 +3666,7 @@ packages:
   license_family: Other
   size: 594801
   timestamp: 1709318510622
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/readline-8.2-hca72f7f_0.tar.bz2
   sha256: 1735fe90c89244a6144598197cc99a4daf21ccd8152520d953d88fd094193a7f
   md5: e8977fc2e69cb52f8dbb1b676d04cc45
   depends:
@@ -3675,7 +3675,7 @@ packages:
   license_family: GPL
   size: 386061
   timestamp: 1666648077019
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/referencing-0.30.2-py311hecd8cb5_0.tar.bz2
   sha256: d784dc26c5de8e41845350a899e5779250b71f45d39e2aece62e739e9add7308
   md5: 7b077b7f46112bb31dc066396c51d3fa
   depends:
@@ -3686,7 +3686,7 @@ packages:
   license_family: MIT
   size: 74776
   timestamp: 1699012164201
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/requests-2.32.3-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/requests-2.32.3-py311hecd8cb5_1.tar.bz2
   sha256: 022bc34ef458cf0f26cb2e94f3238618e72ca59489efb074d25e5a4700e53707
   md5: 4f1d626c702cbb79e25aa92375049279
   depends:
@@ -3702,7 +3702,7 @@ packages:
   license_family: Apache
   size: 124655
   timestamp: 1730999183404
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3339-validator-0.1.4-py311hecd8cb5_0.tar.bz2
   sha256: 727fb8d957e02d03b928d049ffbc712316f176a2c331391766d646621b45655a
   md5: 7e0e416c642f3ee4ddfb084a811fb4df
   depends:
@@ -3712,7 +3712,7 @@ packages:
   license_family: MIT
   size: 10236
   timestamp: 1683077214314
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rfc3986-validator-0.1.1-py311hecd8cb5_0.tar.bz2
   sha256: a8a67143ccb65cfd6f50055176b6c26179a83130a45d0a12e79dd2de68d8db63
   md5: a2065790f41e3eeb6efe0ef6daa75377
   depends:
@@ -3721,7 +3721,7 @@ packages:
   license_family: MIT
   size: 10600
   timestamp: 1683059285216
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/rpds-py-0.10.6-py311h83de92b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/rpds-py-0.10.6-py311h83de92b_1.tar.bz2
   sha256: ff1effe1a0558882611efd943822ca2d60dab801b6d643519a8a956fdd7f0424
   md5: eb5880cb36e5b133f17a899acde434ad
   depends:
@@ -3732,7 +3732,7 @@ packages:
   license_family: MIT
   size: 308653
   timestamp: 1732231060164
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/send2trash-1.8.2-py311hecd8cb5_0.tar.bz2
   sha256: beba0555707dac1e8484d73cee9e4128ac4b10e2a0d4209357481179022e8fdc
   md5: baa8b304607b3a9ae8a3d9acb354c31c
   depends:
@@ -3741,7 +3741,7 @@ packages:
   license_family: BSD
   size: 33343
   timestamp: 1699371216044
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/setuptools-72.1.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/setuptools-72.1.0-py311hecd8cb5_0.tar.bz2
   sha256: e8ae4e9fd18d355497c67165d57ab11205c87a29a3f1ca3e183f999383dccf52
   md5: c12aca7f16288ed88f100109dd6035e7
   depends:
@@ -3750,7 +3750,7 @@ packages:
   license_family: MIT
   size: 3292002
   timestamp: 1722860295070
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sniffio-1.3.0-py311hecd8cb5_0.tar.bz2
   sha256: 0eb44a16ef74a13ef7839209899d009cd94974fbc406a417d958c7bc8d955245
   md5: 41f239a5b67b1daf819849023aa5d12f
   depends:
@@ -3759,7 +3759,7 @@ packages:
   license_family: Other
   size: 19056
   timestamp: 1705431379885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/soupsieve-2.5-py311hecd8cb5_0.tar.bz2
   sha256: 14775231982e1ea150189c956927ccfb1ad01a8c9395cdeea4d5a48b9b8ce664
   md5: 729badc4bf7ba8ccc70e0f9e58075c99
   depends:
@@ -3768,7 +3768,7 @@ packages:
   license_family: MIT
   size: 89812
   timestamp: 1696347694075
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/sqlite-3.45.3-h6c40b1e_0.tar.bz2
   sha256: 5c02813e7173908a1186ed67daec12da5d1f36ea02893d57ac3f8a69f8c33c77
   md5: 6bef1694163a68ac4c37e5857b8da4f5
   depends:
@@ -3780,7 +3780,7 @@ packages:
   license_family: Other
   size: 1900191
   timestamp: 1714488351925
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/terminado-0.17.1-py311hecd8cb5_0.tar.bz2
   sha256: 3d5c2968f581006437df3932cd5d3c1c4afa78f0e13757b958440245d3248856
   md5: 605ea221d225ad8e79284dbcfdab0715
   depends:
@@ -3791,7 +3791,7 @@ packages:
   license_family: BSD
   size: 37699
   timestamp: 1678317755913
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tinycss2-1.2.1-py311hecd8cb5_0.tar.bz2
   sha256: ed059e32ce5a1c0511575f29d2fb6da12c54a37000bfa80f9e5aa9dfd9e04101
   md5: 4d2261a92d25136a68b8d01d101119f5
   depends:
@@ -3801,7 +3801,7 @@ packages:
   license_family: BSD
   size: 49145
   timestamp: 1678317386284
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tk-8.6.14-h4d00af3_0.tar.bz2
   sha256: ddbec7c0ccea5e642f0f26a6a4cf23514bf395101deb1a712f74797d562e4ff6
   md5: 523c006cc67c011383678c762015479b
   depends:
@@ -3810,7 +3810,7 @@ packages:
   license_family: BSD
   size: 3594448
   timestamp: 1714770737885
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tornado-6.4.2-py311h46256e1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tornado-6.4.2-py311h46256e1_0.tar.bz2
   sha256: 926f89ddb422d2868f65532d07637474578c27ddc90ef9202410f075fe310b95
   md5: 1c4aad6b2e2e721689e4b7f0d24bbd9a
   depends:
@@ -3819,7 +3819,7 @@ packages:
   license_family: Apache
   size: 916363
   timestamp: 1733960657634
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/tqdm-4.66.5-py311h85bffb1_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/tqdm-4.66.5-py311h85bffb1_0.tar.bz2
   sha256: ec67885e979483932bf0ce9e720841d6f9d44bbc5a049f2e4a15232803f8362a
   md5: 044460e02becd58190c03e794461acee
   depends:
@@ -3830,7 +3830,7 @@ packages:
   license_family: MOZILLA
   size: 155741
   timestamp: 1724854618448
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/traitlets-5.14.3-py311hecd8cb5_0.tar.bz2
   sha256: 5283f2b23a6e9d888b2834cba2bbf284f551e199d2c1b4add176b1cbafb19ee0
   md5: 58bf7871ca100fbda0492bb5a3363c80
   depends:
@@ -3839,7 +3839,7 @@ packages:
   license_family: BSD
   size: 208200
   timestamp: 1718227205760
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing-extensions-4.12.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing-extensions-4.12.2-py311hecd8cb5_0.tar.bz2
   sha256: 8022de54a1fbd9c3477536d96ac53f7fd5a32d8746f3993c2bc2bf5c5bcd82ae
   md5: 3134d7e75b5c6cb1b98c1220bfc2924e
   depends:
@@ -3849,7 +3849,7 @@ packages:
   license_family: PSF
   size: 10063
   timestamp: 1734714948797
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/typing_extensions-4.12.2-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/typing_extensions-4.12.2-py311hecd8cb5_0.tar.bz2
   sha256: 1a33aba353b4c72ee219540fbaf361f575c7c6fe0259bfb8c453b9c61320beec
   md5: b71aa2fc23e5979b7443d52ee91265ee
   depends:
@@ -3858,7 +3858,7 @@ packages:
   license_family: PSF
   size: 82779
   timestamp: 1734714943158
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/uc-micro-py-1.0.1-py311hecd8cb5_0.tar.bz2
   sha256: a9960485ced319ac91afe69eaaf703c7e6b3049f1e06a4a8c2818b64155943f0
   md5: 0a9c8ea92a14330a07edabac249e32a9
   depends:
@@ -3867,7 +3867,7 @@ packages:
   license_family: MIT
   size: 11399
   timestamp: 1678394892923
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/unicodedata2-15.1.0-py311h6c40b1e_0.tar.bz2
   sha256: d42ae57366d05e12f10074583568355752436d66ad018ffbcfa24135f593810a
   md5: 1a98e48aa0bd8b3ec09e2cbdbb236575
   depends:
@@ -3876,7 +3876,7 @@ packages:
   license_family: Apache
   size: 498952
   timestamp: 1713213079520
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/urllib3-2.2.3-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/urllib3-2.2.3-py311hecd8cb5_0.tar.bz2
   sha256: 89314728453fa65647c24a1991a18f1105ed5da67c69dc42231d26a6bc96c42c
   md5: 3c07406e5e9575d136d225c57159cec3
   depends:
@@ -3892,7 +3892,7 @@ packages:
   license_family: MIT
   size: 218673
   timestamp: 1727770118330
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/webencodings-0.5.1-py311hecd8cb5_1.tar.bz2
   sha256: 597015e8a038a111f03ffbc9a217fcda549d75230c86ce53c1f23c53d6f1a0cb
   md5: 62e98aac883bccc1c87ca0d2ce2f08e0
   depends:
@@ -3901,7 +3901,7 @@ packages:
   license_family: BSD
   size: 25798
   timestamp: 1678317074170
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/websocket-client-1.8.0-py311hecd8cb5_0.tar.bz2
   sha256: 1430e6f4b4dd9354b7bb88f7f7bc9cdbab26a034ad1ae5c278de0f5a99329372
   md5: be0832862b29bf5767a707ac6bd53b93
   depends:
@@ -3910,7 +3910,7 @@ packages:
   license_family: Apache
   size: 114834
   timestamp: 1715878445060
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/wheel-0.44.0-py311hecd8cb5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/wheel-0.44.0-py311hecd8cb5_0.tar.bz2
   sha256: 907fd39137318473d447c56d77f775c9d3fef5b4e840f8c43f50f8f9c016710f
   md5: 2106db0f651f613ca1971e60afe3f5f2
   depends:
@@ -3919,7 +3919,7 @@ packages:
   license_family: MIT
   size: 139423
   timestamp: 1726165218455
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xyzservices-2022.9.0-py311hecd8cb5_1.tar.bz2
   sha256: 5b6d5246955b5f9480ff7027eb002442a7ade24f5c354da54ed513042f76cedc
   md5: f32aa8a37d5e65a8dc30f9a1f46bc63d
   depends:
@@ -3928,20 +3928,20 @@ packages:
   license_family: BSD
   size: 54719
   timestamp: 1678325412288
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/xz-5.4.6-h6c40b1e_1.tar.bz2
   sha256: ed0152ad6b87ffd9e01f4a62bc358e805ad59637f898a801b0a9cf903ae8e1fb
   md5: 8a92f8c663608f24e14d8a2068b9d83a
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 415323
   timestamp: 1714511993944
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/yaml-0.2.5-haf1e3a3_0.tar.bz2
   sha256: c39a7da619b6fb3979784eb324e5dac686de71c6bf8c37bbd47939ecf0a468b4
   md5: cbfabc8518e50cc4726b86d1d8b6400a
   license: MIT
   size: 87049
   timestamp: 1593116269220
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zeromq-4.3.5-hcec6c5f_0.tar.bz2
   sha256: cbf0763533954a19223b6656a2ee319f0dfc48949b658f23fc0fcdb741ad2efe
   md5: c25b6d40f834647d0bbe767f6c776031
   depends:
@@ -3951,14 +3951,14 @@ packages:
   license_family: Other
   size: 329449
   timestamp: 1705602140856
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zlib-1.2.13-h4b97444_1.tar.bz2
   sha256: 1e70694e68fd2e0fa39bbf292f5c90b6168c92cf0c5b47b8a26e7ff72221164f
   md5: f2519b551f99765d9d98950c5e2b4713
   license: Zlib
   license_family: Other
   size: 119782
   timestamp: 1714511811597
-- conda: https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-64/zstd-1.5.6-h138b38a_0.tar.bz2
   sha256: a1f470eabe211500d2ec7866ecf421c067f159045f0245f19e9ba8272c5a177e
   md5: f8bd5fb9fac17a47c64ae56355faba24
   depends:
@@ -3969,7 +3969,7 @@ packages:
   license_family: BSD
   size: 1033188
   timestamp: 1728487057684
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/anyio-4.6.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/anyio-4.6.2-py311hca03da5_0.tar.bz2
   sha256: 8d925b1438e14479c33257054daaf3acab8db996d49fc1f57f9a675569a90493
   md5: 7277b32d35b11efb43245178c3f99fb4
   depends:
@@ -3983,7 +3983,7 @@ packages:
   license_family: MIT
   size: 245764
   timestamp: 1729121361882
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/appnope-0.1.2-py311hca03da5_1001.tar.bz2
   sha256: 43405cc7341ce3efb2e24013ad62c64f26a69926635adceaa5459ccbcafb3776
   md5: effa6d22f497e164cc8455f7f329c304
   depends:
@@ -3992,7 +3992,7 @@ packages:
   license_family: BSD
   size: 12510
   timestamp: 1677917870614
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/argon2-cffi-bindings-21.2.0-py311h80987f9_1.tar.bz2
   sha256: 34eff2dd23f43b16903603d5a629e65d0da4f4c3556bbdc4e81c54ca4f2287b4
   md5: 1f421ad5db9e7301fb935e6f0328dea2
   depends:
@@ -4002,7 +4002,7 @@ packages:
   license_family: MIT
   size: 35693
   timestamp: 1736182683157
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/attrs-24.3.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/attrs-24.3.0-py311hca03da5_0.tar.bz2
   sha256: b21a439235347e2b0ca4fc059c7be459ef3597a141138dd8ca5004877a1dd86d
   md5: b5c410a1799c550d53e5f11219819850
   depends:
@@ -4011,7 +4011,7 @@ packages:
   license_family: MIT
   size: 163887
   timestamp: 1734533146293
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/beautifulsoup4-4.12.3-py311hca03da5_0.tar.bz2
   sha256: ae3c6633ed84bac16592b3b756f96ffc577414971014ca9efa498a162588757f
   md5: ea600f99d012d734f831d1bc00a17661
   depends:
@@ -4021,12 +4021,12 @@ packages:
   license_family: MIT
   size: 281227
   timestamp: 1718029919645
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/blas-1.0-openblas.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/blas-1.0-openblas.tar.bz2
   sha256: e9eb4f90cbfd75e9e1bc8cd9fe52bf5ee99a5a0025c2c3790d9b3fa49a4ac5f3
   md5: 9a229bd94ce6f3045c9ffa953c602fd7
   size: 10252
   timestamp: 1628529248300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bleach-6.2.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bleach-6.2.0-py311hca03da5_0.tar.bz2
   sha256: 557a8b96a55bd208098771332ba46454d76f4a864679d1d4cfe9f7533db4eaca
   md5: c0e11382888896052023f0f8b4ac242a
   depends:
@@ -4038,7 +4038,7 @@ packages:
   license_family: Apache
   size: 370511
   timestamp: 1732292237553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bokeh-3.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bokeh-3.6.0-py311hca03da5_0.tar.bz2
   sha256: 2504fa4295015f621e607dde7a42efba5fec71bf691785ba8e2f86e72df19e88
   md5: c961dda50ad88ee093645de69e768a4c
   depends:
@@ -4056,7 +4056,7 @@ packages:
   license_family: BSD
   size: 5908154
   timestamp: 1727914592573
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bottleneck-1.4.2-py311hb9f6ed7_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bottleneck-1.4.2-py311hb9f6ed7_0.tar.bz2
   sha256: db1a051d5329611e3e0fab1ea11b2ec06ae511e6c34935738a701ac2ae2fcf86
   md5: 14b2ca28694689fa950ae434e4390224
   depends:
@@ -4066,7 +4066,7 @@ packages:
   license_family: BSD
   size: 135731
   timestamp: 1731058941306
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-1.0.9-h80987f9_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-1.0.9-h80987f9_9.tar.bz2
   sha256: 590fa74213a250f8ab4e3249cdb214c34f93121d249c413b201ff92b10c70ff6
   md5: 9de7e158b8e00fbc39af88efd56be8ee
   depends:
@@ -4076,7 +4076,7 @@ packages:
   license: MIT
   size: 19988
   timestamp: 1736182733370
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-bin-1.0.9-h80987f9_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-bin-1.0.9-h80987f9_9.tar.bz2
   sha256: 6e11a01df09bb5213eeb65c3347b45567a972c2557a27c2d8f76c7fa792a5c45
   md5: 6b9fd6a4720fdbd87280ccfb063b9684
   depends:
@@ -4085,7 +4085,7 @@ packages:
   license: MIT
   size: 19371
   timestamp: 1736182689529
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/brotli-python-1.0.9-py311h313beb8_9.tar.bz2
   sha256: 5c439398dfaf525e3183dd04df18dede76ee247feffe3ca0103d8506b3785cd4
   md5: 316001829060774b502831c8abf6b634
   depends:
@@ -4094,21 +4094,21 @@ packages:
   license: MIT
   size: 380565
   timestamp: 1736182939936
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/bzip2-1.0.8-h80987f9_6.tar.bz2
   sha256: a976bc66d54e08fc8777d53ca2601885405ba5eba29b1ec33d9681215c37c08f
   md5: 56d1386c7f1f338f0d18f82af6525273
   license: bzip2-1.0.8
   license_family: BSD
   size: 158748
   timestamp: 1714510571033
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ca-certificates-2024.12.31-hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ca-certificates-2024.12.31-hca03da5_0.tar.bz2
   sha256: 45e4b0988896cdeb75f075f3be015d833de761b869bde21794447b6569ad6398
   md5: 6615c8afe0cb6026dfc8ccbe87feed35
   license: MPL-2.0
   license_family: Other
   size: 139547
   timestamp: 1736360393211
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/certifi-2024.12.14-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/certifi-2024.12.14-py311hca03da5_0.tar.bz2
   sha256: 752f20f65febccd832d3a64029abaaadf3ea01a6cdfa26d48cef2b5462ee3bc4
   md5: c2bd26697a5a4ff7e6a49e9926e72419
   depends:
@@ -4117,7 +4117,7 @@ packages:
   license_family: Other
   size: 168121
   timestamp: 1734473316071
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/cffi-1.17.1-py311h3eb5a62_1.tar.bz2
   sha256: 7f00d92fcfb1a24b4c8fcbe695ce117d985ed44a58b294cd9d4d5d2cf513bba1
   md5: 93179889226fd770fec62ff555acce5f
   depends:
@@ -4128,7 +4128,7 @@ packages:
   license_family: MIT
   size: 292644
   timestamp: 1736182914702
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/colorcet-3.1.0-py311hca03da5_0.tar.bz2
   sha256: 808e56fb70f3d38599ee7a54c2a707b282ba9a401fa69a1f54cdc26425d9ce01
   md5: fc37321833175bda4fc5c21afe32db49
   depends:
@@ -4137,7 +4137,7 @@ packages:
   license_family: CC
   size: 539588
   timestamp: 1709758479776
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/comm-0.2.1-py311hca03da5_0.tar.bz2
   sha256: d9c126d8bcd1c89ea37186c172d6b1f73f45ada60e3ae1790a017b530baa0147
   md5: f0223aae3d622547f6accb212579c58e
   depends:
@@ -4147,7 +4147,7 @@ packages:
   license_family: BSD
   size: 17967
   timestamp: 1709322909223
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/contourpy-1.3.1-py311h48ca7d4_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/contourpy-1.3.1-py311h48ca7d4_0.tar.bz2
   sha256: d76cf29e53f303a799da85cd45c5dc65e9d52f050acf9c42ae448b32cb19e3b9
   md5: 1bd0fdf6a0fcf98ed2e968c7359ddc4d
   depends:
@@ -4158,7 +4158,7 @@ packages:
   license_family: BSD
   size: 299096
   timestamp: 1732540161576
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/debugpy-1.8.11-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/debugpy-1.8.11-py311h313beb8_0.tar.bz2
   sha256: a694b8a82ab88f241d100b86586ee802c1d6874e42da4e1bc4fc154df95637f2
   md5: 39b58c0525acb9a7014bb007aa34ddd1
   depends:
@@ -4168,7 +4168,7 @@ packages:
   license_family: MIT
   size: 2793877
   timestamp: 1736267724300
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/entrypoints-0.4-py311hca03da5_0.tar.bz2
   sha256: b1481ffa475c65200626f051d5dcbdb264730b533e928dde608a79ce7a5b4e48
   md5: aada2761547a291d68f4c016a1a9bc7b
   depends:
@@ -4177,7 +4177,7 @@ packages:
   license_family: MIT
   size: 18265
   timestamp: 1677911915719
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/fonttools-4.51.0-py311h80987f9_0.tar.bz2
   sha256: eb82a0e2ca36d0973b5f6642e27609554edad4b72696f989776d5db8cd4a6a42
   md5: fa8d9dd8a2fabba964c6bb75ace8c572
   depends:
@@ -4195,7 +4195,7 @@ packages:
   license_family: MIT
   size: 3201601
   timestamp: 1713551611540
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/freetype-2.12.1-h1192e45_0.tar.bz2
   sha256: a624310f41a107bd273ae26811380c507543093cb770e38585e3efcd3b54195a
   md5: 44de39124e1b0f5f731c11631eac18ac
   depends:
@@ -4205,7 +4205,7 @@ packages:
   license_family: Other
   size: 914169
   timestamp: 1666798307824
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/holoviews-1.20.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/holoviews-1.20.0-py311hca03da5_0.tar.bz2
   sha256: 1fc120c7bb3c245be0b2805ffaba6518b56e32ca510439b592172138e02e8700
   md5: be7cf3596496c3d91885749d37e71362
   depends:
@@ -4225,7 +4225,7 @@ packages:
   license_family: BSD
   size: 6103533
   timestamp: 1730827873611
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/hvplot-0.11.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/hvplot-0.11.2-py311hca03da5_0.tar.bz2
   sha256: 496491093dc391b9358f7fc3ff92846144e9e25e7d7e2bc8304bc3babf59ddcc
   md5: 4b3be5c46e52fd21a5a3a3ce1964b24b
   depends:
@@ -4242,7 +4242,7 @@ packages:
   license_family: BSD
   size: 373148
   timestamp: 1734469778843
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/idna-3.7-py311hca03da5_0.tar.bz2
   sha256: 4d4ab70ae0ce008c1cc96a4edfbf3866d5e636acc4799a545ea93acee51635f7
   md5: 86a085a440729020d1d7b0b74d6a0c6c
   depends:
@@ -4251,7 +4251,7 @@ packages:
   license_family: BSD
   size: 148448
   timestamp: 1714398923507
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipykernel-6.29.5-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipykernel-6.29.5-py311hca03da5_0.tar.bz2
   sha256: 12ecf9e8614e4d864a3a82d1244b35bd93a3625c7521f44d75c1fb198501e3b5
   md5: 6c05e1ef68be71ffae5bc818f393c6fa
   depends:
@@ -4273,7 +4273,7 @@ packages:
   license_family: BSD
   size: 238518
   timestamp: 1728665670755
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ipython-8.30.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ipython-8.30.0-py311hca03da5_0.tar.bz2
   sha256: 6520fa19784d319996b26b76afa58631ba1c947941b0b3140cfe812421c99924
   md5: afdd96e6adde92b303856588dd9562a3
   depends:
@@ -4291,7 +4291,7 @@ packages:
   license_family: BSD
   size: 1639167
   timestamp: 1734548338159
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jedi-0.19.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jedi-0.19.2-py311hca03da5_0.tar.bz2
   sha256: bc8c88ebbfe7a0a575e5546ca9b02bc6629cf8ed04467d74b921328918852b4a
   md5: a73b1ed92ff1b9528898c3d09f34889a
   depends:
@@ -4301,7 +4301,7 @@ packages:
   license_family: MIT
   size: 1192471
   timestamp: 1733987575145
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jinja2-3.1.4-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jinja2-3.1.4-py311hca03da5_1.tar.bz2
   sha256: 5057f548fb76e0afa997f69dd08a0c1a1d0b13382ca58e909fd378f1ff74de57
   md5: 329e65306aa67a099eb34e39f80ef912
   depends:
@@ -4313,14 +4313,14 @@ packages:
   license_family: BSD
   size: 357841
   timestamp: 1730902943889
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jpeg-9e-h80987f9_3.tar.bz2
   sha256: 9d5cbffa98f3a4391f66b0c5ce1f411f0bfb0eb83137dc7146fb7bae23cb3570
   md5: 95c92318023482e4e8c698ae6c4597fe
   license: IJG
   license_family: Other
   size: 274078
   timestamp: 1722872672311
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-4.23.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-4.23.0-py311hca03da5_0.tar.bz2
   sha256: 5e1400c72584b88b0ea13d2e66110eb7571f155f8b8d62ede4ca61b8279b8bdc
   md5: 6924a112e8115ffdb74a5c8840903b84
   depends:
@@ -4333,7 +4333,7 @@ packages:
   license_family: MIT
   size: 193322
   timestamp: 1728486773537
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jsonschema-specifications-2023.7.1-py311hca03da5_0.tar.bz2
   sha256: 404b0847029f77bedd7902a170a046219e0dc5c0ec2be19ff45361cff25b2181
   md5: 3a02bbe8d45fdbcb2350f672be74c9f5
   depends:
@@ -4343,7 +4343,7 @@ packages:
   license_family: MIT
   size: 16524
   timestamp: 1699032463763
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_client-7.4.9-py311hca03da5_0.tar.bz2
   sha256: 7deb8ad28c34c369573754304a03ea2acda8ee39102a56526ec689a4d9210109
   md5: 675ea1a746a78ff6bf8fc4b39139efff
   depends:
@@ -4359,7 +4359,7 @@ packages:
   license_family: BSD
   size: 277400
   timestamp: 1677914250715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_core-5.7.2-py311hca03da5_0.tar.bz2
   sha256: ceec15c84f5c699b8055d01e046be04ccb7cfd7c8bd090fc18959f2a4d9f8cf8
   md5: f85c11f7068312e1e84505efef9d55e3
   depends:
@@ -4370,7 +4370,7 @@ packages:
   license_family: BSD
   size: 98520
   timestamp: 1718818476094
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_events-0.10.0-py311hca03da5_0.tar.bz2
   sha256: b2f1ee2a297e001a2e70bc218f60deb08c50b9b727668913ed5a106640413d2e
   md5: fc4e797a17ff5dccadfb5d19346b7800
   depends:
@@ -4386,7 +4386,7 @@ packages:
   license_family: BSD
   size: 43099
   timestamp: 1718738212629
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server-2.14.1-py311hca03da5_0.tar.bz2
   sha256: 2d96618ab2e9b3de870a713d7e5b19f6cde936291f3c87972f945b6e27024e77
   md5: 534159d29d9aba9c7e70ee52c27b326b
   depends:
@@ -4413,7 +4413,7 @@ packages:
   license_family: BSD
   size: 614003
   timestamp: 1718827110867
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyter_server_terminals-0.4.4-py311hca03da5_1.tar.bz2
   sha256: 501e929d345aaa9079c965552b942b4e8bde35b87ae89faef003687a40bab3a4
   md5: 54c7b8554a405acd7c8326c41ba93e63
   depends:
@@ -4423,7 +4423,7 @@ packages:
   license_family: BSD
   size: 28237
   timestamp: 1686870817418
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/jupyterlab_pygments-0.2.2-py311hca03da5_0.tar.bz2
   sha256: 773e7c4571f482a744dfb18ae26fb22635f5d3f51389c838bd97f9044ea55cc4
   md5: 5161546aba5597318cb5653390cdecd8
   depends:
@@ -4435,7 +4435,7 @@ packages:
   license_family: BSD
   size: 20235
   timestamp: 1700168681687
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/kiwisolver-1.4.4-py311h313beb8_0.tar.bz2
   sha256: 8c1c64d51be73aad381992a9df19d8336910bdfc40f19940231df86e177d17cc
   md5: b1f786f96684a143cf30d1f6b8aebdb3
   depends:
@@ -4445,7 +4445,7 @@ packages:
   license_family: BSD
   size: 65045
   timestamp: 1677925371836
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lcms2-2.16-he93ba84_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lcms2-2.16-he93ba84_0.tar.bz2
   sha256: 4b45c39ed7c4267baa88eee55413830c87863c9dee6e8af40e0261aa0fcd9469
   md5: dfd7325cb25e3e7d0d2c3f77209d12b3
   depends:
@@ -4455,7 +4455,7 @@ packages:
   license_family: MIT
   size: 246476
   timestamp: 1734428527302
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lerc-4.0.0-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lerc-4.0.0-h313beb8_0.tar.bz2
   sha256: f123fe7eb47ac10d174364902a64c311b1875f4863b1b3791e6b3fca8e0ab272
   md5: b62145f1eeed0a89b5d76c3bb9b409d5
   depends:
@@ -4464,13 +4464,13 @@ packages:
   license_family: Apache
   size: 222115
   timestamp: 1734423410079
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlicommon-1.0.9-h80987f9_9.tar.bz2
   sha256: bc3732d108e184da32b682c94421173529842f8b429fd693592575b637707b9b
   md5: 0e753a927e7ef21b248c739b7846903a
   license: MIT
   size: 69063
   timestamp: 1736182580217
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlidec-1.0.9-h80987f9_9.tar.bz2
   sha256: cd3149e7fb36e67ae496ff37827870c6822619d09b235e2adc7ba5ce9b33f938
   md5: ae813d7d06d4672d06fad704b7bd4077
   depends:
@@ -4478,7 +4478,7 @@ packages:
   license: MIT
   size: 33265
   timestamp: 1736182639925
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_9.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libbrotlienc-1.0.9-h80987f9_9.tar.bz2
   sha256: e3a1bd31d21200c8841e7305cf4ac1ed21ef75c72acbdb0412747be7b27069c1
   md5: 86fd5a04180dbcf27c012d9fe8b01a94
   depends:
@@ -4486,28 +4486,28 @@ packages:
   license: MIT
   size: 310515
   timestamp: 1736182663109
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libcxx-14.0.6-h848a8c0_0.tar.bz2
   sha256: 9f18ed8c85be4698d120faff0a7b159c0e1b32995ad150983dce9cc2e0c66400
   md5: 083096f7a9d29ecabfd47d8d0cbf2bbc
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1387034
   timestamp: 1662620483620
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libdeflate-1.22-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libdeflate-1.22-h80987f9_0.tar.bz2
   sha256: 695c939431f7fd074d175e62944daca33ff51f3abfe1ee5c51d92d89ad663da8
   md5: 8985f8e47c5bd81416ed08c28d7f305a
   license: MIT
   license_family: MIT
   size: 60900
   timestamp: 1734423344642
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libffi-3.4.4-hca03da5_1.tar.bz2
   sha256: a5029e80ba2bf905d0faf5f4ee9c490f2acfcd6e10f2251f1ff5e85b266e7199
   md5: f31e4eb9cd6447cc2f5ef0243a76540c
   license: MIT
   license_family: MIT
   size: 120460
   timestamp: 1714483461787
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran-5.0.0-11_3_0_hca03da5_28.tar.bz2
   sha256: 97fc3c71361060b624a203b2d8fc9895d34a7dde9456f6090a220321776a3e1c
   md5: 9a6698e6a01e492ef22889e4ec340e99
   depends:
@@ -4516,7 +4516,7 @@ packages:
   license_family: GPL
   size: 151487
   timestamp: 1665499021664
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libgfortran5-11.3.0-h009349e_28.tar.bz2
   sha256: 16d7bcec0e6012ae6b6140e6d0ab2473ec3c3917b38fa9a21746c6ec60c15a51
   md5: 8f9dde854442b1597ec249e512b88673
   depends:
@@ -4527,7 +4527,7 @@ packages:
   license_family: GPL
   size: 1387621
   timestamp: 1665498967410
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libopenblas-0.3.21-h269037a_0.tar.bz2
   sha256: ec0e83103c71d3f338c35c4bad8e5109ac9f94ed06a08d16f5b98d38be295ca9
   md5: 0ba7c7444f2cbc64396d3873b874ec63
   depends:
@@ -4538,7 +4538,7 @@ packages:
   license_family: BSD
   size: 13307698
   timestamp: 1664897510704
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libpng-1.6.39-h80987f9_0.tar.bz2
   sha256: 02bb08d72753d812b9723935fd8fd385929b089536ff7177c950677b252498ac
   md5: 54add4e3b9ad35f25d34f3c2955abc7d
   depends:
@@ -4547,13 +4547,13 @@ packages:
   license_family: Other
   size: 320926
   timestamp: 1677841799096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libsodium-1.0.18-h1a28f6b_0.tar.bz2
   sha256: 9223387c1c9295fbd95b934d8eceaebb6d45331798deec93256b751146e82500
   md5: 189d927763e0d79f379df224726e3611
   license: ISC
   size: 287344
   timestamp: 1629287561438
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libtiff-4.5.1-hc9ead59_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libtiff-4.5.1-hc9ead59_1.tar.bz2
   sha256: 209b3214c150026e4de2a962e4a9c26457c3d4f3f113bcb115bd7a5373422827
   md5: 5624e697d929ac1b10bc3b3a89c1a8be
   depends:
@@ -4569,7 +4569,7 @@ packages:
   license_family: Other
   size: 607843
   timestamp: 1734425782308
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/libwebp-base-1.3.2-h80987f9_1.tar.bz2
   sha256: 479cf759232c2361af87493ecd124e7d3a8940030e42e1931234c35bea73c3bd
   md5: cd8fe2c981594a457c6af3a0d5de0bd5
   constrains:
@@ -4578,7 +4578,7 @@ packages:
   license_family: BSD
   size: 341817
   timestamp: 1729160040909
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/linkify-it-py-2.0.0-py311hca03da5_0.tar.bz2
   sha256: 41c62a460bb81a1a272aa28b219fab9c26510adac177ff1528b1980eabc6e868
   md5: 8d312c5628dc7ea833e9b4dcb73e9c45
   depends:
@@ -4588,7 +4588,7 @@ packages:
   license_family: MIT
   size: 42346
   timestamp: 1677973051421
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/llvm-openmp-14.0.6-hc6e5704_0.tar.bz2
   sha256: a32d44d2e02431c3b1a0cf3bb6ff92a87e79820679944a1612fda69cb6de46a5
   md5: 56eac4019124c7ae17dc2ae5bffce909
   constrains:
@@ -4597,7 +4597,7 @@ packages:
   license_family: Apache
   size: 302507
   timestamp: 1662635703553
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/lz4-c-1.9.4-h313beb8_1.tar.bz2
   sha256: 09e2fbc434ddfc200a46250f0524acc3d33a830cd503bdcaf92103baee1d34ac
   md5: f5f7e6e7541d8dc3d3df270d488d2e24
   depends:
@@ -4606,7 +4606,7 @@ packages:
   license_family: BSD
   size: 176990
   timestamp: 1714510588159
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-3.4.1-py311hca03da5_0.tar.bz2
   sha256: d024f5142416961a5e66e424d4d14aec652f9e9dd738b41a97f45674c2ffc9d5
   md5: 0e2d94b125d802f7b006cf19c71655a1
   depends:
@@ -4615,7 +4615,7 @@ packages:
   license_family: BSD
   size: 163084
   timestamp: 1677932947966
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markdown-it-py-2.2.0-py311hca03da5_1.tar.bz2
   sha256: acfd84e29ff4dc2d85543bb973a07f22b4ba53c5d00bca84608ee7f13b2a8676
   md5: 5ca161cd51e2db358e768453b3ee485e
   depends:
@@ -4625,7 +4625,7 @@ packages:
   license_family: MIT
   size: 135871
   timestamp: 1684279980293
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/markupsafe-2.1.3-py311h80987f9_0.tar.bz2
   sha256: b1bed54c7bfb7304cde9e8e6f798543d08e808e81286a5a48296fc94d621f9da
   md5: 774358285c9e496c9f5c121cc546c823
   depends:
@@ -4636,7 +4636,7 @@ packages:
   license_family: BSD
   size: 27438
   timestamp: 1704206026910
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-base-3.10.0-py311h7ef442a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-base-3.10.0-py311h7ef442a_0.tar.bz2
   sha256: 012a1113fd728eaca513b2f71d3be101e8b5a600b8c749822f323eb2675ba3d8
   md5: 9dddca88e71c2b941a6555b09e4b0a67
   depends:
@@ -4656,7 +4656,7 @@ packages:
   license_family: PSF
   size: 9718053
   timestamp: 1736278806782
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/matplotlib-inline-0.1.6-py311hca03da5_0.tar.bz2
   sha256: 3276d61fc353c537bb09d4b7473d7abe12be38806f42c8cc383b62f40850a5cc
   md5: 6e9c9d47f264b77d9a8461f0899848a7
   depends:
@@ -4666,7 +4666,7 @@ packages:
   license_family: BSD
   size: 20446
   timestamp: 1677918370379
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdit-py-plugins-0.3.0-py311hca03da5_0.tar.bz2
   sha256: 43c96d30775b61b4968422a47f9605049428120669f0742bbb9e5ba145c7d11e
   md5: a31ca0d9284860adf5463cf45a5e3145
   depends:
@@ -4676,7 +4676,7 @@ packages:
   license_family: MIT
   size: 69243
   timestamp: 1677995336989
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mdurl-0.1.0-py311hca03da5_0.tar.bz2
   sha256: 96d8c9f42a38651b7bafe5f3cb132601db76cd1e28fa58e2eaf090e634292fff
   md5: 5ebc793a17b6aa84d13f19433545ffa5
   depends:
@@ -4685,7 +4685,7 @@ packages:
   license_family: MIT
   size: 23895
   timestamp: 1677942274932
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/mistune-2.0.4-py311hca03da5_0.tar.bz2
   sha256: db9bd659ada23f1ded443d2db00dd13b5d5c0b30f5062544b1ee2c2b88d63d29
   md5: 03c48121614cf12abfe30eced9b34717
   depends:
@@ -4696,7 +4696,7 @@ packages:
   license_family: BSD
   size: 105333
   timestamp: 1677916687032
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclassic-1.1.0-py311hca03da5_0.tar.bz2
   sha256: b6fa12e4bde747bf288bda31ce8ec5e24292dbf74fde67f18f9c9c100b845a38
   md5: 2eddc760c15171a1e8aa838d9d162e18
   depends:
@@ -4709,7 +4709,7 @@ packages:
   license_family: BSD
   size: 8291605
   timestamp: 1717622676584
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbclient-0.8.0-py311hca03da5_0.tar.bz2
   sha256: e8eee27fb667aa10b26f3bc4b93f449b7d991ded27b9cb457effee394ce05f6f
   md5: 6a3e5cd0e1141c01ffb91285bdccfe83
   depends:
@@ -4722,7 +4722,7 @@ packages:
   license_family: BSD
   size: 123043
   timestamp: 1698934328890
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbconvert-7.16.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbconvert-7.16.4-py311hca03da5_0.tar.bz2
   sha256: 1f6d171443b30990cd724ef1e5fa287311d1cf9064c0f5984e6acb2225a0197c
   md5: 9a8675276a35db6cc6649f0bddecf53d
   depends:
@@ -4749,7 +4749,7 @@ packages:
   license_family: BSD
   size: 531141
   timestamp: 1728049778343
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nbformat-5.10.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nbformat-5.10.4-py311hca03da5_0.tar.bz2
   sha256: ae983360f1f69987f0fb3a8de9767b362dc903a9b0b130d87fcfcca445dddc4b
   md5: f56cbcd18632f7f669a28363c6d3fe4e
   depends:
@@ -4762,14 +4762,14 @@ packages:
   license_family: BSD
   size: 171380
   timestamp: 1728049515633
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/ncurses-6.4-h313beb8_0.tar.bz2
   sha256: 44c466a5df82f2091a398ca1263f0b6e18cf8c5eac355a56e7fe5433447edb45
   md5: 43568079a90f14ee6d763f2c1cdd3cfa
   license: MIT AND X11
   license_family: MIT
   size: 1078472
   timestamp: 1674734099883
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/nest-asyncio-1.6.0-py311hca03da5_0.tar.bz2
   sha256: 417ace1ce51e81f3f92ddc26e0e3a83c1e19c9ebb7af7104452002a5573da534
   md5: 3e11de6cef096091bb733e07802f00b0
   depends:
@@ -4778,7 +4778,7 @@ packages:
   license_family: BSD
   size: 16979
   timestamp: 1708532698253
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-6.5.7-py311hca03da5_0.tar.bz2
   sha256: 8ea1be4285e2e7d361cbcc1daf9c220f87ceaab2308bf7b339d2513d6ea22184
   md5: 774ce02efa90f212023541c0b24e92c1
   depends:
@@ -4803,7 +4803,7 @@ packages:
   license_family: BSD
   size: 726598
   timestamp: 1717630964815
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/notebook-shim-0.2.3-py311hca03da5_0.tar.bz2
   sha256: b0cc542e2a6f42ba716e7e4ccf29eddcb155ad167fcdbc72d2db9c7873eb5639
   md5: 7acf81b17d2c4ceb3cd39dc9f173855c
   depends:
@@ -4813,7 +4813,7 @@ packages:
   license_family: BSD
   size: 27539
   timestamp: 1699455954000
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numexpr-2.10.1-py311h5d9532f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numexpr-2.10.1-py311h5d9532f_0.tar.bz2
   sha256: e7085ecdcbb7814ab5b588399963d6877083cbcbce27407b5ded3c099af1e6a9
   md5: b656e9369b00f6f0eec85203e35eaa42
   depends:
@@ -4825,7 +4825,7 @@ packages:
   license_family: MIT
   size: 189479
   timestamp: 1730216150682
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-2.2.1-py311he598dae_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-2.2.1-py311he598dae_0.tar.bz2
   sha256: 6797ddf1604569b26af1846a8c75470af5c78759a2d2543fe9fa561b94ce6aea
   md5: 2b410acdc298c586eef78e0ac23ab977
   depends:
@@ -4840,7 +4840,7 @@ packages:
   license_family: BSD
   size: 11900
   timestamp: 1736500573879
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/numpy-base-2.2.1-py311hfbfe69c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/numpy-base-2.2.1-py311hfbfe69c_0.tar.bz2
   sha256: 7eb1f398489cee9312cb1f8cafed9e3e06838918726715e54ea3bda3a5ff9d19
   md5: e5a12ca1488317bb1e1977370a6e052d
   depends:
@@ -4854,7 +4854,7 @@ packages:
   license_family: BSD
   size: 8018207
   timestamp: 1736500561675
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openjpeg-2.5.2-h54b8e55_0.tar.bz2
   sha256: b9f781280f49644ca05e18aacbdde1c57cc5107e7cc2471b843ea8461672aa7f
   md5: 9125d30e4e105b45f7f7d9c20acafa10
   depends:
@@ -4865,7 +4865,7 @@ packages:
   license_family: BSD
   size: 450131
   timestamp: 1722872679313
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/openssl-3.0.15-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/openssl-3.0.15-h80987f9_0.tar.bz2
   sha256: 503def27e5229dc31eb3eea4c86ecabcd46a27b6711a968bafeaf7facfc8eeb1
   md5: 2261823151398e7df6ee94c234f21f11
   depends:
@@ -4874,7 +4874,7 @@ packages:
   license_family: Apache
   size: 4762637
   timestamp: 1725545955868
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/overrides-7.4.0-py311hca03da5_0.tar.bz2
   sha256: 77b0c0a0fb14d817390244ebd93c36d44a7867239963f211f7c0a72a3f98d382
   md5: b90336feb8a50d2eff880e89acb02f40
   depends:
@@ -4883,7 +4883,7 @@ packages:
   license_family: APACHE
   size: 39617
   timestamp: 1699371253760
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/packaging-24.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/packaging-24.2-py311hca03da5_0.tar.bz2
   sha256: 7e81c844126506e5e9a3245f094bfb83d7a7e8b108757551ba2cdc9c81602357
   md5: 40ead0e0477f2925e2a333f79f5d8511
   depends:
@@ -4892,7 +4892,7 @@ packages:
   license_family: Apache
   size: 190184
   timestamp: 1734472332475
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pandas-2.2.3-py311hcf29cfe_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pandas-2.2.3-py311hcf29cfe_0.tar.bz2
   sha256: 9d1b4942a2e900c2ce21b4c5d1b7cbb352aad96480b8a5e54c8de3f3ef158143
   md5: 174139c81708a96f152437fcdc06fca8
   depends:
@@ -4942,7 +4942,7 @@ packages:
   license_family: BSD
   size: 17075464
   timestamp: 1732735585667
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/panel-1.5.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/panel-1.5.3-py311hca03da5_0.tar.bz2
   sha256: aecb0fe7cd9004af633b8f2beef0f2c0eefce35f206d2ff4de80501fcb37f2dc
   md5: b2e3ca6dd4a306e635ebd2119d58b448
   depends:
@@ -4967,7 +4967,7 @@ packages:
   license_family: BSD
   size: 24200241
   timestamp: 1730381212320
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/param-2.2.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/param-2.2.0-py311hca03da5_0.tar.bz2
   sha256: 00a71c24e865b2a60d7aac81508c1c7144a73d7611961214c562eaf270286ff8
   md5: 0fbf4531ff5194c1df47533fcafeec6a
   depends:
@@ -4976,7 +4976,7 @@ packages:
   license_family: BSD
   size: 269736
   timestamp: 1734618675560
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/parso-0.8.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/parso-0.8.4-py311hca03da5_0.tar.bz2
   sha256: d4507aa0fe135a06d918e4217eb89bf2de87574b36ae0fbcc5e0568e10daf1f9
   md5: 379218d52b3715c7664153dd035ebc8a
   depends:
@@ -4985,7 +4985,7 @@ packages:
   license_family: MIT
   size: 224689
   timestamp: 1733963346031
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pillow-11.0.0-py311h84e58ab_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pillow-11.0.0-py311h84e58ab_1.tar.bz2
   sha256: 44fe7a39cfaf817e2ddfacf7473e8cd300111df36a9b762ab939651fcdacddae
   md5: 73c9669bf1fdaca9cfcd755cca8c8477
   depends:
@@ -5002,7 +5002,7 @@ packages:
   license_family: Other
   size: 950716
   timestamp: 1734430712715
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pip-24.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pip-24.2-py311hca03da5_0.tar.bz2
   sha256: 4f82ab7dc13317069ec808da81c472668e6ab85f5d74d5b385b6d86b4ef32bad
   md5: f9c03ed21097422236806938a7b7dd64
   depends:
@@ -5013,7 +5013,7 @@ packages:
   license_family: MIT
   size: 2918476
   timestamp: 1723484709578
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/platformdirs-3.10.0-py311hca03da5_0.tar.bz2
   sha256: b6200816d65673aa1707c20a768c9cff87dd8dbe1335f9c1478e5931dfa08ee0
   md5: 14b1e0fa73eb33f9c83048482dcce57b
   depends:
@@ -5022,7 +5022,7 @@ packages:
   license_family: MIT
   size: 38423
   timestamp: 1692205689597
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prometheus_client-0.21.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prometheus_client-0.21.0-py311hca03da5_0.tar.bz2
   sha256: 16e6ef97591f7833c9cd8f2f369812ac62a13e9241b1e8d605932a8da92c2df1
   md5: fa273fbe5dbea433b860c4b89dad0184
   depends:
@@ -5031,7 +5031,7 @@ packages:
   license_family: Apache
   size: 123030
   timestamp: 1731958853048
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/prompt-toolkit-3.0.43-py311hca03da5_0.tar.bz2
   sha256: 07cfba50d9e94364bde077731a824ca4f537138b35ee6b66d07aee16ac9850f1
   md5: 919bf486280a11e6acb3c2c3a82f7473
   depends:
@@ -5043,7 +5043,7 @@ packages:
   license_family: BSD
   size: 763225
   timestamp: 1704404463402
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/psutil-5.9.0-py311h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/psutil-5.9.0-py311h80987f9_1.tar.bz2
   sha256: a6d24cb3a6a50bcb52a37548ce3d4d2ee58b8d23403bc7f63018b184263c5968
   md5: d8201518af79a2d79e517846e9f68872
   depends:
@@ -5052,7 +5052,7 @@ packages:
   license_family: BSD
   size: 500255
   timestamp: 1736367725875
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pygments-2.15.1-py311hca03da5_1.tar.bz2
   sha256: 121b5b66721760c05f1d4eee91626229d1814663d3fb5f23126ef870aa496e26
   md5: 0c588c2ca790a05d422c06e8568201ad
   depends:
@@ -5061,7 +5061,7 @@ packages:
   license_family: BSD
   size: 2124200
   timestamp: 1684280082141
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyparsing-3.2.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyparsing-3.2.0-py311hca03da5_0.tar.bz2
   sha256: 86cd1c9d1c73f7dac9f3038d16ac2d6952d42bda57d4da52b18c8561d2901082
   md5: fe581970af66b493353b9dcdb6bf572f
   depends:
@@ -5070,7 +5070,7 @@ packages:
   license_family: MIT
   size: 487783
   timestamp: 1731445552436
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pysocks-1.7.1-py311hca03da5_0.tar.bz2
   sha256: 0bb3d2a57b332c5cf73ea40ea13c850ae24a1f9a3a41ed9267832d9e3c767572
   md5: 45a7fcf1641980d5114999736428502d
   depends:
@@ -5079,7 +5079,7 @@ packages:
   license_family: BSD
   size: 36755
   timestamp: 1677906514270
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-3.11.11-hb885b13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-3.11.11-hb885b13_0.tar.bz2
   sha256: 8359c229ad74991a35ad4e9cd24223a8102b10e2647624965b29a0bce4f88a31
   md5: 70344859c29c4298141767a093918a61
   depends:
@@ -5098,7 +5098,7 @@ packages:
   license_family: PSF
   size: 16479225
   timestamp: 1733934794096
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-dateutil-2.9.0post0-py311hca03da5_2.tar.bz2
   sha256: c3cbf5bd237b0a7458640191016b2701fe120c547df9afc835da76663a9c17f7
   md5: 843568c76b6b9384635b7fca74c79792
   depends:
@@ -5108,7 +5108,7 @@ packages:
   license_family: BSD
   size: 332222
   timestamp: 1716495881101
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-fastjsonschema-2.20.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-fastjsonschema-2.20.0-py311hca03da5_0.tar.bz2
   sha256: 9c37d0d46f2e1930d0efc33f5ae7f9b6ba72f835a1b8b4311ec76953a796fe8f
   md5: 59292a5980e93058c2b8700c4680fb62
   depends:
@@ -5117,7 +5117,7 @@ packages:
   license_family: BSD
   size: 282469
   timestamp: 1731939575445
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/python-json-logger-3.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/python-json-logger-3.2.1-py311hca03da5_0.tar.bz2
   sha256: e836037601159fe5cd5cf2fa5b818bb4b9a9465f8b0753e78c1b5e809b052627
   md5: fcdab3a23d5db6e00399f5f66dd2bb27
   depends:
@@ -5126,7 +5126,7 @@ packages:
   license_family: BSD
   size: 29575
   timestamp: 1734370349925
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pytz-2024.1-py311hca03da5_0.tar.bz2
   sha256: d945744eb133f19ca61325cac5128bdb053ae04de4a0ba6f69c061449cac8af7
   md5: 34baa81490d667381bc7021435b0e1f2
   depends:
@@ -5135,7 +5135,7 @@ packages:
   license_family: MIT
   size: 275858
   timestamp: 1713974457562
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyviz_comms-3.0.2-py311hca03da5_0.tar.bz2
   sha256: 012585bdb5ae54c2cded50be703734e6dbf418b003635b6f6d7c1e36e7020c30
   md5: da7e99a707bd0cfa20db651b5c068bfd
   depends:
@@ -5147,7 +5147,7 @@ packages:
   license_family: BSD
   size: 65556
   timestamp: 1711136890180
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyyaml-6.0.2-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyyaml-6.0.2-py311h80987f9_0.tar.bz2
   sha256: 8d6910a02d0a30dabb40104565c0c74531aafd4c959431ddbfde47ef52f4c83c
   md5: b1619588c95cb65375af1d2eb448ecc8
   depends:
@@ -5157,7 +5157,7 @@ packages:
   license_family: MIT
   size: 205890
   timestamp: 1728658038659
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/pyzmq-24.0.1-py311h80987f9_0.tar.bz2
   sha256: ae8cdd5be5a7ad19ff82925a035859fafcc5942cd3899d127a508dbb9a235090
   md5: 252a7b997d08bf72f10b3bc2dc68333e
   depends:
@@ -5167,7 +5167,7 @@ packages:
   license_family: Other
   size: 580346
   timestamp: 1709318480624
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/readline-8.2-h1a28f6b_0.tar.bz2
   sha256: dc538f807c2e80873205d560f21e7a3e384af2ec5be50f7e8a593ce2c282e8eb
   md5: a276a37815f1f5e0af0d6445e4f33e0d
   depends:
@@ -5176,7 +5176,7 @@ packages:
   license_family: GPL
   size: 463867
   timestamp: 1666648067390
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/referencing-0.30.2-py311hca03da5_0.tar.bz2
   sha256: 7a208abc002a2fc208ae25cb2cf932999a3e4980aa4c9edff315cb9ac62b12ce
   md5: bd22ebd3cff811577ea61f115ba7f4f2
   depends:
@@ -5187,7 +5187,7 @@ packages:
   license_family: MIT
   size: 74744
   timestamp: 1699012126255
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/requests-2.32.3-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/requests-2.32.3-py311hca03da5_1.tar.bz2
   sha256: 4cefdf48ebab7544252ce5f4274b5b86f8107e5af556bf387445a2eb4d42449c
   md5: 482973b9a55bd1a4cdc33c557a6afb29
   depends:
@@ -5203,7 +5203,7 @@ packages:
   license_family: Apache
   size: 124539
   timestamp: 1730999249799
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3339-validator-0.1.4-py311hca03da5_0.tar.bz2
   sha256: 52368d9b557b8f54ef5ca4bf6cd5a3ec665171f2b2d2082cdd410bab88f4829c
   md5: ac76fb4d2eef3ecdd491cf5d3fb8620d
   depends:
@@ -5213,7 +5213,7 @@ packages:
   license_family: MIT
   size: 10204
   timestamp: 1683077239143
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rfc3986-validator-0.1.1-py311hca03da5_0.tar.bz2
   sha256: 491d116c5f54ef340e3bce631835f7138cd1923d7b63e6ca9aa01b48110cb8f9
   md5: 9b81bd8ea808704f5433884b567f1f15
   depends:
@@ -5222,7 +5222,7 @@ packages:
   license_family: MIT
   size: 10557
   timestamp: 1683059079547
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/rpds-py-0.10.6-py311h2aea54e_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/rpds-py-0.10.6-py311h2aea54e_1.tar.bz2
   sha256: dafe2192ec46eed9702b6e5a221ffac2c916249c01f6772a4adf3bec7486cf94
   md5: 06d7e1fce00afef0b290df51f259bab5
   depends:
@@ -5231,7 +5231,7 @@ packages:
   license_family: MIT
   size: 317991
   timestamp: 1732229174647
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/send2trash-1.8.2-py311hca03da5_0.tar.bz2
   sha256: c80d52567084b1caaed2862b77b70065ca17afaf0b020733e9d6c273b4a63e78
   md5: ddf7d88c1967f3f7a4ce1c975fd47e0d
   depends:
@@ -5240,7 +5240,7 @@ packages:
   license_family: BSD
   size: 33321
   timestamp: 1699371225235
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/setuptools-72.1.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/setuptools-72.1.0-py311hca03da5_0.tar.bz2
   sha256: dc1b284c230e143ee75b7f93662a1c5c5cc8407e7328e358e7698bfc6d2a9740
   md5: 71ce2e23600829422b23461f0fd1d98a
   depends:
@@ -5249,7 +5249,7 @@ packages:
   license_family: MIT
   size: 3318492
   timestamp: 1722860227978
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sniffio-1.3.0-py311hca03da5_0.tar.bz2
   sha256: cd71091a234874d2826fa063ec5222b3191c9f47e1b5281c352d9df3f31a06bf
   md5: 0db8e29016c6bff026c083d9923a7566
   depends:
@@ -5258,7 +5258,7 @@ packages:
   license_family: Other
   size: 19073
   timestamp: 1705431415504
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/soupsieve-2.5-py311hca03da5_0.tar.bz2
   sha256: 3e18cdafc607c6d7623b1c8f041cbfbb50a27e298f961abdcce7e36834ac39e1
   md5: 9ee0da74c55d0b8d83edf246fd717f20
   depends:
@@ -5267,7 +5267,7 @@ packages:
   license_family: MIT
   size: 89862
   timestamp: 1696347657368
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/sqlite-3.45.3-h80987f9_0.tar.bz2
   sha256: 2da42632c035b944e1fcdc7b17fdd9f620ccace80d9c4974b2078ff51bff2691
   md5: d8c1e9910392d0bcb22a173f9ce30fa6
   depends:
@@ -5279,7 +5279,7 @@ packages:
   license_family: Other
   size: 1758290
   timestamp: 1714488307689
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/terminado-0.17.1-py311hca03da5_0.tar.bz2
   sha256: b5c265e9ed9a1ff2238a09b83bdc1826950faa87fd6b685debe60888de6e7a50
   md5: 5827c8a32317894ce18576e334daba47
   depends:
@@ -5290,7 +5290,7 @@ packages:
   license_family: BSD
   size: 38559
   timestamp: 1677918962258
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tinycss2-1.2.1-py311hca03da5_0.tar.bz2
   sha256: cfefd86d0f4981d22b7611b3dc60359b8698bf39f2b743cb90b7005aaca88e1e
   md5: a04dbcd6095f6b8f3ad195a78d48b262
   depends:
@@ -5300,7 +5300,7 @@ packages:
   license_family: BSD
   size: 50058
   timestamp: 1677917499177
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tk-8.6.14-h6ba3021_0.tar.bz2
   sha256: c04d0c3dcf62109c1384f8680a932b180678291374e15513b0f988c563955541
   md5: 3c25b4f4768ccda28b20a03ba27e7759
   depends:
@@ -5309,7 +5309,7 @@ packages:
   license_family: BSD
   size: 3484151
   timestamp: 1714770744982
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tornado-6.4.2-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tornado-6.4.2-py311h80987f9_0.tar.bz2
   sha256: cf80ec43ca8cd5066bb4b673815b3ee0d81cba428d8cde5fdad2b275e8e2a192
   md5: d481b72f67890c155e69c27b0e723391
   depends:
@@ -5318,7 +5318,7 @@ packages:
   license_family: Apache
   size: 915674
   timestamp: 1733960659590
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/tqdm-4.66.5-py311hb6e6a13_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/tqdm-4.66.5-py311hb6e6a13_0.tar.bz2
   sha256: f6cda770cbe84b10f2d78d41bab43e1a1386e9722569c9b2b235083947fe90cc
   md5: f5306a7b16da13a7258a20cecb62cdd5
   depends:
@@ -5329,7 +5329,7 @@ packages:
   license_family: MOZILLA
   size: 155732
   timestamp: 1724854273737
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/traitlets-5.14.3-py311hca03da5_0.tar.bz2
   sha256: 707e5dfdb9116f31bc1ad7f497f6e8416683add460258fdc2a4c16eec85226be
   md5: ffb602322a388ec8e1f385edaca3ce12
   depends:
@@ -5338,7 +5338,7 @@ packages:
   license_family: BSD
   size: 208171
   timestamp: 1718227091374
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing-extensions-4.12.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing-extensions-4.12.2-py311hca03da5_0.tar.bz2
   sha256: 76bfd11a14fed1c680f48ab1d85cfab450f28798b393949c7be3932fb124d6a0
   md5: e2d3691e6d2d812b68b13c7ac3086a67
   depends:
@@ -5348,7 +5348,7 @@ packages:
   license_family: PSF
   size: 9928
   timestamp: 1734715032666
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/typing_extensions-4.12.2-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/typing_extensions-4.12.2-py311hca03da5_0.tar.bz2
   sha256: 6ed1e28c504268da2e42490301a1c0bad8b7f9261693d457233f675b3f5d9387
   md5: a25a484145929656f3e0c6acda51117a
   depends:
@@ -5357,7 +5357,7 @@ packages:
   license_family: PSF
   size: 82601
   timestamp: 1734715026245
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/uc-micro-py-1.0.1-py311hca03da5_0.tar.bz2
   sha256: 2ea2d0520b330d381a2ab241bdb9ae146ef815ee7c96ee52a9773fb9ae85f4fd
   md5: 66f7f8979cfb2cccffac972d70482130
   depends:
@@ -5366,7 +5366,7 @@ packages:
   license_family: MIT
   size: 12614
   timestamp: 1677963554857
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/unicodedata2-15.1.0-py311h80987f9_0.tar.bz2
   sha256: df7fe7740bd853b641d624e2ec97f1aacb2b82691936a8c04ef18fa9768539c2
   md5: d5c7626d45fd03b22797c18e47812beb
   depends:
@@ -5375,7 +5375,7 @@ packages:
   license_family: Apache
   size: 518048
   timestamp: 1713213046424
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/urllib3-2.2.3-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/urllib3-2.2.3-py311hca03da5_0.tar.bz2
   sha256: 428c7365b106ed161342704298d14101e12cdd778caee3d167587fc2807e483d
   md5: 86cd9cef3c89a98a98548f18c621e61e
   depends:
@@ -5391,7 +5391,7 @@ packages:
   license_family: MIT
   size: 218842
   timestamp: 1727769914621
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/webencodings-0.5.1-py311hca03da5_1.tar.bz2
   sha256: 09738b7f9075386bf062b12ddb6fb72a06450d2481f6b5ca2026c811cd849569
   md5: 9afdec076c95746ac21235f971190e40
   depends:
@@ -5400,7 +5400,7 @@ packages:
   license_family: BSD
   size: 26727
   timestamp: 1677910175964
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/websocket-client-1.8.0-py311hca03da5_0.tar.bz2
   sha256: b4ced7366de8eb7258f31d516616e70c62ed4a798780e57e208509d2b52ab435
   md5: 65a9a05a726734c1da667f9bd3c78c14
   depends:
@@ -5409,7 +5409,7 @@ packages:
   license_family: Apache
   size: 114733
   timestamp: 1715878377412
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/wheel-0.44.0-py311hca03da5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/wheel-0.44.0-py311hca03da5_0.tar.bz2
   sha256: 088f397ff8a4a7e178415dd7e2ff987c02b3674c7b6885972fb6c669978aff40
   md5: a87f4be160e50ea022588aab7c7322bf
   depends:
@@ -5418,7 +5418,7 @@ packages:
   license_family: MIT
   size: 139304
   timestamp: 1726165038360
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xyzservices-2022.9.0-py311hca03da5_1.tar.bz2
   sha256: 2cd108896df65636769e3804ecc2ca421ad9b54e64fa21922bbabe40c90c247a
   md5: b3a1e5077b28f71298d891fbfb5ff03e
   depends:
@@ -5427,20 +5427,20 @@ packages:
   license_family: BSD
   size: 55645
   timestamp: 1677927459979
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/xz-5.4.6-h80987f9_1.tar.bz2
   sha256: 5be8c968f2da5c4bf14f28d63e31b4c1b6993d980023769732c7f58f396c2e0b
   md5: 3f5f62d4e85e3bdd48d39189b01805a6
   license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_family: GPL2
   size: 459197
   timestamp: 1714510992914
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/yaml-0.2.5-h1a28f6b_0.tar.bz2
   sha256: 1f91e06065113aba9d584758b87cb19d6e830281eaf4bb4588a46933001fb9a8
   md5: 990ccbdae7ddeea76e2bf0546d4c6369
   license: MIT
   size: 88367
   timestamp: 1629137313522
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zeromq-4.3.5-h313beb8_0.tar.bz2
   sha256: 2175f921238c98f98ae74acbf44c27ac2ec69d47fc33f0bff129c8885dbf5546
   md5: 3d57d1adadca9388aaaa1c529b65ba65
   depends:
@@ -5450,14 +5450,14 @@ packages:
   license_family: Other
   size: 322790
   timestamp: 1705602163804
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zlib-1.2.13-h18a0788_1.tar.bz2
   sha256: a75dca6889cbc372f5d4f77cd51971c44813a52b7d9eb6e0ae4233489158b8bd
   md5: f6eaf6f4f72949f671c4fa6e47bbb1b2
   license: Zlib
   license_family: Other
   size: 104928
   timestamp: 1714510936868
-- conda: https://repo.anaconda.com/pkgs/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
+- conda: https://conda.anaconda.org/main/osx-arm64/zstd-1.5.6-hfb09047_0.tar.bz2
   sha256: 43667132ec8fa4c34ba438e13a01b08073e3e3e8a648ecdb6afe4141a7c197e2
   md5: fb8c3f5683b19dd3743d125797b8e2dd
   depends:
@@ -5468,7 +5468,7 @@ packages:
   license_family: BSD
   size: 817614
   timestamp: 1728486986031
-- conda: https://repo.anaconda.com/pkgs/main/win-64/anyio-4.6.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/anyio-4.6.2-py311haa95532_0.tar.bz2
   sha256: 6fbb6b2aa38cb576b17299bf2fdc3779ca090059bfd35e92127f692f2b912aef
   md5: 403069f811c54afaf3d6e3be619bbab8
   depends:
@@ -5481,7 +5481,7 @@ packages:
   license_family: MIT
   size: 244161
   timestamp: 1729121358016
-- conda: https://repo.anaconda.com/pkgs/main/win-64/argon2-cffi-bindings-21.2.0-py311h827c3e9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/argon2-cffi-bindings-21.2.0-py311h827c3e9_1.tar.bz2
   sha256: c6ca6f120f5e09524f2e6bf0db3d88f765e1700b2a5ae115028e5536dbc6d596
   md5: afdf42981074a40b5f08bc6af82670a9
   depends:
@@ -5493,7 +5493,7 @@ packages:
   license_family: MIT
   size: 47000
   timestamp: 1736183077470
-- conda: https://repo.anaconda.com/pkgs/main/win-64/attrs-24.3.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/attrs-24.3.0-py311haa95532_0.tar.bz2
   sha256: 530abbccadda1fcb2cc52ef46c1615cc64f81932a9565f28e4d0684dae754265
   md5: b630c6316defef2d31cf5e31a74ee656
   depends:
@@ -5502,7 +5502,7 @@ packages:
   license_family: MIT
   size: 163897
   timestamp: 1734533441204
-- conda: https://repo.anaconda.com/pkgs/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/beautifulsoup4-4.12.3-py311haa95532_0.tar.bz2
   sha256: f1eb2a5aeb25efa0b38fc1dd94a36d431bc80d654f11a052f67a899dcc471f57
   md5: 9db5a441c7cbcf4dc617f8c722e4310d
   depends:
@@ -5512,12 +5512,12 @@ packages:
   license_family: MIT
   size: 276663
   timestamp: 1718029990621
-- conda: https://repo.anaconda.com/pkgs/main/win-64/blas-1.0-mkl.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/blas-1.0-mkl.tar.bz2
   sha256: b7106623ef385591000a017ced576f2f4629c6de016d687d0d061cc8bfacaa16
   md5: e8aa6b7daaf0925245c148aaeaa0722e
   size: 6183
   timestamp: 1528122357636
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bleach-6.2.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bleach-6.2.0-py311haa95532_0.tar.bz2
   sha256: 0837002d1a1cd03ff18ec4328ad308859cfeb02e9ebb56c7565f2540a410c207
   md5: 89be604fc06ac9ec44500f933bab9ca9
   depends:
@@ -5529,7 +5529,7 @@ packages:
   license_family: Apache
   size: 371219
   timestamp: 1732292957244
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bokeh-3.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bokeh-3.6.0-py311haa95532_0.tar.bz2
   sha256: d6077bf47e0740168accab42135139ebb4bdd5cf1111f81881b148777468100e
   md5: 7281ca887bccf048f735eb5acb1e5118
   depends:
@@ -5547,7 +5547,7 @@ packages:
   license_family: BSD
   size: 5918010
   timestamp: 1727915199711
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bottleneck-1.4.2-py311h57dcf0c_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bottleneck-1.4.2-py311h57dcf0c_0.tar.bz2
   sha256: 42f1a2eb775091e9aec87f3f08ba76891e45032c980b9c00c108437df6b5fc56
   md5: 327b522b59ec41d6e5d4a100c228415b
   depends:
@@ -5559,7 +5559,7 @@ packages:
   license_family: BSD
   size: 160724
   timestamp: 1731059089575
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-1.0.9-h827c3e9_9.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-1.0.9-h827c3e9_9.tar.bz2
   sha256: 7b77dcc19206868494e1b0595d2f575bc7222a000825f0142409d4f7689dd2a8
   md5: 87a9ff016a169e488858bd6b6876bbc2
   depends:
@@ -5571,7 +5571,7 @@ packages:
   license: MIT
   size: 19711
   timestamp: 1736183369640
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-bin-1.0.9-h827c3e9_9.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-bin-1.0.9-h827c3e9_9.tar.bz2
   sha256: 5e0ebd9da1061b360f75d51da7cb12f54f485e9669f93f431028c234f2e81dd5
   md5: a3019a2306b44dd386bc06e8fe013c83
   depends:
@@ -5582,7 +5582,7 @@ packages:
   license: MIT
   size: 33689
   timestamp: 1736183347666
-- conda: https://repo.anaconda.com/pkgs/main/win-64/brotli-python-1.0.9-py311h5da7b33_9.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/brotli-python-1.0.9-py311h5da7b33_9.tar.bz2
   sha256: 1d1267a7b0eb3de746900b4c6dd06ca141085fd12b076b6ae38e8800e8b6d305
   md5: 7e55ca44341f40eea68607d12479f367
   depends:
@@ -5592,7 +5592,7 @@ packages:
   license: MIT
   size: 356583
   timestamp: 1736183647928
-- conda: https://repo.anaconda.com/pkgs/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/bzip2-1.0.8-h2bbff1b_6.tar.bz2
   sha256: d07d035f6be0eb59f5bb92104717a2e14f5d353ac54fe823048c4a07ccb1d355
   md5: 11e0af09a31e2d5df51c65a342032b85
   depends:
@@ -5602,14 +5602,14 @@ packages:
   license_family: BSD
   size: 112994
   timestamp: 1714511182837
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ca-certificates-2024.12.31-haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ca-certificates-2024.12.31-haa95532_0.tar.bz2
   sha256: c705fdedd20c3e3dbd1f2dca0bcfe75528c0892d0ce0325dc1969b049579ede5
   md5: e59f75f1c0aa213d91dbc683155c562f
   license: MPL-2.0
   license_family: Other
   size: 173115
   timestamp: 1736360411856
-- conda: https://repo.anaconda.com/pkgs/main/win-64/certifi-2024.12.14-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/certifi-2024.12.14-py311haa95532_0.tar.bz2
   sha256: 20d5658001133d159efd12aa8f12cd4f4092840015f7664fb6b210b239c72de1
   md5: 6a8975d5b0a4ca161ca92071b51d85ec
   depends:
@@ -5618,7 +5618,7 @@ packages:
   license_family: Other
   size: 167825
   timestamp: 1734473486300
-- conda: https://repo.anaconda.com/pkgs/main/win-64/cffi-1.17.1-py311h827c3e9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/cffi-1.17.1-py311h827c3e9_1.tar.bz2
   sha256: 14cb2182124ca010739f78e856e5d4ee50cc1b1da55550c9d2fc817f2c67dbbe
   md5: d8ee3acca8b6a61a3f58b83f820e8900
   depends:
@@ -5630,7 +5630,7 @@ packages:
   license_family: MIT
   size: 317912
   timestamp: 1736184391679
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorama-0.4.6-py311haa95532_0.tar.bz2
   sha256: 4099898f02e1f6119fcda65e747c3cbfef0bf563c8855b79a0245160709d5b45
   md5: ab9705c34e67fb8c8faec69d63ff4064
   depends:
@@ -5639,7 +5639,7 @@ packages:
   license_family: BSD
   size: 36410
   timestamp: 1676422341506
-- conda: https://repo.anaconda.com/pkgs/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/colorcet-3.1.0-py311haa95532_0.tar.bz2
   sha256: c722f50980d7416ffb2cfc7bf72649307a0bb78c5a24eccefcd049cb61d6b355
   md5: c7c9ff0513ff3c99700919293b702410
   depends:
@@ -5648,7 +5648,7 @@ packages:
   license_family: CC
   size: 543258
   timestamp: 1709758602437
-- conda: https://repo.anaconda.com/pkgs/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/comm-0.2.1-py311haa95532_0.tar.bz2
   sha256: 8fb3e816a5ad1da05125462dbc9e2a7e933b001a871aa65703802c0a894c6277
   md5: ee4b2fa9fce130496d5c7c86c35a1a05
   depends:
@@ -5658,7 +5658,7 @@ packages:
   license_family: BSD
   size: 17723
   timestamp: 1709323150229
-- conda: https://repo.anaconda.com/pkgs/main/win-64/contourpy-1.3.1-py311h214f63a_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/contourpy-1.3.1-py311h214f63a_0.tar.bz2
   sha256: f78afa9b88ee6210adc2619ba09e20b1ef1fbe97505958a6291d8cdfee9f42b7
   md5: c9d405de1665e2d6e8cef51450f2a7a4
   depends:
@@ -5670,7 +5670,7 @@ packages:
   license_family: BSD
   size: 248779
   timestamp: 1732540644947
-- conda: https://repo.anaconda.com/pkgs/main/win-64/debugpy-1.8.11-py311h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/debugpy-1.8.11-py311h5da7b33_0.tar.bz2
   sha256: 6f2f0fa6cd6b041d5dd3dfc6beeb0528b563f1d138e0c1937dda07b3ef243846
   md5: 47eb9e788ad8380d20fcdf8b40ea08a1
   depends:
@@ -5681,7 +5681,7 @@ packages:
   license_family: MIT
   size: 4034402
   timestamp: 1736269847465
-- conda: https://repo.anaconda.com/pkgs/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/entrypoints-0.4-py311haa95532_0.tar.bz2
   sha256: 5d5fc8a24c804010b8cb5963227230352ea3ccf56bea9e8116e34f77223218f2
   md5: 8f989a72eed6293dfe0533c83057980d
   depends:
@@ -5690,7 +5690,7 @@ packages:
   license_family: MIT
   size: 17688
   timestamp: 1676423357100
-- conda: https://repo.anaconda.com/pkgs/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/fonttools-4.51.0-py311h2bbff1b_0.tar.bz2
   sha256: 27fb03eb57d25711a15e145f47a64320a9955b585efc9fd0a1a51cdd71b9fde3
   md5: eb3869e98f6f53dfec76e2eff4d6b61e
   depends:
@@ -5710,7 +5710,7 @@ packages:
   license_family: MIT
   size: 2732423
   timestamp: 1713552175344
-- conda: https://repo.anaconda.com/pkgs/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/freetype-2.12.1-ha860e81_0.tar.bz2
   sha256: 603e04f5064dac7538a697ff69c8a72c13714b375c322fd2f4047ba472eabda6
   md5: ef1b830ffb28c46ec812362318ea7ec3
   depends:
@@ -5722,7 +5722,7 @@ packages:
   license_family: Other
   size: 527643
   timestamp: 1666798364378
-- conda: https://repo.anaconda.com/pkgs/main/win-64/holoviews-1.20.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/holoviews-1.20.0-py311haa95532_0.tar.bz2
   sha256: d991c3ed55771bd642ffebbef209c4d94b9db7c206fb7ef52d8013baadfb6005
   md5: 4ec4007efb1e5167568de53a8b03ac43
   depends:
@@ -5742,7 +5742,7 @@ packages:
   license_family: BSD
   size: 6147331
   timestamp: 1730827981525
-- conda: https://repo.anaconda.com/pkgs/main/win-64/hvplot-0.11.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/hvplot-0.11.2-py311haa95532_0.tar.bz2
   sha256: 4760ed2d77621477f47cdd4d96bc0c26cdba9fe93308df92c01d20d812b129ac
   md5: 990ecc3db2641f58e3541e4b0a05c875
   depends:
@@ -5759,7 +5759,7 @@ packages:
   license_family: BSD
   size: 368606
   timestamp: 1734470082250
-- conda: https://repo.anaconda.com/pkgs/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/idna-3.7-py311haa95532_0.tar.bz2
   sha256: 102c803186db6d62eaf41a906f6c563ff0d62b53c1eaede8a381e18c0d005ed9
   md5: 9d30dec03058758a428cf152e0ae28b5
   depends:
@@ -5768,7 +5768,7 @@ packages:
   license_family: BSD
   size: 148193
   timestamp: 1714399061601
-- conda: https://repo.anaconda.com/pkgs/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/intel-openmp-2023.1.0-h59b6b97_46320.tar.bz2
   sha256: cd7e8044e2e2d99e142d117bdb26c1f47570d5ba51484aab05d5630053feac18
   md5: d215cc8ee7ca2cc83cc250cc5d822fe0
   depends:
@@ -5778,7 +5778,7 @@ packages:
   license_family: Proprietary
   size: 3929136
   timestamp: 1699647939158
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipykernel-6.29.5-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipykernel-6.29.5-py311haa95532_0.tar.bz2
   sha256: 6f702a1b807648373dff43ba42e92978b52cfe392ca426dfb9ebf556a1189a70
   md5: db5be371e83b27b4c763d1b1c3777df0
   depends:
@@ -5799,7 +5799,7 @@ packages:
   license_family: BSD
   size: 237277
   timestamp: 1728665671824
-- conda: https://repo.anaconda.com/pkgs/main/win-64/ipython-8.30.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/ipython-8.30.0-py311haa95532_0.tar.bz2
   sha256: 849c5c284c450d0a254fdb09872a56bc36736fad80b5602d51034cd3c5e1f244
   md5: 85c6796b362a934aefccd96c6f4e84c9
   depends:
@@ -5817,7 +5817,7 @@ packages:
   license_family: BSD
   size: 1677847
   timestamp: 1734548277969
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jedi-0.19.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jedi-0.19.2-py311haa95532_0.tar.bz2
   sha256: 47280ad8a680828014eceff93c5c587c0c290579486377e696c78d8461a172a1
   md5: d38c4583143de20b5c9c8571889e1980
   depends:
@@ -5827,7 +5827,7 @@ packages:
   license_family: MIT
   size: 1189371
   timestamp: 1733987881391
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jinja2-3.1.4-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jinja2-3.1.4-py311haa95532_1.tar.bz2
   sha256: 8694788240bbdddbc5d111ee8d0ef11106ddadb13d56cd4c46b8140b88ab6277
   md5: 64856a8473ebc5effe17f370b4e91016
   depends:
@@ -5839,7 +5839,7 @@ packages:
   license_family: BSD
   size: 357167
   timestamp: 1730903506013
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jpeg-9e-h827c3e9_3.tar.bz2
   sha256: 0238fb10912d9345a9d327ff314a179de38369f8e1d0de0b5f4fab04defab0e4
   md5: 16a420ea83811cfa0c7cadba8f9f0995
   depends:
@@ -5849,7 +5849,7 @@ packages:
   license_family: Other
   size: 409932
   timestamp: 1722872751697
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-4.23.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-4.23.0-py311haa95532_0.tar.bz2
   sha256: 99f6618c5969b13451072defdcf3441b83f710010ef10b7a620b42e156ed919e
   md5: 501a297479b97960e249bdb117f7cda7
   depends:
@@ -5862,7 +5862,7 @@ packages:
   license_family: MIT
   size: 224348
   timestamp: 1728486919376
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jsonschema-specifications-2023.7.1-py311haa95532_0.tar.bz2
   sha256: 9581be54128954080d7cef448b1728874c2ebbe5064f55adece422cf12eafa5a
   md5: 3adc105f87d5c7f0b1248bc3423f5b48
   depends:
@@ -5872,7 +5872,7 @@ packages:
   license_family: MIT
   size: 16187
   timestamp: 1699032556953
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_client-7.4.9-py311haa95532_0.tar.bz2
   sha256: ad8343bad7c8f0448cbcfbaf872cc94b56da81c52e5cdcee2a5d6b89f029eb75
   md5: addceff8d46c9d1d322618a9ce9e5b39
   depends:
@@ -5888,7 +5888,7 @@ packages:
   license_family: BSD
   size: 300354
   timestamp: 1676424060532
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_core-5.7.2-py311haa95532_0.tar.bz2
   sha256: fe0bf805dfa60d8b5d61670900442d0cda12523135176f60e1ebafb797e521d8
   md5: c8cf5ea3d4b0bc57dfe6b189b47e69e9
   depends:
@@ -5900,7 +5900,7 @@ packages:
   license_family: BSD
   size: 136783
   timestamp: 1718818384444
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_events-0.10.0-py311haa95532_0.tar.bz2
   sha256: 262c35a28d0af4d73ea1c010ce0c022005512a26d5c27064c8e009c0b7b789d9
   md5: 8367c61552aa274c0843201d88e461c8
   depends:
@@ -5916,7 +5916,7 @@ packages:
   license_family: BSD
   size: 72131
   timestamp: 1718738283200
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server-2.14.1-py311haa95532_0.tar.bz2
   sha256: 00bf8449a37eb10c91ebfaa14b231905fde9493740cbda7ec89a8d3d8d9d1ff3
   md5: 1f3abe3cbf365249ebae7465a57e4cae
   depends:
@@ -5944,7 +5944,7 @@ packages:
   license_family: BSD
   size: 655133
   timestamp: 1718827724346
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyter_server_terminals-0.4.4-py311haa95532_1.tar.bz2
   sha256: 90420847230e72a648417f5f77cebcf7f17b89f70788652c276acc0c440e135f
   md5: ef3d8dee197aa37897bf6d39d2dd878f
   depends:
@@ -5955,7 +5955,7 @@ packages:
   license_family: BSD
   size: 27639
   timestamp: 1686871052174
-- conda: https://repo.anaconda.com/pkgs/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/jupyterlab_pygments-0.2.2-py311haa95532_0.tar.bz2
   sha256: 97faaf26ce5254ec3649a8ee7f480b1556e4e8e6e4356d2fab1e6a5532631a0f
   md5: da23bd831c50c877f63038b7e16720ad
   depends:
@@ -5967,7 +5967,7 @@ packages:
   license_family: BSD
   size: 20163
   timestamp: 1700168785472
-- conda: https://repo.anaconda.com/pkgs/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/kiwisolver-1.4.4-py311hd77b12b_0.tar.bz2
   sha256: 8a2f0909fad0387e57cb0e9ee30db2b20761a9106e794381ffeac387a298fb07
   md5: 6058b2efc3284e27aacec2e6e6280433
   depends:
@@ -5978,7 +5978,7 @@ packages:
   license_family: BSD
   size: 62334
   timestamp: 1676432044242
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lcms2-2.16-hb4a4139_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lcms2-2.16-hb4a4139_0.tar.bz2
   sha256: ef4d7e1443c7c510b6e690e344392075bc4d89b5818907f544ce98fd967d029a
   md5: 6541897ab2fd34b35519b95c922b3192
   depends:
@@ -5990,7 +5990,7 @@ packages:
   license_family: MIT
   size: 1089573
   timestamp: 1734428606761
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lerc-4.0.0-h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lerc-4.0.0-h5da7b33_0.tar.bz2
   sha256: 3a915692cf3e21e7cc4259faea2e17535530515acb3bc8fa00832d646bdeecf0
   md5: eda551db9b747f0606eddd001343ed36
   depends:
@@ -6000,7 +6000,7 @@ packages:
   license_family: Apache
   size: 207263
   timestamp: 1734423494890
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlicommon-1.0.9-h827c3e9_9.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlicommon-1.0.9-h827c3e9_9.tar.bz2
   sha256: 5c51b1860e91be66584f6932b86de344a7158894e98b59ed5f973c39e3d77fbc
   md5: 4273c278acae05def47ce1bbf4a604bc
   depends:
@@ -6009,7 +6009,7 @@ packages:
   license: MIT
   size: 80775
   timestamp: 1736183139175
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlidec-1.0.9-h827c3e9_9.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlidec-1.0.9-h827c3e9_9.tar.bz2
   sha256: c34366f1af8c499501c660caed188191869198af323f28f9fdf36cdc3bd9b983
   md5: 17978e34dd336c03b45064a092e24b2c
   depends:
@@ -6019,7 +6019,7 @@ packages:
   license: MIT
   size: 45764
   timestamp: 1736183205643
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libbrotlienc-1.0.9-h827c3e9_9.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libbrotlienc-1.0.9-h827c3e9_9.tar.bz2
   sha256: 3db56a17b192f502d1658eff34ed0d3d4ca137c9611e22c5ea866d217004d939
   md5: 4b5c2afa55286a51a06fb2e7f2ffa135
   depends:
@@ -6029,7 +6029,7 @@ packages:
   license: MIT
   size: 755218
   timestamp: 1736183274598
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libdeflate-1.22-h5bf469e_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libdeflate-1.22-h5bf469e_0.tar.bz2
   sha256: 46c58457ec8c074d5af22fe36a182d5c29e76f6248e7d1d5cb76c66beefe52aa
   md5: 5bd6c216dd03f3ccf9d108b7c8a29367
   depends:
@@ -6039,7 +6039,7 @@ packages:
   license_family: MIT
   size: 223776
   timestamp: 1734423384478
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libffi-3.4.4-hd77b12b_1.tar.bz2
   sha256: d3df70b3b29761d434dd2fb4c6a6ee3762b7951784909720a328e722884c12a2
   md5: cf949d76148be1e2a534218d9c57df86
   depends:
@@ -6049,7 +6049,7 @@ packages:
   license_family: MIT
   size: 155435
   timestamp: 1714484319443
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libpng-1.6.39-h8cc25b3_0.tar.bz2
   sha256: 09c88f271eaa24d5c2b6c83a1636b8a800392d12ccb7c8ae68f59466e2dc3bbf
   md5: 78315f89b8550030dc574d04bc69c115
   depends:
@@ -6060,7 +6060,7 @@ packages:
   license_family: Other
   size: 707959
   timestamp: 1677841899214
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libsodium-1.0.18-h62dcd97_0.tar.bz2
   sha256: 2c27c5f612aa3e11b1bfe236a6b02bcfecf7f9dd393c6427e85f55b762b9b006
   md5: 3151bf6860a305eeb17df6f0e7a4658a
   depends:
@@ -6069,7 +6069,7 @@ packages:
   license: ISC
   size: 681655
   timestamp: 1581697249749
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libtiff-4.5.1-h44ae7cf_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libtiff-4.5.1-h44ae7cf_1.tar.bz2
   sha256: 224c9ee15d52fd10544bdae6738e8d8ad12a04a6c48692574d51426d0ea421f2
   md5: ba5f521d36280d34950fc5d99a58676b
   depends:
@@ -6085,7 +6085,7 @@ packages:
   license_family: Other
   size: 1213382
   timestamp: 1734425893191
-- conda: https://repo.anaconda.com/pkgs/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/libwebp-base-1.3.2-h3d04722_1.tar.bz2
   sha256: e54ee28f6ba01b3addf61ee9dfbdedc16eac8654fc334f713b5f181cf037d0f2
   md5: 47aa151852fc9b07e7573d22f0af945d
   depends:
@@ -6097,7 +6097,7 @@ packages:
   license_family: BSD
   size: 339944
   timestamp: 1729160123353
-- conda: https://repo.anaconda.com/pkgs/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/linkify-it-py-2.0.0-py311haa95532_0.tar.bz2
   sha256: 4534c822511a052a72c2b070a05e5d8d6f3550f18ea00a33f9d8a9a92b4382cc
   md5: 82f24e7660831445a2183216e280a6a4
   depends:
@@ -6107,7 +6107,7 @@ packages:
   license_family: MIT
   size: 41464
   timestamp: 1676474474981
-- conda: https://repo.anaconda.com/pkgs/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/lz4-c-1.9.4-h2bbff1b_1.tar.bz2
   sha256: 4904383b0c6283735a01bd1d089e9fafcec0850c9ee19d64db462bd038e43c46
   md5: 320f40b75d93f3b96931c6d13c23946c
   depends:
@@ -6117,7 +6117,7 @@ packages:
   license_family: BSD
   size: 158902
   timestamp: 1714512129889
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-3.4.1-py311haa95532_0.tar.bz2
   sha256: e0dc6e119b224bb31ef34b6ba270ffadc181d38b698c5318de8df7a5d2c4ccbd
   md5: 992ccd756f09408f0b74dfb9852a8b7f
   depends:
@@ -6126,7 +6126,7 @@ packages:
   license_family: BSD
   size: 182381
   timestamp: 1676437963591
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markdown-it-py-2.2.0-py311haa95532_1.tar.bz2
   sha256: 050b5fd4b28132d8102a7e6b40179894dc7f5e41f7ad9ee19211e67446c5740f
   md5: 3ae0b2f6baec708554648ddafa81b756
   depends:
@@ -6136,7 +6136,7 @@ packages:
   license_family: MIT
   size: 154386
   timestamp: 1684279992864
-- conda: https://repo.anaconda.com/pkgs/main/win-64/markupsafe-2.1.3-py311h827c3e9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/markupsafe-2.1.3-py311h827c3e9_1.tar.bz2
   sha256: e02c539068d82ac6a709a4bb33b18a181afdfa78f43c97451209c5903af7e4f7
   md5: d9678fcceae215a8b3fb4639a77f818c
   depends:
@@ -6149,7 +6149,7 @@ packages:
   license_family: BSD
   size: 40937
   timestamp: 1736370643775
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-base-3.10.0-py311he19b0ae_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-base-3.10.0-py311he19b0ae_0.tar.bz2
   sha256: 35078ccb78b0b35ea07ccff575a056166fe32df8c2e4a2265c3aca75e00a482b
   md5: 3d61e9d9826f4a3664bc102588ab2fa4
   depends:
@@ -6170,7 +6170,7 @@ packages:
   license_family: PSF
   size: 12369480
   timestamp: 1736279003945
-- conda: https://repo.anaconda.com/pkgs/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/matplotlib-inline-0.1.6-py311haa95532_0.tar.bz2
   sha256: 43279276850eb6e621812448cddc1093524cee0b7f8ed58b4600b68a4fb659f2
   md5: 5968b2b5c1f3cf5c8c8c9aaa4d8d66a2
   depends:
@@ -6180,7 +6180,7 @@ packages:
   license_family: BSD
   size: 19886
   timestamp: 1676425829787
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdit-py-plugins-0.3.0-py311haa95532_0.tar.bz2
   sha256: 3062a8254ca351b54f15bea85cc928a3ba4d879bb98ce97ece39a9f7eca215a5
   md5: 8f1565663abb34ad7fdd512e76da5532
   depends:
@@ -6190,7 +6190,7 @@ packages:
   license_family: MIT
   size: 68031
   timestamp: 1676481862508
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mdurl-0.1.0-py311haa95532_0.tar.bz2
   sha256: cdff5215c292fe59649ca40ca72f5d26da352760c1d6a56feba14eb13f7bbf61
   md5: e0f3f32b22135dfeaec277bc87183ca9
   depends:
@@ -6199,7 +6199,7 @@ packages:
   license_family: MIT
   size: 23328
   timestamp: 1676442709081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mistune-2.0.4-py311haa95532_0.tar.bz2
   sha256: 3b173a25605d2aaacc57ec0e425f1d1c51327eb2521c8742a736e2c76069bc8d
   md5: 169f1c93a443f95a88665f3008623ce1
   depends:
@@ -6210,7 +6210,7 @@ packages:
   license_family: BSD
   size: 104882
   timestamp: 1676425142412
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-2023.1.0-h6b88ed4_46358.tar.bz2
   sha256: 004153943a85cd568258d349e8745bc3f5d8fdda8fc0e5ca91b74cd7b7b2d3f3
   md5: 527155127b9fada5e5c5c69a624674b9
   depends:
@@ -6222,7 +6222,7 @@ packages:
   license_family: Proprietary
   size: 187498166
   timestamp: 1699648376430
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl-service-2.4.0-py311h827c3e9_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl-service-2.4.0-py311h827c3e9_2.tar.bz2
   sha256: d05715a691b223d6c7f592c21032f9bee1e7cad6834c942eec1f2d5bf2da100d
   md5: 04bd233faebb0a8c2841e648ea39e801
   depends:
@@ -6234,7 +6234,7 @@ packages:
   license_family: BSD
   size: 80594
   timestamp: 1736370888084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_fft-1.3.11-py311h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_fft-1.3.11-py311h827c3e9_0.tar.bz2
   sha256: 513b8fe5da01b8460084688d99c977d173b19d7d58ad2aa6b27a961665ae25f4
   md5: c07115b0a05892c721b7324ef8598c2f
   depends:
@@ -6249,7 +6249,7 @@ packages:
   license_family: BSD
   size: 212966
   timestamp: 1730823150084
-- conda: https://repo.anaconda.com/pkgs/main/win-64/mkl_random-1.2.8-py311hea22821_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/mkl_random-1.2.8-py311hea22821_0.tar.bz2
   sha256: f8ea6da83e88b353bf66ae609d0377e45fe0d4dcdba2c920ca7b600559f49679
   md5: 98805ec361a795613a97773fab63653b
   depends:
@@ -6264,7 +6264,7 @@ packages:
   license_family: BSD
   size: 345997
   timestamp: 1730822892388
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclassic-1.1.0-py311haa95532_0.tar.bz2
   sha256: 636f369607118a6ee3d0b63b7edb925d8081fd3fc829a7699136ce0dedbde067
   md5: b7e49c9cea50d8406cac81cd720dd80a
   depends:
@@ -6277,7 +6277,7 @@ packages:
   license_family: BSD
   size: 8323655
   timestamp: 1717622931223
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbclient-0.8.0-py311haa95532_0.tar.bz2
   sha256: e940f9178ee2fa0a7c12873ae35ebea0074371653e5cfa1be8aa8d9271fd343b
   md5: 355d0835215911738a28010dfa6aa382
   depends:
@@ -6290,7 +6290,7 @@ packages:
   license_family: BSD
   size: 141785
   timestamp: 1698934346590
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbconvert-7.16.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbconvert-7.16.4-py311haa95532_0.tar.bz2
   sha256: d5a6346c8d081061777b5327284f3836342ad3e4869c3584a8bf1b7abac56466
   md5: 0d00b9e90c3df8cb479490dc136f0577
   depends:
@@ -6317,7 +6317,7 @@ packages:
   license_family: BSD
   size: 573057
   timestamp: 1728052469536
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nbformat-5.10.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nbformat-5.10.4-py311haa95532_0.tar.bz2
   sha256: 952df0af8037fd3131a3f64481660272040fc30816c5b6a5377fa2357d3bcede
   md5: e0f63c7653d679b5ec3f50b14424ad1d
   depends:
@@ -6330,7 +6330,7 @@ packages:
   license_family: BSD
   size: 202609
   timestamp: 1728050720194
-- conda: https://repo.anaconda.com/pkgs/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/nest-asyncio-1.6.0-py311haa95532_0.tar.bz2
   sha256: 90fb3f14c49da1397982eae21cd09e8d60d491d76f94c57590c56723fe6dc172
   md5: 46a523661fe5c1bce7b4213fd428c3de
   depends:
@@ -6339,7 +6339,7 @@ packages:
   license_family: BSD
   size: 16732
   timestamp: 1708532795328
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-6.5.7-py311haa95532_0.tar.bz2
   sha256: 62732e34b2cdcb73846cfdf53284067d32113aae0f6d736ca30ce2b0073bce27
   md5: ec7191b2ea4e65b5eed6f7fdd9271d28
   depends:
@@ -6364,7 +6364,7 @@ packages:
   license_family: BSD
   size: 769732
   timestamp: 1717630919732
-- conda: https://repo.anaconda.com/pkgs/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/notebook-shim-0.2.3-py311haa95532_0.tar.bz2
   sha256: e040ebcab948325fbe17e4ab15be62e1fafa7bad225457e59764adb60eb40db5
   md5: 4d40a09df8cb74a9f044eab317436d67
   depends:
@@ -6374,7 +6374,7 @@ packages:
   license_family: BSD
   size: 27282
   timestamp: 1699456187703
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numexpr-2.10.1-py311h4cd664f_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numexpr-2.10.1-py311h4cd664f_0.tar.bz2
   sha256: 7bf058d86876ca3d1f23b21ca8f3d9340e7f26fef9366eca092302c4fdc04e8b
   md5: 7492afa4cb19e783c400ae35b90753cc
   depends:
@@ -6390,7 +6390,7 @@ packages:
   license_family: MIT
   size: 210960
   timestamp: 1730216100891
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-2.2.1-py311hdab7c0b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-2.2.1-py311hdab7c0b_0.tar.bz2
   sha256: da5a7e7f64c68b2c77eac97fda013ef6d16b79e6a9110e98939fdb693695483d
   md5: ed1db38fa6cf50302eb6b9a25f0b6daa
   depends:
@@ -6409,7 +6409,7 @@ packages:
   license_family: BSD
   size: 11696
   timestamp: 1736506710332
-- conda: https://repo.anaconda.com/pkgs/main/win-64/numpy-base-2.2.1-py311hd01c5d8_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/numpy-base-2.2.1-py311hd01c5d8_0.tar.bz2
   sha256: 0ba9563d76efa6cda7e29c6d5d6b8e243d64837b9fb9ddebcd51cccf3ebf4aa7
   md5: 60fd1362aba347e454a23f9863847eec
   depends:
@@ -6425,7 +6425,7 @@ packages:
   license_family: BSD
   size: 11894274
   timestamp: 1736506680884
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openjpeg-2.5.2-hae555c5_0.tar.bz2
   sha256: e2afce0548808d27293a03661ee5f7ac3e18f82a92c9fb23f420eb5e92126fc6
   md5: 9dd921a785844abe0aa842c3800d405a
   depends:
@@ -6437,7 +6437,7 @@ packages:
   license_family: BSD
   size: 286986
   timestamp: 1722872761369
-- conda: https://repo.anaconda.com/pkgs/main/win-64/openssl-3.0.15-h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/openssl-3.0.15-h827c3e9_0.tar.bz2
   sha256: a72f51f69a6893797b51345f9fd6b6a3b12764b435bb50e247e9e05d75711bd0
   md5: c05007cfd519c5097f50d9c830ad897f
   depends:
@@ -6448,7 +6448,7 @@ packages:
   license_family: Apache
   size: 8396971
   timestamp: 1725547066793
-- conda: https://repo.anaconda.com/pkgs/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/overrides-7.4.0-py311haa95532_0.tar.bz2
   sha256: b2f5f50a1ddf811102636f3acebd76716c88ebb628754b91eda7a3a962adf26c
   md5: 712527b4d84c350dca4b67f511c04414
   depends:
@@ -6457,7 +6457,7 @@ packages:
   license_family: APACHE
   size: 39421
   timestamp: 1699371341381
-- conda: https://repo.anaconda.com/pkgs/main/win-64/packaging-24.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/packaging-24.2-py311haa95532_0.tar.bz2
   sha256: 55ead6073f34770ba6ab735643411f2219ecd820d186ca3af266954d05e09487
   md5: 6bae6e1982c2e8a4eb1c66df62521fa3
   depends:
@@ -6466,7 +6466,7 @@ packages:
   license_family: Apache
   size: 189953
   timestamp: 1734472735678
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pandas-2.2.3-py311h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pandas-2.2.3-py311h5da7b33_0.tar.bz2
   sha256: 82cc56df413c3875ccc7c811d3268a1404c6ed2b8d02bf7980f2c87a88918168
   md5: e109a06ad54fcea29bdaa01596179a8b
   depends:
@@ -6517,7 +6517,7 @@ packages:
   license_family: BSD
   size: 17254708
   timestamp: 1732738447404
-- conda: https://repo.anaconda.com/pkgs/main/win-64/panel-1.5.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/panel-1.5.3-py311haa95532_0.tar.bz2
   sha256: b0200b6e41271d9e8d37a423315190d4e0932c9f7fbc49895bfb6dd3af815b32
   md5: 6e9c63ef2b4e4705c1df990034b685cb
   depends:
@@ -6542,7 +6542,7 @@ packages:
   license_family: BSD
   size: 24127520
   timestamp: 1730381316612
-- conda: https://repo.anaconda.com/pkgs/main/win-64/param-2.2.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/param-2.2.0-py311haa95532_0.tar.bz2
   sha256: 4086a9512de16e81900140f66ed8e693f05f333f298a83b39a11d5c887fb2434
   md5: 1314cc7bad5784cd7bee147f44ec9947
   depends:
@@ -6551,7 +6551,7 @@ packages:
   license_family: BSD
   size: 273134
   timestamp: 1734618723915
-- conda: https://repo.anaconda.com/pkgs/main/win-64/parso-0.8.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/parso-0.8.4-py311haa95532_0.tar.bz2
   sha256: d9548c1a2c3292e37ff5d8a4b8f10785f3718b445a64b3e259cbed4ec17700e7
   md5: 59cb810d1a41684238817cb875734af2
   depends:
@@ -6560,7 +6560,7 @@ packages:
   license_family: MIT
   size: 224906
   timestamp: 1733963496420
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pillow-11.0.0-py311h096bfcc_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pillow-11.0.0-py311h096bfcc_1.tar.bz2
   sha256: 55f0d0c9b64311a8514632574e27e05476366459253db82694fa6c36566ebf3d
   md5: f852ef4aa5f61e08da8afcfb6ea75f83
   depends:
@@ -6579,7 +6579,7 @@ packages:
   license_family: Other
   size: 990296
   timestamp: 1734431204885
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pip-24.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pip-24.2-py311haa95532_0.tar.bz2
   sha256: 9c0dc12161f77b43137dad2e520ed7a343c5d8d8fd545492336e84201d1bb74c
   md5: 22cda044cb24e1db8fbaa5864feb4261
   depends:
@@ -6590,7 +6590,7 @@ packages:
   license_family: MIT
   size: 3199019
   timestamp: 1723485404416
-- conda: https://repo.anaconda.com/pkgs/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/platformdirs-3.10.0-py311haa95532_0.tar.bz2
   sha256: e5f8cbfb5fc25d460a9117bfc5511959c5e86ccb193316033f87bd516e0c8881
   md5: 9f7e8b5eb651539386bb92c14e5c321b
   depends:
@@ -6599,7 +6599,7 @@ packages:
   license_family: MIT
   size: 37730
   timestamp: 1692205554840
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prometheus_client-0.21.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prometheus_client-0.21.0-py311haa95532_0.tar.bz2
   sha256: 98674172e2820965291e63eab571fde1fd26cbbad3856be6f86f415e7e1037b8
   md5: 30ffc1f7b25ca073001fb641f9724520
   depends:
@@ -6608,7 +6608,7 @@ packages:
   license_family: Apache
   size: 122618
   timestamp: 1731961709745
-- conda: https://repo.anaconda.com/pkgs/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/prompt-toolkit-3.0.43-py311haa95532_0.tar.bz2
   sha256: 546819d922b03f3a25ca9f98fd069d0588d481fc0603c6d74bd598fb6a93687f
   md5: 86c18e3e0b67ee099457475ed6caf2e6
   depends:
@@ -6620,7 +6620,7 @@ packages:
   license_family: BSD
   size: 751763
   timestamp: 1704404627180
-- conda: https://repo.anaconda.com/pkgs/main/win-64/psutil-5.9.0-py311h827c3e9_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/psutil-5.9.0-py311h827c3e9_1.tar.bz2
   sha256: ac23609428982448c7d8e4457b4c7ad3cf0373fd33cf12767b6b064ebca729bc
   md5: ce75fc6d561dbe9fc629b7a7c4359af3
   depends:
@@ -6631,7 +6631,7 @@ packages:
   license_family: BSD
   size: 523851
   timestamp: 1736372163558
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pygments-2.15.1-py311haa95532_1.tar.bz2
   sha256: d95c88d06f4f3f667bd9a39e5f18179e83b3cd4c115c06ce0fff390ff6d3a700
   md5: c6d00a8a4d89b1be99bfa3aff19d96b4
   depends:
@@ -6640,7 +6640,7 @@ packages:
   license_family: BSD
   size: 2134881
   timestamp: 1684280285492
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyparsing-3.2.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyparsing-3.2.0-py311haa95532_0.tar.bz2
   sha256: 30ed42a98c68d6c98d48f871197c5c9c745e7545a12818a21d36689fe1a3a856
   md5: dfd92ad9c788e9c687ca8adc3f541ce0
   depends:
@@ -6649,7 +6649,7 @@ packages:
   license_family: MIT
   size: 486618
   timestamp: 1731445794006
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pysocks-1.7.1-py311haa95532_0.tar.bz2
   sha256: 974c22de09078bf07c5db31fe12d8d89d6433508defc8237cbe52e08c69ed56b
   md5: 9cf10bfd49140a527cf4b1d912097e6d
   depends:
@@ -6659,7 +6659,7 @@ packages:
   license_family: BSD
   size: 36072
   timestamp: 1676426019064
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-3.11.11-h4607a30_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-3.11.11-h4607a30_0.tar.bz2
   sha256: a53f9aa74ecbe1f97a4956425ad1636d8c936750636dd7de0ac8d35ae14b105b
   md5: b3717cd05b5595bd3c839f202df46e74
   depends:
@@ -6680,7 +6680,7 @@ packages:
   license_family: PSF
   size: 20212416
   timestamp: 1733935177242
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-dateutil-2.9.0post0-py311haa95532_2.tar.bz2
   sha256: 2c61639b3bb56fc864c86558bceb7845b1731ac44bf1a94894172ea47a995bd4
   md5: 404805e547b4d50b5cd17e16bca87527
   depends:
@@ -6690,7 +6690,7 @@ packages:
   license_family: BSD
   size: 332043
   timestamp: 1716495838826
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-fastjsonschema-2.20.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-fastjsonschema-2.20.0-py311haa95532_0.tar.bz2
   sha256: dbd986e65f63d73389c7ecf060c0954905f3dba4b2f9f33bf930ca4cb0875310
   md5: c2604164bf8765f3281c1f65ef5eac92
   depends:
@@ -6699,7 +6699,7 @@ packages:
   license_family: BSD
   size: 282101
   timestamp: 1731939443247
-- conda: https://repo.anaconda.com/pkgs/main/win-64/python-json-logger-3.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/python-json-logger-3.2.1-py311haa95532_0.tar.bz2
   sha256: 68389376bdfc521ad3b3f264267420b4c1f99356e90fb0f894128f40f5975ab3
   md5: 65408c0fbd3705ce3fcd630e19effa73
   depends:
@@ -6708,7 +6708,7 @@ packages:
   license_family: BSD
   size: 29508
   timestamp: 1734370229403
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pytz-2024.1-py311haa95532_0.tar.bz2
   sha256: 803274d986d0c4e3b5ec1018747ede86ef57137455b3e44a60e834717eafb92b
   md5: c9f134ddeff6fdf0373a45534ddb7079
   depends:
@@ -6717,7 +6717,7 @@ packages:
   license_family: MIT
   size: 273009
   timestamp: 1713974722039
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyviz_comms-3.0.2-py311haa95532_0.tar.bz2
   sha256: 6fbcba97c1dcb5157afd23f264c3cff069c7e4be5ea55980fc349eb8dc2cb49e
   md5: 8153e3f8b3283926bcf9403804a365f5
   depends:
@@ -6729,7 +6729,7 @@ packages:
   license_family: BSD
   size: 65050
   timestamp: 1711137009299
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywin32-308-py311h5da7b33_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywin32-308-py311h5da7b33_0.tar.bz2
   sha256: 6b6a583ddae1f7fdf8b3923bd2b8c56382b2c77d0d08ed536e3237c8b82f9f02
   md5: 01baaaa03f7066e272de93b25539c834
   depends:
@@ -6738,7 +6738,7 @@ packages:
   license: HPND AND BSD-3-Clause AND LGPL-2.1-or-later AND MIT
   size: 13813074
   timestamp: 1732201761313
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pywinpty-2.0.14-py311h72d21ff_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pywinpty-2.0.14-py311h72d21ff_0.tar.bz2
   sha256: dd0c35a9a5a0e35033b3a5a4c1a98b121670b9e9c795ee8dcf400534760af267
   md5: 2addb0793c3e949f71e415943db41e70
   depends:
@@ -6750,7 +6750,7 @@ packages:
   license_family: MIT
   size: 250185
   timestamp: 1733515229618
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyyaml-6.0.2-py311h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyyaml-6.0.2-py311h827c3e9_0.tar.bz2
   sha256: b54065893111c3bf4ab784feb9a0b7b58bd829c414adda935624790d6541885f
   md5: 1d84022dd238ec68d7c0499885d18c86
   depends:
@@ -6762,7 +6762,7 @@ packages:
   license_family: MIT
   size: 209408
   timestamp: 1728658205944
-- conda: https://repo.anaconda.com/pkgs/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/pyzmq-24.0.1-py311h2bbff1b_0.tar.bz2
   sha256: ea39db411361d96545a04fb976940e9590147acb4ca9caacf7e8264780379347
   md5: b411b8be8e53e5059949dde02dd07faf
   depends:
@@ -6774,7 +6774,7 @@ packages:
   license_family: Other
   size: 565148
   timestamp: 1709319072176
-- conda: https://repo.anaconda.com/pkgs/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/referencing-0.30.2-py311haa95532_0.tar.bz2
   sha256: 47653b45a5f2d97b5bf0dbf0e620908880f9078da427eef69012effe3f19af67
   md5: 44e709ae67d89bccee2d4d46d358fee3
   depends:
@@ -6785,7 +6785,7 @@ packages:
   license_family: MIT
   size: 74493
   timestamp: 1699012356534
-- conda: https://repo.anaconda.com/pkgs/main/win-64/requests-2.32.3-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/requests-2.32.3-py311haa95532_1.tar.bz2
   sha256: a225c1d6a873991bed5c9e93806f0ef0af35830cd6ce09a849e20084a8372200
   md5: 321bb6bf4f0afb4e9175bcb75ab57976
   depends:
@@ -6801,7 +6801,7 @@ packages:
   license_family: Apache
   size: 124386
   timestamp: 1731000647310
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3339-validator-0.1.4-py311haa95532_0.tar.bz2
   sha256: d6daaa6b45272819176e4aeb467ae00e3db43386548464a9993688f292709d40
   md5: 9fe721d7f7420c259df4f07d4503f654
   depends:
@@ -6811,7 +6811,7 @@ packages:
   license_family: MIT
   size: 9683
   timestamp: 1683077110211
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rfc3986-validator-0.1.1-py311haa95532_0.tar.bz2
   sha256: 6051860575f9448aea5799d74469c928cd7cdeeca1eb53657872262a77b1a7a8
   md5: 60e193eca497130034facd5fed168249
   depends:
@@ -6820,7 +6820,7 @@ packages:
   license_family: MIT
   size: 10094
   timestamp: 1683059114376
-- conda: https://repo.anaconda.com/pkgs/main/win-64/rpds-py-0.10.6-py311h636fa0f_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/rpds-py-0.10.6-py311h636fa0f_1.tar.bz2
   sha256: f97f61e82acb6b6481684fc7b48a5ceeda7dec8ad47dad1d2a5889e89a2f8330
   md5: 48c238f5dc664b9d53cb375f3ecad8f6
   depends:
@@ -6831,7 +6831,7 @@ packages:
   license_family: MIT
   size: 222327
   timestamp: 1732234798230
-- conda: https://repo.anaconda.com/pkgs/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/send2trash-1.8.2-py311haa95532_0.tar.bz2
   sha256: 6fd52bae6360fbc8135d72e0c1e4fd407769fa4d0f4b59356e7aed3e000eb339
   md5: 49fd52885250da8aab17ed72e2e18b81
   depends:
@@ -6840,7 +6840,7 @@ packages:
   license_family: BSD
   size: 88901
   timestamp: 1699371435766
-- conda: https://repo.anaconda.com/pkgs/main/win-64/setuptools-72.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/setuptools-72.1.0-py311haa95532_0.tar.bz2
   sha256: 9b5fdd849cbbf043c586ec778e225b2ed6f47f933a668f5a3969173254ae41e6
   md5: 833f99fc56cb5e9c31ce0a4eba51b796
   depends:
@@ -6849,7 +6849,7 @@ packages:
   license_family: MIT
   size: 3307874
   timestamp: 1722860376387
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sniffio-1.3.0-py311haa95532_0.tar.bz2
   sha256: 5d1b7e14dc04816692de0f8518ea8fcbefb26ab61cec83f96f2c44c1bee67fab
   md5: 505d2a70a875b5082dc857aa4dfab0d4
   depends:
@@ -6858,7 +6858,7 @@ packages:
   license_family: Other
   size: 18830
   timestamp: 1705431395254
-- conda: https://repo.anaconda.com/pkgs/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/soupsieve-2.5-py311haa95532_0.tar.bz2
   sha256: 5ff3b4ac3fbce4dd67a87856c04698d0397deb0ac288ff4e7eb02fbab57f1253
   md5: 0ca650a7001c6650809d3361de8cb005
   depends:
@@ -6867,7 +6867,7 @@ packages:
   license_family: MIT
   size: 89590
   timestamp: 1696347858925
-- conda: https://repo.anaconda.com/pkgs/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/sqlite-3.45.3-h2bbff1b_0.tar.bz2
   sha256: 7f445822dbed4137e0e405d5a889e0322d1b8cfdceaf745c334c80ad4ff9488d
   md5: 833b93a2daade3407898f15588945d83
   depends:
@@ -6877,7 +6877,7 @@ packages:
   license_family: Other
   size: 1440481
   timestamp: 1714488344682
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tbb-2021.8.0-h59b6b97_0.tar.bz2
   sha256: c4e36a3adf4f3094dce341edfca0d68149fdd6f9178bfb9f8d5215494e5ec714
   md5: 2d00fccaf04f00047d71d21d309cf764
   depends:
@@ -6887,7 +6887,7 @@ packages:
   license_family: Apache
   size: 152822
   timestamp: 1680167347239
-- conda: https://repo.anaconda.com/pkgs/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/terminado-0.17.1-py311haa95532_0.tar.bz2
   sha256: 78d89b50a29fbeb19a562f5dad95615e3f192bb4f3b86cd6ea75f2f825418232
   md5: 4a4040df560ea47704e0898c4c015808
   depends:
@@ -6898,7 +6898,7 @@ packages:
   license_family: BSD
   size: 38069
   timestamp: 1678228553220
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tinycss2-1.2.1-py311haa95532_0.tar.bz2
   sha256: 70a3cc4a4e81a6421bc19cd410d1d6064aadb2b1cce38b020f85e5346716d8e7
   md5: 32a9a2539579a3d522dce3b5cb4f987b
   depends:
@@ -6908,7 +6908,7 @@ packages:
   license_family: BSD
   size: 49495
   timestamp: 1676425411739
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tk-8.6.14-h0416ee5_0.tar.bz2
   sha256: 0a95736cfd0bb25fc201cd6be4a2450ea8fc30eeb349d861812675b84c94fa74
   md5: a8a9fb30c6dd8e7a16d5dcd2333c3c49
   depends:
@@ -6919,7 +6919,7 @@ packages:
   license_family: BSD
   size: 3844176
   timestamp: 1714770894235
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tornado-6.4.2-py311h827c3e9_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tornado-6.4.2-py311h827c3e9_0.tar.bz2
   sha256: 04c7dd95fc472792fd29e76a8a5a0d1e9f87dd2569c3db59c36253f2f7fb420f
   md5: c24e1d36c566681be5bba111e5883c0d
   depends:
@@ -6930,7 +6930,7 @@ packages:
   license_family: Apache
   size: 933447
   timestamp: 1733960990402
-- conda: https://repo.anaconda.com/pkgs/main/win-64/tqdm-4.66.5-py311h746a85d_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/tqdm-4.66.5-py311h746a85d_0.tar.bz2
   sha256: 283f31f5ef79657b27b9a6d82b5366b869744b553f90bad219714f2771b0088f
   md5: cea2f913161c630749f8e8ac190c99f3
   depends:
@@ -6942,7 +6942,7 @@ packages:
   license_family: MOZILLA
   size: 186694
   timestamp: 1724854118410
-- conda: https://repo.anaconda.com/pkgs/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/traitlets-5.14.3-py311haa95532_0.tar.bz2
   sha256: a724711191ac1226bf228eab49718eed7b5c7394f539294eb0f88baf8e7bb24d
   md5: c78482e07d0aa6df9fcfa5b366dd87e3
   depends:
@@ -6951,7 +6951,7 @@ packages:
   license_family: BSD
   size: 207744
   timestamp: 1718227224929
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing-extensions-4.12.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing-extensions-4.12.2-py311haa95532_0.tar.bz2
   sha256: 81ba8633c9266a47ccf6c13e675548ac10b3a6e6a7bfa978c1fa1c3bac078909
   md5: 15f63d935470581900fb5cb5a77bddfa
   depends:
@@ -6961,7 +6961,7 @@ packages:
   license_family: PSF
   size: 9887
   timestamp: 1734714947897
-- conda: https://repo.anaconda.com/pkgs/main/win-64/typing_extensions-4.12.2-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/typing_extensions-4.12.2-py311haa95532_0.tar.bz2
   sha256: d348f55f9646a6d564dddbc3b2fcdcb6972bb1da9d9ad38941399cafc2d35f21
   md5: 8f78d5a156c9f79284c5d191e091101c
   depends:
@@ -6970,7 +6970,7 @@ packages:
   license_family: PSF
   size: 82553
   timestamp: 1734714936074
-- conda: https://repo.anaconda.com/pkgs/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/uc-micro-py-1.0.1-py311haa95532_0.tar.bz2
   sha256: d091897f05318c22ca31028370f25355065999078f7db6f88ab27bf4cb030ec8
   md5: 1776502c1cfb351554eeda6cddaf255f
   depends:
@@ -6979,7 +6979,7 @@ packages:
   license_family: MIT
   size: 11588
   timestamp: 1676457729096
-- conda: https://repo.anaconda.com/pkgs/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/unicodedata2-15.1.0-py311h2bbff1b_0.tar.bz2
   sha256: c16498f8238cc331618720d078b87995eceb6bbf20268a7a4e8efbf7b5859a9a
   md5: 770432c0ca1ab9d99ffe95e51d3a3e74
   depends:
@@ -6990,7 +6990,7 @@ packages:
   license_family: Apache
   size: 517433
   timestamp: 1713213261710
-- conda: https://repo.anaconda.com/pkgs/main/win-64/urllib3-2.2.3-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/urllib3-2.2.3-py311haa95532_0.tar.bz2
   sha256: de79b019200fdeb430ce7971edaa7af403cbfc1b52e1bdca6e496c6eeaf6b37f
   md5: ba54713eec74d8c2636f137608ad8959
   depends:
@@ -7006,7 +7006,7 @@ packages:
   license_family: MIT
   size: 218619
   timestamp: 1727770119876
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vc-14.40-haa95532_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vc-14.40-haa95532_2.tar.bz2
   sha256: 2347a1c63da77846cb2161daaca7a7918fd1f2f8fc6c482b1da15f2c81ff9401
   md5: 82f790121c5a4b129df23a0c264a5371
   depends:
@@ -7015,12 +7015,12 @@ packages:
   license_family: BSD
   size: 9297
   timestamp: 1733348498082
-- conda: https://repo.anaconda.com/pkgs/main/win-64/vs2015_runtime-14.42.34433-h9531ae6_2.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/vs2015_runtime-14.42.34433-h9531ae6_2.tar.bz2
   sha256: e5a9bb7ea0534170f6cd52021dd2c9cdd2048eb7cf30bd983ce12caf7fdcdb21
   md5: 8a633c6afbd406dcec4a824949408c1a
   size: 2461182
   timestamp: 1733348487481
-- conda: https://repo.anaconda.com/pkgs/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/webencodings-0.5.1-py311haa95532_1.tar.bz2
   sha256: 24ea3d3e0cb98d0d246338dbb4562b67967bb32002e3704e495a5c863476e831
   md5: c7b9cdbe87b3c9720aeca1164a0fd6df
   depends:
@@ -7029,7 +7029,7 @@ packages:
   license_family: BSD
   size: 26181
   timestamp: 1676424437003
-- conda: https://repo.anaconda.com/pkgs/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/websocket-client-1.8.0-py311haa95532_0.tar.bz2
   sha256: 92d27e41ce34387e59acb47572fcb2e92c4defaeadafd11ce190226022023e69
   md5: f1bf142d852987acbe4b0bc94e87d958
   depends:
@@ -7038,7 +7038,7 @@ packages:
   license_family: Apache
   size: 145306
   timestamp: 1715878654770
-- conda: https://repo.anaconda.com/pkgs/main/win-64/wheel-0.44.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/wheel-0.44.0-py311haa95532_0.tar.bz2
   sha256: 2eb16eafe8322ad10c73b19be8f2c8b6135561bead6f73f48c069417f5db8928
   md5: b28ec461da7eac99523f146ae752529b
   depends:
@@ -7047,7 +7047,7 @@ packages:
   license_family: MIT
   size: 170318
   timestamp: 1726165294131
-- conda: https://repo.anaconda.com/pkgs/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/win_inet_pton-1.1.0-py311haa95532_0.tar.bz2
   sha256: 17fadf35aa8917c107e7b369e9364ac7c09537776e7943d37e225e14b7026c94
   md5: 0e67c3b9624540581b894b11267a837b
   depends:
@@ -7055,13 +7055,13 @@ packages:
   license: PUBLIC-DOMAIN
   size: 10197
   timestamp: 1676425485716
-- conda: https://repo.anaconda.com/pkgs/main/win-64/winpty-0.4.3-4.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/winpty-0.4.3-4.tar.bz2
   sha256: db5ffabd6ca5ac83a8a3f7ace6e51a0e8bd06c8730e477b2f39e11462699b2d4
   md5: c5bdb727945bad906d23e44199144746
   license: MIT
   size: 1177536
   timestamp: 1517593466234
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xyzservices-2022.9.0-py311haa95532_1.tar.bz2
   sha256: b849b368e27920838fe40a512b102879693a55cb187dd1c8d3a83fa8c05a8054
   md5: 7b1f6e9c71906a93039b3446b99a5498
   depends:
@@ -7070,7 +7070,7 @@ packages:
   license_family: BSD
   size: 55114
   timestamp: 1676434863173
-- conda: https://repo.anaconda.com/pkgs/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/xz-5.4.6-h8cc25b3_1.tar.bz2
   sha256: 344a5276a9928638dcde054dfe4e87c8cb40bd2d4d356378b9ab2f863ca62e4b
   md5: fe471fd8b5a3d77be6fa5dbf9b99dafb
   depends:
@@ -7080,7 +7080,7 @@ packages:
   license_family: GPL2
   size: 1432281
   timestamp: 1714515119689
-- conda: https://repo.anaconda.com/pkgs/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/yaml-0.2.5-he774522_0.tar.bz2
   sha256: 2181ce05c742ecabe4cf54e6f3fd4cb24d6d30043d0391588c5f684c73e84ac7
   md5: daa42ad494a780c2f433596651132c1c
   depends:
@@ -7089,7 +7089,7 @@ packages:
   license: MIT
   size: 66759
   timestamp: 1593116189318
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zeromq-4.3.5-hd77b12b_0.tar.bz2
   sha256: ed1cda8854bcfe8174182df6dcd8b9c78a3fb6f9ce43976ca078d86983e72b63
   md5: e5aed81295b61b6d1eb62830799a0297
   depends:
@@ -7100,7 +7100,7 @@ packages:
   license_family: Other
   size: 9125184
   timestamp: 1705602328351
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zlib-1.2.13-h8cc25b3_1.tar.bz2
   sha256: 4b307319e5708dbc3fb5eb54fc747aee8d22f62508c5caaf30c1fca9b6bca9d8
   md5: f295b54ab59f5b8658e2a322ac6aa721
   depends:
@@ -7110,7 +7110,7 @@ packages:
   license_family: Other
   size: 162161
   timestamp: 1714514792081
-- conda: https://repo.anaconda.com/pkgs/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
+- conda: https://conda.anaconda.org/main/win-64/zstd-1.5.6-h8880b57_0.tar.bz2
   sha256: 1f68cd378c6cdec34a5a3a21c56c9b8422b0f037b868b3db72065c0a2ca27921
   md5: d455a04486eddfb94c280974c0c33ae3
   depends:

--- a/world_cup/pixi.toml
+++ b/world_cup/pixi.toml
@@ -19,15 +19,15 @@ hvplot = ">=0.11.2"
 holoviews = ">=1.20.0"
 numpy = ">=1.26.4"
 pandas = ">=2.2.2"
-pip = "*"
-setuptools = "*"
-wheel = "*"
+pip = "*"  # promoted from anaconda-project lock
+setuptools = "*"  # promoted from anaconda-project lock
+wheel = "*"  # promoted from anaconda-project lock
 
 [target.osx-64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [target.osx-arm64.dependencies]
-libgfortran = "*"
+libgfortran = "*"  # promoted from anaconda-project lock
 
 [tasks.notebook]
 cmd = "jupyter notebook world_cup.ipynb"

--- a/world_cup/pixi.toml
+++ b/world_cup/pixi.toml
@@ -1,0 +1,51 @@
+[workspace]
+name = "world_cup"
+channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+
+[tool.metadata]
+created = "2024-06-24"
+maintainers = ["azaya89"]
+categories = ["Sports"]
+labels = ["hvplot", "holoviews", "bokeh", "panel"]
+title = "FIFA World Cup 2018"
+description = "Analysis of key events in the 2018 FIFA World Cup"
+
+[dependencies]
+notebook = "<7"
+python = "3.11.*"
+panel = ">=1.5.3"
+hvplot = ">=0.11.2"
+holoviews = ">=1.20.0"
+numpy = ">=1.26.4"
+pandas = ">=2.2.2"
+pip = "*"
+setuptools = "*"
+wheel = "*"
+
+[target.osx-64.dependencies]
+libgfortran = "*"
+
+[target.osx-arm64.dependencies]
+libgfortran = "*"
+
+[tasks.notebook]
+cmd = "jupyter notebook world_cup.ipynb"
+depends-on = ["download"]
+
+[tasks.dashboard]
+cmd = "panel serve --rest-session-info --session-history -1 world_cup.ipynb --show"
+depends-on = ["download"]
+
+[tasks.download]
+depends-on = ["download-DATA_1", "download-DATA_2"]
+
+[tasks.download-DATA_1]
+env = { FILENAME = "data/players.json" }
+cmd = "mkdir -p data && curl -fsSL -o $FILENAME https://datasets.holoviz.org/soccer_match_event/v1/players.json"
+outputs = ["data/players.json"]
+
+[tasks.download-DATA_2]
+env = { FILENAME = "data/events" }
+cmd = "mkdir -p $FILENAME && curl -fsSL -o .DATA_2.zip https://datasets.holoviz.org/soccer_match_event/v1/events.zip && python -m zipfile -e .DATA_2.zip $FILENAME && rm .DATA_2.zip"
+outputs = ["data/events"]

--- a/world_cup/pixi.toml
+++ b/world_cup/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "world_cup"
-channels = ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/msys2"]
+channels = ["main", "msys2"]
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 
 [tool.metadata]


### PR DESCRIPTION
<!--
If you are opening a PR to modernize/update an existing example, refer to the [modernization checklist](https://github.com/holoviz-topics/examples/wiki/Example-Modernization-Checklist-(2024)) in the Wiki of this repo.
-->

Making a script which can convert anaconda-project + lock to pixi format. The script tries to be as true as possible to the existing lock format. For the anaconda-project.yaml I have chosen not to add the deployment section.


Have locally (linux) run:

``` bash
for i in $(fd 'pixi.toml' -x dirname); do
    cd $i
    pixi install
    if $(pixi task list | grep -q download); then
        pixi run download
    fi
    cd ..
done
```

Keeping anaconda-project files for now.

Used Opus for the script.

